### PR TITLE
Add horizon_incl_fact parameter

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -176,7 +176,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D8[PIDNAVR] = 83; // NAV_D * 1000;
     pidProfile->P8[PIDLEVEL] = 50;
     pidProfile->I8[PIDLEVEL] = 50;
-    pidProfile->D8[PIDLEVEL] = 100;
+    pidProfile->D8[PIDLEVEL] = 75;
     pidProfile->P8[PIDMAG] = 40;
     pidProfile->P8[PIDVEL] = 55;
     pidProfile->I8[PIDVEL] = 55;
@@ -188,6 +188,8 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->yawItermIgnoreRate = 35;
     pidProfile->dterm_lpf_hz = 110;    // filtering ON by default
     pidProfile->dynamic_pid = 1;
+
+    pidProfile->horizon_incl_fact = 75;
 
 #ifdef GTUNE
     pidProfile->gtune_lolimP[ROLL] = 10;          // [0..200] Lower limit of ROLL P during G tune.

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -73,6 +73,7 @@ typedef struct pidProfile_s {
     uint16_t yaw_p_limit;
     uint8_t dterm_average_count;            // Configurable delta count for dterm
     uint8_t dynamic_pid;                    // Dynamic PID implementation (currently only P and I)
+    uint8_t horizon_incl_fact;              // inclination factor for Horizon mode
 
 #ifdef GTUNE
     uint8_t  gtune_lolimP[3];               // [0..200] Lower limit of P during G tune

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -755,6 +755,7 @@ const clivalue_t valueTable[] = {
     { "p_level",                    VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDLEVEL], .config.minmax = { 0,  200 } },
     { "i_level",                    VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PIDLEVEL], .config.minmax = { 0,  200 } },
     { "d_level",                    VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.D8[PIDLEVEL], .config.minmax = { 0,  200 } },
+    { "horizon_incl_fact",          VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.horizon_incl_fact, .config.minmax = { 0,  250 } },
 
     { "p_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDVEL], .config.minmax = { 0,  200 } },
     { "i_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PIDVEL], .config.minmax = { 0,  200 } },


### PR DESCRIPTION
This modification adds a new CLI parameter, 'horizon_incl_fact' ("inclination factor"), which controls the effect the current inclination has on self-leveling in the Horizon flight mode.  With the existing horizon mode, the strength of the self-leveling is solely dependent on the stick position.  This is problematic when trying to do maneuvers like large loops and fast-forward flight.  Adding a factor that takes into account the current inclination of the craft provides a big improvement for these maneuvers and improves the "feel" of horizon mode.  (The current inclination is the number of degrees of pitch or roll that the vehicle is away from level, whichever is greater).

This mod also addresses an issue with the "Transition (Horizon)" ('d_level') parameter -- in recent versions of Betaflight the 'sensitivity_horizon' (LUX) and 'd_level' (REWRITE) CLI parameters were merged so that both use the 'd_level' parameter.  The problem is that the ranges behave differently -- in LUX, increasing the value results in more self leveling and zero results in no self leveling; in REWRITE, increasing the value results in less self leveling.  With this mod, increasing the value results in more self leveling and zero results in no self leveling.  The default has been changed to 75, which should give relatively unchanged default behavior for this parameter on both PID controllers.

The original idea for this mod came from ctzsnooze (see CleanFlight [issue #695](http://github.com/cleanflight/cleanflight/issues/695)); I've expanded on it and turned it into a configurable option.  One characteristic of horizon mode I made a point of retaining is that, when the vehicle is flat and the sticks are near center, the self-leveling effect is not diminished by larger 'horizon_incl_fact' settings.  Like in the existing horizon mode, the strength of the self-leveling can be effectively managed using the "Strength (Horizon)" ('i_level') parameter.  Also, the "Transition (Horizon)" ('d_level') parameter operates the same as before.

Setting 'horizon_incl_fact' to 0 will run the current horizon-mode behavior.  For other values, there are two ranges for the 'horizon_incl_fact' parameter:

1 to 99 => Range 1 - leveling always active when sticks centered:
This is the "safer" range because the self-leveling is always active when the sticks are centered.  So, when the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle will immediately be self-leveled to upright and flat.  This is similar to the current horizon-mode behavior.  (Note that after this kind of very-fast 180-degree self-leveling, the heading of the vehicle can be unpredictable.)  Larger values result in less self-leveling in response to large inclinations.  The 'horizon_incl_fact' value is combined with the 'level_horizon' parameter to control the self-leveling effect.  The default value of 75 should provide significant improvements in horizon-mode flight characteristics.

100 to 250 => Range 2 - leveling can be totally off when inverted:
In this range, the inclination of the vehicle can fully "override" the self-leveling.  When the parameter set to around 150, and the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle is not self-leveled.  This can be desirable for performing more-acrobatic maneuvers and potentially for 3D-mode flying.

The 'horizon_incl_fact' parameter value is different for each profile, and is implemented for both the LUX and REWRITE PID controllers.

I test flew this mod with the current Betaflight master (as of 2016-05-05) using basically default settings and found that works well with LUX, but there seems be a problem in the current master with REWRITE and Horizon mode (the leveling is unsteady).  When the mod is applied to the v2.6.1 release version of Betaflight, it flies well in both modes -- the code for this 2.6.1 version is [here](https://github.com/ethomas999/betaflight/tree/addHorizonInclFactCmd_v2.6.1rel), and I've posted a [hex file](http://www.etheli.com/CF/addHorizonInclFactCmd/betaflight_v2.6.1rel_addHorizonInclFactCmd_20160505_NAZE.hex) for this 2.6.1 version at:  http://www.etheli.com/CF/addHorizonInclFactCmd

I've been flying this mod in my [MiniFTC](http://www.etheli.com/MiniFTC) for quite a while now; I think it makes Horizon mode much better.

--ET