### PR TITLE
Add  missing CONFIG_FASTLOOP_PREFERRED_ACC define

### DIFF
--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -19,6 +19,8 @@
 
 #define TARGET_BOARD_IDENTIFIER "SRF3"
 
+#define CONFIG_FASTLOOP_PREFERRED_ACC 0
+
 #define LED0    PB3
 
 #define BEEPER      PC15

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -19,6 +19,8 @@
 
 #define TARGET_BOARD_IDENTIFIER "SRFM"
 
+#define CONFIG_FASTLOOP_PREFERRED_ACC 0
+
 // early prototype had slightly different pin mappings.
 //#define SPRACINGF3MINI_MKII_REVA
 


### PR DESCRIPTION
This fixes some missing #defines for SPRACING target.h files.