### PR TITLE
Serial rx telemetry on same port for flight testing

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -194,7 +194,11 @@ serialPort_t *findNextSharedSerialPort(uint16_t functionMask, serialPortFunction
     return NULL;
 }
 
+#ifdef TELEMETRY
+#define ALL_TELEMETRY_FUNCTIONS_MASK (TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_SMARTPORT)
+#else
 #define ALL_TELEMETRY_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_SMARTPORT | FUNCTION_TELEMETRY_LTM)
+#endif
 #define ALL_FUNCTIONS_SHARABLE_WITH_MSP (FUNCTION_BLACKBOX | ALL_TELEMETRY_FUNCTIONS_MASK)
 
 bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
@@ -203,7 +207,8 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
     /*
      * rules:
      * - 1 MSP port minimum, max MSP ports is defined and must be adhered to.
-     * - Only MSP is allowed to be shared with EITHER any telemetry OR blackbox.
+     * - MSP is allowed to be shared with EITHER any telemetry OR blackbox.
+     * - serial RX and FrSky / LTM telemetry can be shared
      * - No other sharing combinations are valid.
      */
     uint8_t mspPortCount = 0;
@@ -223,12 +228,14 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
                 return false;
             }
 
-            if (!(portConfig->functionMask & FUNCTION_MSP)) {
-                return false;
-            }
-
-            if (!(portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP)) {
-                // some other bit must have been set.
+            if ((portConfig->functionMask & FUNCTION_MSP) && (portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP)) {
+                // MSP & telemetry
+#ifdef TELEMETRY
+            } else if (telemetryCheckRxPortShared(portConfig)) {
+                // serial RX & telemetry
+#endif
+            } else {
+                // some other combination
                 return false;
             }
         }

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -477,16 +477,23 @@ bool hasEnoughTimeLapsedSinceLastTelemetryTransmission(uint32_t currentMillis)
 
 void checkFrSkyTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(frskyPortSharing);
+    if (portConfig && telemetryCheckRxPortShared(portConfig)) {
+        if (!frskyTelemetryEnabled && telemetrySharedPort != NULL) {
+            frskyPort = telemetrySharedPort;
+            frskyTelemetryEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(frskyPortSharing);
 
-    if (newTelemetryEnabledValue == frskyTelemetryEnabled) {
-        return;
+        if (newTelemetryEnabledValue == frskyTelemetryEnabled) {
+            return;
+        }
+
+        if (newTelemetryEnabledValue)
+            configureFrSkyTelemetryPort();
+        else
+            freeFrSkyTelemetryPort();
     }
-
-    if (newTelemetryEnabledValue)
-        configureFrSkyTelemetryPort();
-    else
-        freeFrSkyTelemetryPort();
 }
 
 void handleFrSkyTelemetry(rxConfig_t *rxConfig, uint16_t deadband3d_throttle)

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -299,12 +299,19 @@ void configureLtmTelemetryPort(void)
 
 void checkLtmTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(ltmPortSharing);
-    if (newTelemetryEnabledValue == ltmEnabled)
-        return;
-    if (newTelemetryEnabledValue)
-        configureLtmTelemetryPort();
-    else
-        freeLtmTelemetryPort();
+    if (portConfig && telemetryCheckRxPortShared(portConfig)) {
+        if (!ltmEnabled && telemetrySharedPort != NULL) {
+            ltmPort = telemetrySharedPort;
+            ltmEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(ltmPortSharing);
+        if (newTelemetryEnabledValue == ltmEnabled)
+            return;
+        if (newTelemetryEnabledValue)
+            configureLtmTelemetryPort();
+        else
+            freeLtmTelemetryPort();
+    }
 }
 #endif

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -74,6 +74,13 @@ bool telemetryDetermineEnabledState(portSharing_e portSharing)
     return enabled;
 }
 
+bool telemetryCheckRxPortShared(serialPortConfig_t *portConfig)
+{
+    return portConfig->functionMask & FUNCTION_RX_SERIAL && portConfig->functionMask & TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK;
+}
+
+serialPort_t *telemetrySharedPort = NULL;
+
 void telemetryCheckState(void)
 {
     checkFrSkyTelemetryState();

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -48,11 +48,16 @@ typedef struct telemetryConfig_s {
     uint8_t hottAlarmSoundInterval;
 } telemetryConfig_t;
 
+bool telemetryCheckRxPortShared(serialPortConfig_t *portConfig);
+extern serialPort_t *telemetrySharedPort;
+
 void telemetryCheckState(void);
 void telemetryProcess(rxConfig_t *rxConfig, uint16_t deadband3d_throttle);
 
 bool telemetryDetermineEnabledState(portSharing_e portSharing);
 
 void telemetryUseConfig(telemetryConfig_t *telemetryConfig);
+
+#define TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_LTM)
 
 #endif /* TELEMETRY_COMMON_H_ */


### PR DESCRIPTION
@blckmn This is my feature for testing on the development branch. It builds for the NAZE target, but fails for others that are part of the release set in the `betaflight` branch. Unfortunately I could not find the documentation stating which targets should work in this branch.

Please let me know how your flight tests are going, and what hardware you are testing with. Maybe this will convince @borisbstyle to try and learn what is required for him to understand what this feature does.