### PR TITLE
SINGULARITY build failed. Added missing io/vtx.c to target.mk

### DIFF
--- a/src/main/target/SINGULARITY/target.mk
+++ b/src/main/target/SINGULARITY/target.mk
@@ -7,5 +7,6 @@ TARGET_SRC = \
             drivers/light_ws2811strip.c \
             drivers/light_ws2811strip_stm32f30x.c \
             drivers/serial_softserial.c \
-            drivers/vtx_rtc6705.c
+            drivers/vtx_rtc6705.c \
+            io/vtx.c
 


### PR DESCRIPTION
CI build still fails. The SINGULARITY build failes. Added missing io/vtx.c to target.mk seems to fix it. Not sure it is the correct way of fixing it. Please review.


 