### PR TITLE
Re-added support for the AFROMINI target.

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -352,10 +352,6 @@ void init(void)
         .isInverted = false
 #endif
     };
-#ifdef AFROMINI
-    beeperConfig.isOD = true;
-    beeperConfig.isInverted = true;
-#endif
 #ifdef NAZE
     if (hardwareRevision >= NAZE32_REV5) {
         // naze rev4 and below used opendrain to PNP for buzzer. Rev5 and above use PP to NPN.

--- a/src/main/target/NAZE/AFROMINI.mk
+++ b/src/main/target/NAZE/AFROMINI.mk
@@ -1,0 +1,1 @@
+# AFROMINI is a VARIANT of NAZE being recognized as rev4, but needs to use rev5

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -26,6 +26,9 @@
 #define LED1    PB4 // PB4 (LED)
 
 #define BEEPER      PA12 // PA12 (Beeper)
+#ifdef AFROMINI
+#define BEEPER_INVERTED
+#endif
 
 #define BARO_XCLR_PIN    PC13
 #define BARO_EOC_PIN     PC14


### PR DESCRIPTION
Just picked this up when I fixed the NAZE32 beeper. Not sure if this was working before the IO revamp, so not sure if this is working now.