### PR TITLE
Add servo_tilt and flash chip capability to Doge target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -657,6 +657,8 @@ DOGE_SRC = \
 		   drivers/light_ws2811strip.c \
 		   drivers/light_ws2811strip_stm32f30x.c \
 		   drivers/serial_usb_vcp.c \
+           drivers/flash_m25p16.c \
+           io/flashfs.c \
 		   $(HIGHEND_SRC) \
 		   $(COMMON_SRC) \
 		   $(VCP_SRC)

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -933,6 +933,12 @@ if (init->useBuzzerP6) {
                 type = MAP_TO_SERVO_OUTPUT;
 #endif
 
+#if defined(DOGE)
+            // remap outputs 1+2 (PWM2+3) as servos
+            if ((timerIndex == PWM2 || timerIndex == PWM3) && timerHardwarePtr->tim == TIM4)
+                type = MAP_TO_SERVO_OUTPUT;
+#endif
+
 #if defined(COLIBRI_RACE) || defined(LUX_RACE)
             // remap PWM1+2 as servos
             if ((timerIndex == PWM6 || timerIndex == PWM7 || timerIndex == PWM8 || timerIndex == PWM9) && timerHardwarePtr->tim == TIM2)

--- a/src/main/target/DOGE/target.h
+++ b/src/main/target/DOGE/target.h
@@ -79,6 +79,14 @@
 #define SPI2_MOSI_PIN           GPIO_Pin_15
 #define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource15
 
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_SPI_SHARED
+#define M25P16_CS_GPIO                GPIOC
+#define M25P16_CS_PIN                 GPIO_Pin_15
+#define M25P16_CS_GPIO_CLK_PERIPHERAL RCC_AHBPeriph_GPIOC
+#define M25P16_SPI_INSTANCE           SPI2
+
 // timer definitions in drivers/timer.c
 // channel mapping in drivers/pwm_mapping.c
 // only 6 outputs available on hardware


### PR DESCRIPTION
Also adds support for an additional flash chip. The GPIO change is because the additional SPI2 CS GPIO isn't the 'default' (copied from Naze) so it needed to be init'd before use.