### PR TITLE
Add servo_tilt and flash chip to doge target (dev branch commit)

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -44,6 +44,7 @@
 #define JEDEC_ID_MICRON_M25P16         0x202015
 #define JEDEC_ID_MICRON_N25Q064        0x20BA17
 #define JEDEC_ID_WINBOND_W25Q64        0xEF4017
+#define JEDEC_ID_MACRONIX_MX25L6406E   0xC22017
 #define JEDEC_ID_MICRON_N25Q128        0x20ba18
 #define JEDEC_ID_WINBOND_W25Q128       0xEF4018
 
@@ -163,6 +164,7 @@ static bool m25p16_readIdentification()
         break;
         case JEDEC_ID_MICRON_N25Q064:
         case JEDEC_ID_WINBOND_W25Q64:
+        case JEDEC_ID_MACRONIX_MX25L6406E:
             geometry.sectors = 128;
             geometry.pagesPerSector = 256;
         break;
@@ -204,8 +206,12 @@ bool m25p16_init()
     IOInit(m25p16CsPin, OWNER_FLASH, RESOURCE_SPI);
     IOConfigGPIO(m25p16CsPin, SPI_IO_CS_CFG);
     
+    DISABLE_M25P16;
+
+#ifndef M25P16_SPI_SHARED
     //Maximum speed for standard READ command is 20mHz, other commands tolerate 25mHz
     spiSetDivisor(M25P16_SPI_INSTANCE, SPI_18MHZ_CLOCK_DIVIDER);
+#endif
 
     return m25p16_readIdentification();
 }

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -213,6 +213,12 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
                 type = MAP_TO_SERVO_OUTPUT;
 #endif
 
+#if defined(DOGE)
+            // remap outputs 1+2 (PWM2+3) as servos
+            if ((timerIndex == PWM2 || timerIndex == PWM3) && timerHardwarePtr->tim == TIM4)
+                type = MAP_TO_SERVO_OUTPUT;
+#endif
+
 #if defined(COLIBRI_RACE) || defined(LUX_RACE)
             // remap PWM1+2 as servos
             if ((timerIndex == PWM6 || timerIndex == PWM7 || timerIndex == PWM8 || timerIndex == PWM9) && timerHardwarePtr->tim == TIM2)

--- a/src/main/target/DOGE/target.h
+++ b/src/main/target/DOGE/target.h
@@ -73,6 +73,12 @@
 #define SPI2_MOSI_PIN           PB15
 #define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource15
 
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_SPI_SHARED
+#define M25P16_CS_PIN       PC15
+#define M25P16_SPI_INSTANCE SPI2
+
 // timer definitions in drivers/timer.c
 // channel mapping in drivers/pwm_mapping.c
 // only 6 outputs available on hardware

--- a/src/main/target/DOGE/target.mk
+++ b/src/main/target/DOGE/target.mk
@@ -1,5 +1,5 @@
 F3_TARGETS  += $(TARGET)
-FEATURES    = VCP 
+FEATURES    = VCP ONBOARDFLASH
 
 TARGET_SRC = \
             drivers/accgyro_mpu.c \


### PR DESCRIPTION
Also adds support for an additional flash chip. The previous GPIO addition was simplified due to the new IO scheme. Tested on production Doge with baro + Macronix flash chip.