### PR TITLE
Moving ADC to new IO

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -33,6 +33,14 @@
 adc_config_t adcConfig[ADC_CHANNEL_COUNT];
 volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 
+uint8_t adcChannelByPin(ioTag_t pin)
+{
+	for (uint8_t i = 0; i < ARRAYLEN(adcPinMap); i++) {
+		if (pin == adcPinMap[i].pin)
+			return adcPinMap[i].channel;
+	}
+	return 0;    
+}
 
 uint16_t adcGetChannel(uint8_t channel)
 {

--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -33,11 +33,11 @@
 adc_config_t adcConfig[ADC_CHANNEL_COUNT];
 volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 
-uint8_t adcChannelByPin(ioTag_t pin)
+uint8_t adcChannelByTag(ioTag_t ioTag)
 {
-	for (uint8_t i = 0; i < ARRAYLEN(adcPinMap); i++) {
-		if (pin == adcPinMap[i].pin)
-			return adcPinMap[i].channel;
+	for (uint8_t i = 0; i < ARRAYLEN(adcTagMap); i++) {
+		if (ioTag == adcTagMap[i].tag)
+			return adcTagMap[i].channel;
 	}
 	return 0;    
 }

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -17,5 +17,27 @@
 
 #pragma once
 
+#include "rcc.h"
+
+typedef enum ADCDevice {
+    ADCINVALID = -1,
+    ADCDEV_1   = 0,
+    ADCDEV_2,
+    ADCDEV_3,
+    ADCDEV_MAX = ADCDEV_3,
+} ADCDevice;
+
+typedef struct adcDevice_s {
+    ADC_TypeDef* ADCx;
+    rccPeriphTag_t rccADC;
+    rccPeriphTag_t rccDMA;
+#if defined(STM32F4)
+    DMA_Stream_TypeDef* DMAy_Streamx;
+#else
+    DMA_Channel_TypeDef* DMAy_Channelx;
+#endif
+} adcDevice_t;
+
+extern const adcDevice_t adcHardware[];
 extern adc_config_t adcConfig[ADC_CHANNEL_COUNT];
 extern volatile uint16_t adcValues[ADC_CHANNEL_COUNT];

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -17,27 +17,52 @@
 
 #pragma once
 
+#include "io.h"
 #include "rcc.h"
+
+#if defined(STM32F4)
+#define ADC_PIN_MAP_COUNT 16
+#elif defined(STM32F3)
+#define ADC_PIN_MAP_COUNT 39
+#else 
+#define ADC_PIN_MAP_COUNT 10
+#endif 
 
 typedef enum ADCDevice {
     ADCINVALID = -1,
     ADCDEV_1   = 0,
+#if defined(STM32F3) 
+    ADCDEV_2,
+    ADCDEV_MAX = ADCDEV_2,
+#elif defined(STM32F4)
     ADCDEV_2,
     ADCDEV_3,
-    ADCDEV_MAX = ADCDEV_3,
+    ADCDEV_MAX = ADCDEV_3,    
+#else
+    ADCDEV_MAX = ADCDEV_1,
+#endif
 } ADCDevice;
 
+typedef struct adcPinMap_s {
+    ioTag_t pin;
+    uint8_t channel;
+} adcPinMap_t;
+    
 typedef struct adcDevice_s {
     ADC_TypeDef* ADCx;
     rccPeriphTag_t rccADC;
     rccPeriphTag_t rccDMA;
 #if defined(STM32F4)
     DMA_Stream_TypeDef* DMAy_Streamx;
+    uint32_t channel;
 #else
     DMA_Channel_TypeDef* DMAy_Channelx;
 #endif
 } adcDevice_t;
 
 extern const adcDevice_t adcHardware[];
+extern const adcPinMap_t adcPinMap[ADC_PIN_MAP_COUNT];
 extern adc_config_t adcConfig[ADC_CHANNEL_COUNT];
 extern volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
+
+uint8_t adcChannelByPin(ioTag_t pin);

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -21,11 +21,11 @@
 #include "rcc.h"
 
 #if defined(STM32F4)
-#define ADC_PIN_MAP_COUNT 16
+#define ADC_TAG_MAP_COUNT 16
 #elif defined(STM32F3)
-#define ADC_PIN_MAP_COUNT 39
+#define ADC_TAG_MAP_COUNT 39
 #else 
-#define ADC_PIN_MAP_COUNT 10
+#define ADC_TAG_MAP_COUNT 10
 #endif 
 
 typedef enum ADCDevice {
@@ -43,10 +43,10 @@ typedef enum ADCDevice {
 #endif
 } ADCDevice;
 
-typedef struct adcPinMap_s {
-    ioTag_t pin;
+typedef struct adcTagMap_s {
+    ioTag_t tag;
     uint8_t channel;
-} adcPinMap_t;
+} adcTagMap_t;
     
 typedef struct adcDevice_s {
     ADC_TypeDef* ADCx;
@@ -61,8 +61,8 @@ typedef struct adcDevice_s {
 } adcDevice_t;
 
 extern const adcDevice_t adcHardware[];
-extern const adcPinMap_t adcPinMap[ADC_PIN_MAP_COUNT];
+extern const adcTagMap_t adcTagMap[ADC_TAG_MAP_COUNT];
 extern adc_config_t adcConfig[ADC_CHANNEL_COUNT];
 extern volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 
-uint8_t adcChannelByPin(ioTag_t pin);
+uint8_t adcChannelByTag(ioTag_t ioTag);

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -54,6 +54,19 @@ ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
     return ADCINVALID;
 }
 
+const adcPinMap_t adcPinMap[] = { 
+    { .pin = DEFIO_TAG_E__PA0, .channel = ADC_Channel_0 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA1, .channel = ADC_Channel_1 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA2, .channel = ADC_Channel_2 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA3, .channel = ADC_Channel_3 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA4, .channel = ADC_Channel_4 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA5, .channel = ADC_Channel_5 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA6, .channel = ADC_Channel_6 }, // ADC12
+    { .pin = DEFIO_TAG_E__PA7, .channel = ADC_Channel_7 }, // ADC12
+    { .pin = DEFIO_TAG_E__PB0, .channel = ADC_Channel_8 }, // ADC12
+    { .pin = DEFIO_TAG_E__PB1, .channel = ADC_Channel_9 }, // ADC12   
+};
+
 // Driver for STM32F103CB onboard ADC
 //
 // Naze32
@@ -80,7 +93,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableVBat) {
         IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
         IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_BATTERY].adcChannel = VBAT_ADC_CHANNEL;
+        adcConfig[ADC_BATTERY].adcChannel = adcChannelByPin(IO_TAG(VBAT_ADC_PIN));
         adcConfig[ADC_BATTERY].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_BATTERY].enabled = true;
         adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_239Cycles5;
@@ -91,7 +104,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableRSSI) {
         IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
         IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_RSSI].adcChannel = RSSI_ADC_CHANNEL;
+        adcConfig[ADC_RSSI].adcChannel = adcChannelByPin(IO_TAG(RSSI_ADC_PIN));
         adcConfig[ADC_RSSI].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_RSSI].enabled = true;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_239Cycles5;
@@ -102,7 +115,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableExternal1) {
         IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
+        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByPin(IO_TAG(EXTERNAL1_ADC_PIN));
         adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_EXTERNAL1].enabled = true;
         adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_239Cycles5;
@@ -113,7 +126,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableCurrentMeter) {
         IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_CURRENT].adcChannel = CURRENT_METER_ADC_CHANNEL;
+        adcConfig[ADC_CURRENT].adcChannel = adcChannelByPin(IO_TAG(CURRENT_METER_ADC_PIN));
         adcConfig[ADC_CURRENT].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_CURRENT].enabled = true;
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_239Cycles5;

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -29,16 +29,30 @@
 
 #include "sensor.h"
 #include "accgyro.h"
-
 #include "adc.h"
 #include "adc_impl.h"
+#include "io.h"
+#include "rcc.h"
 
 #ifndef ADC_INSTANCE
-#define ADC_INSTANCE                ADC1
-#define ADC_ABP2_PERIPHERAL         RCC_APB2Periph_ADC1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
+#define ADC_INSTANCE   ADC1
 #endif
+
+const adcDevice_t adcHardware[] = { 
+    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .rccDMA = RCC_AHB(DMA1), .DMAy_Channelx = DMA1_Channel1 }  
+};
+
+ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
+{
+    if (instance == ADC1) 
+        return ADCDEV_1;
+
+/* TODO -- ADC2 available on large 10x devices.
+    if (instance == ADC2)
+        return ADCDEV_2;
+*/
+    return ADCINVALID;
+}
 
 // Driver for STM32F103CB onboard ADC
 //
@@ -50,27 +64,22 @@
 // NAZE rev.5 hardware has PA5 (ADC1_IN5) on breakout pad on bottom of board
 //
 
-
 void adcInit(drv_adc_config_t *init)
 {
-#if defined(CJMCU) || defined(CC3D)
-    UNUSED(init);
+    
+#if !defined(VBAT_ADC_PIN) && !defined(EXTERNAL1_ADC_PIN) && !defined(RSSI_ADC_PIN) && !defined(CURRENT_METER_ADC_PIN)
+	UNUSED(init);
 #endif
-
 
     uint8_t i;
     uint8_t configuredAdcChannels = 0;
 
     memset(&adcConfig, 0, sizeof(adcConfig));
 
-    GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_StructInit(&GPIO_InitStructure);
-    GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AIN;
-
-#ifdef VBAT_ADC_GPIO
+#ifdef VBAT_ADC_PIN
     if (init->enableVBat) {
-        GPIO_InitStructure.GPIO_Pin = VBAT_ADC_GPIO_PIN;
-        GPIO_Init(VBAT_ADC_GPIO, &GPIO_InitStructure);
+        IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+        IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
         adcConfig[ADC_BATTERY].adcChannel = VBAT_ADC_CHANNEL;
         adcConfig[ADC_BATTERY].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_BATTERY].enabled = true;
@@ -78,10 +87,10 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
-#ifdef RSSI_ADC_GPIO
+#ifdef RSSI_ADC_PIN
     if (init->enableRSSI) {
-        GPIO_InitStructure.GPIO_Pin = RSSI_ADC_GPIO_PIN;
-        GPIO_Init(RSSI_ADC_GPIO, &GPIO_InitStructure);
+        IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+        IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
         adcConfig[ADC_RSSI].adcChannel = RSSI_ADC_CHANNEL;
         adcConfig[ADC_RSSI].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_RSSI].enabled = true;
@@ -89,10 +98,10 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
-#ifdef EXTERNAL1_ADC_GPIO
+#ifdef EXTERNAL1_ADC_PIN
     if (init->enableExternal1) {
-        GPIO_InitStructure.GPIO_Pin = EXTERNAL1_ADC_GPIO_PIN;
-        GPIO_Init(EXTERNAL1_ADC_GPIO, &GPIO_InitStructure);
+        IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
         adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
         adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_EXTERNAL1].enabled = true;
@@ -100,10 +109,10 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
-#ifdef CURRENT_METER_ADC_GPIO
+#ifdef CURRENT_METER_ADC_PIN
     if (init->enableCurrentMeter) {
-        GPIO_InitStructure.GPIO_Pin   = CURRENT_METER_ADC_GPIO_PIN;
-        GPIO_Init(CURRENT_METER_ADC_GPIO, &GPIO_InitStructure);
+        IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
         adcConfig[ADC_CURRENT].adcChannel = CURRENT_METER_ADC_CHANNEL;
         adcConfig[ADC_CURRENT].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_CURRENT].enabled = true;
@@ -111,16 +120,22 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
+    ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);
+    if (device == ADCINVALID)
+        return;
+    
+    adcDevice_t adc = adcHardware[device];  
+    
     RCC_ADCCLKConfig(RCC_PCLK2_Div8);  // 9MHz from 72MHz APB2 clock(HSE), 8MHz from 64MHz (HSI)
-    RCC_AHBPeriphClockCmd(ADC_AHB_PERIPHERAL, ENABLE);
-    RCC_APB2PeriphClockCmd(ADC_ABP2_PERIPHERAL, ENABLE);
-
+    RCC_ClockCmd(adc.rccADC, ENABLE);
+    RCC_ClockCmd(adc.rccDMA, ENABLE);
+    
     // FIXME ADC driver assumes all the GPIO was already placed in 'AIN' mode
 
-    DMA_DeInit(ADC_DMA_CHANNEL);
+    DMA_DeInit(adc.DMAy_Channelx);
     DMA_InitTypeDef DMA_InitStructure;
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&ADC_INSTANCE->DR;
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&adc.ADCx->DR;
     DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t)adcValues;
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralSRC;
     DMA_InitStructure.DMA_BufferSize = configuredAdcChannels;
@@ -131,8 +146,8 @@ void adcInit(drv_adc_config_t *init)
     DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;
     DMA_InitStructure.DMA_Priority = DMA_Priority_High;
     DMA_InitStructure.DMA_M2M = DMA_M2M_Disable;
-    DMA_Init(ADC_DMA_CHANNEL, &DMA_InitStructure);
-    DMA_Cmd(ADC_DMA_CHANNEL, ENABLE);
+    DMA_Init(adc.DMAy_Channelx, &DMA_InitStructure);
+    DMA_Cmd(adc.DMAy_Channelx, ENABLE);
 
     ADC_InitTypeDef ADC_InitStructure;
     ADC_StructInit(&ADC_InitStructure);
@@ -142,23 +157,23 @@ void adcInit(drv_adc_config_t *init)
     ADC_InitStructure.ADC_ExternalTrigConv = ADC_ExternalTrigConv_None;
     ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
     ADC_InitStructure.ADC_NbrOfChannel = configuredAdcChannels;
-    ADC_Init(ADC_INSTANCE, &ADC_InitStructure);
+    ADC_Init(adc.ADCx, &ADC_InitStructure);
 
     uint8_t rank = 1;
     for (i = 0; i < ADC_CHANNEL_COUNT; i++) {
         if (!adcConfig[i].enabled) {
             continue;
         }
-        ADC_RegularChannelConfig(ADC_INSTANCE, adcConfig[i].adcChannel, rank++, adcConfig[i].sampleTime);
+        ADC_RegularChannelConfig(adc.ADCx, adcConfig[i].adcChannel, rank++, adcConfig[i].sampleTime);
     }
 
-    ADC_DMACmd(ADC_INSTANCE, ENABLE);
-    ADC_Cmd(ADC_INSTANCE, ENABLE);
+    ADC_DMACmd(adc.ADCx, ENABLE);
+    ADC_Cmd(adc.ADCx, ENABLE);
 
-    ADC_ResetCalibration(ADC_INSTANCE);
-    while(ADC_GetResetCalibrationStatus(ADC_INSTANCE));
-    ADC_StartCalibration(ADC_INSTANCE);
-    while(ADC_GetCalibrationStatus(ADC_INSTANCE));
+    ADC_ResetCalibration(adc.ADCx);
+    while (ADC_GetResetCalibrationStatus(adc.ADCx));
+    ADC_StartCalibration(adc.ADCx);
+    while (ADC_GetCalibrationStatus(adc.ADCx));
 
-    ADC_SoftwareStartConvCmd(ADC_INSTANCE, ENABLE);
+    ADC_SoftwareStartConvCmd(adc.ADCx, ENABLE);
 }

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -54,17 +54,17 @@ ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
     return ADCINVALID;
 }
 
-const adcPinMap_t adcPinMap[] = { 
-    { .pin = DEFIO_TAG_E__PA0, .channel = ADC_Channel_0 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA1, .channel = ADC_Channel_1 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA2, .channel = ADC_Channel_2 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA3, .channel = ADC_Channel_3 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA4, .channel = ADC_Channel_4 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA5, .channel = ADC_Channel_5 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA6, .channel = ADC_Channel_6 }, // ADC12
-    { .pin = DEFIO_TAG_E__PA7, .channel = ADC_Channel_7 }, // ADC12
-    { .pin = DEFIO_TAG_E__PB0, .channel = ADC_Channel_8 }, // ADC12
-    { .pin = DEFIO_TAG_E__PB1, .channel = ADC_Channel_9 }, // ADC12   
+const adcTagMap_t adcTagMap[] = { 
+    { DEFIO_TAG_E__PA0, ADC_Channel_0 }, // ADC12
+    { DEFIO_TAG_E__PA1, ADC_Channel_1 }, // ADC12
+    { DEFIO_TAG_E__PA2, ADC_Channel_2 }, // ADC12
+    { DEFIO_TAG_E__PA3, ADC_Channel_3 }, // ADC12
+    { DEFIO_TAG_E__PA4, ADC_Channel_4 }, // ADC12
+    { DEFIO_TAG_E__PA5, ADC_Channel_5 }, // ADC12
+    { DEFIO_TAG_E__PA6, ADC_Channel_6 }, // ADC12
+    { DEFIO_TAG_E__PA7, ADC_Channel_7 }, // ADC12
+    { DEFIO_TAG_E__PB0, ADC_Channel_8 }, // ADC12
+    { DEFIO_TAG_E__PB1, ADC_Channel_9 }, // ADC12   
 };
 
 // Driver for STM32F103CB onboard ADC
@@ -93,7 +93,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableVBat) {
         IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
         IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_BATTERY].adcChannel = adcChannelByPin(IO_TAG(VBAT_ADC_PIN));
+        adcConfig[ADC_BATTERY].adcChannel = adcChannelByTag(IO_TAG(VBAT_ADC_PIN));
         adcConfig[ADC_BATTERY].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_BATTERY].enabled = true;
         adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_239Cycles5;
@@ -104,7 +104,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableRSSI) {
         IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
         IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_RSSI].adcChannel = adcChannelByPin(IO_TAG(RSSI_ADC_PIN));
+        adcConfig[ADC_RSSI].adcChannel = adcChannelByTag(IO_TAG(RSSI_ADC_PIN));
         adcConfig[ADC_RSSI].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_RSSI].enabled = true;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_239Cycles5;
@@ -115,7 +115,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableExternal1) {
         IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByPin(IO_TAG(EXTERNAL1_ADC_PIN));
+        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByTag(IO_TAG(EXTERNAL1_ADC_PIN));
         adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_EXTERNAL1].enabled = true;
         adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_239Cycles5;
@@ -126,7 +126,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableCurrentMeter) {
         IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AIN, 0));
-        adcConfig[ADC_CURRENT].adcChannel = adcChannelByPin(IO_TAG(CURRENT_METER_ADC_PIN));
+        adcConfig[ADC_CURRENT].adcChannel = adcChannelByTag(IO_TAG(CURRENT_METER_ADC_PIN));
         adcConfig[ADC_CURRENT].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_CURRENT].enabled = true;
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_239Cycles5;

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -41,46 +41,46 @@ const adcDevice_t adcHardware[] = {
     { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12), .rccDMA = RCC_AHB(DMA2), .DMAy_Channelx = DMA2_Channel1 }  
 };
 
-const adcPinMap_t adcPinMap[] = { 
-    { .pin = DEFIO_TAG_E__PA0,  .channel = ADC_Channel_1  }, // ADC1
-    { .pin = DEFIO_TAG_E__PA1,  .channel = ADC_Channel_2  }, // ADC1
-    { .pin = DEFIO_TAG_E__PA2,  .channel = ADC_Channel_3  }, // ADC1
-    { .pin = DEFIO_TAG_E__PA3,  .channel = ADC_Channel_4  }, // ADC1
-    { .pin = DEFIO_TAG_E__PA4,  .channel = ADC_Channel_1  }, // ADC2
-    { .pin = DEFIO_TAG_E__PA5,  .channel = ADC_Channel_2  }, // ADC2
-    { .pin = DEFIO_TAG_E__PA6,  .channel = ADC_Channel_3  }, // ADC2
-    { .pin = DEFIO_TAG_E__PA7,  .channel = ADC_Channel_4  }, // ADC2
-    { .pin = DEFIO_TAG_E__PB0,  .channel = ADC_Channel_12 }, // ADC3
-    { .pin = DEFIO_TAG_E__PB1,  .channel = ADC_Channel_1  }, // ADC3
-    { .pin = DEFIO_TAG_E__PB2,  .channel = ADC_Channel_12 }, // ADC2
-    { .pin = DEFIO_TAG_E__PB12, .channel = ADC_Channel_3  }, // ADC4
-    { .pin = DEFIO_TAG_E__PB13, .channel = ADC_Channel_5  }, // ADC3
-    { .pin = DEFIO_TAG_E__PB14, .channel = ADC_Channel_4  }, // ADC4
-    { .pin = DEFIO_TAG_E__PB15, .channel = ADC_Channel_5  }, // ADC4
-    { .pin = DEFIO_TAG_E__PC0,  .channel = ADC_Channel_6  }, // ADC12
-    { .pin = DEFIO_TAG_E__PC1,  .channel = ADC_Channel_7  }, // ADC12
-    { .pin = DEFIO_TAG_E__PC2,  .channel = ADC_Channel_8  }, // ADC12
-    { .pin = DEFIO_TAG_E__PC3,  .channel = ADC_Channel_9  }, // ADC12
-    { .pin = DEFIO_TAG_E__PC4,  .channel = ADC_Channel_5  }, // ADC2
-    { .pin = DEFIO_TAG_E__PC5,  .channel = ADC_Channel_11 }, // ADC2
-    { .pin = DEFIO_TAG_E__PD8,  .channel = ADC_Channel_12 }, // ADC4
-    { .pin = DEFIO_TAG_E__PD9,  .channel = ADC_Channel_13 }, // ADC4
-    { .pin = DEFIO_TAG_E__PD10, .channel = ADC_Channel_7  }, // ADC34
-    { .pin = DEFIO_TAG_E__PD11, .channel = ADC_Channel_8  }, // ADC34
-    { .pin = DEFIO_TAG_E__PD12, .channel = ADC_Channel_9  }, // ADC34
-    { .pin = DEFIO_TAG_E__PD13, .channel = ADC_Channel_10 }, // ADC34
-    { .pin = DEFIO_TAG_E__PD14, .channel = ADC_Channel_11 }, // ADC34
-    { .pin = DEFIO_TAG_E__PE7,  .channel = ADC_Channel_13 }, // ADC3
-    { .pin = DEFIO_TAG_E__PE8,  .channel = ADC_Channel_6  }, // ADC34
-    { .pin = DEFIO_TAG_E__PE9,  .channel = ADC_Channel_2  }, // ADC3
-    { .pin = DEFIO_TAG_E__PE10, .channel = ADC_Channel_14 }, // ADC3
-    { .pin = DEFIO_TAG_E__PE11, .channel = ADC_Channel_15 }, // ADC3
-    { .pin = DEFIO_TAG_E__PE12, .channel = ADC_Channel_16 }, // ADC3
-    { .pin = DEFIO_TAG_E__PE13, .channel = ADC_Channel_3  }, // ADC3
-    { .pin = DEFIO_TAG_E__PE14, .channel = ADC_Channel_1  }, // ADC4
-    { .pin = DEFIO_TAG_E__PE15, .channel = ADC_Channel_2  }, // ADC4
-    { .pin = DEFIO_TAG_E__PF2,  .channel = ADC_Channel_10 }, // ADC12
-    { .pin = DEFIO_TAG_E__PF4,  .channel = ADC_Channel_5  }, // ADC1
+const adcTagMap_t adcTagMap[] = { 
+    { DEFIO_TAG_E__PA0,  ADC_Channel_1  }, // ADC1
+    { DEFIO_TAG_E__PA1,  ADC_Channel_2  }, // ADC1
+    { DEFIO_TAG_E__PA2,  ADC_Channel_3  }, // ADC1
+    { DEFIO_TAG_E__PA3,  ADC_Channel_4  }, // ADC1
+    { DEFIO_TAG_E__PA4,  ADC_Channel_1  }, // ADC2
+    { DEFIO_TAG_E__PA5,  ADC_Channel_2  }, // ADC2
+    { DEFIO_TAG_E__PA6,  ADC_Channel_3  }, // ADC2
+    { DEFIO_TAG_E__PA7,  ADC_Channel_4  }, // ADC2
+    { DEFIO_TAG_E__PB0,  ADC_Channel_12 }, // ADC3
+    { DEFIO_TAG_E__PB1,  ADC_Channel_1  }, // ADC3
+    { DEFIO_TAG_E__PB2,  ADC_Channel_12 }, // ADC2
+    { DEFIO_TAG_E__PB12, ADC_Channel_3  }, // ADC4
+    { DEFIO_TAG_E__PB13, ADC_Channel_5  }, // ADC3
+    { DEFIO_TAG_E__PB14, ADC_Channel_4  }, // ADC4
+    { DEFIO_TAG_E__PB15, ADC_Channel_5  }, // ADC4
+    { DEFIO_TAG_E__PC0,  ADC_Channel_6  }, // ADC12
+    { DEFIO_TAG_E__PC1,  ADC_Channel_7  }, // ADC12
+    { DEFIO_TAG_E__PC2,  ADC_Channel_8  }, // ADC12
+    { DEFIO_TAG_E__PC3,  ADC_Channel_9  }, // ADC12
+    { DEFIO_TAG_E__PC4,  ADC_Channel_5  }, // ADC2
+    { DEFIO_TAG_E__PC5,  ADC_Channel_11 }, // ADC2
+    { DEFIO_TAG_E__PD8,  ADC_Channel_12 }, // ADC4
+    { DEFIO_TAG_E__PD9,  ADC_Channel_13 }, // ADC4
+    { DEFIO_TAG_E__PD10, ADC_Channel_7  }, // ADC34
+    { DEFIO_TAG_E__PD11, ADC_Channel_8  }, // ADC34
+    { DEFIO_TAG_E__PD12, ADC_Channel_9  }, // ADC34
+    { DEFIO_TAG_E__PD13, ADC_Channel_10 }, // ADC34
+    { DEFIO_TAG_E__PD14, ADC_Channel_11 }, // ADC34
+    { DEFIO_TAG_E__PE7,  ADC_Channel_13 }, // ADC3
+    { DEFIO_TAG_E__PE8,  ADC_Channel_6  }, // ADC34
+    { DEFIO_TAG_E__PE9,  ADC_Channel_2  }, // ADC3
+    { DEFIO_TAG_E__PE10, ADC_Channel_14 }, // ADC3
+    { DEFIO_TAG_E__PE11, ADC_Channel_15 }, // ADC3
+    { DEFIO_TAG_E__PE12, ADC_Channel_16 }, // ADC3
+    { DEFIO_TAG_E__PE13, ADC_Channel_3  }, // ADC3
+    { DEFIO_TAG_E__PE14, ADC_Channel_1  }, // ADC4
+    { DEFIO_TAG_E__PE15, ADC_Channel_2  }, // ADC4
+    { DEFIO_TAG_E__PF2,  ADC_Channel_10 }, // ADC12
+    { DEFIO_TAG_E__PF4,  ADC_Channel_5  }, // ADC1
 };
 
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
@@ -110,7 +110,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_BATTERY].adcChannel = adcChannelByPin(IO_TAG(VBAT_ADC_PIN));
+        adcConfig[ADC_BATTERY].adcChannel = adcChannelByTag(IO_TAG(VBAT_ADC_PIN));
         adcConfig[ADC_BATTERY].dmaIndex = adcChannelCount;
         adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_BATTERY].enabled = true;
@@ -123,7 +123,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_RSSI].adcChannel = adcChannelByPin(IO_TAG(RSSI_ADC_PIN));
+        adcConfig[ADC_RSSI].adcChannel = adcChannelByTag(IO_TAG(RSSI_ADC_PIN));
         adcConfig[ADC_RSSI].dmaIndex = adcChannelCount;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_RSSI].enabled = true;
@@ -136,7 +136,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_CURRENT].adcChannel = adcChannelByPin(IO_TAG(CURRENT_METER_ADC_PIN));
+        adcConfig[ADC_CURRENT].adcChannel = adcChannelByTag(IO_TAG(CURRENT_METER_ADC_PIN));
         adcConfig[ADC_CURRENT].dmaIndex = adcChannelCount;
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_CURRENT].enabled = true;
@@ -149,7 +149,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByPin(IO_TAG(EXTERNAL1_ADC_PIN));
+        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByTag(IO_TAG(EXTERNAL1_ADC_PIN));
         adcConfig[ADC_EXTERNAL1].dmaIndex = adcChannelCount;
         adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_EXTERNAL1].enabled = true;

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -41,6 +41,48 @@ const adcDevice_t adcHardware[] = {
     { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12), .rccDMA = RCC_AHB(DMA2), .DMAy_Channelx = DMA2_Channel1 }  
 };
 
+const adcPinMap_t adcPinMap[] = { 
+    { .pin = DEFIO_TAG_E__PA0,  .channel = ADC_Channel_1  }, // ADC1
+    { .pin = DEFIO_TAG_E__PA1,  .channel = ADC_Channel_2  }, // ADC1
+    { .pin = DEFIO_TAG_E__PA2,  .channel = ADC_Channel_3  }, // ADC1
+    { .pin = DEFIO_TAG_E__PA3,  .channel = ADC_Channel_4  }, // ADC1
+    { .pin = DEFIO_TAG_E__PA4,  .channel = ADC_Channel_1  }, // ADC2
+    { .pin = DEFIO_TAG_E__PA5,  .channel = ADC_Channel_2  }, // ADC2
+    { .pin = DEFIO_TAG_E__PA6,  .channel = ADC_Channel_3  }, // ADC2
+    { .pin = DEFIO_TAG_E__PA7,  .channel = ADC_Channel_4  }, // ADC2
+    { .pin = DEFIO_TAG_E__PB0,  .channel = ADC_Channel_12 }, // ADC3
+    { .pin = DEFIO_TAG_E__PB1,  .channel = ADC_Channel_1  }, // ADC3
+    { .pin = DEFIO_TAG_E__PB2,  .channel = ADC_Channel_12 }, // ADC2
+    { .pin = DEFIO_TAG_E__PB12, .channel = ADC_Channel_3  }, // ADC4
+    { .pin = DEFIO_TAG_E__PB13, .channel = ADC_Channel_5  }, // ADC3
+    { .pin = DEFIO_TAG_E__PB14, .channel = ADC_Channel_4  }, // ADC4
+    { .pin = DEFIO_TAG_E__PB15, .channel = ADC_Channel_5  }, // ADC4
+    { .pin = DEFIO_TAG_E__PC0,  .channel = ADC_Channel_6  }, // ADC12
+    { .pin = DEFIO_TAG_E__PC1,  .channel = ADC_Channel_7  }, // ADC12
+    { .pin = DEFIO_TAG_E__PC2,  .channel = ADC_Channel_8  }, // ADC12
+    { .pin = DEFIO_TAG_E__PC3,  .channel = ADC_Channel_9  }, // ADC12
+    { .pin = DEFIO_TAG_E__PC4,  .channel = ADC_Channel_5  }, // ADC2
+    { .pin = DEFIO_TAG_E__PC5,  .channel = ADC_Channel_11 }, // ADC2
+    { .pin = DEFIO_TAG_E__PD8,  .channel = ADC_Channel_12 }, // ADC4
+    { .pin = DEFIO_TAG_E__PD9,  .channel = ADC_Channel_13 }, // ADC4
+    { .pin = DEFIO_TAG_E__PD10, .channel = ADC_Channel_7  }, // ADC34
+    { .pin = DEFIO_TAG_E__PD11, .channel = ADC_Channel_8  }, // ADC34
+    { .pin = DEFIO_TAG_E__PD12, .channel = ADC_Channel_9  }, // ADC34
+    { .pin = DEFIO_TAG_E__PD13, .channel = ADC_Channel_10 }, // ADC34
+    { .pin = DEFIO_TAG_E__PD14, .channel = ADC_Channel_11 }, // ADC34
+    { .pin = DEFIO_TAG_E__PE7,  .channel = ADC_Channel_13 }, // ADC3
+    { .pin = DEFIO_TAG_E__PE8,  .channel = ADC_Channel_6  }, // ADC34
+    { .pin = DEFIO_TAG_E__PE9,  .channel = ADC_Channel_2  }, // ADC3
+    { .pin = DEFIO_TAG_E__PE10, .channel = ADC_Channel_14 }, // ADC3
+    { .pin = DEFIO_TAG_E__PE11, .channel = ADC_Channel_15 }, // ADC3
+    { .pin = DEFIO_TAG_E__PE12, .channel = ADC_Channel_16 }, // ADC3
+    { .pin = DEFIO_TAG_E__PE13, .channel = ADC_Channel_3  }, // ADC3
+    { .pin = DEFIO_TAG_E__PE14, .channel = ADC_Channel_1  }, // ADC4
+    { .pin = DEFIO_TAG_E__PE15, .channel = ADC_Channel_2  }, // ADC4
+    { .pin = DEFIO_TAG_E__PF2,  .channel = ADC_Channel_10 }, // ADC12
+    { .pin = DEFIO_TAG_E__PF4,  .channel = ADC_Channel_5  }, // ADC1
+};
+
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
 {
     if (instance == ADC1) 
@@ -68,7 +110,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_BATTERY].adcChannel = VBAT_ADC_CHANNEL;
+        adcConfig[ADC_BATTERY].adcChannel = adcChannelByPin(IO_TAG(VBAT_ADC_PIN));
         adcConfig[ADC_BATTERY].dmaIndex = adcChannelCount;
         adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_BATTERY].enabled = true;
@@ -81,7 +123,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_RSSI].adcChannel = RSSI_ADC_CHANNEL;
+        adcConfig[ADC_RSSI].adcChannel = adcChannelByPin(IO_TAG(RSSI_ADC_PIN));
         adcConfig[ADC_RSSI].dmaIndex = adcChannelCount;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_RSSI].enabled = true;
@@ -94,7 +136,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_CURRENT].adcChannel = CURRENT_METER_ADC_CHANNEL;
+        adcConfig[ADC_CURRENT].adcChannel = adcChannelByPin(IO_TAG(CURRENT_METER_ADC_PIN));
         adcConfig[ADC_CURRENT].dmaIndex = adcChannelCount;
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_CURRENT].enabled = true;
@@ -107,7 +149,7 @@ void adcInit(drv_adc_config_t *init)
 	    IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
-        adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
+        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByPin(IO_TAG(EXTERNAL1_ADC_PIN));
         adcConfig[ADC_EXTERNAL1].dmaIndex = adcChannelCount;
         adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_601Cycles5;
         adcConfig[ADC_EXTERNAL1].enabled = true;

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -29,33 +29,44 @@
 
 #include "adc.h"
 #include "adc_impl.h"
+#include "io.h"
+#include "rcc.h"
 
 #ifndef ADC_INSTANCE
 #define ADC_INSTANCE                ADC1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
 #endif
+
+const adcDevice_t adcHardware[] = { 
+    { .ADCx = ADC1, .rccADC = RCC_AHB(ADC12), .rccDMA = RCC_AHB(DMA1), .DMAy_Channelx = DMA1_Channel1 },  
+    { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12), .rccDMA = RCC_AHB(DMA2), .DMAy_Channelx = DMA2_Channel1 }  
+};
+
+ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
+{
+    if (instance == ADC1) 
+        return ADCDEV_1;
+
+    if (instance == ADC2)
+        return ADCDEV_2;
+
+    return ADCINVALID;
+}
 
 void adcInit(drv_adc_config_t *init)
 {
     UNUSED(init);
     ADC_InitTypeDef ADC_InitStructure;
     DMA_InitTypeDef DMA_InitStructure;
-    GPIO_InitTypeDef GPIO_InitStructure;
 
     uint8_t i;
     uint8_t adcChannelCount = 0;
 
     memset(&adcConfig, 0, sizeof(adcConfig));
 
-    GPIO_StructInit(&GPIO_InitStructure);
-    GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AN;
-    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL ;
-
-#ifdef VBAT_ADC_GPIO
+#ifdef VBAT_ADC_PIN
     if (init->enableVBat) {
-        GPIO_InitStructure.GPIO_Pin   = VBAT_ADC_GPIO_PIN;
-        GPIO_Init(VBAT_ADC_GPIO, &GPIO_InitStructure);
+	    IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+	    IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
         adcConfig[ADC_BATTERY].adcChannel = VBAT_ADC_CHANNEL;
         adcConfig[ADC_BATTERY].dmaIndex = adcChannelCount;
@@ -65,10 +76,10 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
-#ifdef RSSI_ADC_GPIO
+#ifdef RSSI_ADC_PIN
     if (init->enableRSSI) {
-        GPIO_InitStructure.GPIO_Pin = RSSI_ADC_GPIO_PIN;
-        GPIO_Init(RSSI_ADC_GPIO, &GPIO_InitStructure);
+	    IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+	    IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
         adcConfig[ADC_RSSI].adcChannel = RSSI_ADC_CHANNEL;
         adcConfig[ADC_RSSI].dmaIndex = adcChannelCount;
@@ -80,8 +91,8 @@ void adcInit(drv_adc_config_t *init)
 
 #ifdef CURRENT_METER_ADC_GPIO
     if (init->enableCurrentMeter) {
-        GPIO_InitStructure.GPIO_Pin = CURRENT_METER_ADC_GPIO_PIN;
-        GPIO_Init(CURRENT_METER_ADC_GPIO, &GPIO_InitStructure);
+	    IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
         adcConfig[ADC_CURRENT].adcChannel = CURRENT_METER_ADC_CHANNEL;
         adcConfig[ADC_CURRENT].dmaIndex = adcChannelCount;
@@ -93,8 +104,8 @@ void adcInit(drv_adc_config_t *init)
 
 #ifdef EXTERNAL1_ADC_GPIO
     if (init->enableExternal1) {
-        GPIO_InitStructure.GPIO_Pin   = EXTERNAL1_ADC_GPIO_PIN;
-        GPIO_Init(EXTERNAL1_ADC_GPIO, &GPIO_InitStructure);
+	    IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
+	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
 
         adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
         adcConfig[ADC_EXTERNAL1].dmaIndex = adcChannelCount;
@@ -104,13 +115,20 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
-    RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div256);  // 72 MHz divided by 256 = 281.25 kHz
-    RCC_AHBPeriphClockCmd(ADC_AHB_PERIPHERAL | RCC_AHBPeriph_ADC12, ENABLE);
+    ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);
+    if (device == ADCINVALID)
+        return;
+    
+    adcDevice_t adc = adcHardware[device];     
 
-    DMA_DeInit(ADC_DMA_CHANNEL);
+    RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div256);  // 72 MHz divided by 256 = 281.25 kHz
+    RCC_ClockCmd(adc.rccADC, ENABLE);
+    RCC_ClockCmd(adc.rccDMA, ENABLE);
+
+    DMA_DeInit(adc.DMAy_Channelx);
 
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&ADC_INSTANCE->DR;
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&adc.ADCx->DR;
     DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t)adcValues;
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralSRC;
     DMA_InitStructure.DMA_BufferSize = adcChannelCount;
@@ -122,20 +140,18 @@ void adcInit(drv_adc_config_t *init)
     DMA_InitStructure.DMA_Priority = DMA_Priority_High;
     DMA_InitStructure.DMA_M2M = DMA_M2M_Disable;
 
-    DMA_Init(ADC_DMA_CHANNEL, &DMA_InitStructure);
+    DMA_Init(adc.DMAy_Channelx, &DMA_InitStructure);
 
-    DMA_Cmd(ADC_DMA_CHANNEL, ENABLE);
-
+    DMA_Cmd(adc.DMAy_Channelx, ENABLE);
 
     // calibrate
 
-    ADC_VoltageRegulatorCmd(ADC_INSTANCE, ENABLE);
+    ADC_VoltageRegulatorCmd(adc.ADCx, ENABLE);
     delay(10);
-    ADC_SelectCalibrationMode(ADC_INSTANCE, ADC_CalibrationMode_Single);
-    ADC_StartCalibration(ADC_INSTANCE);
-    while(ADC_GetCalibrationStatus(ADC_INSTANCE) != RESET);
-    ADC_VoltageRegulatorCmd(ADC_INSTANCE, DISABLE);
-
+    ADC_SelectCalibrationMode(adc.ADCx, ADC_CalibrationMode_Single);
+    ADC_StartCalibration(adc.ADCx);
+    while (ADC_GetCalibrationStatus(adc.ADCx) != RESET);
+    ADC_VoltageRegulatorCmd(adc.ADCx, DISABLE);
 
     ADC_CommonInitTypeDef ADC_CommonInitStructure;
 
@@ -145,7 +161,7 @@ void adcInit(drv_adc_config_t *init)
     ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_1;
     ADC_CommonInitStructure.ADC_DMAMode = ADC_DMAMode_Circular;
     ADC_CommonInitStructure.ADC_TwoSamplingDelay = 0;
-    ADC_CommonInit(ADC_INSTANCE, &ADC_CommonInitStructure);
+    ADC_CommonInit(adc.ADCx, &ADC_CommonInitStructure);
 
     ADC_StructInit(&ADC_InitStructure);
 
@@ -158,24 +174,24 @@ void adcInit(drv_adc_config_t *init)
     ADC_InitStructure.ADC_AutoInjMode           = ADC_AutoInjec_Disable;
     ADC_InitStructure.ADC_NbrOfRegChannel       = adcChannelCount;
 
-    ADC_Init(ADC_INSTANCE, &ADC_InitStructure);
+    ADC_Init(adc.ADCx, &ADC_InitStructure);
 
     uint8_t rank = 1;
     for (i = 0; i < ADC_CHANNEL_COUNT; i++) {
         if (!adcConfig[i].enabled) {
             continue;
         }
-        ADC_RegularChannelConfig(ADC_INSTANCE, adcConfig[i].adcChannel, rank++, adcConfig[i].sampleTime);
+        ADC_RegularChannelConfig(adc.ADCx, adcConfig[i].adcChannel, rank++, adcConfig[i].sampleTime);
     }
 
-    ADC_Cmd(ADC_INSTANCE, ENABLE);
+    ADC_Cmd(adc.ADCx, ENABLE);
 
-    while(!ADC_GetFlagStatus(ADC_INSTANCE, ADC_FLAG_RDY));
+    while (!ADC_GetFlagStatus(adc.ADCx, ADC_FLAG_RDY));
 
-    ADC_DMAConfig(ADC_INSTANCE, ADC_DMAMode_Circular);
+    ADC_DMAConfig(adc.ADCx, ADC_DMAMode_Circular);
 
-    ADC_DMACmd(ADC_INSTANCE, ENABLE);
+    ADC_DMACmd(adc.ADCx, ENABLE);
 
-    ADC_StartConversion(ADC_INSTANCE);
+    ADC_StartConversion(adc.ADCx);
 }
 

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -44,33 +44,33 @@ const adcDevice_t adcHardware[] = {
 };
 
 /* note these could be packed up for saving space */
-const adcPinMap_t adcPinMap[] = { 
+const adcTagMap_t adcTagMap[] = { 
 /*
-    { .pin = DEFIO_TAG_E__PF3,  .channel = ADC_Channel_9  },
-    { .pin = DEFIO_TAG_E__PF4,  .channel = ADC_Channel_14 },
-    { .pin = DEFIO_TAG_E__PF5,  .channel = ADC_Channel_15 },
-    { .pin = DEFIO_TAG_E__PF6,  .channel = ADC_Channel_4  },
-    { .pin = DEFIO_TAG_E__PF7,  .channel = ADC_Channel_5  },
-    { .pin = DEFIO_TAG_E__PF8,  .channel = ADC_Channel_6  },
-    { .pin = DEFIO_TAG_E__PF9,  .channel = ADC_Channel_7  },
-    { .pin = DEFIO_TAG_E__PF10, .channel = ADC_Channel_8  },
+    { DEFIO_TAG_E__PF3,  ADC_Channel_9  },
+    { DEFIO_TAG_E__PF4,  ADC_Channel_14 },
+    { DEFIO_TAG_E__PF5,  ADC_Channel_15 },
+    { DEFIO_TAG_E__PF6,  ADC_Channel_4  },
+    { DEFIO_TAG_E__PF7,  ADC_Channel_5  },
+    { DEFIO_TAG_E__PF8,  ADC_Channel_6  },
+    { DEFIO_TAG_E__PF9,  ADC_Channel_7  },
+    { DEFIO_TAG_E__PF10, ADC_Channel_8  },
 */
-    { .pin = DEFIO_TAG_E__PC0, .channel = ADC_Channel_10 },
-    { .pin = DEFIO_TAG_E__PC1, .channel = ADC_Channel_11 },
-    { .pin = DEFIO_TAG_E__PC2, .channel = ADC_Channel_12 },
-    { .pin = DEFIO_TAG_E__PC3, .channel = ADC_Channel_13 },
-    { .pin = DEFIO_TAG_E__PC4, .channel = ADC_Channel_14 },
-    { .pin = DEFIO_TAG_E__PC5, .channel = ADC_Channel_15 },
-    { .pin = DEFIO_TAG_E__PB0, .channel = ADC_Channel_8  },
-    { .pin = DEFIO_TAG_E__PB1, .channel = ADC_Channel_9  },
-    { .pin = DEFIO_TAG_E__PA0, .channel = ADC_Channel_0  },
-    { .pin = DEFIO_TAG_E__PA1, .channel = ADC_Channel_1  },
-    { .pin = DEFIO_TAG_E__PA2, .channel = ADC_Channel_2  },
-    { .pin = DEFIO_TAG_E__PA3, .channel = ADC_Channel_3  },
-    { .pin = DEFIO_TAG_E__PA4, .channel = ADC_Channel_4  },
-    { .pin = DEFIO_TAG_E__PA5, .channel = ADC_Channel_5  },
-    { .pin = DEFIO_TAG_E__PA6, .channel = ADC_Channel_6  },
-    { .pin = DEFIO_TAG_E__PA7, .channel = ADC_Channel_7  },    
+    { DEFIO_TAG_E__PC0, ADC_Channel_10 },
+    { DEFIO_TAG_E__PC1, ADC_Channel_11 },
+    { DEFIO_TAG_E__PC2, ADC_Channel_12 },
+    { DEFIO_TAG_E__PC3, ADC_Channel_13 },
+    { DEFIO_TAG_E__PC4, ADC_Channel_14 },
+    { DEFIO_TAG_E__PC5, ADC_Channel_15 },
+    { DEFIO_TAG_E__PB0, ADC_Channel_8  },
+    { DEFIO_TAG_E__PB1, ADC_Channel_9  },
+    { DEFIO_TAG_E__PA0, ADC_Channel_0  },
+    { DEFIO_TAG_E__PA1, ADC_Channel_1  },
+    { DEFIO_TAG_E__PA2, ADC_Channel_2  },
+    { DEFIO_TAG_E__PA3, ADC_Channel_3  },
+    { DEFIO_TAG_E__PA4, ADC_Channel_4  },
+    { DEFIO_TAG_E__PA5, ADC_Channel_5  },
+    { DEFIO_TAG_E__PA6, ADC_Channel_6  },
+    { DEFIO_TAG_E__PA7, ADC_Channel_7  },    
 };
 
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
@@ -102,7 +102,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableVBat) {
         IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
         IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_BATTERY].adcChannel = adcChannelByPin(IO_TAG(VBAT_ADC_PIN)); //VBAT_ADC_CHANNEL;
+        adcConfig[ADC_BATTERY].adcChannel = adcChannelByTag(IO_TAG(VBAT_ADC_PIN)); //VBAT_ADC_CHANNEL;
         adcConfig[ADC_BATTERY].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_BATTERY].enabled = true;
         adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_480Cycles;
@@ -113,7 +113,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableExternal1) {
         IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByPin(IO_TAG(EXTERNAL1_ADC_PIN)); //EXTERNAL1_ADC_CHANNEL;
+        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByTag(IO_TAG(EXTERNAL1_ADC_PIN)); //EXTERNAL1_ADC_CHANNEL;
         adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_EXTERNAL1].enabled = true;
         adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_480Cycles;
@@ -124,7 +124,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableRSSI) {
         IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_RSSI].adcChannel = adcChannelByPin(IO_TAG(RSSI_ADC_PIN));  //RSSI_ADC_CHANNEL;
+        adcConfig[ADC_RSSI].adcChannel = adcChannelByTag(IO_TAG(RSSI_ADC_PIN));  //RSSI_ADC_CHANNEL;
         adcConfig[ADC_RSSI].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_RSSI].enabled = true;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_480Cycles;
@@ -135,7 +135,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableCurrentMeter) {
         IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_CURRENT].adcChannel = adcChannelByPin(IO_TAG(CURRENT_METER_ADC_PIN));  //CURRENT_METER_ADC_CHANNEL;
+        adcConfig[ADC_CURRENT].adcChannel = adcChannelByTag(IO_TAG(CURRENT_METER_ADC_PIN));  //CURRENT_METER_ADC_CHANNEL;
         adcConfig[ADC_CURRENT].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_CURRENT].enabled = true;
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_480Cycles;

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -23,6 +23,7 @@
 #include "system.h"
 
 #include "io.h"
+#include "io_impl.h"
 #include "rcc.h"
 
 #include "sensors/sensors.h" // FIXME dependency into the main code
@@ -38,8 +39,38 @@
 #endif
 
 const adcDevice_t adcHardware[] = { 
-	{ .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream4 },  
-	//{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream1 }  
+	{ .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream4, .channel = DMA_Channel_0 },  
+	//{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 }  
+};
+
+/* note these could be packed up for saving space */
+const adcPinMap_t adcPinMap[] = { 
+/*
+    { .pin = DEFIO_TAG_E__PF3,  .channel = ADC_Channel_9  },
+    { .pin = DEFIO_TAG_E__PF4,  .channel = ADC_Channel_14 },
+    { .pin = DEFIO_TAG_E__PF5,  .channel = ADC_Channel_15 },
+    { .pin = DEFIO_TAG_E__PF6,  .channel = ADC_Channel_4  },
+    { .pin = DEFIO_TAG_E__PF7,  .channel = ADC_Channel_5  },
+    { .pin = DEFIO_TAG_E__PF8,  .channel = ADC_Channel_6  },
+    { .pin = DEFIO_TAG_E__PF9,  .channel = ADC_Channel_7  },
+    { .pin = DEFIO_TAG_E__PF10, .channel = ADC_Channel_8  },
+*/
+    { .pin = DEFIO_TAG_E__PC0, .channel = ADC_Channel_10 },
+    { .pin = DEFIO_TAG_E__PC1, .channel = ADC_Channel_11 },
+    { .pin = DEFIO_TAG_E__PC2, .channel = ADC_Channel_12 },
+    { .pin = DEFIO_TAG_E__PC3, .channel = ADC_Channel_13 },
+    { .pin = DEFIO_TAG_E__PC4, .channel = ADC_Channel_14 },
+    { .pin = DEFIO_TAG_E__PC5, .channel = ADC_Channel_15 },
+    { .pin = DEFIO_TAG_E__PB0, .channel = ADC_Channel_8  },
+    { .pin = DEFIO_TAG_E__PB1, .channel = ADC_Channel_9  },
+    { .pin = DEFIO_TAG_E__PA0, .channel = ADC_Channel_0  },
+    { .pin = DEFIO_TAG_E__PA1, .channel = ADC_Channel_1  },
+    { .pin = DEFIO_TAG_E__PA2, .channel = ADC_Channel_2  },
+    { .pin = DEFIO_TAG_E__PA3, .channel = ADC_Channel_3  },
+    { .pin = DEFIO_TAG_E__PA4, .channel = ADC_Channel_4  },
+    { .pin = DEFIO_TAG_E__PA5, .channel = ADC_Channel_5  },
+    { .pin = DEFIO_TAG_E__PA6, .channel = ADC_Channel_6  },
+    { .pin = DEFIO_TAG_E__PA7, .channel = ADC_Channel_7  },    
 };
 
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
@@ -47,11 +78,12 @@ ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
 	if (instance == ADC1) 
 		return ADCDEV_1;
 /*
-	if (instance == ADC2)
+	if (instance == ADC2) // TODO add ADC2 and 3
 		return ADCDEV_2;
 */
 	return ADCINVALID;
 }
+
 void adcInit(drv_adc_config_t *init)
 {
     ADC_InitTypeDef ADC_InitStructure;
@@ -70,7 +102,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableVBat) {
         IOInit(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
         IOConfigGPIO(IOGetByTag(IO_TAG(VBAT_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_BATTERY].adcChannel = VBAT_ADC_CHANNEL;
+        adcConfig[ADC_BATTERY].adcChannel = adcChannelByPin(IO_TAG(VBAT_ADC_PIN)); //VBAT_ADC_CHANNEL;
         adcConfig[ADC_BATTERY].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_BATTERY].enabled = true;
         adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_480Cycles;
@@ -81,7 +113,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableExternal1) {
         IOInit(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(EXTERNAL1_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
+        adcConfig[ADC_EXTERNAL1].adcChannel = adcChannelByPin(IO_TAG(EXTERNAL1_ADC_PIN)); //EXTERNAL1_ADC_CHANNEL;
         adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_EXTERNAL1].enabled = true;
         adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_480Cycles;
@@ -92,7 +124,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableRSSI) {
         IOInit(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(RSSI_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_RSSI].adcChannel = RSSI_ADC_CHANNEL;
+        adcConfig[ADC_RSSI].adcChannel = adcChannelByPin(IO_TAG(RSSI_ADC_PIN));  //RSSI_ADC_CHANNEL;
         adcConfig[ADC_RSSI].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_RSSI].enabled = true;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_480Cycles;
@@ -103,7 +135,7 @@ void adcInit(drv_adc_config_t *init)
     if (init->enableCurrentMeter) {
         IOInit(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), OWNER_SYSTEM, RESOURCE_ADC);
 	    IOConfigGPIO(IOGetByTag(IO_TAG(CURRENT_METER_ADC_PIN)), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-        adcConfig[ADC_CURRENT].adcChannel = CURRENT_METER_ADC_CHANNEL;
+        adcConfig[ADC_CURRENT].adcChannel = adcChannelByPin(IO_TAG(CURRENT_METER_ADC_PIN));  //CURRENT_METER_ADC_CHANNEL;
         adcConfig[ADC_CURRENT].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_CURRENT].enabled = true;
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_480Cycles;
@@ -125,7 +157,7 @@ void adcInit(drv_adc_config_t *init)
 
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&adc.ADCx->DR;
-    DMA_InitStructure.DMA_Channel = DMA_Channel_0;
+    DMA_InitStructure.DMA_Channel = adc.channel;
     DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)adcValues;
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
     DMA_InitStructure.DMA_BufferSize = configuredAdcChannels;

--- a/src/main/drivers/barometer_spi_bmp280.c
+++ b/src/main/drivers/barometer_spi_bmp280.c
@@ -28,11 +28,13 @@
 #include "barometer.h"
 #include "barometer_bmp280.h"
 
-#define DISABLE_BMP280       GPIO_SetBits(BMP280_CS_GPIO,   BMP280_CS_PIN)
-#define ENABLE_BMP280        GPIO_ResetBits(BMP280_CS_GPIO, BMP280_CS_PIN)
+#define DISABLE_BMP280       IOHi(bmp280CsPin)
+#define ENABLE_BMP280        IOLo(bmp280CsPin)
 
 extern int32_t bmp280_up;
 extern int32_t bmp280_ut;
+
+static IO_t bmp280CsPin = IO_NONE;
 
 bool bmp280WriteRegister(uint8_t reg, uint8_t data)
 {
@@ -62,30 +64,11 @@ void bmp280SpiInit(void)
         return;
     }
 
-#ifdef STM32F303
-    RCC_AHBPeriphClockCmd(BMP280_CS_GPIO_CLK_PERIPHERAL, ENABLE);
+    bmp280CsPin = IOGetByTag(IO_TAG(BMP280_CS_PIN));
+    IOInit(bmp280CsPin, OWNER_BARO, RESOURCE_SPI);
+    IOConfigGPIO(bmp280CsPin, IOCFG_OUT_PP);
 
-    GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_InitStructure.GPIO_Pin = BMP280_CS_PIN;
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-    GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
-
-    GPIO_Init(BMP280_CS_GPIO, &GPIO_InitStructure);
-#endif
-
-#ifdef STM32F10X
-    RCC_APB2PeriphClockCmd(BMP280_CS_GPIO_CLK_PERIPHERAL, ENABLE);
-
-    gpio_config_t gpio;
-    gpio.mode = Mode_Out_PP;
-    gpio.pin = BMP280_CS_PIN;
-    gpio.speed = Speed_50MHz;
-    gpioInit(BMP280_CS_GPIO, &gpio);
-#endif
-
-    GPIO_SetBits(BMP280_CS_GPIO, BMP280_CS_PIN);
+    DISABLE_BMP280;
 
     spiSetDivisor(BMP280_SPI_INSTANCE, SPI_9MHZ_CLOCK_DIVIDER);
 

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -23,7 +23,9 @@ typedef enum {
     OWNER_FLASH,
     OWNER_USB,
     OWNER_BEEPER,
-    OWNER_OSD
+    OWNER_OSD,
+    OWNER_BARO,
+    OWNER_TOTAL_COUNT
 } resourceOwner_t;
 
 // Currently TIMER should be shared resource (softserial dualtimer and timerqueue needs to allocate timer channel, but pin can be used for other function)

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -47,8 +47,9 @@ typedef uint32_t timCCER_t;
 typedef uint32_t timSR_t;
 typedef uint32_t timCNT_t;
 #else
-# error "Unknown CPU defined"
+#error "Unknown CPU defined"
 #endif
+
 
 // use different types from capture and overflow - multiple overflow handlers are implemented as linked list
 struct timerCCHandlerRec_s;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -3038,7 +3038,7 @@ void cliProcess(void)
     }
 }
 
-const char * const ownerNames[] = {
+const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "FREE",
     "PWM IN",
     "PPM IN",
@@ -3060,6 +3060,8 @@ const char * const ownerNames[] = {
     "FLASH",
     "USB",
     "BEEPER",
+    "OSD",
+    "BARO",
 };
 
 static void cliResource(char *cmdline)

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -118,13 +118,8 @@
 #define USE_ADC
 
 #define ADC_INSTANCE         ADC2
-#define ADC_DMA_CHANNEL      DMA2_Channel1
-#define ADC_AHB_PERIPHERAL   RCC_AHBPeriph_DMA2
-
 //#define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define VBAT_ADC_PIN         PA4
-#define VBAT_ADC_CHANNEL     ADC_Channel_1
 
 // alternative defaults for AlienFlight F3 target
 #define ALIENFLIGHT

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -123,8 +123,7 @@
 
 //#define BOARD_HAS_VOLTAGE_DIVIDER
 
-#define VBAT_ADC_GPIO        GPIOA
-#define VBAT_ADC_GPIO_PIN    GPIO_Pin_4
+#define VBAT_ADC_PIN         PA4
 #define VBAT_ADC_CHANNEL     ADC_Channel_1
 
 // alternative defaults for AlienFlight F3 target

--- a/src/main/target/ALIENFLIGHTF4/target.h
+++ b/src/main/target/ALIENFLIGHTF4/target.h
@@ -152,18 +152,10 @@
 
 #define USE_ADC
 //#define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define VBAT_ADC_PIN               PC0
-#define VBAT_ADC_CHANNEL           ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN      PC1
-#define CURRENT_METER_ADC_CHANNEL  ADC_Channel_0
-
 #define RSSI_ADC_PIN               PC4
-#define RSSI_ADC_CHANNEL           ADC_Channel_4
-
 #define EXTERNAL1_ADC_GPIO_PIN     PC5
-#define EXTERNAL1_ADC_CHANNEL      ADC_Channel_5
 
 // LED strip configuration using RC5 pin.
 //#define LED_STRIP

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -133,7 +133,7 @@
 #define SPI3_MOSI_PIN           PC12
 
 #define USE_I2C
-#define I2C_DEVICE (I2CDEV_1)
+#define I2C_DEVICE             (I2CDEV_1)
 #define USE_I2C_PULLUP
 
 #define USE_ADC

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -138,7 +138,6 @@
 
 #define USE_ADC
 #define VBAT_ADC_PIN           PC3
-#define VBAT_ADC_CHANNEL       ADC_Channel_13
 
 #define DEFAULT_RX_FEATURE FEATURE_RX_PPM
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -92,15 +92,9 @@
 #define I2C_DEVICE (I2CDEV_2) // Flex port - SCL/PB10, SDA/PB11
 
 #define USE_ADC
-
 #define CURRENT_METER_ADC_PIN       PB1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
-
 #define VBAT_ADC_PIN                PA0
-#define VBAT_ADC_CHANNEL            ADC_Channel_0
-
 #define RSSI_ADC_PIN                PB0
-#define RSSI_ADC_CHANNEL            ADC_Channel_8
 
 #define LED_STRIP
 #define LED_STRIP_TIMER              TIM3

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -93,20 +93,17 @@
 
 #define USE_ADC
 
-#define CURRENT_METER_ADC_GPIO      GPIOB
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PB1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PA0
 #define VBAT_ADC_CHANNEL            ADC_Channel_0
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_0
+#define RSSI_ADC_PIN                PB0
 #define RSSI_ADC_CHANNEL            ADC_Channel_8
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM3
+#define LED_STRIP_TIMER              TIM3
 #define WS2811_DMA_TC_FLAG           DMA1_FLAG_TC6
 #define WS2811_DMA_HANDLER_IDENTIFER DMA1_CH6_HANDLER
 

--- a/src/main/target/CHEBUZZF3/target.h
+++ b/src/main/target/CHEBUZZF3/target.h
@@ -101,22 +101,11 @@
 #define I2C_DEVICE (I2CDEV_1)
 
 #define USE_ADC
-
 #define ADC_INSTANCE                ADC1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
-
 #define VBAT_ADC_PIN                PC0
-#define VBAT_ADC_CHANNEL            ADC_Channel_6
-
 #define CURRENT_METER_ADC_PIN       PC1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
-
 #define RSSI_ADC_PIN                PC2
-#define RSSI_ADC_CHANNEL            ADC_Channel_8
-
 #define EXTERNAL1_ADC_PIN           PC3
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
 // IO - assuming 303 in 64pin package, TODO
 #define TARGET_IO_PORTA 0xffff

--- a/src/main/target/CHEBUZZF3/target.h
+++ b/src/main/target/CHEBUZZF3/target.h
@@ -106,20 +106,16 @@
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
 #define ADC_DMA_CHANNEL             DMA1_Channel1
 
-#define VBAT_ADC_GPIO               GPIOC
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PC0
 #define VBAT_ADC_CHANNEL            ADC_Channel_6
 
-#define CURRENT_METER_ADC_GPIO      GPIOC
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PC1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
 
-#define RSSI_ADC_GPIO               GPIOC
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PC2
 #define RSSI_ADC_CHANNEL            ADC_Channel_8
 
-#define EXTERNAL1_ADC_GPIO          GPIOC
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_3
+#define EXTERNAL1_ADC_PIN           PC3
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
 // IO - assuming 303 in 64pin package, TODO

--- a/src/main/target/COLIBRI_RACE/target.h
+++ b/src/main/target/COLIBRI_RACE/target.h
@@ -126,20 +126,16 @@
 #define ADC_DMA_CHANNEL             DMA1_Channel1
 
 #define BOARD_HAS_VOLTAGE_DIVIDER
-#define VBAT_ADC_GPIO               GPIOC
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PC0
 #define VBAT_ADC_CHANNEL            ADC_Channel_6
 
-#define CURRENT_METER_ADC_GPIO      GPIOC
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PC1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
 
-#define RSSI_ADC_GPIO               GPIOC
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PC2
 #define RSSI_ADC_CHANNEL            ADC_Channel_8
 
-#define EXTERNAL1_ADC_GPIO          GPIOC
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_3
+#define EXTERNAL1_ADC_PIN           PC3
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
 #define LED_STRIP

--- a/src/main/target/COLIBRI_RACE/target.h
+++ b/src/main/target/COLIBRI_RACE/target.h
@@ -103,16 +103,8 @@
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_2)
 
-#define I2C2_SCL_GPIO        GPIOA
-#define I2C2_SCL_GPIO_AF     GPIO_AF_4
-#define I2C2_SCL_PIN         GPIO_Pin_9
-#define I2C2_SCL_PIN_SOURCE  GPIO_PinSource9
-#define I2C2_SCL_CLK_SOURCE  RCC_AHBPeriph_GPIOA
-#define I2C2_SDA_GPIO        GPIOA
-#define I2C2_SDA_GPIO_AF     GPIO_AF_4
-#define I2C2_SDA_PIN         GPIO_Pin_10
-#define I2C2_SDA_PIN_SOURCE  GPIO_PinSource10
-#define I2C2_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOA
+#define I2C2_SCL_PIN         PA9
+#define I2C2_SDA_PIN         PA10
 
 #define USE_BST
 #define BST_DEVICE (BSTDEV_1)
@@ -120,28 +112,17 @@
 #define BST_CRC_POLYNOM                         0xD5
 
 #define USE_ADC
-
 #define ADC_INSTANCE                ADC1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
-
 #define BOARD_HAS_VOLTAGE_DIVIDER
 #define VBAT_ADC_PIN                PC0
-#define VBAT_ADC_CHANNEL            ADC_Channel_6
-
 #define CURRENT_METER_ADC_PIN       PC1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
-
 #define RSSI_ADC_PIN                PC2
-#define RSSI_ADC_CHANNEL            ADC_Channel_8
-
 #define EXTERNAL1_ADC_PIN           PC3
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
 #define LED_STRIP
 #define USE_COLIBTI_RACE_LED_DEFAULT_CONFIG
 
-#define LED_STRIP_TIMER TIM16
+#define LED_STRIP_TIMER                 TIM16
 
 #define WS2811_GPIO                     GPIOA
 #define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA

--- a/src/main/target/DOGE/target.h
+++ b/src/main/target/DOGE/target.h
@@ -34,44 +34,29 @@
 #define BEEPER_INVERTED
 
 // tqfp48 pin 3
-#define MPU6500_CS_GPIO_CLK_PERIPHERAL   RCC_AHBPeriph_GPIOC
-#define MPU6500_CS_GPIO                  GPIOC
 #define MPU6500_CS_PIN                   PC14
 #define MPU6500_SPI_INSTANCE             SPI1
 
 // tqfp48 pin 25
-#define BMP280_CS_GPIO_CLK_PERIPHERAL    RCC_AHBPeriph_GPIOB
-#define BMP280_CS_GPIO                   GPIOB
-#define BMP280_CS_PIN                    GPIO_Pin_12
+#define BMP280_CS_PIN                    PB12
 #define BMP280_SPI_INSTANCE              SPI2
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
 
-#define SPI1_GPIO               GPIOB
-#define SPI1_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOB
 // tqfp48 pin 39
 #define SPI1_SCK_PIN            PB3
-#define SPI1_SCK_PIN_SOURCE     GPIO_PinSource3
 // tqfp48 pin 40
 #define SPI1_MISO_PIN           PB4
-#define SPI1_MISO_PIN_SOURCE    GPIO_PinSource4
 // tqfp48 pin 41
 #define SPI1_MOSI_PIN           PB5
-#define SPI1_MOSI_PIN_SOURCE    GPIO_PinSource5
-
-#define SPI2_GPIO               GPIOB
-#define SPI2_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOB
 // tqfp48 pin 26
 #define SPI2_SCK_PIN            PB13
-#define SPI2_SCK_PIN_SOURCE     GPIO_PinSource13
 // tqfp48 pin 27
 #define SPI2_MISO_PIN           PB14
-#define SPI2_MISO_PIN_SOURCE    GPIO_PinSource14
 // tqfp48 pin 28
 #define SPI2_MOSI_PIN           PB15
-#define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource15
 
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
@@ -139,18 +124,9 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define ADC_INSTANCE                ADC2
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-
-// tqfp48 pin 14
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
-// tqfp48 pin 15
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
 // mpu_int definition in sensors/initialisation.c
 #define USE_EXTI

--- a/src/main/target/DOGE/target.h
+++ b/src/main/target/DOGE/target.h
@@ -145,13 +145,11 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 
 // tqfp48 pin 14
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
 // tqfp48 pin 15
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
 // mpu_int definition in sensors/initialisation.c

--- a/src/main/target/EUSTM32F103RC/target.h
+++ b/src/main/target/EUSTM32F103RC/target.h
@@ -97,18 +97,10 @@
 // #define SOFT_I2C_PB67
 
 #define USE_ADC
-
 #define CURRENT_METER_ADC_PIN       PB1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_4
-
 #define RSSI_ADC_PIN                PA1
-#define RSSI_ADC_CHANNEL            ADC_Channel_1
-
 #define EXTERNAL1_ADC_PIN           PA5
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 //#define LED_STRIP
 #define LED_STRIP_TIMER TIM3

--- a/src/main/target/EUSTM32F103RC/target.h
+++ b/src/main/target/EUSTM32F103RC/target.h
@@ -98,20 +98,16 @@
 
 #define USE_ADC
 
-#define CURRENT_METER_ADC_GPIO      GPIOB
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PB1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_4
 
-#define RSSI_ADC_GPIO               GPIOA
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_1
+#define RSSI_ADC_PIN                PA1
 #define RSSI_ADC_CHANNEL            ADC_Channel_1
 
-#define EXTERNAL1_ADC_GPIO          GPIOA
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_5
+#define EXTERNAL1_ADC_PIN           PA5
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 //#define LED_STRIP

--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -150,22 +150,13 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define ADC_INSTANCE                ADC1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-
 #define VBAT_ADC_PIN                PA0
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define RSSI_ADC_PIN                PA1
-#define RSSI_ADC_CHANNEL            ADC_Channel_2
-
 #define CURRENT_METER_ADC_PIN       PA2
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_3
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM1
+#define LED_STRIP_TIMER                 TIM1
 
 #define USE_LED_STRIP_ON_DMA1_CHANNEL2
 #define WS2811_GPIO                     GPIOA

--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -155,16 +155,13 @@
 #define ADC_DMA_CHANNEL             DMA1_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PA0
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define RSSI_ADC_GPIO               GPIOA
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_1
+#define RSSI_ADC_PIN                PA1
 #define RSSI_ADC_CHANNEL            ADC_Channel_2
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_2
+#define CURRENT_METER_ADC_PIN       PA2
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_3
 
 #define LED_STRIP

--- a/src/main/target/FURYF4/target.h
+++ b/src/main/target/FURYF4/target.h
@@ -144,15 +144,9 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
-#define VBAT_ADC_PIN           PC1
-#define VBAT_ADC_CHANNEL       ADC_Channel_11
-
-#define RSSI_ADC_GPIO_PIN      PC2
-#define RSSI_ADC_CHANNEL       ADC_Channel_12
-
+#define VBAT_ADC_PIN                PC1
+#define RSSI_ADC_GPIO_PIN           PC2
 #define CURRENT_METER_ADC_PIN       PC3
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_13
 
 #define DEFAULT_RX_FEATURE FEATURE_RX_PPM
 

--- a/src/main/target/IRCFUSIONF3/target.h
+++ b/src/main/target/IRCFUSIONF3/target.h
@@ -80,7 +80,6 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_2 // PB12,13,14,15 on AF5
 
-#define M25P16_CS_GPIO          GPIOB
 #define M25P16_CS_PIN           PB12
 #define M25P16_SPI_INSTANCE     SPI2
 
@@ -92,21 +91,18 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define SPEKTRUM_BIND
 // USART3,
-#define BIND_PIN   PB11
+#define BIND_PIN                    PB11
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 /*

--- a/src/main/target/IRCFUSIONF3/target.h
+++ b/src/main/target/IRCFUSIONF3/target.h
@@ -85,20 +85,10 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define SPEKTRUM_BIND
 // USART3,

--- a/src/main/target/KISSFC/target.h
+++ b/src/main/target/KISSFC/target.h
@@ -77,16 +77,13 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 

--- a/src/main/target/KISSFC/target.h
+++ b/src/main/target/KISSFC/target.h
@@ -72,20 +72,11 @@
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1) // PB6/SCL, PB7/SDA
 
-
+//#define USE_ADC
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
-
 
 
 #define SPEKTRUM_BIND

--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -93,25 +93,21 @@
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
 #define ADC_DMA_CHANNEL             DMA1_Channel1
 
-#define VBAT_ADC_GPIO               GPIOC
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PC0
 #define VBAT_ADC_CHANNEL            ADC_Channel_6
 
-#define CURRENT_METER_ADC_GPIO      GPIOC
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PC1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
 
-#define RSSI_ADC_GPIO               GPIOC
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PC2
 #define RSSI_ADC_CHANNEL            ADC_Channel_8
 
-#define EXTERNAL1_ADC_GPIO          GPIOC
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_3
+#define EXTERNAL1_ADC_PIN           PC3
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
-#define LED_STRIP
 
-#define LED_STRIP_TIMER TIM16
+#define LED_STRIP
+#define LED_STRIP_TIMER                 TIM16
 
 #define WS2811_GPIO                     GPIOA
 #define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA

--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -88,23 +88,11 @@
 #define I2C_DEVICE (I2CDEV_2)
 
 #define USE_ADC
-
 #define ADC_INSTANCE                ADC1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
-
 #define VBAT_ADC_PIN                PC0
-#define VBAT_ADC_CHANNEL            ADC_Channel_6
-
 #define CURRENT_METER_ADC_PIN       PC1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
-
 #define RSSI_ADC_PIN                PC2
-#define RSSI_ADC_CHANNEL            ADC_Channel_8
-
 #define EXTERNAL1_ADC_PIN           PC3
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
-
 
 #define LED_STRIP
 #define LED_STRIP_TIMER                 TIM16

--- a/src/main/target/MOTOLAB/target.h
+++ b/src/main/target/MOTOLAB/target.h
@@ -119,19 +119,10 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA5
-#define VBAT_ADC_CHANNEL            ADC_Channel_2
-
 //#define CURRENT_METER_ADC_PIN       PA5
-//#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #if 1

--- a/src/main/target/MOTOLAB/target.h
+++ b/src/main/target/MOTOLAB/target.h
@@ -124,16 +124,13 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_5
+#define VBAT_ADC_PIN                PA5
 #define VBAT_ADC_CHANNEL            ADC_Channel_2
 
-//#define CURRENT_METER_ADC_GPIO      GPIOA
-//#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+//#define CURRENT_METER_ADC_PIN       PA5
 //#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -147,18 +147,10 @@
 // #define SOFT_I2C_PB67
 
 #define USE_ADC
-
 #define CURRENT_METER_ADC_PIN       PB1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_4
-
 #define RSSI_ADC_PIN                PA1
-#define RSSI_ADC_CHANNEL            ADC_Channel_1
-
 #define EXTERNAL1_ADC_PIN           PA5
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 
 #define LED_STRIP

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -33,8 +33,8 @@
 #define BARO_XCLR_PIN    PC13
 #define BARO_EOC_PIN     PC14
 
-#define INVERTER    PB2 // PB2 (BOOT1) abused as inverter select GPIO
-#define INVERTER_USART USART2
+#define INVERTER         PB2 // PB2 (BOOT1) abused as inverter select GPIO
+#define INVERTER_USART   USART2
 
 #define USE_EXTI
 
@@ -148,25 +148,21 @@
 
 #define USE_ADC
 
-#define CURRENT_METER_ADC_GPIO      GPIOB
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PB1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_4
 
-#define RSSI_ADC_GPIO               GPIOA
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_1
+#define RSSI_ADC_PIN                PA1
 #define RSSI_ADC_CHANNEL            ADC_Channel_1
 
-#define EXTERNAL1_ADC_GPIO          GPIOA
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_5
+#define EXTERNAL1_ADC_PIN           PA5
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM3
+#define LED_STRIP_TIMER              TIM3
 #define WS2811_DMA_TC_FLAG           DMA1_FLAG_TC6
 #define WS2811_DMA_HANDLER_IDENTIFER DMA1_CH6_HANDLER
 

--- a/src/main/target/OLIMEXINO/target.h
+++ b/src/main/target/OLIMEXINO/target.h
@@ -84,20 +84,16 @@
 
 #define USE_ADC
 
-#define CURRENT_METER_ADC_GPIO      GPIOB
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PB1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_4
 
-#define RSSI_ADC_GPIO               GPIOA
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_1
+#define RSSI_ADC_PIN                PA1
 #define RSSI_ADC_CHANNEL            ADC_Channel_1
 
-#define EXTERNAL1_ADC_GPIO          GPIOA
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_5
+#define EXTERNAL1_ADC_PIN           PA5
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 //#define LED_STRIP

--- a/src/main/target/OLIMEXINO/target.h
+++ b/src/main/target/OLIMEXINO/target.h
@@ -83,18 +83,10 @@
 // #define SOFT_I2C_PB67
 
 #define USE_ADC
-
 #define CURRENT_METER_ADC_PIN       PB1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_4
-
 #define RSSI_ADC_PIN                PA1
-#define RSSI_ADC_CHANNEL            ADC_Channel_1
-
 #define EXTERNAL1_ADC_PIN           PA5
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 //#define LED_STRIP
 //#define LED_STRIP_TIMER TIM3

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -160,25 +160,21 @@
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
 
-
 #define ADC_INSTANCE                ADC2
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM1
+#define LED_STRIP_TIMER             TIM1
 
 #define WS2811_GPIO                     GPIOA
 #define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -159,19 +159,11 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
+
 
 #define LED_STRIP
 #define LED_STRIP_TIMER             TIM1

--- a/src/main/target/PIKOBLX/target.h
+++ b/src/main/target/PIKOBLX/target.h
@@ -87,19 +87,10 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define CURRENT_METER_ADC_PIN       PA2
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_3
-
 #define VBAT_ADC_PIN                PA5
-#define VBAT_ADC_CHANNEL            ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #if 1

--- a/src/main/target/PIKOBLX/target.h
+++ b/src/main/target/PIKOBLX/target.h
@@ -92,21 +92,18 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_2
+#define CURRENT_METER_ADC_PIN       PA2
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_3
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_5
+#define VBAT_ADC_PIN                PA5
 #define VBAT_ADC_CHANNEL            ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #if 1
-#define LED_STRIP_TIMER TIM16
+#define LED_STRIP_TIMER                 TIM16
 
 #define USE_LED_STRIP_ON_DMA1_CHANNEL3
 #define WS2811_GPIO                     GPIOB

--- a/src/main/target/PORT103R/target.h
+++ b/src/main/target/PORT103R/target.h
@@ -38,22 +38,17 @@
 #define USE_SPI_DEVICE_2
 
 #define PORT103R_SPI_INSTANCE     SPI2
-#define PORT103R_SPI_CS_GPIO      GPIOB
 #define PORT103R_SPI_CS_PIN       PB12
 
 // We either have this 16mbit flash chip on SPI or the MPU6500 acc/gyro depending on board revision:
-#define M25P16_CS_GPIO        PORT103R_SPI_CS_GPIO
 #define M25P16_CS_PIN         PORT103R_SPI_CS_PIN
 #define M25P16_SPI_INSTANCE   PORT103R_SPI_INSTANCE
 
-#define MPU6000_CS_GPIO       PORT103R_SPI_CS_GPIO
 #define MPU6000_CS_PIN        PORT103R_SPI_CS_PIN
 #define MPU6000_SPI_INSTANCE  PORT103R_SPI_INSTANCE
 
-#define MPU6500_CS_GPIO       PORT103R_SPI_CS_GPIO
 #define MPU6500_CS_PIN        PORT103R_SPI_CS_PIN
 #define MPU6500_SPI_INSTANCE  PORT103R_SPI_INSTANCE
-#define MPU6500_CS_GPIO_CLK_PERIPHERAL   RCC_APB2Periph_GPIOB
 
 #define GYRO
 #define USE_FAKE_GYRO
@@ -115,18 +110,10 @@
 // #define SOFT_I2C_PB67
 
 #define USE_ADC
-
 #define CURRENT_METER_ADC_PIN       PB1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_4
-
 #define RSSI_ADC_PIN                PA1
-#define RSSI_ADC_CHANNEL            ADC_Channel_1
-
 #define EXTERNAL1_ADC_PIN           PA5
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 //#define LED_STRIP
 //#define LED_STRIP_TIMER TIM3

--- a/src/main/target/PORT103R/target.h
+++ b/src/main/target/PORT103R/target.h
@@ -116,20 +116,16 @@
 
 #define USE_ADC
 
-#define CURRENT_METER_ADC_GPIO      GPIOB
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PB1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_9
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_4
 
-#define RSSI_ADC_GPIO               GPIOA
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_1
+#define RSSI_ADC_PIN                PA1
 #define RSSI_ADC_CHANNEL            ADC_Channel_1
 
-#define EXTERNAL1_ADC_GPIO          GPIOA
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_5
+#define EXTERNAL1_ADC_PIN           PA5
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_5
 
 //#define LED_STRIP

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -32,11 +32,11 @@
 	#define USBD_SERIALNUMBER_STRING "0x8020000"
 #endif
 
-#define LED0 PB5
-#define LED1 PB4
-#define BEEPER PB4
-#define INVERTER PC0 // PC0 used as inverter select GPIO
-#define INVERTER_USART USART1
+#define LED0            PB5
+#define LED1            PB4
+#define BEEPER          PB4
+#define INVERTER        PC0 // PC0 used as inverter select GPIO
+#define INVERTER_USART  USART1
 
 #define MPU6000_CS_PIN        PA4
 #define MPU6000_SPI_INSTANCE  SPI1
@@ -110,14 +110,10 @@
 
 #define USE_ADC
 #define CURRENT_METER_ADC_PIN       PC1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_11
-
 #define VBAT_ADC_PIN                PC2
-#define VBAT_ADC_CHANNEL            ADC_Channel_12
-
 #define RSSI_ADC_GPIO_PIN           PA0
-#define RSSI_ADC_CHANNEL            ADC_Channel_0
 
+ 
 #define SENSORS_SET (SENSOR_ACC)
 
 //#define LED_STRIP

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -112,11 +112,11 @@
 #define CURRENT_METER_ADC_PIN       PC1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_11
 
-#define VBAT_ADC_PIN           PC2
-#define VBAT_ADC_CHANNEL       ADC_Channel_12
+#define VBAT_ADC_PIN                PC2
+#define VBAT_ADC_CHANNEL            ADC_Channel_12
 
-#define RSSI_ADC_GPIO_PIN      PA0
-#define RSSI_ADC_CHANNEL       ADC_Channel_0
+#define RSSI_ADC_GPIO_PIN           PA0
+#define RSSI_ADC_CHANNEL            ADC_Channel_0
 
 #define SENSORS_SET (SENSOR_ACC)
 

--- a/src/main/target/REVONANO/target.h
+++ b/src/main/target/REVONANO/target.h
@@ -87,18 +87,9 @@
 #define I2C_DEVICE (I2CDEV_3)
 
 #define USE_ADC
-
-//FLEXI-IO	6
 #define CURRENT_METER_ADC_PIN       PA7
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
-
-//FLEXI-IO	7
 #define VBAT_ADC_PIN                PA6
-#define VBAT_ADC_CHANNEL            ADC_Channel_6
-
-//FLEXI-IO	8
 #define RSSI_ADC_PIN                PA5
-#define RSSI_ADC_CHANNEL            ADC_Channel_5
 
 
 //#define SENSORS_SET (SENSOR_ACC|SENSOR_MAG)

--- a/src/main/target/RMDO/target.h
+++ b/src/main/target/RMDO/target.h
@@ -112,20 +112,17 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM1
+#define LED_STRIP_TIMER                 TIM1
 
 #define USE_LED_STRIP_ON_DMA1_CHANNEL2
 #define WS2811_GPIO                     GPIOA

--- a/src/main/target/RMDO/target.h
+++ b/src/main/target/RMDO/target.h
@@ -106,20 +106,10 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #define LED_STRIP_TIMER                 TIM1

--- a/src/main/target/SINGULARITY/target.h
+++ b/src/main/target/SINGULARITY/target.h
@@ -97,8 +97,7 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOB
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_2
+#define VBAT_ADC_PIN                PB2
 #define VBAT_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP

--- a/src/main/target/SINGULARITY/target.h
+++ b/src/main/target/SINGULARITY/target.h
@@ -94,11 +94,7 @@
 #define BOARD_HAS_VOLTAGE_DIVIDER
 
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PB2
-#define VBAT_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #define LED_STRIP_TIMER TIM1

--- a/src/main/target/SIRINFPV/target.h
+++ b/src/main/target/SIRINFPV/target.h
@@ -143,8 +143,7 @@
 #define ADC_DMA_CHANNEL             DMA1_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PA0
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
 //#define USE_QUAD_MIXER_ONLY

--- a/src/main/target/SIRINFPV/target.h
+++ b/src/main/target/SIRINFPV/target.h
@@ -140,11 +140,7 @@
 #define BOARD_HAS_VOLTAGE_DIVIDER
 
 #define ADC_INSTANCE                ADC1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-
 #define VBAT_ADC_PIN                PA0
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
 
 //#define USE_QUAD_MIXER_ONLY
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -88,16 +88,9 @@
 #define I2C_DEVICE (I2CDEV_2) // SDA (PA10/AF4), SCL (PA9/AF4)
 
 #define USE_ADC
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA7
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_4
 
 #define DEFAULT_RX_FEATURE          FEATURE_RX_PPM
 

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -87,37 +87,24 @@
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_2) // SDA (PA10/AF4), SCL (PA9/AF4)
 
-#define I2C2_SCL_GPIO        GPIOA
-#define I2C2_SCL_GPIO_AF     GPIO_AF_4
-#define I2C2_SCL_PIN         GPIO_Pin_9
-#define I2C2_SCL_PIN_SOURCE  GPIO_PinSource9
-#define I2C2_SCL_CLK_SOURCE  RCC_AHBPeriph_GPIOA
-#define I2C2_SDA_GPIO        GPIOA
-#define I2C2_SDA_GPIO_AF     GPIO_AF_4
-#define I2C2_SDA_PIN         GPIO_Pin_10
-#define I2C2_SDA_PIN_SOURCE  GPIO_PinSource10
-#define I2C2_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOA
-
 #define USE_ADC
 
 #define ADC_INSTANCE                ADC2
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_7
+#define CURRENT_METER_ADC_PIN       PA7
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_4
 
-#define DEFAULT_RX_FEATURE FEATURE_RX_PPM
+#define DEFAULT_RX_FEATURE          FEATURE_RX_PPM
 
 #define LED_STRIP
 #if 1
 // LED strip configuration using PWM motor output pin 5.
-#define LED_STRIP_TIMER TIM16
+#define LED_STRIP_TIMER                 TIM16
 
 #define USE_LED_STRIP_ON_DMA1_CHANNEL3
 #define WS2811_GPIO                     GPIOA

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -114,20 +114,10 @@
 
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
-
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #define LED_STRIP_TIMER             TIM1

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -120,20 +120,17 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM1
+#define LED_STRIP_TIMER             TIM1
 
 #define USE_LED_STRIP_ON_DMA1_CHANNEL2
 #define WS2811_GPIO                     GPIOA

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -141,20 +141,17 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM1
+#define LED_STRIP_TIMER                 TIM1
 
 #define USE_LED_STRIP_ON_DMA1_CHANNEL2
 #define WS2811_GPIO                     GPIOA

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -136,19 +136,10 @@
 #define USE_ADC
 #define BOARD_HAS_VOLTAGE_DIVIDER
 
-
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #define LED_STRIP_TIMER                 TIM1

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -148,20 +148,17 @@
 #define ADC_DMA_CHANNEL             DMA2_Channel1
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
 
-#define VBAT_ADC_GPIO               GPIOA
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_PIN                PA4
 #define VBAT_ADC_CHANNEL            ADC_Channel_1
 
-#define CURRENT_METER_ADC_GPIO      GPIOA
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_5
+#define CURRENT_METER_ADC_PIN       PA5
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
 
-#define RSSI_ADC_GPIO               GPIOB
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PB2
 #define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM1
+#define LED_STRIP_TIMER                 TIM1
 
 #define WS2811_GPIO                     GPIOA
 #define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -145,17 +145,9 @@
 
 
 #define ADC_INSTANCE                ADC2
-#define ADC_DMA_CHANNEL             DMA2_Channel1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
-
 #define VBAT_ADC_PIN                PA4
-#define VBAT_ADC_CHANNEL            ADC_Channel_1
-
 #define CURRENT_METER_ADC_PIN       PA5
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_2
-
 #define RSSI_ADC_PIN                PB2
-#define RSSI_ADC_CHANNEL            ADC_Channel_12
 
 #define LED_STRIP
 #define LED_STRIP_TIMER                 TIM1

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -144,24 +144,20 @@
 #define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
 #define ADC_DMA_CHANNEL             DMA1_Channel1
 
-#define VBAT_ADC_GPIO               GPIOC
-#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_PIN                PC0
 #define VBAT_ADC_CHANNEL            ADC_Channel_6
 
-#define CURRENT_METER_ADC_GPIO      GPIOC
-#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_1
+#define CURRENT_METER_ADC_PIN       PC1
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
 
-#define RSSI_ADC_GPIO               GPIOC
-#define RSSI_ADC_GPIO_PIN           GPIO_Pin_2
+#define RSSI_ADC_PIN                PC2
 #define RSSI_ADC_CHANNEL            ADC_Channel_8
 
-#define EXTERNAL1_ADC_GPIO          GPIOC
-#define EXTERNAL1_ADC_GPIO_PIN      GPIO_Pin_3
+#define EXTERNAL1_ADC_PIN           PC3
 #define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
 #define LED_STRIP
-#define LED_STRIP_TIMER TIM16
+#define LED_STRIP_TIMER                 TIM16
 #define WS2811_GPIO                     GPIOB
 #define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOB
 #define WS2811_GPIO_AF                  GPIO_AF_1

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -139,22 +139,11 @@
 #define I2C_DEVICE (I2CDEV_1)
 
 #define USE_ADC
-
 #define ADC_INSTANCE                ADC1
-#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
-#define ADC_DMA_CHANNEL             DMA1_Channel1
-
 #define VBAT_ADC_PIN                PC0
-#define VBAT_ADC_CHANNEL            ADC_Channel_6
-
 #define CURRENT_METER_ADC_PIN       PC1
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_7
-
 #define RSSI_ADC_PIN                PC2
-#define RSSI_ADC_CHANNEL            ADC_Channel_8
-
 #define EXTERNAL1_ADC_PIN           PC3
-#define EXTERNAL1_ADC_CHANNEL       ADC_Channel_9
 
 #define LED_STRIP
 #define LED_STRIP_TIMER                 TIM16


### PR DESCRIPTION
- Fixed up BMP280 (SPI) to use new IO
- ADC: Moved to new IO for STM32F1 and F3
- ADC: Using RCC, DMA etc from hardware map arrays
- ADC: Channel numbers from pin mapping array (could include ADC instance also in future)
- Couple of warnings
