### PR TITLE
Bugfix MSP_ADVANCED_TUNING

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1259,7 +1259,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize16(currentProfile->pidProfile.yaw_lpf_hz);
         break;
     case MSP_ADVANCED_TUNING:
-        headSerialReply(3 * 3);
+        headSerialReply(3 * 2);
         serialize16(currentProfile->pidProfile.rollPitchItermIgnoreRate);
         serialize16(currentProfile->pidProfile.yawItermIgnoreRate);
         serialize16(currentProfile->pidProfile.yaw_p_limit);


### PR DESCRIPTION
This seems to be a bug, the configurator got stuck waiting for this MSP. 