### PR TITLE
Stop using uint8_t to determine if bytes are available from USB.

### DIFF
--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -62,7 +62,7 @@ typedef struct serialPort_s {
 struct serialPortVTable {
     void (*serialWrite)(serialPort_t *instance, uint8_t ch);
 
-    uint8_t (*serialTotalRxWaiting)(serialPort_t *instance);
+    uint32_t (*serialTotalRxWaiting)(serialPort_t *instance);
     uint8_t (*serialTotalTxFree)(serialPort_t *instance);
 
     uint8_t (*serialRead)(serialPort_t *instance);

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -165,7 +165,7 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback,
             DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
 #endif
             DMA_InitStructure.DMA_BufferSize = s->port.rxBufferSize;
-            
+
 #ifdef STM32F4
             DMA_InitStructure.DMA_Channel = s->rxDMAChannel;
             DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
@@ -176,7 +176,7 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback,
             DMA_Cmd(s->rxDMAStream, ENABLE);
             USART_DMACmd(s->USARTx, USART_DMAReq_Rx, ENABLE);
             s->rxDMAPos = DMA_GetCurrDataCounter(s->rxDMAStream);
-#else            
+#else
             DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralSRC;
             DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;
             DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t)s->port.rxBuffer;
@@ -228,7 +228,7 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback,
             DMA_Init(s->txDMAStream, &DMA_InitStructure);
             DMA_ITConfig(s->txDMAStream, DMA_IT_TC | DMA_IT_FE | DMA_IT_TE | DMA_IT_DME, ENABLE);
             DMA_SetCurrDataCounter(s->txDMAStream, 0);
-#else            
+#else
             DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralDST;
             DMA_InitStructure.DMA_Mode = DMA_Mode_Normal;
             DMA_DeInit(s->txDMAChannel);
@@ -292,7 +292,7 @@ void uartStartTxDMA(uartPort_t *s)
 #endif
 }
 
-uint8_t uartTotalRxBytesWaiting(serialPort_t *instance)
+uint32_t uartTotalRxBytesWaiting(serialPort_t *instance)
 {
     uartPort_t *s = (uartPort_t*)instance;
 #ifdef STM32F4

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -38,7 +38,7 @@
 
 typedef struct {
     serialPort_t port;
-    
+
 #ifdef STM32F4
 	DMA_Stream_TypeDef *rxDMAStream;
 	DMA_Stream_TypeDef *txDMAStream;
@@ -65,7 +65,7 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback,
 
 // serialPort API
 void uartWrite(serialPort_t *instance, uint8_t ch);
-uint8_t uartTotalRxBytesWaiting(serialPort_t *instance);
+uint32_t uartTotalRxBytesWaiting(serialPort_t *instance);
 uint8_t uartTotalTxBytesFree(serialPort_t *instance);
 uint8_t uartRead(serialPort_t *instance);
 void uartSetBaudRate(serialPort_t *s, uint32_t baudRate);

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -66,11 +66,11 @@ static bool isUsbVcpTransmitBufferEmpty(serialPort_t *instance)
     return true;
 }
 
-static uint8_t usbVcpAvailable(serialPort_t *instance)
+static uint32_t usbVcpAvailable(serialPort_t *instance)
 {
     UNUSED(instance);
 
-    return receiveLength & 0xFF; // FIXME use uint32_t return type everywhere
+    return receiveLength;
 }
 
 static uint8_t usbVcpRead(serialPort_t *instance)
@@ -120,7 +120,7 @@ static bool usbVcpFlush(vcpPort_t *port)
     if (!usbIsConnected() || !usbIsConfigured()) {
         return false;
     }
-    
+
     uint32_t txed;
     uint32_t start = millis();
 
@@ -147,7 +147,7 @@ static void usbVcpBeginWrite(serialPort_t *instance)
     port->buffering = true;
 }
 
-uint8_t usbTxBytesFree() 
+uint8_t usbTxBytesFree()
 {
     // Because we block upon transmit and don't buffer bytes, our "buffer" capacity is effectively unlimited.
     return 255;


### PR DESCRIPTION
If we buffer more than 256 bytes and the host stops sending, then we'll never be able to read it all. We'll read one byte at a time until its a multiple of 256 and then we'll think we're done.

This should help #481 because BLHeliSuite sends 263 bytes at a time frequently.