### PR TITLE
VCP fix from cleanflight PR#2120 by ledvinap

### DIFF
--- a/lib/main/STM32_USB-FS-Device_Driver/inc/usb_regs.h
+++ b/lib/main/STM32_USB-FS-Device_Driver/inc/usb_regs.h
@@ -228,8 +228,8 @@ enum EP_BUF_NUM
 /* GetDADDR */
 #define _GetDADDR()  ((__IO uint16_t) *DADDR)
 
-/* GetBTABLE */
-#define _GetBTABLE() ((__IO uint16_t) *BTABLE)
+/* GetBTABLE ; clear low-order bits explicitly to avoid problems in gcc 5.x */
+#define _GetBTABLE() (((__IO uint16_t) *BTABLE) & ~0x07)
 
 /* SetENDPOINT */
 #define _SetENDPOINT(bEpNum,wRegValue)  (*(EP0REG + bEpNum)= \


### PR DESCRIPTION
Will fix non working F3 VCP targets when build with GCC versions after 5.3. Tested this locally and going to merge this directly.