### PR TITLE
gyro sync and initialisation cleanup

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -325,9 +325,6 @@ extern uint32_t currentTime;
 //From rx.c:
 extern uint16_t rssi;
 
-//From gyro.c
-extern uint32_t targetLooptime;
-
 //From rc_controls.c
 extern uint32_t rcModeActivationMask;
 
@@ -1169,7 +1166,7 @@ static bool blackboxWriteSysinfo()
             }
             );
 
-        BLACKBOX_PRINT_HEADER_LINE("looptime:%d",                         targetLooptime);
+        BLACKBOX_PRINT_HEADER_LINE("looptime:%d",                         gyro.targetLooptime);
         BLACKBOX_PRINT_HEADER_LINE("rcRate:%d",                           masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rcRate8);
         BLACKBOX_PRINT_HEADER_LINE("rcExpo:%d",                           masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rcExpo8);
         BLACKBOX_PRINT_HEADER_LINE("rcYawRate:%d",                        masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rcYawRate8);

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -22,7 +22,6 @@
 #include "drivers/accgyro.h"
 #include "drivers/light_led.h"
 #include "drivers/sound_beeper.h"
-#include "drivers/gyro_sync.h"
 
 #include "sensors/sensors.h"
 #include "sensors/boardalignment.h"

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -750,7 +750,7 @@ void activateConfig(void)
         &currentProfile->pidProfile
     );
 
-    useGyroConfig(&masterConfig.gyroConfig, masterConfig.gyro_soft_lpf_hz);
+    gyroUseConfig(&masterConfig.gyroConfig, masterConfig.gyro_soft_lpf_hz);
 
 #ifdef TELEMETRY
     telemetryUseConfig(&masterConfig.telemetryConfig);

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -38,7 +38,6 @@
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/serial.h"
-#include "drivers/gyro_sync.h"
 #include "drivers/pwm_output.h"
 #include "drivers/max7456.h"
 

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -27,6 +27,7 @@ typedef struct gyro_s {
     sensorReadFuncPtr temperature;                          // read temperature if available
     sensorInterruptFuncPtr intStatus;
     float scale;                                            // scalefactor
+    uint32_t targetLooptime;
 } gyro_t;
 
 typedef struct acc_s {

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -32,7 +32,6 @@
 #include "gpio.h"
 #include "exti.h"
 #include "bus_i2c.h"
-#include "gyro_sync.h"
 
 #include "sensor.h"
 #include "accgyro.h"
@@ -300,11 +299,14 @@ bool mpuGyroRead(int16_t *gyroADC)
     return true;
 }
 
-void checkMPUDataReady(bool *mpuDataReadyPtr) {
+bool checkMPUDataReady(void)
+{
+    bool ret;
     if (mpuDataReady) {
-        *mpuDataReadyPtr = true;
+        ret = true;
         mpuDataReady= false;
     } else {
-        *mpuDataReadyPtr = false;
+        ret = false;
     }
+    return ret;
 }

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -185,4 +185,4 @@ void mpuIntExtiInit(void);
 bool mpuAccRead(int16_t *accData);
 bool mpuGyroRead(int16_t *gyroADC);
 mpuDetectionResult_t *detectMpu(const extiConfig_t *configToUse);
-void checkMPUDataReady(bool *mpuDataReadyPtr);
+bool checkMPUDataReady(void);

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -30,7 +30,6 @@
 #include "accgyro.h"
 #include "accgyro_mpu.h"
 #include "accgyro_mpu3050.h"
-#include "gyro_sync.h"
 
 // MPU3050, Standard address 0x68
 #define MPU3050_ADDRESS         0x68

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of Cleanflight.
  *
  * Cleanflight is free software: you can redistribute it and/or modify

--- a/src/main/drivers/gyro_sync.c
+++ b/src/main/drivers/gyro_sync.c
@@ -4,48 +4,40 @@
  *  Created on: 3 aug. 2015
  *      Author: borisb
  */
+
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #include "platform.h"
 #include "build_config.h"
-
-#include "common/axis.h"
-#include "common/maths.h"
 
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/gyro_sync.h"
 
-#include "sensors/sensors.h"
-#include "sensors/acceleration.h"
-
-#include "config/runtime_config.h"
-#include "config/config.h"
-
-extern gyro_t gyro;
-
-uint32_t targetLooptime;
 static uint8_t mpuDividerDrops;
 
-bool getMpuDataStatus(gyro_t *gyro)
+bool gyroSyncCheckUpdate(const gyro_t *gyro)
 {
-    bool mpuDataStatus;
     if (!gyro->intStatus)
-      return false;
-    gyro->intStatus(&mpuDataStatus);
-    return mpuDataStatus;
+        return false;
+    return gyro->intStatus();
 }
 
-bool gyroSyncCheckUpdate(void) {
-    return getMpuDataStatus(&gyro);
-}
+#define GYRO_LPF_256HZ      0
+#define GYRO_LPF_188HZ      1
+#define GYRO_LPF_98HZ       2
+#define GYRO_LPF_42HZ       3
+#define GYRO_LPF_20HZ       4
+#define GYRO_LPF_10HZ       5
+#define GYRO_LPF_5HZ        6
+#define GYRO_LPF_NONE       7
 
-void gyroUpdateSampleRate(uint8_t lpf, uint8_t gyroSyncDenominator) {
+uint32_t gyroSetSampleRate(uint8_t lpf, uint8_t gyroSyncDenominator)
+{
     int gyroSamplePeriod;
 
-    if (!lpf || lpf == 7) {
+    if (lpf == GYRO_LPF_256HZ || lpf == GYRO_LPF_NONE) {
         gyroSamplePeriod = 125;
     } else {
         gyroSamplePeriod = 1000;
@@ -54,9 +46,11 @@ void gyroUpdateSampleRate(uint8_t lpf, uint8_t gyroSyncDenominator) {
 
     // calculate gyro divider and targetLooptime (expected cycleTime)
     mpuDividerDrops  = gyroSyncDenominator - 1;
-    targetLooptime = (mpuDividerDrops + 1) * gyroSamplePeriod;
+    const uint32_t targetLooptime = gyroSyncDenominator * gyroSamplePeriod;
+    return targetLooptime;
 }
 
-uint8_t gyroMPU6xxxGetDividerDrops(void) {
+uint8_t gyroMPU6xxxGetDividerDrops(void)
+{
     return mpuDividerDrops;
 }

--- a/src/main/drivers/gyro_sync.h
+++ b/src/main/drivers/gyro_sync.h
@@ -5,8 +5,7 @@
  *      Author: borisb
  */
 
-extern uint32_t targetLooptime;
-
-bool gyroSyncCheckUpdate(void);
+struct gyro_s;
+bool gyroSyncCheckUpdate(const struct gyro_s *gyro);
 uint8_t gyroMPU6xxxGetDividerDrops(void);
-void gyroUpdateSampleRate(uint8_t lpf, uint8_t gyroSyncDenominator);
+uint32_t gyroSetSampleRate(uint8_t lpf, uint8_t gyroSyncDenominator);

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -22,4 +22,4 @@ typedef void (*sensorInitFuncPtr)(void);                    // sensor init proto
 typedef bool (*sensorReadFuncPtr)(int16_t *data);           // sensor read and align prototype
 typedef void (*sensorAccInitFuncPtr)(struct acc_s *acc);    // sensor init prototype
 typedef void (*sensorGyroInitFuncPtr)(uint8_t lpf);         // gyro sensor init prototype
-typedef void (*sensorInterruptFuncPtr)(bool *data);         // sensor Interrupt Data Ready
+typedef bool (*sensorInterruptFuncPtr)(void);               // sensor Interrupt Data Ready

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -36,7 +36,6 @@
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/system.h"
-#include "drivers/gyro_sync.h"
 
 #include "rx/rx.h"
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -29,7 +29,6 @@
 #include "common/filter.h"
 
 #include "drivers/sensor.h"
-#include "drivers/gyro_sync.h"
 
 #include "drivers/accgyro.h"
 #include "sensors/sensors.h"
@@ -74,7 +73,7 @@ pidControllerFuncPtr pid_controller = pidInteger; // which pid controller are we
 
 void setTargetPidLooptime(uint8_t pidProcessDenom) 
 {
-    targetPidLooptime = targetLooptime * pidProcessDenom;
+    targetPidLooptime = gyro.targetLooptime * pidProcessDenom;
 }
 
 uint16_t getDynamicKi(int axis, const pidProfile_t *pidProfile, int32_t angleRate) 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -52,7 +52,6 @@
 #include "drivers/inverter.h"
 #include "drivers/flash_m25p16.h"
 #include "drivers/sonar_hcsr04.h"
-#include "drivers/gyro_sync.h"
 #include "drivers/usb_io.h"
 #include "drivers/transponder_ir.h"
 #include "drivers/sdcard.h"

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -209,7 +209,7 @@ void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStat
 
     if (rcSticks == THR_LO + YAW_LO + PIT_LO + ROL_CE) {
         // GYRO calibration
-        gyroSetCalibrationCycles(gyroCalculateCalibratingCycles());
+        gyroSetCalibrationCycles();
 
 #ifdef GPS
         if (feature(FEATURE_GPS)) {

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -34,7 +34,6 @@
 #include "drivers/system.h"
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
-#include "drivers/gyro_sync.h"
 
 #include "sensors/barometer.h"
 #include "sensors/battery.h"

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -209,7 +209,7 @@ void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStat
 
     if (rcSticks == THR_LO + YAW_LO + PIT_LO + ROL_CE) {
         // GYRO calibration
-        gyroSetCalibrationCycles(calculateCalibratingCycles());
+        gyroSetCalibrationCycles(gyroCalculateCalibratingCycles());
 
 #ifdef GPS
         if (feature(FEATURE_GPS)) {

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -48,7 +48,6 @@
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/sdcard.h"
-#include "drivers/gyro_sync.h"
 
 #include "drivers/buf_writer.h"
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -40,7 +40,6 @@
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
-#include "drivers/gyro_sync.h"
 #include "drivers/sdcard.h"
 #include "drivers/buf_writer.h"
 #include "drivers/max7456.h"
@@ -109,8 +108,8 @@ void setGyroSamplingSpeed(uint16_t looptime) {
     uint16_t gyroSampleRate = 1000;
     uint8_t maxDivider = 1;
 
-    if (looptime != targetLooptime || looptime == 0) {
-        if (looptime == 0) looptime = targetLooptime; // needed for pid controller changes
+    if (looptime != gyro.targetLooptime || looptime == 0) {
+        if (looptime == 0) looptime = gyro.targetLooptime; // needed for pid controller changes
 #ifdef STM32F303xC
         if (looptime < 1000) {
             masterConfig.gyro_lpf = 0;
@@ -854,7 +853,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
     case MSP_LOOP_TIME:
         headSerialReply(2);
-        serialize16((uint16_t)targetLooptime);
+        serialize16((uint16_t)gyro.targetLooptime);
         break;
     case MSP_RC_TUNING:
         headSerialReply(11);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -49,7 +49,6 @@
 #include "drivers/inverter.h"
 #include "drivers/flash_m25p16.h"
 #include "drivers/sonar_hcsr04.h"
-#include "drivers/gyro_sync.h"
 #include "drivers/sdcard.h"
 #include "drivers/usb_io.h"
 #include "drivers/transponder_ir.h"
@@ -694,12 +693,12 @@ void main_init(void)
 
     /* Setup scheduler */
     schedulerInit();
-    rescheduleTask(TASK_GYROPID, targetLooptime);
+    rescheduleTask(TASK_GYROPID, gyro.targetLooptime);
     setTaskEnabled(TASK_GYROPID, true);
 
     if(sensors(SENSOR_ACC)) {
         setTaskEnabled(TASK_ACCEL, true);
-        switch(targetLooptime) {  // Switch statement kept in place to change acc rates in the future
+        switch(gyro.targetLooptime) {  // Switch statement kept in place to change acc rates in the future
              case(500):
              case(375):
              case(250):

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -625,7 +625,7 @@ void init(void)
     if (masterConfig.mixerMode == MIXER_GIMBAL) {
         accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
     }
-    gyroSetCalibrationCycles(calculateCalibratingCycles());
+    gyroSetCalibrationCycles(gyroCalculateCalibratingCycles());
 #ifdef BARO
     baroSetCalibrationCycles(CALIBRATING_BARO_CYCLES);
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -625,7 +625,7 @@ void init(void)
     if (masterConfig.mixerMode == MIXER_GIMBAL) {
         accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
     }
-    gyroSetCalibrationCycles(gyroCalculateCalibratingCycles());
+    gyroSetCalibrationCycles();
 #ifdef BARO
     baroSetCalibrationCycles(CALIBRATING_BARO_CYCLES);
 #endif

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -377,7 +377,7 @@ void mwArm(void)
     static bool firstArmingCalibrationWasCompleted;
 
     if (masterConfig.gyro_cal_on_first_arm && !firstArmingCalibrationWasCompleted) {
-        gyroSetCalibrationCycles(gyroCalculateCalibratingCycles());
+        gyroSetCalibrationCycles();
         armingCalibrationWasInitialised = true;
         firstArmingCalibrationWasCompleted = true;
     }

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -800,7 +800,7 @@ void taskMainPidLoopCheck(void)
 
     const uint32_t startTime = micros();
     while (true) {
-        if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - previousTime)) >= (targetLooptime + GYRO_WATCHDOG_DELAY))) {
+        if (gyroSyncCheckUpdate(&gyro) || ((currentDeltaTime + (micros() - previousTime)) >= (gyro.targetLooptime + GYRO_WATCHDOG_DELAY))) {
             static uint8_t pidUpdateCountdown;
 
             if (debugMode == DEBUG_PIDLOOP) {debug[0] = micros() - startTime;} // time spent busy waiting

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -377,7 +377,7 @@ void mwArm(void)
     static bool firstArmingCalibrationWasCompleted;
 
     if (masterConfig.gyro_cal_on_first_arm && !firstArmingCalibrationWasCompleted) {
-        gyroSetCalibrationCycles(calculateCalibratingCycles());
+        gyroSetCalibrationCycles(gyroCalculateCalibratingCycles());
         armingCalibrationWasInitialised = true;
         firstArmingCalibrationWasCompleted = true;
     }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -41,7 +41,6 @@
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/system.h"
-#include "drivers/gyro_sync.h"
 #include "rx/pwm.h"
 #include "rx/sbus.h"
 #include "rx/spektrum.h"

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -28,7 +28,6 @@
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/system.h"
-#include "drivers/gyro_sync.h"
 
 #include "sensors/battery.h"
 #include "sensors/sensors.h"

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -39,10 +39,9 @@ typedef struct gyroConfig_s {
     uint8_t gyroMovementCalibrationThreshold; // people keep forgetting that moving model while init results in wrong gyro offsets. and then they never reset gyro. so this is now on by default.
 } gyroConfig_t;
 
-void gyroUseConfig(gyroConfig_t *gyroConfigToUse, uint8_t gyro_lpf_hz);
-void gyroSetCalibrationCycles(uint16_t calibrationCyclesRequired);
+void gyroUseConfig(const gyroConfig_t *gyroConfigToUse, uint8_t gyro_lpf_hz);
+void gyroSetCalibrationCycles(void);
 void gyroInit(void);
 void gyroUpdate(void);
 bool isGyroCalibrationComplete(void);
-uint16_t gyroCalculateCalibratingCycles(void);
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -39,9 +39,10 @@ typedef struct gyroConfig_s {
     uint8_t gyroMovementCalibrationThreshold; // people keep forgetting that moving model while init results in wrong gyro offsets. and then they never reset gyro. so this is now on by default.
 } gyroConfig_t;
 
-void useGyroConfig(gyroConfig_t *gyroConfigToUse, float gyro_lpf_hz);
+void gyroUseConfig(gyroConfig_t *gyroConfigToUse, uint8_t gyro_lpf_hz);
 void gyroSetCalibrationCycles(uint16_t calibrationCyclesRequired);
+void gyroInit(void);
 void gyroUpdate(void);
 bool isGyroCalibrationComplete(void);
-uint16_t calculateCalibratingCycles(void);
+uint16_t gyroCalculateCalibratingCycles(void);
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -31,11 +31,9 @@ typedef enum {
 } gyroSensor_e;
 
 extern gyro_t gyro;
-extern sensor_align_e gyroAlign;
 
 extern int32_t gyroADC[XYZ_AXIS_COUNT];
 extern float gyroADCf[XYZ_AXIS_COUNT];
-extern int32_t gyroZero[FLIGHT_DYNAMICS_INDEX_COUNT];
 
 typedef struct gyroConfig_s {
     uint8_t gyroMovementCalibrationThreshold; // people keep forgetting that moving model while init results in wrong gyro offsets. and then they never reset gyro. so this is now on by default.

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -635,6 +635,7 @@ bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint8_t a
     // this is safe because either mpu6050 or mpu3050 or lg3d20 sets it, and in case of fail, we never get here.
     gyro.targetLooptime = gyroSetSampleRate(gyroLpf, gyroSyncDenominator);    // Set gyro sample rate before initialisation
     gyro.init(gyroLpf);
+    gyroInit();
 
     detectMag(magHardwareToUse);
 

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -79,6 +79,7 @@ extern float magneticDeclination;
 extern gyro_t gyro;
 extern baro_t baro;
 extern acc_t acc;
+extern sensor_align_e gyroAlign;
 
 uint8_t detectedSensors[MAX_SENSORS_TO_DETECT] = { GYRO_NONE, ACC_NONE, BARO_NONE, MAG_NONE };
 
@@ -632,7 +633,7 @@ bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint8_t a
         acc.init(&acc);
     }
     // this is safe because either mpu6050 or mpu3050 or lg3d20 sets it, and in case of fail, we never get here.
-    gyroUpdateSampleRate(gyroLpf, gyroSyncDenominator);    // Set gyro refresh rate before initialisation
+    gyro.targetLooptime = gyroSetSampleRate(gyroLpf, gyroSyncDenominator);    // Set gyro sample rate before initialisation
     gyro.init(gyroLpf);
 
     detectMag(magHardwareToUse);


### PR DESCRIPTION
Some general cleanup of gyro sync and initialisation:

1. moved `targetLooptime` into `gyro_t` structure, so `targetLooptime` no longer owned by `gyro_sync.c`
2. some gyro function renaming and parameter cleanup
3. made some `sensors/gyro.c` functions static
4. used explicit initialisation of gyro filter rather than lazy initialisation
5. removed no longer required `#includes`