### PR TITLE
Move deadband3d_throttle from MSP_3D to MSP_RC_DEADBAND

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1242,7 +1242,6 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize16(masterConfig.flight3DConfig.deadband3d_low);
         serialize16(masterConfig.flight3DConfig.deadband3d_high);
         serialize16(masterConfig.flight3DConfig.neutral3d);
-        serialize16(masterConfig.flight3DConfig.deadband3d_throttle);
         break;
 
     case MSP_RC_DEADBAND:
@@ -1250,6 +1249,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize8(masterConfig.rcControlsConfig.deadband);
         serialize8(masterConfig.rcControlsConfig.yaw_deadband);
         serialize8(masterConfig.rcControlsConfig.alt_hold_deadband);
+        serialize16(masterConfig.flight3DConfig.deadband3d_throttle);
         break;
     case MSP_SENSOR_ALIGNMENT:
         headSerialReply(3);
@@ -1505,13 +1505,13 @@ static bool processInCommand(void)
         masterConfig.flight3DConfig.deadband3d_low = read16();
         masterConfig.flight3DConfig.deadband3d_high = read16();
         masterConfig.flight3DConfig.neutral3d = read16();
-        masterConfig.flight3DConfig.deadband3d_throttle = read16();
         break;
 
     case MSP_SET_RC_DEADBAND:
         masterConfig.rcControlsConfig.deadband = read8();
         masterConfig.rcControlsConfig.yaw_deadband = read8();
         masterConfig.rcControlsConfig.alt_hold_deadband = read8();
+        masterConfig.flight3DConfig.deadband3d_throttle = read16();
         break;
 
     case MSP_SET_RESET_CURR_PID:


### PR DESCRIPTION
Only for MSP framing compatibility with CF.
Does not include to change from global to profile.

Required for https://github.com/betaflight/betaflight/pull/583 and https://github.com/betaflight/betaflight-configurator/issues/43