### PR TITLE
Added I2C clock stretching.

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -422,6 +422,9 @@ void i2cInit(I2CDevice device)
 
     I2C_Cmd(i2c->dev, ENABLE);
     I2C_Init(i2c->dev, &i2cInit);
+
+    I2C_StretchClockCmd(i2c->dev, ENABLE);
+    
     
     // I2C ER Interrupt
     nvic.NVIC_IRQChannel = i2c->er_irq;

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -101,6 +101,8 @@ void i2cInit(I2CDevice device)
     
     I2C_Init(I2Cx, &i2cInit);
 
+    I2C_StretchClockCmd(I2Cx, ENABLE);
+      
     I2C_Cmd(I2Cx, ENABLE);
 }
 


### PR DESCRIPTION
I2C clock stretching seems to be missing. Slow devices can then not slow down the master. Probably the cause for SPRF3Delux not booting with I2C overclocking. Needs testing though, I only have Acros, (non-Delux).
