### PR TITLE
Added I2C clock stretching.

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -422,6 +422,9 @@ void i2cInit(I2CDevice device)
 
     I2C_Cmd(i2c->dev, ENABLE);
     I2C_Init(i2c->dev, &i2cInit);
+
+    I2C_StretchClockCmd(i2c->dev, ENABLE);
+    
     
     // I2C ER Interrupt
     nvic.NVIC_IRQChannel = i2c->er_irq;

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -101,6 +101,8 @@ void i2cInit(I2CDevice device)
     
     I2C_Init(I2Cx, &i2cInit);
 
+    I2C_StretchClockCmd(I2Cx, ENABLE);
+      
     I2C_Cmd(I2Cx, ENABLE);
 }
 


### PR DESCRIPTION
To be fully I2C compliant the master should support clock stretching. Thus allowing the slaves to slow down the rate when needed. We are taking a chances and living on assumption that all slaves are capable to keep up without it, particular when also doing overclocking. Weird thing can happen when not. "Assumptions are the mother of all f...ups".

With normal/fast slaves clock stretching seems not to affect performance at all, at least not measurable as CPU load or task exec times. Have not measured in detail on the bus though.