### PR TITLE
Ignore linker wchar size warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -600,6 +600,7 @@ LDFLAGS     = -lm \
               -Wl,-gc-sections,-Map,$(TARGET_MAP) \
               -Wl,-L$(LINKER_DIR) \
               -Wl,--cref \
+              -Wl,--no-wchar-size-warning \
               -T$(LD_SCRIPT)
 
 ###############################################################################


### PR DESCRIPTION
Added " -Wl,--no-wchar-size-warning " to linker flags. This will suppress all those linker warnings:

    arm-none-eabi/bin/ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/../../../arm-none-eabi/lib/armv7-m/libnosys.a(sbrk.o) uses 4-byte wchar_t yet the output is to use 2-byte wchar_t; use of wchar_t values across objects may fail

As long as we do not use any unicode strings in the code this is totally safe.
