### PR TITLE
Throttle expo redesign (and some cleanup)

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -355,7 +355,7 @@ static void resetControlRateConfig(controlRateConfig_t *controlRateConfig)
     controlRateConfig->rcExpo8 = 10;
     controlRateConfig->thrMid8 = 50;
     controlRateConfig->thrExpo8 = 0;
-    controlRateConfig->thrExpoMethod = THR_EXPO_TX_STYLE;
+    controlRateConfig->thrExpoMethod = THR_EXPO_NO_EXPO;
     controlRateConfig->dynThrPID = 20;
     controlRateConfig->rcYawExpo8 = 10;
     controlRateConfig->tpa_breakpoint = 1650;

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -355,6 +355,7 @@ static void resetControlRateConfig(controlRateConfig_t *controlRateConfig)
     controlRateConfig->rcExpo8 = 10;
     controlRateConfig->thrMid8 = 50;
     controlRateConfig->thrExpo8 = 0;
+    controlRateConfig->thrExpoMethod = THR_EXPO_TX_STYLE;
     controlRateConfig->dynThrPID = 20;
     controlRateConfig->rcYawExpo8 = 10;
     controlRateConfig->tpa_breakpoint = 1650;
@@ -728,16 +729,9 @@ static bool isEEPROMContentValid(void)
     return true;
 }
 
-void activateControlRateConfig(void)
-{
-    generateThrottleCurve(currentControlRateProfile, &masterConfig.escAndServoConfig);
-}
-
 void activateConfig(void)
 {
     static imuRuntimeConfig_t imuRuntimeConfig;
-
-    activateControlRateConfig();
 
     resetAdjustmentStates();
 
@@ -1044,7 +1038,6 @@ void changeControlRateProfile(uint8_t profileIndex)
         profileIndex = MAX_RATEPROFILES - 1;    
     }        
     setControlRateProfile(profileIndex);    
-    activateControlRateConfig();    
 }
 
 void latchActiveFeatures()

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -328,12 +328,12 @@ bool isModeActivationConditionPresent(modeActivationCondition_t *modeActivationC
 
     for (index = 0; index < MAX_MODE_ACTIVATION_CONDITION_COUNT; index++) {
         modeActivationCondition_t *modeActivationCondition = &modeActivationConditions[index];
-        
+
         if (modeActivationCondition->modeId == modeId && IS_RANGE_USABLE(&modeActivationCondition->range)) {
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -513,7 +513,6 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
         case ADJUSTMENT_THROTTLE_EXPO:
             newValue = constrain((int)controlRateConfig->thrExpo8 + delta, 0, 100); // FIXME magic numbers repeated in serial_cli.c
             controlRateConfig->thrExpo8 = newValue;
-            generateThrottleCurve(controlRateConfig, escAndServoConfig);
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_THROTTLE_EXPO, newValue);
         break;
         case ADJUSTMENT_PITCH_ROLL_RATE:
@@ -607,7 +606,7 @@ void applySelectAdjustment(uint8_t adjustmentFunction, uint8_t position)
     switch(adjustmentFunction) {
         case ADJUSTMENT_RATE_PROFILE:
             if (getCurrentControlRateProfile() != position) {
-				changeControlRateProfile(position);  
+				changeControlRateProfile(position);
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RATE_PROFILE, position);
                 applied = true;
             }
@@ -672,8 +671,8 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig, rxConfig_t *rx
 
             applyStepAdjustment(controlRateConfig, adjustmentFunction, delta);
         } else if (adjustmentState->config->mode == ADJUSTMENT_MODE_SELECT) {
-            uint16_t rangeWidth = ((2100 - 900) / adjustmentState->config->data.selectConfig.switchPositions); 
-            uint8_t position = (constrain(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth; 
+            uint16_t rangeWidth = ((2100 - 900) / adjustmentState->config->data.selectConfig.switchPositions);
+            uint8_t position = (constrain(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
 
             applySelectAdjustment(adjustmentFunction, position);
         }
@@ -713,4 +712,3 @@ void resetAdjustmentStates(void)
 {
     memset(adjustmentStates, 0, sizeof(adjustmentStates));
 }
-

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -200,7 +200,8 @@ typedef enum {
 } adjustmentMode_e;
 
 typedef enum {
-    THR_EXPO_TX_STYLE = 0,
+    THR_EXPO_NO_EXPO,
+    THR_EXPO_RC,
     THR_EXPO_FLATSPOT
 } thrExpoMethod_e;
 

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -140,6 +140,7 @@ typedef struct controlRateConfig_s {
     uint8_t rcExpo8;
     uint8_t thrMid8;
     uint8_t thrExpo8;
+    uint8_t thrExpoMethod;
     uint8_t rates[3];
     uint8_t dynThrPID;
     uint8_t rcYawExpo8;
@@ -197,6 +198,11 @@ typedef enum {
     ADJUSTMENT_MODE_STEP,
     ADJUSTMENT_MODE_SELECT
 } adjustmentMode_e;
+
+typedef enum {
+    THR_EXPO_TX_STYLE = 0,
+    THR_EXPO_FLATSPOT
+} thrExpoMethod_e;
 
 typedef struct adjustmentStepConfig_s {
     uint8_t step;

--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -52,7 +52,7 @@ int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *contr
     float minThrottle, maxThrottle;
     if (feature(FEATURE_3D && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH))) { //3D, bidirectional
         minThrottle = PWM_RANGE_MIN;
-        maxThrottle = escAndServoConfig->maxthrottle; //shouldn't this be PWM_RANGE_MAX?
+        maxThrottle = escAndServoConfig->maxthrottle;
     } else { //normal (non-bidirecitonal)
         minThrottle = escAndServoConfig->minthrottle;
         maxThrottle = escAndServoConfig->maxthrottle;
@@ -65,7 +65,7 @@ int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *contr
         float thrMidf = (float)controlRateConfig->thrMid8 / 100.0f;
         float thrf = inputf - thrMidf;
 
-        //normalize
+        //normalize to [-1, 1]
         if (thrf >= 0) {
             thrf /= (1.0f - thrMidf);
         } else {

--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -26,36 +26,65 @@
 
 #include "config/config.h"
 
-#define THROTTLE_LOOKUP_LENGTH 12
-static int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];    // lookup table for expo & mid THROTTLE
-
-void generateThrottleCurve(controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig)
+/*
+    maps input from [-500, 500] to [-500, 500]*(rate/100) with expo
+    max expo (100) is cubic, i.e., x^3
+*/
+int16_t rcLookup(int32_t input, uint8_t expo, uint8_t rate)
 {
-    uint8_t i;
-    uint16_t minThrottle = (feature(FEATURE_3D && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH)) ? PWM_RANGE_MIN : escAndServoConfig->minthrottle);
+    float inputf = (float)input / 500.0f;
+    float expof = (float)expo / 100.0f;
 
-    for (i = 0; i < THROTTLE_LOOKUP_LENGTH; i++) {
-        int16_t tmp = 10 * i - controlRateConfig->thrMid8;
-        uint8_t y = 1;
-        if (tmp > 0)
-            y = 100 - controlRateConfig->thrMid8;
-        if (tmp < 0)
-            y = controlRateConfig->thrMid8;
-        lookupThrottleRC[i] = 10 * controlRateConfig->thrMid8 + tmp * (100 - controlRateConfig->thrExpo8 + (int32_t) controlRateConfig->thrExpo8 * (tmp * tmp) / (y * y)) / 10;
-        lookupThrottleRC[i] = minThrottle + (int32_t) (escAndServoConfig->maxthrottle - minThrottle) * lookupThrottleRC[i] / 1000; // [MINTHROTTLE;MAXTHROTTLE]
+    float expoAppliedInputf = inputf * ((1.0f - expof) + expof * inputf * inputf);
+
+    return (int16_t)(expoAppliedInputf * 5.0f * (float)rate);
+}
+
+/*
+    maps input from [0, 1000] to [min throttle, max throttle] with expo
+    max expo is cubic, i.e., x^3
+*/
+int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig)
+{
+    float inputf = (float)input / 1000.0f; //[0, 1] where 0 = 0% thr and 1 = 100% thr
+    float expof = (float)expo / 100.0f; //[0, 1] where 0 = no expo and 1 = max expo
+
+    float minThrottle, maxThrottle;
+    if (feature(FEATURE_3D && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH))) { //3D, bidirectional
+        minThrottle = PWM_RANGE_MIN;
+        maxThrottle = escAndServoConfig->maxthrottle; //shouldn't this be PWM_RANGE_MAX?
+    } else { //normal (non-bidirecitonal)
+        minThrottle = escAndServoConfig->minthrottle;
+        maxThrottle = escAndServoConfig->maxthrottle;
+    }
+
+    if (controlRateConfig->thrExpoMethod == THR_EXPO_TX_STYLE) {
+        float expoAppliedInputf = inputf * ((1.0f - expof) + expof * inputf * inputf); //[0, 1] input with expo applied
+        return (int16_t)(minThrottle + (maxThrottle - minThrottle) * expoAppliedInputf);
+    } else { //THR_EXPO_FLATSPOT
+        float thrMidf = (float)controlRateConfig->thrMid8 / 100.0f;
+        float thrf = inputf - thrMidf;
+
+        //normalize
+        if (thrf >= 0) {
+            thrf /= (1.0f - thrMidf);
+        } else {
+            thrf /= thrMidf;
+        }
+
+        //apply expo
+        thrf *= ((1.0f - expof) + expof * thrf * thrf); //[-1, 1]
+
+        //find mid throttle pwm
+        float midThrottle = minThrottle + (maxThrottle - minThrottle) * thrMidf;
+
+        //scale back
+        if (thrf >= 0) {
+            thrf *= maxThrottle - midThrottle;
+        } else {
+            thrf *= midThrottle - minThrottle;
+        }
+
+        return (int16_t)(midThrottle + thrf);
     }
 }
-
-int16_t rcLookup(int32_t tmp, uint8_t expo, uint8_t rate)
-{
-    float tmpf = tmp / 100.0f;
-    return (int16_t)((2500.0f + (float)expo * (tmpf * tmpf - 25.0f)) * tmpf * (float)(rate) / 2500.0f );
-}
-
-int16_t rcLookupThrottle(int32_t tmp)
-{
-    const int32_t tmp2 = tmp / 100;
-    // [0;1000] -> expo -> [MINTHROTTLE;MAXTHROTTLE]
-    return lookupThrottleRC[tmp2] + (tmp - tmp2 * 100) * (lookupThrottleRC[tmp2 + 1] - lookupThrottleRC[tmp2]) / 100;
-}
-

--- a/src/main/io/rc_curves.h
+++ b/src/main/io/rc_curves.h
@@ -17,8 +17,5 @@
 
 #pragma once
 
-void generateThrottleCurve(controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig);
-
-int16_t rcLookup(int32_t tmp, uint8_t expo, uint8_t rate);
-int16_t rcLookupThrottle(int32_t tmp);
-
+int16_t rcLookup(int32_t input, uint8_t expo, uint8_t rate);
+int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -471,7 +471,7 @@ static const char * const lookupDeltaMethod[] = {
 };
 
 static const char * const lookupThrExpoMethod[] = {
-    "TX_STYLE", "FLATSPOT"
+    "NO_EXPO", "RC", "FLATSPOT"
 };
 
 typedef struct lookupTableEntry_s {

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -295,7 +295,7 @@ static void updateRcCommands(void)
         tmp = constrain(rcData[THROTTLE], masterConfig.rxConfig.mincheck, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - masterConfig.rxConfig.mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - masterConfig.rxConfig.mincheck);
     }
-    rcCommand[THROTTLE] = rcLookupThrottle(tmp);
+    rcCommand[THROTTLE] = rcLookupThrottle(tmp, currentControlRateProfile->thrExpo8, currentControlRateProfile, &masterConfig.escAndServoConfig);
 
     if (feature(FEATURE_3D) && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH) && !failsafeIsActive()) {
         fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -687,7 +687,6 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController2)
 
 extern "C" {
 void saveConfigAndNotify(void) {}
-void generateThrottleCurve(controlRateConfig_t *, escAndServoConfig_t *) {}
 void changeProfile(uint8_t) {}
 void accSetCalibrationCycles(uint16_t) {}
 void gyroSetCalibrationCycles(uint16_t) {}


### PR DESCRIPTION
After testing normal expo in the transmitter for the throttle I quickly realized that it would be great to be able to do this in Betaflight instead. Rewrote the expo functions, especially for throttle. The behaviour for r/p/y stays the same. You can now select the expo style for the throttle. "FLATSPOT" is about the same as the old style, "TX_STYLE" is the same as for r/p/y (transmitter style expo). thr_mid is not used for "TX_STYLE". Also, this gets rid of the lookup table and therefore should increase the accuracy.

Sure, this is maybe a bit slower but I think it's worth it. Maybe I could add a "LINEAR" or "NO_EXPO" style which just passes though the input. That's what most of race pilots use anyway.

This PR also cleans up some whitespace.

Note that this PR requires a configurator update.