### PR TITLE
Made filter naming, parameters and state consistent

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -17,20 +17,26 @@
 
 #define DELTA_MAX_SAMPLES 12
 
-typedef struct filterStatePt1_s {
-	float state;
-	float RC;
-	float constdT;
-} filterStatePt1_t;
+typedef struct pt1Filter_s {
+    float state;
+    float RC;
+    float dT;
+} pt1Filter_t;
 
 /* this holds the data required to update samples thru a filter */
-typedef struct biquad_s {
+typedef struct biquadFilter_s {
     float b0, b1, b2, a1, a2;
     float d1, d2;
-} biquad_t;
+} biquadFilter_t;
 
-float applyBiQuadFilter(float sample, biquad_t *state);
-float filterApplyPt1(float input, filterStatePt1_t *filter, float f_cut, float dt);
+
+void biquadFilterInit(biquadFilter_t *filter, float filterCutFreq, uint32_t refreshRate);
+float biquadFilterApply(biquadFilter_t *filter, float input);
+
+void pt1FilterInit(pt1Filter_t *filter, uint8_t f_cut, float dT);
+float pt1FilterApply(pt1Filter_t *filter, float input);
+float pt1FilterApply4(pt1Filter_t *filter, float input, uint8_t f_cut, float dT);
+
 int32_t filterApplyAverage(int32_t input, uint8_t averageCount, int32_t averageState[DELTA_MAX_SAMPLES]);
 float filterApplyAveragef(float input, uint8_t averageCount, float averageState[DELTA_MAX_SAMPLES]);
-void BiQuadNewLpf(float filterCutFreq, biquad_t *newState, uint32_t refreshRate);
+

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -28,7 +28,6 @@
 #include "debug.h"
 
 #include "common/axis.h"
-#include "common/filter.h"
 
 #include "drivers/system.h"
 #include "drivers/sensor.h"

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -946,7 +946,7 @@ void filterServos(void)
 #ifdef USE_SERVOS
     static int16_t servoIdx;
     static bool servoFilterIsSet;
-    static biquad_t servoFilterState[MAX_SUPPORTED_SERVOS];
+    static biquadFilter_t servoFilter[MAX_SUPPORTED_SERVOS];
 
 #if defined(MIXER_DEBUG)
     uint32_t startTime = micros();
@@ -955,11 +955,11 @@ void filterServos(void)
     if (mixerConfig->servo_lowpass_enable) {
         for (servoIdx = 0; servoIdx < MAX_SUPPORTED_SERVOS; servoIdx++) {
             if (!servoFilterIsSet) {
-                BiQuadNewLpf(mixerConfig->servo_lowpass_freq, &servoFilterState[servoIdx], targetPidLooptime);
+                biquadFilterInit(&servoFilter[servoIdx], mixerConfig->servo_lowpass_freq, targetPidLooptime);
                 servoFilterIsSet = true;
             }
 
-            servo[servoIdx] = lrintf(applyBiQuadFilter((float) servo[servoIdx], &servoFilterState[servoIdx]));
+            servo[servoIdx] = lrintf(biquadFilterApply(&servoFilter[servoIdx], (float)servo[servoIdx]));
             // Sanity check
             servo[servoIdx] = constrain(servo[servoIdx], servoConf[servoIdx].min, servoConf[servoIdx].max);
         }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -112,8 +112,8 @@ float getdT (void)
 
 const angle_index_t rcAliasToAngleIndexMap[] = { AI_ROLL, AI_PITCH };
 
-static filterStatePt1_t deltaFilterState[3];
-static filterStatePt1_t yawFilterState;
+static pt1Filter_t deltaFilter[3];
+static pt1Filter_t yawFilter;
 
 #ifndef SKIP_PID_LUXFLOAT
 static void pidFloat(const pidProfile_t *pidProfile, uint16_t max_angle_inclination,
@@ -205,7 +205,7 @@ static void pidFloat(const pidProfile_t *pidProfile, uint16_t max_angle_inclinat
 
         //-----calculate D-term
         if (axis == YAW) {
-            if (pidProfile->yaw_lpf_hz) PTerm = filterApplyPt1(PTerm, &yawFilterState, pidProfile->yaw_lpf_hz, getdT());
+            if (pidProfile->yaw_lpf_hz) PTerm = pt1FilterApply4(&yawFilter, PTerm, pidProfile->yaw_lpf_hz, getdT());
 
             axisPID[axis] = lrintf(PTerm + ITerm);
 
@@ -230,7 +230,7 @@ static void pidFloat(const pidProfile_t *pidProfile, uint16_t max_angle_inclinat
             delta *= (1.0f / getdT());
 
             // Filter delta
-            if (pidProfile->dterm_lpf_hz) delta = filterApplyPt1(delta, &deltaFilterState[axis], pidProfile->dterm_lpf_hz, getdT());
+            if (pidProfile->dterm_lpf_hz) delta = pt1FilterApply4(&deltaFilter[axis], delta, pidProfile->dterm_lpf_hz, getdT());
 
             DTerm = constrainf(luxDTermScale * delta * (float)pidProfile->D8[axis] * tpaFactor, -300.0f, 300.0f);
 
@@ -344,7 +344,7 @@ static void pidInteger(const pidProfile_t *pidProfile, uint16_t max_angle_inclin
 
         //-----calculate D-term
         if (axis == YAW) {
-            if (pidProfile->yaw_lpf_hz) PTerm = filterApplyPt1(PTerm, &yawFilterState, pidProfile->yaw_lpf_hz, getdT());
+            if (pidProfile->yaw_lpf_hz) PTerm = pt1FilterApply4(&yawFilter, PTerm, pidProfile->yaw_lpf_hz, getdT());
 
             axisPID[axis] = PTerm + ITerm;
 
@@ -369,7 +369,7 @@ static void pidInteger(const pidProfile_t *pidProfile, uint16_t max_angle_inclin
             delta = (delta * ((uint16_t) 0xFFFF / ((uint16_t)targetPidLooptime >> 4))) >> 5;
 
             // Filter delta
-            if (pidProfile->dterm_lpf_hz) delta = filterApplyPt1((float)delta, &deltaFilterState[axis], pidProfile->dterm_lpf_hz, getdT());
+            if (pidProfile->dterm_lpf_hz) delta = pt1FilterApply4(&deltaFilter[axis], (float)delta, pidProfile->dterm_lpf_hz, getdT());
 
             DTerm = (delta * pidProfile->D8[axis] * PIDweight[axis] / 100) >> 8;
 

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -63,20 +63,19 @@ uint16_t batteryAdcToVoltage(uint16_t src)
 
 static void updateBatteryVoltage(void)
 {
-    uint16_t vbatSample;
-    static biquad_t vbatFilterState;
-    static bool vbatFilterStateIsSet;
+    static biquadFilter_t vbatFilter;
+    static bool vbatFilterIsInitialised;
 
     // store the battery voltage with some other recent battery voltage readings
-    vbatSample = vbatLatestADC = adcGetChannel(ADC_BATTERY);
+    uint16_t vbatSample = vbatLatestADC = adcGetChannel(ADC_BATTERY);
 
     if (debugMode == DEBUG_BATTERY) debug[0] = vbatSample;
 
-    if (!vbatFilterStateIsSet) {
-        BiQuadNewLpf(VBATT_LPF_FREQ, &vbatFilterState, 50000); //50HZ Update
-        vbatFilterStateIsSet = true;
+    if (!vbatFilterIsInitialised) {
+        biquadFilterInit(&vbatFilter, VBATT_LPF_FREQ, 50000); //50HZ Update
+        vbatFilterIsInitialised = true;
     }
-    vbatSample = applyBiQuadFilter(vbatSample, &vbatFilterState);
+    vbatSample = biquadFilterApply(&vbatFilter, vbatSample);
     vbat = batteryAdcToVoltage(vbatSample);
 
     if (debugMode == DEBUG_BATTERY) debug[1] = vbat;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -43,7 +43,7 @@ float gyroADCf[XYZ_AXIS_COUNT];
 
 static int32_t gyroZero[XYZ_AXIS_COUNT] = { 0, 0, 0 };
 static const gyroConfig_t *gyroConfig;
-static biquad_t gyroFilterState[XYZ_AXIS_COUNT];
+static biquadFilter_t gyroFilter[XYZ_AXIS_COUNT];
 static uint8_t gyroSoftLpfHz;
 static uint16_t calibratingG = 0;
 
@@ -57,7 +57,7 @@ void gyroInit(void)
 {
     if (gyroSoftLpfHz && gyro.targetLooptime) {  // Initialisation needs to happen once samplingrate is known
         for (int axis = 0; axis < 3; axis++) {
-            BiQuadNewLpf(gyroSoftLpfHz, &gyroFilterState[axis], gyro.targetLooptime);
+            biquadFilterInit(&gyroFilter[axis], gyroSoftLpfHz, gyro.targetLooptime);
         }
     }
 }
@@ -157,7 +157,7 @@ void gyroUpdate(void)
 
     if (gyroSoftLpfHz) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            gyroADCf[axis] = applyBiQuadFilter((float)gyroADC[axis], &gyroFilterState[axis]);
+            gyroADCf[axis] = biquadFilterApply(&gyroFilter[axis], (float)gyroADC[axis]);
             gyroADC[axis] = lrintf(gyroADCf[axis]);
         }
     } else {


### PR DESCRIPTION
Cleaned up the filter code so that
1. Naming is consistent, of the form `<filter><action>`, e.g. `biquadFilterInit`, `pt1FilterApply`
2. Filter state is first parameter to all filter functions

