### PR TITLE
currentTime passed in scheduler task call

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -319,9 +319,6 @@ typedef struct blackboxSlowState_s {
 //From mixer.c:
 extern uint8_t motorCount;
 
-//From mw.c:
-extern uint32_t currentTime;
-
 //From rx.c:
 extern uint16_t rssi;
 
@@ -906,7 +903,7 @@ static void writeGPSHomeFrame()
     gpsHistory.GPS_home[1] = GPS_home[1];
 }
 
-static void writeGPSFrame()
+static void writeGPSFrame(uint32_t currentTime)
 {
     blackboxWrite('G');
 
@@ -937,7 +934,7 @@ static void writeGPSFrame()
 /**
  * Fill the current state of the blackbox using values read from the flight controller
  */
-static void loadMainState(void)
+static void loadMainState(uint32_t currentTime)
 {
     blackboxMainState_t *blackboxCurrent = blackboxHistory[0];
     int i;
@@ -1344,7 +1341,7 @@ static void blackboxAdvanceIterationTimers()
 }
 
 // Called once every FC loop in order to log the current state
-static void blackboxLogIteration()
+static void blackboxLogIteration(uint32_t currentTime)
 {
     // Write a keyframe every BLACKBOX_I_INTERVAL frames so we can resynchronise upon missing frames
     if (blackboxShouldLogIFrame()) {
@@ -1354,7 +1351,7 @@ static void blackboxLogIteration()
          */
         writeSlowFrameIfNeeded(blackboxIsOnlyLoggingIntraframes());
 
-        loadMainState();
+        loadMainState(currentTime);
         writeIntraframe();
     } else {
         blackboxCheckAndLogArmingBeep();
@@ -1367,7 +1364,7 @@ static void blackboxLogIteration()
              */
             writeSlowFrameIfNeeded(true);
 
-            loadMainState();
+            loadMainState(currentTime);
             writeInterframe();
         }
 #ifdef GPS
@@ -1383,11 +1380,11 @@ static void blackboxLogIteration()
                 || (blackboxPFrameIndex == BLACKBOX_I_INTERVAL / 2 && blackboxIFrameIndex % 128 == 0)) {
 
                 writeGPSHomeFrame();
-                writeGPSFrame();
+                writeGPSFrame(currentTime);
             } else if (GPS_numSat != gpsHistory.GPS_numSat || GPS_coord[0] != gpsHistory.GPS_coord[0]
                     || GPS_coord[1] != gpsHistory.GPS_coord[1]) {
                 //We could check for velocity changes as well but I doubt it changes independent of position
-                writeGPSFrame();
+                writeGPSFrame(currentTime);
             }
         }
 #endif
@@ -1400,7 +1397,7 @@ static void blackboxLogIteration()
 /**
  * Call each flight loop iteration to perform blackbox logging.
  */
-void handleBlackbox(void)
+void handleBlackbox(uint32_t currentTime)
 {
     int i;
 
@@ -1497,7 +1494,7 @@ void handleBlackbox(void)
                 blackboxLogEvent(FLIGHT_LOG_EVENT_LOGGING_RESUME, (flightLogEventData_t *) &resume);
                 blackboxSetState(BLACKBOX_STATE_RUNNING);
                 
-                blackboxLogIteration();
+                blackboxLogIteration(currentTime);
             }
 
             // Keep the logging timers ticking so our log iteration continues to advance
@@ -1508,7 +1505,7 @@ void handleBlackbox(void)
             if (blackboxModeActivationConditionPresent && !IS_RC_MODE_ACTIVE(BOXBLACKBOX)) {
                 blackboxSetState(BLACKBOX_STATE_PAUSED);
             } else {
-                blackboxLogIteration();
+                blackboxLogIteration(currentTime);
             }
 
             blackboxAdvanceIterationTimers();

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -22,7 +22,7 @@
 void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data);
 
 void initBlackbox(void);
-void handleBlackbox(void);
+void handleBlackbox(uint32_t currentTime);
 void startBlackbox(void);
 void finishBlackbox(void);
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -372,7 +372,7 @@ static bool isMagnetometerHealthy(void)
     return (magADC[X] != 0) && (magADC[Y] != 0) && (magADC[Z] != 0);
 }
 
-static void imuCalculateEstimatedAttitude(void)
+static void imuCalculateEstimatedAttitude(uint32_t currentTime)
 {
     static uint32_t previousIMUUpdateTime;
     float rawYawError = 0;
@@ -380,7 +380,6 @@ static void imuCalculateEstimatedAttitude(void)
     bool useMag = false;
     bool useYaw = false;
 
-    uint32_t currentTime = micros();
     uint32_t deltaT = currentTime - previousIMUUpdateTime;
     previousIMUUpdateTime = currentTime;
 
@@ -418,10 +417,10 @@ void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims)
     }
 }
 
-void imuUpdateAttitude(void)
+void imuUpdateAttitude(uint32_t currentTime)
 {
     if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {
-        imuCalculateEstimatedAttitude();
+        imuCalculateEstimatedAttitude(currentTime);
     } else {
         accSmooth[X] = 0;
         accSmooth[Y] = 0;

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -79,7 +79,7 @@ void imuConfigure(
 float getCosTiltAngle(void);
 void calculateEstimatedAltitude(uint32_t currentTime);
 void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims);
-void imuUpdateAttitude(void);
+void imuUpdateAttitude(uint32_t currentTime);
 float calculateThrottleAngleScale(uint16_t throttle_correction_angle);
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value);
 float calculateAccZLowPassFilterRCTimeConstant(float accz_lpf_hz);

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -580,17 +580,16 @@ void showDebugPage(void)
 }
 #endif
 
-void updateDisplay(void)
+void updateDisplay(uint32_t currentTime)
 {
-    uint32_t now = micros();
     static uint8_t previousArmedState = 0;
 
-    bool updateNow = (int32_t)(now - nextDisplayUpdateAt) >= 0L;
+    const bool updateNow = (int32_t)(currentTime - nextDisplayUpdateAt) >= 0L;
     if (!updateNow) {
         return;
     }
 
-    nextDisplayUpdateAt = now + DISPLAY_UPDATE_FREQUENCY;
+    nextDisplayUpdateAt = currentTime + DISPLAY_UPDATE_FREQUENCY;
 
     bool armedState = ARMING_FLAG(ARMED) ? true : false;
     bool armedStateChanged = armedState != previousArmedState;
@@ -610,7 +609,7 @@ void updateDisplay(void)
         }
 
         pageState.pageChanging = (pageState.pageFlags & PAGE_STATE_FLAG_FORCE_PAGE_CHANGE) ||
-                (((int32_t)(now - pageState.nextPageAt) >= 0L && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)));
+                (((int32_t)(currentTime - pageState.nextPageAt) >= 0L && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)));
         if (pageState.pageChanging && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)) {
             pageState.cycleIndex++;
             pageState.cycleIndex = pageState.cycleIndex % CYCLE_PAGE_ID_COUNT;
@@ -620,7 +619,7 @@ void updateDisplay(void)
 
     if (pageState.pageChanging) {
         pageState.pageFlags &= ~PAGE_STATE_FLAG_FORCE_PAGE_CHANGE;
-        pageState.nextPageAt = now + PAGE_CYCLE_FREQUENCY;
+        pageState.nextPageAt = currentTime + PAGE_CYCLE_FREQUENCY;
 
         // Some OLED displays do not respond on the first initialisation so refresh the display
         // when the page changes in the hopes the hardware responds.  This also allows the
@@ -701,7 +700,7 @@ void displayInit(rxConfig_t *rxConfigToUse)
     memset(&pageState, 0, sizeof(pageState));
     displaySetPage(PAGE_WELCOME);
 
-    updateDisplay();
+    updateDisplay(micros());
 
     displaySetNextPageChangeAt(micros() + (1000 * 1000 * 5));
 }

--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -35,7 +35,7 @@ typedef enum {
 #endif
 } pageId_e;
 
-void updateDisplay(void);
+void updateDisplay(uint32_t currentTime);
 
 void displayShowFixedPage(pageId_e pageId);
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1063,7 +1063,7 @@ static void gpsHandlePassthrough(uint8_t data)
      gpsNewData(data);
  #ifdef DISPLAY
      if (feature(FEATURE_DISPLAY)) {
-         updateDisplay();
+         updateDisplay(micros());
      }
  #endif
  	

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -935,7 +935,7 @@ static void applyLedAnimationLayer(void)
 }
 #endif
 
-void updateLedStrip(void)
+void updateLedStrip(uint32_t currentTime)
 {
 
 	if (!(ledStripInitialised && isWS2811LedStripReady())) {
@@ -956,13 +956,11 @@ void updateLedStrip(void)
     }
     
 
-    uint32_t now = micros();
-
-    bool indicatorFlashNow = (int32_t)(now - nextIndicatorFlashAt) >= 0L;
-    bool warningFlashNow = (int32_t)(now - nextWarningFlashAt) >= 0L;
-    bool rotationUpdateNow = (int32_t)(now - nextRotationUpdateAt) >= 0L;
+    bool indicatorFlashNow = (int32_t)(currentTime - nextIndicatorFlashAt) >= 0L;
+    bool warningFlashNow = (int32_t)(currentTime - nextWarningFlashAt) >= 0L;
+    bool rotationUpdateNow = (int32_t)(currentTime - nextRotationUpdateAt) >= 0L;
 #ifdef USE_LED_ANIMATION
-    bool animationUpdateNow = (int32_t)(now - nextAnimationUpdateAt) >= 0L;
+    bool animationUpdateNow = (int32_t)(currentTime - nextAnimationUpdateAt) >= 0L;
 #endif
     if (!(
             indicatorFlashNow ||
@@ -984,7 +982,7 @@ void updateLedStrip(void)
     // LAYER 2
 
     if (warningFlashNow) {
-        nextWarningFlashAt = now + LED_STRIP_10HZ;
+        nextWarningFlashAt = currentTime + LED_STRIP_10HZ;
     }
     applyLedWarningLayer(warningFlashNow);
 
@@ -995,7 +993,7 @@ void updateLedStrip(void)
         uint8_t rollScale = ABS(rcCommand[ROLL]) / 50;
         uint8_t pitchScale = ABS(rcCommand[PITCH]) / 50;
         uint8_t scale = MAX(rollScale, pitchScale);
-        nextIndicatorFlashAt = now + (LED_STRIP_5HZ / MAX(1, scale));
+        nextIndicatorFlashAt = currentTime + (LED_STRIP_5HZ / MAX(1, scale));
 
         if (indicatorFlashState == 0) {
             indicatorFlashState = 1;
@@ -1008,7 +1006,7 @@ void updateLedStrip(void)
 
 #ifdef USE_LED_ANIMATION
     if (animationUpdateNow) {
-        nextAnimationUpdateAt = now + LED_STRIP_20HZ;
+        nextAnimationUpdateAt = currentTime + LED_STRIP_20HZ;
         updateLedAnimationState();
     }
     applyLedAnimationLayer();
@@ -1024,7 +1022,7 @@ void updateLedStrip(void)
             animationSpeedScale = scaleRange(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX, 1, 10);
         }
 
-        nextRotationUpdateAt = now + LED_STRIP_5HZ/animationSpeedScale;
+        nextRotationUpdateAt = currentTime + LED_STRIP_5HZ/animationSpeedScale;
     }
 
     ws2811UpdateStrip();

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -84,7 +84,7 @@ extern uint8_t ledsInRingCount;
 
 
 bool parseLedStripConfig(uint8_t ledIndex, const char *config);
-void updateLedStrip(void);
+void updateLedStrip(uint32_t currentTime);
 void updateLedRing(void);
 
 void applyDefaultLedStripConfig(ledConfig_t *ledConfig);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -627,20 +627,19 @@ void show_menu(void) {
     max7456_write_string(">", cursor_x + cursor_y * OSD_LINE_LENGTH);
 }
 
-void updateOsd(void)
+void updateOsd(uint32_t currentTime)
 {
     static uint8_t skip = 0;
     static bool blink = false;
     static uint8_t arming = 0;
     uint32_t seconds;
     char line[30];
-    uint32_t now = micros();
 
-    bool updateNow = (int32_t)(now - next_osd_update_at) >= 0L;
+    const bool updateNow = (int32_t)(currentTime - next_osd_update_at) >= 0L;
     if (!updateNow) {
         return;
     }
-    next_osd_update_at = now + OSD_UPDATE_FREQUENCY;
+    next_osd_update_at = currentTime + OSD_UPDATE_FREQUENCY;
     if ( !(skip % 2))
         blink = !blink;
 
@@ -655,7 +654,7 @@ void updateOsd(void)
         } else {
             if (armed) {
                 armed = false;
-                armed_seconds += ((now - armed_at) / 1000000);
+                armed_seconds += ((currentTime - armed_at) / 1000000);
             }
             for (uint8_t channelIndex = 0; channelIndex < 4; channelIndex++) {
                 sticks[channelIndex] = (constrain(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN);
@@ -699,12 +698,12 @@ void updateOsd(void)
             }
             if (masterConfig.osdProfile.item_pos[OSD_TIMER] != -1) {
                 if (armed) {
-                    seconds = armed_seconds + ((now-armed_at) / 1000000);
+                    seconds = armed_seconds + ((currentTime-armed_at) / 1000000);
                     line[0] = SYM_FLY_M;
                     sprintf(line+1, " %02d:%02d", seconds / 60, seconds % 60);
                 } else {
                     line[0] = SYM_ON_M;
-                    seconds = now  / 1000000;
+                    seconds = currentTime  / 1000000;
                     sprintf(line+1, " %02d:%02d", seconds / 60, seconds % 60);
                 }
                 max7456_write_string(line, masterConfig.osdProfile.item_pos[OSD_TIMER]);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -60,6 +60,6 @@ typedef struct {
     int16_t item_pos[OSD_MAX_ITEMS];
 } osd_profile;
 
-void updateOsd(void);
+void updateOsd(uint32_t currentTime);
 void osdInit(void);
 void resetOsdConfig(void);

--- a/src/main/io/transponder_ir.c
+++ b/src/main/io/transponder_ir.c
@@ -42,7 +42,7 @@ static uint32_t nextUpdateAt = 0;
 #define JITTER_DURATION_COUNT (sizeof(jitterDurations) / sizeof(uint8_t))
 static uint8_t jitterDurations[] = {0,9,4,8,3,9,6,7,1,6,9,7,8,2,6};
 
-void updateTransponder(void)
+void updateTransponder(uint32_t currentTime)
 {
     static uint32_t jitterIndex = 0;
 
@@ -50,9 +50,7 @@ void updateTransponder(void)
         return;
     }
 
-    uint32_t now = micros();
-
-    bool updateNow = (int32_t)(now - nextUpdateAt) >= 0L;
+    const bool updateNow = (int32_t)(currentTime - nextUpdateAt) >= 0L;
     if (!updateNow) {
         return;
     }
@@ -63,12 +61,12 @@ void updateTransponder(void)
         jitterIndex = 0;
     }
 
-    nextUpdateAt = now + 4500 + jitter;
+    nextUpdateAt = currentTime + 4500 + jitter;
 
 #ifdef REDUCE_TRANSPONDER_CURRENT_DRAW_WHEN_USB_CABLE_PRESENT
     // reduce current draw when USB cable is plugged in by decreasing the transponder transmit rate.
     if (usbCableIsInserted()) {
-        nextUpdateAt = now + (1000 * 1000) / 10; // 10 hz.
+        nextUpdateAt = currentTime + (1000 * 1000) / 10; // 10 hz.
     }
 #endif
 

--- a/src/main/io/transponder_ir.h
+++ b/src/main/io/transponder_ir.h
@@ -21,7 +21,7 @@ void transponderInit(uint8_t* transponderCode);
 
 void transponderEnable(void);
 void transponderDisable(void);
-void updateTransponder(void);
+void updateTransponder(uint32_t currentTime);
 void transponderUpdateData(uint8_t* transponderData);
 void transponderTransmitOnce(void);
 void transponderStartRepeating(void);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -117,7 +117,6 @@ uint8_t motorControlEnable = false;
 int16_t telemTemperature1;      // gyro sensor temperature
 static uint32_t disarmAt;     // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
 
-extern uint32_t currentTime;
 extern uint8_t PIDweight[3];
 
 uint16_t filteredCycleTime;
@@ -480,7 +479,7 @@ void updateMagHold(void)
         magHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 }
 
-void processRx(void)
+void processRx(uint32_t currentTime)
 {
     static bool armedBeeperOn = false;
     static bool wasAirmodeIsActivated;
@@ -676,7 +675,8 @@ void subTaskPidController(void)
     if (debugMode == DEBUG_PIDLOOP) {debug[2] = micros() - startTime;}
 }
 
-void subTaskMainSubprocesses(void) {
+void subTaskMainSubprocesses(void)
+{
 
     const uint32_t startTime = micros();
 
@@ -742,12 +742,12 @@ void subTaskMainSubprocesses(void) {
 
     #ifdef BLACKBOX
         if (!cliMode && feature(FEATURE_BLACKBOX)) {
-            handleBlackbox();
+            handleBlackbox(startTime);
         }
     #endif
 
     #ifdef TRANSPONDER
-        updateTransponder();
+        updateTransponder(startTime);
     #endif
     if (debugMode == DEBUG_PIDLOOP) {debug[1] = micros() - startTime;}
 }
@@ -776,7 +776,8 @@ void subTaskMotorUpdate(void)
     if (debugMode == DEBUG_PIDLOOP) {debug[3] = micros() - startTime;}
 }
 
-uint8_t setPidUpdateCountDown(void) {
+uint8_t setPidUpdateCountDown(void)
+{
     if (masterConfig.gyro_soft_lpf_hz) {
         return masterConfig.pid_process_denom - 1;
     } else {
@@ -785,22 +786,22 @@ uint8_t setPidUpdateCountDown(void) {
 }
 
 // Function for loop trigger
-void taskMainPidLoopCheck(void)
+void taskMainPidLoopCheck(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+
     static uint32_t previousTime;
     static bool runTaskMainSubprocesses;
 
-    const uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
-
-    cycleTime = micros() - previousTime;
-    previousTime = micros();
+    const uint32_t startTime = micros();
+    cycleTime = startTime - previousTime;
+    previousTime = startTime;
 
     if (debugMode == DEBUG_CYCLETIME) {
         debug[0] = cycleTime;
         debug[1] = averageSystemLoadPercent;
     }
 
-    const uint32_t startTime = micros();
     while (true) {
         if (gyroSyncCheckUpdate(&gyro) || ((currentDeltaTime + (micros() - previousTime)) >= (gyro.targetLooptime + GYRO_WATCHDOG_DELAY))) {
             static uint8_t pidUpdateCountdown;
@@ -827,27 +828,41 @@ void taskMainPidLoopCheck(void)
     }
 }
 
-void taskUpdateAccelerometer(void)
+void taskUpdateAccelerometer(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     imuUpdateAccelerometer(&masterConfig.accelerometerTrims);
 }
 
-void taskUpdateAttitude(void) {
-    imuUpdateAttitude();
+void taskUpdateAttitude(uint32_t currentTime, uint32_t currentDeltaTime)
+{
+    UNUSED(currentDeltaTime);
+
+    imuUpdateAttitude(currentTime);
 }
 
-void taskHandleSerial(void)
+void taskHandleSerial(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     handleSerial();
 }
 
-void taskUpdateBeeper(void)
+void taskUpdateBeeper(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     beeperUpdate();          //call periodic beeper handler
 }
 
-void taskUpdateBattery(void)
+void taskUpdateBattery(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     static uint32_t vbatLastServiced = 0;
     static uint32_t ibatLastServiced = 0;
 
@@ -859,7 +874,7 @@ void taskUpdateBattery(void)
     }
 
     if (feature(FEATURE_CURRENT_METER)) {
-        int32_t ibatTimeSinceLastServiced = cmp32(currentTime, ibatLastServiced);
+        const int32_t ibatTimeSinceLastServiced = cmp32(currentTime, ibatLastServiced);
 
         if (ibatTimeSinceLastServiced >= IBATINTERVAL) {
             ibatLastServiced = currentTime;
@@ -868,16 +883,19 @@ void taskUpdateBattery(void)
     }
 }
 
-bool taskUpdateRxCheck(uint32_t currentDeltaTime)
+bool taskUpdateRxCheck(uint32_t currentTime, uint32_t currentDeltaTime)
 {
     UNUSED(currentDeltaTime);
+
     updateRx(currentTime);
     return shouldProcessRx(currentTime);
 }
 
-void taskUpdateRxMain(void)
+void taskUpdateRxMain(uint32_t currentTime, uint32_t currentDeltaTime)
 {
-    processRx();
+    UNUSED(currentDeltaTime);
+
+    processRx(currentTime);
     isRXDataNew = true;
 
 #if !defined(BARO) && !defined(SONAR)
@@ -900,8 +918,11 @@ void taskUpdateRxMain(void)
 }
 
 #ifdef GPS
-void taskProcessGPS(void)
+void taskProcessGPS(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     // if GPS feature is enabled, gpsThread() will be called at some intervals to check for stuck
     // hardware, wrong baud rates, init GPS if needed, etc. Don't use SENSOR_GPS here as gpsThread() can and will
     // change this based on available hardware
@@ -916,17 +937,22 @@ void taskProcessGPS(void)
 #endif
 
 #ifdef MAG
-void taskUpdateCompass(void)
+void taskUpdateCompass(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     if (sensors(SENSOR_MAG)) {
-        updateCompass(&masterConfig.magZero);
+        updateCompass(currentTime, &masterConfig.magZero);
     }
 }
 #endif
 
 #ifdef BARO
-void taskUpdateBaro(void)
+void taskUpdateBaro(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     if (sensors(SENSOR_BARO)) {
         uint32_t newDeadline = baroUpdate();
         rescheduleTask(TASK_SELF, newDeadline);
@@ -935,8 +961,11 @@ void taskUpdateBaro(void)
 #endif
 
 #ifdef SONAR
-void taskUpdateSonar(void)
+void taskUpdateSonar(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     if (sensors(SENSOR_SONAR)) {
         sonarUpdate();
     }
@@ -944,8 +973,10 @@ void taskUpdateSonar(void)
 #endif
 
 #if defined(BARO) || defined(SONAR)
-void taskCalculateAltitude(void)
+void taskCalculateAltitude(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     if (false
 #if defined(BARO)
         || (sensors(SENSOR_BARO) && isBaroReady())
@@ -959,17 +990,22 @@ void taskCalculateAltitude(void)
 #endif
 
 #ifdef DISPLAY
-void taskUpdateDisplay(void)
+void taskUpdateDisplay(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     if (feature(FEATURE_DISPLAY)) {
-        updateDisplay();
+        updateDisplay(currentTime);
     }
 }
 #endif
 
 #ifdef TELEMETRY
-void taskTelemetry(void)
+void taskTelemetry(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
     telemetryCheckState();
 
     if (!cliMode && feature(FEATURE_TELEMETRY)) {
@@ -979,28 +1015,34 @@ void taskTelemetry(void)
 #endif
 
 #ifdef LED_STRIP
-void taskLedStrip(void)
+void taskLedStrip(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     if (feature(FEATURE_LED_STRIP)) {
-        updateLedStrip();
+        updateLedStrip(currentTime);
     }
 }
 #endif
 
 #ifdef TRANSPONDER
-void taskTransponder(void)
+void taskTransponder(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     if (feature(FEATURE_TRANSPONDER)) {
-        updateTransponder();
+        updateTransponder(currentTime);
     }
 }
 #endif
 
 #ifdef OSD
-void taskUpdateOsd(void)
+void taskUpdateOsd(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+    UNUSED(currentDeltaTime);
+
     if (feature(FEATURE_OSD)) {
-        updateOsd();
+        updateOsd(currentTime);
     }
 }
 #endif

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -38,7 +38,6 @@ static cfTask_t *currentTask = NULL;
 static uint32_t totalWaitingTasks;
 static uint32_t totalWaitingTasksSamples;
 
-uint32_t currentTime = 0;
 uint16_t averageSystemLoadPercent = 0;
 
 
@@ -110,9 +109,12 @@ cfTask_t *queueNext(void)
     return taskQueueArray[++taskQueuePos]; // guaranteed to be NULL at end of queue
 }
 
-void taskSystem(void)
+void taskSystem(uint32_t currentTime, uint32_t currentDeltaTime)
 {
-    /* Calculate system load */
+    UNUSED(currentTime);
+    UNUSED(currentDeltaTime);
+
+    // Calculate system load
     if (totalWaitingTasksSamples > 0) {
         averageSystemLoadPercent = 100 * totalWaitingTasks / totalWaitingTasksSamples;
         totalWaitingTasksSamples = 0;
@@ -155,16 +157,6 @@ void setTaskEnabled(cfTaskId_e taskId, bool enabled)
     }
 }
 
-uint32_t getTaskDeltaTime(cfTaskId_e taskId)
-{
-    if (taskId == TASK_SELF || taskId < TASK_COUNT) {
-        cfTask_t *task = taskId == TASK_SELF ? currentTask : &cfTasks[taskId];
-        return task->taskLatestDeltaTime;
-    } else {
-        return 0;
-    }
-}
-
 void schedulerInit(void)
 {
     queueClear();
@@ -174,7 +166,7 @@ void schedulerInit(void)
 void scheduler(void)
 {
     // Cache currentTime
-    currentTime = micros();
+    const uint32_t currentTime = micros();
 
     // Check for realtime tasks
     uint32_t timeToNextRealtimeTask = UINT32_MAX;
@@ -203,7 +195,7 @@ void scheduler(void)
                 task->taskAgeCycles = 1 + ((currentTime - task->lastSignaledAt) / task->desiredPeriod);
                 task->dynamicPriority = 1 + task->staticPriority * task->taskAgeCycles;
                 waitingTasks++;
-            } else if (task->checkFunc(currentTime - task->lastExecutedAt)) {
+            } else if (task->checkFunc(currentTime, currentTime - task->lastExecutedAt)) {
                 task->lastSignaledAt = currentTime;
                 task->taskAgeCycles = 1;
                 task->dynamicPriority = 1 + task->staticPriority;
@@ -246,7 +238,7 @@ void scheduler(void)
 
         // Execute task
         const uint32_t currentTimeBeforeTaskCall = micros();
-        selectedTask->taskFunc();
+        selectedTask->taskFunc(currentTimeBeforeTaskCall, selectedTask->taskLatestDeltaTime);
         const uint32_t taskExecutionTime = micros() - currentTimeBeforeTaskCall;
 
         selectedTask->averageExecutionTime = ((uint32_t)selectedTask->averageExecutionTime * 31 + taskExecutionTime) / 32;

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -98,8 +98,8 @@ typedef struct {
     /* Configuration */
     const char * taskName;
     const char * subTaskName;
-    bool (*checkFunc)(uint32_t currentDeltaTime);
-    void (*taskFunc)(void);
+    bool (*checkFunc)(uint32_t currentTime, uint32_t currentDeltaTime);
+    void (*taskFunc)(uint32_t currentTime, uint32_t currentDeltaTime);
     uint32_t desiredPeriod;         // target period of execution
     const uint8_t staticPriority;   // dynamicPriority grows in steps of this size, shouldn't be zero
 
@@ -125,7 +125,6 @@ extern uint16_t averageSystemLoadPercent;
 void getTaskInfo(cfTaskId_e taskId, cfTaskInfo_t * taskInfo);
 void rescheduleTask(cfTaskId_e taskId, uint32_t newPeriodMicros);
 void setTaskEnabled(cfTaskId_e taskId, bool newEnabledState);
-uint32_t getTaskDeltaTime(cfTaskId_e taskId);
 
 void schedulerInit(void);
 void scheduler(void);

--- a/src/main/scheduler/scheduler_tasks.h
+++ b/src/main/scheduler/scheduler_tasks.h
@@ -17,29 +17,29 @@
 
 #pragma once
 
-void taskSystem(void);
-void taskMainPidLoopCheck(void);
-void taskUpdateAccelerometer(void);
-void taskUpdateAttitude(void);
-bool taskUpdateRxCheck(uint32_t currentDeltaTime);
-void taskUpdateRxMain(void);
-void taskHandleSerial(void);
-void taskUpdateBattery(void);
-void taskUpdateBeeper(void);
-void taskProcessGPS(void);
-void taskUpdateCompass(void);
-void taskUpdateBaro(void);
-void taskUpdateSonar(void);
-void taskCalculateAltitude(void);
-void taskUpdateDisplay(void);
-void taskTelemetry(void);
-void taskLedStrip(void);
-void taskTransponder(void);
+void taskSystem(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskMainPidLoopCheck(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateAccelerometer(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateAttitude(uint32_t currentTime, uint32_t currentDeltaTime);
+bool taskUpdateRxCheck(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateRxMain(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskHandleSerial(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateBattery(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateBeeper(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskProcessGPS(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateCompass(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateBaro(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateSonar(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskCalculateAltitude(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateDisplay(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskTelemetry(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskLedStrip(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskTransponder(uint32_t currentTime, uint32_t currentDeltaTime);
 #ifdef OSD
-void taskUpdateOsd(void);
+void taskUpdateOsd(uint32_t currentTime, uint32_t currentDeltaTime);
 #endif
 #ifdef USE_BST
-void taskBstReadWrite(void);
-void taskBstMasterProcess(void);
+void taskBstReadWrite(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskBstMasterProcess(uint32_t currentTime, uint32_t currentDeltaTime);
 #endif
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -45,8 +45,6 @@ sensor_align_e magAlign = 0;
 
 #ifdef MAG
 
-extern uint32_t currentTime; // FIXME dependency on global variable, pass it in instead.
-
 static int16_t magADCRaw[XYZ_AXIS_COUNT];
 static uint8_t magInit = 0;
 
@@ -59,7 +57,7 @@ void compassInit(void)
     magInit = 1;
 }
 
-void updateCompass(flightDynamicsTrims_t *magZero)
+void updateCompass(uint32_t currentTime, flightDynamicsTrims_t *magZero)
 {
     static uint32_t tCal = 0;
     static flightDynamicsTrims_t magZeroTempMin;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -29,7 +29,7 @@ typedef enum {
 
 void compassInit(void);
 union flightDynamicsTrims_u;
-void updateCompass(union flightDynamicsTrims_u *magZero);
+void updateCompass(uint32_t currentTime, union flightDynamicsTrims_u *magZero);
 
 extern int32_t magADC[XYZ_AXIS_COUNT];
 

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -1499,11 +1499,10 @@ void bstProcessInCommand(void)
     }
 }
 
-void resetBstChecker(void)
+static void resetBstChecker(uint32_t currentTime)
 {
     if(needResetCheck) {
-        uint32_t currentTimer = micros();
-        if(currentTimer >= (resetBstTimer + BST_RESET_TIME))
+        if(currentTime >= (resetBstTimer + BST_RESET_TIME))
         {
             bstTimeoutUserCallback();
             needResetCheck = false;
@@ -1520,15 +1519,17 @@ static uint32_t next20hzUpdateAt_1 = 0;
 
 static uint8_t sendCounter = 0;
 
-void taskBstMasterProcess(void)
+void taskBstMasterProcess(uint32_t currentTime, uint32_t currentDeltaTime)
 {
+
+    UNUSED(currentDeltaTime);
+
     if(coreProReady) {
-        uint32_t now = micros();
-        if(now >= next02hzUpdateAt_1 && !bstWriteBusy()) {
+        if(currentTime >= next02hzUpdateAt_1 && !bstWriteBusy()) {
             writeFCModeToBST();
-            next02hzUpdateAt_1 = now + UPDATE_AT_02HZ;
+            next02hzUpdateAt_1 = currentTime + UPDATE_AT_02HZ;
         }
-        if(now >= next20hzUpdateAt_1 && !bstWriteBusy()) {
+        if(currentTime >= next20hzUpdateAt_1 && !bstWriteBusy()) {
             if(sendCounter == 0)
                 writeRCChannelToBST();
             else if(sendCounter == 1)
@@ -1536,7 +1537,7 @@ void taskBstMasterProcess(void)
             sendCounter++;
             if(sendCounter > 1)
                 sendCounter = 0;
-            next20hzUpdateAt_1 = now + UPDATE_AT_20HZ;
+            next20hzUpdateAt_1 = currentTime + UPDATE_AT_20HZ;
         }
 
         if(sensors(SENSOR_GPS) && !bstWriteBusy())
@@ -1547,7 +1548,7 @@ void taskBstMasterProcess(void)
         stopMotors();
         systemReset();
     }
-    resetBstChecker();
+    resetBstChecker(currentTime);
 }
 
 /*************************************************************************************************/

--- a/src/main/target/COLIBRI_RACE/i2c_bst.h
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.h
@@ -19,7 +19,7 @@
 
 void bstProcessInCommand(void);
 void bstSlaveProcessInCommand(void);
-void taskBstMasterProcess(void);
+void taskBstMasterProcess(uint32_t currentTime, uint32_t currentDeltaTime);
 
 bool writeGpsPositionPrameToBST(void);
 bool writeRollPitchYawToBST(void);


### PR DESCRIPTION
This gets rid of the global `currentTime` and instead `currentTime` is passed in the scheduler task call. This is both neater and more efficient (on ARM you get 4 parameters "for free" in a function call). It also avoids some unnecessary calls to 'micros()`.

Not fully tested, so not ready for merge.
