### PR TITLE
Only speed up SPI clock at end of mpu6000AccAndGyroInit

### DIFF
--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -134,8 +134,6 @@ void mpu6000SpiGyroInit(uint8_t lpf)
     mpu6000WriteRegister(MPU6000_CONFIG, lpf);
     delayMicroseconds(1);
 
-    spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
-
     int16_t data[3];
     mpuGyroRead(data);
 


### PR DESCRIPTION
I think this addresses the current problem we have with SPI