### PR TITLE
Adding back the third profile for targets with more than 128kB flash.

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
+#if FLASH_SIZE <= 128
 #define MAX_PROFILE_COUNT 2
+#else
+#define MAX_PROFILE_COUNT 3
+#endif
 #define MAX_RATEPROFILES 3
 #define ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS 1500
 


### PR DESCRIPTION
There is no need to remove the third profile for all targets. modern FC's have plenty of space and profiles are useful for testing different settings or have settings for different use (i.e. for 3S or 4S  batteries, agile setup for racing and more stable setup for filming).