### PR TITLE
Throttle expo rewrite

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -356,7 +356,7 @@ static void resetControlRateConfig(controlRateConfig_t *controlRateConfig)
     controlRateConfig->rcExpo8 = 10;
     controlRateConfig->thrMid8 = 50;
     controlRateConfig->thrExpo8 = 0;
-    controlRateConfig->thrExpoMethod = THR_EXPO_TX_STYLE;
+    controlRateConfig->thrExpoMethod = THR_EXPO_NO_EXPO;
     controlRateConfig->dynThrPID = 20;
     controlRateConfig->rcYawExpo8 = 10;
     controlRateConfig->tpa_breakpoint = 1650;

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -356,6 +356,7 @@ static void resetControlRateConfig(controlRateConfig_t *controlRateConfig)
     controlRateConfig->rcExpo8 = 10;
     controlRateConfig->thrMid8 = 50;
     controlRateConfig->thrExpo8 = 0;
+    controlRateConfig->thrExpoMethod = THR_EXPO_TX_STYLE;
     controlRateConfig->dynThrPID = 20;
     controlRateConfig->rcYawExpo8 = 10;
     controlRateConfig->tpa_breakpoint = 1650;
@@ -696,16 +697,9 @@ static bool isEEPROMContentValid(void)
     return true;
 }
 
-void activateControlRateConfig(void)
-{
-    generateThrottleCurve(currentControlRateProfile, &masterConfig.escAndServoConfig);
-}
-
 void activateConfig(void)
 {
     static imuRuntimeConfig_t imuRuntimeConfig;
-
-    activateControlRateConfig();
 
     resetAdjustmentStates();
 
@@ -1012,7 +1006,6 @@ void changeControlRateProfile(uint8_t profileIndex)
         profileIndex = MAX_RATEPROFILES - 1;    
     }        
     setControlRateProfile(profileIndex);    
-    activateControlRateConfig();    
 }
 
 void latchActiveFeatures()

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -328,12 +328,12 @@ bool isModeActivationConditionPresent(modeActivationCondition_t *modeActivationC
 
     for (index = 0; index < MAX_MODE_ACTIVATION_CONDITION_COUNT; index++) {
         modeActivationCondition_t *modeActivationCondition = &modeActivationConditions[index];
-        
+
         if (modeActivationCondition->modeId == modeId && IS_RANGE_USABLE(&modeActivationCondition->range)) {
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -513,7 +513,6 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
         case ADJUSTMENT_THROTTLE_EXPO:
             newValue = constrain((int)controlRateConfig->thrExpo8 + delta, 0, 100); // FIXME magic numbers repeated in serial_cli.c
             controlRateConfig->thrExpo8 = newValue;
-            generateThrottleCurve(controlRateConfig, escAndServoConfig);
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_THROTTLE_EXPO, newValue);
         break;
         case ADJUSTMENT_PITCH_ROLL_RATE:
@@ -607,7 +606,7 @@ void applySelectAdjustment(uint8_t adjustmentFunction, uint8_t position)
     switch(adjustmentFunction) {
         case ADJUSTMENT_RATE_PROFILE:
             if (getCurrentControlRateProfile() != position) {
-				changeControlRateProfile(position);  
+				changeControlRateProfile(position);
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RATE_PROFILE, position);
                 applied = true;
             }
@@ -672,8 +671,8 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig, rxConfig_t *rx
 
             applyStepAdjustment(controlRateConfig, adjustmentFunction, delta);
         } else if (adjustmentState->config->mode == ADJUSTMENT_MODE_SELECT) {
-            uint16_t rangeWidth = ((2100 - 900) / adjustmentState->config->data.selectConfig.switchPositions); 
-            uint8_t position = (constrain(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth; 
+            uint16_t rangeWidth = ((2100 - 900) / adjustmentState->config->data.selectConfig.switchPositions);
+            uint8_t position = (constrain(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
 
             applySelectAdjustment(adjustmentFunction, position);
         }
@@ -713,4 +712,3 @@ void resetAdjustmentStates(void)
 {
     memset(adjustmentStates, 0, sizeof(adjustmentStates));
 }
-

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -200,7 +200,8 @@ typedef enum {
 } adjustmentMode_e;
 
 typedef enum {
-    THR_EXPO_TX_STYLE = 0,
+    THR_EXPO_NO_EXPO,
+    THR_EXPO_RC,
     THR_EXPO_FLATSPOT
 } thrExpoMethod_e;
 

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -140,6 +140,7 @@ typedef struct controlRateConfig_s {
     uint8_t rcExpo8;
     uint8_t thrMid8;
     uint8_t thrExpo8;
+    uint8_t thrExpoMethod;
     uint8_t rates[3];
     uint8_t dynThrPID;
     uint8_t rcYawExpo8;
@@ -197,6 +198,11 @@ typedef enum {
     ADJUSTMENT_MODE_STEP,
     ADJUSTMENT_MODE_SELECT
 } adjustmentMode_e;
+
+typedef enum {
+    THR_EXPO_TX_STYLE = 0,
+    THR_EXPO_FLATSPOT
+} thrExpoMethod_e;
 
 typedef struct adjustmentStepConfig_s {
     uint8_t step;

--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -52,7 +52,7 @@ int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *contr
     float minThrottle, maxThrottle;
     if (feature(FEATURE_3D && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH))) { //3D, bidirectional
         minThrottle = PWM_RANGE_MIN;
-        maxThrottle = escAndServoConfig->maxthrottle; //shouldn't this be PWM_RANGE_MAX?
+        maxThrottle = escAndServoConfig->maxthrottle;
     } else { //normal (non-bidirecitonal)
         minThrottle = escAndServoConfig->minthrottle;
         maxThrottle = escAndServoConfig->maxthrottle;
@@ -65,7 +65,7 @@ int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *contr
         float thrMidf = (float)controlRateConfig->thrMid8 / 100.0f;
         float thrf = inputf - thrMidf;
 
-        //normalize
+        //normalize to [-1, 1]
         if (thrf >= 0) {
             thrf /= (1.0f - thrMidf);
         } else {

--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -47,7 +47,7 @@ int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *contr
 {
     float inputf = (float)input / 1000.0f; //[0, 1] where 0 = 0% thr and 1 = 100% thr
 
-    if (controlRateConfig->thrExpoMethod == THR_EXPO_NO_EXPO) {
+    if (controlRateConfig->thrExpoMethod == THR_EXPO_NO_EXPO || expo == 0) {
         //no expo, we use ints for min/max throttle for speed
 
         int16_t maxThrottle = escAndServoConfig->maxthrottle;
@@ -78,10 +78,8 @@ int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *contr
             float thrf = inputf - thrMidf;
 
             //normalize to [-1, 1]
-            if (thrf >= 0) {
-                thrf /= (1.0f - thrMidf);
-            } else {
-                thrf /= thrMidf;
+            if (!(controlRateConfig->thrMid8 == 0 || controlRateConfig->thrMid8 == 100)) {
+                thrf /= thrf > 0 ? (1.0f - thrMidf) : thrMidf;
             }
 
             //apply expo

--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -26,36 +26,65 @@
 
 #include "config/config.h"
 
-#define THROTTLE_LOOKUP_LENGTH 12
-static int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];    // lookup table for expo & mid THROTTLE
-
-void generateThrottleCurve(controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig)
+/*
+    maps input from [-500, 500] to [-500, 500]*(rate/100) with expo
+    max expo (100) is cubic, i.e., x^3
+*/
+int16_t rcLookup(int32_t input, uint8_t expo, uint8_t rate)
 {
-    uint8_t i;
-    uint16_t minThrottle = (feature(FEATURE_3D && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH)) ? PWM_RANGE_MIN : escAndServoConfig->minthrottle);
+    float inputf = (float)input / 500.0f;
+    float expof = (float)expo / 100.0f;
 
-    for (i = 0; i < THROTTLE_LOOKUP_LENGTH; i++) {
-        int16_t tmp = 10 * i - controlRateConfig->thrMid8;
-        uint8_t y = 1;
-        if (tmp > 0)
-            y = 100 - controlRateConfig->thrMid8;
-        if (tmp < 0)
-            y = controlRateConfig->thrMid8;
-        lookupThrottleRC[i] = 10 * controlRateConfig->thrMid8 + tmp * (100 - controlRateConfig->thrExpo8 + (int32_t) controlRateConfig->thrExpo8 * (tmp * tmp) / (y * y)) / 10;
-        lookupThrottleRC[i] = minThrottle + (int32_t) (escAndServoConfig->maxthrottle - minThrottle) * lookupThrottleRC[i] / 1000; // [MINTHROTTLE;MAXTHROTTLE]
+    float expoAppliedInputf = inputf * ((1.0f - expof) + expof * inputf * inputf);
+
+    return (int16_t)(expoAppliedInputf * 5.0f * (float)rate);
+}
+
+/*
+    maps input from [0, 1000] to [min throttle, max throttle] with expo
+    max expo is cubic, i.e., x^3
+*/
+int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig)
+{
+    float inputf = (float)input / 1000.0f; //[0, 1] where 0 = 0% thr and 1 = 100% thr
+    float expof = (float)expo / 100.0f; //[0, 1] where 0 = no expo and 1 = max expo
+
+    float minThrottle, maxThrottle;
+    if (feature(FEATURE_3D && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH))) { //3D, bidirectional
+        minThrottle = PWM_RANGE_MIN;
+        maxThrottle = escAndServoConfig->maxthrottle; //shouldn't this be PWM_RANGE_MAX?
+    } else { //normal (non-bidirecitonal)
+        minThrottle = escAndServoConfig->minthrottle;
+        maxThrottle = escAndServoConfig->maxthrottle;
+    }
+
+    if (controlRateConfig->thrExpoMethod == THR_EXPO_TX_STYLE) {
+        float expoAppliedInputf = inputf * ((1.0f - expof) + expof * inputf * inputf); //[0, 1] input with expo applied
+        return (int16_t)(minThrottle + (maxThrottle - minThrottle) * expoAppliedInputf);
+    } else { //THR_EXPO_FLATSPOT
+        float thrMidf = (float)controlRateConfig->thrMid8 / 100.0f;
+        float thrf = inputf - thrMidf;
+
+        //normalize
+        if (thrf >= 0) {
+            thrf /= (1.0f - thrMidf);
+        } else {
+            thrf /= thrMidf;
+        }
+
+        //apply expo
+        thrf *= ((1.0f - expof) + expof * thrf * thrf); //[-1, 1]
+
+        //find mid throttle pwm
+        float midThrottle = minThrottle + (maxThrottle - minThrottle) * thrMidf;
+
+        //scale back
+        if (thrf >= 0) {
+            thrf *= maxThrottle - midThrottle;
+        } else {
+            thrf *= midThrottle - minThrottle;
+        }
+
+        return (int16_t)(midThrottle + thrf);
     }
 }
-
-int16_t rcLookup(int32_t tmp, uint8_t expo, uint8_t rate)
-{
-    float tmpf = tmp / 100.0f;
-    return (int16_t)((2500.0f + (float)expo * (tmpf * tmpf - 25.0f)) * tmpf * (float)(rate) / 2500.0f );
-}
-
-int16_t rcLookupThrottle(int32_t tmp)
-{
-    const int32_t tmp2 = tmp / 100;
-    // [0;1000] -> expo -> [MINTHROTTLE;MAXTHROTTLE]
-    return lookupThrottleRC[tmp2] + (tmp - tmp2 * 100) * (lookupThrottleRC[tmp2 + 1] - lookupThrottleRC[tmp2]) / 100;
-}
-

--- a/src/main/io/rc_curves.h
+++ b/src/main/io/rc_curves.h
@@ -17,8 +17,5 @@
 
 #pragma once
 
-void generateThrottleCurve(controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig);
-
-int16_t rcLookup(int32_t tmp, uint8_t expo, uint8_t rate);
-int16_t rcLookupThrottle(int32_t tmp);
-
+int16_t rcLookup(int32_t input, uint8_t expo, uint8_t rate);
+int16_t rcLookupThrottle(int32_t input, uint8_t expo, controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -473,7 +473,7 @@ static const char * const lookupDeltaMethod[] = {
 };
 
 static const char * const lookupThrExpoMethod[] = {
-    "TX_STYLE", "FLATSPOT"
+    "NO_EXPO", "RC", "FLATSPOT"
 };
 
 typedef struct lookupTableEntry_s {

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -472,6 +472,10 @@ static const char * const lookupDeltaMethod[] = {
     "ERROR", "MEASUREMENT"
 };
 
+static const char * const lookupThrExpoMethod[] = {
+    "TX_STYLE", "FLATSPOT"
+};
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -486,7 +490,7 @@ typedef enum {
     TABLE_GPS_SBAS_MODE,
 #endif
 #ifdef BLACKBOX
-    TABLE_BLACKBOX_DEVICE,  
+    TABLE_BLACKBOX_DEVICE,
 #endif
     TABLE_CURRENT_SENSOR,
     TABLE_GIMBAL_MODE,
@@ -500,6 +504,7 @@ typedef enum {
     TABLE_SUPEREXPO_YAW,
     TABLE_MOTOR_PWM_PROTOCOL,
     TABLE_DELTA_METHOD,
+    TABLE_THR_EXPO_METHOD,
 #ifdef OSD
     TABLE_OSD,
 #endif
@@ -528,6 +533,7 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableSuperExpoYaw, sizeof(lookupTableSuperExpoYaw) / sizeof(char *) },
     { lookupTablePwmProtocol, sizeof(lookupTablePwmProtocol) / sizeof(char *) },
     { lookupDeltaMethod, sizeof(lookupDeltaMethod) / sizeof(char *) },
+    { lookupThrExpoMethod, sizeof(lookupThrExpoMethod) / sizeof(char *) },
 #ifdef OSD
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
 #endif
@@ -724,6 +730,7 @@ const clivalue_t valueTable[] = {
     { "rc_yaw_expo",                VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].rcYawExpo8, .config.minmax = { 0,  100 } },
     { "thr_mid",                    VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].thrMid8, .config.minmax = { 0,  100 } },
     { "thr_expo",                   VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].thrExpo8, .config.minmax = { 0,  100 } },
+    { "thr_expo_method",            VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].controlRateProfile[0].thrExpoMethod, .config.lookup = { TABLE_THR_EXPO_METHOD } },
     { "roll_rate",                  VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].rates[FD_ROLL], .config.minmax = { 0,  CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX } },
     { "pitch_rate",                 VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].rates[FD_PITCH], .config.minmax = { 0,  CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX } },
     { "yaw_rate",                   VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].rates[FD_YAW], .config.minmax = { 0,  CONTROL_RATE_CONFIG_YAW_RATE_MAX } },
@@ -1941,7 +1948,7 @@ static void cliDump(char *cmdline)
         dumpMask = DUMP_PROFILE; // only
     }
     if (strcasecmp(cmdline, "rates") == 0) {
-        dumpMask = DUMP_RATES; 
+        dumpMask = DUMP_RATES;
     }
 
     if (strcasecmp(cmdline, "all") == 0) {
@@ -1983,7 +1990,7 @@ static void cliDump(char *cmdline)
             cliPrintf("%s\r\n", ftoa(yaw, buf));
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
         }
 
 #ifdef USE_SERVOS
@@ -2008,7 +2015,7 @@ static void cliDump(char *cmdline)
 
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
         }
 
 #endif
@@ -2023,7 +2030,7 @@ static void cliDump(char *cmdline)
             cliPrintf("feature -%s\r\n", featureNames[i]);
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
         }
         for (i = 0; ; i++) {  // reenable what we want.
             if (featureNames[i] == NULL)
@@ -2032,7 +2039,7 @@ static void cliDump(char *cmdline)
                 cliPrintf("feature %s\r\n", featureNames[i]);
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
         }
 
 
@@ -2094,7 +2101,7 @@ static void cliDump(char *cmdline)
                     cliPrintf("smix reverse %d %d r\r\n", i , channel);
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
                 }
             }
         }
@@ -2111,7 +2118,7 @@ static void cliDump(char *cmdline)
 
         cliPrint("\r\n# rxfail\r\n");
         cliRxFail("");
-        
+
         if (dumpMask & DUMP_ALL) {
             uint8_t activeProfile = masterConfig.current_profile_index;
             uint8_t profileCount;
@@ -2129,7 +2136,7 @@ static void cliDump(char *cmdline)
                 cliRateProfile("");
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
             }
 
             cliPrint("\r\n# restore original profile selection\r\n");
@@ -2158,7 +2165,7 @@ void cliDumpProfile(uint8_t profileIndex)
 {
         if (profileIndex >= MAX_PROFILE_COUNT) // Faulty values
             return;
-        
+
         changeProfile(profileIndex);
         cliPrint("\r\n# profile\r\n");
         cliProfile("");
@@ -2174,7 +2181,7 @@ void cliDumpRateProfile(uint8_t rateProfileIndex)
 {
     if (rateProfileIndex >= MAX_RATEPROFILES) // Faulty values
             return;
-    
+
     changeControlRateProfile(rateProfileIndex);
     cliPrint("\r\n# rateprofile\r\n");
     cliRateProfile("");
@@ -2551,7 +2558,7 @@ static void cliProfile(char *cmdline)
 
 static void cliRateProfile(char *cmdline) {
     int i;
-    
+
     if (isEmpty(cmdline)) {
         cliPrintf("rateprofile %d\r\n", getCurrentControlRateProfile());
         return;
@@ -2681,7 +2688,7 @@ static void cliPrintVar(const clivalue_t *var, uint32_t full)
             break;
     }
 }
-static void cliPrintVarRange(const clivalue_t *var) 
+static void cliPrintVarRange(const clivalue_t *var)
 {
     switch (var->type & VALUE_MODE_MASK) {
         case (MODE_DIRECT): {
@@ -2693,7 +2700,7 @@ static void cliPrintVarRange(const clivalue_t *var)
             cliPrint("Allowed values:");
             uint8_t i;
             for (i = 0; i < tableEntry->valueCount ; i++) {
-                if (i > 0) 
+                if (i > 0)
                     cliPrint(",");
                 cliPrintf(" %s", tableEntry->values[i]);
             }
@@ -2749,10 +2756,10 @@ static void cliSet(char *cmdline)
             cliPrintf("%s = ", valueTable[i].name);
             cliPrintVar(val, len); // when len is 1 (when * is passed as argument), it will print min/max values as well, for gui
             cliPrint("\r\n");
-            
+
 #ifdef USE_SLOW_SERIAL_CLI
             delay(2);
-#endif            
+#endif
         }
     } else if ((eqptr = strstr(cmdline, "=")) != NULL) {
         // has equals

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -295,7 +295,7 @@ static void updateRcCommands(void)
         tmp = constrain(rcData[THROTTLE], masterConfig.rxConfig.mincheck, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - masterConfig.rxConfig.mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - masterConfig.rxConfig.mincheck);
     }
-    rcCommand[THROTTLE] = rcLookupThrottle(tmp);
+    rcCommand[THROTTLE] = rcLookupThrottle(tmp, currentControlRateProfile->thrExpo8, currentControlRateProfile, &masterConfig.escAndServoConfig);
 
     if (feature(FEATURE_3D) && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH) && !failsafeIsActive()) {
         fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -687,7 +687,6 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController2)
 
 extern "C" {
 void saveConfigAndNotify(void) {}
-void generateThrottleCurve(controlRateConfig_t *, escAndServoConfig_t *) {}
 void changeProfile(uint8_t) {}
 void accSetCalibrationCycles(uint16_t) {}
 void gyroSetCalibrationCycles(uint16_t) {}


### PR DESCRIPTION
Made a new PR as the old one was deleted due to merging branches.

After testing normal expo in the transmitter for the throttle I quickly realized that it would be great to be able to do this in Betaflight instead. Rewrote the expo functions, especially for throttle. The behaviour for r/p/y stays the same.

You can now select the expo style for the throttle:
- "NO_EXPO" is what the name suggests - no expo. Good for F1 targets as it's just a simple mapping.
- "RC" is the same as for r/p/y. thr_mid is not used.
- "FLATSPOT" is about the same as the old style, but does not use the lookup table and therefore has better resolution.

Note that this PR requires a configurator update, which I'll happily do asap if this is merged.