### PR TITLE
SPI CS must be driven high also on F1. Some do not have external pull…

### DIFF
--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -30,7 +30,7 @@
 #define SPI_IO_AF_SCK_CFG     IO_CONFIG(GPIO_Mode_AF_PP,       GPIO_Speed_50MHz)
 #define SPI_IO_AF_MOSI_CFG    IO_CONFIG(GPIO_Mode_AF_PP,       GPIO_Speed_50MHz)
 #define SPI_IO_AF_MISO_CFG    IO_CONFIG(GPIO_Mode_IN_FLOATING, GPIO_Speed_50MHz)
-#define SPI_IO_CS_CFG         IO_CONFIG(GPIO_Mode_Out_OD,      GPIO_Speed_50MHz)
+#define SPI_IO_CS_CFG         IO_CONFIG(GPIO_Mode_Out_PP,      GPIO_Speed_50MHz)
 #else
 #error "Unknown processor"
 #endif


### PR DESCRIPTION
SPI CS must be driven high also on F1. Some FCs do not have external pullups.
Ref issue #697 
