### PR TITLE
Defined I2C_SCL and I2C_SDA for MOTOLAB

### DIFF
--- a/src/main/target/MOTOLAB/target.h
+++ b/src/main/target/MOTOLAB/target.h
@@ -90,18 +90,9 @@
 #define UART3_RX_PINSOURCE  GPIO_PinSource11
 
 #define USE_I2C
-#define I2C_DEVICE (I2CDEV_2) // SDA (PA10/AF4), SCL (PA9/AF4)
-
-#define I2C2_SCL_GPIO        GPIOA
-#define I2C2_SCL_GPIO_AF     GPIO_AF_4
-#define I2C2_SCL_PIN         PA9
-#define I2C2_SCL_PIN_SOURCE  GPIO_PinSource9
-#define I2C2_SCL_CLK_SOURCE  RCC_AHBPeriph_GPIOA
-#define I2C2_SDA_GPIO        GPIOA
-#define I2C2_SDA_GPIO_AF     GPIO_AF_4
-#define I2C2_SDA_PIN         PA10
-#define I2C2_SDA_PIN_SOURCE  GPIO_PinSource10
-#define I2C2_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOA
+#define I2C_DEVICE      (I2CDEV_2)
+#define I2C2_SCL        PA9
+#define I2C2_SDA        PA10
 
 #define USE_SPI
 #define USE_SPI_DEVICE_2


### PR DESCRIPTION
Fixes gyro detection failure for MOTOLAB targets using MPU6050 on I2C bus.