### PR TITLE
some #defines

### DIFF
--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -41,6 +41,9 @@
 #include "sensor.h"
 #include "accgyro.h"
 #include "accgyro_mpu.h"
+
+#if defined(USE_GYRO_SPI_MPU6000) || defined(USE_ACC_SPI_MPU6000)
+
 #include "accgyro_spi_mpu6000.h"
 
 static void mpu6000AccAndGyroInit(void);
@@ -283,3 +286,5 @@ bool mpu6000SpiGyroDetect(gyro_t *gyro)
 
     return true;
 }
+
+#endif

--- a/src/main/drivers/barometer_spi_bmp280.c
+++ b/src/main/drivers/barometer_spi_bmp280.c
@@ -28,6 +28,7 @@
 #include "barometer.h"
 #include "barometer_bmp280.h"
 
+#ifdef USE_BARO_SPI_BMP280
 #define DISABLE_BMP280       IOHi(bmp280CsPin)
 #define ENABLE_BMP280        IOLo(bmp280CsPin)
 
@@ -91,3 +92,4 @@ void bmp280_spi_get_up(void)
     bmp280_up = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
     bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
 }
+#endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -193,7 +193,7 @@ void init(void)
     EXTIInit();
 #endif
 
-#if defined(SPRACINGF3MINI) || defined(OMNIBUS)
+#if defined(BUTTONS)
     gpio_config_t buttonAGpioConfig = {
         BUTTON_A_PIN,
         Mode_IPU,


### PR DESCRIPTION
preprocessor define guards for spi mpu6000 and spi bmp280 (makes debugging w/ fake gyro/acc a bit easier)

check for the `BUTTONS` feature, not specific targets