### PR TITLE
SDCard Detect/Delay Fix

### DIFF
--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -44,7 +44,7 @@
 // Chosen so that CMD8 will have the same CRC as CMD0:
 #define SDCARD_IF_COND_CHECK_PATTERN 0xAB
 
-#define SDCARD_TIMEOUT_INIT_MILLIS      2000
+#define SDCARD_TIMEOUT_INIT_MILLIS      200
 #define SDCARD_MAX_CONSECUTIVE_FAILURES 8
 
 /* Break up 512-byte SD card sectors into chunks of this size when writing without DMA to reduce the peak overhead


### PR DESCRIPTION
This is a fix for the delay present on boot up on SDCard targets when the SDCard is not present in the slot.   Right now, there is a 16 second delay/settling issue when the SDCard is not present in the slot.   If someone is able to arm the board during this time and throttle up, the quad will go crazy.   Very dangerous.   This reduces the delay to only 1.6 seconds which is negotiable.  

This can be verified on targets by setting cycle to 250 or so.  Connect board (no SDCard in slot) to configurator via USB and press connect.   Look at the cycle times.  It takes around 16 seconds for the board to settle to the prescribed cycle time.

I've tried it and there seem to be no issues; even with a newly formatted card.  

If there is a better way to resolve this issue, please bring it up.