### PR TITLE
fixed compile error on transponder_ir.c

### DIFF
--- a/src/main/drivers/transponder_ir.c
+++ b/src/main/drivers/transponder_ir.c
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <platform.h>
 


### PR DESCRIPTION
...
%% transponder_ir.c
./src/main/drivers/transponder_ir.c: In function 'transponderIrInit':
./src/main/drivers/transponder_ir.c:52:5: warning: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
     memset(&transponderIrDMABuffer, 0, TRANSPONDER_DMA_BUFFER_SIZE);
     ^
./src/main/drivers/transponder_ir.c:52:5: warning: incompatible implicit declaration of built-in function 'memset'
./src/main/drivers/transponder_ir.c:52:5: note: include '<string.h>' or provide a declaration of 'memset'
%% blackbox.c
...