### PR TITLE
Fix transponder targets

### DIFF
--- a/src/main/drivers/transponder_ir.c
+++ b/src/main/drivers/transponder_ir.c
@@ -23,6 +23,8 @@
 
 #include "build_config.h"
 
+#ifdef TRANSPONDER
+
 #include "drivers/dma.h"
 #include "drivers/transponder_ir.h"
 
@@ -123,3 +125,5 @@ void transponderIrTransmit(void)
     transponderIrDataTransferInProgress = 1;
     transponderIrDMAEnable();
 }
+
+#endif

--- a/src/main/io/transponder_ir.c
+++ b/src/main/io/transponder_ir.c
@@ -25,6 +25,8 @@
 
 #include <build_config.h>
 
+#ifdef TRANSPONDER
+
 #include "drivers/transponder_ir.h"
 #include "drivers/system.h"
 
@@ -114,3 +116,5 @@ void transponderTransmitOnce(void) {
     }
     transponderIrTransmit();
 }
+
+#endif

--- a/src/main/target/PIKOBLX/target.h
+++ b/src/main/target/PIKOBLX/target.h
@@ -109,18 +109,18 @@
 #define WS2811_IRQ                      DMA1_Channel7_IRQn
 #endif
 
-#define TRANSPONDER
-#define TRANSPONDER_GPIO                     GPIOA
-#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
-#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
-#define TRANSPONDER_PIN                      GPIO_Pin_8
-#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
-#define TRANSPONDER_TIMER                    TIM1
-#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
-#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
-#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
-#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
-#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+//#define TRANSPONDER
+//#define TRANSPONDER_GPIO                     GPIOA
+//#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+//#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
+//#define TRANSPONDER_PIN                      GPIO_Pin_8
+//#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
+//#define TRANSPONDER_TIMER                    TIM1
+//#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
+//#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
+//#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
+//#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
+//#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
 
 #define SPEKTRUM_BIND
 // USART3, PB11

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -134,18 +134,18 @@
 #define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC2
 #define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
 
-#define TRANSPONDER
-#define TRANSPONDER_GPIO                     GPIOA
-#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
-#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
-#define TRANSPONDER_PIN                      GPIO_Pin_8
-#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
-#define TRANSPONDER_TIMER                    TIM1
-#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
-#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
-#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
-#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
-#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+//#define TRANSPONDER
+//#define TRANSPONDER_GPIO                     GPIOA
+//#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+//#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
+//#define TRANSPONDER_PIN                      GPIO_Pin_8
+//#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
+//#define TRANSPONDER_TIMER                    TIM1
+//#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
+//#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
+//#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
+//#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
+//#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -142,18 +142,18 @@
 #define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
 
 
-#define TRANSPONDER
-#define TRANSPONDER_GPIO                     GPIOA
-#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
-#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
-#define TRANSPONDER_PIN                      GPIO_Pin_8
-#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
-#define TRANSPONDER_TIMER                    TIM1
-#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
-#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
-#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
-#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
-#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+//#define TRANSPONDER
+//#define TRANSPONDER_GPIO                     GPIOA
+//#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+//#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
+//#define TRANSPONDER_PIN                      GPIO_Pin_8
+//#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
+//#define TRANSPONDER_TIMER                    TIM1
+//#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
+//#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
+//#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
+//#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
+//#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
 
 #define REDUCE_TRANSPONDER_CURRENT_DRAW_WHEN_USB_CABLE_PRESENT
 


### PR DESCRIPTION
comment out transponder target defines until they're moved to the new DMA driver. cc @savaga

without this, i see:

```
./src/main/drivers/transponder_ir.c: In function 'transponderIrInit':
./src/main/drivers/transponder_ir.c:55:60: error: 'NVIC_PRIO_TRANSPONDER_DMA' undeclared (first use in this function)
     dmaSetHandler(TRANSPONDER_DMA_HANDLER_IDENTIFER, transponderDMAHandler, NVIC_PRIO_TRANSPONDER_DMA, 0);
                                                            ^
./src/main/drivers/transponder_ir.c:55:60: note: each undeclared identifier is reported only once for each function it appears in
```