### PR TITLE
Use ccache if it is installed on the system.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -546,10 +546,17 @@ VPATH        := $(VPATH):$(STDPERIPH_DIR)/src
 # Things that might need changing to use different tools
 #
 
+# Find out if ccache is installed on the system
+CCACHE := ccache
+RESULT = $(shell which $(CCACHE))
+ifeq ($(RESULT),)
+CCACHE :=
+endif
+
 # Tool names
-CC          = arm-none-eabi-gcc
-OBJCOPY     = arm-none-eabi-objcopy
-SIZE        = arm-none-eabi-size
+CC          := $(CCACHE) arm-none-eabi-gcc
+OBJCOPY     := arm-none-eabi-objcopy
+SIZE        := arm-none-eabi-size
 
 #
 # Tool options.


### PR DESCRIPTION
Detects if ccache is installed on the build host. If installed, build times can improve by a factor 3. Otherwise it all builds as normal.
So. if you want to speed up the build, all you need to do is:

    sudo apt-get install ccache
