### PR TITLE
Support for offline compilation

### DIFF
--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -31,6 +31,7 @@
 #define SPI_IO_AF_MOSI_CFG    IO_CONFIG(GPIO_Mode_AF_PP,       GPIO_Speed_50MHz)
 #define SPI_IO_AF_MISO_CFG    IO_CONFIG(GPIO_Mode_IN_FLOATING, GPIO_Speed_50MHz)
 #define SPI_IO_CS_CFG         IO_CONFIG(GPIO_Mode_Out_PP,      GPIO_Speed_50MHz)
+#elif defined(NOPROCESSOR)
 #else
 #error "Unknown processor"
 #endif

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -118,10 +118,15 @@ static bool fakeGyroReadTemp(int16_t *tempData)
     return true;
 }
 
+static bool fakeGyroIntStatus(void) {
+    return true;
+}
+
 bool fakeGyroDetect(gyro_t *gyro)
 {
     gyro->init = fakeGyroInit;
     gyro->read = fakeGyroRead;
+    gyro->intStatus = fakeGyroIntStatus;
     gyro->temperature = fakeGyroReadTemp;
     gyro->scale = 1.0f / 16.4f;
     return true;
@@ -143,6 +148,7 @@ bool fakeAccDetect(acc_t *acc)
 {
     acc->init = fakeAccInit;
     acc->read = fakeAccRead;
+    acc->acc_1G = 512*8;
     acc->revisionCode = 0;
     return true;
 }


### PR DESCRIPTION
I added some code that will allow betaflight to compile on non-STM32 processors if NOPROCESSOR is set.

Also added new support for the fake gyro setup for the new code design.