### PR TITLE
Fix for ccache detection problem on cygwin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,8 +548,8 @@ VPATH        := $(VPATH):$(STDPERIPH_DIR)/src
 
 # Find out if ccache is installed on the system
 CCACHE := ccache
-RESULT = $(shell which $(CCACHE))
-ifeq ($(RESULT),)
+RESULT = $(shell (which $(CCACHE) > /dev/null 2>&1; echo $$?) )
+ifneq ($(RESULT),0)
 CCACHE :=
 endif
 


### PR DESCRIPTION
The "which" utility on cygwin is too verbose, should really shutup as "normal" variants do when not finding that target. This PR should fix that. Still, this requires and assumes bash style shells, not csh style.
