### PR TITLE
Turn off MAG support for CC3D to save some flash space.

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -117,6 +117,7 @@
 #undef GPS
 
 #undef BARO
+#undef MAG
 
 #ifdef CC3D_OPBL
 #define SKIP_CLI_COMMAND_HELP


### PR DESCRIPTION
Build failed for CC3D_OPBL, turning of MAG support helps. Barely. Ref issue #768 

New sizes with gcc 5.4.1:

arm-none-eabi-size ./obj/main/betaflight_CC3D_OPBL.elf
   text    data     bss     dec     hex filename
 114756    1228   11136  127120   1f090 ./obj/main/betaflight_CC3D_OPBL.elf

New sizes with gcc 4.9.3:

arm-none-eabi-size ./obj/main/betaflight_CC3D_OPBL.elf
   text    data     bss     dec     hex filename
 115164    1224   11556  127944   1f3c8 ./obj/main/betaflight_CC3D_OPBL.elf
