### PR TITLE
cc3d opbl flash is overflowing w/ new bf pidc, undef led_strip for now?

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -121,6 +121,7 @@
 
 #ifdef CC3D_OPBL
 #define SKIP_CLI_COMMAND_HELP
+#undef LED_STRIP
 #undef DISPLAY
 #undef SONAR
 #endif


### PR DESCRIPTION
not sure what to disable? led strip?

```
LD betaflight_CC3D_OPBL.elf
/usr/local/Cellar/gcc-arm-none-eabi/20140805/bin/../lib/gcc/arm-none-eabi/4.8.4/../../../../arm-none-eabi/bin/ld: obj/main/betaflight_CC3D_OPBL.elf section `.data' will not fit in region `FLASH'
/usr/local/Cellar/gcc-arm-none-eabi/20140805/bin/../lib/gcc/arm-none-eabi/4.8.4/../../../../arm-none-eabi/bin/ld: region `FLASH' overflowed by 460 bytes
collect2: error: ld returned 1 exit status
make[2]: *** [obj/main/betaflight_CC3D_OPBL.elf] Error 1
```