### PR TITLE
Changed Vbat hysteresis to be applied only once

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -127,14 +127,14 @@ void updateBattery(void)
             if (vbat <= (batteryCriticalVoltage - batteryConfig->vbathysteresis)) {
                 batteryState = BATTERY_CRITICAL;
                 beeper(BEEPER_BAT_CRIT_LOW);
-            } else if (vbat > (batteryWarningVoltage + batteryConfig->vbathysteresis)){
+            } else if (vbat > batteryWarningVoltage) {
                 batteryState = BATTERY_OK;
             } else {
                 beeper(BEEPER_BAT_LOW);
             }
             break;
         case BATTERY_CRITICAL:
-            if (vbat > (batteryCriticalVoltage + batteryConfig->vbathysteresis)){
+            if (vbat > batteryCriticalVoltage) {
                 batteryState = BATTERY_WARNING;
                 beeper(BEEPER_BAT_LOW);
             } else {


### PR DESCRIPTION
Hysteresis is now only applied downwards of the configured minimum levels, and not downwards and upwards.

In my opinion this is a bit more intuitive than the amount of hysteresis being actually twice of what is set, because it is applied twice. It also makes it a bit easier to configure the required amount of hysteresis to compensate for sagging battery voltage, as the minimum voltages can be kept constant.