### PR TITLE
Set default acc rate to 1000Hz, for all targets

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -690,21 +690,21 @@ void main_init(void)
     rescheduleTask(TASK_GYROPID, gyro.targetLooptime);
     setTaskEnabled(TASK_GYROPID, true);
 
-    if(sensors(SENSOR_ACC)) {
+    if (sensors(SENSOR_ACC)) {
         setTaskEnabled(TASK_ACCEL, true);
-        switch(gyro.targetLooptime) {  // Switch statement kept in place to change acc rates in the future
-             case(500):
-             case(375):
-             case(250):
-             case(125):
-                 accTargetLooptime = 1000;
-                 break;
-             default:
-                 case(1000):
+        switch (gyro.targetLooptime) {  // Switch statement kept in place to change acc rates in the future
+        case 500:
+        case 375:
+        case 250:
+        case 125:
+            accTargetLooptime = 1000;
+            break;
+        default:
+        case 1000:
 #ifdef STM32F10X
-                accTargetLooptime = 3000;
+            accTargetLooptime = 1000;
 #else
-                accTargetLooptime = 1000;
+            accTargetLooptime = 1000;
 #endif
         }
         rescheduleTask(TASK_ACCEL, accTargetLooptime);

--- a/src/main/scheduler/scheduler_tasks.c
+++ b/src/main/scheduler/scheduler_tasks.c
@@ -43,7 +43,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_ACCEL] = {
         .taskName = "ACCEL",
         .taskFunc = taskUpdateAccelerometer,
-        .desiredPeriod = 1000000 / 100,     // every 10ms
+        .desiredPeriod = 1000000 / 1000,    // every 1ms
         .staticPriority = TASK_PRIORITY_MEDIUM,
     },
 


### PR DESCRIPTION
Including F1 targets.

Task statistics show this is safe, and this is the rate used by Cleanflight and iNav.