### PR TITLE
Move PIDweight to a common place. 

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -53,6 +53,9 @@ bool pidStabilisationEnabled;
 
 int16_t axisPID[3];
 
+// PIDweight is a scale factor for PIDs which is derived from the throttle and TPA setting, and 100 = 100% scale means no PID reduction
+uint8_t PIDweight[3];
+
 #ifdef BLACKBOX
 int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 #endif

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -127,6 +127,9 @@ extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 bool airmodeWasActivated;
 extern uint32_t targetPidLooptime;
 
+// PIDweight is a scale factor for PIDs which is derived from the throttle and TPA setting, and 100 = 100% scale means no PID reduction
+extern uint8_t PIDweight[3];
+
 void pidSetController(pidControllerType_e type);
 void pidResetErrorGyroState(void);
 void pidStabilisationState(pidStabilisationState_e pidControllerState);

--- a/src/main/flight/pid_betaflight.c
+++ b/src/main/flight/pid_betaflight.c
@@ -62,9 +62,6 @@ extern biquadFilter_t dtermFilterNotch[3];
 extern bool dtermNotchInitialised;
 extern bool dtermBiquadLpfInitialised;
 
-// PIDweight is a scale factor for PIDs which is derived from the throttle and TPA setting, and 100 = 100% scale means no PID reduction
-uint8_t PIDweight[3];
-
 void initFilters(const pidProfile_t *pidProfile);
 float getdT(void);
 


### PR DESCRIPTION
Builds with SKIP_PID_FLOAT fails due to unwanted dependency between pid_legacy and pid_betaflight. 
There might be more nasty cross deps, have not checked. This PR just fixes the red.
