### PR TITLE
Enable spektrum sat bind on REVO, REVNANO and BLUEJAYF4.

### DIFF
--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -161,6 +161,9 @@
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
+#define SPEKTRUM_BIND
+#define BIND_PIN                PB11
+
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -112,6 +112,10 @@
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
 #define DEFAULT_FEATURES        (FEATURE_BLACKBOX)
 
+#define SPEKTRUM_BIND
+// USART3,
+#define BIND_PIN                PB11
+
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff

--- a/src/main/target/REVONANO/target.h
+++ b/src/main/target/REVONANO/target.h
@@ -92,6 +92,10 @@
 #define USE_SERVOS
 #define USE_CLI
 
+#define SPEKTRUM_BIND
+// USART2, PA3
+#define BIND_PIN                PA3
+
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff


### PR DESCRIPTION
Enable spektrum sat bind on Flexiport on REVO. Missing. Tested on RTFQ Revo Acro with Dx18 and LemonRx DSMx diversity.
Missing on Nano as well, but I do not have any such FC to test with. And I am not sure what the HW supports.

