### PR TITLE
Fix FuryF3 INT Pin Error

### DIFF
--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -28,7 +28,7 @@
 #define BEEPER_INVERTED
 
 #define USE_EXTI
-#define MPU_INT_EXTI            PC4
+#define MPU_INT_EXTI            PA3
 #define EXTI_CALLBACK_HANDLER_COUNT 2 // MPU INT, SDCardDetect
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW


### PR DESCRIPTION
Please merge before next RC release.  MPU INT pin got changed somehow to a incorrect pin assignment.  Should be PA3, not PC4.