### PR TITLE
Fix CC3D beeper.

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -22,8 +22,8 @@
 #define INVERTER                PB2 // PB2 (BOOT1) used as inverter select GPIO
 #define INVERTER_USART          USART1
 
-#define BEEPER                  PB15
-#define BEEPER_OPT              PB2
+#define BEEPER                  PA15
+#define BEEPER_OPT              PA2
 
 #define USE_EXTI
 #define MPU_INT_EXTI            PA3


### PR DESCRIPTION
Wrong beeper pins defined in CC3D/target.h 
Beeper on pin 6 did not work. Fixed and tested.

The BP6 special code for CC3D only is still there, needs some generalization and restructuring. But that is another issue, not covered with this PR. Only get it going as it is, people will miss it and complain otherwise.

