### PR TITLE
MPU6500 INT Fix

### DIFF
--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -106,11 +106,10 @@ void mpu6500GyroInit(uint8_t lpf)
     delay(100);
 
     // Data ready interrupt configuration
-#ifdef USE_MPU9250_MAG
+
     mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-#else
-    mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-#endif
+    delay(15);
+
 #ifdef USE_MPU_DATA_READY_SIGNAL
     mpuConfiguration.write(MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif


### PR DESCRIPTION
INT pin on 6500 was not active on the F4 causing elevated CPU usage.  Confirmed on the scope.  Enabling BYPASS_EN on Register 55 activates the INT on the 6500.   This is tested and does not impact other F3 targets.   @blckmn confirms this resolves the issue.