### PR TITLE
MPU6500 INT Fix for F4

### DIFF
--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -111,6 +111,9 @@ void mpu6500GyroInit(uint8_t lpf)
 #else
     mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #endif
+
+    delay(15);
+    
 #ifdef USE_MPU_DATA_READY_SIGNAL
     mpuConfiguration.write(MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif


### PR DESCRIPTION
INT not enabling on the F4 6500.   Delay needed on F4 between register writes.  