### PR TITLE
add support for flysky and turnigy ibus receiver ia6

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -517,6 +517,7 @@ static void resetConf(void)
 #else
     masterConfig.rxConfig.serialrx_provider = 0;
 #endif
+    masterConfig.rxConfig.ibus_model = 0;
     masterConfig.rxConfig.sbus_inversion = 1;
     masterConfig.rxConfig.spektrum_sat_bind = 0;
     masterConfig.rxConfig.spektrum_sat_bind_autoreset = 1;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -411,6 +411,9 @@ static const char * const lookupTableSerialRX[] = {
     "IBUS",
     "JETIEXBUS"
 };
+static const char * const lookupTableIbusModel[] = {
+    "IA6B", "IA6"
+};
 #endif
 
 static const char * const lookupTableGyroLpf[] = {
@@ -523,6 +526,7 @@ typedef enum {
     TABLE_PID_CONTROLLER,
 #ifdef SERIAL_RX
     TABLE_SERIAL_RX,
+    TABLE_IBUS_MODEL,
 #endif
     TABLE_GYRO_LPF,
     TABLE_ACC_HARDWARE,
@@ -561,6 +565,7 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTablePidController, sizeof(lookupTablePidController) / sizeof(char *) },
 #ifdef SERIAL_RX
     { lookupTableSerialRX, sizeof(lookupTableSerialRX) / sizeof(char *) },
+    { lookupTableIbusModel, sizeof(lookupTableIbusModel) / sizeof(char *) },
 #endif
     { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) },
     { lookupTableAccHardware, sizeof(lookupTableAccHardware) / sizeof(char *) },
@@ -705,6 +710,7 @@ const clivalue_t valueTable[] = {
 
 #ifdef SERIAL_RX
     { "serialrx_provider",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.rxConfig.serialrx_provider, .config.lookup = { TABLE_SERIAL_RX } },
+    { "ibus_model",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.rxConfig.ibus_model, .config.lookup = { TABLE_IBUS_MODEL } },
 #endif
     { "sbus_inversion",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.rxConfig.sbus_inversion, .config.lookup = { TABLE_OFF_ON } },
 #ifdef SPEKTRUM_BIND

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -112,6 +112,7 @@ typedef struct rxChannelRangeConfiguration_s {
 typedef struct rxConfig_s {
     uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS];  // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_provider;              // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_RX_SERIAL first.
+    uint8_t ibus_model;                     // ibus receiver specialisation (0 = IAB6B the real ibus. 1 = IAB which must be grabbed from a chip pin.
     uint8_t sbus_inversion;                 // default sbus (Futaba, FrSKY) is inverted. Support for uninverted OpenLRS (and modified FrSKY) receivers.
     uint8_t spektrum_sat_bind;              // number of bind pulses for Spektrum satellite receivers
     uint8_t spektrum_sat_bind_autoreset;    // whenever we will reset (exit) binding mode after hard reboot


### PR DESCRIPTION
Normally only the FS-IA6B receiver from FlySky/Turnigy supports its IBUS protocol. As documented in http://www.rcgroups.com/forums/showthread.php?t=2711184 this PR adds support for the IA6 receiver, which is shipped with the remote by default. You just have to solder one pin on the backside of the receiver.
Thanks again to darven for his co-work!

![image](https://cloud.githubusercontent.com/assets/3606067/17460547/198a3a62-5c6c-11e6-87fb-9fc51ed20d89.png)


I added the CLI command ibus_model which defaults to the official IBUS receiver,
but can be changed by setting:

set ibus_model = IA6

Both receiver types were tested successfully.