### PR TITLE
armed led color adjustment by aux channel implemented

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -649,6 +649,7 @@ static void resetConf(void)
     applyDefaultModeColors(masterConfig.modeColors);
     applyDefaultSpecialColors(&(masterConfig.specialColors));
     masterConfig.ledstrip_visual_beeper = 0;
+    masterConfig.ledstrip_aux_channel = 0;
 #endif
 
 #ifdef VTX

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -125,6 +125,7 @@ typedef struct master_t {
     modeColorIndexes_t modeColors[LED_MODE_COUNT];
     specialColorIndexes_t specialColors;
     uint8_t ledstrip_visual_beeper; // suppress LEDLOW mode if beeper is on
+    uint8_t ledstrip_aux_channel;
 #endif
 
 #ifdef TRANSPONDER

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -621,6 +621,10 @@ static void applyLedFixedLayers()
 
             case LED_FUNCTION_ARM_STATE:
                 color = ARMING_FLAG(ARMED) ? *getSC(LED_SCOLOR_ARMED) : *getSC(LED_SCOLOR_DISARMED);
+                if(ARMING_FLAG(ARMED) && masterConfig.ledstrip_aux_channel>0){
+                	int rcDataValue=rcData[NON_AUX_CHANNEL_COUNT+masterConfig.ledstrip_aux_channel-1];
+                	hOffset+=scaleRange(rcDataValue, 1000, 2000, 0, HSV_HUE_MAX);
+                }
                 break;
 
             case LED_FUNCTION_BATTERY:

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -500,6 +500,10 @@ static const char * const lookupTableLowpassType[] = {
     "NORMAL", "HIGH"
 };
 
+static const char * const lookupTableLedAux[] = {
+    "OFF", "1","2","3","4"
+};
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -541,6 +545,9 @@ typedef enum {
 #ifdef OSD
     TABLE_OSD,
 #endif
+#ifdef LED_STRIP
+	TABLE_LED_AUX
+#endif
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -578,6 +585,9 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableLowpassType, sizeof(lookupTableLowpassType) / sizeof(char *) },
 #ifdef OSD
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
+#endif
+#ifdef LED_STRIP
+	{ lookupTableLedAux, sizeof(lookupTableLedAux) / sizeof(char *) },
 #endif
 };
 
@@ -884,6 +894,7 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef LED_STRIP
     { "ledstrip_visual_beeper",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.ledstrip_visual_beeper, .config.lookup = { TABLE_OFF_ON } },
+    { "ledstrip_aux_channel",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.ledstrip_aux_channel, .config.lookup = {TABLE_LED_AUX} },
 #endif
 #ifdef USE_RTC6705
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, &masterConfig.vtx_channel, .config.minmax = { 0,  39 } },


### PR DESCRIPTION
enable function by cli "set ledstrip_aux_channel=OFF,1,2,3,4"
default is OFF

Maps rc channel value 1000-2000 to hue offset 0-359. Offset applys to
armed color.

Affects only to led function A:"Arm State"

Its my first GIT experience, i hope everything is fine :-)