### PR TITLE
Added missing includes. COLIBRI build failed.

### DIFF
--- a/src/main/target/COLIBRI/target.c
+++ b/src/main/target/COLIBRI/target.c
@@ -20,6 +20,9 @@
 
 #include <platform.h>
 #include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/io.h"
+
 
 const uint16_t multiPPM[] = {
     PWM1  | (MAP_TO_PPM_INPUT << 8),     // PPM input


### PR DESCRIPTION
COLIBRI build failed on development branch, a few missing include files. Strangely it works on master, probably due to some indirect includes done in some other module. Did not investigate further, since we should not have any indirect or implicit dependencies. If a module uses a symbol it must first either define it, or include it's definition. 
 