### PR TITLE
Fix compile warnigs when only USE_VCP is defined.

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -270,7 +270,7 @@ serialPort_t *openSerialPort(
     portMode_t mode,
     portOptions_t options)
 {
-#if (!defined(USE_VCP) && !defined(USE_UART1) && !defined(USE_UART2) && !defined(USE_UART3) && !defined(USE_UART4) && !defined(USE_UART5) && !defined(USE_UART6) && !defined(USE_SOFTSERIAL1) && !defined(USE_SOFTSERIAL2))
+#if (!defined(USE_UART1) && !defined(USE_UART2) && !defined(USE_UART3) && !defined(USE_UART4) && !defined(USE_UART5) && !defined(USE_UART6) && !defined(USE_SOFTSERIAL1) && !defined(USE_SOFTSERIAL2))
     UNUSED(callback);
     UNUSED(baudRate);
     UNUSED(mode);


### PR DESCRIPTION
Compile warnings in serial.c when only USE_VCP is defined, fixed.

Noticed when building SPARKY2 and SPARKY_OPBL(!?). 
SPARKY is OK. Strange that SPARKY2 has a SPARKY_OPBL.mk in the target dir. Someone who knows SPARKY/SPARKY2 may want to have a look at those target config files and the UART support.
 