### PR TITLE
FuryF3 I2C Fix

### DIFF
--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -123,8 +123,8 @@
 #define USE_I2C
 #define I2C_DEVICE              (I2CDEV_1) // SDA (PB9/AF4), SCL (PB8/AF4)
 
-#define I2C1_SCL_PIN            PB8
-#define I2C1_SDA_PIN            PB9
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
 
 #define BOARD_HAS_VOLTAGE_DIVIDER
 #define USE_ADC


### PR DESCRIPTION
I2C Pin define incorrect.  I2C1 defaulted to pins PB6/7 which makes motors 1/2 not work.  Please merge for next 3.0 RC.