### PR TITLE
Corrected the usage of TARGET_FLAGS in main Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,6 @@ LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f303_$(FLASH_SIZE)k.ld
 
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
 DEVICE_FLAGS    = -DSTM32F303xC -DSTM32F303
-TARGET_FLAGS    = -D$(TARGET)
 # End F3 targets
 #
 # Start F4 targets
@@ -273,7 +272,6 @@ $(error Unknown MCU for F4 target)
 endif
 DEVICE_FLAGS    += -DHSE_VALUE=$(HSE_VALUE)
 
-TARGET_FLAGS = -D$(TARGET)
 # End F4 targets
 #
 # Start F1 targets
@@ -313,7 +311,6 @@ endif
 
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f103_$(FLASH_SIZE)k.ld
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m3
-TARGET_FLAGS   := -D$(TARGET) -pedantic $(TARGET_FLAGS)
 
 ifeq ($(DEVICE_FLAGS),)
 DEVICE_FLAGS    = -DSTM32F10X_MD
@@ -581,8 +578,10 @@ CFLAGS      += $(ARCH_FLAGS) \
               -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
               -ffunction-sections \
               -fdata-sections \
+              -pedantic \
               $(DEVICE_FLAGS) \
               -DUSE_STDPERIPH_DRIVER \
+              -D$(TARGET) \
               $(TARGET_FLAGS) \
               -D'__FORKNAME__="$(FORKNAME)"' \
               -D'__TARGET__="$(TARGET)"' \


### PR DESCRIPTION
TARGET_FLAGS was used incorrectly in the Makefile, resetting any potential usage by the target.mk. And also some other misuse, like "-pedantic" that has nothing with TARGET_FLAGS to do.
 