### PR TITLE
Fix: 3D deadband in MSP

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1501,13 +1501,13 @@ static bool processInCommand(void)
         masterConfig.flight3DConfig.deadband3d_low = read16();
         masterConfig.flight3DConfig.deadband3d_high = read16();
         masterConfig.flight3DConfig.neutral3d = read16();
-        masterConfig.flight3DConfig.deadband3d_throttle = read16();
         break;
 
     case MSP_SET_RC_DEADBAND:
         masterConfig.rcControlsConfig.deadband = read8();
         masterConfig.rcControlsConfig.yaw_deadband = read8();
         masterConfig.rcControlsConfig.alt_hold_deadband = read8();
+        masterConfig.flight3DConfig.deadband3d_throttle = read16();
         break;
 
     case MSP_SET_RESET_CURR_PID:


### PR DESCRIPTION
This is a fix for the problem described in #717 .
Did some debugging and testing, here are the results:
The 3D deadband appeared to be 1000, which caused some unexpected behaiviour in the mixer. Conditions in there failed since deadband was much bigger than the default vaule of 50.
I noticed that after saving the configurations page in the configuratore once the value was corrupted. So I had a closer look at the MSP parameters, it seems like the 3D deadband value was moved from MSP_3D to MSP_RC_DEADBAND but not for the corresponding set commands: MSP_SET_3D and MSP_SET_RC_DEADBAND. So the flight controller was expecting this value but it was never sent by the configurator.
This fixes the problem for the flight controller but it also need to be fixed in msp.js for the configurator. Will do that next.