### PR TITLE
Added MPU9250 to acc lookup table. Duplication. 

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -450,6 +450,7 @@ static const char * const lookupTableAccHardware[] = {
     "LSM303DLHC",
     "MPU6000",
     "MPU6500",
+    "MPU9250",
     "FAKE"
 };
 


### PR DESCRIPTION
Missing in Allowed Values printout. Duplication really......