### PR TITLE
Changed mpu6500GyroInit to only call mpuIntExtiInit once

### DIFF
--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -86,8 +86,6 @@ void mpu6500GyroInit(uint8_t lpf)
     }
 #endif
 
-    mpuIntExtiInit();
-
     mpuConfiguration.write(MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
     mpuConfiguration.write(MPU_RA_SIGNAL_PATH_RESET, 0x07);


### PR DESCRIPTION
`mpu6500GyroInit` calls `mpuIntExtiInit` twice. This removes the second call.