### PR TITLE
Added missing delay for F4 to CLI dump

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2975,7 +2975,11 @@ static bool cliDumpPrintf(uint8_t dumpMask, bool equalsDefault, const char *form
         tfp_format(cliWriter, cliPutp, format, va);
         va_end(va);
 
-	return true;
+#ifdef USE_SLOW_SERIAL_CLI
+        delay(1);
+#endif
+
+	    return true;
     }
 
     return false;


### PR DESCRIPTION
Fixes bad dump on F4 following introduction of "diff" cli option.