### PR TITLE
option to set `V=1 make ...` for verbose make output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,18 @@ SERIAL_DEVICE   ?= $(firstword $(wildcard /dev/ttyUSB*) no-port-found)
 # Flash size (KB).  Some low-end chips actually have more flash than advertised, use this to override.
 FLASH_SIZE ?=
 
+# Decide on a verbosity level based on the V= parameter
+export AT := @
+
+ifndef V
+export V0    :=
+export V1    := $(AT)
+else ifeq ($(V), 0)
+export V0    := $(AT)
+export V1    := $(AT)
+else ifeq ($(V), 1)
+endif
+
 ###############################################################################
 # Things that need to be maintained as the source changes
 #
@@ -639,42 +651,42 @@ CLEAN_ARTIFACTS += $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP)
 # It would be nice to compute these lists, but that seems to be just beyond make.
 
 $(TARGET_HEX): $(TARGET_ELF)
-	$(OBJCOPY) -O ihex --set-start 0x8000000 $< $@
+	$(V0) $(OBJCOPY) -O ihex --set-start 0x8000000 $< $@
 
 $(TARGET_BIN): $(TARGET_ELF)
-	$(OBJCOPY) -O binary $< $@
+	$(V0) $(OBJCOPY) -O binary $< $@
 
 $(TARGET_ELF):  $(TARGET_OBJS)
-	@echo LD $(notdir $@)
-	@$(CC) -o $@ $^ $(LDFLAGS)
-	$(SIZE) $(TARGET_ELF)
+	$(V1) echo LD $(notdir $@)
+	$(V1) $(CC) -o $@ $^ $(LDFLAGS)
+	$(V0) $(SIZE) $(TARGET_ELF)
 
 # Compile
 $(OBJECT_DIR)/$(TARGET)/%.o: %.c
-	@mkdir -p $(dir $@)
-	@echo %% $(notdir $<)
-	@$(CC) -c -o $@ $(CFLAGS) $<
+	$(V1) mkdir -p $(dir $@)
+	$(V1) echo %% $(notdir $<)
+	$(V1) $(CC) -c -o $@ $(CFLAGS) $<
 
 # Assemble
 $(OBJECT_DIR)/$(TARGET)/%.o: %.s
-	@mkdir -p $(dir $@)
-	@echo %% $(notdir $<)
-	@$(CC) -c -o $@ $(ASFLAGS) $<
+	$(V1) mkdir -p $(dir $@)
+	$(V1) echo %% $(notdir $<)
+	$(V1) $(CC) -c -o $@ $(ASFLAGS) $<
 
 $(OBJECT_DIR)/$(TARGET)/%.o: %.S
-	@mkdir -p $(dir $@)
-	@echo %% $(notdir $<)
-	@$(CC) -c -o $@ $(ASFLAGS) $<
+	$(V1) mkdir -p $(dir $@)
+	$(V1) echo %% $(notdir $<)
+	$(V1) $(CC) -c -o $@ $(ASFLAGS) $<
 
 
 ## all               : Build all valid targets
 all: $(VALID_TARGETS)
 
 $(VALID_TARGETS):
-		echo "" && \
-		echo "Building $@" && \
-		$(MAKE) binary hex TARGET=$@ && \
-		echo "Building $@ succeeded."
+		$(V0) echo "" && \
+		$(V0) echo "Building $@" && \
+		$(V0) $(MAKE) binary hex TARGET=$@ && \
+		$(V0) echo "Building $@ succeeded."
 
 
 
@@ -683,22 +695,22 @@ TARGETS_CLEAN = $(addsuffix _clean,$(VALID_TARGETS) )
 
 ## clean             : clean up temporary / machine-generated files
 clean:
-	echo "Cleaning $(TARGET)"
-	rm -f $(CLEAN_ARTIFACTS)
-	rm -rf $(OBJECT_DIR)/$(TARGET)
-	echo "Cleaning $(TARGET) succeeded."
+	$(V0) echo "Cleaning $(TARGET)"
+	$(V0) rm -f $(CLEAN_ARTIFACTS)
+	$(V0) rm -rf $(OBJECT_DIR)/$(TARGET)
+	$(V0) echo "Cleaning $(TARGET) succeeded."
 
 ## clean_test        : clean up temporary / machine-generated files (tests)
 clean_test:
-	cd src/test && $(MAKE) clean || true
+	$(V0) cd src/test && $(MAKE) clean || true
 
 ## clean_<TARGET>    : clean up one specific target
 $(CLEAN_TARGETS) :
-	$(MAKE) -j TARGET=$(subst clean_,,$@) clean
+	$(V0) $(MAKE) -j TARGET=$(subst clean_,,$@) clean
 
 ## <TARGET>_clean    : clean up one specific target (alias for above)
 $(TARGETS_CLEAN) :
-	$(MAKE) -j TARGET=$(subst _clean,,$@) clean
+	$(V0) $(MAKE) -j TARGET=$(subst _clean,,$@) clean
 
 ## clean_all         : clean all valid targets
 clean_all:$(CLEAN_TARGETS)
@@ -708,62 +720,62 @@ all_clean:$(TARGETS_CLEAN)
 
 
 flash_$(TARGET): $(TARGET_HEX)
-	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
-	echo -n 'R' >$(SERIAL_DEVICE)
-	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+	$(V0) stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
+	$(V0) echo -n 'R' >$(SERIAL_DEVICE)
+	$(V0) stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
 
 ## flash             : flash firmware (.hex) onto flight controller
 flash: flash_$(TARGET)
 
 st-flash_$(TARGET): $(TARGET_BIN)
-	st-flash --reset write $< 0x08000000
+	$(V0) st-flash --reset write $< 0x08000000
 
 ## st-flash          : flash firmware (.bin) onto flight controller
 st-flash: st-flash_$(TARGET)
 
 binary:
-	$(MAKE) -j $(TARGET_BIN)
+	$(V0) $(MAKE) -j $(TARGET_BIN)
 
 hex:
-	$(MAKE) -j $(TARGET_HEX)
+	$(V0) $(MAKE) -j $(TARGET_HEX)
 
 unbrick_$(TARGET): $(TARGET_HEX)
-	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
-	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+	$(V0) stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
+	$(V0) stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
 
 ## unbrick           : unbrick flight controller
 unbrick: unbrick_$(TARGET)
 
 ## cppcheck          : run static analysis on C source code
 cppcheck: $(CSOURCES)
-	$(CPPCHECK)
+	$(V0) $(CPPCHECK)
 
 cppcheck-result.xml: $(CSOURCES)
-	$(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
+	$(V0) $(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
 
 ## help              : print this help message and exit
 help: Makefile
-	@echo ""
-	@echo "Makefile for the $(FORKNAME) firmware"
-	@echo ""
-	@echo "Usage:"
-	@echo "        make [TARGET=<target>] [OPTIONS=\"<options>\"]"
-	@echo "Or:"
-	@echo "        make <target> [OPTIONS=\"<options>\"]"
-	@echo ""
-	@echo "Valid TARGET values are: $(VALID_TARGETS)"
-	@echo ""
-	@sed -n 's/^## //p' $<
+	$(V0) @echo ""
+	$(V0) @echo "Makefile for the $(FORKNAME) firmware"
+	$(V0) @echo ""
+	$(V0) @echo "Usage:"
+	$(V0) @echo "        make [TARGET=<target>] [OPTIONS=\"<options>\"]"
+	$(V0) @echo "Or:"
+	$(V0) @echo "        make <target> [OPTIONS=\"<options>\"]"
+	$(V0) @echo ""
+	$(V0) @echo "Valid TARGET values are: $(VALID_TARGETS)"
+	$(V0) @echo ""
+	$(V0) @sed -n 's/^## //p' $<
 
 ## targets           : print a list of all valid target platforms (for consumption by scripts)
 targets:
-	@echo "Valid targets: $(VALID_TARGETS)"
-	@echo "Target:        $(TARGET)"
-	@echo "Base target:   $(BASE_TARGET)"
+	$(V0) @echo "Valid targets: $(VALID_TARGETS)"
+	$(V0) @echo "Target:        $(TARGET)"
+	$(V0) @echo "Base target:   $(BASE_TARGET)"
 
 ## test              : run the cleanflight test suite
 test:
-	cd src/test && $(MAKE) test || true
+	$(V0) cd src/test && $(MAKE) test || true
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS) : Makefile

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ SERIAL_DEVICE   ?= $(firstword $(wildcard /dev/ttyUSB*) no-port-found)
 # Flash size (KB).  Some low-end chips actually have more flash than advertised, use this to override.
 FLASH_SIZE ?=
 
-# Decide on a verbosity level based on the V= parameter
+## Set verbosity level based on the V= parameter
+## V=0 Low
+## v=1 High
 export AT := @
 
 ifndef V
@@ -684,9 +686,9 @@ all: $(VALID_TARGETS)
 
 $(VALID_TARGETS):
 		$(V0) echo "" && \
-		$(V0) echo "Building $@" && \
-		$(V0) $(MAKE) binary hex TARGET=$@ && \
-		$(V0) echo "Building $@ succeeded."
+		echo "Building $@" && \
+		$(MAKE) binary hex TARGET=$@ && \
+		echo "Building $@ succeeded."
 
 
 
@@ -759,9 +761,9 @@ help: Makefile
 	$(V0) @echo "Makefile for the $(FORKNAME) firmware"
 	$(V0) @echo ""
 	$(V0) @echo "Usage:"
-	$(V0) @echo "        make [TARGET=<target>] [OPTIONS=\"<options>\"]"
+	$(V0) @echo "        make [V=<verbosity>] [TARGET=<target>] [OPTIONS=\"<options>\"]"
 	$(V0) @echo "Or:"
-	$(V0) @echo "        make <target> [OPTIONS=\"<options>\"]"
+	$(V0) @echo "        make <target> [V=<verbosity>] [OPTIONS=\"<options>\"]"
 	$(V0) @echo ""
 	$(V0) @echo "Valid TARGET values are: $(VALID_TARGETS)"
 	$(V0) @echo ""


### PR DESCRIPTION
does this seem ok @AndersHoglund? it's basically straight from: https://github.com/d-ronin/dRonin/blob/next/Makefile#L52

i successfully compiled all targets with `make all` after making this change in the branch