### PR TITLE
REVO. Added Beeper on motor pin 6 support.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -500,7 +500,7 @@ void createDefaultConfig(master_t *config)
 
     config->servo_pwm_rate = 50;
 
-#ifdef CC3D
+#ifdef BEEPER_OPT
     config->use_buzzer_p6 = 0;
 #endif
 

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -45,7 +45,7 @@ typedef struct master_t {
     gimbalConfig_t gimbalConfig;
 #endif
 
-#ifdef CC3D
+#ifdef BEEPER_OPT
     uint8_t use_buzzer_p6;
 #endif
 

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -71,7 +71,7 @@ const uint16_t * const hardwareMaps[] = {
     airPPM,
 };
 
-#ifdef CC3D
+#ifdef BEEPER_OPT
 const uint16_t * const hardwareMapsBP6[] = {
     multiPWM_BP6,
     multiPPM_BP6,
@@ -104,7 +104,7 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
     if (init->usePPM || init->useSerialRx)
         i++; // next index is for PPM
 
-#ifdef CC3D
+#ifdef BEEPER_OPT
     setup = init->useBuzzerP6 ? hardwareMapsBP6[i] : hardwareMaps[i];
 #else
     setup = hardwareMaps[i];

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -60,7 +60,7 @@ typedef struct drv_pwm_config_s {
     uint16_t servoPwmRate;
     uint16_t servoCenterPulse;
 #endif
-#ifdef CC3D
+#ifdef BEEPER_OPT
     bool useBuzzerP6;
 #endif
     bool airplane;       // fixed wing hardware config, lots of servos etc
@@ -131,7 +131,7 @@ extern const uint16_t multiPWM[];
 extern const uint16_t airPPM[];
 extern const uint16_t airPWM[];
 
-#ifdef CC3D
+#ifdef BEEPER_OPT
 extern const uint16_t multiPPM_BP6[];
 extern const uint16_t multiPWM_BP6[];
 extern const uint16_t airPPM_BP6[];

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -672,7 +672,7 @@ const clivalue_t valueTable[] = {
     { "3d_neutral",                 VAR_UINT16 | MASTER_VALUE,  &masterConfig.flight3DConfig.neutral3d, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX } },
     { "3d_deadband_throttle",       VAR_UINT16 | MASTER_VALUE,  &masterConfig.flight3DConfig.deadband3d_throttle, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX } },
 
-#ifdef CC3D
+#ifdef BEEPER_OPT
     { "enable_buzzer_p6",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.use_buzzer_p6, .config.lookup = { TABLE_OFF_ON } },
 #endif
     { "use_unsynced_pwm",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.use_unsyncedPwm, .config.lookup = { TABLE_OFF_ON } },

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -340,7 +340,7 @@ void init(void)
 /* temp until PGs are implemented. */
 #ifdef BLUEJAYF4
     if (hardwareRevision <= BJF4_REV2) {
-        beeperConfig.ioTag = IO_TAG(BEEPER_OPT);
+        beeperConfig.ioTag = IO_TAG(BEEPER_BJF4_REV2);
     }
 #endif
 #ifdef BEEPER_OPT

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -305,7 +305,7 @@ void init(void)
         featureClear(FEATURE_3D);
         pwm_params.idlePulse = 0; // brushed motors
     }
-#ifdef CC3D
+#ifdef BEEPER_OPT
     pwm_params.useBuzzerP6 = masterConfig.use_buzzer_p6 ? true : false;
 #endif
 #ifndef SKIP_RX_PWM_PPM
@@ -343,7 +343,7 @@ void init(void)
         beeperConfig.ioTag = IO_TAG(BEEPER_OPT);
     }
 #endif
-#ifdef CC3D
+#ifdef BEEPER_OPT
     if (masterConfig.use_buzzer_p6 == 1)
         beeperConfig.ioTag = IO_TAG(BEEPER_OPT);
 #endif

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -34,6 +34,7 @@
 #define LED2                    PB4
 
 #define BEEPER                  PC1
+#define BEEPER_BJF4_REV2        PB7
 #define BEEPER_INVERTED
 
 #define INVERTER                PB15

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -34,7 +34,6 @@
 #define LED2                    PB4
 
 #define BEEPER                  PC1
-#define BEEPER_OPT              PB7
 #define BEEPER_INVERTED
 
 #define INVERTER                PB15

--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -86,6 +86,68 @@ const uint16_t airPWM[] = {
     0xFFFF
 };
 
+#ifdef BEEPER_OPT
+const uint16_t multiPPM_BP6[] = {
+    PWM6  | (MAP_TO_PPM_INPUT     << 8),  // PPM input
+    PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM8  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM9  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM4  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM5  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM1  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    0xFFFF
+};
+
+const uint16_t multiPWM_BP6[] = {
+    PWM1  | (MAP_TO_PWM_INPUT     << 8), // input #1
+    PWM2  | (MAP_TO_PWM_INPUT     << 8),
+    PWM3  | (MAP_TO_PWM_INPUT     << 8),
+    PWM4  | (MAP_TO_PWM_INPUT     << 8),
+    PWM5  | (MAP_TO_PWM_INPUT     << 8),
+    PWM6  | (MAP_TO_PWM_INPUT     << 8), // input #6
+    PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1 or servo #1 (swap to servo if needed)
+    PWM8  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2 or servo #2 (swap to servo if needed)
+    PWM9  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1 or #3
+    PWM10 | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT  << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM_BP6[] = {
+    PWM6  | (MAP_TO_PPM_INPUT     << 8), // PPM input
+    PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM2  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM3  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM1  | (MAP_TO_SERVO_OUTPUT  << 8),
+    0xFFFF
+};
+
+const uint16_t airPWM_BP6[] = {
+    PWM1  | (MAP_TO_PWM_INPUT     << 8), // input #1
+    PWM2  | (MAP_TO_PWM_INPUT     << 8),
+    PWM3  | (MAP_TO_PWM_INPUT     << 8),
+    PWM4  | (MAP_TO_PWM_INPUT     << 8),
+    PWM5  | (MAP_TO_PWM_INPUT     << 8),
+    PWM6  | (MAP_TO_PWM_INPUT     << 8), // input #6
+    PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1
+    PWM8  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #2
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #3
+    0xFFFF
+};
+#endif
+
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     { TIM12, IO_TAG(PB14), TIM_Channel_1, TIM8_BRK_TIM12_IRQn, 0, IOCFG_AF_PP, GPIO_AF_TIM12 },  // PPM (5th pin on FlexiIO port)
     { TIM12, IO_TAG(PB15), TIM_Channel_2, TIM8_BRK_TIM12_IRQn, 0, IOCFG_AF_PP, GPIO_AF_TIM12 },  // S2_IN - GPIO_PartialRemap_TIM3

--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -88,7 +88,7 @@ const uint16_t airPWM[] = {
 
 #ifdef BEEPER_OPT
 const uint16_t multiPPM_BP6[] = {
-    PWM6  | (MAP_TO_PPM_INPUT     << 8),  // PPM input
+    PWM1  | (MAP_TO_PPM_INPUT     << 8),  // PPM input
     PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
     PWM8  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
     PWM9  | (MAP_TO_MOTOR_OUTPUT  << 8),
@@ -98,7 +98,7 @@ const uint16_t multiPPM_BP6[] = {
     PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
     PWM4  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
     PWM5  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
-    PWM1  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
+    PWM6  | (MAP_TO_MOTOR_OUTPUT  << 8),  // Swap to servo if needed
     0xFFFF
 };
 
@@ -118,7 +118,7 @@ const uint16_t multiPWM_BP6[] = {
 };
 
 const uint16_t airPPM_BP6[] = {
-    PWM6  | (MAP_TO_PPM_INPUT     << 8), // PPM input
+    PWM1  | (MAP_TO_PPM_INPUT     << 8), // PPM input
     PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8),
     PWM8  | (MAP_TO_MOTOR_OUTPUT  << 8),
     PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
@@ -128,7 +128,7 @@ const uint16_t airPPM_BP6[] = {
     PWM3  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM4  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM1  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8),
     0xFFFF
 };
 

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -29,6 +29,7 @@
 #define LED0                    PB5
 #define LED1                    PB4
 #define BEEPER                  PB4
+#define BEEPER_OPT              PA0 // Motor pin 6
 #define INVERTER                PC0 // PC0 used as inverter select GPIO
 #define INVERTER_USART          USART1
 
@@ -103,7 +104,7 @@
 #define USE_ADC
 #define CURRENT_METER_ADC_PIN   PC1
 #define VBAT_ADC_PIN            PC2
-#define RSSI_ADC_GPIO_PIN       PA0
+#define RSSI_ADC_GPIO_PIN       PA0 // Todo: Check. Conflicts with motor 6 out and thus also BEEPER_OPT.
 
 
 #define SENSORS_SET (SENSOR_ACC)


### PR DESCRIPTION
Added support for "enable_buzzer_p6" on REVO. Required some generalization and also some cleanup of BLUEJF4. Tested on RTFQ Revo Acro. 
Note, there seems to be a conflict with RSSI_ADC_GPIO_PIN using the same PA0/Motor6 pin. Is this a correct pin for that function? 
