### PR TITLE
NAZE hardware revision fix

### DIFF
--- a/src/main/target/NAZE/hardware_revision.c
+++ b/src/main/target/NAZE/hardware_revision.c
@@ -53,8 +53,8 @@ void detectHardwareRevision(void)
 
 #ifdef USE_SPI
 
-#define DISABLE_SPI_CS       IOLo(nazeSpiCsPin)
-#define ENABLE_SPI_CS        IOHi(nazeSpiCsPin)
+#define DISABLE_SPI_CS       IOHi(nazeSpiCsPin)
+#define ENABLE_SPI_CS        IOLo(nazeSpiCsPin)
 
 #define SPI_DEVICE_NONE (0)
 #define SPI_DEVICE_FLASH (1)


### PR DESCRIPTION
Disabling CS pin is to take it high, and enabling is to bring it low.