### PR TITLE
add support for flysky and turnigy ibus receiver ia6 [rebased to development]

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -448,6 +448,7 @@ void createDefaultConfig(master_t *config)
 #else
     config->rxConfig.serialrx_provider = 0;
 #endif
+    config->rxConfig.ibus_model = 0;
     config->rxConfig.sbus_inversion = 1;
     config->rxConfig.spektrum_sat_bind = 0;
     config->rxConfig.spektrum_sat_bind_autoreset = 1;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -431,6 +431,10 @@ static const char * const lookupTableSerialRX[] = {
 };
 #endif
 
+static const char * const lookupTableIbusModel[] = {
+    "IA6B", "IA6"
+};
+
 static const char * const lookupTableGyroLpf[] = {
     "OFF",
     "188HZ",
@@ -543,6 +547,7 @@ typedef enum {
 #ifdef SERIAL_RX
     TABLE_SERIAL_RX,
 #endif
+    TABLE_IBUS_MODEL,
     TABLE_GYRO_LPF,
     TABLE_ACC_HARDWARE,
 #ifdef BARO
@@ -581,6 +586,7 @@ static const lookupTableEntry_t lookupTables[] = {
 #ifdef SERIAL_RX
     { lookupTableSerialRX, sizeof(lookupTableSerialRX) / sizeof(char *) },
 #endif
+    { lookupTableIbusModel, sizeof(lookupTableIbusModel) / sizeof(char *) },
     { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) },
     { lookupTableAccHardware, sizeof(lookupTableAccHardware) / sizeof(char *) },
 #ifdef BARO
@@ -725,6 +731,7 @@ const clivalue_t valueTable[] = {
 #ifdef SERIAL_RX
     { "serialrx_provider",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.rxConfig.serialrx_provider, .config.lookup = { TABLE_SERIAL_RX } },
 #endif
+    { "ibus_model",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.rxConfig.ibus_model, .config.lookup = { TABLE_IBUS_MODEL } },
     { "sbus_inversion",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.rxConfig.sbus_inversion, .config.lookup = { TABLE_OFF_ON } },
 #ifdef SPEKTRUM_BIND
     { "spektrum_sat_bind",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.rxConfig.spektrum_sat_bind, .config.minmax = { SPEKTRUM_SAT_BIND_DISABLED,  SPEKTRUM_SAT_BIND_MAX} },

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -42,11 +42,19 @@
 #include "rx/rx.h"
 #include "rx/ibus.h"
 
-#define IBUS_MAX_CHANNEL 10
+#define IBUS_MAX_CHANNEL 14
 #define IBUS_BUFFSIZE 32
-#define IBUS_SYNCBYTE 0x20
+#define IBUS_MODEL_IA6B 0
+#define IBUS_MODEL_IA6 1
 
 #define IBUS_BAUDRATE 115200
+
+static uint8_t ibusModel = 0;
+static uint8_t ibusSyncByte = 0x20;
+static uint8_t ibusFrameSize = 32;
+static uint8_t ibusChannelOffset = 2;
+static uint32_t ibusInterframeGap = 3000;
+static uint16_t ibusChecksum = 0xFFFF;
 
 static bool ibusFrameDone = false;
 static uint32_t ibusChannelData[IBUS_MAX_CHANNEL];
@@ -56,7 +64,15 @@ static uint16_t ibusReadRawRC(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
 
 bool ibusInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback)
 {
-    UNUSED(rxConfig);
+
+    if (rxConfig->ibus_model == IBUS_MODEL_IA6) {
+        ibusModel = 1;
+        ibusSyncByte = 0x55;
+        ibusFrameSize = 31;
+        ibusInterframeGap = 500;
+        ibusChecksum = 0x0000;
+        ibusChannelOffset = 1;
+    }
 
     if (callback)
         *callback = ibusReadRawRC;
@@ -96,17 +112,17 @@ static void ibusDataReceive(uint16_t c)
 
     ibusTime = micros();
 
-    if ((ibusTime - ibusTimeLast) > 3000)
+    if ((ibusTime - ibusTimeLast) > ibusInterframeGap) 
         ibusFramePosition = 0;
 
     ibusTimeLast = ibusTime;
 
-    if (ibusFramePosition == 0 && c != IBUS_SYNCBYTE)
+    if (ibusFramePosition == 0 && c != ibusSyncByte)
         return;
 
     ibus[ibusFramePosition] = (uint8_t)c;
 
-    if (ibusFramePosition == IBUS_BUFFSIZE - 1) {
+    if (ibusFramePosition == ibusFrameSize - 1) {
         ibusFrameDone = true;
     } else {
         ibusFramePosition++;
@@ -125,17 +141,22 @@ uint8_t ibusFrameStatus(void)
 
     ibusFrameDone = false;
 
-    chksum = 0xFFFF;
-    for (i = 0; i < 30; i++)
-        chksum -= ibus[i];
-        
-    rxsum = ibus[30] + (ibus[31] << 8);
+    chksum = ibusChecksum;
+    rxsum = ibus[ibusFrameSize - 2] + (ibus[ibusFrameSize - 1] << 8);
+    
+    if (ibusModel == IBUS_MODEL_IA6) {
+	    for (i = 0, offset = ibusChannelOffset; i < IBUS_MAX_CHANNEL; i++, offset += 2)
+		chksum += ibus[offset] + (ibus[offset + 1] << 8);
+    } else { 
+	    for (i = 0; i < 30; i++)
+		chksum -= ibus[i];
+    }
 
     if (chksum == rxsum) {
-        for (i = 0, offset = 2; i < IBUS_MAX_CHANNEL; i++, offset += 2) {
-            ibusChannelData[i] = ibus[offset] + (ibus[offset + 1] << 8);
-        }
-        frameStatus = SERIAL_RX_FRAME_COMPLETE;
+        for (i = 0, offset = ibusChannelOffset; i < IBUS_MAX_CHANNEL; i++, offset += 2) {
+	    ibusChannelData[i] = ibus[offset] + (ibus[offset + 1] << 8);
+	}
+	frameStatus = SERIAL_RX_FRAME_COMPLETE;
     }
 
     return frameStatus;

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -112,6 +112,7 @@ typedef struct rxChannelRangeConfiguration_s {
 typedef struct rxConfig_s {
     uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS];  // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_provider;              // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_RX_SERIAL first.
+    uint8_t ibus_model;
     uint8_t sbus_inversion;                 // default sbus (Futaba, FrSKY) is inverted. Support for uninverted OpenLRS (and modified FrSKY) receivers.
     uint8_t nrf24rx_protocol;               // type of nrf24 protocol (0 = v202 250kbps). Must be enabled by FEATURE_RX_NRF24 first.
     uint32_t nrf24rx_id;


### PR DESCRIPTION
Normally only the FS-IA6B receiver from FlySky/Turnigy supports its IBUS protocol. As documented in http://www.rcgroups.com/forums/showthread.php?t=2711184 this PR adds support for the IA6 receiver, which is shipped with the remote by default. You just have to solder one pin on the backside of the receiver.
Thanks again to darven for his co-work!

![image](https://cloud.githubusercontent.com/assets/3606067/17460547/198a3a62-5c6c-11e6-87fb-9fc51ed20d89.png)


I added the CLI command ibus_model which defaults to the official IBUS receiver,
but can be changed by setting:

set ibus_model = IA6

Both receiver types were tested successfully.