### PR TITLE
Enable using of any RC channel to set the color hue modifier.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -581,6 +581,7 @@ void createDefaultConfig(master_t *config)
     applyDefaultModeColors(config->modeColors);
     applyDefaultSpecialColors(&(config->specialColors));
     config->ledstrip_visual_beeper = 0;
+    config->ledstrip_aux_channel = THROTTLE;
 #endif
 
 #ifdef VTX

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -125,6 +125,7 @@ typedef struct master_t {
     modeColorIndexes_t modeColors[LED_MODE_COUNT];
     specialColorIndexes_t specialColors;
     uint8_t ledstrip_visual_beeper; // suppress LEDLOW mode if beeper is on
+    rc_alias_e ledstrip_aux_channel;
 #endif
 
 #ifdef TRANSPONDER

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -169,6 +169,7 @@ static const specialColorIndexes_t defaultSpecialColors[] = {
 };
 
 static int scaledThrottle;
+static int scaledAux;
 
 static void updateLedRingCounts(void);
 
@@ -252,7 +253,7 @@ bool parseLedStripConfig(int ledIndex, const char *config)
         RING_COLORS,
         PARSE_STATE_COUNT
     };
-    static const char chunkSeparators[PARSE_STATE_COUNT] = {',', ':', ':',':', '\0'};
+    static const char chunkSeparators[PARSE_STATE_COUNT] = {',', ':', ':', ':', '\0'};
 
     ledConfig_t *ledConfig = &masterConfig.ledConfigs[ledIndex];
     memset(ledConfig, 0, sizeof(ledConfig_t));
@@ -489,7 +490,7 @@ static void applyLedFixedLayers()
         }
 
         if (ledGetOverlayBit(ledConfig, LED_OVERLAY_THROTTLE)) {
-            hOffset += ((scaledThrottle - 10) * 4) / 3;
+            hOffset += scaledAux;
         }
 
         color.h = (color.h + hOffset) % (HSV_HUE_MAX + 1);
@@ -959,6 +960,7 @@ void updateLedStrip(void)
     // apply all layers; triggered timed functions has to update timers
 
     scaledThrottle = ARMING_FLAG(ARMED) ? scaleRange(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX, 10, 100) : 10;
+    scaledAux = scaleRange(rcData[masterConfig.ledstrip_aux_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, HSV_HUE_MAX + 1);
 
     applyLedFixedLayers();
 
@@ -1032,6 +1034,10 @@ bool setModeColor(ledModeIndex_e modeIndex, int modeColorIndex, int colorIndex)
         if (modeColorIndex < 0 || modeColorIndex >= LED_SPECIAL_COLOR_COUNT)
             return false;
         masterConfig.specialColors.color[modeColorIndex] = colorIndex;
+    } else if (modeIndex == LED_AUX_CHANNEL) {
+        if (modeColorIndex < 0 || modeColorIndex >= 1)
+            return false;
+        masterConfig.ledstrip_aux_channel = colorIndex;
     } else {
         return false;
     }

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -73,7 +73,8 @@ typedef enum {
     LED_MODE_ANGLE,
     LED_MODE_MAG,
     LED_MODE_BARO,
-    LED_SPECIAL
+    LED_SPECIAL,
+    LED_AUX_CHANNEL
 } ledModeIndex_e;
 
 typedef enum {

--- a/src/main/io/msp_protocol.h
+++ b/src/main/io/msp_protocol.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   20 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   21 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1666,6 +1666,10 @@ static void printModeColor(uint8_t dumpMask, master_t *defaultConfig)
         int colorIndexDefault = defaultConfig->specialColors.color[j];
         cliDumpPrintf(dumpMask, colorIndex == colorIndexDefault, "mode_color %u %u %u\r\n", LED_SPECIAL, j, colorIndex);
     }
+
+    int ledStripAuxChannel = masterConfig.ledstrip_aux_channel;
+    int ledStripAuxChannelDefault = defaultConfig->ledstrip_aux_channel;
+    cliDumpPrintf(dumpMask, ledStripAuxChannel == ledStripAuxChannelDefault, "mode_color %u %u %u\r\n", LED_AUX_CHANNEL, 0, ledStripAuxChannel);
 }
 
 static void cliModeColor(char *cmdline)

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1135,7 +1135,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
 
     case MSP_LED_STRIP_MODECOLOR:
-        headSerialReply(((LED_MODE_COUNT * LED_DIRECTION_COUNT) + LED_SPECIAL_COLOR_COUNT) * 3);
+        headSerialReply(((LED_MODE_COUNT * LED_DIRECTION_COUNT) + LED_SPECIAL_COLOR_COUNT + 1) * 3);
         for (int i = 0; i < LED_MODE_COUNT; i++) {
             for (int j = 0; j < LED_DIRECTION_COUNT; j++) {
                 serialize8(i);
@@ -1149,6 +1149,10 @@ static bool processOutCommand(uint8_t cmdMSP)
             serialize8(j);
             serialize8(masterConfig.specialColors.color[j]);
         }
+
+        serialize8(LED_AUX_CHANNEL);
+        serialize8(0);
+        serialize8(masterConfig.ledstrip_aux_channel);
         break;
 #endif
 


### PR DESCRIPTION
Can be set via MSP (bumped to version 21)
New CLI command: `mode_color 7 0 AUX_Channel`
AUX_Channel possible values:
    ROLL = 0
    PITCH = 1
    YAW = 2
    THROTTLE = 3
    AUX1 = 4
    AUX2 = 5
    AUX3 = 6
    AUX4 = 7
    AUX5 = 8
    AUX6 = 9
    AUX7 = 10
    AUX8 = 11

Refactors https://github.com/betaflight/betaflight/pull/913
Requires https://github.com/betaflight/betaflight-configurator/pull/224