### PR TITLE
Fix deadband behaviour for 3D Throttle

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -803,12 +803,12 @@ void mixTable(void *pidProfilePtr)
             throttleMax = flight3DConfig->deadband3d_low;
             throttleMin = escAndServoConfig->minthrottle;
             throttlePrevious = rcCommand[THROTTLE];
-			throttle = rcCommand[THROTTLE] + flight3DConfig->deadband3d_throttle;
+		    throttle = rcCommand[THROTTLE] + flight3DConfig->deadband3d_throttle;
         } else if (rcCommand[THROTTLE] >= (rxConfig->midrc + flight3DConfig->deadband3d_throttle)) { // Positive handling
             throttleMax = escAndServoConfig->maxthrottle;
             throttleMin = flight3DConfig->deadband3d_high;
             throttlePrevious = rcCommand[THROTTLE];
-			throttle = rcCommand[THROTTLE] - flight3DConfig->deadband3d_throttle;
+		    throttle = rcCommand[THROTTLE] - flight3DConfig->deadband3d_throttle;
         } else if ((throttlePrevious <= (rxConfig->midrc - flight3DConfig->deadband3d_throttle)))  { // Deadband handling from negative to positive
             throttle = throttleMax = flight3DConfig->deadband3d_low;
             throttleMin = escAndServoConfig->minthrottle;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -802,11 +802,13 @@ void mixTable(void *pidProfilePtr)
         if ((rcCommand[THROTTLE] <= (rxConfig->midrc - flight3DConfig->deadband3d_throttle))) { // Out of band handling
             throttleMax = flight3DConfig->deadband3d_low;
             throttleMin = escAndServoConfig->minthrottle;
-            throttlePrevious = throttle = rcCommand[THROTTLE];
+            throttlePrevious = rcCommand[THROTTLE];
+			throttle = rcCommand[THROTTLE] + flight3DConfig->deadband3d_throttle;
         } else if (rcCommand[THROTTLE] >= (rxConfig->midrc + flight3DConfig->deadband3d_throttle)) { // Positive handling
             throttleMax = escAndServoConfig->maxthrottle;
             throttleMin = flight3DConfig->deadband3d_high;
-            throttlePrevious = throttle = rcCommand[THROTTLE];
+            throttlePrevious = rcCommand[THROTTLE];
+			throttle = rcCommand[THROTTLE] - flight3DConfig->deadband3d_throttle;
         } else if ((throttlePrevious <= (rxConfig->midrc - flight3DConfig->deadband3d_throttle)))  { // Deadband handling from negative to positive
             throttle = throttleMax = flight3DConfig->deadband3d_low;
             throttleMin = escAndServoConfig->minthrottle;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -803,12 +803,12 @@ void mixTable(void *pidProfilePtr)
             throttleMax = flight3DConfig->deadband3d_low;
             throttleMin = escAndServoConfig->minthrottle;
             throttlePrevious = rcCommand[THROTTLE];
-		    throttle = rcCommand[THROTTLE] + flight3DConfig->deadband3d_throttle;
+            throttle = rcCommand[THROTTLE] + flight3DConfig->deadband3d_throttle;
         } else if (rcCommand[THROTTLE] >= (rxConfig->midrc + flight3DConfig->deadband3d_throttle)) { // Positive handling
             throttleMax = escAndServoConfig->maxthrottle;
             throttleMin = flight3DConfig->deadband3d_high;
             throttlePrevious = rcCommand[THROTTLE];
-		    throttle = rcCommand[THROTTLE] - flight3DConfig->deadband3d_throttle;
+            throttle = rcCommand[THROTTLE] - flight3DConfig->deadband3d_throttle;
         } else if ((throttlePrevious <= (rxConfig->midrc - flight3DConfig->deadband3d_throttle)))  { // Deadband handling from negative to positive
             throttle = throttleMax = flight3DConfig->deadband3d_low;
             throttleMin = escAndServoConfig->minthrottle;


### PR DESCRIPTION
The 3D Throttle was not working correctly with deadband... the minute you stepped out of the deadband range, you had a lot of throttle (positive or negative). That was because the deadband value was not subtracted from the throttle before it was used. I fixed this. Makes 3D flying with a large-ish deadband feasible.