### PR TITLE
Added average to FIR filter. Added int16 FIR filter.

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -47,6 +47,14 @@ typedef struct firFilter_s {
     uint8_t coeffsLength;
 } firFilter_t;
 
+typedef struct firFilterInt16_s {
+    int16_t *buf;
+    const float *coeffs;
+    uint8_t bufLength;
+    uint8_t coeffsLength;
+} firFilterInt16_t;
+
+
 void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
 void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType);
 float biquadFilterApply(biquadFilter_t *filter, float input);
@@ -56,11 +64,21 @@ void pt1FilterInit(pt1Filter_t *filter, uint8_t f_cut, float dT);
 float pt1FilterApply(pt1Filter_t *filter, float input);
 float pt1FilterApply4(pt1Filter_t *filter, float input, uint8_t f_cut, float dT);
 
-int32_t filterApplyAverage(int32_t input, uint8_t averageCount, int32_t averageState[DELTA_MAX_SAMPLES]);
-float filterApplyAveragef(float input, uint8_t averageCount, float averageState[DELTA_MAX_SAMPLES]);
-
 void firFilterInit(firFilter_t *filter, float *buf, uint8_t bufLength, const float *coeffs);
 void firFilterInit2(firFilter_t *filter, float *buf, uint8_t bufLength, const float *coeffs, uint8_t coeffsLength);
 void firFilterUpdate(firFilter_t *filter, float input);
-float firFilterApply(firFilter_t *filter);
+float firFilterApply(const firFilter_t *filter);
+float firFilterCalcPartialAverage(const firFilter_t *filter, uint8_t count);
+float firFilterCalcAverage(const firFilter_t *filter);
+float firFilterLastInput(const firFilter_t *filter);
+float firFilterGet(const firFilter_t *filter, int index);
+
+void firFilterInt16Init(firFilterInt16_t *filter, int16_t *buf, uint8_t bufLength, const float *coeffs);
+void firFilterInt16Init2(firFilterInt16_t *filter, int16_t *buf, uint8_t bufLength, const float *coeffs, uint8_t coeffsLength);
+void firFilterInt16Update(firFilterInt16_t *filter, int16_t input);
+float firFilterInt16Apply(const firFilterInt16_t *filter);
+float firFilterInt16CalcPartialAverage(const firFilterInt16_t *filter, uint8_t count);
+float firFilterInt16CalcAverage(const firFilterInt16_t *filter);
+int16_t firFilterInt16LastInput(const firFilterInt16_t *filter);
+int16_t firFilterInt16Get(const firFilter_t *filter, int index);
 


### PR DESCRIPTION
@borisbstyle , added average calculation to FIR filter as requested.

I've also added the `firFilterInt16` I've been using. This takes `int16_t` values as input so can be used to directly buffer the gyro and acc output. These values can subsequently be processed, either by averaging, using a FIR filter or using the `firFilterInt16Get` function to recover the values from the buffer and (say) input them into a biquad filter before processing.