### PR TITLE
Update RMDO MPU interrupt support

### DIFF
--- a/src/main/target/RMDO/target.h
+++ b/src/main/target/RMDO/target.h
@@ -26,11 +26,13 @@
 #define BEEPER                  PC15
 #define BEEPER_INVERTED
 
+#define USE_EXTI
+#define MPU_INT_EXTI PC13
 #define EXTI_CALLBACK_HANDLER_COUNT 2 // MPU data ready and MAG data ready
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW
-#define USE_MAG_DATA_READY_SIGNAL
-#define ENSURE_MAG_DATA_READY_IS_HIGH
+//#define USE_MAG_DATA_READY_SIGNAL       // XXX Do RMDO has onboard mag???
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
 
 #define GYRO
 #define USE_GYRO_MPU6050


### PR DESCRIPTION
The RMDO/target.h was under maintained that it was probably outdated by EXTI changes at some stage.