### PR TITLE
Add missing pin to IRCFUSION3 target

### DIFF
--- a/src/main/target/IRCFUSIONF3/target.h
+++ b/src/main/target/IRCFUSIONF3/target.h
@@ -25,6 +25,9 @@
 
 #define USABLE_TIMER_CHANNEL_COUNT 17
 
+#define USE_EXTI
+#define MPU_INT_EXTI PC13
+
 #define EXTI_CALLBACK_HANDLER_COUNT 1 // MPU data ready, no MAG
 
 #define USE_MPU_DATA_READY_SIGNAL


### PR DESCRIPTION
Without the pin for the IRCFUSION3 target, connecting to the FC was not possible. To fix it, the missing pin is added to the target.

This resolves #1056.