### PR TITLE
Add horizon_tilt_effect command

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -157,7 +157,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D8[PIDNAVR] = 83;  // NAV_D * 1000;
     pidProfile->P8[PIDLEVEL] = 50;
     pidProfile->I8[PIDLEVEL] = 50;
-    pidProfile->D8[PIDLEVEL] = 100;
+    pidProfile->D8[PIDLEVEL] = 75;
     pidProfile->P8[PIDMAG] = 40;
     pidProfile->P8[PIDVEL] = 55;
     pidProfile->I8[PIDVEL] = 55;
@@ -182,6 +182,9 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->rateAccelLimit = 0;
     pidProfile->itermThrottleGain = 0;
     pidProfile->levelSensitivity = 2.0f;
+
+    pidProfile->horizon_tilt_effect = 75;
+    pidProfile->horizon_tilt_mode = HORIZON_TILT_MODE_SAFE;
 
 #ifdef GTUNE
     pidProfile->gtune_lolimP[ROLL] = 10;          // [0..200] Lower limit of ROLL P during G tune.

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -55,6 +55,11 @@ typedef enum {
     PID_STABILISATION_ON
 } pidStabilisationState_e;
 
+typedef enum {
+    HORIZON_TILT_MODE_SAFE = 0,
+    HORIZON_TILT_MODE_EXPERT
+} horizonTiltMode_e;
+
 typedef struct pidProfile_s {
     uint8_t P8[PID_ITEM_COUNT];
     uint8_t I8[PID_ITEM_COUNT];
@@ -80,6 +85,9 @@ typedef struct pidProfile_s {
     uint16_t yawRateAccelLimit;             // yaw accel limiter for deg/sec/ms
     uint16_t rateAccelLimit;                // accel limiter roll/pitch deg/sec/ms
     float levelSensitivity;
+
+    uint8_t horizon_tilt_effect;            // inclination factor for Horizon mode
+    uint8_t horizon_tilt_mode;              // SAFE or EXPERT
 
 #ifdef GTUNE
     uint8_t  gtune_lolimP[3];               // [0..200] Lower limit of P during G tune

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -554,6 +554,10 @@ static const char * const lookupTableFailsafe[] = {
     "AUTO-LAND", "DROP"
 };
 
+static const char * const lookupTableHorizonTiltMode[] = {
+    "SAFE", "EXPERT"
+};
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -597,6 +601,7 @@ typedef enum {
 #ifdef OSD
     TABLE_OSD,
 #endif
+    TABLE_HORIZON_TILT_MODE,
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -637,6 +642,7 @@ static const lookupTableEntry_t lookupTables[] = {
 #ifdef OSD
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
 #endif
+    { lookupTableHorizonTiltMode, sizeof(lookupTableHorizonTiltMode) / sizeof(char *) },
 };
 
 #define VALUE_TYPE_OFFSET 0
@@ -837,6 +843,10 @@ const clivalue_t valueTable[] = {
     { "yaw_motor_direction",        VAR_INT8   | MASTER_VALUE, &mixerConfig()->yaw_motor_direction, .config.minmax = { -1,  1 } },
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yaw_p_limit, .config.minmax = { YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX } },
     { "pidsum_limit",               VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.pidSumLimit, .config.minmax = { 0.1, 1.0 } },
+
+    { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.horizon_tilt_effect, .config.minmax = { 0,  250 } },
+    { "horizon_tilt_mode",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.horizon_tilt_mode, .config.lookup = { TABLE_HORIZON_TILT_MODE } },
+
 #ifdef USE_SERVOS
     { "servo_center_pulse",         VAR_UINT16 | MASTER_VALUE,  &servoConfig()->servoCenterPulse, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX } },
     { "tri_unarmed_servo",          VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, &servoMixerConfig()->tri_unarmed_servo, .config.lookup = { TABLE_OFF_ON } },


### PR DESCRIPTION
The PR has been surperseded by #2570

This is an updated version of PR #382 "Add horizon_incl_fact parameter"

This modification adds two new CLI commands, 'horizon_tilt_effect' and 'horizon_tilt_mode', which control the effect the current inclination has on self-leveling in the Horizon flight mode.  With the existing horizon mode, the strength of the self-leveling is solely dependent on the stick position.  This is problematic when trying to do maneuvers like large loops and fast-forward flight.  Adding a factor that takes into account the current inclination of the craft provides a big improvement for these maneuvers and improves the "feel" of horizon mode.  (The current inclination is the number of degrees of pitch or roll that the vehicle is away from level, whichever is greater).

This mod also addresses an issue with the "Transition (Horizon)" ('d_level') parameter -- in recent versions of Betaflight the 'sensitivity_horizon' (LUX) and 'd_level' (REWRITE) CLI parameters were merged so that both use the 'd_level' parameter.  The problem is that the ranges behave differently -- in LUX, increasing the value results in more self leveling and zero results in no self leveling; in REWRITE, increasing the value results in less self leveling.  With this mod, increasing the value results in more self leveling and zero results in no self leveling.  The default has been changed to 75, which should give relatively unchanged default behavior for this parameter on both PID controllers.

The original idea for this mod came from ctzsnooze (see CleanFlight [issue #695](http://github.com/cleanflight/cleanflight/issues/695)); I've expanded on it and turned it into a configurable option.  One characteristic of horizon mode I made a point of retaining is that, when the vehicle is flat and the sticks are near center, the self-leveling effect is not diminished by larger 'horizon_incl_fact' settings.  Like in the existing horizon mode, the strength of the self-leveling can be effectively managed using the "Strength (Horizon)" ('i_level') parameter.  Also, the "Transition (Horizon)" ('d_level') parameter operates the same as before.

Setting 'horizon_tilt_effect' to 0 will run the old horizon-mode behavior.  For other values, see below:

horizon_tilt_effect 0|175|75: Controls the effect the current inclination (tilt) has on self-leveling in the Horizon flight mode. Larger values result in less self-leveling (more "acro") as the tilt of the vehicle increases. The default value of 75 provides good performance when doing large loops and fast-forward flight. With a value of 0 the strength of the self-leveling would be solely dependent on the stick position.

horizon_tilt_mode SAFE|EXPERT: Sets the preformance mode for 'horizon_tilt_effect'

SAFE = leveling always active when sticks centered:
This is the "safer" range because the self-leveling is always active when the sticks are centered. So, when the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle will immediately be self-leveled to upright and flat. (Note that after this kind of very-fast 180-degree self-leveling, the heading of the vehicle can be unpredictable.)

EXPERT = leveling can be totally off when inverted:
In this range, the inclination (tilt) of the vehicle can fully "override" the self-leveling. In this mode, when the 'horizon_tilt_effect' parameter is set to around 75, and the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle is not self-leveled. This can be desirable for performing more-acrobatic maneuvers and potentially for 3D-mode flying.

The 'horizon_tilt_effect' and 'horizon_tilt_mode' values are separate for each profile.

I've posted a version of this modification applied to the 2.9.1 (release) and 3.0.0-RC8 versions of Betaflight, [here](http://www.etheli.com/CF/addHorizonTiltEffect#bf).  An analogous PR for Cleanflight is [here](https://github.com/cleanflight/cleanflight/pull/2364).

--ET
