### PR TITLE
Variable battery NOT PRESENT level

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -282,6 +282,7 @@ void resetBatteryConfig(batteryConfig_t *batteryConfig)
     batteryConfig->currentMeterScale = 400; // for Allegro ACS758LCB-100U (40mV/A)
     batteryConfig->batteryCapacity = 0;
     batteryConfig->currentMeterType = CURRENT_SENSOR_ADC;
+    batteryConfig->batterynotpresentlevel = 55; // VBAT below 5.5 V will be igonored
 }
 
 #ifdef SWAP_SERIAL_PORT_0_AND_1_DEFAULTS

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -758,7 +758,7 @@ const clivalue_t valueTable[] = {
     { "current_meter_offset",       VAR_UINT16 | MASTER_VALUE,  &masterConfig.batteryConfig.currentMeterOffset, .config.minmax = { 0,  3300 } },
     { "multiwii_current_meter_output", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.batteryConfig.multiwiiCurrentMeterOutput, .config.lookup = { TABLE_OFF_ON } },
     { "current_meter_type",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.batteryConfig.currentMeterType, .config.lookup = { TABLE_CURRENT_SENSOR } },
-
+    { "battery_notpresent_level",   VAR_UINT8  | MASTER_VALUE, &masterConfig.batteryConfig.batterynotpresentlevel, .config.minmax = { 0, 200 } },
     { "align_gyro",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.sensorAlignmentConfig.gyro_align, .config.lookup = { TABLE_ALIGNMENT } },
     { "align_acc",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.sensorAlignmentConfig.acc_align, .config.lookup = { TABLE_ALIGNMENT } },
     { "align_mag",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.sensorAlignmentConfig.mag_align, .config.lookup = { TABLE_ALIGNMENT } },

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -110,7 +110,7 @@ void updateBattery(void)
         batteryCriticalVoltage = batteryCellCount * batteryConfig->vbatmincellvoltage;
     }
     /* battery has been disconnected - can take a while for filter cap to disharge so we use a threshold of VBATT_PRESENT_THRESHOLD */
-    else if (batteryState != BATTERY_NOT_PRESENT && vbat <= batteryConfig->batterynotpresentlevel)
+    else if (batteryState != BATTERY_NOT_PRESENT && vbat <= batteryConfig->batterynotpresentlevel && !ARMING_FLAG(ARMED))
     {
         batteryState = BATTERY_NOT_PRESENT;
         batteryCellCount = 0;

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -39,7 +39,6 @@
 
 #include "rx/rx.h"
 
-#define VBATT_PRESENT_THRESHOLD    10
 #define VBATT_LPF_FREQ  0.4f
 
 // Battery monitoring stuff
@@ -90,7 +89,7 @@ void updateBattery(void)
     updateBatteryVoltage();
 
     /* battery has just been connected*/
-    if (batteryState == BATTERY_NOT_PRESENT && vbat > MAX(VBATT_PRESENT_THRESHOLD, batteryConfig->batterynotpresentlevel))
+    if (batteryState == BATTERY_NOT_PRESENT && vbat > batteryConfig->batterynotpresentlevel )
     {
         /* Actual battery state is calculated below, this is really BATTERY_PRESENT */
         batteryState = BATTERY_OK;
@@ -111,7 +110,7 @@ void updateBattery(void)
         batteryCriticalVoltage = batteryCellCount * batteryConfig->vbatmincellvoltage;
     }
     /* battery has been disconnected - can take a while for filter cap to disharge so we use a threshold of VBATT_PRESENT_THRESHOLD */
-    else if (batteryState != BATTERY_NOT_PRESENT && vbat <= MAX(VBATT_PRESENT_THRESHOLD, batteryConfig->batterynotpresentlevel))
+    else if (batteryState != BATTERY_NOT_PRESENT && vbat <= batteryConfig->batterynotpresentlevel)
     {
         batteryState = BATTERY_NOT_PRESENT;
         batteryCellCount = 0;

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -39,7 +39,7 @@
 
 #include "rx/rx.h"
 
-#define VBATT_PRESENT_THRESHOLD_MV    10
+#define VBATT_PRESENT_THRESHOLD    10
 #define VBATT_LPF_FREQ  0.4f
 
 // Battery monitoring stuff
@@ -90,7 +90,7 @@ void updateBattery(void)
     updateBatteryVoltage();
 
     /* battery has just been connected*/
-    if (batteryState == BATTERY_NOT_PRESENT && vbat > VBATT_PRESENT_THRESHOLD_MV)
+    if (batteryState == BATTERY_NOT_PRESENT && vbat > MAX(VBATT_PRESENT_THRESHOLD, batteryConfig->batterynotpresentlevel))
     {
         /* Actual battery state is calculated below, this is really BATTERY_PRESENT */
         batteryState = BATTERY_OK;
@@ -110,8 +110,8 @@ void updateBattery(void)
         batteryWarningVoltage = batteryCellCount * batteryConfig->vbatwarningcellvoltage;
         batteryCriticalVoltage = batteryCellCount * batteryConfig->vbatmincellvoltage;
     }
-    /* battery has been disconnected - can take a while for filter cap to disharge so we use a threshold of VBATT_PRESENT_THRESHOLD_MV */
-    else if (batteryState != BATTERY_NOT_PRESENT && vbat <= VBATT_PRESENT_THRESHOLD_MV)
+    /* battery has been disconnected - can take a while for filter cap to disharge so we use a threshold of VBATT_PRESENT_THRESHOLD */
+    else if (batteryState != BATTERY_NOT_PRESENT && vbat <= MAX(VBATT_PRESENT_THRESHOLD, batteryConfig->batterynotpresentlevel))
     {
         batteryState = BATTERY_NOT_PRESENT;
         batteryCellCount = 0;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -50,6 +50,7 @@ typedef struct batteryConfig_s {
     // FIXME this doesn't belong in here since it's a concern of MSP, not of the battery code.
     uint8_t multiwiiCurrentMeterOutput;     // if set to 1 output the amperage in milliamp steps instead of 0.01A steps via msp
     uint16_t batteryCapacity;               // mAh
+    uint8_t batterynotpresentlevel;         // Below this level battery is considered as not present
 } batteryConfig_t;
 
 typedef enum {


### PR DESCRIPTION
Some boards feedback USB voltage to rest of board, and in some cases also to VBAT (e.g. DoDO). This causes VBAT to constantly beep whenever connected to USB (without battery connected). 

This change allows user to select a voltage level (e.g. 6V) that will always trigger battery NOT PRESENT, and thus inhibit battery warning. 

- E.g `set battery_notpresent_level = 60` will set battery state to NOT PRESENT when connected to USB (VBAT below 6.0V). 