### PR TITLE
Added PID values over smartport telemetry

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -266,6 +266,7 @@ void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
     telemetryConfig->frsky_vfas_precision = 0;
     telemetryConfig->frsky_vfas_cell_voltage = 0;
     telemetryConfig->hottAlarmSoundInterval = 5;
+    telemetryConfig->pidValuesAsTelemetry = 0;
 }
 #endif
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -746,6 +746,7 @@ const clivalue_t valueTable[] = {
     { "frsky_vfas_precision",       VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_vfas_precision, .config.minmax = { FRSKY_VFAS_PRECISION_LOW,  FRSKY_VFAS_PRECISION_HIGH } },
     { "frsky_vfas_cell_voltage",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.telemetryConfig.frsky_vfas_cell_voltage, .config.lookup = { TABLE_OFF_ON } },
     { "hott_alarm_sound_interval",  VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.hottAlarmSoundInterval, .config.minmax = { 0,  120 } },
+    { "pid_values_as_telemetry",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.telemetryConfig.pidValuesAsTelemetry, .config.lookup = {TABLE_OFF_ON } },
 #endif
 
     { "battery_capacity",           VAR_UINT16 | MASTER_VALUE,  &masterConfig.batteryConfig.batteryCapacity, .config.minmax = { 0,  20000 } },

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -469,7 +469,8 @@ void handleSmartPortTelemetry(void)
                     smartPortSendPackage(id, 0);
                     smartPortHasRequest = 0;
                 }
-                else {
+
+                else if (telemetryConfig->pidValuesAsTelemetry){
                     switch (t2Cnt) {
                         case 0:
                             tmp2 = currentProfile->pidProfile.P8[ROLL];

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -61,6 +61,9 @@
 #include "fc/runtime_config.h"
 
 #include "config/config.h"
+#include "config/config_profile.h"
+extern profile_t *currentProfile;
+extern controlRateConfig_t *currentControlRateProfile;
 
 enum
 {
@@ -314,7 +317,9 @@ void handleSmartPortTelemetry(void)
         smartPortIdCnt++;
 
         int32_t tmpi;
+        uint32_t tmp2;
         static uint8_t t1Cnt = 0;
+        static uint8_t t2Cnt = 0;
 
         switch(id) {
 #ifdef GPS
@@ -462,6 +467,37 @@ void handleSmartPortTelemetry(void)
                 }
                 else if (feature(FEATURE_GPS)) {
                     smartPortSendPackage(id, 0);
+                    smartPortHasRequest = 0;
+                }
+                else {
+                    switch (t2Cnt) {
+                        case 0:
+                            tmp2 = currentProfile->pidProfile.P8[ROLL];
+                            tmp2 += (currentProfile->pidProfile.P8[PITCH]<<8);
+                            tmp2 += (currentProfile->pidProfile.P8[YAW]<<16);
+                        break;
+                        case 1:
+                            tmp2 = currentProfile->pidProfile.I8[ROLL];
+                            tmp2 += (currentProfile->pidProfile.I8[PITCH]<<8);
+                            tmp2 += (currentProfile->pidProfile.I8[YAW]<<16);
+                        break;
+                        case 2:
+                            tmp2 = currentProfile->pidProfile.D8[ROLL];
+                            tmp2 += (currentProfile->pidProfile.D8[PITCH]<<8);
+                            tmp2 += (currentProfile->pidProfile.D8[YAW]<<16);
+                        break;
+                        case 3:
+                            tmp2 = currentControlRateProfile->rates[FD_ROLL];
+                            tmp2 += (currentControlRateProfile->rates[FD_PITCH]<<8);
+                            tmp2 += (currentControlRateProfile->rates[FD_YAW]<<16);
+                        break;
+                    }
+                    tmp2 += t2Cnt<<24;
+                    t2Cnt++;
+                    if (t2Cnt == 4) {
+                        t2Cnt = 0;
+                    }
+                    smartPortSendPackage(id, tmp2);
                     smartPortHasRequest = 0;
                 }
                 break;

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -44,6 +44,7 @@ typedef struct telemetryConfig_s {
     uint8_t frsky_vfas_precision;
     uint8_t frsky_vfas_cell_voltage;
     uint8_t hottAlarmSoundInterval;
+    uint8_t pidValuesAsTelemetry;
 } telemetryConfig_t;
 
 void telemetryInit(void);


### PR DESCRIPTION
PID/rate values over smartport telemetry has been requested several times, e.g. in #409 

This change adds P, I, D and rates for roll, pitch and yaw in Smartport variable Tmp2. 
Several values are sent together as an uint32, thus receiver need to bitmask values. Can be done with a simple LUA script similar to https://github.com/KiteAnton/Taranis/blob/master/tuning.lua

![image](https://cloud.githubusercontent.com/assets/15310830/17945603/d5819e6e-6a44-11e6-9559-9ac123f82c9d.png)

Fixes #409 
