### PR TITLE
Remove SONAR for NAZE to save FLASH

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -104,11 +104,11 @@
 #define USE_MAG_HMC5883
 #define MAG_HMC5883_ALIGN       CW180_DEG
 
-#define SONAR
-#define SONAR_TRIGGER_PIN       PB0
-#define SONAR_ECHO_PIN          PB1
-#define SONAR_TRIGGER_PIN_PWM   PB8
-#define SONAR_ECHO_PIN_PWM      PB9
+//#define SONAR
+//#define SONAR_TRIGGER_PIN       PB0
+//#define SONAR_ECHO_PIN          PB1
+//#define SONAR_TRIGGER_PIN_PWM   PB8
+//#define SONAR_ECHO_PIN_PWM      PB9
 
 //#define DISPLAY
 


### PR DESCRIPTION
NAZE seems to be really on the edge on FLASH size. 

Compiling NAZE target without SONAR saves 1112 bytes of FLASH. 

With sonar: 
   text	   data	    bss	    dec	    hex	filename
 127628	   1252	  14536	 143416	  23038	./obj/main/betaflight_NAZE.elf

Without SONAR:
   text	   data	    bss	    dec	    hex	filename
 126516	   1196	  14436	 142148	  22b44	./obj/main/betaflight_NAZE.elf
