### PR TITLE
Change baro detect order

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -460,7 +460,14 @@ static void detectBaro(baroSensor_e baroHardwareToUse)
     switch (baroHardware) {
         case BARO_DEFAULT:
             ; // fallthough
-
+        case BARO_BMP085:
+#ifdef USE_BARO_BMP085
+            if (bmp085Detect(bmp085Config, &baro)) {
+                baroHardware = BARO_BMP085;
+                break;
+            }
+#endif
+            ; // fallthough
         case BARO_MS5611:
 #ifdef USE_BARO_MS5611
             if (ms5611Detect(&baro)) {
@@ -469,14 +476,6 @@ static void detectBaro(baroSensor_e baroHardwareToUse)
             }
 #endif
             ; // fallthough
-        case BARO_BMP085:
-#ifdef USE_BARO_BMP085
-            if (bmp085Detect(bmp085Config, &baro)) {
-                baroHardware = BARO_BMP085;
-                break;
-            }
-#endif
-        ; // fallthough
         case BARO_BMP280:
 #ifdef USE_BARO_BMP280
             if (bmp280Detect(&baro)) {
@@ -484,6 +483,7 @@ static void detectBaro(baroSensor_e baroHardwareToUse)
                 break;
             }
 #endif
+            ; // fallthough
         case BARO_NONE:
             baroHardware = BARO_NONE;
             break;


### PR DESCRIPTION
Probe BMP085/BMP180 before MS5611, because BMP085 can be misdetected as a MS5611.
should fix https://github.com/betaflight/betaflight/issues/1098