### PR TITLE
Made AIRMODE and 3D override 'auto_disarm_delay', to make it consistent with handling of MOTOR_STOP.

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -572,6 +572,8 @@ void processRx(void)
     if (ARMING_FLAG(ARMED)
         && feature(FEATURE_MOTOR_STOP)
         && !STATE(FIXED_WING)
+		&& !feature(FEATURE_3D)
+		&& !isAirmodeActive()
     ) {
         if (isUsingSticksForArming()) {
             if (throttleStatus == THROTTLE_LOW) {


### PR DESCRIPTION
Fixes #1096.