### PR TITLE
Motor Outputs back again / only PWM8 and PWM9 for Servo Output

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.c
+++ b/src/main/target/SPRACINGF3EVO/target.c
@@ -30,8 +30,8 @@ const uint16_t multiPPM[] = {
     PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM9  | (MAP_TO_SERVO_OUTPUT << 8),
     PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
     0xFFFF
@@ -44,8 +44,8 @@ const uint16_t multiPWM[] = {
     PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM9  | (MAP_TO_SERVO_OUTPUT << 8),
     PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
     0xFFFF

--- a/src/main/target/SPRACINGF3EVO/target.c
+++ b/src/main/target/SPRACINGF3EVO/target.c
@@ -30,10 +30,10 @@ const uint16_t multiPPM[] = {
     PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM8  | (MAP_TO_SERVO_OUTPUT << 8),
-    PWM9  | (MAP_TO_SERVO_OUTPUT << 8),
-    PWM10 | (MAP_TO_SERVO_OUTPUT << 8),
-    PWM11 | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
     0xFFFF
 };
 
@@ -44,10 +44,10 @@ const uint16_t multiPWM[] = {
     PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM8  | (MAP_TO_SERVO_OUTPUT << 8),
-    PWM9  | (MAP_TO_SERVO_OUTPUT << 8),
-    PWM10 | (MAP_TO_SERVO_OUTPUT << 8),
-    PWM11 | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
     0xFFFF
 };
 


### PR DESCRIPTION
* redo latest commit #1092 
* motor 1 and 2 not working correct ... begin rotate only at mid throttle and above
* esc 1 and 2 learning incorrect throttle travel

**_imho very urgent!!!_**

EDIT:
I see this at cleanflight ... mapped only pwm8 / pwm9 to Servo outpus