### PR TITLE
include the make arm_sdk_install target, for easy building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ startup_stm32f10x_md_gcc.s
 docs/Manual.pdf
 README.pdf
 
+# artifacts of top-level Makefile
+/downloads
+/tools
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,10 @@ addons:
 language: cpp
 compiler: clang
 
-before_install:
-    - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2" | tar xfj -
-
 install:
-  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_4-2016q2/bin
+  - make arm_sdk_install
 
-before_script: arm-none-eabi-gcc --version
+before_script: tools/gcc-arm-none-*/bin/arm-none-eabi-gcc --version
 script: ./.travis.sh
 
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ compiler: clang
 install:
   - make arm_sdk_install
 
-before_script: tools/gcc-arm-none-*/bin/arm-none-eabi-gcc --version
+before_script: tools/gcc-arm-none-eabi-5_4-2016q2/bin/arm-none-eabi-gcc --version
 script: ./.travis.sh
 
 cache: apt

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,23 @@ INCLUDE_DIRS    = $(SRC_DIR) \
                   $(ROOT)/src/main/target
 LINKER_DIR      = $(ROOT)/src/main/target
 
+## Build tools, so we all share the same versions
+# import macros common to all supported build systems
+include $(ROOT)/make/system-id.mk
+
+# configure some directories that are relative to wherever ROOT_DIR is located
+TOOLS_DIR := $(ROOT)/tools
+BUILD_DIR := $(ROOT)/build
+DL_DIR := $(ROOT)/downloads
+
+export RM := rm
+
+# import macros that are OS specific
+include $(ROOT)/make/$(OSFAMILY).mk
+
+# include the tools makefile
+include $(ROOT)/make/tools.mk
+
 # default xtal value for F4 targets
 HSE_VALUE       = 8000000
 
@@ -572,9 +589,10 @@ CCACHE :=
 endif
 
 # Tool names
-CC          := $(CCACHE) arm-none-eabi-gcc
-OBJCOPY     := arm-none-eabi-objcopy
-SIZE        := arm-none-eabi-size
+CC          := $(CCACHE) $(ARM_SDK_DIR)/bin/arm-none-eabi-gcc
+CPP         := $(CCACHE) $(ARM_SDK_DIR)/bin/arm-none-eabi-g++
+OBJCOPY     := $(ARM_SDK_DIR)/bin/arm-none-eabi-objcopy
+SIZE        := $(ARM_SDK_DIR)/bin/arm-none-eabi-size
 
 #
 # Tool options.
@@ -759,6 +777,16 @@ cppcheck: $(CSOURCES)
 
 cppcheck-result.xml: $(CSOURCES)
 	$(V0) $(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
+
+## mkdirs
+$(DL_DIR):
+	mkdir -p $@
+
+$(TOOLS_DIR):
+	mkdir -p $@
+
+$(BUILD_DIR):
+	mkdir -p $@
 
 ## help              : print this help message and exit
 help: Makefile

--- a/make/linux.mk
+++ b/make/linux.mk
@@ -1,0 +1,35 @@
+# linux.mk
+#
+# Goals:
+#   Configure an environment that will allow Taulabs GCS and firmware to be built
+#   on a Linux system. The environment will support the current versions of Qt SDK
+#   and the ARM toolchain installed to either the Taulabs/tools directory, their
+#   respective default installation locations, or made available on the system path.
+
+# Check for and find Python 2
+
+# Get Python version, separate major/minor/patch, then put into wordlist
+PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
+# Get major version from aforementioned list
+PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))
+# Just in case Make has some weird scope stuff
+PYTHON=0
+# If the major Python version is the one we want..
+ifeq ($(PYTHON_MAJOR_VERSION_),2)
+	# Then we can just use the normal Python executable
+	PYTHON:=python
+else
+	# However, this isn't always the case..
+	# Let's look for `python2`. If `which` doesn't return a null value, then
+	#  it exists!
+	ifneq ($(shell which python2), "")
+		PYTHON:=python2
+	else
+		# And if it doesn't exist, let's use the default Python, and warn the user.
+		# PYTHON NOT FOUND.
+		PYTHON:=python
+		echo "Python not found."
+	endif
+endif
+
+export PYTHON

--- a/make/macosx.mk
+++ b/make/macosx.mk
@@ -1,0 +1,35 @@
+# macosx.mk
+#
+# Goals:
+#   Configure an environment that will allow Taulabs GCS and firmware to be built
+#   on a Mac OSX system. The environment will support the current version of the
+#   ARM toolchain installed to either their respective default installation
+#   locations, the tools directory or made available on the system path.
+
+# Check for and find Python 2
+
+# Get Python version, separate major/minor/patch, then put into wordlist
+PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
+# Get major version from aforementioned list
+PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))
+# Just in case Make has some weird scope stuff
+PYTHON=0
+# If the major Python version is the one we want..
+ifeq ($(PYTHON_MAJOR_VERSION_),2)
+	# Then we can just use the normal Python executable
+	PYTHON:=python
+else
+	# However, this isn't always the case..
+	# Let's look for `python2`. If `which` doesn't return a null value, then
+	#  it exists!
+	ifneq ($(shell which python2), "")
+		PYTHON:=python2
+	else
+		# And if it doesn't exist, let's use the default Python, and warn the user.
+		# PYTHON NOT FOUND.
+		PYTHON:=python
+		echo "Python not found."
+	endif
+endif
+
+export PYTHON

--- a/make/system-id.mk
+++ b/make/system-id.mk
@@ -1,0 +1,50 @@
+# shared.mk
+#
+# environment variables common to all operating systems supported by the make system
+
+# Make sure we know a few things about the architecture
+UNAME := $(shell uname)
+ARCH := $(shell uname -m)
+ifneq (,$(filter $(ARCH), x86_64 amd64))
+  X86-64 := 1
+  X86_64 := 1
+  AMD64 := 1
+  ARCHFAMILY := x86_64
+else
+  ARCHFAMILY := $(ARCH)
+endif
+
+# configure some variables dependent upon what type of system this is
+
+# Linux
+ifeq ($(UNAME), Linux)
+  OSFAMILY := linux
+  LINUX := 1
+endif
+
+# Mac OSX
+ifeq ($(UNAME), Darwin)
+  OSFAMILY := macosx
+  MACOSX := 1
+endif
+
+# Windows using MinGW shell
+ifeq (MINGW, $(findstring MINGW,$(UNAME)))
+  OSFAMILY := windows
+  MINGW := 1
+  WINDOWS := 1
+endif
+
+# Windows using Cygwin shell
+ifeq (CYGWIN ,$(findstring CYGWIN,$(UNAME)))
+  OSFAMILY := windows
+  WINDOWS := 1
+  CYGWIN := 1
+endif
+
+# report an error if we couldn't work out what OS this is running on
+ifndef OSFAMILY
+  $(info uname reports $(UNAME))
+  $(info uname -m reports $(ARCH))
+  $(error failed to detect operating system)
+endif

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -1,0 +1,330 @@
+###############################################################
+#
+# Installers for tools
+#
+# NOTE: These are not tied to the default goals
+#       and must be invoked manually
+#
+###############################################################
+
+##############################
+#
+# Check that environmental variables are sane
+#
+##############################
+
+# Set up ARM (STM32) SDK
+ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-5_4-2016q2
+
+.PHONY: arm_sdk_install
+
+# source: https://launchpad.net/gcc-arm-embedded/5.0/
+ifdef LINUX
+  arm_sdk_install: ARM_SDK_URL  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2
+endif
+
+ifdef MACOSX
+  arm_sdk_install: ARM_SDK_URL  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-mac.tar.bz2
+endif
+
+ifdef WINDOWS
+  arm_sdk_install: ARM_SDK_URL  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-win32.zip
+endif
+
+arm_sdk_install: ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
+# order-only prereq on directory existance:
+arm_sdk_install: | $(DL_DIR) $(TOOLS_DIR)
+arm_sdk_install: arm_sdk_clean
+ifneq ($(OSFAMILY), windows)
+        # download the source only if it's newer than what we already have
+	$(V1) wget --no-check-certificate -N -P "$(DL_DIR)" "$(ARM_SDK_URL)"
+
+        # binary only release so just extract it
+	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
+else
+	$(V1) curl -L -k -o "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
+	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
+endif
+
+.PHONY: arm_sdk_clean
+arm_sdk_clean:
+	$(V1) [ ! -d "$(ARM_SDK_DIR)" ] || $(RM) -r $(ARM_SDK_DIR)
+
+.PHONY: openocd_win_install
+
+openocd_win_install: | $(DL_DIR) $(TOOLS_DIR)
+openocd_win_install: OPENOCD_URL  := git://git.code.sf.net/p/openocd/code
+openocd_win_install: OPENOCD_REV  := cf1418e9a85013bbf8dbcc2d2e9985695993d9f4
+openocd_win_install: OPENOCD_OPTIONS :=
+
+ifeq ($(OPENOCD_FTDI), yes)
+openocd_win_install: OPENOCD_OPTIONS := $(OPENOCD_OPTIONS) --enable-ft2232_ftd2xx --with-ftd2xx-win32-zipdir=$(FTD2XX_DIR)
+endif
+
+openocd_win_install: openocd_win_clean libusb_win_install ftd2xx_install
+        # download the source
+	$(V0) @echo " DOWNLOAD     $(OPENOCD_URL) @ $(OPENOCD_REV)"
+	$(V1) [ ! -d "$(OPENOCD_BUILD_DIR)" ] || $(RM) -rf "$(OPENOCD_BUILD_DIR)"
+	$(V1) mkdir -p "$(OPENOCD_BUILD_DIR)"
+	$(V1) git clone --no-checkout $(OPENOCD_URL) "$(DL_DIR)/openocd-build"
+	$(V1) ( \
+	  cd $(OPENOCD_BUILD_DIR) ; \
+	  git checkout -q $(OPENOCD_REV) ; \
+	)
+
+        # apply patches
+	$(V0) @echo " PATCH        $(OPENOCD_BUILD_DIR)"
+	$(V1) ( \
+	  cd $(OPENOCD_BUILD_DIR) ; \
+	  git apply < $(ROOT_DIR)/flight/Project/OpenOCD/0003-freertos-cm4f-fpu-support.patch ; \
+	  git apply < $(ROOT_DIR)/flight/Project/OpenOCD/0004-st-icdi-disable.patch ; \
+	)
+
+        # build and install
+	$(V0) @echo " BUILD        $(OPENOCD_WIN_DIR)"
+	$(V1) mkdir -p "$(OPENOCD_WIN_DIR)"
+	$(V1) ( \
+	  cd $(OPENOCD_BUILD_DIR) ; \
+	  ./bootstrap ; \
+	  ./configure --enable-maintainer-mode --prefix="$(OPENOCD_WIN_DIR)" \
+		--build=i686-pc-linux-gnu --host=i586-mingw32msvc \
+		CPPFLAGS=-I$(LIBUSB_WIN_DIR)/include \
+		LDFLAGS=-L$(LIBUSB_WIN_DIR)/lib/gcc \
+		$(OPENOCD_OPTIONS) \
+		--disable-werror \
+		--enable-stlink ; \
+	  $(MAKE) ; \
+	  $(MAKE) install ; \
+	)
+
+        # delete the extracted source when we're done
+	$(V1) [ ! -d "$(OPENOCD_BUILD_DIR)" ] || $(RM) -rf "$(OPENOCD_BUILD_DIR)"
+
+.PHONY: openocd_win_clean
+openocd_win_clean:
+	$(V0) @echo " CLEAN        $(OPENOCD_WIN_DIR)"
+	$(V1) [ ! -d "$(OPENOCD_WIN_DIR)" ] || $(RM) -r "$(OPENOCD_WIN_DIR)"
+
+# Set up openocd tools
+OPENOCD_DIR       := $(TOOLS_DIR)/openocd
+OPENOCD_WIN_DIR   := $(TOOLS_DIR)/openocd_win
+OPENOCD_BUILD_DIR := $(DL_DIR)/openocd-build
+
+.PHONY: openocd_install
+
+openocd_install: | $(DL_DIR) $(TOOLS_DIR)
+openocd_install: OPENOCD_URL     := git://git.code.sf.net/p/openocd/code
+openocd_install: OPENOCD_TAG     := v0.9.0
+openocd_install: OPENOCD_OPTIONS := --enable-maintainer-mode --prefix="$(OPENOCD_DIR)" --enable-buspirate --enable-stlink
+
+ifeq ($(OPENOCD_FTDI), yes)
+openocd_install: OPENOCD_OPTIONS := $(OPENOCD_OPTIONS) --enable-ftdi
+endif
+
+ifeq ($(UNAME), Darwin)
+openocd_install: OPENOCD_OPTIONS := $(OPENOCD_OPTIONS) --disable-option-checking
+endif
+
+openocd_install: openocd_clean
+        # download the source
+	$(V0) @echo " DOWNLOAD     $(OPENOCD_URL) @ $(OPENOCD_TAG)"
+	$(V1) [ ! -d "$(OPENOCD_BUILD_DIR)" ] || $(RM) -rf "$(OPENOCD_BUILD_DIR)"
+	$(V1) mkdir -p "$(OPENOCD_BUILD_DIR)"
+	$(V1) git clone --no-checkout $(OPENOCD_URL) "$(OPENOCD_BUILD_DIR)"
+	$(V1) ( \
+	  cd $(OPENOCD_BUILD_DIR) ; \
+	  git checkout -q tags/$(OPENOCD_TAG) ; \
+	)
+
+        # build and install
+	$(V0) @echo " BUILD        $(OPENOCD_DIR)"
+	$(V1) mkdir -p "$(OPENOCD_DIR)"
+	$(V1) ( \
+	  cd $(OPENOCD_BUILD_DIR) ; \
+	  ./bootstrap ; \
+	  ./configure  $(OPENOCD_OPTIONS) ; \
+	  $(MAKE) ; \
+	  $(MAKE) install ; \
+	)
+
+        # delete the extracted source when we're done
+	$(V1) [ ! -d "$(OPENOCD_BUILD_DIR)" ] || $(RM) -rf "$(OPENOCD_BUILD_DIR)"
+
+.PHONY: openocd_clean
+openocd_clean:
+	$(V0) @echo " CLEAN        $(OPENOCD_DIR)"
+	$(V1) [ ! -d "$(OPENOCD_DIR)" ] || $(RM) -r "$(OPENOCD_DIR)"
+
+STM32FLASH_DIR := $(TOOLS_DIR)/stm32flash
+
+.PHONY: stm32flash_install
+stm32flash_install: STM32FLASH_URL := http://stm32flash.googlecode.com/svn/trunk
+stm32flash_install: STM32FLASH_REV := 61
+stm32flash_install: stm32flash_clean
+        # download the source
+	$(V0) @echo " DOWNLOAD     $(STM32FLASH_URL) @ r$(STM32FLASH_REV)"
+	$(V1) svn export -q -r "$(STM32FLASH_REV)" "$(STM32FLASH_URL)" "$(STM32FLASH_DIR)"
+
+        # build
+	$(V0) @echo " BUILD        $(STM32FLASH_DIR)"
+	$(V1) $(MAKE) --silent -C $(STM32FLASH_DIR) all
+
+.PHONY: stm32flash_clean
+stm32flash_clean:
+	$(V0) @echo " CLEAN        $(STM32FLASH_DIR)"
+	$(V1) [ ! -d "$(STM32FLASH_DIR)" ] || $(RM) -r "$(STM32FLASH_DIR)"
+
+DFUUTIL_DIR := $(TOOLS_DIR)/dfu-util
+
+.PHONY: dfuutil_install
+dfuutil_install: DFUUTIL_URL  := http://dfu-util.sourceforge.net/releases/dfu-util-0.8.tar.gz
+dfuutil_install: DFUUTIL_FILE := $(notdir $(DFUUTIL_URL))
+dfuutil_install: | $(DL_DIR) $(TOOLS_DIR)
+dfuutil_install: dfuutil_clean
+        # download the source
+	$(V0) @echo " DOWNLOAD     $(DFUUTIL_URL)"
+	$(V1) wget -N -P "$(DL_DIR)" "$(DFUUTIL_URL)"
+
+        # extract the source
+	$(V0) @echo " EXTRACT      $(DFUUTIL_FILE)"
+	$(V1) [ ! -d "$(DL_DIR)/dfuutil-build" ] || $(RM) -r "$(DL_DIR)/dfuutil-build"
+	$(V1) mkdir -p "$(DL_DIR)/dfuutil-build"
+	$(V1) tar -C $(DL_DIR)/dfuutil-build -xf "$(DL_DIR)/$(DFUUTIL_FILE)"
+
+        # build
+	$(V0) @echo " BUILD        $(DFUUTIL_DIR)"
+	$(V1) mkdir -p "$(DFUUTIL_DIR)"
+	$(V1) ( \
+	  cd $(DL_DIR)/dfuutil-build/dfu-util-0.8 ; \
+	  ./configure --prefix="$(DFUUTIL_DIR)" ; \
+	  $(MAKE) ; \
+	  $(MAKE) install ; \
+	)
+
+.PHONY: dfuutil_clean
+dfuutil_clean:
+	$(V0) @echo " CLEAN        $(DFUUTIL_DIR)"
+	$(V1) [ ! -d "$(DFUUTIL_DIR)" ] || $(RM) -r "$(DFUUTIL_DIR)"
+
+# Set up uncrustify tools
+UNCRUSTIFY_DIR := $(TOOLS_DIR)/uncrustify-0.61
+UNCRUSTIFY_BUILD_DIR := $(DL_DIR)/uncrustify
+
+.PHONY: uncrustify_install
+uncrustify_install: | $(DL_DIR) $(TOOLS_DIR)
+uncrustify_install: UNCRUSTIFY_URL := http://downloads.sourceforge.net/project/uncrustify/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz
+uncrustify_install: UNCRUSTIFY_FILE := uncrustify-0.61.tar.gz
+uncrustify_install: UNCRUSTIFY_OPTIONS := prefix=$(UNCRUSTIFY_DIR)
+uncrustify_install: uncrustify_clean
+ifneq ($(OSFAMILY), windows)
+	$(V0) @echo " DOWNLOAD     $(UNCRUSTIFY_URL)"
+	$(V1) wget --no-check-certificate -N -P "$(DL_DIR)" "$(UNCRUSTIFY_URL)"
+else
+	$(V1) curl -L -k -o "$(DL_DIR)/$(UNCRUSTIFY_FILE)" "$(UNCRUSTIFY_URL)"
+endif
+        # extract the src
+	$(V0) @echo " EXTRACT      $(UNCRUSTIFY_FILE)"
+	$(V1) tar -C $(TOOLS_DIR) -xf "$(DL_DIR)/$(UNCRUSTIFY_FILE)"
+
+	$(V0) @echo " BUILD        $(UNCRUSTIFY_DIR)"
+	$(V1) ( \
+	  cd $(UNCRUSTIFY_DIR) ; \
+	  ./configure --prefix="$(UNCRUSTIFY_DIR)" ; \
+	  $(MAKE) ; \
+	  $(MAKE) install ; \
+	)
+	      # delete the extracted source when we're done
+	$(V1) [ ! -d "$(UNCRUSTIFY_BUILD_DIR)" ] || $(RM) -r "$(UNCRUSTIFY_BUILD_DIR)"
+
+.PHONY: uncrustify_clean
+uncrustify_clean:
+	$(V0) @echo " CLEAN        $(UNCRUSTIFY_DIR)"
+	$(V1) [ ! -d "$(UNCRUSTIFY_DIR)" ] || $(RM) -r "$(UNCRUSTIFY_DIR)"
+	$(V0) @echo " CLEAN        $(UNCRUSTIFY_BUILD_DIR)"
+	$(V1) [ ! -d "$(UNCRUSTIFY_BUILD_DIR)" ] || $(RM) -r "$(UNCRUSTIFY_BUILD_DIR)"
+
+# ZIP download URL
+zip_install: ZIP_URL  := http://pkgs.fedoraproject.org/repo/pkgs/zip/zip30.tar.gz/7b74551e63f8ee6aab6fbc86676c0d37/zip30.tar.gz
+
+zip_install: ZIP_FILE := $(notdir $(ZIP_URL))
+
+ZIP_DIR = $(TOOLS_DIR)/zip30
+
+# order-only prereq on directory existance:
+zip_install : | $(DL_DIR) $(TOOLS_DIR)
+zip_install: zip_clean
+	$(V1) curl -L -k -o "$(DL_DIR)/$(ZIP_FILE)" "$(ZIP_URL)"
+	$(V1) tar --force-local -C $(TOOLS_DIR) -xzf "$(DL_DIR)/$(ZIP_FILE)"
+ifneq ($(OSFAMILY), windows)
+	$(V1) cd "$(ZIP_DIR)" && $(MAKE) -f unix/Makefile generic_gcc
+else
+	$(V1) cd "$(ZIP_DIR)" && $(MAKE) -f win32/makefile.gcc
+endif
+
+.PHONY: zip_clean
+zip_clean:
+	$(V1) [ ! -d "$(ZIP_DIR)" ] || $(RM) -rf $(ZIP_DIR)
+
+##############################
+#
+# Set up paths to tools
+#
+##############################
+
+ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
+  ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
+else
+  ifndef IGNORE_MISSING_TOOLCHAIN
+    ifeq (,$(findstring _install,$(MAKECMDGOALS)))
+      $(error **WARNING** ARM-SDK not in $(ARM_SDK_DIR)  Please run 'make arm_sdk_install')
+    endif
+  endif
+  # not installed, hope it's in the path...
+  ARM_SDK_PREFIX ?= arm-none-eabi-
+endif
+
+ifeq ($(shell [ -d "$(ZIP_DIR)" ] && echo "exists"), exists)
+  export ZIPBIN := $(ZIP_DIR)/zip
+else
+  export ZIPBIN := zip
+endif
+
+ifeq ($(shell [ -d "$(OPENOCD_DIR)" ] && echo "exists"), exists)
+  OPENOCD := $(OPENOCD_DIR)/bin/openocd
+else
+  # not installed, hope it's in the path...
+  OPENOCD ?= openocd
+endif
+
+ifeq ($(shell [ -d "$(UNCRUSTIFY_DIR)" ] && echo "exists"), exists)
+  UNCRUSTIFY := $(UNCRUSTIFY_DIR)/bin/uncrustify
+else
+  # not installed, hope it's in the path...
+  UNCRUSTIFY ?= uncrustify
+endif
+
+# Google Breakpad
+DUMP_SYMBOLS_TOOL := $(TOOLS_DIR)/breakpad/$(OSFAMILY)-$(ARCHFAMILY)/dump_syms
+BREAKPAD_URL := http://dronin.tracer.nz/tools/breakpad.zip
+BREAKPAD_DL_FILE := $(DL_DIR)/$(notdir $(BREAKPAD_URL))
+BREAKPAD_DIR := $(TOOLS_DIR)/breakpad
+
+.PHONY: breakpad_install
+breakpad_install: | $(DL_DIR) $(TOOLS_DIR)
+breakpad_install: breakpad_clean
+	$(V0) @echo " DOWNLOAD     $(BREAKPAD_URL)"
+	$(V1) $(V1) curl -L -k -z "$(BREAKPAD_DL_FILE)" -o "$(BREAKPAD_DL_FILE)" "$(BREAKPAD_URL)"
+	$(V0) @echo " EXTRACT      $(notdir $(BREAKPAD_DL_FILE))"
+	$(V1) mkdir -p "$(BREAKPAD_DIR)"
+	$(V1) unzip -q -d $(BREAKPAD_DIR) "$(BREAKPAD_DL_FILE)"
+ifeq ($(OSFAMILY), windows)
+	$(V1) ln -s "$(TOOLS_DIR)/breakpad/$(OSFAMILY)-i686" "$(TOOLS_DIR)/breakpad/$(OSFAMILY)-x86_64"
+endif
+
+.PHONY: breakpad_clean
+breakpad_clean:
+	$(V0) @echo " CLEAN        $(BREAKPAD_DIR)"
+	$(V1) [ ! -d "$(BREAKPAD_DIR)" ] || $(RM) -rf $(BREAKPAD_DIR)
+	$(V0) @echo " CLEAN        $(BREAKPAD_DL_FILE)"
+	$(V1) $(RM) -f $(BREAKPAD_DL_FILE)
+

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -1,0 +1,14 @@
+# windows.mk
+#
+# Goals:
+#   Configure an environment that will allow Taulabs GCS and firmware to be built
+#   on a Windows system. The environment will support the current version of the
+#   ARM toolchain installed to either their respective default installation
+#   locations, the tools directory or made available on the system path.
+#
+# Requirements:
+#   msysGit
+#   Python
+
+PYTHON := python
+export PYTHON


### PR DESCRIPTION
this adds the `make arm_sdk_install` target, required to build, which installs the latest version the gcc arm cross compiler for all platforms (linux, mac, windows)

the idea behind this is twofold:

- make it easier for anyone to compile a binary. the setup instructions will always be the same, basically just download a copy of the repo (or git clone), open a terminal (install cygwin if using windows), `cd` into the downloaded directory, and run:

```
make arm_sdk_install
make NAZE
```
or whatever target one wishes to compile, and open the `obj` folder to find the hex file when done.

- the other benefit is that we can manage the gcc version in once place, to make sure we're all compiling to the same binaries with the same gcc version :)

as for the code, it's basically just from: https://github.com/d-ronin/dRonin