### PR TITLE
Sparky 2 beeper correction. Tested and working.

### DIFF
--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -30,6 +30,8 @@
 #define LED2                    PB6
 
 #define BEEPER                  PC9
+#define BEEPER_INVERTED
+
 
 #define INVERTER                PC6
 #define INVERTER_USART          USART6


### PR DESCRIPTION
Beeper on sparky 2 is triggered by a N-Channel mosfet, so it should be Push-Pull and inverted. #define BEEPER_INVERTED was missing.