### PR TITLE
Serial Blackbox Baudrates suitable for OpenLager; throttling

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -85,7 +85,7 @@ const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
 
 static uint8_t serialPortCount;
 
-const uint32_t baudRates[] = {0, 9600, 19200, 38400, 57600, 115200, 230400, 250000}; // see baudRate_e
+const uint32_t baudRates[] = {0, 9600, 19200, 38400, 57600, 115200, 230400, 250000, 1500000, 2000000, 2470000}; // see baudRate_e
 
 #define BAUD_RATE_COUNT (sizeof(baudRates) / sizeof(baudRates[0]))
 

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -46,6 +46,9 @@ typedef enum {
     BAUD_115200,
     BAUD_230400,
     BAUD_250000,
+    BAUD_1500000,
+    BAUD_2000000,
+    BAUD_2470000
 } baudRate_e;
 
 extern const uint32_t baudRates[];

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1302,7 +1302,7 @@ static void cliSerial(char *cmdline)
                 portConfig.telemetry_baudrateIndex = baudRateIndex;
                 break;
             case 3:
-                if (baudRateIndex < BAUD_19200 || baudRateIndex > BAUD_250000) {
+                if (baudRateIndex < BAUD_19200 || baudRateIndex > BAUD_2470000) {
                     continue;
                 }
                 portConfig.blackbox_baudrateIndex = baudRateIndex;


### PR DESCRIPTION
Hi there!

I've been trying to use my OpenLager ![OpenLager](https://cloud.githubusercontent.com/assets/90903/16476344/5b94a7d4-3e3b-11e6-870b-53d76c161a85.png) (https://github.com/d-ronin/openlager) with Betaflight 3.0-RC13 to acquire high frequency (non-sampled) blackbox logging, unfortunately it seems to be limiting itself to around 197,000bps.

I noticed that the serial port for blackbox itself is limited to 250,000bps, compared to the 2.47mbps we have in dRonin. I also saw that there is some throttling constraint based on latency when writing to OpenLog (thankfully no longer/less applicable to OpenLager, with the F4's 125KB buffer) - so uncorked the throttle there, when the user has selected the new serial baudrates: 1.5mbps, 2mbps, 2.47mbps.

I have a matching configurator branch here: https://github.com/fujin/betaflight-configurator/tree/baudrates-suitable-for-openlager which I'll also PR, pending feedback here.

So far I have bench tested that the config sticks on REVO. It seems to at least accept the baudrates :joy:. The next steps will of course be arming and actually blackboxing at high frequency, but I'm giving up for tonight. I loaned out my last spare openlager and don't have one in this new REVO rig.

Ultimately Betaflight may end up requiring DMA for the UART transmission (_of which I have no idea how to help with_) to sustain logging operations at these baudrates, I'm not yet sure what the CPU cost will be.. Please exercise caution while testing, observe yer' looptime stability, and so-forth.
- [ ] consider other, slightly less obscene baudrates. 0.5mbps? may reduce cpu% cost.
- [ ] test board arming still works with 1.5mbps/2mbps/2.47mbps baudrates
- [ ] test blackboxing can still be enabled
- [ ] test blackboxing can log at 1.5mbps/2mbps/2.47mbps baudrates ideally at 100% rates
- [ ] do radical 8khz logged flying :rocket:
- [ ] test other weird hardware? regression test openlog?

Would welcome any feedback - I have not worked in any *flight codebase before. Thanks in advance for your consideration. Feel free to edit the check-list above too. Cheers! :boom:
