### PR TITLE
AlienFlight F3 Buzzer on motor 6

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -573,7 +573,7 @@ void createDefaultConfig(master_t *config)
 
     config->servo_pwm_rate = 50;
 
-#ifdef CC3D
+#ifdef BUZZERM6
     config->use_buzzer_p6 = 0;
 #endif
 

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -44,7 +44,7 @@ typedef struct master_t {
     gimbalConfig_t gimbalConfig;
 #endif
 
-#ifdef CC3D
+#ifdef BUZZERM6
     uint8_t use_buzzer_p6;
 #endif
 

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -71,7 +71,7 @@ const uint16_t * const hardwareMaps[] = {
     airPPM,
 };
 
-#ifdef CC3D
+#ifdef BUZZERM6
 const uint16_t * const hardwareMapsBP6[] = {
     multiPWM_BP6,
     multiPPM_BP6,
@@ -104,7 +104,7 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
     if (init->usePPM || init->useSerialRx)
         i++; // next index is for PPM
 
-#ifdef CC3D
+#ifdef BUZZERM6
     setup = init->useBuzzerP6 ? hardwareMapsBP6[i] : hardwareMaps[i];
 #else
     setup = hardwareMaps[i];

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -60,7 +60,7 @@ typedef struct drv_pwm_config_s {
     uint16_t servoPwmRate;
     uint16_t servoCenterPulse;
 #endif
-#ifdef CC3D
+#ifdef BUZZERM6
     bool useBuzzerP6;
 #endif
     bool airplane;       // fixed wing hardware config, lots of servos etc
@@ -130,7 +130,7 @@ extern const uint16_t multiPWM[];
 extern const uint16_t airPPM[];
 extern const uint16_t airPWM[];
 
-#ifdef CC3D
+#ifdef BUZZERM6
 extern const uint16_t multiPPM_BP6[];
 extern const uint16_t multiPWM_BP6[];
 extern const uint16_t airPPM_BP6[];

--- a/src/main/drivers/sound_beeper.h
+++ b/src/main/drivers/sound_beeper.h
@@ -29,6 +29,14 @@
 #define BEEP_ON     do {} while(0)
 #endif
 
+#ifdef BUZZERM6
+typedef enum {
+    OFF = 0,
+    ON,
+    INVERTED
+} buzzerP6mode_t;
+#endif
+
 typedef struct beeperConfig_s {
     ioTag_t ioTag;
     unsigned isInverted : 1;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -522,6 +522,12 @@ static const char * const lookupTableFailsafe[] = {
     "AUTO-LAND", "DROP"
 };
 
+#ifdef BUZZERM6
+static const char * const lookupTableBuzzerP6[] = {
+    "OFF", "ON", "INVERTED"
+};
+#endif
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -564,6 +570,9 @@ typedef enum {
 #ifdef OSD
     TABLE_OSD,
 #endif
+#ifdef BUZZERM6
+    TABLE_BUZZER_P6,
+#endif
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -602,6 +611,9 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableFailsafe, sizeof(lookupTableFailsafe) / sizeof(char *) },
 #ifdef OSD
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
+#endif
+#ifdef BUZZERM6
+    { lookupTableBuzzerP6, sizeof(lookupTableBuzzerP6) / sizeof(char *) },
 #endif
 };
 
@@ -677,8 +689,8 @@ const clivalue_t valueTable[] = {
     { "3d_neutral",                 VAR_UINT16 | MASTER_VALUE,  &masterConfig.flight3DConfig.neutral3d, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX } },
     { "3d_deadband_throttle",       VAR_UINT16 | MASTER_VALUE,  &masterConfig.flight3DConfig.deadband3d_throttle, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX } },
 
-#ifdef CC3D
-    { "enable_buzzer_p6",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.use_buzzer_p6, .config.lookup = { TABLE_OFF_ON } },
+#ifdef BUZZERM6
+    { "enable_buzzer_p6",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.use_buzzer_p6, .config.lookup = { TABLE_BUZZER_P6 } },
 #endif
     { "use_unsynced_pwm",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.use_unsyncedPwm, .config.lookup = { TABLE_OFF_ON } },
     { "motor_pwm_protocol",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.motor_pwm_protocol, .config.lookup = { TABLE_MOTOR_PWM_PROTOCOL } },

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -302,7 +302,7 @@ void init(void)
         featureClear(FEATURE_3D);
         pwm_params.idlePulse = 0; // brushed motors
     }
-#ifdef CC3D
+#ifdef BUZZERM6
     pwm_params.useBuzzerP6 = masterConfig.use_buzzer_p6 ? true : false;
 #endif
 #ifndef SKIP_RX_PWM_PPM
@@ -340,9 +340,17 @@ void init(void)
         beeperConfig.ioTag = IO_TAG(BEEPER_OPT);
     }
 #endif
-#ifdef CC3D
-    if (masterConfig.use_buzzer_p6 == 1)
+#ifdef BUZZERM6
+    if (masterConfig.use_buzzer_p6) {
         beeperConfig.ioTag = IO_TAG(BEEPER_OPT);
+        if (masterConfig.use_buzzer_p6 == INVERTED) {
+            beeperConfig.isOD = false;
+            beeperConfig.isInverted = true;
+        } else {
+            beeperConfig.isOD = true;
+            beeperConfig.isInverted = false;
+        }
+    }
 #endif
 
     beeperInit(&beeperConfig);

--- a/src/main/target/ALIENFLIGHTF3/target.c
+++ b/src/main/target/ALIENFLIGHTF3/target.c
@@ -61,6 +61,44 @@ const uint16_t airPWM[] = {
     0xFFFF
 };
 
+const uint16_t multiPPM_BP6[] = {
+    PWM11 | (MAP_TO_PPM_INPUT << 8), // PPM input
+
+    PWM1  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM15
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM15
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM1
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM3
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM3
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM3
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM17
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM3
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),  // TIM2
+    0xFFFF
+};
+
+const uint16_t multiPWM_BP6[] = {
+    PWM1  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM_BP6[] = {
+    // TODO
+    0xFFFF
+};
+
+const uint16_t airPWM_BP6[] = {
+    // TODO
+    0xFFFF
+};
+
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     // up to 10 Motor Outputs

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -34,6 +34,8 @@
 #define LED1_A                  PB9
 
 #define BEEPER                  PA5
+#define BEEPER_OPT              PA2
+#define BUZZERM6
 
 #define USABLE_TIMER_CHANNEL_COUNT 11
 

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -24,6 +24,7 @@
 
 #define BEEPER                  PA15
 #define BEEPER_OPT              PA2
+#define BUZZERM6
 
 #define USE_EXTI
 #define MPU_INT_EXTI            PA3


### PR DESCRIPTION
As discussed on Gitter. Here is an proposal for the update. Will affect only the AlienFlight F3 and the CC3D target for now but can be used for any other FC with an real buzzer port. This could be an intermediate solution till we have 3.1 and can solve this problem in an better way. Since the mechanism will work on any motor port we also can rename the configuration parameter "enable_buzzer_p6" to make it more general. The same may apply to the "BUZZERM6" definition.