### PR TITLE
Add Synthetic Spektrum RSSI from fade counter

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -524,6 +524,7 @@ void createDefaultConfig(master_t *config)
     config->rxConfig.sbus_inversion = 1;
     config->rxConfig.spektrum_sat_bind = 0;
     config->rxConfig.spektrum_sat_bind_autoreset = 1;
+    config->rxConfig.spektrum_rssi_enabled = 0;
     config->rxConfig.midrc = 1500;
     config->rxConfig.mincheck = 1100;
     config->rxConfig.maxcheck = 1900;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -735,6 +735,7 @@ const clivalue_t valueTable[] = {
     { "spektrum_sat_bind",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.rxConfig.spektrum_sat_bind, .config.minmax = { SPEKTRUM_SAT_BIND_DISABLED,  SPEKTRUM_SAT_BIND_MAX} },
     { "spektrum_sat_bind_autoreset",VAR_UINT8  | MASTER_VALUE,  &masterConfig.rxConfig.spektrum_sat_bind_autoreset, .config.minmax = { 0,  1} },
 #endif
+    { "spektrum_rssi_enabled",              VAR_UINT8  | MASTER_VALUE,  &masterConfig.rxConfig.spektrum_rssi_enabled, .config.minmax = { 0,  1} },
 
 #ifdef TELEMETRY
     { "telemetry_switch",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.telemetryConfig.telemetry_switch, .config.lookup = { TABLE_OFF_ON } },

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -115,6 +115,7 @@ typedef struct rxConfig_s {
     uint8_t sbus_inversion;                 // default sbus (Futaba, FrSKY) is inverted. Support for uninverted OpenLRS (and modified FrSKY) receivers.
     uint8_t spektrum_sat_bind;              // number of bind pulses for Spektrum satellite receivers
     uint8_t spektrum_sat_bind_autoreset;    // whenever we will reset (exit) binding mode after hard reboot
+    uint8_t spektrum_rssi_enabled;          // enable forwarding of Spektrum fade count as an RSSI figure on one of the RX channels.
     uint8_t rssi_channel;
     uint8_t rssi_scale;
     uint8_t rssi_ppm_invert;

--- a/src/main/rx/spektrum.h
+++ b/src/main/rx/spektrum.h
@@ -23,4 +23,5 @@
 uint8_t spektrumFrameStatus(void);
 struct rxConfig_s;
 void spektrumBind(struct rxConfig_s *rxConfig);
+extern uint8_t spekRssiEnabled;
 


### PR DESCRIPTION
The Spektrum satellites, when in "slave" or "external"
mode, continously output a counter of lost frames.
By keeping track of how quickly this counter is incrementing,
a pseudo-RSSI can be generated.

This patch:
- Adds a calculation method for generating an RSSI figure from
  the Spektrum fade counter.
- Adds a new configuration option, spektrum_rssi_enabled, which
  takes over RC channel 9 and feeds the synthetic RSSI into it
  (on Spektrum RX's only)

Known Limitations:
- The fade counter only works with the satellite is in external mode,
   which is *not* the case when it is bound to the TX via the FC. You
   *must* bind the satellite the old-school way using another RX.
- Total signal loss freezes the RSSI figure (it will not indicate 0%)
- Spektrum RSSI is more "sensitive" than other RSSI figures due to
   the fact it is based on packet loss. What this means is that you will
   generally be flying at 100% signal, even near the boundaries of signal
   loss. Signal loss will occur quickly such that if you see anything below
   75% or so you should immediately turn back.

Testing Instructions:
- Bind a speksat using an external RC RX, not via the FC.
- Configure FC using following commands:
set spektrum_rssi_enabled = 1
set rssi_channel = 9
save
- Fly quadcopter with whatever RSSI reporting mechanism you use.