### PR TITLE
Added missing timer.h include.

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.c
+++ b/src/main/target/BETAFLIGHTF3/target.c
@@ -20,6 +20,7 @@
 
 #include <platform.h>
 #include "drivers/io.h"
+#include "drivers/timer.h"
 #include "drivers/pwm_mapping.h"
 
 const uint16_t multiPPM[] = {


### PR DESCRIPTION
Why is this such a common mistake?
