### PR TITLE
Implemented support for MSP jumbo frames, switched dataflash reading to be using jumbo frames.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -308,7 +308,7 @@ void resetSerialConfig(serialConfig_t *serialConfig)
 
     for (index = 0; index < SERIAL_PORT_COUNT; index++) {
         serialConfig->portConfigs[index].identifier = serialPortIdentifiers[index];
-        serialConfig->portConfigs[index].msp_baudrateIndex = BAUD_115200;
+        serialConfig->portConfigs[index].msp_baudrateIndex = BAUD_500000;
         serialConfig->portConfigs[index].gps_baudrateIndex = BAUD_57600;
         serialConfig->portConfigs[index].telemetry_baudrateIndex = BAUD_AUTO;
         serialConfig->portConfigs[index].blackbox_baudrateIndex = BAUD_115200;

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -85,7 +85,7 @@ const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
 
 static uint8_t serialPortCount;
 
-const uint32_t baudRates[] = {0, 9600, 19200, 38400, 57600, 115200, 230400, 250000}; // see baudRate_e
+const uint32_t baudRates[] = {0, 9600, 19200, 38400, 57600, 115200, 230400, 250000, 500000, 1000000}; // see baudRate_e
 
 #define BAUD_RATE_COUNT (sizeof(baudRates) / sizeof(baudRates[0]))
 

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -46,6 +46,8 @@ typedef enum {
     BAUD_115200,
     BAUD_230400,
     BAUD_250000,
+    BAUD_500000,
+    BAUD_1000000,
 } baudRate_e;
 
 extern const uint32_t baudRates[];


### PR DESCRIPTION
Set default MSP serial speed to 500000 kbps.

Fixes #1156.