### PR TITLE
Add barometric altitude to OSD

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -787,6 +787,19 @@ void updateOsd(void)
             sprintf(line+2, "%3d", (constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN));
             max7456_write_string(line, masterConfig.osdProfile.item_pos[OSD_THROTTLE_POS]);
         }
+
+        if (masterConfig.osdProfile.item_pos[OSD_ALTITUDE] != -1) {
+            int16_t alt = BaroAlt; // Metre x 100
+            char unitSym = 0xC; // m
+            if (masterConfig.osdProfile.units == OSD_UNIT_IMPERIAL) {
+                alt = (alt * 328) / 100; // Convert to feet x 100
+                unitSym = 0xF; // ft
+            }
+
+            sprintf(line, "%c%d.%01d%c", alt < 0 ? '-' : ' ', abs(alt / 100), abs((alt % 100) / 10), unitSym);
+            max7456_write_string(line, masterConfig.osdProfile.item_pos[OSD_ALTITUDE]);
+        }
+
         if (masterConfig.osdProfile.item_pos[OSD_TIMER] != -1) {
             if (armed) {
                 seconds = armed_seconds + ((now-armed_at) / 1000000);
@@ -834,6 +847,7 @@ void osdInit(void)
 void resetOsdConfig(osd_profile *osdProfile)
 {
     osdProfile->video_system = AUTO;
+    osdProfile->units = OSD_UNIT_IMPERIAL;
     osdProfile->item_pos[OSD_MAIN_BATT_VOLTAGE]  = -29;
     osdProfile->item_pos[OSD_RSSI_VALUE]         = -59;
     osdProfile->item_pos[OSD_TIMER]              = -39;
@@ -848,5 +862,6 @@ void resetOsdConfig(osd_profile *osdProfile)
     osdProfile->item_pos[OSD_CURRENT_DRAW]       = -23;
     osdProfile->item_pos[OSD_MAH_DRAWN]          = -18;
     osdProfile->item_pos[OSD_CRAFT_NAME]         = 1;
+    osdProfile->item_pos[OSD_ALTITUDE]           = 60;
 }
 #endif

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -53,13 +53,19 @@ typedef enum {
     OSD_CURRENT_DRAW,
     OSD_MAH_DRAWN,
     OSD_CRAFT_NAME,
+    OSD_ALTITUDE,
     OSD_MAX_ITEMS, // MUST BE LAST
 } osd_items_t;
 
+typedef enum {
+    OSD_UNIT_IMPERIAL,
+    OSD_UNIT_METRIC
+} osd_unit_t;
 
 typedef struct {
     // AUTO / PAL / NTSC in VIDEO_TYPES enum
     uint8_t video_system;
+    osd_unit_t units;
     int16_t item_pos[OSD_MAX_ITEMS];
 } osd_profile;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -915,6 +915,7 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef OSD
     { "osd_video_system",           VAR_UINT8  | MASTER_VALUE, &masterConfig.osdProfile.video_system, .config.minmax = { 0, 2 } },
+    { "osd_units",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.osdProfile.units, .config.lookup = { TABLE_UNIT } },
     { "osd_main_voltage_pos",       VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_MAIN_BATT_VOLTAGE], .config.minmax = { -480, 480 } },
     { "osd_rssi_pos",               VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_RSSI_VALUE], .config.minmax = { -480, 480 } },
     { "osd_timer_pos",              VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_TIMER], .config.minmax = { -480, 480 } },
@@ -929,6 +930,7 @@ const clivalue_t valueTable[] = {
     { "osd_current_draw_pos",       VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_CURRENT_DRAW], .config.minmax = { -480, 480 } },
     { "osd_mah_drawn_pos",          VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_MAH_DRAWN], .config.minmax = { -480, 480 } },
     { "osd_craft_name_pos",         VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_CRAFT_NAME], .config.minmax = { -480, 480 } },
+    { "osd_altitude_pos",           VAR_INT16  | MASTER_VALUE, &masterConfig.osdProfile.item_pos[OSD_ALTITUDE], .config.minmax = { -480, 480 } },
 #endif
 };
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1197,10 +1197,11 @@ static bool processOutCommand(uint8_t cmdMSP)
 
     case MSP_OSD_CONFIG:
 #ifdef OSD
-        headSerialReply(2 + (OSD_MAX_ITEMS * 2));
+        headSerialReply(3 + (OSD_MAX_ITEMS * 2));
         serialize8(1); // OSD supported
         // send video system (AUTO/PAL/NTSC)
         serialize8(masterConfig.osdProfile.video_system);
+        serialize8(masterConfig.osdProfile.units);
         for (i = 0; i < OSD_MAX_ITEMS; i++) {
             serialize16(masterConfig.osdProfile.item_pos[i]);
         }
@@ -1581,6 +1582,7 @@ static bool processInCommand(void)
         // set all the other settings
         if ((int8_t)addr == -1) {
             masterConfig.osdProfile.video_system = read8();
+            masterConfig.osdProfile.units = read8();
         }
         // set a position setting
         else {


### PR DESCRIPTION
Adds the option to display baro altitude on OSD in either metres or feet.

Will need configurator changes which I should get round to in a day or so assuming there is no issue with the proposed changes here.