### PR TITLE
Scheduler refactoring - currentTime passed in scheduler task call

### DIFF
--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -22,7 +22,7 @@
 void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data);
 
 void initBlackbox(void);
-void handleBlackbox(void);
+void handleBlackbox(uint32_t currentTime);
 void startBlackbox(void);
 void finishBlackbox(void);
 

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -855,7 +855,6 @@ void taskMainPidLoopCheck(uint32_t currentTime)
 {
     UNUSED(currentTime);
 
-    static uint32_t previousTime;
     static bool runTaskMainSubprocesses;
     static uint8_t pidUpdateCountdown;
 
@@ -904,9 +903,7 @@ void taskHandleSerial(uint32_t currentTime)
 
 void taskUpdateBeeper(uint32_t currentTime)
 {
-    UNUSED(currentTime);
-
-    beeperUpdate();          //call periodic beeper handler
+    beeperUpdate(currentTime);          //call periodic beeper handler
 }
 
 void taskUpdateBattery(uint32_t currentTime)
@@ -934,10 +931,8 @@ void taskUpdateBattery(uint32_t currentTime)
 
 bool taskUpdateRxCheck(uint32_t currentTime, uint32_t currentDeltaTime)
 {
-	UNUSED(currentDeltaTime);
-
-	updateRx(currentTime);
-    return shouldProcessRx(currentTime);
+    UNUSED(currentDeltaTime);
+    return rxUpdate(currentTime);
 }
 
 void taskUpdateRxMain(uint32_t currentTime)
@@ -967,8 +962,6 @@ void taskUpdateRxMain(uint32_t currentTime)
 #ifdef GPS
 void taskProcessGPS(uint32_t currentTime)
 {
-    UNUSED(currentTime);
-
     // if GPS feature is enabled, gpsThread() will be called at some intervals to check for stuck
     // hardware, wrong baud rates, init GPS if needed, etc. Don't use SENSOR_GPS here as gpsThread() can and will
     // change this based on available hardware
@@ -997,7 +990,7 @@ void taskUpdateBaro(uint32_t currentTime)
     UNUSED(currentTime);
 
     if (sensors(SENSOR_BARO)) {
-        uint32_t newDeadline = baroUpdate();
+        const uint32_t newDeadline = baroUpdate();
         rescheduleTask(TASK_SELF, newDeadline);
     }
 }
@@ -1041,12 +1034,10 @@ void taskUpdateDisplay(uint32_t currentTime)
 #ifdef TELEMETRY
 void taskTelemetry(uint32_t currentTime)
 {
-    UNUSED(currentTime);
-
     telemetryCheckState();
 
     if (!cliMode && feature(FEATURE_TELEMETRY)) {
-        telemetryProcess(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
+        telemetryProcess(currentTime, &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
     }
 }
 #endif

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -374,7 +374,7 @@ static bool isMagnetometerHealthy(void)
     return (magADC[X] != 0) && (magADC[Y] != 0) && (magADC[Z] != 0);
 }
 
-static void imuCalculateEstimatedAttitude(void)
+static void imuCalculateEstimatedAttitude(uint32_t currentTime)
 {
     static uint32_t previousIMUUpdateTime;
     float rawYawError = 0;
@@ -382,7 +382,6 @@ static void imuCalculateEstimatedAttitude(void)
     bool useMag = false;
     bool useYaw = false;
 
-    uint32_t currentTime = micros();
     uint32_t deltaT = currentTime - previousIMUUpdateTime;
     previousIMUUpdateTime = currentTime;
 
@@ -420,10 +419,10 @@ void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims)
     }
 }
 
-void imuUpdateAttitude(void)
+void imuUpdateAttitude(uint32_t currentTime)
 {
     if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {
-        imuCalculateEstimatedAttitude();
+        imuCalculateEstimatedAttitude(currentTime);
     } else {
         accSmooth[X] = 0;
         accSmooth[Y] = 0;

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -80,7 +80,7 @@ void imuConfigure(
 float getCosTiltAngle(void);
 void calculateEstimatedAltitude(uint32_t currentTime);
 void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims);
-void imuUpdateAttitude(void);
+void imuUpdateAttitude(uint32_t currentTime);
 float calculateThrottleAngleScale(uint16_t throttle_correction_angle);
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value);
 float calculateAccZLowPassFilterRCTimeConstant(float accz_lpf_hz);

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -283,7 +283,7 @@ void beeperGpsStatus(void)
  * Beeper handler function to be called periodically in loop. Updates beeper
  * state via time schedule.
  */
-void beeperUpdate(void)
+void beeperUpdate(uint32_t currentTime)
 {
     // If beeper option from AUX switch has been selected
     if (IS_RC_MODE_ACTIVE(BOXBEEPERON)) {
@@ -303,8 +303,7 @@ void beeperUpdate(void)
         return;
     }
 
-    uint32_t now = millis();
-    if (beeperNextToggleTime > now) {
+    if (beeperNextToggleTime > currentTime) {
         return;
     }
 
@@ -403,7 +402,7 @@ bool isBeeperOn(void) {
 void beeper(beeperMode_e mode) {UNUSED(mode);}
 void beeperSilence(void) {}
 void beeperConfirmationBeeps(uint8_t beepCount) {UNUSED(beepCount);}
-void beeperUpdate(void) {}
+void beeperUpdate(uint32_t currentTime) {}
 uint32_t getArmingBeepTimeMicros(void) {return 0;}
 beeperMode_e beeperModeForTableIndex(int idx) {UNUSED(idx); return BEEPER_SILENCE;}
 const char *beeperNameForTableIndex(int idx) {UNUSED(idx); return NULL;}

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -47,7 +47,7 @@ typedef enum {
 
 void beeper(beeperMode_e mode);
 void beeperSilence(void);
-void beeperUpdate(void);
+void beeperUpdate(uint32_t currentTime);
 void beeperConfirmationBeeps(uint8_t beepCount);
 uint32_t getArmingBeepTimeMicros(void);
 beeperMode_e beeperModeForTableIndex(int idx);

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -582,17 +582,16 @@ void showDebugPage(void)
 }
 #endif
 
-void updateDisplay(void)
+void updateDisplay(uint32_t currentTime)
 {
-    uint32_t now = micros();
     static uint8_t previousArmedState = 0;
 
-    bool updateNow = (int32_t)(now - nextDisplayUpdateAt) >= 0L;
+    const bool updateNow = (int32_t)(currentTime - nextDisplayUpdateAt) >= 0L;
     if (!updateNow) {
         return;
     }
 
-    nextDisplayUpdateAt = now + DISPLAY_UPDATE_FREQUENCY;
+    nextDisplayUpdateAt = currentTime + DISPLAY_UPDATE_FREQUENCY;
 
     bool armedState = ARMING_FLAG(ARMED) ? true : false;
     bool armedStateChanged = armedState != previousArmedState;
@@ -612,7 +611,7 @@ void updateDisplay(void)
         }
 
         pageState.pageChanging = (pageState.pageFlags & PAGE_STATE_FLAG_FORCE_PAGE_CHANGE) ||
-                (((int32_t)(now - pageState.nextPageAt) >= 0L && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)));
+                (((int32_t)(currentTime - pageState.nextPageAt) >= 0L && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)));
         if (pageState.pageChanging && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)) {
             pageState.cycleIndex++;
             pageState.cycleIndex = pageState.cycleIndex % CYCLE_PAGE_ID_COUNT;
@@ -622,7 +621,7 @@ void updateDisplay(void)
 
     if (pageState.pageChanging) {
         pageState.pageFlags &= ~PAGE_STATE_FLAG_FORCE_PAGE_CHANGE;
-        pageState.nextPageAt = now + PAGE_CYCLE_FREQUENCY;
+        pageState.nextPageAt = currentTime + PAGE_CYCLE_FREQUENCY;
 
         // Some OLED displays do not respond on the first initialisation so refresh the display
         // when the page changes in the hopes the hardware responds.  This also allows the
@@ -703,7 +702,7 @@ void displayInit(rxConfig_t *rxConfigToUse)
     memset(&pageState, 0, sizeof(pageState));
     displaySetPage(PAGE_WELCOME);
 
-    updateDisplay();
+    updateDisplay(micros());
 
     displaySetNextPageChangeAt(micros() + (1000 * 1000 * 5));
 }

--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -37,7 +37,7 @@ typedef enum {
 
 struct rxConfig_s;
 void displayInit(struct rxConfig_s *intialRxConfig);
-void updateDisplay(void);
+void updateDisplay(uint32_t currentTime);
 
 void displayShowFixedPage(pageId_e pageId);
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1065,7 +1065,7 @@ static void gpsHandlePassthrough(uint8_t data)
      gpsNewData(data);
  #ifdef DISPLAY
      if (feature(FEATURE_DISPLAY)) {
-         updateDisplay();
+         updateDisplay(micros());
      }
  #endif
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -925,7 +925,7 @@ static applyLayerFn_timed* layerTable[] = {
     [timRing] = &applyLedThrustRingLayer
 };
 
-void updateLedStrip(void)
+void updateLedStrip(uint32_t currentTime)
 {
     if (!(ledStripInitialised && isWS2811LedStripReady())) {
         return;
@@ -940,7 +940,7 @@ void updateLedStrip(void)
     }
     ledStripEnabled = true;
 
-    uint32_t now = micros();
+    const uint32_t now = currentTime;
 
     // test all led timers, setting corresponding bits
     uint32_t timActive = 0;

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -165,7 +165,7 @@ void reevaluateLedConfig(void);
 
 void ledStripInit(ledConfig_t *ledConfigsToUse, hsvColor_t *colorsToUse, modeColorIndexes_t *modeColorsToUse, specialColorIndexes_t *specialColorsToUse);
 void ledStripEnable(void);
-void updateLedStrip(void);
+void updateLedStrip(uint32_t currentTime);
 
 bool setModeColor(ledModeIndex_e modeIndex, int modeColorIndex, int colorIndex);
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -701,32 +701,31 @@ void osdDrawArtificialHorizon(int rollAngle, int pitchAngle, uint8_t show_sideba
     }
 }
 
-void updateOsd(void)
+void updateOsd(uint32_t currentTime)
 {
     static uint8_t blink = 0;
     static uint8_t arming = 0;
     uint32_t seconds;
     char line[30];
-    uint32_t now = micros();
 
-    bool updateNow = (int32_t)(now - next_osd_update_at) >= 0L;
+    const bool updateNow = (int32_t)(currentTime - next_osd_update_at) >= 0L;
     if (!updateNow) {
         return;
     }
-    next_osd_update_at = now + OSD_UPDATE_FREQUENCY;
+    next_osd_update_at = currentTime + OSD_UPDATE_FREQUENCY;
     blink++;
 
     if (ARMING_FLAG(ARMED)) {
         if (!armed) {
             armed = true;
-            armed_at = now;
+            armed_at = currentTime;
             in_menu = false;
             arming = 5;
         }
     } else {
         if (armed) {
             armed = false;
-            armed_seconds += ((now - armed_at) / 1000000);
+            armed_seconds += ((currentTime - armed_at) / 1000000);
         }
         for (uint8_t channelIndex = 0; channelIndex < 4; channelIndex++) {
             sticks[channelIndex] = (constrain(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN);
@@ -792,12 +791,12 @@ void updateOsd(void)
         }
         if (masterConfig.osdProfile.item_pos[OSD_TIMER] != -1) {
             if (armed) {
-                seconds = armed_seconds + ((now-armed_at) / 1000000);
+                seconds = armed_seconds + ((currentTime - armed_at) / 1000000);
                 line[0] = SYM_FLY_M;
                 sprintf(line+1, " %02d:%02d", seconds / 60, seconds % 60);
             } else {
                 line[0] = SYM_ON_M;
-                seconds = now  / 1000000;
+                seconds = currentTime / 1000000;
                 sprintf(line+1, " %02d:%02d", seconds / 60, seconds % 60);
             }
             max7456_write_string(line, masterConfig.osdProfile.item_pos[OSD_TIMER]);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -63,6 +63,6 @@ typedef struct {
     int16_t item_pos[OSD_MAX_ITEMS];
 } osd_profile;
 
-void updateOsd(void);
+void updateOsd(uint32_t currentTime);
 void osdInit(void);
 void resetOsdConfig(osd_profile *osdProfile);

--- a/src/main/io/transponder_ir.c
+++ b/src/main/io/transponder_ir.c
@@ -42,7 +42,7 @@ static uint32_t nextUpdateAt = 0;
 #define JITTER_DURATION_COUNT (sizeof(jitterDurations) / sizeof(uint8_t))
 static uint8_t jitterDurations[] = {0,9,4,8,3,9,6,7,1,6,9,7,8,2,6};
 
-void updateTransponder(void)
+void updateTransponder(uint32_t currentTime)
 {
     static uint32_t jitterIndex = 0;
 
@@ -50,9 +50,7 @@ void updateTransponder(void)
         return;
     }
 
-    uint32_t now = micros();
-
-    bool updateNow = (int32_t)(now - nextUpdateAt) >= 0L;
+    const bool updateNow = (int32_t)(currentTime - nextUpdateAt) >= 0L;
     if (!updateNow) {
         return;
     }
@@ -63,12 +61,12 @@ void updateTransponder(void)
         jitterIndex = 0;
     }
 
-    nextUpdateAt = now + 4500 + jitter;
+    nextUpdateAt = currentTime + 4500 + jitter;
 
 #ifdef REDUCE_TRANSPONDER_CURRENT_DRAW_WHEN_USB_CABLE_PRESENT
     // reduce current draw when USB cable is plugged in by decreasing the transponder transmit rate.
     if (usbCableIsInserted()) {
-        nextUpdateAt = now + (1000 * 1000) / 10; // 10 hz.
+        nextUpdateAt = currentTime + (1000 * 1000) / 10; // 10 hz.
     }
 #endif
 

--- a/src/main/io/transponder_ir.h
+++ b/src/main/io/transponder_ir.h
@@ -21,7 +21,7 @@ void transponderInit(uint8_t* transponderCode);
 
 void transponderEnable(void);
 void transponderDisable(void);
-void updateTransponder(void);
+void updateTransponder(uint32_t currentTime);
 void transponderUpdateData(uint8_t* transponderData);
 void transponderTransmitOnce(void);
 void transponderStartRepeating(void);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -333,7 +333,7 @@ void resumeRxSignal(void)
     failsafeOnRxResume();
 }
 
-void updateRx(uint32_t currentTime)
+bool rxUpdate(uint32_t currentTime)
 {
     resetRxSignalReceivedFlagIfNeeded(currentTime);
 
@@ -384,11 +384,7 @@ void updateRx(uint32_t currentTime)
         }
     }
 #endif
-}
-
-bool shouldProcessRx(uint32_t currentTime)
-{
-    return rxDataReceived || ((int32_t)(currentTime - rxUpdateAt) >= 0); // data driven or 50Hz
+    return rxDataReceived || (currentTime >= rxUpdateAt); // data driven or 50Hz
 }
 
 static uint16_t calculateNonDataDrivenChannel(uint8_t chan, uint16_t sample)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -151,10 +151,9 @@ typedef uint16_t (*rcReadRawDataPtr)(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t
 struct modeActivationCondition_s;
 void rxInit(rxConfig_t *rxConfig, struct modeActivationCondition_s *modeActivationConditions);
 void useRxConfig(rxConfig_t *rxConfigToUse);
-void updateRx(uint32_t currentTime);
+bool rxUpdate(uint32_t currentTime);
 bool rxIsReceivingSignal(void);
 bool rxAreFlightChannelsValid(void);
-bool shouldProcessRx(uint32_t currentTime);
 void calculateRxChannelsAndUpdateFailsafe(uint32_t currentTime);
 
 void parseRcChannels(const char *input, rxConfig_t *rxConfig);

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -38,7 +38,6 @@ static cfTask_t *currentTask = NULL;
 static uint32_t totalWaitingTasks;
 static uint32_t totalWaitingTasksSamples;
 
-uint32_t currentTime = 0;
 uint16_t averageSystemLoadPercent = 0;
 
 
@@ -110,9 +109,11 @@ cfTask_t *queueNext(void)
     return taskQueueArray[++taskQueuePos]; // guaranteed to be NULL at end of queue
 }
 
-void taskSystem(void)
+void taskSystem(uint32_t currentTime)
 {
-    /* Calculate system load */
+    UNUSED(currentTime);
+
+    // Calculate system load
     if (totalWaitingTasksSamples > 0) {
         averageSystemLoadPercent = 100 * totalWaitingTasks / totalWaitingTasksSamples;
         totalWaitingTasksSamples = 0;
@@ -174,7 +175,7 @@ void schedulerInit(void)
 void scheduler(void)
 {
     // Cache currentTime
-    currentTime = micros();
+    const uint32_t currentTime = micros();
 
     // Check for realtime tasks
     uint32_t timeToNextRealtimeTask = UINT32_MAX;
@@ -203,7 +204,7 @@ void scheduler(void)
                 task->taskAgeCycles = 1 + ((currentTime - task->lastSignaledAt) / task->desiredPeriod);
                 task->dynamicPriority = 1 + task->staticPriority * task->taskAgeCycles;
                 waitingTasks++;
-            } else if (task->checkFunc(currentTime - task->lastExecutedAt)) {
+            } else if (task->checkFunc(currentTime, currentTime - task->lastExecutedAt)) {
                 task->lastSignaledAt = currentTime;
                 task->taskAgeCycles = 1;
                 task->dynamicPriority = 1 + task->staticPriority;
@@ -246,7 +247,7 @@ void scheduler(void)
 
         // Execute task
         const uint32_t currentTimeBeforeTaskCall = micros();
-        selectedTask->taskFunc();
+        selectedTask->taskFunc(currentTimeBeforeTaskCall);
         const uint32_t taskExecutionTime = micros() - currentTimeBeforeTaskCall;
 
         selectedTask->averageExecutionTime = ((uint32_t)selectedTask->averageExecutionTime * 31 + taskExecutionTime) / 32;

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -98,8 +98,8 @@ typedef struct {
     /* Configuration */
     const char * taskName;
     const char * subTaskName;
-    bool (*checkFunc)(uint32_t currentDeltaTime);
-    void (*taskFunc)(void);
+    bool (*checkFunc)(uint32_t currentTime, uint32_t currentDeltaTime);
+    void (*taskFunc)(uint32_t currentTime);
     uint32_t desiredPeriod;         // target period of execution
     const uint8_t staticPriority;   // dynamicPriority grows in steps of this size, shouldn't be zero
 

--- a/src/main/scheduler/scheduler_tasks.h
+++ b/src/main/scheduler/scheduler_tasks.h
@@ -17,29 +17,29 @@
 
 #pragma once
 
-void taskSystem(void);
-void taskMainPidLoopCheck(void);
-void taskUpdateAccelerometer(void);
-void taskUpdateAttitude(void);
-bool taskUpdateRxCheck(uint32_t currentDeltaTime);
-void taskUpdateRxMain(void);
-void taskHandleSerial(void);
-void taskUpdateBattery(void);
-void taskUpdateBeeper(void);
-void taskProcessGPS(void);
-void taskUpdateCompass(void);
-void taskUpdateBaro(void);
-void taskUpdateSonar(void);
-void taskCalculateAltitude(void);
-void taskUpdateDisplay(void);
-void taskTelemetry(void);
-void taskLedStrip(void);
-void taskTransponder(void);
+void taskSystem(uint32_t currentTime);
+void taskMainPidLoopCheck(uint32_t currentTime);
+void taskUpdateAccelerometer(uint32_t currentTime);
+void taskUpdateAttitude(uint32_t currentTime);
+bool taskUpdateRxCheck(uint32_t currentTime, uint32_t currentDeltaTime);
+void taskUpdateRxMain(uint32_t currentTime);
+void taskHandleSerial(uint32_t currentTime);
+void taskUpdateBattery(uint32_t currentTime);
+void taskUpdateBeeper(uint32_t currentTime);
+void taskProcessGPS(uint32_t currentTime);
+void taskUpdateCompass(uint32_t currentTime);
+void taskUpdateBaro(uint32_t currentTime);
+void taskUpdateSonar(uint32_t currentTime);
+void taskCalculateAltitude(uint32_t currentTime);
+void taskUpdateDisplay(uint32_t currentTime);
+void taskTelemetry(uint32_t currentTime);
+void taskLedStrip(uint32_t currentTime);
+void taskTransponder(uint32_t currentTime);
 #ifdef OSD
-void taskUpdateOsd(void);
+void taskUpdateOsd(uint32_t currentTime);
 #endif
 #ifdef USE_BST
-void taskBstReadWrite(void);
-void taskBstMasterProcess(void);
+void taskBstReadWrite(uint32_t currentTime);
+void taskBstMasterProcess(uint32_t currentTime);
 #endif
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -45,8 +45,6 @@ sensor_align_e magAlign = 0;
 
 #ifdef MAG
 
-extern uint32_t currentTime; // FIXME dependency on global variable, pass it in instead.
-
 static int16_t magADCRaw[XYZ_AXIS_COUNT];
 static uint8_t magInit = 0;
 
@@ -59,7 +57,7 @@ void compassInit(void)
     magInit = 1;
 }
 
-void updateCompass(flightDynamicsTrims_t *magZero)
+void updateCompass(uint32_t currentTime, flightDynamicsTrims_t *magZero)
 {
     static uint32_t tCal = 0;
     static flightDynamicsTrims_t magZeroTempMin;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -29,7 +29,7 @@ typedef enum {
 
 void compassInit(void);
 union flightDynamicsTrims_u;
-void updateCompass(union flightDynamicsTrims_u *magZero);
+void updateCompass(uint32_t currentTime, union flightDynamicsTrims_u *magZero);
 
 extern int32_t magADC[XYZ_AXIS_COUNT];
 

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -1479,11 +1479,10 @@ void bstProcessInCommand(void)
     }
 }
 
-void resetBstChecker(void)
+static void resetBstChecker(uint32_t currentTime)
 {
     if(needResetCheck) {
-        uint32_t currentTimer = micros();
-        if(currentTimer >= (resetBstTimer + BST_RESET_TIME))
+        if(currentTime >= (resetBstTimer + BST_RESET_TIME))
         {
             bstTimeoutUserCallback();
             needResetCheck = false;
@@ -1500,15 +1499,14 @@ static uint32_t next20hzUpdateAt_1 = 0;
 
 static uint8_t sendCounter = 0;
 
-void taskBstMasterProcess(void)
+void taskBstMasterProcess(uint32_t currentTime)
 {
     if(coreProReady) {
-        uint32_t now = micros();
-        if(now >= next02hzUpdateAt_1 && !bstWriteBusy()) {
+        if(currentTime >= next02hzUpdateAt_1 && !bstWriteBusy()) {
             writeFCModeToBST();
-            next02hzUpdateAt_1 = now + UPDATE_AT_02HZ;
+            next02hzUpdateAt_1 = currentTime + UPDATE_AT_02HZ;
         }
-        if(now >= next20hzUpdateAt_1 && !bstWriteBusy()) {
+        if(currentTime >= next20hzUpdateAt_1 && !bstWriteBusy()) {
             if(sendCounter == 0)
                 writeRCChannelToBST();
             else if(sendCounter == 1)
@@ -1516,7 +1514,7 @@ void taskBstMasterProcess(void)
             sendCounter++;
             if(sendCounter > 1)
                 sendCounter = 0;
-            next20hzUpdateAt_1 = now + UPDATE_AT_20HZ;
+            next20hzUpdateAt_1 = currentTime + UPDATE_AT_20HZ;
         }
 
         if(sensors(SENSOR_GPS) && !bstWriteBusy())
@@ -1527,7 +1525,7 @@ void taskBstMasterProcess(void)
         stopMotors();
         systemReset();
     }
-    resetBstChecker();
+    resetBstChecker(currentTime);
 }
 
 /*************************************************************************************************/

--- a/src/main/target/COLIBRI_RACE/i2c_bst.h
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.h
@@ -19,7 +19,7 @@
 
 void bstProcessInCommand(void);
 void bstSlaveProcessInCommand(void);
-void taskBstMasterProcess(void);
+void taskBstMasterProcess(uint32_t currentTime);
 
 bool writeGpsPositionPrameToBST(void);
 bool writeRollPitchYawToBST(void);

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -490,7 +490,7 @@ void checkHoTTTelemetryState(void)
         freeHoTTTelemetryPort();
 }
 
-void handleHoTTTelemetry(void)
+void handleHoTTTelemetry(uint32_t currentTime)
 {
     static uint32_t serialTimer;
 
@@ -498,27 +498,25 @@ void handleHoTTTelemetry(void)
         return;
     }
 
-    uint32_t now = micros();
-
-    if (shouldPrepareHoTTMessages(now)) {
+    if (shouldPrepareHoTTMessages(currentTime)) {
         hottPrepareMessages();
-        lastMessagesPreparedAt = now;
+        lastMessagesPreparedAt = currentTime;
     }
 
     if (shouldCheckForHoTTRequest()) {
-        hottCheckSerialData(now);
+        hottCheckSerialData(currentTime);
     }
 
     if (!hottMsg)
         return;
 
     if (hottIsSending) {
-        if(now - serialTimer < HOTT_TX_DELAY_US) {
+        if(currentTime - serialTimer < HOTT_TX_DELAY_US) {
             return;
         }
     }
     hottSendTelemetryData();
-    serialTimer = now;
+    serialTimer = currentTime;
 }
 
 #endif

--- a/src/main/telemetry/hott.h
+++ b/src/main/telemetry/hott.h
@@ -485,7 +485,7 @@ typedef struct HOTT_AIRESC_MSG_s {
     uint8_t stop_byte;      //#44 constant value 0x7d
 } HOTT_AIRESC_MSG_t;
 
-void handleHoTTTelemetry(void);
+void handleHoTTTelemetry(uint32_t currentTime);
 void checkHoTTTelemetryState(void);
 
 void initHoTTTelemetry(telemetryConfig_t *telemetryConfig);

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -90,10 +90,10 @@ void telemetryCheckState(void)
     checkJetiExBusTelemetryState();
 }
 
-void telemetryProcess(rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
+void telemetryProcess(uint32_t currentTime, rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
 {
     handleFrSkyTelemetry(rxConfig, deadband3d_throttle);
-    handleHoTTTelemetry();
+    handleHoTTTelemetry(currentTime);
     handleSmartPortTelemetry();
     handleLtmTelemetry();
     handleJetiExBusTelemetry();

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -53,7 +53,7 @@ extern serialPort_t *telemetrySharedPort;
 
 void telemetryCheckState(void);
 struct rxConfig_s;
-void telemetryProcess(struct rxConfig_s *rxConfig, uint16_t deadband3d_throttle);
+void telemetryProcess(uint32_t currentTime, struct rxConfig_s *rxConfig, uint16_t deadband3d_throttle);
 
 bool telemetryDetermineEnabledState(portSharing_e portSharing);
 


### PR DESCRIPTION
This is something I've had kicking around for a while. I wonder what other people think of the idea.

What I've done is got rid of the global variable `currentTime` and instead the scheduler passes `currentTime` as a parameter when it calls the `task...` functions.

Personally I think it's a neater way of doing things. Codesize wise it is pretty neutral - it saves about 60 bytes of code on a CC3D build, so there's no real advantage gained, but also no cost incurred either.

It's really just a question of whether this is regarded as a better way of doing things.

Thoughts please...