### PR TITLE
IMPULSERCF3 build failed. Timer.h missing. Fixed.

### DIFF
--- a/src/main/target/IMPULSERCF3/target.c
+++ b/src/main/target/IMPULSERCF3/target.c
@@ -19,6 +19,7 @@
 
 #include <platform.h>
 #include "drivers/io.h"
+#include "drivers/timer.h"
 #include "drivers/pwm_mapping.h"
 
 


### PR DESCRIPTION
Again, #include timer.h missing. Why is this still so common? All recent new targets have had this flaw. 
/A, Janitor.
