### PR TITLE
REVO. Added support for Beeper on PB4. Used by AirbotF4 and Flip32F4.

### DIFF
--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -27,8 +27,12 @@
 #endif
 
 #define LED0                    PB5
-#define LED1                    PB4
+// Disable LED1, conflicts with AirbotF4/Flip32F4 beeper
+//#define LED1                    PB4
+
 #define BEEPER                  PB4
+#define BEEPER_INVERTED
+
 #define INVERTER                PC0 // PC0 used as inverter select GPIO
 #define INVERTER_USART          USART1
 

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -17,7 +17,7 @@
 
 #define FC_VERSION_MAJOR            3  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            0  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      0  // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      1  // increment when a bug is fixed
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)


### PR DESCRIPTION
LED1 disabled and beeper port inverted.
Ref: http://www.rcgroups.com/forums/showthread.php?t=2731917&page=8
