### PR TITLE
corrected modes display for MAG, HEADFREE and HEADADJ

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -484,7 +484,7 @@ void mspInit(serialConfig_t *serialConfig)
         activeBoxIds[activeBoxIdCount++] = BOXBARO;
     }
 
-    if (sensors(SENSOR_ACC) || sensors(SENSOR_MAG)) {
+    if (sensors(SENSOR_ACC) && sensors(SENSOR_MAG)) {
         activeBoxIds[activeBoxIdCount++] = BOXMAG;
         activeBoxIds[activeBoxIdCount++] = BOXHEADFREE;
         activeBoxIds[activeBoxIdCount++] = BOXHEADADJ;


### PR DESCRIPTION
* mode required magnetometer only displays when magnetometer and accelerometer is enabled 
* imho this modes have no sense when only accelerometer is enabled