### PR TITLE
RACEBASE build failed. Incomplete include path corrected.

### DIFF
--- a/src/main/target/RACEBASE/hardware_revision.c
+++ b/src/main/target/RACEBASE/hardware_revision.c
@@ -21,7 +21,7 @@
 
 #include "platform.h"
 
-#include "build_config.h"
+#include "build/build_config.h"
 
 #include "drivers/system.h"
 #include "drivers/bus_spi.h"


### PR DESCRIPTION
RACEBASE build failed. Incomplete include path corrected.