### PR TITLE
Fix micros using COUNTFLAG

### DIFF
--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -213,6 +213,8 @@ extiCallbackRec_t mpuIntCallbackRec;
 
 #define DEBUG_MPU_DATA_READY_INTERRUPT
 
+extern uint32_t isr_micros(void);
+
 void mpuIntExtiHandler(extiCallbackRec_t *cb)
 {
     UNUSED(cb);
@@ -221,6 +223,7 @@ void mpuIntExtiHandler(extiCallbackRec_t *cb)
 #ifdef DEBUG_MPU_DATA_READY_INTERRUPT
     static uint32_t lastCalledAt = 0;
     uint32_t now = micros();
+    //uint32_t now = isr_micros();
     uint32_t callDelta = now - lastCalledAt;
     debug[0] = callDelta;
 

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -210,7 +210,6 @@ static void mpu6050FindRevision(void)
 }
 
 extiCallbackRec_t mpuIntCallbackRec;
-#define DEBUG_MPU_DATA_READY_INTERRUPT
 
 void mpuIntExtiHandler(extiCallbackRec_t *cb)
 {
@@ -221,7 +220,6 @@ void mpuIntExtiHandler(extiCallbackRec_t *cb)
     static uint32_t lastCalledAt = 0;
     uint32_t now = micros();
     uint32_t callDelta = now - lastCalledAt;
-    if (now < lastCalledAt) debug[1]++;
     debug[0] = callDelta;
     lastCalledAt = now;
 #endif

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -211,6 +211,8 @@ static void mpu6050FindRevision(void)
 
 extiCallbackRec_t mpuIntCallbackRec;
 
+#define DEBUG_MPU_DATA_READY_INTERRUPT
+
 void mpuIntExtiHandler(extiCallbackRec_t *cb)
 {
     UNUSED(cb);
@@ -221,6 +223,10 @@ void mpuIntExtiHandler(extiCallbackRec_t *cb)
     uint32_t now = micros();
     uint32_t callDelta = now - lastCalledAt;
     debug[0] = callDelta;
+
+    if (now < lastCalledAt)
+        debug[1]++;
+
     lastCalledAt = now;
 #endif
 }

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -210,10 +210,7 @@ static void mpu6050FindRevision(void)
 }
 
 extiCallbackRec_t mpuIntCallbackRec;
-
 #define DEBUG_MPU_DATA_READY_INTERRUPT
-
-extern uint32_t isr_micros(void);
 
 void mpuIntExtiHandler(extiCallbackRec_t *cb)
 {
@@ -223,13 +220,9 @@ void mpuIntExtiHandler(extiCallbackRec_t *cb)
 #ifdef DEBUG_MPU_DATA_READY_INTERRUPT
     static uint32_t lastCalledAt = 0;
     uint32_t now = micros();
-    //uint32_t now = isr_micros();
     uint32_t callDelta = now - lastCalledAt;
+    if (now < lastCalledAt) debug[1]++;
     debug[0] = callDelta;
-
-    if (now < lastCalledAt)
-        debug[1]++;
-
     lastCalledAt = now;
 #endif
 }

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -84,7 +84,7 @@ uint32_t microsISR(void)
 
         if (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) {
             // Update pending.
-            // Remember it for calls within the same rollover period
+            // Remember it for multiple calls within the same rollover period
             // (Will be cleared when serviced).
 
             // XXX Do we care for multiple rollovers?

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -22,6 +22,7 @@ void delayMicroseconds(uint32_t us);
 void delay(uint32_t ms);
 
 uint32_t micros(void);
+uint32_t microsISR(void);
 uint32_t millis(void);
 
 typedef enum {


### PR DESCRIPTION
Working PR for #1212 

Trying to come up with micros() that is safe to call from ISRs.
Using COUNTFLAG as pending interrupt flag to add extra 1msec.
accgyro_mpu.c had a nice piece of code; using it as a micros() caller.

I'm still loosing lots of cases... I must be overlooking something.