### PR TITLE
Moved LED to ESC output 5 - REVO

### DIFF
--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -112,15 +112,15 @@
 #define LED_STRIP
 // LED Strip can run off Pin 6 (PA0) of the MOTOR outputs.
 #define WS2811_GPIO_AF                  GPIO_AF_TIM5
-#define WS2811_PIN                      PA0 
+#define WS2811_PIN                      PA1 
 #define WS2811_TIMER                    TIM5
 #define WS2811_TIMER_CHANNEL            TIM_Channel_2
-#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST2_HANDLER
-#define WS2811_DMA_STREAM               DMA1_Stream2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST4_HANDLER
+#define WS2811_DMA_STREAM               DMA1_Stream4
 #define WS2811_DMA_CHANNEL              DMA_Channel_6
-#define WS2811_DMA_IRQ                  DMA1_Stream2_IRQn
-#define WS2811_DMA_FLAG                 DMA_FLAG_TCIF2
-#define WS2811_DMA_IT                   DMA_IT_TCIF2
+#define WS2811_DMA_IRQ                  DMA1_Stream4_IRQn
+#define WS2811_DMA_FLAG                 DMA_FLAG_TCIF4
+#define WS2811_DMA_IT                   DMA_IT_TCIF4
 
 #define SENSORS_SET (SENSOR_ACC)
 

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -110,7 +110,7 @@
 //#define RSSI_ADC_PIN            PA0
 
 #define LED_STRIP
-// LED Strip can run off Pin 6 (PA0) of the MOTOR outputs.
+// LED Strip can run off Pin 5 (PA1) of the MOTOR outputs.
 #define WS2811_GPIO_AF                  GPIO_AF_TIM5
 #define WS2811_PIN                      PA1 
 #define WS2811_TIMER                    TIM5


### PR DESCRIPTION
This is tested - and works fine for RTFQ REVO.