### PR TITLE
SINGULARITY build failed. Added missing includes.

### DIFF
--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -50,6 +50,7 @@
 #include "io/serial.h"
 #include "io/gimbal.h"
 #include "io/motors.h"
+#include "io/servos.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_curves.h"
 #include "io/ledstrip.h"
@@ -70,6 +71,7 @@
 #include "config/config.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
+#include "config/config_eeprom.h"
 #include "fc/runtime_config.h"
 
 


### PR DESCRIPTION
This PR is just a quick fix in the current style of include chains to put out the red lights.
BUT it is not the really correct way. In this case, vtx.c includes a lot of header files that it does not need itself, only to cover up for other modules that does not take care of its own dependencies.
In this case "config_master.h" uses "servoConfig_t" but does not include the type definition. In fact it does not include ANY of the header files it is dependant on. 

    In file included from ./src/main/io/vtx.c:72:0:
    ./src/main/config/config_master.h:32:5: error: unknown type name 'servoConfig_t'
         servoConfig_t servoConfig;
