### PR TITLE
Move master_t required #includes into config_master.h

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -16,76 +16,42 @@
  */
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "platform.h"
 
 #ifdef BLACKBOX
 
-#include "build/version.h"
 #include "build/debug.h"
+#include "build/version.h"
 
-#include "common/maths.h"
 #include "common/axis.h"
-#include "common/color.h"
 #include "common/encoding.h"
 #include "common/utils.h"
 
-#include "drivers/gpio.h"
-#include "drivers/sensor.h"
-#include "drivers/system.h"
-#include "drivers/serial.h"
-#include "drivers/compass.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/accgyro.h"
-#include "drivers/light_led.h"
+#include "blackbox.h"
+#include "blackbox_io.h"
 
-#include "sensors/sensors.h"
-#include "sensors/boardalignment.h"
-#include "sensors/sonar.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/gyro.h"
-#include "sensors/battery.h"
+#include "drivers/sensor.h"
+#include "drivers/compass.h"
+#include "drivers/system.h"
+
+#include "fc/rc_controls.h"
+#include "fc/runtime_config.h"
+
+#include "flight/pid.h"
 
 #include "io/beeper.h"
-#include "io/display.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "io/gimbal.h"
-#include "io/gps.h"
-#include "io/ledstrip.h"
-#include "io/serial.h"
-#include "io/serial_cli.h"
-#include "io/serial_msp.h"
-#include "io/statusindicator.h"
-#include "io/osd.h"
-#include "io/vtx.h"
 
-#include "rx/rx.h"
-#include "rx/msp.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/altitudehold.h"
-#include "flight/failsafe.h"
-#include "flight/imu.h"
-#include "flight/pid.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
+#include "sensors/sonar.h"
 
 #include "config/config.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
 #include "config/feature.h"
-
-#include "blackbox.h"
-#include "blackbox_io.h"
 
 #define BLACKBOX_I_INTERVAL 32
 #define BLACKBOX_SHUTDOWN_TIMEOUT_MILLIS 200

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <stdint.h>
-
 typedef enum FlightLogFieldCondition {
     FLIGHT_LOG_FIELD_CONDITION_ALWAYS = 0,
     FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_MOTORS_1,

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -1,72 +1,32 @@
+#include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+
+#include "platform.h"
+
+#ifdef BLACKBOX
 
 #include "blackbox_io.h"
 
 #include "build/version.h"
 #include "build/build_config.h"
 
-#include "common/maths.h"
-#include "common/axis.h"
-#include "common/color.h"
 #include "common/encoding.h"
-
-#include "drivers/gpio.h"
-#include "drivers/sensor.h"
-#include "drivers/system.h"
-#include "drivers/serial.h"
-#include "drivers/compass.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/accgyro.h"
-#include "drivers/light_led.h"
-#include "drivers/sound_beeper.h"
-
-#include "sensors/sensors.h"
-#include "sensors/boardalignment.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/gyro.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/display.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "rx/rx.h"
-#include "fc/rc_controls.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "io/gimbal.h"
-#include "io/gps.h"
-#include "io/ledstrip.h"
-#include "io/serial.h"
-#include "io/serial_cli.h"
-#include "io/serial_msp.h"
-#include "io/statusindicator.h"
-#include "rx/msp.h"
-#include "telemetry/telemetry.h"
 #include "common/printf.h"
 
-#include "flight/mixer.h"
-#include "flight/altitudehold.h"
-#include "flight/failsafe.h"
-#include "flight/imu.h"
-#include "flight/pid.h"
-#include "flight/navigation.h"
+#include "fc/rc_controls.h"
 
-#include "fc/runtime_config.h"
+#include "flight/pid.h"
+
+#include "io/asyncfatfs/asyncfatfs.h"
+#include "io/flashfs.h"
+#include "io/serial_msp.h"
 
 #include "config/config.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
-
-#include "io/flashfs.h"
-#include "io/asyncfatfs/asyncfatfs.h"
-
-#ifdef BLACKBOX
 
 #define BLACKBOX_SERIAL_PORT_MODE MODE_TX
 

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -17,11 +17,6 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stdbool.h>
-
-#include "platform.h"
-
 typedef enum BlackboxDevice {
     BLACKBOX_DEVICE_SERIAL = 0,
 

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -51,7 +51,7 @@ typedef struct fp_vector {
     float Z;
 } t_fp_vector_def;
 
-typedef union {
+typedef union u_fp_vector {
     float A[3];
     t_fp_vector_def V;
 } t_fp_vector;

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -21,53 +21,14 @@
 
 #include "platform.h"
 
-#include "build/build_config.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
 #include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
 
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
+#include "config/config_master.h"
 
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
+#include "build/build_config.h"
 
 #include "config/config.h"
 #include "config/config_eeprom.h"
-#include "config/config_profile.h"
 #include "config/config_master.h"
 
 #if !defined(FLASH_SIZE)

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -17,6 +17,51 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "common/color.h"
+#include "common/axis.h"
+
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+#include "drivers/pwm_rx.h"
+#include "drivers/serial.h"
+
+#include "sensors/sensors.h"
+#include "sensors/gyro.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/boardalignment.h"
+#include "sensors/battery.h"
+
+#include "io/serial.h"
+#include "io/gimbal.h"
+#include "io/motors.h"
+#include "io/servos.h"
+#include "fc/rc_controls.h"
+#include "io/ledstrip.h"
+#include "io/gps.h"
+#include "io/osd.h"
+#include "io/vtx.h"
+
+#include "rx/rx.h"
+
+#include "telemetry/telemetry.h"
+
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/imu.h"
+#include "flight/failsafe.h"
+#include "flight/altitudehold.h"
+#include "flight/navigation.h"
+
+#include "config/config.h"
+#include "config/config_profile.h"
+#include "config/config_master.h"
+
+
 // System-wide
 typedef struct master_s {
     uint8_t version;

--- a/src/main/config/feature.c
+++ b/src/main/config/feature.c
@@ -21,54 +21,10 @@
 
 #include "platform.h"
 
-#include "build/build_config.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
 #include "config/config.h"
-#include "config/config_profile.h"
 #include "config/config_master.h"
 #include "config/feature.h"
+
 
 static uint32_t activeFeaturesLatch = 0;
 

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -22,6 +22,7 @@
 
 #ifdef USE_FLASH_M25P16
 
+#include "flash.h"
 #include "flash_m25p16.h"
 #include "io.h"
 #include "bus_spi.h"

--- a/src/main/drivers/flash_m25p16.h
+++ b/src/main/drivers/flash_m25p16.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <stdint.h>
-#include "flash.h"
 #include "io_types.h"
 
 #define M25P16_PAGESIZE 256
@@ -39,4 +38,5 @@ int m25p16_readBytes(uint32_t address, uint8_t *buffer, int length);
 bool m25p16_isReady();
 bool m25p16_waitForReady(uint32_t timeoutMillis);
 
-const flashGeometry_t* m25p16_getGeometry();
+struct flashGeometry_s;
+const struct flashGeometry_s* m25p16_getGeometry();

--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -24,11 +24,11 @@ typedef enum {
 
 #define PPM_RCVR_TIMEOUT            0
 
+struct timerHardware_s;
+void ppmInConfig(const struct timerHardware_s *timerHardwarePtr);
+void ppmAvoidPWMTimerClash(const struct timerHardware_s *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer, uint8_t pwmProtocol);
 
-void ppmInConfig(const timerHardware_t *timerHardwarePtr);
-void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer, uint8_t pwmProtocol);
-
-void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel);
+void pwmInConfig(const struct timerHardware_s *timerHardwarePtr, uint8_t channel);
 uint16_t pwmRead(uint8_t channel);
 uint16_t ppmRead(uint8_t channel);
 

--- a/src/main/fc/mw.h
+++ b/src/main/fc/mw.h
@@ -19,7 +19,8 @@
 
 extern int16_t magHold;
 
-void applyAndSaveAccelerometerTrimsDelta(rollAndPitchTrims_t *rollAndPitchTrimsDelta);
+union rollAndPitchTrims_u;
+void applyAndSaveAccelerometerTrimsDelta(union rollAndPitchTrims_u *rollAndPitchTrimsDelta);
 void handleInflightCalibrationStickPosition();
 
 void mwDisarm(void);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -79,14 +79,16 @@ void imuConfigure(
 
 float getCosTiltAngle(void);
 void calculateEstimatedAltitude(uint32_t currentTime);
-void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims);
+union rollAndPitchTrims_u;
+void imuUpdateAccelerometer(union rollAndPitchTrims_u *accelerometerTrims);
 void imuUpdateAttitude(uint32_t currentTime);
 float calculateThrottleAngleScale(uint16_t throttle_correction_angle);
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value);
 float calculateAccZLowPassFilterRCTimeConstant(float accz_lpf_hz);
 
-int16_t imuCalculateHeading(t_fp_vector *vec);
+union u_fp_vector;
+int16_t imuCalculateHeading(union u_fp_vector *vec);
 
 void imuResetAccelerationSum(void);
-void imuUpdateAcc(rollAndPitchTrims_t *accelerometerTrims);
+void imuUpdateAcc(union rollAndPitchTrims_u *accelerometerTrims);
 void imuInit(void);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -114,7 +114,7 @@ void pidLegacy(const pidProfile_t *pidProfile, uint16_t max_angle_inclination,
 void pidBetaflight(const pidProfile_t *pidProfile, uint16_t max_angle_inclination,
         const union rollAndPitchTrims_u *angleTrim, const struct rxConfig_s *rxConfig);
 
-extern int16_t axisPID[XYZ_AXIS_COUNT];
+extern int16_t axisPID[3];
 extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 bool airmodeWasActivated;
 extern uint32_t targetPidLooptime;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -402,7 +402,7 @@ bool isBeeperOn(void) {
 void beeper(beeperMode_e mode) {UNUSED(mode);}
 void beeperSilence(void) {}
 void beeperConfirmationBeeps(uint8_t beepCount) {UNUSED(beepCount);}
-void beeperUpdate(uint32_t currentTime) {}
+void beeperUpdate(uint32_t currentTime) {UNUSED(currentTime);}
 uint32_t getArmingBeepTimeMicros(void) {return 0;}
 beeperMode_e beeperModeForTableIndex(int idx) {UNUSED(idx); return BEEPER_SILENCE;}
 const char *beeperNameForTableIndex(int idx) {UNUSED(idx); return NULL;}

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -33,8 +33,10 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "drivers/flash.h"
 #include "drivers/flash_m25p16.h"
-#include "flashfs.h"
+
+#include "io/flashfs.h"
 
 static uint8_t flashWriteBuffer[FLASHFS_WRITE_BUFFER_SIZE];
 

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -17,10 +17,6 @@
 
 #pragma once
 
-#include <stdint.h>
-
-#include "drivers/flash.h"
-
 #define FLASHFS_WRITE_BUFFER_SIZE 128
 #define FLASHFS_WRITE_BUFFER_USABLE (FLASHFS_WRITE_BUFFER_SIZE - 1)
 
@@ -35,7 +31,8 @@ uint32_t flashfsGetOffset();
 uint32_t flashfsGetWriteBufferFreeSpace();
 uint32_t flashfsGetWriteBufferSize();
 int flashfsIdentifyStartOfFreeSpace();
-const flashGeometry_t* flashfsGetGeometry();
+struct flashGeometry_s;
+const struct flashGeometry_s* flashfsGetGeometry();
 
 void flashfsSeekAbs(uint32_t offset);
 void flashfsSeekRel(int32_t offset);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -22,91 +22,28 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
-#include <math.h>
 #include <ctype.h>
 
 #include "platform.h"
 
 #ifdef OSD
 
-#include "build/atomic.h"
-#include "build/build_config.h"
-#include "build/debug.h"
 #include "build/version.h"
 
-#include "scheduler/scheduler.h"
+#include "common/utils.h"
 
-#include "common/axis.h"
-#include "common/color.h"
-#include "common/maths.h"
-#include "common/typeconversion.h"
-
-#include "drivers/nvic.h"
-
-#include "drivers/sensor.h"
 #include "drivers/system.h"
-#include "drivers/gpio.h"
-#include "drivers/light_led.h"
-#include "drivers/sound_beeper.h"
-#include "drivers/timer.h"
-#include "drivers/serial.h"
-#include "drivers/serial_softserial.h"
-#include "drivers/serial_uart.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/pwm_mapping.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/adc.h"
-#include "drivers/bus_i2c.h"
-#include "drivers/bus_spi.h"
-#include "drivers/inverter.h"
-#include "drivers/flash_m25p16.h"
-#include "drivers/sonar_hcsr04.h"
-#include "drivers/usb_io.h"
-#include "drivers/transponder_ir.h"
-#include "drivers/sdcard.h"
 
-#include "rx/rx.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
 #include "io/flashfs.h"
-#include "io/gps.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "io/gimbal.h"
-#include "io/ledstrip.h"
-#include "io/display.h"
-#include "io/asyncfatfs/asyncfatfs.h"
-#include "io/transponder_ir.h"
 #include "io/osd.h"
 
-#include "sensors/sensors.h"
-#include "sensors/sonar.h"
-#include "sensors/barometer.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/gyro.h"
-#include "sensors/battery.h"
-#include "sensors/boardalignment.h"
-#include "sensors/initialisation.h"
-
-#include "telemetry/telemetry.h"
-#include "blackbox/blackbox.h"
-
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/mixer.h"
-#include "flight/failsafe.h"
-#include "flight/navigation.h"
-
+#include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
+#include "flight/pid.h"
+
 #include "config/config.h"
-#include "config/config_eeprom.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
 #include "config/feature.h"

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -27,19 +27,20 @@
 #include "build/debug.h"
 #include "build/version.h"
 
+#include "blackbox/blackbox.h"
+
 #include "common/axis.h"
 #include "common/color.h"
 #include "common/maths.h"
 
 #include "drivers/system.h"
-
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/compass.h"
-
 #include "drivers/serial.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/io.h"
+#include "drivers/flash.h"
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
@@ -47,13 +48,14 @@
 #include "drivers/buf_writer.h"
 #include "drivers/max7456.h"
 #include "drivers/vtx_soft_spi_rtc6705.h"
-#include "rx/rx.h"
-#include "rx/msp.h"
+
+#include "fc/mw.h"
+#include "fc/rc_controls.h"
+#include "fc/runtime_config.h"
 
 #include "io/beeper.h"
 #include "io/motors.h"
 #include "io/servos.h"
-#include "fc/rc_controls.h"
 #include "io/gps.h"
 #include "io/gimbal.h"
 #include "io/serial.h"
@@ -62,10 +64,13 @@
 #include "io/transponder_ir.h"
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/osd.h"
+#include "io/serial_4way.h"
+#include "io/serial_msp.h"
 #include "io/vtx.h"
 #include "io/msp_protocol.h"
 
-#include "telemetry/telemetry.h"
+#include "rx/rx.h"
+#include "rx/msp.h"
 
 #include "scheduler/scheduler.h"
 
@@ -78,18 +83,14 @@
 #include "sensors/compass.h"
 #include "sensors/gyro.h"
 
+#include "telemetry/telemetry.h"
+
 #include "flight/mixer.h"
 #include "flight/pid.h"
 #include "flight/imu.h"
 #include "flight/failsafe.h"
 #include "flight/navigation.h"
 #include "flight/altitudehold.h"
-
-#include "blackbox/blackbox.h"
-
-#include "fc/mw.h"
-
-#include "fc/runtime_config.h"
 
 #include "config/config.h"
 #include "config/config_eeprom.h"
@@ -100,10 +101,6 @@
 #ifdef USE_HARDWARE_REVISION_DETECTION
 #include "hardware_revision.h"
 #endif
-
-#include "serial_msp.h"
-
-#include "io/serial_4way.h"
 
 static serialPort_t *mspSerialPort;
 

--- a/src/main/io/serial_msp.h
+++ b/src/main/io/serial_msp.h
@@ -32,8 +32,9 @@ typedef enum {
 
 #define MSP_PORT_INBUF_SIZE 64
 
+struct serialPort_s;
 typedef struct mspPort_s {
-    serialPort_t *port; // null when port unused.
+    struct serialPort_s *port; // null when port unused.
     uint8_t offset;
     uint8_t dataSize;
     uint8_t checksum;

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -17,62 +17,25 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "platform.h"
 
 #ifdef VTX
 
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/maths.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
 #include "drivers/vtx_rtc6705.h"
 
+#include "fc/rc_controls.h"
+#include "fc/runtime_config.h"
 
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
+#include "flight/pid.h"
 
 #include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
 #include "io/vtx.h"
 
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
 #include "config/config.h"
+#include "config/config_eeprom.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
-#include "config/config_eeprom.h"
-#include "fc/runtime_config.h"
 
 
 static uint8_t locked = 0;

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -43,6 +43,7 @@
 #include "drivers/accgyro_lsm303dlhc.h"
 
 #include "drivers/bus_spi.h"
+#include "drivers/accgyro_spi_icm20689.h"
 #include "drivers/accgyro_spi_mpu6000.h"
 #include "drivers/accgyro_spi_mpu6500.h"
 #include "drivers/accgyro_spi_mpu9250.h"

--- a/src/main/target/ALIENFLIGHTF1/config.c
+++ b/src/main/target/ALIENFLIGHTF1/config.c
@@ -15,61 +15,23 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/filter.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
 #include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
 
 #include "rx/rx.h"
 
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
-
 #include "config/config.h"
-
 #include "config/config_profile.h"
 #include "config/config_master.h"
+
 
 // alternative defaults settings for AlienFlight targets
 void targetConfiguration(master_t *config)

--- a/src/main/target/ALIENFLIGHTF3/config.c
+++ b/src/main/target/ALIENFLIGHTF3/config.c
@@ -15,70 +15,35 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
 #include "common/axis.h"
-#include "common/filter.h"
 
 #include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
 
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
 #include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
 
 #include "rx/rx.h"
 
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
 
 #include "config/config.h"
-
 #include "config/config_profile.h"
 #include "config/config_master.h"
 
+
 // alternative defaults settings for AlienFlight targets
-void targetConfiguration(master_t *config) {
+void targetConfiguration(master_t *config)
+{
     config->mag_hardware = MAG_NONE;            // disabled by default
     config->rxConfig.spektrum_sat_bind = 5;
     config->rxConfig.spektrum_sat_bind_autoreset = 1;

--- a/src/main/target/ALIENFLIGHTF3/hardware_revision.h
+++ b/src/main/target/ALIENFLIGHTF3/hardware_revision.h
@@ -16,8 +16,6 @@
  */
 #pragma once
 
-#include "drivers/exti.h"
-
 typedef enum awf3HardwareRevision_t {
     UNKNOWN = 0,
     AFF3_REV_1, // MPU6050 / MPU9150 (I2C)
@@ -29,4 +27,5 @@ extern uint8_t hardwareRevision;
 void updateHardwareRevision(void);
 void detectHardwareRevision(void);
 
-const extiConfig_t *selectMPUIntExtiConfigByHardwareRevision(void);
+struct extiConfig_s;
+const struct extiConfig_s *selectMPUIntExtiConfigByHardwareRevision(void);

--- a/src/main/target/ALIENFLIGHTF4/config.c
+++ b/src/main/target/ALIENFLIGHTF4/config.c
@@ -15,70 +15,35 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
 #include "common/axis.h"
-#include "common/filter.h"
 
 #include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
 
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
 #include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
 
 #include "rx/rx.h"
 
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
 
 #include "config/config.h"
-
 #include "config/config_profile.h"
 #include "config/config_master.h"
 
+
 // alternative defaults settings for AlienFlight targets
-void targetConfiguration(master_t *config) {
+void targetConfiguration(master_t *config)
+{
     config->mag_hardware = MAG_NONE;            // disabled by default
     config->rxConfig.spektrum_sat_bind = 5;
     config->rxConfig.spektrum_sat_bind_autoreset = 1;

--- a/src/main/target/BLUEJAYF4/config.c
+++ b/src/main/target/BLUEJAYF4/config.c
@@ -19,65 +19,10 @@
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/filter.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
-
-#include "config/config.h"
-
-#include "config/config_profile.h"
 #include "config/config_master.h"
 
 #include "hardware_revision.h"
+
 
 // alternative defaults settings for BlueJayF4 targets
 void targetConfiguration(master_t *config)

--- a/src/main/target/CJMCU/hardware_revision.h
+++ b/src/main/target/CJMCU/hardware_revision.h
@@ -16,9 +16,7 @@
  */
 #pragma once
 
- #include "drivers/exti.h"
-
-typedef enum cjmcuHardwareRevision_t {
+ typedef enum cjmcuHardwareRevision_t {
     UNKNOWN = 0,
     REV_1, // Blue LED3
     REV_2  // Green LED3
@@ -31,4 +29,5 @@ void detectHardwareRevision(void);
 
 void spiBusInit(void);
 
-const extiConfig_t *selectMPUIntExtiConfigByHardwareRevision(void);
+struct extiConfig_s;
+const struct extiConfig_s *selectMPUIntExtiConfigByHardwareRevision(void);

--- a/src/main/target/COLIBRI/config.c
+++ b/src/main/target/COLIBRI/config.c
@@ -17,67 +17,25 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "platform.h"
 
-#include "build/build_config.h"
-#include "build/debug.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/maths.h"
-#include "common/filter.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
 #include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
 
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
 #include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
 
 #include "flight/mixer.h"
 #include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
 
-#include "fc/runtime_config.h"
+#include "io/motors.h"
+#include "io/serial.h"
+
+#include "rx/rx.h"
+
 #include "config/config.h"
-
 #include "config/config_profile.h"
 #include "config/config_master.h"
+
 
 // alternative defaults settings for Colibri/Gemini targets
 void targetConfiguration(master_t *config)

--- a/src/main/target/COLIBRI_RACE/config.c
+++ b/src/main/target/COLIBRI_RACE/config.c
@@ -15,70 +15,22 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <platform.h>
 
-#include "build/build_config.h"
+#include "io/motors.h"
 
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/filter.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
 #include "sensors/battery.h"
 
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
-
 #include "config/config.h"
-
-#include "config/config_profile.h"
 #include "config/config_master.h"
 
+
 // alternative defaults settings for COLIBRI RACE targets
-void targetConfiguration(master_t *config) {
+void targetConfiguration(master_t *config)
+{
     config->motorConfig.minthrottle = 1025;
     config->motorConfig.maxthrottle = 1980;
     config->batteryConfig.vbatmaxcellvoltage = 45;

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -63,8 +63,10 @@
 #include "fc/runtime_config.h"
 
 #include "config/config.h"
+#include "config/config_eeprom.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
+#include "config/feature.h"
 
 #ifdef NAZE
 #include "hardware_revision.h"

--- a/src/main/target/MOTOLAB/config.c
+++ b/src/main/target/MOTOLAB/config.c
@@ -15,70 +15,18 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/filter.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
-#include "rx/rx.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "fc/runtime_config.h"
-
 #include "config/config.h"
-
-#include "config/config_profile.h"
 #include "config/config_master.h"
 
+
 // Motolab target supports 2 different type of boards Tornado / Cyclone.
-void targetConfiguration(master_t *config) {
+void targetConfiguration(master_t *config)
+{
     config->gyro_sync_denom = 4;
     config->pid_process_denom = 1;
 }

--- a/src/main/target/NAZE/hardware_revision.h
+++ b/src/main/target/NAZE/hardware_revision.h
@@ -16,8 +16,6 @@
  */
 #pragma once
 
-#include "drivers/exti.h"
-
 typedef enum nazeHardwareRevision_t {
     UNKNOWN = 0,
     NAZE32, // Naze32 and compatible with 8MHz HSE
@@ -32,4 +30,5 @@ void detectHardwareRevision(void);
 
 void spiBusInit(void);
 
-const extiConfig_t *selectMPUIntExtiConfigByHardwareRevision(void);
+struct extiConfig_s;
+const struct extiConfig_s *selectMPUIntExtiConfigByHardwareRevision(void);

--- a/src/main/target/RACEBASE/config.c
+++ b/src/main/target/RACEBASE/config.c
@@ -15,70 +15,20 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "common/color.h"
-#include "common/axis.h"
-#include "common/filter.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_output.h"
-#include "drivers/max7456.h"
-#include "drivers/io.h"
-#include "drivers/pwm_mapping.h"
-
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "fc/runtime_config.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-#include "io/osd.h"
-#include "io/vtx.h"
-
 #include "rx/rx.h"
 
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
 #include "config/config.h"
-
-#include "config/config_profile.h"
 #include "config/config_master.h"
 
+
 // alternative defaults settings for COLIBRI RACE targets
-void targetConfiguration(master_t *config) {
+void targetConfiguration(master_t *config)
+{
     config->rxConfig.sbus_inversion = 0;
     config->rxConfig.rssi_scale = 19;
     config->rxConfig.serialrx_provider = SERIALRX_SBUS;

--- a/src/main/target/RACEBASE/hardware_revision.h
+++ b/src/main/target/RACEBASE/hardware_revision.h
@@ -16,8 +16,6 @@
  */
 #pragma once
 
-#include "drivers/exti.h"
-
 extern uint8_t hardwareRevision;
 
 void updateHardwareRevision(void);


### PR DESCRIPTION
Removed subsequently unrequired `#includes` from `.c` files.

Also use forward references to remove some header file dependencies.

Some header file tidying.

Part of issue https://github.com/betaflight/betaflight/issues/941 - Preparation for conversion to parameter groups