### PR TITLE
Clean up vtx.c includes, move all not directly used to where they belong.

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #if FLASH_SIZE <= 128
 #define MAX_PROFILE_COUNT 2
 #else

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -17,49 +17,38 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include <stdint.h>
 #include <stdlib.h>
 
-#include "common/color.h"
-#include "common/axis.h"
+#include "config/config_profile.h"
 
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/pwm_rx.h"
-#include "drivers/serial.h"
 
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/imu.h"
+#include "flight/navigation.h"
 
 #include "io/serial.h"
 #include "io/gimbal.h"
 #include "io/motors.h"
 #include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "io/ledstrip.h"
 #include "io/gps.h"
 #include "io/osd.h"
+#include "io/ledstrip.h"
 #include "io/vtx.h"
 
 #include "rx/rx.h"
 
 #include "telemetry/telemetry.h"
 
-#include "flight/mixer.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/altitudehold.h"
-#include "flight/navigation.h"
-
-#include "config/config.h"
-#include "config/config_profile.h"
-#include "config/config_master.h"
+#include "sensors/sensors.h"
+#include "sensors/gyro.h"
+#include "sensors/acceleration.h"
+#include "sensors/boardalignment.h"
+#include "sensors/barometer.h"
+#include "sensors/battery.h"
 
 
 // System-wide

--- a/src/main/config/config_profile.h
+++ b/src/main/config/config_profile.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+#include "config/config.h"
+#include "common/axis.h"
+#include "fc/rc_controls.h"
+#include "flight/pid.h"
+
 typedef struct profile_s {
     pidProfile_t pidProfile;
     uint8_t activeRateProfile;

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "drivers/sensor.h"
+
 #ifndef MPU_I2C_INSTANCE
 #define MPU_I2C_INSTANCE I2C_DEVICE
 #endif

--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -26,7 +26,6 @@ typedef enum {
 
 #define PPM_RCVR_TIMEOUT            0
 
-struct timerHardware_s;
 void ppmInConfig(const struct timerHardware_s *timerHardwarePtr);
 void ppmAvoidPWMTimerClash(const struct timerHardware_s *timerHardwarePtr, TIM_TypeDef *sharedPwmTimer, uint8_t pwmProtocol);
 

--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "drivers/timer.h"
+
 typedef enum {
     INPUT_FILTERING_DISABLED = 0,
     INPUT_FILTERING_ENABLED

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 typedef enum {
     BOXARM = 0,
     BOXANGLE,

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "sensors/acceleration.h"
+
 extern int16_t throttleAngleCorrection;
 extern uint32_t accTimeSum;
 extern int accSumCount;

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -22,6 +22,13 @@
 
 #include "sensors/acceleration.h"
 
+// Exported symbols
+extern uint32_t accTimeSum;
+extern int accSumCount;
+extern float accVelScale;
+extern int32_t accSum[XYZ_AXIS_COUNT];
+
+
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)
 #define DECIDEGREES_TO_DEGREES(angle) (angle / 10)
 #define DECIDEGREES_TO_RADIANS(angle) ((angle / 10.0f) * 0.0174532925f)

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -22,12 +22,6 @@
 
 #include "sensors/acceleration.h"
 
-extern int16_t throttleAngleCorrection;
-extern uint32_t accTimeSum;
-extern int accSumCount;
-extern float accVelScale;
-extern int32_t accSum[XYZ_AXIS_COUNT];
-
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)
 #define DECIDEGREES_TO_DEGREES(angle) (angle / 10)
 #define DECIDEGREES_TO_RADIANS(angle) ((angle / 10.0f) * 0.0174532925f)

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #define GYRO_I_MAX 256                      // Gyro I limiter
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <string.h>
 #include "common/color.h"
 
 #define LED_MAX_STRIP_LENGTH           32

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <string.h>
+#include "common/color.h"
+
 #define LED_MAX_STRIP_LENGTH           32
 #define LED_CONFIGURABLE_COLOR_COUNT   16
 #define LED_MODE_COUNT                  6

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "drivers/serial.h"
+
 typedef enum {
     PORTSHARING_UNUSED = 0,
     PORTSHARING_NOT_SHARED,

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -15,27 +15,21 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdbool.h>
-#include <stdint.h>
 
+// Get target build configuration
 #include "platform.h"
 
 #ifdef VTX
 
-#include "drivers/vtx_rtc6705.h"
-
-#include "fc/rc_controls.h"
-#include "fc/runtime_config.h"
-
-#include "flight/pid.h"
-
-#include "io/beeper.h"
+// Own interfaces
 #include "io/vtx.h"
 
-#include "config/config.h"
-#include "config/config_eeprom.h"
-#include "config/config_profile.h"
+//External dependencies
 #include "config/config_master.h"
+#include "config/config_eeprom.h"
+#include "drivers/vtx_rtc6705.h"
+#include "fc/runtime_config.h"
+#include "io/beeper.h"
 
 
 static uint8_t locked = 0;

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "fc/rc_controls.h"
+
 #define VTX_BAND_MIN                            1
 #define VTX_BAND_MAX                            5
 #define VTX_CHANNEL_MIN                         1

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include "drivers/accgyro.h"
+#include "sensors/sensors.h"
+
 // Type of accelerometer used/detected
 typedef enum {
     ACC_DEFAULT = 0,

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include "drivers/accgyro.h"
+#include "common/axis.h"
+
 typedef enum {
     GYRO_NONE = 0,
     GYRO_DEFAULT,


### PR DESCRIPTION
My contribution on the include tree refactoring started by PR #1243 . Rebased and conflicts resolved.

No real analysis of deps done. Used compiler in a T&E way by removing ALL includes in vtx.c then adding them back one by one in the file where the compiler finds a missing declaration. This will/may of course still leave some indirect deps somewhere in the include-tree. But the root (vtx.c) is cleaner at least. Doing this on each and every *.c file is a daunting and tedious task, really impossible if done manually.... But we can pick the ones with unreasonably large include sections one by one, and eventually the code will be cleaner. 
