### PR TITLE
Fix missing baro support for AIRHEROF3 target

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -490,7 +490,7 @@ static bool detectBaro(baroSensor_e baroHardwareToUse)
 #endif
             ; // fallthough
         case BARO_BMP280:
-#ifdef USE_BARO_BMP280
+#if defined(USE_BARO_BMP280) || defined(USE_BARO_SPI_BMP280)
             if (bmp280Detect(&baro)) {
                 baroHardware = BARO_BMP280;
                 break;

--- a/src/main/target/AIRHEROF3/target.mk
+++ b/src/main/target/AIRHEROF3/target.mk
@@ -5,6 +5,7 @@ TARGET_SRC = \
             drivers/accgyro_mpu.c \
             drivers/accgyro_mpu6500.c \
             drivers/accgyro_spi_mpu6500.c \
+            drivers/barometer_bmp280.c \
             drivers/barometer_spi_bmp280.c \
             drivers/light_ws2811strip.c \
             drivers/light_ws2811strip_stm32f30x.c \


### PR DESCRIPTION
MWC's AirF3 boards have a BMP280 baro onboard. This PR enables support for it.