### PR TITLE
Fix micros using COUNTFLAG

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -122,6 +122,7 @@ uint32_t micros(void)
          */
         asm volatile("\tnop\n");
     } while (ms != sysTickUptime);
+
     return (ms * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
 }
 

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -24,6 +24,7 @@
 #include "light_led.h"
 #include "sound_beeper.h"
 #include "nvic.h"
+#include "common/atomic.h"
 
 #include "system.h"
 
@@ -61,15 +62,56 @@ void cycleCounterInit(void)
 }
 
 // SysTick
+
+static volatile int sysTickPending = 0;
+
 void SysTick_Handler(void)
 {
-    sysTickUptime++;
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        sysTickUptime++;
+        sysTickPending = 0;
+        (void)(SysTick->CTRL);
+    }
 }
 
 // Return system uptime in microseconds (rollover in 70minutes)
+
+uint32_t microsISR(void)
+{
+    register uint32_t ms, cycle_cnt;
+
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        cycle_cnt = SysTick->VAL;
+
+        if (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) {
+            // Update pending.
+            // Remember it for multiple calls within the same rollover period
+            // (Will be cleared when serviced).
+            // Note that multiple rollovers are not considered.
+
+            sysTickPending = 1;
+
+            // Read VAL again to ensure the value is read after the rollover.
+
+            cycle_cnt = SysTick->VAL;
+        }
+
+        ms = sysTickUptime;
+    }
+
+    return ((ms + sysTickPending) * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
+}
+
 uint32_t micros(void)
 {
     register uint32_t ms, cycle_cnt;
+
+    // Call microsISR() in interrupt and elevated (non-zero) BASEPRI context
+
+    if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) || (__get_BASEPRI())) {
+        return microsISR();
+    }
+
     do {
         ms = sysTickUptime;
         cycle_cnt = SysTick->VAL;

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -78,7 +78,7 @@ void SysTick_Handler(void)
 
 uint32_t microsISR(void)
 {
-    register uint32_t ms, cycle_cnt;
+    register uint32_t ms, pending, cycle_cnt;
 
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
         cycle_cnt = SysTick->VAL;
@@ -97,9 +97,10 @@ uint32_t microsISR(void)
         }
 
         ms = sysTickUptime;
+        pending = sysTickPending;
     }
 
-    return ((ms + sysTickPending) * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
+    return ((ms + pending) * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
 }
 
 uint32_t micros(void)

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -85,7 +85,7 @@ uint32_t microsISR(void)
 
         if (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) {
             // Update pending.
-            // Remember it for multiple calls within the same rollover period
+            // Record it for multiple calls within the same rollover period
             // (Will be cleared when serviced).
             // Note that multiple rollovers are not considered.
 

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -24,7 +24,7 @@
 #include "light_led.h"
 #include "sound_beeper.h"
 #include "nvic.h"
-#include "common/atomic.h"
+#include "build/atomic.h"
 
 #include "system.h"
 

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -22,6 +22,7 @@ void delayMicroseconds(uint32_t us);
 void delay(uint32_t ms);
 
 uint32_t micros(void);
+uint32_t microsISR(void);
 uint32_t millis(void);
 
 typedef enum {


### PR DESCRIPTION
Current micros() may return past time when called from ISR or elevated BASEPRI context. This is because a call to the SysTick interrupt handler sysTick_Hanlder(), which is responsible for 1ms rollover is blocked in these contexts.

This PR introduces microsISR() that is guranteed to return correct time in these contexts. Legacy micros() was also modified to call microISR() in these contexts.

The microISR() uses SysTick's COUNTFLAG to detect a pending rollover and use it to compensate the return value on its own. Actual rollover to sysTickUptime variable is still handled in the sysTick_Hanlder().