### PR TITLE
Fix pwm value overflow for Brushed

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -17,7 +17,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <math.h>
+#include "common/maths.h"
 
 #include "platform.h"
 
@@ -130,6 +130,7 @@ static pwmOutputPort_t *pwmOutConfig(const timerHardware_t *timerHardware, uint8
 
 static void pwmWriteBrushed(uint8_t index, uint16_t value)
 {
+    value = constrain(value, 1000, 2000);
     *motors[index]->ccr = (value - 1000) * motors[index]->period / 1000;
 }
 

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -130,7 +130,6 @@ static pwmOutputPort_t *pwmOutConfig(const timerHardware_t *timerHardware, uint8
 
 static void pwmWriteBrushed(uint8_t index, uint16_t value)
 {
-    value = constrain(value, 1000, 2000); // Fix pwm value overflow
     *motors[index]->ccr = (value - 1000) * motors[index]->period / 1000;
 }
 

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -130,6 +130,7 @@ static pwmOutputPort_t *pwmOutConfig(const timerHardware_t *timerHardware, uint8
 
 static void pwmWriteBrushed(uint8_t index, uint16_t value)
 {
+    value = constrain(value, 1000, 2000); // Fix pwm value overflow
     *motors[index]->ccr = (value - 1000) * motors[index]->period / 1000;
 }
 


### PR DESCRIPTION
Setting mincommand below 1000 will cause brushed quad to spin at nearly max throttle due to an uint overflow. Adding a constrain to limit the value in the valid range.