### PR TITLE
Improved efficiency of FIR filters by avoiding memmov and caching moving sum

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -156,12 +156,12 @@ void firFilterUpdate(firFilter_t *filter, float input)
 float firFilterApply(const firFilter_t *filter)
 {
     float ret = 0.0f;
-    int index = filter->index;
-    for (int ii = 0; ii < filter->coeffsLength; ++ii) {
-        --index;
-        if (index < 0) {
-            index = filter->bufLength - 1;
-        }
+    int ii = 0;
+    int index;
+    for (index = filter->index - 1; index >= 0; ++ii, --index) {
+        ret += filter->coeffs[ii] * filter->buf[index];
+    }
+    for (index = filter->bufLength - 1; ii < filter->coeffsLength; ++ii, --index) {
         ret += filter->coeffs[ii] * filter->buf[index];
     }
     return ret;

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -142,6 +142,17 @@ void firFilterInit(firFilter_t *filter, float *buf, uint8_t bufLength, const flo
 
 void firFilterUpdate(firFilter_t *filter, float input)
 {
+    filter->buf[filter->index++] = input; // index is at the first empty buffer positon
+    if (filter->index >= filter->bufLength) {
+        filter->index = 0;
+    }
+}
+
+/*
+ * Update FIR filter maintaining a moving sum for quick moving average computation
+ */
+void firFilterUpdateAverage(firFilter_t *filter, float input)
+{
     filter->movingSum += input; // sum of the last <count> items, to allow quick moving average computation
     filter->movingSum -=  filter->buf[filter->index]; // subtract the value that "drops off" the end of the moving sum
     filter->buf[filter->index++] = input; // index is at the first empty buffer positon

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -78,6 +78,7 @@ float pt1FilterApply4(pt1Filter_t *filter, float input, uint8_t f_cut, float dT)
 void firFilterInit(firFilter_t *filter, float *buf, uint8_t bufLength, const float *coeffs);
 void firFilterInit2(firFilter_t *filter, float *buf, uint8_t bufLength, const float *coeffs, uint8_t coeffsLength);
 void firFilterUpdate(firFilter_t *filter, float input);
+void firFilterUpdateAverage(firFilter_t *filter, float input);
 float firFilterApply(const firFilter_t *filter);
 float firFilterCalcPartialAverage(const firFilter_t *filter, uint8_t count);
 float firFilterCalcMovingAverage(const firFilter_t *filter);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -51,6 +51,9 @@ typedef enum {
 typedef struct firFilter_s {
     float *buf;
     const float *coeffs;
+    float movingSum;
+    uint8_t index;
+    uint8_t count;
     uint8_t bufLength;
     uint8_t coeffsLength;
 } firFilter_t;
@@ -77,9 +80,8 @@ void firFilterInit2(firFilter_t *filter, float *buf, uint8_t bufLength, const fl
 void firFilterUpdate(firFilter_t *filter, float input);
 float firFilterApply(const firFilter_t *filter);
 float firFilterCalcPartialAverage(const firFilter_t *filter, uint8_t count);
-float firFilterCalcAverage(const firFilter_t *filter);
+float firFilterCalcMovingAverage(const firFilter_t *filter);
 float firFilterLastInput(const firFilter_t *filter);
-float firFilterGet(const firFilter_t *filter, int index);
 
 void firFilterInt16Init(firFilterInt16_t *filter, int16_t *buf, uint8_t bufLength, const float *coeffs);
 void firFilterInt16Init2(firFilterInt16_t *filter, int16_t *buf, uint8_t bufLength, const float *coeffs, uint8_t coeffsLength);


### PR DESCRIPTION
Input values are now stored in a circular buffer. A moving sum is maintained to enable quick calculation of moving average.