### PR TITLE
add guard around taskUpdateBeeper to remove unused error

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -99,10 +99,12 @@ static void taskHandleSerial(uint32_t currentTime)
     mspSerialProcess();
 }
 
+#ifdef BEEPER
 static void taskUpdateBeeper(uint32_t currentTime)
 {
     beeperUpdate(currentTime);          //call periodic beeper handler
 }
+#endif
 
 static void taskUpdateBattery(uint32_t currentTime)
 {
@@ -489,5 +491,3 @@ cfTask_t cfTasks[TASK_COUNT] = {
     },
 #endif
 };
-
-


### PR DESCRIPTION
add guard around taskUpdateBeeper to remove unused error, also removed tailing whitespaces at the end of the file.