### PR TITLE
 Fix pwm value overflow for Brushed when mincommand is set below 1000

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -738,6 +738,10 @@ void activateConfig(void)
 
 void validateAndFixConfig(void)
 {
+    if((masterConfig.motorConfig.motorPwmProtocol == PWM_TYPE_BRUSHED) && (masterConfig.motorConfig.mincommand < 1000)){
+        masterConfig.motorConfig.mincommand = 1000;
+    }
+
     if (!(featureConfigured(FEATURE_RX_PARALLEL_PWM) || featureConfigured(FEATURE_RX_PPM) || featureConfigured(FEATURE_RX_SERIAL) || featureConfigured(FEATURE_RX_MSP) || featureConfigured(FEATURE_RX_SPI))) {
         featureSet(DEFAULT_RX_FEATURE);
     }


### PR DESCRIPTION
 Fix pwm value overflow for Brushed when mincommand is set below 1000. Now mincommand can't be set below 1000 if protocol is brushed.