### PR TITLE
ICM20689 Gyro Fix

### DIFF
--- a/src/main/drivers/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro_spi_icm20689.c
@@ -81,16 +81,30 @@ static void icm20689SpiInit(void)
 bool icm20689SpiDetect(void)
 {
     uint8_t tmp;
-
+    uint8_t attemptsRemaining = 20;
+    
     icm20689SpiInit();
+    
+    spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
 
-    icm20689ReadRegister(MPU_RA_WHO_AM_I, 1, &tmp);
+    icm20689WriteRegister(MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
 
-    if (tmp == ICM20689_WHO_AM_I_CONST) {
-        return true;
-    }
+    do {
+        delay(150);
 
-    return false;
+        icm20689ReadRegister(MPU_RA_WHO_AM_I, 1, &tmp);
+        if (tmp == ICM20689_WHO_AM_I_CONST) {
+            break;
+        }
+        if (!attemptsRemaining) {
+            return false;
+        }
+    } while (attemptsRemaining--);
+
+    spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_FAST);
+
+    return true;
+
 }
 
 bool icm20689SpiAccDetect(acc_t *acc)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -241,9 +241,9 @@ static const char * const sensorTypeNames[] = {
 
 #define SENSOR_NAMES_MASK (SENSOR_GYRO | SENSOR_ACC | SENSOR_BARO | SENSOR_MAG)
 
-static const char * const sensorHardwareNames[4][13] = {
+static const char * const sensorHardwareNames[4][12] = {
     { "", "None", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "MPU9250", "ICM20689", "FAKE", NULL },
-    { "", "None", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "MPU9250", "ICM20689", "FAKE", NULL },
+    { "", "None", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "ICM20689", "FAKE", NULL },
     { "", "None", "BMP085", "MS5611", "BMP280", NULL },
     { "", "None", "HMC5883", "AK8975", "AK8963", NULL }
 };

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -31,7 +31,7 @@ typedef enum {
     ACC_LSM303DLHC = 6,
     ACC_MPU6000 = 7,
     ACC_MPU6500 = 8,
-	ACC_ICM20689 = 9,
+    ACC_ICM20689 = 9,
     ACC_FAKE = 10,
     ACC_MAX = ACC_FAKE
 } accelerationSensor_e;


### PR DESCRIPTION
Found that the gyro init needed several attempts to check the WHO_AM_I on the F4 and F7.  Added loop similar to the 9250.   