### PR TITLE
OMNIBUS timerHardware cleanup and I2C support

### DIFF
--- a/src/main/target/OMNIBUS/target.c
+++ b/src/main/target/OMNIBUS/target.c
@@ -35,11 +35,4 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     // UART3 RX/TX
     { TIM2,  IO_TAG(PB10), TIM_Channel_3, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM5  - PB10 - TIM2_CH3 / UART3_TX (AF7)
     { TIM2,  IO_TAG(PB11), TIM_Channel_4, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM6 - PB11 - TIM2_CH4 / UART3_RX (AF7)
-
-    // SDA / SCL
-    { TIM4,  IO_TAG(PB7),  TIM_Channel_2, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 },  // PWM7 - PB7
-    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 },  // PWM8 - PB6
-
-    // LED Strip Pad
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP, GPIO_AF_6 },  // GPIO_TIMER / LED_STRIP
 };

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -49,11 +49,10 @@
 #define USE_BARO_BMP280
 #define USE_BARO_SPI_BMP280
 
-//#define MAG
-//#define USE_MAG_AK8975
-//#define USE_MAG_HMC5883 // External
-//
-//#define MAG_AK8975_ALIGN CW90_DEG_FLIP
+#define MAG // External
+#define USE_MAG_AK8963
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
 
 //#define SONAR
 //#define SONAR_ECHO_PIN          PB1
@@ -78,8 +77,8 @@
 #define UART3_TX_PIN            PB10 // PB10 (AF7)
 #define UART3_RX_PIN            PB11 // PB11 (AF7)
 
-//#define USE_I2C
-//#define I2C_DEVICE (I2CDEV_1) // PB6/SCL, PB7/SDA
+#define USE_I2C
+#define I2C_DEVICE (I2CDEV_1) // PB6/SCL, PB7/SDA
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1
@@ -193,5 +192,5 @@
 #define TARGET_IO_PORTC         (BIT(13)|BIT(14)|BIT(15))
 #define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(4))
 
-#define USABLE_TIMER_CHANNEL_COUNT 10 // 6 Outputs; PPM; LED Strip; 2 additional PWM pins also on UART3 RX/TX pins.
+#define USABLE_TIMER_CHANNEL_COUNT 7 // PPM + 6 Outputs (2 shared with UART3)
 #define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(15))

--- a/src/main/target/OMNIBUS/target.mk
+++ b/src/main/target/OMNIBUS/target.mk
@@ -6,6 +6,9 @@ TARGET_SRC = \
             drivers/accgyro_spi_mpu6000.c \
             drivers/barometer_bmp280.c \
             drivers/barometer_spi_bmp280.c \
+            drivers/compass_ak8963.c \
+            drivers/compass_ak8975.c \
+            drivers/compass_hmc5883l.c \
             drivers/serial_usb_vcp.c \
             drivers/transponder_ir.c \
             drivers/transponder_ir_stm32f30x.c \


### PR DESCRIPTION
- I2C permanently enabled on PWM7 & 8 (J3 and J22)
- Enabled external compass on I2C
- Removed LED_STRIP and I2C from timerHardware array

Completed tests
- [x] PPM functionality
- [x] PWM1-4 functionality
- [x] PWM1-4 ordering on through-holes
- [x] I2C functionality
- [x] LED_STRIP functionality
