### PR TITLE
Refactor to remove duplicate define of UNUSED macro.

### DIFF
--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#define UNUSED(x) (void)(x)
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
 
 #ifdef UNIT_TEST

--- a/src/main/common/printf.c
+++ b/src/main/common/printf.c
@@ -38,6 +38,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/serial.h"
 #include "io/serial.h"
 

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -43,8 +43,6 @@ http://resnet.uoregon.edu/~gurney_j/jmpc/bitwise.html
 #define BITCOUNT(x) (((BX_(x)+(BX_(x)>>4)) & 0x0F0F0F0F) % 255)
 #define BX_(x) ((x) - (((x)>>1)&0x77777777) - (((x)>>2)&0x33333333) - (((x)>>3)&0x11111111))
 
-#define UNUSED(x) (void)(x)
-
 /*
  * https://groups.google.com/forum/?hl=en#!msg/comp.lang.c/attFnqwhvGk/sGBKXvIkY3AJ
  * Return (v ? floor(log2(v)) : 0) when 0 <= v < 1<<[8, 16, 32, 64].

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -21,11 +21,9 @@
 
 #include "platform.h"
 
-#include "build/build_config.h"
 #include "build/debug.h"
 
 #include "common/maths.h"
-
 #include "common/utils.h"
 
 #include "nvic.h"

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -26,6 +26,8 @@
 
 #include "common/maths.h"
 
+#include "common/utils.h"
+
 #include "nvic.h"
 
 #include "system.h"

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -27,6 +27,7 @@
 
 #include "common/axis.h"
 #include "common/maths.h"
+#include "common/utils.h"
 
 #include "system.h"
 #include "bus_i2c.h"

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -22,7 +22,6 @@
 
 #include "platform.h"
 
-#include "build/build_config.h"
 #include "build/debug.h"
 
 #include "common/axis.h"

--- a/src/main/drivers/compass_ak8975.c
+++ b/src/main/drivers/compass_ak8975.c
@@ -28,6 +28,7 @@
 
 #include "common/axis.h"
 #include "common/maths.h"
+#include "common/utils.h"
 
 #include "system.h"
 #include "gpio.h"

--- a/src/main/drivers/compass_ak8975.c
+++ b/src/main/drivers/compass_ak8975.c
@@ -24,8 +24,6 @@
 
 #ifdef USE_MAG_AK8975
 
-#include "build/build_config.h"
-
 #include "common/axis.h"
 #include "common/maths.h"
 #include "common/utils.h"

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -21,8 +21,6 @@
 
 #include <platform.h>
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/gpio.h"

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -23,6 +23,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/gpio.h"
 #include "drivers/sound_beeper.h"
 #include "drivers/system.h"
@@ -392,7 +394,7 @@ int beeperTableEntryCount(void)
 /*
  * Returns true if the beeper is on, false otherwise
  */
-bool isBeeperOn(void) 
+bool isBeeperOn(void)
 {
     return beeperIsOn;
 }

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -29,8 +29,6 @@
 
 #ifdef SERIAL_RX
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/system.h"

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -31,6 +31,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -22,8 +22,6 @@
 
 #ifndef SKIP_RX_MSP
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/system.h"

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -24,6 +24,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/system.h"
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"

--- a/src/main/rx/nrf24_h8_3d.c
+++ b/src/main/rx/nrf24_h8_3d.c
@@ -28,6 +28,7 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
 
 #include "drivers/rx_nrf24l01.h"
 #include "drivers/rx_xn297.h"

--- a/src/main/rx/nrf24_h8_3d.c
+++ b/src/main/rx/nrf24_h8_3d.c
@@ -26,8 +26,6 @@
 
 #ifdef USE_RX_H8_3D
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/rx_nrf24l01.h"

--- a/src/main/rx/nrf24_inav.c
+++ b/src/main/rx/nrf24_inav.c
@@ -26,6 +26,8 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
+#include "common/utils.h"
+
 #include "drivers/rx_nrf24l01.h"
 #include "drivers/system.h"
 

--- a/src/main/rx/nrf24_inav.c
+++ b/src/main/rx/nrf24_inav.c
@@ -23,7 +23,6 @@
 
 #ifdef USE_RX_INAV
 
-#include "build/build_config.h"
 #include "build/debug.h"
 
 #include "common/utils.h"

--- a/src/main/rx/nrf24_v202.c
+++ b/src/main/rx/nrf24_v202.c
@@ -25,6 +25,8 @@
 #include <platform.h>
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 
 #ifdef USE_RX_V202
 

--- a/src/main/rx/nrf24_v202.c
+++ b/src/main/rx/nrf24_v202.c
@@ -23,10 +23,8 @@
 #include <stdlib.h>
 
 #include <platform.h>
-#include "build/build_config.h"
 
 #include "common/utils.h"
-
 
 #ifdef USE_RX_V202
 

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -25,6 +25,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/system.h"
 
 #include "drivers/gpio.h"

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -23,8 +23,6 @@
 
 #ifdef SERIAL_RX
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/system.h"

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -25,6 +25,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/system.h"
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -23,8 +23,6 @@
 
 #ifdef SERIAL_RX
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/system.h"

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -29,8 +29,6 @@
 
 #ifdef SERIAL_RX
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 #include "drivers/system.h"

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -31,6 +31,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -29,6 +29,7 @@
 #include "scheduler/scheduler.h"
 
 #include "common/maths.h"
+#include "common/utils.h"
 
 #include "drivers/system.h"
 

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -23,7 +23,6 @@
 
 #include "platform.h"
 
-#include "build/build_config.h"
 #include "build/debug.h"
 
 #include "scheduler/scheduler.h"

--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -39,8 +39,6 @@
 #include "drivers/system.h"
 #include "drivers/nvic.h"
 
-#include "build/build_config.h"
-
 #include "common/utils.h"
 
 

--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -41,6 +41,8 @@
 
 #include "build/build_config.h"
 
+#include "common/utils.h"
+
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -68,7 +70,7 @@ void Set_System(void)
 {
 #if !defined(STM32L1XX_MD) && !defined(STM32L1XX_HD) && !defined(STM32L1XX_MD_PLUS)
     GPIO_InitTypeDef GPIO_InitStructure;
-#endif /* STM32L1XX_MD && STM32L1XX_XD */ 
+#endif /* STM32L1XX_MD && STM32L1XX_XD */
 
 #if defined(USB_USE_EXTERNAL_PULLUP)
     GPIO_InitTypeDef GPIO_InitStructure;
@@ -277,7 +279,7 @@ static void IntToUnicode(uint32_t value, uint8_t *pbuf, uint8_t len)
 
 /*******************************************************************************
  * Function Name  : Send DATA .
- * Description    : send the data received from the STM32 to the PC through USB 
+ * Description    : send the data received from the STM32 to the PC through USB
  * Input          : None.
  * Output         : None.
  * Return         : None.


### PR DESCRIPTION
Fix for #1339 

Colibri build fails due to unrelated change.