### PR TITLE
Sdk update to 5.4.1 2016q3 (was q2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ compiler: clang
 install:
   - make arm_sdk_install
 
-before_script: tools/gcc-arm-none-eabi-5_4-2016q2/bin/arm-none-eabi-gcc --version
+before_script: tools/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-gcc --version
 script: ./.travis.sh
 
 cache: apt

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ SERIAL_DEVICE   ?= $(firstword $(wildcard /dev/ttyUSB*) no-port-found)
 # Flash size (KB).  Some low-end chips actually have more flash than advertised, use this to override.
 FLASH_SIZE ?=
 
-## Set verbosity level based on the V= parameter
-## V=0 Low
-## v=1 High
+## V                 : Set verbosity level based on the V= parameter
+##                     V=0 Low
+##                     V=1 High
 export AT := @
 
 ifndef V
@@ -67,7 +67,7 @@ INCLUDE_DIRS    = $(SRC_DIR) \
                   $(ROOT)/src/main/target
 LINKER_DIR      = $(ROOT)/src/main/target/link
 
-## Build tools, so we all share the same versions
+# Build tools, so we all share the same versions
 # import macros common to all supported build systems
 include $(ROOT)/make/system-id.mk
 # developer preferences, edit these at will, they'll be gitignored
@@ -902,7 +902,7 @@ cppcheck: $(CSOURCES)
 cppcheck-result.xml: $(CSOURCES)
 	$(V0) $(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
 
-## mkdirs
+# mkdirs
 $(DL_DIR):
 	mkdir -p $@
 
@@ -913,7 +913,7 @@ $(BUILD_DIR):
 	mkdir -p $@
 
 ## help              : print this help message and exit
-help: Makefile
+help: Makefile make/tools.mk
 	$(V0) @echo ""
 	$(V0) @echo "Makefile for the $(FORKNAME) firmware"
 	$(V0) @echo ""
@@ -924,7 +924,7 @@ help: Makefile
 	$(V0) @echo ""
 	$(V0) @echo "Valid TARGET values are: $(VALID_TARGETS)"
 	$(V0) @echo ""
-	$(V0) @sed -n 's/^## //p' $<
+	$(V0) @sed -n 's/^## //p' $?
 
 ## targets           : print a list of all valid target platforms (for consumption by scripts)
 targets:

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -18,6 +18,7 @@ ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-5_4-2016q2
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
 GCC_REQUIRED_VERSION := 5.4.1
 
+## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
 # source: https://launchpad.net/gcc-arm-embedded/5.0/
@@ -48,6 +49,7 @@ else
 	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
 endif
 
+## arm_sdk_clean     : Uninstall Arm SDK
 .PHONY: arm_sdk_clean
 arm_sdk_clean:
 	$(V1) [ ! -d "$(ARM_SDK_DIR)" ] || $(RM) -r $(ARM_SDK_DIR)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -14,24 +14,26 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-5_4-2016q2
+ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-5_4-2016q3
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
 GCC_REQUIRED_VERSION := 5.4.1
 
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
+ARM_SDK_URL_BASE  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926
+
 # source: https://launchpad.net/gcc-arm-embedded/5.0/
 ifdef LINUX
-  arm_sdk_install: ARM_SDK_URL  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2
+  arm_sdk_install: ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-linux.tar.bz2
 endif
 
 ifdef MACOSX
-  arm_sdk_install: ARM_SDK_URL  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-mac.tar.bz2
+  arm_sdk_install: ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-mac.tar.bz2
 endif
 
 ifdef WINDOWS
-  arm_sdk_install: ARM_SDK_URL  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-win32.zip
+  arm_sdk_install: ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip
 endif
 
 arm_sdk_install: ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))


### PR DESCRIPTION
Sdk update to 5.4.1 2016q3 (was q2).

Apparently solves some issue with baro readouts #986 . Would perhaps be good if someone can confirm this, I do not have any FC with baro.

Downside with this update is also slightly larger arm libs, causing target with little or no spare space to fail. I.e. CC3D and CC3D_OPBL. Not sure how to fix this, those targets are minimized already.

    LD betaflight_CC3D.elf
    /home/andho/projects/cleanflight/andwho/betaflight/tools/gcc-arm-none-eabi-5_4-2016q3/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/bin/ld: obj/main/betaflight_CC3D.elf section `._user_heap_stack' will not fit in region `RAM'
    /home/andho/projects/cleanflight/andwho/betaflight/tools/gcc-arm-none-eabi-5_4-2016q3/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/bin/ld: region `RAM' overflowed by 88 bytes
    ......
    LD betaflight_CC3D_OPBL.elf
    /home/andho/projects/cleanflight/andwho/betaflight/tools/gcc-arm-none-eabi-5_4-2016q3/bin/./lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/bin/ld: obj/main/betaflight_CC3D_OPBL.elf section `.data' will not fit in region `FLASH'
    /home/andho/projects/cleanflight/andwho/betaflight/tools/gcc-arm-none-eabi-5_4-2016q3/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/bin/ld: region `FLASH' overflowed by 140 bytes

Also some Makefile tidy-ing, helptexts etc.
