### PR TITLE
Travis. Update Arm toolchain to 5.4.1 2016q3 on master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ language: cpp
 compiler: clang
 
 before_install:
-    - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2" | tar xfj -
+    - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2" | tar xfj -
 
 install:
-  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_4-2016q2/bin
+  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_4-2016q3/bin
 
 before_script: arm-none-eabi-gcc --version
 script: ./.travis.sh

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -115,11 +115,11 @@
 #undef GPS
 #define CLI_MINIMAL_VERBOSITY
 #undef MAG
+#undef BARO
 
 #ifdef CC3D_OPBL
 #define SKIP_CLI_COMMAND_HELP
 #define SKIP_PID_FLOAT
-#undef BARO
 #undef SONAR
 #undef LED_STRIP
 #endif

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -17,7 +17,7 @@
 
 #define FC_VERSION_MAJOR            3  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            0  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      1  // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      2  // increment when a bug is fixed
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)


### PR DESCRIPTION
Travis. Update Arm toolchain to 5.4.1 2016q3 on master branch. Same as on development branch.
Version increment, 3.0.2, needed to differentiate builds with above toolchain from already released build.
Target CC3D, disabled BARO.  Otherwise it would be broken due to larger 2016q3 libs. Flash image 176 bytes too large. 
