### PR TITLE
Frsky Smart Port / MSP bridge

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -497,6 +497,10 @@ bool smartPortSendMspReply()
 
         checksum = sbufBytesRemaining(txBuf) ^ smartPortMspReply.cmd;        
     }
+    else {
+        // header
+        *(p++) = (SMARTPORT_MSP_VERSION << 5) | (seq++ & 0xF);
+    }
 
     while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {
         *p = sbufReadU8(txBuf);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -451,10 +451,13 @@ bool smartPortSendMspReply()
         if (smartPortMspReply.result == MSP_RESULT_ERROR) {
             *p++ |= SMARTPORT_MSP_ERROR_FLAG;
             *p++ = SMARTPORT_MSP_ERROR;
+            *p++ = SMARTPORT_MSP_ERROR ^ smartPortMspReply.cmd; // MSP checksum
+            while (p < end) *p++ = 0; // pad with zeros
             smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
             return false;
         }
 
+        p++;
         *p++ = size;
         checksum = size ^ smartPortMspReply.cmd;
     }

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -491,10 +491,7 @@ bool smartPortSendMspReply()
 
         // header
         *(p++) = (SMARTPORT_MSP_VERSION << 5) | (1 << 4) | (seq++ & 0xF);
-        
         *(p++) = size;
-        *(p++) = smartPortMspReply.cmd;
-
         checksum = sbufBytesRemaining(txBuf) ^ smartPortMspReply.cmd;        
     }
     else {

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -461,7 +461,7 @@ bool smartPortSendMspReply()
     }
     else {
         // header
-        *p++ = SMARTPORT_MSP_VERSION_S | (seq++ & SMARTPORT_MSP_SEQ_MASK);
+        *p++ = (seq++ & SMARTPORT_MSP_SEQ_MASK);
     }
 
     while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -202,6 +202,8 @@ static uint8_t smartPortMspTxBuffer[SMARTPORT_TX_BUF_SIZE];
 static mspPacket_t smartPortMspReply;
 static bool smartPortMspReplyPending = false;
 
+#define SMARTPORT_MSP_RES_ERROR -10
+
 enum {
     SMARTPORT_MSP_VER_MISMATCH=0,
     SMARTPORT_MSP_CRC_ERROR=1,
@@ -401,8 +403,10 @@ static void processMspPacket(mspPacket_t* packet)
 {
     initSmartPortMspReply(0);
 
-    mspFcProcessCommand(packet, &smartPortMspReply, NULL);
-
+    if (mspFcProcessCommand(packet, &smartPortMspReply, NULL) == MSP_RESULT_ERROR) {
+        sbufWriteU8(&smartPortMspReply.buf, SMARTPORT_MSP_ERROR);
+    }
+    
     // change streambuf direction
     sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
     smartPortMspReplyPending = true;
@@ -422,7 +426,8 @@ static void processMspPacket(mspPacket_t* packet)
  *     - payload
  *     - CRC (request type included)
  *   - if Error-flag == 1:
- *     - Error: 1 Byte
+ *     - size: 1 byte (== 1)
+ *     - error: 1 Byte
  *       - 0: Version mismatch (type=0)
  *       - 1: Sequence number error
  *       - 2: MSP error
@@ -442,23 +447,16 @@ bool smartPortSendMspReply()
     // detect first reply packet
     if (txBuf->ptr == smartPortMspTxBuffer) {
 
-        uint8_t size = sbufBytesRemaining(txBuf);
-
         // header
-        
-        *p = SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
-
-        if (smartPortMspReply.result == MSP_RESULT_ERROR) {
-            *p++ |= SMARTPORT_MSP_ERROR_FLAG;
-            *p++ = SMARTPORT_MSP_ERROR;
-            *p++ = SMARTPORT_MSP_ERROR ^ smartPortMspReply.cmd; // MSP checksum
-            while (p < end) *p++ = 0; // pad with zeros
-            smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
-            return false;
+        uint8_t head = SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
+        if (smartPortMspReply.result < 0) {
+            head |= SMARTPORT_MSP_ERROR_FLAG;
         }
+        *p++ = head;
 
-        p++;
+        uint8_t size = sbufBytesRemaining(txBuf);
         *p++ = size;
+
         checksum = size ^ smartPortMspReply.cmd;
     }
     else {
@@ -493,6 +491,8 @@ void smartPortSendErrorReply(uint8_t error, int16_t cmd)
 {
     initSmartPortMspReply(cmd);
     sbufWriteU8(&smartPortMspReply.buf,error);
+    smartPortMspReply.result = SMARTPORT_MSP_RES_ERROR;
+
     sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
     smartPortMspReplyPending = true;
 }

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -192,6 +192,7 @@ static bool smartPortFrameReceived = false;
 #define SMARTPORT_MSP_VER_MASK   (0x7 << SMARTPORT_MSP_VER_SHIFT)
 #define SMARTPORT_MSP_VERSION_S  (SMARTPORT_MSP_VERSION << SMARTPORT_MSP_VER_SHIFT)
 
+#define SMARTPORT_MSP_ERROR_FLAG (1 << 5)
 #define SMARTPORT_MSP_START_FLAG (1 << 4)
 #define SMARTPORT_MSP_SEQ_MASK   0x0F
 
@@ -200,6 +201,12 @@ static bool smartPortFrameReceived = false;
 static uint8_t smartPortMspTxBuffer[SMARTPORT_TX_BUF_SIZE];
 static mspPacket_t smartPortMspReply;
 static bool smartPortMspReplyPending = false;
+
+enum {
+    SMARTPORT_MSP_VER_MISMATCH=0,
+    SMARTPORT_MSP_CRC_ERROR=1,
+    SMARTPORT_MSP_ERROR=2
+};
 
 static void smartPortDataReceive(uint16_t c)
 {
@@ -268,10 +275,11 @@ static void smartPortSendByte(uint8_t c, uint16_t *crcp)
     // smart port escape sequence
     if (c == FSSP_DLE || c == FSSP_START_STOP) {
         serialWrite(smartPortSerialPort, FSSP_DLE);
-        c ^= FSSP_DLE_XOR;
+        serialWrite(smartPortSerialPort, c ^ FSSP_DLE_XOR);
     }
-
-    serialWrite(smartPortSerialPort, c);
+    else {
+        serialWrite(smartPortSerialPort, c);
+    }
 
     if (crcp == NULL)
         return;
@@ -380,29 +388,114 @@ static void resetMspPacket(mspPacket_t* packet)
     packet->result  = 0;
 }
 
-static void processMspPacket(mspPacket_t* packet)
+static void initSmartPortMspReply(int16_t cmd)
 {
     smartPortMspReply.buf.ptr    = smartPortMspTxBuffer;
     smartPortMspReply.buf.end    = ARRAYEND(smartPortMspTxBuffer);
 
-    smartPortMspReply.cmd    = -1;
+    smartPortMspReply.cmd    = cmd;
     smartPortMspReply.result = 0;
+}
 
-    const mspResult_e status = mspFcProcessCommand(packet, &smartPortMspReply, NULL);
+static void processMspPacket(mspPacket_t* packet)
+{
+    initSmartPortMspReply(0);
 
-    if (status != MSP_RESULT_NO_REPLY) {
-        // change streambuf direction
-        sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
+    mspFcProcessCommand(packet, &smartPortMspReply, NULL);
 
-        smartPortMspReplyPending = true;
-    }
-    else {
-        //TODO: send ACK reply to avoid re-transmission?
-    }
+    // change streambuf direction
+    sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
+    smartPortMspReplyPending = true;
 }
 
 /**
- * Frame format:
+ * Request frame format:
+ * - Header: 1 byte
+ *   - Reserved: 2 bits (future use)
+ *   - Error-flag: 1 bit
+ *   - Start-flag: 1 bit
+ *   - CSeq: 4 bits
+ *
+ * - MSP payload:
+ *   - if Error-flag == 0:
+ *     - size: 1 byte
+ *     - payload
+ *     - CRC (request type included)
+ *   - if Error-flag == 1:
+ *     - Error: 1 Byte
+ *       - 0: Version mismatch (type=0)
+ *       - 1: Sequence number error
+ *       - 2: MSP error
+ *     - CRC (request type included)
+ */
+bool smartPortSendMspReply()
+{
+    static uint8_t checksum = 0;
+    static uint8_t seq = 0;
+
+    uint8_t packet[SMARTPORT_PAYLOAD_SIZE];
+    uint8_t* p = packet;
+    uint8_t* end = p + SMARTPORT_PAYLOAD_SIZE;
+    
+    sbuf_t* txBuf = &smartPortMspReply.buf;
+
+    // detect first reply packet
+    if (txBuf->ptr == smartPortMspTxBuffer) {
+
+        uint8_t size = sbufBytesRemaining(txBuf);
+
+        // header
+        
+        *p = SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
+
+        if (smartPortMspReply.result == MSP_RESULT_ERROR) {
+            *p++ |= SMARTPORT_MSP_ERROR_FLAG;
+            *p++ = SMARTPORT_MSP_ERROR;
+            smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+            return false;
+        }
+
+        *p++ = size;
+        checksum = size ^ smartPortMspReply.cmd;
+    }
+    else {
+        // header
+        *p++ = SMARTPORT_MSP_VERSION_S | (seq++ & SMARTPORT_MSP_SEQ_MASK);
+    }
+
+    while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {
+        *p = sbufReadU8(txBuf);
+        checksum ^= *p++; // MSP checksum
+    }
+
+    // to be continued...
+    if (p == end) {
+        smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+        return true;
+    }
+
+    // nothing left in txBuf,
+    // append the MSP checksum
+    *p++ = checksum;
+
+    // pad with zeros
+    while (p < end)
+        *p++ = 0;
+
+    smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+    return false;
+}
+
+void smartPortSendErrorReply(uint8_t error, int16_t cmd)
+{
+    initSmartPortMspReply(cmd);
+    sbufWriteU8(&smartPortMspReply.buf,error);
+    sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
+    smartPortMspReplyPending = true;
+}
+
+/**
+ * Request frame format:
  * - Header: 1 byte
  *   - Version: 3 bits
  *   - Start-flag: 1 bit
@@ -420,12 +513,7 @@ void handleSmartPortMspFrame(smartPortFrame_t* sp_frame)
     static uint8_t mspStarted = 0;
     static uint8_t lastSeq = 0;
     static uint8_t checksum = 0;
-
-    static mspPacket_t cmd = {
-        .buf = { .ptr = mspBuffer, .end = mspBuffer },
-        .cmd = -1,
-        .result = 0
-    };
+    static mspPacket_t cmd;
     
     // re-assemble MSP frame & forward to MSP port when complete
     uint8_t* p = ((uint8_t*)sp_frame) + SMARTPORT_PAYLOAD_OFFSET;
@@ -436,9 +524,8 @@ void handleSmartPortMspFrame(smartPortFrame_t* sp_frame)
     uint8_t version = (head & SMARTPORT_MSP_VER_MASK) >> SMARTPORT_MSP_VER_SHIFT;
 
     if (version != SMARTPORT_MSP_VERSION) {
-        // TODO: should a version mismatch error
-        //       be sent back to the transmitter?
-        resetMspPacket(&cmd);
+        mspStarted = 0;
+        smartPortSendErrorReply(SMARTPORT_MSP_VER_MISMATCH,0);
         return;
     }
 
@@ -480,7 +567,8 @@ void handleSmartPortMspFrame(smartPortFrame_t* sp_frame)
 
     // last byte must be the checksum
     if (checksum != *p) {
-        resetMspPacket(&cmd);
+        mspStarted = 0;
+        smartPortSendErrorReply(SMARTPORT_MSP_CRC_ERROR,cmd.cmd);
         return;
     }
 
@@ -489,56 +577,6 @@ void handleSmartPortMspFrame(smartPortFrame_t* sp_frame)
     sbufSwitchToReader(&cmd.buf,mspBuffer);
 
     processMspPacket(&cmd);
-}
-
-bool smartPortSendMspReply()
-{
-    static uint8_t checksum = 0;
-    static uint8_t seq = 0;
-
-    uint8_t packet[SMARTPORT_PAYLOAD_SIZE];
-    uint8_t* p = packet;
-    uint8_t* end = p + SMARTPORT_PAYLOAD_SIZE;
-    
-    sbuf_t* txBuf = &smartPortMspReply.buf;
-
-    // detect first reply packet
-    if (txBuf->ptr == smartPortMspTxBuffer) {
-
-        uint8_t size = sbufBytesRemaining(txBuf);
-
-        // header
-        *p++ = SMARTPORT_MSP_VERSION_S | SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
-
-        *p++ = size;
-        checksum = sbufBytesRemaining(txBuf) ^ smartPortMspReply.cmd;        
-    }
-    else {
-        // header
-        *p++ = SMARTPORT_MSP_VERSION_S | (seq++ & SMARTPORT_MSP_SEQ_MASK);
-    }
-
-    while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {
-        *p = sbufReadU8(txBuf);
-        checksum ^= *p++; // MSP checksum
-    }
-
-    // to be continued...
-    if (p == end) {
-        smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
-        return true;
-    }
-
-    // nothing left in txBuf,
-    // append the MSP checksum
-    *p++ = checksum;
-
-    // pad with zeros
-    while (p < end)
-        *p++ = 0;
-
-    smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
-    return false;
 }
 
 void handleSmartPortTelemetry(void)

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -30,6 +30,7 @@
 #include "fc/config.h"
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
+#include "fc/fc_msp.h"
 
 #include "io/beeper.h"
 #include "io/motors.h"
@@ -64,6 +65,8 @@
 #include "config/config_profile.h"
 #include "config/feature.h"
 
+#include "msp/msp.h"
+
 extern profile_t *currentProfile;
 extern controlRateConfig_t *currentControlRateProfile;
 
@@ -78,7 +81,11 @@ enum
 enum
 {
     FSSP_START_STOP = 0x7E,
+    FSSP_BYTE_STUFF = 0x7D,
+
     FSSP_DATA_FRAME = 0x10,
+    FSSP_MSPC_FRAME = 0x30, // MSP client frame
+    FSSP_MSPS_FRAME = 0x32, // MSP server frame
 
     // ID of sensor. Must be something that is polled by FrSky RX
     FSSP_SENSOR_ID1 = 0x1B,
@@ -160,22 +167,79 @@ static uint8_t smartPortHasRequest = 0;
 static uint8_t smartPortIdCnt = 0;
 static uint32_t smartPortLastRequestTime = 0;
 
+/* uint8_t physicalId */
+/* uint8_t primId */
+/* uint16_t id */
+/* uint32_t data */
+#define SMARTPORT_FRAME_SIZE 8
+
+#define SMARTPORT_MSP_VERSION 1
+
+static uint8_t smartPortRxBuffer[SMARTPORT_FRAME_SIZE];
+static uint8_t smartPortRxBytes = 0;
+static bool smartPortFrameReceived = false;
+
+static uint8_t smartPortMspTxBuffer[256];
+static mspPacket_t smartPortMspReply;
+static bool smartPortMspReplyPending = false;
+
+// If set, this should be executed once the reply buffer
+// has been sent back to the transmitter
+static mspPostProcessFnPtr mspPostProcessFn = NULL;
+
 static void smartPortDataReceive(uint16_t c)
 {
+    static bool skipUntilStart = true;
+    static bool byteStuffing = false;
+
     uint32_t now = millis();
 
-    // look for a valid request sequence
-    static uint8_t lastChar;
-    if (lastChar == FSSP_START_STOP) {
-        smartPortState = SPSTATE_WORKING;
-        if (c == FSSP_SENSOR_ID1 && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
+    if (c == FSSP_START_STOP) {
+        smartPortRxBytes = 0;
+        smartPortHasRequest = 0;
+        skipUntilStart = false;
+        return;
+    }
+    else if (skipUntilStart) {
+        return;
+    }
+
+    if (smartPortRxBytes == 0) {
+        if ((c == FSSP_SENSOR_ID1)
+            && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
+
+            // our slot is starting...
             smartPortLastRequestTime = now;
             smartPortHasRequest = 1;
-            // we only responde to these IDs
-            // the X4R-SB does send other IDs, we ignore them, but take note of the time
+        }
+        else if (c == FSSP_SENSOR_ID2) {
+            smartPortRxBuffer[smartPortRxBytes++] = c;
+        }
+        else {
+            skipUntilStart = true;
         }
     }
-    lastChar = c;
+    else {
+
+        //TODO: add CRC checking
+
+        if (c == FSSP_BYTE_STUFF) {
+            byteStuffing = true;
+            return;
+        }
+
+        if (byteStuffing) {
+            c ^= 0x20;
+            byteStuffing = false;
+        }
+
+        smartPortRxBuffer[smartPortRxBytes++] = c;
+
+        if(smartPortRxBytes == SMARTPORT_FRAME_SIZE) {
+            smartPortFrameReceived = true;
+            skipUntilStart = true;
+        }
+    }
 }
 
 static void smartPortSendByte(uint8_t c, uint16_t *crcp)
@@ -198,19 +262,29 @@ static void smartPortSendByte(uint8_t c, uint16_t *crcp)
     *crcp = crc;
 }
 
-static void smartPortSendPackage(uint16_t id, uint32_t val)
+static void smartPortSendPackageEx(uint8_t primId, uint8_t* data)
 {
     uint16_t crc = 0;
-    smartPortSendByte(FSSP_DATA_FRAME, &crc);
-    uint8_t *u8p = (uint8_t*)&id;
-    smartPortSendByte(u8p[0], &crc);
-    smartPortSendByte(u8p[1], &crc);
-    u8p = (uint8_t*)&val;
-    smartPortSendByte(u8p[0], &crc);
-    smartPortSendByte(u8p[1], &crc);
-    smartPortSendByte(u8p[2], &crc);
-    smartPortSendByte(u8p[3], &crc);
+    smartPortSendByte(primId, &crc);
+    for(uint8_t i=0;i<6;i++) {
+        smartPortSendByte(*(data++), &crc);
+    }
     smartPortSendByte(0xFF - (uint8_t)crc, NULL);
+}
+
+static void smartPortSendPackage(uint16_t id, uint32_t val)
+{
+    uint8_t packet[6];
+    uint8_t *u8p = (uint8_t*)&id;
+    packet[0] = u8p[0];
+    packet[1] = u8p[1];
+    u8p = (uint8_t*)&val;
+    packet[2] = u8p[0];
+    packet[3] = u8p[1];
+    packet[4] = u8p[2];
+    packet[5] = u8p[3];
+
+    smartPortSendPackageEx(FSSP_DATA_FRAME,packet);
 }
 
 void initSmartPortTelemetry(telemetryConfig_t *initialTelemetryConfig)
@@ -278,6 +352,175 @@ void checkSmartPortTelemetryState(void)
         freeSmartPortTelemetryPort();
 }
 
+static void resetMspPacket(mspPacket_t* packet)
+{
+    packet->buf.ptr = NULL;
+    packet->buf.end = NULL;
+    packet->cmd     = -1;
+    packet->result  = 0;
+}
+
+static void processMspPacket(mspPacket_t* packet)
+{
+    smartPortMspReply.buf.ptr    = smartPortMspTxBuffer;
+    smartPortMspReply.buf.end    = ARRAYEND(smartPortMspTxBuffer);
+
+    smartPortMspReply.cmd    = -1;
+    smartPortMspReply.result = 0;
+
+    mspPostProcessFn = NULL;
+    const mspResult_e status = mspFcProcessCommand(packet, &smartPortMspReply,
+                                                   &mspPostProcessFn);
+
+    if (status != MSP_RESULT_NO_REPLY) {
+        // change streambuf direction
+        sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
+
+        smartPortMspReplyPending = true;
+    }
+    else {
+        //TODO: send ACK reply to avoid re-transmission?
+    }
+}
+
+/**
+ * Frame format:
+ * - Header: 1 byte
+ *   - Version: 3 bits
+ *   - Start-flag: 1 bit
+ *   - CSeq: 4 bits
+ *
+ * - MSP payload:
+ *   - Size: 1 Byte
+ *   - Type: 1 Byte
+ *   - payload...
+ *   - CRC
+ */
+void handleSmartPortMspFrame(uint8_t* frame, uint8_t size)
+{
+    static uint8_t mspBuffer[64];
+    static uint8_t mspStarted = 0;
+    static uint8_t lastSeq = 0;
+    static uint8_t checksum = 0;
+
+    static mspPacket_t cmd = {
+        .buf = { .ptr = mspBuffer, .end = mspBuffer },
+        .cmd = -1,
+        .result = 0
+    };
+    
+    //TODO: re-assemble MSP frame & forward to MSP port when complete
+    uint8_t* p = frame;
+    uint8_t* end = frame + size;
+    
+    uint8_t head = *(p++);  
+    uint8_t seq = head & 0xF;
+    uint8_t version = (head & 0xE0) >> 5;
+
+    if (version != SMARTPORT_MSP_VERSION) {
+        // TODO: should a version mismatch error
+        //       be sent back to the transmitter?
+        resetMspPacket(&cmd);
+        return;
+    }
+
+    // check start-flag
+    if (head & (1 << 4)) {
+
+        //TODO: if (frame[1] > 64) error!
+        uint8_t p_size = *(p++);
+        cmd.cmd = *(p++);
+        cmd.result = 0;
+
+        cmd.buf.ptr = mspBuffer;
+        cmd.buf.end = mspBuffer + p_size;
+
+        checksum = p_size ^ cmd.cmd;
+        mspStarted = 1;
+    }
+    else if (!mspStarted) {
+        // no start packet yet, throw this one away
+        return;
+    }
+    else if (((lastSeq + 1) & 0x7) != seq) {
+        // packet loss detected!
+        resetMspPacket(&cmd);
+        return;
+    }
+
+    // copy payload bytes
+    while ((p < end) && sbufBytesRemaining(&cmd.buf)) {
+        checksum ^= *p;
+        sbufWriteU8(&cmd.buf,*(p++));
+    }
+
+    // reached end of smart port frame
+    if (p == end) {
+        lastSeq = seq;
+        return;
+    }
+
+    // last byte must be the checksum
+    if (checksum != *p) {
+        resetMspPacket(&cmd);
+        return;
+    }
+
+    // end of MSP packet reached
+    mspStarted = 0;
+    sbufSwitchToReader(&cmd.buf,mspBuffer);
+
+    processMspPacket(&cmd);
+}
+
+bool smartPortSendMspReply()
+{
+    static uint8_t checksum = 0;
+    static uint8_t seq = 0;
+
+    uint8_t packet[6];
+    uint8_t* p = packet;
+    uint8_t* end = p + 6;
+    
+    sbuf_t* txBuf = &smartPortMspReply.buf;
+
+    // detect first reply packet
+    if (txBuf->ptr == smartPortMspTxBuffer) {
+
+        uint8_t size = sbufBytesRemaining(txBuf);
+
+        // header
+        *(p++) = (SMARTPORT_MSP_VERSION << 5) | (1 << 4) | (seq++ & 0xF);
+        
+        *(p++) = size;
+        *(p++) = smartPortMspReply.cmd;
+
+        checksum = sbufBytesRemaining(txBuf) ^ smartPortMspReply.cmd;        
+    }
+
+    while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {
+        *p = sbufReadU8(txBuf);
+        checksum ^= *(p++); // MSP checksum
+    }
+
+    // to be continued...
+    if (p == end) {
+        smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+        return true;
+    }
+
+    // nothing left in txBuf,
+    // append the MSP checksum
+    *(p++) = checksum;
+
+    // pad with zeros
+    while (p < end)
+        *(p++) = 0;
+
+    smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+    return false;
+}
+
 void handleSmartPortTelemetry(void)
 {
     uint32_t smartPortLastServiceTime = millis();
@@ -303,6 +546,16 @@ void handleSmartPortTelemetry(void)
         return;
     }
 
+    if(smartPortFrameReceived) {
+        smartPortFrameReceived = false;
+        // do not check the physical ID here again
+        // unless we start receiving other sensors' packets
+        uint8_t primId = smartPortRxBuffer[1];
+        if(primId == FSSP_MSPC_FRAME) {
+            handleSmartPortMspFrame(smartPortRxBuffer+2,6);
+        }
+    }
+    
     while (smartPortHasRequest) {
         // Ensure we won't get stuck in the loop if there happens to be nothing available to send in a timely manner - dump the slot if we loop in there for too long.
         if ((millis() - smartPortLastServiceTime) > SMARTPORT_SERVICE_TIMEOUT_MS) {
@@ -310,6 +563,12 @@ void handleSmartPortTelemetry(void)
             return;
         }
 
+        if(smartPortMspReplyPending) {
+            smartPortMspReplyPending = smartPortSendMspReply();
+            smartPortHasRequest = 0;
+            return;
+        }
+        
         // we can send back any data we want, our table keeps track of the order and frequency of each data type we send
         uint16_t id = frSkyDataIdTable[smartPortIdCnt];
         if (id == 0) { // end of table reached, loop back

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -81,7 +81,9 @@ enum
 enum
 {
     FSSP_START_STOP = 0x7E,
-    FSSP_BYTE_STUFF = 0x7D,
+
+    FSSP_DLE        = 0x7D,
+    FSSP_DLE_XOR    = 0x20,
 
     FSSP_DATA_FRAME = 0x10,
     FSSP_MSPC_FRAME = 0x30, // MSP client frame
@@ -167,25 +169,36 @@ static uint8_t smartPortHasRequest = 0;
 static uint8_t smartPortIdCnt = 0;
 static uint32_t smartPortLastRequestTime = 0;
 
-/* uint8_t physicalId */
-/* uint8_t primId */
-/* uint16_t id */
-/* uint32_t data */
-#define SMARTPORT_FRAME_SIZE 8
+typedef struct smartPortFrame_s {
+    uint8_t  sensorId;
+    uint8_t  frameId;
+    uint16_t valueId;
+    uint32_t data;
+} smartPortFrame_t;
 
-#define SMARTPORT_MSP_VERSION 1
+#define SMARTPORT_FRAME_SIZE  sizeof(smartPortFrame_t)
+#define SMARTPORT_TX_BUF_SIZE 256
+
+#define SMARTPORT_PAYLOAD_SIZE   (SMARTPORT_FRAME_SIZE - 2*sizeof(uint8_t))
+#define SMARTPORT_PAYLOAD_OFFSET 2
 
 static uint8_t smartPortRxBuffer[SMARTPORT_FRAME_SIZE];
 static uint8_t smartPortRxBytes = 0;
 static bool smartPortFrameReceived = false;
 
-static uint8_t smartPortMspTxBuffer[256];
+#define SMARTPORT_MSP_VERSION    1
+#define SMARTPORT_MSP_VER_SHIFT  5
+#define SMARTPORT_MSP_VER_MASK   0xE0
+#define SMARTPORT_MSP_VERSION_S  (SMARTPORT_MSP_VERSION << SMARTPORT_MSP_VER_SHIFT)
+
+#define SMARTPORT_MSP_START_FLAG (1 << 4)
+#define SMARTPORT_MSP_SEQ_MASK   0x0F
+
+#define SMARTPORT_MSP_RX_BUF_SIZE 64
+
+static uint8_t smartPortMspTxBuffer[SMARTPORT_TX_BUF_SIZE];
 static mspPacket_t smartPortMspReply;
 static bool smartPortMspReplyPending = false;
-
-// If set, this should be executed once the reply buffer
-// has been sent back to the transmitter
-static mspPostProcessFnPtr mspPostProcessFn = NULL;
 
 static void smartPortDataReceive(uint16_t c)
 {
@@ -205,8 +218,7 @@ static void smartPortDataReceive(uint16_t c)
     }
 
     if (smartPortRxBytes == 0) {
-        if ((c == FSSP_SENSOR_ID1)
-            && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
+        if ((c == FSSP_SENSOR_ID1) && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
 
             // our slot is starting...
             smartPortLastRequestTime = now;
@@ -223,13 +235,13 @@ static void smartPortDataReceive(uint16_t c)
 
         //TODO: add CRC checking
 
-        if (c == FSSP_BYTE_STUFF) {
+        if (c == FSSP_DLE) {
             byteStuffing = true;
             return;
         }
 
         if (byteStuffing) {
-            c ^= 0x20;
+            c ^= FSSP_DLE_XOR;
             byteStuffing = false;
         }
 
@@ -245,9 +257,9 @@ static void smartPortDataReceive(uint16_t c)
 static void smartPortSendByte(uint8_t c, uint16_t *crcp)
 {
     // smart port escape sequence
-    if (c == 0x7D || c == 0x7E) {
-        serialWrite(smartPortSerialPort, 0x7D);
-        c ^= 0x20;
+    if (c == FSSP_DLE || c == FSSP_START_STOP) {
+        serialWrite(smartPortSerialPort, FSSP_DLE);
+        c ^= FSSP_DLE_XOR;
     }
 
     serialWrite(smartPortSerialPort, c);
@@ -262,29 +274,28 @@ static void smartPortSendByte(uint8_t c, uint16_t *crcp)
     *crcp = crc;
 }
 
-static void smartPortSendPackageEx(uint8_t primId, uint8_t* data)
+static void smartPortSendPackageEx(uint8_t frameId, uint8_t* data)
 {
     uint16_t crc = 0;
-    smartPortSendByte(primId, &crc);
-    for(uint8_t i=0;i<6;i++) {
-        smartPortSendByte(*(data++), &crc);
+    smartPortSendByte(frameId, &crc);
+    for(unsigned i = 0; i < SMARTPORT_PAYLOAD_SIZE; i++) {
+        smartPortSendByte(*data++, &crc);
     }
     smartPortSendByte(0xFF - (uint8_t)crc, NULL);
 }
 
 static void smartPortSendPackage(uint16_t id, uint32_t val)
 {
-    uint8_t packet[6];
-    uint8_t *u8p = (uint8_t*)&id;
-    packet[0] = u8p[0];
-    packet[1] = u8p[1];
-    u8p = (uint8_t*)&val;
-    packet[2] = u8p[0];
-    packet[3] = u8p[1];
-    packet[4] = u8p[2];
-    packet[5] = u8p[3];
+    uint8_t payload[SMARTPORT_PAYLOAD_SIZE];
+    uint8_t *dst = payload;
+    *dst++ = id & 0xFF;
+    *dst++ = id >> 8;
+    *dst++ = val & 0xFF;
+    *dst++ = (val >> 8) & 0xFF;
+    *dst++ = (val >> 16) & 0xFF;
+    *dst++ = (val >> 24) & 0xFF;
 
-    smartPortSendPackageEx(FSSP_DATA_FRAME,packet);
+    smartPortSendPackageEx(FSSP_DATA_FRAME,payload);
 }
 
 void initSmartPortTelemetry(telemetryConfig_t *initialTelemetryConfig)
@@ -368,9 +379,7 @@ static void processMspPacket(mspPacket_t* packet)
     smartPortMspReply.cmd    = -1;
     smartPortMspReply.result = 0;
 
-    mspPostProcessFn = NULL;
-    const mspResult_e status = mspFcProcessCommand(packet, &smartPortMspReply,
-                                                   &mspPostProcessFn);
+    const mspResult_e status = mspFcProcessCommand(packet, &smartPortMspReply, NULL);
 
     if (status != MSP_RESULT_NO_REPLY) {
         // change streambuf direction
@@ -398,7 +407,7 @@ static void processMspPacket(mspPacket_t* packet)
  */
 void handleSmartPortMspFrame(uint8_t* frame, uint8_t size)
 {
-    static uint8_t mspBuffer[64];
+    static uint8_t mspBuffer[SMARTPORT_MSP_RX_BUF_SIZE];
     static uint8_t mspStarted = 0;
     static uint8_t lastSeq = 0;
     static uint8_t checksum = 0;
@@ -409,13 +418,13 @@ void handleSmartPortMspFrame(uint8_t* frame, uint8_t size)
         .result = 0
     };
     
-    //TODO: re-assemble MSP frame & forward to MSP port when complete
+    // re-assemble MSP frame & forward to MSP port when complete
     uint8_t* p = frame;
     uint8_t* end = frame + size;
     
-    uint8_t head = *(p++);  
-    uint8_t seq = head & 0xF;
-    uint8_t version = (head & 0xE0) >> 5;
+    uint8_t head = *p++;
+    uint8_t seq = head & SMARTPORT_MSP_SEQ_MASK;
+    uint8_t version = (head & SMARTPORT_MSP_VER_MASK) >> SMARTPORT_MSP_VER_SHIFT;
 
     if (version != SMARTPORT_MSP_VERSION) {
         // TODO: should a version mismatch error
@@ -425,11 +434,11 @@ void handleSmartPortMspFrame(uint8_t* frame, uint8_t size)
     }
 
     // check start-flag
-    if (head & (1 << 4)) {
+    if (head & SMARTPORT_MSP_START_FLAG) {
 
-        //TODO: if (frame[1] > 64) error!
-        uint8_t p_size = *(p++);
-        cmd.cmd = *(p++);
+        //TODO: if (p_size > SMARTPORT_MSP_RX_BUF_SIZE) error!
+        uint8_t p_size = *p++;
+        cmd.cmd = *p++;
         cmd.result = 0;
 
         cmd.buf.ptr = mspBuffer;
@@ -442,7 +451,7 @@ void handleSmartPortMspFrame(uint8_t* frame, uint8_t size)
         // no start packet yet, throw this one away
         return;
     }
-    else if (((lastSeq + 1) & 0x7) != seq) {
+    else if (((lastSeq + 1) & SMARTPORT_MSP_SEQ_MASK) != seq) {
         // packet loss detected!
         resetMspPacket(&cmd);
         return;
@@ -451,7 +460,7 @@ void handleSmartPortMspFrame(uint8_t* frame, uint8_t size)
     // copy payload bytes
     while ((p < end) && sbufBytesRemaining(&cmd.buf)) {
         checksum ^= *p;
-        sbufWriteU8(&cmd.buf,*(p++));
+        sbufWriteU8(&cmd.buf,*p++);
     }
 
     // reached end of smart port frame
@@ -478,9 +487,9 @@ bool smartPortSendMspReply()
     static uint8_t checksum = 0;
     static uint8_t seq = 0;
 
-    uint8_t packet[6];
+    uint8_t packet[SMARTPORT_PAYLOAD_SIZE];
     uint8_t* p = packet;
-    uint8_t* end = p + 6;
+    uint8_t* end = p + SMARTPORT_PAYLOAD_SIZE;
     
     sbuf_t* txBuf = &smartPortMspReply.buf;
 
@@ -490,18 +499,19 @@ bool smartPortSendMspReply()
         uint8_t size = sbufBytesRemaining(txBuf);
 
         // header
-        *(p++) = (SMARTPORT_MSP_VERSION << 5) | (1 << 4) | (seq++ & 0xF);
-        *(p++) = size;
+        *p++ = SMARTPORT_MSP_VERSION_S | SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
+
+        *p++ = size;
         checksum = sbufBytesRemaining(txBuf) ^ smartPortMspReply.cmd;        
     }
     else {
         // header
-        *(p++) = (SMARTPORT_MSP_VERSION << 5) | (seq++ & 0xF);
+        *p++ = SMARTPORT_MSP_VERSION_S | (seq++ & SMARTPORT_MSP_SEQ_MASK);
     }
 
     while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {
         *p = sbufReadU8(txBuf);
-        checksum ^= *(p++); // MSP checksum
+        checksum ^= *p++; // MSP checksum
     }
 
     // to be continued...
@@ -512,11 +522,11 @@ bool smartPortSendMspReply()
 
     // nothing left in txBuf,
     // append the MSP checksum
-    *(p++) = checksum;
+    *p++ = checksum;
 
     // pad with zeros
     while (p < end)
-        *(p++) = 0;
+        *p++ = 0;
 
     smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
     return false;
@@ -551,9 +561,11 @@ void handleSmartPortTelemetry(void)
         smartPortFrameReceived = false;
         // do not check the physical ID here again
         // unless we start receiving other sensors' packets
-        uint8_t primId = smartPortRxBuffer[1];
-        if(primId == FSSP_MSPC_FRAME) {
-            handleSmartPortMspFrame(smartPortRxBuffer+2,6);
+        smartPortFrame_t* frame = (smartPortFrame_t*)smartPortRxBuffer;
+        if(frame->frameId == FSSP_MSPC_FRAME) {
+
+            // Pass only the payload: skip sensorId & frameId
+            handleSmartPortMspFrame(smartPortRxBuffer + SMARTPORT_PAYLOAD_OFFSET, SMARTPORT_PAYLOAD_SIZE);
         }
     }
     

--- a/src/test/SpMsp.lua
+++ b/src/test/SpMsp.lua
@@ -1,0 +1,77 @@
+--
+-- Test script for the MSP/SPORT bridge
+--
+
+-- Protocol version
+SPORT_MSP_VERSION = 1
+
+-- Sensor ID used by the local LUA script
+LOCAL_SENSOR_ID  = 0x0D
+
+-- Sensor ID used by the MSP server (BF, CF, MW, etc...)
+REMOTE_SENSOR_ID = 0x1B
+
+REQUEST_FRAME_ID = 0x30
+REPLY_FRAME_ID   = 0x32
+
+-- Sequence number for next MSP/SPORT packet
+sportMspSeq = 0
+
+-- Stats
+requestsSent    = 0
+repliesReceived = 0
+
+lastReqTS = 0
+
+local function pollReply()
+   local sensorId, frameId, dataId, value = sportTelemetryPop()
+   if sensorId == REMOTE_SENSOR_ID and frameId == REPLY_FRAME_ID then
+      repliesReceived = repliesReceived + 1
+   end
+end
+
+local function mspSendRequest(cmd)
+
+   local dataId = 0
+   dataId = sportMspSeq                                -- sequence number
+   dataId = dataId + bit32.lshift(1,4)                 -- start flag
+   dataId = dataId + bit32.lshift(SPORT_MSP_VERSION,5) -- MSP/SPORT version
+   -- size is 0 for now, no need to add it to dataId
+   -- dataId = dataId + bit32.lshift(0,8)
+   sportMspSeq = bit32.band(sportMspSeq + 1, 0x0F)
+   
+   local value = 0
+   value = bit32.band(cmd,0xFF)        -- MSP command
+   value = value + bit32.lshift(cmd,8) -- CRC
+
+   requestsSent = requestsSent + 1
+   return sportTelemetryPush(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
+end
+
+local function run(event)
+
+   local now = getTime()
+
+   if event == EVT_MINUS_FIRST or event == EVT_ROT_LEFT or event == EVT_MINUS_REPT then
+      requestsSent    = 0
+      repliesReceived = 0
+   end
+
+   lcd.clear()
+
+   lcd.drawText(1,11,"Requests:",0)
+   lcd.drawNumber(60,11,requestsSent)
+   
+   lcd.drawText(1,21,"Replies:",0)
+   lcd.drawNumber(60,21,repliesReceived)
+
+   -- last request is at least 2s old
+   if lastReqTS + 200 <= now then
+      mspSendRequest(117) -- MSP_PIDNAMES
+      lastReqTS = now
+   end
+
+   pollReply()
+end
+
+return {run=run}

--- a/src/test/SpMsp.lua
+++ b/src/test/SpMsp.lua
@@ -17,18 +17,21 @@ REPLY_FRAME_ID   = 0x32
 -- Sequence number for next MSP/SPORT packet
 sportMspSeq = 0
 
+mspRxBuf = {}
+mspRxIdx = 1
+mspRxCRC = 0
+mspStarted = false
+
 -- Stats
 requestsSent    = 0
 repliesReceived = 0
 
-lastReqTS = 0
+mspReceivedReply_cnt = 0
+mspReceivedReply_cnt1 = 0
+mspReceivedReply_cnt2 = 0
+mspReceivedReply_cnt3 = 0
 
-local function pollReply()
-   local sensorId, frameId, dataId, value = sportTelemetryPop()
-   if sensorId == REMOTE_SENSOR_ID and frameId == REPLY_FRAME_ID then
-      repliesReceived = repliesReceived + 1
-   end
-end
+lastReqTS = 0
 
 local function mspSendRequest(cmd)
 
@@ -48,6 +51,95 @@ local function mspSendRequest(cmd)
    return sportTelemetryPush(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
 end
 
+local function mspReceivedReply(payload)
+
+   -- TODO: MSP checksum checking
+
+   mspReceivedReply_cnt = mspReceivedReply_cnt + 1
+   
+   local idx      = 1
+   local head     = payload[idx]
+   local err_flag = (bit32.band(head,0x20) ~= 0)
+   idx = idx + 1
+
+   if err_flag then
+      -- error flag set
+      mspStarted = false
+
+      mspReceivedReply_cnt1 = mspReceivedReply_cnt1 + 1
+
+      -- return error
+      -- CRC checking missing
+
+      --return bit32.band(payload[idx],0xFF)
+      return nil
+   end
+   
+   local start = (bit32.band(head,0x10) ~= 0)
+   local seq   = bit32.band(head,0x0F)
+
+   if start then
+      -- start flag set
+      mspRxIdx = 1
+      mspRxBuf = {}
+
+      mspRxSize = payload[idx]
+      mspRxCRC  = mspRxSize
+      idx = idx + 1
+      mspStarted = true
+      
+      mspReceivedReply_cnt2 = mspReceivedReply_cnt2 + 1
+
+   elseif not mspStarted then
+      mspReceivedReply_cnt3 = mspReceivedReply_cnt3 + 1
+      return nil
+   -- TODO: add sequence number checking
+   -- elseif ...
+   end
+
+   while (idx <= 6) and (mspRxIdx <= mspRxSize) do
+      mspRxBuf[mspRxIdx] = payload[idx]
+      mspRxCRC = bit32.bxor(mspRxCRC,payload[idx])
+      mspRxIdx = mspRxIdx + 1
+      idx = idx + 1
+   end
+
+   if idx > 6 then
+      lastRxSeq = seq
+      return
+   end
+
+   -- check CRC
+   if mspRxCRC ~= payload[idx] then
+      mspStarted = false
+   end
+
+   repliesReceived = repliesReceived + 1
+   mspStarted = false
+   return mspRxBuf
+end
+
+local function pollReply()
+   local sensorId, frameId, dataId, value = sportTelemetryPop()
+   if sensorId == REMOTE_SENSOR_ID and frameId == REPLY_FRAME_ID then
+
+      local payload = {}
+      payload[1] = bit32.band(dataId,0xFF)
+      dataId = bit32.rshift(dataId,8)
+      payload[2] = bit32.band(dataId,0xFF)
+
+      payload[3] = bit32.band(value,0xFF)
+      value = bit32.rshift(value,8)
+      payload[4] = bit32.band(value,0xFF)
+      value = bit32.rshift(value,8)
+      payload[5] = bit32.band(value,0xFF)
+      value = bit32.rshift(value,8)
+      payload[6] = bit32.band(value,0xFF)
+
+      return mspReceivedReply(payload)
+   end
+end
+
 local function run(event)
 
    local now = getTime()
@@ -55,6 +147,10 @@ local function run(event)
    if event == EVT_MINUS_FIRST or event == EVT_ROT_LEFT or event == EVT_MINUS_REPT then
       requestsSent    = 0
       repliesReceived = 0
+      mspReceivedReply_cnt = 0
+      mspReceivedReply_cnt1 = 0
+      mspReceivedReply_cnt2 = 0
+      mspReceivedReply_cnt3 = 0
    end
 
    lcd.clear()
@@ -64,6 +160,18 @@ local function run(event)
    
    lcd.drawText(1,21,"Replies:",0)
    lcd.drawNumber(60,21,repliesReceived)
+
+   lcd.drawText(1,31,"cnt:",0)
+   lcd.drawNumber(30,31,mspReceivedReply_cnt)
+
+   lcd.drawText(1,41,"cnt1:",0)
+   lcd.drawNumber(30,41,mspReceivedReply_cnt1)
+
+   lcd.drawText(71,31,"cnt2:",0)
+   lcd.drawNumber(100,31,mspReceivedReply_cnt2)
+
+   lcd.drawText(71,41,"cnt3:",0)
+   lcd.drawNumber(100,41,mspReceivedReply_cnt3)
 
    -- last request is at least 2s old
    if lastReqTS + 200 <= now then


### PR DESCRIPTION
This is the very first draft of the feature discussed in issue #1311. It is not final nor has it been tested against a real LUA script running in OpenTX. It has been tested so far with the python script included in this branch, with only one MSP request (MSP_API_VERSION), which reply requires 2 S.PORT messages to be transmitted (one containing the SPORT/MSP header, size + cmd; another containing the MSP checksum).

Please feel free to comment.