### PR TITLE
cleanup f7 gcc warnings

### DIFF
--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -85,7 +85,7 @@ void ws2811LedStripHardwareInit(void)
 
     __DMA1_CLK_ENABLE();
 
-    
+
     /* Set the parameters to be configured */
     hdma_tim.Init.Channel  = WS2811_DMA_CHANNEL;
     hdma_tim.Init.Direction = DMA_MEMORY_TO_PERIPH;
@@ -103,23 +103,18 @@ void ws2811LedStripHardwareInit(void)
     /* Set hdma_tim instance */
     hdma_tim.Instance = WS2811_DMA_STREAM;
 
-    uint32_t channelAddress = 0;
     switch (WS2811_TIMER_CHANNEL) {
         case TIM_CHANNEL_1:
             timDMASource = TIM_DMA_ID_CC1;
-            channelAddress = (uint32_t)(&WS2811_TIMER->CCR1);
             break;
         case TIM_CHANNEL_2:
             timDMASource = TIM_DMA_ID_CC2;
-            channelAddress = (uint32_t)(&WS2811_TIMER->CCR2);
             break;
         case TIM_CHANNEL_3:
             timDMASource = TIM_DMA_ID_CC3;
-            channelAddress = (uint32_t)(&WS2811_TIMER->CCR3);
             break;
         case TIM_CHANNEL_4:
             timDMASource = TIM_DMA_ID_CC4;
-            channelAddress = (uint32_t)(&WS2811_TIMER->CCR4);
             break;
     }
 

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -57,7 +57,6 @@ static void usartConfigurePinInversion(uartPort_t *uartPort) {
 
 static void uartReconfigure(uartPort_t *uartPort)
 {
-    HAL_StatusTypeDef status = HAL_ERROR;
     /*RCC_PeriphCLKInitTypeDef RCC_PeriphClkInit;
     RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1|RCC_PERIPHCLK_USART2|RCC_PERIPHCLK_USART3|
             RCC_PERIPHCLK_UART4|RCC_PERIPHCLK_UART5|RCC_PERIPHCLK_USART6|RCC_PERIPHCLK_UART7|RCC_PERIPHCLK_UART8;
@@ -90,11 +89,11 @@ static void uartReconfigure(uartPort_t *uartPort)
 
     if(uartPort->port.options & SERIAL_BIDIR)
     {
-        status = HAL_HalfDuplex_Init(&uartPort->Handle);
+        HAL_HalfDuplex_Init(&uartPort->Handle);
     }
     else
     {
-        status = HAL_UART_Init(&uartPort->Handle);
+        HAL_UART_Init(&uartPort->Handle);
     }
 
     // Receive DMA or IRQ
@@ -216,7 +215,7 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback,
 
 
     s->txDMAEmpty = true;
-    
+
     // common serial initialisation code should move to serialPort::init()
     s->port.rxBufferHead = s->port.rxBufferTail = 0;
     s->port.txBufferHead = s->port.txBufferTail = 0;
@@ -252,7 +251,7 @@ void uartStartTxDMA(uartPort_t *s)
     HAL_UART_StateTypeDef state = HAL_UART_GetState(&s->Handle);
     if((state & HAL_UART_STATE_BUSY_TX) == HAL_UART_STATE_BUSY_TX)
         return;
-   
+
     if (s->port.txBufferHead > s->port.txBufferTail) {
         size = s->port.txBufferHead - s->port.txBufferTail;
         fromwhere = s->port.txBufferTail;
@@ -387,4 +386,3 @@ const struct serialPortVTable uartVTable[] = {
         .endWrite = NULL,
     }
 };
-

--- a/src/main/drivers/timer_stm32f7xx.c
+++ b/src/main/drivers/timer_stm32f7xx.c
@@ -96,6 +96,7 @@ const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
 
 uint8_t timerClockDivisor(TIM_TypeDef *tim)
 {
+    UNUSED(tim);
     return 1;
 }
 


### PR DESCRIPTION
this removes some of the gcc warnings introduce with the f7 target
there are still 22 warning missing in the libs folder