### PR TITLE
Renamed display to dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ HIGHEND_SRC = \
             flight/gps_conversion.c \
             io/gps.c \
             io/ledstrip.c \
-            io/display.c \
+            io/dashboard.c \
             sensors/sonar.c \
             sensors/barometer.c \
             telemetry/telemetry.c \

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -903,8 +903,8 @@ void validateAndFixConfig(void)
 #endif
 
 #if defined(CC3D) && defined(DISPLAY) && defined(USE_UART3)
-    if (doesConfigurationUsePort(SERIAL_PORT_USART3) && feature(FEATURE_DISPLAY)) {
-        featureClear(FEATURE_DISPLAY);
+    if (doesConfigurationUsePort(SERIAL_PORT_USART3) && feature(FEATURE_DASHBOARD)) {
+        featureClear(FEATURE_DASHBOARD);
     }
 #endif
 

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -45,7 +45,7 @@ typedef enum {
     FEATURE_RX_MSP = 1 << 14,
     FEATURE_RSSI_ADC = 1 << 15,
     FEATURE_LED_STRIP = 1 << 16,
-    FEATURE_DISPLAY = 1 << 17,
+    FEATURE_DASHBOARD = 1 << 17,
     FEATURE_OSD = 1 << 18,
     FEATURE_BLACKBOX = 1 << 19,
     FEATURE_CHANNEL_FORWARDING = 1 << 20,

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -41,7 +41,7 @@
 #include "flight/altitudehold.h"
 
 #include "io/beeper.h"
-#include "io/display.h"
+#include "io/dashboard.h"
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/osd.h"
@@ -222,11 +222,11 @@ static void taskCalculateAltitude(uint32_t currentTime)
     }}
 #endif
 
-#ifdef DISPLAY
-static void taskUpdateDisplay(uint32_t currentTime)
+#ifdef USE_DASHBOARD
+static void taskUpdateDashboard(uint32_t currentTime)
 {
-    if (feature(FEATURE_DISPLAY)) {
-        displayUpdate(currentTime);
+    if (feature(FEATURE_DASHBOARD)) {
+        dashboardUpdate(currentTime);
     }
 }
 #endif
@@ -307,8 +307,8 @@ void fcTasksInit(void)
 #if defined(BARO) || defined(SONAR)
     setTaskEnabled(TASK_ALTITUDE, sensors(SENSOR_BARO) || sensors(SENSOR_SONAR));
 #endif
-#ifdef DISPLAY
-    setTaskEnabled(TASK_DISPLAY, feature(FEATURE_DISPLAY));
+#ifdef USE_DASHBOARD
+    setTaskEnabled(TASK_DASHBOARD, feature(FEATURE_DASHBOARD));
 #endif
 #ifdef TELEMETRY
     setTaskEnabled(TASK_TELEMETRY, feature(FEATURE_TELEMETRY));
@@ -446,10 +446,10 @@ cfTask_t cfTasks[TASK_COUNT] = {
     },
 #endif
 
-#ifdef DISPLAY
-    [TASK_DISPLAY] = {
-        .taskName = "DISPLAY",
-        .taskFunc = taskUpdateDisplay,
+#ifdef USE_DASHBOARD
+    [TASK_DASHBOARD] = {
+        .taskName = "DASHBOARD",
+        .taskFunc = taskUpdateDashboard,
         .desiredPeriod = 1000000 / 10,
         .staticPriority = TASK_PRIORITY_LOW,
     },

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -44,7 +44,7 @@
 #include "io/beeper.h"
 #include "io/motors.h"
 #include "io/vtx.h"
-#include "io/display.h"
+#include "io/dashboard.h"
 
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
@@ -291,13 +291,13 @@ void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStat
         return;
     }
 
-#ifdef DISPLAY
+#ifdef USE_DASHBOARD
     if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_LO) {
-        displayDisablePageCycling();
+        dashboardDisablePageCycling();
     }
 
     if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_HI) {
-        displayEnablePageCycling();
+        dashboardEnablePageCycling();
     }
 #endif
 

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -21,7 +21,7 @@
 
 #include "platform.h"
 
-#ifdef DISPLAY
+#ifdef USE_DASHBOARD
 
 #include "build/version.h"
 #include "build/debug.h"
@@ -58,7 +58,7 @@
 #include "config/feature.h"
 #include "config/config_profile.h"
 
-#include "io/display.h"
+#include "io/dashboard.h"
 
 #include "rx/rx.h"
 
@@ -74,7 +74,7 @@ controlRateConfig_t *getControlRateConfig(uint8_t profileIndex);
 #define PAGE_CYCLE_FREQUENCY (MICROSECONDS_IN_A_SECOND * 5)
 
 static uint32_t nextDisplayUpdateAt = 0;
-static bool displayPresent = false;
+static bool dashboardPresent = false;
 
 static rxConfig_t *rxConfig;
 
@@ -98,7 +98,7 @@ static const char* const pageTitles[] = {
 #ifdef GPS
     ,"GPS"
 #endif
-#ifdef ENABLE_DEBUG_OLED_PAGE
+#ifdef ENABLE_DEBUG_DASHBOARD_PAGE
     ,"DEBUG"
 #endif
 };
@@ -116,7 +116,7 @@ const pageId_e cyclePageIds[] = {
 #ifndef SKIP_TASK_STATISTICS
     ,PAGE_TASKS
 #endif
-#ifdef ENABLE_DEBUG_OLED_PAGE
+#ifdef ENABLE_DEBUG_DASHBOARD_PAGE
     ,PAGE_DEBUG,
 #endif
 };
@@ -144,7 +144,7 @@ typedef struct pageState_s {
 static pageState_t pageState;
 
 void resetDisplay(void) {
-    displayPresent = ug2864hsweg01InitI2C();
+    dashboardPresent = ug2864hsweg01InitI2C();
 }
 
 void LCDprint(uint8_t i) {
@@ -562,7 +562,7 @@ void showTasksPage(void)
 }
 #endif
 
-#ifdef ENABLE_DEBUG_OLED_PAGE
+#ifdef ENABLE_DEBUG_DASHBOARD_PAGE
 
 void showDebugPage(void)
 {
@@ -577,7 +577,7 @@ void showDebugPage(void)
 }
 #endif
 
-void displayUpdate(uint32_t currentTime)
+void dashboardUpdate(uint32_t currentTime)
 {
     static uint8_t previousArmedState = 0;
 
@@ -623,13 +623,13 @@ void displayUpdate(uint32_t currentTime)
         // user to power off/on the display or connect it while powered.
         resetDisplay();
 
-        if (!displayPresent) {
+        if (!dashboardPresent) {
             return;
         }
         handlePageChange();
     }
 
-    if (!displayPresent) {
+    if (!dashboardPresent) {
         return;
     }
 
@@ -666,7 +666,7 @@ void displayUpdate(uint32_t currentTime)
             }
             break;
 #endif
-#ifdef ENABLE_DEBUG_OLED_PAGE
+#ifdef ENABLE_DEBUG_DASHBOARD_PAGE
         case PAGE_DEBUG:
             showDebugPage();
             break;
@@ -680,13 +680,13 @@ void displayUpdate(uint32_t currentTime)
 
 }
 
-void displaySetPage(pageId_e pageId)
+void dashboardSetPage(pageId_e pageId)
 {
     pageState.pageId = pageId;
     pageState.pageFlags |= PAGE_STATE_FLAG_FORCE_PAGE_CHANGE;
 }
 
-void displayInit(rxConfig_t *rxConfigToUse)
+void dashboardInit(rxConfig_t *rxConfigToUse)
 {
     delay(200);
     resetDisplay();
@@ -695,36 +695,36 @@ void displayInit(rxConfig_t *rxConfigToUse)
     rxConfig = rxConfigToUse;
 
     memset(&pageState, 0, sizeof(pageState));
-    displaySetPage(PAGE_WELCOME);
+    dashboardSetPage(PAGE_WELCOME);
 
-    displayUpdate(micros());
+    dashboardUpdate(micros());
 
-    displaySetNextPageChangeAt(micros() + (1000 * 1000 * 5));
+    dashboardSetNextPageChangeAt(micros() + (1000 * 1000 * 5));
 }
 
-void displayShowFixedPage(pageId_e pageId)
+void dashboardShowFixedPage(pageId_e pageId)
 {
-    displaySetPage(pageId);
-    displayDisablePageCycling();
+    dashboardSetPage(pageId);
+    dashboardDisablePageCycling();
 }
 
-void displaySetNextPageChangeAt(uint32_t futureMicros)
+void dashboardSetNextPageChangeAt(uint32_t futureMicros)
 {
     pageState.nextPageAt = futureMicros;
 }
 
-void displayEnablePageCycling(void)
+void dashboardEnablePageCycling(void)
 {
     pageState.pageFlags |= PAGE_STATE_FLAG_CYCLE_ENABLED;
 }
 
-void displayResetPageCycling(void)
+void dashboardResetPageCycling(void)
 {
     pageState.cycleIndex = CYCLE_PAGE_ID_COUNT - 1; // start at first page
 
 }
 
-void displayDisablePageCycling(void)
+void dashboardDisablePageCycling(void)
 {
     pageState.pageFlags &= ~PAGE_STATE_FLAG_CYCLE_ENABLED;
 }

--- a/src/main/io/dashboard.h
+++ b/src/main/io/dashboard.h
@@ -15,7 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define ENABLE_DEBUG_OLED_PAGE
+#define ENABLE_DEBUG_DASHBOARD_PAGE
 
 typedef enum {
     PAGE_WELCOME,
@@ -30,18 +30,18 @@ typedef enum {
 #ifdef GPS
     PAGE_GPS,
 #endif
-#ifdef ENABLE_DEBUG_OLED_PAGE
+#ifdef ENABLE_DEBUG_DASHBOARD_PAGE
     PAGE_DEBUG,
 #endif
 } pageId_e;
 
 struct rxConfig_s;
-void displayInit(struct rxConfig_s *intialRxConfig);
-void displayUpdate(uint32_t currentTime);
+void dashboardInit(struct rxConfig_s *intialRxConfig);
+void dashboardUpdate(uint32_t currentTime);
 
-void displayShowFixedPage(pageId_e pageId);
+void dashboardShowFixedPage(pageId_e pageId);
 
-void displayEnablePageCycling(void);
-void displayDisablePageCycling(void);
-void displayResetPageCycling(void);
-void displaySetNextPageChangeAt(uint32_t futureMicros);
+void dashboardEnablePageCycling(void);
+void dashboardDisablePageCycling(void);
+void dashboardResetPageCycling(void);
+void dashboardSetNextPageChangeAt(uint32_t futureMicros);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -39,7 +39,7 @@
 #include "sensors/sensors.h"
 
 #include "io/serial.h"
-#include "io/display.h"
+#include "io/dashboard.h"
 #include "io/gps.h"
 
 #include "flight/gps_conversion.h"
@@ -1072,9 +1072,9 @@ static bool gpsNewFrameUBLOX(uint8_t data)
 static void gpsHandlePassthrough(uint8_t data)
  {
      gpsNewData(data);
- #ifdef DISPLAY
-     if (feature(FEATURE_DISPLAY)) {
-         displayUpdate(micros());
+ #ifdef USE_DASHBOARD
+     if (feature(FEATURE_DASHBOARD)) {
+         dashboardUpdate(micros());
      }
  #endif
 
@@ -1088,9 +1088,9 @@ void gpsEnablePassthrough(serialPort_t *gpsPassthroughPort)
     if(!(gpsPort->mode & MODE_TX))
         serialSetMode(gpsPort, gpsPort->mode | MODE_TX);
 
-#ifdef DISPLAY
-    if (feature(FEATURE_DISPLAY)) {
-        displayShowFixedPage(PAGE_GPS);
+#ifdef USE_DASHBOARD
+    if (feature(FEATURE_DASHBOARD)) {
+        dashboardShowFixedPage(PAGE_GPS);
     }
 #endif
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -82,7 +82,7 @@
 #include "io/servos.h"
 #include "io/gimbal.h"
 #include "io/ledstrip.h"
-#include "io/display.h"
+#include "io/dashboard.h"
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/serial_cli.h"
 #include "io/transponder_ir.h"
@@ -395,9 +395,9 @@ void init(void)
 
     initBoardAlignment(&masterConfig.boardAlignment);
 
-#ifdef DISPLAY
-    if (feature(FEATURE_DISPLAY)) {
-        displayInit(&masterConfig.rxConfig);
+#ifdef USE_DASHBOARD
+    if (feature(FEATURE_DASHBOARD)) {
+        dashboardInit(&masterConfig.rxConfig);
     }
 #endif
 
@@ -585,13 +585,13 @@ void init(void)
     if (feature(FEATURE_VBAT | FEATURE_CURRENT_METER))
         batteryInit(&masterConfig.batteryConfig);
 
-#ifdef DISPLAY
-    if (feature(FEATURE_DISPLAY)) {
+#ifdef USE_DASHBOARD
+    if (feature(FEATURE_DASHBOARD)) {
 #ifdef USE_OLED_GPS_DEBUG_PAGE_ONLY
-        displayShowFixedPage(PAGE_GPS);
+        dashboardShowFixedPage(PAGE_GPS);
 #else
-        displayResetPageCycling();
-        displayEnablePageCycling();
+        dashboardResetPageCycling();
+        dashboardEnablePageCycling();
 #endif
     }
 #endif

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -67,8 +67,8 @@ typedef enum {
 #if defined(BARO) || defined(SONAR)
     TASK_ALTITUDE,
 #endif
-#ifdef DISPLAY
-    TASK_DISPLAY,
+#ifdef USE_DASHBOARD
+    TASK_DASHBOARD,
 #endif
 #ifdef TELEMETRY
     TASK_TELEMETRY,

--- a/src/main/target/AIR32/target.h
+++ b/src/main/target/AIR32/target.h
@@ -89,7 +89,6 @@
 #define SENSORS_SET             (SENSOR_ACC)
 
 #undef GPS
-#define DISPLAY
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 

--- a/src/main/target/MICROSCISKY/target.h
+++ b/src/main/target/MICROSCISKY/target.h
@@ -91,7 +91,6 @@
 #undef GPS
 #undef USE_SERVOS
 #define USE_QUAD_MIXER_ONLY
-#define DISPLAY
 
 
 // IO - assuming all IOs on 48pin package

--- a/src/main/target/MOTOLAB/target.h
+++ b/src/main/target/MOTOLAB/target.h
@@ -91,7 +91,6 @@
 #define SENSORS_SET             (SENSOR_ACC)
 
 #undef GPS
-#define DISPLAY
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -118,8 +118,6 @@
 //#define SONAR_TRIGGER_PIN_PWM   PB8
 //#define SONAR_ECHO_PIN_PWM      PB9
 
-//#define DISPLAY
-
 #define USE_UART1
 #define USE_UART2
 /* only 2 uarts available on the NAZE, add ifdef here if present on other boards */ 

--- a/src/main/target/RCEXPLORERF3/target.h
+++ b/src/main/target/RCEXPLORERF3/target.h
@@ -130,7 +130,6 @@
 #define TELEMETRY
 #define SERIAL_RX
 #define AUTOTUNE
-#define DISPLAY
 #define USE_SERVOS
 #define USE_CLI
 

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -55,7 +55,7 @@
 #endif
 
 #if (FLASH_SIZE > 128)
-#define DISPLAY
+#define USE_DASHBOARD
 #define TELEMETRY_MAVLINK
 #else
 #define SKIP_CLI_COMMAND_HELP


### PR DESCRIPTION
Renamed display to dashboard since:

1. This is a more accurate description of what it is.
2. It frees up the name display for use by the new display abstraction