### PR TITLE
Smart Port telemetry GPS ground speed unit is not applicable. (#2166)

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -628,8 +628,10 @@ void handleSmartPortTelemetry(void)
 #ifdef GPS
             case FSSP_DATAID_SPEED      :
                 if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
-                    uint32_t tmpui = (GPS_speed * 36 + 36 / 2) / 100;
-                    smartPortSendPackage(id, tmpui); // given in 0.1 m/s, provide in KM/H
+                    //convert to knots: 1cm/s = 0.0194384449 knots
+                    //Speed should be sent in knots/1000 (GPS speed is in cm/s)
+                    uint32_t tmpui = GPS_speed * 1944 / 100; 
+                    smartPortSendPackage(id, tmpui);
                     smartPortHasRequest = 0;
                 }
                 break;


### PR DESCRIPTION
Pull in fix already done for Cleanflight and iNav to fix the speed units on SmartPort telemetry