### PR TITLE
Fixed SPort Acc values to display in G

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -703,18 +703,15 @@ void handleSmartPortTelemetry(void)
                 smartPortHasRequest = 0;
                 break;
             case FSSP_DATAID_ACCX       :
-                smartPortSendPackage(id, accSmooth[X] / 44);
-                // unknown input and unknown output unit
-                // we can only show 00.00 format, another digit won't display right on Taranis
-                // dividing by roughly 44 will give acceleration in G units
+                smartPortSendPackage(id, 100 * accSmooth[X] / acc.acc_1G); // Multiply by 100 to show as x.xx g on Taranis
                 smartPortHasRequest = 0;
                 break;
             case FSSP_DATAID_ACCY       :
-                smartPortSendPackage(id, accSmooth[Y] / 44);
+                smartPortSendPackage(id, 100 * accSmooth[Y] / acc.acc_1G);
                 smartPortHasRequest = 0;
                 break;
             case FSSP_DATAID_ACCZ       :
-                smartPortSendPackage(id, accSmooth[Z] / 44);
+                smartPortSendPackage(id, 100 * accSmooth[Z] / acc.acc_1G);
                 smartPortHasRequest = 0;
                 break;
             case FSSP_DATAID_T1         :


### PR DESCRIPTION
Noticed that the AccX,Y,Z readings on my Taranis were around half the expected value. (~0.48G Z at rest)
I changed the division of accsmooth[ ] from hard coded number (44) to acc.acc_1G
Tested on Taranis and now works as expected.