### PR TITLE
YuPi F4 target update

### DIFF
--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -33,12 +33,12 @@
 #define INVERTER_USART 	        USART6
 
 
-// MPU6500 interrupt
+// Gyro interrupt
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
 #define MPU_INT_EXTI            PC4
 
-//MPU6500
+//ICM 20689
 #define ICM20689_CS_PIN          PA4
 #define ICM20689_SPI_INSTANCE    SPI1
 
@@ -49,6 +49,21 @@
 #define GYRO
 #define USE_GYRO_SPI_ICM20689
 #define GYRO_ICM20689_ALIGN      CW90_DEG
+
+// MPU 6500
+#define MPU6500_CS_PIN          PA4
+#define MPU6500_SPI_INSTANCE    SPI1
+
+#define ACC
+#define USE_ACC_MPU6500
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW90_DEG
+
+#define GYRO
+#define USE_GYRO_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN      CW90_DEG
+
 
 #define USE_VCP
 //#define VBUS_SENSING_PIN        PA8

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -116,7 +116,6 @@
 
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1) // SCL PB8 - SDA PB9
-#define USE_I2C_PULLUP
 
 // ADC inputs
 #define BOARD_HAS_VOLTAGE_DIVIDER

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -27,6 +27,7 @@
 #define LED2                    PB5
 
 #define BEEPER                  PC9
+#define BEEPER_INVERTED
 
 #define INVERTER                PB15
 #define INVERTER_USART 	        USART6

--- a/src/main/target/YUPIF4/target.mk
+++ b/src/main/target/YUPIF4/target.mk
@@ -2,5 +2,7 @@ F405_TARGETS    += $(TARGET)
 FEATURES        += SDCARD VCP
 
 TARGET_SRC = \
+            drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu6500.c \
             drivers/accgyro_spi_icm20689.c
 


### PR DESCRIPTION
Only target.h and target.mk of the YupiF4 target is changed to invert the Beeper logic, deactivate the I2C pull-up and add yhe possibiliity to use an MPU 6500.