### PR TITLE
Adding DMA ownership for ADC, LED STRIP, USART and MOTOR

### DIFF
--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -51,7 +51,6 @@ typedef struct adcTagMap_s {
 typedef struct adcDevice_s {
     ADC_TypeDef* ADCx;
     rccPeriphTag_t rccADC;
-    rccPeriphTag_t rccDMA;
 #if defined(STM32F4) || defined(STM32F7)
     DMA_Stream_TypeDef* DMAy_Streamx;
     uint32_t channel;

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -32,13 +32,14 @@
 #include "adc_impl.h"
 #include "io.h"
 #include "rcc.h"
+#include "dma.h"
 
 #ifndef ADC_INSTANCE
 #define ADC_INSTANCE   ADC1
 #endif
 
 const adcDevice_t adcHardware[] = {
-    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .rccDMA = RCC_AHB(DMA1), .DMAy_Channelx = DMA1_Channel1 } 
+    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Channelx = DMA1_Channel1 } 
 };
 
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
@@ -131,7 +132,8 @@ void adcInit(drv_adc_config_t *init)
 
     RCC_ADCCLKConfig(RCC_PCLK2_Div8);  // 9MHz from 72MHz APB2 clock(HSE), 8MHz from 64MHz (HSI)
     RCC_ClockCmd(adc.rccADC, ENABLE);
-    RCC_ClockCmd(adc.rccDMA, ENABLE);
+
+    dmaInit(dmaGetIdentifier(adc.DMAy_Channelx), OWNER_ADC, RESOURCE_INDEX(device));
 
     DMA_DeInit(adc.DMAy_Channelx);
     DMA_InitTypeDef DMA_InitStructure;

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -30,6 +30,7 @@
 #include "adc_impl.h"
 #include "io.h"
 #include "rcc.h"
+#include "dma.h"
 
 #include "common/utils.h"
 
@@ -38,8 +39,8 @@
 #endif
 
 const adcDevice_t adcHardware[] = {
-    { .ADCx = ADC1, .rccADC = RCC_AHB(ADC12), .rccDMA = RCC_AHB(DMA1), .DMAy_Channelx = DMA1_Channel1 }, 
-    { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12), .rccDMA = RCC_AHB(DMA2), .DMAy_Channelx = DMA2_Channel1 } 
+    { .ADCx = ADC1, .rccADC = RCC_AHB(ADC12), .DMAy_Channelx = DMA1_Channel1 }, 
+    { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12), .DMAy_Channelx = DMA2_Channel1 } 
 };
 
 const adcTagMap_t adcTagMap[] = {
@@ -149,7 +150,8 @@ void adcInit(drv_adc_config_t *init)
 
     RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div256);  // 72 MHz divided by 256 = 281.25 kHz
     RCC_ClockCmd(adc.rccADC, ENABLE);
-    RCC_ClockCmd(adc.rccDMA, ENABLE);
+
+    dmaInit(dmaGetIdentifier(adc.DMAy_Channelx), OWNER_ADC, RESOURCE_INDEX(device));
 
     DMA_DeInit(adc.DMAy_Channelx);
 

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -25,6 +25,7 @@
 #include "io.h"
 #include "io_impl.h"
 #include "rcc.h"
+#include "dma.h"
 
 #include "sensor.h"
 #include "accgyro.h"
@@ -37,8 +38,8 @@
 #endif
 
 const adcDevice_t adcHardware[] = {
-    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream4, .channel = DMA_Channel_0 }, 
-    //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 } 
+    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = DMA2_Stream4, .channel = DMA_Channel_0 }, 
+    //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 } 
 };
 
 /* note these could be packed up for saving space */
@@ -140,8 +141,9 @@ void adcInit(drv_adc_config_t *init)
         adcConfig[i].enabled = true;
     }
 
-    RCC_ClockCmd(adc.rccDMA, ENABLE);
     RCC_ClockCmd(adc.rccADC, ENABLE);
+
+    dmaInit(dmaGetIdentifier(adc.DMAy_Streamx), OWNER_ADC, RESOURCE_INDEX(device));
 
     DMA_DeInit(adc.DMAy_Streamx);
 

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -25,6 +25,7 @@
 #include "io.h"
 #include "io_impl.h"
 #include "rcc.h"
+#include "dma.h"
 
 #include "sensor.h"
 #include "accgyro.h"
@@ -37,8 +38,8 @@
 #endif
 
 const adcDevice_t adcHardware[] = { 
-    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream4, .channel = DMA_CHANNEL_0 },
-    //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .rccDMA = RCC_AHB1(DMA2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 }  
+    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = DMA2_Stream4, .channel = DMA_CHANNEL_0 },
+    //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 }  
 };
 
 /* note these could be packed up for saving space */
@@ -138,8 +139,9 @@ void adcInit(drv_adc_config_t *init)
         adcConfig[i].enabled = true;
     }
 
-    RCC_ClockCmd(adc.rccDMA, ENABLE);
+
     RCC_ClockCmd(adc.rccADC, ENABLE);
+    dmaInit(dmaGetIdentifier(adc.DMAy_Streamx), OWNER_ADC, RESOURCE_INDEX(device));
 
     ADCHandle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV8;
     ADCHandle.Init.ContinuousConvMode    = ENABLE;

--- a/src/main/drivers/dma.c
+++ b/src/main/drivers/dma.c
@@ -63,16 +63,18 @@ DEFINE_DMA_IRQ_HANDLER(2, 4, DMA2_CH4_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 5, DMA2_CH5_HANDLER)
 #endif
 
-
-void dmaInit(void)
+void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)
 {
-    // TODO: Do we need this?
+    RCC_AHBPeriphClockCmd(dmaDescriptors[identifier].rcc, ENABLE);
+    dmaDescriptors[identifier].owner = owner;
+    dmaDescriptors[identifier].resourceIndex = resourceIndex;
 }
 
-void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
+void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
 {
     NVIC_InitTypeDef NVIC_InitStructure;
 
+    /* TODO: remove this - enforce the init */
     RCC_AHBPeriphClockCmd(dmaDescriptors[identifier].rcc, ENABLE);
     dmaDescriptors[identifier].irqHandlerCallback = callback;
     dmaDescriptors[identifier].userParam = userParam;
@@ -84,3 +86,22 @@ void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr 
     NVIC_Init(&NVIC_InitStructure);
 }
 
+resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+{
+    return dmaDescriptors[identifier].owner;
+}
+
+uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
+{
+    return dmaDescriptors[identifier].resourceIndex;    
+}
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Channel_TypeDef* channel)
+{
+    for (int i = 0; i < DMA_MAX_DESCRIPTORS; i++) {
+        if (dmaDescriptors[i].channel == channel) {
+            return i;
+        }
+    }
+    return 0;    
+}

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -17,8 +17,26 @@
 
 #pragma once
 
+#include "resource.h"
+
 struct dmaChannelDescriptor_s;
 typedef void (*dmaCallbackHandlerFuncPtr)(struct dmaChannelDescriptor_s *channelDescriptor);
+
+typedef struct dmaChannelDescriptor_s {
+    DMA_TypeDef*                dma;
+#if defined(STM32F4) || defined(STM32F7)
+    DMA_Stream_TypeDef*         stream;
+#else
+    DMA_Channel_TypeDef*        channel;
+#endif
+    dmaCallbackHandlerFuncPtr   irqHandlerCallback;
+    uint8_t                     flagsShift;
+    IRQn_Type                   irqN;
+    uint32_t                    rcc;
+    uint32_t                    userParam;
+    resourceOwner_e             owner;
+    uint8_t                     resourceIndex;
+} dmaChannelDescriptor_t;
 
 #if defined(STM32F4) || defined(STM32F7)
 
@@ -41,19 +59,15 @@ typedef enum {
     DMA2_ST5_HANDLER,
     DMA2_ST6_HANDLER,
     DMA2_ST7_HANDLER,
-} dmaHandlerIdentifier_e;
+    DMA_MAX_DESCRIPTORS
+} dmaIdentifier_e;
 
-typedef struct dmaChannelDescriptor_s {
-    DMA_TypeDef*                dma;
-    DMA_Stream_TypeDef*         stream;
-    dmaCallbackHandlerFuncPtr   irqHandlerCallback;
-    uint8_t                     flagsShift;
-    IRQn_Type                   irqN;
-    uint32_t                    rcc;
-    uint32_t                    userParam;
-} dmaChannelDescriptor_t;
+#define DMA_MOD_VALUE       8
+#define DMA_MOD_OFFSET      0
+#define DMA_OUTPUT_INDEX    0
+#define DMA_OUTPUT_STRING   "DMA%d Stream %d:"
 
-#define DEFINE_DMA_CHANNEL(d, s, f, i, r) {.dma = d, .stream = s, .irqHandlerCallback = NULL, .flagsShift = f, .irqN = i, .rcc = r, .userParam = 0}
+#define DEFINE_DMA_CHANNEL(d, s, f, i, r) {.dma = d, .stream = s, .irqHandlerCallback = NULL, .flagsShift = f, .irqN = i, .rcc = r, .userParam = 0, .owner = 0, .resourceIndex = 0 }
 #define DEFINE_DMA_IRQ_HANDLER(d, s, i) void DMA ## d ## _Stream ## s ## _IRQHandler(void) {\
                                                                 if (dmaDescriptors[i].irqHandlerCallback)\
                                                                     dmaDescriptors[i].irqHandlerCallback(&dmaDescriptors[i]);\
@@ -63,11 +77,13 @@ typedef struct dmaChannelDescriptor_s {
 #define DMA_GET_FLAG_STATUS(d, flag) (d->flagsShift > 31 ? d->dma->HISR & (flag << (d->flagsShift - 32)): d->dma->LISR & (flag << d->flagsShift))
 
 
-#define DMA_IT_TCIF                         ((uint32_t)0x00000020)
-#define DMA_IT_HTIF                         ((uint32_t)0x00000010)
-#define DMA_IT_TEIF                         ((uint32_t)0x00000008)
-#define DMA_IT_DMEIF                        ((uint32_t)0x00000004)
-#define DMA_IT_FEIF                         ((uint32_t)0x00000001)
+#define DMA_IT_TCIF         ((uint32_t)0x00000020)
+#define DMA_IT_HTIF         ((uint32_t)0x00000010)
+#define DMA_IT_TEIF         ((uint32_t)0x00000008)
+#define DMA_IT_DMEIF        ((uint32_t)0x00000004)
+#define DMA_IT_FEIF         ((uint32_t)0x00000001)
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream);
    
 #else
 
@@ -79,24 +95,22 @@ typedef enum {
     DMA1_CH5_HANDLER,
     DMA1_CH6_HANDLER,
     DMA1_CH7_HANDLER,
+#if defined(STM32F3) || defined(STM32F10X_CL)    
     DMA2_CH1_HANDLER,
     DMA2_CH2_HANDLER,
     DMA2_CH3_HANDLER,
     DMA2_CH4_HANDLER,
     DMA2_CH5_HANDLER,
-} dmaHandlerIdentifier_e;
+#endif
+    DMA_MAX_DESCRIPTORS
+} dmaIdentifier_e;
 
-typedef struct dmaChannelDescriptor_s {
-    DMA_TypeDef*                dma;
-    DMA_Channel_TypeDef*        channel;
-    dmaCallbackHandlerFuncPtr   irqHandlerCallback;
-    uint8_t                     flagsShift;
-    IRQn_Type                   irqN;
-    uint32_t                    rcc;
-    uint32_t                    userParam;
-} dmaChannelDescriptor_t;
+#define DMA_MOD_VALUE       7
+#define DMA_MOD_OFFSET      1
+#define DMA_OUTPUT_INDEX    0
+#define DMA_OUTPUT_STRING   "DMA%d Channel %d:"
 
-#define DEFINE_DMA_CHANNEL(d, c, f, i, r) {.dma = d, .channel = c, .irqHandlerCallback = NULL, .flagsShift = f, .irqN = i, .rcc = r, .userParam = 0}
+#define DEFINE_DMA_CHANNEL(d, c, f, i, r) {.dma = d, .channel = c, .irqHandlerCallback = NULL, .flagsShift = f, .irqN = i, .rcc = r, .userParam = 0, .owner = 0, .resourceIndex = 0 }
 #define DEFINE_DMA_IRQ_HANDLER(d, c, i) void DMA ## d ## _Channel ## c ## _IRQHandler(void) {\
                                                                         if (dmaDescriptors[i].irqHandlerCallback)\
                                                                             dmaDescriptors[i].irqHandlerCallback(&dmaDescriptors[i]);\
@@ -105,12 +119,16 @@ typedef struct dmaChannelDescriptor_s {
 #define DMA_CLEAR_FLAG(d, flag) d->dma->IFCR = (flag << d->flagsShift)
 #define DMA_GET_FLAG_STATUS(d, flag) (d->dma->ISR & (flag << d->flagsShift))
 
-#define DMA_IT_TCIF                          ((uint32_t)0x00000002)
-#define DMA_IT_HTIF                          ((uint32_t)0x00000004)
-#define DMA_IT_TEIF                          ((uint32_t)0x00000008)
+#define DMA_IT_TCIF         ((uint32_t)0x00000002)
+#define DMA_IT_HTIF         ((uint32_t)0x00000004)
+#define DMA_IT_TEIF         ((uint32_t)0x00000008)
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Channel_TypeDef* channel);
 
 #endif
 
-void dmaInit(void);
-void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam);
+void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);
+void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam);
 
+resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier);
+uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier);

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -23,11 +23,12 @@
 
 #include "nvic.h"
 #include "dma.h"
+#include "resource.h"
 
 /*
  * DMA descriptors.
  */
-static dmaChannelDescriptor_t dmaDescriptors[] = {
+static dmaChannelDescriptor_t dmaDescriptors[DMA_MAX_DESCRIPTORS] = {
     DEFINE_DMA_CHANNEL(DMA1, DMA1_Stream0,  0, DMA1_Stream0_IRQn, RCC_AHB1Periph_DMA1),
     DEFINE_DMA_CHANNEL(DMA1, DMA1_Stream1,  6, DMA1_Stream1_IRQn, RCC_AHB1Periph_DMA1),
     DEFINE_DMA_CHANNEL(DMA1, DMA1_Stream2, 16, DMA1_Stream2_IRQn, RCC_AHB1Periph_DMA1),
@@ -67,12 +68,14 @@ DEFINE_DMA_IRQ_HANDLER(2, 5, DMA2_ST5_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 6, DMA2_ST6_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
-void dmaInit(void)
+void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)
 {
-    // TODO: Do we need this?
+    RCC_AHB1PeriphClockCmd(dmaDescriptors[identifier].rcc, ENABLE);
+    dmaDescriptors[identifier].owner = owner;
+    dmaDescriptors[identifier].resourceIndex = resourceIndex;
 }
 
-void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
+void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
 {
     NVIC_InitTypeDef NVIC_InitStructure;
 
@@ -99,5 +102,25 @@ uint32_t dmaFlag_IT_TCIF(const DMA_Stream_TypeDef *stream)
     RETURN_TCIF_FLAG(stream, 5);
     RETURN_TCIF_FLAG(stream, 6);
     RETURN_TCIF_FLAG(stream, 7);
+    return 0;
+}
+
+resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+{
+    return dmaDescriptors[identifier].owner;
+}
+
+uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
+{
+    return dmaDescriptors[identifier].resourceIndex;    
+}
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
+{
+    for (int i = 0; i < DMA_MAX_DESCRIPTORS; i++) {
+        if (dmaDescriptors[i].stream == stream) {
+            return i;
+        }
+    }
     return 0;
 }

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -23,11 +23,12 @@
 
 #include "drivers/nvic.h"
 #include "drivers/dma.h"
+#include "resource.h"
 
 /*
  * DMA descriptors.
  */
-static dmaChannelDescriptor_t dmaDescriptors[] = {
+static dmaChannelDescriptor_t dmaDescriptors[DMA_MAX_DESCRIPTORS] = {
     DEFINE_DMA_CHANNEL(DMA1, DMA1_Stream0,  0, DMA1_Stream0_IRQn, RCC_AHB1ENR_DMA1EN),
     DEFINE_DMA_CHANNEL(DMA1, DMA1_Stream1,  6, DMA1_Stream1_IRQn, RCC_AHB1ENR_DMA1EN),
     DEFINE_DMA_CHANNEL(DMA1, DMA1_Stream2, 16, DMA1_Stream2_IRQn, RCC_AHB1ENR_DMA1EN),
@@ -68,30 +69,50 @@ DEFINE_DMA_IRQ_HANDLER(2, 5, DMA2_ST5_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 6, DMA2_ST6_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
-
-void dmaInit(void)
+static void enableDmaClock(uint32_t rcc)
 {
-    // TODO: Do we need this?
-}
-
-void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
-{
-    //clock
-    //RCC_AHB1PeriphClockCmd(dmaDescriptors[identifier].rcc, ENABLE);
-
     do {
         __IO uint32_t tmpreg;
-        SET_BIT(RCC->AHB1ENR, dmaDescriptors[identifier].rcc);
+        SET_BIT(RCC->AHB1ENR, rcc);
         /* Delay after an RCC peripheral clock enabling */
-        tmpreg = READ_BIT(RCC->AHB1ENR, dmaDescriptors[identifier].rcc);
+        tmpreg = READ_BIT(RCC->AHB1ENR, rcc);
         UNUSED(tmpreg);
     } while(0);
+}
 
+void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)
+{
+    enableDmaClock(dmaDescriptors[identifier].rcc);
+    dmaDescriptors[identifier].owner = owner;
+    dmaDescriptors[identifier].resourceIndex = resourceIndex;
+}
+
+void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
+{
+    enableDmaClock(dmaDescriptors[identifier].rcc);
     dmaDescriptors[identifier].irqHandlerCallback = callback;
     dmaDescriptors[identifier].userParam = userParam;
-
 
     HAL_NVIC_SetPriority(dmaDescriptors[identifier].irqN, NVIC_PRIORITY_BASE(priority), NVIC_PRIORITY_SUB(priority));
     HAL_NVIC_EnableIRQ(dmaDescriptors[identifier].irqN);
 }
 
+resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+{
+    return dmaDescriptors[identifier].owner;
+}
+
+uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
+{
+    return dmaDescriptors[identifier].resourceIndex;    
+}
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
+{
+    for (int i = 0; i < DMA_MAX_DESCRIPTORS; i++) {
+        if (dmaDescriptors[i].stream == stream) {
+            return i;
+        }
+    }
+    return 0;
+}

--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -65,7 +65,7 @@ const struct ioPortDef_s ioPortDefs[] = {
 const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "FREE", "PWM", "PPM", "MOTOR", "SERVO", "SOFTSERIAL", "ADC", "SERIAL", "DEBUG", "TIMER",
     "SONAR_TRIGGER", "SONAR_ECHO", "SYSTEM", "SPI", "I2C", "SDCARD", "FLASH", "USB", "BEEPER", "OSD",
-    "BARO", "MPU", "INVERTER", "LED_STRIP", "LED", "RX", "TX", "SOFT_SPI", "RX_SPI" 
+    "BARO", "MPU", "INVERTER", "LED_STRIP", "LED", "RX", "TX", "SOFT_SPI", "RX_SPI", "MAX7456"
 };
 
 const char * const resourceNames[RESOURCE_TOTAL_COUNT] = {

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -106,6 +106,7 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&TimHandle, hdma[dmaSource], hdma_tim);
 
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, dmaSource);
 
     /* Initialize TIMx DMA handle */

--- a/src/main/drivers/light_ws2811strip_stm32f10x.c
+++ b/src/main/drivers/light_ws2811strip_stm32f10x.c
@@ -114,6 +114,8 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_DMACmd(timer, timerDmaSource(timerHardware->channel), ENABLE);
 
     DMA_ITConfig(dmaChannel, DMA_IT_TC, ENABLE);
+
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, 0);
 
     const hsvColor_t hsv_white = {  0, 255, 255};

--- a/src/main/drivers/light_ws2811strip_stm32f30x.c
+++ b/src/main/drivers/light_ws2811strip_stm32f30x.c
@@ -124,6 +124,8 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_DMACmd(timer, timerDmaSource(timerHardware->channel), ENABLE);
 
     DMA_ITConfig(dmaChannel, DMA_IT_TC, ENABLE);
+
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, 0);
 
     const hsvColor_t hsv_white = {  0, 255, 255};

--- a/src/main/drivers/light_ws2811strip_stm32f4xx.c
+++ b/src/main/drivers/light_ws2811strip_stm32f4xx.c
@@ -138,6 +138,7 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     DMA_ITConfig(stream, DMA_IT_TC, ENABLE);
     DMA_ClearITPendingBit(stream, dmaFlag_IT_TCIF(stream));
 
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, 0);
 
     const hsvColor_t hsv_white = { 0, 255, 255 };

--- a/src/main/drivers/pwm_output_stm32f3xx.c
+++ b/src/main/drivers/pwm_output_stm32f3xx.c
@@ -173,6 +173,7 @@ void pwmDigitalMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t
 
     DMA_Channel_TypeDef *channel = timerHardware->dmaChannel;
 
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_MOTOR, motorIndex);
     dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
         
     DMA_Cmd(channel, DISABLE);

--- a/src/main/drivers/pwm_output_stm32f4xx.c
+++ b/src/main/drivers/pwm_output_stm32f4xx.c
@@ -173,9 +173,13 @@ void pwmDigitalMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t
     }
 
     DMA_Stream_TypeDef *stream = timerHardware->dmaStream;
+
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_MOTOR, motorIndex);
+    dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
     
     DMA_Cmd(stream, DISABLE);
     DMA_DeInit(stream);
+
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_Channel = timerHardware->dmaChannel;
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)timerChCCR(timerHardware);
@@ -197,8 +201,6 @@ void pwmDigitalMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t
 
     DMA_ITConfig(stream, DMA_IT_TC, ENABLE);
     DMA_ClearITPendingBit(stream, dmaFlag_IT_TCIF(timerHardware->dmaStream));
-    
-    dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 }
 
 #endif

--- a/src/main/drivers/pwm_output_stm32f7xx.c
+++ b/src/main/drivers/pwm_output_stm32f7xx.c
@@ -202,6 +202,7 @@ void pwmDigitalMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&motor->TimHandle, hdma[motor->timerDmaSource], motor->hdma_tim);
 
+    dmaInit(timerHardware->dmaIrqHandler, OWNER_MOTOR, motorIndex);
     dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 
     /* Initialize TIMx DMA handle */

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -33,6 +33,7 @@ typedef enum {
     OWNER_TX,
     OWNER_SOFTSPI,
     OWNER_RX_SPI,
+    OWNER_MAX7456,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -109,8 +109,8 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     s->USARTx = USART1;
 
-
 #ifdef USE_UART1_RX_DMA
+    dmaInit(DMA1_CH5_HANDLER, OWNER_SERIAL, 1);
     s->rxDMAChannel = DMA1_Channel5;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
 #endif
@@ -118,7 +118,6 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
 
     RCC_ClockCmd(RCC_APB2(USART1), ENABLE);
-    RCC_ClockCmd(RCC_AHB(DMA1), ENABLE);
 
     // UART1_TX    PA9
     // UART1_RX    PA10
@@ -138,6 +137,7 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
     }
 
     // DMA TX Interrupt
+    dmaInit(DMA1_CH4_HANDLER, OWNER_SERIAL, 1);
     dmaSetHandler(DMA1_CH4_HANDLER, uart_tx_dma_IRQHandler, NVIC_PRIO_SERIALUART1_TXDMA, (uint32_t)&uartPort1);
 
 #ifndef USE_UART1_RX_DMA
@@ -189,7 +189,6 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
 
     RCC_ClockCmd(RCC_APB1(USART2), ENABLE);
-    RCC_ClockCmd(RCC_AHB(DMA1), ENABLE);
 
     // UART2_TX    PA2
     // UART2_RX    PA3

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -160,6 +160,7 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
     s->USARTx = USART1;
 
 #ifdef USE_UART1_RX_DMA
+    dmaInit(DMA1_CH5_HANDLER, OWNER_SERIAL, 1);
     s->rxDMAChannel = DMA1_Channel5;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->RDR;
 #endif
@@ -177,6 +178,7 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
     serialUARTInit(IOGetByTag(IO_TAG(UART1_TX_PIN)), IOGetByTag(IO_TAG(UART1_RX_PIN)), mode, options, GPIO_AF_7, 1);
 
 #ifdef USE_UART1_TX_DMA
+    dmaInit(DMA1_CH4_HANDLER, OWNER_SERIAL, 1);
     dmaSetHandler(DMA1_CH4_HANDLER, handleUsartTxDma, NVIC_PRIO_SERIALUART1_TXDMA, (uint32_t)&uartPort1);
 #endif
 
@@ -214,10 +216,12 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
     s->USARTx = USART2;
 
 #ifdef USE_UART2_RX_DMA
+    dmaInit(DMA1_CH6_HANDLER, OWNER_SERIAL, 2);
     s->rxDMAChannel = DMA1_Channel6;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->RDR;
 #endif
 #ifdef USE_UART2_TX_DMA
+    dmaInit(DMA1_CH7_HANDLER, OWNER_SERIAL, 2);
     s->txDMAChannel = DMA1_Channel7;
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->TDR;
 #endif
@@ -269,10 +273,12 @@ uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t option
     s->USARTx = USART3;
 
 #ifdef USE_UART3_RX_DMA
+    dmaInit(DMA1_CH3_HANDLER, OWNER_SERIAL, 3);
     s->rxDMAChannel = DMA1_Channel3;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->RDR;
 #endif
 #ifdef USE_UART3_TX_DMA
+    dmaInit(DMA1_CH2_HANDLER, OWNER_SERIAL, 3);
     s->txDMAChannel = DMA1_Channel2;
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->TDR;
 #endif

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -315,9 +315,13 @@ uartPort_t *serialUART(UARTDevice device, uint32_t baudRate, portMode_t mode, po
     if (uart->rxDMAStream) {
         s->rxDMAChannel = uart->DMAChannel;
         s->rxDMAStream = uart->rxDMAStream;
+        dmaInit(dmaGetIdentifier(uart->rxDMAStream), OWNER_SERIAL, RESOURCE_INDEX(device));
     }
-    s->txDMAChannel = uart->DMAChannel;
-    s->txDMAStream = uart->txDMAStream;
+    if (uart->txDMAStream) {
+        s->txDMAChannel = uart->DMAChannel;
+        s->txDMAStream = uart->txDMAStream;
+        dmaInit(dmaGetIdentifier(uart->txDMAStream), OWNER_SERIAL, RESOURCE_INDEX(device));
+    }
 
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -50,6 +50,7 @@ uint8_t cliMode = 0;
 #include "drivers/flash.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
+#include "drivers/dma.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/sdcard.h"
@@ -1242,12 +1243,12 @@ static void printSerial(uint8_t dumpMask, master_t *defaultConfig)
     serialConfig_t *serialConfigDefault;
     bool equalsDefault;
     for (uint32_t i = 0; i < SERIAL_PORT_COUNT; i++) {
-	serialConfig = &masterConfig.serialConfig;
+    serialConfig = &masterConfig.serialConfig;
         if (!serialIsPortAvailable(serialConfig->portConfigs[i].identifier)) {
             continue;
         };
-	serialConfigDefault = &defaultConfig->serialConfig;
-	equalsDefault = serialConfig->portConfigs[i].identifier == serialConfigDefault->portConfigs[i].identifier
+    serialConfigDefault = &defaultConfig->serialConfig;
+    equalsDefault = serialConfig->portConfigs[i].identifier == serialConfigDefault->portConfigs[i].identifier
             && serialConfig->portConfigs[i].functionMask == serialConfigDefault->portConfigs[i].functionMask
             && serialConfig->portConfigs[i].msp_baudrateIndex == serialConfigDefault->portConfigs[i].msp_baudrateIndex
             && serialConfig->portConfigs[i].gps_baudrateIndex == serialConfigDefault->portConfigs[i].gps_baudrateIndex
@@ -1961,11 +1962,11 @@ static void cliServo(char *cmdline)
 static void printServoMix(uint8_t dumpMask, master_t *defaultConfig)
 {
     for (uint32_t i = 0; i < MAX_SERVO_RULES; i++) {
-		servoMixer_t customServoMixer = masterConfig.customServoMixer[i];
-		servoMixer_t customServoMixerDefault = defaultConfig->customServoMixer[i];
+        servoMixer_t customServoMixer = masterConfig.customServoMixer[i];
+        servoMixer_t customServoMixerDefault = defaultConfig->customServoMixer[i];
         if (customServoMixer.rate == 0) {
             break;
-		}
+        }
 
         bool equalsDefault = customServoMixer.targetChannel == customServoMixerDefault.targetChannel
             && customServoMixer.inputSource == customServoMixerDefault.inputSource
@@ -1975,7 +1976,7 @@ static void printServoMix(uint8_t dumpMask, master_t *defaultConfig)
             && customServoMixer.max == customServoMixerDefault.max
             && customServoMixer.box == customServoMixerDefault.box;
 
-		const char *format = "smix %d %d %d %d %d %d %d %d\r\n";
+        const char *format = "smix %d %d %d %d %d %d %d %d\r\n";
         cliDefaultPrintf(dumpMask, equalsDefault, format,
             i,
             customServoMixerDefault.targetChannel,
@@ -1998,7 +1999,7 @@ static void printServoMix(uint8_t dumpMask, master_t *defaultConfig)
         );
     }
 
-	cliPrint("\r\n");
+    cliPrint("\r\n");
 
     // print servo directions
     for (uint32_t i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
@@ -2026,7 +2027,7 @@ static void cliServoMix(char *cmdline)
     len = strlen(cmdline);
 
     if (len == 0) {
-		printServoMix(DUMP_MASTER, NULL);
+        printServoMix(DUMP_MASTER, NULL);
     } else if (strncasecmp(cmdline, "reset", 5) == 0) {
         // erase custom mixer
         memset(masterConfig.customServoMixer, 0, sizeof(masterConfig.customServoMixer));
@@ -2371,7 +2372,7 @@ static void cliVtx(char *cmdline)
 static void printName(uint8_t dumpMask)
 {
     bool equalsDefault = strlen(masterConfig.name) == 0;
-	cliDumpPrintf(dumpMask, equalsDefault, "name %s\r\n", equalsDefault ? emptyName : masterConfig.name);
+    cliDumpPrintf(dumpMask, equalsDefault, "name %s\r\n", equalsDefault ? emptyName : masterConfig.name);
 }
 
 static void cliName(char *cmdline)
@@ -2599,7 +2600,7 @@ static void cliMap(char *cmdline)
         parseRcChannels(cmdline, &masterConfig.rxConfig);
     }
     cliPrint("Map: ");
-	uint32_t i;
+    uint32_t i;
     for (i = 0; i < 8; i++)
         out[masterConfig.rxConfig.rcmap[i]] = rcChannelLetters[i];
     out[i] = '\0';
@@ -3834,7 +3835,7 @@ static void cliResource(char *cmdline)
 #ifndef CLI_MINIMAL_VERBOSITY
         cliPrintf("Currently active IO resource assignments:\r\n(reboot to update)\r\n----------------------\r\n");
 #endif
-        for (uint32_t i = 0; i < DEFIO_IO_USED_COUNT; i++) {
+        for (int i = 0; i < DEFIO_IO_USED_COUNT; i++) {
             const char* owner;
             owner = ownerNames[ioRecs[i].owner];
 
@@ -3847,6 +3848,21 @@ static void cliResource(char *cmdline)
                 cliPrintf("%c%02d: %s %s\r\n", IO_GPIOPortIdx(ioRecs + i) + 'A', IO_GPIOPinIdx(ioRecs + i), owner, resource);
             }
         }
+
+        cliPrintf("\r\n\r\nCurrently active DMA:\r\n");
+        for (int i = 0; i < DMA_MAX_DESCRIPTORS; i++) {
+            const char* owner;
+            owner = ownerNames[dmaGetOwner(i)];
+            
+            cliPrintf(DMA_OUTPUT_STRING, i / DMA_MOD_VALUE + 1, (i % DMA_MOD_VALUE) + DMA_MOD_OFFSET);
+            uint8_t resourceIndex = dmaGetResourceIndex(i);
+            if (resourceIndex > 0) {
+                cliPrintf(" %s%d\r\n", owner, resourceIndex);
+            } else {
+                cliPrintf(" %s\r\n", owner);
+            }            
+        }
+
 #ifndef CLI_MINIMAL_VERBOSITY
         cliPrintf("\r\nUse: 'resource' to see how to change resources.\r\n");
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -233,10 +233,6 @@ void init(void)
 
     timerInit();  // timer must be initialized before any channel is allocated
 
-#if !defined(USE_HAL_DRIVER)
-    dmaInit();
-#endif
-
 #if defined(AVOID_UART1_FOR_PWM_PPM)
     serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
             feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART1 : SERIAL_PORT_NONE);


### PR DESCRIPTION
By running the command `resource list` the DMA ownership should be output after the pin ownership list.