### PR TITLE
For discussion: 'Fix' dataflash read by disabling buffer transmission.

### DIFF
--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -37,13 +37,16 @@ uint32_t serialGetBaudRate(serialPort_t *instance)
 
 void serialWrite(serialPort_t *instance, uint8_t ch)
 {
-    instance->vTable->serialWrite(instance, ch);
+    while (!serialTxBytesFree(instance)) {
+    };
+
+	instance->vTable->serialWrite(instance, ch);
 }
 
 
 void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count)
 {
-    if (instance->vTable->writeBuf) {
+    if (false && instance->vTable->writeBuf) {
         instance->vTable->writeBuf(instance, data, count);
     } else {
         for (const uint8_t *p = data; count > 0; count--, p++) {


### PR DESCRIPTION
@martinbudden: I had another look at why dataflash downloading in jumbo frame mode does not work. I found the following things:

- using a mix of alternating `serialWriteBuf` and `serialWrite` fails because `serialWrite` defaults to buffering output, and `serialWriteBuf` does not flush the Tx buffer before writing, thus breaking the order;
- `serialWriteBuf` seems to be causing a buffer overrun for buffer sizes >= 255, switching it to writing with a buffer size of 20 fixes this.

I had these findings on a BLUEJAYF4 with VCP, but dataflash downloading under 3.1. is broken on a NAZE as well, so there seem to be problems in non-VCP serial drivers too.

The good news is that your changes to convert MSP to streambuf work fine for jumbo frames once the underlying serial driver problems are worked around. ;-)