### PR TITLE
Travis. Run both unit tests and target builds.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,7 +8,6 @@ TARGET_FILE=obj/betaflight_${TARGET}
 TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
 BUILDNAME=${BUILDNAME:=travis}
 TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
-MAKEFILE="-f Makefile"
 
 CURL_BASEOPTS=(
 	"--retry" "10"
@@ -22,12 +21,8 @@ CURL_PUB_BASEOPTS=(
 	"--form" "github_repo=${TRAVIS_REPO_SLUG}"
 	"--form" "build_name=${BUILDNAME}" )
 
-# A hacky way of running the unit tests at the same time as the normal builds.
-if [ $RUNTESTS ] ; then
-	cd ./src/test && make test
-
 # A hacky way of building the docs at the same time as the normal builds.
-elif [ $PUBLISHDOCS ] ; then
+if [ $PUBLISHDOCS ] ; then
 	if [ $PUBLISH_URL ] ; then
 
 		# Patch Gimli to fix underscores_inside_words
@@ -51,8 +46,8 @@ elif [ $PUBLISHMETA ] ; then
 	fi
 
 elif [ $TARGET ] ; then
+    make $TARGET
 	if [ $PUBLISH_URL ] ; then
-		make -j2 $MAKEFILE
 		if   [ -f ${TARGET_FILE}.bin ] ; then
 			TARGET_FILE=${TARGET_FILE}.bin
 		elif [ -f ${TARGET_FILE}.hex ] ; then
@@ -64,10 +59,9 @@ elif [ $TARGET ] ; then
 
 		curl -k "${CURL_BASEOPTS[@]}" "${CURL_PUB_BASEOPTS[@]}" --form "file=@${TARGET_FILE}" ${PUBLISH_URL} || true
 		exit 0;
-	else
-		make -j2 $MAKEFILE
 	fi
-else
-# No target specified, build all with very low verbosity.
+elif [ $GOAL ] ; then
+    make V=0 $GOAL
+else 
     make V=0 all
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 
 env:
-# Specify target(s) to build, or none to build all.
-#  - RUNTESTS=True
 #  - PUBLISHMETA=True
 #  - PUBLISHDOCS=True
+# Specify the main Mafile supported goals.
+  - GOAL=test
+  - GOAL=all
+# Or specify targets to run.
 #  - TARGET=AFROMINI
 #  - TARGET=AIORACERF3
 #  - TARGET=AIR32
@@ -79,7 +81,11 @@ compiler: clang
 install:
   - make arm_sdk_install
 
-before_script: tools/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-gcc --version
+before_script:
+  - tools/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-gcc --version
+  - clang --version
+  - clang++ --version
+
 script: ./.travis.sh
 
 cache: 
@@ -100,4 +106,3 @@ notifications:
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: always     # options: [always|never|change] default: always
-

--- a/Makefile
+++ b/Makefile
@@ -740,7 +740,7 @@ endif
 
 # Tool names
 CROSS_CC    := $(CCACHE) $(ARM_SDK_PREFIX)gcc
-CROSS_CXX   := $(CROSS_CCACHE) $(ARM_SDK_PREFIX)g++
+CROSS_CXX   := $(CCACHE) $(ARM_SDK_PREFIX)g++
 OBJCOPY     := $(ARM_SDK_PREFIX)objcopy
 SIZE        := $(ARM_SDK_PREFIX)size
 

--- a/Makefile
+++ b/Makefile
@@ -739,8 +739,8 @@ CCACHE :=
 endif
 
 # Tool names
-CC          := $(CCACHE) $(ARM_SDK_PREFIX)gcc
-CPP         := $(CCACHE) $(ARM_SDK_PREFIX)g++
+CROSS_CC    := $(CCACHE) $(ARM_SDK_PREFIX)gcc
+CROSS_CXX   := $(CROSS_CCACHE) $(ARM_SDK_PREFIX)g++
 OBJCOPY     := $(ARM_SDK_PREFIX)objcopy
 SIZE        := $(ARM_SDK_PREFIX)size
 
@@ -833,25 +833,25 @@ $(TARGET_BIN): $(TARGET_ELF)
 
 $(TARGET_ELF):  $(TARGET_OBJS)
 	$(V1) echo Linking $(TARGET)
-	$(V1) $(CC) -o $@ $^ $(LDFLAGS)
+	$(V1) $(CROSS_CC) -o $@ $^ $(LDFLAGS)
 	$(V0) $(SIZE) $(TARGET_ELF)
 
 # Compile
 $(OBJECT_DIR)/$(TARGET)/%.o: %.c
 	$(V1) mkdir -p $(dir $@)
 	$(V1) echo "%% $(notdir $<)" "$(STDOUT)"
-	$(V1) $(CC) -c -o $@ $(CFLAGS) $<
+	$(V1) $(CROSS_CC) -c -o $@ $(CFLAGS) $<
 
 # Assemble
 $(OBJECT_DIR)/$(TARGET)/%.o: %.s
 	$(V1) mkdir -p $(dir $@)
 	$(V1) echo "%% $(notdir $<)" "$(STDOUT)"
-	$(V1) $(CC) -c -o $@ $(ASFLAGS) $<
+	$(V1) $(CROSS_CC) -c -o $@ $(ASFLAGS) $<
 
 $(OBJECT_DIR)/$(TARGET)/%.o: %.S
 	$(V1) mkdir -p $(dir $@)
 	$(V1) echo "%% $(notdir $<)" "$(STDOUT)"
-	$(V1) $(CC) -c -o $@ $(ASFLAGS) $<
+	$(V1) $(CROSS_CC) -c -o $@ $(ASFLAGS) $<
 
 ## sample            : Build all sample (travis) targets
 sample: $(SAMPLE_TARGETS)
@@ -963,7 +963,7 @@ targets:
 ## test              : run the cleanflight test suite
 ## junittest         : run the cleanflight test suite, producing Junit XML result files.
 test junittest:
-	$(V0) cd src/test && $(MAKE) $@  || true
+	$(V0) cd src/test && $(MAKE) $@
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS) : Makefile


### PR DESCRIPTION
Updates to allow unit tests and target builds in Travis. 

Main makefile updated due to a clash in usage of symbols CC etc, was used for both native and cross compilers. Travis setup CC for native compile while main Makefile uses and changes that to arm_eabi-none-gcc. The test Makefile uses whatever setting of CC from environment, or make default value (cc). Now using the name "CROSS_CC" to resolve the clash. 

This clash is only noticeable with env var CC, CXX exported in the shell, as Travis does. In an interactive shell those may not be set nor exported and then the clash is not noticed. The test Makefile in this case uses its default CC and CCX (cc and g++), that fails in Travis. 

Travis default native cc and g++ are too old (4.6) to be used. We must use clang and clang++ that are a bit more up-to-date (3.4) for use of C++11 in test suite.
Phew, what a mess.....
