### PR TITLE
Passthrough Settings for Castle Creations ESCs

### DIFF
--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -32,7 +32,7 @@ typedef enum {
     PROTOCOL_BLHELI = 1,
     PROTOCOL_KISS = 2,
     PROTOCOL_KISSALL = 3,
-	PROTOCOL_CASTLE = 4,
+    PROTOCOL_CASTLE = 4,
 } escProtocol_e;
 
 #if defined(USE_ESCSERIAL)
@@ -335,11 +335,12 @@ serialPort_t *openEscSerial(escSerialPortIndex_e portIndex, serialReceiveCallbac
         }
         setTxSignalEsc(escSerial, ENABLE);
         serialTimerTxConfigBL(escSerial->txTimerHardware, portIndex, baud);
-    } else if(mode == PROTOCOL_CASTLE){
+    }
+    else if(mode == PROTOCOL_CASTLE){
         escSerialOutputPortConfig(escSerial->rxTimerHardware);
         serialTimerTxConfigBL(escSerial->txTimerHardware, portIndex, baud);
         serialTimerRxConfigBL(escSerial->rxTimerHardware, portIndex, options);
-	}
+    }
     return &escSerial->port;
 }
 
@@ -929,15 +930,15 @@ void escEnablePassthrough(serialPort_t *escPassthroughPort, uint16_t output, uin
 
     uint32_t escBaudrate;
     switch (mode) {
-    case PROTOCOL_KISS:
-        escBaudrate = BAUDRATE_KISS;
-        break;
-    case PROTOCOL_CASTLE:
-        escBaudrate = BAUDRATE_CASTLE;
-        break;
-    default:
-        escBaudrate = BAUDRATE_NORMAL;
-        break;
+        case PROTOCOL_KISS:
+            escBaudrate = BAUDRATE_KISS;
+            break;
+        case PROTOCOL_CASTLE:
+            escBaudrate = BAUDRATE_CASTLE;
+            break;
+        default:
+            escBaudrate = BAUDRATE_NORMAL;
+            break;
     }
 
     if((mode == PROTOCOL_KISS) && (output == 255)){
@@ -999,9 +1000,9 @@ void escEnablePassthrough(serialPort_t *escPassthroughPort, uint16_t output, uin
             }
             LED1_OFF;
         }
-		if(mode != PROTOCOL_CASTLE){
-        	delay(5);
-		}
+        if(mode != PROTOCOL_CASTLE){
+            delay(5);
+        }
     }
 }
 

--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -23,14 +23,16 @@
 
 typedef enum {
     BAUDRATE_NORMAL = 19200,
-    BAUDRATE_KISS   = 38400
+    BAUDRATE_KISS   = 38400,
+    BAUDRATE_CASTLE = 18880,
 } escBaudRate_e;
 
 typedef enum {
     PROTOCOL_SIMONK = 0,
     PROTOCOL_BLHELI = 1,
     PROTOCOL_KISS = 2,
-    PROTOCOL_KISSALL = 3
+    PROTOCOL_KISSALL = 3,
+	PROTOCOL_CASTLE = 4,
 } escProtocol_e;
 
 #if defined(USE_ESCSERIAL)
@@ -117,7 +119,7 @@ static void escSerialICConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t polari
 
 void setTxSignalEsc(escSerial_t *escSerial, uint8_t state)
 {
-    if((escSerial->mode = PROTOCOL_KISSALL))
+    if((escSerial->mode == PROTOCOL_KISSALL))
     {
         for (volatile uint8_t i = 0; i < escSerial->outputCount; i++) {
             uint8_t state_temp = state;
@@ -333,7 +335,11 @@ serialPort_t *openEscSerial(escSerialPortIndex_e portIndex, serialReceiveCallbac
         }
         setTxSignalEsc(escSerial, ENABLE);
         serialTimerTxConfigBL(escSerial->txTimerHardware, portIndex, baud);
-    }
+    } else if(mode == PROTOCOL_CASTLE){
+        escSerialOutputPortConfig(escSerial->rxTimerHardware);
+        serialTimerTxConfigBL(escSerial->txTimerHardware, portIndex, baud);
+        serialTimerRxConfigBL(escSerial->rxTimerHardware, portIndex, options);
+	}
     return &escSerial->port;
 }
 
@@ -485,7 +491,7 @@ void processTxStateBL(escSerial_t *escSerial)
 
 
         //set output
-        if(escSerial->mode==PROTOCOL_BLHELI) {
+        if(escSerial->mode==PROTOCOL_BLHELI || escSerial->mode==PROTOCOL_CASTLE) {
             escSerialOutputPortConfig(escSerial->rxTimerHardware);
         }
         return;
@@ -502,7 +508,7 @@ void processTxStateBL(escSerial_t *escSerial)
 
     escSerial->isTransmittingData = false;
     if (isEscSerialTransmitBufferEmpty((serialPort_t *)escSerial)) {
-        if(escSerial->mode==PROTOCOL_BLHELI)
+        if(escSerial->mode==PROTOCOL_BLHELI || escSerial->mode==PROTOCOL_CASTLE)
         {
             escSerialInputPortConfig(escSerial->rxTimerHardware);
         }
@@ -921,7 +927,18 @@ void escEnablePassthrough(serialPort_t *escPassthroughPort, uint16_t output, uin
     pwmDisableMotors();
     passPort = escPassthroughPort;
 
-    uint32_t escBaudrate = (mode == PROTOCOL_KISS) ? BAUDRATE_KISS : BAUDRATE_NORMAL;
+    uint32_t escBaudrate;
+    switch (mode) {
+    case PROTOCOL_KISS:
+        escBaudrate = BAUDRATE_KISS;
+        break;
+    case PROTOCOL_CASTLE:
+        escBaudrate = BAUDRATE_CASTLE;
+        break;
+    default:
+        escBaudrate = BAUDRATE_NORMAL;
+        break;
+    }
 
     if((mode == PROTOCOL_KISS) && (output == 255)){
         motor_output = 255;
@@ -982,7 +999,9 @@ void escEnablePassthrough(serialPort_t *escPassthroughPort, uint16_t output, uin
             }
             LED1_OFF;
         }
-        delay(5);
+		if(mode != PROTOCOL_CASTLE){
+        	delay(5);
+		}
     }
 }
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2994,6 +2994,10 @@ static void cliEscPassthrough(char *cmdline)
                 {
                     mode = 2;
                 }
+                else if(strncasecmp(pch, "cc", strlen(pch)) == 0)
+                {
+                    mode = 4;
+                }
                 else
                 {
                     cliShowParseError();


### PR DESCRIPTION
Added serial passthrough mode for Castle Creations ESCs
Note: CLI parameter ("cc") to access this mode intentionally omitted from CLI command. The intent is to initiate communications using the Castle Link PC application.
Fixed conditional in setTxSignalEsc