### PR TITLE
PWM fix - and rename SKIP PWM and PPM to USE_PWM and USE_PPM

### DIFF
--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -151,8 +151,11 @@ typedef struct master_s {
     serialConfig_t serialConfig;
     telemetryConfig_t telemetryConfig;
 
-#ifndef SKIP_RX_PWM_PPM
+#ifdef USE_PPM
     ppmConfig_t ppmConfig;
+#endif
+    
+#ifdef USE_PWM
     pwmConfig_t pwmConfig;
 #endif
 

--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -20,7 +20,7 @@
 
 #include <platform.h>
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
 
 #include "build/build_config.h"
 #include "build/debug.h"
@@ -408,7 +408,11 @@ void pwmRxInit(const pwmConfig_t *pwmConfig)
 
         IO_t io = IOGetByTag(pwmConfig->ioTags[channel]);
         IOInit(io, OWNER_PWMINPUT, RESOURCE_INDEX(channel));
+#ifdef STM32F1
         IOConfigGPIO(io, IOCFG_IPD);
+#else
+        IOConfigGPIO(io, IOCFG_AF_PP);
+#endif
 
 #if defined(USE_HAL_DRIVER)
     pwmICConfig(timer->tim, timer->channel, TIM_ICPOLARITY_RISING);
@@ -472,7 +476,11 @@ void ppmRxInit(const ppmConfig_t *ppmConfig, uint8_t pwmProtocol)
 
     IO_t io = IOGetByTag(ppmConfig->ioTag);
     IOInit(io, OWNER_PPMINPUT, 0);
+#ifdef STM32F1
     IOConfigGPIO(io, IOCFG_IPD);
+#else
+    IOConfigGPIO(io, IOCFG_AF_PP);
+#endif
 
 #if defined(USE_HAL_DRIVER)
     pwmICConfig(timer->tim, timer->channel, TIM_ICPOLARITY_RISING);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -361,7 +361,7 @@ void resetBeeperConfig(beeperConfig_t *beeperConfig)
 }
 #endif
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
 void resetPpmConfig(ppmConfig_t *ppmConfig)
 {
 #ifdef PPM_PIN
@@ -588,7 +588,7 @@ void createDefaultConfig(master_t *config)
 
     resetBatteryConfig(&config->batteryConfig);
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
     resetPpmConfig(&config->ppmConfig);
     resetPwmConfig(&config->pwmConfig);
 #endif

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -3763,7 +3763,7 @@ const cliResourceValue_t resourceTable[] = {
 #ifdef USE_SERVOS
     { OWNER_SERVO,         &masterConfig.servoConfig.ioTags[0], MAX_SUPPORTED_SERVOS },
 #endif
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
     { OWNER_PPMINPUT,      &masterConfig.ppmConfig.ioTag, 0 },
     { OWNER_PWMINPUT,      &masterConfig.pwmConfig.ioTags[0], PWM_INPUT_PORT_COUNT },
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -276,7 +276,7 @@ void init(void)
     }
 #endif
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
     if (feature(FEATURE_RX_PPM)) {
         ppmRxInit(&masterConfig.ppmConfig, masterConfig.motorConfig.motorPwmProtocol);
     } else if (feature(FEATURE_RX_PARALLEL_PWM)) {

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -23,7 +23,7 @@
 
 #include "platform.h"
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
 
 #include "build/build_config.h"
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -256,7 +256,7 @@ void rxInit(const rxConfig_t *rxConfig, const modeActivationCondition_t *modeAct
     }
 #endif
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
     if (feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM)) {
         rxPwmInit(rxConfig, &rxRuntimeConfig);
     }
@@ -311,7 +311,7 @@ bool rxUpdateCheck(uint32_t currentTime, uint32_t currentDeltaTime)
         }
     }
 
-#ifndef SKIP_RX_PWM_PPM
+#if defined(USE_PWM) || defined(USE_PPM)
     if (feature(FEATURE_RX_PPM)) {
         if (isPPMDataBeingReceived()) {
             rxSignalReceivedNotDataDriven = true;

--- a/src/main/target/CJMCU/target.h
+++ b/src/main/target/CJMCU/target.h
@@ -91,8 +91,17 @@
 //#define TELEMETRY
 //#define TELEMETRY_LTM
 //#define TELEMETRY_NRF24_LTM
-#define SKIP_RX_PWM_PPM
+#ifdef USE_PWM
+#undef USE_PWM
+#endif
+
+#ifdef USE_PPM
+#undef USE_PPM
+#endif
+
+#ifdef SERIAL_RX
 #undef SERIAL_RX
+#endif
 //#undef SKIP_TASK_STATISTICS
 
 #else

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -51,6 +51,8 @@
 #define USE_SERIALRX_SUMH       // Graupner legacy protocol
 #define USE_SERIALRX_XBUS       // JR
 #define USE_CLI
+#define USE_PWM
+#define USE_PPM
 
 #if defined(STM_FAST_TARGET)
 #define MAX_AUX_CHANNELS                99


### PR DESCRIPTION
This fixes the PPM and PWM issues experienced on F3 and F4.

Also includes a minor tidy up of double negative define.