### PR TITLE
Improved efficiency of gyro update

### DIFF
--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -688,7 +688,8 @@ void processRx(uint32_t currentTime)
 
 void subTaskPidController(void)
 {
-    const uint32_t startTime = micros();
+    uint32_t startTime;
+    if (debugMode == DEBUG_PIDLOOP) {startTime = micros();}
     // PID - note this is function pointer set by setPIDController()
     pidController(
         &currentProfile->pidProfile,

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -64,54 +64,52 @@ static void alignBoard(int32_t *vec)
 
 void alignSensors(const int32_t *src, int32_t *dest, uint8_t rotation)
 {
-    int32_t x;
+    const int32_t x = src[X];
+    const int32_t y = src[Y];
+    const int32_t z = src[Z];
 
     // note src and dest may point to the same address
     switch (rotation) {
     default:
     case CW0_DEG:
-        dest[X] = src[X];
-        dest[Y] = src[Y];
-        dest[Z] = src[Z];
+        dest[X] = x;
+        dest[Y] = y;
+        dest[Z] = z;
         break;
     case CW90_DEG:
-        x = src[X];
-        dest[X] = src[Y];
+        dest[X] = y;
         dest[Y] = -x;
-        dest[Z] = src[Z];
+        dest[Z] = z;
         break;
     case CW180_DEG:
-        dest[X] = -src[X];
-        dest[Y] = -src[Y];
-        dest[Z] = src[Z];
+        dest[X] = -x;
+        dest[Y] = -y;
+        dest[Z] = z;
         break;
     case CW270_DEG:
-        x = src[X];
-        dest[X] = -src[Y];
+        dest[X] = -y;
         dest[Y] = x;
-        dest[Z] = src[Z];
+        dest[Z] = z;
         break;
     case CW0_DEG_FLIP:
-        dest[X] = -src[X];
-        dest[Y] = src[Y];
-        dest[Z] = -src[Z];
+        dest[X] = -x;
+        dest[Y] = y;
+        dest[Z] = -z;
         break;
     case CW90_DEG_FLIP:
-        x = src[X];
-        dest[X] = src[Y];
+        dest[X] = y;
         dest[Y] = x;
-        dest[Z] = -src[Z];
+        dest[Z] = -z;
         break;
     case CW180_DEG_FLIP:
-        dest[X] = src[X];
-        dest[Y] = -src[Y];
-        dest[Z] = -src[Z];
+        dest[X] = x;
+        dest[Y] = -y;
+        dest[Z] = -z;
         break;
     case CW270_DEG_FLIP:
-        x = src[X];
-        dest[X] = -src[Y];
+        dest[X] = -y;
         dest[Y] = -x;
-        dest[Z] = -src[Z];
+        dest[Z] = -z;
         break;
     }
 

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -64,51 +64,55 @@ static void alignBoard(int32_t *vec)
 
 void alignSensors(const int32_t *src, int32_t *dest, uint8_t rotation)
 {
-    static uint32_t swap[3];
-    memcpy(swap, src, sizeof(swap));
+    int32_t x;
 
+    // note src and dest may point to the same address
     switch (rotation) {
-        default:
-        case CW0_DEG:
-            dest[X] = swap[X];
-            dest[Y] = swap[Y];
-            dest[Z] = swap[Z];
-            break;
-        case CW90_DEG:
-            dest[X] = swap[Y];
-            dest[Y] = -swap[X];
-            dest[Z] = swap[Z];
-            break;
-        case CW180_DEG:
-            dest[X] = -swap[X];
-            dest[Y] = -swap[Y];
-            dest[Z] = swap[Z];
-            break;
-        case CW270_DEG:
-            dest[X] = -swap[Y];
-            dest[Y] = swap[X];
-            dest[Z] = swap[Z];
-            break;
-        case CW0_DEG_FLIP:
-            dest[X] = -swap[X];
-            dest[Y] = swap[Y];
-            dest[Z] = -swap[Z];
-            break;
-        case CW90_DEG_FLIP:
-            dest[X] = swap[Y];
-            dest[Y] = swap[X];
-            dest[Z] = -swap[Z];
-            break;
-        case CW180_DEG_FLIP:
-            dest[X] = swap[X];
-            dest[Y] = -swap[Y];
-            dest[Z] = -swap[Z];
-            break;
-        case CW270_DEG_FLIP:
-            dest[X] = -swap[Y];
-            dest[Y] = -swap[X];
-            dest[Z] = -swap[Z];
-            break;
+    default:
+    case CW0_DEG:
+        dest[X] = src[X];
+        dest[Y] = src[Y];
+        dest[Z] = src[Z];
+        break;
+    case CW90_DEG:
+        x = src[X];
+        dest[X] = src[Y];
+        dest[Y] = -x;
+        dest[Z] = src[Z];
+        break;
+    case CW180_DEG:
+        dest[X] = -src[X];
+        dest[Y] = -src[Y];
+        dest[Z] = src[Z];
+        break;
+    case CW270_DEG:
+        x = src[X];
+        dest[X] = -src[Y];
+        dest[Y] = x;
+        dest[Z] = src[Z];
+        break;
+    case CW0_DEG_FLIP:
+        dest[X] = -src[X];
+        dest[Y] = src[Y];
+        dest[Z] = -src[Z];
+        break;
+    case CW90_DEG_FLIP:
+        x = src[X];
+        dest[X] = src[Y];
+        dest[Y] = x;
+        dest[Z] = -src[Z];
+        break;
+    case CW180_DEG_FLIP:
+        dest[X] = src[X];
+        dest[Y] = -src[Y];
+        dest[Z] = -src[Z];
+        break;
+    case CW270_DEG_FLIP:
+        x = src[X];
+        dest[X] = -src[Y];
+        dest[Y] = -x;
+        dest[Z] = -src[Z];
+        break;
     }
 
     if (!standardBoardAlignment)

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -157,13 +157,6 @@ static void performGyroCalibration(uint8_t gyroMovementCalibrationThreshold)
 
 }
 
-static void applyGyroZero(void)
-{
-    for (int axis = 0; axis < 3; axis++) {
-        gyroADC[axis] -= gyroZero[axis];
-    }
-}
-
 void gyroUpdate(void)
 {
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
@@ -173,9 +166,9 @@ void gyroUpdate(void)
         return;
     }
 
-    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        gyroADC[axis] = gyroADCRaw[axis];
-    }
+    gyroADC[X] = gyroADCRaw[X];
+    gyroADC[Y] = gyroADCRaw[Y];
+    gyroADC[Z] = gyroADCRaw[Z];
 
     alignSensors(gyroADC, gyroADC, gyroAlign);
 
@@ -183,7 +176,9 @@ void gyroUpdate(void)
         performGyroCalibration(gyroConfig->gyroMovementCalibrationThreshold);
     }
 
-    applyGyroZero();
+    gyroADC[X] -= gyroZero[X];
+    gyroADC[Y] -= gyroZero[Y];
+    gyroADC[Z] -= gyroZero[Z];
 
     if (gyroSoftLpfHz) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {


### PR DESCRIPTION
After the talk in slack about speed improvement, I had a quick look at `gyroUpdate`. Here are a few minor improvements.

1. Unrolled a couple of loops in `gyroUpdate`
2. Removed unnecessary `memcpy` in `alignSensors`
3. Removed unnecessary call to `micros()` in `subTaskPidController`

The improvements are all minor, but they are free - not only is speed increased, code size is reduced as well (again minor about 56 bytes on Naze).

There are some further cheap improvements: currently we have both `int32_t gyroADC[XYZ_AXIS_COUNT];` and `float gyroADCf[XYZ_AXIS_COUNT];` and there is wasted effort using both and copying between the two. This is a leftover from before the PID was converted to float. So there could be further savings by copying into `gyroADCf` after the gyro is read and then just using that throughout (we'd need to convert back to integer for blackbox and MSP, but that's not performance critical). Thoughts?


