### PR TITLE
Fixed a problem when the motor count for motorInit came from custom mixer 

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -242,11 +242,6 @@ void motorInit(const motorConfig_t *motorConfig, uint16_t idlePulse, uint8_t mot
     }
 }
 
-bool pwmIsSynced(void)
-{
-    return pwmCompleteWritePtr != NULL;
-}
-
 pwmOutputPort_t *pwmGetMotors(void)
 {
     return motors;

--- a/src/main/drivers/pwm_output_hal.c
+++ b/src/main/drivers/pwm_output_hal.c
@@ -253,11 +253,6 @@ void motorInit(const motorConfig_t *motorConfig, uint16_t idlePulse, uint8_t mot
     }
 }
 
-bool pwmIsSynced(void)
-{
-    return pwmCompleteWritePtr != NULL;
-}
-
 pwmOutputPort_t *pwmGetMotors(void)
 {
     return motors;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -65,7 +65,6 @@ static flight3DConfig_t *flight3DConfig;
 static motorConfig_t *motorConfig;
 static airplaneConfig_t *airplaneConfig;
 rxConfig_t *rxConfig;
-static bool syncMotorOutputWithPidLoop = false;
 
 mixerMode_e currentMixerMode;
 static motorMixer_t currentMixer[MAX_SUPPORTED_MOTORS];
@@ -301,8 +300,6 @@ void mixerConfigureOutput(void)
 
     motorCount = 0;
 
-    syncMotorOutputWithPidLoop = pwmIsSynced();
-
     if (currentMixerMode == MIXER_CUSTOM || currentMixerMode == MIXER_CUSTOM_TRI || currentMixerMode == MIXER_CUSTOM_AIRPLANE) {
         // load custom mixer into currentMixer
         for (i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
@@ -354,8 +351,6 @@ void mixerLoadMix(int index, motorMixer_t *customMixers)
 #else
 void mixerConfigureOutput(void)
 {
-    syncMotorOutputWithPidLoop = pwmIsSynced();
-
     motorCount = QUAD_MOTOR_COUNT;
 
     for (uint8_t i = 0; i < motorCount; i++) {
@@ -380,9 +375,7 @@ void writeMotors(void)
         pwmWriteMotor(i, motor[i]);
     }
 
-    if (syncMotorOutputWithPidLoop) {
-        pwmCompleteMotorUpdate(motorCount);
-    }
+    pwmCompleteMotorUpdate(motorCount);
 }
 
 static void writeAllMotors(int16_t mc)

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -109,6 +109,7 @@ typedef struct airplaneConfig_s {
 
 #define CHANNEL_FORWARDING_DISABLED (uint8_t)0xFF
 
+extern uint8_t motorCount;
 extern const mixer_t mixers[];
 extern int16_t motor[MAX_SUPPORTED_MOTORS];
 extern int16_t motor_disarmed[MAX_SUPPORTED_MOTORS];

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -263,10 +263,15 @@ void init(void)
         idlePulse = 0; // brushed motors
     }
 
+    mixerConfigureOutput();
+#ifdef USE_SERVOS
+    servoConfigureOutput();
+#endif
+
 #ifdef USE_QUAD_MIXER_ONLY
     motorInit(&masterConfig.motorConfig, idlePulse, QUAD_MOTOR_COUNT);
 #else
-    motorInit(&masterConfig.motorConfig, idlePulse, mixers[masterConfig.mixerMode].motorCount);
+    motorInit(&masterConfig.motorConfig, idlePulse, motorCount);
 #endif
 
 #ifdef USE_SERVOS
@@ -285,10 +290,7 @@ void init(void)
     pwmRxSetInputFilteringMode(masterConfig.inputFilteringMode);
 #endif
 
-    mixerConfigureOutput();
-#ifdef USE_SERVOS
-    servoConfigureOutput();
-#endif
+
     systemState |= SYSTEM_STATE_MOTORS_READY;
 
 #ifdef BEEPER


### PR DESCRIPTION
fixes #1448 
Not flight tested but PWM outputs checked with Logic analyser, oneshot, normal pwm, both with mixer quadx and custom.

1. took the motor count from the loading of the custom mixer table.
2. Moved the mixerconfig to before motorInit as motorInit needs the
motorCount.
3. removed pwmIsSynced checks as this was a order of init problem, and
not required as pwmCompleteMotorUpdate protects itself.