### PR TITLE
Fix a few cppcheck warnings.

### DIFF
--- a/src/main/common/typeconversion.c
+++ b/src/main/common/typeconversion.c
@@ -30,12 +30,12 @@ void uli2a(unsigned long int num, unsigned int base, int uc, char *bf)
         d *= base;
     while (d != 0) {
         int dgt = num / d;
-        num %= d;
-        d /= base;
-        if (n || dgt > 0 || d == 0) {
+        if (n || dgt > 0) {
             *bf++ = dgt + (dgt < 10 ? '0' : (uc ? 'A' : 'a') - 10);
             ++n;
         }
+        num %= d;
+        d /= base;
     }
     *bf = 0;
 }
@@ -59,12 +59,12 @@ void ui2a(unsigned int num, unsigned int base, int uc, char *bf)
         d *= base;
     while (d != 0) {
         int dgt = num / d;
-        num %= d;
-        d /= base;
-        if (n || dgt > 0 || d == 0) {
+        if (n || dgt > 0) {
             *bf++ = dgt + (dgt < 10 ? '0' : (uc ? 'A' : 'a') - 10);
             ++n;
         }
+        num %= d;
+        d /= base;
     }
     *bf = 0;
 }


### PR DESCRIPTION
Fix a few cppcheck warnings and save a few bytes of code space as well as a few CPU cycles. No real issues, but every drop counts. And by getting less of cppcheck small issues and noise, the big issues will be more visible and easier to catch. 

