### PR TITLE
Minor cleanups and fixes 1

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -48,17 +48,17 @@ uint8_t adcChannelByTag(ioTag_t ioTag)
 uint16_t adcGetChannel(uint8_t channel)
 {
 #ifdef DEBUG_ADC_CHANNELS
-    if (adcConfig[0].enabled) {
-        debug[0] = adcValues[adcConfig[0].dmaIndex];
+    if (adcOperatingConfig[0].enabled) {
+        debug[0] = adcValues[adcOperatingConfig[0].dmaIndex];
     }
-    if (adcConfig[1].enabled) {
-        debug[1] = adcValues[adcConfig[1].dmaIndex];
+    if (adcOperatingConfig[1].enabled) {
+        debug[1] = adcValues[adcOperatingConfig[1].dmaIndex];
     }
-    if (adcConfig[2].enabled) {
-        debug[2] = adcValues[adcConfig[2].dmaIndex];
+    if (adcOperatingConfig[2].enabled) {
+        debug[2] = adcValues[adcOperatingConfig[2].dmaIndex];
     }
-    if (adcConfig[3].enabled) {
-        debug[3] = adcValues[adcConfig[3].dmaIndex];
+    if (adcOperatingConfig[3].enabled) {
+        debug[3] = adcValues[adcOperatingConfig[3].dmaIndex];
     }
 #endif
     return adcValues[adcOperatingConfig[channel].dmaIndex];

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -37,8 +37,12 @@
 #define ADC_INSTANCE                ADC1
 #endif
 
+#ifndef ADC1_DMA_STREAM
+#define ADC1_DMA_STREAM DMA2_Stream4
+#endif
+
 const adcDevice_t adcHardware[] = {
-    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = DMA2_Stream4, .channel = DMA_Channel_0 },
+    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = ADC1_DMA_STREAM, .channel = DMA_Channel_0 },
     //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 }
 };
 

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -136,7 +136,7 @@ static uartDevice_t uart3 =
 static uartDevice_t uart4 =
 {
     .DMAChannel = DMA_Channel_4,
-#ifdef USE_UART1_RX_DMA
+#ifdef USE_UART4_RX_DMA
     .rxDMAStream = DMA1_Stream2,
 #endif
     .txDMAStream = DMA1_Stream4,
@@ -159,10 +159,10 @@ static uartDevice_t uart4 =
 static uartDevice_t uart5 =
 {
     .DMAChannel = DMA_Channel_4,
-#ifdef USE_UART1_RX_DMA
+#ifdef USE_UART5_RX_DMA
     .rxDMAStream = DMA1_Stream0,
 #endif
-    .txDMAStream = DMA2_Stream7,
+    .txDMAStream = DMA1_Stream7,
     .dev = UART5,
     .rx = IO_TAG(UART5_RX_PIN),
     .tx = IO_TAG(UART5_TX_PIN),
@@ -171,7 +171,7 @@ static uartDevice_t uart5 =
     .rcc_ahb1 = UART5_AHB1_PERIPHERALS,
 #endif
     .rcc_apb1 = RCC_APB1(UART5),
-    .txIrq = DMA2_ST7_HANDLER,
+    .txIrq = DMA1_ST7_HANDLER,
     .rxIrq = UART5_IRQn,
     .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
     .rxPriority = NVIC_PRIO_SERIALUART5


### PR DESCRIPTION
See commit messages.  

With regards to ADC stream specification, ADC1 is also available on DMA2 which will help some targets with DSHOT timer/DMA support.