### PR TITLE
CMS: Cleanup: Remove standard options from targets.

### DIFF
--- a/src/main/target/MULTIFLITEPICO/target.h
+++ b/src/main/target/MULTIFLITEPICO/target.h
@@ -142,11 +142,3 @@
 
 #define USABLE_TIMER_CHANNEL_COUNT 17
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(15) | TIM_N(16) | TIM_N(17) )
-
-#define USE_DASHBOARD
-
-// Configuratoin Menu System
-#define CMS
-
-// Use external display connected by MSP to run CMS
-#define USE_MSP_DISPLAYPORT

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -91,15 +91,6 @@
 #define SPI1_MISO_PIN           PA6
 #define SPI1_MOSI_PIN           PA7
 
-#define USE_DASHBOARD
-
-// Configuratoin Menu System
-#define CMS
-#define CMS_MAX_DEVICE 4
-
-// Use external display connected by MSP to run CMS
-#define USE_MSP_DISPLAYPORT
-
 // OSD define info:
 //   feature name (includes source) -> MAX_OSD, used in target.mk
 // include the osd code

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -70,9 +70,6 @@
 //#define MAX7456_DMA_CHANNEL_RX              DMA1_Stream0
 //#define MAX7456_DMA_IRQ_HANDLER_ID          DMA1_ST0_HANDLER
 
-#define CMS
-#define USE_MSP_DISPLAYPORT
-
 //#define PITOT
 //#define USE_PITOT_MS4525
 //#define MS4525_BUS I2C_DEVICE_EXT

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -170,6 +170,3 @@
 #endif
 
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(12) | TIM_N(8) | TIM_N(9) )
-
-#define CMS
-#define USE_MSP_DISPLAYPORT

--- a/src/main/target/SIRINFPV/target.h
+++ b/src/main/target/SIRINFPV/target.h
@@ -137,15 +137,7 @@
 //#define USE_QUAD_MIXER_ONLY
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 
-#define USE_DASHBOARD
-
 #define OSD
-
-// Configuratoin Menu System
-#define CMS
-
-// Use external display connected by MSP to run CMS
-#define USE_MSP_DISPLAYPORT
 
 #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_DEFAULT
 

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -145,11 +145,3 @@
 
 #define USABLE_TIMER_CHANNEL_COUNT 17
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(15) | TIM_N(16) | TIM_N(17) )
-
-#define USE_DASHBOARD
-
-// Configuratoin Menu System
-#define CMS
-
-// Use external display connected by MSP to run CMS
-#define USE_MSP_DISPLAYPORT


### PR DESCRIPTION
Remove following build options from targets used during development of the CMS.

- `USE_DASHBOARD`
- `CMS`
- `USE_MSP_DISPLAYPORT`

These options are standard for >128K targets and defined in `target/common.h`