### PR TITLE
Only register dashboard with CMS if hardware is present

### DIFF
--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -708,7 +708,9 @@ void dashboardInit(rxConfig_t *rxConfigToUse)
 
     displayPort = displayPortOledInit();
 #if defined(CMS)
-    cmsDisplayPortRegister(displayPort);
+    if (dashboardPresent) {
+        cmsDisplayPortRegister(displayPort);
+    }
 #endif
 
     rxConfig = rxConfigToUse;


### PR DESCRIPTION
Fixes issue https://github.com/betaflight/betaflight/issues/1623 - CMS: DISPLAY(DASHBOARD) feature without OLED hardware causes massive I2C errors