### PR TITLE
Use function pointers to simplify gyro filter calls

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -33,7 +33,7 @@
 
 // NULL filter
 
-float nullFilterApply(const void *filter, float input)
+float nullFilterApply(void *filter, float input)
 {
     UNUSED(filter);
     return input;

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -22,12 +22,23 @@
 
 #include "common/filter.h"
 #include "common/maths.h"
+#include "common/utils.h"
 
 #define M_LN2_FLOAT 0.69314718055994530942f
 #define M_PI_FLOAT  3.14159265358979323846f
 
 #define BIQUAD_BANDWIDTH 1.9f     /* bandwidth in octaves */
 #define BIQUAD_Q 1.0f / sqrtf(2.0f)     /* quality factor - butterworth*/
+
+
+// NULL filter
+
+float nullFilterApply(const void *filter, float input)
+{
+    UNUSED(filter);
+    return input;
+}
+
 
 // PT1 Low Pass filter
 
@@ -176,6 +187,12 @@ float firFilterApply(const firFilter_t *filter)
         ret += filter->coeffs[ii] * filter->buf[index];
     }
     return ret;
+}
+
+float firFilterUpdateAndApply(firFilter_t *filter, float input)
+{
+    firFilterUpdate(filter, input);
+    return firFilterApply(filter);
 }
 
 /*

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -62,6 +62,9 @@ typedef struct firFilter_s {
     uint8_t coeffsLength;
 } firFilter_t;
 
+typedef float (*filterApplyFnPtr)(const void *filter, float input);
+
+float nullFilterApply(const void *filter, float input);
 
 void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
 void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType);
@@ -77,6 +80,7 @@ void firFilterInit2(firFilter_t *filter, float *buf, uint8_t bufLength, const fl
 void firFilterUpdate(firFilter_t *filter, float input);
 void firFilterUpdateAverage(firFilter_t *filter, float input);
 float firFilterApply(const firFilter_t *filter);
+float firFilterUpdateAndApply(firFilter_t *filter, float input);
 float firFilterCalcPartialAverage(const firFilter_t *filter, uint8_t count);
 float firFilterCalcMovingAverage(const firFilter_t *filter);
 float firFilterLastInput(const firFilter_t *filter);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -62,9 +62,9 @@ typedef struct firFilter_s {
     uint8_t coeffsLength;
 } firFilter_t;
 
-typedef float (*filterApplyFnPtr)(const void *filter, float input);
+typedef float (*filterApplyFnPtr)(void *filter, float input);
 
-float nullFilterApply(const void *filter, float input);
+float nullFilterApply(void *filter, float input);
 
 void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
 void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType);

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -32,7 +32,7 @@
 #define EXPAND_I(x) x
 #define EXPAND(x) EXPAND_I(x)
 
-#if !defined(USE_HAL_DRIVER)
+#if !defined(UNUSED)
 #define UNUSED(x) (void)(x)
 #endif
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))

--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -15,11 +15,11 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- #include "common/utils.h"
-
 #include "io.h"
 #include "io_impl.h"
 #include "rcc.h"
+
+#include "common/utils.h"
 
 #include "target.h"
 


### PR DESCRIPTION
Simplifies code and makes it more efficient.