### PR TITLE
Fix dataflash read by only using serialWriteBuf in mspSerialEncode

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -125,20 +125,21 @@ static int mspSerialEncode(mspPort_t *msp, mspPacket_t *packet)
     serialBeginWrite(msp->port);
     const int len = sbufBytesRemaining(&packet->buf);
     const int mspLen = len < JUMBO_FRAME_SIZE_LIMIT ? len : JUMBO_FRAME_SIZE_LIMIT;
-    const uint8_t hdr[5] = {'$', 'M', packet->result == MSP_RESULT_ERROR ? '!' : '>', mspLen, packet->cmd};
-    serialWriteBuf(msp->port, hdr, sizeof(hdr));
-    uint8_t checksum = mspSerialChecksumBuf(0, hdr + 3, 2); // checksum starts from len field
+    uint8_t hdr[8] = {'$', 'M', packet->result == MSP_RESULT_ERROR ? '!' : '>', mspLen, packet->cmd};
+    int hdrLen = 5;
+#define CHECKSUM_STARTPOS 3  // checksum starts from mspLen field
     if (len >= JUMBO_FRAME_SIZE_LIMIT) {
-        serialWrite(msp->port, len & 0xff);
-        checksum ^= len & 0xff;
-        serialWrite(msp->port, (len >> 8) & 0xff);
-        checksum ^= (len >> 8) & 0xff;
+        hdrLen += 2;
+        hdr[5] = len & 0xff;
+        hdr[6] = (len >> 8) & 0xff;
     }
+    serialWriteBuf(msp->port, hdr, hdrLen);
+    uint8_t checksum = mspSerialChecksumBuf(0, hdr + CHECKSUM_STARTPOS, hdrLen - CHECKSUM_STARTPOS);
     if (len > 0) {
         serialWriteBuf(msp->port, sbufPtr(&packet->buf), len);
         checksum = mspSerialChecksumBuf(checksum, sbufPtr(&packet->buf), len);
     }
-    serialWrite(msp->port, checksum);
+    serialWriteBuf(msp->port, &checksum, 1);
     serialEndWrite(msp->port);
     return sizeof(hdr) + len + 1; // header, data, and checksum
 }


### PR DESCRIPTION
"Fixes" dataflash read problem https://github.com/betaflight/betaflight/pull/1499 by only using `serialWriteBuf` in `mspSerialEncode`.

This avoids the underlying problem in the serial drivers that `serialWriteBuf` and `serialWrite` do not work together (see discussion in above referenced PR).

So this avoids the underlying problem, rather than fixing it. But the fixing the underlying problem is non-trivial and this allows us to move on until someone has time to look at the serial drivers.