### PR TITLE
VCP could only handle max 256 byte frames, too small data type uint8_t

### DIFF
--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -156,7 +156,7 @@ static uint16_t VCP_Ctrl(uint32_t Cmd, uint8_t* Buf, uint32_t Len)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint8_t sendLength)
+uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength)
 {
     VCP_DataTx(ptrBuffer, sendLength);
     return sendLength;

--- a/src/main/vcpf4/usbd_cdc_vcp.h
+++ b/src/main/vcpf4/usbd_cdc_vcp.h
@@ -36,7 +36,7 @@
 
 __ALIGN_BEGIN USB_OTG_CORE_HANDLE  USB_OTG_dev __ALIGN_END;
 
-uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint8_t sendLength);  // HJI
+uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength);
 uint32_t CDC_Send_FreeBytes(void);
 uint32_t CDC_Receive_DATA(uint8_t* recvBuf, uint32_t len);       // HJI
 uint32_t CDC_Receive_BytesAvailable(void);


### PR DESCRIPTION
VCP could only handle max 256 byte frames, too small data type uint8t. Now uint32_t.

Fixes #1499 and #1642 for VCP devices.
 