### PR TITLE
Add Esc telemetry to YuPiF4 Target

### DIFF
--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -139,6 +139,7 @@
 #define RSSI_ADC_GPIO_PIN       PC0
 
 #define USE_DSHOT
+#define USE_ESC_TELEMETRY
 #define LED_STRIP
 
 // Default configuration


### PR DESCRIPTION
The define for ESC Telemetry was added to the target.h file of the YuPiF4 Target.