### PR TITLE
Prevent motor spin-up when on ground

### DIFF
--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -517,7 +517,7 @@ void processRx(uint32_t currentTime)
         failsafeUpdateState();
     }
 
-    throttleStatus_e throttleStatus = calculateThrottleStatus(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
+    const throttleStatus_e throttleStatus = calculateThrottleStatus(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
 
     if (isAirmodeActive() && ARMING_FLAG(ARMED)) {
         if (rcCommand[THROTTLE] >= masterConfig.rxConfig.airModeActivateThreshold) airmodeIsActivated = true; // Prevent Iterm from being reset
@@ -530,11 +530,39 @@ void processRx(uint32_t currentTime)
     if (throttleStatus == THROTTLE_LOW && !airmodeIsActivated) {
         pidResetErrorGyroState();
         if (currentProfile->pidProfile.pidAtMinThrottle)
-            pidStabilisationState(PID_STABILISATION_ON);
+            pidSetStabilisationState(PID_STABILISATION_ON);
         else
-            pidStabilisationState(PID_STABILISATION_OFF);
+            pidSetStabilisationState(PID_STABILISATION_OFF);
     } else {
-        pidStabilisationState(PID_STABILISATION_ON);
+        pidSetStabilisationState(PID_STABILISATION_ON);
+    }
+
+    // Prevent motor windup on when on ground
+    // rcCommand in the range -500 to 500 at this point
+    // create a center band slightly wider than the deadband
+    const int centerBand = masterConfig.rcControlsConfig.deadband + 4;
+    const int yawCenterBand = masterConfig.rcControlsConfig.yaw_deadband + 4;
+    if (rcCommand[THROTTLE] > 1200
+            || rcCommand[ROLL]  < -centerBand || rcCommand[ROLL]  > centerBand
+            || rcCommand[PITCH] < -centerBand || rcCommand[PITCH] > centerBand
+            || rcCommand[YAW]   < -yawCenterBand || rcCommand[YAW]   > yawCenterBand) {
+        // do nothing
+    } else {
+        // all sticks centered and throttle low
+#define COS_5_DEGREES 0.996194698091746f
+        if (getCosTiltAngle() > COS_5_DEGREES) {
+            // we are nearly level
+            if (sensors(SENSOR_ACC)) {
+                const int32_t accZ = accSmooth[Z] * 100 / acc.acc_1G;
+                if ((accZ > 80) && (accZ < 110)) {
+                    // accelerometer  Z readings is in the range 0.80g - 1.10g, so we are not in free fall
+                    // so don't allow ITerm to wind-up
+                    pidSetStabilisationState(PID_STABILISATION_ZERO_ITERM);
+                }
+            } else {
+                pidSetStabilisationState(PID_STABILISATION_ZERO_ITERM);
+            }
+        }
     }
 
     // When armed and motors aren't spinning, do beeps and then disarm

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -52,6 +52,7 @@ typedef enum {
 
 typedef enum {
     PID_STABILISATION_OFF = 0,
+    PID_STABILISATION_ZERO_ITERM,
     PID_STABILISATION_ON
 } pidStabilisationState_e;
 
@@ -103,7 +104,7 @@ extern uint32_t targetPidLooptime;
 extern uint8_t PIDweight[3];
 
 void pidResetErrorGyroState(void);
-void pidStabilisationState(pidStabilisationState_e pidControllerState);
+void pidSetStabilisationState(pidStabilisationState_e pidControllerState);
 void pidSetTargetLooptime(uint32_t pidLooptime);
 void pidInitFilters(const pidProfile_t *pidProfile);
 


### PR DESCRIPTION
Prompted by @joshuabardwell 's answer to the question "Why Do Quadcopter Motors Spin Up By Themselves With Props Off?" https://www.youtube.com/watch?v=xBaefeQtA1c , I thought, indeed, why does the FC software allow this when it confuses so many people?

So here's a proposed fix.

First note what motors spin up because of random noise in the system. The I-part of the PID controller integrates this noise, and the integral of noise is drift, and this drift manifests itself as motor spin-up. So switching off the I-part of the PID controller stops spin up.

So the question remains, when to switch of the ITerm? This PR uses the following conditions:
1. Throttle below 1200
2. Other sticks near center (within deadband + 4)
3. Craft nearly level (angle < 5 degrees)
4. Z-term of acceleration between 0.8g and 1.2g (if the craft in in the air and falling because of low throttle rate, Z-term of acceleration would be much lower).

Note that even if this heuristic is wrong, the P and D terms of the PID controller are active. And of course as soon as the user moves any of the sticks off center, the ITerm will be reactivated.

Comments please.