### PR TITLE
add more optimization for targets that have enough space left

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -756,7 +756,15 @@ ifeq ($(DEBUG),GDB)
 OPTIMIZE    = -O0
 LTO_FLAGS   = $(OPTIMIZE)
 else
+OPTIMIZE    = -Ofast
+
+ifeq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))
+OPTIMIZE    = -O2
+endif
+ifeq ($(TARGET),$(filter $(TARGET),$(F1_TARGETS)))
 OPTIMIZE    = -Os
+endif
+
 LTO_FLAGS   = -flto -fuse-linker-plugin $(OPTIMIZE)
 endif
 


### PR DESCRIPTION
Prefere Optimization for speed and not for space for targets with enough space
Currently O3 and Ofast binarys are to even big for F3 Targets

disabling GPS would allow F3 Targets to also use Ofast
Ofast on f3 targets reduce cpu usage around 20-30%

colibri race maybe needs some love and testing. it creates some warnings with Ofast:
```
./src/main/target/COLIBRI_RACE/bus_bst_stm32f30x.c: In function 'I2C_EV_IRQHandler':
./src/main/target/COLIBRI_RACE/i2c_bst.c:343:37: warning: iteration 16 invokes undefined behavior [-Waggressive-loop-optimizations]
     writeData[writeBufferPointer++] = data;
                                     ^
./src/main/target/COLIBRI_RACE/i2c_bst.c:718:13: note: containing loop
             for (i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
             ^
./src/main/target/COLIBRI_RACE/i2c_bst.c:343:37: warning: iteration 11 invokes undefined behavior [-Waggressive-loop-optimizations]
     writeData[writeBufferPointer++] = data;
                                     ^
./src/main/target/COLIBRI_RACE/i2c_bst.c:728:13: note: containing loop
             for (i = 0; i < MAX_ADJUSTMENT_RANGE_COUNT; i++) {
             ^
./src/main/target/COLIBRI_RACE/i2c_bst.c:343:37: warning: iteration 9 invokes undefined behavior [-Waggressive-loop-optimizations]
     writeData[writeBufferPointer++] = data;
                                     ^
./src/main/target/COLIBRI_RACE/i2c_bst.c:638:13: note: containing loop
             for (i = 0; i < MAX_SERVO_RULES; i++) {

```