### PR TITLE
remove unused hardwareRevisonNames

### DIFF
--- a/src/main/target/ALIENFLIGHTF1/hardware_revision.c
+++ b/src/main/target/ALIENFLIGHTF1/hardware_revision.c
@@ -28,11 +28,6 @@
 #include "drivers/exti.h"
 #include "hardware_revision.h"
 
-static const char * const hardwareRevisionNames[] = {
-        "Unknown",
-        "AlienFlight F1 V1",
-};
-
 uint8_t hardwareRevision = AFF1_REV_1;
 uint8_t hardwareMotorType = MOTOR_UNKNOWN;
 

--- a/src/main/target/ALIENFLIGHTF3/hardware_revision.c
+++ b/src/main/target/ALIENFLIGHTF3/hardware_revision.c
@@ -28,12 +28,6 @@
 #include "drivers/exti.h"
 #include "hardware_revision.h"
 
-static const char * const hardwareRevisionNames[] = {
-        "Unknown",
-        "AlienFlight F3 V1",
-        "AlienFlight F3 V2"
-};
-
 uint8_t hardwareRevision = AFF3_UNKNOWN;
 uint8_t hardwareMotorType = MOTOR_UNKNOWN;
 

--- a/src/main/target/ALIENFLIGHTF4/hardware_revision.c
+++ b/src/main/target/ALIENFLIGHTF4/hardware_revision.c
@@ -27,12 +27,6 @@
 #include "drivers/io.h"
 #include "hardware_revision.h"
 
-static const char * const hardwareRevisionNames[] = {
-        "Unknown",
-        "AlienFlight F4 V1",
-        "AlienFlight F4 V2"
-};
-
 uint8_t hardwareRevision = AFF4_UNKNOWN;
 uint8_t hardwareMotorType = MOTOR_UNKNOWN;
 

--- a/src/main/target/BLUEJAYF4/hardware_revision.c
+++ b/src/main/target/BLUEJAYF4/hardware_revision.c
@@ -29,14 +29,6 @@
 #include "drivers/flash_m25p16.h"
 #include "hardware_revision.h"
 
-static const char * const hardwareRevisionNames[] = {
-    "Unknown",
-    "BlueJay rev1",
-    "BlueJay rev2",
-    "BlueJay rev3",
-    "BlueJay rev3a"
-};
-
 uint8_t hardwareRevision = UNKNOWN;
 
 void detectHardwareRevision(void)
@@ -99,5 +91,3 @@ void updateHardwareRevision(void)
         IOInit(IOGetByTag(IO_TAG(PB3)), OWNER_FREE, 0);
     }
 }
-
-

--- a/src/main/target/CJMCU/hardware_revision.c
+++ b/src/main/target/CJMCU/hardware_revision.c
@@ -32,12 +32,6 @@
 
 #include "hardware_revision.h"
 
-static const char * const hardwareRevisionNames[] = {
-        "Unknown",
-        "R1",
-        "R2"
-};
-
 uint8_t hardwareRevision = UNKNOWN;
 
 void detectHardwareRevision(void)

--- a/src/main/target/NAZE/hardware_revision.c
+++ b/src/main/target/NAZE/hardware_revision.c
@@ -34,13 +34,6 @@
 
 #include "hardware_revision.h"
 
-static const char * const hardwareRevisionNames[] = {
-        "Unknown",
-        "Naze 32",
-        "Naze32 rev.5",
-        "Naze32 SP"
-};
-
 uint8_t hardwareRevision = UNKNOWN;
 
 void detectHardwareRevision(void)


### PR DESCRIPTION
those throw unused warnings with arm-none-eabi-gcc 6.2.0
as far as i understand those are never used and HardwareRevision enum replaced them
