### PR TITLE
clean target #define

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -35,7 +35,6 @@
 #define USE_MAG_DATA_READY_SIGNAL
 #define ENSURE_MAG_DATA_READY_IS_HIGH
 
-#define USE_DSHOT
 #define USE_ESC_TELEMETRY
 
 #define GYRO


### PR DESCRIPTION
removed `#define USE_DSHOT` it's also defined as standard for STM32F3 in` /target/common.h`