### PR TITLE
Spektrum bind pin detection

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -218,6 +218,19 @@ void init(void)
     }
 #endif
 
+#if defined(AVOID_UART1_FOR_PWM_PPM)
+    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
+            feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART1 : SERIAL_PORT_NONE);
+#elif defined(AVOID_UART2_FOR_PWM_PPM)
+    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
+            feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART2 : SERIAL_PORT_NONE);
+#elif defined(AVOID_UART3_FOR_PWM_PPM)
+    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
+            feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART3 : SERIAL_PORT_NONE);
+#else
+    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL), SERIAL_PORT_NONE);
+#endif
+
 #ifdef SPEKTRUM_BIND
     if (feature(FEATURE_RX_SERIAL)) {
         switch (rxConfig()->serialrx_provider) {
@@ -235,19 +248,6 @@ void init(void)
     delay(100);
 
     timerInit();  // timer must be initialized before any channel is allocated
-
-#if defined(AVOID_UART1_FOR_PWM_PPM)
-    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
-            feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART1 : SERIAL_PORT_NONE);
-#elif defined(AVOID_UART2_FOR_PWM_PPM)
-    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
-            feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART2 : SERIAL_PORT_NONE);
-#elif defined(AVOID_UART3_FOR_PWM_PPM)
-    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL),
-            feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART3 : SERIAL_PORT_NONE);
-#else
-    serialInit(&masterConfig.serialConfig, feature(FEATURE_SOFTSERIAL), SERIAL_PORT_NONE);
-#endif
 
     mixerInit(mixerConfig()->mixerMode, masterConfig.customMotorMixer);
 #ifdef USE_SERVOS

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -248,7 +248,7 @@ void spektrumBind(rxConfig_t *rxConfig)
 		case SERIAL_PORT_USART8:
 			BindPin = IOGetByTag(IO_TAG(UART8_RX_PIN));
 		break;
-	#endif
+#endif
 		default:
 			return;
 	}

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -208,6 +208,11 @@ void spektrumBind(rxConfig_t *rxConfig)
 
 	LED1_ON;
 
+#ifdef STM32F10X
+#define UART1_RX_PIN	PA10
+#define UART2_RX_PIN	PA3
+#endif
+
 	switch(portConfig->identifier){
 #ifdef USE_UART1
 		case SERIAL_PORT_USART1:

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -200,9 +200,59 @@ void spektrumBind(rxConfig_t *rxConfig)
         return;
     }
 
-    LED1_ON;
+	//find bind pin automatically
+	const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+	if (!portConfig) {
+		return;
+	}
 
-    BindPin = IOGetByTag(IO_TAG(BIND_PIN));
+	LED1_ON;
+
+	switch(portConfig->identifier){
+#ifdef USE_UART1
+		case SERIAL_PORT_USART1:
+			BindPin = IOGetByTag(IO_TAG(UART1_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART2
+		case SERIAL_PORT_USART2:
+			BindPin = IOGetByTag(IO_TAG(UART2_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART3
+		case SERIAL_PORT_USART3:
+			BindPin = IOGetByTag(IO_TAG(UART3_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART4
+		case SERIAL_PORT_USART4:
+			BindPin = IOGetByTag(IO_TAG(UART4_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART5
+		case SERIAL_PORT_USART5:
+			BindPin = IOGetByTag(IO_TAG(UART5_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART6
+		case SERIAL_PORT_USART6:
+			BindPin = IOGetByTag(IO_TAG(UART6_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART7
+		case SERIAL_PORT_USART7:
+			BindPin = IOGetByTag(IO_TAG(UART7_RX_PIN));
+		break;
+#endif
+#ifdef USE_UART8
+		case SERIAL_PORT_USART8:
+			BindPin = IOGetByTag(IO_TAG(UART8_RX_PIN));
+		break;
+	#endif
+		default:
+			return;
+	}
+
     IOInit(BindPin, OWNER_RX_BIND, 0);
     IOConfigGPIO(BindPin, IOCFG_OUT_PP);
 
@@ -295,4 +345,3 @@ bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
     return spektrumPort != NULL;
 }
 #endif // SERIAL_RX
-


### PR DESCRIPTION
I recently read about people complaining that binding spektrum satellites does not work properly.
At the moment the pin for binding is defined in the specific target file. On some boards a pin header is mounted but often there are several options how to connect the satellite.
So my idea was to select the bind pin depending on the uart port configuration.