### PR TITLE
OLED default I2C bus to I2C_DEVICE instead of I2CDEV_1

### DIFF
--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -26,7 +26,7 @@
 #include "display_ug2864hsweg01.h"
 
 #ifndef OLED_I2C_INSTANCE
-#define OLED_I2C_INSTANCE I2CDEV_1
+#define OLED_I2C_INSTANCE I2C_DEVICE
 #endif
 
 #define INVERSE_CHAR_FORMAT 0x7f // 0b01111111


### PR DESCRIPTION
An intuitive and immediate solution for #1755.