### PR TITLE
I2C3 (F4 targets) is on PA8/PC9

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -79,7 +79,7 @@ static void i2cUnstick(IO_t scl, IO_t sda);
 #define I2C3_SCL PA8
 #endif
 #ifndef I2C3_SDA
-#define I2C3_SDA PB4
+#define I2C3_SDA PC9
 #endif
 #endif
 


### PR DESCRIPTION
Per STM32F405xx datasheet.