### PR TITLE
SPRACINGF3EVO. Brushed motor protocol by default.

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -21,6 +21,9 @@
 
 #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_DEFAULT
 
+// Safe ESC/Motor protocol default, not to spin the motors on some FC when config is reset.
+#define BRUSHED_MOTORS
+
 #define LED0                    PB8
 
 #define BEEPER                  PC15


### PR DESCRIPTION
Avoid spinning motors when config is reset on brushed FCs. 
Some ( BeeCoreF3) even spin when only on USB power, which may cause cyclic re-boot due to too much current drain from USB. 
Replaces PR #1721 
