### PR TITLE
add the mpu9250 as an option to the revo target

### DIFF
--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -70,6 +70,9 @@
 #define MPU6500_CS_PIN          PA4
 #define MPU6500_SPI_INSTANCE    SPI1
 
+#define MPU9250_CS_PIN          PA4
+#define MPU9250_SPI_INSTANCE    SPI1
+
 #if defined(SOULF4)
     #define ACC
     #define USE_ACC_SPI_MPU6000
@@ -82,19 +85,30 @@
 #else
     #define ACC
     #define USE_ACC_SPI_MPU6000
-    #define GYRO_MPU6000_ALIGN      CW270_DEG
+    #define ACC_MPU6000_ALIGN      CW270_DEG
 
     #define USE_ACC_MPU6500
     #define USE_ACC_SPI_MPU6500
     #define ACC_MPU6500_ALIGN       CW270_DEG
 
+    #define USE_ACC_MPU9250
+    #define USE_ACC_SPI_MPU9250
+    #define ACC_MPU9250_ALIGN       CW270_DEG
+
     #define GYRO
     #define USE_GYRO_SPI_MPU6000
-    #define ACC_MPU6000_ALIGN       CW270_DEG
+    #define GYRO_MPU6000_ALIGN       CW270_DEG
 
     #define USE_GYRO_MPU6500
     #define USE_GYRO_SPI_MPU6500
     #define GYRO_MPU6500_ALIGN      CW270_DEG
+
+    #define USE_GYRO_SPI_MPU9250
+    #define GYRO_MPU9250_ALIGN       CW270_DEG
+
+    #define MAG
+    #define USE_MAG_AK8963
+    #define MAG_AK8963_ALIGN        CW270_DEG
 
 #endif
 

--- a/src/main/target/REVO/target.mk
+++ b/src/main/target/REVO/target.mk
@@ -5,5 +5,7 @@ TARGET_SRC = \
             drivers/accgyro_spi_mpu6000.c \
             drivers/accgyro_mpu6500.c \
             drivers/accgyro_spi_mpu6500.c \
+            drivers/accgyro_spi_mpu9250.c \
             drivers/barometer_ms5611.c \
+            drivers/compass_ak8963.c \
             drivers/compass_hmc5883l.c


### PR DESCRIPTION
cleanup the revo `ACC_MPU6000_ALIGN` / `GYRO_MPU6000_ALIGN` position, add the mpu9250 as an option (airbotf4 optionally has an mpu9250)