### PR TITLE
Add support for X9E rotary encoder in lua setup script

### DIFF
--- a/src/test/BFSetup.lua
+++ b/src/test/BFSetup.lua
@@ -545,9 +545,9 @@ local function run(event)
    elseif gState == MENU_DISP then
       if event == EVT_EXIT_BREAK then
          gState = PAGE_DISPLAY
-      elseif event == EVT_PLUS_BREAK then
+      elseif event == EVT_PLUS_BREAK or event == EVT_ROT_LEFT then
          incMenu(-1)
-      elseif event == EVT_MINUS_BREAK then
+      elseif event == EVT_MINUS_BREAK or event == EVT_ROT_RIGHT then
          incMenu(1)
       elseif event == EVT_ENTER_BREAK then
          gState = PAGE_DISPLAY
@@ -557,9 +557,9 @@ local function run(event)
    elseif gState <= PAGE_DISPLAY then
       if event == EVT_MENU_BREAK then
          incPage(1)
-      elseif event == EVT_PLUS_BREAK then
+      elseif event == EVT_PLUS_BREAK or event == EVT_ROT_LEFT then
          incLine(-1)
-      elseif event == EVT_MINUS_BREAK then
+      elseif event == EVT_MINUS_BREAK or event == EVT_ROT_RIGHT then
          incLine(1)
       elseif event == EVT_ENTER_BREAK then
          local page = SetupPages[currentPage]
@@ -573,9 +573,9 @@ local function run(event)
    elseif gState == EDITING then
       if (event == EVT_EXIT_BREAK) or (event == EVT_ENTER_BREAK) then
          gState = PAGE_DISPLAY
-      elseif event == EVT_PLUS_FIRST or event == EVT_PLUS_REPT then
+      elseif event == EVT_PLUS_FIRST or event == EVT_PLUS_REPT or event == EVT_ROT_RIGHT then
          incValue(1)
-      elseif event == EVT_MINUS_FIRST or event == EVT_MINUS_REPT then
+      elseif event == EVT_MINUS_FIRST or event == EVT_MINUS_REPT or event == EVT_ROT_LEFT then
          incValue(-1)
       end
    end


### PR DESCRIPTION
Scripts have to explicitly handle rotary events because of the different "polarity" needed for value editing and navigation.