### PR TITLE
Cli flash_erase print buffer flush and progress indicator added.

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2252,18 +2252,28 @@ static void cliFlashInfo(char *cmdline)
             layout->sectors, layout->sectorSize, layout->pagesPerSector, layout->pageSize, layout->totalSize, flashfsGetOffset());
 }
 
+
 static void cliFlashErase(char *cmdline)
 {
     UNUSED(cmdline);
+    uint32_t i;
 
-    cliPrintf("Erasing...\r\n");
+    cliPrintf("Erasing, please wait ... \r\n");
+    bufWriterFlush(cliWriter);
     flashfsEraseCompletely();
 
     while (!flashfsIsReady()) {
+        cliPrintf(".");
+        if (i++ > 120) {
+	    i=0;
+	    cliPrintf("\r\n");
+	}
+
+	bufWriterFlush(cliWriter);
         delay(100);
     }
 
-    cliPrintf("Done.\r\n");
+    cliPrintf("\r\nDone.\r\n");
 }
 
 #ifdef USE_FLASH_TOOLS

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2256,13 +2256,19 @@ static void cliFlashInfo(char *cmdline)
 static void cliFlashErase(char *cmdline)
 {
     UNUSED(cmdline);
-    uint32_t i;
 
+#ifndef CLI_MINIMAL_VERBOSITY
+    uint32_t i;
     cliPrintf("Erasing, please wait ... \r\n");
+#else
+    cliPrintf("Erasing,\r\n");
+#endif
+
     bufWriterFlush(cliWriter);
     flashfsEraseCompletely();
 
     while (!flashfsIsReady()) {
+#ifndef CLI_MINIMAL_VERBOSITY
         cliPrintf(".");
         if (i++ > 120) {
 	    i=0;
@@ -2270,6 +2276,7 @@ static void cliFlashErase(char *cmdline)
 	}
 
 	bufWriterFlush(cliWriter);
+#endif
         delay(100);
     }
 


### PR DESCRIPTION
CLI command "flash_erase" did not flush its print buffer, output was halted until flash erase operation was complete. Probably due to interrupts being disabled (speculation). Board seemed to hang, dead.

Added flushing of buffer and also an crude progress indicator to fix this. 

Before:

    # flash_erase
    Era
wait wait then:

         sing...
    Done.
    
    # 
    
Now: 

    # flash_erase
    Erasing, please wait ... 
    ..........................................................................................................................
    ..........................................................................................................................
    ..........................................................................................................................
    ......................................................................................................................
    Done.
    
    #  