### PR TITLE
Build date and rev was not updated on incremental builds. Fixed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -831,6 +831,9 @@ CLEAN_ARTIFACTS := $(TARGET_BIN)
 CLEAN_ARTIFACTS += $(TARGET_HEX)
 CLEAN_ARTIFACTS += $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP)
 
+# Make sure build date and revision is updated on every incremental build
+$(OBJECT_DIR)/$(TARGET)/build/version.o : $(TARGET_SRC)
+
 # List of buildable ELF files and their object dependencies.
 # It would be nice to compute these lists, but that seems to be just beyond make.
 


### PR DESCRIPTION
When doing incremental builds the build/version.o file was not updated. Thus the cli "version" cmd returned incorrect build date, time and git revision. 
Added full target source dependency for build/version.o . Touching any source file will now also re-build version.o:

    $ touch src/main/io/serial_cli.c
    $ make REVO
    .....
    Building REVO
    .....
    %% version.c
    %% serial_cli.c
    Linking REVO
    .....
    Building REVO succeeded.
 
Cosmetic maybe, but somewhat important with correct metadata without having to re-build everything. For example "make clean_REVO REVO" takes time, and easy to forget to do.
