### PR TITLE
CMS files as size optimized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -686,6 +686,14 @@ SIZE_OPTIMISED_SRC = \
             io/serial_4way_avrootloader.c \
             io/serial_4way_stk500v2.c \
             msp/msp_serial.c \
+            cms/cms.c \
+            cms/cms_menu_blackbox.c \
+            cms/cms_menu_builtin.c \
+            cms/cms_menu_imu.c \
+            cms/cms_menu_ledstrip.c \
+            cms/cms_menu_misc.c \
+            cms/cms_menu_osd.c \
+            cms/cms_menu_vtx.c
 
 ifeq ($(TARGET),$(filter $(TARGET),$(F4_TARGETS)))
 VCP_SRC = \


### PR DESCRIPTION
CMS is ran only when unarmed.

1904 bytes savings on SPRACINGF3.