### PR TITLE
Makefile: Changed variable REVISION to immediate expansion.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ ifeq ($(DEBUG_HARDFAULTS),F7)
 CFLAGS               += -DDEBUG_HARDFAULTS
 endif
 
-REVISION = $(shell git log -1 --format="%h")
+REVISION := $(shell git log -1 --format="%h")
 
 FC_VER_MAJOR := $(shell grep " FC_VERSION_MAJOR" src/main/build/version.h | awk '{print $$3}' )
 FC_VER_MINOR := $(shell grep " FC_VERSION_MINOR" src/main/build/version.h | awk '{print $$3}' )


### PR DESCRIPTION
This prevents the git command log from command being executed during
every use of the variable REVISION and so speeds up the build by ~5sec
on my machine