### PR TITLE
Makefile optimization cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,11 @@ HIGHEND_SRC = \
             telemetry/mavlink.c \
             sensors/esc_sensor.c \
 
-SPEED_OPTIMISED_SRC = \
+SPEED_OPTIMISED_SRC := ""
+SIZE_OPTIMISED_SRC  := ""
+
+ifeq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))
+SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             common/encoding.c \
             common/filter.c \
             common/maths.c \
@@ -682,7 +686,7 @@ SPEED_OPTIMISED_SRC = \
             telemetry/mavlink.c \
             telemetry/esc_telemetry.c \
 
-SIZE_OPTIMISED_SRC = \
+SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             drivers/serial_escserial.c \
             io/serial_cli.c \
             io/serial_4way.c \
@@ -697,6 +701,7 @@ SIZE_OPTIMISED_SRC = \
             cms/cms_menu_misc.c \
             cms/cms_menu_osd.c \
             cms/cms_menu_vtx.c
+endif #F3
 
 ifeq ($(TARGET),$(filter $(TARGET),$(F4_TARGETS)))
 VCP_SRC = \
@@ -856,32 +861,41 @@ SIZE        := $(ARM_SDK_PREFIX)size
 # Tool options.
 #
 
-ifeq ($(DEBUG),GDB)
-OPTIMISE              = -O0
-CC_SPEED_OPTIMISATION = $(OPTIMISE)
-CC_OPTIMISATION       = $(OPTIMISE)
-CC_SIZE_OPTIMISATION  = $(OPTIMISE)
-LTO_FLAGS             = $(OPTIMISE)
-else
+ifneq ($(DEBUG),GDB)
+OPTIMISATION_BASE   := -flto -fuse-linker-plugin -ffast-math
+OPTIMISE_SPEED      := ""
+OPTIMISE_SIZE       := ""
+
 ifeq ($(TARGET),$(filter $(TARGET),$(F1_TARGETS)))
-OPTIMISE_SPEED        = -Os
-OPTIMISE              = -Os
-OPTIMISE_SIZE         = -Os
+OPTIMISE_DEFAULT    := -Os
+
+LTO_FLAGS           := $(OPTIMISATION_BASE) $(OPTIMISE_DEFAULT)
+
 else ifeq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))
-OPTIMISE_SPEED        = -Ofast
-OPTIMISE              = -O2
-OPTIMISE_SIZE         = -Os
+OPTIMISE_DEFAULT    := -O2
+OPTIMISE_SPEED      := -Ofast
+OPTIMISE_SIZE       := -Os
+
+LTO_FLAGS           := $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
+
 else
-OPTIMISE_SPEED        = -Ofast
-OPTIMISE              = -Ofast
-OPTIMISE_SIZE         = -Ofast
-endif
-OPTIMISATION_BASE     = -flto -fuse-linker-plugin -ffast-math
-CC_SPEED_OPTIMISATION = $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
-CC_OPTIMISATION       = $(OPTIMISATION_BASE) $(OPTIMISE)
-CC_SIZE_OPTIMISATION  = $(OPTIMISATION_BASE) $(OPTIMISE_SIZE)
-LTO_FLAGS             = $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
-endif
+OPTIMISE_DEFAULT    := -Ofast
+
+LTO_FLAGS           := $(OPTIMISATION_BASE) $(OPTIMISE_DEFAULT)
+
+endif #TARGETS
+
+CC_DEFAULT_OPTIMISATION := $(OPTIMISATION_BASE) $(OPTIMISE_DEFAULT)
+CC_SPEED_OPTIMISATION   := $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
+CC_SIZE_OPTIMISATION    := $(OPTIMISATION_BASE) $(OPTIMISE_SIZE)
+
+else #DEBUG
+OPTIMISE_DEFAULT    := -O0
+
+CC_DEBUG_OPTIMISATION := $(OPTIMISE_DEFAULT)
+
+LTO_FLAGS           := $(OPTIMISE_DEFAULT)
+endif #DEBUG
 
 DEBUG_FLAGS = -ggdb3 -DDEBUG
 
@@ -966,16 +980,23 @@ $(TARGET_ELF):  $(TARGET_OBJS)
 	$(V0) $(SIZE) $(TARGET_ELF)
 
 # Compile
+ifneq ($(DEBUG),GDB)
 $(OBJECT_DIR)/$(TARGET)/%.o: %.c
 	$(V1) mkdir -p $(dir $@)
-	$(V1) $(if $(findstring $(subst ./src/main/,,$<), $(SPEED_OPTIMISED_SRC)), \
+	$(V1) $(if $(findstring $(subst ./src/main/,,$<),$(SPEED_OPTIMISED_SRC)), \
 	echo "%% (speed optimised) $(notdir $<)" "$(STDOUT)" && \
 	$(CROSS_CC) -c -o $@ $(CFLAGS) $(CC_SPEED_OPTIMISATION) $<, \
-	$(if $(findstring $(subst ./src/main/,,$<), $(SIZE_OPTIMISED_SRC)), \
+	$(if $(findstring $(subst ./src/main/,,$<),$(SIZE_OPTIMISED_SRC)), \
 	echo "%% (size optimised) $(notdir $<)" "$(STDOUT)" && \
 	$(CROSS_CC) -c -o $@ $(CFLAGS) $(CC_SIZE_OPTIMISATION) $<, \
 	echo "%% $(notdir $<)" "$(STDOUT)" && \
-	$(CROSS_CC) -c -o $@ $(CFLAGS) $(CC_OPTIMISATION) $<))
+	$(CROSS_CC) -c -o $@ $(CFLAGS) $(CC_DEFAULT_OPTIMISATION) $<))
+else
+$(OBJECT_DIR)/$(TARGET)/%.o: %.c
+	$(V1) mkdir -p $(dir $@)
+	$(V1) echo "%% $(notdir $<)" "$(STDOUT)" && \
+	$(CROSS_CC) -c -o $@ $(CFLAGS) $(CC_DEBUG_OPTIMISATION) $<
+endif
 
 # Assemble
 $(OBJECT_DIR)/$(TARGET)/%.o: %.s


### PR DESCRIPTION
Proposal for fixes to @AndersHoglund's #1818:
- duplicate file names are handled properly
- files under `lib/` are built with the default optimisation for the target
- it is clear what the file lists for optimisation are used for

I think this is sufficient for our needs for the moment. If we want differentiated optimisations for files under `lib/`, the best way is probably to do it by library, since these files are grouped by library, and are only built if a certain library is included for a target.