### PR TITLE
(obf4sd) gyro/acc alignment

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -43,11 +43,17 @@
 
 #define ACC
 #define USE_ACC_SPI_MPU6000
-#define GYRO_MPU6000_ALIGN      CW180_DEG
 
 #define GYRO
 #define USE_GYRO_SPI_MPU6000
-#define ACC_MPU6000_ALIGN       CW180_DEG
+
+#ifdef OMNIBUSF4SD
+  #define GYRO_MPU6000_ALIGN      CW270_DEG
+  #define ACC_MPU6000_ALIGN       CW270_DEG
+#else
+  #define GYRO_MPU6000_ALIGN      CW180_DEG
+  #define ACC_MPU6000_ALIGN       CW180_DEG
+#endif
 
 // MPU6000 interrupts
 #define USE_EXTI


### PR DESCRIPTION
target-only (obf4sd) bugfix as reported by @joshuabardwell