### PR TITLE
Activate BOXOSD unconditionally (Fixes #1870)

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -397,9 +397,7 @@ void initActiveBoxIds(void)
         activeBoxIds[activeBoxIdCount++] = BOXCALIB;
     }
 
-    if (feature(FEATURE_OSD)) {
-        activeBoxIds[activeBoxIdCount++] = BOXOSD;
-    }
+    activeBoxIds[activeBoxIdCount++] = BOXOSD;
 
 #ifdef TELEMETRY
     if (feature(FEATURE_TELEMETRY) && telemetryConfig()->telemetry_switch) {


### PR DESCRIPTION
Per #1870.

Activation of BOXOSD was made to depend on FEATURE_OSD when BFOSD (the integrated OSD) was introduced in 3.0.

However, the BOXOSD is not related with BFOSD, but MSP.

This PR reverts the activation of BOXOSD to unconditional, as it was prior to 3.0. 