### PR TITLE
Cli cmnd rxrange hangs on F4 with speed optimization.

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1697,11 +1697,14 @@ static void printRxRange(uint8_t dumpMask, master_t *defaultConfig)
             channelRangeConfigurationDefault->min,
             channelRangeConfigurationDefault->max
         );
+	bufWriterFlush(cliWriter);
         cliDumpPrintf(dumpMask, equalsDefault, format,
             i,
             channelRangeConfiguration->min,
             channelRangeConfiguration->max
         );
+	bufWriterFlush(cliWriter);
+
     }
 }
 


### PR DESCRIPTION
 Added flushing of print buffer in-between printfs.
