### PR TITLE
Avoid TRANSPONDERVTX and random owner name

### DIFF
--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -58,7 +58,7 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "RX_BIND",
     "INVERTER",
     "LED_STRIP",
-    "TRANSPONDER"
+    "TRANSPONDER",
     "VTX",
 };
 


### PR DESCRIPTION
This one escapes from compiler check, and creates TRANSPONDERVTX for OWNER_TRANSPONDER and random string for OWNER_VTX.