### PR TITLE
fix for vcp buffersize uin8_t overflow on using CDC_Send (broken blackbox dl on vcp targets)

### DIFF
--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -111,7 +111,7 @@ static void usbVcpWriteBuf(serialPort_t *instance, const void *data, int count)
 
 static bool usbVcpFlush(vcpPort_t *port)
 {
-    uint8_t count = port->txAt;
+    uint32_t count = port->txAt;
     port->txAt = 0;
 
     if (count == 0) {

--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -282,7 +282,7 @@ static void IntToUnicode(uint32_t value, uint8_t *pbuf, uint8_t len)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint8_t sendLength)
+uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength)
 {
     /* Last transmission hasn't finished, abort */
     if (packetSent) {

--- a/src/main/vcp/hw_config.h
+++ b/src/main/vcp/hw_config.h
@@ -55,7 +55,7 @@ void Leave_LowPowerMode(void);
 void USB_Interrupts_Config(void);
 void USB_Cable_Config(FunctionalState NewState);
 void Get_SerialNum(void);
-uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint8_t sendLength);  // HJI
+uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength);  // HJI
 uint32_t CDC_Send_FreeBytes(void);
 uint32_t CDC_Receive_DATA(uint8_t* recvBuf, uint32_t len);       // HJI
 uint32_t CDC_Receive_BytesAvailable(void);


### PR DESCRIPTION
this fixes 
https://github.com/betaflight/betaflight/pull/1642
and
https://github.com/betaflight/betaflight/issues/1899
for VCP targets

 CDC_Send_DATA(...) is using an uint8_t as size! passing e.g. 4096 results in 0 bytes beeing sent...