### PR TITLE
VTX cleanups from Cleanflight.

### DIFF
--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -84,37 +84,38 @@
 #define RTC6705_SET_WRITE 0x11 //10001b to write to register
 #define RTC6705_SET_DIVMULT 1000000 //Division value (to fit into a uint32_t) (Hz to MHz)
 
-#define DISABLE_RTC6705 GPIO_SetBits(RTC6705_CS_GPIO,   RTC6705_CS_PIN)
-#define ENABLE_RTC6705  GPIO_ResetBits(RTC6705_CS_GPIO, RTC6705_CS_PIN)
+#define DISABLE_RTC6705 IOHi(vtxCSPin)
+#ifdef USE_RTC6705_CLK_HACK
+// HACK for missing pull up on CLK line - drive the CLK high *before* enabling the CS pin.
+#define ENABLE_RTC6705  {GPIO_SetBits(RTC6705_CLK_GPIO, RTC6705_CLK_PIN); delayMicroseconds(5); IOLo(vtxCSPin); }
+#else
+#define ENABLE_RTC6705  IOLo(vtxCSPin)
+#endif
 
-static IO_t vtxPowerPin        = IO_NONE;
+#define DP_5G_MASK          0x7000 // b111000000000000
+#define PA5G_BS_MASK        0x0E00 // b000111000000000
+#define PA5G_PW_MASK        0x0180 // b000000110000000
+#define PD_Q5G_MASK         0x0040 // b000000001000000
+#define QI_5G_MASK          0x0038 // b000000000111000
+#define PA_BS_MASK          0x0007 // b000000000000111
+
+#define PA_CONTROL_DEFAULT  0x4FBD
+
+static IO_t vtxPowerPin     = IO_NONE;
+static IO_t vtxCSPin        = IO_NONE;
 
 #define ENABLE_VTX_POWER       IOLo(vtxPowerPin)
 #define DISABLE_VTX_POWER      IOHi(vtxPowerPin)
 
 
 // Define variables
-static const uint32_t channelArray[RTC6705_BAND_MAX][RTC6705_CHANNEL_MAX] = {
+static const uint32_t channelArray[RTC6705_BAND_COUNT][RTC6705_CHANNEL_COUNT] = {
     { RTC6705_SET_A1, RTC6705_SET_A2, RTC6705_SET_A3, RTC6705_SET_A4, RTC6705_SET_A5, RTC6705_SET_A6, RTC6705_SET_A7, RTC6705_SET_A8 },
     { RTC6705_SET_B1, RTC6705_SET_B2, RTC6705_SET_B3, RTC6705_SET_B4, RTC6705_SET_B5, RTC6705_SET_B6, RTC6705_SET_B7, RTC6705_SET_B8 },
     { RTC6705_SET_E1, RTC6705_SET_E2, RTC6705_SET_E3, RTC6705_SET_E4, RTC6705_SET_E5, RTC6705_SET_E6, RTC6705_SET_E7, RTC6705_SET_E8 },
     { RTC6705_SET_F1, RTC6705_SET_F2, RTC6705_SET_F3, RTC6705_SET_F4, RTC6705_SET_F5, RTC6705_SET_F6, RTC6705_SET_F7, RTC6705_SET_F8 },
     { RTC6705_SET_R1, RTC6705_SET_R2, RTC6705_SET_R3, RTC6705_SET_R4, RTC6705_SET_R5, RTC6705_SET_R6, RTC6705_SET_R7, RTC6705_SET_R8 },
 };
-
-/**
- * Send a command and return if good
- * TODO chip detect
- */
-static bool rtc6705IsReady(void)
-{
-    // Sleep a little bit to make sure it has booted
-    delay(50);
-
-    // TODO Do a read and get current config (note this would be reading on MOSI (data) line)
-
-    return true;
-}
 
 /**
  * Reverse a uint32_t (LSB to MSB)
@@ -137,7 +138,7 @@ static uint32_t reverse32(uint32_t in)
  * Start chip if available
  */
 
-bool rtc6705Init(void)
+void rtc6705Init(void)
 {
 #ifdef RTC6705_POWER_PIN
     vtxPowerPin = IOGetByTag(IO_TAG(RTC6705_POWER_PIN));
@@ -147,9 +148,15 @@ bool rtc6705Init(void)
     ENABLE_VTX_POWER;
 #endif
 
+    vtxCSPin = IOGetByTag(IO_TAG(RTC6705_CS_PIN));
+    IOInit(vtxCSPin, OWNER_VTX, 0);
+
     DISABLE_RTC6705;
-    spiSetDivisor(RTC6705_SPI_INSTANCE, SPI_CLOCK_SLOW);
-    return rtc6705IsReady();
+    // GPIO bit is enabled so here so the output is not pulled low when the GPIO is set in output mode.
+    // Note: It's critical to ensure that incorrect signals are not sent to the VTX.
+    IOConfigGPIO(vtxCSPin, IOCFG_OUT_PP);
+
+    delay(RTC6705_BOOT_DELAY);
 }
 
 /**
@@ -168,7 +175,11 @@ static void rtc6705Transfer(uint32_t command)
     spiTransferByte(RTC6705_SPI_INSTANCE, (command >> 8) & 0xFF);
     spiTransferByte(RTC6705_SPI_INSTANCE, (command >> 0) & 0xFF);
 
+    delayMicroseconds(2);
+
     DISABLE_RTC6705;
+
+    delayMicroseconds(2);
 }
 
 /**
@@ -176,11 +187,13 @@ static void rtc6705Transfer(uint32_t command)
  */
 void rtc6705SetChannel(uint8_t band, uint8_t channel)
 {
-    band = constrain(band, RTC6705_BAND_MIN, RTC6705_BAND_MAX);
-    channel = constrain(channel, RTC6705_CHANNEL_MIN, RTC6705_CHANNEL_MAX);
+    band = constrain(band, 0, RTC6705_BAND_COUNT - 1);
+    channel = constrain(channel, 0, RTC6705_CHANNEL_COUNT - 1);
+
+    spiSetDivisor(RTC6705_SPI_INSTANCE, SPI_CLOCK_SLOW);
 
     rtc6705Transfer(RTC6705_SET_HEAD);
-    rtc6705Transfer(channelArray[band-1][channel-1]);
+    rtc6705Transfer(channelArray[band][channel]);
 }
 
  /**
@@ -200,8 +213,37 @@ void rtc6705SetFreq(uint16_t freq)
     val_hex |= (val_a << 5);
     val_hex |= (val_n << 12);
 
+    spiSetDivisor(RTC6705_SPI_INSTANCE, SPI_CLOCK_SLOW);
+
     rtc6705Transfer(RTC6705_SET_HEAD);
+    delayMicroseconds(10);
     rtc6705Transfer(val_hex);
+}
+
+void rtc6705SetRFPower(uint8_t rf_power)
+{
+    spiSetDivisor(RTC6705_SPI_INSTANCE, SPI_CLOCK_SLOW);
+
+    uint32_t val_hex = 0x10; // write
+    val_hex |= 7; // address
+    uint32_t data = rf_power == 0 ? (PA_CONTROL_DEFAULT | PD_Q5G_MASK) & (~(PA5G_PW_MASK | PA5G_BS_MASK)) : PA_CONTROL_DEFAULT;
+    val_hex |= data << 5; // 4 address bits and 1 rw bit.
+
+    rtc6705Transfer(val_hex);
+}
+
+void rtc6705Disable(void)
+{
+#ifdef RTC6705_POWER_PIN
+    DISABLE_VTX_POWER;
+#endif
+}
+
+void rtc6705Enable(void)
+{
+#ifdef RTC6705_POWER_PIN
+    ENABLE_VTX_POWER;
+#endif
 }
 
 #endif

--- a/src/main/drivers/vtx_rtc6705.h
+++ b/src/main/drivers/vtx_rtc6705.h
@@ -26,13 +26,16 @@
 
 #include <stdint.h>
 
-#define RTC6705_BAND_MIN    1
-#define RTC6705_BAND_MAX    5
-#define RTC6705_CHANNEL_MIN 1
-#define RTC6705_CHANNEL_MAX 8
+#define RTC6705_BAND_COUNT    5
+#define RTC6705_CHANNEL_COUNT 8
+#define RTC6705_RF_POWER_COUNT 2
+
 #define RTC6705_FREQ_MIN    5600
 #define RTC6705_FREQ_MAX    5950
 
-bool rtc6705Init(void);
+#define RTC6705_BOOT_DELAY 350 // milliseconds
+
+void rtc6705Init(void);
 void rtc6705SetChannel(uint8_t band, uint8_t channel);
 void rtc6705SetFreq(uint16_t freq);
+void rtc6705SetRFPower(uint8_t rf_power);

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -45,7 +45,7 @@ void vtxInit(void)
     }
 }
 
-static void setChannelSaveAndNotify(uint8_t *bandOrChannel, uint8_t step, int32_t min, int32_t max)
+static void setChannelSaveAndNotify(uint8_t *bandOrChannel, uint8_t step, int32_t max)
 {
     if (ARMING_FLAG(ARMED)) {
         locked = 1;
@@ -53,7 +53,7 @@ static void setChannelSaveAndNotify(uint8_t *bandOrChannel, uint8_t step, int32_
 
     if (masterConfig.vtx_mode == 0 && !locked) {
         uint8_t temp = (*bandOrChannel) + step;
-        temp = constrain(temp, min, max);
+        temp = constrain(temp, 0, max);
         *bandOrChannel = temp;
 
         rtc6705SetChannel(masterConfig.vtx_band, masterConfig.vtx_channel);
@@ -65,22 +65,22 @@ static void setChannelSaveAndNotify(uint8_t *bandOrChannel, uint8_t step, int32_
 
 void vtxIncrementBand(void)
 {
-    setChannelSaveAndNotify(&(masterConfig.vtx_band), 1, RTC6705_BAND_MIN, RTC6705_BAND_MAX);
+    setChannelSaveAndNotify(&(masterConfig.vtx_band), 1, RTC6705_BAND_COUNT - 1);
 }
 
 void vtxDecrementBand(void)
 {
-    setChannelSaveAndNotify(&(masterConfig.vtx_band), -1, RTC6705_BAND_MIN, RTC6705_BAND_MAX);
+    setChannelSaveAndNotify(&(masterConfig.vtx_band), -1, RTC6705_BAND_COUNT - 1);
 }
 
 void vtxIncrementChannel(void)
 {
-    setChannelSaveAndNotify(&(masterConfig.vtx_channel), 1, RTC6705_CHANNEL_MIN, RTC6705_CHANNEL_MAX);
+    setChannelSaveAndNotify(&(masterConfig.vtx_channel), 1, RTC6705_CHANNEL_COUNT - 1);
 }
 
 void vtxDecrementChannel(void)
 {
-    setChannelSaveAndNotify(&(masterConfig.vtx_channel), -1, RTC6705_CHANNEL_MIN, RTC6705_CHANNEL_MAX);
+    setChannelSaveAndNotify(&(masterConfig.vtx_channel), -1, RTC6705_CHANNEL_COUNT - 1);
 }
 
 void vtxUpdateActivatedChannel(void)

--- a/src/main/target/SINGULARITY/target.h
+++ b/src/main/target/SINGULARITY/target.h
@@ -72,8 +72,7 @@
 #define USE_SPI_DEVICE_2 // PB12,13,14,15 on AF5
 
 #define VTX
-#define RTC6705_CS_GPIO         GPIOA
-#define RTC6705_CS_PIN          GPIO_Pin_4
+#define RTC6705_CS_PIN          PA4
 #define RTC6705_SPI_INSTANCE    SPI1
 
 #define M25P16_CS_GPIO          GPIOB

--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -98,8 +98,11 @@
 #define VTX
 #define RTC6705_CS_PIN          PF4
 #define RTC6705_SPI_INSTANCE    SPI3
-
 #define RTC6705_POWER_PIN       PC3
+
+#define USE_RTC6705_CLK_HACK
+#define RTC6705_CLK_GPIO        GPIOB
+#define RTC6705_CLK_PIN         GPIO_Pin_3
 
 #define USE_MAX7456
 #define MAX7456_SPI_INSTANCE    SPI3

--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -96,8 +96,7 @@
 #define SPI3_MOSI_PIN           PB5
 
 #define VTX
-#define RTC6705_CS_GPIO         GPIOF
-#define RTC6705_CS_PIN          GPIO_Pin_4
+#define RTC6705_CS_PIN          PF4
 #define RTC6705_SPI_INSTANCE    SPI3
 
 #define RTC6705_POWER_PIN       PC3


### PR DESCRIPTION
* Some transitions to use new IO system for VTX CS pin. 
* Fix missing VTX CS GPIO pin initialisation - occurs when CS is not the default SPI CS pin.
* Ensure VTX CS is set correctly when enabling the VTX module.
* Configure VTX module boot delay - 50ms in old code was too slow on some cold boots.
* VTX SPI divisor is now set each time an SPI transfer occurs so that the VTX module can co-exist on the same SPI bus as other devices - NEO uses MAX7456 and RTC6705 VTX on the same SPI bus.
* cleanup return type of vtx6705Init since it was always true and the return value was never used.
* add rtc6705SetRFPower - wanted by #1782 - currently unsed by the BF codebase, but it works in CF.