### PR TITLE
remove obsolete .mk file and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ LINKER_DIR      = $(ROOT)/src/main/target/link
 # Build tools, so we all share the same versions
 # import macros common to all supported build systems
 include $(ROOT)/make/system-id.mk
-# developer preferences, edit these at will, they'll be gitignored
-include $(ROOT)/make/local.mk
 
 # configure some directories that are relative to wherever ROOT_DIR is located
 TOOLS_DIR := $(ROOT)/tools

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ LINKER_DIR      = $(ROOT)/src/main/target/link
 # import macros common to all supported build systems
 include $(ROOT)/make/system-id.mk
 
+# developer preferences, edit these at will, they'll be gitignored
+include $(ROOT)/make/local.mk
+ 
 # configure some directories that are relative to wherever ROOT_DIR is located
 TOOLS_DIR := $(ROOT)/tools
 BUILD_DIR := $(ROOT)/build

--- a/make/local.mk
+++ b/make/local.mk
@@ -1,2 +1,0 @@
-# override the toolchain version, should match the output from of your version of the toolchain: $(arm-none-eabi-gcc -dumpversion)
-#GCC_REQUIRED_VERSION=5.4.1

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -293,7 +293,7 @@ else ifeq (,$(findstring _install,$(MAKECMDGOALS)))
   ifeq ($(GCC_VERSION),)
     $(error **ERROR** arm-none-eabi-gcc not in the PATH. Run 'make arm_sdk_install' to install automatically in the tools folder of this repo)
   else ifneq ($(GCC_VERSION), $(GCC_REQUIRED_VERSION))
-    $(error **ERROR** your arm-none-eabi-gcc is '$(GCC_VERSION)', but '$(GCC_REQUIRED_VERSION)' is expected. Override with 'GCC_REQUIRED_VERSION' in make/local.mk or run 'make arm_sdk_install' to install the right version automatically in the tools folder of this repo)
+    $(error **ERROR** your arm-none-eabi-gcc is '$(GCC_VERSION)', but '$(GCC_REQUIRED_VERSION)' is expected. Override with 'GCC_REQUIRED_VERSION' in make/tools.mk or run 'make arm_sdk_install' to install the right version automatically in the tools folder of this repo)
   endif
   # not installed, hope it's in the path...
   ARM_SDK_PREFIX ?= arm-none-eabi-


### PR DESCRIPTION
- `make/local.mk` is no longer needed
- `GCC_REQUIRED_VERSION` is also set in `make/tools.mk`
- remove relations to `make/local.mk`