### PR TITLE
OMNIBUSF4SD: Fix LED_STRIP

### DIFF
--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -26,27 +26,27 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 #ifdef OMNIBUSF4SD
-    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_PWM | TIM_USE_PPM,   0, 0), // PPM
-    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_PWM,                 0, 0), // S2_IN
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_PWM | TIM_USE_PPM,   TIMER_OUTPUT_NONE,     0), // PPM
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S2_IN
 #else
-    DEF_TIM(TIM12, CH1, PB14, TIM_USE_PWM | TIM_USE_PPM,   0, 0), // PPM
-    DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM,                 0, 0), // S2_IN
+    DEF_TIM(TIM12, CH1, PB14, TIM_USE_PWM | TIM_USE_PPM,   TIMER_OUTPUT_NONE,     0), // PPM
+    DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S2_IN
 #endif
-    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,                 0, 0), // S3_IN
-    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,                 0, 0), // S4_IN
-    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,                 0, 0), // S5_IN
-    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,                 0, 0), // S6_IN
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S3_IN
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S4_IN
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S5_IN
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S6_IN
 
-    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               1, 0), // S1_OUT D1_ST7
-    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               1, 0), // S2_OUT D1_ST2
-    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               1, 1), // S3_OUT D1_ST6
-    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               1, 0), // S4_OUT D1_ST1
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S1_OUT D1_ST7
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S2_OUT D1_ST2
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 1), // S3_OUT D1_ST6
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S4_OUT D1_ST1
 
 #ifdef OMNIBUSF4SD
-    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               1, 0), // S5_OUT
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0), // S6_OUT
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S5_OUT
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR | TIM_USE_LED, TIMER_OUTPUT_STANDARD, 0), // S6_OUT
 #else
-    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0), // S5_OUT
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR,               1, 0), // S6_OUT
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, TIMER_OUTPUT_STANDARD, 0), // S5_OUT
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S6_OUT
 #endif
 };

--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -20,26 +20,33 @@
 #include <platform.h>
 #include "drivers/io.h"
 
-#include "drivers/timer.h"
 #include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 #ifdef OMNIBUSF4SD
-    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, TIM_USE_PWM | TIM_USE_PPM, 0, GPIO_AF_TIM4, NULL, 0, 0}, // PPM
-    { TIM4,  IO_TAG(PB9),  TIM_Channel_4, TIM_USE_PWM, 0, GPIO_AF_TIM4, NULL, 0, 0}, // S2_IN
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_PWM | TIM_USE_PPM,   0, 0), // PPM
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_PWM,                 0, 0), // S2_IN
 #else
-    { TIM12, IO_TAG(PB14), TIM_Channel_1, TIM_USE_PWM | TIM_USE_PPM, 0, GPIO_AF_TIM12, NULL, 0, 0 }, // PPM
-    { TIM12, IO_TAG(PB15), TIM_Channel_2, TIM_USE_PWM, 0, GPIO_AF_TIM12, NULL, 0, 0 }, // S2_IN
+    DEF_TIM(TIM12, CH1, PB14, TIM_USE_PWM | TIM_USE_PPM,   0, 0), // PPM
+    DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM,                 0, 0), // S2_IN
 #endif
-    { TIM8,  IO_TAG(PC6),  TIM_Channel_1, TIM_USE_PWM, 0, GPIO_AF_TIM8,  NULL, 0, 0 }, // S3_IN
-    { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM_USE_PWM, 0, GPIO_AF_TIM8,  NULL, 0, 0 }, // S4_IN
-    { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM_USE_PWM, 0, GPIO_AF_TIM8,  NULL, 0, 0 }, // S5_IN
-    { TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_PWM, 0, GPIO_AF_TIM8,  NULL, 0, 0 }, // S6_IN
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,                 0, 0), // S3_IN
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,                 0, 0), // S4_IN
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,                 0, 0), // S5_IN
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,                 0, 0), // S6_IN
 
-    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_TIM3, DMA1_Stream7, DMA_Channel_5, DMA1_ST7_HANDLER }, // S1_OUT
-    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_TIM3, DMA1_Stream2, DMA_Channel_5, DMA1_ST2_HANDLER }, // S2_OUT
-    { TIM2,  IO_TAG(PA3),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_TIM2, DMA1_Stream6, DMA_Channel_3, DMA1_ST6_HANDLER }, // S4_OUT
-    { TIM2,  IO_TAG(PA2),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_TIM2, DMA1_Stream1, DMA_Channel_3, DMA1_ST1_HANDLER }, // S4_OUT
-    { TIM5,  IO_TAG(PA1),  TIM_Channel_2, TIM_USE_MOTOR | TIM_USE_LED, 1, GPIO_AF_TIM5, DMA1_Stream4, DMA_Channel_6, DMA1_ST4_HANDLER }, // S5_OUT - GPIO_PartialRemap_TIM3
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_TIM1, NULL, 0, 0 }, // S6_OUT
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               1, 0), // S1_OUT D1_ST7
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               1, 0), // S2_OUT D1_ST2
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               1, 1), // S3_OUT D1_ST6
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               1, 0), // S4_OUT D1_ST1
+
+#ifdef OMNIBUSF4SD
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               1, 0), // S5_OUT
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0), // S6_OUT
+#else
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0), // S5_OUT
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR,               1, 0), // S6_OUT
+#endif
 };


### PR DESCRIPTION
OMNIBUSF4 used PWM5 (TIM5 CH2, DMA1 ST4) for LED_STRIP.

On OMNIBUSF4SD, default assignment is PWM6 (TIM1 CH1, DMA2 ST6).