### PR TITLE
Cleanup conversion warnings in CMS and some more.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -120,8 +120,8 @@ static displayPort_t *cmsDisplayPortSelectNext(void)
 //
 
 #define LEFT_MENU_COLUMN  1
-#define RIGHT_MENU_COLUMN(p) ((uint8_t)((p)->cols - 8))
-#define MAX_MENU_ITEMS(p)    ((uint8_t)((p)->rows - 2))
+static inline uint8_t RIGHT_MENU_COLUMN(displayPort_t *p) { return (uint8_t)((p)->cols - 8); }
+static inline uint8_t MAX_MENU_ITEMS(displayPort_t *p) { return (uint8_t)((p)->rows - 2); }
 
 static bool cmsInMenu = false;
 
@@ -432,10 +432,7 @@ static void cmsDrawMenu(displayPort_t *pDisplay, uint32_t currentTimeUs)
     for (i = 0, p = pageTop; i < MAX_MENU_ITEMS(pDisplay) && p->type != OME_END; i++, p++) {
         if (IS_PRINTLABEL(p)) {
             uint8_t coloff = LEFT_MENU_COLUMN;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-            coloff += (p->type == OME_Label) ? 1 : 2;
-#pragma GCC diagnostic pop
+            coloff = (uint8_t)(coloff + ((p->type == OME_Label) ? 1 : 2));
             room -= displayWrite(pDisplay, coloff, (uint8_t)(i + top), p->text);
             CLR_PRINTLABEL(p);
             if (room < 30)
@@ -480,10 +477,7 @@ long cmsMenuChange(displayPort_t *pDisplay, const void *ptr)
 
         if (pMenu != currentMenu) {
             menuStack[menuStackIdx] = currentMenu;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-            cursorRow += pageTop - currentMenu->entries; // Convert cursorRow to absolute value
-#pragma GCC diagnostic pop
+            cursorRow = (int8_t)(cursorRow + pageTop - currentMenu->entries); // Convert cursorRow to absolute value
             menuStackHistory[menuStackIdx] = cursorRow;
             menuStackIdx++;
 
@@ -527,10 +521,7 @@ STATIC_UNIT_TESTED long cmsMenuBack(displayPort_t *pDisplay)
             // Cursor was in the second page.
             pageTopAlt = currentMenu->entries;
             pageTop = pageTopAlt + maxRow + 1;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-            cursorRow -= (maxRow + 1);
-#pragma GCC diagnostic pop
+            cursorRow = (int8_t)(cursorRow - (maxRow + 1));
             cmsUpdateMaxRow(pDisplay); // Update maxRow for the second page
         }
     }
@@ -630,8 +621,8 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
 #define BUTTON_TIME   250 // msec
 #define BUTTON_PAUSE  500 // msec
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
+//#pragma GCC diagnostic push
+//#pragma GCC diagnostic ignored "-Wconversion"
 
 STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
 {
@@ -748,11 +739,11 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
                 OSD_UINT8_t *ptr = p->data;
                 if (key == KEY_RIGHT) {
                     if (*ptr->val < ptr->max)
-                        *ptr->val += ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val + ptr->step);
                 }
                 else {
                     if (*ptr->val > ptr->min)
-                        *ptr->val -= ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val - ptr->step);
                 }
                 SET_PRINTVALUE(p);
                 if (p->func) {
@@ -767,11 +758,11 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
 
                 if (key == KEY_RIGHT) {
                     if (*ptr->val < ptr->max)
-                        *ptr->val += 1;
+                        *ptr->val = (uint8_t)(*ptr->val + 1);
                 }
                 else {
                     if (*ptr->val > 0)
-                        *ptr->val -= 1;
+                        *ptr->val = (uint8_t)(*ptr->val - 1);
                 }
                 if (p->func)
                     p->func(pDisplay, p->data);
@@ -784,11 +775,11 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
                 OSD_INT8_t *ptr = p->data;
                 if (key == KEY_RIGHT) {
                     if (*ptr->val < ptr->max)
-                        *ptr->val += ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val + ptr->step);
                 }
                 else {
                     if (*ptr->val > ptr->min)
-                        *ptr->val -= ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val - ptr->step);
                 }
                 SET_PRINTVALUE(p);
                 if (p->func) {
@@ -802,11 +793,11 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
                 OSD_UINT16_t *ptr = p->data;
                 if (key == KEY_RIGHT) {
                     if (*ptr->val < ptr->max)
-                        *ptr->val += ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val + ptr->step);
                 }
                 else {
                     if (*ptr->val > ptr->min)
-                        *ptr->val -= ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val - ptr->step);
                 }
                 SET_PRINTVALUE(p);
                 if (p->func) {
@@ -820,11 +811,11 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
                 OSD_INT16_t *ptr = p->data;
                 if (key == KEY_RIGHT) {
                     if (*ptr->val < ptr->max)
-                        *ptr->val += ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val + ptr->step);
                 }
                 else {
                     if (*ptr->val > ptr->min)
-                        *ptr->val -= ptr->step;
+                        *ptr->val = (uint8_t)(*ptr->val - ptr->step);
                 }
                 SET_PRINTVALUE(p);
                 if (p->func) {
@@ -847,7 +838,6 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
     return res;
 }
 
-#pragma GCC diagnostic pop
 
 uint16_t cmsHandleKeyWithRepeat(displayPort_t *pDisplay, uint8_t key, int repeatCount)
 {
@@ -862,7 +852,7 @@ uint16_t cmsHandleKeyWithRepeat(displayPort_t *pDisplay, uint8_t key, int repeat
 
 static void cmsUpdate(uint32_t currentTimeUs)
 {
-    static int16_t rcDelayMs = BUTTON_TIME;
+    static timeDelta_t rcDelayMs = BUTTON_TIME;
     static int holdCount = 1;
     static int repeatCount = 1;
     static int repeatBase = 0;
@@ -916,10 +906,7 @@ static void cmsUpdate(uint32_t currentTimeUs)
         }
 
         if (rcDelayMs > 0) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
             rcDelayMs -= (currentTimeMs - lastCalledMs);
-#pragma GCC diagnostic pop
         } else if (key) {
             rcDelayMs = cmsHandleKeyWithRepeat(pCurrentDisplay, key, repeatCount);
 
@@ -937,10 +924,7 @@ static void cmsUpdate(uint32_t currentTimeUs)
 
                 // Decrease rcDelayMs reciprocally
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
                 rcDelayMs /= (holdCount - 20);
-#pragma GCC diagnostic pop
 
                 // When we reach the scheduling limit,
 

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -433,7 +433,7 @@ static void cmsDrawMenu(displayPort_t *pDisplay, uint32_t currentTimeUs)
         if (IS_PRINTLABEL(p)) {
             int coloff = LEFT_MENU_COLUMN;
             coloff += (p->type == OME_Label) ? 1 : 2;
-        room -= displayWrite(pDisplay, (diplayPos_t)coloff, (diplayPos_t)(i + top), p->text);
+            room -= displayWrite(pDisplay, (diplayPos_t)coloff, (diplayPos_t)(i + top), p->text);
             CLR_PRINTLABEL(p);
             if (room < 30)
                 return;
@@ -539,10 +539,7 @@ STATIC_UNIT_TESTED void cmsMenuOpen(void)
             return;
         cmsInMenu = true;
         currentMenu = &menuMain;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
         DISABLE_ARMING_FLAG(OK_TO_ARM);
-#pragma GCC diagnostic pop
     } else {
         // Switch display
         displayPort_t *pNextDisplay = cmsDisplayPortSelectNext();

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -53,13 +53,15 @@ typedef enum
 
 typedef long (*CMSEntryFuncPtr)(displayPort_t *displayPort, const void *ptr);
 
+typedef uint8_t OSD_flags_t;
+
 typedef struct
 {
     const char *text;
     const OSD_MenuElement type;
     const CMSEntryFuncPtr func;
     void *data;
-    uint8_t flags;
+    OSD_flags_t flags;
 } OSD_Entry;
 
 // Bits in flags
@@ -68,15 +70,15 @@ typedef struct
 #define DYNAMIC        0x04  // Value should be updated dynamically
 #define OPTSTRING      0x08  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 
-#define IS_PRINTVALUE(p) ((p)->flags & PRINT_VALUE)
-#define SET_PRINTVALUE(p) { (p)->flags |= PRINT_VALUE; }
-#define CLR_PRINTVALUE(p) { (p)->flags &= (uint8_t)~PRINT_VALUE; }
+static inline OSD_flags_t IS_PRINTVALUE(OSD_Entry *p) { return (p->flags & PRINT_VALUE); }
+static inline void SET_PRINTVALUE(OSD_Entry *p) { p->flags |= PRINT_VALUE; }
+static inline void CLR_PRINTVALUE(OSD_Entry *p) { p->flags &= (OSD_flags_t)~PRINT_VALUE; }
 
-#define IS_PRINTLABEL(p) ((p)->flags & PRINT_LABEL)
-#define SET_PRINTLABEL(p) { (p)->flags |= PRINT_LABEL; }
-#define CLR_PRINTLABEL(p) { (p)->flags &= (uint8_t)~PRINT_LABEL; }
+static inline OSD_flags_t IS_PRINTLABEL(OSD_Entry *p) { return (p->flags & PRINT_LABEL); }
+static inline void SET_PRINTLABEL(OSD_Entry *p) { p->flags |= PRINT_LABEL; }
+static inline void CLR_PRINTLABEL(OSD_Entry *p) { p->flags &= (OSD_flags_t)~PRINT_LABEL; }
 
-#define IS_DYNAMIC(p) ((p)->flags & DYNAMIC)
+static inline OSD_flags_t IS_DYNAMIC(OSD_Entry *p) { return (p->flags & DYNAMIC); }
 
 typedef long (*CMSMenuFuncPtr)(void);
 

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -70,11 +70,11 @@ typedef struct
 
 #define IS_PRINTVALUE(p) ((p)->flags & PRINT_VALUE)
 #define SET_PRINTVALUE(p) { (p)->flags |= PRINT_VALUE; }
-#define CLR_PRINTVALUE(p) { (p)->flags &= ~PRINT_VALUE; }
+#define CLR_PRINTVALUE(p) { (p)->flags &= (uint8_t)~PRINT_VALUE; }
 
 #define IS_PRINTLABEL(p) ((p)->flags & PRINT_LABEL)
 #define SET_PRINTLABEL(p) { (p)->flags |= PRINT_LABEL; }
-#define CLR_PRINTLABEL(p) { (p)->flags &= ~PRINT_LABEL; }
+#define CLR_PRINTLABEL(p) { (p)->flags &= (uint8_t)~PRINT_LABEL; }
 
 #define IS_DYNAMIC(p) ((p)->flags & DYNAMIC)
 

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -188,7 +188,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
 
     // determine product ID and accel revision
     ack = gyro->mpuConfiguration.read(MPU_RA_XA_OFFS_H, 6, readBuffer);
-    revision = ((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01);
+    revision = (uint8_t)(((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01));
     if (revision) {
         /* Congrats, these parts are better. */
         if (revision == 1) {

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -147,7 +147,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
     i2cState_t *state;
     state = &(i2cState[device]);
 
-    state->addr = addr_ << 1;
+    state->addr = (uint8_t)(addr_ << 1);
     state->reg = reg_;
     state->writing = 1;
     state->reading = 0;
@@ -193,7 +193,7 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
     i2cState_t *state;
     state = &(i2cState[device]);
 
-    state->addr = addr_ << 1;
+    state->addr = (uint8_t)(addr_ << 1);
     state->reg = reg_;
     state->writing = 0;
     state->reading = 1;
@@ -252,7 +252,7 @@ static void i2c_er_handler(I2CDevice device) {
             }
         }
     }
-    I2Cx->SR1 &= ~0x0F00;                                                       // reset all the error bits to clear the interrupt
+    I2Cx->SR1 &= (uint16_t)~0x0F00;                                                       // reset all the error bits to clear the interrupt
     state->busy = 0;
 }
 
@@ -266,10 +266,10 @@ void i2c_ev_handler(I2CDevice device) {
 
     static uint8_t subaddress_sent, final_stop;                                 // flag to indicate if subaddess sent, flag to indicate final bus condition
     static int8_t index;                                                        // index is signed -1 == send the subaddress
-    uint8_t SReg_1 = I2Cx->SR1;                                                 // read the status register here
+    uint16_t SReg_1 = I2Cx->SR1;                                                // read the status register here
 
     if (SReg_1 & I2C_SR1_SB) {                                                  // we just sent a start - EV5 in ref manual
-        I2Cx->CR1 &= ~I2C_CR1_POS;                                              // reset the POS bit so ACK/NACK applied to the current byte
+        I2Cx->CR1 &= (uint16_t)~I2C_CR1_POS;                                    // reset the POS bit so ACK/NACK applied to the current byte
         I2C_AcknowledgeConfig(I2Cx, ENABLE);                                    // make sure ACK is on
         index = 0;                                                              // reset the index
         if (state->reading && (subaddress_sent || 0xFF == state->reg)) {          // we have sent the subaddr
@@ -387,8 +387,8 @@ void i2cInit(I2CDevice device)
     IO_t scl = IOGetByTag(i2c->scl);
     IO_t sda = IOGetByTag(i2c->sda);
 
-    IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(device));
-    IOInit(sda, OWNER_I2C_SDA, RESOURCE_INDEX(device));
+    IOInit(scl, OWNER_I2C_SCL, (uint8_t)RESOURCE_INDEX(device));
+    IOInit(sda, OWNER_I2C_SDA, (uint8_t)RESOURCE_INDEX(device));
 
     // Enable RCC
     RCC_ClockCmd(i2c->rcc, ENABLE);

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -17,15 +17,17 @@
 
 #pragma once
 
+typedef uint8_t diplayPos_t;
+
 struct displayPortVTable_s;
 typedef struct displayPort_s {
     const struct displayPortVTable_s *vTable;
-    uint8_t rows;
-    uint8_t cols;
+    diplayPos_t rows;
+    diplayPos_t cols;
 
     // CMS state
     bool cleared;
-    int8_t cursorRow;
+    int cursorRow;
     int8_t grabCount;
 } displayPort_t;
 
@@ -35,8 +37,8 @@ typedef struct displayPortVTable_s {
     int (*clearScreen)(displayPort_t *displayPort);
     int (*drawScreen)(displayPort_t *displayPort);
     int (*screenSize)(const displayPort_t *displayPort);
-    int (*write)(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *text);
-    int (*writeChar)(displayPort_t *displayPort, uint8_t x, uint8_t y, uint8_t c);
+    int (*write)(displayPort_t *displayPort, diplayPos_t x, diplayPos_t y, const char *text);
+    int (*writeChar)(displayPort_t *displayPort, diplayPos_t x, diplayPos_t y, uint8_t c);
     bool (*isTransferInProgress)(const displayPort_t *displayPort);
     int (*heartbeat)(displayPort_t *displayPort);
     void (*resync)(displayPort_t *displayPort);
@@ -50,8 +52,8 @@ bool displayIsGrabbed(const displayPort_t *instance);
 void displayClearScreen(displayPort_t *instance);
 void displayDrawScreen(displayPort_t *instance);
 int displayScreenSize(const displayPort_t *instance);
-int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, const char *s);
-int displayWriteChar(displayPort_t *instance, uint8_t x, uint8_t y, uint8_t c);
+int displayWrite(displayPort_t *instance, diplayPos_t x, diplayPos_t y, const char *s);
+int displayWriteChar(displayPort_t *instance, diplayPos_t x, diplayPos_t y, uint8_t c);
 bool displayIsTransferInProgress(const displayPort_t *instance);
 void displayHeartbeat(displayPort_t *instance);
 void displayResync(displayPort_t *instance);

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -25,11 +25,16 @@ typedef enum {
     WAS_EVER_ARMED  = (1 << 3)
 } armingFlag_e;
 
+// This is really an armingFlag_e type. Args and return values in the inlined funcs too.
+// But clang++ in unittests does not like that in the compound assignments.
+// It would also be expanded to the native size of enum-types, 32-bit int typically.
+// Keep as is for now.
 extern uint8_t armingFlags;
 
-#define DISABLE_ARMING_FLAG(mask) (armingFlags &= ~(mask))
-#define ENABLE_ARMING_FLAG(mask) (armingFlags |= (mask))
-#define ARMING_FLAG(mask) (armingFlags & (mask))
+static inline void DISABLE_ARMING_FLAG(uint8_t mask) { (armingFlags &= (uint8_t)~(mask)); }
+static inline void ENABLE_ARMING_FLAG(uint8_t mask) { (armingFlags |= (uint8_t)(mask)); }
+static inline uint8_t ARMING_FLAG(uint8_t mask) { return (armingFlags & (mask)); }
+
 
 typedef enum {
     ANGLE_MODE      = (1 << 0),

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -157,14 +157,14 @@ specialColorIndexes_t specialColors;
 #define LD(name) LED_FLAG_DIRECTION(LED_DIRECTION_ ## name)
 #define DEFINE_LED(x, y, col, dir, func, ol, params) (LED_MOV_POS(CALCULATE_LED_XY(x, y)) | LED_MOV_COLOR(col) | LED_MOV_DIRECTION(dir) | LED_MOV_FUNCTION(func) | LED_MOV_OVERLAY(ol) | LED_MOV_PARAMS(params))
 
-static inline uint8_t ledGetXY(const ledConfig_t *lcfg)         { return ((*lcfg >> LED_POS_OFFSET) & LED_BIT_MASK(LED_POS_BITCNT)); }
-static inline uint8_t ledGetX(const ledConfig_t *lcfg)          { return ((*lcfg >> (LED_POS_OFFSET + LED_X_BIT_OFFSET)) & LED_XY_MASK); }
-static inline uint8_t ledGetY(const ledConfig_t *lcfg)          { return ((*lcfg >> (LED_POS_OFFSET + LED_Y_BIT_OFFSET)) & LED_XY_MASK); }
-static inline uint8_t ledGetFunction(const ledConfig_t *lcfg)   { return ((*lcfg >> LED_FUNCTION_OFFSET) & LED_BIT_MASK(LED_FUNCTION_BITCNT)); }
-static inline uint8_t ledGetOverlay(const ledConfig_t *lcfg)    { return ((*lcfg >> LED_OVERLAY_OFFSET) & LED_BIT_MASK(LED_OVERLAY_BITCNT)); }
-static inline uint8_t ledGetColor(const ledConfig_t *lcfg)      { return ((*lcfg >> LED_COLOR_OFFSET) & LED_BIT_MASK(LED_COLOR_BITCNT)); }
-static inline uint8_t ledGetDirection(const ledConfig_t *lcfg)  { return ((*lcfg >> LED_DIRECTION_OFFSET) & LED_BIT_MASK(LED_DIRECTION_BITCNT)); }
-static inline uint8_t ledGetParams(const ledConfig_t *lcfg)     { return ((*lcfg >> LED_PARAMS_OFFSET) & LED_BIT_MASK(LED_PARAMS_BITCNT)); }
+static inline uint8_t ledGetXY(const ledConfig_t *lcfg)         { return ((uint8_t)(*lcfg >> LED_POS_OFFSET) & LED_BIT_MASK(LED_POS_BITCNT)); }
+static inline uint8_t ledGetX(const ledConfig_t *lcfg)          { return ((uint8_t)(*lcfg >> (LED_POS_OFFSET + LED_X_BIT_OFFSET)) & LED_XY_MASK); }
+static inline uint8_t ledGetY(const ledConfig_t *lcfg)          { return ((uint8_t)(*lcfg >> (LED_POS_OFFSET + LED_Y_BIT_OFFSET)) & LED_XY_MASK); }
+static inline uint8_t ledGetFunction(const ledConfig_t *lcfg)   { return ((uint8_t)(*lcfg >> LED_FUNCTION_OFFSET) & LED_BIT_MASK(LED_FUNCTION_BITCNT)); }
+static inline uint8_t ledGetOverlay(const ledConfig_t *lcfg)    { return ((uint8_t)(*lcfg >> LED_OVERLAY_OFFSET) & LED_BIT_MASK(LED_OVERLAY_BITCNT)); }
+static inline uint8_t ledGetColor(const ledConfig_t *lcfg)      { return ((uint8_t)(*lcfg >> LED_COLOR_OFFSET) & LED_BIT_MASK(LED_COLOR_BITCNT)); }
+static inline uint8_t ledGetDirection(const ledConfig_t *lcfg)  { return ((uint8_t)(*lcfg >> LED_DIRECTION_OFFSET) & LED_BIT_MASK(LED_DIRECTION_BITCNT)); }
+static inline uint8_t ledGetParams(const ledConfig_t *lcfg)     { return ((uint8_t)(*lcfg >> LED_PARAMS_OFFSET) & LED_BIT_MASK(LED_PARAMS_BITCNT)); }
 
 static inline bool ledGetOverlayBit(const ledConfig_t *lcfg, int id) { return ((ledGetOverlay(lcfg) >> id) & 1); }
 static inline bool ledGetDirectionBit(const ledConfig_t *lcfg, int id) { return ((ledGetDirection(lcfg) >> id) & 1); }


### PR DESCRIPTION
Had to use  `#pragma GCC diagnostic ignored "-Wconversion"` to turn of warnings in a lot of places. gcc gives false positives. Unfortunately his clutters the code and looks awful. Ideas please to do this in a prettier way.
