### PR TITLE
Add transponder header to fc_hardfaults.c

### DIFF
--- a/src/main/fc/fc_hardfaults.c
+++ b/src/main/fc/fc_hardfaults.c
@@ -22,6 +22,7 @@
 
 #include "drivers/light_led.h"
 #include "drivers/system.h"
+#include "drivers/transponder_ir.h"
 
 #include "fc/fc_init.h"
 


### PR DESCRIPTION
Suppress implicit function warning.