### PR TITLE
Revert 907a184 (#1712)

### DIFF
--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -148,9 +148,9 @@
 
 #define LED_STRIP
 
-//#define SONAR
-//#define SONAR_ECHO_PIN          PB1
-//#define SONAR_TRIGGER_PIN       PB0
+#define SONAR
+#define SONAR_ECHO_PIN          PB1
+#define SONAR_TRIGGER_PIN       PB0
 
 #define DEFAULT_FEATURES        FEATURE_BLACKBOX
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -45,14 +45,14 @@
 #define BMP280_SPI_INSTANCE     SPI1
 #define BMP280_CS_PIN           PA13
 
-//#define BARO
-//#define USE_BARO_BMP280
-//#define USE_BARO_SPI_BMP280
+#define BARO
+#define USE_BARO_BMP280
+#define USE_BARO_SPI_BMP280
 
-//#define MAG // External
-//#define USE_MAG_AK8963
-//#define USE_MAG_AK8975
-//#define USE_MAG_HMC5883
+#define MAG // External
+#define USE_MAG_AK8963
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
 
 //#define SONAR
 //#define SONAR_ECHO_PIN          PB1

--- a/src/main/target/RCEXPLORERF3/target.h
+++ b/src/main/target/RCEXPLORERF3/target.h
@@ -109,15 +109,15 @@
 #define SERIALRX_PROVIDER       SERIALRX_SBUS
 #define SERIALRX_UART           SERIAL_PORT_USART1
 
-//#define NAV
-//#define NAV_AUTO_MAG_DECLINATION
-//#define NAV_GPS_GLITCH_DETECTION
-//#define NAV_MAX_WAYPOINTS               60
-//#define GPS
+#define NAV
+#define NAV_AUTO_MAG_DECLINATION
+#define NAV_GPS_GLITCH_DETECTION
+#define NAV_MAX_WAYPOINTS               60
+#define GPS
 #define BLACKBOX
 #define TELEMETRY
 #define SERIAL_RX
-//#define AUTOTUNE
+#define AUTOTUNE
 #define USE_SERVOS
 #define USE_CLI
 


### PR DESCRIPTION
PR STATUS: Under testing and review by board maintainers.

Per #2008.

Some F3 targets were modified to drop some features during compiler speed optimization deployment.

There were 6 targets which received the modification:

FURYF3
RCEXPLORERF3
OMNIBUS
SPRACINGF3
SPRACINGF3EVO
SPRACINGF3MINI

SPRACINGF3* seem to have reverted already.

This PR reverts the changes for the rest of the targets.