### PR TITLE
Optimise RC interpolation

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -181,7 +181,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->levelSensitivity = 100;  // 100 degrees at full stick
     pidProfile->setpointRelaxRatio = 30;
     pidProfile->dtermSetpointWeight = 200;
-    pidProfile->yawRateAccelLimit = 20.0f;
+    pidProfile->yawRateAccelLimit = 10.0f;
     pidProfile->rateAccelLimit = 0.0f;
     pidProfile->itermThrottleThreshold = 350;
 }
@@ -693,6 +693,7 @@ void createDefaultConfig(master_t *config)
     config->rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
     config->rxConfig.rssi_ppm_invert = 0;
     config->rxConfig.rcInterpolation = RC_SMOOTHING_AUTO;
+    config->rxConfig.rcInterpolationChannels = 0;
     config->rxConfig.rcInterpolationInterval = 19;
     config->rxConfig.fpvCamAngleDegrees = 0;
     config->rxConfig.max_aux_channel = MAX_AUX_CHANNELS;

--- a/src/main/fc/fc_main.c
+++ b/src/main/fc/fc_main.c
@@ -209,6 +209,7 @@ void processRcCommand(void)
     static int16_t deltaRC[4] = { 0, 0, 0, 0 };
     static int16_t factor, rcInterpolationFactor;
     static uint16_t currentRxRefreshRate;
+    const uint8_t interpolationChannels = rxConfig()->rcInterpolationChannels + 1;
     uint16_t rxRefreshRate;
     bool readyToCalculateRate = false;
 
@@ -240,7 +241,7 @@ void processRcCommand(void)
                 debug[3] = rxRefreshRate;
             }
 
-            for (int channel=0; channel < 4; channel++) {
+            for (int channel=ROLL; channel <= interpolationChannels; channel++) {
                 deltaRC[channel] = rcCommand[channel] -  (lastCommand[channel] - deltaRC[channel] * factor / rcInterpolationFactor);
                 lastCommand[channel] = rcCommand[channel];
             }
@@ -252,7 +253,8 @@ void processRcCommand(void)
 
         // Interpolate steps of rcCommand
         if (factor > 0) {
-            for (int channel=0; channel < 4; channel++) rcCommand[channel] = lastCommand[channel] - deltaRC[channel] * factor/rcInterpolationFactor;
+            for (int channel=ROLL; channel <= interpolationChannels; channel++)
+                rcCommand[channel] = lastCommand[channel] - deltaRC[channel] * factor/rcInterpolationFactor;
         } else {
             factor = 0;
         }

--- a/src/main/fc/serial_cli.c
+++ b/src/main/fc/serial_cli.c
@@ -340,6 +340,10 @@ static const char * const lookupTableRcInterpolation[] = {
     "OFF", "PRESET", "AUTO", "MANUAL"
 };
 
+static const char * const lookupTableRcInterpolationChannels[] = {
+    "RP", "RPY", "RPYT"
+};
+
 static const char * const lookupTableLowpassType[] = {
     "PT1", "BIQUAD", "FIR"
 };
@@ -387,6 +391,7 @@ typedef enum {
     TABLE_SUPEREXPO_YAW,
     TABLE_MOTOR_PWM_PROTOCOL,
     TABLE_RC_INTERPOLATION,
+    TABLE_RC_INTERPOLATION_CHANNELS,
     TABLE_LOWPASS_TYPE,
     TABLE_FAILSAFE,
 #ifdef OSD
@@ -428,6 +433,7 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableSuperExpoYaw, sizeof(lookupTableSuperExpoYaw) / sizeof(char *) },
     { lookupTablePwmProtocol, sizeof(lookupTablePwmProtocol) / sizeof(char *) },
     { lookupTableRcInterpolation, sizeof(lookupTableRcInterpolation) / sizeof(char *) },
+    { lookupTableRcInterpolationChannels, sizeof(lookupTableRcInterpolationChannels) / sizeof(char *) },    
     { lookupTableLowpassType, sizeof(lookupTableLowpassType) / sizeof(char *) },
     { lookupTableFailsafe, sizeof(lookupTableFailsafe) / sizeof(char *) },
 #ifdef OSD
@@ -492,6 +498,7 @@ const clivalue_t valueTable[] = {
     { "rssi_channel",               VAR_INT8   | MASTER_VALUE,  &rxConfig()->rssi_channel, .config.minmax = { 0,  MAX_SUPPORTED_RC_CHANNEL_COUNT } },
     { "rssi_scale",                 VAR_UINT8  | MASTER_VALUE,  &rxConfig()->rssi_scale, .config.minmax = { RSSI_SCALE_MIN,  RSSI_SCALE_MAX } },
     { "rc_interpolation",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &rxConfig()->rcInterpolation, .config.lookup = { TABLE_RC_INTERPOLATION } },
+    { "rc_interpolation_channels",  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &rxConfig()->rcInterpolationChannels, .config.lookup = { TABLE_RC_INTERPOLATION_CHANNELS } },
     { "rc_interpolation_interval",  VAR_UINT8  | MASTER_VALUE,  &rxConfig()->rcInterpolationInterval, .config.minmax = { 1,  50 } },
     { "rssi_ppm_invert",            VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  &rxConfig()->rssi_ppm_invert, .config.lookup = { TABLE_OFF_ON } },
 #if defined(USE_PWM)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -125,6 +125,7 @@ typedef struct rxConfig_s {
     uint16_t mincheck;                      // minimum rc end
     uint16_t maxcheck;                      // maximum rc end
     uint8_t rcInterpolation;
+    uint8_t rcInterpolationChannels;
     uint8_t rcInterpolationInterval;
     uint8_t fpvCamAngleDegrees;             // Camera angle to be scaled into rc commands
     uint8_t max_aux_channel;


### PR DESCRIPTION
By default only interpolate roll and pitch and have throttle and yaw optional.

Only roll and pitch use derivative