### PR TITLE
SMARTAUDIO: Autobaud scan range is now configurable

### DIFF
--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -50,6 +50,7 @@
 #include "io/osd.h"
 #include "io/ledstrip.h"
 #include "io/vtx.h"
+#include "io/vtx_smartaudio.h"
 
 #include "rx/rx.h"
 
@@ -105,6 +106,7 @@
 #define servoProfile(x) (&masterConfig.servoProfile)
 #define customMotorMixer(i) (&masterConfig.customMotorMixer[i])
 #define customServoMixer(i) (&masterConfig.customServoMixer[i])
+#define smartAudioConfig(x) (&masterConfig.smartAudioConfig)
 
 
 // System-wide
@@ -237,6 +239,10 @@ typedef struct master_s {
 
 #ifdef USE_FLASHFS
     flashConfig_t flashConfig;
+#endif
+
+#ifdef VTX_SMARTAUDIO
+    smartAudioConfig_t smartAudioConfig;
 #endif
 
     uint32_t beeper_off_flags;

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -88,6 +88,7 @@ uint8_t cliMode = 0;
 #include "io/serial.h"
 #include "io/servos.h"
 #include "io/vtx.h"
+#include "io/vtx_smartaudio.h"
 
 #include "rx/rx.h"
 #include "rx/spektrum.h"
@@ -796,6 +797,10 @@ const clivalue_t valueTable[] = {
     { "vcd_video_system",           VAR_UINT8   | MASTER_VALUE, &vcdProfile()->video_system, .config.minmax = { 0, 2 } },
     { "vcd_h_offset",               VAR_INT8    | MASTER_VALUE, &vcdProfile()->h_offset, .config.minmax = { -32, 31 } },
     { "vcd_v_offset",               VAR_INT8    | MASTER_VALUE, &vcdProfile()->v_offset, .config.minmax = { -15, 16 } },
+#endif
+#ifdef VTX_SMARTAUDIO
+    { "smartaudio_autobaud_min",    VAR_UINT16  | MASTER_VALUE, &smartAudioConfig()->autobaud_min, .config.minmax = { 4550, 4800 } },
+    { "smartaudio_autobaud_max",    VAR_UINT16  | MASTER_VALUE, &smartAudioConfig()->autobaud_max, .config.minmax = { 4850, 5100 } },
 #endif
 };
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -73,6 +73,7 @@
 #include "io/gps.h"
 #include "io/osd.h"
 #include "io/vtx.h"
+#include "io/vtx_smartaudio.h"
 
 #include "rx/rx.h"
 #include "rx/rx_spi.h"
@@ -829,6 +830,11 @@ void createDefaultConfig(master_t *config)
 
 #ifdef USE_FLASHFS
     resetFlashConfig(&config->flashConfig);
+#endif
+
+#ifdef VTX_SMARTAUDIO
+    config->smartAudioConfig.autobaud_min = SMARTAUDIO_AUTOBAUD_DEFAULT_MIN;
+    config->smartAudioConfig.autobaud_max = SMARTAUDIO_AUTOBAUD_DEFAULT_MAX;
 #endif
 
     resetStatusLedConfig(&config->statusLedConfig);

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -524,7 +524,7 @@ void init(void)
 #endif
 
 #ifdef VTX_SMARTAUDIO
-    smartAudioInit();
+    smartAudioInit(smartAudioConfig());
 #endif
 
     // start all timers

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -1,35 +1,31 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
-// For generic API use, but here for now
+/* Created by jflyper */
 
-bool smartAudioInit();
+#pragma once
+
+typedef struct smartAudioConfig_s {
+    uint16_t autobaud_min;
+    uint16_t autobaud_max;
+} smartAudioConfig_t;
+
+#define SMARTAUDIO_AUTOBAUD_DEFAULT_MIN 4800
+#define SMARTAUDIO_AUTOBAUD_DEFAULT_MAX 4950
+
+bool smartAudioInit(smartAudioConfig_t *configToUse);
 void smartAudioProcess(uint32_t);
-
-#if 0
-#ifdef CMS
-
-uint16_t smartAudioSmartbaud;
-
-uint16_t saerr_badpre;
-uint16_t saerr_badlen;
-uint16_t saerr_crcerr;
-uint16_t saerr_oooresp;
-
-uint8_t smartAudioOpModel;
-uint8_t smartAudioStatus;
-uint8_t smartAudioBand;
-uint8_t smartAudioChan;
-uint16_t smartAudioFreq;
-uint8_t smartAudioPower;
-uint8_t smartAudioTxMode;
-uint8_t smartAudioPitFMode;
-uint16_t smartAudioORFreq;
-
-long smartAudioConfigureOpModelByGvar(displayPort_t *, const void *self);
-long smartAudioConfigurePitFModeByGvar(displayPort_t *, const void *self);
-long smartAudioConfigureBandByGvar(displayPort_t *, const void *self);
-long smartAudioConfigureChanByGvar(displayPort_t *, const void *self);
-long smartAudioConfigurePowerByGvar(displayPort_t *, const void *self);
-long smartAudioSetTxModeByGvar(displayPort_t *, const void *self);
-
-#endif
-#endif


### PR DESCRIPTION
PR Status: Experimental

Some users are having problem connecting to their smartaudio devices.
This PR introduces cli variables `smartaudio_autobaud_{min,max}` (should be multiples of 50), so that they can experiment lower and upper limit of baud rate scanning.
