### PR TITLE
SPRACINGF3NEO - Alternative timers for DSHOT builds

### DIFF
--- a/src/main/target/SPRACINGF3NEO/target.c
+++ b/src/main/target/SPRACINGF3NEO/target.c
@@ -29,18 +29,35 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM15, CH1, PA2,  TIM_USE_PWM, 1 ), // PWM2
 
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR, 1 ),  // ESC1
-    DEF_TIM(TIM3,  CH2, PC7,  TIM_USE_MOTOR, 1 ),  // ESC2
-    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR, 1 ),  // ESC3
-    DEF_TIM(TIM3,  CH1, PC6,  TIM_USE_MOTOR, 1 ),  // ESC4
 
+#ifdef USE_DSHOT
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR, 1 ),  // ESC2
+#else
+    DEF_TIM(TIM3,  CH2, PC7,  TIM_USE_MOTOR, 1 ),  // ESC2
+#endif
+
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR, 1 ),  // ESC3
+
+#ifdef USE_DSHOT
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_MOTOR, 1 ),  // ESC4
+#else
+    DEF_TIM(TIM3,  CH1, PC6,  TIM_USE_MOTOR, 1 ),  // ESC4
+#endif
+
+#ifndef USE_DSHOT
+    // with DSHOT TIM8 is used for DSHOT and cannot be used for PWM
     DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR, 1 ),  // ESC5
     DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MOTOR, 1 ),  // ESC6
+#endif
 
     DEF_TIM(TIM2,  CH3, PB10, TIM_USE_MOTOR, 1 ),  // PWM3 - PB10 - *TIM2_CH3, UART3_TX (AF7)
     DEF_TIM(TIM2,  CH4, PB11, TIM_USE_MOTOR, 1 ),  // PWM4 - PB11 - *TIM2_CH4, UART3_RX (AF7)
 
+#ifndef USE_DSHOT
+    // with DSHOT DMA1-CH3 conflicts with TIM3_CH4 / ESC1.
     DEF_TIM(TIM16,  CH1, PB8, TIM_USE_TRANSPONDER, 0 ),
-
+    // with DSHOT TIM8 is used for DSHOT and cannot be used for LED too.
     DEF_TIM(TIM8,  CH1, PA15, TIM_USE_LED,   0 ),
+#endif
 };
 

--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -152,17 +152,6 @@
 #define WS2811_TIMER_GPIO_AF            GPIO_AF_6
 
 #define TRANSPONDER
-#define TRANSPONDER_GPIO                     GPIOB
-#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOB
-#define TRANSPONDER_GPIO_AF                  GPIO_AF_1
-#define TRANSPONDER_PIN                      GPIO_Pin_8 // TIM16_CH1
-#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
-#define TRANSPONDER_TIMER                    TIM16
-#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM16
-#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel3
-#define TRANSPONDER_IRQ                      DMA1_Channel3_IRQn
-#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC3
-#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH3_HANDLER
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 


### PR DESCRIPTION
This PR enables DSHOT on all 4 motor main outputs by using TIM8 instead of TIM3 for 2 of the pins.

This has the side affect of disabling the use of the transponder and led strip features capabilities due to other conflicts.

Tested on production hardware.