### PR TITLE
Fixed 'unused variable' warning in 'fc_msp'.

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1237,7 +1237,6 @@ static void mspFcDataFlashReadCommand(sbuf_t *dst, sbuf_t *src)
 static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 {
     uint32_t i;
-    uint16_t tmp;
     uint8_t value;
     const unsigned int dataSize = sbufBytesRemaining(src);
 #ifdef GPS
@@ -1636,7 +1635,8 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 
 #ifdef USE_RTC6705
     case MSP_SET_VTX_CONFIG:
-        tmp = sbufReadU16(src);
+        ;
+        uint16_t tmp = sbufReadU16(src);
         if  (tmp < 40)
             masterConfig.vtx_channel = tmp;
         if (current_vtx_channel != masterConfig.vtx_channel) {


### PR DESCRIPTION
Fixes #2124.