### PR TITLE
CMS Avoid right column protrusion

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -120,7 +120,8 @@ static displayPort_t *cmsDisplayPortSelectNext(void)
 //
 
 #define LEFT_MENU_COLUMN  1
-#define RIGHT_MENU_COLUMN(p) ((p)->cols - 8)
+//#define RIGHT_MENU_COLUMN(p) ((p)->cols - 8)
+#define RIGHT_MENU_COLUMN(p) ((p)->cols > 21 ? (p)->cols - 10 : (p)->cols - 8)
 #define MAX_MENU_ITEMS(p)    ((p)->rows - 2)
 
 static bool cmsInMenu = false;


### PR DESCRIPTION
Many video displays/goggles seem to have problem displaying full 30 characters horizontally, resulting in failure to display 8 character values. Fix this by shifting the right column by 2 chars to the left
(only effective if horizontal resolution is greater than 21 chars; OLED is 21 chars wide).

There is a vcd_h_offset variable which adjust the starting position of the left edge, but this one deals with ability to full horizontal field, which can not be adjusted by manipulating MAX/AB7456 parameters.