### PR TITLE
Moved enabling of USB interpt after USB_init, for F1 and F3.

### DIFF
--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -204,8 +204,8 @@ serialPort_t *usbVcpOpen(void)
 #else
     Set_System();
     Set_USBClock();
-    USB_Interrupts_Config();
     USB_Init();
+    USB_Interrupts_Config();
 #endif
 
     s = &vcpPort;


### PR DESCRIPTION
It seems as USB interrupts was enabled before USB was completely initialized, probably the cause for CC3D startup problems in issue #2036 . When moving `USB_Interupts_Config()` after `USB_Init()` CC3D now starts properly. Also tested on BETAFLIGHTF3 and BeeCoreF3 (SPRACINGF3EVO).  F4 and F7 boards are not affected by this change.


 