### PR TITLE
DISPLAYPORT+CMS: Add displayPortProfile

### DIFF
--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -33,6 +33,7 @@
 #include "drivers/vcd.h"
 #include "drivers/light_led.h"
 #include "drivers/flash.h"
+#include "drivers/display.h"
 
 #include "fc/rc_controls.h"
 
@@ -105,7 +106,9 @@
 #define servoProfile(x) (&masterConfig.servoProfile)
 #define customMotorMixer(i) (&masterConfig.customMotorMixer[i])
 #define customServoMixer(i) (&masterConfig.customServoMixer[i])
-
+#define displayPortProfileMsp(x) (&masterConfig.displayPortProfileMsp)
+#define displayPortProfileMax7456(x) (&masterConfig.displayPortProfileMax7456)
+#define displayPortProfileOled(x) (&masterConfig.displayPortProfileOled)
 
 // System-wide
 typedef struct master_s {
@@ -212,6 +215,13 @@ typedef struct master_s {
 #ifdef USE_MAX7456
     vcdProfile_t vcdProfile;
 #endif
+
+# ifdef USE_MSP_DISPLAYPORT
+    displayPortProfile_t displayPortProfileMsp;
+# endif
+# ifdef USE_MAX7456
+    displayPortProfile_t displayPortProfileMax7456;
+# endif
 
 #ifdef USE_SDCARD
     sdcardConfig_t sdcardConfig;

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -43,6 +43,11 @@ typedef struct displayPortVTable_s {
     uint32_t (*txBytesFree)(const displayPort_t *displayPort);
 } displayPortVTable_t;
 
+typedef struct displayPortProfile_s {
+    int8_t colAdjust;
+    int8_t rowAdjust;
+} displayPortProfile_t;
+
 void displayGrab(displayPort_t *instance);
 void displayRelease(displayPort_t *instance);
 void displayReleaseAll(displayPort_t *instance);

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -65,6 +65,7 @@ uint8_t cliMode = 0;
 #include "drivers/system.h"
 #include "drivers/timer.h"
 #include "drivers/vcd.h"
+#include "drivers/display.h"
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
@@ -796,6 +797,14 @@ const clivalue_t valueTable[] = {
     { "vcd_video_system",           VAR_UINT8   | MASTER_VALUE, &vcdProfile()->video_system, .config.minmax = { 0, 2 } },
     { "vcd_h_offset",               VAR_INT8    | MASTER_VALUE, &vcdProfile()->h_offset, .config.minmax = { -32, 31 } },
     { "vcd_v_offset",               VAR_INT8    | MASTER_VALUE, &vcdProfile()->v_offset, .config.minmax = { -15, 16 } },
+#endif
+#ifdef USE_MSP_DISPLAYPORT
+    { "displayport_msp_col_adjust", VAR_INT8    | MASTER_VALUE, &displayPortProfileMsp()->colAdjust, .config.minmax = { -6, 0 } },
+    { "displayport_msp_row_adjust", VAR_INT8    | MASTER_VALUE, &displayPortProfileMsp()->rowAdjust, .config.minmax = { -3, 0 } },
+#endif
+#ifdef OSD
+    { "displayport_max7456_col_adjust", VAR_INT8    | MASTER_VALUE, &displayPortProfileMax7456()->colAdjust, .config.minmax = { -6, 0 } },
+    { "displayport_max7456_row_adjust", VAR_INT8    | MASTER_VALUE, &displayPortProfileMax7456()->rowAdjust, .config.minmax = { -3, 0 } },
 #endif
 };
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -485,6 +485,12 @@ void resetMax7456Config(vcdProfile_t *pVcdProfile)
 }
 #endif
 
+void resetDisplayPortProfile(displayPortProfile_t *pDisplayPortProfile)
+{
+    pDisplayPortProfile->colAdjust = 0;
+    pDisplayPortProfile->rowAdjust = 0;
+}
+
 void resetStatusLedConfig(statusLedConfig_t *statusLedConfig)
 {
     for (int i = 0; i < LED_NUMBER; i++) {
@@ -571,6 +577,13 @@ void createDefaultConfig(master_t *config)
     intFeatureSet(DEFAULT_RX_FEATURE | FEATURE_FAILSAFE , featuresPtr);
 #ifdef DEFAULT_FEATURES
     intFeatureSet(DEFAULT_FEATURES, featuresPtr);
+#endif
+
+#ifdef USE_MSP_DISPLAYPORT
+    resetDisplayPortProfile(&config->displayPortProfileMsp);
+#endif
+#ifdef USE_MAX7456
+    resetDisplayPortProfile(&config->displayPortProfileMax7456);
 #endif
 
 #ifdef USE_MAX7456

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -392,9 +392,9 @@ void init(void)
     if (feature(FEATURE_OSD)) {
 #ifdef USE_MAX7456
         // if there is a max7456 chip for the OSD then use it, otherwise use MSP
-        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
+        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile(), displayPortProfileMax7456());
 #else
-        displayPort_t *osdDisplayPort = displayPortMspInit();
+        displayPort_t *osdDisplayPort = displayPortMspInit(displayPortProfileMax7456());
 #endif
         osdInit(osdDisplayPort);
     }
@@ -438,7 +438,7 @@ void init(void)
     mspSerialInit();
 
 #if defined(USE_MSP_DISPLAYPORT) && defined(CMS)
-    cmsDisplayPortRegister(displayPortMspInit());
+    cmsDisplayPortRegister(displayPortMspInit(displayPortProfileMsp()));
 #endif
 
 #ifdef USE_CLI

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -30,6 +30,7 @@
 #include "drivers/max7456.h"
 
 displayPort_t max7456DisplayPort; // Referenced from osd.c
+displayPortProfile_t *max7456DisplayPortProfile;
 
 extern uint16_t refreshTimeout;
 
@@ -101,8 +102,8 @@ static void resync(displayPort_t *displayPort)
 {
     UNUSED(displayPort);
     max7456RefreshAll();
-    displayPort->rows = max7456GetRowsCount();
-    displayPort->cols = 30;
+    displayPort->rows = max7456GetRowsCount() + max7456DisplayPortProfile->rowAdjust;
+    displayPort->cols = 30 + max7456DisplayPortProfile->colAdjust;
 }
 
 static int heartbeat(displayPort_t *displayPort)
@@ -131,8 +132,9 @@ static const displayPortVTable_t max7456VTable = {
     .txBytesFree = txBytesFree,
 };
 
-displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile)
+displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile, displayPortProfile_t *displayPortProfileToUse)
 {
+    max7456DisplayPortProfile = displayPortProfileToUse;
     displayInit(&max7456DisplayPort, &max7456VTable);
     max7456Init(vcdProfile);
     resync(&max7456DisplayPort);

--- a/src/main/io/displayport_max7456.h
+++ b/src/main/io/displayport_max7456.h
@@ -18,4 +18,4 @@
 #pragma once
 
 struct vcdProfile_s;
-displayPort_t *max7456DisplayPortInit(const struct vcdProfile_s *vcdProfile);
+displayPort_t *max7456DisplayPortInit(const struct vcdProfile_s *vcdProfile, displayPortProfile_t *displayPortProfileToUse);

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -36,6 +36,8 @@
 
 static displayPort_t mspDisplayPort;
 
+static displayPortProfile_t *mspDisplayPortProfile;
+
 static int output(displayPort_t *displayPort, uint8_t cmd, const uint8_t *buf, int len)
 {
     UNUSED(displayPort);
@@ -116,8 +118,8 @@ static bool isTransferInProgress(const displayPort_t *displayPort)
 
 static void resync(displayPort_t *displayPort)
 {
-    displayPort->rows = 13; // XXX Will reflect NTSC/PAL in the future
-    displayPort->cols = 30;
+    displayPort->rows = 13 + mspDisplayPortProfile->rowAdjust; // XXX Will reflect NTSC/PAL in the future
+    displayPort->cols = 30 + mspDisplayPortProfile->colAdjust;
 }
 
 static uint32_t txBytesFree(const displayPort_t *displayPort)
@@ -140,8 +142,9 @@ static const displayPortVTable_t mspDisplayPortVTable = {
     .txBytesFree = txBytesFree
 };
 
-displayPort_t *displayPortMspInit(void)
+displayPort_t *displayPortMspInit(displayPortProfile_t *displayPortProfileToUse)
 {
+    mspDisplayPortProfile = displayPortProfileToUse;
     displayInit(&mspDisplayPort, &mspDisplayPortVTable);
     resync(&mspDisplayPort);
     return &mspDisplayPort;

--- a/src/main/io/displayport_msp.h
+++ b/src/main/io/displayport_msp.h
@@ -18,4 +18,4 @@
 #pragma once
 
 struct displayPort_s;
-struct displayPort_s *displayPortMspInit(void);
+struct displayPort_s *displayPortMspInit(displayPortProfile_t *displayPortProfileToUse);


### PR DESCRIPTION
Many video displays/goggles seem to have problem displaying full 30 characters horizontally, resulting in failure to display 8 character values in the right column.

This is a issue raised by characteristics of each display devices, and it is not a trivial task to provide a true (correct) solution; we need to define an abstraction of display devices, and have mechanism to (virtually) connect the abstraction to the displayPort abstraction.

Instead, this PR provides pragmatic solution; an ability to adjust horizontal width (columns) per displayport. The best approximation we can do.

Two variables for MSP_DISPLAYPORT and MAX7456 displayport are introduced:
`displayport_{msp,max7456}_{row,col}_adjust`