### PR TITLE
Added define for turning on MSP on first UART for custom build

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -452,6 +452,10 @@ void resetSerialConfig(serialConfig_t *serialConfig)
     }
 
     serialConfig->portConfigs[0].functionMask = FUNCTION_MSP;
+#if defined(USE_VCP) && defined(USE_MSP_UART)
+    // This allows MSP connection via USART & VCP so the board can be reconfigured.
+    serialConfig->portConfigs[1].functionMask = FUNCTION_MSP;
+#endif
 }
 
 void resetRcControlsConfig(rcControlsConfig_t *rcControlsConfig)


### PR DESCRIPTION
Added define for turning on MSP on first UART when option set for custom build.

command line for custom firmware: `make CC3D OPTIONS=USE_MSP_UART`