### PR TITLE
Allow remap motor output to PWM6 on KISS FC with DSHOT enabled

### DIFF
--- a/src/main/target/KISSFC/target.h
+++ b/src/main/target/KISSFC/target.h
@@ -27,6 +27,7 @@
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_HARDWARE 6
+#define REMAP_TIM17_DMA
 
 #define LED0                    PB1
 


### PR DESCRIPTION
This PR allows the use of DSHOT on PWM6 when remapping motor output is necessary on defective motor output pads on KISS FC. Both PWM5 and PWM6 can be used to remap motor output with the resource command.

Pad PWM5: `resource MOTOR ?? PA6`
Pad PWM6: `resource MOTOR ?? PA7`

?? is the motor index to be remapped 