### PR TITLE
CC3D_OPBL did not start, spurious interrupts during init. 

### DIFF
--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -218,6 +218,27 @@ void USB_Interrupts_Config(void)
 }
 
 /*******************************************************************************
+ * Function Name  : USB_Interrupts_Disable
+ * Description    : Disables the USB interrupts
+ * Input          : None.
+ * Return         : None.
+ *******************************************************************************/
+void USB_Interrupts_Disable(void)
+{
+    NVIC_InitTypeDef NVIC_InitStructure;
+
+    /* Disable the USB interrupt */
+    NVIC_InitStructure.NVIC_IRQChannel    = USB_LP_CAN1_RX0_IRQn;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
+    NVIC_Init(&NVIC_InitStructure);
+
+    /* Disable the USB Wake-up interrupt */
+    NVIC_InitStructure.NVIC_IRQChannel    = USBWakeUp_IRQn;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
+    NVIC_Init(&NVIC_InitStructure);
+}
+
+/*******************************************************************************
  * Function Name  : USB_Cable_Config
  * Description    : Software Connection/Disconnection of USB Cable
  * Input          : None.

--- a/src/main/vcp/hw_config.h
+++ b/src/main/vcp/hw_config.h
@@ -53,6 +53,7 @@ void Set_USBClock(void);
 void Enter_LowPowerMode(void);
 void Leave_LowPowerMode(void);
 void USB_Interrupts_Config(void);
+void USB_Interrupts_Disable(void);
 void USB_Cable_Config(FunctionalState NewState);
 void Get_SerialNum(void);
 uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength);  // HJI

--- a/src/main/vcp/usb_prop.c
+++ b/src/main/vcp/usb_prop.c
@@ -87,6 +87,8 @@ ONE_DESCRIPTOR String_Descriptor[4] = { { (uint8_t*)Virtual_Com_Port_StringLangI
  *******************************************************************************/
 void Virtual_Com_Port_init(void)
 {
+    /* Make absolutly sure interrupts are disabled. */
+    USB_Interrupts_Disable();
 
     /* Update the serial number string descriptor with the data from the unique
      ID*/


### PR DESCRIPTION
Made sure NVIC is disabled early. Theory is that the OP Boot loader leaves interrupts enabled when handing over execution to BF. There was no code to reset or disable it explicitly, relied entirely on hardware reset to do that. Not true when OP BootLoader is run prior to BF startup.
Second attempt tp fix issue #2036 .  Tested with targets CC3D and CC3D_OPBL.
