### PR TITLE
USB VCP Interrupt fix only for STM32F10X, problem on DOGE fixed.

### DIFF
--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -217,6 +217,8 @@ void USB_Interrupts_Config(void)
     NVIC_Init(&NVIC_InitStructure);
 }
 
+#ifdef STM32F10X
+
 /*******************************************************************************
  * Function Name  : USB_Interrupts_Disable
  * Description    : Disables the USB interrupts
@@ -237,6 +239,7 @@ void USB_Interrupts_Disable(void)
     NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
     NVIC_Init(&NVIC_InitStructure);
 }
+#endif
 
 /*******************************************************************************
  * Function Name  : USB_Cable_Config

--- a/src/main/vcp/hw_config.h
+++ b/src/main/vcp/hw_config.h
@@ -53,7 +53,9 @@ void Set_USBClock(void);
 void Enter_LowPowerMode(void);
 void Leave_LowPowerMode(void);
 void USB_Interrupts_Config(void);
+#ifdef STM32F10X
 void USB_Interrupts_Disable(void);
+#endif
 void USB_Cable_Config(FunctionalState NewState);
 void Get_SerialNum(void);
 uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength);  // HJI

--- a/src/main/vcp/usb_prop.c
+++ b/src/main/vcp/usb_prop.c
@@ -87,8 +87,10 @@ ONE_DESCRIPTOR String_Descriptor[4] = { { (uint8_t*)Virtual_Com_Port_StringLangI
  *******************************************************************************/
 void Virtual_Com_Port_init(void)
 {
+#ifdef STM32F10X
     /* Make absolutly sure interrupts are disabled. */
     USB_Interrupts_Disable();
+#endif
 
     /* Update the serial number string descriptor with the data from the unique
      ID*/


### PR DESCRIPTION
Issue #2157 solved. 
Tested by me on CC3D, CC3D_OPBL, SPRACINGF3 (BeeCoreF3) and BETAFLIGHTF3. Test on DOGE by issuer @brycedjohnson
