### PR TITLE
smartport: removed disabling on timeout

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -64,8 +64,7 @@ enum
 {
     SPSTATE_UNINITIALIZED,
     SPSTATE_INITIALIZED,
-    SPSTATE_WORKING,
-    SPSTATE_TIMEDOUT
+    SPSTATE_WORKING
 };
 
 enum
@@ -145,7 +144,6 @@ const uint16_t frSkyDataIdTable[] = {
 #define SMARTPORT_BAUD 57600
 #define SMARTPORT_UART_MODE MODE_RXTX
 #define SMARTPORT_SERVICE_TIMEOUT_MS 1 // max allowed time to find a value to send
-#define SMARTPORT_NOT_CONNECTED_TIMEOUT_MS 7000
 
 static serialPort_t *smartPortSerialPort = NULL; // The 'SmartPort'(tm) Port.
 static serialPortConfig_t *portConfig;
@@ -352,15 +350,9 @@ bool canSendSmartPortTelemetry(void)
     return smartPortSerialPort && (smartPortState == SPSTATE_INITIALIZED || smartPortState == SPSTATE_WORKING);
 }
 
-bool isSmartPortTimedOut(void)
-{
-    return smartPortState >= SPSTATE_TIMEDOUT;
-}
-
 void checkSmartPortTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(smartPortPortSharing);
-
+    bool newTelemetryEnabledValue = (smartPortPortSharing == PORTSHARING_NOT_SHARED);
     if (newTelemetryEnabledValue == smartPortTelemetryEnabled) {
         return;
     }
@@ -576,14 +568,6 @@ void handleSmartPortTelemetry(void)
     while (serialRxBytesWaiting(smartPortSerialPort) > 0) {
         uint8_t c = serialRead(smartPortSerialPort);
         smartPortDataReceive(c);
-    }
-
-    uint32_t now = millis();
-
-    // if timed out, reconfigure the UART back to normal so the GUI or CLI works
-    if ((now - smartPortLastRequestTime) > SMARTPORT_NOT_CONNECTED_TIMEOUT_MS) {
-        smartPortState = SPSTATE_TIMEDOUT;
-        return;
     }
 
     if(smartPortFrameReceived) {

--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -15,5 +15,3 @@ void checkSmartPortTelemetryState(void);
 void configureSmartPortTelemetryPort(void);
 void freeSmartPortTelemetryPort(void);
 
-bool isSmartPortTimedOut(void);
-


### PR DESCRIPTION
In the current state, smart port will disable itself until the next power cycle if no SPORT receiver can be found. This means that if the FC does not power the receiver, connecting to USB, and then plugin the battery will cause smart port to be disabled. There is not real reason for behaving this way, as smart port cannot share the serial port with anything else.

To avoid conflicts, smart port will now refuse to start if any other serial protocol is configured to share the same port.