### PR TITLE
BFF3 correct Spektrum sat bind pin.

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.h
+++ b/src/main/target/BETAFLIGHTF3/target.h
@@ -126,8 +126,7 @@
 #define DEFAULT_FEATURES        (FEATURE_BLACKBOX |  FEATURE_CURRENT_METER)
 
 #define SPEKTRUM_BIND
-// USART3,
-#define BIND_PIN                PB11
+#define BIND_PIN                UART2_RX_PIN
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 


### PR DESCRIPTION
BFF3 has a dedicated solder pad for spektrum satellites on UART2 Rx, labled "DSM2" for some reason.  
Then it is kind of logical to have the Spektrum Bind pin definition there as well, not on UART3 Rx.
Tested with Dx18g1 and a LemonRx Diversity sat. OK.
 