### PR TITLE
Add start channel for CHANNEL_FORWARDING

### DIFF
--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -69,6 +69,7 @@
 #define servoConfig(x) (&masterConfig.servoConfig)
 #define servoMixerConfig(x) (&masterConfig.servoMixerConfig)
 #define gimbalConfig(x) (&masterConfig.gimbalConfig)
+#define channelForwardingConfig(x) (&masterConfig.channelForwardingConfig)
 #define boardAlignment(x) (&masterConfig.boardAlignment)
 #define imuConfig(x) (&masterConfig.imuConfig)
 #define gyroConfig(x) (&masterConfig.gyroConfig)
@@ -131,6 +132,8 @@ typedef struct master_s {
     servoProfile_t servoProfile;
     // gimbal-related configuration
     gimbalConfig_t gimbalConfig;
+    // Channel forwarding start channel
+    channelForwardingConfig_t channelForwardingConfig;
 #endif
 
     boardAlignment_t boardAlignment;

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -649,6 +649,7 @@ const clivalue_t valueTable[] = {
     { "servo_lowpass_enable",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, &servoMixerConfig()->servo_lowpass_enable, .config.lookup = { TABLE_OFF_ON } },
     { "servo_pwm_rate",             VAR_UINT16 | MASTER_VALUE,  &servoConfig()->servoPwmRate, .config.minmax = { 50,  498 } },
     { "gimbal_mode",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &gimbalConfig()->mode, .config.lookup = { TABLE_GIMBAL_MODE } },
+    { "channel_forwarding_start",    VAR_UINT8  | MASTER_VALUE, &channelForwardingConfig()->startChannel, .config.minmax = { AUX1, MAX_SUPPORTED_RC_CHANNEL_COUNT } },
 #endif
 
     { "rc_rate",                    VAR_UINT8  | PROFILE_RATE_VALUE, &masterConfig.profile[0].controlRateProfile[0].rcRate8, .config.minmax = { 0,  255 } },

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -800,6 +800,9 @@ void createDefaultConfig(master_t *config)
 
     // gimbal
     config->gimbalConfig.mode = GIMBAL_MODE_NORMAL;
+
+    // Channel forwarding;
+    config->channelForwardingConfig.startChannel = AUX1;
 #endif
 
 #ifdef GPS
@@ -918,9 +921,8 @@ void activateConfig(void)
     );
 
 #ifdef USE_SERVOS
-    servoUseConfigs(&masterConfig.servoMixerConfig, masterConfig.servoProfile.servoConf, &masterConfig.gimbalConfig);
+    servoUseConfigs(&masterConfig.servoMixerConfig, masterConfig.servoProfile.servoConf, &masterConfig.gimbalConfig, &masterConfig.channelForwardingConfig);
 #endif
-
 
     imuConfigure(
         &masterConfig.imuConfig,

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -57,6 +57,7 @@ static gimbalConfig_t *gimbalConfig;
 int16_t servo[MAX_SUPPORTED_SERVOS];
 static int useServo;
 static servoParam_t *servoConf;
+static channelForwardingConfig_t *channelForwardingConfig;
 
 
 #define COUNT_SERVO_RULES(rules) (sizeof(rules) / sizeof(servoMixer_t))
@@ -142,11 +143,12 @@ const mixerRules_t servoMixers[] = {
 
 static servoMixer_t *customServoMixers;
 
-void servoUseConfigs(servoMixerConfig_t *servoMixerConfigToUse, servoParam_t *servoParamsToUse, struct gimbalConfig_s *gimbalConfigToUse)
+void servoUseConfigs(servoMixerConfig_t *servoMixerConfigToUse, servoParam_t *servoParamsToUse, struct gimbalConfig_s *gimbalConfigToUse, struct channelForwardingConfig_s *channelForwardingConfigToUse)
 {
     servoMixerConfig = servoMixerConfigToUse;
     servoConf = servoParamsToUse;
     gimbalConfig = gimbalConfigToUse;
+    channelForwardingConfig = channelForwardingConfigToUse;
 }
 
 int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
@@ -250,7 +252,7 @@ void servoMixerLoadMix(int index, servoMixer_t *customServoMixers)
 STATIC_UNIT_TESTED void forwardAuxChannelsToServos(uint8_t firstServoIndex)
 {
     // start forwarding from this channel
-    uint8_t channelOffset = AUX1;
+    uint8_t channelOffset = channelForwardingConfig->startChannel;
 
     uint8_t servoOffset;
     for (servoOffset = 0; servoOffset < MAX_AUX_CHANNEL_COUNT && channelOffset < MAX_SUPPORTED_RC_CHANNEL_COUNT; servoOffset++) {

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -114,6 +114,10 @@ typedef struct servoProfile_s {
     servoParam_t servoConf[MAX_SUPPORTED_SERVOS];
 } servoProfile_t;
 
+typedef struct channelForwardingConfig_s {
+    uint8_t startChannel;
+} channelForwardingConfig_t;
+
 extern int16_t servo[MAX_SUPPORTED_SERVOS];
 
 void servoTable(void);
@@ -123,7 +127,7 @@ void filterServos(void);
 
 void servoMixerInit(servoMixer_t *customServoMixers);
 struct gimbalConfig_s;
-void servoUseConfigs(servoMixerConfig_t *servoConfigToUse, servoParam_t *servoParamsToUse, struct gimbalConfig_s *gimbalConfigToUse);
+void servoUseConfigs(servoMixerConfig_t *servoConfigToUse, servoParam_t *servoParamsToUse, struct gimbalConfig_s *gimbalConfigToUse, struct channelForwardingConfig_s *channelForwardingConfigToUse);
 void servoMixerLoadMix(int index, servoMixer_t *customServoMixers);
 void loadCustomServoMixer(void);
 void servoConfigureOutput(void);


### PR DESCRIPTION
PR status: Ready to merge.

The CHANNEL_FORWARDING feature is pretty much useless because it starts mapping from AUX1, effectively killing all AUX channels. In other words, it is extremely difficult, if not impossible, to set up modes based on AUX channels if CHANNEL_FORWARDING feature is turned on.

This PR adds new cli variable `channel_forwarding_start` that specify the start of the mapped channel. It defaults to AUX1 (4) to keep backward compatibility with current CHANNEL_FORWARDING use cases.

