### PR TITLE
Adjusted 'amperageLatest' data type to be 'int32_t' to be consistent with 'amperage'.

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -61,7 +61,7 @@ uint16_t vbat = 0;                  // battery voltage in 0.1V steps (filtered)
 uint16_t vbatLatest = 0;            // most recent unsmoothed value
 
 int32_t amperage = 0;               // amperage read by current sensor in centiampere (1/100th A)
-uint16_t amperageLatest = 0;        // most recent value
+int32_t amperageLatest = 0;        // most recent value
 
 int32_t mAhDrawn = 0;               // milliampere hours drawn from the battery since start
 

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -74,7 +74,7 @@ extern uint16_t vbatRaw;
 extern uint16_t vbatLatest;
 extern uint8_t batteryCellCount;
 extern uint16_t batteryWarningVoltage;
-extern uint16_t amperageLatest;
+extern int32_t amperageLatest;
 extern int32_t amperage;
 extern int32_t mAhDrawn;
 


### PR DESCRIPTION
Fixes #2190.

@GaryKeeble: We'll also have to switch `amperageLatest` in `blackbox.c` to `SIGNED`, but I'll leave it to you when you want to do this, since it will change the blackbox format. (n.b. The meaning of the `amperageLatest` value already changed from 'raw ADC reading' to 'centiamp value` with the introduction of ESC feedback for current sensing.)