### PR TITLE
CMS Revert ledstrip color function

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1150,7 +1150,7 @@ static void printRxFail(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxCo
     for (uint32_t channel = 0; channel < MAX_SUPPORTED_RC_CHANNEL_COUNT; channel++) {
         const rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &rxConfig->failsafe_channel_configurations[channel];
         const rxFailsafeChannelConfiguration_t *channelFailsafeConfigurationDefault;
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultRxConfig) {
             channelFailsafeConfigurationDefault = &defaultRxConfig->failsafe_channel_configurations[channel];
             equalsDefault = channelFailsafeConfiguration->mode == channelFailsafeConfigurationDefault->mode
@@ -1273,7 +1273,7 @@ static void printAux(uint8_t dumpMask, const modeActivationProfile_t *modeActiva
     // print out aux channel settings
     for (uint32_t i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
         const modeActivationCondition_t *mac = &modeActivationProfile->modeActivationConditions[i];
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultModeActivationProfile) {
             const modeActivationCondition_t *macDefault = &defaultModeActivationProfile->modeActivationConditions[i];
             equalsDefault = mac->modeId == macDefault->modeId
@@ -1345,7 +1345,7 @@ static void printSerial(uint8_t dumpMask, const serialConfig_t *serialConfig, co
         if (!serialIsPortAvailable(serialConfig->portConfigs[i].identifier)) {
             continue;
         };
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (serialConfigDefault) {
             equalsDefault = serialConfig->portConfigs[i].identifier == serialConfigDefault->portConfigs[i].identifier
                 && serialConfig->portConfigs[i].functionMask == serialConfigDefault->portConfigs[i].functionMask
@@ -1540,7 +1540,7 @@ static void printAdjustmentRange(uint8_t dumpMask, const adjustmentProfile_t *ad
     // print out adjustment ranges channel settings
     for (uint32_t i = 0; i < MAX_ADJUSTMENT_RANGE_COUNT; i++) {
         const adjustmentRange_t *ar = &adjustmentProfile->adjustmentRanges[i];
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultAdjustmentProfile) {
             const adjustmentRange_t *arDefault = &defaultAdjustmentProfile->adjustmentRanges[i];
             equalsDefault = ar->auxChannelIndex == arDefault->auxChannelIndex
@@ -1646,7 +1646,7 @@ static void printMotorMix(uint8_t dumpMask, const motorMixer_t *customMotorMixer
         const float roll = customMotorMixer[i].roll;
         const float pitch = customMotorMixer[i].pitch;
         const float yaw = customMotorMixer[i].yaw;
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultCustomMotorMixer) {
             const float thrDefault = defaultCustomMotorMixer[i].throttle;
             const float rollDefault = defaultCustomMotorMixer[i].roll;
@@ -1744,7 +1744,7 @@ static void printRxRange(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxC
     const char *format = "rxrange %u %u %u\r\n";
     for (uint32_t i = 0; i < NON_AUX_CHANNEL_COUNT; i++) {
         const rxChannelRangeConfiguration_t *channelRangeConfiguration = &rxConfig->channelRanges[i];
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultRxConfig) {
             const rxChannelRangeConfiguration_t *channelRangeConfigurationDefault = &defaultRxConfig->channelRanges[i];
             equalsDefault = channelRangeConfiguration->min == channelRangeConfigurationDefault->min
@@ -1814,7 +1814,7 @@ static void printLed(uint8_t dumpMask, const ledConfig_t *ledConfigs, const ledC
     for (uint32_t i = 0; i < LED_MAX_STRIP_LENGTH; i++) {
         ledConfig_t ledConfig = ledConfigs[i];
         generateLedConfig(&ledConfig, ledConfigBuffer, sizeof(ledConfigBuffer));
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultLedConfigs) {
             ledConfig_t ledConfigDefault = defaultLedConfigs[i];
             equalsDefault = ledConfig == ledConfigDefault;
@@ -1851,7 +1851,7 @@ static void printColor(uint8_t dumpMask, const hsvColor_t *colors, const hsvColo
     const char *format = "color %u %d,%u,%u\r\n";
     for (uint32_t i = 0; i < LED_CONFIGURABLE_COLOR_COUNT; i++) {
         const hsvColor_t *color = &colors[i];
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultColors) {
             const hsvColor_t *colorDefault = &defaultColors[i];
             equalsDefault = color->h == colorDefault->h
@@ -1890,7 +1890,7 @@ static void printModeColor(uint8_t dumpMask, const ledStripConfig_t *ledStripCon
     for (uint32_t i = 0; i < LED_MODE_COUNT; i++) {
         for (uint32_t j = 0; j < LED_DIRECTION_COUNT; j++) {
             int colorIndex = ledStripConfig->modeColors[i].color[j];
-            bool equalsDefault = true;
+            bool equalsDefault = false;
             if (defaultLedStripConfig) {
                 int colorIndexDefault = defaultLedStripConfig->modeColors[i].color[j];
                 equalsDefault = colorIndex == colorIndexDefault;
@@ -1902,7 +1902,7 @@ static void printModeColor(uint8_t dumpMask, const ledStripConfig_t *ledStripCon
 
     for (uint32_t j = 0; j < LED_SPECIAL_COLOR_COUNT; j++) {
         const int colorIndex = ledStripConfig->specialColors.color[j];
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultLedStripConfig) {
             const int colorIndexDefault = defaultLedStripConfig->specialColors.color[j];
             equalsDefault = colorIndex == colorIndexDefault;
@@ -1912,7 +1912,7 @@ static void printModeColor(uint8_t dumpMask, const ledStripConfig_t *ledStripCon
     }
 
     const int ledStripAuxChannel = ledStripConfig->ledstrip_aux_channel;
-    bool equalsDefault = true;
+    bool equalsDefault = false;
     if (defaultLedStripConfig) {
         const int ledStripAuxChannelDefault = defaultLedStripConfig->ledstrip_aux_channel;
         equalsDefault = ledStripAuxChannel == ledStripAuxChannelDefault;
@@ -1960,7 +1960,7 @@ static void printServo(uint8_t dumpMask, servoProfile_t *defaultServoProfile)
     const char *format = "servo %u %d %d %d %d %d %d %d\r\n";
     for (uint32_t i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
         const servoParam_t *servoConf = &servoProfile()->servoConf[i];
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultServoProfile) {
             const servoParam_t *servoConfDefault = &defaultServoProfile->servoConf[i];
             equalsDefault = servoConf->min == servoConfDefault->min
@@ -2080,7 +2080,7 @@ static void printServoMix(uint8_t dumpMask, const master_t *defaultConfig)
             break;
         }
 
-        bool equalsDefault = true;
+        bool equalsDefault = false;
         if (defaultConfig) {
             servoMixer_t customServoMixerDefault = defaultConfig->customServoMixer[i];
             equalsDefault = customServoMixer.targetChannel == customServoMixerDefault.targetChannel
@@ -2428,7 +2428,7 @@ static void printVtx(uint8_t dumpMask, const master_t *defaultConfig)
 {
     // print out vtx channel settings
     const char *format = "vtx %u %u %u %u %u %u\r\n";
-    bool equalsDefault = true;
+    bool equalsDefault = false;
     for (uint32_t i = 0; i < MAX_CHANNEL_ACTIVATION_CONDITION_COUNT; i++) {
         const vtxChannelActivationCondition_t *cac = &masterConfig.vtxChannelActivationConditions[i];
         if (defaultConfig) {
@@ -2702,7 +2702,7 @@ static void cliBeeper(char *cmdline)
 
 static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfig_t *defaultRxConfig)
 {
-    bool equalsDefault = true;
+    bool equalsDefault = false;
     char buf[16];
     char bufDefault[16];
     uint32_t i;

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -407,6 +407,9 @@ void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
     telemetryConfig->frsky_vfas_cell_voltage = 0;
     telemetryConfig->hottAlarmSoundInterval = 5;
     telemetryConfig->pidValuesAsTelemetry = 0;
+#ifdef TELEMETRY_IBUS
+    telemetryConfig->report_cell_voltage = false;
+#endif
 }
 #endif
 

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -34,6 +34,7 @@
 #define STM_FAST_TARGET
 #define I2C3_OVERCLOCK true
 #define I2C4_OVERCLOCK true
+#define TELEMETRY_IBUS
 #endif
 
 /****************************
@@ -43,6 +44,7 @@
 #define STM_FAST_TARGET
 #define USE_DSHOT
 #define I2C3_OVERCLOCK true
+#define TELEMETRY_IBUS
 #endif
 
 #ifdef STM32F3
@@ -85,7 +87,6 @@
 #define TELEMETRY
 #define TELEMETRY_FRSKY
 #define TELEMETRY_HOTT
-#define TELEMETRY_IBUS
 #define TELEMETRY_LTM
 #define TELEMETRY_SMARTPORT
 #define USE_SERVOS
@@ -100,7 +101,6 @@
 #define TELEMETRY_SRXL
 #define TELEMETRY_JETIEXBUS
 #define TELEMETRY_MAVLINK
-#define TELEMETRY_IBUS
 #define USE_RX_MSP
 #define USE_SERIALRX_JETIEXBUS
 #define VTX_COMMON

--- a/src/main/telemetry/ibus.c
+++ b/src/main/telemetry/ibus.c
@@ -167,7 +167,7 @@ PG_RESET_TEMPLATE(ibusTelemetryConfig_t, ibusTelemetryConfig,
                  );
 */
 
-#define IBUS_TASK_PERIOD_US (500)
+#define IBUS_TASK_PERIOD_US (1000)
 
 #define IBUS_UART_MODE     (MODE_RXTX)
 #define IBUS_BAUDRATE      (115200)

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -137,6 +137,9 @@ void telemetryCheckState(void)
 #ifdef TELEMETRY_SRXL
     checkSrxlTelemetryState();
 #endif
+#ifdef TELEMETRY_IBUS
+    checkIbusTelemetryState();
+#endif
 }
 
 void telemetryProcess(uint32_t currentTime, rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
@@ -169,6 +172,9 @@ void telemetryProcess(uint32_t currentTime, rxConfig_t *rxConfig, uint16_t deadb
 #endif
 #ifdef TELEMETRY_SRXL
     handleSrxlTelemetry(currentTime);
+#endif
+#ifdef TELEMETRY_IBUS
+    handleIbusTelemetry();
 #endif
 }
 


### PR DESCRIPTION
PR status: Testing

The ability to change LED strip color with CMS was dropped due to on going PG migration work on LED strip side. This PR restores the function.