### PR TITLE
Hide BFOSD when OSDSW is active

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -377,6 +377,10 @@ void osdDrawElements(void)
 {
     displayClearScreen(osdDisplayPort);
 
+    /* Hide OSD when OSDSW mode is active */
+    if (IS_RC_MODE_ACTIVE(BOXOSD))
+      return;
+
 #if 0
     if (currentElement)
         osdDrawElementPositioningHelp();


### PR DESCRIPTION
Toggles viability of internal/BFOSD with OSDSW mode.
BY default OSD is visible and activating OSDSW mode hides it (this is to preserve existing functionality, i.e. not configuring it makes the OSD active all the time)