### PR TITLE
Add PID and rate profile and battery warn to OSD

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -804,6 +804,8 @@ static const clivalue_t valueTable[] = {
     { "osd_pid_pitch_pos",          VAR_UINT16  | MASTER_VALUE, &osdProfile()->item_pos[OSD_PITCH_PIDS], .config.minmax = { 0, OSD_POS_MAX } },
     { "osd_pid_yaw_pos",            VAR_UINT16  | MASTER_VALUE, &osdProfile()->item_pos[OSD_YAW_PIDS], .config.minmax = { 0, OSD_POS_MAX } },
     { "osd_power_pos",              VAR_UINT16  | MASTER_VALUE, &osdProfile()->item_pos[OSD_POWER], .config.minmax = { 0, OSD_POS_MAX } },
+    { "osd_pidrate_profile_pos",    VAR_UINT16  | MASTER_VALUE, &osdProfile()->item_pos[OSD_PIDRATE_PROFILE], .config.minmax = { 0, OSD_POS_MAX } },
+    { "osd_battery_warning_pos",    VAR_UINT16  | MASTER_VALUE, &osdProfile()->item_pos[OSD_MAIN_BATT_WARNING], .config.minmax = { 0, OSD_POS_MAX } },
 #endif
 #ifdef USE_MAX7456
     { "vcd_video_system",           VAR_UINT8   | MASTER_VALUE, &vcdProfile()->video_system, .config.minmax = { 0, 2 } },

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -366,6 +366,23 @@ static void osdDrawSingleElement(uint8_t item)
             break;
         }
 
+        case OSD_PIDRATE_PROFILE:
+        {
+            uint8_t profileIndex = masterConfig.current_profile_index;
+            uint8_t rateProfileIndex = masterConfig.profile[profileIndex].activeRateProfile;
+            sprintf(buff, "%d-%d", profileIndex + 1, rateProfileIndex + 1);
+            break;
+        }
+
+        case OSD_MAIN_BATT_WARNING:
+        {
+            if (getVbat() > (batteryWarningVoltage - 1))
+              return;
+
+            sprintf(buff, "LOW VOLTAGE");
+            break;
+        }
+
         default:
             return;
     }
@@ -409,6 +426,8 @@ void osdDrawElements(void)
     osdDrawSingleElement(OSD_PITCH_PIDS);
     osdDrawSingleElement(OSD_YAW_PIDS);
     osdDrawSingleElement(OSD_POWER);
+    osdDrawSingleElement(OSD_PIDRATE_PROFILE);
+    osdDrawSingleElement(OSD_MAIN_BATT_WARNING);
 
 #ifdef GPS
 #ifdef CMS
@@ -444,6 +463,8 @@ void osdResetConfig(osd_profile_t *osdProfile)
     osdProfile->item_pos[OSD_PITCH_PIDS] = OSD_POS(2, 11);
     osdProfile->item_pos[OSD_YAW_PIDS] = OSD_POS(2, 12);
     osdProfile->item_pos[OSD_POWER] = OSD_POS(15, 1);
+    osdProfile->item_pos[OSD_PIDRATE_PROFILE] = OSD_POS(2, 13);
+    osdProfile->item_pos[OSD_MAIN_BATT_WARNING] = OSD_POS(8, 6);
 
     osdProfile->rssi_alarm = 20;
     osdProfile->cap_alarm = 2200;
@@ -502,10 +523,13 @@ void osdUpdateAlarms(void)
     else
         pOsdProfile->item_pos[OSD_RSSI_VALUE] &= ~BLINK_FLAG;
 
-    if (getVbat() <= (batteryWarningVoltage - 1))
+    if (getVbat() <= (batteryWarningVoltage - 1)) {
         pOsdProfile->item_pos[OSD_MAIN_BATT_VOLTAGE] |= BLINK_FLAG;
-    else
+        pOsdProfile->item_pos[OSD_MAIN_BATT_WARNING] |= BLINK_FLAG;
+    } else {
         pOsdProfile->item_pos[OSD_MAIN_BATT_VOLTAGE] &= ~BLINK_FLAG;
+        pOsdProfile->item_pos[OSD_MAIN_BATT_WARNING] &= ~BLINK_FLAG;
+    }
 
     if (STATE(GPS_FIX) == 0)
         pOsdProfile->item_pos[OSD_GPS_SATS] |= BLINK_FLAG;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -47,6 +47,8 @@ typedef enum {
     OSD_PITCH_PIDS,
     OSD_YAW_PIDS,
     OSD_POWER,
+    OSD_PIDRATE_PROFILE,
+    OSD_MAIN_BATT_WARNING,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Adds elements to:
- display the current PID and rate profiles (in format `P-R`)
- flash a textual warning when battery voltage is low