### PR TITLE
[OSD] Add VTX channel display item for VTX_COMMON devices

### DIFF
--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -23,9 +23,11 @@
 #include <string.h>
 
 #include "platform.h"
-#include "build/debug.h"
-
 #if defined(VTX_COMMON)
+
+#include "common/typeconversion.h"
+
+#include "build/debug.h"
 
 #include "vtx_common.h"
 
@@ -65,7 +67,7 @@ void vtxCommonSetBandChan(uint8_t band, uint8_t chan)
     if (!vtxDevice)
         return;
 
-    if ((band > vtxDevice->numBand)|| (chan > vtxDevice->numChan))
+    if ((band > vtxDevice->devParam.numBand)|| (chan > vtxDevice->devParam.numChan))
         return;
     
     if (vtxDevice->vTable->setBandChan)
@@ -78,7 +80,7 @@ void vtxCommonSetPowerByIndex(uint8_t index)
     if (!vtxDevice)
         return;
 
-    if (index > vtxDevice->numPower)
+    if (index > vtxDevice->devParam.numPower)
         return;
     
     if (vtxDevice->vTable->setPowerByIndex)
@@ -126,5 +128,44 @@ bool vtxCommonGetPitmode(uint8_t *pOnoff)
         return vtxDevice->vTable->getPitmode(pOnoff);
     else
         return false;
+}
+
+const vtxDeviceParameter_t *vtxCommonGetDeviceParameter(void)
+{
+    if (!vtxDevice)
+        return NULL;
+
+    return(&vtxDevice->devParam);
+}
+
+char *vtxCommonGetBandChanString(void)
+{
+    static char strbuf[3];
+    uint8_t curBand;
+    uint8_t curChan;
+
+    if (vtxDevice && vtxCommonGetBandChan(&curBand, &curChan)) {
+        strbuf[0] = vtxDevice->devParam.bandLetters[curBand];
+        strbuf[1] = vtxDevice->devParam.chanNames[curChan][0];
+        strbuf[2] = 0;
+        return strbuf;
+    }
+
+    return NULL;
+}
+
+// XXX Some device operating in non-band/chan mode requires special handling.
+char *vtxCommonGetFreqString(void)
+{
+    static char strbuf[5];
+    uint8_t curBand;
+    uint8_t curChan;
+
+    if (vtxDevice && vtxCommonGetBandChan(&curBand, &curChan)) {
+        itoa(vtxDevice->devParam.freqTable[(curBand - 1) * vtxDevice->devParam.numBand + curChan], strbuf, 10);
+        return strbuf;
+    }
+
+    return NULL;
 }
 #endif

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -26,25 +26,29 @@ typedef enum {
     VTXDEV_UNKNOWN    = 0xFF,
 } vtxDevType_e;
 
-struct vtxVTable_s;
-
-typedef struct vtxDevice_s {
-    const struct vtxVTable_s *vTable;
+typedef struct vtxDeviceParameter_s {
+    uint8_t deviceType;
 
     uint8_t numBand;
     uint8_t numChan;
     uint8_t numPower;
 
     uint16_t *freqTable;  // Array of [numBand][numChan]
-    char **bandNames;    // char *bandNames[numBand]
-    char **chanNames;    // char *chanNames[numChan]
-    char **powerNames;   // char *powerNames[numPower]
+    char **bandNames;    // char *bandNames[numBand + 1]
+    char *bandLetters;   // char bandLetters[numBand + 1]
+    char **chanNames;    // char *chanNames[numChan + 1]
+    char **powerNames;   // char *powerNames[numPower + 1]
+} vtxDeviceParameter_t;
 
+struct vtxVTable_s;
+
+typedef struct vtxDevice_s {
+    const struct vtxVTable_s *vTable;
+    const vtxDeviceParameter_t devParam;
     uint8_t curBand;
     uint8_t curChan;
     uint8_t curPowerIndex;
     uint8_t curPitState; // 0 = non-PIT, 1 = PIT
-
 } vtxDevice_t;
 
 // {set,get}BandChan: band and chan are 1 origin
@@ -63,6 +67,8 @@ typedef struct vtxVTable_s {
     bool (*getBandChan)(uint8_t *pBand, uint8_t *pChan);
     bool (*getPowerIndex)(uint8_t *pIndex);
     bool (*getPitmode)(uint8_t *pOnoff);
+
+    vtxDeviceParameter_t (*getDeviceParameter)(void);
 } vtxVTable_t;
 
 // 3.1.0
@@ -82,3 +88,8 @@ void vtxCommonSetPitmode(uint8_t onoff);
 bool vtxCommonGetBandChan(uint8_t *pBand, uint8_t *pChan);
 bool vtxCommonGetPowerIndex(uint8_t *pIndex);
 bool vtxCommonGetPitmode(uint8_t *pOnoff);
+
+// API 1.1
+const vtxDeviceParameter_t *vtxCommonGetDeviceParameter(void);
+char *vtxCommonGetBandChanString(void);
+char *vtxCommonGetFreqString(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -40,8 +40,14 @@
 #include "drivers/max7456_symbols.h"
 #include "drivers/display.h"
 #include "drivers/system.h"
+
+// XXX This will eventurally be gone.
 #ifdef USE_RTC6705
 #include "drivers/vtx_soft_spi_rtc6705.h"
+#endif
+
+#ifdef VTX_COMMON
+#include "drivers/vtx_common.h"
 #endif
 
 #include "cms/cms.h"
@@ -50,9 +56,6 @@
 
 #include "io/flashfs.h"
 #include "io/osd.h"
-
-#include "io/vtx.h"
-
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
@@ -103,7 +106,6 @@ uint16_t refreshTimeout = 0;
 static uint8_t armState;
 
 static displayPort_t *osdDisplayPort;
-
 
 #define AH_MAX_PITCH 200 // Specify maximum AHI pitch value displayed. Default 200 = 20.0 degrees
 #define AH_MAX_ROLL 400  // Specify maximum AHI roll value displayed. Default 400 = 40.0 degrees
@@ -258,12 +260,34 @@ static void osdDrawSingleElement(uint8_t item)
         }
 
 #ifdef USE_RTC6705
+
+#endif
+
+// This will eventually be gone.
+#ifdef USE_RTC6705
         case OSD_VTX_CHANNEL:
         {
             sprintf(buff, "CH:%d", current_vtx_channel % CHANNELS_PER_BAND + 1);
             break;
         }
-#endif // VTX
+#endif // USE_RTC6705
+
+#ifdef VTX_COMMON
+        case OSD_VTX_CHANNEL:
+        {
+            // Some devices may be operating in non-band/chan mode,
+            // in which case current operating frequency is displayed.
+            char *str;
+            if ((str = vtxCommonGetBandChanString()) != NULL) {
+                sprintf(buff, "CH:%s", vtxCommonGetBandChanString());
+            } else if ((str = vtxCommonGetBandChanString()) != NULL) {
+                sprintf(buff, "%s", vtxCommonGetBandChanString());
+            } else {
+                sprintf(buff, "CH:--");
+            }
+            break;
+        }
+#endif // VTX_COMMON
 
         case OSD_CROSSHAIRS:
             elemPosX = 14 - 1; // Offset for 1 char to the left

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -279,11 +279,11 @@ static void osdDrawSingleElement(uint8_t item)
             // in which case current operating frequency is displayed.
             char *str;
             if ((str = vtxCommonGetBandChanString()) != NULL) {
-                sprintf(buff, "CH:%s", vtxCommonGetBandChanString());
-            } else if ((str = vtxCommonGetBandChanString()) != NULL) {
-                sprintf(buff, "%s", vtxCommonGetBandChanString());
+                sprintf(buff, "CH:%s", str);
+            } else if ((str = vtxCommonGetFreqString()) != NULL) {
+                sprintf(buff, "%s", str);
             } else {
-                sprintf(buff, "CH:--");
+                memcpy(buff, "CH:--", 6);
             }
             break;
         }

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -81,12 +81,15 @@ static const char * const saPowerNames[] = {
 static vtxVTable_t saVTable;    // Forward
 static vtxDevice_t vtxSmartAudio = {
     .vTable = &saVTable,
-    .numBand = 5,
-    .numChan = 8,
-    .numPower = 4,
-    .bandNames = (char **)vtx58BandNames,
-    .chanNames = (char **)vtx58ChannelNames,
-    .powerNames = (char **)saPowerNames,
+    .devParam = {
+        .numBand = 5,
+        .numChan = 8,
+        .numPower = 4,
+        .bandNames = (char **)vtx58BandNames,
+        .bandLetters = (char *)vtx58BandLetter,
+        .chanNames = (char **)vtx58ChannelNames,
+        .powerNames = (char **)saPowerNames,
+    },
 };
 #endif
 

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -53,12 +53,15 @@ static const char * const trampPowerNames[] = {
 #if defined(VTX_COMMON)
 static vtxDevice_t vtxTramp = {
     .vTable = NULL,
-    .numBand = 5,
-    .numChan = 8,
-    .numPower = sizeof(trampPowerTable),
-    .bandNames = (char **)vtx58BandNames,
-    .chanNames = (char **)vtx58ChannelNames,
-    .powerNames = (char **)trampPowerNames,
+    .devParam = {
+        .numBand = 5,
+        .numChan = 8,
+        .numPower = sizeof(trampPowerTable),
+        .bandNames = (char **)vtx58BandNames,
+        .bandLetters = (char *)vtx58BandLetter,
+        .chanNames = (char **)vtx58ChannelNames,
+        .powerNames = (char **)trampPowerNames,
+    },
 };
 #endif
 


### PR DESCRIPTION
PR status: Testing

Per #2247 

- Display band and channel in CH:bc format (e.g., CH:R4, CH:F1).

- For frequency display, I think it should be a separate display item, since band and channel would suffice the purpose of this display item most of the time.

- The band and channel item may displayed in frequency if the device is not operating in band-channel mode (e.g., SmartAudio and Tramp).

- RTC6705 based VTX (USE_RTC6705) is left as is for now. Will be gone in the VTX consolidation phase 2.