### PR TITLE
[VTX SmartAudio] Fix status string for user frequency mode

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -1206,7 +1206,6 @@ static long saCmsCommence(displayPort_t *pDisp, const void *self)
         // Setup band, freq and power.
 
         saSetBandChan(saCmsBand - 1, saCmsChan - 1);
-        saSetPowerByIndex(saCmsPower - 1);
 
         // If in pit mode, cancel it.
 
@@ -1222,6 +1221,8 @@ static long saCmsCommence(displayPort_t *pDisp, const void *self)
         else
             saSetFreq(saCmsUserFreq);
     }
+
+    saSetPowerByIndex(saCmsPower - 1);
 
     return MENU_CHAIN_BACK;
 }
@@ -1268,15 +1269,15 @@ static long saCmsSetUserFreqOnEnter(void)
     return 0;
 }
 
-static long saCmsSetUserFreq(displayPort_t *pDisp, const void *self)
+static long saCmsConfigUserFreq(displayPort_t *pDisp, const void *self)
 {
     UNUSED(pDisp);
     UNUSED(self);
 
     saCmsUserFreq = saCmsUserFreqNew;
-    saSetFreq(saCmsUserFreq);
+    //saSetFreq(saCmsUserFreq);
 
-    return 0;
+    return MENU_CHAIN_BACK;
 }
 
 static OSD_Entry saCmsMenuPORFreqEntries[] = {
@@ -1305,7 +1306,7 @@ static OSD_Entry saCmsMenuUserFreqEntries[] = {
 
     { "CUR FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5900, 0 },    DYNAMIC },
     { "NEW FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 }, 0 },
-    { "SET",           OME_Funcall, saCmsSetUserFreq, NULL,                                                0 },
+    { "SET",           OME_Funcall, saCmsConfigUserFreq, NULL,                                                0 },
 
     { "BACK",          OME_Back,    NULL,             NULL,                                                0 },
     { NULL,            OME_END,     NULL,             NULL,                                                0 }

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -950,8 +950,14 @@ else
     saCmsPitFMode = 0;
 
     saCmsStatusString[0] = "-FR"[saCmsOpmodel];
-    saCmsStatusString[2] = "ABEFR"[saDevice.chan / 8];
-    saCmsStatusString[3] = '1' + (saDevice.chan % 8);
+
+    if (saCmsFselMode == 0) {
+        saCmsStatusString[2] = "ABEFR"[saDevice.chan / 8];
+        saCmsStatusString[3] = '1' + (saDevice.chan % 8);
+    } else {
+        saCmsStatusString[2] = 'U';
+        saCmsStatusString[3] = 'F';
+    }
 
     if ((saDevice.mode & SA_MODE_GET_PITMODE)
        && (saDevice.mode & SA_MODE_GET_OUT_RANGE_PITMODE))
@@ -1067,6 +1073,8 @@ static long saCmsConfigPitFModeByGvar(displayPort_t *pDisp, const void *self)
     return 0;
 }
 
+static long saCmsConfigFreqModeByGvar(displayPort_t *pDisp, const void *self); // Forward
+
 static long saCmsConfigOpmodelByGvar(displayPort_t *pDisp, const void *self)
 {
     UNUSED(pDisp);
@@ -1086,6 +1094,10 @@ static long saCmsConfigOpmodelByGvar(displayPort_t *pDisp, const void *self)
         // out-range receivers from getting blinded.
         saCmsPitFMode = 0;
         saCmsConfigPitFModeByGvar(pDisp, self);
+
+        // Direct frequency mode is not available in RACE opmodel
+        saCmsFselMode = 0;
+        saCmsConfigFreqModeByGvar(pDisp, self);
     } else {
         // Trying to go back to unknown state; bounce back
         saCmsOpmodel = SACMS_OPMODEL_UNDEF + 1;
@@ -1314,8 +1326,8 @@ static OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
 static OSD_Entry saCmsMenuConfigEntries[] = {
     { "- SA CONFIG -", OME_Label, NULL, NULL, 0 },
 
-    { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, 0 },
-    { "FSEL MODE", OME_TAB,     saCmsConfigFreqModeByGvar,             &saCmsEntFselMode,                                   0 },
+    { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
+    { "FSEL MODE", OME_TAB,     saCmsConfigFreqModeByGvar,             &saCmsEntFselMode,                                   DYNAMIC },
     { "PIT FMODE", OME_TAB,     saCmsConfigPitFModeByGvar,             &saCmsEntPitFMode,                                   0 },
     { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, &saCmsMenuPORFreq,                                   OPTSTRING },
     { "STATX",     OME_Submenu, cmsMenuChange,                         &saCmsMenuStats,                                     0 },


### PR DESCRIPTION
PR status: Ready to merge.

- Status string continued to display band/chan when in user specified frequency mode. Modified to show "UF" instead of band/chan.

- Added constraint that when RACE operational model is selected, frequency mode is automatically changed to BANDCHAN (user frequency mode is not supported in RACE operational model).

- Description about how to use the user frequency mode will be added in the Betaflight wiki page.