### PR TITLE
Tramp fix 3.1.5

### DIFF
--- a/src/main/io/vtx_string.c
+++ b/src/main/io/vtx_string.c
@@ -53,10 +53,12 @@ const char * const vtx58ChannelNames[] = {
 
 bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChan)
 {
-    uint8_t band;
+    int8_t band;
     uint8_t chan;
 
-    for (band = 0 ; band < 5 ; band++) {
+    // Use reverse lookup order so that 5880Mhz
+    // get Raceband 7 instead of Fatshark 8.
+    for (band = 4 ; band >= 0 ; band--) {
         for (chan = 0 ; chan < 8 ; chan++) {
             if (vtx58FreqTable[band][chan] == freq) {
                 *pBand = band + 1;

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -134,6 +134,8 @@ void trampCmdU16(uint8_t cmd, uint16_t param)
 void trampSetFreq(uint16_t freq)
 {
     trampConfFreq = freq;
+    if(trampConfFreq != trampCurFreq)
+        trampFreqRetries = TRAMP_MAX_RETRIES;
 }
 
 void trampSendFreq(uint16_t freq)
@@ -149,6 +151,8 @@ void trampSetBandChan(uint8_t band, uint8_t chan)
 void trampSetRFPower(uint16_t level)
 {
     trampConfPower = level;
+    if(trampConfPower != trampCurPower)
+        trampPowerRetries = TRAMP_MAX_RETRIES;
 }
 
 void trampSendRFPower(uint16_t level)
@@ -163,13 +167,6 @@ bool trampCommitChanges()
         return false;
 
     trampStatus = TRAMP_STATUS_SET_FREQ_PW;
-
-    if(trampConfFreq != trampCurFreq)
-        trampFreqRetries = TRAMP_MAX_RETRIES;
-
-    if(trampConfPower != trampCurPower)
-        trampPowerRetries = TRAMP_MAX_RETRIES;
-
     return true;
 }
 

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -508,6 +508,18 @@ static long trampCmsConfigChan(displayPort_t *pDisp, const void *self)
     return 0;
 }
 
+static long trampCmsConfigPower(displayPort_t *pDisp, const void *self)
+{
+    UNUSED(pDisp);
+    UNUSED(self);
+
+    if (trampCmsPower == 0)
+        // Bounce back
+        trampCmsPower = 1;
+
+    return 0;
+}
+
 static OSD_INT16_t trampCmsEntTemp = { &trampCurTemp, -100, 300, 0 };
 
 static const char * const trampCmsPitmodeNames[] = {
@@ -595,7 +607,7 @@ static OSD_Entry trampMenuEntries[] =
     { "BAND",   OME_TAB,     trampCmsConfigBand,     &trampCmsEntBand,      0 },
     { "CHAN",   OME_TAB,     trampCmsConfigChan,     &trampCmsEntChan,      0 },
     { "(FREQ)", OME_UINT16,  NULL,                   &trampCmsEntFreqRef,   DYNAMIC },
-    { "POWER",  OME_TAB,     NULL,                   &trampCmsEntPower,     0 },
+    { "POWER",  OME_TAB,     trampCmsConfigPower,    &trampCmsEntPower,     0 },
     { "T(C)",   OME_INT16,   NULL,                   &trampCmsEntTemp,      DYNAMIC },
     { "SET",    OME_Submenu, cmsMenuChange,          &trampCmsMenuCommence, 0 },
 


### PR DESCRIPTION
Fixes some more Tramp bugs:
- issue with multiple changes through MSP (introduced with 662b9552dff)
- fixed power menu on OSD (would allow ‘---‘ to be selected).
