### PR TITLE
Rebase of #1917: Update SDK to 6.2.1 2016q4 (thanks to @TheAngularity).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ install:
   - make arm_sdk_install
 
 before_script:
-  - tools/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-gcc --version
+  - tools/gcc-arm-none-eabi-6_2-2016q4/bin/arm-none-eabi-gcc --version
   - clang --version
   - clang++ --version
 

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -14,16 +14,16 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-5_4-2016q3
+ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-6_2-2016q4
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
-GCC_REQUIRED_VERSION ?= 5.4.1
+GCC_REQUIRED_VERSION ?= 6.2.1
 
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
-ARM_SDK_URL_BASE  := https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926
+ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216
 
-# source: https://launchpad.net/gcc-arm-embedded/5.0/
+# source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifdef LINUX
   ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-linux.tar.bz2
 endif
@@ -33,7 +33,7 @@ ifdef MACOSX
 endif
 
 ifdef WINDOWS
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip
+  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32-zip.zip
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))

--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -85,7 +85,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 // ideally this would only protect memory passed as parameter (any type should work), but gcc is curently creating almost full barrier
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
-#if (__GNUC__ > 5)
+#if (__GNUC__ > 6)
 #warning "Please verify that ATOMIC_BARRIER works as intended"
 // increment version number is BARRIER works
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead


### PR DESCRIPTION
Cherry-picked commit 2070246314ecf3fbde487af6ccbe1346122ef05e into 3.1.x track. 

BFF3 build failed with gcc5.4, 92 bytes overflow. With gcc6.2 it builds OK, with 632 bytes to spare.
