### PR TITLE
Makefile cleanup. Remove the concept of HIGHEND and the HIGHEND_SRC list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -635,10 +635,6 @@ COMMON_SRC = \
             sensors/compass.c \
             sensors/gyro.c \
             sensors/initialisation.c \
-            $(CMSIS_SRC) \
-            $(DEVICE_STDPERIPH_SRC)
-
-HIGHEND_SRC = \
             blackbox/blackbox.c \
             blackbox/blackbox_io.c \
             cms/cms.c \
@@ -679,7 +675,10 @@ HIGHEND_SRC = \
             sensors/esc_sensor.c \
             io/vtx_string.c \
             io/vtx_smartaudio.c \
-            io/vtx_tramp.c
+            io/vtx_tramp.c \
+            $(CMSIS_SRC) \
+            $(DEVICE_STDPERIPH_SRC)
+
 
 SPEED_OPTIMISED_SRC := ""
 SIZE_OPTIMISED_SRC  := ""
@@ -872,13 +871,8 @@ TARGET_SRC += \
             io/flashfs.c
 endif
 
-ifeq ($(TARGET),$(filter $(TARGET),$(F7_TARGETS) $(F4_TARGETS) $(F3_TARGETS)))
-TARGET_SRC += $(HIGHEND_SRC)
-else ifneq ($(filter HIGHEND,$(FEATURES)),)
-TARGET_SRC += $(HIGHEND_SRC)
-endif
-
 TARGET_SRC += $(COMMON_SRC)
+
 #excludes
 ifeq ($(TARGET),$(filter $(TARGET),$(F7_TARGETS)))
 TARGET_SRC   := $(filter-out ${F7EXCLUDES}, $(TARGET_SRC))

--- a/src/main/target/ALIENFLIGHTF1/target.mk
+++ b/src/main/target/ALIENFLIGHTF1/target.mk
@@ -1,5 +1,4 @@
 F1_TARGETS  += $(TARGET)
-FEATURES    = HIGHEND 
 
 TARGET_SRC = \
             drivers/accgyro_mpu.c \

--- a/src/main/target/CC3D/target.mk
+++ b/src/main/target/CC3D/target.mk
@@ -1,5 +1,5 @@
 F1_TARGETS  += $(TARGET)
-FEATURES    = ONBOARDFLASH HIGHEND VCP
+FEATURES    = ONBOARDFLASH VCP
 
 TARGET_SRC = \
             drivers/accgyro_mpu.c \

--- a/src/main/target/MICROSCISKY/target.mk
+++ b/src/main/target/MICROSCISKY/target.mk
@@ -1,5 +1,4 @@
 F1_TARGETS  += $(TARGET)
-FEATURES    = HIGHEND
 
 TARGET_SRC = \
             drivers/accgyro_mpu.c \

--- a/src/main/target/NAZE/target.mk
+++ b/src/main/target/NAZE/target.mk
@@ -1,5 +1,5 @@
 F1_TARGETS  += $(TARGET)
-FEATURES    = ONBOARDFLASH HIGHEND 
+FEATURES    = ONBOARDFLASH
 
 TARGET_SRC = \
             drivers/accgyro_adxl345.c \

--- a/src/main/target/STM32F3DISCOVERY/target.mk
+++ b/src/main/target/STM32F3DISCOVERY/target.mk
@@ -1,5 +1,5 @@
 F3_TARGETS  += $(TARGET)
-FEATURES    = VCP SDCARD HIGHEND
+FEATURES    = VCP SDCARD
 
 TARGET_SRC = \
             drivers/accgyro_adxl345.c \


### PR DESCRIPTION
Removal of the HIGHEND feature and the files in the HIGHEND_SRC list added to COMMON_SRC for less build configuration complexity. Hard to keep target.h defined functions in sync with target.mk defined FEATURES. Ideally a build config item should only need to be defined once, in one place.
There are still a few FEATURES items left, VCP, ONBOARDFLASH and SDCARD, that needs to be in sync with similar defines in target.h files.

You might have expected this would affect compile times, but I have not been able to measure any noticeable difference. With ccache cleared make all takes about 35minutes in both cases on my Ubuntu machine. With ccache filled it takes about 20 minutes.
On cygwin it takes about 77min (without ccache).
