### PR TITLE
Disable F7 D-cache until more knowledge is acquired

### DIFF
--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -193,7 +193,7 @@ void adcInit(adcConfig_t *config)
         }
     }
 
-    HAL_CLEANINVALIDATECACHE((uint32_t*)&adcValues, configuredAdcChannels);
+    //HAL_CLEANINVALIDATECACHE((uint32_t*)&adcValues, configuredAdcChannels);
     /*##-4- Start the conversion process #######################################*/
     if(HAL_ADC_Start_DMA(&adc.ADCHandle, (uint32_t*)&adcValues, configuredAdcChannels) != HAL_OK)
     {

--- a/src/main/drivers/bus_spi_hal.c
+++ b/src/main/drivers/bus_spi_hal.c
@@ -390,7 +390,7 @@ DMA_HandleTypeDef* spiSetDMATransmit(DMA_Stream_TypeDef *Stream, uint32_t Channe
     // DMA TX Interrupt
     dmaSetHandler(spiHardwareMap[device].dmaIrqHandler, dmaSPIIRQHandler, NVIC_BUILD_PRIORITY(3, 0), (uint32_t)device);
 
-    HAL_CLEANCACHE(pData,Size);
+    //HAL_CLEANCACHE(pData,Size);
     // And Transmit
     HAL_SPI_Transmit_DMA(&spiHardwareMap[device].hspi, pData, Size);
 

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -39,8 +39,8 @@ typedef struct dmaChannelDescriptor_s {
 } dmaChannelDescriptor_t;
 
 #if defined(STM32F7)
-#define HAL_CLEANINVALIDATECACHE(addr, size) (SCB_CleanInvalidateDCache_by_Addr((uint32_t*)((uint32_t)addr & ~0x1f), ((uint32_t)(addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
-#define HAL_CLEANCACHE(addr, size) (SCB_CleanDCache_by_Addr((uint32_t*)((uint32_t)addr & ~0x1f), ((uint32_t)(addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
+//#define HAL_CLEANINVALIDATECACHE(addr, size) (SCB_CleanInvalidateDCache_by_Addr((uint32_t*)((uint32_t)addr & ~0x1f), ((uint32_t)(addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
+//#define HAL_CLEANCACHE(addr, size) (SCB_CleanDCache_by_Addr((uint32_t*)((uint32_t)addr & ~0x1f), ((uint32_t)(addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
 #endif
 
 #if defined(STM32F4) || defined(STM32F7)

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -266,7 +266,7 @@ void uartStartTxDMA(uartPort_t *s)
         s->port.txBufferTail = 0;
     }
     s->txDMAEmpty = false;
-    HAL_CLEANCACHE((uint8_t *)&s->port.txBuffer[fromwhere],size);
+    //HAL_CLEANCACHE((uint8_t *)&s->port.txBuffer[fromwhere],size);
     HAL_UART_Transmit_DMA(&s->Handle, (uint8_t *)&s->port.txBuffer[fromwhere], size);
 }
 

--- a/src/main/target/system_stm32f7xx.c
+++ b/src/main/target/system_stm32f7xx.c
@@ -283,14 +283,14 @@ void SystemInit(void)
   SCB_EnableICache();
 
   /* Enable D-Cache */
-  SCB_EnableDCache();
+  //SCB_EnableDCache();
 
   /* Configure the system clock to 216 MHz */
   SystemClock_Config();
 
-  //if(SystemCoreClock != 260000000)
+  if(SystemCoreClock != 216000000)
   {
-      //while(1)
+      while(1)
       {
           // There is a mismatch between the configured clock and the expected clock in portable.h
       }


### PR DESCRIPTION
On F7 D-cache is causing some issues, most likely me not using it properly. I-cache gives nice performance boost but would be nice to have both enabled. 
Cases here https://www.dropbox.com/sh/50w59acst2fxttq/AACz7gLzwCMhPqg9WXtCkEvka?dl=0
I had to disable them in Inav as it was causing attitude corruption, might be safer to disable also here.