### PR TITLE
Fix #2364 remove defines for I2C

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -33,9 +33,6 @@
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
 
-#define USE_I2C
-#define I2C_DEVICE (I2CDEV_2) // Flex port - SCL/PB10, SDA/PB11
-
 #define MPU6000_CS_GPIO         GPIOA
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_INSTANCE    SPI1
@@ -57,6 +54,9 @@
 
 // MPU6000 interrupts
 #define USE_MPU_DATA_READY_SIGNAL
+
+//#define USE_I2C
+//#define I2C_DEVICE (I2CDEV_2) // Flex port - SCL/PB10, SDA/PB11
 
 // External I2C BARO
 //#define BARO


### PR DESCRIPTION
USE_I2C was still defined even though no I2C devices BARO MAG were
defined. This led to the I2C being active but not being handled. So any
data on the I2C line caused it to error and not be handled.

Tested with IA6B RX hooked upto the flexport of the CC3D with TX on
before the FC boots.