### PR TITLE
SPRF3EVO and AIORF3 builds broken. Include file problems fixed.

### DIFF
--- a/src/main/target/SPRACINGF3EVO/config.c
+++ b/src/main/target/SPRACINGF3EVO/config.c
@@ -15,37 +15,15 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//#include <stdbool.h>
-//#include <stdint.h>
-
-//#include <platform.h>
-
-//#include "common/axis.h"
-
-//#include "drivers/compass.h"
-//#include "drivers/io.h"
-//#include "drivers/pwm_esc_detect.h"
-//#include "drivers/pwm_output.h"
-//#include "drivers/sensor.h"
-
-//#include "fc/rc_controls.h"
-
-//#include "flight/failsafe.h"
-//#include "flight/mixer.h"
-//#include "flight/pid.h"
-
-//#include "rx/rx.h"
-
-//#include "sensors/sensors.h"
-//#include "sensors/compass.h"
-
-//#include "config/config_profile.h"
+#include <platform.h>
 #include "config/config_master.h"
 
-//#include "hardware_revision.h"
+#ifdef TARGET_CONFIG
 
 void targetConfiguration(master_t *config)
 {
     // Temporary workaround: Disable SDCard DMA by default since it causes errors on this target
     config->sdcardConfig.useDma = false;
 }
+
+#endif


### PR DESCRIPTION
SPRACINGF3EVO and AIORACERF3 builds broken. Include file problems in target config.c fixed.
