### PR TITLE
Sparky 2.0 Accelerometer (fix mpu9250 detection)

### DIFF
--- a/src/main/drivers/accgyro_mpu6500.h
+++ b/src/main/drivers/accgyro_mpu6500.h
@@ -19,6 +19,7 @@
 
 #define MPU6500_WHO_AM_I_CONST              (0x70)
 #define MPU9250_WHO_AM_I_CONST              (0x71)
+#define MPU9255_WHO_AM_I_CONST              (0x73)
 #define ICM20608G_WHO_AM_I_CONST            (0xAF)
 #define ICM20602_WHO_AM_I_CONST             (0x12)
 

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -90,6 +90,7 @@ uint8_t mpu6500SpiDetect(void)
         mpuDetected = MPU_65xx_SPI;
         break;
     case MPU9250_WHO_AM_I_CONST:
+    case MPU9255_WHO_AM_I_CONST:
         mpuDetected = MPU_9250_SPI;
         break;
     case ICM20608G_WHO_AM_I_CONST:

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -198,7 +198,7 @@ bool mpu9250SpiDetect(void)
         delay(150);
 
         mpu9250ReadRegister(MPU_RA_WHO_AM_I, 1, &in);
-        if (in == MPU9250_WHO_AM_I_CONST) {
+        if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }
         if (!attemptsRemaining) {

--- a/src/main/drivers/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro_spi_mpu9250.h
@@ -17,6 +17,7 @@
 #define GYRO_SCALE_FACTOR  0.00053292f  // (4/131) * pi/180   (32.75 LSB = 1 DPS)
 
 #define MPU9250_WHO_AM_I_CONST              (0x71)
+#define MPU9255_WHO_AM_I_CONST              (0x73)
 
 #define MPU9250_BIT_RESET                   (0x80)
 

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -162,10 +162,20 @@ retry:
         }
 #endif
         ; // fallthrough
+    case ACC_MPU9250:
+#ifdef USE_ACC_SPI_MPU9250
+        if (mpu9250SpiAccDetect(dev)) {
+#ifdef ACC_MPU9250_ALIGN
+            dev->accAlign = ACC_MPU9250_ALIGN;
+#endif
+            accHardware = ACC_MPU9250;
+            break;
+        }
+#endif
+        ; // fallthrough
     case ACC_MPU6500:
     case ACC_ICM20608G:
     case ACC_ICM20602:
-    case ACC_MPU9250:
 #if defined(USE_ACC_MPU6500) || defined(USE_ACC_SPI_MPU6500)
 #ifdef USE_ACC_SPI_MPU6500
         if (mpu6500AccDetect(dev) || mpu6500SpiAccDetect(dev))


### PR DESCRIPTION
Fix for https://github.com/betaflight/betaflight/issues/2386