### PR TITLE
Use usbGenerateDisconnectPulse for F1/F3 targets.

### DIFF
--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -37,6 +37,7 @@
 
 #include <stdbool.h>
 #include "drivers/system.h"
+#include "drivers/usb_io.h"
 #include "drivers/nvic.h"
 
 #include "common/utils.h"
@@ -85,30 +86,7 @@ void Set_System(void)
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
 #endif /* STM32L1XX_XD */
 
-    /*Pull down PA12 to create USB Disconnect Pulse*/     // HJI
-#if defined(STM32F303xC)                                    // HJI
-    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOA, ENABLE);   // HJI
-
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12;          // HJI
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;     // HJI
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;        // HJI
-    GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;        // HJI
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;     // HJI
-#else
-    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE); // HJI
-
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12;// HJI
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;// HJI
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_OD;// HJI
-#endif
-
-    GPIO_Init(GPIOA, &GPIO_InitStructure);                // HJI
-
-    GPIO_ResetBits(GPIOA, GPIO_Pin_12);                   // HJI
-
-    delay(200);                                           // HJI
-
-    GPIO_SetBits(GPIOA, GPIO_Pin_12);                     // HJI
+    usbGenerateDisconnectPulse();
 
 #if defined(STM32F37X) || defined(STM32F303xC)
 


### PR DESCRIPTION
restore lost code change.   tested via patch_v3.1.5 branch on SPRacingF3MINI.
