### PR TITLE
SPRACINGF3MINI - Fix missing spektrum bind support.

### DIFF
--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -184,8 +184,11 @@
 #define BUTTON_A_PIN            PB1
 #define BUTTON_B_PIN            PB0
 
+#define SPEKTRUM_BIND
+#define BIND_PIN                UART2_RX_PIN
+
 #define HARDWARE_BIND_PLUG
-#define BINDPLUG_PIN            PB0
+#define BINDPLUG_PIN            BUTTON_B_PIN
 #endif
 
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
Not sure what happened to the code, but here's a fix.  Likely the TINYBEEF3 code changes broke it but I'm guessing here.