### PR TITLE
Rework PWM and PPM input for F7

### DIFF
--- a/src/main/drivers/rx_pwm.c
+++ b/src/main/drivers/rx_pwm.c
@@ -339,6 +339,7 @@ void pwmICConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t polarity)
     }
 
     HAL_TIM_IC_ConfigChannel(Handle, &TIM_ICInitStructure, channel);
+    HAL_TIM_IC_Start_IT(Handle,channel);
 }
 #else
 void pwmICConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t polarity)
@@ -386,20 +387,23 @@ void pwmRxInit(const pwmConfig_t *pwmConfig)
         IOInit(io, OWNER_PWMINPUT, RESOURCE_INDEX(channel));
 #ifdef STM32F1
         IOConfigGPIO(io, IOCFG_IPD);
+#elif defined(STM32F7)
+        IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 #else
         IOConfigGPIO(io, IOCFG_AF_PP);
 #endif
 
-#if defined(USE_HAL_DRIVER)
-    pwmICConfig(timer->tim, timer->channel, TIM_ICPOLARITY_RISING);
-#else
-    pwmICConfig(timer->tim, timer->channel, TIM_ICPolarity_Rising);
-#endif
         timerConfigure(timer, (uint16_t)PWM_TIMER_PERIOD, PWM_TIMER_MHZ);
-
         timerChCCHandlerInit(&port->edgeCb, pwmEdgeCallback);
         timerChOvrHandlerInit(&port->overflowCb, pwmOverflowCallback);
         timerChConfigCallbacks(timer, &port->edgeCb, &port->overflowCb);
+
+#if defined(USE_HAL_DRIVER)
+        pwmICConfig(timer->tim, timer->channel, TIM_ICPOLARITY_RISING);
+#else
+        pwmICConfig(timer->tim, timer->channel, TIM_ICPolarity_Rising);
+#endif
+
     }
 }
 
@@ -454,21 +458,22 @@ void ppmRxInit(const ppmConfig_t *ppmConfig, uint8_t pwmProtocol)
     IOInit(io, OWNER_PPMINPUT, 0);
 #ifdef STM32F1
     IOConfigGPIO(io, IOCFG_IPD);
+#elif defined(STM32F7)
+    IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 #else
     IOConfigGPIO(io, IOCFG_AF_PP);
 #endif
+
+    timerConfigure(timer, (uint16_t)PPM_TIMER_PERIOD, PWM_TIMER_MHZ);
+    timerChCCHandlerInit(&port->edgeCb, ppmEdgeCallback);
+    timerChOvrHandlerInit(&port->overflowCb, ppmOverflowCallback);
+    timerChConfigCallbacks(timer, &port->edgeCb, &port->overflowCb);
 
 #if defined(USE_HAL_DRIVER)
     pwmICConfig(timer->tim, timer->channel, TIM_ICPOLARITY_RISING);
 #else
     pwmICConfig(timer->tim, timer->channel, TIM_ICPolarity_Rising);
 #endif
-
-    timerConfigure(timer, (uint16_t)PPM_TIMER_PERIOD, PWM_TIMER_MHZ);
-
-    timerChCCHandlerInit(&port->edgeCb, ppmEdgeCallback);
-    timerChOvrHandlerInit(&port->overflowCb, ppmOverflowCallback);
-    timerChConfigCallbacks(timer, &port->edgeCb, &port->overflowCb);
 }
 
 uint16_t ppmRead(uint8_t channel)

--- a/src/main/target/ANYFCF7/target.c
+++ b/src/main/target/ANYFCF7/target.c
@@ -31,8 +31,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM,   0,  0 ), // S2_IN
     DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,   0,  0 ), // S3_IN
     DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,   0,  0 ), // S4_IN
-    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,   0,  0 ), // S5_IN
-    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,   0,  0 ), // S6_IN
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,   0,  0 ), // S5_IN
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,   0,  0 ), // S6_IN
 
     DEF_TIM(TIM4, CH3, PB8, TIM_USE_MOTOR,   1,  0 ), // S10_OUT 1 DMA1_ST7
     DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR,   1,  0 ), // S6_OUT  2 DMA1_ST1


### PR DESCRIPTION
Fix IO init for F7
Timer Handle needs to be initialized before IC config
Add missing IT start
Fix AnyFCF7 input pinout

Note:  check if moving pwmICConfig after timerConfigure breaks something on F1/F3.
Tested this change on F4 and F7 with PWM input