### PR TITLE
BlackBox - initialise  SDCARD or FLASH if selected (not both)

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1657,7 +1657,8 @@ void handleBlackbox(timeUs_t currentTimeUs)
 
 static bool canUseBlackboxWithCurrentConfiguration(void)
 {
-    return feature(FEATURE_BLACKBOX);
+    return feature(FEATURE_BLACKBOX) && 
+        (blackboxConfig()->device != BLACKBOX_SDCARD || feature(FEATURE_SDCARD));
 }
 
 /**

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -23,6 +23,12 @@
 
 #include "config/parameter_group.h"
 
+typedef enum {
+	BLACKBOX_SERIAL = 0, 
+	BLACKBOX_SPIFLASH,
+	BLACKBOX_SDCARD
+} blackBoxDevice_e;
+
 typedef struct blackboxConfig_s {
     uint8_t rate_num;
     uint8_t rate_denom;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -488,15 +488,16 @@ void init(void)
 #endif
 
 #ifdef USE_FLASHFS
+    if (blackboxConfig()->device == BLACKBOX_SPIFLASH) {
 #if defined(USE_FLASH_M25P16)
-    m25p16_init(flashConfig());
+        m25p16_init(flashConfig());
 #endif
-
-    flashfsInit();
+        flashfsInit();
+    }
 #endif
 
 #ifdef USE_SDCARD
-    if (feature(FEATURE_SDCARD)) {
+    if (feature(FEATURE_SDCARD) && blackboxConfig()->device == BLACKBOX_SDCARD) {
         sdcardInsertionDetectInit();
         sdcard_init(sdcardConfig()->useDma);
         afatfs_init();

--- a/src/main/target/BLUEJAYF4/initialisation.c
+++ b/src/main/target/BLUEJAYF4/initialisation.c
@@ -57,9 +57,13 @@ void targetPreInit(void)
 
     /* ensure the CS pin for the flash is pulled hi so any SD card initialisation does not impact the chip */
     if (hardwareRevision == BJF4_REV3) {
-        IO_t io = IOGetByTag(IO_TAG(M25P16_CS_PIN));
-        IOConfigGPIO(io, IOCFG_OUT_PP);
-        IOHi(io);
+        IO_t flashIo = IOGetByTag(IO_TAG(M25P16_CS_PIN));
+        IOConfigGPIO(flashIo, IOCFG_OUT_PP);
+        IOHi(flashIo);
+
+        IO_t sdcardIo = IOGetByTag(IO_TAG(SDCARD_SPI_CS_PIN));
+        IOConfigGPIO(sdcardIo, IOCFG_OUT_PP);
+        IOHi(sdcardIo);
     }
 }
 


### PR DESCRIPTION
Protection to ensure only one or the other is initialised in regards to blackbox (for BlueJayF4).

Prevents the horrid crazy drone / fly away scenario.