### PR TITLE
Re-added check to reset EEPROM config if board identifier has changed.

### DIFF
--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -320,9 +320,6 @@ typedef struct master_s {
 
     beeperConfig_t beeperConfig;
 
-    char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER)];
-
-    uint8_t magic_ef;                       // magic number, should be 0xEF
     uint8_t chk;                            // XOR checksum
     /*
         do not add properties after the MAGIC_EF and CHK

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -1097,9 +1097,6 @@ void createDefaultConfig(master_t *config)
 
     resetStatusLedConfig(&config->statusLedConfig);
 
-    /* merely to force a reset if the person inadvertently flashes the wrong target */
-    strncpy(config->boardIdentifier, TARGET_BOARD_IDENTIFIER, sizeof(TARGET_BOARD_IDENTIFIER));
-
 #if defined(TARGET_CONFIG)
     targetConfiguration(config);
 #endif


### PR DESCRIPTION
Reinstating the functionality of #2013.

@martinbudden: I find that `configHeader_t.format` is a bit unintuitive as name for the configuration version. Should this have a different name?