### PR TITLE
lcov report

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -67,7 +67,7 @@ elif [ $GOAL ] ; then
     make V=0 $GOAL || exit $?
     
     if [ "test" == "$GOAL" ] ; then
-        lcov --directory . -b src/test --capture --output-file coverage.info # capture coverage info
+        lcov --directory . -b src/test --capture --output-file coverage.info 2>&1 | grep -E ":version '402\*', prefer.*'406\*" --invert-match
         lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info # filter out system and test code
         lcov --list coverage.info # debug before upload
         coveralls-lcov coverage.info # uploads to coveralls

--- a/.travis.sh
+++ b/.travis.sh
@@ -64,7 +64,14 @@ elif [ $TARGET ] ; then
 	fi
 
 elif [ $GOAL ] ; then
-    make V=0 $GOAL
+    make V=0 $GOAL || exit $?
+    
+    if [ "test" == "$GOAL" ] ; then
+        lcov --directory . -b src/test --capture --output-file coverage.info # capture coverage info
+        lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info # filter out system and test code
+        lcov --list coverage.info # debug before upload
+        coveralls-lcov coverage.info # uploads to coveralls
+    fi
 
 else 
     make V=0 all

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,19 @@ git:
 addons:
   apt:
     packages:
+      - lcov
+      - build-essential
+      - git
       - libc6-i386
       - time
 
 # We use cpp for unit tests, and c for the main project.
 language: cpp
 compiler: clang
+
+before_install:
+  - pip install --user cpp-coveralls
+  - gem install coveralls-lcov
 
 install:
   - make arm_sdk_install

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ https://travis-ci.org/betaflight/betaflight
 
 [![Build Status](https://travis-ci.org/betaflight/betaflight.svg?branch=master)](https://travis-ci.org/betaflight/betaflight)
 
+Coveralls is used to monitor code coverage: https://coveralls.io/github/betaflight/betaflight
+
+[![Coverage Status](https://coveralls.io/repos/github/betaflight/betaflight/badge.svg?branch=master)](https://coveralls.io/github/betaflight/betaflight?branch=master)
+
 ## Betaflight Releases
 
 https://github.com/betaflight/betaflight/releases


### PR DESCRIPTION
Updated:
This pull request publishes code coverage to the server at https://coveralls.io which is free for open source projects.
(Example page from cleanfligt: https://coveralls.io/github/cleanflight/cleanflight)

Credits are due to @mkschreder for initial idea/implementation

Stuff to do by the maintainer when merging:

- Create account at coveralls.io and enable the cleanflight repository (it takes like five seconds)
- Possibly update the link for the status gadget in the end of README.md 

This PR contatins the coverall reporting in the same way as the cleanflight PR: https://github.com/cleanflight/cleanflight/pull/2487