### PR TITLE
ALIENFLIGHT*. Fix compiler redefine warnings,

### DIFF
--- a/src/main/target/ALIENFLIGHTF1/config.c
+++ b/src/main/target/ALIENFLIGHTF1/config.c
@@ -35,6 +35,10 @@
 #include "config/config_profile.h"
 #include "config/config_master.h"
 
+#ifdef BRUSHED_MOTORS_PWM_RATE
+#undef BRUSHED_MOTORS_PWM_RATE
+#endif
+
 #define BRUSHED_MOTORS_PWM_RATE 32000           // 32kHz
 
 // alternative defaults settings for AlienFlight targets

--- a/src/main/target/ALIENFLIGHTF3/config.c
+++ b/src/main/target/ALIENFLIGHTF3/config.c
@@ -45,6 +45,10 @@
 
 #include "hardware_revision.h"
 
+#ifdef BRUSHED_MOTORS_PWM_RATE
+#undef BRUSHED_MOTORS_PWM_RATE
+#endif
+
 #define BRUSHED_MOTORS_PWM_RATE 32000           // 32kHz
 
 // alternative defaults settings for AlienFlight targets

--- a/src/main/target/ALIENFLIGHTF4/config.c
+++ b/src/main/target/ALIENFLIGHTF4/config.c
@@ -53,6 +53,10 @@
 #define CURRENTOFFSET 2500                      // ACS712/714-30A - 0A = 2.5V
 #define CURRENTSCALE -667                       // ACS712/714-30A - 66.666 mV/A inverted mode
 
+#ifdef BRUSHED_MOTORS_PWM_RATE
+#undef BRUSHED_MOTORS_PWM_RATE
+#endif
+
 #define BRUSHED_MOTORS_PWM_RATE 32000           // 32kHz
 
 // alternative defaults settings for AlienFlight targets

--- a/src/main/target/ALIENFLIGHTNGF7/config.c
+++ b/src/main/target/ALIENFLIGHTNGF7/config.c
@@ -53,6 +53,10 @@
 #define CURRENTOFFSET 2500                      // ACS712/714-30A - 0A = 2.5V
 #define CURRENTSCALE -667                       // ACS712/714-30A - 66.666 mV/A inverted mode
 
+#ifdef BRUSHED_MOTORS_PWM_RATE
+#undef BRUSHED_MOTORS_PWM_RATE
+#endif
+
 #define BRUSHED_MOTORS_PWM_RATE 32000           // 32kHz
 
 // alternative defaults settings for AlienFlight targets


### PR DESCRIPTION
Fixes compiler warnings in all four ALIENFLIGHT targets:

     warning: "BRUSHED_MOTORS_PWM_RATE" redefined
 

    