### PR TITLE
Fix SINGULARITY target timer mapping

### DIFF
--- a/src/main/target/SINGULARITY/target.c
+++ b/src/main/target/SINGULARITY/target.c
@@ -25,15 +25,15 @@
 #include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_PWM | TIM_USE_PPM,   0), // PPM/SERIAL RX
-    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_PWM,                 0), // PWM1
-    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_PWM,                 0), // PWM2
-    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_PWM,                 0), // PWM3
-    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_PWM,                 0), // PWM4
-    DEF_TIM(TIM16, CH1, PB8,  TIM_USE_MOTOR,               1), // PWM5
-    DEF_TIM(TIM17, CH1, PB9,  TIM_USE_MOTOR,               1), // PWM6
-    DEF_TIM(TIM15, CH1, PA2,  TIM_USE_MOTOR,               1), // SOFTSERIAL1 RX (NC)
-    DEF_TIM(TIM15, CH2, PA3,  TIM_USE_MOTOR,               1), // SOFTSERIAL1 TX
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR | TIM_USE_LED, 1), // LED_STRIP
+    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_PPM,   0), // PPM/SERIAL RX
+    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_MOTOR, 1), // PWM1
+    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_MOTOR, 1), // PWM2
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR, 1), // PWM3
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR, 1), // PWM4
+    DEF_TIM(TIM16, CH1, PB8,  TIM_USE_MOTOR, 1), // PWM5
+    DEF_TIM(TIM17, CH1, PB9,  TIM_USE_MOTOR, 1), // PWM6
+    DEF_TIM(TIM15, CH1, PA2,  TIM_USE_MOTOR, 1), // SOFTSERIAL1 RX (NC)
+    DEF_TIM(TIM15, CH2, PA3,  TIM_USE_MOTOR, 1), // SOFTSERIAL1 TX
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED,   1), // LED_STRIP
 };
 


### PR DESCRIPTION
Remap timers so correct motor outputs are used in corners of PCB.
PWM not supported on this target!