### PR TITLE
Make RSSI inversion work for PWM ADC

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -536,7 +536,7 @@ static const clivalue_t valueTable[] = {
     { "rssi_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { RSSI_SCALE_MIN,  RSSI_SCALE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rssi_scale) },
     { "rc_interpolation",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RC_INTERPOLATION }, PG_RX_CONFIG, offsetof(rxConfig_t, rcInterpolation) },
     { "rc_interpolation_interval",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1,  50 }, PG_RX_CONFIG, offsetof(rxConfig_t, rcInterpolationInterval) },
-    { "rssi_ppm_invert",            VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, rssi_ppm_invert) },
+    { "rssi_invert",                VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, rssi_invert) },
     { "roll_yaw_cam_mix_degrees",   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  50 }, PG_RX_CONFIG, offsetof(rxConfig_t, fpvCamAngleDegrees) },
     { "max_aux_channels",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  13 }, PG_RX_CONFIG, offsetof(rxConfig_t, max_aux_channel) },
 #ifdef SERIAL_RX
@@ -573,7 +573,7 @@ static const clivalue_t valueTable[] = {
     { "rc_interp",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &rxConfig()->rcInterpolation, .config.lookup = { TABLE_RC_INTERPOLATION } },
     { "rc_interp_ch",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &rxConfig()->rcInterpolationChannels, .config.lookup = { TABLE_RC_INTERPOLATION_CHANNELS } },
     { "rc_interp_int",              VAR_UINT8  | MASTER_VALUE,  &rxConfig()->rcInterpolationInterval, .config.minmax = { 1,  50 } },
-    { "rssi_ppm_invert",            VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  &rxConfig()->rssi_ppm_invert, .config.lookup = { TABLE_OFF_ON } },
+    { "rssi_invert",                VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  &rxConfig()->rssi_invert, .config.lookup = { TABLE_OFF_ON } },
 #if defined(USE_PWM)
     { "input_filtering_mode",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  &pwmConfig()->inputFilteringMode, .config.lookup = { TABLE_OFF_ON } },
 #endif

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -991,7 +991,7 @@ void createDefaultConfig(master_t *config)
 
     config->rxConfig.rssi_channel = 0;
     config->rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
-    config->rxConfig.rssi_ppm_invert = 0;
+    config->rxConfig.rssi_invert = 0;
     config->rxConfig.rcInterpolation = RC_SMOOTHING_AUTO;
     config->rxConfig.rcInterpolationChannels = 0;
     config->rxConfig.rcInterpolationInterval = 19;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -117,7 +117,7 @@ PG_RESET_TEMPLATE(rxConfig_t, rxConfig,
     .rx_max_usec = 2115,         // any of first 4 channels above this value will trigger rx loss detection
     .rssi_channel = 0,
     .rssi_scale = RSSI_SCALE_DEFAULT,
-    .rssi_ppm_invert = 0,
+    .rssi_invert = 0,
     .rcInterpolation = RC_SMOOTHING_AUTO,
     .rcInterpolationChannels = 0,
     .rcInterpolationInterval = 19,
@@ -599,7 +599,7 @@ static void updateRSSIPWM(void)
     pwmRssi = rcData[rxConfig()->rssi_channel - 1];
 
     // RSSI_Invert option
-    if (rxConfig()->rssi_ppm_invert) {
+    if (rxConfig()->rssi_invert) {
         pwmRssi = ((2000 - pwmRssi) + 1000);
     }
 
@@ -638,7 +638,14 @@ static void updateRSSIADC(timeUs_t currentTimeUs)
 
     adcRssiMean = adcRssiMean / RSSI_ADC_SAMPLE_COUNT;
 
-    rssi = (uint16_t)((constrain(adcRssiMean, 0, 100) / 100.0f) * 1023.0f);
+    adcRssiMean=constrain(adcRssiMean, 0, 100);
+
+    // RSSI_Invert option
+    if (rxConfig()->rssi_invert) {
+        adcRssiMean = 100 - adcRssiMean;
+    }
+
+    rssi = (uint16_t)((adcRssiMean / 100.0f) * 1023.0f);
 #endif
 }
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -127,7 +127,7 @@ typedef struct rxConfig_s {
     uint8_t spektrum_sat_bind_autoreset;    // whenever we will reset (exit) binding mode after hard reboot
     uint8_t rssi_channel;
     uint8_t rssi_scale;
-    uint8_t rssi_ppm_invert;
+    uint8_t rssi_invert;
     uint16_t midrc;                         // Some radios have not a neutral point centered on 1500. can be changed here
     uint16_t mincheck;                      // minimum rc end
     uint16_t maxcheck;                      // maximum rc end


### PR DESCRIPTION
Needed for using analog PWM ADC input with FrSKY receivers with separated RSSI pad.
Also renamed rssi_ppm_invert option into rssi_invert for uniformity.
According to the same change in Cleanflight: cleanflight#2536

This PR replaces https://github.com/betaflight/betaflight/pull/2411