### PR TITLE
Fixed sign of angleTrim value in pid.c

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -277,7 +277,7 @@ static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPit
     errorAngle += GPS_angle[axis];
 #endif
     errorAngle = constrainf(errorAngle, -pidProfile->levelAngleLimit, pidProfile->levelAngleLimit);
-    errorAngle = (errorAngle - ((attitude.raw[axis] + angleTrim->raw[axis]) / 10.0f));
+    errorAngle = errorAngle - ((attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f);
     if(FLIGHT_MODE(ANGLE_MODE)) {
         // ANGLE mode - control is angle based, so control loop is needed
         currentPidSetpoint = errorAngle * levelGain;


### PR DESCRIPTION
In changes made to 'pid.c' on 2016-12-30, the line:
`errorAngle = (errorAngle - attitude.raw[axis] + angleTrim->raw[axis]) / 10.0f;`
was modified to:
`errorAngle = (errorAngle - ((attitude.raw[axis] + angleTrim->raw[axis]) / 10.0f));`

This resulted in a functional sign change for "angleTrim->raw[axis]".  Where this is especially noticeable is when doing accelerometer trim via stick inputs; the trimming is reversed.  I believe the line should be like this:

`errorAngle = errorAngle - ((attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f);`

(Also removing extraneous surrounding parentheses.)

--ET