### PR TITLE
Added KroozX board

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -405,18 +405,6 @@ void init(void)
     }
 #endif
 
-#ifdef OSD
-    if (feature(FEATURE_OSD)) {
-#if defined(USE_MAX7456)
-        // if there is a max7456 chip for the OSD then use it, otherwise use MSP
-        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
-#elif defined(USE_MSP_DISPLAYPORT)
-        displayPort_t *osdDisplayPort = displayPortMspInit();
-#endif
-        osdInit(osdDisplayPort);
-    }
-#endif
-
     if (!sensorsAutodetect()) {
         // if gyro was not detected due to whatever reason, we give up now.
         failureMode(FAILURE_MISSING_ACC);
@@ -460,6 +448,18 @@ void init(void)
     failsafeInit();
 
     rxInit();
+
+#ifdef OSD
+    if (feature(FEATURE_OSD)) {
+#if defined(USE_MAX7456)
+        // if there is a max7456 chip for the OSD then use it, otherwise use MSP
+        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
+#elif defined(USE_MSP_DISPLAYPORT)
+        displayPort_t *osdDisplayPort = displayPortMspInit();
+#endif
+        osdInit(osdDisplayPort);
+    }
+#endif
 
 #ifdef GPS
     if (feature(FEATURE_GPS)) {

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -405,6 +405,18 @@ void init(void)
     }
 #endif
 
+#ifdef OSD
+    if (feature(FEATURE_OSD)) {
+#if defined(USE_MAX7456)
+        // if there is a max7456 chip for the OSD then use it, otherwise use MSP
+        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
+#elif defined(USE_MSP_DISPLAYPORT)
+        displayPort_t *osdDisplayPort = displayPortMspInit();
+#endif
+        osdInit(osdDisplayPort);
+    }
+#endif
+
     if (!sensorsAutodetect()) {
         // if gyro was not detected due to whatever reason, we give up now.
         failureMode(FAILURE_MISSING_ACC);
@@ -448,18 +460,6 @@ void init(void)
     failsafeInit();
 
     rxInit();
-
-#ifdef OSD
-    if (feature(FEATURE_OSD)) {
-#if defined(USE_MAX7456)
-        // if there is a max7456 chip for the OSD then use it, otherwise use MSP
-        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
-#elif defined(USE_MSP_DISPLAYPORT)
-        displayPort_t *osdDisplayPort = displayPortMspInit();
-#endif
-        osdInit(osdDisplayPort);
-    }
-#endif
 
 #ifdef GPS
     if (feature(FEATURE_GPS)) {

--- a/src/main/target/KROOZX/config.c
+++ b/src/main/target/KROOZX/config.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "config/config_master.h"
+
+#define VBAT_SCALE       113
+#define CURRENT_SCALE    1000
+#define CURRENT_OFFSET   0
+
+#define OSD_POS(x,y)  (x | (y << 5))
+
+#ifdef TARGET_CONFIG
+void targetConfiguration(master_t *config)
+{
+    config->batteryConfig.vbatscale = VBAT_SCALE;
+    config->batteryConfig.currentMeterScale = CURRENT_SCALE;
+    config->batteryConfig.currentMeterOffset = CURRENT_OFFSET;
+    config->barometerConfig.baro_hardware = 0;
+    config->compassConfig.mag_hardware = 0;
+    config->osdConfig.item_pos[OSD_MAIN_BATT_VOLTAGE] = OSD_POS(12, 1) | VISIBLE_FLAG;
+}
+#endif

--- a/src/main/target/KROOZX/initialisation.c
+++ b/src/main/target/KROOZX/initialisation.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "drivers/io.h"
+#include "drivers/bus_i2c.h"
+#include "drivers/bus_spi.h"
+
+void targetBusInit(void)
+{
+#ifdef USE_SPI
+	#ifdef USE_SPI_DEVICE_1
+		spiInit(SPIDEV_1);
+	#endif
+	#ifdef USE_SPI_DEVICE_2
+		spiInit(SPIDEV_2);
+	#endif
+	#ifdef USE_SPI_DEVICE_3
+		spiInit(SPIDEV_3);
+	#endif
+	#ifdef USE_SPI_DEVICE_4
+		spiInit(SPIDEV_4);
+	#endif
+#endif
+
+#ifdef USE_I2C
+    #ifdef USE_I2C_DEVICE_1
+        i2cInit(I2CDEV_1);
+    #endif
+    #ifdef USE_I2C_DEVICE_3
+        i2cInit(I2CDEV_3);
+    #endif
+#endif
+}
+
+void targetPreInit(void)
+{
+	IO_t osdChSwitch = IOGetByTag(IO_TAG(OSD_CH_SWITCH));
+    IOInit(osdChSwitch, OWNER_SYSTEM, 0);
+    IOConfigGPIO(osdChSwitch, IOCFG_OUT_PP);
+	IOLo(osdChSwitch);
+}
+

--- a/src/main/target/KROOZX/target.c
+++ b/src/main/target/KROOZX/target.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+#include "drivers/dma.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM8, CH2, PC7,  TIM_USE_PPM,   TIMER_INPUT_ENABLED,  0), // PPM IN
+    DEF_TIM(TIM5, CH3, PA2,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM1
+    DEF_TIM(TIM5, CH4, PA3,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM2
+    DEF_TIM(TIM5, CH1, PA0,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM3
+    DEF_TIM(TIM5, CH2, PA1,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM4
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM5
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM6
+    DEF_TIM(TIM4, CH3, PB8,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM7
+    DEF_TIM(TIM4, CH4, PB9,  TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0), // PWM8
+    DEF_TIM(TIM8, CH1, PC6,  TIM_USE_LED, 	TIMER_OUTPUT_ENABLED, 0), // LED_STRIP
+};

--- a/src/main/target/KROOZX/target.h
+++ b/src/main/target/KROOZX/target.h
@@ -1,0 +1,159 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "KROOZX"
+
+#define CONFIG_START_FLASH_ADDRESS (0x08080000) //0x08080000 to 0x080A0000 (FLASH_Sector_8)
+#define TARGET_XTAL_MHZ         16
+
+#define USBD_PRODUCT_STRING     "KroozX"
+
+#define TARGET_CONFIG
+#define TARGET_BUS_INIT
+#define TARGET_PREINIT
+
+#define LED0                    PA14 // Red LED
+#define LED1                    PA13 // Green LED
+
+#define BEEPER                  PC1
+
+#define INVERTER_PIN_UART1      PB13
+#define INVERTER_PIN_UART6      PB12
+
+#define MPU6000_CS_PIN          PB2
+#define MPU6000_SPI_INSTANCE    SPI1
+
+// MPU6000 interrupts
+#define USE_EXTI
+#define USE_MPU_DATA_READY_SIGNAL
+#define MPU_INT_EXTI            PA4
+
+#define GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW90_DEG
+
+#define ACC
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN       CW270_DEG
+
+#define MAG
+#define USE_MAG_HMC5883
+#define MAG_HMC5883_ALIGN       CW180_DEG
+#define MAG_I2C_INSTANCE        I2CDEV_1
+
+#define BARO
+#define USE_BARO_MS5611
+
+#define USE_SDCARD
+#define SDCARD_DETECT_INVERTED
+#define SDCARD_DETECT_PIN                   PC13
+#define SDCARD_SPI_INSTANCE                 SPI3
+#define SDCARD_SPI_CS_PIN                   PA15
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER     4 // 21MHz
+
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Stream5
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA_FLAG_TCIF5
+#define SDCARD_DMA_CLK                      RCC_AHB1Periph_DMA1
+#define SDCARD_DMA_CHANNEL                  DMA_Channel_0
+
+#define OSD
+#ifdef USE_MSP_DISPLAYPORT
+#undef USE_MSP_DISPLAYPORT
+#endif
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI1
+#define MAX7456_SPI_CS_PIN      PC4
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD*2)
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#define OSD_CH_SWITCH           PC5
+
+#define BOARD_HAS_VOLTAGE_DIVIDER
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+#define VBAT_ADC_PIN            PC3
+#define CURRENT_METER_ADC_PIN   PC2
+#define RSSI_ADC_PIN            PC0
+
+#define USE_VCP
+//#define VBUS_SENSING_PIN        PA9
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PC11
+#define UART4_TX_PIN            PC10
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            PC12
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       6
+
+#define USE_I2C
+#define I2C_DEVICE              (I2CDEV_3)
+
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_I2C_DEVICE_3
+#define I2C3_SCL                PA8
+#define I2C3_SDA                PC9
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_NSS_PIN            PC4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
+#define RX_CHANNELS_TAER
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_CURRENT_METER | FEATURE_OSD)
+
+#define LED_STRIP
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 10
+#define USED_TIMERS             (TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(8))

--- a/src/main/target/KROOZX/target.mk
+++ b/src/main/target/KROOZX/target.mk
@@ -1,0 +1,9 @@
+F405_TARGETS   += $(TARGET)
+FEATURES       += VCP SDCARD
+HSE_VALUE    = 16000000
+
+TARGET_SRC = \
+            drivers/accgyro_spi_mpu6000.c \
+            drivers/barometer_ms5611.c \
+            drivers/compass_hmc5883l.c \
+            drivers/max7456.c


### PR DESCRIPTION
Ported KroozX board:
https://www.flickr.com/photos/150376428@N06/31024530144/in/dateposted-public/
I found out, that initialising OSD prior to GYRO caused falling into FAILURE_MISSING_ACC error state. Initialising OSD after GYRO solved the problem.
