### PR TITLE
Add horizon_tilt_effect command (2)

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -778,6 +778,9 @@ static const clivalue_t valueTable[] = {
 
     { "level_sensitivity",          VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelSensitivity) },
     { "level_limit",                VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10, 120 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelAngleLimit) },
+
+    { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0,  250 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_effect) },
+    { "horizon_tilt_expert_mode",   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_expert_mode) },
 #ifdef GPS
     { "gps_pos_p",                  VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, P8[PIDPOS]) },
     { "gps_pos_i",                  VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, I8[PIDPOS]) },

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -84,6 +84,9 @@ typedef struct pidProfile_s {
     uint8_t levelAngleLimit;                // Max angle in degrees in level mode
     uint8_t levelSensitivity;               // Angle mode sensitivity reflected in degrees assuming user using full stick
 
+    uint8_t horizon_tilt_effect;            // inclination factor for Horizon mode
+    uint8_t horizon_tilt_expert_mode;       // OFF or ON
+
     // Betaflight PID controller parameters
     uint16_t itermThrottleThreshold;        // max allowed throttle delta before iterm accelerated in ms
     uint16_t itermAcceleratorGain;          // Iterm Accelerator Gain when itermThrottlethreshold is hit


### PR DESCRIPTION
This is an updated version of PR #1064

This modification adds two new CLI commands, 'horizon_tilt_effect' and 'horizon_tilt_mode', which control the effect the current inclination has on self-leveling in the Horizon flight mode. With the existing horizon mode, the strength of the self-leveling is solely dependent on the stick position. This is problematic when trying to do maneuvers like large loops and fast-forward flight. Adding a factor that takes into account the current inclination of the craft provides a big improvement for these maneuvers and improves the "feel" of horizon mode.

This modification was merged by @hydra into Cleanflight and is part of the v1.4.2 release.  See [here in the CF docs](https://github.com/cleanflight/cleanflight/blob/master/docs/PID%20tuning.md#horizon-mode-commands) for details on the 'horizon_tilt_effect' and 'horizon_tilt_mode' commands.

I've posted a version of this modification applied to the 3.0.1 and 3.1.6 versions of Betaflight, with firmware files, [here](http://www.etheli.com/CF/addHorizonTiltEffect/index.html#bf).

Regarding the question of whether this modification "fits in" with Betaflight, I would say:

* While Betaflight is certainly favored by a core group of acro-only racing-oriented pilots, its user base goes well beyond that.  There are flight controllers (like the BeeBrain) that use Betaflight as their "stock" firmware.  The recent merge of Betaflight into Cleanflight-2.0 is a testament to how Betaflight has become the standard. 

* Without any changes to default settings, this modification improves the flight characteristics of Horizon mode (better "big" loops and fast-forward flight, FPV & LOS), without any drawbacks.  Why stay with a sub-par Horizon mode?

--ET