### PR TITLE
Initialise OSD after GYRO

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -448,6 +448,7 @@ void init(void)
     rxInit();
 
 #ifdef OSD
+    //The OSD need to be initialised after GYRO to avoid GYRO initialisation failure on some targets
     if (feature(FEATURE_OSD)) {
 #if defined(USE_MAX7456)
         // if there is a max7456 chip for the OSD then use it, otherwise use MSP

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -405,18 +405,6 @@ void init(void)
     }
 #endif
 
-#ifdef OSD
-    if (feature(FEATURE_OSD)) {
-#if defined(USE_MAX7456)
-        // if there is a max7456 chip for the OSD then use it, otherwise use MSP
-        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
-#elif defined(USE_MSP_DISPLAYPORT)
-        displayPort_t *osdDisplayPort = displayPortMspInit();
-#endif
-        osdInit(osdDisplayPort);
-    }
-#endif
-
     if (!sensorsAutodetect()) {
         // if gyro was not detected due to whatever reason, we give up now.
         failureMode(FAILURE_MISSING_ACC);
@@ -458,6 +446,18 @@ void init(void)
     failsafeInit();
 
     rxInit();
+
+#ifdef OSD
+    if (feature(FEATURE_OSD)) {
+#if defined(USE_MAX7456)
+        // if there is a max7456 chip for the OSD then use it, otherwise use MSP
+        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
+#elif defined(USE_MSP_DISPLAYPORT)
+        displayPort_t *osdDisplayPort = displayPortMspInit();
+#endif
+        osdInit(osdDisplayPort);
+    }
+#endif
 
 #ifdef GPS
     if (feature(FEATURE_GPS)) {


### PR DESCRIPTION
Move OSD initialisation after GYRO initialisation. It solves the problem of falling into FAILURE_MISSING_ACC mode on F4 boards with MPU6000 GYRO and MAX7456 OSD on the same SPI bus.