### PR TITLE
User selectable gyro chip (with new target AIRBOTF4SD)

### DIFF
--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -26,6 +26,7 @@
 
 #include "cms/cms.h"
 
+#include "drivers/accgyro_spi_mpu6000.h"
 #include "drivers/adc.h"
 #include "drivers/rx_pwm.h"
 #include "drivers/sound_beeper.h"
@@ -84,6 +85,9 @@
 #define channelForwardingConfig(x) (&masterConfig.channelForwardingConfig)
 #define boardAlignment(x) (&masterConfig.boardAlignment)
 #define imuConfig(x) (&masterConfig.imuConfig)
+# ifdef MPU_CS_CONFIGURABLE
+#  define mpuPinConfig(x) (&masterConfig.mpuPinConfig)
+# endif
 #define gyroConfig(x) (&masterConfig.gyroConfig)
 #define compassConfig(x) (&masterConfig.compassConfig)
 #define accelerometerConfig(x) (&masterConfig.accelerometerConfig)
@@ -225,6 +229,9 @@ typedef struct master_s {
 
     pidConfig_t pidConfig;
 
+#ifdef MPU_CS_CONFIGURABLE
+    mpuPinConfig_t mpuPinConfig;
+#endif
     gyroConfig_t gyroConfig;
     compassConfig_t compassConfig;
 

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -190,6 +190,12 @@ typedef struct mpuDetectionResult_s {
     mpu6050Resolution_e resolution;
 } mpuDetectionResult_t;
 
+#if defined(MPU_CS_CONFIGURABLE)
+typedef struct mpuPinConfig_s {
+    ioTag_t ioTagCS;
+} mpuPinConfig_t;
+#endif
+
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 struct accDev_s;

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -41,6 +41,8 @@
 #include "accgyro.h"
 #include "accgyro_mpu.h"
 
+#include "config/config_master.h"
+
 #if defined(USE_GYRO_SPI_MPU6000) || defined(USE_ACC_SPI_MPU6000)
 
 #include "accgyro_spi_mpu6000.h"
@@ -155,9 +157,12 @@ bool mpu6000SpiDetect(void)
     uint8_t in;
     uint8_t attemptsRemaining = 5;
 
-#ifdef MPU6000_CS_PIN
+#ifdef MPU_CS_CONFIGURABLE
+    mpuSpi6000CsPin = IOGetByTag(mpuPinConfig()->ioTagCS);
+#elif defined(MPU6000_CS_PIN)
     mpuSpi6000CsPin = IOGetByTag(IO_TAG(MPU6000_CS_PIN));
 #endif
+
     IOInit(mpuSpi6000CsPin, OWNER_MPU_CS, 0);
     IOConfigGPIO(mpuSpi6000CsPin, SPI_IO_CS_CFG);
 

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "drivers/accgyro.h"
+
 #define MPU6000_CONFIG              0x1A
 
 #define BITS_DLPF_CFG_256HZ         0x00
@@ -15,6 +17,12 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
+#if defined(MPU_CS_CONFIGURABLE)
+typedef struct mpuPinConfig_s {
+    ioTag_t ioTagCS;
+} mpuPinConfig_t;
+#endif
+
 bool mpu6000SpiDetect(void);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
@@ -22,3 +30,4 @@ bool mpu6000SpiGyroDetect(gyroDev_t *gyro);
 
 bool mpu6000WriteRegister(uint8_t reg, uint8_t data);
 bool mpu6000ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -17,12 +17,6 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-#if defined(MPU_CS_CONFIGURABLE)
-typedef struct mpuPinConfig_s {
-    ioTag_t ioTagCS;
-} mpuPinConfig_t;
-#endif
-
 bool mpu6000SpiDetect(void);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -34,6 +34,8 @@
 #include "accgyro_mpu6500.h"
 #include "accgyro_spi_mpu6500.h"
 
+#include "config/config_master.h"
+
 #define DISABLE_MPU6500       IOHi(mpuSpi6500CsPin)
 #define ENABLE_MPU6500        IOLo(mpuSpi6500CsPin)
 
@@ -67,7 +69,11 @@ static void mpu6500SpiInit(void)
         return;
     }
 
+#ifdef MPU_CS_CONFIGURABLE
+    mpuSpi6500CsPin = IOGetByTag(mpuPinConfig()->ioTagCS);
+#else
     mpuSpi6500CsPin = IOGetByTag(IO_TAG(MPU6500_CS_PIN));
+#endif
     IOInit(mpuSpi6500CsPin, OWNER_MPU_CS, 0);
     IOConfigGPIO(mpuSpi6500CsPin, SPI_IO_CS_CFG);
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -53,6 +53,7 @@ uint8_t cliMode = 0;
 #include "config/parameter_group_ids.h"
 
 #include "drivers/accgyro.h"
+#include "drivers/accgyro_spi_mpu6000.h"
 #include "drivers/buf_writer.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/compass.h"
@@ -4056,6 +4057,10 @@ const cliResourceValue_t resourceTable[] = {
 #endif
     { OWNER_SERIAL_TX,     &serialPinConfig()->ioTagTx[0], SERIAL_PORT_MAX_INDEX },
     { OWNER_SERIAL_RX,     &serialPinConfig()->ioTagRx[0], SERIAL_PORT_MAX_INDEX },
+#endif
+    // AIRBOTF4DG has two gyros (MPU6000 & variant) which can be selected by CS
+#if defined(MPU_CS_SELECT)
+    { OWNER_MPU_CS,        &mpuPinConfig()->ioTagCS, 0 },
 #endif
 };
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -4059,7 +4059,7 @@ const cliResourceValue_t resourceTable[] = {
     { OWNER_SERIAL_RX,     &serialPinConfig()->ioTagRx[0], SERIAL_PORT_MAX_INDEX },
 #endif
     // AIRBOTF4DG has two gyros (MPU6000 & variant) which can be selected by CS
-#if defined(MPU_CS_SELECT)
+#if defined(MPU_CS_CONFIGURABLE)
     { OWNER_MPU_CS,        &mpuPinConfig()->ioTagCS, 0 },
 #endif
 };

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -887,6 +887,11 @@ void createDefaultConfig(master_t *config)
     config->imuConfig.acc_unarmedcal = 1;
 #endif
 #ifndef USE_PARAMETER_GROUPS
+# if defined(MPU_CS_CONFIGURABLE)
+    config->mpuPinConfig.ioTagCS = IO_TAG(MPU6000_CS_PIN);
+# endif
+#endif
+#ifndef USE_PARAMETER_GROUPS
     config->gyroConfig.gyro_lpf = GYRO_LPF_256HZ;    // 256HZ default
 #ifdef STM32F10X
     config->gyroConfig.gyro_sync_denom = 8;

--- a/src/main/target/REVO/AIRBOTF4SD.mk
+++ b/src/main/target/REVO/AIRBOTF4SD.mk
@@ -1,0 +1,11 @@
+FEATURES       += VCP SDCARD
+
+TARGET_SRC += \
+            drivers/accgyro_spi_mpu6000.c \
+            drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu6500.c \
+            drivers/barometer_ms5611.c \
+            drivers/barometer_bmp280.c \
+            drivers/barometer_spi_bmp280.c \
+            drivers/compass_hmc5883l.c
+

--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -35,14 +35,27 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR, 1, 0),  // S2_OUT D1_ST2
     DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR, 1, 1),  // S3_OUT D1_ST6
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 1, 0),  // S4_OUT D1_ST1
+
+    // S5_OUT variations
 #ifdef REVOLT
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED for REVOLT D1_ST0
+#elif defined(AIRBOTF4) || defined(AIRBOTF4SD)
+    // Newer revisios of AIRBOTF4, and AIRBOTF4SD has dedicated LED strip pin.
+    // Older revisions of AIRBOTF4 must specify A1 for LED strip to work on S5_OUT.
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR, 1, 0),  // S5_OUT
 #else
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0),  // S5_OUT / LED for REVO D1_ST4
-#ifdef AIRBOTF4
+#endif
+
+    // S6_OUT variations
+#if defined(AIRBOTF4) || defined(AIRBOTF4SD)
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR, 1, 0),  // S6_OUT
 #else
     DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_MOTOR, 1, 0),  // S6_OUT D1_ST2
-#endif /* AIRBOTF4 */
-#endif /* REVOLT */
+#endif
+
+    // Newer revisions of AIRBOTF4, and AIRBOTF4SD has extra pin/timer for LED
+#if defined(AIRBOTF4) || defined(AIRBOTF4SD)
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED for AIRBOTF4SD
+#endif
 };

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -80,12 +80,12 @@
 
 
 #ifdef AIRBOTF4SD
-   // An variant of AIRBOTF4SD has dual gyro:
-   //    ICM-20601 (supported by MPU6500) with CS on PA4
-   //    MPU6000 with CS on PB13.
+// An variant of AIRBOTF4SD has dual gyro:
+//    ICM-20601 (supported by MPU6500) with CS on PA4
+//    MPU6000 with CS on PB13.
 # define MPU_CS_CONFIGURABLE
-   // Default to PA4 (ICM-20601).
-# define MPU6000_CS_PIN        PA4  // ICM20601 on PA4 (XXX Served through MPU6000 code?)
+// Default to PA4 (ICM-20601).
+# define MPU6000_CS_PIN        PA4  // Default to ICM20601 on PA4 (XXX Served through MPU6000 code???)
 //#  define MPU6000_CS_PIN       PB13 // MPU6000 on PB13
 # define MPU6000_SPI_INSTANCE    SPI1
 # define MPU6500_SPI_INSTANCE    SPI1 // Required for ICM-20601 support

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -21,6 +21,10 @@
 #define TARGET_BOARD_IDENTIFIER "AIR4"
 #define USBD_PRODUCT_STRING     "AirbotF4"
 
+#elif defined(AIRBOTF4SD)
+#define TARGET_BOARD_IDENTIFIER "A4SD"
+#define USBD_PRODUCT_STRING     "AirbotF4SD"
+
 #elif defined(REVOLT)
 #define TARGET_BOARD_IDENTIFIER "RVLT"
 #define USBD_PRODUCT_STRING     "Revolt"
@@ -52,8 +56,8 @@
 #define LED2                    PB6
 #endif
 
-// Disable LED1, conflicts with AirbotF4/Flip32F4/Revolt beeper
-#if defined(AIRBOTF4)
+// Disable LED1, conflicts with AirbotF4/AirbotF4SD/Flip32F4/Revolt beeper
+#if defined(AIRBOTF4) || defined(AIRBOTF4SD)
 #define BEEPER                  PB4
 #define BEEPER_INVERTED
 #elif defined(REVOLT)
@@ -67,14 +71,30 @@
 #define BEEPER                  NONE
 #endif
 
-// PC0 used as inverter select GPIO
-#define INVERTER_PIN_UART1      PC0
+// UART inverters
+#ifdef AIRBOTF4SD
+#  define INVERTER_PIN_UART6      PD2
+#else
+#  define INVERTER_PIN_UART1      PC0
+#endif
 
-#define MPU6000_CS_PIN          PA4
-#define MPU6000_SPI_INSTANCE    SPI1
 
-#define MPU6500_CS_PIN          PA4
-#define MPU6500_SPI_INSTANCE    SPI1
+#ifdef AIRBOTF4SD
+   // An variant of AIRBOTF4SD has dual gyro with CS on PB13.
+# define MPU_CS_CONFIGURABLE
+   // Default to PA4 (ICM-20601).
+# define MPU6000_CS_PIN        PA4  // ICM20601 on PA4
+//#  define MPU6000_CS_PIN      PB13 // MPU6000 on PB13
+# define MPU6000_SPI_INSTANCE    SPI1
+
+#else
+
+# define MPU6000_CS_PIN          PA4
+# define MPU6000_SPI_INSTANCE    SPI1
+
+# define MPU6500_CS_PIN          PA4
+# define MPU6500_SPI_INSTANCE    SPI1
+#endif
 
 #if defined(SOULF4)
 #define ACC
@@ -125,15 +145,48 @@
 #define MAG_HMC5883_ALIGN       CW90_DEG
 
 #define BARO
-#define USE_BARO_MS5611
+#ifdef AIRBOTF4SD
+#  define USE_BARO_BMP280
+#  define USE_BARO_SPI_BMP280
+#  define BMP280_SPI_INSTANCE   SPI1
+#  define BMP280_CS_PIN         PC13
+#else
+#  define USE_BARO_MS5611
+#endif
 
 #endif
+
+// SDCARD support for AIRBOTF4SD
+#if defined(AIRBOTF4SD)
+
+#  define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+#  define USE_SDCARD
+#  define USE_SDCARD_SPI3
+
+#  define SDCARD_DETECT_INVERTED
+#  define SDCARD_DETECT_PIN               PC0
+#  define SDCARD_SPI_INSTANCE             SPI3
+#  define SDCARD_SPI_CS_PIN               SPI3_NSS_PIN
+
+// SPI2 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
+#  define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+// Divide to under 25MHz for normal operation:
+#  define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER 4 // 21MHz
+
+#  define SDCARD_DMA_CHANNEL_TX               DMA1_Stream5
+#  define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA_FLAG_TCIF5
+#  define SDCARD_DMA_CLK                      RCC_AHB1Periph_DMA1
+#  define SDCARD_DMA_CHANNEL                  DMA_Channel_0
+
+#else
 
 #define M25P16_CS_PIN           PB3
 #define M25P16_SPI_INSTANCE     SPI3
 
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
+
+#endif
 
 #define USE_VCP
 #if defined(PODIUMF4)
@@ -186,6 +239,10 @@
 #define VBAT_ADC_CHANNEL        ADC_Channel_13
 #endif
 
+#if defined(AIRBOTF4SD)
+#  define RSSI_ADC_PIN          PA0
+#endif
+
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
 #if defined(PODIUMF4)
 #define SERIALRX_PROVIDER       SERIALRX_SBUS
@@ -207,12 +264,14 @@
 #ifdef REVOLT
 #define USABLE_TIMER_CHANNEL_COUNT 11
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(12) )
+
+#elif defined(AIRBOTF4) || defined(AIRBOTF4SD)
+#define USABLE_TIMER_CHANNEL_COUNT 13
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
+
 #else
 #define USABLE_TIMER_CHANNEL_COUNT 12
-#ifdef AIRBOTF4
-#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
-#else
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
-#endif // AIRBOTF4
+
 #endif // REVOLT
 

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -80,13 +80,15 @@
 
 
 #ifdef AIRBOTF4SD
-   // An variant of AIRBOTF4SD has dual gyro with CS on PB13.
+   // An variant of AIRBOTF4SD has dual gyro:
+   //    ICM-20601 (supported by MPU6500) with CS on PA4
+   //    MPU6000 with CS on PB13.
 # define MPU_CS_CONFIGURABLE
    // Default to PA4 (ICM-20601).
-# define MPU6000_CS_PIN        PA4  // ICM20601 on PA4
-//#  define MPU6000_CS_PIN      PB13 // MPU6000 on PB13
+# define MPU6000_CS_PIN        PA4  // ICM20601 on PA4 (XXX Served through MPU6000 code?)
+//#  define MPU6000_CS_PIN       PB13 // MPU6000 on PB13
 # define MPU6000_SPI_INSTANCE    SPI1
-# define MPU6500_SPI_INSTANCE    SPI1
+# define MPU6500_SPI_INSTANCE    SPI1 // Required for ICM-20601 support
 
 #else
 

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -86,6 +86,7 @@
 # define MPU6000_CS_PIN        PA4  // ICM20601 on PA4
 //#  define MPU6000_CS_PIN      PB13 // MPU6000 on PB13
 # define MPU6000_SPI_INSTANCE    SPI1
+# define MPU6500_SPI_INSTANCE    SPI1
 
 #else
 


### PR DESCRIPTION
PR status: Experimental & for discussion.

This PR includes a new target AIRBOTF4SD and cleanups of AIRBOTF4, but I want to hear thoughts about how user can select a gyro out of available two.

---
### AIRBOTF4SD (New target)

- SDCARD support has been added
- Serial RX is on UART6, has programmable inverter.
- UART6 TX also has a programmable inverter, but not used at the moment.
- BMP280 on SPI
- Support for dual gyro
A variant of AIRBOTF4SD has two gyros, ICM-20601 with CS on PA4, and MPU6000 with CS on PB13. `MPU_CS_CONFIGURABLE` will enable resource `MPU_CS` to be configurable with `resource` command. The `MPU_CS` defaults to PA4 (ICM-20601) for this particular target.

### AIRBOTF4 (Cleanup)

- Newer revisions/variants of AIRBOTF4 has a dedicaed LED strip port on PB6.
With this update, all AIRBOTF4 targets will define `PB6` as a default for LED strip;
older revisions/variants must remap `led_strip` to `PA1` (S5_OUT/PWM5/Motor5).