### PR TITLE
Unittests fails to compile with gcc/g++. clang/clang++ is required.

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -23,6 +23,10 @@ USER_INCLUDE_DIR = $(USER_DIR)
 
 OBJECT_DIR = ../../obj/test
 
+# Use clang/clang++ by default
+CC  := clang
+CXX := clang++
+
 COMMON_FLAGS = \
 	-g \
 	-Wall \


### PR DESCRIPTION
Unit tests requires clang/clang++ to compile. Some constructs in PG tests are not supported by gcc/g++
Typical error output:

    ../main/config/parameter_group.h:258:5: sorry, unimplemented: non-trivial designated initializers not supported

Until now clang/clang++ has been specified as an environment setting prior to running the tests:

    export CC=clang
    export CXX=clang++
    make test
The build system should have correct defaults and be independent from environment settings, as far as possible. This PR fixes that. 
You can still override those new defaults, for example:

    export CC=some_other_cc
    export CXX=some_other_c++
    make -e test
