### PR TITLE
Add digital_idle_percent to CMS (for v3.1.x)

### DIFF
--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -78,15 +78,31 @@ CMS_Menu cmsx_menuRcPreview = {
     .entries = cmsx_menuRcEntries
 };
 
+static uint8_t motorConfig_digitalIdleOffsetPercent;
+
+static long cmsx_menuMiscOnEnter(void)
+{
+    motorConfig_digitalIdleOffsetPercent = 10 * motorConfig()->digitalIdleOffsetPercent;
+    return 0;
+}
+
+static long cmsx_menuMiscOnExit(const OSD_Entry *self)
+{
+    UNUSED(self);
+
+    motorConfig()->digitalIdleOffsetPercent = motorConfig_digitalIdleOffsetPercent / 10.0f;
+    return 0;
+}
 
 static OSD_Entry menuMiscEntries[]=
 {
     { "-- MISC --", OME_Label, NULL, NULL, 0 },
 
-    { "MIN THR",    OME_UINT16,  NULL,          &(OSD_UINT16_t){ &motorConfig()->minthrottle,         1000, 2000, 1 }, 0 },
-    { "VBAT SCALE", OME_UINT8,   NULL,          &(OSD_UINT8_t) { &batteryConfig()->vbatscale,             1, 250, 1 }, 0 },
-    { "VBAT CLMAX", OME_UINT8,   NULL,          &(OSD_UINT8_t) { &batteryConfig()->vbatmaxcellvoltage,   10,  50, 1 }, 0 },
-    { "RC PREV",    OME_Submenu, cmsMenuChange, &cmsx_menuRcPreview, 0},
+    { "MIN THR",      OME_UINT16,  NULL,          &(OSD_UINT16_t){ &motorConfig()->minthrottle,          1000, 2000, 1 },      0 },
+    { "DIGITAL IDLE", OME_FLOAT,   NULL,          &(OSD_FLOAT_t) { &motorConfig_digitalIdleOffsetPercent,   0,  200, 1, 100 }, 0 },
+    { "VBAT SCALE",   OME_UINT8,   NULL,          &(OSD_UINT8_t) { &batteryConfig()->vbatscale,             1,  250, 1 },      0 },
+    { "VBAT CLMAX",   OME_UINT8,   NULL,          &(OSD_UINT8_t) { &batteryConfig()->vbatmaxcellvoltage,   10,   50, 1 },      0 },
+    { "RC PREV",      OME_Submenu, cmsMenuChange, &cmsx_menuRcPreview, 0},
 
     { "BACK", OME_Back, NULL, NULL, 0},
     { NULL, OME_END, NULL, NULL, 0}
@@ -95,8 +111,8 @@ static OSD_Entry menuMiscEntries[]=
 CMS_Menu cmsx_menuMisc = {
     .GUARD_text = "XMISC",
     .GUARD_type = OME_MENU,
-    .onEnter = NULL,
-    .onExit = NULL,
+    .onEnter = cmsx_menuMiscOnEnter,
+    .onExit = cmsx_menuMiscOnExit,
     .onGlobalExit = NULL,
     .entries = menuMiscEntries
 };


### PR DESCRIPTION
Backport of #2560 to v3.1. Unfortunately, I couldn't test it yet, I don't have my Taranis here. I can test it in a day or two (or maybe someone else can also give it a try).