### PR TITLE
Convert motor values at the final stage // F4 Overclocking runtime option

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -323,7 +323,7 @@ typedef struct blackboxSlowState_s {
 } __attribute__((__packed__)) blackboxSlowState_t; // We pack this struct so that padding doesn't interfere with memcmp()
 
 //From mixer.c:
-extern uint16_t motorOutputHigh, motorOutputLow;
+extern float motorOutputHigh, motorOutputLow;
 
 //From rc_controls.c
 extern uint32_t rcModeActivationMask;
@@ -1194,6 +1194,9 @@ static bool sendFieldDefinition(char mainFrameChar, char deltaFrameChar, const v
  */
 static bool blackboxWriteSysinfo()
 {
+    const uint16_t motorOutputLowInt = lrintf(motorOutputLow);
+    const uint16_t motorOutputHighInt = lrintf(motorOutputHigh);
+
     // Make sure we have enough room in the buffer for our longest line (as of this writing, the "Firmware date" line)
     if (blackboxDeviceReserveBufferSpace(64) != BLACKBOX_RESERVE_SUCCESS) {
         return false;
@@ -1209,7 +1212,7 @@ static bool blackboxWriteSysinfo()
         BLACKBOX_PRINT_HEADER_LINE("minthrottle:%d",                      motorConfig()->minthrottle);
         BLACKBOX_PRINT_HEADER_LINE("maxthrottle:%d",                      motorConfig()->maxthrottle);
         BLACKBOX_PRINT_HEADER_LINE("gyro_scale:0x%x",                     castFloatBytesToInt(1.0f));
-        BLACKBOX_PRINT_HEADER_LINE("motorOutput:%d,%d",                   motorOutputLow,motorOutputHigh);
+        BLACKBOX_PRINT_HEADER_LINE("motorOutput:%d,%d",                   motorOutputLowInt,motorOutputHighInt);
         BLACKBOX_PRINT_HEADER_LINE("acc_1G:%u",                           acc.dev.acc_1G);
 
         BLACKBOX_PRINT_HEADER_LINE_CUSTOM(

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -83,7 +83,7 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_Cmd(timer, DISABLE);
 
     /* Compute the prescaler value */
-    uint16_t prescaler = timerGetPrescalerByDesiredMhz(timer, WS2811_TIMER_MHZ);
+    uint16_t prescaler = timerGetPrescalerByDesiredHz(timer, WS2811_TIMER_MHZ * 1000000);
     uint16_t period = timerGetPeriodByPrescaler(timer, prescaler, WS2811_CARRIER_HZ);
 
     BIT_COMPARE_1 = period / 3 * 2;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -112,38 +112,38 @@ static void pwmOutConfig(pwmOutputPort_t *port, const timerHardware_t *timerHard
     *port->ccr = 0;
 }
 
-static void pwmWriteUnused(uint8_t index, uint16_t value)
+static void pwmWriteUnused(uint8_t index, float value)
 {
     UNUSED(index);
     UNUSED(value);
 }
 
-static void pwmWriteBrushed(uint8_t index, uint16_t value)
+static void pwmWriteBrushed(uint8_t index, float value)
 {
-    *motors[index].ccr = (value - 1000) * motors[index].period / 1000;
+    *motors[index].ccr = lrintf((value - 1000) * motors[index].period / 1000);
 }
 
-static void pwmWriteStandard(uint8_t index, uint16_t value)
+static void pwmWriteStandard(uint8_t index, float value)
 {
-    *motors[index].ccr = value;
+    *motors[index].ccr = lrintf(value);
 }
 
-static void pwmWriteOneShot125(uint8_t index, uint16_t value)
+static void pwmWriteOneShot125(uint8_t index, float value)
 {
-    *motors[index].ccr = lrintf((float)(value * ONESHOT125_TIMER_MHZ/8.0f));
+    *motors[index].ccr = lrintf(value * ONESHOT125_TIMER_MHZ/8.0f);
 }
 
-static void pwmWriteOneShot42(uint8_t index, uint16_t value)
+static void pwmWriteOneShot42(uint8_t index, float value)
 {
-    *motors[index].ccr = lrintf((float)(value * ONESHOT42_TIMER_MHZ/24.0f));
+    *motors[index].ccr = lrintf(value * ONESHOT42_TIMER_MHZ/24.0f);
 }
 
-static void pwmWriteMultiShot(uint8_t index, uint16_t value)
+static void pwmWriteMultiShot(uint8_t index, float value)
 {
-    *motors[index].ccr = lrintf(((float)(value-1000) * MULTISHOT_20US_MULT) + MULTISHOT_5US_PW);
+    *motors[index].ccr = lrintf(((value-1000) * MULTISHOT_20US_MULT) + MULTISHOT_5US_PW);
 }
 
-void pwmWriteMotor(uint8_t index, uint16_t value)
+void pwmWriteMotor(uint8_t index, float value)
 {
     pwmWritePtr(index, value);
 }
@@ -342,10 +342,10 @@ void pwmWriteDshotCommand(uint8_t index, uint8_t command)
 #endif
 
 #ifdef USE_SERVOS
-void pwmWriteServo(uint8_t index, uint16_t value)
+void pwmWriteServo(uint8_t index, float value)
 {
     if (index < MAX_SUPPORTED_SERVOS && servos[index].ccr) {
-        *servos[index].ccr = value;
+        *servos[index].ccr = lrintf(value);
     }
 }
 

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -104,7 +104,7 @@ motorDmaOutput_t *getMotorDmaOutput(uint8_t index);
 extern bool pwmMotorsEnabled;
 
 struct timerHardware_s;
-typedef void(*pwmWriteFuncPtr)(uint8_t index, uint16_t value);  // function pointer used to write motors
+typedef void(*pwmWriteFuncPtr)(uint8_t index, float value);  // function pointer used to write motors
 typedef void(*pwmCompleteWriteFuncPtr)(uint8_t motorCount);   // function pointer used after motors are written
 
 typedef struct {
@@ -140,16 +140,16 @@ void pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIn
 #ifdef USE_DSHOT
 uint32_t getDshotHz(motorPwmProtocolTypes_e pwmProtocolType);
 void pwmWriteDshotCommand(uint8_t index, uint8_t command);
-void pwmWriteDigital(uint8_t index, uint16_t value);
+void pwmWriteDigital(uint8_t index, float value);
 void pwmDigitalMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, motorPwmProtocolTypes_e pwmProtocolType, uint8_t output);
 void pwmCompleteDigitalMotorUpdate(uint8_t motorCount);
 #endif
 
-void pwmWriteMotor(uint8_t index, uint16_t value);
+void pwmWriteMotor(uint8_t index, float value);
 void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
 void pwmCompleteMotorUpdate(uint8_t motorCount);
 
-void pwmWriteServo(uint8_t index, uint16_t value);
+void pwmWriteServo(uint8_t index, float value);
 
 pwmOutputPort_t *pwmGetMotors(void);
 bool pwmIsSynced(void);

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -55,8 +55,9 @@ uint8_t getTimerIndex(TIM_TypeDef *timer)
     return dmaMotorTimerCount-1;
 }
 
-void pwmWriteDigital(uint8_t index, uint16_t value)
+void pwmWriteDigital(uint8_t index, float value)
 {
+    const uint16_t dshotValue = lrintf(value);
 
     if (!pwmMotorsEnabled) {
         return;
@@ -68,7 +69,7 @@ void pwmWriteDigital(uint8_t index, uint16_t value)
         return;
     }
 
-    uint16_t packet = (value << 1) | (motor->requestTelemetry ? 1 : 0);
+    uint16_t packet = (dshotValue << 1) | (motor->requestTelemetry ? 1 : 0);
     motor->requestTelemetry = false;    // reset telemetry request to make sure it's triggered only once in a row
 
     // compute checksum

--- a/src/main/drivers/pwm_output_stm32f7xx.c
+++ b/src/main/drivers/pwm_output_stm32f7xx.c
@@ -50,8 +50,10 @@ uint8_t getTimerIndex(TIM_TypeDef *timer)
     return dmaMotorTimerCount-1;
 }
 
-void pwmWriteDigital(uint8_t index, uint16_t value)
+void pwmWriteDigital(uint8_t index, float value)
 {
+    const uint16_t dshotValue = lrintf(value);
+
     if (!pwmMotorsEnabled) {
         return;
     }
@@ -62,7 +64,7 @@ void pwmWriteDigital(uint8_t index, uint16_t value)
         return;
     }
 
-    uint16_t packet = (value << 1) | (motor->requestTelemetry ? 1 : 0);
+    uint16_t packet = (dshotValue << 1) | (motor->requestTelemetry ? 1 : 0);
     motor->requestTelemetry = false;    // reset telemetry request to make sure it's triggered only once in a row
 
     // compute checksum

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -844,16 +844,16 @@ uint16_t timerDmaSource(uint8_t channel)
 }
 #endif
 
-uint16_t timerGetPrescalerByDesiredMhz(TIM_TypeDef *tim, uint16_t mhz)
+uint16_t timerGetPrescalerByDesiredHz(TIM_TypeDef *tim, uint32_t hz)
 {
     // protection here for desired MHZ > SystemCoreClock???
-    if ((uint32_t)(mhz * 1000000) > (SystemCoreClock / timerClockDivisor(tim))) {
+    if (hz > (SystemCoreClock / timerClockDivisor(tim))) {
         return 0;
     }
-    return (uint16_t)(round((SystemCoreClock / timerClockDivisor(tim) / (mhz * 1000000)) - 1));
+    return (uint16_t)(round((SystemCoreClock / timerClockDivisor(tim) / hz) - 1));
 }
 
-uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hertz)
+uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hz)
 {
-    return ((uint16_t)((SystemCoreClock / timerClockDivisor(tim) / (prescaler + 1)) / hertz));
+    return ((uint16_t)((SystemCoreClock / timerClockDivisor(tim) / (prescaler + 1)) / hz));
 }

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -198,5 +198,5 @@ void timerOCPreloadConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t preload);
 volatile timCCR_t *timerCCR(TIM_TypeDef *tim, uint8_t channel);
 uint16_t timerDmaSource(uint8_t channel);
 
-uint16_t timerGetPrescalerByDesiredMhz(TIM_TypeDef *tim, uint16_t mhz);
-uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hertz);
+uint16_t timerGetPrescalerByDesiredHz(TIM_TypeDef *tim, uint32_t hz);
+uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hz);

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -896,16 +896,16 @@ uint16_t timerDmaSource(uint8_t channel)
     return 0;
 }
 
-uint16_t timerGetPrescalerByDesiredMhz(TIM_TypeDef *tim, uint16_t mhz)
+uint16_t timerGetPrescalerByDesiredHz(TIM_TypeDef *tim, uint32_t hz)
 {
     // protection here for desired MHZ > SystemCoreClock???
-    if (mhz * 1000000 > (SystemCoreClock / timerClockDivisor(tim))) {
+    if (hz > (SystemCoreClock / timerClockDivisor(tim))) {
         return 0;
     }
-    return (uint16_t)(round((SystemCoreClock / timerClockDivisor(tim) / (mhz * 1000000)) - 1));
+    return (uint16_t)(round((SystemCoreClock / timerClockDivisor(tim) / hz) - 1));
 }
 
-uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hertz)
+uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hz)
 {
-    return ((uint16_t)((SystemCoreClock / timerClockDivisor(tim) / (prescaler + 1)) / hertz));
+    return ((uint16_t)((SystemCoreClock / timerClockDivisor(tim) / (prescaler + 1)) / hz));
 }

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -842,7 +842,9 @@ static const clivalue_t valueTable[] = {
     { "task_statistics",            VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, task_statistics) },
 #endif
     { "debug_mode",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DEBUG }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, debug_mode) },
-
+#ifdef STM32F4
+    { "cpu_overclock",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, cpu_overclock) },
+#endif
 // PG_VTX_CONFIG
 #ifdef VTX
     { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 5 }, PG_VTX_CONFIG, offsetof(vtxConfig_t, vtx_band) },

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -123,6 +123,7 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .activeRateProfile = 0,
     .debug_mode = DEBUG_MODE,
     .task_statistics = true,
+    .cpu_overclock = false,
     .name = { 0 }
 );
 

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -68,6 +68,7 @@ typedef struct systemConfig_s {
     uint8_t activeRateProfile;
     uint8_t debug_mode;
     uint8_t task_statistics;
+    uint8_t cpu_overclock;
     char name[MAX_NAME_LENGTH + 1];
 } systemConfig_t;
 

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -167,6 +167,15 @@ void init(void)
 
     printfSupportInit();
 
+    initEEPROM();
+
+    ensureEEPROMContainsValidData();
+    readEEPROM();
+
+#if defined(STM32F4)
+    initOcSettings(systemConfig()->cpu_overclock);
+#endif
+
     systemInit();
 
     // initialize IO (needed for all IO operations)
@@ -179,11 +188,6 @@ void init(void)
 #ifdef BRUSHED_ESC_AUTODETECT
     detectBrushedESC();
 #endif
-
-    initEEPROM();
-
-    ensureEEPROMContainsValidData();
-    readEEPROM();
 
     systemState |= SYSTEM_STATE_CONFIG_LOADED;
 

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -118,8 +118,8 @@ PG_DECLARE(motorConfig_t, motorConfig);
 #define CHANNEL_FORWARDING_DISABLED (uint8_t)0xFF
 
 extern const mixer_t mixers[];
-extern int16_t motor[MAX_SUPPORTED_MOTORS];
-extern int16_t motor_disarmed[MAX_SUPPORTED_MOTORS];
+extern float motor[MAX_SUPPORTED_MOTORS];
+extern float motor_disarmed[MAX_SUPPORTED_MOTORS];
 struct rxConfig_s;
 
 uint8_t getMotorCount();
@@ -139,5 +139,5 @@ void stopMotors(void);
 void stopPwmAllMotors(void);
 
 bool isMotorProtocolDshot(void);
-uint16_t convertExternalToMotor(uint16_t externalValue);
-uint16_t convertMotorToExternal(uint16_t motorValue);
+float convertExternalToMotor(uint16_t externalValue);
+uint16_t convertMotorToExternal(float motorValue);

--- a/src/main/startup/startup_stm32f40xx.s
+++ b/src/main/startup/startup_stm32f40xx.s
@@ -135,7 +135,7 @@ LoopMarkHeapStack:
  str     r1,[r0]
 
 /* Call the clock system intitialization function.*/
-  bl  SystemInit   
+/*  bl  SystemInit   */
 
 /* Call the application's entry point.*/
   bl  main

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -273,7 +273,7 @@ static uint8_t activeBoxIds[CHECKBOX_ITEM_COUNT];
 // this is the number of filled indexes in above array
 static uint8_t activeBoxIdCount = 0;
 // from mixer.c
-extern int16_t motor_disarmed[MAX_SUPPORTED_MOTORS];
+extern float motor_disarmed[MAX_SUPPORTED_MOTORS];
 
 // cause reboot after BST processing complete
 static bool isRebootScheduled = false;

--- a/src/main/target/system_stm32f4xx.c
+++ b/src/main/target/system_stm32f4xx.c
@@ -405,6 +405,23 @@ uint32_t hse_value = HSE_VALUE;
 #define PLL_Q      8
 #endif /* STM32F410xx || STM32F411xE */
 
+uint32_t SystemCoreClock;
+uint32_t pll_p = PLL_P, pll_n = PLL_N, pll_q = PLL_Q;
+
+void initOcSettings(uint8_t oc) {
+#if defined (STM32F40_41xxx)  // TODO - Add other MCU's later as well
+    if(oc) {
+        pll_n = 480;
+        pll_p = 2;
+        pll_q = 10;
+    }
+#else
+    (void)(oc);
+#endif
+  /* core clock is simply a mhz of PLL_N / PLL_P */
+  SystemCoreClock = (pll_n / pll_p) * 1000000;
+}
+
 /******************************************************************************/
 
 /**
@@ -422,8 +439,6 @@ uint32_t hse_value = HSE_VALUE;
 /** @addtogroup STM32F4xx_System_Private_Variables
   * @{
   */
-/* core clock is simply a mhz of PLL_N / PLL_P */
-uint32_t SystemCoreClock = (PLL_N / PLL_P) * 1000000;
 
 __I uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
 
@@ -673,12 +688,12 @@ void SetSysClock(void)
 
 #if defined(STM32F446xx)
     /* Configure the main PLL */
-    RCC->PLLCFGR = PLL_M | (PLL_N << 6) | (((PLL_P >> 1) -1) << 16) |
-                   (RCC_PLLCFGR_PLLSRC_HSE) | (PLL_Q << 24) | (PLL_R << 28);
+    RCC->PLLCFGR = PLL_M | (pll_n << 6) | (((pll_p >> 1) -1) << 16) |
+                   (RCC_PLLCFGR_PLLSRC_HSE) | (pll_q << 24) | (PLL_R << 28);
 #else
     /* Configure the main PLL */
-    RCC->PLLCFGR = PLL_M | (PLL_N << 6) | (((PLL_P >> 1) -1) << 16) |
-                   (RCC_PLLCFGR_PLLSRC_HSE) | (PLL_Q << 24);
+    RCC->PLLCFGR = PLL_M | (pll_n << 6) | (((pll_p >> 1) -1) << 16) |
+                   (RCC_PLLCFGR_PLLSRC_HSE) | (pll_q << 24);
 #endif /* STM32F446xx */
 
     /* Enable the main PLL */

--- a/src/main/target/system_stm32f4xx.h
+++ b/src/main/target/system_stm32f4xx.h
@@ -35,6 +35,7 @@
 extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Clock) */
 extern void SystemInit(void);
 extern void SystemCoreClockUpdate(void);
+extern void initOcSettings(uint8_t oc);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Since we already have all logic in floats it would be better to perform the conversion to int where needed as the final step to maintain the highest resolution at all times.