### PR TITLE
BlueJayF4: removed softserial 2

### DIFF
--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -114,9 +114,7 @@
 #define SOFTSERIAL1_RX_PIN      PB0 // PWM5
 #define SOFTSERIAL1_TX_PIN      PB1 // PWM6
 
-#define USE_SOFTSERIAL2
-
-#define SERIAL_PORT_COUNT       6
+#define SERIAL_PORT_COUNT       5
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1


### PR DESCRIPTION
BlueJayF4 (any revision) hasn't pins for softserial 2