### PR TITLE
Compile warnings on unused cliVtx() fixed.

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3236,6 +3236,7 @@ static void printVtx(uint8_t dumpMask, const vtxConfig_t *vtxConfig, const vtxCo
     }
 }
 
+#ifdef VTX
 static void cliVtx(char *cmdline)
 {
     int i, val = 0;
@@ -3283,6 +3284,7 @@ static void cliVtx(char *cmdline)
         }
     }
 }
+#endif // VTX
 #endif
 
 static void printName(uint8_t dumpMask)


### PR DESCRIPTION
Complier warned on unused cliVtx() function for targets FISHDRONEF4 and SIRINFPV.
Added compile condition to make the reference and definition consistent, i.e. using the the same condition.
Explicit dead code removal as well. However, the linker might have done that anyhow.

Too bad, we had a 9 day streak without warnings that was broken.
