### PR TITLE
Fixed USB disconnect (pull LOW for 200 ms)

### DIFF
--- a/src/main/drivers/usb_io.c
+++ b/src/main/drivers/usb_io.c
@@ -68,10 +68,10 @@ void usbGenerateDisconnectPulse(void)
     IO_t usbPin = IOGetByTag(IO_TAG(PA12));
     IOConfigGPIO(usbPin, IOCFG_OUT_OD);
 
-    IOHi(usbPin);
+    IOLo(usbPin);
 
     delay(200);
 
-    IOLo(usbPin);
+    IOHi(usbPin);
 }
 #endif


### PR DESCRIPTION
New code was pulling PA12 HIGH instead of LOW, tested on PIKOBLX after fixing. Tests on BlueJay and other VCP targets are welcome.

Fixes #2602.