### PR TITLE
Fix F4 Connectivity

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -125,6 +125,7 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
 #endif
 
     serialConfig->reboot_character = 'R';
+    serialConfig->serial_update_rate_hz = 100;
 }
 
 baudRate_e lookupBaudRateIndex(uint32_t baudRate)


### PR DESCRIPTION
serialConfig reset function was lacking assignment to `serial_update_rate_hz` which is used in `fc_tasks.c` for a call to `rescheduleTask`.
This lead to serial task not being invoked at all on F4 and presumably F7 targets.

Summoning @martinbudden @borisbstyle 