### PR TITLE
Usable DSHOT on SINGULARITY target (motors 1-4 only)

### DIFF
--- a/src/main/target/SINGULARITY/target.c
+++ b/src/main/target/SINGULARITY/target.c
@@ -27,11 +27,11 @@
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2,  CH1, PA15, TIM_USE_PWM | TIM_USE_PPM,   0), // PPM/SERIAL RX
     DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_PWM,                 0), // PWM1
-    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_PWM,                 0), // PWM2
+    DEF_TIM(TIM17, CH1, PB5,  TIM_USE_PWM,                 0), // PWM2
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_PWM,                 0), // PWM3
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_PWM,                 0), // PWM4
     DEF_TIM(TIM16, CH1, PB8,  TIM_USE_MOTOR,               1), // PWM5
-    DEF_TIM(TIM17, CH1, PB9,  TIM_USE_MOTOR,               1), // PWM6
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_MOTOR,               1), // PWM6
     DEF_TIM(TIM15, CH1, PA2,  TIM_USE_MOTOR,               1), // SOFTSERIAL1 RX (NC)
     DEF_TIM(TIM15, CH2, PA3,  TIM_USE_MOTOR,               1), // SOFTSERIAL1 TX
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR | TIM_USE_LED, 1), // LED_STRIP


### PR DESCRIPTION
I recently flashed 3.1.6 on my Singularity. Motor outputs didn't work, but that seems to have been fixed already by @sblakemore [1] and thanks to the resource command it can be remedied in 3.1.6 [2].

However when trying to setup Dshot, I noticed that only motor 2 wouldn't spin up. After some investigation, it appears that PB5 can't use DMA on TIM3_CH2.

By using TIM17_CH1 from motor 6, Dshot becomes usable on motors 1-4 which suits my purpose. I have assigned TIM4_CH4 to motor 6 now based on the datasheet, but since I have a quad this has not been tested (and it wouldn't run Dshot anyway).

With this small change I have now flown Dshot on my quad (using the Racerstar 4in1 ESC). Edit: just flew 6 packs on this branch without experiencing any issues.

I based my commit on 3.1.7, because in 3.2.0 serial input was not working: my AUX channels were registering fine, but my 4 sticks all stayed stuck at 1000 (in the RX tab). And when arming the motors just went to 100%.

[1] https://github.com/betaflight/betaflight/pull/2530
[2] https://www.rcgroups.com/forums/showpost.php?p=36946396&postcount=45513