### PR TITLE
IO: Handle NONE (NULL) io pin

### DIFF
--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -238,6 +238,8 @@ void IOToggle(IO_t io)
 // claim IO pin, set owner and resources
 void IOInit(IO_t io, resourceOwner_e owner, uint8_t index)
 {
+    if (!io)
+        return;
     ioRec_t *ioRec = IO_Rec(io);
     ioRec->owner = owner;
     ioRec->index = index;
@@ -245,12 +247,16 @@ void IOInit(IO_t io, resourceOwner_e owner, uint8_t index)
 
 void IORelease(IO_t io)
 {
+    if (!io)
+        return;
     ioRec_t *ioRec = IO_Rec(io);
     ioRec->owner = OWNER_FREE;
 }
 
 resourceOwner_e IOGetOwner(IO_t io)
 {
+    if (!io)
+        return OWNER_FREE;
     ioRec_t *ioRec = IO_Rec(io);
     return ioRec->owner;
 }

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -115,7 +115,7 @@ static void handleUsartTxDma(dmaChannelDescriptor_t* descriptor)
 
 void serialUARTInit(IO_t tx, IO_t rx, portMode_t mode, portOptions_t options, uint8_t af, uint8_t index)
 {
-    if (options & SERIAL_BIDIR) {
+    if ((options & SERIAL_BIDIR) && tx) {
         ioConfig_t ioCfg = IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz,
             ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP)) ? GPIO_OType_PP : GPIO_OType_OD,
             ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP)) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP
@@ -128,12 +128,12 @@ void serialUARTInit(IO_t tx, IO_t rx, portMode_t mode, portOptions_t options, ui
             IOLo(tx);   // OpenDrain output should be inactive
     } else {
         ioConfig_t ioCfg = IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_PP, (options & SERIAL_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP);
-        if (mode & MODE_TX) {
+        if ((mode & MODE_TX) && tx) {
             IOInit(tx, OWNER_SERIAL_TX, index);
             IOConfigGPIOAF(tx, ioCfg, af);
         }
 
-        if (mode & MODE_RX) {
+        if ((mode & MODE_RX) && rx) {
             IOInit(rx, OWNER_SERIAL_RX, index);
             IOConfigGPIOAF(rx, ioCfg, af);
         }

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -329,12 +329,12 @@ uartPort_t *serialUART(UARTDevice device, uint32_t baudRate, portMode_t mode, po
             IOConfigGPIOAF(tx, IOCFG_AF_OD, uart->af);
     }
     else {
-        if (mode & MODE_TX) {
+        if ((mode & MODE_TX) && tx) {
             IOInit(tx, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
             IOConfigGPIOAF(tx, IOCFG_AF_PP_UP, uart->af);
         }
 
-        if (mode & MODE_RX) {
+        if ((mode & MODE_RX) && rx) {
             IOInit(rx, OWNER_SERIAL_RX, RESOURCE_INDEX(device));
             IOConfigGPIOAF(rx, IOCFG_AF_PP_UP, uart->af);
         }

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -405,17 +405,17 @@ uartPort_t *serialUART(UARTDevice device, uint32_t baudRate, portMode_t mode, po
     IO_t tx = IOGetByTag(uart->tx);
     IO_t rx = IOGetByTag(uart->rx);
 
-    if (options & SERIAL_BIDIR) {
+    if ((options & SERIAL_BIDIR) && tx) {
         IOInit(tx, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->af);
     }
     else {
-        if (mode & MODE_TX) {
+        if ((mode & MODE_TX) && tx) {
             IOInit(tx, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
             IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->af);
         }
 
-        if (mode & MODE_RX) {
+        if ((mode & MODE_RX) && rx) {
             IOInit(rx, OWNER_SERIAL_RX, RESOURCE_INDEX(device));
             IOConfigGPIOAF(rx, IOCFG_AF_PP, uart->af);
         }


### PR DESCRIPTION
This was creating a problem with BrainFPV RE1, which doesn't have a pin assigned to UART3 Tx (as the UART is dedicated to be used for receivers).

Most other IO functions have the null handling, so it makes sense for IOInit etc to have it as well.