### PR TITLE
Add average cell voltage to OSD

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -105,6 +105,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"--- ACTIV ELEM ---", OME_Label, NULL, NULL, 0},
     {"RSSI", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
     {"MAIN BATTERY", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
+    {"AVG CELL VOLTAGE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], 0},
     {"HORIZON", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ARTIFICIAL_HORIZON], 0},
     {"HORIZON SIDEBARS", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HORIZON_SIDEBARS], 0},
     {"UPTIME", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ONTIME], 0},

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -835,6 +835,7 @@ static const clivalue_t valueTable[] = {
     { "osd_power_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_POWER]) },
     { "osd_pidrate_profile_pos",    VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_PIDRATE_PROFILE]) },
     { "osd_battery_warning_pos",    VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_WARNING]) },
+    { "osd_avg_cell_voltage_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_AVG_CELL_VOLTAGE]) },
 #endif
 
 // PG_SYSTEM_CONFIG

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -409,6 +409,14 @@ static void osdDrawSingleElement(uint8_t item)
             break;
         }
 
+	case OSD_AVG_CELL_VOLTAGE:
+        {
+            uint16_t cellV = getVbat() * 10 / batteryCellCount;
+            buff[0] = SYM_BATT_5;
+            sprintf(buff + 1, "%d.%dV", cellV / 100, cellV % 100);
+            break;
+        }
+
         default:
             return;
     }
@@ -458,6 +466,7 @@ void osdDrawElements(void)
     osdDrawSingleElement(OSD_POWER);
     osdDrawSingleElement(OSD_PIDRATE_PROFILE);
     osdDrawSingleElement(OSD_MAIN_BATT_WARNING);
+    osdDrawSingleElement(OSD_AVG_CELL_VOLTAGE);
 
 #ifdef GPS
 #ifdef CMS
@@ -495,6 +504,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdProfile)
     osdProfile->item_pos[OSD_POWER] = OSD_POS(15, 1);
     osdProfile->item_pos[OSD_PIDRATE_PROFILE] = OSD_POS(2, 13);
     osdProfile->item_pos[OSD_MAIN_BATT_WARNING] = OSD_POS(8, 6);
+    osdProfile->item_pos[OSD_MAIN_BATT_VOLTAGE] = OSD_POS(12, 0);
 
     osdProfile->rssi_alarm = 20;
     osdProfile->cap_alarm = 2200;
@@ -556,9 +566,11 @@ void osdUpdateAlarms(void)
     if (getVbat() <= (batteryWarningVoltage - 1)) {
         SET_BLINK(OSD_MAIN_BATT_VOLTAGE);
         SET_BLINK(OSD_MAIN_BATT_WARNING);
+        SET_BLINK(OSD_AVG_CELL_VOLTAGE);
     } else {
         CLR_BLINK(OSD_MAIN_BATT_VOLTAGE);
         CLR_BLINK(OSD_MAIN_BATT_WARNING);
+        CLR_BLINK(OSD_AVG_CELL_VOLTAGE);
     }
 
     if (STATE(GPS_FIX) == 0)
@@ -591,6 +603,7 @@ void osdResetAlarms(void)
     CLR_BLINK(OSD_FLYTIME);
     CLR_BLINK(OSD_MAH_DRAWN);
     CLR_BLINK(OSD_ALTITUDE);
+    CLR_BLINK(OSD_AVG_CELL_VOLTAGE);
 }
 
 static void osdResetStats(void)

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -48,6 +48,7 @@ typedef enum {
     OSD_POWER,
     OSD_PIDRATE_PROFILE,
     OSD_MAIN_BATT_WARNING,
+    OSD_AVG_CELL_VOLTAGE,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
This can make it a little easier for some pilots to see where their
battery is at, especially if they move forth and back between different
cell counts a lot.