### PR TITLE
fix missing yaw default when using PGs.

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -76,7 +76,8 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .deadband = 0,
     .yaw_deadband = 0,
     .alt_hold_deadband = 40,
-    .alt_hold_fast_change = 1
+    .alt_hold_fast_change = 1,
+    .yaw_control_direction = 1,
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 0);


### PR DESCRIPTION
this resulted in no yaw from RC input.

from https://github.com/cleanflight/cleanflight/pull/2657