### PR TITLE
Give cell voltage element a default position

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -504,7 +504,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdProfile)
     osdProfile->item_pos[OSD_POWER] = OSD_POS(15, 1);
     osdProfile->item_pos[OSD_PIDRATE_PROFILE] = OSD_POS(2, 13);
     osdProfile->item_pos[OSD_MAIN_BATT_WARNING] = OSD_POS(8, 6);
-    osdProfile->item_pos[OSD_MAIN_BATT_VOLTAGE] = OSD_POS(12, 0);
+    osdProfile->item_pos[OSD_AVG_CELL_VOLTAGE] = OSD_POS(12, 0);
 
     osdProfile->rssi_alarm = 20;
     osdProfile->cap_alarm = 2200;


### PR DESCRIPTION
This is a follow-up to a151d5092, which got merged with a copy-and-paste
error. Sorry about that!

This PR previously got merged as https://github.com/betaflight/betaflight/pull/2687 but seems to have been accidentally reverted since.