### PR TITLE
VTX RTC6705 new power selector PITMODE, 25mW, 200mW and 400mW

### DIFF
--- a/src/main/cms/cms_menu_vtx.c
+++ b/src/main/cms/cms_menu_vtx.c
@@ -50,7 +50,7 @@ static uint8_t cmsx_vtxChannel;
 static uint8_t cmsx_vtxMode;
 static uint16_t cmsx_vtxMhz;
 #endif
-static bool cmsx_vtxPower;
+static uint8_t cmsx_vtxPower;
 
 static long cmsx_Vtx_FeatureRead(void)
 {
@@ -81,9 +81,16 @@ static const char * const vtxBandNames[] = {
     "FATSHARK",
     "RACEBAND",
 };
+static const char * const vtxPowerNames[] = {
+    "PIT MODE", //1dBm
+    "25mW",
+    "200mW",
+    "400mW"
+};
 
 static OSD_TAB_t entryVtxBand = {&cmsx_vtxBand,4,&vtxBandNames[0]};
 static OSD_UINT8_t entryVtxChannel =  {&cmsx_vtxChannel, 1, 8, 1};
+static OSD_TAB_t entryVtxPower =  {&cmsx_vtxPower, 3, &vtxPowerNames[0]};
 #ifdef VTX
 static OSD_UINT8_t entryVtxMode =  {&cmsx_vtxMode, 0, 2, 1};
 static OSD_UINT16_t entryVtxMhz =  {&cmsx_vtxMhz, 5600, 5950, 1};
@@ -149,7 +156,8 @@ static OSD_Entry cmsx_menuVtxEntries[] =
     {"BAND", OME_TAB, NULL, &entryVtxBand, 0},
     {"CHANNEL", OME_UINT8, NULL, &entryVtxChannel, 0},
 #ifdef USE_RTC6705
-    {"LOW POWER", OME_Bool, NULL, &cmsx_vtxPower, 0},
+    {"POWER", OME_TAB, NULL, &entryVtxPower, 0},
+    //{"LOW POWER", OME_Bool, NULL, &cmsx_vtxPower, 0},
 #endif // USE_RTC6705
     {"BACK", OME_Back, NULL, NULL, 0},
     {NULL, OME_END, NULL, NULL, 0}

--- a/src/main/drivers/vtx_soft_spi_rtc6705.c
+++ b/src/main/drivers/vtx_soft_spi_rtc6705.c
@@ -123,7 +123,21 @@ void rtc6705_soft_spi_set_channel(uint16_t channel_freq)
 
 void rtc6705_soft_spi_set_rf_power(uint8_t reduce_power)
 {
-    rtc6705_write_register(7, (reduce_power ? (PA_CONTROL_DEFAULT | PD_Q5G_MASK) & (~(PA5G_PW_MASK | PA5G_BS_MASK)) : PA_CONTROL_DEFAULT));
+    switch(reduce_power)
+    {
+        case 0:// 1dBm
+            rtc6705_write_register(7, 0x006A);
+            break;
+        case 1:// 14dBm
+            rtc6705_write_register(7, 0x4C7D);
+            break;
+        case 2:// 23dBm
+            rtc6705_write_register(7, 0x4D0D);
+            break;
+        case 3:// 27dBm
+            rtc6705_write_register(7, 0x4FBD);
+            break;
+    }
 }
 
 #endif

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -859,7 +859,7 @@ static const clivalue_t valueTable[] = {
 #endif
 #if defined(USE_RTC6705)
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 39 }, PG_VTX_CONFIG, offsetof(vtxConfig_t, vtx_channel) },
-    { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 1 }, PG_VTX_CONFIG, offsetof(vtxConfig_t, vtx_power) },
+    { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 3 }, PG_VTX_CONFIG, offsetof(vtxConfig_t, vtx_power) },
 #endif
 
 // PG_VCD_CONFIG


### PR DESCRIPTION
VTX RTC6705 new power selector PITMODE, 25mW, 200mW and 400mW, these values are already tested using a FISHTOWERF4 using the firmware FISHDRONEF4. 