### PR TITLE
BFF3, fix ibat_scale reset default problem.

### DIFF
--- a/src/main/target/BETAFLIGHTF3/config.c
+++ b/src/main/target/BETAFLIGHTF3/config.c
@@ -38,8 +38,6 @@
 
 void targetConfiguration(master_t *config)
 {
-    UNUSED(config);
-
-    batteryConfig->currentMeterScale = 220;
+    config->batteryConfig.currentMeterScale = 220;
 }
 #endif


### PR DESCRIPTION
Fixes the problem with reset of  target specific ibat_scale parameter when doing a diff etc, mentioned in #2655 
This PR is directed towards 3.1.7, should probably also be merged into master/3.2.0
