### PR TITLE
Bf cleanup travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+FC_VER_MAJOR=$(grep " FC_VERSION_MAJOR" src/main/build/version.h | awk '{print $3}' )
+FC_VER_MINOR=$(grep " FC_VERSION_MINOR" src/main/build/version.h | awk '{print $3}' )
+FC_VER_PATCH=$(grep " FC_VERSION_PATCH" src/main/build/version.h | awk '{print $3}' )
+FC_VER="${FC_VER_MAJOR}.${FC_VER_MINOR}.${FC_VER_PATCH}"
+
 REVISION=$(git rev-parse --short HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 REVISION=$(git rev-parse --short HEAD)
 LAST_COMMIT_DATE=$(git log -1 --date=short --format="%cd")
-TARGET_FILE=obj/betaflight_${TARGET}
+TARGET_FILE=obj/betaflight_${FC_VER}_${TARGET}
 TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
 BUILDNAME=${BUILDNAME:=travis}
 TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
@@ -47,21 +52,24 @@ elif [ $PUBLISHMETA ] ; then
 
 elif [ $TARGET ] ; then
     make $TARGET
-	if [ $PUBLISH_URL ] ; then
-		if   [ -f ${TARGET_FILE}.bin ] ; then
-			TARGET_FILE=${TARGET_FILE}.bin
-		elif [ -f ${TARGET_FILE}.hex ] ; then
-			TARGET_FILE=${TARGET_FILE}.hex
-		else
-			echo "build artifact (hex or bin) for ${TARGET_FILE} not found, aborting";
-			exit 1
-		fi
 
+	if   [ -f ${TARGET_FILE}.bin ] ; then
+		TARGET_FILE=${TARGET_FILE}.bin
+	elif [ -f ${TARGET_FILE}.hex ] ; then
+		TARGET_FILE=${TARGET_FILE}.hex
+	else
+		echo "build artifact (hex or bin) for ${TARGET_FILE} not found, aborting";
+		exit 1
+	fi
+
+	if [ $PUBLISH_URL ] ; then
 		curl -k "${CURL_BASEOPTS[@]}" "${CURL_PUB_BASEOPTS[@]}" --form "file=@${TARGET_FILE}" ${PUBLISH_URL} || true
 		exit 0;
 	fi
+
 elif [ $GOAL ] ; then
     make V=0 $GOAL
+
 else 
     make V=0 all
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,64 +4,19 @@ env:
 #  - PUBLISHDOCS=True
 # Specify the main Mafile supported goals.
   - GOAL=test
-  - GOAL=all
+  # - GOAL=targets-group-1
+  # - GOAL=targets-group-2
+  # - GOAL=targets-group-3
+  # - GOAL=targets-group-rest
+#  - GOAL=all
+#  - GOAL=AFROMINI
+#  - GOAL=AIORACERF3
+#  - GOAL=...
 # Or specify targets to run.
-#  - TARGET=AFROMINI
-#  - TARGET=AIORACERF3
-#  - TARGET=AIR32
-#  - TARGET=AIRBOTF4
-#  - TARGET=AIRHEROF3
-#  - TARGET=ALIENFLIGHTF1
-#  - TARGET=ALIENFLIGHTF3
-#  - TARGET=ALIENFLIGHTF4
-#  - TARGET=ANYFCF7
-#  - TARGET=BEEBRAIN
-#  - TARGET=BETAFLIGHTF3
-#  - TARGET=BLUEJAYF4
-#  - TARGET=CC3D
-#  - TARGET=CC3D_OPBL
-#  - TARGET=CHEBUZZF3
-#  - TARGET=CJMCU
-#  - TARGET=COLIBRI
-#  - TARGET=COLIBRI_OPBL
-#  - TARGET=COLIBRI_RACE
-#  - TARGET=DOGE
-#  - TARGET=F4BY
-#  - TARGET=FURYF3
-#  - TARGET=FURYF4
-#  - TARGET=FURYF7
-#  - TARGET=IMPULSERCF3
-#  - TARGET=IRCFUSIONF3
-#  - TARGET=ISHAPEDF3
-#  - TARGET=KISSFC
-#  - TARGET=LUXV2_RACE
-#  - TARGET=LUX_RACE
-#  - TARGET=MICROSCISKY
-#  - TARGET=MOTOLAB
-#  - TARGET=NAZE
-#  - TARGET=OMNIBUS
-#  - TARGET=OMNIBUSF4
-#  - TARGET=PIKOBLX
-#  - TARGET=RACEBASE
-#  - TARGET=RCEXPLORERF3
-#  - TARGET=REVO
-#  - TARGET=REVOLT
-#  - TARGET=REVONANO
-#  - TARGET=REVO_OPBL
-#  - TARGET=RMDO
-#  - TARGET=SINGULARITY
-#  - TARGET=SIRINFPV
-#  - TARGET=SOULF4
-#  - TARGET=SPARKY
-#  - TARGET=SPARKY2
-#  - TARGET=SPRACINGF3
-#  - TARGET=SPRACINGF3EVO
-#  - TARGET=SPRACINGF3MINI
-#  - TARGET=STM32F3DISCOVERY
-#  - TARGET=VRRACE
-#  - TARGET=X_RACERSPI
-#  - TARGET=YUPIF4
-#  - TARGET=ZCOREF3
+# - TARGET=AFROMINI
+# - TARGET=AIORACERF3
+#  - TARGET=...
+
 
 # use new docker environment
 sudo: false
@@ -105,4 +60,4 @@ notifications:
       - https://webhooks.gitter.im/e/0c20f7a1a7e311499a88
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: always     # options: [always|never|change] default: always
+    on_start:   always  # options: [always|never|change] default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ env:
 #  - PUBLISHDOCS=True
 # Specify the main Mafile supported goals.
   - GOAL=test
-  # - GOAL=targets-group-1
-  # - GOAL=targets-group-2
-  # - GOAL=targets-group-3
-  # - GOAL=targets-group-rest
+  - GOAL=targets-group-1
+  - GOAL=targets-group-2
+  - GOAL=targets-group-3
+  - GOAL=targets-group-4
+  - GOAL=targets-group-rest
 #  - GOAL=all
 #  - GOAL=AFROMINI
 #  - GOAL=AIORACERF3
@@ -28,6 +29,7 @@ addons:
   apt:
     packages:
       - libc6-i386
+      - time
 
 # We use cpp for unit tests, and c for the main project.
 language: cpp
@@ -48,6 +50,7 @@ cache:
   - downloads
   - tools
     
+
 #notifications:
 #  irc: "chat.freenode.net#cleanflight"
 #  use_notice: true

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,85 @@ VALID_TARGETS  := $(subst /,, $(subst ./src/main/target/,, $(VALID_TARGETS)))
 VALID_TARGETS  := $(VALID_TARGETS) $(ALT_TARGETS)
 VALID_TARGETS  := $(sort $(VALID_TARGETS))
 
+GROUP_1_TARGETS := \
+	AFROMINI \
+	AIORACERF3 \
+	AIR32  \
+	AIRBOTF4  \
+	AIRHEROF3  \
+	ALIENFLIGHTF1  \
+	ALIENFLIGHTF3 \
+	ALIENFLIGHTF4 \
+	ALIENFLIGHTNGF7 \
+	ANYFCF7  \
+	BEEBRAIN  \
+	BEEROTORF4 \
+	BETAFLIGHTF3 \
+	CC3D \
+	CC3D_OPBL  \
+	CHEBUZZF3 \
+	CJMCU \
+	CL_RACINGF4 \
+	COLIBRI \
+
+GROUP_2_TARGETS := \
+	COLIBRI_OPBL \
+	COLIBRI_RACE \
+	DOGE \
+	ELLE0 \
+	F4BY \
+	FISHDRONEF4  \
+	FLIP32F3OSD \
+	FURYF3 \
+	FURYF4 \
+	FURYF7 \
+	IMPULSERCF3 \
+	IRCFUSIONF3 \
+	ISHAPEDF3 \
+	BLUEJAYF4 \
+	KAKUTEF4 \
+	KISSCC \
+
+GROUP_3_TARGETS := \
+	KIWIF4 \
+	LUX_RACE \
+	LUXV2_RACE \
+	MICROSCISKY \
+	MOTOLAB  \
+	MULTIFLITEPICO \
+	NAZE \
+	NERO \
+	OMNIBUS \
+	OMNIBUSF4SD \
+	PIKOBLX \
+	PLUMF4 \
+	PODIUMF4 \
+	RACEBASE  \
+	RCEXPLORERF3 \
+	REVO \
+	REVO_OPBL \
+	REVOLT \
+	REVONANO \
+
+GROUP_4_TARGETS := \
+	RMDO \
+	SINGULARITY \
+	SIRINFPV   \
+	SOULF4 \
+	SPARKY \
+	SPARKY2 \
+	SPRACINGF3 \
+	SPRACINGF3EVO \
+	SPRACINGF3MINI \
+	SPRACINGF3NEO \
+	KROOZX \
+	NUCLEOF7 \
+	OMNIBUSF4 \
+	STM32F3DISCOVERY \
+
+GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS) $(GROUP_4_TARGETS), $(VALID_TARGETS))
+
+
 ifeq ($(filter $(TARGET),$(ALT_TARGETS)), $(TARGET))
 BASE_TARGET    := $(firstword $(subst /,, $(subst ./src/main/target/,, $(dir $(wildcard $(ROOT)/src/main/target/*/$(TARGET).mk)))))
 -include $(ROOT)/src/main/target/$(BASE_TARGET)/$(TARGET).mk
@@ -1102,16 +1181,33 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S
 	$(V1) echo "%% $(notdir $<)" "$(STDOUT)"
 	$(V1) $(CROSS_CC) -c -o $@ $(ASFLAGS) $<
 
-## official            : Build all official (travis) targets
-official: $(OFFICIAL_TARGETS)
 
 ## all               : Build all valid targets
 all: $(VALID_TARGETS)
 
+## official          : Build all official (travis) targets
+official: $(OFFICIAL_TARGETS)
+
+## targets-group-1   : build some targets
+targets-group-1: $(GROUP_1_TARGETS)
+
+## targets-group-2   : build some targets
+targets-group-2: $(GROUP_2_TARGETS)
+
+## targets-group-3   : build some targets
+targets-group-3: $(GROUP_3_TARGETS)
+
+## targets-group-3   : build some targets
+targets-group-4: $(GROUP_4_TARGETS)
+
+## targets-group-rest: build the rest of the targets (not listed in group 1, 2 or 3)
+targets-group-rest: $(GROUP_OTHER_TARGETS)
+
+
 $(VALID_TARGETS):
 		$(V0) echo "" && \
 		echo "Building $@" && \
-		$(MAKE) binary hex TARGET=$@ && \
+		time $(MAKE) binary hex TARGET=$@ && \
 		echo "Building $@ succeeded."
 
 
@@ -1205,9 +1301,14 @@ help: Makefile make/tools.mk
 
 ## targets           : print a list of all valid target platforms (for consumption by scripts)
 targets:
-	$(V0) @echo "Valid targets: $(VALID_TARGETS)"
-	$(V0) @echo "Target:        $(TARGET)"
-	$(V0) @echo "Base target:   $(BASE_TARGET)"
+	$(V0) @echo "Valid targets:      $(VALID_TARGETS)"
+	$(V0) @echo "Target:             $(TARGET)"
+	$(V0) @echo "Base target:        $(BASE_TARGET)"
+	$(V0) @echo "targets-group-1:    $(GROUP_1_TARGETS)"
+	$(V0) @echo "targets-group-2:    $(GROUP_2_TARGETS)"
+	$(V0) @echo "targets-group-3:    $(GROUP_3_TARGETS)"
+	$(V0) @echo "targets-group-4:    $(GROUP_4_TARGETS)"
+	$(V0) @echo "targets-group-rest: $(GROUP_OTHER_TARGETS)"
 
 ## test              : run the cleanflight test suite
 ## junittest         : run the cleanflight test suite, producing Junit XML result files.


### PR DESCRIPTION
When troubleshooting https://github.com/betaflight/betaflight/issues/2708 I was looking in .travis.yml and travis.sh. and also in the build logs on travis. 

Does anyone use the functions publish_url, publish_docs, publish_meta and the target targets?

This PR has:
1. removed all but the $GOAL related stuff
2. made sure that we can use the current build goals {test, all} and also specify like {test, naze32, spracing, ..} - ie a selected number of targets for our work branches
3. made an attempt to bring down build times to approximately 7 minutes. This is done with a manual grouping of targets in the makefile and a few new targets that are invoked from the travis.yml file
```
> make help
...
test                 : run unit tests
targets-group-1      : build some targets        
targets-group-2      : build some targets       
targets-group-3      : build some targets       
targets-group-rest   : build the rest of the targets (not listed in group 1, 2 or 3)
...
```
The build is divided in five jobs to make full use of the travis account plan (which is five concurrent builds, at least for me)

Build times are now approximately 7 minutes for all targets including tests. Before it was about 23 minutes.

Some more work can be done by moving some targets to the job running tests but I decided against it for now - keeping the test separated from the target builds. 
