### PR TITLE
Speedup build by grouping the builds in a few groups to be run in par…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,64 +4,19 @@ env:
 #  - PUBLISHDOCS=True
 # Specify the main Mafile supported goals.
   - GOAL=test
-  - GOAL=all
+  - GOAL=targets-group-1
+  - GOAL=targets-group-2
+  - GOAL=targets-group-3
+  - GOAL=targets-group-4
+  - GOAL=targets-group-rest
+#  - GOAL=all
+#  - GOAL=AFROMINI
+#  - GOAL=AIORACERF3
+#  - GOAL=...
 # Or specify targets to run.
 #  - TARGET=AFROMINI
 #  - TARGET=AIORACERF3
-#  - TARGET=AIR32
-#  - TARGET=AIRBOTF4
-#  - TARGET=AIRHEROF3
-#  - TARGET=ALIENFLIGHTF1
-#  - TARGET=ALIENFLIGHTF3
-#  - TARGET=ALIENFLIGHTF4
-#  - TARGET=ANYFCF7
-#  - TARGET=BEEBRAIN
-#  - TARGET=BETAFLIGHTF3
-#  - TARGET=BLUEJAYF4
-#  - TARGET=CC3D
-#  - TARGET=CC3D_OPBL
-#  - TARGET=CHEBUZZF3
-#  - TARGET=CJMCU
-#  - TARGET=COLIBRI
-#  - TARGET=COLIBRI_OPBL
-#  - TARGET=COLIBRI_RACE
-#  - TARGET=DOGE
-#  - TARGET=F4BY
-#  - TARGET=FURYF3
-#  - TARGET=FURYF4
-#  - TARGET=FURYF7
-#  - TARGET=IMPULSERCF3
-#  - TARGET=IRCFUSIONF3
-#  - TARGET=ISHAPEDF3
-#  - TARGET=KISSFC
-#  - TARGET=LUXV2_RACE
-#  - TARGET=LUX_RACE
-#  - TARGET=MICROSCISKY
-#  - TARGET=MOTOLAB
-#  - TARGET=NAZE
-#  - TARGET=OMNIBUS
-#  - TARGET=OMNIBUSF4
-#  - TARGET=PIKOBLX
-#  - TARGET=RACEBASE
-#  - TARGET=RCEXPLORERF3
-#  - TARGET=REVO
-#  - TARGET=REVOLT
-#  - TARGET=REVONANO
-#  - TARGET=REVO_OPBL
-#  - TARGET=RMDO
-#  - TARGET=SINGULARITY
-#  - TARGET=SIRINFPV
-#  - TARGET=SOULF4
-#  - TARGET=SPARKY
-#  - TARGET=SPARKY2
-#  - TARGET=SPRACINGF3
-#  - TARGET=SPRACINGF3EVO
-#  - TARGET=SPRACINGF3MINI
-#  - TARGET=STM32F3DISCOVERY
-#  - TARGET=VRRACE
-#  - TARGET=X_RACERSPI
-#  - TARGET=YUPIF4
-#  - TARGET=ZCOREF3
+#  - TARGET=...
 
 # use new docker environment
 sudo: false
@@ -73,6 +28,7 @@ addons:
   apt:
     packages:
       - libc6-i386
+      - time
 
 # We use cpp for unit tests, and c for the main project.
 language: cpp
@@ -93,6 +49,7 @@ cache:
   - downloads
   - tools
     
+
 #notifications:
 #  irc: "chat.freenode.net#cleanflight"
 #  use_notice: true

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,85 @@ VALID_TARGETS  := $(subst /,, $(subst ./src/main/target/,, $(VALID_TARGETS)))
 VALID_TARGETS  := $(VALID_TARGETS) $(ALT_TARGETS)
 VALID_TARGETS  := $(sort $(VALID_TARGETS))
 
+GROUP_1_TARGETS := \
+	AFROMINI \
+	AIORACERF3 \
+	AIR32  \
+	AIRBOTF4  \
+	AIRHEROF3  \
+	ALIENFLIGHTF1  \
+	ALIENFLIGHTF3 \
+	ALIENFLIGHTF4 \
+	ALIENFLIGHTNGF7 \
+	ANYFCF7  \
+	BEEBRAIN  \
+	BEEROTORF4 \
+	BETAFLIGHTF3 \
+	CC3D \
+	CC3D_OPBL  \
+	CHEBUZZF3 \
+	CJMCU \
+	CL_RACINGF4 \
+	COLIBRI \
+
+GROUP_2_TARGETS := \
+	COLIBRI_OPBL \
+	COLIBRI_RACE \
+	DOGE \
+	ELLE0 \
+	F4BY \
+	FISHDRONEF4  \
+	FLIP32F3OSD \
+	FURYF3 \
+	FURYF4 \
+	FURYF7 \
+	IMPULSERCF3 \
+	IRCFUSIONF3 \
+	ISHAPEDF3 \
+	BLUEJAYF4 \
+	KAKUTEF4 \
+	KISSCC \
+
+GROUP_3_TARGETS := \
+	KIWIF4 \
+	LUX_RACE \
+	LUXV2_RACE \
+	MICROSCISKY \
+	MOTOLAB  \
+	MULTIFLITEPICO \
+	NAZE \
+	NERO \
+	OMNIBUS \
+	OMNIBUSF4SD \
+	PIKOBLX \
+	PLUMF4 \
+	PODIUMF4 \
+	RACEBASE  \
+	RCEXPLORERF3 \
+	REVO \
+	REVO_OPBL \
+	REVOLT \
+	REVONANO \
+
+GROUP_4_TARGETS := \
+	RMDO \
+	SINGULARITY \
+	SIRINFPV   \
+	SOULF4 \
+	SPARKY \
+	SPARKY2 \
+	SPRACINGF3 \
+	SPRACINGF3EVO \
+	SPRACINGF3MINI \
+	SPRACINGF3NEO \
+	KROOZX \
+	NUCLEOF7 \
+	OMNIBUSF4 \
+	STM32F3DISCOVERY \
+
+GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS) $(GROUP_4_TARGETS), $(VALID_TARGETS))
+
+
 ifeq ($(filter $(TARGET),$(ALT_TARGETS)), $(TARGET))
 BASE_TARGET    := $(firstword $(subst /,, $(subst ./src/main/target/,, $(dir $(wildcard $(ROOT)/src/main/target/*/$(TARGET).mk)))))
 -include $(ROOT)/src/main/target/$(BASE_TARGET)/$(TARGET).mk
@@ -1102,16 +1181,33 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S
 	$(V1) echo "%% $(notdir $<)" "$(STDOUT)"
 	$(V1) $(CROSS_CC) -c -o $@ $(ASFLAGS) $<
 
-## official            : Build all official (travis) targets
-official: $(OFFICIAL_TARGETS)
 
 ## all               : Build all valid targets
 all: $(VALID_TARGETS)
 
+## official          : Build all official (travis) targets
+official: $(OFFICIAL_TARGETS)
+
+## targets-group-1   : build some targets
+targets-group-1: $(GROUP_1_TARGETS)
+
+## targets-group-2   : build some targets
+targets-group-2: $(GROUP_2_TARGETS)
+
+## targets-group-3   : build some targets
+targets-group-3: $(GROUP_3_TARGETS)
+
+## targets-group-3   : build some targets
+targets-group-4: $(GROUP_4_TARGETS)
+
+## targets-group-rest: build the rest of the targets (not listed in group 1, 2 or 3)
+targets-group-rest: $(GROUP_OTHER_TARGETS)
+
+
 $(VALID_TARGETS):
 		$(V0) echo "" && \
 		echo "Building $@" && \
-		$(MAKE) binary hex TARGET=$@ && \
+		time $(MAKE) binary hex TARGET=$@ && \
 		echo "Building $@ succeeded."
 
 
@@ -1205,9 +1301,14 @@ help: Makefile make/tools.mk
 
 ## targets           : print a list of all valid target platforms (for consumption by scripts)
 targets:
-	$(V0) @echo "Valid targets: $(VALID_TARGETS)"
-	$(V0) @echo "Target:        $(TARGET)"
-	$(V0) @echo "Base target:   $(BASE_TARGET)"
+	$(V0) @echo "Valid targets:      $(VALID_TARGETS)"
+	$(V0) @echo "Target:             $(TARGET)"
+	$(V0) @echo "Base target:        $(BASE_TARGET)"
+	$(V0) @echo "targets-group-1:    $(GROUP_1_TARGETS)"
+	$(V0) @echo "targets-group-2:    $(GROUP_2_TARGETS)"
+	$(V0) @echo "targets-group-3:    $(GROUP_3_TARGETS)"
+	$(V0) @echo "targets-group-4:    $(GROUP_4_TARGETS)"
+	$(V0) @echo "targets-group-rest: $(GROUP_OTHER_TARGETS)"
 
 ## test              : run the cleanflight test suite
 ## junittest         : run the cleanflight test suite, producing Junit XML result files.


### PR DESCRIPTION
Brings down build times to approximately 7 minutes. This is done with a manual grouping of targets in the makefile and a few new targets that are invoked from the .travis.yml file
> make help
...
test                 : run unit tests
targets-group-1      : build some targets        
targets-group-2      : build some targets       
targets-group-3      : build some targets       
targets-group-4      : build some targets       
targets-group-rest   : build the rest of the targets (not listed in group 1, 2, 3 or 4)
...
The build is divided in test + five jobs to make full use of the travis account plan (which is five concurrent builds, at least for me)

Build times are now approximately 7 minutes for all targets including tests. Before it was about 23 minutes.