### PR TITLE
Added KISS ESC sensor information for rpm and temperature to debug fields

### DIFF
--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -62,5 +62,7 @@ typedef enum {
     DEBUG_ESC_SENSOR,
     DEBUG_SCHEDULER,
     DEBUG_STACK,
+    DEBUG_ESC_SENSOR_RPM,
+    DEBUG_ESC_SENSOR_TMP,
     DEBUG_COUNT
 } debugType_e;

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -323,7 +323,9 @@ static const char * const lookupTableDebug[DEBUG_COUNT] = {
     "ANGLERATE",
     "ESC_SENSOR",
     "SCHEDULER",
-    "STACK"
+    "STACK",
+    "ESC_SENSOR_RPM",
+    "ESC_SENSOR_TMP"
 };
 
 #ifdef OSD
@@ -4041,7 +4043,7 @@ static void cliResource(char *cmdline)
             cliPrintf("%c%02d: %s ", IO_GPIOPortIdx(ioRecs + i) + 'A', IO_GPIOPinIdx(ioRecs + i), owner);
             if (ioRecs[i].index > 0) {
                 cliPrintf("%d", ioRecs[i].index);
-            } 
+            }
             cliPrintf("\r\n");
         }
 

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -68,7 +68,7 @@ Byte 9: 8-bit CRC
 DEBUG INFORMATION
 -----------------
 
-set debug_mode = DEBUG_ESC_TELEMETRY in cli
+set debug_mode = DEBUG_ESC_SENSOR in cli
 
 */
 
@@ -235,6 +235,9 @@ static uint8_t decodeEscFrame(void)
         combinedDataNeedsUpdate = true;
 
         frameStatus = ESC_SENSOR_FRAME_COMPLETE;
+
+        DEBUG_SET(DEBUG_ESC_SENSOR_RPM, escSensorMotor, escSensorData[escSensorMotor].rpm);
+        DEBUG_SET(DEBUG_ESC_SENSOR_TMP, escSensorMotor, escSensorData[escSensorMotor].temperature);
     } else {
         frameStatus = ESC_SENSOR_FRAME_FAILED;
     }


### PR DESCRIPTION
Debug additional ESC sensor data from KISS 24A ESCs.

Usage:

`set debug_mode = ESC_SENSOR_RPM`

debug[0-3] contains the rpm value of the corresponding motor index (0 = motor1, 1 = motor2, ...)

`set debug_mode = ESC_SENSOR_TMP`

debug[0-3] contains the temperature of the corresponding motor index (0 = motor1, 1 = motor2, ...)

This information can be viewed realtime in the BFC tab 'Sensors' (check Debug).