### PR TITLE
AIRBOTF4SD Add PB6 as LED strip (with pad)

### DIFF
--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -37,8 +37,12 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 1, 0),  // S4_OUT D1_ST1
 #ifdef REVOLT
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED for REVOLT D1_ST0
+#elif defined(AIRBOTF4SD)
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR, 1, 0),  // S5_OUT
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR, 1, 0),  // S6_OUT
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED D1_ST0
 #else
-    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0),  // S5_OUT / LED for REVO D1_ST4
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0),  // S5_OUT / LED
 #ifdef AIRBOTF4
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR, 1, 0),  // S6_OUT
 #else

--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -37,16 +37,12 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 1, 0),  // S4_OUT D1_ST1
 #ifdef REVOLT
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED for REVOLT D1_ST0
-#elif defined(AIRBOTF4SD)
+#elif defined(AIRBOTF4) || defined(AIRBOTF4SD)
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR, 1, 0),  // S5_OUT
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR, 1, 0),  // S6_OUT
-    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED D1_ST0
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,   0, 0),  // LED D1_ST0, n/a on older AIRBOTF4
 #else
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0),  // S5_OUT / LED
-#ifdef AIRBOTF4
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR, 1, 0),  // S6_OUT
-#else
     DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_MOTOR, 1, 0),  // S6_OUT D1_ST2
-#endif /* AIRBOTF4 */
-#endif /* REVOLT */
+#endif
 };

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -252,12 +252,9 @@
 #ifdef REVOLT
 #define USABLE_TIMER_CHANNEL_COUNT 11
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(12) )
-#elif defined(AIRBOTF4)
-#define USABLE_TIMER_CHANNEL_COUNT 12
-#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
-#elif defined(AIRBOTF4SD)
+#elif defined(AIRBOTF4) || defined(AIRBOTF4SD)
 #define USABLE_TIMER_CHANNEL_COUNT 13
-#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
 #else
 #define USABLE_TIMER_CHANNEL_COUNT 12
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -252,9 +252,12 @@
 #ifdef REVOLT
 #define USABLE_TIMER_CHANNEL_COUNT 11
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(12) )
-#elif defined(AIRBOTF4) || defined(AIRBOTF4SD)
-#define USABLE_TIMER_CHANNEL_COUNT 13
+#elif defined(AIRBOTF4)
+#define USABLE_TIMER_CHANNEL_COUNT 12
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
+#elif defined(AIRBOTF4SD)
+#define USABLE_TIMER_CHANNEL_COUNT 13
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(8) | TIM_N(12) )
 #else
 #define USABLE_TIMER_CHANNEL_COUNT 12
 #define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(12) )


### PR DESCRIPTION
AIRBOTF4SD has PB6 connected to LED strip pad.

Note: `ifdef`s are getting confusing in `timerHardware` array; should we just group timers into different targets (with lots of duplicates)?