### PR TITLE
Fixed ADC current meter for negative offset.

### DIFF
--- a/src/main/sensors/current.h
+++ b/src/main/sensors/current.h
@@ -63,7 +63,7 @@ typedef struct currentMeterADCState_s {
 
 typedef struct currentSensorADCConfig_s {
     int16_t scale;              // scale the current sensor output voltage to milliamps. Value in 1/10th mV/A
-    uint16_t offset;            // offset of the current sensor in millivolt steps
+    int16_t offset;            // offset of the current sensor in millivolt steps
 } currentSensorADCConfig_t;
 
 PG_DECLARE(currentSensorADCConfig_t, currentSensorADCConfig);


### PR DESCRIPTION
@hydra: Not sure if there are more of parameters in the new battery code that have a mismatch between the CLI allowing negative values and the parameter being unsigned. I can have a look, but you probably know better where to look. (Also, there seem to be boards out there that require negative offset and / or scale, so it makes sense to allow them.)