### PR TITLE
Fix CMS invocation failure

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -427,10 +427,6 @@ void init(void)
     mspFcInit();
     mspSerialInit();
 
-#if defined(USE_MSP_DISPLAYPORT) && defined(CMS)
-    cmsDisplayPortRegister(displayPortMspInit());
-#endif
-
 #ifdef USE_CLI
     cliInit(serialConfig());
 #endif
@@ -439,17 +435,28 @@ void init(void)
 
     rxInit();
 
+    displayPort_t *osdDisplayPort = NULL;
+
 #ifdef OSD
     //The OSD need to be initialised after GYRO to avoid GYRO initialisation failure on some targets
+
     if (feature(FEATURE_OSD)) {
 #if defined(USE_MAX7456)
         // if there is a max7456 chip for the OSD then use it, otherwise use MSP
-        displayPort_t *osdDisplayPort = max7456DisplayPortInit(vcdProfile());
+        osdDisplayPort = max7456DisplayPortInit(vcdProfile());
 #elif defined(USE_MSP_DISPLAYPORT)
-        displayPort_t *osdDisplayPort = displayPortMspInit();
+        osdDisplayPort = displayPortMspInit();
 #endif
         osdInit(osdDisplayPort);
     }
+#endif
+
+#if defined(USE_MSP_DISPLAYPORT) && defined(CMS)
+    // If BFOSD is active, then register it as CMS device, else register MSP.
+    if (osdDisplayPort)
+        cmsDisplayPortRegister(osdDisplayPort);
+    else
+        cmsDisplayPortRegister(displayPortMspInit());
 #endif
 
 #ifdef GPS


### PR DESCRIPTION
This PR fixes the CMS invocation failure issue introduced by #2582.

When #2582 was introduced, CMS device registration order was modified from "BFOSD then MSP_DISPLAYPORT" to "MSP_DISPLAYPORT then BFOSD". The CMS code was designed so that it can cycle through multiple devices by repeatedly entering the invocation stick command, so the change of ordering should not have been fatal. However, as I examined the CMS code, the multiple device capability is apparently gone, making the CMS stuck at the MSP_DISPLAYPORT state in  "MSP_DISPLAYPORT then BFOSD" case.

So, this issue actually revealed two issues:

1. Registering MSP_DISPLAYPORT even when the BFOSD is active.
2. Multiple device support in CMS is gone.

This PR deals with 1. For 2, this needs further investigation, so I will submit a new issue for reminder. 