### PR TITLE
Fix compile warning on unused osdDisplayPort

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -435,7 +435,9 @@ void init(void)
 
     rxInit();
 
+#if ( defined(OSD) || (defined(USE_MSP_DISPLAYPORT) && defined(CMS)) )
     displayPort_t *osdDisplayPort = NULL;
+#endif
 
 #ifdef OSD
     //The OSD need to be initialised after GYRO to avoid GYRO initialisation failure on some targets


### PR DESCRIPTION
Previous zero warnings high score is broken: no warnings for 11 days. Now let's start over by fixing this:

    ./src/main/fc/fc_init.c: In function 'init':
    ./src/main/fc/fc_init.c:438:20: warning: unused variable 'osdDisplayPort' [-Wunused-variable]
         displayPort_t *osdDisplayPort = NULL;
