### PR TITLE
Switch SD card detect polarity for AnyFC-F7 production boards

### DIFF
--- a/src/main/target/ANYFCF7/target.h
+++ b/src/main/target/ANYFCF7/target.h
@@ -112,7 +112,6 @@
 #define SPI4_MOSI_PIN           PE14
 
 #define USE_SDCARD
-#define SDCARD_DETECT_INVERTED
 #define SDCARD_DETECT_PIN                   PD3
 #define SDCARD_DETECT_EXTI_LINE             EXTI_Line3
 #define SDCARD_DETECT_EXTI_PIN_SOURCE       EXTI_PinSource3


### PR DESCRIPTION
Switch SD card detect polarity for production boards