### PR TITLE
Fix MPU9250 SPI AK8963 MAG detection

### DIFF
--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -114,9 +114,9 @@ static bool ak8963SensorRead(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t 
     mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
     delay(10);
     __disable_irq();
-    mpuReadRegisterI2C(NULL, MPU_RA_EXT_SENS_DATA_00, len_, buf);         // read I2C
+    bool ack = mpuReadRegisterI2C(NULL, MPU_RA_EXT_SENS_DATA_00, len_, buf);         // read I2C
     __enable_irq();
-    return true;
+    return ack;
 }
 
 static bool ak8963SensorWrite(uint8_t addr_, uint8_t reg_, uint8_t data)
@@ -316,7 +316,7 @@ bool ak8963Detect(magDev_t *mag)
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
+    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);
     delay(10);
 
     verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -58,6 +58,7 @@
 #define USE_BARO_BMP280
 
 #define MAG
+#define USE_MPU9250_MAG // Enables bypass configuration
 #define USE_MAG_AK8963
 //#define USE_MAG_HMC5883 // External
 

--- a/src/main/target/SPRACINGF3MINI/target.mk
+++ b/src/main/target/SPRACINGF3MINI/target.mk
@@ -5,9 +5,9 @@ TARGET_SRC = \
             drivers/accgyro_mpu.c \
             drivers/accgyro_mpu6500.c \
             drivers/barometer_bmp280.c \
+            drivers/compass_ak8963.c \
             drivers/compass_ak8975.c \
             drivers/compass_hmc5883l.c \
-            drivers/compass_ak8963.c \
             drivers/flash_m25p16.c 
 
 ifeq ($(TARGET), TINYBEEF3)


### PR DESCRIPTION
It was broken, again. 😒 

I bisected it, found that this commit broke it:

https://github.com/betaflight/betaflight/commit/60c2b81#diff-b0765a975ceb7d528b0ce88f63dcda40L112

the changes seemed incorrect and/or unfinished.

I also added the MPU6500_BIT_BYPASS_EN to the MPU9250 configuration - though this is actually being done twice now, once via the MPU6500 code and once in the al8963 spi detection code.

Please can I respectfully request that any future changes to the MPU9250 and AK8963 code are tested on real hardware.

Note that it's not enough to just run your changes without cold booting, you need to also test from a COLD BOOT and a WARM BOOT.