### PR TITLE
Disable i2c on CC3D flexiport, fixes the problem with MSP on UART3 not working.

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -33,9 +33,6 @@
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
 
-#define USE_I2C
-#define I2C_DEVICE (I2CDEV_2) // Flex port - SCL/PB10, SDA/PB11
-
 #define MPU6000_CS_GPIO         GPIOA
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_INSTANCE    SPI1
@@ -57,16 +54,6 @@
 
 // MPU6000 interrupts
 #define USE_MPU_DATA_READY_SIGNAL
-
-// External I2C BARO
-//#define BARO
-//#define USE_BARO_MS5611
-//#define USE_BARO_BMP085
-//#define USE_BARO_BMP280
-
-// External I2C MAG
-//#define MAG
-//#define USE_MAG_HMC5883
 
 #define USE_VCP
 #define USE_UART1


### PR DESCRIPTION
Disable i2c on CC3D flexiport, fixes the problem with MSP on UART3 not working. Same as is already done on master/BF3.2.0
Probable fix for issue #2805.
