### PR TITLE
junittest xml output was lost, fixed.

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -351,7 +351,7 @@ $(OBJECT_DIR)/$1/$1 : $$($$1_OBJS) \
 
 
 test-$1: $(OBJECT_DIR)/$1/$1
-	$(V1) $$< $(EXEC_OPTS) "$(STDOUT)" && echo "running $$@: PASS" 
+	$(V1) $$< $$(EXEC_OPTS) "$(STDOUT)" && echo "running $$@: PASS"
 
 endef
 


### PR DESCRIPTION
When unittest/Makefile was refactored all junittest xml output was lost, fixed.
