### PR TITLE
Spektrum bind did not work. Incomplete use of compiler conditionals fixed.

### DIFF
--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -60,9 +60,11 @@
 #define USE_UART3
 #define USE_UART4
 #define USE_UART5
-#define USE_SOFTSERIAL1
-#define USE_SOFTSERIAL2
-#define SERIAL_PORT_COUNT       8
+// Disable Soft Serial, no room for it in flash.
+//#define USE_SOFTSERIAL1
+//#define USE_SOFTSERIAL2
+//#define SERIAL_PORT_COUNT       8
+#define SERIAL_PORT_COUNT       6
 
 #define UART1_TX_PIN            PA9
 #define UART1_RX_PIN            PA10

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -25,3 +25,11 @@
 # undef VTX_SMARTAUDIO
 # undef VTX_TRAMP
 #endif
+
+#if defined(SPEKTRUM_BIND_PIN) && !defined(SPEKTRUM_BIND)
+#define SPEKTRUM_BIND
+#endif
+
+#if !defined(SPEKTRUM_BIND_PIN) && defined(SPEKTRUM_BIND)
+# warning SPEKTRUM_BIND_PIN undefined
+#endif


### PR DESCRIPTION
CLI cmnd `set spektrum_sat_pin` did not work. Incomplete/inconsistant use of conditionals `SPEKTRUM_BIND` (in `src/mainfc/cli.c` etc) and `SPEKTRUM_BIND_PIN` in target config headers. 
Fixed by makeing sure both are defined.
