### PR TITLE
Fix configurator DSHOT off-by-one error preventing maximum throttle

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -644,13 +644,15 @@ uint16_t convertExternalToMotor(uint16_t externalValue)
     uint16_t motorValue = externalValue;
 #ifdef USE_DSHOT
     if (isMotorProtocolDshot()) {
-        motorValue = externalValue <= EXTERNAL_CONVERSION_MIN_VALUE ? DSHOT_DISARM_COMMAND : constrain((externalValue - EXTERNAL_DSHOT_CONVERSION_OFFSET) * EXTERNAL_DSHOT_CONVERSION_FACTOR, DSHOT_MIN_THROTTLE, DSHOT_MAX_THROTTLE);
+        // Add 1 to the value, otherwise throttle tops out at 2046
+        motorValue = externalValue <= EXTERNAL_CONVERSION_MIN_VALUE ? DSHOT_DISARM_COMMAND : constrain((externalValue - EXTERNAL_DSHOT_CONVERSION_OFFSET) * EXTERNAL_DSHOT_CONVERSION_FACTOR + 1, DSHOT_MIN_THROTTLE, DSHOT_MAX_THROTTLE);
 
         if (feature(FEATURE_3D)) {
             if (externalValue == EXTERNAL_CONVERSION_3D_MID_VALUE) {
                 motorValue = DSHOT_DISARM_COMMAND;
             } else if (motorValue >= DSHOT_MIN_THROTTLE && motorValue <= DSHOT_3D_DEADBAND_LOW) {
-                motorValue = DSHOT_MIN_THROTTLE + (DSHOT_3D_DEADBAND_LOW - motorValue);
+                // Add 1 to the value, otherwise throttle tops out at 2046
+                motorValue = DSHOT_MIN_THROTTLE + (DSHOT_3D_DEADBAND_LOW - motorValue) + 1;
             }
         }
     }


### PR DESCRIPTION
This change fixes the off-by-one error when controlling DSHOT ESCs from the configurator described in #2879.

After this change, a motor output value of 1001 results in 49 being sent:

![motor output value of 1001 results in 49](https://cloud.githubusercontent.com/assets/201344/25025321/ad175248-2056-11e7-86d3-1146fcd91aab.jpg)

And a motor output value of 2000 results in 2047 being sent (maximum throttle):

![img_0894](https://cloud.githubusercontent.com/assets/201344/25025366/ce16e4ea-2056-11e7-9128-045f8af72664.jpg)

A few sample values:

For 2D flight:

2000 => 2047
1501 => 1049
1500 => 1047
1499 => 1045
1001 => 49
1000 => 0

For 3D flight:

2000 => 2047
1501 => 1049
1500 => 0
1499 => 51
1001 => 1047
1000 => 0

The fix is described in greater detail in the issue itself.

Tested on an OMNIBUS F3 Nano by patching the latest 3.1.7 code as the code in the master branch had a number of bugs.
