### PR TITLE
Fixing debug compile errors due to beeper defines

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -761,40 +761,70 @@ void changePidProfile(uint8_t pidProfileIndex)
 
 void beeperOffSet(uint32_t mask)
 {
+#ifdef BEEPER
     beeperConfigMutable()->beeper_off_flags |= mask;
+#else
+    UNUSED(mask);
+#endif
 }
 
 void beeperOffSetAll(uint8_t beeperCount)
 {
+#ifdef BEEPER
     beeperConfigMutable()->beeper_off_flags = (1 << beeperCount) -1;
+#else
+    UNUSED(beeperCount);
+#endif
 }
 
 void beeperOffClear(uint32_t mask)
 {
+#ifdef BEEPER
     beeperConfigMutable()->beeper_off_flags &= ~(mask);
+#else
+    UNUSED(mask);
+#endif
 }
 
 void beeperOffClearAll(void)
 {
+#ifdef BEEPER
     beeperConfigMutable()->beeper_off_flags = 0;
+#endif
 }
 
 uint32_t getBeeperOffMask(void)
 {
+#ifdef BEEPER
     return beeperConfig()->beeper_off_flags;
+#else
+    return 0;
+#endif
 }
 
 void setBeeperOffMask(uint32_t mask)
 {
+#ifdef BEEPER
     beeperConfigMutable()->beeper_off_flags = mask;
+#else
+    UNUSED(mask);
+#endif
 }
 
 uint32_t getPreferredBeeperOffMask(void)
 {
+#ifdef BEEPER
     return beeperConfig()->preferred_beeper_off_flags;
+#else
+    return 0;
+#endif
 }
 
 void setPreferredBeeperOffMask(uint32_t mask)
 {
+#ifdef BEEPER
     beeperConfigMutable()->preferred_beeper_off_flags = mask;
+#else
+    UNUSED(mask);
+#endif
 }

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -53,8 +53,9 @@ typedef struct beeperConfig_s {
     uint32_t preferred_beeper_off_flags;
 } beeperConfig_t;
 
+#ifdef BEEPER
 PG_DECLARE(beeperConfig_t, beeperConfig);
-
+#endif
 
 void beeper(beeperMode_e mode);
 void beeperSilence(void);


### PR DESCRIPTION
Setting "DEBUG = GDB" fails to compile due to some beeper defines. 