### PR TITLE
Updates for NERO. Fix for 20602, move i2c for LEDs

### DIFF
--- a/src/main/drivers/bus_spi_hal.c
+++ b/src/main/drivers/bus_spi_hal.c
@@ -138,7 +138,12 @@ void spiInitDevice(SPIDevice device)
         spi->leadingEdge = true;
     }
 #endif
-
+#ifdef MPU6500_SPI_INSTANCE
+    if (spi->dev == MPU6500_SPI_INSTANCE) {
+        spi->leadingEdge = true;
+    }
+#endif
+    
     // Enable SPI clock
     RCC_ClockCmd(spi->rcc, ENABLE);
     RCC_ResetCmd(spi->rcc, ENABLE);

--- a/src/main/target/NERO/target.h
+++ b/src/main/target/NERO/target.h
@@ -70,6 +70,8 @@
 #define USE_I2C
 #define USE_I2C_DEVICE_1
 #define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
 
 #define USE_VCP
 //#define VBUS_SENSING_PIN PA8

--- a/src/main/vcp_hal/usbd_conf.h
+++ b/src/main/vcp_hal/usbd_conf.h
@@ -58,7 +58,7 @@
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 /* Common Config */
-#define USBD_MAX_NUM_INTERFACES               1
+#define USBD_MAX_NUM_INTERFACES               0
 #define USBD_MAX_NUM_CONFIGURATION            1
 #define USBD_MAX_STR_DESC_SIZ                 0x100
 #define USBD_SUPPORT_USER_STRING              0

--- a/src/main/vcp_hal/usbd_desc.c
+++ b/src/main/vcp_hal/usbd_desc.c
@@ -98,7 +98,7 @@ __ALIGN_BEGIN uint8_t USBD_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   USB_DESC_TYPE_DEVICE,       /* bDescriptorType */
   0x00,                       /* bcdUSB */
   0x02,
-  0x00,                       /* bDeviceClass */
+  0x02,                       /* bDeviceClass */
   0x00,                       /* bDeviceSubClass */
   0x00,                       /* bDeviceProtocol */
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */


### PR DESCRIPTION
Updates for NERO. Fix for 20602, move i2c for LEDs
Update the config for VCD to populate only 1 interface, and use device class allowing for built in Windows 10 driver.