### PR TITLE
Removed erroneous "n" char added to the end of a CLI resource line

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2780,7 +2780,7 @@ static void printResource(uint8_t dumpMask)
             const ioTag_t ioTagDefault = *((const ioTag_t *)defaultConfig + resourceTable[i].offset + index);
 
             bool equalsDefault = ioTag == ioTagDefault;
-            const char *format = "resource %s %d %c%02dn";
+            const char *format = "resource %s %d %c%02d";
             const char *formatUnassigned = "resource %s %d NONE";
             if (!ioTagDefault) {
                 cliDefaultPrintLinef(dumpMask, equalsDefault, formatUnassigned, owner, RESOURCE_INDEX(index));


### PR DESCRIPTION
The character was added in 970f193, the change was:

Before:
`const char *format = "resource %s %d %c%02d\r\n";`

After:
`const char *format = "resource %s %d %c%02dn";`

Example of the `resource` CLI output of my Omnibus F4 Pro V3 before the fix:

```
resource BEEPER 1 B04n
resource MOTOR 1 B00n
resource MOTOR 2 B01n
resource MOTOR 3 A03n
resource MOTOR 4 A02n
resource MOTOR 5 A01n
resource MOTOR 6 A08n
resource PPM 1 B08n
resource PWM 1 B08n
resource PWM 2 B09n
resource PWM 3 C06n
resource PWM 4 C07n
resource PWM 5 C08n
resource PWM 6 C09n
resource LED_STRIP 1 B06n
resource SERIAL_TX 1 A09n
resource SERIAL_TX 3 B10n
resource SERIAL_TX 6 C06n
resource SERIAL_RX 1 A10n
resource SERIAL_RX 3 B11n
resource SERIAL_RX 6 C07n
```