### PR TITLE
Reconfigurable inverter pin

### DIFF
--- a/src/main/config/parameter_group_ids.h
+++ b/src/main/config/parameter_group_ids.h
@@ -105,7 +105,8 @@
 #define PG_VCD_CONFIG 514
 #define PG_VTX_CONFIG 515
 #define PG_SONAR_CONFIG 516
-#define PG_BETAFLIGHT_END 516
+#define PG_INVERTER_CONFIG 517
+#define PG_BETAFLIGHT_END 517
 
 
 // OSD configuration (subject to change)

--- a/src/main/drivers/inverter.c
+++ b/src/main/drivers/inverter.c
@@ -98,6 +98,7 @@ static void initInverter(ioTag_t ioTag)
 
 void initInverters(const inverterConfig_t *inverterConfigToUse)
 {
+#ifdef USE_INVERTER
     pInverterConfig = inverterConfigToUse;
 
 #ifdef INVERTER_PIN_UART1
@@ -122,6 +123,9 @@ void initInverters(const inverterConfig_t *inverterConfigToUse)
 
 #ifdef INVERTER_PIN_UART6
     initInverter(pInverterConfig->ioTag[5]);
+#endif
+#else
+    UNUSED(inverterConfigToUse);
 #endif
 }
 

--- a/src/main/drivers/inverter.c
+++ b/src/main/drivers/inverter.c
@@ -21,11 +21,66 @@
 #include "platform.h"
 
 #include "drivers/io.h"
-#include "io_impl.h"
+#include "drivers/serial.h"
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
 
 #include "inverter.h"
 
 #ifdef USE_INVERTER
+
+#ifdef INVERTER_PIN_UART1
+#define INVERTER_IOTAG_UART1 IO_TAG(INVERTER_PIN_UART1)
+#else
+#define INVERTER_IOTAG_UART1 IO_TAG_NONE
+#endif
+
+#ifdef INVERTER_PIN_UART2
+#define INVERTER_IOTAG_UART2 IO_TAG(INVERTER_PIN_UART2)
+#else
+#define INVERTER_IOTAG_UART2 IO_TAG_NONE
+#endif
+
+#ifdef INVERTER_PIN_UART3
+#define INVERTER_IOTAG_UART3 IO_TAG(INVERTER_PIN_UART3)
+#else
+#define INVERTER_IOTAG_UART3 IO_TAG_NONE
+#endif
+
+#ifdef INVERTER_PIN_UART4
+#define INVERTER_IOTAG_UART4 IO_TAG(INVERTER_PIN_UART4)
+#else
+#define INVERTER_IOTAG_UART4 IO_TAG_NONE
+#endif
+
+#ifdef INVERTER_PIN_UART5
+#define INVERTER_IOTAG_UART5 IO_TAG(INVERTER_PIN_UART5)
+#else
+#define INVERTER_IOTAG_UART5 IO_TAG_NONE
+#endif
+
+#ifdef INVERTER_PIN_UART6
+#define INVERTER_IOTAG_UART6 IO_TAG(INVERTER_PIN_UART6)
+#else
+#define INVERTER_IOTAG_UART6 IO_TAG_NONE
+#endif
+
+const inverterConfig_t *pInverterConfig;
+
+PG_REGISTER_WITH_RESET_TEMPLATE(inverterConfig_t, inverterConfig, PG_INVERTER_CONFIG, 0);
+
+PG_RESET_TEMPLATE(inverterConfig_t, inverterConfig,
+    .ioTag = {
+        INVERTER_IOTAG_UART1,
+        INVERTER_IOTAG_UART2,
+        INVERTER_IOTAG_UART3,
+        INVERTER_IOTAG_UART4,
+        INVERTER_IOTAG_UART5,
+        INVERTER_IOTAG_UART6,
+    },
+);
+
 static void inverterSet(IO_t pin, bool on)
 {
     IOWrite(pin, on);
@@ -41,30 +96,32 @@ static void initInverter(ioTag_t ioTag)
 }
 #endif
 
-void initInverters(void)
+void initInverters(const inverterConfig_t *inverterConfigToUse)
 {
+    pInverterConfig = inverterConfigToUse;
+
 #ifdef INVERTER_PIN_UART1
-    initInverter(IO_TAG(INVERTER_PIN_UART1));
+    initInverter(pInverterConfig->ioTag[0]);
 #endif
 
 #ifdef INVERTER_PIN_UART2
-    initInverter(IO_TAG(INVERTER_PIN_UART2));
+    initInverter(pInverterConfig->ioTag[1]);
 #endif
 
 #ifdef INVERTER_PIN_UART3
-    initInverter(IO_TAG(INVERTER_PIN_UART3));
+    initInverter(pInverterConfig->ioTag[2]);
 #endif
 
 #ifdef INVERTER_PIN_UART4
-    initInverter(IO_TAG(INVERTER_PIN_UART4));
+    initInverter(pInverterConfig->ioTag[3]);
 #endif
 
 #ifdef INVERTER_PIN_UART5
-    initInverter(IO_TAG(INVERTER_PIN_UART5));
+    initInverter(pInverterConfig->ioTag[4]);
 #endif
 
 #ifdef INVERTER_PIN_UART6
-    initInverter(IO_TAG(INVERTER_PIN_UART6));
+    initInverter(pInverterConfig->ioTag[5]);
 #endif
 }
 
@@ -75,37 +132,37 @@ void enableInverter(USART_TypeDef *USARTx, bool on)
 
 #ifdef INVERTER_PIN_UART1
     if (USARTx == USART1) {
-        pin = IOGetByTag(IO_TAG(INVERTER_PIN_UART1));
+        pin = IOGetByTag(pInverterConfig->ioTag[0]);
     }
 #endif
 
 #ifdef INVERTER_PIN_UART2
     if (USARTx == USART2) {
-        pin = IOGetByTag(IO_TAG(INVERTER_PIN_UART2));
+        pin = IOGetByTag(pInverterConfig->ioTag[1]);
     }
 #endif
 
 #ifdef INVERTER_PIN_UART3
     if (USARTx == USART3) {
-        pin = IOGetByTag(IO_TAG(INVERTER_PIN_UART3));
+        pin = IOGetByTag(pInverterConfig->ioTag[2]);
     }
 #endif
 
 #ifdef INVERTER_PIN_UART4
     if (USARTx == UART4) {
-        pin = IOGetByTag(IO_TAG(INVERTER_PIN_UART4));
+        pin = IOGetByTag(pInverterConfig->ioTag[3]);
     }
 #endif
 
 #ifdef INVERTER_PIN_UART5
     if (USARTx == UART5) {
-        pin = IOGetByTag(IO_TAG(INVERTER_PIN_UART5));
+        pin = IOGetByTag(pInverterConfig->ioTag[4]);
     }
 #endif
 
 #ifdef INVERTER_PIN_UART6
     if (USARTx == USART6) {
-        pin = IOGetByTag(IO_TAG(INVERTER_PIN_UART6));
+        pin = IOGetByTag(pInverterConfig->ioTag[5]);
     }
 #endif
 

--- a/src/main/drivers/inverter.h
+++ b/src/main/drivers/inverter.h
@@ -21,6 +21,16 @@
 #define USE_INVERTER
 #endif
 
-void initInverters(void);
+#include "config/parameter_group.h"
+#include "drivers/io.h"
+#include "drivers/serial.h"
+
+typedef struct inverterConfig_s {
+    ioTag_t ioTag[SERIAL_PORT_MAX_INDEX]; // XXX Should be hard uart count
+} inverterConfig_t;
+
+PG_DECLARE(inverterConfig_t, inverterConfig);
+
+void initInverters(const inverterConfig_t *inverterConfigToUse);
 
 void enableInverter(USART_TypeDef *USARTx, bool on);

--- a/src/main/drivers/inverter.h
+++ b/src/main/drivers/inverter.h
@@ -26,7 +26,7 @@
 #include "drivers/serial.h"
 
 typedef struct inverterConfig_s {
-    ioTag_t ioTag[SERIAL_PORT_MAX_INDEX]; // XXX Should be hard uart count
+    ioTag_t ioTag[SERIAL_PORT_MAX_INDEX]; // XXX Many waisted bytes here; should be hard uart count
 } inverterConfig_t;
 
 PG_DECLARE(inverterConfig_t, inverterConfig);

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -62,6 +62,7 @@ extern uint8_t __config_end;
 #include "drivers/flash.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
+#include "drivers/inverter.h"
 #include "drivers/rx_pwm.h"
 #include "drivers/sdcard.h"
 #include "drivers/sensor.h"
@@ -2744,6 +2745,9 @@ const cliResourceValue_t resourceTable[] = {
 #endif
     { OWNER_SERIAL_TX,     PG_SERIAL_PIN_CONFIG, offsetof(serialPinConfig_t, ioTagTx[0]), SERIAL_PORT_MAX_INDEX },
     { OWNER_SERIAL_RX,     PG_SERIAL_PIN_CONFIG, offsetof(serialPinConfig_t, ioTagRx[0]), SERIAL_PORT_MAX_INDEX },
+#ifdef USE_INVERTER
+    { OWNER_INVERTER,      PG_INVERTER_CONFIG, offsetof(inverterConfig_t, ioTag[0]), SERIAL_PORT_MAX_INDEX },
+#endif
 };
 
 static ioTag_t *getIoTag(const cliResourceValue_t value, uint8_t index)

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -339,7 +339,7 @@ void init(void)
 #endif
 /* temp until PGs are implemented. */
 #ifdef USE_INVERTER
-    initInverters();
+    initInverters(inverterConfig());
 #endif
 
 #ifdef TARGET_BUS_INIT


### PR DESCRIPTION
PR status: Need review

Some variants/clones of OMNIBUSF4 and AIRBOTF4 have slightly different pin assignment for inverter control. Rather than defining separate targets, reconfigurable inverter pin assignment can take care of it.

---
I would like to define max number of hardware UART ports so that `inverterConfig_t` can be kept at the minimum size.