### PR TITLE
Added OSD Battery Usage progressbar

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -103,7 +103,8 @@ OSD_Entry menuOsdActiveElemsEntries[] =
 {
     {"--- ACTIV ELEM ---", OME_Label, NULL, NULL, 0},
     {"RSSI", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
-    {"MAIN BATTERY", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
+    {"BATTERY VOLTAGE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
+    {"BATTERY USAGE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_USAGE], 0},
     {"AVG CELL VOLTAGE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], 0},
     {"CROSSHAIRS", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CROSSHAIRS], 0},
     {"HORIZON", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ARTIFICIAL_HORIZON], 0},

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -217,3 +217,11 @@
 //sport
 #define SYM_MIN 0xB3
 #define SYM_AVG 0xB4
+
+// Progress bar
+#define SYM_PB_START 0x8A
+#define SYM_PB_FULL  0x8B
+#define SYM_PB_HALF  0x8C
+#define SYM_PB_EMPTY 0x8D
+#define SYM_PB_END   0x8E
+#define SYM_PB_CLOSE 0x8F

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -649,6 +649,8 @@ const clivalue_t valueTable[] = {
     { "osd_avg_cell_voltage_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_AVG_CELL_VOLTAGE]) },
     { "osd_pit_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_PITCH_ANGLE]) },
     { "osd_rol_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ROLL_ANGLE]) },
+    { "osd_battery_usage_pos",      VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_USAGE]) },
+
 #endif
 
 // PG_SYSTEM_CONFIG

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -483,38 +483,32 @@ static void osdDrawSingleElement(uint8_t item)
     case OSD_MAIN_BATT_USAGE:
     {
         //Set length of indicator bar
-        uint8_t progressSteps = 10;
+        #define MAIN_BATT_USAGE_STEPS 10
 
         //Calculate constrained value
-        float value = constrain(osdConfig()->cap_alarm - getMAhDrawn(), 0, osdConfig()->cap_alarm);
+        float value = constrain(batteryConfig()->batteryCapacity - getMAhDrawn(), 0, batteryConfig()->batteryCapacity);
 
         //Calculate mAh used progress
-        uint8_t mAhUsedProgress = ceil((value / (osdConfig()->cap_alarm / progressSteps)));
+        uint8_t mAhUsedProgress = ceil((value / (batteryConfig()->batteryCapacity / MAIN_BATT_USAGE_STEPS)));
 
         //Create empty battery indicator bar
         buff[0] = SYM_PB_START;
-        for(uint8_t i = 1; i <= progressSteps; i++)
-        {
-            buff[i] = SYM_PB_EMPTY;
+        for(uint8_t i = 1; i <= MAIN_BATT_USAGE_STEPS; i++) {
+            if (i <= mAhUsedProgress)
+                buff[i] = SYM_PB_FULL;
+            else
+                buff[i] = SYM_PB_EMPTY;
         }
-        buff[progressSteps+1] = SYM_PB_CLOSE;
+        buff[MAIN_BATT_USAGE_STEPS+1] = SYM_PB_CLOSE;
 
-        //Fill indicator bar progress
-        for(uint8_t i = 1; i <= mAhUsedProgress; i++)
-        {
-            buff[i] = SYM_PB_FULL;
-        }
-
-        if (mAhUsedProgress > 0 && mAhUsedProgress < progressSteps)
-        {
+        if (mAhUsedProgress > 0 && mAhUsedProgress < MAIN_BATT_USAGE_STEPS) {
             buff[1+mAhUsedProgress] = SYM_PB_END;
         }
 
-        buff[progressSteps+2] = 0;
+        buff[MAIN_BATT_USAGE_STEPS+2] = 0;
 
         break;
     }
-
 
     default:
         return;
@@ -706,13 +700,11 @@ void osdUpdateAlarms(void)
     else
         CLR_BLINK(OSD_FLYTIME);
 
-    if (getMAhDrawn() >= osdConfig()->cap_alarm)
-    {
+    if (getMAhDrawn() >= osdConfig()->cap_alarm) {
         SET_BLINK(OSD_MAH_DRAWN);
         SET_BLINK(OSD_MAIN_BATT_USAGE);
     }
-    else
-    {
+    else {
         CLR_BLINK(OSD_MAH_DRAWN);
         CLR_BLINK(OSD_MAIN_BATT_USAGE);
     }

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -55,6 +55,7 @@ typedef enum {
     OSD_DEBUG,
     OSD_PITCH_ANGLE,
     OSD_ROLL_ANGLE,
+    OSD_MAIN_BATT_USAGE,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Added a progress bar indicator for used battery capacity based in mAh drawn and selected battery capacity. 
* Progress bar starts fully filled.
* Progress bar decreases every 10% of mAh capacity is drawn.
* Progress bar is empty when mAh drawn is equal or greater than capacity.

Betaflight Configurator pull-request to enable/disable this OSD feature: https://github.com/betaflight/betaflight-configurator/pull/489

Screenshot of actual DVR video:
![image](https://cloud.githubusercontent.com/assets/334779/25636664/67086252-2f82-11e7-81f6-5468b805ffe9.png)
