### PR TITLE
fixed left servo pitch contribution for servoMixerBI

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -118,7 +118,7 @@ static const servoMixer_t servoMixerFlyingWing[] = {
 
 static const servoMixer_t servoMixerBI[] = {
     { SERVO_BICOPTER_LEFT, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
-    { SERVO_BICOPTER_LEFT, INPUT_STABILIZED_PITCH, 100, 0, 0, 100, 0 },
+    { SERVO_BICOPTER_LEFT, INPUT_STABILIZED_PITCH, -100, 0, 0, 100, 0 },
     { SERVO_BICOPTER_RIGHT, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
     { SERVO_BICOPTER_RIGHT, INPUT_STABILIZED_PITCH, 100, 0, 0, 100, 0 },
 };


### PR DESCRIPTION
added a minus sign to the left servo pitch contribution. the existing yaw configuration appears to be correct.

the beginning of [this video](https://www.youtube.com/watch?v=lL0-NaDt3-g) shows the corrected servo behaviour. without the minus sign on the left servo pitch, the servos move in opposite directions when pitch forward and backward.