### PR TITLE
Remove reference to USART_TypeDef in io layer

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -100,37 +100,43 @@ static void uartReconfigure(uartPort_t *uartPort)
     USART_Cmd(uartPort->USARTx, ENABLE);
 }
 
-serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, uint32_t baudRate, portMode_t mode, portOptions_t options)
+serialPort_t *uartOpen(UARTDevice device, serialReceiveCallbackPtr rxCallback, uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
     uartPort_t *s = NULL;
 
     if (false) {
 #ifdef USE_UART1
-    } else if (USARTx == USART1) {
+    } else if (device == UARTDEV_1) {
         s = serialUART1(baudRate, mode, options);
-
 #endif
 #ifdef USE_UART2
-    } else if (USARTx == USART2) {
+    } else if (device == UARTDEV_2) {
         s = serialUART2(baudRate, mode, options);
 #endif
 #ifdef USE_UART3
-    } else if (USARTx == USART3) {
+    } else if (device == UARTDEV_3) {
         s = serialUART3(baudRate, mode, options);
 #endif
 #ifdef USE_UART4
-    } else if (USARTx == UART4) {
+    } else if (device == UARTDEV_4) {
         s = serialUART4(baudRate, mode, options);
 #endif
 #ifdef USE_UART5
-    } else if (USARTx == UART5) {
+    } else if (device == UARTDEV_5) {
         s = serialUART5(baudRate, mode, options);
 #endif
 #ifdef USE_UART6
-    } else if (USARTx == USART6) {
+    } else if (device == UARTDEV_6) {
         s = serialUART6(baudRate, mode, options);
 #endif
-
+#ifdef USE_UART7
+    } else if (device == UARTDEV_7) {
+        s = serialUART7(baudRate, mode, options);
+#endif
+#ifdef USE_UART8
+    } else if (device == UARTDEV_8) {
+        s = serialUART8(baudRate, mode, options);
+#endif
     } else {
         return (serialPort_t *)s;
     }

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -40,6 +40,17 @@
 #define UART8_RX_BUFFER_SIZE    256
 #define UART8_TX_BUFFER_SIZE    256
 
+typedef enum UARTDevice {
+    UARTDEV_1 = 0,
+    UARTDEV_2 = 1,
+    UARTDEV_3 = 2,
+    UARTDEV_4 = 3,
+    UARTDEV_5 = 4,
+    UARTDEV_6 = 5,
+    UARTDEV_7 = 6,
+    UARTDEV_8 = 7
+} UARTDevice;
+
 typedef struct {
     serialPort_t port;
 
@@ -72,7 +83,7 @@ typedef struct {
     USART_TypeDef *USARTx;
 } uartPort_t;
 
-serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, uint32_t baudRate, portMode_t mode, portOptions_t options);
+serialPort_t *uartOpen(UARTDevice device, serialReceiveCallbackPtr rxCallback, uint32_t baudRate, portMode_t mode, portOptions_t options);
 
 // serialPort API
 void uartWrite(serialPort_t *instance, uint8_t ch);

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -176,41 +176,41 @@ static void uartReconfigure(uartPort_t *uartPort)
     return;
 }
 
-serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback, uint32_t baudRate, portMode_t mode, portOptions_t options)
+serialPort_t *uartOpen(UARTDevice device, serialReceiveCallbackPtr callback, uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
     uartPort_t *s = NULL;
 
     if (false) {
 #ifdef USE_UART1
-    } else if (USARTx == USART1) {
+    } else if (device == UARTDEV_1) {
         s = serialUART1(baudRate, mode, options);
 #endif
 #ifdef USE_UART2
-    } else if (USARTx == USART2) {
+    } else if (device == UARTDEV_2) {
         s = serialUART2(baudRate, mode, options);
 #endif
 #ifdef USE_UART3
-    } else if (USARTx == USART3) {
+    } else if (device == UARTDEV_3) {
         s = serialUART3(baudRate, mode, options);
 #endif
 #ifdef USE_UART4
-    } else if (USARTx == UART4) {
+    } else if (device == UARTDEV_4) {
         s = serialUART4(baudRate, mode, options);
 #endif
 #ifdef USE_UART5
-    } else if (USARTx == UART5) {
+    } else if (device == UARTDEV_5) {
         s = serialUART5(baudRate, mode, options);
 #endif
 #ifdef USE_UART6
-    } else if (USARTx == USART6) {
+    } else if (device == UARTDEV_6) {
         s = serialUART6(baudRate, mode, options);
 #endif
 #ifdef USE_UART7
-    } else if (USARTx == UART7) {
+    } else if (device == UARTDEV_7) {
         s = serialUART7(baudRate, mode, options);
 #endif
 #ifdef USE_UART8
-    } else if (USARTx == UART8) {
+    } else if (device == UARTDEV_8) {
         s = serialUART8(baudRate, mode, options);
 #endif
     } else {

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -33,15 +33,6 @@
 #define UART_RX_BUFFER_SIZE 512
 #define UART_TX_BUFFER_SIZE 512
 
-typedef enum UARTDevice {
-    UARTDEV_1 = 0,
-    UARTDEV_2 = 1,
-    UARTDEV_3 = 2,
-    UARTDEV_4 = 3,
-    UARTDEV_5 = 4,
-    UARTDEV_6 = 5
-} UARTDevice;
-
 typedef struct uartDevice_s {
     USART_TypeDef* dev;
     uartPort_t port;

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -35,17 +35,6 @@ static void handleUsartTxDma(uartPort_t *s);
 #define UART_RX_BUFFER_SIZE UART1_RX_BUFFER_SIZE
 #define UART_TX_BUFFER_SIZE UART1_TX_BUFFER_SIZE
 
-typedef enum UARTDevice {
-    UARTDEV_1 = 0,
-    UARTDEV_2 = 1,
-    UARTDEV_3 = 2,
-    UARTDEV_4 = 3,
-    UARTDEV_5 = 4,
-    UARTDEV_6 = 5,
-    UARTDEV_7 = 6,
-    UARTDEV_8 = 7
-} UARTDevice;
-
 typedef struct uartDevice_s {
     USART_TypeDef* dev;
     uartPort_t port;

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -351,42 +351,42 @@ serialPort_t *openSerialPort(
 #endif
 #ifdef USE_UART1
         case SERIAL_PORT_USART1:
-            serialPort = uartOpen(USART1, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_1, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART2
         case SERIAL_PORT_USART2:
-            serialPort = uartOpen(USART2, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_2, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART3
         case SERIAL_PORT_USART3:
-            serialPort = uartOpen(USART3, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_3, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART4
         case SERIAL_PORT_UART4:
-            serialPort = uartOpen(UART4, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_4, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART5
         case SERIAL_PORT_UART5:
-            serialPort = uartOpen(UART5, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_5, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART6
         case SERIAL_PORT_USART6:
-            serialPort = uartOpen(USART6, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_6, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART7
         case SERIAL_PORT_USART7:
-            serialPort = uartOpen(UART7, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_7, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_UART8
         case SERIAL_PORT_USART8:
-            serialPort = uartOpen(UART8, rxCallback, baudRate, mode, options);
+            serialPort = uartOpen(UARTDEV_8, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_SOFTSERIAL1

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -320,6 +320,10 @@ bool doesConfigurationUsePort(serialPortIdentifier_e identifier)
     return candidate != NULL && candidate->functionMask;
 }
 
+#define USE_UART (defined(USE_UART1) || defined(USE_UART2) || defined(USE_UART3) || defined(USE_UART4) || defined(USE_UART5) || defined(USE_UART6) || defined(USE_UART7) || defined(USE_UART8))
+
+#define USE_SERIAL (USE_UART || defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2))
+
 serialPort_t *openSerialPort(
     serialPortIdentifier_e identifier,
     serialPortFunction_e function,
@@ -328,7 +332,7 @@ serialPort_t *openSerialPort(
     portMode_t mode,
     portOptions_t options)
 {
-#if (!defined(USE_UART1) && !defined(USE_UART2) && !defined(USE_UART3) && !defined(USE_UART4) && !defined(USE_UART5) && !defined(USE_UART6) && !defined(USE_SOFTSERIAL1) && !defined(USE_SOFTSERIAL2))
+#if !(USESERIAL)
     UNUSED(rxCallback);
     UNUSED(baudRate);
     UNUSED(mode);
@@ -351,44 +355,33 @@ serialPort_t *openSerialPort(
 #endif
 #ifdef USE_UART1
         case SERIAL_PORT_USART1:
-            serialPort = uartOpen(UARTDEV_1, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART2
         case SERIAL_PORT_USART2:
-            serialPort = uartOpen(UARTDEV_2, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART3
         case SERIAL_PORT_USART3:
-            serialPort = uartOpen(UARTDEV_3, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART4
         case SERIAL_PORT_UART4:
-            serialPort = uartOpen(UARTDEV_4, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART5
         case SERIAL_PORT_UART5:
-            serialPort = uartOpen(UARTDEV_5, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART6
         case SERIAL_PORT_USART6:
-            serialPort = uartOpen(UARTDEV_6, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART7
         case SERIAL_PORT_USART7:
-            serialPort = uartOpen(UARTDEV_7, rxCallback, baudRate, mode, options);
-            break;
 #endif
 #ifdef USE_UART8
         case SERIAL_PORT_USART8:
-            serialPort = uartOpen(UARTDEV_8, rxCallback, baudRate, mode, options);
+#endif
+#if defined(USE_UART)
+            serialPort = uartOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, baudRate, mode, options);
             break;
 #endif
+
 #ifdef USE_SOFTSERIAL1
         case SERIAL_PORT_SOFTSERIAL1:
             serialPort = openSoftSerial(SOFTSERIAL1, rxCallback, baudRate, mode, options);

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -353,6 +353,8 @@ serialPort_t *openSerialPort(
             serialPort = usbVcpOpen();
             break;
 #endif
+
+#if defined(USE_UART)
 #ifdef USE_UART1
         case SERIAL_PORT_USART1:
 #endif
@@ -377,7 +379,6 @@ serialPort_t *openSerialPort(
 #ifdef USE_UART8
         case SERIAL_PORT_USART8:
 #endif
-#if defined(USE_UART)
             serialPort = uartOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, baudRate, mode, options);
             break;
 #endif

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -87,6 +87,8 @@ extern const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT];
 
 #define SERIAL_PORT_IDENTIFIER_TO_INDEX(x) (((x) <= SERIAL_PORT_USART8) ? (x) : (RESOURCE_SOFT_OFFSET + ((x) - SERIAL_PORT_SOFTSERIAL1)))
 
+#define SERIAL_PORT_IDENTIFIER_TO_UARTDEV(x) ((x) - SERIAL_PORT_USART1 + UARTDEV_1)
+
 //
 // runtime
 //


### PR DESCRIPTION
PR status: For discussion

In preparation for code refactoring associated with forth coming configurable UART, I would like to propose removing reference to `USART_TypeDef` (a pointer to mapped i/o) as much as possible, at least in the io layer.

This PR make use of `UARTDevice` type which were defined and used in the F4 and F7 code to give some idea of what it is going to look like. In the refactoring process, it should give easier to read and smaller code (I believe).

Ref:
https://github.com/betaflight/betaflight/pull/2154#pullrequestreview-17717085

P.S. Also adds UART7 and UART8 support (for F7)