### PR TITLE
Disallow any compiler warnings by turning them into hard errors by the -Werror option.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -10,6 +10,8 @@ TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
 BUILDNAME=${BUILDNAME:=travis}
 TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
 
+MAKE="make EXTRA_FLAGS=-Werror V=0"
+
 CURL_BASEOPTS=(
 	"--retry" "10"
 	"--retry-max-time" "120" )
@@ -47,7 +49,7 @@ elif [ $PUBLISHMETA ] ; then
 	fi
 
 elif [ $TARGET ] ; then
-    make $TARGET || exit $?
+    $MAKE $TARGET || exit $?
 
 	if [ $PUBLISH_URL ] ; then
 		if   [ -f ${TARGET_FILE}.bin ] ; then
@@ -64,7 +66,7 @@ elif [ $TARGET ] ; then
 	fi
 
 elif [ $GOAL ] ; then
-    make V=0 $GOAL || exit $?
+    $MAKE $GOAL || exit $?
     
     if [ "test" == "$GOAL" ] ; then
         lcov --directory . -b src/test --capture --output-file coverage.info 2>&1 | grep -E ":version '402\*', prefer.*'406\*" --invert-match
@@ -74,5 +76,5 @@ elif [ $GOAL ] ; then
     fi
 
 else 
-    make V=0 all
+    $MAKE all
 fi

--- a/Makefile
+++ b/Makefile
@@ -1158,6 +1158,7 @@ CFLAGS      += $(ARCH_FLAGS) \
               $(DEBUG_FLAGS) \
               -std=gnu99 \
               -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
+              -Werror \
               -ffunction-sections \
               -fdata-sections \
               -pedantic \

--- a/Makefile
+++ b/Makefile
@@ -1158,7 +1158,6 @@ CFLAGS      += $(ARCH_FLAGS) \
               $(DEBUG_FLAGS) \
               -std=gnu99 \
               -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
-              -Werror \
               -ffunction-sections \
               -fdata-sections \
               -pedantic \
@@ -1170,7 +1169,9 @@ CFLAGS      += $(ARCH_FLAGS) \
               -D'__TARGET__="$(TARGET)"' \
               -D'__REVISION__="$(REVISION)"' \
               -save-temps=obj \
-              -MMD -MP
+              -MMD -MP \
+              $(EXTRA_FLAGS)
+
 
 ASFLAGS     = $(ARCH_FLAGS) \
               -x assembler-with-cpp \


### PR DESCRIPTION
This is just an example and a suggestion for discussion how to block all compiler warnings and make them visible as hard red errors. I am not sure we want to be this strict. Currently all builds would be RED, mainly by some 11 warnings in the SITL target build. 
