### PR TITLE
AlienFlight F4/F7 DMA updates

### DIFF
--- a/src/main/target/ALIENFLIGHTF4/target.c
+++ b/src/main/target/ALIENFLIGHTF4/target.c
@@ -25,9 +25,9 @@
 #include "drivers/timer_def.h"
 
 // DSHOT will work for motor 1,3,4,5,6,7 and 8.
-// Motor 2 pin timers have no DMA channel assigned in the hardware.
-// If the ADC is used motor 7 will not work.
-// If UART1 is used motor 8 will not work.
+// Motor 2 pin timers have no DMA channel assigned in the hardware. Remapping of the pin is needed.
+// If SDCard or UART4 DMA is used motor 4 will not work.
+// If UART1 DMA is used motor 8 will not work.
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH1, PA8,  TIM_USE_PWM | TIM_USE_PPM, TIMER_INPUT_ENABLED,  1), // PWM1  - PA8  RC1  - DMA2_ST6, *DMA2_ST1, DMA2_ST3

--- a/src/main/target/ALIENFLIGHTF4/target.h
+++ b/src/main/target/ALIENFLIGHTF4/target.h
@@ -148,6 +148,7 @@
 #define I2C1_SDA                PB7
 
 #define USE_ADC
+#define ADC1_DMA_STREAM         DMA2_Stream0
 //#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
 //#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define VBAT_ADC_PIN            PC0

--- a/src/main/target/ALIENFLIGHTNGF7/target.c
+++ b/src/main/target/ALIENFLIGHTNGF7/target.c
@@ -25,8 +25,7 @@
 #include "drivers/timer_def.h"
 
 // DSHOT will work for motor 1-8.
-// If SDCard or UART4 DMA is used motor 6 will not work.
-// If the ADC is used motor 7 will not work.
+// If SDCard or UART4 DMA is used motor 7 will not work.
 // If UART1 DMA is used motor 8 will not work.
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
@@ -36,8 +35,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH2N, PB14, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED , 0), // PWM3  - DMA2_ST6, DMA2_ST2
     DEF_TIM(TIM3, CH3,  PB0,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM4  - DMA1_ST7
     DEF_TIM(TIM5, CH1,  PA0,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM5  - DMA1_ST2
-    DEF_TIM(TIM5, CH2,  PA1,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM6  - (DMA1_ST4)             - DMA SDCard, DMA Serial_TX4
-    DEF_TIM(TIM8, CH3,  PC8,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM7  - (DMA2_ST4) DMA2_ST2    - DMA ADC
+    DEF_TIM(TIM8, CH3,  PC8,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM6  - (DMA2_ST4) DMA2_ST2
+    DEF_TIM(TIM5, CH2,  PA1,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM7  - (DMA1_ST4)             - DMA SDCard, DMA Serial_TX4
     DEF_TIM(TIM8, CH4,  PC9,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM8  - (DMA2_ST7)             - DMA Serial_TX1
     DEF_TIM(TIM3, CH4,  PB1,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM9  - (DMA1_ST2)             - Collision
     DEF_TIM(TIM1, CH3N, PB15, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED , 0), // PWM10 - (DMA2_ST6), (DMA2_ST6) - Collision

--- a/src/main/target/ALIENFLIGHTNGF7/target.h
+++ b/src/main/target/ALIENFLIGHTNGF7/target.h
@@ -158,6 +158,7 @@
 #define I2C1_SDA                PB7
 
 #define USE_ADC
+#define ADC1_DMA_STREAM         DMA2_Stream0
 //#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
 //#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define VBAT_ADC_PIN            PC0


### PR DESCRIPTION
AlienFlight F7 Ver 1.0 Hexa boards need an remap which swaps motor 6 and 7. This boards don't have an SDCard port anyhow and will not suffer from DMA restrictions. All other boards will be fine. This change will allow to operate Hexacopters using DSHOT without any DMA restrictions.