### PR TITLE
Added 'esc_sensor_halfduplex' setting to enable KISSFC owners to use 'TLM' pads for ESC stelemetry lines.

### DIFF
--- a/src/main/config/parameter_group_ids.h
+++ b/src/main/config/parameter_group_ids.h
@@ -105,7 +105,8 @@
 #define PG_VCD_CONFIG 514
 #define PG_VTX_CONFIG 515
 #define PG_SONAR_CONFIG 516
-#define PG_BETAFLIGHT_END 516
+#define PG_ESC_SENSOR_CONFIG 517
+#define PG_BETAFLIGHT_END 517
 
 
 // OSD configuration (subject to change)

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -32,6 +32,7 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
+#include "sensors/esc_sensor.h"
 #include "sensors/gyro.h"
 
 #include "fc/settings.h"
@@ -688,6 +689,10 @@ const clivalue_t valueTable[] = {
 #ifdef USE_MAX7456
     { "displayport_max7456_col_adjust", VAR_INT8| MASTER_VALUE, .config.minmax = { -6, 0 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, colAdjust) },
     { "displayport_max7456_row_adjust", VAR_INT8| MASTER_VALUE, .config.minmax = { -3, 0 }, PG_DISPLAY_PORT_MAX7456_CONFIG, offsetof(displayPortProfile_t, rowAdjust) },
+#endif
+
+#ifdef USE_ESC_SENSOR
+    { "esc_sensor_halfduplex",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, halfDuplex) },
 #endif
 };
 

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -64,6 +64,12 @@ Byte 9: 8-bit CRC
 
 */
 
+PG_REGISTER_WITH_RESET_TEMPLATE(escSensorConfig_t, escSensorConfig, PG_ESC_SENSOR_CONFIG, 0);
+
+PG_RESET_TEMPLATE(escSensorConfig_t, escSensorConfig,
+        .halfDuplex = 0
+);
+
 /*
 DEBUG INFORMATION
 -----------------
@@ -183,7 +189,7 @@ bool escSensorInit(void)
         return false;
     }
 
-    portOptions_t options = (SERIAL_NOT_INVERTED);
+    portOptions_t options = SERIAL_NOT_INVERTED  | (escSensorConfig()->halfDuplex ? SERIAL_BIDIR : 0);
 
     // Initialize serial port
     escSensorPort = openSerialPort(portConfig->identifier, FUNCTION_ESC_SENSOR, escSensorDataReceive, ESC_SENSOR_BAUDRATE, MODE_RX, options);

--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -19,6 +19,12 @@
 
 #include "common/time.h"
 
+typedef struct escSensorConfig_s {
+    uint8_t halfDuplex;             // Set to false to listen on the TX pin for telemetry data
+} escSensorConfig_t;
+
+PG_DECLARE(escSensorConfig_t, escSensorConfig);
+
 typedef struct {
     uint8_t dataAge;
     int8_t temperature;


### PR DESCRIPTION
Fixes #3121.

Setting `esc_sensor_halfduplex` to true sets `SERIAL_BIDIR` on the port used for the ESC sensor. This allows owners of the KISSFC to use the 'TLM' pads on their board for ESC telemetry connections, which are wired to UART3 TX.

(I know 'halfduplex' is somewhat daft in this context, but for RX / telemetry, `halfduplex` is used to enable `SERIAL_BIDIR` on the port, so it's at least consistent. Suggestions for a better name for all three of them are welcome.)