### PR TITLE
Allow customisation of the OSD stats screen

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -653,6 +653,13 @@ const clivalue_t valueTable[] = {
     { "osd_rol_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ROLL_ANGLE]) },
     { "osd_battery_usage_pos",      VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_USAGE]) },
 
+    { "osd_stat_max_spd",           VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MAX_SPEED])},
+    { "osd_stat_min_batt",          VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MIN_BATTERY])},
+    { "osd_stat_min_rssi",          VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MIN_RSSI])},
+    { "osd_stat_max_curr",          VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MAX_CURRENT])},
+    { "osd_stat_used_mah",          VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_USED_MAH])},
+    { "osd_stat_max_alt",           VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MAX_ALTITUDE])},
+    { "osd_stat_bbox",              VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_BLACKBOX])},
 #endif
 
 // PG_SYSTEM_CONFIG

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -660,6 +660,9 @@ const clivalue_t valueTable[] = {
     { "osd_stat_used_mah",          VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_USED_MAH])},
     { "osd_stat_max_alt",           VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MAX_ALTITUDE])},
     { "osd_stat_bbox",              VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_BLACKBOX])},
+    { "osd_stat_endbatt",           VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_END_BATTERY])},
+    { "osd_stat_flytime",           VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_FLYTIME])},
+    { "osd_stat_armtime",           VAR_UINT8   | MASTER_VALUE, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_ARMEDTIME])},
 #endif
 
 // PG_SYSTEM_CONFIG

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -824,6 +824,13 @@ static void osdGetBlackboxStatusString(char * buff, uint8_t len)
 }
 #endif
 
+static void osdDisplayStatisticLabel(uint8_t y, const char * text, const char * value)
+{
+    displayWrite(osdDisplayPort, 2, y, text);
+    displayWrite(osdDisplayPort, 20, y, ":");
+    displayWrite(osdDisplayPort, 22, y, value);
+}
+
 static void osdShowStats(void)
 {
     uint8_t top = 2;
@@ -833,70 +840,59 @@ static void osdShowStats(void)
     displayWrite(osdDisplayPort, 2, top++, "  --- STATS ---");
 
     if (osdConfig()->enabled_stats[OSD_STAT_ARMEDTIME]) {
-        displayWrite(osdDisplayPort, 2, top, "ARMED TIME       :");
         tfp_sprintf(buff, "%02d:%02d", stats.armed_time / 60, stats.armed_time % 60);
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "ARMED TIME", buff);
     }
 
     if (osdConfig()->enabled_stats[OSD_STAT_FLYTIME]) {
-        displayWrite(osdDisplayPort, 2, top, "FLY TIME         :");
         tfp_sprintf(buff, "%02d:%02d", flyTime / 60, flyTime % 60);
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "FLY TIME", buff);
     }
 
     if (osdConfig()->enabled_stats[OSD_STAT_MAX_SPEED] && STATE(GPS_FIX)) {
-        displayWrite(osdDisplayPort, 2, top, "MAX SPEED        :");
         itoa(stats.max_speed, buff, 10);
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "MAX SPEED", buff);
     }
 
     if (osdConfig()->enabled_stats[OSD_STAT_MIN_BATTERY]) {
-        displayWrite(osdDisplayPort, 2, top, "MIN BATTERY      :");
         tfp_sprintf(buff, "%d.%1dV", stats.min_voltage / 10, stats.min_voltage % 10);
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "MIN BATTERY", buff);
     }
 
     if (osdConfig()->enabled_stats[OSD_STAT_END_BATTERY]) {
-        displayWrite(osdDisplayPort, 2, top, "END BATTERY      :");
         tfp_sprintf(buff, "%d.%1dV", getBatteryVoltage() / 10, getBatteryVoltage() % 10);
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "END BATTERY", buff);
     }
 
     if (osdConfig()->enabled_stats[OSD_STAT_MIN_RSSI]) {
-        displayWrite(osdDisplayPort, 2, top, "MIN RSSI         :");
         itoa(stats.min_rssi, buff, 10);
         strcat(buff, "%");
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "MIN RSSI", buff);
     }
 
     if (batteryConfig()->currentMeterSource != CURRENT_METER_NONE) {
         if (osdConfig()->enabled_stats[OSD_STAT_MAX_CURRENT]) {
-            displayWrite(osdDisplayPort, 2, top, "MAX CURRENT      :");
             itoa(stats.max_current, buff, 10);
             strcat(buff, "A");
-            displayWrite(osdDisplayPort, 22, top++, buff);
+            osdDisplayStatisticLabel(top++, "MAX CURRENT", buff);
         }
 
         if (osdConfig()->enabled_stats[OSD_STAT_USED_MAH]) {
-            displayWrite(osdDisplayPort, 2, top, "USED MAH         :");
-            itoa(getMAhDrawn(), buff, 10);
-            strcat(buff, "\x07");
-            displayWrite(osdDisplayPort, 22, top++, buff);
+            tfp_sprintf(buff, "%d%c", getMAhDrawn(), SYM_MAH);
+            osdDisplayStatisticLabel(top++, "USED MAH", buff);
         }
     }
 
     if (osdConfig()->enabled_stats[OSD_STAT_MAX_ALTITUDE]) {
-        displayWrite(osdDisplayPort, 2, top, "MAX ALTITUDE     :");
         int32_t alt = osdGetAltitude(stats.max_altitude);
         tfp_sprintf(buff, "%c%d.%01d%c", alt < 0 ? '-' : ' ', abs(alt / 100), abs((alt % 100) / 10), osdGetAltitudeSymbol());
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "MAX ALTITUDE", buff);
     }
 
 #ifdef BLACKBOX
     if (osdConfig()->enabled_stats[OSD_STAT_BLACKBOX] && blackboxConfig()->device && blackboxConfig()->device != BLACKBOX_DEVICE_SERIAL) {
-        displayWrite(osdDisplayPort, 2, top, "BLACKBOX         :");
         osdGetBlackboxStatusString(buff, 10);
-        displayWrite(osdDisplayPort, 22, top++, buff);
+        osdDisplayStatisticLabel(top++, "BLACKBOX", buff);
     }
 #endif
 }

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -60,12 +60,24 @@ typedef enum {
 } osd_items_e;
 
 typedef enum {
+    OSD_STAT_MAX_SPEED,
+    OSD_STAT_MIN_BATTERY,
+    OSD_STAT_MIN_RSSI,
+    OSD_STAT_MAX_CURRENT,
+    OSD_STAT_USED_MAH,
+    OSD_STAT_MAX_ALTITUDE,
+    OSD_STAT_BLACKBOX,
+    OSD_STAT_COUNT // MUST BE LAST
+} osd_states_e;
+
+typedef enum {
     OSD_UNIT_IMPERIAL,
     OSD_UNIT_METRIC
 } osd_unit_e;
 
 typedef struct osdConfig_s {
     uint16_t item_pos[OSD_ITEM_COUNT];
+    bool enabled_stats[OSD_STAT_COUNT];
 
     // Alarms
     uint8_t rssi_alarm;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -56,6 +56,7 @@ typedef enum {
     OSD_PITCH_ANGLE,
     OSD_ROLL_ANGLE,
     OSD_MAIN_BATT_USAGE,
+    OSD_ARMED_TIME,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -67,6 +68,9 @@ typedef enum {
     OSD_STAT_USED_MAH,
     OSD_STAT_MAX_ALTITUDE,
     OSD_STAT_BLACKBOX,
+    OSD_STAT_END_BATTERY,
+    OSD_STAT_FLYTIME,
+    OSD_STAT_ARMEDTIME,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_states_e;
 


### PR DESCRIPTION
Implements suggestions from #3039.

Allows configuration of the info displayed on the statistics/disarm screen.