### PR TITLE
Unified 'frsky_vfas_cell_voltage' and 'ibus_report_cell_voltage' into 'report_cell_voltage'.

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -601,11 +601,10 @@ const clivalue_t valueTable[] = {
     { "frsky_gps_format",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, FRSKY_FORMAT_NMEA }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, frsky_coordinate_format) },
     { "frsky_unit",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_UNIT }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, frsky_unit) },
     { "frsky_vfas_precision",       VAR_UINT8  | MASTER_VALUE, .config.minmax = { FRSKY_VFAS_PRECISION_LOW,  FRSKY_VFAS_PRECISION_HIGH }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, frsky_vfas_precision) },
-    { "frsky_vfas_cell_voltage",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, frsky_vfas_cell_voltage) },
     { "hott_alarm_int",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 120 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, hottAlarmSoundInterval) },
     { "pid_in_tlm",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = {TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, pidValuesAsTelemetry) },
 #if defined(TELEMETRY_IBUS)
-    { "ibus_report_cell_voltage",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, report_cell_voltage) },
+    { "report_cell_voltage",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, report_cell_voltage) },
 #endif
 #endif
 

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -416,7 +416,7 @@ static void sendVoltageAmp(void)
     } else {
         uint16_t voltage = (batteryVoltage * 110) / 21;
         uint16_t vfasVoltage;
-        if (telemetryConfig()->frsky_vfas_cell_voltage) {
+        if (telemetryConfig()->report_cell_voltage) {
             vfasVoltage = voltage / getBatteryCellCount();
         } else {
             vfasVoltage = voltage;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -619,7 +619,7 @@ void handleSmartPortTelemetry(void)
             case FSSP_DATAID_VFAS       :
                 if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && getBatteryCellCount() > 0) {
                     uint16_t vfasVoltage;
-                    if (telemetryConfig()->frsky_vfas_cell_voltage) {
+                    if (telemetryConfig()->report_cell_voltage) {
                         vfasVoltage = getBatteryVoltage() / getBatteryCellCount();
                     } else {
                         vfasVoltage = getBatteryVoltage();

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -46,7 +46,7 @@ typedef struct telemetryConfig_s {
     frskyGpsCoordFormat_e frsky_coordinate_format;
     frskyUnit_e frsky_unit;
     uint8_t frsky_vfas_precision;
-    uint8_t frsky_vfas_cell_voltage;
+    uint8_t frsky_vfas_cell_voltage;        // Unused. Use 'report_cell_voltage' instead.
     uint8_t hottAlarmSoundInterval;
     uint8_t pidValuesAsTelemetry;
     uint8_t report_cell_voltage;


### PR DESCRIPTION
@martinbudden Can you confirm that leaving disused parameters in the parameter group is the right thing to do, or should they be removed?