### PR TITLE
[OMNIBUSF4/OMNIBUSF4SD] Protect non-CL_RACINGF4 targets from using PWM beeper

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -41,7 +41,9 @@
 //#define LED1                    PB4 // Remove this at the next major release
 #define BEEPER                  PB4
 #define BEEPER_INVERTED
+#if defined(CL_RACINGF4)
 #define BEEPER_PWM_HZ           3800 // Beeper PWM frequency in Hz
+#endif
 
 #ifdef OMNIBUSF4SD
 #define INVERTER_PIN_UART6      PC8 // Omnibus F4 V3 and later


### PR DESCRIPTION
PR status: Merge (immediately)

Target independent `BEEPER_PWM_HZ` definition prevents proper beeper operation on non-`CL_RACINGF4` targets.