### PR TITLE
Coverage only created and published if PUBLISHCOV is defined.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -68,13 +68,14 @@ elif [ $TARGET ] ; then
 elif [ $GOAL ] ; then
     $MAKE $GOAL || exit $?
     
+  if [ $PUBLISHCOV ] ; then
     if [ "test" == "$GOAL" ] ; then
         lcov --directory . -b src/test --capture --output-file coverage.info 2>&1 | grep -E ":version '402\*', prefer.*'406\*" --invert-match
         lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info # filter out system and test code
         lcov --list coverage.info # debug before upload
         coveralls-lcov coverage.info # uploads to coveralls
     fi
-
+  fi
 else 
     $MAKE all
 fi


### PR DESCRIPTION
Since there are some problems with lcov/gcov with current version of clang used to compile unittests, all coverage computation and publishing on the coverall site is made conditional on  `PUBLISHCOV ` being defined. I.e. to enable coverage:

    export PUBLISHCOV=YES
    export GOAL=test
    ./.travis.sh

By default no coverage data is computed nor published, as long as `$PUBLISHCOV `is undefined.
