### PR TITLE
Replace sprintf with tfp_sprintf

### DIFF
--- a/lib/main/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
+++ b/lib/main/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
@@ -47,7 +47,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx.h"
 #include "Legacy/stm32_hal_legacy.h"
-#include <stdio.h>
+#include <stddef.h>
 /* Exported types ------------------------------------------------------------*/
 
 /** 

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -21,7 +21,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 
@@ -38,6 +37,7 @@
 #include "cms/cms_types.h"
 #include "cms/cms_menu_blackbox.h"
 
+#include "common/printf.h"
 #include "common/utils.h"
 
 #include "config/feature.h"
@@ -108,22 +108,22 @@ static void cmsx_Blackbox_GetDeviceStatus()
         unit = "MB";
 
         if (!sdcard_isInserted()) {
-            snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "NO CARD");
+            tfp_sprintf(cmsx_BlackboxStatus, "NO CARD");
         } else if (!sdcard_isFunctional()) {
-            snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "FAULT");
+            tfp_sprintf(cmsx_BlackboxStatus, "FAULT");
         } else {
             switch (afatfs_getFilesystemState()) {
             case AFATFS_FILESYSTEM_STATE_READY:
-                snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "READY");
+                tfp_sprintf(cmsx_BlackboxStatus, "READY");
                 storageDeviceIsWorking = true;
                 break;
             case AFATFS_FILESYSTEM_STATE_INITIALIZATION:
-                snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "INIT");
+                tfp_sprintf(cmsx_BlackboxStatus, "INIT");
                 break;
             case AFATFS_FILESYSTEM_STATE_FATAL:
             case AFATFS_FILESYSTEM_STATE_UNKNOWN:
             default:
-                snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "FAULT");
+                tfp_sprintf(cmsx_BlackboxStatus, "FAULT");
                 break;
             }
         }
@@ -142,25 +142,25 @@ static void cmsx_Blackbox_GetDeviceStatus()
 
         storageDeviceIsWorking = flashfsIsReady();
         if (storageDeviceIsWorking) {
-            snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "READY");
+            tfp_sprintf(cmsx_BlackboxStatus, "READY");
 
             const flashGeometry_t *geometry = flashfsGetGeometry();
             storageUsed = flashfsGetOffset() / 1024;
             storageFree = (geometry->totalSize / 1024) - storageUsed;
         } else {
-            snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "FAULT");
+            tfp_sprintf(cmsx_BlackboxStatus, "FAULT");
         }
 
         break;
 #endif
 
     default:
-        snprintf(cmsx_BlackboxStatus, CMS_BLACKBOX_STRING_LENGTH, "---");
+        tfp_sprintf(cmsx_BlackboxStatus, "---");
     }
 
     /* Storage counters */
-    snprintf(cmsx_BlackboxDeviceStorageUsed, CMS_BLACKBOX_STRING_LENGTH, "%ld%s", storageUsed, unit);
-    snprintf(cmsx_BlackboxDeviceStorageFree, CMS_BLACKBOX_STRING_LENGTH, "%ld%s", storageFree, unit);
+    tfp_sprintf(cmsx_BlackboxDeviceStorageUsed, "%ld%s", storageUsed, unit);
+    tfp_sprintf(cmsx_BlackboxDeviceStorageFree, "%ld%s", storageFree, unit);
 }
 
 static long cmsx_Blackbox_onEnter(void)

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -17,7 +17,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -24,7 +24,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -323,7 +322,7 @@ static void osdDrawSingleElement(uint8_t item)
 
             const char vtxBandLetter = vtx58BandLetter[band];
             const char *vtxChannelName = vtx58ChannelNames[channel];
-            sprintf(buff, "%c:%s:%d", vtxBandLetter, vtxChannelName, power);
+            tfp_sprintf(buff, "%c:%s:%d", vtxBandLetter, vtxChannelName, power);
             break;
         }
 #endif
@@ -450,7 +449,7 @@ static void osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_DEBUG:
-        sprintf(buff, "DBG %5d %5d %5d %5d", debug[0], debug[1], debug[2], debug[3]);
+        tfp_sprintf(buff, "DBG %5d %5d %5d %5d", debug[0], debug[1], debug[2], debug[3]);
         break;
 
     case OSD_PITCH_ANGLE:
@@ -755,14 +754,13 @@ static void osdUpdateStats(void)
 }
 
 #ifdef BLACKBOX
-static void osdGetBlackboxStatusString(char * buff, uint8_t len)
+static void osdGetBlackboxStatusString(char * buff)
 {
     bool storageDeviceIsWorking = false;
     uint32_t storageUsed = 0;
     uint32_t storageTotal = 0;
 
-    switch (blackboxConfig()->device)
-    {
+    switch (blackboxConfig()->device) {
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
         storageDeviceIsWorking = sdcard_isInserted() && sdcard_isFunctional() && (afatfs_getFilesystemState() == AFATFS_FILESYSTEM_STATE_READY);
@@ -789,10 +787,10 @@ static void osdGetBlackboxStatusString(char * buff, uint8_t len)
     }
 
     if (storageDeviceIsWorking) {
-        uint16_t storageUsedPercent = (storageUsed * 100) / storageTotal;
-        snprintf(buff, len, "%d%%", storageUsedPercent);
+        const uint16_t storageUsedPercent = (storageUsed * 100) / storageTotal;
+        tfp_sprintf(buff, "%d%%", storageUsedPercent);
     } else {
-        snprintf(buff, len, "FAULT");
+        tfp_sprintf(buff, "FAULT");
     }
 }
 #endif
@@ -864,7 +862,7 @@ static void osdShowStats(void)
 
 #ifdef BLACKBOX
     if (osdConfig()->enabled_stats[OSD_STAT_BLACKBOX] && blackboxConfig()->device && blackboxConfig()->device != BLACKBOX_DEVICE_SERIAL) {
-        osdGetBlackboxStatusString(buff, 10);
+        osdGetBlackboxStatusString(buff);
         osdDisplayStatisticLabel(top++, "BLACKBOX", buff);
     }
 #endif

--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -30,7 +30,6 @@
 #include "cms/cms.h"
 #include "cms/cms_types.h"
 
-#include "common/printf.h"
 #include "common/utils.h"
 
 #include "config/parameter_group.h"

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -64,7 +64,7 @@ serialPort_t *debugSerialPort = NULL;
 #define dprintf(x) if (debugSerialPort) printf x
 #else
 #define dprintf(x)
-#endif
+#endif // SMARTAUDIO_DPRINTF
 
 #include "build/debug.h"
 

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if !defined(UNIT_TEST) && !defined(SITL)
+#if !defined(UNIT_TEST) && !defined(SITL) && !(USBD_DEBUG_LEVEL > 0)
 #pragma GCC poison sprintf snprintf
 #endif
 

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#if !defined(UNIT_TEST) && !defined(SITL)
+#pragma GCC poison sprintf snprintf
+#endif
+
 #if defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F722xx)
 #include "stm32f7xx.h"
 #include "stm32f7xx_hal.h"

--- a/src/main/vcp_hal/usbd_conf.h
+++ b/src/main/vcp_hal/usbd_conf.h
@@ -51,7 +51,9 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx_hal.h"
+#if (USBD_DEBUG_LEVEL > 0)
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Saves 2452 bytes of ROM for BETAFLIGHTF3. Savings should be similar for other targets with OSD.