### PR TITLE
Fix targets using UART instead of USART for inverter pin

### DIFF
--- a/src/main/target/BEEROTORF4/target.h
+++ b/src/main/target/BEEROTORF4/target.h
@@ -88,14 +88,14 @@
 #define UART2_RX_PIN            PA3 //Shared with PPM
 #define UART2_TX_PIN            PA2
 
-#define INVERTER_PIN_UART2      PC15
+#define INVERTER_PIN_USART2     PC15
 
 //Telemetry
 #define USE_UART3
 #define UART3_RX_PIN            PB11
 #define UART3_TX_PIN            PB10
 
-#define INVERTER_PIN_UART3      PC14
+#define INVERTER_PIN_USART3     PC14
 
 #define SERIAL_PORT_COUNT 4
 

--- a/src/main/target/KROOZX/target.h
+++ b/src/main/target/KROOZX/target.h
@@ -33,8 +33,8 @@
 
 #define BEEPER                  PC1
 
-#define INVERTER_PIN_UART1      PB13
-#define INVERTER_PIN_UART6      PB12
+#define INVERTER_PIN_USART1     PB13
+#define INVERTER_PIN_USART6     PB12
 
 #define MPU6000_CS_PIN          PB2
 #define MPU6000_SPI_INSTANCE    SPI1

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -45,9 +45,9 @@
 #define BEEPER_INVERTED
 
 #ifdef OMNIBUSF4SD
-#define INVERTER_PIN_UART6      PC8 // Omnibus F4 V3 and later
+#define INVERTER_PIN_USART6     PC8 // Omnibus F4 V3 and later
 #else
-#define INVERTER_PIN_UART1      PC0 // PC0 used as inverter select GPIO XXX this is not used --- remove it at the next major release
+#define INVERTER_PIN_USART1     PC0 // PC0 used as inverter select GPIO XXX this is not used --- remove it at the next major release
 #endif
 
 #define MPU6000_CS_PIN          PA4


### PR DESCRIPTION
This commit fixes the inverter pin definitions for the BEEROTORF4, KROOZX and OMNIBUSF4 targets in the 3.1.7 release. This fixes ticket #2840 which was closed but others are having problems even with original OMNIBUSF4 hardware.