### PR TITLE
enable 'USE_RX_MSP' for NAZE targets

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -73,6 +73,8 @@
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 
+#define USE_RX_MSP
+
 #define GYRO
 #define USE_GYRO_MPU3050
 #define USE_GYRO_MPU6050


### PR DESCRIPTION
Porting PR https://github.com/cleanflight/cleanflight/pull/2819 from cleanflight. Successfully tested on NAZE rev6.