### PR TITLE
Reset mixer to MIXER_CUSTOM if configured mixer is not supported

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -546,7 +546,7 @@ void activateConfig(void)
 
 void validateAndFixConfig(void)
 {
-#if !defined(USE_UNCOMMON_MIXERS) || defined(USE_QUADX_MIXER_ONLY)
+#if !defined(USE_UNCOMMON_MIXERS) && !defined(USE_QUAD_MIXER_ONLY) && !defined(USE_OSD_SLAVE)
     if (mixers[mixerConfigMutable()->mixerMode].motor == NULL) {
         mixerConfigMutable()->mixerMode = MIXER_CUSTOM;
     }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -546,6 +546,12 @@ void activateConfig(void)
 
 void validateAndFixConfig(void)
 {
+#if !defined(USE_UNCOMMON_MIXERS) || defined(USE_QUADX_MIXER_ONLY)
+    if (mixers[mixerConfigMutable()->mixerMode].motor == NULL) {
+        mixerConfigMutable()->mixerMode = MIXER_CUSTOM;
+    }
+#endif
+
 #ifndef USE_OSD_SLAVE
     if((motorConfig()->dev.motorPwmProtocol == PWM_TYPE_BRUSHED) && (motorConfig()->mincommand < 1000)){
         motorConfigMutable()->mincommand = 1000;


### PR DESCRIPTION
Users of small flash boards who wishes to use uncommon mixers are often bit by absence of `USE_UNCOMMON_MIXERS`. Signify them by resetting the uncommon mixers to `MIXER_CUSTOM` to indicate there is something wrong with the mixer mode selection.