### PR TITLE
Avoid custom mixers from resetting into MIXER_CUSTOM

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -547,7 +547,8 @@ void activateConfig(void)
 void validateAndFixConfig(void)
 {
 #if !defined(USE_UNCOMMON_MIXERS) && !defined(USE_QUAD_MIXER_ONLY) && !defined(USE_OSD_SLAVE)
-    if (mixers[mixerConfigMutable()->mixerMode].motor == NULL) {
+    mixerMode_e mixerMode = mixerConfigMutable()->mixerMode;
+    if (mixerMode != MIXER_CUSTOM && mixerMode != MIXER_CUSTOM_AIRPLANE && mixerMode != MIXER_CUSTOM_TRI && mixers[mixerMode].motor == NULL) {
         mixerConfigMutable()->mixerMode = MIXER_CUSTOM;
     }
 #endif


### PR DESCRIPTION
This is a follow up to #3174.