### PR TITLE
Add back the OSD disarmed element

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -655,6 +655,8 @@ const clivalue_t valueTable[] = {
     { "osd_pit_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_PITCH_ANGLE]) },
     { "osd_rol_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ROLL_ANGLE]) },
     { "osd_battery_usage_pos",      VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_USAGE]) },
+    { "osd_arm_time_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ARMED_TIME]) },
+    { "osd_disarmed_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_DISARMED]) },
 
     { "osd_stat_max_spd",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MAX_SPEED])},
     { "osd_stat_min_batt",          VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MIN_BATTERY])},

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -509,6 +509,14 @@ static void osdDrawSingleElement(uint8_t item)
             break;
         }
 
+    case OSD_DISARMED:
+        if (!ARMING_FLAG(ARMED)) {
+            tfp_sprintf(buff, "DISARMED");
+            break;
+        } else {
+            return;
+        }
+
     default:
         return;
     }
@@ -564,6 +572,7 @@ void osdDrawElements(void)
     osdDrawSingleElement(OSD_ROLL_ANGLE);
     osdDrawSingleElement(OSD_MAIN_BATT_USAGE);
     osdDrawSingleElement(OSD_ARMED_TIME);
+    osdDrawSingleElement(OSD_DISARMED);
 
 #ifdef GPS
 #ifdef CMS
@@ -612,6 +621,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdProfile)
     osdProfile->item_pos[OSD_GPS_LON] = OSD_POS(18, 15) | VISIBLE_FLAG;
     osdProfile->item_pos[OSD_MAIN_BATT_USAGE] = OSD_POS(15, 10) | VISIBLE_FLAG;
     osdProfile->item_pos[OSD_ARMED_TIME] = OSD_POS(1, 2) | VISIBLE_FLAG;
+    osdProfile->item_pos[OSD_DISARMED] = OSD_POS(10, 4) | VISIBLE_FLAG;
 
     osdProfile->enabled_stats[OSD_STAT_MAX_SPEED] = true;
     osdProfile->enabled_stats[OSD_STAT_MIN_BATTERY] = true;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -57,6 +57,7 @@ typedef enum {
     OSD_ROLL_ANGLE,
     OSD_MAIN_BATT_USAGE,
     OSD_ARMED_TIME,
+    OSD_DISARMED,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
As per a recent request.

(This also includes a missing CLI setting for another OSD element)