### PR TITLE
Set telemetry_inversion to default on

### DIFF
--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -56,11 +56,7 @@
 
 PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
 
-#if defined(STM32F3)
 #define TELEMETRY_DEFAULT_INVERSION 1
-#else
-#define TELEMETRY_DEFAULT_INVERSION 0
-#endif
 
 PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     .telemetry_inversion = TELEMETRY_DEFAULT_INVERSION,


### PR DESCRIPTION
PR status: Ready to merge

As reported in #3190, migration to PG made `telemetry_inversion` initialized to off (0) for non-F3 targets, which caused SmartPort to fail on non-F3 targets.

Since `telemetry_inversion` is referenced only frsky and smartport telemetries, it is safe to initialize it to on (1) (at least atm).