### PR TITLE
Restored BLHELI 4WAY interface on BEEBRAIN

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -148,10 +148,6 @@
 
 #define SPEKTRUM_BIND_PIN       PA3
 
-#if !defined(BRUSHED_MOTORS)
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
-#endif
-
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
 
 // IO - assuming all IOs on 48pin package


### PR DESCRIPTION
Since BEEBRAIN can be used with brushless motors and there is room.

Addresses issue https://github.com/betaflight/betaflight/issues/3204