### PR TITLE
enable BOXHEADADJ when HEADFREEE is enabled

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -317,6 +317,7 @@ void initActiveBoxIds(void)
         BME(BOXANGLE);
         BME(BOXHORIZON);
         BME(BOXHEADFREE);
+        BME(BOXHEADADJ);
     }
 
 #ifdef BARO
@@ -328,7 +329,6 @@ void initActiveBoxIds(void)
 #ifdef MAG
     if (sensors(SENSOR_MAG)) {
         BME(BOXMAG);
-        BME(BOXHEADADJ);
     }
 #endif
 


### PR DESCRIPTION
enable BOXHEADADJ when HEADFREEE is enabled, to enable correction of gyro drift 