### PR TITLE
VTX LED Strip (Issue #3228)

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -40,6 +40,7 @@
 
 #include "drivers/light_ws2811strip.h"
 #include "drivers/serial.h"
+#include "drivers/vtx_common.h"
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
@@ -57,6 +58,7 @@
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/serial.h"
+#include "io/vtx_string.h"
 
 #include "rx/rx.h"
 
@@ -258,7 +260,7 @@ static const hsvColor_t* getSC(ledSpecialColorIds_e index)
 
 static const char directionCodes[LED_DIRECTION_COUNT] = { 'N', 'E', 'S', 'W', 'U', 'D' };
 static const char baseFunctionCodes[LED_BASEFUNCTION_COUNT]   = { 'C', 'F', 'A', 'L', 'S', 'G', 'R' };
-static const char overlayCodes[LED_OVERLAY_COUNT]   = { 'T', 'O', 'B', 'N', 'I', 'W' };
+static const char overlayCodes[LED_OVERLAY_COUNT]   = { 'T', 'O', 'B', 'V', 'I', 'W' };
 
 #define CHUNK_BUFFER_SIZE 11
 
@@ -488,16 +490,16 @@ static void applyLedFixedLayers()
 
         if (ledGetOverlayBit(ledConfig, LED_OVERLAY_THROTTLE))   //smooth fade with selected Aux channel of all HSV values from previousColor through color to nextColor
 	{
-	    int centerPWM = (PWM_RANGE_MIN + PWM_RANGE_MAX) / 2; 
-            if (auxInput < centerPWM) 
+	    int centerPWM = (PWM_RANGE_MIN + PWM_RANGE_MAX) / 2;
+            if (auxInput < centerPWM)
                 {
-                    color.h = scaleRange(auxInput, PWM_RANGE_MIN, centerPWM, previousColor.h, color.h);  
+                    color.h = scaleRange(auxInput, PWM_RANGE_MIN, centerPWM, previousColor.h, color.h);
                     color.s = scaleRange(auxInput, PWM_RANGE_MIN, centerPWM, previousColor.s, color.s);
                     color.v = scaleRange(auxInput, PWM_RANGE_MIN, centerPWM, previousColor.v, color.v);
                 }
-            else 
+            else
                 {
-                    color.h = scaleRange(auxInput, centerPWM, PWM_RANGE_MAX, color.h, nextColor.h);  
+                    color.h = scaleRange(auxInput, centerPWM, PWM_RANGE_MAX, color.h, nextColor.h);
                     color.s = scaleRange(auxInput, centerPWM, PWM_RANGE_MAX, color.s, nextColor.s);
                     color.v = scaleRange(auxInput, centerPWM, PWM_RANGE_MAX, color.v, nextColor.v);
                 }
@@ -573,6 +575,85 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_WARNING)), warningColor);
     }
 }
+
+#ifdef VTX_COMMON
+static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
+{
+    static uint16_t frequency = 0;
+    static uint8_t power = 255;
+    static uint8_t pit = 255;
+    static uint8_t showSettings = false;
+    static uint16_t lastCheck = 0;
+    static bool active = false;
+    static bool blink = false;
+    uint8_t band = 255, channel = 255;
+    uint16_t check = 0;
+
+    if (updateNow) {
+        // keep counter running, so it stays in sync with vtx
+        active = vtxCommonGetBandAndChannel(&band, &channel);
+        vtxCommonGetPowerIndex(&power);
+        vtxCommonGetPitMode(&pit);
+
+        frequency = vtx58frequencyTable[band][channel];
+
+        // check if last vtx values have changed.
+        check = pit + (power << 1) + (band << 4) + (channel << 8);
+        if(!showSettings && check != lastCheck) {
+            // display settings for 3 seconds.
+            showSettings = 15;
+        }
+        lastCheck = check; // quick way to check if any settings changed.
+
+        if(showSettings) {
+            showSettings--;
+        }
+        blink = !blink;
+        *timer += HZ_TO_US(5); // check 5 times a second
+    }
+
+    if(!active) { // no vtx device detected
+        return;
+    }
+
+    hsvColor_t color = {0, 0, 0};
+    if(showSettings) { // show settings
+        uint8_t vtxLedCount = 0;
+        for (int i = 0; i < ledCounts.count && vtxLedCount < 6; ++i) {
+            const ledConfig_t *ledConfig = &ledStripConfig()->ledConfigs[i];
+            if (ledGetOverlayBit(ledConfig, LED_OVERLAY_VTX)) {
+                if(vtxLedCount == 0) {
+                    color.h = HSV(GREEN).h;
+                    color.s = HSV(GREEN).s;
+                    color.v = blink ? 15 : 0; // blink received settings
+                }
+                else if(vtxLedCount > 0 && power >= vtxLedCount && !pit) { // show power
+                    color.h = HSV(ORANGE).h;
+                    color.s = HSV(ORANGE).s;
+                    color.v = blink ? 15 : 0; // blink received settings
+                }
+                else { // turn rest off
+                    color.h = HSV(BLACK).h;
+                    color.s = HSV(BLACK).s;
+                    color.v = HSV(BLACK).v;
+                }
+                setLedHsv(i, &color);
+                ++vtxLedCount;
+            }
+        }
+    }
+    else { // show frequency
+        // calculate the VTX color based on frequency
+        int hue = constrain((frequency - 5645.0 ) * 1.2, 0, 360);
+        // if we ever want to wrap the hue around the wheel for L band frequencies...
+        //hue = (hue+(hue<0)*((0-hue)/360+1)*361)%361;
+        color.h = hue;
+        color.s = 0;
+        color.v = pit ? (blink ? 15 : 0) : 255; // blink when in pit mode`
+        applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
+    }
+}
+#endif
 
 static void applyLedBatteryLayer(bool updateNow, timeUs_t *timer)
 {
@@ -855,8 +936,7 @@ static void applyLedBlinkLayer(bool updateNow, timeUs_t *timer)
         for (int i = 0; i < ledCounts.count; ++i) {
             const ledConfig_t *ledConfig = &ledStripConfig()->ledConfigs[i];
 
-            if (ledGetOverlayBit(ledConfig, LED_OVERLAY_BLINK) ||
-                    (ledGetOverlayBit(ledConfig, LED_OVERLAY_LANDING_FLASH) && scaledThrottle < 50)) {
+            if (ledGetOverlayBit(ledConfig, LED_OVERLAY_BLINK)) {
                 setLedHsv(i, getSC(LED_SCOLOR_BLINKBACKGROUND));
             }
         }
@@ -904,6 +984,9 @@ typedef enum {
     timGps,
 #endif
     timWarning,
+#ifdef VTX_COMMON
+    timVtx,
+#endif
     timIndicator,
 #ifdef USE_LED_ANIMATION
     timAnimation,
@@ -930,6 +1013,9 @@ static applyLayerFn_timed* layerTable[] = {
     [timGps] = &applyLedGpsLayer,
 #endif
     [timWarning] = &applyLedWarningLayer,
+#ifdef VTX_COMMON
+    [timVtx] = &applyLedVtxLayer,
+#endif
     [timIndicator] = &applyLedIndicatorLayer,
 #ifdef USE_LED_ANIMATION
     [timAnimation] = &applyLedAnimationLayer,

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -116,7 +116,7 @@ typedef enum {
     LED_OVERLAY_THROTTLE,
     LED_OVERLAY_LARSON_SCANNER,
     LED_OVERLAY_BLINK,
-    LED_OVERLAY_LANDING_FLASH,
+    LED_OVERLAY_VTX,
     LED_OVERLAY_INDICATOR,
     LED_OVERLAY_WARNING
 } ledOverlayId_e;
@@ -192,4 +192,3 @@ void applyDefaultLedStripConfig(ledConfig_t *ledConfig);
 void applyDefaultColors(hsvColor_t *colors);
 void applyDefaultModeColors(modeColorIndexes_t *modeColors);
 void applyDefaultSpecialColors(specialColorIndexes_t *specialColors);
-


### PR DESCRIPTION
This PR is in regards to [Change RGB LED color based on VTX channel](https://github.com/betaflight/betaflight/issues/3228)

In order to accomplish this I wound up having to replace the BLINK_ON_LANDING overlay since there was no more room for new overlay bits without heavy modification to the configurator and ledstrip.c code.

If no vtx device is connected the overlay will default back to user defined color.

When the are vtx settings are changed; a green led followed by the current power index will blink for 3 seconds at 5hz. The power index is device dependent with regards to mW power.
<img width="400" alt="screen shot 2017-06-10 at 11 42 09 pm" src="https://user-images.githubusercontent.com/3945263/27008973-7a2e0d78-4e36-11e7-9140-7c25e1780917.png">
(above example power index = 3)


Pit mode is represented by dimmed led's blinking at 5hz (color is based off the frequency).

Below is the frequency colormap.
<img width="1192" alt="screen shot 2017-06-10 at 11 32 15 pm" src="https://user-images.githubusercontent.com/3945263/27008933-3c1b9d4e-4e35-11e7-9c47-d5768ba924cb.png">

Frequencies outside 5645-5945 range will be red. I have a placeholder incase we ever want to have the color wheel loop around and support the illegal L Band.

I'll add a link to the corresponding configurator PR later.