### PR TITLE
[FRSKYF4] Remove MAG support

### DIFF
--- a/src/main/target/FRSKYF4/target.h
+++ b/src/main/target/FRSKYF4/target.h
@@ -41,9 +41,9 @@
 #define MPU_INT_EXTI            PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
-#define MAG
-#define USE_MAG_HMC5883
-#define MAG_HMC5883_ALIGN       CW90_DEG
+//#define MAG
+//#define USE_MAG_HMC5883
+//#define MAG_HMC5883_ALIGN       CW90_DEG
 
 #define BARO
 #define USE_BARO_MS5611


### PR DESCRIPTION
PR status: Ready to merge.

Remove MAG support from FRSKYF4 target, at least temporarily.

- It does not define any I2C bus to use (undefined behavior if mag is enabled?)
- It prevents reconfigurable I2C PR to build.
