### PR TITLE
[FRSKYF4] Drop I2C baro support

### DIFF
--- a/src/main/target/FRSKYF4/target.h
+++ b/src/main/target/FRSKYF4/target.h
@@ -46,7 +46,7 @@
 //#define MAG_HMC5883_ALIGN       CW90_DEG
 
 #define BARO
-#define USE_BARO_MS5611
+//#define USE_BARO_MS5611
 
 #define USE_BARO_BMP280
 #define USE_BARO_SPI_BMP280


### PR DESCRIPTION
PR status: Ready to merge.

This is a follow up to #3253.
I2C baro should be dropped also (no i2c bus defined).