### PR TITLE
Fix GPS coordinates in OSD

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -250,21 +250,20 @@ static void osdDrawSingleElement(uint8_t item)
         {
             int32_t val;
             if (item == OSD_GPS_LAT) {
-                buff[0] = 0x64; // right arrow
+                buff[0] = SYM_ARROW_EAST;
                 val = GPS_coord[LAT];
             } else {
-                buff[0] = 0x60; // down arrow
+                buff[0] = SYM_ARROW_SOUTH;
                 val = GPS_coord[LON];
             }
-            if (val >= 0) {
-                val += 1000000000;
-            } else {
-                val -= 1000000000;
-            }
-            itoa(val, &buff[1], 10);
-            buff[1] = buff[2];
-            buff[2] = buff[3];
-            buff[3] = '.';
+
+            char wholeDegreeString[5];
+            tfp_sprintf(wholeDegreeString, "%d", val / GPS_DEGREES_DIVIDER);
+
+            char wholeUnshifted[12];
+            tfp_sprintf(wholeUnshifted, "%d", val);
+
+            tfp_sprintf(buff + 1, "%s.%s", wholeDegreeString, wholeUnshifted + strlen(wholeDegreeString));
             break;
         }
 


### PR DESCRIPTION
The actual GPS coordinates shown in the OSD are wrong in some cases, they have several problems:
- The LON can be bigger than 99 (it goes from -180 to 180), but the code expect only two positions before the decimal point.
```
buff[1] = buff[2];
buff[2] = buff[3];
buff[3] = '.';
```
- When negative, the minus sign is deleted and replaced with the `1` from `val -= 1000000000`

I can modify the actual code, with a loop and some auxiliar variables, but I thinked that the actual iNav code is right and tested and seems to work, so I replaced it. Tested and works (at least in my GPS place).

Is that right? Do you prefer that I try to change the actual code?

