### PR TITLE
Heading and vario OSD elements

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -132,6 +132,8 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"PITCH PID",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_PITCH_PIDS], 0},
     {"YAW PID",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_YAW_PIDS], 0},
     {"DEBUG",              OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_DEBUG], 0},
+    {"HEADING",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_NUMERICAL_HEADING], 0},
+    {"VARIO",              OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_NUMERICAL_VARIO], 0},
     {"BACK",               OME_Back,    NULL, NULL, 0},
     {NULL,                 OME_END,     NULL, NULL, 0}
 };

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -658,6 +658,8 @@ const clivalue_t valueTable[] = {
     { "osd_battery_usage_pos",      VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_USAGE]) },
     { "osd_arm_time_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ARMED_TIME]) },
     { "osd_disarmed_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_DISARMED]) },
+    { "osd_nheading_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_NUMERICAL_HEADING]) },
+    { "osd_nvario_pos",             VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_NUMERICAL_VARIO]) },
 
     { "osd_stat_max_spd",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MAX_SPEED])},
     { "osd_stat_min_batt",          VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_MIN_BATTERY])},

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -189,6 +189,21 @@ static void osdFormatPID(char * buff, const char * label, const pid8_t * pid)
     tfp_sprintf(buff, "%s %3d %3d %3d", label, pid->P, pid->I, pid->D);
 }
 
+static uint8_t osdGetDirectionSymbolFromHeading(int heading)
+{
+    heading = (heading + 360) % 360;
+
+    heading = heading * 2 / 45;
+
+    // Now heading has a heading with Up=0, Right=4, Down=8 and Left=12
+    // Our symbols are Down=0, Right=4, Up=8 and Left=12
+    // There're 16 arrow symbols. Transform it.
+    heading = 16 - heading;
+    heading = (heading + 8) % 16;
+
+    return SYM_ARROW_SOUTH + heading;
+}
+
 static void osdDrawSingleElement(uint8_t item)
 {
     if (!VISIBLE(osdConfig()->item_pos[item]) || BLINK(item)) {
@@ -278,19 +293,8 @@ static void osdDrawSingleElement(uint8_t item)
     case OSD_HOME_DIR:
         if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
             if (GPS_distanceToHome > 0) {
-                int16_t h = GPS_directionToHome - DECIDEGREES_TO_DEGREES(attitude.values.yaw);
-
-                h = (h + 360) % 360;
-
-                h = h * 2 / 45;
-
-                // Now h has a heading with Up=0, Right=4, Down=8 and Left=12
-                // Our symbols are Down=0, Right=4, Up=8 and Left=12
-                // There're 16 arrow symbols. Transform it.
-                h = 16 - h;
-                h = (h + 8) % 16;
-
-                buff[0] = SYM_ARROW_SOUTH + h;
+                const int h = GPS_directionToHome - DECIDEGREES_TO_DEGREES(attitude.values.yaw);
+                buff[0] = osdGetDirectionSymbolFromHeading(h);
             } else {
                 // We don't have a HOME symbol in the font, by now we use this
                 buff[0] = SYM_THR1;
@@ -555,6 +559,21 @@ static void osdDrawSingleElement(uint8_t item)
             return;
         }
 
+    case OSD_NUMERICAL_HEADING:
+        {
+            const int heading = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
+            tfp_sprintf(buff, "%c%03d", osdGetDirectionSymbolFromHeading(heading), heading);
+            break;
+        }
+
+    case OSD_NUMERICAL_VARIO:
+        {
+            const int verticalSpeed = osdGetMetersToSelectedUnit(getEstimatedVario());
+            const char directionSymbol = verticalSpeed < 0 ? SYM_ARROW_SOUTH : SYM_ARROW_NORTH;
+            tfp_sprintf(buff, "%c%01d.%01d", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10));
+            break;
+        }
+
     default:
         return;
     }
@@ -611,6 +630,8 @@ void osdDrawElements(void)
     osdDrawSingleElement(OSD_MAIN_BATT_USAGE);
     osdDrawSingleElement(OSD_ARMED_TIME);
     osdDrawSingleElement(OSD_DISARMED);
+    osdDrawSingleElement(OSD_NUMERICAL_HEADING);
+    osdDrawSingleElement(OSD_NUMERICAL_VARIO);
 
 #ifdef GPS
 #ifdef CMS
@@ -664,6 +685,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_MAIN_BATT_USAGE]    = OSD_POS(8, 12)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ARMED_TIME]         = OSD_POS(1, 2)   | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_DISARMED]           = OSD_POS(10, 4)  | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_NUMERICAL_HEADING]  = OSD_POS(23, 9)  | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_NUMERICAL_VARIO]    = OSD_POS(23, 8)  | VISIBLE_FLAG;
 
     osdConfig->enabled_stats[OSD_STAT_MAX_SPEED]    = true;
     osdConfig->enabled_stats[OSD_STAT_MIN_BATTERY]  = true;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -60,6 +60,8 @@ typedef enum {
     OSD_DISARMED,
     OSD_HOME_DIR,
     OSD_HOME_DIST,
+    OSD_NUMERICAL_HEADING,
+    OSD_NUMERICAL_VARIO,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Adds numerical heading and vario OSD elements.

Vario is in either m/s or ft/s based on unit system setting.

It would be good for someone to test this on an FC with a barometer. I've tried injecting dummy values and the display/formatting appears to be fine.