### PR TITLE
Fix for MAG dependency in OSD HOME DIR

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -123,9 +123,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
 #ifdef GPS
     {"GPS SPEED",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_SPEED], 0},
     {"GPS SATS.",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_SATS], 0},
-#ifdef COMPASS
     {"HOME DIR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIR], 0},
-#endif
     {"HOME DIST",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIST], 0},
 #endif // GPS
     {"ALTITUDE",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ALTITUDE], 0},

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -78,7 +78,6 @@
 
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
-#include "sensors/compass.h"
 #include "sensors/sensors.h"
 
 #ifdef USE_HARDWARE_REVISION_DETECTION
@@ -276,7 +275,6 @@ static void osdDrawSingleElement(uint8_t item)
         }
         break;
 
-#ifdef MAG
     case OSD_HOME_DIR:
         if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
             if (GPS_distanceToHome > 0) {
@@ -307,7 +305,6 @@ static void osdDrawSingleElement(uint8_t item)
 
         break;
 
-#endif // COMPASS
 #endif // GPS
 
     case OSD_ALTITUDE:
@@ -627,11 +624,7 @@ void osdDrawElements(void)
         osdDrawSingleElement(OSD_GPS_LAT);
         osdDrawSingleElement(OSD_GPS_LON);
         osdDrawSingleElement(OSD_HOME_DIST);
-#ifdef COMPASS
-        if (sensors(SENSOR_MAG) || sensors(SENSOR_GPSMAG))
-        	osdDrawSingleElement(OSD_HOME_DIR);            
-#endif
-        
+        osdDrawSingleElement(OSD_HOME_DIR);
     }
 #endif // GPS
 }


### PR DESCRIPTION
This PR is a FIX over https://github.com/betaflight/betaflight/pull/3240

I made two mistakes:
- The attitude does not need the MAG dependency. The compiler error can be solved modifying an include in the `navigation`files. It only needs the GPS feature.
- By error, in a latest modification I added some `#ifdef COMPASS` when the correct form is `#ifdef MAG` so the HOME DIR element of the OSD will never work :(

Sorry for this errors. Please merge this PR soon to solve them.