### PR TITLE
Unit tests with clang warnings slips by unnoticed, added -Werror compiler option.

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -192,6 +192,7 @@ COMMON_FLAGS = \
 	-g \
 	-Wall \
 	-Wextra \
+	-Werror \
 	-ggdb3 \
 	-pthread \
 	-O0 \


### PR DESCRIPTION
There are currently a compiler warning in unit test that slips by unnoticed by Travis. This is now turned into an error by adding -Werror compiler option:

    compiling ../main/io/ledstrip.c
    In file included from ../main/io/ledstrip.c:43:
    ../main/drivers/vtx_common.h:38:30: error: duplicate 'const' declaration specifier [-Werror,-Wduplicate-decl-specifier]
        const struct vtxVTable_s const *vTable;
                                 ^
    1 error generated.
    Makefile:364: recipe for target '../../obj/test/ledstrip_unittest/io/ledstrip.c.o' failed
    make[1]: *** [../../obj/test/ledstrip_unittest/io/ledstrip.c.o] Error 1
