### PR TITLE
fix iterm acclerator gain scale

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -166,7 +166,7 @@ static void scaleRcCommandToFpvCamAngle(void) {
     const int16_t rcCommandSpeed = rcCommand[THROTTLE] - rcCommandThrottlePrevious[index];
 
     if(ABS(rcCommandSpeed) > throttleVelocityThreshold)
-        pidSetItermAccelerator(0.0001f * currentPidProfile->itermAcceleratorGain);
+        pidSetItermAccelerator(0.001f * currentPidProfile->itermAcceleratorGain);
     else
         pidSetItermAccelerator(1.0f);
 }


### PR DESCRIPTION
default value is 1000 and after scaling it should be 1 and not 0.1

see commit: https://github.com/betaflight/betaflight/commit/9c29475ba474caf673ee4f47f13798715b12002d

default value got changed from  .itermAcceleratorGain = 1.0f to .itermAcceleratorGain = 1000. 
so 0.001 should be correct and not 0.0001 :) 
