### PR TITLE
Configurable spektrum bind and bind plug pins

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2751,6 +2751,9 @@ const cliResourceValue_t resourceTable[] = {
 #ifdef USE_INVERTER
     { OWNER_INVERTER,      PG_SERIAL_PIN_CONFIG, offsetof(serialPinConfig_t, ioTagInverter[0]), SERIAL_PORT_MAX_INDEX },
 #endif
+#ifdef USE_SPEKTRUM_BIND
+    { OWNER_RX_BIND,       PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_bind_pin[0]), 2 }, // 0 = bind pin, 1 = bind plug
+#endif
 };
 
 static ioTag_t *getIoTag(const cliResourceValue_t value, uint8_t index)

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -24,6 +24,7 @@
 
 #include "common/utils.h"
 
+#include "drivers/io_types.h"
 #include "rx/rx.h"
 #include "rx/msp.h"
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -35,6 +35,7 @@
 #include "config/parameter_group_ids.h"
 
 #include "drivers/adc.h"
+#include "drivers/io_types.h"
 #include "drivers/rx_pwm.h"
 #include "drivers/rx_spi.h"
 #include "drivers/time.h"
@@ -107,6 +108,14 @@ static uint8_t rcSampleIndex = 0;
 #define RX_MAX_USEC 2115
 #define RX_MID_USEC 1500
 
+#ifndef SPEKTRUM_BIND_PIN
+#define SPEKTRUM_BIND_PIN NONE
+#endif
+
+#ifndef BINDPLUG_PIN
+#define BINDPLUG_PIN NONE
+#endif
+
 PG_REGISTER_WITH_RESET_FN(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
 void pgResetFn_rxConfig(rxConfig_t *rxConfig)
 {
@@ -115,6 +124,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .serialrx_provider = SERIALRX_PROVIDER,
         .rx_spi_protocol = RX_SPI_DEFAULT_PROTOCOL,
         .sbus_inversion = 1,
+        .spektrum_bind_pin = { IO_TAG(SPEKTRUM_BIND_PIN), IO_TAG(BINDPLUG_PIN) },
         .spektrum_sat_bind = 0,
         .spektrum_sat_bind_autoreset = 1,
         .midrc = RX_MID_USEC,

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -122,6 +122,7 @@ typedef struct rxConfig_s {
     uint8_t rx_spi_protocol;                // type of nrf24 protocol (0 = v202 250kbps). Must be enabled by FEATURE_RX_NRF24 first.
     uint32_t rx_spi_id;
     uint8_t rx_spi_rf_channel_count;
+    ioTag_t spektrum_bind_pin[2];           // 0: Bind pin, 1: Bind plug pin
     uint8_t spektrum_sat_bind;              // number of bind pulses for Spektrum satellite receivers
     uint8_t spektrum_sat_bind_autoreset;    // whenever we will reset (exit) binding mode after hard reboot
     uint8_t rssi_channel;

--- a/src/main/rx/spektrum.h
+++ b/src/main/rx/spektrum.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+// Indices of spektrum_bind_pin[]
+#define SPEKTRUM_BIND_PIN_INDEX        0
+#define SPEKTRUM_BIND_PLUG_PIN_INDEX   1
+
 #define SPEKTRUM_SAT_BIND_DISABLED     0
 #define SPEKTRUM_SAT_BIND_MAX         10
 

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -28,3 +28,11 @@
 #if defined(USE_QUAD_MIXER_ONLY) && defined(USE_SERVOS)
 #undef USE_SERVOS
 #endif
+
+// Backward compatibility for Spektrum bind functions
+#ifdef SPEKTRUM_BIND_PIN
+#define USE_SPEKTRUM_BIND
+#endif
+#ifdef BINDPLUG_PIN
+#define USE_SPEKTRUM_BIND_PLUG
+#endif


### PR DESCRIPTION
PR status: For discussion

An attempt to make spektrum bind and bind plug pins presented another interesting case of pin configurability.

The original code treated both bind and bind plug pins as sole `RX_BIND` resource (which is questionable but practically okay), but for configurability, these pins must be treated differently.

In this PR, rather than creating another resource `RX_BIND_PLUG`, these pins are treated as `RX_BIND 1` and `RX_BIND 2` respectively.

Thoughts?
