### PR TITLE
Configurable status LED

### DIFF
--- a/src/main/drivers/light_led.c
+++ b/src/main/drivers/light_led.c
@@ -17,13 +17,51 @@
 
 #include "platform.h"
 
+#include "config/parameter_group_ids.h"
 #include "drivers/io.h"
-#include "io_impl.h"
-
 #include "light_led.h"
 
 static IO_t leds[LED_NUMBER];
 static uint8_t ledPolarity = 0;
+
+PG_REGISTER_WITH_RESET_FN(statusLedConfig_t, statusLedConfig, PG_STATUS_LED_CONFIG, 0);
+
+#ifndef LED0
+#define LED0 NONE
+#endif
+
+#ifndef LED1
+#define LED1 NONE
+#endif
+
+#ifndef LED2
+#define LED2 NONE
+#endif
+
+void pgResetFn_statusLedConfig(statusLedConfig_t *statusLedConfig)
+{
+#ifdef LED0
+    statusLedConfig->ledTags[0] = IO_TAG(LED0);
+#endif
+#ifdef LED1
+    statusLedConfig->ledTags[1] = IO_TAG(LED1);
+#endif
+#ifdef LED2
+    statusLedConfig->ledTags[2] = IO_TAG(LED2);
+#endif
+
+    statusLedConfig->polarity = 0
+#ifdef LED0_INVERTED
+    | BIT(0)
+#endif
+#ifdef LED1_INVERTED
+    | BIT(1)
+#endif
+#ifdef LED2_INVERTED
+    | BIT(2)
+#endif
+    ;
+}
 
 void ledInit(const statusLedConfig_t *statusLedConfig)
 {

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -63,6 +63,7 @@ extern uint8_t __config_end;
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/inverter.h"
+#include "drivers/light_led.h"
 #include "drivers/rx_pwm.h"
 #include "drivers/sdcard.h"
 #include "drivers/sensor.h"
@@ -2751,6 +2752,7 @@ const cliResourceValue_t resourceTable[] = {
 #ifdef USE_INVERTER
     { OWNER_INVERTER,      PG_SERIAL_PIN_CONFIG, offsetof(serialPinConfig_t, ioTagInverter[0]), SERIAL_PORT_MAX_INDEX },
 #endif
+    { OWNER_LED,           PG_STATUS_LED_CONFIG, offsetof(statusLedConfig_t, ledTags[0]), LED_NUMBER },
 };
 
 static ioTag_t *getIoTag(const cliResourceValue_t value, uint8_t index)

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -148,7 +148,6 @@ PG_REGISTER_WITH_RESET_FN(pwmConfig_t, pwmConfig, PG_PWM_CONFIG, 0);
 #ifdef USE_PPM
 PG_REGISTER_WITH_RESET_FN(ppmConfig_t, ppmConfig, PG_PPM_CONFIG, 0);
 #endif
-PG_REGISTER_WITH_RESET_FN(statusLedConfig_t, statusLedConfig, PG_STATUS_LED_CONFIG, 0);
 
 #ifdef USE_FLASHFS
 PG_REGISTER_WITH_RESET_TEMPLATE(flashConfig_t, flashConfig, PG_FLASH_CONFIG, 0);
@@ -254,35 +253,6 @@ void pgResetFn_pwmConfig(pwmConfig_t *pwmConfig)
 #define FIRST_PORT_INDEX 0
 #define SECOND_PORT_INDEX 1
 #endif
-
-void pgResetFn_statusLedConfig(statusLedConfig_t *statusLedConfig)
-{
-    for (int i = 0; i < LED_NUMBER; i++) {
-        statusLedConfig->ledTags[i] = IO_TAG_NONE;
-    }
-
-#ifdef LED0
-    statusLedConfig->ledTags[0] = IO_TAG(LED0);
-#endif
-#ifdef LED1
-    statusLedConfig->ledTags[1] = IO_TAG(LED1);
-#endif
-#ifdef LED2
-    statusLedConfig->ledTags[2] = IO_TAG(LED2);
-#endif
-
-    statusLedConfig->polarity = 0
-#ifdef LED0_INVERTED
-    | BIT(0)
-#endif
-#ifdef LED1_INVERTED
-    | BIT(1)
-#endif
-#ifdef LED2_INVERTED
-    | BIT(2)
-#endif
-    ;
-}
 
 #ifndef USE_OSD_SLAVE
 uint8_t getCurrentPidProfileIndex(void)


### PR DESCRIPTION
PR status: For discussion

An attempt to make status LEDs configurable revealed another interesting problem; how to specify additional parameters for a resource.

For status LEDs, the parameter is `LEDx_INVERTED` (which is not handled in the initial cut).

How are we going to handle this?

(1) By allowing optional parameters following a pin name, e.g.,
```
resource LED 1 B03 0 # for non-inverted
resource LED 1 B03 1 # for non-inverted
```

(2) Using separate CLI variable(s)?
```
set led_0_inverted = true
set led_2_inverted = true
```
or encode inversion for leds as bits?
```
set led_inversion = 101 # == (LED0_INVERTED | LED2_INVERTED)
```

Thoughts?
