### PR TITLE
Remove SPIx_NSS_PIN from target.h

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -93,12 +93,10 @@
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 #define USE_SDCARD
 #define USE_SDCARD_SPI2
-#if defined(OMNIBUSF4SD)
 #define SDCARD_DETECT_INVERTED
-#endif
 #define SDCARD_DETECT_PIN               PB7
 #define SDCARD_SPI_INSTANCE             SPI2
-#define SDCARD_SPI_CS_PIN               SPI2_NSS_PIN
+#define SDCARD_SPI_CS_PIN               PB12
 // SPI2 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
 #define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
 // Divide to under 25MHz for normal operation:
@@ -116,7 +114,7 @@
 #define USE_FLASH_M25P16
 #else
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
-#define M25P16_CS_PIN           SPI3_NSS_PIN
+#define M25P16_CS_PIN           PB3
 #define M25P16_SPI_INSTANCE     SPI3
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
@@ -151,18 +149,12 @@
 
 #if defined(OMNIBUSF4SD) || defined(LUXF4OSD)
 #define USE_SPI_DEVICE_2
-#define SPI2_NSS_PIN            PB12
 #define SPI2_SCK_PIN            PB13
 #define SPI2_MISO_PIN           PB14
 #define SPI2_MOSI_PIN           PB15
 #endif
 
 #define USE_SPI_DEVICE_3
-#if defined(OMNIBUSF4SD)
-  #define SPI3_NSS_PIN          PA15
-#else
-  #define SPI3_NSS_PIN          PB3
-#endif
 #define SPI3_SCK_PIN            PC10
 #define SPI3_MISO_PIN           PC11
 #define SPI3_MOSI_PIN           PC12


### PR DESCRIPTION
PR status: For discussion

Many target.h includes definitions for `SPIx_NSS_PIN`, then use this to further define chip select pins for SPI attached devices. However, since we are not using SPI controller initiated select (the auto mode) at all and using manual mode for everything, this way of specifying the chip selects are semantically incorrect.

This PR demonstrates the removal of `SPIx_NSS_PIN` defines from a selected target.
(The process actually detected redundant `SPIx_NSS_PIN` definition, and incorrect ordering of `SPIx_NSS_PIN` definition and where it is used.)