### PR TITLE
Configurable HMC5883 (Preview)

### DIFF
--- a/src/main/config/parameter_group_ids.h
+++ b/src/main/config/parameter_group_ids.h
@@ -107,7 +107,8 @@
 #define PG_SONAR_CONFIG 516
 #define PG_ESC_SENSOR_CONFIG 517
 #define PG_I2C_CONFIG 518
-#define PG_BETAFLIGHT_END 518
+#define PG_BUSDEV_HMC5883_CONFIG 519
+#define PG_BETAFLIGHT_END 519
 
 
 // OSD configuration (subject to change)

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -18,7 +18,26 @@
 #pragma once
 
 #include "platform.h"
+#include "drivers/io_types.h"
 
 #ifdef TARGET_BUS_INIT
 void targetBusInit(void);
 #endif
+
+typedef enum {
+    BUSTYPE_NONE = 0,
+    BUSTYPE_I2C,
+    BUSTYPE_SPI,
+} busType_e;
+
+#define BUSTYPE_NONE_STR "NONE"
+#define BUSTYPE_I2C_STR  "I2C"
+#define BUSTYPE_SPI_STR  "SPI"
+
+typedef struct busDeviceConfig_s {
+    busType_e busType;
+    uint8_t   busNum;
+    uint8_t   i2cAddr;
+    ioTag_t   spiCsPin;
+    ioTag_t   drdyPin;
+} busDeviceConfig_t;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -38,6 +38,6 @@ typedef struct busDeviceConfig_s {
     busType_e busType;
     uint8_t   busNum;
     uint8_t   i2cAddr;
-    ioTag_t   spiCsPin;
-    ioTag_t   drdyPin;
+    ioTag_t   spiCsTag;
+    ioTag_t   drdyTag;
 } busDeviceConfig_t;

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -97,6 +97,15 @@ SPIDevice spiDeviceByInstance(SPI_TypeDef *instance)
     return SPIINVALID;
 }
 
+SPI_TypeDef *spiInstanceByDevice(SPIDevice device)
+{
+    if (device < SPIDEV_1 || device > (int)ARRAYLEN(spiHardwareMap)) {
+        return NULL;
+    }
+
+    return spiHardwareMap[device].dev;
+}
+
 void spiInitDevice(SPIDevice device)
 {
     spiDevice_t *spi = &(spiHardwareMap[device]);

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -96,6 +96,7 @@ bool spiTransfer(SPI_TypeDef *instance, uint8_t *out, const uint8_t *in, int len
 uint16_t spiGetErrorCounter(SPI_TypeDef *instance);
 void spiResetErrorCounter(SPI_TypeDef *instance);
 SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
+SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
 #if defined(USE_HAL_DRIVER)
 SPI_HandleTypeDef* spiHandleByInstance(SPI_TypeDef *instance);

--- a/src/main/drivers/bus_spi_hal.c
+++ b/src/main/drivers/bus_spi_hal.c
@@ -93,6 +93,15 @@ SPIDevice spiDeviceByInstance(SPI_TypeDef *instance)
     return SPIINVALID;
 }
 
+SPI_TypeDef *spiInstanceByDevice(SPIDevice device)
+{
+    if (device < SPIDEV_1 || device > (int)ARRAYLEN(spiHardwareMap)) {
+        return NULL;
+    }
+
+    return spiHardwareMap[device].dev;
+}
+
 SPI_HandleTypeDef* spiHandleByInstance(SPI_TypeDef *instance)
 {
     return &spiHardwareMap[spiDeviceByInstance(instance)].hspi;

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -81,11 +81,13 @@ PG_RESET_TEMPLATE(busDeviceConfig_t, magHMC5883Config,
     .busType = HMC5883_BUSTYPE,
     .busNum = I2C_DEV_TO_CFG(HMC5883_BUSNUM),
     .i2cAddr = MAG_ADDRESS,
-    .spiCsPin = IO_TAG(HMC5883_CS_PIN),
-    .drdyPin = IO_TAG(HMC5883_INT_EXTI),
+    .spiCsTag = IO_TAG(HMC5883_CS_PIN),
+    .drdyTag = IO_TAG(HMC5883_INT_EXTI),
 );
 
+#ifndef USE_MAG_SPI_HMC5883
 static I2CDevice i2cBus;
+#endif
 
 // HMC5883L, default address 0x1E
 // NAZE Target connections
@@ -330,7 +332,7 @@ static bool hmc5883lInit(void)
 bool hmc5883lDetect(magDev_t* mag)
 {
 #ifdef USE_MAG_DATA_READY_SIGNAL
-    hmc5883InterruptIO = IOGetByTag(magHMC5883Config()->drdyPin);
+    hmc5883InterruptIO = IOGetByTag(magHMC5883Config()->drdyTag);
 #endif
 
     uint8_t sig = 0;

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -29,6 +29,7 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
+#include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
@@ -37,12 +38,54 @@
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
 #include "compass.h"
 
 #include "compass_hmc5883l.h"
 #include "compass_spi_hmc5883l.h"
 
 //#define DEBUG_MAG_DATA_READY_INTERRUPT
+
+PG_REGISTER_WITH_RESET_TEMPLATE(busDeviceConfig_t, magHMC5883Config, PG_BUSDEV_HMC5883_CONFIG, 0);
+
+#ifdef USE_MAG_SPI_HMC5883
+#define HMC5883_BUSTYPE BUSTYPE_SPI
+#else
+#define HMC5883_BUSTYPE BUSTYPE_I2C
+#endif
+
+#ifdef MAG_I2C_INSTANCE
+#define HMC5883_BUSNUM MAG_I2C_INSTANCE
+#else
+#define HMC5883_BUSNUM I2CINVALID
+#endif
+
+#ifndef HMC5883_CS_PIN
+#define HMC5883_CS_PIN NONE
+#endif
+
+#if defined(USE_MAG_DATA_READY_SIGNAL) && defined(MAG_INT_EXTI)
+#define HMC5883_INT_EXTI MAG_INT_EXTI
+#else
+#define HMC5883_INT_EXTI NONE
+#endif
+
+#define MAG_ADDRESS 0x1E
+
+#define I2C_DEV_TO_CFG(x) ((x) + 1)
+#define I2C_CFG_TO_DEV(x) ((x) - 1)
+
+PG_RESET_TEMPLATE(busDeviceConfig_t, magHMC5883Config,
+    .busType = HMC5883_BUSTYPE,
+    .busNum = I2C_DEV_TO_CFG(HMC5883_BUSNUM),
+    .i2cAddr = MAG_ADDRESS,
+    .spiCsPin = IO_TAG(HMC5883_CS_PIN),
+    .drdyPin = IO_TAG(HMC5883_INT_EXTI),
+);
+
+static I2CDevice i2cBus;
 
 // HMC5883L, default address 0x1E
 // NAZE Target connections
@@ -104,7 +147,6 @@
  *              1  |  1   |  Sleep Mode
  */
 
-#define MAG_ADDRESS 0x1E
 #define MAG_DATA_REGISTER 0x03
 
 #define HMC58X3_R_CONFA 0
@@ -171,7 +213,7 @@ static bool hmc5883lRead(int16_t *magData)
 #ifdef USE_MAG_SPI_HMC5883
 	bool ack = hmc5883SpiReadCommand(MAG_DATA_REGISTER, 6, buf);
 #else
-    bool ack = i2cRead(MAG_I2C_INSTANCE, MAG_ADDRESS, MAG_DATA_REGISTER, 6, buf);
+    bool ack = i2cRead(i2cBus, MAG_ADDRESS, MAG_DATA_REGISTER, 6, buf);
 #endif
     if (!ack) {
         return false;
@@ -197,14 +239,14 @@ static bool hmc5883lInit(void)
 #ifdef USE_MAG_SPI_HMC5883
     hmc5883SpiWriteCommand(HMC58X3_R_CONFA, 0x010 + HMC_POS_BIAS);   // Reg A DOR = 0x010 + MS1, MS0 set to pos bias
 #else
-    i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_CONFA, 0x010 + HMC_POS_BIAS);   // Reg A DOR = 0x010 + MS1, MS0 set to pos bias
+    i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_CONFA, 0x010 + HMC_POS_BIAS);   // Reg A DOR = 0x010 + MS1, MS0 set to pos bias
 #endif
     // Note that the  very first measurement after a gain change maintains the same gain as the previous setting.
     // The new gain setting is effective from the second measurement and on.
 #ifdef USE_MAG_SPI_HMC5883
 	hmc5883SpiWriteCommand(HMC58X3_R_CONFB, 0x60); // Set the Gain to 2.5Ga (7:5->011)
 #else
-    i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_CONFB, 0x60); // Set the Gain to 2.5Ga (7:5->011)
+    i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_CONFB, 0x60); // Set the Gain to 2.5Ga (7:5->011)
 #endif
     delay(100);
     hmc5883lRead(magADC);
@@ -213,7 +255,7 @@ static bool hmc5883lInit(void)
 #ifdef USE_MAG_SPI_HMC5883
 		hmc5883SpiWriteCommand(HMC58X3_R_MODE, 1);
 #else
-        i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_MODE, 1);
+        i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_MODE, 1);
 #endif
         delay(50);
         hmc5883lRead(magADC);       // Get the raw values in case the scales have already been changed.
@@ -235,13 +277,13 @@ static bool hmc5883lInit(void)
 #ifdef USE_MAG_SPI_HMC5883
 	hmc5883SpiWriteCommand(HMC58X3_R_CONFA, 0x010 + HMC_NEG_BIAS);   // Reg A DOR = 0x010 + MS1, MS0 set to negative bias.
 #else
-    i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_CONFA, 0x010 + HMC_NEG_BIAS);   // Reg A DOR = 0x010 + MS1, MS0 set to negative bias.
+    i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_CONFA, 0x010 + HMC_NEG_BIAS);   // Reg A DOR = 0x010 + MS1, MS0 set to negative bias.
 #endif
     for (i = 0; i < 10; i++) {
 #ifdef USE_MAG_SPI_HMC5883
         hmc5883SpiWriteCommand(HMC58X3_R_MODE, 1);
 #else
-        i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_MODE, 1);
+        i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_MODE, 1);
 #endif
         delay(50);
         hmc5883lRead(magADC);               // Get the raw values in case the scales have already been changed.
@@ -269,9 +311,9 @@ static bool hmc5883lInit(void)
     hmc5883SpiWriteCommand(HMC58X3_R_CONFB, 0x20);   // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
     hmc5883SpiWriteCommand(HMC58X3_R_MODE, 0x00);    // Mode register             -- 000000 00    continuous Conversion Mode
 #else
-    i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_CONFA, 0x70);   // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode
-    i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_CONFB, 0x20);   // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
-    i2cWrite(MAG_I2C_INSTANCE, MAG_ADDRESS, HMC58X3_R_MODE, 0x00);    // Mode register             -- 000000 00    continuous Conversion Mode
+    i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_CONFA, 0x70);   // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode
+    i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_CONFB, 0x20);   // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
+    i2cWrite(i2cBus, MAG_ADDRESS, HMC58X3_R_MODE, 0x00);    // Mode register             -- 000000 00    continuous Conversion Mode
 #endif
     delay(100);
 
@@ -285,12 +327,10 @@ static bool hmc5883lInit(void)
     return true;
 }
 
-bool hmc5883lDetect(magDev_t* mag, ioTag_t interruptTag)
+bool hmc5883lDetect(magDev_t* mag)
 {
 #ifdef USE_MAG_DATA_READY_SIGNAL
-    hmc5883InterruptIO = IOGetByTag(interruptTag);
-#else
-    UNUSED(interruptTag);
+    hmc5883InterruptIO = IOGetByTag(magHMC5883Config()->drdyPin);
 #endif
 
     uint8_t sig = 0;
@@ -298,7 +338,13 @@ bool hmc5883lDetect(magDev_t* mag, ioTag_t interruptTag)
     hmc5883SpiInit();
     bool ack = hmc5883SpiReadCommand(0x0A, 1, &sig);
 #else
-    bool ack = i2cRead(MAG_I2C_INSTANCE, MAG_ADDRESS, 0x0A, 1, &sig);
+    if (magHMC5883Config()->busType == BUSTYPE_I2C) {
+        i2cBus = I2C_CFG_TO_DEV(magHMC5883Config()->busNum);
+    } else {
+        return false;
+    }
+
+    bool ack = i2cRead(i2cBus, MAG_ADDRESS, 0x0A, 1, &sig);
 #endif
 
     if (!ack || sig != 'H')

--- a/src/main/drivers/compass/compass_hmc5883l.h
+++ b/src/main/drivers/compass/compass_hmc5883l.h
@@ -18,5 +18,8 @@
 #pragma once
 
 #include "drivers/io_types.h"
+#include "drivers/bus.h"
 
-bool hmc5883lDetect(magDev_t* mag, ioTag_t interruptTag);
+PG_DECLARE(busDeviceConfig_t, magHMC5883Config);
+
+bool hmc5883lDetect(magDev_t* mag);

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -61,6 +61,8 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "LED_STRIP",
     "TRANSPONDER",
     "VTX",
-    "COMPASS_CS"
+    "COMPASS_CS",
+    "HMC5883_CS",
+    "HMC5883_EXTI",
 };
 

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -62,6 +62,8 @@ typedef enum {
     OWNER_TRANSPONDER,
     OWNER_VTX,
     OWNER_COMPASS_CS,
+    OWNER_HMC5883_CS,
+    OWNER_HMC5883_EXTI,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -55,8 +55,10 @@ extern uint8_t __config_end;
 
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/buf_writer.h"
+#include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/compass/compass.h"
+#include "drivers/compass/compass_hmc5883l.h"
 #include "drivers/display.h"
 #include "drivers/dma.h"
 #include "drivers/flash.h"
@@ -2829,6 +2831,12 @@ const cliResourceValue_t resourceTable[] = {
     { OWNER_I2C_SDA,       PG_I2C_CONFIG, offsetof(i2cConfig_t, ioTagSda[0]), I2CDEV_COUNT },
 #endif
     { OWNER_LED,           PG_STATUS_LED_CONFIG, offsetof(statusLedConfig_t, ioTags[0]), STATUS_LED_NUMBER },
+#ifdef USE_MAG_HMC5883
+    { OWNER_HMC5883_EXTI,  PG_BUSDEV_HMC5883_CONFIG, offsetof(busDeviceConfig_t, drdyTag), 0 },
+#ifdef USE_MAG_SPI_HMC5883
+    { OWNER_HMC5883_CS,    PG_BUSDEV_HMC5883_CONFIG, offsetof(busDeviceConfig_t, spiCsTag), 0 },
+#endif
+#endif
 };
 
 static ioTag_t *getIoTag(const cliResourceValue_t value, uint8_t index)

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -36,6 +36,7 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
+#include "drivers/bus.h"
 #include "drivers/light_led.h"
 
 #include "fc/config.h"
@@ -248,6 +249,10 @@ static const char * const lookupTableFailsafe[] = {
     "AUTO-LAND", "DROP"
 };
 
+static const char * const lookupTableBusType[] = {
+    BUSTYPE_NONE_STR, BUSTYPE_I2C_STR, BUSTYPE_SPI_STR
+};
+
 const lookupTableEntry_t lookupTables[] = {
     { lookupTableOffOn, sizeof(lookupTableOffOn) / sizeof(char *) },
     { lookupTableUnit, sizeof(lookupTableUnit) / sizeof(char *) },
@@ -289,6 +294,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef OSD
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
 #endif
+    { lookupTableBusType, sizeof(lookupTableBusType) / sizeof(char *) },
 };
 
 const clivalue_t valueTable[] = {
@@ -719,6 +725,12 @@ const clivalue_t valueTable[] = {
     { "esc_sensor_halfduplex",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, halfDuplex) },
 #endif
     { "led_inversion",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, ((1 << STATUS_LED_NUMBER) - 1) }, PG_STATUS_LED_CONFIG, offsetof(statusLedConfig_t, inversion) },
+#ifdef MAG
+#ifdef USE_MAG_HMC5883
+    { "mag_hmc5883_bustype",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BUS_TYPE }, PG_BUSDEV_HMC5883_CONFIG, offsetof(busDeviceConfig_t, busType) },
+    { "mag_hmc5883_busnum",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, I2CDEV_COUNT - 1 }, PG_BUSDEV_HMC5883_CONFIG, offsetof(busDeviceConfig_t, busNum) },
+#endif
+#endif
 };
 
 const uint16_t valueTableEntryCount = ARRAYLEN(valueTable);

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -59,6 +59,7 @@ typedef enum {
 #ifdef OSD
     TABLE_OSD,
 #endif
+    TABLE_BUS_TYPE,
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -48,12 +48,6 @@
 magDev_t magDev;
 mag_t mag;                   // mag access functions
 
-#ifdef MAG_INT_EXTI
-#define COMPASS_INTERRUPT_TAG   IO_TAG(MAG_INT_EXTI)
-#else
-#define COMPASS_INTERRUPT_TAG   IO_TAG_NONE
-#endif
-
 PG_REGISTER_WITH_RESET_TEMPLATE(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 0);
 
 PG_RESET_TEMPLATE(compassConfig_t, compassConfig,
@@ -61,7 +55,6 @@ PG_RESET_TEMPLATE(compassConfig_t, compassConfig,
     // xxx_hardware: 0:default/autodetect, 1: disable
     .mag_hardware = 1,
     .mag_declination = 0,
-    .interruptTag = COMPASS_INTERRUPT_TAG
 );
 
 #ifdef MAG
@@ -83,7 +76,7 @@ retry:
 
     case MAG_HMC5883:
 #ifdef USE_MAG_HMC5883
-        if (hmc5883lDetect(dev, compassConfig()->interruptTag)) {
+        if (hmc5883lDetect(dev)) {
 #ifdef MAG_HMC5883_ALIGN
             dev->magAlign = MAG_HMC5883_ALIGN;
 #endif

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -44,7 +44,6 @@ typedef struct compassConfig_s {
                                             // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
     sensor_align_e mag_align;               // mag alignment
     uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
-    ioTag_t interruptTag;
     flightDynamicsTrims_t magZero;
 } compassConfig_t;
 


### PR DESCRIPTION
PR status: For discussion

This is the first trial and example of reconfigurable sensors. The HMC5883 mag support was chosen.

- The strategy here is to provide per device configurability, so the `mag_device` can still be used to select one of the configured mag devices, and to avoid device selection mechanisms to be repeated and/or moving into driver layer.

- The generic `busDeviceConfig_t` was created and used for these purposes; I decided that the existing `compassConfig_t` will represent the sole logical compass device with underlying hardware compass described by (one of) `busDeviceConfig_t`.

- A drawback of this approach is that we will going to have a half a dozen cli variables and one or two resource(s) for each bus oriented device supported.
