### PR TITLE
Add post flight statistic for SD card blackbox log number

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -511,6 +511,14 @@ bool isBlackboxDeviceFull(void)
     }
 }
 
+unsigned int blackboxGetLogNumber()
+{
+#ifdef USE_SDCARD
+    return blackboxSDCard.largestLogFileNumber;
+#endif
+    return 0;
+}
+
 /**
  * Call once every loop iteration in order to maintain the global blackboxHeaderBudget with the number of bytes we can
  * transmit this iteration.

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -52,6 +52,7 @@ bool blackboxDeviceBeginLog(void);
 bool blackboxDeviceEndLog(bool retainLog);
 
 bool isBlackboxDeviceFull(void);
+unsigned int blackboxGetLogNumber();
 
 void blackboxReplenishHeaderBudget();
 blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes);

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -678,6 +678,7 @@ const clivalue_t valueTable[] = {
     { "osd_stat_endbatt",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_END_BATTERY])},
     { "osd_stat_flytime",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_FLYTIME])},
     { "osd_stat_armtime",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_ARMEDTIME])},
+    { "osd_stat_bb_no",             VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats[OSD_STAT_BLACKBOX_NUMBER])},
 #endif
 
 // PG_SYSTEM_CONFIG

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -737,17 +737,18 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_ESC_TMP]            = OSD_POS(18, 2)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ESC_RPM]            = OSD_POS(19, 2)  | VISIBLE_FLAG;
 
-    osdConfig->enabled_stats[OSD_STAT_MAX_SPEED]    = true;
-    osdConfig->enabled_stats[OSD_STAT_MIN_BATTERY]  = true;
-    osdConfig->enabled_stats[OSD_STAT_MIN_RSSI]     = true;
-    osdConfig->enabled_stats[OSD_STAT_MAX_CURRENT]  = true;
-    osdConfig->enabled_stats[OSD_STAT_USED_MAH]     = true;
-    osdConfig->enabled_stats[OSD_STAT_MAX_ALTITUDE] = false;
-    osdConfig->enabled_stats[OSD_STAT_BLACKBOX]     = true;
-    osdConfig->enabled_stats[OSD_STAT_END_BATTERY]  = false;
-    osdConfig->enabled_stats[OSD_STAT_FLYTIME]      = false;
-    osdConfig->enabled_stats[OSD_STAT_ARMEDTIME]    = true;
-    osdConfig->enabled_stats[OSD_STAT_MAX_DISTANCE] = false;
+    osdConfig->enabled_stats[OSD_STAT_MAX_SPEED]       = true;
+    osdConfig->enabled_stats[OSD_STAT_MIN_BATTERY]     = true;
+    osdConfig->enabled_stats[OSD_STAT_MIN_RSSI]        = true;
+    osdConfig->enabled_stats[OSD_STAT_MAX_CURRENT]     = true;
+    osdConfig->enabled_stats[OSD_STAT_USED_MAH]        = true;
+    osdConfig->enabled_stats[OSD_STAT_MAX_ALTITUDE]    = false;
+    osdConfig->enabled_stats[OSD_STAT_BLACKBOX]        = true;
+    osdConfig->enabled_stats[OSD_STAT_END_BATTERY]     = false;
+    osdConfig->enabled_stats[OSD_STAT_FLYTIME]         = false;
+    osdConfig->enabled_stats[OSD_STAT_ARMEDTIME]       = true;
+    osdConfig->enabled_stats[OSD_STAT_MAX_DISTANCE]    = false;
+    osdConfig->enabled_stats[OSD_STAT_BLACKBOX_NUMBER] = true;
 
     osdConfig->units = OSD_UNIT_METRIC;
 
@@ -1020,6 +1021,11 @@ static void osdShowStats(void)
     if (osdConfig()->enabled_stats[OSD_STAT_BLACKBOX] && blackboxConfig()->device && blackboxConfig()->device != BLACKBOX_DEVICE_SERIAL) {
         osdGetBlackboxStatusString(buff);
         osdDisplayStatisticLabel(top++, "BLACKBOX", buff);
+    }
+
+    if (osdConfig()->enabled_stats[OSD_STAT_BLACKBOX_NUMBER] && blackboxConfig()->device && blackboxConfig()->device != BLACKBOX_DEVICE_SERIAL) {
+        itoa(blackboxGetLogNumber(), buff, 10);
+        osdDisplayStatisticLabel(top++, "BB LOG NUM", buff);
     }
 #endif
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -80,6 +80,7 @@ typedef enum {
     OSD_STAT_FLYTIME,
     OSD_STAT_ARMEDTIME,
     OSD_STAT_MAX_DISTANCE,
+    OSD_STAT_BLACKBOX_NUMBER,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 


### PR DESCRIPTION
Can someone give this another test on actual hardware, it was a couple of months ago I originally wrote this and I don't have a suitable FC for testing right now.