### PR TITLE
Add RSSI ADC input pin to OMNIBUSF4 target

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -178,10 +178,9 @@
 #define OLED_I2C_INSTANCE              (I2CDEV_3)
 
 #define USE_ADC
-#define CURRENT_METER_ADC_PIN   PC1
-#define VBAT_ADC_PIN            PC2
-
-//#define RSSI_ADC_PIN          PA0
+#define CURRENT_METER_ADC_PIN   PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
+#define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
+#define RSSI_ADC_PIN            PA0  // Direct from RSSI pad
 
 #define TRANSPONDER
 


### PR DESCRIPTION
PR status: Ready to merge.

It has been disabled from the beginning, but it is wired and it works.

I believe there were some confusion about how RSSI is connected and how F4 handles ADC inputs (as compared to F3).

>OMNIBUS F3
RSSI is connected to PB2 via RC filter (1KR + 1uF).
ADC-wise, PB2 is ADC2_IN12.
Because VBAT and Current sensor ADCs are on ADC1, with current ADC driver, it is a choice between `Voltage and Current` or `RSSI only`.
>
>OMNIBUS F4
RSSI is connected directly to PA0 (without RC filter, so it is analog 0-3V3 input).
Because F4 allows ADC inputs to be connected freely to ADC1 or ADC2, the current ADC driver can handle all three inputs at the same time.