### PR TITLE
Make SPI read and write register generic

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -241,8 +241,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (mpu6000SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegBuf;
-        gyro->mpuConfiguration.writeFn = spiWriteReg;
+        gyro->mpuConfiguration.readFn = spiReadRegisterBuffer;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif
@@ -255,8 +255,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (mpu6500Sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = mpu6500Sensor;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegBuf;
-        gyro->mpuConfiguration.writeFn = spiWriteReg;
+        gyro->mpuConfiguration.readFn = spiReadRegisterBuffer;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif
@@ -267,8 +267,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (mpu9250SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegBuf;
-        gyro->mpuConfiguration.writeFn = mpu9250SpiWriteReg;
+        gyro->mpuConfiguration.readFn = spiReadRegisterBuffer;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         gyro->mpuConfiguration.resetFn = mpu9250SpiResetGyro;
         return true;
     }
@@ -280,8 +280,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (icm20689SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegBuf;
-        gyro->mpuConfiguration.writeFn = spiWriteReg;
+        gyro->mpuConfiguration.readFn = spiReadRegisterBuffer;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif
@@ -291,8 +291,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->bus.spi.csnPin;
     if (bmi160Detect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = BMI_160_SPI;
-        gyro->mpuConfiguration.readFn = spiReadRegBuf;
-        gyro->mpuConfiguration.writeFn = spiWriteReg;
+        gyro->mpuConfiguration.readFn = spiReadRegisterBuffer;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -276,12 +276,13 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef USE_GYRO_SPI_ICM20689
+    gyro->bus.spi.instance = ICM20689_SPI_INSTANCE;
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->bus.spi.csnPin;
     if (icm20689SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = icm20689SpiReadRegister;
-        gyro->mpuConfiguration.writeFn = icm20689SpiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegister;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -287,11 +287,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef USE_ACCGYRO_BMI160
+    gyro->bus.spi.instance = BMI160_SPI_INSTANCE;
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->bus.spi.csnPin;
     if (bmi160Detect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = BMI_160_SPI;
-        gyro->mpuConfiguration.readFn = bmi160SpiReadRegister;
-        gyro->mpuConfiguration.writeFn = bmi160SpiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegBuf;
+        gyro->mpuConfiguration.writeFn = spiWriteReg;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -262,13 +262,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef  USE_GYRO_SPI_MPU9250
+    gyro->bus.spi.instance = MPU9250_SPI_INSTANCE;
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->bus.spi.csnPin;
     if (mpu9250SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = mpu9250SpiReadRegister;
-        gyro->mpuConfiguration.slowreadFn = mpu9250SpiSlowReadRegister;
-        gyro->mpuConfiguration.verifywriteFn = verifympu9250SpiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegister;
         gyro->mpuConfiguration.writeFn = mpu9250SpiWriteRegister;
         gyro->mpuConfiguration.resetFn = mpu9250SpiResetGyro;
         return true;

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -248,14 +248,15 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef USE_GYRO_SPI_MPU6500
+    gyro->bus.spi.instance = MPU6500_SPI_INSTANCE;
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->bus.spi.csnPin;
     const uint8_t mpu6500Sensor = mpu6500SpiDetect(&gyro->bus);
     // some targets using MPU_9250_SPI, ICM_20608_SPI or ICM_20602_SPI state sensor is MPU_65xx_SPI
     if (mpu6500Sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = mpu6500Sensor;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = mpu6500SpiReadRegister;
-        gyro->mpuConfiguration.writeFn = mpu6500SpiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegister;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -241,8 +241,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (mpu6000SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegister;
-        gyro->mpuConfiguration.writeFn = spiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegBuf;
+        gyro->mpuConfiguration.writeFn = spiWriteReg;
         return true;
     }
 #endif
@@ -255,8 +255,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (mpu6500Sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = mpu6500Sensor;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegister;
-        gyro->mpuConfiguration.writeFn = spiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegBuf;
+        gyro->mpuConfiguration.writeFn = spiWriteReg;
         return true;
     }
 #endif
@@ -267,8 +267,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (mpu9250SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegister;
-        gyro->mpuConfiguration.writeFn = mpu9250SpiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegBuf;
+        gyro->mpuConfiguration.writeFn = mpu9250SpiWriteReg;
         gyro->mpuConfiguration.resetFn = mpu9250SpiResetGyro;
         return true;
     }
@@ -280,8 +280,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     if (icm20689SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = spiReadRegister;
-        gyro->mpuConfiguration.writeFn = spiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegBuf;
+        gyro->mpuConfiguration.writeFn = spiWriteReg;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -30,6 +30,7 @@
 #include "common/utils.h"
 
 #include "drivers/bus_i2c.h"
+#include "drivers/bus_spi.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
 #include "drivers/nvic.h"
@@ -233,14 +234,15 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 {
     UNUSED(gyro); // since there are FCs which have gyro on I2C but other devices on SPI
 #ifdef USE_GYRO_SPI_MPU6000
+    gyro->bus.spi.instance = MPU6000_SPI_INSTANCE;
 #ifdef MPU6000_CS_PIN
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->bus.spi.csnPin;
 #endif
     if (mpu6000SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = mpu6000SpiReadRegister;
-        gyro->mpuConfiguration.writeFn = mpu6000SpiWriteRegister;
+        gyro->mpuConfiguration.readFn = spiReadRegister;
+        gyro->mpuConfiguration.writeFn = spiWriteRegister;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -127,15 +127,13 @@
 
 typedef bool (*mpuReadRegisterFnPtr)(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t* data);
 typedef bool (*mpuWriteRegisterFnPtr)(const busDevice_t *bus, uint8_t reg, uint8_t data);
-typedef void(*mpuResetFnPtr)(void);
+typedef void (*mpuResetFnPtr)(void);
 
 extern mpuResetFnPtr mpuResetFn;
 
 typedef struct mpuConfiguration_s {
     mpuReadRegisterFnPtr readFn;
     mpuWriteRegisterFnPtr writeFn;
-    mpuReadRegisterFnPtr slowreadFn;
-    mpuWriteRegisterFnPtr verifywriteFn;
     mpuResetFnPtr resetFn;
     uint8_t gyroReadXRegister; // Y and Z must registers follow this, 2 words each
 } mpuConfiguration_t;

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -90,29 +90,27 @@ static volatile bool bmi160ExtiInitDone = false;
 //! Private functions
 static int32_t BMI160_Config(const busDevice_t *bus);
 static int32_t BMI160_do_foc(const busDevice_t *bus);
-static uint8_t BMI160_ReadReg(const busDevice_t *bus, uint8_t reg);
 static int32_t BMI160_WriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
-
-#define DISABLE_BMI160(spiCsnPin)       IOHi(spiCsnPin)
-#define ENABLE_BMI160(spiCsnPin)        IOLo(spiCsnPin)
 
 
 bool bmi160Detect(const busDevice_t *bus)
 {
-    if (BMI160Detected)
+    if (BMI160Detected) {
         return true;
+    }
+
     IOInit(bus->spi.csnPin, OWNER_MPU_CS, 0);
     IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
     IOHi(bus->spi.csnPin);
 
-    spiSetDivisor(BMI160_SPI_INSTANCE, BMI160_SPI_DIVISOR);
+    spiSetDivisor(bus->spi.instance, BMI160_SPI_DIVISOR);
 
     /* Read this address to acticate SPI (see p. 84) */
-    BMI160_ReadReg(bus, 0x7F);
+    spiReadReg(bus, 0x7F);
     delay(10); // Give SPI some time to start up
 
     /* Check the chip ID */
-    if (BMI160_ReadReg(bus, BMI160_REG_CHIPID) != 0xd1){
+    if (spiReadReg(bus, BMI160_REG_CHIPID) != 0xd1){
         return false;
     }
 
@@ -127,8 +125,9 @@ bool bmi160Detect(const busDevice_t *bus)
  */
 static void BMI160_Init(const busDevice_t *bus)
 {
-    if (BMI160InitDone || !BMI160Detected)
+    if (BMI160InitDone || !BMI160Detected) {
         return;
+    }
 
     /* Configure the BMI160 Sensor */
     if (BMI160_Config(bus) != 0){
@@ -164,7 +163,7 @@ static int32_t BMI160_Config(const busDevice_t *bus)
     delay(5); // can take up to 3.8ms
 
     // Verify that normal power mode was entered
-    uint8_t pmu_status = BMI160_ReadReg(bus, BMI160_REG_PMU_STAT);
+    uint8_t pmu_status = spiReadReg(bus, BMI160_REG_PMU_STAT);
     if ((pmu_status & 0x3C) != 0x14){
         return -3;
     }
@@ -193,7 +192,7 @@ static int32_t BMI160_Config(const busDevice_t *bus)
     delay(1);
 
     // Enable offset compensation
-    uint8_t val = BMI160_ReadReg(bus, BMI160_REG_OFFSET_0);
+    uint8_t val = spiReadReg(bus, BMI160_REG_OFFSET_0);
     if (BMI160_WriteReg(bus, BMI160_REG_OFFSET_0, val | 0xC0) != 0){
         return -7;
     }
@@ -234,7 +233,7 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
 
     // Wait for FOC to complete
     for (int i=0; i<50; i++) {
-        val = BMI160_ReadReg(bus, BMI160_REG_STATUS);
+        val = spiReadReg(bus, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_FOC_RDY) {
             break;
         }
@@ -245,7 +244,7 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
     }
 
     // Program NVM
-    val = BMI160_ReadReg(bus, BMI160_REG_CONF);
+    val = spiReadReg(bus, BMI160_REG_CONF);
     if (BMI160_WriteReg(bus, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN) != 0) {
         return -4;
     }
@@ -256,7 +255,7 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
 
     // Wait for NVM programming to complete
     for (int i=0; i<50; i++) {
-        val = BMI160_ReadReg(bus, BMI160_REG_STATUS);
+        val = spiReadReg(bus, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_NVM_RDY) {
             break;
         }
@@ -269,41 +268,6 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
     return 0;
 }
 
-/**
- * @brief Read a register from BMI160
- * @returns The register value
- * @param reg[in] Register address to be read
- */
-uint8_t BMI160_ReadReg(const busDevice_t *bus, uint8_t reg)
-{
-    uint8_t data;
-
-    ENABLE_BMI160(bus->spi.csnPin);
-
-    spiTransferByte(BMI160_SPI_INSTANCE, 0x80 | reg); // request byte
-    spiTransfer(BMI160_SPI_INSTANCE, &data, NULL, 1);   // receive response
-
-    DISABLE_BMI160(bus->spi.csnPin);
-
-    return data;
-}
-
-bool bmi160SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
-{
-    ENABLE_BMI160(bus->spi.csnPin);
-    spiTransferByte(BMI160_SPI_INSTANCE, reg | 0x80); // read transaction
-    spiTransfer(BMI160_SPI_INSTANCE, data, NULL, length);
-    ENABLE_BMI160(bus->spi.csnPin);
-
-    return true;
-}
-
-/**
- * @brief Writes one byte to the BMI160 register
- * \param[in] reg Register address
- * \param[in] data Byte to write
- * @returns 0 when success
- */
 static int32_t BMI160_WriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     ENABLE_BMI160(bus->spi.csnPin);
@@ -314,11 +278,6 @@ static int32_t BMI160_WriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data
     DISABLE_BMI160(bus->spi.csnPin);
 
     return 0;
-}
-
-bool bmi160SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
-{
-    return BMI160_WriteReg(bus, reg, data);
 }
 
 extiCallbackRec_t bmi160IntCallbackRec;
@@ -366,9 +325,9 @@ bool bmi160AccRead(accDev_t *acc)
     uint8_t bmi160_rec_buf[BUFFER_SIZE];
     uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
 
-    ENABLE_BMI160(acc->bus.spi.csnPin);
-    spiTransfer(BMI160_SPI_INSTANCE, bmi160_rec_buf, bmi160_tx_buf, BUFFER_SIZE);   // receive response
-    DISABLE_BMI160(acc->bus.spi.csnPin);
+    IOLo(acc->bus.spi.csnPin);
+    spiTransfer(acc->bus.spi.instance, bmi160_rec_buf, bmi160_tx_buf, BUFFER_SIZE);   // receive response
+    IOHi(acc->bus.spi.csnPin);
 
     acc->ADCRaw[X] = (int16_t)((bmi160_rec_buf[IDX_ACCEL_XOUT_H] << 8) | bmi160_rec_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi160_rec_buf[IDX_ACCEL_YOUT_H] << 8) | bmi160_rec_buf[IDX_ACCEL_YOUT_L]);
@@ -394,9 +353,9 @@ bool bmi160GyroRead(gyroDev_t *gyro)
     uint8_t bmi160_rec_buf[BUFFER_SIZE];
     uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
 
-    ENABLE_BMI160(gyro->bus.spi.csnPin);
-    spiTransfer(BMI160_SPI_INSTANCE, bmi160_rec_buf, bmi160_tx_buf, BUFFER_SIZE);   // receive response
-    DISABLE_BMI160(gyro->bus.spi.csnPin);
+    IOLo(gyro->bus.spi.csnPin);
+    spiTransfer(gyro->bus.spi.instance, bmi160_rec_buf, bmi160_tx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->bus.spi.csnPin);
 
     gyro->gyroADCRaw[X] = (int16_t)((bmi160_rec_buf[IDX_GYRO_XOUT_H] << 8) | bmi160_rec_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi160_rec_buf[IDX_GYRO_YOUT_H] << 8) | bmi160_rec_buf[IDX_GYRO_YOUT_L]);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -106,11 +106,11 @@ bool bmi160Detect(const busDevice_t *bus)
     spiSetDivisor(bus->spi.instance, BMI160_SPI_DIVISOR);
 
     /* Read this address to acticate SPI (see p. 84) */
-    spiReadReg(bus, 0x7F);
+    spiReadRegister(bus, 0x7F);
     delay(10); // Give SPI some time to start up
 
     /* Check the chip ID */
-    if (spiReadReg(bus, BMI160_REG_CHIPID) != 0xd1){
+    if (spiReadRegister(bus, BMI160_REG_CHIPID) != 0xd1){
         return false;
     }
 
@@ -163,7 +163,7 @@ static int32_t BMI160_Config(const busDevice_t *bus)
     delay(5); // can take up to 3.8ms
 
     // Verify that normal power mode was entered
-    uint8_t pmu_status = spiReadReg(bus, BMI160_REG_PMU_STAT);
+    uint8_t pmu_status = spiReadRegister(bus, BMI160_REG_PMU_STAT);
     if ((pmu_status & 0x3C) != 0x14){
         return -3;
     }
@@ -192,7 +192,7 @@ static int32_t BMI160_Config(const busDevice_t *bus)
     delay(1);
 
     // Enable offset compensation
-    uint8_t val = spiReadReg(bus, BMI160_REG_OFFSET_0);
+    uint8_t val = spiReadRegister(bus, BMI160_REG_OFFSET_0);
     if (BMI160_WriteReg(bus, BMI160_REG_OFFSET_0, val | 0xC0) != 0){
         return -7;
     }
@@ -233,7 +233,7 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
 
     // Wait for FOC to complete
     for (int i=0; i<50; i++) {
-        val = spiReadReg(bus, BMI160_REG_STATUS);
+        val = spiReadRegister(bus, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_FOC_RDY) {
             break;
         }
@@ -244,7 +244,7 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
     }
 
     // Program NVM
-    val = spiReadReg(bus, BMI160_REG_CONF);
+    val = spiReadRegister(bus, BMI160_REG_CONF);
     if (BMI160_WriteReg(bus, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN) != 0) {
         return -4;
     }
@@ -255,7 +255,7 @@ static int32_t BMI160_do_foc(const busDevice_t *bus)
 
     // Wait for NVM programming to complete
     for (int i=0; i<50; i++) {
-        val = spiReadReg(bus, BMI160_REG_STATUS);
+        val = spiReadRegister(bus, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_NVM_RDY) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.h
@@ -68,9 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-bool bmi160SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool bmi160SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
-
 bool bmi160Detect(const busDevice_t *bus);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -55,20 +55,17 @@ static void icm20689SpiInit(const busDevice_t *bus)
 
 bool icm20689SpiDetect(const busDevice_t *bus)
 {
-    uint8_t tmp;
-    uint8_t attemptsRemaining = 20;
-
     icm20689SpiInit(bus);
 
     spiSetDivisor(bus->spi.instance, SPI_CLOCK_INITIALIZATON); //low speed
 
-    spiWriteRegister(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
 
+    uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-
-        spiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &tmp);
-        if (tmp == ICM20689_WHO_AM_I_CONST) {
+        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        if (whoAmI == ICM20689_WHO_AM_I_CONST) {
             break;
         }
         if (!attemptsRemaining) {

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -59,12 +59,12 @@ bool icm20689SpiDetect(const busDevice_t *bus)
 
     spiSetDivisor(bus->spi.instance, SPI_CLOCK_INITIALIZATON); //low speed
 
-    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    spiWriteRegister(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
 
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadRegister(bus, MPU_RA_WHO_AM_I);
         if (whoAmI == ICM20689_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.h
@@ -31,6 +31,3 @@ bool icm20689SpiDetect(const busDevice_t *bus);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);
-
-bool icm20689SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool icm20689SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -99,42 +99,19 @@ static bool mpuSpi6000InitDone = false;
 #define MPU6000_REV_D9 0x59
 #define MPU6000_REV_D10 0x5A
 
-#define DISABLE_MPU6000(spiCsnPin)       IOHi(spiCsnPin)
-#define ENABLE_MPU6000(spiCsnPin)        IOLo(spiCsnPin)
-
-bool mpu6000SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
-{
-    ENABLE_MPU6000(bus->spi.csnPin);
-    spiTransferByte(MPU6000_SPI_INSTANCE, reg);
-    spiTransferByte(MPU6000_SPI_INSTANCE, data);
-    DISABLE_MPU6000(bus->spi.csnPin);
-
-    return true;
-}
-
-bool mpu6000SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
-{
-    ENABLE_MPU6000(bus->spi.csnPin);
-    spiTransferByte(MPU6000_SPI_INSTANCE, reg | 0x80); // read transaction
-    spiTransfer(MPU6000_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6000(bus->spi.csnPin);
-
-    return true;
-}
-
 void mpu6000SpiGyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
     mpu6000AccAndGyroInit(gyro);
 
-    spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
+    spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    mpu6000SpiWriteRegister(&gyro->bus, MPU6000_CONFIG, gyro->lpf);
+    spiWriteRegister(&gyro->bus, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
-    spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
+    spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
 
     mpuGyroRead(gyro);
 
@@ -157,14 +134,14 @@ bool mpu6000SpiDetect(const busDevice_t *bus)
     IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
     IOHi(bus->spi.csnPin);
 
-    spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
+    spiSetDivisor(bus->spi.instance, SPI_CLOCK_INITIALIZATON);
 
-    mpu6000SpiWriteRegister(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiWriteRegister(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
 
     do {
         delay(150);
 
-        mpu6000SpiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &in);
+        spiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -173,7 +150,7 @@ bool mpu6000SpiDetect(const busDevice_t *bus)
         }
     } while (attemptsRemaining--);
 
-    mpu6000SpiReadRegister(bus, MPU_RA_PRODUCT_ID, 1, &in);
+    spiReadRegister(bus, MPU_RA_PRODUCT_ID, 1, &in);
 
     /* look for a product ID we recognise */
 
@@ -203,48 +180,48 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
         return;
     }
 
-    spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
+    spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    spiWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    spiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    spiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_2, 0x00);
+    spiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    spiWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    spiWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    spiWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    spiWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    spiWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 
-    spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
 
     mpuSpi6000InitDone = true;

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -108,7 +108,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    spiWriteReg(&gyro->bus, MPU6000_CONFIG, gyro->lpf);
+    spiWriteRegister(&gyro->bus, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
@@ -133,13 +133,13 @@ bool mpu6000SpiDetect(const busDevice_t *bus)
 
     spiSetDivisor(bus->spi.instance, SPI_CLOCK_INITIALIZATON);
 
-    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiWriteRegister(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
 
     uint8_t attemptsRemaining = 5;
     do {
         delay(150);
 
-        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadRegister(bus, MPU_RA_WHO_AM_I);
         if (whoAmI == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -148,7 +148,7 @@ bool mpu6000SpiDetect(const busDevice_t *bus)
         }
     } while (attemptsRemaining--);
 
-    const uint8_t productID = spiReadReg(bus, MPU_RA_PRODUCT_ID);
+    const uint8_t productID = spiReadRegister(bus, MPU_RA_PRODUCT_ID);
 
     /* look for a product ID we recognise */
 
@@ -181,41 +181,41 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    spiWriteReg(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    spiWriteReg(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    spiWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    spiWriteReg(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    spiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    spiWriteReg(&gyro->bus, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    spiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    spiWriteReg(&gyro->bus, MPU_RA_PWR_MGMT_2, 0x00);
+    spiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    spiWriteReg(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    spiWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    spiWriteReg(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    spiWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    spiWriteReg(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    spiWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    spiWriteReg(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    spiWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiWriteReg(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    spiWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.h
@@ -21,6 +21,3 @@ bool mpu6000SpiDetect(const busDevice_t *bus);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);
-
-bool mpu6000SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu6000SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -34,38 +34,7 @@
 #include "accgyro_mpu6500.h"
 #include "accgyro_spi_mpu6500.h"
 
-#define DISABLE_MPU6500(spiCsnPin)       IOHi(spiCsnPin)
-#define ENABLE_MPU6500(spiCsnPin)        IOLo(spiCsnPin)
-
 #define BIT_SLEEP                   0x40
-
-bool mpu6500SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
-{
-    ENABLE_MPU6500(bus->spi.csnPin);
-    spiTransferByte(MPU6500_SPI_INSTANCE, reg);
-    spiTransferByte(MPU6500_SPI_INSTANCE, data);
-    DISABLE_MPU6500(bus->spi.csnPin);
-
-    return true;
-}
-
-bool mpu6500SpiWriteRegisterDelayed(const busDevice_t *bus, uint8_t reg, uint8_t data)
-{
-    mpu6500SpiWriteRegister(bus, reg, data);
-    delayMicroseconds(10);
-
-    return true;
-}
-
-bool mpu6500SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
-{
-    ENABLE_MPU6500(bus->spi.csnPin);
-    spiTransferByte(MPU6500_SPI_INSTANCE, reg | 0x80); // read transaction
-    spiTransfer(MPU6500_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6500(bus->spi.csnPin);
-
-    return true;
-}
 
 static void mpu6500SpiInit(const busDevice_t *bus)
 {
@@ -79,7 +48,7 @@ static void mpu6500SpiInit(const busDevice_t *bus)
     IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
     IOHi(bus->spi.csnPin);
 
-    spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);
+    spiSetDivisor(bus->spi.instance, SPI_CLOCK_FAST);
 
     hardwareInitialised = true;
 }
@@ -89,7 +58,7 @@ uint8_t mpu6500SpiDetect(const busDevice_t *bus)
     mpu6500SpiInit(bus);
 
     uint8_t tmp;
-    mpu6500SpiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &tmp);
+    spiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &tmp);
 
     uint8_t mpuDetected = MPU_NONE;
     switch (tmp) {
@@ -122,16 +91,16 @@ void mpu6500SpiAccInit(accDev_t *acc)
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro)
 {
-    spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_SLOW);
+    spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_SLOW);
     delayMicroseconds(1);
 
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    mpu6500SpiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    spiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
-    spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -57,7 +57,7 @@ uint8_t mpu6500SpiDetect(const busDevice_t *bus)
 {
     mpu6500SpiInit(bus);
 
-    const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+    const uint8_t whoAmI = spiReadRegister(bus, MPU_RA_WHO_AM_I);
 
     uint8_t mpuDetected = MPU_NONE;
     switch (whoAmI) {
@@ -96,7 +96,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    spiWriteReg(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    spiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -57,11 +57,10 @@ uint8_t mpu6500SpiDetect(const busDevice_t *bus)
 {
     mpu6500SpiInit(bus);
 
-    uint8_t tmp;
-    spiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &tmp);
+    const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
 
     uint8_t mpuDetected = MPU_NONE;
-    switch (tmp) {
+    switch (whoAmI) {
     case MPU6500_WHO_AM_I_CONST:
         mpuDetected = MPU_65xx_SPI;
         break;
@@ -97,7 +96,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    spiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    spiWriteReg(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.h
@@ -24,9 +24,5 @@ uint8_t mpu6500SpiDetect(const busDevice_t *bus);
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6500SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu6500SpiWriteRegisterDelayed(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu6500SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
-
 void mpu6500SpiGyroInit(gyroDev_t *gyro);
 void mpu6500SpiAccInit(accDev_t *acc);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -50,7 +50,7 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro);
 
 static bool mpuSpi9250InitDone = false;
 
-bool mpu9250SpiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
+bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
     delayMicroseconds(1);
@@ -62,7 +62,7 @@ bool mpu9250SpiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
     return true;
 }
 
-static bool mpu9250SpiSlowReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+static bool mpu9250SpiSlowReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
     IOLo(bus->spi.csnPin);
     delayMicroseconds(1);
@@ -79,7 +79,7 @@ void mpu9250SpiResetGyro(void)
     // Device Reset
 #ifdef MPU9250_CS_PIN
     busDevice_t bus = { .spi = { .csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) } };
-    mpu9250SpiWriteReg(&bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(&bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(150);
 #endif
 }
@@ -107,20 +107,20 @@ void mpu9250SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 8;
 }
 
-bool mpu9250SpiWriteRegVerify(const busDevice_t *bus, uint8_t reg, uint8_t data)
+bool mpu9250SpiWriteRegisterVerify(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
-    mpu9250SpiWriteReg(bus, reg, data);
+    mpu9250SpiWriteRegister(bus, reg, data);
     delayMicroseconds(100);
 
     uint8_t attemptsRemaining = 20;
     do {
         uint8_t in;
-        mpu9250SpiSlowReadRegBuf(bus, reg, 1, &in);
+        mpu9250SpiSlowReadRegisterBuffer(bus, reg, 1, &in);
         if (in == data) {
             return true;
         } else {
             debug[3]++;
-            mpu9250SpiWriteReg(bus, reg, data);
+            mpu9250SpiWriteRegister(bus, reg, data);
             delayMicroseconds(100);
         }
     } while (attemptsRemaining--);
@@ -135,30 +135,30 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_INITIALIZATON); //low speed for writing to slow registers
 
-    mpu9250SpiWriteReg(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
 
-    mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
 
     //Fchoice_b defaults to 00 which makes fchoice 11
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_GYRO_CONFIG, raGyroConfigData);
 
     if (gyro->lpf == 4) {
-        mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
+        mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
     } else if (gyro->lpf < 4) {
-        mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
+        mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
     } else if (gyro->lpf > 4) {
-        mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
+        mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
     }
 
-    mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
 
-    mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
-    mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
 #if defined(USE_MPU_DATA_READY_SIGNAL)
-    mpu9250SpiWriteRegVerify(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
 
     spiSetDivisor(gyro->bus.spi.instance, SPI_CLOCK_FAST);
@@ -172,12 +172,12 @@ bool mpu9250SpiDetect(const busDevice_t *bus)
     IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(bus->spi.instance, SPI_CLOCK_INITIALIZATON); //low speed
-    mpu9250SpiWriteReg(bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
 
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t in = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t in = spiReadRegister(bus, MPU_RA_WHO_AM_I);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
@@ -33,6 +33,6 @@ bool mpu9250SpiDetect(const busDevice_t *bus);
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu9250SpiWriteRegVerify(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiWriteRegisterVerify(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool mpu9250SpiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
@@ -36,4 +36,3 @@ bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool verifympu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool mpu9250SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
-bool mpu9250SpiSlowReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
@@ -33,6 +33,6 @@ bool mpu9250SpiDetect(const busDevice_t *bus);
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool verifympu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu9250SpiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiWriteRegVerify(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -353,7 +353,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance)
         spiHardwareMap[device].errorCount = 0;
 }
 
-bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
+bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg);
@@ -363,7 +363,7 @@ bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
@@ -371,4 +371,15 @@ bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_
     IOHi(bus->spi.csnPin);
 
     return true;
+}
+
+uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg)
+{
+    uint8_t data;
+    IOLo(bus->spi.csnPin);
+    spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
+    spiTransfer(bus->spi.instance, &data, NULL, 1);
+    IOHi(bus->spi.csnPin);
+
+    return data;
 }

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -353,7 +353,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance)
         spiHardwareMap[device].errorCount = 0;
 }
 
-bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
+bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg);
@@ -363,7 +363,7 @@ bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+bool spiReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
@@ -373,7 +373,7 @@ bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t 
     return true;
 }
 
-uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg)
+uint8_t spiReadRegister(const busDevice_t *bus, uint8_t reg)
 {
     uint8_t data;
     IOLo(bus->spi.csnPin);

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -20,11 +20,12 @@
 
 #include <platform.h>
 
+#include "drivers/bus.h"
 #include "drivers/bus_spi.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
-#include "io_impl.h"
-#include "rcc.h"
+#include "drivers/io_impl.h"
+#include "drivers/rcc.h"
 
 /* for F30x processors */
 #if defined(STM32F303xC)
@@ -350,4 +351,24 @@ void spiResetErrorCounter(SPI_TypeDef *instance)
     SPIDevice device = spiDeviceByInstance(instance);
     if (device != SPIINVALID)
         spiHardwareMap[device].errorCount = 0;
+}
+
+bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
+{
+    IOLo(bus->spi.csnPin);
+    spiTransferByte(bus->spi.instance, reg);
+    spiTransferByte(bus->spi.instance, data);
+    IOHi(bus->spi.csnPin);
+
+    return true;
+}
+
+bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+{
+    IOLo(bus->spi.csnPin);
+    spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
+    spiTransfer(bus->spi.instance, data, NULL, length);
+    IOHi(bus->spi.csnPin);
+
+    return true;
 }

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -103,5 +103,6 @@ SPI_HandleTypeDef* spiHandleByInstance(SPI_TypeDef *instance);
 DMA_HandleTypeDef* spiSetDMATransmit(DMA_Stream_TypeDef *Stream, uint32_t Channel, SPI_TypeDef *Instance, uint8_t *pData, uint16_t Size);
 #endif
 
-bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg);

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -103,6 +103,6 @@ SPI_HandleTypeDef* spiHandleByInstance(SPI_TypeDef *instance);
 DMA_HandleTypeDef* spiSetDMATransmit(DMA_Stream_TypeDef *Stream, uint32_t Channel, SPI_TypeDef *Instance, uint8_t *pData, uint16_t Size);
 #endif
 
-bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
-uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg);
+bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool spiReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+uint8_t spiReadRegister(const busDevice_t *bus, uint8_t reg);

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -18,7 +18,8 @@
 #pragma once
 
 #include "drivers/io_types.h"
-#include "rcc_types.h"
+#include "drivers/bus.h"
+#include "drivers/rcc_types.h"
 
 #if defined(STM32F4) || defined(STM32F3)
 #define SPI_IO_AF_CFG      IO_CONFIG(GPIO_Mode_AF,  GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL)
@@ -101,3 +102,6 @@ SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
 SPI_HandleTypeDef* spiHandleByInstance(SPI_TypeDef *instance);
 DMA_HandleTypeDef* spiSetDMATransmit(DMA_Stream_TypeDef *Stream, uint32_t Channel, SPI_TypeDef *Instance, uint8_t *pData, uint16_t Size);
 #endif
+
+bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/bus_spi_hal.c
+++ b/src/main/drivers/bus_spi_hal.c
@@ -346,7 +346,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance)
         spiHardwareMap[device].errorCount = 0;
 }
 
-bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
+bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg);
@@ -356,7 +356,7 @@ bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+bool spiReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
@@ -366,7 +366,7 @@ bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t 
     return true;
 }
 
-uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg)
+uint8_t spiReadRegister(const busDevice_t *bus, uint8_t reg)
 {
     uint8_t data;
     IOLo(bus->spi.csnPin);

--- a/src/main/drivers/bus_spi_hal.c
+++ b/src/main/drivers/bus_spi_hal.c
@@ -346,7 +346,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance)
         spiHardwareMap[device].errorCount = 0;
 }
 
-bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
+bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg);
@@ -356,7 +356,7 @@ bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
@@ -364,6 +364,17 @@ bool spiReadRegister(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_
     IOHi(bus->spi.csnPin);
 
     return true;
+}
+
+uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg)
+{
+    uint8_t data;
+    IOLo(bus->spi.csnPin);
+    spiTransferByte(bus->spi.instance, reg | 0x80); // read transaction
+    spiTransfer(bus->spi.instance, &data, NULL, 1);
+    IOHi(bus->spi.csnPin);
+
+    return data;
 }
 
 void dmaSPIIRQHandler(dmaChannelDescriptor_t* descriptor)

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -90,7 +90,7 @@ static busDevice_t *bus = NULL; // HACK
 // Is an separate MPU9250 driver really needed? The GYRO/ACC part between MPU6500 and MPU9250 is exactly the same.
 #if defined(MPU6500_SPI_INSTANCE) && !defined(MPU9250_SPI_INSTANCE)
 #define MPU9250_SPI_INSTANCE
-#define mpu9250SpiWriteRegVerify mpu6500SpiWriteRegDelayed
+#define mpu9250SpiWriteRegisterVerify mpu6500SpiWriteRegDelayed
 static bool mpu6500SpiWriteRegDelayed(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
@@ -121,22 +121,22 @@ static queuedReadState_t queuedRead = { false, 0, 0};
 
 static bool ak8963SensorRead(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf)
 {
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
     delay(10);
     __disable_irq();
-    bool ack = spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, len_, buf);    // read I2C
+    bool ack = spiReadRegisterBuffer(bus, MPU_RA_EXT_SENS_DATA_00, len_, buf);    // read I2C
     __enable_irq();
     return ack;
 }
 
 static bool ak8963SensorWrite(uint8_t addr_, uint8_t reg_, uint8_t data)
 {
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
     return true;
 }
 
@@ -148,9 +148,9 @@ static bool ak8963SensorStartRead(uint8_t addr_, uint8_t reg_, uint8_t len_)
 
     queuedRead.len = len_;
 
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpu9250SpiWriteRegisterVerify(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
 
     queuedRead.readStartedAt = micros();
     queuedRead.waiting = true;
@@ -185,7 +185,7 @@ static bool ak8963SensorCompleteRead(uint8_t *buf)
 
     queuedRead.waiting = false;
 
-    spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
+    spiReadRegisterBuffer(bus, MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
     return true;
 }
 #else
@@ -334,13 +334,13 @@ bool ak8963Detect(magDev_t *mag)
     bus->spi.instance = MPU9250_SPI_INSTANCE;
     // initialze I2C master via SPI bus (MPU9250)
 
-    mpu9250SpiWriteRegVerify(&mag->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
+    mpu9250SpiWriteRegisterVerify(&mag->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
     delay(10);
 
-    mpu9250SpiWriteRegVerify(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    mpu9250SpiWriteRegisterVerify(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    mpu9250SpiWriteRegVerify(&mag->bus, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    mpu9250SpiWriteRegisterVerify(&mag->bus, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 #endif

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -90,8 +90,8 @@ static busDevice_t *bus = NULL; // HACK
 // Is an separate MPU9250 driver really needed? The GYRO/ACC part between MPU6500 and MPU9250 is exactly the same.
 #if defined(MPU6500_SPI_INSTANCE) && !defined(MPU9250_SPI_INSTANCE)
 #define MPU9250_SPI_INSTANCE
-#define verifympu9250SpiWriteRegister mpu6500SpiWriteRegisterDelayed
-static bool mpu6500SpiWriteRegisterDelayed(const busDevice_t *bus, uint8_t reg, uint8_t data)
+#define mpu9250SpiWriteRegVerify mpu6500SpiWriteRegDelayed
+static bool mpu6500SpiWriteRegDelayed(const busDevice_t *bus, uint8_t reg, uint8_t data)
 {
     IOLo(bus->spi.csnPin);
     spiTransferByte(bus->spi.instance, reg);
@@ -121,22 +121,22 @@ static queuedReadState_t queuedRead = { false, 0, 0};
 
 static bool ak8963SensorRead(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf)
 {
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
     delay(10);
     __disable_irq();
-    bool ack = spiReadRegister(bus, MPU_RA_EXT_SENS_DATA_00, len_, buf);    // read I2C
+    bool ack = spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, len_, buf);    // read I2C
     __enable_irq();
     return ack;
 }
 
 static bool ak8963SensorWrite(uint8_t addr_, uint8_t reg_, uint8_t data)
 {
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
     return true;
 }
 
@@ -148,9 +148,9 @@ static bool ak8963SensorStartRead(uint8_t addr_, uint8_t reg_, uint8_t len_)
 
     queuedRead.len = len_;
 
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    verifympu9250SpiWriteRegister(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpu9250SpiWriteRegVerify(bus, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
 
     queuedRead.readStartedAt = micros();
     queuedRead.waiting = true;
@@ -185,7 +185,7 @@ static bool ak8963SensorCompleteRead(uint8_t *buf)
 
     queuedRead.waiting = false;
 
-    spiReadRegister(bus, MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
+    spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
     return true;
 }
 #else
@@ -334,13 +334,13 @@ bool ak8963Detect(magDev_t *mag)
     bus->spi.instance = MPU9250_SPI_INSTANCE;
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
+    mpu9250SpiWriteRegVerify(&mag->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
     delay(10);
 
-    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    mpu9250SpiWriteRegVerify(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    mpu9250SpiWriteRegVerify(&mag->bus, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 #endif


### PR DESCRIPTION
Create generic `spiWriteRegister` and `spiReadRegister` functions.

Convert `accgyro_spi_mpu6000` to use these as an example/template.