### PR TITLE
Fix KakuteF4 blackbox and BFOSD issue 

### DIFF
--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -62,16 +62,16 @@
 #define MAX7456_SPI_INSTANCE    SPI3
 #define MAX7456_SPI_CS_PIN      PB14
 
-#define MAX7456_DMA_CHANNEL_TX              DMA1_Stream5
-#define MAX7456_DMA_CHANNEL_RX              DMA1_Stream0
-#define MAX7456_DMA_IRQ_HANDLER_ID          DMA1_ST0_HANDLER
+//#define MAX7456_DMA_CHANNEL_TX              DMA1_Stream5
+//#define MAX7456_DMA_CHANNEL_RX              DMA1_Stream0
+//#define MAX7456_DMA_IRQ_HANDLER_ID          DMA1_ST0_HANDLER
 
 #define M25P16_CS_PIN           PB3
 #define M25P16_SPI_INSTANCE     SPI3
 
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-#define USE_FLASH_TOOLS
+//#define USE_FLASH_TOOLS
 
 #define USE_VCP
 #define VBUS_SENSING_PIN        PA8


### PR DESCRIPTION
MAX7456 and onboard FLASH share SPI3 on KakuteF4. When SPI3 DMA is enabled,  BFOSD and blackbox are conflicted. Thay can not work at the same time.

By turning off SPI3 DMA,  BFOSD and blackbox work fine at the same time.