### PR TITLE
[CJMCU] Disable USE_RX_INAV for flash space

### DIFF
--- a/src/main/target/CJMCU/target.h
+++ b/src/main/target/CJMCU/target.h
@@ -76,7 +76,7 @@
 #define USE_RX_NRF24
 #define USE_RX_CX10
 #define USE_RX_H8_3D
-#define USE_RX_INAV
+//#define USE_RX_INAV // Temporary disabled to make some room in flash
 #define USE_RX_SYMA
 #define USE_RX_V202
 //#define RX_SPI_DEFAULT_PROTOCOL RX_SPI_NRF24_SYMA_X5


### PR DESCRIPTION
PR status: Ready to merge.

Disable (and leave it as a comment) experimental RX protocol in trade with some flash space.

