### PR TITLE
Fix SITL compile.

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -478,8 +478,10 @@ void init(void)
     initBoardAlignment(boardAlignment());
 
     if (!sensorsAutodetect()) {
+#if !defined(SITL)
         // if gyro was not detected due to whatever reason, notify and don't arm.
         failureLedCode(FAILURE_MISSING_ACC, 2);
+#endif
         setArmingDisabled(ARMING_DISABLED_NO_GYRO);
     }
 


### PR DESCRIPTION
Jenkins fails when building target SITL. Fails also when I do it manually on Ubuntu 16.04.

    ./src/main/fc/fc_init.c:482: undefined reference to `failureLedCode'
    collect2: error: ld returned 1 exit status
    Makefile:1290: recipe for target 'obj/main/betaflight_SITL.elf' failed
The strange thing is that on Travis and in Vagrant, using older gcc, it works by some kind of magic or auto-stubbing. In Vagrant I can see this reference to a "plugin" : 

    vagrant@vagrant-ubuntu-trusty-64:/vagrant$ grep -r failureLedCode obj/main/
    obj/main/betaflight_SITL.map:failureLedCode                                    obj/main/SITL/fc/fc_init.o (symbol from plugin)
Looking at the sources it is clear that the symbol `failureLedCode` is defined in `drivers/system.c`, which is excluded from the SITL build. The reference to this symbol in `fc/fc_init.c` must thus be conditional on SITL, or we must depend on this magic auto-stubbing in some `plugin`. I have tried some reading on the linker option `-fuse-linker-plugin` but have not yet found anything related to this. I frankly do not really understand this option and its possible magic. 