### PR TITLE
Cache SPI handle to improve performance for F7 boards

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -234,7 +234,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 {
     UNUSED(gyro); // since there are FCs which have gyro on I2C but other devices on SPI
 #ifdef USE_GYRO_SPI_MPU6000
-    gyro->bus.spi.instance = MPU6000_SPI_INSTANCE;
+    spiBusSetInstance(&gyro->bus, MPU6000_SPI_INSTANCE);
 #ifdef MPU6000_CS_PIN
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->bus.spi.csnPin;
 #endif
@@ -248,7 +248,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef USE_GYRO_SPI_MPU6500
-    gyro->bus.spi.instance = MPU6500_SPI_INSTANCE;
+    spiBusSetInstance(&gyro->bus, MPU6500_SPI_INSTANCE);
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->bus.spi.csnPin;
     const uint8_t mpu6500Sensor = mpu6500SpiDetect(&gyro->bus);
     // some targets using MPU_9250_SPI, ICM_20608_SPI or ICM_20602_SPI state sensor is MPU_65xx_SPI
@@ -262,7 +262,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef  USE_GYRO_SPI_MPU9250
-    gyro->bus.spi.instance = MPU9250_SPI_INSTANCE;
+    spiBusSetInstance(&gyro->bus, MPU9250_SPI_INSTANCE);
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->bus.spi.csnPin;
     if (mpu9250SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
@@ -275,7 +275,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef USE_GYRO_SPI_ICM20689
-    gyro->bus.spi.instance = ICM20689_SPI_INSTANCE;
+    spiBusSetInstance(&gyro->bus, ICM20689_SPI_INSTANCE);
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->bus.spi.csnPin;
     if (icm20689SpiDetect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
@@ -287,7 +287,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 #endif
 
 #ifdef USE_ACCGYRO_BMI160
-    gyro->bus.spi.instance = BMI160_SPI_INSTANCE;
+    spiBusSetInstance(&gyro->bus, BMI160_SPI_INSTANCE);
     gyro->bus.spi.csnPin = gyro->bus.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->bus.spi.csnPin;
     if (bmi160Detect(&gyro->bus)) {
         gyro->mpuDetectionResult.sensor = BMI_160_SPI;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -25,6 +25,9 @@
 typedef union busDevice_u {
     struct deviceSpi_s {
         SPI_TypeDef *instance;
+#if defined(USE_HAL_DRIVER)
+        SPI_HandleTypeDef* handle; // cached here for efficiency
+#endif
         IO_t csnPin;
     } spi;
     struct deviceI2C_s {

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -383,3 +383,8 @@ uint8_t spiReadRegister(const busDevice_t *bus, uint8_t reg)
 
     return data;
 }
+
+void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance)
+{
+    bus->spi.instance = instance;
+}

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -106,3 +106,4 @@ DMA_HandleTypeDef* spiSetDMATransmit(DMA_Stream_TypeDef *Stream, uint32_t Channe
 bool spiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool spiReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
 uint8_t spiReadRegister(const busDevice_t *bus, uint8_t reg);
+void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance);

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -84,7 +84,9 @@
 
 static float magGain[3] = { 1.0f, 1.0f, 1.0f };
 
+#if defined(USE_SPI)
 static busDevice_t *bus = NULL; // HACK
+#endif
 
 // FIXME pretend we have real MPU9250 support
 // Is an separate MPU9250 driver really needed? The GYRO/ACC part between MPU6500 and MPU9250 is exactly the same.
@@ -325,21 +327,18 @@ bool ak8963Detect(magDev_t *mag)
 {
     uint8_t sig = 0;
 
-    bus = &mag->bus;
-
 #if defined(USE_SPI)
+    bus = &mag->bus;
 #if defined(MPU6500_SPI_INSTANCE)
-    bus->spi.instance = MPU6500_SPI_INSTANCE;
+    spiBusSetInstance(&mag->bus, MPU6500_SPI_INSTANCE);
 #elif defined(MPU9250_SPI_INSTANCE)
-    bus->spi.instance = MPU9250_SPI_INSTANCE;
-    // initialze I2C master via SPI bus (MPU9250)
+    spiBusSetInstance(&mag->bus, MPU9250_SPI_INSTANCE);
 
+    // initialze I2C master via SPI bus (MPU9250)
     mpu9250SpiWriteRegisterVerify(&mag->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
     delay(10);
-
     mpu9250SpiWriteRegisterVerify(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
-
     mpu9250SpiWriteRegisterVerify(&mag->bus, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif


### PR DESCRIPTION
This extends PR https://github.com/betaflight/betaflight/pull/3381 - "Make SPI read and write register generic" by caching the SPI handle to improve performance of F7 boards.