### PR TITLE
Add most common reason for not arming to OSD

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -190,13 +190,6 @@ static const char * const *sensorHardwareNames[] = {
 };
 #endif // USE_SENSOR_NAMES
 
-#ifndef MINIMAL_CLI
-static const char *armingDisableFlagNames[] = {
-    "NOGYRO", "FAILSAFE", "BOXFAILSAFE", "THROTTLE",
-    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
-};
-#endif
-
 static void cliPrint(const char *str)
 {
     while (*str) {

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -29,6 +29,13 @@ uint16_t flightModeFlags = 0;
 
 static uint32_t enabledSensors = 0;
 
+#if defined(OSD) || !defined(MINIMAL_CLI)
+const char *armingDisableFlagNames[]= {
+    "NOGYRO", "FAILSAFE", "BOXFAILSAFE", "THROTTLE",
+    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
+};
+#endif
+
 static armingDisableFlags_e armingDisableFlags = 0;
 
 void setArmingDisabled(armingDisableFlags_e flag)

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -47,6 +47,11 @@ typedef enum {
     ARMING_DISABLED_BST         = (1 << 10),
 } armingDisableFlags_e;
 
+#define NUM_ARMING_DISABLE_FLAGS 11
+#if defined(OSD) || !defined(MINIMAL_CLI)
+extern const char *armingDisableFlagNames[NUM_ARMING_DISABLE_FLAGS];
+#endif
+
 void setArmingDisabled(armingDisableFlags_e flag);
 void unsetArmingDisabled(armingDisableFlags_e flag);
 bool isArmingDisabled(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -128,7 +128,6 @@ static uint8_t armState;
 
 static displayPort_t *osdDisplayPort;
 
-
 #define AH_MAX_PITCH 200 // Specify maximum AHI pitch value displayed. Default 200 = 20.0 degrees
 #define AH_MAX_ROLL 400  // Specify maximum AHI roll value displayed. Default 400 = 40.0 degrees
 #define AH_SIDEBAR_WIDTH_POS 7
@@ -520,6 +519,19 @@ static void osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_WARNINGS:
+        /* Show common reason for arming being disabled */
+        if (IS_RC_MODE_ACTIVE(BOXARM) && isArmingDisabled()) {
+            const armingDisableFlags_e flags = getArmingDisableFlags();
+            for (int i = 0; i < NUM_ARMING_DISABLE_FLAGS; i++) {
+                if (flags & (1 << i)) {
+                    tfp_sprintf(buff, "%s", armingDisableFlagNames[i]);
+                    break;
+                }
+            }
+            break;
+        }
+
+        /* Show battery state warning */
         switch(getBatteryState()) {
         case BATTERY_WARNING:
             tfp_sprintf(buff, "LOW BATTERY");
@@ -530,6 +542,7 @@ static void osdDrawSingleElement(uint8_t item)
             break;
 
         default:
+            /* Show visual beeper if battery is OK */
             if (showVisualBeeper) {
                 tfp_sprintf(buff, "  * * * *");
             } else {

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -113,7 +113,8 @@ osd_unittest_SRC := \
 		$(USER_DIR)/common/typeconversion.c \
 		$(USER_DIR)/drivers/display.c \
 		$(USER_DIR)/common/maths.c \
-		$(USER_DIR)/common/printf.c
+		$(USER_DIR)/common/printf.c \
+		$(USER_DIR)/fc/runtime_config.c
 
 osd_unittest_DEFINES := \
 		OSD

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -48,9 +48,6 @@ extern "C" {
 
     void osdRefresh(timeUs_t currentTimeUs);
 
-    uint8_t stateFlags;
-    uint8_t armingFlags;
-    uint16_t flightModeFlags;
     uint16_t rssi;
     attitudeEulerAngles_t attitude;
     pidProfile_t *currentPidProfile;
@@ -498,9 +495,8 @@ TEST(OsdTest, TestElementRssi)
 
 // STUBS
 extern "C" {
-    bool sensors(uint32_t mask) {
-        UNUSED(mask);
-        return true;
+    void beeperConfirmationBeeps(uint8_t beepCount) {
+        UNUSED(beepCount);
     }
 
     bool IS_RC_MODE_ACTIVE(boxId_e boxId) {
@@ -574,7 +570,4 @@ extern "C" {
         UNUSED(pDisplay);
         return false;
     }
-
-    void setArmingDisabled(armingDisableFlags_e flag) { UNUSED(flag); }
-    void unsetArmingDisabled(armingDisableFlags_e flag) { UNUSED(flag); }
 }


### PR DESCRIPTION
Adds the most common reasons for not arming to the OSD with a generic message for all other conditions.

Only added the most common (throttle not zero, craft not level, calibration not complete) to save flash space used for strings.