### PR TITLE
removed triple definition of MIN/MAX macros

### DIFF
--- a/src/main/drivers/sdcard_standard.c
+++ b/src/main/drivers/sdcard_standard.c
@@ -1,8 +1,7 @@
 #include <stdint.h>
 
 #include "sdcard_standard.h"
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#include "common/maths.h"
 
 /**
  * Read a bitfield from an array of bits (the bit at index 0 being the most-significant bit of the first byte in

--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -28,6 +28,7 @@
 
 #include "fat_standard.h"
 #include "drivers/sdcard.h"
+#include "common/maths.h"
 
 #ifdef AFATFS_DEBUG
     #define ONLY_EXPOSE_FOR_TESTING
@@ -91,9 +92,6 @@
 #define AFATFS_FREESPACE_FILENAME "FREESPAC.E"
 
 #define AFATFS_INTROSPEC_LOG_FILENAME "ASYNCFAT.LOG"
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 typedef enum {
     AFATFS_SAVE_DIRECTORY_NORMAL,


### PR DESCRIPTION
I found it by accident, the MIN/MAX macros are defined multiple times ;)

Maybe it would be a good idea to replace them by safe versions as listed below?

```
#define MIN(x,y) ({ \
	typeof(x) _x = (x);	\
	typeof(y) _y = (y);	\
	(void) (&_x == &_y);	\
	_x < _y ? _x : _y; })

#define MAX(x,y) ({ \
	typeof(x) _x = (x);	\
	typeof(y) _y = (y);	\
	(void) (&_x == &_y);	\
	_x > _y ? _x : _y; })
```

The current version suffers a double evaluation bug. For example
MIN(a++, b) would execute a++ twice... 