### PR TITLE
Update vagrant, Ubuntu16.04LTS/Xenial and build tool chain.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,12 @@ Vagrant.configure(2) do |config|
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/trusty64"
+  # boxes at https://app.vagrantup.com/boxes/search
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provider "virtualbox" do |v|
+      v.memory = 4096
+  end
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
@@ -21,7 +25,8 @@ Vagrant.configure(2) do |config|
     apt-get remove -y binutils-arm-none-eabi gcc-arm-none-eabi
     add-apt-repository ppa:team-gcc-arm-embedded/ppa
     apt-get update
-    apt-get install -y git ccache gcc-arm-embedded=6-2017q1-1~trusty3
+    apt-get install -y git gcc-arm-embedded=6-2017q2-1~xenial1
+    apt-get install -y make python gcc clang
   SHELL
 end
 


### PR DESCRIPTION
Vagrant update, to match tool chain update in other env. It was also needed to refresh the base env to more recent Ubuntu and gcc versions etc. 

Also, the Vagrant / Hasicorp base boxes used have changed to be very small and empty virtual machines. The old ubuntu/trust64 are now only a 512Mbyte machine and this new ubuntu/xenial64 is a 1Gbyte. Very little of our needed tool chain is installed. But this is actually a good thing, now we must specify a bit more exactly our env dependencies. Previously we took whatever was pre-installed in the base box. Tested on Win10 and Ubuntu16.04 hosts. 
There are however a few problems still, that I have been fighting and found no solutions to: 

- On Win10 the setup of a new virtual machine, with the initial `vagrant up` command, might break with a message something like "Invalid state...". Workaround is to stop the VM ( `vagrant halt` ) and try again.
- On Linux large builds might hang ( typically `make all` ). Workaround is to only make one or only a few targets at a time. 
- Running unit tests will cause some printouts like `profiling: /vagrant/src/test/../../obj/test/gtest_main.gcda: cannot map: Invalid argument`. Probably a VM shared dir linking problem. No workaround found, but this does not affect the end result. Coverage and profiling is a known pain in the lower back parts....

Note: Some of the problems above might be caused by lack of Virtual Memory, this was very noticable when running the small defaults VMs (.5 and 1Gb). Did some trials with adding Virtual Mem via dynamic swap service `swapspace`, but that seemed even more unstable. Frequent hangups. Fix so far is to setup VM for 4Gb memory and remove ccache to minimize memory demand.

All-in-all, be cautioned when/if using Vagrant. And please, contribute if some solutions or workarounds are found. Not sure I can spend more time on this right now.

  