### PR TITLE
flash usage on F3 targets - size optimization?

### DIFF
--- a/src/main/common/optimization.h
+++ b/src/main/common/optimization.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define OPTIMIZE_FOR_SIZE __attribute__((optimize("Os")))
+

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "common/optimization.h"
 #include "config/parameter_group.h"
 #include "drivers/serial.h"
 
@@ -127,22 +128,22 @@ typedef void serialConsumer(uint8_t);
 //
 // configuration
 //
-void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisable);
-void serialRemovePort(serialPortIdentifier_e identifier);
-uint8_t serialGetAvailablePortCount(void);
-bool serialIsPortAvailable(serialPortIdentifier_e identifier);
-bool isSerialConfigValid(const serialConfig_t *serialConfig);
-serialPortConfig_t *serialFindPortConfiguration(serialPortIdentifier_e identifier);
-bool doesConfigurationUsePort(serialPortIdentifier_e portIdentifier);
-serialPortConfig_t *findSerialPortConfig(serialPortFunction_e function);
-serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function);
+void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisable) OPTIMIZE_FOR_SIZE;
+void serialRemovePort(serialPortIdentifier_e identifier) OPTIMIZE_FOR_SIZE;
+uint8_t serialGetAvailablePortCount(void) OPTIMIZE_FOR_SIZE;
+bool serialIsPortAvailable(serialPortIdentifier_e identifier) OPTIMIZE_FOR_SIZE;
+bool isSerialConfigValid(const serialConfig_t *serialConfig) OPTIMIZE_FOR_SIZE;
+serialPortConfig_t *serialFindPortConfiguration(serialPortIdentifier_e identifier) OPTIMIZE_FOR_SIZE;
+bool doesConfigurationUsePort(serialPortIdentifier_e portIdentifier) OPTIMIZE_FOR_SIZE;
+serialPortConfig_t *findSerialPortConfig(serialPortFunction_e function) OPTIMIZE_FOR_SIZE;
+serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function) OPTIMIZE_FOR_SIZE;
 
-portSharing_e determinePortSharing(const serialPortConfig_t *portConfig, serialPortFunction_e function);
-bool isSerialPortShared(const serialPortConfig_t *portConfig, uint16_t functionMask, serialPortFunction_e sharedWithFunction);
+portSharing_e determinePortSharing(const serialPortConfig_t *portConfig, serialPortFunction_e function) OPTIMIZE_FOR_SIZE;
+bool isSerialPortShared(const serialPortConfig_t *portConfig, uint16_t functionMask, serialPortFunction_e sharedWithFunction) OPTIMIZE_FOR_SIZE;
 
-void pgResetFn_serialConfig(serialConfig_t *serialConfig); //!!TODO remove need for this
-serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e identifier);
-int findSerialPortIndexByIdentifier(serialPortIdentifier_e identifier);
+void pgResetFn_serialConfig(serialConfig_t *serialConfig) OPTIMIZE_FOR_SIZE; //!!TODO remove need for this
+serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e identifier) OPTIMIZE_FOR_SIZE;
+int findSerialPortIndexByIdentifier(serialPortIdentifier_e identifier) OPTIMIZE_FOR_SIZE;
 //
 // runtime
 //
@@ -153,8 +154,8 @@ serialPort_t *openSerialPort(
     uint32_t baudrate,
     portMode_t mode,
     portOptions_t options
-);
-void closeSerialPort(serialPort_t *serialPort);
+) OPTIMIZE_FOR_SIZE;
+void closeSerialPort(serialPort_t *serialPort) OPTIMIZE_FOR_SIZE;
 
 void waitForSerialPortToFinishTransmitting(serialPort_t *serialPort);
 
@@ -164,5 +165,5 @@ baudRate_e lookupBaudRateIndex(uint32_t baudRate);
 //
 // msp/cli/bootloader
 //
-void serialEvaluateNonMspData(serialPort_t *serialPort, uint8_t receivedChar);
-void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer *leftC, serialConsumer *rightC);
+void serialEvaluateNonMspData(serialPort_t *serialPort, uint8_t receivedChar) __attribute__((optimize("Os")));
+void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer *leftC, serialConsumer *rightC)__attribute__((optimize("Os")));


### PR DESCRIPTION
Seems like the flash space is getting low for some F3 targets. I was wondering if there is a way to squeeze the code a bit more...
This is not meant to be merged, it's meant for discussion.

I know that there are arguments against function based size optimization (and I have read some discussions in issues and pull requests). And I know the phrase in the gcc manual that one should not use this on production code.

I was wondering what is the strategy to solve to low flash space?
I did some tests with manual size optimization for the serial code (only non timing critical code).
This squeezed the .text section  from 234672 to 232040 (TARGET=BETAFLIGHTF3).

Interestingly the manual size optimization does not help on all functions (probably because of -flto).

How do you think about this level of manual optimization? If this might be an option I can have a look on which functions this might help.