### PR TITLE
Fix #3431

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -269,11 +269,11 @@ void init(void)
 #if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     // If F4 Overclocking is set and System core clock is not correct a reset is forced
     if (systemConfig()->cpu_overclock && SystemCoreClock != 240000000) {
-        *((uint32_t *)0x2001FFFC) = 0xDEADBABE; // 128KB SRAM STM32F4XX
+        *((uint32_t *)0x2001FFF8) = 0xDEADBABE; // 128KB SRAM STM32F4XX
         __disable_irq();
         NVIC_SystemReset();
     } else if (!systemConfig()->cpu_overclock && SystemCoreClock == 240000000) {
-        *((uint32_t *)0x2001FFFC) = 0x0;        // 128KB SRAM STM32F4XX
+        *((uint32_t *)0x2001FFF8) = 0x0;        // 128KB SRAM STM32F4XX
         __disable_irq();
         NVIC_SystemReset();
     }

--- a/src/main/startup/startup_stm32f40xx.s
+++ b/src/main/startup/startup_stm32f40xx.s
@@ -79,14 +79,6 @@ Reset_Handler:
   str     r1, [r0, #0x30]
   dsb
 
-  // Check for overclocking request
-  ldr r0, =0x2001FFFC         // Faduf
-  ldr r1, =0xDEADBABE         // Faduf
-  ldr r2, [r0, #0]            // Faduf
-  str r0, [r0, #0]            // Faduf
-  cmp r2, r1                  // Faduf
-  beq Boot_OC                 // Faduf
-
   // Check for bootloader reboot
   ldr r0, =0x2001FFFC         // mj666
   ldr r1, =0xDEADBEEF         // mj666
@@ -94,6 +86,14 @@ Reset_Handler:
   str r0, [r0, #0]            // mj666
   cmp r2, r1                  // mj666
   beq Reboot_Loader           // mj666
+
+  // Check for overclocking request
+  ldr r0, =0x2001FFF8         // Faduf
+  ldr r1, =0xDEADBABE         // Faduf
+  ldr r2, [r0, #0]            // Faduf
+  str r0, [r0, #0]            // Faduf
+  cmp r2, r1                  // Faduf
+  beq Boot_OC                 // Faduf
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0


### PR DESCRIPTION
PR status: Ready to merge.

0x2001FFFC is used by bootloader request marker.
Use 0x2001FFF8 instead for overclock request marker.
#3432 only fixed the order of checking.