### PR TITLE
Overclockin' baby face!!!

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -269,7 +269,7 @@ void init(void)
 #if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     // If F4 Overclocking is set and System core clock is not correct a reset is forced
     if (systemConfig()->cpu_overclock && SystemCoreClock != 240000000) {
-        *((uint32_t *)0x2001FFF8) = 0xDEADBABE; // 128KB SRAM STM32F4XX
+        *((uint32_t *)0x2001FFF8) = 0xBABEFACE; // 128KB SRAM STM32F4XX
         __disable_irq();
         NVIC_SystemReset();
     } else if (!systemConfig()->cpu_overclock && SystemCoreClock == 240000000) {

--- a/src/main/startup/startup_stm32f40xx.s
+++ b/src/main/startup/startup_stm32f40xx.s
@@ -89,7 +89,7 @@ Reset_Handler:
 
   // Check for overclocking request
   ldr r0, =0x2001FFF8         // Faduf
-  ldr r1, =0xDEADBABE         // Faduf
+  ldr r1, =0xBABEFACE         // Faduf
   ldr r2, [r0, #0]            // Faduf
   str r0, [r0, #0]            // Faduf
   cmp r2, r1                  // Faduf


### PR DESCRIPTION
And of course, overclocking should be identified by `BABEFACE` 🚼 