### PR TITLE
Define PLL setting for overclock

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -268,11 +268,11 @@ void init(void)
 
 #if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     // If F4 Overclocking is set and System core clock is not correct a reset is forced
-    if (systemConfig()->cpu_overclock && SystemCoreClock != 240000000) {
+    if (systemConfig()->cpu_overclock && SystemCoreClock != OC_FREQUENCY_HZ) {
         *((uint32_t *)0x2001FFF8) = 0xBABEFACE; // 128KB SRAM STM32F4XX
         __disable_irq();
         NVIC_SystemReset();
-    } else if (!systemConfig()->cpu_overclock && SystemCoreClock == 240000000) {
+    } else if (!systemConfig()->cpu_overclock && SystemCoreClock == OC_FREQUENCY_HZ) {
         *((uint32_t *)0x2001FFF8) = 0x0;        // 128KB SRAM STM32F4XX
         __disable_irq();
         NVIC_SystemReset();

--- a/src/main/target/system_stm32f4xx.c
+++ b/src/main/target/system_stm32f4xx.c
@@ -505,9 +505,9 @@ void SystemInit(void)
 void SystemInitOC(void)
 {
     /* PLL setting for overclocking */
-    pll_n = 480;
-    pll_p = 2;
-    pll_q = 10;
+    pll_n = PLL_N_OC;
+    pll_p = PLL_P_OC;
+    pll_q = PLL_Q_OC;
 
     SystemInit();
 }

--- a/src/main/target/system_stm32f4xx.h
+++ b/src/main/target/system_stm32f4xx.h
@@ -32,6 +32,11 @@
  extern "C" {
 #endif
 
+#define PLL_N_OC         480
+#define PLL_P_OC         2
+#define PLL_Q_OC         10
+#define OC_FREQUENCY_HZ  PLL_N_OC/PLL_P_OC*1000000
+
 extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Clock) */
 extern void SystemInit(void);
 extern void SystemInitOC(void);

--- a/src/main/target/system_stm32f4xx.h
+++ b/src/main/target/system_stm32f4xx.h
@@ -35,7 +35,7 @@
 #define PLL_N_OC         480
 #define PLL_P_OC         2
 #define PLL_Q_OC         10
-#define OC_FREQUENCY_HZ  PLL_N_OC/PLL_P_OC*1000000
+#define OC_FREQUENCY_HZ  (1000000*PLL_N_OC/PLL_P_OC)
 
 extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Clock) */
 extern void SystemInit(void);


### PR DESCRIPTION
With these changes PLL values for overclocking are defined to calculate the overclocked frequency. Frequency change will be automatically change in fc_init.c if PLL for overclocking are changed.