### PR TITLE
Fix #3448 Bad UART pin configuration

### DIFF
--- a/src/main/drivers/serial_pinconfig.c
+++ b/src/main/drivers/serial_pinconfig.c
@@ -262,8 +262,6 @@ PG_REGISTER_WITH_RESET_FN(serialPinConfig_t, serialPinConfig, PG_SERIAL_PIN_CONF
 
 void pgResetFn_serialPinConfig(serialPinConfig_t *serialPinConfig)
 {
-    memset(serialPinConfig, 0, sizeof(*serialPinConfig));
-
     for (size_t index = 0 ; index < ARRAYLEN(serialDefaultPin) ; index++) {
         const serialDefaultPin_t *defpin = &serialDefaultPin[index];
         serialPinConfig->ioTagRx[SERIAL_PORT_IDENTIFIER_TO_INDEX(defpin->ident)] = defpin->rxIO;

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -111,6 +111,10 @@
 
 #define UARTDEV_COUNT (UARTDEV_COUNT_1 + UARTDEV_COUNT_2 + UARTDEV_COUNT_3 + UARTDEV_COUNT_4 + UARTDEV_COUNT_5 + UARTDEV_COUNT_6 + UARTDEV_COUNT_7 + UARTDEV_COUNT_8)
 
+#if UARTDEV_COUNT > UARTDEV_COUNT_MAX
+#error Too many USE_UARTx defined for the MCU
+#endif
+
 typedef struct uartHardware_s {
     UARTDevice device;    // XXX Not required for full allocation
     USART_TypeDef* reg;

--- a/src/main/drivers/serial_uart_pinconfig.c
+++ b/src/main/drivers/serial_uart_pinconfig.c
@@ -46,6 +46,12 @@ void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig)
     for (size_t hindex = 0; hindex < UARTDEV_COUNT_MAX; hindex++) {
 
         const uartHardware_t *hardware = &uartHardware[hindex];
+
+        if (!hardware->reg) {
+            // Empty entry
+            continue;
+        }
+
         UARTDevice device = hardware->device;
 
         for (int pindex = 0 ; pindex < UARTHARDWARE_MAX_PINS ; pindex++) {

--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -57,8 +57,7 @@
 #define UART3_RX_DMA_CHANNEL 0
 #define UART3_TX_DMA_CHANNEL 0
 
-const uartHardware_t uartHardware[UARTDEV_COUNT] = {
-#ifdef USE_UART1
+const uartHardware_t uartHardware[UARTDEV_COUNT_MAX] = {
     {
         .device = UARTDEV_1,
         .reg = USART1,
@@ -72,8 +71,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1
     },
-#endif
-#ifdef USE_UART2
     { 
         .device = UARTDEV_2,
         .reg = USART2,
@@ -87,8 +84,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART2,
         .rxPriority = NVIC_PRIO_SERIALUART2
     },
-#endif
-#ifdef USE_UART3
     {
         .device = UARTDEV_3,
         .reg = USART3,
@@ -102,7 +97,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART3,
         .rxPriority = NVIC_PRIO_SERIALUART3
     },
-#endif
 };
 
 void uart_tx_dma_IRQHandler(dmaChannelDescriptor_t* descriptor)

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -80,8 +80,7 @@
 # define UART3_TX_DMA 0
 #endif
 
-const uartHardware_t uartHardware[UARTDEV_COUNT] = {
-#ifdef USE_UART1
+const uartHardware_t uartHardware[UARTDEV_COUNT_MAX] = {
     {
         .device = UARTDEV_1,
         .reg = USART1,
@@ -95,9 +94,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1_RXDMA,
     },
-#endif
-
-#ifdef USE_UART2
     {
         .device = UARTDEV_2,
         .reg = USART2,
@@ -111,9 +107,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2_RXDMA,
     },
-#endif
-
-#ifdef USE_UART3
     {
         .device = UARTDEV_3,
         .reg = USART3,
@@ -127,9 +120,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3_RXDMA,
     },
-#endif
-
-#ifdef USE_UART4
     // UART4 XXX Not tested (yet!?) Need 303RC, e.g. LUX for testing
     {
         .device = UARTDEV_4,
@@ -144,9 +134,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4_RXDMA,
     },
-#endif
-
-#ifdef USE_UART5
     // UART5 XXX Not tested (yet!?) Need 303RC; e.g. LUX for testing
     {
         .device = UARTDEV_5,
@@ -161,7 +148,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART5,
         .rxPriority = NVIC_PRIO_SERIALUART5,
     },
-#endif
 };
 
 static void handleUsartTxDma(dmaChannelDescriptor_t* descriptor)

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -36,8 +36,7 @@
 
 #ifdef USE_UART
 
-const uartHardware_t uartHardware[UARTDEV_COUNT] = {
-#ifdef USE_UART1
+const uartHardware_t uartHardware[UARTDEV_COUNT_MAX] = {
     {
         .device = UARTDEV_1,
         .reg = USART1,
@@ -56,9 +55,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1
     },
-#endif
-
-#ifdef USE_UART2
     {
         .device = UARTDEV_2,
         .reg = USART2,
@@ -77,9 +73,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2
     },
-#endif
 
-#ifdef USE_UART3
+#if !defined(STM32F411xE)
     {
         .device = UARTDEV_3,
         .reg = USART3,
@@ -98,9 +93,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3
     },
-#endif
-
-#ifdef USE_UART4
     {
         .device = UARTDEV_4,
         .reg = UART4,
@@ -119,9 +111,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4
     },
-#endif
-
-#ifdef USE_UART5
     {
         .device = UARTDEV_5,
         .reg = UART5,
@@ -140,9 +129,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART5
     },
-#endif
+#endif // !STM32F411xE
 
-#ifdef USE_UART6
     {
         .device = UARTDEV_6,
         .reg = USART6,
@@ -161,7 +149,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6
     },
-#endif
 };
 
 static void handleUsartTxDma(uartPort_t *s)

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -38,8 +38,7 @@
 
 static void handleUsartTxDma(uartPort_t *s);
 
-const uartHardware_t uartHardware[UARTDEV_COUNT] = {
-#ifdef USE_UART1
+const uartHardware_t uartHardware[UARTDEV_COUNT_MAX] = {
     {
         .device = UARTDEV_1,
         .reg = USART1,
@@ -60,9 +59,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1
     },
-#endif
-
-#ifdef USE_UART2
     {
         .device = UARTDEV_2,
         .reg = USART2,
@@ -83,9 +79,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2
     },
-#endif
-
-#ifdef USE_UART3
     {
         .device = UARTDEV_3,
         .reg = USART3,
@@ -106,9 +99,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3
     },
-#endif
-
-#ifdef USE_UART4
     {
         .device = UARTDEV_4,
         .reg = UART4,
@@ -129,9 +119,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4
     },
-#endif
-
-#ifdef USE_UART5
     {
         .device = UARTDEV_5,
         .reg = UART5,
@@ -152,9 +139,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART5
     },
-#endif
-
-#ifdef USE_UART6
     {
         .device = UARTDEV_6,
         .reg = USART6,
@@ -175,9 +159,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6
     },
-#endif
-
-#ifdef USE_UART7
     {
         .device = UARTDEV_7,
         .reg = UART7,
@@ -198,9 +179,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART7_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART7
     },
-#endif
-
-#ifdef USE_UART8
     {
         .device = UARTDEV_8,
         .reg = UART8,
@@ -221,7 +199,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPriority = NVIC_PRIO_SERIALUART8_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART8
     },
-#endif
 };
 
 void uartIrqHandler(uartPort_t *s)


### PR DESCRIPTION
PR status: Ready to merge (critical fix)

In `uartPinConfigure`, outer most for goes around as many as `UARTDEV_COUNT_MAX` (5 for F3), while `uartHardware` only defines what has been declared as used (3 for X_RACERSPI); last two loops work on
something that does not define UART hardware.

- uartHardware is now defined to have `UARTDEV_COUNT_MAX` elements, which is actually required for full configurability.

Other minor amendments

- Added a watchdog for `UARTDEV_COUNT > UARTDEV_COUNT_MAX` case.
- Memory clear (by means of `memset`) has been deleted from uart pin PG reset function per @ledvinap 's previous comment.
