### PR TITLE
Optimise OSD fonts to release more symbol space

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -768,11 +768,17 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 static void osdDrawLogo(int x, int y)
 {
     // display logo and help
-    int fontOffset = 160;
-    for (int row = 0; row < 4; row++) {
+    int fontOffset = 0xb8;
+    for (int row = 0; row < 3; row++) {
         for (int column = 0; column < 24; column++) {
-            if (fontOffset <= SYM_END_OF_FONT)
-                displayWriteChar(osdDisplayPort, x + column, y + row, fontOffset++);
+            if (fontOffset <= SYM_END_OF_FONT) {
+                if((fontOffset < 0xbd) || (fontOffset > 0xcf)) { // exclude characters 189 through 207 (as they are blank)
+                    displayWriteChar(osdDisplayPort, x + column, y + row, fontOffset++);
+                } else {
+                    displayWriteChar(osdDisplayPort, x + column, y + row, SYM_BLANK); // write blank character
+                    fontOffset++;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
By moving the Betaflight logo down a couple of pixels, the logo completely fits on only 4 rows (not 5). This will make characters 0xA0 to 0xB7 available for re-use.

Also, within the logo itself, characters 0xBD through 0xCF also become completely blank.
By modifying the draw logo function slightly, then we can skip these characters (and draw SYM_BLANK) and thus also free them up for other use.

This will release a total of 43 characters for use for other osd symbols.

Requires the update of the .mcm font files (attached) with the logo moved down slightly.
[NewFonts.zip](https://github.com/betaflight/betaflight/files/1132837/NewFonts.zip)

![image](https://user-images.githubusercontent.com/7362663/27983732-546b1316-63bb-11e7-99b0-01e140974163.png)

