### PR TITLE
Fix timerClock for F411xE

### DIFF
--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -82,9 +82,13 @@ const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
 
 uint8_t timerClockDivisor(TIM_TypeDef *tim)
 {
-#if defined (STM32F40_41xxx)
+#if defined (STM32F411xE)
+    UNUSED(tim);
+    return 1;
+#elif defined (STM32F40_41xxx)
     if (tim == TIM8) return 1;
 #endif
+
     if (tim == TIM1 || tim == TIM9 || tim == TIM10 || tim == TIM11) {
         return 1;
     } else {
@@ -94,17 +98,5 @@ uint8_t timerClockDivisor(TIM_TypeDef *tim)
 
 uint32_t timerClock(TIM_TypeDef *tim)
 {
-#if defined (STM32F411xE)
-    UNUSED(tim);
-    return SystemCoreClock;
-#else
-#if defined (STM32F40_41xxx)
-    if (tim == TIM8) return SystemCoreClock;
-#endif
-    if (tim == TIM1 || tim == TIM9 || tim == TIM10 || tim == TIM11) {
-        return SystemCoreClock;
-    } else {
-        return SystemCoreClock / 2;
-    }
-#endif
+    return SystemCoreClock / timerClockDivisor(tim);
 }

--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -94,6 +94,10 @@ uint8_t timerClockDivisor(TIM_TypeDef *tim)
 
 uint32_t timerClock(TIM_TypeDef *tim)
 {
+#if defined (STM32F411xE)
+    UNUSED(tim);
+    return SystemCoreClock;
+#else
 #if defined (STM32F40_41xxx)
     if (tim == TIM8) return SystemCoreClock;
 #endif
@@ -102,4 +106,5 @@ uint32_t timerClock(TIM_TypeDef *tim)
     } else {
         return SystemCoreClock / 2;
     }
+#endif
 }


### PR DESCRIPTION
PR status: Ready to merge

It has been reported that motor outputs from certain timers on F411xE targets are half the width of what they should be. Affected timers were TIM2,3,4 and 5.

By comparing timer feature comparison table, it is revealed that F411xE has different clock source from F405xx for these timers.

F411xE:
![www_st_com_content_ccc_resource_technical_document_datasheet_b3_a5_46_3b_b4_e5_4c_85_dm00115249_pdf_files_dm00115249_pdf_jcr_content_translations_en_dm00115249_pdf](https://user-images.githubusercontent.com/14850998/27985838-7df6b0aa-642e-11e7-97fa-167cf5b59368.jpg)

F405xx
![www_st_com_content_ccc_resource_technical_document_datasheet_ef_92_76_6d_bb_c2_4f_f7_dm00037051_pdf_files_dm00037051_pdf_jcr_content_translations_en_dm00037051_pdf](https://user-images.githubusercontent.com/14850998/27985844-aaf4a8d2-642e-11e7-9227-832416f6b456.jpg)
![www_st_com_content_ccc_resource_technical_document_datasheet_ef_92_76_6d_bb_c2_4f_f7_dm00037051_pdf_files_dm00037051_pdf_jcr_content_translations_en_dm00037051_pdf](https://user-images.githubusercontent.com/14850998/27985850-c9a64f7e-642e-11e7-98f8-6105bf559fce.jpg)

Fix is to let `timerClock` return `systemCoreClock` for all timers for F411xE.