### PR TITLE
BF - Port cleaned-up map command from CF.

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2097,31 +2097,41 @@ static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfi
     cliDumpPrintLinef(dumpMask, equalsDefault, formatMap, buf);
 }
 
+
 static void cliMap(char *cmdline)
 {
-    uint32_t len;
-    char out[9];
+    uint32_t i;
+    char buf[RX_MAPPABLE_CHANNEL_COUNT + 1];
 
-    len = strlen(cmdline);
+    uint32_t len = strlen(cmdline);
+    if (len == RX_MAPPABLE_CHANNEL_COUNT) {
 
-    if (len == 8) {
-        // uppercase it
-        for (uint32_t i = 0; i < 8; i++)
-            cmdline[i] = toupper((unsigned char)cmdline[i]);
-        for (uint32_t i = 0; i < 8; i++) {
-            if (strchr(rcChannelLetters, cmdline[i]) && !strchr(cmdline + i + 1, cmdline[i]))
+        for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
+            buf[i] = toupper((unsigned char)cmdline[i]);
+        }
+        buf[i] = '\0';
+
+        for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
+            buf[i] = toupper((unsigned char)cmdline[i]);
+
+            if (strchr(rcChannelLetters, buf[i]) && !strchr(buf + i + 1, buf[i]))
                 continue;
+
             cliShowParseError();
             return;
         }
-        parseRcChannels(cmdline, rxConfigMutable());
+        parseRcChannels(buf, rxConfigMutable());
+    } else if (len > 0) {
+        cliShowParseError();
+        return;
     }
-    cliPrint("Map: ");
-    uint32_t i;
-    for (i = 0; i < 8; i++)
-        out[rxConfig()->rcmap[i]] = rcChannelLetters[i];
-    out[i] = '\0';
-    cliPrintLine(out);
+
+    for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
+        buf[rxConfig()->rcmap[i]] = rcChannelLetters[i];
+    }
+
+    buf[i] = '\0';
+    cliPrintLinef("map %s", buf);
 }
 
 static char *checkCommand(char *cmdLine, const char *command)


### PR DESCRIPTION
@mikeller Note: this uses the recently renamed RX_MAPPABLE_CHANNEL_COUNT instead of magic numbers.  That change caused a merge conflict in CF so here's the PR so we can avoid that conflict in the future.