### PR TITLE
ANYFCF7 Activate I2C2 as external I2C

### DIFF
--- a/src/main/target/ANYFCF7/target.h
+++ b/src/main/target/ANYFCF7/target.h
@@ -44,13 +44,16 @@
 #define USE_EXTI
 
 #define MAG
-//#define USE_MAG_HMC5883
-//#define HMC5883_BUS I2C_DEVICE_EXT
+#define USE_MAG_HMC5883
+#define MAG_I2C_INSTANCE           (I2CDEV_2)
+
 //#define MAG_HMC5883_ALIGN CW270_DEG_FLIP
 //#define MAG_HMC5883_ALIGN CW90_DEG
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP280
+#define BARO_I2C_INSTANCE           (I2CDEV_2)
 
 #define USABLE_TIMER_CHANNEL_COUNT 16
 
@@ -128,8 +131,9 @@
 #define SDCARD_DMA_CHANNEL                  DMA_CHANNEL_4
 
 #define USE_I2C
-#define USE_I2C_DEVICE_4
-#define I2C_DEVICE                  (I2CDEV_4)
+#define USE_I2C_DEVICE_2  // External I2C
+#define USE_I2C_DEVICE_4  // Onboard I2C
+#define I2C_DEVICE                  (I2CDEV_2)
 
 #define USE_ADC
 #define VBAT_ADC_PIN                PC0

--- a/src/main/target/ANYFCF7/target.mk
+++ b/src/main/target/ANYFCF7/target.mk
@@ -4,6 +4,8 @@ FEATURES       += SDCARD VCP
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
             drivers/barometer/barometer_ms5611.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/compass/compass_hmc5883l.c \
             drivers/light_ws2811strip.c \
             drivers/light_ws2811strip_hal.c
 


### PR DESCRIPTION
ANYFCF7 board design has two I2C buses provisioned (I2C2 for external connectivity and I2C4 for onboard MS5611 baro), but current target.h only configures I2C4.

This PR does the followings.

1. Activates I2C2 for the external I2C connectivity.

2. Change default `I2C_DEVICE` to `I2CDEV_2`.
Onboard baro, if installed, will be ignored for the moment. It will resurrect once bus for baro become configurable.

3. Added HMC5883 and BMP280 I2C drivers so that commonly available GPS puck and baro BoB can be used.
