### PR TITLE
Ensure PID/rate profile is updated before editing values in CMS

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -88,6 +88,7 @@ static long cmsx_profileIndexOnChange(displayPort_t *displayPort, const void *pt
     UNUSED(ptr);
 
     pidProfileIndex = tmpPidProfileIndex - 1;
+    changePidProfile(pidProfileIndex);
 
     return 0;
 }
@@ -98,6 +99,7 @@ static long cmsx_rateProfileIndexOnChange(displayPort_t *displayPort, const void
     UNUSED(ptr);
 
     rateProfileIndex = tmpRateProfileIndex - 1;
+    changeControlRateProfile(rateProfileIndex);
 
     return 0;
 }


### PR DESCRIPTION
Ensure the PID and rate profiles are set as soon as they are changed, ensures that the values being edited are for the correct selected profile.

Fixes #3508 