### PR TITLE
MSP changes for the new Power & Battery tab in configurator

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -706,7 +706,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 
     case MSP_VOLTAGE_METERS:
         // write out id and voltage meter values, once for each meter we support
-        for (int i = 0; i < supportedVoltageMeterCount - (12-getMotorCount()); i++) {
+        for (int i = 0; i < supportedVoltageMeterCount - (VOLTAGE_METER_ID_ESC_COUNT - getMotorCount()); i++) {
 
             voltageMeter_t meter;
             uint8_t id = (uint8_t)voltageMeterIds[i];
@@ -719,7 +719,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 
     case MSP_CURRENT_METERS:
         // write out id and current meter values, once for each meter we support
-        for (int i = 0; i < supportedCurrentMeterCount - (12-getMotorCount()); i++) {
+        for (int i = 0; i < supportedCurrentMeterCount - (VOLTAGE_METER_ID_ESC_COUNT - getMotorCount()); i++) {
 
             currentMeter_t meter;
             uint8_t id = (uint8_t)currentMeterIds[i];

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -60,6 +60,8 @@ typedef enum {
 #define MAX_VOLTAGE_SENSOR_ADC 1 // VBAT - some boards have external, 12V, 9V and 5V meters.
 #endif
 
+#define VOLTAGE_METER_ID_ESC_COUNT 12
+
 typedef enum {
     VOLTAGE_SENSOR_ADC_VBAT = 0,
     VOLTAGE_SENSOR_ADC_12V = 1,


### PR DESCRIPTION
To finish the new Power & Battery tab in the configurator there are some MSP changes needed. This PR adds two MSP command for reading/saving voltage and current meter settings.

Needs Betaflight configurator PR: https://github.com/betaflight/betaflight-configurator/pull/547