### PR TITLE
BFF3 Timer mapping re-adjustment

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.c
+++ b/src/main/target/BETAFLIGHTF3/target.c
@@ -26,25 +26,22 @@
 #include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM4, CH2, PB7, TIM_USE_PPM,                 TIMER_INPUT_ENABLED),                          // PPM
-    DEF_TIM(TIM16,CH1, PA6, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM1 (1,4)
-    DEF_TIM(TIM8, CH1N,PA7, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED), // PWM2 (2,3)
-    DEF_TIM(TIM8, CH2, PB8, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM3 (2,5)
-    DEF_TIM(TIM17,CH1, PB9, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM4 (1,1)
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_PPM,                 TIMER_INPUT_ENABLED),                          // PPM  DMA(1,4)
 
-#ifdef BFF3_USE_HEXA_DSHOT
-    // For HEXA dshot
-    DEF_TIM(TIM1, CH2N,PB0, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED), // PWM5 (1,3)
-    DEF_TIM(TIM8, CH3N,PB1, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED), // PWM6 (2,1)
-#else
-    // For softserial
-    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED), // PWM5 (1,2) !LED
-    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED), // PWM6 (1,3)
-#endif
+    // Motors 1-4
+    DEF_TIM(TIM16,CH1, PA6, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM1 DMA(1,6)
+    DEF_TIM(TIM8, CH1N,PA7, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED), // PWM2 DMA(2,3)
+    DEF_TIM(TIM8, CH2, PB8, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM3 DMA(2,5)
+    DEF_TIM(TIM17,CH1, PB9, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM4 DMA(1,7)
 
+    // Motors 5-6 or SoftSerial
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM5 DMA(1,2) !LED
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM6 DMA(1,3)
+
+    // Motors 7-8 or UART2
     DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM7/UART2_RX
     DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED),                         // PWM8/UART2_TX
 
-    // When using softserial config, LED will have DMA conflict with PB0 (SOFTSERIAL1_RX).
-    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MOTOR | TIM_USE_LED, TIMER_OUTPUT_ENABLED),                         // LED  (1,2)
+    // No LED for Hexa-Dshot; DMA conflict with Motor 5 (PB0); consider PPM if not used.
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MOTOR | TIM_USE_LED, TIMER_OUTPUT_ENABLED),                         // LED  DMA(1,2)
 };


### PR DESCRIPTION
PR status: Ready to merge

Removed BFF3_USE_HEXA_DSHOT (Still capable of Hexa-DSHOT).

- Selection of SoftSerial and Hexa-DSHOT is now possible with a single firmware (no more compile option)
- In Hexa-DSHOT configuration, LED strip has DMA conflict with motor 5. PPM is a candidate for alternate connection for the LED strip signal.