### PR TITLE
Enable UART4 (S5_OUT and S6_OUT) on REVO

### DIFF
--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -192,11 +192,11 @@
 #define UART3_RX_PIN            PB11
 #define UART3_TX_PIN            PB10
 
-#if defined(REVOLT)
+#if defined(REVOLT) || defined(REVO)
 #define USE_UART4
 #define UART4_RX_PIN            PA1
 #define UART4_TX_PIN            PA0
-#endif // REVOLT
+#endif // REVOLT || REVO
 
 #define USE_UART6
 #define UART6_RX_PIN            PC7
@@ -205,7 +205,7 @@
 #define USE_SOFTSERIAL1
 #define USE_SOFTSERIAL2
 
-#if defined(REVOLT)
+#if defined(REVOLT) || defined(REVO)
 #define SERIAL_PORT_COUNT       7 //VCP, USART1, USART3, UART4,  USART6, SOFTSERIAL x 2
 #else
 #define SERIAL_PORT_COUNT       6 //VCP, USART1, USART3, USART6, SOFTSERIAL x 2


### PR DESCRIPTION
PR status: Ready to merge