### PR TITLE
Allow setting debug mode from CMS

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -26,3 +26,28 @@ uint8_t debugMode;
 #ifdef DEBUG_SECTION_TIMES
 uint32_t sectionTimes[2][4];
 #endif
+
+const char * const debugModeNames[DEBUG_COUNT] = {
+    "NONE",
+    "CYCLETIME",
+    "BATTERY",
+    "GYRO",
+    "ACCELEROMETER",
+    "MIXER",
+    "AIRMODE",
+    "PIDLOOP",
+    "NOTCH",
+    "RC_INTERPOLATION",
+    "VELOCITY",
+    "DFILTER",
+    "ANGLERATE",
+    "ESC_SENSOR",
+    "SCHEDULER",
+    "STACK",
+    "ESC_SENSOR_RPM",
+    "ESC_SENSOR_TMP",
+    "ALTITUDE",
+    "FFT",
+    "FFT_TIME",
+    "FFT_FREQ"
+};

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -70,3 +70,5 @@ typedef enum {
     DEBUG_FFT_FREQ,
     DEBUG_COUNT
 } debugType_e;
+
+extern const char * const debugModeNames[DEBUG_COUNT];

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -41,6 +41,7 @@
 #include "cms/cms_menu_builtin.h"
 #include "cms/cms_types.h"
 
+#include "common/maths.h"
 #include "common/typeconversion.h"
 
 #include "drivers/system.h"
@@ -260,7 +261,8 @@ static void cmsPadToSize(char *buf, int size)
 
 static int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row)
 {
-    char buff[10];
+    #define CMS_DRAW_BUFFER_LEN 10
+    char buff[CMS_DRAW_BUFFER_LEN];
     int cnt = 0;
 
     switch (p->type) {
@@ -306,8 +308,10 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row)
     case OME_TAB:
         if (IS_PRINTVALUE(p)) {
             OSD_TAB_t *ptr = p->data;
-            //cnt = displayWrite(pDisplay, RIGHT_MENU_COLUMN(pDisplay) - 5, row, (char *)ptr->names[*ptr->val]);
-            cnt = displayWrite(pDisplay, RIGHT_MENU_COLUMN(pDisplay), row, (char *)ptr->names[*ptr->val]);
+            char * str = (char *)ptr->names[*ptr->val];
+            memcpy(buff, str, MAX(CMS_DRAW_BUFFER_LEN, strlen(str)));
+            cmsPadToSize(buff, CMS_DRAW_BUFFER_LEN);
+            cnt = displayWrite(pDisplay, RIGHT_MENU_COLUMN(pDisplay), row, buff);
             CLR_PRINTVALUE(p);
         }
         break;

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -24,6 +24,7 @@
 
 #ifdef CMS
 
+#include "build/debug.h"
 #include "build/version.h"
 
 #include "drivers/time.h"
@@ -38,6 +39,7 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
+#include "fc/config.h"
 #include "fc/rc_controls.h"
 
 #include "flight/mixer.h"
@@ -92,6 +94,7 @@ static uint16_t motorConfig_minthrottle;
 static uint8_t motorConfig_digitalIdleOffsetValue;
 static uint8_t voltageSensorADCConfig_vbatscale;
 static uint8_t batteryConfig_vbatmaxcellvoltage;
+static debugType_e systemConfig_debug_mode;
 
 static long cmsx_menuMiscOnEnter(void)
 {
@@ -99,6 +102,8 @@ static long cmsx_menuMiscOnEnter(void)
     motorConfig_digitalIdleOffsetValue = motorConfig()->digitalIdleOffsetValue / 10;
     voltageSensorADCConfig_vbatscale = voltageSensorADCConfig(VOLTAGE_SENSOR_ADC_VBAT)->vbatscale;
     batteryConfig_vbatmaxcellvoltage = batteryConfig()->vbatmaxcellvoltage;
+    systemConfig_debug_mode = systemConfig()->debug_mode;
+
     return 0;
 }
 
@@ -110,6 +115,8 @@ static long cmsx_menuMiscOnExit(const OSD_Entry *self)
     motorConfigMutable()->digitalIdleOffsetValue = 10 * motorConfig_digitalIdleOffsetValue;
     voltageSensorADCConfigMutable(VOLTAGE_SENSOR_ADC_VBAT)->vbatscale = voltageSensorADCConfig_vbatscale;
     batteryConfigMutable()->vbatmaxcellvoltage = batteryConfig_vbatmaxcellvoltage;
+    systemConfigMutable()->debug_mode = systemConfig_debug_mode;
+
     return 0;
 }
 
@@ -121,6 +128,7 @@ static OSD_Entry menuMiscEntries[]=
     { "DIGITAL IDLE", OME_UINT8,   NULL,          &(OSD_UINT8_t) { &motorConfig_digitalIdleOffsetValue,      0,  200, 1 },      0 },
     { "VBAT SCALE",   OME_UINT8,   NULL,          &(OSD_UINT8_t) { &voltageSensorADCConfig_vbatscale,        1,  250, 1 },      0 },
     { "VBAT CLMAX",   OME_UINT8,   NULL,          &(OSD_UINT8_t) { &batteryConfig_vbatmaxcellvoltage,       10,   50, 1 },      0 },
+    { "DEBUG MODE",   OME_TAB,     NULL,          &(OSD_TAB_t) { &systemConfig_debug_mode, DEBUG_COUNT - 1, debugModeNames },      0 },
     { "RC PREV",      OME_Submenu, cmsMenuChange, &cmsx_menuRcPreview, 0},
 
     { "BACK", OME_Back, NULL, NULL, 0},

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -195,31 +195,6 @@ static const char * const lookupTableGyroLpf[] = {
     "EXPERIMENTAL"
 };
 
-static const char * const lookupTableDebug[DEBUG_COUNT] = {
-    "NONE",
-    "CYCLETIME",
-    "BATTERY",
-    "GYRO",
-    "ACCELEROMETER",
-    "MIXER",
-    "AIRMODE",
-    "PIDLOOP",
-    "NOTCH",
-    "RC_INTERPOLATION",
-    "VELOCITY",
-    "DFILTER",
-    "ANGLERATE",
-    "ESC_SENSOR",
-    "SCHEDULER",
-    "STACK",
-    "ESC_SENSOR_RPM",
-    "ESC_SENSOR_TMP",
-    "ALTITUDE",
-    "FFT",
-    "FFT_TIME",
-    "FFT_FREQ"
-};
-
 #ifdef OSD
 static const char * const lookupTableOsdType[] = {
     "AUTO",
@@ -286,7 +261,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef MAG
     { lookupTableMagHardware, sizeof(lookupTableMagHardware) / sizeof(char *) },
 #endif
-    { lookupTableDebug, sizeof(lookupTableDebug) / sizeof(char *) },
+    { debugModeNames, sizeof(debugModeNames) / sizeof(char *) },
     { lookupTableSuperExpoYaw, sizeof(lookupTableSuperExpoYaw) / sizeof(char *) },
     { lookupTablePwmProtocol, sizeof(lookupTablePwmProtocol) / sizeof(char *) },
     { lookupTableRcInterpolation, sizeof(lookupTableRcInterpolation) / sizeof(char *) },


### PR DESCRIPTION
Adds an option in the "MISC" menu for changing debug mode. Save and reboot must be used for the change to take affect.

Fixes #3524