### PR TITLE
Add warning for SKIP_TARGETS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1342,6 +1342,7 @@ targets-group-rest: $(GROUP_OTHER_TARGETS)
 
 
 $(VALID_TARGETS):
+		$(V0) @echo "The following targets, listed in 'SKIP_TARGETS', will not be built:\r\n\t$(SKIP_TARGETS)"
 		$(V0) @echo "" && \
 		echo "Building $@" && \
 		time $(MAKE) binary hex TARGET=$@ && \


### PR DESCRIPTION
@mikeller asked if I would add "a warning message if targets are not built because of `SKIP_TARGETS`" to avoid confusion and frustration." I've put it at the beginning of the VALID_TARGETS target.

- Charlie Stevenson