### PR TITLE
Remove hardcoded unconditional measurement of target build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ targets-group-rest: $(GROUP_OTHER_TARGETS)
 
 $(VALID_TARGETS):
 	$(V0) @echo "Building $@" && \
-	time $(MAKE) binary hex TARGET=$@ && \
+	$(MAKE) binary hex TARGET=$@ && \
 	echo "Building $@ succeeded."
 
 $(SKIP_TARGETS):


### PR DESCRIPTION
Are there anyone actually using the build time per target measurement stats from the Makefile? It is executed and printed regardless of verbosity level. If no-one is using it , I suggest it could be removed as it looks only noisy and takes up space in the build logs. If anyone likes to measure build time, it is easy to do manually with a `time make <TARGET>` command. 
Alternative is to only do build time measurement on high verbosity level (1), but still; Why do that if no-one is using it. Simplicity.

