### PR TITLE
F4 Dshot with N channels on advanced timers (TIM1 & TIM8) don't work

### DIFF
--- a/src/main/target/KIWIF4/target.c
+++ b/src/main/target/KIWIF4/target.c
@@ -25,13 +25,16 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR, 1, 1),
-    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR, 1, 0),
-    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR, 1, 0),
-    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 1, 0),
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR, 0, 1),                     // (1,6)
+    DEF_TIM(TIM1,  CH2N,PB0,  TIM_USE_MOTOR, TIMER_OUTPUT_INVERTED, 1), // (2,2)
+    DEF_TIM(TIM1,  CH3N,PB1,  TIM_USE_MOTOR, TIMER_OUTPUT_INVERTED, 0), // (2,6)
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 0, 0),                     // (1,1)
 #if defined(PLUMF4) || defined(KIWIF4V2)
-    DEF_TIM(TIM2,  CH1, PA0,  TIM_USE_LED,   1, 0),  //LED
+    DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_LED,   0, 0), // LED              // (1,2)
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_NONE,  0, 0), // VTX.CLK
+    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_NONE,  0, 0), // VTX.DTA
 #else
-    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_LED,   0, 0),  // LED
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_NONE,  0, 0), // VTX.CLK
+    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_LED,   0, 0), // LED (VTX.CLK)    // (1,3)
 #endif
 };

--- a/src/main/target/KIWIF4/target.h
+++ b/src/main/target/KIWIF4/target.h
@@ -185,9 +185,13 @@
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         (BIT(2))
 
-#define USABLE_TIMER_CHANNEL_COUNT 12
+#if defined(PLUMF4) || defined(KIWIF4V2)
+#define USABLE_TIMER_CHANNEL_COUNT 7
+#else
+#define USABLE_TIMER_CHANNEL_COUNT 6
+#endif
 
-#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(9) )
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(4) | TIM_N(5) )
 
 #define CMS
 #define USE_MSP_DISPLAYPORT

--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -39,10 +39,19 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S5_IN
     DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,                 TIMER_OUTPUT_NONE,     0), // S6_IN
 
+#if 1
+    // Problematic config
+    DEF_TIM(TIM1,  CH2N,PB0,  TIM_USE_MOTOR, TIMER_OUTPUT_INVERTED, 1), // (2,2)
+    DEF_TIM(TIM1,  CH3N,PB1,  TIM_USE_MOTOR, TIMER_OUTPUT_INVERTED, 0), // (2,6)
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR, 0, 1),                     // (1,6)
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 0, 0),                     // (1,1)
+#else
+    // Working config
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S1_OUT D1_ST7
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S2_OUT D1_ST2
     DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 1), // S3_OUT D1_ST6
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S4_OUT D1_ST1
+#endif
 
 #if defined(OMNIBUSF4SD)
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               TIMER_OUTPUT_STANDARD, 0), // S5_OUT


### PR DESCRIPTION
PR status: Need investigation

As a solution to #3493, I came up with #3514 which introduced an erratic behavior on particular timer channels with dshot. While #3514 was for KIWIF4, the same behavior was reproduced with OMNIBUSF4 family (which happened to have the same set of pins for motors) with modified timer allocation for motors.

The timer channels under question is TIM1_CH2N on PB0 and TIM1_CH3N on PB1.

The behavior I have observed with OMNIBUSF4 is as follow.

1. These channels work flawlessly with non-Dshot protocols.
2. With Dshot, PB0 works, but PB1 keeps initializing (not resetting) when throttle is applied.
3. With Dshot, applying throttle to PB0 also makes PB1 to keep initializing (!!!)
