### PR TITLE
DYSF4PRO Use PC3 for RSSI ADC input

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -199,7 +199,11 @@
 #define USE_ADC
 #define CURRENT_METER_ADC_PIN   PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
 #define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
+#ifdef DYSF4PRO
+#define RSSI_ADC_PIN            PC3  // Direct from RSSI pad
+#else
 #define RSSI_ADC_PIN            PA0  // Direct from RSSI pad
+#endif
 
 #define TRANSPONDER
 


### PR DESCRIPTION
PR status: Ready to merge

The RSSI pad has direct connection to PC3.