### PR TITLE
Enable Camera Control

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3032,7 +3032,7 @@ const cliResourceValue_t resourceTable[] = {
 #ifdef USE_ESCSERIAL
     { OWNER_ESCSERIAL,     PG_ESCSERIAL_CONFIG, offsetof(escSerialConfig_t, ioTag), 0 },
 #endif
-#ifdef CAMERA_CONTROL
+#ifdef USE_CAMERA_CONTROL
     { OWNER_CAMERA_CONTROL, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, ioTag), 0 },
 #endif
 };

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -470,7 +470,7 @@ void init(void)
     rtc6705IOInit();
 #endif
 
-#ifdef CAMERA_CONTROL
+#ifdef USE_CAMERA_CONTROL
     cameraControlInit();
 #endif
 


### PR DESCRIPTION
Seems like I have missed some occurrences of `#ifdef CAMERA_CONTROL` while renaming to `USE_CAMERA_CONTROL`.