### PR TITLE
Define firmwareName and use it where possible

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1200,7 +1200,7 @@ static bool blackboxWriteSysinfo(void)
     const controlRateConfig_t *currentControlRateProfile = controlRateProfiles(systemConfig()->activeRateProfile);
     switch (xmitState.headerIndex) {
         BLACKBOX_PRINT_HEADER_LINE("Firmware type", "%s",                   "Cleanflight");
-        BLACKBOX_PRINT_HEADER_LINE("Firmware revision", "%s %s (%s) %s",    FC_FIRMWARE_NAME, FC_VERSION_STRING, shortGitRevision, targetName);
+        BLACKBOX_PRINT_HEADER_LINE("Firmware revision", "%s %s (%s) %s",    firmwareName, FC_VERSION_STRING, shortGitRevision, targetName);
         BLACKBOX_PRINT_HEADER_LINE("Firmware date", "%s %s",                buildDate, buildTime);
         BLACKBOX_PRINT_HEADER_LINE("Craft name", "%s",                      systemConfig()->name);
         BLACKBOX_PRINT_HEADER_LINE("P interval", "%d/%d",                   blackboxConfig()->rate_num, blackboxConfig()->rate_denom);

--- a/src/main/build/version.c
+++ b/src/main/build/version.c
@@ -17,6 +17,7 @@
 
 #include "version.h"
 
+const char * const firmwareName = FC_FIRMWARE_NAME;
 const char * const targetName = __TARGET__;
 const char * const shortGitRevision = __REVISION__;
 const char * const buildDate = __DATE__;

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -26,6 +26,7 @@
 
 #define MW_VERSION              231
 
+extern const char* const firmwareName;
 extern const char* const targetName;
 
 #define GIT_SHORT_REVISION_LENGTH   7 // lower case hexadecimal digits.

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2968,7 +2968,7 @@ static void cliVersion(char *cmdline)
     UNUSED(cmdline);
 
     cliPrintLinef("# %s / %s %s %s / %s (%s)",
-        FC_FIRMWARE_NAME,
+        firmwareName,
         targetName,
         FC_VERSION_STRING,
         buildDate,

--- a/src/main/vcp_hal/usbd_desc.c
+++ b/src/main/vcp_hal/usbd_desc.c
@@ -57,7 +57,7 @@
 #define USBD_VID                      0x0483
 #define USBD_PID                      0x5740
 #define USBD_LANGID_STRING            0x409
-#define USBD_MANUFACTURER_STRING      FC_FIRMWARE_NAME
+#define USBD_MANUFACTURER_STRING      firmwareName
 #define USBD_PRODUCT_HS_STRING        "STM32 Virtual ComPort in HS Mode"
 #define USBD_PRODUCT_FS_STRING        "STM32 Virtual ComPort in FS Mode"
 #define USBD_CONFIGURATION_HS_STRING  "VCP Config"

--- a/src/main/vcpf4/usbd_desc.c
+++ b/src/main/vcpf4/usbd_desc.c
@@ -58,7 +58,7 @@
   * @{
   */
 #define USBD_LANGID_STRING              0x409
-#define USBD_MANUFACTURER_STRING        FC_FIRMWARE_NAME
+#define USBD_MANUFACTURER_STRING        firmwareName
 
 #ifdef USBD_PRODUCT_STRING
   #define USBD_PRODUCT_HS_STRING          USBD_PRODUCT_STRING


### PR DESCRIPTION
PR status: Need review

#3568 reminded me that I was doing this.

The string literal FC_FIRMWARE_NAME (defined as "Betaflight") is used three times in the standard configuration, which is 20 bytes of waste. This PR defines a string `firmwareName` and tries to use this where possible:
```
const char * const firmwareName = FC_FIRMWARE_NAME;
```

The mods are straight forward, but I want to hear thoughts about replacements in USB descriptor code; i.e.,
```
#define USBD_MANUFACTURER_STRING        FC_FIRMWARE_NAME
```
to
```
#define USBD_MANUFACTURER_STRING        firmwareName
```