### PR TITLE
Run sensor detection to the end regardless of the gyro detection stataus

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -56,12 +56,14 @@ static bool sonarDetect(void)
 
 bool sensorsAutodetect(void)
 {
-    // gyro must be initialised before accelerometer
-    if (!gyroInit()) {
-        return false;
-    }
 
-    accInit(gyro.targetLooptime);
+    // gyro must be initialised before accelerometer
+
+    bool gyroDetected = gyroInit();
+
+    if (gyroDetected) {
+        accInit(gyro.targetLooptime);
+    }
 
 #ifdef MAG
     compassInit();
@@ -77,5 +79,5 @@ bool sensorsAutodetect(void)
     }
 #endif
 
-    return true;
+    return gyroDetected;
 }


### PR DESCRIPTION
PR status: Ready to merge

It may prevent users of faulty gyro from falsely reporting "baro and mag are not detected either".

Is it harmful for drivers that handle mag inside the gyro chip?