### PR TITLE
REVONANO Use I2C1 instead of I2C3

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -56,12 +56,14 @@ static bool sonarDetect(void)
 
 bool sensorsAutodetect(void)
 {
-    // gyro must be initialised before accelerometer
-    if (!gyroInit()) {
-        return false;
-    }
 
-    accInit(gyro.targetLooptime);
+    // gyro must be initialised before accelerometer
+
+    bool gyroDetected = gyroInit();
+
+    if (gyroDetected) {
+        accInit(gyro.targetLooptime);
+    }
 
 #ifdef MAG
     compassInit();
@@ -77,5 +79,5 @@ bool sensorsAutodetect(void)
     }
 #endif
 
-    return true;
+    return gyroDetected;
 }

--- a/src/main/target/REVONANO/target.h
+++ b/src/main/target/REVONANO/target.h
@@ -28,8 +28,6 @@
 
 #define BEEPER                  PC13
 
-#define INVERTER_PIN_UART2      PC15 //Sbus on USART 2 of nano.
-
 #define MPU6500_CS_PIN          PB12
 #define MPU6500_SPI_INSTANCE    SPI2
 
@@ -54,13 +52,14 @@
 #define USE_VCP
 //#define VBUS_SENSING_PIN        PA9
 
-#define USE_UART1
+#define USE_UART1 // Flexi Port
 #define UART1_RX_PIN            PB7
 #define UART1_TX_PIN            PB6
 
-#define USE_UART2
+#define USE_UART2 // Main Port
 #define UART2_RX_PIN            PA3
 #define UART2_TX_PIN            PA2
+#define INVERTER_PIN_UART2      PC15 //Sbus on USART 2 of nano.
 
 #define USE_SOFTSERIAL1
 #define USE_SOFTSERIAL2
@@ -74,8 +73,8 @@
 #define USE_SPI_DEVICE_2
 
 #define USE_I2C
-#define USE_I2C_DEVICE_3
-#define I2C_DEVICE (I2CDEV_3)
+#define USE_I2C_DEVICE_1        // UART1/FlexiPort (PB6,PB7)
+#define I2C_DEVICE (I2CDEV_1)
 
 #undef LED_STRIP
 
@@ -86,7 +85,7 @@
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
-#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTC         (BIT(13) | BIT(14) | BIT(15))
 
 #define USABLE_TIMER_CHANNEL_COUNT 12
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) )


### PR DESCRIPTION
PR status: Ready to merge

- REVONANO was configured with I2C3 that uses PC9 which is non-exisitent in F411CE.
- FlexiPort is PB6,PB7, so it should be I2C1 (shared with UART1).
- Strict TARGET_IO_PORT_x for F411CE.

Despite this mod, I can't make the onboard MS5611 to respond. Scope is okay. Tried both 0x76 and 0x77.
But this doesn't prevent the PR from merging 😬 

![saleae_logic_software](https://user-images.githubusercontent.com/14850998/28423032-d80f77fa-6da4-11e7-809d-2a7ef7492769.jpg)
