### PR TITLE
CMS Remove left stick constraints

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -130,7 +130,7 @@ static displayPort_t *cmsDisplayPortSelectNext(void)
 #define RIGHT_MENU_COLUMN(p) ((p)->cols - 8)
 #define MAX_MENU_ITEMS(p)    ((p)->rows - 2)
 
-static bool cmsInMenu = false;
+bool cmsInMenu = false;
 
 typedef struct cmsCtx_s {
     const CMS_Menu *menu;         // menu for this context
@@ -913,19 +913,19 @@ void cmsUpdate(uint32_t currentTimeUs)
         if (IS_MID(THROTTLE) && IS_LO(YAW) && IS_HI(PITCH) && !ARMING_FLAG(ARMED)) {
             key = KEY_MENU;
         }
-        else if (IS_MID(THROTTLE) && IS_MID(YAW) && IS_MID(ROLL) && IS_HI(PITCH)) {
+        else if (IS_HI(PITCH)) {
             key = KEY_UP;
         }
-        else if (IS_MID(THROTTLE) && IS_MID(YAW) && IS_MID(ROLL) && IS_LO(PITCH)) {
+        else if (IS_LO(PITCH)) {
             key = KEY_DOWN;
         }
-        else if (IS_MID(THROTTLE) && IS_MID(YAW) && IS_LO(ROLL) && IS_MID(PITCH)) {
+        else if (IS_LO(ROLL)) {
             key = KEY_LEFT;
         }
-        else if (IS_MID(THROTTLE) && IS_MID(YAW) && IS_HI(ROLL) && IS_MID(PITCH)) {
+        else if (IS_HI(ROLL)) {
             key = KEY_RIGHT;
         }
-        else if ((IS_HI(YAW) || IS_LO(YAW)) && IS_MID(THROTTLE) && IS_MID(ROLL) && IS_MID(PITCH))
+        else if (IS_HI(YAW) || IS_LO(YAW))
         {
             key = KEY_ESC;
         }

--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -4,6 +4,8 @@
 
 #include "common/time.h"
 
+extern bool cmsInMenu;
+
 // Device management
 bool cmsDisplayPortRegister(displayPort_t *pDisplay);
 

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -34,6 +34,8 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
+#include "cms/cms.h"
+
 #include "drivers/camera_control.h"
 
 #include "fc/config.h"
@@ -123,6 +125,12 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
     static uint8_t rcDisarmTicks;       // this is an extra guard for disarming through switch to prevent that one frame can disarm it
     uint8_t stTmp = 0;
     int i;
+
+#ifdef CMS
+    if (cmsInMenu) {
+        return;
+    }
+#endif
 
     // ------------------ STICKS COMMAND HANDLER --------------------
     // checking sticks positions

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -695,6 +695,7 @@ void baroSetCalibrationCycles(uint16_t) {}
 
 void blackboxLogEvent(FlightLogEvent, flightLogEventData_t *) {}
 
+bool cmsInMenu = false;
 uint8_t armingFlags = 0;
 int16_t heading;
 uint8_t stateFlags = 0;


### PR DESCRIPTION
PR status: Need review

Reverts constraints on left stick position while in CMS, introduced by #2833.
This constraints were intended to avoid stick movements in CMS from being interpreted as standard stick commands, but seems like users don't like this at all.

This PR will
- Remove constraints on left stick positions.
- Expose `cmsInMenu` state variable
- Reference the `cmsInMenu` at the top of `processRcStickPositions` to return if in CMS menu.
