### PR TITLE
Update pid.c (A try to add delay to crash detection)

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -549,6 +549,7 @@ const clivalue_t valueTable[] = {
     { "crash_dthreshold",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_dthreshold) },
     { "crash_gthreshold",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_gthreshold) },
     { "crash_time",                 VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 5000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_time) },
+    { "crash_delay",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_delay) },
     { "crash_recovery_angle",       VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery_angle) },
     { "crash_recovery_rate",        VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery_rate) },
     { "crash_recovery",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRASH_RECOVERY }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery) },

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -264,7 +264,7 @@ void pidInitConfig(const pidProfile_t *pidProfile) {
     ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
     ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
     crashTimeLimitUs = pidProfile->crash_time * 1000;
-    crashTimeLimitMaybeUs = pidProfile->crash_delay;
+    crashTimeLimitMaybeUs = pidProfile->crash_delay * 1000;
     crashRecoveryAngleDeciDegrees = pidProfile->crash_recovery_angle * 10;
     crashRecoveryRate = pidProfile->crash_recovery_rate;
     crashGyroThreshold = pidProfile->crash_gthreshold;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -462,8 +462,8 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                         BEEP_ON;
                     }}
                     // inCrashRecoveryMode = true only if the error is longer than crashTimeLimitMaybeUs
-                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold) 
-                    && (cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs)) {
+                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold 
+                    && cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     inCrashRecoveryMaybe = false;
@@ -471,12 +471,12 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                         BEEP_ON;
                     }}
                     // start to measure time if error is greater than crashGyroThreshold
-                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold) && inCrashRecoveryMaybe = false {
+                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold && inCrashRecoveryMaybe = false) {
                     inCrashRecoveryMaybe = true;
                     crashDetectedMaybeAtUs = currentTimeUs;
                     }
                     // reset inCrashRecoveryMaybe if error become smaller than crashGyroThreshold
-                if (motorMixRange >= 1.0f && ABS(errorRate) < crashGyroThreshold) && inCrashRecoveryMaybe = true {
+                if (motorMixRange >= 1.0f && ABS(errorRate) < crashGyroThreshold && inCrashRecoveryMaybe = true) {
                     inCrashRecoveryMaybe = false;
                     }
             }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -264,7 +264,7 @@ void pidInitConfig(const pidProfile_t *pidProfile) {
     ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
     ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
     crashTimeLimitUs = pidProfile->crash_time * 1000;
-    crashTimeLimitMaybeUs = crash_delay;
+    crashTimeLimitMaybeUs = pidProfile->crash_delay;
     crashRecoveryAngleDeciDegrees = pidProfile->crash_recovery_angle * 10;
     crashRecoveryRate = pidProfile->crash_recovery_rate;
     crashGyroThreshold = pidProfile->crash_gthreshold;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -471,12 +471,12 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                         BEEP_ON;
                     }}
                     // start to measure time if error is greater than crashGyroThreshold
-                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold && inCrashRecoveryMaybe = false) {
+                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold && inCrashRecoveryMaybe == false) {
                     inCrashRecoveryMaybe = true;
                     crashDetectedMaybeAtUs = currentTimeUs;
                     }
                     // reset inCrashRecoveryMaybe if error become smaller than crashGyroThreshold
-                if (motorMixRange >= 1.0f && ABS(errorRate) < crashGyroThreshold && inCrashRecoveryMaybe = true) {
+                if (motorMixRange >= 1.0f && ABS(errorRate) < crashGyroThreshold && inCrashRecoveryMaybe == true) {
                     inCrashRecoveryMaybe = false;
                     }
             }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -456,15 +456,9 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 
             // if crash recovery is on and accelerometer enabled then check for a crash
             if (pidProfile->crash_recovery && sensors(SENSOR_ACC) && inCrashRecoveryMode == false) {
-                    // Here this is only the test for crashDtermThreshold i dont really know how this part work ;)
-                if (motorMixRange >= 1.0f && ABS(delta) > crashDtermThreshold) {
-                    inCrashRecoveryMode = true;
-                    crashDetectedAtUs = currentTimeUs;
-                    inCrashRecoveryMaybe = false;
-                    }
                     // inCrashRecoveryMode = true only if the error is longer than crashTimeLimitMaybeUs
-                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold 
-                    && cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs) {
+                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold  && inCrashRecoveryMaybe == true
+                    && ABS(delta) > crashDtermThreshold && cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     inCrashRecoveryMaybe = false;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -463,7 +463,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                     }}
                     // inCrashRecoveryMode = true only if the error is longer than crashTimeLimitMaybeUs
                 if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold) 
-                    && (cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs) {
+                    && (cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs)) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     inCrashRecoveryMaybe = false;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -398,6 +398,9 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 
         if (inCrashRecoveryMode && axis != FD_YAW) {
             // self-level - errorAngle is deviation from horizontal
+            if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {
+                        BEEP_ON;
+                    }
             const float errorAngle =  -(attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f;
             currentPidSetpoint = errorAngle * levelGain;
             if (cmpTimeUs(currentTimeUs, crashDetectedAtUs) > crashTimeLimitUs
@@ -458,18 +461,14 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     inCrashRecoveryMaybe = false;
-                    if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {
-                        BEEP_ON;
-                    }}
+                    }
                     // inCrashRecoveryMode = true only if the error is longer than crashTimeLimitMaybeUs
                 if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold 
                     && cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     inCrashRecoveryMaybe = false;
-                    if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {
-                        BEEP_ON;
-                    }}
+                    }
                     // start to measure time if error is greater than crashGyroThreshold
                 if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold && inCrashRecoveryMaybe == false) {
                     inCrashRecoveryMaybe = true;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -105,6 +105,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .rateAccelLimit = 0,
         .itermThrottleThreshold = 350,
         .itermAcceleratorGain = 1000,
+        .crash_delay = 70,          // 70ms
         .crash_time = 500,          // 500ms
         .crash_recovery_angle = 10, //  10 degrees
         .crash_recovery_rate = 100, // 100 degrees/second
@@ -237,10 +238,12 @@ static float levelGain, horizonGain, horizonTransition, horizonCutoffDegrees,
              horizonFactorRatio, ITermWindupPoint, ITermWindupPointInv;
 static uint8_t horizonTiltExpertMode;
 static timeDelta_t crashTimeLimitUs;
+static timeDelta_t crashTimeLimitMaybeUs;
 static int32_t crashRecoveryAngleDeciDegrees;
 static float crashRecoveryRate;
 static float crashDtermThreshold;
 static float crashGyroThreshold;
+static float inCrashRecoveryMaybe;
 
 void pidInitConfig(const pidProfile_t *pidProfile) {
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
@@ -261,6 +264,7 @@ void pidInitConfig(const pidProfile_t *pidProfile) {
     ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
     ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
     crashTimeLimitUs = pidProfile->crash_time * 1000;
+    crashTimeLimitMaybeUs = crash_delay;
     crashRecoveryAngleDeciDegrees = pidProfile->crash_recovery_angle * 10;
     crashRecoveryRate = pidProfile->crash_recovery_rate;
     crashGyroThreshold = pidProfile->crash_gthreshold;
@@ -375,6 +379,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     const float motorMixRange = getMotorMixRange();
     static bool inCrashRecoveryMode = false;
     static timeUs_t crashDetectedAtUs;
+    static timeUs_t crashDetectedMaybeAtUs;
 
     // Dynamic ki component to gradually scale back integration when above windup point
     const float dynKi = MIN((1.0f - motorMixRange) * ITermWindupPointInv, 1.0f);
@@ -448,13 +453,32 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 
             // if crash recovery is on and accelerometer enabled then check for a crash
             if (pidProfile->crash_recovery && sensors(SENSOR_ACC)) {
-                if (motorMixRange >= 1.0f && ABS(delta) > crashDtermThreshold && ABS(errorRate) > crashGyroThreshold) {
+                    // Here this is only the test for crashDtermThreshold i dont really know how this part work ;)
+                if (motorMixRange >= 1.0f && ABS(delta) > crashDtermThreshold) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
+                    inCrashRecoveryMaybe = false;
                     if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {
                         BEEP_ON;
+                    }}
+                    // inCrashRecoveryMode = true only if the error is longer than crashTimeLimitMaybeUs
+                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold) 
+                    && (cmpTimeUs(currentTimeUs, crashDetectedMaybeAtUs) > crashTimeLimitMaybeUs) {
+                    inCrashRecoveryMode = true;
+                    crashDetectedAtUs = currentTimeUs;
+                    inCrashRecoveryMaybe = false;
+                    if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {
+                        BEEP_ON;
+                    }}
+                    // start to measure time if error is greater than crashGyroThreshold
+                if (motorMixRange >= 1.0f && ABS(errorRate) > crashGyroThreshold) && inCrashRecoveryMaybe = false {
+                    inCrashRecoveryMaybe = true;
+                    crashDetectedMaybeAtUs = currentTimeUs;
                     }
-                }
+                    // reset inCrashRecoveryMaybe if error become smaller than crashGyroThreshold
+                if (motorMixRange >= 1.0f && ABS(errorRate) < crashGyroThreshold) && inCrashRecoveryMaybe = true {
+                    inCrashRecoveryMaybe = false;
+                    }
             }
 
             axisPID_D[axis] = Kd[axis] * delta * tpaFactor;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -452,7 +452,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             previousRateError[axis] = rD;
 
             // if crash recovery is on and accelerometer enabled then check for a crash
-            if (pidProfile->crash_recovery && sensors(SENSOR_ACC)) {
+            if (pidProfile->crash_recovery && sensors(SENSOR_ACC) && inCrashRecoveryMode == false) {
                     // Here this is only the test for crashDtermThreshold i dont really know how this part work ;)
                 if (motorMixRange >= 1.0f && ABS(delta) > crashDtermThreshold) {
                     inCrashRecoveryMode = true;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -101,6 +101,7 @@ typedef struct pidProfile_s {
     uint16_t crash_dthreshold;              // dterm crash value
     uint16_t crash_gthreshold;              // gyro crash value
     uint16_t crash_time;                    // ms
+    uint16_t crash_delay;                   // ms
     uint8_t crash_recovery_angle;           // degrees
     uint8_t crash_recovery_rate;            // degree/second
     pidCrashRecovery_e crash_recovery;      // off, on, on and beeps when it is in crash recovery mode


### PR DESCRIPTION
A try to add a delay to the crash recovery feature.
The idea is to set a crash_delay.
Then instead of going directly in crash recovery mode when the pid error is greater than crash_gthreshold we start to measure time from this instant. If after crash_delay(ms) the error is still bigger than crash_gthreshold we can go in crash recovery feature.
During the delay, if the error become smaller than crash_gthreshold  then the feature will not be activated.

The idea is to be able to have a crash_gthreshold more accurate.
Without this modification we had to use a higher crash_gthreshold to avoid false crash detection.
With this modification you can set the value according to your flight style.

If the pid errors are long because you are a freestyler then the crash_delay will have to be higher.
If the pid errors are short because your P are high to race then the crash_delay will be short too.
(i mean pid errors related to the physic of your quadcopter, not the pid errors related to crash ;) )