### PR TITLE
Update pid.c CrashRecovery

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -450,7 +450,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             previousRateError[axis] = rD;
 
             // if crash recovery is on and accelerometer enabled then check for a crash
-            if (pidProfile->crash_recovery && sensors(SENSOR_ACC)) {
+            if (pidProfile->crash_recovery && sensors(SENSOR_ACC) && inCrashRecoveryMode ==false) {
                 if (motorMixRange >= 1.0f
                         && ABS(delta) > crashDtermThreshold
                         && ABS(errorRate) > crashGyroThreshold

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -450,7 +450,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             previousRateError[axis] = rD;
 
             // if crash recovery is on and accelerometer enabled then check for a crash
-            if (pidProfile->crash_recovery && sensors(SENSOR_ACC) && inCrashRecoveryMode == false) {
+            if (pidProfile->crash_recovery && inCrashRecoveryMode == false && sensors(SENSOR_ACC) && ARMING_FLAG(ARMED)) {
                 if (motorMixRange >= 1.0f
                         && ABS(delta) > crashDtermThreshold
                         && ABS(errorRate) > crashGyroThreshold

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -450,7 +450,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             previousRateError[axis] = rD;
 
             // if crash recovery is on and accelerometer enabled then check for a crash
-            if (pidProfile->crash_recovery && sensors(SENSOR_ACC) && inCrashRecoveryMode ==false) {
+            if (pidProfile->crash_recovery && sensors(SENSOR_ACC) && inCrashRecoveryMode == false) {
                 if (motorMixRange >= 1.0f
                         && ABS(delta) > crashDtermThreshold
                         && ABS(errorRate) > crashGyroThreshold


### PR DESCRIPTION
To solve the problem where the quad is stuck in crashrecoverymode because he is stuck on the floor :)

As we were still detecting crash even in crashrecoverymode, when the quad is locked on something (in fact not only upside down, but anywere outside the crash_recovery_angle) the error become bigger and then the crash detection is repeated again and again, updating crashDetectedAtUs and so that make an infinite loop. 