### PR TITLE
Fixed wrong cell count when voltage reading is not stable at startup

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -133,7 +133,7 @@ void taskBatteryAlerts(timeUs_t currentTimeUs)
 {
     if (!ARMING_FLAG(ARMED)) {
         // the battery *might* fall out in flight, but if that happens the FC will likely be off too unless the user has battery backup.
-        batteryUpdatePresence();
+        batteryUpdatePresence(currentTimeUs);
     }
     batteryUpdateStates(currentTimeUs);
     batteryUpdateAlarms();

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -160,6 +160,8 @@ static void updateBatteryBeeperAlert(void)
 
 void batteryUpdatePresence(timeUs_t currentTimeUs)
 {
+    UNUSED(currentTimeUs);
+
     bool isVoltageStable = ABS(voltageMeter.filtered - voltageMeter.unfiltered) <= VBAT_STABLE_MAX_DELTA;
 
 #ifdef USE_ESC_SENSOR

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -158,9 +158,14 @@ static void updateBatteryBeeperAlert(void)
     }
 }
 
-void batteryUpdatePresence(void)
+void batteryUpdatePresence(timeUs_t currentTimeUs)
 {
     bool isVoltageStable = ABS(voltageMeter.filtered - voltageMeter.unfiltered) <= VBAT_STABLE_MAX_DELTA;
+
+#ifdef USE_ESC_SENSOR
+    // Delaying cell detection when voltage meter source is ESC Sensor
+    isVoltageStable = isVoltageStable && (batteryConfig()->voltageMeterSource == VOLTAGE_METER_ESC && currentTimeUs > ESC_SENSOR_BOOT_DELAY * 1000);
+#endif
 
     bool isVoltageFromBat = (voltageMeter.filtered >= batteryConfig()->vbatnotpresentcellvoltage  //above ~0V
                             && voltageMeter.filtered <= batteryConfig()->vbatmaxcellvoltage)  //1s max cell voltage check

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -62,9 +62,11 @@ typedef enum {
     BATTERY_NOT_PRESENT
 } batteryState_e;
 
+#define ESC_SENSOR_BOOT_DELAY 6000      // 6 seconds
+
 void batteryInit(void);
 void batteryUpdateVoltage(timeUs_t currentTimeUs);
-void batteryUpdatePresence(void);
+void batteryUpdatePresence(timeUs_t currentTimeUs);
 
 batteryState_e getBatteryState(void);
 const  char * getBatteryStateString(void);


### PR DESCRIPTION
I noted that the voltage on the OSD is flashing when using ESC_SENSOR (KISS24A) and that the battery icon is wrong. Turns out that the cell count is calculated too early as the voltage is not stable yet.

See DVR video:
https://gfycat.com/EachSimplisticGypsymoth