### PR TITLE
Fixed missing ESC motor 4 on Amperage meter part

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -441,9 +441,9 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 
     case MSP_CURRENT_METERS: {
         // write out id and current meter values, once for each meter we support
-        uint8_t count = supportedVoltageMeterCount;
+        uint8_t count = supportedCurrentMeterCount;
 #ifndef USE_OSD_SLAVE
-        count = supportedVoltageMeterCount - (VOLTAGE_METER_ID_ESC_COUNT - getMotorCount());
+        count = supportedCurrentMeterCount - (VOLTAGE_METER_ID_ESC_COUNT - getMotorCount());
 #endif
         for (int i = 0; i < count; i++) {
 


### PR DESCRIPTION
Oops, unfortunately created a little bug in the MSP_CURRENT_METERS. 
ESC Motor 4 is missing in the Amperage Meter part. This PR fixes it.

![image](https://user-images.githubusercontent.com/334779/28543609-97ed7c0c-70c0-11e7-9d91-17fed58f9704.png)
