### PR TITLE
Add MSP_BEEPER_CONFIG and MSP_SET_BEEPER_CONFIG for beeper configuration

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -405,6 +405,12 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU32(dst, featureMask());
         break;
 
+#ifdef BEEPER
+    case MSP_BEEPER_CONFIG:
+        sbufWriteU32(dst, getBeeperOffMask());
+        break;
+#endif
+
     case MSP_BATTERY_STATE: {
         // battery characteristics
         sbufWriteU8(dst, (uint8_t)constrain(getBatteryCellCount(), 0, 255)); // 0 indicates battery not detected.
@@ -1652,6 +1658,13 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         featureClearAll();
         featureSet(sbufReadU32(src)); // features bitmap
         break;
+
+#ifdef BEEPER
+    case MSP_SET_BEEPER_CONFIG:
+        beeperOffClearAll();
+        setBeeperOffMask(sbufReadU32(src));
+        break;
+#endif
 
     case MSP_SET_BOARD_ALIGNMENT_CONFIG:
         boardAlignmentMutable()->rollDegrees = sbufReadU16(src);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -214,9 +214,6 @@
 
 #define MSP_CAMERA_CONTROL              98
 
-#define MSP_BEEPER_CONFIG               99
-#define MSP_SET_BEEPER_CONFIG           100
-
 //
 // OSD specific
 //
@@ -225,6 +222,9 @@
 
 // External OSD displayport mode messages
 #define MSP_DISPLAYPORT                 182
+
+#define MSP_BEEPER_CONFIG               184
+#define MSP_SET_BEEPER_CONFIG           185
 
 //
 // Multwii original MSP commands

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -214,6 +214,9 @@
 
 #define MSP_CAMERA_CONTROL              98
 
+#define MSP_BEEPER_CONFIG               99
+#define MSP_SET_BEEPER_CONFIG           100
+
 //
 // OSD specific
 //


### PR DESCRIPTION
Adds the ability to change beeper configuration through MSP commands.

Corresponding Betaflight Configurator PR: https://github.com/betaflight/betaflight-configurator/pull/563