### PR TITLE
Crash recovery - merge parameters

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -548,7 +548,6 @@ const clivalue_t valueTable[] = {
     { "acc_limit",                  VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 1, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, rateAccelLimit) },
     { "crash_dthreshold",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_dthreshold) },
     { "crash_gthreshold",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_gthreshold) },
-    { "crash_setpoint_threshold",   VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_setpoint_threshold) },
     { "crash_time",                 VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 5000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_time) },
     { "crash_recovery_angle",       VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery_angle) },
     { "crash_recovery_rate",        VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery_rate) },

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -266,7 +266,6 @@ void pidInitConfig(const pidProfile_t *pidProfile) {
     crashRecoveryRate = pidProfile->crash_recovery_rate;
     crashGyroThreshold = pidProfile->crash_gthreshold;
     crashDtermThreshold = pidProfile->crash_dthreshold;
-    crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
 }
 
 void pidInit(const pidProfile_t *pidProfile)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -241,7 +241,6 @@ static int32_t crashRecoveryAngleDeciDegrees;
 static float crashRecoveryRate;
 static float crashDtermThreshold;
 static float crashGyroThreshold;
-static float crashSetpointThreshold;
 
 void pidInitConfig(const pidProfile_t *pidProfile) {
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -110,7 +110,6 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .crash_recovery_rate = 100, // degrees/second
         .crash_dthreshold = 50,     // degrees/second/second
         .crash_gthreshold = 400,    // degrees/second
-        .crash_setpoint_threshold = 350, // degrees/second
         .crash_recovery = PID_CRASH_RECOVERY_OFF, // off by default
         .horizon_tilt_effect = 75,
         .horizon_tilt_expert_mode = false
@@ -454,7 +453,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                 if (motorMixRange >= 1.0f
                         && ABS(delta) > crashDtermThreshold
                         && ABS(errorRate) > crashGyroThreshold
-                        && ABS(getSetpointRate(axis)) < crashSetpointThreshold) {
+                        && ABS(getSetpointRate(axis)) < crashGyroThreshold) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -451,7 +451,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                 if (motorMixRange >= 1.0f
                         && ABS(delta) > crashDtermThreshold
                         && ABS(errorRate) > crashGyroThreshold
-                        && ABS(getSetpointRate(axis)) < crashGyroThreshold) {
+                        && ABS(getSetpointRate(axis)) < (crashGyroThreshold - 50)) {
                     inCrashRecoveryMode = true;
                     crashDetectedAtUs = currentTimeUs;
                     if (pidProfile->crash_recovery == PID_CRASH_RECOVERY_BEEP) {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -100,7 +100,6 @@ typedef struct pidProfile_s {
     uint16_t rateAccelLimit;                // accel limiter roll/pitch deg/sec/ms
     uint16_t crash_dthreshold;              // dterm crash value
     uint16_t crash_gthreshold;              // gyro crash value
-    uint16_t crash_setpoint_threshold;      // setpoint must be below this value to detect crash, so flips and rolls are not interpreted as crashes
     uint16_t crash_time;                    // ms
     uint8_t crash_recovery_angle;           // degrees
     uint8_t crash_recovery_rate;            // degree/second


### PR DESCRIPTION
I think that there is no need to add crash_setpoint_threshold as a setting.
User could set it higher than crash_gthreshold and then get false positive like before.
In my opinion if crash_setpoint_threshold=crash_gthreshold the result is the same and this is easier to understand for the user.