### PR TITLE
ALIENFLIGHTNGF7 Avoid TIM1 conflict between PPM(LED) and MOTOR 3

### DIFF
--- a/src/main/target/ALIENFLIGHTNGF7/target.c
+++ b/src/main/target/ALIENFLIGHTNGF7/target.c
@@ -31,8 +31,8 @@
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH1,  PA8,  TIM_USE_PPM | TIM_USE_LED,   TIMER_INPUT_ENABLED,                           1), // PPM   - DMA2_ST6, *DMA2_ST1, DMA2_ST3
     DEF_TIM(TIM8, CH1,  PC6,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM1  - DMA2_ST2, DMA2_ST2
-    DEF_TIM(TIM8, CH2,  PC7,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM2  - DMA2_ST3, DMA2_ST2
-    DEF_TIM(TIM1, CH2N, PB14, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED , 0), // PWM3  - DMA2_ST6, DMA2_ST2
+    DEF_TIM(TIM3, CH2,  PC7,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM2  - DMA1_ST5
+    DEF_TIM(TIM8, CH2N, PB14, TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_INVERTED , 0), // PWM3  - DMA2_ST3, DMA2_ST2
     DEF_TIM(TIM3, CH3,  PB0,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM4  - DMA1_ST7
     DEF_TIM(TIM5, CH1,  PA0,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM5  - DMA1_ST2
     DEF_TIM(TIM8, CH3,  PC8,  TIM_USE_MOTOR,               TIMER_OUTPUT_ENABLED,                          0), // PWM6  - (DMA2_ST4) DMA2_ST2


### PR DESCRIPTION
PR status: Need review

TIM1 conflict prevented PPM/LED and motor 3 from working with PPM/LED enabled.

This PR proposes the following change:

MOTOR 3 (PB14) : TIM1_CH2N -> TIM8_CH2N
MOTOR 2 (PC7) : TIM8_CH2N -> TIM3_CH2 D(1,5,5) = DMA safe

TIM3 is also used by MOTOR 4, so this change is as timer safe as it was before the change.

The modified timer configuration is working with HEXA-Dshot (Raiju) by @burtlo.