### PR TITLE
cutoff 0 will disable notch filter now since users wonder about not arming quads

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -430,10 +430,10 @@ void validateAndFixConfig(void)
 void validateAndFixGyroConfig(void)
 {
     // Prevent invalid notch cutoff
-    if (gyroConfig()->gyro_soft_notch_cutoff_1 >= gyroConfig()->gyro_soft_notch_hz_1) {
+    if (gyroConfig()->gyro_soft_notch_cutoff_1 >= gyroConfig()->gyro_soft_notch_hz_1 || gyroConfig()->gyro_soft_notch_cutoff_1 == 0) {
         gyroConfigMutable()->gyro_soft_notch_hz_1 = 0;
     }
-    if (gyroConfig()->gyro_soft_notch_cutoff_2 >= gyroConfig()->gyro_soft_notch_hz_2) {
+    if (gyroConfig()->gyro_soft_notch_cutoff_2 >= gyroConfig()->gyro_soft_notch_hz_2 || gyroConfig()->gyro_soft_notch_cutoff_2 == 0) {
         gyroConfigMutable()->gyro_soft_notch_hz_2 = 0;
     }
 


### PR DESCRIPTION
currently some users set cutoff to 0 which will lead in a not arming quad / invalid settings.

with this pr notch will be disable when cutoff is 0. since that is what the user wanted to setup.

another solution would be be to reset the cutoff to the default value.
