### PR TITLE
Reduced MAX_SUPPORTED_MOTORS from 12 to 8

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -17,18 +17,12 @@
 
 #pragma once
 
+#include "platform.h"
+
 #include "drivers/io_types.h"
-#include "timer.h"
+#include "drivers/pwm_output_counts.h"
+#include "drivers/timer.h"
 
-#ifndef MAX_SUPPORTED_MOTORS 
-#define MAX_SUPPORTED_MOTORS 12
-#endif
-
-#if defined(USE_QUAD_MIXER_ONLY)
-#define MAX_SUPPORTED_SERVOS 1
-#else
-#define MAX_SUPPORTED_SERVOS 8
-#endif
 
 #define DSHOT_MAX_COMMAND 47
 

--- a/src/main/drivers/pwm_output_counts.h
+++ b/src/main/drivers/pwm_output_counts.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+
+#if defined(USE_QUAD_MIXER_ONLY)
+#define MAX_SUPPORTED_MOTORS 4
+#define MAX_SUPPORTED_SERVOS 1
+#else
+#ifndef MAX_SUPPORTED_MOTORS
+#define MAX_SUPPORTED_MOTORS 8
+#endif
+#define MAX_SUPPORTED_SERVOS 8
+#endif

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
+#include "platform.h"
+
 #include "config/parameter_group.h"
+#include "drivers/pwm_output_counts.h"
 #include "drivers/io_types.h"
 #include "drivers/pwm_output.h"
 

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -181,6 +181,8 @@
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
+#define MAX_SUPPORTED_MOTORS    12
+
 // IO - 303 in 100pin package
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -36,7 +36,6 @@
 // Using RX DMA disables the use of receive callbacks
 #define USE_UART1_RX_DMA
 #define USE_UART1_TX_DMA
-#define MAX_SUPPORTED_MOTORS 8
 #endif
 
 #ifdef STM32F3


### PR DESCRIPTION
Saves 792 bytes of RAM. (ROM usage actually increases, since, presumably, with reduced motor count some loops are now unrolled.)