### PR TITLE
Disable arming as soon as an RX link is lost

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -32,7 +32,8 @@ static uint32_t enabledSensors = 0;
 #if defined(OSD) || !defined(MINIMAL_CLI)
 const char *armingDisableFlagNames[]= {
     "NOGYRO", "FAILSAFE", "BOXFAILSAFE", "THROTTLE",
-    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
+    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST",
+    "RX LOSS"
 };
 #endif
 

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -31,9 +31,8 @@ static uint32_t enabledSensors = 0;
 
 #if defined(OSD) || !defined(MINIMAL_CLI)
 const char *armingDisableFlagNames[]= {
-    "NOGYRO", "FAILSAFE", "BOXFAILSAFE", "THROTTLE",
-    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST",
-    "RX LOSS"
+    "NOGYRO", "FAILSAFE", "RX LOSS", "BOXFAILSAFE", "THROTTLE",
+    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
 };
 #endif
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -36,16 +36,16 @@ extern uint8_t armingFlags;
 typedef enum {
     ARMING_DISABLED_NO_GYRO     = (1 << 0),
     ARMING_DISABLED_FAILSAFE    = (1 << 1),
-    ARMING_DISABLED_BOXFAILSAFE = (1 << 2),
-    ARMING_DISABLED_THROTTLE    = (1 << 3),
-    ARMING_DISABLED_ANGLE       = (1 << 4),
-    ARMING_DISABLED_LOAD        = (1 << 5),
-    ARMING_DISABLED_CALIBRATING = (1 << 6),
-    ARMING_DISABLED_CLI         = (1 << 7),
-    ARMING_DISABLED_CMS_MENU    = (1 << 8),
-    ARMING_DISABLED_OSD_MENU    = (1 << 9),
-    ARMING_DISABLED_BST         = (1 << 10),
-    ARMING_DISABLED_RX_FAILSAFE = (1 << 11),
+    ARMING_DISABLED_RX_FAILSAFE = (1 << 2),
+    ARMING_DISABLED_BOXFAILSAFE = (1 << 3),
+    ARMING_DISABLED_THROTTLE    = (1 << 4),
+    ARMING_DISABLED_ANGLE       = (1 << 5),
+    ARMING_DISABLED_LOAD        = (1 << 6),
+    ARMING_DISABLED_CALIBRATING = (1 << 7),
+    ARMING_DISABLED_CLI         = (1 << 8),
+    ARMING_DISABLED_CMS_MENU    = (1 << 9),
+    ARMING_DISABLED_OSD_MENU    = (1 << 10),
+    ARMING_DISABLED_BST         = (1 << 11)
 } armingDisableFlags_e;
 
 #define NUM_ARMING_DISABLE_FLAGS 12

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -45,9 +45,10 @@ typedef enum {
     ARMING_DISABLED_CMS_MENU    = (1 << 8),
     ARMING_DISABLED_OSD_MENU    = (1 << 9),
     ARMING_DISABLED_BST         = (1 << 10),
+    ARMING_DISABLED_RX_FAILSAFE = (1 << 11),
 } armingDisableFlags_e;
 
-#define NUM_ARMING_DISABLE_FLAGS 11
+#define NUM_ARMING_DISABLE_FLAGS 12
 #if defined(OSD) || !defined(MINIMAL_CLI)
 extern const char *armingDisableFlagNames[NUM_ARMING_DISABLE_FLAGS];
 #endif

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -154,11 +154,13 @@ void failsafeOnValidDataReceived(void)
     failsafeState.validRxDataReceivedAt = millis();
     if ((failsafeState.validRxDataReceivedAt - failsafeState.validRxDataFailedAt) > PERIOD_RXDATA_RECOVERY) {
         failsafeState.rxLinkState = FAILSAFE_RXLINK_UP;
+        unsetArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
     }
 }
 
 void failsafeOnValidDataFailed(void)
 {
+    setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE); // To prevent arming with no RX link
     failsafeState.validRxDataFailedAt = millis();
     if ((failsafeState.validRxDataFailedAt - failsafeState.validRxDataReceivedAt) > failsafeState.rxDataFailurePeriod) {
         failsafeState.rxLinkState = FAILSAFE_RXLINK_DOWN;

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -405,6 +405,23 @@ TEST(FlightFailsafeTest, TestFailsafeNotActivatedWhenDisarmedAndRXLossIsDetected
     EXPECT_EQ(false, failsafeIsActive());
     EXPECT_EQ(FAILSAFE_IDLE, failsafePhase());
     EXPECT_EQ(1, CALL_COUNTER(COUNTER_MW_DISARM));
+    EXPECT_TRUE(isArmingDisabled());
+
+    // given
+    // enough valid data is received
+    uint32_t sysTickTarget = sysTickUptime + PERIOD_RXDATA_RECOVERY;
+    for (; sysTickUptime < sysTickTarget; sysTickUptime++) {
+        failsafeOnValidDataReceived();
+        failsafeUpdateState();
+
+        EXPECT_TRUE(isArmingDisabled());
+    }
+
+    // and
+    sysTickUptime++;                                // adjust time to point just past the failure time to
+    failsafeOnValidDataReceived();                  // cause link recovery
+
+    // then
     EXPECT_FALSE(isArmingDisabled());
 }
 


### PR DESCRIPTION
Ensures that the craft cannot be armed if no RX link is detected.

Previously a user could arm the quad via the box modes using stage 1 failsafe settings, in this case the quad would arm for the duration of the stage 1 delay and then disarm.

(note that setting arming disable flags will not disarm the quad if already armed, therefore this will not interfere with the transition from stage 1 to stage 2 over the guard time)

Here are the relevant parts of a config that demonstrate the issue:
```
aux 0 0 0 1700 2100
rxfail 4 s 1900
```

(a nice side effect of this change is that you will get an "RX LOSS" warning in the OSD as soon as you lose the RX link)