### PR TITLE
Add in prearm option for safer arming

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -182,6 +182,13 @@ void updateArmingStatus(void)
             unsetArmingDisabled(ARMING_DISABLED_CALIBRATING);
         }
 
+        if ((isModeActivationConditionPresent(BOXPREARM) && IS_RC_MODE_ACTIVE(BOXPREARM) && !ARMING_FLAG(WAS_ARMED_WITH_PREARM)) 
+            || !isModeActivationConditionPresent(BOXPREARM)) {
+            unsetArmingDisabled(ARMING_DISABLED_NOPREARM);
+        } else {
+            setArmingDisabled(ARMING_DISABLED_NOPREARM);            
+        }
+
         if (isArmingDisabled()) {
             warningLedFlash();
         } else {
@@ -237,6 +244,9 @@ void tryArm(void)
 
         ENABLE_ARMING_FLAG(ARMED);
         ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+        if (isModeActivationConditionPresent(BOXPREARM)) {
+            ENABLE_ARMING_FLAG(WAS_ARMED_WITH_PREARM);
+        }
         headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
         disarmAt = millis() + armingConfig()->auto_disarm_delay * 1000;   // start disarm timeout, will be extended when throttle is nonzero
@@ -449,6 +459,10 @@ void processRx(timeUs_t currentTimeUs)
         LED1_ON;
     } else {
         LED1_OFF;
+    }
+
+    if (!IS_RC_MODE_ACTIVE(BOXPREARM) && ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {
+        DISABLE_ARMING_FLAG(WAS_ARMED_WITH_PREARM);
     }
 
 #if defined(ACC) || defined(MAG)

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -77,6 +77,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
     { BOXCAMERA2, "CAMERA CONTROL 2", 33},
     { BOXCAMERA3, "CAMERA CONTROL 3", 34 },
     { BOXDSHOTREVERSE, "DSHOT REVERSE MOTORS", 35 },
+    { BOXPREARM, "PREARM", 36 },
 };
 
 // mask of enabled IDs, calculated on startup based on enabled features. boxId_e is used as bit index
@@ -147,7 +148,7 @@ void initActiveBoxIds(void)
     // macro to enable boxId (BoxidMaskEnable). Reference to ena is hidden, local use only
 #define BME(boxId) do { bitArraySet(&ena, boxId); } while (0)
     BME(BOXARM);
-
+    BME(BOXPREARM);
     if (!feature(FEATURE_AIRMODE)) {
         BME(BOXAIRMODE);
     }

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -58,6 +58,7 @@ typedef enum {
     BOXCAMERA2,
     BOXCAMERA3,
     BOXDSHOTREVERSE,
+    BOXPREARM,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -19,8 +19,9 @@
 
 // FIXME some of these are flight modes, some of these are general status indicators
 typedef enum {
-    ARMED           = (1 << 0),
-    WAS_EVER_ARMED  = (1 << 1)
+    ARMED                       = (1 << 0),
+    WAS_EVER_ARMED              = (1 << 1),
+    WAS_ARMED_WITH_PREARM       = (1 << 2)
 } armingFlag_e;
 
 extern uint8_t armingFlags;
@@ -40,15 +41,17 @@ typedef enum {
     ARMING_DISABLED_BOXFAILSAFE = (1 << 3),
     ARMING_DISABLED_THROTTLE    = (1 << 4),
     ARMING_DISABLED_ANGLE       = (1 << 5),
-    ARMING_DISABLED_LOAD        = (1 << 6),
-    ARMING_DISABLED_CALIBRATING = (1 << 7),
-    ARMING_DISABLED_CLI         = (1 << 8),
-    ARMING_DISABLED_CMS_MENU    = (1 << 9),
-    ARMING_DISABLED_OSD_MENU    = (1 << 10),
-    ARMING_DISABLED_BST         = (1 << 11)
+    ARMING_DISABLED_NOPREARM    = (1 << 6),
+    ARMING_DISABLED_LOAD        = (1 << 7),
+    ARMING_DISABLED_CALIBRATING = (1 << 8),
+    ARMING_DISABLED_CLI         = (1 << 9),
+    ARMING_DISABLED_CMS_MENU    = (1 << 10),
+    ARMING_DISABLED_OSD_MENU    = (1 << 11),
+    ARMING_DISABLED_BST         = (1 << 12)
 } armingDisableFlags_e;
 
-#define NUM_ARMING_DISABLE_FLAGS 12
+#define NUM_ARMING_DISABLE_FLAGS 13
+
 #if defined(OSD) || !defined(MINIMAL_CLI)
 extern const char *armingDisableFlagNames[NUM_ARMING_DISABLE_FLAGS];
 #endif


### PR DESCRIPTION
When prearm is used, it must be enabled before arming.  
Before you can arm again, the prearm switch needs to get toggled.

Only did a quick bench test on quad with a omnibus board.

I know this can all be done on some transmitters, but it is too complicated for many people.. and some transmitters don't support doing much.  Having a easy way just in betaflight might save some fingers. 

