### PR TITLE
Allow toggling of the DShot beeper

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -156,7 +156,10 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
 #endif
 
 #ifdef BEEPER
-PG_REGISTER(beeperConfig_t, beeperConfig, PG_BEEPER_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(beeperConfig_t, beeperConfig, PG_BEEPER_CONFIG, 0);
+PG_RESET_TEMPLATE(beeperConfig_t, beeperConfig,
+    .dshotForward = true
+);
 #endif
 #ifdef USE_ADC
 PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -54,6 +54,7 @@
 #include "flight/pid.h"
 #include "flight/servos.h"
 
+#include "io/beeper.h"
 #include "io/dashboard.h"
 #include "io/gimbal.h"
 #include "io/gps.h"
@@ -445,11 +446,16 @@ const clivalue_t valueTable[] = {
     { "ibatv_offset",               VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, offset) },
 #endif
 
-// PG_BEEPER_DEV_CONFIG
 #ifdef BEEPER
+// PG_BEEPER_DEV_CONFIG
     { "beeper_inversion",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, isInverted) },
     { "beeper_od",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, isOpenDrain) },
     { "beeper_frequency",           VAR_INT16  | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, frequency) },
+
+// PG_BEEPER_CONFIG
+#ifdef USE_DSHOT
+    { "beeper_dshot",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BEEPER_CONFIG, offsetof(beeperConfig_t, dshotForward) },
+#endif
 #endif
 
 // PG_MIXER_CONFIG

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -363,7 +363,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
     }
 
     #ifdef USE_DSHOT
-    if (!ARMING_FLAG(ARMED) && currentBeeperEntry->mode == BEEPER_RX_SET) {
+    if (!ARMING_FLAG(ARMED) && beeperConfig()->dshotForward && currentBeeperEntry->mode == BEEPER_RX_SET) {
         for (unsigned index = 0; index < getMotorCount(); index++) {
             pwmWriteDshotCommand(index, DSHOT_CMD_BEEP3);
         }

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -51,6 +51,7 @@ typedef enum {
 typedef struct beeperConfig_s {
     uint32_t beeper_off_flags;
     uint32_t preferred_beeper_off_flags;
+    bool dshotForward;
 } beeperConfig_t;
 
 #ifdef BEEPER


### PR DESCRIPTION
Adds a CLI setting `beeper_dshot` that can be used to toggle forwarding the beeper to DShot ESCs (defaults to on).