### PR TITLE
Adding vertical auto increment string write mode for osd devices

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -129,75 +129,7 @@ uint16_t i2cGetErrorCounter(void)
 
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
 {
-    if (device == I2CINVALID || device > I2CDEV_COUNT) {
-        return false;
-    }
-
-    I2C_TypeDef *I2Cx = i2cDevice[device].reg;
-
-    if (!I2Cx) {
-        return false;
-    }
-
-    addr_ <<= 1;
-
-    /* Test on BUSY Flag */
-    i2cTimeout = I2C_LONG_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_BUSY) != RESET) {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback();
-        }
-    }
-
-    /* Configure slave address, nbytes, reload, end mode and start or stop generation */
-    I2C_TransferHandling(I2Cx, addr_, 1, I2C_Reload_Mode, I2C_Generate_Start_Write);
-
-    /* Wait until TXIS flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback();
-        }
-    }
-
-    /* Send Register address */
-    I2C_SendData(I2Cx, (uint8_t) reg);
-
-    /* Wait until TCR flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TCR) == RESET)
-    {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback();
-        }
-    }
-
-    /* Configure slave address, nbytes, reload, end mode and start or stop generation */
-    I2C_TransferHandling(I2Cx, addr_, 1, I2C_AutoEnd_Mode, I2C_No_StartStop);
-
-    /* Wait until TXIS flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback();
-        }
-    }
-
-    /* Write data to TXDR */
-    I2C_SendData(I2Cx, data);
-
-    /* Wait until STOPF flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_STOPF) == RESET) {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback();
-        }
-    }
-
-    /* Clear STOPF flag */
-    I2C_ClearFlag(I2Cx, I2C_ICR_STOPCF);
-
-    return true;
+    return i2cWriteBuffer(device, addr_, reg, 1, &data);
 }
 
 

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -200,6 +200,83 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
     return true;
 }
 
+
+bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *data)
+{
+    if (device == I2CINVALID || device > I2CDEV_COUNT) {
+        return false;
+    }
+
+    I2C_TypeDef *I2Cx = i2cDevice[device].reg;
+
+    if (!I2Cx) {
+        return false;
+    }
+
+    addr_ <<= 1;
+
+    /* Test on BUSY Flag */
+    i2cTimeout = I2C_LONG_TIMEOUT;
+    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_BUSY) != RESET) {
+        if ((i2cTimeout--) == 0) {
+            return i2cTimeoutUserCallback();
+        }
+    }
+
+    /* Configure slave address, nbytes, reload, end mode and start or stop generation */
+    I2C_TransferHandling(I2Cx, addr_, 1, I2C_Reload_Mode, I2C_Generate_Start_Write);
+
+    /* Wait until TXIS flag is set */
+    i2cTimeout = I2C_LONG_TIMEOUT;
+    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
+        if ((i2cTimeout--) == 0) {
+            return i2cTimeoutUserCallback();
+        }
+    }
+
+    /* Send Register address */
+    I2C_SendData(I2Cx, (uint8_t) reg);
+
+    /* Wait until TCR flag is set */
+    i2cTimeout = I2C_LONG_TIMEOUT;
+    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TCR) == RESET)
+    {
+        if ((i2cTimeout--) == 0) {
+            return i2cTimeoutUserCallback();
+        }
+    }
+
+    /* Configure slave address, nbytes, reload, end mode and start or stop generation */
+    I2C_TransferHandling(I2Cx, addr_, len, I2C_AutoEnd_Mode, I2C_No_StartStop);
+
+    while (len) {
+        /* Wait until TXIS flag is set */
+        i2cTimeout = I2C_LONG_TIMEOUT;
+        while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
+            if ((i2cTimeout--) == 0) {
+                return i2cTimeoutUserCallback();
+            }
+        }
+
+        /* Write data to TXDR */
+        I2C_SendData(I2Cx, *data++);
+        len--;
+    }
+
+    /* Wait until STOPF flag is set */
+    i2cTimeout = I2C_LONG_TIMEOUT;
+    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_STOPF) == RESET) {
+        if ((i2cTimeout--) == 0) {
+            return i2cTimeoutUserCallback();
+        }
+    }
+
+    /* Clear STOPF flag */
+    I2C_ClearFlag(I2Cx, I2C_ICR_STOPCF);
+
+    return true;
+}
+
 bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device > I2CDEV_COUNT) {

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -80,6 +80,13 @@ int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, const char *s)
     return instance->vTable->writeString(instance, x, y, s);
 }
 
+int displayWriteVertical(displayPort_t *instance, uint8_t x, uint8_t y, const char *s)
+{
+    instance->posX = x;
+    instance->posY = y + strlen(s);
+    return instance->vTable->writeStringVertical(instance, x, y, s);
+}
+
 int displayWriteChar(displayPort_t *instance, uint8_t x, uint8_t y, uint8_t c)
 {
     instance->posX = x + 1;

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -39,6 +39,7 @@ typedef struct displayPortVTable_s {
     int (*drawScreen)(displayPort_t *displayPort);
     int (*screenSize)(const displayPort_t *displayPort);
     int (*writeString)(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *text);
+    int (*writeStringVertical)(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *text);
     int (*writeChar)(displayPort_t *displayPort, uint8_t x, uint8_t y, uint8_t c);
     bool (*isTransferInProgress)(const displayPort_t *displayPort);
     int (*heartbeat)(displayPort_t *displayPort);
@@ -63,6 +64,7 @@ void displayDrawScreen(displayPort_t *instance);
 int displayScreenSize(const displayPort_t *instance);
 void displaySetXY(displayPort_t *instance, uint8_t x, uint8_t y);
 int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, const char *s);
+int displayWriteVertical(displayPort_t *instance, uint8_t x, uint8_t y, const char *s);
 int displayWriteChar(displayPort_t *instance, uint8_t x, uint8_t y, uint8_t c);
 bool displayIsTransferInProgress(const displayPort_t *instance);
 void displayHeartbeat(displayPort_t *instance);

--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "platform.h"
 
@@ -297,15 +298,15 @@ void i2c_OLED_send_string_vertical(busDevice_t *bus, uint8_t x, uint8_t y, const
     // vertical mode
     i2c_OLED_set_vertical_adressing_mode(bus);
 
-    char buffer[128/8];
+    uint8_t buffer[SCREEN_HEIGHT/8];
 
     // Sends a string of chars until null terminator
-    char *sptr;
+    const char *sptr;
     uint8_t i;
     uint8_t j;
 
     uint8_t len = strlen(string);
-    if (len > 128/8) len = 128/8;
+    if (len > SCREEN_HEIGHT/8) len = SCREEN_HEIGHT/8;
 
     for (i = 0; i < 5; i++) {
         i2c_OLED_set_xy(bus, x + i, y);
@@ -313,7 +314,7 @@ void i2c_OLED_send_string_vertical(busDevice_t *bus, uint8_t x, uint8_t y, const
         for(j = 0; j<len; j++) {
             buffer[j] = multiWiiFont[*sptr - 32][i];
             buffer[j] ^= CHAR_FORMAT;  // apply
-            *sptr++;
+            sptr++;
         }
         i2cWriteBuffer(bus->busdev_u.i2c.device, bus->busdev_u.i2c.address, 0x40, len, buffer);
     }

--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -228,7 +228,7 @@ void i2c_OLED_set_horizontal_adressing_mode(busDevice_t *bus)
 void i2c_OLED_set_vertical_adressing_mode(busDevice_t *bus)
 {
     static const uint8_t i2c_OLED_cmd_clear_display_pre[] = {
-        0x00, // Set Memory Addressing Mode to Horizontal addressing mode
+        0x01, // Set Memory Addressing Mode to Vertical addressing mode
     };
 
     i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_pre, ARRAYLEN(i2c_OLED_cmd_clear_display_pre));

--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -215,6 +215,24 @@ void i2c_OLED_clear_display_quick(busDevice_t *bus)
     }
 }
 
+void i2c_OLED_set_horizontal_adressing_mode(busDevice_t *bus)
+{
+    static const uint8_t i2c_OLED_cmd_clear_display_pre[] = {
+        0x00, // Set Memory Addressing Mode to Horizontal addressing mode
+    };
+
+    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_pre, ARRAYLEN(i2c_OLED_cmd_clear_display_pre));
+}
+
+void i2c_OLED_set_vertical_adressing_mode(busDevice_t *bus)
+{
+    static const uint8_t i2c_OLED_cmd_clear_display_pre[] = {
+        0x00, // Set Memory Addressing Mode to Horizontal addressing mode
+    };
+
+    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_pre, ARRAYLEN(i2c_OLED_cmd_clear_display_pre));
+}
+
 void i2c_OLED_clear_display(busDevice_t *bus)
 {   
     static const uint8_t i2c_OLED_cmd_clear_display_pre[] = {
@@ -273,6 +291,43 @@ void i2c_OLED_send_string(busDevice_t *bus, const char *string)
         string++;
     }
 }
+
+void i2c_OLED_send_string_vertical(busDevice_t *bus, uint8_t x, uint8_t y, const char *string)
+{
+    // vertical mode
+    i2c_OLED_set_vertical_adressing_mode(bus);
+
+    char buffer[128/8];
+
+    // Sends a string of chars until null terminator
+    char *sptr;
+    uint8_t i;
+    uint8_t j;
+
+    uint8_t len = strlen(string);
+    if (len > 128/8) len = 128/8;
+
+    for (i = 0; i < 5; i++) {
+        i2c_OLED_set_xy(bus, x + i, y);
+        sptr = string;
+        for(j = 0; j<len; j++) {
+            buffer[j] = multiWiiFont[*sptr - 32][i];
+            buffer[j] ^= CHAR_FORMAT;  // apply
+            *sptr++;
+        }
+        i2cWriteBuffer(bus->busdev_u.i2c.device, bus->busdev_u.i2c.address, 0x40, len, buffer);
+    }
+    // send blank line after string:
+    for(j = 0; j<len; j++) {
+        buffer[j] = 0;
+    }
+    i2c_OLED_set_xy(bus, x + 5, y);
+    i2cWriteBuffer(bus->busdev_u.i2c.device, bus->busdev_u.i2c.address, 0x40, len, buffer);
+
+    // back to normal
+    i2c_OLED_set_horizontal_adressing_mode(bus);
+}
+
 
 /**
 * according to http://www.adafruit.com/datasheets/UG-2864HSWEG01.pdf Chapter 4.4 Page 15

--- a/src/main/drivers/display_ug2864hsweg01.h
+++ b/src/main/drivers/display_ug2864hsweg01.h
@@ -42,5 +42,6 @@ void i2c_OLED_set_xy(busDevice_t *bus, uint8_t col, uint8_t row);
 void i2c_OLED_set_line(busDevice_t *bus, uint8_t row);
 void i2c_OLED_send_char(busDevice_t *bus, unsigned char ascii);
 void i2c_OLED_send_string(busDevice_t *bus, const char *string);
+void i2c_OLED_send_string_vertical(busDevice_t *bus, uint8_t x, uint8_t y, const char *string);
 void i2c_OLED_clear_display(busDevice_t *bus);
 void i2c_OLED_clear_display_quick(busDevice_t *bus);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -25,6 +25,7 @@
 #ifdef USE_MAX7456
 
 #include "common/printf.h"
+#include "common/maths.h"
 
 #include "drivers/bus_spi.h"
 #include "drivers/dma.h"
@@ -473,6 +474,14 @@ void max7456Write(uint8_t x, uint8_t y, const char *buff)
     for (i = 0; *(buff+i); i++)
         if (x+i < CHARS_PER_LINE) // Do not write over screen
             screenBuffer[y*CHARS_PER_LINE+x+i] = *(buff+i);
+}
+
+void max7456WriteVertical(uint8_t x, uint8_t y, const char *buff)
+{
+    uint16_t offset;
+    for (offset = y*CHARS_PER_LINE + x; *buff; offset+= CHARS_PER_LINE)
+        if (offset < MAX(VIDEO_LINES_PAL, VIDEO_LINES_NTSC)) // Do not write over screen
+            screenBuffer[offset] = *buff++;
 }
 
 bool max7456DmaInProgress(void)

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -43,6 +43,7 @@ void    max7456DrawScreen(void);
 void    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
 uint8_t max7456GetRowsCount(void);
 void    max7456Write(uint8_t x, uint8_t y, const char *buff);
+void    max7456WriteVertical(uint8_t x, uint8_t y, const char *buff);
 void    max7456WriteChar(uint8_t x, uint8_t y, uint8_t c);
 void    max7456ClearScreen(void);
 void    max7456RefreshAll(void);

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -103,6 +103,14 @@ static int writeString(displayPort_t *displayPort, uint8_t x, uint8_t y, const c
     return 0;
 }
 
+static int writeStringVertical(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *s)
+{
+    UNUSED(displayPort);
+    max7456WriteVertical(x, y, s);
+
+    return 0;
+}
+
 static int writeChar(displayPort_t *displayPort, uint8_t x, uint8_t y, uint8_t c)
 {
     UNUSED(displayPort);
@@ -144,6 +152,7 @@ static const displayPortVTable_t max7456VTable = {
     .drawScreen = drawScreen,
     .screenSize = screenSize,
     .writeString = writeString,
+    .writeStringVertical = writeStringVertical,
     .writeChar = writeChar,
     .isTransferInProgress = isTransferInProgress,
     .heartbeat = heartbeat,

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -119,6 +119,26 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, con
     return output(displayPort, MSP_DISPLAYPORT, buf, len + 4);
 }
 
+static int writeStringVertical(displayPort_t *displayPort, uint8_t col, uint8_t row, const char *string)
+{
+    // NOTE: this could be a nice enhancement to the displayport msp command
+    // set as well. By adding a vertical draw sub command (e.g. 0x04)
+    // this could speed up the drawing of vertical elements a lot!
+    // for now stick to the standard and issue single x/y draw commands:
+    char buf[2];
+    buf[1] = 0;
+
+    uint16_t bytes_sent = 0;
+
+    while ((*string) && (row < displayPort->rows)){
+        buf[0] = *string++;
+        bytes_sent += writeString(displayPort, col, row, buf);
+        row++;
+    }
+
+    return bytes_sent;
+}
+
 static int writeChar(displayPort_t *displayPort, uint8_t col, uint8_t row, uint8_t c)
 {
     char buf[2];
@@ -153,6 +173,7 @@ static const displayPortVTable_t mspDisplayPortVTable = {
     .drawScreen = drawScreen,
     .screenSize = screenSize,
     .writeString = writeString,
+    .writeStringVertical = writeStringVertical,
     .writeChar = writeChar,
     .isTransferInProgress = isTransferInProgress,
     .heartbeat = heartbeat,

--- a/src/main/io/displayport_oled.c
+++ b/src/main/io/displayport_oled.c
@@ -63,6 +63,17 @@ static int oledWriteString(displayPort_t *displayPort, uint8_t x, uint8_t y, con
     return 0;
 }
 
+static int oledWriteStringVertical(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *s)
+{
+    while ((*s) && (y < displayPort->rows)){
+        i2c_OLED_set_xy(displayPort->device, x, y);
+        i2c_OLED_send_char(displayPort->device, *s);
+        y += displayPort->cols;
+        s++;
+    }
+    return 0;
+}
+
 static int oledWriteChar(displayPort_t *displayPort, uint8_t x, uint8_t y, uint8_t c)
 {
     i2c_OLED_set_xy(displayPort->device, x, y);
@@ -100,6 +111,7 @@ static const displayPortVTable_t oledVTable = {
     .drawScreen = oledDrawScreen,
     .screenSize = oledScreenSize,
     .writeString = oledWriteString,
+    .writeStringVertical = oledWriteStringVertical,
     .writeChar = oledWriteChar,
     .isTransferInProgress = oledIsTransferInProgress,
     .heartbeat = oledHeartbeat,

--- a/src/main/io/displayport_oled.c
+++ b/src/main/io/displayport_oled.c
@@ -65,12 +65,7 @@ static int oledWriteString(displayPort_t *displayPort, uint8_t x, uint8_t y, con
 
 static int oledWriteStringVertical(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *s)
 {
-    while ((*s) && (y < displayPort->rows)){
-        i2c_OLED_set_xy(displayPort->device, x, y);
-        i2c_OLED_send_char(displayPort->device, *s);
-        y += displayPort->cols;
-        s++;
-    }
+    i2c_OLED_send_string_vertical(displayPort->device, x, y, s);
     return 0;
 }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -526,16 +526,28 @@ static void osdDrawSingleElement(uint8_t item)
             }
 
             // Draw AH sides
-            const int8_t hudwidth = AH_SIDEBAR_WIDTH_POS;
-            const int8_t hudheight = AH_SIDEBAR_HEIGHT_POS;
-            for (int y = -hudheight; y <= hudheight; y++) {
-                displayWriteChar(osdDisplayPort, elemPosX - hudwidth, elemPosY + y, SYM_AH_DECORATION);
-                displayWriteChar(osdDisplayPort, elemPosX + hudwidth, elemPosY + y, SYM_AH_DECORATION);
-            }
+            uint8_t hudHeight = AH_SIDEBAR_HEIGHT_POS;
+            uint8_t hudWidth = AH_SIDEBAR_WIDTH_POS;
 
-            // AH level indicators
-            displayWriteChar(osdDisplayPort, elemPosX - hudwidth + 1, elemPosY, SYM_AH_LEFT);
-            displayWriteChar(osdDisplayPort, elemPosX + hudwidth - 1, elemPosY, SYM_AH_RIGHT);
+            // draw the left uppermost icon in combination with the special symbol:
+            buff[0] = SYM_AH_LEFT;
+            buff[1] = SYM_AH_DECORATION;
+            buff[2] = 0;
+            displayWriteVertical(osdDisplayPort, elemPosX - hudWidth, elemPosY, buff);
+            // right uppermost icon
+            buff[0] = SYM_AH_DECORATION;
+            buff[1] = SYM_AH_RIGHT;
+            displayWriteVertical(osdDisplayPort, elemPosX + hudWidth, elemPosY, buff);
+
+            // the first row of side bars has already been drawn
+            elemPosY++;
+
+            // draw the remaining side bars in vertical mode
+            for (int i=0 ; i<=hudHeight*2 - 1; i++) {
+                buff[i] = SYM_AH_DECORATION;
+            }
+            displayWriteVertical(osdDisplayPort, elemPosX - hudWidth, elemPosY, buff);
+            displayWriteVertical(osdDisplayPort, elemPosX + hudWidth, elemPosY, buff);
 
             return;
         }


### PR DESCRIPTION
This will add vertical auto increment write mode for osd devices.
Drawing of the HUD uses a lot of single x/y writes in order to draw the vertical bar.

For the i2c oled and serial devices such as displayport msp or tinyOSD it would make sense to have a 
vertical write mode. Drawing the HUD would be a single writeStringVertical() call.
This will allow tinyOSD support without the need of the large, ram wasting (double) char screenbuffer as the max7456.

Note that in order to utilize the advantage in mwosd one will have to add a vertical write subcommand.
This patch will use single write calls for the msp displayport calls for now.

The Oled code could also be optimized for this vertical write mode
by using vertical adressing (mode 0x01) and sending the single char columns after each other.

I also though about using the normal write call and adding a mode flag for horizontal (normal) or vertical write. Any preferences?

DO NOT MERGE RIGHT NOW. 
This is not tested yet (my max7456 fc is still in transit...) and open for discussion.
