### PR TITLE
Power on arming guard

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -134,6 +134,7 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .debug_mode = DEBUG_MODE,
     .task_statistics = true,
     .cpu_overclock = false,
+    .powerOnArmGuardTime = 5,
     .boardIdentifier = TARGET_BOARD_IDENTIFIER
 );
 #else

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -72,7 +72,7 @@ typedef struct systemConfig_s {
 #if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     uint8_t cpu_overclock;
 #endif
-    uint8_t powerOnArmGuardTime;
+    uint8_t powerOnArmGuardTime; // in seconds
     char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER) + 1];
 } systemConfig_t;
 #endif

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -72,6 +72,7 @@ typedef struct systemConfig_s {
 #if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     uint8_t cpu_overclock;
 #endif
+    uint8_t powerOnArmGuardTime;
     char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER) + 1];
 } systemConfig_t;
 #endif

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -189,7 +189,7 @@ void updateArmingStatus(void)
             unsetArmingDisabled(ARMING_DISABLED_CALIBRATING);
         }
 
-        if ((getArmingDisableFlags() & ARMING_DISABLED_POWER_ON_GUARD)) {
+        if ((getArmingDisableFlags() & ARMING_DISABLED_POWER_ON_GUARD) && isModeActivationConditionPresent(BOXARM)) {
             if (IS_RC_MODE_ACTIVE(BOXARM)) {
                 resetPowerOnGuardTime();
             } else {

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -189,7 +189,7 @@ void updateArmingStatus(void)
             unsetArmingDisabled(ARMING_DISABLED_CALIBRATING);
         }
 
-        if ((getArmingDisableFlags() & ARMING_DISABLED_POWER_ON_GUARD) && isModeActivationConditionPresent(BOXARM)) {
+        if ((getArmingDisableFlags() & ARMING_DISABLED_POWER_ON_GUARD) && !isUsingSticksForArming()) {
             if (IS_RC_MODE_ACTIVE(BOXARM)) {
                 // Arm switch is active so guard period timer is reset
                 resetPowerOnGuardTime();

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -110,7 +110,7 @@ int16_t headFreeModeHold;
 
 static bool reverseMotors = false;
 static uint32_t disarmAt;     // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
-static uint32_t powerOnGuardExpiry;
+static uint32_t powerOnGuardExpiry;  // Time in milliseconds at which the power on arming guard expires
 
 bool isRXDataNew;
 static int lastArmingDisabledReason = 0;
@@ -191,10 +191,11 @@ void updateArmingStatus(void)
 
         if ((getArmingDisableFlags() & ARMING_DISABLED_POWER_ON_GUARD) && isModeActivationConditionPresent(BOXARM)) {
             if (IS_RC_MODE_ACTIVE(BOXARM)) {
+                // Arm switch is active so guard period timer is reset
                 resetPowerOnGuardTime();
-            } else {
-                if (millis() >= powerOnGuardExpiry)
-                    unsetArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
+            } else if (millis() >= powerOnGuardExpiry) {
+                // Arm switch is off and guard period has elapsed so remove the arming prevention
+                unsetArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
             }
         }
 

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -39,6 +39,7 @@ void applyAndSaveAccelerometerTrimsDelta(union rollAndPitchTrims_u *rollAndPitch
 void handleInflightCalibrationStickPosition();
 
 void resetArmingDisabled(void);
+void resetPowerOnGuardTime(void);
 
 void disarm(void);
 void tryArm(void);

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -720,8 +720,11 @@ void init(void)
     latchActiveFeatures();
     pwmEnableMotors();
 
-    resetPowerOnGuardTime();
-    setArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
+    // Reset arming guard if using switch arming
+    if (isModeActivationConditionPresent(BOXARM)) {
+        resetPowerOnGuardTime();
+        setArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
+    }
 
 #ifdef USE_OSD_SLAVE
     osdSlaveTasksInit();

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -721,7 +721,7 @@ void init(void)
     pwmEnableMotors();
 
     // Reset arming guard if using switch arming
-    if (isModeActivationConditionPresent(BOXARM)) {
+    if (!isUsingSticksForArming()) {
         resetPowerOnGuardTime();
         setArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
     }

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -71,6 +71,7 @@
 #include "drivers/camera_control.h"
 
 #include "fc/config.h"
+#include "fc/fc_core.h"
 #include "fc/fc_init.h"
 #include "fc/fc_msp.h"
 #include "fc/fc_tasks.h"
@@ -718,6 +719,9 @@ void init(void)
     // Latch active features AGAIN since some may be modified by init().
     latchActiveFeatures();
     pwmEnableMotors();
+
+    resetPowerOnGuardTime();
+    setArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
 
 #ifdef USE_OSD_SLAVE
     osdSlaveTasksInit();

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -32,7 +32,8 @@ static uint32_t enabledSensors = 0;
 #if defined(OSD) || !defined(MINIMAL_CLI)
 const char *armingDisableFlagNames[]= {
     "NOGYRO", "FAILSAFE", "RX LOSS", "BOXFAILSAFE", "THROTTLE",
-    "ANGLE", "NO PREARM", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
+    "ANGLE", "NO PREARM", "ARM SW", "LOAD", "CALIB", "CLI",
+    "CMS", "OSD", "BST"
 };
 #endif
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -35,22 +35,23 @@ extern uint8_t armingFlags;
  * (Beeper code can notify the most critical reason.)
  */
 typedef enum {
-    ARMING_DISABLED_NO_GYRO     = (1 << 0),
-    ARMING_DISABLED_FAILSAFE    = (1 << 1),
-    ARMING_DISABLED_RX_FAILSAFE = (1 << 2),
-    ARMING_DISABLED_BOXFAILSAFE = (1 << 3),
-    ARMING_DISABLED_THROTTLE    = (1 << 4),
-    ARMING_DISABLED_ANGLE       = (1 << 5),
-    ARMING_DISABLED_NOPREARM    = (1 << 6),
-    ARMING_DISABLED_LOAD        = (1 << 7),
-    ARMING_DISABLED_CALIBRATING = (1 << 8),
-    ARMING_DISABLED_CLI         = (1 << 9),
-    ARMING_DISABLED_CMS_MENU    = (1 << 10),
-    ARMING_DISABLED_OSD_MENU    = (1 << 11),
-    ARMING_DISABLED_BST         = (1 << 12)
+    ARMING_DISABLED_NO_GYRO        = (1 << 0),
+    ARMING_DISABLED_FAILSAFE       = (1 << 1),
+    ARMING_DISABLED_RX_FAILSAFE    = (1 << 2),
+    ARMING_DISABLED_BOXFAILSAFE    = (1 << 3),
+    ARMING_DISABLED_THROTTLE       = (1 << 4),
+    ARMING_DISABLED_ANGLE          = (1 << 5),
+    ARMING_DISABLED_NOPREARM       = (1 << 6),
+    ARMING_DISABLED_POWER_ON_GUARD = (1 << 7),
+    ARMING_DISABLED_LOAD           = (1 << 8),
+    ARMING_DISABLED_CALIBRATING    = (1 << 9),
+    ARMING_DISABLED_CLI            = (1 << 10),
+    ARMING_DISABLED_CMS_MENU       = (1 << 11),
+    ARMING_DISABLED_OSD_MENU       = (1 << 12),
+    ARMING_DISABLED_BST            = (1 << 13)
 } armingDisableFlags_e;
 
-#define NUM_ARMING_DISABLE_FLAGS 13
+#define NUM_ARMING_DISABLE_FLAGS 14
 
 #if defined(OSD) || !defined(MINIMAL_CLI)
 extern const char *armingDisableFlagNames[NUM_ARMING_DISABLE_FLAGS];

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -697,6 +697,7 @@ const clivalue_t valueTable[] = {
 #if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     { "cpu_overclock",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, cpu_overclock) },
 #endif
+    { "pwr_on_arm_guard",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, powerOnArmGuardTime) },
 
 // PG_VTX_CONFIG
 #ifdef VTX_RTC6705

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -28,6 +28,14 @@ altitude_hold_unittest_SRC :=  \
 		$(USER_DIR)/flight/altitude.c
 
 
+arming_prevention_unittest_SRC := \
+		$(USER_DIR)/fc/fc_core.c \
+		$(USER_DIR)/fc/rc_controls.c \
+		$(USER_DIR)/fc/rc_modes.c \
+		$(USER_DIR)/fc/runtime_config.c \
+		$(USER_DIR)/common/bitarray.c
+
+
 baro_bmp085_unittest_SRC := \
 		$(USER_DIR)/drivers/barometer/barometer_bmp085.c \
 		$(USER_DIR)/drivers/io.c

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1,0 +1,281 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+extern "C" {
+    #include "blackbox/blackbox.h"
+    #include "build/debug.h"
+    #include "common/maths.h"
+    #include "config/parameter_group.h"
+    #include "config/parameter_group_ids.h"
+    #include "fc/config.h"
+    #include "fc/controlrate_profile.h"
+    #include "fc/fc_core.h"
+    #include "fc/rc_controls.h"
+    #include "fc/rc_modes.h"
+    #include "fc/runtime_config.h"
+    #include "flight/imu.h"
+    #include "flight/mixer.h"
+    #include "flight/pid.h"
+    #include "flight/servos.h"
+    #include "io/beeper.h"
+    #include "io/gps.h"
+    #include "rx/rx.h"
+    #include "scheduler/scheduler.h"
+    #include "sensors/acceleration.h"
+    #include "sensors/gyro.h"
+    #include "telemetry/telemetry.h"
+
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+    PG_REGISTER(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 0);
+    PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+    PG_REGISTER(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
+    PG_REGISTER(pidConfig_t, pidConfig, PG_PID_CONFIG, 0);
+    PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
+    PG_REGISTER(servoConfig_t, servoConfig, PG_SERVO_CONFIG, 0);
+    PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 0);
+    PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
+
+    float rcCommand[4];
+    int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+    uint16_t averageSystemLoadPercent = 0;
+    uint8_t cliMode = 0;
+    uint8_t debugMode = 0;
+    int16_t debug[DEBUG16_VALUE_COUNT];
+    pidProfile_t *currentPidProfile;
+    controlRateConfig_t *currentControlRateProfile;
+    attitudeEulerAngles_t attitude;
+    gpsSolutionData_t gpsSol;
+    uint32_t targetPidLooptime;
+    bool cmsInMenu = false;
+}
+
+uint32_t simulationTime = 0;
+
+#include "gtest/gtest.h"
+
+TEST(ArmingPreventionTest, AngleThrottleArmguard)
+{
+    // given
+    simulationTime = 0;
+
+    // and
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXARM;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(1750);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+    useRcControlsConfig(NULL);
+
+    // and
+    rxConfigMutable()->mincheck = 1050;
+    systemConfigMutable()->powerOnArmGuardTime = 5;
+
+    // and
+    // arming initially disabled by guard
+    setArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
+    resetPowerOnGuardTime();
+
+    // and
+    // default channel positions
+    rcData[THROTTLE] = 1400;
+    rcData[4] = 1800;
+
+    // when
+    updateActivatedModes();
+    updateArmingStatus();
+
+    // expect
+    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_EQ(ARMING_DISABLED_ANGLE | ARMING_DISABLED_POWER_ON_GUARD | ARMING_DISABLED_THROTTLE, getArmingDisableFlags());
+
+    // given
+    // quad is level
+    ENABLE_STATE(SMALL_ANGLE);
+
+    // when
+    updateArmingStatus();
+
+    // expect
+    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_EQ(ARMING_DISABLED_POWER_ON_GUARD | ARMING_DISABLED_THROTTLE, getArmingDisableFlags());
+
+    // given
+    rcData[THROTTLE] = 1000;
+
+    // when
+    updateArmingStatus();
+
+    // expect
+    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_EQ(ARMING_DISABLED_POWER_ON_GUARD, getArmingDisableFlags());
+
+    // when
+    // arm guard time elapses
+    for (int i = 0; i < systemConfig()->powerOnArmGuardTime; i++) {
+        simulationTime += 1e6;
+        updateActivatedModes();
+        updateArmingStatus();
+    }
+
+    // expect
+    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_EQ(ARMING_DISABLED_POWER_ON_GUARD, getArmingDisableFlags());
+
+    // given
+    rcData[4] = 1000;
+
+    // when
+    // arm guard time elapses
+    for (int i = 0; i < systemConfig()->powerOnArmGuardTime; i++) {
+        simulationTime += 1e6;
+        updateActivatedModes();
+        updateArmingStatus();
+    }
+
+    // expect
+    EXPECT_EQ(0, getArmingDisableFlags());
+    EXPECT_FALSE(isArmingDisabled());
+}
+
+TEST(ArmingPreventionTest, ArmingGuardRadioLeftOnAndArmed)
+{
+    // given
+    simulationTime = 0;
+
+    // and
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXARM;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(1750);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+    useRcControlsConfig(NULL);
+
+    // and
+    rxConfigMutable()->mincheck = 1050;
+    systemConfigMutable()->powerOnArmGuardTime = 5;
+
+    // and
+    // arming initially disabled by guard
+    setArmingDisabled(ARMING_DISABLED_POWER_ON_GUARD);
+    resetPowerOnGuardTime();
+
+    // given
+    rcData[THROTTLE] = 1000;
+    ENABLE_STATE(SMALL_ANGLE);
+
+    // when
+    updateActivatedModes();
+    updateArmingStatus();
+
+    // expect
+    EXPECT_FALSE(isUsingSticksForArming());
+    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_EQ(ARMING_DISABLED_POWER_ON_GUARD, getArmingDisableFlags());
+
+    // given
+    // arm channel takes a safe default value from the RX after power on
+    rcData[4] = 1500;
+
+    // and
+    // a short time passes before the RF link is made
+    simulationTime += 1e6;
+
+    // when
+    updateActivatedModes();
+    updateArmingStatus();
+
+    // expect
+    // arming should still be disabled as the timeout has yet to elapse
+    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_EQ(ARMING_DISABLED_POWER_ON_GUARD, getArmingDisableFlags());
+
+    // given
+    // arm switch is switched off by user
+    rcData[4] = 1000;
+
+    // and
+    simulationTime += 1e6 * systemConfig()->powerOnArmGuardTime;
+
+    // when
+    updateActivatedModes();
+    updateArmingStatus();
+
+    // expect
+    // arming enabled as arm switch has been off for sufficient time
+    EXPECT_EQ(0, getArmingDisableFlags());
+    EXPECT_FALSE(isArmingDisabled());
+}
+
+// STUBS
+extern "C" {
+    uint32_t micros(void) { return simulationTime; }
+    uint32_t millis(void) { return micros() / 1000; }
+    bool rxIsReceivingSignal(void) { return false; }
+
+    bool feature(uint32_t) { return false; }
+    void warningLedFlash(void) {}
+    void warningLedDisable(void) {}
+    void warningLedUpdate(void) {}
+    void beeper(beeperMode_e) {}
+    void beeperConfirmationBeeps(uint8_t) {}
+    void beeperWarningBeeps(uint8_t) {}
+    void beeperSilence(void) {}
+    void systemBeep(bool) {}
+    void saveConfigAndNotify(void) {}
+    void blackboxFinish(void) {}
+    bool isAccelerationCalibrationComplete(void) { return true; }
+    bool isBaroCalibrationComplete(void) { return true; }
+    bool isGyroCalibrationComplete(void) { return true; }
+    void gyroStartCalibration(bool) {}
+    bool isFirstArmingGyroCalibrationRunning(void) { return false; }
+    void pidController(const pidProfile_t *, const rollAndPitchTrims_t *, timeUs_t) {}
+    void pidStabilisationState(pidStabilisationState_e) {}
+    void mixTable(uint8_t) {};
+    void writeMotors(void) {};
+    void writeServos(void) {};
+    void calculateRxChannelsAndUpdateFailsafe(timeUs_t) {}
+    bool isMixerUsingServos(void) { return false; }
+    void gyroUpdate(void) {}
+    timeDelta_t getTaskDeltaTime(cfTaskId_e) { return 0; }
+    void updateRSSI(timeUs_t) {}
+    bool failsafeIsMonitoring(void) { return false; }
+    void failsafeStartMonitoring(void) {}
+    void failsafeUpdateState(void) {}
+    bool failsafeIsActive(void) { return false; }
+    void pidResetErrorGyroState(void) {}
+    void updateAdjustmentStates(void) {}
+    void processRcAdjustments(controlRateConfig_t *) {}
+    void updateGpsWaypointsAndMode(void) {}
+    void releaseSharedTelemetryPorts(void) {}
+    void telemetryCheckState(void) {}
+    void mspSerialAllocatePorts(void) {}
+    void gyroReadTemperature(void) {}
+    void updateRcCommands(void) {}
+    void applyAltHold(void) {}
+    void resetYawAxis(void) {}
+    int16_t calculateThrottleAngleCorrection(uint8_t) { return 0; }
+    void processRcCommand(void) {}
+    void updateGpsStateForHomeAndHoldMode(void) {}
+    void blackboxUpdate(timeUs_t) {}
+    void transponderUpdate(timeUs_t) {}
+    void GPS_reset_home_position(void) {}
+    void accSetCalibrationCycles(uint16_t) {}
+    void baroSetCalibrationCycles(uint16_t) {}
+    void changePidProfile(uint8_t) {}
+    void dashboardEnablePageCycling(void) {}
+    void dashboardDisablePageCycling(void) {}
+}


### PR DESCRIPTION
Adds a guard that prevents arming until the arm switch has been off for a given number of seconds.

This only affects the first arming and is designed to protect against the user powering on the quad with the RX giving a channel value that would arm the quad.

(if anyone can think of a better name for this guard then please suggest it)