### PR TITLE
Add missing arming disable flag name

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -32,7 +32,7 @@ static uint32_t enabledSensors = 0;
 #if defined(OSD) || !defined(MINIMAL_CLI)
 const char *armingDisableFlagNames[]= {
     "NOGYRO", "FAILSAFE", "RX LOSS", "BOXFAILSAFE", "THROTTLE",
-    "ANGLE", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
+    "ANGLE", "NO PREARM", "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
 };
 #endif
 


### PR DESCRIPTION
#3683 missed out the string for the `NOPREARM` flag.