### PR TITLE
partial osd update

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -486,7 +486,7 @@ bool max7456DmaInProgress(void)
 
 #include "build/debug.h"
 
-void max7456DrawScreen(void)
+void max7456DrawScreenPartial(void)
 {
     uint8_t stallCheck;
     uint8_t videoSense;

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -39,7 +39,7 @@ void    max7456HardwareReset(void);
 void    max7456Init(const struct vcdProfile_s *vcdProfile);
 void    max7456Invert(bool invert);
 void    max7456Brightness(uint8_t black, uint8_t white);
-void    max7456DrawScreen(void);
+void    max7456DrawScreenPartial(void);
 void    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
 uint8_t max7456GetRowsCount(void);
 void    max7456Write(uint8_t x, uint8_t y, const char *buff);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -43,6 +43,7 @@
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/compass/compass.h"
+#include "drivers/display.h"
 #include "drivers/flash.h"
 #include "drivers/io.h"
 #include "drivers/max7456.h"
@@ -2047,6 +2048,9 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                 } else {
                   return MSP_RESULT_ERROR;
                 }
+
+                // force full screen rewrite
+                if (osdDisplayPort) displayClearScreen(osdDisplayPort);
 #else
                 return MSP_RESULT_ERROR;
 #endif

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -534,7 +534,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_OSD] = {
         .taskName = "OSD",
         .taskFunc = osdUpdate,
-        .desiredPeriod = TASK_PERIOD_HZ(60),        // 60 Hz
+        .desiredPeriod = TASK_PERIOD_HZ(OSD_TASK_FREQUENCY_HZ),        // 60 Hz
         .staticPriority = TASK_PRIORITY_LOW,
     },
 #endif

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -84,7 +84,7 @@ static int clearScreen(displayPort_t *displayPort)
 static int drawScreen(displayPort_t *displayPort)
 {
     UNUSED(displayPort);
-    max7456DrawScreen();
+    max7456DrawScreenPartial();
 
     return 0;
 }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -131,8 +131,9 @@ uint32_t resumeRefreshAt = 0;
 #define REFRESH_1S    1000 * 1000
 
 static uint8_t armState;
+static uint8_t osdCurrentElementIndex;
 
-static displayPort_t *osdDisplayPort;
+displayPort_t *osdDisplayPort = NULL;
 
 #define AH_MAX_PITCH 200 // Specify maximum AHI pitch value displayed. Default 200 = 20.0 degrees
 #define AH_MAX_ROLL 400  // Specify maximum AHI roll value displayed. Default 400 = 40.0 degrees
@@ -291,16 +292,47 @@ STATIC_UNIT_TESTED void osdFormatTimer(char *buff, bool showSymbol, int timerInd
     osdFormatTime(buff, OSD_TIMER_PRECISION(timer), osdGetTimerValue(src));
 }
 
-static void osdDrawSingleElement(uint8_t item)
-{
-    if (!VISIBLE(osdConfig()->item_pos[item]) || BLINK(item)) {
-        return;
+static uint8_t osdIncElementIndex(uint8_t elementIndex) {
+    // this makes sure that we do not enter an endless loop
+    // in case there are no visible items
+    uint8_t max_inc = OSD_ITEM_COUNT-1;
+
+    while (max_inc) {
+        // next item
+        elementIndex++;
+        max_inc--;
+
+        // make sure not to exceed maximum
+        if (elementIndex >= OSD_ITEM_COUNT) {
+            elementIndex = 0;
+        }
+
+        // check for visibility
+        if (VISIBLE(osdConfig()->item_pos[elementIndex])) {
+            // found next visible item
+            break;
+        }
+    }
+    if (max_inc == 0) {
+        // no osd item is visible
+        elementIndex = OSD_ITEM_COUNT;
     }
 
+    return elementIndex;
+}
+
+static void osdDrawSingleElement(uint8_t item)
+{
     uint8_t elemPosX = OSD_X(osdConfig()->item_pos[item]);
     uint8_t elemPosY = OSD_Y(osdConfig()->item_pos[item]);
     uint8_t elemOffsetX = 0;
     char buff[OSD_ELEMENT_BUFFER_LENGTH];
+
+    if (item == OSD_ITEM_COUNT) {
+        // no osd items are visible
+        displayClearScreen(osdDisplayPort);
+        return;
+    }
 
     switch (item) {
     case OSD_RSSI_VALUE:
@@ -310,7 +342,7 @@ static void osdDrawSingleElement(uint8_t item)
                 osdRssi = 99;
 
             buff[0] = SYM_RSSI;
-            tfp_sprintf(buff + 1, "%d", osdRssi);
+            tfp_sprintf(buff + 1, "%2d", osdRssi);
             break;
         }
 
@@ -323,19 +355,19 @@ static void osdDrawSingleElement(uint8_t item)
         {
             const int32_t amperage = getAmperage();
             buff[0] = SYM_AMP;
-            tfp_sprintf(buff + 1, "%d.%02d", abs(amperage) / 100, abs(amperage) % 100);
+            tfp_sprintf(buff + 1, "%3d.%02d", abs(amperage) / 100, abs(amperage) % 100);
             break;
         }
 
     case OSD_MAH_DRAWN:
         buff[0] = SYM_MAH;
-        tfp_sprintf(buff + 1, "%d", getMAhDrawn());
+        tfp_sprintf(buff + 1, "%4d", getMAhDrawn());
         break;
 
 #ifdef GPS
     case OSD_GPS_SATS:
         buff[0] = 0x1f;
-        tfp_sprintf(buff + 1, "%d", gpsSol.numSat);
+        tfp_sprintf(buff + 1, "%2d", gpsSol.numSat);
         break;
 
     case OSD_GPS_SPEED:
@@ -355,20 +387,39 @@ static void osdDrawSingleElement(uint8_t item)
                 val = gpsSol.llh.lon;
             }
 
-            char wholeDegreeString[5];
-            tfp_sprintf(wholeDegreeString, "%d", val / GPS_DEGREES_DIVIDER);
-
-            char wholeUnshifted[12];
-            tfp_sprintf(wholeUnshifted, "%d", val);
-
-            tfp_sprintf(buff + 1, "%s.%s", wholeDegreeString, wholeUnshifted + strlen(wholeDegreeString));
+            // add sign
+            if (val < 0) {
+                val = -val;
+                buff[1] = '-';
+            }else{
+                buff[1] = ' ';
+            }
+            // add whole degree number
+            tfp_sprintf(buff + 1, "%3d", val / GPS_DEGREES_DIVIDER);
+            // add '.'
+            buff[5] = '.';
+            // add fraction
+            val = val - (val * GPS_DEGREES_DIVIDER);
+            tfp_sprintf(&buff[6], "%d", val);
+            // convert to fixed length string by filling the rest with spaces
+            // gps data maximum is -DDD.1234567 = 12chars
+            // start at the end
+            uint8_t pos = 12;
+            // new end of string:
+            buff[pos--] = 0;
+            // fill with spaces
+            while ((pos > 0) && (buff[pos])) {
+                buff[pos--] = ' ';
+            }
+            // remove old eof marker
+            buff[pos] = ' ';
             break;
         }
 
     case OSD_HOME_DIST:
         if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
             int32_t distance = osdGetMetersToSelectedUnit(GPS_distanceToHome);
-            tfp_sprintf(buff, "%d%c", distance, osdGetMetersToSelectedUnitSymbol());
+            tfp_sprintf(buff, "%5d%c", distance, osdGetMetersToSelectedUnitSymbol());
         } else {
             // We use this symbol when we don't have a FIX
             buff[0] = SYM_COLON;
@@ -410,8 +461,14 @@ static void osdDrawSingleElement(uint8_t item)
 
     case OSD_ALTITUDE:
         {
-            const int32_t alt = osdGetMetersToSelectedUnit(getEstimatedAltitude());
-            tfp_sprintf(buff, "%c%d.%01d%c", alt < 0 ? '-' : ' ', abs(alt / 100), abs((alt % 100) / 10), osdGetMetersToSelectedUnitSymbol());
+            int32_t alt = osdGetMetersToSelectedUnit(getEstimatedAltitude());
+            if (alt < 0) {
+                alt = -alt;
+                buff[0] = '-';
+            } else {
+                buff[0] = ' ';
+            }
+            tfp_sprintf(buff + 1, "%3d.%01d%c", alt / 100, (alt % 100) / 10, osdGetMetersToSelectedUnitSymbol());
             break;
         }
 
@@ -428,35 +485,38 @@ static void osdDrawSingleElement(uint8_t item)
             char *p = "ACRO";
 
             if (isAirmodeActive())
-                p = "AIR";
+                p = " AIR";
 
             if (FLIGHT_MODE(FAILSAFE_MODE))
                 p = "!FS!";
             else if (FLIGHT_MODE(ANGLE_MODE))
                 p = "STAB";
             else if (FLIGHT_MODE(HORIZON_MODE))
-                p = "HOR";
+                p = " HOR";
 
-            displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
-            return;
+            strcpy(buff, p);
+            break;
         }
 
     case OSD_CRAFT_NAME:
         if (strlen(pilotConfig()->name) == 0)
-            strcpy(buff, "CRAFT_NAME");
+            strcpy(buff, "   CRAFT_NAME   ");
         else {
+            memset(buff, ' ', MAX_NAME_LENGTH);
             for (int i = 0; i < MAX_NAME_LENGTH; i++) {
-                buff[i] = toupper((unsigned char)pilotConfig()->name[i]);
-                if (pilotConfig()->name[i] == 0)
+                if (pilotConfig()->name[i] == 0){
                     break;
+                }
+                buff[i] = toupper((unsigned char)pilotConfig()->name[i]);
             }
+            buff[MAX_NAME_LENGTH-1] = 0;
         }
         break;
 
     case OSD_THROTTLE_POS:
         buff[0] = SYM_THR;
         buff[1] = SYM_THR1;
-        tfp_sprintf(buff + 2, "%d", (constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN));
+        tfp_sprintf(buff + 2, "%3d", (constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN));
         break;
 
 #if defined(VTX_COMMON)
@@ -502,6 +562,16 @@ static void osdDrawSingleElement(uint8_t item)
             // Convert pitchAngle to y compensation value
             pitchAngle = (pitchAngle / 8) - 41; // 41 = 4 * 9 + 5
 
+            // clear the area before writing the new horizon characters
+            for (int y = 0; y <= 7; y++) {
+                displayWrite(osdDisplayPort, elemPosX - 4, elemPosY+y, "         ");
+            }
+
+            // if not visible: abort after clearing here
+            if (!VISIBLE(osdConfig()->item_pos[item])){
+                return;
+            }
+
             for (int x = -4; x <= 4; x++) {
                 int y = (-rollAngle * x) / 64;
                 y -= pitchAngle;
@@ -510,8 +580,6 @@ static void osdDrawSingleElement(uint8_t item)
                     displayWriteChar(osdDisplayPort, elemPosX + x, elemPosY + (y / 9), (SYM_AH_BAR9_0 + (y % 9)));
                 }
             }
-
-            osdDrawSingleElement(OSD_HORIZON_SIDEBARS);
 
             return;
         }
@@ -529,13 +597,27 @@ static void osdDrawSingleElement(uint8_t item)
             const int8_t hudwidth = AH_SIDEBAR_WIDTH_POS;
             const int8_t hudheight = AH_SIDEBAR_HEIGHT_POS;
             for (int y = -hudheight; y <= hudheight; y++) {
-                displayWriteChar(osdDisplayPort, elemPosX - hudwidth, elemPosY + y, SYM_AH_DECORATION);
-                displayWriteChar(osdDisplayPort, elemPosX + hudwidth, elemPosY + y, SYM_AH_DECORATION);
+                if (!VISIBLE(osdConfig()->item_pos[item])){
+                    // clear sidebars
+                    displayWriteChar(osdDisplayPort, elemPosX - hudwidth, elemPosY + y, ' ');
+                    displayWriteChar(osdDisplayPort, elemPosX + hudwidth, elemPosY + y, ' ');
+                } else {
+                    // show sidebars
+                    displayWriteChar(osdDisplayPort, elemPosX - hudwidth, elemPosY + y, SYM_AH_DECORATION);
+                    displayWriteChar(osdDisplayPort, elemPosX + hudwidth, elemPosY + y, SYM_AH_DECORATION);
+                }
             }
 
             // AH level indicators
-            displayWriteChar(osdDisplayPort, elemPosX - hudwidth + 1, elemPosY, SYM_AH_LEFT);
-            displayWriteChar(osdDisplayPort, elemPosX + hudwidth - 1, elemPosY, SYM_AH_RIGHT);
+            if (!VISIBLE(osdConfig()->item_pos[item])){
+                // not visible -> clear
+                displayWriteChar(osdDisplayPort, elemPosX - hudwidth + 1, elemPosY, ' ');
+                displayWriteChar(osdDisplayPort, elemPosX + hudwidth - 1, elemPosY, ' ');
+            } else {
+                // render bars
+                displayWriteChar(osdDisplayPort, elemPosX - hudwidth + 1, elemPosY, SYM_AH_LEFT);
+                displayWriteChar(osdDisplayPort, elemPosX + hudwidth - 1, elemPosY, SYM_AH_RIGHT);
+            }
 
             return;
         }
@@ -562,7 +644,7 @@ static void osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_POWER:
-        tfp_sprintf(buff, "%dW", getAmperage() * getBatteryVoltage() / 1000);
+        tfp_sprintf(buff, "%4dW", getAmperage() * getBatteryVoltage() / 1000);
         break;
 
     case OSD_PIDRATE_PROFILE:
@@ -579,7 +661,7 @@ static void osdDrawSingleElement(uint8_t item)
             const armingDisableFlags_e flags = getArmingDisableFlags();
             for (int i = 0; i < NUM_ARMING_DISABLE_FLAGS; i++) {
                 if (flags & (1 << i)) {
-                    tfp_sprintf(buff, "%s", armingDisableFlagNames[i]);
+                    tfp_sprintf(buff, "%11s", armingDisableFlagNames[i]);
                     break;
                 }
             }
@@ -593,18 +675,18 @@ static void osdDrawSingleElement(uint8_t item)
             break;
 
         case BATTERY_CRITICAL:
-            tfp_sprintf(buff, " LAND NOW");
+            tfp_sprintf(buff, " LAND NOW  ");
             break;
 
         default:
             /* Show visual beeper if battery is OK */
             if (showVisualBeeper) {
-                tfp_sprintf(buff, "  * * * *");
+                tfp_sprintf(buff, "  * * * *  ");
+                showVisualBeeper = false;
             } else {
-                return;
+                tfp_sprintf(buff, "           ");
             }
             break;
-
         }
         break;
 
@@ -661,10 +743,10 @@ static void osdDrawSingleElement(uint8_t item)
     case OSD_DISARMED:
         if (!ARMING_FLAG(ARMED)) {
             tfp_sprintf(buff, "DISARMED");
-            break;
         } else {
-            return;
+            tfp_sprintf(buff, "        ");
         }
+        break;
 
     case OSD_NUMERICAL_HEADING:
         {
@@ -683,11 +765,11 @@ static void osdDrawSingleElement(uint8_t item)
 #ifdef USE_ESC_SENSOR
     case OSD_ESC_TMP:
         buff[0] = SYM_TEMP_C;
-        tfp_sprintf(buff + 1, "%d", escData == NULL ? 0 : escData->temperature);
+        tfp_sprintf(buff + 1, "%3d", escData == NULL ? 0 : escData->temperature);
         break;
 
     case OSD_ESC_RPM:
-        tfp_sprintf(buff, "%d", escData == NULL ? 0 : escData->rpm);
+        tfp_sprintf(buff, "%5d", escData == NULL ? 0 : escData->rpm);
         break;
 #endif
 
@@ -695,66 +777,18 @@ static void osdDrawSingleElement(uint8_t item)
         return;
     }
 
+    if (BLINK(item)) {
+        // this item should be invisible right now because it blinks
+        // send "empty" string to clear previously used space
+        char *bptr = buff;
+        while (*bptr) {
+            *bptr++ = ' ';
+        }
+    }
+
+    // send prepared string to display at given position
     displayWrite(osdDisplayPort, elemPosX + elemOffsetX, elemPosY, buff);
-}
 
-static void osdDrawElements(void)
-{
-    displayClearScreen(osdDisplayPort);
-
-    /* Hide OSD when OSDSW mode is active */
-    if (IS_RC_MODE_ACTIVE(BOXOSD))
-      return;
-
-    if (sensors(SENSOR_ACC)) {
-        osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
-    }
-
-    osdDrawSingleElement(OSD_MAIN_BATT_VOLTAGE);
-    osdDrawSingleElement(OSD_RSSI_VALUE);
-    osdDrawSingleElement(OSD_CROSSHAIRS);
-    osdDrawSingleElement(OSD_ITEM_TIMER_1);
-    osdDrawSingleElement(OSD_ITEM_TIMER_2);
-    osdDrawSingleElement(OSD_FLYMODE);
-    osdDrawSingleElement(OSD_THROTTLE_POS);
-    osdDrawSingleElement(OSD_VTX_CHANNEL);
-    osdDrawSingleElement(OSD_CURRENT_DRAW);
-    osdDrawSingleElement(OSD_MAH_DRAWN);
-    osdDrawSingleElement(OSD_CRAFT_NAME);
-    osdDrawSingleElement(OSD_ALTITUDE);
-    osdDrawSingleElement(OSD_ROLL_PIDS);
-    osdDrawSingleElement(OSD_PITCH_PIDS);
-    osdDrawSingleElement(OSD_YAW_PIDS);
-    osdDrawSingleElement(OSD_POWER);
-    osdDrawSingleElement(OSD_PIDRATE_PROFILE);
-    osdDrawSingleElement(OSD_WARNINGS);
-    osdDrawSingleElement(OSD_AVG_CELL_VOLTAGE);
-    osdDrawSingleElement(OSD_DEBUG);
-    osdDrawSingleElement(OSD_PITCH_ANGLE);
-    osdDrawSingleElement(OSD_ROLL_ANGLE);
-    osdDrawSingleElement(OSD_MAIN_BATT_USAGE);
-    osdDrawSingleElement(OSD_DISARMED);
-    osdDrawSingleElement(OSD_NUMERICAL_HEADING);
-    osdDrawSingleElement(OSD_NUMERICAL_VARIO);
-    osdDrawSingleElement(OSD_COMPASS_BAR);
-
-#ifdef GPS
-    if (sensors(SENSOR_GPS)) {
-        osdDrawSingleElement(OSD_GPS_SATS);
-        osdDrawSingleElement(OSD_GPS_SPEED);
-        osdDrawSingleElement(OSD_GPS_LAT);
-        osdDrawSingleElement(OSD_GPS_LON);
-        osdDrawSingleElement(OSD_HOME_DIST);
-        osdDrawSingleElement(OSD_HOME_DIR);
-    }
-#endif // GPS
-
-#ifdef USE_ESC_SENSOR
-  if (feature(FEATURE_ESC_SENSOR)) {
-      osdDrawSingleElement(OSD_ESC_TMP);
-      osdDrawSingleElement(OSD_ESC_RPM);
-  }
-#endif
 }
 
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)
@@ -762,7 +796,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_RSSI_VALUE]         = OSD_POS(8, 1)   | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_MAIN_BATT_VOLTAGE]  = OSD_POS(12, 1)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_CROSSHAIRS]         = OSD_POS(8, 6)   | VISIBLE_FLAG;
-    osdConfig->item_pos[OSD_ARTIFICIAL_HORIZON] = OSD_POS(8, 6)   | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_ARTIFICIAL_HORIZON] = OSD_POS(8, 6)   | (sensors(SENSOR_ACC)?VISIBLE_FLAG:0);
     osdConfig->item_pos[OSD_HORIZON_SIDEBARS]   = OSD_POS(8, 6)   | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ITEM_TIMER_1]       = OSD_POS(22, 1)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ITEM_TIMER_2]       = OSD_POS(1, 1)   | VISIBLE_FLAG;
@@ -772,8 +806,15 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_VTX_CHANNEL]        = OSD_POS(25, 11) | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_CURRENT_DRAW]       = OSD_POS(1, 12)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_MAH_DRAWN]          = OSD_POS(1, 11)  | VISIBLE_FLAG;
+#ifdef GPS
     osdConfig->item_pos[OSD_GPS_SPEED]          = OSD_POS(26, 6)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_GPS_SATS]           = OSD_POS(19, 1)  | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_GPS_LAT]            = OSD_POS(1, 2)   | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_GPS_LON]            = OSD_POS(18, 2)  | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_HOME_DIST]          = OSD_POS(15, 9)  | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_HOME_DIR]           = OSD_POS(14, 9)  | VISIBLE_FLAG;
+#endif
+
     osdConfig->item_pos[OSD_ALTITUDE]           = OSD_POS(23, 7)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ROLL_PIDS]          = OSD_POS(7, 13)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_PITCH_PIDS]         = OSD_POS(7, 14)  | VISIBLE_FLAG;
@@ -785,17 +826,16 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_DEBUG]              = OSD_POS(1, 0)   | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_PITCH_ANGLE]        = OSD_POS(1, 8)   | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ROLL_ANGLE]         = OSD_POS(1, 9)   | VISIBLE_FLAG;
-    osdConfig->item_pos[OSD_GPS_LAT]            = OSD_POS(1, 2)   | VISIBLE_FLAG;
-    osdConfig->item_pos[OSD_GPS_LON]            = OSD_POS(18, 2)  | VISIBLE_FLAG;
-    osdConfig->item_pos[OSD_HOME_DIST]          = OSD_POS(15, 9)  | VISIBLE_FLAG;
-    osdConfig->item_pos[OSD_HOME_DIR]           = OSD_POS(14, 9)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_COMPASS_BAR]        = OSD_POS(10, 8)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_MAIN_BATT_USAGE]    = OSD_POS(8, 12)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_DISARMED]           = OSD_POS(10, 4)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_NUMERICAL_HEADING]  = OSD_POS(23, 9)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_NUMERICAL_VARIO]    = OSD_POS(23, 8)  | VISIBLE_FLAG;
+
+#ifdef USE_ESC_SENSOR
     osdConfig->item_pos[OSD_ESC_TMP]            = OSD_POS(18, 2)  | VISIBLE_FLAG;
     osdConfig->item_pos[OSD_ESC_RPM]            = OSD_POS(19, 2)  | VISIBLE_FLAG;
+#endif
 
     osdConfig->enabled_stats[OSD_STAT_MAX_SPEED]       = true;
     osdConfig->enabled_stats[OSD_STAT_MIN_BATTERY]     = true;
@@ -843,6 +883,8 @@ void osdInit(displayPort_t *osdDisplayPortToUse)
 #ifdef CMS
     cmsDisplayPortRegister(osdDisplayPort);
 #endif
+
+    osdCurrentElementIndex = 0;
 
     armState = ARMING_FLAG(ARMED);
 
@@ -1138,6 +1180,7 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
         if (cmp32(currentTimeUs, resumeRefreshAt) < 0) {
             // in timeout period, check sticks for activity to resume display.
             if (IS_HI(THROTTLE) || IS_HI(PITCH)) {
+                displayClearScreen(osdDisplayPort);
                 resumeRefreshAt = 0;
             }
 
@@ -1147,25 +1190,31 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
             displayClearScreen(osdDisplayPort);
             resumeRefreshAt = 0;
         }
-    }
-
-    blinkState = (currentTimeUs / 200000) % 2;
+    } else {
+        blinkState = (currentTimeUs / 200000) % 2;
 
 #ifdef USE_ESC_SENSOR
-    if (feature(FEATURE_ESC_SENSOR)) {
-        escData = getEscSensorData(ESC_SENSOR_COMBINED);
-    }
+        if (feature(FEATURE_ESC_SENSOR)) {
+            escData = getEscSensorData(ESC_SENSOR_COMBINED);
+        }
 #endif
 
 #ifdef CMS
-    if (!displayIsGrabbed(osdDisplayPort)) {
-        osdUpdateAlarms();
-        osdDrawElements();
-        displayHeartbeat(osdDisplayPort);
+        if (!displayIsGrabbed(osdDisplayPort)) {
+            osdUpdateAlarms();
+
+            if (! IS_RC_MODE_ACTIVE(BOXOSD)) {
+                // draw single element
+                osdDrawSingleElement(osdCurrentElementIndex);
+                osdCurrentElementIndex = osdIncElementIndex(osdCurrentElementIndex);
+            }
+
+            displayHeartbeat(osdDisplayPort);
 #ifdef OSD_CALLS_CMS
-    } else {
-        cmsUpdate(currentTimeUs);
+        } else {
+            cmsUpdate(currentTimeUs);
 #endif
+        }
     }
 #endif
 }
@@ -1175,8 +1224,6 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
  */
 void osdUpdate(timeUs_t currentTimeUs)
 {
-    static uint32_t counter = 0;
-
     if (isBeeperOn()) {
         showVisualBeeper = true;
     }
@@ -1188,13 +1235,6 @@ void osdUpdate(timeUs_t currentTimeUs)
     }
 #endif // MAX7456_DMA_CHANNEL_TX
 
-    // redraw values in buffer
-#ifdef USE_MAX7456
-#define DRAW_FREQ_DENOM 5
-#else
-#define DRAW_FREQ_DENOM 10 // MWOSD @ 115200 baud (
-#endif
-
 #ifdef USE_SLOW_MSP_DISPLAYPORT_RATE_WHEN_UNARMED
     static uint32_t idlecounter = 0;
     if (!ARMING_FLAG(ARMED)) {
@@ -1204,13 +1244,8 @@ void osdUpdate(timeUs_t currentTimeUs)
     }
 #endif
 
-    if (counter++ % DRAW_FREQ_DENOM == 0) {
-        osdRefresh(currentTimeUs);
-
-        showVisualBeeper = false;
-    } else { // rest of time redraw screen 10 chars per idle so it doesn't lock the main idle
-        displayDrawScreen(osdDisplayPort);
-    }
+    // fill screen element by element (one each call)
+    osdRefresh(currentTimeUs);
 
 #ifdef CMS
     // do not allow ARM if we are in menu

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -310,15 +310,12 @@ static uint8_t osdIncElementIndex(uint8_t elementIndex) {
         // check for visibility
         if (VISIBLE(osdConfig()->item_pos[elementIndex])) {
             // found next visible item
-            break;
+            return elementIndex;
         }
     }
-    if (max_inc == 0) {
-        // no osd item is visible
-        elementIndex = OSD_ITEM_COUNT;
-    }
 
-    return elementIndex;
+    // no item found
+    return OSD_ITEM_COUNT;
 }
 
 static void osdDrawSingleElement(uint8_t item)

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -21,6 +21,8 @@
 #include "common/time.h"
 #include "config/parameter_group.h"
 
+#define OSD_TASK_FREQUENCY_HZ   100
+
 #define OSD_NUM_TIMER_TYPES 3
 extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 
@@ -145,6 +147,8 @@ extern uint32_t resumeRefreshAt;
 PG_DECLARE(osdConfig_t, osdConfig);
 
 struct displayPort_s;
+extern struct displayPort_s *osdDisplayPort;
+
 void osdInit(struct displayPort_s *osdDisplayPort);
 void osdResetConfig(osdConfig_t *osdProfile);
 void osdResetAlarms(void);

--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -63,11 +63,11 @@ PG_RESET_TEMPLATE(vtxRTC6705Config_t, vtxRTC6705Config,
 #if defined(CMS) || defined(VTX_COMMON)
 #ifdef RTC6705_POWER_PIN
 static const char * const rtc6705PowerNames[RTC6705_POWER_COUNT] = {
-    "---", "25 ", "200",
+    "---", " 25 ", "200",
 };
 #else
 static const char * const rtc6705PowerNames[RTC6705_POWER_COUNT] = {
-    "25 ", "200",
+    " 25 ", "200",
 };
 #endif
 #endif

--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -63,11 +63,11 @@ PG_RESET_TEMPLATE(vtxRTC6705Config_t, vtxRTC6705Config,
 #if defined(CMS) || defined(VTX_COMMON)
 #ifdef RTC6705_POWER_PIN
 static const char * const rtc6705PowerNames[RTC6705_POWER_COUNT] = {
-    "---", " 25 ", "200",
+    "---", " 25", "200",
 };
 #else
 static const char * const rtc6705PowerNames[RTC6705_POWER_COUNT] = {
-    " 25 ", "200",
+    " 25", "200",
 };
 #endif
 #endif

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -76,7 +76,7 @@ static serialPort_t *smartAudioSerialPort = NULL;
 
 #if defined(CMS) || defined(VTX_COMMON)
 static const char * const saPowerNames[] = {
-    "---", "25 ", "200", "500", "800",
+    "---", " 25 ", "200", "500", "800",
 };
 #endif
 

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -45,7 +45,7 @@ static const uint16_t trampPowerTable[] = {
 };
 
 static const char * const trampPowerNames[] = {
-    "---", "25 ", "100", "200", "400", "600"
+    "---", " 25 ", "100", "200", "400", "600"
 };
 #endif
 

--- a/src/test/unit/unittest_displayport.h
+++ b/src/test/unit/unittest_displayport.h
@@ -26,6 +26,10 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
+extern "C" {
+    extern uint32_t micros();
+};
+
 void displayPortTestBufferSubstring(int x, int y, const char * expectedFormat, ...) __attribute__ ((format (printf, 3, 4)));
 
 #define UNITTEST_DISPLAYPORT_ROWS 16
@@ -70,6 +74,9 @@ static int displayPortTestScreenSize(const displayPort_t *displayPort)
 static int displayPortTestWriteString(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *s)
 {
     UNUSED(displayPort);
+#ifdef DEBUG_OSD
+    printf("@%10d: writing %2d %2d '%s'\n",micros(),x, y, s);
+#endif
     for (unsigned int i = 0; i < strlen(s); i++) {
         testDisplayPortBuffer[(y * UNITTEST_DISPLAYPORT_COLS) + x + i] = s[i];
     }
@@ -159,7 +166,20 @@ void displayPortTestBufferSubstring(int x, int y, const char * expectedFormat, .
     displayPortTestPrint();
 #endif
 
+    bool success = true;
     for (size_t i = 0; i < strlen(expected); i++) {
+        if (expected[i] != testDisplayPortBuffer[(y * testDisplayPort.cols) + x + i]){
+            success = false;
+        }
         EXPECT_EQ(expected[i], testDisplayPortBuffer[(y * testDisplayPort.cols) + x + i]);
+    }
+    if (!success){
+        char fbuf[256];
+        strncpy(fbuf, &testDisplayPortBuffer[(y * testDisplayPort.cols) + x], 256);
+        fbuf[strlen(expected)] = 0;
+        std::cout << "displayPortTestBufferSubstring("
+             << (int)x << ", "
+             << (int)y << ", '"
+             << expected << "') failed! got '" << fbuf << "' instead\n";
     }
 }


### PR DESCRIPTION
based on https://github.com/iNavFlight/inav/pull/1831

@martinbudden:
All osd elements have a fixed length now.
I reworked the blink code to clear the necessary characters.
I modified the flow a bit, instead of using #ifdef guards for not printing e.g. gps data
I use the visibility flag to skip those items in osdIncElementIndex.

I fixed the unit test to actually use the simulation time. 
Not tested on FC yet.

By using this we could probably live without the char double buffer in the max7456 implementation!
This will save ~1k of ram and probably some flash as well.