### PR TITLE
BLUEJAYF4 Add appropriate I2C1 pin assignments

### DIFF
--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -140,6 +140,8 @@
 #define USE_I2C
 #define USE_I2C_DEVICE_1
 #define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
 #define USE_I2C_PULLUP
 
 #define USE_ADC


### PR DESCRIPTION
PR status: Ready to merge

I2C1 default pins are PB6 and PB7. Board has it on PB8 and PB9 (has to explicitly specify in target.h).