### PR TITLE
MS5611 Wow ... don't set spi clock divisor against plain i/o port...

### DIFF
--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -98,7 +98,7 @@ void ms5611BusInit(busDevice_t *busdev)
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
         IOHi(busdev->busdev_u.spi.csnPin); // Disable
-        spiSetDivisor(busdev->busdev_u.spi.csnPin, SPI_CLOCK_STANDARD);
+        spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
     UNUSED(busdev);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -64,7 +64,7 @@ void pgResetFn_barometerConfig(barometerConfig_t *barometerConfig)
     //   a. Precedence is in the order of popularity; BMP280, MS5611 then BMP085, then
     //   b. If SPI variant is specified, it is likely onboard, so take it.
 
-#if !(defined(DEFAULT_BARO_SPI_BMP280) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_SPI_MS5611) || defined(DEFAULT_BARO_BARO_MS5611) || defined(DEFAULT_BARO_BMP085))
+#if !(defined(DEFAULT_BARO_SPI_BMP280) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_SPI_MS5611) || defined(DEFAULT_BARO_MS5611) || defined(DEFAULT_BARO_BMP085))
 #if defined(USE_BARO_BMP280) || defined(USE_BARO_SPI_BMP280)
 #if defined(USE_BARO_SPI_BMP280)
 #define DEFAULT_BARO_SPI_BMP280


### PR DESCRIPTION
PR status: Ready to merge

Device initialization for SPI connected MS5611 was mistakenly using `busdev_u.spi.csnPin` for call to `spiSetDivisor`. Correct parameter is `busdev_u.spi.instance`.

This stupidity was preventing MS5611 on SPI from being detected, and also caused BMP280 on SPI that is configured to have overlapping CS line from being detected by clobbering the CS line i/o completely prior to `bmp280Detect`.