### PR TITLE
Fix MSP_SET_SERVO_CONFIGURATION data length

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1447,7 +1447,7 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 
     case MSP_SET_SERVO_CONFIGURATION:
 #ifdef USE_SERVOS
-        if (dataSize != 1 + 14) {
+        if (dataSize != 1 + 12) {
             return MSP_RESULT_ERROR;
         }
         i = sbufReadU8(src);


### PR DESCRIPTION
PR status: Ready to merge

Fixes #3540 and betaflight/betaflight-configurator#555.

Trivial bug introduced when angleAtMin and angleAtMax was deleted in #2737.
Should have been caught if configurator was tested (should have came up as a length error).