### PR TITLE
Decrease default failsafe delay

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -60,7 +60,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CO
 PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_throttle = 1000,                       // default throttle off.
     .failsafe_throttle_low_delay = 100,              // default throttle low delay for "just disarm" on failsafe condition
-    .failsafe_delay = 10,                            // 1sec
+    .failsafe_delay = 4,                             // 0,4sec
     .failsafe_off_delay = 10,                        // 1sec
     .failsafe_kill_switch = 0,                       // default failsafe switch action is identical to rc link loss
     .failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT // default full failsafe procedure is 0: auto-landing


### PR DESCRIPTION
Answer to issue
https://github.com/betaflight/betaflight/issues/3749

Default failsafe delay used to be 1,2sec and is reduced now to 0,6sec
`failsafeState.rxDataFailurePeriod = PERIOD_RXDATA_FAILURE + failsafeConfig()->failsafe_delay * MILLIS_PER_TENTH_SECOND;`