### PR TITLE
Re-add spi flash support for MOTOLAB target

### DIFF
--- a/src/main/target/MOTOLAB/target.mk
+++ b/src/main/target/MOTOLAB/target.mk
@@ -4,5 +4,6 @@ FEATURES    = VCP ONBOARDFLASH
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_mpu6050.c \
-            drivers/accgyro/accgyro_spi_mpu6000.c
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/flash_m25p16.c
 


### PR DESCRIPTION
Some MOTOLAB (F3) targets have spi flash onboard.