### PR TITLE
BLUEJAYF4 Add provision for UART4 over motor outputs 1 & 2

### DIFF
--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -112,13 +112,19 @@
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 
+// Provisioning for UART4 on motor outputs 1 & 2
+// Keep pins NONE here to avoid UART4 showing up unless explicitly resource-mapped.
+#define USE_UART4
+#define UART4_RX_PIN            NONE // PA1
+#define UART4_TX_PIN            NONE // PA0
+
 #define USE_SOFTSERIAL1
 #define SOFTSERIAL1_RX_PIN      PB0 // PWM5
 #define SOFTSERIAL1_TX_PIN      PB1 // PWM6
 
 #define USE_SOFTSERIAL2
 
-#define SERIAL_PORT_COUNT       6
+#define SERIAL_PORT_COUNT       7
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PC7  // (HARDARE=0,PPM)


### PR DESCRIPTION
PR status: Need testing

- UART4 pins are kept to NONE to avoid UART4 showing up as an usable UART unless explicitly resource-mapped by
```
resource serial_tx 4 a0
resource serial_rx 4 a1
```
- Motor output will be shifted by two and goes on to motor outputs 3, 4, 5 and 6 (a2, a3, b0 and b1 respectively). Users can use resource command to map these pins to suit their actual wiring.

- LED strip can goto DEBUG pad (b3) if necessary.