### PR TITLE
Set camera_control_key_delay_ms default to 180 ms

### DIFF
--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -62,7 +62,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig, PG_C
 PG_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig,
     .mode = CAMERA_CONTROL_MODE_HARDWARE_PWM,
     .refVoltage = 330,
-    .keyDelayMs = 150,
+    .keyDelayMs = 180,
     .ioTag = IO_TAG(CAMERA_CONTROL_PIN)
 );
 


### PR DESCRIPTION
This change has been approved by @azolyoung from RunCam, suggesting that 180ms should be OK for most cameras.