### PR TITLE
Converting BST to newer IO driver

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -157,7 +157,6 @@ void processLoopback(void)
 #endif
 }
 
-
 #ifdef VTX_RTC6705
 bool canUpdateVTX(void)
 {

--- a/src/main/target/COLIBRI_RACE/target.c
+++ b/src/main/target/COLIBRI_RACE/target.c
@@ -62,6 +62,8 @@ void targetBusInit(void)
 #endif
 
     i2cHardwareConfigure();
+    i2cInit(I2CDEV_2);
+    
     bstInit(BST_DEVICE);
 }
 #endif

--- a/src/main/target/COLIBRI_RACE/target.h
+++ b/src/main/target/COLIBRI_RACE/target.h
@@ -20,7 +20,7 @@
 #define TARGET_BOARD_IDENTIFIER "CLBR"
 #define BST_DEVICE_NAME         "COLIBRI RACE"
 #define BST_DEVICE_NAME_LENGTH  12
-//#define TARGET_BUS_INIT
+#define TARGET_BUS_INIT
 
 #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_DEFAULT
 
@@ -105,10 +105,10 @@
 #define I2C2_SCL_PIN            PA9
 #define I2C2_SDA_PIN            PA10
 
-//#define USE_BST
-//#define BST_DEVICE              (BSTDEV_1)
+#define USE_BST
+#define BST_DEVICE              (BSTDEV_1)
 /* Configure the CRC peripheral to use the polynomial x8 + x7 + x6 + x4 + x2 + 1 */
-//#define BST_CRC_POLYNOM         0xD5
+#define BST_CRC_POLYNOM         0xD5
 
 #define USE_ADC
 #define ADC_INSTANCE            ADC1


### PR DESCRIPTION
Fix for colibri race target, updated BST interface to utilise newer IO driver, and improve in preparation for v3.3 and reduced target footprint.