### PR TITLE
Make Dshot reversing command being sent conditional on DSHOT_REVERSE mode being configured (unconfiguring it fixes problem with BLHeli_S 16.62).

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -227,7 +227,7 @@ void tryArm(void)
             return;
         }
 #ifdef USE_DSHOT
-        if (isMotorProtocolDshot()) {
+        if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXDSHOTREVERSE)) {
             if (!IS_RC_MODE_ACTIVE(BOXDSHOTREVERSE)) {
                 reverseMotors = false;
                 for (unsigned index = 0; index < getMotorCount(); index++) {


### PR DESCRIPTION
(We should probably go through the other modes and add check to only execute mode dependent code when the mode is configured in other places as well.)