### PR TITLE
PID sum limits applied before scaling

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -120,9 +120,6 @@ float motor_disarmed[MAX_SUPPORTED_MOTORS];
 mixerMode_e currentMixerMode;
 static motorMixer_t currentMixer[MAX_SUPPORTED_MOTORS];
 
-float pidSumLimit;
-float pidSumLimitYaw;
-
 
 static const motorMixer_t mixerQuadX[] = {
     { 1.0f, -1.0f,  1.0f, -1.0f },          // REAR_R
@@ -379,12 +376,6 @@ void mixerInit(mixerMode_e mixerMode)
     initEscEndpoints();
 }
 
-void pidInitMixer(const struct pidProfile_s *pidProfile)
-{
-    pidSumLimit = CONVERT_PARAMETER_TO_FLOAT(pidProfile->pidSumLimit);
-    pidSumLimitYaw = CONVERT_PARAMETER_TO_FLOAT(pidProfile->pidSumLimitYaw);
-}
-
 #ifndef USE_QUAD_MIXER_ONLY
 
 void mixerConfigureOutput(void)
@@ -591,11 +582,11 @@ void mixTable(uint8_t vbatPidCompensation)
 
     // Calculate and Limit the PIDsum
     float scaledAxisPidRoll =
-        constrainf(axisPID_P[FD_ROLL] + axisPID_I[FD_ROLL] + axisPID_D[FD_ROLL], -pidSumLimit, pidSumLimit) / PID_MIXER_SCALING;
+        constrainf(axisPID_P[FD_ROLL] + axisPID_I[FD_ROLL] + axisPID_D[FD_ROLL], -currentPidProfile->pidSumLimit, currentPidProfile->pidSumLimit) / PID_MIXER_SCALING;
     float scaledAxisPidPitch =
-        constrainf(axisPID_P[FD_PITCH] + axisPID_I[FD_PITCH] + axisPID_D[FD_PITCH], -pidSumLimit, pidSumLimit) / PID_MIXER_SCALING;
+        constrainf(axisPID_P[FD_PITCH] + axisPID_I[FD_PITCH] + axisPID_D[FD_PITCH], -currentPidProfile->pidSumLimit, currentPidProfile->pidSumLimit) / PID_MIXER_SCALING;
     float scaledAxisPidYaw =
-        constrainf(axisPID_P[FD_YAW] + axisPID_I[FD_YAW], -pidSumLimitYaw, pidSumLimitYaw) / PID_MIXER_SCALING;
+        constrainf(axisPID_P[FD_YAW] + axisPID_I[FD_YAW], -currentPidProfile->pidSumLimitYaw, currentPidProfile->pidSumLimitYaw) / PID_MIXER_SCALING;
     if (isMotorsReversed()) {
         scaledAxisPidRoll = -scaledAxisPidRoll;
         scaledAxisPidPitch = -scaledAxisPidPitch;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -591,17 +591,17 @@ void mixTable(uint8_t vbatPidCompensation)
 
     // Calculate and Limit the PIDsum
     float scaledAxisPidRoll =
-        constrainf((axisPID_P[FD_ROLL] + axisPID_I[FD_ROLL] + axisPID_D[FD_ROLL]) / PID_MIXER_SCALING, -pidSumLimit, pidSumLimit);
+        constrainf(axisPID_P[FD_ROLL] + axisPID_I[FD_ROLL] + axisPID_D[FD_ROLL], -pidSumLimit, pidSumLimit) / PID_MIXER_SCALING;
     float scaledAxisPidPitch =
-        constrainf((axisPID_P[FD_PITCH] + axisPID_I[FD_PITCH] + axisPID_D[FD_PITCH]) / PID_MIXER_SCALING, -pidSumLimit, pidSumLimit);
+        constrainf(axisPID_P[FD_PITCH] + axisPID_I[FD_PITCH] + axisPID_D[FD_PITCH], -pidSumLimit, pidSumLimit) / PID_MIXER_SCALING;
     float scaledAxisPidYaw =
-        -constrainf((axisPID_P[FD_YAW] + axisPID_I[FD_YAW]) / PID_MIXER_SCALING, -pidSumLimitYaw, pidSumLimitYaw);
+        constrainf(axisPID_P[FD_YAW] + axisPID_I[FD_YAW], -pidSumLimitYaw, pidSumLimitYaw) / PID_MIXER_SCALING;
     if (isMotorsReversed()) {
         scaledAxisPidRoll = -scaledAxisPidRoll;
         scaledAxisPidPitch = -scaledAxisPidPitch;
         scaledAxisPidYaw = -scaledAxisPidYaw;
     }
-    if (mixerConfig()->yaw_motors_reversed) {
+    if (!mixerConfig()->yaw_motors_reversed) {
         scaledAxisPidYaw = -scaledAxisPidYaw;
     }
 

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -113,8 +113,6 @@ bool mixerIsOutputSaturated(int axis, float errorRate);
 
 void mixerLoadMix(int index, motorMixer_t *customMixers);
 void mixerInit(mixerMode_e mixerMode);
-struct pidProfile_s;
-void pidInitMixer(const struct pidProfile_s *pidProfile);
 
 void mixerConfigureOutput(void);
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -290,7 +290,6 @@ void pidInit(const pidProfile_t *pidProfile)
     pidSetTargetLooptime(gyro.targetLooptime * pidConfig()->pid_process_denom); // Initialize pid looptime
     pidInitFilters(pidProfile);
     pidInitConfig(pidProfile);
-    pidInitMixer(pidProfile);
 }
 
 // calculates strength of horizon leveling; 0 = none, 1.0 = most leveling


### PR DESCRIPTION
I was thinking about the "Yaw spin to the moon" problem and thought that surely the yaw PIDsum limit should prevent this. So I had a look at the code. I think the limiting is applied incorrectly, namely it is applied after the scaling and so would never take effect.

I'm not 100% sure about this though. @mikeller , @borisbstyle could you check?