### PR TITLE
Fix RSSI_SCALE_DEFAULT to 100% @ 1023

### DIFF
--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -82,7 +82,7 @@ extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2
 
 #define RSSI_SCALE_MIN 1
 #define RSSI_SCALE_MAX 255
-#define RSSI_SCALE_DEFAULT 30
+#define RSSI_SCALE_DEFAULT (0xFFF / 100.0f) // 100% @ 1023
 
 typedef enum {
     RX_FAILSAFE_MODE_AUTO = 0,


### PR DESCRIPTION
PR status: For discussion

`RSSI_SCALE_DEFAULT` should be 100% @ 1023 (3.3V full scale).

Was there any reason for this to be 30, which is rather small (RSSI percentage value will saturate at around 30%)?