### PR TITLE
Change RSSI_SCALE_DEFAULT to 100% @ 4095

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -617,7 +617,6 @@ static void updateRSSIPWM(void)
 }
 
 #define RSSI_ADC_SAMPLE_COUNT 16
-//#define RSSI_SCALE (0xFFF / 100.0f)
 
 static void updateRSSIADC(timeUs_t currentTimeUs)
 {

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -82,7 +82,7 @@ extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2
 
 #define RSSI_SCALE_MIN 1
 #define RSSI_SCALE_MAX 255
-#define RSSI_SCALE_DEFAULT 30
+#define RSSI_SCALE_DEFAULT (4095.0f / 100.0f + 0.5f) // 100% @ 4095
 
 typedef enum {
     RX_FAILSAFE_MODE_AUTO = 0,


### PR DESCRIPTION
PR status: Ready to merge

The `RSSI_SCALE_DEFAULT` is defined as 30, which makes 2.4V as 100%.
Should be 41-ish (4095.0f/100.0f + 0.5).

Is there any historical reason to set 2.4V as 100%?