### PR TITLE
fixed typo for f4 openocd config

### DIFF
--- a/make/openocd.mk
+++ b/make/openocd.mk
@@ -5,7 +5,7 @@ ifeq ($(TARGET_MCU),STM32F3)
 OPENOCD_CFG := target/stm32f3x.cfg
 
 else ifeq ($(TARGET_MCU),STM32F4)
-OPENOCD_CFG := target/stm32f34.cfg
+OPENOCD_CFG := target/stm32f4x.cfg
 
 else ifeq ($(TARGET_MCU),STM32F7)
 OPENOCD_CFG := target/stm32f7x.cfg


### PR DESCRIPTION
this fixes a typo for make openocd-gdb