### PR TITLE
Fix for potential dangerous MIN/MAX/ABS macros?

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -37,9 +37,17 @@
 
 #define CM_S_TO_KM_H(centimetersPerSecond) (centimetersPerSecond * 36 / 1000)
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#define ABS(x) ((x) > 0 ? (x) : -(x))
+#define MIN(a,b) \
+  __extension__ ({ __typeof__ (a) _a = (a); \
+  __typeof__ (b) _b = (b); \
+  _a < _b ? _a : _b; })
+#define MAX(a,b) \
+  __extension__ ({ __typeof__ (a) _a = (a); \
+  __typeof__ (b) _b = (b); \
+  _a > _b ? _a : _b; })
+#define ABS(x) \
+  __extension__ ({ __typeof__ (x) _x = (x); \
+  _x > 0 ? _x : -_x; })
 
 #define Q12 (1 << 12)
 


### PR DESCRIPTION
The MIN, MAX, ABS macors in common/math.h are potentially dangerous
as the statement could be double evaluated.

Eg writing
```
uint32_t bla = MIN(100, sbufReadU8(src));
```
will evaluate sbufReadU8() twice (which is bad).

see https://dustri.org/b/min-and-max-macro-considered-harmful.html

Any opinions on this? The new macro definition will throw some unsigned vs signed comparison warnings as well.