### PR TITLE
OMNIBUSF4 and variants: Remove duplicate def for BMP280

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -91,7 +91,6 @@
 
 #define BARO
 #if defined(OMNIBUSF4SD)
-#define USE_BARO_BMP280
 #define USE_BARO_SPI_BMP280
 #define BMP280_SPI_INSTANCE     SPI3
 #define BMP280_CS_PIN           PB3 // v1


### PR DESCRIPTION
PR status: Ready to merge

OMNIBUSF4 and variants target.h tidy.