### PR TITLE
IOConfigGPIOConfigAF:  OD flag to OutputType member

### DIFF
--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -294,8 +294,9 @@ void IOConfigGPIOAF(IO_t io, ioConfig_t cfg, uint8_t af)
 
     LL_GPIO_InitTypeDef init = {
         .Pin = IO_Pin(io),
-        .Mode = (cfg >> 0) & 0x13,
+        .Mode = (cfg >> 0) & 0x03,
         .Speed = (cfg >> 2) & 0x03,
+        .OutputType = (cfg >> 4) & 0x01,
         .Pull = (cfg >> 5) & 0x03,
         .Alternate = af
     };


### PR DESCRIPTION
PR status: Ready to merge

- Put OD flag to `OutputType`, not as a part of `Mode`.

It is amazing that i/o is only partially broken ...  everything that uses OD has been broken since LL migration? 😓