### PR TITLE
3D Throttle Fix Issue #3696

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -512,6 +512,8 @@ void calculateThrottleAndCurrentMotorEndpoints(void)
         if((rcCommand[THROTTLE] <= (rxConfig()->midrc - flight3DConfig()->deadband3d_throttle))) {
             motorOutputMax = deadbandMotor3dLow;
             motorOutputMin = motorOutputLow;
+            throttlePrevious = rcCommand[THROTTLE];					//3D Mode Throttle Fix #3696
+            throttle = rcCommand[THROTTLE] - rxConfig()->mincheck; //3D Mode Throttle Fix #3696
             currentThrottleInputRange = rcCommandThrottleRange3dLow;
             if(isMotorProtocolDshot()) mixerInversion = true;
         } else if(rcCommand[THROTTLE] >= (rxConfig()->midrc + flight3DConfig()->deadband3d_throttle)) {


### PR DESCRIPTION
Added two missing lines of code to address a problem with the throttle transition from normal to reverse going directly to full reverse throttle.