### PR TITLE
Configurable ADC

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -43,6 +43,31 @@ uint8_t adcChannelByTag(ioTag_t ioTag)
     return 0;
 }
 
+ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
+{
+    if (instance == ADC1) {
+        return ADCDEV_1;
+    }
+
+#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
+    if (instance == ADC2) {
+        return ADCDEV_2;
+    }
+
+    if (instance == ADC3) {
+        return ADCDEV_3;
+    }
+#endif
+
+#ifdef STM32F3
+    if (instance == ADC4) {
+        return ADCDEV_4;
+    }
+#endif
+
+    return ADCINVALID;
+}
+
 uint16_t adcGetChannel(uint8_t channel)
 {
 #ifdef DEBUG_ADC_CHANNELS
@@ -60,6 +85,23 @@ uint16_t adcGetChannel(uint8_t channel)
     }
 #endif
     return adcValues[adcOperatingConfig[channel].dmaIndex];
+}
+
+// Verify a pin designated by tag has connection to an ADC instance designated by device
+
+bool adcVerifyPin(ioTag_t tag, ADCDevice device)
+{
+    if (!tag) {
+        return false;
+    }
+
+    for (int map = 0 ; map < ADC_TAG_MAP_COUNT ; map++) {
+        if ((adcTagMap[map].tag == tag) && (adcTagMap[map].devices & (1 << device))) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 #else

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -19,6 +19,40 @@
 
 #include "drivers/io_types.h"
 
+#ifndef ADC_INSTANCE
+#define ADC_INSTANCE                ADC1
+#endif
+
+#if defined(STM32F4) || defined(STM32F7)
+#ifndef ADC1_DMA_STREAM
+#define ADC1_DMA_STREAM DMA2_Stream4 // ST0 or ST4
+#endif
+
+#ifndef ADC2_DMA_STREAM
+#define ADC2_DMA_STREAM DMA2_Stream3 // ST2 or ST3
+#endif
+
+#ifndef ADC3_DMA_STREAM
+#define ADC3_DMA_STREAM DMA2_Stream0 // ST0 or ST1
+#endif
+#endif
+
+typedef enum ADCDevice {
+    ADCINVALID = -1,
+    ADCDEV_1   = 0,
+#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
+    ADCDEV_2,
+    ADCDEV_3,
+#endif
+#if defined(STM32F3)
+    ADCDEV_4,
+#endif
+    ADCDEV_COUNT
+} ADCDevice;
+
+#define ADC_CFG_TO_DEV(x) ((x) - 1)
+#define ADC_DEV_TO_CFG(x) ((x) + 1)
+
 typedef enum {
     ADC_BATTERY = 0,
     ADC_CURRENT = 1,
@@ -45,7 +79,12 @@ typedef struct adcConfig_s {
     adcChannelConfig_t rssi;
     adcChannelConfig_t current;
     adcChannelConfig_t external1;
+    int8_t device; // ADCDevice
 } adcConfig_t;
 
 void adcInit(const adcConfig_t *config);
 uint16_t adcGetChannel(uint8_t channel);
+
+#ifndef SITL
+ADCDevice adcDeviceByInstance(ADC_TypeDef *instance);
+#endif

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -28,19 +28,23 @@
 #define ADC_TAG_MAP_COUNT 10
 #endif
 
-typedef enum ADCDevice {
-    ADCINVALID = -1,
-    ADCDEV_1   = 0,
-#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
-    ADCDEV_2,
-    ADCDEV_3
-#endif
-} ADCDevice;
-
 typedef struct adcTagMap_s {
     ioTag_t tag;
+#if !defined(STM32F1) // F1 pins have uniform connection to ADC instances
+    uint8_t devices;
+#endif
     uint8_t channel;
 } adcTagMap_t;
+
+// Encoding for adcTagMap_t.devices
+
+#define ADC_DEVICES_1   (1 << ADCDEV_1)
+#define ADC_DEVICES_2   (1 << ADCDEV_2)
+#define ADC_DEVICES_3   (1 << ADCDEV_3)
+#define ADC_DEVICES_4   (1 << ADCDEV_4)
+#define ADC_DEVICES_12  ((1 << ADCDEV_1)|(1 << ADCDEV_2))
+#define ADC_DEVICES_34  ((1 << ADCDEV_3)|(1 << ADCDEV_4))
+#define ADC_DEVICES_123 ((1 << ADCDEV_1)|(1 << ADCDEV_2)|(1 << ADCDEV_3))
 
 typedef struct adcDevice_s {
     ADC_TypeDef* ADCx;
@@ -63,3 +67,5 @@ extern adcOperatingConfig_t adcOperatingConfig[ADC_CHANNEL_COUNT];
 extern volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 
 uint8_t adcChannelByTag(ioTag_t ioTag);
+ADCDevice adcDeviceByInstance(ADC_TypeDef *instance);
+bool adcVerifyPin(ioTag_t tag, ADCDevice device);

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -33,10 +33,6 @@
 #include "rcc.h"
 #include "dma.h"
 
-#ifndef ADC_INSTANCE
-#define ADC_INSTANCE   ADC1
-#endif
-
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Channelx = DMA1_Channel1 }
 };

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -33,10 +33,6 @@
 
 #include "common/utils.h"
 
-#ifndef ADC_INSTANCE
-#define ADC_INSTANCE                ADC1
-#endif
-
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_AHB(ADC12), .DMAy_Channelx = DMA1_Channel1 },
 #ifdef ADC24_DMA_REMAP
@@ -48,60 +44,46 @@ const adcDevice_t adcHardware[] = {
 };
 
 const adcTagMap_t adcTagMap[] = {
-    { DEFIO_TAG_E__PA0,  ADC_Channel_1  }, // ADC1
-    { DEFIO_TAG_E__PA1,  ADC_Channel_2  }, // ADC1
-    { DEFIO_TAG_E__PA2,  ADC_Channel_3  }, // ADC1
-    { DEFIO_TAG_E__PA3,  ADC_Channel_4  }, // ADC1
-    { DEFIO_TAG_E__PA4,  ADC_Channel_1  }, // ADC2
-    { DEFIO_TAG_E__PA5,  ADC_Channel_2  }, // ADC2
-    { DEFIO_TAG_E__PA6,  ADC_Channel_3  }, // ADC2
-    { DEFIO_TAG_E__PA7,  ADC_Channel_4  }, // ADC2
-    { DEFIO_TAG_E__PB0,  ADC_Channel_12 }, // ADC3
-    { DEFIO_TAG_E__PB1,  ADC_Channel_1  }, // ADC3
-    { DEFIO_TAG_E__PB2,  ADC_Channel_12 }, // ADC2
-    { DEFIO_TAG_E__PB12, ADC_Channel_3  }, // ADC4
-    { DEFIO_TAG_E__PB13, ADC_Channel_5  }, // ADC3
-    { DEFIO_TAG_E__PB14, ADC_Channel_4  }, // ADC4
-    { DEFIO_TAG_E__PB15, ADC_Channel_5  }, // ADC4
-    { DEFIO_TAG_E__PC0,  ADC_Channel_6  }, // ADC12
-    { DEFIO_TAG_E__PC1,  ADC_Channel_7  }, // ADC12
-    { DEFIO_TAG_E__PC2,  ADC_Channel_8  }, // ADC12
-    { DEFIO_TAG_E__PC3,  ADC_Channel_9  }, // ADC12
-    { DEFIO_TAG_E__PC4,  ADC_Channel_5  }, // ADC2
-    { DEFIO_TAG_E__PC5,  ADC_Channel_11 }, // ADC2
-    { DEFIO_TAG_E__PD8,  ADC_Channel_12 }, // ADC4
-    { DEFIO_TAG_E__PD9,  ADC_Channel_13 }, // ADC4
-    { DEFIO_TAG_E__PD10, ADC_Channel_7  }, // ADC34
-    { DEFIO_TAG_E__PD11, ADC_Channel_8  }, // ADC34
-    { DEFIO_TAG_E__PD12, ADC_Channel_9  }, // ADC34
-    { DEFIO_TAG_E__PD13, ADC_Channel_10 }, // ADC34
-    { DEFIO_TAG_E__PD14, ADC_Channel_11 }, // ADC34
-    { DEFIO_TAG_E__PE7,  ADC_Channel_13 }, // ADC3
-    { DEFIO_TAG_E__PE8,  ADC_Channel_6  }, // ADC34
-    { DEFIO_TAG_E__PE9,  ADC_Channel_2  }, // ADC3
-    { DEFIO_TAG_E__PE10, ADC_Channel_14 }, // ADC3
-    { DEFIO_TAG_E__PE11, ADC_Channel_15 }, // ADC3
-    { DEFIO_TAG_E__PE12, ADC_Channel_16 }, // ADC3
-    { DEFIO_TAG_E__PE13, ADC_Channel_3  }, // ADC3
-    { DEFIO_TAG_E__PE14, ADC_Channel_1  }, // ADC4
-    { DEFIO_TAG_E__PE15, ADC_Channel_2  }, // ADC4
-    { DEFIO_TAG_E__PF2,  ADC_Channel_10 }, // ADC12
-    { DEFIO_TAG_E__PF4,  ADC_Channel_5  }, // ADC1
+    { DEFIO_TAG_E__PA0,  ADC_DEVICES_1,  ADC_Channel_1  }, // ADC1
+    { DEFIO_TAG_E__PA1,  ADC_DEVICES_1,  ADC_Channel_2  }, // ADC1
+    { DEFIO_TAG_E__PA2,  ADC_DEVICES_1,  ADC_Channel_3  }, // ADC1
+    { DEFIO_TAG_E__PA3,  ADC_DEVICES_1,  ADC_Channel_4  }, // ADC1
+    { DEFIO_TAG_E__PA4,  ADC_DEVICES_2,  ADC_Channel_1  }, // ADC2
+    { DEFIO_TAG_E__PA5,  ADC_DEVICES_2,  ADC_Channel_2  }, // ADC2
+    { DEFIO_TAG_E__PA6,  ADC_DEVICES_2,  ADC_Channel_3  }, // ADC2
+    { DEFIO_TAG_E__PA7,  ADC_DEVICES_4,  ADC_Channel_4  }, // ADC2
+    { DEFIO_TAG_E__PB0,  ADC_DEVICES_3,  ADC_Channel_12 }, // ADC3
+    { DEFIO_TAG_E__PB1,  ADC_DEVICES_3,  ADC_Channel_1  }, // ADC3
+    { DEFIO_TAG_E__PB2,  ADC_DEVICES_2,  ADC_Channel_12 }, // ADC2
+    { DEFIO_TAG_E__PB12, ADC_DEVICES_4,  ADC_Channel_3  }, // ADC4
+    { DEFIO_TAG_E__PB13, ADC_DEVICES_3,  ADC_Channel_5  }, // ADC3
+    { DEFIO_TAG_E__PB14, ADC_DEVICES_4,  ADC_Channel_4  }, // ADC4
+    { DEFIO_TAG_E__PB15, ADC_DEVICES_4,  ADC_Channel_5  }, // ADC4
+    { DEFIO_TAG_E__PC0,  ADC_DEVICES_12, ADC_Channel_6  }, // ADC12
+    { DEFIO_TAG_E__PC1,  ADC_DEVICES_12, ADC_Channel_7  }, // ADC12
+    { DEFIO_TAG_E__PC2,  ADC_DEVICES_12, ADC_Channel_8  }, // ADC12
+    { DEFIO_TAG_E__PC3,  ADC_DEVICES_12, ADC_Channel_9  }, // ADC12
+    { DEFIO_TAG_E__PC4,  ADC_DEVICES_2,  ADC_Channel_5  }, // ADC2
+    { DEFIO_TAG_E__PC5,  ADC_DEVICES_2,  ADC_Channel_11 }, // ADC2
+    { DEFIO_TAG_E__PD8,  ADC_DEVICES_4,  ADC_Channel_12 }, // ADC4
+    { DEFIO_TAG_E__PD9,  ADC_DEVICES_4,  ADC_Channel_13 }, // ADC4
+    { DEFIO_TAG_E__PD10, ADC_DEVICES_34, ADC_Channel_7  }, // ADC34
+    { DEFIO_TAG_E__PD11, ADC_DEVICES_34, ADC_Channel_8  }, // ADC34
+    { DEFIO_TAG_E__PD12, ADC_DEVICES_34, ADC_Channel_9  }, // ADC34
+    { DEFIO_TAG_E__PD13, ADC_DEVICES_34, ADC_Channel_10 }, // ADC34
+    { DEFIO_TAG_E__PD14, ADC_DEVICES_34, ADC_Channel_11 }, // ADC34
+    { DEFIO_TAG_E__PE7,  ADC_DEVICES_3,  ADC_Channel_13 }, // ADC3
+    { DEFIO_TAG_E__PE8,  ADC_DEVICES_34, ADC_Channel_6  }, // ADC34
+    { DEFIO_TAG_E__PE9,  ADC_DEVICES_3,  ADC_Channel_2  }, // ADC3
+    { DEFIO_TAG_E__PE10, ADC_DEVICES_3,  ADC_Channel_14 }, // ADC3
+    { DEFIO_TAG_E__PE11, ADC_DEVICES_3,  ADC_Channel_15 }, // ADC3
+    { DEFIO_TAG_E__PE12, ADC_DEVICES_3,  ADC_Channel_16 }, // ADC3
+    { DEFIO_TAG_E__PE13, ADC_DEVICES_3,  ADC_Channel_3  }, // ADC3
+    { DEFIO_TAG_E__PE14, ADC_DEVICES_4,  ADC_Channel_1  }, // ADC4
+    { DEFIO_TAG_E__PE15, ADC_DEVICES_4,  ADC_Channel_2  }, // ADC4
+    { DEFIO_TAG_E__PF2,  ADC_DEVICES_12, ADC_Channel_10 }, // ADC12
+    { DEFIO_TAG_E__PF4,  ADC_DEVICES_1,  ADC_Channel_5  }, // ADC1
 };
-
-ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
-{
-    if (instance == ADC1)
-        return ADCDEV_1;
-
-    if (instance == ADC2)
-        return ADCDEV_2;
-
-    if (instance == ADC3)
-        return ADCDEV_3;
-
-    return ADCINVALID;
-}
 
 void adcInit(const adcConfig_t *config)
 {
@@ -139,8 +121,9 @@ void adcInit(const adcConfig_t *config)
 
     bool adcActive = false;
     for (int i = 0; i < ADC_CHANNEL_COUNT; i++) {
-        if (!adcOperatingConfig[i].tag)
+        if (!adcVerifyPin(adcOperatingConfig[i].tag, device)) {
             continue;
+        }
 
         adcActive = true;
         IOInit(IOGetByTag(adcOperatingConfig[i].tag), OWNER_ADC_BATT + i, 0);

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -34,59 +34,62 @@
 #include "adc.h"
 #include "adc_impl.h"
 
-#ifndef ADC_INSTANCE
-#define ADC_INSTANCE                ADC1
-#endif
-
-#ifndef ADC1_DMA_STREAM
-#define ADC1_DMA_STREAM DMA2_Stream4
-#endif
-
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = ADC1_DMA_STREAM, .channel = DMA_Channel_0 },
-    //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 }
+#if !defined(STM32F411xE)
+    { .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = ADC2_DMA_STREAM, .channel = DMA_Channel_1 },
+    { .ADCx = ADC3, .rccADC = RCC_APB2(ADC3), .DMAy_Streamx = ADC3_DMA_STREAM, .channel = DMA_Channel_2 }
+#endif
 };
 
 /* note these could be packed up for saving space */
 const adcTagMap_t adcTagMap[] = {
 /*
-    { DEFIO_TAG_E__PF3,  ADC_Channel_9  },
-    { DEFIO_TAG_E__PF4,  ADC_Channel_14 },
-    { DEFIO_TAG_E__PF5,  ADC_Channel_15 },
-    { DEFIO_TAG_E__PF6,  ADC_Channel_4  },
-    { DEFIO_TAG_E__PF7,  ADC_Channel_5  },
-    { DEFIO_TAG_E__PF8,  ADC_Channel_6  },
-    { DEFIO_TAG_E__PF9,  ADC_Channel_7  },
-    { DEFIO_TAG_E__PF10, ADC_Channel_8  },
+    { DEFIO_TAG_E__PF3, ADC_DEVICES_3,   ADC_Channel_9  },
+    { DEFIO_TAG_E__PF4, ADC_DEVICES_3,   ADC_Channel_14 },
+    { DEFIO_TAG_E__PF5, ADC_DEVICES_3,   ADC_Channel_15 },
+    { DEFIO_TAG_E__PF6, ADC_DEVICES_3,   ADC_Channel_4  },
+    { DEFIO_TAG_E__PF7, ADC_DEVICES_3,   ADC_Channel_5  },
+    { DEFIO_TAG_E__PF8, ADC_DEVICES_3,   ADC_Channel_6  },
+    { DEFIO_TAG_E__PF9, ADC_DEVICES_3,   ADC_Channel_7  },
+    { DEFIO_TAG_E__PF10,ADC_DEVICES_3,   ADC_Channel_8  },
 */
-    { DEFIO_TAG_E__PC0, ADC_Channel_10 },
-    { DEFIO_TAG_E__PC1, ADC_Channel_11 },
-    { DEFIO_TAG_E__PC2, ADC_Channel_12 },
-    { DEFIO_TAG_E__PC3, ADC_Channel_13 },
-    { DEFIO_TAG_E__PC4, ADC_Channel_14 },
-    { DEFIO_TAG_E__PC5, ADC_Channel_15 },
-    { DEFIO_TAG_E__PB0, ADC_Channel_8  },
-    { DEFIO_TAG_E__PB1, ADC_Channel_9  },
-    { DEFIO_TAG_E__PA0, ADC_Channel_0  },
-    { DEFIO_TAG_E__PA1, ADC_Channel_1  },
-    { DEFIO_TAG_E__PA2, ADC_Channel_2  },
-    { DEFIO_TAG_E__PA3, ADC_Channel_3  },
-    { DEFIO_TAG_E__PA4, ADC_Channel_4  },
-    { DEFIO_TAG_E__PA5, ADC_Channel_5  },
-    { DEFIO_TAG_E__PA6, ADC_Channel_6  },
-    { DEFIO_TAG_E__PA7, ADC_Channel_7  },
+#if defined(STM32F411xE)
+    { DEFIO_TAG_E__PC0, ADC_DEVICES_1,   ADC_Channel_10 },
+    { DEFIO_TAG_E__PC1, ADC_DEVICES_1,   ADC_Channel_11 },
+    { DEFIO_TAG_E__PC2, ADC_DEVICES_1,   ADC_Channel_12 },
+    { DEFIO_TAG_E__PC3, ADC_DEVICES_1,   ADC_Channel_13 },
+    { DEFIO_TAG_E__PC4, ADC_DEVICES_1,   ADC_Channel_14 },
+    { DEFIO_TAG_E__PC5, ADC_DEVICES_1,   ADC_Channel_15 },
+    { DEFIO_TAG_E__PB0, ADC_DEVICES_1,   ADC_Channel_8  },
+    { DEFIO_TAG_E__PB1, ADC_DEVICES_1,   ADC_Channel_9  },
+    { DEFIO_TAG_E__PA0, ADC_DEVICES_1,   ADC_Channel_0  },
+    { DEFIO_TAG_E__PA1, ADC_DEVICES_1,   ADC_Channel_1  },
+    { DEFIO_TAG_E__PA2, ADC_DEVICES_1,   ADC_Channel_2  },
+    { DEFIO_TAG_E__PA3, ADC_DEVICES_1,   ADC_Channel_3  },
+    { DEFIO_TAG_E__PA4, ADC_DEVICES_1,   ADC_Channel_4  },
+    { DEFIO_TAG_E__PA5, ADC_DEVICES_1,   ADC_Channel_5  },
+    { DEFIO_TAG_E__PA6, ADC_DEVICES_1,   ADC_Channel_6  },
+    { DEFIO_TAG_E__PA7, ADC_DEVICES_1,   ADC_Channel_7  },
+#else
+    { DEFIO_TAG_E__PC0, ADC_DEVICES_123, ADC_Channel_10 },
+    { DEFIO_TAG_E__PC1, ADC_DEVICES_123, ADC_Channel_11 },
+    { DEFIO_TAG_E__PC2, ADC_DEVICES_123, ADC_Channel_12 },
+    { DEFIO_TAG_E__PC3, ADC_DEVICES_123, ADC_Channel_13 },
+    { DEFIO_TAG_E__PC4, ADC_DEVICES_12,  ADC_Channel_14 },
+    { DEFIO_TAG_E__PC5, ADC_DEVICES_12,  ADC_Channel_15 },
+    { DEFIO_TAG_E__PB0, ADC_DEVICES_12,  ADC_Channel_8  },
+    { DEFIO_TAG_E__PB1, ADC_DEVICES_12,  ADC_Channel_9  },
+    { DEFIO_TAG_E__PA0, ADC_DEVICES_123, ADC_Channel_0  },
+    { DEFIO_TAG_E__PA1, ADC_DEVICES_123, ADC_Channel_1  },
+    { DEFIO_TAG_E__PA2, ADC_DEVICES_123, ADC_Channel_2  },
+    { DEFIO_TAG_E__PA3, ADC_DEVICES_123, ADC_Channel_3  },
+    { DEFIO_TAG_E__PA4, ADC_DEVICES_12,  ADC_Channel_4  },
+    { DEFIO_TAG_E__PA5, ADC_DEVICES_12,  ADC_Channel_5  },
+    { DEFIO_TAG_E__PA6, ADC_DEVICES_12,  ADC_Channel_6  },
+    { DEFIO_TAG_E__PA7, ADC_DEVICES_12,  ADC_Channel_7  },
+#endif
 };
-
-ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
-{
-    if (instance == ADC1)
-        return ADCDEV_1;
-/*
-    if (instance == ADC2) // TODO add ADC2 and 3
-        return ADCDEV_2;
-*/
-    return ADCINVALID;
-}
 
 void adcInit(const adcConfig_t *config)
 {
@@ -114,7 +117,7 @@ void adcInit(const adcConfig_t *config)
         adcOperatingConfig[ADC_CURRENT].tag = config->current.ioTag;  //CURRENT_METER_ADC_CHANNEL;
     }
 
-    ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);
+    ADCDevice device = ADC_CFG_TO_DEV(config->device);
     if (device == ADCINVALID)
         return;
 
@@ -122,8 +125,9 @@ void adcInit(const adcConfig_t *config)
 
     bool adcActive = false;
     for (int i = 0; i < ADC_CHANNEL_COUNT; i++) {
-        if (!adcOperatingConfig[i].tag)
+        if (!adcVerifyPin(adcOperatingConfig[i].tag, device)) {
             continue;
+        }
 
         adcActive = true;
         IOInit(IOGetByTag(adcOperatingConfig[i].tag), OWNER_ADC_BATT + i, 0);

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -44,49 +44,39 @@
 
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = ADC1_DMA_STREAM, .channel = DMA_CHANNEL_0 },
-    //{ .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = DMA2_Stream1, .channel = DMA_Channel_0 }
+    { .ADCx = ADC2, .rccADC = RCC_APB2(ADC2), .DMAy_Streamx = ADC2_DMA_STREAM, .channel = DMA_CHANNEL_1 },
+    { .ADCx = ADC3, .rccADC = RCC_APB2(ADC3), .DMAy_Streamx = ADC3_DMA_STREAM, .channel = DMA_CHANNEL_2 }
 };
 
 /* note these could be packed up for saving space */
 const adcTagMap_t adcTagMap[] = {
 /*
-    { DEFIO_TAG_E__PF3,  ADC_Channel_9  },
-    { DEFIO_TAG_E__PF4,  ADC_Channel_14 },
-    { DEFIO_TAG_E__PF5,  ADC_Channel_15 },
-    { DEFIO_TAG_E__PF6,  ADC_Channel_4  },
-    { DEFIO_TAG_E__PF7,  ADC_Channel_5  },
-    { DEFIO_TAG_E__PF8,  ADC_Channel_6  },
-    { DEFIO_TAG_E__PF9,  ADC_Channel_7  },
-    { DEFIO_TAG_E__PF10, ADC_Channel_8  },
+    { DEFIO_TAG_E__PF3, ADC_DEVICES_3,   ADC_CHANNEL_9  },
+    { DEFIO_TAG_E__PF4, ADC_DEVICES_3,   ADC_CHANNEL_14 },
+    { DEFIO_TAG_E__PF5, ADC_DEVICES_3,   ADC_CHANNEL_15 },
+    { DEFIO_TAG_E__PF6, ADC_DEVICES_3,   ADC_CHANNEL_4  },
+    { DEFIO_TAG_E__PF7, ADC_DEVICES_3,   ADC_CHANNEL_5  },
+    { DEFIO_TAG_E__PF8, ADC_DEVICES_3,   ADC_CHANNEL_6  },
+    { DEFIO_TAG_E__PF9, ADC_DEVICES_3,   ADC_CHANNEL_7  },
+    { DEFIO_TAG_E__PF10,ADC_DEVICES_3,   ADC_CHANNEL_8  },
 */
-    { DEFIO_TAG_E__PC0, ADC_CHANNEL_10 },
-    { DEFIO_TAG_E__PC1, ADC_CHANNEL_11 },
-    { DEFIO_TAG_E__PC2, ADC_CHANNEL_12 },
-    { DEFIO_TAG_E__PC3, ADC_CHANNEL_13 },
-    { DEFIO_TAG_E__PC4, ADC_CHANNEL_14 },
-    { DEFIO_TAG_E__PC5, ADC_CHANNEL_15 },
-    { DEFIO_TAG_E__PB0, ADC_CHANNEL_8  },
-    { DEFIO_TAG_E__PB1, ADC_CHANNEL_9  },
-    { DEFIO_TAG_E__PA0, ADC_CHANNEL_0  },
-    { DEFIO_TAG_E__PA1, ADC_CHANNEL_1  },
-    { DEFIO_TAG_E__PA2, ADC_CHANNEL_2  },
-    { DEFIO_TAG_E__PA3, ADC_CHANNEL_3  },
-    { DEFIO_TAG_E__PA4, ADC_CHANNEL_4  },
-    { DEFIO_TAG_E__PA5, ADC_CHANNEL_5  },
-    { DEFIO_TAG_E__PA6, ADC_CHANNEL_6  },
-    { DEFIO_TAG_E__PA7, ADC_CHANNEL_7  },
+    { DEFIO_TAG_E__PC0, ADC_DEVICES_123, ADC_CHANNEL_10 },
+    { DEFIO_TAG_E__PC1, ADC_DEVICES_123, ADC_CHANNEL_11 },
+    { DEFIO_TAG_E__PC2, ADC_DEVICES_123, ADC_CHANNEL_12 },
+    { DEFIO_TAG_E__PC3, ADC_DEVICES_123, ADC_CHANNEL_13 },
+    { DEFIO_TAG_E__PC4, ADC_DEVICES_12,  ADC_CHANNEL_14 },
+    { DEFIO_TAG_E__PC5, ADC_DEVICES_12,  ADC_CHANNEL_15 },
+    { DEFIO_TAG_E__PB0, ADC_DEVICES_12,  ADC_CHANNEL_8  },
+    { DEFIO_TAG_E__PB1, ADC_DEVICES_12,  ADC_CHANNEL_9  },
+    { DEFIO_TAG_E__PA0, ADC_DEVICES_123, ADC_CHANNEL_0  },
+    { DEFIO_TAG_E__PA1, ADC_DEVICES_123, ADC_CHANNEL_1  },
+    { DEFIO_TAG_E__PA2, ADC_DEVICES_123, ADC_CHANNEL_2  },
+    { DEFIO_TAG_E__PA3, ADC_DEVICES_123, ADC_CHANNEL_3  },
+    { DEFIO_TAG_E__PA4, ADC_DEVICES_12,  ADC_CHANNEL_4  },
+    { DEFIO_TAG_E__PA5, ADC_DEVICES_12,  ADC_CHANNEL_5  },
+    { DEFIO_TAG_E__PA6, ADC_DEVICES_12,  ADC_CHANNEL_6  },
+    { DEFIO_TAG_E__PA7, ADC_DEVICES_12,  ADC_CHANNEL_7  },
 };
-
-ADCDevice adcDeviceByInstance(ADC_TypeDef *instance)
-{
-    if (instance == ADC1)
-        return ADCDEV_1;
-/*
-    if (instance == ADC2) // TODO add ADC2 and 3
-        return ADCDEV_2;
-*/
-    return ADCINVALID;
-}
 
 void adcInit(const adcConfig_t *config)
 {
@@ -119,8 +109,9 @@ void adcInit(const adcConfig_t *config)
 
     bool adcActive = false;
     for (int i = 0; i < ADC_CHANNEL_COUNT; i++) {
-        if (!adcOperatingConfig[i].tag)
+        if (!adcVerifyPin(adcOperatingConfig[i].tag, device)) {
             continue;
+        }
 
         adcActive = true;
         IOInit(IOGetByTag(adcOperatingConfig[i].tag), OWNER_ADC_BATT + i, 0);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -200,6 +200,8 @@ PG_REGISTER(vcdProfile_t, vcdProfile, PG_VCD_CONFIG, 0);
 #ifdef USE_ADC
 void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
+    adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
+
 #ifdef VBAT_ADC_PIN
     adcConfig->vbat.enabled = true;
     adcConfig->vbat.ioTag = IO_TAG(VBAT_ADC_PIN);

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "platform.h"
+
 #include "rc_modes.h"
 
 #include "common/bitarray.h"

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -376,6 +376,11 @@ const clivalue_t valueTable[] = {
     { "rx_spi_protocol",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RX_SPI }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_spi_protocol) },
 #endif
 
+// PG_ADC_CONFIG
+#if defined(ADC)
+    { "adc_device",                 VAR_INT8   | MASTER_VALUE, .config.minmax = { 0, ADCDEV_COUNT }, PG_ADC_CONFIG, offsetof(adcConfig_t, device) },
+#endif
+
 // PG_PWM_CONFIG
 #if defined(USE_PWM)
     { "input_filtering_mode",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PWM_CONFIG, offsetof(pwmConfig_t, inputFilteringMode) },

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -203,6 +203,7 @@
 #define I2C_DEVICE              (I2CDEV_2)
 
 #define USE_ADC
+#define ADC_INSTANCE            ADC2
 #define CURRENT_METER_ADC_PIN   PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
 #define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
 #ifdef DYSF4PRO

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -181,6 +181,7 @@
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 
 #define USE_ADC
+#define ADC_INSTANCE            ADC2
 #define CURRENT_METER_ADC_PIN   PC2
 #define VBAT_ADC_PIN            PC3
 #define RSSI_ADC_PIN            PC5

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -90,6 +90,11 @@ typedef struct
     void *test;
 } I2C_TypeDef;
 
+typedef struct
+{
+    void* test;
+} ADC_TypeDef;
+
 #define WS2811_DMA_TC_FLAG (void *)1
 #define WS2811_DMA_HANDLER_IDENTIFER 0
 


### PR DESCRIPTION
PR status: Need review

Make ADC instance configurable.

- Existing code was ready for ADC instance configurability.
- `adcTagMap` was amended with pin connectivity to ADC instances.
- Added `adcHardware` entries.
- Default streams were added/defined.
- Minor touch-ups.