### PR TITLE
Fix SCLK frequency for SPI2 and SPI3

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -275,6 +275,8 @@ void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor)
     instance->CR1 = (tempRegister | ((ffs(divisor | 0x100) - 2) << 3));
 
     SPI_Cmd(instance, ENABLE);
+
+#undef BR_BITS
 }
 
 uint16_t spiGetErrorCounter(SPI_TypeDef *instance)

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -302,13 +302,14 @@ bool spiBusTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxDa
 
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor)
 {
+    // SPI2 and SPI3 are always on APB1/AHB1 which PCLK is half that of APB2/AHB2.
+
+    if (instance == SPI2 || instance == SPI3) {
+        divisor /= 2; // Safe for divisor == 0 or 1
+    }
+
     LL_SPI_Disable(instance);
-#define BR_CLEAR_MASK 0xFFC7
-
-    const uint16_t tempRegister = (instance->CR1 & BR_CLEAR_MASK);
-    instance->CR1 = (tempRegister | ((ffs(divisor | 0x100) - 2) << 3));
-
-    //LL_SPI_SetBaudRatePrescaler(instance, baudRatePrescaler);
+    LL_SPI_SetBaudRatePrescaler(instance, (ffs(divisor | 0x100) - 2) << SPI_CR1_BR_Pos);
     LL_SPI_Enable(instance);
 }
 


### PR DESCRIPTION
PR status: Ready to merge

Clock divisor for SPI2 and SPI3 must be halved.

- SCK frequencies for devices on SPI2 and SPI3 has been half of what they are intended to be, because SPI2 and SPI3 are on AHB1/APB1 throughout the entire STM32F1,F3,F4 and F7 chips that we support,  which is fed with half the PCLK of AHB2/APB2 which `SPI_CLK_*` definitions in `bus_spi.h` are based on.

- The PR modifies the `spiSetDivisor` so that it halves the divisor if instance is SPI2 or SPI3.

- Effect of overclocking is not considered (as was the case for the original code).

- MAX and SDCARD driver working in non-DMA mode, and FLASH driver will consume half the CPU.

- MAX and SDCARD driver working in DMA mode will request the bus at twice the rate; must watch for possible side effects.