### PR TITLE
Added post-process function calls to SmartPort MSP implementation. 

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -155,7 +155,9 @@ uint8_t escPortIndex;
 #ifdef USE_ESCSERIAL
 static void mspEscPassthroughFn(serialPort_t *serialPort)
 {
-    escEnablePassthrough(serialPort, escPortIndex, escMode);
+    if (serialPort) {
+        escEnablePassthrough(serialPort, escPortIndex, escMode);
+    }
 }
 #endif
 

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -422,6 +422,10 @@ void esc4wayProcess(serialPort_t *mspPort)
     uint8_t *InBuff;
     ioMem_t ioMem;
 
+    if (!mspPort) {
+        return;
+    }
+
     port = mspPort;
 
     // Start here  with UART Main loop

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -365,8 +365,12 @@ static void processMspPacket(mspPacket_t* packet)
 {
     initSmartPortMspReply(0);
 
-    if (mspFcProcessCommand(packet, &smartPortMspReply, NULL) == MSP_RESULT_ERROR) {
+    mspPostProcessFnPtr mspPostProcessFn = NULL;
+    if (mspFcProcessCommand(packet, &smartPortMspReply, &mspPostProcessFn) == MSP_RESULT_ERROR) {
         sbufWriteU8(&smartPortMspReply.buf, SMARTPORT_MSP_ERROR);
+    }
+    if (mspPostProcessFn) {
+        mspPostProcessFn(NULL);
     }
 
     // change streambuf direction


### PR DESCRIPTION
Enables telemetry-based calls to MSP_REBOOT, for example. This functionality strengthens the interactivity between OpenTX LUA scripts and flight controller configurations.