### PR TITLE
Configurable OSD warnings

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -664,6 +664,9 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         for (int i = 0; i < OSD_TIMER_COUNT; i++) {
             sbufWriteU16(dst, osdConfig()->timers[i]);
         }
+
+        // Enabled warnings
+        sbufWriteU16(dst, osdConfig()->enabledWarnings);
 #endif
         break;
     }
@@ -2083,6 +2086,11 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                 osdConfigMutable()->cap_alarm = sbufReadU16(src);
                 sbufReadU16(src); // Skip unused (previously fly timer)
                 osdConfigMutable()->alt_alarm = sbufReadU16(src);
+
+                if (sbufBytesRemaining(src) >= 2) {
+                    /* Enabled warnings */
+                    osdConfigMutable()->enabledWarnings = sbufReadU16(src);
+                }
 #endif
             } else if ((int8_t)addr == -2) {
 #if defined(OSD)

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -669,6 +669,7 @@ const clivalue_t valueTable[] = {
 // PG_OSD_CONFIG
 #ifdef OSD
     { "osd_units",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_UNIT }, PG_OSD_CONFIG, offsetof(osdConfig_t, units) },
+    { "osd_warnings",               VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings) },
 
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -126,6 +126,15 @@ typedef enum {
     OSD_TIMER_PREC_COUNT
 } osd_timer_precision_e;
 
+typedef enum {
+    OSD_WARNING_ARMING_DISABLE    = (1 << 0),
+    OSD_WARNING_BATTERY_NOT_FULL  = (1 << 1),
+    OSD_WARNING_BATTERY_WARNING   = (1 << 2),
+    OSD_WARNING_BATTERY_CRITICAL  = (1 << 3),
+    OSD_WARNING_VISUAL_BEEPER     = (1 << 4),
+    OSD_WARNING_CRASH_FLIP        = (1 << 5)
+} osdWarningsFlags_e;
+
 typedef struct osdConfig_s {
     uint16_t item_pos[OSD_ITEM_COUNT];
     bool enabled_stats[OSD_STAT_COUNT];
@@ -138,6 +147,7 @@ typedef struct osdConfig_s {
     osd_unit_e units;
 
     uint16_t timers[OSD_TIMER_COUNT];
+    uint16_t enabledWarnings;
 
     uint8_t ahMaxPitch;
     uint8_t ahMaxRoll;

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -730,6 +730,7 @@ TEST(OsdTest, TestElementWarningsBattery)
 {
     // given
     osdConfigMutable()->item_pos[OSD_WARNINGS] = OSD_POS(9, 10) | VISIBLE_FLAG;
+    osdConfigMutable()->enabledWarnings = OSD_WARNING_BATTERY_WARNING | OSD_WARNING_BATTERY_CRITICAL | OSD_WARNING_BATTERY_NOT_FULL;
 
     // and
     batteryConfigMutable()->vbatfullcellvoltage = 41;


### PR DESCRIPTION
Allows toggling the enabled warning that show on the `WARNINGS` OSD element.