### PR TITLE
Fix overclocked SPI2 and SPI3 (F1 & F3) back to normal.

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -263,16 +263,18 @@ void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor)
 {
 #define BR_BITS ((BIT(5) | BIT(4) | BIT(3)))
 
-    // SPI2 and SPI3 are always on APB1/AHB1 which PCLK is half that of APB2/AHB2.
+#if !(defined(STM32F1) || defined(STM32F3))
+    // SPI2 and SPI3 are on APB1/AHB1 which PCLK is half that of APB2/AHB2.
 
     if (instance == SPI2 || instance == SPI3) {
         divisor /= 2; // Safe for divisor == 0 or 1
     }
+#endif
 
     SPI_Cmd(instance, DISABLE);
 
     const uint16_t tempRegister = (instance->CR1 & ~BR_BITS);
-    instance->CR1 = (tempRegister | ((ffs(divisor | 0x100) - 2) << 3));
+    instance->CR1 = tempRegister | (divisor ? ((ffs(divisor | 0x100) - 2) << 3) : 0);
 
     SPI_Cmd(instance, ENABLE);
 

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -302,14 +302,16 @@ bool spiBusTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxDa
 
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor)
 {
-    // SPI2 and SPI3 are always on APB1/AHB1 which PCLK is half that of APB2/AHB2.
+#if !(defined(STM32F1) || defined(STM32F3))
+    // SPI2 and SPI3 are on APB1/AHB1 which PCLK is half that of APB2/AHB2.
 
     if (instance == SPI2 || instance == SPI3) {
         divisor /= 2; // Safe for divisor == 0 or 1
     }
+#endif
 
     LL_SPI_Disable(instance);
-    LL_SPI_SetBaudRatePrescaler(instance, (ffs(divisor | 0x100) - 2) << SPI_CR1_BR_Pos);
+    LL_SPI_SetBaudRatePrescaler(instance, divisor ? (ffs(divisor | 0x100) - 2) << SPI_CR1_BR_Pos : 0);
     LL_SPI_Enable(instance);
 }
 


### PR DESCRIPTION
PR status: Need testing

- Fix mistakenly doubled SPI2 and SPI3 clock frequency for F1 and F3 back to original.
- Also prevent zero divisor from turning into ultra slow clock.

F1, F3, F4 and F7 all have two (peripheral) buses, APB2 which is usually clocked at half the HCLK, and APB1 which is clocked at half the speed of APB2. SPI controllers on STM32 have fixed assignments on these buses; SPI2 and SPI3 on APB1, and everything else on APB2.

SPI2 and SPI3 on F4 and F7 follows the intuitive inference that maximum SCLK (and therefore divided clocks) is based on the maximum bus clock. However, it is different for F1 and F3, where a fixed divide-by-two pre-scaler is assumed for SPIs (SPI1 specifically) on APB2.

|           | F1    | F1    | F3    | F3    | F4    | F4    | F7     | F7    |
|-----------|-------|-------|-------|-------|-------|-------|--------|-------|
| Bus       | APB2  | APB1  | APB2  | APB1  | APB2  | APB1  | APB2   | APB1  |
| SPI       | 2 & 3 | other | 2 & 3 | other | 2 & 3 | other | 2 & 3  | other |
| Bus clock | 36    | 72    | 36    | 72    | 42    | 84    | 54     | 108   |
| Pclk      | 36    | 36    | 36    | 36    | 42    | 84    | 54     | 108   |
| /2        | 18    | 18    | 18    | 18    | 21    | 42    | 27     | 54    |
| /4        | 9     | 9     | 9     | 9     | 10.5  | 21.0  | 13.5   | 27    |
| /8        | 4.5   | 4.5   | 4.5   | 4.5   | 5.25  | 10.5  | 6.75   | 13.5  |
| /16       | 2.25  | 2.25  | 2.25  | 2.25  | 2.63  | 5.25  | 3.38   | 6.75  |
| /32       | 1.13  | 1.13  | 1.13  | 1.13  | 1.31  | 2.63  | 1.69   | 3.38  |
| /64       | 0.563 | 0.563 | 0.563 | 0.563 | 0.656 | 1.31  | 0.844  | 1.69  |