### PR TITLE
Enabled ESC serial passthrough for MATEKF405 board.

### DIFF
--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -152,7 +152,7 @@
 
 #define LED_STRIP
 
-//#define USE_ESCSERIAL
+#define USE_ESCSERIAL
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
Fixes #3939.