### PR TITLE
clear the DYNAMIC_FILTER if not enabled in code.

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -418,6 +418,10 @@ void validateAndFixConfig(void)
         pgResetFn_serialConfig(serialConfigMutable());
     }
 
+#ifndef USE_GYRO_DATA_ANALYSE
+    featureClear(FEATURE_DYNAMIC_FILTER);
+#endif
+
 #if defined(TARGET_VALIDATECONFIG)
     targetValidateConfiguration();
 #endif


### PR DESCRIPTION
Couple of peeps said that they enabled dynamic filtering on F1 boards and had amazing flight. 
Shall we spoil the placebo ;-)