### PR TITLE
Added default ESCPROG timer pin definition for MATEKF405.

### DIFF
--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -153,6 +153,7 @@
 #define LED_STRIP
 
 #define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN PA3
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
Fixes #3943.