### PR TITLE
Increase EEPROM config version to trigger config reset.

### DIFF
--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define EEPROM_CONF_VERSION 160
+#define EEPROM_CONF_VERSION 161
 
 bool isEEPROMContentValid(void);
 bool loadEEPROM(void);


### PR DESCRIPTION
Trigger a config reset for users upgrading to the next RC. There has been a number of issues opened by users for 'malfunctions' of the flight controller that went away after they reset their config to defaults.

@martinbudden: I think from now on, the release manager should increase the EEPROM version after (or before) every release. Even if there are no direct changes to the config data structures, changed defaults (or rather their use) will cause configs with the old defaults to behave in non-desired ways. 