### PR TITLE
MSPv2 implementation

### DIFF
--- a/src/main/interface/msp.h
+++ b/src/main/interface/msp.h
@@ -19,6 +19,17 @@
 
 #include "common/streambuf.h"
 
+#define MSP_V2_FRAME_ID         255
+
+typedef enum {
+    MSP_V1          = 0,
+    MSP_V2_OVER_V1  = 1,
+    MSP_V2_NATIVE   = 2,
+    MSP_VERSION_COUNT
+} mspVersion_e;
+
+#define MSP_VERSION_MAGIC_INITIALIZER { 'M', 'M', 'X' }
+
 // return positive for ACK, negative on error, zero for no reply
 typedef enum {
     MSP_RESULT_ACK = 1,
@@ -35,6 +46,7 @@ typedef enum {
 typedef struct mspPacket_s {
     sbuf_t buf;
     int16_t cmd;
+    uint8_t flags;
     int16_t result;
     uint8_t direction;
 } mspPacket_t;

--- a/src/main/interface/msp_protocol.h
+++ b/src/main/interface/msp_protocol.h
@@ -312,7 +312,7 @@
 #define MSP_RESERVE_2            252    //reserved for system usage
 #define MSP_DEBUGMSG             253    //out message         debug string buffer
 #define MSP_DEBUG                254    //out message         debug1,debug2,debug3,debug4
-#define MSP_RESERVE_3            255    //reserved for system usage
+#define MSP_V2_FRAME             255    //MSPv2 payload indicator
 
 // Additional commands that are not compatible with MultiWii
 #define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -27,9 +27,20 @@ typedef enum {
     MSP_IDLE,
     MSP_HEADER_START,
     MSP_HEADER_M,
-    MSP_HEADER_ARROW,
-    MSP_HEADER_SIZE,
-    MSP_HEADER_CMD,
+    MSP_HEADER_X,
+
+    MSP_HEADER_V1,
+    MSP_PAYLOAD_V1,
+    MSP_CHECKSUM_V1,
+
+    MSP_HEADER_V2_OVER_V1,
+    MSP_PAYLOAD_V2_OVER_V1,
+    MSP_CHECKSUM_V2_OVER_V1,
+
+    MSP_HEADER_V2_NATIVE,
+    MSP_PAYLOAD_V2_NATIVE,
+    MSP_CHECKSUM_V2_NATIVE,
+
     MSP_COMMAND_RECEIVED
 } mspState_e;
 
@@ -62,18 +73,38 @@ typedef enum {
 #define MSP_PORT_OUTBUF_SIZE 256
 #endif
 
+typedef struct __attribute__((packed)) {
+    uint8_t size;
+    uint8_t cmd;
+} mspHeaderV1_t;
+
+typedef struct __attribute__((packed)) {
+    uint16_t size;
+} mspHeaderJUMBO_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t  flags;
+    uint16_t cmd;
+    uint16_t size;
+} mspHeaderV2_t;
+
+#define MSP_MAX_HEADER_SIZE     9
+
 struct serialPort_s;
 typedef struct mspPort_s {
     struct serialPort_s *port; // null when port unused.
     timeMs_t lastActivityMs;
     mspPendingSystemRequest_e pendingRequest;
-    uint8_t offset;
-    uint8_t dataSize;
-    uint8_t checksum;
-    uint8_t cmdMSP;
     mspState_e c_state;
     mspPacketType_e packetType;
     uint8_t inBuf[MSP_PORT_INBUF_SIZE];
+    uint16_t cmdMSP;
+    uint8_t cmdFlags;
+    mspVersion_e mspVersion;
+    uint_fast16_t offset;
+    uint_fast16_t dataSize;
+    uint8_t checksum1;
+    uint8_t checksum2;
 } mspPort_t;
 
 void mspSerialInit(void);


### PR DESCRIPTION
Direct port of https://github.com/iNavFlight/inav/pull/1976

Deprecates usage of JUMBO frames - allows up to 65535 bytes payloads.
Adds more MSP command IDs - up to 65536 (commands 0-255 are inhereted from MSPv1). Pre-allocating a 4K command range for usage in Befaflight firmware is strongly recommended - https://github.com/iNavFlight/inav/wiki/MSP-V2