### PR TITLE
Avoid initializing TIM_USE_NONE pins

### DIFF
--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -709,6 +709,9 @@ void timerInit(void)
 #if defined(STM32F3) || defined(STM32F4)
     for (int timerIndex = 0; timerIndex < USABLE_TIMER_CHANNEL_COUNT; timerIndex++) {
         const timerHardware_t *timerHardwarePtr = &timerHardware[timerIndex];
+        if (timerHardwarePtr->usageFlags == TIM_USE_NONE) {
+            continue;
+        }
         IOConfigGPIOAF(IOGetByTag(timerHardwarePtr->tag), IOCFG_AF_PP, timerHardwarePtr->alternateFunction);
     }
 #endif

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -712,6 +712,7 @@ void timerInit(void)
         if (timerHardwarePtr->usageFlags == TIM_USE_NONE) {
             continue;
         }
+        // XXX IOConfigGPIOAF in timerInit should eventually go away.
         IOConfigGPIOAF(IOGetByTag(timerHardwarePtr->tag), IOCFG_AF_PP, timerHardwarePtr->alternateFunction);
     }
 #endif

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -810,6 +810,7 @@ void timerInit(void)
         if (timerHardwarePtr->usageFlags == TIM_USE_NONE) {
             continue;
         }
+        // XXX IOConfigGPIOAF in timerInit should eventually go away.
         IOConfigGPIOAF(IOGetByTag(timerHardwarePtr->tag), IOCFG_AF_PP, timerHardwarePtr->alternateFunction);
     }
 #endif

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -807,6 +807,9 @@ void timerInit(void)
 #if defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
     for (int timerIndex = 0; timerIndex < USABLE_TIMER_CHANNEL_COUNT; timerIndex++) {
         const timerHardware_t *timerHardwarePtr = &timerHardware[timerIndex];
+        if (timerHardwarePtr->usageFlags == TIM_USE_NONE) {
+            continue;
+        }
         IOConfigGPIOAF(IOGetByTag(timerHardwarePtr->tag), IOCFG_AF_PP, timerHardwarePtr->alternateFunction);
     }
 #endif


### PR DESCRIPTION
PR status: Ready to merge

The `timerHardware` array now includes _backdoor_ channels for pins that are normally used for something else, e.g. UARTs. It may be desirable to avoid `timerInit` to skip such entries.

The PR was motivated by a bug that caused backdoor channels to be activated as timer outputs ( #3982 ).