### PR TITLE
F3&F4 Fix N-Channel handling for LED strip

### DIFF
--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -22,6 +22,8 @@
 
 #ifdef LED_STRIP
 
+#include "build/debug.h"
+
 #include "drivers/io.h"
 #include "drivers/nvic.h"
 
@@ -99,14 +101,17 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     /* PWM1 Mode configuration */
     TIM_OCStructInit(&TIM_OCInitStructure);
     TIM_OCInitStructure.TIM_OCMode = TIM_OCMode_PWM1;
+
     if (timerHardware->output & TIMER_OUTPUT_N_CHANNEL) {
         TIM_OCInitStructure.TIM_OutputNState = TIM_OutputNState_Enable;
         TIM_OCInitStructure.TIM_OCNIdleState = TIM_OCNIdleState_Reset;
+        TIM_OCInitStructure.TIM_OCNPolarity =  (timerHardware->output & TIMER_OUTPUT_INVERTED) ? TIM_OCNPolarity_Low : TIM_OCNPolarity_High;
     } else {
         TIM_OCInitStructure.TIM_OutputState = TIM_OutputState_Enable;
         TIM_OCInitStructure.TIM_OCIdleState = TIM_OCIdleState_Set;
+        TIM_OCInitStructure.TIM_OCPolarity =  (timerHardware->output & TIMER_OUTPUT_INVERTED) ? TIM_OCPolarity_Low : TIM_OCPolarity_High;
     }
-    TIM_OCInitStructure.TIM_OCPolarity =  (timerHardware->output & TIMER_OUTPUT_INVERTED) ? TIM_OCPolarity_Low : TIM_OCPolarity_High;
+
     TIM_OCInitStructure.TIM_Pulse = 0;
 
     timerOCInit(timer, timerHardware->channel, &TIM_OCInitStructure);
@@ -115,7 +120,11 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_CtrlPWMOutputs(timer, ENABLE);
     TIM_ARRPreloadConfig(timer, ENABLE);
 
-    TIM_CCxCmd(timer, timerHardware->channel, TIM_CCx_Enable);
+    if (timerHardware->output & TIMER_OUTPUT_N_CHANNEL)
+        TIM_CCxNCmd(timer, timerHardware->channel, TIM_CCxN_Enable);
+    else
+        TIM_CCxCmd(timer, timerHardware->channel, TIM_CCx_Enable);
+
     TIM_Cmd(timer, ENABLE);
 
     dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -105,7 +105,11 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     if (timerHardware->output & TIMER_OUTPUT_N_CHANNEL) {
         TIM_OCInitStructure.TIM_OutputNState = TIM_OutputNState_Enable;
         TIM_OCInitStructure.TIM_OCNIdleState = TIM_OCNIdleState_Reset;
+#ifndef TEMPORARY_FIX_FOR_LED_ON_NCHAN_AND_HAVE_OUTPUT_INVERTED_FIX_ME_FOR_3_3
+        TIM_OCInitStructure.TIM_OCNPolarity =  TIM_OCNPolarity_High;
+#else
         TIM_OCInitStructure.TIM_OCNPolarity =  (timerHardware->output & TIMER_OUTPUT_INVERTED) ? TIM_OCNPolarity_Low : TIM_OCNPolarity_High;
+#endif
     } else {
         TIM_OCInitStructure.TIM_OutputState = TIM_OutputState_Enable;
         TIM_OCInitStructure.TIM_OCIdleState = TIM_OCIdleState_Set;
@@ -120,10 +124,11 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_CtrlPWMOutputs(timer, ENABLE);
     TIM_ARRPreloadConfig(timer, ENABLE);
 
-    if (timerHardware->output & TIMER_OUTPUT_N_CHANNEL)
+    if (timerHardware->output & TIMER_OUTPUT_N_CHANNEL) {
         TIM_CCxNCmd(timer, timerHardware->channel, TIM_CCxN_Enable);
-    else
+    } else {
         TIM_CCxCmd(timer, timerHardware->channel, TIM_CCx_Enable);
+    }
 
     TIM_Cmd(timer, ENABLE);
 


### PR DESCRIPTION
PR status: Ready to merge

Fixes a bug that caused N-Channels to fail for LED strip.

~Can't merge until `TIMER_OUTPUT_INVERTED`/`TIMER_OUTPUT_N_CHANNEL` confusion is solved.~

Ref: #3982

EDIT
To fix this problem in 3.2, a special treatment for N-channel LED and `MOTOR_OUTPUT_INVERTED` case has been added. This should be removed in the next release.