### PR TITLE
Fix serial_escserial.c to use TIM_USE_MOTOR instead of TIMER_OUTPUT_ENABLED

### DIFF
--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -944,7 +944,7 @@ void escEnablePassthrough(serialPort_t *escPassthroughPort, uint16_t output, uin
     else {
         uint8_t first_output = 0;
         for (int i = 0; i < USABLE_TIMER_CHANNEL_COUNT; i++) {
-            if (timerHardware[i].output & TIMER_OUTPUT_ENABLED) {
+            if (timerHardware[i].usageFlags & TIM_USE_MOTOR) {
                 first_output = i;
                 break;
             }


### PR DESCRIPTION
PR status: Ready to merge

Use `TIM_USE_MOTOR` instead of `TIMER_OUTPUT_ENABLED` when looking for the first motor.

This PR will also (coincidentally) remove the last `TIMER_OUTPUT_ENABLED` user outside the target.c.
