### PR TITLE
fix crsf mah telemetry

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -135,7 +135,7 @@ void crsfFrameGps(sbuf_t *dst)
 Payload:
 uint16_t    Voltage ( mV * 100 )
 uint16_t    Current ( mA * 100 )
-uint24_t    Capacity ( mAh )
+uint24_t    Fuel ( drawn mAh )
 uint8_t     Battery remaining ( percent )
 */
 void crsfFrameBatterySensor(sbuf_t *dst)
@@ -145,11 +145,11 @@ void crsfFrameBatterySensor(sbuf_t *dst)
     sbufWriteU8(dst, CRSF_FRAMETYPE_BATTERY_SENSOR);
     sbufWriteU16BigEndian(dst, getBatteryVoltage()); // vbat is in units of 0.1V
     sbufWriteU16BigEndian(dst, getAmperage() / 10);
-    const uint32_t batteryCapacity = batteryConfig()->batteryCapacity;
+    const uint32_t mAhDrawn = getMAhDrawn();
     const uint8_t batteryRemainingPercentage = calculateBatteryPercentageRemaining();
-    sbufWriteU8(dst, (batteryCapacity >> 16));
-    sbufWriteU8(dst, (batteryCapacity >> 8));
-    sbufWriteU8(dst, (uint8_t)batteryCapacity);
+    sbufWriteU8(dst, (mAhDrawn >> 16));
+    sbufWriteU8(dst, (mAhDrawn >> 8));
+    sbufWriteU8(dst, (uint8_t)mAhDrawn);
     sbufWriteU8(dst, batteryRemainingPercentage);
 }
 

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -58,6 +58,7 @@ extern "C" {
 
     uint16_t testBatteryVoltage = 0;
     int32_t testAmperage = 0;
+    int32_t testmAhDrawn = 0;
 
     serialPort_t *telemetrySharedPort;
     PG_REGISTER(batteryConfig_t, batteryConfig, PG_BATTERY_CONFIG, 0);
@@ -155,7 +156,7 @@ TEST(TelemetryCrsfTest, TestBattery)
 
     testBatteryVoltage = 33; // 3.3V = 3300 mv
     testAmperage = 2960; // = 29.60A = 29600mA - amperage is in 0.01A steps
-    batteryConfigMutable()->batteryCapacity = 1234;
+    testmAhDrawn = 1234;
     frameLen = getCrsfFrame(frame, CRSF_FRAMETYPE_BATTERY_SENSOR);
     voltage = frame[3] << 8 | frame[4]; // mV * 100
     EXPECT_EQ(33, voltage);
@@ -316,6 +317,10 @@ batteryState_e getBatteryState(void) {
 
 uint8_t calculateBatteryPercentageRemaining(void) {
     return 67;
+}
+
+int32_t getMAhDrawn(void){
+  return testmAhDrawn;
 }
 
 }


### PR DESCRIPTION
current implementation just sends the config value batteryCapacity.
documentation(bf & tbs) says Capacity ( mAh ) but Users and tbs want fuel aka current drawn mah
