### PR TITLE
SOFTSERIAL Avoid using N-Channel for RX function

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -255,7 +255,7 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
         // If RX and TX pins are both assigned, we CAN use either with a timer.
         // However, for consistency with hardware UARTs, we only use TX pin,
         // and this pin must have a timer, and it should not be N-Channel.
-        if (!(timerTx && !(timerTx->output & TIMER_OUTPUT_N_CHANNEL))) {
+        if (!timerTx || (timerTx->output & TIMER_OUTPUT_N_CHANNEL)) {
             return NULL;
         }
 
@@ -266,7 +266,7 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     } else {
         if (mode & MODE_RX) {
             // Need a pin & a timer on RX. Channel should not be N-Channel.
-            if (!(timerRx && !(timerRx->output & TIMER_OUTPUT_N_CHANNEL))) {
+            if (!timerRx || (timerRx->output & TIMER_OUTPUT_N_CHANNEL)) {
                 return NULL;
             }
 

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -255,8 +255,9 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
         // If RX and TX pins are both assigned, we CAN use either with a timer.
         // However, for consistency with hardware UARTs, we only use TX pin,
         // and this pin must have a timer, and it should not be N-Channel.
-        if (!(timerTx && !(timerTx->output & TIMER_OUTPUT_N_CHANNEL)))
+        if (!(timerTx && !(timerTx->output & TIMER_OUTPUT_N_CHANNEL))) {
             return NULL;
+        }
 
         softSerial->timerHardware = timerTx;
         softSerial->txIO = txIO;
@@ -265,8 +266,9 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     } else {
         if (mode & MODE_RX) {
             // Need a pin & a timer on RX. Channel should not be N-Channel.
-            if (!(timerRx && !(timerRx->output & TIMER_OUTPUT_N_CHANNEL)))
+            if (!(timerRx && !(timerRx->output & TIMER_OUTPUT_N_CHANNEL))) {
                 return NULL;
+            }
 
             softSerial->rxIO = rxIO;
             softSerial->timerHardware = timerRx;

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -254,8 +254,8 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     if (options & SERIAL_BIDIR) {
         // If RX and TX pins are both assigned, we CAN use either with a timer.
         // However, for consistency with hardware UARTs, we only use TX pin,
-        // and this pin must have a timer.
-        if (!timerTx)
+        // and this pin must have a timer, and it should not be N-Channel.
+        if (!(timerTx && !(timerTx->output & TIMER_OUTPUT_N_CHANNEL)))
             return NULL;
 
         softSerial->timerHardware = timerTx;
@@ -264,8 +264,8 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
     } else {
         if (mode & MODE_RX) {
-            // Need a pin & a timer on RX
-            if (!(tagRx && timerRx))
+            // Need a pin & a timer on RX. Channel should not be N-Channel.
+            if (!(timerRx && !(timerRx->output & TIMER_OUTPUT_N_CHANNEL)))
                 return NULL;
 
             softSerial->rxIO = rxIO;


### PR DESCRIPTION
PR status: Need review

Since N-Channel is output only, it can not be used for RX function which requires edge interrupt.

`openSoftSerial` detects this configuration and returns `NULL`. CLI command `resource list` can be used to examine the open result by looking at the pin resource mapping status.