### PR TITLE
Fixed conflict between USE_MSP_UART and other UART defines.

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -119,15 +119,6 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
 
     serialConfig->portConfigs[0].functionMask = FUNCTION_MSP;
 
-#if defined(USE_VCP) && defined(USE_MSP_UART)
-    if (serialConfig->portConfigs[0].identifier == SERIAL_PORT_USB_VCP) {
-        serialPortConfig_t * uart1Config = serialFindPortConfiguration(SERIAL_PORT_USART1);
-        if (uart1Config) {
-            uart1Config->functionMask = FUNCTION_MSP;
-        }
-    }
-#endif
-
 #ifdef SERIALRX_UART
     serialPortConfig_t *serialRxUartConfig = serialFindPortConfiguration(SERIALRX_UART);
     if (serialRxUartConfig) {
@@ -139,6 +130,15 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
     serialPortConfig_t *serialTlemetryUartConfig = serialFindPortConfiguration(SBUS_TELEMETRY_UART);
     if (serialTlemetryUartConfig) {
         serialTlemetryUartConfig->functionMask = FUNCTION_TELEMETRY_SMARTPORT;
+    }
+#endif
+
+#if defined(USE_VCP) && defined(USE_MSP_UART)
+    if (serialConfig->portConfigs[0].identifier == SERIAL_PORT_USB_VCP) {
+        serialPortConfig_t * uart1Config = serialFindPortConfiguration(SERIAL_PORT_USART1);
+        if (uart1Config) {
+            uart1Config->functionMask = FUNCTION_MSP;
+        }
     }
 #endif
 


### PR DESCRIPTION
This change keeps other UART related defines from overriding `USE_MSP_UART`, since this one is normally used as last resort for boards with broken USB port, so it needs to take precedence. (UART1 could still be assigned a different function in `targetConfiguration`, but this fix catches the more common cases.

@AndersHoglund: Can you test with BETAFLIGHTF3 please?