### PR TITLE
OMNIBUSF7V2: Rotate ICM20608 90deg CW to match MPU6000

### DIFF
--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -55,6 +55,8 @@
 #define MPU6500_SPI_INSTANCE    SPI3
 #define GYRO_1_CS_PIN           MPU6000_CS_PIN
 #define GYRO_0_CS_PIN           MPU6500_CS_PIN
+#define GYRO_MPU6500_ALIGN      CW90_DEG
+#define ACC_MPU6500_ALIGN       CW90_DEG
 #else
 #define MPU6000_CS_PIN          SPI3_NSS_PIN
 #define MPU6000_SPI_INSTANCE    SPI3


### PR DESCRIPTION
PR status: Ready to merge

OMNIBUSF7V2 requires ICM20608 to be rotated CW90 to match the orientation with MPU6000 (USB connector to the right).