### PR TITLE
Workaround for blheli 16.63 issue of motors not always reversing

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -384,7 +384,7 @@ void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command)
         case DSHOT_CMD_SAVE_SETTINGS:
         case DSHOT_CMD_SPIN_DIRECTION_NORMAL:
         case DSHOT_CMD_SPIN_DIRECTION_REVERSED:
-            repeats = 10;
+            repeats = 20;
             break;
         default:
             repeats = 1;


### PR DESCRIPTION
Sometimes the motors aren't reversing when told to.  Not sure where the issue is yet, but this workaround fixes it. 

It looked like 11 repeats fixed it as well, but sending 20 to be safe.   Not going to cause any issues and should be safer then one motor not reversing.

It might be the first dshot command is sometimes getting clobbered?  (by another motor command)  Or blheli issue?

There wasn't this issue on blheli 16.67 because there was a bug that caused it to only needed one command to reverse.