### PR TITLE
Rate Limiter prospective solution for YTTM

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -58,6 +58,7 @@ typedef struct gyroDev_s {
     int32_t gyroZero[XYZ_AXIS_COUNT];
     int32_t gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
+    int32_t gyroADCRawP[XYZ_AXIS_COUNT];					// prev gyro data for slew limit check
     int16_t temperature;
     uint8_t lpf;
     gyroRateKHz_e gyroRateKHz;

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -58,7 +58,7 @@ typedef struct gyroDev_s {
     int32_t gyroZero[XYZ_AXIS_COUNT];
     int32_t gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
-    int32_t gyroADCRawP[XYZ_AXIS_COUNT];					// prev gyro data for slew limit check
+    int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
     int16_t temperature;
     uint8_t lpf;
     gyroRateKHz_e gyroRateKHz;

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -58,7 +58,7 @@ typedef struct gyroDev_s {
     int32_t gyroZero[XYZ_AXIS_COUNT];
     int32_t gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
-#if !defined(BEEBRAIN)
+#if defined(USE_GYRO_SLEW_LIMITER)
     int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
 #endif
     int16_t temperature;

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -58,9 +58,7 @@ typedef struct gyroDev_s {
     int32_t gyroZero[XYZ_AXIS_COUNT];
     int32_t gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
-#if defined(USE_GYRO_SLEW_LIMITER)
     int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
-#endif
     int16_t temperature;
     uint8_t lpf;
     gyroRateKHz_e gyroRateKHz;

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -58,7 +58,9 @@ typedef struct gyroDev_s {
     int32_t gyroZero[XYZ_AXIS_COUNT];
     int32_t gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
+#if !defined(BEEBRAIN)
     int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
+#endif
     int16_t temperature;
     uint8_t lpf;
     gyroRateKHz_e gyroRateKHz;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -437,11 +437,13 @@ static uint16_t calculateNyquistAdjustedNotchHz(uint16_t notchHz, uint16_t notch
     return notchHz;
 }
 
+#if !defined(BEEBRAIN)
 void gyroInitSlewLimiter(gyroSensor_t *gyroSensor) {
 
     for (int axis = 0; axis < 3; axis++)
     	gyroSensor->gyroDev.gyroADCRawPrevious[axis] = 0;
 }
+#endif
 
 static void gyroInitFilterNotch1(gyroSensor_t *gyroSensor, uint16_t notchHz, uint16_t notchCutoffHz)
 {
@@ -490,7 +492,9 @@ static void gyroInitFilterDynamicNotch(gyroSensor_t *gyroSensor)
 
 static void gyroInitSensorFilters(gyroSensor_t *gyroSensor)
 {
+#if !defined(BEEBRAIN)
 	gyroInitSlewLimiter(gyroSensor);
+#endif
     gyroInitFilterLpf(gyroSensor, gyroConfig()->gyro_soft_lpf_hz);
     gyroInitFilterNotch1(gyroSensor, gyroConfig()->gyro_soft_notch_hz_1, gyroConfig()->gyro_soft_notch_cutoff_1);
     gyroInitFilterNotch2(gyroSensor, gyroConfig()->gyro_soft_notch_hz_2, gyroConfig()->gyro_soft_notch_cutoff_2);
@@ -589,7 +593,9 @@ STATIC_UNIT_TESTED void performGyroCalibration(gyroSensor_t *gyroSensor, uint8_t
 
 }
 
-uint32_t gyroSlewLimiter(int axis, gyroSensor_t *gyroSensor)
+//#if defined(USE_GYRO_SPI_ICM20649) || defined(USE_GYRO_SPI_ICM20689)
+#if !defined(BEEBRAIN)
+int32_t gyroSlewLimiter(int axis, gyroSensor_t *gyroSensor)
 {
 	int32_t newRawGyro = (int32_t) gyroSensor->gyroDev.gyroADCRaw[axis];
 
@@ -600,6 +606,8 @@ uint32_t gyroSlewLimiter(int axis, gyroSensor_t *gyroSensor)
 
 	return newRawGyro;
 }
+#endif
+
 
 void gyroUpdateSensor(gyroSensor_t *gyroSensor)
 {
@@ -615,9 +623,13 @@ void gyroUpdateSensor(gyroSensor_t *gyroSensor)
     			- gyroSensor->gyroDev.gyroZero[X];
     	gyroSensor->gyroDev.gyroADC[Y] = gyroSensor->gyroDev.gyroADCRaw[Y]
     			- gyroSensor->gyroDev.gyroZero[Y];
-
+#if !defined(BEEBRAIN)
     	gyroSensor->gyroDev.gyroADC[Z] = gyroSlewLimiter(Z, gyroSensor)
     			- gyroSensor->gyroDev.gyroZero[Z];
+#else
+    	gyroSensor->gyroDev.gyroADC[Z] = gyroSensor->gyroDev.gyroADCRaw[Z]
+    	    			- gyroSensor->gyroDev.gyroZero[Z];
+#endif
 
         alignSensors(gyroSensor->gyroDev.gyroADC, gyroSensor->gyroDev.gyroAlign);
     } else {

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -70,7 +70,7 @@
 #include "hardware_revision.h"
 #endif
 
-#if !defined(USE_GYRO_SPI_MPU6000) && (FLASH_SIZE > 128)
+#if (FLASH_SIZE > 128) && !defined(USE_GYRO_SPI_MPU6000)
 #define USE_GYRO_SLEW_LIMITER
 #endif
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -70,6 +70,10 @@
 #include "hardware_revision.h"
 #endif
 
+#if !defined(USE_GYRO_SPI_MPU6000) && (FLASH_SIZE > 128)
+#define USE_GYRO_SLEW_LIMITER
+#endif
+
 gyro_t gyro;
 static uint8_t gyroDebugMode;
 
@@ -437,10 +441,10 @@ static uint16_t calculateNyquistAdjustedNotchHz(uint16_t notchHz, uint16_t notch
     return notchHz;
 }
 
-#if !defined(BEEBRAIN)
+#if defined(USE_GYRO_SLEW_LIMITER)
 void gyroInitSlewLimiter(gyroSensor_t *gyroSensor) {
 
-    for (int axis = 0; axis < 3; axis++)
+    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++)
     	gyroSensor->gyroDev.gyroADCRawPrevious[axis] = 0;
 }
 #endif
@@ -492,7 +496,7 @@ static void gyroInitFilterDynamicNotch(gyroSensor_t *gyroSensor)
 
 static void gyroInitSensorFilters(gyroSensor_t *gyroSensor)
 {
-#if !defined(BEEBRAIN)
+#if defined(USE_GYRO_SLEW_LIMITER)
 	gyroInitSlewLimiter(gyroSensor);
 #endif
     gyroInitFilterLpf(gyroSensor, gyroConfig()->gyro_soft_lpf_hz);
@@ -593,8 +597,7 @@ STATIC_UNIT_TESTED void performGyroCalibration(gyroSensor_t *gyroSensor, uint8_t
 
 }
 
-//#if defined(USE_GYRO_SPI_ICM20649) || defined(USE_GYRO_SPI_ICM20689)
-#if !defined(BEEBRAIN)
+#if defined(USE_GYRO_SLEW_LIMITER)
 int32_t gyroSlewLimiter(int axis, gyroSensor_t *gyroSensor)
 {
 	int32_t newRawGyro = (int32_t) gyroSensor->gyroDev.gyroADCRaw[axis];
@@ -623,7 +626,7 @@ void gyroUpdateSensor(gyroSensor_t *gyroSensor)
     			- gyroSensor->gyroDev.gyroZero[X];
     	gyroSensor->gyroDev.gyroADC[Y] = gyroSensor->gyroDev.gyroADCRaw[Y]
     			- gyroSensor->gyroDev.gyroZero[Y];
-#if !defined(BEEBRAIN)
+#if defined(USE_GYRO_SLEW_LIMITER)
     	gyroSensor->gyroDev.gyroADC[Z] = gyroSlewLimiter(Z, gyroSensor)
     			- gyroSensor->gyroDev.gyroZero[Z];
 #else

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -70,7 +70,7 @@
 #include "hardware_revision.h"
 #endif
 
-#if (FLASH_SIZE > 128) && !defined(USE_GYRO_SPI_MPU6000)
+#if (FLASH_SIZE > 128) // && !defined(USE_GYRO_SPI_MPU6000)
 #define USE_GYRO_SLEW_LIMITER
 #endif
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -70,7 +70,7 @@
 #include "hardware_revision.h"
 #endif
 
-#if (FLASH_SIZE > 128) // && !defined(USE_GYRO_SPI_MPU6000)
+#if ((FLASH_SIZE > 128) && (defined(USE_GYRO_SPI_MPU6500) ||  defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20601) || defined(USE_GYRO_SPI_ICM20689)))
 #define USE_GYRO_SLEW_LIMITER
 #endif
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -622,16 +622,12 @@ void gyroUpdateSensor(gyroSensor_t *gyroSensor)
     if (isGyroSensorCalibrationComplete(gyroSensor)) {
     	// move 16-bit gyro data into 32-bit variables to avoid overflows in calculations
 
-    	gyroSensor->gyroDev.gyroADC[X] = gyroSensor->gyroDev.gyroADCRaw[X]
-    			- gyroSensor->gyroDev.gyroZero[X];
-    	gyroSensor->gyroDev.gyroADC[Y] = gyroSensor->gyroDev.gyroADCRaw[Y]
-    			- gyroSensor->gyroDev.gyroZero[Y];
+    	gyroSensor->gyroDev.gyroADC[X] = gyroSensor->gyroDev.gyroADCRaw[X] - gyroSensor->gyroDev.gyroZero[X];
+    	gyroSensor->gyroDev.gyroADC[Y] = gyroSensor->gyroDev.gyroADCRaw[Y] - gyroSensor->gyroDev.gyroZero[Y];
 #if defined(USE_GYRO_SLEW_LIMITER)
-    	gyroSensor->gyroDev.gyroADC[Z] = gyroSlewLimiter(Z, gyroSensor)
-    			- gyroSensor->gyroDev.gyroZero[Z];
+    	gyroSensor->gyroDev.gyroADC[Z] = gyroSlewLimiter(Z, gyroSensor) - gyroSensor->gyroDev.gyroZero[Z];
 #else
-    	gyroSensor->gyroDev.gyroADC[Z] = gyroSensor->gyroDev.gyroADCRaw[Z]
-    	    			- gyroSensor->gyroDev.gyroZero[Z];
+    	gyroSensor->gyroDev.gyroADC[Z] = gyroSensor->gyroDev.gyroADCRaw[Z] - gyroSensor->gyroDev.gyroZero[Z];
 #endif
 
         alignSensors(gyroSensor->gyroDev.gyroADC, gyroSensor->gyroDev.gyroAlign);

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -61,7 +61,9 @@ typedef struct gyroConfig_s {
     uint16_t gyro_soft_notch_cutoff_1;
     uint16_t gyro_soft_notch_hz_2;
     uint16_t gyro_soft_notch_cutoff_2;
+#if !defined(BEEBRAIN)
     uint32_t gyro_slewlimit;
+#endif
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -61,9 +61,6 @@ typedef struct gyroConfig_s {
     uint16_t gyro_soft_notch_cutoff_1;
     uint16_t gyro_soft_notch_hz_2;
     uint16_t gyro_soft_notch_cutoff_2;
-#if !defined(BEEBRAIN)
-    uint32_t gyro_slewlimit;
-#endif
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -61,6 +61,7 @@ typedef struct gyroConfig_s {
     uint16_t gyro_soft_notch_cutoff_1;
     uint16_t gyro_soft_notch_hz_2;
     uint16_t gyro_soft_notch_cutoff_2;
+    uint32_t gyro_slewlimit;
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);


### PR DESCRIPTION
Proposal is intended to detect "impossible" changes between successive gyro readings. This first arose as a possible fault within the ICM with wraparounds in readings at extreme rates. The proposal may also detect bad sensor readings if the slew constant is chosen appropriately.  The code checks all three axes but can be limited to just yaw if desired.

Also suggested by others that it may be useful for gate strikes.   Gate clip at 20 M/S gives rotation of say 45 deg at a 0.1M radius or a contact time of 5mS.  The average yaw rate 9000 deg/S so gyro max rate probably exceeded almost instantly. 

Needs to be tested as I do not have the equipment needed to fly.