### PR TITLE
Fading arm state function LEDs

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -474,13 +474,10 @@ static void applyLedFixedLayers()
         case LED_FUNCTION_ARM_STATE:
             color = ARMING_FLAG(ARMED) ? *getSC(LED_SCOLOR_ARMED) : *getSC(LED_SCOLOR_DISARMED);
             
-            if (ARMING_FLAG(ARMED))
-                {
+            if (ARMING_FLAG(ARMED)) {
                     nextColor = ledStripConfig()->colors[15];
                     previousColor = ledStripConfig()->colors[14];
-                }
-            else
-                {
+                } else {
                     nextColor = ledStripConfig()->colors[13];
                     previousColor = ledStripConfig()->colors[12];
                 }


### PR DESCRIPTION
This change assigns arbitrary palette colors to `nextColor` and `previousColor` for aux and throttle fading when using arm state function LEDs. This allows for full customization of fades in both armed and disarmed states using the last 4 palette colors. Issue #4044 