### PR TITLE
[SITL] fix cli crash on 'get', 'dump', 'diff'

### DIFF
--- a/make/mcu/SITL.mk
+++ b/make/mcu/SITL.mk
@@ -25,7 +25,6 @@ MCU_EXCLUDES = \
             drivers/dma.c \
             drivers/pwm_output.c \
             drivers/timer.c \
-            drivers/light_led.c \
             drivers/system.c \
             drivers/rcc.c \
             drivers/serial_escserial.c \

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -33,11 +33,7 @@
 
 #include "drivers/system.h"
 
-#ifdef EEPROM_IN_RAM
-extern uint8_t eepromData[EEPROM_SIZE];
-# define __config_start (*eepromData)
-# define __config_end (*ARRAYEND(eepromData))
-#else
+#ifndef EEPROM_IN_RAM
 extern uint8_t __config_start;   // configured via linker script when building binaries.
 extern uint8_t __config_end;
 #endif

--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -23,8 +23,10 @@
 
 #include "config/config_streamer.h"
 
+#ifndef EEPROM_IN_RAM
 extern uint8_t __config_start;   // configured via linker script when building binaries.
 extern uint8_t __config_end;
+#endif
 
 #if !defined(FLASH_PAGE_SIZE)
 // F1

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -254,12 +254,6 @@ void systemResetToBootloader(void) {
     exit(0);
 }
 
-// drivers/light_led.c
-void ledInit(const statusLedConfig_t *statusLedConfig) {
-    UNUSED(statusLedConfig);
-    printf("[led]Init...\n");
-}
-
 void timerInit(void) {
     printf("[timer]Init...\n");
 }

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -35,7 +35,7 @@
 // file name to save config
 #define EEPROM_FILENAME "eeprom.bin"
 #define EEPROM_IN_RAM
-#define EEPROM_SIZE     8192
+#define EEPROM_SIZE     32768
 
 #define U_ID_0 0
 #define U_ID_1 1
@@ -136,6 +136,15 @@
 #include <stddef.h>
 
 uint32_t SystemCoreClock;
+
+#ifdef EEPROM_IN_RAM
+extern uint8_t eepromData[EEPROM_SIZE];
+#define __config_start (*eepromData)
+#define __config_end (*ARRAYEND(eepromData))
+#else
+extern uint8_t __config_start;   // configured via linker script when building binaries.
+extern uint8_t __config_end;
+#endif
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
As title,
because there didn't have parameter group for `led_inversion`.
Add `drivers/light_led.c` back will fix.