### PR TITLE
OMNIBUSF4SD: Configure inverter for UART3

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -43,7 +43,10 @@
 #define BEEPER_INVERTED
 
 #ifdef OMNIBUSF4SD
+// These inverter control pins collide with timer channels on CH5 and CH6 pads.
+// Users of these timers/pads must un-map the inverter assignment explicitly.
 #define INVERTER_PIN_UART6      PC8 // Omnibus F4 V3 and later
+#define INVERTER_PIN_UART3      PC9 // Omnibus F4 Pro Corners
 #else
 #define INVERTER_PIN_UART1      PC0 // PC0 used as inverter select GPIO XXX this is not used --- remove it at the next major release
 #endif


### PR DESCRIPTION
PR status: Ready to merge

OMNIBUS F4 Pro Corners has an inverter on UART3, controlled by PC9.

This inverter can be activated by explicitly by `resource inverter 3 c9`, but it is better for majority of users to have this configured and activated by default.

Note that users of PC8 and PC9 as timer channels (pads CH5 and CH6), available in some variants that use OMNIBUSF4SD target (e.g. OMNIBUS F4 V2) must explicitly release the mapping by `resource inverter 3 none` and/or `resource inverter 6 none`.