### PR TITLE
Adds vagrant file to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ stm32.mak
 # artefacts for CLion
 /cmake-build-debug/
 /CMakeLists.txt
+
+.vagrant
+ubuntu*.log


### PR DESCRIPTION
Prevent `vagrant up` from adding files to working tree. 