### PR TITLE
Added internal resistance adjustment

### DIFF
--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -63,6 +63,7 @@ PG_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig,
     .mode = CAMERA_CONTROL_MODE_HARDWARE_PWM,
     .refVoltage = 330,
     .keyDelayMs = 180,
+    .internalResistance = 470,
     .ioTag = IO_TAG(CAMERA_CONTROL_PIN)
 );
 
@@ -158,13 +159,12 @@ void cameraControlProcess(uint32_t currentTimeUs)
     }
 }
 
-static const int cameraPullUpResistance = 47000;
 static const int buttonResistanceValues[] = { 45000, 27000, 15000, 6810, 0 };
 
 static float calculateKeyPressVoltage(const cameraControlKey_e key)
 {
     const int buttonResistance = buttonResistanceValues[key];
-    return 1.0e-2f * cameraControlConfig()->refVoltage * buttonResistance / (cameraPullUpResistance + buttonResistance);
+    return 1.0e-2f * cameraControlConfig()->refVoltage * buttonResistance / (100 * cameraControlConfig()->internalResistance + buttonResistance);
 }
 
 #if defined(CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE) || defined(CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE)

--- a/src/main/drivers/camera_control.h
+++ b/src/main/drivers/camera_control.h
@@ -38,8 +38,11 @@ typedef enum {
 
 typedef struct cameraControlConfig_s {
     cameraControlMode_e mode;
+    // measured in 10 mV steps
     uint16_t refVoltage;
     uint16_t keyDelayMs;
+    // measured 100 Ohm steps
+    uint16_t internalResistance;
 
     ioTag_t ioTag;
 } cameraControlConfig_t;

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -777,6 +777,7 @@ const clivalue_t valueTable[] = {
     { "camera_control_mode", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CAMERA_CONTROL_MODE }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, mode) },
     { "camera_control_ref_voltage", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 200, 400 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, refVoltage) },
     { "camera_control_key_delay", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 100, 500 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, keyDelayMs) },
+    { "camera_control_internal_resistance", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 10, 1000 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, internalResistance) },
 #endif
 };
 


### PR DESCRIPTION
More info on the wiki page: https://github.com/betaflight/betaflight/wiki/FPV-Camera-Control-(Joystick-Emulation)
Some cameras turned out to have internal resistance different from 47 kΩ.