### PR TITLE
Experimental serial activity monitor

### DIFF
--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -69,6 +69,15 @@ typedef struct serialPort_s {
     uint32_t txBufferTail;
 
     serialReceiveCallbackPtr rxCallback;
+
+    // Statistics
+    int32_t  statState;
+    uint32_t statRxBytes;
+    uint32_t statTxBytes;
+    uint32_t statRxFrames;
+    uint32_t statTxFrames;
+    uint32_t statErrors;
+
 } serialPort_t;
 
 #if defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2)
@@ -125,3 +134,10 @@ uint32_t serialGetBaudRate(serialPort_t *instance);
 void serialWriteBufShim(void *instance, const uint8_t *data, int count);
 void serialBeginWrite(serialPort_t *instance);
 void serialEndWrite(serialPort_t *instance);
+
+// Statistics service for transport level frames
+void serialStatSetState(serialPort_t *instance, int state);
+void serialStatRxFrame(serialPort_t *instance);
+void serialStatTxFrame(serialPort_t *instance);
+void serialStatError(serialPort_t *instance);
+void serialStatCopyToDebug(serialPort_t *instance);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -220,6 +220,7 @@ static void smartPortDataReceive(uint16_t c)
             // our slot is starting...
             smartPortLastRequestTime = now;
             smartPortHasRequest = 1;
+            serialStatRxFrame(smartPortSerialPort);
         } else if (c == FSSP_SENSOR_ID2) {
             rxBuffer[smartPortRxBytes++] = c;
             checksum = 0;
@@ -245,6 +246,9 @@ static void smartPortDataReceive(uint16_t c)
         if (smartPortRxBytes == SMARTPORT_FRAME_SIZE) {
             if (c == (0xFF - checksum)) {
                 smartPortFrameReceived = true;
+                serialStatRxFrame(smartPortSerialPort);
+            } else {
+                serialStatError(smartPortSerialPort);
             }
             skipUntilStart = true;
         } else if (smartPortRxBytes < SMARTPORT_FRAME_SIZE) {
@@ -278,6 +282,7 @@ static void smartPortSendByte(uint8_t c, uint16_t *crcp)
 
 static void smartPortSendPackageEx(uint8_t frameId, uint8_t* data)
 {
+    serialStatTxFrame(smartPortSerialPort);
     uint16_t crc = 0;
     smartPortSendByte(frameId, &crc);
     for (unsigned i = 0; i < SMARTPORT_PAYLOAD_SIZE; i++) {
@@ -308,6 +313,8 @@ void initSmartPortTelemetry(void)
 
 void freeSmartPortTelemetryPort(void)
 {
+    serialStatSetState(smartPortSerialPort, -1);
+
     closeSerialPort(smartPortSerialPort);
     smartPortSerialPort = NULL;
 
@@ -328,6 +335,8 @@ void configureSmartPortTelemetryPort(void)
     if (!smartPortSerialPort) {
         return;
     }
+
+    serialStatSetState(smartPortSerialPort, 1);
 
     smartPortState = SPSTATE_INITIALIZED;
     smartPortTelemetryEnabled = true;
@@ -574,13 +583,13 @@ void handleSmartPortTelemetry(void)
         // Ensure we won't get stuck in the loop if there happens to be nothing available to send in a timely manner - dump the slot if we loop in there for too long.
         if ((millis() - smartPortLastServiceTime) > SMARTPORT_SERVICE_TIMEOUT_MS) {
             smartPortHasRequest = 0;
-            return;
+            goto out;
         }
 
         if (smartPortMspReplyPending) {
             smartPortMspReplyPending = smartPortSendMspReply();
             smartPortHasRequest = 0;
-            return;
+            goto out;
         }
 
         // we can send back any data we want, our table keeps track of the order and frequency of each data type we send
@@ -793,6 +802,9 @@ void handleSmartPortTelemetry(void)
                 // if nothing is sent, smartPortHasRequest isn't cleared, we already incremented the counter, just loop back to the start
         }
     }
+
+out:;
+    serialStatCopyToDebug(smartPortSerialPort);
 }
 
 #endif


### PR DESCRIPTION
PR status: For discussion

There must be dozens, if not hundreds of people trying to troubleshoot their serially connected devices right at this moment. A serial activity monitor can help them to "_Do things **MORE** correctly_".

This PR use SmartPort as an example, and tries to implement the activity monitor for the SmartPort with `debug` variables in a rather naive way.

The point of discussion is whether we should create a new MSP message type for serial activity monitor.

- As there are only four 16-bit variables in `debug` array, RX/TX bytes pair and RX/TX frame pair are each encoded into 16-bit using upper 10000 and lower 100. While this is enough to show there are some kind of activities on these channels, it is difficult to see what actually is going on.

- Protocols do have more than RX/TX {bytes, frames} information.
SmartPort for example, handle regular polling reception and MSP message reception differently. It would be nice to distinguish these two, to distinguish troubles caused by SmartPort or MSP over SmartPort.

Comments are welcome.
