### PR TITLE
Anti turtle mode warnings

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -465,6 +465,13 @@ void processRx(timeUs_t currentTimeUs)
 
     updateActivatedModes();
 
+#ifdef USE_DSHOT
+    /* Enable beep warning when the crash flip mode is active */
+    if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+        beeper(BEEPER_CRASH_FLIP_MODE);
+    }
+#endif
+
     if (!cliMode) {
         updateAdjustmentStates();
         processRcAdjustments(currentControlRateProfile);
@@ -732,6 +739,7 @@ bool isMotorsReversed(void)
 {
     return reverseMotors;
 }
+
 bool isFlipOverAfterCrashMode(void)
 {
     return flipOverAfterCrashMode;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -212,8 +212,9 @@ typedef struct beeperTableEntry_s {
     { BEEPER_ENTRY(BEEPER_SYSTEM_INIT,           16, NULL,                 "SYSTEM_INIT") },
     { BEEPER_ENTRY(BEEPER_USB,                   17, NULL,                 "ON_USB") },
     { BEEPER_ENTRY(BEEPER_BLACKBOX_ERASE,        18, beep_2shortBeeps,     "BLACKBOX_ERASE") },
-    { BEEPER_ENTRY(BEEPER_ALL,                   19, NULL,                 "ALL") },
-    { BEEPER_ENTRY(BEEPER_PREFERENCE,            20, NULL,                 "PREFERRED") },
+    { BEEPER_ENTRY(BEEPER_CRASH_FLIP_MODE,       19, beep_2longerBeeps,    "CRASH FLIP") },
+    { BEEPER_ENTRY(BEEPER_ALL,                   20, NULL,                 "ALL") },
+    { BEEPER_ENTRY(BEEPER_PREFERENCE,            21, NULL,                 "PREFERRED") },
 };
 
 static const beeperTableEntry_t *currentBeeperEntry = NULL;
@@ -363,7 +364,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
         return;
     }
 
-    #ifdef USE_DSHOT
+#ifdef USE_DSHOT
     if (!areMotorsRunning() && beeperConfig()->dshotBeaconTone && (beeperConfig()->dshotBeaconTone <= DSHOT_CMD_BEACON5) && (currentBeeperEntry->mode == BEEPER_RX_SET || currentBeeperEntry->mode == BEEPER_RX_LOST)) {
         pwmDisableMotors();
         delay(1);
@@ -372,7 +373,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
 
         pwmEnableMotors();
     }
-    #endif
+#endif
 
     if (!beeperIsOn) {
         beeperIsOn = 1;

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -43,6 +43,7 @@ typedef enum {
     BEEPER_SYSTEM_INIT,             // Initialisation beeps when board is powered on
     BEEPER_USB,                     // Some boards have beeper powered USB connected
     BEEPER_BLACKBOX_ERASE,          // Beep when blackbox erase completes
+    BEEPER_CRASH_FLIP_MODE,         // Crash flip mode is active
     BEEPER_ALL,                     // Turn ON or OFF all beeper conditions
     BEEPER_PREFERENCE               // Save preferred beeper configuration
     // BEEPER_ALL and BEEPER_PREFERENCE must remain at the bottom of this enum

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -584,7 +584,13 @@ static void osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_WARNINGS:
-        /* Show common reason for arming being disabled */
+        /* Warn when in flip over after crash mode */
+        if ((isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+            tfp_sprintf(buff, "CRASH FLIP");
+            break;
+        }
+
+        /* Show most severe reason for arming being disabled */
         if (IS_RC_MODE_ACTIVE(BOXARM) && isArmingDisabled()) {
             const armingDisableFlags_e flags = getArmingDisableFlags();
             for (int i = 0; i < NUM_ARMING_DISABLE_FLAGS; i++) {

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -843,12 +843,13 @@ TEST(OsdTest, TestFormatTimeString)
 
 // STUBS
 extern "C" {
-    void beeperConfirmationBeeps(uint8_t beepCount) {
-        UNUSED(beepCount);
+    void beeperConfirmationBeeps(uint8_t) {}
+
+    bool isModeActivationConditionPresent(boxId_e) {
+        return false;
     }
 
-    bool IS_RC_MODE_ACTIVE(boxId_e boxId) {
-        UNUSED(boxId);
+    bool IS_RC_MODE_ACTIVE(boxId_e) {
         return false;
     }
 
@@ -908,18 +909,13 @@ extern "C" {
         return 0;
     }
 
-    bool isSerialTransmitBufferEmpty(const serialPort_t *instance) {
-        UNUSED(instance);
+    bool isSerialTransmitBufferEmpty(const serialPort_t *) {
         return false;
     }
 
-    void serialWrite(serialPort_t *instance, uint8_t ch) {
-        UNUSED(instance);
-        UNUSED(ch);
-    }
+    void serialWrite(serialPort_t *, uint8_t) {}
 
-    bool cmsDisplayPortRegister(displayPort_t *pDisplay) {
-        UNUSED(pDisplay);
+    bool cmsDisplayPortRegister(displayPort_t *) {
         return false;
     }
 }


### PR DESCRIPTION
Adds OSD warning and beeper pattern any time anti turtle mode is active.

Feel free to suggest a better warning text for the OSD.

Fixes #4091