### PR TITLE
Allow GYRO_CALIBRATED beeps to override the -ON_USB option

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -225,6 +225,8 @@ void beeper(beeperMode_e mode)
         mode == BEEPER_SILENCE || (
             (getBeeperOffMask() & (1 << (BEEPER_USB - 1)))
             && (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && (getBatteryCellCount() == 0))
+            && (mode != BEEPER_GYRO_CALIBRATED)  // Allow the GYRO_CALIBRATED beeps to override -ON_USB because
+                                                 // calibration can complete before the battery cells detection
         )
     ) {
         beeperSilence();


### PR DESCRIPTION
This is to prevent the suppression of the initial calibration beeps while battery cell detection is not yet completed.

The problem is caused by battery cell detection taking longer than the initial gyro calibration.  As a result the ON_USB condition is initially set because the voltage detection hasn't completed and this suppresses the gyro calibration beeps.  The downside to this is that the gyro calibration beeps will now happen when connected to USB regardless of the ON_USB setting.  Of course the user can still disable the GYRO_CALIBRATION beeper option if desired.

Addresses:
https://github.com/betaflight/betaflight/issues/4107
https://github.com/betaflight/betaflight/issues/3901