### PR TITLE
OSD power formatting

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -572,7 +572,7 @@ static void osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_POWER:
-        tfp_sprintf(buff, "%dW", getAmperage() * getBatteryVoltage() / 1000);
+        tfp_sprintf(buff, "%4dW", getAmperage() * getBatteryVoltage() / 1000);
         break;
 
     case OSD_PIDRATE_PROFILE:

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -616,24 +616,24 @@ TEST(OsdTest, TestElementPower)
     simulationBatteryVoltage = 100; // 10V
 
     // and
-    simulationBatteryAmperage = 0;
+    simulationBatteryAmperage = 0; // 0A
 
     // when
     displayClearScreen(&testDisplayPort);
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 10, "0W");
+    displayPortTestBufferSubstring(1, 10, "   0W");
 
     // given
-    simulationBatteryAmperage = 10; // 0.1AA
+    simulationBatteryAmperage = 10; // 0.1A
 
     // when
     displayClearScreen(&testDisplayPort);
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 10, "1W");
+    displayPortTestBufferSubstring(1, 10, "   1W");
 
     // given
     simulationBatteryAmperage = 120; // 1.2A
@@ -643,7 +643,7 @@ TEST(OsdTest, TestElementPower)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 10, "12W");
+    displayPortTestBufferSubstring(1, 10, "  12W");
 
     // given
     simulationBatteryAmperage = 1230; // 12.3A
@@ -653,7 +653,7 @@ TEST(OsdTest, TestElementPower)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 10, "123W");
+    displayPortTestBufferSubstring(1, 10, " 123W");
 
     // given
     simulationBatteryAmperage = 12340; // 123.4A

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -605,6 +605,68 @@ TEST(OsdTest, TestElementMahDrawn)
 }
 
 /*
+ * Tests the instantaneous electrical power OSD element.
+ */
+TEST(OsdTest, TestElementPower)
+{
+    // given
+    osdConfigMutable()->item_pos[OSD_POWER] = OSD_POS(1, 10)  | VISIBLE_FLAG;
+
+    // and
+    simulationBatteryVoltage = 100; // 10V
+
+    // and
+    simulationBatteryAmperage = 0;
+
+    // when
+    displayClearScreen(&testDisplayPort);
+    osdRefresh(simulationTime);
+
+    // then
+    displayPortTestBufferSubstring(1, 10, "0W");
+
+    // given
+    simulationBatteryAmperage = 10; // 0.1AA
+
+    // when
+    displayClearScreen(&testDisplayPort);
+    osdRefresh(simulationTime);
+
+    // then
+    displayPortTestBufferSubstring(1, 10, "1W");
+
+    // given
+    simulationBatteryAmperage = 120; // 1.2A
+
+    // when
+    displayClearScreen(&testDisplayPort);
+    osdRefresh(simulationTime);
+
+    // then
+    displayPortTestBufferSubstring(1, 10, "12W");
+
+    // given
+    simulationBatteryAmperage = 1230; // 12.3A
+
+    // when
+    displayClearScreen(&testDisplayPort);
+    osdRefresh(simulationTime);
+
+    // then
+    displayPortTestBufferSubstring(1, 10, "123W");
+
+    // given
+    simulationBatteryAmperage = 12340; // 123.4A
+
+    // when
+    displayClearScreen(&testDisplayPort);
+    osdRefresh(simulationTime);
+
+    // then
+    displayPortTestBufferSubstring(1, 10, "1234W");
+}
+
+/*
  * Tests the altitude OSD element.
  */
 TEST(OsdTest, TestElementAltitude)


### PR DESCRIPTION
Left pads the OSD power readout as per the formatting from #3615.