### PR TITLE
Reset msp handling upon receipt of new incoming frames in msp_shared

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -195,7 +195,7 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(void)
                 // TODO: CRC CHECK
                 uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + 2;
                 uint8_t *frameEnd = (uint8_t *)&crsfFrame.frame.payload + 2 + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE;
-                if(handleMspFrame(frameStart, frameEnd, MSP_FRAME_HANDLING_NORMAL)) {
+                if(handleMspFrame(frameStart, frameEnd)) {
                     scheduleMspResponse();
                 }
                 return RX_FRAME_COMPLETE;

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -284,9 +284,7 @@ static uint8_t crsfSchedule[CRSF_SCHEDULE_COUNT_MAX];
 
 #if defined(USE_MSP_OVER_TELEMETRY)
 void scheduleMspResponse() {
-    if (!mspReplyPending) {
-        mspReplyPending = true;
-    }
+    mspReplyPending = true;
 }
 
 void crsfSendMspResponse(uint8_t *payload)

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -86,13 +86,13 @@ void sendMspErrorResponse(uint8_t error, int16_t cmd)
     sbufSwitchToReader(&mspPackage.responsePacket->buf, mspPackage.responseBuffer);
 }
 
-bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd, mspFrameHandling_t handling)
+bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd)
 {
     static uint8_t mspStarted = 0;
     static uint8_t lastSeq = 0;
 
-    if (handling != MSP_FRAME_HANDLING_FORCED && sbufBytesRemaining(&mspPackage.responsePacket->buf) > 0) {
-        return false;
+    if (sbufBytesRemaining(&mspPackage.responsePacket->buf) > 0) {
+        mspStarted = 0;
     }
 
     if (mspStarted == 0) {

--- a/src/main/telemetry/msp_shared.h
+++ b/src/main/telemetry/msp_shared.h
@@ -24,11 +24,6 @@ typedef union mspTxBuffer_u {
     uint8_t crsfMspTxBuffer[CRSF_MSP_TX_BUF_SIZE];
 } mspTxBuffer_t;
 
-typedef enum mspFrameHandling_e {
-    MSP_FRAME_HANDLING_NORMAL,
-    MSP_FRAME_HANDLING_FORCED
-} mspFrameHandling_t;
-
 void initSharedMsp();
-bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd, mspFrameHandling_t handling);
+bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd);
 bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -363,7 +363,7 @@ void handleSmartPortTelemetry(void)
             uint8_t *frameStart = (uint8_t *)&smartPortRxBuffer + SMARTPORT_PAYLOAD_OFFSET;
             uint8_t *frameEnd = (uint8_t *)&smartPortRxBuffer + SMARTPORT_PAYLOAD_OFFSET + SMARTPORT_PAYLOAD_SIZE;
 
-            smartPortMspReplyPending = handleMspFrame(frameStart, frameEnd, MSP_FRAME_HANDLING_FORCED);
+            smartPortMspReplyPending = handleMspFrame(frameStart, frameEnd);
         }
 #endif
     }

--- a/src/test/unit/rx_crsf_unittest.cc
+++ b/src/test/unit/rx_crsf_unittest.cc
@@ -284,5 +284,5 @@ bool telemetryCheckRxPortShared(const serialPortConfig_t *) {return false;}
 serialPort_t *telemetrySharedPort = NULL;
 void scheduleDeviceInfoResponse(void) {};
 void scheduleMspResponse(mspPackage_t *package) { UNUSED(package); };
-bool handleMspFrame(uint8_t *, uint8_t *, mspFrameHandling_t) { return false; }
+bool handleMspFrame(uint8_t *, uint8_t *) { return false; }
 }

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -60,7 +60,7 @@ extern "C" {
     #include "telemetry/msp_shared.h"
     #include "telemetry/smartport.h"
 
-    bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd, mspFrameHandling_t handling);
+    bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd);
     bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn);
     uint8_t sbufReadU8(sbuf_t *src);
     int sbufBytesRemaining(sbuf_t *buf);
@@ -130,7 +130,7 @@ TEST(CrossFireMSPTest, ResponsePacketTest)
     crsfFrameDone = true;
     uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE + 2;
-    handleMspFrame(frameStart, frameEnd, MSP_FRAME_HANDLING_NORMAL);
+    handleMspFrame(frameStart, frameEnd);
     for (unsigned int ii=1; ii<30; ii++) {
         EXPECT_EQ(ii, sbufReadU8(&mspPackage.responsePacket->buf));
     }
@@ -151,7 +151,7 @@ TEST(CrossFireMSPTest, WriteResponseTest)
     crsfFrameDone = true;
     uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE + 2;
-    bool pending1 = handleMspFrame(frameStart, frameEnd, MSP_FRAME_HANDLING_NORMAL);
+    bool pending1 = handleMspFrame(frameStart, frameEnd);
     EXPECT_FALSE(pending1); // not done yet*/
     EXPECT_EQ(0x29, mspPackage.requestBuffer[0]);
     EXPECT_EQ(0x28, mspPackage.requestBuffer[1]);
@@ -164,7 +164,7 @@ TEST(CrossFireMSPTest, WriteResponseTest)
     crsfFrameDone = true;
     uint8_t *frameStart2 = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd2 = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE + 2;
-    bool pending2 = handleMspFrame(frameStart2, frameEnd2, MSP_FRAME_HANDLING_NORMAL);
+    bool pending2 = handleMspFrame(frameStart2, frameEnd2);
     EXPECT_FALSE(pending2); // not done yet
     EXPECT_EQ(0x23, mspPackage.requestBuffer[5]);
     EXPECT_EQ(0x46, mspPackage.requestBuffer[6]);
@@ -179,7 +179,7 @@ TEST(CrossFireMSPTest, WriteResponseTest)
     crsfFrameDone = true;
     uint8_t *frameStart3 = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd3 = frameStart3 + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE;
-    bool pending3 = handleMspFrame(frameStart3, frameEnd3, MSP_FRAME_HANDLING_NORMAL);
+    bool pending3 = handleMspFrame(frameStart3, frameEnd3);
     EXPECT_FALSE(pending3); // not done yet
     EXPECT_EQ(0x0F, mspPackage.requestBuffer[12]);
     EXPECT_EQ(0x00, mspPackage.requestBuffer[13]);
@@ -194,7 +194,7 @@ TEST(CrossFireMSPTest, WriteResponseTest)
     crsfFrameDone = true;
     uint8_t *frameStart4 = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd4 = frameStart4 + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE;
-    bool pending4 = handleMspFrame(frameStart4, frameEnd4, MSP_FRAME_HANDLING_NORMAL);
+    bool pending4 = handleMspFrame(frameStart4, frameEnd4);
     EXPECT_FALSE(pending4); // not done yet
     EXPECT_EQ(0x21, mspPackage.requestBuffer[19]);
     EXPECT_EQ(0x53, mspPackage.requestBuffer[20]);
@@ -210,7 +210,7 @@ TEST(CrossFireMSPTest, WriteResponseTest)
     crsfFrameDone = true;
     uint8_t *frameStart5 = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd5 = frameStart2 + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE;
-    bool pending5 = handleMspFrame(frameStart5, frameEnd5, MSP_FRAME_HANDLING_NORMAL);
+    bool pending5 = handleMspFrame(frameStart5, frameEnd5);
     EXPECT_TRUE(pending5); // not done yet
     EXPECT_EQ(0x00, mspPackage.requestBuffer[26]);
     EXPECT_EQ(0x37, mspPackage.requestBuffer[27]);
@@ -233,7 +233,7 @@ TEST(CrossFireMSPTest, SendMspReply) {
     crsfFrameDone = true;
     uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + 2;
     uint8_t *frameEnd = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_RX_MSP_PAYLOAD_SIZE + 2;
-    bool handled = handleMspFrame(frameStart, frameEnd, MSP_FRAME_HANDLING_NORMAL);
+    bool handled = handleMspFrame(frameStart, frameEnd);
     EXPECT_TRUE(handled);
     bool replyPending = sendMspReply(64, &testSendMspResponse);
     EXPECT_FALSE(replyPending);

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -330,6 +330,6 @@ int32_t getMAhDrawn(void){
 }
 
 bool sendMspReply(uint8_t, mspResponseFnPtr) { return false; }
-bool handleMspFrame(uint8_t *, uint8_t *, mspFrameHandling_t) { return false; }
+bool handleMspFrame(uint8_t *, uint8_t *)  { return false; }
 
 }


### PR DESCRIPTION
This change will simply reset the msp handling routine entirely upon receipt of a new request frame.  This restores original/expected SmartPort functionality while simplifying the implementation in both CRSF and SmartPort. Tested reads and writes on both SmartPort and CRSF.