### PR TITLE
BEEPER_USB flag will silence the beeper only when battery is really not present

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -224,7 +224,6 @@ void beeper(beeperMode_e mode)
     if (
         mode == BEEPER_SILENCE || (
             (getBeeperOffMask() & (1 << (BEEPER_USB - 1)))
-            && batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE 
             && getBatteryState() == BATTERY_NOT_PRESENT
         )
     ) {

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -224,7 +224,8 @@ void beeper(beeperMode_e mode)
     if (
         mode == BEEPER_SILENCE || (
             (getBeeperOffMask() & (1 << (BEEPER_USB - 1)))
-            && (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && (getBatteryCellCount() == 0))
+            && batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE 
+            && getBatteryState() == BATTERY_NOT_PRESENT
         )
     ) {
         beeperSilence();

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -154,6 +154,7 @@ static void updateBatteryBeeperAlert(void)
             break;
         case BATTERY_OK:
         case BATTERY_NOT_PRESENT:
+        case BATTERY_INIT:
             break;
     }
 }
@@ -168,7 +169,7 @@ void batteryUpdatePresence(void)
 
 
     if (
-        voltageState == BATTERY_NOT_PRESENT
+        (voltageState == BATTERY_NOT_PRESENT || voltageState == BATTERY_INIT)
         && isVoltageFromBat
         && isVoltageStable
     ) {
@@ -275,7 +276,7 @@ batteryState_e getBatteryState(void)
     return batteryState;
 }
 
-const char * const batteryStateStrings[] = {"OK", "WARNING", "CRITICAL", "NOT PRESENT"};
+const char * const batteryStateStrings[] = {"OK", "WARNING", "CRITICAL", "NOT PRESENT", "INIT"};
 
 const char * getBatteryStateString(void)
 {
@@ -287,13 +288,13 @@ void batteryInit(void)
     //
     // presence
     //
-    batteryState = BATTERY_NOT_PRESENT;
+    batteryState = BATTERY_INIT;
     batteryCellCount = 0;
 
     //
     // voltage
     //
-    voltageState = BATTERY_NOT_PRESENT;
+    voltageState = BATTERY_INIT;
     batteryWarningVoltage = 0;
     batteryCriticalVoltage = 0;
     lowVoltageCutoff.enabled = false;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -59,7 +59,8 @@ typedef enum {
     BATTERY_OK = 0,
     BATTERY_WARNING,
     BATTERY_CRITICAL,
-    BATTERY_NOT_PRESENT
+    BATTERY_NOT_PRESENT,
+    BATTERY_INIT
 } batteryState_e;
 
 void batteryInit(void);


### PR DESCRIPTION
Issue #4115 partial workarround

Since battery initialization is asynchronous we need to handle initialization state. Second change adjusting BEEPER_USB usage only when the batteryState is really detected, so the gyro calibration beeps always happen also on USB.



