### PR TITLE
Show MSP API version in cli

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -36,3 +36,5 @@ extern const char* const buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
 
 #define BUILD_TIME_LENGTH 8
 extern const char* const buildTime;  // "HH:MM:SS"
+
+#define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR)

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -114,6 +114,8 @@ extern uint8_t __config_end;
 #include "io/vtx_rtc6705.h"
 #include "io/vtx_control.h"
 
+#include "msp/msp_protocol.h"
+
 #include "rx/rx.h"
 #include "rx/spektrum.h"
 #include "rx/frsky_d.h"
@@ -3079,14 +3081,15 @@ static void cliVersion(char *cmdline)
 {
     UNUSED(cmdline);
 
-    cliPrintLinef("# %s / %s (%s) %s %s / %s (%s)",
+    cliPrintLinef("# %s / %s (%s) %s %s / %s (%s) MSP API: %s",
         FC_FIRMWARE_NAME,
         targetName,
         systemConfig()->boardIdentifier,
         FC_VERSION_STRING,
         buildDate,
         buildTime,
-        shortGitRevision
+        shortGitRevision,
+        MSP_API_VERSION_STRING
     );
 }
 


### PR DESCRIPTION
Shows the MSP api version in the cli under `version`. In this case `1.36`

```
# version
# Betaflight / SPRACINGF3 (SRF3) 3.2.0 Sep 10 2017 / 21:24:44 (a8ad6f645) 1.36
```