### PR TITLE
Adds full MSP api version

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -37,4 +37,4 @@ extern const char* const buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
 #define BUILD_TIME_LENGTH 8
 extern const char* const buildTime;  // "HH:MM:SS"
 
-#define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR) "." STR(MSP_PROTOCOL_VERSION)
+#define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR) ".0"

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -37,4 +37,4 @@ extern const char* const buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
 #define BUILD_TIME_LENGTH 8
 extern const char* const buildTime;  // "HH:MM:SS"
 
-#define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR)
+#define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR) "." STR(MSP_PROTOCOL_VERSION)


### PR DESCRIPTION
The api version is 3 digits. This changes the output from `1.36` to `1.36.0`

I'm not positive that `MSP_PROTOCOL_VERSION` is the variable that defines the 3rd digit, but it is the only variable that is currently set to `0` inside `msp_protocol.h`, so thats my best guess. 

Before
```
# version
# Betaflight / SPRACINGF3 (SRF3) 3.2.0 Sep 11 2017 / 08:47:24 (b1f47c8a8) MSP API: 1.36
```

after
```
# version
# Betaflight / SPRACINGF3 (SRF3) 3.2.0 Sep 11 2017 / 08:47:24 (b1f47c8a8) MSP API: 1.36.0
```