### PR TITLE
"diff|dump all" export can be used as direct copy/paste import

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2762,9 +2762,19 @@ static void cliSave(char *cmdline)
 
 static void cliDefaults(char *cmdline)
 {
+    bool saveConfigs;
+
+    if (isEmpty(cmdline)) {
+        saveConfigs = true;
+    } else if (strncasecmp(cmdline, "nosave", 6) == 0) {
+        saveConfigs = false;
+    } else {
+        return;
+    }
+
     cliPrintHashLine("resetting to defaults");
     resetConfigs();
-    if (isEmpty(cmdline)) {
+    if (saveConfigs) {
         cliSave(NULL);
     }
 }

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2762,11 +2762,11 @@ static void cliSave(char *cmdline)
 
 static void cliDefaults(char *cmdline)
 {
-    UNUSED(cmdline);
-
     cliPrintHashLine("resetting to defaults");
-    resetEEPROM();
-    cliReboot();
+    resetConfigs();
+    if (isEmpty(cmdline)) {
+        cliSave(NULL);
+    }
 }
 
 STATIC_UNIT_TESTED void cliGet(char *cmdline)
@@ -3435,7 +3435,7 @@ static void printConfig(char *cmdline, bool doDiff)
 
         if ((dumpMask & (DUMP_ALL | DO_DIFF)) == (DUMP_ALL | DO_DIFF)) {
             cliPrintHashLine("reset configuration to default settings");
-            cliPrint("defaults");
+            cliPrint("defaults nosave");
             cliPrintLinefeed();
         }
 
@@ -3600,7 +3600,7 @@ const clicmd_t cmdTable[] = {
 #ifdef LED_STRIP
     CLI_COMMAND_DEF("color", "configure colors", NULL, cliColor),
 #endif
-    CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", NULL, cliDefaults),
+    CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", "[nosave]", cliDefaults),
     CLI_COMMAND_DEF("diff", "list configuration changes from default",
         "[master|profile|rates|all] {defaults}", cliDiff),
 #ifdef USE_DSHOT


### PR DESCRIPTION
This is fix for #3973

"defaults" command causing reboot of the FC and ignoring remaining part of the pasted commands from "diff|dump all" exports. This change adding "nosave" parameter/functionality for the "defaults" command and "diff|dump all" exports. This parameter will not save eeprom and do not reboot the FC. The implementation is minimalistics as posible.