### PR TITLE
Fix define dependencies for VTX code

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -21,7 +21,7 @@
 
 #include "platform.h"
 
-#ifdef CMS
+#if defined(CMS) && defined(VTX_SMARTAUDIO)
 
 #include "common/printf.h"
 #include "common/utils.h"

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -21,7 +21,8 @@
 
 #include "platform.h"
 
-#ifdef CMS
+#if defined(CMS) && defined(VTX_TRAMP)
+
 #include "common/printf.h"
 #include "common/utils.h"
 

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -56,3 +56,11 @@
 #undef USE_MSP_OVER_TELEMETRY
 #endif
 #endif
+
+/* If either VTX_CONTROL or VTX_COMMON is undefined then remove common code and device drivers */
+#if !defined(VTX_COMMON) || !defined(VTX_CONTROL)
+#undef VTX_COMMON
+#undef VTX_CONTROL
+#undef VTX_TRAMP
+#undef VTX_SMARTAUDIO
+#endif


### PR DESCRIPTION
Ensures CMS menus are only compiled if the required device driver is also compiled and removes compilation of device drivers and common code if either `VTX_COMMON` or `VTX_CONTROL` are undefined.

Fixes #4147 