### PR TITLE
Low Race band support for TBS Smart Audio and IRC Tramp telemetry

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -80,11 +80,9 @@ void saCmsUpdate(void)
 
         saCmsFselMode = (saDevice.mode & SA_MODE_GET_FREQ_BY_FREQ) ? 1 : 0;
 
-        saCmsBand = (saDevice.channel / 8) + 1;
-        saCmsChan = (saDevice.channel % 8) + 1;
-        saCmsFreqRef = vtx58frequencyTable[saDevice.channel / 8][saDevice.channel % 8];
-
-        saCmsDeviceFreq = vtx58frequencyTable[saDevice.channel / 8][saDevice.channel % 8];
+        saCmsBand = saGetBand(saDevice.channel) + 1;
+        saCmsChan = saGetChannel(saDevice.channel) + 1;
+        saCmsFreqRef = saCmsDeviceFreq = vtx58frequencyTable[saGetBand(saDevice.channel)][saGetChannel(saDevice.channel)];
 
         if ((saDevice.mode & SA_MODE_GET_PITMODE) == 0) {
             saCmsRFState = SACMS_TXMODE_ACTIVE;
@@ -137,8 +135,9 @@ if (saDevice.version == 2) {
     saCmsStatusString[0] = "-FR"[saCmsOpmodel];
 
     if (saCmsFselMode == 0) {
-        saCmsStatusString[2] = "ABEFR"[saDevice.channel / 8];
-        saCmsStatusString[3] = '1' + (saDevice.channel % 8);
+        uint8_t band = saGetBand(saDevice.channel);
+        saCmsStatusString[2] = vtx58BandLetter[band < VTX_SA_BAND_COUNT ? band + 1 : 0];
+        saCmsStatusString[3] = '1' + saGetChannel(saDevice.channel);
     } else {
         saCmsStatusString[2] = 'U';
         saCmsStatusString[3] = 'F';
@@ -151,7 +150,7 @@ if (saDevice.version == 2) {
         tfp_sprintf(&saCmsStatusString[5], "%4d", saDevice.freq);
     else
         tfp_sprintf(&saCmsStatusString[5], "%4d",
-            vtx58frequencyTable[saDevice.channel / 8][saDevice.channel % 8]);
+            vtx58frequencyTable[saGetBand(saDevice.channel)][saGetChannel(saDevice.channel)]);
 
     saCmsStatusString[9] = ' ';
 
@@ -340,7 +339,7 @@ static CMS_Menu saCmsMenuStats = {
     .entries = saCmsMenuStatsEntries
 };
 
-static OSD_TAB_t saCmsEntBand = { &saCmsBand, 5, vtx58BandNames };
+static OSD_TAB_t saCmsEntBand = { &saCmsBand, VTX_SA_BAND_COUNT, vtx58BandNames };
 
 static OSD_TAB_t saCmsEntChan = { &saCmsChan, 8, vtx58ChannelNames };
 
@@ -352,9 +351,9 @@ static const char * const saCmsPowerNames[] = {
     "800",
 };
 
-static OSD_TAB_t saCmsEntPower = { &saCmsPower, 4, saCmsPowerNames};
+static OSD_TAB_t saCmsEntPower = { &saCmsPower, VTX_SA_POWER_COUNT, saCmsPowerNames};
 
-static OSD_UINT16_t saCmsEntFreqRef = { &saCmsFreqRef, 5600, 5900, 0 };
+static OSD_UINT16_t saCmsEntFreqRef = { &saCmsFreqRef, 5300, 5950, 0 };
 
 static const char * const saCmsOpmodelNames[] = {
     "----",

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -62,15 +62,15 @@ uint8_t trampCmsBand = 1;
 uint8_t trampCmsChan = 1;
 uint16_t trampCmsFreqRef;
 
-static OSD_TAB_t trampCmsEntBand = { &trampCmsBand, 5, vtx58BandNames };
+static OSD_TAB_t trampCmsEntBand = { &trampCmsBand, VTX_TRAMP_BAND_COUNT, vtx58BandNames };
 
 static OSD_TAB_t trampCmsEntChan = { &trampCmsChan, 8, vtx58ChannelNames };
 
-static OSD_UINT16_t trampCmsEntFreqRef = { &trampCmsFreqRef, 5600, 5900, 0 };
+static OSD_UINT16_t trampCmsEntFreqRef = { &trampCmsFreqRef, 5300, 5950, 0 };
 
 static uint8_t trampCmsPower = 1;
 
-static OSD_TAB_t trampCmsEntPower = { &trampCmsPower, 5, trampPowerNames };
+static OSD_TAB_t trampCmsEntPower = { &trampCmsPower, VTX_TRAMP_POWER_COUNT, trampPowerNames };
 
 static void trampCmsUpdateFreqRef(void)
 {

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#define VTX_SA_BAND_COUNT 6
+#define VTX_SA_POWER_COUNT 4
+
 // opmode flags, GET side
 #define SA_MODE_GET_FREQ_BY_FREQ            1
 #define SA_MODE_GET_PITMODE                 2
@@ -10,7 +13,7 @@
 
 // opmode flags, SET side
 #define SA_MODE_SET_IN_RANGE_PITMODE        1 // Immediate
-#define SA_MODE_SET_OUT_RANGE_PITMODE        2 // Immediate
+#define SA_MODE_SET_OUT_RANGE_PITMODE       2 // Immediate
 #define SA_MODE_CLR_PITMODE                 4 // Immediate
 #define SA_MODE_SET_UNLOCK                  8
 #define SA_MODE_SET_LOCK                    0 // ~UNLOCK
@@ -56,6 +59,8 @@ extern uint16_t sa_smartbaud;
 extern bool saDeferred;
 
 int saDacToPowerIndex(int dac);
+uint8_t saGetBand(int8_t deviceChannel);
+uint8_t saGetChannel(int8_t deviceChannel);
 void saSetBandAndChannel(uint8_t band, uint8_t channel);
 void saSetMode(int mode);
 void saSetPowerByIndex(uint8_t index);

--- a/src/main/io/vtx_string.c
+++ b/src/main/io/vtx_string.c
@@ -24,16 +24,18 @@
 
 #include "platform.h"
 #include "build/debug.h"
+#include "common/utils.h"
 
 #if defined(VTX_COMMON)
 
-const uint16_t vtx58frequencyTable[5][8] =
+const uint16_t vtx58frequencyTable[6][8] =
 {
     { 5865, 5845, 5825, 5805, 5785, 5765, 5745, 5725 }, // Boscam A
     { 5733, 5752, 5771, 5790, 5809, 5828, 5847, 5866 }, // Boscam B
     { 5705, 5685, 5665, 5645, 5885, 5905, 5925, 5945 }, // Boscam E
     { 5740, 5760, 5780, 5800, 5820, 5840, 5860, 5880 }, // FatShark
     { 5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917 }, // RaceBand
+    { 5362, 5399, 5436, 5473, 5510, 5547, 5584, 5621 }, // LowRace
 };
 
 const char * const vtx58BandNames[] = {
@@ -43,9 +45,10 @@ const char * const vtx58BandNames[] = {
     "BOSCAM E",
     "FATSHARK",
     "RACEBAND",
+    "LOW RACE",
 };
 
-const char vtx58BandLetter[] = "-ABEFR";
+const char vtx58BandLetter[] = "-ABEFRL";
 
 const char * const vtx58ChannelNames[] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",
@@ -53,13 +56,9 @@ const char * const vtx58ChannelNames[] = {
 
 bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
 {
-    int8_t band;
-    uint8_t channel;
-
-    // Use reverse lookup order so that 5880Mhz
-    // get Raceband 7 instead of Fatshark 8.
-    for (band = 4 ; band >= 0 ; band--) {
-        for (channel = 0 ; channel < 8 ; channel++) {
+    // Use reverse lookup order so that 5880MHz get RaceBand 7 instead of FatShark 8.
+    for (int8_t band = ARRAYLEN(vtx58frequencyTable) - 1 ; band >= 0 ; band--) {
+        for (uint8_t channel = 0 ; channel < 8 ; channel++) {
             if (vtx58frequencyTable[band][channel] == freq) {
                 *pBand = band + 1;
                 *pChannel = channel + 1;

--- a/src/main/io/vtx_string.h
+++ b/src/main/io/vtx_string.h
@@ -4,7 +4,7 @@
 
 #if defined(VTX_COMMON)
 
-extern const uint16_t vtx58frequencyTable[5][8];
+extern const uint16_t vtx58frequencyTable[6][8];
 extern const char * const vtx58BandNames[];
 extern const char * const vtx58ChannelNames[];
 extern const char vtx58BandLetter[];

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -53,9 +53,9 @@ const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1] = {
 static const vtxVTable_t trampVTable; // forward
 static vtxDevice_t vtxTramp = {
     .vTable = &trampVTable,
-    .capability.bandCount = 5,
+    .capability.bandCount = VTX_TRAMP_BAND_COUNT,
     .capability.channelCount = 8,
-    .capability.powerCount = sizeof(trampPowerTable),
+    .capability.powerCount = VTX_TRAMP_POWER_COUNT,
     .bandNames = (char **)vtx58BandNames,
     .channelNames = (char **)vtx58ChannelNames,
     .powerNames = (char **)trampPowerNames,

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#define VTX_TRAMP_BAND_COUNT 6
 #define VTX_TRAMP_POWER_COUNT 5
+
 extern const uint16_t trampPowerTable[VTX_TRAMP_POWER_COUNT];
 extern const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1];
 


### PR DESCRIPTION
<img width="533" alt="screen shot 2017-09-19 at 03 44 41" src="https://user-images.githubusercontent.com/194765/30570917-f537ccd4-9cec-11e7-8309-c6bc09915815.png">

This pull request adds support for "Low Race" band selection to BetaFlight's TBS Smart Audio and IRC Tramp telemetry support features.

* On TBS Unify vtx it is already possible to use Low Race band frequencies by switching Smart Audio device in "user frequency" mode. However, normally Unify vtx operates in "channel" mode and Low Race band is available to switch to via physical button. Switching to any of Low Race band channels in "channel mode" with push button results in wrong vtx status line presentation in OSD, since BF's Smart Audio support code is not ready for vtx reporting back channels above band 5 (RaceBand). For example, this code:
```
     saCmsStatusString[2] = "ABEFR"[saDevice.channel / 8];
```
when `saDevice.channel / 8` is `6` (Low Race) results in `'\0'` character (for band presentation) that effectively terminates the status line of OSD menu :)

* On IRC Tramp the Low Race band frequencies are only available via "Touch'n'Race mini-wand" device, however Tramp Telemetry protocol supports setting arbitrary frequency (in fact it always works in "user frequency" mode). For some reason Tramp telemetry OSD submenu do not allows entering user frequency like in Smart Audio (I'll hope to implement this if anyone is interesting in this Low Race pull request at all). So at this point I don't see any reasons not to extend the list of well-known channels to include Low Race band, this would unify experience with the Smart Audio devices a bit.

### Demo

Here is the silly video to demonstrate Low Race band selection working on IRC Tramp HV and TBS Unify HV Race Edition: https://www.youtube.com/watch?v=lZtmJLU3Yqk

### Known issues

* For some reason TBS Unify vtx in channel selection mode has reversed order of Low Race channels (reversed from the table included with the vtx). I've asked multiple pilots and they do confirm this behavior on Unify HV and Unify HV Race Edition vtx. This applies not only for Smart Audio interface, but for physical button as well — setting channel 6-1 via push button results in transmission on 5621 MHz frequency (this is Low Race #8), settings 6-8 results in 5362 MHz (Low Race #1).

I decided to abstract this from user by doing the channel number "inversion" when sending/receiving data from Smart Audio interface (new `saGetChannel`/`saGetBand` functions to decompose repeating receive code and a fixup in `saSetBandAndChannel` send function).

This works great, hovewer I saw somewhere (in Joshua Bardwell videos I think) that there is some less-known Smart Audio compatible vtx and it maybe do not has this weird reverse channel order for Low Race band. To be fair I'm not sure this is an issue at all, just saying to inform.

* This pull request completely ignores RTC6705 vtx support, since I don't have hardware to test.

* BetaFlight OpenTX lua script currently crashes when switching on the third vtx page, but that's easily fixable and do not prevents to set PIDs and Rates.