### PR TITLE
F3/F4 PPM & PWM: Do proper IOConfigGPIOAF in ppmRxInit and pwmRxInit

### DIFF
--- a/src/main/drivers/rx_pwm.c
+++ b/src/main/drivers/rx_pwm.c
@@ -385,12 +385,9 @@ void pwmRxInit(const pwmConfig_t *pwmConfig)
         IOInit(io, OWNER_PWMINPUT, RESOURCE_INDEX(channel));
 #ifdef STM32F1
         IOConfigGPIO(io, IOCFG_IPD);
-#elif defined(STM32F7)
-        IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 #else
-        IOConfigGPIO(io, IOCFG_AF_PP);
+        IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 #endif
-
         timerConfigure(timer, (uint16_t)PWM_TIMER_PERIOD, PWM_TIMER_1MHZ);
         timerChCCHandlerInit(&port->edgeCb, pwmEdgeCallback);
         timerChOvrHandlerInit(&port->overflowCb, pwmOverflowCallback);
@@ -442,10 +439,8 @@ void ppmRxInit(const ppmConfig_t *ppmConfig)
     IOInit(io, OWNER_PPMINPUT, 0);
 #ifdef STM32F1
     IOConfigGPIO(io, IOCFG_IPD);
-#elif defined(STM32F7)
-    IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 #else
-    IOConfigGPIO(io, IOCFG_AF_PP);
+    IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 #endif
 
     timerConfigure(timer, (uint16_t)PPM_TIMER_PERIOD, PWM_TIMER_1MHZ);


### PR DESCRIPTION
PR status: Ready to merge

Fixes #4178.

#3991 should have included this.