### PR TITLE
F3EVO,F4EVO,F4NEO: Liberation from RTC6705 locked VTX feature.

### DIFF
--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -42,6 +42,11 @@ void vtxCommonRegisterDevice(vtxDevice_t *pDevice)
     vtxDevice = pDevice;
 }
 
+bool vtxCommonDeviceRegistered(void)
+{
+    return vtxDevice;
+}
+
 void vtxCommonProcess(uint32_t currentTimeUs)
 {
     if (!vtxDevice)

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -78,6 +78,7 @@ typedef struct vtxVTable_s {
 
 void vtxCommonInit(void);
 void vtxCommonRegisterDevice(vtxDevice_t *pDevice);
+bool vtxCommonDeviceRegistered(void);
 
 // VTable functions
 void vtxCommonProcess(uint32_t currentTimeUs);

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -677,7 +677,7 @@ void init(void)
 #endif
 
 #ifdef VTX_RTC6705
-#ifdef VTX_RTC6705OPTIONAL
+#ifdef VTX_RTC6705_OPTIONAL
     if (!vtxCommonDeviceRegistered()) // external VTX takes precedence when configured.
 #endif
     {


### PR DESCRIPTION
PR status: Need review

Users of SPRacing F3 EVO, F4 EVO and F4 NEO has been suffering from their VTX feature locked to SPI-connected RTC6705. There is `VTX_RTC6705_OPTIONAL` option that enables a code to prevent this from happening, but it was not active due to a typo. A function to test if there is another VTX device already registered was also missing.

