### PR TITLE
Disable baro in favor of the (presumably) more useful BLHeli 4way IF on Naze

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -100,9 +100,9 @@
 #define ACC_BMA280_ALIGN        CW0_DEG
 #define ACC_MPU6500_ALIGN       CW0_DEG
 
-#define BARO
-#define USE_BARO_MS5611 // needed for Flip32 board
-#define USE_BARO_BMP280
+//#define BARO
+//#define USE_BARO_MS5611 // needed for Flip32 board
+//#define USE_BARO_BMP280
 
 /*
 #define MAG
@@ -150,6 +150,8 @@
 #define USE_SPEKTRUM_BIND_PIN
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 // IO - assuming all IOs on 48pin package
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
Without GPS support, baro support is less important than 4way interface. Not to mention that it doesn't seem to be documented that the BLHeli interface is disabled on Naze.