### PR TITLE
Fast camera control mode

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -57,6 +57,7 @@
 #include "sensors/acceleration.h"
 
 #include "rx/rx.h"
+#include "scheduler/scheduler.h"
 
 #include "flight/pid.h"
 #include "flight/navigation.h"
@@ -122,7 +123,7 @@ throttleStatus_e calculateThrottleStatus(void)
 void processRcStickPositions(throttleStatus_e throttleStatus)
 {
     // RC refresh rate converted to number of time the sticks must be maintained
-    uint8_t rcDelayTicks = constrain(RC_DELAY_TIME / rxGetRefreshRate(), 10, 20);
+    uint8_t rcDelayTicks = constrain(RC_DELAY_TIME / getTaskDeltaTime(TASK_RX), 10, 20);
     // indicates the number of time the sticks are maintained
     static uint8_t rcDelayCommand;
     // hold sticks position for command combos

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -118,11 +118,17 @@ throttleStatus_e calculateThrottleStatus(void)
     return THROTTLE_HIGH;
 }
 
+#define RC_DELAY_TIME 222000 //usec
 void processRcStickPositions(throttleStatus_e throttleStatus)
 {
-    static uint8_t rcDelayCommand;      // this indicates the number of time (multiple of RC measurement at 50Hz) the sticks must be maintained to run or switch off motors
-    static uint8_t rcSticks;            // this hold sticks position for command combos
-    static uint8_t rcDisarmTicks;       // this is an extra guard for disarming through switch to prevent that one frame can disarm it
+    // RC refresh rate converted to number of time the sticks must be maintained
+    uint8_t rcDelayTicks = constrain(RC_DELAY_TIME / rxGetRefreshRate(), 10, 20);
+    // indicates the number of time the sticks are maintained
+    static uint8_t rcDelayCommand;
+    // hold sticks position for command combos
+    static uint8_t rcSticks;
+    // an extra guard for disarming through switch to prevent that one frame can disarm it
+    static uint8_t rcDisarmTicks;
     uint8_t stTmp = 0;
     int i;
 
@@ -172,7 +178,7 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
         }
     }
 
-    if (rcDelayCommand != 20) {
+    if (rcDelayCommand != rcDelayTicks) {
         return;
     }
 

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -155,6 +155,32 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
     rcSticks = stTmp;
 
     // perform actions
+#ifdef USE_CAMERA_CONTROL
+    static bool inCameraControlMode = false;
+    if (inCameraControlMode) {
+        if (rcDelayCommand == rcDelayTicks / 4) {
+            if (rcSticks == THR_CE + YAW_HI + PIT_CE + ROL_CE) {
+                cameraControlKeyPress(CAMERA_CONTROL_KEY_ENTER, 0);
+            } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_LO) {
+                cameraControlKeyPress(CAMERA_CONTROL_KEY_LEFT, 0);
+            } else if (rcSticks == THR_CE + YAW_CE + PIT_HI + ROL_CE) {
+                cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 0);
+            } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_HI) {
+                cameraControlKeyPress(CAMERA_CONTROL_KEY_RIGHT, 0);
+            } else if (rcSticks == THR_CE + YAW_CE + PIT_LO + ROL_CE) {
+                cameraControlKeyPress(CAMERA_CONTROL_KEY_DOWN, 0);
+            } else if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_CE) {
+                cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 2000);
+            }
+        }
+        if (rcSticks == THR_CE + YAW_LO + PIT_CE + ROL_CE && rcDelayCommand == rcDelayTicks) {
+            inCameraControlMode = false;
+            beeperConfirmationBeeps(2);
+        }
+        return;
+    }
+#endif
+
     if (!isUsingSticksToArm) {
 
         if (IS_RC_MODE_ACTIVE(BOXARM)) {
@@ -320,18 +346,9 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
 
 #ifdef USE_CAMERA_CONTROL
     if (rcSticks == THR_CE + YAW_HI + PIT_CE + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_ENTER, 0);
-    } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_LO) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_LEFT, 0);
-    } else if (rcSticks == THR_CE + YAW_CE + PIT_HI + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 0);
-    } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_HI) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_RIGHT, 0);
-    } else if (rcSticks == THR_CE + YAW_CE + PIT_LO + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_DOWN, 0);
-    } else if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 2000);
-   }
+        inCameraControlMode = true;
+        beeperConfirmationBeeps(1);
+    }
 #endif
 }
 


### PR DESCRIPTION
This is major improvement to camera control feature. First commit fixing problem with stick command timing dependedency from RX refresh rate. Timing has been normalized to feeling with sbus receiver (0.222s to enter stick command). Second commit adding new fast camera control mode. Yaw Right will enter the mode with one beep confirmation, Yaw Left will exit the mode with 2 beeps confirmation. During this mode arming is disabled and stick commands response are 4 times fater than before (8 times with PPM and other slow receivers due to normalization of timing)