### PR TITLE
Remove space from arming disabled flag print name for readability

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -31,8 +31,8 @@ static uint32_t enabledSensors = 0;
 
 #if defined(OSD) || !defined(MINIMAL_CLI)
 const char *armingDisableFlagNames[]= {
-    "NOGYRO", "FAILSAFE", "RX LOSS", "BAD RX", "BOXFAILSAFE",
-    "THROTTLE", "ANGLE", "BOOT GRACE", "NO PREARM", "ARM SWITCH",
+    "NOGYRO", "FAILSAFE", "RXLOSS", "BADRX", "BOXFAILSAFE",
+    "THROTTLE", "ANGLE", "BOOTGRACE", "NOPREARM", "ARMSWITCH",
     "LOAD", "CALIB", "CLI", "CMS", "OSD", "BST"
 };
 #endif


### PR DESCRIPTION
PR status: Ready to merge

Delete spaces from each names of arming disabled flags to increase readability, e.g.,
```
BOXFAILSAFE BAD RX RX LOSS NOGYRO
```
to
```
BOXFAILSAFE BADRX RXLOSS NOGYRO
```

The names are also used in OSD, but I think this change will not affect the function.