### PR TITLE
Fast stick commands

### DIFF
--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -48,6 +48,8 @@ extern "C" {
     #include "fc/rc_adjustments.h"
 
     #include "fc/rc_controls.h"
+
+    #include "scheduler/scheduler.h"
 }
 
 #include "unittest_macros.h"
@@ -703,4 +705,5 @@ int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 rxRuntimeConfig_t rxRuntimeConfig;
 PG_REGISTER(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 0);
 void resetArmingDisabled(void) {}
+timeDelta_t getTaskDeltaTime(cfTaskId_e) { return 20000; }
 }


### PR DESCRIPTION
This is major improvement to camera control feature. This PR fixing slow stick command response when using slower RX protocols like PPM, command delay has been normalized across all receiver protocols to 0.5s for arm/disarm and 0.05s for other stick commands.

@DieHertz thanks, i completly reworked this PR by your suggestions from #4201