### PR TITLE
EXTI2_TS_IRQHandler is actually only on F3, F4 startup files point to…

### DIFF
--- a/src/main/drivers/exti.c
+++ b/src/main/drivers/exti.c
@@ -207,9 +207,9 @@ void EXTI_IRQHandler(void)
 
 _EXTI_IRQ_HANDLER(EXTI0_IRQHandler);
 _EXTI_IRQ_HANDLER(EXTI1_IRQHandler);
-#if defined(STM32F1) || defined(STM32F7)
+#if defined(STM32F1) || defined(STM32F4) || defined(STM32F7)
 _EXTI_IRQ_HANDLER(EXTI2_IRQHandler);
-#elif defined(STM32F3) || defined(STM32F4)
+#elif defined(STM32F3)
 _EXTI_IRQ_HANDLER(EXTI2_TS_IRQHandler);
 #else
 # warning "Unknown CPU"


### PR DESCRIPTION
… EXTI2_IRQHandler for pins on line 2

https://github.com/betaflight/betaflight/blob/master/src/main/startup/startup_stm32f40xx.s#L274
https://github.com/betaflight/betaflight/blob/master/src/main/startup/startup_stm32f411xe.s#L207

note, startup_stm32f446xx.s appears to be missing from https://github.com/betaflight/betaflight/blob/master/make/mcu/STM32F4.mk#L149 ?


