### PR TITLE
Preinit for MAX7456 on Kakute F4 requires output hi.

### DIFF
--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -87,6 +87,8 @@ typedef enum SPIDevice {
 #define SPI_DEV_TO_CFG(x)   ((x) + 1)
 
 void spiPreInitCs(ioTag_t iotag);
+void spiPreInitCsOutPU(ioTag_t iotag);
+
 bool spiInit(SPIDevice device);
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor);
 uint8_t spiTransferByte(SPI_TypeDef *instance, uint8_t data);

--- a/src/main/drivers/bus_spi_config.c
+++ b/src/main/drivers/bus_spi_config.c
@@ -25,7 +25,14 @@
 
 // Bring a pin for possible CS line to pull-up state in preparation for
 // sequential initialization by relevant drivers.
-// Note that the pin is set to input for safety at this point.
+
+// There are two versions:
+// spiPreInitCs set the pin to input with pullup (IOCFG_IPU) for safety at this point.
+// spiPreInitCsOutPU which actually drive the pin for digital hi.
+//
+// The later is required for SPI slave devices on some targets, interfaced through level shifters, such as Kakute F4.
+// Note that with this handling, a pin declared as CS pin for MAX7456 needs special care when re-purposing the pin for other, especially, input uses.
+// This will/should be fixed when we go fully reconfigurable.
 
 void spiPreInitCs(ioTag_t iotag)
 {
@@ -33,5 +40,15 @@ void spiPreInitCs(ioTag_t iotag)
     if (io) {
         IOInit(io, OWNER_SPI_PREINIT, 0);
         IOConfigGPIO(io, IOCFG_IPU);
+    }
+}
+
+void spiPreInitCsOutPU(ioTag_t iotag)
+{
+    IO_t io = IOGetByTag(iotag);
+    if (io) {
+        IOInit(io, OWNER_SPI_PREINIT, 0);
+        IOConfigGPIO(io, IOCFG_OUT_PP);
+        IOHi(io);
     }
 }

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -213,7 +213,7 @@ void spiPreInit(void)
     spiPreInitCs(IO_TAG(L3GD20_CS_PIN));
 #endif
 #ifdef USE_MAX7456
-    spiPreInitCs(IO_TAG(MAX7456_SPI_CS_PIN));
+    spiPreInitCsOutPU(IO_TAG(MAX7456_SPI_CS_PIN)); // XXX 3.2 workaround for Kakute F4. See comment for spiPreInitCSOutPU.
 #endif
 #ifdef USE_SDCARD
     spiPreInitCs(IO_TAG(SDCARD_SPI_CS_PIN));


### PR DESCRIPTION
PR status: Ready to merge

Per #4223.

CS pins for all configured SPI slave devices are initialized as hi by `IOCFG_IPU` from `init` via `spiPreInit` and `spiPreInitCs` at the time of SPI bus initialization, to avoid slave devices sharing a bus from reacting to transactions destined for other slave devices.

However, it is found out that on some targets using the original 5V MAX7456 with logic level shifter that requires output driving capability to bring the pin hi.

This PR adds output hi drive type `spiPreInitCsOutPP` for MAX7456 to cope with this situation.

Note that, towards full configurability, how `spiPreInit` calls `spiPreInitCs` and with which pull up method should be revisited (it currently use fixed pin; should use xxxPinConfig at least).
