### PR TITLE
Add UART1 inverter to YupiF4 target

### DIFF
--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -34,8 +34,6 @@
 #define BEEPER_OPT              PB14
 #define BEEPER_PWM_HZ           3150 // Beeper PWM frequency in Hz
 
-#define INVERTER_PIN_UART6      PB15
-
 // Gyro interrupt
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
@@ -72,6 +70,7 @@
 
 // UART Ports
 #define USE_UART1
+#define INVERTER_PIN_UART1      PB12
 #define UART1_RX_PIN            PA10
 #define UART1_TX_PIN            PA9
 
@@ -80,6 +79,7 @@
 #define UART3_TX_PIN            PB10
 
 #define USE_UART6
+#define INVERTER_PIN_UART6      PB15
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 


### PR DESCRIPTION
Sorry I forgot this to the last PR...
Only target.h file of the YupiF4 board is modified to add the support of the UART1 inverter.