### PR TITLE
Update Vagrant env with libblocksruntime-dev required by unittest.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,7 @@ Vagrant.configure(2) do |config|
     apt-get update
     apt-get install -y git gcc-arm-embedded=6-2017q2-1~xenial1
     apt-get install -y make python gcc clang
+    apt-get install -y libblocksruntime-dev
   SHELL
 end
 


### PR DESCRIPTION
Additional cleanup for unittesting in Vagrant, required by PRs #4240 and #4243. 
