### PR TITLE
BFF4: Beeper is on PB4, and is INVERTED

### DIFF
--- a/src/main/target/BETAFLIGHTF4/target.h
+++ b/src/main/target/BETAFLIGHTF4/target.h
@@ -24,8 +24,8 @@
 
 #define LED0_PIN                PB5
 
-// Leave beeper here but with none as io - so disabled unless mapped.
 #define BEEPER                  PB4
+#define BEEPER_INVERTED
 
 // PC13 used as inverter select GPIO for UART2
 #define INVERTER_PIN_UART2      PC13


### PR DESCRIPTION
PR status: Ready to merge

Add missing `BEEPER_INVERTED`, which prevented beeper from working.
Also remove a out dated comment about the beeper.