### PR TITLE
Add antigravity config to the CMS

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -228,11 +228,13 @@ static CMS_Menu cmsx_menuRateProfile = {
     .entries = cmsx_menuRateProfileEntries
 };
 
-static uint8_t cmsx_dtermSetpointWeight;
-static uint8_t cmsx_setpointRelaxRatio;
-static uint8_t cmsx_angleStrength;
-static uint8_t cmsx_horizonStrength;
-static uint8_t cmsx_horizonTransition;
+static uint8_t  cmsx_dtermSetpointWeight;
+static uint8_t  cmsx_setpointRelaxRatio;
+static uint8_t  cmsx_angleStrength;
+static uint8_t  cmsx_horizonStrength;
+static uint8_t  cmsx_horizonTransition;
+static uint16_t cmsx_itermAcceleratorGain;
+static uint16_t cmsx_itermThrottleThreshold;
 
 static long cmsx_profileOtherOnEnter(void)
 {
@@ -245,6 +247,9 @@ static long cmsx_profileOtherOnEnter(void)
     cmsx_angleStrength =     pidProfile->pid[PID_LEVEL].P;
     cmsx_horizonStrength =   pidProfile->pid[PID_LEVEL].I;
     cmsx_horizonTransition = pidProfile->pid[PID_LEVEL].D;
+
+    cmsx_itermAcceleratorGain   = pidProfile->itermAcceleratorGain;
+    cmsx_itermThrottleThreshold = pidProfile->itermThrottleThreshold;
 
     return 0;
 }
@@ -262,17 +267,22 @@ static long cmsx_profileOtherOnExit(const OSD_Entry *self)
     pidProfile->pid[PID_LEVEL].I = cmsx_horizonStrength;
     pidProfile->pid[PID_LEVEL].D = cmsx_horizonTransition;
 
+    pidProfile->itermAcceleratorGain   = cmsx_itermAcceleratorGain;
+    pidProfile->itermThrottleThreshold = cmsx_itermThrottleThreshold;
+
     return 0;
 }
 
 static OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "-- OTHER PP --", OME_Label, NULL, pidProfileIndexString, 0 },
 
-    { "D SETPT WT",  OME_FLOAT, NULL, &(OSD_FLOAT_t) { &cmsx_dtermSetpointWeight, 0, 255, 1, 10 }, 0 },
-    { "SETPT TRS",   OME_FLOAT, NULL, &(OSD_FLOAT_t) { &cmsx_setpointRelaxRatio,  0, 100, 1, 10 }, 0 },
-    { "ANGLE STR",   OME_UINT8, NULL, &(OSD_UINT8_t) { &cmsx_angleStrength,       0, 200, 1 }    , 0 },
-    { "HORZN STR",   OME_UINT8, NULL, &(OSD_UINT8_t) { &cmsx_horizonStrength,     0, 200, 1 }    , 0 },
-    { "HORZN TRS",   OME_UINT8, NULL, &(OSD_UINT8_t) { &cmsx_horizonTransition,   0, 200, 1 }    , 0 },
+    { "D SETPT WT",  OME_FLOAT,  NULL, &(OSD_FLOAT_t)  { &cmsx_dtermSetpointWeight,    0,    255,   1, 10 }, 0 },
+    { "SETPT TRS",   OME_FLOAT,  NULL, &(OSD_FLOAT_t)  { &cmsx_setpointRelaxRatio,     0,    100,   1, 10 }, 0 },
+    { "ANGLE STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleStrength,          0,    200,   1 }    , 0 },
+    { "HORZN STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonStrength,        0,    200,   1 }    , 0 },
+    { "HORZN TRS",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonTransition,      0,    200,   1 }    , 0 },
+    { "AG GAIN",     OME_UINT16, NULL, &(OSD_UINT16_t) { &cmsx_itermAcceleratorGain,   1000, 30000, 1 }    , 0 },
+    { "AG THR",      OME_UINT16, NULL, &(OSD_UINT16_t) { &cmsx_itermThrottleThreshold, 20,   1000,  1 }    , 0 },
 
     { "BACK", OME_Back, NULL, NULL, 0 },
     { NULL, OME_END, NULL, NULL, 0 }


### PR DESCRIPTION
Added the antigravity gain and threshold to the CMS menu.

I've left the step as 1, for maximum precision, but I don't know if it will be better to make it bigger (10 maybe?) for the antigravity gain. Any thoughts?