### PR TITLE
Disarm if crash recovery activated in failsafe mode

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -42,6 +42,8 @@
 
 #include "rx/rx.h"
 
+#include "flight/pid.h"
+
 /*
  * Usage:
  *
@@ -256,7 +258,7 @@ void failsafeUpdateState(void)
                     failsafeApplyControlInput();
                     beeperMode = BEEPER_RX_LOST_LANDING;
                 }
-                if (failsafeShouldHaveCausedLandingByNow() || !armed) {
+                if (failsafeShouldHaveCausedLandingByNow() || crashRecoveryModeActive() || !armed) {
                     failsafeState.receivingRxDataPeriodPreset = PERIOD_OF_30_SECONDS; // require 30 seconds of valid rxData
                     failsafeState.phase = FAILSAFE_LANDED;
                     reprocessState = true;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -52,6 +52,8 @@
 uint32_t targetPidLooptime;
 static bool pidStabilisationEnabled;
 
+static bool inCrashRecoveryMode = false;
+
 float axisPID_P[3], axisPID_I[3], axisPID_D[3];
 
 static float dT;
@@ -406,7 +408,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     static float previousRateError[2];
     const float tpaFactor = getThrottlePIDAttenuation();
     const float motorMixRange = getMotorMixRange();
-    static bool inCrashRecoveryMode = false;
     static timeUs_t crashDetectedAtUs;
 
     // Dynamic ki component to gradually scale back integration when above windup point
@@ -538,4 +539,9 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             axisPID_D[axis] = 0;
         }
     }
+}
+
+bool crashRecoveryModeActive(void)
+{
+	return inCrashRecoveryMode;
 }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -134,3 +134,4 @@ void pidInitFilters(const pidProfile_t *pidProfile);
 void pidInitConfig(const pidProfile_t *pidProfile);
 void pidInit(const pidProfile_t *pidProfile);
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex);
+bool crashRecoveryModeActive(void);

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -471,4 +471,6 @@ bool isUsingSticksForArming(void)
 }
 
 void beeperConfirmationBeeps(uint8_t beepCount) { UNUSED(beepCount); }
+
+bool crashRecoveryModeActive(void) { return false; }
 }


### PR DESCRIPTION
While the "failsafeState.phase = FAILSAFE_LANDED" procedure is active, crash recovery will cause immediate disarm.

This will cause the engines to stop when the drone has completed its automatic landing, as well as prevent crash recovery from attempting to level the copter after contacting an object in failsafe mode.

Outdoor tested.  Requires "crash_recovery = on" option.