### PR TITLE
CRSF Attitude Telemetry Fix

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -56,6 +56,7 @@
 #include "telemetry/msp_shared.h"
 
 #include "fc/config.h"
+#include "sensors/sensors.h"
 
 #define CRSF_CYCLETIME_US                   100000 // 100ms, 10 Hz
 #define CRSF_DEVICEINFO_VERSION             0x01
@@ -350,7 +351,9 @@ void initCrsfTelemetry(void)
 #endif
 
     int index = 0;
-    crsfSchedule[index++] = BV(CRSF_FRAME_ATTITUDE_INDEX);
+    if (sensors(SENSOR_ACC)) {
+        crsfSchedule[index++] = BV(CRSF_FRAME_ATTITUDE_INDEX);
+    }
     crsfSchedule[index++] = BV(CRSF_FRAME_BATTERY_SENSOR_INDEX);
     crsfSchedule[index++] = BV(CRSF_FRAME_FLIGHT_MODE_INDEX);
     if (feature(FEATURE_GPS)) {

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -59,6 +59,7 @@ extern "C" {
     #include "telemetry/telemetry.h"
     #include "telemetry/msp_shared.h"
     #include "telemetry/smartport.h"
+    #include "sensors/acceleration.h"
 
     bool handleMspFrame(uint8_t *frameStart, uint8_t *frameEnd);
     bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn);
@@ -78,6 +79,7 @@ extern "C" {
     PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 0);
     PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG,0);
 
     extern bool crsfFrameDone;
     extern crsfFrame_t crsfFrame;

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -54,6 +54,7 @@ extern "C" {
 
     #include "sensors/battery.h"
     #include "sensors/sensors.h"
+    #include "sensors/acceleration.h"
 
     #include "telemetry/crsf.h"
     #include "telemetry/telemetry.h"
@@ -70,6 +71,7 @@ extern "C" {
     PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 0);
     PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
 }
 
 #include "unittest_macros.h"


### PR DESCRIPTION
It has been found that disabling accelerometer hardware causes issues with CRSF telemetry.  The result of disabling accelerometer hardware reliably produces random dips of 10-12% LQ.  This fix applies an additional check to the accelerometer configuration to confirm the configuration exists before sending attitude related telemetry.