### PR TITLE
CameraControl: Add output inversion option

### DIFF
--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -64,7 +64,8 @@ PG_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig,
     .refVoltage = 330,
     .keyDelayMs = 180,
     .internalResistance = 470,
-    .ioTag = IO_TAG(CAMERA_CONTROL_PIN)
+    .ioTag = IO_TAG(CAMERA_CONTROL_PIN),
+    .inverted = 0
 );
 
 static struct {
@@ -72,21 +73,40 @@ static struct {
     IO_t io;
     timerChannel_t channel;
     uint32_t period;
+    uint8_t inverted;
 } cameraControlRuntime;
 
 static uint32_t endTimeMillis;
 
 #ifdef CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE
+static void cameraControlHi(void)
+{
+    if (cameraControlRuntime.inverted) {
+        IOLo(cameraControlRuntime.io);
+    } else {
+        IOHi(cameraControlRuntime.io);
+    }
+}
+
+static void cameraControlLo(void)
+{
+    if (cameraControlRuntime.inverted) {
+        IOHi(cameraControlRuntime.io);
+    } else {
+        IOLo(cameraControlRuntime.io);
+    }
+}
+
 void TIM6_DAC_IRQHandler(void)
 {
-    IOHi(cameraControlRuntime.io);
+    cameraControlHi();
 
     TIM6->SR = 0;
 }
 
 void TIM7_IRQHandler(void)
 {
-    IOLo(cameraControlRuntime.io);
+    cameraControlLo();
 
     TIM7->SR = 0;
 }
@@ -97,6 +117,7 @@ void cameraControlInit(void)
     if (cameraControlConfig()->ioTag == IO_TAG_NONE)
         return;
 
+    cameraControlRuntime.inverted = cameraControlConfig()->inverted;
     cameraControlRuntime.io = IOGetByTag(cameraControlConfig()->ioTag);
     IOInit(cameraControlRuntime.io, OWNER_CAMERA_CONTROL, 0);
 
@@ -114,7 +135,7 @@ void cameraControlInit(void)
             IOConfigGPIOAF(cameraControlRuntime.io, IOCFG_AF_PP, timerHardware->alternateFunction);
         #endif
 
-        pwmOutConfig(&cameraControlRuntime.channel, timerHardware, CAMERA_CONTROL_TIMER_HZ, CAMERA_CONTROL_PWM_RESOLUTION, 0, 0);
+        pwmOutConfig(&cameraControlRuntime.channel, timerHardware, CAMERA_CONTROL_TIMER_HZ, CAMERA_CONTROL_PWM_RESOLUTION, 0, cameraControlRuntime.inverted);
 
         cameraControlRuntime.period = CAMERA_CONTROL_PWM_RESOLUTION;
         *cameraControlRuntime.channel.ccr = cameraControlRuntime.period;
@@ -122,8 +143,9 @@ void cameraControlInit(void)
 #endif
     } else if (CAMERA_CONTROL_MODE_SOFTWARE_PWM == cameraControlConfig()->mode) {
 #ifdef CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE
+
         IOConfigGPIO(cameraControlRuntime.io, IOCFG_OUT_PP);
-        IOHi(cameraControlRuntime.io);
+        cameraControlHi();
 
         cameraControlRuntime.period = CAMERA_CONTROL_SOFT_PWM_RESOLUTION;
         cameraControlRuntime.enabled = true;
@@ -200,9 +222,9 @@ void cameraControlKeyPress(cameraControlKey_e key, uint32_t holdDurationMs)
         const uint32_t hiTime = lrintf(dutyCycle * cameraControlRuntime.period);
 
         if (0 == hiTime) {
-            IOLo(cameraControlRuntime.io);
+            cameraControlLo();
             delay(cameraControlConfig()->keyDelayMs + holdDurationMs);
-            IOHi(cameraControlRuntime.io);
+            cameraControlHi();
         } else {
             TIM6->CNT = hiTime;
             TIM6->ARR = cameraControlRuntime.period;

--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -65,7 +65,8 @@ PG_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig,
     .keyDelayMs = 180,
     .internalResistance = 470,
     .ioTag = IO_TAG(CAMERA_CONTROL_PIN),
-    .inverted = 0
+    .inverted = 0,   // Output is inverted externally
+    .boost = 0       // Percentile of target output voltage adjustment (-10,10), negative = lower, positive = higher.
 );
 
 static struct {
@@ -185,8 +186,10 @@ static const int buttonResistanceValues[] = { 45000, 27000, 15000, 6810, 0 };
 
 static float calculateKeyPressVoltage(const cameraControlKey_e key)
 {
+#define BOOST ((100.0 + (float)cameraControlConfig()->boost) / 100.0)
     const int buttonResistance = buttonResistanceValues[key];
-    return 1.0e-2f * cameraControlConfig()->refVoltage * buttonResistance / (100 * cameraControlConfig()->internalResistance + buttonResistance);
+    return 1.0e-2f * cameraControlConfig()->refVoltage * buttonResistance / (100 * cameraControlConfig()->internalResistance + buttonResistance) * BOOST;
+#undef BOOST
 }
 
 #if defined(CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE) || defined(CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE)

--- a/src/main/drivers/camera_control.h
+++ b/src/main/drivers/camera_control.h
@@ -45,6 +45,7 @@ typedef struct cameraControlConfig_s {
     uint16_t internalResistance;
 
     ioTag_t ioTag;
+    uint8_t inverted;
 } cameraControlConfig_t;
 
 PG_DECLARE(cameraControlConfig_t, cameraControlConfig);

--- a/src/main/drivers/camera_control.h
+++ b/src/main/drivers/camera_control.h
@@ -46,6 +46,7 @@ typedef struct cameraControlConfig_s {
 
     ioTag_t ioTag;
     uint8_t inverted;
+    int8_t  boost;
 } cameraControlConfig_t;
 
 PG_DECLARE(cameraControlConfig_t, cameraControlConfig);

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -794,6 +794,7 @@ const clivalue_t valueTable[] = {
     { "camera_control_key_delay", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 100, 500 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, keyDelayMs) },
     { "camera_control_internal_resistance", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 10, 1000 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, internalResistance) },
     { "camera_control_inverted", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, inverted) },
+    { "camera_control_boost", VAR_INT8 | MASTER_VALUE, .config.minmax = { -10, 10 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, boost) },
 #endif
 };
 

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -793,6 +793,7 @@ const clivalue_t valueTable[] = {
     { "camera_control_ref_voltage", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 200, 400 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, refVoltage) },
     { "camera_control_key_delay", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 100, 500 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, keyDelayMs) },
     { "camera_control_internal_resistance", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 10, 1000 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, internalResistance) },
+    { "camera_control_inverted", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, inverted) },
 #endif
 };
 


### PR DESCRIPTION
PR stauts: Testing

Add output signal inversion option.

On some boards, users are forced to use signal pads that has inverters for various reasons.
This PR provides an opportunity for these users to use such pads for camera control.

The option was added as a configuration/PG variable, as `MOTOR_OUTPUT_INVERTED` can not be used in this case, as there are cases that programmable inverters controls the inversion based on the main usage of the pads. Some Omnibus F4 variants and Betaflight F4 are examples of such boards.