### PR TITLE
Moved LED_STRIP pin back to VTX.DTA for KIWIF4V2 / PLUMF4.

### DIFF
--- a/src/main/target/KIWIF4/target.c
+++ b/src/main/target/KIWIF4/target.c
@@ -30,7 +30,9 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR, TIMER_OUTPUT_STANDARD, 0),
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, TIMER_OUTPUT_STANDARD, 0),
 #if defined(PLUMF4) || defined(KIWIF4V2)
-    DEF_TIM(TIM4,  CH1, PA0,  TIM_USE_LED,   TIMER_OUTPUT_STANDARD, 0),  //LED
+//    DEF_TIM(TIM4,  CH1, PA0,  TIM_USE_LED,   TIMER_OUTPUT_STANDARD, 0),  //LED
+//Switch LED_STRIP back to VTX.DTA, since the LED pad does not seem to be working:
+    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_LED,   TIMER_OUTPUT_STANDARD, 0),  // LED
 #else
     DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_LED,   TIMER_OUTPUT_NONE, 0),  // LED
 #endif


### PR DESCRIPTION
Fixes #3160.