### PR TITLE
Camera control. Added forced OSD timeout so camera menues are alone on display.

### DIFF
--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -56,6 +56,9 @@
 #define CAMERA_CONTROL_PIN NONE
 #endif
 
+#ifdef OSD
+#include "io/osd.h"
+#endif
 
 PG_REGISTER_WITH_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig, PG_CAMERA_CONTROL_CONFIG, 0);
 
@@ -188,6 +191,11 @@ void cameraControlKeyPress(cameraControlKey_e key, uint32_t holdDurationMs)
     const float dutyCycle = calculatePWMDutyCycle(key);
 #else
     (void) holdDurationMs;
+#endif
+
+#ifdef OSD
+    // Force OSD timeout so we are alone on the display.
+    resumeRefreshAt = 0;
 #endif
 
     if (CAMERA_CONTROL_MODE_HARDWARE_PWM == cameraControlConfig()->mode) {


### PR DESCRIPTION
When disarming and trying to get into the camera control menues, you have to either wait 60s until the ordinary OSD statistics page has cleared. Or first enter and exit CMS, as this also clears the screen. Otherwise you will have both the camera menues and the OSD stats displayed on top of each other.
This PR fixes that by forcing immediate OSD time out when a cam control key is entered. 

The global `resumeRefreshAt ` should maybe also be have been renamed to hint what subsystem it belongs to, like `OSD_resumeRefreshAt `. Or rather a function/method doing this job. Sharing and touching globals is so so.... A case for a later refactoring and tidying PR maybe, this is a quick fix PR. 
 