### PR TITLE
Fix vtx power

### DIFF
--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -92,11 +92,11 @@ bool vtxRTC6705Init(void)
 
 void vtxRTC6705Configure(void)
 {
-    #ifdef RTC6705_POWER_PIN
-        rtc6705SetRFPower(vtxRTC6705.powerIndex - 1);
-    #else
-        rtc6705SetRFPower(vtxRTC6705.powerIndex);
-    #endif
+#ifdef RTC6705_POWER_PIN
+    rtc6705SetRFPower(vtxRTC6705.powerIndex - 1);
+#else
+    rtc6705SetRFPower(vtxRTC6705.powerIndex);
+#endif
     rtc6705SetBandAndChannel(vtxRTC6705.band - 1, vtxRTC6705.channel - 1);
 }
 

--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -92,7 +92,11 @@ bool vtxRTC6705Init(void)
 
 void vtxRTC6705Configure(void)
 {
-    rtc6705SetRFPower(vtxRTC6705.powerIndex - 1);
+    #ifdef RTC6705_POWER_PIN
+        rtc6705SetRFPower(vtxRTC6705.powerIndex - 1);
+    #else
+        rtc6705SetRFPower(vtxRTC6705.powerIndex);
+    #endif
     rtc6705SetBandAndChannel(vtxRTC6705.band - 1, vtxRTC6705.channel - 1);
 }
 


### PR DESCRIPTION
VTXs without power pin can use power index 0 and 1, then it's no need to minor 1 when setting power. 