### PR TITLE
VTX color based on frequency

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -646,11 +646,36 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
     }
     else { // show frequency
         // calculate the VTX color based on frequency
-        int hue = constrain((frequency - 5645.0 ) * 1.2, 0, 360);
-        // if we ever want to wrap the hue around the wheel for L band frequencies...
-        //hue = (hue+(hue<0)*((0-hue)/360+1)*361)%361;
-        color.h = hue;
-        color.s = 0;
+	    color.s = 0;
+        switch (floor((Frequency-5633)/39)) {
+            case 0:
+                color.h = HSV(WHITE).h;
+                color.s = HSV(WHITE).s;
+                break;
+            case 1:
+                color.h = HSV(RED).h;
+                break;
+            case 2:
+                color.h = HSV(ORANGE).h;
+                break;
+            case 3:
+                color.h = HSV(YELLOW).h;
+                break;
+            case 4:
+                color.h = HSV(GREEN).h;
+                break;
+            case 5:
+                color.h = HSV(BLUE).h;
+                break;
+            case 6:
+                color.h = HSV(DARK_VIOLET).h;
+                break;
+            case 7:
+                color.h = HSV(MAGENTA).h;
+                break;
+            default:
+                color.h = HSV(BLACK).h;
+		        break;
         color.v = pit ? (blink ? 15 : 0) : 255; // blink when in pit mode`
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
     }


### PR DESCRIPTION
VTX controlled LED color. 8 fixed colors rather than a variable hue. This ensures a perceivable color difference. The channel groups are based on 39Mhz spacing across the full spectrum.

Fixes #4316 