### PR TITLE
Apply rounding rules to dshot prescaler to minimize error

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -116,7 +116,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         RCC_ClockCmd(timerRCC(timer), ENABLE);
         TIM_Cmd(timer, DISABLE);
 
-        TIM_TimeBaseStructure.TIM_Prescaler = (uint16_t)((timerClock(timer) / getDshotHz(pwmProtocolType)) - 1);
+        TIM_TimeBaseStructure.TIM_Prescaler = (uint16_t)(lrintf((float) timerClock(timer) / getDshotHz(pwmProtocolType) + 0.01f) - 1);
         TIM_TimeBaseStructure.TIM_Period = pwmProtocolType == PWM_TYPE_PROSHOT1000 ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH;
         TIM_TimeBaseStructure.TIM_ClockDivision = TIM_CKD_DIV1;
         TIM_TimeBaseStructure.TIM_RepetitionCounter = 0;

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -108,7 +108,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     RCC_ClockCmd(timerRCC(timer), ENABLE);
 
     motor->TimHandle.Instance = timerHardware->tim;
-    motor->TimHandle.Init.Prescaler = (timerClock(timer) / getDshotHz(pwmProtocolType)) - 1;
+    motor->TimHandle.Init.Prescaler = lrintf((float) timerClock(timer) / getDshotHz(pwmProtocolType) + 0.01f) - 1;
     motor->TimHandle.Init.Period = pwmProtocolType == PWM_TYPE_PROSHOT1000 ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH;
     motor->TimHandle.Init.RepetitionCounter = 0;
     motor->TimHandle.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;


### PR DESCRIPTION
Turns out BF DSHOT code was under-estimating timer prescaler value leading to higher than advertised bitrates. The root of this issue lies in integral division for prescaler calculation.
For DSHOT on F4 with 168 MHz it resulted in 1350-1450 KHz according to my logic analyzer.

As a quick fix, I decided to apply `lrintf` function to the calculation to minimize error.

For some reason DSHOT1200 on F7 and 108 MHz timer was giving 4.5 for prescaler, but `lrintf` performed rounding towards 4 rather than 5. Probably has to do with IEEE-754 ordinary precision floating point number properties.
To account for this, I've added a small margin for rounding to work towards higher value.

Sanity check (https://ideone.com/fiaGT3):
>F3 DSHOT150 old PSC 24 real PSC 24 new PSC 24
>F3 DSHOT300 old PSC 12 real PSC 12 new PSC 12
>F3 DSHOT600 old PSC 6 real PSC 6 new PSC 6
>F3 DSHOT1200 old PSC 3 real PSC 3 new PSC 3
>F405 DSHOT150 old PSC 28 real PSC 28 new PSC 28
>F405 DSHOT300 old PSC 14 real PSC 14 new PSC 14
>F405 DSHOT600 old PSC 7 real PSC 7 new PSC 7
>**F405 DSHOT1200 old PSC 3 real PSC 3.5 new PSC 4**
>F411 DSHOT150 old PSC 33 real PSC 33.3333 new PSC 33
>F411 DSHOT300 old PSC 16 real PSC 16.6667 new PSC 17
>F411 DSHOT600 old PSC 8 real PSC 8.33333 new PSC 8
>F411 DSHOT1200 old PSC 4 real PSC 4.16667 new PSC 4
>F7 (108 MHz timer) DSHOT150 old PSC 36 real PSC 36 new PSC 36
>F7 (108 MHz timer) DSHOT300 old PSC 18 real PSC 18 new PSC 18
>F7 (108 MHz timer) DSHOT600 old PSC 9 real PSC 9 new PSC 9
>**F7 (108 MHz timer) DSHOT1200 old PSC 4 real PSC 4.5 new PSC 5**
>F405 OC DSHOT150 old PSC 40 real PSC 40 new PSC 40
>F405 OC DSHOT300 old PSC 20 real PSC 20 new PSC 20
>F405 OC DSHOT600 old PSC 10 real PSC 10 new PSC 10
>F405 OC DSHOT1200 old PSC 5 real PSC 5 new PSC 5
>F7 (216 MHz timer) DSHOT150 old PSC 72 real PSC 72 new PSC 72
>F7 (216 MHz timer) DSHOT300 old PSC 36 real PSC 36 new PSC 36
>F7 (216 MHz timer) DSHOT600 old PSC 18 real PSC 18 new PSC 18
>F7 (216 MHz timer) DSHOT1200 old PSC 9 real PSC 9 new PSC 9

As visible above, the change only affects DSHOT1200 for F405 and F7, the only two configurations that were independently reported.