### PR TITLE
Allow hold repeating of stick commands

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -328,14 +328,19 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
 #ifdef USE_CAMERA_CONTROL
     if (rcSticks == THR_CE + YAW_HI + PIT_CE + ROL_CE) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_ENTER, 0);
+        repeatAfter(3 * STICK_DELAY_MS);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_LO) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_LEFT, 0);
+        repeatAfter(3 * STICK_DELAY_MS);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_HI + ROL_CE) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 0);
+        repeatAfter(3 * STICK_DELAY_MS);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_HI) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_RIGHT, 0);
+        repeatAfter(3 * STICK_DELAY_MS);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_LO + ROL_CE) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_DOWN, 0);
+        repeatAfter(3 * STICK_DELAY_MS);
     } else if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_CE) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 2000);
     }


### PR DESCRIPTION
This change allows holding sticks in order to access special menus of modern FPV cameras and also navigate menus more easily.
A more complicated PR with key-handling akin to the one used in BF CMS is postponed for 3.3 due to possible complications.