### PR TITLE
fix toggle wi-fi  will cause rcsplit turnoff

### DIFF
--- a/src/main/io/rcsplit.c
+++ b/src/main/io/rcsplit.c
@@ -24,6 +24,7 @@
 
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
+#include "fc/runtime_config.h"
 
 #include "io/rcsplit.h"
 #include "io/serial.h"
@@ -82,7 +83,11 @@ static void rcSplitProcessMode(void)
             uint8_t argument = RCSPLIT_CTRL_ARGU_INVALID;
             switch (i) {
             case BOXCAMERA1:
-                argument = RCSPLIT_CTRL_ARGU_WIFI_BTN;
+                // check  whether arm unlock, we found a bug in rcsplit firmware:
+                // if rcsplit running without Wi-Fi module, and user try to turn on wifi, it'll cause rcsplit to turn off itself, this is danger
+                if (!ARMING_FLAG(ARMED)) {
+                    argument = RCSPLIT_CTRL_ARGU_WIFI_BTN;
+                }
                 break;
             case BOXCAMERA2:
                 argument = RCSPLIT_CTRL_ARGU_POWER_BTN;

--- a/src/test/unit/rcsplit_unittest.cc
+++ b/src/test/unit/rcsplit_unittest.cc
@@ -423,4 +423,5 @@ extern "C" {
 
     bool feature(uint32_t) { return false;}
     void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count) { UNUSED(instance); UNUSED(data); UNUSED(count); }
+    uint8_t armingFlags = 0;
 }


### PR DESCRIPTION
Fix toggle wifi on rcsplit will cause rcsplit to turn off itself, this bug will happen when there is no wifi module plugin on rcpslit. 

Normally, this bug we should solve in the rcsplit firmware, but in the foreseeable period of time, the bug can not be solved, we still want to accurately detect the WiFi module is inserted, so as to avoid the occurrence of bug, fix the PR is to avoid the user in flight trigger this bug, leading to crashed.