### PR TITLE
Sane serialrx_inverted default values.

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -105,6 +105,14 @@ static uint8_t rcSampleIndex = 0;
 #define SERIALRX_PROVIDER 0
 #endif
 
+#ifndef SERIALRX_INVERTED
+#if (SERIALRX_PROVIDER == SERIALRX_PROVIDER_SBUS)
+#define SERIALRX_INVERTED 1
+#else
+#define SERIALRX_INVERTED 0
+#endif
+#endif
+
 #define RX_MIN_USEC 885
 #define RX_MAX_USEC 2115
 #define RX_MID_USEC 1500
@@ -124,7 +132,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .halfDuplex = 0,
         .serialrx_provider = SERIALRX_PROVIDER,
         .rx_spi_protocol = RX_SPI_DEFAULT_PROTOCOL,
-        .serialrx_inverted = 0,
+        .serialrx_inverted = SERIALRX_INVERTED,
         .spektrum_bind_pin_override_ioTag = IO_TAG(SPEKTRUM_BIND_PIN),
         .spektrum_bind_plug_ioTag = IO_TAG(BINDPLUG_PIN),
         .spektrum_sat_bind = 0,


### PR DESCRIPTION
The introduction of the generalized serialrx_inverted handling in PR #4173 leaves a few targets with non-working defaults, i.e. non-inverted SBUS. 
For example BETAFLIGHTF3:

```
# version
# Betaflight / BETAFLIGHTF3 (BFF3) 3.3.0 Oct 17 2017 / 23:20:03 (3168452) MSP API: 1.37

# get serialrx
serialrx_provider = SBUS
Allowed values: SPEK1024, SPEK2048, SBUS, SUMD, SUMH, XB-B, XB-B-RJ01, IBUS, JETIEXBUS, CRSF, SRXL

serialrx_inverted = OFF
Allowed values: OFF, ON
```

With this PR it looks like this:
```
# version
# Betaflight / BETAFLIGHTF3 (BFF3) 3.3.0 Oct 17 2017 / 23:24:06 (a18f80b) MSP API: 1.37

# get serialrx
serialrx_provider = SBUS
Allowed values: SPEK1024, SPEK2048, SBUS, SUMD, SUMH, XB-B, XB-B-RJ01, IBUS, JETIEXBUS, CRSF, SRXL

serialrx_inverted = ON
Allowed values: OFF, ON
```

Unfortunatly there are still functionality missing, connecting serialrx_provider with serialrx_inverted. This was done earlier by each rx provider driver, now removed. So when changing provider/protocol you can end up in an invalid state:

```
# get serialrx
serialrx_provider = SRXL
Allowed values: SPEK1024, SPEK2048, SBUS, SUMD, SUMH, XB-B, XB-B-RJ01, IBUS, JETIEXBUS, CRSF, SRXL

serialrx_inverted = ON
Allowed values: OFF, ON 

```
The user now has to do two selections, provider (using GUI or CLI) and inversion (CLI only).
This is a problem also with serialrx_parity, discussed in PR #4371, and needs a systematic solution.
This PR only handles the case of sane default values for serialrx_inverted. 

There are also target specific config.c files dealing with, and over-riding, this. No harm doing that, but would need some cleanup too. Maybe as a part of the bigger picture of protocol and serialrx parameter systematisations. 
Provider, inversion and parity needs coordination on some level. Even baud rate, duplex, and more??
