### PR TITLE
Crash recovery little change for Beeper

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -529,8 +529,10 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                         inCrashRecoveryMode = false;
                     }
                 } else {
+                    if (inCrashRecoveryMode) {
+                       BEEP_OFF;
+                    }
                     inCrashRecoveryMode = false;
-                    BEEP_OFF;
                 }
             }
             axisPID_D[axis] = Kd[axis] * delta * tpaFactor;


### PR DESCRIPTION
I did a mistake in my latest PR and the beeper was not working at all when quad was disarmed.
Now it work and it will also stop beeping if we disarm during a crashrecovery.