### PR TITLE
remove esc sensor if dshot is undefined

### DIFF
--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -29,6 +29,10 @@
 #undef USE_SERVOS
 #endif
 
+#ifndef USE_DSHOT
+#undef USE_ESC_SENSOR
+#endif
+
 // XXX Followup implicit dependencies among DASHBOARD, display_xxx and USE_I2C.
 // XXX This should eventually be cleaned up.
 #ifndef USE_I2C


### PR DESCRIPTION
betaflight doesnt link if dshot isnt defined but esc sensor is.
i think adding guards to all esc_sensor is useless since fc_post can just undefined it.
also this solution allows to extend it more easily. if there will be esc_sensor over spi just the post check needs to be extended.
