### PR TITLE
Show stats only if enabled

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1015,8 +1015,25 @@ static void osdDisplayStatisticLabel(uint8_t y, const char * text, const char * 
     displayWrite(osdDisplayPort, 22, y, value);
 }
 
+/*
+ * Test if there's some stat enabled
+ */
+static bool isSomeStatEnabled(void) {
+    for (int i = 0; i < OSD_STAT_COUNT; i++) {
+            if (osdConfig()->enabled_stats[i]) {
+                return true;
+            }
+        }
+    return false;
+}
+
 static void osdShowStats(void)
 {
+
+    if (!isSomeStatEnabled()) {
+        return;
+    }
+
     uint8_t top = 2;
     char buff[10];
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -132,6 +132,18 @@ void doTestArm(bool testEmpty = true)
 }
 
 /*
+ * Auxiliary function. Test is there're stats that must be shown
+ */
+bool isSomeStatEnabled(void) {
+    for (int i = 0; i < OSD_STAT_COUNT; i++) {
+            if (osdConfigMutable()->enabled_stats[i]) {
+                return true;
+            }
+        }
+    return false;
+}
+
+/*
  * Performs a test of the OSD actions on disarming.
  * (reused throughout the test suite)
  */
@@ -147,9 +159,10 @@ void doTestDisarm()
 
     // then
     // post flight statistics displayed
-    displayPortTestBufferSubstring(2, 2, "  --- STATS ---");
+    if (isSomeStatEnabled()) {
+        displayPortTestBufferSubstring(2, 2, "  --- STATS ---");
+    }
 }
-
 
 /*
  * Tests initialisation of the OSD and the power on splash screen.


### PR DESCRIPTION
If no enabled stat to show, don't show the stats page in the OSD. This solves this feature request: https://github.com/betaflight/betaflight/issues/4423

I don't know if there's a better way to do it, but my C skills are very limited ;) 