### PR TITLE
Call vtx power change wrapper instead of direct power function

### DIFF
--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -148,7 +148,7 @@ static long trampCmsCommence(displayPort_t *pDisp, const void *self)
     UNUSED(self);
 
     trampSetBandAndChannel(trampCmsBand, trampCmsChan);
-    trampSetRFPower(trampPowerTable[trampCmsPower-1]);
+    vtxTrampSetPowerByIndex(trampCmsPower);
 
     // If it fails, the user should retry later
     trampCommitChanges();

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -175,7 +175,7 @@ void trampSetBandAndChannel(uint8_t band, uint8_t channel)
     vtxSettingsSaveBandAndChannel(band, channel);
 }
 
-void trampSetRFPower(uint16_t level)
+static void trampSetRFPower(uint16_t level)
 {
     trampConfPower = level;
     if (trampConfPower != trampPower) {

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -45,7 +45,7 @@ extern uint16_t trampConfiguredPower; // Configured transmitting power
 extern int16_t trampTemperature;
 
 bool vtxTrampInit(void);
+void vtxTrampSetPowerByIndex(uint8_t index);
 bool trampCommitChanges(void);
 void trampSetPitMode(uint8_t onoff);
 void trampSetBandAndChannel(uint8_t band, uint8_t channel);
-void trampSetRFPower(uint16_t level);


### PR DESCRIPTION
Fixes #4426 

PR status: Needs Testing -- Do not own a Tramp.

The original function call directly applies power to the device without saving the value back to the parameter group.  Changing the function call to this wrapper takes care of both power update and pg update.