### PR TITLE
Fix saving vtx_tramp power to 'vtx_power' setting

### DIFF
--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -153,6 +153,8 @@ static long trampCmsCommence(displayPort_t *pDisp, const void *self)
     // If it fails, the user should retry later
     trampCommitChanges();
 
+    // update'vtx_' settings
+    vtxSettingsSaveBandChanAndPower(trampCmsBand, trampCmsChan, trampCmsPower);
 
     return MENU_CHAIN_BACK;
 }

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -172,7 +172,6 @@ void trampSetBandAndChannel(uint8_t band, uint8_t channel)
 {
     trampSetByFreqFlag = false;        //set freq via band/channel
     trampDevSetBandAndChannel(band, channel);
-    vtxSettingsSaveBandAndChannel(band, channel);
 }
 
 void trampSetRFPower(uint16_t level)
@@ -545,6 +544,7 @@ void vtxTrampSetBandAndChannel(uint8_t band, uint8_t channel)
     if (trampValidateBandAndChannel(band, channel)) {
         trampSetBandAndChannel(band, channel);
         trampCommitChanges();
+        vtxSettingsSaveBandAndChannel(band, channel);
     }
 }
 


### PR DESCRIPTION
This fixes issue #4426 where changes to Tramp VTX power via CMS OSD would be reverted on reboot.  I've done a successful test of the fix with a Tramp VTX.

Changes:

In vtx_tramp.c 'trampSetBandAndChannel()' removed call to 'vtxSettingsSaveBandAndChannel()'

In vtx_tramp.c 'vtxTrampSetBandAndChannel()' added call to 'vtxSettingsSaveBandAndChannel()'

In cms_menu_vtx_tramp.c 'trampCmsCommence()' added call to 'vtxSettingsSaveBandChanAndPower()'

--ET