### PR TITLE
fix Segmentation fault in SITL (maybe other without define USE_OSD_SLAVE)

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -322,7 +322,7 @@ void activateConfig(void)
 #endif // USE_OSD_SLAVE
 }
 
-void validateAndFixConfig(void)
+static void validateAndFixConfig(void)
 {
 #if !defined(USE_QUAD_MIXER_ONLY) && !defined(USE_OSD_SLAVE)
     // Reset unsupported mixer mode to default.
@@ -345,8 +345,16 @@ void validateAndFixConfig(void)
     if (systemConfig()->activeRateProfile >= CONTROL_RATE_PROFILE_COUNT) {
         systemConfigMutable()->activeRateProfile = 0;
     }
+    setControlRateProfile(systemConfig()->activeRateProfile);
+
     if (systemConfig()->pidProfileIndex >= MAX_PROFILE_COUNT) {
         systemConfigMutable()->pidProfileIndex = 0;
+    }
+    setPidProfile(systemConfig()->pidProfileIndex);
+
+    // Prevent invalid notch cutoff
+    if (currentPidProfile->dterm_notch_cutoff >= currentPidProfile->dterm_notch_hz) {
+        currentPidProfile->dterm_notch_hz = 0;
     }
 
     if ((motorConfig()->dev.motorPwmProtocol == PWM_TYPE_BRUSHED) && (motorConfig()->mincommand < 1000)) {
@@ -356,6 +364,8 @@ void validateAndFixConfig(void)
     if ((motorConfig()->dev.motorPwmProtocol == PWM_TYPE_STANDARD) && (motorConfig()->dev.motorPwmRate > BRUSHLESS_MOTORS_PWM_RATE)) {
         motorConfigMutable()->dev.motorPwmRate = BRUSHLESS_MOTORS_PWM_RATE;
     }
+
+    validateAndFixGyroConfig();
 
     if (!(featureConfigured(FEATURE_RX_PARALLEL_PWM) || featureConfigured(FEATURE_RX_PPM) || featureConfigured(FEATURE_RX_SERIAL) || featureConfigured(FEATURE_RX_MSP) || featureConfigured(FEATURE_RX_SPI))) {
         featureSet(DEFAULT_RX_FEATURE);
@@ -409,12 +419,6 @@ void validateAndFixConfig(void)
     }
 #endif // USE_SOFTSPI
 
-    // Prevent invalid notch cutoff
-    if (currentPidProfile->dterm_notch_cutoff >= currentPidProfile->dterm_notch_hz) {
-        currentPidProfile->dterm_notch_hz = 0;
-    }
-
-    validateAndFixGyroConfig();
 #endif // USE_OSD_SLAVE
 
     if (!isSerialConfigValid(serialConfig())) {
@@ -606,10 +610,6 @@ void readEEPROM(void)
     }
 
     validateAndFixConfig();
-#ifndef USE_OSD_SLAVE
-    setControlRateProfile(systemConfig()->activeRateProfile);
-    setPidProfile(systemConfig()->pidProfileIndex);
-#endif
     activateConfig();
 
 #ifndef USE_OSD_SLAVE

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -113,7 +113,6 @@ void writeEEPROM(void);
 void ensureEEPROMContainsValidData(void);
 
 void saveConfigAndNotify(void);
-void validateAndFixConfig(void);
 void validateAndFixGyroConfig(void);
 void activateConfig(void);
 


### PR DESCRIPTION
As title,
`*currentPidProfile` did not initialize when `validateAndFixConfig()` called.

