### PR TITLE
show inflight adjustments in osd

### DIFF
--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -50,7 +50,6 @@ typedef enum {
     ADJUSTMENT_FUNCTION_COUNT
 } adjustmentFunction_e;
 
-
 typedef enum {
     ADJUSTMENT_MODE_STEP,
     ADJUSTMENT_MODE_SELECT
@@ -88,7 +87,6 @@ typedef struct adjustmentState_s {
     uint32_t timeoutAt;
 } adjustmentState_t;
 
-
 #ifndef MAX_SIMULTANEOUS_ADJUSTMENT_COUNT
 #define MAX_SIMULTANEOUS_ADJUSTMENT_COUNT 4 // enough for 4 x 3position switches / 4 aux channel
 #endif
@@ -103,3 +101,4 @@ struct controlRateConfig_s;
 void processRcAdjustments(struct controlRateConfig_s *controlRateConfig);
 struct pidProfile_s;
 void useAdjustmentConfig(struct pidProfile_s *pidProfileToUse);
+bool isAnyAdjustmentFunctionBusy();

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -70,6 +70,7 @@
 #include "fc/config.h"
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
+#include "fc/rc_adjustments.h"
 
 #include "flight/altitude.h"
 #include "flight/navigation.h"
@@ -1127,6 +1128,12 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
 {
     static timeUs_t lastTimeUs = 0;
 
+#ifdef USE_OSD_ADJUSTMENTS
+    if (isAnyAdjustmentFunctionBusy()) {
+        return;
+    }
+#endif
+ 
     // detect arm/disarm
     if (armState != ARMING_FLAG(ARMED)) {
         if (ARMING_FLAG(ARMED)) {
@@ -1239,4 +1246,14 @@ void osdUpdate(timeUs_t currentTimeUs)
     }
 #endif
 }
+
+#ifdef USE_OSD_ADJUSTMENTS
+void osdShowAdjustment(const char * type, int newValue)
+{
+    char buff[OSD_ELEMENT_BUFFER_LENGTH];
+    tfp_sprintf(buff, "%s: %3d", type, newValue);
+    displayWrite(osdDisplayPort, round(15 - strlen(buff) / 2), 7, buff);
+}
+#endif
+ 
 #endif // OSD

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -162,5 +162,6 @@ void osdInit(struct displayPort_s *osdDisplayPort);
 void osdResetConfig(osdConfig_t *osdProfile);
 void osdResetAlarms(void);
 void osdUpdate(timeUs_t currentTimeUs);
+void osdShowAdjustment(const char * type, int newValue);
 
 #endif

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -105,7 +105,7 @@
 #define USE_RESOURCE_MGMT
 #define USE_SERVOS
 #endif
-
+ 
 #if (FLASH_SIZE > 128)
 #define USE_CMS
 #define TELEMETRY_CRSF
@@ -144,4 +144,5 @@
 #define USE_GPS
 #define USE_NAV
 #define USE_UNCOMMON_MIXERS
+#define USE_OSD_ADJUSTMENTS
 #endif


### PR DESCRIPTION
To cover multiple adjustments I combine multiple switches on my transmitter.
It's hard to keep the overview, so like to have the actual changes showed up in the osd.
