### PR TITLE
External SPI OSD support for AnyFC series

### DIFF
--- a/src/main/target/ANYFCF7/target.h
+++ b/src/main/target/ANYFCF7/target.h
@@ -102,6 +102,7 @@
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_3
 #define USE_SPI_DEVICE_4
 
 #define SPI1_NSS_PIN            PA4
@@ -109,10 +110,22 @@
 #define SPI1_MISO_PIN           PA6
 #define SPI1_MOSI_PIN           PA7
 
+#define SPI3_NSS_PIN            PD2
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
 #define SPI4_NSS_PIN            PE11
 #define SPI4_SCK_PIN            PE12
 #define SPI4_MISO_PIN           PE13
 #define SPI4_MOSI_PIN           PE14
+
+#define OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      SPI3_NSS_PIN
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
 
 #define USE_SDCARD
 #define SDCARD_DETECT_INVERTED

--- a/src/main/target/ANYFCF7/target.mk
+++ b/src/main/target/ANYFCF7/target.mk
@@ -7,4 +7,5 @@ TARGET_SRC = \
             drivers/barometer/barometer_bmp280.c \
             drivers/compass/compass_hmc5883l.c \
             drivers/light_ws2811strip.c \
-            drivers/light_ws2811strip_hal.c
+            drivers/light_ws2811strip_hal.c \
+            drivers/max7456.c

--- a/src/main/target/ANYFCM7/target.h
+++ b/src/main/target/ANYFCM7/target.h
@@ -94,6 +94,7 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
+#define USE_SPI_DEVICE_3
 
 #define SPI1_NSS_PIN            PA4
 #define SPI1_SCK_PIN            PA5
@@ -105,12 +106,23 @@
 #define SPI2_MISO_PIN           PC2
 #define SPI2_MOSI_PIN           PC1
 
+#define SPI3_NSS_PIN            PD2
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
 
 #define M25P16_CS_PIN           PB12
 #define M25P16_SPI_INSTANCE     SPI2
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#define OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      SPI3_NSS_PIN
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
 
 #define USE_I2C
 #define USE_I2C_DEVICE_2

--- a/src/main/target/ANYFCM7/target.mk
+++ b/src/main/target/ANYFCM7/target.mk
@@ -5,4 +5,5 @@ TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
             drivers/barometer/barometer_ms5611.c \
             drivers/light_ws2811strip.c \
-            drivers/light_ws2811strip_hal.c
+            drivers/light_ws2811strip_hal.c \
+            drivers/max7456.c


### PR DESCRIPTION
Add SPI OSD addon support for AnyFC series on uart4/5 connector.
Tested