### PR TITLE
Fixed two leftover cases from the conversion to 'USE_<x>'.

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -336,7 +336,7 @@ static void saProcessResponse(uint8_t *buf, int len)
     }
 
     if (memcmp(&saDevice, &saDevicePrev, sizeof(smartAudioDevice_t))) {
-#ifdef CMS    //if changes then trigger saCms update
+#ifdef USE_CMS    //if changes then trigger saCms update
         saCmsResetOpmodel();
 #endif
 #ifdef SMARTAUDIO_DPRINTF    // Debug

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -61,7 +61,7 @@
 #define BARO_I2C_INSTANCE       I2C_DEVICE
 #define MAG_I2C_INSTANCE        I2C_DEVICE
 
-#define MAG           
+#define USE_MAG
 #define USE_MAG_HMC5883                   //External, connect to I2C1
 #define MAG_HMC5883_ALIGN       CW180_DEG
 


### PR DESCRIPTION
Found with `for i in GYRO ACC MAG BARO GPS SONAR OSD BLACKBOX CMS; do grep -Er "^#.*[^_]${i}[^_]"  src/; done`. Any further refinements welcome.