### PR TITLE
Fixed logging of 'amperageLatest' when non-ADC source is used.

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -429,7 +429,7 @@ static bool testBlackboxConditionUncached(FlightLogFieldCondition condition)
         return batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE;
 
     case FLIGHT_LOG_FIELD_CONDITION_AMPERAGE_ADC:
-        return batteryConfig()->currentMeterSource == CURRENT_METER_ADC;
+        return (batteryConfig()->currentMeterSource != CURRENT_METER_NONE) && (batteryConfig()->currentMeterSource != CURRENT_METER_VIRTUAL);
 
     case FLIGHT_LOG_FIELD_CONDITION_SONAR:
 #ifdef USE_SONAR


### PR DESCRIPTION
Fixes #4491.