### PR TITLE
Set RSSI value with MSP (e.g. with SmartPort)

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1974,6 +1974,17 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
     break;
 #endif
 
+    case MSP_TX_INFO:
+    {
+        uint8_t rssi_tx = sbufReadU8(src);
+        // Ignore rssi from MSP when RSSI channel or RSSIPWM feature is enabled
+        if (rxConfig()->rssi_channel == 0 && !featureConfigured(FEATURE_RSSI_ADC)) {
+            // Range of rssi_tx is [1;100]. rssi should be in [0;1023];
+            rssi = (uint16_t)((rssi_tx / 100.0f) * 1023.0f);
+        }
+    }
+    break;
+
     default:
         // we do not know how to handle the (valid) message, indicate error MSP $M!
         return MSP_RESULT_ERROR;

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -230,6 +230,8 @@
 #define MSP_BEEPER_CONFIG               184
 #define MSP_SET_BEEPER_CONFIG           185
 
+#define MSP_TX_INFO                     186
+
 //
 // Multwii original MSP commands
 //


### PR DESCRIPTION
The following condition has to be met to set the RSSI value with MSP
- RSSI channel has to be disabled
- Feature RSSI_ADC is off

If one of the above conditions is not true, the RSSI value is not set when received with MSP. This is to prevent the RSSI value from another 'source' to be overwritten.

![image](https://user-images.githubusercontent.com/334779/32514872-8e21f7c0-c3fe-11e7-97e3-68960dd98148.png)
