### PR TITLE
FURYF3 FURYF3OSD. Remove SONAR support to make room for other features.

### DIFF
--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -143,10 +143,6 @@
 #define SOFTSERIAL1_RX_PIN      PB0
 #define SOFTSERIAL1_TX_PIN      PB1
 
-#define USE_SONAR
-#define SONAR_ECHO_PIN          PB1
-#define SONAR_TRIGGER_PIN       PB0
-
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PB3  // (HARDARE=0,PPM)
 


### PR DESCRIPTION
Remove SONAR support to make room for other features, on both FURYF3 and FURYF3OSD. 
 