### PR TITLE
OMNIBUS. Remove SOFTSERIAL to make room for other features.

### DIFF
--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -67,10 +67,8 @@
 #define USE_UART1
 #define USE_UART2
 #define USE_UART3
-#define USE_SOFTSERIAL1
-#define USE_SOFTSERIAL2
 
-#define SERIAL_PORT_COUNT       6
+#define SERIAL_PORT_COUNT       4
 
 #define UART1_TX_PIN            PA9
 #define UART1_RX_PIN            PA10


### PR DESCRIPTION
Remove SOFTSERIAL to make room for other features on OMNIBUS. Another alternative would be to disable BARO, but this FC is sold with a barometer option. Are anyone buying and using that ??
