### PR TITLE
Size optimise CMS modules. Improve const correctness

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -271,6 +271,9 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             cms/cms_menu_ledstrip.c \
             cms/cms_menu_misc.c \
             cms/cms_menu_osd.c \
+            cms/cms_menu_vtx_rtc6705.c \
+            cms/cms_menu_vtx_smartaudio.c \
+            cms/cms_menu_vtx_tramp.c \
             io/vtx_string.c \
             io/vtx_settings_config.c \
             io/vtx_rtc6705.c \

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -492,7 +492,7 @@ static void cmsDrawMenu(displayPort_t *pDisplay, uint32_t currentTimeUs)
 
 static void cmsMenuCountPage(displayPort_t *pDisplay)
 {
-    OSD_Entry *p;
+    const OSD_Entry *p;
     for (p = currentCtx.menu->entries; p->type != OME_END; p++);
     pageCount = (p - currentCtx.menu->entries - 1) / MAX_MENU_ITEMS(pDisplay) + 1;
 }
@@ -501,7 +501,7 @@ STATIC_UNIT_TESTED long cmsMenuBack(displayPort_t *pDisplay); // Forward; will b
 
 long cmsMenuChange(displayPort_t *pDisplay, const void *ptr)
 {
-    CMS_Menu *pMenu = (CMS_Menu *)ptr;
+    const CMS_Menu *pMenu = (const CMS_Menu *)ptr;
 
     if (!pMenu) {
         return 0;

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -55,7 +55,7 @@ typedef long (*CMSEntryFuncPtr)(displayPort_t *displayPort, const void *ptr);
 
 typedef struct
 {
-    const char *text;
+    const char * const text;
     const OSD_MenuElement type;
     const CMSEntryFuncPtr func;
     void *data;


### PR DESCRIPTION
Saves about 156 bytes of ROM.