### PR TITLE
Removed CMS menu guards when not debugging

### DIFF
--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -209,8 +209,10 @@ static OSD_Entry cmsx_menuBlackboxEntries[] =
 };
 
 CMS_Menu cmsx_menuBlackbox = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUBB",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_Blackbox_onEnter,
     .onExit = cmsx_Blackbox_onExit,
     .onGlobalExit = cmsx_Blackbox_FeatureWriteback,

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -81,8 +81,10 @@ static OSD_Entry menuInfoEntries[] = {
 };
 
 static CMS_Menu menuInfo = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUINFO",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_InfoInit,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -117,8 +119,10 @@ static OSD_Entry menuFeaturesEntries[] =
 };
 
 static CMS_Menu menuFeatures = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUFEATURES",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -149,8 +153,10 @@ static OSD_Entry menuMainEntries[] =
 };
 
 CMS_Menu menuMain = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUMAIN",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -161,8 +161,10 @@ static OSD_Entry cmsx_menuPidEntries[] =
 };
 
 static CMS_Menu cmsx_menuPid = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XPID",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_PidOnEnter,
     .onExit = cmsx_PidWriteback,
     .onGlobalExit = NULL,
@@ -222,8 +224,10 @@ static OSD_Entry cmsx_menuRateProfileEntries[] =
 };
 
 static CMS_Menu cmsx_menuRateProfile = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENURATE",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_RateProfileOnEnter,
     .onExit = cmsx_RateProfileWriteback,
     .onGlobalExit = NULL,
@@ -291,8 +295,10 @@ static OSD_Entry cmsx_menuProfileOtherEntries[] = {
 };
 
 static CMS_Menu cmsx_menuProfileOther = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XPROFOTHER",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_profileOtherOnEnter,
     .onExit = cmsx_profileOtherOnExit,
     .onGlobalExit = NULL,
@@ -344,8 +350,10 @@ static OSD_Entry cmsx_menuFilterGlobalEntries[] =
 };
 
 static CMS_Menu cmsx_menuFilterGlobal = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XFLTGLB",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_menuGyro_onEnter,
     .onExit = cmsx_menuGyro_onExit,
     .onGlobalExit = NULL,
@@ -395,8 +403,10 @@ static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
 };
 
 static CMS_Menu cmsx_menuFilterPerProfile = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XFLTPP",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_FilterPerProfileRead,
     .onExit = cmsx_FilterPerProfileWriteback,
     .onGlobalExit = NULL,
@@ -464,8 +474,10 @@ static OSD_Entry cmsx_menuCopyProfileEntries[] =
 };
 
 CMS_Menu cmsx_menuCopyProfile = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XCPY",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_menuCopyProfile_onEnter,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -496,8 +508,10 @@ static OSD_Entry cmsx_menuImuEntries[] =
 };
 
 CMS_Menu cmsx_menuImu = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XIMU",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_menuImu_onEnter,
     .onExit = cmsx_menuImu_onExit,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -74,8 +74,10 @@ static OSD_Entry cmsx_menuLedstripEntries[] =
 };
 
 CMS_Menu cmsx_menuLedstrip = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENULED",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_Ledstrip_FeatureRead,
     .onExit = NULL,
     .onGlobalExit = cmsx_Ledstrip_FeatureWriteback,

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -82,8 +82,10 @@ static OSD_Entry cmsx_menuRcEntries[] =
 };
 
 CMS_Menu cmsx_menuRcPreview = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XRCPREV",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = cmsx_menuRcConfirmBack,
     .onGlobalExit = NULL,
@@ -136,8 +138,10 @@ static OSD_Entry menuMiscEntries[]=
 };
 
 CMS_Menu cmsx_menuMisc = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XMISC",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_menuMiscOnEnter,
     .onExit = cmsx_menuMiscOnExit,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -103,8 +103,10 @@ OSD_Entry menuOsdActiveElemsEntries[] =
 };
 
 CMS_Menu menuOsdActiveElems = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUOSDACT",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = menuOsdActiveElemsOnEnter,
     .onExit = menuOsdActiveElemsOnExit,
     .onGlobalExit = NULL,
@@ -146,8 +148,10 @@ OSD_Entry menuAlarmsEntries[] =
 };
 
 CMS_Menu menuAlarms = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUALARMS",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = menuAlarmsOnEnter,
     .onExit = menuAlarmsOnExit,
     .onGlobalExit = NULL,
@@ -197,8 +201,10 @@ OSD_Entry menuTimersEntries[] =
 };
 
 CMS_Menu menuTimers = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUTIMERS",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = menuTimersOnEnter,
     .onExit = menuTimersOnExit,
     .onGlobalExit = NULL,
@@ -254,8 +260,10 @@ OSD_Entry cmsx_menuOsdEntries[] =
 };
 
 CMS_Menu cmsx_menuOsd = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUOSD",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_menuOsdOnEnter,
     .onExit = cmsx_menuOsdOnExit,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -91,8 +91,10 @@ static OSD_Entry cmsx_menuVtxEntries[] =
 };
 
 CMS_Menu cmsx_menuVtxRTC6705 = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUVTX",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = cmsx_Vtx_onEnter,
     .onExit= cmsx_Vtx_onExit,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -348,8 +348,10 @@ static OSD_Entry saCmsMenuStatsEntries[] = {
 };
 
 static CMS_Menu saCmsMenuStats = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSAST",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -514,8 +516,10 @@ static OSD_Entry saCmsMenuPORFreqEntries[] = {
 
 static CMS_Menu saCmsMenuPORFreq =
 {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSAPOR",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = saCmsSetPORFreqOnEnter,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -535,8 +539,10 @@ static OSD_Entry saCmsMenuUserFreqEntries[] = {
 
 static CMS_Menu saCmsMenuUserFreq =
 {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSAUFQ",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = saCmsSetUserFreqOnEnter,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -559,8 +565,10 @@ static OSD_Entry saCmsMenuConfigEntries[] = {
 };
 
 static CMS_Menu saCmsMenuConfig = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSACFG",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -577,8 +585,10 @@ static OSD_Entry saCmsMenuCommenceEntries[] = {
 };
 
 static CMS_Menu saCmsMenuCommence = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXCOM",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -642,8 +652,10 @@ static long sacms_SetupTopMenu(void)
 }
 
 CMS_Menu cmsx_menuVtxSmartAudio = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXSA",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = sacms_SetupTopMenu,
     .onExit = NULL,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -191,8 +191,10 @@ static OSD_Entry trampCmsMenuCommenceEntries[] = {
 };
 
 static CMS_Menu trampCmsMenuCommence = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXTRC",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,
@@ -217,8 +219,10 @@ static OSD_Entry trampMenuEntries[] =
 };
 
 CMS_Menu cmsx_menuVtxTramp = {
+#ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXTR",
     .GUARD_type = OME_MENU,
+#endif
     .onEnter = trampCmsOnEnter,
     .onExit = NULL,
     .onGlobalExit = NULL,

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -94,10 +94,11 @@ typedef long (*CMSMenuOnExitPtr)(const OSD_Entry *self);
 
 typedef struct
 {
+#ifdef CMS_MENU_DEBUG
     // These two are debug aids for menu content creators.
     const char *GUARD_text;
     const OSD_MenuElement GUARD_type;
-
+#endif
     const CMSMenuFuncPtr onEnter;
     const CMSMenuOnExitPtr onExit;
     const CMSMenuFuncPtr onGlobalExit;

--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -125,8 +125,10 @@ static OSD_Entry menuMainEntries[] =
     {NULL, OME_END, NULL, NULL, 0}
 };
 CMS_Menu menuMain = {
+#ifdef CMS_MENU_DEBUG
     "MENUMAIN",
     OME_MENU,
+#endif
     NULL,
     NULL,
     NULL,


### PR DESCRIPTION
Saves about 424 bytes of ROM.