### PR TITLE
Remove almost entirely unused CMS ononGlobalExit function

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -605,9 +605,6 @@ static void cmsTraverseGlobalExit(const CMS_Menu *pMenu)
         }
     }
 
-    if (pMenu->onGlobalExit) {
-        pMenu->onGlobalExit();
-    }
 }
 
 long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -186,11 +186,6 @@ static long cmsx_Blackbox_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static long cmsx_Blackbox_FeatureWriteback(void)
-{
-    return 0;
-}
-
 static OSD_Entry cmsx_menuBlackboxEntries[] =
 {
     { "-- BLACKBOX --", OME_Label, NULL, NULL, 0},
@@ -213,7 +208,6 @@ CMS_Menu cmsx_menuBlackbox = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_Blackbox_onEnter,
     .onExit = cmsx_Blackbox_onExit,
-    .onGlobalExit = cmsx_Blackbox_FeatureWriteback,
     .entries = cmsx_menuBlackboxEntries
 };
 

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -85,7 +85,6 @@ static CMS_Menu menuInfo = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_InfoInit,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = menuInfoEntries
 };
 
@@ -121,7 +120,6 @@ static CMS_Menu menuFeatures = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = menuFeaturesEntries,
 };
 
@@ -153,7 +151,6 @@ CMS_Menu menuMain = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = menuMainEntries,
 };
 #endif

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -165,7 +165,6 @@ static CMS_Menu cmsx_menuPid = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_PidOnEnter,
     .onExit = cmsx_PidWriteback,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuPidEntries
 };
 
@@ -226,7 +225,6 @@ static CMS_Menu cmsx_menuRateProfile = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_RateProfileOnEnter,
     .onExit = cmsx_RateProfileWriteback,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuRateProfileEntries
 };
 
@@ -295,7 +293,6 @@ static CMS_Menu cmsx_menuProfileOther = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_profileOtherOnEnter,
     .onExit = cmsx_profileOtherOnExit,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuProfileOtherEntries,
 };
 
@@ -348,7 +345,6 @@ static CMS_Menu cmsx_menuFilterGlobal = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_menuGyro_onEnter,
     .onExit = cmsx_menuGyro_onExit,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuFilterGlobalEntries,
 };
 
@@ -399,7 +395,6 @@ static CMS_Menu cmsx_menuFilterPerProfile = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_FilterPerProfileRead,
     .onExit = cmsx_FilterPerProfileWriteback,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuFilterPerProfileEntries,
 };
 
@@ -468,7 +463,6 @@ CMS_Menu cmsx_menuCopyProfile = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_menuCopyProfile_onEnter,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuCopyProfileEntries,
 };
 
@@ -500,7 +494,6 @@ CMS_Menu cmsx_menuImu = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_menuImu_onEnter,
     .onExit = cmsx_menuImu_onExit,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuImuEntries,
 };
 

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -52,8 +52,9 @@ static long cmsx_Ledstrip_FeatureRead(void)
     return 0;
 }
 
-static long cmsx_Ledstrip_FeatureWriteback(void)
+static long cmsx_Ledstrip_FeatureWriteback(const OSD_Entry *self)
 {
+    UNUSED(self);
     if (featureRead) {
         if (cmsx_FeatureLedstrip)
             featureSet(FEATURE_LED_STRIP);
@@ -77,8 +78,7 @@ CMS_Menu cmsx_menuLedstrip = {
     .GUARD_text = "MENULED",
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_Ledstrip_FeatureRead,
-    .onExit = NULL,
-    .onGlobalExit = cmsx_Ledstrip_FeatureWriteback,
+    .onExit = cmsx_Ledstrip_FeatureWriteback,
     .entries = cmsx_menuLedstripEntries
 };
 #endif // LED_STRIP

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -86,7 +86,6 @@ CMS_Menu cmsx_menuRcPreview = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = cmsx_menuRcConfirmBack,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuRcEntries
 };
 
@@ -140,7 +139,6 @@ CMS_Menu cmsx_menuMisc = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_menuMiscOnEnter,
     .onExit = cmsx_menuMiscOnExit,
-    .onGlobalExit = NULL,
     .entries = menuMiscEntries
 };
 

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -107,7 +107,6 @@ CMS_Menu menuOsdActiveElems = {
     .GUARD_type = OME_MENU,
     .onEnter = menuOsdActiveElemsOnEnter,
     .onExit = menuOsdActiveElemsOnExit,
-    .onGlobalExit = NULL,
     .entries = menuOsdActiveElemsEntries
 };
 
@@ -150,7 +149,6 @@ CMS_Menu menuAlarms = {
     .GUARD_type = OME_MENU,
     .onEnter = menuAlarmsOnEnter,
     .onExit = menuAlarmsOnExit,
-    .onGlobalExit = NULL,
     .entries = menuAlarmsEntries,
 };
 
@@ -201,7 +199,6 @@ CMS_Menu menuTimers = {
     .GUARD_type = OME_MENU,
     .onEnter = menuTimersOnEnter,
     .onExit = menuTimersOnExit,
-    .onGlobalExit = NULL,
     .entries = menuTimersEntries,
 };
 #endif /* DISABLE_EXTENDED_CMS_OSD_MENU */
@@ -258,7 +255,6 @@ CMS_Menu cmsx_menuOsd = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_menuOsdOnEnter,
     .onExit = cmsx_menuOsdOnExit,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuOsdEntries
 };
 #endif // CMS

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -95,7 +95,6 @@ CMS_Menu cmsx_menuVtxRTC6705 = {
     .GUARD_type = OME_MENU,
     .onEnter = cmsx_Vtx_onEnter,
     .onExit= cmsx_Vtx_onExit,
-    .onGlobalExit = NULL,
     .entries = cmsx_menuVtxEntries
 };
 

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -352,7 +352,6 @@ static CMS_Menu saCmsMenuStats = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = saCmsMenuStatsEntries
 };
 
@@ -518,7 +517,6 @@ static CMS_Menu saCmsMenuPORFreq =
     .GUARD_type = OME_MENU,
     .onEnter = saCmsSetPORFreqOnEnter,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = saCmsMenuPORFreqEntries,
 };
 
@@ -539,7 +537,6 @@ static CMS_Menu saCmsMenuUserFreq =
     .GUARD_type = OME_MENU,
     .onEnter = saCmsSetUserFreqOnEnter,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = saCmsMenuUserFreqEntries,
 };
 
@@ -563,7 +560,6 @@ static CMS_Menu saCmsMenuConfig = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = saCmsMenuConfigEntries
 };
 
@@ -581,7 +577,6 @@ static CMS_Menu saCmsMenuCommence = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = saCmsMenuCommenceEntries,
 };
 
@@ -646,7 +641,6 @@ CMS_Menu cmsx_menuVtxSmartAudio = {
     .GUARD_type = OME_MENU,
     .onEnter = sacms_SetupTopMenu,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = saCmsMenuOfflineEntries,
 };
 

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -195,7 +195,6 @@ static CMS_Menu trampCmsMenuCommence = {
     .GUARD_type = OME_MENU,
     .onEnter = NULL,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = trampCmsMenuCommenceEntries,
 };
 
@@ -221,7 +220,6 @@ CMS_Menu cmsx_menuVtxTramp = {
     .GUARD_type = OME_MENU,
     .onEnter = trampCmsOnEnter,
     .onExit = NULL,
-    .onGlobalExit = NULL,
     .entries = trampMenuEntries,
 };
 #endif

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -100,7 +100,6 @@ typedef struct
 
     const CMSMenuFuncPtr onEnter;
     const CMSMenuOnExitPtr onExit;
-    const CMSMenuFuncPtr onGlobalExit;
     OSD_Entry *entries;
 } CMS_Menu;
 

--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -129,7 +129,6 @@ CMS_Menu menuMain = {
     OME_MENU,
     NULL,
     NULL,
-    NULL,
     menuMainEntries,
 };
 uint8_t armingFlags;


### PR DESCRIPTION
Saves 168 bytes of ROM.