### PR TITLE
vtx_low_power_disarm: minimize vtx power output while disarmed

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -423,6 +423,7 @@ static long saCmsCommence(displayPort_t *pDisp, const void *self)
         .channel = vtxSettingsConfig()->channel,
         .freq = vtxSettingsConfig()->freq,
         .power = vtxSettingsConfig()->power,
+        .lowPowerDisarm = vtxSettingsConfig()->lowPowerDisarm,
     };
     vtxSettingsConfig_t newSettings = prevSettings;
 

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -212,11 +212,11 @@ static void taskTelemetry(timeUs_t currentTimeUs)
 // Everything that listens to VTX devices
 void taskVtxControl(timeUs_t currentTime)
 {
-    if (ARMING_FLAG(ARMED) || cliMode)
+    if (cliMode)
         return;
 
 #ifdef VTX_COMMON
-    vtxProcess(currentTime);
+    vtxProcessSchedule(currentTime);
 #endif
 }
 #endif

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -761,6 +761,7 @@ const clivalue_t valueTable[] = {
     { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_BAND }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, band) },
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_CHANNEL, VTX_SETTINGS_MAX_CHANNEL }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, channel) },
     { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_POWER_COUNT }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
+    { "vtx_low_power_disarm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, lowPowerDisarm) },
 #ifdef VTX_SETTINGS_FREQCMD
     { "vtx_freq",                   VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, freq) },
 #endif

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -28,9 +28,10 @@ typedef struct vtxSettingsConfig_s {
     uint8_t channel;    // 1-8
     uint8_t power;      // 0 = lowest
     uint16_t freq;      // sets freq in MHz if band=0
+    uint8_t lowPowerDisarm;  // min power while disarmed
 } vtxSettingsConfig_t;
 
 PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);
 
 void vtxInit(void);
-void vtxProcess(timeUs_t currentTimeUs);
+void vtxProcessSchedule(timeUs_t currentTimeUs);

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -265,6 +265,7 @@ const uint8_t vtxTrampPi[] = {           // Spektrum Spec    Tx menu  Tx sends  
         .channel = vtxSettingsConfig()->channel,
         .freq = vtxSettingsConfig()->freq,
         .power = vtxSettingsConfig()->power,
+        .lowPowerDisarm = vtxSettingsConfig()->lowPowerDisarm,
       };
       vtxSettingsConfig_t newSettings = prevSettings;
 


### PR DESCRIPTION
Minimize vtx power output while disarmed and restore to configured state after arm.