### PR TITLE
Fixes for vtx_low_power_disarm_fix issue

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -493,7 +493,11 @@ static void osdDrawSingleElement(uint8_t item)
         {
             const char vtxBandLetter = vtx58BandLetter[vtxSettingsConfig()->band];
             const char *vtxChannelName = vtx58ChannelNames[vtxSettingsConfig()->channel];
-            tfp_sprintf(buff, "%c:%s:%d", vtxBandLetter, vtxChannelName, vtxSettingsConfig()->power);
+            uint8_t vtxPower = vtxSettingsConfig()->power;
+            if (vtxSettingsConfig()->lowPowerDisarm) {
+                vtxCommonGetPowerIndex(&vtxPower);
+            }
+            tfp_sprintf(buff, "%c:%s:%d", vtxBandLetter, vtxChannelName, vtxPower);
             break;
         }
 #endif


### PR DESCRIPTION
Corrected min power constant.

Updated OSD VTX channel widget (b:c:p). While vtx_low_power_disarm mode is active, the power should be polled from the hardware instead of the PG.  This provides visual confirmation of the power switch upon arming/disarming.

Added task to the vtx schedule to confirm consistency between the PG and hardware.  

Three reasons for this:
1) Running vtxCommonProcess once to update a change is not enough to guarantee immediate feedback that an update has been processed and is active on the VTX.
2) Ensure consistency between the hardware and the PG.
3) Prevent unwanted polling of the VTX hardware while armed (keep SmartAudio quiet).  When the state is consistent (ie power update is confirmed), no additional polling is necessary.