### PR TITLE
Update PID calculations to use actual deltaT

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -413,9 +413,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     static timeUs_t previousTime;
 
     // calculate actual deltaT
-#ifndef SITL
-    currentTimeUs = microsISR(); // re-get current time, since there can be variations in timing since scheduler invocation
-#endif
     const float deltaT = currentTimeUs - previousTime;
     previousTime = currentTimeUs;
 


### PR DESCRIPTION
Currently the constant `dT` is used. This means when jitter occurs, the DTerm is overestimated (the ITerm is also underestimated, but that has less effect on flight).