### PR TITLE
Use max7456SpiClock in ENABLE_MAX7456 macro

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -175,7 +175,7 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-    #define ENABLE_MAX7456        {spiSetDivisor(MAX7456_SPI_INSTANCE, MAX7456_SPI_CLK);IOLo(max7456CsPin);}
+    #define ENABLE_MAX7456        {spiSetDivisor(MAX7456_SPI_INSTANCE, max7456SpiClock);IOLo(max7456CsPin);}
 #else
     #define ENABLE_MAX7456        IOLo(max7456CsPin)
 #endif


### PR DESCRIPTION
PR status: Ready to merge

Follow up to #4150, which switch SPI clock based on overlay chip type detection.
The PR made problematic boards work, while the `ENABLE_MAX7456` macro continued to contained `MAX7456_SPI_CLK`.

For safety reasons, the macro is changed to use `max7456SpiClock`.