### PR TITLE
BFF4: Add hmc5883, bmp280 and ms5611, remove bmp280 on spi

### DIFF
--- a/src/main/target/BETAFLIGHTF4/target.h
+++ b/src/main/target/BETAFLIGHTF4/target.h
@@ -49,10 +49,11 @@
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_BARO
-#define USE_BARO_SPI_BMP280
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
 
-#define BMP280_SPI_INSTANCE     SPI2
-#define BMP280_CS_PIN           PB3
+#define USE_MAG
+#define USE_MAG_HMC5883
 
 #define USE_OSD
 #define USE_MAX7456

--- a/src/main/target/BETAFLIGHTF4/target.mk
+++ b/src/main/target/BETAFLIGHTF4/target.mk
@@ -6,4 +6,6 @@ TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_spi_mpu6000.c \
             drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms5611.c \
+            drivers/compass/compass_hmc5883l.c \
             drivers/max7456.c


### PR DESCRIPTION
PR status: Ready to merge

- Added compass support
- Added compass HMC5883 on I2C
- Added barometer BMP280 and MS5611 on I2C
- Removed barometer BMP280 on SPI