### PR TITLE
When in ACRO mode use trim sticks to adjust RATE profile

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -243,13 +243,13 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
         return;
     }
 
-    // Multiple configuration profiles
+    // Change PID profile
     int newPidProfile = 0;
-    if (rcSticks == THR_LO + YAW_LO + PIT_CE + ROL_LO) {        // ROLL left  -> Profile 1
+    if (rcSticks == THR_LO + YAW_LO + PIT_CE + ROL_LO) {        // ROLL left  -> PID profile 1
         newPidProfile = 1;
-    } else if (rcSticks == THR_LO + YAW_LO + PIT_HI + ROL_CE) { // PITCH up   -> Profile 2
+    } else if (rcSticks == THR_LO + YAW_LO + PIT_HI + ROL_CE) { // PITCH up   -> PID profile 2
         newPidProfile = 2;
-    } else if (rcSticks == THR_LO + YAW_LO + PIT_CE + ROL_HI) { // ROLL right -> Profile 3
+    } else if (rcSticks == THR_LO + YAW_LO + PIT_CE + ROL_HI) { // ROLL right -> PID profile 3
         newPidProfile = 3;
     }
     if (newPidProfile) {
@@ -275,28 +275,46 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
     }
 
 
-    // Accelerometer Trim
-    rollAndPitchTrims_t accelerometerTrimsDelta;
-    memset(&accelerometerTrimsDelta, 0, sizeof(accelerometerTrimsDelta));
+    if (FLIGHT_MODE(ANGLE_MODE|HORIZON_MODE)) {
+        // in ANGLE or HORIZON mode, so use sticks to apply accelerometer trims
+        rollAndPitchTrims_t accelerometerTrimsDelta;
+        memset(&accelerometerTrimsDelta, 0, sizeof(accelerometerTrimsDelta));
 
-    bool shouldApplyRollAndPitchTrimDelta = false;
-    if (rcSticks == THR_HI + YAW_CE + PIT_HI + ROL_CE) {
-        accelerometerTrimsDelta.values.pitch = 2;
-        shouldApplyRollAndPitchTrimDelta = true;
-    } else if (rcSticks == THR_HI + YAW_CE + PIT_LO + ROL_CE) {
-        accelerometerTrimsDelta.values.pitch = -2;
-        shouldApplyRollAndPitchTrimDelta = true;
-    } else if (rcSticks == THR_HI + YAW_CE + PIT_CE + ROL_HI) {
-        accelerometerTrimsDelta.values.roll = 2;
-        shouldApplyRollAndPitchTrimDelta = true;
-    } else if (rcSticks == THR_HI + YAW_CE + PIT_CE + ROL_LO) {
-        accelerometerTrimsDelta.values.roll = -2;
-        shouldApplyRollAndPitchTrimDelta = true;
-    }
-    if (shouldApplyRollAndPitchTrimDelta) {
-        applyAndSaveAccelerometerTrimsDelta(&accelerometerTrimsDelta);
-        repeatAfter(STICK_AUTOREPEAT_MS);
-        return;
+        bool shouldApplyRollAndPitchTrimDelta = false;
+        if (rcSticks == THR_HI + YAW_CE + PIT_HI + ROL_CE) {
+            accelerometerTrimsDelta.values.pitch = 2;
+            shouldApplyRollAndPitchTrimDelta = true;
+        } else if (rcSticks == THR_HI + YAW_CE + PIT_LO + ROL_CE) {
+            accelerometerTrimsDelta.values.pitch = -2;
+            shouldApplyRollAndPitchTrimDelta = true;
+        } else if (rcSticks == THR_HI + YAW_CE + PIT_CE + ROL_HI) {
+            accelerometerTrimsDelta.values.roll = 2;
+            shouldApplyRollAndPitchTrimDelta = true;
+        } else if (rcSticks == THR_HI + YAW_CE + PIT_CE + ROL_LO) {
+            accelerometerTrimsDelta.values.roll = -2;
+            shouldApplyRollAndPitchTrimDelta = true;
+        }
+        if (shouldApplyRollAndPitchTrimDelta) {
+            applyAndSaveAccelerometerTrimsDelta(&accelerometerTrimsDelta);
+            repeatAfter(STICK_AUTOREPEAT_MS);
+            return;
+        }
+    } else {
+        // in ACRO mode, so use sticks to change RATE profile
+        switch (rcSticks) {
+        case THR_HI + YAW_CE + PIT_HI + ROL_CE:
+            changeControlRateProfile(0);
+            return;
+        case THR_HI + YAW_CE + PIT_LO + ROL_CE:
+            changeControlRateProfile(1);
+            return;
+        case THR_HI + YAW_CE + PIT_CE + ROL_HI:
+            changeControlRateProfile(2);
+            return;
+        case THR_HI + YAW_CE + PIT_CE + ROL_LO:
+            changeControlRateProfile(3);
+            return;
+        }
     }
 
 #ifdef USE_DASHBOARD

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -662,6 +662,7 @@ extern "C" {
     void accSetCalibrationCycles(uint16_t) {}
     void baroSetCalibrationCycles(uint16_t) {}
     void changePidProfile(uint8_t) {}
+    void changeControlRateProfile(uint8_t) {}
     void dashboardEnablePageCycling(void) {}
     void dashboardDisablePageCycling(void) {}
     bool imuQuaternionHeadfreeOffsetSet(void) { return true; }

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -699,6 +699,7 @@ void blackboxLogEvent(FlightLogEvent, flightLogEventData_t *) {}
 
 bool cmsInMenu = false;
 uint8_t armingFlags = 0;
+uint16_t flightModeFlags = 0;
 int16_t heading;
 uint8_t stateFlags = 0;
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];


### PR DESCRIPTION
Second part of https://github.com/betaflight/betaflight/issues/4302 - [Please add this back] - 9 rate profiles are needed