### PR TITLE
check for clang feature to avoid build errors

### DIFF
--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -32,6 +32,16 @@
 #define UNIT_TESTED
 #endif
 
+#ifndef __has_feature
+  #define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#endif
+
+#if __has_feature(cxx_aggregate_nsdmi)
+#define CONST_DEFINITION(member)  const member
+#else
+#define CONST_DEFINITION(member) member
+#endif
+
 //#define SOFT_I2C // enable to test software i2c
 
 #ifndef __CC_ARM

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -21,7 +21,6 @@
 #include <stdbool.h>
 #include "config/parameter_group.h"
 
-
 typedef enum {
     TABLE_OFF_ON = 0,
     TABLE_UNIT,
@@ -109,16 +108,16 @@ typedef enum {
 #define VALUE_MODE_MASK (0x30)
 
 typedef struct cliMinMaxConfig_s {
-    const int16_t min;
-    const int16_t max;
+    CONST_DEFINITION(int16_t min);
+    CONST_DEFINITION(int16_t max);
 } cliMinMaxConfig_t;
 
 typedef struct cliLookupTableConfig_s {
-    const lookupTableIndex_e tableIndex;
+    CONST_DEFINITION(lookupTableIndex_e tableIndex);
 } cliLookupTableConfig_t;
 
 typedef struct cliArrayLengthConfig_s {
-    const uint8_t length;
+    CONST_DEFINITION(uint8_t length);
 } cliArrayLengthConfig_t;
 
 typedef union {
@@ -130,7 +129,7 @@ typedef union {
 typedef struct clivalue_s {
     const char *name;
     const uint8_t type; // see cliValueFlag_e
-    const cliValueConfig_t config;
+    CONST_DEFINITION(cliValueConfig_t config);
 
     pgn_t pgn;
     uint16_t offset;

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -132,15 +132,15 @@ typedef struct {
     const char * subTaskName;
     bool (*checkFunc)(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
     void (*taskFunc)(timeUs_t currentTimeUs);
-    timeDelta_t desiredPeriod;      // target period of execution
-    const uint8_t staticPriority;   // dynamicPriority grows in steps of this size, shouldn't be zero
+    timeDelta_t desiredPeriod;               // target period of execution
+    CONST_DEFINITION(uint8_t staticPriority); // dynamicPriority grows in steps of this size, shouldn't be zero
 
     // Scheduling
-    uint16_t dynamicPriority;       // measurement of how old task was last executed, used to avoid task starvation
+    uint16_t dynamicPriority;                // measurement of how old task was last executed, used to avoid task starvation
     uint16_t taskAgeCycles;
     timeDelta_t taskLatestDeltaTime;
-    timeUs_t lastExecutedAt;        // last time of invocation
-    timeUs_t lastSignaledAt;        // time of invocation event for event-driven tasks
+    timeUs_t lastExecutedAt;                 // last time of invocation
+    timeUs_t lastSignaledAt;                 // time of invocation event for event-driven tasks
 
 #ifndef SKIP_TASK_STATISTICS
     // Statistics


### PR DESCRIPTION
Fixes #4597

structures containing const members are statically initialized, but some
compilers will not support it.
Instead, defining those member as being const should be conditionned by
the presence of cclang feature cxx_aggregate_nsdmi

Signed-off-by: Steven HUET <steven.huet@gmail.com>
