### PR TITLE
Fixed cpu overclock in systemConfig

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -124,10 +124,15 @@ PG_RESET_TEMPLATE(pilotConfig_t, pilotConfig,
     .name = { 0 }
 );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);
 
-#ifndef USE_OSD_SLAVE
-#if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
+#ifdef USE_OSD_SLAVE
+PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
+    .debug_mode = DEBUG_MODE,
+    .task_statistics = true,
+    .boardIdentifier = TARGET_BOARD_IDENTIFIER
+);
+#else
 PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .pidProfileIndex = 0,
     .activeRateProfile = 0,
@@ -137,24 +142,8 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .powerOnArmingGraceTime = 5,
     .boardIdentifier = TARGET_BOARD_IDENTIFIER
 );
-#else
-PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
-    .pidProfileIndex = 0,
-    .activeRateProfile = 0,
-    .debug_mode = DEBUG_MODE,
-    .task_statistics = true,
-    .boardIdentifier = TARGET_BOARD_IDENTIFIER
-);
-#endif
 #endif
 
-#ifdef USE_OSD_SLAVE
-PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
-    .debug_mode = DEBUG_MODE,
-    .task_statistics = true,
-    .boardIdentifier = TARGET_BOARD_IDENTIFIER
-);
-#endif
 
 #ifdef USE_ADC
 PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -75,9 +75,7 @@ typedef struct systemConfig_s {
     uint8_t activeRateProfile;
     uint8_t debug_mode;
     uint8_t task_statistics;
-#if defined(STM32F4) && !defined(DISABLE_OVERCLOCK)
     uint8_t cpu_overclock;
-#endif
     uint8_t powerOnArmingGraceTime; // in seconds
     char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER) + 1];
 } systemConfig_t;


### PR DESCRIPTION
Removed conditional inclusion of `cpu_overclock` in `systemConfig_t`.