### PR TITLE
Add RTC date/time to OSD stats

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -861,6 +861,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->enabled_stats[OSD_STAT_BLACKBOX_NUMBER] = true;
     osdConfig->enabled_stats[OSD_STAT_TIMER_1]         = false;
     osdConfig->enabled_stats[OSD_STAT_TIMER_2]         = true;
+    osdConfig->enabled_stats[OSD_STAT_RTC_DATE_TIME]   = false;
 
     osdConfig->units = OSD_UNIT_METRIC;
 
@@ -1103,10 +1104,22 @@ static bool isSomeStatEnabled(void) {
 static void osdShowStats(void)
 {
     uint8_t top = 2;
-    char buff[10];
+    char buff[OSD_ELEMENT_BUFFER_LENGTH];
 
     displayClearScreen(osdDisplayPort);
     displayWrite(osdDisplayPort, 2, top++, "  --- STATS ---");
+
+    if (osdConfig()->enabled_stats[OSD_STAT_RTC_DATE_TIME]) {
+        bool success = false;
+#ifdef USE_RTC_TIME
+        success = printRtcDateTime(&buff[0]);
+#endif
+        if (!success) {
+            tfp_sprintf(buff, "NO RTC");
+        }
+
+        displayWrite(osdDisplayPort, 2, top++, buff);
+    }
 
     if (osdConfig()->enabled_stats[OSD_STAT_TIMER_1]) {
         osdFormatTimer(buff, false, OSD_TIMER_1);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -102,6 +102,7 @@ typedef enum {
     OSD_STAT_TIMER_2,
     OSD_STAT_MAX_DISTANCE,
     OSD_STAT_BLACKBOX_NUMBER,
+    OSD_STAT_RTC_DATE_TIME,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -155,10 +155,12 @@ osd_unittest_SRC := \
 		$(USER_DIR)/drivers/display.c \
 		$(USER_DIR)/common/maths.c \
 		$(USER_DIR)/common/printf.c \
+		$(USER_DIR)/common/time.c \
 		$(USER_DIR)/fc/runtime_config.c
 
 osd_unittest_DEFINES := \
-		USE_OSD
+		USE_OSD \
+		USE_RTC_TIME
 
 
 parameter_groups_unittest_SRC := \

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -29,6 +29,8 @@ extern "C" {
 
     #include "config/parameter_group_ids.h"
 
+    #include "common/time.h"
+
     #include "drivers/max7456_symbols.h"
 
     #include "fc/config.h"
@@ -291,6 +293,7 @@ TEST(OsdTest, TestStatsImperial)
     osdConfigMutable()->enabled_stats[OSD_STAT_END_BATTERY]     = true;
     osdConfigMutable()->enabled_stats[OSD_STAT_TIMER_1]         = true;
     osdConfigMutable()->enabled_stats[OSD_STAT_TIMER_2]         = true;
+    osdConfigMutable()->enabled_stats[OSD_STAT_RTC_DATE_TIME]   = true;
     osdConfigMutable()->enabled_stats[OSD_STAT_MAX_DISTANCE]    = true;
     osdConfigMutable()->enabled_stats[OSD_STAT_BLACKBOX_NUMBER] = false;
 
@@ -309,6 +312,18 @@ TEST(OsdTest, TestStatsImperial)
     // and
     // a GPS fix is present
     stateFlags |= GPS_FIX | GPS_FIX_HOME;
+
+    // and
+    // this RTC time
+    dateTime_t dateTime;
+    dateTime.year = 2017;
+    dateTime.month = 11;
+    dateTime.day = 19;
+    dateTime.hours = 10;
+    dateTime.minutes = 12;
+    dateTime.seconds = 0;
+    dateTime.millis = 0;
+    rtcSetDateTime(&dateTime);
 
     // when
     // the craft is armed
@@ -347,6 +362,7 @@ TEST(OsdTest, TestStatsImperial)
     // then
     // statistics screen should display the following
     int row = 3;
+    displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:05.00");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:03");
     displayPortTestBufferSubstring(2, row++, "MAX SPEED         : 28");
@@ -397,6 +413,7 @@ TEST(OsdTest, TestStatsMetric)
     // then
     // statistics screen should display the following
     int row = 3;
+    displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:07.50");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:02");
     displayPortTestBufferSubstring(2, row++, "MAX SPEED         : 28");
@@ -871,6 +888,10 @@ extern "C" {
 
     uint32_t micros() {
         return simulationTime;
+    }
+
+    uint32_t millis() {
+        return micros() / 1000;
     }
 
     bool isBeeperOn() {


### PR DESCRIPTION
Fixes #4575 

Adds the option to display RTC date and time on OSD stats page.

Does not use the standard `LABEL    : VALUE` syntax for the sake of fitting on one line (plus it is mostly obvious what this is).