### PR TITLE
Boot fix

### DIFF
--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -365,6 +365,7 @@ uint8_t spiBusReadRegister(const busDevice_t *bus, uint8_t reg)
 
 void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance)
 {
+    bus->bustype = BUSTYPE_SPI;
     bus->busdev_u.spi.instance = instance;
 }
 


### PR DESCRIPTION
Fix AlienFlightNG F7 boot issue (likely all F7 targets using the MPU6500 driver are affected)
Remove redundand SPI gyro read function  