### PR TITLE
Add MCU dependent optimization to sources.mk

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -219,8 +219,10 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             drivers/buf_writer.c \
             drivers/bus.c \
             drivers/bus_spi.c \
+            drivers/bus_spi_ll.c \
             drivers/exti.c \
             drivers/io.c \
+            drivers/max7456.c \
             drivers/pwm_output.c \
             drivers/rcc.c \
             drivers/serial.c \

--- a/make/source.mk
+++ b/make/source.mk
@@ -219,10 +219,8 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             drivers/buf_writer.c \
             drivers/bus.c \
             drivers/bus_spi.c \
-            drivers/bus_spi_ll.c \
             drivers/exti.c \
             drivers/io.c \
-            drivers/max7456.c \
             drivers/pwm_output.c \
             drivers/rcc.c \
             drivers/serial.c \
@@ -314,6 +312,16 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \
             io/vtx_control.c
+
+# F4 and F7 optimizations
+ifneq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))
+SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
+            drivers/bus_i2c_hal.c \
+            drivers/bus_spi_ll.c \
+            drivers/max7456.c \
+            drivers/pwm_output_dshot.c \
+            drivers/pwm_output_dshot_hal.c
+endif #!F3
 endif #!F1
 
 # check if target.mk supplied


### PR DESCRIPTION
PR status: For discussion

This is an alternative approach to specify target and mcu dependent optimization.
It tries to do everything in `make/sources.mk`, which is at the other end of the spectrum compared to #4590.