### PR TITLE
Improve ACC filter initialisation

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -307,7 +307,7 @@ void activateConfig(void)
 
     failsafeReset();
     setAccelerationTrims(&accelerometerConfigMutable()->accZero);
-    setAccelerationFilter(accelerometerConfig()->acc_lpf_hz);
+    accInitFilters();
 
     imuConfigure(throttleCorrectionConfig()->throttle_correction_angle);
 #endif // USE_OSD_SLAVE

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -511,7 +511,7 @@ void init(void)
     // so we are ready to call validateAndFixGyroConfig(), pidInit(), and setAccelerationFilter()
     validateAndFixGyroConfig();
     pidInit(currentPidProfile);
-    setAccelerationFilter(accelerometerConfig()->acc_lpf_hz);
+    accInitFilters();
 
 #ifdef USE_SERVOS
     servosInit();

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -499,9 +499,9 @@ void setAccelerationTrims(flightDynamicsTrims_t *accelerationTrimsToUse)
     accelerationTrims = accelerationTrimsToUse;
 }
 
-void setAccelerationFilter(uint16_t initialAccLpfCutHz)
+void accInitFilters(void)
 {
-    accLpfCutHz = initialAccLpfCutHz;
+    accLpfCutHz = accelerometerConfig()->acc_lpf_hz;
     if (acc.accSamplingInterval) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             biquadFilterInitLPF(&accFilter[axis], accLpfCutHz, acc.accSamplingInterval);

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -80,4 +80,4 @@ void resetRollAndPitchTrims(rollAndPitchTrims_t *rollAndPitchTrims);
 void accUpdate(rollAndPitchTrims_t *rollAndPitchTrims);
 union flightDynamicsTrims_u;
 void setAccelerationTrims(union flightDynamicsTrims_u *accelerationTrimsToUse);
-void setAccelerationFilter(uint16_t initialAccLpfCutHz);
+void accInitFilters(void);


### PR DESCRIPTION
Amazingly this saves 392 bytes of ROM on OMNIBUS target, more on BETAFLIGHTF3 target. That just seems too much. Can anyone else confirm?