### PR TITLE
SOFTSERIAL: Work around for disappearing start bit in SERIAL_BIDIR case.

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -498,6 +498,12 @@ void onSerialRxPinChange(timerCCHandlerRec_t *cbRec, captureCompare_t capture)
         return;
     }
 
+    // XXX Workaround for disappearing start bit in SERIAL_BIDIR case.
+    // This shouldn't happen, since edge interrupt is disabled by serialInputPortDeActivate when going into transmit mode...
+    if ((self->port.options & SERIAL_BIDIR) && (self->isTransmittingData)) {
+        return;
+    }
+
     if (self->isSearchingForStartBit) {
         // Synchronize the bit timing so that it will interrupt at the center
         // of the bit period.


### PR DESCRIPTION
PR status: Need review

This PR provides a work around for disappearing start bit in `(SERIAL_BIDIR|SERIAL_INVERTED)`case.

In some cases depending on serial options, very first bit after idle channel (the first start bit) was magically disappearing. When scoped, it looks as if the bit has been cancelled.

![saleae_logic_software](https://user-images.githubusercontent.com/14850998/33232904-84e48c48-d251-11e7-9043-8bb34dcf6a93.jpg)

After some investigation, the cancelling is occurring at edge interrupt handler. This shouldn't happen, as edge interrupt is disabled by `serialInputPortDeActivate` when going into transmit mode. The PR checks if transmission is active in SERIAL_BIDIR mode, and returns if so.

The reason for the interrupt is left for further investigation.