### PR TITLE
[GPS] Convert baudrate index into value when calling openSerialPort

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -285,7 +285,7 @@ void gpsInit(void)
 #endif
 
     // no callback - buffer will be consumed in gpsUpdate()
-    gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, NULL, gpsInitData[gpsData.baudrateIndex].baudrateIndex, mode, SERIAL_NOT_INVERTED);
+    gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, NULL, baudRates[gpsInitData[gpsData.baudrateIndex].baudrateIndex], mode, SERIAL_NOT_INVERTED);
     if (!gpsPort) {
         featureClear(FEATURE_GPS);
         return;


### PR DESCRIPTION
PR status: Ready to merge

Fixed the `baudrate` argument to `openSerialPort` in `gpsInit` from index to value.

This has been broken since 27 Feb. 2015.
https://github.com/cleanflight/cleanflight/commit/1a8500c768157b902206956644b83eacf3b50faa#diff-62a123af09bd3b80f478b220998900f3