### PR TITLE
Add TIMUP pseudo resource to use with DMAR

### DIFF
--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -177,7 +177,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&motor->TimHandle, hdma[motor->timerDmaIndex], motor->hdma_tim);
 
-    dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+    dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim));
     dmaSetHandler(timerHardware->dmaTimUPIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #else
     motor->timerDmaIndex = timerDmaIndex(timerHardware->channel);

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -67,4 +67,5 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "RX_BIND_PLUG",
     "ESCSERIAL",
     "CAMERA_CONTROL",
+    "TIMUP",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -67,6 +67,7 @@ typedef enum {
     OWNER_RX_BIND_PLUG,
     OWNER_ESCSERIAL,
     OWNER_CAMERA_CONTROL,
+    OWNER_TIMUP,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -210,3 +210,5 @@ uint16_t timerDmaSource(uint8_t channel);
 uint16_t timerGetPrescalerByDesiredHertz(TIM_TypeDef *tim, uint32_t hz);
 uint16_t timerGetPrescalerByDesiredMhz(TIM_TypeDef *tim, uint16_t mhz);
 uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hz);
+
+int8_t timerGetTIMNumber(const TIM_TypeDef *tim);

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -198,6 +198,75 @@ TIM_TypeDef * const usedTimers[USED_TIMER_COUNT] = {
 #undef _DEF
 };
 
+// Map timer index to timer number (Straight copy of usedTimers array)
+const int8_t timerNumbers[USED_TIMER_COUNT] = {
+#define _DEF(i) i
+
+#if USED_TIMERS & TIM_N(1)
+    _DEF(1),
+#endif
+#if USED_TIMERS & TIM_N(2)
+    _DEF(2),
+#endif
+#if USED_TIMERS & TIM_N(3)
+    _DEF(3),
+#endif
+#if USED_TIMERS & TIM_N(4)
+    _DEF(4),
+#endif
+#if USED_TIMERS & TIM_N(5)
+    _DEF(5),
+#endif
+#if USED_TIMERS & TIM_N(6)
+    _DEF(6),
+#endif
+#if USED_TIMERS & TIM_N(7)
+    _DEF(7),
+#endif
+#if USED_TIMERS & TIM_N(8)
+    _DEF(8),
+#endif
+#if USED_TIMERS & TIM_N(9)
+    _DEF(9),
+#endif
+#if USED_TIMERS & TIM_N(10)
+    _DEF(10),
+#endif
+#if USED_TIMERS & TIM_N(11)
+    _DEF(11),
+#endif
+#if USED_TIMERS & TIM_N(12)
+    _DEF(12),
+#endif
+#if USED_TIMERS & TIM_N(13)
+    _DEF(13),
+#endif
+#if USED_TIMERS & TIM_N(14)
+    _DEF(14),
+#endif
+#if USED_TIMERS & TIM_N(15)
+    _DEF(15),
+#endif
+#if USED_TIMERS & TIM_N(16)
+    _DEF(16),
+#endif
+#if USED_TIMERS & TIM_N(17)
+    _DEF(17),
+#endif
+#undef _DEF
+};
+
+int8_t timerGetTIMNumber(const TIM_TypeDef *tim)
+{
+    uint8_t index = lookupTimerIndex(tim);
+
+    if (index < USED_TIMER_COUNT) {
+        return timerNumbers[index];
+    } else {
+        return 0;
+    }
+}
+
 static inline uint8_t lookupChannelIndex(const uint16_t channel)
 {
     return channel >> 2;
@@ -1049,4 +1118,3 @@ HAL_StatusTypeDef DMA_SetCurrDataCounter(TIM_HandleTypeDef *htim, uint32_t Chann
     /* Return function status */
     return HAL_OK;
 }
-


### PR DESCRIPTION
PR status: Ready to merge

When DMAR is in effect, DMA stream/channel allocation displayed by `resource list` only shows the last motor allocated for a stream/channel, and is bit confusing. Creating and using a new resource `TIMUP` would at least indicate it is not a normal motor usage. ~Indices are still motor numbers, but timer number (x as in TIMx) may be better, but it may be expensive to get that information (`getTimerNumberFromTIM` like function is required).~ Now `TIMUP` shows timer number.

![betaflight_configurator](https://user-images.githubusercontent.com/14850998/33242523-a3c6c3f6-d319-11e7-91e2-c75da4b914dc.jpg)
