### PR TITLE
Mask timerDefinitions by USED_TIMERS

### DIFF
--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -177,7 +177,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&motor->TimHandle, hdma[motor->timerDmaIndex], motor->hdma_tim);
 
-    dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, RESOURCE_INDEX(motorIndex)); // XXX May be better to use timer number as index for clarity?
+    dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetNumber(timerHardware->tim));
     dmaSetHandler(timerHardware->dmaTimUPIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #else
     motor->timerDmaIndex = timerDmaIndex(timerHardware->channel);

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -177,7 +177,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&motor->TimHandle, hdma[motor->timerDmaIndex], motor->hdma_tim);
 
-    dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+    dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, RESOURCE_INDEX(motorIndex)); // XXX May be better to use timer number as index for clarity?
     dmaSetHandler(timerHardware->dmaTimUPIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #else
     motor->timerDmaIndex = timerDmaIndex(timerHardware->channel);

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -67,4 +67,5 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "RX_BIND_PLUG",
     "ESCSERIAL",
     "CAMERA_CONTROL",
+    "TIMUP",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -67,6 +67,7 @@ typedef enum {
     OWNER_RX_BIND_PLUG,
     OWNER_ESCSERIAL,
     OWNER_CAMERA_CONTROL,
+    OWNER_TIMUP,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -136,63 +136,6 @@ static uint8_t lookupTimerIndex(const TIM_TypeDef *tim)
 #undef _CASE_
 }
 
-TIM_TypeDef * const usedTimers[USED_TIMER_COUNT] = {
-#define _DEF(i) TIM##i
-
-#if USED_TIMERS & TIM_N(1)
-    _DEF(1),
-#endif
-#if USED_TIMERS & TIM_N(2)
-    _DEF(2),
-#endif
-#if USED_TIMERS & TIM_N(3)
-    _DEF(3),
-#endif
-#if USED_TIMERS & TIM_N(4)
-    _DEF(4),
-#endif
-#if USED_TIMERS & TIM_N(5)
-    _DEF(5),
-#endif
-#if USED_TIMERS & TIM_N(6)
-    _DEF(6),
-#endif
-#if USED_TIMERS & TIM_N(7)
-    _DEF(7),
-#endif
-#if USED_TIMERS & TIM_N(8)
-    _DEF(8),
-#endif
-#if USED_TIMERS & TIM_N(9)
-    _DEF(9),
-#endif
-#if USED_TIMERS & TIM_N(10)
-    _DEF(10),
-#endif
-#if USED_TIMERS & TIM_N(11)
-    _DEF(11),
-#endif
-#if USED_TIMERS & TIM_N(12)
-    _DEF(12),
-#endif
-#if USED_TIMERS & TIM_N(13)
-    _DEF(13),
-#endif
-#if USED_TIMERS & TIM_N(14)
-    _DEF(14),
-#endif
-#if USED_TIMERS & TIM_N(15)
-    _DEF(15),
-#endif
-#if USED_TIMERS & TIM_N(16)
-    _DEF(16),
-#endif
-#if USED_TIMERS & TIM_N(17)
-    _DEF(17),
-#endif
-#undef _DEF
-};
-
 static inline uint8_t lookupChannelIndex(const uint16_t channel)
 {
     return channel >> 2;
@@ -200,20 +143,20 @@ static inline uint8_t lookupChannelIndex(const uint16_t channel)
 
 rccPeriphTag_t timerRCC(TIM_TypeDef *tim)
 {
-    for (int i = 0; i < HARDWARE_TIMER_DEFINITION_COUNT; i++) {
-        if (timerDefinitions[i].TIMx == tim) {
-            return timerDefinitions[i].rcc;
-        }
+    uint8_t index = lookupTimerIndex(tim);
+
+    if (index < USED_TIMER_COUNT) {
+        return timerDefinitions[index].rcc;
     }
     return 0;
 }
 
 uint8_t timerInputIrq(TIM_TypeDef *tim)
 {
-    for (int i = 0; i < HARDWARE_TIMER_DEFINITION_COUNT; i++) {
-        if (timerDefinitions[i].TIMx == tim) {
-            return timerDefinitions[i].inputIrq;
-        }
+    uint8_t index = lookupTimerIndex(tim);
+
+    if (index < USED_TIMER_COUNT) {
+        return timerDefinitions[index].inputIrq;
     }
     return 0;
 }
@@ -296,8 +239,8 @@ void timerChInit(const timerHardware_t *timHw, channelType_t type, int irqPriori
         return;
     if (irqPriority < timerInfo[timer].priority) {
         // it would be better to set priority in the end, but current startup sequence is not ready
-        configTimeBase(usedTimers[timer], 0, 1);
-        TIM_Cmd(usedTimers[timer],  ENABLE);
+        configTimeBase(timerDefinitions[timer].TIMx, 0, 1);
+        TIM_Cmd(timerDefinitions[timer].TIMx,  ENABLE);
 
         NVIC_InitTypeDef NVIC_InitStructure;
 
@@ -736,13 +679,13 @@ void timerStart(void)
         int priority = -1;
         int irq = -1;
         for (unsigned hwc = 0; hwc < USABLE_TIMER_CHANNEL_COUNT; hwc++)
-            if ((timerChannelInfo[hwc].type != TYPE_FREE) && (timerHardware[hwc].tim == usedTimers[timer])) {
+            if ((timerChannelInfo[hwc].type != TYPE_FREE) && (timerHardware[hwc].tim == timerDefinitions[timer].TIMx)) {
                 // TODO - move IRQ to timer info
                 irq = timerHardware[hwc].irq;
             }
         // TODO - aggregate required timer paramaters
-        configTimeBase(usedTimers[timer], 0, 1);
-        TIM_Cmd(usedTimers[timer],  ENABLE);
+        configTimeBase(timerDefinitions[timer].TIMx, 0, 1);
+        TIM_Cmd(timerDefinitions[timer].TIMx,  ENABLE);
         if (priority >= 0) {  // maybe none of the channels was configured
             NVIC_InitTypeDef NVIC_InitStructure;
 

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -210,3 +210,5 @@ uint16_t timerDmaSource(uint8_t channel);
 uint16_t timerGetPrescalerByDesiredHertz(TIM_TypeDef *tim, uint32_t hz);
 uint16_t timerGetPrescalerByDesiredMhz(TIM_TypeDef *tim, uint16_t mhz);
 uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hz);
+
+int8_t timerGetNumber(const TIM_TypeDef *tim);

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -198,6 +198,75 @@ TIM_TypeDef * const usedTimers[USED_TIMER_COUNT] = {
 #undef _DEF
 };
 
+// Map timer index to timer number (Straight copy of usedTimers array)
+const int8_t timerNumbers[USED_TIMER_COUNT] = {
+#define _DEF(i) i
+
+#if USED_TIMERS & TIM_N(1)
+    _DEF(1),
+#endif
+#if USED_TIMERS & TIM_N(2)
+    _DEF(2),
+#endif
+#if USED_TIMERS & TIM_N(3)
+    _DEF(3),
+#endif
+#if USED_TIMERS & TIM_N(4)
+    _DEF(4),
+#endif
+#if USED_TIMERS & TIM_N(5)
+    _DEF(5),
+#endif
+#if USED_TIMERS & TIM_N(6)
+    _DEF(6),
+#endif
+#if USED_TIMERS & TIM_N(7)
+    _DEF(7),
+#endif
+#if USED_TIMERS & TIM_N(8)
+    _DEF(8),
+#endif
+#if USED_TIMERS & TIM_N(9)
+    _DEF(9),
+#endif
+#if USED_TIMERS & TIM_N(10)
+    _DEF(10),
+#endif
+#if USED_TIMERS & TIM_N(11)
+    _DEF(11),
+#endif
+#if USED_TIMERS & TIM_N(12)
+    _DEF(12),
+#endif
+#if USED_TIMERS & TIM_N(13)
+    _DEF(13),
+#endif
+#if USED_TIMERS & TIM_N(14)
+    _DEF(14),
+#endif
+#if USED_TIMERS & TIM_N(15)
+    _DEF(15),
+#endif
+#if USED_TIMERS & TIM_N(16)
+    _DEF(16),
+#endif
+#if USED_TIMERS & TIM_N(17)
+    _DEF(17),
+#endif
+#undef _DEF
+};
+
+int8_t timerGetNumber(const TIM_TypeDef *tim)
+{
+    uint8_t index = lookupTimerIndex(tim);
+
+    if (index < USED_TIMER_COUNT) {
+        return timerNumbers[index];
+    } else {
+        return 0;
+    }
+}
+
 static inline uint8_t lookupChannelIndex(const uint16_t channel)
 {
     return channel >> 2;
@@ -1048,24 +1117,4 @@ HAL_StatusTypeDef DMA_SetCurrDataCounter(TIM_HandleTypeDef *htim, uint32_t Chann
     }
     /* Return function status */
     return HAL_OK;
-}
-
-int8_t timerGetNumber(const TIM_TypeDef *tim)
-{
-#define TIM_COUNT(tim, base) (((unsigned)tim - base) >> 10)
-
-    if (tim >= TIM2 && tim <= TIM7) {
-        return TIM_COUNT(tim, TIM2_BASE) + 2;
-    } else if (tim >= TIM12 && tim <= TIM14) {
-        return TIM_COUNT(tim, TIM12_BASE) + 12;
-    } else if (tim == TIM1) {
-        return 1;
-    } else if (tim == TIM8) {
-        return 8;
-    } else if (tim >= TIM9 && tim <= TIM11) {
-        return TIM_COUNT(tim, TIM9_BASE) + 9;
-    } else {
-        return -1;
-    }
-#undef TIM_COUNT
 }

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -1050,3 +1050,22 @@ HAL_StatusTypeDef DMA_SetCurrDataCounter(TIM_HandleTypeDef *htim, uint32_t Chann
     return HAL_OK;
 }
 
+int8_t timerGetNumber(const TIM_TypeDef *tim)
+{
+#define TIM_COUNT(tim, base) (((unsigned)tim - base) >> 10)
+
+    if (tim >= TIM2 && tim <= TIM7) {
+        return TIM_COUNT(tim, TIM2_BASE) + 2;
+    } else if (tim >= TIM12 && tim <= TIM14) {
+        return TIM_COUNT(tim, TIM12_BASE) + 12;
+    } else if (tim == TIM1) {
+        return 1;
+    } else if (tim == TIM8) {
+        return 8;
+    } else if (tim >= TIM9 && tim <= TIM11) {
+        return TIM_COUNT(tim, TIM9_BASE) + 9;
+    } else {
+        return -1;
+    }
+#undef TIM_COUNT
+}

--- a/src/main/drivers/timer_stm32f10x.c
+++ b/src/main/drivers/timer_stm32f10x.c
@@ -23,24 +23,55 @@
 #include "rcc.h"
 #include "timer.h"
 
-const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
+#define TIM_N(n) (1 << (n))
+#define USED_TIMER_COUNT BITCOUNT(USED_TIMERS)
+
+const timerDef_t timerDefinitions[USED_TIMER_COUNT] = {
+#if USED_TIMERS & TIM_N(1)
     { .TIMx = TIM1,  .rcc = RCC_APB2(TIM1), .inputIrq = TIM1_CC_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(2)
     { .TIMx = TIM2,  .rcc = RCC_APB1(TIM2), .inputIrq = TIM2_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(3)
     { .TIMx = TIM3,  .rcc = RCC_APB1(TIM3), .inputIrq = TIM3_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(4)
     { .TIMx = TIM4,  .rcc = RCC_APB1(TIM4), .inputIrq = TIM4_IRQn },
+#endif
 #if defined(STM32F10X_HD) || defined(STM32F10X_CL) || defined(STM32F10X_XL) || defined(STM32F10X_HD_VL)
+#if USED_TIMERS & TIM_N(5)
     { .TIMx = TIM5,  .rcc = RCC_APB1(TIM5), .inputIrq = TIM5_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(6)
     { .TIMx = TIM6,  .rcc = RCC_APB1(TIM6), .inputIrq = 0 },
+#endif
+#if USED_TIMERS & TIM_N(7)
     { .TIMx = TIM7,  .rcc = RCC_APB1(TIM7), .inputIrq = 0 },
 #endif
+#endif
 #if defined(STM32F10X_XL) || defined(STM32F10X_HD_VL)
+#if USED_TIMERS & TIM_N(8)
     { .TIMx = TIM8,  .rcc = RCC_APB1(TIM8),  .inputIrq = TIM8_CC_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(9)
     { .TIMx = TIM9,  .rcc = RCC_APB2(TIM9),  .inputIrq = TIM1_BRK_TIM9_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(10)
     { .TIMx = TIM10, .rcc = RCC_APB2(TIM10), .inputIrq = TIM1_UP_TIM10_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(11)
     { .TIMx = TIM11, .rcc = RCC_APB2(TIM11), .inputIrq = TIM1_TRG_COM_TIM11_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(12)
     { .TIMx = TIM12, .rcc = RCC_APB1(TIM12), .inputIrq = TIM12_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(13)
     { .TIMx = TIM13, .rcc = RCC_APB1(TIM13), .inputIrq = TIM13_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(14)
     { .TIMx = TIM14, .rcc = RCC_APB1(TIM14), .inputIrq = TIM14_IRQn },
+#endif
 #endif
 };
 

--- a/src/main/drivers/timer_stm32f30x.c
+++ b/src/main/drivers/timer_stm32f30x.c
@@ -23,17 +23,40 @@
 #include "rcc.h"
 #include "timer.h"
 
-const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
+#define TIM_N(n) (1 << (n))
+#define USED_TIMER_COUNT BITCOUNT(USED_TIMERS)
+
+const timerDef_t timerDefinitions[USED_TIMER_COUNT] = {
+#if USED_TIMERS & TIM_N(1)
     { .TIMx = TIM1,  .rcc = RCC_APB2(TIM1),  .inputIrq = TIM1_CC_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(2)
     { .TIMx = TIM2,  .rcc = RCC_APB1(TIM2),  .inputIrq = TIM2_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(3)
     { .TIMx = TIM3,  .rcc = RCC_APB1(TIM3),  .inputIrq = TIM3_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(4)
     { .TIMx = TIM4,  .rcc = RCC_APB1(TIM4),  .inputIrq = TIM4_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(6)
     { .TIMx = TIM6,  .rcc = RCC_APB1(TIM6),  .inputIrq = 0 },
+#endif
+#if USED_TIMERS & TIM_N(7)
     { .TIMx = TIM7,  .rcc = RCC_APB1(TIM7),  .inputIrq = 0 },
+#endif
+#if USED_TIMERS & TIM_N(8)
     { .TIMx = TIM8,  .rcc = RCC_APB2(TIM8),  .inputIrq = TIM8_CC_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(15)
     { .TIMx = TIM15, .rcc = RCC_APB2(TIM15), .inputIrq = TIM1_BRK_TIM15_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(16)
     { .TIMx = TIM16, .rcc = RCC_APB2(TIM16), .inputIrq = TIM1_UP_TIM16_IRQn },
+#endif
+#if USED_TIMERS & TIM_N(17)
     { .TIMx = TIM17, .rcc = RCC_APB2(TIM17), .inputIrq = TIM1_TRG_COM_TIM17_IRQn },
+#endif
 };
 
 uint32_t timerClock(TIM_TypeDef *tim)

--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -23,24 +23,55 @@
 #include "rcc.h"
 #include "timer.h"
 
-const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
+#define TIM_N(n) (1 << (n))
+#define USED_TIMER_COUNT BITCOUNT(USED_TIMERS)
+
+const timerDef_t timerDefinitions[USED_TIMER_COUNT] = {
+#if USED_TIMERS & TIM_N(1)
     { .TIMx = TIM1,  .rcc = RCC_APB2(TIM1),  .inputIrq = TIM1_CC_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(2)
     { .TIMx = TIM2,  .rcc = RCC_APB1(TIM2),  .inputIrq = TIM2_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(3)
     { .TIMx = TIM3,  .rcc = RCC_APB1(TIM3),  .inputIrq = TIM3_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(4)
     { .TIMx = TIM4,  .rcc = RCC_APB1(TIM4),  .inputIrq = TIM4_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(5)
     { .TIMx = TIM5,  .rcc = RCC_APB1(TIM5),  .inputIrq = TIM5_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(6)
     { .TIMx = TIM6,  .rcc = RCC_APB1(TIM6),  .inputIrq = 0},
+#endif
+#if USED_TIMERS & TIM_N(7)
     { .TIMx = TIM7,  .rcc = RCC_APB1(TIM7),  .inputIrq = 0},
+#endif
 #if !defined(STM32F411xE) && !defined(STM32F446xx)
+#if USED_TIMERS & TIM_N(8)
     { .TIMx = TIM8,  .rcc = RCC_APB2(TIM8),  .inputIrq = TIM8_CC_IRQn},
 #endif
+#endif
+#if USED_TIMERS & TIM_N(9)
     { .TIMx = TIM9,  .rcc = RCC_APB2(TIM9),  .inputIrq = TIM1_BRK_TIM9_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(10)
     { .TIMx = TIM10, .rcc = RCC_APB2(TIM10), .inputIrq = TIM1_UP_TIM10_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(11)
     { .TIMx = TIM11, .rcc = RCC_APB2(TIM11), .inputIrq = TIM1_TRG_COM_TIM11_IRQn},
+#endif
 #ifndef STM32F411xE
+#if USED_TIMERS & TIM_N(12)
     { .TIMx = TIM12, .rcc = RCC_APB1(TIM12), .inputIrq = TIM8_BRK_TIM12_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(13)
     { .TIMx = TIM13, .rcc = RCC_APB1(TIM13), .inputIrq = TIM8_UP_TIM13_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(14)
     { .TIMx = TIM14, .rcc = RCC_APB1(TIM14), .inputIrq = TIM8_TRG_COM_TIM14_IRQn},
+#endif
 #endif
 };
 

--- a/src/main/drivers/timer_stm32f7xx.c
+++ b/src/main/drivers/timer_stm32f7xx.c
@@ -22,22 +22,54 @@
 #include "stm32f7xx.h"
 #include "rcc.h"
 #include "timer.h"
+#include "timer_impl.h"
 
-const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
+#define TIM_N(n) (1 << (n))
+#define USED_TIMER_COUNT BITCOUNT(USED_TIMERS)
+
+const timerDef_t timerDefinitions[USED_TIMER_COUNT] = {
+#if USED_TIMERS & TIM_N(1)
     { .TIMx = TIM1,  .rcc = RCC_APB2(TIM1),  .inputIrq = TIM1_CC_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(2)
     { .TIMx = TIM2,  .rcc = RCC_APB1(TIM2),  .inputIrq = TIM2_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(3)
     { .TIMx = TIM3,  .rcc = RCC_APB1(TIM3),  .inputIrq = TIM3_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(4)
     { .TIMx = TIM4,  .rcc = RCC_APB1(TIM4),  .inputIrq = TIM4_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(5)
     { .TIMx = TIM5,  .rcc = RCC_APB1(TIM5),  .inputIrq = TIM5_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(6)
     { .TIMx = TIM6,  .rcc = RCC_APB1(TIM6),  .inputIrq = 0},
+#endif
+#if USED_TIMERS & TIM_N(7)
     { .TIMx = TIM7,  .rcc = RCC_APB1(TIM7),  .inputIrq = 0},
+#endif
+#if USED_TIMERS & TIM_N(8)
     { .TIMx = TIM8,  .rcc = RCC_APB2(TIM8),  .inputIrq = TIM8_CC_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(9)
     { .TIMx = TIM9,  .rcc = RCC_APB2(TIM9),  .inputIrq = TIM1_BRK_TIM9_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(10)
     { .TIMx = TIM10, .rcc = RCC_APB2(TIM10), .inputIrq = TIM1_UP_TIM10_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(11)
     { .TIMx = TIM11, .rcc = RCC_APB2(TIM11), .inputIrq = TIM1_TRG_COM_TIM11_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(12)
     { .TIMx = TIM12, .rcc = RCC_APB1(TIM12), .inputIrq = TIM8_BRK_TIM12_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(13)
     { .TIMx = TIM13, .rcc = RCC_APB1(TIM13), .inputIrq = TIM8_UP_TIM13_IRQn},
+#endif
+#if USED_TIMERS & TIM_N(14)
     { .TIMx = TIM14, .rcc = RCC_APB1(TIM14), .inputIrq = TIM8_TRG_COM_TIM14_IRQn},
+#endif
 };
 
 /*


### PR DESCRIPTION
PR status: Need review

As suggested by @ledvinap in https://github.com/betaflight/betaflight/pull/4667#pullrequestreview-79105464 : 
> BTW: `timerDefinitions` should be masked by USED_TIMERS, so that it matches `usedTimers` (which can be removed then). Then `timerRCC` and `timerInputIrq` can be implemented using `lookupTimerIndex`, removing lot of unnecessary code ... 
