### PR TITLE
[SOFTSERIAL] Fix disappearing start bit in SERIAL_BIDIR case.

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -161,11 +161,7 @@ static void serialInputPortDeActivate(softSerial_t *softSerial)
     TIM_CCxCmd(softSerial->timerHardware->tim, softSerial->timerHardware->channel, TIM_CCx_Disable);
 #endif
 
-#ifdef STM32F1
     IOConfigGPIO(softSerial->rxIO, IOCFG_IN_FLOATING);
-#else
-    IOConfigGPIOAF(softSerial->rxIO, IOCFG_IN_FLOATING, softSerial->timerHardware->alternateFunction);
-#endif
     softSerial->rxActive = false;
 }
 
@@ -380,9 +376,14 @@ void processTxState(softSerial_t *softSerial)
             // Half-duplex: Deactivate receiver, activate transmitter
             serialInputPortDeActivate(softSerial);
             serialOutputPortActivate(softSerial);
-        }
 
-        return;
+            // Start sending on next bit timing, as port manipulation takes time,
+            // and continuing here may cause bit period to decrease causing sampling errors
+            // at the receiver under high rates.
+            // Note that there will be (little less than) 1-bit delay; take it as "turn around time".
+            // XXX We may be able to reload counter and continue. (Future work.)
+            return;
+        }
     }
 
     if (softSerial->bitsLeftToTransmit) {


### PR DESCRIPTION
PR status: Need testing

This PR provides a fix for disappearing start bit in (SERIAL_BIDIR|SERIAL_INVERTED) case which was discovered during a test of applicability of software serial to FPort.

In some cases depending on serial options, very first bit after idle channel (the first start bit) was magically disappearing. When scoped, it looks as if the bit has been cancelled.

![saleae_logic_software](https://user-images.githubusercontent.com/14850998/33232904-84e48c48-d251-11e7-9043-8bb34dcf6a93.jpg)

An investigation revealed that it was caused by `IOConfigGPIOAF` in `serialInputPortDeActivate`. Changing this call to simple `IOConfigGPIO` fixes the issue.

Regression testing is required, as IIRC, this part of the code is a result of consolidation of conditionals for different MCU types.

