### PR TITLE
Separated ADC parameter group code into separate files.

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -61,6 +61,7 @@ COMMON_SRC = \
             io/statusindicator.c \
             io/transponder_ir.c \
             msp/msp_serial.c \
+            parameter_groups/adc_pg.c \
             scheduler/scheduler.c \
             sensors/battery.c \
             sensors/current.c \

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -19,6 +19,8 @@
 
 #include "drivers/io_types.h"
 
+#include "parameter_groups/adc.h"
+
 #ifndef ADC_INSTANCE
 #define ADC_INSTANCE                ADC1
 #endif
@@ -68,19 +70,6 @@ typedef struct adc_config_s {
     bool enabled;
     uint8_t sampleTime;
 } adcOperatingConfig_t;
-
-typedef struct adcChannelConfig_t {
-    bool enabled;
-    ioTag_t ioTag;
-} adcChannelConfig_t;
-
-typedef struct adcConfig_s {
-    adcChannelConfig_t vbat;
-    adcChannelConfig_t rssi;
-    adcChannelConfig_t current;
-    adcChannelConfig_t external1;
-    int8_t device; // ADCDevice
-} adcConfig_t;
 
 void adcInit(const adcConfig_t *config);
 uint16_t adcGetChannel(uint8_t channel);

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "drivers/io_types.h"
-#include "rcc_types.h"
+#include "drivers/rcc_types.h"
 
 #if defined(STM32F4) || defined(STM32F7)
 #define ADC_TAG_MAP_COUNT 16

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -26,12 +26,16 @@
 #include "build/build_config.h"
 
 #include "drivers/accgyro/accgyro.h"
+
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/rcc.h"
 #include "drivers/sensor.h"
+
+#include "parameter_groups/adc.h"
+
 #include "adc.h"
 #include "adc_impl.h"
-#include "drivers/io.h"
-#include "rcc.h"
-#include "dma.h"
 
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Channelx = DMA1_Channel1 }

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -21,17 +21,20 @@
 
 #include "platform.h"
 
+#include "common/utils.h"
+
 #include "drivers/accgyro/accgyro.h"
+
+#include "drivers/dma.h"
 #include "drivers/io.h"
+#include "drivers/rcc.h"
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
+#include "parameter_groups/adc.h"
+
 #include "adc.h"
 #include "adc_impl.h"
-#include "rcc.h"
-#include "dma.h"
-
-#include "common/utils.h"
 
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_AHB(ADC12), .DMAy_Channelx = DMA1_Channel1 },

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -22,14 +22,15 @@
 #include "platform.h"
 
 #include "drivers/accgyro/accgyro.h"
+
+#include "drivers/dma.h"
+#include "drivers/io.h"
+#include "drivers/io_impl.h"
+#include "drivers/rcc.h"
+#include "drivers/sensor.h"
 #include "drivers/system.h"
 
-#include "drivers/io.h"
-#include "io_impl.h"
-#include "rcc.h"
-#include "dma.h"
-
-#include "drivers/sensor.h"
+#include "parameter_groups/adc.h"
 
 #include "adc.h"
 #include "adc_impl.h"

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -22,14 +22,15 @@
 #include "platform.h"
 
 #include "drivers/accgyro/accgyro.h"
+
+#include "drivers/dma.h"
+#include "drivers/io.h"
+#include "drivers/io_impl.h"
+#include "drivers/rcc.h"
+#include "drivers/sensor.h"
 #include "drivers/system.h"
 
-#include "drivers/io.h"
-#include "io_impl.h"
-#include "rcc.h"
-#include "dma.h"
-
-#include "drivers/sensor.h"
+#include "parameter_groups/adc.h"
 
 #include "adc.h"
 #include "adc_impl.h"

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -145,9 +145,6 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
 #endif
 
 
-#ifdef USE_ADC
-PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);
-#endif
 #ifdef USE_PWM
 PG_REGISTER_WITH_RESET_FN(pwmConfig_t, pwmConfig, PG_PWM_CONFIG, 0);
 #endif
@@ -179,34 +176,6 @@ PG_RESET_TEMPLATE(sdcardConfig_t, sdcardConfig,
 
 // no template required since defaults are zero
 PG_REGISTER(vcdProfile_t, vcdProfile, PG_VCD_CONFIG, 0);
-
-#ifdef USE_ADC
-void pgResetFn_adcConfig(adcConfig_t *adcConfig)
-{
-    adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
-
-#ifdef VBAT_ADC_PIN
-    adcConfig->vbat.enabled = true;
-    adcConfig->vbat.ioTag = IO_TAG(VBAT_ADC_PIN);
-#endif
-
-#ifdef EXTERNAL1_ADC_PIN
-    adcConfig->external1.enabled = true;
-    adcConfig->external1.ioTag = IO_TAG(EXTERNAL1_ADC_PIN);
-#endif
-
-#ifdef CURRENT_METER_ADC_PIN
-    adcConfig->current.enabled = true;
-    adcConfig->current.ioTag = IO_TAG(CURRENT_METER_ADC_PIN);
-#endif
-
-#ifdef RSSI_ADC_PIN
-    adcConfig->rssi.enabled = true;
-    adcConfig->rssi.ioTag = IO_TAG(RSSI_ADC_PIN);
-#endif
-
-}
-#endif // USE_ADC
 
 
 #if defined(USE_PWM) || defined(USE_PPM)

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -22,7 +22,6 @@
 
 #include "config/parameter_group.h"
 
-#include "drivers/adc.h"
 #include "drivers/flash.h"
 #include "drivers/rx_pwm.h"
 #include "drivers/sdcard.h"
@@ -84,7 +83,6 @@ typedef struct systemConfig_s {
 
 PG_DECLARE(pilotConfig_t, pilotConfig);
 PG_DECLARE(systemConfig_t, systemConfig);
-PG_DECLARE(adcConfig_t, adcConfig);
 PG_DECLARE(beeperDevConfig_t, beeperDevConfig);
 PG_DECLARE(flashConfig_t, flashConfig);
 PG_DECLARE(ppmConfig_t, ppmConfig);

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -36,6 +36,7 @@
 #include "cms/cms.h"
 #include "cms/cms_types.h"
 
+#include "drivers/adc.h"
 #include "drivers/nvic.h"
 #include "drivers/sensor.h"
 #include "drivers/system.h"
@@ -53,7 +54,6 @@
 #include "drivers/pwm_esc_detect.h"
 #include "drivers/rx_pwm.h"
 #include "drivers/pwm_output.h"
-#include "drivers/adc.h"
 #include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/bus_spi.h"
@@ -79,6 +79,8 @@
 #include "interface/msp.h"
 
 #include "msp/msp_serial.h"
+
+#include "parameter_groups/adc_pg.h"
 
 #include "rx/rx.h"
 #include "rx/rx_spi.h"

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -116,6 +116,8 @@ extern uint8_t __config_end;
 #include "io/vtx_control.h"
 #include "io/vtx.h"
 
+#include "parameter_groups/adc_pg.h"
+
 #include "rx/rx.h"
 #include "rx/spektrum.h"
 #include "../rx/cc2500_frsky_common.h"

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -31,6 +31,7 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
+#include "drivers/adc.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/bus_spi.h"
 #include "drivers/light_led.h"
@@ -63,6 +64,8 @@
 #include "io/vtx.h"
 #include "io/vtx_control.h"
 #include "io/vtx_rtc6705.h"
+
+#include "parameter_groups/adc_pg.h"
 
 #include "rx/rx.h"
 #include "rx/cc2500_frsky_common.h"

--- a/src/main/osd_slave/osd_slave_init.c
+++ b/src/main/osd_slave/osd_slave_init.c
@@ -62,11 +62,6 @@
 #include "interface/cli.h"
 #include "interface/msp.h"
 
-#include "msp/msp_serial.h"
-
-#include "rx/rx.h"
-#include "rx/spektrum.h"
-
 #include "io/beeper.h"
 #include "io/displayport_max7456.h"
 #include "io/flashfs.h"
@@ -75,7 +70,14 @@
 #include "io/serial.h"
 #include "io/transponder_ir.h"
 
+#include "msp/msp_serial.h"
+
+#include "rx/rx.h"
+#include "rx/spektrum.h"
+
 #include "osd_slave/osd_slave_init.h"
+
+#include "parameter_groups/adc_pg.h"
 
 #include "scheduler/scheduler.h"
 

--- a/src/main/parameter_groups/adc.h
+++ b/src/main/parameter_groups/adc.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drivers/io_types.h"
+
+typedef struct adcChannelConfig_t {
+    bool enabled;
+    ioTag_t ioTag;
+} adcChannelConfig_t;
+
+typedef struct adcConfig_s {
+    adcChannelConfig_t vbat;
+    adcChannelConfig_t rssi;
+    adcChannelConfig_t current;
+    adcChannelConfig_t external1;
+    int8_t device; // ADCDevice
+} adcConfig_t;

--- a/src/main/parameter_groups/adc_pg.c
+++ b/src/main/parameter_groups/adc_pg.c
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#ifdef USE_ADC
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
+#include "drivers/adc.h"
+#include "drivers/adc_impl.h"
+#include "drivers/io.h"
+
+#include "adc_pg.h"
+
+PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);
+
+void pgResetFn_adcConfig(adcConfig_t *adcConfig)
+{
+    adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
+
+#ifdef VBAT_ADC_PIN
+    adcConfig->vbat.enabled = true;
+    adcConfig->vbat.ioTag = IO_TAG(VBAT_ADC_PIN);
+#endif
+
+#ifdef EXTERNAL1_ADC_PIN
+    adcConfig->external1.enabled = true;
+    adcConfig->external1.ioTag = IO_TAG(EXTERNAL1_ADC_PIN);
+#endif
+
+#ifdef CURRENT_METER_ADC_PIN
+    adcConfig->current.enabled = true;
+    adcConfig->current.ioTag = IO_TAG(CURRENT_METER_ADC_PIN);
+#endif
+
+#ifdef RSSI_ADC_PIN
+    adcConfig->rssi.enabled = true;
+    adcConfig->rssi.ioTag = IO_TAG(RSSI_ADC_PIN);
+#endif
+}
+#endif

--- a/src/main/parameter_groups/adc_pg.h
+++ b/src/main/parameter_groups/adc_pg.h
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "adc.h"
+
+PG_DECLARE(adcConfig_t, adcConfig);

--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -30,6 +30,7 @@
 #include "common/maths.h"
 #include "common/utils.h"
 
+#include "drivers/adc.h"
 #include "drivers/cc2500.h"
 #include "drivers/io.h"
 #include "drivers/system.h"

--- a/src/main/target/BLUEJAYF4/config.c
+++ b/src/main/target/BLUEJAYF4/config.c
@@ -30,6 +30,8 @@
 
 #include "fc/config.h"
 
+#include "parameter_groups/adc_pg.h"
+
 #include "sensors/acceleration.h"
 #include "sensors/gyro.h"
 

--- a/src/main/target/YUPIF4/config.c
+++ b/src/main/target/YUPIF4/config.c
@@ -22,12 +22,16 @@
 
 #ifdef USE_TARGET_CONFIG
 #include "blackbox/blackbox.h"
+
 #include "fc/config.h"
+
 #include "flight/pid.h"
+
+#include "parameter_groups/adc_pg.h"
+
 #include "telemetry/telemetry.h"
 
 #include "hardware_revision.h"
-
 
 
 // alternative defaults settings for YuPiF4 targets


### PR DESCRIPTION
@martinbudden: This is a trial to see how separating out parameter group code works. After having done this, I am not so sure anymore if this is the right way to go, it ends up pulling a lot of code into the parameter group handling code, and requires a lot more includes to make it work for consumers of the parameter group structs.
I have split the header file into `adc.h` and `adc_impl.h` such that `adc.h` contains only the structs used for the parameter groups, and the declaration itself, so that this could be generated from an interface contract at a later stage.