### PR TITLE
Fix MSP code in switch for MSP_SET_TX_INFO

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1993,7 +1993,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         break;
 #endif
 
-    case MSP_TX_INFO:
+    case MSP_SET_TX_INFO:
         setRssiMsp(sbufReadU8(src));
 
         break;


### PR DESCRIPTION
Case was handling MSP_TX_INFO which is an out command and already
handled in mspProcessOutCommand. This case should handle MSP_SET_TX_INFO.