### PR TITLE
Change MSP_SET_RTC to accept seconds and milliseconds

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1979,15 +1979,13 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 #ifdef USE_RTC_TIME
     case MSP_SET_RTC:
         {
-            dateTime_t dt;
-            dt.year = sbufReadU16(src);
-            dt.month = sbufReadU8(src);
-            dt.day = sbufReadU8(src);
-            dt.hours = sbufReadU8(src);
-            dt.minutes = sbufReadU8(src);
-            dt.seconds = sbufReadU8(src);
-            dt.millis = 0;
-            rtcSetDateTime(&dt);
+            // Use seconds and milliseconds to make senders
+            // easier to implement. Generating a 64 bit value
+            // might not be trivial in some platforms.
+            int32_t secs = (int32_t)sbufReadU32(src);
+            uint16_t millis = sbufReadU16(src);
+            rtcTime_t t = rtcTimeMake(secs, millis);
+            rtcSet(&t);
         }
 
         break;


### PR DESCRIPTION
This makes it compatible with INAV, which was already using this
MSP code and has already released some versions using it.

I've made this change to allow LUA scripts to work with both BF and INAV, since the expected time format was different. I think there aren't any BF releases using this functionality yet, so changing the command format shouldn't be problematic at this point.

If compatibility has to be kept (there might be 3rd party software or scripts already relying on the previous time format that I'm not aware of), I can amend this PR support both time formats, since INAV's is 6 bytes and BF's is 7, so it's possible to support both. However, if there's no reason to allow both formats we're probably better off saving some flash space.