### PR TITLE
Fixed incorrect definitions for targets in `v3.2.x-maintenance` branch.

### DIFF
--- a/src/main/target/ALIENFLIGHTF1/target.h
+++ b/src/main/target/ALIENFLIGHTF1/target.h
@@ -62,7 +62,7 @@
 #define RSSI_ADC_PIN            PA1
 #define EXTERNAL1_ADC_PIN       PA5
 
-#define USE_SPEKTRUM_BIND
+#define SPEKTRUM_BIND
 #define USE_SPEKTRUM_BIND_PLUG
 #define BINDPLUG_PIN            PB5
 

--- a/src/main/target/ALIENWHOOP/target.h
+++ b/src/main/target/ALIENWHOOP/target.h
@@ -184,7 +184,7 @@
  */
 /* Assume Spektrum following defines inherited from common_fc_pre.h:
 //#define USE_SERIALRX_SPEKTRUM
-//#define USE_SPEKTRUM_BIND
+//#define SPEKTRUM_BIND
 //#define USE_SPEKTRUM_BIND_PLUG
 */
 #define BINDPLUG_PIN            PC13 // PC13 Current Limited (3 mA). Not suitable for LED/Beeper

--- a/src/main/target/BETAFLIGHTF4/target.h
+++ b/src/main/target/BETAFLIGHTF4/target.h
@@ -52,7 +52,7 @@
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
 
-#define USE_MAG
+#define MAG
 #define USE_MAG_HMC5883
 
 #define OSD

--- a/src/main/target/CJMCU/target.h
+++ b/src/main/target/CJMCU/target.h
@@ -107,7 +107,7 @@
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
 #define USE_RX_MSP
-#define USE_SPEKTRUM_BIND
+#define SPEKTRUM_BIND
 
 #endif //USE_RX_NRF24
 

--- a/src/main/target/MICROSCISKY/target.h
+++ b/src/main/target/MICROSCISKY/target.h
@@ -70,7 +70,7 @@
 #define USE_I2C_DEVICE_2
 #define I2C_DEVICE              (I2CDEV_2)
 
-#define USE_SPEKTRUM_BIND
+#define SPEKTRUM_BIND
 
 #define BRUSHED_MOTORS
 #define DEFAULT_FEATURES        FEATURE_MOTOR_STOP

--- a/src/main/target/NOX/config.c
+++ b/src/main/target/NOX/config.c
@@ -20,7 +20,7 @@
 
 #include <platform.h>
 
-#ifdef USE_TARGET_CONFIG
+#ifdef TARGET_CONFIG
 
 #include "io/serial.h"
 

--- a/src/main/target/NOX/target.h
+++ b/src/main/target/NOX/target.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#define USE_TARGET_CONFIG
+#define TARGET_CONFIG
 
 #define TARGET_BOARD_IDENTIFIER "NOX1"
 #define USBD_PRODUCT_STRING "NoxF4V1"
@@ -27,11 +27,11 @@
 
 #define INVERTER_PIN_UART2      PC14
 
-#define USE_ACC
+#define ACC
 #define USE_ACC_SPI_MPU6500
 #define USE_ACC_SPI_MPU6000
 
-#define USE_GYRO
+#define GYRO
 #define USE_GYRO_SPI_MPU6500
 #define USE_GYRO_SPI_MPU6000
 
@@ -45,13 +45,13 @@
 #define MPU_INT_EXTI            PA8
 #define USE_MPU_DATA_READY_SIGNAL
 
-#define USE_BARO
+#define BARO
 #define USE_BARO_BMP280
 #define USE_BARO_SPI_BMP280
 #define BMP280_SPI_INSTANCE     SPI2
 #define BMP280_CS_PIN           PA9
 
-#define USE_OSD
+#define OSD
 #define USE_MAX7456
 #define MAX7456_SPI_INSTANCE    SPI2
 #define MAX7456_SPI_CS_PIN      PA10

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -94,7 +94,7 @@
 #define SONAR_ECHO_PIN          PB1
 
 #elif defined(RMDO)
-#undef USE_GPS
+#undef GPS
 
 #elif defined(ZCOREF3)
 #define USE_MAG_DATA_READY_SIGNAL


### PR DESCRIPTION
These are defines that are wrong compared to how these defines are done in 3.2. They are either the result of faulty backports, or because they have always been wrong.

I am undecided as to whether this should be merged into the 3.2 maintenance branch (it is clearly bug fixes, but not for bugs that have yet been reported by users). Please provide feedback.