### PR TITLE
Fixed incorrect definitions for code in `v3.2.x-maintenance` branch.

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3144,7 +3144,7 @@ const cliResourceValue_t resourceTable[] = {
     { OWNER_I2C_SDA,       PG_I2C_CONFIG, offsetof(i2cConfig_t, ioTagSda[0]), I2CDEV_COUNT },
 #endif
     { OWNER_LED,           PG_STATUS_LED_CONFIG, offsetof(statusLedConfig_t, ioTags[0]), STATUS_LED_NUMBER },
-#ifdef USE_SPEKTRUM_BIND
+#ifdef SPEKTRUM_BIND
     { OWNER_RX_BIND,       PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_bind_pin_override_ioTag), 0 },
     { OWNER_RX_BIND_PLUG,  PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_bind_plug_ioTag), 0 },
 #endif

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -322,7 +322,7 @@ void init(void)
     }
 #endif
 
-#if defined(USE_SPEKTRUM_BIND)
+#if defined(SPEKTRUM_BIND)
     if (feature(FEATURE_RX_SERIAL)) {
         switch (rxConfig()->serialrx_provider) {
         case SERIALRX_SPEKTRUM1024:

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -381,7 +381,7 @@ const clivalue_t valueTable[] = {
     { "serialrx_provider",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SERIAL_RX }, PG_RX_CONFIG, offsetof(rxConfig_t, serialrx_provider) },
     { "sbus_inversion",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, sbus_inversion) },
 #endif
-#ifdef USE_SPEKTRUM_BIND
+#ifdef SPEKTRUM_BIND
     { "spektrum_sat_bind",          VAR_UINT8  | MASTER_VALUE, .config.minmax = { SPEKTRUM_SAT_BIND_DISABLED, SPEKTRUM_SAT_BIND_MAX}, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind) },
     { "spektrum_sat_bind_autoreset",VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind_autoreset) },
 #endif

--- a/src/main/flight/navigation.c
+++ b/src/main/flight/navigation.c
@@ -113,7 +113,7 @@ static void GPS_calc_longitude_scaling(int32_t lat);
 static void GPS_calc_velocity(void);
 static void GPS_calc_location_error(int32_t * target_lat, int32_t * target_lng, int32_t * gps_lat, int32_t * gps_lng);
 
-#ifdef USE_NAV
+#ifdef NAV
 static bool check_missed_wp(void);
 static void GPS_calc_poshold(void);
 static void GPS_calc_nav_rate(uint16_t max_speed);
@@ -149,7 +149,7 @@ typedef struct {
 static PID posholdPID[2];
 static PID poshold_ratePID[2];
 
-#ifdef USE_NAV
+#ifdef NAV
 static PID_PARAM navPID_PARAM;
 static PID navPID[2];
 
@@ -205,7 +205,7 @@ static int16_t actual_speed[2] = { 0, 0 };
 static float GPS_scaleLonDown = 1.0f;  // this is used to offset the shrinking longitude as we go towards the poles
 static int32_t error[2];
 
-#ifdef USE_NAV
+#ifdef NAV
 // The difference between the desired rate of travel and the actual rate of travel
 // updated after GPS read - 5-10hz
 static int16_t rate_error[2];
@@ -326,7 +326,7 @@ void onGpsNewData(void)
     // calculate the current velocity based on gps coordinates continously to get a valid speed at the moment when we start navigating
     GPS_calc_velocity();
 
-#ifdef USE_NAV
+#ifdef NAV
     if (FLIGHT_MODE(GPS_HOLD_MODE) || FLIGHT_MODE(GPS_HOME_MODE)) {
         // we are navigating
 
@@ -393,7 +393,7 @@ void GPS_reset_nav(void)
         nav[i] = 0;
         reset_PID(&posholdPID[i]);
         reset_PID(&poshold_ratePID[i]);
-#ifdef USE_NAV
+#ifdef NAV
         reset_PID(&navPID[i]);
 #endif
     }
@@ -411,7 +411,7 @@ void gpsUsePIDs(pidProfile_t *pidProfile)
     poshold_ratePID_PARAM.kD = (float)pidProfile->pid[PID_POSR].D / 1000.0f;
     poshold_ratePID_PARAM.Imax = POSHOLD_RATE_IMAX * 100;
 
-#ifdef USE_NAV
+#ifdef NAV
     navPID_PARAM.kP = (float)pidProfile->pid[PID_NAVR].P / 10.0f;
     navPID_PARAM.kI = (float)pidProfile->pid[PID_NAVR].I / 100.0f;
     navPID_PARAM.kD = (float)pidProfile->pid[PID_NAVR].D / 1000.0f;
@@ -454,7 +454,7 @@ void GPS_set_next_wp(int32_t *lat, int32_t *lon)
     waypoint_speed_gov = navigationConfig()->nav_speed_min;
 }
 
-#ifdef USE_NAV
+#ifdef NAV
 ////////////////////////////////////////////////////////////////////////////////////
 // Check if we missed the destination somehow
 //
@@ -536,7 +536,7 @@ static void GPS_calc_location_error(int32_t *target_lat, int32_t *target_lng, in
     error[LAT] = *target_lat - *gps_lat;        // Y Error
 }
 
-#ifdef USE_NAV
+#ifdef NAV
 ////////////////////////////////////////////////////////////////////////////////////
 // Calculate nav_lat and nav_lon from the x and y error and the speed
 //
@@ -656,7 +656,7 @@ static int32_t wrap_18000(int32_t error)
     return error;
 }
 
-#ifdef USE_NAV
+#ifdef NAV
 static int32_t wrap_36000(int32_t angle)
 {
     if (angle > 36000)

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -173,7 +173,7 @@ static uint16_t spektrumReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint
     return data;
 }
 
-#ifdef USE_SPEKTRUM_BIND
+#ifdef SPEKTRUM_BIND
 
 bool spekShouldBind(uint8_t spektrum_sat_bind)
 {

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -129,7 +129,7 @@
 #define USE_MSP_OVER_TELEMETRY
 
 #ifdef USE_SERIALRX_SPEKTRUM
-#define USE_SPEKTRUM_BIND
+#define SPEKTRUM_BIND
 #define USE_SPEKTRUM_BIND_PLUG
 #endif
 #endif
@@ -137,6 +137,6 @@
 #if (FLASH_SIZE > 256)
 // Temporarily moved GPS here because of overflowing flash size on F3
 #define GPS
-#define USE_NAV
+#define NAV
 #define USE_UNCOMMON_MIXERS
 #endif


### PR DESCRIPTION
These are defines that are wrong compared to how these defines are done in 3.2. They are either the result of faulty backports, or because they have always been wrong.

I am undecided as to whether this should be merged into the 3.2 maintenance branch (it is clearly bug fixes, but not for bugs that have yet been reported by users). Please provide feedback.