### PR TITLE
Battery: support for custom vfref

### DIFF
--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -23,6 +23,10 @@
 #define ADC_INSTANCE                ADC1
 #endif
 
+#if !defined(ADC_VOLTAGE_REFERENCE_MV)
+#define ADC_VOLTAGE_REFERENCE_MV 3300
+#endif
+
 #if defined(STM32F4) || defined(STM32F7)
 #ifndef ADC1_DMA_STREAM
 #define ADC1_DMA_STREAM DMA2_Stream4 // ST0 or ST4

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -77,7 +77,9 @@ void currentMeterReset(currentMeter_t *meter)
 // ADC/Virtual shared
 //
 
+#if !defined(ADCVREF)
 #define ADCVREF 3300   // in mV
+#endif
 
 #define IBAT_LPF_FREQ  0.4f
 static biquadFilter_t adciBatFilter;

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -77,10 +77,6 @@ void currentMeterReset(currentMeter_t *meter)
 // ADC/Virtual shared
 //
 
-#if !defined(ADCVREF)
-#define ADCVREF 3300   // in mV
-#endif
-
 #define IBAT_LPF_FREQ  0.4f
 static biquadFilter_t adciBatFilter;
 
@@ -108,7 +104,7 @@ static int32_t currentMeterADCToCentiamps(const uint16_t src)
 
     const currentSensorADCConfig_t *config = currentSensorADCConfig();
 
-    int32_t millivolts = ((uint32_t)src * ADCVREF) / 4096;
+    int32_t millivolts = ((uint32_t)src * ADC_VOLTAGE_REFERENCE_MV) / 4096;
     millivolts -= config->offset;
 
     return (millivolts * 1000) / (int32_t)config->scale; // current in 0.01A steps

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -134,15 +134,12 @@ static const uint8_t voltageMeterAdcChannelMap[] = {
 #endif
 };
 
-#if !defined(ADCVREF)
-#define ADCVREF 3300
-#endif
 
 STATIC_UNIT_TESTED uint16_t voltageAdcToVoltage(const uint16_t src, const voltageSensorADCConfig_t *config)
 {
     // calculate battery voltage based on ADC reading
     // result is Vbatt in 0.1V steps. 3.3V = ADC Vref, 0xFFF = 12bit adc, 110 = 10:1 voltage divider (10k:1k) * 10 for 0.1V
-    return ((((uint32_t)src * config->vbatscale * ADCVREF + (0xFFF * 500)) / (0xFFF * 100 *  config->vbatresdivval)) / config->vbatresdivmultiplier);
+    return ((((uint32_t)src * config->vbatscale * ADC_VOLTAGE_REFERENCE_MV + (0xFFF * 500)) / (0xFFF * 100 *  config->vbatresdivval)) / config->vbatresdivmultiplier);
 }
 
 void voltageMeterADCRefresh(void)

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -134,11 +134,15 @@ static const uint8_t voltageMeterAdcChannelMap[] = {
 #endif
 };
 
+#if !defined(ADCVREF)
+#define ADCVREF 3300
+#endif
+
 STATIC_UNIT_TESTED uint16_t voltageAdcToVoltage(const uint16_t src, const voltageSensorADCConfig_t *config)
 {
     // calculate battery voltage based on ADC reading
     // result is Vbatt in 0.1V steps. 3.3V = ADC Vref, 0xFFF = 12bit adc, 110 = 10:1 voltage divider (10k:1k) * 10 for 0.1V
-    return ((((uint32_t)src * config->vbatscale * 33 + (0xFFF * 5)) / (0xFFF * config->vbatresdivval)) / config->vbatresdivmultiplier);
+    return ((((uint32_t)src * config->vbatscale * ADCVREF + (0xFFF * 500)) / (0xFFF * 100 *  config->vbatresdivval)) / config->vbatresdivmultiplier);
 }
 
 void voltageMeterADCRefresh(void)


### PR DESCRIPTION
Allows setting the ADC reference voltage in mV. I'm working on a target where the supply is about 2% below 3.3V and assuming 3.3V makes quite a large difference for high voltages (about 0.5V for 6S). 