### PR TITLE
VREFINT PoC implementation

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -94,7 +94,8 @@ uint16_t adcGetChannel(uint8_t channel)
     debug[0] = adcValues[adcOperatingConfig[ADC_BATTERY].dmaIndex];
     debug[1] = *adcVrefInternal;
     debug[2] = adcVrefCalibration;
-    debug[3] = *adcVrefInternal * 3300 / adcVrefCalibration;
+    //debug[3] = *adcVrefInternal * 3300 / adcVrefCalibration;
+    debug[3] = debug[0] * adcVrefCalibration / *adcVrefInternal - debug[0];
 #endif
 
 #if defined(USE_VREFINT)

--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -34,6 +34,12 @@
 adcOperatingConfig_t adcOperatingConfig[ADC_CHANNEL_COUNT];
 volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 
+#if defined(STM32F4)
+uint16_t adcVrefCalibration;
+volatile uint16_t *adcVrefInternal;
+uint16_t adcVrefInternalStatic;
+#endif
+
 uint8_t adcChannelByTag(ioTag_t ioTag)
 {
     for (uint8_t i = 0; i < ARRAYLEN(adcTagMap); i++) {
@@ -84,7 +90,18 @@ uint16_t adcGetChannel(uint8_t channel)
         debug[3] = adcValues[adcOperatingConfig[3].dmaIndex];
     }
 #endif
+#if 1
+    debug[0] = adcValues[adcOperatingConfig[ADC_BATTERY].dmaIndex];
+    debug[1] = *adcVrefInternal;
+    debug[2] = adcVrefCalibration;
+    debug[3] = *adcVrefInternal * 3300 / adcVrefCalibration;
+#endif
+
+#if defined(USE_VREFINT)
+    return (uint32_t)adcVrefCalibration * adcValues[adcOperatingConfig[channel].dmaIndex] / *adcVrefInternal;
+#else
     return adcValues[adcOperatingConfig[channel].dmaIndex];
+#endif
 }
 
 // Verify a pin designated by tag has connection to an ADC instance designated by device

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -58,6 +58,11 @@ typedef enum {
     ADC_CURRENT = 1,
     ADC_EXTERNAL1 = 2,
     ADC_RSSI = 3,
+#ifdef USE_VREFINT
+    ADC_CHANNEL_COUNT_EXTERNAL = 4,
+    ADC_TEMPERATURE = 4,
+    ADC_VREFINT = 5,
+#endif
     ADC_CHANNEL_COUNT
 } AdcChannel;
 
@@ -84,6 +89,7 @@ typedef struct adcConfig_s {
 
 void adcInit(const adcConfig_t *config);
 uint16_t adcGetChannel(uint8_t channel);
+void adcSampleVrefintStatic(void);
 
 #ifndef SITL
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance);

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -69,3 +69,9 @@ extern volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 uint8_t adcChannelByTag(ioTag_t ioTag);
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance);
 bool adcVerifyPin(ioTag_t tag, ADCDevice device);
+
+#ifdef USE_VREFINT
+extern uint16_t adcVrefCalibration;
+extern volatile uint16_t *adcVrefInternal;
+extern uint16_t adcVrefInternalStatic;
+#endif

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -21,6 +21,8 @@
 
 #include "platform.h"
 
+#ifdef USE_ADC
+
 #include "build/debug.h"
 
 #include "drivers/accgyro/accgyro.h"

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -34,8 +34,6 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
-#include "drivers/adc.h"
-#include "drivers/gyro_sync.h"
 #include "drivers/light_led.h"
 #include "drivers/system.h"
 #include "drivers/time.h"

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -34,6 +34,7 @@
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
 
+#include "drivers/adc.h"
 #include "drivers/gyro_sync.h"
 #include "drivers/light_led.h"
 #include "drivers/system.h"
@@ -306,6 +307,9 @@ void tryArm(void)
         }
 #else
         beeper(BEEPER_ARMING);
+#endif
+#ifdef USE_VREFINT
+        adcSampleVrefintStatic();
 #endif
     } else {
         if (!isFirstArmingGyroCalibrationRunning()) {

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -216,7 +216,8 @@
 #define I2C_DEVICE              (I2CDEV_2)
 
 #define USE_ADC
-#define ADC_INSTANCE            ADC2
+//#define ADC_INSTANCE            ADC2
+#define ADC_INSTANCE            ADC1
 #define CURRENT_METER_ADC_PIN   PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
 #define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
 #ifdef DYSF4PRO
@@ -228,6 +229,8 @@
 #define TRANSPONDER
 
 #define USE_SONAR
+
+#define USE_VREFINT
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
 


### PR DESCRIPTION
PR status: For discussion

As promised in https://github.com/betaflight/betaflight/pull/4697#issuecomment-348542865.

- VREFINT channel is only connected to ADC1, so this PoC is only valid for those targets that defines `ADC_INSTANCE` as `ADC1`. The example target (`OMNIBUSF4*`) was modified to use `ADC1` instead of `ADC2` for this limitation. Non-ADC1 case should be handled separately, as periodic task or one-shot sampling at boot (and/or upon arming).

- As commented in https://github.com/betaflight/betaflight/pull/4697#issuecomment-348643525, accuracy of the VREFINT is 2.5%. So, it would not be better than manually set reference voltage that #4697 propose, but may provide an alternative for casual users.

Thoughts?

P.S. It also provides internal temperature sensor reading 😉 

P.P.S. Values from these channels
<img width="1053" alt="betaflight_configurator" src="https://user-images.githubusercontent.com/14850998/33511218-1d041554-d75a-11e7-8131-190378c31c75.png">

