### PR TITLE
Change switch default handling

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1069,7 +1069,7 @@ static void osdGetBlackboxStatusString(char * buff)
 #endif
 
     default:
-        storageDeviceIsWorking = true;
+        break;
     }
 
     if (storageDeviceIsWorking) {


### PR DESCRIPTION
Currently if no black box device is selected the default case sets
storageDeviceIsWorking = true. 

I believe this to be wrong.

This commit keeps the initial setting of false.
