### PR TITLE
Crashflip (Turtlemode) 3d fix

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -275,10 +275,14 @@ void tryArm(void)
 
             if (!IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                 flipOverAfterCrashMode = false;
-                pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL);
+                if (!feature(FEATURE_3D)) {
+                    pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL);
+                }
             } else {
                 flipOverAfterCrashMode = true;
-                pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED);
+                if (!feature(FEATURE_3D)) {
+                    pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED);
+                }
             }
 
             pwmEnableMotors();


### PR DESCRIPTION
Makes the turtles play nice and not fight in 3d mode.

The dshot command to set temp forward and reverse was not playing well when 3d mode for blheli_s escs (probably others).

Tested on the switched 3d mode

Might fix #4517