### PR TITLE
Fixed unittest compile warnings caused by inconsistant data types.

### DIFF
--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -371,7 +371,7 @@ struct pidProfile_s;
 struct pidProfile_s *currentPidProfile;
 uint32_t targetPidLooptime;
 
-uint32_t rcModeActivationMask;
+boxBitmask_t rcModeActivationMask;
 
 void mspSerialAllocatePorts(void) {}
 uint32_t getArmingBeepTimeMicros(void) {return 0;}

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -198,7 +198,7 @@ TEST(FlightImuTest, TestSmallAngle)
 // STUBS
 
 extern "C" {
-uint32_t rcModeActivationMask;
+boxBitmask_t rcModeActivationMask;
 float rcCommand[4];
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -297,7 +297,7 @@ uint8_t stateFlags = 0;
 uint16_t flightModeFlags = 0;
 float rcCommand[4];
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
-uint32_t rcModeActivationMask;
+boxBitmask_t rcModeActivationMask;
 gpsSolutionData_t gpsSol;
 
 batteryState_e getBatteryState(void) {

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -34,10 +34,8 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
-#define DE_ACTIVATE_ALL_BOXES   0
-
 extern "C" {
-uint32_t rcModeActivationMask;
+boxBitmask_t rcModeActivationMask;
 
 extern uint16_t applyRxChannelRangeConfiguraton(int sample, const rxChannelRangeConfig_t *range);
 }
@@ -46,7 +44,7 @@ extern uint16_t applyRxChannelRangeConfiguraton(int sample, const rxChannelRange
 
 TEST(RxChannelRangeTest, TestRxChannelRanges)
 {
-    rcModeActivationMask = DE_ACTIVATE_ALL_BOXES;   // BOXFAILSAFE must be OFF
+    memset(&rcModeActivationMask, 0, sizeof(rcModeActivationMask)); // BOXFAILSAFE must be OFF
 
     // No signal, special condition
     EXPECT_EQ(0, applyRxChannelRangeConfiguraton(0, RANGE_CONFIGURATION(1000, 2000)));


### PR DESCRIPTION
Compile warnings in unittests due to data type mismatches fixed. 
Unfortunatly this slips by un-noticed, if you do not look for it. The Makefile is not strict enough. Those warnings was seen:

```
/usr/bin/ld: Warning: size of symbol `rcModeActivationMask' changed from 8 in ../../obj/test/flight_imu_unittest/fc/rc_modes.c.o to 4 in ../../obj/test/flight_imu_unittest/flight_imu_unittest.o
.....
/usr/bin/ld: Warning: size of symbol `rcModeActivationMask' changed from 8 in ../../obj/test/ledstrip_unittest/fc/rc_modes.c.o to 4 in ../../obj/test/ledstrip_unittest/ledstrip_unittest.o
.....
/usr/bin/ld: Warning: size of symbol `rcModeActivationMask' changed from 8 in ../../obj/test/rx_ranges_unittest/fc/rc_modes.c.o to 4 in ../../obj/test/rx_ranges_unittest/rx_ranges_unittest.o
 
```
