### PR TITLE
Kissfcv2 f7

### DIFF
--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -124,7 +124,9 @@ STARTUP_SRC     = startup_stm32f746xx.s
 TARGET_FLASH   := 2048
 else ifeq ($(TARGET),$(filter $(TARGET),$(F7X2RE_TARGETS)))
 DEVICE_FLAGS   += -DSTM32F722xx
+ifndef LD_SCRIPT
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f722.ld
+endif
 STARTUP_SRC     = startup_stm32f722xx.s
 TARGET_FLASH   := 512
 else

--- a/src/main/target/KISSFCV2F7/README.md
+++ b/src/main/target/KISSFCV2F7/README.md
@@ -1,0 +1,11 @@
+# KISSFCV2
+
+
+* available: https://flyduino.net
+
+## HW info
+
+* STM32F722RET6
+* MPU6000 SPI
+* All 5 uarts available
+* 6 pwm outputs

--- a/src/main/target/KISSFCV2F7/config.c
+++ b/src/main/target/KISSFCV2F7/config.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "drivers/serial.h"
+#include "rx/rx.h"
+
+#include "telemetry/telemetry.h"
+
+#include "fc/config.h"
+
+
+#ifdef USE_TARGET_CONFIG
+void targetConfiguration(void){
+	rxConfigMutable()->halfDuplex = true;
+	serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_UART4)].functionMask = FUNCTION_MSP;
+}
+#endif

--- a/src/main/target/KISSFCV2F7/stm32_flash_f722_no_split.ld
+++ b/src/main/target/KISSFCV2F7/stm32_flash_f722_no_split.ld
@@ -1,0 +1,184 @@
+/*
+*****************************************************************************
+**
+**  File        : stm32_flash_f722.ld
+**
+**  Abstract    : Linker script for STM32F722RETx Device with
+**                512KByte FLASH, 256KByte RAM
+**
+*****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+
+/* Specify the memory areas */
+MEMORY
+{
+    /* Bootloader stays in the first sector (16K) */
+    FLASH_CONFIG (r)  : ORIGIN = 0x08004000, LENGTH = 16K /*second (16K) sector for eeprom emulation*/
+    FLASH (rx)        : ORIGIN = 0x08008000, LENGTH = 480K /*main fw*/
+
+    TCM (rwx)         : ORIGIN = 0x20000000, LENGTH = 64K
+    RAM (rwx)         : ORIGIN = 0x20010000, LENGTH = 192K
+    MEMORY_B1 (rx)    : ORIGIN = 0x60000000, LENGTH = 0K
+}
+
+/* note TCM could be used for stack */
+REGION_ALIAS("STACKRAM", TCM)
+
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(STACKRAM) + LENGTH(STACKRAM);    /* end of RAM */
+
+/* Base address where the config is stored. */
+__config_start = ORIGIN(FLASH_CONFIG);
+__config_end = ORIGIN(FLASH_CONFIG) + LENGTH(FLASH_CONFIG);
+
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0;      /* required amount of heap  */
+_Min_Stack_Size = 0x800; /* required amount of stack */
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    PROVIDE (isr_vector_table_base = .);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+
+   .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+    .ARM : {
+    __exidx_start = .;
+      *(.ARM.exidx*)
+      __exidx_end = .;
+    } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(.fini_array*))
+    KEEP (*(SORT(.fini_array.*)))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+  .pg_registry :
+  {
+    PROVIDE_HIDDEN (__pg_registry_start = .);
+    KEEP (*(.pg_registry))
+    KEEP (*(SORT(.pg_registry.*)))
+    PROVIDE_HIDDEN (__pg_registry_end = .);
+  } >FLASH
+  .pg_resetdata :
+  {
+    PROVIDE_HIDDEN (__pg_resetdata_start = .);
+    KEEP (*(.pg_resetdata))
+    PROVIDE_HIDDEN (__pg_resetdata_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = .;
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(SORT_BY_ALIGNMENT(.bss*))
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  _heap_stack_end = ORIGIN(STACKRAM)+LENGTH(STACKRAM) - 8; /* 8 bytes to allow for alignment */
+  _heap_stack_begin = _heap_stack_end - _Min_Stack_Size  - _Min_Heap_Size;
+  . = _heap_stack_begin;
+  ._user_heap_stack :
+  {
+    . = ALIGN(4);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(4);
+  } >STACKRAM = 0xa5
+
+  /* MEMORY_bank1 section, code must be located here explicitly            */
+  /* Example: extern int foo(void) __attribute__ ((section (".mb1text"))); */
+  .memory_b1_text :
+  {
+    *(.mb1text)        /* .mb1text sections (code) */
+    *(.mb1text*)       /* .mb1text* sections (code)  */
+    *(.mb1rodata)      /* read-only data (constants) */
+    *(.mb1rodata*)
+  } >MEMORY_B1
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}
+

--- a/src/main/target/KISSFCV2F7/target.c
+++ b/src/main/target/KISSFCV2F7/target.c
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+
+	DEF_TIM(TIM9, CH1, PA2, TIM_USE_PWM | TIM_USE_PPM,   0, 0),
+	
+	DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_MOTOR,               0, 0),
+	DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_MOTOR,               0, 0),
+	DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_MOTOR,               0, 0),	
+	DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_MOTOR,               0, 0),
+	
+	DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_MOTOR,               0, 0),
+	DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR,               0, 0),
+	
+	DEF_TIM(TIM2,  CH2, PB3,  TIM_USE_LED,                    0, 0)
+
+};
+

--- a/src/main/target/KISSFCV2F7/target.h
+++ b/src/main/target/KISSFCV2F7/target.h
@@ -1,0 +1,117 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER "KISSV2"
+
+#define USBD_PRODUCT_STRING "KISSFCV2F7"
+
+#define USE_ESC_SENSOR
+
+#define LED0   PA8  // blue
+#define LED1   PC8 // blingbling
+#define LED1_INVERTED
+
+#define BEEPER   PC9
+#define BEEPER_INVERTED
+
+#define MPU6000_CS_PIN          PB12
+#define MPU6000_SPI_INSTANCE    SPI2
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW90_DEG
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN       CW90_DEG
+
+
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PC11
+#define UART4_TX_PIN            PC10
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            PC12
+
+//#define USE_UART6
+//#define UART6_RX_PIN            PC7
+//#define UART6_TX_PIN            PC6
+
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL1_TX_PIN      PB4
+#define SOFTSERIAL1_RX_PIN      NONE //PB5
+
+#define SERIAL_PORT_COUNT       6
+
+#define USE_LED_STRIP
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+#define AVOID_UART2_FOR_PWM_PPM
+
+#define SPEKTRUM_BIND_PIN        UART2_RX_PIN
+
+#define USE_ADC
+#define BOARD_HAS_VOLTAGE_DIVIDER
+#define VBAT_SCALE_DEFAULT      160
+#define VBAT_ADC_PIN            PB1
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 8
+
+#define USED_TIMERS  ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(12) | TIM_N(8) | TIM_N(9) | TIM_N(10) | TIM_N(11))

--- a/src/main/target/KISSFCV2F7/target.mk
+++ b/src/main/target/KISSFCV2F7/target.mk
@@ -1,0 +1,7 @@
+F7X2RE_TARGETS += $(TARGET)
+LD_SCRIPT       =    $(ROOT)/src/main/target/$(TARGET)/stm32_flash_f722_no_split.ld
+CFLAGS +=             -D'CUSTOM_VECT_TAB_OFFSET=0x8000' \
+			      -DCLOCK_SOURCE_USE_HSI
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_spi_mpu6000.c 

--- a/src/main/target/system_stm32f7xx.c
+++ b/src/main/target/system_stm32f7xx.c
@@ -103,8 +103,12 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
-                                   This value must be a multiple of 0x200. */
+#ifdef CUSTOM_VECT_TAB_OFFSET
+#define VECT_TAB_OFFSET CUSTOM_VECT_TAB_OFFSET
+#else
+#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.*/
+#endif
+                                   /*This value must be a multiple of 0x200. */
 /******************************************************************************/
 
 /**
@@ -156,15 +160,28 @@
 
       __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
 
-      /* Enable HSE Oscillator and activate PLL with HSE as source */
-      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-      RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-      RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-      RCC_OscInitStruct.PLL.PLLM = PLL_M;
-      RCC_OscInitStruct.PLL.PLLN = PLL_N;
-      RCC_OscInitStruct.PLL.PLLP = PLL_P;
-      RCC_OscInitStruct.PLL.PLLQ = PLL_Q;
+#ifdef CLOCK_SOURCE_USE_HSI
+      /* Enable HSI Oscillator and activate PLL with HSI as source */
+      RCC_OscInitStruct.OscillatorType       = RCC_OSCILLATORTYPE_HSI;
+      RCC_OscInitStruct.HSIState             = RCC_HSI_ON;
+      RCC_OscInitStruct.HSICalibrationValue  = RCC_HSICALIBRATION_DEFAULT;
+      RCC_OscInitStruct.PLL.PLLState         = RCC_PLL_ON;
+      RCC_OscInitStruct.PLL.PLLSource        = RCC_PLLSOURCE_HSI;
+      RCC_OscInitStruct.PLL.PLLM             = 16;
+      RCC_OscInitStruct.PLL.PLLN             = 432;
+      RCC_OscInitStruct.PLL.PLLP             = RCC_PLLP_DIV2;
+      RCC_OscInitStruct.PLL.PLLQ             = 9;
+#else
+      /* Enable HSE Oscillator and activate PLL with HSE as source */ 
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE; 
+      RCC_OscInitStruct.HSEState = RCC_HSE_ON; 
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON; 
+      RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE; 
+      RCC_OscInitStruct.PLL.PLLM = PLL_M; 
+      RCC_OscInitStruct.PLL.PLLN = PLL_N; 
+      RCC_OscInitStruct.PLL.PLLP = PLL_P; 
+      RCC_OscInitStruct.PLL.PLLQ = PLL_Q;  
+#endif
 
       ret = HAL_RCC_OscConfig(&RCC_OscInitStruct);
       if (ret != HAL_OK) {


### PR DESCRIPTION
Hi,

i just made BF working on the KISSFC bootloader. it needs to be flashed with my flashloader or the GUI (press the reset button once before you connect to the GUI to get directly to the FC flasher tab). 

BF code wise i had to add some defines and also changed the linker script.

main changes:

1. added a define to use a custom vector table offset (CUSTOM_VECT_TAB_OFFSET in system_stm32f7xx.c)
2. added a define and code to use the 1% 16mhz internal oscillatior (CLOCK_SOURCE_USE_HSI in system_stm32f7xx.c)
3. the KISSFCV2F7 target includes its own liker file as the main FW starts after 32k (sector 0 = BL, sector 1 = eeprom emu) so i made your mk file check if the liker script is already defined by the target.mk

hope it fits :)

BTW. the KISSFCV2 drives its outer LED's by a small P fet to not have too much load on the MCU pin. it seems that the LED outputs on the F7 are configured in opendrain?, which dont works well here (LED's are always on)
is that meant to be like that?

thanks!




