### PR TITLE
ignore padding warning in accgyro tests

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -27,7 +27,7 @@
 #pragma GCC diagnostic push
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_MULTITHREAD)
 #include <pthread.h>
-#else
+#elif !defined(UNIT_TEST)
 #pragma GCC diagnostic warning "-Wpadded"
 #endif
 


### PR DESCRIPTION
open warning that still needs to be fixed: 

/var/jenkins_home/workspace/Betaflight/tools/gcc-arm-none-eabi-6-2017-q2-update/bin/../lib/gcc/arm-none-eabi/6.3.1/../../../../arm-none-eabi/bin/ld:stm32_flash_f7_split.ld:51: warning: memory region `ITCM_RAM' not declared