### PR TITLE
upgrade to gcc 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - make arm_sdk_install
 
 before_script:
-  - tools/gcc-arm-none-eabi-6-2017-q2-update/bin/arm-none-eabi-gcc --version
+  - tools/gcc-arm-none-eabi-7-2017-q4-major/bin/arm-none-eabi-gcc --version
   - clang --version
   - clang++ --version
   - gcc --version

--- a/make/mcu/STM32F1.mk
+++ b/make/mcu/STM32F1.mk
@@ -40,7 +40,7 @@ DEVICE_STDPERIPH_SRC := $(DEVICE_STDPERIPH_SRC) \
 endif
 
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f103_$(FLASH_SIZE)k.ld
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m3
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m3 -Wimplicit-fallthrough=0
 
 ifeq ($(DEVICE_FLAGS),)
 DEVICE_FLAGS    = -DSTM32F10X_MD

--- a/make/mcu/STM32F3.mk
+++ b/make/mcu/STM32F3.mk
@@ -53,7 +53,7 @@ endif
 
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f303_$(FLASH_SIZE)k.ld
 
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion -Wimplicit-fallthrough=0
 DEVICE_FLAGS    = -DSTM32F303xC -DSTM32F303
 
 VCP_SRC = \

--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -133,7 +133,7 @@ VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion -Wimplicit-fallthrough=0
 
 ifeq ($(TARGET),$(filter $(TARGET),$(F411_TARGETS)))
 DEVICE_FLAGS    = -DSTM32F411xE

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -109,7 +109,7 @@ VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant -Wdouble-promotion -Wimplicit-fallthrough=0
 
 DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER
 ifeq ($(TARGET),$(filter $(TARGET),$(F7X5XG_TARGETS)))

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -14,14 +14,14 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-6-2017-q2-update
+ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-7-2017-q4-major
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
-GCC_REQUIRED_VERSION ?= 6.3.1
+GCC_REQUIRED_VERSION ?= 7.2.1
 
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
-ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update
+ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major
 
 # source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifdef LINUX

--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -142,7 +142,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 // On gcc 5 and higher, this protects only memory passed as parameter (any type can be used)
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
-#if (__GNUC__ > 6)
+#if (__GNUC__ > 7)
 # warning "Please verify that ATOMIC_BARRIER works as intended"
 // increment version number if BARRIER works
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead


### PR DESCRIPTION
lets hope there isnt any compiler bug ;)

I currently disabled the new implicit-fallthrough warnings. i think those warnings should be fixed in another pull request since those are plenty.

The const changes are because of new double const warnings. RESET_CONFIG allready has const in it ;)
(duplicate 'const' declaration specifier [-Wduplicate-decl-specifier])

The sizeof changes are because of new memset warning
('memset' used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size])