### PR TITLE
remove const from reset_conf( since it allready is defined in the marko

### DIFF
--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -39,7 +39,7 @@ PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT,
 void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
 {
     for (int i = 0; i < CONTROL_RATE_PROFILE_COUNT; i++) {
-        RESET_CONFIG(const controlRateConfig_t, &controlRateConfig[i],
+        RESET_CONFIG(controlRateConfig_t, &controlRateConfig[i],
             .rcRate8 = 100,
             .rcYawRate8 = 100,
             .rcExpo8 = 0,

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -77,7 +77,7 @@ PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, MAX_PROFILE_COUNT, pidProfiles, PG
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
-    RESET_CONFIG(const pidProfile_t, pidProfile,
+    RESET_CONFIG(pidProfile_t, pidProfile,
         .pid = {
             [PID_ROLL] =  { 40, 40, 30 },
             [PID_PITCH] = { 58, 50, 35 },

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -79,7 +79,7 @@ PG_REGISTER_ARRAY_WITH_RESET_FN(servoParam_t, MAX_SUPPORTED_SERVOS, servoParams,
 void pgResetFn_servoParams(servoParam_t *instance)
 {
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
-        RESET_CONFIG(const servoParam_t, &instance[i],
+        RESET_CONFIG(servoParam_t, &instance[i],
             .min = DEFAULT_SERVO_MIN,
             .max = DEFAULT_SERVO_MAX,
             .middle = DEFAULT_SERVO_MIDDLE,


### PR DESCRIPTION
as noticed when updating to gcc7 which throws more warnings.

other solution would be to remove const from the marko. then the const should be removed from the makro below and a const need to be added to RESET_CONFIG(voltageSensorADCConfig_t