### PR TITLE
remove some double const

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -199,7 +199,7 @@ static const adjustmentConfig_t defaultAdjustmentConfigs[ADJUSTMENT_FUNCTION_COU
 };
 
 #if defined(USE_OSD) && defined(USE_OSD_ADJUSTMENTS)
-static const char const *adjustmentLabels[] = {
+static const char *adjustmentLabels[] = {
     "RC RATE",
     "RC EXPO",
     "THROTTLE EXPO",
@@ -226,7 +226,7 @@ static const char const *adjustmentLabels[] = {
     "HORIZON STRENGTH",
 };
 
-const char const *adjustmentRangeName;
+const char *adjustmentRangeName;
 int adjustmentRangeValue = -1;
 #endif
 

--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -93,7 +93,7 @@ typedef struct adjustmentState_s {
 
 #define MAX_ADJUSTMENT_RANGE_COUNT 15
 
-extern char const *adjustmentRangeName;
+extern const char *adjustmentRangeName;
 extern int adjustmentRangeValue;
 
 PG_DECLARE_ARRAY(adjustmentRange_t, MAX_ADJUSTMENT_RANGE_COUNT, adjustmentRanges);


### PR DESCRIPTION
as notice when updating to gcc7 which throws more errors.

fixes 2 double const delecation which are uneeded
and fix char const to const char to be in sync with the other file and the all over codebase style