### PR TITLE
filter: Fix calculation of alpha value in biquad.

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -112,7 +112,8 @@ void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refresh
     const float omega = 2.0f * M_PI_FLOAT * filterFreq * refreshRate * 0.000001f;
     const float sn = sin_approx(omega);
     const float cs = cos_approx(omega);
-    const float alpha = sn / (2.0f * Q);
+    const float sf = M_LN2_FLOAT * 0.5f * Q * omega / sn;
+    const float alpha = sn * 0.5f * (expf(sf) - expf(-sf));
 
     float b0 = 0, b1 = 0, b2 = 0, a0 = 0, a1 = 0, a2 = 0;
 


### PR DESCRIPTION
When Boris added the code, he had it nearly correct, except it should have been sinhf instead of sinf. Interestingly commit f62ec04 spotted the mistake (see the added comment in said commit), but then replaced it with a solution that I'm not sure about what it is supposed to do. The alpha values calculated by this diverge a lot from what the original implementation with the hyperbolic sine spits out. This patch should fix the biquad.

Be aware that this may detune things on existing quads to some degree, since it's being applied in lots of different areas.