### PR TITLE
Renamed / cleaned up the CC2500 driver.

### DIFF
--- a/src/main/drivers/rx_cc2500.c
+++ b/src/main/drivers/rx_cc2500.c
@@ -1,4 +1,21 @@
 /*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
 * CC2500 SPI drivers
 */
 #include <stdbool.h>
@@ -7,14 +24,16 @@
 
 #include "platform.h"
 
+#ifdef USE_RX_CC2500
+
 #include "build/build_config.h"
 
-#include "drivers/cc2500.h"
 #include "drivers/io.h"
 #include "drivers/rx_spi.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
 
+#include "rx_cc2500.h"
 
 #define NOP 0xFF
 
@@ -82,3 +101,4 @@ uint8_t cc2500Reset(void)
     // TX_EN_off;//off rx
     return cc2500ReadReg(CC2500_0E_FREQ1) == 0xC4; // check if reset
 }
+#endif

--- a/src/main/drivers/rx_cc2500.h
+++ b/src/main/drivers/rx_cc2500.h
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /*
  CC2500 SPI drivers

--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -31,7 +31,7 @@
 #include "common/utils.h"
 
 #include "drivers/adc.h"
-#include "drivers/cc2500.h"
+#include "drivers/rx_cc2500.h"
 #include "drivers/io.h"
 #include "drivers/system.h"
 #include "drivers/time.h"

--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -23,7 +23,7 @@
 
 #include "common/maths.h"
 
-#include "drivers/cc2500.h"
+#include "drivers/rx_cc2500.h"
 #include "drivers/io.h"
 #include "drivers/time.h"
 

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -33,7 +33,7 @@
 #include "common/utils.h"
 
 #include "drivers/adc.h"
-#include "drivers/cc2500.h"
+#include "drivers/rx_cc2500.h"
 #include "drivers/io.h"
 #include "drivers/io_def.h"
 #include "drivers/io_types.h"

--- a/src/main/rx/rx_spi.c
+++ b/src/main/rx/rx_spi.c
@@ -28,7 +28,7 @@
 
 #include "config/feature.h"
 
-#include "drivers/cc2500.h"
+#include "drivers/rx_spi.h"
 #include "drivers/rx_nrf24l01.h"
 
 #include "fc/config.h"
@@ -59,7 +59,6 @@ static protocolSetRcDataFromPayloadFnPtr protocolSetRcDataFromPayload;
 
 STATIC_UNIT_TESTED uint16_t rxSpiReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t channel)
 {
-
     BUILD_BUG_ON(NRF24L01_MAX_PAYLOAD_SIZE > RX_SPI_MAX_PAYLOAD_SIZE);
 
     if (channel >= rxRuntimeConfig->channelCount) {

--- a/src/main/target/MIDELICF3/target.mk
+++ b/src/main/target/MIDELICF3/target.mk
@@ -5,7 +5,7 @@ FEATURES  = VCP SDCARD
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_mpu6050.c \
-            drivers/cc2500.c \
+            drivers/rx_cc2500.c \
             rx/cc2500_frsky_shared.c \
             rx/cc2500_frsky_d.c \
             rx/cc2500_frsky_x.c

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -75,6 +75,7 @@
 #endif
 
 #if defined(USE_RX_FRSKY_SPI_D) || defined(USE_RX_FRSKY_SPI_X)
+#define USE_RX_CC2500
 #define USE_RX_FRSKY_SPI
 #endif
 


### PR DESCRIPTION
@martinbudden: When working on this I noticed two things to do with the NRF24 code that was contributed by you:
- since the only target that seems to be using this is CJMCU, and this target is one of the F1 targets that were dropped from 3.3, the code currently does not have CI coverage; I think it would make sense to add it to a >= F3 target (STM32F3DISCOVERY being an obvious candidate), to get it back into coverage;
- This line seems to be out of place where it is: https://github.com/mikeller/betaflight/blob/0a1290685f66a369eaa89cd586f7e276d46cb34c/src/main/rx/rx_spi.c#L62
Can this be moved into the `rx_nrf24` code (will potentially best be done by introducing `rx_nrf24_shared`), so we are not bugging out if this ever breaks for targets that include `rx_spi` but not `rx_nrf24`? (The dependency of `rx_spi` on the `rx_nrf24` driver is also a bit odd.)
