### PR TITLE
DSHOT Use striding loadDmaBuffer to avoid buffer copy

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -137,20 +137,20 @@ static void pwmWriteDshot(uint8_t index, float value)
     pwmWriteDshotInt(index, lrintf(value));
 }
 
-static uint8_t loadDmaBufferDshot(motorDmaOutput_t *const motor, uint16_t packet)
+static uint8_t loadDmaBufferDshot(uint32_t *dmaBuffer, int stride, uint16_t packet)
 {
     for (int i = 0; i < 16; i++) {
-        motor->dmaBuffer[i] = (packet & 0x8000) ? MOTOR_BIT_1 : MOTOR_BIT_0;  // MSB first
+        dmaBuffer[i * stride] = (packet & 0x8000) ? MOTOR_BIT_1 : MOTOR_BIT_0;  // MSB first 
         packet <<= 1;
     }
 
     return DSHOT_DMA_BUFFER_SIZE;
 }
 
-static uint8_t loadDmaBufferProshot(motorDmaOutput_t *const motor, uint16_t packet)
+static uint8_t loadDmaBufferProshot(uint32_t *dmaBuffer, int stride, uint16_t packet)
 {
     for (int i = 0; i < 4; i++) {
-        motor->dmaBuffer[i] = PROSHOT_BASE_SYMBOL + ((packet & 0xF000) >> 12) * PROSHOT_BIT_WIDTH;  // Most significant nibble first
+        dmaBuffer[i * stride] = PROSHOT_BASE_SYMBOL + ((packet & 0xF000) >> 12) * PROSHOT_BIT_WIDTH;  // Most significant nibble first
         packet <<= 4;   // Shift 4 bits
     }
 

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -185,7 +185,7 @@ void pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIn
 bool isMotorProtocolDshot(void);
 
 #ifdef USE_DSHOT
-typedef uint8_t loadDmaBufferFn(motorDmaOutput_t *const motor, uint16_t packet);  // function pointer used to encode a digital motor value into the DMA buffer representation
+typedef uint8_t loadDmaBufferFn(uint32_t *dmaBuffer, int stride, uint16_t packet);  // function pointer used to encode a digital motor value into the DMA buffer representation
 
 uint16_t prepareDshotPacket(motorDmaOutput_t *const motor, uint16_t value);
 

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -272,6 +272,11 @@ static inline uint8_t lookupChannelIndex(const uint16_t channel)
     return channel >> 2;
 }
 
+uint8_t timerLookupChannelIndex(const uint16_t channel)
+{
+    return lookupChannelIndex(channel);
+}
+
 rccPeriphTag_t timerRCC(TIM_TypeDef *tim)
 {
     for (int i = 0; i < HARDWARE_TIMER_DEFINITION_COUNT; i++) {


### PR DESCRIPTION
This was easier than I first thought...

Let's hope lto would do a good job in the following areas.

- `timerLookupChannelIndex`, which is an interface to inline function `lookupChannelIndex`.
- `loadDmaBuffer` with `stride` being always 1 (non-DMAR case) and 4 (DMAR case).