### PR TITLE
PT1 filter size optimizations, remove unsed func & vars from struct

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -44,28 +44,13 @@ FAST_CODE float nullFilterApply(void *filter, float input)
 
 void pt1FilterInit(pt1Filter_t *filter, uint8_t f_cut, float dT)
 {
-    filter->RC = 1.0f / ( 2.0f * M_PI_FLOAT * f_cut );
-    filter->dT = dT;
-    filter->k = filter->dT / (filter->RC + filter->dT);
+    float RC = 1.0f / ( 2.0f * M_PI_FLOAT * f_cut );
+    filter->k = dT / (RC + dT);
 }
 
 FAST_CODE float pt1FilterApply(pt1Filter_t *filter, float input)
 {
     filter->state = filter->state + filter->k * (input - filter->state);
-    return filter->state;
-}
-
-FAST_CODE float pt1FilterApply4(pt1Filter_t *filter, float input, uint8_t f_cut, float dT)
-{
-    // Pre calculate and store RC
-    if (!filter->RC) {
-        filter->RC = 1.0f / ( 2.0f * M_PI_FLOAT * f_cut );
-        filter->dT = dT;
-        filter->k = filter->dT / (filter->RC + filter->dT);
-    }
-
-    filter->state = filter->state + filter->k * (input - filter->state);
-
     return filter->state;
 }
 

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -28,8 +28,6 @@
 typedef struct pt1Filter_s {
     float state;
     float k;
-    float RC;
-    float dT;
 } pt1Filter_t;
 
 typedef struct slewFilter_s {
@@ -91,7 +89,6 @@ float filterGetNotchQ(uint16_t centerFreq, uint16_t cutoff);
 
 void pt1FilterInit(pt1Filter_t *filter, uint8_t f_cut, float dT);
 float pt1FilterApply(pt1Filter_t *filter, float input);
-float pt1FilterApply4(pt1Filter_t *filter, float input, uint8_t f_cut, float dT);
 
 void slewFilterInit(slewFilter_t *filter, float slewLimit, float threshold);
 float slewFilterApply(slewFilter_t *filter, float input);


### PR DESCRIPTION
RC and dT from the struct pt1Filter_s/t are never used after initialization and can be removed.
pt1FilterApply4 is completely obsolete to the best of my knowledge.