### PR TITLE
F3 DSHOT-DMAR

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -111,7 +111,11 @@ typedef struct {
     TIM_TypeDef *timer;
 #if defined(USE_DSHOT_DMAR)
 #if !defined(USE_HAL_DRIVER)
+#ifdef STM32F3
+    DMA_Channel_TypeDef *dmaBurstRef;
+#else
     DMA_Stream_TypeDef *dmaBurstRef;
+#endif
     uint16_t dmaBurstLength;
 #endif
     uint32_t dmaBurstBuffer[DSHOT_DMA_BUFFER_SIZE * 4];

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -100,14 +100,18 @@ typedef struct timerHardware_s {
 #if defined(STM32F4) || defined(STM32F7)
     DMA_Stream_TypeDef *dmaRef;
     uint32_t dmaChannel;
-#elif defined(STM32F3) || defined(STM32F1)
+#else
     DMA_Channel_TypeDef *dmaRef;
 #endif
     uint8_t dmaIrqHandler;
-#if defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
     // TIMUP
+#ifdef STM32F3
+    DMA_Channel_TypeDef *dmaTimUPRef;
+#else
     DMA_Stream_TypeDef *dmaTimUPRef;
     uint32_t dmaTimUPChannel;
+#endif
     uint8_t dmaTimUPIrqHandler;
 #endif
 #endif

--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -171,6 +171,10 @@
     DEF_TIM_DMA_COND(                                                   \
         DEF_TIM_DMA_CHANNEL(TCH_## tim ## _ ## chan),                   \
         DEF_TIM_DMA_HANDLER(TCH_## tim ## _ ## chan)                    \
+    ),                                                                  \
+    DEF_TIM_DMA_COND(                                                   \
+        DEF_TIM_DMA_CHANNEL(TCH_## tim ## _UP),                         \
+        DEF_TIM_DMA_HANDLER(TCH_## tim ## _UP)                          \
     )                                                                   \
     }                                                                   \
 /**/
@@ -198,11 +202,9 @@
 #define DEF_TIM_DMA__BTCH_TIM1_CH4    D(1, 4)
 #define DEF_TIM_DMA__BTCH_TIM1_TRIG   D(1, 4)
 #define DEF_TIM_DMA__BTCH_TIM1_COM    D(1, 4)
-#define DEF_TIM_DMA__BTCH_TIM1_UP     D(1, 5)
 #define DEF_TIM_DMA__BTCH_TIM1_CH3    D(1, 6)
 
 #define DEF_TIM_DMA__BTCH_TIM2_CH3    D(1, 1)
-#define DEF_TIM_DMA__BTCH_TIM2_UP     D(1, 2)
 #define DEF_TIM_DMA__BTCH_TIM2_CH1    D(1, 5)
 #define DEF_TIM_DMA__BTCH_TIM2_CH2    D(1, 7)
 #define DEF_TIM_DMA__BTCH_TIM2_CH4    D(1, 7)
@@ -210,14 +212,12 @@
 #define DEF_TIM_DMA__BTCH_TIM3_CH2    NONE
 #define DEF_TIM_DMA__BTCH_TIM3_CH3    D(1, 2)
 #define DEF_TIM_DMA__BTCH_TIM3_CH4    D(1, 3)
-#define DEF_TIM_DMA__BTCH_TIM3_UP     D(1, 3)
 #define DEF_TIM_DMA__BTCH_TIM3_CH1    D(1, 6)
 #define DEF_TIM_DMA__BTCH_TIM3_TRIG   D(1, 6)
 
 #define DEF_TIM_DMA__BTCH_TIM4_CH1    D(1, 1)
 #define DEF_TIM_DMA__BTCH_TIM4_CH2    D(1, 4)
 #define DEF_TIM_DMA__BTCH_TIM4_CH3    D(1, 5)
-#define DEF_TIM_DMA__BTCH_TIM4_UP     D(1, 7)
 #define DEF_TIM_DMA__BTCH_TIM4_CH4    NONE
 
 #define DEF_TIM_DMA__BTCH_TIM15_CH1   D(1, 5)
@@ -228,27 +228,42 @@
 
 #ifdef REMAP_TIM16_DMA
 #define DEF_TIM_DMA__BTCH_TIM16_CH1   D(1, 6)
-#define DEF_TIM_DMA__BTCH_TIM16_UP    D(1, 6)
 #else
 #define DEF_TIM_DMA__BTCH_TIM16_CH1   D(1, 3)
-#define DEF_TIM_DMA__BTCH_TIM16_UP    D(1, 3)
 #endif
 
 #ifdef REMAP_TIM17_DMA
 #define DEF_TIM_DMA__BTCH_TIM17_CH1   D(1, 7)
-#define DEF_TIM_DMA__BTCH_TIM17_UP    D(1, 7)
 #else
 #define DEF_TIM_DMA__BTCH_TIM17_CH1   D(1, 1)
-#define DEF_TIM_DMA__BTCH_TIM17_UP    D(1, 1)
 #endif
 
 #define DEF_TIM_DMA__BTCH_TIM8_CH3    D(2, 1)
-#define DEF_TIM_DMA__BTCH_TIM8_UP     D(2, 1)
 #define DEF_TIM_DMA__BTCH_TIM8_CH4    D(2, 2)
 #define DEF_TIM_DMA__BTCH_TIM8_TRIG   D(2, 2)
 #define DEF_TIM_DMA__BTCH_TIM8_COM    D(2, 2)
 #define DEF_TIM_DMA__BTCH_TIM8_CH1    D(2, 3)
 #define DEF_TIM_DMA__BTCH_TIM8_CH2    D(2, 5)
+
+// TIM_UP table
+#define DEF_TIM_DMA__BTCH_TIM1_UP     D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM2_UP     D(1, 2)
+#define DEF_TIM_DMA__BTCH_TIM3_UP     D(1, 3)
+#define DEF_TIM_DMA__BTCH_TIM4_UP     D(1, 7)
+#define DEF_TIM_DMA__BTCH_TIM6_UP     D(2, 3)
+#define DEF_TIM_DMA__BTCH_TIM7_UP     D(2, 4)
+#define DEF_TIM_DMA__BTCH_TIM8_UP     D(2, 1)
+#define DEF_TIM_DMA__BTCH_TIM15_UP    D(1, 5)
+#ifdef REMAP_TIM16_DMA
+#define DEF_TIM_DMA__BTCH_TIM16_UP    D(1, 6)
+#else
+#define DEF_TIM_DMA__BTCH_TIM16_UP    D(1, 3)
+#endif
+#ifdef REMAP_TIM17_DMA
+#define DEF_TIM_DMA__BTCH_TIM17_UP    D(1, 7)
+#else
+#define DEF_TIM_DMA__BTCH_TIM17_UP    D(1, 1)
+#endif
 
 // AF table
 

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -41,6 +41,7 @@
 #ifdef STM32F3
 #define MINIMAL_CLI
 #define USE_DSHOT
+#define USE_DSHOT_DMAR
 #define USE_GYRO_DATA_ANALYSE
 #endif
 


### PR DESCRIPTION
It was pretty easy, but may still require a bit of work.
Tested on:
* STM32F3DISCOVERY - by means of a logic analyzer
* SPRACINGF3EVO - on my Warlark F3 which required modification to run DSHOT before, now it flies without any fiddling in CLI or soldering additional wires.

Needs testing on other targets and looking for DMA Stream clashes. For some reason on SPRF3EVO DSHOT-DMAR + Dynamic Filter on 8k/8k skyrockets CPU usage from 44% to 100% upon booting, works fine with ordinary DSHOT at 34% with no dynamic filtering and at 45% with.
