### PR TITLE
UART Make VTable functions static

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -41,14 +41,14 @@
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
 
-void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
+static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartPort->port.baudRate = baudRate;
     uartReconfigure(uartPort);
 }
 
-void uartSetMode(serialPort_t *instance, portMode_e mode)
+static void uartSetMode(serialPort_t *instance, portMode_e mode)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartPort->port.mode = mode;
@@ -138,7 +138,7 @@ void uartTryStartTxDMA(uartPort_t *s)
     }
 }
 
-uint32_t uartTotalRxBytesWaiting(const serialPort_t *instance)
+static uint32_t uartTotalRxBytesWaiting(const serialPort_t *instance)
 {
     const uartPort_t *s = (const uartPort_t*)instance;
 #ifdef STM32F4
@@ -162,7 +162,7 @@ uint32_t uartTotalRxBytesWaiting(const serialPort_t *instance)
     }
 }
 
-uint32_t uartTotalTxBytesFree(const serialPort_t *instance)
+static uint32_t uartTotalTxBytesFree(const serialPort_t *instance)
 {
     const uartPort_t *s = (const uartPort_t*)instance;
 
@@ -205,7 +205,7 @@ uint32_t uartTotalTxBytesFree(const serialPort_t *instance)
     return (s->port.txBufferSize - 1) - bytesUsed;
 }
 
-bool isUartTransmitBufferEmpty(const serialPort_t *instance)
+static bool isUartTransmitBufferEmpty(const serialPort_t *instance)
 {
     const uartPort_t *s = (const uartPort_t *)instance;
 #ifdef STM32F4
@@ -218,7 +218,7 @@ bool isUartTransmitBufferEmpty(const serialPort_t *instance)
         return s->port.txBufferTail == s->port.txBufferHead;
 }
 
-uint8_t uartRead(serialPort_t *instance)
+static uint8_t uartRead(serialPort_t *instance)
 {
     uint8_t ch;
     uartPort_t *s = (uartPort_t *)instance;
@@ -243,7 +243,7 @@ uint8_t uartRead(serialPort_t *instance)
     return ch;
 }
 
-void uartWrite(serialPort_t *instance, uint8_t ch)
+static void uartWrite(serialPort_t *instance, uint8_t ch)
 {
     uartPort_t *s = (uartPort_t *)instance;
     s->port.txBuffer[s->port.txBufferHead] = ch;

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -73,11 +73,3 @@ typedef struct uartPort_s {
 
 void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig);
 serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options);
-
-// serialPort API
-void uartWrite(serialPort_t *instance, uint8_t ch);
-uint32_t uartTotalRxBytesWaiting(const serialPort_t *instance);
-uint32_t uartTotalTxBytesFree(const serialPort_t *instance);
-uint8_t uartRead(serialPort_t *instance);
-void uartSetBaudRate(serialPort_t *s, uint32_t baudRate);
-bool isUartTransmitBufferEmpty(const serialPort_t *s);

--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -277,7 +277,7 @@ void handleJetiExBusTelemetry(void)
             jetiExSensors[EX_TIME_DIFF].value = timeDiff;
 
             // switch to TX mode
-            if (uartTotalRxBytesWaiting(jetiExBusPort) == 0) {
+            if (serialRxBytesWaiting(jetiExBusPort) == 0) {
                 serialSetMode(jetiExBusPort, MODE_TX);
                 jetiExBusTransceiveState = EXBUS_TRANS_TX;
                 sendJetiExBusTelemetry(jetiExBusRequestFrame[EXBUS_HEADER_PACKET_ID]);


### PR DESCRIPTION
Make VTable functions static.

As a by product, found a call to `uartTotalRxBytesWaiting`, which was replace with `serialRxBytesWaiting`   in `jetiexbus.c`.