### PR TITLE
Add WORMFC target

### DIFF
--- a/src/main/target/WORMFC/target.c
+++ b/src/main/target/WORMFC/target.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+
+    DEF_TIM(TIM4, CH4, PB9, TIM_USE_PPM | TIM_USE_PWM, 1,  0 ),     // PPM IN
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MOTOR, 0, 1 ),                 // S1_OUT - DMA1_ST1_CH3
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MOTOR, 0, 1 ),              // S2_OUT - DMA1_ST2_CH5
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR, 0, 0 ),              // S3_OUT - DMA1_ST6_CH3
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR, 0, 1 ),              // S4_OUT - DMA1_ST7_CH5
+
+    DEF_TIM(TIM5, CH2, PA1, TIM_USE_LED,   0, 0 ),              // LED_STRIP - DMA1_ST2_CH5
+
+};
+

--- a/src/main/target/WORMFC/target.h
+++ b/src/main/target/WORMFC/target.h
@@ -1,0 +1,133 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "RRF4"
+#define USBD_PRODUCT_STRING     "Worm FC"
+
+//LEDs
+#define LED0_PIN                PA15
+#define LED1_PIN                PC14
+
+//BEEPER
+#define BEEPER                  PB14
+#define BEEPER_INVERTED
+
+// MPU6500 interrupt
+#define USE_EXTI
+#define MPU_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+//#define DEBUG_MPU_DATA_READY_INTERRUPT
+
+#define MPU6500_CS_PIN          PA4
+#define MPU6500_SPI_INSTANCE    SPI1
+
+// ACC section -- start
+#define ACC
+#define USE_ACC
+#define USE_ACC_MPU6500
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW180_DEG_FLIP
+// ACC section -- end
+
+// GYRO section -- start
+#define GYRO
+#define USE_GYRO
+#define USE_GYRO_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN      CW180_DEG_FLIP
+// GYRO section -- end
+
+//BARO
+#define BARO
+#define USE_BARO
+#define USE_BARO_LPS
+#define LPS_SPI_INSTANCE SPI3
+#define LPS_CS_PIN PB8
+
+//UARTs
+#define INVERTER_PIN_UART6      PB13
+#define INVERTER_PIN_UART3      PB12
+
+#define USE_VCP
+#define VBUS_SENSING_PIN        PA9
+#define VBUS_SENSING_ENABLED
+
+#define USE_UART1
+#define UART1_RX_PIN            PB7
+#define UART1_TX_PIN            PB6
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       4 //VCP, USART1, USART3, USART6
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1
+
+//SPI
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+//OSD
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PC0
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#define USE_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define BOARD_HAS_VOLTAGE_DIVIDER
+#define VBAT_ADC_PIN            PC1
+//#define RSSI_ADC_PIN            PC2
+#define CURRENT_METER_ADC_PIN   PC2
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+//SD CARD
+#define USE_SDCARD
+#define USE_SDCARD_SDIO
+#define SDIO_DMA
+#define SDCARD_SPI_CS_PIN NONE //This is not used on SDIO, has to be kept for now to keep compiler happy
+#define SDCARD_DETECT_PIN PB15
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 6
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(8))

--- a/src/main/target/WORMFC/target.mk
+++ b/src/main/target/WORMFC/target.mk
@@ -1,0 +1,18 @@
+F405_TARGETS    += $(TARGET)
+FEATURES        += VCP
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/barometer/barometer_lps.c \
+            drivers/max7456.c \
+            io/osd.c
+            
+            
+TARGET_SRC += \
+            drivers/sdio_stdlib.c \
+            drivers/sdcard_sdio_stdlib.c \
+            drivers/sdcard_standard.c \
+            io/asyncfatfs/asyncfatfs.c \
+            io/asyncfatfs/fat_standard.c


### PR DESCRIPTION
Adds open source WORMFC F4 flight controller. Source files can be found on: https://github.com/conkerkh/wormfcF4. This will not compile without accepting previous PRs (SDIO driver and LPS25HB)