### PR TITLE
remove cellvoltage from vfas since there allready is a4 for cell voltage

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -375,13 +375,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
         switch (id) {
             case FSSP_DATAID_VFAS       :
                 if (isBatteryVoltageAvailable()) {
-                    uint16_t vfasVoltage;
-                    if (telemetryConfig()->report_cell_voltage) {
-                        vfasVoltage = getBatteryVoltage() / getBatteryCellCount();
-                    } else {
-                        vfasVoltage = getBatteryVoltage();
-                    }
-                    smartPortSendPackage(id, vfasVoltage * 10); // given in 0.1V, convert to volts
+                    smartPortSendPackage(id, getBatteryVoltage() * 10); // given in 0.1V, convert to volts
                     *clearToSend = false;
                 }
                 break;


### PR DESCRIPTION
just a small cleanup.
a4 got added some years ago which already send the cell voltage.
so VFAS can be used to only send the full voltage.

the enum looks a little outdated and the link is dead.
i think current file to check would be this: https://github.com/opentx/opentx/blob/2.2/radio/src/telemetry/frsky.h
i will have a look in some bigger cleanup in the future