### PR TITLE
Enable PWM5 and PWM6 timers for MOTOLABF4

### DIFF
--- a/src/main/target/MOTOLABF4/target.c
+++ b/src/main/target/MOTOLABF4/target.c
@@ -28,9 +28,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0 ), // PWM2
     DEF_TIM(TIM2, CH2, PB3, TIM_USE_MOTOR, 0, 0 ), // PWM3
     DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0 ), // PWM4
-#ifdef ML_PWM_6
     DEF_TIM(TIM5, CH3, PA2, TIM_USE_MOTOR, 0, 0 ), // PWM5
     DEF_TIM(TIM5, CH4, PA3, TIM_USE_MOTOR, 0, 0 ), // PWM6
-#endif
     DEF_TIM(TIM1, CH1, PA8, TIM_USE_LED,   0, 0 ), // Serial LED
 };

--- a/src/main/target/MOTOLABF4/target.h
+++ b/src/main/target/MOTOLABF4/target.h
@@ -153,10 +153,5 @@
 #define TARGET_IO_PORTC 0xffff
 #define TARGET_IO_PORTD (BIT(2))
 
-#ifndef ML_PWM_6
-#define USABLE_TIMER_CHANNEL_COUNT 5
-#define USED_TIMERS  ( TIM_N(1) | TIM_N(2) | TIM_N(3) )
-#else
 #define USABLE_TIMER_CHANNEL_COUNT 7
 #define USED_TIMERS  ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) )
-#endif


### PR DESCRIPTION
Adds timer selection for motors 5 and 6 in the MOTOLABF4 board specs, used for MLTEMPF4 and MLTYPHF4 targets.