### PR TITLE
VREFINT and core temperature support, full task polling version

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -71,6 +71,7 @@ COMMON_SRC = \
             pg/sdcard.c \
             pg/vcd.c \
             scheduler/scheduler.c \
+            sensors/adcinternal.c \
             sensors/battery.c \
             sensors/current.c \
             sensors/voltage.c \

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -59,4 +59,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RANGEFINDER",
     "RANGEFINDER_QUALITY",
     "LIDAR_TF",
+    "CORE_TEMP",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -77,6 +77,7 @@ typedef enum {
     DEBUG_RANGEFINDER,
     DEBUG_RANGEFINDER_QUALITY,
     DEBUG_LIDAR_TF,
+    DEBUG_CORE_TEMP,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -19,10 +19,9 @@
 #include <stdint.h>
 
 #include "platform.h"
+#include "common/utils.h"
 
 #ifdef USE_ADC
-
-#include "common/utils.h"
 
 #include "build/build_config.h"
 #include "build/debug.h"
@@ -34,11 +33,17 @@
 
 #include "adc.h"
 
-
 //#define DEBUG_ADC_CHANNELS
 
 adcOperatingConfig_t adcOperatingConfig[ADC_CHANNEL_COUNT];
 volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
+
+#ifdef USE_ADC_INTERNAL
+uint16_t adcTSCAL1;
+uint16_t adcTSCAL2;
+uint16_t adcTSSlopeK;
+uint16_t adcVREFINTCAL;
+#endif
 
 uint8_t adcChannelByTag(ioTag_t ioTag)
 {
@@ -115,5 +120,12 @@ bool adcVerifyPin(ioTag_t tag, ADCDevice device)
     }
 
     return false;
+}
+
+#else
+uint16_t adcGetChannel(uint8_t channel)
+{
+    UNUSED(channel);
+    return 0;
 }
 #endif

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 
 #include "drivers/io_types.h"
+#include "drivers/time.h"
 
 #ifndef ADC_INSTANCE
 #define ADC_INSTANCE                ADC1
@@ -74,6 +75,18 @@ typedef struct adcOperatingConfig_s {
 struct adcConfig_s;
 void adcInit(const struct adcConfig_s *config);
 uint16_t adcGetChannel(uint8_t channel);
+
+#ifdef USE_ADC_INTERNAL
+extern uint16_t adcVREFINTCAL;
+extern uint16_t adcTSCAL1;
+extern uint16_t adcTSCAL2;
+extern uint16_t adcTSSlopeK;
+
+bool adcInternalIsBusy(void);
+void adcInternalStartConversion(void);
+uint16_t adcInternalReadVrefint(void);
+uint16_t adcInternalReadTempsensor(void);
+#endif
 
 #ifndef SITL
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance);

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -71,6 +71,7 @@
 #include "rx/rx.h"
 
 #include "sensors/acceleration.h"
+#include "sensors/adcinternal.h"
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/compass.h"
@@ -323,6 +324,9 @@ void fcTasksInit(void)
 #endif
 #ifdef USE_ESC_SENSOR
     setTaskEnabled(TASK_ESC_SENSOR, feature(FEATURE_ESC_SENSOR));
+#endif
+#ifdef USE_ADC_INTERNAL
+    setTaskEnabled(TASK_ADC_INTERNAL, true);
 #endif
 #ifdef USE_CMS
 #ifdef USE_MSP_DISPLAYPORT
@@ -592,6 +596,15 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskName = "CAMCTRL",
         .taskFunc = taskCameraControl,
         .desiredPeriod = TASK_PERIOD_HZ(5),
+        .staticPriority = TASK_PRIORITY_IDLE
+    },
+#endif
+
+#ifdef USE_ADC_INTERNAL
+    [TASK_ADC_INTERNAL] = {
+        .taskName = "ADCINTERNAL",
+        .taskFunc = adcInternalProcess,
+        .desiredPeriod = TASK_PERIOD_HZ(1),
         .staticPriority = TASK_PRIORITY_IDLE
     },
 #endif

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -130,6 +130,7 @@ extern uint8_t __config_end;
 #include "scheduler/scheduler.h"
 
 #include "sensors/acceleration.h"
+#include "sensors/adcinternal.h"
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/boardalignment.h"
@@ -3010,6 +3011,12 @@ static void cliStatus(char *cmdline)
     cliPrintLinef("Voltage: %d * 0.1V (%dS battery - %s)", getBatteryVoltage(), getBatteryCellCount(), getBatteryStateString());
 
     cliPrintf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
+
+#ifdef USE_ADC_INTERNAL
+    uint16_t vrefintMv = getVrefMv();
+    uint16_t coretemp = getCoreTemperatureCelsius();
+    cliPrintf(", Vref=%d.%2dV, Core temp=%ddegC", vrefintMv / 1000, (vrefintMv % 1000) / 10, coretemp);
+#endif
 
 #if defined(USE_SENSOR_NAMES)
     const uint32_t detectedSensorsMask = sensorsMask();

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -118,6 +118,10 @@ typedef enum {
     TASK_RCDEVICE,
 #endif
 
+#ifdef USE_ADC_INTERNAL
+    TASK_ADC_INTERNAL,
+#endif
+
     /* Count of real tasks */
     TASK_COUNT,
 

--- a/src/main/sensors/adcinternal.c
+++ b/src/main/sensors/adcinternal.c
@@ -1,0 +1,114 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#if defined(USE_ADC) && defined(USE_ADC_INTERNAL)
+
+#include "build/debug.h"
+
+#include "common/utils.h"
+
+#include "drivers/adc.h"
+
+typedef struct movingAverageStateUint16_s {
+    uint32_t sum;
+    uint16_t *values;
+    uint8_t size;
+    uint8_t pos;
+} movingAverageStateUint16_t;
+
+uint16_t updateMovingAverageUint16(movingAverageStateUint16_t *state, uint16_t newValue)
+{
+    state->sum -= state->values[state->pos];
+    state->values[state->pos] = newValue;
+    state->sum += newValue;
+    state->pos = (state->pos + 1) % state->size;
+
+    return state->sum / state->size;
+}
+
+static uint16_t adcVrefintValue;
+static uint16_t adcVrefintValues[8];
+movingAverageStateUint16_t adcVrefintAverageState = { 0, adcVrefintValues, 8, 0 } ;
+
+static uint16_t adcTempsensorValue;
+static uint16_t adcTempsensorValues[8];
+movingAverageStateUint16_t adcTempsensorAverageState = { 0, adcTempsensorValues, 8, 0 } ;
+
+static int16_t coreTemperature;
+
+uint16_t getVrefMv(void)
+{
+#ifdef ADC_VOLTAGE_REFERENCE_MV
+    return ADC_VOLTAGE_REFERENCE_MV;
+#else
+    return 3300 * adcVrefintValue / adcVREFINTCAL;
+#endif
+}
+
+uint16_t getCoreTemperatureCelsius(void)
+{
+    return coreTemperature;
+}
+
+void adcInternalProcess(timeUs_t currentTimeUs)
+{
+    UNUSED(currentTimeUs);
+
+    if (adcInternalIsBusy()) {
+        return;
+    }
+
+    uint16_t vrefintSample = adcInternalReadVrefint();
+    uint16_t tempsensorSample = adcInternalReadTempsensor();
+
+    adcVrefintValue = updateMovingAverageUint16(&adcVrefintAverageState, vrefintSample);
+    adcTempsensorValue = updateMovingAverageUint16(&adcTempsensorAverageState, tempsensorSample);
+
+    int32_t adcTempsensorAdjusted = (int32_t)adcTempsensorValue * 3300 / getVrefMv();
+    coreTemperature = ((adcTempsensorAdjusted - adcTSCAL1) * adcTSSlopeK + 30 * 1000 + 500) / 1000;
+
+    DEBUG_SET(DEBUG_CORE_TEMP, 0, coreTemperature);
+
+    adcInternalStartConversion(); // Start next conversion
+}
+
+void adcInternalInit(void)
+{
+    // Call adcInternalProcess repeatedly to fill moving average array
+    for (int i = 0 ; i < 9 ; i++) {
+        while (adcInternalIsBusy()) {
+            // empty
+        }
+        adcInternalProcess(0);
+    }
+}
+#else
+uint16_t getVrefMv(void)
+{
+#ifdef ADC_VOLTAGE_REFERENCE_MV
+    return ADC_VOLTAGE_REFERENCE_MV;
+#else
+    return 3300;
+#endif
+}
+#endif

--- a/src/main/sensors/adcinternal.h
+++ b/src/main/sensors/adcinternal.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drivers/time.h"
+
+void adcInternalInit(void);
+void adcInternalProcess(timeUs_t currentTimeUs);
+uint16_t getCoreTemperatureCelsius(void);
+uint16_t getVrefMv(void);

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -32,6 +32,7 @@
 #include "pg/pg_ids.h"
 #include "config/config_reset.h"
 
+#include "sensors/adcinternal.h"
 #include "sensors/current.h"
 #include "sensors/esc_sensor.h"
 
@@ -77,8 +78,6 @@ void currentMeterReset(currentMeter_t *meter)
 // ADC/Virtual shared
 //
 
-#define ADCVREF 3300   // in mV
-
 #define IBAT_LPF_FREQ  0.4f
 static biquadFilter_t adciBatFilter;
 
@@ -106,7 +105,7 @@ static int32_t currentMeterADCToCentiamps(const uint16_t src)
 
     const currentSensorADCConfig_t *config = currentSensorADCConfig();
 
-    int32_t millivolts = ((uint32_t)src * ADCVREF) / 4096;
+    int32_t millivolts = ((uint32_t)src * getVrefMv()) / 4096;
     // y=x/m+b m is scale in (mV/10A) and b is offset in (mA)
     int32_t centiAmps = (millivolts * 10000 / (int32_t)config->scale + (int32_t)config->offset) / 10;
 

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -31,6 +31,7 @@
 #include "fc/runtime_config.h"
 
 #include "sensors/sensors.h"
+#include "sensors/adcinternal.h"
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
 #include "sensors/gyro.h"
@@ -63,6 +64,10 @@ bool sensorsAutodetect(void)
 
 #ifdef USE_RANGEFINDER
     rangefinderInit();
+#endif
+
+#ifdef USE_ADC_INTERNAL
+    adcInternalInit();
 #endif
 
     return gyroDetected;

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -33,6 +33,7 @@
 #include "pg/pg_ids.h"
 #include "config/config_reset.h"
 
+#include "sensors/adcinternal.h"
 #include "sensors/voltage.h"
 #include "sensors/esc_sensor.h"
 
@@ -138,7 +139,7 @@ STATIC_UNIT_TESTED uint16_t voltageAdcToVoltage(const uint16_t src, const voltag
 {
     // calculate battery voltage based on ADC reading
     // result is Vbatt in 0.1V steps. 3.3V = ADC Vref, 0xFFF = 12bit adc, 110 = 10:1 voltage divider (10k:1k) * 10 for 0.1V
-    return ((((uint32_t)src * config->vbatscale * 33 + (0xFFF * 5)) / (0xFFF * config->vbatresdivval)) / config->vbatresdivmultiplier);
+    return ((((uint32_t)src * config->vbatscale * getVrefMv() / 100 + (0xFFF * 5)) / (0xFFF * config->vbatresdivval)) / config->vbatresdivmultiplier);
 }
 
 void voltageMeterADCRefresh(void)

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -237,6 +237,8 @@
 
 #define USE_ADC
 #define ADC_INSTANCE            ADC2
+//#define ADC_INSTANCE            ADC1
+
 #define CURRENT_METER_ADC_PIN   PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
 #define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
 #ifdef DYSF4PRO

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -51,6 +51,8 @@
 #define I2C3_OVERCLOCK true
 #define USE_TELEMETRY_IBUS
 #define USE_GYRO_DATA_ANALYSE
+#define USE_ADC
+#define USE_ADC_INTERNAL
 #endif
 
 #ifdef STM32F722xx


### PR DESCRIPTION
The VREF voltage used for reference voltage for ADC is assumed to be 3.3V, but it actually differs from board to board. The difference is caused by circuit design, errors in feedback resistors, temperature shifts, and even by design. This PR enables firmware to measure VREF voltage for the board using internal band gap voltage and provide better basis for all ADC measurements (voltage, current, RSSI).

The implementation will provide an internal thermometer reading as an added bonus.

One side effect of this feature is that scales for voltage and current meters would change. Calibrations for these values might be redone. 

---
This is a version that uses a task to poll both internal sensors, at very low rate.

There is another version, #4707, which uses DMA along side with other ADC sources to continuously convert VREFINT and temperature sensor. The #4707, as a PoC, can only work if main ADC is ADC1, but it is not very hard to extend it for cases in which main ADC being other than ADC1.

Points of comparison

- DMA bus cycles (rate matters)
- Extra task and instructions
- Code footprint
- Elegance

Thoughts?
  