### PR TITLE
Change in servo enumeration for airplanes

### DIFF
--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -44,11 +44,11 @@ enum {
 typedef enum {
     SERVO_GIMBAL_PITCH = 0,
     SERVO_GIMBAL_ROLL = 1,
-    SERVO_FLAPS = 2,
-    SERVO_FLAPPERON_1 = 3,
-    SERVO_FLAPPERON_2 = 4,
-    SERVO_RUDDER = 5,
-    SERVO_ELEVATOR = 6,
+    SERVO_FLAPPERON_1 = 2,
+    SERVO_FLAPPERON_2 = 3,
+    SERVO_RUDDER = 4,
+    SERVO_ELEVATOR = 5,
+    SERVO_FLAPS = 6,
     SERVO_THROTTLE = 7, // for internal combustion (IC) planes
 
     SERVO_BICOPTER_LEFT = 4,
@@ -69,7 +69,7 @@ typedef enum {
 
 } servoIndex_e; // FIXME rename to servoChannel_e
 
-#define SERVO_PLANE_INDEX_MIN SERVO_FLAPS
+#define SERVO_PLANE_INDEX_MIN SERVO_FLAPPERON_1
 #define SERVO_PLANE_INDEX_MAX SERVO_THROTTLE
 
 #define SERVO_DUALCOPTER_INDEX_MIN SERVO_DUALCOPTER_LEFT


### PR DESCRIPTION
- Change in the servo enumeration for airplanes. 

Needed to get the following FC output to servo assignement, like the airplane model picture in the configurator :  

- Output 1 => Motor 1
- Output 2 => Motor 2
- Output 3 => Flaperon 1
- Output 4 => Flaperon 2
- Output 5 => Rudder
- Output 6 => Elevator

![airplane_mixer](https://user-images.githubusercontent.com/17528067/34481851-b08454a2-efb4-11e7-9602-598c4d69d2fd.png)