### PR TITLE
Overlooked USE_SONAR to USE_RANGEFINDER

### DIFF
--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -63,8 +63,8 @@
 #endif
 #endif
 
-// undefine USE_ALT_HOLD if there is no baro or sonar to support it
-#if defined(USE_ALT_HOLD) && !defined(USE_BARO) && !defined(USE_SONAR)
+// undefine USE_ALT_HOLD if there is no baro or rangefinder to support it
+#if defined(USE_ALT_HOLD) && !defined(USE_BARO) && !defined(USE_RANGEFINDER)
 #undef USE_ALT_HOLD
 #endif
 


### PR DESCRIPTION
`USE_SONAR` in terms of altimeter is now called `USE_RANGEFINDER`.

 Btw, device-wise `USE_SONAR` is now `USE_RANGEFINDER_HCSR04`.