### PR TITLE
Fast Kalman Gyro Filter: Implementation and parameter groups only

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -53,6 +53,15 @@ typedef struct firFilterDenoise_s {
     float state[MAX_FIR_DENOISE_WINDOW_SIZE];
 } firFilterDenoise_t;
 
+typedef struct fastKalman_s {
+    float q;       // process noise covariance
+    float r;       // measurement noise covariance
+    float p;       // estimation error covariance matrix
+    float k;       // kalman gain
+    float x;       // state
+    float lastX;   // previous state
+} fastKalman_t;
+
 typedef enum {
     FILTER_PT1 = 0,
     FILTER_BIQUAD,
@@ -86,6 +95,9 @@ void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint32_t refre
 float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
 float biquadFilterApply(biquadFilter_t *filter, float input);
 float filterGetNotchQ(uint16_t centerFreq, uint16_t cutoff);
+
+void fastKalmanInit(fastKalman_t *filter, float q, float r, float p);
+float fastKalmanUpdate(fastKalman_t *filter, float input);
 
 // not exactly correct, but very very close and much much faster
 #define filterGetNotchQApprox(centerFreq, cutoff)   ((float)(cutoff * centerFreq) / ((float)(centerFreq - cutoff) * (float)(centerFreq + cutoff)))

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -356,6 +356,11 @@ const clivalue_t valueTable[] = {
     { "gyro_notch1_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_1) },
     { "gyro_notch2_hz",             VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_hz_2) },
     { "gyro_notch2_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_2) },
+#if defined(USE_GYRO_FAST_KALMAN)
+    { "gyro_kalman_q",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_kalman_q) },
+    { "gyro_kalman_r",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_kalman_r) },
+    { "gyro_kalman_p",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_kalman_p) },
+#endif
     { "moron_threshold",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold) },
 #ifdef USE_GYRO_OVERFLOW_CHECK
     { "gyro_overflow_detect",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_OVERFLOW_CHECK }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, checkOverflow) },

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -70,6 +70,9 @@ typedef struct gyroConfig_s {
     uint16_t gyro_soft_notch_hz_2;
     uint16_t gyro_soft_notch_cutoff_2;
     gyroOverflowCheck_e checkOverflow;
+    uint16_t gyro_kalman_q;
+    uint16_t gyro_kalman_r;
+    uint16_t gyro_kalman_p;
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -170,4 +170,5 @@
 #define USE_NAV
 #define USE_TELEMETRY_IBUS
 #define USE_UNCOMMON_MIXERS
+#define USE_GYRO_FAST_KALMAN
 #endif


### PR DESCRIPTION
As per https://github.com/betaflight/betaflight/pull/4887#issuecomment-354937159 here we have @rs2k's Fast Kalman implementation and parameter group to suit. Note that it is disabled by default. I also incorporated all of the feedback from the previous PR.

Signed-off-by: AJ Christensen <aj@junglistheavy.industries>

