### PR TITLE
BetaFlighF3, Motors 2 and 3 fail with DMAR on Dshot600. Disabled DMAR.

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.h
+++ b/src/main/target/BETAFLIGHTF3/target.h
@@ -31,7 +31,8 @@
 #define BEEPER                  PC15
 #define BEEPER_INVERTED
 
-#define USE_DSHOT_DMAR
+#define USE_DSHOT_DMA
+#undef USE_DSHOT_DMAR
 
 #define USABLE_TIMER_CHANNEL_COUNT 10
 


### PR DESCRIPTION
Fix for issue #4896 
Motors 2 and 3 fails on BETAFLIGHTF3 with DMAR, introduced by PR #4852 
