### PR TITLE
RaceFlight Rates: Initial implementation and parameter groups

### DIFF
--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -50,7 +50,17 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .tpa_breakpoint = 1650,
             .rates[FD_ROLL] = 70,
             .rates[FD_PITCH] = 70,
-            .rates[FD_YAW] = 70
+            .rates[FD_YAW] = 70,
+            .rfRatesEnabled = 0,
+            .rfRate[FD_ROLL] = 400,
+            .rfAcro[FD_ROLL] = 140,
+            .rfExpo[FD_ROLL] = 50,
+            .rfRate[FD_PITCH] = 400,
+            .rfAcro[FD_PITCH] = 140,
+            .rfExpo[FD_PITCH] = 50,
+            .rfRate[FD_YAW] = 400,
+            .rfAcro[FD_YAW] = 140,
+            .rfExpo[FD_YAW] = 50
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -33,6 +33,10 @@ typedef struct controlRateConfig_s {
     uint8_t dynThrPID;
     uint8_t rcYawExpo8;
     uint16_t tpa_breakpoint;                // Breakpoint where TPA is activated
+    uint8_t rfRatesEnabled;
+    uint16_t rfRate[3];
+    uint8_t rfAcro[3];
+    uint8_t rfExpo[3];
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -560,6 +560,16 @@ const clivalue_t valueTable[] = {
     { "yaw_srate",                  VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, CONTROL_RATE_CONFIG_YAW_RATE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rates[FD_YAW]) },
     { "tpa_rate",                   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, CONTROL_RATE_CONFIG_TPA_MAX}, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, dynThrPID) },
     { "tpa_breakpoint",             VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, tpa_breakpoint) },
+    { "rf_rates_enabled",           VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfRatesEnabled) },
+    { "rf_rate_roll",               VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmax = { 200, 1500 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfRate[FD_ROLL]) },
+    { "rf_acro_roll",               VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 255 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfAcro[FD_ROLL]) },
+    { "rf_expo_roll",               VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfExpo[FD_ROLL]) },
+    { "rf_rate_pitch",              VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmax = { 200, 1500 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfRate[FD_PITCH]) },
+    { "rf_acro_pitch",              VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 255 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfAcro[FD_PITCH]) },
+    { "rf_expo_pitch",              VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfExpo[FD_PITCH]) },
+    { "rf_rate_yaw",                VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmax = { 200, 1500 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfRate[FD_YAW]) },
+    { "rf_acro_yaw",                VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 255 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfAcro[FD_YAW]) },
+    { "rf_expo_yaw",                VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rfExpo[FD_YAW]) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },


### PR DESCRIPTION
Per https://github.com/betaflight/betaflight/pull/4887#issuecomment-354937159, here we have the RaceFlight Rates system and parameter group. Please read through the following list of remaining items and keep them in mind while reviewing. A number of changes are required here by my reckoning.

* This implementation will require some changes (per the other PR), I think to
  start:
  * Figure out how to make use of a FEATURE if possible
  * See if we can use the existing parameter group RC Rate and such
   Obviously, we have the problem where there is only 'RC Rate' as opposed to
   'RC Rate Pitch' and 'RC Rate Roll'
  * See if we can use the exiting parameter group for at least, expo, potentially
   acro+. Basically, while the RaceFlight Rates feature is on, do things differently.
* Reorganize the controlrate_profile struct so that the uint8_t are towards the
  end (so there is no filler in the struct.)
* Rewrite the rcCommandF assignment so that it is clearer to read.