### PR TITLE
Add definition of temperature ADC sensor channel for STM32F446xx

### DIFF
--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -40,6 +40,10 @@
 
 #include "pg/adc.h"
 
+// These are missing from STM32F4xx_StdPeriph_Driver/inc/stm32f4xx_adc.h
+#ifdef STM32F446xx
+#define ADC_Channel_TempSensor ADC_Channel_18
+#endif
 
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = ADC1_DMA_STREAM, .channel = DMA_Channel_0 },

--- a/src/main/target/NUCLEOF446RE/target.h
+++ b/src/main/target/NUCLEOF446RE/target.h
@@ -131,6 +131,7 @@
 
 #define USE_ADC
 #define ADC_INSTANCE            ADC1
+//#define ADC_INSTANCE            ADC2
 #define VBAT_ADC_PIN            PC0
 #define CURRENT_METER_ADC_PIN   PC1
 #define RSSI_ADC_PIN            PC2

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -51,10 +51,7 @@
 #define I2C3_OVERCLOCK true
 #define USE_GYRO_DATA_ANALYSE
 #define USE_ADC
-#if !defined(STM32F446xx)
-// This needs a library / pathing fix first
 #define USE_ADC_INTERNAL
-#endif
 #endif // STM32F4
 
 #ifdef STM32F722xx


### PR DESCRIPTION
Fixes #4929 

Still having some problem with initialization regarding ADC1 instance with no channel active. There was a fix in #4926, but seems like there is another edge case. I will look into it.
EDIT
Fixed it. #4934