### PR TITLE
Initial implementation of Runaway Takeoff Prevention (anti-taz)

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -56,4 +56,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RANGEFINDER_QUALITY",
     "LIDAR_TF",
     "CORE_TEMP",
+    "RUNAWAY_TAKEOFF",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -74,6 +74,7 @@ typedef enum {
     DEBUG_RANGEFINDER_QUALITY,
     DEBUG_LIDAR_TF,
     DEBUG_CORE_TEMP,
+    DEBUG_RUNAWAY_TAKEOFF,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -195,6 +195,14 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
             else {
                 beeper(BEEPER_DISARM_REPEAT);     // sound tone while stick held
                 repeatAfter(STICK_AUTOREPEAT_MS); // disarm tone will repeat
+
+#ifdef USE_RUNAWAY_TAKEOFF
+                // Unset the ARMING_DISABLED_RUNAWAY_TAKEOFF arming disabled flag that might have been set
+                // by a runaway pidSum detection auto-disarm.
+                // This forces the pilot to explicitly perform a disarm sequence (even though we're implicitly disarmed)
+                // before they're able to rearm
+                unsetArmingDisabled(ARMING_DISABLED_RUNAWAY_TAKEOFF);
+#endif
             }
         }
         return;

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -32,7 +32,7 @@ static uint32_t enabledSensors = 0;
 const char *armingDisableFlagNames[]= {
     "NOGYRO", "FAILSAFE", "RXLOSS", "BADRX", "BOXFAILSAFE",
     "THROTTLE", "ANGLE", "BOOTGRACE", "NOPREARM", "LOAD",
-    "CALIB", "CLI", "CMS", "OSD", "BST", "MSP", "ARMSWITCH"
+    "CALIB", "CLI", "CMS", "OSD", "BST", "MSP", "RUNAWAY", "ARMSWITCH"
 };
 
 static armingDisableFlags_e armingDisableFlags = 0;

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -51,10 +51,12 @@ typedef enum {
     ARMING_DISABLED_OSD_MENU        = (1 << 13),
     ARMING_DISABLED_BST             = (1 << 14),
     ARMING_DISABLED_MSP             = (1 << 15),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 16), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_RUNAWAY_TAKEOFF = (1 << 16),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 17), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
-#define ARMING_DISABLE_FLAGS_COUNT 17
+#define ARMING_DISABLE_FLAGS_COUNT 18
+
 extern const char *armingDisableFlagNames[ARMING_DISABLE_FLAGS_COUNT];
 
 void setArmingDisabled(armingDisableFlags_e flag);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -69,9 +69,21 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 1);
 #else
 #define PID_PROCESS_DENOM_DEFAULT       2
 #endif
+
+#ifdef USE_RUNAWAY_TAKEOFF
+PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
+    .pid_process_denom = PID_PROCESS_DENOM_DEFAULT,
+    .runaway_takeoff_prevention = true,
+    .runaway_takeoff_threshold = 60,            // corresponds to a pidSum value of 60% (raw 600) in the blackbox viewer
+    .runaway_takeoff_activate_delay = 75,       // 75ms delay before activation (pidSum above threshold time)
+    .runaway_takeoff_deactivate_throttle = 25,  // throttle level % needed to accumulate deactivation time
+    .runaway_takeoff_deactivate_delay = 500     // Accumulated time (in milliseconds) before deactivation in successful takeoff
+);
+#else
 PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
     .pid_process_denom = PID_PROCESS_DENOM_DEFAULT
 );
+#endif
 
 PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, MAX_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 2);
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -113,6 +113,11 @@ PG_DECLARE_ARRAY(pidProfile_t, MAX_PROFILE_COUNT, pidProfiles);
 
 typedef struct pidConfig_s {
     uint8_t pid_process_denom;              // Processing denominator for PID controller vs gyro sampling rate
+    uint8_t runaway_takeoff_prevention;          // off, on - enables pidsum runaway disarm logic
+    uint8_t runaway_takeoff_threshold;           // runaway pidsum trigger threshold
+    uint8_t runaway_takeoff_activate_delay;      // delay in ms where pidSum is above threshold before activation
+    uint16_t runaway_takeoff_deactivate_delay;   // delay in ms for "in-flight" conditions before deactivation (successful flight)
+    uint8_t runaway_takeoff_deactivate_throttle; // minimum throttle percent required during deactivation phase
 } pidConfig_t;
 
 PG_DECLARE(pidConfig_t, pidConfig);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -605,6 +605,13 @@ const clivalue_t valueTable[] = {
 
 // PG_PID_CONFIG
     { "pid_process_denom",          VAR_UINT8  | MASTER_VALUE,  .config.minmax = { 1, MAX_PID_PROCESS_DENOM }, PG_PID_CONFIG, offsetof(pidConfig_t, pid_process_denom) },
+#ifdef USE_RUNAWAY_TAKEOFF
+    { "runaway_takeoff_prevention", VAR_UINT8  | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_prevention) },    // enables/disables runaway takeoff prevention
+    { "runaway_takeoff_threshold",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 30, 100 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_threshold) },          // pidSum limit to trigger prevention
+    { "runaway_takeoff_activate_delay",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 255 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_activate_delay) }, // time in ms where pidSum is above threshold to trigger prevention
+    { "runaway_takeoff_deactivate_delay",  VAR_UINT16  | MASTER_VALUE, .config.minmax = { 100, 5000 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_delay) },           // deactivate time in ms
+    { "runaway_takeoff_deactivate_throttle_percent",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_throttle) }, // minimum throttle percentage during deactivation phase
+#endif
 
 // PG_PID_PROFILE
     { "dterm_lowpass_type",         VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_LOWPASS_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_filter_type) },

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -123,6 +123,7 @@
 #define USE_TELEMETRY_SMARTPORT
 #define USE_RESOURCE_MGMT
 #define USE_SERVOS
+#define USE_RUNAWAY_TAKEOFF     // Runaway Takeoff Prevention (anti-taz)
 #endif
 
 #if (FLASH_SIZE > 128)

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -64,6 +64,7 @@ extern "C" {
     gpsSolutionData_t gpsSol;
     uint32_t targetPidLooptime;
     bool cmsInMenu = false;
+    float axisPID_P[3], axisPID_I[3], axisPID_D[3], axisPIDSum[3];
     rxRuntimeConfig_t rxRuntimeConfig = {};
 }
 

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -50,12 +50,17 @@ extern "C" {
     #include "fc/rc_adjustments.h"
 
     #include "fc/rc_controls.h"
+    #include "fc/runtime_config.h"
 
     #include "scheduler/scheduler.h"
 }
 
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
+
+void unsetArmingDisabled(armingDisableFlags_e flag) {
+  UNUSED(flag);
+}
 
 class RcControlsModesTest : public ::testing::Test {
 protected:


### PR DESCRIPTION
Addresses https://github.com/betaflight/betaflight/issues/4815

Detects runaway pidSum values and auto-disarms to prevent the "Tasmanian Devil" caused by incorrect props, wrong motor order/direction, incorrect flight controller orientation, etc.  After a successful takeoff and normal flight is detected the feature is disabled for the remainder of the battery.

For the initial implementation there are a lot of CLI parameters that adjust the trigger and deactivation behavior.  After testing I expect that some of the parameters will be removed and replaced with hard-coded optimum values.

The following parameters relate to the triggering phase:

**runaway_takeoff_prevention** - ON/OFF (default ON).

**runaway_takeoff_threshold** - The pidSum threshold limit on any axis required to trigger prevention (default 60 - equates to 60% in blackbox or 600 raw value).

**runaway_takeoff_activate_delay** - The amount of time in milliseconds that the pidSum must be above the threshold for triggering (default 75).

The remaining parameters are used to determine "successful flight" and deactivate the feature for the remainder of the battery.  The deactivation works by accumulating in-flight time if a number of conditions are met.  Once this accumulated time reaches the configured value, the prevention is deactivated.  This way crashes or gate clips won't trigger a disarm.  We're looking for the throttle level, activity on the sticks, and the pidSum staying low.

**runaway_takeoff_deactivate_throttle_percent** - The minimum throttle percentage required to accumulate in-flight time (default 25).

~~**runaway_takeoff_deactivate_pidlimit** - The pidSum on every axis must be below this limit (default 10).~~  **Parameter removed (hard-coded to 10).**

~~**runaway_takeoff_deactivate_stick_percent** - The minimum stick deflection percentage for any axis (default 15).~~ **Parameter removed (hard-coded to 15).**

**runaway_takeoff_deactivate_delay** - The accumulated time limit for deactivation in milliseconds (default 500 meaning 0.5 seconds).

For testing there is a new debug mode added: `set debug_mode = RUNAWAY_TAKEOFF`

debug[0] - boolean indicating whether the feature is active and in detection mode

debug[1] - boolean indicating whether the pidSum has exceeded the threshold and we are in a countdown for runaway_takeoff_activate_delay milliseconds.

debug[2] - boolean indicating that the criteria for deactivation has been met and we are accumulating in-flight time.

debug[3] - number indicating the in-flight milliseconds accumulated so far.  Once this reaches runaway_takeoff_deactivate_delay the feature will be disabled.

Some caveats/known issues:

1. ~~3D mode is not properly supported yet.  Triggering will work but deactivation will happen early because the throttle percentage is not taking into account the dual direction.  This will be fixed.~~   **3D support fixed.**

2. It's possible to trigger the disarm by crashing immediately after liftoff before the deactivation occurs.  You will be able to rearm.  Although it's generally resistant, severe bouncing on takeoff could also trigger the disarm.  Increasing the runaway_takeoff_activate_delay can help with this at the risk of making the triggering during a real event slower and possibly less effective.

3. Arming with no props on and then significantly moving the sticks could trigger a disarm.  This is because the pidSum values are growing to large values because the quad is not responding to the command inputs.  There's nothing wrong with this but it's a point to make clear to avoid confusion.