### PR TITLE
Prepare OSD for iterative updating

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -29,6 +29,8 @@
 // Satellite Graphics
 #define SYM_SAT_L 0x1E
 #define SYM_SAT_R 0x1F
+#define SYM_HDP_L 0xBD
+#define SYM_HDP_R 0xBE
 //#define SYM_SAT 0x0F  // Not used
 
 // Degrees Icon for HEADING/DIRECTION HOME
@@ -104,6 +106,7 @@
 #define SYM_GMISSION1 0xB6
 #define SYM_GLAND     0xB7
 #define SYM_GLAND1    0xB8
+#define SYM_HOME_DIST 0xA0
 
 // Gimbal active Mode
 #define SYM_GIMBAL  0x16
@@ -202,6 +205,7 @@
 #define SYM_FLY_M 0x9C
 #define SYM_ON_H  0x70
 #define SYM_FLY_H 0x71
+#define SYM_CLOCK 0xBC
 
 // Throttle Position (%)
 #define SYM_THR   0x04
@@ -215,6 +219,8 @@
 
 //Misc
 #define SYM_COLON 0x2D
+#define SYM_ZERO_HALF_TRAILING_DOT 0xC0
+#define SYM_ZERO_HALF_LEADING_DOT 0xD0
 
 //sport
 #define SYM_MIN 0xB3

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -139,10 +139,10 @@ void doTestArm(bool testEmpty = true)
  */
 bool isSomeStatEnabled(void) {
     for (int i = 0; i < OSD_STAT_COUNT; i++) {
-            if (osdConfigMutable()->enabled_stats[i]) {
-                return true;
-            }
+        if (osdConfigMutable()->enabled_stats[i]) {
+            return true;
         }
+    }
     return false;
 }
 
@@ -544,7 +544,7 @@ TEST(OsdTest, TestElementRssi)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(8, 1, "%c0", SYM_RSSI);
+    displayPortTestBufferSubstring(8, 1, "%c 0", SYM_RSSI);
 
     // when
     rssi = 512;

--- a/src/test/unit/unittest_displayport.h
+++ b/src/test/unit/unittest_displayport.h
@@ -143,6 +143,12 @@ void displayPortTestBufferIsEmpty()
 {
     for (size_t i = 0; i < UNITTEST_DISPLAYPORT_BUFFER_LEN; i++) {
         EXPECT_EQ(' ', testDisplayPortBuffer[i]);
+        if (testDisplayPortBuffer[i] != ' ') {
+            testDisplayPortBuffer[UNITTEST_DISPLAYPORT_BUFFER_LEN - 1] = '\0';
+            printf("FIRST ERROR AT:%d\r\n", (int)i);
+            printf("DISPLAY:%s\r\n", testDisplayPortBuffer);
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
Change `osdDrawSingleElement` so each item draws itself fully, and does not rely on the screen being cleared before it is drawn.

This will allow iterative updating, ie each time around the update loop one item is drawn, rather than clearing the screen and drawing all the items.

This means:
1.  OSD update takes less time, and so causes less jitter in the main PID loop.
2. Micro MinimOSD will be more responsive

This change is all ready implemented in iNav.