### PR TITLE
Added new target MATEKF405MINI

### DIFF
--- a/src/main/target/MATEKF405/MATEKF405MINI.mk
+++ b/src/main/target/MATEKF405/MATEKF405MINI.mk
@@ -1,0 +1,1 @@
+# MATEKF405MINI is a variant of MATEKF405 but with 32M Flash instead of Micro SD Slot

--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -92,10 +92,15 @@
 #define SPI3_MISO_PIN           PB4
 #define SPI3_MOSI_PIN           PB5
 
+#ifdef MATEKF405MINI
+// *************** Flash ****************************
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 #define M25P16_CS_PIN           PC0
 #define M25P16_SPI_INSTANCE     SPI3
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#else
 
 // *************** SD Card **************************
 #define USE_SDCARD
@@ -113,6 +118,7 @@
 #define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA_FLAG_TCIF7
 #define SDCARD_DMA_CLK                      RCC_AHB1Periph_DMA1
 #define SDCARD_DMA_CHANNEL                  DMA_Channel_0
+#endif
 
 // *************** OSD *****************************
 #define USE_SPI_DEVICE_2

--- a/src/main/target/MATEKF405/target.mk
+++ b/src/main/target/MATEKF405/target.mk
@@ -1,5 +1,9 @@
 F405_TARGETS    += $(TARGET)
-FEATURES        += VCP ONBOARDFLASH SDCARD
+ifeq ($(TARGET), MATEKF405MINI)
+FEATURES        += VCP ONBOARDFLASH
+else
+FEATURES        += VCP SDCARD
+endif
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6500.c \


### PR DESCRIPTION
this added a new target MATEKF405MINI ... all MATEKF405 FC's using Micro SD Slot only the MATEKF405MINI used 32M Flash ... this pr makes flash support only for the MATEKF405MINI and removed Micro SD Slot support from the MATEKF405MINI  and also removed flash support from MATEKF405 ... also this save spaces on both target's