### PR TITLE
DSHOT Avoid dup initialization of timer and DMA?

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -45,14 +45,16 @@ motorDmaOutput_t *getMotorDmaOutput(uint8_t index)
     return &dmaMotors[index];
 }
 
-uint8_t getTimerIndex(TIM_TypeDef *timer)
+uint8_t getTimerIndex(TIM_TypeDef *timer, bool *newTimer)
 {
     for (int i = 0; i < dmaMotorTimerCount; i++) {
         if (dmaMotorTimers[i].timer == timer) {
+            *newTimer = false;
             return i;
         }
     }
     dmaMotorTimers[dmaMotorTimerCount++].timer = timer;
+    *newTimer = true;
     return dmaMotorTimerCount-1;
 }
 
@@ -144,8 +146,8 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     TIM_TypeDef *timer = timerHardware->tim;
     const IO_t motorIO = IOGetByTag(timerHardware->tag);
 
-    const uint8_t timerIndex = getTimerIndex(timer);
-    const bool configureTimer = (timerIndex == dmaMotorTimerCount-1);
+    bool configureTimer;
+    const uint8_t timerIndex = getTimerIndex(timer, &configureTimer);
 
     IOConfigGPIOAF(motorIO, IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_UP), timerHardware->alternateFunction);
 

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -55,7 +55,7 @@ uint8_t getTimerIndex(TIM_TypeDef *timer, bool *newTimer)
     }
     dmaMotorTimers[dmaMotorTimerCount++].timer = timer;
     *newTimer = true;
-    return dmaMotorTimerCount-1;
+    return dmaMotorTimerCount - 1;
 }
 
 void pwmWriteDshotInt(uint8_t index, uint16_t value)

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -48,7 +48,7 @@ uint8_t getTimerIndex(TIM_TypeDef *timer, bool *newTimer)
     }
     dmaMotorTimers[dmaMotorTimerCount++].timer = timer;
     *newTimer = true;
-    return dmaMotorTimerCount-1;
+    return dmaMotorTimerCount - 1;
 }
 
 void pwmWriteDshotInt(uint8_t index, uint16_t value)


### PR DESCRIPTION
For Discussion.

Timers (not channels) and DMA are always initialized because `const bool configureTimer = (timerIndex == dmaMotorTimerCount-1);` has been always true, causing duplicate initialization of timers and DMAs.

To fix this, `getTimerIndex`, which registers and returns index of a given timer in `dmaMotorTimers` array, was amended to return if the timer was newly registered.

The HAL variant, however, does not use the `configureTimer`.

Then I begin to think if we can intentionally allow dup initializations to happen because the initializations are idempotent and will save some flash space...

Thoughts?