### PR TITLE
BFF3 DMAR compatibility fix

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.c
+++ b/src/main/target/BETAFLIGHTF3/target.c
@@ -29,19 +29,18 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM4,  CH2,  PB7, TIM_USE_PPM,                 0), // PPM  DMA(1,4)
 
     // Motors 1-4
-    DEF_TIM(TIM16, CH1,  PA6, TIM_USE_MOTOR,               0), // PWM1 DMA(1,6)
-    DEF_TIM(TIM8,  CH1N, PA7, TIM_USE_MOTOR,               0), // PWM2 DMA(2,3)
-    DEF_TIM(TIM8,  CH2,  PB8, TIM_USE_MOTOR,               0), // PWM3 DMA(2,5)
-    DEF_TIM(TIM17, CH1,  PB9, TIM_USE_MOTOR,               0), // PWM4 DMA(1,7)
+    DEF_TIM(TIM16, CH1,  PA6, TIM_USE_MOTOR,               0), // PWM1 UP(1,6)
+    DEF_TIM(TIM8,  CH1N, PA7, TIM_USE_MOTOR,               0), // PWM2 UP(2,1)
+    DEF_TIM(TIM8,  CH2,  PB8, TIM_USE_MOTOR,               0), // PWM3 UP(2,1)
+    DEF_TIM(TIM17, CH1,  PB9, TIM_USE_MOTOR,               0), // PWM4 UP(1,7)
 
     // Motors 5-6 or SoftSerial
-    DEF_TIM(TIM3,  CH3,  PB0, TIM_USE_MOTOR,               0), // PWM5 DMA(1,2) !LED
-    DEF_TIM(TIM3,  CH4,  PB1, TIM_USE_MOTOR,               0), // PWM6 DMA(1,3)
+    DEF_TIM(TIM3,  CH3,  PB0, TIM_USE_MOTOR,               0), // PWM5 UP(1,3)
+    DEF_TIM(TIM3,  CH4,  PB1, TIM_USE_MOTOR,               0), // PWM6 UP(1,3)
 
     // Motors 7-8 or UART2
     DEF_TIM(TIM2,  CH4,  PA3, TIM_USE_MOTOR,               0), // PWM7/UART2_RX
     DEF_TIM(TIM2,  CH3,  PA2, TIM_USE_MOTOR,               0), // PWM8/UART2_TX
 
-    // No LED for Hexa-Dshot; DMA conflict with Motor 5 (PB0); consider PPM if not used.
     DEF_TIM(TIM1,  CH1,  PA8, TIM_USE_MOTOR | TIM_USE_LED, 0), // LED  DMA(1,2)
 };

--- a/src/main/target/BETAFLIGHTF3/target.h
+++ b/src/main/target/BETAFLIGHTF3/target.h
@@ -30,7 +30,7 @@
 #define BEEPER                  PC15
 #define BEEPER_INVERTED
 
-#define USE_DSHOT_DMA
+#define USE_DSHOT_DMAR
 
 #define USABLE_TIMER_CHANNEL_COUNT 10
 
@@ -120,6 +120,7 @@
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define USE_ADC
 #define ADC_INSTANCE            ADC2
+#define ADC24_DMA_REMAP
 #define VBAT_ADC_PIN            PA4
 #define CURRENT_METER_ADC_PIN   PA5
 #define RSSI_ADC_PIN            PB2


### PR DESCRIPTION
Avoid DMA channel collision between LED strip and TIM8_UP (motors 2 and 3) by defining `ADC24_DMA_REMAP`.

Evaluation of the DMAR effect on BFF3:
- Not too much efficiency gain (one DMA channel reduction).
- HEXA Dshot does not collide with LED strip now.

Possible improvements, left for future work are:
- Motor 1, 4, 5, 6 can be used to maximize DMAR effect by using TIM3_CH{1,2,3,4}.
- Motor 1 and 4 can be moved to TIM4 for next best effect.