### PR TITLE
Improved arming disabled reason beeps.

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -20,12 +20,13 @@
 
 #include "platform.h"
 
-#include "light_led.h"
-#include "sound_beeper.h"
-#include "drivers/nvic.h"
 #include "build/atomic.h"
 
-#include "drivers/system.h"
+#include "drivers/light_led.h"
+#include "drivers/nvic.h"
+#include "drivers/sound_beeper.h"
+
+#include "system.h"
 
 // cycles per microsecond
 static uint32_t usTicks = 0;
@@ -160,10 +161,6 @@ void delay(uint32_t ms)
         delayMicroseconds(1000);
 }
 
-#define SHORT_FLASH_DURATION 50
-#define SHORT_FLASH_COUNT 5
-#define CODE_FLASH_DURATION 250
-
 static void indicate(uint8_t count, uint16_t duration)
 {
     if (count) {
@@ -187,11 +184,11 @@ static void indicate(uint8_t count, uint16_t duration)
 void indicateFailure(failureMode_e mode, int codeRepeatsRemaining)
 {
     while (codeRepeatsRemaining--) {
-        indicate(SHORT_FLASH_COUNT, SHORT_FLASH_DURATION);
+        indicate(WARNING_FLASH_COUNT, WARNING_FLASH_DURATION_MS);
 
-        delay(500);
+        delay(WARNING_PAUSE_DURATION_MS);
 
-        indicate(mode + 1, CODE_FLASH_DURATION);
+        indicate(mode + 1, WARNING_CODE_DURATION_LONG_MS);
 
         delay(1000);
     }

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -32,6 +32,12 @@ typedef enum {
     FAILURE_GYRO_INIT_FAILED
 } failureMode_e;
 
+#define WARNING_FLASH_DURATION_MS 50
+#define WARNING_FLASH_COUNT 5
+#define WARNING_PAUSE_DURATION_MS 500
+#define WARNING_CODE_DURATION_LONG_MS 250
+#define WARNING_CODE_DURATION_SHORT_MS 50
+
 // failure
 void indicateFailure(failureMode_e mode, int repeatCount);
 void failureMode(failureMode_e mode);


### PR DESCRIPTION
The growing number of arming disable reasons makes counting the number of beeps for the higher up codes hard. Instead of just beeping out a number of beeps, the flight controller now uses a similar beeping pattern than the 'boot failure' reason codes:

- 5 short beeps to get attention;
- a number of longer beeps (same length as boot failure beeps). Each one of these counts for 5 for the arming disabled reason;
- a number of short beeps with long intervals. Each one of these counts for 1.

Adding (5 * numLongBeeps) + numShortBeeps allows the user to calculate the arming disabled reason.