### PR TITLE
Drop global USE_DSHOT_DMAR from F3

### DIFF
--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -41,7 +41,6 @@
 #ifdef STM32F3
 #define MINIMAL_CLI
 #define USE_DSHOT
-#define USE_DSHOT_DMAR
 #define USE_GYRO_DATA_ANALYSE
 #endif
 


### PR DESCRIPTION
I think this change is required for #4859 to work for F3 also.