### PR TITLE
OMNIBUS (F3) Disable DMAR for backward compatibility

### DIFF
--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -29,6 +29,10 @@
 
 #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_NONE
 
+// Can be configured for DMAR, but keep it legacy DSHOT for backward compatibility of
+// Motor x 1 + Servo x 3 on PWM1~4 use case.
+#define USE_DSHOT_DMA
+
 #define LED0_PIN                PB3
 
 #define BEEPER                  PC15


### PR DESCRIPTION
OMNIBUS (F3) can be compatible with DMAR dshot at the cost of sacrificing users of motor x 1 + servo x 3 for first four outputs (PWM1~4).

This PR explicitly keep legacy DMA dshot for backward compatibility.