### PR TITLE
PoC target to show "How (re)configurable it is atm."

### DIFF
--- a/src/main/target/CFGF4OMNI/config.c
+++ b/src/main/target/CFGF4OMNI/config.c
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#ifdef USE_TARGET_CONFIG
+
+#include "io/serial.h"
+
+#include "pg/max7456.h"
+#include "pg/pg.h"
+
+void targetConfiguration(void)
+{
+    int index;
+
+    index = findSerialPortIndexByIdentifier(SERIAL_PORT_USART6);
+    serialConfigMutable()->portConfigs[index].functionMask = FUNCTION_RX_SERIAL;
+}
+#endif

--- a/src/main/target/CFGF4OMNI/config.txt
+++ b/src/main/target/CFGF4OMNI/config.txt
@@ -1,0 +1,137 @@
+resource ppm b8
+
+resource pwm 2 c6
+resource pwm 3 c7
+resource pwm 4 c8
+resource pwm 5 c9
+
+resource motor 1 b0
+resource motor 2 b1
+resource motor 3 a3
+resource motor 4 a2
+
+resource motor 5 a1
+resource motor 6 a8
+
+resource led_strip b6
+
+resource motor 7 a9   # UART1_TX
+resource motor 8 a10  # UART1_RX
+
+#define LED0_PIN                PB5
+#define BEEPER                  PB4
+#define BEEPER_INVERTED
+
+resource inverter 3 c9
+resource inverter 6 c8
+
+#define MPU6500_CS_PIN          MPU6000_CS_PIN
+
+#define USE_MAG
+#define USE_MAG_HMC5883
+#define MAG_HMC5883_ALIGN       CW90_DEG
+
+#define USE_BARO
+
+set baro_hardware = BMP280
+set baro_bustype = SPI
+set baro_spi_device = 3
+resource baro_cs b3
+
+set baro_i2c_device = 2
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PA15
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+set blackbox_device = SDCARD
+
+#define USE_SDCARD
+#define SDCARD_DETECT_INVERTED
+#define SDCARD_DETECT_PIN               PB7
+#define SDCARD_SPI_INSTANCE             SPI2
+#define SDCARD_SPI_CS_PIN               SPI2_NSS_PIN
+// SPI2 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER 4 // 21MHz
+
+#define SDCARD_DMA_CHANNEL_TX                   DMA1_Stream4
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG     DMA_FLAG_TCIF4
+#define SDCARD_DMA_CLK                          RCC_AHB1Periph_DMA1
+#define SDCARD_DMA_CHANNEL                      DMA_Channel_0
+
+#define USE_VCP
+#define VBUS_SENSING_PIN PC5
+
+resource serial_tx 1 a9
+resource serial_rx 1 a10
+
+resource serial_tx 3 b10
+resource serial_rx 3 b11
+
+resource serial_tx 6 c6
+resource serial_rx 6 c7
+
+resource serial_tx 11 none
+resource serial_rx 11 none
+
+resource serial_tx 12 none
+resource serial_rx 12 none
+
+resource ESCSERIAL b8
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+resource spi_sck 1 a5
+resource spi_miso 1 a6
+resource spi_mosi 1 a7
+
+#define USE_SPI_DEVICE_2
+
+resource spi_sck 2 b13
+resource spi_miso 2 b14
+resource spi_mosi 2 b15
+
+#define USE_SPI_DEVICE_3
+resource spi_sck 3 c10
+resource spi_miso 3 c11
+resource spi_mosi 3 c12
+
+#define USE_I2C
+#define USE_I2C_DEVICE_2
+resource i2c_scl 2 none # PB10, shared with UART3TX
+resource i2c_sda 2 none # PB10, shared with UART3RX
+
+#define USE_I2C_DEVICE_3
+resource i2c_scl 3 none # PA8, PWM6
+resource i2c_sda 3 none # PC9, CH6
+
+#define I2C_DEVICE              (I2CDEV_2)
+set baro_i2c_device = 2
+set mag_i2c_device = 2
+set dashboard_i2c_bus = 2
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC2
+//#define ADC_INSTANCE            ADC1
+set adc_device = 2
+
+resource adc_curr c1
+resource adc_batt c2
+resource adc_rssi a0
+
+resource transponder b6
+
+resource sonar_trigger a1
+resource sonar_echo a8
+
+feature rx_serial
+feature osd
+
+set current_meter = ADC
+set battery_meter = ADC

--- a/src/main/target/CFGF4OMNI/target.c
+++ b/src/main/target/CFGF4OMNI/target.c
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+
+    DEF_TIM(TIM10, CH1, PB8,  TIM_USE_NONE, 0, 0), // PPM
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_NONE, 0, 0), // S2_IN
+
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_NONE, 0, 0), // S3_IN, UART6_TX
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_NONE, 0, 0), // S4_IN, UART6_RX
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_NONE, 0, 0), // S5_IN
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_NONE, 0, 0), // S6_IN
+
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_NONE, 0, 0), // S1_OUT D1_ST7
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_NONE, 0, 0), // S2_OUT D1_ST2
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_NONE, 0, 1), // S3_OUT D1_ST6
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_NONE, 0, 0), // S4_OUT D1_ST1
+
+    DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_NONE, 0, 0), // S5_OUT
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_NONE, 0, 0), // LED strip for F4 V2 / F4-Pro-0X and later (RCD_CS for F4)
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_NONE, 0, 0), // S6_OUT
+    DEF_TIM(TIM1,  CH2, PA9,  TIM_USE_NONE, 0, 0), // UART1_TX
+    DEF_TIM(TIM1,  CH3, PA10, TIM_USE_NONE, 0, 0), // UART1_RX
+};

--- a/src/main/target/CFGF4OMNI/target.h
+++ b/src/main/target/CFGF4OMNI/target.h
@@ -1,0 +1,165 @@
+/*
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER "F4OM"
+#define USBD_PRODUCT_STRING "Betaflight F4 Omni"
+
+#define LED0_PIN                PB5
+#define BEEPER                  PB4
+#define BEEPER_INVERTED
+
+#define USE_DSHOT_DMAR
+
+// These inverter control pins collide with timer channels on CH5 and CH6 pads.
+// Users of these timers/pads must un-map the inverter assignment explicitly.
+#define INVERTER_PIN_UART6      NONE // PC8 // Omnibus F4 V3 and later
+#define INVERTER_PIN_UART3      NONE // PC9 // Omnibus F4 Pro Corners
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_INSTANCE    SPI1
+
+// MPU6000 interrupts
+#define USE_EXTI
+#define MPU_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define GYRO_MPU6000_ALIGN       CW270_DEG
+#define ACC_MPU6000_ALIGN        CW270_DEG
+
+// Support for iFlight OMNIBUS F4 V3
+// Has ICM20608 instead of MPU6000
+// OMNIBUSF4SD is linked with both MPU6000 and MPU6500 drivers
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define MPU6500_CS_PIN          MPU6000_CS_PIN
+#define MPU6500_SPI_INSTANCE    MPU6000_SPI_INSTANCE
+#define GYRO_MPU6500_ALIGN      GYRO_MPU6000_ALIGN
+#define ACC_MPU6500_ALIGN       ACC_MPU6000_ALIGN
+
+#define USE_MAG
+#define USE_MAG_HMC5883
+#define MAG_HMC5883_ALIGN       CW90_DEG
+
+#define USE_BARO
+#define USE_BARO_SPI_BMP280
+#define BMP280_SPI_INSTANCE     SPI3
+#define BMP280_CS_PIN           NONE
+#define USE_BARO_BMP085
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define BARO_I2C_INSTANCE       (I2CDEV_2)
+
+#define DEFAULT_BARO_SPI_BMP280
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PA15
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#define USE_SDCARD
+#define SDCARD_DETECT_INVERTED
+#define SDCARD_DETECT_PIN               PB7
+#define SDCARD_SPI_INSTANCE             SPI2
+#define SDCARD_SPI_CS_PIN               PB12
+// SPI2 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER 4 // 21MHz
+
+#define SDCARD_DMA_CHANNEL_TX                   DMA1_Stream4
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG     DMA_FLAG_TCIF4
+#define SDCARD_DMA_CLK                          RCC_AHB1Periph_DMA1
+#define SDCARD_DMA_CHANNEL                      DMA_Channel_0
+
+#define USE_VCP
+#define VBUS_SENSING_PIN PC5
+
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_UART6
+
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+#define SERIAL_PORT_COUNT       9 // VCP, USART1, USART3, UART4, USART6, SOFTSERIAL x 2
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  NONE  // b8 (PPM)
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            NONE // PA5
+#define SPI1_MISO_PIN           NONE // PA6
+#define SPI1_MOSI_PIN           NONE // PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            NONE // PB13
+#define SPI2_MISO_PIN           NONE // PB14
+#define SPI2_MOSI_PIN           NONE // PB15
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            NONE // PC10
+#define SPI3_MISO_PIN           NONE // PC11
+#define SPI3_MOSI_PIN           NONE // PC12
+
+#define USE_I2C
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                NONE // PB10, shared with UART3TX
+#define I2C2_SDA                NONE // PB11, shared with UART3RX
+
+#define USE_I2C_DEVICE_3
+#define I2C3_SCL                NONE // PA8, PWM6
+#define I2C3_SDA                NONE // PC9, CH6
+
+#define I2C_DEVICE              (I2CDEV_2)
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC2
+//#define ADC_INSTANCE            ADC1
+
+#define CURRENT_METER_ADC_PIN   NONE // PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
+#define VBAT_ADC_PIN            NONE // PC2  // 11:1 (10K + 1K) divider
+#define RSSI_ADC_PIN            NONE // PA0  // Direct from RSSI pad
+
+#define USE_TRANSPONDER
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_HCSR04
+#define USE_RANGEFINDER_TF
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
+#define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
+#define TARGET_IO_PORTC (0xffff & ~(BIT(15)|BIT(14)|BIT(13)))
+#define TARGET_IO_PORTD BIT(2)
+
+#define USABLE_TIMER_CHANNEL_COUNT 15
+#define USED_TIMERS ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(10) | TIM_N(12) | TIM_N(8) | TIM_N(9))

--- a/src/main/target/CFGF4OMNI/target.mk
+++ b/src/main/target/CFGF4OMNI/target.mk
@@ -1,0 +1,13 @@
+F405_TARGETS   += $(TARGET)
+//FEATURES       += VCP ONBOARDFLASH
+FEATURES       += VCP SDCARD
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms5611.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/max7456.c
+			


### PR DESCRIPTION
An PoC target to show how (re)configurable BF is atm, prepared for OMNIBUSF4SD compatible boards.

After flashing, pour contents of `config.txt` into CLI and `save`.