### PR TITLE
Add PYRODRONEF4 target

### DIFF
--- a/docs/boards/Board - PyroDroneF4.md
+++ b/docs/boards/Board - PyroDroneF4.md
@@ -1,0 +1,47 @@
+# Board - PYRODRONEF4
+
+The PYRODRONEF4 target is new board developed by http://pirofliprc.com/
+
+* flat bottom.(No component on the bottom)
+* 6 uarts with 4 motor outputs(D-shot supported)
+* uart 1 inverted for sbus(selectable) , uart 3 with inverter for frsky telemetry
+* onboard 5V bec.
+* direct solder pad layout for 4 IN 1 ESC or use 4 in 1 ESC Plug
+* With uart RX pin layout inside the 4 IN 1 ESC plug for use ESC telemetry.
+* USB -VCP
+
+## Serial Ports
+
+| Value | Identifier   | RX   | TX   | Notes                                                                                       |
+| ----- | ------------ | -----| -----| ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PA10 |  PA9 |  |
+| 2     | USART2       | PA3  |  PA2 |                                                                                             |
+| 3     | USART3       | PB11 |  PB10|                                                                                             |
+| 4     | USART4       | PA1  |  PA0 |                                                                                             |
+| 6     | USART5       | PD2  |  PC12|                                                                                             |
+| 6     | USART6       | PC7  |  PC6 |                                                                                             |
+
+## Pinout
+TX1, RX1  -> UART1  sbus pad       (RX1 Use for Sbus has inverter build in)
+TX2, RX2  -> UART2  Esc Telemetry  (use for esc telemetery)
+TX3, RX3  -> UART3	TEL PAD	       (use for frsky temeletery has inverter build in)
+TX4, RX4  -> UART4                 (Free uart)
+TX5, RX5  -> UART5	TX5			   (TX5 use for smart audio, No RX5 pinout )
+TX6, RX6  -> UART5  			   (design to use crossfire rx)
+
+## board label
+vtx_+       VTX power (Vbat)
+vtx_-		VTX ground
+video		VTX Signal
+current     Current sensor input
+bb+         Buzzer +
+bb-			Buzzer -
+m1			Motor 1
+m2			Motor 2
+m3          Motor 3
+m4          Motor 4
+Vbat        Battery input positive
+Gnd			Battery input negative
+Cam_C		Camera control(with build in Resistor and capacitor)
+5V			5v output
+led_s		Led strip signal

--- a/src/main/target/PYRODRONEF4/target.c
+++ b/src/main/target/PYRODRONEF4/target.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+
+    DEF_TIM(TIM11, CH1,  PB9, TIM_USE_ANY,     0, 0), // CAMERA_CONTROL_PIN
+
+    DEF_TIM(TIM3,  CH4,  PB1, TIM_USE_MOTOR,   0, 0),  // M1_OUT - D1_ST2_CH5
+    DEF_TIM(TIM8,  CH2N, PB0, TIM_USE_MOTOR,   0, 0),  // M2_OUT - D2_ST3_CH7
+    DEF_TIM(TIM8,  CH4,  PC9, TIM_USE_MOTOR,   0, 0),  // M3_OUT - D2_ST7_CH7
+    DEF_TIM(TIM1,  CH1,  PA8, TIM_USE_MOTOR,   0, 1),  // M4_OUT - D2_ST1_CH6
+    DEF_TIM(TIM4,  CH3,  PB8, TIM_USE_LED ,    0,  0)    // LED & MOTOR5 D1_ST7_CH2
+};

--- a/src/main/target/PYRODRONEF4/target.h
+++ b/src/main/target/PYRODRONEF4/target.h
@@ -1,0 +1,116 @@
+/*
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#define TARGET_BOARD_IDENTIFIER "PYRO"
+#define USBD_PRODUCT_STRING "PYRODRONEF4"
+
+#define LED0_PIN                  PB4
+#define BEEPER                    PB5
+#define BEEPER_INVERTED
+
+#define INVERTER_PIN_UART1        PC3       // PC3 used as sBUS inverter select GPIO
+#define CAMERA_CONTROL_PIN        PB9       // define dedicated camera_osd_control pin
+
+#define USE_EXTI
+#define MPU_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+
+// DEFINE SPI USAGE
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+//  MPU 6000
+#define MPU6000_CS_PIN            PA4
+#define MPU6000_SPI_INSTANCE      SPI1
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN       CW0_DEG
+#define ACC_MPU6000_ALIGN        CW0_DEG
+
+// DEFINE OSD
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI2
+#define MAX7456_SPI_CS_PIN      PB12
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+
+
+// DEFINE UART AND VCP
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+#define UART1_AHB1_PERIPHERALS  RCC_AHB1Periph_DMA2
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            PC12
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+#define SERIAL_PORT_COUNT       7 //VCP, USART1, USART2,USART3,USART4, USART5,USART6
+
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  PB9  // (HARDARE=0,PPM)
+
+
+
+//DEFINE BATTERY METER 
+#define USE_ADC
+#define CURRENT_METER_ADC_PIN   PC1
+#define VBAT_ADC_PIN            PC2
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_NONE
+#define TRANSPONDER
+
+// DEFINE DEFAULT FEATURE
+#define DEFAULT_RX_FEATURE          FEATURE_RX_SERIAL
+#define DEFAULT_FEATURES            FEATURE_OSD
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
+#define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
+#define TARGET_IO_PORTC (0xffff & ~(BIT(15)|BIT(14)|BIT(13)))
+#define TARGET_IO_PORTD BIT(2)
+
+// DEFINE TIMERS
+#define USABLE_TIMER_CHANNEL_COUNT 6
+#define USED_TIMERS  (  TIM_N(1)  | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(11))

--- a/src/main/target/PYRODRONEF4/target.mk
+++ b/src/main/target/PYRODRONEF4/target.mk
@@ -1,0 +1,7 @@
+F405_TARGETS   += $(TARGET)
+FEATURES       += VCP 
+TARGET_SRC = \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/max7456.c


### PR DESCRIPTION
PYRODRONEF4
feature:
1. flat bottom.(No component on the bottom)
2. 6 uarts with 4 motor outputs(D-shot supported)
3. uart 1 inverted for sbus(selectable) , uart 3 with inverter for frsky telemetry
4. onboard 5V bec.
5. direct solder pad layout for 4 IN 1 ESC or use 4 in 1 ESC Plug 
6. With uart RX pin layout inside the 4 IN 1 ESC plug for use ESC telemetry.

