### PR TITLE
Add hooks for triflight

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -102,8 +102,10 @@ FC_SRC = \
             flight/failsafe.c \
             flight/imu.c \
             flight/mixer.c \
+            flight/mixer_tricopter.c \
             flight/pid.c \
             flight/servos.c \
+            flight/servos_tricopter.c \
             interface/cli.c \
             interface/settings.c \
             io/serial_4way.c \

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -128,3 +128,4 @@ void stopPwmAllMotors(void);
 
 float convertExternalToMotor(uint16_t externalValue);
 uint16_t convertMotorToExternal(float motorValue);
+bool mixerIsTricopter(void);

--- a/src/main/flight/mixer_tricopter.c
+++ b/src/main/flight/mixer_tricopter.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_SERVOS
+
+#include "common/utils.h"
+
+#include "flight/mixer.h"
+#include "flight/mixer_tricopter.h"
+
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+
+
+PG_REGISTER_WITH_RESET_TEMPLATE(tricopterMixerConfig_t, tricopterMixerConfig, PG_TRICOPTER_CONFIG, 0);
+
+PG_RESET_TEMPLATE(tricopterMixerConfig_t, tricopterMixerConfig,
+    .dummy = 0
+);
+
+#define TRICOPTER_ERROR_RATE_YAW_SATURATED 75 // rate at which tricopter yaw axis becomes saturated, determined experimentally by TriFlight
+
+bool mixerTricopterIsServoSaturated(float errorRate)
+{
+    return errorRate > TRICOPTER_ERROR_RATE_YAW_SATURATED;
+}
+
+float mixerTricopterMotorCorrection(int motor)
+{
+    UNUSED(motor);
+    return 0.0f;
+}
+
+void mixerTricopterInit(void)
+{
+
+}
+
+#endif // USE_SERVOS

--- a/src/main/flight/mixer_tricopter.h
+++ b/src/main/flight/mixer_tricopter.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#include "pg/pg.h"
+
+typedef struct tricopterMixerConfig_s {
+    uint8_t dummy;
+} tricopterMixerConfig_t;
+
+PG_DECLARE(tricopterMixerConfig_t, tricopterMixerConfig);
+
+
+bool mixerTricopterIsServoSaturated(float errorRate);
+void mixerTricopterInit(void);
+float mixerTricopterMotorCorrection(int motor);

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -232,6 +232,10 @@ void servosInit(void)
     for (uint8_t i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
         servo[i] = DEFAULT_SERVO_MIDDLE;
     }
+
+    if (mixerIsTricopter()) {
+        servosTricopterInit();
+    }
 }
 
 void loadCustomServoMixer(void)
@@ -319,7 +323,7 @@ void writeServos(void)
     switch (currentMixerMode) {
     case MIXER_TRI:
     case MIXER_CUSTOM_TRI:
-        if (servoConfig()->tri_unarmed_servo) {
+        if (servosTricopterIsEnabledServoUnarmed()) {
             // if unarmed flag set, we always move servo
             pwmWriteServo(servoIndex++, servo[SERVO_RUDDER]);
         } else {
@@ -385,7 +389,7 @@ void writeServos(void)
     }
 }
 
-STATIC_UNIT_TESTED void servoMixer(void)
+void servoMixer(void)
 {
     int16_t input[INPUT_SOURCE_COUNT]; // Range [-500:+500]
     static int16_t currentOutput[MAX_SERVO_RULES];
@@ -467,12 +471,14 @@ static void servoTable(void)
 {
     // airplane / servo mixes
     switch (currentMixerMode) {
+    case MIXER_CUSTOM_TRI:
+    case MIXER_TRI:
+        servosTricopterMixer();
+        break;
     case MIXER_CUSTOM_AIRPLANE:
     case MIXER_FLYING_WING:
     case MIXER_AIRPLANE:
     case MIXER_BICOPTER:
-    case MIXER_CUSTOM_TRI:
-    case MIXER_TRI:
     case MIXER_DUALCOPTER:
     case MIXER_SINGLECOPTER:
     case MIXER_HELI_120_CCPM:

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -140,3 +140,8 @@ int servoDirection(int servoIndex, int fromChannel);
 void servoConfigureOutput(void);
 void servosInit(void);
 void servosFilterInit(void);
+void servoMixer(void);
+// tricopter specific
+void servosTricopterInit(void);
+void servosTricopterMixer(void);
+bool servosTricopterIsEnabledServoUnarmed(void);

--- a/src/main/flight/servos_tricopter.c
+++ b/src/main/flight/servos_tricopter.c
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_SERVOS
+
+#include "flight/mixer.h"
+#include "flight/mixer_tricopter.h"
+#include "flight/servos.h"
+
+
+bool servosTricopterIsEnabledServoUnarmed(void)
+{
+    return servoConfig()->tri_unarmed_servo;
+}
+
+void servosTricopterMixer(void)
+{
+    servoMixer();
+}
+
+void servosTricopterInit(void)
+{
+
+}
+
+#endif // USE_SERVOS

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -118,7 +118,8 @@
 #define PG_FLYSKY_CONFIG 525
 #define PG_TIME_CONFIG 526
 #define PG_RANGEFINDER_CONFIG 527 // iNav
-#define PG_BETAFLIGHT_END 527
+#define PG_TRICOPTER_CONFIG 528
+#define PG_BETAFLIGHT_END 528
 
 
 // OSD configuration (subject to change)


### PR DESCRIPTION
This PR should make it easier for @lkaino to keep [triflight](https://github.com/lkaino/Triflight) up to date with betaflight.

@lkaino , can you confirm this is useful to you? The aim is to make it easier for you to keep Triflight up to date with future releases of betaflight. `mixer_triflight.c`, `servos_triflight.c` (and corresponding `.h` files) have been separated out to enable all (or at least most) Triflight related changes to be made in those files.

Alternatively, if you would like to merge your code in to betaflight that is also an option.

I've contacted @Ikaino at https://rcexplorer.se/forums/topic/testing-triflight-rebased-on-3-2-2-betaflight/page/3/#post-40750