### PR TITLE
Always use arming disable flag names

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -29,13 +29,11 @@ uint16_t flightModeFlags = 0;
 
 static uint32_t enabledSensors = 0;
 
-#if defined(USE_OSD) || !defined(MINIMAL_CLI)
 const char *armingDisableFlagNames[]= {
     "NOGYRO", "FAILSAFE", "RXLOSS", "BADRX", "BOXFAILSAFE",
     "THROTTLE", "ANGLE", "BOOTGRACE", "NOPREARM", "LOAD",
     "CALIB", "CLI", "CMS", "OSD", "BST", "MSP", "ARMSWITCH"
 };
-#endif
 
 static armingDisableFlags_e armingDisableFlags = 0;
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -54,11 +54,8 @@ typedef enum {
     ARMING_DISABLED_ARM_SWITCH      = (1 << 16), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
-#define NUM_ARMING_DISABLE_FLAGS 17
-
-#if defined(USE_OSD) || !defined(MINIMAL_CLI)
-extern const char *armingDisableFlagNames[NUM_ARMING_DISABLE_FLAGS];
-#endif
+#define ARMING_DISABLE_FLAGS_COUNT 17
+extern const char *armingDisableFlagNames[ARMING_DISABLE_FLAGS_COUNT];
 
 void setArmingDisabled(armingDisableFlags_e flag);
 void unsetArmingDisabled(armingDisableFlags_e flag);

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3063,19 +3063,14 @@ static void cliStatus(char *cmdline)
     const int systemRate = getTaskDeltaTime(TASK_SYSTEM) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_SYSTEM)));
     cliPrintLinef("CPU:%d%%, cycle time: %d, GYRO rate: %d, RX rate: %d, System rate: %d",
             constrain(averageSystemLoadPercent, 0, 100), getTaskDeltaTime(TASK_GYROPID), gyroRate, rxRate, systemRate);
-#if defined(USE_OSD) || !defined(MINIMAL_CLI)
-    /* Flag strings are present if OSD is compiled so may as well use them even with MINIMAL_CLI */
     cliPrint("Arming disable flags:");
     armingDisableFlags_e flags = getArmingDisableFlags();
     while (flags) {
-        int bitpos = ffs(flags) - 1;
+        const int bitpos = ffs(flags) - 1;
         flags &= ~(1 << bitpos);
         cliPrintf(" %s", armingDisableFlagNames[bitpos]);
     }
     cliPrintLinefeed();
-#else
-    cliPrintLinef("Arming disable flags: 0x%x", getArmingDisableFlags());
-#endif
 }
 
 #ifndef SKIP_TASK_STATISTICS

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -755,7 +755,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
 
             // Write arming disable flags
             // 1 byte, flag count
-            sbufWriteU8(dst, NUM_ARMING_DISABLE_FLAGS);
+            sbufWriteU8(dst, ARMING_DISABLE_FLAGS_COUNT);
             // 4 bytes, flags
             const uint32_t armingDisableFlags = getArmingDisableFlags();
             sbufWriteU32(dst, armingDisableFlags);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -663,7 +663,7 @@ static bool osdDrawSingleElement(uint8_t item)
             // Show most severe reason for arming being disabled
             if (enabledWarnings & OSD_WARNING_ARMING_DISABLE && IS_RC_MODE_ACTIVE(BOXARM) && isArmingDisabled()) {
                 const armingDisableFlags_e flags = getArmingDisableFlags();
-                for (int i = 0; i < NUM_ARMING_DISABLE_FLAGS; i++) {
+                for (int i = 0; i < ARMING_DISABLE_FLAGS_COUNT; i++) {
                     if (flags & (1 << i)) {
                         osdFormatMessage(buff, sizeof(buff), armingDisableFlagNames[i]);
                         break;


### PR DESCRIPTION
Always display the arming disabled flag name, even if `MINIMAL_CLI` is defined, since this is very useful and ROM savings have been made elsewhere.