### PR TITLE
Fix F446 timer clocks

### DIFF
--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -82,10 +82,10 @@ const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
 
 uint32_t timerClock(TIM_TypeDef *tim)
 {
-#if defined (STM32F411xE) || defined (STM32F446xx)
+#if defined (STM32F411xE)
     UNUSED(tim);
     return SystemCoreClock;
-#elif defined (STM32F40_41xxx)
+#elif defined (STM32F40_41xxx) || defined (STM32F446xx)
     if (tim == TIM8 || tim == TIM1 || tim == TIM9 || tim == TIM10 || tim == TIM11) {
         return SystemCoreClock;
     } else {


### PR DESCRIPTION
I noticed that F446 timer clocks seem to be off. I.e.,  the code assumes that all timers run at 180MHz, while the APB1 timers run at 90MHz in reality.

From the ref manual:
![image](https://user-images.githubusercontent.com/647005/35249672-b4e542ee-ff87-11e7-9e88-53800954333a.png)

For maximum specified speed:
SystemClock is 180MHz
AHB Presc is 1, so HCLK is 180MHz
APB1 Presc is 4, so APB1 PCLK is 45MHz (max allowed)
APB2 Presc is 2, so APB2 PCLK is 90MHz (max allowed)

For this configuration, the APB1 and APB2 timer clocks are 90MHz and 180MHz, as per screenshot above.

I noticed that the timers were off when updating the BrainFPV targets to 3.2.4. But unless I missed something or the other F446 targets use slower than allowed clocks, it should affect the other F446 targets as well.

