### PR TITLE
hide OSD Disable SW if OSD not supported

### DIFF
--- a/src/main/interface/msp_box.c
+++ b/src/main/interface/msp_box.c
@@ -234,7 +234,11 @@ void initActiveBoxIds(void)
         BME(BOXCALIB);
     }
 
-    BME(BOXOSD);
+#ifdef USE_OSD
+    if (feature(FEATURE_OSD)) {
+        BME(BOXOSD);
+    }
+#endif
 
 #ifdef USE_TELEMETRY
     if (feature(FEATURE_TELEMETRY) && telemetryConfig()->telemetry_switch) {


### PR DESCRIPTION
shows `OSD DISABLE SW` in Modes-Tab only if OSD is supported and enabled