### PR TITLE
Spektrum VTX control moved to VTX control task.

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -321,6 +321,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \
             io/vtx_control.c \
+            io/spektrum_vtx_control.c \
             pg/pg.h
 
 # F4 and F7 optimizations

--- a/src/main/io/spektrum_vtx_control.h
+++ b/src/main/io/spektrum_vtx_control.h
@@ -82,9 +82,11 @@ typedef struct
     uint8_t power;
     uint8_t region;
     uint8_t pitMode;
-} stru_vtx;
+} spektrumVtx_t;
+
 
 void spektrumHandleVtxControl(uint32_t vtxControl);
+void spektrumVtxControl(void);
 
 
 

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -36,6 +36,7 @@
 
 #include "io/vtx.h"
 #include "io/vtx_string.h"
+#include "io/vtx_control.h"
 
 #include "interface/cli.h"
 
@@ -207,6 +208,9 @@ void vtxUpdate(timeUs_t currentTimeUs)
     if (cliMode) {
         return;
     }
+
+    // Check input sources for config updates
+    vtxControlInputPoll();
 
     if (vtxCommonDeviceRegistered()) {
         bool vtxUpdatePending = false;

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -37,10 +37,11 @@
 #include "fc/config.h"
 #include "fc/runtime_config.h"
 
-#include "io/beeper.h"
 #include "io/osd.h"
 #include "io/vtx_control.h"
 #include "io/vtx.h"
+
+#include "io/spektrum_vtx_control.h"
 
 
 
@@ -56,6 +57,15 @@ static uint8_t locked = 0;
 void vtxControlInit(void)
 {
     // NOTHING TO DO
+}
+
+void vtxControlInputPoll(void)
+{
+  // Check variuos input sources for VTX config updates
+#if defined(USE_SPEKTRUM_VTX_CONTROL)
+    // Get VTX updates
+    spektrumVtxControl();
+#endif
 }
 
 static void vtxUpdateBandAndChannel(uint8_t bandStep, uint8_t channelStep)

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -42,6 +42,7 @@ typedef struct vtxConfig_s {
 PG_DECLARE(vtxConfig_t, vtxConfig);
 
 void vtxControlInit(void);
+void vtxControlInputPoll(void);
 
 void vtxIncrementBand(void);
 void vtxDecrementBand(void);

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -93,6 +93,7 @@ static void spektrumDataReceive(uint16_t c, void *data)
     }
 }
 
+
 uint32_t spekChannelData[SPEKTRUM_MAX_SUPPORTED_CHANNEL_COUNT];
 static dispatchEntry_t srxlTelemetryDispatch = { .dispatch = srxlRxSendTelemetryDataDispatch};
 
@@ -129,7 +130,7 @@ static uint8_t spektrumFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
                            (spekFrame[SPEKTRUM_VTX_CONTROL_4] <<  0) );
 
     // Handle VTX control frame,
-    if ( (vtxControl & SPEKTRUM_VTX_CONTROL_FRAME_MASK) == SPEKTRUM_VTX_CONTROL_FRAME ) {
+    if ((vtxControl & SPEKTRUM_VTX_CONTROL_FRAME_MASK) == SPEKTRUM_VTX_CONTROL_FRAME) {
       spektrumHandleVtxControl(vtxControl);
     }
 


### PR DESCRIPTION
Rework Spektrum VTX control.

- Move from RX task to VTX CONTROL task
- Added some missing compile conditionals.
- Some cosmetic cleanups.

Tested on BETAFLIGHTF3 and DYSF4PRO more than 50 times each. Both using SPM4649T and TrampHV.
No more sign of any of the hangup/crashing problems seen in #4991.  But also no proof of any real problem found either...
