### PR TITLE
SmartAudio frame requires a trailing zero on software serial

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -450,6 +450,8 @@ static void saSendFrame(uint8_t *buf, int len)
         serialWrite(smartAudioSerialPort, buf[i]);
     }
 
+    serialWrite(smartAudioSerialPort, 0x00); // XXX Software serial case needs this (Need investigation for a reason)
+
     sa_lastTransmissionMs = millis();
     saStat.pktsent++;
 }


### PR DESCRIPTION
This line was deleted in #4636, but turned out that it is required for the current software serial implementation.

Theory behind the scene is unknown yet and need some investigation. It may be related with number of stop bits, as #4636 also introduced the 2-stop change at the same time and hardware UART does not suffer the same problem (Software serial does not handle 2-stops at this point.)