### PR TITLE
Improve conditional handling for USE_SPEKTRUM_xxx

### DIFF
--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -63,6 +63,17 @@
 #endif
 #endif
 
+// If USE_SERIALRX_SPEKTRUM was dropped by a target, drop all related options
+#ifndef USE_SERIALRX_SPEKTRUM
+#undef USE_SPEKTRUM_BIND
+#undef USE_SPEKTRUM_BIND_PLUG
+#undef USE_SPEKTRUM_REAL_RSSI
+#undef USE_SPEKTRUM_FAKE_RSSI
+#undef USE_SPEKTRUM_RSSI_PERCENT_CONVERSION
+#undef USE_SPEKTRUM_VTX_CONTROL
+#undef USE_SPEKTRUM_CMS_TELEMETRY
+#endif
+
 // undefine USE_ALT_HOLD if there is no baro or rangefinder to support it
 #if defined(USE_ALT_HOLD) && !defined(USE_BARO) && !defined(USE_RANGEFINDER)
 #undef USE_ALT_HOLD


### PR DESCRIPTION
Improves conditional handling for `USE_SPEKTRUM_xxx` so that minor options are disabled if `USE_SERIALRX_SPEKTRUM` is not defined.

~Improves the conditional for calling `spektrumBind`.~
~Is it better to drop all `USE_SPEKTRUM_xxx` in `common_*_post.h` if `USE_SERIALRX_SPEKTRUM` is not defined?~~
