### PR TITLE
BetaFlight rates: re-add RF_RATE_INCREMENTAL multiplier

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -93,7 +93,10 @@ float applyBetaflightRates(const int axis, float rcCommandf, const float rcComma
         rcCommandf = rcCommandf * power3(rcCommandfAbs) * expof + rcCommandf * (1 - expof);
     }
 
-    const float rcRate = currentControlRateProfile->rcRates[axis] / 100.0f;
+    float rcRate = currentControlRateProfile->rcRates[axis] / 100.0f;
+    if (rcRate > 2.0f) {
+        rcRate += RC_RATE_INCREMENTAL * (rcRate - 2.0f);
+    }
     float angleRate = 200.0f * rcRate * rcCommandf;
     if (currentControlRateProfile->rates[axis]) {
         const float rcSuperfactor = 1.0f / (constrainf(1.0f - (rcCommandfAbs * (currentControlRateProfile->rates[axis] / 100.0f)), 0.01f, 1.00f));


### PR DESCRIPTION
* By my understanding, when rcRate ended up being larger than 2.0, it was
  affected by this additional multiplier in calculateSetpointRate, line 101 of
  the previous implementation

https://github.com/betaflight/betaflight/pull/4973
https://github.com/betaflight/betaflight/commit/ee65eba88ddeff054769e8a41e2f1793a712806b#diff-45d98ee6ab7d8ca2047ff2dae953c1c9L112

(untested)