### PR TITLE
Fix RF rates calculation

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -108,13 +108,11 @@ float applyBetaflightRates(const int axis, float rcCommandf, const float rcComma
 
 float applyRaceFlightRates(const int axis, float rcCommandf, const float rcCommandfAbs)
 {
-    UNUSED(rcCommandfAbs);
-
     // -1.0 to 1.0 ranged and curved
     rcCommandf = ((1.0f + 0.01f * currentControlRateProfile->rcExpo[axis] * (rcCommandf * rcCommandf - 1.0f)) * rcCommandf);
     // convert to -2000 to 2000 range using acro+ modifier
-    float angleRate = 10.0f * currentControlRateProfile->rcRates[axis] * rcCommandf;
-    angleRate = angleRate * (1 + (float)currentControlRateProfile->rates[axis] * 0.01f);
+    float angleRate = 10.0f * currentControlRateProfile->rcRates[axis];
+    angleRate = (rcCommandf * (angleRate + (rcCommandfAbs * angleRate * (float)currentControlRateProfile->rates[axis] * 0.01f )));
 
     return angleRate;
 }


### PR DESCRIPTION
Did some test flights on RF rates and noticed that the rates where way to sensitive around center.
Used apocolipse's rates comparer to convert my BF rates and tried again, still way to sensitive.

Noticed that the original code from fuijn's PR differs from the current master, this is the calculation in fuijn's PR:

```angleRate = (rcCommandf * ( (float)currentControlRateProfile->rfRate[axis] + ( rcCommandfAbs * (float)currentControlRateProfile->rfRate[axis] * (float)currentControlRateProfile->rfAcro[axis] * 0.01f ) ) );```