### PR TITLE
BLUEJAYF4 Assign DEBUG pad (PB3) as default half-duplex software serial

### DIFF
--- a/src/main/target/BLUEJAYF4/target.c
+++ b/src/main/target/BLUEJAYF4/target.c
@@ -26,7 +26,8 @@
 
 /*
  * - Support HEXA-Dshot
- * - S5_OUT, S6_OUT and DEBUG can be assigned to any combination of LED, software serial and servos
+ * - S5_OUT, S6_OUT are N-channels, which are only capable of outputs. (E.g., motors, servos, LED strip, PWM outputs.)
+ * - Input is only available on DEBUG pad. See comment on SOFTSERIAL1 in target.h for details.
  */
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM3, CH2,  PC7, TIM_USE_PPM,                 0, 0 ), // PPM IN

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -119,8 +119,12 @@
 #define UART4_TX_PIN            NONE // PA0
 
 #define USE_SOFTSERIAL1
-#define SOFTSERIAL1_RX_PIN      PB0 // PWM5
-#define SOFTSERIAL1_TX_PIN      PB1 // PWM6
+// Since PB0 (motor 5) and PB1 (motor 6) are assigned with N-channels, these pin can not handle input.
+// Therefore, receiving function of SOFTSERIAL1 can only be assigned to PB3 (DEBUG).
+// Default defined here is to use DEBUG for half-duplex serial, suitable for VTX (SmartAudio or Tramp) controls.
+// For non-half-duplex requirement (full-duplex or simplex in either direction), assign PB3 to RX and PB0 or PB1 to TX.
+#define SOFTSERIAL1_RX_PIN      NONE
+#define SOFTSERIAL1_TX_PIN      PB3  // DEBUG
 
 #define USE_SOFTSERIAL2
 


### PR DESCRIPTION
Since PB0 (motor 5) and PB1 (motor 6) are assigned with N-channels, these pin can not handle input.
Therefore, receiving function of SOFTSERIAL1 can only be assigned to PB3 (DEBUG).
Default defined here is to use DEBUG for half-duplex serial, suitable for VTX (SmartAudio or Tramp) controls.
For non-half-duplex requirement (full-duplex or simplex in either direction), assign PB3 to RX and PB0 or PB1 to TX.

See https://github.com/betaflight/betaflight/pull/3720#commitcomment-27065487 for the story.
