### PR TITLE
BUGFIX: DMA IRQ handler index incorrect

### DIFF
--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -89,8 +89,9 @@ typedef enum {
     } 
 
 #define DEFINE_DMA_IRQ_HANDLER(d, s, i) void DMA ## d ## _Stream ## s ## _IRQHandler(void) {\
-                                                                if (dmaDescriptors[i].irqHandlerCallback)\
-                                                                    dmaDescriptors[i].irqHandlerCallback(&dmaDescriptors[i]);\
+                                                                const uint8_t index = DMA_IDENTIFIER_TO_INDEX(i); \
+                                                                if (dmaDescriptors[index].irqHandlerCallback)\
+                                                                    dmaDescriptors[index].irqHandlerCallback(&dmaDescriptors[index]);\
                                                             }
 
 #define DMA_CLEAR_FLAG(d, flag) if (d->flagsShift > 31) d->dma->HIFCR = (flag << (d->flagsShift - 32)); else d->dma->LIFCR = (flag << d->flagsShift)
@@ -149,8 +150,9 @@ typedef enum {
     }
 
 #define DEFINE_DMA_IRQ_HANDLER(d, c, i) void DMA ## d ## _Channel ## c ## _IRQHandler(void) {\
-                                                                        if (dmaDescriptors[i].irqHandlerCallback)\
-                                                                            dmaDescriptors[i].irqHandlerCallback(&dmaDescriptors[i]);\
+                                                                        const uint8_t index = DMA_IDENTIFIER_TO_INDEX(i); \
+                                                                        if (dmaDescriptors[index].irqHandlerCallback)\
+                                                                            dmaDescriptors[index].irqHandlerCallback(&dmaDescriptors[index]);\
                                                                     }
 
 #define DMA_CLEAR_FLAG(d, flag) d->dma->IFCR = (flag << d->flagsShift)


### PR DESCRIPTION
Fixes error in DMA irq handling. Most often caused when enabling DSHOT