### PR TITLE
add arm state pin

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -186,7 +186,8 @@ FC_SRC = \
             io/vtx_rtc6705.c \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \
-            io/vtx_control.c
+            io/vtx_control.c \
+            io/arm_state.c
 
 COMMON_DEVICE_SRC = \
             $(CMSIS_SRC) \

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -69,5 +69,6 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "CAMERA_CONTROL",
     "TIMUP",
     "RANGEFINDER",
-    "RX_SPI"
+    "RX_SPI",
+    "OWNER_ARM_STATE"
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -70,6 +70,7 @@ typedef enum {
     OWNER_TIMUP,
     OWNER_RANGEFINDER,
     OWNER_RX_SPI,
+    OWNER_ARM_STATE,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -84,6 +84,9 @@
 #include "flight/pid.h"
 #include "flight/servos.h"
 
+#ifdef USE_ARM_STATE
+#include "io/arm_state.h"
+#endif
 
 // June 2013     V2.2-dev
 
@@ -253,6 +256,10 @@ void disarm(void)
 #endif
         BEEP_OFF;
         beeper(BEEPER_DISARMING);      // emit disarm tone
+
+#ifdef USE_ARM_STATE
+        armStateUpdate(false);
+#endif
     }
 }
 
@@ -310,6 +317,10 @@ void tryArm(void)
         }
 #else
         beeper(BEEPER_ARMING);
+#endif
+
+#ifdef USE_ARM_STATE
+        armStateUpdate(true);
 #endif
     } else {
         if (!isFirstArmingGyroCalibrationRunning()) {

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -69,6 +69,7 @@
 #include "io/transponder_ir.h"
 #include "io/vtx_control.h"
 #include "io/vtx_rtc6705.h"
+#include "io/arm_state.h"
 
 #include "rx/rx.h"
 
@@ -84,9 +85,6 @@
 #include "flight/pid.h"
 #include "flight/servos.h"
 
-#ifdef USE_ARM_STATE
-#include "io/arm_state.h"
-#endif
 
 // June 2013     V2.2-dev
 

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -149,6 +149,10 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
+#ifdef USE_ARM_STATE
+#include "io/arm_state.h"
+#endif
+
 #ifdef TARGET_PREINIT
 void targetPreInit(void);
 #endif
@@ -744,6 +748,10 @@ void init(void)
 #ifdef USE_RCDEVICE
     rcdeviceInit();
 #endif // USE_RCDEVICE
+
+#ifdef USE_ARM_STATE
+    armStateInit();
+#endif
 
     // Latch active features AGAIN since some may be modified by init().
     latchActiveFeatures();

--- a/src/main/io/arm_state.c
+++ b/src/main/io/arm_state.c
@@ -22,21 +22,18 @@
 
 #ifdef USE_ARM_STATE
 
-#include "fc/runtime_config.h"
-
-#include "drivers/io_types.h"
 #include "drivers/io.h"
 
 #ifndef ARM_STATE_PIN
 #define ARM_STATE_PIN NONE
 #endif
 
-static IO_t armStatePin = NULL;
+static IO_t armStatePin = IO_NONE;
 
 bool armStateInit(void)
 {
     armStatePin = IOGetByTag(IO_TAG(ARM_STATE_PIN));
-    if (armStatePin == NULL) {
+    if (armStatePin == IO_NONE) {
         return false;
     }
 
@@ -48,9 +45,9 @@ bool armStateInit(void)
     return true;
 }
 
-void armStateUpdate(bool isArming)
+void armStateUpdate(bool isArmed)
 {
-    IOWrite(armStatePin, !isArming);
+    IOWrite(armStatePin, !isArmed);
 }
 
 #endif

--- a/src/main/io/arm_state.c
+++ b/src/main/io/arm_state.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#ifdef USE_ARM_STATE
+
+#include "fc/runtime_config.h"
+
+#include "drivers/io_types.h"
+#include "drivers/io.h"
+
+#ifndef ARM_STATE_PIN
+#define ARM_STATE_PIN NONE
+#endif
+
+static IO_t armStatePin = NULL;
+
+bool armStateInit(void)
+{
+    armStatePin = IOGetByTag(IO_TAG(ARM_STATE_PIN));
+    if (armStatePin == NULL) {
+        return false;
+    }
+
+    IOInit(armStatePin, OWNER_ARM_STATE, 0);
+    IOConfigGPIO(armStatePin, IOCFG_OUT_PP);
+
+    IOLo(armStatePin); // default state is Lo
+
+    return true;
+}
+
+void armStateUpdate(bool isArming)
+{
+    IOWrite(armStatePin, !isArming);
+}
+
+#endif

--- a/src/main/io/arm_state.h
+++ b/src/main/io/arm_state.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+bool armStateInit(void);
+void armStateUpdate(bool isArming);


### PR DESCRIPTION
Hi there,

This PR is replace implementation of #5048 , the armhook idea in #5048 is a bit complicated and it is a target-dependency.

When disarmed, the arm state pin is Lo, else it is HI. so we can use this pin to control the external device on the FC state.

Which target need use the amr state pin, just define the following marcos in target.h:
#define USE_ARM_STATE
#define ARM_STATE_PIN PD12 // the GPIO you want to use to indicate arm state.

Thanks  for @ledvinap, @blckmn , @mikeller comments. 