### PR TITLE
Updated smartaudio and softserial to improve reliability

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -444,8 +444,6 @@ static void saReceiveFramer(uint8_t c)
 
 static void saSendFrame(uint8_t *buf, int len)
 {
-    serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start bit
-
     for (int i = 0 ; i < len ; i++) {
         serialWrite(smartAudioSerialPort, buf[i]);
     }


### PR DESCRIPTION
PR Status:  Testing *required* on as many VTX formats as possible.

This PR attempts to address what appears to be a voltage issue when using soft serial for VTX control.  More specifically, it addresses issues with the Unify Pro, but has been written in a way that may help correct similar voltage issues on other formats as well.