### PR TITLE
Remove RTC_TIME from OMNIBUS to free up flash space

### DIFF
--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -23,6 +23,7 @@
 #undef USE_SERIALRX_JETIEXBUS
 #undef USE_TELEMETRY_MAVLINK
 #undef USE_TELEMETRY_LTM
+#undef USE_RTC_TIME
 
 
 #define TARGET_BOARD_IDENTIFIER "OMNI" // https://en.wikipedia.org/wiki/Omnibus


### PR DESCRIPTION
Added `#undef USE_RTC_TIME` to target/OMNIBUS/target.h
Frees up 1384 bytes.
