### PR TITLE
OMNIBUSF7* Revert ADC instance change

### DIFF
--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -177,7 +177,7 @@
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 
 #define USE_ADC
-#define ADC_INSTANCE            ADC2
+#define ADC_INSTANCE            ADC1
 #define CURRENT_METER_ADC_PIN   PC2
 #define VBAT_ADC_PIN            PC3
 #define RSSI_ADC_PIN            PC5


### PR DESCRIPTION
Reverts ADC instance change introduced accidentally by #3898, causing stream collision between ADC2 and motor 3.