### PR TITLE
CAMERA_CONTROL Drop software PWM mode

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -65,6 +65,7 @@ COMMON_SRC = \
             pg/beeper_dev.c \
             pg/bus_i2c.c \
             pg/bus_spi.c \
+            pg/camera_control.c \
             pg/max7456.c \
             pg/pg.c \
             pg/rx_pwm.c \

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -118,6 +118,7 @@ extern uint8_t __config_end;
 #include "pg/beeper_dev.h"
 #include "pg/bus_i2c.h"
 #include "pg/bus_spi.h"
+#include "pg/camera_control.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/rx_pwm.h"

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -67,6 +67,7 @@
 #include "pg/max7456.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
+#include "pg/camera_control.h"
 #include "pg/rx_pwm.h"
 #include "pg/sdcard.h"
 #include "pg/vcd.h"
@@ -229,7 +230,6 @@ static const char * const lookupTableGyroLpf[] = {
 #ifdef USE_CAMERA_CONTROL
 static const char * const lookupTableCameraControlMode[] = {
     "HARDWARE_PWM",
-    "SOFTWARE_PWM",
     "DAC"
 };
 #endif

--- a/src/main/pg/camera_control.c
+++ b/src/main/pg/camera_control.c
@@ -15,23 +15,32 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include <platform.h>
 
-typedef enum {
-    CAMERA_CONTROL_KEY_ENTER,
-    CAMERA_CONTROL_KEY_LEFT,
-    CAMERA_CONTROL_KEY_UP,
-    CAMERA_CONTROL_KEY_RIGHT,
-    CAMERA_CONTROL_KEY_DOWN,
-    CAMERA_CONTROL_KEYS_COUNT
-} cameraControlKey_e;
+#ifdef USE_CAMERA_CONTROL
 
-typedef enum {
-    CAMERA_CONTROL_MODE_HARDWARE_PWM,
-    CAMERA_CONTROL_MODE_DAC,
-    CAMERA_CONTROL_MODES_COUNT
-} cameraControlMode_e;
+#include "pg/pg_ids.h"
+#include "pg/camera_control.h"
+#include "drivers/camera_control.h"
+#include "drivers/io.h"
 
-void cameraControlInit(void);
-void cameraControlProcess(uint32_t currentTimeUs);
-void cameraControlKeyPress(cameraControlKey_e key, uint32_t holdDurationMs);
+//#include "math.h"
+//#include "nvic.h"
+//#include "pwm_output.h"
+//#include "time.h"
+
+#ifndef CAMERA_CONTROL_PIN
+#define CAMERA_CONTROL_PIN NONE
+#endif
+
+PG_REGISTER_WITH_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig, PG_CAMERA_CONTROL_CONFIG, 0);
+
+PG_RESET_TEMPLATE(cameraControlConfig_t, cameraControlConfig,
+    .mode = CAMERA_CONTROL_MODE_HARDWARE_PWM,
+    .refVoltage = 330,
+    .keyDelayMs = 180,
+    .internalResistance = 470,
+    .ioTag = IO_TAG(CAMERA_CONTROL_PIN)
+);
+
+#endif

--- a/src/main/pg/camera_control.h
+++ b/src/main/pg/camera_control.h
@@ -17,21 +17,19 @@
 
 #pragma once
 
-typedef enum {
-    CAMERA_CONTROL_KEY_ENTER,
-    CAMERA_CONTROL_KEY_LEFT,
-    CAMERA_CONTROL_KEY_UP,
-    CAMERA_CONTROL_KEY_RIGHT,
-    CAMERA_CONTROL_KEY_DOWN,
-    CAMERA_CONTROL_KEYS_COUNT
-} cameraControlKey_e;
+#include "drivers/io_types.h"
+#include "drivers/camera_control.h"
+#include "pg/pg.h"
 
-typedef enum {
-    CAMERA_CONTROL_MODE_HARDWARE_PWM,
-    CAMERA_CONTROL_MODE_DAC,
-    CAMERA_CONTROL_MODES_COUNT
-} cameraControlMode_e;
+typedef struct cameraControlConfig_s {
+    cameraControlMode_e mode;
+    // measured in 10 mV steps
+    uint16_t refVoltage;
+    uint16_t keyDelayMs;
+    // measured 100 Ohm steps
+    uint16_t internalResistance;
 
-void cameraControlInit(void);
-void cameraControlProcess(uint32_t currentTimeUs);
-void cameraControlKeyPress(cameraControlKey_e key, uint32_t holdDurationMs);
+    ioTag_t ioTag;
+} cameraControlConfig_t;
+
+PG_DECLARE(cameraControlConfig_t, cameraControlConfig);


### PR DESCRIPTION
- Drop software PWM mode, as it has a problem under current implementation.
- Also separates PG related code to pg directory.
