### PR TITLE
Fix broken PPM+PWM after 4982 and 5016

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -399,6 +399,7 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
 #if defined(USE_PWM) || defined(USE_PPM)
     if (feature(FEATURE_RX_PPM)) {
         if (isPPMDataBeingReceived()) {
+            rxDataProcessingRequired = true;
             rxSignalReceived = true;
             rxIsInFailsafeMode = false;
             needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;
@@ -406,6 +407,7 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
         }
     } else if (feature(FEATURE_RX_PARALLEL_PWM)) {
         if (isPWMDataBeingReceived()) {
+            rxDataProcessingRequired = true;
             rxSignalReceived = true;
             rxIsInFailsafeMode = false;
             needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;


### PR DESCRIPTION
Fixes #5125.

Without understanding what #4982 and #5016 was all about, it seems like `rxUpdateCheck` requires to flag `rxDataProcessingRequired` for PPM and PWM when `is{PPM,PWM}DataBeingReceived`.