### PR TITLE
Corrected issue with telemetry init when battery cell estimation is undefined

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -450,9 +450,9 @@ void batteryUpdateAlarms(void)
     }
 }
 
-bool isBatteryVoltageAvailable(void)
+bool isBatteryVoltageConfigured(void)
 {
-    return batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && getBatteryCellCount() > 0;
+    return batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE;
 }
 
 uint16_t getBatteryVoltage(void)
@@ -475,7 +475,7 @@ uint16_t getBatteryAverageCellVoltage(void)
     return voltageMeter.filtered / batteryCellCount;
 }
 
-bool isAmperageAvailable(void)
+bool isAmperageConfigured(void)
 {
     return batteryConfig()->currentMeterSource != CURRENT_METER_NONE;
 }

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -77,13 +77,13 @@ struct rxConfig_s;
 
 float calculateVbatPidCompensation(void);
 uint8_t calculateBatteryPercentageRemaining(void);
-bool isBatteryVoltageAvailable(void);
+bool isBatteryVoltageConfigured(void);
 uint16_t getBatteryVoltage(void);
 uint16_t getBatteryVoltageLatest(void);
 uint8_t getBatteryCellCount(void);
 uint16_t getBatteryAverageCellVoltage(void);
 
-bool isAmperageAvailable(void);
+bool isAmperageConfigured(void);
 int32_t getAmperage(void);
 int32_t getAmperageLatest(void);
 int32_t getMAhDrawn(void);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -399,7 +399,7 @@ void initCrsfTelemetry(void)
     if (sensors(SENSOR_ACC)) {
         crsfSchedule[index++] = BV(CRSF_FRAME_ATTITUDE_INDEX);
     }
-    if (isBatteryVoltageAvailable() || isAmperageAvailable()) {
+    if (isBatteryVoltageConfigured() || isAmperageConfigured()) {
         crsfSchedule[index++] = BV(CRSF_FRAME_BATTERY_SENSOR_INDEX);
     }
     crsfSchedule[index++] = BV(CRSF_FRAME_FLIGHT_MODE_INDEX);

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -208,6 +208,16 @@ void mavlinkSendSystemStatus(void)
     if (sensors(SENSOR_BARO)) onboardControlAndSensors |=  8200;
     if (sensors(SENSOR_GPS))  onboardControlAndSensors |= 16416;
 
+    uint16_t batteryVoltage = 0;
+    int16_t batteryAmperage = -1;
+    int8_t batteryRemaining = 100;
+
+    if (getBatteryState() < BATTERY_NOT_PRESENT) {
+        batteryVoltage = isBatteryVoltageConfigured() ? getBatteryVoltage() * 100 : batteryVoltage;
+        batteryAmperage = isAmperageConfigured() ? getAmperage() : batteryAmperage;
+        batteryRemaining = isBatteryVoltageConfigured() ? calculateBatteryPercentageRemaining() : batteryRemaining;
+    }
+
     mavlink_msg_sys_status_pack(0, 200, &mavMsg,
         // onboard_control_sensors_present Bitmask showing which onboard controllers and sensors are present.
         //Value of 0: not present. Value of 1: present. Indices: 0: 3D gyro, 1: 3D acc, 2: 3D mag, 3: absolute pressure,
@@ -222,11 +232,11 @@ void mavlinkSendSystemStatus(void)
         // load Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000
         0,
         // voltage_battery Battery voltage, in millivolts (1 = 1 millivolt)
-        isBatteryVoltageAvailable() ? getBatteryVoltage() * 100 : 0,
+        batteryVoltage,
         // current_battery Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current
-        isAmperageAvailable() ? getAmperage() : -1,
+        batteryAmperage,
         // battery_remaining Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery
-        isBatteryVoltageAvailable() ? calculateBatteryPercentageRemaining() : 100,
+        batteryRemaining,
         // drop_rate_comm Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)
         0,
         // errors_comm Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -376,10 +376,11 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 
         switch (id) {
             case FSSP_DATAID_VFAS       :
-                if (isBatteryVoltageAvailable()) {
+                if (isBatteryVoltageConfigured()) {
                     uint16_t vfasVoltage;
                     if (telemetryConfig()->report_cell_voltage) {
-                        vfasVoltage = getBatteryVoltage() / getBatteryCellCount();
+                        const uint8_t cellCount = getBatteryCellCount();
+                        vfasVoltage = cellCount ? getBatteryVoltage() / cellCount : 0;
                     } else {
                         vfasVoltage = getBatteryVoltage();
                     }
@@ -388,7 +389,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 }
                 break;
             case FSSP_DATAID_CURRENT    :
-                if (isAmperageAvailable()) {
+                if (isAmperageConfigured()) {
                     smartPortSendPackage(id, getAmperage() / 10); // given in 10mA steps, unknown requested unit
                     *clearToSend = false;
                 }
@@ -401,7 +402,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 }
                 break;
             case FSSP_DATAID_FUEL       :
-                if (isAmperageAvailable()) {
+                if (isAmperageConfigured()) {
                     smartPortSendPackage(id, getMAhDrawn()); // given in mAh, unknown requested unit
                     *clearToSend = false;
                 }
@@ -563,8 +564,10 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 break;
 #endif
             case FSSP_DATAID_A4         :
-                if (isBatteryVoltageAvailable()) {
-                    smartPortSendPackage(id, getBatteryVoltage() * 10 / getBatteryCellCount()); // given in 0.1V, convert to volts
+                if (isBatteryVoltageConfigured()) {
+                    const uint8_t cellCount = getBatteryCellCount();
+                    const uint32_t vfasVoltage = cellCount ? (getBatteryVoltage() * 10 / cellCount) : 0; // given in 0.1V, convert to volts
+                    smartPortSendPackage(id, vfasVoltage);
                     *clearToSend = false;
                 }
                 break;

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -254,11 +254,11 @@ extern "C" {
     uint32_t micros(void) {return dummyTimeUs;}
     serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e, serialReceiveCallbackPtr, void *, uint32_t, portMode_e, portOptions_e) {return NULL;}
     serialPortConfig_t *findSerialPortConfig(serialPortFunction_e ) {return NULL;}
-    bool isBatteryVoltageAvailable(void) { return true; }
+    bool isBatteryVoltageConfigured(void) { return true; }
     uint16_t getBatteryVoltage(void) {
         return testBatteryVoltage;
     }
-    bool isAmperageAvailable(void) { return true; }
+    bool isAmperageConfigured(void) { return true; }
     int32_t getAmperage(void) {
         return testAmperage;
     }

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -336,7 +336,7 @@ int32_t getMAhDrawn(void){
 bool sendMspReply(uint8_t, mspResponseFnPtr) { return false; }
 bool handleMspFrame(uint8_t *, int)  { return false; }
 void crsfScheduleMspResponse(void) {};
-bool isBatteryVoltageAvailable(void) { return true; }
-bool isAmperageAvailable(void) { return true; }
+bool isBatteryVoltageConfigured(void) { return true; }
+bool isAmperageConfigured(void) { return true; }
 
 }


### PR DESCRIPTION
If battery cell estimate and voltage meter are undefined during telemetry initialization, battery telemetry for CRSF is not sent.  Corrected isBatteryVoltageAvailable() to no longer require a cell count estimation to be present in order to be true.  Added getBatteryCellCount() checks when calls to isBatteryVoltageAvailable() also require a cell count.