### PR TITLE
Allow RX-only softserial

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -457,11 +457,13 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
 
         if ((serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1
 #ifdef USE_SOFTSERIAL1
-            && !(softserialEnabled && serialPinConfig()->ioTagTx[RESOURCE_SOFT_OFFSET + SOFTSERIAL1])
+            && !(softserialEnabled && (serialPinConfig()->ioTagTx[RESOURCE_SOFT_OFFSET + SOFTSERIAL1] ||
+                serialPinConfig()->ioTagRx[RESOURCE_SOFT_OFFSET + SOFTSERIAL1]))
 #endif
            ) || (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL2
 #ifdef USE_SOFTSERIAL2
-            && !(softserialEnabled && serialPinConfig()->ioTagTx[RESOURCE_SOFT_OFFSET + SOFTSERIAL2])
+            && !(softserialEnabled && (serialPinConfig()->ioTagTx[RESOURCE_SOFT_OFFSET + SOFTSERIAL2] ||
+                serialPinConfig()->ioTagRx[RESOURCE_SOFT_OFFSET + SOFTSERIAL2]))
 #endif
             )) {
             serialPortUsageList[index].identifier = SERIAL_PORT_NONE;


### PR DESCRIPTION
It can be viewed as a bugfix, as some existing targets recommend running ESC-telemetry on a RX-only softserial, while it's not possible with current code.
Probably requires some testing, I don't have an FC with me right now.