### PR TITLE
Biquad RC+FIR2: Allow user to specify cutoff Hz parameter directly

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -303,10 +303,11 @@ float firFilterDenoiseUpdate(firFilterDenoise_t *filter, float input)
     }
 }
 
-// ledvinap's proposed RC+FIR2 Biquad-- equivalent to 'static' fast Kalman, without error estimation
-void biquadRCFIR2FilterInit(biquadFilter_t *filter, float q, float r)
+// ledvinap's proposed RC+FIR2 Biquad-- 1st order IIR, RC filter k
+void biquadRCFIR2FilterInit(biquadFilter_t *filter, uint16_t f_cut, float dT)
 {
-    float k = 2 * 2 * sqrt(q) / (sqrt(q + 4 * r) + sqrt(q));  // 1st order IIR filter k
+    float RC = 1.0f / ( 2.0f * M_PI_FLOAT * f_cut );
+    float k = dT / (RC + dT);
     filter->b0 = k / 2;
     filter->b1 = k / 2;
     filter->b2 = 0;

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -96,7 +96,7 @@ float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
 float biquadFilterApply(biquadFilter_t *filter, float input);
 float filterGetNotchQ(uint16_t centerFreq, uint16_t cutoff);
 
-void biquadRCFIR2FilterInit(biquadFilter_t *filter, float q, float r);
+void biquadRCFIR2FilterInit(biquadFilter_t *filter, uint16_t f_cut, float dT);
 
 void fastKalmanInit(fastKalman_t *filter, float q, float r, float p);
 float fastKalmanUpdate(fastKalman_t *filter, float input);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -345,7 +345,9 @@ const clivalue_t valueTable[] = {
     { "gyro_notch1_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_1) },
     { "gyro_notch2_hz",             VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_hz_2) },
     { "gyro_notch2_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_2) },
-#if defined(USE_GYRO_FAST_KALMAN) || defined(USE_GYRO_BIQUAD_RC_FIR2)
+#if defined(USE_GYRO_BIQUAD_RC_FIR2)
+    { "gyro_stage2_lowpass_hz",     VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_lpf_hz_2) },
+#elif defined(USE_GYRO_FAST_KALMAN)
     { "gyro_filter_q",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_q) },
     { "gyro_filter_r",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_r) },
     { "gyro_filter_p",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_p) },

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -65,6 +65,7 @@ typedef struct gyroConfig_s {
     bool     gyro_high_fsr;
     bool     gyro_use_32khz;
     uint8_t  gyro_to_use;
+    uint16_t gyro_soft_lpf_hz_2;
     uint16_t gyro_soft_notch_hz_1;
     uint16_t gyro_soft_notch_cutoff_1;
     uint16_t gyro_soft_notch_hz_2;


### PR DESCRIPTION
* Generate 'k' per the code for the PT1. ~Please review :)~
* Adjust function prototypes/functions to accept f_cut/dT where applicable
* Adjust gyro configuration, parameter group, interface settings to suit. ~Open to suggestions on the ~name.

~edit: Completely untested, have not even flashed my board yet.~