### PR TITLE
Fix for #5117. Also, max character count was off by one.

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -335,21 +335,17 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
 {
     // latitude maximum integer width is 3 (-90).
     // longitude maximum integer width is 4 (-180).
-    // We show 7 decimals, so we need to use 11 characters because
-    // we are embedding the decimal separator between two digits
-    // eg: s-1801234567z   s=symbol, z=zero terminator, decimal separator embedded between 0 and 1
+    // We show 7 decimals, so we need to use 12 characters:
+    // eg: s-180.1234567z   s=symbol, z=zero terminator, decimal separator  between 0 and 1
 
     static const int decimalPlaces = 7;
-    static const int coordinateMaxLength = 11;//5 + decimalPlaces; // 4 for the integer part of the number + 1 for the symbol
+    static const int coordinateMaxLength = 13;//12 for the number (4 + dot + 7) + 1 for the symbol
 
     buff[0] = sym;
     const int32_t integerPart = val / GPS_DEGREES_DIVIDER;
     const int32_t decimalPart = labs(val % GPS_DEGREES_DIVIDER);
-    const int written = tfp_sprintf(buff + 1, "%d", integerPart);
+    const int written = tfp_sprintf(buff + 1, "%d.", integerPart);
     tfp_sprintf(buff + 1 + written, "%07d", decimalPart);
-    // embed the decimal separator
-    buff[1+written-1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
-    buff[1+written] += SYM_ZERO_HALF_LEADING_DOT - '0';
     // pad with blanks to coordinateMaxLength
     for (int pos = 1 + decimalPlaces + written; pos < coordinateMaxLength; ++pos) {
         buff[pos] = SYM_BLANK;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -338,16 +338,14 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     // We show 7 decimals, so we need to use 12 characters:
     // eg: s-180.1234567z   s=symbol, z=zero terminator, decimal separator  between 0 and 1
 
-    static const int decimalPlaces = 7;
     static const int coordinateMaxLength = 13;//12 for the number (4 + dot + 7) + 1 for the symbol
 
     buff[0] = sym;
     const int32_t integerPart = val / GPS_DEGREES_DIVIDER;
     const int32_t decimalPart = labs(val % GPS_DEGREES_DIVIDER);
-    const int written = tfp_sprintf(buff + 1, "%d.", integerPart);
-    tfp_sprintf(buff + 1 + written, "%07d", decimalPart);
+    const int written = tfp_sprintf(buff + 1, "%d.%07d", integerPart, decimalPart);
     // pad with blanks to coordinateMaxLength
-    for (int pos = 1 + decimalPlaces + written; pos < coordinateMaxLength; ++pos) {
+    for (int pos = 1 + written; pos < coordinateMaxLength; ++pos) {
         buff[pos] = SYM_BLANK;
     }
     buff[coordinateMaxLength] = '\0';


### PR DESCRIPTION
Fixes #5117. Reverted the changes that require the special font, and also fixed an unreported off-by-one error that was clobbering the last digit of longitude in locations with three-digit longitudes (it was already fixed on iNav, it seems).

Note: because I don't have the font installed, the symbols for latitude and longitude still don't look right to me, but I left them alone.