### PR TITLE
Adding 'acro beginner' feature

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -115,6 +115,7 @@ FC_SRC = \
             flight/pid.c \
             flight/servos.c \
             flight/servos_tricopter.c \
+            flight/beginner_mode.c \
             interface/cli.c \
             interface/settings.c \
             io/serial_4way.c \

--- a/src/main/flight/beginner_mode.c
+++ b/src/main/flight/beginner_mode.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+#ifdef USE_BEGINNER_MODE
+#include "common/maths.h"
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+#include "fc/fc_core.h"
+#include "io/serial.h"
+#include "beginner_mode.h"
+
+PG_REGISTER_WITH_RESET_TEMPLATE(beginnerModeConfig_t, beginnerModeConfig, PG_BEGINNER_MODE_CONFIG, 0);
+PG_RESET_TEMPLATE(beginnerModeConfig_t, beginnerModeConfig,
+    .enabled_beginnerMode = 0,
+    .maxRoll = 10,
+    .maxPitch = 10
+);
+
+void beginnerModeHandleAttitude(float roll, float pitch, float yaw)
+{
+    UNUSED(yaw);
+    roll = ABS(roll);
+    pitch = ABS(pitch);
+    if (((beginnerModeConfig()->enabled_beginnerMode & BEGINNER_MODE_ROLL) && roll >= beginnerModeConfig()->maxRoll) ||
+            ((beginnerModeConfig()->enabled_beginnerMode & BEGINNER_MODE_PITCH) && pitch >= beginnerModeConfig()->maxPitch))
+    {
+        disarm();
+    }
+}
+
+#endif //USE_BEGINNER_MODE

--- a/src/main/flight/beginner_mode.h
+++ b/src/main/flight/beginner_mode.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    BEGINNER_MODE_NONE = 0x00,
+    BEGINNER_MODE_ROLL = 0x01,
+    BEGINNER_MODE_PITCH = 0x02,
+    BEGINNER_MODE_ROLLPITCH = 0x03,
+} beginnerMode_e;
+
+typedef struct beginnerModeConfig_d {
+    uint8_t enabled_beginnerMode;
+    uint8_t maxRoll;
+    uint8_t maxPitch;
+} beginnerModeConfig_t;
+
+PG_DECLARE(beginnerModeConfig_t, beginnerModeConfig);
+
+void beginnerModeHandleAttitude(float roll, float pitch, float yaw);

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -68,6 +68,10 @@ static bool imuUpdated = false;
 
 #endif
 
+#ifdef USE_BEGINNER_MODE
+#include "beginner_mode.h"
+#endif //USE_BEGINNER_MODE
+
 // the limit (in degrees/second) beyond which we stop integrating
 // omega_I. At larger spin rates the DCM PI controller can get 'dizzy'
 // which results in false gyro drift. See
@@ -510,6 +514,14 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
                         useYaw, rawYawError, imuCalcKpGain(currentTimeUs, useAcc, gyroAverage));
 
     imuUpdateEulerAngles();
+
+#ifdef USE_BEGINNER_MODE
+    beginnerModeHandleAttitude(
+        DECIDEGREES_TO_DEGREES(attitude.values.roll), 
+        DECIDEGREES_TO_DEGREES(attitude.values.pitch), 
+        DECIDEGREES_TO_DEGREES(attitude.values.yaw));
+#endif //USE_BEGINNER_MODE
+
 #endif
 #if defined(USE_ALT_HOLD)
     imuCalculateAcceleration(deltaT); // rotate acc vector into earth frame

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -49,6 +49,7 @@
 #include "flight/navigation.h"
 #include "flight/pid.h"
 #include "flight/servos.h"
+#include "flight/beginner_mode.h"
 
 #include "interface/settings.h"
 
@@ -320,6 +321,12 @@ static const char * const lookupOverclock[] = {
     };
 #endif
 
+#ifdef USE_BEGINNER_MODE
+static const char * const lookupTableBeginnerModeTargets[] = {
+    "NONE", "ROLL", "PITCH", "ROLLPITCH"
+};
+#endif
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -386,6 +393,9 @@ const lookupTableEntry_t lookupTables[] = {
 #endif
 #ifdef USE_DUAL_GYRO
     LOOKUP_TABLE_ENTRY(lookupTableGyro),
+#endif
+#ifdef USE_BEGINNER_MODE
+    LOOKUP_TABLE_ENTRY(lookupTableBeginnerModeTargets),
 #endif
 };
 
@@ -964,6 +974,12 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef USE_USB_MSC
     { "usb_msc_pin_pullup", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_USB_CONFIG, offsetof(usbDev_t, mscButtonUsePullup) },
+#endif
+
+#ifdef USE_BEGINNER_MODE
+    { "bm_targets", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BEGINNER_MODE_TARGETS }, PG_BEGINNER_MODE_CONFIG, offsetof(beginnerModeConfig_t, enabled_beginnerMode) },
+    { "bm_maxroll", VAR_UINT8 | MASTER_VALUE , .config.minmax = { 0, 80 }, PG_BEGINNER_MODE_CONFIG, offsetof(beginnerModeConfig_t, maxRoll) },
+    { "bm_maxpitch", VAR_UINT8 | MASTER_VALUE , .config.minmax = { 0, 80 }, PG_BEGINNER_MODE_CONFIG, offsetof(beginnerModeConfig_t, maxPitch) },
 #endif
 };
 

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -87,6 +87,9 @@ typedef enum {
 #ifdef USE_DUAL_GYRO
     TABLE_GYRO,
 #endif
+#ifdef USE_BEGINNER_MODE
+    TABLE_BEGINNER_MODE_TARGETS,
+#endif
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -122,8 +122,8 @@
 #define PG_PINIO_CONFIG 529
 #define PG_PINIOBOX_CONFIG 530
 #define PG_USB_CONFIG 531
-#define PG_BETAFLIGHT_END 531
-
+#define PG_BEGINNER_MODE_CONFIG 532
+#define PG_BETAFLIGHT_END 532
 
 // OSD configuration (subject to change)
 #define PG_OSD_FONT_CONFIG 2047

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -114,6 +114,7 @@
 #define USE_SERIALRX_SUMD       // Graupner Hott protocol
 #define USE_SERIALRX_SUMH       // Graupner legacy protocol
 #define USE_SERIALRX_XBUS       // JR
+#define USE_BEGINNER_MODE
 
 #if (FLASH_SIZE > 64)
 #define MAX_PROFILE_COUNT 3


### PR DESCRIPTION
This PR, in addition to being educational, it adds Watchdogs feature:
   - Allows users to set max limits on drone attitude and disarm the motors if these limits are reached/exceeded.
   - This is helpful for new drone pilots (myself!) specially when practicing hover in tight space where a large tilt can cause drone to drift, hit walls, and at best break propellers.
   - I can see this helpful also during testing/PID tuning to protect against things getting out of hand.
   - limits on roll/pitch can be set independently and each can be enabled and disabled
   - feature is disabled by default

Thanks to @klaus, @race_fpv, @rafl for helping me implementing this and getting up to speed with the code!

Demo of usage: https://www.youtube.com/watch?v=IGZm-jkPq9M
