### PR TITLE
Added support for serial debugging

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -188,7 +188,8 @@ FC_SRC = \
             io/vtx_rtc6705.c \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \
-            io/vtx_control.c
+            io/vtx_control.c \
+            io/debugserial.c
 
 COMMON_DEVICE_SRC = \
             $(CMSIS_SRC) \

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -149,6 +149,10 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
+#ifdef USE_DEBUG_SERIAL
+#include "io/debugserial.h"
+#endif
+
 #ifdef TARGET_PREINIT
 void targetPreInit(void);
 #endif
@@ -387,6 +391,10 @@ void init(void)
             feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM) ? SERIAL_PORT_USART3 : SERIAL_PORT_NONE);
 #else
     serialInit(feature(FEATURE_SOFTSERIAL), SERIAL_PORT_NONE);
+#endif
+
+#ifdef USE_DEBUG_SERIAL
+    dbg_initialize(DBG_DEFAULT_PORT, DBG_DEFAULT_BAUDRATE);
 #endif
 
     mixerInit(mixerConfig()->mixerMode);

--- a/src/main/io/debugserial.c
+++ b/src/main/io/debugserial.c
@@ -1,0 +1,125 @@
+
+#include "platform.h"
+
+#ifdef USE_DEBUG_SERIAL
+
+#include "io/serial.h"
+#include "common/printf.h"
+#include "io/debugserial.h"
+
+#define INDENTATION_CHAR " "
+#define INDENTATION_LENGTH 3
+#define CLEAR_SEQUENCE "%s", "\x1b[2J\x0"
+#define INITIALIZATION_MESSAGE "DebugSerial_Initialize: OK\r\n"
+#define CHECK_ENABLED if(!debugSerial.enabled) return
+
+typedef struct debugSerial_s {
+    serialPort_t *port;
+    uint8_t tabs;
+    bool enabled;
+    uint16_t count;
+    uint16_t rate;
+} debugSerial_t;
+
+debugSerial_t debugSerial = {0};
+
+void dbg_enable(void);
+inline void dbg_disable(void);
+static void dbg_indent(void);
+static inline void dbg_addIndent(void);
+static inline void dbg_subIndent(void);
+
+void dbg_initialize(serialPortIdentifier_e port_id, uint32_t baudrate) {
+    debugSerial.port = openSerialPort(port_id, FUNCTION_NONE, NULL, NULL, baudrate, MODE_RXTX, 0);
+    if (debugSerial.port) {
+        setPrintfSerialPort(debugSerial.port);
+        debugSerial.enabled = true;
+        __printf((CLEAR_SEQUENCE));
+        __printf((INITIALIZATION_MESSAGE));
+    }
+}
+
+void dbg_setRate(uint16_t rate) {
+    // When called from periodic tasks, only first hit will set the rate, then it will be no op.
+    if(debugSerial.rate == 0) {
+        debugSerial.rate = rate;
+        debugSerial.count = 0;
+        debugSerial.enabled = false;
+    }
+}
+
+void dbg_tick(void) {
+    debugSerial.count++;
+    if(debugSerial.count == debugSerial.rate) {
+        debugSerial.enabled = true;
+    }
+
+    if(debugSerial.count > debugSerial.rate) {
+        debugSerial.count = 0;
+        debugSerial.enabled = false;
+    }
+}
+
+void dbg_enable(void) { 
+    debugSerial.rate = 0;
+    debugSerial.count = 0;
+    debugSerial.enabled = true;
+}
+
+inline void dbg_disable(void) {
+    debugSerial.enabled = false;
+}
+
+void dbg_clear(void) {
+    CHECK_ENABLED;
+    __printf((CLEAR_SEQUENCE));
+}
+
+void dbg_write(const char* str) {
+    CHECK_ENABLED;
+    __printf((str));
+}
+
+void dbg_writeLine(const char* str) {
+    CHECK_ENABLED;
+    dbg_indent();
+    __printf(("%s\r\n", str));
+}
+
+void dbg_valuef(const char* label, float val) {
+    CHECK_ENABLED;
+    int i = (int)val;
+    int d = (int)((val - i) * 1000);
+    dbg_indent();
+    __printf(("%s: %d.%d\r\n", label, i, d));
+}
+
+void dbg_enterFunction(const char* str) {
+    CHECK_ENABLED;
+    dbg_indent();
+    __printf(("+%s\r\n", str));
+    dbg_addIndent();
+}
+
+void dbg_leaveFunction(const char* str) {
+    CHECK_ENABLED;
+    dbg_subIndent();
+    dbg_indent();
+    __printf(("-%s\r\n", str));
+}
+
+void dbg_indent(void) {
+    for(uint8_t i=0; i< debugSerial.tabs; i++) {
+        __printf((INDENTATION_CHAR));
+    }
+}
+
+inline void dbg_addIndent(void) {
+    debugSerial.tabs += INDENTATION_LENGTH; 
+}
+
+inline void dbg_subIndent(void) {
+    debugSerial.tabs -= INDENTATION_LENGTH; 
+}
+
+#endif // USE_DEBUG_SERIAL

--- a/src/main/io/debugserial.h
+++ b/src/main/io/debugserial.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#define DBG_DEFAULT_BAUDRATE 115200
+#define DBG_DEFAULT_PORT SERIAL_PORT_USART3
+
+#ifdef USE_DEBUG_SERIAL
+	#define __DBG_SETRATE(x)    dbg_setRate(x)
+	#define __DBG_TICK()		dbg_tick()
+	#define __DBG_ENABLE()      dbg_enable()
+	#define __DBG_DISABLE()		dbg_disable()
+	#define __DBG_CLS()			dbg_clear()
+	#define	__DBG_ENTER()		dbg_enterFunction(__func__)
+	#define	__DBG_LEAVE()		dbg_leaveFunction(__func__)
+	#define __DBG_TEXT(x)		dbg_write(x)
+    #define __DBG_LINE(x)		dbg_writeLine(x)
+	#define __DBG_VALUEF(x, y)  dbg_valuef(x, y)
+	#define __printf(x) 		tfp_printf x
+	#define __DBG_EVERY(x,y) do {	\
+	        __DBG_SETRATE(x); 		\
+			y               		\
+			__DBG_TICK();     		\
+		} while(0);
+#else
+	#define __DBG_SETRATE(x)
+	#define __DBG_TICK()
+	#define __DBG_ENABLE()
+	#define __DBG_DISABLE()
+	#define __DBG_CLS()
+	#define	__DBG_ENTER(x)
+	#define	__DBG_LEAVE()
+    #define __DBG_TEXT(x)
+	#define __DBG_LINE(x)
+	#define __DBG_VALUEF(x, y)
+	#define __printf(x)
+	#define __DBG_EVERY(x,y) y
+#endif  // USE_DEBUG_SERIAL
+
+void dbg_initialize(serialPortIdentifier_e port_id, uint32_t baudrate);
+void dbg_setRate(uint16_t rate);
+void dbg_tick(void);
+void dbg_clear(void);
+void dbg_write(const char* str);
+void dbg_writeLine(const char* str);
+void dbg_valuef(const char* label, float val);
+void dbg_enterFunction(const char* str);
+void dbg_leaveFunction(const char* str);

--- a/src/main/osd_slave/osd_slave_init.c
+++ b/src/main/osd_slave/osd_slave_init.c
@@ -94,6 +94,11 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
+#ifdef USE_DEBUG_SERIAL
+#include "io/serial.h"
+#include "io/debugserial.h"
+#endif
+
 #ifdef TARGET_PREINIT
 void targetPreInit(void);
 #endif
@@ -172,6 +177,10 @@ void init(void)
 #endif
 
     serialInit(false, SERIAL_PORT_NONE);
+
+#ifdef USE_DEBUG_SERIAL
+    dbg_initialize(DBG_DEFAULT_PORT, DBG_DEFAULT_BAUDRATE);
+#endif
 
 #ifdef BEEPER
     beeperInit(beeperDevConfig());

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -28,6 +28,9 @@
 //#define SCHEDULER_DEBUG // define this to use scheduler debug[] values. Undefined by default for performance reasons
 #define DEBUG_MODE DEBUG_NONE // change this to change initial debug mode
 
+// Uncomment to enable serial debugging
+//#define USE_DEBUG_SERIAL
+
 #define I2C1_OVERCLOCK true
 #define I2C2_OVERCLOCK true
 


### PR DESCRIPTION
This PR adds generic support for serial debugging:
   - Based on code from smart audio (vtx_smartaudio.c)
   - Extracts details of debugging work and make it easier to write debugging info to serial port from any file using predefined macros. 
   - Code is disabled by default.