### PR TITLE
extend crash-flip mode

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -650,10 +650,10 @@ static void applyFlipOverAfterCrashModeToMotors(void)
             signYaw = 0;
         }
 
-        float cosPhi = (stickDeflectionPitchAbs + stickDeflectionRollAbs)/(sqrtf(2.0f) * stickDeflectionLength);
-        const float cos22p5 = 0.9238795f; // cos(PI/8.0f)
+        float cosPhi = (stickDeflectionPitchAbs + stickDeflectionRollAbs) / (sqrtf(2.0f) * stickDeflectionLength);
+        const float cosThreshold = sqrtf(3.0f)/2.0f; // cos(PI/6.0f)
 
-        if (cosPhi < cos22p5) {
+        if (cosPhi < cosThreshold) {
             // Enforce either roll or pitch exclusively, if not on diagonal
             if (stickDeflectionRollAbs > stickDeflectionPitchAbs) {
                 signPitch = 0;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -626,7 +626,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
 }
 
 #define CRASH_FLIP_DEADBAND 20
-#define CRASH_FLIP_STICK_MINF 0.1f
+#define CRASH_FLIP_STICK_MINF 0.15f
 
 static void applyFlipOverAfterCrashModeToMotors(void)
 {


### PR DESCRIPTION
This PR adds diagonal flipping (using one motor) and yaw wiggling (two motors) to the classic anti-turtle mode which only allows for pure pitch/roll (using two motors).

Tested it, works fine for me, but I have to admit that the outcome of using only one motor is a little less predictable than classic pitch/roll. This might be dangerous for larger quads and certainly needs some testing.

Which "mode" (classic roll/pitch, diagonal, yaw) is used is determined by the maximum absolute stick deflection. "Yaw wiggling" might be very useful when stuck in a tree, just gives it a little twist...