### PR TITLE
Runaway Takeoff Prevention - temporarily disable during configurator bench testing

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -127,6 +127,7 @@ static timeUs_t runawayTakeoffDeactivateUs = 0;
 static timeUs_t runawayTakeoffAccumulatedUs = 0;
 static bool runawayTakeoffCheckDisabled = false;
 static timeUs_t runawayTakeoffTriggerUs = 0;
+static bool runawayTakeoffTemporarilyDisabled = false;
 #endif
 
 
@@ -444,6 +445,14 @@ bool areSticksActive(uint8_t stickPercentLimit)
     }
     return false;
 }
+
+
+// allow temporarily disabling runaway takeoff prevention if we are connected
+// to the configurator and the ARMING_DISABLED_MSP flag is cleared.
+void runawayTakeoffTemporaryDisable(uint8_t disableFlag)
+{
+    runawayTakeoffTemporarilyDisabled = disableFlag;
+}
 #endif
 
 
@@ -530,6 +539,7 @@ bool processRx(timeUs_t currentTimeUs)
         && pidConfig()->runaway_takeoff_prevention
         && !runawayTakeoffCheckDisabled
         && !flipOverAfterCrashMode
+        && !runawayTakeoffTemporarilyDisabled
         && !STATE(FIXED_WING)) {
 
         // Determine if we're in "flight"
@@ -767,6 +777,7 @@ static void subTaskPidController(timeUs_t currentTimeUs)
         && pidConfig()->runaway_takeoff_prevention
         && !runawayTakeoffCheckDisabled
         && !flipOverAfterCrashMode
+        && !runawayTakeoffTemporarilyDisabled
         && (!feature(FEATURE_MOTOR_STOP) || isAirmodeActive() || (calculateThrottleStatus() != THROTTLE_LOW))) {
 
         const float runawayTakeoffThreshold = pidConfig()->runaway_takeoff_threshold * 10.0f;

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -48,3 +48,5 @@ void updateRcCommands(void);
 
 void taskMainPidLoop(timeUs_t currentTimeUs);
 bool isFlipOverAfterCrashMode(void);
+
+void runawayTakeoffTemporaryDisable(uint8_t disableFlag);

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1777,13 +1777,23 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
     case MSP_SET_ARMING_DISABLED:
         {
             const uint8_t command = sbufReadU8(src);
+            uint8_t disableRunawayTakeoff = 0;
+            if (sbufBytesRemaining(src)) {
+                disableRunawayTakeoff = sbufReadU8(src);
+            }
             if (command) {
                 setArmingDisabled(ARMING_DISABLED_MSP);
                 if (ARMING_FLAG(ARMED)) {
                     disarm();
                 }
+#ifdef USE_RUNAWAY_TAKEOFF
+                runawayTakeoffTemporaryDisable(false);
+#endif
             } else {
                 unsetArmingDisabled(ARMING_DISABLED_MSP);
+#ifdef USE_RUNAWAY_TAKEOFF
+                runawayTakeoffTemporaryDisable(disableRunawayTakeoff);
+#endif
             }
         }
         break;


### PR DESCRIPTION
**Temporarily** disables Runaway Takeoff Prevention when the `ARMING_DISABLED_MSP` flag is cleared in the configurator by switching the safety switch on the motors tab.  Allows bench testing the motors and flight controller response without triggering a runaway takeoff auto-disarm.

Partially addresses https://github.com/betaflight/betaflight/issues/5164

Requires coordination with the Configurator to pass an extra flag in the `MSP_ARMING_DISABLE` msp command to determine if runaway takeoff should be temporarily disabled.  If the extra flag is not found (empty buffer) then it is assumed to be false to preserve compatibility while changes are made to the configurator.