### PR TITLE
Fixed parameter group violations in `motorDevConfig_t`, incremented EEPROM config version before 3.3.0 release.

### DIFF
--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define EEPROM_CONF_VERSION 167
+#define EEPROM_CONF_VERSION 168
 
 bool isEEPROMContentValid(void);
 bool loadEEPROM(void);

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -165,14 +165,13 @@ typedef struct {
     IO_t io;
 } pwmOutputPort_t;
 
+//CAVEAT: This is used in the `motorConfig_t` parameter group, so the parameter group constraints apply
 typedef struct motorDevConfig_s {
     uint16_t motorPwmRate;                  // The update rate of motor outputs (50-498Hz)
     uint8_t  motorPwmProtocol;              // Pwm Protocol
     uint8_t  motorPwmInversion;             // Active-High vs Active-Low. Useful for brushed FCs converted for brushless operation
     uint8_t  useUnsyncedPwm;
-#ifdef USE_DSHOT_DMAR
     uint8_t  useBurstDshot;
-#endif
     ioTag_t  ioTags[MAX_SUPPORTED_MOTORS];
 } motorDevConfig_t;
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -66,7 +66,7 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .yaw_motors_reversed = false,
 );
 
-PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 1);
 
 void pgResetFn_motorConfig(motorConfig_t *motorConfig)
 {


### PR DESCRIPTION
There have been a number of reports of 'bugs' that in the end turned out to be caused by users with corrupted EEPROM config. Since the EEPROM version number was increased **right after the 3.2 release** to enable users to cleanly test 3.3 nightly builds, I think increasing the version number (and thus forcing a reset to defaults), now, **before the 3.3.0 release**, will help us to reduce the number of false bug reports caused by users switching from nightly builds to release candidates / the released version.
Any thoughts on how to better manage the EEPROM version / config reset functionality?