### PR TITLE
Spektrum iX12 adaption of CMS start screen.

### DIFF
--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -67,9 +67,9 @@ static int srxlClearScreen(displayPort_t *displayPort)
     srxlWriteString(displayPort, 1, 0,  "BETAFLIGHT");
 
     if ( displayPort->grabCount == 0 ) {
-        srxlWriteString(displayPort, 0, 3,  CMS_STARTUP_HELP_TEXT1);
-        srxlWriteString(displayPort, 2, 4,  CMS_STARTUP_HELP_TEXT2);
-        srxlWriteString(displayPort, 2, 5,  CMS_STARTUP_HELP_TEXT3);
+        srxlWriteString(displayPort, 0, 2,  CMS_STARTUP_HELP_TEXT1);
+        srxlWriteString(displayPort, 2, 3,  CMS_STARTUP_HELP_TEXT2);
+        srxlWriteString(displayPort, 2, 4,  CMS_STARTUP_HELP_TEXT3);
     }
     return 0;
 }


### PR DESCRIPTION
Minor cosmetic adaptation to the new Spektrum iX12 Tx. The CMS welcome screen looked awful because of the way iX12 has divided the TM screen into 2 columns. Work around by moving the text up one row.

Looks like this before the change, on DX18 and iX12.
![spektrum_dx18_tm_text_cms_before](https://user-images.githubusercontent.com/15121917/36144325-04ea2ab6-10ae-11e8-9d07-2eb08cee4e05.jpg)
![spektrum_ix12_tm_text_cms_before](https://user-images.githubusercontent.com/15121917/36144326-05060a56-10ae-11e8-96a7-3adb51baab3a.jpg)

After this PR it looks like this
![spektrum_dx18_tm_text_cms_after](https://user-images.githubusercontent.com/15121917/36144338-0bfbacb2-10ae-11e8-9814-73a09fb2d349.jpg)
![spektrum_ix12_tm_text_cms_after](https://user-images.githubusercontent.com/15121917/36144339-0c25f35a-10ae-11e8-9f71-097281dd3377.jpg)
