### PR TITLE
Disarm when configurator sets ARMING_DISABLED_MSP arming disabled flag

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1779,6 +1779,9 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             const uint8_t command = sbufReadU8(src);
             if (command) {
                 setArmingDisabled(ARMING_DISABLED_MSP);
+                if (ARMING_FLAG(ARMED)) {
+                    disarm();
+                }
             } else {
                 unsetArmingDisabled(ARMING_DISABLED_MSP);
             }


### PR DESCRIPTION
Addresses an edge case where the user could turn on the safety switch (on motors tab), arm and spin the motors, and then turn off the safety switch (without disarming first).  In this scenario the motors would keep spinning even though the `ARMING_DISABLED_MSP` arming disabled flag would be set.

This change checks the arming state and disarms when the configurator sets the `ARMING_DISABLED_MSP` flag.