### PR TITLE
Enable ESCSERIAL for MOTOLABF4 targets

### DIFF
--- a/src/main/target/MOTOLABF4/target.c
+++ b/src/main/target/MOTOLABF4/target.c
@@ -28,7 +28,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0 ), // PWM2
     DEF_TIM(TIM2, CH2, PB3, TIM_USE_MOTOR, 0, 0 ), // PWM3
     DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0 ), // PWM4
-    DEF_TIM(TIM5, CH3, PA2, TIM_USE_MOTOR, 0, 0 ), // PWM5
-    DEF_TIM(TIM5, CH4, PA3, TIM_USE_MOTOR, 0, 0 ), // PWM6
+    DEF_TIM(TIM5, CH3, PA2, TIM_USE_NONE,  0, 0 ), // PWM5, UART 2 TX
+    DEF_TIM(TIM5, CH4, PA3, TIM_USE_NONE,  0, 0 ), // PWM6, UART 2 RX
     DEF_TIM(TIM1, CH1, PA8, TIM_USE_LED,   0, 0 ), // Serial LED
+    DEF_TIM(TIM4, CH3, PB8, TIM_USE_NONE,  0, 0 ), // ESC serial (unwired)
 };

--- a/src/main/target/MOTOLABF4/target.h
+++ b/src/main/target/MOTOLABF4/target.h
@@ -104,6 +104,9 @@
 #define RTC6705_CS_PIN          PC7
 #endif
 
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  PB8
+
 #define USE_SPI
 #define USE_SPI_DEVICE_1        // MPU6000
 #define USE_SPI_DEVICE_2        // SDcard
@@ -150,5 +153,5 @@
 #define TARGET_IO_PORTC 0xffff
 #define TARGET_IO_PORTD (BIT(2))
 
-#define USABLE_TIMER_CHANNEL_COUNT 7
-#define USED_TIMERS  ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) )
+#define USABLE_TIMER_CHANNEL_COUNT 8
+#define USED_TIMERS  ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) )


### PR DESCRIPTION
Adds ESCSERIAL #defines for MOTOLABF4 targets MLTEMPF4 and MLTYPHF4.