### PR TITLE
Fixed ordering of SPI RX protocols.

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -207,7 +207,8 @@ static const char * const lookupTableRxSpi[] = {
     "FRSKY_D",
     "FRSKY_X",
     "FLYSKY",
-    "FLYSKY_2A"
+    "FLYSKY_2A",
+    "KN"
 };
 #endif
 

--- a/src/main/rx/rx_spi.h
+++ b/src/main/rx/rx_spi.h
@@ -19,6 +19,7 @@
 
 #include "rx/rx.h"
 
+// Used in MSP. Append at end.
 typedef enum {
     RX_SPI_NRF24_V202_250K = 0,
     RX_SPI_NRF24_V202_1M,
@@ -28,11 +29,11 @@ typedef enum {
     RX_SPI_NRF24_CX10A,
     RX_SPI_NRF24_H8_3D,
     RX_SPI_NRF24_INAV,
-    RX_SPI_NRF24_KN,
     RX_SPI_FRSKY_D,
     RX_SPI_FRSKY_X,
     RX_SPI_A7105_FLYSKY,
     RX_SPI_A7105_FLYSKY_2A,
+    RX_SPI_NRF24_KN,
     RX_SPI_PROTOCOL_COUNT
 } rx_spi_protocol_e;
 


### PR DESCRIPTION
Fixes #5194.

@fgiudice98: This was broken by your #4994 inserting an element into the middle of the `rx_spi_protocol_e` enum. Like a siginficant number of other enums that are used as parameter values, it is also used directly in MSP. As a consequence, all new elements should be appended to the end, since inserting / deleting in the middle will require a change in the configurator (and potentially other applications using MSP to configure Betaflight), and should be avoided.

Also, a pull request to the configurator to make the new protocol known would be appreciated.