### PR TITLE
motorDevInit  IOConfigGPIOAF instead of IOConfigGPIO

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -303,11 +303,7 @@ void motorDevInit(const motorDevConfig_t *motorConfig, uint16_t idlePulse, uint8
         }
 #endif
 
-#if defined(USE_HAL_DRIVER)
         IOConfigGPIOAF(motors[motorIndex].io, IOCFG_AF_PP, timerHardware->alternateFunction);
-#else
-        IOConfigGPIO(motors[motorIndex].io, IOCFG_AF_PP);
-#endif
 
         /* standard PWM outputs */
         // margin of safety is 4 periods when unsynced


### PR DESCRIPTION
#3991 strikes back again!!!

A call to `IOConfigGPIO` here for F4 caused pins with `TIM_USE_NONE` in `timerHardware` initialized as simple GPIO, not a timer, preventing purely dynamic assignment of pins to motors.

I think this is the last case mentioned in https://github.com/betaflight/betaflight/pull/3991#issuecomment-326214013