### PR TITLE
Change gyro_overflow_detect to use filtered instead of raw gyro data

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -183,23 +183,6 @@ bool mpuGyroRead(gyroDev_t *gyro)
     return true;
 }
 
-gyroOverflow_e mpuGyroCheckOverflow(const gyroDev_t *gyro)
-{
-    // we cannot detect overflow directly, so assume overflow if absolute gyro rate is large
-    gyroOverflow_e ret = GYRO_OVERFLOW_NONE;
-    const int16_t overflowValue = 0x7C00; // this is a slightly conservative value, could probably be as high as 0x7FF0
-    if (gyro->gyroADCRaw[X] > overflowValue || gyro->gyroADCRaw[X] < -overflowValue) {
-        ret |= GYRO_OVERFLOW_X;
-    }
-    if (gyro->gyroADCRaw[Y] > overflowValue || gyro->gyroADCRaw[Y] < -overflowValue) {
-        ret |= GYRO_OVERFLOW_Y;
-    }
-    if (gyro->gyroADCRaw[Z] > overflowValue || gyro->gyroADCRaw[Z] < -overflowValue) {
-        ret |= GYRO_OVERFLOW_Z;
-    }
-    return ret;
-}
-
 bool mpuGyroReadSPI(gyroDev_t *gyro)
 {
     static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -211,7 +211,6 @@ typedef struct mpuDetectionResult_s {
 
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
-gyroOverflow_e mpuGyroCheckOverflow(const struct gyroDev_s *gyro);
 bool mpuGyroRead(struct gyroDev_s *gyro);
 bool mpuGyroReadSPI(struct gyroDev_s *gyro);
 void mpuDetect(struct gyroDev_s *gyro);


### PR DESCRIPTION
Addresses https://github.com/betaflight/betaflight/issues/5171

Noise and momentary spikes in gyro data (particularly in 32K mode) were causing false triggering of the gyro overflow detection.

Also adjusted the trigger and reset rates slightly (approx. 1950dps and 1850dps respectively for 2000dps gyros).

Optimized the gyro loop slightly by eliminating 3 floating point multiplies.

Fixed bug for gyros that may not be +-2000dps full scale.  The previous code used a straight integer comparison to the raw ADC value of approximately 0x7C00 which resulted in about 96.8% full scale.  The problem is that we may encounter a gyro that's not +-2000dps.  The reset logic was based on 1800dps times the gyro scaling to get the cutoff point.  So it was assuming a +-2000dps scale.  The new logic uses 97.5% and 92.5% of the full scale values for trigger and reset.  So it's no longer dependent in the full range scale of the gyro.