### PR TITLE
Reactivate Runaway Takeoff Prevention after using crash-flip

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -307,6 +307,9 @@ void tryArm(void)
                 }
             } else {
                 flipOverAfterCrashMode = true;
+#ifdef USE_RUNAWAY_TAKEOFF
+                runawayTakeoffCheckDisabled = false;
+#endif
                 if (!feature(FEATURE_3D)) {
                     pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED);
                 }


### PR DESCRIPTION
Reset Runaway Takeoff Prevention so that on the next arming after crash-flip is used it will once again be active.  The use-case is that the pilot may have broken props or other damage that could cause a runaway event.  After successful takeoff the feature will deactivate for the remainder of the battery as before.

Based on an excellent suggestion from a pilot that experienced a runway on arming after crash-flip because of unknown damage (pre-BF3.3).