### PR TITLE
Output more information in MSP_BOARD_INFO

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -427,6 +427,14 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, 0);  // 0 == FC
 #endif
 #endif
+        // 1 = USE_VCP, 0 = no VCP
+        // This way the configurator can find wether a board
+        // uses VCP without relying on a board list.
+#ifdef USE_VCP
+        sbufWriteU8(dst, 1);
+#else
+        sbufWriteU8(dst, 0);
+#endif
         sbufWriteU8(dst, strlen(targetName));
         sbufWriteData(dst, targetName, strlen(targetName));
         break;

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -427,6 +427,8 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, 0);  // 0 == FC
 #endif
 #endif
+        sbufWriteU8(dst, strlen(targetName));
+        sbufWriteData(dst, targetName, strlen(targetName));
         break;
 
     case MSP_BUILD_INFO:


### PR DESCRIPTION
Two new items added to MSP_BOARD_INFO

- Wether the board uses VCP (uint8 - [0,1]). This lets the configurator find wether the board uses VCP without relying on a external list.

- The full target name (length as uint8 followed by the board name without null terminator). This allows MSP clients to retrieve the actual target name, which
is useful for e.g. automatically upgrading the firmware on a board
without asking the user to select the target manually or to present
a warning dialog if we detect the user has chosen the wrong target.