### PR TITLE
Fixed motor order for KISSCC to match manual (QUADX1234).

### DIFF
--- a/src/main/target/KISSFC/target.c
+++ b/src/main/target/KISSFC/target.c
@@ -26,10 +26,11 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 #ifdef KISSCC
-    DEF_TIM(TIM1,  CH2N, PB14, TIM_USE_MOTOR,               0),
-    DEF_TIM(TIM8,  CH2N, PB0,  TIM_USE_MOTOR,               0),
-    DEF_TIM(TIM15, CH1N, PB15, TIM_USE_MOTOR,               0),
     DEF_TIM(TIM1,  CH1,  PA8,  TIM_USE_MOTOR,               0),
+    DEF_TIM(TIM8,  CH2N, PB0,  TIM_USE_MOTOR,               0),
+    DEF_TIM(TIM1,  CH2N, PB14, TIM_USE_MOTOR,               0),
+    DEF_TIM(TIM15, CH1N, PB15, TIM_USE_MOTOR,               0),
+
     DEF_TIM(TIM3,  CH1,  PA6,  TIM_USE_MOTOR,               0),
     DEF_TIM(TIM17, CH1,  PA7,  TIM_USE_MOTOR,               0),
     DEF_TIM(TIM16, CH1N, PA13, TIM_USE_PWM,                 0),

--- a/src/main/target/KISSFC/target.h
+++ b/src/main/target/KISSFC/target.h
@@ -48,6 +48,9 @@
 #define USE_ACC
 #define USE_ACC_MPU6050
 #define ACC_MPU6050_ALIGN       CW90_DEG
+
+#define TARGET_DEFAULT_MIXER    MIXER_QUADX_1234
+
 #undef USE_LED_STRIP
 #else
 #define USE_GYRO


### PR DESCRIPTION
Fixes #5201.