### PR TITLE
YupiF7 - Correction of DMA conflict

### DIFF
--- a/src/main/target/YUPIF7/target.c
+++ b/src/main/target/YUPIF7/target.c
@@ -26,7 +26,7 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PPM,                 0, 0 ), // PPM IN
-    DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_MOTOR,               0, 0 ), // S1_OUT - DMA1_ST2
+    DEF_TIM(TIM2,  CH1, PA0,  TIM_USE_MOTOR,               0, 0 ), // S1_OUT - DMA1_ST2
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               0, 0 ), // S2_OUT - DMA1_ST4
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               0, 0 ), // S3_OUT - DMA1_ST1
     DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               0, 1 ), // S4_OUT - DMA1_ST6


### PR DESCRIPTION
Only change in target.c file of YupiF7 target. Timer change to avoid DMA conflict when Dshot is used with Led strip.