### PR TITLE
Biquad RC+FIR2: Fix 'k' calculation to match previous Q/R impl.

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -306,8 +306,7 @@ float firFilterDenoiseUpdate(firFilterDenoise_t *filter, float input)
 // ledvinap's proposed RC+FIR2 Biquad-- 1st order IIR, RC filter k
 void biquadRCFIR2FilterInit(biquadFilter_t *filter, uint16_t f_cut, float dT)
 {
-    float RC = 1.0f / ( 2.0f * M_PI_FLOAT * f_cut );
-    float k = dT / (RC + dT);
+    float k = 1 - exp(-2 * M_PI_FLOAT * f_cut * dT);
     filter->b0 = k / 2;
     filter->b1 = k / 2;
     filter->b2 = 0;


### PR DESCRIPTION
* When I initially implemented the ability to specify the cutoff frequency directly (#5144), I took the logic from the pt1FilterInit to generate (k), the filter gain, without testing that 'k' would be similar to the previous (Q/R) version.
* It was shown by Saxin's MATLAB/Octave code that there was some divergence between the FKF code and the current Biquad RC+FIR2 code: https://github.com/betaflight/betaflight/pull/5215#issuecomment-366558358
> The differences are small but they do exist:
> Difference RMS = 0.4
> Max absolute diff. = 16
> Diff. Mean = 0.0015
* glowtape supplied a simple calculation in https://github.com/betaflight/betaflight/pull/5215#issuecomment-366580888 which generates similar
  'k' as the previous implementation. Notably, it is off for values of `Q=300 R=88` / `613Hz @ 32kHz` by `0.00254272`, but definitely closer than it was:

![difference between FKF / BiquadRC+FIR2](https://user-images.githubusercontent.com/6873/36363685-cc280bb2-15a3-11e8-9ffb-6b767069e201.png)

Here's the octave code previously shown by ledvinap modified to show both versions of 'k' calculation, and the difference (which you can see in your octave 'Workspace' section):
``` octave
len = 1000;

lastX = 0;
q = 300 * 0.000001;
r = 88 * 0.001;
p = 0;

vx = zeros([len,1]);
vk = zeros([len,1]);

input = rand([len,1]);

x = 0;


for i = 1:length(input)
  x += (x - lastX);

  % update last state
  lastX = x;

  % prediction update
  p = p + q;

  % measurement update
  k = p / (p + r);
  x += k * (input(i) - x);
  p = (1 - k) * p;

  vx(i)=x;
  vk(i)=k;
endfor


f_cut = 613;
dT = 32 * 0.000001;

q_r_k = 2 * 2 * sqrt(q) / (sqrt(q + 4 * r) + sqrt(q));  % RC filter k
k = 1 - exp(-2 * pi * f_cut * dT); % glowtape's proposed 'k'
diff_k = k - q_r_k; % difference between the two (check workspace for value)

b = [k/2, k/2, 0];
a = [1, -(1-k), 0];

fx = filter(b,a,input);   % IIR filter input data

plot(fx-vx);
```
Resulting values from workspace:
```
k = 0.115958
q_r_k = 0.113416
diff_k = 0.00254272
```

I'm opening this now for discussion in the hopes that we can come up with a minor modification to this commit which causes equivalence (e.g. diff_k = 0) while retaining the ability to specify the frequency cutoff.
