### PR TITLE
Add gyro rate checking to runaway takeoff activation to improve bench testing

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -100,6 +100,8 @@ enum {
 #ifdef USE_RUNAWAY_TAKEOFF
 #define RUNAWAY_TAKEOFF_DEACTIVATE_STICK_PERCENT 15   // 15% - minimum stick deflection during deactivation phase
 #define RUNAWAY_TAKEOFF_DEACTIVATE_PIDSUM_LIMIT  100  // 10.0% - pidSum limit during deactivation phase
+#define RUNAWAY_TAKEOFF_GYRO_LIMIT_RP            15   // Roll/pitch 15 deg/sec threshold to prevent triggering during bench testing without props
+#define RUNAWAY_TAKEOFF_GYRO_LIMIT_YAW           50   // Yaw 50 deg/sec threshold to prevent triggering during bench testing without props
 
 #define DEBUG_RUNAWAY_TAKEOFF_ENABLED_STATE      0
 #define DEBUG_RUNAWAY_TAKEOFF_ACTIVATING_DELAY   1
@@ -773,7 +775,8 @@ static void subTaskPidController(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_PIDLOOP, 1, micros() - startTime);
 
 #ifdef USE_RUNAWAY_TAKEOFF
-    // Check to see if runaway takeoff detection is active (anti-spaz) and the pidSum is over the threshold.
+    // Check to see if runaway takeoff detection is active (anti-taz), the pidSum is over the threshold,
+    // and gyro rate for any axis is above the limit for at least the activate delay period.
     // If so, disarm for safety
     if (ARMING_FLAG(ARMED)
         && !STATE(FIXED_WING)
@@ -784,9 +787,13 @@ static void subTaskPidController(timeUs_t currentTimeUs)
         && (!feature(FEATURE_MOTOR_STOP) || isAirmodeActive() || (calculateThrottleStatus() != THROTTLE_LOW))) {
 
         const float runawayTakeoffThreshold = pidConfig()->runaway_takeoff_threshold * 10.0f;
-        if ((fabsf(axisPIDSum[FD_PITCH]) >= runawayTakeoffThreshold)
+
+        if (((fabsf(axisPIDSum[FD_PITCH]) >= runawayTakeoffThreshold)
             || (fabsf(axisPIDSum[FD_ROLL]) >= runawayTakeoffThreshold)
-            || (fabsf(axisPIDSum[FD_YAW]) >= runawayTakeoffThreshold)) {
+            || (fabsf(axisPIDSum[FD_YAW]) >= runawayTakeoffThreshold))
+            && ((ABS(gyroAbsRateDps(FD_PITCH)) > RUNAWAY_TAKEOFF_GYRO_LIMIT_RP)
+                || (ABS(gyroAbsRateDps(FD_ROLL)) > RUNAWAY_TAKEOFF_GYRO_LIMIT_RP)
+                || (ABS(gyroAbsRateDps(FD_YAW)) > RUNAWAY_TAKEOFF_GYRO_LIMIT_YAW))) {
 
             if (runawayTakeoffTriggerUs == 0) {
                 runawayTakeoffTriggerUs = currentTimeUs + (pidConfig()->runaway_takeoff_activate_delay * 1000);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -915,3 +915,8 @@ bool gyroOverflowDetected(void)
 {
     return gyroSensor1.overflowDetected;
 }
+
+uint16_t gyroAbsRateDps(int axis)
+{
+    return fabsf(gyro.gyroADCf[axis]);
+}

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -96,3 +96,4 @@ void gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 int16_t gyroRateDps(int axis);
 bool gyroOverflowDetected(void);
+uint16_t gyroAbsRateDps(int axis);


### PR DESCRIPTION
Changed the triggering phase so that in addition to the pidSum needing to exceed runaway_takeoff_threshold, the gyro rate on any axis must exceed a threshold value to indicate the quad is actually moving. The threshold for the yaw axis is much higher since the torque of the motors can still yaw the craft without props whereas the roll/pitch axes have no authority and can't move the quad.

Bench testing without props will generally be better now and it's possible to wiggle the quad around without props.  It's still possible to trigger a disarm if you really crank the yaw around hard, but roll/pitch won't trigger.  Hand flying and moving the quad around to see the motors react will still cause a trigger because it's indistinguishable from a real runaway event.  However it's possible to hold the quad (**with the props removed!!!**) and move the sticks to feel the reaction of the motors.  As long as the quad is held still the disarm won't be triggered.

The thresholds are 15 deg/sec for roll/pitch, and 50 deg/sec for yaw.  These values are hard coded and no additional CLI parameters were needed.