### PR TITLE
Fix arming disabled beeps and OSD warning for runaway takeoff trigger

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -664,10 +664,15 @@ static bool osdDrawSingleElement(uint8_t item)
             // Show most severe reason for arming being disabled
             if (enabledWarnings & OSD_WARNING_ARMING_DISABLE && IS_RC_MODE_ACTIVE(BOXARM) && isArmingDisabled()) {
                 const armingDisableFlags_e flags = getArmingDisableFlags();
-                for (int i = 0; i < ARMING_DISABLE_FLAGS_COUNT; i++) {
-                    if (flags & (1 << i)) {
-                        osdFormatMessage(buff, sizeof(buff), armingDisableFlagNames[i]);
-                        break;
+                // if ARMING_DISABLED_RUNAWAY_TAKEOFF is set we want to display that message in preference to the others
+                if (flags & ARMING_DISABLED_RUNAWAY_TAKEOFF) {
+                    osdFormatMessage(buff, sizeof(buff), armingDisableFlagNames[ffs(ARMING_DISABLED_RUNAWAY_TAKEOFF)-1]);
+                } else {
+                    for (int i = 0; i < ARMING_DISABLE_FLAGS_COUNT; i++) {
+                        if (flags & (1 << i)) {
+                            osdFormatMessage(buff, sizeof(buff), armingDisableFlagNames[i]);
+                            break;
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
The disarming beep pattern was suppressing the arming disabled beeps for ARMING_DISABLED_RUNAWAY_TAKEOFF when the feature triggered and disarmed.  Changed to skip the disarming beeps if runaway takeoff triggered the disarm.

Additionally since the logic plays the first reason's pattern (in bit position order) if any other condition was set that was earlier in the list (like throttle) that would play instead.  The same applied to the OSD message.  This change gives preference to the ARMING_DISABLED_RUNAWAY_TAKEOFF reason in both the beep pattern and OSD warning message.

**I don't have a flight controller with and OSD currently built so I need someone to test the OSD portion.**  It looks correct to me but I would like confirmation that it's not breaking the arming disabled reason display.  To easily trigger a runaway takeoff event to test, simply arm the quad with **no props** and with the motors spinning give it a good shake.

I have tested the beep pattern and it's working as expected.