### PR TITLE
Spektrum CMS over TM performance increase.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -71,7 +71,7 @@
 #define CMS_MAX_DEVICE 4
 #endif
 
-static displayPort_t *pCurrentDisplay;
+displayPort_t *pCurrentDisplay;
 
 static displayPort_t *cmsDisplayPorts[CMS_MAX_DEVICE];
 static int cmsDeviceCount;

--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -8,6 +8,7 @@ extern bool cmsInMenu;
 
 // Device management
 bool cmsDisplayPortRegister(displayPort_t *pDisplay);
+displayPort_t *pCurrentDisplay;
 
 // For main.c and scheduler
 void cmsInit(void);

--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -29,7 +29,7 @@
 
 #include "telemetry/srxl.h"
 
-static displayPort_t srxlDisplayPort;
+displayPort_t srxlDisplayPort;
 
 static int srxlDrawScreen(displayPort_t *displayPort)
 {

--- a/src/main/io/displayport_srxl.h
+++ b/src/main/io/displayport_srxl.h
@@ -18,3 +18,4 @@
 #pragma once
 
 displayPort_t *displayPortSrxlInit();
+displayPort_t srxlDisplayPort;

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -25,6 +25,8 @@
 
 #include "build/version.h"
 
+#include "cms/cms.h"
+
 #include "common/crc.h"
 #include "common/streambuf.h"
 #include "common/utils.h"
@@ -232,8 +234,11 @@ static bool lineSent[SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS];
 int spektrumTmTextGenPutChar(uint8_t col, uint8_t row, char c)
 {
     if (row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS && col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS) {
-        srxlTextBuff[row][col] = c;
-        lineSent[row] = false;
+        // Only update and force a tm transmision if something has actually changed.
+        if (srxlTextBuff[row][col] != c) {
+          srxlTextBuff[row][col] = c;
+          lineSent[row] = false;
+        }
     }
     return 0;
 }
@@ -448,6 +453,7 @@ const srxlScheduleFnPtr srxlScheduleFuncs[SRXL_TOTAL_COUNT] = {
 #endif
 };
 
+
 static void processSrxl(timeUs_t currentTimeUs)
 {
     static uint8_t srxlScheduleIndex = 0;
@@ -462,6 +468,15 @@ static void processSrxl(timeUs_t currentTimeUs)
     } else {
         srxlFnPtr = srxlScheduleFuncs[srxlScheduleIndex + srxlScheduleUserIndex];
         srxlScheduleUserIndex = (srxlScheduleUserIndex + 1) % SRXL_SCHEDULE_USER_COUNT;
+
+#if defined (USE_SPEKTRUM_CMS_TELEMETRY) && defined (USE_CMS)
+        // Boost CMS performance by sending nothing else but CMS Text frames when in a CMS menu.
+        // Sideeffect, all other reports are still not sent if user leaves CMS without a proper EXIT.
+        if (cmsInMenu) {
+          srxlFnPtr = srxlFrameText;
+        }
+#endif
+
     }
 
     if (srxlFnPtr) {

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -26,6 +26,7 @@
 #include "build/version.h"
 
 #include "cms/cms.h"
+#include "io/displayport_srxl.h"
 
 #include "common/crc.h"
 #include "common/streambuf.h"
@@ -234,7 +235,7 @@ static bool lineSent[SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS];
 int spektrumTmTextGenPutChar(uint8_t col, uint8_t row, char c)
 {
     if (row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS && col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS) {
-        // Only update and force a tm transmision if something has actually changed.
+      // Only update and force a tm transmision if something has actually changed.
         if (srxlTextBuff[row][col] != c) {
           srxlTextBuff[row][col] = c;
           lineSent[row] = false;
@@ -472,8 +473,9 @@ static void processSrxl(timeUs_t currentTimeUs)
 #if defined (USE_SPEKTRUM_CMS_TELEMETRY) && defined (USE_CMS)
         // Boost CMS performance by sending nothing else but CMS Text frames when in a CMS menu.
         // Sideeffect, all other reports are still not sent if user leaves CMS without a proper EXIT.
-        if (cmsInMenu) {
-          srxlFnPtr = srxlFrameText;
+        if (cmsInMenu &&
+            (pCurrentDisplay == &srxlDisplayPort)) {
+            srxlFnPtr = srxlFrameText;
         }
 #endif
 


### PR DESCRIPTION
Some performance improvement on CMS over Spektrum Textgen telemetry. 
1. When in a CMS menu, only send Textgen TM reports. Nothing else.
2. Send only changed CMS rows, 

Side effect from no 1. If the user does not exit CMS properly the Current, Capacity and VTX status telemetry reports will not be available. Might need a note in the WiKi, saying "Leave CMS properly, or else...". 

Performance increases from about 24% to 33% bandwidth utilization of the telemetry rf link. Unfortunatly  there is no way to reach 100%, as the Spektrum protocol requires tm reports to be sent in sets of three with two mandatory tm reports. So, Textgen can only get 1/3 at best.
Still, performace is not even close to be called "fast", only going from "very slow" to "slow".

Before this PR:
![spektrum_tm_all_five_reports](https://user-images.githubusercontent.com/15121917/36432239-028b6904-165a-11e8-9f8d-8f3a7bf0e336.jpg)
With this PR:
![spektrum_tm_only_three_reports](https://user-images.githubusercontent.com/15121917/36432240-02b2189c-165a-11e8-8df6-2ee4936631bf.jpg)
