### PR TITLE
Removed duplicate legacy gyro_lpf validation from msp.c

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1157,13 +1157,8 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         break;
 
     case MSP_ADVANCED_CONFIG:
-        if (gyroConfig()->gyro_lpf) {
-            sbufWriteU8(dst, 8); // If gyro_lpf != OFF then looptime is set to 1000
-            sbufWriteU8(dst, 1);
-        } else {
-            sbufWriteU8(dst, gyroConfig()->gyro_sync_denom);
-            sbufWriteU8(dst, pidConfig()->pid_process_denom);
-        }
+        sbufWriteU8(dst, gyroConfig()->gyro_sync_denom);
+        sbufWriteU8(dst, pidConfig()->pid_process_denom);
         sbufWriteU8(dst, motorConfig()->dev.useUnsyncedPwm);
         sbufWriteU8(dst, motorConfig()->dev.motorPwmProtocol);
         sbufWriteU16(dst, motorConfig()->dev.motorPwmRate);


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/5039
 
Additional validation in `interface/msp.c` was resetting the gyro and pid denoms incorrectly under the assumption that any non-zero gyro_lpf value means the gyro is in 1KHz refresh rate.  The correct validation is already been performed by `fc/config.c` so the extra legacy validtions are not needed.
