### PR TITLE
Change crash-flip OSD message to track actual state rather than switch

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -57,6 +57,7 @@
 #include "drivers/time.h"
 
 #include "fc/config.h"
+#include "fc/fc_core.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
@@ -655,8 +656,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
             // Warn when in flip over after crash mode
             if ((enabledWarnings & OSD_WARNING_CRASH_FLIP)
-                  && (isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH))
-                  && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+                  && (isFlipOverAfterCrashMode())) {
                 osdFormatMessage(buff, sizeof(buff), "CRASH FLIP");
                 break;
             }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -35,6 +35,7 @@ extern "C" {
     #include "drivers/serial.h"
 
     #include "fc/config.h"
+    #include "fc/fc_core.h"
     #include "fc/rc_controls.h"
     #include "fc/rc_modes.h"
     #include "fc/runtime_config.h"
@@ -1015,4 +1016,8 @@ extern "C" {
     uint16_t getRssi(void) { return rssi; }
 
     uint16_t getCoreTemperatureCelsius(void) { return simulationCoreTemperature; }
+
+    bool isFlipOverAfterCrashMode(void) {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/5248

Needs Testing.

Previously the OSD crash-flip warning would only track the state of the activation switch.  So if the switch was disabled but still armed the message would go away, but the quad was still in active crash-flip mode until it was disarmed.  This change makes the OSD message follow the actual internal state for crash-flip.
