### PR TITLE
CF/BF - Fix incorrect ACC sensor name for ICM20608G.

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -96,7 +96,7 @@
 // sync with accelerationSensor_e
 const char * const lookupTableAccHardware[] = {
     "AUTO", "NONE", "ADXL345", "MPU6050", "MMA8452", "BMA280", "LSM303DLHC",
-    "MPU6000", "MPU6500", "MPU9250", "ICM20601", "ICM20602", "ICM20608", "ICM20649", "ICM20689",
+    "MPU6000", "MPU6500", "MPU9250", "ICM20601", "ICM20602", "ICM20608G", "ICM20649", "ICM20689",
     "BMI160", "FAKE"
 };
 


### PR DESCRIPTION
It was missing the 'G' suffix when compared to the gyro names.  Now the
two sensor name strings can be de-duplicated by the linker.

see `lookupTableAccHardware` and `lookupTableGyroHardware`.