### PR TITLE
Simplify HMC5883 Compass

### DIFF
--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -58,7 +58,7 @@ mag_t mag;                   // mag access functions
 #define COMPASS_INTERRUPT_TAG   IO_TAG_NONE
 #endif
 
-PG_REGISTER_WITH_RESET_FN(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 1);
 
 void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 {


### PR DESCRIPTION
Remove the mag gain calculation. After some tests the maximun difference
is 6 degrees, so is not important.

iNav, after some tests decided to remove the gain calculation of the HMC5883. If this is good for them (navigation based), must be good for us (racing based). More info: https://github.com/iNavFlight/inav/pull/2809

I've not tested it, my GPS+MAG died yesterday, so it needs some testing. This work is based in the iNav one but maybe I had some mistake :)

Some space free, before:
```
Linking OMNIBUSF4SD
   text    data     bss     dec     hex filename
 304793   10048   50836  365677   5946d ./obj/main/betaflight_OMNIBUSF4SD.elf
```

After:
```
Linking OMNIBUSF4SD
   text    data     bss     dec     hex filename
 304503   10048   50844  365395   59353 ./obj/main/betaflight_OMNIBUSF4SD.elf
```