### PR TITLE
VTX low power on disarm correction 

### DIFF
--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -31,6 +31,8 @@
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
 
+#include "flight/failsafe.h"
+
 #include "io/vtx.h"
 #include "io/vtx_string.h"
 #include "io/vtx_control.h"
@@ -106,7 +108,7 @@ static vtxSettingsConfig_t vtxGetSettings(void)
     }
 #endif
 
-    if (!ARMING_FLAG(ARMED) && settings.lowPowerDisarm) {
+    if (!ARMING_FLAG(ARMED) && settings.lowPowerDisarm && !failsafeIsActive()) {
         settings.power = VTX_SETTINGS_DEFAULT_POWER;
     }
 


### PR DESCRIPTION
Made VTX low power on disarm conditional on failsafe. …Keep VTX power up when in failsafe.
As per discussion in issue #5251. Makes it easier to find a failsafed Quad, if VTX keeps sending ar full power and does not go into a low power disarmed state.

Tested on BETAFLIGHTF3 by observing VTX power index on OSD while turning RC-Tx off. Now stays at configured full power (3 in my case), used to fall to low power (1). 
VTX Low power on dis-arm by AUX switch still works as earlier.
