### PR TITLE
Fix 3D on a switch throttle inversion/scale

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -324,20 +324,22 @@ void updateRcCommands(void)
 
     rcCommand[THROTTLE] = rcLookupThrottle(tmp);
 
-    if (feature(FEATURE_3D) && IS_RC_MODE_ACTIVE(BOX3D) && !failsafeIsActive()) {
-        fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);
-        rcCommand[THROTTLE] = rxConfig()->midrc + qMultiply(throttleScaler, PWM_RANGE_MAX - rxConfig()->midrc);
-    }
-
-    if (feature(FEATURE_3D) && flight3DConfig()->switched_mode3d && !failsafeIsActive()) {
-        if (IS_RC_MODE_ACTIVE(BOX3D)) {
-            reverseMotors = false;
-            fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);
-            rcCommand[THROTTLE] = rxConfig()->midrc + qMultiply(throttleScaler, PWM_RANGE_MAX - rxConfig()->midrc);
+    if (feature(FEATURE_3D) && !failsafeIsActive()) {
+        if (!flight3DConfig()->switched_mode3d) {
+            if (IS_RC_MODE_ACTIVE(BOX3D)) {
+                fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);
+                rcCommand[THROTTLE] = rxConfig()->midrc + qMultiply(throttleScaler, PWM_RANGE_MAX - rxConfig()->midrc);
+            }
         } else {
-            reverseMotors = true;
-            fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);
-            rcCommand[THROTTLE] = rxConfig()->midrc + qMultiply(throttleScaler, PWM_RANGE_MIN - rxConfig()->midrc);
+            if (IS_RC_MODE_ACTIVE(BOX3D)) {
+                reverseMotors = true;
+                fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);
+                rcCommand[THROTTLE] = rxConfig()->midrc + qMultiply(throttleScaler, PWM_RANGE_MIN - rxConfig()->midrc);
+            } else {
+                reverseMotors = false;
+                fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);
+                rcCommand[THROTTLE] = rxConfig()->midrc + qMultiply(throttleScaler, PWM_RANGE_MAX - rxConfig()->midrc);
+            }
         }
     }
     if (FLIGHT_MODE(HEADFREE_MODE)) {


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/5275

There was a logic inversion when 3d_switched_mode = ON causing the motor directions to be inverted.  Also the throttle scaling for reverse thrust was being applied twice from both the 3d_switched_mode = ON and 3d_switched_mode = OFF sections.

I don't have a 3D quad to test with, but I verified all of the motor outputs behaving correctly in the configurator and exactly matching the outputs before https://github.com/betaflight/betaflight/pull/5179