### PR TITLE
Add camera control pin define of the DALRCF405 target

### DIFF
--- a/src/main/target/DALRCF405/target.c
+++ b/src/main/target/DALRCF405/target.c
@@ -29,9 +29,9 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0),   // S1 (1,7)
     DEF_TIM(TIM8, CH1, PC6,  TIM_USE_MOTOR, 0, 0),   // S2 (2,2)
-    DEF_TIM(TIM1, CH3, PA10,  TIM_USE_MOTOR, 0, 0),  // S3 (2,6)  
-    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MOTOR, 0, 0),   // S4 (2,1)  (2.3 2.6 ) 
-    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MOTOR, 0, 0),    // S5 (2,4)  (2.2)
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MOTOR, 0, 0),   // S3 (2,6)
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MOTOR, 0, 1),   // S4 (2,1)  (2.3 2.6)
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_MOTOR, 0, 0),   // S5 (2,4)  (2.2)
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0),   // S6 (1,2)
 
     DEF_TIM(TIM3, CH2, PC7,  TIM_USE_MOTOR, 0, 0),   // S7 (1,5)

--- a/src/main/target/DALRCF405/target.h
+++ b/src/main/target/DALRCF405/target.h
@@ -29,6 +29,9 @@
 #define BEEPER                  PC13
 #define BEEPER_INVERTED
 
+//define camera control
+#define CAMERA_CONTROL_PIN PA5
+
 //Gyro & ACC------------------------------- 
 #define USE_SPI
 #define USE_SPI_DEVICE_1


### PR DESCRIPTION
With DALRCF405 target .Add camera control pin define PA5.
Can use for pwm or dac in fureture

