### PR TITLE
disable runcam camera control in runaway takeoff status

### DIFF
--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -225,7 +225,7 @@ static void rcdevice5KeySimulationProcess(timeUs_t currentTimeUs)
     }
 #endif
 
-    if (ARMING_FLAG(ARMED)) {
+    if (ARMING_FLAG(ARMED) || getArmingDisableFlags() & ARMING_DISABLED_RUNAWAY_TAKEOFF) {
         return;
     }
 

--- a/src/test/unit/rcdevice_unittest.cc
+++ b/src/test/unit/rcdevice_unittest.cc
@@ -1615,4 +1615,5 @@ extern "C" {
     uint8_t armingFlags = 0;
     bool cmsInMenu;
     uint32_t resumeRefreshAt = 0;
+    int getArmingDisableFlags(void) {return 0;}
 }


### PR DESCRIPTION
For the function of OSD cable simulation, it conflicts with the runaway take off prevent, for this version, we have disabled the function of OSD synchronization when the drone is detected in the state of runaway take off.