### PR TITLE
Disable stick command processing while ARMING_DISABLED_RUNAWAY_TAKEOFF is set

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -215,7 +215,7 @@ void processRcStickPositions()
         return;
     }
 
-    if (ARMING_FLAG(ARMED) || doNotRepeat || rcDelayMs <= STICK_DELAY_MS) {
+    if (ARMING_FLAG(ARMED) || doNotRepeat || rcDelayMs <= STICK_DELAY_MS || (getArmingDisableFlags() & ARMING_DISABLED_RUNAWAY_TAKEOFF)) {
         return;
     }
     doNotRepeat = true;

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -730,3 +730,6 @@ PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);
 void resetArmingDisabled(void) {}
 timeDelta_t getTaskDeltaTime(cfTaskId_e) { return 20000; }
 }
+armingDisableFlags_e getArmingDisableFlags(void) {
+    return (armingDisableFlags_e) 0;
+}


### PR DESCRIPTION
NOTE: This is a supplement to https://github.com/betaflight/betaflight/pull/5296 - not a replacement.

Addresses the rare possibility that if runway takeoff triggers and disarms while the pilot has the sticks in some valid stick command configuration. Prevents the stick command from processing until the craft is disarmed and the ARMING_DISABLED_RUNAWAY_TAKEOFF condition is cleared.

For example, if the pilot was mid throttle and went full yaw right and runway takeoff triggered, then camera control would have be entered.