### PR TITLE
Derived target FF_PIKOBLX_BURST PicoBLX with DShot and LED without rewiring and remapping

### DIFF
--- a/src/main/target/FF_PIKOBLX/target.h
+++ b/src/main/target/FF_PIKOBLX/target.h
@@ -107,5 +107,11 @@
 #define TARGET_IO_PORTC         (BIT(13)|BIT(14)|BIT(15))
 #define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(4))
 
+// Thanks to burst dshot, PIKOBLX is now capable of handling dshot and LED strip without any rewiring and remapping by a user
+#if defined(FF_PIKOBLX_BURST)
+#define ENABLE_DSHOT_DMAR true  // All 4 motors on TIM3, TIMUP on DMA1_CH3
+#define REMAP_TIM16_DMA         // Dodge DMA1_CH3 by remapping it to DMA1_CH6
+#endif
+
 #define USABLE_TIMER_CHANNEL_COUNT 9
 #define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(16) | TIM_N(17))


### PR DESCRIPTION
Thanks to burst dshot, PikoBLX is now capable of handling dshot and LED strip without any user side rewiring and remapping. PikoBLX actually has an ideal motor timer assignment for burst dshot, as all motors are on channels of the single timer TIM3.

The new target FF_PIKOBLX_BURST is created so that existing builds, which remaps PPM to one of motors will not break.