### PR TITLE
Simplified PID rate counter code

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -929,7 +929,7 @@ static void subTaskMotorUpdate(timeUs_t currentTimeUs)
 // Function for loop trigger
 void taskMainPidLoop(timeUs_t currentTimeUs)
 {
-    static uint8_t pidUpdateCountdown = 0;
+    static uint32_t pidUpdateCounter = 0;
 
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_GYROPID_SYNC)
     if (lockMainPID() != 0) return;
@@ -937,16 +937,13 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
 
     // DEBUG_PIDLOOP, timings for:
     // 0 - gyroUpdate()
-    // 1 - pidController()
+    // 1 - subTaskPidController()
     // 2 - subTaskMotorUpdate()
     // 3 - subTaskMainSubprocesses()
     gyroUpdate(currentTimeUs);
     DEBUG_SET(DEBUG_PIDLOOP, 0, micros() - currentTimeUs);
 
-    if (pidUpdateCountdown) {
-        pidUpdateCountdown--;
-    } else {
-        pidUpdateCountdown = pidConfig()->pid_process_denom - 1;
+    if (pidUpdateCounter++ % pidConfig()->pid_process_denom == 0) {
         subTaskPidController(currentTimeUs);
         subTaskMotorUpdate(currentTimeUs);
         subTaskMainSubprocesses(currentTimeUs);


### PR DESCRIPTION
After recent discussion over #5344 I've decided to go with `uint32_t` for `pidUpdateCounter` and skip explicit rollover logic as it's unlike to ever be reached. That saves one `str` instruction for resetting the `pidUpdateCounter` value.

If rollover is ever reached, it's effect would be an increase in PID loop rate for just one iteration as shown in the table below:
```
pid_process_denom	equivalent pid_process_denom due to rollover
1			no changes
2			no changes
3			1
4			no changes
5			1
6			4
7			4
8			no changes
9			4
10			6
11			4
12			4
13			9
14			4
15			1
16			no changes

gyro rate (KHz)		period (hours)
32			37
16			74
8			149
4			298
```

E.g. when running 32/10.67, every once in 37 hours PID rate may jump to 32 KHz for one invocation.
An effect occurring with a period of that many hours shouldn't be of concern to us :-)