### PR TITLE
CF/BF - Fix SPI init on SPRacingF3OSD.

### DIFF
--- a/src/main/osd_slave/osd_slave_init.c
+++ b/src/main/osd_slave/osd_slave_init.c
@@ -77,6 +77,7 @@
 
 #include "pg/adc.h"
 #include "pg/bus_i2c.h"
+#include "pg/bus_spi.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/vcd.h"
@@ -116,6 +117,20 @@ static IO_t busSwitchResetPin        = IO_NONE;
 
     // ENABLE
     IOLo(busSwitchResetPin);
+}
+#endif
+
+
+#ifdef USE_SPI
+// Pre-initialize all CS pins to input with pull-up.
+// It's sad that we can't do this with an initialized array,
+// since we will be taking care of configurable CS pins shortly.
+
+void spiPreInit(void)
+{
+#ifdef USE_MAX7456
+    spiPreInitCs(IO_TAG(MAX7456_SPI_CS_PIN));
+#endif
 }
 #endif
 
@@ -186,6 +201,11 @@ void init(void)
 #else
 
 #ifdef USE_SPI
+    spiPinConfigure(spiPinConfig());
+
+    // Initialize CS lines and keep them high
+    spiPreInit();
+
 #ifdef USE_SPI_DEVICE_1
     spiInit(SPIDEV_1);
 #endif


### PR DESCRIPTION
SPI init is currently broken, I had made this changes in CF a long time ago but noticed they had not been merged in so here's a new PR to fix it.

I noticed this due to the merge of the BF master branch into CF as there were some changes to spiPinConfig that also needed to be merged into CF.