### PR TITLE
Updated README and pull request template after 3.3 release.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,3 @@
-## Important: Feature freeze / release candidate phase for Betaflight 3.3
-
-From 01/02/2018 until the release of Betaflight 3.3.0 (scheduled for 01/03/2018), the project is in a 'feature freeze / release candidate' phase. This means:
-
-1. Pull requests can still be submitted as normal. Comments / discussions will probably be slower than normal due to shifted priorities;
-
-2. If your pull request is a fix for an existing bug, or an update for a single target that has a low risk of side effect for other targets, it will be reviewed, and if accepted merged into `master` for the 3.3 release;
-
-3. All other pull requests will be scheduled for 3.4, and discussed / reviewed / merged into `master` after 3.3.0 has been released. Please keep in mind that this will potentially mean that you will have to rebase your changes if they are broken by bugfixes made to 3.3.
-
-
 ## Important considerations when opening a pull request:
 
 1. Pull requests will only be accepted if they are opened against the `master` branch. Pull requests opened against other branches without prior consent from the maintainers will be closed;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![BetaFlight Notice, version 3.2 will be the last version of Betaflight to support STM32F1 based flight controllers, this includes NAZE, CC3D (original) and CJMCU like flight controllers](https://raw.githubusercontent.com/wiki/betaflight/betaflight/images/betaflight/bf3_2_notice.png)
+![Important Notice: Support for STM32F1 based flight controllers has been dropped in Betaflight release 3.3. This includes NAZE, CC3D (original) and CJMCU like flight controllers](https://raw.githubusercontent.com/wiki/betaflight/betaflight/images/betaflight/bf3_3_notice.png)
 
-![BetaFlight](https://raw.githubusercontent.com/wiki/betaflight/betaflight/images/betaflight/bf_logo.png)
+![Betaflight](https://raw.githubusercontent.com/wiki/betaflight/betaflight/images/betaflight/bf_logo.png)
 
 Betaflight is flight controller software (firmware) used to fly multi-rotor craft and fixed wing craft.
 
@@ -10,8 +10,7 @@ This fork differs from Baseflight and Cleanflight in that it focuses on flight p
 
 | Date  | Event |
 | - | - |
-| 01 February 2018 | Start of feature freeze / Release Candidate window for Betaflight 3.3 |
-| 01 March 2018 | Planned [release](https://github.com/betaflight/betaflight/milestone/6) date for Betaflight 3.3 |
+| 01 July 2018 | Planned [release](https://github.com/betaflight/betaflight/milestone/7) date for Betaflight 3.4 |
 
 ## Features
 


### PR DESCRIPTION
Needs the new F1 EOL notice to be deployed to https://raw.githubusercontent.com/wiki/betaflight/betaflight/images/betaflight/bf3_3_notice.png first.