### PR TITLE
Enabled Dshot burst by default for DALRCF405.

### DIFF
--- a/src/main/target/DALRCF405/target.h
+++ b/src/main/target/DALRCF405/target.h
@@ -20,9 +20,6 @@
 #define USBD_PRODUCT_STRING  "DALRCF405"
 //----------------------------------------
 
-//#define USE_TARGET_CONFIG
-#define USE_DSHOT_DMAR
-
 //LED & BEE------------------------------- 
 #define LED0_PIN                PC14
 
@@ -139,6 +136,8 @@
  
 #define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
 #define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+#define ENABLE_DSHOT_DMAR       true
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN PA3

--- a/src/main/target/NOX/target.h
+++ b/src/main/target/NOX/target.h
@@ -25,8 +25,6 @@
 #define BEEPER                  PC13
 #define BEEPER_INVERTED
 
-#define USE_DSHOT_DMAR
-
 #define INVERTER_PIN_UART2      PC14
 
 #define USE_ACC


### PR DESCRIPTION
Also removed some unneeded `USE_DSHOT_DMAR` defines.