### PR TITLE
Fixed possibility of getting stuck in F7 bootloader mode

### DIFF
--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -197,6 +197,9 @@ void checkForBootLoaderRequest(void)
     bt = (*(__IO uint32_t *) (BKPSRAM_BASE + 4)) ;
     if ( bt == 0xDEADBEEF ) {
         (*(__IO uint32_t *) (BKPSRAM_BASE + 4)) =  0xCAFEFEED; // Reset our trigger
+        // Backup SRAM is write-back by default, ensure value actually reaches memory
+        // Another solution would be marking BKPSRAM as write-through in Memory Protection Unit settings
+        SCB_CleanDCache_by_Addr((uint32_t *) (BKPSRAM_BASE + 4), sizeof(uint32_t));
 
         void (*SysMemBootJump)(void);
         __SYSCFG_CLK_ENABLE();


### PR DESCRIPTION
Backup SRAM used for bootloader reboot request flag on F7 is `write-back` and there's a possibility `0xCAFEFEED` will never be written to actual memory, making FC stuck in bootloader mode until a power cycle.
