### PR TITLE
Ensure beeper is silenced after turning off the AUX switch

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -168,6 +168,8 @@ static uint8_t beep_multiBeeps[MAX_MULTI_BEEPS + 1];
 // Beeper off = 0 Beeper on = 1
 static uint8_t beeperIsOn = 0;
 
+static uint8_t beeperRxSet = 0;
+
 // Place in current sequence
 static uint16_t beeperPos = 0;
 // Time when beeper routine must act next time
@@ -371,6 +373,10 @@ void beeperUpdate(timeUs_t currentTimeUs)
     // If beeper option from AUX switch has been selected
     if (IS_RC_MODE_ACTIVE(BOXBEEPERON)) {
         beeper(BEEPER_RX_SET);
+        beeperRxSet = 1;
+    } else if (beeperRxSet) {
+        beeperSilence();
+        beeperRxSet = 0;
 #ifdef USE_GPS
     } else if (feature(FEATURE_GPS) && IS_RC_MODE_ACTIVE(BOXBEEPGPSCOUNT)) {
         beeperGpsStatus();


### PR DESCRIPTION
This may be specific to my Kakute F4 V2 board.  After triggering RX_SET then turning the switch back off, the beeper stays on with a continuous tone.  I've tried beeper_inversion on (the default for this board) and off with the same results.

Open to other fixes as I could be missing something obvious or more fundamental, but this fixes it for me.