### PR TITLE
Fix OSD "DISARMED" blanking the display when armed

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -134,6 +134,7 @@ timeUs_t resumeRefreshAt = 0;
 #define REFRESH_1S    1000 * 1000
 
 static uint8_t armState;
+static bool lastArmState;
 
 static displayPort_t *osdDisplayPort;
 
@@ -387,7 +388,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     uint8_t elemPosX = OSD_X(osdConfig()->item_pos[item]);
     uint8_t elemPosY = OSD_Y(osdConfig()->item_pos[item]);
-    char buff[OSD_ELEMENT_BUFFER_LENGTH];
+    char buff[OSD_ELEMENT_BUFFER_LENGTH] = "";
 
     switch (item) {
     case OSD_RSSI_VALUE:
@@ -724,7 +725,9 @@ static bool osdDrawSingleElement(uint8_t item)
         if (!ARMING_FLAG(ARMED)) {
             tfp_sprintf(buff, "DISARMED");
         } else {
-            tfp_sprintf(buff, "        ");
+            if (!lastArmState) {  // previously disarmed - blank out the message one time
+                tfp_sprintf(buff, "        ");
+            }
         }
         break;
 
@@ -1291,6 +1294,7 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
 #endif
     }
 #endif
+    lastArmState = ARMING_FLAG(ARMED);
 }
 
 /*


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/5378

The "DISARMED" message was displaying blank space when armed and this was overriding other OSD items.