### PR TITLE
Dshot now beeps with beeper preferred flags

### DIFF
--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -22,8 +22,13 @@
 
 #include "drivers/io.h"
 #include "drivers/pwm_output.h"
+#include "drivers/time.h"
+
+#include "flight/mixer.h"
+#include "fc/runtime_config.h"
 
 #include "pg/beeper_dev.h"
+#include "pg/beeper.h"
 
 #include "sound_beeper.h"
 
@@ -31,6 +36,22 @@
 static IO_t beeperIO = DEFIO_IO(NONE);
 static bool beeperInverted = false;
 static uint16_t beeperFrequency = 0;
+#endif
+
+#ifdef BEEPER
+void systemBeepDshot(void)
+{
+#ifdef USE_DSHOT
+    if (!ARMING_FLAG(ARMED)) {
+        pwmDisableMotors();
+        delay(1);
+        pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), beeperConfig()->dshotBeaconTone);
+        pwmEnableMotors();
+    }
+#else
+    UNUSED(void)
+#endif
+}
 #endif
 
 void systemBeep(bool onoff)
@@ -43,7 +64,7 @@ void systemBeep(bool onoff)
     }
 #else
     UNUSED(onoff);
-#endif
+#endif // BEEPER
 }
 
 void systemBeepToggle(void)

--- a/src/main/drivers/sound_beeper.h
+++ b/src/main/drivers/sound_beeper.h
@@ -20,13 +20,18 @@
 #ifdef BEEPER
 #define BEEP_TOGGLE              systemBeepToggle()
 #define BEEP_OFF                 systemBeep(false)
+#ifdef USE_DSHOT
+#define BEEP_ON                  systemBeepDshot()
+#else  // USE_DSHOT
 #define BEEP_ON                  systemBeep(true)
-#else
+#endif // USE_DSHOT
+#else  // BEEPER
 #define BEEP_TOGGLE do {} while (0)
 #define BEEP_OFF    do {} while (0)
 #define BEEP_ON     do {} while (0)
-#endif
+#endif // BEEPER
 
+void systemBeepDshot(void);
 void systemBeep(bool on);
 void systemBeepToggle(void);
 struct beeperDevConfig_s;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -389,17 +389,6 @@ void beeperUpdate(timeUs_t currentTimeUs)
     if (!beeperIsOn) {
         beeperIsOn = 1;
 
-#ifdef USE_DSHOT
-        if (!areMotorsRunning() && beeperConfig()->dshotBeaconTone && (beeperConfig()->dshotBeaconTone <= DSHOT_CMD_BEACON5) && (currentBeeperEntry->mode == BEEPER_RX_SET || currentBeeperEntry->mode == BEEPER_RX_LOST)) {
-            pwmDisableMotors();
-            delay(1);
-
-            pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), beeperConfig()->dshotBeaconTone);
-
-            pwmEnableMotors();
-        }
-#endif
-
         if (currentBeeperEntry->sequence[beeperPos] != 0) {
             if (!(getBeeperOffMask() & (1 << (currentBeeperEntry->mode - 1))))
                 BEEP_ON;


### PR DESCRIPTION
If dshot is selected for beeps, beeper preferred flags work for dshot beeps now.

Update:
 - Added safeguard conditional to prevent in-flight dshot beeping.

Tested on BetaflightF4 board.