### PR TITLE
Run FFT off statically filtered data

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -65,7 +65,6 @@ typedef struct gyroDev_s {
     float scale;                                            // scalefactor
     float gyroZero[XYZ_AXIS_COUNT];
     float gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
-    float gyroADCStaticf[XYZ_AXIS_COUNT];
     float gyroADCf[XYZ_AXIS_COUNT];
     int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -65,6 +65,7 @@ typedef struct gyroDev_s {
     float scale;                                            // scalefactor
     float gyroZero[XYZ_AXIS_COUNT];
     float gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
+    float gyroADCStaticf[XYZ_AXIS_COUNT];
     float gyroADCf[XYZ_AXIS_COUNT];
     int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -999,7 +999,7 @@ static FAST_CODE void gyroUpdateSensor(gyroSensor_t *gyroSensor, timeUs_t curren
 
 #ifdef USE_GYRO_DATA_ANALYSE
     if (isDynamicFilterActive()) {
-        gyroDataAnalyse(&gyroSensor->gyroDev, gyroSensor->notchFilterDyn);
+        gyroDataAnalyse(gyroSensor->notchFilterDyn);
     }
 #endif
 }

--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -135,7 +135,7 @@ void gyroDataAnalysePush(const int axis, const float sample)
 /*
  * Collect gyro data, to be analysed in gyroDataAnalyseUpdate function
  */
-void gyroDataAnalyse(const struct gyroDev_s *gyroDev, biquadFilter_t *notchFilterDyn)
+void gyroDataAnalyse(biquadFilter_t *notchFilterDyn)
 {
     // samples should have been pushed by `gyroDataAnalysePush`
     // if gyro sampling is > 1kHz, accumulate multiple samples

--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -130,11 +130,11 @@ const gyroFftData_t *gyroFftData(int axis)
 /*
  * Collect gyro data, to be analysed in gyroDataAnalyseUpdate function
  */
-void gyroDataAnalyse(const gyroDev_t *gyroDev, biquadFilter_t *notchFilterDyn)
+void gyroDataAnalyse(const struct gyroDev_s *gyroDev, biquadFilter_t *notchFilterDyn)
 {
     // if gyro sampling is > 1kHz, accumulate multiple samples
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        fftAcc[axis] += gyroDev->gyroADC[axis];
+        fftAcc[axis] += gyroDev->gyroADCStaticf[axis];
     }
     fftAccCount++;
 
@@ -148,7 +148,7 @@ void gyroDataAnalyse(const gyroDev_t *gyroDev, biquadFilter_t *notchFilterDyn)
             sample = biquadFilterApply(&fftGyroFilter[axis], sample);
             gyroData[axis][fftIdx] = sample;
             if (axis == 0)
-                DEBUG_SET(DEBUG_FFT, 2, lrintf(sample * gyroDev->scale));
+                DEBUG_SET(DEBUG_FFT, 2, lrintf(sample));
             fftAcc[axis] = 0;
         }
 

--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -127,15 +127,18 @@ const gyroFftData_t *gyroFftData(int axis)
     return &fftResult[axis];
 }
 
+void gyroDataAnalysePush(const int axis, const float sample)
+{
+    fftAcc[axis] += sample;
+}
+
 /*
  * Collect gyro data, to be analysed in gyroDataAnalyseUpdate function
  */
 void gyroDataAnalyse(const struct gyroDev_s *gyroDev, biquadFilter_t *notchFilterDyn)
 {
+    // samples should have been pushed by `gyroDataAnalysePush`
     // if gyro sampling is > 1kHz, accumulate multiple samples
-    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        fftAcc[axis] += gyroDev->gyroADCStaticf[axis];
-    }
     fftAccCount++;
 
     // this runs at 1kHz

--- a/src/main/sensors/gyroanalyse.h
+++ b/src/main/sensors/gyroanalyse.h
@@ -30,5 +30,5 @@ void gyroDataAnalyseInit(uint32_t targetLooptime);
 const gyroFftData_t *gyroFftData(int axis);
 struct gyroDev_s;
 void gyroDataAnalysePush(int axis, float sample);
-void gyroDataAnalyse(const struct gyroDev_s *gyroDev, biquadFilter_t *notchFilterDyn);
+void gyroDataAnalyse(biquadFilter_t *notchFilterDyn);
 void gyroDataAnalyseUpdate(biquadFilter_t *notchFilterDyn);

--- a/src/main/sensors/gyroanalyse.h
+++ b/src/main/sensors/gyroanalyse.h
@@ -29,5 +29,6 @@ typedef struct gyroFftData_s {
 void gyroDataAnalyseInit(uint32_t targetLooptime);
 const gyroFftData_t *gyroFftData(int axis);
 struct gyroDev_s;
+void gyroDataAnalysePush(int axis, float sample);
 void gyroDataAnalyse(const struct gyroDev_s *gyroDev, biquadFilter_t *notchFilterDyn);
 void gyroDataAnalyseUpdate(biquadFilter_t *notchFilterDyn);


### PR DESCRIPTION
This PR changes filtering to calculate dynamic notch center frequency off statically filtered data, as discussed under PR about unifying stage1&2 gyro lowpass.
This may lead to more effective noise targeting, but requires performance measurement (probably not affected, but I will still measure) and test data.
As an experiment, we could allow selecting between `notch` and `lowpass` for dynamic filter, using some heuristic to derive cutoff frequency.