### PR TITLE
Suppress OSD stats screen if runaway takeoff triggered the disarm

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1240,7 +1240,9 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
             osdResetStats();
             osdShowArmed();
             resumeRefreshAt = currentTimeUs + (REFRESH_1S / 2);
-        } else if (isSomeStatEnabled()) {
+        } else if (isSomeStatEnabled()
+                   && (!(getArmingDisableFlags() & ARMING_DISABLED_RUNAWAY_TAKEOFF)
+                       || !VISIBLE(osdConfig()->item_pos[OSD_WARNINGS]))) { // suppress stats if runaway takeoff triggered disarm and WARNINGS element is visible
             osdShowStats();
             resumeRefreshAt = currentTimeUs + (60 * REFRESH_1S);
         }


### PR DESCRIPTION
and OSD_WARNINGS is visible in the OSD.

The stats screen was preventing the user from knowing that a disarm might be casued by runaway takeoff.  If the warnings element is visible it will have the message "RUNAWAY" but the disarm it triggers caused the stats display to replace the screen.

The change prevents the stats page from displaying if the ARMING_DISABLED_RUNAWAY_TAKEOFF flag is set and the OSD_WARNINGS element is visible.  Otherwise the stats screen is displayed as normal.