### PR TITLE
Correct nested if else for USE_MAG and USE_GPS

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -428,7 +428,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     }
 #endif
 #if defined(USE_GPS)
-    else if (STATE(FIXED_WING) && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 5 && gpsSol.groundSpeed >= 300) {
+    if (!useMag && STATE(FIXED_WING) && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 5 && gpsSol.groundSpeed >= 300) {
         // In case of a fixed-wing aircraft we can use GPS course over ground to correct heading
         rawYawError = DECIDEGREES_TO_RADIANS(attitude.values.yaw - gpsSol.groundCourse);
         useYaw = true;


### PR DESCRIPTION
Blocking https://github.com/betaflight/betaflight/pull/5413

If USE_MAG was undefined but USE_GPS was defined, then the `else if` in the USE_GPS section would incorrectly apply to the `imuIsAccelerometerHealthy()` condition above making the USE_GPS section unlikely to execute.