### PR TITLE
make CRSF lq available in OSD as 0-300 value

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -84,10 +84,10 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"GPS LON",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_LON], 0},
     {"HOME DIR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIR], 0},
     {"HOME DIST",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIST], 0},
+#endif // GPS
 #ifdef USE_SERIALRX_CRSF
     {"CRSF LINK QUALITY",  OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_LINK_QUALITY], 0},
 #endif //CRSF
-#endif // GPS
     {"COMPASS BAR",        OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_COMPASS_BAR], 0},
     {"ALTITUDE",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ALTITUDE], 0},
     {"POWER",              OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_POWER], 0},

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -84,6 +84,9 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"GPS LON",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_LON], 0},
     {"HOME DIR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIR], 0},
     {"HOME DIST",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIST], 0},
+#ifdef USE_SERIALRX_CRSF
+    {"CRSF LINK QUALITY",  OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_LINK_QUALITY], 0},
+#endif //CRSF
 #endif // GPS
     {"COMPASS BAR",        OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_COMPASS_BAR], 0},
     {"ALTITUDE",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ALTITUDE], 0},

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -764,6 +764,7 @@ const clivalue_t valueTable[] = {
 
     { "osd_vbat_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_VOLTAGE]) },
     { "osd_rssi_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RSSI_VALUE]) },
+    { "osd_crsf_link_quality_pos",  VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_LINK_QUALITY]) },
     { "osd_tim_1_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_1]) },
     { "osd_tim_2_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_2]) },
     { "osd_remaining_time_estimate_pos",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_REMAINING_TIME_ESTIMATE]) },

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -78,6 +78,7 @@
 #include "pg/pg_ids.h"
 
 #include "rx/rx.h"
+#include "rx/crsf.h"
 
 #include "sensors/adcinternal.h"
 #include "sensors/barometer.h"
@@ -397,6 +398,13 @@ static bool osdDrawSingleElement(uint8_t item)
                 osdRssi = 99;
 
             tfp_sprintf(buff, "%c%2d", SYM_RSSI, osdRssi);
+            break;
+        }
+
+    case OSD_CRSF_LINK_QUALITY:
+        {
+            uint16_t lq = (crsfLQ + (crsfRFMode * 100));
+            tfp_sprintf(buff, "%c%d", SYM_RSSI, lq);
             break;
         }
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -86,6 +86,7 @@ typedef enum {
     OSD_RTC_DATETIME,
     OSD_ADJUSTMENT_RANGE,
     OSD_CORE_TEMPERATURE,
+    OSD_CRSF_LINK_QUALITY,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -37,6 +37,9 @@ typedef union crsfFrame_u {
     crsfFrameDef_t frame;
 } crsfFrame_t;
 
+extern int8_t crsfRFMode;
+extern int8_t crsfLQ;
+
 void crsfRxWriteTelemetryData(const void *data, int len);
 void crsfRxSendTelemetryData(void);
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -56,6 +56,8 @@ extern "C" {
     int osdConvertTemperatureToSelectedUnit(int tempInDeciDegrees);
 
     uint16_t rssi;
+    int16_t crsfLQ;
+    int16_t crsfRFMode;
     attitudeEulerAngles_t attitude;
     pidProfile_t *currentPidProfile;
     int16_t debug[DEBUG16_VALUE_COUNT];


### PR DESCRIPTION
I would like to add an OSD element for CRSF Link Quality to show a 0-300 value instead of having to shoehorn the 0-100 constrained value using RSSI element.

This should give a single value to represent both uplink packet loss as well as the link rate.