### PR TITLE
MSP_RAW_IMU to convert accADC from float to integer

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -798,7 +798,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
             }
 
             for (int i = 0; i < 3; i++) {
-                sbufWriteU16(dst, acc.accADC[i] / scale);
+                sbufWriteU16(dst, lrintf(acc.accADC[i] / scale));
             }
             for (int i = 0; i < 3; i++) {
                 sbufWriteU16(dst, gyroRateDps(i));


### PR DESCRIPTION
Fixes overlooked case from #4986, which caused acc component of the `MSP_RAW_IMU` be always positive.

Related: inavFlight/inav#2532

Fixes #5410