### PR TITLE
Uniformly reduce UART buffer sizes to 128 bytes

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -23,37 +23,37 @@
 #define UARTDEV_COUNT_MAX 3
 #define UARTHARDWARE_MAX_PINS 3
 #ifndef UART_RX_BUFFER_SIZE
-#define UART_RX_BUFFER_SIZE     256
+#define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     128
 #endif
 #elif defined(STM32F3)
 #define UARTDEV_COUNT_MAX 5
 #define UARTHARDWARE_MAX_PINS 4
 #ifndef UART_RX_BUFFER_SIZE
-#define UART_RX_BUFFER_SIZE     256
+#define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     128
 #endif
 #elif defined(STM32F4)
 #define UARTDEV_COUNT_MAX 6
 #define UARTHARDWARE_MAX_PINS 4
 #ifndef UART_RX_BUFFER_SIZE
-#define UART_RX_BUFFER_SIZE     512
+#define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     512
+#define UART_TX_BUFFER_SIZE     128
 #endif
 #elif defined(STM32F7)
 #define UARTDEV_COUNT_MAX 8
 #define UARTHARDWARE_MAX_PINS 3
 #ifndef UART_RX_BUFFER_SIZE
-#define UART_RX_BUFFER_SIZE     512
+#define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     512
+#define UART_TX_BUFFER_SIZE     128
 #endif
 #else
 #error unknown MCU family


### PR DESCRIPTION
A study in https://github.com/betaflight/betaflight/issues/3650#issuecomment-318799575, although incomplete, shows that there is a good chance that we can uniformly reduce UART buffer sizes to 128 bytes.

I would propose that we do this now, at early stage before 3.4.

Beyond 128 bytes
- We can probably further reduce this to 64 bytes by doubling GSP task frequency to 200Hz, or
- Introduce simple memory allocator.


| Tested | Module | Rx | Tx | Note | Test note |
|-|---------|---|---|------|------|
| O | Blackbox | -  | 64  | Tx = Max record size  | @etracer65 |
| O | CLI |   | 64  |  Tx = CLI_OUT_BUFFER_SIZE | Omnibus F4 V3 UART3 via FTDI |
| O | GPS | 115  |   | Rx max =100Hz@115.2Kbps; varies on GPS output option, TX max = Initialization data block (ubloxInit? Need to check) | Neo-M8N@115200 |
| | SmartAudio | 11  | 7  | Request/response client  |
| | Tramp | 16 | 16  | Request/response client  |
| | RC Split | |  |   |
| O | MSP Serial |   |   |  Tx theoretical max = # of requests in Rx buffer * max MSP message length | Omnibus F4 V3, BFC over UART3 via FTDI |
| | CRSF | 0  | 36  |  ISR callback, CRSF_FRAME_SIZE_MAX |
| | IBUS | 0  | 6  | ISR callback  |
| | JETIEXBUS | 0 | 0 | ISR callback, open with MODE_RXTX then immediately switches to MODE_RX  |   |
| O | SBUS | 0  |  0 (tlm?) | ISR callback  |
| | Spektrum | 0  |  21 | ISR callback, SPEK_FRAME_SIZE + SRXL_FRAME_OVERHEAD   |
| | SUMD | 0   | 0 (tlm?)  | ISR callback  |
| | SUMH |  0 |  0 (tlm?) | ISR callback   |
| | XBUS |  0 |  0 (tlm?) | ISR callback   |
| | FrSky (tlm) | ---  | var  |   |
| | HoTT (tlm) | ?  | ?  |   |
| | IBUS (tlm) | ?  | ?  |   |
| | LTM | ---  | var  |   |
| | Mavlink |   |   |   |
| O | SmartPort | 8  |  7 |  Measured, F3, 8k/8k idle (Rx peak at 167 --- immediately after initialization) , no MSP | Raw S.Port only, Lua needs testing |
| | Serial Pass Through |   |   |   |
| | ESC Pass Through |   |   |  Currently TX and RX buffers are both 1024 bytes. Can RX buffer be reduced in size? |