### PR TITLE
Add USB Mass Storage Class support

### DIFF
--- a/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_bot.h
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_bot.h
@@ -1,0 +1,153 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_bot.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header for the usbd_msc_bot.c file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+
+#include "usbd_core.h"
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_MSC_BOT_H
+#define __USBD_MSC_BOT_H
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+  
+/** @defgroup MSC_BOT
+  * @brief This file is the Header file for usbd_bot.c
+  * @{
+  */ 
+
+
+/** @defgroup USBD_CORE_Exported_Defines
+  * @{
+  */ 
+#define BOT_IDLE                      0       /* Idle state */
+#define BOT_DATA_OUT                  1       /* Data Out state */
+#define BOT_DATA_IN                   2       /* Data In state */
+#define BOT_LAST_DATA_IN              3       /* Last Data In Last */
+#define BOT_SEND_DATA                 4       /* Send Immediate data */
+
+#define BOT_CBW_SIGNATURE             0x43425355
+#define BOT_CSW_SIGNATURE             0x53425355
+#define BOT_CBW_LENGTH                31
+#define BOT_CSW_LENGTH                13
+
+/* CSW Status Definitions */
+#define CSW_CMD_PASSED                0x00
+#define CSW_CMD_FAILED                0x01
+#define CSW_PHASE_ERROR               0x02
+
+/* BOT Status */
+#define BOT_STATE_NORMAL              0
+#define BOT_STATE_RECOVERY            1
+#define BOT_STATE_ERROR               2
+
+
+#define DIR_IN                        0
+#define DIR_OUT                       1
+#define BOTH_DIR                      2
+
+/**
+  * @}
+  */ 
+
+/** @defgroup MSC_CORE_Private_TypesDefinitions
+  * @{
+  */ 
+
+typedef struct _MSC_BOT_CBW
+{
+  uint32_t dSignature;
+  uint32_t dTag;
+  uint32_t dDataLength;
+  uint8_t  bmFlags;
+  uint8_t  bLUN;
+  uint8_t  bCBLength;
+  uint8_t  CB[16];
+}
+MSC_BOT_CBW_TypeDef;
+
+
+typedef struct _MSC_BOT_CSW
+{
+  uint32_t dSignature;
+  uint32_t dTag;
+  uint32_t dDataResidue;
+  uint8_t  bStatus;
+}
+MSC_BOT_CSW_TypeDef;
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBD_CORE_Exported_Types
+  * @{
+  */
+
+extern uint8_t              MSC_BOT_Data[];
+extern uint16_t             MSC_BOT_DataLen;
+extern uint8_t              MSC_BOT_State;
+extern uint8_t              MSC_BOT_BurstMode;
+extern MSC_BOT_CBW_TypeDef  MSC_BOT_cbw;
+extern MSC_BOT_CSW_TypeDef  MSC_BOT_csw;
+/**
+  * @}
+  */ 
+/** @defgroup USBD_CORE_Exported_FunctionsPrototypes
+  * @{
+  */ 
+void MSC_BOT_Init (USB_OTG_CORE_HANDLE  *pdev);
+void MSC_BOT_Reset (USB_OTG_CORE_HANDLE  *pdev);
+void MSC_BOT_DeInit (USB_OTG_CORE_HANDLE  *pdev);
+void MSC_BOT_DataIn (USB_OTG_CORE_HANDLE  *pdev, 
+                     uint8_t epnum);
+
+void MSC_BOT_DataOut (USB_OTG_CORE_HANDLE  *pdev, 
+                      uint8_t epnum);
+
+void MSC_BOT_SendCSW (USB_OTG_CORE_HANDLE  *pdev,
+                             uint8_t CSW_Status);
+
+void  MSC_BOT_CplClrFeature (USB_OTG_CORE_HANDLE  *pdev, 
+                             uint8_t epnum);
+/**
+  * @}
+  */ 
+
+#endif /* __USBD_MSC_BOT_H */
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_core.h
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_core.h
@@ -1,0 +1,77 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_core.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header for the usbd_msc_core.c file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef _USB_MSC_CORE_H_
+#define _USB_MSC_CORE_H_
+
+#include  "usbd_ioreq.h"
+
+/** @addtogroup USBD_MSC_BOT
+  * @{
+  */
+  
+/** @defgroup USBD_MSC
+  * @brief This file is the Header file for USBD_msc.c
+  * @{
+  */ 
+
+
+/** @defgroup USBD_BOT_Exported_Defines
+  * @{
+  */ 
+
+
+#define BOT_GET_MAX_LUN              0xFE
+#define BOT_RESET                    0xFF
+#define USB_MSC_CONFIG_DESC_SIZ      32
+
+#define MSC_EPIN_SIZE                MSC_MAX_PACKET 
+#define MSC_EPOUT_SIZE               MSC_MAX_PACKET 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CORE_Exported_Types
+  * @{
+  */ 
+
+extern USBD_Class_cb_TypeDef  USBD_MSC_cb;
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+#endif /* _USB_MSC_CORE_H_ */
+/**
+  * @}
+  */ 
+  
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_data.h
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_data.h
@@ -1,0 +1,104 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_data.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header for the usbd_msc_data.c file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+
+#ifndef _USBD_MSC_DATA_H_
+#define _USBD_MSC_DATA_H_
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_conf.h"
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+  
+/** @defgroup USB_INFO
+  * @brief general defines for the usb device library file
+  * @{
+  */ 
+
+/** @defgroup USB_INFO_Exported_Defines
+  * @{
+  */ 
+#define MODE_SENSE6_LEN			 8
+#define MODE_SENSE10_LEN		 8
+#define LENGTH_INQUIRY_PAGE00		 7
+#define LENGTH_FORMAT_CAPACITIES    	20
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBD_INFO_Exported_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup USBD_INFO_Exported_Macros
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_INFO_Exported_Variables
+  * @{
+  */ 
+extern const uint8_t MSC_Page00_Inquiry_Data[];  
+extern const uint8_t MSC_Mode_Sense6_data[];
+extern const uint8_t MSC_Mode_Sense10_data[] ;
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_INFO_Exported_FunctionsPrototypes
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+#endif /* _USBD_MSC_DATA_H_ */
+
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_mem.h
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_mem.h
@@ -1,0 +1,112 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_mem.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header for the STORAGE DISK file file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+
+#ifndef __USBD_MEM_H
+#define __USBD_MEM_H
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_def.h"
+
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+  
+/** @defgroup USBD_MEM
+  * @brief header file for the storage disk file
+  * @{
+  */ 
+
+/** @defgroup USBD_MEM_Exported_Defines
+  * @{
+  */ 
+#define USBD_STD_INQUIRY_LENGTH		36
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBD_MEM_Exported_TypesDefinitions
+  * @{
+  */
+
+typedef struct _USBD_STORAGE
+{
+  int8_t (* Init) (uint8_t lun);
+  int8_t (* GetCapacity) (uint8_t lun, uint32_t *block_num, uint32_t *block_size);
+  int8_t (* IsReady) (uint8_t lun);
+  int8_t (* IsWriteProtected) (uint8_t lun);
+  int8_t (* Read) (uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len);
+  int8_t (* Write)(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len);
+  int8_t (* GetMaxLun)(void);
+  int8_t *pInquiry;
+  
+}USBD_STORAGE_cb_TypeDef;
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup USBD_MEM_Exported_Macros
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_MEM_Exported_Variables
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_MEM_Exported_FunctionsPrototype
+  * @{
+  */ 
+extern USBD_STORAGE_cb_TypeDef *USBD_STORAGE_fops;
+/**
+  * @}
+  */ 
+
+#endif /* __USBD_MEM_H */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_scsi.h
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/inc/usbd_msc_scsi.h
@@ -1,0 +1,195 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_scsi.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header for the usbd_msc_scsi.c file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_MSC_SCSI_H
+#define __USBD_MSC_SCSI_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_def.h"
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+  
+/** @defgroup USBD_SCSI
+  * @brief header file for the storage disk file
+  * @{
+  */ 
+
+/** @defgroup USBD_SCSI_Exported_Defines
+  * @{
+  */ 
+
+#define SENSE_LIST_DEEPTH                          4
+
+/* SCSI Commands */
+#define SCSI_FORMAT_UNIT                            0x04
+#define SCSI_INQUIRY                                0x12
+#define SCSI_MODE_SELECT6                           0x15
+#define SCSI_MODE_SELECT10                          0x55
+#define SCSI_MODE_SENSE6                            0x1A
+#define SCSI_MODE_SENSE10                           0x5A
+#define SCSI_ALLOW_MEDIUM_REMOVAL                   0x1E
+#define SCSI_READ6                                  0x08
+#define SCSI_READ10                                 0x28
+#define SCSI_READ12                                 0xA8
+#define SCSI_READ16                                 0x88
+
+#define SCSI_READ_CAPACITY10                        0x25
+#define SCSI_READ_CAPACITY16                        0x9E
+
+#define SCSI_REQUEST_SENSE                          0x03
+#define SCSI_START_STOP_UNIT                        0x1B
+#define SCSI_TEST_UNIT_READY                        0x00
+#define SCSI_WRITE6                                 0x0A
+#define SCSI_WRITE10                                0x2A
+#define SCSI_WRITE12                                0xAA
+#define SCSI_WRITE16                                0x8A
+
+#define SCSI_VERIFY10                               0x2F
+#define SCSI_VERIFY12                               0xAF
+#define SCSI_VERIFY16                               0x8F
+
+#define SCSI_SEND_DIAGNOSTIC                        0x1D
+#define SCSI_READ_FORMAT_CAPACITIES                 0x23
+
+#define NO_SENSE                                    0
+#define RECOVERED_ERROR                             1
+#define NOT_READY                                   2
+#define MEDIUM_ERROR                                3
+#define HARDWARE_ERROR                              4
+#define ILLEGAL_REQUEST                             5
+#define UNIT_ATTENTION                              6
+#define DATA_PROTECT                                7
+#define BLANK_CHECK                                 8
+#define VENDOR_SPECIFIC                             9
+#define COPY_ABORTED                               10
+#define ABORTED_COMMAND                            11
+#define VOLUME_OVERFLOW                            13
+#define MISCOMPARE                                 14
+
+
+#define INVALID_CDB                                 0x20
+#define INVALID_FIELED_IN_COMMAND                   0x24
+#define PARAMETER_LIST_LENGTH_ERROR                 0x1A
+#define INVALID_FIELD_IN_PARAMETER_LIST             0x26
+#define ADDRESS_OUT_OF_RANGE                        0x21
+#define MEDIUM_NOT_PRESENT                          0x3A
+#define MEDIUM_HAVE_CHANGED                         0x28
+#define WRITE_PROTECTED                             0x27 
+#define UNRECOVERED_READ_ERROR			    0x11
+#define WRITE_FAULT				    0x03 
+
+#define READ_FORMAT_CAPACITY_DATA_LEN               0x0C
+#define READ_CAPACITY10_DATA_LEN                    0x08
+#define MODE_SENSE10_DATA_LEN                       0x08
+#define MODE_SENSE6_DATA_LEN                        0x04
+#define REQUEST_SENSE_DATA_LEN                      0x12
+#define STANDARD_INQUIRY_DATA_LEN                   0x24
+#define BLKVFY                                      0x04
+
+extern  uint8_t Page00_Inquiry_Data[];
+extern  uint8_t Standard_Inquiry_Data[];
+extern  uint8_t Standard_Inquiry_Data2[];
+extern  uint8_t Mode_Sense6_data[];
+extern  uint8_t Mode_Sense10_data[];
+extern  uint8_t Scsi_Sense_Data[];
+extern  uint8_t ReadCapacity10_Data[];
+extern  uint8_t ReadFormatCapacity_Data [];
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBD_SCSI_Exported_TypesDefinitions
+  * @{
+  */
+
+typedef struct _SENSE_ITEM {                
+  char Skey;
+  union {
+    struct _ASCs {
+      char ASC;
+      char ASCQ;
+    }b;
+    unsigned int	ASC;
+    char *pData;
+  } w;
+} SCSI_Sense_TypeDef; 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_SCSI_Exported_Macros
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_SCSI_Exported_Variables
+  * @{
+  */ 
+extern SCSI_Sense_TypeDef     SCSI_Sense [SENSE_LIST_DEEPTH]; 
+extern uint8_t   SCSI_Sense_Head;
+extern uint8_t   SCSI_Sense_Tail;
+
+/**
+  * @}
+  */ 
+/** @defgroup USBD_SCSI_Exported_FunctionsPrototype
+  * @{
+  */ 
+int8_t SCSI_ProcessCmd(USB_OTG_CORE_HANDLE  *pdev,
+                           uint8_t lun, 
+                           uint8_t *cmd);
+
+void   SCSI_SenseCode(uint8_t lun, 
+                    uint8_t sKey, 
+                    uint8_t ASC);
+
+/**
+  * @}
+  */ 
+
+#endif /* __USBD_MSC_SCSI_H */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_bot.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_bot.c
@@ -1,0 +1,404 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_bot.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   This file provides all the BOT protocol core functions.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_msc_bot.h"
+#include "usbd_msc_scsi.h"
+#include "usbd_ioreq.h"
+#include "usbd_msc_mem.h"
+
+#define UNUSED(x) (void)(x)
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup MSC_BOT
+  * @brief BOT protocol module
+  * @{
+  */
+
+/** @defgroup MSC_BOT_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_BOT_Private_Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_BOT_Private_Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_BOT_Private_Variables
+  * @{
+  */
+uint16_t             MSC_BOT_DataLen;
+uint8_t              MSC_BOT_State;
+uint8_t              MSC_BOT_Status;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN uint8_t              MSC_BOT_Data[MSC_MEDIA_PACKET] __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN MSC_BOT_CBW_TypeDef  MSC_BOT_cbw __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN MSC_BOT_CSW_TypeDef  MSC_BOT_csw __ALIGN_END ;
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_BOT_Private_FunctionPrototypes
+  * @{
+  */
+static void MSC_BOT_CBW_Decode (USB_OTG_CORE_HANDLE  *pdev);
+
+static void MSC_BOT_SendData (USB_OTG_CORE_HANDLE  *pdev,
+                              uint8_t* pbuf,
+                              uint16_t len);
+
+static void MSC_BOT_Abort(USB_OTG_CORE_HANDLE  *pdev);
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_BOT_Private_Functions
+  * @{
+  */
+
+
+
+/**
+* @brief  MSC_BOT_Init
+*         Initialize the BOT Process
+* @param  pdev: device instance
+* @retval None
+*/
+void MSC_BOT_Init (USB_OTG_CORE_HANDLE  *pdev)
+{
+  MSC_BOT_State = BOT_IDLE;
+  MSC_BOT_Status = BOT_STATE_NORMAL;
+  USBD_STORAGE_fops->Init(0);
+
+  DCD_EP_Flush(pdev, MSC_OUT_EP);
+  DCD_EP_Flush(pdev, MSC_IN_EP);
+  /* Prapare EP to Receive First BOT Cmd */
+  DCD_EP_PrepareRx (pdev,
+                    MSC_OUT_EP,
+                    (uint8_t *)&MSC_BOT_cbw,
+                    BOT_CBW_LENGTH);
+}
+
+/**
+* @brief  MSC_BOT_Reset
+*         Reset the BOT Machine
+* @param  pdev: device instance
+* @retval  None
+*/
+void MSC_BOT_Reset (USB_OTG_CORE_HANDLE  *pdev)
+{
+  MSC_BOT_State = BOT_IDLE;
+  MSC_BOT_Status = BOT_STATE_RECOVERY;
+  /* Prapare EP to Receive First BOT Cmd */
+  DCD_EP_PrepareRx (pdev,
+                    MSC_OUT_EP,
+                    (uint8_t *)&MSC_BOT_cbw,
+                    BOT_CBW_LENGTH);
+}
+
+/**
+* @brief  MSC_BOT_DeInit
+*         Uninitialize the BOT Machine
+* @param  pdev: device instance
+* @retval None
+*/
+void MSC_BOT_DeInit (USB_OTG_CORE_HANDLE  *pdev)
+{
+  UNUSED(pdev);
+  MSC_BOT_State = BOT_IDLE;
+}
+
+/**
+* @brief  MSC_BOT_DataIn
+*         Handle BOT IN data stage
+* @param  pdev: device instance
+* @param  epnum: endpoint index
+* @retval None
+*/
+void MSC_BOT_DataIn (USB_OTG_CORE_HANDLE  *pdev,
+                     uint8_t epnum)
+{
+  UNUSED(epnum);
+  switch (MSC_BOT_State)
+  {
+  case BOT_DATA_IN:
+    if(SCSI_ProcessCmd(pdev,
+                        MSC_BOT_cbw.bLUN,
+                        &MSC_BOT_cbw.CB[0]) < 0)
+    {
+      MSC_BOT_SendCSW (pdev, CSW_CMD_FAILED);
+    }
+    break;
+
+  case BOT_SEND_DATA:
+  case BOT_LAST_DATA_IN:
+    MSC_BOT_SendCSW (pdev, CSW_CMD_PASSED);
+
+    break;
+
+  default:
+    break;
+  }
+}
+/**
+* @brief  MSC_BOT_DataOut
+*         Proccess MSC OUT data
+* @param  pdev: device instance
+* @param  epnum: endpoint index
+* @retval None
+*/
+void MSC_BOT_DataOut (USB_OTG_CORE_HANDLE  *pdev,
+                      uint8_t epnum)
+{
+  UNUSED(epnum);
+  switch (MSC_BOT_State)
+  {
+  case BOT_IDLE:
+    MSC_BOT_CBW_Decode(pdev);
+    break;
+
+  case BOT_DATA_OUT:
+
+    if(SCSI_ProcessCmd(pdev,
+                        MSC_BOT_cbw.bLUN,
+                        &MSC_BOT_cbw.CB[0]) < 0)
+    {
+      MSC_BOT_SendCSW (pdev, CSW_CMD_FAILED);
+    }
+
+    break;
+
+  default:
+    break;
+  }
+
+}
+
+/**
+* @brief  MSC_BOT_CBW_Decode
+*         Decode the CBW command and set the BOT state machine accordingtly
+* @param  pdev: device instance
+* @retval None
+*/
+static void  MSC_BOT_CBW_Decode (USB_OTG_CORE_HANDLE  *pdev)
+{
+
+  MSC_BOT_csw.dTag = MSC_BOT_cbw.dTag;
+  MSC_BOT_csw.dDataResidue = MSC_BOT_cbw.dDataLength;
+
+  if ((USBD_GetRxCount (pdev ,MSC_OUT_EP) != BOT_CBW_LENGTH) ||
+      (MSC_BOT_cbw.dSignature != BOT_CBW_SIGNATURE)||
+        (MSC_BOT_cbw.bLUN > 1) ||
+          (MSC_BOT_cbw.bCBLength < 1) ||
+            (MSC_BOT_cbw.bCBLength > 16))
+  {
+
+    SCSI_SenseCode(MSC_BOT_cbw.bLUN,
+                   ILLEGAL_REQUEST,
+                   INVALID_CDB);
+     MSC_BOT_Status = BOT_STATE_ERROR;
+    MSC_BOT_Abort(pdev);
+
+  }
+  else
+  {
+    if(SCSI_ProcessCmd(pdev,
+                              MSC_BOT_cbw.bLUN,
+                              &MSC_BOT_cbw.CB[0]) < 0)
+    {
+      MSC_BOT_Abort(pdev);
+    }
+    /*Burst xfer handled internally*/
+    else if ((MSC_BOT_State != BOT_DATA_IN) &&
+             (MSC_BOT_State != BOT_DATA_OUT) &&
+             (MSC_BOT_State != BOT_LAST_DATA_IN))
+    {
+      if (MSC_BOT_DataLen > 0)
+      {
+        MSC_BOT_SendData(pdev,
+                         MSC_BOT_Data,
+                         MSC_BOT_DataLen);
+      }
+      else if (MSC_BOT_DataLen == 0)
+      {
+        MSC_BOT_SendCSW (pdev,
+                         CSW_CMD_PASSED);
+      }
+    }
+  }
+}
+
+/**
+* @brief  MSC_BOT_SendData
+*         Send the requested data
+* @param  pdev: device instance
+* @param  buf: pointer to data buffer
+* @param  len: Data Length
+* @retval None
+*/
+static void  MSC_BOT_SendData(USB_OTG_CORE_HANDLE  *pdev,
+                              uint8_t* buf,
+                              uint16_t len)
+{
+
+  len = MIN (MSC_BOT_cbw.dDataLength, len);
+  MSC_BOT_csw.dDataResidue -= len;
+  MSC_BOT_csw.bStatus = CSW_CMD_PASSED;
+  MSC_BOT_State = BOT_SEND_DATA;
+
+  DCD_EP_Tx (pdev, MSC_IN_EP, buf, len);
+}
+
+/**
+* @brief  MSC_BOT_SendCSW
+*         Send the Command Status Wrapper
+* @param  pdev: device instance
+* @param  status : CSW status
+* @retval None
+*/
+void  MSC_BOT_SendCSW (USB_OTG_CORE_HANDLE  *pdev,
+                              uint8_t CSW_Status)
+{
+  MSC_BOT_csw.dSignature = BOT_CSW_SIGNATURE;
+  MSC_BOT_csw.bStatus = CSW_Status;
+  MSC_BOT_State = BOT_IDLE;
+
+  DCD_EP_Tx (pdev,
+             MSC_IN_EP,
+             (uint8_t *)&MSC_BOT_csw,
+             BOT_CSW_LENGTH);
+
+  /* Prepare EP to Receive next Cmd */
+  DCD_EP_PrepareRx (pdev,
+                    MSC_OUT_EP,
+                    (uint8_t *)&MSC_BOT_cbw,
+                    BOT_CBW_LENGTH);
+
+}
+
+/**
+* @brief  MSC_BOT_Abort
+*         Abort the current transfer
+* @param  pdev: device instance
+* @retval status
+*/
+
+static void  MSC_BOT_Abort (USB_OTG_CORE_HANDLE  *pdev)
+{
+
+  if ((MSC_BOT_cbw.bmFlags == 0) &&
+      (MSC_BOT_cbw.dDataLength != 0) &&
+      (MSC_BOT_Status == BOT_STATE_NORMAL) )
+  {
+    DCD_EP_Stall(pdev, MSC_OUT_EP );
+  }
+  DCD_EP_Stall(pdev, MSC_IN_EP);
+
+  if(MSC_BOT_Status == BOT_STATE_ERROR)
+  {
+    DCD_EP_PrepareRx (pdev,
+                      MSC_OUT_EP,
+                      (uint8_t *)&MSC_BOT_cbw,
+                      BOT_CBW_LENGTH);
+  }
+}
+
+/**
+* @brief  MSC_BOT_CplClrFeature
+*         Complete the clear feature request
+* @param  pdev: device instance
+* @param  epnum: endpoint index
+* @retval None
+*/
+
+void  MSC_BOT_CplClrFeature (USB_OTG_CORE_HANDLE  *pdev, uint8_t epnum)
+{
+  if(MSC_BOT_Status == BOT_STATE_ERROR )/* Bad CBW Signature */
+  {
+    DCD_EP_Stall(pdev, MSC_IN_EP);
+    MSC_BOT_Status = BOT_STATE_NORMAL;
+  }
+  else if(((epnum & 0x80) == 0x80) && ( MSC_BOT_Status != BOT_STATE_RECOVERY))
+  {
+    MSC_BOT_SendCSW (pdev, CSW_CMD_FAILED);
+  }
+
+}
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_core.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_core.c
@@ -1,0 +1,499 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_core.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   This file provides all the MSC core functions.
+  *
+  * @verbatim
+  *
+  *          ===================================================================
+  *                                MSC Class  Description
+  *          ===================================================================
+  *           This module manages the MSC class V1.0 following the "Universal
+  *           Serial Bus Mass Storage Class (MSC) Bulk-Only Transport (BOT) Version 1.0
+  *           Sep. 31, 1999".
+  *           This driver implements the following aspects of the specification:
+  *             - Bulk-Only Transport protocol
+  *             - Subclass : SCSI transparent command set (ref. SCSI Primary Commands - 3 (SPC-3))
+  *
+  *  @endverbatim
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_msc_mem.h"
+#include "usbd_msc_core.h"
+#include "usbd_msc_bot.h"
+#include "usbd_req.h"
+
+#define UNUSED(x) (void)(x)
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup MSC_CORE
+  * @brief Mass storage core module
+  * @{
+  */
+
+/** @defgroup MSC_CORE_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_CORE_Private_Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_CORE_Private_Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_CORE_Private_FunctionPrototypes
+  * @{
+  */
+uint8_t  USBD_MSC_Init (void  *pdev,
+                            uint8_t cfgidx);
+
+uint8_t  USBD_MSC_DeInit (void  *pdev,
+                              uint8_t cfgidx);
+
+uint8_t  USBD_MSC_Setup (void  *pdev,
+                             USB_SETUP_REQ *req);
+
+uint8_t  USBD_MSC_DataIn (void  *pdev,
+                              uint8_t epnum);
+
+
+uint8_t  USBD_MSC_DataOut (void  *pdev,
+                               uint8_t epnum);
+
+uint8_t  *USBD_MSC_GetCfgDesc (uint8_t speed,
+                                      uint16_t *length);
+
+#ifdef USB_OTG_HS_CORE
+uint8_t  *USBD_MSC_GetOtherCfgDesc (uint8_t speed,
+                                      uint16_t *length);
+#endif
+
+
+uint8_t USBD_MSC_CfgDesc[USB_MSC_CONFIG_DESC_SIZ];
+
+
+
+
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_CORE_Private_Variables
+  * @{
+  */
+
+
+USBD_Class_cb_TypeDef  USBD_MSC_cb =
+{
+  USBD_MSC_Init,
+  USBD_MSC_DeInit,
+  USBD_MSC_Setup,
+  NULL, /*EP0_TxSent*/
+  NULL, /*EP0_RxReady*/
+  USBD_MSC_DataIn,
+  USBD_MSC_DataOut,
+  NULL, /*SOF */
+  NULL,
+  NULL,
+  USBD_MSC_GetCfgDesc,
+#ifdef USB_OTG_HS_CORE
+  USBD_MSC_GetOtherCfgDesc,
+#endif
+};
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+/* USB Mass storage device Configuration Descriptor */
+/*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor */
+__ALIGN_BEGIN uint8_t USBD_MSC_CfgDesc[USB_MSC_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+
+  0x09,   /* bLength: Configuation Descriptor size */
+  USB_DESC_TYPE_CONFIGURATION,   /* bDescriptorType: Configuration */
+  USB_MSC_CONFIG_DESC_SIZ,
+
+  0x00,
+  0x01,   /* bNumInterfaces: 1 interface */
+  0x01,   /* bConfigurationValue: */
+  0x04,   /* iConfiguration: */
+  0xC0,   /* bmAttributes: */
+  0x32,   /* MaxPower 100 mA */
+
+  /********************  Mass Storage interface ********************/
+  0x09,   /* bLength: Interface Descriptor size */
+  0x04,   /* bDescriptorType: */
+  0x00,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints*/
+  0x08,   /* bInterfaceClass: MSC Class */
+  0x06,   /* bInterfaceSubClass : SCSI transparent*/
+  0x50,   /* nInterfaceProtocol */
+  0x05,          /* iInterface: */
+  /********************  Mass Storage Endpoints ********************/
+  0x07,   /*Endpoint descriptor length = 7*/
+  0x05,   /*Endpoint descriptor type */
+  MSC_IN_EP,   /*Endpoint address (IN, address 1) */
+  0x02,   /*Bulk endpoint type */
+  LOBYTE(MSC_MAX_PACKET),
+  HIBYTE(MSC_MAX_PACKET),
+  0x00,   /*Polling interval in milliseconds */
+
+  0x07,   /*Endpoint descriptor length = 7 */
+  0x05,   /*Endpoint descriptor type */
+  MSC_OUT_EP,   /*Endpoint address (OUT, address 1) */
+  0x02,   /*Bulk endpoint type */
+  LOBYTE(MSC_MAX_PACKET),
+  HIBYTE(MSC_MAX_PACKET),
+  0x00     /*Polling interval in milliseconds*/
+};
+#ifdef USB_OTG_HS_CORE
+ #ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+   #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+     #pragma data_alignment=4
+   #endif
+ #endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN uint8_t USBD_MSC_OtherCfgDesc[USB_MSC_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+
+  0x09,   /* bLength: Configuation Descriptor size */
+  USB_DESC_TYPE_OTHER_SPEED_CONFIGURATION,
+  USB_MSC_CONFIG_DESC_SIZ,
+
+  0x00,
+  0x01,   /* bNumInterfaces: 1 interface */
+  0x01,   /* bConfigurationValue: */
+  0x04,   /* iConfiguration: */
+  0xC0,   /* bmAttributes: */
+  0x32,   /* MaxPower 100 mA */
+
+  /********************  Mass Storage interface ********************/
+  0x09,   /* bLength: Interface Descriptor size */
+  0x04,   /* bDescriptorType: */
+  0x00,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints*/
+  0x08,   /* bInterfaceClass: MSC Class */
+  0x06,   /* bInterfaceSubClass : SCSI transparent command set*/
+  0x50,   /* nInterfaceProtocol */
+  0x05,          /* iInterface: */
+  /********************  Mass Storage Endpoints ********************/
+  0x07,   /*Endpoint descriptor length = 7*/
+  0x05,   /*Endpoint descriptor type */
+  MSC_IN_EP,   /*Endpoint address (IN, address 1) */
+  0x02,   /*Bulk endpoint type */
+  0x40,
+  0x00,
+  0x00,   /*Polling interval in milliseconds */
+
+  0x07,   /*Endpoint descriptor length = 7 */
+  0x05,   /*Endpoint descriptor type */
+  MSC_OUT_EP,   /*Endpoint address (OUT, address 1) */
+  0x02,   /*Bulk endpoint type */
+  0x40,
+  0x00,
+  0x00     /*Polling interval in milliseconds*/
+};
+#endif
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN static uint8_t  USBD_MSC_MaxLun  __ALIGN_END = 0;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN static uint8_t  USBD_MSC_AltSet  __ALIGN_END = 0;
+
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_CORE_Private_Functions
+  * @{
+  */
+
+/**
+* @brief  USBD_MSC_Init
+*         Initialize  the mass storage configuration
+* @param  pdev: device instance
+* @param  cfgidx: configuration index
+* @retval status
+*/
+uint8_t  USBD_MSC_Init (void  *pdev,
+                            uint8_t cfgidx)
+{
+  USBD_MSC_DeInit(pdev , cfgidx );
+
+  /* Open EP IN */
+  DCD_EP_Open(pdev,
+              MSC_IN_EP,
+              MSC_EPIN_SIZE,
+              USB_OTG_EP_BULK);
+
+  /* Open EP OUT */
+  DCD_EP_Open(pdev,
+              MSC_OUT_EP,
+              MSC_EPOUT_SIZE,
+              USB_OTG_EP_BULK);
+
+  /* Init the BOT  layer */
+  MSC_BOT_Init(pdev);
+
+  return USBD_OK;
+}
+
+/**
+* @brief  USBD_MSC_DeInit
+*         DeInitilaize  the mass storage configuration
+* @param  pdev: device instance
+* @param  cfgidx: configuration index
+* @retval status
+*/
+uint8_t  USBD_MSC_DeInit (void  *pdev,
+                              uint8_t cfgidx)
+{
+  UNUSED(cfgidx);
+  /* Close MSC EPs */
+  DCD_EP_Close (pdev , MSC_IN_EP);
+  DCD_EP_Close (pdev , MSC_OUT_EP);
+
+  /* Un Init the BOT layer */
+  MSC_BOT_DeInit(pdev);
+  return USBD_OK;
+}
+/**
+* @brief  USBD_MSC_Setup
+*         Handle the MSC specific requests
+* @param  pdev: device instance
+* @param  req: USB request
+* @retval status
+*/
+uint8_t  USBD_MSC_Setup (void  *pdev, USB_SETUP_REQ *req)
+{
+
+  switch (req->bmRequest & USB_REQ_TYPE_MASK)
+  {
+
+  /* Class request */
+  case USB_REQ_TYPE_CLASS :
+    switch (req->bRequest)
+    {
+    case BOT_GET_MAX_LUN :
+
+      if((req->wValue  == 0) &&
+         (req->wLength == 1) &&
+         ((req->bmRequest & 0x80) == 0x80))
+      {
+        USBD_MSC_MaxLun = USBD_STORAGE_fops->GetMaxLun();
+        if(USBD_MSC_MaxLun > 0)
+        {
+           USBD_CtlSendData (pdev,
+                             &USBD_MSC_MaxLun,
+                              1);
+        }
+        else
+        {
+          USBD_CtlError(pdev , req);
+          return USBD_FAIL;
+
+        }
+      }
+      else
+      {
+         USBD_CtlError(pdev , req);
+         return USBD_FAIL;
+      }
+      break;
+
+    case BOT_RESET :
+      if((req->wValue  == 0) &&
+         (req->wLength == 0) &&
+        ((req->bmRequest & 0x80) != 0x80))
+      {
+         MSC_BOT_Reset(pdev);
+      }
+      else
+      {
+         USBD_CtlError(pdev , req);
+         return USBD_FAIL;
+      }
+      break;
+
+    default:
+       USBD_CtlError(pdev , req);
+       return USBD_FAIL;
+    }
+    break;
+  /* Interface & Endpoint request */
+  case USB_REQ_TYPE_STANDARD:
+    switch (req->bRequest)
+    {
+    case USB_REQ_GET_INTERFACE :
+      USBD_CtlSendData (pdev,
+                        &USBD_MSC_AltSet,
+                        1);
+      break;
+
+    case USB_REQ_SET_INTERFACE :
+      USBD_MSC_AltSet = (uint8_t)(req->wValue);
+      break;
+
+    case USB_REQ_CLEAR_FEATURE:
+
+      /* Flush the FIFO and Clear the stall status */
+      DCD_EP_Flush(pdev, (uint8_t)req->wIndex);
+
+      /* Re-activate the EP */
+      DCD_EP_Close (pdev , (uint8_t)req->wIndex);
+      if((((uint8_t)req->wIndex) & 0x80) == 0x80)
+      {
+        DCD_EP_Open(pdev,
+                    ((uint8_t)req->wIndex),
+                    MSC_EPIN_SIZE,
+                    USB_OTG_EP_BULK);
+      }
+      else
+      {
+        DCD_EP_Open(pdev,
+                    ((uint8_t)req->wIndex),
+                    MSC_EPOUT_SIZE,
+                    USB_OTG_EP_BULK);
+      }
+
+      /* Handle BOT error */
+      MSC_BOT_CplClrFeature(pdev, (uint8_t)req->wIndex);
+      break;
+
+    }
+    break;
+
+  default:
+    break;
+  }
+  return USBD_OK;
+}
+
+/**
+* @brief  USBD_MSC_DataIn
+*         handle data IN Stage
+* @param  pdev: device instance
+* @param  epnum: endpoint index
+* @retval status
+*/
+uint8_t  USBD_MSC_DataIn (void  *pdev,
+                              uint8_t epnum)
+{
+  MSC_BOT_DataIn(pdev , epnum);
+  return USBD_OK;
+}
+
+/**
+* @brief  USBD_MSC_DataOut
+*         handle data OUT Stage
+* @param  pdev: device instance
+* @param  epnum: endpoint index
+* @retval status
+*/
+uint8_t  USBD_MSC_DataOut (void  *pdev,
+                               uint8_t epnum)
+{
+  MSC_BOT_DataOut(pdev , epnum);
+  return USBD_OK;
+}
+
+/**
+* @brief  USBD_MSC_GetCfgDesc
+*         return configuration descriptor
+* @param  speed : current device speed
+* @param  length : pointer data length
+* @retval pointer to descriptor buffer
+*/
+uint8_t  *USBD_MSC_GetCfgDesc (uint8_t speed, uint16_t *length)
+{
+  UNUSED(speed);
+  *length = sizeof (USBD_MSC_CfgDesc);
+  return USBD_MSC_CfgDesc;
+}
+
+/**
+* @brief  USBD_MSC_GetOtherCfgDesc
+*         return other speed configuration descriptor
+* @param  speed : current device speed
+* @param  length : pointer data length
+* @retval pointer to descriptor buffer
+*/
+#ifdef USB_OTG_HS_CORE
+uint8_t  *USBD_MSC_GetOtherCfgDesc (uint8_t speed,
+                                      uint16_t *length)
+{
+  *length = sizeof (USBD_MSC_OtherCfgDesc);
+  return USBD_MSC_OtherCfgDesc;
+}
+#endif
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_data.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_data.c
@@ -1,0 +1,134 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_data.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   This file provides all the vital inquiry pages and sense data.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_msc_data.h"
+
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup MSC_DATA 
+  * @brief Mass storage info/data module
+  * @{
+  */ 
+
+/** @defgroup MSC_DATA_Private_TypesDefinitions
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup MSC_DATA_Private_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup MSC_DATA_Private_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup MSC_DATA_Private_Variables
+  * @{
+  */ 
+
+
+/* USB Mass storage Page 0 Inquiry Data */
+const uint8_t  MSC_Page00_Inquiry_Data[] = {//7						
+	0x00,		
+	0x00, 
+	0x00, 
+	(LENGTH_INQUIRY_PAGE00 - 4),
+	0x00, 
+	0x80, 
+	0x83 
+};  
+/* USB Mass storage sense 6  Data */
+const uint8_t  MSC_Mode_Sense6_data[] = {
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00, 
+	0x00,
+	0x00
+};	
+/* USB Mass storage sense 10  Data */
+const uint8_t  MSC_Mode_Sense10_data[] = {
+	0x00,
+	0x06, 
+	0x00, 
+	0x00, 
+	0x00, 
+	0x00, 
+	0x00, 
+	0x00
+};
+/**
+  * @}
+  */ 
+
+
+/** @defgroup MSC_DATA_Private_FunctionPrototypes
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup MSC_DATA_Private_Functions
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+
+/**
+  * @}
+  */ 
+
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -1,0 +1,744 @@
+/**
+  ******************************************************************************
+  * @file    usbd_msc_scsi.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   This file provides all the USBD SCSI layer functions.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_msc_bot.h"
+#include "usbd_msc_scsi.h"
+#include "usbd_msc_mem.h"
+#include "usbd_msc_data.h"
+
+#define UNUSED(x) (void)(x)
+
+
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup MSC_SCSI
+  * @brief Mass storage SCSI layer module
+  * @{
+  */
+
+/** @defgroup MSC_SCSI_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_SCSI_Private_Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_SCSI_Private_Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_SCSI_Private_Variables
+  * @{
+  */
+
+SCSI_Sense_TypeDef     SCSI_Sense [SENSE_LIST_DEEPTH];
+uint8_t   SCSI_Sense_Head;
+uint8_t   SCSI_Sense_Tail;
+
+uint32_t  SCSI_blk_size;
+uint32_t  SCSI_blk_nbr;
+
+uint32_t  SCSI_blk_addr;
+uint32_t  SCSI_blk_len;
+
+USB_OTG_CORE_HANDLE  *cdev;
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_SCSI_Private_FunctionPrototypes
+  * @{
+  */
+static int8_t SCSI_TestUnitReady(uint8_t lun, uint8_t *params);
+static int8_t SCSI_Inquiry(uint8_t lun, uint8_t *params);
+static int8_t SCSI_ReadFormatCapacity(uint8_t lun, uint8_t *params);
+static int8_t SCSI_ReadCapacity10(uint8_t lun, uint8_t *params);
+static int8_t SCSI_RequestSense (uint8_t lun, uint8_t *params);
+static int8_t SCSI_StartStopUnit(uint8_t lun, uint8_t *params);
+static int8_t SCSI_ModeSense6 (uint8_t lun, uint8_t *params);
+static int8_t SCSI_ModeSense10 (uint8_t lun, uint8_t *params);
+static int8_t SCSI_Write10(uint8_t lun , uint8_t *params);
+static int8_t SCSI_Read10(uint8_t lun , uint8_t *params);
+static int8_t SCSI_Verify10(uint8_t lun, uint8_t *params);
+static int8_t SCSI_CheckAddressRange (uint8_t lun ,
+                                      uint32_t blk_offset ,
+                                      uint16_t blk_nbr);
+static int8_t SCSI_ProcessRead (uint8_t lun);
+
+static int8_t SCSI_ProcessWrite (uint8_t lun);
+/**
+  * @}
+  */
+
+
+/** @defgroup MSC_SCSI_Private_Functions
+  * @{
+  */
+
+
+/**
+* @brief  SCSI_ProcessCmd
+*         Process SCSI commands
+* @param  pdev: device instance
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+int8_t SCSI_ProcessCmd(USB_OTG_CORE_HANDLE  *pdev,
+                           uint8_t lun,
+                           uint8_t *params)
+{
+  cdev = pdev;
+
+  switch (params[0])
+  {
+  case SCSI_TEST_UNIT_READY:
+    return SCSI_TestUnitReady(lun, params);
+
+  case SCSI_REQUEST_SENSE:
+    return SCSI_RequestSense (lun, params);
+  case SCSI_INQUIRY:
+    return SCSI_Inquiry(lun, params);
+
+  case SCSI_START_STOP_UNIT:
+    return SCSI_StartStopUnit(lun, params);
+
+  case SCSI_ALLOW_MEDIUM_REMOVAL:
+    return SCSI_StartStopUnit(lun, params);
+
+  case SCSI_MODE_SENSE6:
+    return SCSI_ModeSense6 (lun, params);
+
+  case SCSI_MODE_SENSE10:
+    return SCSI_ModeSense10 (lun, params);
+
+  case SCSI_READ_FORMAT_CAPACITIES:
+    return SCSI_ReadFormatCapacity(lun, params);
+
+  case SCSI_READ_CAPACITY10:
+    return SCSI_ReadCapacity10(lun, params);
+
+  case SCSI_READ10:
+    return SCSI_Read10(lun, params);
+
+  case SCSI_WRITE10:
+    return SCSI_Write10(lun, params);
+
+  case SCSI_VERIFY10:
+    return SCSI_Verify10(lun, params);
+
+  default:
+    SCSI_SenseCode(lun,
+                   ILLEGAL_REQUEST,
+                   INVALID_CDB);
+    return -1;
+  }
+}
+
+
+/**
+* @brief  SCSI_TestUnitReady
+*         Process SCSI Test Unit Ready Command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_TestUnitReady(uint8_t lun, uint8_t *params)
+{
+  UNUSED(params);
+  /* case 9 : Hi > D0 */
+  if (MSC_BOT_cbw.dDataLength != 0)
+  {
+    SCSI_SenseCode(MSC_BOT_cbw.bLUN,
+                   ILLEGAL_REQUEST,
+                   INVALID_CDB);
+    return -1;
+  }
+
+  if(USBD_STORAGE_fops->IsReady(lun) !=0 )
+  {
+    SCSI_SenseCode(lun,
+                   NOT_READY,
+                   MEDIUM_NOT_PRESENT);
+    return -1;
+  }
+  MSC_BOT_DataLen = 0;
+  return 0;
+}
+
+/**
+* @brief  SCSI_Inquiry
+*         Process Inquiry command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t  SCSI_Inquiry(uint8_t lun, uint8_t *params)
+{
+  uint8_t* pPage;
+  uint16_t len;
+
+  if (params[1] & 0x01)/*Evpd is set*/
+  {
+    pPage = (uint8_t *)MSC_Page00_Inquiry_Data;
+    len = LENGTH_INQUIRY_PAGE00;
+  }
+  else
+  {
+
+    pPage = (uint8_t *)&USBD_STORAGE_fops->pInquiry[lun * USBD_STD_INQUIRY_LENGTH];
+    len = pPage[4] + 5;
+
+    if (params[4] <= len)
+    {
+      len = params[4];
+    }
+  }
+  MSC_BOT_DataLen = len;
+
+  while (len)
+  {
+    len--;
+    MSC_BOT_Data[len] = pPage[len];
+  }
+  return 0;
+}
+
+/**
+* @brief  SCSI_ReadCapacity10
+*         Process Read Capacity 10 command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_ReadCapacity10(uint8_t lun, uint8_t *params)
+{
+  UNUSED(params);
+  if(USBD_STORAGE_fops->GetCapacity(lun, &SCSI_blk_nbr, &SCSI_blk_size) != 0)
+  {
+    SCSI_SenseCode(lun,
+                   NOT_READY,
+                   MEDIUM_NOT_PRESENT);
+    return -1;
+  }
+  else
+  {
+
+    MSC_BOT_Data[0] = (uint8_t)((SCSI_blk_nbr - 1) >> 24);
+    MSC_BOT_Data[1] = (uint8_t)((SCSI_blk_nbr - 1) >> 16);
+    MSC_BOT_Data[2] = (uint8_t)((SCSI_blk_nbr - 1) >>  8);
+    MSC_BOT_Data[3] = (uint8_t)(SCSI_blk_nbr - 1);
+
+    MSC_BOT_Data[4] = (uint8_t)(SCSI_blk_size >>  24);
+    MSC_BOT_Data[5] = (uint8_t)(SCSI_blk_size >>  16);
+    MSC_BOT_Data[6] = (uint8_t)(SCSI_blk_size >>  8);
+    MSC_BOT_Data[7] = (uint8_t)(SCSI_blk_size);
+
+    MSC_BOT_DataLen = 8;
+    return 0;
+  }
+}
+/**
+* @brief  SCSI_ReadFormatCapacity
+*         Process Read Format Capacity command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_ReadFormatCapacity(uint8_t lun, uint8_t *params)
+{
+  UNUSED(params);
+  uint32_t blk_size;
+  uint32_t blk_nbr;
+  uint16_t i;
+
+  for(i=0 ; i < 12 ; i++)
+  {
+    MSC_BOT_Data[i] = 0;
+  }
+
+  if(USBD_STORAGE_fops->GetCapacity(lun, &blk_nbr, &blk_size) != 0)
+  {
+    SCSI_SenseCode(lun,
+                   NOT_READY,
+                   MEDIUM_NOT_PRESENT);
+    return -1;
+  }
+  else
+  {
+    MSC_BOT_Data[3] = 0x08;
+    MSC_BOT_Data[4] = (uint8_t)((blk_nbr - 1) >> 24);
+    MSC_BOT_Data[5] = (uint8_t)((blk_nbr - 1) >> 16);
+    MSC_BOT_Data[6] = (uint8_t)((blk_nbr - 1) >>  8);
+    MSC_BOT_Data[7] = (uint8_t)(blk_nbr - 1);
+
+    MSC_BOT_Data[8] = 0x02;
+    MSC_BOT_Data[9] = (uint8_t)(blk_size >>  16);
+    MSC_BOT_Data[10] = (uint8_t)(blk_size >>  8);
+    MSC_BOT_Data[11] = (uint8_t)(blk_size);
+
+    MSC_BOT_DataLen = 12;
+    return 0;
+  }
+}
+/**
+* @brief  SCSI_ModeSense6
+*         Process Mode Sense6 command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_ModeSense6 (uint8_t lun, uint8_t *params)
+{
+  UNUSED(params);
+  UNUSED(lun);
+  uint16_t len = 8 ;
+  MSC_BOT_DataLen = len;
+
+  while (len)
+  {
+    len--;
+    MSC_BOT_Data[len] = MSC_Mode_Sense6_data[len];
+  }
+  return 0;
+}
+
+/**
+* @brief  SCSI_ModeSense10
+*         Process Mode Sense10 command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_ModeSense10 (uint8_t lun, uint8_t *params)
+{
+ UNUSED(params);
+ UNUSED(lun);
+ uint16_t len = 8;
+
+ MSC_BOT_DataLen = len;
+
+ while (len)
+  {
+    len--;
+    MSC_BOT_Data[len] = MSC_Mode_Sense10_data[len];
+  }
+  return 0;
+}
+
+/**
+* @brief  SCSI_RequestSense
+*         Process Request Sense command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+
+static int8_t SCSI_RequestSense (uint8_t lun, uint8_t *params)
+{
+  UNUSED(lun);
+  uint8_t i;
+
+  for(i=0 ; i < REQUEST_SENSE_DATA_LEN ; i++)
+  {
+    MSC_BOT_Data[i] = 0;
+  }
+
+  MSC_BOT_Data[0]	= 0x70;
+  MSC_BOT_Data[7]	= REQUEST_SENSE_DATA_LEN - 6;
+
+  if((SCSI_Sense_Head != SCSI_Sense_Tail)) {
+
+    MSC_BOT_Data[2]     = SCSI_Sense[SCSI_Sense_Head].Skey;
+    MSC_BOT_Data[12]    = SCSI_Sense[SCSI_Sense_Head].w.b.ASCQ;
+    MSC_BOT_Data[13]    = SCSI_Sense[SCSI_Sense_Head].w.b.ASC;
+    SCSI_Sense_Head++;
+
+    if (SCSI_Sense_Head == SENSE_LIST_DEEPTH)
+    {
+      SCSI_Sense_Head = 0;
+    }
+  }
+  MSC_BOT_DataLen = REQUEST_SENSE_DATA_LEN;
+
+  if (params[4] <= REQUEST_SENSE_DATA_LEN)
+  {
+    MSC_BOT_DataLen = params[4];
+  }
+  return 0;
+}
+
+/**
+* @brief  SCSI_SenseCode
+*         Load the last error code in the error list
+* @param  lun: Logical unit number
+* @param  sKey: Sense Key
+* @param  ASC: Additional Sense Key
+* @retval none
+
+*/
+void SCSI_SenseCode(uint8_t lun, uint8_t sKey, uint8_t ASC)
+{
+  UNUSED(lun);
+  SCSI_Sense[SCSI_Sense_Tail].Skey  = sKey;
+  SCSI_Sense[SCSI_Sense_Tail].w.ASC = ASC << 8;
+  SCSI_Sense_Tail++;
+  if (SCSI_Sense_Tail == SENSE_LIST_DEEPTH)
+  {
+    SCSI_Sense_Tail = 0;
+  }
+}
+/**
+* @brief  SCSI_StartStopUnit
+*         Process Start Stop Unit command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_StartStopUnit(uint8_t lun, uint8_t *params)
+{
+  UNUSED(params);
+  UNUSED(lun);
+  MSC_BOT_DataLen = 0;
+  return 0;
+}
+
+/**
+* @brief  SCSI_Read10
+*         Process Read10 command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+static int8_t SCSI_Read10(uint8_t lun , uint8_t *params)
+{
+  if(MSC_BOT_State == BOT_IDLE)  /* Idle */
+  {
+
+    /* case 10 : Ho <> Di */
+
+    if ((MSC_BOT_cbw.bmFlags & 0x80) != 0x80)
+    {
+      SCSI_SenseCode(MSC_BOT_cbw.bLUN,
+                     ILLEGAL_REQUEST,
+                     INVALID_CDB);
+      return -1;
+    }
+
+    if(USBD_STORAGE_fops->IsReady(lun) !=0 )
+    {
+      SCSI_SenseCode(lun,
+                     NOT_READY,
+                     MEDIUM_NOT_PRESENT);
+      return -1;
+    }
+
+    SCSI_blk_addr = (params[2] << 24) | \
+      (params[3] << 16) | \
+        (params[4] <<  8) | \
+          params[5];
+
+    SCSI_blk_len =  (params[7] <<  8) | \
+      params[8];
+
+
+
+    if( SCSI_CheckAddressRange(lun, SCSI_blk_addr, SCSI_blk_len) < 0)
+    {
+      return -1; /* error */
+    }
+
+    MSC_BOT_State = BOT_DATA_IN;
+    SCSI_blk_addr *= SCSI_blk_size;
+    SCSI_blk_len  *= SCSI_blk_size;
+
+    /* cases 4,5 : Hi <> Dn */
+    if (MSC_BOT_cbw.dDataLength != SCSI_blk_len)
+    {
+      SCSI_SenseCode(MSC_BOT_cbw.bLUN,
+                     ILLEGAL_REQUEST,
+                     INVALID_CDB);
+      return -1;
+    }
+  }
+  MSC_BOT_DataLen = MSC_MEDIA_PACKET;
+
+  return SCSI_ProcessRead(lun);
+}
+
+/**
+* @brief  SCSI_Write10
+*         Process Write10 command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+
+static int8_t SCSI_Write10 (uint8_t lun , uint8_t *params)
+{
+  if (MSC_BOT_State == BOT_IDLE) /* Idle */
+  {
+
+    /* case 8 : Hi <> Do */
+
+    if ((MSC_BOT_cbw.bmFlags & 0x80) == 0x80)
+    {
+      SCSI_SenseCode(MSC_BOT_cbw.bLUN,
+                     ILLEGAL_REQUEST,
+                     INVALID_CDB);
+      return -1;
+    }
+
+    /* Check whether Media is ready */
+    if(USBD_STORAGE_fops->IsReady(lun) !=0 )
+    {
+      SCSI_SenseCode(lun,
+                     NOT_READY,
+                     MEDIUM_NOT_PRESENT);
+      return -1;
+    }
+
+    /* Check If media is write-protected */
+    if(USBD_STORAGE_fops->IsWriteProtected(lun) !=0 )
+    {
+      SCSI_SenseCode(lun,
+                     NOT_READY,
+                     WRITE_PROTECTED);
+      return -1;
+    }
+
+
+    SCSI_blk_addr = (params[2] << 24) | \
+      (params[3] << 16) | \
+        (params[4] <<  8) | \
+          params[5];
+    SCSI_blk_len = (params[7] <<  8) | \
+      params[8];
+
+    /* check if LBA address is in the right range */
+    if(SCSI_CheckAddressRange(lun, SCSI_blk_addr, SCSI_blk_len) < 0)
+    {
+      return -1; /* error */
+    }
+
+    SCSI_blk_addr *= SCSI_blk_size;
+    SCSI_blk_len  *= SCSI_blk_size;
+
+    /* cases 3,11,13 : Hn,Ho <> D0 */
+    if (MSC_BOT_cbw.dDataLength != SCSI_blk_len)
+    {
+      SCSI_SenseCode(MSC_BOT_cbw.bLUN,
+                     ILLEGAL_REQUEST,
+                     INVALID_CDB);
+      return -1;
+    }
+
+    /* Prepare EP to receive first data packet */
+    MSC_BOT_State = BOT_DATA_OUT;
+    DCD_EP_PrepareRx (cdev,
+                      MSC_OUT_EP,
+                      MSC_BOT_Data,
+                      MIN (SCSI_blk_len, MSC_MEDIA_PACKET));
+  }
+  else /* Write Process ongoing */
+  {
+    return SCSI_ProcessWrite(lun);
+  }
+  return 0;
+}
+
+
+/**
+* @brief  SCSI_Verify10
+*         Process Verify10 command
+* @param  lun: Logical unit number
+* @param  params: Command parameters
+* @retval status
+*/
+
+static int8_t SCSI_Verify10(uint8_t lun , uint8_t *params){
+  if ((params[1]& 0x02) == 0x02)
+  {
+    SCSI_SenseCode (lun, ILLEGAL_REQUEST, INVALID_FIELED_IN_COMMAND);
+    return -1; /* Error, Verify Mode Not supported*/
+  }
+
+  SCSI_blk_addr = (params[2] << 24) | \
+    (params[3] << 16) | \
+      (params[4] <<  8) | \
+        params[5];
+  SCSI_blk_len = (params[7] <<  8) | \
+    params[8];
+
+  if(SCSI_CheckAddressRange(lun, SCSI_blk_addr, SCSI_blk_len) < 0)
+  {
+    return -1; /* error */
+  }
+  MSC_BOT_DataLen = 0;
+  return 0;
+}
+
+/**
+* @brief  SCSI_CheckAddressRange
+*         Check address range
+* @param  lun: Logical unit number
+* @param  blk_offset: first block address
+* @param  blk_nbr: number of block to be processed
+* @retval status
+*/
+static int8_t SCSI_CheckAddressRange (uint8_t lun , uint32_t blk_offset , uint16_t blk_nbr)
+{
+
+  if ((blk_offset + blk_nbr) > SCSI_blk_nbr )
+  {
+    SCSI_SenseCode(lun, ILLEGAL_REQUEST, ADDRESS_OUT_OF_RANGE);
+    return -1;
+  }
+  return 0;
+}
+
+/**
+* @brief  SCSI_ProcessRead
+*         Handle Read Process
+* @param  lun: Logical unit number
+* @retval status
+*/
+static int8_t SCSI_ProcessRead (uint8_t lun)
+{
+  uint32_t len;
+
+  len = MIN(SCSI_blk_len , MSC_MEDIA_PACKET);
+
+  if( USBD_STORAGE_fops->Read(lun ,
+                              MSC_BOT_Data,
+                              SCSI_blk_addr / SCSI_blk_size,
+                              len / SCSI_blk_size) < 0)
+  {
+
+    SCSI_SenseCode(lun, HARDWARE_ERROR, UNRECOVERED_READ_ERROR);
+    return -1;
+  }
+
+
+  DCD_EP_Tx (cdev,
+             MSC_IN_EP,
+             MSC_BOT_Data,
+             len);
+
+
+  SCSI_blk_addr   += len;
+  SCSI_blk_len    -= len;
+
+  /* case 6 : Hi = Di */
+  MSC_BOT_csw.dDataResidue -= len;
+
+  if (SCSI_blk_len == 0)
+  {
+    MSC_BOT_State = BOT_LAST_DATA_IN;
+  }
+  return 0;
+}
+
+/**
+* @brief  SCSI_ProcessWrite
+*         Handle Write Process
+* @param  lun: Logical unit number
+* @retval status
+*/
+
+static int8_t SCSI_ProcessWrite (uint8_t lun)
+{
+  uint32_t len;
+
+  len = MIN(SCSI_blk_len , MSC_MEDIA_PACKET);
+
+  if(USBD_STORAGE_fops->Write(lun ,
+                              MSC_BOT_Data,
+                              SCSI_blk_addr / SCSI_blk_size,
+                              len / SCSI_blk_size) < 0)
+  {
+    SCSI_SenseCode(lun, HARDWARE_ERROR, WRITE_FAULT);
+    return -1;
+  }
+
+
+  SCSI_blk_addr  += len;
+  SCSI_blk_len   -= len;
+
+  /* case 12 : Ho = Do */
+  MSC_BOT_csw.dDataResidue -= len;
+
+  if (SCSI_blk_len == 0)
+  {
+    MSC_BOT_SendCSW (cdev, CSW_CMD_PASSED);
+  }
+  else
+  {
+    /* Prapare EP to Receive next packet */
+    DCD_EP_PrepareRx (cdev,
+                      MSC_OUT_EP,
+                      MSC_BOT_Data,
+                      MIN (SCSI_blk_len, MSC_MEDIA_PACKET));
+  }
+
+  return 0;
+}
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_storage_template.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_storage_template.c
@@ -1,0 +1,185 @@
+/**
+  ******************************************************************************
+  * @file    usbd_storage_template.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   Memory management layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_msc_mem.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Extern function prototypes ------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+#define STORAGE_LUN_NBR                  1                    
+
+int8_t STORAGE_Init (uint8_t lun);
+
+int8_t STORAGE_GetCapacity (uint8_t lun, 
+                           uint32_t *block_num, 
+                           uint16_t *block_size);
+
+int8_t  STORAGE_IsReady (uint8_t lun);
+
+int8_t  STORAGE_IsWriteProtected (uint8_t lun);
+
+int8_t STORAGE_Read (uint8_t lun, 
+                        uint8_t *buf, 
+                        uint32_t blk_addr,
+                        uint16_t blk_len);
+
+int8_t STORAGE_Write (uint8_t lun, 
+                        uint8_t *buf, 
+                        uint32_t blk_addr,
+                        uint16_t blk_len);
+
+int8_t STORAGE_GetMaxLun (void);
+
+/* USB Mass storage Standard Inquiry Data */
+const int8_t  STORAGE_Inquirydata[] = {//36
+  
+  /* LUN 0 */
+  0x00,		
+  0x80,		
+  0x02,		
+  0x02,
+  (USBD_STD_INQUIRY_LENGTH - 5),
+  0x00,
+  0x00,	
+  0x00,
+  'S', 'T', 'M', ' ', ' ', ' ', ' ', ' ', /* Manufacturer : 8 bytes */
+  'P', 'r', 'o', 'd', 'u', 't', ' ', ' ', /* Product      : 16 Bytes */
+  ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+  '0', '.', '0' ,'1',                     /* Version      : 4 Bytes */
+}; 
+
+USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
+{
+  STORAGE_Init,
+  STORAGE_GetCapacity,
+  STORAGE_IsReady,
+  STORAGE_IsWriteProtected,
+  STORAGE_Read,
+  STORAGE_Write,
+  STORAGE_GetMaxLun,
+  STORAGE_Inquirydata,
+  
+};
+
+USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the microSD card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Init (uint8_t lun)
+{
+  return (0);
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint16_t *block_size)
+{
+  return (0);
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t  STORAGE_IsReady (uint8_t lun)
+{
+  return (0);
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t  STORAGE_IsWriteProtected (uint8_t lun)
+{
+  return  0;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Read (uint8_t lun, 
+                 uint8_t *buf, 
+                 uint32_t blk_addr,                       
+                 uint16_t blk_len)
+{
+  return 0;
+}
+/*******************************************************************************
+* Function Name  : Write_Memory
+* Description    : Handle the Write operation to the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Write (uint8_t lun, 
+                  uint8_t *buf, 
+                  uint32_t blk_addr,
+                  uint16_t blk_len)
+{
+  return (0);
+}
+/*******************************************************************************
+* Function Name  : Write_Memory
+* Description    : Handle the Write operation to the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_GetMaxLun (void)
+{
+  return (STORAGE_LUN_NBR - 1);
+}
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -89,12 +89,17 @@ USBCDC_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/cdc
 USBCDC_SRC  = $(notdir $(wildcard $(USBCDC_DIR)/src/*.c))
 EXCLUDES    = usbd_cdc_if_template.c
 USBCDC_SRC  := $(filter-out ${EXCLUDES}, $(USBCDC_SRC))
-VPATH       := $(VPATH):$(USBOTG_DIR)/src:$(USBCORE_DIR)/src:$(USBCDC_DIR)/src
+USBMSC_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/msc
+USBMSC_SRC  = $(notdir $(wildcard $(USBMSC_DIR)/src/*.c))
+EXCLUDES    = usbd_storage_template.c
+USBMSC_SRC  := $(filter-out ${EXCLUDES}, $(USBMSC_SRC))
+VPATH       := $(VPATH):$(USBOTG_DIR)/src:$(USBCORE_DIR)/src:$(USBCDC_DIR)/src:$(USBMSC_DIR)/src
 
 DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
                         $(USBOTG_SRC) \
                         $(USBCORE_SRC) \
-                        $(USBCDC_SRC)
+                        $(USBCDC_SRC) \
+                        $(USBMSC_SRC)
 endif
 
 #CMSIS
@@ -117,6 +122,7 @@ INCLUDE_DIRS    := $(INCLUDE_DIRS) \
                    $(USBOTG_DIR)/inc \
                    $(USBCORE_DIR)/inc \
                    $(USBCDC_DIR)/inc \
+                   $(USBMSC_DIR)/inc \
                    $(USBFS_DIR)/inc \
                    $(CMSIS_DIR)/Core/Include \
                    $(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx \
@@ -181,6 +187,9 @@ VCP_SRC = \
             drivers/serial_usb_vcp.c \
             drivers/usb_io.c
 endif
+
+MSC_SRC = \
+           drivers/usb_msc_f4xx.c
 
 DSP_LIB := $(ROOT)/lib/main/CMSIS/DSP
 DEVICE_FLAGS += -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1 -DUNALIGNED_SUPPORT_DISABLE -DARM_MATH_CM4

--- a/make/source.mk
+++ b/make/source.mk
@@ -388,6 +388,10 @@ endif
 ifneq ($(filter VCP,$(FEATURES)),)
 SRC += $(VCP_SRC)
 endif
+
+ifneq ($(filter MSC,$(FEATURES)),)
+SRC += $(MSC_SRC)
+endif
 # end target specific make file checks
 
 # Search path and source files for the ST stdperiph library

--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -1,0 +1,13 @@
+/*
+ * usb_msc.h
+ *
+ *  Created on: Feb 15, 2018
+ *      Author: khockuba
+ */
+
+#ifndef SRC_MAIN_DRIVERS_USB_MSC_H_
+#define SRC_MAIN_DRIVERS_USB_MSC_H_
+
+uint8_t startMsc(void);
+
+#endif /* SRC_MAIN_DRIVERS_USB_MSC_H_ */

--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -1,8 +1,21 @@
 /*
- * usb_msc.h
+ * This file is part of Cleanflight.
  *
- *  Created on: Feb 15, 2018
- *      Author: khockuba
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Chris Hockuba (https://github.com/conkerkh)
+ *
  */
 
 #ifndef SRC_MAIN_DRIVERS_USB_MSC_H_

--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -8,6 +8,11 @@
 #ifndef SRC_MAIN_DRIVERS_USB_MSC_H_
 #define SRC_MAIN_DRIVERS_USB_MSC_H_
 
+#include "platform.h"
+
 uint8_t startMsc(void);
+void mscButtonInit(void);
+void mscCheck(void);
+bool mscButton(void);
 
 #endif /* SRC_MAIN_DRIVERS_USB_MSC_H_ */

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -1,0 +1,62 @@
+/*
+ * usb_msc_f4xx.c
+ *
+ *  Created on: Feb 15, 2018
+ *      Author: khockuba
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "drivers/usb_msc.h"
+
+#include "platform.h"
+
+#ifdef USB_MSC
+
+#include "build/build_config.h"
+
+#include "common/utils.h"
+#include "drivers/io.h"
+#include "drivers/nvic.h"
+#include "drivers/time.h"
+#include "drivers/sdmmc_sdio.h"
+#include "drivers/light_led.h"
+
+#if defined(STM32F4)
+#include "usb_core.h"
+#include "usbd_cdc_vcp.h"
+#include "usb_io.h"
+#elif defined(STM32F7)
+#include "vcp_hal/usbd_cdc_interface.h"
+#include "usb_io.h"
+USBD_HandleTypeDef USBD_Device;
+#else
+#include "usb_core.h"
+#include "usb_init.h"
+#include "hw_config.h"
+#endif
+
+#include "usbd_msc_core.h"
+
+uint8_t startMsc(void)
+{
+	ledInit(statusLedConfig());
+
+	//Start USB
+	usbGenerateDisconnectPulse();
+
+	IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
+	IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
+	USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &MSC_desc, &USBD_MSC_cb, &USR_cb);
+
+	// NVIC configuration for SYSTick
+	NVIC_DisableIRQ(SysTick_IRQn);
+	NVIC_SetPriority(SysTick_IRQn, NVIC_BUILD_PRIORITY(0, 0));
+	NVIC_EnableIRQ(SysTick_IRQn);
+
+	return 0;
+}
+
+#endif

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -59,4 +59,52 @@ uint8_t startMsc(void)
 	return 0;
 }
 
+void mscButtonInit(void)
+{
+#ifdef MSC_BUTTON
+    IO_t msc_button = IOGetByTag(IO_TAG(MSC_BUTTON));
+	IOInit(msc_button, OWNER_USB, 0);
+#ifdef MSC_BUTTON_IPU
+	IOConfigGPIO(msc_button, IOCFG_IPU);
+#else
+	IOConfigGPIO(msc_button, IOCFG_IPD);
+#endif
+#endif
+}
+
+#ifdef MSC_BUTTON
+#ifdef MSC_BUTTON_IPU
+#define BUTTON_STATUS IORead(msc_button) == 0
+#else
+#define BUTTON_STATUS IORead(msc_button) == 1
+#endif
+#else
+#define BUTTON_STATUS 0
+#endif
+
+void mscCheck(void)
+{
+	//In order to exit MSC mode simply disconnect the board
+#ifdef MSC_BUTTON
+	IO_t msc_button = IOGetByTag(IO_TAG(MSC_BUTTON));
+#endif
+
+	while(BUTTON_STATUS);
+	while(1) {
+		asm("NOP");
+		if (BUTTON_STATUS) {
+			*((uint32_t *)0x2001FFF0) = 0xDDDD1011;
+			delay(1);
+			NVIC_SystemReset();
+		}
+	}
+}
+
+bool mscButton(void) {
+#ifdef MSC_BUTTON
+	IO_t msc_button = IOGetByTag(IO_TAG(MSC_BUTTON));
+#endif
+	return BUTTON_STATUS;
+}
+
 #endif

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -1,8 +1,21 @@
 /*
- * usb_msc_f4xx.c
+ * This file is part of Cleanflight.
  *
- *  Created on: Feb 15, 2018
- *      Author: khockuba
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Chris Hockuba (https://github.com/conkerkh)
+ *
  */
 
 #include <stdint.h>

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -71,7 +71,9 @@
 #include "drivers/usb_io.h"
 #include "drivers/vtx_rtc6705.h"
 #include "drivers/vtx_common.h"
+#ifdef USB_MSC
 #include "drivers/usb_msc.h"
+#endif
 
 #include "fc/config.h"
 #include "fc/fc_init.h"
@@ -452,38 +454,14 @@ void init(void)
 #endif // USE_SPI
 
 #ifdef USB_MSC
-#ifdef MSC_BUTTON
-    IO_t msc_button = IOGetByTag(IO_TAG(MSC_BUTTON));
-	IOInit(msc_button, OWNER_USB, 0);
-#ifdef MSC_BUTTON_IPU
-	IOConfigGPIO(msc_button, IOCFG_IPU);
-#define BUTTON_STATUS IORead(msc_button) == 0
-#else
-	IOConfigGPIO(msc_button, IOCFG_IPD);
-#define BUTTON_STATUS IORead(msc_button) == 1
-#endif
-#else
-#define BUTTON_STATUS 0
-#endif
-
 /* MSC mode will start after init, but will not allow scheduler to run,
  *  so there is no bottleneck in reading and writing data */
-    if (*((uint32_t *)0x2001FFF0) == 0xDDDD1010 || BUTTON_STATUS) {
+    mscButtonInit();
+    if (*((uint32_t *)0x2001FFF0) == 0xDDDD1010 || mscButton()) {
     		if (startMsc() == 0) {
-    			//In order to exit MSC mode simply disconnect the board
-#ifdef MSC_BUTTON
-    			while(BUTTON_STATUS);
-#endif
-    			while(1) {
-    				asm("NOP");
-#ifdef MSC_BUTTON
-    				if (BUTTON_STATUS) {
-    					*((uint32_t *)0x2001FFF0) = 0xDDDD1011;
-    					delay(1);
-    					NVIC_SystemReset();
-    				}
-#endif
-    			}
+    			mscCheck();
+    		} else {
+    			NVIC_SystemReset();
     		}
     }
 #endif

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -79,6 +79,7 @@ extern uint8_t __config_end;
 #include "drivers/light_led.h"
 #include "drivers/camera_control.h"
 #include "drivers/vtx_common.h"
+#include "drivers/usb_msc.h"
 
 #include "fc/config.h"
 #include "fc/controlrate_profile.h"
@@ -3654,6 +3655,33 @@ static void cliDiff(char *cmdline)
     printConfig(cmdline, true);
 }
 
+#ifdef USB_MSC
+static void cliMsc(char *cmdline)
+{
+    UNUSED(cmdline);
+
+    if (sdcard_isFunctional()) {
+        cliPrintHashLine("restarting in mass storage mode");
+        cliPrint("\r\nRebooting");
+        bufWriterFlush(cliWriter);
+        delay(1000);
+        waitForSerialPortToFinishTransmitting(cliPort);
+        stopPwmAllMotors();
+        if (mpuResetFn) {
+            mpuResetFn();
+        }
+
+        *((uint32_t *)0x2001FFF0) = 0xDDDD1010; // Same location as bootloader magic but different value
+
+        __disable_irq();
+        NVIC_SystemReset();
+    } else {
+        cliPrint("\r\nSD Card not present or failed to initialize!");
+        bufWriterFlush(cliWriter);
+    }
+}
+#endif
+
 typedef struct {
     const char *name;
 #ifndef MINIMAL_CLI
@@ -3772,6 +3800,9 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("version", "show version", NULL, cliVersion),
 #ifdef USE_VTX_CONTROL
     CLI_COMMAND_DEF("vtx", "vtx channels on switch", NULL, cliVtx),
+#endif
+#ifdef USB_MSC
+	CLI_COMMAND_DEF("msc", "switch into msc mode", NULL, cliMsc),
 #endif
 };
 

--- a/src/main/msc/usbd_msc_desc.c
+++ b/src/main/msc/usbd_msc_desc.c
@@ -1,0 +1,384 @@
+/**
+  ******************************************************************************
+  * @file    usbd_desc.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   This file provides the USBD descriptors and string formating method.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_core.h"
+#include "usbd_desc.h"
+#include "usbd_req.h"
+#include "usbd_conf.h"
+#include "usb_regs.h"
+#include "platform.h"
+
+#define         DEVICE_ID1          (0x1FFFF7E8)
+#define         DEVICE_ID2          (0x1FFFF7EA)
+#define         DEVICE_ID3          (0x1FFFF7EC)
+#define  USB_SIZ_STRING_SERIAL       0x1A
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup USBD_DESC
+  * @brief USBD descriptors module
+  * @{
+  */
+
+/** @defgroup USBD_DESC_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_DESC_Private_Defines
+  * @{
+  */
+
+#define USBD_VID                   0x0483
+#define USBD_PID                   0x5720
+
+#define USBD_LANGID_STRING         0x409
+#define USBD_MANUFACTURER_STRING   "STMicroelectronics"
+#define USBD_PRODUCT_HS_STRING        "Mass Storage in HS Mode"
+#define USBD_PRODUCT_FS_STRING        "Mass Storage in FS Mode"
+#define USBD_CONFIGURATION_HS_STRING  "MSC Config"
+#define USBD_INTERFACE_HS_STRING      "MSC Interface"
+#define USBD_CONFIGURATION_FS_STRING  "MSC Config"
+#define USBD_INTERFACE_FS_STRING      "MSC Interface"
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_DESC_Private_Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_DESC_Private_Variables
+  * @{
+  */
+
+USBD_DEVICE MSC_desc =
+{
+  USBD_MSC_DeviceDescriptor,
+  USBD_MSC_LangIDStrDescriptor,
+  USBD_MSC_ManufacturerStrDescriptor,
+  USBD_MSC_ProductStrDescriptor,
+  USBD_MSC_SerialStrDescriptor,
+  USBD_MSC_ConfigStrDescriptor,
+  USBD_MSC_InterfaceStrDescriptor,
+};
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+/* USB Standard Device Descriptor */
+__ALIGN_BEGIN uint8_t USBD_DeviceDesc_MSC[USB_SIZ_DEVICE_DESC] __ALIGN_END =
+{
+  0x12,                       /*bLength */
+  USB_DEVICE_DESCRIPTOR_TYPE, /*bDescriptorType*/
+  0x00,                       /*bcdUSB */
+  0x02,
+  0x00,                       /*bDeviceClass*/
+  0x00,                       /*bDeviceSubClass*/
+  0x00,                       /*bDeviceProtocol*/
+  USB_OTG_MAX_EP0_SIZE,      /*bMaxPacketSize*/
+  LOBYTE(USBD_VID),           /*idVendor*/
+  HIBYTE(USBD_VID),           /*idVendor*/
+  LOBYTE(USBD_PID),           /*idVendor*/
+  HIBYTE(USBD_PID),           /*idVendor*/
+  0x00,                       /*bcdDevice rel. 2.00*/
+  0x02,
+  USBD_IDX_MFC_STR,           /*Index of manufacturer  string*/
+  USBD_IDX_PRODUCT_STR,       /*Index of product string*/
+  USBD_IDX_SERIAL_STR,        /*Index of serial number string*/
+  USBD_CFG_MAX_NUM            /*bNumConfigurations*/
+} ; /* USB_DeviceDescriptor */
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+/* USB Standard Device Descriptor */
+__ALIGN_BEGIN uint8_t USBD_DeviceQualifierDesc_MSC[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END =
+{
+  USB_LEN_DEV_QUALIFIER_DESC,
+  USB_DESC_TYPE_DEVICE_QUALIFIER,
+  0x00,
+  0x02,
+  0x00,
+  0x00,
+  0x00,
+  0x40,
+  0x01,
+  0x00,
+};
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+/* USB Standard Device Descriptor */
+__ALIGN_BEGIN uint8_t USBD_LangIDDesc_MSC[USB_SIZ_STRING_LANGID] __ALIGN_END =
+{
+  USB_SIZ_STRING_LANGID,
+  USB_DESC_TYPE_STRING,
+  LOBYTE(USBD_LANGID_STRING),
+  HIBYTE(USBD_LANGID_STRING),
+};
+
+uint8_t USBD_StringSerial_MSC[USB_SIZ_STRING_SERIAL] =
+{
+  USB_SIZ_STRING_SERIAL,
+  USB_DESC_TYPE_STRING,
+};
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN uint8_t USBD_StrDesc_MSC[USB_MAX_STR_DESC_SIZ] __ALIGN_END ;
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_DESC_Private_FunctionPrototypes
+  * @{
+  */
+static void IntToUnicode (uint32_t value , uint8_t *pbuf , uint8_t len);
+static void Get_SerialNum(void);
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_DESC_Private_Functions
+  * @{
+  */
+
+/**
+* @brief  USBD_USR_DeviceDescriptor
+*         return the device descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_DeviceDescriptor( uint8_t speed , uint16_t *length)
+{
+  (void)(speed);
+  *length = sizeof(USBD_DeviceDesc_MSC);
+  return (uint8_t*)USBD_DeviceDesc_MSC;
+}
+
+/**
+* @brief  USBD_USR_LangIDStrDescriptor
+*         return the LangID string descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_LangIDStrDescriptor( uint8_t speed , uint16_t *length)
+{
+  (void)(speed);
+  *length =  sizeof(USBD_LangIDDesc_MSC);
+  return (uint8_t*)USBD_LangIDDesc_MSC;
+}
+
+
+/**
+* @brief  USBD_USR_ProductStrDescriptor
+*         return the product string descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_ProductStrDescriptor( uint8_t speed , uint16_t *length)
+{
+  if(speed == 0)
+  {
+    USBD_GetString((uint8_t *)(uint8_t *)USBD_PRODUCT_HS_STRING, USBD_StrDesc_MSC, length);
+  }
+  else
+  {
+    USBD_GetString((uint8_t *)(uint8_t *)USBD_PRODUCT_FS_STRING, USBD_StrDesc_MSC, length);
+  }
+  return USBD_StrDesc_MSC;
+}
+
+/**
+* @brief  USBD_USR_ManufacturerStrDescriptor
+*         return the manufacturer string descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_ManufacturerStrDescriptor( uint8_t speed , uint16_t *length)
+{
+  (void)(speed);
+  USBD_GetString((uint8_t *)(uint8_t *)USBD_MANUFACTURER_STRING, USBD_StrDesc_MSC, length);
+  return USBD_StrDesc_MSC;
+}
+
+/**
+* @brief  USBD_USR_SerialStrDescriptor
+*         return the serial number string descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_SerialStrDescriptor( uint8_t speed , uint16_t *length)
+{
+  (void)(speed);
+  *length = USB_SIZ_STRING_SERIAL;
+
+  /* Update the serial number string descriptor with the data from the unique ID*/
+  Get_SerialNum();
+
+  return (uint8_t*)USBD_StringSerial_MSC;
+}
+
+/**
+* @brief  USBD_USR_ConfigStrDescriptor
+*         return the configuration string descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_ConfigStrDescriptor( uint8_t speed , uint16_t *length)
+{
+  if(speed  == USB_OTG_SPEED_HIGH)
+  {
+    USBD_GetString((uint8_t *)(uint8_t *)USBD_CONFIGURATION_HS_STRING, USBD_StrDesc_MSC, length);
+  }
+  else
+  {
+    USBD_GetString((uint8_t *)(uint8_t *)USBD_CONFIGURATION_FS_STRING, USBD_StrDesc_MSC, length);
+  }
+  return USBD_StrDesc_MSC;
+}
+
+
+/**
+* @brief  USBD_USR_InterfaceStrDescriptor
+*         return the interface string descriptor
+* @param  speed : current device speed
+* @param  length : pointer to data length variable
+* @retval pointer to descriptor buffer
+*/
+uint8_t *  USBD_MSC_InterfaceStrDescriptor( uint8_t speed , uint16_t *length)
+{
+  if(speed == 0)
+  {
+    USBD_GetString((uint8_t *)(uint8_t *)USBD_INTERFACE_HS_STRING, USBD_StrDesc_MSC, length);
+  }
+  else
+  {
+    USBD_GetString((uint8_t *)(uint8_t *)USBD_INTERFACE_FS_STRING, USBD_StrDesc_MSC, length);
+  }
+  return USBD_StrDesc_MSC;
+}
+
+/**
+  * @brief  Create the serial number string descriptor
+  * @param  None
+  * @retval None
+  */
+static void Get_SerialNum(void)
+{
+  uint32_t deviceserial0, deviceserial1, deviceserial2;
+
+  deviceserial0 = *(uint32_t*)DEVICE_ID1;
+  deviceserial1 = *(uint32_t*)DEVICE_ID2;
+  deviceserial2 = *(uint32_t*)DEVICE_ID3;
+
+  deviceserial0 += deviceserial2;
+
+  if (deviceserial0 != 0)
+  {
+    IntToUnicode (deviceserial0, &USBD_StringSerial_MSC[2] ,8);
+    IntToUnicode (deviceserial1, &USBD_StringSerial_MSC[18] ,4);
+  }
+}
+
+/**
+  * @brief  Convert Hex 32Bits value into char
+  * @param  value: value to convert
+  * @param  pbuf: pointer to the buffer
+  * @param  len: buffer length
+  * @retval None
+  */
+static void IntToUnicode (uint32_t value , uint8_t *pbuf , uint8_t len)
+{
+  uint8_t idx = 0;
+
+  for( idx = 0 ; idx < len ; idx ++)
+  {
+    if( ((value >> 28)) < 0xA )
+    {
+      pbuf[ 2* idx] = (value >> 28) + '0';
+    }
+    else
+    {
+      pbuf[2* idx] = (value >> 28) + 'A' - 10;
+    }
+
+    value = value << 4;
+
+    pbuf[ 2* idx + 1] = 0;
+  }
+}
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/main/msc/usbd_msc_desc.h
+++ b/src/main/msc/usbd_msc_desc.h
@@ -2,20 +2,26 @@
   ******************************************************************************
   * @file    usbd_desc.h
   * @author  MCD Application Team
-  * @version V1.0.0
-  * @date    19-September-2011
+  * @version V1.2.0
+  * @date    09-November-2015
   * @brief   header file for the usbd_desc.c file
   ******************************************************************************
   * @attention
   *
-  * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-  * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-  * TIME. AS A RESULT, STMICROELECTRONICS SHALL NOT BE HELD LIABLE FOR ANY
-  * DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-  * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-  * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
   *
-  * <h2><center>&copy; COPYRIGHT 2011 STMicroelectronics</center></h2>
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
   ******************************************************************************
   */
 
@@ -25,7 +31,7 @@
 #define __USB_DESC_H
 
 /* Includes ------------------------------------------------------------------*/
-#include "usbd_def.h"
+#include "usbd_req.h"
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
   * @{
@@ -47,6 +53,18 @@
 #define USB_SIZ_DEVICE_DESC                     18
 #define USB_SIZ_STRING_LANGID                   4
 
+#if !defined (USE_STM3210C_EVAL)
+#define         DEVICE_ID1          (0x1FFF7A10)
+#define         DEVICE_ID2          (0x1FFF7A14)
+#define         DEVICE_ID3          (0x1FFF7A18)
+
+#else
+#define         DEVICE_ID1          (0x1FFFF7E8)
+#define         DEVICE_ID2          (0x1FFFF7EA)
+#define         DEVICE_ID3          (0x1FFFF7EC)
+#endif
+
+#define  USB_SIZ_STRING_SERIAL       0x1A
 /**
   * @}
   */
@@ -77,13 +95,6 @@ extern  uint8_t USBD_OtherSpeedCfgDesc[USB_LEN_CFG_DESC];
 extern  uint8_t USBD_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC];
 extern  uint8_t USBD_LangIDDesc[USB_SIZ_STRING_LANGID];
 extern  USBD_DEVICE USR_desc;
-
-extern  uint8_t USBD_DeviceDesc_MSC  [USB_SIZ_DEVICE_DESC];
-extern  uint8_t USBD_StrDesc_MSC[USB_MAX_STR_DESC_SIZ];
-extern  uint8_t USBD_OtherSpeedCfgDesc_MSC[USB_LEN_CFG_DESC];
-extern  uint8_t USBD_DeviceQualifierDesc_MSC[USB_LEN_DEV_QUALIFIER_DESC];
-extern  uint8_t USBD_LangIDDesc_MSC[USB_SIZ_STRING_LANGID];
-extern  USBD_DEVICE MSC_desc;
 /**
   * @}
   */
@@ -100,14 +111,6 @@ uint8_t *     USBD_USR_ProductStrDescriptor ( uint8_t speed , uint16_t *length);
 uint8_t *     USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length);
 uint8_t *     USBD_USR_ConfigStrDescriptor( uint8_t speed , uint16_t *length);
 uint8_t *     USBD_USR_InterfaceStrDescriptor( uint8_t speed , uint16_t *length);
-
-uint8_t *     USBD_MSC_DeviceDescriptor( uint8_t speed , uint16_t *length);
-uint8_t *     USBD_MSC_LangIDStrDescriptor( uint8_t speed , uint16_t *length);
-uint8_t *     USBD_MSC_ManufacturerStrDescriptor ( uint8_t speed , uint16_t *length);
-uint8_t *     USBD_MSC_ProductStrDescriptor ( uint8_t speed , uint16_t *length);
-uint8_t *     USBD_MSC_SerialStrDescriptor( uint8_t speed , uint16_t *length);
-uint8_t *     USBD_MSC_ConfigStrDescriptor( uint8_t speed , uint16_t *length);
-uint8_t *     USBD_MSC_InterfaceStrDescriptor( uint8_t speed , uint16_t *length);
 
 #ifdef USB_SUPPORT_USER_STRING_DESC
 uint8_t *     USBD_USR_USRStringDesc (uint8_t speed, uint8_t idx , uint16_t *length);
@@ -126,4 +129,4 @@ uint8_t *     USBD_USR_USRStringDesc (uint8_t speed, uint8_t idx , uint16_t *len
 /**
 * @}
 */
-/******************* (C) COPYRIGHT 2011 STMicroelectronics *****END OF FILE****/
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/main/msc/usbd_storage_sd_spi.c
+++ b/src/main/msc/usbd_storage_sd_spi.c
@@ -1,0 +1,234 @@
+/**
+  ******************************************************************************
+  * @file    usbd_storage_template.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   Memory management layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "platform.h"
+
+#include "usbd_msc_mem.h"
+#include "usbd_msc_core.h"
+#include "common/utils.h"
+
+#include "drivers/sdcard.h"
+#include "drivers/light_led.h"
+#include "drivers/io.h"
+#include "drivers/bus_spi.h"
+
+#include "pg/sdcard.h"
+#include "pg/bus_spi.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Extern function prototypes ------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/* USB NVIC Priority has to be lower than both DMA and SDIO priority,
+ * otherwise SDIO won't be able to preempt USB.
+ */
+
+#define STORAGE_LUN_NBR                  1
+
+int8_t STORAGE_Init (uint8_t lun);
+
+int8_t STORAGE_GetCapacity (uint8_t lun,
+                           uint32_t *block_num,
+                           uint32_t *block_size);
+
+int8_t  STORAGE_IsReady (uint8_t lun);
+
+int8_t  STORAGE_IsWriteProtected (uint8_t lun);
+
+int8_t STORAGE_Read (uint8_t lun,
+                        uint8_t *buf,
+                        uint32_t blk_addr,
+                        uint16_t blk_len);
+
+int8_t STORAGE_Write (uint8_t lun,
+                        uint8_t *buf,
+                        uint32_t blk_addr,
+                        uint16_t blk_len);
+
+int8_t STORAGE_GetMaxLun (void);
+
+/* USB Mass storage Standard Inquiry Data */
+uint8_t  STORAGE_Inquirydata[] = {//36
+
+  /* LUN 0 */
+  0x00,
+  0x80,
+  0x02,
+  0x02,
+  (USBD_STD_INQUIRY_LENGTH - 5),
+  0x00,
+  0x00,
+  0x00,
+  'S', 'T', 'M', ' ', ' ', ' ', ' ', ' ', /* Manufacturer : 8 bytes */
+  'P', 'r', 'o', 'd', 'u', 't', ' ', ' ', /* Product      : 16 Bytes */
+  ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+  '0', '.', '0' ,'1',                     /* Version      : 4 Bytes */
+};
+
+USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
+{
+  STORAGE_Init,
+  STORAGE_GetCapacity,
+  STORAGE_IsReady,
+  STORAGE_IsWriteProtected,
+  STORAGE_Read,
+  STORAGE_Write,
+  STORAGE_GetMaxLun,
+  (int8_t*)STORAGE_Inquirydata,
+
+};
+
+USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the microSD card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Init (uint8_t lun)
+{
+	UNUSED(lun);
+	LED0_OFF;
+	sdcard_init(sdcardConfig());
+	while (sdcard_poll() == 0);
+	LED0_ON;
+	return 0;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
+{
+	UNUSED(lun);
+	*block_num = sdcard_getMetadata()->numBlocks;
+	*block_size = 512;
+	return (0);
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t  STORAGE_IsReady (uint8_t lun)
+{
+	UNUSED(lun);
+	int8_t ret = -1;
+	if (sdcard_poll()) {
+        ret = 0;
+	}
+	return ret;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t  STORAGE_IsWriteProtected (uint8_t lun)
+{
+  UNUSED(lun);
+  return  0;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Read (uint8_t lun,
+                 uint8_t *buf,
+                 uint32_t blk_addr,
+                 uint16_t blk_len)
+{
+	UNUSED(lun);
+	LED1_ON;
+	for (int i = 0; i < blk_len; i++) {
+	    while (sdcard_readBlock(blk_addr + i, buf + (512 * i), NULL, NULL) == 0);
+		while (sdcard_poll() == 0);
+	}
+	LED1_OFF;
+	return 0;
+}
+/*******************************************************************************
+* Function Name  : Write_Memory
+* Description    : Handle the Write operation to the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Write (uint8_t lun,
+                  uint8_t *buf,
+                  uint32_t blk_addr,
+                  uint16_t blk_len)
+{
+	UNUSED(lun);
+	LED1_ON;
+	for (int i = 0; i < blk_len; i++) {
+		while (sdcard_writeBlock(blk_addr + i, buf + (i * 512), NULL, NULL) != SDCARD_OPERATION_IN_PROGRESS) {
+			sdcard_poll();
+		}
+		while (sdcard_poll() == 0);
+	}
+	LED1_OFF;
+	return 0;
+}
+/*******************************************************************************
+* Function Name  : Write_Memory
+* Description    : Handle the Write operation to the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_GetMaxLun (void)
+{
+  return (STORAGE_LUN_NBR - 1);
+}
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/main/msc/usbd_storage_sdio.c
+++ b/src/main/msc/usbd_storage_sdio.c
@@ -1,0 +1,251 @@
+/**
+  ******************************************************************************
+  * @file    usbd_storage_template.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   Memory management layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "platform.h"
+
+#include "usbd_msc_mem.h"
+#include "usbd_msc_core.h"
+#include "drivers/sdmmc_sdio.h"
+#include "drivers/light_led.h"
+#include "drivers/io.h"
+#include "common/utils.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Extern function prototypes ------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/* USB NVIC Priority has to be lower than both DMA and SDIO priority,
+ * otherwise SDIO won't be able to preempt USB.
+ */
+
+#define STORAGE_LUN_NBR                  1
+
+int8_t STORAGE_Init (uint8_t lun);
+
+int8_t STORAGE_GetCapacity (uint8_t lun,
+                           uint32_t *block_num,
+                           uint32_t *block_size);
+
+int8_t  STORAGE_IsReady (uint8_t lun);
+
+int8_t  STORAGE_IsWriteProtected (uint8_t lun);
+
+int8_t STORAGE_Read (uint8_t lun,
+                        uint8_t *buf,
+                        uint32_t blk_addr,
+                        uint16_t blk_len);
+
+int8_t STORAGE_Write (uint8_t lun,
+                        uint8_t *buf,
+                        uint32_t blk_addr,
+                        uint16_t blk_len);
+
+int8_t STORAGE_GetMaxLun (void);
+
+/* USB Mass storage Standard Inquiry Data */
+uint8_t  STORAGE_Inquirydata[] = {//36
+
+  /* LUN 0 */
+  0x00,
+  0x80,
+  0x02,
+  0x02,
+  (USBD_STD_INQUIRY_LENGTH - 5),
+  0x00,
+  0x00,
+  0x00,
+  'S', 'T', 'M', ' ', ' ', ' ', ' ', ' ', /* Manufacturer : 8 bytes */
+  'P', 'r', 'o', 'd', 'u', 't', ' ', ' ', /* Product      : 16 Bytes */
+  ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+  '0', '.', '0' ,'1',                     /* Version      : 4 Bytes */
+};
+
+USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
+{
+  STORAGE_Init,
+  STORAGE_GetCapacity,
+  STORAGE_IsReady,
+  STORAGE_IsWriteProtected,
+  STORAGE_Read,
+  STORAGE_Write,
+  STORAGE_GetMaxLun,
+  (int8_t*)STORAGE_Inquirydata,
+
+};
+
+USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the microSD card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Init (uint8_t lun)
+{
+	//Initialize SD_DET
+#ifdef SDCARD_DETECT_PIN
+	const IO_t sd_det = IOGetByTag(IO_TAG(SDCARD_DETECT_PIN));
+	IOInit(sd_det, OWNER_SDCARD_DETECT, 0);
+	IOConfigGPIO(sd_det, IOCFG_IPU);
+#endif
+
+	UNUSED(lun);
+	LED0_OFF;
+	SD_Initialize_LL(SDIO_DMA);
+	if (SD_Init() != 0) return 1;
+	LED0_ON;
+	return 0;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
+{
+	UNUSED(lun);
+	if (SD_IsDetected() == 0) {
+		return -1;
+	}
+	SD_GetCardInfo();
+
+	*block_num = SD_CardInfo.CardCapacity;
+	*block_size = 512;
+	return (0);
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t  STORAGE_IsReady (uint8_t lun)
+{
+	UNUSED(lun);
+	int8_t ret = -1;
+	if (SD_GetState() == true && SD_IsDetected() == SD_PRESENT) {
+        ret = 0;
+	}
+	return ret;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t  STORAGE_IsWriteProtected (uint8_t lun)
+{
+  UNUSED(lun);
+  return  0;
+}
+
+/*******************************************************************************
+* Function Name  : Read_Memory
+* Description    : Handle the Read operation from the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Read (uint8_t lun,
+                 uint8_t *buf,
+                 uint32_t blk_addr,
+                 uint16_t blk_len)
+{
+	UNUSED(lun);
+	if (SD_IsDetected() == 0) {
+		return -1;
+	}
+	LED1_ON;
+	//buf should be 32bit aligned, but usually is so we don't do byte alignment
+	if (SD_ReadBlocks_DMA(blk_addr, (uint32_t*) buf, 512, blk_len) == 0) {
+		while (SD_CheckRead());
+		while(SD_GetState() == false);
+		LED1_OFF;
+		return 0;
+	}
+	LED1_OFF;
+	return -1;
+}
+/*******************************************************************************
+* Function Name  : Write_Memory
+* Description    : Handle the Write operation to the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_Write (uint8_t lun,
+                  uint8_t *buf,
+                  uint32_t blk_addr,
+                  uint16_t blk_len)
+{
+	UNUSED(lun);
+	if (SD_IsDetected() == 0) {
+		return -1;
+	}
+	LED1_ON;
+	//buf should be 32bit aligned, but usually is so we don't do byte alignment
+	if (SD_WriteBlocks_DMA(blk_addr, (uint32_t*) buf, 512, blk_len) == 0) {
+		while (SD_CheckWrite());
+		while(SD_GetState() == false);
+		LED1_OFF;
+		return 0;
+	}
+	LED1_OFF;
+	return -1;
+}
+/*******************************************************************************
+* Function Name  : Write_Memory
+* Description    : Handle the Write operation to the STORAGE card.
+* Input          : None.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+int8_t STORAGE_GetMaxLun (void)
+{
+  return (STORAGE_LUN_NBR - 1);
+}
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/main/target/WORMFC/target.mk
+++ b/src/main/target/WORMFC/target.mk
@@ -1,5 +1,5 @@
 F405_TARGETS    += $(TARGET)
-FEATURES        += VCP
+FEATURES        += VCP MSC
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
@@ -15,4 +15,6 @@ TARGET_SRC += \
             drivers/sdcard_sdio_baremetal.c \
             drivers/sdcard_standard.c \
             io/asyncfatfs/asyncfatfs.c \
-            io/asyncfatfs/fat_standard.c
+            io/asyncfatfs/fat_standard.c \
+            msc/usbd_storage_sdio.c \
+            msc/usbd_msc_desc.c

--- a/src/main/vcpf4/usbd_conf.h
+++ b/src/main/vcpf4/usbd_conf.h
@@ -59,6 +59,23 @@
 #define APP_TX_DATA_SIZE               2048  /* total size of the OUT (inbound to FC) buffer */
 #endif /* USE_USB_OTG_HS */
 
+/* MSC */
+#define MSC_IN_EP                    0x81
+#define MSC_OUT_EP                   0x01
+#ifdef USE_USB_OTG_HS
+#ifdef USE_ULPI_PHY
+#define MSC_MAX_PACKET               512
+#else
+#define MSC_MAX_PACKET               64
+#endif
+#else  /*USE_USB_OTG_FS*/
+#define MSC_MAX_PACKET                64
+#endif
+
+
+#define MSC_MEDIA_PACKET             4096
+/* END MSC */
+
 #define APP_FOPS                        VCP_fops
 /**
   * @}


### PR DESCRIPTION
Adds support for mass storage class on USB. Basically you can mount FC as flash drive with single cli command, or a dedicated button if present on the board. PR might not compile due to depency on SDIO and WORMFC related PR.