### PR TITLE
added trailing 0x00 byte to SmartAudio

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -447,6 +447,8 @@ static void saSendFrame(uint8_t *buf, int len)
         serialWrite(smartAudioSerialPort, buf[i]);
     }
 
+    serialWrite(smartAudioSerialPort, 0x00);
+
     sa_lastTransmissionMs = millis();
     saStat.pktsent++;
 }


### PR DESCRIPTION
The byte (not) heard 'round the world.

This PR is purely for discussion and is not intended for merging or release.