### PR TITLE
Simplify CLI case-insensitive by using new strcasestr()

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -208,16 +208,6 @@ static const char * const *sensorHardwareNames[] = {
 };
 #endif // USE_SENSOR_NAMES
 
-static char *cliStringToLowercase(char *str)
-{
-    char *s = str;
-    while (*s) {
-        *s = tolower((unsigned char)*s);
-        s++;
-    }
-    return str;
-}
-
 static void cliPrint(const char *str)
 {
     while (*str) {
@@ -2838,7 +2828,7 @@ STATIC_UNIT_TESTED void cliGet(char *cmdline)
     int matchedCommands = 0;
 
     for (uint32_t i = 0; i < valueTableEntryCount; i++) {
-        if (strstr(valueTable[i].name, cliStringToLowercase(cmdline))) {
+        if (strcasestr(valueTable[i].name, cmdline)) {
             val = &valueTable[i];
             cliPrintf("%s = ", valueTable[i].name);
             cliPrintVar(val, 0);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -350,6 +350,8 @@ COVERAGE_FLAGS := --coverage
 C_FLAGS   += $(COVERAGE_FLAGS)
 CXX_FLAGS += $(COVERAGE_FLAGS)
 
+C_FLAGS   += -D_GNU_SOURCE
+
 # Set up the parameter group linker flags according to OS
 ifdef MACOSX
 LDFLAGS  += -Wl,-map,$(OBJECT_DIR)/$@.map


### PR DESCRIPTION
Remove string lowercase function from cli.c and use the new strcasestr() added to string_light.c
