### PR TITLE
Fix MSP values of the MAG

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -804,7 +804,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
                 sbufWriteU16(dst, gyroRateDps(i));
             }
             for (int i = 0; i < 3; i++) {
-                sbufWriteU16(dst, mag.magADC[i]);
+                sbufWriteU16(dst, lrintf(mag.magADC[i]));
             }
         }
         break;


### PR DESCRIPTION
The MAG only shows positive (and strange) values in the configurator (some axis are zero, too big values, etc.). This fixes it.

I think that the problem was introduced in this PR: https://github.com/betaflight/betaflight/pull/4986 when changing the MAG axis values from int32 to float.

The problem was detected for the ACC (https://github.com/betaflight/betaflight/issues/5410) and the problem was solved here: https://github.com/betaflight/betaflight/pull/5417 so I applied the same solution to the MAG.

Some things:
- Now it shows positive and negative values, so seems fixed, but...
- The MAG values must be between -1 and +1, but I see them more or less between -1.5 and +1.5 so maybe this solution is not good.

@adrianmiriuta, can you help me to find a better solution that makes the MAG work right? My knowledge of C is limited and I'm a little lost with castings and all this stuff.

