### PR TITLE
Change 'vtx_band' min back to zero

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -836,7 +836,7 @@ const clivalue_t valueTable[] = {
 
 // PG_VTX_CONFIG
 #ifdef USE_VTX_COMMON
-    { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_BAND, VTX_SETTINGS_MAX_BAND }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, band) },
+    { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_BAND }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, band) },
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_CHANNEL, VTX_SETTINGS_MAX_CHANNEL }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, channel) },
     { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_POWER_COUNT-1 }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
     { "vtx_low_power_disarm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, lowPowerDisarm) },


### PR DESCRIPTION
The minimum value for the 'vtx_band' setting needs to be zero (not VTX_SETTINGS_MIN_BAND) to support the functionality of the 'vtx_freq' setting; see:  https://github.com/betaflight/betaflight/wiki/VTX-CLI-Settings

Also, 'vtx_band' can be set to zero via MSP commands (when a "user" frequency is entered using CMS-OSD or Taranis 'lua' script).

The non-zero 'vtx_band' min value was noticed in issue #5464.

At some point around Jan 9, 2018 the 'vtx_band' min value was changed in "interface/settings.c", but I've not been able to find a specific commit that did it in the Git history.

--ET