### PR TITLE
Increase ibata_offset range to accommodate certain Hall effect sensors

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -538,7 +538,7 @@ const clivalue_t valueTable[] = {
 
 // PG_CURRENT_SENSOR_ADC_CONFIG
     { "ibata_scale",                VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_ADC_CONFIG, offsetof(currentSensorADCConfig_t, scale) },
-    { "ibata_offset",               VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_ADC_CONFIG, offsetof(currentSensorADCConfig_t, offset) },
+    { "ibata_offset",               VAR_INT16  | MASTER_VALUE, .config.minmax = { -32000, 32000 }, PG_CURRENT_SENSOR_ADC_CONFIG, offsetof(currentSensorADCConfig_t, offset) },
 // PG_CURRENT_SENSOR_ADC_CONFIG
 #ifdef USE_VIRTUAL_CURRENT_METER
     { "ibatv_scale",                VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, scale) },


### PR DESCRIPTION
The change in the way the current meter offset is handled by #4743 caused offset values to overflow from the range -16000 to 16000.

For example, Allegro Systems ACS781KLRTR-150U-T has 17.6 [mV/A] slope and Vcc (=3.3V) * 0.1 = 0.33 [V] quocient output voltage. To correctly compensate the offset voltage (0.33[V] at 0[A]), we should be able to enter -(330 * 10000 / 176) = -18750.

This PR expand the range for `ibata_offset` to `-32000` to `32000`.