### PR TITLE
ITerm rotation

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -457,13 +457,14 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     const float dynCd = flightModeFlags ? 0.0f : dtermSetpointWeight;
 
     // rotate old I to the new coordinate system
-    const float gyroToAngle = dT * 2.0f * 3.14159f / 360.0f;
-    for( int i = 3; i--; ) {
+    const float gyroToAngle = dT * RAD;
+    for (int i = FD_YAW; i != FD_ROLL; i--) {
         int i_1 = ( i + 1 ) % 3;
         int i_2 = ( i + 2 ) % 3;
         float angle = gyro.gyroADCf[i] * gyroToAngle;
-        axisPID_I[i_1] += axisPID_I[i_2] * angle;
+        float newPID_I_i_1 = axisPID_I[i_1] + axisPID_I[i_2] * angle;
         axisPID_I[i_2] -= axisPID_I[i_1] * angle;
+        axisPID_I[i_1] = newPID_I_i_1;
     }
 
     // ----------PID controller----------

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -458,7 +458,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 
     // rotate old I to the new coordinate system
     const float gyroToAngle = dT * RAD;
-    for (int i = FD_YAW; i != FD_ROLL; i--) {
+    for (int i = FD_ROLL; i <= FD_YAW; i++) {
         int i_1 = ( i + 1 ) % 3;
         int i_2 = ( i + 2 ) % 3;
         float angle = gyro.gyroADCf[i] * gyroToAngle;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -456,6 +456,16 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     // Dynamic d component, enable 2-DOF PID controller only for rate mode
     const float dynCd = flightModeFlags ? 0.0f : dtermSetpointWeight;
 
+    // rotate old I to the new coordinate system
+    const float gyroToAngle = dT * 2.0f * 3.14159f / 360.0f;
+    for( int i = 3; i--; ) {
+        int i_1 = ( i + 1 ) % 3;
+        int i_2 = ( i + 2 ) % 3;
+        float angle = gyro.gyroADCf[i] * gyroToAngle;
+        axisPID_I[i_1] += axisPID_I[i_2] * angle;
+        axisPID_I[i_2] -= axisPID_I[i_1] * angle;
+    }
+
     // ----------PID controller----------
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
         float currentPidSetpoint = getSetpointRate(axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -51,6 +51,7 @@
 #include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 
+
 FAST_RAM uint32_t targetPidLooptime;
 static FAST_RAM bool pidStabilisationEnabled;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -109,7 +109,7 @@ typedef struct pidProfile_s {
     uint16_t dterm_lowpass2_hz;                // Extra PT1 Filter on D in hz
     uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
     uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
-    
+    uint8_t  iterm_rotation;                    // rotates iterm to translate world errors to local coordinate system
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -709,6 +709,7 @@ const clivalue_t valueTable[] = {
     { "crash_limit_yaw",            VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_limit_yaw) },
     { "crash_recovery",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRASH_RECOVERY }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery) },
 
+    { "iterm_rotation",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_rotation) },
     { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
     { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 100, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },


### PR DESCRIPTION
I've been adding more yaw to my LOS flying which has exposed the following problem: when I yaw the quad changes attitude, normally the quad will drift into the direction in which I yaw, so after some yaw right the quad will get a drift to the right (in the original coordinate system). This is annoying: I just want to yaw around while flying about. Correcting while yawing is difficult enough so I don't want to correct for a systematic drift.

I've found that if I increase I to very high values - like 75 for a super light weight 210mm 2204 LOS tubular quad - it solves the problem almost completely. Haven't flown much with such high I, but I expect I'll get bounce backs from quick rolls and other typical high I problems with that approach.

Here's why this happens: 

The ITerm integrates the error on each axis over time and applies a proportional counter force. That's great: the integral of angular velocity error is the error angle so it brings the quad back into the same attitude under normal circumstances. However when you add yaw (or other rotations for that matter) the coordinate system changes. The quad will now attempt to correct e.g. accumulated roll errors on all the axis it traversed as roll while yawing by rolling in the opposite direction in the current roll axis. This clearly cannot eliminate the accumulated angular error in the general case.

Setting I very high is effective since it shortens the delay between error and I action, thereby minimizing the difference between the coordinate system in which the error is corrected to the one it occurred in. But that seems like a crutch. It would be better to rotate the accumulated error so that it applies consistently to the current coordinate system of the quad.

The fix:

The core problem is that the iterm vector is a sum of items which relate to different attitudes (= different coordinate systems). Thus a correction can't be applied in the current coordinate system based on the iterm vector in its current form. 

We correct for the accumulated error by applying the iterm to the pids, thus causing a simultaneous rotation around all axis with a a speed corresponding to the iterm vector elements. According to https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3231471/ that is the same as a rotation around the iterm vector. In order for that to be correct the iterm vector needs to be maintained in current coordinates. So we need to rotate the iterm with gyro * looptime at each step.

Luckily the rotation angle at each step is small, so we can substitute 1 for cos( angle ) and angle for sin( angle) for each axis. This makes the fix ultra small and simple. 

Demo:

https://youtu.be/UwtAj7PKrqA
