### PR TITLE
Add Composite CDC+HID device option.

### DIFF
--- a/lib/main/STM32_USB_Device_Library/Class/hid/inc/usbd_hid_core.h
+++ b/lib/main/STM32_USB_Device_Library/Class/hid/inc/usbd_hid_core.h
@@ -1,0 +1,122 @@
+/**
+  ******************************************************************************
+  * @file    usbd_hid_core.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header file for the usbd_hid_core.c file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+
+#ifndef __USB_HID_CORE_H_
+#define __USB_HID_CORE_H_
+
+#include  "usbd_ioreq.h"
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+/** @defgroup USBD_HID
+  * @brief This file is the Header file for USBD_msc.c
+  * @{
+  */
+
+
+/** @defgroup USBD_HID_Exported_Defines
+  * @{
+  */
+#define USB_HID_CONFIG_DESC_SIZ       34
+#define USB_HID_DESC_SIZ              9
+
+#define HID_MOUSE_REPORT_DESC_SIZE    38
+
+#define HID_DESCRIPTOR_TYPE           0x21
+#define HID_REPORT_DESC               0x22
+
+#define HID_HS_BINTERVAL              0x07
+#define HID_FS_BINTERVAL              0x0A
+
+#define HID_REQ_SET_PROTOCOL          0x0B
+#define HID_REQ_GET_PROTOCOL          0x03
+
+#define HID_REQ_SET_IDLE              0x0A
+#define HID_REQ_GET_IDLE              0x02
+
+#define HID_REQ_SET_REPORT            0x09
+#define HID_REQ_GET_REPORT            0x01
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_CORE_Exported_TypesDefinitions
+  * @{
+  */
+
+
+/**
+  * @}
+  */
+
+
+
+/** @defgroup USBD_CORE_Exported_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CORE_Exported_Variables
+  * @{
+  */
+
+extern USBD_Class_cb_TypeDef  USBD_HID_cb;
+/**
+  * @}
+  */
+
+/** @defgroup USB_CORE_Exported_Functions
+  * @{
+  */
+uint8_t USBD_HID_SendReport (USB_OTG_CORE_HANDLE  *pdev,
+                                 uint8_t *report,
+                                 uint16_t len);
+
+uint32_t USBD_HID_GetPollingInterval (USB_OTG_CORE_HANDLE *pdev);
+
+/**
+  * @}
+  */
+
+#endif  /*  __USB_HID_CORE_H_ */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/hid/src/usbd_hid_core.c
+++ b/lib/main/STM32_USB_Device_Library/Class/hid/src/usbd_hid_core.c
@@ -1,0 +1,499 @@
+/**
+  ******************************************************************************
+  * @file    usbd_hid_core.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   This file provides the HID core functions.
+  *
+  * @verbatim
+  *
+  *          ===================================================================
+  *                                HID Class  Description
+  *          ===================================================================
+  *           This module manages the HID class V1.11 following the "Device Class Definition
+  *           for Human Interface Devices (HID) Version 1.11 Jun 27, 2001".
+  *           This driver implements the following aspects of the specification:
+  *             - The Boot Interface Subclass
+  *             - The Mouse protocol
+  *             - Usage Page : Generic Desktop
+  *             - Usage : Joystick)
+  *             - Collection : Application
+  *
+  * @note     In HS mode and when the DMA is used, all variables and data structures
+  *           dealing with the DMA during the transaction process should be 32-bit aligned.
+  *
+  *
+  *  @endverbatim
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_hid_core.h"
+#include "usbd_desc.h"
+#include "usbd_req.h"
+
+#include "common/utils.h"
+
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup USBD_HID
+  * @brief usbd core module
+  * @{
+  */
+
+/** @defgroup USBD_HID_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_HID_Private_Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_HID_Private_Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+
+
+/** @defgroup USBD_HID_Private_FunctionPrototypes
+  * @{
+  */
+
+
+uint8_t  USBD_HID_Init (void  *pdev,
+                               uint8_t cfgidx);
+
+uint8_t  USBD_HID_DeInit (void  *pdev,
+                                 uint8_t cfgidx);
+
+uint8_t  USBD_HID_Setup (void  *pdev,
+                                USB_SETUP_REQ *req);
+
+static uint8_t  *USBD_HID_GetCfgDesc (uint8_t speed, uint16_t *length);
+
+uint8_t  USBD_HID_DataIn (void  *pdev, uint8_t epnum);
+/**
+  * @}
+  */
+
+/** @defgroup USBD_HID_Private_Variables
+  * @{
+  */
+
+USBD_Class_cb_TypeDef  USBD_HID_cb =
+{
+  USBD_HID_Init,
+  USBD_HID_DeInit,
+  USBD_HID_Setup,
+  NULL, /*EP0_TxSent*/
+  NULL, /*EP0_RxReady*/
+  USBD_HID_DataIn, /*DataIn*/
+  NULL, /*DataOut*/
+  NULL, /*SOF */
+  NULL,
+  NULL,
+  USBD_HID_GetCfgDesc,
+#ifdef USB_OTG_HS_CORE
+  USBD_HID_GetCfgDesc, /* use same config as per FS */
+#endif
+};
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN static uint32_t  USBD_HID_AltSet  __ALIGN_END = 0;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN static uint32_t  USBD_HID_Protocol  __ALIGN_END = 0;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN static uint32_t  USBD_HID_IdleState __ALIGN_END = 0;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+/* USB HID device Configuration Descriptor */
+__ALIGN_BEGIN static uint8_t USBD_HID_CfgDesc[USB_HID_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+  0x09, /* bLength: Configuration Descriptor size */
+  USB_CONFIGURATION_DESCRIPTOR_TYPE, /* bDescriptorType: Configuration */
+  USB_HID_CONFIG_DESC_SIZ,
+  /* wTotalLength: Bytes returned */
+  0x00,
+  0x01,         /*bNumInterfaces: 1 interface*/
+  0x01,         /*bConfigurationValue: Configuration value*/
+  0x00,         /*iConfiguration: Index of string descriptor describing
+  the configuration*/
+  0xE0,         /*bmAttributes: bus powered and Support Remote Wake-up */
+  0x32,         /*MaxPower 100 mA: this current is used for detecting Vbus*/
+
+  /************** Descriptor of Joystick Mouse interface ****************/
+  /* 09 */
+  0x09,         /*bLength: Interface Descriptor size*/
+  USB_INTERFACE_DESCRIPTOR_TYPE,/*bDescriptorType: Interface descriptor type*/
+  0x00,         /*bInterfaceNumber: Number of Interface*/
+  0x00,         /*bAlternateSetting: Alternate setting*/
+  0x01,         /*bNumEndpoints*/
+  0x03,         /*bInterfaceClass: HID*/
+  0x01,         /*bInterfaceSubClass : 1=BOOT, 0=no boot*/
+  0x02,         /*nInterfaceProtocol : 0=none, 1=keyboard, 2=mouse*/
+  0,            /*iInterface: Index of string descriptor*/
+  /******************** Descriptor of Joystick Mouse HID ********************/
+  /* 18 */
+  0x09,         /*bLength: HID Descriptor size*/
+  HID_DESCRIPTOR_TYPE, /*bDescriptorType: HID*/
+  0x11,         /*bcdHID: HID Class Spec release number*/
+  0x01,
+  0x00,         /*bCountryCode: Hardware target country*/
+  0x01,         /*bNumDescriptors: Number of HID class descriptors to follow*/
+  0x22,         /*bDescriptorType*/
+  HID_MOUSE_REPORT_DESC_SIZE,/*wItemLength: Total length of Report descriptor*/
+  0x00,
+  /******************** Descriptor of Mouse endpoint ********************/
+  /* 27 */
+  0x07,          /*bLength: Endpoint Descriptor size*/
+  USB_ENDPOINT_DESCRIPTOR_TYPE, /*bDescriptorType:*/
+
+  HID_IN_EP,     /*bEndpointAddress: Endpoint Address (IN)*/
+  0x03,          /*bmAttributes: Interrupt endpoint*/
+  HID_IN_PACKET, /*wMaxPacketSize: 4 Byte max */
+  0x00,
+  HID_FS_BINTERVAL,          /*bInterval: Polling Interval (10 ms)*/
+  /* 34 */
+} ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+/* USB HID device Configuration Descriptor */
+__ALIGN_BEGIN static uint8_t USBD_HID_Desc[USB_HID_DESC_SIZ] __ALIGN_END=
+{
+  /* 18 */
+  0x09,         /*bLength: HID Descriptor size*/
+  HID_DESCRIPTOR_TYPE, /*bDescriptorType: HID*/
+  0x11,         /*bcdHID: HID Class Spec release number*/
+  0x01,
+  0x00,         /*bCountryCode: Hardware target country*/
+  0x01,         /*bNumDescriptors: Number of HID class descriptors to follow*/
+  0x22,         /*bDescriptorType*/
+  HID_MOUSE_REPORT_DESC_SIZE,/*wItemLength: Total length of Report descriptor*/
+  0x00,
+};
+#endif
+
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN static uint8_t HID_MOUSE_ReportDesc[HID_MOUSE_REPORT_DESC_SIZE] __ALIGN_END =
+{
+0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
+0x09, 0x05,                    // USAGE (Game Pad)
+0xa1, 0x01,                    // COLLECTION (Application)
+0xa1, 0x00,                    //   COLLECTION (Physical)
+0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
+0x09, 0x30,                    //     USAGE (X)
+0x09, 0x31,                    //     USAGE (Y)
+0x09, 0x32,                    //     USAGE (Z)
+0x09, 0x33,                    //     USAGE (Rx)
+0x09, 0x35,                    //     USAGE (Rz)
+0x09, 0x34,                    //     USAGE (Ry)
+0x09, 0x40,                    //     USAGE (Vx)
+0x09, 0x38,                    //     USAGE (Wheel)
+0x15, 0x81,                    //     LOGICAL_MINIMUM (-127)
+0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
+0x75, 0x08,                    //     REPORT_SIZE (8)
+0x95, 0x08,                    //     REPORT_COUNT (8)
+0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+0xc0,                          //   END_COLLECTION
+0xc0                           /*     END_COLLECTION	             */
+};
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_HID_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  USBD_HID_Init
+  *         Initialize the HID interface
+  * @param  pdev: device instance
+  * @param  cfgidx: Configuration index
+  * @retval status
+  */
+uint8_t  USBD_HID_Init (void  *pdev,
+                               uint8_t cfgidx)
+{
+
+  UNUSED(cfgidx);
+  /* Open EP IN */
+  DCD_EP_Open(pdev,
+              HID_IN_EP,
+              HID_IN_PACKET,
+              USB_OTG_EP_INT);
+
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_HID_Init
+  *         DeInitialize the HID layer
+  * @param  pdev: device instance
+  * @param  cfgidx: Configuration index
+  * @retval status
+  */
+uint8_t  USBD_HID_DeInit (void  *pdev,
+                                 uint8_t cfgidx)
+{
+  UNUSED(cfgidx);
+  /* Close HID EPs */
+  DCD_EP_Close (pdev , HID_IN_EP);
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_HID_Setup
+  *         Handle the HID specific requests
+  * @param  pdev: instance
+  * @param  req: usb requests
+  * @retval status
+  */
+uint8_t  USBD_HID_Setup (void  *pdev,
+                         USB_SETUP_REQ *req)
+{
+  uint16_t len = 0;
+  uint8_t  *pbuf = NULL;
+
+  switch (req->bmRequest & USB_REQ_TYPE_MASK)
+  {
+  case USB_REQ_TYPE_CLASS :
+    switch (req->bRequest)
+    {
+    case HID_REQ_SET_PROTOCOL:
+      USBD_HID_Protocol = (uint8_t)(req->wValue);
+      break;
+
+    case HID_REQ_GET_PROTOCOL:
+      USBD_CtlSendData (pdev,
+                        (uint8_t *)&USBD_HID_Protocol,
+                        1);
+      break;
+
+    case HID_REQ_SET_IDLE:
+      USBD_HID_IdleState = (uint8_t)(req->wValue >> 8);
+      break;
+
+    case HID_REQ_GET_IDLE:
+      USBD_CtlSendData (pdev,
+                        (uint8_t *)&USBD_HID_IdleState,
+                        1);
+      break;
+
+    default:
+      USBD_CtlError (pdev, req);
+      return USBD_FAIL;
+    }
+    break;
+
+  case USB_REQ_TYPE_STANDARD:
+    switch (req->bRequest)
+    {
+    case USB_REQ_GET_DESCRIPTOR:
+      if( req->wValue >> 8 == HID_REPORT_DESC)
+      {
+        len = MIN(HID_MOUSE_REPORT_DESC_SIZE , req->wLength);
+        pbuf = HID_MOUSE_ReportDesc;
+      }
+      else if( req->wValue >> 8 == HID_DESCRIPTOR_TYPE)
+      {
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+        pbuf = USBD_HID_Desc;
+#else
+        pbuf = USBD_HID_CfgDesc + 0x12;
+#endif
+        len = MIN(USB_HID_DESC_SIZ , req->wLength);
+      }
+      else
+      {
+        /* Do Nothing */
+      }
+
+      USBD_CtlSendData (pdev,
+                        pbuf,
+                        len);
+
+      break;
+
+    case USB_REQ_GET_INTERFACE :
+      USBD_CtlSendData (pdev,
+                        (uint8_t *)&USBD_HID_AltSet,
+                        1);
+      break;
+
+    case USB_REQ_SET_INTERFACE :
+      USBD_HID_AltSet = (uint8_t)(req->wValue);
+      break;
+
+    default:
+      USBD_HID_AltSet = (uint8_t)(req->wValue);
+      break;
+    }
+    break;
+
+  default:
+    USBD_CtlSendData (pdev,
+                      (uint8_t *)&USBD_HID_AltSet,
+                      1);
+    break;
+  }
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_HID_SendReport
+  *         Send HID Report
+  * @param  pdev: device instance
+  * @param  buff: pointer to report
+  * @retval status
+  */
+uint8_t USBD_HID_SendReport     (USB_OTG_CORE_HANDLE  *pdev,
+                                 uint8_t *report,
+                                 uint16_t len)
+{
+  if (pdev->dev.device_status == USB_OTG_CONFIGURED )
+  {
+    DCD_EP_Tx (pdev, HID_IN_EP, report, len);
+  }
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_HID_GetCfgDesc
+  *         return configuration descriptor
+  * @param  speed : current device speed
+  * @param  length : pointer data length
+  * @retval pointer to descriptor buffer
+  */
+static uint8_t  *USBD_HID_GetCfgDesc (uint8_t speed, uint16_t *length)
+{
+  UNUSED(speed);
+  *length = sizeof (USBD_HID_CfgDesc);
+  return USBD_HID_CfgDesc;
+}
+
+/**
+  * @brief  USBD_HID_DataIn
+  *         handle data IN Stage
+  * @param  pdev: device instance
+  * @param  epnum: endpoint index
+  * @retval status
+  */
+uint8_t  USBD_HID_DataIn (void  *pdev,
+                              uint8_t epnum)
+{
+
+  /* Ensure that the FIFO is empty before a new transfer, this condition could
+  be caused by  a new transfer before the end of the previous transfer */
+  UNUSED(epnum);
+  DCD_EP_Flush(pdev, HID_IN_EP);
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_HID_GetPollingInterval
+  *         return polling interval from endpoint descriptor
+  * @param  pdev: device instance
+  * @retval polling interval
+  */
+uint32_t USBD_HID_GetPollingInterval (USB_OTG_CORE_HANDLE *pdev)
+{
+  uint32_t polling_interval = 0;
+
+  /* HIGH-speed endpoints */
+  if(pdev->cfg.speed == USB_OTG_SPEED_HIGH)
+  {
+   /* Sets the data transfer polling interval for high speed transfers.
+    Values between 1..16 are allowed. Values correspond to interval
+    of 2 ^ (bInterval-1). This option (8 ms, corresponds to HID_HS_BINTERVAL */
+    polling_interval = (((1 <<(HID_HS_BINTERVAL - 1)))/8);
+  }
+  else   /* LOW and FULL-speed endpoints */
+  {
+    /* Sets the data transfer polling interval for low and full
+    speed transfers */
+    polling_interval =  HID_FS_BINTERVAL;
+  }
+
+  return ((uint32_t)(polling_interval));
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/hid_cdc_wrapper/inc/usbd_hid_cdc_wrapper.h
+++ b/lib/main/STM32_USB_Device_Library/Class/hid_cdc_wrapper/inc/usbd_hid_cdc_wrapper.h
@@ -1,0 +1,96 @@
+/**
+  ******************************************************************************
+  * @file    usbd_hid_cdc_wrapper.h
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief   header file for the usbd_hid_cdc_wrapper.c file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+
+#ifndef __USB_HID_CDC_WRAPPER_H_
+#define __USB_HID_CDC_WRAPPER_H_
+
+#include  "usbd_ioreq.h"
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+  
+/** @defgroup USBD_HID_CDC
+  * @brief This file is the Header file for usbd_msc_cdc_wrapper.c
+  * @{
+  */ 
+
+
+/** @defgroup USBD_HID_MSC_Exported_Defines
+  * @{
+  */ 
+
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBD_CORE_Exported_TypesDefinitions
+  * @{
+  */
+
+
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup USBD_CORE_Exported_Macros
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBD_CORE_Exported_Variables
+  * @{
+  */ 
+
+extern USBD_Class_cb_TypeDef  USBD_HID_CDC_cb;
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#endif /* __USB_MSC_CDC_WRAPPER_H_ */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+/******************* (C) COPYRIGHT 2015 STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_Device_Library/Class/hid_cdc_wrapper/src/usbd_hid_cdc_wrapper.c
+++ b/lib/main/STM32_USB_Device_Library/Class/hid_cdc_wrapper/src/usbd_hid_cdc_wrapper.c
@@ -1,0 +1,450 @@
+/**
+  ******************************************************************************
+  * @file    usbd_hid_cdc_wrapper.c
+  * @author  MCD Application Team
+  * @version V1.2.0
+  * @date    09-November-2015
+  * @brief
+  *
+  * @verbatim
+  *
+  *          ===================================================================
+  *                                composite HID_CDC
+  *          ===================================================================
+  *
+  * @note     In HS mode and when the DMA is used, all variables and data structures
+  *           dealing with the DMA during the transaction process should be 32-bit aligned.
+  *
+  *
+  *  @endverbatim
+  *
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_hid_core.h"
+#include "usbd_cdc_core.h"
+#include "usbd_hid_cdc_wrapper.h"
+#include "usbd_desc.h"
+#include "usbd_req.h"
+
+
+/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
+  * @{
+  */
+
+
+/** @defgroup USBD_MSC_VCP
+  * @brief usbd core module
+  * @{
+  */
+
+/** @defgroup USBD_MSC_VCP_Private_TypesDefinitions
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_MSC_VCP_Private_Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USBD_MSC_VCP_Private_Macros
+  * @{
+  */
+/**
+  * @}
+  */
+
+
+
+
+/** @defgroup USBD_MSC_VCP_Private_FunctionPrototypes
+  * @{
+  */
+
+/*********************************************
+   CDC Device library callbacks
+ *********************************************/
+extern uint8_t  usbd_cdc_Init        (void  *pdev, uint8_t cfgidx);
+extern uint8_t  usbd_cdc_DeInit      (void  *pdev, uint8_t cfgidx);
+extern uint8_t  usbd_cdc_Setup       (void  *pdev, USB_SETUP_REQ *req);
+extern uint8_t  usbd_cdc_EP0_RxReady  (void *pdev);
+extern uint8_t  usbd_cdc_DataIn      (void *pdev, uint8_t epnum);
+extern uint8_t  usbd_cdc_DataOut     (void *pdev, uint8_t epnum);
+extern uint8_t  usbd_cdc_SOF         (void *pdev);
+
+extern uint8_t  *USBD_cdc_GetCfgDesc (uint8_t speed, uint16_t *length);
+#ifdef USE_USB_OTG_HS
+extern uint8_t  *USBD_cdc_GetOtherCfgDesc (uint8_t speed, uint16_t *length);
+#endif
+
+/*********************************************
+   MSC Device library callbacks
+ *********************************************/
+extern uint8_t  USBD_HID_Init (void  *pdev, uint8_t cfgidx);
+extern uint8_t  USBD_HID_DeInit (void  *pdev, uint8_t cfgidx);
+extern uint8_t  USBD_HID_Setup (void  *pdev, USB_SETUP_REQ *req);
+extern uint8_t  USBD_HID_DataIn (void  *pdev, uint8_t epnum);
+extern uint8_t  *USBD_HID_GetCfgDesc (uint8_t speed, uint16_t *length);
+extern uint8_t USBD_HID_CfgDesc[USB_HID_CONFIG_DESC_SIZ];
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_MSC_CDC_Private_Variables
+  * @{
+  */
+
+
+static uint8_t  USBD_HID_CDC_Init         (void *pdev , uint8_t cfgidx);
+static uint8_t  USBD_HID_CDC_DeInit       (void *pdev , uint8_t cfgidx);
+
+/* Control Endpoints*/
+static uint8_t  USBD_HID_CDC_Setup        (void *pdev , USB_SETUP_REQ  *req);
+static uint8_t  USBD_HID_CDC_EP0_RxReady  (void *pdev );
+
+/* Class Specific Endpoints*/
+static uint8_t  USBD_HID_CDC_DataIn       (void *pdev , uint8_t epnum);
+static uint8_t  USBD_HID_CDC_DataOut      (void *pdev , uint8_t epnum);
+static uint8_t  USBD_HID_CDC_SOF          (void *pdev);
+static uint8_t*  USBD_HID_CDC_GetConfigDescriptor( uint8_t speed , uint16_t *length);
+
+#define USB_HID_CDC_CONFIG_DESC_SIZ  (USB_HID_CONFIG_DESC_SIZ - 9 + USB_CDC_CONFIG_DESC_SIZ)
+
+#define HID_INTERFACE 0x0
+#define CDC_COM_INTERFACE 0x1
+
+
+USBD_Class_cb_TypeDef  USBD_HID_CDC_cb =
+{
+  USBD_HID_CDC_Init,
+  USBD_HID_CDC_DeInit,
+  USBD_HID_CDC_Setup,
+  NULL,
+  USBD_HID_CDC_EP0_RxReady,
+  USBD_HID_CDC_DataIn,
+  USBD_HID_CDC_DataOut,
+  USBD_HID_CDC_SOF,
+  NULL,
+  NULL,
+  USBD_HID_CDC_GetConfigDescriptor,
+};
+
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+/* USB MSC/CDC device Configuration Descriptor */
+__ALIGN_BEGIN static uint8_t USBD_HID_CDC_CfgDesc[USB_HID_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
+{
+  0x09, /* bLength: Configuration Descriptor size */
+  USB_CONFIGURATION_DESCRIPTOR_TYPE, /* bDescriptorType: Configuration */
+  USB_HID_CDC_CONFIG_DESC_SIZ,
+  /* wTotalLength: Bytes returned */
+  0x00,
+  0x02,         /*bNumInterfaces: 2 interfaces (1 for CDC, 1 for HID)*/
+  0x01,         /*bConfigurationValue: Configuration value*/
+  0x00,         /*iConfiguration: Index of string descriptor describing
+  the configuration*/
+  0xC0,         /*bmAttributes: bus powered and Support Remote Wake-up */
+  0x32,         /*MaxPower 100 mA: this current is used for detecting Vbus*/
+
+  /************** Descriptor of Joystick Mouse interface ****************/
+  /* 09 */
+  0x09,         /*bLength: Interface Descriptor size*/
+  USB_INTERFACE_DESCRIPTOR_TYPE,/*bDescriptorType: Interface descriptor type*/
+  HID_INTERFACE,         /*bInterfaceNumber: Number of Interface*/
+  0x00,         /*bAlternateSetting: Alternate setting*/
+  0x01,         /*bNumEndpoints*/
+  0x03,         /*bInterfaceClass: HID*/
+  0x00,         /*bInterfaceSubClass : 1=BOOT, 0=no boot*/
+  0x00,         /*nInterfaceProtocol : 0=none, 1=keyboard, 2=mouse*/
+  0,            /*iInterface: Index of string descriptor*/
+  /******************** Descriptor of Joystick Mouse HID ********************/
+  /* 18 */
+  0x09,         /*bLength: HID Descriptor size*/
+  HID_DESCRIPTOR_TYPE, /*bDescriptorType: HID*/
+  0x11,         /*bcdHID: HID Class Spec release number*/
+  0x01,
+  0x00,         /*bCountryCode: Hardware target country*/
+  0x01,         /*bNumDescriptors: Number of HID class descriptors to follow*/
+  0x22,         /*bDescriptorType*/
+  HID_MOUSE_REPORT_DESC_SIZE,/*wItemLength: Total length of Report descriptor*/
+  0x00,
+  /******************** Descriptor of Mouse endpoint ********************/
+  /* 27 */
+  0x07,          /*bLength: Endpoint Descriptor size*/
+  USB_ENDPOINT_DESCRIPTOR_TYPE, /*bDescriptorType:*/
+
+  HID_IN_EP,     /*bEndpointAddress: Endpoint Address (IN)*/
+  0x03,          /*bmAttributes: Interrupt endpoint*/
+  HID_IN_PACKET, /*wMaxPacketSize: 8 Byte max */
+  0x00,
+  0x0A,          /*bInterval: Polling Interval (10 ms)*/
+  /* 34 */
+
+   /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_INTERFACE_DESCRIPTOR_TYPE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  CDC_COM_INTERFACE,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x01,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  0x02,   /* bDataInterface: 2 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0x01,   /* bMasterInterface: Communication class interface */
+  0x02,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_ENDPOINT_DESCRIPTOR_TYPE,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SZE),
+  0xFF,                           /* bInterval: */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_INTERFACE_DESCRIPTOR_TYPE,  /* bDescriptorType: */
+  0x02,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_ENDPOINT_DESCRIPTOR_TYPE,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_ENDPOINT_DESCRIPTOR_TYPE,     /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                        /* bEndpointAddress */
+  0x02,                             /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval */
+
+} ;
+
+
+/**
+  * @}
+  */
+
+/** @defgroup USBD_CDC_MSC_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  USBD_MSC_CDC_Init
+  *         Initialize the MSC & CDC interfaces
+  * @param  pdev: device instance
+  * @param  cfgidx: Configuration index
+  * @retval status
+  */
+static uint8_t  USBD_HID_CDC_Init (void  *pdev,
+                               uint8_t cfgidx)
+{
+
+  /* HID initialization */
+  USBD_HID_Init (pdev,cfgidx);
+
+  /* CDC initialization */
+  usbd_cdc_Init (pdev,cfgidx);
+
+  return USBD_OK;
+
+}
+
+/**
+  * @brief  USBD_MSC_CDC_Init
+  *         DeInitialize the MSC/CDC interfaces
+  * @param  pdev: device instance
+  * @param  cfgidx: Configuration index
+  * @retval status
+  */
+static uint8_t  USBD_HID_CDC_DeInit (void  *pdev,
+                                 uint8_t cfgidx)
+{
+  /* MSC De-initialization */
+  USBD_HID_DeInit (pdev,cfgidx);
+
+  /* CDC De-initialization */
+  usbd_cdc_DeInit (pdev,cfgidx);
+
+
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_MSC_CDC_Setup
+  *         Handle the MSC/CDC specific requests
+  * @param  pdev: instance
+  * @param  req: usb requests
+  * @retval status
+  */
+static uint8_t  USBD_HID_CDC_Setup (void  *pdev,
+                                    USB_SETUP_REQ *req)
+{
+  switch (req->bmRequest & USB_REQ_RECIPIENT_MASK)
+  {
+  case USB_REQ_RECIPIENT_INTERFACE:
+    if (req->wIndex == HID_INTERFACE)
+    {
+      return (USBD_HID_Setup (pdev, req));
+    }
+    else
+    {
+      return (usbd_cdc_Setup(pdev, req));
+    }
+
+  case USB_REQ_RECIPIENT_ENDPOINT:
+    if (req->wIndex == HID_IN_EP)
+    {
+      return (USBD_HID_Setup (pdev, req));
+    }
+    else
+    {
+      return (usbd_cdc_Setup(pdev, req));
+    }
+  }
+  return USBD_OK;
+}
+
+/**
+  * @brief  USBD_MSC_CDC_GetCfgDesc
+  *         return configuration descriptor
+  * @param  speed : current device speed
+  * @param  length : pointer data length
+  * @retval pointer to descriptor buffer
+  */
+uint8_t  *USBD_HID_CDC_GetConfigDescriptor (uint8_t speed, uint16_t *length)
+{
+  (void)(speed);
+  *length = sizeof (USBD_HID_CDC_CfgDesc);
+  return USBD_HID_CDC_CfgDesc;
+}
+
+/**
+  * @brief  USBD_MSC_CDC_DataIn
+  *         handle data IN Stage
+  * @param  pdev: device instance
+  * @param  epnum: endpoint index
+  * @retval status
+  */
+static uint8_t  USBD_HID_CDC_DataIn (void  *pdev,
+                                     uint8_t epnum)
+{
+  /*DataIN can be for CDC or MSC */
+
+  if (epnum == (CDC_IN_EP&~0x80) )
+  {
+    return (usbd_cdc_DataIn(pdev, epnum));
+  }
+  else
+  {
+    return (USBD_HID_DataIn(pdev, epnum));
+  }
+}
+
+
+uint8_t  USBD_HID_CDC_DataOut(void *pdev , uint8_t epnum)
+{
+  /*DataOut can be for CDC */
+  return (usbd_cdc_DataOut(pdev, epnum));
+}
+
+
+uint8_t  USBD_HID_CDC_SOF (void *pdev)
+{
+  /*SOF processing needed for CDC */
+  return (usbd_cdc_SOF(pdev));
+}
+
+
+uint8_t  USBD_HID_CDC_EP0_RxReady  (void *pdev )
+{
+  /*RxReady processing needed for CDC only*/
+  return (usbd_cdc_EP0_RxReady(pdev));
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/******************* (C) COPYRIGHT 2013 STMicroelectronics *****END OF FILE****/

--- a/lib/main/STM32_USB_OTG_Driver/inc/usb_defines.h
+++ b/lib/main/STM32_USB_OTG_Driver/inc/usb_defines.h
@@ -174,7 +174,9 @@
 #define HCCHAR_BULK                            2
 #define HCCHAR_INTR                            3
 
+#ifndef MIN
 #define  MIN(a, b)      (((a) < (b)) ? (a) : (b))
+#endif
 
 /**
   * @}

--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -93,12 +93,18 @@ USBMSC_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/msc
 USBMSC_SRC  = $(notdir $(wildcard $(USBMSC_DIR)/src/*.c))
 EXCLUDES    = usbd_storage_template.c
 USBMSC_SRC  := $(filter-out ${EXCLUDES}, $(USBMSC_SRC))
-VPATH       := $(VPATH):$(USBOTG_DIR)/src:$(USBCORE_DIR)/src:$(USBCDC_DIR)/src:$(USBMSC_DIR)/src
+USBHID_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/hid
+USBHID_SRC  = $(notdir $(wildcard $(USBHID_DIR)/src/*.c))
+USBWRAPPER_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/hid_cdc_wrapper
+USBWRAPPER_SRC  = $(notdir $(wildcard $(USBWRAPPER_DIR)/src/*.c))
+VPATH       := $(VPATH):$(USBOTG_DIR)/src:$(USBCORE_DIR)/src:$(USBCDC_DIR)/src:$(USBMSC_DIR)/src:$(USBHID_DIR)/src:$(USBWRAPPER_DIR)/src
 
 DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
                         $(USBOTG_SRC) \
                         $(USBCORE_SRC) \
                         $(USBCDC_SRC) \
+                        $(USBHID_SRC) \
+                        $(USBWRAPPER_SRC) \
                         $(USBMSC_SRC)
 endif
 
@@ -122,6 +128,8 @@ INCLUDE_DIRS    := $(INCLUDE_DIRS) \
                    $(USBOTG_DIR)/inc \
                    $(USBCORE_DIR)/inc \
                    $(USBCDC_DIR)/inc \
+                   $(USBHID_DIR)/inc \
+                   $(USBWRAPPER_DIR)/inc \
                    $(USBMSC_DIR)/inc \
                    $(USBFS_DIR)/inc \
                    $(CMSIS_DIR)/Core/Include \

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -30,6 +30,9 @@
 #if defined(STM32F4)
 #include "usb_core.h"
 #include "usbd_cdc_vcp.h"
+#ifdef USB_CDC_HID
+#include "usbd_hid_cdc_wrapper.h"
+#endif
 #include "usb_io.h"
 #elif defined(STM32F7)
 #include "vcp_hal/usbd_cdc_interface.h"
@@ -211,7 +214,11 @@ serialPort_t *usbVcpOpen(void)
 
     IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
     IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
+#ifdef USB_CDC_HID
+    USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_HID_CDC_cb, &USR_cb);
+#else
     USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_CDC_cb, &USR_cb);
+#endif
 #elif defined(STM32F7)
     usbGenerateDisconnectPulse();
 

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -38,13 +38,6 @@
 #include "drivers/stack_check.h"
 #include "drivers/transponder_ir.h"
 #include "drivers/vtx_common.h"
-#ifdef USB_CDC_HID
-//TODO: Make it platform independent in the future
-#include "vcpf4/usbd_cdc_vcp.h"
-#include "usbd_hid_core.h"
-//TODO: Nicer way to handle this...
-#undef MIN
-#endif
 
 #include "fc/config.h"
 #include "fc/fc_core.h"
@@ -91,6 +84,12 @@
 #include "scheduler/scheduler.h"
 
 #include "telemetry/telemetry.h"
+
+#ifdef USB_CDC_HID
+//TODO: Make it platform independent in the future
+#include "vcpf4/usbd_cdc_vcp.h"
+#include "usbd_hid_core.h"
+#endif
 
 #ifdef USE_BST
 void taskBstMasterProcess(timeUs_t currentTimeUs);

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -38,6 +38,13 @@
 #include "drivers/stack_check.h"
 #include "drivers/transponder_ir.h"
 #include "drivers/vtx_common.h"
+#ifdef USB_CDC_HID
+//TODO: Make it platform independent in the future
+#include "vcpf4/usbd_cdc_vcp.h"
+#include "usbd_hid_core.h"
+//TODO: Nicer way to handle this...
+#undef MIN
+#endif
 
 #include "fc/config.h"
 #include "fc/fc_core.h"
@@ -138,6 +145,16 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
     }
 
     isRXDataNew = true;
+
+#ifdef USB_CDC_HID
+    if (!ARMING_FLAG(ARMED)) {
+        int8_t report[8];
+        for (int i = 0; i < 8; i++) {
+	        	report[i] = scaleRange(constrain(rcData[i], 1000, 2000), 1000, 2000, -127, 127);
+        }
+        USBD_HID_SendReport(&USB_OTG_dev, (uint8_t*)report, sizeof(report));
+    }
+#endif
 
 #if !defined(USE_ALT_HOLD)
     // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -51,6 +51,7 @@
 #define USE_GYRO_DATA_ANALYSE
 #define USE_ADC
 #define USE_ADC_INTERNAL
+#define USB_CDC_HID
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)
 #define USE_OVERCLOCK

--- a/src/main/vcpf4/usb_conf.h
+++ b/src/main/vcpf4/usb_conf.h
@@ -161,12 +161,10 @@
 /****************** USB OTG FS CONFIGURATION **********************************/
 #ifdef USB_OTG_FS_CORE
  #define RX_FIFO_FS_SIZE                          128
- #define TX0_FIFO_FS_SIZE                          64
- #define TX1_FIFO_FS_SIZE                         128
+ #define TX0_FIFO_FS_SIZE                          32
+ #define TX1_FIFO_FS_SIZE                          64
  #define TX2_FIFO_FS_SIZE                          0
- #define TX3_FIFO_FS_SIZE                          0
- #define TXH_NP_FS_FIFOSIZ                         96
- #define TXH_P_FS_FIFOSIZ                          96
+ #define TX3_FIFO_FS_SIZE                          64
 
  //#define USB_OTG_FS_LOW_PWR_MGMT_SUPPORT
  //#define USB_OTG_FS_SOF_OUTPUT_ENABLED

--- a/src/main/vcpf4/usbd_conf.h
+++ b/src/main/vcpf4/usbd_conf.h
@@ -31,7 +31,7 @@
   */
 #define USBD_CFG_MAX_NUM                1
 #define USBD_ITF_MAX_NUM                1
-#define USB_MAX_STR_DESC_SIZ            50
+#define USB_MAX_STR_DESC_SIZ            255
 
 /** @defgroup USB_VCP_Class_Layer_Parameter
   * @{
@@ -39,6 +39,9 @@
 #define CDC_IN_EP                       0x81  /* EP1 for data IN */
 #define CDC_OUT_EP                      0x01  /* EP1 for data OUT */
 #define CDC_CMD_EP                      0x82  /* EP2 for CDC commands */
+
+#define HID_IN_EP                       0x83
+#define HID_IN_PACKET                   8
 
 /* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
 #ifdef USE_USB_OTG_HS


### PR DESCRIPTION
- It passes on though HID interface 8 channels received from TX
- Endpoints are reconfigured to support HID interface
- Potentially this can slow down SPI Flash transfer though CDC interface...
- This could be addressed by support for MSC when using SPI Flash (emulating FATFS)