### PR TITLE
[KAKUTEF4] Move ADC to DMA2_Stream0 to avoid conflict

### DIFF
--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -139,13 +139,8 @@
 #define USE_ADC
 #define ADC1_DMA_STREAM 			DMA2_Stream0
 #define VBAT_ADC_PIN                PC3
-#define VBAT_ADC_CHANNEL            ADC_Channel_13
-
 #define CURRENT_METER_ADC_PIN       PC2
-#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_12
-
 #define RSSI_ADC_PIN                PC1
-#define RSSI_ADC_CHANNEL            ADC_Channel_11
 
 #define DEFAULT_FEATURES        ( FEATURE_TELEMETRY | FEATURE_OSD )
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -137,6 +137,7 @@
 
 #define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
 #define USE_ADC
+#define ADC1_DMA_STREAM 			DMA2_Stream0
 #define VBAT_ADC_PIN                PC3
 #define VBAT_ADC_CHANNEL            ADC_Channel_13
 


### PR DESCRIPTION
Motor 6 output is declared to use DMA2_ST4, which is used by default by ADC so Dshot is not possible on that output.