### PR TITLE
Revert "Reinstate software serial (#5480)"

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -90,8 +90,9 @@
 #define USE_UART1
 #define USE_UART2
 #define USE_UART3
-#define USE_SOFTSERIAL1
-#define USE_SOFTSERIAL2
+// Disabled to make the target fit into flash
+//#define USE_SOFTSERIAL1
+//#define USE_SOFTSERIAL2
 
 #define SOFTSERIAL1_RX_PIN      PA6 // PWM 5
 #define SOFTSERIAL1_TX_PIN      PA7 // PWM 6
@@ -99,7 +100,7 @@
 #define SOFTSERIAL2_RX_PIN      PB0 // PWM 7
 #define SOFTSERIAL2_TX_PIN      PB1 // PWM 8
 
-#define SERIAL_PORT_COUNT       6
+#define SERIAL_PORT_COUNT       4
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PA15  // (HARDARE=0,PPM)


### PR DESCRIPTION
This reverts commit f7c10593bec6c9ff019b017fe3aaaa7b1caa97f6.

@jflyper: Turns out that the extra space has already been eaten up by other changes, like the improved filters, which seemingly went in after the branch for this was cut.