### PR TITLE
Allow the use of NULL values in CLI lookup tables.

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -489,10 +489,13 @@ static void cliPrintVarRange(const clivalue_t *var)
     case (MODE_LOOKUP): {
         const lookupTableEntry_t *tableEntry = &lookupTables[var->config.lookup.tableIndex];
         cliPrint("Allowed values:");
-        for (uint32_t i = 0; i < tableEntry->valueCount ; i++) {
-            if (i > 0)
-                cliPrint(",");
-            cliPrintf(" %s", tableEntry->values[i]);
+        for (uint32_t i = 0; i < tableEntry->valueCount; i++) {
+            if (tableEntry->values[i]) {
+                cliPrintf(" %s", tableEntry->values[i]);
+                if (i + 1 < tableEntry->valueCount) {
+                    cliPrint(",");
+                }
+            }
         }
         cliPrintLinefeed();
     }
@@ -2965,7 +2968,7 @@ STATIC_UNIT_TESTED void cliSet(char *cmdline)
                         const lookupTableEntry_t *tableEntry = &lookupTables[val->config.lookup.tableIndex];
                         bool matched = false;
                         for (uint32_t tableValueIndex = 0; tableValueIndex < tableEntry->valueCount && !matched; tableValueIndex++) {
-                            matched = strcasecmp(tableEntry->values[tableValueIndex], eqptr) == 0;
+                            matched = tableEntry->values[tableValueIndex] && strcasecmp(tableEntry->values[tableValueIndex], eqptr) == 0;
 
                             if (matched) {
                                 value = tableValueIndex;


### PR DESCRIPTION
This is intended to be used in cases where parameter enums have entries that are only available for certain targets. These entries should still be defined, in order to have consistent indexes for all values across all targets, which makes it possible for the configurator to handle these parameters without knowing if a given target supports all possible values.

In this case:
- define the enum to contain all possible values unconditionally;
- define the CLI lookup table like so:

```
#if defined(<feature>)
￼    "<lookup value name>",
#else
    NULL,
#endif
```￼

@fujin: For use here: https://github.com/betaflight/betaflight/pull/5391/files#diff-e714e5d584a26c4bdb31e37e574ef15dR259