### PR TITLE
Throttle boost

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -765,8 +765,8 @@ void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
     }
 
     motorMixRange = motorMixMax - motorMixMin;
-    if( targetPidLooptime && throttle_boost > 0.0f) {
-        float throttlehpf = throttle - pt1FilterApply( &throttlelpf, throttle );
+    if( throttle_boost > 0.0f) {
+        float throttlehpf = throttle - pt1FilterApply( &throttleLpf, throttle );
         throttle = constrainf( throttle + throttle_boost * throttlehpf, 0.0f, 1.0f );
     }
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -766,8 +766,8 @@ void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
 
     motorMixRange = motorMixMax - motorMixMin;
     if( throttleBoost > 0.0f) {
-        float throttlehpf = throttle - pt1FilterApply( &throttleLpf, throttle );
-        throttle = constrainf( throttle + throttleBoost * throttlehpf, 0.0f, 1.0f );
+        float throttlehpf = throttle - pt1FilterApply(&throttleLpf, throttle);
+        throttle = constrainf(throttle + throttleBoost * throttlehpf, 0.0f, 1.0f);
     }
 
     if (motorMixRange > 1.0f) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -765,6 +765,10 @@ void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
     }
 
     motorMixRange = motorMixMax - motorMixMin;
+    if( targetPidLooptime && throttle_boost > 0.0f) {
+        float throttlehpf = throttle - pt1FilterApply( &throttlelpf, throttle );
+        throttle = constrainf( throttle + throttle_boost * throttlehpf, 0.0f, 1.0f );
+    }
 
     if (motorMixRange > 1.0f) {
         for (int i = 0; i < motorCount; i++) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -765,9 +765,9 @@ void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
     }
 
     motorMixRange = motorMixMax - motorMixMin;
-    if( throttle_boost > 0.0f) {
+    if( throttleBoost > 0.0f) {
         float throttlehpf = throttle - pt1FilterApply( &throttleLpf, throttle );
-        throttle = constrainf( throttle + throttle_boost * throttlehpf, 0.0f, 1.0f );
+        throttle = constrainf( throttle + throttleBoost * throttlehpf, 0.0f, 1.0f );
     }
 
     if (motorMixRange > 1.0f) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -765,7 +765,7 @@ void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
     }
 
     motorMixRange = motorMixMax - motorMixMin;
-    if( throttleBoost > 0.0f) {
+    if (throttleBoost > 0.0f) {
         float throttlehpf = throttle - pt1FilterApply(&throttleLpf, throttle);
         throttle = constrainf(throttle + throttleBoost * throttlehpf, 0.0f, 1.0f);
     }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -269,7 +269,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         pt1FilterInit(&ptermYawLowpass, pt1FilterGain(pidProfile->yaw_lowpass_hz, dT));
     }
 
-    pt1FilterInit( &throttleLpf, pt1FilterGain( pidProfile->throttle_boost_cutoff, dT ));
+    pt1FilterInit(&throttleLpf, pt1FilterGain(pidProfile->throttle_boost_cutoff, dT));
 }
 
 static FAST_RAM float Kp[3], Ki[3], Kd[3];

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -323,7 +323,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     crashLimitYaw = pidProfile->crash_limit_yaw;
     itermLimit = pidProfile->itermLimit;
-    throttleBoost = pidProfile->throttle_boost * 0.1;
+    throttleBoost = pidProfile->throttle_boost * 0.1f;
 }
 
 void pidInit(const pidProfile_t *pidProfile)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -269,9 +269,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         pt1FilterInit(&ptermYawLowpass, pt1FilterGain(pidProfile->yaw_lowpass_hz, dT));
     }
 
-    float RC = 1.0f / ( 2.0f * M_PIf * pidProfile->throttle_boost_cutoff );
-    float k = targetPidLooptime * 0.000001f / (RC + targetPidLooptime * 0.000001f);
-    pt1FilterInit( &throttlelpf, k );
+    pt1FilterInit( &throttlelpf, pt1FilterGain( pidProfile->throttle_boost_cutoff, targetPidLooptime * 0.000001f ));
 }
 
 static FAST_RAM float Kp[3], Ki[3], Kd[3];

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -269,7 +269,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         pt1FilterInit(&ptermYawLowpass, pt1FilterGain(pidProfile->yaw_lowpass_hz, dT));
     }
 
-    pt1FilterInit( &throttlelpf, pt1FilterGain( pidProfile->throttle_boost_cutoff, targetPidLooptime * 0.000001f ));
+    pt1FilterInit( &throttleLpf, pt1FilterGain( pidProfile->throttle_boost_cutoff, dT ));
 }
 
 static FAST_RAM float Kp[3], Ki[3], Kd[3];
@@ -288,8 +288,8 @@ static FAST_RAM float crashGyroThreshold;
 static FAST_RAM float crashSetpointThreshold;
 static FAST_RAM float crashLimitYaw;
 static FAST_RAM float itermLimit;
-FAST_RAM float throttle_boost;
-pt1Filter_t throttlelpf;
+FAST_RAM float throttleBoost;
+pt1Filter_t throttleLpf;
 
 void pidInitConfig(const pidProfile_t *pidProfile)
 {
@@ -323,7 +323,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     crashLimitYaw = pidProfile->crash_limit_yaw;
     itermLimit = pidProfile->itermLimit;
-    throttle_boost = pidProfile->throttle_boost * 0.1;
+    throttleBoost = pidProfile->throttle_boost * 0.1;
 }
 
 void pidInit(const pidProfile_t *pidProfile)

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -145,5 +145,5 @@ void pidInit(const pidProfile_t *pidProfile);
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex);
 bool crashRecoveryModeActive(void);
 
-FAST_RAM float   throttle_boost;
-pt1Filter_t throttlelpf;
+FAST_RAM float   throttleBoost;
+pt1Filter_t throttleLpf;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -108,7 +108,7 @@ typedef struct pidProfile_s {
     uint16_t itermLimit;
     uint16_t dterm_lowpass2_hz;                // Extra PT1 Filter on D in hz
     uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
-    uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for longer. Specified in hz
+    uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
     
 } pidProfile_t;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include "common/time.h"
+#include "common/filter.h"
 #include "pg/pg.h"
 
 #define MAX_PID_PROCESS_DENOM       16
@@ -106,6 +107,9 @@ typedef struct pidProfile_s {
     uint16_t crash_limit_yaw;               // limits yaw errorRate, so crashes don't cause huge throttle increase
     uint16_t itermLimit;
     uint16_t dterm_lowpass2_hz;                // Extra PT1 Filter on D in hz
+    uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
+    uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for longer. Specified in hz
+    
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE
@@ -140,3 +144,6 @@ void pidInitConfig(const pidProfile_t *pidProfile);
 void pidInit(const pidProfile_t *pidProfile);
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex);
 bool crashRecoveryModeActive(void);
+
+FAST_RAM float   throttle_boost;
+pt1Filter_t throttlelpf;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -145,5 +145,5 @@ void pidInit(const pidProfile_t *pidProfile);
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex);
 bool crashRecoveryModeActive(void);
 
-FAST_RAM float   throttleBoost;
+FAST_RAM float throttleBoost;
 pt1Filter_t throttleLpf;

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -714,6 +714,9 @@ const clivalue_t valueTable[] = {
     { "pidsum_limit_yaw",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 100, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimitYaw) },
     { "yaw_lowpass_hz",             VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lowpass_hz) },
 
+    { "throttle_boost",             VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost) },
+    { "throttle_boost_cutoff",      VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 10, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost_cutoff) },
+    
     { "p_pitch",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_PITCH].P) },
     { "i_pitch",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_PITCH].I) },
     { "d_pitch",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_PITCH].D) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -715,7 +715,7 @@ const clivalue_t valueTable[] = {
     { "yaw_lowpass_hz",             VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lowpass_hz) },
 
     { "throttle_boost",             VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost) },
-    { "throttle_boost_cutoff",      VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 10, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost_cutoff) },
+    { "throttle_boost_cutoff",      VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 5, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost_cutoff) },
     
     { "p_pitch",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_PITCH].P) },
     { "i_pitch",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_PITCH].I) },


### PR DESCRIPTION
Motors take time to spin up and down. This delays thrust response to pid and throttle changes. Luckily the pids ramp up as error gets higher, increasing the torque to the motors and reducing response time. But throttle response is currently not fixable.

This feature allows throttle to be temporarily boosted to the up to down-side to increase acceleration torque to the motors, providing a much faster throttle response. It's implemented by adding a high pass filtered throttle signal, multiplied by the boost strength to throttle itself.

I've added the changes on top of the iterm rotation changes, assuming we will take these anyway. If preferred I can separate them out.

This feature is inspired by TorqueBoost and credit for a similar implementation goes to silverxxx at SilverWare.