### PR TITLE
Discontinuity fix

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -449,19 +449,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     // Dynamic d component, enable 2-DOF PID controller only for rate mode
     const float dynCd = flightModeFlags ? 0.0f : dtermSetpointWeight;
 
-    if (iterm_rotation) {
-        // rotate old I to the new coordinate system
-        const float gyroToAngle = dT * RAD;
-        for (int i = FD_ROLL; i <= FD_YAW; i++) {
-            int i_1 = ( i + 1 ) % 3;
-            int i_2 = ( i + 2 ) % 3;
-            float angle = gyro.gyroADCf[i] * gyroToAngle;
-            float newPID_I_i_1 = axisPID_I[i_1] + axisPID_I[i_2] * angle * Rki[i_1][i_2];
-            axisPID_I[i_2] -= axisPID_I[i_1] * angle * Rki[i_2][i_1];
-            axisPID_I[i_1] = newPID_I_i_1;
-        }
-    }
-
     // ----------PID controller----------
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
         float currentPidSetpoint = getSetpointRate(axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -534,7 +534,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             }
             // Divide rate change by deltaT to get differential (ie dr/dt)
             const float delta = (
-                dynCd * transition * ( currentPidSetpoint - previousPidSetpoint[axis] ) -
+                dynCd * transition * (currentPidSetpoint - previousPidSetpoint[axis]) -
                 (gyroRateFiltered - previousGyroRateFiltered[axis])) / deltaT;
             
             previousPidSetpoint[axis] = currentPidSetpoint;


### PR DESCRIPTION
Since @ctzsnooze just fixed allowing 0 for transition instead of 0.1 to avoid a discontinuity of the D term there I wanted to highlight the following issue: 

A related issue is that as the dterm is calculated two setpoint weights are used: the last measurement implicitly uses its dynC * transition and the new one uses the one freshly calculated from setpoint. That means that D not only contains the derivative of setpoint, but also the derivative of setpoint weight which is discontinuous at the transition point.

I think what's actually intended is the behavior after applying this PR which uses the current dynC * transition as weight for both the new and the old setpoint.