### PR TITLE
Simplified LMA a bit

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -420,11 +420,8 @@ FAST_CODE float lmaSmoothingUpdate(laggedMovingAverage_t *filter, float input)
     filter->buf[filter->movingWindowIndex] = input;
     filter->movingSum += input;
 
-    uint8_t windowIndex = filter->movingWindowIndex;
-    if (++windowIndex >= filter->windowSize) {
+    if (++filter->movingWindowIndex == filter->windowSize) {
         filter->movingWindowIndex = 0;
-    } else {
-        filter->movingWindowIndex = windowIndex;
     }
 
     return input + (((filter->movingSum  / filter->windowSize) - input) * filter->weight);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -69,8 +69,8 @@ typedef struct fastKalman_s {
 } fastKalman_t;
 
 typedef struct laggedMovingAverage_s {
-    uint8_t movingWindowIndex;
-    uint8_t windowSize;
+    uint16_t movingWindowIndex;
+    uint16_t windowSize;
     float weight;
     float movingSum;
     float buf[MAX_LMA_WINDOW_SIZE];


### PR DESCRIPTION
Following @apoc's observation about `laggedMovingAverage_t` float members being unaligned we've measured performance for different implementations and arrived with this one.

Taking BlueJay F4 with no overclock as a baseline, roughly 8K samples per axis, this gives following performance figures:
```
hertz$ python filter_performance.py 
Optimized LMA:	ROLL	PITCH	YAW
mean (us)	0.3674	0.3219	0.3205
std (us)	0.0372	0.0536	0.0431
total mean (us)	0.3366
total std (us)	0.0501

Original LMA:		ROLL	PITCH	YAW
mean (us)	0.3740	0.3253	0.3254
std (us)	0.0464	0.0401	0.0367
total mean (us)	0.3415
total std (us)	0.0472

Original LMA slowdown:	1.78%	1.04%	1.52%
Original LMA average slowdown:	1.46%
```

Not much, but worth having. It also simplifies code by getting rid of some loads, but these were optimized out by the compiler anyway for original code.