### PR TITLE
Get current time using gps

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -635,6 +635,8 @@ typedef struct gpsDataNmea_s {
     uint16_t altitude;
     uint16_t speed;
     uint16_t ground_course;
+    uint32_t time;
+    uint32_t date;
 } gpsDataNmea_t;
 
 static bool gpsNewFrameNMEA(char c)
@@ -703,11 +705,17 @@ static bool gpsNewFrameNMEA(char c)
                     break;
                 case FRAME_RMC:        //************* GPRMC FRAME parsing
                     switch (param) {
+                        case 1:
+                            gps_Msg.time = grab_fields(string, 2);
+                            break;
                         case 7:
                             gps_Msg.speed = ((grab_fields(string, 1) * 5144L) / 1000L);    // speed in cm/s added by Mis
                             break;
                         case 8:
                             gps_Msg.ground_course = (grab_fields(string, 1));      // ground course deg * 10
+                            break;
+                        case 9:
+                            gps_Msg.date = grab_fields(string, 0);
                             break;
                     }
                     break;
@@ -789,6 +797,19 @@ static bool gpsNewFrameNMEA(char c)
                         *gpsPacketLogChar = LOG_NMEA_RMC;
                         gpsSol.groundSpeed = gps_Msg.speed;
                         gpsSol.groundCourse = gps_Msg.ground_course;
+                        // This check will miss 00:00:00.00, but we shouldn't care - next report will be valid
+                        if(!rtcHasTime() && gps_Msg.date != 0 && gps_Msg.time != 0)
+                        {
+                            dateTime_t temp_time;
+                            temp_time.year = (gps_Msg.date % 100) + 2000;
+                            temp_time.month = (gps_Msg.date / 100) % 100;
+                            temp_time.day = (gps_Msg.date / 10000) % 100;
+                            temp_time.hours = (gps_Msg.time / 1000000) % 100;
+                            temp_time.minutes = (gps_Msg.time / 10000) % 100;
+                            temp_time.seconds = (gps_Msg.time / 100) % 100;
+                            temp_time.millis = (gps_Msg.time & 100) * 10;
+                            rtcSetDateTime(&temp_time);
+                        }
                         break;
                     } // end switch
                 } else {
@@ -1010,6 +1031,12 @@ static bool UBLOX_parse_gps(void)
             DISABLE_STATE(GPS_FIX);
         gpsSol.numSat = _buffer.solution.satellites;
         gpsSol.hdop = _buffer.solution.position_DOP;
+        //set clock, when gps time is available
+        if(!rtcHasTime() && _buffer.solution.week != 0 && _buffer.solution.time != 0) {
+            //calculate rtctime: week number * ms in a week + ms of week + fractions of second + offset to UNIX reference year - 18 leap seconds
+            rtcTime_t temp_time = (((int64_t) _buffer.solution.week)*7*24*60*60*1000) + _buffer.solution.time + (_buffer.solution.time_nsec/1000000) + 315964800000LL - 18000;
+            rtcSet(&temp_time);
+        }
         break;
     case MSG_VELNED:
         *gpsPacketLogChar = LOG_UBLOX_VELNED;


### PR DESCRIPTION
This uses gps to set the internal rtctime, when it is not set and gps time is available.
The nmea time decoding is very similar to inav. For ublox I used the gps time of week and week number, because otherwise additional message types (e.g. UBX-NAV-TIMEUTC ) would be required to get the time.

The nmea decoding is not tested, because I don't have a nmea gps module!
The ublox decoding works and generates the correct time as ms since unix start. The conversion to string for displaying the time with rtcTimeToDateTime is wrong by a day (The ms since unix start is converted to the correct time using other converters. I'll probably look into fixing that later).

This results in the correct time being used for blackbox log files and the osd overlay.