### PR TITLE
Fix OSD stats not clearing when entering OSD menu

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1265,17 +1265,23 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
         flyTime += deltaT;
         stats.armed_time += deltaT;
     } else if (osdStatsEnabled) {  // handle showing/hiding stats based on OSD disable switch position
-        if (IS_RC_MODE_ACTIVE(BOXOSD) && osdStatsVisible) {
-            osdStatsVisible = false;
-            displayClearScreen(osdDisplayPort);
-        } else if (!IS_RC_MODE_ACTIVE(BOXOSD)) {
-            if (!osdStatsVisible) {
-                osdStatsVisible = true;
-                osdStatsRefreshTimeUs = 0;
-            }
-            if (currentTimeUs >= osdStatsRefreshTimeUs) {
-                osdStatsRefreshTimeUs = currentTimeUs + REFRESH_1S;
-                osdShowStats(endBatteryVoltage);
+        if (displayIsGrabbed(osdDisplayPort)) {
+            osdStatsEnabled = false;
+            resumeRefreshAt = 0;
+            stats.armed_time = 0;
+        } else {
+            if (IS_RC_MODE_ACTIVE(BOXOSD) && osdStatsVisible) {
+                osdStatsVisible = false;
+                displayClearScreen(osdDisplayPort);
+            } else if (!IS_RC_MODE_ACTIVE(BOXOSD)) {
+                if (!osdStatsVisible) {
+                    osdStatsVisible = true;
+                    osdStatsRefreshTimeUs = 0;
+                }
+                if (currentTimeUs >= osdStatsRefreshTimeUs) {
+                    osdStatsRefreshTimeUs = currentTimeUs + REFRESH_1S;
+                    osdShowStats(endBatteryVoltage);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #5497 

The pitch stick high can be used to clear the OSD stats screen, but it's also part of the sequence to enter the OSD menu. Entering the OSD menu from the stats page should have cleared the stats, but because of a race condition they weren't always cleared and the OSD menu would draw on top of the stats.  Changed the logic to ensure that if the OSD menu is entered the stats page is exited and cleared.