### PR TITLE
Enable Composite USB HID for all F4, add PG for USB device.

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -77,6 +77,7 @@ COMMON_SRC = \
             pg/rx_pwm.c \
             pg/sdcard.c \
             pg/vcd.c \
+            pg/usb.c \
             scheduler/scheduler.c \
             sensors/adcinternal.c \
             sensors/battery.c \

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -30,8 +30,10 @@
 #if defined(STM32F4)
 #include "usb_core.h"
 #include "usbd_cdc_vcp.h"
-#ifdef USB_CDC_HID
+#ifdef USE_USB_CDC_HID
 #include "usbd_hid_cdc_wrapper.h"
+#include "pg/pg.h"
+#include "pg/usb.h"
 #endif
 #include "usb_io.h"
 #elif defined(STM32F7)
@@ -214,10 +216,14 @@ serialPort_t *usbVcpOpen(void)
 
     IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
     IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
-#ifdef USB_CDC_HID
-    USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_HID_CDC_cb, &USR_cb);
-#else
-    USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_CDC_cb, &USR_cb);
+#ifdef USE_USB_CDC_HID
+    if (usbDevice()->type == COMPOSITE) {
+        USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_HID_CDC_cb, &USR_cb);
+    } else {
+#endif
+        USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_CDC_cb, &USR_cb);
+#ifdef USE_USB_CDC_HID
+    }
 #endif
 #elif defined(STM32F7)
     usbGenerateDisconnectPulse();

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -85,7 +85,7 @@
 
 #include "telemetry/telemetry.h"
 
-#ifdef USB_CDC_HID
+#ifdef USE_USB_CDC_HID
 //TODO: Make it platform independent in the future
 #include "vcpf4/usbd_cdc_vcp.h"
 #include "usbd_hid_core.h"
@@ -145,7 +145,7 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
 
     isRXDataNew = true;
 
-#ifdef USB_CDC_HID
+#ifdef USE_USB_CDC_HID
     if (!ARMING_FLAG(ARMED)) {
         int8_t report[8];
         for (int i = 0; i < 8; i++) {

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -74,6 +74,7 @@
 #include "pg/rx_pwm.h"
 #include "pg/sdcard.h"
 #include "pg/vcd.h"
+#include "pg/usb.h"
 
 #include "rx/rx.h"
 #include "rx/cc2500_frsky_common.h"
@@ -320,7 +321,7 @@ static const char * const lookupOverclock[] = {
 #endif
 
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
-    
+
 const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOffOn),
     LOOKUP_TABLE_ENTRY(lookupTableUnit),
@@ -950,6 +951,11 @@ const clivalue_t valueTable[] = {
 #ifdef USE_PINIOBOX
     { "pinio_box", VAR_UINT8 | MASTER_VALUE | MODE_ARRAY, .config.array.length = PINIO_COUNT, PG_PINIOBOX_CONFIG, offsetof(pinioBoxConfig_t, permanentId) },
 #endif
+#endif
+
+//PG USB
+#ifdef USE_USB_CDC_HID
+    { "usb_hid_cdc", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_USB_CONFIG, offsetof(usbDev_t, type) },
 #endif
 };
 

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -121,7 +121,8 @@
 #define PG_TRICOPTER_CONFIG 528
 #define PG_PINIO_CONFIG 529
 #define PG_PINIOBOX_CONFIG 530
-#define PG_BETAFLIGHT_END 530
+#define PG_USB_CONFIG 531
+#define PG_BETAFLIGHT_END 531
 
 
 // OSD configuration (subject to change)

--- a/src/main/pg/usb.c
+++ b/src/main/pg/usb.c
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#include "pg/usb.h"
+#include "pg/pg_ids.h"
+
+//Initialize to default - non composite
+PG_REGISTER(usbDev_t, usbDevice, PG_USB_CONFIG, 0);

--- a/src/main/pg/usb.h
+++ b/src/main/pg/usb.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pg/pg.h"
+
+enum USB_DEV {
+    DEFAULT,
+    COMPOSITE
+};
+
+typedef struct usbDev_s {
+    uint8_t type;
+} usbDev_t;
+
+PG_DECLARE(usbDev_t, usbDevice);

--- a/src/main/target/WORMFC/target.h
+++ b/src/main/target/WORMFC/target.h
@@ -66,7 +66,6 @@
 #define INVERTER_PIN_UART3      PB12
 
 #define USE_VCP
-#define USB_CDC_HID
 #define VBUS_SENSING_PIN        PA9
 #define VBUS_SENSING_ENABLED
 

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -51,6 +51,7 @@
 #define USE_GYRO_DATA_ANALYSE
 #define USE_ADC
 #define USE_ADC_INTERNAL
+#define USE_USB_CDC_HID
 #define USE_USB_MSC
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)


### PR DESCRIPTION
Allows to set Composite_HID device instead of regular VCP only. It defaults to VCP only since there are issues on some Windows OSes.

usb_device = COMPOSITE_HID
Allowed values: DEFAULT, COMPOSITE_HID

Test on other targets and OSes. Unfortunately I have only my FC and access to OSX 10.13 and W10