### PR TITLE
Battery voltage throttle compensation

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -732,6 +732,13 @@ void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
 
     // Calculate voltage compensation
     const float vbatCompensationFactor = vbatPidCompensation ? calculateVbatPidCompensation() : 1.0f;
+    
+    // Apply battery voltage compensation to throttle
+    if(currentPidProfile->vbatThrottleCompensationEnabled) {     
+        float vbatThrottleCompensationFactor = 
+            constrainf( (float)currentPidProfile->vbatThrottleCompensationVoltage / getBatteryAverageCellVoltage(), 0.5f, 1.5f );
+        throttle = constrainf(throttle * vbatThrottleCompensationFactor, 0.0f, 1.0f);
+    }
 
     // Find roll/pitch/yaw desired output
     float motorMix[MAX_SUPPORTED_MOTORS];

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -134,7 +134,9 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .itermLimit = 150,
         .throttle_boost = 0,
         .throttle_boost_cutoff = 15,
-        .iterm_rotation = false                 
+        .iterm_rotation = false,
+        .vbatThrottleCompensationEnabled = 0,
+        .vbatThrottleCompensationVoltage = 35 // Target voltage in 0.1V steps
     );
 }
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -110,6 +110,8 @@ typedef struct pidProfile_s {
     uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
     uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
     uint8_t  iterm_rotation;                    // rotates iterm to translate world errors to local coordinate system
+    uint8_t vbatThrottleCompensationEnabled;   // Enable vbat throttle compensation
+    uint8_t vbatThrottleCompensationVoltage;    // Target voltage to center scaling of throttle (compensation = 1 at this voltage)
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -729,6 +729,9 @@ const clivalue_t valueTable[] = {
     { "i_yaw",                      VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].I) },
     { "d_yaw",                      VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].D) },
 
+    { "vbat_throttle_compensation_enabled", VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, vbatThrottleCompensationEnabled) },
+    { "vbat_throttle_compensation_voltage", VAR_UINT8 | PROFILE_VALUE, .config.minmax = { 20, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, vbatThrottleCompensationVoltage) },
+    
 #ifdef USE_ALT_HOLD
     { "p_alt",                      VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_ALT].P) },
     { "i_alt",                      VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_ALT].I) },

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -633,7 +633,7 @@ extern "C" {
     bool isFirstArmingGyroCalibrationRunning(void) { return false; }
     void pidController(const pidProfile_t *, const rollAndPitchTrims_t *, timeUs_t) {}
     void pidStabilisationState(pidStabilisationState_e) {}
-    void mixTable(timeUs_t , uint8_t) {};
+    void mixTable(timeUs_t, uint8_t) {};
     void writeMotors(void) {};
     void writeServos(void) {};
     bool calculateRxChannelsAndUpdateFailsafe(timeUs_t) { return true; }


### PR DESCRIPTION
Battery voltage throttle compensation.  Increases the throttle slightly in response to battery voltage decreases during flight.  Uses code similar to vbat pid compensation.  Intended for 1S micro quads.
