### PR TITLE
Fixed notch Q calculation to be dimensionless as it should

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -86,11 +86,8 @@ FAST_CODE float slewFilterApply(slewFilter_t *filter, float input)
 
 // get notch filter Q given center frequency (f0) and lower cutoff frequency (f1)
 // Q = f0 / (f2 - f1) ; f2 = f0^2 / f1
-float filterGetNotchQ(uint16_t centerFreq, uint16_t cutoff) {
-    const float f0sq = (float)centerFreq * centerFreq;
-    const float f1 = cutoff;
-
-    return (f1 * f0sq) / (f0sq - f1 * f1);
+float filterGetNotchQ(float centerFreq, float cutoffFreq) {
+    return centerFreq * cutoffFreq / (centerFreq - cutoffFreq) / (centerFreq + cutoffFreq);
 }
 
 /* sets up a biquad Filter */

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -87,7 +87,7 @@ FAST_CODE float slewFilterApply(slewFilter_t *filter, float input)
 // get notch filter Q given center frequency (f0) and lower cutoff frequency (f1)
 // Q = f0 / (f2 - f1) ; f2 = f0^2 / f1
 float filterGetNotchQ(float centerFreq, float cutoffFreq) {
-    return centerFreq * cutoffFreq / (centerFreq - cutoffFreq) / (centerFreq + cutoffFreq);
+    return centerFreq * cutoffFreq / (centerFreq * centerFreq - cutoffFreq * cutoffFreq);
 }
 
 /* sets up a biquad Filter */

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -116,7 +116,7 @@ int biquadFilterLpfCascadeInit(biquadFilter_t *sections, int order, float filter
 float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
 float biquadFilterApply(biquadFilter_t *filter, float input);
 float biquadCascadeFilterApply(biquadFilterCascade_t *filter, float input);
-float filterGetNotchQ(uint16_t centerFreq, uint16_t cutoff);
+float filterGetNotchQ(float centerFreq, float cutoffFreq);
 
 void biquadRCFIR2FilterInit(biquadFilter_t *filter, float k);
 
@@ -125,9 +125,6 @@ float fastKalmanUpdate(fastKalman_t *filter, float input);
 
 void lmaSmoothingInit(laggedMovingAverage_t *filter, uint8_t windowSize, float weight);
 float lmaSmoothingUpdate(laggedMovingAverage_t *filter, float input);
-
-// not exactly correct, but very very close and much much faster
-#define filterGetNotchQApprox(centerFreq, cutoff)   ((float)(cutoff * centerFreq) / ((float)(centerFreq - cutoff) * (float)(centerFreq + cutoff)))
 
 float pt1FilterGain(uint16_t f_cut, float dT);
 void pt1FilterInit(pt1Filter_t *filter, float k);

--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -281,7 +281,7 @@ void gyroDataAnalyseUpdate(biquadFilter_t *notchFilterDyn)
             // 7us
             // calculate new filter coefficients
             float cutoffFreq = constrain(fftResult[axis].centerFreq - DYN_NOTCH_WIDTH, DYN_NOTCH_MIN_CUTOFF, DYN_NOTCH_MAX_CUTOFF);
-            float notchQ = filterGetNotchQApprox(fftResult[axis].centerFreq, cutoffFreq);
+            float notchQ = filterGetNotchQ(fftResult[axis].centerFreq, cutoffFreq);
             biquadFilterUpdate(&notchFilterDyn[axis], fftResult[axis].centerFreq, gyro.targetLooptime, notchQ, FILTER_NOTCH);
             DEBUG_SET(DEBUG_FFT_TIME, 1, micros() - startTime);
 


### PR DESCRIPTION
Fixed #5526, spotted by @apoc (great job, mate!)

During #5287, `filterGetNotchQ` was rewritten in such a way that Q acquired a dimensionality of `1 /  [time]`, which is not correct.

The original formula was:
```
octaves = 2 * log2(center / cutoff)
Q = sqrt(2^octaves) / (2^octaves - 1)
```

Let's rewrite Q, simplifying it:
```
Q = sqrt(2^2log2(center / cutoff)) / (2^2log2(center / cutoff) - 1) // move 2* into logarithm and get rid of 2 to the power of logarithm
= sqrt((center / cutoff)^2) / ((center/cutoff)^2 - 1) // get rid of sqrt
= center/cutoff / (center^2 / cutoff^2 -1) // multiply denominator and numerator by cutoff^2
= center * cutoff^2 / cutoff / ( center^2 - cutoff^2)
= center * cutoff / (center^2 - cutoff^2)
```

What we currently have in the code is:
```
Q = center^2 * cutoff / (center^2 - cutoff^2)
```
