### PR TITLE
Made MSC initialisation pin configurable.

### DIFF
--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -71,4 +71,5 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "RANGEFINDER",
     "RX_SPI",
     "PINIO",
+    "USB_MSC_PIN",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -71,6 +71,7 @@ typedef enum {
     OWNER_RANGEFINDER,
     OWNER_RX_SPI,
     OWNER_PINIO,
+    OWNER_USB_MSC_PIN,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -217,7 +217,7 @@ serialPort_t *usbVcpOpen(void)
     IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
     IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
 #ifdef USE_USB_CDC_HID
-    if (usbDevice()->type == COMPOSITE) {
+    if (usbDevConfig()->type == COMPOSITE) {
         USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_HID_CDC_cb, &USR_cb);
     } else {
 #endif

--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -18,14 +18,7 @@
  *
  */
 
-#ifndef SRC_MAIN_DRIVERS_USB_MSC_H_
-#define SRC_MAIN_DRIVERS_USB_MSC_H_
-
-#include "platform.h"
-
-uint8_t startMsc(void);
-void mscButtonInit(void);
-void mscCheck(void);
-bool mscButton(void);
-
-#endif /* SRC_MAIN_DRIVERS_USB_MSC_H_ */
+void mscInit(void);
+uint8_t mscStart(void);
+bool mscCheckButton(void);
+void mscWaitForButton(void);

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -456,13 +456,13 @@ void init(void)
 #ifdef USE_USB_MSC
 /* MSC mode will start after init, but will not allow scheduler to run,
  *  so there is no bottleneck in reading and writing data */
-    mscButtonInit();
-    if (*((uint32_t *)0x2001FFF0) == 0xDDDD1010 || mscButton()) {
-    		if (startMsc() == 0) {
-    			mscCheck();
-    		} else {
-    			NVIC_SystemReset();
-    		}
+    mscInit();
+    if (*((uint32_t *)0x2001FFF0) == 0xDDDD1010 || mscCheckButton()) {
+        if (mscStart() == 0) {
+             mscWaitForButton();
+        } else {
+             NVIC_SystemReset();
+        }
     }
 #endif
 

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -123,6 +123,7 @@ extern uint8_t __config_end;
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/rx_pwm.h"
+#include "pg/usb.h"
 
 #include "rx/rx.h"
 #include "rx/spektrum.h"
@@ -3303,6 +3304,9 @@ const cliResourceValue_t resourceTable[] = {
 #endif
 #ifdef USE_PINIO
     { OWNER_PINIO,         PG_PINIO_CONFIG, offsetof(pinioConfig_t, ioTag), PINIO_COUNT },
+#endif
+#if defined(USE_USB_MSC)
+    { OWNER_USB_MSC_PIN,   PG_USB_CONFIG, offsetof(usbDev_t, mscButtonPin), 0 },
 #endif
 };
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -961,6 +961,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_USB_CDC_HID
     { "usb_hid_cdc", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_USB_CONFIG, offsetof(usbDev_t, type) },
 #endif
+#ifdef USE_USB_MSC
+    { "usb_msc_pin_pullup", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_USB_CONFIG, offsetof(usbDev_t, mscButtonUsePullup) },
+#endif
 };
 
 const uint16_t valueTableEntryCount = ARRAYLEN(valueTable);

--- a/src/main/pg/usb.c
+++ b/src/main/pg/usb.c
@@ -17,8 +17,28 @@
 
 #include "platform.h"
 
-#include "pg/usb.h"
+#if defined(USE_USB_ADVANCED_PROFILES)
+#include "drivers/io.h"
+
 #include "pg/pg_ids.h"
 
-//Initialize to default - non composite
-PG_REGISTER(usbDev_t, usbDevice, PG_USB_CONFIG, 0);
+#include "usb.h"
+
+#if !defined(USB_MSC_BUTTON_PIN)
+#define USB_MSC_BUTTON_PIN NONE
+#endif
+
+#if defined(USE_USB_MSC_BUTTON_IPU)
+#define MSC_BUTTON_IPU true
+#else
+#define MSC_BUTTON_IPU false
+#endif
+
+PG_REGISTER_WITH_RESET_TEMPLATE(usbDev_t, usbDevConfig, PG_USB_CONFIG, 0);
+
+PG_RESET_TEMPLATE(usbDev_t, usbDevConfig,
+    .type = DEFAULT,
+    .mscButtonPin = IO_TAG(USB_MSC_BUTTON_PIN),
+    .mscButtonUsePullup = MSC_BUTTON_IPU,
+);
+#endif

--- a/src/main/pg/usb.h
+++ b/src/main/pg/usb.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "drivers/io_types.h"
+
 #include "pg/pg.h"
 
 enum USB_DEV {
@@ -26,6 +28,8 @@ enum USB_DEV {
 
 typedef struct usbDev_s {
     uint8_t type;
+    ioTag_t mscButtonPin;
+    uint8_t mscButtonUsePullup;
 } usbDev_t;
 
-PG_DECLARE(usbDev_t, usbDevice);
+PG_DECLARE(usbDev_t, usbDevConfig);

--- a/src/main/target/STM32F4DISCOVERY/target.h
+++ b/src/main/target/STM32F4DISCOVERY/target.h
@@ -55,7 +55,7 @@
 // GYRO section -- end
 
 #define USE_VCP
-#define MSC_BUTTON              PA0
+#define USB_MSC_BUTTON_PIN      PA0
 #define VBUS_SENSING_PIN        PA9
 #define VBUS_SENSING_ENABLED
 

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -107,6 +107,10 @@
 #undef USE_USB_MSC
 #endif
 
+#if defined(USE_USB_CDC_HID) || defined(USE_USB_MSC)
+#define USE_USB_ADVANCED_PROFILES
+#endif
+
 // Determine if the target could have a 32KHz capable gyro
 #if defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20689)
 #define USE_32K_CAPABLE_GYRO

--- a/src/main/vcpf4/usbd_desc.c
+++ b/src/main/vcpf4/usbd_desc.c
@@ -223,7 +223,7 @@ uint8_t *  USBD_USR_DeviceDescriptor( uint8_t speed , uint16_t *length)
 {
     (void)speed;
 #ifdef USE_USB_CDC_HID
-    if (usbDevice()->type == COMPOSITE) {
+    if (usbDevConfig()->type == COMPOSITE) {
 	    *length = sizeof(USBD_DeviceDesc_Composite);
 	    return USBD_DeviceDesc_Composite;
     }


### PR DESCRIPTION
@conkerkh: I made the pin for triggering MSC mode configurable. I think will want to add a switch for this to an otherwise unused pin.

One thing that I noticed is that in `mscCheck()`, you comment 'In order to exit MSC mode simply disconnect the board', but then you still keep polling the button, and reset if it's pushed again. My hunch would be that at this point (assuming that the MSC device is mounted and needs to be flushed before it can be disconnected), it is probably not desirable for an accidental button push to trigger a reset. (Or else the comment should be amended.) What do you think?
 