### PR TITLE
Fix MSP_VOLTAGE_METERS and MSP_CURRENT_METERS

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -513,8 +513,8 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
     case MSP_VOLTAGE_METERS: {
         // write out id and voltage meter values, once for each meter we support
         uint8_t count = supportedVoltageMeterCount;
-#ifndef USE_OSD_SLAVE
-        count = supportedVoltageMeterCount - (VOLTAGE_METER_ID_ESC_COUNT - getMotorCount());
+#if !defined(USE_OSD_SLAVE) && defined(USE_ESC_SENSOR)
+        count -= VOLTAGE_METER_ID_ESC_COUNT - getMotorCount();
 #endif
 
         for (int i = 0; i < count; i++) {
@@ -532,8 +532,8 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
     case MSP_CURRENT_METERS: {
         // write out id and current meter values, once for each meter we support
         uint8_t count = supportedCurrentMeterCount;
-#ifndef USE_OSD_SLAVE
-        count = supportedCurrentMeterCount - (VOLTAGE_METER_ID_ESC_COUNT - getMotorCount());
+#if !defined(USE_OSD_SLAVE) && defined(USE_ESC_SENSOR)
+        count -= VOLTAGE_METER_ID_ESC_COUNT - getMotorCount();
 #endif
         for (int i = 0; i < count; i++) {
 


### PR DESCRIPTION
Only remove the unused voltage meters from ESC when USE_ESC_SENSOR is
defined.

Fixes https://github.com/betaflight/betaflight/issues/5546

I'm not too sure that this is the correct solution. If I'm not wrong, when the OSD SLAVE is defined, we must pass all the voltage sensors, when not, we must remove the ESC sensors that are not possible (only let one ESC sensor by motor).

EDIT: Fixes this too https://github.com/betaflight/betaflight/issues/3690