### PR TITLE
Fixed missing extern on throttleBoost

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -145,5 +145,5 @@ void pidInit(const pidProfile_t *pidProfile);
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex);
 bool crashRecoveryModeActive(void);
 
-FAST_RAM float throttleBoost;
-pt1Filter_t throttleLpf;
+extern float throttleBoost;
+extern pt1Filter_t throttleLpf;


### PR DESCRIPTION
How did this slip into master?