### PR TITLE
Simplify the precompiler condition for MSP_VOLTAGE_METERS

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -513,7 +513,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
     case MSP_VOLTAGE_METERS: {
         // write out id and voltage meter values, once for each meter we support
         uint8_t count = supportedVoltageMeterCount;
-#if !defined(USE_OSD_SLAVE) && defined(USE_ESC_SENSOR)
+#ifdef USE_ESC_SENSOR
         count -= VOLTAGE_METER_ID_ESC_COUNT - getMotorCount();
 #endif
 
@@ -532,7 +532,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
     case MSP_CURRENT_METERS: {
         // write out id and current meter values, once for each meter we support
         uint8_t count = supportedCurrentMeterCount;
-#if !defined(USE_OSD_SLAVE) && defined(USE_ESC_SENSOR)
+#ifdef USE_ESC_SENSOR
         count -= VOLTAGE_METER_ID_ESC_COUNT - getMotorCount();
 #endif
         for (int i = 0; i < count; i++) {


### PR DESCRIPTION
As comented in https://github.com/betaflight/betaflight/pull/5547, simplify the condition.

The USE_ESC_SENSOR is not defined for USE_OSD_SLAVE and if defined by error, is better to have the same behaviour than others FC (only return the correct number of sensors).