### PR TITLE
Spektrum SRXL improvements. Telemetry performance and current report fixed.

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -633,7 +633,7 @@ void init(void)
     }
 #endif
 
-#if defined(USE_CMS) && defined(USE_SPEKTRUM_CMS_TELEMETRY)
+#if defined(USE_CMS) && defined(USE_SPEKTRUM_CMS_TELEMETRY) && defined(USE_TELEMETRY_SRXL)
     // Register the srxl Textgen telemetry sensor as a displayport device
     cmsDisplayPortRegister(displayPortSrxlInit());
 #endif

--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 #include "platform.h"
-#if defined (USE_SPEKTRUM_CMS_TELEMETRY) && defined (USE_CMS)
+#if defined (USE_SPEKTRUM_CMS_TELEMETRY) && defined (USE_CMS) && defined(USE_TELEMETRY_SRXL)
 
 #include "common/utils.h"
 

--- a/src/main/telemetry/srxl.h
+++ b/src/main/telemetry/srxl.h
@@ -19,6 +19,7 @@
 
 #include "common/time.h"
 
+void srxlCollectTelemetryNow(void);
 void initSrxlTelemetry(void);
 bool checkSrxlTelemetryState(void);
 void handleSrxlTelemetry(timeUs_t currentTimeUs);


### PR DESCRIPTION
1. Collect TM data in sync with transmission instead of async 30Hz, performance +50%. Most noticeable when running CMS over TM. Still a bit slow, but now usable without too much frustration. No measurable CPU load increase.
2. B-channel Capacity and Current was visible even though not used, corrected. 
3. Incomplete telemetry compile conditions corrected.

I am so sorry, I am breaking the rule of only one issue per PR, but the last two are too small for their own PRs.
