### PR TITLE
Clear crash flip mode flag on disarming

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -180,6 +180,9 @@ void updateArmingStatus(void)
             unsetArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
         }
 
+        // Clear the crash flip active status
+        flipOverAfterCrashMode = false;
+
         // If switch is used for arming then check it is not defaulting to on when the RX link recovers from a fault
         if (!isUsingSticksForArming()) {
             static bool hadRx = false;


### PR DESCRIPTION
Fixes #5565 

Previously the flag was only set or cleared during arming so after crash flip mode was used the flag would stay active until the next arming. This caused the "CRASH FLIP" warning message to erroneously display on the OSD when disarmed.

This problem was exposed by #5253 which changed the OSD logic to display the actual state of crash flip mode flag rather than simply track the switch.