### PR TITLE
3dmixergain

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -64,7 +64,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
 PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .mixerMode = TARGET_DEFAULT_MIXER,
     .yaw_motors_reversed = false,
-    .3d_mixergain_halving = true,
+    .ddd_mixergain_halving = true,
 );
 
 PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 1);
@@ -450,7 +450,7 @@ void mixerConfigureOutput(void)
     }
 
     // in 3D mode, mixer gain has to be halved - 20180329-teracis: added cli switch for testing
-    if (feature(FEATURE_3D) && (mixerConfig()->3d_mixergain_halving)) {
+    if (feature(FEATURE_3D) && (mixerConfig()->ddd_mixergain_halving)) {
         if (motorCount > 1) {
             for (int i = 0; i < motorCount; i++) {
                 currentMixer[i].pitch *= 0.5f;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -64,6 +64,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
 PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .mixerMode = TARGET_DEFAULT_MIXER,
     .yaw_motors_reversed = false,
+    .3d_mixergain_halving = true,
 );
 
 PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 1);
@@ -448,8 +449,8 @@ void mixerConfigureOutput(void)
         }
     }
 
-    // in 3D mode, mixer gain has to be halved
-    if (feature(FEATURE_3D)) {
+    // in 3D mode, mixer gain has to be halved - 20180329-teracis: added cli switch for testing
+    if (feature(FEATURE_3D) && (mixerConfig()->3d_mixergain_halving)) {
         if (motorCount > 1) {
             for (int i = 0; i < motorCount; i++) {
                 currentMixer[i].pitch *= 0.5f;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -64,7 +64,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
 PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .mixerMode = TARGET_DEFAULT_MIXER,
     .yaw_motors_reversed = false,
-    .ddd_mixergain_halving = true,
+    .mix3d_gain_fix = false,
 );
 
 PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 1);
@@ -450,7 +450,7 @@ void mixerConfigureOutput(void)
     }
 
     // in 3D mode, mixer gain has to be halved - 20180329-teracis: added cli switch for testing
-    if (feature(FEATURE_3D) && (mixerConfig()->ddd_mixergain_halving)) {
+    if (feature(FEATURE_3D) && !(mixerConfig()->mix3d_gain_fix)) {
         if (motorCount > 1) {
             for (int i = 0; i < motorCount; i++) {
                 currentMixer[i].pitch *= 0.5f;

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -87,6 +87,7 @@ typedef struct mixer_s {
 typedef struct mixerConfig_s {
     uint8_t mixerMode;
     bool yaw_motors_reversed;
+    bool 3d_mixergain_halving;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -87,7 +87,7 @@ typedef struct mixer_s {
 typedef struct mixerConfig_s {
     uint8_t mixerMode;
     bool yaw_motors_reversed;
-    bool ddd_mixergain_halving;
+    bool mix3d_gain_fix;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -87,7 +87,7 @@ typedef struct mixer_s {
 typedef struct mixerConfig_s {
     uint8_t mixerMode;
     bool yaw_motors_reversed;
-    bool 3d_mixergain_halving;
+    bool ddd_mixergain_halving;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -594,6 +594,7 @@ const clivalue_t valueTable[] = {
 
 // PG_MIXER_CONFIG
     { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
+    { "3d_mixergain_halving",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, 3d_mixergain_halving) },
 
 // PG_MOTOR_3D_CONFIG
     { "3d_deadband_low",            VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_RANGE_MIDDLE }, PG_MOTOR_3D_CONFIG, offsetof(flight3DConfig_t, deadband3d_low) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -594,7 +594,7 @@ const clivalue_t valueTable[] = {
 
 // PG_MIXER_CONFIG
     { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
-    { "ddd_mixergain_halving",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, ddd_mixergain_halving) },
+    { "3d_mixer_gain_fix",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, mix3d_gain_fix) },
 
 // PG_MOTOR_3D_CONFIG
     { "3d_deadband_low",            VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_RANGE_MIDDLE }, PG_MOTOR_3D_CONFIG, offsetof(flight3DConfig_t, deadband3d_low) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -594,7 +594,7 @@ const clivalue_t valueTable[] = {
 
 // PG_MIXER_CONFIG
     { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
-    { "3d_mixergain_halving",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, 3d_mixergain_halving) },
+    { "ddd_mixergain_halving",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, ddd_mixergain_halving) },
 
 // PG_MOTOR_3D_CONFIG
     { "3d_deadband_low",            VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_RANGE_MIDDLE }, PG_MOTOR_3D_CONFIG, offsetof(flight3DConfig_t, deadband3d_low) },


### PR DESCRIPTION
Potential fix for 3D flight behavior.
If a machine is configured and flying well in 2D, enabling standard 3D mode causes a reduction in performance and flight handling.
This fix is an attempt at resolving the above issue, whereby the mixer gain halving block in mixer.c may have been left in after a code rework which potentially already handles the 3D scaling requirements elsewhere. Investigation is required and underway to confirm.
"3d_mixer_gain_fix" cli variable was added in order to provide a way to test the effect of removing the mixer gain halving without having to re-flash the FC.
The cli variable version was added after first confirming that the removal of the 3D mixer gain halving was beneficial and didn't appear to break anything else.

EDIT: Parameter name