### PR TITLE
Removed mixer gain halving in 3D mode.

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -447,18 +447,6 @@ void mixerConfigureOutput(void)
                 currentMixer[i] = mixers[currentMixerMode].motor[i];
         }
     }
-
-    // in 3D mode, mixer gain has to be halved
-    if (feature(FEATURE_3D)) {
-        if (motorCount > 1) {
-            for (int i = 0; i < motorCount; i++) {
-                currentMixer[i].pitch *= 0.5f;
-                currentMixer[i].roll *= 0.5f;
-                currentMixer[i].yaw *= 0.5f;
-            }
-        }
-    }
-
     mixerResetDisarmedMotors();
 }
 


### PR DESCRIPTION
This fix removes the code block in mixer.c which halves the mixer gain when 3D mode is enabled. This was left in by accident after mixer rework in PR #4161 and the fix tested in PR #5571 which this PR supersedes.