### PR TITLE
Add PID adjustment from AUX transmitter channel

### DIFF
--- a/docs/TxPID.md
+++ b/docs/TxPID.md
@@ -1,0 +1,46 @@
+# Tx PID
+
+This allows control of the PID settings for Roll, Pitch and Yaw to be adjusted using an aux channel on the transmitter. 
+
+## Configuration via CLI
+
+Tx PID configuration is performed by setting the following variables.
+
+These are each arrays of eight values, interpreted thus:
+
+| Array Item | Function |
+| ---------- | -------- |
+| 1 | Roll P Value |
+| 2 | Roll I Value |
+| 3 | Roll D Value |
+| 4 | Pitch P Value |
+| 5 | Pitch I Value |
+| 6 | Pitch D Value |
+| 7 | Yaw P Value |
+| 8 | Yaw I Value |
+
+
+| Variable | Function |
+| -------- | --------- |
+| txpid_channel  | Sets the Aux channel number, or zero to disable |
+| txpid_center | Sets the P, I or D value to set when aux channel is at mid-point |
+| txpid_adjust | Setes the amount to increase/decrease the P, I or D value when the aux channel is at max/min point respectively |
+
+### Example Setting
+
+The following example will allow the Pitch P value to be adjusted from Aux channel 1, with a center value of 50, adjustable between 40 and 60 by adjusting the Aux 1 channel setting.
+
+```
+set txpid_channel=0,0.0,1,0,0,0,0
+set txpid_center=0,0,0,50,0,0,0,0
+set txpid_adjust=0,0,0,10,0,0,0,0
+```
+
+The following example adjusts all value of Roll P, I and D at the same time using Aux channel 2 with center settings of 40, 40 and 40 respectively, all values of Pitch P, I and D at the same time using Aux channel 3 with center settings of 58,50 and 35 respectively, and both value of Yaw P and I at the same time using Aud channel 4 with center settings of 70 and 45. In this example the adjustment range is set to ± half the center value.
+
+```
+set txpid_channel=2,2,2,3,3,3,4,4
+set txpid_center=40,40,40,58,50,35,70,45
+set txpid_adjust=20,20,15,29,25,17,35,22
+```
+

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -72,6 +72,7 @@ typedef enum {
     OWNER_RX_SPI,
     OWNER_PINIO,
     OWNER_USB_MSC_PIN,
+    OWNER_TXPID,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -48,6 +48,8 @@
 
 #include "io/gps.h"
 
+#include "rx/rx.h"
+
 #include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 
@@ -86,22 +88,10 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, MAX_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 2);
 
-// Tx control of PID using aux channels
-enum {
-    TERM_P = 0,
-    TERM_I,
-    TERM_D,
-    TERM_COUNT
-} TermPID_e;
-
-struct {
-    int auxChannel[TERM_COUNT];
-    int16_t centerVal[TERM_COUNT];
-    int16_t adjustVal[TERM_COUNT];
-} TxPID[PID_ITEM_COUNT];
+PG_REGISTER(txPID_t, txPID, PG_TXPID_CONFIG, 0);
 
 // Scale txPID value around mid-point assuming RC input range of 1000-2000
-#define TX_PID_VAL(PID, TERM) TxPID[PID].centerVal[TERM] + ((rcData[TxPID[PID].auxChannel[TERM]] - stickCenter) * (TxPID[PID].adjustVal[TERM]) / 500.0)
+#define TX_PID_VAL(PID, TERM) txPID()->centerVal[PID][TERM] + ((rcData[NON_AUX_CHANNEL_COUNT + txPID()->auxChannel[PID][TERM] - 1] - stickCenter) * (txPID()->adjustVal[PID][TERM]) / 500.0)
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -348,39 +338,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     itermRotation = pidProfile->iterm_rotation == 1;
 }
 
-void pidInitTxPID()
-{
-    // Aux channel 2
-    TxPID[FD_ROLL].auxChannel[TERM_P] = 5;
-    TxPID[FD_ROLL].centerVal[TERM_P] = 40;
-    TxPID[FD_ROLL].adjustVal[TERM_P] = 20;
-    TxPID[FD_ROLL].auxChannel[TERM_I] = 5;
-    TxPID[FD_ROLL].centerVal[TERM_I] = 40;
-    TxPID[FD_ROLL].adjustVal[TERM_I] = 20;
-    TxPID[FD_ROLL].auxChannel[TERM_D] = 5;
-    TxPID[FD_ROLL].centerVal[TERM_D] = 30;
-    TxPID[FD_ROLL].adjustVal[TERM_D] = 15;
-
-    // Aux channel 3
-    TxPID[FD_PITCH].auxChannel[TERM_P] = 6;
-    TxPID[FD_PITCH].centerVal[TERM_P] = 58;
-    TxPID[FD_PITCH].adjustVal[TERM_P] = 29;
-    TxPID[FD_PITCH].auxChannel[TERM_I] = 6;
-    TxPID[FD_PITCH].centerVal[TERM_I] = 50;
-    TxPID[FD_PITCH].adjustVal[TERM_I] = 25;
-    TxPID[FD_PITCH].auxChannel[TERM_D] = 6;
-    TxPID[FD_PITCH].centerVal[TERM_D] = 35;
-    TxPID[FD_PITCH].adjustVal[TERM_D] = 17;
-
-    // Aux channel 4
-    TxPID[FD_YAW].auxChannel[TERM_P] = 7;
-    TxPID[FD_YAW].centerVal[TERM_P] = 70;
-    TxPID[FD_YAW].adjustVal[TERM_P] = 35;
-    TxPID[FD_YAW].auxChannel[TERM_I] = 7;
-    TxPID[FD_YAW].centerVal[TERM_I] = 45;
-    TxPID[FD_YAW].adjustVal[TERM_I] = 22;
-}
-
+#ifdef USE_TXPID
 void pidUpdateRates(pidProfile_t *pidProfile, int16_t *rcData)
 {
     int16_t stickCenter = flight3DConfig()->neutral3d;
@@ -389,27 +347,31 @@ void pidUpdateRates(pidProfile_t *pidProfile, int16_t *rcData)
     // pid values are of type uint8_t, so scale accordingly
 
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
-        if (TxPID[axis].auxChannel[TERM_P]) {
+        if ((txPID()->auxChannel[axis][TERM_P]) &&
+            (txPID()->auxChannel[axis][TERM_P] < RX_MAPPABLE_CHANNEL_COUNT)) {
             pidProfile->pid[axis].P = TX_PID_VAL(axis, TERM_P);
             Kp[axis] = PTERM_SCALE * pidProfile->pid[axis].P;
         }
-        if (TxPID[axis].auxChannel[TERM_I]) {
+        if ((txPID()->auxChannel[axis][TERM_I]) &&
+            (txPID()->auxChannel[axis][TERM_I] < RX_MAPPABLE_CHANNEL_COUNT)) {
             pidProfile->pid[axis].I = TX_PID_VAL(axis, TERM_I);
             Ki[axis] = ITERM_SCALE * pidProfile->pid[axis].I;
         }
-        if ((axis != FD_YAW) && (TxPID[axis].auxChannel[TERM_D])) {
+        if ((axis != FD_YAW) &&
+            (txPID()->auxChannel[axis][TERM_D]) &&
+            (txPID()->auxChannel[axis][TERM_D] < RX_MAPPABLE_CHANNEL_COUNT)) {
             pidProfile->pid[axis].D = TX_PID_VAL(axis, TERM_D);
             Kd[axis] = DTERM_SCALE * pidProfile->pid[axis].D;
         }
     }
 }
+#endif /* USE_TXPID */
 
 void pidInit(const pidProfile_t *pidProfile)
 {
     pidSetTargetLooptime(gyro.targetLooptime * pidConfig()->pid_process_denom); // Initialize pid looptime
     pidInitFilters(pidProfile);
     pidInitConfig(pidProfile);
-    pidInitTxPID();
 }
 
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -125,6 +125,24 @@ typedef struct pidConfig_s {
 
 PG_DECLARE(pidConfig_t, pidConfig);
 
+#ifdef USE_TXPID
+// Tx control of PID using aux channels
+enum {
+    TERM_P = 0,
+    TERM_I,
+    TERM_D,
+    TERM_COUNT
+} TermPID_e;
+
+typedef struct txPID_s {
+    uint8_t auxChannel[3][TERM_COUNT];
+    uint16_t centerVal[3][TERM_COUNT];
+    uint8_t adjustVal[3][TERM_COUNT];
+} txPID_t;
+
+PG_DECLARE(txPID_t, txPID);
+#endif /* USE_TXPID */
+
 union rollAndPitchTrims_u;
 void pidController(const pidProfile_t *pidProfile, const union rollAndPitchTrims_u *angleTrim, timeUs_t currentTimeUs);
 
@@ -144,6 +162,7 @@ void pidInitConfig(const pidProfile_t *pidProfile);
 void pidInit(const pidProfile_t *pidProfile);
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex);
 bool crashRecoveryModeActive(void);
+void pidUpdateRates(pidProfile_t *pidProfile, int16_t *rcData);
 
 extern float throttleBoost;
 extern pt1Filter_t throttleLpf;

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3005,7 +3005,7 @@ STATIC_UNIT_TESTED void cliSet(char *cmdline)
                             char *valEndPtr = strchr(valPtr, ',');
 
                             // comma found or last item?
-                            if ((valEndPtr != NULL) || (i == arrayLength - 1)){
+                            if ((valPtr != NULL) || (i == arrayLength - 1)){
                                 // process substring [valPtr, valEndPtr[
                                 // note: no need to copy substrings for atoi()
                                 //       it stops at the first character that cannot be converted...
@@ -3307,6 +3307,9 @@ const cliResourceValue_t resourceTable[] = {
 #endif
 #if defined(USE_USB_MSC)
     { OWNER_USB_MSC_PIN,   PG_USB_CONFIG, offsetof(usbDev_t, mscButtonPin), 0 },
+#endif
+#ifdef USE_TXPID
+    { OWNER_TXPID,         PG_TXPID_CONFIG, offsetof(txPID_t, auxChannel), 0 },
 #endif
 };
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -965,6 +965,11 @@ const clivalue_t valueTable[] = {
 #ifdef USE_USB_MSC
     { "usb_msc_pin_pullup", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_USB_CONFIG, offsetof(usbDev_t, mscButtonUsePullup) },
 #endif
+#ifdef USE_TXPID
+    { "txpid_channel", VAR_UINT8 | MASTER_VALUE | MODE_ARRAY, .config.array.length = 8, PG_TXPID_CONFIG, offsetof(txPID_t, auxChannel) },
+    { "txpid_center", VAR_UINT16 | MASTER_VALUE | MODE_ARRAY, .config.array.length = 8, PG_TXPID_CONFIG, offsetof(txPID_t, centerVal) },
+    { "txpid_adjust", VAR_UINT8 | MASTER_VALUE | MODE_ARRAY, .config.array.length = 8, PG_TXPID_CONFIG, offsetof(txPID_t, adjustVal) },
+#endif
 };
 
 const uint16_t valueTableEntryCount = ARRAYLEN(valueTable);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -122,7 +122,8 @@
 #define PG_PINIO_CONFIG 529
 #define PG_PINIOBOX_CONFIG 530
 #define PG_USB_CONFIG 531
-#define PG_BETAFLIGHT_END 531
+#define PG_TXPID_CONFIG 532
+#define PG_BETAFLIGHT_END 532
 
 
 // OSD configuration (subject to change)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -42,6 +42,7 @@
 #include "fc/rc_modes.h"
 
 #include "flight/failsafe.h"
+#include "flight/pid.h"
 
 #include "io/serial.h"
 
@@ -608,7 +609,9 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
 
     readRxChannelsApplyRanges();
     detectAndApplySignalLossBehaviour();
+#ifdef USE_TXPID
     pidUpdateRates(currentPidProfile, rcData);
+#endif /* USE_TXPID */
 
     rcSampleIndex++;
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -608,6 +608,7 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
 
     readRxChannelsApplyRanges();
     detectAndApplySignalLossBehaviour();
+    pidUpdateRates(currentPidProfile, rcData);
 
     rcSampleIndex++;
 

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -281,6 +281,7 @@
 #endif
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define USE_TXPID
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff


### PR DESCRIPTION
This feature addition allows for the P, I and D of the Roll, Pitch and Yaw axis to be controlled individually or grouped together.

## Configuration via CLI

Tx PID configuration is performed by setting the following variables.

These are each arrays of eight values, interpreted thus:

| Array Item | Function |
| ---------- | -------- |
| 1 | Roll P Value |
| 2 | Roll I Value |
| 3 | Roll D Value |
| 4 | Pitch P Value |
| 5 | Pitch I Value |
| 6 | Pitch D Value |
| 7 | Yaw P Value |
| 8 | Yaw I Value |


| Variable | Function |
| -------- | --------- |
| txpid_channel  | Sets the Aux channel number, or zero to disable |
| txpid_center | Sets the P, I or D value to set when aux channel is at mid-point |
| txpid_adjust | Setes the amount to increase/decrease the P, I or D value when the aux channel is at max/min point respectively |

### Example Setting

The following example will allow the Pitch P value to be adjusted from Aux channel 1, with a center value of 50, adjustable between 40 and 60 by adjusting the Aux 1 channel setting.

```
set txpid_channel=0,0.0,1,0,0,0,0
set txpid_center=0,0,0,50,0,0,0,0
set txpid_adjust=0,0,0,10,0,0,0,0
```

The following example adjusts all value of Roll P, I and D at the same time using Aux channel 2 with center settings of 40, 40 and 40 respectively, all values of Pitch P, I and D at the same time using Aux channel 3 with center settings of 58,50 and 35 respectively, and both value of Yaw P and I at the same time using Aud channel 4 with center settings of 70 and 45. In this example the adjustment range is set to ± half the center value.

```
set txpid_channel=2,2,2,3,3,3,4,4
set txpid_center=40,40,40,58,50,35,70,45
set txpid_adjust=20,20,15,29,25,17,35,22
```
