### PR TITLE
Fix PWM rx 100% CPU load

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -392,6 +392,8 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
     UNUSED(currentDeltaTime);
 
     bool signalReceived = false;
+    bool useDataDrivenProcessing = true;
+
 #if defined(USE_PWM) || defined(USE_PPM)
     if (feature(FEATURE_RX_PPM)) {
         if (isPPMDataBeingReceived()) {
@@ -405,6 +407,7 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
             signalReceived = true;
             rxIsInFailsafeMode = false;
             needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;
+            useDataDrivenProcessing = false;
         }
     } else
 #endif
@@ -438,7 +441,7 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
         rxSignalReceived = false;
     }
 
-    if (signalReceived || cmpTimeUs(currentTimeUs, rxNextUpdateAtUs) > 0) {
+    if ((signalReceived && useDataDrivenProcessing) || cmpTimeUs(currentTimeUs, rxNextUpdateAtUs) > 0) {
         rxDataProcessingRequired = true;
     }
 


### PR DESCRIPTION
Fixes #5564 

Previous logic changes were causing the RX task to run every loop for PWM rx leading to 100% CPU load. Reverted PWM processing to be based on a time interval rather than whether new data is available. With PWM we can't differentiate when new data is available as it's a continuous stream.