### PR TITLE
Turtle/Flip after crash: Add options to use all the motors

### DIFF
--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -87,6 +87,7 @@ typedef struct mixer_s {
 typedef struct mixerConfig_s {
     uint8_t mixerMode;
     bool yaw_motors_reversed;
+    uint8_t crashflip_motor_percent;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -600,6 +600,7 @@ const clivalue_t valueTable[] = {
 
 // PG_MIXER_CONFIG
     { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
+    { "crashflip_motor_percent",    VAR_UINT8 |  MASTER_VALUE,  .config.minmax = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_motor_percent) },
 
 // PG_MOTOR_3D_CONFIG
     { "3d_deadband_low",            VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_RANGE_MIDDLE }, PG_MOTOR_3D_CONFIG, offsetof(flight3DConfig_t, deadband3d_low) },


### PR DESCRIPTION
Added crashflip_motor_percent. This will use the other motors while doing a turtle. This is typically only useful on lower power ducted quads.  Setting to 0 will use just 2 motors which is the default. 50-70% seemed to work for getting a brushless tinywhoop flipped over easier.

Quick test here:  Helps a lot!
http://www.youtube.com/watch?v=Qwh1MBNnZj4

[Tinywhoop.com](http://www.tinywhoop.com) helped me with some motors and frames to test!