### PR TITLE
Simplify compilation of F4 SDIO enabled targets.

### DIFF
--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -205,5 +205,12 @@ MSC_SRC += \
             msc/usbd_storage_sd_spi.c
 endif
 
+ifneq ($(filter SDIO,$(FEATURES)),)
+MSC_SRC += \
+            msc/usbd_storage_sdio.c
+MCU_COMMON_SRC += \
+            drivers/sdio_f4xx.c
+endif
+
 DSP_LIB := $(ROOT)/lib/main/CMSIS/DSP
 DEVICE_FLAGS += -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1 -DUNALIGNED_SUPPORT_DISABLE -DARM_MATH_CM4

--- a/make/source.mk
+++ b/make/source.mk
@@ -390,6 +390,15 @@ SRC += \
             $(MSC_SRC)
 endif
 
+ifneq ($(filter SDIO,$(FEATURES)),)
+SRC += \
+            drivers/sdcard_sdio_baremetal.c \
+            drivers/sdcard_standard.c \
+            io/asyncfatfs/asyncfatfs.c \
+            io/asyncfatfs/fat_standard.c \
+            $(MSC_SRC)
+endif
+
 ifneq ($(filter VCP,$(FEATURES)),)
 SRC += $(VCP_SRC)
 endif

--- a/src/main/target/WORMFC/target.mk
+++ b/src/main/target/WORMFC/target.mk
@@ -1,5 +1,5 @@
 F405_TARGETS    += $(TARGET)
-FEATURES        += VCP MSC
+FEATURES        += VCP SDIO
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
@@ -8,12 +8,3 @@ TARGET_SRC = \
             drivers/barometer/barometer_lps.c \
             drivers/max7456.c \
             io/osd.c
-            
-            
-TARGET_SRC += \
-            drivers/sdio_f4xx.c \
-            drivers/sdcard_sdio_baremetal.c \
-            drivers/sdcard_standard.c \
-            io/asyncfatfs/asyncfatfs.c \
-            io/asyncfatfs/fat_standard.c \
-            msc/usbd_storage_sdio.c


### PR DESCRIPTION
Can be added as a feature in target makefile.