### PR TITLE
Throttle limit feature

### DIFF
--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -52,7 +52,9 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rcExpo[FD_YAW] = 0,
             .rates[FD_ROLL] = 70,
             .rates[FD_PITCH] = 70,
-            .rates[FD_YAW] = 70
+            .rates[FD_YAW] = 70,
+            .throttle_limit_type = THROTTLE_LIMIT_TYPE_OFF,
+            .throttle_limit_percent = 100
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -28,6 +28,12 @@ typedef enum {
     RATES_TYPE_RACEFLIGHT,
 } ratesType_e;
 
+typedef enum {
+    THROTTLE_LIMIT_TYPE_OFF = 0,
+    THROTTLE_LIMIT_TYPE_SCALE,
+    THROTTLE_LIMIT_TYPE_CLIP,
+} throttleLimitType_e;
+
 typedef struct controlRateConfig_s {
     uint8_t thrMid8;
     uint8_t thrExpo8;
@@ -37,6 +43,8 @@ typedef struct controlRateConfig_s {
     uint8_t rates[3];
     uint8_t dynThrPID;
     uint16_t tpa_breakpoint;                // Breakpoint where TPA is activated
+    uint8_t throttle_limit_type;            // Sets the throttle limiting type - off, scale or clip
+    uint8_t throttle_limit_percent;         // Sets the maximum pilot commanded throttle limit
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -134,7 +134,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .itermLimit = 150,
         .throttle_boost = 0,
         .throttle_boost_cutoff = 15,
-        .iterm_rotation = false                 
+        .iterm_rotation = false,
     );
 }
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -320,6 +320,10 @@ static const char * const lookupOverclock[] = {
     };
 #endif
 
+static const char * const lookupTableThrottleLimitType[] = {
+    "OFF", "SCALE", "CLIP"
+};
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -387,6 +391,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef USE_DUAL_GYRO
     LOOKUP_TABLE_ENTRY(lookupTableGyro),
 #endif
+    LOOKUP_TABLE_ENTRY(lookupTableThrottleLimitType),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -628,6 +633,8 @@ const clivalue_t valueTable[] = {
     { "yaw_srate",                  VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, CONTROL_RATE_CONFIG_RATE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rates[FD_YAW]) },
     { "tpa_rate",                   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, CONTROL_RATE_CONFIG_TPA_MAX}, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, dynThrPID) },
     { "tpa_breakpoint",             VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, tpa_breakpoint) },
+    { "throttle_limit_type",        VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_THROTTLE_LIMIT_TYPE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, throttle_limit_type) },
+    { "throttle_limit_percent",     VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 25, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, throttle_limit_percent) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -87,6 +87,7 @@ typedef enum {
 #ifdef USE_DUAL_GYRO
     TABLE_GYRO,
 #endif
+    TABLE_THROTTLE_LIMIT_TYPE,
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 


### PR DESCRIPTION
Fixes #5567 

Adds new `throttle_limit_type` and `throttle_limit_percent` parameters that allow the pilot to limit the maximum commanded throttle seen by the flight controller and determine how the limiting is applied.  `throttle_limit_type` can be `OFF | SCALE | CLIP`.  The `SCALE` value will scale the commanded throttle linearly to the limit specified by `throttle_limit_percent` based on the full stick range.  The `CLIP` type will leave stick scaling unchanged below the limit, and cap the throttle so that additional throttle input above the limit has no effect.

The settings are part of the Rate Profile.

These capabilities replace methods of limiting throttle in the radio which some pilots are using to manage throttle on tight courses or reduce overall battery consumption when the extra power isn't needed.

There is no effect on the maximum throttle seen by the motors so the mixer still has full authority.

Flight tested in normal mode and bench tested in various 3D modes (normal and on-a-switch).