### PR TITLE
VTX Pit Mode control conflict resolved, Tx switch vs menues.

### DIFF
--- a/src/main/io/spektrum_vtx_control.c
+++ b/src/main/io/spektrum_vtx_control.c
@@ -150,10 +150,17 @@ void spektrumHandleVtxControl(uint32_t vtxCntrl)
 // ############ VTX_CONTROL task #############
 void spektrumVtxControl(void)
 {
+    static uint32_t prevVtxControl =0;
+    uint32_t vtxControl;
+
     // Check for invalid VTX ctrl frames
     if ((vtxControl_ipc & SPEKTRUM_VTX_CONTROL_FRAME_MASK) != SPEKTRUM_VTX_CONTROL_FRAME) return;
 
-    uint32_t vtxControl = vtxControl_ipc;
+    vtxControl = vtxControl_ipc;
+    vtxControl_ipc = 0;
+
+    if (prevVtxControl == vtxControl) return;
+    prevVtxControl = vtxControl;
 
     spektrumVtx_t vtx = {
         .pitMode = (vtxControl & SPEKTRUM_VTX_PIT_MODE_MASK) >> SPEKTRUM_VTX_PIT_MODE_SHIFT,
@@ -201,9 +208,10 @@ void spektrumVtxControl(void)
         }
         // Everyone seems to agree on what PIT ON/OFF means
         uint8_t currentPitMode = 0;
-        vtxCommonGetPitMode(vtxDevice, &currentPitMode);
-        if (currentPitMode != vtx.pitMode) {
-            vtxCommonSetPitMode(vtxDevice, vtx.pitMode);
+        if (vtxCommonGetPitMode(vtxDevice, &currentPitMode)) {
+            if (currentPitMode != vtx.pitMode) {
+                vtxCommonSetPitMode(vtxDevice, vtx.pitMode);
+            }
         }
     }
 

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -164,17 +164,27 @@ static bool vtxProcessPower(vtxDevice_t *vtxDevice)
 static bool vtxProcessPitMode(vtxDevice_t *vtxDevice)
 {
     uint8_t pitOnOff;
+
+    bool        currPmSwitchState;
+    static bool prevPmSwitchState = false;
+
     if (!ARMING_FLAG(ARMED) && vtxCommonGetPitMode(vtxDevice, &pitOnOff)) {
-        if (IS_RC_MODE_ACTIVE(BOXVTXPITMODE)) {
+        currPmSwitchState = IS_RC_MODE_ACTIVE(BOXVTXPITMODE);
+
+        if (currPmSwitchState != prevPmSwitchState) {
+            prevPmSwitchState = currPmSwitchState;
+
+            if (currPmSwitchState) {
 #if defined(VTX_SETTINGS_FREQCMD)
-            if (vtxSettingsConfig()->pitModeFreq) {
-                return false;
-            }
+                if (vtxSettingsConfig()->pitModeFreq) {
+                    return false;
+                }
 #endif
-            if (isModeActivationConditionPresent(BOXVTXPITMODE)) {
-                if (!pitOnOff) {
-                    vtxCommonSetPitMode(vtxDevice, true);
-                    return true;
+                if (isModeActivationConditionPresent(BOXVTXPITMODE)) {
+                    if (!pitOnOff) {
+                        vtxCommonSetPitMode(vtxDevice, true);
+                        return true;
+                    }
                 }
             } else {
                 if (pitOnOff) {


### PR DESCRIPTION
This PR fixes issue #5617 by introducing detection of control toggles in both the Pitmode Switch handling and in the Spektrum VTX Setup Menu. CMS menues seem to already have this. 
Tested on BETAFLIGHF3, Tramp HV, Spektrum Dx18g1 Tx, Spektrum SPM4649T Rx.

