### PR TITLE
Increased MSP API version for 3.3.1 to 1.38.

### DIFF
--- a/src/main/interface/msp_protocol.h
+++ b/src/main/interface/msp_protocol.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1  // increment when major changes are made
-#define API_VERSION_MINOR                   37 // increment after a release, to set the version for all changes to go into the following release (if no changes to MSP are made between the releases, this can be reverted before the release)
+#define API_VERSION_MINOR                   38 // increment after a release, to set the version for all changes to go into the following release (if no changes to MSP are made between the releases, this can be reverted before the release)
 
 #define API_VERSION_LENGTH                  2
 


### PR DESCRIPTION
This is to go with #5367 and betaflight/betaflight-configurator#984, in order to enable setting of DTerm setpoint transition to 0 (disabled).

This was already done in #5503, but for some reason the merge of this pull request never made it into the branch.