### PR TITLE
update slack url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See: https://github.com/betaflight/betaflight/wiki
 
 There's a dedicated Slack chat channel here:
 
-http://www.betaflight.ch/
+https://slack.betaflight.com/
 
 Etiquette: Don't ask to ask and please wait around long enough for a reply - sometimes people are out flying, asleep or at work and can't answer immediately.
 


### PR DESCRIPTION
changing it to the url shared in the facebook post and in the wiki