### PR TITLE
Expose vbat divider and multiplier parameters in CLI

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -576,6 +576,8 @@ const clivalue_t valueTable[] = {
 
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },
+    { "vbat_divider",               VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_DIVIDER_MIN, VBAT_DIVIDER_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatresdivval) },
+    { "vbat_multiplier",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_MULTIPLIER_MIN, VBAT_MULTIPLIER_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatresdivmultiplier) },
 
 // PG_CURRENT_SENSOR_ADC_CONFIG
     { "ibata_scale",                VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_ADC_CONFIG, offsetof(currentSensorADCConfig_t, scale) },

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -58,6 +58,12 @@ typedef enum {
 #define VBAT_SCALE_MIN 0
 #define VBAT_SCALE_MAX 255
 
+#define VBAT_DIVIDER_MIN 1
+#define VBAT_DIVIDER_MAX 255
+
+#define VBAT_MULTIPLIER_MIN 1
+#define VBAT_MULTIPLIER_MAX 255
+
 #define VBAT_LPF_FREQ  0.1f
 
 #ifndef MAX_VOLTAGE_SENSOR_ADC


### PR DESCRIPTION
Fixes #5640 

Previously only `vbat_scale` was exposed. Adds `vbat_divider` and `vbat_multiplier` parameters.

Note that all of these parameters only apply to the first voltage sensor (`VOLTAGE_SENSOR_ADC_VBAT`).  There is the capability to have multiple sensors and those will not have their parameters exposed.  Currently there are no target definitions that use multiple sensors.
