### PR TITLE
Prepare MSC for simultaneous multiple storages

### DIFF
--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -199,7 +199,8 @@ endif
 
 MSC_SRC = \
             drivers/usb_msc_f4xx.c \
-            msc/usbd_msc_desc.c
+            msc/usbd_msc_desc.c \
+            msc/usbd_storage.c
 
 ifneq ($(filter SDCARD,$(FEATURES)),)
 MSC_SRC += \

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -179,10 +179,11 @@ MCU_EXCLUDES = \
             drivers/bus_i2c.c \
             drivers/timer.c \
             drivers/serial_uart.c
-            
+
 MSC_SRC = \
-            drivers/usb_msc_f7xx.c
-            
+            drivers/usb_msc_f7xx.c \
+            msc/usbd_storage.c
+
 ifneq ($(filter SDIO,$(FEATURES)),)
 MCU_COMMON_SRC += \
             drivers/sdio_f7xx.c            

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -30,6 +30,8 @@
 
 #include "common/utils.h"
 
+#include "blackbox/blackbox.h"
+
 #include "drivers/io.h"
 #include "drivers/light_led.h"
 #include "drivers/nvic.h"
@@ -53,7 +55,7 @@ USBD_HandleTypeDef USBD_Device;
 #include "hw_config.h"
 #endif
 
-#include "usbd_msc_core.h"
+#include "msc/usbd_storage.h"
 
 #define DEBOUNCE_TIME_MS 20
 
@@ -81,6 +83,17 @@ uint8_t mscStart(void)
 
     IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
     IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
+
+    switch (blackboxConfig()->device) {
+#ifdef USE_SDCARD
+    case BLACKBOX_DEVICE_SDCARD:
+        USBD_STORAGE_fops = &USBD_MSC_MICRO_SDIO_fops;
+        break;
+#endif
+    default:
+        return 1;
+    }
+
     USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &MSC_desc, &USBD_MSC_cb, &USR_cb);
 
     // NVIC configuration for SYSTick

--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -30,6 +30,7 @@
 
 #include "common/utils.h"
 
+#include "blackbox/blackbox.h"
 #include "drivers/io.h"
 #include "drivers/light_led.h"
 #include "drivers/nvic.h"
@@ -42,6 +43,7 @@
 #include "usb_io.h"
 #include "usbd_msc.h"
 #include "msc/usbd_storage.h"
+
 USBD_HandleTypeDef USBD_Device;
 
 #define DEBOUNCE_TIME_MS 20
@@ -77,7 +79,15 @@ uint8_t mscStart(void)
     USBD_RegisterClass(&USBD_Device, USBD_MSC_CLASS);
 
     /** Register interface callbacks */
-    USBD_MSC_RegisterStorage(&USBD_Device, &USBD_MSC_Template_fops);
+    switch (blackboxConfig()->device) {
+#ifdef USE_SDCARD
+    case BLACKBOX_DEVICE_SDCARD:
+        USBD_MSC_RegisterStorage(&USBD_Device, &USBD_MSC_MICRO_SDIO_fops);
+        break;
+#endif
+    default:
+        return 1;
+    }
 
     USBD_Start(&USBD_Device);
 

--- a/src/main/msc/usbd_storage.c
+++ b/src/main/msc/usbd_storage.c
@@ -14,11 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Author: Chris Hockuba (https://github.com/conkerkh)
+ * Author: jflyper (https://github.com/jflyper)
  *
  */
-
-#pragma once
 
 #ifdef USE_HAL_DRIVER
 #include "usbd_msc.h"
@@ -27,14 +25,10 @@
 #include "usbd_msc_core.h"
 #endif
 
+#include "usbd_storage.h"
+
 #ifdef USE_HAL_DRIVER
-extern USBD_StorageTypeDef *USBD_STORAGE_fops;
-#ifdef USE_SDCARD
-extern USBD_StorageTypeDef USBD_MSC_MICRO_SDIO_fops;
-#endif
+USBD_StorageTypeDef *USBD_STORAGE_fops;
 #else
-extern USBD_STORAGE_cb_TypeDef *USBD_STORAGE_fops;
-#ifdef USE_SDCARD
-extern USBD_STORAGE_cb_TypeDef USBD_MSC_MICRO_SDIO_fops;
-#endif
+USBD_STORAGE_cb_TypeDef *USBD_STORAGE_fops;
 #endif

--- a/src/main/msc/usbd_storage_sd_spi.c
+++ b/src/main/msc/usbd_storage_sd_spi.c
@@ -40,6 +40,8 @@
 #include "usbd_msc_core.h"
 #endif
 
+#include "usbd_storage.h"
+
 #include "drivers/sdcard.h"
 #include "drivers/light_led.h"
 #include "drivers/io.h"
@@ -64,36 +66,36 @@
 #define STORAGE_BLK_NBR                  0x10000
 #define STORAGE_BLK_SIZ                  0x200
 
-int8_t STORAGE_Init (uint8_t lun);
+static int8_t STORAGE_Init (uint8_t lun);
 
 #ifdef USE_HAL_DRIVER
-int8_t STORAGE_GetCapacity (uint8_t lun,
+static int8_t STORAGE_GetCapacity (uint8_t lun,
                            uint32_t *block_num,
                            uint16_t *block_size);
 #else
-int8_t STORAGE_GetCapacity (uint8_t lun,
+static int8_t STORAGE_GetCapacity (uint8_t lun,
                            uint32_t *block_num,
                            uint32_t *block_size);
 #endif
 
-int8_t  STORAGE_IsReady (uint8_t lun);
+static int8_t  STORAGE_IsReady (uint8_t lun);
 
-int8_t  STORAGE_IsWriteProtected (uint8_t lun);
+static int8_t  STORAGE_IsWriteProtected (uint8_t lun);
 
-int8_t STORAGE_Read (uint8_t lun,
+static int8_t STORAGE_Read (uint8_t lun,
                         uint8_t *buf,
                         uint32_t blk_addr,
                         uint16_t blk_len);
 
-int8_t STORAGE_Write (uint8_t lun,
+static int8_t STORAGE_Write (uint8_t lun,
                         uint8_t *buf,
                         uint32_t blk_addr,
                         uint16_t blk_len);
 
-int8_t STORAGE_GetMaxLun (void);
+static int8_t STORAGE_GetMaxLun (void);
 
 /* USB Mass storage Standard Inquiry Data */
-uint8_t  STORAGE_Inquirydata[] = {//36
+static uint8_t  STORAGE_Inquirydata[] = {//36
 
   /* LUN 0 */
   0x00,
@@ -115,7 +117,7 @@ uint8_t  STORAGE_Inquirydata[] = {//36
 };
 
 #ifdef USE_HAL_DRIVER
-USBD_StorageTypeDef USBD_MSC_Template_fops =
+USBD_StorageTypeDef USBD_MSC_MICRO_SDIO_fops =
 {
   STORAGE_Init,
   STORAGE_GetCapacity,
@@ -127,7 +129,7 @@ USBD_StorageTypeDef USBD_MSC_Template_fops =
   (int8_t*)STORAGE_Inquirydata,
 };
 #else
-USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
+USBD_STORAGE_cb_TypeDef USBD_MSC_MICRO_SDIO_fops =
 {
   STORAGE_Init,
   STORAGE_GetCapacity,
@@ -138,9 +140,8 @@ USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
   STORAGE_GetMaxLun,
   (int8_t*)STORAGE_Inquirydata,
 };
-
-USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
 #endif
+
 /*******************************************************************************
 * Function Name  : Read_Memory
 * Description    : Handle the Read operation from the microSD card.
@@ -148,7 +149,7 @@ USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_Init (uint8_t lun)
+static int8_t STORAGE_Init (uint8_t lun)
 {
 	UNUSED(lun);
 	LED0_OFF;
@@ -166,9 +167,9 @@ int8_t STORAGE_Init (uint8_t lun)
 * Return         : None.
 *******************************************************************************/
 #ifdef USE_HAL_DRIVER
-int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint16_t *block_size)
+static int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint16_t *block_size)
 #else
-int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
+static int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
 #endif
 {
 	UNUSED(lun);
@@ -184,7 +185,7 @@ int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_si
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t  STORAGE_IsReady (uint8_t lun)
+static int8_t  STORAGE_IsReady (uint8_t lun)
 {
 	UNUSED(lun);
 	int8_t ret = -1;
@@ -201,7 +202,7 @@ int8_t  STORAGE_IsReady (uint8_t lun)
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t  STORAGE_IsWriteProtected (uint8_t lun)
+static int8_t  STORAGE_IsWriteProtected (uint8_t lun)
 {
   UNUSED(lun);
   return  0;
@@ -214,7 +215,7 @@ int8_t  STORAGE_IsWriteProtected (uint8_t lun)
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_Read (uint8_t lun,
+static int8_t STORAGE_Read (uint8_t lun,
                  uint8_t *buf,
                  uint32_t blk_addr,
                  uint16_t blk_len)
@@ -235,7 +236,7 @@ int8_t STORAGE_Read (uint8_t lun,
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_Write (uint8_t lun,
+static int8_t STORAGE_Write (uint8_t lun,
                   uint8_t *buf,
                   uint32_t blk_addr,
                   uint16_t blk_len)
@@ -258,7 +259,7 @@ int8_t STORAGE_Write (uint8_t lun,
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_GetMaxLun (void)
+static int8_t STORAGE_GetMaxLun (void)
 {
   return (STORAGE_LUN_NBR - 1);
 }

--- a/src/main/msc/usbd_storage_sdio.c
+++ b/src/main/msc/usbd_storage_sdio.c
@@ -44,6 +44,8 @@
 #include "usbd_msc_core.h"
 #endif
 
+#include "usbd_storage.h"
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -60,36 +62,36 @@
 #define STORAGE_BLK_NBR                  0x10000
 #define STORAGE_BLK_SIZ                  0x200
 
-int8_t STORAGE_Init (uint8_t lun);
+static int8_t STORAGE_Init (uint8_t lun);
 
 #ifdef USE_HAL_DRIVER
-int8_t STORAGE_GetCapacity (uint8_t lun,
+static int8_t STORAGE_GetCapacity (uint8_t lun,
                            uint32_t *block_num,
                            uint16_t *block_size);
 #else
-int8_t STORAGE_GetCapacity (uint8_t lun,
+static int8_t STORAGE_GetCapacity (uint8_t lun,
                            uint32_t *block_num,
                            uint32_t *block_size);
 #endif
 
-int8_t  STORAGE_IsReady (uint8_t lun);
+static int8_t  STORAGE_IsReady (uint8_t lun);
 
-int8_t  STORAGE_IsWriteProtected (uint8_t lun);
+static int8_t  STORAGE_IsWriteProtected (uint8_t lun);
 
-int8_t STORAGE_Read (uint8_t lun,
+static int8_t STORAGE_Read (uint8_t lun,
                         uint8_t *buf,
                         uint32_t blk_addr,
                         uint16_t blk_len);
 
-int8_t STORAGE_Write (uint8_t lun,
+static int8_t STORAGE_Write (uint8_t lun,
                         uint8_t *buf,
                         uint32_t blk_addr,
                         uint16_t blk_len);
 
-int8_t STORAGE_GetMaxLun (void);
+static int8_t STORAGE_GetMaxLun (void);
 
 /* USB Mass storage Standard Inquiry Data */
-uint8_t  STORAGE_Inquirydata[] = {//36
+static uint8_t  STORAGE_Inquirydata[] = {//36
 
   /* LUN 0 */
   0x00,
@@ -111,7 +113,7 @@ uint8_t  STORAGE_Inquirydata[] = {//36
 };
 
 #ifdef USE_HAL_DRIVER
-USBD_StorageTypeDef USBD_MSC_Template_fops =
+USBD_StorageTypeDef USBD_MSC_MICRO_SDIO_fops =
 {
   STORAGE_Init,
   STORAGE_GetCapacity,
@@ -123,7 +125,7 @@ USBD_StorageTypeDef USBD_MSC_Template_fops =
   (int8_t*)STORAGE_Inquirydata,
 };
 #else
-USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
+USBD_STORAGE_cb_TypeDef USBD_MSC_MICRO_SDIO_fops =
 {
   STORAGE_Init,
   STORAGE_GetCapacity,
@@ -134,9 +136,8 @@ USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
   STORAGE_GetMaxLun,
   (int8_t*)STORAGE_Inquirydata,
 };
-
-USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
 #endif
+
 /*******************************************************************************
 * Function Name  : Read_Memory
 * Description    : Handle the Read operation from the microSD card.
@@ -144,7 +145,7 @@ USBD_STORAGE_cb_TypeDef  *USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_Init (uint8_t lun)
+static int8_t STORAGE_Init (uint8_t lun)
 {
 	//Initialize SD_DET
 #ifdef SDCARD_DETECT_PIN
@@ -169,9 +170,9 @@ int8_t STORAGE_Init (uint8_t lun)
 * Return         : None.
 *******************************************************************************/
 #ifdef USE_HAL_DRIVER
-int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint16_t *block_size)
+static int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint16_t *block_size)
 #else
-int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
+static int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
 #endif
 {
 	UNUSED(lun);
@@ -192,7 +193,7 @@ int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_si
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t  STORAGE_IsReady (uint8_t lun)
+static int8_t  STORAGE_IsReady (uint8_t lun)
 {
 	UNUSED(lun);
 	int8_t ret = -1;
@@ -209,7 +210,7 @@ int8_t  STORAGE_IsReady (uint8_t lun)
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t  STORAGE_IsWriteProtected (uint8_t lun)
+static int8_t  STORAGE_IsWriteProtected (uint8_t lun)
 {
   UNUSED(lun);
   return  0;
@@ -222,7 +223,7 @@ int8_t  STORAGE_IsWriteProtected (uint8_t lun)
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_Read (uint8_t lun,
+static int8_t STORAGE_Read (uint8_t lun,
                  uint8_t *buf,
                  uint32_t blk_addr,
                  uint16_t blk_len)
@@ -249,7 +250,7 @@ int8_t STORAGE_Read (uint8_t lun,
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_Write (uint8_t lun,
+static int8_t STORAGE_Write (uint8_t lun,
                   uint8_t *buf,
                   uint32_t blk_addr,
                   uint16_t blk_len)
@@ -276,7 +277,7 @@ int8_t STORAGE_Write (uint8_t lun,
 * Output         : None.
 * Return         : None.
 *******************************************************************************/
-int8_t STORAGE_GetMaxLun (void)
+static int8_t STORAGE_GetMaxLun (void)
 {
   return (STORAGE_LUN_NBR - 1);
 }


### PR DESCRIPTION
In preparation for supporting FAT emulated flash under MSC, this PR allow simultaneously configured and/or installed multiple storage types (i.e., SD card and onboard flash chip).
