### PR TITLE
Fix timer definition for REVOLTOSD

### DIFF
--- a/src/main/target/REVOLT/target.c
+++ b/src/main/target/REVOLT/target.c
@@ -27,10 +27,10 @@
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM11, CH1,  PB9, TIM_USE_ANY,                 0, 0), //cam control
 
-    DEF_TIM(TIM8,  CH2N, PB0,  TIM_USE_MOTOR,               0, 0), // Motor 1
-    DEF_TIM(TIM8,  CH3N, PB1,  TIM_USE_MOTOR,               0, 0), // Motor 2
-    DEF_TIM(TIM5,  CH4, PA2,  TIM_USE_MOTOR,               0, 1), // Motor 3
-    DEF_TIM(TIM5,  CH3, PA3,  TIM_USE_MOTOR,               0, 0), // Motor 4
+    DEF_TIM(TIM8,  CH2N, PB0, TIM_USE_MOTOR,               0, 0), // Motor 1
+    DEF_TIM(TIM8,  CH3N, PB1, TIM_USE_MOTOR,               0, 0), // Motor 2
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               0, 0), // Motor 3
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR,               0, 0), // Motor 4
 
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,                 0, 0), // LED for REVOLT
 };


### PR DESCRIPTION
Fixes #5652, REVOLTOSD had suboptimal timer arrangement with TIM5_UP DMA colliding to TIM4_CH1 DMA.
Also motor 3 & 4 had pin names mixed up, but it did not matter as we don't use them directly for motor output.