### PR TITLE
Fix MSP Flash FS supported

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -149,6 +149,11 @@ typedef enum {
     MSP_SDCARD_FLAG_SUPPORTTED   = 1
 } mspSDCardFlags_e;
 
+typedef enum {
+    MSP_FLASHFS_FLAG_READY       = 1,
+    MSP_FLASHFS_FLAG_SUPPORTED  = 2
+} mspFlashFsFlags_e;
+
 #define RATEPROFILE_MASK (1 << 7)
 #endif //USE_OSD_SLAVE
 
@@ -281,7 +286,8 @@ static void serializeDataflashSummaryReply(sbuf_t *dst)
 {
 #ifdef USE_FLASHFS
     const flashGeometry_t *geometry = flashfsGetGeometry();
-    uint8_t flags = (flashfsIsReady() ? 1 : 0) | 2 /* FlashFS is supported */;
+    uint8_t flags = (flashfsIsReady() ? MSP_FLASHFS_FLAG_READY : 0);
+    flags |= (flashfsIsSupported() ? MSP_FLASHFS_FLAG_SUPPORTED : 0);
 
     sbufWriteU8(dst, flags);
     sbufWriteU32(dst, geometry->sectors);

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -111,6 +111,11 @@ bool flashfsIsReady(void)
     return m25p16_isReady();
 }
 
+bool flashfsIsSupported(void)
+{
+    return flashfsGetSize() > 0;
+}
+
 uint32_t flashfsGetSize(void)
 {
     return m25p16_getGeometry()->totalSize;

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -46,6 +46,7 @@ bool flashfsFlushAsync(void);
 void flashfsFlushSync(void);
 
 void flashfsInit(void);
+bool flashfsIsSupported(void);
 
 bool flashfsIsReady(void);
 bool flashfsIsEOF(void);


### PR DESCRIPTION
Some targets, for example the MATEKF405 that have multiple variants, some with SDCARD, others with FLASH, makes that the Blackbox tab of the configurator show both, the FLASH and the SDCARD but the first appear with strange appearance because the size, sectors, etc. are zero.

The MSP command `MSP_DATAFLASH_SUMMARY` returns FLASHFS supported if the define `USE_FLASHFS` exists, but I think it must return it only if if the define exist and the flash is detected, recognized and supported.

There are others solutions for this. For example in the configurator test if the size is > 0 and not only if supported.

What do you think? Is better to solve this problem here, at the root, or patch the configurator?

I don't have a FC only with flash to test that I've not broken anything... so it need some test.