### PR TITLE
Disable CMS when USB is connected on CDC_HID enabled targets.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -70,7 +70,6 @@
 
 #ifdef USE_USB_CDC_HID
 #include "sensors/battery.h"
-#include "pg/pg.h"
 #include "pg/usb.h"
 #endif
 

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -70,6 +70,8 @@
 
 #ifdef USE_USB_CDC_HID
 #include "sensors/battery.h"
+#include "pg/pg.h"
+#include "pg/usb.h"
 #endif
 
 // DisplayPort management
@@ -998,7 +1000,7 @@ void cmsUpdate(uint32_t currentTimeUs)
     }
 #endif
 #ifdef USE_USB_CDC_HID
-    if (getBatteryCellCount() == 0) {
+    if (getBatteryCellCount() == 0 && usbDevConfig()->type == COMPOSITE) {
         return;
     }
 #endif

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -68,6 +68,10 @@
 
 #include "rx/rx.h"
 
+#ifdef USE_USB_CDC_HID
+#include "sensors/battery.h"
+#endif
+
 // DisplayPort management
 
 #ifndef CMS_MAX_DEVICE
@@ -991,6 +995,11 @@ void cmsUpdate(uint32_t currentTimeUs)
 #ifdef USE_RCDEVICE
     if(rcdeviceInMenu) {
         return ;
+    }
+#endif
+#ifdef USE_USB_CDC_HID
+    if (getBatteryCellCount() == 0) {
+        return;
     }
 #endif
 


### PR DESCRIPTION
Some poeople reported that when flying sims, cms menu might accidentally trigger on and messup settings...