### PR TITLE
Improve ESC warning message and include current threshold check.

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -816,6 +816,7 @@ const clivalue_t valueTable[] = {
     { "osd_alt_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 10000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, alt_alarm) },
     { "osd_esc_temp_alarm",         VAR_INT8   | MASTER_VALUE, .config.minmax = { INT8_MIN, INT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_temp_alarm) },
     { "osd_esc_rpm_alarm",          VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_RPM_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_rpm_alarm) },
+    { "osd_esc_current_alarm",      VAR_INT8   | MASTER_VALUE, .config.minmax = { INT8_MIN, INT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_current_alarm) },
 
     { "osd_ah_max_pit",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 90 }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahMaxPitch) },
     { "osd_ah_max_rol",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 90 }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahMaxRoll) },

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -143,6 +143,7 @@ typedef enum {
 
 #define ESC_RPM_ALARM_OFF -1
 #define ESC_TEMP_ALARM_OFF INT8_MIN
+#define ESC_CURRENT_ALARM_OFF INT8_MIN
 
 typedef struct osdConfig_s {
     uint16_t item_pos[OSD_ITEM_COUNT];
@@ -162,6 +163,7 @@ typedef struct osdConfig_s {
     bool enabled_stats[OSD_STAT_COUNT];
     int8_t esc_temp_alarm;
     int16_t esc_rpm_alarm;
+    int8_t esc_current_alarm;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
Fix for a bug where the warning message is always displayed. Incidentally had an esc failure today so I have DVR of this feature in action.
[AVI video](https://github.com/betaflight/betaflight/files/1911490/esc-fail.zip)
The alarm initially triggers for 3 and then the rest. After recovery, the front-left esc (4) was found to be dead. When an esc dies, you seem to lose telemetry for all so I assume the descrepency is due to latency in the updates. It would be good if one esc didnt take down the whole telemetry, not sure if it is technically possible without having separate uarts for each esc. Without that, displaying the individual number of the failing esc has little value and is mis-leading.

