### PR TITLE
fixes Issue #5379, MPS VTX Settings werent saved

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1795,6 +1795,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                             vtxCommonSetPitMode(vtxDevice, newPitmode);
                         }
                     }
+                    saveConfigAndNotify();
                 }
             }
         }


### PR DESCRIPTION
Pretty simple fix, when the feature to set vtx parameters at startup was added. It broke Lua scripts. Because setting VTX settings over MSP didn't save the internal vtx config. Settings were lost upon rebooting.
See discussion at:
https://github.com/betaflight/betaflight/pull/5694

pull request was closed unreasonably