### PR TITLE
fixes Issue #5379, MPS VTX Settings werent saved

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1795,6 +1795,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                             vtxCommonSetPitMode(vtxDevice, newPitmode);
                         }
                     }
+                    saveConfigAndNotify();
                 }
             }
         }

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1795,7 +1795,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                             vtxCommonSetPitMode(vtxDevice, newPitmode);
                         }
                     }
-                    saveConfigAndNotify();
+                    writeEEPROM();
                 }
             }
         }


### PR DESCRIPTION
Pretty simple fix, when the feature to set vtx parameters at startup was added. It broke Lua scripts. Because setting VTX settings over MSP didn't save the internal vtx config. Settings were lost upon rebooting.
See discussion at:
#5694

pull request was closed unreasonably, please STOP ABUSING your power to manage pull requests.

You are closing discussions that aren't done. By closing my request you give me no other choice than to open a new one. There are other MSP commands that save the config. Your argument that I'm breaking MSP with my change is wrong and you are refusing to prove your point and have a discussion. Look at the saveConfigAndNotify and what it does. Now look at the MSP_EEPROM_WRITE command.... 


    case MSP_EEPROM_WRITE:
        writeEEPROM();
        readEEPROM();
        break;

void saveConfigAndNotify(void)
{
    writeEEPROM();
    readEEPROM();
    beeperConfirmationBeeps(1);
}





