### PR TITLE
Dshot queue first cut

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -196,10 +196,15 @@ uint16_t prepareDshotPacket(motorDmaOutput_t *const motor, uint16_t value);
 extern loadDmaBufferFn *loadDmaBuffer;
 
 uint32_t getDshotHz(motorPwmProtocolTypes_e pwmProtocolType);
-void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command);
+void pwmWriteDshotCommandControl(uint8_t index);
+void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command, bool blocking);
 void pwmWriteDshotInt(uint8_t index, uint16_t value);
 void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, motorPwmProtocolTypes_e pwmProtocolType, uint8_t output);
 void pwmCompleteDshotMotorUpdate(uint8_t motorCount);
+bool pwmIsProcessingDshotCommand(void);
+uint8_t pwmGetDshotCommand(uint8_t index);
+bool pwmProcessDshotCommand(uint8_t motorCount);
+
 #endif
 
 #ifdef USE_BEEPER

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -37,6 +37,7 @@
 #endif
 #include "pwm_output.h"
 #include "drivers/nvic.h"
+#include "drivers/time.h"
 #include "dma.h"
 #include "rcc.h"
 
@@ -57,7 +58,7 @@ uint8_t getTimerIndex(TIM_TypeDef *timer)
         }
     }
     dmaMotorTimers[dmaMotorTimerCount++].timer = timer;
-    return dmaMotorTimerCount-1;
+    return dmaMotorTimerCount - 1;
 }
 
 void pwmWriteDshotInt(uint8_t index, uint16_t value)
@@ -68,6 +69,12 @@ void pwmWriteDshotInt(uint8_t index, uint16_t value)
         return;
     }
 
+    /*If there is a command ready to go overwrite the value and send that instead*/
+    if (pwmIsProcessingDshotCommand()) {
+        value = pwmGetDshotCommand(index);
+        motor->requestTelemetry = true;
+    }
+    
     uint16_t packet = prepareDshotPacket(motor, value);
     uint8_t bufferSize;
 
@@ -88,6 +95,11 @@ void pwmWriteDshotInt(uint8_t index, uint16_t value)
 void pwmCompleteDshotMotorUpdate(uint8_t motorCount)
 {
     UNUSED(motorCount);
+
+    /* If there is a dshot command loaded up, time it correctly with motor update*/
+    if (pwmProcessDshotCommand(motorCount)) {
+        return; //Skip motor update
+    }
 
     for (int i = 0; i < dmaMotorTimerCount; i++) {
 #ifdef USE_DSHOT_DMAR

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -329,10 +329,7 @@ void disarm(void)
         if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH) && !feature(FEATURE_3D)) {
             flipOverAfterCrashMode = false;
             if (!feature(FEATURE_3D)) {
-                pwmDisableMotors();
-                delay(1);
-                pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL);
-                pwmEnableMotors();
+                pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, false);
             }
         }
 #endif
@@ -357,13 +354,10 @@ void tryArm(void)
         }
 #ifdef USE_DSHOT
         if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
-            pwmDisableMotors();
-            delay(1);
-
             if (!IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                 flipOverAfterCrashMode = false;
                 if (!feature(FEATURE_3D)) {
-                    pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL);
+                    pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, false);
                 }
             } else {
                 flipOverAfterCrashMode = true;
@@ -371,11 +365,9 @@ void tryArm(void)
                 runawayTakeoffCheckDisabled = false;
 #endif
                 if (!feature(FEATURE_3D)) {
-                    pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED);
+                    pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED, false);
                 }
             }
-
-            pwmEnableMotors();
         }
 #endif
 

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2775,7 +2775,7 @@ static void executeEscInfoCommand(uint8_t escIndex)
 
     startEscDataRead(escInfoBuffer, ESC_INFO_BLHELI32_EXPECTED_FRAME_SIZE);
 
-    pwmWriteDshotCommand(escIndex, getMotorCount(), DSHOT_CMD_ESC_INFO);
+    pwmWriteDshotCommand(escIndex, getMotorCount(), DSHOT_CMD_ESC_INFO, true);
 
     delay(10);
 
@@ -2822,7 +2822,7 @@ static void cliDshotProg(char *cmdline)
                     }
 
                     if (command != DSHOT_CMD_ESC_INFO) {
-                        pwmWriteDshotCommand(escIndex, getMotorCount(), command);
+                        pwmWriteDshotCommand(escIndex, getMotorCount(), command, true);
                     } else {
 #if defined(USE_ESC_SENSOR) && defined(USE_ESC_SENSOR_INFO)
                         if (feature(FEATURE_ESC_SENSOR)) {
@@ -2842,9 +2842,6 @@ static void cliDshotProg(char *cmdline)
 
                     cliPrintLinef("Command Sent: %d", command);
 
-                    if (command <= 5) {
-                        delay(20); // wait for sound output to finish
-                    }
                 } else {
                     cliPrintErrorLinef("Invalid command. Range: 1 - %d.", DSHOT_MIN_THROTTLE - 1);
                 }

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -393,12 +393,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
 
 #ifdef USE_DSHOT
         if (!areMotorsRunning() && beeperConfig()->dshotBeaconTone && (beeperConfig()->dshotBeaconTone <= DSHOT_CMD_BEACON5) && (currentBeeperEntry->mode == BEEPER_RX_SET || currentBeeperEntry->mode == BEEPER_RX_LOST)) {
-            pwmDisableMotors();
-            delay(1);
-
-            pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), beeperConfig()->dshotBeaconTone);
-
-            pwmEnableMotors();
+            pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), beeperConfig()->dshotBeaconTone, false);
         }
 #endif
 


### PR DESCRIPTION
Right now on SPI-RX, all the delays in dshot commands during arm and disarm make the RX lose a bunch of packets.  Also during the beeps.

Did a quick test on crazybee F3 and it appears to fix that issue for crash-flip and beeps.

Didn't really test for edge cases or hook to a logic analyzer yet.  Wanted to get some feedback on first before I did a bunch more testing.

Just remembered that this may have broke the CLI dshotprog, I'll check that out if everyone is happy with this arch.