### PR TITLE
Fixes to ranges of esc warning thresholds.

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -816,7 +816,7 @@ const clivalue_t valueTable[] = {
     { "osd_alt_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 10000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, alt_alarm) },
     { "osd_esc_temp_alarm",         VAR_INT8   | MASTER_VALUE, .config.minmax = { INT8_MIN, INT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_temp_alarm) },
     { "osd_esc_rpm_alarm",          VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_RPM_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_rpm_alarm) },
-    { "osd_esc_current_alarm",      VAR_INT8   | MASTER_VALUE, .config.minmax = { INT8_MIN, INT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_current_alarm) },
+    { "osd_esc_current_alarm",      VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_CURRENT_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_current_alarm) },
 
     { "osd_ah_max_pit",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 90 }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahMaxPitch) },
     { "osd_ah_max_rol",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 90 }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahMaxRoll) },

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -143,7 +143,7 @@ typedef enum {
 
 #define ESC_RPM_ALARM_OFF -1
 #define ESC_TEMP_ALARM_OFF INT8_MIN
-#define ESC_CURRENT_ALARM_OFF INT8_MIN
+#define ESC_CURRENT_ALARM_OFF -1
 
 typedef struct osdConfig_s {
     uint16_t item_pos[OSD_ITEM_COUNT];
@@ -163,7 +163,7 @@ typedef struct osdConfig_s {
     bool enabled_stats[OSD_STAT_COUNT];
     int8_t esc_temp_alarm;
     int16_t esc_rpm_alarm;
-    int8_t esc_current_alarm;
+    int16_t esc_current_alarm;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -27,11 +27,11 @@ PG_DECLARE(escSensorConfig_t, escSensorConfig);
 
 typedef struct {
     uint8_t dataAge;
-    int8_t temperature;
-    int16_t voltage;
-    int16_t current;
-    int16_t consumption;
-    int16_t rpm;
+    int8_t temperature;  // C degrees
+    int16_t voltage;     // 0.01V
+    int16_t current;     // 0.01A
+    int16_t consumption; // mAh
+    int16_t rpm;         // 0.01erpm
 } escSensorData_t;
 
 #define ESC_DATA_INVALID 255


### PR DESCRIPTION
Realised the esc current is stored as a unint16 and is measured in cA (centi-amps). Documented units too. Need to check if any unit conversion is missing in the smartport telemetry.