### PR TITLE
Fixing the #5705 (D-Term spikes)

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -489,7 +489,7 @@ static void handleCrashRecovery(
 }
 
 static void detectAndSetCrashRecovery(
-    const pidCrashRecovery_e crash_recovery, const uint8_t axis,
+    const pidCrashRecovery_e crash_recovery, const int axis,
     const timeUs_t currentTimeUs, const float delta, const float errorRate)
 {
     // if crash recovery is on and accelerometer enabled and there is no gyro overflow, then check for a crash

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -515,16 +515,10 @@ static void detectAndSetCrashRecovery(
     }
 }
 
-static void handleItermRotation(const timeUs_t currentTimeUs)
+static void handleItermRotation()
 {
-    static timeUs_t previousTimeUs;
-
-    // calculate actual deltaT in seconds
-    const float deltaT = (currentTimeUs - previousTimeUs) * 1e-6f;
-    previousTimeUs = currentTimeUs;
-
     // rotate old I to the new coordinate system
-    const float gyroToAngle = deltaT * RAD;
+    const float gyroToAngle = dT * RAD;
     for (int i = FD_ROLL; i <= FD_YAW; i++) {
         int i_1 = (i + 1) % 3;
         int i_2 = (i + 2) % 3;
@@ -574,7 +568,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
     }
 
     if (itermRotation) {
-        handleItermRotation(currentTimeUs);
+        handleItermRotation();
     }
 
     // ----------PID controller----------

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -520,7 +520,7 @@ static void handleItermRotation(const timeUs_t currentTimeUs)
     static timeUs_t previousTimeUs;
 
     // calculate actual deltaT in seconds
-    const float deltaT = (currentTimeUs - previousTimeUs) * 0.000001f;
+    const float deltaT = (currentTimeUs - previousTimeUs) * 1e-6f;
     previousTimeUs = currentTimeUs;
 
     // rotate old I to the new coordinate system


### PR DESCRIPTION
Looks like the change switching D-Term calculation to real time deltaT, caused the D-Term spikes due to the jittery nature of deltaT.

Reverting back to dT constant fixing the issue (tested by @spatzengr, thanks for this)