### PR TITLE
Added FAST_RAM_INITIALIZED

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -265,10 +265,18 @@ void init(void)
 {
 #ifdef USE_ITCM_RAM
     /* Load functions into ITCM RAM */
-    extern unsigned char tcm_code_start;
-    extern unsigned char tcm_code_end;
-    extern unsigned char tcm_code;
-    memcpy(&tcm_code_start, &tcm_code, (int)(&tcm_code_end - &tcm_code_start));
+    extern uint8_t *tcm_code_start;
+    extern uint8_t *tcm_code_end;
+    extern uint8_t *tcm_code;
+    memcpy(tcm_code_start, tcm_code, (size_t) (tcm_code_end - tcm_code_start));
+#endif
+
+#ifdef USE_FAST_RAM
+    /* Load FAST_RAM_INITIALIZED variable intializers into FAST RAM */
+    extern uint8_t *_sfastram_data;
+    extern uint8_t *_efastram_data;
+    extern uint8_t *_sfastram_idata;
+    memcpy(_sfastram_data, _sfastram_idata, (size_t) (_efastram_data - _sfastram_data));
 #endif
 
 #ifdef USE_HAL_DRIVER

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -265,18 +265,18 @@ void init(void)
 {
 #ifdef USE_ITCM_RAM
     /* Load functions into ITCM RAM */
-    extern uint8_t *tcm_code_start;
-    extern uint8_t *tcm_code_end;
-    extern uint8_t *tcm_code;
-    memcpy(tcm_code_start, tcm_code, (size_t) (tcm_code_end - tcm_code_start));
+    extern uint8_t tcm_code_start;
+    extern uint8_t tcm_code_end;
+    extern uint8_t tcm_code;
+    memcpy(&tcm_code_start, &tcm_code, (size_t) (&tcm_code_end - &tcm_code_start));
 #endif
 
 #ifdef USE_FAST_RAM
     /* Load FAST_RAM_INITIALIZED variable intializers into FAST RAM */
-    extern uint8_t *_sfastram_data;
-    extern uint8_t *_efastram_data;
-    extern uint8_t *_sfastram_idata;
-    memcpy(_sfastram_data, _sfastram_idata, (size_t) (_efastram_data - _sfastram_data));
+    extern uint8_t _sfastram_data;
+    extern uint8_t _efastram_data;
+    extern uint8_t _sfastram_idata;
+    memcpy(&_sfastram_data, &_sfastram_idata, (size_t) (&_efastram_data - &_sfastram_data));
 #endif
 
 #ifdef USE_HAL_DRIVER

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -158,7 +158,7 @@ void pidResetITerm(void)
     }
 }
 
-static FAST_RAM float itermAccelerator = 1.0f;
+static FAST_RAM_INITIALIZED float itermAccelerator = 1.0f;
 
 void pidSetItermAccelerator(float newItermAccelerator)
 {

--- a/src/main/target/KISSFCV2F7/stm32_flash_f722_no_split.ld
+++ b/src/main/target/KISSFCV2F7/stm32_flash_f722_no_split.ld
@@ -136,7 +136,7 @@ SECTIONS
   } >FLASH
 
   /* used by the startup to initialize data */
-  _sidata = .;
+  _sidata = LOADADDR(.data);
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data :
@@ -183,7 +183,7 @@ SECTIONS
   } >SRAM2
 
   /* used during startup to initialized fastram_data */
-  _sfastram_idata = .;
+  _sfastram_idata = LOADADDR(.fastram_data);
 
   /* Initialized FAST_RAM section for unsuspecting developers */
   .fastram_data :

--- a/src/main/target/KISSFCV2F7/stm32_flash_f722_no_split.ld
+++ b/src/main/target/KISSFCV2F7/stm32_flash_f722_no_split.ld
@@ -182,6 +182,21 @@ SECTIONS
     __sram2_end__ = _esram2;
   } >SRAM2
 
+  /* used during startup to initialized fastram_data */
+  _sfastram_idata = .;
+
+  /* Initialized FAST_RAM section for unsuspecting developers */
+  .fastram_data :
+  {
+    . = ALIGN(4);
+    _sfastram_data = .;        /* create a global symbol at data start */
+    *(.fastram_data)           /* .data sections */
+    *(.fastram_data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _efastram_data = .;        /* define a global symbol at data end */
+  } >FASTRAM AT> FLASH
+
   . = ALIGN(4);
   .fastram_bss (NOLOAD) :
   {

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -92,15 +92,17 @@
 #endif
 
 #ifdef USE_ITCM_RAM
-#define FAST_CODE __attribute__((section(".tcm_code")))
+#define FAST_CODE                   __attribute__((section(".tcm_code")))
 #else
 #define FAST_CODE
 #endif // USE_ITCM_RAM
 
 #ifdef USE_FAST_RAM
 #define FAST_RAM                    __attribute__ ((section(".fastram_bss"), aligned(4)))
+#define FAST_RAM_INITIALIZED        __attribute__ ((section(".fastram_data"), aligned(4)))
 #else
 #define FAST_RAM
+#define FAST_RAM_INITIALIZED
 #endif // USE_FAST_RAM
 
 #ifdef STM32F4

--- a/src/main/target/link/stm32_flash_f7_split.ld
+++ b/src/main/target/link/stm32_flash_f7_split.ld
@@ -93,7 +93,7 @@ SECTIONS
   } >FLASH AT >AXIM_FLASH
 
   /* used by the startup to initialize data */
-  _sidata = .;
+  _sidata = LOADADDR(.data);
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data :
@@ -140,7 +140,7 @@ SECTIONS
   } >SRAM2
 
   /* used during startup to initialized fastram_data */
-  _sfastram_idata = .;
+  _sfastram_idata = LOADADDR(.fastram_data);
 
   /* Initialized FAST_RAM section for unsuspecting developers */
   .fastram_data :

--- a/src/main/target/link/stm32_flash_f7_split.ld
+++ b/src/main/target/link/stm32_flash_f7_split.ld
@@ -139,6 +139,21 @@ SECTIONS
     __sram2_end__ = _esram2;
   } >SRAM2
 
+  /* used during startup to initialized fastram_data */
+  _sfastram_idata = .;
+
+  /* Initialized FAST_RAM section for unsuspecting developers */
+  .fastram_data :
+  {
+    . = ALIGN(4);
+    _sfastram_data = .;        /* create a global symbol at data start */
+    *(.fastram_data)           /* .data sections */
+    *(.fastram_data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _efastram_data = .;        /* define a global symbol at data end */
+  } >FASTRAM AT> FLASH
+
   . = ALIGN(4);
   .fastram_bss (NOLOAD) :
   {

--- a/src/main/target/link/stm32_flash_split.ld
+++ b/src/main/target/link/stm32_flash_split.ld
@@ -136,6 +136,22 @@ SECTIONS
     __bss_end__ = _ebss;
   } >RAM
 
+  /* used during startup to initialized fastram_data */
+  _sfastram_idata = .;
+
+  /* Initialized FAST_RAM section for unsuspecting developers */
+  .fastram_data :
+  {
+    . = ALIGN(4);
+    _sfastram_data = .;        /* create a global symbol at data start */
+    *(.fastram_data)           /* .data sections */
+    *(.fastram_data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _efastram_data = .;        /* define a global symbol at data end */
+  } >FASTRAM AT> FLASH
+
+  . = ALIGN(4);
   .fastram_bss (NOLOAD) :
   {
     __fastram_bss_start__ = .;

--- a/src/main/target/link/stm32_flash_split.ld
+++ b/src/main/target/link/stm32_flash_split.ld
@@ -106,7 +106,7 @@ SECTIONS
   } >FLASH
 
   /* used by the startup to initialize data */
-  _sidata = .;
+  _sidata = LOADADDR(.data);
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data :
@@ -137,7 +137,7 @@ SECTIONS
   } >RAM
 
   /* used during startup to initialized fastram_data */
-  _sfastram_idata = .;
+  _sfastram_idata = LOADADDR(.fastram_data);
 
   /* Initialized FAST_RAM section for unsuspecting developers */
   .fastram_data :


### PR DESCRIPTION
This PR adds `FAST_RAM_INITIALIZER` storage class for use with non-trivially initialized variables (e.g. initialized to anything different from 0).

Please keep the usage scenarios in mind in case you're going to add new `FAST_RAM` variables:
```cpp
FAST_RAM int triviallyInitializedVariable1;
FAST_RAM int triviallyInitializedVarible2 = 0;
FAST_RAM bool triviallyInitializedVariable3 = false;
FAST_RAM void *triviallyInitializedVariable4 = NULL;
FAST_RAM_INITIALIZED int nontriviallyInitializedVariable = 1;
```
After enabling `FAST_RAM` for F4 in #5674 an issue with `itermAccelerator` got uncovered. It was marked `FAST_RAM` but had a non-trivial initializer, which was effectively ignored, hence `itermAccelerator` was always 0.
An interesting consequence is I-term wasn't working properly on F7 as well, unless anti-gravity gain was used and re-initialized the value to `1`.

Fixes #5731 