### PR TITLE
Set FAST_RAM_INITIALIZED LMA to AXIM-FLASH

### DIFF
--- a/src/main/target/link/stm32_flash_f7_split.ld
+++ b/src/main/target/link/stm32_flash_f7_split.ld
@@ -152,7 +152,7 @@ SECTIONS
 
     . = ALIGN(4);
     _efastram_data = .;        /* define a global symbol at data end */
-  } >FASTRAM AT> FLASH
+  } >FASTRAM AT >AXIM_FLASH
 
   . = ALIGN(4);
   .fastram_bss (NOLOAD) :


### PR DESCRIPTION
As noted by @richard-scott in #5733, after merging it F74x stopped working after flashing via DFU bootloader.
This had to do with the fact that DFU bootloader doesn't translate ITCM addresses to AXIM automatically.
When working over a debugger addresses are translated automatically, hence I didn't notice the typo in linker script.
