### PR TITLE
Fixed inconsistent handling of servos for USE_QUAD_MIXER_ONLY.

### DIFF
--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -29,10 +29,6 @@
 #undef USE_VTX_TRAMP
 #endif
 
-#if defined(USE_QUAD_MIXER_ONLY) && defined(USE_SERVOS)
-#undef USE_SERVOS
-#endif
-
 #ifndef USE_DSHOT
 #undef USE_ESC_SENSOR
 #endif


### PR DESCRIPTION
Resolves the inconsistency with https://github.com/betaflight/betaflight/blob/bede91212866f7068e7a8da3f5e9effe4d78080d/src/main/drivers/pwm_output_counts.h#L25-L28.