### PR TITLE
[GPS RESCUE] - Use GPS when present for correcting attitude.values.yaw

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -529,6 +529,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     UNUSED(useMag);
     UNUSED(useCOG);
     UNUSED(canUseGPSHeading);
+    UNUSED(courseOverGround);
 #else
 
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_IMU_SYNC)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -262,8 +262,13 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
     // Use raw heading error (from GPS or whatever else)
     float ex = 0, ey = 0, ez = 0;
     if (useCOG) {
-        while (courseOverGround >  M_PIf) courseOverGround -= (2.0f * M_PIf);
-        while (courseOverGround < -M_PIf) courseOverGround += (2.0f * M_PIf);
+        while (courseOverGround >  M_PIf) {
+            courseOverGround -= (2.0f * M_PIf);
+        }
+
+        while (courseOverGround < -M_PIf) {
+            courseOverGround += (2.0f * M_PIf);
+        }
 
         const float ez_ef = (- sin_approx(courseOverGround) * rMat[0][0] - cos_approx(courseOverGround) * rMat[1][0]);
 

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -29,6 +29,7 @@ extern uint32_t accTimeSum;
 extern int accSumCount;
 extern float accVelScale;
 extern int32_t accSum[XYZ_AXIS_COUNT];
+extern bool canUseGPSHeading;
 
 typedef struct {
     float w,x,y,z;
@@ -79,6 +80,7 @@ typedef struct imuRuntimeConfig_s {
 void imuConfigure(uint16_t throttle_correction_angle);
 
 float getCosTiltAngle(void);
+void getQuaternion(quaternion * q);
 void imuUpdateAttitude(timeUs_t currentTimeUs);
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value);
 
@@ -96,3 +98,5 @@ void imuSetHasNewData(uint32_t dt);
 void imuQuaternionComputeProducts(quaternion *quat, quaternionProducts *quatProd);
 bool imuQuaternionHeadfreeOffsetSet(void);
 void imuQuaternionHeadfreeTransformVectorEarthToBody(t_fp_vector_def * v);
+void imuComputeQuaternionFromRPY(quaternionProducts *qP, int16_t initialRoll, int16_t initialPitch, int16_t initialYaw);
+bool shouldInitializeGPSHeading(void);


### PR DESCRIPTION
This PR feeds yaw correction data into the mahony ahrs filter. This should remove the requirement for the quad to be plugged in pointing north to get a proper home arrow.

This PR is a small part of GPS rescue mode, which is a return to home failsafe method for betaflight.

In regards to the addition of shouldInitializeGPSHeading() only returning true once - this works fine generally, but the method was added because we will likely find ways to pick good times to reinitialize during rescue mode so this method gives us a place to put that future logic.

The getQuaternion() method will be used for a subsequent PR in altitude.c for rotating acceleration vector body to earth.

👍 