### PR TITLE
Use -g rather than -Og for debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ LD_FLAGS         :=
 # Default Tool options - can be overridden in {mcu}.mk files.
 #
 ifeq ($(DEBUG),GDB)
-OPTIMISE_DEFAULT      := -Og
+OPTIMISE_DEFAULT      := -g
 
 LTO_FLAGS             := $(OPTIMISE_DEFAULT)
 DEBUG_FLAGS            = -ggdb3 -DDEBUG


### PR DESCRIPTION
If I build using `DEBUG=GDB` I still find variables are displayed as ```<optimised out>``` in Eclipse. Changing the debug optimisation flag from `-Og` to `-g` fixes this.

The gcc help shows `-Og` to be the correct option.

```
$ ./tools/gcc-arm-none-eabi-7-2017-q4-major/bin/arm-none-eabi-gcc --help=optimizers
The following options control optimizations:
  -O<number>                  Set optimization level to <number>.
  -Ofast                      Optimize for speed disregarding exact standards
                              compliance.
  -Og                         Optimize for debugging experience rather than
                              speed or size.
  -Os                         Optimize for space rather than speed.
```

The '-g' option was the norm on older version of the compiler.