### PR TITLE
Fix potential overflow in combined ESC sensor data

### DIFF
--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -31,8 +31,8 @@ typedef struct {
     uint8_t dataAge;
     int8_t temperature;  // C degrees
     int16_t voltage;     // 0.01V
-    int16_t current;     // 0.01A
-    int16_t consumption; // mAh
+    int32_t current;     // 0.01A
+    int32_t consumption; // mAh
     int16_t rpm;         // 0.01erpm
 } escSensorData_t;
 


### PR DESCRIPTION
The calculated combined ESC sensor data could potentially overflow in some extreme cases and the problem would be more likely in cases with more than 4 motors.

Updated to only change the data types to int32 for current and mah consumption to match the types used in the current meter.