### PR TITLE
FLASH: Handle overloaded SPI CS pin

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -46,13 +46,19 @@ static flashDevice_t flashDevice;
 bool flashInit(const flashConfig_t *flashConfig)
 {
     busdev = &busInstance;
-    busdev->bustype = BUSTYPE_SPI;
-    spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(flashConfig->spiDevice)));
+
     if (flashConfig->csTag) {
         busdev->busdev_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
     } else {
         return false;
     }
+
+    if (IOGetOwner(busdev->busdev_u.spi.csnPin) != OWNER_SPI_PREINIT) {
+        return false;
+    }
+
+    busdev->bustype = BUSTYPE_SPI;
+    spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(flashConfig->spiDevice)));
 
     IOInit(busdev->busdev_u.spi.csnPin, OWNER_FLASH_CS, 0);
     IOConfigGPIO(busdev->busdev_u.spi.csnPin, SPI_IO_CS_CFG);


### PR DESCRIPTION
A new `flashInit`, introduced by #5683 which de-init designated CS pin when it fails to detect a valid flash chip, broke some target that has flash CS pin overloaded with other SPI devices. MOTOLAB (overloaded with MPU gyro) and FF_FORTINI (overloaded with MAX OSD chip) are known to be affected by this behavior.

Older flash device detection did not de-init, which "accidentally" allowed actual resident device on the CS pin to continue to work.

This PR proposes a limited but simple solution to prevent `flashInit` from touching a CS pin that is already initialized and being used by some other device/driver.

Fixes #5770
Fixes #5772
