### PR TITLE
Add descriptive enumeration for vcd_video_system values

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -329,6 +329,12 @@ static const char * const lookupTableThrottleLimitType[] = {
     "OFF", "SCALE", "CLIP"
 };
 
+#ifdef USE_MAX7456
+static const char * const lookupTableVideoSystem[] = {
+    "AUTO", "PAL", "NTSC"
+};
+#endif // USE_MAX7456
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -397,6 +403,9 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableGyro),
 #endif
     LOOKUP_TABLE_ENTRY(lookupTableThrottleLimitType),
+#ifdef USE_MAX7456
+    LOOKUP_TABLE_ENTRY(lookupTableVideoSystem),
+#endif // USE_MAX7456
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -921,7 +930,7 @@ const clivalue_t valueTable[] = {
 
 // PG_VCD_CONFIG
 #ifdef USE_MAX7456
-    { "vcd_video_system",           VAR_UINT8   | MASTER_VALUE, .config.minmax = { 0, 2 }, PG_VCD_CONFIG, offsetof(vcdProfile_t, video_system) },
+    { "vcd_video_system",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_VIDEO_SYSTEM }, PG_VCD_CONFIG, offsetof(vcdProfile_t, video_system) },
     { "vcd_h_offset",               VAR_INT8    | MASTER_VALUE, .config.minmax = { -32, 31 }, PG_VCD_CONFIG, offsetof(vcdProfile_t, h_offset) },
     { "vcd_v_offset",               VAR_INT8    | MASTER_VALUE, .config.minmax = { -15, 16 }, PG_VCD_CONFIG, offsetof(vcdProfile_t, v_offset) },
 #endif

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -91,6 +91,9 @@ typedef enum {
     TABLE_GYRO,
 #endif
     TABLE_THROTTLE_LIMIT_TYPE,
+#ifdef USE_MAX7456
+    TABLE_VIDEO_SYSTEM,
+#endif // USE_MAX7456
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 


### PR DESCRIPTION
Previously the values were numeric and ranged from 0 to 2. This change adds a descriptive value list as "AUTO", "PAL" and "NTSC".