### PR TITLE
Use i2cUnstick() from bus_i2c_hal.c

### DIFF
--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -37,6 +37,17 @@
 
 #define CLOCKSPEED 800000    // i2c clockspeed 400kHz default (conform specs), 800kHz  and  1200kHz (Betaflight default)
 
+// Number of bits in I2C protocol phase
+#define LEN_ADDR 7
+#define LEN_RW 1
+#define LEN_ACK 1
+
+// Clock period in us during unstick transfer
+#define UNSTICK_CLK_US 10
+
+// Allow 500us for clock strech to complete during unstick
+#define UNSTICK_CLK_STRETCH (500/UNSTICK_CLK_US)
+
 static void i2cUnstick(IO_t scl, IO_t sda);
 
 #define IOCFG_I2C_PU IO_CONFIG(GPIO_MODE_AF_OD, GPIO_SPEED_FREQ_VERY_HIGH, GPIO_PULLUP)
@@ -292,31 +303,33 @@ static void i2cUnstick(IO_t scl, IO_t sda)
     IOConfigGPIO(scl, IOCFG_OUT_OD);
     IOConfigGPIO(sda, IOCFG_OUT_OD);
 
-    // Analog Devices AN-686
-    // We need 9 clock pulses + STOP condition
-    for (i = 0; i < 9; i++) {
+    // Clock out, with SDA high:
+    //   7 data bits
+    //   1 READ bit
+    //   1 cycle for the ACK
+    for (i = 0; i < (LEN_ADDR + LEN_RW + LEN_ACK); i++) {
         // Wait for any clock stretching to finish
-        int timeout = 100;
+        int timeout = UNSTICK_CLK_STRETCH;
         while (!IORead(scl) && timeout) {
-            delayMicroseconds(5);
+            delayMicroseconds(UNSTICK_CLK_US);
             timeout--;
         }
 
         // Pull low
         IOLo(scl); // Set bus low
-        delayMicroseconds(5);
+        delayMicroseconds(UNSTICK_CLK_US/2);
         IOHi(scl); // Set bus high
-        delayMicroseconds(5);
+        delayMicroseconds(UNSTICK_CLK_US/2);
     }
 
     // Generate a stop condition in case there was none
     IOLo(scl);
-    delayMicroseconds(5);
+    delayMicroseconds(UNSTICK_CLK_US/2);
     IOLo(sda);
-    delayMicroseconds(5);
+    delayMicroseconds(UNSTICK_CLK_US/2);
 
     IOHi(scl); // Set bus scl high
-    delayMicroseconds(5);
+    delayMicroseconds(UNSTICK_CLK_US/2);
     IOHi(sda); // Set bus sda high
 }
 

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -473,7 +473,6 @@ uint16_t i2cGetErrorCounter(void)
 static void i2cUnstick(IO_t scl, IO_t sda)
 {
     int i;
-    int timeout = 100;
 
     IOHi(scl);
     IOHi(sda);
@@ -481,27 +480,31 @@ static void i2cUnstick(IO_t scl, IO_t sda)
     IOConfigGPIO(scl, IOCFG_OUT_OD);
     IOConfigGPIO(sda, IOCFG_OUT_OD);
 
-    for (i = 0; i < 8; i++) {
+    // Analog Devices AN-686
+    // We need 9 clock pulses + STOP condition
+    for (i = 0; i < 9; i++) {
         // Wait for any clock stretching to finish
+        int timeout = 100;
         while (!IORead(scl) && timeout) {
-            delayMicroseconds(10);
+            delayMicroseconds(5);
             timeout--;
         }
 
         // Pull low
         IOLo(scl); // Set bus low
-        delayMicroseconds(10);
+        delayMicroseconds(5);
         IOHi(scl); // Set bus high
-        delayMicroseconds(10);
+        delayMicroseconds(5);
     }
 
-    // Generate a start then stop condition
-    IOLo(sda); // Set bus data low
-    delayMicroseconds(10);
-    IOLo(scl); // Set bus scl low
-    delayMicroseconds(10);
+    // Generate a stop condition in case there was none
+    IOLo(scl);
+    delayMicroseconds(5);
+    IOLo(sda);
+    delayMicroseconds(5);
+
     IOHi(scl); // Set bus scl high
-    delayMicroseconds(10);
+    delayMicroseconds(5);
     IOHi(sda); // Set bus sda high
 }
 

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -37,6 +37,17 @@
 
 #define CLOCKSPEED 800000    // i2c clockspeed 400kHz default (conform specs), 800kHz  and  1200kHz (Betaflight default)
 
+// Number of bits in I2C protocol phase
+#define LEN_ADDR 7
+#define LEN_RW 1
+#define LEN_ACK 1
+
+// Clock period in us during unstick transfer
+#define UNSTICK_CLK_US 10
+
+// Allow 500us for clock strech to complete during unstick
+#define UNSTICK_CLK_STRETCH (500/UNSTICK_CLK_US)
+
 static void i2c_er_handler(I2CDevice device);
 static void i2c_ev_handler(I2CDevice device);
 static void i2cUnstick(IO_t scl, IO_t sda);
@@ -480,31 +491,33 @@ static void i2cUnstick(IO_t scl, IO_t sda)
     IOConfigGPIO(scl, IOCFG_OUT_OD);
     IOConfigGPIO(sda, IOCFG_OUT_OD);
 
-    // Analog Devices AN-686
-    // We need 9 clock pulses + STOP condition
-    for (i = 0; i < 9; i++) {
+    // Clock out, with SDA high:
+    //   7 data bits
+    //   1 READ bit
+    //   1 cycle for the ACK
+    for (i = 0; i < (LEN_ADDR + LEN_RW + LEN_ACK); i++) {
         // Wait for any clock stretching to finish
-        int timeout = 100;
+        int timeout = UNSTICK_CLK_STRETCH;
         while (!IORead(scl) && timeout) {
-            delayMicroseconds(5);
+            delayMicroseconds(UNSTICK_CLK_US);
             timeout--;
         }
 
         // Pull low
         IOLo(scl); // Set bus low
-        delayMicroseconds(5);
+        delayMicroseconds(UNSTICK_CLK_US/2);
         IOHi(scl); // Set bus high
-        delayMicroseconds(5);
+        delayMicroseconds(UNSTICK_CLK_US/2);
     }
 
     // Generate a stop condition in case there was none
     IOLo(scl);
-    delayMicroseconds(5);
+    delayMicroseconds(UNSTICK_CLK_US/2);
     IOLo(sda);
-    delayMicroseconds(5);
+    delayMicroseconds(UNSTICK_CLK_US/2);
 
     IOHi(scl); // Set bus scl high
-    delayMicroseconds(5);
+    delayMicroseconds(UNSTICK_CLK_US/2);
     IOHi(sda); // Set bus sda high
 }
 


### PR DESCRIPTION
This PR addresses issues with the MS5611 barometer which fails it's first access on a Revo Nano FC. This replaces the `i2cUnstick()` routine in `bus_i2c_stm32f10x.c` with that in `bus_i2c_hal.c`. Below is an explanation of the testing performed to demonstrate that this change fixes the issue without undesirable side effects.

Using the Segger RTT debug support, see https://github.com/betaflight/betaflight/pull/5318, I've conducted the following experiments.

In each test I'm performing three consecutive accesses to either a non-existant device (address 0xaa on I2CDEV_3), the MS5611 Baro at address 0x77, or the 24C512 EEPROM at address 0x50.

Each is done immediately following code, added in `ms5611Detect()`, with only one block included at a time.

```
    dbgPrintf(DBG_SYSTEM, 0, "I2C unstick test\n");
#if 1
    busDevice_t nack_busdev = {
            .bustype = BUSTYPE_I2C,
            .busdev_u.i2c.device = I2CDEV_3,
            .busdev_u.i2c.address = 0xaa
    };
    dbgPrintf(DBG_SYSTEM, 0, "Initial access to non-existant device %s\n", busReadRegisterBuffer(&nack_busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
    dbgPrintf(DBG_SYSTEM, 0, "Second access to non-existant device %s\n", busReadRegisterBuffer(&nack_busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
    dbgPrintf(DBG_SYSTEM, 0, "Third access to non-existant device %s\n", busReadRegisterBuffer(&nack_busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
#endif
#if 0
    dbgPrintf(DBG_SYSTEM, 0, "Initial access to ms5611 %s\n", busReadRegisterBuffer(busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
    dbgPrintf(DBG_SYSTEM, 0, "Second access to ms5611 %s\n", busReadRegisterBuffer(busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
    dbgPrintf(DBG_SYSTEM, 0, "Third access to ms5611 %s\n", busReadRegisterBuffer(busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
#endif
#if 0
    busDevice_t eeprom_busdev = {
            .bustype = BUSTYPE_I2C,
            .busdev_u.i2c.device = I2CDEV_3,
            .busdev_u.i2c.address = 0x50
    };
    dbgPrintf(DBG_SYSTEM, 0, "Initial access to eeprom %s\n", busReadRegisterBuffer(&eeprom_busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
    dbgPrintf(DBG_SYSTEM, 0, "Second access to eeprom %s\n", busReadRegisterBuffer(&eeprom_busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
    dbgPrintf(DBG_SYSTEM, 0, "Third access to eeprom %s\n", busReadRegisterBuffer(&eeprom_busdev, CMD_PROM_RD, &sig, 1) ? "pass" : "fail");
#endif
```

Using the original `i2cUnstick()` routine I see the following results.

```
1:0 I2C unstick test
1:0 Initial access to non-existant device fail
1:0 Second access to non-existant device fail
1:0 Third access to non-existant device fail
```

```
1:0 I2C unstick test
1:0 Initial access to ms5611 fail
1:0 Second access to ms5611 pass
1:0 Third access to ms5611 pass
```

```
1:0 I2C unstick test
1:0 Initial access to eeprom pass
1:0 Second access to eeprom pass
1:0 Third access to eeprom pass
```

The above demonstrates that with the original `i2cUnstick()` routine the ms5611 fails on the 1st access, whereas the EEPROM does not.

Repeating the same tests, but replacing the original `i2cUnstick()` routine with the one from `bus_i2c_hal.c`, gives the following results.

```
1:0 I2C unstick test
1:0 Initial access to non-existant device fail
1:0 Second access to non-existant device fail
1:0 Third access to non-existant device fail
```

```
1:0 I2C unstick test
1:0 Initial access to ms5611 pass
1:0 Second access to ms5611 pass
1:0 Third access to ms5611 pass
```

```
1:0 I2C unstick test
1:0 Initial access to eeprom pass
1:0 Second access to eeprom pass
1:0 Third access to eeprom pass
```

This demonstrates no negative impact on the EEPROM access, but allows the Baro to operate correctly.