### PR TITLE
Fix incorrect double increment in MAX7456 screen drawing

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -629,7 +629,6 @@ void max7456DrawScreen(void)
                 spiBuff[buff_len++] = MAX7456ADD_DMDI;
                 spiBuff[buff_len++] = screenBuffer[pos];
                 shadowBuffer[pos] = screenBuffer[pos];
-                k++;
             }
 
             if (++pos >= maxScreenSize) {


### PR DESCRIPTION
The for loop variable was being erroneously double incremented when a character was updated. This would cause fewer characters to be checked/updated during each cycle based on how many were found to be updated.

This is only a minor problem as the screen update logic would continue to update on the next cycle and all characters would eventually be updated.