### PR TITLE
Default OSD ESC current alarm to off

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -962,6 +962,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->alt_alarm  = 100; // meters or feet depend on configuration
     osdConfig->esc_temp_alarm = ESC_TEMP_ALARM_OFF; // off by default
     osdConfig->esc_rpm_alarm = ESC_RPM_ALARM_OFF; // off by default
+    osdConfig->esc_current_alarm = ESC_CURRENT_ALARM_OFF; // off by default
 
     osdConfig->ahMaxPitch = 20; // 20 degrees
     osdConfig->ahMaxRoll = 40; // 40 degrees


### PR DESCRIPTION
The `osd_esc_current_alarm` was added but never assigned a default value. Therefore it defaulted to 0 instead of off (-1).  This resulted in OSD warnings if the ESCs weren't providing current data as the test looked for values >= the warning setting.