### PR TITLE
Kakutef7 IMU change

### DIFF
--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -28,7 +28,7 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM1, CH3, PE13, TIM_USE_ANY,   0, 1), // CAM_CONTROL , DMA2_ST6
+    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,   0, 1), // PPM / CAM_CONTROL, DMA2_ST6
     
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // M1 , DMA1_ST7
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // M2 , DMA1_ST2

--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -29,7 +29,7 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,   0, 1), // PPM / CAM_CONTROL, DMA2_ST6
-    
+
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // M1 , DMA1_ST7
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // M2 , DMA1_ST2
     DEF_TIM(TIM1, CH1, PE9,  TIM_USE_MOTOR, 0, 2), // M3 , DMA2_ST2

--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -28,7 +28,7 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,   0, 1), // PPM , DMA2_ST6
+    DEF_TIM(TIM1, CH3, PE13, TIM_USE_ANY,   0, 1), // CAM_CONTROL , DMA2_ST6
 
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // M1 , DMA1_ST7
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // M2 , DMA1_ST2

--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -29,7 +29,7 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH3, PE13, TIM_USE_ANY,   0, 1), // CAM_CONTROL , DMA2_ST6
-
+    
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // M1 , DMA1_ST7
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // M2 , DMA1_ST2
     DEF_TIM(TIM1, CH1, PE9,  TIM_USE_MOTOR, 0, 2), // M3 , DMA2_ST2

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -33,38 +33,26 @@
 
 #define USE_ACC
 #define USE_GYRO
-#define USE_DUAL_GYRO
+
+//define camera control
+#define CAMERA_CONTROL_PIN PE13
 
 // ICM-20689
 #define USE_ACC_SPI_ICM20689
 #define USE_GYRO_SPI_ICM20689
 #define GYRO_ICM20689_ALIGN      CW270_DEG
 #define ACC_ICM20689_ALIGN       CW270_DEG
-//#define MPU_INT_EXTI               PE1
-
-// MPU6000
-#define USE_ACC_SPI_MPU6000
-#define USE_GYRO_SPI_MPU6000
-#define GYRO_MPU6000_ALIGN       CW270_DEG
-#define ACC_MPU6000_ALIGN        CW270_DEG
-//#define MPU_INT_EXTI                PB9
+#define MPU_INT_EXTI               PE1
 
 #define ICM20689_CS_PIN          SPI4_NSS_PIN
 #define ICM20689_SPI_INSTANCE    SPI4
-#define MPU6000_CS_PIN           SPI3_NSS_PIN
-#define MPU6000_SPI_INSTANCE     SPI3
 #define GYRO_1_CS_PIN            ICM20689_CS_PIN
-#define GYRO_2_CS_PIN            MPU6000_CS_PIN
 #define GYRO_1_SPI_INSTANCE      ICM20689_SPI_INSTANCE
-#define GYRO_2_SPI_INSTANCE      MPU6000_SPI_INSTANCE
 
 #define ACC_1_ALIGN              ACC_ICM20689_ALIGN
-#define ACC_2_ALIGN              ACC_MPU6000_ALIGN
 #define GYRO_1_ALIGN             GYRO_ICM20689_ALIGN
-#define GYRO_2_ALIGN             GYRO_MPU6000_ALIGN
 
-//#define USE_MPU_DATA_READY_SIGNAL
-
+#define USE_MPU_DATA_READY_SIGNAL
 #define USE_EXTI
 
 #define USE_VCP
@@ -107,7 +95,6 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_1   //SD Card
 #define USE_SPI_DEVICE_2   //OSD
-#define USE_SPI_DEVICE_3   //MPU6000
 #define USE_SPI_DEVICE_4   //ICM20689
 
 #define SPI1_NSS_PIN            PA4
@@ -120,16 +107,10 @@
 #define SPI2_MISO_PIN           PB14
 #define SPI2_MOSI_PIN           PB15
 
-#define SPI3_NSS_PIN            PA15
-#define SPI3_SCK_PIN            PB3
-#define SPI3_MISO_PIN           PB4
-#define SPI3_MOSI_PIN           PB5
-
 #define SPI4_NSS_PIN            PE4
 #define SPI4_SCK_PIN            PE2
 #define SPI4_MISO_PIN           PE5
 #define SPI4_MOSI_PIN           PE6
-
 
 #define USE_MAX7456
 #define MAX7456_SPI_INSTANCE    SPI2

--- a/src/main/target/KAKUTEF7/target.mk
+++ b/src/main/target/KAKUTEF7/target.mk
@@ -4,7 +4,6 @@ FEATURES       += SDCARD VCP
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_spi_icm20689.c \
-            drivers/accgyro/accgyro_spi_mpu6000.c \
             drivers/barometer/barometer_bmp280.c \
             drivers/compass/compass_hmc5883l.c \
             drivers/compass/compass_qmc5883l.c \


### PR DESCRIPTION
1. CAM_CONTROL is more useful , TIM1 CH3 is setted to CAM_CONTROL  in default.

2. Installing sponge as shock absorber for IMU is helpful.  To save the PCB room to Installing shock absorber, MPU6000 is deleted.
