### PR TITLE
Fixed flash overflow for MIDELICF3

### DIFF
--- a/src/main/target/MIDELICF3/target.h
+++ b/src/main/target/MIDELICF3/target.h
@@ -24,6 +24,12 @@
 
 // prevent flash overflow
 #undef USE_CRSF_CMS_TELEMETRY
+#undef USE_GYRO_OVERFLOW_CHECK  // target does not use an affected gyro
+#undef USE_SERIALRX_SUMD
+#undef USE_SERIALRX_SUMH
+#undef USE_SERIALRX_XBUS
+#undef USE_TELEMETRY_HOTT
+#undef USE_TELEMETRY_LTM
 
 #define LED0_PIN                PB5
 


### PR DESCRIPTION
Since this board has built-in Frsky rx, remove some lesser used rx protocols and telemetry.  Also remove gyro overflow detect as the board has an unaffected MPU6050.