### PR TITLE
Exclude KISSFCV2F7 from CI

### DIFF
--- a/make/targets.mk
+++ b/make/targets.mk
@@ -16,6 +16,7 @@ $(error The target specified, $(TARGET), cannot be built. Use one of the ALT tar
 endif
 
 UNSUPPORTED_TARGETS := \
+	KISSFCV2F7 \
 	AFROMINI \
 	ALIENFLIGHTF1 \
 	BEEBRAIN \


### PR DESCRIPTION
This PR temporarily exclude KISSFCV2F7 target from CI builds until the local linker script is fixed.

As reported in #5707, KISSFCV2F7 is using a local version of linker script which fell behind when F7 optimization was applied to rest of the targets, and it is now overflowing in some code sections, preventing CI to succeed for some PR.

@ronlix Can you look into this?