### PR TITLE
Fixed flash overflow for FRSKYF3

### DIFF
--- a/src/main/target/FRSKYF3/target.h
+++ b/src/main/target/FRSKYF3/target.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+// Removed to make the firmware fit into flash (in descending order of priority):
+#undef USE_GYRO_OVERFLOW_CHECK // target does not use affected gyros
+#undef USE_RTC_TIME
+
 #define TARGET_BOARD_IDENTIFIER "FRF3"
 #define USE_TARGET_CONFIG
 #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_NONE


### PR DESCRIPTION
Before:
```
   text	   data	    bss	    dec	    hex	filename
 248981	   8828	  32964	 290773	  46fd5	./obj/main/betaflight_FRSKYF3.elf
```
After:
```
after
   text	   data	    bss	    dec	    hex	filename
 245377	   8828	  32944	 287149	  461ad	./obj/main/betaflight_FRSKYF3.elf
```