### PR TITLE
Fix rx rate calculation when using fport

### DIFF
--- a/src/main/fc/fc_rc.h
+++ b/src/main/fc/fc_rc.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+extern uint16_t currentRxRefreshRate;
+
 void processRcCommand(void);
 float getSetpointRate(int axis);
 float getRcDeflection(int axis);

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -44,6 +44,7 @@
 
 #include "fc/config.h"
 #include "fc/fc_core.h"
+#include "fc/fc_rc.h"
 #include "fc/fc_dispatch.h"
 #include "fc/fc_tasks.h"
 #include "fc/rc_controls.h"
@@ -151,13 +152,16 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
         return;
     }
 
+    static timeUs_t lastRxTimeUs;
+    currentRxRefreshRate = constrain(currentTimeUs - lastRxTimeUs, 1000, 20000);
+    lastRxTimeUs = currentTimeUs;
     isRXDataNew = true;
 
 #ifdef USE_USB_CDC_HID
     if (!ARMING_FLAG(ARMED)) {
         int8_t report[8];
         for (int i = 0; i < 8; i++) {
-	        	report[i] = scaleRange(constrain(rcData[i], 1000, 2000), 1000, 2000, -127, 127);
+                report[i] = scaleRange(constrain(rcData[i], 1000, 2000), 1000, 2000, -127, 127);
         }
 #ifdef STM32F4
         USBD_HID_SendReport(&USB_OTG_dev, (uint8_t*)report, sizeof(report));

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -87,6 +87,7 @@ extern uint8_t __config_end;
 #include "fc/config.h"
 #include "fc/controlrate_profile.h"
 #include "fc/fc_core.h"
+#include "fc/fc_rc.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
@@ -3178,7 +3179,7 @@ static void cliStatus(char *cmdline)
     cliPrintLinef("I2C Errors: %d, config size: %d, max available config: %d", i2cErrorCounter, getEEPROMConfigSize(), CONFIG_SIZE);
 
     const int gyroRate = getTaskDeltaTime(TASK_GYROPID) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_GYROPID)));
-    const int rxRate = getTaskDeltaTime(TASK_RX) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_RX)));
+    const int rxRate = currentRxRefreshRate == 0 ? 0 : (int)(1000000.0f / ((float)currentRxRefreshRate));
     const int systemRate = getTaskDeltaTime(TASK_SYSTEM) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_SYSTEM)));
     cliPrintLinef("CPU:%d%%, cycle time: %d, GYRO rate: %d, RX rate: %d, System rate: %d",
             constrain(averageSystemLoadPercent, 0, 100), getTaskDeltaTime(TASK_GYROPID), gyroRate, rxRate, systemRate);
@@ -3931,7 +3932,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("vtx", "vtx channels on switch", NULL, cliVtx),
 #endif
 #ifdef USE_USB_MSC
-	CLI_COMMAND_DEF("msc", "switch into msc mode", NULL, cliMsc),
+    CLI_COMMAND_DEF("msc", "switch into msc mode", NULL, cliMsc),
 #endif
 };
 

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -230,6 +230,7 @@ uint8_t __config_end = 0x10;
 uint16_t averageSystemLoadPercent = 0;
 
 timeDelta_t getTaskDeltaTime(cfTaskId_e){ return 0; }
+uint16_t currentRxRefreshRate = 9000;
 armingDisableFlags_e getArmingDisableFlags(void) { return ARMING_DISABLED_NO_GYRO; }
 
 const char *armingDisableFlagNames[]= {


### PR DESCRIPTION
Since auxiliary rx processing has been introduced in #4982 rx refresh rate required for rc interpolation and cli status command is calculated incorrectly. This patch replacing getTaskDeltaTime(TASK_RX) with real calculation because TASK_RX is not scheduled anymore only for RX data but also for telemetry processing. Also some tabs has been replaces with spaces by my editor.