### PR TITLE
Add cli parameter bit mapping mode

### DIFF
--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -104,31 +104,33 @@ typedef struct lookupTableEntry_s {
 
 
 #define VALUE_TYPE_OFFSET 0
-#define VALUE_SECTION_OFFSET 2
-#define VALUE_MODE_OFFSET 4
+#define VALUE_SECTION_OFFSET 3
+#define VALUE_MODE_OFFSET 5
 
 typedef enum {
-    // value type, bits 0-1
+    // value type, bits 0-2
     VAR_UINT8 = (0 << VALUE_TYPE_OFFSET),
     VAR_INT8 = (1 << VALUE_TYPE_OFFSET),
     VAR_UINT16 = (2 << VALUE_TYPE_OFFSET),
     VAR_INT16 = (3 << VALUE_TYPE_OFFSET),
+    VAR_UINT32 = (4 << VALUE_TYPE_OFFSET),
 
-    // value section, bits 2-3
+    // value section, bits 3-4
     MASTER_VALUE = (0 << VALUE_SECTION_OFFSET),
     PROFILE_VALUE = (1 << VALUE_SECTION_OFFSET),
     PROFILE_RATE_VALUE = (2 << VALUE_SECTION_OFFSET),
 
-    // value mode, bits 4-5
+    // value mode, bits 5-6
     MODE_DIRECT = (0 << VALUE_MODE_OFFSET),
     MODE_LOOKUP = (1 << VALUE_MODE_OFFSET),
-    MODE_ARRAY = (2 << VALUE_MODE_OFFSET)
+    MODE_ARRAY = (2 << VALUE_MODE_OFFSET),
+    MODE_BITSET = (3 << VALUE_MODE_OFFSET)
 } cliValueFlag_e;
 
 
-#define VALUE_TYPE_MASK (0x03)
-#define VALUE_SECTION_MASK (0x0c)
-#define VALUE_MODE_MASK (0x30)
+#define VALUE_TYPE_MASK (0x07)
+#define VALUE_SECTION_MASK (0x18)
+#define VALUE_MODE_MASK (0x60)
 
 typedef struct cliMinMaxConfig_s {
     const int16_t min;
@@ -147,6 +149,7 @@ typedef union {
     cliLookupTableConfig_t lookup;
     cliMinMaxConfig_t minmax;
     cliArrayLengthConfig_t array;
+    uint8_t bitpos;
 } cliValueConfig_t;
 
 typedef struct clivalue_s {


### PR DESCRIPTION
Adds a new parameter mode `MODE_BITSET` that allows associating a cli parameter with a specific bit in a stored value. Bit packed values can be exposed with individual cli parameters for each bit as needed. Supports UINT8, UINT16 and newly added UINT32 data types (UINT32 not supported for other modes at this time). When the settings are defined, a new `.config.bitpos = x` is used where x specifies the bit position linked to the parameter (zero-based).  `diff` is properly supported at the bit level.

Here's a practical example that exposes the enabled OSD warning types.  The warning types are stored as a bit packed 16bit as defined by:
```
typedef enum {
    OSD_WARNING_ARMING_DISABLE    = (1 << 0),
    OSD_WARNING_BATTERY_NOT_FULL  = (1 << 1),
    OSD_WARNING_BATTERY_WARNING   = (1 << 2),
    OSD_WARNING_BATTERY_CRITICAL  = (1 << 3),
    OSD_WARNING_VISUAL_BEEPER     = (1 << 4),
    OSD_WARNING_CRASH_FLIP        = (1 << 5),
    OSD_WARNING_ESC_FAIL          = (1 << 6)
} osdWarningsFlags_e;
```

The parameter definition is as follows:
```
    { "osd_warnings",               VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings) },
```
This is exposed in the cli as (note that uint16 ranges aren't handled so the allowed range is incorrect - but not relevant here):
```
# get osd_warnings
osd_warnings = 63
Allowed range: 0 - 32767
```

Now by using the new `MODE_BITSET` type we can expose the individual settings as:
```
    { "osd_warnings_arming_disable",   VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 0, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
    { "osd_warnings_battery_not_full", VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 1, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
    { "osd_warnings_battery_warning",  VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 2, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
    { "osd_warnings_battery_critical", VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 3, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
    { "osd_warnings_visual_beeper",    VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 4, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
    { "osd_warnings_crash_flip",       VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 5, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
    { "osd_warnings_esc_fail",         VAR_UINT16 | MASTER_VALUE | MODE_BITSET, .config.bitpos = 6, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
```
This results in the individual bits being exposed in the cli as:
```
# get osd_warnings
osd_warnings_arming_disable = ON
Allowed values: OFF, ON

osd_warnings_battery_not_full = ON
Allowed values: OFF, ON

osd_warnings_battery_warning = ON
Allowed values: OFF, ON

osd_warnings_battery_critical = ON
Allowed values: OFF, ON

osd_warnings_visual_beeper = ON
Allowed values: OFF, ON

osd_warnings_crash_flip = ON
Allowed values: OFF, ON

osd_warnings_esc_fail = OFF
Allowed values: OFF, ON
```

Note that only supports unsigned uint8, uint16 and uint32.  Using signed data types in the settings definition will result in misbehavior (mainly just not displaying or updating values).  Also uint32 support is only added for `MODE_BITSET` at this time.