### PR TITLE
remove unused swap serial define

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -87,14 +87,6 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .boardIdentifier = TARGET_BOARD_IDENTIFIER
 );
 
-#ifdef SWAP_SERIAL_PORT_0_AND_1_DEFAULTS
-#define FIRST_PORT_INDEX 1
-#define SECOND_PORT_INDEX 0
-#else
-#define FIRST_PORT_INDEX 0
-#define SECOND_PORT_INDEX 1
-#endif
-
 #ifndef USE_OSD_SLAVE
 uint8_t getCurrentPidProfileIndex(void)
 {


### PR DESCRIPTION
SWAP_SERIAL_PORT_0_AND_1_DEFAULTS, FIRST_PORT_INDEX and SECOND_PORT_INDEX arent used anywhere in the codebase