### PR TITLE
Add individual OSD warning options as cli parameters

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -787,7 +787,14 @@ const clivalue_t valueTable[] = {
 // PG_OSD_CONFIG
 #ifdef USE_OSD
     { "osd_units",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_UNIT }, PG_OSD_CONFIG, offsetof(osdConfig_t, units) },
-    { "osd_warnings",               VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings) },
+
+    { "osd_warn_arming_disable",    VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_ARMING_DISABLE,   PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_warn_batt_not_full",     VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_BATTERY_NOT_FULL, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_warn_batt_warning",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_BATTERY_WARNING,  PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_warn_batt_critical",     VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_BATTERY_CRITICAL, PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_warn_visual_beeper",     VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_VISUAL_BEEPER,    PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_warn_crash_flip",        VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_CRASH_FLIP,       PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_warn_esc_fail",          VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_ESC_FAIL,         PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
 
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -150,14 +150,18 @@ typedef enum {
 } osd_timer_precision_e;
 
 typedef enum {
-    OSD_WARNING_ARMING_DISABLE    = (1 << 0),
-    OSD_WARNING_BATTERY_NOT_FULL  = (1 << 1),
-    OSD_WARNING_BATTERY_WARNING   = (1 << 2),
-    OSD_WARNING_BATTERY_CRITICAL  = (1 << 3),
-    OSD_WARNING_VISUAL_BEEPER     = (1 << 4),
-    OSD_WARNING_CRASH_FLIP        = (1 << 5),
-    OSD_WARNING_ESC_FAIL          = (1 << 6)
+    OSD_WARNING_ARMING_DISABLE,
+    OSD_WARNING_BATTERY_NOT_FULL,
+    OSD_WARNING_BATTERY_WARNING,
+    OSD_WARNING_BATTERY_CRITICAL,
+    OSD_WARNING_VISUAL_BEEPER,
+    OSD_WARNING_CRASH_FLIP,
+    OSD_WARNING_ESC_FAIL,
+    OSD_WARNING_COUNT // MUST BE LAST
 } osdWarningsFlags_e;
+
+// Make sure the number of warnings do not exceed the available 16bit storage
+STATIC_ASSERT(OSD_WARNING_COUNT <= 16, osdwarnings_overflow);
 
 #define ESC_RPM_ALARM_OFF -1
 #define ESC_TEMP_ALARM_OFF INT8_MIN
@@ -194,4 +198,7 @@ void osdResetAlarms(void);
 void osdUpdate(timeUs_t currentTimeUs);
 void osdStatSetState(uint8_t statIndex, bool enabled);
 bool osdStatGetState(uint8_t statIndex);
+void osdWarnSetState(uint8_t warningIndex, bool enabled);
+bool osdWarnGetState(uint8_t warningIndex);
+
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -791,7 +791,10 @@ TEST(OsdTest, TestElementWarningsBattery)
 {
     // given
     osdConfigMutable()->item_pos[OSD_WARNINGS] = OSD_POS(9, 10) | VISIBLE_FLAG;
-    osdConfigMutable()->enabledWarnings = OSD_WARNING_BATTERY_WARNING | OSD_WARNING_BATTERY_CRITICAL | OSD_WARNING_BATTERY_NOT_FULL;
+    osdConfigMutable()->enabledWarnings = 0;  // disable all warnings
+    osdWarnSetState(OSD_WARNING_BATTERY_WARNING, true);
+    osdWarnSetState(OSD_WARNING_BATTERY_CRITICAL, true);
+    osdWarnSetState(OSD_WARNING_BATTERY_NOT_FULL, true);
 
     // and
     batteryConfigMutable()->vbatfullcellvoltage = 41;


### PR DESCRIPTION
Previously only the single bitmapped parameter `osd_warnings` was available in the cli but this wasn't very useful as the users would have to understand the bit positions to enable/disable warning options. This change exposes each warning item as a separate parameter.