### PR TITLE
DSHOT max throttle percentage.

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1318,6 +1318,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE("motor_pwm_protocol", "%d",              motorConfig()->dev.motorPwmProtocol);
         BLACKBOX_PRINT_HEADER_LINE("motor_pwm_rate", "%d",                  motorConfig()->dev.motorPwmRate);
         BLACKBOX_PRINT_HEADER_LINE("dshot_idle_value", "%d",                motorConfig()->digitalIdleOffsetValue);
+        BLACKBOX_PRINT_HEADER_LINE("dshot_max_value", "%d",                 motorConfig()->digitalMaxOffsetValue);
         BLACKBOX_PRINT_HEADER_LINE("debug_mode", "%d",                      systemConfig()->debug_mode);
         BLACKBOX_PRINT_HEADER_LINE("features", "%d",                        featureConfig()->enabledFeatures);
 

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -96,12 +96,14 @@ CMS_Menu cmsx_menuRcPreview = {
 
 static uint16_t motorConfig_minthrottle;
 static uint8_t motorConfig_digitalIdleOffsetValue;
+static uint8_t motorConfig_digitalMaxOffsetValue;
 static debugType_e systemConfig_debug_mode;
 
 static long cmsx_menuMiscOnEnter(void)
 {
     motorConfig_minthrottle = motorConfig()->minthrottle;
     motorConfig_digitalIdleOffsetValue = motorConfig()->digitalIdleOffsetValue / 10;
+    motorConfig_digitalMaxOffsetValue = motorConfig()->digitalMaxOffsetValue / 10;
     systemConfig_debug_mode = systemConfig()->debug_mode;
 
     return 0;
@@ -113,6 +115,7 @@ static long cmsx_menuMiscOnExit(const OSD_Entry *self)
 
     motorConfigMutable()->minthrottle = motorConfig_minthrottle;
     motorConfigMutable()->digitalIdleOffsetValue = 10 * motorConfig_digitalIdleOffsetValue;
+    motorConfigMutable()->digitalMaxOffsetValue = 10 * motorConfig_digitalMaxOffsetValue;
     systemConfigMutable()->debug_mode = systemConfig_debug_mode;
 
     return 0;
@@ -124,6 +127,7 @@ static OSD_Entry menuMiscEntries[]=
 
     { "MIN THR",      OME_UINT16,  NULL,          &(OSD_UINT16_t){ &motorConfig_minthrottle,              1000, 2000, 1 },      0 },
     { "DIGITAL IDLE", OME_UINT8,   NULL,          &(OSD_UINT8_t) { &motorConfig_digitalIdleOffsetValue,      0,  200, 1 },      0 },
+    { "DIGITAL MAX",  OME_UINT8,   NULL,          &(OSD_UINT8_t) { &motorConfig_digitalMaxOffsetValue,       0,  200, 1 },      0 },
     { "DEBUG MODE",   OME_TAB,     NULL,          &(OSD_TAB_t) { &systemConfig_debug_mode, DEBUG_COUNT - 1, debugModeNames },      0 },
     { "RC PREV",      OME_Submenu, cmsMenuChange, &cmsx_menuRcPreview, 0},
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,6 +100,7 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
     motorConfig->maxthrottle = 2000;
     motorConfig->mincommand = 1000;
     motorConfig->digitalIdleOffsetValue = 450;
+    motorConfig->digitalMaxOffsetValue = 0;
 #ifdef USE_DSHOT_DMAR
     motorConfig->dev.useBurstDshot = ENABLE_DSHOT_DMAR;
 #endif
@@ -384,7 +385,7 @@ void initEscEndpoints(void)
         } else {
             motorOutputLow = DSHOT_MIN_THROTTLE + ((DSHOT_MAX_THROTTLE - DSHOT_MIN_THROTTLE) / 100.0f) * CONVERT_PARAMETER_TO_PERCENT(motorConfig()->digitalIdleOffsetValue);
         }
-        motorOutputHigh = DSHOT_MAX_THROTTLE;
+        motorOutputHigh = DSHOT_MAX_THROTTLE - ((DSHOT_MAX_THROTTLE - DSHOT_MIN_THROTTLE) / 100.0f) * CONVERT_PARAMETER_TO_PERCENT(motorConfig()->digitalMaxOffsetValue);
         deadbandMotor3dHigh = DSHOT_3D_DEADBAND_HIGH + ((DSHOT_MAX_THROTTLE - DSHOT_3D_DEADBAND_HIGH) / 100.0f) * CONVERT_PARAMETER_TO_PERCENT(motorConfig()->digitalIdleOffsetValue);
         deadbandMotor3dLow = DSHOT_3D_DEADBAND_LOW;
 

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -98,6 +98,7 @@ PG_DECLARE(mixerConfig_t, mixerConfig);
 typedef struct motorConfig_s {
     motorDevConfig_t dev;
     uint16_t digitalIdleOffsetValue;        // Idle value for DShot protocol, full motor output = 10000
+    uint16_t digitalMaxOffsetValue;         // Max value for DShot protocol, full motor output = 10000
     uint16_t minthrottle;                   // Set the minimum throttle command sent to the ESC (Electronic Speed Controller). This is the minimum value that allow motors to run at a idle speed.
     uint16_t maxthrottle;                   // This is the maximum value for the ESCs at full power this value can be increased up to 2000
     uint16_t mincommand;                    // This is the value for the ESCs when they are not armed. In some cases, this value must be lowered down to 900 for some specific ESCs

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1200,6 +1200,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, motorConfig()->dev.motorPwmProtocol);
         sbufWriteU16(dst, motorConfig()->dev.motorPwmRate);
         sbufWriteU16(dst, motorConfig()->digitalIdleOffsetValue);
+        sbufWriteU16(dst, motorConfig()->digitalMaxOffsetValue);        
         sbufWriteU8(dst, gyroConfig()->gyro_use_32khz);
         sbufWriteU8(dst, motorConfig()->dev.motorPwmInversion);
         break;
@@ -1636,9 +1637,14 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         motorConfigMutable()->dev.motorPwmProtocol = constrain(sbufReadU8(src), 0, PWM_TYPE_BRUSHED);
 #endif
         motorConfigMutable()->dev.motorPwmRate = sbufReadU16(src);
-        if (sbufBytesRemaining(src) >= 2) {
+
+        if (sbufBytesRemaining(src) >= 4) {
             motorConfigMutable()->digitalIdleOffsetValue = sbufReadU16(src);
+            motorConfigMutable()->digitalMaxOffsetValue = sbufReadU16(src);
+        } else if (sbufBytesRemaining(src) >= 2) {
+             motorConfigMutable()->digitalIdleOffsetValue = sbufReadU16(src);
         }
+
         if (sbufBytesRemaining(src)) {
             gyroConfigMutable()->gyro_use_32khz = sbufReadU8(src);
         }

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -545,6 +545,7 @@ const clivalue_t valueTable[] = {
     { "min_command",                VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, mincommand) },
 #ifdef USE_DSHOT
     { "dshot_idle_value",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 2000 }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, digitalIdleOffsetValue) },
+    { "dshot_max_value",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 2000 }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, digitalMaxOffsetValue) },
 #ifdef USE_DSHOT_DMAR
     { "dshot_burst",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useBurstDshot) },
 #endif


### PR DESCRIPTION
Just like idle percent but for max throttle. Reduces the dshot max throttle value by a given percentage. This allows you to quickly limit the max motor speed for greater efficiency or testing higher voltages. It has the advantage over limiting your throttle, by not allowing the mixer/PID controller to push the motors past the max throttle value. 