### PR TITLE
Add handling for array of PG structures in cli resource command.

### DIFF
--- a/src/main/drivers/bus_i2c_config.c
+++ b/src/main/drivers/bus_i2c_config.c
@@ -71,14 +71,14 @@ void i2cHardwareConfigure(const i2cConfig_t *i2cConfig)
         memset(pDev, 0, sizeof(*pDev));
 
         for (int pindex = 0 ; pindex < I2C_PIN_SEL_MAX ; pindex++) {
-            if (i2cConfig->ioTagScl[device] == hardware->sclPins[pindex].ioTag) {
-                pDev->scl = IOGetByTag(i2cConfig->ioTagScl[device]);
+            if (i2cConfig[device].ioTagScl == hardware->sclPins[pindex].ioTag) {
+                pDev->scl = IOGetByTag(i2cConfig[device].ioTagScl);
 #if defined(STM32F4)
                 pDev->sclAF = hardware->sclPins[pindex].af;
 #endif
             }
-            if (i2cConfig->ioTagSda[device] == hardware->sdaPins[pindex].ioTag) {
-                pDev->sda = IOGetByTag(i2cConfig->ioTagSda[device]);
+            if (i2cConfig[device].ioTagSda == hardware->sdaPins[pindex].ioTag) {
+                pDev->sda = IOGetByTag(i2cConfig[device].ioTagSda);
 #if defined(STM32F4)
                 pDev->sdaAF = hardware->sdaPins[pindex].af;
 #endif
@@ -88,8 +88,8 @@ void i2cHardwareConfigure(const i2cConfig_t *i2cConfig)
         if (pDev->scl && pDev->sda) {
             pDev->hardware = hardware;
             pDev->reg = hardware->reg;
-            pDev->overClock = i2cConfig->overClock[device];
-            pDev->pullUp = i2cConfig->pullUp[device];
+            pDev->overClock = i2cConfig[device].overClock;
+            pDev->pullUp = i2cConfig[device].pullUp;
         }
     }
 }

--- a/src/main/drivers/bus_spi_pinconfig.c
+++ b/src/main/drivers/bus_spi_pinconfig.c
@@ -294,19 +294,19 @@ void spiPinConfigure(const spiPinConfig_t *pConfig)
         spiDevice_t *pDev = &spiDevice[device];
 
         for (int pindex = 0 ; pindex < MAX_SPI_PIN_SEL ; pindex++) {
-            if (pConfig->ioTagSck[device] == hw->sckPins[pindex].pin) {
+            if (pConfig[device].ioTagSck == hw->sckPins[pindex].pin) {
                 pDev->sck = hw->sckPins[pindex].pin;
 #ifdef STM32F7
                 pDev->sckAF = hw->sckPins[pindex].af;
 #endif
             }
-            if (pConfig->ioTagMiso[device] == hw->misoPins[pindex].pin) {
+            if (pConfig[device].ioTagMiso == hw->misoPins[pindex].pin) {
                 pDev->miso = hw->misoPins[pindex].pin;
 #ifdef STM32F7
                 pDev->misoAF = hw->misoPins[pindex].af;
 #endif
             }
-            if (pConfig->ioTagMosi[device] == hw->mosiPins[pindex].pin) {
+            if (pConfig[device].ioTagMosi == hw->mosiPins[pindex].pin) {
                 pDev->mosi = hw->mosiPins[pindex].pin;
 #ifdef STM32F7
                 pDev->mosiAF = hw->mosiPins[pindex].af;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -446,7 +446,7 @@ void init(void)
 #else
 
 #ifdef USE_SPI
-    spiPinConfigure(spiPinConfig());
+    spiPinConfigure(spiPinConfig(0));
 
     // Initialize CS lines and keep them high
     spiPreInit();
@@ -479,7 +479,7 @@ void init(void)
 #endif
 
 #ifdef USE_I2C
-    i2cHardwareConfigure(i2cConfig());
+    i2cHardwareConfigure(i2cConfig(0));
 
     // Note: Unlike UARTs which are configured when client is present,
     // I2C buses are initialized unconditionally if they are configured.

--- a/src/main/osd_slave/osd_slave_init.c
+++ b/src/main/osd_slave/osd_slave_init.c
@@ -204,7 +204,7 @@ void init(void)
 #else
 
 #ifdef USE_SPI
-    spiPinConfigure(spiPinConfig());
+    spiPinConfigure(spiPinConfig(0));
 
     // Initialize CS lines and keep them high
     spiPreInit();
@@ -224,7 +224,7 @@ void init(void)
 #endif /* USE_SPI */
 
 #ifdef USE_I2C
-    i2cHardwareConfigure(i2cConfig());
+    i2cHardwareConfigure(i2cConfig(0));
 
     // Note: Unlike UARTs which are configured when client is present,
     // I2C buses are initialized unconditionally if they are configured.

--- a/src/main/pg/bus_i2c.c
+++ b/src/main/pg/bus_i2c.c
@@ -67,13 +67,14 @@ void pgResetFn_i2cConfig(i2cConfig_t *i2cConfig)
 
     for (size_t index = 0 ; index < ARRAYLEN(i2cDefaultConfig) ; index++) {
         const i2cDefaultConfig_t *defconf = &i2cDefaultConfig[index];
-        i2cConfig->ioTagScl[defconf->device] = defconf->ioTagScl;
-        i2cConfig->ioTagSda[defconf->device] = defconf->ioTagSda;
-        i2cConfig->overClock[defconf->device] = defconf->overClock;
-        i2cConfig->pullUp[defconf->device] = defconf->pullUp;
+        int device = defconf->device;
+        i2cConfig[device].ioTagScl = defconf->ioTagScl;
+        i2cConfig[device].ioTagSda = defconf->ioTagSda;
+        i2cConfig[device].overClock = defconf->overClock;
+        i2cConfig[device].pullUp = defconf->pullUp;
     }
 }
 
-PG_REGISTER_WITH_RESET_FN(i2cConfig_t, i2cConfig, PG_I2C_CONFIG, 0);
+PG_REGISTER_ARRAY_WITH_RESET_FN(i2cConfig_t, I2CDEV_COUNT, i2cConfig, PG_I2C_CONFIG, 0);
 
 #endif // defined(USE_I2C) && !defined(USE_SOFT_I2C)

--- a/src/main/pg/bus_i2c.h
+++ b/src/main/pg/bus_i2c.h
@@ -29,10 +29,10 @@
 #include "pg/pg.h"
 
 typedef struct i2cConfig_s {
-    ioTag_t ioTagScl[I2CDEV_COUNT];
-    ioTag_t ioTagSda[I2CDEV_COUNT];
-    bool overClock[I2CDEV_COUNT];
-    bool pullUp[I2CDEV_COUNT];
+    ioTag_t ioTagScl;
+    ioTag_t ioTagSda;
+    bool overClock;
+    bool pullUp;
 } i2cConfig_t;
 
-PG_DECLARE(i2cConfig_t, i2cConfig);
+PG_DECLARE_ARRAY(i2cConfig_t, I2CDEV_COUNT, i2cConfig);

--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -51,15 +51,15 @@ const spiDefaultConfig_t spiDefaultConfig[] = {
 #endif
 };
 
-PG_REGISTER_WITH_RESET_FN(spiPinConfig_t, spiPinConfig, PG_SPI_PIN_CONFIG, 0);
+PG_REGISTER_ARRAY_WITH_RESET_FN(spiPinConfig_t, SPIDEV_COUNT, spiPinConfig, PG_SPI_PIN_CONFIG, 1);
 
 void pgResetFn_spiPinConfig(spiPinConfig_t *spiPinConfig)
 {
     for (size_t i = 0 ; i < ARRAYLEN(spiDefaultConfig) ; i++) {
         const spiDefaultConfig_t *defconf = &spiDefaultConfig[i];
-        spiPinConfig->ioTagSck[defconf->device] = defconf->sck;
-        spiPinConfig->ioTagMiso[defconf->device] = defconf->miso;
-        spiPinConfig->ioTagMosi[defconf->device] = defconf->mosi;
+        spiPinConfig[defconf->device].ioTagSck = defconf->sck;
+        spiPinConfig[defconf->device].ioTagMiso = defconf->miso;
+        spiPinConfig[defconf->device].ioTagMosi = defconf->mosi;
     }
 }
 #endif

--- a/src/main/pg/bus_spi.h
+++ b/src/main/pg/bus_spi.h
@@ -26,9 +26,9 @@
 #include "pg/pg.h"
 
 typedef struct spiPinConfig_s {
-    ioTag_t ioTagSck[SPIDEV_COUNT];
-    ioTag_t ioTagMiso[SPIDEV_COUNT];
-    ioTag_t ioTagMosi[SPIDEV_COUNT];
+    ioTag_t ioTagSck;
+    ioTag_t ioTagMiso;
+    ioTag_t ioTagMosi;
 } spiPinConfig_t;
 
-PG_DECLARE(spiPinConfig_t, spiPinConfig);
+PG_DECLARE_ARRAY(spiPinConfig_t, SPIDEV_COUNT, spiPinConfig);

--- a/src/main/target/ALIENFLIGHTF3/initialisation.c
+++ b/src/main/target/ALIENFLIGHTF3/initialisation.c
@@ -35,10 +35,10 @@ extern void spiPreInit(void);
 void targetBusInit(void)
 {
     if (hardwareRevision == AFF3_REV_2) {
-        spiPinConfigure(spiPinConfig());
+        spiPinConfigure(spiPinConfig(0));
         spiPreInit();
         spiInit(SPIDEV_3);
     }
-    i2cHardwareConfigure(i2cConfig());
+    i2cHardwareConfigure(i2cConfig(0));
     i2cInit(I2CDEV_2);
 }

--- a/src/main/target/CJMCU/initialisation.c
+++ b/src/main/target/CJMCU/initialisation.c
@@ -35,14 +35,14 @@ extern void spiPreInit(void); // XXX In fc/fc_init.c
 void targetBusInit(void)
 {
 #if defined(USE_SPI) && defined(USE_SPI_DEVICE_1)
-    spiPinConfigure(spiPinConfig());
+    spiPinConfigure(spiPinConfig(0));
     spiPreInit();
     spiInit(SPIDEV_1);
 #endif
 
     if (!doesConfigurationUsePort(SERIAL_PORT_USART3)) {
         serialRemovePort(SERIAL_PORT_USART3);
-        i2cHardwareConfigure(i2cConfig());
+        i2cHardwareConfigure(i2cConfig(0));
         i2cInit(I2C_DEVICE);
     }
 }

--- a/src/main/target/COLIBRI_RACE/target.c
+++ b/src/main/target/COLIBRI_RACE/target.c
@@ -59,13 +59,13 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 void targetBusInit(void)
 {
 #ifdef USE_SPI
-    spiPinConfigure(spiPinConfig());
+    spiPinConfigure(spiPinConfig(0));
 #ifdef USE_SPI_DEVICE_1
     spiInit(SPIDEV_1);
 #endif
 #endif
 
-    i2cHardwareConfigure(i2cConfig());
+    i2cHardwareConfigure(i2cConfig(0));
     i2cInit(I2CDEV_2);
 
     bstInit(BST_DEVICE);

--- a/src/main/target/NAZE/initialisation.c
+++ b/src/main/target/NAZE/initialisation.c
@@ -36,7 +36,7 @@ extern void spiPreInit(void); // XXX In fc/fc_init.c
 void targetBusInit(void)
 {
 #ifdef USE_SPI
-    spiPinConfigure(spiPinConfig());
+    spiPinConfigure(spiPinConfig(0));
     spiPreInit();
 #ifdef USE_SPI_DEVICE_2
     spiInit(SPIDEV_2);
@@ -48,11 +48,11 @@ void targetBusInit(void)
 
         if (!doesConfigurationUsePort(SERIAL_PORT_USART3)) {
             serialRemovePort(SERIAL_PORT_USART3);
-            i2cHardwareConfigure(i2cConfig());
+            i2cHardwareConfigure(i2cConfig(0));
             i2cInit(I2C_DEVICE);
         }
     } else {
-        i2cHardwareConfigure(i2cConfig());
+        i2cHardwareConfigure(i2cConfig(0));
         i2cInit(I2C_DEVICE);
     }
 }


### PR DESCRIPTION
Multi-resource handling in CLI assumes iotags are stored in an array of `ioTag_t`, which is not a structure that is always preferred.

This PR extends the `cliResourceValue_t` with `stride` member that tells how far each iotags are separated from each other.

`spiPinConfig_t` and `i2cConfig_t` was converted to array style as an example.