### PR TITLE
Fix numeric overflow for gyro calibration samples when using 32KHz sampling

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -98,7 +98,7 @@ static bool gyroHasOverflowProtection = true;
 typedef struct gyroCalibration_s {
     int32_t sum[XYZ_AXIS_COUNT];
     stdev_t var[XYZ_AXIS_COUNT];
-    uint16_t calibratingG;
+    uint32_t calibratingG;
 } gyroCalibration_t;
 
 bool firstArmingCalibrationWasStarted = false;
@@ -872,7 +872,7 @@ static bool isOnFinalGyroCalibrationCycle(const gyroCalibration_t *gyroCalibrati
     return gyroCalibration->calibratingG == 1;
 }
 
-static uint16_t gyroCalculateCalibratingCycles(void)
+static uint32_t gyroCalculateCalibratingCycles(void)
 {
     return (CALIBRATING_GYRO_TIME_US / gyro.targetLooptime);
 }


### PR DESCRIPTION
The current data type was uint16 and that would overflow when using 32KHz sampling.  This caused the calibration to only run for about 0.9 seconds instead of the expected 3 seconds.  At 32KHz the sample count is 96774 which overflows uint16.  This fix changes the data types to uint32.