### PR TITLE
Break out rc interpolation as a separate task and run before pid controller and motor update

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -905,8 +905,6 @@ static NOINLINE void subTaskMainSubprocesses(timeUs_t currentTimeUs)
         rcCommand[THROTTLE] += calculateThrottleAngleCorrection(throttleCorrectionConfig()->throttle_correction_value);
     }
 
-    processRcCommand();
-
 #ifdef USE_SDCARD
     afatfs_poll();
 #endif
@@ -958,6 +956,12 @@ static void subTaskMotorUpdate(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_PIDLOOP, 2, micros() - startTime);
 }
 
+static void subTaskRcCommand(timeUs_t currentTimeUs)
+{
+    processRcCommand();
+    UNUSED(currentTimeUs);
+}
+
 // Function for loop trigger
 FAST_CODE void taskMainPidLoop(timeUs_t currentTimeUs)
 {
@@ -976,6 +980,7 @@ FAST_CODE void taskMainPidLoop(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_PIDLOOP, 0, micros() - currentTimeUs);
 
     if (pidUpdateCounter++ % pidConfig()->pid_process_denom == 0) {
+        subTaskRcCommand(currentTimeUs);
         subTaskPidController(currentTimeUs);
         subTaskMotorUpdate(currentTimeUs);
         subTaskMainSubprocesses(currentTimeUs);


### PR DESCRIPTION
Fixes #5759 

Fixes an issue with motor "spikes" when rc interpolation was enabled for throttle. The problem was that the smoothing was happening too late in the sequence and the earlier process `subTaskMotorUpdate()` would use the un-smoothed throttle value in the mixer if new rx data had come in between the last and current PID loop.  So the mixer would use the large step in the rc data for the first loop after new data came in causing the spike.

Also because the setPointRate was calculated at the end of the smoothing, the PID controller would always be using the value from the previous loop iteration.

It looks like the problem has existed for a while but was relatively rare because it required a specific timing between the PID loop and the receipt of new rx data.  However it looks like changes implemented in #5764 accidentally exposed it to happening more frequently but the exact reason is unknown.
