### PR TITLE
Fix gyro calibration zero offset calculation

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -933,7 +933,7 @@ STATIC_UNIT_TESTED void performGyroCalibration(gyroSensor_t *gyroSensor, uint8_t
             }
 
             // please take care with exotic boardalignment !!
-            gyroSensor->gyroDev.gyroZero[axis] = gyroSensor->calibration.sum[axis] / gyroCalculateCalibratingCycles();
+            gyroSensor->gyroDev.gyroZero[axis] = (float)gyroSensor->calibration.sum[axis] / (float)gyroCalculateCalibratingCycles();
             if (axis == Z) {
               gyroSensor->gyroDev.gyroZero[axis] -= ((float)gyroConfig()->gyro_offset_yaw / 100);
             }


### PR DESCRIPTION
Fixes #5906

It seems like the gyro calibration sample count overflow fix (#5898) caused a downstream problem with the math to calculate the zero offset.  Casting the components of the formula to (float) solves the problem.