### PR TITLE
Linear Buffer for CRSF CMS display port

### DIFF
--- a/src/main/interface/crsf_protocol.h
+++ b/src/main/interface/crsf_protocol.h
@@ -52,15 +52,20 @@ typedef enum {
     CRSF_FRAMETYPE_MSP_REQ = 0x7A,   // response request using msp sequence as command
     CRSF_FRAMETYPE_MSP_RESP = 0x7B,  // reply with 58 byte chunked binary
     CRSF_FRAMETYPE_MSP_WRITE = 0x7C,  // write with 8 byte chunked binary (OpenTX outbound telemetry buffer limit)
-    CRSF_FRAMETYPE_DISPLAYPORT_UPDATE = 0x7D, // transmit displayport buffer to remote
-    CRSF_FRAMETYPE_DISPLAYPORT_CLEAR = 0x7E, // clear remote
-    CRSF_FRAMETYPE_DISPLAYPORT_CMD = 0x7F, // client request
+    CRSF_FRAMETYPE_DISPLAYPORT_CMD = 0x7D, // displayport control command
 } crsfFrameType_e;
 
 enum {
-    CRSF_DISPLAYPORT_SUBCMD_OPEN = 0x01,  // client request to open cms menu
-    CRSF_DISPLAYPORT_SUBCMD_CLOSE = 0x02,  // client request to close cms menu
-    CRSF_DISPLAYPORT_SUBCMD_POLL = 0x03,  // client request to poll/refresh cms menu
+    CRSF_DISPLAYPORT_SUBCMD_UPDATE = 0x01, // transmit displayport buffer to remote
+    CRSF_DISPLAYPORT_SUBCMD_CLEAR = 0X02, // clear client screen
+    CRSF_DISPLAYPORT_SUBCMD_OPEN = 0x03,  // client request to open cms menu
+    CRSF_DISPLAYPORT_SUBCMD_CLOSE = 0x04,  // client request to close cms menu
+    CRSF_DISPLAYPORT_SUBCMD_POLL = 0x05,  // client request to poll/refresh cms menu
+};
+
+enum {
+    CRSF_DISPLAYPORT_OPEN_ROWS_OFFSET = 1,
+    CRSF_DISPLAYPORT_OPEN_COLS_OFFSET = 2,
 };
 
 enum {

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -949,12 +949,6 @@ const clivalue_t valueTable[] = {
     { "displayport_msp_row_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -3, 0 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, rowAdjust) },
 #endif
 
-// PG_DISPLAY_PORT_CRSF_CONFIG
-#if defined(USE_CRSF_CMS_TELEMETRY)
-    { "displayport_crsf_col_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -8, 0 }, PG_DISPLAY_PORT_CRSF_CONFIG, offsetof(displayPortProfile_t, colAdjust) },
-    { "displayport_crsf_row_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -3, 0 }, PG_DISPLAY_PORT_CRSF_CONFIG, offsetof(displayPortProfile_t, rowAdjust) },
-#endif
-
 // PG_DISPLAY_PORT_MSP_CONFIG
 #ifdef USE_MAX7456
     { "displayport_max7456_col_adjust", VAR_INT8| MASTER_VALUE, .config.minmax = { -6, 0 }, PG_DISPLAY_PORT_MAX7456_CONFIG, offsetof(displayPortProfile_t, colAdjust) },

--- a/src/main/io/displayport_crsf.h
+++ b/src/main/io/displayport_crsf.h
@@ -20,23 +20,19 @@
 
 #pragma once
 
-#include "pg/pg.h"
 #include "drivers/display.h"
 
-#define CRSF_DISPLAY_PORT_ROWS_MAX 8
-#define CRSF_DISPLAY_PORT_COLS_MAX 32
-
-typedef struct crsfDisplayPortRow_s {
-    char data[CRSF_DISPLAY_PORT_COLS_MAX];
-    bool pendingTransport;
-} crsfDisplayPortRow_t;
+#define CRSF_DISPLAY_PORT_ROWS_MAX          9
+#define CRSF_DISPLAY_PORT_COLS_MAX          32
+#define CRSF_DISPLAY_PORT_MAX_BUFFER_SIZE   (CRSF_DISPLAY_PORT_ROWS_MAX * CRSF_DISPLAY_PORT_COLS_MAX)
 
 typedef struct crsfDisplayPortScreen_s {
-    crsfDisplayPortRow_t rows[CRSF_DISPLAY_PORT_ROWS_MAX];
+    char buffer[CRSF_DISPLAY_PORT_MAX_BUFFER_SIZE];
+    bool pendingTransport[CRSF_DISPLAY_PORT_ROWS_MAX];
+    uint8_t rows;
+    uint8_t cols;
     bool reset;
 } crsfDisplayPortScreen_t;
-
-PG_DECLARE(displayPortProfile_t, displayPortProfileCrsf);
 
 struct displayPort_s;
 struct displayPort_s *displayPortCrsfInit(void);
@@ -45,3 +41,4 @@ void crsfDisplayPortMenuOpen(void);
 void crsfDisplayPortMenuExit(void);
 void crsfDisplayPortRefresh(void);
 int crsfDisplayPortNextRow(void);
+void crsfDisplayPortSetDimensions(uint8_t rows, uint8_t cols);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -127,7 +127,7 @@
 #define PG_PINIOBOX_CONFIG 530
 #define PG_USB_CONFIG 531
 #define PG_SDIO_CONFIG 532
-#define PG_DISPLAY_PORT_CRSF_CONFIG 533
+#define PG_DISPLAY_PORT_CRSF_CONFIG 533  // no longer required -- never released
 #define PG_TIMER_IO_CONFIG 534 // used to store the index for timer use in timerHardware array in target.c
 #define PG_BETAFLIGHT_END 534
 

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -159,21 +159,23 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
                     {
 #if defined(USE_MSP_OVER_TELEMETRY)
                         case CRSF_FRAMETYPE_MSP_REQ:
-                        case CRSF_FRAMETYPE_MSP_WRITE: ;
+                        case CRSF_FRAMETYPE_MSP_WRITE: {
                             uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_ORIGIN_DEST_SIZE;
                             if (bufferCrsfMspFrame(frameStart, CRSF_FRAME_RX_MSP_FRAME_SIZE)) {
                                 crsfScheduleMspResponse();
                             }
                             break;
+                        }
 #endif
                         case CRSF_FRAMETYPE_DEVICE_PING:
                             crsfScheduleDeviceInfoResponse();
                             break;
 #if defined(USE_CRSF_CMS_TELEMETRY)
-                        case CRSF_FRAMETYPE_DISPLAYPORT_CMD: ;
-                            uint8_t *cmd = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_ORIGIN_DEST_SIZE;
-                            crsfProcessDisplayPortCmd(*cmd);
+                        case CRSF_FRAMETYPE_DISPLAYPORT_CMD: {
+                            uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_ORIGIN_DEST_SIZE;
+                            crsfProcessDisplayPortCmd(frameStart);
                             break;
+                        }
 #endif
                         default:
                             break;

--- a/src/main/telemetry/crsf.h
+++ b/src/main/telemetry/crsf.h
@@ -36,7 +36,7 @@ void crsfScheduleDeviceInfoResponse(void);
 void crsfScheduleMspResponse(void);
 int getCrsfFrame(uint8_t *frame, crsfFrameType_e frameType);
 #if defined(USE_CRSF_CMS_TELEMETRY)
-void crsfProcessDisplayPortCmd(uint8_t cmd);
+void crsfProcessDisplayPortCmd(uint8_t *frameStart);
 #endif
 #if defined(USE_MSP_OVER_TELEMETRY)
 void initCrsfMspBuffer(void);


### PR DESCRIPTION
Converted CRSF CMS Display Port buffer to a linear design instead of nested structs.  Improved the `CRSF_DISPLAYPORT_SUBCMD_OPEN` request to permit the remote to provide the screen size instead of using CLI-based offsets.  When a remote requests to open the display port, sending `<CRSF_DISPLAYPORT_SUBCMD_OPEN><RowCount><ColumnCount>` will configure the buffer and CMS output accordingly.

An additional PR is being opened on the betaflight-crsf-tx-scripts repo that contains the LUA change for this update. 