### PR TITLE
Make gyro calibration period user configurable and rename moron_threshold

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -447,7 +447,8 @@ const clivalue_t valueTable[] = {
     { "gyro_lma_depth",             VAR_UINT8  | MASTER_VALUE, .config.minmax = {0, 11}, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lma_depth)},
     { "gyro_lma_weight",            VAR_UINT8  | MASTER_VALUE, .config.minmax = {0, 100}, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lma_weight)},
 
-    { "moron_threshold",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold) },
+    { "gyro_calib_duration",        VAR_UINT16 | MASTER_VALUE, .config.minmax = { 50,  3000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroCalibrationDuration) },
+    { "gyro_calib_noise_limit",     VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold) },
     { "gyro_offset_yaw",            VAR_INT16  | MASTER_VALUE, .config.minmax = { -1000, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_offset_yaw) },
 #ifdef USE_GYRO_OVERFLOW_CHECK
     { "gyro_overflow_detect",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_OVERFLOW_CHECK }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, checkOverflow) },

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -187,6 +187,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 2);
 
 PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
     .gyro_align = ALIGN_DEFAULT,
+    .gyroCalibrationDuration = 125,        // 1.25 seconds
     .gyroMovementCalibrationThreshold = 48,
     .gyro_sync_denom = GYRO_SYNC_DENOM_DEFAULT,
     .gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL,
@@ -877,7 +878,7 @@ static bool isOnFinalGyroCalibrationCycle(const gyroCalibration_t *gyroCalibrati
 
 static int32_t gyroCalculateCalibratingCycles(void)
 {
-    return (CALIBRATING_GYRO_TIME_US / gyro.targetLooptime);
+    return (gyroConfig()->gyroCalibrationDuration * 10000) / gyro.targetLooptime;
 }
 
 static bool isOnFirstGyroCalibrationCycle(const gyroCalibration_t *gyroCalibration)

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -105,6 +105,8 @@ typedef struct gyroConfig_s {
     bool     yaw_spin_recovery;
     int16_t  yaw_spin_threshold;
 
+    uint16_t gyroCalibrationDuration;  // Gyro calibration duration in 1/100 second
+
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/main/sensors/sensors.h
+++ b/src/main/sensors/sensors.h
@@ -43,7 +43,6 @@ typedef union flightDynamicsTrims_u {
     flightDynamicsTrims_def_t values;
 } flightDynamicsTrims_t;
 
-#define CALIBRATING_GYRO_TIME_US            3000000
 #define CALIBRATING_ACC_CYCLES              400
 #define CALIBRATING_BARO_CYCLES             200 // 10 seconds init_delay + 200 * 25 ms = 15 seconds before ground pressure settles
 


### PR DESCRIPTION
Gryo calibration period can be configured in 1/100 second intervals using `gyro_calib_duration` (default is 125 or 1.25 seconds).  Configurable range is from 50 - 3000 (0.5 to 30 seconds).

Renamed the `moron_threshold` parameter to `gyro_calib_noise_limit`. Functionally it is unchanged.