### PR TITLE
Replaced PCRE with egrep for macOS users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -477,7 +477,7 @@ test junittest:
 
 check-target-independence:
 	$(V1) for test_target in $(VALID_TARGETS); do \
-		FOUND=$$(grep -rP "\W$${test_target}\W?" src/main/ | grep -vP "(\/\/)|(\/\*).*\W$${test_target}\W?" | grep -vP "^src/main/target"); \
+		FOUND=$$(grep -rE "\W$${test_target}\W?" src/main | grep -vE "(//)|(/\*).*\W$${test_target}\W?" | grep -vE "^src/main/target"); \
 		if [ "$${FOUND}" != "" ]; then \
 			echo "Target dependencies found:"; \
 			echo "$${FOUND}"; \


### PR DESCRIPTION
macOS comes with a non-GNU (BSD) grep which has no perl-compatible regular expressions support.
Fortunately, we're not using PCRE features like lazy quantifiers, hence I could replace them with `grep -E` (`egrep`).