### PR TITLE
Apply NOINLINE conditionally on ITCM presence

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -886,7 +886,7 @@ static void subTaskPidController(timeUs_t currentTimeUs)
 #endif
 }
 
-static NOINLINE void subTaskMainSubprocesses(timeUs_t currentTimeUs)
+static FAST_CODE_NOINLINE void subTaskMainSubprocesses(timeUs_t currentTimeUs)
 {
     uint32_t startTime = 0;
     if (debugMode == DEBUG_PIDLOOP) {

--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -180,7 +180,7 @@ static void checkForThrottleErrorResetState(uint16_t rxRefreshRate)
     }
 }
 
-FAST_CODE NOINLINE void processRcCommand(void)
+FAST_CODE FAST_CODE_NOINLINE void processRcCommand(void)
 {
     static float rcCommandInterp[4];
     static float rcStepSize[4];
@@ -266,7 +266,7 @@ FAST_CODE NOINLINE void processRcCommand(void)
     }
 }
 
-FAST_CODE NOINLINE void updateRcCommands(void)
+FAST_CODE FAST_CODE_NOINLINE void updateRcCommands(void)
 {
     // PITCH & ROLL only dynamic PID adjustment,  depending on throttle value
     int32_t prop;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -735,7 +735,7 @@ float applyThrottleLimit(float throttle)
     return throttle;
 }
 
-NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
+FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
 {
     if (isFlipOverAfterCrashMode()) {
         applyFlipOverAfterCrashModeToMotors();

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -38,7 +38,7 @@ int main(void)
     return 0;
 }
 
-void FAST_CODE NOINLINE run(void)
+void FAST_CODE FAST_CODE_NOINLINE run(void)
 {
     while (true) {
         scheduler();

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -972,7 +972,7 @@ FAST_CODE int32_t gyroSlewLimiter(gyroSensor_t *gyroSensor, int axis)
 #endif
 
 #ifdef USE_GYRO_OVERFLOW_CHECK
-static NOINLINE void handleOverflow(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs)
+static FAST_CODE_NOINLINE void handleOverflow(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs)
 {
     const float gyroOverflowResetRate = GYRO_OVERFLOW_RESET_THRESHOLD * gyroSensor->gyroDev.scale;
     if ((abs(gyro.gyroADCf[X]) < gyroOverflowResetRate)
@@ -1024,7 +1024,7 @@ static FAST_CODE void checkForOverflow(gyroSensor_t *gyroSensor, timeUs_t curren
 #endif // USE_GYRO_OVERFLOW_CHECK
 
 #ifdef USE_YAW_SPIN_RECOVERY
-static NOINLINE void handleYawSpin(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs)
+static FAST_CODE_NOINLINE void handleYawSpin(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs)
 {
     const float yawSpinResetRate = gyroConfig()->yaw_spin_threshold - 100.0f;
     if (abs(gyro.gyroADCf[Z]) < yawSpinResetRate) {
@@ -1062,7 +1062,7 @@ static FAST_CODE void checkForYawSpin(gyroSensor_t *gyroSensor, timeUs_t current
 }
 #endif // USE_YAW_SPIN_RECOVERY
 
-static FAST_CODE NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs)
+static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs)
 {
     if (!gyroSensor->gyroDev.readFn(&gyroSensor->gyroDev)) {
         return;

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -96,8 +96,10 @@
 
 #ifdef USE_ITCM_RAM
 #define FAST_CODE                   __attribute__((section(".tcm_code")))
+#define FAST_CODE_NOINLINE          NOINLINE
 #else
 #define FAST_CODE
+#define FAST_CODE_NOINLINE
 #endif // USE_ITCM_RAM
 
 #ifdef USE_FAST_RAM

--- a/src/main/target/common_osd_slave.h
+++ b/src/main/target/common_osd_slave.h
@@ -60,6 +60,7 @@
 #endif
 
 #define FAST_CODE
+#define FAST_CODE_NOINLINE
 #define FAST_RAM_ZERO_INIT
 #define FAST_RAM
 

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -27,6 +27,7 @@
 
 #define NOINLINE
 #define FAST_CODE
+#define FAST_CODE_NOINLINE
 #define FAST_RAM_ZERO_INIT
 #define FAST_RAM
 


### PR DESCRIPTION
Added `FAST_CODE_NOINLINE` storage attribute defined to `NOINLINE` conditionally on `USE_ITCM_RAM`.

This change ensures no penalty for targets having no fast executable RAM due to inlining restrictions.