### PR TITLE
Add missing RTH debug mode to debug.c

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -68,4 +68,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "CURRENT_SENSOR",
     "USB",
     "SMARTAUDIO",
+    "RTH",
 };


### PR DESCRIPTION
As part of #5899 debugging was added under the enum DEBUG_RTH but it was never added to the list of debug_mode values. This would prevent the debugging from working and would misalign any future debugging modes.
