### PR TITLE
Add new target FOXEERF405

### DIFF
--- a/docs/boards/Board - FOXEERF405.md
+++ b/docs/boards/Board - FOXEERF405.md
@@ -1,0 +1,21 @@
+# Board - FOXEERF405
+
+The FOXEERF405  described here:
+
+This board use the STM32F405RGT6 microcontroller and have the following features:
+* 1024K bytes of flash memory,192K bytes RAM,168 MHz CPU/210 DMIPS
+* The 16M byte SPI flash for data logging
+* USB VCP and boot select button on board(for DFU)
+* Stable voltage regulation,9V/2A DCDC BEC for VTX/camera etc.And could select 5v/9v with pad
+* Serial LED interface(LED_STRIP)
+* VBAT/CURR/RSSI sensors input
+* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
+* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
+* Supports I2C device extend(baro/compass/OLED etc)
+* Supports GPS 
+* Supports MPU6000 or ICM20689
+
+
+
+
+

--- a/src/main/target/FOXEERF405/target.c
+++ b/src/main/target/FOXEERF405/target.c
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM12, CH2, PB15,  TIM_USE_PPM,   0, 0), // PPM
+
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0),   // S1 (1,7)
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_MOTOR, 0, 0),   // S2 (1,4)
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MOTOR, 0, 0),    // S3 (2,4)
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_MOTOR, 0, 0),   // S4 (2,7)  
+    DEF_TIM(TIM8, CH1, PC6,  TIM_USE_MOTOR, 0, 0),   // S5 (2,2) 
+    DEF_TIM(TIM8, CH2, PC7,  TIM_USE_MOTOR, 0, 0),   // S6 (2,3)
+
+
+    DEF_TIM(TIM1, CH3, PA10,  TIM_USE_LED, 0, 0),    // LED STRIP(2,6)
+
+    DEF_TIM(TIM2, CH2, PB3,  TIM_USE_PWM, 0, 0),     // FC CAM	
+	
+};

--- a/src/main/target/FOXEERF405/target.h
+++ b/src/main/target/FOXEERF405/target.h
@@ -1,0 +1,164 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "FXF4"
+#define USBD_PRODUCT_STRING  "FOXEERF405"
+//----------------------------------------
+
+//LED & BEE------------------------------- 
+#define LED0_PIN                PC15
+
+#define USE_BEEPER
+#define BEEPER_PIN              PA4
+#define BEEPER_INVERTED
+
+//define camera control
+#define CAMERA_CONTROL_PIN PB3
+
+//Gyro & ACC------------------------------- 
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_EXTI
+#define MPU_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define USE_GYRO
+#define USE_ACC
+//------ICM20689
+#define ICM20689_CS_PIN          PB2 
+#define ICM20689_SPI_INSTANCE    SPI1
+
+#define USE_GYRO_SPI_ICM20689
+#define GYRO_ICM20689_ALIGN      CW90_DEG
+
+#define USE_ACC_SPI_ICM20689
+#define ACC_ICM20689_ALIGN       CW90_DEG
+//------MPU6000
+#define MPU6000_CS_PIN           PB2 
+#define MPU6000_SPI_INSTANCE     SPI1
+
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW90_DEG
+
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN       CW90_DEG
+
+//Baro & MAG------------------------------- 
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB8      
+#define I2C1_SDA                PB9 
+
+//ON BOARD FLASH -----------------------------------
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PC3
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PB12
+#define M25P16_SPI_INSTANCE     SPI2
+
+//GPS ----------------------------------------------
+#define USE_GPS
+#define USE_GPS_UBLOX
+#define USE_GPS_NMEA
+//OSD ----------------------------------------------
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11 
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PA15 
+
+//UART ----------------------------------------------
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PB7
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5   
+#define UART5_RX_PIN            PD2  
+#define UART5_TX_PIN            PC12  
+
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+#define SERIAL_PORT_COUNT       8
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+
+//ADC ----------------------------------------------
+#define USE_ADC
+#define ADC1_DMA_STREAM         DMA2_Stream0
+#define VBAT_ADC_PIN            PC0
+#define CURRENT_METER_ADC_PIN   PC1
+#define RSSI_ADC_PIN            PA0  //TIM5_CH1 & UART4_TX & TELEMETRY & FPORT
+ 
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+#define CURRENT_METER_SCALE_DEFAULT     166
+
+#define ENABLE_DSHOT_DMAR       true
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN PA3
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+
+#define USABLE_TIMER_CHANNEL_COUNT 9
+#define USED_TIMERS             (TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(8)|TIM_N(12))
+
+
+

--- a/src/main/target/FOXEERF405/target.h
+++ b/src/main/target/FOXEERF405/target.h
@@ -83,8 +83,8 @@
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-#define M25P16_CS_PIN           PB12
-#define M25P16_SPI_INSTANCE     SPI2
+#define FLASH_CS_PIN            PB12
+#define FLASH_SPI_INSTANCE      SPI2
 
 //GPS ----------------------------------------------
 #define USE_GPS

--- a/src/main/target/FOXEERF405/target.h
+++ b/src/main/target/FOXEERF405/target.h
@@ -158,7 +158,7 @@
 
 
 #define USABLE_TIMER_CHANNEL_COUNT 9
-#define USED_TIMERS             (TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(8)|TIM_N(12))
+#define USED_TIMERS             (TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(8)|TIM_N(12))
 
 
 

--- a/src/main/target/FOXEERF405/target.mk
+++ b/src/main/target/FOXEERF405/target.mk
@@ -1,0 +1,11 @@
+F405_TARGETS   += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+TARGET_SRC = \
+            drivers/accgyro/accgyro_spi_icm20689.c \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms5611.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/max7456.c
+			


### PR DESCRIPTION
Board - FOXEERF405

This board use the STM32F405RGT6 microcontroller and have the following features:
* 1024K bytes of flash memory,192K bytes RAM,168 MHz CPU/210 DMIPS
* The 16M byte SPI flash for data logging
* USB VCP and boot select button on board(for DFU)
* Stable voltage regulation,9V/2A DCDC BEC for VTX/camera etc.And could select 5v/9v with pad
* Serial LED interface(LED_STRIP)
* VBAT/CURR/RSSI sensors input
* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
* Supports I2C device extend(baro/compass/OLED etc)
* Supports GPS
* Supports MPU6000 or ICM20689
![1](https://user-images.githubusercontent.com/20869563/40410062-57fef13e-5e9f-11e8-8472-9cee4e44f985.jpg)
![2](https://user-images.githubusercontent.com/20869563/40410068-5c735e26-5e9f-11e8-888a-78a477c268b4.jpg)

