### PR TITLE
.fastram_data doesn't fit in FLASH section

### DIFF
--- a/src/main/target/link/stm32_flash_split.ld
+++ b/src/main/target/link/stm32_flash_split.ld
@@ -149,7 +149,7 @@ SECTIONS
 
     . = ALIGN(4);
     _efastram_data = .;        /* define a global symbol at data end */
-  } >FASTRAM AT> FLASH
+  } >FASTRAM AT> FLASH1
 
   . = ALIGN(4);
   .fastram_bss (NOLOAD) :


### PR DESCRIPTION
#5939 places `.fastram_data` in `FLASH` (not `FLASH1`), causing it overflowing with the "Always dual gyro" branch.

This PR place will place it in `FLASH1`.

There are other initializing data in `FLASH`; are they intentional?

```
Linking OMNIBUSF4SD 
Memory region         Used Size  Region Size  %age Used
           FLASH:       19816 B        16 KB    120.95%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      331496 B       992 KB     32.63%
   SYSTEM_MEMORY:          0 GB        29 KB      0.00%
             RAM:       69096 B       128 KB     52.72%
             CCM:       12956 B        64 KB     19.77%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB       nan%
arm-none-eabi/bin/ld: obj/main/betaflight_OMNIBUSF4SD.elf section `.fastram_data' will not fit in region `FLASH'
arm-none-eabi/bin/ld: region `FLASH' overflowed by 3432 bytes
collect2: error: ld returned 1 exit status
```