### PR TITLE
If P and FF have same sign take larger one

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -638,13 +638,13 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             pidData[axis].D = pidCoefficient[axis].Kd * delta * tpaFactor;
 
 
-            const float pid_ff =
+            const float pidFeedForward =
                 pidCoefficient[axis].Kd * dynCd * transition *
                 (currentPidSetpoint - previousPidSetpoint[axis]) * tpaFactor / dT;
-            if ((pidData[axis].P > 0) == (pid_ff > 0)) {
-                if (ABS(pid_ff) > ABS(pidData[axis].P)) {
+            if ((pidData[axis].P > 0) == (pidFeedForward > 0)) {
+                if (ABS(pidFeedForward) > ABS(pidData[axis].P)) {
                     pidData[axis].P = 0;
-                    pidData[axis].D += pid_ff;
+                    pidData[axis].D += pidFeedForward;
                 }
             }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -633,8 +633,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             const float delta =
                 - (gyroRateDterm[axis] - previousGyroRateDterm[axis]) / dT;
 
-            previousPidSetpoint[axis] = currentPidSetpoint;
-
             detectAndSetCrashRecovery(pidProfile->crash_recovery, axis, currentTimeUs, delta, errorRate);
 
             pidData[axis].D = pidCoefficient[axis].Kd * delta * tpaFactor;
@@ -657,6 +655,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                 pidData[axis].D += pidFeedForward;
             }
             previousGyroRateDterm[axis] = gyroRateDterm[axis];
+            previousPidSetpoint[axis] = currentPidSetpoint;
 
 #ifdef USE_YAW_SPIN_RECOVERY
             if (yawSpinActive)  {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -640,19 +640,23 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 
             pidData[axis].D = pidCoefficient[axis].Kd * delta * tpaFactor;
 
-
             const float pidFeedForward =
                 pidCoefficient[axis].Kd * dynCd * transition *
                 (currentPidSetpoint - previousPidSetpoint[axis]) * tpaFactor / dT;
             bool addFeedforward = true;
-            if (smartFeedforward)
+            if (smartFeedforward) {
                 if (pidData[axis].P * pidFeedForward > 0) {
                     if (ABS(pidFeedForward) > ABS(pidData[axis].P)) {
                         pidData[axis].P = 0;
                     }
-                    else addFeedforward = false;
+                    else {
+                        addFeedforward = false;
+                    }
                 }
-            if (addFeedforward) pidData[axis].D += pidFeedForward;
+            }
+            if (addFeedforward) {
+                pidData[axis].D += pidFeedForward;
+            }
 
 #ifdef USE_YAW_SPIN_RECOVERY
             if (yawSpinActive)  {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -634,7 +634,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                 - (gyroRateDterm[axis] - previousGyroRateDterm[axis]) / dT;
 
             previousPidSetpoint[axis] = currentPidSetpoint;
-            previousGyroRateDterm[axis] = gyroRateDterm[axis];
 
             detectAndSetCrashRecovery(pidProfile->crash_recovery, axis, currentTimeUs, delta, errorRate);
 
@@ -657,6 +656,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             if (addFeedforward) {
                 pidData[axis].D += pidFeedForward;
             }
+            previousGyroRateDterm[axis] = gyroRateDterm[axis];
 
 #ifdef USE_YAW_SPIN_RECOVERY
             if (yawSpinActive)  {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -659,7 +659,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
         }
     }
 
-    
     // calculating the PID sum
     pidData[FD_ROLL].Sum = pidData[FD_ROLL].P + pidData[FD_ROLL].I + pidData[FD_ROLL].D;
     pidData[FD_PITCH].Sum = pidData[FD_PITCH].P + pidData[FD_PITCH].I + pidData[FD_PITCH].D;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -641,7 +641,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             const float pidFeedForward =
                 pidCoefficient[axis].Kd * dynCd * transition *
                 (currentPidSetpoint - previousPidSetpoint[axis]) * tpaFactor / dT;
-            if ((pidData[axis].P > 0) == (pidFeedForward > 0)) {
+            if (pidData[axis].P * pidFeedForward > 0) {
                 if (ABS(pidFeedForward) > ABS(pidData[axis].P)) {
                     pidData[axis].P = 0;
                     pidData[axis].D += pidFeedForward;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -114,8 +114,8 @@ typedef struct pidProfile_s {
     uint16_t dterm_lowpass2_hz;                // Extra PT1 Filter on D in hz
     uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
     uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
-    uint8_t  iterm_rotation;                    // rotates iterm to translate world errors to local coordinate system
-    uint8_t  smart_feedforward;
+    uint8_t  iterm_rotation;                // rotates iterm to translate world errors to local coordinate system
+    uint8_t  smart_feedforward;             // takes only the larger of P and the D weight feed forward term if they have the same sign.
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -115,6 +115,7 @@ typedef struct pidProfile_s {
     uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
     uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
     uint8_t  iterm_rotation;                    // rotates iterm to translate world errors to local coordinate system
+    uint8_t  smart_feedforward;
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -752,6 +752,7 @@ const clivalue_t valueTable[] = {
     { "crash_recovery",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRASH_RECOVERY }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery) },
 
     { "iterm_rotation",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_rotation) },
+    { "smart_feedforward",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, smart_feedforward) },
     { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
     { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },


### PR DESCRIPTION
This is a simple change to setpoint weight which allows to use larger weight without overshoot, resulting in a more front-loaded control response. I like it better in every case but could make it configurable if people feel a need.

The feature is enabled on the CLI by setting smart_feedforward=ON.

It's a simple fix, but maybe a bit of background is helpful understanding it. See below from a recent rcgroups chat:

Let me just quickly explain how I see the pid elements, then you'll understand why I find it confusing to look at setpoint weight as making D based on error.

We all know P is proportional to error and should steer the quad to reduce it. D is traditionally proportional to derivative of gyro, so it's proportional to the angular acceleration. For each error there's an acceleration such that P = -D. That's the acceleration the FC steers the quad to. As we can see that acceleration is also proportional to the error. So D and P together steer the quad towards an acceleration towards target rate which linearly approaches zero as the quad hits target rate. That's D's damping function. But then if the error widens D also adds impetus and thus helps stop external disturbances in the early stages when P isn't big yet. That's why high D is good against prop wash.

Now if you write D = Kd * d ( w * SP - G ) / dt [SP = setpoint, G = gyro, w = setpoint weight, Kd = D setting], then you can rewrite that as Kd * w * d SP / dt - Kd * d G / dt. And now we can understand things in the context above: The second part is the traditional D term which dampens and reacts early to outside disturbances. And the first part - lets call it FF - just puts the change in angular velocity as demanded by the movement of your sticks to the pid sum.

Now such an FF makes a lot of sense:

A pid controller is normally purely reactive and doesn't really know much about the system its controlling. But if you know how a system will change due to external influence or control input you can improve it by forwarding a correcting signal directly to the control output. Then the pid only needs to deal with the error in that FF and with external influences. That's typically called feed forward. 

And we know what one would do, too: stick velocity is demanded angular acceleration. And angular acceleration is directly proportional to differential motor speed on an axis. So in the first approximation you'd just add a term to the pids - lets call it FF - which is Kff * d SP / dt.

Wait a minute - that's exactly what we had called FF above with Kff substituted for Kd * w. Cool! So setpoint weight is nothing but a feed forward term with an awkward choice of constant. And it's great to have since it creates pid output way earlier than P could, at the beginning of the stick move. But the size of Kff depends on the characteristics of the quad, such as moment of inertia, motor strength etc. It's not really proportional to Kd in any sense - other than if you chose w as 1 FF and D together are D from error.

And once you look at it that way something else becomes clear: our quad needs to fly well without stick input, so P and D need to be tuned so that that's possible. That means that D is sized exactly right to have the pids close the error on a slow enough path so there's no overshoot once you reach the target rate. But if we now add FF we effectively increase the target acceleration at errors during which both P and FF are active.

That's not really what we wanted. We now need to keep FF and P so small that FF + P against D don't cause overshoot. We might lower P a bit to get enough FF. Or raise D. What we really wanted is just to front load the reaction to stick input and since P comes in late when the error is already big it's now forcing us to get less front loading that we could.

The answer: if we know the pids want P at level x and if FF is already bigger than x, just don't add P. Similarly if P is already larger than FF don't include FF. That way you can use higher Kff and the control response is more front loaded. So in the pidsum just replace P with FF if FF is in the same direction and larger than P.

You can then make Kff bigger without reducing P or increasing D. The benefit is better response to stick, but maintained response to the environment: since you don't need to reduce P to make room for FF without overshoot it's still there to fight disturbances when needed.