### PR TITLE
ITerm relax feature

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -69,4 +69,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "USB",
     "SMARTAUDIO",
     "RTH",
+    "ITERM_RELAX"
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -87,6 +87,7 @@ typedef enum {
     DEBUG_USB,
     DEBUG_SMARTAUDIO,
     DEBUG_RTH,
+    DEBUG_ITERM_RELAX,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -629,20 +629,20 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         // -----calculate I component
         float itermErrorRate;
         if (itermRelax) {
-            const float gyroTargetHigh = pt1FilterApply(&windupLpf[axis][0], currentPidSetpoint);
-            const float gyroTargetLow =  pt1FilterApply(&windupLpf[axis][1], currentPidSetpoint);
+            const float gyroTargetLow = pt1FilterApply(&windupLpf[axis][0], currentPidSetpoint);
+            const float gyroTargetHigh =  pt1FilterApply(&windupLpf[axis][1], currentPidSetpoint);
             DEBUG_SET(DEBUG_ITERM_RELAX, 0, gyroTargetHigh);
             DEBUG_SET(DEBUG_ITERM_RELAX, 1, gyroTargetLow);
             const float gmax = MAX(gyroTargetHigh, gyroTargetLow);
             const float gmin = MIN(gyroTargetHigh, gyroTargetLow);
             if (gyroRate >= gmin && gyroRate <= gmax) {
                 itermErrorRate = 0.0f;
-            }
-            else {
+            } else {
                 itermErrorRate = (gyroRate > gmax ? gmax : gmin ) - gyroRate;
             }
+        } else {
+            itermErrorRate = errorRate;
         }
-        else itermErrorRate = errorRate;
         
         const float ITerm = pidData[axis].I;
         const float ITermNew = constrainf(ITerm + pidCoefficient[axis].Ki * itermErrorRate * dynCi, -itermLimit, itermLimit);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -202,7 +202,7 @@ static FAST_RAM_ZERO_INIT pt1Filter_t dtermLowpass2[2];
 static FAST_RAM_ZERO_INIT filterApplyFnPtr ptermYawLowpassApplyFn;
 static FAST_RAM_ZERO_INIT pt1Filter_t ptermYawLowpass;
 static FAST_RAM_ZERO_INIT pt1Filter_t windupLpf[3][2];
-static FAST_RAM_ZERO_INIT bool itermRelax;
+static FAST_RAM_ZERO_INIT uint8_t itermRelax;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxCutoffLow;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxCutoffHigh;
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -607,7 +607,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
             currentPidSetpoint = 0.0f;
         }
 #endif // USE_YAW_SPIN_RECOVERY
-        
+
         // -----calculate error rate
         const float gyroRate = gyro.gyroADCf[axis]; // Process variable from gyro output in deg/sec
         float errorRate = currentPidSetpoint - gyroRate; // r - y
@@ -635,10 +635,12 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
             DEBUG_SET(DEBUG_ITERM_RELAX, 1, gyroTargetLow);
             const float gmax = MAX(gyroTargetHigh, gyroTargetLow);
             const float gmin = MIN(gyroTargetHigh, gyroTargetLow);
-            if (gyroRate >= gmin && gyroRate <= gmax)
+            if (gyroRate >= gmin && gyroRate <= gmax) {
                 itermErrorRate = 0.0f;
-            else
+            }
+            else {
                 itermErrorRate = (gyroRate > gmax ? gmax : gmin ) - gyroRate;
+            }
         }
         else itermErrorRate = errorRate;
         

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -631,6 +631,8 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         if (itermRelax) {
             const float gyroTargetHigh = pt1FilterApply(&windupLpf[axis][0], currentPidSetpoint);
             const float gyroTargetLow =  pt1FilterApply(&windupLpf[axis][1], currentPidSetpoint);
+            DEBUG_SET(DEBUG_ITERM_RELAX, 0, gyroTargetHigh);
+            DEBUG_SET(DEBUG_ITERM_RELAX, 1, gyroTargetLow);
             const float gmax = MAX(gyroTargetHigh, gyroTargetLow);
             const float gmin = MIN(gyroTargetHigh, gyroTargetLow);
             if (gyroRate >= gmin && gyroRate <= gmax)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -628,7 +628,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
 
         // -----calculate I component
         float itermErrorRate;
-        if (itermRelax) {
+        if (itermRelax && (axis < FD_YAW || itermRelax == 2 )) {
             const float gyroTargetLow = pt1FilterApply(&windupLpf[axis][0], currentPidSetpoint);
             const float gyroTargetHigh =  pt1FilterApply(&windupLpf[axis][1], currentPidSetpoint);
             if (axis < FD_YAW) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -140,7 +140,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .throttle_boost_cutoff = 15,
         .iterm_rotation = false,
         .smart_feedforward = false,
-        .iterm_relax = false,
+        .iterm_relax = ITERM_RELAX_OFF,
         .iterm_relax_cutoff_low = 3,
         .iterm_relax_cutoff_high = 15,
     );
@@ -202,7 +202,7 @@ static FAST_RAM_ZERO_INIT pt1Filter_t dtermLowpass2[2];
 static FAST_RAM_ZERO_INIT filterApplyFnPtr ptermYawLowpassApplyFn;
 static FAST_RAM_ZERO_INIT pt1Filter_t ptermYawLowpass;
 static FAST_RAM_ZERO_INIT pt1Filter_t windupLpf[3][2];
-static FAST_RAM_ZERO_INIT uint8_t itermRelax;
+static FAST_RAM_ZERO_INIT itermRelax_e itermRelax;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxCutoffLow;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxCutoffHigh;
 
@@ -628,7 +628,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
 
         // -----calculate I component
         float itermErrorRate;
-        if (itermRelax && (axis < FD_YAW || itermRelax == 2 )) {
+        if (itermRelax && (axis < FD_YAW || itermRelax == ITERM_RELAX_RPY )) {
             const float gyroTargetLow = pt1FilterApply(&windupLpf[axis][0], currentPidSetpoint);
             const float gyroTargetHigh =  pt1FilterApply(&windupLpf[axis][1], currentPidSetpoint);
             if (axis < FD_YAW) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -631,8 +631,11 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         if (itermRelax) {
             const float gyroTargetLow = pt1FilterApply(&windupLpf[axis][0], currentPidSetpoint);
             const float gyroTargetHigh =  pt1FilterApply(&windupLpf[axis][1], currentPidSetpoint);
-            DEBUG_SET(DEBUG_ITERM_RELAX, 0, gyroTargetHigh);
-            DEBUG_SET(DEBUG_ITERM_RELAX, 1, gyroTargetLow);
+            if (axis < FD_YAW) {
+                int itemOffset = (axis << 1);
+                DEBUG_SET(DEBUG_ITERM_RELAX, itemOffset++, gyroTargetHigh);
+                DEBUG_SET(DEBUG_ITERM_RELAX, itemOffset, gyroTargetLow);
+            }
             const float gmax = MAX(gyroTargetHigh, gyroTargetLow);
             const float gmin = MIN(gyroTargetHigh, gyroTargetLow);
             if (gyroRate >= gmin && gyroRate <= gmax) {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -76,6 +76,15 @@ typedef struct pid8_s {
     uint8_t D;
 } pid8_t;
 
+typedef enum 
+{
+    ITERM_RELAX_OFF,
+    ITERM_RELAX_RP,
+    ITERM_RELAX_RPY
+} itermRelax_e;
+
+    
+
 typedef struct pidProfile_s {
     pid8_t  pid[PID_ITEM_COUNT];
 
@@ -118,7 +127,7 @@ typedef struct pidProfile_s {
     uint8_t  smart_feedforward;             // takes only the larger of P and the D weight feed forward term if they have the same sign.
     uint8_t iterm_relax_cutoff_low;        // Slowest setpoint response to prevent iterm accumulation
     uint8_t iterm_relax_cutoff_high;       // Fastest setpoint response to prevent iterm accumulation
-    uint8_t iterm_relax;                   // Enable iterm suppression during stick input
+    itermRelax_e iterm_relax;                   // Enable iterm suppression during stick input
     
 } pidProfile_t;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -116,6 +116,10 @@ typedef struct pidProfile_s {
     uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
     uint8_t  iterm_rotation;                // rotates iterm to translate world errors to local coordinate system
     uint8_t  smart_feedforward;             // takes only the larger of P and the D weight feed forward term if they have the same sign.
+    uint8_t iterm_relax_cutoff_low;        // Slowest setpoint response to prevent iterm accumulation
+    uint8_t iterm_relax_cutoff_high;       // Fastest setpoint response to prevent iterm accumulation
+    uint8_t iterm_relax;                   // Enable iterm suppression during stick input
+    
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -757,6 +757,9 @@ const clivalue_t valueTable[] = {
 
     { "iterm_rotation",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_rotation) },
     { "smart_feedforward",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, smart_feedforward) },
+    { "iterm_relax",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax) },
+    { "iterm_relax_cutoff_low",     VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff_low) },
+    { "iterm_relax_cutoff_high",     VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff_high) },
     { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
     { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -344,6 +344,11 @@ static const char * const lookupTableVideoSystem[] = {
 };
 #endif // USE_MAX7456
 
+static const char * const lookupTableItermRelax[] = {
+    "OFF", "RP", "RPY"
+};
+
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -418,6 +423,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef USE_MAX7456
     LOOKUP_TABLE_ENTRY(lookupTableVideoSystem),
 #endif // USE_MAX7456
+    LOOKUP_TABLE_ENTRY(lookupTableItermRelax),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -757,9 +763,9 @@ const clivalue_t valueTable[] = {
 
     { "iterm_rotation",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_rotation) },
     { "smart_feedforward",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, smart_feedforward) },
-    { "iterm_relax",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax) },
+    { "iterm_relax",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ITERM_RELAX }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax) },
     { "iterm_relax_cutoff_low",     VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff_low) },
-    { "iterm_relax_cutoff_high",     VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff_high) },
+    { "iterm_relax_cutoff_high",    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff_high) },
     { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
     { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -97,6 +97,7 @@ typedef enum {
 #ifdef USE_MAX7456
     TABLE_VIDEO_SYSTEM,
 #endif // USE_MAX7456
+    TABLE_ITERM_RELAX,
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -298,6 +298,7 @@ pid_unittest_SRC :=  \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
 		$(USER_DIR)/flight/pid.c \
 		$(USER_DIR)/pg/pg.c \
+		$(USER_DIR)/build/debug.c \
 		$(USER_DIR)/fc/runtime_config.c
 
 rcdevice_unittest_DEFINES := \

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -298,7 +298,6 @@ pid_unittest_SRC :=  \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
 		$(USER_DIR)/flight/pid.c \
 		$(USER_DIR)/pg/pg.c \
-		$(USER_DIR)/build/debug.c \
 		$(USER_DIR)/fc/runtime_config.c
 
 rcdevice_unittest_DEFINES := \

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -22,13 +22,16 @@
 
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
-
+#include "build/debug.h"
 
 bool simulateMixerSaturated = false;
 float simulatedSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
 float simulatedThrottlePIDAttenuation = 1.0f;
 float simulatedMotorMixRange = 0.0f;
+
+int16_t debug[DEBUG16_VALUE_COUNT];
+uint8_t debugMode;
 
 extern "C" {
     #include "build/debug.h"


### PR DESCRIPTION
The ITerm accumulates error between setpoint and gyro and applies a proportional correction. This is fine as long as the quad has a realistic chance of following the setpoint. If however the setpoint is moved so quickly that the quad can't catch up the Iterm accumulates an increasing error which leads to a bounce back after quick moves.

Now the ITerm is already windup protected against motor saturation and gradually against the size of the motorMixRange. But there's an important aspect that's still missing:

If you use heavy props, you need a larger kD. That causes the PIDs to slow down the acceleration earlier as the error reduces, to avoid overshoot. That D offsets P and leads to a low motor mix range, thus not reducing iterm accumulation. But just like during motor saturation there's nothing the PIDs can do about it. It's just the fastest the quad can follow the setpoint. The situation isn't helped by bounces at the end of the move: a clean roll end is more important than absolute angle.

Because of the above it's currently not possible to use betaflight with heavy props on light motors: you need a high D to get clean moves, but the resulting slow response to quick setpoint changes leads to intolerably large bounce back.

This PR addresses the issue by defining a range of "ok" paths for the quad following a setpoint change. If the quad stays in that range no iterm will be accumulated. If gyro is outside the allowed band iterm will only be accumulated against the range boundary on which side gyro is violating the band.

The implementation uses two pt1 filters to achieve this. Set iterm_relax=ON to activate. then iterm_relax_cutott_low and iterm_relax_cutott_high are the filter cutoff frequencies which together define the allowed path range for the quad.

