### PR TITLE
Mark crucial inlined functions with FAST_CODE

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -835,7 +835,7 @@ bool processRx(timeUs_t currentTimeUs)
     return true;
 }
 
-static void subTaskPidController(timeUs_t currentTimeUs)
+static FAST_CODE void subTaskPidController(timeUs_t currentTimeUs)
 {
     uint32_t startTime = 0;
     if (debugMode == DEBUG_PIDLOOP) {startTime = micros();}
@@ -951,7 +951,7 @@ static FAST_CODE_NOINLINE void subTaskMainSubprocesses(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_PIDLOOP, 3, micros() - startTime);
 }
 
-static void subTaskMotorUpdate(timeUs_t currentTimeUs)
+static FAST_CODE void subTaskMotorUpdate(timeUs_t currentTimeUs)
 {
     uint32_t startTime = 0;
     if (debugMode == DEBUG_CYCLETIME) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -540,7 +540,7 @@ static void handleItermRotation()
 
 // Betaflight pid controller, which will be maintained in the future with additional features specialised for current (mini) multirotor usage.
 // Based on 2DOF reference design (matlab)
-void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, timeUs_t currentTimeUs)
+void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, timeUs_t currentTimeUs)
 {
     static float previousGyroRateDterm[2];
     static float previousPidSetpoint[2];


### PR DESCRIPTION
To avoid the increasing number of issues like in #5970 I've marked the most crucial functions I could think of as `FAST_CODE`.
They are ending up in ITCM-RAM anyway due to inlining (and that's the intended behaviour), now they're explicitly marked so for better understanding and locality by other contributors.