### PR TITLE
Marked pidAudioUpdate not for inlining

### DIFF
--- a/src/main/io/pidaudio.c
+++ b/src/main/io/pidaudio.c
@@ -64,7 +64,7 @@ void pidAudioSetMode(pidAudioModes_e mode)
     pidAudioMode = mode;
 }
 
-void pidAudioUpdate(void)
+void FAST_CODE_NOINLINE pidAudioUpdate(void)
 {
     bool newState = IS_RC_MODE_ACTIVE(BOXPIDAUDIO);
 


### PR DESCRIPTION
Saves 560 bytes of ITCM-RAM on SPRF7DUAL.
Up for debate.