### PR TITLE
honor report_cell_voltage for DIY frsky modules

### DIFF
--- a/src/main/telemetry/frsky_hub.c
+++ b/src/main/telemetry/frsky_hub.c
@@ -404,6 +404,9 @@ static void sendVoltageAmp(void)
 
     if (telemetryConfig()->frsky_vfas_precision == FRSKY_VFAS_PRECISION_HIGH) {
         // Use new ID 0x39 to send voltage directly in 0.1 volts resolution
+        if (telemetryConfig()->report_cell_voltage && cellCount) {
+            voltage /= cellCount;
+        }
         frSkyHubWriteFrame(ID_VOLTAGE_AMP, voltage);
     } else {
         // send in 0.2 volts resolution


### PR DESCRIPTION
Simple fix to honor report_cell_voltage for DIY frsky modules