### PR TITLE
Cleaned up CLI output generation, added 'cliPrintErrorLinef'.

### DIFF
--- a/src/main/common/printf.h
+++ b/src/main/common/printf.h
@@ -108,7 +108,8 @@ regs Kusti, 23.10.2004
 
 void init_printf(void *putp, void (*putf) (void *, char));
 
-int tfp_printf(const char *fmt, ...);
+// Disabling this, in favour of tfp_format to be used in cli.c
+//int tfp_printf(const char *fmt, ...);
 int tfp_sprintf(char *s, const char *fmt, ...);
 
 int tfp_format(void *putp, void (*putf) (void *, char), const char *fmt, va_list va);


### PR DESCRIPTION
The motivation for `cliPrintErrorLinef` is to return a prominent `###ERROR###` for things that fail when restoring a CLI diff, to make it easier to spot things that have not been restored properly.