### PR TITLE
Reset the entire config when parameter groups have changed.

### DIFF
--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -25,7 +25,7 @@
 
 #define EEPROM_CONF_VERSION 169
 
-bool isEEPROMContentValid(void);
+bool isEEPROMStructureValid(void);
 bool loadEEPROM(void);
 void writeConfigToEEPROM(void);
 uint16_t getEEPROMConfigSize(void);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -454,16 +454,14 @@ void validateAndFixGyroConfig(void)
 }
 #endif // USE_OSD_SLAVE
 
-void readEEPROM(void)
+bool readEEPROM(void)
 {
 #ifndef USE_OSD_SLAVE
     suspendRxSignal();
 #endif
 
     // Sanity check, read flash
-    if (!loadEEPROM()) {
-        failureMode(FAILURE_INVALID_EEPROM_CONTENTS);
-    }
+    bool success = loadEEPROM();
 
     validateAndFixConfig();
     activateConfig();
@@ -471,6 +469,8 @@ void readEEPROM(void)
 #ifndef USE_OSD_SLAVE
     resumeRxSignal();
 #endif
+
+    return success;
 }
 
 void writeEEPROM(void)
@@ -489,12 +489,16 @@ void writeEEPROM(void)
 void resetEEPROM(void)
 {
     resetConfigs();
+
+    validateAndFixConfig();
+    activateConfig();
+
     writeEEPROM();
 }
 
-void ensureEEPROMContainsValidData(void)
+void ensureEEPROMStructureIsValid(void)
 {
-    if (isEEPROMContentValid()) {
+    if (isEEPROMStructureValid()) {
         return;
     }
     resetEEPROM();

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -60,9 +60,9 @@ void setPreferredBeeperOffMask(uint32_t mask);
 
 void initEEPROM(void);
 void resetEEPROM(void);
-void readEEPROM(void);
+bool readEEPROM(void);
 void writeEEPROM(void);
-void ensureEEPROMContainsValidData(void);
+void ensureEEPROMStructureIsValid(void);
 
 void saveConfigAndNotify(void);
 void validateAndFixGyroConfig(void);

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -237,12 +237,13 @@ void init(void)
 
     initEEPROM();
 
-    ensureEEPROMContainsValidData();
-    readEEPROM();
+    ensureEEPROMStructureIsValid();
+    bool readSuccess = readEEPROM();
 
-    // !!TODO: Check to be removed when moving to generic targets
-    if (strncasecmp(systemConfig()->boardIdentifier, TARGET_BOARD_IDENTIFIER, sizeof(TARGET_BOARD_IDENTIFIER))) {
+    if (!readSuccess || strncasecmp(systemConfig()->boardIdentifier, TARGET_BOARD_IDENTIFIER, sizeof(TARGET_BOARD_IDENTIFIER))) {
         resetEEPROM();
+
+        activateConfig();
     }
 
     systemState |= SYSTEM_STATE_CONFIG_LOADED;

--- a/src/main/osd_slave/osd_slave_init.c
+++ b/src/main/osd_slave/osd_slave_init.c
@@ -139,7 +139,7 @@ void init(void)
 
     initEEPROM();
 
-    ensureEEPROMContainsValidData();
+    ensureEEPROMStructureIsValid();
     readEEPROM();
 
     systemState |= SYSTEM_STATE_CONFIG_LOADED;

--- a/src/main/pg/pg.c
+++ b/src/main/pg/pg.c
@@ -72,14 +72,18 @@ bool pgResetCopy(void *copy, pgn_t pgn)
     return false;
 }
 
-void pgLoad(const pgRegistry_t* reg, const void *from, int size, int version)
+bool pgLoad(const pgRegistry_t* reg, const void *from, int size, int version)
 {
     pgResetInstance(reg, pgOffset(reg));
     // restore only matching version, keep defaults otherwise
     if (version == pgVersion(reg)) {
         const int take = MIN(size, pgSize(reg));
         memcpy(pgOffset(reg), from, take);
+
+        return true;
     }
+
+    return false;
 }
 
 int pgStore(const pgRegistry_t* reg, void *to, int size)

--- a/src/main/pg/pg.h
+++ b/src/main/pg/pg.h
@@ -187,7 +187,7 @@ extern const uint8_t __pg_resetdata_end[];
 
 const pgRegistry_t* pgFind(pgn_t pgn);
 
-void pgLoad(const pgRegistry_t* reg, const void *from, int size, int version);
+bool pgLoad(const pgRegistry_t* reg, const void *from, int size, int version);
 int pgStore(const pgRegistry_t* reg, void *to, int size);
 void pgResetAll(void);
 void pgResetInstance(const pgRegistry_t *reg, uint8_t *base);


### PR DESCRIPTION
The rationale for this is that in the current situation, it is not user friendly how changes to parameter groups are handled when the firmware is updated: If the version of individual parameter groups has changed, only the parameter groups in question will be reset, and the rest of the config will be untouched. This leaves it up to the user to figure out that _some but not all_ of his settings have been reset, and then restore the settings.

After this change, whenever a parameter group version is changed, this will result in the entire configuration being reset, making it fail obvious, and removing the potential for a partial reset to result in an unsafe configuration.

Another advantage of this is that it will make it possible to retire the overall EEPROM_VERSION, and eliminate the work needed to manually maintain it,.