### PR TITLE
Fix yaw reset and throttle angle correction to be before rc interpolation

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -910,26 +910,6 @@ static FAST_CODE_NOINLINE void subTaskMainSubprocesses(timeUs_t currentTimeUs)
 #ifdef USE_GPS_RESCUE
     updateGPSRescueState();
 #endif
-    
-    // If we're armed, at minimum throttle, and we do arming via the
-    // sticks, do not process yaw input from the rx.  We do this so the
-    // motors do not spin up while we are trying to arm or disarm.
-    // Allow yaw control for tricopters if the user wants the servo to move even when unarmed.
-    if (isUsingSticksForArming() && rcData[THROTTLE] <= rxConfig()->mincheck
-#ifndef USE_QUAD_MIXER_ONLY
-#ifdef USE_SERVOS
-                && !((mixerConfig()->mixerMode == MIXER_TRI || mixerConfig()->mixerMode == MIXER_CUSTOM_TRI) && servoConfig()->tri_unarmed_servo)
-#endif
-                && mixerConfig()->mixerMode != MIXER_AIRPLANE
-                && mixerConfig()->mixerMode != MIXER_FLYING_WING
-#endif
-    ) {
-        resetYawAxis();
-    }
-
-    if (throttleCorrectionConfig()->throttle_correction_value && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE))) {
-        rcCommand[THROTTLE] += calculateThrottleAngleCorrection(throttleCorrectionConfig()->throttle_correction_value);
-    }
 
 #ifdef USE_SDCARD
     afatfs_poll();
@@ -984,6 +964,27 @@ static FAST_CODE void subTaskMotorUpdate(timeUs_t currentTimeUs)
 
 static void subTaskRcCommand(timeUs_t currentTimeUs)
 {
+
+    // If we're armed, at minimum throttle, and we do arming via the
+    // sticks, do not process yaw input from the rx.  We do this so the
+    // motors do not spin up while we are trying to arm or disarm.
+    // Allow yaw control for tricopters if the user wants the servo to move even when unarmed.
+    if (isUsingSticksForArming() && rcData[THROTTLE] <= rxConfig()->mincheck
+#ifndef USE_QUAD_MIXER_ONLY
+#ifdef USE_SERVOS
+                && !((mixerConfig()->mixerMode == MIXER_TRI || mixerConfig()->mixerMode == MIXER_CUSTOM_TRI) && servoConfig()->tri_unarmed_servo)
+#endif
+                && mixerConfig()->mixerMode != MIXER_AIRPLANE
+                && mixerConfig()->mixerMode != MIXER_FLYING_WING
+#endif
+    ) {
+        resetYawAxis();
+    }
+
+    if (throttleCorrectionConfig()->throttle_correction_value && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE))) {
+        rcCommand[THROTTLE] += calculateThrottleAngleCorrection(throttleCorrectionConfig()->throttle_correction_value);
+    }
+
     processRcCommand();
     UNUSED(currentTimeUs);
 }

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -962,7 +962,7 @@ static FAST_CODE void subTaskMotorUpdate(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_PIDLOOP, 2, micros() - startTime);
 }
 
-static void subTaskRcCommand(timeUs_t currentTimeUs)
+static FAST_CODE_NOINLINE void subTaskRcCommand(timeUs_t currentTimeUs)
 {
 
     // If we're armed, at minimum throttle, and we do arming via the


### PR DESCRIPTION
Fixes #5969 

In #5905 the ordering of rc interpolation processing was moved out of `subTaskMainSubprocesses()` and into a separate `subTaskRcCommand()` process that ran earlier in the PID loop. Previously the logic to handle stick arming yaw reset was immediately before the rc interpolation logic and after the previous change it ran later in the process and after rc interpolation.

This fix moves the related throttle/yaw processing into the `subTaskRcCommand()` before rc interpolation to match the ordering that existed previously.  The fixes introduced by #5905 (throttle spikes) are still retained.

Also changed `subTaskRcCommand()` to be `FAST_CODE_NOINLINE` to match how it was previously when still included in `subTaskMainSubprocesses()`.  Otherwise it was getting inlined and causing extra ITCM_RAM usage.