### PR TITLE
Reduce flash usage in OSD element display logic

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -167,6 +167,39 @@ static const char compassBar[] = {
   SYM_HEADING_LINE, SYM_HEADING_DIVIDED_LINE, SYM_HEADING_LINE
 };
 
+static const uint8_t osdElementDisplayOrder[] = {
+    OSD_MAIN_BATT_VOLTAGE,
+    OSD_RSSI_VALUE,
+    OSD_CROSSHAIRS,
+    OSD_HORIZON_SIDEBARS,
+    OSD_ITEM_TIMER_1,
+    OSD_ITEM_TIMER_2,
+    OSD_REMAINING_TIME_ESTIMATE,
+    OSD_FLYMODE,
+    OSD_THROTTLE_POS,
+    OSD_VTX_CHANNEL,
+    OSD_CURRENT_DRAW,
+    OSD_MAH_DRAWN,
+    OSD_CRAFT_NAME,
+    OSD_ALTITUDE,
+    OSD_ROLL_PIDS,
+    OSD_PITCH_PIDS,
+    OSD_YAW_PIDS,
+    OSD_POWER,
+    OSD_PIDRATE_PROFILE,
+    OSD_WARNINGS,
+    OSD_AVG_CELL_VOLTAGE,
+    OSD_DEBUG,
+    OSD_PITCH_ANGLE,
+    OSD_ROLL_ANGLE,
+    OSD_MAIN_BATT_USAGE,
+    OSD_DISARMED,
+    OSD_NUMERICAL_HEADING,
+    OSD_NUMERICAL_VARIO,
+    OSD_COMPASS_BAR,
+    OSD_ANTI_GRAVITY
+};
+
 PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 3);
 
 /**
@@ -916,36 +949,10 @@ static void osdDrawElements(void)
         osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
     }
 
-    osdDrawSingleElement(OSD_MAIN_BATT_VOLTAGE);
-    osdDrawSingleElement(OSD_RSSI_VALUE);
-    osdDrawSingleElement(OSD_CROSSHAIRS);
-    osdDrawSingleElement(OSD_HORIZON_SIDEBARS);
-    osdDrawSingleElement(OSD_ITEM_TIMER_1);
-    osdDrawSingleElement(OSD_ITEM_TIMER_2);
-    osdDrawSingleElement(OSD_REMAINING_TIME_ESTIMATE);
-    osdDrawSingleElement(OSD_FLYMODE);
-    osdDrawSingleElement(OSD_THROTTLE_POS);
-    osdDrawSingleElement(OSD_VTX_CHANNEL);
-    osdDrawSingleElement(OSD_CURRENT_DRAW);
-    osdDrawSingleElement(OSD_MAH_DRAWN);
-    osdDrawSingleElement(OSD_CRAFT_NAME);
-    osdDrawSingleElement(OSD_ALTITUDE);
-    osdDrawSingleElement(OSD_ROLL_PIDS);
-    osdDrawSingleElement(OSD_PITCH_PIDS);
-    osdDrawSingleElement(OSD_YAW_PIDS);
-    osdDrawSingleElement(OSD_POWER);
-    osdDrawSingleElement(OSD_PIDRATE_PROFILE);
-    osdDrawSingleElement(OSD_WARNINGS);
-    osdDrawSingleElement(OSD_AVG_CELL_VOLTAGE);
-    osdDrawSingleElement(OSD_DEBUG);
-    osdDrawSingleElement(OSD_PITCH_ANGLE);
-    osdDrawSingleElement(OSD_ROLL_ANGLE);
-    osdDrawSingleElement(OSD_MAIN_BATT_USAGE);
-    osdDrawSingleElement(OSD_DISARMED);
-    osdDrawSingleElement(OSD_NUMERICAL_HEADING);
-    osdDrawSingleElement(OSD_NUMERICAL_VARIO);
-    osdDrawSingleElement(OSD_COMPASS_BAR);
-    osdDrawSingleElement(OSD_ANTI_GRAVITY);
+
+    for (unsigned i = 0; i < sizeof(osdElementDisplayOrder); i++) {
+        osdDrawSingleElement(osdElementDisplayOrder[i]);
+    }
 
 #ifdef USE_GPS
     if (sensors(SENSOR_GPS)) {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -49,6 +49,9 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 
 // NB: to ensure backwards compatibility, new enum values must be appended at the end but before the OSD_XXXX_COUNT entry.
 
+// *** IMPORTANT ***
+// If you are adding additional elements that do not require any conditional display logic,
+// you must add the elements to the osdElementDisplayOrder[] array in src/main/io/osd.c
 typedef enum {
     OSD_RSSI_VALUE,
     OSD_MAIN_BATT_VOLTAGE,


### PR DESCRIPTION
Simple rework of the display logic for OSD elements that don't require any conditional processing.

Saves 132 bytes of flash.

For OMNIBUS before:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      257168 B       252 KB     99.66%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       37688 B        40 KB     92.01%
             CCM:          2 KB         8 KB     25.00%
       MEMORY_B1:          0 GB         0 GB       nan%
   text	   data	    bss	    dec	    hex	filename
 249916	   7252	  32484	 289652	  46b74	./obj/main/betaflight_OMNIBUS.elf
```
After:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      257036 B       252 KB     99.61%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       37688 B        40 KB     92.01%
             CCM:          2 KB         8 KB     25.00%
       MEMORY_B1:          0 GB         0 GB       nan%
   text	   data	    bss	    dec	    hex	filename
 249784	   7252	  32484	 289520	  46af0	./obj/main/betaflight_OMNIBUS.elf
```

Ideally a more complete solution would be to change the ordering of the main enumeration for the elements `osd_items_e`.  But doing so would require substantial changes to the Configurator as it uses the order must match the field labeling defined in the Configurator.  Also changing the order would corrupt any saved configurations so it would be necessary to bump the PG version.
