### PR TITLE
Fix cli get resetting to profile 0

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -93,7 +93,7 @@ uint8_t getCurrentPidProfileIndex(void)
     return systemConfig()->pidProfileIndex;
 }
 
-static void setPidProfile(uint8_t pidProfileIndex)
+void setPidProfile(uint8_t pidProfileIndex)
 {
     if (pidProfileIndex < MAX_PROFILE_COUNT) {
         systemConfigMutable()->pidProfileIndex = pidProfileIndex;
@@ -532,8 +532,7 @@ void changePidProfile(uint8_t pidProfileIndex)
     if (pidProfileIndex >= MAX_PROFILE_COUNT) {
         pidProfileIndex = MAX_PROFILE_COUNT - 1;
     }
-    systemConfigMutable()->pidProfileIndex = pidProfileIndex;
-    currentPidProfile = pidProfilesMutable(pidProfileIndex);
+    setPidProfile(pidProfileIndex);
     beeperConfirmationBeeps(pidProfileIndex + 1);
 }
 #endif

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -61,6 +61,7 @@ void activateConfig(void);
 
 uint8_t getCurrentPidProfileIndex(void);
 void changePidProfile(uint8_t pidProfileIndex);
+void setPidProfile(uint8_t pidProfileIndex);
 struct pidProfile_s;
 void resetPidProfile(struct pidProfile_s *profile);
 

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3271,7 +3271,11 @@ STATIC_UNIT_TESTED void cliGet(char *cmdline)
     const clivalue_t *val;
     int matchedCommands = 0;
 
+    uint8_t backupPidProfile = getCurrentPidProfileIndex();
+    uint8_t backupRateProfile = getCurrentControlRateProfileIndex();
     backupAndResetConfigs();
+    setPidProfile(backupPidProfile);
+    setControlRateProfile(backupRateProfile);
 
     for (uint32_t i = 0; i < valueTableEntryCount; i++) {
         if (strcasestr(valueTable[i].name, cmdline)) {

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -280,4 +280,8 @@ bool boardInformationIsSet(void) { return true; };
 bool setBoardName(char *newBoardName) { UNUSED(newBoardName); return true; };
 bool setManufacturerId(char *newManufacturerId) { UNUSED(newManufacturerId); return true; };
 bool persistBoardInformation(void) { return true; };
+
+void setPidProfile(uint8_t pidProfileIndex) { UNUSED(pidProfileIndex); };
+void setControlRateProfile(uint8_t controlRateProfileIndex) { UNUSED(controlRateProfileIndex); };
+
 }


### PR DESCRIPTION
Fixes #6015 

Corrects a bug introduced with #5935 that caused the profile and rateprofile to be reset to 0 during the cli get command. The logic that reset the config so that the default values could be determined also was resetting the profile and rateprofile values and this wasn't noticed.  The fix preserves the profile indexes and restores them to their previous value.