### PR TITLE
RC smoothing: improve rx frame rate detection, add rc_smoothing_info cli command

### DIFF
--- a/src/main/fc/fc_rc.h
+++ b/src/main/fc/fc_rc.h
@@ -39,3 +39,4 @@ void updateRcCommands(void);
 void resetYawAxis(void);
 void initRcProcessing(void);
 bool isMotorsReversed(void);
+uint16_t rcSmoothingGetValue(int whichValue);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -76,6 +76,13 @@ typedef enum {
     RC_SMOOTHING_DERIVATIVE_BIQUAD
 } rcSmoothingDerivativeFilter_e;
 
+typedef enum {
+    RC_SMOOTHING_VALUE_INPUT_AUTO,
+    RC_SMOOTHING_VALUE_INPUT_ACTIVE,
+    RC_SMOOTHING_VALUE_DERIVATIVE_AUTO,
+    RC_SMOOTHING_VALUE_DERIVATIVE_ACTIVE,
+    RC_SMOOTHING_VALUE_AVERAGE_FRAME
+} rcSmoothingInfoType_e;
 
 #define ROL_LO (1 << (2 * ROLL))
 #define ROL_CE (3 << (2 * ROLL))

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -306,18 +306,21 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 }
 
 #ifdef USE_RC_SMOOTHING_FILTER
-void pidInitSetpointDerivativeLpf(uint16_t filterCutoff, uint8_t debugAxis, uint8_t filterType) {
-    setpointDerivativeLpfInitialized = true;
+void pidInitSetpointDerivativeLpf(uint16_t filterCutoff, uint8_t debugAxis, uint8_t filterType)
+{
     rcSmoothingDebugAxis = debugAxis;
     rcSmoothingFilterType = filterType;
-    for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
-        switch (rcSmoothingFilterType) {
-            case RC_SMOOTHING_DERIVATIVE_PT1:
-                pt1FilterInit(&setpointDerivativePt1[axis], pt1FilterGain(filterCutoff, dT));
-                break;
-            case RC_SMOOTHING_DERIVATIVE_BIQUAD:
-                biquadFilterInitLPF(&setpointDerivativeBiquad[axis], filterCutoff, targetPidLooptime);
-                break;
+    if ((filterCutoff > 0) && (rcSmoothingFilterType != RC_SMOOTHING_DERIVATIVE_OFF)) {
+        setpointDerivativeLpfInitialized = true;
+        for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
+            switch (rcSmoothingFilterType) {
+                case RC_SMOOTHING_DERIVATIVE_PT1:
+                    pt1FilterInit(&setpointDerivativePt1[axis], pt1FilterGain(filterCutoff, dT));
+                    break;
+                case RC_SMOOTHING_DERIVATIVE_BIQUAD:
+                    biquadFilterInitLPF(&setpointDerivativeBiquad[axis], filterCutoff, targetPidLooptime);
+                    break;
+            }
         }
     }
 }
@@ -896,7 +899,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
             if (axis == rcSmoothingDebugAxis) {
                 DEBUG_SET(DEBUG_RC_SMOOTHING, 1, lrintf(pidSetpointDelta * 100.0f));
             }
-            if ((dynCd != 0) && setpointDerivativeLpfInitialized && (rcSmoothingFilterType != RC_SMOOTHING_DERIVATIVE_OFF)) {
+            if ((dynCd != 0) && setpointDerivativeLpfInitialized) {
                 switch (rcSmoothingFilterType) {
                     case RC_SMOOTHING_DERIVATIVE_PT1:
                         pidSetpointDelta = pt1FilterApply(&setpointDerivativePt1[axis], pidSetpointDelta);

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3654,6 +3654,44 @@ static void cliVersion(char *cmdline)
     );
 }
 
+#ifdef USE_RC_SMOOTHING_FILTER
+static void cliRcSmoothing(char *cmdline)
+{
+    UNUSED(cmdline);
+    cliPrint("# RC Smoothing Type: ");
+    if (rxConfig()->rc_smoothing_type == RC_SMOOTHING_TYPE_FILTER) {
+        cliPrintLine("FILTER");
+        uint16_t avgRxFrameMs = rcSmoothingGetValue(RC_SMOOTHING_VALUE_AVERAGE_FRAME);
+        cliPrint("# Detected RX frame rate: ");
+        if (avgRxFrameMs == 0) {
+            cliPrintLine("NO SIGNAL");
+        } else {
+            cliPrintLinef("%d.%dms", avgRxFrameMs / 1000, avgRxFrameMs % 1000);
+        }
+        cliPrintLinef("# Auto input cutoff: %dhz", rcSmoothingGetValue(RC_SMOOTHING_VALUE_INPUT_AUTO));
+        cliPrintf("# Active input cutoff: %dhz ", rcSmoothingGetValue(RC_SMOOTHING_VALUE_INPUT_ACTIVE));
+        if (rxConfig()->rc_smoothing_input_cutoff == 0) {
+            cliPrintLine("(auto)");
+        } else {
+            cliPrintLine("(manual)");
+        }
+        cliPrintLinef("# Auto derivative cutoff: %dhz", rcSmoothingGetValue(RC_SMOOTHING_VALUE_DERIVATIVE_AUTO));
+        cliPrintf("# Active derivative cutoff: %dhz (", rcSmoothingGetValue(RC_SMOOTHING_VALUE_DERIVATIVE_ACTIVE));
+        if (rxConfig()->rc_smoothing_derivative_type == RC_SMOOTHING_DERIVATIVE_OFF) {
+            cliPrintLine("off)");
+        } else {
+            if (rxConfig()->rc_smoothing_derivative_cutoff == 0) {
+                cliPrintLine("auto)");
+            } else {
+                cliPrintLine("manual)");
+            }
+        }
+    } else {
+        cliPrintLine("INTERPOLATION");
+    }
+}
+#endif // USE_RC_SMOOTHING_FILTER
+
 #if defined(USE_RESOURCE_MGMT)
 
 #define MAX_RESOURCE_INDEX(x) ((x) == 0 ? 1 : (x))
@@ -4441,6 +4479,9 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("profile", "change profile", "[<index>]", cliProfile),
     CLI_COMMAND_DEF("rateprofile", "change rate profile", "[<index>]", cliRateProfile),
+#ifdef USE_RC_SMOOTHING_FILTER
+    CLI_COMMAND_DEF("rc_smoothing_info", "show rc_smoothing operational settings", NULL, cliRcSmoothing),
+#endif // USE_RC_SMOOTHING_FILTER
 #ifdef USE_RESOURCE_MGMT
     CLI_COMMAND_DEF("resource", "show/set resources", NULL, cliResource),
 #endif


### PR DESCRIPTION
Improved the rx frame rate detection/training by delaying calculation to avoid loop time jitter during flight controller initialization.

For auto cutoffs calculate a value appropriate for BIQUAD or PT1 depending on the configuration.

Added a new `rc_smoothing_info` cli command to display internal details about its operation.
```
# rc_smoothing_info
# RC Smoothing Type: FILTER
# Detected RX frame rate: 8.981ms
# Auto input cutoff: 50hz
# Active input cutoff: 50hz (auto)
# Auto derivative cutoff: 60hz
# Active derivative cutoff: 58hz (manual)
```