### PR TITLE
Moving sensor frame throttling from SmartPort to FPort only.

### DIFF
--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -75,3 +75,4 @@ smartPortPayload_t *smartPortDataReceive(uint16_t c, bool *clearToSend, smartPor
 struct serialPort_s;
 void smartPortWriteFrameSerial(const smartPortPayload_t *payload, struct serialPort_s *port, uint16_t checksum);
 void smartPortSendByte(uint8_t c, uint16_t *checksum, struct serialPort_s *port);
+bool smartPortPayloadContainsMSP(const smartPortPayload_t *payload);


### PR DESCRIPTION
@fiam, @pulquero, @jirif:

This moves the throttling for telemetry frames from SmartPort & FPort to FPort only. The reason for this is that, unlike FPort, SmartPort already uses requests sent by the RX to throttle the rate of frames to what can be handled by the queue in the RX.
The fear is that with additional throttling in SmartPort, the sending queue in the RX will run constantly empty, resulting in missed slots, and less telemetry frames sent than possible.
There are reports from users about 'sensor lost' alerts when using a large number of sensors, so the telemetry frame rate should be maximised.

Code copied from, with thanks: iNavFlight/inav#3308