### PR TITLE
Fixed null pointer reference

### DIFF
--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -347,7 +347,7 @@ static bool fportProcessFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
     if (clearToSend) {
         DEBUG_SET(DEBUG_FPORT, DEBUG_FPORT_TELEMETRY_DELAY, currentTimeUs - lastTelemetryFrameReceivedUs);
 
-        if (consecutiveSensorCount >= FPORT_TELEMETRY_MAX_CONSECUTIVE_SENSORS && !smartPortPayloadContainsMSP(mspPayload)) {
+        if (consecutiveSensorCount >= FPORT_TELEMETRY_MAX_CONSECUTIVE_SENSORS && !(mspPayload && smartPortPayloadContainsMSP(mspPayload))) {
 // Stop one cycle to avoid saturating the buffer in the RX, since the
 // downstream bandwidth doesn't allow sensor sensors on every cycle.
 // We allow MSP frames to run over the resting period, expecting that

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -464,18 +464,15 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
     static uint8_t smartPortIdOffset = 0;
 #endif
 
-    if (payload) {
-        // do not check the physical ID here again
-        // unless we start receiving other sensors' packets
-
 #if defined(USE_MSP_OVER_TELEMETRY)
-        if (smartPortPayloadContainsMSP(payload)) {
-            // Pass only the payload: skip frameId
-            uint8_t *frameStart = (uint8_t *)&payload->valueId;
-            smartPortMspReplyPending = handleMspFrame(frameStart, SMARTPORT_MSP_PAYLOAD_SIZE);
-        }
-#endif
+    if (payload && smartPortPayloadContainsMSP(payload)) {
+        // Do not check the physical ID here again
+        // unless we start receiving other sensors' packets
+        // Pass only the payload: skip frameId
+         uint8_t *frameStart = (uint8_t *)&payload->valueId;
+         smartPortMspReplyPending = handleMspFrame(frameStart, SMARTPORT_MSP_PAYLOAD_SIZE);
     }
+#endif
 
     bool doRun = true;
     while (doRun && *clearToSend) {


### PR DESCRIPTION
@mikeller today i have found this leftover from #6056 , mspPayload should be NULL when is called from fport.c and its not checked in smartPortPayloadContainsMSP(). I have refactored the code to take care about this.