### PR TITLE
Add guard time between dshot beacon and arming/disarming

### DIFF
--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -53,3 +53,6 @@ bool isFlipOverAfterCrashMode(void);
 
 void runawayTakeoffTemporaryDisable(uint8_t disableFlag);
 bool isAirmodeActivated();
+timeUs_t getLastDisarmTimeUs(void);
+bool isTryingToArm();
+void resetTryingToArm();

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -179,6 +179,7 @@ void processRcStickPositions()
             // Arming via ARM BOX
             tryArm();
         } else {
+            resetTryingToArm();
             // Disarming via ARM BOX
             resetArmingDisabled();
             if (ARMING_FLAG(ARMED) && rxIsReceivingSignal() && !failsafeIsActive()  ) {
@@ -192,6 +193,7 @@ void processRcStickPositions()
         if (rcDelayMs >= ARM_DELAY_MS && !doNotRepeat) {
             doNotRepeat = true;
             // Disarm on throttle down + yaw
+            resetTryingToArm();
             if (ARMING_FLAG(ARMED))
                 disarm();
             else {
@@ -214,11 +216,16 @@ void processRcStickPositions()
             if (!ARMING_FLAG(ARMED)) {
                 // Arm via YAW
                 tryArm();
+                if (isTryingToArm()) {
+                    doNotRepeat = false;
+                }
             } else {
                 resetArmingDisabled();
             }
         }
         return;
+    } else {
+        resetTryingToArm();
     }
 
     if (ARMING_FLAG(ARMED) || doNotRepeat || rcDelayMs <= STICK_DELAY_MS || (getArmingDisableFlags() & ARMING_DISABLED_RUNAWAY_TAKEOFF)) {

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -24,6 +24,11 @@
 
 #define BEEPER_GET_FLAG(mode) (1 << (mode - 1))
 
+#ifdef USE_DSHOT
+#define DSHOT_BEACON_GUARD_DELAY_US 2000000  // Time to separate dshot beacon and armining/disarming events
+                                             // to prevent interference with motor direction commands
+#endif
+
 typedef enum {
     // IMPORTANT: these are in priority order, 0 = Highest
     BEEPER_SILENCE = 0,             // Silence, see beeperSilence()
@@ -94,3 +99,4 @@ uint32_t beeperModeMaskForTableIndex(int idx);
 const char *beeperNameForTableIndex(int idx);
 int beeperTableEntryCount(void);
 bool isBeeperOn(void);
+timeUs_t getLastDshotBeaconCommandTimeUs(void);

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -52,6 +52,7 @@ extern "C" {
 
     #include "fc/rc_controls.h"
     #include "fc/runtime_config.h"
+    #include "fc/fc_core.h"
 
     #include "scheduler/scheduler.h"
 }
@@ -737,3 +738,5 @@ timeDelta_t getTaskDeltaTime(cfTaskId_e) { return 20000; }
 armingDisableFlags_e getArmingDisableFlags(void) {
     return (armingDisableFlags_e) 0;
 }
+bool isTryingToArm(void) { return false; }
+void resetTryingToArm(void) {}


### PR DESCRIPTION
Fixes #6066 

Tries to prevent DSHOT beacon commands from interfering with commands to set the motor direction.

Adds a 2 second delay after disarming before DSHOT beacon commands will be sent. This attempts to prevent the beacon commands from interfering with the motor direction reset that happens after using crash flip mode and disarming.

During arming if a DSHOT beacon command has been sent within 2 seconds the arming will be delayed until the 2 seconds have passed. This attempts to prevent interference with the motor direction commands sent at arming.