### PR TITLE
GPS: handle negative and high altitudes; safer macros in maths.h

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -1,5 +1,4 @@
 /*
-/*
  * This file is part of Cleanflight and Betaflight.
  *
  * Cleanflight and Betaflight are free software. You can redistribute

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -1,4 +1,5 @@
 /*
+/*
  * This file is part of Cleanflight and Betaflight.
  *
  * Cleanflight and Betaflight are free software. You can redistribute
@@ -33,13 +34,13 @@
 #define M_PIf       3.14159265358979323846f
 
 #define RAD    (M_PIf / 180.0f)
-#define DEGREES_TO_DECIDEGREES(angle) (angle * 10)
-#define DECIDEGREES_TO_DEGREES(angle) (angle / 10)
-#define DECIDEGREES_TO_RADIANS(angle) ((angle / 10.0f) * 0.0174532925f)
+#define DEGREES_TO_DECIDEGREES(angle) ((angle) * 10)
+#define DECIDEGREES_TO_DEGREES(angle) ((angle) / 10)
+#define DECIDEGREES_TO_RADIANS(angle) ((angle) / 10.0f * 0.0174532925f)
 #define DEGREES_TO_RADIANS(angle) ((angle) * 0.0174532925f)
 
-#define CM_S_TO_KM_H(centimetersPerSecond) (centimetersPerSecond * 36 / 1000)
-#define CM_S_TO_MPH(centimetersPerSecond) (((centimetersPerSecond * 10000) / 5080) / 88)
+#define CM_S_TO_KM_H(centimetersPerSecond) ((centimetersPerSecond) * 36 / 1000)
+#define CM_S_TO_MPH(centimetersPerSecond) ((centimetersPerSecond) * 10000 / 5080 / 88)
 
 #define MIN(a,b) \
   __extension__ ({ __typeof__ (a) _a = (a); \

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1033,9 +1033,10 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, gpsSol.numSat);
         sbufWriteU32(dst, gpsSol.llh.lat);
         sbufWriteU32(dst, gpsSol.llh.lon);
-        sbufWriteU16(dst, gpsSol.llh.alt);
+        sbufWriteU16(dst, MIN(gpsSol.llh.alt,65535));
         sbufWriteU16(dst, gpsSol.groundSpeed);
         sbufWriteU16(dst, gpsSol.groundCourse);
+        sbufWriteU32(dst, gpsSol.llh.alt);
         break;
 
     case MSP_COMP_GPS:
@@ -1899,8 +1900,11 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsSol.numSat = sbufReadU8(src);
         gpsSol.llh.lat = sbufReadU32(src);
         gpsSol.llh.lon = sbufReadU32(src);
-        gpsSol.llh.alt = sbufReadU32(src);
+        gpsSol.llh.alt = sbufReadU16(src);
         gpsSol.groundSpeed = sbufReadU16(src);
+        if (sbufBytesRemaining(src) >= 4) {
+            gpsSol.llh.alt = sbufReadU32(src);
+        }
         GPS_update |= 2;        // New data signalisation to GPS functions // FIXME Magic Numbers
         break;
 #endif // USE_GPS

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1899,7 +1899,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsSol.numSat = sbufReadU8(src);
         gpsSol.llh.lat = sbufReadU32(src);
         gpsSol.llh.lon = sbufReadU32(src);
-        gpsSol.llh.alt = sbufReadU16(src);
+        gpsSol.llh.alt = sbufReadU32(src);
         gpsSol.groundSpeed = sbufReadU16(src);
         GPS_update |= 2;        // New data signalisation to GPS functions // FIXME Magic Numbers
         break;

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1033,7 +1033,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, gpsSol.numSat);
         sbufWriteU32(dst, gpsSol.llh.lat);
         sbufWriteU32(dst, gpsSol.llh.lon);
-        sbufWriteU16(dst, (uint16_t)constrain(gpsSol.llh.alt / 10, 0, UINT16_MAX));
+        sbufWriteU16(dst, (uint16_t)constrain(gpsSol.llh.alt / 100, 0, UINT16_MAX)); // alt changed from 1m to 0.01m per lsb since MSP API 1.39 by RTH. To maintain backwards compatibility compensate to 1m per lsb in MSP again.
         sbufWriteU16(dst, gpsSol.groundSpeed);
         sbufWriteU16(dst, gpsSol.groundCourse);
         break;
@@ -1899,7 +1899,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsSol.numSat = sbufReadU8(src);
         gpsSol.llh.lat = sbufReadU32(src);
         gpsSol.llh.lon = sbufReadU32(src);
-        gpsSol.llh.alt = sbufReadU16(src) * 10;
+        gpsSol.llh.alt = sbufReadU16(src) * 100; // alt changed from 1m to 0.01m per lsb since MSP API 1.39 by RTH. Received MSP altitudes in 1m per lsb have to upscaled.
         gpsSol.groundSpeed = sbufReadU16(src);
         GPS_update |= 2;        // New data signalisation to GPS functions // FIXME Magic Numbers
         break;

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1033,7 +1033,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, gpsSol.numSat);
         sbufWriteU32(dst, gpsSol.llh.lat);
         sbufWriteU32(dst, gpsSol.llh.lon);
-        sbufWriteU16(dst, MIN(gpsSol.llh.alt,65535));
+        sbufWriteU16(dst, MIN(gpsSol.llh.alt / 10, 65535));
         sbufWriteU16(dst, gpsSol.groundSpeed);
         sbufWriteU16(dst, gpsSol.groundCourse);
         sbufWriteU32(dst, gpsSol.llh.alt);
@@ -1900,7 +1900,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsSol.numSat = sbufReadU8(src);
         gpsSol.llh.lat = sbufReadU32(src);
         gpsSol.llh.lon = sbufReadU32(src);
-        gpsSol.llh.alt = sbufReadU16(src);
+        gpsSol.llh.alt = sbufReadU16(src) * 10;
         gpsSol.groundSpeed = sbufReadU16(src);
         if (sbufBytesRemaining(src) >= 4) {
             gpsSol.llh.alt = sbufReadU32(src);

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1033,10 +1033,9 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, gpsSol.numSat);
         sbufWriteU32(dst, gpsSol.llh.lat);
         sbufWriteU32(dst, gpsSol.llh.lon);
-        sbufWriteU16(dst, MIN(gpsSol.llh.alt / 10, 65535));
+        sbufWriteU16(dst, (uint16_t)constrain(gpsSol.llh.alt / 10, 0, UINT16_MAX));
         sbufWriteU16(dst, gpsSol.groundSpeed);
         sbufWriteU16(dst, gpsSol.groundCourse);
-        sbufWriteU32(dst, gpsSol.llh.alt);
         break;
 
     case MSP_COMP_GPS:
@@ -1902,9 +1901,6 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsSol.llh.lon = sbufReadU32(src);
         gpsSol.llh.alt = sbufReadU16(src) * 10;
         gpsSol.groundSpeed = sbufReadU16(src);
-        if (sbufBytesRemaining(src) >= 4) {
-            gpsSol.llh.alt = sbufReadU32(src);
-        }
         GPS_update |= 2;        // New data signalisation to GPS functions // FIXME Magic Numbers
         break;
 #endif // USE_GPS

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -651,8 +651,7 @@ static uint32_t grab_fields(char *src, uint8_t mult)
             i++;
             if (mult == 0) {
                 break;
-            }
-            else {
+            } else {
                 src[i + mult] = 0;
             }
         }

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -662,7 +662,7 @@ typedef struct gpsDataNmea_s {
     int32_t latitude;
     int32_t longitude;
     uint8_t numSat;
-    uint16_t altitude;
+    int32_t altitude;
     uint16_t speed;
     uint16_t hdop;
     uint16_t ground_course;
@@ -734,6 +734,8 @@ static bool gpsNewFrameNMEA(char c)
                             break;
                         case 9:
                             gps_Msg.altitude = grab_fields(string, 0);     // altitude in meters added by Mis
+                            if (string[0] == '-')
+                                gps_Msg.altitude = -gps_Msg.altitude;     // handle negative altitudes
                             break;
                     }
                     break;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -649,21 +649,22 @@ static uint32_t grab_fields(char *src, uint8_t mult)
         }
         if (src[i] == '.') {
             i++;
-            if (mult == 0)
+            if (mult == 0) {
                 break;
-            else
+            }
+            else {
                 src[i + mult] = 0;
+            }
         }
         tmp *= 10;
-        if (src[i] >= '0' && src[i] <= '9')
+        if (src[i] >= '0' && src[i] <= '9') {
             tmp += src[i] - '0';
-        if (i >= 15)
+        }
+        if (i >= 15) {
             return 0; // out of bounds
+        }
     }
-    if (isneg)
-        return -tmp;     // handle negative altitudes
-    else
-        return tmp;
+    return isneg ? -tmp : tmp;     // handle negative altitudes
 }
 
 typedef struct gpsDataNmea_s {

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -664,7 +664,7 @@ static uint32_t grab_fields(char *src, uint8_t mult)
             return 0; // out of bounds
         }
     }
-    return isneg ? -tmp : tmp;     // handle negative altitudes
+    return isneg ? -tmp : tmp;    // handle negative altitudes
 }
 
 typedef struct gpsDataNmea_s {

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -641,7 +641,8 @@ static uint32_t grab_fields(char *src, uint8_t mult)
 {                               // convert string to uint32
     uint32_t i;
     uint32_t tmp = 0;
-    for (i = 0; src[i] != 0; i++) {
+    int isneg = src[0] == '-';
+    for (i = isneg; src[i] != 0; i++) {
         if (src[i] == '.') {
             i++;
             if (mult == 0)
@@ -655,6 +656,8 @@ static uint32_t grab_fields(char *src, uint8_t mult)
         if (i >= 15)
             return 0; // out of bounds
     }
+    if (isneg)
+        return -tmp;     // handle negative altitudes
     return tmp;
 }
 
@@ -734,8 +737,6 @@ static bool gpsNewFrameNMEA(char c)
                             break;
                         case 9:
                             gps_Msg.altitude = grab_fields(string, 0);     // altitude in meters added by Mis
-                            if (string[0] == '-')
-                                gps_Msg.altitude = -gps_Msg.altitude;     // handle negative altitudes
                             break;
                     }
                     break;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -741,7 +741,7 @@ static bool gpsNewFrameNMEA(char c)
                             gps_Msg.hdop = grab_fields(string, 1) * 100;          // hdop
                             break;
                         case 9:
-                            gps_Msg.altitude = grab_fields(string, 0);     // altitude in meters added by Mis
+                            gps_Msg.altitude = grab_fields(string, 1) * 10;     // altitude in centimeters. Note: NMEA delivers altitude with 1 or 3 decimals. It's safer to cut at 0.1m and multiply by 10
                             break;
                     }
                     break;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -641,8 +641,12 @@ static uint32_t grab_fields(char *src, uint8_t mult)
 {                               // convert string to uint32
     uint32_t i;
     uint32_t tmp = 0;
-    int isneg = src[0] == '-';
-    for (i = isneg; src[i] != 0; i++) {
+    int isneg = 0;
+    for (i = 0; src[i] != 0; i++) {
+        if ((i == 0) && (src[0] == '-')) { // detect negative sign
+            isneg = 1;
+            continue; // jump to next character if the first one was a negative sign
+        }
         if (src[i] == '.') {
             i++;
             if (mult == 0)
@@ -658,7 +662,8 @@ static uint32_t grab_fields(char *src, uint8_t mult)
     }
     if (isneg)
         return -tmp;     // handle negative altitudes
-    return tmp;
+    else
+        return tmp;
 }
 
 typedef struct gpsDataNmea_s {

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -86,7 +86,7 @@ typedef struct gpsCoordinateDDDMMmmmm_s {
 typedef struct gpsLocation_s {
     int32_t lat;                    // latitude * 1e+7
     int32_t lon;                    // longitude * 1e+7
-    int32_t alt;                   // altitude in 0.1m
+    int32_t alt;                    // altitude in 0.01m
 } gpsLocation_t;
 
 typedef struct gpsSolutionData_s {

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -91,7 +91,6 @@ typedef struct gpsLocation_s {
 
 typedef struct gpsSolutionData_s {
     gpsLocation_t llh;
-//    int32_t GPS_altitude;          // altitude in 0.1m: UNUSED!
     uint16_t groundSpeed;           // speed in 0.1m/s
     uint16_t groundCourse;          // degrees * 10
     uint16_t hdop;                  // generic HDOP value (*100)

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -91,7 +91,7 @@ typedef struct gpsLocation_s {
 
 typedef struct gpsSolutionData_s {
     gpsLocation_t llh;
-    uint16_t GPS_altitude;          // altitude in 0.1m
+//    int32_t GPS_altitude;          // altitude in 0.1m: UNUSED!
     uint16_t groundSpeed;           // speed in 0.1m/s
     uint16_t groundCourse;          // degrees * 10
     uint16_t hdop;                  // generic HDOP value (*100)


### PR DESCRIPTION
Fixes underflows at negative altitude (below MSL) and overflows at altitudes higher than 655.35m
Corrected parenthesis in maths.h avoid incorrect equations if arguments contain expressions.