### PR TITLE
[GPS Rescue] - Only run idle tasks when throttle is not THROTTLE_LOW

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -294,7 +294,7 @@ void rescueStop()
 void idleTasks()
 {
     // Do not calculate any of the idle task values when we are not flying
-    if (!ARMING_FLAG(ARMED)) {
+    if (!ARMING_FLAG(ARMED) || calculateThrottleStatus() == THROTTLE_LOW) {
         return;
     }
 

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -293,7 +293,7 @@ void rescueStop()
 // Things that need to run regardless of GPS rescue mode being enabled or not
 void idleTasks()
 {
-    // Do not calculate any of the idle task values when we are not flying
+    // Do not calculate any of the idle task values when we are not flying.  No sense in storing max altitude or throttle samples if not climbing.
     if (!ARMING_FLAG(ARMED) || calculateThrottleStatus() == THROTTLE_LOW) {
         return;
     }


### PR DESCRIPTION
This should prevent a race condition from happening when idleTasks() runs when the quad is armed, but the altitude offset is not yet applied.  This will also increase the accuracy of the hoverThrottle calculation.