### PR TITLE
Display OSD message and countdown if arming is delayed due to beacon

### DIFF
--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -45,6 +45,7 @@ extern "C" {
     #include "flight/pid.h"
     #include "flight/imu.h"
 
+    #include "io/beeper.h"
     #include "io/gps.h"
     #include "io/osd.h"
 


### PR DESCRIPTION
Provides a clear indication that arming is delayed for cases where DSHOT beacon is active.

Clears the OSD and displays "DISABLING BEACON" and "ARMING IN X.Y" with an active countdown in tenths of a second while arming is delayed due to DSHOT beacon. Once delay period is over the normal "ARMING" message appears.

If the DSHOT beacon is not active then this delay screen is not displayed.
