### PR TITLE
Fix wrong QMC5883L mag detection

### DIFF
--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -135,6 +135,12 @@ bool qmc5883lDetect(magDev_t *magDev)
     uint8_t sig = 0;
     bool ack = busReadRegisterBuffer(busdev, QMC5883L_REG_ID, &sig, 1);
     if (ack && sig == QMC5883_ID_VAL) {
+        // Should be in standby mode after soft reset and sensor is really present
+        // Reading ChipID of 0xFF alone is not sufficient to be sure the QMC is present
+        ack = busReadRegisterBuffer(busdev, QMC5883L_REG_CONF1, &sig, 1);
+        if (ack && sig != QMC5883L_MODE_STANDBY) {
+            return false;
+        }
         magDev->init = qmc5883lInit;
         magDev->read = qmc5883lRead;
         return true;


### PR DESCRIPTION
Proposed fix for erroneous QMC5883L mag detection. Issue #6120. Fix need to be tested on FC's with QMC5883L. May be the mode bits in status register need to be masked for proper detection? Looking forward for feedback and test results.