### PR TITLE
[GPS Rescue] - Fix the calculation of acceleration magnitude average to run at gps u…

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -213,12 +213,12 @@ void sensorUpdate()
         rescueState.sensor.zVelocity = (rescueState.sensor.currentAltitude - previousAltitude) * 1000000.0f / dTime;
         rescueState.sensor.zVelocityAvg = 0.8f * rescueState.sensor.zVelocityAvg + rescueState.sensor.zVelocity * 0.2f;
 
+        rescueState.sensor.accMagnitude = (float) sqrt(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y]) / sq(acc.dev.acc_1G));
+        rescueState.sensor.accMagnitudeAvg = (rescueState.sensor.accMagnitudeAvg * 0.8f) + (rescueState.sensor.accMagnitude * 0.2f);
+
         previousAltitude = rescueState.sensor.currentAltitude;
         previousTimeUs = currentTimeUs;
     }
-
-    rescueState.sensor.accMagnitude = (float) sqrt(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y]) / sq(acc.dev.acc_1G));
-    rescueState.sensor.accMagnitudeAvg = (rescueState.sensor.accMagnitudeAvg * 0.998f) + (rescueState.sensor.accMagnitude * 0.002f);
 }
 
 void performSanityChecks()


### PR DESCRIPTION
updateRescueState() running as a core FC task and re-calculating the average magnitude of acceleration via the sqrt function is very CPU intensive and costly with very little benefit. 

Down the road it may be great to make a task that runs at a low frequency for GPS rescue related updates but currently with the way rcCommand is globally mutable, it will take some refactoring to make this possible.  I believe the best solution at this point is to simply reduce the CPU overhead with the structure remaining as is.