### PR TITLE
Reduce beacon arming guard time to 1.2 seconds

### DIFF
--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -25,7 +25,7 @@
 #define BEEPER_GET_FLAG(mode) (1 << (mode - 1))
 
 #ifdef USE_DSHOT
-#define DSHOT_BEACON_GUARD_DELAY_US 2000000  // Time to separate dshot beacon and armining/disarming events
+#define DSHOT_BEACON_GUARD_DELAY_US 1200000  // Time to separate dshot beacon and armining/disarming events
                                              // to prevent interference with motor direction commands
 #endif
 


### PR DESCRIPTION
Based on feedback from KISS and BLHeli developers the maximum delay for a beacon command is 1020ms.  Since there is some built-in delay in sendint the DSHOT beacon command 10 times leaving a little margin for error at 1.2 seconds.  Tested for reliability on both BLHeli_S and BLHeli_32.