### PR TITLE
remove double transponder update call

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -945,9 +945,6 @@ static FAST_CODE_NOINLINE void subTaskMainSubprocesses(timeUs_t currentTimeUs)
     UNUSED(currentTimeUs);
 #endif
 
-#ifdef USE_TRANSPONDER
-    transponderUpdate(currentTimeUs);
-#endif
     DEBUG_SET(DEBUG_PIDLOOP, 3, micros() - startTime);
 }
 


### PR DESCRIPTION
Transponder update is allready called from a task (https://github.com/betaflight/betaflight/blob/master/src/main/fc/fc_tasks.c#L383) 
so there shouldnt be a need to also call it in subTaskMainSubprocesses with a higher rate