### PR TITLE
Removed tasks from PID loop that don't belong there.

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1669,16 +1669,15 @@ void blackboxUpdate(timeUs_t currentTimeUs)
 #ifdef USE_FLASHFS
         if (blackboxState != BLACKBOX_STATE_ERASING
             && blackboxState != BLACKBOX_STATE_START_ERASE
-            && blackboxState != BLACKBOX_STATE_ERASED) {
+            && blackboxState != BLACKBOX_STATE_ERASED)
 #endif
+        {
             blackboxSetState(BLACKBOX_STATE_STOPPED);
             // ensure we reset the test mode flag if we stop due to full memory card
             if (startedLoggingInTestMode) {
                 startedLoggingInTestMode = false;
             }
-#ifdef USE_FLASHFS
         }
-#endif
     } else { // Only log in test mode if there is room!
         switch (blackboxConfig()->mode) {
         case BLACKBOX_MODE_MOTOR_TEST:

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #ifndef sq
 #define sq(x) ((x)*(x))
 #endif

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -28,6 +28,7 @@
 #include "build/build_config.h"
 
 #include "common/utils.h"
+
 #include "drivers/io.h"
 
 #if defined(STM32F4)

--- a/src/main/drivers/serial_usb_vcp.h
+++ b/src/main/drivers/serial_usb_vcp.h
@@ -23,6 +23,8 @@
 #include "drivers/serial.h"
 
 #if defined(STM32F7)
+#include "common/maths.h"
+
 #include "usbd_cdc.h"
 
 extern USBD_HandleTypeDef  USBD_Device;

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -40,12 +40,10 @@
 #include "pg/rx.h"
 
 #include "drivers/light_led.h"
-#include "drivers/serial_usb_vcp.h"
 #include "drivers/sound_beeper.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
 #include "drivers/transponder_ir.h"
-#include "drivers/usb_io.h"
 
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -67,7 +67,6 @@
 
 #include "interface/cli.h"
 
-#include "io/asyncfatfs/asyncfatfs.h"
 #include "io/beeper.h"
 #include "io/gps.h"
 #include "io/motors.h"
@@ -929,15 +928,6 @@ static FAST_CODE_NOINLINE void subTaskPidSubprocesses(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_PIDLOOP, 3, micros() - startTime);
 }
 
-void taskMain(timeUs_t currentTimeUs)
-{
-    UNUSED(currentTimeUs);
-
-#ifdef USE_SDCARD
-    afatfs_poll();
-#endif
-}
-
 #ifdef USE_TELEMETRY
 void subTaskTelemetryPollSensors(timeUs_t currentTimeUs)
 {
@@ -1059,4 +1049,3 @@ void resetTryingToArm()
 {
     tryingToArm = false;
 }
-

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -57,5 +57,4 @@ timeUs_t getLastDisarmTimeUs(void);
 bool isTryingToArm();
 void resetTryingToArm();
 
-void taskMain(timeUs_t currentTimeUs);
 void subTaskTelemetryPollSensors(timeUs_t currentTimeUs);

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -56,3 +56,6 @@ bool isAirmodeActivated();
 timeUs_t getLastDisarmTimeUs(void);
 bool isTryingToArm();
 void resetTryingToArm();
+
+void taskMain(timeUs_t currentTimeUs);
+void subTaskTelemetryPollSensors(timeUs_t currentTimeUs);

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -48,7 +48,6 @@
 #include "fc/fc_core.h"
 #include "fc/fc_rc.h"
 #include "fc/fc_dispatch.h"
-#include "fc/fc_tasks.h"
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
@@ -96,8 +95,21 @@
 #include "telemetry/telemetry.h"
 
 #ifdef USE_BST
-static void taskBstMasterProcess(timeUs_t currentTimeUs);
+#include "COLIBRI_RACE/i2c_bst.h"
 #endif
+
+#ifdef USE_USB_CDC_HID
+//TODO: Make it platform independent in the future
+#ifdef STM32F4
+#include "vcpf4/usbd_cdc_vcp.h"
+#include "usbd_hid_core.h"
+#elif defined(STM32F7)
+#include "usbd_cdc_interface.h"
+#include "usbd_hid.h"
+#endif
+#endif
+
+#include "fc_tasks.h"
 
 static void taskMain(timeUs_t currentTimeUs)
 {

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -95,7 +95,7 @@
 #include "telemetry/telemetry.h"
 
 #ifdef USE_BST
-#include "COLIBRI_RACE/i2c_bst.h"
+#include "i2c_bst.h"
 #endif
 
 #ifdef USE_USB_CDC_HID

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -38,8 +38,10 @@
 #include "drivers/compass/compass.h"
 #include "drivers/sensor.h"
 #include "drivers/serial.h"
+#include "drivers/serial_usb_vcp.h"
 #include "drivers/stack_check.h"
 #include "drivers/transponder_ir.h"
+#include "drivers/usb_io.h"
 #include "drivers/vtx_common.h"
 
 #include "fc/config.h"
@@ -119,6 +121,12 @@ static bool taskSerialCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime
 static void taskHandleSerial(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
+
+#if defined(USE_VCP)
+    DEBUG_SET(DEBUG_USB, 0, usbCableIsInserted());
+    DEBUG_SET(DEBUG_USB, 1, usbVcpIsConnected());
+#endif
+
 #ifdef USE_CLI
     // in cli mode, all serial stuff goes to here. enter cli mode by sending #
     if (cliMode) {

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -186,6 +186,8 @@ static void taskCalculateAltitude(timeUs_t currentTimeUs)
 static void taskTelemetry(timeUs_t currentTimeUs)
 {
     if (!cliMode && feature(FEATURE_TELEMETRY)) {
+        subTaskTelemetryPollSensors(currentTimeUs);
+
         telemetryProcess(currentTimeUs);
     }
 }
@@ -205,6 +207,9 @@ void taskCameraControl(uint32_t currentTime)
 void fcTasksInit(void)
 {
     schedulerInit();
+
+    setTaskEnabled(TASK_SYSTEM, true);
+
     setTaskEnabled(TASK_SERIAL, true);
     rescheduleTask(TASK_SERIAL, TASK_PERIOD_HZ(serialConfig()->serial_update_rate_hz));
 
@@ -318,10 +323,19 @@ void fcTasksInit(void)
 }
 
 cfTask_t cfTasks[TASK_COUNT] = {
+    [TASK_SYSTEM_LOAD] = {
+        .taskName = "SYSTEM",
+        .subTaskName = "LOAD",
+        .taskFunc = taskSystemLoad,
+        .desiredPeriod = TASK_PERIOD_HZ(10),        // 10Hz, every 100 ms
+        .staticPriority = TASK_PRIORITY_MEDIUM_HIGH,
+    },
+
     [TASK_SYSTEM] = {
         .taskName = "SYSTEM",
-        .taskFunc = taskSystem,
-        .desiredPeriod = TASK_PERIOD_HZ(10),        // 10Hz, every 100 ms
+        .subTaskName = "UPDATE",
+        .taskFunc = taskMain,
+        .desiredPeriod = TASK_PERIOD_HZ(100),
         .staticPriority = TASK_PRIORITY_MEDIUM_HIGH,
     },
 

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -367,7 +367,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskName = "SYSTEM",
         .subTaskName = "UPDATE",
         .taskFunc = taskMain,
-        .desiredPeriod = TASK_PERIOD_HZ(100),
+        .desiredPeriod = TASK_PERIOD_HZ(1000),
         .staticPriority = TASK_PRIORITY_MEDIUM_HIGH,
     },
 

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -225,7 +225,7 @@ void schedulerInit(void)
 {
     calculateTaskStatistics = true;
     queueClear();
-    queueAdd(&cfTasks[TASK_SYSTEM_LOAD]);
+    queueAdd(&cfTasks[TASK_SYSTEM]);
 }
 
 FAST_CODE void scheduler(void)

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -123,7 +123,7 @@ FAST_CODE cfTask_t *queueNext(void)
     return taskQueueArray[++taskQueuePos]; // guaranteed to be NULL at end of queue
 }
 
-void taskSystem(timeUs_t currentTimeUs)
+void taskSystemLoad(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
 
@@ -225,7 +225,7 @@ void schedulerInit(void)
 {
     calculateTaskStatistics = true;
     queueClear();
-    queueAdd(&cfTasks[TASK_SYSTEM]);
+    queueAdd(&cfTasks[TASK_SYSTEM_LOAD]);
 }
 
 FAST_CODE void scheduler(void)

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -58,6 +58,7 @@ typedef struct {
 typedef enum {
     /* Actual tasks */
     TASK_SYSTEM = 0,
+    TASK_SYSTEM_LOAD,
     TASK_GYROPID,
     TASK_ACCEL,
     TASK_ATTITUDE,
@@ -179,7 +180,7 @@ void schedulerResetTaskStatistics(cfTaskId_e taskId);
 
 void schedulerInit(void);
 void scheduler(void);
-void taskSystem(timeUs_t currentTime);
+void taskSystemLoad(timeUs_t currentTime);
 
 #define LOAD_PERCENTAGE_ONE 100
 

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -58,7 +58,7 @@ typedef struct {
 typedef enum {
     /* Actual tasks */
     TASK_SYSTEM = 0,
-    TASK_SYSTEM_LOAD,
+    TASK_MAIN,
     TASK_GYROPID,
     TASK_ACCEL,
     TASK_ATTITUDE,

--- a/src/main/target/SIRINFPV/target.h
+++ b/src/main/target/SIRINFPV/target.h
@@ -22,6 +22,14 @@
 
 #define TARGET_BOARD_IDENTIFIER "SIRF"
 
+// Removed to make the firmware fit into flash (in descending order of priority):
+
+#undef USE_EXTENDED_CMS_MENUS
+#undef USE_RTC_TIME
+#undef USE_RX_MSP
+#undef USE_ESC_SENSOR_INFO
+
+
 #define LED0_PIN                PB2
 #define USE_BEEPER
 #define BEEPER_PIN              PA1

--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -46,15 +46,15 @@
   */
 
 /* Includes ------------------------------------------------------------------*/
+#include "drivers/serial_usb_vcp.h"
+#include "drivers/time.h"
+
 #include "stm32f7xx_hal.h"
 #include "usbd_core.h"
 #include "usbd_desc.h"
 #include "usbd_cdc.h"
 #include "usbd_cdc_interface.h"
 #include "stdbool.h"
-
-#include "drivers/serial_usb_vcp.h"
-#include "drivers/time.h"
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/

--- a/src/main/vcp_hal/usbd_cdc_interface.h
+++ b/src/main/vcp_hal/usbd_cdc_interface.h
@@ -50,6 +50,8 @@
 #define __USBD_CDC_IF_H
 
 /* Includes ------------------------------------------------------------------*/
+#include "common/maths.h"
+
 #include "usbd_cdc.h"
 #include "stm32f7xx_hal.h"
 #include "usbd_core.h"

--- a/src/main/vcp_hal/usbd_conf.c
+++ b/src/main/vcp_hal/usbd_conf.c
@@ -46,6 +46,8 @@
   */
 
 /* Includes ------------------------------------------------------------------*/
+#include "common/maths.h"
+
 #include "stm32f7xx_hal.h"
 #include "usbd_core.h"
 #include "usbd_desc.h"

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -259,7 +259,7 @@ TEST(SchedulerUnittest, TestQueueArray)
     EXPECT_EQ(lastTaskPrev, taskQueueArray[enqueuedTasks - 2]);
     EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 1]); // NULL at end of queue
     EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
-    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 1]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
     taskQueueArray[enqueuedTasks - 1] = 0;

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -69,7 +69,7 @@ extern "C" {
     cfTask_t cfTasks[TASK_COUNT] = {
         [TASK_SYSTEM] = {
             .taskName = "SYSTEM",
-            .taskFunc = taskSystem,
+            .taskFunc = taskSystemLoad,
             .desiredPeriod = TASK_PERIOD_HZ(10),
             .staticPriority = TASK_PRIORITY_MEDIUM_HIGH,
         },
@@ -122,8 +122,6 @@ extern "C" {
 
 TEST(SchedulerUnittest, TestPriorites)
 {
-    EXPECT_EQ(20, TASK_COUNT);
-
     EXPECT_EQ(TASK_PRIORITY_MEDIUM_HIGH, cfTasks[TASK_SYSTEM].staticPriority);
     EXPECT_EQ(TASK_PRIORITY_REALTIME, cfTasks[TASK_GYROPID].staticPriority);
     EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_ACCEL].staticPriority);
@@ -238,64 +236,68 @@ TEST(SchedulerUnittest, TestQueueArray)
     queueClear();
     taskQueueArray[TASK_COUNT_UNITTEST + 1] = deadBeefPtr; // note, must set deadBeefPtr after queueClear
 
+    unsigned enqueuedTasks = 0;
+    EXPECT_EQ(enqueuedTasks, taskQueueSize);
+
     for (int taskId = 0; taskId < TASK_COUNT_UNITTEST - 1; ++taskId) {
-        setTaskEnabled(static_cast<cfTaskId_e>(taskId), true);
-        EXPECT_EQ(taskId + 1, taskQueueSize);
-        EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
+        if (cfTasks[taskId].taskFunc) {
+            setTaskEnabled(static_cast<cfTaskId_e>(taskId), true);
+            enqueuedTasks++;
+            EXPECT_EQ(enqueuedTasks, taskQueueSize);
+            EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
+        }
     }
 
-    EXPECT_EQ(TASK_COUNT_UNITTEST - 1, taskQueueSize);
-    EXPECT_NE(static_cast<cfTask_t*>(0), taskQueueArray[TASK_COUNT_UNITTEST - 2]);
-    const cfTask_t *lastTaskPrev = taskQueueArray[TASK_COUNT_UNITTEST - 2];
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]);
+    EXPECT_NE(static_cast<cfTask_t*>(0), taskQueueArray[enqueuedTasks - 1]);
+    const cfTask_t *lastTaskPrev = taskQueueArray[enqueuedTasks - 1];
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
     setTaskEnabled(TASK_SYSTEM, false);
-    EXPECT_EQ(TASK_COUNT_UNITTEST - 2, taskQueueSize);
-    EXPECT_EQ(lastTaskPrev, taskQueueArray[TASK_COUNT_UNITTEST - 3]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 2]); // NULL at end of queue
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]);
+    EXPECT_EQ(enqueuedTasks - 1, taskQueueSize);
+    EXPECT_EQ(lastTaskPrev, taskQueueArray[enqueuedTasks - 2]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 1]); // NULL at end of queue
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
-    taskQueueArray[TASK_COUNT_UNITTEST - 2] = 0;
+    taskQueueArray[enqueuedTasks - 1] = 0;
     setTaskEnabled(TASK_SYSTEM, true);
-    EXPECT_EQ(TASK_COUNT_UNITTEST - 1, taskQueueSize);
-    EXPECT_EQ(lastTaskPrev, taskQueueArray[TASK_COUNT_UNITTEST - 2]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]);
+    EXPECT_EQ(enqueuedTasks, taskQueueSize);
+    EXPECT_EQ(lastTaskPrev, taskQueueArray[enqueuedTasks - 1]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
     cfTaskInfo_t taskInfo;
-    getTaskInfo(static_cast<cfTaskId_e>(TASK_COUNT_UNITTEST - 1), &taskInfo);
+    getTaskInfo(static_cast<cfTaskId_e>(enqueuedTasks + 1), &taskInfo);
     EXPECT_EQ(false, taskInfo.isEnabled);
-    setTaskEnabled(static_cast<cfTaskId_e>(TASK_COUNT_UNITTEST - 1), true);
-    EXPECT_EQ(TASK_COUNT_UNITTEST, taskQueueSize);
-    EXPECT_EQ(lastTaskPrev, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]); // check no buffer overrun
+    setTaskEnabled(static_cast<cfTaskId_e>(enqueuedTasks), true);
+    EXPECT_EQ(enqueuedTasks, taskQueueSize);
+    EXPECT_EQ(lastTaskPrev, taskQueueArray[enqueuedTasks - 1]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]); // check no buffer overrun
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
     setTaskEnabled(TASK_SYSTEM, false);
-    EXPECT_EQ(TASK_COUNT_UNITTEST - 1, taskQueueSize);
-    //EXPECT_EQ(lastTaskPrev, taskQueueArray[TASK_COUNT_UNITTEST - 3]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]);
+    EXPECT_EQ(enqueuedTasks - 1, taskQueueSize);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
     setTaskEnabled(TASK_ACCEL, false);
-    EXPECT_EQ(TASK_COUNT_UNITTEST - 2, taskQueueSize);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 2]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]);
+    EXPECT_EQ(enqueuedTasks - 2, taskQueueSize);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 1]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 
     setTaskEnabled(TASK_BATTERY_VOLTAGE, false);
-    EXPECT_EQ(TASK_COUNT_UNITTEST - 3, taskQueueSize);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 3]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 2]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST - 1]);
-    EXPECT_EQ(NULL, taskQueueArray[TASK_COUNT_UNITTEST]);
+    EXPECT_EQ(enqueuedTasks - 2, taskQueueSize);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 2]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks - 1]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks]);
+    EXPECT_EQ(NULL, taskQueueArray[enqueuedTasks + 1]);
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT_UNITTEST + 1]);
 }
 


### PR DESCRIPTION
Also renames `subTaskMainSubprocesses()` into `subTaskPidSubprocesses()` to make it less likely for functions that are unrelated to the PID loop to end up in there.

The issue of `updateGPSRescueState()` in the PID loop will be addressed in another pull request.

Yields about 10% 'CPU load' reduction on F7 at 32 kHz PID loop.