### PR TITLE
Add Iterm Relax INC modes

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -809,19 +809,27 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         float acCorrection = 0;
         float acErrorRate;
 #endif        
-        float itermErrorRate = 0.0f;
+
+        const float ITerm = pidData[axis].I;
+        float itermErrorRate = currentPidSetpoint - gyroRate;
 
 #if defined(USE_ITERM_RELAX)
-        if (itermRelax && (axis < FD_YAW || itermRelax == ITERM_RELAX_RPY )) {
+        if (itermRelax && (axis < FD_YAW || itermRelax == ITERM_RELAX_RPY || itermRelax == ITERM_RELAX_RPY_INC)) {
             const float setpointLpf = pt1FilterApply(&windupLpf[axis], currentPidSetpoint);
             const float setpointHpf = fabsf(currentPidSetpoint - setpointLpf);
             const float itermRelaxFactor = 1 - setpointHpf / 30.0f;
-            if (itermRelaxType == ITERM_RELAX_SETPOINT && setpointHpf < 30) {
-                itermErrorRate = itermRelaxFactor * (currentPidSetpoint - gyroRate);
+
+            const bool isDecreasingI = ((ITerm > 0) && (itermErrorRate < 0)) || ((ITerm < 0) && (itermErrorRate > 0));
+            if ((itermRelax >= ITERM_RELAX_RP_INC) && isDecreasingI) {
+                // Do Nothing, use the precalculed itermErrorRate
+            } else if (itermRelaxType == ITERM_RELAX_SETPOINT && setpointHpf < 30) {
+                itermErrorRate *= itermRelaxFactor;
             } else if (itermRelaxType == ITERM_RELAX_GYRO ) {
                 itermErrorRate = fapplyDeadband(setpointLpf - gyroRate, setpointHpf);
+            } else {
+                itermErrorRate = 0.0f;
             }
-            
+
             if (axis == FD_ROLL) {
                 DEBUG_SET(DEBUG_ITERM_RELAX, 0, lrintf(setpointHpf));
                 DEBUG_SET(DEBUG_ITERM_RELAX, 1, lrintf(itermRelaxFactor * 100.0f));
@@ -849,7 +857,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         } else
 #endif // USE_ITERM_RELAX
         {
-            itermErrorRate = currentPidSetpoint - gyroRate;
 #if defined(USE_ABSOLUTE_CONTROL)
             acErrorRate = itermErrorRate;
 #endif // USE_ABSOLUTE_CONTROL
@@ -883,8 +890,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         }
 
         // -----calculate I component
-
-        const float ITerm = pidData[axis].I;
         const float ITermNew = constrainf(ITerm + pidCoefficient[axis].Ki * itermErrorRate * dynCi, -itermLimit, itermLimit);
         const bool outputSaturated = mixerIsOutputSaturated(axis, errorRate);
         if (outputSaturated == false || ABS(ITermNew) < ABS(ITerm)) {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -79,7 +79,9 @@ typedef struct pid8_s {
 typedef enum {
     ITERM_RELAX_OFF,
     ITERM_RELAX_RP,
-    ITERM_RELAX_RPY
+    ITERM_RELAX_RPY,
+    ITERM_RELAX_RP_INC,
+    ITERM_RELAX_RPY_INC
 } itermRelax_e;
 
 typedef enum {

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -339,7 +339,7 @@ static const char * const lookupTableVideoSystem[] = {
 
 #if defined(USE_ITERM_RELAX)
 static const char * const lookupTableItermRelax[] = {
-    "OFF", "RP", "RPY"
+    "OFF", "RP", "RPY", "RP_INC", "RPY_INC"
 };
 static const char * const lookupTableItermRelaxType[] = {
     "GYRO", "SETPOINT"


### PR DESCRIPTION
In the original Iterm Relax PR: https://github.com/betaflight/betaflight/pull/5963 I have a discussion with Joe about if it is a good idea or not to freeze the ITerm when it decreases (the error has disappear or is in the opposite direction).

Our ideas were different:
- Joe's idea was that is better to maintain the ITerm because the bias before the movement can exist after the movement, so is better to freeze it in both directions. The ITerm helps in the movement.
- My idea is that the bias before the movement is totally different to the bias after the movement, so is better not to freeze the ITerm when it tries to decrease until zero. The ITerm only must be active to fix errors.

So I decided to add two new modes (`RP_INC` and `RPY_INC`) that only freezes the ITerm when it is incrementing. In this way any user can test them to see if they like it more or less than the original version (or they don't see any difference).

The difference in flight is very small, my version has less second bounce after roll, and Joe's version has less first bounce but a little more of second bounce. But I think that without the freezed ITerm is easier to tune the P and D in this situations (end of rolls and flips).

In the normal version, the ITerm, in the end of the roll is opposing to the direction of the P. In the `INC` versions the I is zero at this moment, so in the `INC` version maybe is better to increment D by one or two points if you see you need it to stop the roll (other pilots have tested it without this change and they didn't modify nothing but it depends on each quad).

@joelucid @ctzsnooze maybe is interesting that you review the code, I tried to maintain the most possible your original code but maybe I made something wrong.