### PR TITLE
Enable using the 'heading' field in MAVlink to display mAh used

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -885,6 +885,12 @@ const clivalue_t valueTable[] = {
 #if defined(USE_TELEMETRY_SMARTPORT)
     { "smartport_use_extra_sensors", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, smartport_use_extra_sensors)},
 #endif
+#ifdef USE_TELEMETRY_MAVLINK
+    // Support for misusing the heading field in MAVlink to indicate mAh drawn for Connex Prosight OSD
+    // Set to 10 to show a tenth of your capacity drawn.
+    // Set to $size_of_battery to get a percentage of battery used.
+    { "mavlink_mah_as_heading_divisor", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 30000 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_mah_as_heading_divisor) },
+#endif
 #endif // USE_TELEMETRY
 
 // PG_LED_STRIP_CONFIG

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -77,6 +77,7 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
             IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE
     },
     .smartport_use_extra_sensors = false,
+    .mavlink_mah_as_heading_divisor = 0,
 );
 
 void telemetryInit(void)

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -54,6 +54,7 @@ typedef struct telemetryConfig_s {
     uint8_t report_cell_voltage;
     uint8_t flysky_sensors[IBUS_SENSOR_COUNT];
     uint8_t smartport_use_extra_sensors;
+    uint16_t mavlink_mah_as_heading_divisor;
 } telemetryConfig_t;
 
 PG_DECLARE(telemetryConfig_t, telemetryConfig);


### PR DESCRIPTION
The Connex Prosight OSD uses MAVlink telemetry to display it's stuff. This is great, because betaflight supports MAVlink. What's not so great is that the only data actually displayed is *heading*. Now, for most of us, getting mAh used is *much* more interesting than heading. Thus, this PR adds a flag that lets you display mAh used instead of heading in the MAVlink output. 
It's disabled by default, obviously, but can be enabled by doing `set mavlink_display_mah_drawn_in_heading_field = ON`.
As the number displayed can only be between 0 and 999, I've also included a scaling factor setting. By default, the scaling factor divides the value by 10, turning 1500 used mAh into "150" in the OSD. It's conceivable that people might want to set this scaling factor to the size of their lipo, to get what is effectively a "percentage used" meter, going from 0 to 100. This scaling factor is also configurable using the CLI.

~I tried write two unit tests, but the tool chain tells me `/usr/bin/ld: cannot find -lBlocksRuntime`. I'm not sure why, and I haven't been able to fix it. As a result, I haven't actually run the unit tests. I'm hoping that you have something like a CI pipeline that'll run the unit tests for me, or that someone can help me with that. I'm on WSL on windows, and I've followed all the instructions that were available.~ Somebody helped me. I'll make sure the tests are correct now...

Fair warning: I'm not a C developer by trade. I'm a Java developer. As a result, if this isn't "pure" or "correct" C, please feel free to tell me. I've done my best to adhere to the coding style etc, but it's entirely possible that I've forgotten something.