### PR TITLE
F4 DMA buffer should not reside in CCM

### DIFF
--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -44,9 +44,12 @@
 
 #if defined(STM32F1) || defined(STM32F3)
 uint8_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
-#else
+#elif defined(STM32F7)
 FAST_RAM_ZERO_INIT uint32_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
+#else
+uint32_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
 #endif
+
 volatile uint8_t ws2811LedDataTransferInProgress = 0;
 
 uint16_t BIT_COMPARE_1 = 0;


### PR DESCRIPTION
F4 DMA buffer should not reside in CCM, as DMA engines do not have path to CCM.
Tested with Omnibus F4 AIO (gen1).

Fixes: #6139 