### PR TITLE
Set low verbosity in Travis. Logs are too big for Travis to handle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_script:
   - clang --version
   - clang++ --version
   - gcc --version
+  - export V=0
 
 script: ./.travis.sh
 


### PR DESCRIPTION
Travis complains about our big logs, we need to set lower verbosity. Quote:

> This log is too long to be displayed. Please reduce the verbosity of your build or download the raw log. 