### PR TITLE
Fix gps rescue heading edge case

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -394,10 +394,11 @@ void setBearing(int16_t deg)
 {
     int16_t dif = DECIDEGREES_TO_DEGREES(attitude.values.yaw) - deg;
 
-    if (dif <= -180)
+    if (dif <= -180) {
         dif += 360;
-    if (dif >= +180)
+    } else if (dif > 180) {
         dif -= 360;
+    }
 
     dif *= -GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
 


### PR DESCRIPTION
The yaw heading calculation didn't handle edge cases like 180 and -180 well.  Also cleaned up coding style.

For example: if the `dif` value was -180 it would have been converted to +180 and then immediately back to -180.