### PR TITLE
New OSD element: Blackbox logging status

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -545,6 +545,9 @@ bool isBlackboxDeviceFull(void)
 bool isBlackboxDeviceWorking(void)
 {
     switch (blackboxConfig()->device) {
+    case BLACKBOX_DEVICE_SERIAL:
+        return true;
+
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
         return sdcard_isInserted() && sdcard_isFunctional() && (afatfs_getFilesystemState() == AFATFS_FILESYSTEM_STATE_READY);

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -41,6 +41,10 @@
 
 #include "msp/msp_serial.h"
 
+#ifdef USE_SDCARD
+#include "drivers/sdcard.h"
+#endif
+
 #define BLACKBOX_SERIAL_PORT_MODE MODE_TX
 
 // How many bytes can we transmit per loop iteration when writing headers?
@@ -532,6 +536,24 @@ bool isBlackboxDeviceFull(void)
     case BLACKBOX_DEVICE_SDCARD:
         return afatfs_isFull();
 #endif // USE_SDCARD
+
+    default:
+        return false;
+    }
+}
+
+bool isBlackboxDeviceWorking(void)
+{
+    switch (blackboxConfig()->device) {
+#ifdef USE_SDCARD
+    case BLACKBOX_DEVICE_SDCARD:
+        return sdcard_isInserted() && sdcard_isFunctional() && (afatfs_getFilesystemState() == AFATFS_FILESYSTEM_STATE_READY);
+#endif
+
+#ifdef USE_FLASHFS
+    case BLACKBOX_DEVICE_FLASH:
+        return flashfsIsReady();
+#endif
 
     default:
         return false;

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -546,7 +546,7 @@ bool isBlackboxDeviceWorking(void)
 {
     switch (blackboxConfig()->device) {
     case BLACKBOX_DEVICE_SERIAL:
-        return true;
+        return blackboxPort != NULL;
 
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -56,6 +56,7 @@ bool blackboxDeviceBeginLog(void);
 bool blackboxDeviceEndLog(bool retainLog);
 
 bool isBlackboxDeviceFull(void);
+bool isBlackboxDeviceWorking(void);
 unsigned int blackboxGetLogNumber(void);
 
 void blackboxReplenishHeaderBudget(void);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -985,6 +985,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_ADC_INTERNAL
     { "osd_core_temp_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CORE_TEMPERATURE]) },
 #endif
+#ifdef USE_BLACKBOX
+    { "osd_log_status_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_LOG_STATUS]) },
+#endif
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -203,7 +203,6 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_NUMERICAL_VARIO,
     OSD_COMPASS_BAR,
     OSD_ANTI_GRAVITY,
-    OSD_LOG_STATUS,
 #ifdef USE_RTC_TIME
     OSD_RTC_DATETIME,
 #endif
@@ -984,9 +983,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
 #ifdef USE_BLACKBOX
     case OSD_LOG_STATUS:
-        if (!IS_RC_MODE_ACTIVE(BOXBLACKBOX)) {
-            break;
-        } else if (!isBlackboxDeviceWorking()) {
+        if (!isBlackboxDeviceWorking()) {
             tfp_sprintf(buff, "L-");
         } else if (isBlackboxDeviceFull()) {
             tfp_sprintf(buff, "L>");
@@ -1042,6 +1039,11 @@ static void osdDrawElements(void)
     }
 #endif
 
+#ifdef USE_BLACKBOX
+    if (IS_RC_MODE_ACTIVE(BOXBLACKBOX)) {
+        osdDrawSingleElement(OSD_LOG_STATUS);
+    }
+#endif
 }
 
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -203,6 +203,7 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_NUMERICAL_VARIO,
     OSD_COMPASS_BAR,
     OSD_ANTI_GRAVITY,
+    OSD_LOG_STATUS,
 #ifdef USE_RTC_TIME
     OSD_RTC_DATETIME,
 #endif
@@ -212,7 +213,6 @@ static const uint8_t osdElementDisplayOrder[] = {
 #ifdef USE_ADC_INTERNAL
     OSD_CORE_TEMPERATURE,
 #endif
-    OSD_LOG_STATUS
 };
 
 PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 3);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -96,6 +96,7 @@ typedef enum {
     OSD_CORE_TEMPERATURE,
     OSD_ANTI_GRAVITY,
     OSD_G_FORCE,
+    OSD_LOG_STATUS,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -26,6 +26,7 @@ extern "C" {
     #include "build/debug.h"
 
     #include "blackbox/blackbox.h"
+    #include "blackbox/blackbox_io.h"
 
     #include "pg/pg.h"
     #include "pg/pg_ids.h"
@@ -1015,6 +1016,14 @@ extern "C" {
 
     unsigned int blackboxGetLogNumber() {
         return 0;
+    }
+
+    bool isBlackboxDeviceWorking() {
+        return true;
+    }
+
+    bool isBlackboxDeviceFull() {
+        return false;
     }
 
     bool isSerialTransmitBufferEmpty(const serialPort_t *) {


### PR DESCRIPTION
This PR adds a new OSD element for monitoring the status of blackbox logging. It displays the current log number when logging is activated and is invisible when logging is inactive. Also indicates the problem when logging is activated, but doesn't work either because the logging device is full or not functioning properly (for eg. SD card is not inserted).

| Symbols      | State                            |
| ------------ | -------------------------------- |
| `L-`         | Logging device is not functional |
| `L>`         | Logging device is full           |
| `L`_N_       | Showing current log number N     |
| (invisible)  | Logging is not active            |

May also be useful to verify whether SD card had been ejected or not after a crash.
