### PR TITLE
Hott telemetry alarm voltage and mAh

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -279,6 +279,16 @@ batteryState_e getBatteryState(void)
     return batteryState;
 }
 
+batteryState_e getVoltageState(void)
+{
+    return voltageState;
+}
+
+batteryState_e getConsumptionState(void)
+{
+    return consumptionState;
+}
+
 const char * const batteryStateStrings[] = {"OK", "WARNING", "CRITICAL", "NOT PRESENT", "INIT"};
 
 const char * getBatteryStateString(void)

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -71,6 +71,8 @@ void batteryUpdateVoltage(timeUs_t currentTimeUs);
 void batteryUpdatePresence(void);
 
 batteryState_e getBatteryState(void);
+batteryState_e getVoltageState(void);
+batteryState_e getConsumptionState(void);
 const  char * getBatteryStateString(void);
 
 void batteryUpdateStates(timeUs_t currentTimeUs);

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -234,15 +234,15 @@ static inline void updateAlarmBatteryStatus(HOTT_EAM_MSG_t *hottEAMMessage)
         if (voltageState == BATTERY_WARNING  || voltageState == BATTERY_CRITICAL) {
             hottEAMMessage->warning_beeps = 0x10;
             hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_BATTERY_1;
-		}
-		else if (consumptionState == BATTERY_WARNING  || consumptionState == BATTERY_CRITICAL) {
+	}
+	else if (consumptionState == BATTERY_WARNING  || consumptionState == BATTERY_CRITICAL) {
             hottEAMMessage->warning_beeps = 0x16;
             hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_MAH;
-		}		
-		else {
+	}		
+	else {
             hottEAMMessage->warning_beeps = HOTT_EAM_ALARM1_FLAG_NONE;
             hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_NONE;
-		}
+	}
     }
 }
 

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -229,14 +229,20 @@ static inline void updateAlarmBatteryStatus(HOTT_EAM_MSG_t *hottEAMMessage)
 {
     if (shouldTriggerBatteryAlarmNow()) {
         lastHottAlarmSoundTime = millis();
-        const batteryState_e batteryState = getBatteryState();
-        if (batteryState == BATTERY_WARNING  || batteryState == BATTERY_CRITICAL) {
+		const batteryState_e voltageState = getVoltageState();
+		const batteryState_e consumptionState = getConsumptionState();
+        if (voltageState == BATTERY_WARNING  || voltageState == BATTERY_CRITICAL) {
             hottEAMMessage->warning_beeps = 0x10;
             hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_BATTERY_1;
-        } else {
+		}
+		else if (consumptionState == BATTERY_WARNING  || consumptionState == BATTERY_CRITICAL) {
+            hottEAMMessage->warning_beeps = 0x16;
+            hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_MAH;
+		}		
+		else {
             hottEAMMessage->warning_beeps = HOTT_EAM_ALARM1_FLAG_NONE;
             hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_NONE;
-        }
+		}
     }
 }
 

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -229,8 +229,8 @@ static inline void updateAlarmBatteryStatus(HOTT_EAM_MSG_t *hottEAMMessage)
 {
     if (shouldTriggerBatteryAlarmNow()) {
         lastHottAlarmSoundTime = millis();
-		const batteryState_e voltageState = getVoltageState();
-		const batteryState_e consumptionState = getConsumptionState();
+	const batteryState_e voltageState = getVoltageState();
+	const batteryState_e consumptionState = getConsumptionState();
         if (voltageState == BATTERY_WARNING  || voltageState == BATTERY_CRITICAL) {
             hottEAMMessage->warning_beeps = 0x10;
             hottEAMMessage->alarm_invers1 = HOTT_EAM_ALARM1_FLAG_BATTERY_1;

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -265,6 +265,16 @@ batteryState_e getBatteryState(void)
 	return BATTERY_OK;
 }
 
+batteryState_e getVoltageState(void)
+{
+	return BATTERY_OK;
+}
+	
+batteryState_e getConsumptionState(void)	
+{
+	return BATTERY_OK;
+}
+	
 uint16_t getBatteryVoltage(void)
 {
     return testBatteryVoltage;


### PR DESCRIPTION
Add Hott voltage and mAh alarms.
batteryState are voltage alarm and mAh used alarm together.
Hott telemetry can difference between voltage alarm and mAh used alarm.