### PR TITLE
fixed open connection twice times and timeout logic

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -82,6 +82,7 @@
 #include "pg/vcd.h"
 #include "pg/usb.h"
 #include "pg/sdio.h"
+#include "pg/rcdevice.h"
 
 #include "rx/rx.h"
 #include "rx/cc2500_frsky_common.h"
@@ -1090,6 +1091,11 @@ const clivalue_t valueTable[] = {
 // PG_FLASH_CONFIG
 #ifdef USE_FLASH
     { "flash_spi_bus", VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, SPIDEV_COUNT }, PG_FLASH_CONFIG, offsetof(flashConfig_t, spiDevice) },
+#endif
+// RCDEVICE
+#ifdef USE_RCDEVICE
+    { "rcdevice_init_dev_attempts", VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 10 }, PG_RCDEVICE_CONFIG, offsetof(rcdeviceConfig_t, initDeviceAttempts) },
+    { "rcdevice_init_dev_attempt_interval", VAR_UINT32 | MASTER_VALUE, .config.minmax = { 500, 5000 }, PG_RCDEVICE_CONFIG, offsetof(rcdeviceConfig_t, initDeviceAttemptInterval) }
 #endif
 };
 

--- a/src/main/io/rcdevice.h
+++ b/src/main/io/rcdevice.h
@@ -125,8 +125,8 @@ struct rcdeviceResponseParseContext_s {
     uint8_t expectedRespLen; // total length of response data
     uint8_t recvRespLen; // length of the data received
     uint8_t *recvBuf; // response data buffer
-    timeUs_t timeout;
-    timeUs_t timeoutTimestamp; // if zero, it's means keep waiting for the response
+    timeMs_t timeout;
+    timeMs_t timeoutTimestamp; // if zero, it's means keep waiting for the response
     rcdeviceRespParseFunc parserFunc;
     runcamDevice_t *device;
     uint8_t paramData[RCDEVICE_PROTOCOL_MAX_DATA_SIZE];

--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -25,7 +25,7 @@
 
 #include "pg/rx.h"
 
-#include "drivers/time.h"
+#include "common/time.h"
 
 #include "cms/cms.h"
 
@@ -147,7 +147,7 @@ static void rcdeviceSimulationRespHandle(rcdeviceResponseParseContext_t *ctx)
         rcdeviceSimulationOSDCableFailed(ctx);
         return;
     }
-    
+
     switch (ctx->command) {
     case RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_RELEASE:
         isButtonPressed = false;
@@ -156,6 +156,7 @@ static void rcdeviceSimulationRespHandle(rcdeviceResponseParseContext_t *ctx)
     {
         // the high 4 bits is the operationID that we sent
         // the low 4 bits is the result code
+        isButtonPressed = true;
         uint8_t operationID = ctx->paramData[0];
         bool errorCode = (ctx->recvBuf[1] & 0x0F);
         if (operationID == RCDEVICE_PROTOCOL_5KEY_CONNECTION_OPEN) {

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -133,7 +133,8 @@
 #define PG_SPI_PREINIT_OPU_CONFIG 536
 #define PG_RX_SPI_CONFIG 537
 #define PG_BOARD_CONFIG 538
-#define PG_BETAFLIGHT_END 538
+#define PG_RCDEVICE_CONFIG 539
+#define PG_BETAFLIGHT_END 539
 
 
 // OSD configuration (subject to change)

--- a/src/main/pg/rcdevice.c
+++ b/src/main/pg/rcdevice.c
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pg/pg_ids.h"
+#include "pg/rcdevice.h"
+
+PG_REGISTER_WITH_RESET_FN(rcdeviceConfig_t, rcdeviceConfig, PG_RCDEVICE_CONFIG, 0);
+
+void pgResetFn_rcdeviceConfig(rcdeviceConfig_t *rcdeviceConfig)
+{
+    rcdeviceConfig->initDeviceAttempts = 4;
+    rcdeviceConfig->initDeviceAttemptInterval = 1000;
+}

--- a/src/main/pg/rcdevice.h
+++ b/src/main/pg/rcdevice.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pg/pg.h"
+#include "common/time.h"
+
+typedef struct rcdeviceConfig_s {
+    uint8_t initDeviceAttempts;
+    timeMs_t initDeviceAttemptInterval;
+} rcdeviceConfig_t;
+
+PG_DECLARE(rcdeviceConfig_t, rcdeviceConfig);


### PR DESCRIPTION
Hi, 

In today's test, two problems were discovered:
1. The timestamp unit in the timeout processing is incorrect
2. There is a bug for the logic of the open connection of UART adapter, which causes the joystick to be pulled to the right to directly open the menu (expected to open the connection mode).

This PR is to fix the above two problems