### PR TITLE
Add SUMD V3 support

### DIFF
--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -44,8 +44,9 @@
 
 // driver for SUMD receiver using UART2
 
-// Support for SUMD, and SUMD v3
-// Should probably work up to 32 (MZ-32 and SUMD V3) channels
+// Support for SUMD and SUMD V3
+// Tested with 16 channels, SUMD supports up to 16(*), SUMD V3 up to 32 (MZ-32) channels, but limit to MAX_SUPPORTED_RC_CHANNEL_COUNT (currently 8, BF 3.4)
+// * According to the original SUMD V1 documentation, SUMD V1 already supports up to 32 Channels?!?
 
 #define SUMD_SYNCBYTE 0xA8
 #define SUMD_MAX_CHANNEL 32

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -44,16 +44,17 @@
 
 // driver for SUMD receiver using UART2
 
-// FIXME test support for more than 8 channels, should probably work up to 12 channels
+// Support for SUMD, and SUMD v3
+// Should probably work up to 32 (MZ-32 and SUMD V3) channels
 
 #define SUMD_SYNCBYTE 0xA8
-#define SUMD_MAX_CHANNEL 16
+#define SUMD_MAX_CHANNEL 32
 #define SUMD_BUFFSIZE (SUMD_MAX_CHANNEL * 2 + 5) // 6 channels + 5 = 17 bytes for 6 channels
 
 #define SUMD_BAUDRATE 115200
 
 static bool sumdFrameDone = false;
-static uint16_t sumdChannels[SUMD_MAX_CHANNEL];
+static uint16_t sumdChannels[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 static uint16_t crc;
 
 static uint8_t sumd[SUMD_BUFFSIZE] = { 0, };
@@ -101,7 +102,8 @@ static void sumdDataReceive(uint16_t c, void *data)
 #define SUMD_BYTES_PER_CHANNEL 2
 
 
-#define SUMD_FRAME_STATE_OK 0x01
+#define SUMDV1_FRAME_STATE_OK 0x01
+#define SUMDV3_FRAME_STATE_OK 0x03
 #define SUMD_FRAME_STATE_FAILSAFE 0x81
 
 static uint8_t sumdFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
@@ -127,15 +129,16 @@ static uint8_t sumdFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
         case SUMD_FRAME_STATE_FAILSAFE:
             frameStatus = RX_FRAME_COMPLETE | RX_FRAME_FAILSAFE;
             break;
-        case SUMD_FRAME_STATE_OK:
+        case SUMDV1_FRAME_STATE_OK:
+        case SUMDV3_FRAME_STATE_OK:
             frameStatus = RX_FRAME_COMPLETE;
             break;
         default:
             return frameStatus;
     }
 
-    if (sumdChannelCount > SUMD_MAX_CHANNEL)
-        sumdChannelCount = SUMD_MAX_CHANNEL;
+    if (sumdChannelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT)
+        sumdChannelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
 
     for (channelIndex = 0; channelIndex < sumdChannelCount; channelIndex++) {
         sumdChannels[channelIndex] = (
@@ -156,7 +159,7 @@ bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     UNUSED(rxConfig);
 
-    rxRuntimeConfig->channelCount = SUMD_MAX_CHANNEL;
+    rxRuntimeConfig->channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
     rxRuntimeConfig->rxRefreshRate = 11000;
 
     rxRuntimeConfig->rcReadRawFn = sumdReadRawRC;

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -28,6 +28,7 @@
 
 #include "common/crc.h"
 #include "common/utils.h"
+#include "common/maths.h"
 
 #include "drivers/time.h"
 
@@ -160,7 +161,7 @@ bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     UNUSED(rxConfig);
 
-    rxRuntimeConfig->channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
+    rxRuntimeConfig->channelCount = MIN(SUMD_MAX_CHANNEL, MAX_SUPPORTED_RC_CHANNEL_COUNT);
     rxRuntimeConfig->rxRefreshRate = 11000;
 
     rxRuntimeConfig->rcReadRawFn = sumdReadRawRC;


### PR DESCRIPTION
The new firmware for Graupner receivers bring us a new SUMD version: V3.
As far as i can see, its pretty the same as the old version, but supports now up to 32 Channels (theoretically already the old version supports 32 channels, according to the documentation), for the new MZ-32 transmitter with 32 real channels.
The header changed and a standard frame transports now 18 channels.
I think its not necessary to implement it as a new protocol, V3 can easily handled in the existing code. 