### PR TITLE
Fixed call to checkBootloaderRequest()

### DIFF
--- a/src/main/startup/startup_stm32f411xe.s
+++ b/src/main/startup/startup_stm32f411xe.s
@@ -71,13 +71,8 @@ defined in linker script */
   .weak  Reset_Handler
   .type  Reset_Handler, %function
 Reset_Handler: 
-  // Check for bootloader reboot
-  ldr r0, =0x2001FFFC         // mj666
-  ldr r1, =0xDEADBEEF         // mj666
-  ldr r2, [r0, #0]            // mj666
-  str r0, [r0, #0]            // mj666
-  cmp r2, r1                  // mj666
-  beq Reboot_Loader           // mj666
+  // Defined in C code
+  bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0
@@ -136,13 +131,6 @@ LoopMarkHeapStack:
 LoopForever:
   b LoopForever
 
-Reboot_Loader:                // mj666
-
-  // Reboot to ROM            // mj666
-  ldr     r0, =0x1FFF0000     // mj666
-  ldr     sp,[r0, #0]         // mj666
-  ldr     r0,[r0, #4]         // mj666
-  bx      r0                  // mj666
 .size  Reset_Handler, .-Reset_Handler
 
 /**


### PR DESCRIPTION
Fixes #5887, overlooked during #5193

Tested on Nox v2.15, only affects F411 targets.