### PR TITLE
Revise GPS Rescue throttle and yaw handling to not modify rcCommand

### DIFF
--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -176,6 +176,12 @@ int scaleRange(int x, int srcFrom, int srcTo, int destFrom, int destTo) {
     return (a / b) + destFrom;
 }
 
+float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float destTo) {
+    float a = (destTo - destFrom) * (x - srcFrom);
+    float b = srcTo - srcFrom;
+    return (a / b) + destFrom;
+}
+
 // Normalize a vector
 void normalizeV(struct fp_vector *src, struct fp_vector *dest)
 {

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -102,6 +102,7 @@ float devStandardDeviation(stdev_t *dev);
 float degreesToRadians(int16_t degrees);
 
 int scaleRange(int x, int srcFrom, int srcTo, int destFrom, int destTo);
+float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float destTo);
 
 void normalizeV(struct fp_vector *src, struct fp_vector *dest);
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -992,11 +992,6 @@ static FAST_CODE_NOINLINE void subTaskRcCommand(timeUs_t currentTimeUs)
 
     processRcCommand();
 
-#if defined(USE_GPS_RESCUE)
-    if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-        gpsRescueInjectRcCommands();
-    }
-#endif
 }
 
 // Function for loop trigger

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -50,6 +50,9 @@
 
 #include "gps_rescue.h"
 
+#define GPS_RESCUE_MAX_YAW_RATE 180        // 180 deg/sec
+#define GPS_RESCUE_RATE_SCALE_DEGREES 20   // Scale the commanded yaw rate when the error is less then this angle
+
 PG_REGISTER_WITH_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 0);
 
 PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
@@ -71,8 +74,8 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .minSats = 8
 );
 
-static uint16_t      rescueThrottle;
-static int16_t       rescueYaw;
+static uint16_t rescueThrottle;
+static float    rescueYaw;
 
 int32_t       gpsRescueAngle[ANGLE_INDEX_COUNT] = { 0, 0 };
 uint16_t      hoverThrottle = 0;
@@ -319,6 +322,11 @@ void idleTasks()
     rescueThrottle = rcCommand[THROTTLE];
 
     //to do: have a default value for hoverThrottle
+    
+    // FIXME: GPS Rescue throttle handling should take into account min_check as the
+    // active throttle is from min_check through PWM_RANGE_MAX. Currently adjusting for this
+    // in gpsRescueGetThrottle() but it would be better handled here.
+
     float ct = getCosTiltAngle();
     if (ct > 0.5 && ct < 0.96 && throttleSamples < 1E6 && rescueThrottle > 1070) { //5 to 45 degrees tilt
         //TO DO: only sample when acceleration is low
@@ -395,25 +403,48 @@ void rescueAttainPosition()
 }
 
 // Very similar to maghold function on betaflight/cleanflight
-void setBearing(int16_t deg)
+void setBearing(int16_t desiredHeading)
 {
-    int16_t dif = DECIDEGREES_TO_DEGREES(attitude.values.yaw) - deg;
+    float errorAngle = DECIDEGREES_TO_DEGREES(attitude.values.yaw) - desiredHeading;
 
-    if (dif <= -180) {
-        dif += 360;
-    } else if (dif > 180) {
-        dif -= 360;
+    // Determine the most efficient direction to rotate
+    if (errorAngle <= -180) {
+        errorAngle += 360;
+    } else if (errorAngle > 180) {
+        errorAngle -= 360;
     }
 
-    dif *= -GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
+    errorAngle *= -GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
+    const int errorAngleSign = (errorAngle < 0) ? -1 : 1;
+    const float errorAngleAbs = ABS(errorAngle);
+        
+    // Calculate a desired yaw rate based on a maximum limit beyond
+    // an error window and then scale the requested rate down inside
+    // the window as error approaches 0.
+    rescueYaw = (errorAngleAbs > GPS_RESCUE_RATE_SCALE_DEGREES) ? GPS_RESCUE_MAX_YAW_RATE : errorAngleAbs;
 
-    rescueYaw = - (dif * gpsRescueConfig()->yawP / 20);
+    rescueYaw *= errorAngleSign;
 }
 
-void gpsRescueInjectRcCommands(void)
+float gpsRescueGetYawRate(void)
 {
-    rcCommand[THROTTLE] = rescueThrottle;
-    rcCommand[YAW] = rescueYaw;
+    return rescueYaw;
+}
+
+float gpsRescueGetThrottle(void)
+{
+    float commandedThrottle = 0;
+    const int minCheck = MAX(rxConfig()->mincheck, 1000);
+    
+    // We need to compensate for min_check since the throttle value set by gps rescue
+    // is based on the raw rcCommand value commanded by the pilot.
+    if (rescueThrottle > minCheck) {
+        // Calculated a desired commanded throttle scaled from 0.0 to 1.0 for use in the mixer.
+        commandedThrottle = (float)(rescueThrottle - minCheck) / (PWM_RANGE_MAX - minCheck);
+        commandedThrottle = constrainf(commandedThrottle, 0.0f, 1.0f);
+    }
+    
+    return commandedThrottle;
 }
 
 #endif

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -50,8 +50,8 @@
 
 #include "gps_rescue.h"
 
-#define GPS_RESCUE_MAX_YAW_RATE 180        // 180 deg/sec
-#define GPS_RESCUE_RATE_SCALE_DEGREES 20   // Scale the commanded yaw rate when the error is less then this angle
+#define GPS_RESCUE_MAX_YAW_RATE       100  // 100 deg/sec max yaw
+#define GPS_RESCUE_RATE_SCALE_DEGREES 45   // Scale the commanded yaw rate when the error is less then this angle
 
 PG_REGISTER_WITH_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 0);
 
@@ -421,6 +421,11 @@ void setBearing(int16_t desiredHeading)
     // Calculate a desired yaw rate based on a maximum limit beyond
     // an error window and then scale the requested rate down inside
     // the window as error approaches 0.
+    if (errorAngleAbs > GPS_RESCUE_RATE_SCALE_DEGREES) {
+        rescueYaw = GPS_RESCUE_MAX_YAW_RATE;
+    } else {
+        rescueYaw = (errorAngleAbs / GPS_RESCUE_RATE_SCALE_DEGREES) * GPS_RESCUE_MAX_YAW_RATE;
+    }
     rescueYaw = (errorAngleAbs > GPS_RESCUE_RATE_SCALE_DEGREES) ? GPS_RESCUE_MAX_YAW_RATE : errorAngleAbs;
 
     rescueYaw *= errorAngleSign;

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -109,4 +109,5 @@ void sensorUpdate(void);
 
 void rescueAttainPosition(void);
 
-void gpsRescueInjectRcCommands(void);
+float gpsRescueGetYawRate(void);
+float gpsRescueGetThrottle(void);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -54,6 +54,7 @@
 
 #include "flight/failsafe.h"
 #include "flight/imu.h"
+#include "flight/gps_rescue.h"
 #include "flight/mixer.h"
 #include "flight/mixer_tricopter.h"
 #include "flight/pid.h"
@@ -807,6 +808,14 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensa
     if (throttleBoost > 0.0f) {
         float throttlehpf = throttle - pt1FilterApply(&throttleLpf, throttle);
         throttle = constrainf(throttle + throttleBoost * throttlehpf, 0.0f, 1.0f);
+    }
+#endif
+
+#ifdef USE_GPS_RESCUE
+    // If gps rescue is active then override the throttle. This prevents things
+    // like throttle boost or throttle limit from negatively affecting the throttle.
+    if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+        throttle = gpsRescueGetThrottle();
     }
 #endif
 


### PR DESCRIPTION
Fixes #6225 

Injecting new values directly into rcCommand to override pilot inputs does not work correctly when rc interpolation or smoothing is enabled. This is because the smoothing functions maintain an internal state that is used to produce the final rcCommand values. So in effect it re-overrides the values set by GPS Rescue.

Additionally, modifying rcCommand directly is undesirable because:
- It happens before rates are applied. So the pilot's rates will effect the control commanded by GPS Rescue.
- rcCommand values are used for more than input in the flight control. They also are used for stick commands, etc.
- In the case of throttle, various modifications can be additionally applied like throttle boost and throttle limit that may negatively effect GPS Rescue.

These changes revise the logic to only modify the commanded values used in the PID controller (yaw) and mixer (throttle) rather than attempting to override rcCommand.
