### PR TITLE
Add OSD elements to order loop

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -197,7 +197,16 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_NUMERICAL_HEADING,
     OSD_NUMERICAL_VARIO,
     OSD_COMPASS_BAR,
-    OSD_ANTI_GRAVITY
+    OSD_ANTI_GRAVITY,
+#ifdef USE_RTC_TIME
+    OSD_RTC_DATETIME,
+#endif
+#ifdef USE_OSD_ADJUSTMENTS
+    OSD_ADJUSTMENT_RANGE,
+#endif
+#ifdef USE_ADC_INTERNAL
+    OSD_CORE_TEMPERATURE,
+#endif
 };
 
 PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 3);
@@ -988,17 +997,6 @@ static void osdDrawElements(void)
     }
 #endif
 
-#ifdef USE_RTC_TIME
-    osdDrawSingleElement(OSD_RTC_DATETIME);
-#endif
-
-#ifdef USE_OSD_ADJUSTMENTS
-    osdDrawSingleElement(OSD_ADJUSTMENT_RANGE);
-#endif
-
-#ifdef USE_ADC_INTERNAL
-    osdDrawSingleElement(OSD_CORE_TEMPERATURE);
-#endif
 }
 
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)


### PR DESCRIPTION
The `osdDrawElements()` method uses the `osdElementDisplayOrder` array to draw in a loop each of the elements of the OSD, except the elements that need to be drawn or not depending on some state in execution (sensor GPS available, sensor ACC, etc.) that are added individually to the code.

Some elements that depend on `defines` where added directly to the `osdDrawElements()` method, but I think is better and cleaner to add them to the `osdElementDisplayOrder` array in a conditional way. 

The ideal will be to have all the elements in an array, but I don't see an easy way to do it.