### PR TITLE
Disable GPS Rescue if 3D feature is enabled

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -256,7 +256,7 @@ void updateArmingStatus(void)
         }
 
 #ifdef USE_GPS_RESCUE
-        if (isModeActivationConditionPresent(BOXGPSRESCUE)) {
+        if (isModeActivationConditionPresent(BOXGPSRESCUE) && !feature(FEATURE_3D)) {
             if (!gpsRescueConfig()->minSats || STATE(GPS_FIX_HOME) || ARMING_FLAG(WAS_EVER_ARMED)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {
@@ -759,7 +759,7 @@ bool processRx(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_GPS_RESCUE
-    if (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE)) {
+    if (!feature(FEATURE_3D) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
         if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }

--- a/src/main/interface/msp_box.c
+++ b/src/main/interface/msp_box.c
@@ -197,7 +197,11 @@ void initActiveBoxIds(void)
     if (feature(FEATURE_GPS)) {
         BME(BOXGPSHOME);
         BME(BOXGPSHOLD);
-        BME(BOXGPSRESCUE);
+#ifdef USE_GPS_RESCUE
+        if (!feature(FEATURE_3D)) {
+            BME(BOXGPSRESCUE);
+        }
+#endif
         BME(BOXBEEPGPSCOUNT);
     }
 #endif

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -532,7 +532,9 @@ void gpsUpdate(timeUs_t currentTimeUs)
         updateGpsIndicator(currentTimeUs);
     }
 #if defined(USE_GPS_RESCUE)
-    updateGPSRescueState();
+    if (!feature(FEATURE_3D)) {
+        updateGPSRescueState();
+    }
 #endif
 }
 


### PR DESCRIPTION
Fixes #6234 

If the 3D feature is active, then disable GPS Rescue.
- Prevent the GPS Rescue flight mode from being activated.
- Prevent the mode from displaying in the configurator.
- Reset the `failsafe_procedure` to DROP if it was previously configured as GPS-RESCUE.
- Don't call updateGPSRescueState()
