### PR TITLE
Change TASK_RX frequency from 50hz (20ms) to 33hz (30ms)

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -486,7 +486,6 @@ FAST_CODE uint8_t processRcSmoothingFilter(void)
                     }
                 } else {
                     // we have either stopped receiving rx samples (failsafe?) or the sample time is unreasonable so reset the accumulation
-                    validRxFrameTimeMs = 0;
                     rcSmoothingResetAccumulation(&rcSmoothingData);
                 }
             }

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -177,7 +177,7 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
     }
 
     static timeUs_t lastRxTimeUs;
-    currentRxRefreshRate = constrain(currentTimeUs - lastRxTimeUs, 1000, 20000);
+    currentRxRefreshRate = constrain(currentTimeUs - lastRxTimeUs, 1000, 30000);
     lastRxTimeUs = currentTimeUs;
     isRXDataNew = true;
 
@@ -459,7 +459,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskName = "RX",
         .checkFunc = rxUpdateCheck,
         .taskFunc = taskUpdateRxMain,
-        .desiredPeriod = TASK_PERIOD_HZ(50),        // If event-based scheduling doesn't work, fallback to periodic scheduling
+        .desiredPeriod = TASK_PERIOD_HZ(33),        // If event-based scheduling doesn't work, fallback to periodic scheduling
         .staticPriority = TASK_PRIORITY_HIGH,
     },
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -102,6 +102,7 @@ uint32_t rcInvalidPulsPeriod[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 #define PPM_AND_PWM_SAMPLE_COUNT 3
 
 #define DELAY_50_HZ (1000000 / 50)
+#define DELAY_33_HZ (1000000 / 33)
 #define DELAY_10_HZ (1000000 / 10)
 #define DELAY_5_HZ (1000000 / 5)
 #define SKIP_RC_ON_SUSPEND_PERIOD 1500000           // 1.5 second period in usec (call frequency independent)
@@ -542,7 +543,7 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
     }
 
     rxDataProcessingRequired = false;
-    rxNextUpdateAtUs = currentTimeUs + DELAY_50_HZ;
+    rxNextUpdateAtUs = currentTimeUs + DELAY_33_HZ;
 
     // only proceed when no more samples to skip and suspend period is over
     if (skipRxSamples) {


### PR DESCRIPTION
Fixes #6257 
Fixes #6239 

Workaround to better handle RX protocols that have frame intervals >= 20ms.  Otherwise the task would run at the end of the task interval causing slower protocols to run again after the remaining delay. This interferes with rc interpolation and also the frame rate detection in rc smoothing.

We should review `processRx()` in fc/fc_core.c and the processing it performs to make sure there's no impact from the potentially slower minimum frequency.  The minimum will only happen during signal loss situations or when using PWM.

Tested with SBUS (9ms), PPM (27ms) and PWM (runs at task rate of 30ms).
