### PR TITLE
Call flashfsIsSupported instead of flashfsIsReady to check flash chip existence

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -259,7 +259,7 @@ bool blackboxDeviceOpen(void)
         break;
 #ifdef USE_FLASHFS
     case BLACKBOX_DEVICE_FLASH:
-        if (flashfsGetSize() == 0 || isBlackboxDeviceFull()) {
+        if (!flashfsIsSupported() || isBlackboxDeviceFull()) {
             return false;
         }
 

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -122,7 +122,7 @@ static void cmsx_Blackbox_GetDeviceStatus(void)
     case BLACKBOX_DEVICE_FLASH:
         unit = "KB";
 
-        storageDeviceIsWorking = flashfsIsReady();
+        storageDeviceIsWorking = flashfsIsSupported();
         if (storageDeviceIsWorking) {
             tfp_sprintf(cmsx_BlackboxStatus, "READY");
 
@@ -149,6 +149,10 @@ static void cmsx_Blackbox_GetDeviceStatus(void)
 static long cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
 {
     UNUSED(ptr);
+
+    if (!flashfsIsSupported()) {
+        return 0;
+    }
 
     displayClearScreen(pDisplay);
     displayWrite(pDisplay, 5, 3, "ERASING FLASH...");

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2057,6 +2057,10 @@ static void cliFlashErase(char *cmdline)
 {
     UNUSED(cmdline);
 
+    if (!flashfsIsSupported()) {
+        return;
+    }
+
 #ifndef MINIMAL_CLI
     uint32_t i = 0;
     cliPrintLine("Erasing, please wait ... ");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1275,7 +1275,7 @@ static void osdGetBlackboxStatusString(char * buff)
 
 #ifdef USE_FLASHFS
     case BLACKBOX_DEVICE_FLASH:
-        storageDeviceIsWorking = flashfsIsReady();
+        storageDeviceIsWorking = flashfsIsSupported();
         if (storageDeviceIsWorking) {
             const flashGeometry_t *geometry = flashfsGetGeometry();
             storageTotal = geometry->totalSize / 1024;


### PR DESCRIPTION
Fixes: #6236 

There are number of cases that a flash chip is non-existent even if it is configured in target definition:
- Flash chip is selected as blackbox device on a flash/sdcard dual storage configuration board, but the board actually does not have the flash chip.
- A flash is provisioned as an optional daughter board.
- Incorrect target firmware, almost identical, but differs in flash v.s. sdcard is flashed (This is #6207 case).

This PR replaces calls to `flashfsIsReady` with calls to `flashfsIsSupported` (or add one) whenever the purpose of the call is to check flash chip existence.