### PR TITLE
Add Acro Trainer as flight mode to OSD

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -583,6 +583,8 @@ static bool osdDrawSingleElement(uint8_t item)
                 strcpy(buff, "HOR ");
             } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
                 strcpy(buff, "RESC");
+            } else if (IS_RC_MODE_ACTIVE(BOXACROTRAINER)) {
+                strcpy(buff, "ATRN");
             } else if (isAirmodeActive()) {
                 strcpy(buff, "AIR ");
             } else {


### PR DESCRIPTION
To help prevent taking off in Acro Trainer mode while flying FPV and avoid surprises. I deliberately picked the string `ATRN` over smth. like `ACTR`, because it is less similar to `ACRO` and hopefully easier to recognize quickly.