### PR TITLE
Fix SPI FrskyD rx frame rate detection

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -75,7 +75,7 @@ enum {
 #define RC_SMOOTHING_FILTER_TRAINING_DELAY_MS   1000  // Additional time to wait after receiving first valid rx frame before initial training starts
 #define RC_SMOOTHING_FILTER_RETRAINING_DELAY_MS 2000  // Guard time to wait after retraining to prevent retraining again too quickly
 #define RC_SMOOTHING_RX_RATE_CHANGE_PERCENT     20    // Look for samples varying this much from the current detected frame rate to initiate retraining
-#define RC_SMOOTHING_RX_RATE_MIN_US             5000  // 5ms or 200hz
+#define RC_SMOOTHING_RX_RATE_MIN_US             1000  // 1ms
 #define RC_SMOOTHING_RX_RATE_MAX_US             50000 // 50ms or 20hz
 
 static FAST_RAM_ZERO_INIT rcSmoothingFilter_t rcSmoothingData;


### PR DESCRIPTION
Decrease the minimum on the valid rx frame time window. SPI FrskyD seems to have frames with quite variable timing and if a frame was outside the valid window training would get reset and never complete.  The valid frame timings have no impact on the calculations or operation - they are just sanity checks.