### PR TITLE
Optimized CMS over CRSF initialization

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -112,7 +112,6 @@
 #include "io/beeper.h"
 #include "io/displayport_max7456.h"
 #include "io/displayport_srxl.h"
-#include "io/displayport_crsf.h"
 #include "io/serial.h"
 #include "io/flashfs.h"
 #include "io/gps.h"
@@ -600,10 +599,6 @@ void init(void)
 #if defined(USE_CMS) && defined(USE_SPEKTRUM_CMS_TELEMETRY) && defined(USE_TELEMETRY_SRXL)
     // Register the srxl Textgen telemetry sensor as a displayport device
     cmsDisplayPortRegister(displayPortSrxlInit());
-#endif
-
-#if defined(USE_CMS) && defined(USE_CRSF_CMS_TELEMETRY) && defined(USE_TELEMETRY)
-    cmsDisplayPortRegister(displayPortCrsfInit());
 #endif
 
 #ifdef USE_GPS

--- a/src/main/io/displayport_crsf.c
+++ b/src/main/io/displayport_crsf.c
@@ -200,6 +200,7 @@ int crsfDisplayPortNextRow(void)
 
 displayPort_t *displayPortCrsfInit()
 {
+    crsfDisplayPortSetDimensions(CRSF_DISPLAY_PORT_ROWS_MAX, CRSF_DISPLAY_PORT_COLS_MAX);
     displayInit(&crsfDisplayPort, &crsfDisplayPortVTable);
     return &crsfDisplayPort;
 }

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -40,6 +40,8 @@
 #include "common/streambuf.h"
 #include "common/utils.h"
 
+#include "cms/cms.h"
+
 #include "drivers/nvic.h"
 
 #include "fc/config.h"
@@ -429,6 +431,10 @@ void initCrsfTelemetry(void)
     deviceInfoReplyPending = false;
 #if defined(USE_MSP_OVER_TELEMETRY)
     mspReplyPending = false;
+#endif
+
+#if defined(USE_CMS) && defined(USE_CRSF_CMS_TELEMETRY)
+    cmsDisplayPortRegister(displayPortCrsfInit());
 #endif
 
     int index = 0;


### PR DESCRIPTION
Moved CMS over CRSF init from `fc/fc_init.c` to `telemetry/crsf.c` and updated initialization to default the screen size to MAX boundaries for rows and columns.

I tested this with a MATEKF405 using an Taranis X9D and X-Lite.  Initialization and screen sizes appear adjusted properly by the lua scripts when opening the telem script.

This should fix the CMS exit issue, but would prefer someone test it with the affected hardware in the reported issue just to ensure a proper test case.