### PR TITLE
[GPS RESCUE] - disable immediate re-arming on land/abort for gps rescue

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -172,6 +172,7 @@ void updateGPSRescueState(void)
 
         // If we are over 120% of average magnitude, just disarm since we're pretty much home
         if (rescueState.sensor.accMagnitude > rescueState.sensor.accMagnitudeAvg * 1.5) {
+            setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
             disarm();
             rescueState.phase = RESCUE_COMPLETE;
         }
@@ -186,6 +187,7 @@ void updateGPSRescueState(void)
         rescueStop();
         break;
     case RESCUE_ABORT:
+        setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
         disarm();
         rescueStop();
         break;


### PR DESCRIPTION
When GPS rescue touches down on ground, the disarm immediately re-engages if the arm switch is active still and it is not a failsafe.  This should do the trick!