### PR TITLE
RC smoothing filters not initialized arming disabled reason

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -265,37 +265,45 @@ void updateArmingStatus(void)
         }
 #endif
 
+#ifdef USE_RC_SMOOTHING_FILTER
+        if ((rxConfig()->rc_smoothing_type == RC_SMOOTHING_TYPE_FILTER) && !rcSmoothingFilterInitialized()) {
+            setArmingDisabled(ARMING_DISABLED_RC_SMOOTHING);
+        } else {
+            unsetArmingDisabled(ARMING_DISABLED_RC_SMOOTHING);
+        }
+#endif // USE_RC_SMOOTHING_FILTER
+
         if (IS_RC_MODE_ACTIVE(BOXPARALYZE) && paralyzeModeAllowed) {
             setArmingDisabled(ARMING_DISABLED_PARALYZE);
             dispatchAdd(&preventModeChangesDispatchEntry, PARALYZE_PREVENT_MODE_CHANGES_DELAY_US);
         }
 
         if (!isUsingSticksForArming()) {
-          /* Ignore ARMING_DISABLED_CALIBRATING if we are going to calibrate gyro on first arm */
-          bool ignoreGyro = armingConfig()->gyro_cal_on_first_arm
-                         && !(getArmingDisableFlags() & ~(ARMING_DISABLED_ARM_SWITCH | ARMING_DISABLED_CALIBRATING));
+            /* Ignore ARMING_DISABLED_CALIBRATING if we are going to calibrate gyro on first arm */
+            bool ignoreGyro = armingConfig()->gyro_cal_on_first_arm
+                              && !(getArmingDisableFlags() & ~(ARMING_DISABLED_ARM_SWITCH | ARMING_DISABLED_CALIBRATING));
 
-          /* Ignore ARMING_DISABLED_THROTTLE (once arm switch is on) if we are in 3D mode */
-          bool ignoreThrottle = feature(FEATURE_3D)
-                             && !IS_RC_MODE_ACTIVE(BOX3D)
-                             && !flight3DConfig()->switched_mode3d
-                             && !(getArmingDisableFlags() & ~(ARMING_DISABLED_ARM_SWITCH | ARMING_DISABLED_THROTTLE));
+            /* Ignore ARMING_DISABLED_THROTTLE (once arm switch is on) if we are in 3D mode */
+            bool ignoreThrottle = feature(FEATURE_3D)
+                                  && !IS_RC_MODE_ACTIVE(BOX3D)
+                                  && !flight3DConfig()->switched_mode3d
+                                  && !(getArmingDisableFlags() & ~(ARMING_DISABLED_ARM_SWITCH | ARMING_DISABLED_THROTTLE));
 
 #ifdef USE_RUNAWAY_TAKEOFF
-           if (!IS_RC_MODE_ACTIVE(BOXARM)) {
-               unsetArmingDisabled(ARMING_DISABLED_RUNAWAY_TAKEOFF);
-           }
+             if (!IS_RC_MODE_ACTIVE(BOXARM)) {
+                 unsetArmingDisabled(ARMING_DISABLED_RUNAWAY_TAKEOFF);
+             }
 #endif
 
-          // If arming is disabled and the ARM switch is on
-          if (isArmingDisabled()
-              && !ignoreGyro
-              && !ignoreThrottle
-              && IS_RC_MODE_ACTIVE(BOXARM)) {
-              setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
-          } else if (!IS_RC_MODE_ACTIVE(BOXARM)) {
-              unsetArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
-          }
+            // If arming is disabled and the ARM switch is on
+            if (isArmingDisabled()
+                && !ignoreGyro
+                && !ignoreThrottle
+                && IS_RC_MODE_ACTIVE(BOXARM)) {
+                setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+            } else if (!IS_RC_MODE_ACTIVE(BOXARM)) {
+                unsetArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+            }
         }
 
         if (isArmingDisabled()) {

--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -754,4 +754,8 @@ int rcSmoothingGetValue(int whichValue)
             return 0;
     }
 }
+
+bool rcSmoothingFilterInitialized(void) {
+    return rcSmoothingData.filterInitialized;
+}
 #endif // USE_RC_SMOOTHING_FILTER

--- a/src/main/fc/fc_rc.h
+++ b/src/main/fc/fc_rc.h
@@ -42,3 +42,4 @@ bool isMotorsReversed(void);
 bool rcSmoothingIsEnabled(void);
 int rcSmoothingGetValue(int whichValue);
 bool rcSmoothingAutoCalculate(void);
+bool rcSmoothingFilterInitialized(void);

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -53,6 +53,7 @@ const char *armingDisableFlagNames[]= {
     "MSP",
     "PARALYZE",
     "GPS",
+    "RCSMOOTHING",
     "ARMSWITCH"
 };
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -57,10 +57,11 @@ typedef enum {
     ARMING_DISABLED_MSP             = (1 << 16),
     ARMING_DISABLED_PARALYZE        = (1 << 17),
     ARMING_DISABLED_GPS             = (1 << 18),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 19), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_RC_SMOOTHING    = (1 << 19),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 20), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
-#define ARMING_DISABLE_FLAGS_COUNT 20
+#define ARMING_DISABLE_FLAGS_COUNT 21
 
 extern const char *armingDisableFlagNames[ARMING_DISABLE_FLAGS_COUNT];
 


### PR DESCRIPTION
Add `ARMING_DISABLED_RC_SMOOTHING` if rc smoothing type `FILTER` is selected but the filter training/initialization has not completed.

Will help find cases where a RX protocol behaves unexpectedly and the filter training logic encounters problems locking onto the frame rate.  Adds an extra check to prevent the pilot from flying unexpectedly with no smoothing.

If the users encounter this arming disabled reason they can always revert back to the default of INTERPOLATION and fly normally.  Hopefully they will also report the issue so we can investigate and add support for any additional protocol edge cases.

Also cleaned up some indention formatting.