### PR TITLE
CLI tasks command: reset max execution time

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3634,6 +3634,8 @@ static void cliTasks(char *cmdline)
             if (taskId == TASK_GYROPID && pidConfig()->pid_process_denom > 1) {
                 cliPrintLinef("   - (%15s) %6d", taskInfo.subTaskName, subTaskFrequency);
             }
+
+            schedulerResetTaskMaxExecutionTime(taskId);
         }
     }
     if (systemConfig()->task_statistics) {

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -221,6 +221,19 @@ void schedulerResetTaskStatistics(cfTaskId_e taskId)
 #endif
 }
 
+void schedulerResetTaskMaxExecutionTime(cfTaskId_e taskId)
+{
+#ifdef SKIP_TASK_STATISTICS
+    UNUSED(taskId);
+#else
+    if (taskId == TASK_SELF) {
+        currentTask->maxExecutionTime = 0;
+    } else if (taskId < TASK_COUNT) {
+        cfTasks[taskId].maxExecutionTime = 0;
+    }
+#endif
+}
+
 void schedulerInit(void)
 {
     calculateTaskStatistics = true;

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -177,6 +177,7 @@ void setTaskEnabled(cfTaskId_e taskId, bool newEnabledState);
 timeDelta_t getTaskDeltaTime(cfTaskId_e taskId);
 void schedulerSetCalulateTaskStatistics(bool calculateTaskStatistics);
 void schedulerResetTaskStatistics(cfTaskId_e taskId);
+void schedulerResetTaskMaxExecutionTime(cfTaskId_e taskId);
 
 void schedulerInit(void);
 void scheduler(void);

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -240,6 +240,7 @@ const char *armingDisableFlagNames[]= {
 
 void getTaskInfo(cfTaskId_e, cfTaskInfo_t *) {}
 void getCheckFuncInfo(cfCheckFuncInfo_t *) {}
+void schedulerResetTaskMaxExecutionTime(cfTaskId_e) {}
 
 const char * const targetName = "UNITTEST";
 const char* const buildDate = "Jan 01 2017";


### PR DESCRIPTION
Makes CLI `tasks` max time field finer-grained, showing maximum task execution time since last `tasks` command.
That way you can still see abnormal spikes in task execution after boot on first `tasks` invocation, but they won't clutter subsequent invocations.