### PR TITLE
Add OSD warning and beeper pattern if rc smoothing initialization not completed

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -848,6 +848,11 @@ bool processRx(timeUs_t currentTimeUs)
     pidSetAcroTrainerState(IS_RC_MODE_ACTIVE(BOXACROTRAINER) && sensors(SENSOR_ACC));
 #endif // USE_ACRO_TRAINER
 
+#ifdef USE_RC_SMOOTHING_FILTER
+    if (ARMING_FLAG(ARMED) && !rcSmoothingInitializationComplete()) {
+        beeper(BEEPER_RC_SMOOTHING_INIT_FAIL);
+    }
+#endif
     return true;
 }
 

--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -754,4 +754,8 @@ int rcSmoothingGetValue(int whichValue)
             return 0;
     }
 }
+
+bool rcSmoothingInitializationComplete(void) {
+    return (rxConfig()->rc_smoothing_type != RC_SMOOTHING_TYPE_FILTER) || rcSmoothingData.filterInitialized;
+}
 #endif // USE_RC_SMOOTHING_FILTER

--- a/src/main/fc/fc_rc.h
+++ b/src/main/fc/fc_rc.h
@@ -42,3 +42,4 @@ bool isMotorsReversed(void);
 bool rcSmoothingIsEnabled(void);
 int rcSmoothingGetValue(int whichValue);
 bool rcSmoothingAutoCalculate(void);
+bool rcSmoothingInitializationComplete(void);

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -160,6 +160,11 @@ static const uint8_t beep_camCloseBeep[] = {
     10, 8, 5, BEEPER_COMMAND_STOP
 };
 
+// RC Smoothing filter not initialized - 3 short + 1 long
+static const uint8_t beep_rcSmoothingInitFail[] = {
+    10, 10, 10, 10, 10, 10, 50, 25, BEEPER_COMMAND_STOP
+};
+
 // array used for variable # of beeps (reporting GPS sat count, etc)
 static uint8_t beep_multiBeeps[MAX_MULTI_BEEPS + 1];
 
@@ -222,6 +227,7 @@ static const beeperTableEntry_t beeperTable[] = {
     { BEEPER_ENTRY(BEEPER_CRASH_FLIP_MODE,       19, beep_2longerBeeps,    "CRASH FLIP") },
     { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_OPEN,   20, beep_camOpenBeep,     "CAM_CONNECTION_OPEN") },
     { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_CLOSE,  21, beep_camCloseBeep,    "CAM_CONNECTION_CLOSED") },
+    { BEEPER_ENTRY(BEEPER_RC_SMOOTHING_INIT_FAIL,22, beep_rcSmoothingInitFail, "RC_SMOOTHING_INIT_FAIL") },
     { BEEPER_ENTRY(BEEPER_ALL,                   22, NULL,                 "ALL") },
 };
 

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -55,6 +55,7 @@ typedef enum {
     BEEPER_CRASH_FLIP_MODE,         // Crash flip mode is active
     BEEPER_CAM_CONNECTION_OPEN,     // When the 5 key simulation stated
     BEEPER_CAM_CONNECTION_CLOSE,    // When the 5 key simulation stop
+    BEEPER_RC_SMOOTHING_INIT_FAIL,  // Warning beep pattern when armed and rc smoothing has not initialized filters
     BEEPER_ALL,                     // Turn ON or OFF all beeper conditions
     // BEEPER_ALL must remain at the bottom of this enum
 } beeperMode_e;
@@ -82,7 +83,8 @@ typedef enum {
     | BEEPER_GET_FLAG(BEEPER_BLACKBOX_ERASE) \
     | BEEPER_GET_FLAG(BEEPER_CRASH_FLIP_MODE) \
     | BEEPER_GET_FLAG(BEEPER_CAM_CONNECTION_OPEN) \
-    | BEEPER_GET_FLAG(BEEPER_CAM_CONNECTION_CLOSE) )
+    | BEEPER_GET_FLAG(BEEPER_CAM_CONNECTION_CLOSE) \
+    | BEEPER_GET_FLAG(BEEPER_RC_SMOOTHING_INIT_FAIL) )
 
 #define DSHOT_BEACON_ALLOWED_MODES ( \
     BEEPER_GET_FLAG(BEEPER_RX_LOST) \

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -63,6 +63,7 @@
 #include "fc/fc_core.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
+#include "fc/fc_rc.h"
 #include "fc/runtime_config.h"
 
 #include "flight/position.h"
@@ -824,6 +825,14 @@ static bool osdDrawSingleElement(uint8_t item)
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "LOW BATTERY");
                 break;
             }
+
+#ifdef USE_RC_SMOOTHING_FILTER
+            // Show warning if rc smoothing hasn't initialized the filters
+            if (ARMING_FLAG(ARMED) && !rcSmoothingInitializationComplete()) {
+                osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "RCSMOOTHING");
+                break;
+            }
+#endif
 
             // Show warning if battery is not fresh
             if (osdWarnGetState(OSD_WARNING_BATTERY_NOT_FULL) && !ARMING_FLAG(WAS_EVER_ARMED) && (getBatteryState() == BATTERY_OK)


### PR DESCRIPTION
In the OSD display the warning "RCSMOOTHING".  Also play a beep pattern of 3 short, 1 long that will repeat.  If rx rate filter training completes the OSD warning/beeper will stop. Both are only active when armed.
