### PR TITLE
Remove MSP BOX BME entries for baro, gps home, gps hold

### DIFF
--- a/src/main/interface/msp_box.c
+++ b/src/main/interface/msp_box.c
@@ -181,12 +181,6 @@ void initActiveBoxIds(void)
         BME(BOXHEADADJ);
     }
 
-#ifdef USE_BARO
-    if (sensors(SENSOR_BARO)) {
-        BME(BOXBARO);
-    }
-#endif
-
 #ifdef USE_MAG
     if (sensors(SENSOR_MAG)) {
         BME(BOXMAG);
@@ -195,8 +189,6 @@ void initActiveBoxIds(void)
 
 #ifdef USE_GPS
     if (feature(FEATURE_GPS)) {
-        BME(BOXGPSHOME);
-        BME(BOXGPSHOLD);
 #ifdef USE_GPS_RESCUE
         if (!feature(FEATURE_3D)) {
             BME(BOXGPSRESCUE);


### PR DESCRIPTION
As the underlying modes were removed, the MSP BOX BME calls should have also been removed. ~I'm unsure of changes required to BFC if any to coincide with this.~

No BFC changes should be required, as the modes/box page is generated from BME's.