### PR TITLE
GPS based Altitude was not converted to meters.

### DIFF
--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -208,10 +208,10 @@ void hottPrepareGPSResponse(HOTT_GPS_MSG_t *hottGPSMessage)
 
     uint16_t altitude = gpsSol.llh.alt;
     if (!STATE(GPS_FIX)) {
-        altitude = getEstimatedAltitude() / 100;
+        altitude = getEstimatedAltitude();
     }
 
-    const uint16_t hottGpsAltitude = (altitude) + HOTT_GPS_ALTITUDE_OFFSET; // gpsSol.llh.alt in m ; offset = 500 -> O m
+    const uint16_t hottGpsAltitude = (altitude / 100) + HOTT_GPS_ALTITUDE_OFFSET; // gpsSol.llh.alt in m ; offset = 500 -> O m
 
     hottGPSMessage->altitude_L = hottGpsAltitude & 0x00FF;
     hottGPSMessage->altitude_H = hottGpsAltitude >> 8;


### PR DESCRIPTION
Bugfix: HoTT telemetry stores altitude in meters but only altitude from barometer was converted to meters.