### PR TITLE
lower airmode threshold to 15

### DIFF
--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -59,7 +59,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .rcInterpolationChannels = INTERPOLATION_CHANNELS_RPT,
         .rcInterpolationInterval = 19,
         .fpvCamAngleDegrees = 0,
-        .airModeActivateThreshold = 32,
+        .airModeActivateThreshold = 15,
         .max_aux_channel = DEFAULT_AUX_CHANNEL_COUNT,
         .rc_smoothing_type = RC_SMOOTHING_TYPE_INTERPOLATION,
         .rc_smoothing_input_cutoff = 0,      // automatically calculate the cutoff by default


### PR DESCRIPTION
Reduce the air mode threshold from 32% throttle to 15% throttle

Intended to ensure reliable air mode activation below hover throttle point, even on high powered quads, and to allow activation while on the starting blocks for racers without needing more than 15% throttle.

Downside is that iTerm may accumulate on the ground if the pilot didn't know that a small increase in throttle would activate air mode.  

Pilots should not throttle up on the ground, other than to perform basic testing.  After doing so, it would be wise to disable air mode via a switch, or disarm, rather than wait on the ground with air mode (and I term accumulation) active.

