### PR TITLE
Allow linking of modes

### DIFF
--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -47,3 +47,12 @@ void bitArrayXor(void *dest, size_t size, void *op1, void *op2)
         ((uint8_t*)dest)[i] = ((uint8_t*)op1)[i] ^ ((uint8_t*)op2)[i];
     }
 }
+
+void bitArrayCopy(void *array, unsigned from, unsigned to)
+{
+    if (bitArrayGet(array, from)) {
+        bitArraySet(array, to);
+    } else {
+        bitArrayClr(array, to);
+    }
+}

--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -24,3 +24,4 @@ bool bitArrayGet(const void *array, unsigned bit);
 void bitArraySet(void *array, unsigned bit);
 void bitArrayClr(void *array, unsigned bit);
 void bitArrayXor(void *dest, size_t size, void *op1, void *op2);
+void bitArrayCopy(void *array, unsigned from, unsigned to);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -55,7 +55,6 @@
 #include "fc/config.h"
 #include "fc/controlrate_profile.h"
 #include "fc/fc_core.h"
-#include "fc/fc_dispatch.h"
 #include "fc/fc_rc.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
@@ -120,8 +119,6 @@ enum {
 #define DEBUG_RUNAWAY_TAKEOFF_FALSE 0
 #endif
 
-#define PARALYZE_PREVENT_MODE_CHANGES_DELAY_US   100000 // Delay after paralyze mode activates to let other mode changes propagate
-
 #if defined(USE_GPS) || defined(USE_MAG)
 int16_t magHold;
 #endif
@@ -142,15 +139,6 @@ static bool runawayTakeoffCheckDisabled = false;
 static timeUs_t runawayTakeoffTriggerUs = 0;
 static bool runawayTakeoffTemporarilyDisabled = false;
 #endif
-
-static bool paralyzeModeAllowed = false;
-
-void preventModeChangesDispatch(dispatchEntry_t *self) {
-    UNUSED(self);
-    preventModeChanges();
-}
-
-static dispatchEntry_t preventModeChangesDispatchEntry = { .dispatch = preventModeChangesDispatch};
 
 PG_REGISTER_WITH_RESET_TEMPLATE(throttleCorrectionConfig_t, throttleCorrectionConfig, PG_THROTTLE_CORRECTION_CONFIG, 0);
 
@@ -265,9 +253,8 @@ void updateArmingStatus(void)
         }
 #endif
 
-        if (IS_RC_MODE_ACTIVE(BOXPARALYZE) && paralyzeModeAllowed) {
+        if (IS_RC_MODE_ACTIVE(BOXPARALYZE)) {
             setArmingDisabled(ARMING_DISABLED_PARALYZE);
-            dispatchAdd(&preventModeChangesDispatchEntry, PARALYZE_PREVENT_MODE_CHANGES_DELAY_US);
         }
 
         if (!isUsingSticksForArming()) {
@@ -305,11 +292,6 @@ void updateArmingStatus(void)
         }
 
         warningLedUpdate();
-    }
-
-    // Check if entering into paralyze mode can be allowed regardless of arming status
-    if (!IS_RC_MODE_ACTIVE(BOXPARALYZE) && !paralyzeModeAllowed) {
-        paralyzeModeAllowed = true;
     }
 }
 

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -117,6 +117,7 @@ typedef struct modeActivationCondition_s {
     uint8_t auxChannelIndex;
     channelRange_t range;
     modeLogic_e modeLogic;
+    boxId_e linkedTo;
 } modeActivationCondition_t;
 
 PG_DECLARE_ARRAY(modeActivationCondition_t, MAX_MODE_ACTIVATION_CONDITION_COUNT, modeActivationConditions);
@@ -129,7 +130,6 @@ typedef struct modeActivationProfile_s {
 
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(boxBitmask_t *newState);
-void preventModeChanges(void);
 
 bool isAirmodeActive(void);
 bool isAntiGravityModeActive(void);

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -612,6 +612,50 @@ TEST(ArmingPreventionTest, WhenUsingSwitched3DModeThenNormalThrottleArmingCondit
     EXPECT_EQ(0, getArmingDisableFlags());
 }
 
+TEST(ArmingPreventionTest, ParalyzeOnAtBoot)
+{
+    // given
+    simulationFeatureFlags = 0;
+    simulationTime = 30e6; // 30 seconds after boot
+    gyroCalibDone = true;
+
+    // and
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXARM;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(1750);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+    modeActivationConditionsMutable(1)->auxChannelIndex = 1;
+    modeActivationConditionsMutable(1)->modeId = BOXPARALYZE;
+    modeActivationConditionsMutable(1)->range.startStep = CHANNEL_VALUE_TO_STEP(1750);
+    modeActivationConditionsMutable(1)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+    useRcControlsConfig(NULL);
+
+    // and
+    rxConfigMutable()->mincheck = 1050;
+
+    // given
+    rcData[THROTTLE] = 1000;
+    rcData[AUX1] = 1000;
+    rcData[AUX2] = 1800; // Paralyze on at boot
+    ENABLE_STATE(SMALL_ANGLE);
+
+    // when
+    updateActivatedModes();
+    updateArmingStatus();
+
+    // expect
+    EXPECT_FALSE(ARMING_FLAG(ARMED));
+    EXPECT_FALSE(isArmingDisabled());
+    EXPECT_EQ(0, getArmingDisableFlags());
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+
+    // when
+    updateActivatedModes();
+
+    // expect
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+}
+
 TEST(ArmingPreventionTest, Paralyze)
 {
     // given
@@ -632,10 +676,8 @@ TEST(ArmingPreventionTest, Paralyze)
     modeActivationConditionsMutable(2)->modeId = BOXBEEPERON;
     modeActivationConditionsMutable(2)->range.startStep = CHANNEL_VALUE_TO_STEP(1750);
     modeActivationConditionsMutable(2)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
-    modeActivationConditionsMutable(3)->auxChannelIndex = 3;
     modeActivationConditionsMutable(3)->modeId = BOXVTXPITMODE;
-    modeActivationConditionsMutable(3)->range.startStep = CHANNEL_VALUE_TO_STEP(1750);
-    modeActivationConditionsMutable(3)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+    modeActivationConditionsMutable(3)->linkedTo = BOXPARALYZE;
     useRcControlsConfig(NULL);
 
     // and
@@ -646,7 +688,6 @@ TEST(ArmingPreventionTest, Paralyze)
     rcData[AUX1] = 1000;
     rcData[AUX2] = 1000;
     rcData[AUX3] = 1000;
-    rcData[AUX4] = 1000;
     ENABLE_STATE(SMALL_ANGLE);
 
     // when
@@ -687,9 +728,8 @@ TEST(ArmingPreventionTest, Paralyze)
     EXPECT_EQ(0, getArmingDisableFlags());
 
     // given
-    // paraylze and enter pit mode
+    // paralyze (and activate linked vtx pit mode)
     rcData[AUX2] = 1800;
-    rcData[AUX4] = 1800;
 
     // when
     updateActivatedModes();
@@ -701,12 +741,8 @@ TEST(ArmingPreventionTest, Paralyze)
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXVTXPITMODE));
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXBEEPERON));
 
-    // and
-    preventModeChanges();
-
     // given
-    // Try exiting pit mode and enable beeper
-    rcData[AUX4] = 1000;
+    // enable beeper
     rcData[AUX3] = 1800;
 
     // when
@@ -717,7 +753,7 @@ TEST(ArmingPreventionTest, Paralyze)
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXBEEPERON));
     
     // given
-    // exit paralyze mode and ensure arming is still disabled
+    // try exiting paralyze mode and ensure arming and pit mode are still disabled
     rcData[AUX2] = 1000;
 
     // when
@@ -727,6 +763,8 @@ TEST(ArmingPreventionTest, Paralyze)
     // expect
     EXPECT_TRUE(isArmingDisabled());
     EXPECT_EQ(ARMING_DISABLED_PARALYZE, getArmingDisableFlags());
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXVTXPITMODE));
 }
 
 // STUBS


### PR DESCRIPTION
This allows modes to be linked, for example to link vtx pit mode to paralyze. Whenever paralyze is activated, vtx pit mode is activated as well. Also the logic to prevent mode changes when enabling paralyze can be removed in favor of making paralyze sticky.

Modes can be linked in CLI by providing the mode id as the last parameter of the aux command. For example in order to link vtx pit mode to paralyze, replace the last 0 of the pit mode aux (39) with the mode id of paralyze (45):

```
aux 2 39 2 1700 2100 0 0
```

becomes

```
aux 2 39 2 1700 2100 0 45
```

_Legal disclaimer: I am making my contributions/submissions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties._