### PR TITLE
Fix low priority warnings when ESC sensor enabled

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -800,8 +800,8 @@ static bool osdDrawSingleElement(uint8_t item)
 
                 if (escWarningCount > 0) {
                     osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, escWarningMsg);
+                    break;
                 }
-                break;
             }
 #endif
 


### PR DESCRIPTION
I thin that this is a fix for https://github.com/betaflight/betaflight/issues/6333 but need testing. I don't have the hardware to verify that.