### PR TITLE
Added IRCSYNERGYF3 target

### DIFF
--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -26,6 +26,8 @@
 #define TARGET_BOARD_IDENTIFIER "ZCF3"
 #elif defined(FLIP32F3OSD)
 #define TARGET_BOARD_IDENTIFIER "FLF3"
+#elif defined(IRCSYNERGYF3)
+#define TARGET_BOARD_IDENTIFIER "ISF3"
 #else
 #define TARGET_BOARD_IDENTIFIER "SRF3"
 #endif
@@ -47,6 +49,9 @@
 #undef USE_RTC_TIME
 #undef USE_RX_MSP
 #undef USE_ESC_SENSOR_INFO
+#if defined(IRCSYNERGYF3)
+#undef USE_LED_STRIP
+#endif
 
 #if defined(ZCOREF3)
 #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_DEFAULT
@@ -58,9 +63,11 @@
 #define LED0_PIN                PB3
 #endif
 
+#if !defined(IRCSYNERGYF3)
 #define USE_BEEPER
 #define BEEPER_PIN              PC15
 #define BEEPER_INVERTED
+#endif
 
 #define USE_EXTI
 #define MPU_INT_EXTI            PC13
@@ -102,6 +109,17 @@
 #define MPU6500_CS_PIN          PB9
 #define MPU6500_SPI_INSTANCE    SPI1
 
+#elif defined(IRCSYNERGYF3)
+#define GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW270_DEG
+
+#define ACC
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN       CW270_DEG
+
+#define MPU6000_CS_PIN           PB12
+#define MPU6000_SPI_INSTANCE     SPI2
 #else
 #define USE_GYRO_MPU6050
 #define GYRO_MPU6050_ALIGN      CW270_DEG
@@ -141,8 +159,10 @@
 #define MAG_INT_EXTI            PC14
 #endif
 
+#if !defined(IRCSYNERGYF3)
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
+#endif
 
 #define USE_UART1
 #define USE_UART2
@@ -181,6 +201,7 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_2 // PB12,13,14,15 on AF5
 
+#if !defined(IRCSYNERGYF3)
 #define FLASH_CS_PIN            PB12
 #define FLASH_SPI_INSTANCE      SPI2
 
@@ -195,6 +216,7 @@
 #define USE_OSD
 #define USE_OSD_OVER_MSP_DISPLAYPORT
 #define USE_SLOW_MSP_DISPLAYPORT_RATE_WHEN_UNARMED
+#endif
 
 #define USE_MSP_CURRENT_METER
 
@@ -205,10 +227,12 @@
 #undef USE_UART1_TX_DMA
 #endif
 
+#if !defined(IRCSYNERGYF3)
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
 #define DEFAULT_FEATURES        (FEATURE_RSSI_ADC | FEATURE_TELEMETRY)
+#endif
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 

--- a/src/main/target/SPRACINGF3/target.mk
+++ b/src/main/target/SPRACINGF3/target.mk
@@ -19,7 +19,12 @@ TARGET_SRC += \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6500.c
 else
+ifeq ($(TARGET), IRCSYNERGYF3)
+TARGET_SRC += \
+			drivers/accgyro/accgyro_spi_mpu6000.c
+else
 TARGET_SRC += \
             drivers/accgyro/accgyro_mpu6050.c
+endif
 endif
 endif


### PR DESCRIPTION
Courtesy of Tony Cake from ImmersionRC.
Testers are needed for this target, as well as trying CPU load with `dshot_burst = on` and `off`.

Original target definitions were converted to a variant of SPRACINGF3.