### PR TITLE
Ensured micros() doesn't return a smaller value on millisecond bound

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -110,7 +110,7 @@ uint32_t micros(void)
     do {
         ms = sysTickUptime;
         cycle_cnt = SysTick->VAL;
-    } while (ms != sysTickUptime || cycle_cnt >= sysTickValStamp);
+    } while (ms != sysTickUptime || cycle_cnt > sysTickValStamp);
 
     return (ms * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
 }

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -35,6 +35,7 @@
 static uint32_t usTicks = 0;
 // current uptime for 1kHz systick timer. will rollover after 49 days. hopefully we won't care.
 static volatile uint32_t sysTickUptime = 0;
+static volatile uint32_t sysTickValStamp = 0;
 // cached value of RCC->CSR
 uint32_t cachedRccCsrValue;
 
@@ -57,6 +58,7 @@ void SysTick_Handler(void)
 {
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
         sysTickUptime++;
+        sysTickValStamp = SysTick->VAL;
         sysTickPending = 0;
         (void)(SysTick->CTRL);
     }
@@ -108,12 +110,7 @@ uint32_t micros(void)
     do {
         ms = sysTickUptime;
         cycle_cnt = SysTick->VAL;
-        /*
-         * If the SysTick timer expired during the previous instruction, we need to give it a little time for that
-         * interrupt to be delivered before we can recheck sysTickUptime:
-         */
-        asm volatile("\tnop\n");
-    } while (ms != sysTickUptime);
+    } while (ms != sysTickUptime || cycle_cnt >= sysTickValStamp);
 
     return (ms * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
 }


### PR DESCRIPTION
Fixes negative numbers in CLI `tasks` output and possible issues with users of `micros()`.
This problem first manifested itself on Cortex-M3, that's why `nop` inline assembly was added, but it wasn't a proper fix.

Cortex-M interrupt entry latency is variable, can be anywhere from 8 to 32 cycles, and should be accounted for when relying on `SysTick_Handler` to be called on `SysTick->VAL` overflow. With M7 featuring I- and D-cache the problem started manifesting itself much more often, with one `nop` being insufficient.

This PR adds a "marker" for remembering value of `SysTick->VAL` as observed by last invocation of `SysTick_Handler`. This value is checked in `micros()` lock-free loop to ensure we won't return a value  ~1ms smaller than the previous one.

 Tested on NERO.
Requires testing on all of F3, F4 and F7.

http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka16366.html