### PR TITLE
Adjustments strings for OSD not kept in sync with enumeration causing invalid pointers

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -247,11 +247,15 @@ static const char * const adjustmentLabels[] = {
     "D SETPOINT",
     "D SETPOINT TRANSITION",
     "HORIZON STRENGTH",
+    "ROLL RC RATE",
+    "PITCH RC RATE",
+    "ROLL RC EXPO",
+    "PITCH RC EXPO",
     "PID AUDIO",
 };
 
-const char *adjustmentRangeName;
-int adjustmentRangeValue = -1;
+static int adjustmentRangeNameIndex = 0;
+static int adjustmentRangeValue = -1;
 #endif
 
 #define ADJUSTMENT_FUNCTION_CONFIG_INDEX_OFFSET 1
@@ -680,7 +684,7 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig)
 
 #if defined(USE_OSD) && defined(USE_OSD_ADJUSTMENTS)
         if (newValue != -1 && adjustmentState->config->adjustmentFunction != ADJUSTMENT_RATE_PROFILE) { // Rate profile already has an OSD element
-            adjustmentRangeName = &adjustmentLabels[adjustmentFunction - 1][0];
+            adjustmentRangeNameIndex = adjustmentFunction;
             adjustmentRangeValue = newValue;
         }
 #else
@@ -733,3 +737,17 @@ void useAdjustmentConfig(pidProfile_t *pidProfileToUse)
 {
     pidProfile = pidProfileToUse;
 }
+
+#if defined(USE_OSD) && defined(USE_OSD_ADJUSTMENTS)
+const char *getAdjustmentsRangeName(void) {
+    if (adjustmentRangeNameIndex > 0) {
+        return &adjustmentLabels[adjustmentRangeNameIndex - 1][0];
+    } else {
+        return NULL;
+    }
+}
+
+int getAdjustmentsRangeValue(void) {
+    return adjustmentRangeValue;
+}
+#endif

--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -105,12 +105,11 @@ typedef struct adjustmentState_s {
 #define MAX_SIMULTANEOUS_ADJUSTMENT_COUNT 4 // enough for 4 x 3position switches / 4 aux channel
 #endif
 
-extern const char *adjustmentRangeName;
-extern int adjustmentRangeValue;
-
 void resetAdjustmentStates(void);
 void updateAdjustmentStates(void);
 struct controlRateConfig_s;
 void processRcAdjustments(struct controlRateConfig_s *controlRateConfig);
 struct pidProfile_s;
 void useAdjustmentConfig(struct pidProfile_s *pidProfileToUse);
+const char *getAdjustmentsRangeName(void);
+int getAdjustmentsRangeValue(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -944,7 +944,9 @@ static bool osdDrawSingleElement(uint8_t item)
 
 #ifdef USE_OSD_ADJUSTMENTS
     case OSD_ADJUSTMENT_RANGE:
-        tfp_sprintf(buff, "%s: %3d", adjustmentRangeName, adjustmentRangeValue);
+        if (getAdjustmentsRangeName()) {
+            tfp_sprintf(buff, "%s: %3d", getAdjustmentsRangeName(), getAdjustmentsRangeValue());
+        }
         break;
 #endif
 


### PR DESCRIPTION
When the adjustments enumerations for separate rc rates and rc expos for roll/pitch were added the descriptive names were never added to the OSD display strings array. Then later PID audio was added causing the string array to be out of sync with the enumerated adjustment types.  This led to a corrupted pointer reference in the OSD display.

Also the adjustment display name used for the OSD display was never initialized so the pointer was pointing to random memory which would display garbage on OSD initialization.

Fixed the OSD display names string array to be synchronized with the enumeration.  Also removed the use of globals and changed to use "getter" functions.