### PR TITLE
Adding MSP for new profile settings introduced in 3.4.

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1308,26 +1308,18 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
 #if defined(USE_ITERM_RELAX)
         sbufWriteU8(dst, currentPidProfile->iterm_relax);
         sbufWriteU8(dst, currentPidProfile->iterm_relax_type);
-        sbufWriteU8(dst, currentPidProfile->iterm_relax_cutoff);
 #else
-        sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
 #endif
 #if defined(USE_ABSOLUTE_CONTROL)
         sbufWriteU8(dst, currentPidProfile->abs_control_gain);
-        sbufWriteU8(dst, currentPidProfile->abs_control_limit);
-        sbufWriteU8(dst, currentPidProfile->abs_control_error_limit);
 #else
-        sbufWriteU8(dst, 0);
-        sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
 #endif
 #if defined(USE_THROTTLE_BOOST)
         sbufWriteU8(dst, currentPidProfile->throttle_boost);
-        sbufWriteU8(dst, currentPidProfile->throttle_boost_cutoff);
 #else
-        sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
 #endif
 #if defined(USE_ACRO_TRAINER)
@@ -1855,7 +1847,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         if (sbufBytesRemaining(src) >= 2) {
             currentPidProfile->dtermSetpointWeight = sbufReadU16(src);
         }
-        if (sbufBytesRemaining(src) >= 11) {
+        if (sbufBytesRemaining(src) >= 7) {
             // Added in MSP API 1.40
             currentPidProfile->iterm_rotation = sbufReadU8(src);
 #if defined(USE_SMART_FEEDFORWARD)
@@ -1866,26 +1858,18 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 #if defined(USE_ITERM_RELAX)
             currentPidProfile->iterm_relax = sbufReadU8(src);
             currentPidProfile->iterm_relax_type = sbufReadU8(src);
-            currentPidProfile->iterm_relax_cutoff = sbufReadU8(src);
 #else
-            sbufReadU8(src);
             sbufReadU8(src);
             sbufReadU8(src);
 #endif
 #if defined(USE_ABSOLUTE_CONTROL)
             currentPidProfile->abs_control_gain = sbufReadU8(src);
-            currentPidProfile->abs_control_limit = sbufReadU8(src);
-            currentPidProfile->abs_control_error_limit = sbufReadU8(src);
 #else
-            sbufReadU8(src);
-            sbufReadU8(src);
             sbufReadU8(src);
 #endif
 #if defined(USE_THROTTLE_BOOST)
             currentPidProfile->throttle_boost = sbufReadU8(src);
-            currentPidProfile->throttle_boost_cutoff = sbufReadU8(src);
 #else
-            sbufReadU8(src);
             sbufReadU8(src);
 #endif
 #if defined(USE_ACRO_TRAINER)

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1307,7 +1307,11 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
 #endif
 #if defined(USE_ITERM_RELAX)
         sbufWriteU8(dst, currentPidProfile->iterm_relax);
+        sbufWriteU8(dst, currentPidProfile->iterm_relax_type);
+        sbufWriteU8(dst, currentPidProfile->iterm_relax_cutoff);
 #else
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
 #endif
 #if defined(USE_ABSOLUTE_CONTROL)
@@ -1319,14 +1323,16 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
 #endif
-#if defined(USE_ACRO_TRAINER)
-        sbufWriteU8(dst, currentPidProfile->acro_trainer_angle_limit);
-        sbufWriteU16(dst, currentPidProfile->acro_trainer_lookahead_ms);
-        sbufWriteU8(dst, currentPidProfile->acro_trainer_gain);
+#if defined(USE_THROTTLE_BOOST)
+        sbufWriteU8(dst, currentPidProfile->throttle_boost);
+        sbufWriteU8(dst, currentPidProfile->throttle_boost_cutoff);
 #else
         sbufWriteU8(dst, 0);
-        sbufWriteU16(dst, 0);
         sbufWriteU8(dst, 0);
+#endif
+#if defined(USE_ACRO_TRAINER)
+        sbufWriteU8(dst, currentPidProfile->acro_trainer_angle_limit);
+#else
         sbufWriteU8(dst, 0);
 #endif
 
@@ -1849,7 +1855,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         if (sbufBytesRemaining(src) >= 2) {
             currentPidProfile->dtermSetpointWeight = sbufReadU16(src);
         }
-        if (sbufBytesRemaining(src) >= 10) {
+        if (sbufBytesRemaining(src) >= 11) {
             // Added in MSP API 1.40
             currentPidProfile->iterm_rotation = sbufReadU8(src);
 #if defined(USE_SMART_FEEDFORWARD)
@@ -1859,7 +1865,11 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 #endif
 #if defined(USE_ITERM_RELAX)
             currentPidProfile->iterm_relax = sbufReadU8(src);
+            currentPidProfile->iterm_relax_type = sbufReadU8(src);
+            currentPidProfile->iterm_relax_cutoff = sbufReadU8(src);
 #else
+            sbufReadU8(src);
+            sbufReadU8(src);
             sbufReadU8(src);
 #endif
 #if defined(USE_ABSOLUTE_CONTROL)
@@ -1871,13 +1881,16 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             sbufReadU8(src);
             sbufReadU8(src);
 #endif
-#if defined(USE_ACRO_TRAINER)
-            currentPidProfile->acro_trainer_angle_limit = sbufReadU8(src);
-            currentPidProfile->acro_trainer_lookahead_ms = sbufReadU16(src);
-            currentPidProfile->acro_trainer_gain = sbufReadU8(src);
+#if defined(USE_THROTTLE_BOOST)
+            currentPidProfile->throttle_boost = sbufReadU8(src);
+            currentPidProfile->throttle_boost_cutoff = sbufReadU8(src);
 #else
             sbufReadU8(src);
-            sbufReadU16(src);
+            sbufReadU8(src);
+#endif
+#if defined(USE_ACRO_TRAINER)
+            currentPidProfile->acro_trainer_angle_limit = sbufReadU8(src);
+#else
             sbufReadU8(src);
 #endif
         }


### PR DESCRIPTION
This adds the new profile dependent settings introduced in 3.4 to MSP:
- iterm rotation;
- smart feedforward;
- iterm relax;
- absolute control;
- acro trainer.

@McGiverGim: Do you have time to add support for these to the configurator? They will have to go onto the PID Tuning tab, since they are profile dependent.
