### PR TITLE
Unified gyro filtering debug and non-debug

### DIFF
--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -1,0 +1,37 @@
+static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor, timeDelta_t sampleDeltaUs)
+{
+    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+        GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_RAW, axis, gyroSensor->gyroDev.gyroADCRaw[axis]);
+        // scale gyro output to degrees per second
+        float gyroADCf = gyroSensor->gyroDev.gyroADC[axis] * gyroSensor->gyroDev.scale;
+        // DEBUG_GYRO_SCALED records the unfiltered, scaled gyro output
+        GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_SCALED, axis, lrintf(gyroADCf));
+
+#ifdef USE_GYRO_DATA_ANALYSE
+        // apply dynamic notch filter
+        if (isDynamicFilterActive()) {
+            if (axis == X) {
+                GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 0, lrintf(gyroADCf)); // store raw data
+            }
+            gyroADCf = gyroSensor->notchFilterDynApplyFn((filter_t *)&gyroSensor->notchFilterDyn[axis], gyroADCf);
+            if (axis == X) {
+                GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 1, lrintf(gyroADCf)); // store data after dynamic notch
+            }
+        }
+#endif
+        // apply static notch filters and software lowpass filters
+        gyroADCf = gyroSensor->notchFilter1ApplyFn((filter_t *)&gyroSensor->notchFilter1[axis], gyroADCf);
+        gyroADCf = gyroSensor->notchFilter2ApplyFn((filter_t *)&gyroSensor->notchFilter2[axis], gyroADCf);
+        gyroADCf = gyroSensor->lowpassFilterApplyFn((filter_t *)&gyroSensor->lowpassFilter[axis], gyroADCf);
+        gyroADCf = gyroSensor->lowpass2FilterApplyFn((filter_t *)&gyroSensor->lowpass2Filter[axis], gyroADCf);
+        // DEBUG_GYRO_FILTERED records the scaled, filtered, after all software filtering has been applied.
+        GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_FILTERED, axis, lrintf(gyroADCf));
+
+        gyroSensor->gyroDev.gyroADCf[axis] = gyroADCf;
+        if (!gyroSensor->overflowDetected) {
+            // integrate using trapezium rule to avoid bias
+            accumulatedMeasurements[axis] += 0.5f * (gyroPrevious[axis] + gyroADCf) * sampleDeltaUs;
+            gyroPrevious[axis] = gyroADCf;
+        }
+    }
+}


### PR DESCRIPTION
We won't ever have to maintain two branches of gyro filtering code anymore and keep them in sync.

Since we're not using C++ and templates, I decided to rely on includes and preprocessor defines rather than macros.
This gives more clarity of code without the necessity to append `\` for each new line, and also doesn't have the shortcoming of `ifdef` not working inside macros.