### PR TITLE
Fixed MPU6500 driver for ICM20601.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -108,6 +108,7 @@ bool mpu6500SpiAccDetect(accDev_t *acc)
     case MPU_9250_SPI:
     case ICM_20608_SPI:
     case ICM_20602_SPI:
+    case ICM_20601_SPI:
         break;
     default:
         return false;
@@ -127,6 +128,7 @@ bool mpu6500SpiGyroDetect(gyroDev_t *gyro)
     case MPU_9250_SPI:
     case ICM_20608_SPI:
     case ICM_20602_SPI:
+    case ICM_20601_SPI:
         break;
     default:
         return false;


### PR DESCRIPTION
In theory the ICM20689 driver supports the ICM20601 as well, but in reality it's detecting the ICM20601 but then getting no gyro input.