### PR TITLE
 Support configurable pull down on Smart Audio VTXs

### DIFF
--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -49,6 +49,7 @@ typedef enum {
     SERIAL_BIDIR_OD        = 0 << 4,
     SERIAL_BIDIR_PP        = 1 << 4,
     SERIAL_BIDIR_NOPULL    = 1 << 5, // disable pulls in BIDIR RX mode
+    SERIAL_BIDIR_PULL_DOWN = 1 << 6,
 } portOptions_e;
 
 // Define known line control states which may be passed up by underlying serial driver callback

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -142,7 +142,9 @@ static void serialInputPortActivate(softSerial_t *softSerial)
 #ifdef STM32F1
         IOConfigGPIO(softSerial->rxIO, IOCFG_IPU);
 #else
-        const uint8_t pinConfig = (softSerial->port.options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_PP : IOCFG_AF_PP_UP;
+        const uint8_t pinConfig = (softSerial->port.options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_PP :
+            (softSerial->port.options & SERIAL_BIDIR_PULL_DOWN) ? IOCFG_AF_PP_PD :
+            IOCFG_AF_PP_UP;
         IOConfigGPIOAF(softSerial->rxIO, pinConfig, softSerial->timerHardware->alternateFunction);
 #endif
     }

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -243,7 +243,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     if (options & SERIAL_BIDIR) {
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        IOConfigGPIOAF(txIO, (options & SERIAL_BIDIR_PP) ? IOCFG_AF_PP : IOCFG_AF_OD, hardware->af);
+        IOConfigGPIOAF(txIO, (options & SERIAL_BIDIR_PP) ? (options & SERIAL_BIDIR_PULL_DOWN) ? IOCFG_AF_PP_PD : IOCFG_AF_PP : IOCFG_AF_OD, hardware->af);
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -1010,6 +1010,7 @@ const clivalue_t valueTable[] = {
 // PG_VTX_CONFIG
 #if defined(USE_VTX_CONTROL) && defined(USE_VTX_COMMON)
     { "vtx_halfduplex",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_CONFIG, offsetof(vtxConfig_t, halfDuplex) },
+    { "vtx_pulldown",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_CONFIG, offsetof(vtxConfig_t, pullDown) },
 #endif
 
 // PG_VCD_CONFIG

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -40,6 +40,7 @@ typedef struct vtxChannelActivationCondition_s {
 typedef struct vtxConfig_s {
     vtxChannelActivationCondition_t vtxChannelActivationConditions[MAX_CHANNEL_ACTIVATION_CONDITION_COUNT];
     uint8_t halfDuplex;
+    uint8_t pullDown;
 } vtxConfig_t;
 
 PG_DECLARE(vtxConfig_t, vtxConfig);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -666,11 +666,12 @@ bool vtxSmartAudioInit(void)
 
     serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_SMARTAUDIO);
     if (portConfig) {
-        portOptions_e portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR_NOPULL;
+        portOptions_e portOptions = SERIAL_STOPBITS_2;
 #if defined(USE_VTX_COMMON)
         portOptions = portOptions | (vtxConfig()->halfDuplex ? SERIAL_BIDIR | SERIAL_BIDIR_PP : SERIAL_UNIDIR);
+        portOptions = portOptions | (vtxConfig()->pullDown ? SERIAL_BIDIR_PULL_DOWN : SERIAL_BIDIR_NOPULL);
 #else
-        portOptions = SERIAL_BIDIR;
+        portOptions = SERIAL_BIDIR | SERIAL_BIDIR_NOPULL;
 #endif
 
         smartAudioSerialPort = openSerialPort(portConfig->identifier, FUNCTION_VTX_SMARTAUDIO, NULL, NULL, 4800, MODE_RXTX, portOptions);


### PR DESCRIPTION
This adds configurable support for TBS Unify Nano VTXs that require a pull low.

Thanks to @DieHertz for the approach.

Addresses #5329 

_Legal disclaimer: I am making my contributions/submissions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties._