### PR TITLE
 Reduce target groups to 4 to speed up PR build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,23 +23,11 @@ language: cpp
 compiler: clang
 
 env:
-#  - PUBLISHMETA=True
-#  - PUBLISHDOCS=True
-# Specify the main Mafile supported goals.
   - GOAL=test
   - GOAL=targets-group-1
   - GOAL=targets-group-2
   - GOAL=targets-group-3
   - GOAL=targets-group-4
-  - GOAL=targets-group-rest
-#  - GOAL=all
-#  - GOAL=AFROMINI
-#  - GOAL=AIORACERF3
-#  - GOAL=...
-# Or specify targets to run.
-#  - TARGET=AFROMINI
-#  - TARGET=AIORACERF3
-#  - TARGET=...
 
 before_install:
   - pip install --user cpp-coveralls

--- a/Makefile
+++ b/Makefile
@@ -346,11 +346,8 @@ targets-group-2: $(GROUP_2_TARGETS)
 ## targets-group-3   : build some targets
 targets-group-3: $(GROUP_3_TARGETS)
 
-## targets-group-3   : build some targets
-targets-group-4: $(GROUP_4_TARGETS)
-
-## targets-group-rest: build the rest of the targets (not listed in group 1, 2 or 3)
-targets-group-rest: $(GROUP_OTHER_TARGETS)
+## targets-group-4   : build some targets
+targets-group-4: $(GROUP_OTHER_TARGETS)
 
 $(VALID_TARGETS):
 	$(V0) @echo "Building $@" && \
@@ -466,14 +463,12 @@ targets:
 	@echo "targets-group-1:     $(GROUP_1_TARGETS)"
 	@echo "targets-group-2:     $(GROUP_2_TARGETS)"
 	@echo "targets-group-3:     $(GROUP_3_TARGETS)"
-	@echo "targets-group-4:     $(GROUP_4_TARGETS)"
-	@echo "targets-group-rest:  $(GROUP_OTHER_TARGETS)"
+	@echo "targets-group-4:     $(GROUP_OTHER_TARGETS)"
 
 	@echo "targets-group-1:     $(words $(GROUP_1_TARGETS)) targets"
 	@echo "targets-group-2:     $(words $(GROUP_2_TARGETS)) targets"
 	@echo "targets-group-3:     $(words $(GROUP_3_TARGETS)) targets"
-	@echo "targets-group-4:     $(words $(GROUP_4_TARGETS)) targets"
-	@echo "targets-group-rest:  $(words $(GROUP_OTHER_TARGETS)) targets"
+	@echo "targets-group-4:     $(words $(GROUP_OTHER_TARGETS)) targets"
 	@echo "total in all groups  $(words $(SUPPORTED_TARGETS)) targets"
 
 ## test              : run the cleanflight test suite

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ targets-group-3: $(GROUP_3_TARGETS)
 targets-group-4: $(GROUP_OTHER_TARGETS)
 
 $(VALID_TARGETS):
-	$(V0) @echo "Building $@" && \
+	$(V0) @echo "$(shell date +%FT%T%Z) Building $@" && \
 	$(MAKE) binary hex TARGET=$@ && \
 	echo "Building $@ succeeded."
 

--- a/make/targets.mk
+++ b/make/targets.mk
@@ -28,7 +28,7 @@ UNSUPPORTED_TARGETS := \
 SUPPORTED_TARGETS := $(filter-out $(UNSUPPORTED_TARGETS), $(VALID_TARGETS))
 
 TARGETS_TOTAL := $(words $(SUPPORTED_TARGETS))
-TARGET_GROUPS := 5
+TARGET_GROUPS := 4
 TARGETS_PER_GROUP := $(shell expr $(TARGETS_TOTAL) / $(TARGET_GROUPS) )
 
 ST := 1
@@ -43,11 +43,7 @@ ST := $(shell expr $(ET) + 1)
 ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
 GROUP_3_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
 
-ST := $(shell expr $(ET) + 1)
-ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
-GROUP_4_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
-
-GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS) $(GROUP_4_TARGETS), $(SUPPORTED_TARGETS))
+GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS), $(SUPPORTED_TARGETS))
 
 ifeq ($(filter $(TARGET),$(ALT_TARGETS)), $(TARGET))
 BASE_TARGET    := $(firstword $(subst /,, $(subst ./src/main/target/,, $(dir $(wildcard $(ROOT)/src/main/target/*/$(TARGET).mk)))))


### PR DESCRIPTION
With Travis CI doing 4 builds in parallel, having 5 groups actually increases overall build times, because the fifth group can only start after the first one is done. This change makes the groups slightly bigger 29 -> 36, but the overall time is reduced by about 30% or so.

Also log target build timestamps.

_Legal disclaimer: I am making my contributions/submissions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties._