### PR TITLE
Add DShot Beacon Support to AG3X Target

### DIFF
--- a/src/main/target/AG3X/target.h
+++ b/src/main/target/AG3X/target.h
@@ -37,6 +37,7 @@
 // Note, beeper is on the LED pin
 #define LED0_PIN                PC13
 
+#define USE_BEEPER
 #define BEEPER                  NONE
 #define BEEPER_INVERTED
 


### PR DESCRIPTION
As the Asgard 32 shares the beeper pad with LED0, USE_BEEPER was not defined in the target.  As a result, the DShot Beacon feature is not available.

Tested on the Kamikaze variant of the Asgard 32 F3.