### PR TITLE
[GPS Rescue] - Allow minimum distance to home to be configurable.

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -72,7 +72,8 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .throttleMax = 1600,
     .throttleHover = 1280,
     .sanityChecks = RESCUE_SANITY_ON,
-    .minSats = 8
+    .minSats = 8,
+    .minRescueDTH = 100
 );
 
 static uint16_t rescueThrottle;
@@ -123,9 +124,9 @@ void updateGPSRescueState(void)
             hoverThrottle = gpsRescueConfig()->throttleHover;
         }
 
-        // Minimum distance detection (100m).  Disarm regardless of sanity check configuration.  Rescue too close is never a good idea.
-        if (rescueState.sensor.distanceToHome < 100) {
-            // Never allow rescue mode to engage as a failsafe within 100 meters or when disarmed.
+        // Minimum distance detection.  Disarm regardless of sanity check configuration.  Rescue too close is never a good idea.
+        if (rescueState.sensor.distanceToHome < gpsRescueConfig()->minRescueDTH) {
+            // Never allow rescue mode to engage as a failsafe  when too close or when disarmed.
             if (rescueState.isFailsafe || !ARMING_FLAG(ARMED)) {
                 rescueState.failure = RESCUE_TOO_CLOSE;
                 setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -37,6 +37,7 @@ typedef struct gpsRescue_s {
     uint16_t throttleHover;
     uint16_t velP, velI, velD;
     uint8_t minSats;
+    uint8_t minRescueDTH; //meters
     gpsRescueSanity_e sanityChecks;
 } gpsRescueConfig_t;
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -761,7 +761,7 @@ const clivalue_t valueTable[] = {
     { "gps_rescue_throttle_hover",  VAR_UINT16 | MASTER_VALUE, .config.minmax = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleHover) },
     { "gps_rescue_sanity_checks",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, sanityChecks) },
     { "gps_rescue_min_sats",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 50 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minSats) },
-    { "gps_rescue_min_dth",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 50, 32000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDTH) },
+    { "gps_rescue_min_dth",         VAR_UINT16  | MASTER_VALUE, .config.minmax = { 50, 32000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDTH) },
 #endif
 #endif
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -761,6 +761,7 @@ const clivalue_t valueTable[] = {
     { "gps_rescue_throttle_hover",  VAR_UINT16 | MASTER_VALUE, .config.minmax = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleHover) },
     { "gps_rescue_sanity_checks",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, sanityChecks) },
     { "gps_rescue_min_sats",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 50 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minSats) },
+    { "gps_rescue_min_dth",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 50, 32000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDTH) },
 #endif
 #endif
 


### PR DESCRIPTION
Since some people are going to want to have rescue mode enabled when flying long range, but are not going to want to trigger it in small parks, indoors, etc, it made sense to allow the currently hardcoded (100m) value to be configurable.  Rescue mode should never be engaged under 50 meters for safety reasons, so the minimum required value is set at this.  

`set gps_rescue_min_dth = 500`