### PR TITLE
Dynamic Notch Filter Update

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -520,6 +520,7 @@ bool gyroInit(void)
 
     switch (debugMode) {
     case DEBUG_FFT:
+    case DEBUG_FFT_FREQ:
     case DEBUG_GYRO_RAW:
     case DEBUG_GYRO_SCALED:
     case DEBUG_GYRO_FILTERED:
@@ -1042,12 +1043,6 @@ static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSens
         return;
     }
 
-#ifdef USE_GYRO_DATA_ANALYSE
-    if (isDynamicFilterActive()) {
-        gyroDataAnalyse(&gyroSensor->gyroDev, gyroSensor->notchFilterDyn);
-    }
-#endif
-
     const timeDelta_t sampleDeltaUs = currentTimeUs - accumulationLastTimeSampledUs;
     accumulationLastTimeSampledUs = currentTimeUs;
     accumulatedMeasurementTimeUs += sampleDeltaUs;
@@ -1069,6 +1064,11 @@ static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSens
     } else {
         filterGyroDebug(gyroSensor, sampleDeltaUs);
     }
+#ifdef USE_GYRO_DATA_ANALYSE
+    if (isDynamicFilterActive()) {
+        gyroDataAnalyse(gyroSensor->notchFilterDyn);
+    }
+#endif
 }
 
 FAST_CODE void gyroUpdate(timeUs_t currentTimeUs)

--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -7,6 +7,15 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor, timeDe
         // DEBUG_GYRO_SCALED records the unfiltered, scaled gyro output
         GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_SCALED, axis, lrintf(gyroADCf));
 
+#ifdef USE_GYRO_DATA_ANALYSE
+        if (isDynamicFilterActive()) {
+            if (axis == X) {
+                GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 0, lrintf(gyroADCf)); // store raw data
+                GYRO_FILTER_DEBUG_SET(DEBUG_FFT_FREQ, 3, lrintf(gyroADCf)); // store raw data
+            }
+        }
+#endif
+
         // apply static notch filters and software lowpass filters
         gyroADCf = gyroSensor->notchFilter1ApplyFn((filter_t *)&gyroSensor->notchFilter1[axis], gyroADCf);
         gyroADCf = gyroSensor->notchFilter2ApplyFn((filter_t *)&gyroSensor->notchFilter2[axis], gyroADCf);
@@ -16,10 +25,6 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor, timeDe
 #ifdef USE_GYRO_DATA_ANALYSE
         if (isDynamicFilterActive()) {
             gyroDataAnalysePush(axis, gyroADCf);
-            if (axis == X) {
-                GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 0, lrintf(gyroADCf)); // store raw data
-                GYRO_FILTER_DEBUG_SET(DEBUG_FFT_FREQ, 3, lrintf(gyroADCf)); // store raw data
-            }
             gyroADCf = gyroSensor->notchFilterDynApplyFn((filter_t *)&gyroSensor->notchFilterDyn[axis], gyroADCf);
             if (axis == X) {
                 GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 1, lrintf(gyroADCf)); // store data after dynamic notch

--- a/src/main/sensors/gyroanalyse.h
+++ b/src/main/sensors/gyroanalyse.h
@@ -31,5 +31,6 @@ typedef struct gyroFftData_s {
 void gyroDataAnalyseInit(uint32_t targetLooptime);
 const gyroFftData_t *gyroFftData(int axis);
 struct gyroDev_s;
-void gyroDataAnalyse(const struct gyroDev_s *gyroDev, biquadFilter_t *notchFilterDyn);
+void gyroDataAnalysePush(int axis, float sample);
+void gyroDataAnalyse(biquadFilter_t *notchFilterDyn);
 void gyroDataAnalyseUpdate(biquadFilter_t *notchFilterDyn);


### PR DESCRIPTION
Improves performance of the dynamic notch filter, increasing peak accuracy over a wider band of frequencies, and generally using a narrower, higher notch.

Details:

- FFT now operates on gyro data *after* gyro notches and lowpasses
- FFT bandpass Q changed from 0.707 to 0.05, to 'open up' the FFT to a greater range of incoming frequencies by making the incoming bandpass 'flatter'
- Increase sampling rate from 1000Hz to 1333Hz, increasing bin width from 31.25Hz to 41.66Hz
- Practical notch centre point now ranges from about 140 to 620Hz, whereas before it rarely went outside 230-340Hz.
- Stops the lowest couple of FFT bins from going into centre frequency calculation
- Analyses FFT bins from low to high, keep ignoring bins until a bin is found that exceeds its previous bin by a factor of 2; then start examining bins from the bin before that (stops the FFT from being biased low, or going to the lowest value if there is no notch at all).
- if current bin height does not exceed previous bin height by more than 2 times, keep looking through successive bins until a 2x rise is found. If no 2x step is found, output will be maximum centre frequency.  If a 2x step is found the preceding and all subsequent bins will be analysed for a peak.
- Dominant bin amplitude is emphasised by cubing bin height before calculating mean, previously only squared.
- Maximum cutoff frequency is half the highest allowable centre frequency
- Default notch width is +/-25% of centre, typically narrower than the previous code.
- Code tidied up

Thanks to rav, Flint, UAV Tech, icr4sh, diehertz and everyone else who helped with this.