### PR TITLE
Fix A-Tail mixer

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -258,10 +258,10 @@ static const motorMixer_t mixerVtail4[] = {
 };
 
 static const motorMixer_t mixerAtail4[] = {
-    { 1.0f,  0.0f,  1.0f,  1.0f },          // REAR_R
-    { 1.0f, -1.0f, -1.0f,  0.0f },          // FRONT_R
-    { 1.0f,  0.0f,  1.0f, -1.0f },          // REAR_L
-    { 1.0f,  1.0f, -1.0f, -0.0f },          // FRONT_L
+    { 1.0f, -0.58f,  0.58f, -1.0f },          // REAR_R
+    { 1.0f, -0.46f, -0.39f,  0.5f },          // FRONT_R
+    { 1.0f,  0.58f,  0.58f, -1.0f },          // REAR_L
+    { 1.0f,  0.46f, -0.39f,  0.5f },          // FRONT_L
 };
 
 #if defined(USE_UNCOMMON_MIXERS)


### PR DESCRIPTION
A-Tail mixer should at least have the same sign-ness as Quad-X mixer.

This PR proposes the theoretically correct sign-ness with level of authority borrowed from V-Tail mixer (which is said to work find for Armattan V-Tail (258 / 355 unknown).

The A-Tail mixer seems broken since the very beginning of the BaseFlight.
https://github.com/multiwii/baseflight/blob/e582e0ce6321b7dd2293a60264e1040d0cbac5a4/src/mixer.c#L116-L121

V-Tail has been also broken from the beginning in respect to correct prop rotational direction, but it was fixed here:
https://github.com/cleanflight/cleanflight/issues/988
A reason A-Tail mixer wasn't evaluated in this discussion is unknown, even thought it was mentioned by @joshuabardwell.