### PR TITLE
Fix KakuteF7 motors 3 and 4

### DIFF
--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -28,7 +28,7 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,   0, 1), // PPM / CAM_CONTROL, DMA2_ST6
+    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,   0, 1), // PPM, DMA2_ST6
 
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // M1 , DMA1_ST7
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // M2 , DMA1_ST2
@@ -37,6 +37,6 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM8, CH4, PC9,  TIM_USE_MOTOR, 0, 0), // M5 , DMA2_ST7
     DEF_TIM(TIM5, CH4, PA3,  TIM_USE_MOTOR, 0, 0), // M6 , DMA1_ST1
 
-    DEF_TIM(TIM4, CH1, PD12, TIM_USE_LED,   0, 0), // LED_TRIP , DMA1_ST0
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_LED,   0, 0), // LED_TRIP, DMA1_ST0
 };
 

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -34,9 +34,6 @@
 #define USE_ACC
 #define USE_GYRO
 
-//define camera control
-#define CAMERA_CONTROL_PIN PE13
-
 // ICM-20689
 #define USE_ACC_SPI_ICM20689
 #define USE_GYRO_SPI_ICM20689


### PR DESCRIPTION
Credit to @davidlittlefarmer for finding and confirming

Fixes #6306.
Pin defined for camera control in #5796 has no dedicated timer and collides with motors 3&4. Only protocol that "works" due to it is MULTISHOT, any other protocol likely doesn't.

Camera control alternative is either of M5, M6 or LED_STRIP, but since this board has a dedicated `CAM` control pad (which doesn't work), I won't set any defaults. We should add a Wiki board description page and mention this issue there, but that will follow in another PR once I get my samples.

http://www.holybro.com/manual/Holybro_Kakute_F7_AIO_Manual.pdf