### PR TITLE
Fixed init order of MAX7456 DisplayPort

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -415,18 +415,18 @@ void max7456ReInit(void)
 // Here we init only CS and try to init MAX for first time.
 // Also detect device type (MAX v.s. AT)
 
-void max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdProfile, bool cpuOverclock)
+bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdProfile, bool cpuOverclock)
 {
     max7456HardwareReset();
 
     if (!max7456Config->csTag) {
-        return;
+        return false;
     }
 
     busdev->busdev_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
 
     if (!IOIsFreeOrPreinit(busdev->busdev_u.spi.csnPin)) {
-        return;
+        return false;
     }
 
     IOInit(busdev->busdev_u.spi.csnPin, OWNER_OSD_CS, 0);
@@ -489,6 +489,7 @@ void max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
 #endif
 
     // Real init will be made later when driver detect idle.
+    return true;
 }
 
 /**

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -31,7 +31,7 @@ extern uint16_t maxScreenSize;
 struct vcdProfile_s;
 void    max7456HardwareReset(void);
 struct max7456Config_s;
-void    max7456Init(const struct max7456Config_s *max7456Config, const struct vcdProfile_s *vcdProfile, bool cpuOverclock);
+bool    max7456Init(const struct max7456Config_s *max7456Config, const struct vcdProfile_s *vcdProfile, bool cpuOverclock);
 void    max7456Invert(bool invert);
 void    max7456Brightness(uint8_t black, uint8_t white);
 void    max7456DrawScreen(void);

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -265,7 +265,7 @@ void fcTasksInit(void)
 #endif
 
 #ifdef USE_OSD_SLAVE
-    setTaskEnabled(TASK_OSD_SLAVE, true);
+    setTaskEnabled(TASK_OSD_SLAVE, osdSlaveInitialized());
 #else
     if (sensors(SENSOR_GYRO)) {
         rescheduleTask(TASK_GYROPID, gyro.targetLooptime);
@@ -319,7 +319,7 @@ void fcTasksInit(void)
     setTaskEnabled(TASK_TRANSPONDER, feature(FEATURE_TRANSPONDER));
 #endif
 #ifdef USE_OSD
-    setTaskEnabled(TASK_OSD, feature(FEATURE_OSD));
+    setTaskEnabled(TASK_OSD, feature(FEATURE_OSD) && osdInitialized());
 #endif
 #ifdef USE_BST
     setTaskEnabled(TASK_BST_MASTER_PROCESS, true);

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -166,12 +166,13 @@ static const displayPortVTable_t max7456VTable = {
 
 displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile)
 {
+    if (
 #ifdef USE_OSD_SLAVE
-    if (!max7456Init(max7456Config(), vcdProfile, false))
+        !max7456Init(max7456Config(), vcdProfile, false)
 #else
-    if (!max7456Init(max7456Config(), vcdProfile, systemConfig()->cpu_overclock))
+        !max7456Init(max7456Config(), vcdProfile, systemConfig()->cpu_overclock)
 #endif
-    {
+    ) {
         return NULL;
     }
 

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -166,12 +166,17 @@ static const displayPortVTable_t max7456VTable = {
 
 displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile)
 {
-    displayInit(&max7456DisplayPort, &max7456VTable);
 #ifdef USE_OSD_SLAVE
-    max7456Init(max7456Config(), vcdProfile, false);
+    if (!max7456Init(max7456Config(), vcdProfile, false))
 #else
-    max7456Init(max7456Config(), vcdProfile, systemConfig()->cpu_overclock);
+    if (!max7456Init(max7456Config(), vcdProfile, systemConfig()->cpu_overclock))
 #endif
+    {
+        return NULL;
+    }
+
+    displayInit(&max7456DisplayPort, &max7456VTable);
+
     resync(&max7456DisplayPort);
     return &max7456DisplayPort;
 }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1131,6 +1131,11 @@ void osdInit(displayPort_t *osdDisplayPortToUse)
     resumeRefreshAt = micros() + (4 * REFRESH_1S);
 }
 
+bool osdInitialized(void)
+{
+    return osdDisplayPort;
+}
+
 void osdUpdateAlarms(void)
 {
     // This is overdone?

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -201,6 +201,7 @@ extern timeUs_t resumeRefreshAt;
 
 struct displayPort_s;
 void osdInit(struct displayPort_s *osdDisplayPort);
+bool osdInitialized(void);
 void osdResetAlarms(void);
 void osdUpdate(timeUs_t currentTimeUs);
 void osdStatSetState(uint8_t statIndex, bool enabled);

--- a/src/main/io/osd_slave.c
+++ b/src/main/io/osd_slave.c
@@ -120,6 +120,11 @@ void osdSlaveInit(displayPort_t *osdDisplayPortToUse)
     displayResync(osdDisplayPort);
 }
 
+bool osdSlaveInitialized(void)
+{
+    return osdDisplayPort;
+}
+
 bool osdSlaveCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
     UNUSED(currentTimeUs);

--- a/src/main/io/osd_slave.h
+++ b/src/main/io/osd_slave.h
@@ -29,6 +29,7 @@ extern bool osdSlaveIsLocked;
 
 // init
 void osdSlaveInit(struct displayPort_s *osdDisplayPort);
+bool osdSlaveInitialized(void);
 
 // task api
 bool osdSlaveCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);


### PR DESCRIPTION
Fixes a segfault which resulted in one of the issues with YUPIF7 reported in #6183.
For `max7456DisplayPortInit` was calling functions in reversed order, resulting in `displayInit` being called before `max7456Init` (where SPI instance is set).

`displayInit(max7456DisplayPort) -> max7456Invert() -> spiSetDivisor(nullptr)`

I don't think it's the only issue with this board, it also seems like we should `setTaskEnabled(TASK_OSD, false)` and `setTaskEnabled(TASK_CMS, false)` if no `displayPort` available.