### PR TITLE
Enabled MPU for ITCM-RAM

### DIFF
--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -30,6 +30,8 @@
 #include "drivers/nvic.h"
 #include "drivers/system.h"
 
+#include "stm32f7xx_ll_cortex.h"
+
 
 #define AIRCR_VECTKEY_MASK    ((uint32_t)0x05FA0000)
 void SystemClock_Config(void);

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -162,6 +162,10 @@ void systemInit(void)
 {
     checkForBootLoaderRequest();
 
+    //  Mark ITCM-RAM as read-only
+    LL_MPU_ConfigRegion(LL_MPU_REGION_NUMBER0, 0, RAMITCM_BASE, LL_MPU_REGION_SIZE_16KB | LL_MPU_REGION_PRIV_RO_URO);
+    LL_MPU_Enable(LL_MPU_CTRL_PRIVILEGED_DEFAULT);
+
     //SystemClock_Config();
 
     // Configure NVIC preempt/priority groups

--- a/src/main/fc/fc_hardfaults.c
+++ b/src/main/fc/fc_hardfaults.c
@@ -36,6 +36,12 @@ void MemManage_Handler(void)
 {
     LED2_ON;
 
+    // fall out of the sky
+    uint8_t requiredStateForMotors = SYSTEM_STATE_CONFIG_LOADED | SYSTEM_STATE_MOTORS_READY;
+    if ((systemState & requiredStateForMotors) == requiredStateForMotors) {
+        stopMotors();
+    }
+
 #ifdef USE_TRANSPONDER
     // prevent IR LEDs from burning out.
     uint8_t requiredStateForTransponder = SYSTEM_STATE_CONFIG_LOADED | SYSTEM_STATE_TRANSPONDER_ENABLED;

--- a/src/main/fc/fc_hardfaults.c
+++ b/src/main/fc/fc_hardfaults.c
@@ -31,6 +31,31 @@
 
 #include "flight/mixer.h"
 
+#ifdef STM32F7
+void MemManage_Handler(void)
+{
+    LED2_ON;
+
+#ifdef USE_TRANSPONDER
+    // prevent IR LEDs from burning out.
+    uint8_t requiredStateForTransponder = SYSTEM_STATE_CONFIG_LOADED | SYSTEM_STATE_TRANSPONDER_ENABLED;
+    if ((systemState & requiredStateForTransponder) == requiredStateForTransponder) {
+        transponderIrDisable();
+    }
+#endif
+
+    LED1_OFF;
+    LED0_OFF;
+
+    while (1) {
+        delay(500);
+        LED2_TOGGLE;
+        delay(50);
+        LED2_TOGGLE;
+    }
+}
+#endif
+
 #ifdef DEBUG_HARDFAULTS
 //from: https://mcuoneclipse.com/2012/11/24/debugging-hard-faults-on-arm-cortex-m/
 /**
@@ -116,10 +141,8 @@ void HardFault_Handler(void)
     LED0_OFF;
 
     while (1) {
-#ifdef LED2
         delay(50);
         LED2_TOGGLE;
-#endif
     }
 }
 #endif

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -31,6 +31,7 @@
 #include "stm32f7xx_hal.h"
 #include "system_stm32f7xx.h"
 
+#include "stm32f7xx_ll_cortex.h"
 #include "stm32f7xx_ll_spi.h"
 #include "stm32f7xx_ll_gpio.h"
 #include "stm32f7xx_ll_dma.h"

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -31,7 +31,6 @@
 #include "stm32f7xx_hal.h"
 #include "system_stm32f7xx.h"
 
-#include "stm32f7xx_ll_cortex.h"
 #include "stm32f7xx_ll_spi.h"
 #include "stm32f7xx_ll_gpio.h"
 #include "stm32f7xx_ll_dma.h"


### PR DESCRIPTION
On F7 we have ITCM-RAM which tends to be the target of null pointer dereferences.
This PR marks ITCM-RAM as read-only, so after initial copy of `FAST_CODE` functions no more modifications are allowed.
Any offending code will trigger a `MemManage_Handler` which is similar to `HardFault_Handler`, but blinks LED2 in following pattern: 500ms ON, 50ms OFF.

Before merging it to master we need to check as many targets as possible to make sure we have identified most of the `nullptr` dereferences.
@jflyper There was some issue with erratic VBAT ADC values? Which target was it?