### PR TITLE
Arrow turtle mode

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -103,6 +103,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"HEADING",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_NUMERICAL_HEADING], 0},
     {"VARIO",              OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_NUMERICAL_VARIO], 0},
     {"G-FORCE",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_G_FORCE], 0},
+    {"FLIP ARROW",         OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_FLIP_ARROW], 0},
     {"BACK",               OME_Back,    NULL, NULL, 0},
     {NULL,                 OME_END,     NULL, NULL, 0}
 };

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -1008,6 +1008,7 @@ const clivalue_t valueTable[] = {
     { "osd_esc_rpm_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ESC_RPM]) },
     { "osd_rtc_date_time_pos",      VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RTC_DATETIME]) },
     { "osd_adjustment_range_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ADJUSTMENT_RANGE]) },
+    { "osd_flip_arrow_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_FLIP_ARROW]) },
 #ifdef USE_ADC_INTERNAL
     { "osd_core_temp_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CORE_TEMPERATURE]) },
 #endif

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -64,6 +64,7 @@
 #include "fc/core.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
+#include "fc/rc_modes.h"
 #include "fc/rc.h"
 #include "fc/runtime_config.h"
 
@@ -204,6 +205,7 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_NUMERICAL_VARIO,
     OSD_COMPASS_BAR,
     OSD_ANTI_GRAVITY,
+    OSD_FLIP_ARROW,
 #ifdef USE_RTC_TIME
     OSD_RTC_DATETIME,
 #endif
@@ -472,6 +474,30 @@ static bool osdDrawSingleElement(uint8_t item)
     char buff[OSD_ELEMENT_BUFFER_LENGTH] = "";
 
     switch (item) {
+    case OSD_FLIP_ARROW: 
+        {
+            const int angleR = attitude.values.roll;
+            const int angleP = attitude.values.pitch; // still gotta update all angleR and angleP pointers.
+            if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+                if (angleP > 0 && ((angleR > 175 && angleR < 180) || (angleR > -180 && angleR < -175))) {
+                    buff[0] = SYM_ARROW_SOUTH;
+                } else if (angleP > 0 && angleR > 0 && angleR < 175) {
+                    buff[0] = (SYM_ARROW_EAST + 2);
+                } else if (angleP > 0 && angleR < 0 && angleR > -175) {
+                    buff[0] = (SYM_ARROW_WEST + 2);
+                } else if (angleP <= 0 && ((angleR > 175 && angleR < 180) || (angleR > -180 && angleR < -175))) {
+                    buff[0] = SYM_ARROW_NORTH;
+                } else if (angleP <= 0 && angleR > 0 && angleR < 175) {
+                    buff[0] = (SYM_ARROW_NORTH + 2);
+                } else if (angleP <= 0 && angleR < 0 && angleR > -175) {
+                    buff[0] = (SYM_ARROW_SOUTH + 2);
+                }
+            } else {
+                buff[0] = ' ';
+            }
+            buff[1] = '\0';
+            break;
+        }
     case OSD_RSSI_VALUE:
         {
             uint16_t osdRssi = getRssi() * 100 / 1024; // change range

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -97,6 +97,7 @@ typedef enum {
     OSD_ANTI_GRAVITY,
     OSD_G_FORCE,
     OSD_LOG_STATUS,
+    OSD_FLIP_ARROW,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/target/BEEBRAIN_V2F/config.c
+++ b/src/main/target/BEEBRAIN_V2F/config.c
@@ -151,6 +151,7 @@ void targetConfiguration(void)
     osdConfigMutable()->item_pos[OSD_ESC_TMP]            &= ~VISIBLE_FLAG;
     osdConfigMutable()->item_pos[OSD_ESC_RPM]            &= ~VISIBLE_FLAG;
     osdConfigMutable()->item_pos[OSD_G_FORCE]            &= ~VISIBLE_FLAG;
+    osdConfigMutable()->item_pos[OSD_FLIP_ARROW]         &= ~VISIBLE_FLAG;
 
     modeActivationConditionsMutable(0)->modeId           = BOXANGLE;
     modeActivationConditionsMutable(0)->auxChannelIndex  = AUX2 - NON_AUX_CHANNEL_COUNT;


### PR DESCRIPTION
Implements Feature Request: #4652 .

This will add an arrow if turtle mode is activated showing which side of the motors is up.

Preview from config [This code is firmware, the picture is just for show]:

![0n](https://user-images.githubusercontent.com/19364969/43345686-b5a5cd4e-91ee-11e8-8283-56506b800551.jpg)

I'm uploading because I need help verifying that the code works/testing as I don't have access to a quad to test any time soon.

Later on I'm planning on getting the arrow in the right directions, I've just "blindly coded".