### PR TITLE
Hardcode adding ability to assign gyros to axises.

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2713,7 +2713,7 @@ static void cliDumpGyroRegisters(char *cmdline)
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         const char axisName[XYZ_AXIS_COUNT] = {'X','Y','Z'};
         const char * const gyroNames[XYZ_AXIS_COUNT] = {"Both gyros", "Gyro 1", "Gyro 2"};
-        cliPrintLinef("# %s for %c-axis.", gyroNames[gyroConfig()->gyro_for_axis[i]], axisName(axis));
+        cliPrintLinef("# %s for %c-axis.", gyroNames[gyroConfig()->gyro_for_axis[axis]], axisName(axis));
     }
    
 

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2711,7 +2711,7 @@ static void cliDumpGyroRegisters(char *cmdline)
         cliPrintGyroRegisters(GYRO_CONFIG_USE_GYRO_2);
     }
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        const char axisName[XYZ_AXIS_COUNT] = {'X','Y','Z'};
+        const char * const axisName[XYZ_AXIS_COUNT] = {'X','Y','Z'};
         const char * const gyroNames[XYZ_AXIS_COUNT] = {"Both gyros", "Gyro 1", "Gyro 2"};
         cliPrintLinef("# %s for %c-axis.", gyroNames[gyroConfig()->gyro_for_axis[axis]], axisName(axis));
     }

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2710,6 +2710,13 @@ static void cliDumpGyroRegisters(char *cmdline)
         cliPrintLinef("\r\n# Gyro 2");
         cliPrintGyroRegisters(GYRO_CONFIG_USE_GYRO_2);
     }
+    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+        const char axisName[XYZ_AXIS_COUNT] = {'X','Y','Z'};
+        const char * const gyroNames[XYZ_AXIS_COUNT] = {"Both gyros", "Gyro 1", "Gyro 2"};
+        cliPrintLinef("# %s for %c-axis.", gyroNames[gyroConfig()->gyro_for_axis[i]], axisName(axis));
+    }
+   
+
 #else
     cliPrintGyroRegisters(GYRO_CONFIG_USE_GYRO_1);
 #endif // USE_DUAL_GYRO

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -528,6 +528,7 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef USE_DUAL_GYRO
     { "gyro_to_use",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_to_use) },
+    { "gyro_for_axis",              VAR_UINT8  | MASTER_VALUE | MODE_ARRAY,  .config.array.length = { XYZ_AXIS_COUNT }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_for_axis[3]) }
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
     { "dyn_fft_location",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DYNAMIC_FFT_LOCATION }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_fft_location) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -528,7 +528,7 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef USE_DUAL_GYRO
     { "gyro_to_use",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_to_use) },
-    { "gyro_for_axis",              VAR_UINT8  | MASTER_VALUE | MODE_ARRAY,  .config.array.length = { XYZ_AXIS_COUNT }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_for_axis[3]) }
+    { "gyro_for_axis",              VAR_UINT8  | MASTER_VALUE | MODE_ARRAY,  .config.array.length = { XYZ_AXIS_COUNT }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_for_axis[3]) },
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
     { "dyn_fft_location",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DYNAMIC_FFT_LOCATION }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_fft_location) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -528,7 +528,7 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef USE_DUAL_GYRO
     { "gyro_to_use",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_to_use) },
-    { "gyro_for_axis",              VAR_UINT8  | MASTER_VALUE | MODE_ARRAY,  .config.array.length = { XYZ_AXIS_COUNT }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_for_axis[3]) },
+    { "gyro_for_axis",              VAR_UINT8  | MASTER_VALUE | MODE_ARRAY,  .config.array.length = XYZ_AXIS_COUNT, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_for_axis[3]) },
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
     { "dyn_fft_location",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DYNAMIC_FFT_LOCATION }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_fft_location) },

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -1136,7 +1136,7 @@ FAST_CODE void gyroUpdate(timeUs_t currentTimeUs)
                 case GYRO_CONFIG_USE_GYRO_1:
                     gyro.gyroADCf[axis] = gyroSensor1.gyroDev.gyroADCf[axis];
                     break;
-                case GYRO_CONFIG_USE_GYRO_2;
+                case GYRO_CONFIG_USE_GYRO_2:
                     gyro.gyroADCf[axis] = gyroSensor2.gyroDev.gyroADCf[axis];
                     break;
                 }

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -92,6 +92,8 @@ typedef struct gyroConfig_s {
     uint8_t  gyro_use_32khz;
     uint8_t  gyro_to_use;
 
+    uint8_t  gyro_for_axis[XYZ_AXIS_COUNT];
+
     uint16_t gyro_lowpass_hz;
     uint16_t gyro_lowpass2_hz;
 


### PR DESCRIPTION
This implements feature request: #6209.

Some gyros are more accurate for some axises and vice versa, that's why this feature would add value.

If you want to test this you will have to manually change the values for [gyroX, gyroY, gyroZ].
// Values for enabling both, 1 or 2 gyro's for each axis:
// 0 is both [Default], 1 is the first gyro, 2 the second.
// X is for X axis, Y for Y etc.

- Tim

