### PR TITLE
Enabled SDIO on NUCLEOF722.

### DIFF
--- a/src/main/target/NUCLEOF722/target.c
+++ b/src/main/target/NUCLEOF722/target.c
@@ -32,8 +32,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM | TIM_USE_PPM, 0, 0),
     DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,               0, 0),
     DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,               0, 0),
-    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,               0, 0),
-    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,               0, 0),
+//    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,               0, 0), // Used for SDIO
+//    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,               0, 0), // Used for SDIO
 
     DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_MOTOR,             0, 0),
     DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,             0, 1),

--- a/src/main/target/NUCLEOF722/target.h
+++ b/src/main/target/NUCLEOF722/target.h
@@ -29,9 +29,9 @@
 #define LED0_PIN   PB7  // blue
 #define LED1_PIN   PB14 // red
 
-#define USE_BEEPER
-#define BEEPER_PIN PA0
-#define BEEPER_INVERTED
+//#define USE_BEEPER
+//#define BEEPER_PIN PA0
+//#define BEEPER_INVERTED
 
 #define USE_ACC
 #define USE_FAKE_ACC
@@ -77,12 +77,14 @@
 #define UART3_TX_PIN PD8
 
 #define USE_UART4
-#define UART4_RX_PIN PC11
-#define UART4_TX_PIN PC10
+//#define UART4_RX_PIN PC11  // Used for SDIO
+//#define UART4_TX_PIN PC10  // Used for SDIO
+#define UART4_RX_PIN PA1
+#define UART4_TX_PIN PA0
 
 //#define USE_UART5
-#define UART5_RX_PIN PD2
-#define UART5_TX_PIN PC12
+//#define UART5_RX_PIN PD2  // Used for SDIO
+//#define UART5_TX_PIN PC12  // Used for SDIO
 
 //#define USE_UART6
 #define UART6_RX_PIN PC7
@@ -99,7 +101,7 @@
 #define USE_SOFTSERIAL1
 #define USE_SOFTSERIAL2
 
-#define SERIAL_PORT_COUNT 6 //VCP, USART2, USART3, UART4,SOFTSERIAL x 2
+#define SERIAL_PORT_COUNT 6 //VCP, USART2, USART3, UART4, SOFTSERIAL x 2
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PB15 // (Hardware=0, PPM)
@@ -118,19 +120,24 @@
 #define SPI4_MISO_PIN           PE13
 #define SPI4_MOSI_PIN           PE14
 
-//#define USE_SDCARD
-#define SDCARD_DETECT_INVERTED
-#define SDCARD_DETECT_PIN                   PF14
+#define USE_SDCARD
 
-#define SDCARD_SPI_INSTANCE                 SPI4
-#define SDCARD_SPI_CS_PIN                   SPI4_NSS_PIN
+//#define SDCARD_DETECT_INVERTED
+//#define SDCARD_DETECT_PIN                   PF14
 
-#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 422kHz
+//#define SDCARD_SPI_INSTANCE                 SPI4
+//#define SDCARD_SPI_CS_PIN                   SPI4_NSS_PIN
+
+//#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 422kHz
 // Divide to under 25MHz for normal operation:
-#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER 8 // 27MHz
+//#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER 8 // 27MHz
 
-#define SDCARD_DMA_STREAM_TX_FULL           DMA2_Stream1
-#define SDCARD_DMA_CHANNEL                  4
+//#define SDCARD_DMA_STREAM_TX_FULL           DMA2_Stream1
+//#define SDCARD_DMA_CHANNEL                  4
+
+#define USE_SDCARD_SDIO
+#define SDIO_DMA          DMA2_Stream3
+#define SDCARD_SPI_CS_PIN NONE //This is not used on SDIO, has to be kept for now to keep compiler happy
 
 #define USE_I2C
 #define USE_I2C_DEVICE_1

--- a/src/main/target/NUCLEOF722/target.mk
+++ b/src/main/target/NUCLEOF722/target.mk
@@ -1,5 +1,5 @@
 F7X2RE_TARGETS += $(TARGET)
-FEATURES       += SDCARD VCP
+FEATURES       += VCP SDIO
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_fake.c \


### PR DESCRIPTION
This is aiming to provide a readily available setup to enable more testing / development for SD card support using SDIO.

One of the aims is to address the lack of reliability when it comes to SD cards being recognised by Betaflight, as documented in #5303.

Interfacing with the SD card is done as documented in https://www.st.com/content/ccc/resource/technical/document/user_manual/group0/26/49/90/2e/33/0d/4a/da/DM00244518/files/DM00244518.pdf/jcr:content/translations/en.DM00244518.pdf:

![image](https://user-images.githubusercontent.com/4742747/43363502-528f26ca-935a-11e8-9407-fd62089a7508.png)

The connection to the SD card can be made with an SD card adapter as available cheaply from electronics supplier:

![img_20180729_180133](https://user-images.githubusercontent.com/4742747/43363518-a325c2ec-935a-11e8-930f-ece26b02504f.jpg)

Current state of work: 

The SD card is recognised, but the data that is read is garbled:

```
Entering CLI Mode, type 'exit' to return, or 'help'

# sd_info
SD card: Manufacturer 0x3, 3872256kB, 10/2011, v8.0, 'SU04G'
Filesystem: Fatal - no FAT MBR partitions
```

(the same card works just fine when inserted into a SPI SD card board)

(Note: Beeper had to be disabled, and UART4 moved to alternate pins (one of them used by the beeper), because the board would not respond to MSP commands when UART4 is not defined.)