### PR TITLE
Make gyro driver more aware of ICM-20601

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -156,6 +156,14 @@ enum gyro_fsr_e {
     NUM_GYRO_FSR
 };
 
+enum icm_high_range_gyro_fsr_e {
+    ICM_HIGH_RANGE_FSR_500DPS = 0,
+    ICM_HIGH_RANGE_FSR_1000DPS,
+    ICM_HIGH_RANGE_FSR_2000DPS,
+    ICM_HIGH_RANGE_FSR_4000DPS,
+    NUM_ICM_HIGH_RANGE_GYRO_FSR
+};
+
 enum fchoice_b {
     FCB_DISABLED = 0x00,
     FCB_8800_32 = 0x01,
@@ -174,6 +182,14 @@ enum accel_fsr_e {
     INV_FSR_8G,
     INV_FSR_16G,
     NUM_ACCEL_FSR
+};
+
+enum icm_high_range_accel_fsr_e {
+    ICM_HIGH_RANGE_FSR_4G = 0,
+    ICM_HIGH_RANGE_FSR_8G,
+    ICM_HIGH_RANGE_FSR_16G,
+    ICM_HIGH_RANGE_FSR_32G,
+    NUM_ICM_HIGH_RANGE_ACCEL_FSR
 };
 
 typedef enum {

--- a/src/main/drivers/accgyro/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6500.c
@@ -56,6 +56,14 @@ void mpu6500GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
+    int gyro_range = INV_FSR_2000DPS;
+    int accel_range = INV_FSR_16G;
+
+    if (gyro->mpuDetectionResult.sensor == ICM_20601_SPI) {
+        gyro_range = gyro->gyro_high_fsr ? ICM_HIGH_RANGE_FSR_4000DPS : ICM_HIGH_RANGE_FSR_2000DPS;
+        accel_range = ICM_HIGH_RANGE_FSR_16G;
+    }
+
     busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
     busWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, 0x07);
@@ -64,9 +72,9 @@ void mpu6500GyroInit(gyroDev_t *gyro)
     delay(100);
     busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    busWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
+    busWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, gyro_range << 3 | mpuGyroFCHOICE(gyro));
     delay(15);
-    busWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    busWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, accel_range << 3);
     delay(15);
     busWriteRegister(&gyro->bus, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
     delay(15);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -128,7 +128,11 @@ bool mpu6500SpiGyroDetect(gyroDev_t *gyro)
     case MPU_9250_SPI:
     case ICM_20608_SPI:
     case ICM_20602_SPI:
+        // 16.4 dps/lsb scalefactor
+        gyro->scale = 1.0f / 16.4f;
+        break;
     case ICM_20601_SPI:
+        gyro->scale = 1.0f / (gyro->gyro_high_fsr ? 8.2f : 16.4f);
         break;
     default:
         return false;
@@ -136,9 +140,6 @@ bool mpu6500SpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = mpu6500SpiGyroInit;
     gyro->readFn = mpuGyroReadSPI;
-
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
 
     return true;
 }


### PR DESCRIPTION
ICM-20601 just like ICM-20649 has a shifted by one bit to the left table of gyro DPS and acc G tables.
As a result ICM-20601 gets treated as a 2K DPS part while it's being configured for 4K.

NB:
* `gyro_high_range` and `acc_high_range` are currently conditional on `USE_ACCGYRO_SPI_ICM20649`, only one target defines this macro and I decided not to add a clause for ICM-20601 because no targets define it explicitly. We should think of a better way of showing/hiding settings based on detected hardware, or just show them all the time. It will be necessary when we go fully-universal on targets
* mpu6500 driver configures acc+gyro in `gyroInit` function, where `acc_t` is unavailable, so I haven't added checking for `acc_high_range`, just made sure all gyros sharing this driver are properly initialized to 16G