### PR TITLE
Added frame quality to OSD.

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -922,6 +922,7 @@ const clivalue_t valueTable[] = {
 
     { "osd_vbat_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_VOLTAGE]) },
     { "osd_rssi_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RSSI_VALUE]) },
+    { "osd_frame_quality_pos",      VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_FRAME_QUALITY]) },
     { "osd_tim_1_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_1]) },
     { "osd_tim_2_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_2]) },
     { "osd_remaining_time_estimate_pos",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_REMAINING_TIME_ESTIMATE]) },

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -198,7 +198,8 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_NUMERICAL_HEADING,
     OSD_NUMERICAL_VARIO,
     OSD_COMPASS_BAR,
-    OSD_ANTI_GRAVITY
+    OSD_ANTI_GRAVITY,
+    OSD_FRAME_QUALITY
 };
 
 PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 3);
@@ -465,6 +466,16 @@ static bool osdDrawSingleElement(uint8_t item)
                 osdRssi = 99;
 
             tfp_sprintf(buff, "%c%2d", SYM_RSSI, osdRssi);
+            break;
+        }
+
+    case OSD_FRAME_QUALITY:
+        {
+            uint8_t osdFrameQuality = getFrameQuality() * 10 / FRAME_QUALITY_MAX_VALUE; // change range
+            if (osdFrameQuality >= 10)
+                osdFrameQuality = 9;
+
+            tfp_sprintf(buff, "%1d", osdFrameQuality);
             break;
         }
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -95,6 +95,7 @@ typedef enum {
     OSD_ADJUSTMENT_RANGE,
     OSD_CORE_TEMPERATURE,
     OSD_ANTI_GRAVITY,
+    OSD_FRAME_QUALITY,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -167,6 +167,10 @@ void updateRSSI(timeUs_t currentTimeUs);
 uint16_t getRssi(void);
 uint8_t getRssiPercent(void);
 
+#define FRAME_QUALITY_MAX_VALUE 100
+
+uint8_t getFrameQuality(void);
+
 void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRangeConfig);
 
 void suspendRxSignal(void);


### PR DESCRIPTION
Added single digit display of frame quality (based on frame errors) to OSD.

Sometimes when flying in non-open environments (e.g. around/above trees), rssi starts to get a bit on the low side. As it is logarithmic there should still be some head-room, but without knowing something about the packet loss it is hard to make an informed decision. The option to have a single digit display of (non) frame errors provides this information.