### PR TITLE
Fix 32KHz gyro targetLooptime calculation

### DIFF
--- a/src/main/drivers/accgyro/gyro_sync.c
+++ b/src/main/drivers/accgyro/gyro_sync.c
@@ -54,7 +54,7 @@ uint32_t gyroSetSampleRate(gyroDev_t *gyro, uint8_t lpf, uint8_t gyroSyncDenomin
     if (lpf == GYRO_HARDWARE_LPF_NORMAL || lpf == GYRO_HARDWARE_LPF_EXPERIMENTAL) {
         if (gyro_use_32khz) {
             gyro->gyroRateKHz = GYRO_RATE_32_kHz;
-            gyroSamplePeriod = 31.5f;
+            gyroSamplePeriod = 31.25f;
         } else {
             switch (gyro->mpuDetectionResult.sensor) {
             case BMI_160_SPI:


### PR DESCRIPTION
The target loop time was being calculated incorrectly for 32KHz gyros. Constant should be 31.25 rather than 31.5.

For example:

8KHz was being calculated to 126us instead of 125us
4KHz was 252us instead of 250us
2KHz was 405us instead of 500us
