### PR TITLE
Adding non-linear integrator take-back-half (TBH) feature to PID

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -226,8 +226,8 @@ static FAST_RAM_ZERO_INIT uint8_t itermRelaxCutoff;
 #endif
 
 #if defined(USE_TBH)
-static FAST_RAM_ZERO_INIT float iPrevTBH[XYZ_AXIS_COUNT];
-static FAST_RAM_ZERO_INIT float errorSignPrevTBH[XYZ_AXIS_COUNT];
+static FAST_RAM_ZERO_INIT float iPrevTbh[XYZ_AXIS_COUNT];
+static FAST_RAM_ZERO_INIT bool tbhErrorSignPrev[XYZ_AXIS_COUNT];
 #endif
 
 #ifdef USE_RC_SMOOTHING_FILTER
@@ -1003,13 +1003,13 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
                 // the I term to non-linearly jump to half-way between the current
                 // accumulated error and the accumulated error at the last zero
                 // crossing.
-                const float thisSign = copysign(1.0f, itermErrorRate); //-1 or 1
-                if (thisSign != errorSignPrevTBH[axis]) { 
-                    const float lastCrossIValue = iPrevTBH[axis];
-                    iPrevTBH[axis] = pidData[axis].I;
+                const bool thisSign = itermErrorRate > 0; //T==Pos, F==Neg or zero
+                if (thisSign != tbhErrorSignPrev[axis]) { 
+                    const float lastCrossIValue = iPrevTbh[axis];
+                    iPrevTbh[axis] = pidData[axis].I;
                     pidData[axis].I = (pidData[axis].I + lastCrossIValue) * 0.5f; //Take-Back-Half error
                 }
-                errorSignPrevTBH[axis] = thisSign;
+                tbhErrorSignPrev[axis] = thisSign;
             }
         #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -168,7 +168,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .abs_control_limit = 90,
         .abs_control_error_limit = 20,
         .antiGravityMode = ANTI_GRAVITY_SMOOTH,
-        .tbh_enabled = 0, //Take-back-half OFF by default
+        .iterm_tbh = ITERM_TBH_OFF, //Take-back-half OFF by default
     );
 }
 
@@ -223,6 +223,11 @@ static FAST_RAM_ZERO_INIT pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT uint8_t itermRelax;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxType;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxCutoff;
+#endif
+
+#if defined(USE_TBH)
+static FAST_RAM_ZERO_INIT float iPrevTBH[XYZ_AXIS_COUNT];
+static FAST_RAM_ZERO_INIT float errorSignPrevTBH[XYZ_AXIS_COUNT];
 #endif
 
 #ifdef USE_RC_SMOOTHING_FILTER
@@ -992,19 +997,19 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
             pidData[axis].I = ITermNew;
         }
         #if defined(USE_TBH)
-            if (pidProfile->tbh_enabled){
+            if (pidProfile->iterm_tbh && (axis < FD_YAW || pidProfile->iterm_tbh == ITERM_TBH_RPY)) {
                 // Non-linear Take-Back Half algorithm
                 // When the error term crosses through zero, this algorithm causes
                 // the I term to non-linearly jump to half-way between the current
                 // accumulated error and the accumulated error at the last zero
                 // crossing.
                 const float thisSign = copysign(1.0f, itermErrorRate); //-1 or 1
-                if (thisSign != pidData[axis].errorSignPrevTBH) { 
-                    const float lastCrossIValue = pidData[axis].IPrevTBH;
-                    pidData[axis].IPrevTBH = pidData[axis].I;
-                    pidData[axis].I = (pidData[axis].I + lastCrossIValue)*0.5f; //TBH
+                if (thisSign != errorSignPrevTBH[axis]) { 
+                    const float lastCrossIValue = iPrevTBH[axis];
+                    iPrevTBH[axis] = pidData[axis].I;
+                    pidData[axis].I = (pidData[axis].I + lastCrossIValue) * 0.5f; //Take-Back-Half error
                 }
-                pidData[axis].errorSignPrevTBH = thisSign;
+                errorSignPrevTBH[axis] = thisSign;
             }
         #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -998,13 +998,13 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
                 // the I term to non-linearly jump to half-way between the current
                 // accumulated error and the accumulated error at the last zero
                 // crossing.
-                const float ThisSign = copysign(1.0, itermErrorRate); //-1 or 1
-                if (ThisSign != pidData[axis].errorSignPrevTBH) { 
+                const float thisSign = copysign(1.0f, itermErrorRate); //-1 or 1
+                if (thisSign != pidData[axis].errorSignPrevTBH) { 
                     const float lastCrossIValue = pidData[axis].IPrevTBH;
                     pidData[axis].IPrevTBH = pidData[axis].I;
-                    pidData[axis].I = (pidData[axis].I + lastCrossIValue)*0.5; //TBH
+                    pidData[axis].I = (pidData[axis].I + lastCrossIValue)*0.5f; //TBH
                 }
-                pidData[axis].errorSignPrevTBH = ThisSign;
+                pidData[axis].errorSignPrevTBH = thisSign;
             }
         #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -94,6 +94,12 @@ typedef enum {
     ITERM_RELAX_SETPOINT
 } itermRelaxType_e;
 
+typedef enum {
+    ITERM_TBH_OFF,
+    ITERM_TBH_RP,
+    ITERM_TBH_RPY
+} itermTBHType_e;
+
 typedef struct pidProfile_s {
     uint16_t yaw_lowpass_hz;                // Additional yaw filter when yaw axis too noisy
     uint16_t dterm_lowpass_hz;              // Delta Filter in hz
@@ -145,7 +151,7 @@ typedef struct pidProfile_s {
     uint8_t abs_control_gain;               // How strongly should the absolute accumulated error be corrected for
     uint8_t abs_control_limit;              // Limit to the correction
     uint8_t abs_control_error_limit;        // Limit to the accumulated error
-    uint8_t tbh_enabled;                    // OFF or ON - Integral term non-linear take-back-half on zero error
+    uint8_t iterm_tbh;                      // Integral term non-linear take-back-half on zero error
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE
@@ -169,8 +175,6 @@ typedef struct pidAxisData_s {
     float I;
     float D;
     float F;
-    float IPrevTBH;
-    float errorSignPrevTBH;
 
     float Sum;
 } pidAxisData_t;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -145,6 +145,7 @@ typedef struct pidProfile_s {
     uint8_t abs_control_gain;               // How strongly should the absolute accumulated error be corrected for
     uint8_t abs_control_limit;              // Limit to the correction
     uint8_t abs_control_error_limit;        // Limit to the accumulated error
+    uint8_t tbh_enabled;                    // OFF or ON - Integral term non-linear take-back-half on zero error
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE
@@ -168,6 +169,8 @@ typedef struct pidAxisData_s {
     float I;
     float D;
     float F;
+    float IPrevTBH;
+    float errorSignPrevTBH;
 
     float Sum;
 } pidAxisData_t;

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -862,6 +862,11 @@ const clivalue_t valueTable[] = {
     { "abs_control_error_limit",    VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 1, 45 }, PG_PID_PROFILE, offsetof(pidProfile_t, abs_control_error_limit) },
 #endif
 
+// Take-back-half non-linear integrator
+#if defined(USE_TBH)
+    { "tbh_enabled",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, tbh_enabled) },
+#endif
+
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -351,6 +351,12 @@ static const char * const lookupTableItermRelaxType[] = {
 };
 #endif
 
+#if defined(USE_TBH)
+static const char * const lookupTableTBH[] = {
+    "OFF", "RP", "RPY"
+};
+#endif
+
 #ifdef USE_ACRO_TRAINER
 static const char * const lookupTableAcroTrainerDebug[] = {
     "ROLL", "PITCH"
@@ -451,6 +457,9 @@ const lookupTableEntry_t lookupTables[] = {
 #if defined(USE_ITERM_RELAX)
     LOOKUP_TABLE_ENTRY(lookupTableItermRelax),
     LOOKUP_TABLE_ENTRY(lookupTableItermRelaxType),
+#endif
+#if defined(USE_TBH)
+    LOOKUP_TABLE_ENTRY(lookupTableTBH),
 #endif
 #ifdef USE_ACRO_TRAINER
     LOOKUP_TABLE_ENTRY(lookupTableAcroTrainerDebug),
@@ -862,11 +871,9 @@ const clivalue_t valueTable[] = {
     { "abs_control_error_limit",    VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 1, 45 }, PG_PID_PROFILE, offsetof(pidProfile_t, abs_control_error_limit) },
 #endif
 
-// Take-back-half non-linear integrator
 #if defined(USE_TBH)
-    { "tbh_enabled",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, tbh_enabled) },
-#endif
-
+    { "iterm_tbh",                  VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_TBH_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_tbh) },
+#endif // Take-back-half non-linear integrator
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -103,6 +103,9 @@ typedef enum {
     TABLE_ITERM_RELAX,
     TABLE_ITERM_RELAX_TYPE,
 #endif
+#if defined(USE_TBH)
+    TABLE_TBH_TYPE,
+#endif
 #ifdef USE_ACRO_TRAINER
     TABLE_ACRO_TRAINER_DEBUG,
 #endif // USE_ACRO_TRAINER

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -220,4 +220,5 @@
 #define USE_UNCOMMON_MIXERS
 #define USE_SIGNATURE
 #define USE_ABSOLUTE_CONTROL
+#define USE_TBH
 #endif


### PR DESCRIPTION
### How to Use
* Off by default - In the CLI _set iterm_tbh = RPY_ {options are OFF, RPY, or RP}
* I term can likely be increased ~1.5x with no negative side effects

### What it does
* The I term of the quadcopter will make some small non-linear "jumps" when error crosses zero.  
* At steady-state, they are negligible.  
* However, during high error periods, the jumps can become much longer.
* The jumps "look" a little like D-term, but will not ring in the same way
* The jumps do cause sudden motor acceleration, just like D-term.

### Figure and logs
* TBH = RPY on left
* TBH = OFF on right.
* PID are defaults to the BF dev defaults; including the new FF term for fair comparisons.
![image](https://user-images.githubusercontent.com/1209150/43812342-79bbea48-9a86-11e8-8a70-76efaa51c3e2.png)
[Quad Logs 5 Inch Cham Ti TBH 2018.08.07.zip](https://github.com/betaflight/betaflight/files/2268690/Quad.Logs.5.Inch.Cham.Ti.TBH.2018.08.07.zip)


### How it's different from other i-term features
I term relax is the normal feature used to modify the I-term of the quadcopter.  However, I-term relax effectively disables the integrator during high-speed maneuvers.  This instead allows the I-term to over-accumulate but then jumps back halfway towards the last known-good position.

The TBH does not disable the saturation features of BetaFlight, so that non-linearity is kept intact.

### Theory of operation
This is the take-back-half algorithm (TBH).  This takes a different approach and adds a non-linear active feature to the integrator; similar to a saturation effect or I-term relax.  Imagine the optimal controller to accelerate a vehicle from a dead stop to highway speed as fast as possible.  As a human former-teenager, we know the best way is to put the gas pedal to 100% until we're close to our desired speed, then suddenly jump back.  This is a non-linear response that a traditional PID controller can't really do.  If it reacts quickly enough to jump towards 100% input, it will tend to not back off enough either once you reach speed.  However, this algorithm does exactly that - once you reach your desired setpoint, it removes half of the accumulated integrator error.  When you reach it again (presumably you're not perfect), it makes consecutively smaller jumps.

If we turn our I-term up too high, normally because the integrator has been 'pushing' the quadcopter back to zero error, once at zero error, the integrator has some additional wind-up.  In order to eliminate this, we normally tune the I term to be ~ critically damped.  However, if we reset the I term to a better location (which we'll define as halfway between present value and the value when the error was last ~0), we can make it more responsive without the overshoot penalty.  Additional information is used to reduce the phase delay over a linear controller.  The value of half is important because it can be shown to converge to unity when summed to infinity against an otherwise unstable plant (1/2 + 1/4 + 1/8... = 1); in our case stability (but not good performance!) is possible with any Ki.

### Known issues/limitations
* This is my first PR - coding is a hobby, not a job.  So... constructive feedback welcome
* Did not add to configurator app
* I don't get enough flying time! Having trouble gathering good data for this PR; I'd love it if anybody is willing to offer performance feedback.  Tested with a friend on his 3", his 5", and my 5" (logs provided for mine only)


