### PR TITLE
Set default iterm relax to RP and RC smoothing to filter

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -157,9 +157,9 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .throttle_boost_cutoff = 15,
         .iterm_rotation = true,
         .smart_feedforward = false,
-        .iterm_relax = ITERM_RELAX_OFF,
+        .iterm_relax = ITERM_RELAX_RP
         .iterm_relax_cutoff = 11,
-        .iterm_relax_type = ITERM_RELAX_GYRO,
+        .iterm_relax_type = ITERM_RELAX_SETPOINT,
         .acro_trainer_angle_limit = 20,
         .acro_trainer_lookahead_ms = 50,
         .acro_trainer_debug_axis = FD_ROLL,

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -157,7 +157,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .throttle_boost_cutoff = 15,
         .iterm_rotation = true,
         .smart_feedforward = false,
-        .iterm_relax = ITERM_RELAX_RP
+        .iterm_relax = ITERM_RELAX_RP,
         .iterm_relax_cutoff = 11,
         .iterm_relax_type = ITERM_RELAX_SETPOINT,
         .acro_trainer_angle_limit = 20,

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -61,7 +61,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .fpvCamAngleDegrees = 0,
         .airModeActivateThreshold = 32,
         .max_aux_channel = DEFAULT_AUX_CHANNEL_COUNT,
-        .rc_smoothing_type = RC_SMOOTHING_TYPE_INTERPOLATION,
+        .rc_smoothing_type = RC_SMOOTHING_TYPE_FILTER,
         .rc_smoothing_input_cutoff = 0,      // automatically calculate the cutoff by default
         .rc_smoothing_derivative_cutoff = 0, // automatically calculate the cutoff by default
         .rc_smoothing_debug_axis = ROLL,     // default to debug logging for the roll axis


### PR DESCRIPTION
Yes I know it's past the feature freeze date, I apologise.

Two changes to defaults:

- item_relax enabled on pitch and roll
- RC smoothing configured in filter mode rather than interpolation

The advantage is that users don't have to read the wiki tuning notes and copy and paste into the CLI to get the benefit of features that were released in 3.4 and we now know are a big step forward.  