### PR TITLE
Add new target FLYWOOF405

### DIFF
--- a/docs/boards/Board - FLYWOOF405.md
+++ b/docs/boards/Board - FLYWOOF405.md
@@ -1,0 +1,101 @@
+# Board - FLYWOOF405
+
+This board use the STM32F405RGT6 microcontroller and have the following features:
+* 1024K bytes of flash memory,192K bytes RAM,168 MHz CPU/210 DMIPS
+
+* The 16M byte SPI flash for data logging
+* USB VCP and boot select button on board(for DFU)
+* Stable voltage regulation,9V/1.5A DCDC BEC for VTX/camera etc.And could select 5v/9v with pad
+* Serial LED interface(LED_STRIP)
+* VBAT/CURR/RSSI sensors input
+* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
+* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
+* Supports I2C device extend(baro/compass/OLED etc)
+* Supports GPS 
+
+### All uarts have pad on board 
+| Value | Identifier   | RX   | TX   | Notes                                                                                       |
+| ----- | ------------ | -----| -----| ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PA10 |  PA9 | USE smartport/FPORT/TEL etc                                                      |
+| 2     | USART3       | PB11 |  PB10| FOR SBUS IN(inverter build in)                                                          |
+| 3     | USART4       | PA1  |  PA0 | PAD USE FOR TRAMP/smart audio                                                                           |
+| 4     | USART5       | PD2  |   /  | PAD ESC sensor                                                            |
+| 5     | USART6       | PC7  |  PC6 | PAD USE FOR GPS/BLE etc                                                                                        |
+
+
+### I2C with GPS port together.Use for BARO or compass etc 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | I2C1         |    SDA   |  PB9   | with GPS outlet
+| 2     | I2C1         |    SCL   |  PB8   | with GPS outlet
+
+
+### Buzzer/LED output 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | LED0         |    LED   |  PC14  | 
+| 2     | BEEPER       |    BEE   |  PC13  | 
+
+
+### VBAT input with 1/10 divider ratio,Current signal input,Analog/digit RSSI input
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | ADC1         |    VBAT   |  PC3  |  DMA2_Stream0
+| 2     | ADC1         |    CURR   |  PC2  |  DMA2_Stream0
+| 3     | ADC1         |    RSSI   |  PC1  |  DMA2_Stream0
+
+
+### 8 Outputs, 1 PPM input 
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | TIM8_CH2     |    PPM    |  PC7  |  PPM
+| 2     | TIM3_CH3     |    OUPUT1 |  PB0  |  DMA1_Stream7
+| 3     | TIM3_CH4     |    OUPUT2 |  PB1  |  DMA1_Stream2
+| 4     | TIM2_CH4     |    OUPUT3 |  PA3  |  DMA1_Stream6
+| 5     | TIM2_CH3     |    OUPUT4 |  PA2  |  DMA1_Stream1
+| 6     | TIM4_CH1     |    OUPUT5 |  PB6  |  DMA1_Stream0
+| 7     | TIM4_CH2     |    OUPUT6 |  PB7  |  DMA1_Stream3
+| 8     | TIM8_CH4     |    OUPUT7 |  PC9  |  DMA2_Stream7   
+| 9     | TIM3_CH1     |    OUPUT8 |  PB4  |  DMA1_Stream4   
+| 10    | TIM8_CH3     |    LED    |  PC8  |  DMA2_Stream2   LED_STRIP
+| 11    | TIM3_CH2     |    PWM    |  PB5  |  FPV Camera Control(FCAM)
+
+
+### Gyro & ACC  ICM20689
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI1         |    SCK   |  PA5   | 
+| 2     | SPI1         |    MISO  |  PA6   | 
+| 3     | SPI1         |    MOSI  |  PA7   | 
+| 4     | SPI1         |    CS    |  PC4   | 
+
+### OSD MAX7456
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI3         |    SCK   |  PC10  | 
+| 2     | SPI3         |    MISO  |  PC11  | 
+| 3     | SPI3         |    MOSI  |  PC12   | 
+| 4     | SPI3         |    CS    |  PB14  |
+
+### 16Mbyte flash
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI3         |    SCK   |  PC10  | 
+| 2     | SPI3         |    MISO  |  PC11  | 
+| 3     | SPI3         |    MOSI  |  PC12   | 
+| 4     | SPI3         |    CS    |  PB3  | 
+
+### SWD
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | SWCLK          | PAD                                          |
+| 2   | Ground         | PAD                                          |
+| 3   | SWDIO          | PAD                                          |
+| 4   | 3V3            | PAD                                          |
+
+* FLYWOO TECH
+
+
+
+
+

--- a/src/main/target/FLYWOOF405/config.c
+++ b/src/main/target/FLYWOOF405/config.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_TARGET_CONFIG
+
+#include "config_helper.h"
+#include "io/serial.h"
+#include "pg/bus_spi.h"
+#include "rx/rx.h"
+#include "telemetry/telemetry.h"
+
+#define TELEMETRY_UART          SERIAL_PORT_USART1
+
+static targetSerialPortFunction_t targetSerialPortFunction[] = {
+    { TELEMETRY_UART, FUNCTION_TELEMETRY_SMARTPORT },
+};
+
+void targetConfiguration(void)
+{
+    targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+    telemetryConfigMutable()->halfDuplex = 0;
+    telemetryConfigMutable()->telemetry_inverted = true;
+
+    // Register MAX7456 CS pin as OPU
+
+    // Invalidate IPU entry first
+    for (int i = 0 ; i < SPI_PREINIT_IPU_COUNT ; i++) {
+        if (spiPreinitIPUConfig(i)->csnTag == IO_TAG(MAX7456_SPI_CS_PIN)) {
+            spiPreinitIPUConfigMutable(i)->csnTag = IO_TAG(NONE);
+            break;
+        }
+    }
+
+    // Add as OPU entry
+    for (int i = 0 ; i < SPI_PREINIT_OPU_COUNT ; i++) {
+        if (spiPreinitOPUConfig(i)->csnTag == IO_TAG(NONE)) {
+            spiPreinitOPUConfigMutable(i)->csnTag = IO_TAG(MAX7456_SPI_CS_PIN);
+            break;
+        }
+    }
+}
+#endif

--- a/src/main/target/FLYWOOF405/target.c
+++ b/src/main/target/FLYWOOF405/target.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM8, CH2, PC7, TIM_USE_PPM,   0, 0), // PPM IN
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0), // S1_OUT - DMA1_ST7
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0), // S2_OUT - DMA1_ST2
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR, 0, 1), // S3_OUT - DMA1_ST6
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR, 0, 0), // S4_OUT - DMA1_ST1
+	DEF_TIM(TIM4, CH1, PB6, TIM_USE_MOTOR, 0, 0), // S5_OUT - DMA1_ST0
+	DEF_TIM(TIM4, CH2, PB7, TIM_USE_MOTOR, 0, 0), // S6_OUT - DMA1_ST3
+	DEF_TIM(TIM8, CH4, PC9, TIM_USE_MOTOR, 0, 0), // S7_OUT - DMA2_ST7
+	DEF_TIM(TIM3, CH1, PB4, TIM_USE_MOTOR, 0, 0), // S8_OUT - DMA1_ST4
+	
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_LED,   0, 0), // LED_STRIP - DMA2_ST2
+
+	DEF_TIM(TIM3, CH2, PB5,  TIM_USE_PWM, 0, 0),     // FC CAM	
+};

--- a/src/main/target/FLYWOOF405/target.h
+++ b/src/main/target/FLYWOOF405/target.h
@@ -1,0 +1,152 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "FWF4"
+#define USBD_PRODUCT_STRING "FLYWOOF405"
+
+#define USE_TARGET_CONFIG
+
+#define LED0_PIN                PC14/////////////
+
+#define USE_BEEPER
+#define BEEPER_PIN              PC13/////////////
+#define BEEPER_INVERTED
+#define INVERTER_PIN_UART3      PB15
+
+//define camera control
+#define CAMERA_CONTROL_PIN      PB5////////////
+
+
+// ICM20689 interrupt
+#define USE_EXTI
+#define MPU_INT_EXTI            PC5
+//#define DEBUG_MPU_DATA_READY_INTERRUPT
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define ICM20689_CS_PIN          PC4
+#define ICM20689_SPI_INSTANCE    SPI1
+
+#define USE_ACC
+#define USE_ACC_SPI_ICM20689
+#define ACC_ICM20689_ALIGN       CW270_DEG
+
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM20689
+#define GYRO_ICM20689_ALIGN      CW270_DEG
+
+#define USE_I2C    
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB8        // SCL pad
+#define I2C1_SDA                PB9        // SDA pad
+#define BARO_I2C_INSTANCE       I2C_DEVICE
+#define MAG_I2C_INSTANCE        I2C_DEVICE
+
+#define USE_MAG
+#define USE_MAG_HMC5883                   //External, connect to I2C1
+#define USE_MAG_QMC5883
+#define MAG_HMC5883_ALIGN       CW180_DEG
+
+#define USE_BARO
+#define USE_BARO_MS5611                  //External, connect to I2C1
+#define USE_BARO_BMP280                  //onboard
+
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PB14
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD)
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define FLASH_CS_PIN            PB3
+#define FLASH_SPI_INSTANCE      SPI3
+
+#define USE_VCP
+#define USB_DETECT_PIN          PA8
+#define USE_USB_DETECT
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+#define UART1_AHB1_PERIPHERALS  RCC_AHB1Periph_DMA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define USE_UART4                // Uart4 can be used for GPS or  RunCam Split
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5               //Uart5 can be used for ESC sensor
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            NONE
+
+#define USE_SOFTSERIAL1         
+#define SERIAL_PORT_COUNT 7     //vcp, uart1, uart3, uart4, uart5, uart6, softSerial1
+
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  PC7  // (HARDARE=0,PPM)
+
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1 //ICM20689
+#define SPI1_NSS_PIN            PC4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_3 //dataflash
+#define SPI3_NSS_PIN            PB3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define USE_ADC
+#define ADC1_DMA_STREAM 			DMA2_Stream0
+#define VBAT_ADC_PIN                PC3
+#define CURRENT_METER_ADC_PIN       PC2
+#define RSSI_ADC_PIN                PC1
+
+#define DEFAULT_FEATURES        ( FEATURE_TELEMETRY | FEATURE_OSD )
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART3
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD        (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 11
+#define USED_TIMERS  ( TIM_N(2) | TIM_N(3) | TIM_N(4)|  TIM_N(8))
+

--- a/src/main/target/FLYWOOF405/target.mk
+++ b/src/main/target/FLYWOOF405/target.mk
@@ -1,0 +1,11 @@
+F405_TARGETS    += $(TARGET)
+FEATURES        += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_spi_icm20689.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms5611.c \
+            drivers/compass/compass_ak8963.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
+            drivers/max7456.c


### PR DESCRIPTION
FLYWOOF405
feature:
MCU:STM32F405RGT6
on board 16M FLASH,OSD AT7456,icm20689.
on board power 9V/1.5A DCDC out for camera/VTX etc,and can choose 9v or 5v with pad.
PPM & SBUS in.
Port:uart1,3,4,5,6,and GPS&I2C port,PWM1-PWM8 ,FCAM,currrent,RSSI,bee,2 LEDS and led_strip.
PWM1-PWM8,LED_STRIP,ADC,SPI,all independent suppose DMA