### PR TITLE
GPS support via MSP

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -2027,7 +2027,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsSol.llh.lon = sbufReadU32(src);
         gpsSol.llh.alt = sbufReadU16(src) * 100; // alt changed from 1m to 0.01m per lsb since MSP API 1.39 by RTH. Received MSP altitudes in 1m per lsb have to upscaled.
         gpsSol.groundSpeed = sbufReadU16(src);
-        GPS_update |= 2;        // New data signalisation to GPS functions // FIXME Magic Numbers
+        GPS_update |= GPS_MSP_UPDATE;        // MSP data signalisation to GPS functions
         break;
 #endif // USE_GPS
     case MSP_SET_FEATURE_CONFIG:

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -137,10 +137,15 @@ typedef enum {
 } navigationMode_e;
 extern navigationMode_e nav_mode;          // Navigation mode
 
+typedef enum {
+    GPS_DIRECT_TICK = 1 << 0,
+    GPS_MSP_UPDATE = 1 << 1
+} gpsUpdateToggle_e;
+
 extern gpsData_t gpsData;
 extern gpsSolutionData_t gpsSol;
 
-extern uint8_t GPS_update;                 // it's a binary toogle to distinct a GPS position update
+extern uint8_t GPS_update;       // toogle to distinct a GPS position update (directly or via MSP)
 extern uint32_t GPS_packetCount;
 extern uint32_t GPS_svInfoReceivedCount;
 extern uint8_t GPS_numCh;                  // Number of channels


### PR DESCRIPTION
MSP_SET_RAW_GPS can be used to push GPS data via MSP. However it was not connected in gpsUpdate() in the current codebase.
This PR fixes this.
