### PR TITLE
Implement MSP_OSD_CHAR_READ

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -164,7 +164,7 @@
 #define MAX7456ADD_STAT         0xA0
 #define MAX7456ADD_CMDO_R       0xC0
 
-#define NVM_RAM_SIZE            54
+#define NVM_RAM_SIZE            64
 #define WRITE_NVR               0xA0
 #define READ_NVR                0x50
 #define STAT_NVR_BUSY           0x20
@@ -737,7 +737,7 @@ void max7456WriteNvm(uint8_t char_address, const uint8_t *font_data)
 
     max7456Send(MAX7456ADD_CMAH, char_address); // set start address high
 
-    for (int x = 0; x < 54; x++) {
+    for (int x = 0; x < NVM_RAM_SIZE; x++) {
         max7456Send(MAX7456ADD_CMAL, x); //set start address low
         max7456Send(MAX7456ADD_CMDI, font_data[x]);
 #ifdef LED0_TOGGLE
@@ -776,7 +776,7 @@ void max7456ReadNvm(uint8_t char_address, uint8_t *font_data)
     max7456Send(MAX7456ADD_CMAH, char_address);                             // set start address high
     max7456Send(MAX7456ADD_CMM, READ_NVR );                                 // copy from NVM to shadow ram
     while ((max7456Send(MAX7456ADD_STAT, 0x00) & STAT_NVR_BUSY) != 0x00);   // wait until bit 5 in the status register returns to 0 (12ms)
-    for (int x = 0; x < 64; x++) {
+    for (int x = 0; x < NVM_RAM_SIZE; x++) {
         max7456Send(MAX7456ADD_CMAL, x);                                    // select the offset address in the shadow RAM
         *(font_data + x) = max7456Send(MAX7456ADD_CMDO_R, 0xFF);                // read the data from the shadow RAM
 #ifdef LED0_TOGGLE

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -36,6 +36,7 @@ void    max7456Invert(bool invert);
 void    max7456Brightness(uint8_t black, uint8_t white);
 void    max7456DrawScreen(void);
 void    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
+void    max7456ReadNvm(uint8_t char_address, uint8_t *font_data);
 uint8_t max7456GetRowsCount(void);
 void    max7456Write(uint8_t x, uint8_t y, const char *buff);
 void    max7456WriteChar(uint8_t x, uint8_t y, uint8_t c);

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1473,7 +1473,6 @@ static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sb
         }
 
         break;
-        
     case MSP_MULTIPLE_MSP:
         {
             uint8_t maxMSPs = 0;
@@ -1508,7 +1507,6 @@ static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sb
             dst->ptr = packetOut.buf.ptr;
         }
         break;
-
     case MSP_OSD_CHAR_READ:
 #ifdef USE_MAX7456
         {
@@ -1523,7 +1521,6 @@ static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sb
 #else
         return MSP_RESULT_ERROR;
 #endif
-
     default:
         return MSP_RESULT_CMD_UNKNOWN;
     }
@@ -2562,7 +2559,6 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPos
 #else
         return MSP_RESULT_ERROR;
 #endif
-
 #endif // OSD || USE_OSD_SLAVE
 
     default:

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1515,7 +1515,7 @@ static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sb
             uint8_t font_data[64];
             const uint8_t addr = sbufReadU8(src);
             max7456ReadNvm(addr, font_data);
-            for (int i = 0; i < 54; i++) {
+            for (int i = 0; i < 64; i++) {
                 sbufWriteU8(dst, font_data[i]);
             }
         }

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1473,6 +1473,7 @@ static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sb
         }
 
         break;
+        
     case MSP_MULTIPLE_MSP:
         {
             uint8_t maxMSPs = 0;
@@ -1507,6 +1508,22 @@ static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sb
             dst->ptr = packetOut.buf.ptr;
         }
         break;
+
+    case MSP_OSD_CHAR_READ:
+#ifdef USE_MAX7456
+        {
+            uint8_t font_data[64];
+            const uint8_t addr = sbufReadU8(src);
+            max7456ReadNvm(addr, font_data);
+            for (int i = 0; i < 54; i++) {
+                sbufWriteU8(dst, font_data[i]);
+            }
+        }
+        break;
+#else
+        return MSP_RESULT_ERROR;
+#endif
+
     default:
         return MSP_RESULT_CMD_UNKNOWN;
     }
@@ -2545,6 +2562,7 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPos
 #else
         return MSP_RESULT_ERROR;
 #endif
+
 #endif // OSD || USE_OSD_SLAVE
 
     default:

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -2552,7 +2552,7 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPos
         {
             uint8_t font_data[64];
             const uint8_t addr = sbufReadU8(src);
-            for (int i = 0; i < 54; i++) {
+            for (int i = 0; i < 64; i++) {
                 font_data[i] = sbufReadU8(src);
             }
             // !!TODO - replace this with a device independent implementation


### PR DESCRIPTION
Opening PR early for discussion.

This adds the ability to read the OSD character set out of EEPROM which is a pre-requisite for #3461 and to allow things like auto updating/flashing OSD fonts.