### PR TITLE
dynamic filter location fix

### DIFF
--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -35,7 +35,7 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor, timeDe
                 GYRO_FILTER_DEBUG_SET(DEBUG_FFT_FREQ, 2, lrintf(gyroDataForAnalysis));
             }
 
-            gyroDataAnalysePush(&gyroSensor->gyroAnalyseState, axis, gyroADCf);
+            gyroDataAnalysePush(&gyroSensor->gyroAnalyseState, axis, gyroDataForAnalysis);
             gyroADCf = gyroSensor->notchFilterDynApplyFn((filter_t *)&gyroSensor->notchFilterDyn[axis], gyroADCf);
         }
 #endif


### PR DESCRIPTION
Needed to correct and issue where a user who chose the before_static location for the FFT would actually have had the same result as choosing after_static.