### PR TITLE
Removed LED_STRIP from F3 targets to make room during the development phase.

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -120,7 +120,6 @@
 #undef USE_SERIALRX_SUMD       // Graupner Hott protocol
 #undef USE_SERIALRX_SUMH       // Graupner legacy protocol
 #undef USE_SERIALRX_XBUS       // JR
-#undef USE_LED_STRIP
 #endif
 
 //#undef USE_LED_STRIP

--- a/src/main/target/FRSKYF3/target.h
+++ b/src/main/target/FRSKYF3/target.h
@@ -30,8 +30,6 @@
 //#undef USE_ITERM_RELAX
 //#undef USE_RC_SMOOTHING_FILTER
 
-#undef USE_LED_STRIP
-
 #undef USE_HUFFMAN
 #undef USE_PINIO
 #undef USE_PINIOBOX

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -29,8 +29,6 @@
 #undef USE_ITERM_RELAX
 #undef USE_RC_SMOOTHING_FILTER
 
-#undef USE_LED_STRIP
-
 #undef USE_HUFFMAN
 #undef USE_PINIO
 #undef USE_PINIOBOX

--- a/src/main/target/RACEBASE/target.h
+++ b/src/main/target/RACEBASE/target.h
@@ -31,8 +31,6 @@
 //#undef USE_ITERM_RELAX
 //#undef USE_RC_SMOOTHING_FILTER
 
-//#undef USE_LED_STRIP
-
 //#undef USE_HUFFMAN
 //#undef USE_PINIO
 //#undef USE_PINIOBOX

--- a/src/main/target/SIRINFPV/target.h
+++ b/src/main/target/SIRINFPV/target.h
@@ -29,8 +29,6 @@
 //#undef USE_ITERM_RELAX
 //#undef USE_RC_SMOOTHING_FILTER
 
-//#undef USE_LED_STRIP
-
 #undef USE_HUFFMAN
 #undef USE_PINIO
 #undef USE_PINIOBOX

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -59,10 +59,6 @@
 #undef USE_RX_MSP
 #undef USE_ESC_SENSOR_INFO
 
-#if defined(IRCSYNERGYF3)
-#undef USE_LED_STRIP
-#endif
-
 #if defined(ZCOREF3)
 
 #define LED0_PIN                PB8

--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -31,8 +31,6 @@
 #undef USE_ITERM_RELAX
 #undef USE_RC_SMOOTHING_FILTER
 
-#undef USE_LED_STRIP
-
 #undef USE_HUFFMAN
 #undef USE_PINIO
 #undef USE_PINIOBOX

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -43,8 +43,6 @@
 //#undef USE_ITERM_RELAX
 //#undef USE_RC_SMOOTHING_FILTER
 
-//#undef USE_LED_STRIP
-
 //#undef USE_HUFFMAN
 //#undef USE_PINIO
 //#undef USE_PINIOBOX

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -146,7 +146,6 @@
 #if (FLASH_SIZE > 64)
 #define USE_ACRO_TRAINER
 #define USE_BLACKBOX
-#define USE_LED_STRIP
 #define USE_RESOURCE_MGMT
 #define USE_RUNAWAY_TAKEOFF     // Runaway Takeoff Prevention (anti-taz)
 #define USE_SERVOS
@@ -221,4 +220,5 @@
 #define USE_SIGNATURE
 #define USE_ABSOLUTE_CONTROL
 #define USE_HOTT_TEXTMODE
+#define USE_LED_STRIP
 #endif


### PR DESCRIPTION
The plan is to re-add the LED_STRIP feature to F3 targets where it fits before 4.0 is released.