### PR TITLE
Disable BARO support for F3 or lower

### DIFF
--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -45,6 +45,11 @@
 #endif
 #endif
 
+// Disable baro support for F3 or lower
+#if (FLASH_SIZE <= 256)
+#undef USE_BARO
+#endif
+
 // XXX Remove USE_BARO_BMP280 and USE_BARO_MS5611 if USE_I2C is not defined.
 // XXX This should go away buy editing relevant target.h files
 #if !defined(USE_I2C)


### PR DESCRIPTION
Saves approximately 4000 bytes on F3 targets that previously supported BARO.
