### PR TITLE
Disable MAG support for F3 targets

### DIFF
--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_MAG_AK8963) || defined(USE_MAG_SPI_AK8963)
+#if defined(USE_MAG) && (defined(USE_MAG_AK8963) || defined(USE_MAG_SPI_AK8963))
 
 #include "build/debug.h"
 

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#ifdef USE_MAG_AK8975
+#if defined(USE_MAG) && defined(USE_MAG_AK8975)
 
 #include "common/axis.h"
 #include "common/maths.h"

--- a/src/main/drivers/compass/compass_fake.c
+++ b/src/main/drivers/compass/compass_fake.c
@@ -23,7 +23,7 @@
 
 #include "platform.h"
 
-#ifdef USE_FAKE_MAG
+#if defined(USE_MAG) && defined(USE_FAKE_MAG)
 
 #include "build/build_config.h"
 

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883)
+#if defined(USE_MAG) && (defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883))
 
 #include "build/debug.h"
 

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#ifdef USE_MAG_QMC5883
+#if defined(USE_MAG) && defined(USE_MAG_QMC5883)
 
 #include "common/axis.h"
 #include "common/maths.h"

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -64,9 +64,10 @@
 //#define USE_BARO_MS5611
 
 // option to use MPU9150 or MPU9250 integrated AK89xx Mag
-#define USE_MAG
-#define USE_MAG_AK8963
-#define MAG_AK8963_ALIGN        CW180_DEG_FLIP
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8963
+//#define MAG_AK8963_ALIGN        CW180_DEG_FLIP
 
 #define USE_VCP
 #define USE_UART1 // Not connected - TX (PB6) RX PB7 (AF7)

--- a/src/main/target/CHEBUZZF3/target.h
+++ b/src/main/target/CHEBUZZF3/target.h
@@ -86,9 +86,10 @@
 #define USE_BARO
 #define USE_BARO_MS5611
 
-#define USE_MAG
-#define USE_MAG_AK8975
-#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8975
+//#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
 
 #define USE_VCP
 #define USE_UART1

--- a/src/main/target/COLIBRI_RACE/target.h
+++ b/src/main/target/COLIBRI_RACE/target.h
@@ -75,11 +75,12 @@
 #define USE_BARO
 #define USE_BARO_MS5611
 
-#define USE_MAG
-#define USE_MAG_HMC5883
-#define USE_MAG_QMC5883
-#define USE_MAG_AK8963
-#define USE_MAG_AK8975
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_HMC5883
+//#define USE_MAG_QMC5883
+//#define USE_MAG_AK8963
+//#define USE_MAG_AK8975
 
 #define USE_VCP
 #define USE_UART1

--- a/src/main/target/MULTIFLITEPICO/target.h
+++ b/src/main/target/MULTIFLITEPICO/target.h
@@ -48,15 +48,16 @@
 #define USE_BARO_BMP085
 #define USE_BARO_BMP280
 
-#define USE_MAG
-#define USE_MAG_AK8975
-#define USE_MAG_HMC5883
-#define USE_MAG_QMC5883
-#define MAG_HMC5883_ALIGN       CW270_DEG
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8975
+//#define USE_MAG_HMC5883
+//#define USE_MAG_QMC5883
+//#define MAG_HMC5883_ALIGN       CW270_DEG
 
-#define USE_MAG_DATA_READY_SIGNAL
-#define ENSURE_MAG_DATA_READY_IS_HIGH
-#define MAG_INT_EXTI            PC14
+//#define USE_MAG_DATA_READY_SIGNAL
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
+//#define MAG_INT_EXTI            PC14
 
 //#define USE_FLASHFS
 //#define USE_FLASH_M25P16

--- a/src/main/target/RCEXPLORERF3/target.h
+++ b/src/main/target/RCEXPLORERF3/target.h
@@ -63,11 +63,12 @@
 #define USE_BARO
 #define USE_BARO_MS5611
 
-#define USE_MAG
-#define USE_MAG_AK8975
-#define USE_MAG_HMC5883 // External
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8975
+//#define USE_MAG_HMC5883 // External
 
-#define MAG_AK8975_ALIGN CW180_DEG
+//#define MAG_AK8975_ALIGN CW180_DEG
 
 #define USE_RANGEFINDER
 #define USE_RANGEFINDER_HCSR04

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -48,10 +48,11 @@
 #define USE_BARO_MS5611
 #define USE_BARO_BMP280
 
-#define USE_MAG
-#define USE_MAG_AK8975
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8975
 
-#define MAG_AK8975_ALIGN        CW180_DEG_FLIP
+//#define MAG_AK8975_ALIGN        CW180_DEG_FLIP
 
 #define USE_VCP
 #define USE_UART1 // Conn 1 - TX (PB6) RX PB7 (AF7)

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -136,8 +136,9 @@
 #define RANGEFINDER_HCSR04_ECHO_PIN          PB1
 
 #elif defined(ZCOREF3)
-#define USE_MAG_DATA_READY_SIGNAL
-#define ENSURE_MAG_DATA_READY_IS_HIGH
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG_DATA_READY_SIGNAL
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
 
 #else //SPRACINGF3
 
@@ -149,15 +150,16 @@
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085
 
-#define USE_MAG
-#define USE_MAG_AK8975
-#define USE_MAG_HMC5883
-#define USE_MAG_QMC5883
-#define MAG_HMC5883_ALIGN       CW270_DEG
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8975
+//#define USE_MAG_HMC5883
+//#define USE_MAG_QMC5883
+//#define MAG_HMC5883_ALIGN       CW270_DEG
 
-#define USE_MAG_DATA_READY_SIGNAL
-#define ENSURE_MAG_DATA_READY_IS_HIGH
-#define MAG_INT_EXTI            PC14
+//#define USE_MAG_DATA_READY_SIGNAL
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
+//#define MAG_INT_EXTI            PC14
 #endif
 
 #if !defined(IRCSYNERGYF3)

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -85,8 +85,9 @@
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW
 
-#define USE_MAG_DATA_READY_SIGNAL
-#define ENSURE_MAG_DATA_READY_IS_HIGH
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG_DATA_READY_SIGNAL
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6500
@@ -100,11 +101,12 @@
 #define USE_BARO
 #define USE_BARO_BMP280
 
-#define USE_MAG
-#define USE_MAG_AK8963
-//#define USE_MAG_HMC5883 // External
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MAG_AK8963
+////#define USE_MAG_HMC5883 // External
 
-#define MAG_AK8963_ALIGN CW270_DEG_FLIP
+//#define MAG_AK8963_ALIGN CW270_DEG_FLIP
 
 //#define USE_RANGEFINDER
 //#define USE_RANGEFINDER_HCSR04

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -83,8 +83,9 @@
 #define ACC_MPU6500_ALIGN       CW270_DEG
 #else
 
-#define USE_MAG_DATA_READY_SIGNAL
-#define ENSURE_MAG_DATA_READY_IS_HIGH
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG_DATA_READY_SIGNAL
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
 
 #define USE_GYRO_MPU6500
 #define GYRO_MPU6500_ALIGN      CW180_DEG
@@ -95,12 +96,13 @@
 #define USE_BARO
 #define USE_BARO_BMP280
 
-#define USE_MAG
-#define USE_MPU9250_MAG // Enables bypass configuration
-#define USE_MAG_AK8975
-#define USE_MAG_HMC5883 // External
-#define USE_MAG_QMC5883
-#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_MPU9250_MAG // Enables bypass configuration
+//#define USE_MAG_AK8975
+//#define USE_MAG_HMC5883 // External
+//#define USE_MAG_QMC5883
+//#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
 #endif
 
 //#define USE_RANGEFINDER

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -176,12 +176,13 @@
 // Performance logging for SD card operations:
 // #define AFATFS_USE_INTROSPECTIVE_LOGGING
 
-#define USE_MAG
-#define USE_FAKE_MAG
-#define USE_MAG_AK8963
-#define USE_MAG_AK8975
-#define USE_MAG_HMC5883
-#define USE_MAG_QMC5883
+// MAG support disabled to reduce F3 flash usage
+//#define USE_MAG
+//#define USE_FAKE_MAG
+//#define USE_MAG_AK8963
+//#define USE_MAG_AK8975
+//#define USE_MAG_HMC5883
+//#define USE_MAG_QMC5883
 
 #define USE_VCP
 #define USE_UART1


### PR DESCRIPTION
As an example, saves 3120 bytes on SPRACINGF3EVO.
