### PR TITLE
Average Cell voltage on crossfire telemetry

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -25,7 +25,7 @@
 #define FC_FIRMWARE_NAME            "Betaflight"
 #define FC_VERSION_MAJOR            3  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            5  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      0  // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      1  // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 

--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define EEPROM_CONF_VERSION 170
+#define EEPROM_CONF_VERSION 171
 
 bool isEEPROMVersionValid(void);
 bool isEEPROMStructureValid(void);


### PR DESCRIPTION
enables `report_cell_voltage = ON` to display the average cell voltage instead of the main battery voltage on the telemetry.
