### PR TITLE
add way to manually override battery cell count

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -654,6 +654,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU16(dst, batteryConfig()->batteryCapacity);
         sbufWriteU8(dst, batteryConfig()->voltageMeterSource);
         sbufWriteU8(dst, batteryConfig()->currentMeterSource);
+        sbufWriteU8(dst, batteryConfig()->setBatteryCellCount);
         break;
 
     case MSP_TRANSPONDER_CONFIG: {
@@ -2418,6 +2419,7 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPos
         batteryConfigMutable()->batteryCapacity = sbufReadU16(src);
         batteryConfigMutable()->voltageMeterSource = sbufReadU8(src);
         batteryConfigMutable()->currentMeterSource = sbufReadU8(src);
+        batteryConfigMutable()->setBatteryCellCount = sbufReadU8(src);
         break;
 
 #if defined(USE_OSD)

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -682,6 +682,7 @@ const clivalue_t valueTable[] = {
     { "use_cbat_alerts",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, useConsumptionAlerts) },
     { "cbat_alert_percent",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, consumptionWarningPercentage) },
     { "vbat_cutoff_percent",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
+    { "set_battery_cell_count",     VAR_UINT8  | MASTER_VALUE, .config.minmax = { 10, 80 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, setBatteryCellCount) },
 
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -105,6 +105,9 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
     .batteryCapacity = 0,
     .currentMeterSource = DEFAULT_CURRENT_METER_SOURCE,
 
+    // cells
+    .setBatteryCellCount = 0, //0 will be ignored
+
     // warnings / alerts
     .useVBatAlerts = true,
     .useConsumptionAlerts = false,
@@ -187,7 +190,14 @@ void batteryUpdatePresence(void)
         }
 
         consumptionState = voltageState = BATTERY_OK;
-        batteryCellCount = cells;
+        if (batteryConfig()->setBatteryCellCount != 0)
+        {
+            batteryCellCount = batteryConfig()->setBatteryCellCount;
+        }
+        else
+        {
+            batteryCellCount = cells;
+        }
         batteryWarningVoltage = batteryCellCount * batteryConfig()->vbatwarningcellvoltage;
         batteryCriticalVoltage = batteryCellCount * batteryConfig()->vbatmincellvoltage;
         lowVoltageCutoff.percentage = 100;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -40,6 +40,9 @@ typedef struct batteryConfig_s {
     currentMeterSource_e currentMeterSource; // source of battery current meter used, either ADC, Virtual or ESC
     uint16_t batteryCapacity;               // mAh
 
+    // cells
+    uint8_t setBatteryCellCount;            // number of cells in battery, used for overwriting auto-detected cell count if someone has issues with it.
+
     // warnings / alerts
     bool useVBatAlerts;                     // Issue alerts based on VBat readings
     bool useConsumptionAlerts;              // Issue alerts based on total power consumption

--- a/src/main/target/BEEBRAIN_V2F/config.c
+++ b/src/main/target/BEEBRAIN_V2F/config.c
@@ -100,6 +100,7 @@ void targetConfiguration(void)
     batteryConfigMutable()->batteryCapacity = 250;
     batteryConfigMutable()->vbatmincellvoltage = 28;
     batteryConfigMutable()->vbatwarningcellvoltage = 33;
+    batteryConfigMutable()->setBatteryCellCount = 0;
 
     *customMotorMixerMutable(0) = (motorMixer_t){ 1.0f, -0.414178f,  1.0f, -1.0f };    // REAR_R
     *customMotorMixerMutable(1) = (motorMixer_t){ 1.0f, -0.414178f, -1.0f,  1.0f };    // FRONT_R

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -381,6 +381,7 @@ static bool bstSlaveProcessFeedbackCommand(uint8_t bstRequest)
             bstWrite8(batteryConfig()->vbatmincellvoltage);
             bstWrite8(batteryConfig()->vbatmaxcellvoltage);
             bstWrite8(batteryConfig()->vbatwarningcellvoltage);
+            bstWrite8(batteryConfig()->setBatteryCellCount);
             break;
 
         case BST_FEATURE:
@@ -538,6 +539,7 @@ static bool bstSlaveProcessWriteCommand(uint8_t bstWriteCommand)
             batteryConfigMutable()->vbatmincellvoltage = bstRead8();  // vbatlevel_warn1 in MWC2.3 GUI
             batteryConfigMutable()->vbatmaxcellvoltage = bstRead8();  // vbatlevel_warn2 in MWC2.3 GUI
             batteryConfigMutable()->vbatwarningcellvoltage = bstRead8();  // vbatlevel when buzzer starts to alert
+            batteryConfigMutable()->setBatteryCellCount = bstRead8(); 
             break;
 
         case BST_ACC_CALIBRATION:

--- a/src/main/target/MULTIFLITEPICO/config.c
+++ b/src/main/target/MULTIFLITEPICO/config.c
@@ -58,6 +58,7 @@ void targetConfiguration(void)
     batteryConfigMutable()->vbatmaxcellvoltage = 44;
     batteryConfigMutable()->vbatmincellvoltage = 32;
     batteryConfigMutable()->vbatwarningcellvoltage = 33;
+    batteryConfigMutable()->setBatteryCellCount = 0;
 
     rxConfigMutable()->spektrum_sat_bind = 5;
     rxConfigMutable()->spektrum_sat_bind_autoreset = 1;

--- a/src/test/unit/battery_unittest.cc.txt
+++ b/src/test/unit/battery_unittest.cc.txt
@@ -52,6 +52,7 @@ TEST(BatteryTest, BatteryADCToVoltage)
         .currentMeterType = CURRENT_SENSOR_NONE,
         .multiwiiCurrentMeterOutput = 0,
         .batteryCapacity = 2200,
+        .setBatteryCellCount = 0,
     };
 
     batteryInit(&batteryConfig);
@@ -112,6 +113,7 @@ TEST(BatteryTest, BatteryState)
         .currentMeterType = CURRENT_SENSOR_NONE,
         .multiwiiCurrentMeterOutput = 0,
         .batteryCapacity = 2200,
+        .setBatteryCellCount = 0,
     };
 
     batteryInit(&batteryConfig);
@@ -171,6 +173,7 @@ TEST(BatteryTest, CellCount)
         .currentMeterType = CURRENT_SENSOR_NONE,
         .multiwiiCurrentMeterOutput = 0,
         .batteryCapacity = 2200,
+        .setBatteryCellCount = 0,
     };
 
     batteryInit(&batteryConfig);


### PR DESCRIPTION
This enables people to deal with the issue of wrong cell detection quickly.

This is not optimal, since people might use a mixture of cell counts, but it is a quick fix for some users for now.

Default is set to zero which will ignore the it and use auto detection.
