### PR TITLE
GPS over MSP related fixes

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -166,7 +166,7 @@ static const char * const lookupTableGyro[] = {
 
 #ifdef USE_GPS
 static const char * const lookupTableGPSProvider[] = {
-    "NMEA", "UBLOX"
+    "NMEA", "UBLOX", "MSP"
 };
 
 static const char * const lookupTableGPSSBASMode[] = {

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -34,7 +34,8 @@
 
 typedef enum {
     GPS_NMEA = 0,
-    GPS_UBLOX
+    GPS_UBLOX,
+    GPS_MSP
 } gpsProvider_e;
 
 typedef enum {

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -449,11 +449,12 @@ void initCrsfTelemetry(void)
         crsfSchedule[index++] = BV(CRSF_FRAME_BATTERY_SENSOR_INDEX);
     }
     crsfSchedule[index++] = BV(CRSF_FRAME_FLIGHT_MODE_INDEX);
+#ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)) {
         crsfSchedule[index++] = BV(CRSF_FRAME_GPS_INDEX);
     }
+#endif
     crsfScheduleCount = (uint8_t)index;
-
  }
 
 bool checkCrsfTelemetryState(void)


### PR DESCRIPTION
This fixes various issues if GPS data is pushed via MSP:

- configuration would self-heal if no serial port is configured; added GPS_MSP to fix this
- fixed CRSF telemetry
- updated signaling of GPS_update in msp.c
