### PR TITLE
Remove IOConfigGPIOAF from timerInit

### DIFF
--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -783,17 +783,6 @@ void timerInit(void)
         RCC_ClockCmd(timerRCC(timerHardware[i].tim), ENABLE);
     }
 
-#if defined(STM32F3) || defined(STM32F4)
-    for (unsigned timerIndex = 0; timerIndex < USABLE_TIMER_CHANNEL_COUNT; timerIndex++) {
-        const timerHardware_t *timerHardwarePtr = &timerHardware[timerIndex];
-        if (timerHardwarePtr->usageFlags == TIM_USE_NONE) {
-            continue;
-        }
-        // XXX IOConfigGPIOAF in timerInit should eventually go away.
-        IOConfigGPIOAF(IOGetByTag(timerHardwarePtr->tag), IOCFG_AF_PP, timerHardwarePtr->alternateFunction);
-    }
-#endif
-
     // initialize timer channel structures
     for (unsigned i = 0; i < USABLE_TIMER_CHANNEL_COUNT; i++) {
         timerChannelInfo[i].type = TYPE_FREE;


### PR DESCRIPTION
This year long project of removing `IOConfigGPIOAF` from `timerInit` (#3991) is finally coming to the grand finale.

It has been removed for F7 targets since 3.0.0, and corresponding initialization were added for each function since then. The servo case which was handled recently (#6679) should have been the last case, and we are ready to remove the conditional for F3 and F4 here.