### PR TITLE
Remove skipping of frames after suspension for serial RX.

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -512,7 +512,7 @@ void validateAndFixGyroConfig(void)
 
 bool readEEPROM(void)
 {
-    suspendRxSignal();
+    suspendRxPwmPpmSignal();
 
     // Sanity check, read flash
     bool success = loadEEPROM();
@@ -521,7 +521,7 @@ bool readEEPROM(void)
 
     activateConfig();
 
-    resumeRxSignal();
+    resumeRxPwmPpmSignal();
 
     return success;
 }
@@ -530,11 +530,11 @@ void writeEEPROM(void)
 {
     validateAndFixConfig();
 
-    suspendRxSignal();
+    suspendRxPwmPpmSignal();
 
     writeConfigToEEPROM();
 
-    resumeRxSignal();
+    resumeRxPwmPpmSignal();
 }
 
 void writeEEPROMWithFeatures(uint32_t features)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -322,26 +322,26 @@ bool rxAreFlightChannelsValid(void)
     return rxFlightChannelsValid;
 }
 
-void suspendRxSignal(void)
+void suspendRxPwmPpmSignal(void)
 {
-    suspendRxSignalUntil = micros() + SKIP_RC_ON_SUSPEND_PERIOD;
 #if defined(USE_PWM) || defined(USE_PPM)
     if (featureIsEnabled(FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM)) {
+        suspendRxSignalUntil = micros() + SKIP_RC_ON_SUSPEND_PERIOD;
         skipRxSamples = SKIP_RC_SAMPLES_ON_RESUME;
+        failsafeOnRxSuspend(SKIP_RC_ON_SUSPEND_PERIOD);
     }
 #endif
-    failsafeOnRxSuspend(SKIP_RC_ON_SUSPEND_PERIOD);
 }
 
-void resumeRxSignal(void)
+void resumeRxPwmPpmSignal(void)
 {
-    suspendRxSignalUntil = micros();
 #if defined(USE_PWM) || defined(USE_PPM)
     if (featureIsEnabled(FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM)) {
+        suspendRxSignalUntil = micros();
         skipRxSamples = SKIP_RC_SAMPLES_ON_RESUME;
+        failsafeOnRxResume();
     }
 #endif
-    failsafeOnRxResume();
 }
 
 bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -405,6 +405,7 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
     return rxDataProcessingRequired || auxiliaryProcessingRequired; // data driven or 50Hz
 }
 
+#if defined(USE_PWM) || defined(USE_PPM)
 static uint16_t calculateChannelMovingAverage(uint8_t chan, uint16_t sample)
 {
     static int16_t rcSamples[MAX_SUPPORTED_RX_PARALLEL_PWM_OR_PPM_CHANNEL_COUNT][PPM_AND_PWM_SAMPLE_COUNT];
@@ -430,6 +431,7 @@ static uint16_t calculateChannelMovingAverage(uint8_t chan, uint16_t sample)
     }
     return rcDataMean[chan] / PPM_AND_PWM_SAMPLE_COUNT;
 }
+#endif
 
 static uint16_t getRxfailValue(uint8_t channel)
 {

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -169,7 +169,7 @@ uint8_t getRssiPercent(void);
 
 void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRangeConfig);
 
-void suspendRxSignal(void);
-void resumeRxSignal(void);
+void suspendRxPwmPpmSignal(void);
+void resumeRxPwmPpmSignal(void);
 
 uint16_t rxGetRefreshRate(void);


### PR DESCRIPTION
There is no reason to skip extra frames after the RX comes out of suspension (used for EEPROM updates).

Fixes betaflight/betaflight-tx-lua-scripts#151.