### PR TITLE
delay for voltage warnings

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -785,7 +785,7 @@ const clivalue_t valueTable[] = {
     { "vbat_cutoff_percent",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
     { "force_battery_cell_count",   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 24 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, forceBatteryCellCount) },
     { "vbat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatLpfPeriod) },
-    { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) }, 
+    { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) },
     { "battery_duration_for_warning",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForWarning) },
     { "battery_duration_for_crit",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForCrit) },
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -786,8 +786,8 @@ const clivalue_t valueTable[] = {
     { "force_battery_cell_count",   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 24 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, forceBatteryCellCount) },
     { "vbat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatLpfPeriod) },
     { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) }, 
-    { "battery_duration_for_warning",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForWarning) },
-    { "battery_duration_for_crit",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForCrit) },
+    { "battery_duration_for_warning",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForWarning) },
+    { "battery_duration_for_crit",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForCrit) },
 
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -785,7 +785,9 @@ const clivalue_t valueTable[] = {
     { "vbat_cutoff_percent",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
     { "force_battery_cell_count",   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 24 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, forceBatteryCellCount) },
     { "vbat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatLpfPeriod) },
-    { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) },
+    { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) }, 
+    { "battery_duration_for_warning",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForWarning) },
+    { "battery_duration_for_crit",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryDurationForCrit) },
 
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -52,10 +52,13 @@ typedef struct batteryConfig_s {
     uint8_t vbathysteresis;                 // hysteresis for alarm, default 1 = 0.1V
 
     uint16_t vbatfullcellvoltage;           // Cell voltage at which the battery is deemed to be "full" 0.01V units, default is 410 (4.1V)
-    
+
     uint8_t forceBatteryCellCount;          // Number of cells in battery, used for overwriting auto-detected cell count if someone has issues with it.
     uint8_t vbatLpfPeriod;                  // Period of the cutoff frequency for the Vbat filter (in 0.1 s)
     uint8_t ibatLpfPeriod;                  // Period of the cutoff frequency for the Ibat filter (in 0.1 s)
+
+    uint8_t batteryDurationForWarning;      // Duration in seconds voltage has to sustain before the battery state is set to BATTERY_WARNING
+    uint8_t batteryDurationForCrit;         // Duration in seconds voltage has to sustain before the battery state is set to BATTERY_CRIT
 } batteryConfig_t;
 
 PG_DECLARE(batteryConfig_t, batteryConfig);

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -57,8 +57,8 @@ typedef struct batteryConfig_s {
     uint8_t vbatLpfPeriod;                  // Period of the cutoff frequency for the Vbat filter (in 0.1 s)
     uint8_t ibatLpfPeriod;                  // Period of the cutoff frequency for the Ibat filter (in 0.1 s)
 
-    uint8_t batteryDurationForWarning;      // Duration in seconds voltage has to sustain before the battery state is set to BATTERY_WARNING
-    uint8_t batteryDurationForCrit;         // Duration in seconds voltage has to sustain before the battery state is set to BATTERY_CRIT
+    uint8_t batteryDurationForWarning;      // Period voltage has to sustain before the battery state is set to BATTERY_WARNING (in 0.1 s)
+    uint8_t batteryDurationForCrit;         // Period voltage has to sustain before the battery state is set to BATTERY_CRIT (in 0.1 s)
 } batteryConfig_t;
 
 PG_DECLARE(batteryConfig_t, batteryConfig);


### PR DESCRIPTION
Implements feature request #1887 .

Will test this with a quad, but I'd like for people to have a look first.