### PR TITLE
support for EU-LBT variant of FrSky X

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -14,7 +14,7 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-7-2017-q4-major
+ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-7-2018-q2-update
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
 GCC_REQUIRED_VERSION ?= 7.2.1
 

--- a/src/main/drivers/rx/rx_spi.h
+++ b/src/main/drivers/rx/rx_spi.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-#define RX_SPI_MAX_PAYLOAD_SIZE 32
+#define RX_SPI_MAX_PAYLOAD_SIZE 48 // TODO: check if 35 is enough
 
 struct rxSpiConfig_s;
 

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -318,6 +318,12 @@ static void cliPrintfva(const char *format, va_list va)
     bufWriterFlush(cliWriter);
 }
 
+static void cliPrintfvabuf(const char *format, va_list va)
+{
+    tfp_format(cliWriter, cliPutp, format, va);
+    bufWriterFlush(cliWriter);
+}
+
 static bool cliDumpPrintLinef(uint8_t dumpMask, bool equalsDefault, const char *format, ...)
 {
     if (!((dumpMask & DO_DIFF) && equalsDefault)) {
@@ -361,6 +367,14 @@ static void cliPrintf(const char *format, ...)
     va_end(va);
 }
 
+void cliBufPrintf(const char *format, ...)
+{
+    return;
+    va_list va;
+    va_start(va, format);
+    cliPrintfvabuf(format, va);
+    va_end(va);
+}
 
 static void cliPrintLinef(const char *format, ...)
 {

--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -148,14 +148,14 @@ void frSkySpiBind(void)
 static void initialise() {
     cc2500Reset();
     cc2500WriteReg(CC2500_02_IOCFG0,   0x01);
-    cc2500WriteReg(CC2500_17_MCSM1,    0x0C);
+    cc2500WriteReg(CC2500_17_MCSM1,    0x0E);
     cc2500WriteReg(CC2500_18_MCSM0,    0x18);
     cc2500WriteReg(CC2500_07_PKTCTRL1, 0x04);
     cc2500WriteReg(CC2500_3E_PATABLE,  0xFF);
     cc2500WriteReg(CC2500_0C_FSCTRL0,  0x00);
     cc2500WriteReg(CC2500_0D_FREQ2,    0x5C);
-    cc2500WriteReg(CC2500_0E_FREQ1,    0x76);
-    cc2500WriteReg(CC2500_0F_FREQ0,    0x27);
+    cc2500WriteReg(CC2500_0E_FREQ1,    0x80);
+    cc2500WriteReg(CC2500_0F_FREQ0,    0x00);
     cc2500WriteReg(CC2500_13_MDMCFG1,  0x23);
     cc2500WriteReg(CC2500_14_MDMCFG0,  0x7A);
     cc2500WriteReg(CC2500_19_FOCCFG,   0x16);
@@ -188,13 +188,13 @@ static void initialise() {
 
         break;
     case RX_SPI_FRSKY_X:
-        cc2500WriteReg(CC2500_06_PKTLEN,   0x1E);
+        cc2500WriteReg(CC2500_06_PKTLEN,   0x23);
         cc2500WriteReg(CC2500_08_PKTCTRL0, 0x01);
-        cc2500WriteReg(CC2500_0B_FSCTRL1,  0x0A);
+        cc2500WriteReg(CC2500_0B_FSCTRL1,  0x08);
         cc2500WriteReg(CC2500_10_MDMCFG4,  0x7B);
-        cc2500WriteReg(CC2500_11_MDMCFG3,  0x61);
-        cc2500WriteReg(CC2500_12_MDMCFG2,  0x13);
-        cc2500WriteReg(CC2500_15_DEVIATN,  0x51);
+        cc2500WriteReg(CC2500_11_MDMCFG3,  0xf8);
+        cc2500WriteReg(CC2500_12_MDMCFG2,  0x03);
+        cc2500WriteReg(CC2500_15_DEVIATN,  0x53);
 
         break;
     default:

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -353,7 +353,7 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
                 cc2500ReadFifo(packet, ccLen);
                 uint16_t lcrc= calculateCrc(&packet[3], (ccLen - 7));
                 if((lcrc >> 8) == packet[ccLen-4] && (lcrc&0x00FF) == packet[ccLen - 3]){ // check calculateCrc
-                    if (packet[0] == 0x1D) {
+                    if (packet[0] == 0x20) {
                         if ((packet[1] == rxFrSkySpiConfig()->bindTxId[0]) &&
                                 (packet[2] == rxFrSkySpiConfig()->bindTxId[1]) &&
                                 (rxFrSkySpiConfig()->rxNum == 0 || packet[6] == 0 || packet[6] == rxFrSkySpiConfig()->rxNum)) {


### PR DESCRIPTION
What the title says. Radio params ported over from [DIY-Multiprotocol-TX](https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/blob/dde5f6e1190269b74b4ac28037beaeb78d2325da/Multiprotocol/Common.ino) (FRSKYXEU_cc2500_conf), and some other little changes to handle the bigger packet size.

Binding works, and RX/Telemetry kinda work, but receiver frequently falls to failsafe and telemetry is lost. Also binding has to be done again after power cycle, even though eeprom is written. Packet format is probably valid, and I suspect the issue might be with the frequency hopping sequence, but I'm not sure exactly. (16ch and 8ch variants work similarly)

Posting this here, if someone wants to comment or participate. Highly WIP code, with questionable hacks.