### PR TITLE
Fix USB HID parameter support in MSP_SET_RX_CONFIG msp message

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -2145,6 +2145,10 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             sbufReadU8(src);
             sbufReadU8(src);
 #endif
+        }
+        if (sbufBytesRemaining(src) >= 1) {
+            // Added in MSP API 1.40
+            // Kept separate from the section above to work around missing Configurator support in version < 10.4.2
 #if defined(USE_USB_CDC_HID)
             usbDevConfigMutable()->type = sbufReadU8(src);
 #else


### PR DESCRIPTION
Fixes #6666 

Workaround to make the firmware tolerant of missing Configurator support in versions 10.4.1 or less. Will still work properly when Configurator support is added.
