### PR TITLE
Add CLI validation of parameters and print a corrupted value message

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -384,6 +384,10 @@ static void cliPrintErrorLinef(const char *format, ...)
     cliPrintLinefeed();
 }
 
+static void cliPrintCorruptMessage(int value)
+{
+    cliPrintf("%d ###CORRUPTED CONFIG###", value);
+}
 
 static void printValuePointer(const clivalue_t *var, const void *valuePointer, bool full)
 {
@@ -439,13 +443,21 @@ static void printValuePointer(const clivalue_t *var, const void *valuePointer, b
 
         switch (var->type & VALUE_MODE_MASK) {
         case MODE_DIRECT:
-            cliPrintf("%d", value);
-            if (full) {
-                cliPrintf(" %d %d", var->config.minmax.min, var->config.minmax.max);
+            if ((value < var->config.minmax.min) || (value > var->config.minmax.max)) {
+                cliPrintCorruptMessage(value);
+            } else {
+                cliPrintf("%d", value);
+                if (full) {
+                    cliPrintf(" %d %d", var->config.minmax.min, var->config.minmax.max);
+                }
             }
             break;
         case MODE_LOOKUP:
-            cliPrint(lookupTables[var->config.lookup.tableIndex].values[value]);
+            if (value < lookupTables[var->config.lookup.tableIndex].valueCount) {
+                cliPrint(lookupTables[var->config.lookup.tableIndex].values[value]);
+            } else {
+                cliPrintCorruptMessage(value);
+            }
             break;
         case MODE_BITSET:
             if (value & 1 << var->config.bitpos) {


### PR DESCRIPTION
Validates the index for lookup values to prevent referencing random memory.  Also validates the range of numeric parameters.

`diff` output will clearly show any corrupted parameters.

Example output:
```
# master
set mid_rc = 1199 ###CORRUPTED CONFIG###
set rssi_offset = -105 ###CORRUPTED CONFIG###
set rc_smoothing_type = 2 ###CORRUPTED CONFIG###
set fpv_mix_degrees = 82 ###CORRUPTED CONFIG###

# profile
profile 0

set anti_gravity_gain = 31000 ###CORRUPTED CONFIG###

# rateprofile
rateprofile 0

set roll_expo = 105 ###CORRUPTED CONFIG###
```