### PR TITLE
Add CLI batch support for presenting warnings when pasting configs

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -162,6 +162,7 @@
 #if (FLASH_SIZE > 64)
 #define USE_ACRO_TRAINER
 #define USE_BLACKBOX
+#define USE_CLI_BATCH
 #define USE_RESOURCE_MGMT
 #define USE_RUNAWAY_TAKEOFF     // Runaway Takeoff Prevention (anti-taz)
 #define USE_SERVOS


### PR DESCRIPTION
Adds a new `batch` command used to delineate a group of commands as a related batch. The primary purpose is to group commands sent from the Configurator resulting from a copy/pasted config. Currently the output of the `diff all` command appends a `save` at the end of its output. So when a user pastes in their config to restore they may not see any errors because the `save` command causes the flight controller to reboot before they can review. When commands are wrapped inside of a batch, any errors will set a flag that will issue a warning when the `save` command is executed. This allows the user ro review and correct their configuration.

While the `batch` command can be used interactively, it's really meant for the Configurator to send when needed for multi-line command pasting.  As such, see related PR for the Configurator: https://github.com/betaflight/betaflight-configurator/pull/1193

Example: Assume a command batch like:
```
batch start
defaults nosave
set p_pitch = 48
set i_pitch = 55
set rc_smoothing_type = OFF
set rc_interp_ch = RPYT
save
```

In this example the `batch end` is redundant because the commands contain a save.

Since the batch contains an error the `save` will be deferred:
```
# batch start
Command batch started

# defaults nosave

# resetting to defaults

# set p_pitch = 48
p_pitch set to 48
# set i_pitch = 55
i_pitch set to 55
# set rc_smoothing_type = OFF
###ERROR### Invalid value
Allowed values: INTERPOLATION, FILTER

# set rc_interp_ch = RPYT
rc_interp_ch set to RPYT
# save
###WARNING### Errors were detected - please review before continuing
###WARNING### Enter the 'save' command again to continue
```
The user can now review and fix the problem. Alternately they can just issue another `save` and it will not be prevented.