### PR TITLE
add specific orientation for mag of the YupiF7 extension board

### DIFF
--- a/src/main/target/YUPIF7/target.h
+++ b/src/main/target/YUPIF7/target.h
@@ -110,7 +110,9 @@
 #define MAG_I2C_INSTANCE       (I2CDEV_1)
 #define USE_MAG
 #define USE_MAG_HMC5883
+#define MAG_HMC5883_ALIGN CW270_DEG_FLIP
 #define USE_MAG_QMC5883
+#define MAG_QMC5883_ALIGN CW270_DEG_FLIP
 
 // *************** OSD *****************************
 #define USE_MAX7456


### PR DESCRIPTION
Specify the default orientation of the mag used on the extension board for the YupiF7 target.