### PR TITLE
fewer I constraints, none on yaw, dynCi fix

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -361,15 +361,6 @@ bool mixerIsTricopter(void)
 #endif
 }
 
-bool mixerIsOutputSaturated(int axis, float errorRate)
-{
-    if (axis == FD_YAW && mixerIsTricopter()) {
-        return mixerTricopterIsServoSaturated(errorRate);
-    }
-
-    return motorMixRange >= 1.0f;
-}
-
 // All PWM motor scaling is done to standard PWM range of 1000-2000 for easier tick conversion with legacy code / configurator
 // DSHOT scaling is done to the actual dshot range
 void initEscEndpoints(void)

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -117,7 +117,6 @@ struct rxConfig_s;
 uint8_t getMotorCount(void);
 float getMotorMixRange(void);
 bool areMotorsRunning(void);
-bool mixerIsOutputSaturated(int axis, float errorRate);
 
 void mixerLoadMix(int index, motorMixer_t *customMixers);
 void mixerInit(mixerMode_e mixerMode);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -445,11 +445,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     horizonFactorRatio = (100 - pidProfile->horizon_tilt_effect) * 0.01f;
     maxVelocity[FD_ROLL] = maxVelocity[FD_PITCH] = pidProfile->rateAccelLimit * 100 * dT;
     maxVelocity[FD_YAW] = pidProfile->yawRateAccelLimit * 100 * dT;
-    float ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
+    const float ITermWindupPoint = pidProfile->itermWindupPointPercent / 100.0f;
     if (ITermWindupPoint == 1.0f) {
         ITermWindupPointInv = 1.0f;
     } else {
-        ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
+        ITermWindupPointInv = 1 / (1 - ITermWindupPoint);
     }
     itermAcceleratorGain = pidProfile->itermAcceleratorGain;
     crashTimeLimitUs = pidProfile->crash_time * 1000;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -987,7 +987,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
 
         // -----calculate I component
         // iterm_windup constrains I accumulation, only on pitch and roll, only when < 100
-        if ((axis <= FD_PITCH) && (ITermWindupPointInv < 1.0f)) {
+        if ((axis <= FD_PITCH) && (ITermWindupPoint < 1.0f)) {
             dynCi *= constrainf((1.0f - motorMixRange) * ITermWindupPointInv, 0.0f, 1.0f);
         }
         pidData[axis].I = constrainf(ITerm + pidCoefficient[axis].Ki * itermErrorRate * dynCi, -itermLimit, itermLimit);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -119,7 +119,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .pid = {
             [PID_ROLL] =  { 46, 45, 25, 60 },
             [PID_PITCH] = { 50, 50, 27, 60 },
-            [PID_YAW] =   { 65, 45, 0 , 60 },
+            [PID_YAW] =   { 50, 150, 0, 120 },
             [PID_LEVEL] = { 50, 50, 75, 0 },
             [PID_MAG] =   { 40, 0, 0, 0 },
         },
@@ -132,12 +132,12 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dterm_notch_hz = 0,
         .dterm_notch_cutoff = 160,
         .dterm_filter_type = FILTER_PT1,
-        .itermWindupPointPercent = 40,
+        .itermWindupPointPercent = 100,
         .vbatPidCompensation = 0,
         .pidAtMinThrottle = PID_STABILISATION_ON,
         .levelAngleLimit = 55,
         .feedForwardTransition = 0,
-        .yawRateAccelLimit = 100,
+        .yawRateAccelLimit = 0,
         .rateAccelLimit = 0,
         .itermThrottleThreshold = 250,
         .itermAcceleratorGain = 5000,
@@ -152,7 +152,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .horizon_tilt_effect = 75,
         .horizon_tilt_expert_mode = false,
         .crash_limit_yaw = 200,
-        .itermLimit = 150,
+        .itermLimit = 300,
         .throttle_boost = 5,
         .throttle_boost_cutoff = 15,
         .iterm_rotation = true,
@@ -445,8 +445,12 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     horizonFactorRatio = (100 - pidProfile->horizon_tilt_effect) * 0.01f;
     maxVelocity[FD_ROLL] = maxVelocity[FD_PITCH] = pidProfile->rateAccelLimit * 100 * dT;
     maxVelocity[FD_YAW] = pidProfile->yawRateAccelLimit * 100 * dT;
-    const float ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
-    ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
+    float ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
+    if (ITermWindupPoint == 1.0f) {
+        ITermWindupPointInv = 1.0f;
+    } else {
+        ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
+    }
     itermAcceleratorGain = pidProfile->itermAcceleratorGain;
     crashTimeLimitUs = pidProfile->crash_time * 1000;
     crashTimeDelayUs = pidProfile->crash_delay * 1000;
@@ -851,14 +855,13 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
     const bool yawSpinActive = gyroYawSpinDetected();
 #endif
 
-    // Dynamic i component,
+    // Anti Gravity
     if ((antiGravityMode == ANTI_GRAVITY_SMOOTH) && antiGravityEnabled) {
         itermAccelerator = 1 + fabsf(antiGravityThrottleHpf) * 0.01f * (itermAcceleratorGain - 1000);
         DEBUG_SET(DEBUG_ANTI_GRAVITY, 1, lrintf(antiGravityThrottleHpf * 1000));
     }
     DEBUG_SET(DEBUG_ANTI_GRAVITY, 0, lrintf(itermAccelerator * 1000));
-    // gradually scale back integration when above windup point
-    const float dynCi = MIN((1.0f - motorMixRange) * ITermWindupPointInv, 1.0f) * dT * itermAccelerator;
+    float dynCi = dT * itermAccelerator;
 
     // Precalculate gyro deta for D-term here, this allows loop unrolling
     float gyroRateDterm[XYZ_AXIS_COUNT];
@@ -983,12 +986,11 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
         }
 
         // -----calculate I component
-        const float ITermNew = constrainf(ITerm + pidCoefficient[axis].Ki * itermErrorRate * dynCi, -itermLimit, itermLimit);
-        const bool outputSaturated = mixerIsOutputSaturated(axis, errorRate);
-        if (outputSaturated == false || ABS(ITermNew) < ABS(ITerm)) {
-            // Only increase ITerm if output is not saturated
-            pidData[axis].I = ITermNew;
+        // iterm_windup constrains I accumulation, only on pitch and roll, only when < 100
+        if ((axis <= FD_PITCH) && (ITermWindupPointInv < 1.0f)) {
+            dynCi *= constrainf((1.0f - motorMixRange) * ITermWindupPointInv, 0.0f, 1.0f);
         }
+        pidData[axis].I = constrainf(ITerm + pidCoefficient[axis].Ki * itermErrorRate * dynCi, -itermLimit, itermLimit);
 
         // -----calculate D component
         if (pidCoefficient[axis].Kd > 0) {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -30,7 +30,7 @@
 #define PID_MIXER_SCALING           1000.0f
 #define PID_SERVO_MIXER_SCALING     0.7f
 #define PIDSUM_LIMIT                500
-#define PIDSUM_LIMIT_YAW            400
+#define PIDSUM_LIMIT_YAW            500
 #define PIDSUM_LIMIT_MIN            100
 #define PIDSUM_LIMIT_MAX            1000
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -846,7 +846,7 @@ const clivalue_t valueTable[] = {
     { "iterm_relax_type",           VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ITERM_RELAX_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_type) },
     { "iterm_relax_cutoff",         VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff) },
 #endif
-    { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 30, 99 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
+    { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
     { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },
     { "pidsum_limit_yaw",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimitYaw) },


### PR DESCRIPTION
Summary:
- Completely remove the mixer_saturated limit code on iTerm for all axes.
- iterm_windup limit always disabled on yaw
- iterm_windup limit also disabled on pitch and roll when iterm_windup = 100
- new default for iterm_windup to 100 (disables all item_windup limits; can be set back to previous default of 40 to restore previous limits on pitch and roll)
- change defaults to allow more I on yaw (set acc_limit yaw = 0, set iterm_limit = 300)
- prevent dynCi going negative (thanks, borisbstyle)

Rationale:
General:
The mixer_saturated limit on iTerm duplicates entirely the term_windup limit method, and is redundant.

Pitch & Roll:
iterm_relax is now on by default for pitch and roll.  All the logs I've seen show no adverse iTerm windup thanks to item_relax, even with the term_windup limit and the mixer_saturated limits disabled.  This PR removes the mixer_saturated limit code completely, and allows item_windup to be disabled by setting the percentage to 100.  The previous default was 40%.  As the percentage set goes up, the effect becomes less, so it makes sense to totally disable the process at 100%.

Yaw: 
Since we learned more about yaw behaviour, we now know that more I works better on yaw, and that, on yaw, I sort of works more like P.  There were multiple constraints limiting yaw performance - acc_limit_yaw, iterm_limit, iterm_windup, output_saturated limit, item_relax.  My testing suggests that most of these should be disabled for FPV flying.  This PR removes all those limits on yaw, except iterm_limit, which is a brick wall for I on all axes.
The end result is far more accurate and precise yaw response than previously possible.  The only downside is a quicker and stronger yaw jump effect, which affects LOS pilots the most, but which can be countered by dropping throttle at the same time as making a large yaw spin.

The suggested Yaw PIDs of 50, 150, 0 and 120 might be bit aggressive for some quads, but on most of my typical quads did result in excellent yaw performance.  Any higher on P and I can cause some low frequency yaw wobble.  Perhaps slightly lower values for P and I might be 'safer' but for the PR let's try these, if that's OK.