### PR TITLE
use the defined value in both places

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -920,7 +920,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
             const bool isDecreasingI = ((ITerm > 0) && (itermErrorRate < 0)) || ((ITerm < 0) && (itermErrorRate > 0));
             if ((itermRelax >= ITERM_RELAX_RP_INC) && isDecreasingI) {
                 // Do Nothing, use the precalculed itermErrorRate
-            } else if (itermRelaxType == ITERM_RELAX_SETPOINT && setpointHpf < 30) {
+            } else if (itermRelaxType == ITERM_RELAX_SETPOINT && setpointHpf < ITERM_RELAX_SETPOINT_THRESHOLD) {
                 itermErrorRate *= itermRelaxFactor;
             } else if (itermRelaxType == ITERM_RELAX_GYRO ) {
                 itermErrorRate = fapplyDeadband(setpointLpf - gyroRate, setpointHpf);


### PR DESCRIPTION
a define was applied for ITERM_RELAX_SETPOINT_THRESHOLD, which currently is set to 30.

I noticed that the defined name was only applied in one of the two places where it should have been applied.  

both values should always be the same.

this PR is intended to ensure that is the case.