### PR TITLE
Change dterm_notch_cutoff default to 0

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -130,7 +130,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dterm_lowpass_hz = 100,    // dual PT1 filtering ON by default
         .dterm_lowpass2_hz = 200,   // second Dterm LPF ON by default
         .dterm_notch_hz = 0,
-        .dterm_notch_cutoff = 160,
+        .dterm_notch_cutoff = 0,
         .dterm_filter_type = FILTER_PT1,
         .itermWindupPointPercent = 40,
         .vbatPidCompensation = 0,


### PR DESCRIPTION
Fixes #6717 

The dterm notch is disabled and `dterm_notch_hz` is already 0 by default. When the Configurator saves changes from the PID Tuning tab and the notch is disabled it sets both `dterm_notch_hz` and `dterm_notch_cutoff` to 0.  Since the default was left at 160, this makes `dterm_notch_cutoff` appear in `diff` outputs.  Ultimately it's just cosmetic since the dterm notch is disabled if either value is zero.  But there's no reason for the `dterm_notch_cutoff` to remain set to the legacy 160 value.

This issue exists in 3.5 as well but I'm not sure we should apply this fix there. Doing so would make every person that still had the original default have `dterm_notch_cutoff` show up in the `diff`. It wouldn't cause a problem - only confusion.  The tradeoff is that is would prevent the `diff` issue for anybody who has saved changes from the PID Tuning tab in the configurator so it's probably a judgement call.