### PR TITLE
Adding a reusable mapping function between alt and base targets.

### DIFF
--- a/make/targets.mk
+++ b/make/targets.mk
@@ -1,58 +1,13 @@
-OFFICIAL_TARGETS  = ALIENFLIGHTF3 ALIENFLIGHTF4 ANYFCF7 BETAFLIGHTF3 BLUEJAYF4 FURYF4 REVO SIRINFPV SPARKY SPRACINGF3 SPRACINGF3EVO SPRACINGF3NEO SPRACINGF4EVO SPRACINGF7DUAL STM32F3DISCOVERY
-ALT_TARGETS       = $(sort $(filter-out target, $(basename $(notdir $(wildcard $(ROOT)/src/main/target/*/*.mk)))))
-NOBUILD_TARGETS   = $(sort $(filter-out target, $(basename $(notdir $(wildcard $(ROOT)/src/main/target/*/*.nomk)))))
-OPBL_TARGETS      = $(filter %_OPBL, $(ALT_TARGETS))
-
-VALID_TARGETS   = $(dir $(wildcard $(ROOT)/src/main/target/*/target.mk))
-VALID_TARGETS  := $(subst /,, $(subst ./src/main/target/,, $(VALID_TARGETS)))
-VALID_TARGETS  := $(VALID_TARGETS) $(ALT_TARGETS)
-VALID_TARGETS  := $(sort $(VALID_TARGETS))
-VALID_TARGETS  := $(filter-out $(NOBUILD_TARGETS), $(VALID_TARGETS))
+include $(ROOT)/make/targets_list.mk
 
 ifeq ($(filter $(TARGET),$(NOBUILD_TARGETS)), $(TARGET))
 ALTERNATES    := $(sort $(filter-out target, $(basename $(notdir $(wildcard $(ROOT)/src/main/target/$(TARGET)/*.mk)))))
 $(error The target specified, $(TARGET), cannot be built. Use one of the ALT targets: $(ALTERNATES))
 endif
 
-UNSUPPORTED_TARGETS := \
-	AFROMINI \
-	ALIENFLIGHTF1 \
-	BEEBRAIN \
-	CC3D \
-	CC3D_OPBL \
-	CJMCU \
-	MICROSCISKY \
-	NAZE
-
-SUPPORTED_TARGETS := $(filter-out $(UNSUPPORTED_TARGETS), $(VALID_TARGETS))
-
-TARGETS_TOTAL := $(words $(SUPPORTED_TARGETS))
-TARGET_GROUPS := 5
-TARGETS_PER_GROUP := $(shell expr $(TARGETS_TOTAL) / $(TARGET_GROUPS) )
-
-ST := 1
-ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
-GROUP_1_TARGETS := $(wordlist  $(ST), $(ET), $(SUPPORTED_TARGETS))
-
-ST := $(shell expr $(ET) + 1)
-ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
-GROUP_2_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
-
-ST := $(shell expr $(ET) + 1)
-ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
-GROUP_3_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
-
-ST := $(shell expr $(ET) + 1)
-ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
-GROUP_4_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
-
-GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS) $(GROUP_4_TARGETS), $(SUPPORTED_TARGETS))
-
-ifeq ($(filter $(TARGET),$(ALT_TARGETS)), $(TARGET))
-BASE_TARGET    := $(firstword $(subst /,, $(subst ./src/main/target/,, $(dir $(wildcard $(ROOT)/src/main/target/*/$(TARGET).mk)))))
+BASE_TARGET   := $(call get_base_target,$(TARGET))
+ifneq ($(TARGET),$(BASE_TARGET))
 include $(ROOT)/src/main/target/$(BASE_TARGET)/$(TARGET).mk
-else
-BASE_TARGET    := $(TARGET)
 endif
 
 ifeq ($(filter $(TARGET),$(OPBL_TARGETS)), $(TARGET))

--- a/make/targets_list.mk
+++ b/make/targets_list.mk
@@ -1,0 +1,67 @@
+OFFICIAL_TARGETS  = \
+    ALIENFLIGHTF3 \
+    ALIENFLIGHTF4 \
+    ANYFCF7 \
+    BETAFLIGHTF3 \
+    BLUEJAYF4 \
+    FURYF4 REVO \
+    SIRINFPV \
+    SPARKY \
+    SPRACINGF3 \
+    SPRACINGF3EVO \
+    SPRACINGF3NEO \
+    SPRACINGF4EVO \
+    SPRACINGF7DUAL \
+    STM32F3DISCOVERY
+
+ALT_TARGET_PATHS  = $(filter-out %/target,$(basename $(wildcard $(ROOT)/src/main/target/*/*.mk)))
+ALT_TARGET_NAMES  = $(notdir $(ALT_TARGET_PATHS))
+BASE_TARGET_NAMES = $(notdir $(patsubst %/,%,$(dir $(ALT_TARGET_PATHS))))
+BASE_ALT_PAIRS    = $(join $(BASE_TARGET_NAMES:=/),$(ALT_TARGET_NAMES))
+
+ALT_TARGETS       = $(sort $(notdir $(BASE_ALT_PAIRS)))
+BASE_TARGETS      = $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(ROOT)/src/main/target/*/target.mk)))))
+NOBUILD_TARGETS   = $(sort $(filter-out target,$(basename $(notdir $(wildcard $(ROOT)/src/main/target/*/*.nomk)))))
+OPBL_TARGETS      = $(sort $(filter %_OPBL,$(ALT_TARGETS)))
+
+VALID_TARGETS     = $(sort $(filter-out $(NOBUILD_TARGETS),$(BASE_TARGETS) $(ALT_TARGETS)))
+
+# For alt targets, returns their base target name.
+# For base targets, returns the (same) target name.
+# param $1 = target name
+find_target_pair  = $(filter %/$(1),$(BASE_ALT_PAIRS))
+get_base_target   = $(if $(call find_target_pair,$(1)),$(patsubst %/,%,$(dir $(call find_target_pair,$(1)))),$(1))
+
+UNSUPPORTED_TARGETS := \
+    AFROMINI \
+    ALIENFLIGHTF1 \
+    BEEBRAIN \
+    CC3D \
+    CC3D_OPBL \
+    CJMCU \
+    MICROSCISKY \
+    NAZE
+
+SUPPORTED_TARGETS := $(filter-out $(UNSUPPORTED_TARGETS), $(VALID_TARGETS))
+
+TARGETS_TOTAL := $(words $(SUPPORTED_TARGETS))
+TARGET_GROUPS := 5
+TARGETS_PER_GROUP := $(shell expr $(TARGETS_TOTAL) / $(TARGET_GROUPS) )
+
+ST := 1
+ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
+GROUP_1_TARGETS := $(wordlist  $(ST), $(ET), $(SUPPORTED_TARGETS))
+
+ST := $(shell expr $(ET) + 1)
+ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
+GROUP_2_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
+
+ST := $(shell expr $(ET) + 1)
+ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
+GROUP_3_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
+
+ST := $(shell expr $(ET) + 1)
+ET := $(shell expr $(ST) + $(TARGETS_PER_GROUP))
+GROUP_4_TARGETS := $(wordlist $(ST), $(ET), $(SUPPORTED_TARGETS))
+
+GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS) $(GROUP_4_TARGETS), $(SUPPORTED_TARGETS))


### PR DESCRIPTION
Adding a make function called `get_base_target` (usage `$(call get_base_target,$(some_target))`) and extracting target listing code into a separate reusable `.mk` file.

This PR is a prerequisite for auto-generated per-target unit tests proposed in #6738.