### PR TITLE
defaults to improve yaw behaviour, ITermWindupPointInv already define…

### DIFF
--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -50,9 +50,9 @@ bool unittest_outsideRealtimeGuardInterval;
 float unittest_pidLuxFloat_lastErrorForDelta[3];
 float unittest_pidLuxFloat_delta1[3];
 float unittest_pidLuxFloat_delta2[3];
-float unittest_pidLuxFloat_PTerm[3];
-float unittest_pidLuxFloat_ITerm[3];
-float unittest_pidLuxFloat_DTerm[3];
+float unittest_pidLuxFloat_pterm[3];
+float unittest_pidLuxFloat_iterm[3];
+float unittest_pidLuxFloat_dterm[3];
 
 #define SET_PID_LUX_FLOAT_LOCALS(axis) \
     { \
@@ -66,15 +66,15 @@ float unittest_pidLuxFloat_DTerm[3];
         unittest_pidLuxFloat_lastErrorForDelta[axis] = lastErrorForDelta[axis]; \
         unittest_pidLuxFloat_delta1[axis] = delta1[axis]; \
         unittest_pidLuxFloat_delta2[axis] = delta2[axis]; \
-        unittest_pidLuxFloat_PTerm[axis] = PTerm; \
-        unittest_pidLuxFloat_ITerm[axis] = ITerm; \
-        unittest_pidLuxFloat_DTerm[axis] = DTerm; \
+        unittest_pidLuxFloat_pterm[axis] = pterm; \
+        unittest_pidLuxFloat_iterm[axis] = iterm; \
+        unittest_pidLuxFloat_dterm[axis] = dterm; \
     }
 
 int32_t unittest_pidMultiWiiRewrite_lastErrorForDelta[3];
-int32_t unittest_pidMultiWiiRewrite_PTerm[3];
-int32_t unittest_pidMultiWiiRewrite_ITerm[3];
-int32_t unittest_pidMultiWiiRewrite_DTerm[3];
+int32_t unittest_pidMultiWiiRewrite_pterm[3];
+int32_t unittest_pidMultiWiiRewrite_iterm[3];
+int32_t unittest_pidMultiWiiRewrite_dterm[3];
 
 #define SET_PID_MULTI_WII_REWRITE_LOCALS(axis) \
     { \
@@ -84,9 +84,9 @@ int32_t unittest_pidMultiWiiRewrite_DTerm[3];
 #define GET_PID_MULTI_WII_REWRITE_LOCALS(axis) \
     { \
         unittest_pidMultiWiiRewrite_lastErrorForDelta[axis] = lastErrorForDelta[axis]; \
-        unittest_pidMultiWiiRewrite_PTerm[axis] = PTerm; \
-        unittest_pidMultiWiiRewrite_ITerm[axis] = ITerm; \
-        unittest_pidMultiWiiRewrite_DTerm[axis] = DTerm; \
+        unittest_pidMultiWiiRewrite_pterm[axis] = pterm; \
+        unittest_pidMultiWiiRewrite_iterm[axis] = iterm; \
+        unittest_pidMultiWiiRewrite_dterm[axis] = dterm; \
     }
 
 #else

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -577,16 +577,16 @@ bool processRx(timeUs_t currentTimeUs)
 
     if (isAirmodeActive() && ARMING_FLAG(ARMED)) {
         if (throttlePercent >= rxConfig()->airModeActivateThreshold) {
-            airmodeIsActivated = true; // Prevent Iterm from being reset
+            airmodeIsActivated = true; // Prevent iterm from being reset
         }
     } else {
         airmodeIsActivated = false;
     }
 
-    /* In airmode Iterm should be prevented to grow when Low thottle and Roll + Pitch Centered.
-     This is needed to prevent Iterm winding on the ground, but keep full stabilisation on 0 throttle while in air */
+    /* In airmode iterm should be prevented to grow when Low thottle and Roll + Pitch Centered.
+     This is needed to prevent iterm winding on the ground, but keep full stabilisation on 0 throttle while in air */
     if (throttleStatus == THROTTLE_LOW && !airmodeIsActivated) {
-        pidResetITerm();
+        pidResetIterm();
         if (currentPidProfile->pidAtMinThrottle)
             pidStabilisationState(PID_STABILISATION_ON);
         else

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -596,8 +596,8 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             currentThrottleInputRange = rcCommandThrottleRange3dHigh;
         }
         if (currentTimeUs - reversalTimeUs < 250000) {
-            // keep ITerm zero for 250ms after motor reversal
-            pidResetITerm();
+            // keep iterm zero for 250ms after motor reversal
+            pidResetIterm();
         }
     } else {
         throttle = rcCommand[THROTTLE] - rxConfig()->mincheck + throttleAngleCorrection;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -130,7 +130,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dterm_notch_hz = 0,
         .dterm_notch_cutoff = 0,
         .dterm_filter_type = FILTER_PT1,
-        .itermWindupPointPercent = 100,
+        .itermWindupPointPercent = 40,
         .vbatPidCompensation = 0,
         .pidAtMinThrottle = PID_STABILISATION_ON,
         .levelAngleLimit = 55,

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -995,7 +995,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, const rollAndPitchT
 
 #if defined(USE_ITERM_RELAX)
         applyItermRelax(axis, iterm, gyroRate, &itermErrorRate, &currentPidSetpoint);
-#endif        
+#endif
 
         // --------low-level gyro-based PID based on 2DOF PID controller. ----------
         // 2-DOF PID controller with optional filter on derivative term.

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -117,7 +117,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .pid = {
             [PID_ROLL] =  { 46, 45, 25, 60 },
             [PID_PITCH] = { 50, 50, 27, 60 },
-            [PID_YAW] =   { 65, 45, 0 , 60 },
+            [PID_YAW] =   { 45, 100, 0, 100 },
             [PID_LEVEL] = { 50, 50, 75, 0 },
             [PID_MAG] =   { 40, 0, 0, 0 },
         },
@@ -135,7 +135,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .pidAtMinThrottle = PID_STABILISATION_ON,
         .levelAngleLimit = 55,
         .feedForwardTransition = 0,
-        .yawRateAccelLimit = 100,
+        .yawRateAccelLimit = 0,
         .rateAccelLimit = 0,
         .itermThrottleThreshold = 250,
         .itermAcceleratorGain = 5000,
@@ -150,7 +150,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .horizon_tilt_effect = 75,
         .horizon_tilt_expert_mode = false,
         .crash_limit_yaw = 200,
-        .itermLimit = 150,
+        .itermLimit = 300,
         .throttle_boost = 5,
         .throttle_boost_cutoff = 15,
         .iterm_rotation = true,
@@ -443,12 +443,9 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     horizonFactorRatio = (100 - pidProfile->horizon_tilt_effect) * 0.01f;
     maxVelocity[FD_ROLL] = maxVelocity[FD_PITCH] = pidProfile->rateAccelLimit * 100 * dT;
     maxVelocity[FD_YAW] = pidProfile->yawRateAccelLimit * 100 * dT;
-    ITermWindupPointInv = 0.0f;
     if (pidProfile->itermWindupPointPercent < 100) {
         float ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
         ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
-    } else {
-        ITermWindupPointInv = 0.0f;
     }
     itermAcceleratorGain = pidProfile->itermAcceleratorGain;
     crashTimeLimitUs = pidProfile->crash_time * 1000;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -444,7 +444,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     maxVelocity[FD_ROLL] = maxVelocity[FD_PITCH] = pidProfile->rateAccelLimit * 100 * dT;
     maxVelocity[FD_YAW] = pidProfile->yawRateAccelLimit * 100 * dT;
     if (pidProfile->itermWindupPointPercent < 100) {
-        float ITermWindupPoint = (float)pidProfile->itermWindupPointPercent / 100.0f;
+        const float ITermWindupPoint = pidProfile->itermWindupPointPercent / 100.0f;
         ITermWindupPointInv = 1.0f / (1.0f - ITermWindupPoint);
     }
     itermAcceleratorGain = pidProfile->itermAcceleratorGain;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -105,7 +105,7 @@ typedef struct pidProfile_s {
     pidf_t  pid[PID_ITEM_COUNT];
 
     uint8_t dterm_filter_type;              // Filter selection for dterm
-    uint8_t itermWindupPointPercent;        // ITerm windup threshold, percent motor saturation
+    uint8_t itermWindupPointPercent;        // iterm windup threshold, percent motor saturation
     uint16_t pidSumLimit;
     uint16_t pidSumLimitYaw;
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.
@@ -181,7 +181,7 @@ extern uint32_t targetPidLooptime;
 extern float throttleBoost;
 extern pt1Filter_t throttleLpf;
 
-void pidResetITerm(void);
+void pidResetIterm(void);
 void pidStabilisationState(pidStabilisationState_e pidControllerState);
 void pidSetItermAccelerator(float newItermAccelerator);
 void pidInitFilters(const pidProfile_t *pidProfile);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -105,7 +105,7 @@ typedef struct pidProfile_s {
     pidf_t  pid[PID_ITEM_COUNT];
 
     uint8_t dterm_filter_type;              // Filter selection for dterm
-    uint8_t itermWindupPointPercent;        // Experimental ITerm windup threshold, percent motor saturation
+    uint8_t itermWindupPointPercent;        // ITerm windup threshold, percent motor saturation
     uint16_t pidSumLimit;
     uint16_t pidSumLimitYaw;
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -823,7 +823,7 @@ extern "C" {
     void failsafeStartMonitoring(void) {}
     void failsafeUpdateState(void) {}
     bool failsafeIsActive(void) { return false; }
-    void pidResetITerm(void) {}
+    void pidResetIterm(void) {}
     void updateAdjustmentStates(void) {}
     void processRcAdjustments(controlRateConfig_t *) {}
     void updateGpsWaypointsAndMode(void) {}

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -145,7 +145,7 @@ extern "C" {
     void failsafeStartMonitoring(void) {}
     void failsafeUpdateState(void) {}
     bool failsafeIsActive(void) { return false; }
-    void pidResetITerm(void) {}
+    void pidResetIterm(void) {}
     void updateAdjustmentStates(void) {}
     void processRcAdjustments(controlRateConfig_t *) {}
     void updateGpsWaypointsAndMode(void) {}


### PR DESCRIPTION
Some changes here to allow peak yaw performance:

- remove the limit on yaw acceleration rate, which had little effect on yaw jump and just limited maximum possible yaw rate

- yaw I and FF at 100, yaw P reduced to 45

ITermWindupPointInv was defined as zero at line 373 of pid.c, so some lines where it was set to zero could be removed.

```
373:  static FAST_RAM_ZERO_INIT float ITermWindupPointInv;
```