### PR TITLE
Fix issue 6722. SRXL data collection was not triggered.

### DIFF
--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -150,8 +150,16 @@ static uint8_t spektrumFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
         }
 
 #if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_SRXL)
-        if (srxlEnabled && telemetryBufLen && (spekFrame[2] & 0x80) == 0) {
-            telemetryFrameRequestedUs = currentTimeUs;
+        if (srxlEnabled) {
+            if (telemetryBufLen) {
+                if ((spekFrame[2] & 0x80) == 0) {
+                    telemetryFrameRequestedUs = currentTimeUs;
+                }
+            }
+            else {
+                // Trigger tm data collection if buffer is empty.
+                srxlCollectTelemetryNow();
+            }
         }
 #endif
 


### PR DESCRIPTION
Fix issue #6722 . SRXL telemetry data collection was only triggered after transmitting tm, creating a "hen and egg" problem as Tm transmission required tm data being collected and buffered. But transmission was never done as there was no data etc etc. Two stages, collection and transmission. Fixed by checking tm buffer.

Side note: when testing on master, I noticed some strange CMS behaviour. When holding sticks in the "CMS enter"-position for too long, CMS is no longer cycling between display ports, it locks up with some beeps. CMS behaves like this even without this PR. When testing this PR cherry-picked into 3.5.x-maint, there is no such CMS behaviour. A separate issue only on master, it seems.
