### PR TITLE
Avoid inactive telemetry port from being registered as a displayport …

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -432,6 +432,10 @@ void initCrsfTelemetry(void)
     // and feature is enabled, if so, set CRSF telemetry enabled
     crsfTelemetryEnabled = crsfRxIsActive();
 
+    if (!crsfTelemetryEnabled) {
+        return;
+    }
+
     deviceInfoReplyPending = false;
 #if defined(USE_MSP_OVER_TELEMETRY)
     mspReplyPending = false;

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -347,6 +347,11 @@ void freeHoTTTelemetryPort(void)
 void initHoTTTelemetry(void)
 {
     portConfig = findSerialPortConfig(FUNCTION_TELEMETRY_HOTT);
+
+    if (!portConfig) {
+        return;
+    }
+
     hottPortSharing = determinePortSharing(portConfig, FUNCTION_TELEMETRY_HOTT);
 
 #if defined (USE_HOTT_TEXTMODE) && defined (USE_CMS)


### PR DESCRIPTION
Fixes #6745 

It seemed that CRSF also had the same problem.

Needs testing by someone with Hott text telemetry (@Scavanger ?) and CRSF.

- [ ] Hott case
- [ ] CRSF case
- [x] Non-Hott and non-CRSF case