### PR TITLE
Add default CAMERA_CONTROL pin for DALRCF722DUAL

### DIFF
--- a/src/main/target/DALRCF722DUAL/target.c
+++ b/src/main/target/DALRCF722DUAL/target.c
@@ -40,6 +40,6 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 
     DEF_TIM(TIM2, CH1, PA15,  TIM_USE_LED, 0, 0),    // LED STRIP(1,5)
 
-    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_PWM, 0, 0),     // FC CAM	
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_CAMERA_CONTROL, 0, 0),     // FC CAM	
 	
 };


### PR DESCRIPTION
Add default CAMERA_CONTROL pin for DALRCF722DUAL.
It was ignored before.