### PR TITLE
Handle NULL SPI instance case

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -228,6 +228,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const gyro
     gyro->bus.bustype = BUSTYPE_SPI;
 
     spiBusSetInstance(&gyro->bus, spiInstanceByDevice(SPI_CFG_TO_DEV(config->spiBus)));
+
+    // SPI instance may be NULL if the bus is non-existent
+    if (!gyro->bus.busdev_u.spi.instance) {
+        return false;
+    }
+
     gyro->bus.busdev_u.spi.csnPin = IOGetByTag(config->csnTag);
     IOInit(gyro->bus.busdev_u.spi.csnPin, OWNER_GYRO_CS, RESOURCE_INDEX(config->index));
     IOConfigGPIO(gyro->bus.busdev_u.spi.csnPin, SPI_IO_CS_CFG);

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -62,7 +62,7 @@ SPIDevice spiDeviceByInstance(SPI_TypeDef *instance)
 
 SPI_TypeDef *spiInstanceByDevice(SPIDevice device)
 {
-    if (device >= SPIDEV_COUNT) {
+    if (device == SPIINVALID || device >= SPIDEV_COUNT) {
         return NULL;
     }
 

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -76,6 +76,10 @@ void spiInitDevice(SPIDevice device)
 {
     spiDevice_t *spi = &(spiDevice[device]);
 
+    if (!spi->dev) {
+        return;
+    }
+
 #ifdef SDCARD_SPI_INSTANCE
     if (spi->dev == SDCARD_SPI_INSTANCE) {
         spi->leadingEdge = true;

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -37,6 +37,10 @@ void spiInitDevice(SPIDevice device)
 {
     spiDevice_t *spi = &(spiDevice[device]);
 
+    if (!spi->dev) {
+        return;
+    }
+
 #ifdef SDCARD_SPI_INSTANCE
     if (spi->dev == SDCARD_SPI_INSTANCE) {
         spi->leadingEdge = true;

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -45,13 +45,13 @@
 #define USE_GYRO_SPI_MPU6500
 // Other USE_ACCs and USE_GYROs should follow
 
-#define GYRO_1_SPI_INSTANCE     SPI1
+#define GYRO_1_SPI_INSTANCE     NULL
 #define GYRO_1_CS_PIN           NONE
 #define GYRO_1_ALIGN            ALIGN_DEFAULT
 #define ACC_1_ALIGN             ALIGN_DEFAULT
 #define GYRO_1_EXTI_PIN         PB15 // XXX Should be gone
 
-#define GYRO_2_SPI_INSTANCE     SPI1
+#define GYRO_2_SPI_INSTANCE     NULL
 #define GYRO_2_CS_PIN           NONE
 #define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define ACC_2_ALIGN             ALIGN_DEFAULT


### PR DESCRIPTION
Fixes #6739 

Generic targets, upon first boot after flashing, has no valid SPI bus configured, but the current code starts looking for acc/gyro devices. This PR detects NULL SPI instance during this process.

Note:
Non-acc/gyro devices have no problem as they are not activated at first boot. Ideally, drivers for them should handle the NULL SPI instance case also. Making `spiBusSetInstance` to return a boolean result which indicates successful initialization would be an idea.