### PR TITLE
Relocate G-force calculation.

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -738,16 +738,8 @@ static bool osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_G_FORCE:
-        {
-            osdGForce = 0.0f;
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                const float a = accAverage[axis];
-                osdGForce += a * a;
-            }
-            osdGForce = sqrtf(osdGForce) * acc.dev.acc_1G_rec;
-            tfp_sprintf(buff, "%01d.%01dG", (int)osdGForce, (int)(osdGForce * 10) % 10);
-            break;
-        }
+        tfp_sprintf(buff, "%01d.%01dG", (int)osdGForce, (int)(osdGForce * 10) % 10);
+        break;
 
     case OSD_ROLL_PIDS:
         osdFormatPID(buff, "ROL", &currentPidProfile->pid[PID_ROLL]);
@@ -1050,6 +1042,12 @@ static void osdDrawElements(void)
     }
 
     if (sensors(SENSOR_ACC)) {
+        osdGForce = 0.0f;
+        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+            const float a = accAverage[axis];
+            osdGForce += a * a;
+        }
+        osdGForce = sqrtf(osdGForce) * acc.dev.acc_1G_rec;
         osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
         osdDrawSingleElement(OSD_G_FORCE);
     }


### PR DESCRIPTION
I have notice the osd max g force stat always displays 0 G, unless the g force osd element is enabled.  I have no desire to use the G force in flight, but as a post flight stat it is interesting.  This PR moves the         osdGForce calculation up one level, before the element is drawn, so the stat can be collected if the element is disabled.