### PR TITLE
GENERIC Fix origins for timer channel list

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -4109,7 +4109,7 @@ static void printTimer(uint8_t dumpMask)
             cliDumpPrintLinef(dumpMask, false, format, 
                 IO_GPIOPortIdxByTag(ioTag) + 'A', 
                 IO_GPIOPinIdxByTag(ioTag),
-                timerIndex
+                timerIndex - 1
                 );
         }
     }
@@ -4160,13 +4160,13 @@ static void cliTimer(char *cmdline)
     if (pch) {
         if (strcasecmp(pch, "list") == 0) {
             /* output the list of available options */
-            uint8_t index = 1;
+            uint8_t index = 0;
             for (unsigned i = 0; i < USABLE_TIMER_CHANNEL_COUNT; i++) {
                 if (timerHardware[i].tag == ioTag) {
                     cliPrintLinef("# %d. TIM%d CH%d",
                         index,
                         timerGetTIMNumber(timerHardware[i].tim),
-                        CC_INDEX_FROM_CHANNEL(timerHardware[i].channel)
+                        CC_INDEX_FROM_CHANNEL(timerHardware[i].channel) + 1
                     );
                     index++;
                 }
@@ -4175,7 +4175,7 @@ static void cliTimer(char *cmdline)
         } else if (strcasecmp(pch, "none") == 0) {
             goto success;
         } else {
-            timerIndex = atoi(pch);
+            timerIndex = atoi(pch) + 1;
         }
     } else {
         goto error;

--- a/src/main/pg/timerio.h
+++ b/src/main/pg/timerio.h
@@ -27,8 +27,6 @@
 
 #ifdef USE_TIMER_MGMT
 
-#define MAX_TIMER_PINMAP_COUNT   10
-
 typedef struct timerIOConfig_s {
     ioTag_t ioTag;
     uint8_t index;

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -269,3 +269,9 @@
 #define MSC_BUTTON_IPU true
 #endif
 #endif
+
+#ifdef USE_TIMER_MGMT
+#ifndef MAX_TIMER_PINMAP_COUNT
+#define MAX_TIMER_PINMAP_COUNT 21 // Largest known for F405RG (OMNINXT)
+#endif
+#endif


### PR DESCRIPTION
Without this fix, available channels for a pin would print:
```
# timer a2 list
# 1. TIM2 CH2
# 2. TIM5 CH2
# 3. TIM9 CH0
```
which should be
```
# timer a2 list
# 0. TIM2 CH3
# 1. TIM5 CH3
# 2. TIM9 CH1
```