### PR TITLE
Handle NULL SPI instance in spiBusSetInstance

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -225,14 +225,11 @@ static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
 
 static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const gyroDeviceConfig_t *config)
 {
-    gyro->bus.bustype = BUSTYPE_SPI;
-
-    spiBusSetInstance(&gyro->bus, spiInstanceByDevice(SPI_CFG_TO_DEV(config->spiBus)));
-
-    // SPI instance may be NULL if the bus is non-existent
-    if (!gyro->bus.busdev_u.spi.instance) {
+    SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(config->spiBus));
+    if (!instance) {
         return false;
     }
+    spiBusSetInstance(&gyro->bus, instance);
 
     gyro->bus.busdev_u.spi.csnPin = IOGetByTag(config->csnTag);
     IOInit(gyro->bus.busdev_u.spi.csnPin, OWNER_GYRO_CS, RESOURCE_INDEX(config->index));


### PR DESCRIPTION
Follow up to #6770.

~As proposed in~
>~Note:
Non-acc/gyro devices have no problem as they are not activated at first boot. Ideally, drivers for them should handle the NULL SPI instance case also. Making spiBusSetInstance to return a boolean result which indicates successful initialization would be an idea.~

Changed to the way suggested by @mikeller and +1'ed by @ledvinap in https://github.com/betaflight/betaflight/pull/6787#discussion_r218305906