### PR TITLE
GENERIC: DMA spec specifier in CLI, SD card as an example

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -393,6 +393,25 @@ static const char * const lookupTableVtxLowPowerDisarm[] = {
 };
 #endif
 
+// DMA spec table. Indices are coherent with respective dmaIndentifier_e value.
+#if defined(STM32F3)
+static const char * const lookupTableDmaChannel[] = {
+    "NONE",
+    "DMA1_CH1", "DMA1_CH2", "DMA1_CH3", "DMA1_CH4",
+    "DMA1_CH5", "DMA1_CH6", "DMA1_CH7",
+    "DMA2_CH1", "DMA2_CH2", "DMA2_CH3", "DMA2_CH4",
+    "DMA2_CH5",
+};
+#elif defined(STM32F4) || defined(STM32F7)
+static const char * const lookupTableDmaStream[] = {
+    "NONE",
+    "DMA1_ST0", "DMA1_ST1", "DMA1_ST2", "DMA1_ST3",
+    "DMA1_ST4", "DMA1_ST5", "DMA1_ST6", "DMA1_ST7",
+    "DMA2_ST0", "DMA2_ST1", "DMA2_ST2", "DMA2_ST3",
+    "DMA2_ST4", "DMA2_ST5", "DMA2_ST6", "DMA2_ST7",
+};
+#endif
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -490,6 +509,12 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableVtxLowPowerDisarm),
 #endif
     LOOKUP_TABLE_ENTRY(lookupTableGyroHardware),
+#if defined(STM32F3)
+    LOOKUP_TABLE_ENTRY(lookupTableDmaChannel),
+#endif
+#if defined(STM32F4) || defined(STM32F7)
+    LOOKUP_TABLE_ENTRY(lookupTableDmaStream),
+#endif
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -936,7 +961,14 @@ const clivalue_t valueTable[] = {
 
 // PG_SDCARD_CONFIG
 #ifdef USE_SDCARD
+    { "sdcard_card_detect_inverted", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SDCARD_CONFIG, offsetof(sdcardConfig_t, cardDetectInverted) },
     { "sdcard_dma",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SDCARD_CONFIG, offsetof(sdcardConfig_t, useDma) },
+#if defined(STM32F3)
+    { "sdcard_dma_channel",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DMA_CHANNEL }, PG_SDCARD_CONFIG, offsetof(sdcardConfig_t, dmaIdentifier) },
+#elif defined(STM32F4) || defined(STM32F7)
+    { "sdcard_dma_stream",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DMA_STREAM }, PG_SDCARD_CONFIG, offsetof(sdcardConfig_t, dmaIdentifier) },
+    { "sdcard_dma_channel",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 7 }, PG_SDCARD_CONFIG, offsetof(sdcardConfig_t, dmaChannel) },
+#endif
 #endif
 #ifdef USE_SDCARD_SDIO
     { "sdio_clk_bypass",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SDIO_CONFIG, offsetof(sdioConfig_t, clockBypass) },

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -120,6 +120,11 @@ typedef enum {
     TABLE_VTX_LOW_POWER_DISARM, 
 #endif
     TABLE_GYRO_HARDWARE,
+#if defined(STM32F3)
+    TABLE_DMA_CHANNEL,
+#elif defined(STM32F4) || defined(STM32F7)
+    TABLE_DMA_STREAM,
+#endif
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -47,16 +47,8 @@ void pgResetFn_sdcardConfig(sdcardConfig_t *config)
     config->enabled = 0;
     config->device = 0;
 #endif
-#ifdef SDCARD_DETECT_PIN
     config->cardDetectTag = IO_TAG(SDCARD_DETECT_PIN);
-#else
-    config->cardDetectTag = IO_TAG_NONE;
-#endif
-#ifdef SDCARD_SPI_CS_PIN
     config->chipSelectTag = IO_TAG(SDCARD_SPI_CS_PIN);
-#else
-    config->chipSelectTag = IO_TAG_NONE;
-#endif
 
 #ifdef SDCARD_DETECT_INVERTED
     config->cardDetectInverted = 1;

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -243,7 +243,7 @@
 #endif
 
 #if !defined(ACC_1_ALIGN)
-#define ACC_1_ALIGN            ALIGN_DEFAULT
+#define ACC_1_ALIGN             ALIGN_DEFAULT
 #endif
 
 #if defined(MPU_ADDRESS)
@@ -256,4 +256,16 @@
 #define MAX_GYRODEV_COUNT 2
 #else
 #define MAX_GYRODEV_COUNT 1
+#endif
+
+#if !defined(SDCARD_SPI_INSTANCE)
+#define SDCARD_SPI_INSTANCE     NULL
+#endif
+
+#if !defined(SDCARD_SPI_CS_PIN)
+#define SDCARD_SPI_CS_PIN       NONE
+#endif
+
+#if !defined(SDCARD_DETECT_PIN)
+#define SDCARD_DETECT_PIN       NONE
 #endif


### PR DESCRIPTION
Generic targets call for a way to handle DMA stream and channel in CLI.

This PR provides a PoC that uses `dmaIdentifier_e` values and associated literal representation in a value table.

SDCard DMA is used as an example of CLI variable handling.

For F3, DMA channel is the only variable associated with the DMA:
```
sdcard_dma_channel = DMA1_CH5
Allowed values: NONE, DMA1_CH1, DMA1_CH2, DMA1_CH3, DMA1_CH4, DMA1_CH5, DMA1_CH6, DMA1_CH7, DMA2_CH1, DMA2_CH2, DMA2_CH3, DMA2_CH4, DMA2_CH5
```

For F4 and F7, DMA stream and channel are handled separately with two variables:
```
sdcard_dma_stream = DMA1_ST5
Allowed values: NONE, DMA1_ST0, DMA1_ST1, DMA1_ST2, DMA1_ST3, DMA1_ST4, DMA1_ST5, DMA1_ST6, DMA1_ST7, DMA2_ST0, DMA2_ST1, DMA2_ST2, DMA2_ST3, DMA2_ST4, DMA2_ST5, DMA2_ST6, DMA2_ST7

sdcard_dma_channel = 0
Allowed range: 0 - 7
```