### PR TITLE
Multiple targets: Remove or convert stale MPU_INT_EXTI defs

### DIFF
--- a/src/main/target/DALRCF722DUAL/target.h
+++ b/src/main/target/DALRCF722DUAL/target.h
@@ -33,9 +33,9 @@
 
 #define USE_DUAL_GYRO
 #define USE_EXTI
+#define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PB10
 #define GYRO_2_EXTI_PIN         PC4
-#define MPU_INT_EXTI
 
 #define GYRO_1_CS_PIN                       PB0   
 #define GYRO_1_SPI_INSTANCE                 SPI1

--- a/src/main/target/NUCLEOF446RE/target.h
+++ b/src/main/target/NUCLEOF446RE/target.h
@@ -56,7 +56,8 @@
 
 #define USE_EXTI
 
-//#define MPU_INT_EXTI PC13
+//#define USE_GYRO_EXTI
+//#define GYRO_1_EXTI_PIN PC13
 //#define USE_MPU_DATA_READY_SIGNAL
 //#define ENSURE_MPU_DATA_READY_IS_LOW
 

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -48,16 +48,14 @@
 // ICM-20608-G
 #define USE_ACC_SPI_MPU6500
 #define USE_GYRO_SPI_MPU6500
-//#define MPU_INT_EXTI            PE8
 
 // MPU6000
 #define USE_ACC_SPI_MPU6000
 #define USE_GYRO_SPI_MPU6000
-//#define MPU_INT_EXTI            PD0
 
-// Provisioned, but not used
-#define GYRO_1_EXTI_PIN         NONE
-#define GYRO_2_EXTI_PIN         NONE
+//#define USE_MPU_DATA_READY_SIGNAL
+#define USE_EXTI
+#define USE_GYRO_EXTI
 
 #if defined(OMNIBUSF7V2)
 #define GYRO_1_SPI_INSTANCE     SPI3
@@ -68,6 +66,8 @@
 #define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define ACC_1_ALIGN             CW90_DEG
 #define ACC_2_ALIGN             ALIGN_DEFAULT
+#define GYRO_1_EXTI_PIN         PD0           // MPU6000
+#define GYRO_2_EXTI_PIN         PE8           // ICM20608
 
 #elif defined(FPVM_BETAFLIGHTF7)
 #define GYRO_1_SPI_INSTANCE     SPI1
@@ -78,6 +78,8 @@
 #define ACC_1_ALIGN             CW90_DEG
 #define GYRO_2_ALIGN            CW270_DEG
 #define ACC_2_ALIGN             CW270_DEG
+#define GYRO_1_EXTI_PIN         PD0           // Assume the same as OMNIBUSF7V2, need to verify
+#define GYRO_2_EXTI_PIN         PE8           // Ditto
 
 #else
 #define GYRO_1_SPI_INSTANCE     SPI3
@@ -88,11 +90,9 @@
 #define ACC_1_ALIGN             ALIGN_DEFAULT
 #define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define ACC_2_ALIGN             ALIGN_DEFAULT
+#define GYRO_1_EXTI_PIN         PE8           // ICM20608
+#define GYRO_2_EXTI_PIN         PD0           // MPU6000
 #endif
-
-// TODO: dual gyro support
-//#define USE_MPU_DATA_READY_SIGNAL
-#define USE_EXTI
 
 //UARTS-------------------------------------
 #define USE_VCP

--- a/src/main/target/SPEDIXF4/target.h
+++ b/src/main/target/SPEDIXF4/target.h
@@ -34,7 +34,8 @@
 #define ENABLE_DSHOT_DMAR       true
 
 #define USE_EXTI
-#define MPU_INT_EXTI            PC4
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_GYRO

--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -56,7 +56,8 @@
 #define BEEPER_INVERTED
 
 //#define USE_EXTI
-//#define MPU_INT_EXTI            PC13
+//#define USE_GYRO_EXTI
+//#define GYRO_1_EXTI_PIN       PC13
 //#define USE_MPU_DATA_READY_SIGNAL
 //#define ENSURE_MPU_DATA_READY_IS_LOW
 

--- a/src/main/target/SPRACINGF7DUAL/target.h
+++ b/src/main/target/SPRACINGF7DUAL/target.h
@@ -43,9 +43,9 @@
 #define BEEPER_INVERTED
 
 #define USE_EXTI
+#define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC13
 #define GYRO_2_EXTI_PIN         PC14
-#define MPU_INT_EXTI
 
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW
@@ -69,7 +69,6 @@
 #define ACC_MPU6500_2_ALIGN         CW270_DEG
 #define GYRO_MPU6500_2_ALIGN        CW270_DEG
 #endif
-
 
 #define GYRO_1_ALIGN                GYRO_MPU6500_1_ALIGN
 #define GYRO_2_ALIGN                GYRO_MPU6500_2_ALIGN


### PR DESCRIPTION
Overlooked by, or resurrected after #5868.