### PR TITLE
Add conditional for rx_xn297.c

### DIFF
--- a/src/main/drivers/rx/rx_xn297.c
+++ b/src/main/drivers/rx/rx_xn297.c
@@ -26,6 +26,8 @@
 
 #include "platform.h"
 
+#if defined(USE_RX_XN297)
+
 #include "common/crc.h"
 
 #include "pg/rx.h"
@@ -95,3 +97,4 @@ uint8_t XN297_WritePayload(uint8_t *data, int len, const uint8_t *rxAddr)
     packet[RX_TX_ADDR_LEN + len + 1] = crc & 0xff;
     return NRF24L01_WritePayload(packet, RX_TX_ADDR_LEN + len + 2);
 }
+#endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -180,3 +180,8 @@
 #if defined(USE_GYRO_SPI_ICM20689) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250)
 #define USE_SPI_GYRO
 #endif
+
+// CX10 is a special case of SPI RX which requires XN297
+#if defined(USE_RX_CX10)
+#define USE_RX_XN297
+#endif


### PR DESCRIPTION
As discussed in #6851.

XN297 is near clone of nRF24L01, and it is only used by nrf24_cx10.c
