### PR TITLE
Fix ordering of gyro filtering and overflow/yaw-spin logic

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -949,6 +949,12 @@ static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSens
         return;
     }
 
+    if (gyroDebugMode == DEBUG_NONE) {
+        filterGyro(gyroSensor);
+    } else {
+        filterGyroDebug(gyroSensor);
+    }
+
 #ifdef USE_GYRO_OVERFLOW_CHECK
     if (gyroConfig()->checkOverflow && !gyroHasOverflowProtection) {
         checkForOverflow(gyroSensor, currentTimeUs);
@@ -960,12 +966,6 @@ static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSens
         checkForYawSpin(gyroSensor, currentTimeUs);
     }
 #endif
-
-    if (gyroDebugMode == DEBUG_NONE) {
-        filterGyro(gyroSensor);
-    } else {
-        filterGyroDebug(gyroSensor);
-    }
 
 #ifdef USE_GYRO_DATA_ANALYSE
     if (isDynamicFilterActive()) {


### PR DESCRIPTION
Since the gyro overflow and yaw-spin logic uses filtered gyro data they need to be after the filter application.

Currently the logic is before causing it to operate on one sample old data. This won't prevent the logic from working and it's not a critical fix, but it's better to have the checks after the filtering.
