### PR TITLE
Update MAX7456 driver for generic target

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -186,10 +186,6 @@
     #define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busdev_u.spi.csnPin)
 #endif
 
-#ifndef MAX7456_SPI_CLK
-#define MAX7456_SPI_CLK           (SPI_CLOCK_STANDARD)
-#endif
-
 busDevice_t max7456BusDevice;
 busDevice_t *busdev = &max7456BusDevice;
 

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -25,6 +25,14 @@
 #define MAX7456_CLOCK_CONFIG_DEFAULT    MAX7456_CLOCK_CONFIG_OC
 #endif
 
+#ifndef MAX7456_SPI_CLK
+#define MAX7456_SPI_CLK                 (SPI_CLOCK_STANDARD)
+#endif
+
+#ifndef MAX7456_RESTORE_CLK
+#define MAX7456_RESTORE_CLK             (SPI_CLOCK_FAST)
+#endif
+
 #ifndef MAX7456_SPI_CS_PIN
 #define MAX7456_SPI_CS_PIN              NONE
 #endif


### PR DESCRIPTION
Separation of #6805.