### PR TITLE
SPI: Refactor sdcard_spi.c to use busDevice_t (again)

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -141,6 +141,11 @@ void spiResetErrorCounter(SPI_TypeDef *instance)
     }
 }
 
+bool spiBusIsBusBusy(const busDevice_t *bus)
+{
+    return spiIsBusBusy(bus->busdev_u.spi.instance);
+}
+
 uint8_t spiBusTransferByte(const busDevice_t *bus, uint8_t data)
 {
     return spiTransferByte(bus->busdev_u.spi.instance, data);
@@ -151,6 +156,11 @@ void spiBusWriteByte(const busDevice_t *bus, uint8_t data)
     IOLo(bus->busdev_u.spi.csnPin);
     spiBusTransferByte(bus, data);
     IOHi(bus->busdev_u.spi.csnPin);
+}
+
+bool spiBusRawTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int len)
+{
+    return spiTransfer(bus->busdev_u.spi.instance, txData, rxData, len);
 }
 
 bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data)

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -112,10 +112,13 @@ void spiResetErrorCounter(SPI_TypeDef *instance);
 SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
 SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
+bool spiBusIsBusBusy(const busDevice_t *bus);
+
 bool spiBusTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length);
 
 uint8_t spiBusTransferByte(const busDevice_t *bus, uint8_t data);
 void spiBusWriteByte(const busDevice_t *bus, uint8_t data);
+bool spiBusRawTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int len);
 
 bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool spiBusRawReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);

--- a/src/main/drivers/sdcard_impl.h
+++ b/src/main/drivers/sdcard_impl.h
@@ -90,8 +90,7 @@ typedef struct sdcard_t {
     IO_t cardDetectPin;
 
 #ifdef USE_SDCARD_SPI
-    SPI_TypeDef *instance;
-    IO_t chipSelectPin;
+    busDevice_t busdev;
     bool useDMAForTx;
     dmaChannelDescriptor_t * dma;
 #endif


### PR DESCRIPTION
A similar work (#6845) was accidentally overwritten by #6842 which introduced the new `sdcard_spi.c` which included most of the change proposed by #6845 thus fooled the conflict detection.

Note:
There is at least one inconsistency on function naming between `spiBus` version and non-`spiBus` version of functions, which is `spiTransfer`. Non-`spiBus` version only takes care of the actual I/O without manipulating chip select line while `spiBus` version does manipulate chip select line. I will probably go through SPI function names and clean things up when the SPI is functionally ready for 4.0.