### PR TITLE
SDCARD: Prevent msp from calling sdcard_getMetadata when card is not ready

### DIFF
--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -150,7 +150,8 @@ bool sdcard_poll(void)
 
 bool sdcard_isFunctional(void)
 {
-    // sdcard_isFunctional is called from multiple places
+    // sdcard_isFunctional is called from multiple places, including the case of hardware implementation
+    // without a detect pin in which case sdcard_isInserted() always returns true.
     if (sdcardVTable) {
         return sdcardVTable->sdcard_isFunctional();
     } else {

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -1999,7 +1999,7 @@ static void cliSdInfo(char *cmdline)
         return;
     }
 
-    if (!sdcard_isInitialized()) {
+    if (!sdcard_isFunctional() || !sdcard_isInitialized()) {
         cliPrintLine("Startup failed");
         return;
     }

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -304,8 +304,13 @@ static void serializeSDCardSummaryReply(sbuf_t *dst)
     sbufWriteU8(dst, state);
     sbufWriteU8(dst, afatfs_getLastError());
     // Write free space and total space in kilobytes
-    sbufWriteU32(dst, afatfs_getContiguousFreeSpace() / 1024);
-    sbufWriteU32(dst, sdcard_getMetadata()->numBlocks / 2); // Block size is half a kilobyte
+    if (state == MSP_SDCARD_STATE_READY) {
+        sbufWriteU32(dst, afatfs_getContiguousFreeSpace() / 1024);
+        sbufWriteU32(dst, sdcard_getMetadata()->numBlocks / 2); // Block size is half a kilobyte
+    } else {
+        sbufWriteU32(dst, 0);
+        sbufWriteU32(dst, 0);
+    }
 #else
     sbufWriteU8(dst, 0);
     sbufWriteU8(dst, 0);


### PR DESCRIPTION
This surfaced as a byproduct of going VTable oriented SPI/SDIO dispatching.

Fixes: #6881.