### PR TITLE
Remove stale gyro cs defs from resource

### DIFF
--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -76,6 +76,4 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "USB_MSC_PIN",
     "SPI_PREINIT_IPU",
     "SPI_PREINIT_OPU",
-    "GYRO1_CS",
-    "GYRO2_CS",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -76,8 +76,6 @@ typedef enum {
     OWNER_USB_MSC_PIN,
     OWNER_SPI_PREINIT_IPU,
     OWNER_SPI_PREINIT_OPU,
-    OWNER_GYRO1_CS,
-    OWNER_GYRO2_CS,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 


### PR DESCRIPTION
Two defs, `GYRO1_CS` and `GYRO2_CS` were added by #5868, but these were bogus due to `GYRO_CS` being made `DEFW`.