### PR TITLE
OMNIBUSF4FW: Allow PC13 and PC14 for Omnibus F4 V6

### DIFF
--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -178,7 +178,7 @@
 
 #define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
 #define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
-#define TARGET_IO_PORTC (0xffff & ~(BIT(15)|BIT(14)|BIT(13)))
+#define TARGET_IO_PORTC (0xffff & ~(BIT(15)))
 #define TARGET_IO_PORTD BIT(2)
 
 #if defined(OMNIBUSF4FW) || defined(OMNIBUSF4FW1)


### PR DESCRIPTION
Omnibus F4 V6, which uses OMNIBUSF4FW target, use PC13 and PC14 for external SPI CS.