### PR TITLE
Add conditionals for receiver protocols

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_CRSF
 
 #include "build/build_config.h"
 #include "build/debug.h"

--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_SERIALRX_FPORT)
+#ifdef USE_SERIALRX_FPORT
 
 #include "build/debug.h"
 

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -31,7 +31,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_IBUS
 
 #include "pg/rx.h"
 

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -42,7 +42,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_JETIEXBUS
 
 #include "build/build_config.h"
 #include "build/debug.h"

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -24,7 +24,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_SBUS
 
 #include "build/debug.h"
 

--- a/src/main/rx/sbus_channels.c
+++ b/src/main/rx/sbus_channels.c
@@ -24,7 +24,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_SBUS
 
 #include "common/utils.h"
 

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -19,7 +19,8 @@
  */
 
 #include "platform.h"
-#ifdef USE_SERIAL_RX
+
+#ifdef USE_SERIALRX_SPEKTRUM
 
 #include <string.h>
 

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -24,7 +24,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_SUMD
 
 #include "common/crc.h"
 #include "common/utils.h"

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -30,7 +30,7 @@
 
 #include "platform.h"
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX_SUMH
 
 #include "common/utils.h"
 
@@ -46,8 +46,6 @@
 
 #include "rx/rx.h"
 #include "rx/sumh.h"
-
-// driver for SUMH receiver using UART2
 
 #define SUMH_BAUDRATE 115200
 

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -24,7 +24,7 @@
 
 #include "platform.h"
 
-#if defined(USE_SERIAL_RX) && defined(USE_SERIALRX_XBUS)
+#ifdef USE_SERIALRX_XBUS
 
 #include "common/crc.h"
 


### PR DESCRIPTION
Receiver protocol drivers did not have appropriate conditionals.

This prevented dropping receiver protocols save as much flash space as expected.

Saving values including those already had the correct conditionals:

| Protocol |Saving (B)| Note |
|-------|----|----|
|USE_SERIALRX_SPEKTRUM | 4912 | |
USE_SERIALRX_IBUS | 1500
USE_SERIALRX_SUMD | 856
USE_SERIALRX_SUMH | 268
USE_SERIALRX_XBUS  | 1348
USE_SERIALRX_SBUS | 1094
USE_SERIALRX_JETIEXBUS | 2384 | F4
USE_SERIALRX_CRSF | 3288 | F4
USE_SERIALRX_FPORT | 2016 | F4

Measure on F3 target (OMNIBUS) unless otherwise noted.
