### PR TITLE
Fix DEF_TIM_DMA_COND usage to including leading comma

### DIFF
--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -120,8 +120,8 @@
     IO_TAG(pin),                                                        \
     DEF_TIM_CHANNEL(CH_ ## chan),                                       \
     flags,                                                              \
-    (DEF_TIM_OUTPUT(CH_ ## chan) | out),                                \
-    DEF_TIM_DMA_COND(                                                   \
+    (DEF_TIM_OUTPUT(CH_ ## chan) | out)                                 \
+    DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_CHANNEL(TCH_## tim ## _ ## chan),                   \
         DEF_TIM_DMA_HANDLER(TCH_## tim ## _ ## chan)                    \
     )                                                                   \
@@ -169,12 +169,12 @@
     DEF_TIM_CHANNEL(CH_ ## chan),                                       \
     flags,                                                              \
     (DEF_TIM_OUTPUT(CH_ ## chan) | out),                                \
-    DEF_TIM_AF(TCH_## tim ## _ ## chan, pin),                           \
-    DEF_TIM_DMA_COND(                                                   \
+    DEF_TIM_AF(TCH_## tim ## _ ## chan, pin)                            \
+    DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_CHANNEL(TCH_## tim ## _ ## chan),                   \
         DEF_TIM_DMA_HANDLER(TCH_## tim ## _ ## chan)                    \
-    ),                                                                  \
-    DEF_TIM_DMA_COND(                                                   \
+    )                                                                   \
+    DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_CHANNEL(TCH_## tim ## _UP),                         \
         DEF_TIM_DMA_HANDLER(TCH_## tim ## _UP)                          \
     )                                                                   \
@@ -386,13 +386,13 @@
     DEF_TIM_CHANNEL(CH_ ## chan),                               \
     flags,                                                      \
     (DEF_TIM_OUTPUT(CH_ ## chan) | out),                        \
-    DEF_TIM_AF(TIM_ ## tim),                                    \
-    DEF_TIM_DMA_COND(                                           \
+    DEF_TIM_AF(TIM_ ## tim)                                     \
+    DEF_TIM_DMA_COND(/* add comma */ ,                          \
         DEF_TIM_DMA_STREAM(dmaopt, TCH_## tim ## _ ## chan),    \
         DEF_TIM_DMA_CHANNEL(dmaopt, TCH_## tim ## _ ## chan),   \
         DEF_TIM_DMA_HANDLER(dmaopt, TCH_## tim ## _ ## chan)    \
-    ),                                                          \
-    DEF_TIM_DMA_COND(                                           \
+    )                                                           \
+    DEF_TIM_DMA_COND(/* add comma */ ,                          \
         DEF_TIM_DMA_STREAM(0, TCH_## tim ## _UP),               \
         DEF_TIM_DMA_CHANNEL(0, TCH_## tim ## _UP),              \
         DEF_TIM_DMA_HANDLER(0, TCH_## tim ## _UP)               \
@@ -492,13 +492,13 @@
     DEF_TIM_CHANNEL(CH_ ## chan),                                       \
     flags,                                                              \
     (DEF_TIM_OUTPUT(CH_ ## chan) | out),                                \
-    DEF_TIM_AF(TCH_## tim ## _ ## chan, pin),                           \
-    DEF_TIM_DMA_COND(                                                   \
+    DEF_TIM_AF(TCH_## tim ## _ ## chan, pin)                            \
+    DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_STREAM(dmaopt, TCH_## tim ## _ ## chan),            \
         DEF_TIM_DMA_CHANNEL(dmaopt, TCH_## tim ## _ ## chan),           \
         DEF_TIM_DMA_HANDLER(dmaopt, TCH_## tim ## _ ## chan)            \
-    ),                                                                  \
-    DEF_TIM_DMA_COND(                                                   \
+    )                                                                   \
+    DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_STREAM(0, TCH_## tim ## _UP),                       \
         DEF_TIM_DMA_CHANNEL(0, TCH_## tim ## _UP),                      \
         DEF_TIM_DMA_HANDLER(0, TCH_## tim ## _UP)                       \


### PR DESCRIPTION
`dmaopt` field of `timerHardware_s` is a conditional on conjunction of `USE_DSHOT`, `USE_TRANSPONDER` and `USE_LED_STRIP`. However, the `DEF_TIM_DMA_COND` macro used to initialize this field does not allow all of these features to be turned off, due to the improper positioning of argument separation comma.

This PR fix this by prepending a comma to macro body `__VAR_ARGS__` of `DEF_TIM_DMA_COND`, and removing corresponding EOL commas from lines preceding the `DEF_TIM_DMA_COND` macro.

EDIT
To reproduce the issue this PR is addressing, undefine the three features from any F4/F7 targets.
```
#undef USE_DSHOT
#undef USE_LED_STRIP
#undef USE_TRANSPONDER
```
It will produce
```
In file included from ./src/main/drivers/timer_stm32f4xx.c:27:0:
./src/main/drivers/timer.h:34:1: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'typedef'
 typedef uint16_t captureCompare_t;        // 16 bit on both 103 and 303, just register access must be 32bit sometimes (use timCCR_t)
```