### PR TITLE
target/system_stm32f{4,7}xxx.c: Prevent signed and unsigned comparison warning

### DIFF
--- a/src/main/target/system_stm32f4xx.c
+++ b/src/main/target/system_stm32f4xx.c
@@ -505,7 +505,7 @@ void OverclockRebootIfNecessary(uint32_t overclockLevel)
   const pllConfig_t * const pll = overclockLevels + overclockLevel;
 
   // Reboot to adjust overclock frequency
-  if (SystemCoreClock != (pll->n / pll->p) * 1000000) {
+  if (SystemCoreClock != (pll->n / pll->p) * 1000000U) {
     currentOverclockLevel = overclockLevel;
     __disable_irq();
     NVIC_SystemReset();

--- a/src/main/target/system_stm32f7xx.c
+++ b/src/main/target/system_stm32f7xx.c
@@ -281,7 +281,7 @@ void OverclockRebootIfNecessary(uint32_t overclockLevel)
     const pllConfig_t * const pll = overclockLevels + overclockLevel;
 
     // Reboot to adjust overclock frequency
-    if (SystemCoreClock != (pll->n / pll->p) * 1000000) {
+    if (SystemCoreClock != (pll->n / pll->p) * 1000000U) {
         REQUEST_OVERCLOCK = REQUEST_OVERCLOCK_MAGIC_COOKIE;
         CURRENT_OVERCLOCK_LEVEL = overclockLevel;
         __disable_irq();


### PR DESCRIPTION
This only comes up when building for debugging (`DEBUG=GDB`).
