### PR TITLE
Add support for Nucleo-F303RE

### DIFF
--- a/lib/main/STM32_USB-FS-Device_Driver/src/usb_core.c
+++ b/lib/main/STM32_USB-FS-Device_Driver/src/usb_core.c
@@ -46,6 +46,8 @@
 #define StatusInfo0 StatusInfo.bw.bb1 /* Reverse bb0 & bb1 */
 #define StatusInfo1 StatusInfo.bw.bb0
 
+extern uint16_t debug[4];
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 uint16_t_uint8_t StatusInfo;
@@ -580,6 +582,7 @@ void NoData_Setup0(void)
           || (pInformation->Current_Configuration != 0))
         /* Device Address should be 127 or less*/
       {
+        debug[0] = 11;
         ControlState = STALLED;
         goto exit_NoData_Setup0;
       }
@@ -660,6 +663,7 @@ void NoData_Setup0(void)
 
   if (Result != USB_SUCCESS)
   {
+    debug[0] = 12;
     ControlState = STALLED;
     goto exit_NoData_Setup0;
   }
@@ -812,6 +816,9 @@ void Data_Setup0(void)
   if ((Result == USB_UNSUPPORT) || (pInformation->Ctrl_Info.Usb_wLength == 0))
   {
     /* Unsupported request */
+    debug[0] = 13;
+    debug[1] = Result;
+    debug[2] = 
     pInformation->ControlState = STALLED;
     return;
   }
@@ -924,11 +931,13 @@ uint8_t In0_Process(void)
       pUser_Standard_Requests->User_SetDeviceAddress();
     }
     (*pProperty->Process_Status_IN)();
+    debug[0] = 14;
     ControlState = STALLED;
   }
 
   else
   {
+    debug[0] = 15;
     ControlState = STALLED;
   }
 
@@ -951,6 +960,7 @@ uint8_t Out0_Process(void)
   if ((ControlState == IN_DATA) || (ControlState == LAST_IN_DATA))
   {
     /* host aborts the transfer before finish */
+    debug[0] = 16;
     ControlState = STALLED;
   }
   else if ((ControlState == OUT_DATA) || (ControlState == LAST_OUT_DATA))
@@ -962,6 +972,7 @@ uint8_t Out0_Process(void)
   else if (ControlState == WAIT_STATUS_OUT)
   {
     (*pProperty->Process_Status_OUT)();
+    debug[0] = 17;
     ControlState = STALLED;
   }
 
@@ -969,6 +980,7 @@ uint8_t Out0_Process(void)
   /* Unexpect state, STALL the endpoint */
   else
   {
+    debug[0] = 18;
     ControlState = STALLED;
   }
 

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -220,11 +220,12 @@ serialPort_t *usbVcpOpen(void)
 {
     vcpPort_t *s;
 
+    IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
+    IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
+
 #if defined(STM32F4)
     usbGenerateDisconnectPulse();
 
-    IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
-    IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
 #ifdef USE_USB_CDC_HID
     if (usbDevConfig()->type == COMPOSITE) {
         USBD_Init(&USB_OTG_dev, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_HID_CDC_cb, &USR_cb);
@@ -237,8 +238,6 @@ serialPort_t *usbVcpOpen(void)
 #elif defined(STM32F7)
     usbGenerateDisconnectPulse();
 
-    IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
-    IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
     /* Init Device Library */
     USBD_Init(&USBD_Device, &VCP_Desc, 0);
 

--- a/src/main/target/NUCLEOF303RE/config.c
+++ b/src/main/target/NUCLEOF303RE/config.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "common/axis.h"
+
+#include "drivers/sensor.h"
+#include "drivers/compass/compass.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "pg/rx.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "telemetry/telemetry.h"
+
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
+#include "sensors/barometer.h"
+
+#include "config/feature.h"
+
+#include "fc/config.h"
+
+#ifdef USE_TARGET_CONFIG
+
+#include "config_helper.h"
+
+#define GPS_UART                            SERIAL_PORT_USART3
+
+#define TELEMETRY_UART                      SERIAL_PORT_UART5
+#define TELEMETRY_PROVIDER_DEFAULT          FUNCTION_TELEMETRY_SMARTPORT
+
+static targetSerialPortFunction_t targetSerialPortFunction[] = {
+    { SERIAL_PORT_USART1, FUNCTION_MSP },
+    { TELEMETRY_UART,     TELEMETRY_PROVIDER_DEFAULT },
+    { GPS_UART,           FUNCTION_GPS },
+};
+
+void targetConfiguration(void)
+{
+    barometerConfigMutable()->baro_hardware = BARO_DEFAULT;
+    compassConfigMutable()->mag_hardware = MAG_DEFAULT;
+    targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+    telemetryConfigMutable()->halfDuplex = true;
+}
+#endif

--- a/src/main/target/NUCLEOF303RE/target.c
+++ b/src/main/target/NUCLEOF303RE/target.c
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+#include "drivers/dma.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM15, CH2, PA3,  TIM_USE_PPM,         0), // PWM1 / PPM / UART2 RX
+    DEF_TIM(TIM15, CH1, PA2,  TIM_USE_PWM,         0), // PWM2
+
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,       0), // ESC1
+
+#ifdef USE_DSHOT
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR,       0), // ESC2
+#else
+    DEF_TIM(TIM3,  CH2, PC7,  TIM_USE_MOTOR,       0), // ESC2
+#endif
+
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,       0), // ESC3
+
+#ifdef USE_DSHOT
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_MOTOR,       0), // ESC4
+#else
+    DEF_TIM(TIM3,  CH1, PC6,  TIM_USE_MOTOR,       0), // ESC4
+#endif
+
+#ifndef USE_DSHOT
+    // with DSHOT TIM8 is used for DSHOT and cannot be used for PWM
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR,       0), // ESC5
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MOTOR,       0), // ESC6
+#endif
+
+    DEF_TIM(TIM2,  CH3, PB10, TIM_USE_MOTOR,       0), // PWM3 - PB10 - *TIM2_CH3, UART3_TX (AF7)
+    DEF_TIM(TIM2,  CH4, PB11, TIM_USE_MOTOR,       0), // PWM4 - PB11 - *TIM2_CH4, UART3_RX (AF7)
+
+    // with DSHOT DMA1-CH3 conflicts with TIM3_CH4 / ESC1.
+    DEF_TIM(TIM16, CH1, PB8,  TIM_USE_TRANSPONDER, 0),
+
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED,         0),
+};

--- a/src/main/target/NUCLEOF303RE/target.h
+++ b/src/main/target/NUCLEOF303RE/target.h
@@ -1,0 +1,212 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "F3RE"
+#define USBD_PRODUCT_STRING     "Nucleo-F303RE"
+#define USE_TARGET_CONFIG
+
+// Removed to make the firmware fit into flash (in descending order of priority):
+// NOTE: Don't disable USE_GYRO_OVERFLOW_CHECK - board has ICM20602 gyro
+//#undef USE_GYRO_OVERFLOW_CHECK
+//#undef USE_GYRO_LPF2
+
+#undef USE_ITERM_RELAX
+#undef USE_RC_SMOOTHING_FILTER
+
+#undef USE_HUFFMAN
+#undef USE_PINIO
+#undef USE_PINIOBOX
+
+#undef USE_TELEMETRY_HOTT
+#undef USE_TELEMETRY_MAVLINK
+#undef USE_TELEMETRY_LTM
+#undef USE_SERIALRX_XBUS
+#undef USE_SERIALRX_SUMH
+#undef USE_PWM
+
+#undef USE_BOARD_INFO
+#undef USE_EXTENDED_CMS_MENUS
+#undef USE_RTC_TIME
+#undef USE_RX_MSP
+#undef USE_ESC_SENSOR_INFO
+
+#define LED0_PIN                PB9
+#define LED1_PIN                PB2
+
+#define USE_BEEPER
+#define BEEPER_PIN              PC15
+#define BEEPER_INVERTED
+
+#define USE_EXTI
+#define USE_GYRO_1_EXTI         PC13
+//#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define USE_MAG_DATA_READY_SIGNAL
+#define ENSURE_MAG_DATA_READY_IS_HIGH
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6500
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6500
+
+#define GYRO_1_CS_PIN           NONE
+#define ACC_1_CS_PIN            NONE
+#define GYRO_1_ALIGN            CW0_DEG
+#define ACC_1_ALIGN             CW0_DEG
+
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+//#define USE_SOFTSERIAL1
+//#define USE_SOFTSERIAL2
+//#define SERIAL_PORT_COUNT       8
+#define SERIAL_PORT_COUNT       6
+
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define UART3_TX_PIN            PB10
+#define UART3_RX_PIN            PB11
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  PA3  // (HARDARE=0,PPM)
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1 // MPU
+#define USE_SPI_DEVICE_2 // SDCard
+#define USE_SPI_DEVICE_3 // External (MAX7456 & RTC6705)
+
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define SPI3_NSS_PIN            PA15
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#if 0
+#define USE_VTX_RTC6705
+#define VTX_RTC6705_OPTIONAL    // VTX/OSD board is OPTIONAL
+
+#define RTC6705_CS_PIN          PF4
+#define RTC6705_SPI_INSTANCE    SPI3
+#define RTC6705_POWER_PIN       PC3
+
+#define USE_RTC6705_CLK_HACK
+#define RTC6705_CLK_PIN         SPI3_SCK_PIN
+#endif
+
+#if 0
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PA15
+
+#define MAX7456_DMA_CHANNEL_TX              DMA2_Channel2
+#define MAX7456_DMA_CHANNEL_RX              DMA2_Channel1
+#define MAX7456_DMA_IRQ_HANDLER_ID          DMA2_CH1_HANDLER
+
+#define SPI_SHARED_MAX7456_AND_RTC6705
+#endif
+
+#define USE_SDCARD
+
+#define SDCARD_DETECT_INVERTED
+#define SDCARD_DETECT_PIN                   PC14
+
+#define SDCARD_SPI_INSTANCE                 SPI2
+#define SDCARD_SPI_CS_PIN                   SPI2_NSS_PIN
+
+// Note, this is the same DMA channel as UART1_RX. Luckily we don't use DMA for USART Rx.
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Channel5
+
+#define MPU6500_CS_PIN                   SPI1_NSS_PIN
+#define MPU6500_SPI_INSTANCE             SPI1
+
+#define CURRENT_METER_SCALE_DEFAULT 300
+
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+#define VBAT_ADC_PIN            PC1
+#define CURRENT_METER_ADC_PIN   PC2
+#define RSSI_ADC_PIN            PC0
+
+#define USE_LED_STRIP_ON_DMA1_CHANNEL2
+#define WS2811_PIN                      PA8
+#define WS2811_TIMER                    TIM1
+#define WS2811_DMA_CHANNEL              DMA1_Channel2
+#define WS2811_IRQ                      DMA1_Channel2_IRQn
+#define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+#define WS2811_TIMER_GPIO_AF            GPIO_AF_6
+
+#define USE_TRANSPONDER
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define USE_OSD
+
+#define DEFAULT_RX_FEATURE                  FEATURE_RX_SERIAL
+#define DEFAULT_FEATURES                    (FEATURE_TRANSPONDER | FEATURE_RSSI_ADC | FEATURE_TELEMETRY | FEATURE_OSD | FEATURE_LED_STRIP)
+
+#define SERIALRX_UART                       SERIAL_PORT_USART2
+#define SERIALRX_PROVIDER                   SERIALRX_SBUS
+
+#define USE_BUTTONS // Physically located on the optional OSD/VTX board.
+#define BUTTON_A_PIN                        PD2
+
+// FIXME While it's possible to use the button on the OSD/VTX board for binding enabling it here will break binding unless you have the OSD/VTX connected.
+//#define BINDPLUG_PIN                        BUTTON_A_PIN
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+// IO - assuming 303 in 144pin package, TODO
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+#define TARGET_IO_PORTF (BIT(0)|BIT(1)|BIT(4))
+
+#define USABLE_TIMER_CHANNEL_COUNT 12 // 2xPPM, 6xPWM, UART3 RX/TX, LED Strip, IR.
+#define USED_TIMERS  (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(8) | TIM_N(15) | TIM_N(16))

--- a/src/main/target/NUCLEOF303RE/target.mk
+++ b/src/main/target/NUCLEOF303RE/target.mk
@@ -1,0 +1,12 @@
+F3_TARGETS  += $(TARGET)
+FEATURES    = VCP SDCARD_SPI
+FLASH_SIZE  = 512
+LD_SCRIPT   = $(ROOT)/src/main/target/$(TARGET)/stm32_flash_f303_512k.ld
+
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/max7456.c \
+            drivers/vtx_rtc6705.c

--- a/src/main/target/link/stm32_flash_f303_512k.ld
+++ b/src/main/target/link/stm32_flash_f303_512k.ld
@@ -1,0 +1,28 @@
+/*
+*****************************************************************************
+**
+**  File        : stm32_flash.ld
+**
+**  Abstract    : Linker script for STM32F303xD/E Device
+**                FLASH 512KByte
+**                SRAM   64KByte
+**                CCM    16KByte
+**
+*****************************************************************************
+*/
+
+/* Specify the memory areas. */
+MEMORY
+{
+    FLASH (rx)        : ORIGIN = 0x08000000, LENGTH = 508K
+    FLASH_CONFIG (r)  : ORIGIN = 0x0807F000, LENGTH = 4K
+
+    RAM (xrw)         : ORIGIN = 0x20000000, LENGTH = 64K
+    CCM (xrw)         : ORIGIN = 0x10000000, LENGTH = 16K
+    MEMORY_B1 (rx)    : ORIGIN = 0x60000000, LENGTH = 0K
+}
+
+REGION_ALIAS("STACKRAM", CCM)
+REGION_ALIAS("FASTRAM", CCM)
+
+INCLUDE "stm32_flash.ld"


### PR DESCRIPTION
I'm stumped and need some help.

As using a debugger with F303CC targets is not an easy task, I thought a board with F303RE which has  512K flash would be a nice generic platform to use the debugger with F3 code.

It builds and runs, but USB VCP is badly broken.
When USB module receives SET_ADDRESS request from a host, `Data_Setup0` in `lib/main/STM32_USB-FS-Device_Driver/src/usb_core.c` detects unsupported request (debug[0] = 13).
`pInformation` looks like this:
```
(gdb) p *pInformation
$7 = {USBbmRequestType = 237 '\355', USBbRequest = 237 '\355',
USBwValues = {
    w = 57625, bw = {bb1 = 25 '\031', bb0 = 225 '\341'}}, USBwIndexs = {
    w = 32141, bw = {bb1 = 141 '\215', bb0 = 125 '}'}}, USBwLengths = {
    w = 10696, bw = {bb1 = 200 '\310', bb0 = 41 ')'}},
  ControlState = 1 '\001', Current_Feature = 192 '\300',
  Current_Configuration = 0 '\000', Current_Interface = 0 '\000',
  Current_AlternateSetting = 0 '\000', Ctrl_Info = {Usb_wLength = 0,
    Usb_wOffset = 0, PacketSize = 0, CopyData = 0x0}}
(gdb) p pInformation
$8 = (DEVICE_INFO *) 0x200093b0 <Device_Info>
```
which is badly broken.

A logic analyzer shows bmRequestType = 0, bRequest = 5 (SET_ADDRESS)…

Note that the USB function block and external connection (including pull-up on D+) is working, as the board goes into DFU and can be flashed via USB.

Any help & comments are appreciated.