### PR TITLE
Move USE_ITERM_RELAX up to prevent unused warning of applyAbsoluteControl

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -838,6 +838,7 @@ void FAST_CODE applySmartFeedforward(int axis)
 }
 #endif // USE_SMART_FEEDFORWARD
 
+#if defined(USE_ITERM_RELAX)
 #if defined(USE_ABSOLUTE_CONTROL)
 STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRate, const bool itermRelaxIsEnabled,
     const float setpointLpf, const float setpointHpf,
@@ -880,7 +881,6 @@ STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRat
 }
 #endif
 
-#if defined(USE_ITERM_RELAX)
 STATIC_UNIT_TESTED void applyItermRelax(const int axis, const float iterm,
     const float gyroRate, float *itermErrorRate, float *currentPidSetpoint)
 {


### PR DESCRIPTION
`USE_ABSOLUTE_CONTROL` without `USE_ITERM_RELAX` generates
```
./src/main/flight/pid.c:842:13: error: 'applyAbsoluteControl' defined but not used [-Werror=unused-function]
```

What is the correct relationship between `USE_ITERM_RELAX` and `USE_ABSOLUTE_CONTROL`?

@joelucid ?