### PR TITLE
Fix overlooked USE_xxx case of ADC

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -629,7 +629,7 @@ const clivalue_t valueTable[] = {
 #endif
 
 // PG_ADC_CONFIG
-#if defined(ADC)
+#if defined(USE_ADC)
     { "adc_device",                 VAR_INT8   | MASTER_VALUE, .config.minmax = { 0, ADCDEV_COUNT }, PG_ADC_CONFIG, offsetof(adcConfig_t, device) },
 #endif
 


### PR DESCRIPTION
Was causing `printValuePointer` to hard fault on uninitialized pg when `USE_ADC` is not defined.