### PR TITLE
Dterm relaxation based on setpoint speed

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -148,6 +148,7 @@ typedef struct pidProfile_s {
     uint8_t abs_control_gain;               // How strongly should the absolute accumulated error be corrected for
     uint8_t abs_control_limit;              // Limit to the correction
     uint8_t abs_control_error_limit;        // Limit to the accumulated error
+    uint16_t dterm_relax_threshold;         // The setpoint speed above which D term is completely attenuated
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, MAX_PROFILE_COUNT, pidProfiles);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -864,6 +864,7 @@ const clivalue_t valueTable[] = {
     { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },
     { "pidsum_limit_yaw",           VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimitYaw) },
     { "yaw_lowpass_hz",             VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lowpass_hz) },
+    { "dterm_relax_threshold",      VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 32000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_relax_threshold) },
 
 #if defined(USE_THROTTLE_BOOST)
     { "throttle_boost",             VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost) },


### PR DESCRIPTION
> This PR is not intended for merge but rather as a point for discussion

Now that we have nicely separated feedforward (depending on setpoint only) and Dterm (depending on gyro only), it is easier to observe the effects of each one.

It is known that Dterm from gyro (aka from measurement) takes the negative derivative of the gyro. As such, D always opposes any change. Here's a classic trace of a roll:

![image](https://user-images.githubusercontent.com/9365881/46823922-2a1bfb00-cd98-11e8-92c7-d61af1a519ef.png)


It is clearly visible that although P and F are acting to initiate the roll, D opposes it. This is not a bad thing - it is not like there are two separate motors that will work against each other and waste energy in the process. The PID Sum is what matters.

Yet, looking at the graph one cannot help but ask "What if D does not fight the movement?"

What I present here is a simple logic that attenuates Dterm whenever there is rapid movement of the setpoint. Here's what it looks like:

![image](https://user-images.githubusercontent.com/9365881/46824052-72d3b400-cd98-11e8-8a63-500ef868a1f9.png)


Note how when the setpoint is moving quickly (same as where FF is high) Dterm is diminished.

This functionality is similar in concept to the Iterm relaxation, thus the name - Dterm relaxation. The actual attenuation is based on the derivative of the setpoint - same as with the feedforward (but does not take into account the ff transition).

The setpoint, as we know, represents the desired angular velocity [deg/s]. The derivative of that is the speed of the setpoint or the angular acceleration of the craft [deg/s<sup>2</sup>]. The new parameter `dterm_relax_threshold` represents the angular acceleration (in deg/s<sup>2</sup>) above which the Dterm would be fully attenuated (Dterm=0). Below that threshold, Dterm is scaled linearly up to its full value when the acceleration is 0 (setpoint not moving).
The attenuation is only applied if Dterm is acting in opposite direction to the setpoint movement. If Dterm would work in the same direction it is not attenuated.

The superficial hope is that it can produce sharper response while preserving the dampening effects of D (slowing down the end of moves, opposing propwash, etc.).

So far my tests are inconclusive. I've only had few LOS flights. I experimented with several threshold values and settled at around 8000 deg/s<sup>2</sup> which seems to attenuate without zeroing the D too aggressively. Obviously this setting will depend on the rates. Mine have maximum at about 720 deg/s.

One thing is certain: this modification requires retuning. Without the opposition of D, the P and F that we normally use, easily overshoot. Also D might need to be rised. It certainly requires some rethinking of tuning habits.

This whole idea might be total nonsense. It is unclear to me at this point if it can have any benefits.

I'll be very happy to hear everyone's opinion on this - the general idea, not just this specific implementation. Testing and experimentation are welcome!