### PR TITLE
Increase fpv_mix_degrees maximum value

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -609,7 +609,7 @@ const clivalue_t valueTable[] = {
     { "rc_smoothing_derivative_type",VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RC_SMOOTHING_DERIVATIVE_TYPE }, PG_RX_CONFIG, offsetof(rxConfig_t, rc_smoothing_derivative_type) },
 #endif // USE_RC_SMOOTHING_FILTER
 
-    { "fpv_mix_degrees",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 50 }, PG_RX_CONFIG, offsetof(rxConfig_t, fpvCamAngleDegrees) },
+    { "fpv_mix_degrees",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 90 }, PG_RX_CONFIG, offsetof(rxConfig_t, fpvCamAngleDegrees) },
     { "max_aux_channels",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, MAX_AUX_CHANNEL_COUNT }, PG_RX_CONFIG, offsetof(rxConfig_t, max_aux_channel) },
 #ifdef USE_SERIAL_RX
     { "serialrx_provider",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SERIAL_RX }, PG_RX_CONFIG, offsetof(rxConfig_t, serialrx_provider) },


### PR DESCRIPTION
I've always been flying with fpv_mix_degrees enabled and matching the cam angle on my quad. It just felt more natural to me. 

Now, I've been flying with more and more aggressive angle as I improved my racing abilities up to a point where 50 degrees compensation is not enough.

This fix is nothing complicated. It's simply increasing the max limit from 50 to 90 degree. I dont expect to ever need or use 90 degree but figured that this best covers all use cases I can think of and cannot think of for now.