### PR TITLE
Fix initial stick arming when gyro_cal_on_first_arm is used

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -216,7 +216,8 @@ void processRcStickPositions()
             if (!ARMING_FLAG(ARMED)) {
                 // Arm via YAW
                 tryArm();
-                if (isTryingToArm()) {
+                if (isTryingToArm() ||
+                    ((getArmingDisableFlags() == ARMING_DISABLED_CALIBRATING) && armingConfig()->gyro_cal_on_first_arm)) {
                     doNotRepeat = false;
                 }
             } else {


### PR DESCRIPTION
Previously the initial arming attempt would initiate the gyro calibration but then fail because gyro calibration was underway. The user is confused as they're holding the arming sticks but nothing is happening. This always forced the user to release the arming stick command and then perform a second arming stick command to actually arm.

After the fix the initial arming will proceed as long as the pilot holds the arming stick command through the duration of the gyro calibration (1.25 seconds by default). This seems normal to the user as they're waiting for the motors to start (or at least the arming beeps) before releasing the sticks anyway.

This problem has existed for a long time but is relatively benign (just annoying/confusing) so I'm not sure it's worth applying to 3.5 maintenance.