### PR TITLE
F7: Remove txIrq from uartHardware_s

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -145,7 +145,6 @@ typedef struct uartHardware_s {
     uint8_t af;
 #endif
 #if defined(STM32F7)
-    uint8_t txIrq;
     uint8_t rxIrq;
 #else
     uint8_t irqn;

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -71,7 +71,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART1_AHB1_PERIPHERALS,
 #endif
         .rcc_apb2 = RCC_APB2(USART1),
-        .txIrq = DMA2_ST7_HANDLER,
         .rxIrq = USART1_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1
@@ -101,7 +100,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART2_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(USART2),
-        .txIrq = DMA1_ST6_HANDLER,
         .rxIrq = USART2_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2
@@ -133,7 +131,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART3_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(USART3),
-        .txIrq = DMA1_ST3_HANDLER,
         .rxIrq = USART3_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3
@@ -171,7 +168,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART4_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART4),
-        .txIrq = DMA1_ST4_HANDLER,
         .rxIrq = UART4_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4
@@ -209,7 +205,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART5_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART5),
-        .txIrq = DMA1_ST7_HANDLER,
         .rxIrq = UART5_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART5
@@ -239,7 +234,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART6_AHB1_PERIPHERALS,
 #endif
         .rcc_apb2 = RCC_APB2(USART6),
-        .txIrq = DMA2_ST6_HANDLER,
         .rxIrq = USART6_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6
@@ -277,7 +271,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART7_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART7),
-        .txIrq = DMA1_ST1_HANDLER,
         .rxIrq = UART7_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART7_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART7
@@ -305,7 +298,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART8_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART8),
-        .txIrq = DMA1_ST0_HANDLER,
         .rxIrq = UART8_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART8_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART8
@@ -432,8 +424,9 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         s->txDMAStream = hardware->txDMAStream;
 
         // DMA TX Interrupt
-        dmaInit(hardware->txIrq, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        dmaSetHandler(hardware->txIrq, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
+        dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
+        dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
+        dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
     }
 
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->TDR;


### PR DESCRIPTION
It was not IRQ at all by itself, but a dmaIdentifier_e for TX side DMA, which can be obtained by dmaGetIdentifier.

Slightly increases genericness of the code toward configurable DMA channel specifier.