### PR TITLE
Reinstate UART TX DMA for F7 (HAL driver)

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -171,11 +171,7 @@ extern uartDevice_t *uartDevmap[];
 
 extern const struct serialPortVTable uartVTable[];
 
-#ifdef USE_HAL_DRIVER
-void uartStartTxDMA(uartPort_t *s);
-#else
 void uartTryStartTxDMA(uartPort_t *s);
-#endif
 
 uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, portOptions_e options);
 

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -376,12 +376,7 @@ void uartIrqHandler(uartPort_t *s)
 
 static void handleUsartTxDma(uartPort_t *s)
 {
-    if (s->port.txBufferHead != s->port.txBufferTail)
-        uartStartTxDMA(s);
-    else
-    {
-        s->txDMAEmpty = true;
-    }
+    uartTryStartTxDMA(s);
 }
 
 void dmaIRQHandler(dmaChannelDescriptor_t* descriptor)


### PR DESCRIPTION
This is a long overdue F7 (HAL driver) version of the "F4 Fix UART TX DMA corruption #3349", which was merged 15 months ago. (In fact, #3349 was based on #1968 and #1991, so it has been almost 2 years since the problem was first reported and investigated.)

This F7 (HAL) version has been tested with Omnibus F7 V2 with UART1 against USB-Serial adapter using CLI and LTM over a terminal emulator on a host PC. It also has been tested with configurator MSP over the serial running gyro + acc graph display for 15 minutes without a single packet error.

The TX DMA is not actually deployed for any target with this PR; it should wait until per port run time DMA enable/disable facility is implemented.
