### PR TITLE
FLASH: Use USE_FLASH instead of USE_FLASHFS to protect flash pg

### DIFF
--- a/src/main/pg/flash.c
+++ b/src/main/pg/flash.c
@@ -23,7 +23,7 @@
 
 #include "platform.h"
 
-#ifdef USE_FLASHFS
+#ifdef USE_FLASH
 
 #include "drivers/bus_spi.h"
 #include "drivers/io.h"


### PR DESCRIPTION
Fixes #6963