### PR TITLE
OSD: Protect ESC stat max temp by USE_ESC_SENSOR

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1556,6 +1556,7 @@ static void osdShowStats(uint16_t endBatteryVoltage)
         osdDisplayStatisticLabel(top++, "MAX G-FORCE", buff);
     }
 
+#ifdef USE_ESC_SENSOR
     if (osdStatGetState(OSD_STAT_MAX_ESC_TEMP)) {
         tfp_sprintf(buff, "%3d%c", osdConvertTemperatureToSelectedUnit(stats.max_esc_temp * 10) / 10, osdGetTemperatureSymbolForSelectedUnit());
         osdDisplayStatisticLabel(top++, "MAX ESC TEMP", buff);
@@ -1565,6 +1566,7 @@ static void osdShowStats(uint16_t endBatteryVoltage)
         itoa(stats.max_esc_rpm, buff, 10);
         osdDisplayStatisticLabel(top++, "MAX ESC RPM", buff);
     }
+#endif
 
 }
 


### PR DESCRIPTION
Fixes #6964 