### PR TITLE
Fix OSD artificial horizon division by zero

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -712,7 +712,10 @@ static bool osdDrawSingleElement(uint8_t item)
             int pitchAngle = constrain(attitude.values.pitch, -maxPitch, maxPitch);
             // Convert pitchAngle to y compensation value
             // (maxPitch / 25) divisor matches previous settings of fixed divisor of 8 and fixed max AHI pitch angle of 20.0 degrees
-            pitchAngle = ((pitchAngle * 25) / maxPitch) - 41; // 41 = 4 * AH_SYMBOL_COUNT + 5
+            if (maxPitch > 0) {
+                pitchAngle = ((pitchAngle * 25) / maxPitch);
+            }
+            pitchAngle -= 41; // 41 = 4 * AH_SYMBOL_COUNT + 5
 
             for (int x = -4; x <= 4; x++) {
                 const int y = ((-rollAngle * x) / 64) - pitchAngle;


### PR DESCRIPTION
If `osd_ah_max_pit` was set to zero there would be a divide by zero error in the calculations for the OSD artificial horizon. Using zero for `osd_ah_max_pit` is a valid use-case to disable the vertical pitch component in the artificial horizon so we can't simply change the parameter range.
