### PR TITLE
Prevent MOTOR_STOP and auto-disarm for stick arming when GPS Rescue is active

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -675,6 +675,7 @@ bool processRx(timeUs_t currentTimeUs)
         && !STATE(FIXED_WING)
         && !featureIsEnabled(FEATURE_3D)
         && !airmodeIsEnabled()
+        && !FLIGHT_MODE(GPS_RESCUE_MODE)  // disable auto-disarm when GPS Rescue is active
     ) {
         if (isUsingSticksForArming()) {
             if (throttleStatus == THROTTLE_LOW) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -851,6 +851,7 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensa
         && ARMING_FLAG(ARMED)
         && !featureIsEnabled(FEATURE_3D)
         && !airmodeEnabled
+        && !FLIGHT_MODE(GPS_RESCUE_MODE)   // disable motor_stop while GPS Rescue is active
         && (rcData[THROTTLE] < rxConfig()->mincheck)) {
         // motor_stop handling
         applyMotorStop();


### PR DESCRIPTION
Fixes #6969 

The MOTOR_STOP logic is designed to stop the motors if:
1. MOTOR_STOP feature is enabled
2. Airmode is disabled
3. Throttle is at minimum

The problem is that this also applied during GPS Rescue and if the pilot had these conditions the motors would stop. Changed to disable MOTOR_STOP while GPS Rescue is active.

Also if stick-arming is used, the MOTOR_STOP logic also will auto-disarm after 5 seconds (`auto_disarm_delay`). Disable this also when GPS Rescue is active.

Needs testing.