### PR TITLE
fix incorrect throttle offset in airmode

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -840,8 +840,7 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensa
         }
     } else {
         if (isAirmodeActive() || throttle > 0.5f) {  // Only automatically adjust throttle when airmode enabled. Airmode logic is always active on high throttle
-            const float throttleLimitOffset = motorMixRange / 2.0f;
-            throttle = constrainf(throttle, 0.0f + throttleLimitOffset, 1.0f - throttleLimitOffset);
+            throttle = constrainf(throttle, -motorMixMin, 1.0f - motorMixMax);
         }
     }
 


### PR DESCRIPTION
In low throttle and max throttle situations airmode is supposed to shift throttle up or down so all motors create the requested amount of thrust.
At first glance motorMixRange / 2 seems to be the correct offset, but unfortunately it is not and here is why:

Ascii art is supposed to be a quad facing north and the numbers represent thrust.
Throttle is at zero.

Let's start rolling... Here's the motor thrust distribution for a roll to the right:
```
roll
+1 -1
+1 -1
```

Now we have:
```
motorMixMin = -1
motorMixMax = +1
motorMixRange = 2
throttleLimitOffset = 1
```

=> Throttle will be shifted from 0 to 1 and motors will output correct values:
output:
```
2 0
2 0
```


Let's add yaw...
```
roll    yaw    mix
+1 -1	-1 +1	0  0
+1 -1	+1 -1	2 -2
```

Now we have:
```
motorMixMin = -2
motorMixMax = +2
motorMixRange = 4
throttleLimitOffset = 2
```

=> Throttle will be shifted from 0 to 2 and motors will output correct values:
```
2 2
4 0
```

Everything is still correct, but now let's add some pitch backward:
```
roll    yaw     pitch   mix
+1 -1	-1 +1	+1 +1	+1 +1
+1 -1	+1 -1	-1 -1	+1 -3
```

Now we have:
```
motorMixMin = -3
motorMixMax = +1
motorMixRange = 4
throttleLimitOffset = 2
```

=> Throttle will be shifted from 0 to 2 and motors will output wrong values:
```
3 3
3 0
```

The correct shift would be 3 in order to keep the difference between lowest and highest thrust and the correct output should be:
```
4 4
4 0
```

Same acceleration in all 3 axis is actually the worst case scenario but it actually means that the motors to the left and the front right motor create 33% less thrust, than they should. This fix should reduce propwash in low throttle situations like this.

The other extreme scenario would be the opposite mix:
```
-1 -1
-1 +3
```
After a shift of 2 output currently is:
```
1 1
1 5
```

Now all 4 motors create more thrust, than they should, but at least the difference between min and max stays correct.
Still it would take a shorter time to reach the desired thrust difference, if only the bottom right motor would accelerate.