### PR TITLE
Gryro configuration parameters cleanup

### DIFF
--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -77,24 +77,6 @@ ioTag_t preinitIPUList[SPI_PREINIT_IPU_COUNT] = {
 #ifdef GYRO_2_CS_PIN
     IO_TAG(GYRO_2_CS_PIN),
 #endif
-#ifdef MPU6000_CS_PIN
-    IO_TAG(MPU6000_CS_PIN),
-#endif
-#ifdef MPU6500_CS_PIN
-    IO_TAG(MPU6500_CS_PIN),
-#endif
-#ifdef MPU9250_CS_PIN
-    IO_TAG(MPU9250_CS_PIN),
-#endif
-#ifdef ICM20649_CS_PIN
-    IO_TAG(ICM20649_CS_PIN),
-#endif
-#ifdef ICM20689_CS_PIN
-    IO_TAG(ICM20689_CS_PIN),
-#endif
-#ifdef BMI160_CS_PIN
-    IO_TAG(BMI160_CS_PIN),
-#endif
 #ifdef L3GD20_CS_PIN
     IO_TAG(L3GD20_CS_PIN),
 #endif

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -157,9 +157,6 @@ retry:
         acc_params.useFifo = false;
         acc_params.dataRate = 800; // unused currently
         if (adxl345Detect(&acc_params, dev)) {
-#ifdef ACC_ADXL345_ALIGN
-            dev->accAlign = ACC_ADXL345_ALIGN;
-#endif
             accHardware = ACC_ADXL345;
             break;
         }
@@ -169,9 +166,6 @@ retry:
 #ifdef USE_ACC_LSM303DLHC
     case ACC_LSM303DLHC:
         if (lsm303dlhcAccDetect(dev)) {
-#ifdef ACC_LSM303DLHC_ALIGN
-            dev->accAlign = ACC_LSM303DLHC_ALIGN;
-#endif
             accHardware = ACC_LSM303DLHC;
             break;
         }
@@ -181,9 +175,6 @@ retry:
 #ifdef USE_ACC_MPU6050
     case ACC_MPU6050: // MPU6050
         if (mpu6050AccDetect(dev)) {
-#ifdef ACC_MPU6050_ALIGN
-            dev->accAlign = ACC_MPU6050_ALIGN;
-#endif
             accHardware = ACC_MPU6050;
             break;
         }
@@ -193,9 +184,6 @@ retry:
 #ifdef USE_ACC_MMA8452
     case ACC_MMA8452: // MMA8452
         if (mma8452Detect(dev)) {
-#ifdef ACC_MMA8452_ALIGN
-            dev->accAlign = ACC_MMA8452_ALIGN;
-#endif
             accHardware = ACC_MMA8452;
             break;
         }
@@ -205,9 +193,6 @@ retry:
 #ifdef USE_ACC_BMA280
     case ACC_BMA280: // BMA280
         if (bma280Detect(dev)) {
-#ifdef ACC_BMA280_ALIGN
-            dev->accAlign = ACC_BMA280_ALIGN;
-#endif
             accHardware = ACC_BMA280;
             break;
         }
@@ -217,9 +202,6 @@ retry:
 #ifdef USE_ACC_SPI_MPU6000
     case ACC_MPU6000:
         if (mpu6000SpiAccDetect(dev)) {
-#ifdef ACC_MPU6000_ALIGN
-            dev->accAlign = ACC_MPU6000_ALIGN;
-#endif
             accHardware = ACC_MPU6000;
             break;
         }
@@ -229,9 +211,6 @@ retry:
 #ifdef USE_ACC_SPI_MPU9250
     case ACC_MPU9250:
         if (mpu9250SpiAccDetect(dev)) {
-#ifdef ACC_MPU9250_ALIGN
-            dev->accAlign = ACC_MPU9250_ALIGN;
-#endif
             accHardware = ACC_MPU9250;
             break;
         }
@@ -247,9 +226,6 @@ retry:
         if (mpu6500AccDetect(dev) || mpu6500SpiAccDetect(dev)) {
 #else
         if (mpu6500AccDetect(dev)) {
-#endif
-#ifdef ACC_MPU6500_ALIGN
-            dev->accAlign = ACC_MPU6500_ALIGN;
 #endif
             switch (dev->mpuDetectionResult.sensor) {
             case MPU_9250_SPI:
@@ -276,9 +252,6 @@ retry:
     case ACC_ICM20649:
         if (icm20649SpiAccDetect(dev)) {
             accHardware = ACC_ICM20649;
-#ifdef ACC_ICM20649_ALIGN
-            dev->accAlign = ACC_ICM20649_ALIGN;
-#endif
             break;
         }
         FALLTHROUGH;
@@ -288,9 +261,6 @@ retry:
     case ACC_ICM20689:
         if (icm20689SpiAccDetect(dev)) {
             accHardware = ACC_ICM20689;
-#ifdef ACC_ICM20689_ALIGN
-            dev->accAlign = ACC_ICM20689_ALIGN;
-#endif
             break;
         }
         FALLTHROUGH;
@@ -300,9 +270,6 @@ retry:
     case ACC_BMI160:
         if (bmi160SpiAccDetect(dev)) {
             accHardware = ACC_BMI160;
-#ifdef ACC_BMI160_ALIGN
-            dev->accAlign = ACC_BMI160_ALIGN;
-#endif
             break;
         }
         FALLTHROUGH;

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -50,13 +50,11 @@
 #define USE_GYRO_SPI_MPU6500
 
 #define GYRO_1_ALIGN            CW270_DEG
-#define GYRO_1_ALIGN            CW270_DEG
 
 #define USE_ACC
 #define USE_ACC_MPU6050
 #define USE_ACC_SPI_MPU6500
 
-#define ACC_1_ALIGN             CW270_DEG
 #define ACC_1_ALIGN             CW270_DEG
 
 // No baro support.

--- a/src/main/target/DALRCF405/target.h
+++ b/src/main/target/DALRCF405/target.h
@@ -46,24 +46,18 @@
 
 #define USE_GYRO
 #define USE_ACC
-//------ICM20689
-#define ICM20689_CS_PIN          PA4 
-#define ICM20689_SPI_INSTANCE    SPI1
-
-#define USE_GYRO_SPI_ICM20689
-#define GYRO_ICM20689_ALIGN      CW90_DEG
-
-#define USE_ACC_SPI_ICM20689
-#define ACC_ICM20689_ALIGN       CW90_DEG
-//------MPU6000
-#define GYRO_1_CS_PIN            PA4 
-#define GYRO_1_SPI_INSTANCE      SPI1
-
-#define USE_GYRO_SPI_MPU6000
+#define GYRO_1_CS_PIN           PA4
+#define GYRO_1_SPI_INSTANCE     SPI1
 #define GYRO_1_ALIGN            CW90_DEG
-
-#define USE_ACC_SPI_MPU6000
 #define ACC_1_ALIGN             CW90_DEG
+
+//------ICM20689
+#define USE_GYRO_SPI_ICM20689
+#define USE_ACC_SPI_ICM20689
+
+//------MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6000
 
 //Baro & MAG------------------------------- 
 #define USE_I2C

--- a/src/main/target/DALRCF722DUAL/target.h
+++ b/src/main/target/DALRCF722DUAL/target.h
@@ -53,15 +53,11 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_MPU6500
 
-#define ACC_MPU6000_1_ALIGN           CW180_DEG
-#define GYRO_MPU6000_1_ALIGN          CW180_DEG
-#define GYRO_1_ALIGN                GYRO_MPU6000_1_ALIGN
-#define ACC_1_ALIGN                 ACC_MPU6000_1_ALIGN
+#define GYRO_1_ALIGN                CW180_DEG
+#define ACC_1_ALIGN                 CW180_DEG
 
-#define ACC_MPU6500_2_ALIGN         CW0_DEG
-#define GYRO_MPU6500_2_ALIGN        CW0_DEG
-#define GYRO_2_ALIGN                GYRO_MPU6500_2_ALIGN 
-#define ACC_2_ALIGN                 ACC_MPU6500_2_ALIGN
+#define GYRO_2_ALIGN                CW0_DEG
+#define ACC_2_ALIGN                 CW0_DEG
 
 #define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_1 
 

--- a/src/main/target/FOXEERF405/target.h
+++ b/src/main/target/FOXEERF405/target.h
@@ -46,24 +46,18 @@
 
 #define USE_GYRO
 #define USE_ACC
-//------ICM20689
-#define ICM20689_CS_PIN          PB2 
-#define ICM20689_SPI_INSTANCE    SPI1
-
-#define USE_GYRO_SPI_ICM20689
-#define GYRO_ICM20689_ALIGN      CW90_DEG
-
-#define USE_ACC_SPI_ICM20689
-#define ACC_ICM20689_ALIGN       CW90_DEG
-//------MPU6000
-#define GYRO_1_CS_PIN            PB2 
-#define GYRO_1_SPI_INSTANCE      SPI1
-
-#define USE_GYRO_SPI_MPU6000
+#define GYRO_1_CS_PIN           PB2
+#define GYRO_1_SPI_INSTANCE     SPI1
 #define GYRO_1_ALIGN            CW90_DEG
-
-#define USE_ACC_SPI_MPU6000
 #define ACC_1_ALIGN             CW90_DEG
+
+//------ICM20689
+#define USE_GYRO_SPI_ICM20689
+#define USE_ACC_SPI_ICM20689
+
+//------MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6000
 
 //Baro & MAG------------------------------- 
 #define USE_I2C

--- a/src/main/target/FOXEERF722DUAL/target.h
+++ b/src/main/target/FOXEERF722DUAL/target.h
@@ -52,15 +52,11 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_MPU6500
 
-#define ACC_MPU6000_1_ALIGN           CW270_DEG
-#define GYRO_MPU6000_1_ALIGN          CW270_DEG
-#define GYRO_1_ALIGN                GYRO_MPU6000_1_ALIGN
-#define ACC_1_ALIGN                 ACC_MPU6000_1_ALIGN
+#define GYRO_1_ALIGN                CW270_DEG
+#define ACC_1_ALIGN                 CW270_DEG
 
-#define ACC_MPU6500_2_ALIGN         CW180_DEG
-#define GYRO_MPU6500_2_ALIGN        CW180_DEG
-#define GYRO_2_ALIGN                GYRO_MPU6500_2_ALIGN 
-#define ACC_2_ALIGN                 ACC_MPU6500_2_ALIGN
+#define GYRO_2_ALIGN                CW180_DEG
+#define ACC_2_ALIGN                 CW180_DEG
 
 #define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_1 
 

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -64,23 +64,19 @@
 
 #define GYRO_1_CS_PIN           PC4
 #define GYRO_1_SPI_INSTANCE     SPI1
+#define ACC_1_ALIGN             CW270_DEG
+#define GYRO_1_ALIGN            CW270_DEG
 
 #define USE_ACC
 #define USE_ACC_SPI_ICM20689
-#define ACC_1_ALIGN             CW270_DEG
 
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM20689
-#define GYRO_1_ALIGN            CW270_DEG
 
 #if defined(FLYWOOF405)
 //------MPU6000
-#define MPU6000_CS_PIN           PC4 
-#define MPU6000_SPI_INSTANCE     SPI1
 #define USE_GYRO_SPI_MPU6000
-#define GYRO_MPU6000_ALIGN      CW270_DEG
 #define USE_ACC_SPI_MPU6000								  
-#define ACC_MPU6000_ALIGN       CW270_DEG
 #endif
 
 #if defined(KAKUTEF4V2) || defined(FLYWOOF405)       // There is invertor on RXD3(PB11), so PB10/PB11 can't be used as I2C2.

--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -91,23 +91,21 @@
 #define GYRO_1_SPI_INSTANCE     SPI1
 
 #define USE_GYRO
+#define GYRO_1_ALIGN       CW270_DEG
 #ifdef LUXV2_RACE
 #define USE_GYRO_SPI_MPU6000
-#define GYRO_1_ALIGN       CW270_DEG
 #else
 #define USE_GYRO_SPI_MPU6500
-#define GYRO_1_ALIGN       CW270_DEG
 #endif
 
 #define USE_ACC
+#define ACC_1_ALIGN       CW270_DEG
 #ifdef LUXV2_RACE
 #define USE_ACC_MPU6000
 #define USE_ACC_SPI_MPU6000
-#define ACC_1_ALIGN       CW270_DEG
 #else
 #define USE_ACC_MPU6500
 #define USE_ACC_SPI_MPU6500
-#define ACC_1_ALIGN       CW270_DEG
 #endif
 
 #define USE_VCP

--- a/src/main/target/MATEKF722/target.h
+++ b/src/main/target/MATEKF722/target.h
@@ -44,9 +44,6 @@
 #define GYRO_1_CS_PIN           PC2
 #define GYRO_1_SPI_INSTANCE     SPI1
 
-#define ICM20689_CS_PIN         PC2
-#define ICM20689_SPI_INSTANCE   SPI1
-
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC3
@@ -56,13 +53,13 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_GYRO_SPI_ICM20689
 #define GYRO_1_ALIGN            CW180_DEG
-//#define GYRO_ICM20689_ALIGN     CW90_DEG // XXX has to be post-flash configured
+//#define GYRO_1_ALIGN            CW90_DEG // XXX has to be post-flash configured
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6500
 #define USE_ACC_SPI_ICM20689
 #define ACC_1_ALIGN             CW180_DEG
-//#define ACC_ICM20689_ALIGN      CW90_DEG // XXX has to be post-flash configured
+//#define ACC_1_ALIGN             CW90_DEG // XXX has to be post-flash configured
 
 // *************** Baro **************************
 #define USE_I2C

--- a/src/main/target/SPRACINGF7DUAL/target.h
+++ b/src/main/target/SPRACINGF7DUAL/target.h
@@ -57,23 +57,18 @@
 #define USE_ACC_SPI_MPU6500
 
 #if (SPRACINGF7DUAL_REV >= 2)
-#define ACC_MPU6500_1_ALIGN           CW0_DEG
-#define GYRO_MPU6500_1_ALIGN          CW0_DEG
+#define GYRO_1_ALIGN        CW0_DEG
+#define ACC_1_ALIGN         CW0_DEG
 
-#define ACC_MPU6500_2_ALIGN         CW270_DEG
-#define GYRO_MPU6500_2_ALIGN        CW270_DEG
+#define GYRO_2_ALIGN        CW270_DEG
+#define ACC_2_ALIGN         CW270_DEG
 #else
-#define ACC_MPU6500_1_ALIGN           CW180_DEG
-#define GYRO_MPU6500_1_ALIGN          CW180_DEG
+#define GYRO_1_ALIGN        CW180_DEG
+#define ACC_1_ALIGN         CW180_DEG
 
-#define ACC_MPU6500_2_ALIGN         CW270_DEG
-#define GYRO_MPU6500_2_ALIGN        CW270_DEG
+#define GYRO_2_ALIGN        CW270_DEG
+#define ACC_2_ALIGN         CW270_DEG
 #endif
-
-#define GYRO_1_ALIGN                GYRO_MPU6500_1_ALIGN
-#define GYRO_2_ALIGN                GYRO_MPU6500_2_ALIGN
-#define ACC_1_ALIGN                ACC_MPU6500_1_ALIGN
-#define ACC_2_ALIGN                ACC_MPU6500_2_ALIGN
 
 #define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_BOTH
 

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -122,8 +122,6 @@
 #define GYRO_1_ALIGN            CW0_DEG
 #define USE_ACCGYRO_BMI160
 #ifdef USE_ACCGYRO_BMI160
-#define BMI160_CS_PIN           SPI2_NSS_PIN
-#define BMI160_SPI_INSTANCE     SPI2
 #define BMI160_SPI_DIVISOR      16
 #define USE_EXTI
 #define USE_GYRO_EXTI


### PR DESCRIPTION
Remove obsolete target definitions and the related code from gyro drivers.