### PR TITLE
Protect variables used only when USE_TELEMETRY_SMARTPORT is defined

### DIFF
--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -256,13 +256,12 @@ static uint8_t fportFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
 {
 #ifdef USE_TELEMETRY_SMARTPORT
     static smartPortPayload_t payloadBuffer;
+    static bool rxDrivenFrameRate = false;
+    static uint8_t consecutiveTelemetryFrameCount = 0;
 #endif
     static bool hasTelemetryRequest = false;
 
     uint8_t result = RX_FRAME_PENDING;
-
-    static bool rxDrivenFrameRate = false;
-    static uint8_t consecutiveTelemetryFrameCount = 0;
 
     if (rxBufferReadIndex != rxBufferWriteIndex) {
         uint8_t bufferLength = rxBuffer[rxBufferReadIndex].length;


### PR DESCRIPTION
Just protecting it without having a knowledge about how these are used... thoughts?