### PR TITLE
Drop USE_CRSF_CMS_TELEMETRY if USE_CMS is not defined

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -91,7 +91,7 @@
 #undef USE_TELEMETRY_CRSF
 #endif
 
-#if !defined(USE_TELEMETRY_CRSF)
+#if !defined(USE_TELEMETRY_CRSF) || !defined(USE_CMS)
 #undef USE_CRSF_CMS_TELEMETRY
 #endif
 


### PR DESCRIPTION
Fixes #7002