### PR TITLE
JETIEXBUS Telemetry: Conditional-ize GPS related functions with USE_GPS

### DIFF
--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -343,6 +343,7 @@ int32_t getSensorValue(uint8_t sensor)
         break;
 #endif
 
+#ifdef USE_GPS
     case EX_GPS_SATS:
         return gpsSol.numSat;
     break;
@@ -374,6 +375,7 @@ int32_t getSensorValue(uint8_t sensor)
     case EX_GPS_ALTITUDE:
         return gpsSol.llh.altCm;
     break;
+#endif
 
     case EX_GFORCE_X:
        return (int16_t)(((float)acc.accADC[0] / acc.dev.acc_1G) * 1000);


### PR DESCRIPTION
Haven't been tested; may be a negative consequences if caller of `getSensorValue` is unaware of return value of '-1`.

Btw, the `getSensorValue` name in the global name space is kinda rough 🤔 