### PR TITLE
EXTI: Amend F7/HAL EXTIConfig to support all trigger types

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -254,6 +254,13 @@ void fcTasksInit(void)
         setTaskEnabled(TASK_ATTITUDE, true);
     }
 
+
+#ifdef USE_RANGEFINDER
+    if (sensors(SENSOR_RANGEFINDER)) {
+        setTaskEnabled(TASK_RANGEFINDER, featureIsEnabled(FEATURE_RANGEFINDER));
+    }
+#endif
+
     setTaskEnabled(TASK_RX, true);
 
     setTaskEnabled(TASK_DISPATCH, dispatchIsEnabled());
@@ -594,6 +601,15 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskName = "PINIOBOX",
         .taskFunc = pinioBoxUpdate,
         .desiredPeriod = TASK_PERIOD_HZ(20),
+        .staticPriority = TASK_PRIORITY_IDLE
+    },
+#endif
+
+#ifdef USE_RANGEFINDER
+    [TASK_RANGEFINDER] = {
+        .taskName = "RANGEFINDER",
+        .taskFunc = rangefinderUpdate,
+        .desiredPeriod = TASK_PERIOD_HZ(10),
         .staticPriority = TASK_PRIORITY_IDLE
     },
 #endif


### PR DESCRIPTION
Unlike peripheral library which supports direct EXTI configuration, HAL only supports it as a part of GPIO initialization through `HAL_GPIO_Init`. This probably was a reason the current implementation of `EXTIConfig` is incomplete; it does not support rising edge trigger only.

This PR amend `EXTIConfig` to support all trigger types.

- Macros `IOConfigGetXXX` were added in `io.h` to extract fields from `ioConfig_s`.
Confortable for everybody?

- A complete `GPIO_Init_TypeDef` is setup and passed to `HAL_GPIO_Init`.
Mode is forced to `GPIO_MODE_INPUT`. Should we reject a call with different mode and return?

- Trigger types are `GPIO_MODE_IT_{RISING,FALLING,RISING_FALLING}` for now.
Should we define `EXTITrigger_TypeDef` equivalent?

- Note that new API is tentatively called `EXTIConfigX` to avoid editing all `EXTIConfig` occurrences; it will be renamed to `EXTIConfig` and all occurrences of `EXTIConfig` will be edited to reflect the new API.

Thoughts?