### PR TITLE
Added 'crash flip active' to the list of warnings to be shown on LED_STRIP.

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -370,7 +370,7 @@ void tryArm(void)
 #ifdef USE_DSHOT
         if (currentTimeUs - getLastDshotBeaconCommandTimeUs() < DSHOT_BEACON_GUARD_DELAY_US) {
             if (tryingToArm == ARMING_DELAYED_DISARMED) {
-                if (isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+                if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                     tryingToArm = ARMING_DELAYED_CRASHFLIP;
 #ifdef USE_LAUNCH_CONTROL
                 } else if (canUseLaunchControl()) {
@@ -784,7 +784,7 @@ bool processRx(timeUs_t currentTimeUs)
 
 #ifdef USE_DSHOT
     /* Enable beep warning when the crash flip mode is active */
-    if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+    if (isFlipOverAfterCrashWarningActive()) {
         beeper(BEEPER_CRASH_FLIP_MODE);
     }
 #endif
@@ -1091,6 +1091,11 @@ FAST_CODE void taskMainPidLoop(timeUs_t currentTimeUs)
 bool isFlipOverAfterCrashMode(void)
 {
     return flipOverAfterCrashMode;
+}
+
+bool isFlipOverAfterCrashWarningActive(void)
+{
+    return flipOverAfterCrashMode || IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH);
 }
 
 timeUs_t getLastDisarmTimeUs(void)

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -66,7 +66,9 @@ bool processRx(timeUs_t currentTimeUs);
 void updateArmingStatus(void);
 
 void taskMainPidLoop(timeUs_t currentTimeUs);
+
 bool isFlipOverAfterCrashMode(void);
+bool isFlipOverAfterCrashWarningActive(void);
 
 void runawayTakeoffTemporaryDisable(uint8_t disableFlag);
 bool isAirmodeActivated();

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -67,8 +67,7 @@ void updateArmingStatus(void);
 
 void taskMainPidLoop(timeUs_t currentTimeUs);
 
-bool isFlipOverAfterCrashMode(void);
-bool isFlipOverAfterCrashWarningActive(void);
+bool isFlipOverAfterCrashActive(void);
 
 void runawayTakeoffTemporaryDisable(uint8_t disableFlag);
 bool isAirmodeActivated();

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -774,7 +774,7 @@ void applyMotorStop(void)
 
 FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensation)
 {
-    if (isFlipOverAfterCrashMode()) {
+    if (isFlipOverAfterCrashActive()) {
         applyFlipOverAfterCrashModeToMotors();
         return;
     }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -47,6 +47,7 @@
 #include "drivers/vtx_common.h"
 
 #include "fc/config.h"
+#include "fc/core.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
@@ -548,7 +549,7 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
             if (!ARMING_FLAG(ARMED) && isArmingDisabled()) {
                 warningFlags |= 1 << WARNING_ARMING_DISABLED;
             }
-            if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+            if (isFlipOverAfterCrashWarningActive()) {
                 warningFlags |= 1 << WARNING_CRASH_FLIP_ACTIVE;
             }
         }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -549,7 +549,7 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
             if (!ARMING_FLAG(ARMED) && isArmingDisabled()) {
                 warningFlags |= 1 << WARNING_ARMING_DISABLED;
             }
-            if (isFlipOverAfterCrashWarningActive()) {
+            if (isFlipOverAfterCrashActive()) {
                 warningFlags |= 1 << WARNING_CRASH_FLIP_ACTIVE;
             }
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -946,7 +946,7 @@ static bool osdDrawSingleElement(uint8_t item)
 #endif
 
             // Warn when in flip over after crash mode
-            if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && isFlipOverAfterCrashMode()) {
+            if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "CRASH FLIP");
                 break;
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -483,7 +483,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             const int angleR = attitude.values.roll / 10;
             const int angleP = attitude.values.pitch / 10; // still gotta update all angleR and angleP pointers.
-            if (isFlipOverAfterCrashMode()) {
+            if (isFlipOverAfterCrashActive()) {
                 if (angleP > 0 && ((angleR > 175 && angleR < 180) || (angleR > -180 && angleR < -175))) {
                     buff[0] = SYM_ARROW_SOUTH;
                 } else if (angleP > 0 && angleR > 0 && angleR < 175) {
@@ -946,7 +946,7 @@ static bool osdDrawSingleElement(uint8_t item)
 #endif
 
             // Warn when in flip over after crash mode
-            if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && isFlipOverAfterCrashWarningActive()) {
+            if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && isFlipOverAfterCrashActive()) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "CRASH FLIP");
                 break;
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -483,7 +483,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             const int angleR = attitude.values.roll / 10;
             const int angleP = attitude.values.pitch / 10; // still gotta update all angleR and angleP pointers.
-            if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+            if (isFlipOverAfterCrashMode()) {
                 if (angleP > 0 && ((angleR > 175 && angleR < 180) || (angleR > -180 && angleR < -175))) {
                     buff[0] = SYM_ARROW_SOUTH;
                 } else if (angleP > 0 && angleR > 0 && angleR < 175) {
@@ -946,7 +946,7 @@ static bool osdDrawSingleElement(uint8_t item)
 #endif
 
             // Warn when in flip over after crash mode
-            if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+            if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && isFlipOverAfterCrashWarningActive()) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "CRASH FLIP");
                 break;
             }

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -388,4 +388,6 @@ bool isArmingDisabled(void) { return false; }
 
 uint8_t getRssiPercent(void) { return 0; }
 
+bool isFlipOverAfterCrashWarningActive(void) { return false; }
+
 }

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -388,6 +388,6 @@ bool isArmingDisabled(void) { return false; }
 
 uint8_t getRssiPercent(void) { return 0; }
 
-bool isFlipOverAfterCrashWarningActive(void) { return false; }
+bool isFlipOverAfterCrashActive(void) { return false; }
 
 }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1055,9 +1055,8 @@ extern "C" {
 
     uint16_t getCoreTemperatureCelsius(void) { return simulationCoreTemperature; }
 
-    bool isFlipOverAfterCrashMode(void) {
-        return false;
-    }
+    bool isFlipOverAfterCrashMode(void) { return false; } 
+    bool isFlipOverAfterCrashWarningActive(void) { return false; }
 
     float pidItermAccelerator(void) { return 1.0; }
     uint8_t getMotorCount(void){ return 4; }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1055,8 +1055,7 @@ extern "C" {
 
     uint16_t getCoreTemperatureCelsius(void) { return simulationCoreTemperature; }
 
-    bool isFlipOverAfterCrashMode(void) { return false; } 
-    bool isFlipOverAfterCrashWarningActive(void) { return false; }
+    bool isFlipOverAfterCrashActive(void) { return false; }
 
     float pidItermAccelerator(void) { return 1.0; }
     uint8_t getMotorCount(void){ return 4; }


### PR DESCRIPTION
Also unifies the crash flip warning to be on when disarmed everywhere.
Fixes #6995.