### PR TITLE
Prevent crash recovery triggering during GPS Rescue startup

### DIFF
--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -45,3 +45,4 @@ void rescueNewGpsData(void);
 float gpsRescueGetYawRate(void);
 float gpsRescueGetThrottle(void);
 bool gpsRescueIsConfigured(void);
+bool gpsRescueInStartup(timeUs_t currentTimeUs);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -740,7 +740,11 @@ static void detectAndSetCrashRecovery(
 {
     // if crash recovery is on and accelerometer enabled and there is no gyro overflow, then check for a crash
     // no point in trying to recover if the crash is so severe that the gyro overflows
-    if ((crash_recovery || FLIGHT_MODE(GPS_RESCUE_MODE)) && !gyroOverflowDetected()) {
+    if ((crash_recovery || FLIGHT_MODE(GPS_RESCUE_MODE)) && !gyroOverflowDetected()
+#ifdef USE_GPS_RESCUE
+        && !gpsRescueInStartup(currentTimeUs)
+#endif
+        ) {
         if (ARMING_FLAG(ARMED)) {
             if (getMotorMixRange() >= 1.0f && !inCrashRecoveryMode
                 && ABS(delta) > crashDtermThreshold


### PR DESCRIPTION
Adds a one second lockout of crash recovery during GPS Rescue initial activation. This is to prevent crash recovery detection during the initial leveling process. In some cases where the correction was severe (like starting from upside down) the initial self-leveling would trigger crash recovery detection and this would then in turn cause GPS Rescue to disarm because it thought a crash had happened.
