### PR TITLE
Prevent crash recovery detection immediately after entering self-level or GPS Rescue modes

### DIFF
--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -457,7 +457,8 @@ TEST(pidControllerTest, testCrashRecoveryMode) {
     simulatedMotorMixRange = 1.2f;
     for (int loop =0; loop <= loopsToCrashTime; loop++) {
         gyro.gyroADCf[FD_ROLL] += gyro.gyroADCf[FD_ROLL];
-        pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+        // advance the time to avoid initialized state prevention of crash recovery
+        pidController(pidProfile, &rollAndPitchTrims, currentTestTime() + 2000000);
     }
 
     EXPECT_TRUE(crashRecoveryModeActive());


### PR DESCRIPTION
If the quad is in an extreme orientation (like upside down) the transition to self-level modes can cause enough motion to trigger crash recovery. Added a 1 second delay during which crash recovery detection is blocked immediately after entering a self-level mode.

This also addresses an issue with GPS Rescue as when it activates it enables self-level. If in the above scenario this triggered a crash recovery detection then GPS Rescue would interpret this as a crash and immediately disarm.
