### PR TITLE
Reduce runaway takeoff deactivate throttle to 20%

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -93,7 +93,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);
 PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
     .pid_process_denom = PID_PROCESS_DENOM_DEFAULT,
     .runaway_takeoff_prevention = true,
-    .runaway_takeoff_deactivate_throttle = 25,  // throttle level % needed to accumulate deactivation time
+    .runaway_takeoff_deactivate_throttle = 20,  // throttle level % needed to accumulate deactivation time
     .runaway_takeoff_deactivate_delay = 500     // Accumulated time (in milliseconds) before deactivation in successful takeoff
 );
 #else


### PR DESCRIPTION
In recognition that the average quad is getting more powerful and can hover at a lower throttle.
