### PR TITLE
Suppress OSD stats if disarming from crash-flip or untriggered launch control

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -67,6 +67,7 @@
 #include "io/beeper.h"
 #include "io/gps.h"
 #include "io/motors.h"
+#include "io/osd.h"
 #include "io/pidaudio.h"
 #include "io/servos.h"
 #include "io/serial.h"
@@ -332,6 +333,12 @@ void disarm(void)
         DISABLE_ARMING_FLAG(ARMED);
         lastDisarmTimeUs = micros();
 
+#ifdef USE_OSD
+        if (flipOverAfterCrashActive || isLaunchControlActive()) {
+            osdSuppressStats(true);
+        }
+#endif
+
 #ifdef USE_BLACKBOX
         if (blackboxConfig()->device && blackboxConfig()->mode != BLACKBOX_MODE_ALWAYS_ON) { // Close the log upon disarm except when logging mode is ALWAYS ON
             blackboxFinish();
@@ -408,6 +415,9 @@ void tryArm(void)
         }
 #endif
 
+#ifdef USE_OSD
+        osdSuppressStats(false);
+#endif
         ENABLE_ARMING_FLAG(ARMED);
         ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -152,6 +152,8 @@ static bool lastArmState;
 
 static displayPort_t *osdDisplayPort;
 
+static bool suppressStatsDisplay = false;
+
 #ifdef USE_ESC_SENSOR
 static escSensorData_t *escDataCombined;
 #endif
@@ -1665,6 +1667,7 @@ STATIC_UNIT_TESTED void osdRefresh(timeUs_t currentTimeUs)
             osdShowArmed();
             resumeRefreshAt = currentTimeUs + (REFRESH_1S / 2);
         } else if (isSomeStatEnabled()
+                   && !suppressStatsDisplay
                    && (!(getArmingDisableFlags() & ARMING_DISABLED_RUNAWAY_TAKEOFF)
                        || !VISIBLE(osdConfig()->item_pos[OSD_WARNINGS]))) { // suppress stats if runaway takeoff triggered disarm and WARNINGS element is visible
             osdStatsEnabled = true;
@@ -1796,4 +1799,8 @@ void osdUpdate(timeUs_t currentTimeUs)
 #endif
 }
 
+void osdSuppressStats(bool flag)
+{
+    suppressStatsDisplay = flag;
+}
 #endif // USE_OSD

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -218,5 +218,6 @@ void osdStatSetState(uint8_t statIndex, bool enabled);
 bool osdStatGetState(uint8_t statIndex);
 void osdWarnSetState(uint8_t warningIndex, bool enabled);
 bool osdWarnGetState(uint8_t warningIndex);
+void osdSuppressStats(bool flag);
 
 

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -851,4 +851,5 @@ extern "C" {
     bool usbCableIsInserted(void) { return false; }
     bool usbVcpIsConnected(void) { return false; }
     void pidSetAntiGravityState(bool) {}
+    void osdSuppressStats(bool) {}
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -173,4 +173,5 @@ extern "C" {
     bool usbCableIsInserted(void) { return false; }
     bool usbVcpIsConnected(void) { return false; }
     void pidSetAntiGravityState(bool newState) { UNUSED(newState); }
+    void osdSuppressStats(bool) {}
 }


### PR DESCRIPTION
The OSD stats provide no meaningful information and are just an annoyance when exiting these special states.

For Launch Control the stats will be displayed if the launch is triggered and normal flight occurrred.
