### PR TITLE
Support for enabling individual ESC telemetry sensors.

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -948,15 +948,13 @@ const clivalue_t valueTable[] = {
 #if defined(USE_TELEMETRY_IBUS)
     { "ibus_sensor",                VAR_UINT8  | MASTER_VALUE | MODE_ARRAY, .config.array.length = IBUS_SENSOR_COUNT, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, flysky_sensors)},
 #endif
-#if defined(USE_TELEMETRY_SMARTPORT)
-    { "smartport_use_extra_sensors", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, smartport_use_extra_sensors)},
-#endif
 #ifdef USE_TELEMETRY_MAVLINK
     // Support for misusing the heading field in MAVlink to indicate mAh drawn for Connex Prosight OSD
     // Set to 10 to show a tenth of your capacity drawn.
     // Set to $size_of_battery to get a percentage of battery used.
     { "mavlink_mah_as_heading_divisor", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 30000 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_mah_as_heading_divisor) },
 #endif
+    { "telemetry_disabled_sensors", VAR_UINT32 | MASTER_VALUE, .config.minmax = { 0, 15 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, disabledSensors)},
 #endif // USE_TELEMETRY
 
 // PG_LED_STRIP_CONFIG

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -58,7 +58,7 @@
 #include "telemetry/ibus.h"
 #include "telemetry/msp_shared.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 3);
 
 PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     .telemetry_inverted = false,
@@ -76,7 +76,7 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
             IBUS_SENSOR_TYPE_RPM_FLYSKY,
             IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE
     },
-    .smartport_use_extra_sensors = false,
+    .disabledSensors = ESC_SENSOR_ALL,
     .mavlink_mah_as_heading_divisor = 0,
 );
 
@@ -226,3 +226,8 @@ void telemetryProcess(uint32_t currentTime)
 #endif
 }
 #endif
+
+bool telemetryIsSensorEnabled(sensor_e sensor)
+{
+    return ~(telemetryConfigMutable()->disabledSensors) & sensor;
+}

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -41,6 +41,17 @@ typedef enum {
     FRSKY_UNIT_IMPERIALS
 } frskyUnit_e;
 
+typedef enum {
+    ESC_SENSOR_CURRENT = 1 << 0,
+    ESC_SENSOR_VOLTAGE = 1 << 1,
+    ESC_SENSOR_RPM = 1 << 2,
+    ESC_SENSOR_TEMPERATURE = 1 << 3,
+    ESC_SENSOR_ALL = ESC_SENSOR_CURRENT \
+                    | ESC_SENSOR_VOLTAGE \
+                    | ESC_SENSOR_RPM \
+                    | ESC_SENSOR_TEMPERATURE,
+} sensor_e;
+
 typedef struct telemetryConfig_s {
     int16_t gpsNoFixLatitude;
     int16_t gpsNoFixLongitude;
@@ -53,8 +64,8 @@ typedef struct telemetryConfig_s {
     uint8_t pidValuesAsTelemetry;
     uint8_t report_cell_voltage;
     uint8_t flysky_sensors[IBUS_SENSOR_COUNT];
-    uint8_t smartport_use_extra_sensors;
     uint16_t mavlink_mah_as_heading_divisor;
+    uint32_t disabledSensors; // bit flags
 } telemetryConfig_t;
 
 PG_DECLARE(telemetryConfig_t, telemetryConfig);
@@ -68,3 +79,5 @@ void telemetryCheckState(void);
 void telemetryProcess(uint32_t currentTime);
 
 bool telemetryDetermineEnabledState(portSharing_e portSharing);
+
+bool telemetryIsSensorEnabled(sensor_e sensor);


### PR DESCRIPTION
Fixes #6321. Added 'telemetry' cli command, in much the same way as 'buzzer' to enable individual esc telemetry sensors. I intend to do a follow-up PR that extends this approach to other sensors, and eventually other protocols to address #5748.
