### PR TITLE
Improve behavior of OSD warnings element blinking

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -817,6 +817,8 @@ static bool osdDrawSingleElement(uint8_t item)
             static timeUs_t armingDisabledUpdateTimeUs;
             static unsigned armingDisabledDisplayIndex;
 
+            CLR_BLINK(OSD_WARNINGS);
+
             // Cycle through the arming disabled reasons
             if (osdWarnGetState(OSD_WARNING_ARMING_DISABLE)) {
                 if (IS_RC_MODE_ACTIVE(BOXARM) && isArmingDisabled()) {
@@ -868,17 +870,20 @@ static bool osdDrawSingleElement(uint8_t item)
 #endif
             if (osdWarnGetState(OSD_WARNING_FAIL_SAFE) && failsafeIsActive()) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "FAIL SAFE");
+                SET_BLINK(OSD_WARNINGS);
                 break;
             }
 
             if (osdWarnGetState(OSD_WARNING_BATTERY_CRITICAL) && batteryState == BATTERY_CRITICAL) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, " LAND NOW");
+                SET_BLINK(OSD_WARNINGS);
                 break;
             }
 
             // Show warning if in HEADFREE flight mode
             if (FLIGHT_MODE(HEADFREE_MODE)) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "HEADFREE");
+                SET_BLINK(OSD_WARNINGS);
                 break;
             }
 
@@ -889,7 +894,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 tfp_sprintf(coreTemperatureWarningMsg, "CORE: %3d%c", osdConvertTemperatureToSelectedUnit(coreTemperature), osdGetTemperatureSymbolForSelectedUnit());
 
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, coreTemperatureWarningMsg);
-
+                SET_BLINK(OSD_WARNINGS);
                 break;
             }
 #endif
@@ -940,6 +945,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
                 if (escWarningCount > 0) {
                     osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, escWarningMsg);
+                    SET_BLINK(OSD_WARNINGS);
                     break;
                 }
             }
@@ -968,6 +974,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
             if (osdWarnGetState(OSD_WARNING_BATTERY_WARNING) && batteryState == BATTERY_WARNING) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "LOW BATTERY");
+                SET_BLINK(OSD_WARNINGS);
                 break;
             }
 
@@ -975,6 +982,7 @@ static bool osdDrawSingleElement(uint8_t item)
             // Show warning if rc smoothing hasn't initialized the filters
             if (osdWarnGetState(OSD_WARNING_RC_SMOOTHING) && ARMING_FLAG(ARMED) && !rcSmoothingInitializationComplete()) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "RCSMOOTHING");
+                SET_BLINK(OSD_WARNINGS);
                 break;
             }
 #endif
@@ -1291,18 +1299,6 @@ void osdUpdateAlarms(void)
         SET_BLINK(OSD_RSSI_VALUE);
     } else {
         CLR_BLINK(OSD_RSSI_VALUE);
-    }
-
-    // Determine if the OSD_WARNINGS should blink
-    if (getBatteryState() != BATTERY_OK
-           && (osdWarnGetState(OSD_WARNING_BATTERY_CRITICAL) || osdWarnGetState(OSD_WARNING_BATTERY_WARNING))
-#ifdef USE_DSHOT
-           && (!isTryingToArm())
-#endif
-       ) {
-        SET_BLINK(OSD_WARNINGS);
-    } else {
-        CLR_BLINK(OSD_WARNINGS);
     }
 
     if (getBatteryState() == BATTERY_OK) {


### PR DESCRIPTION
Previously the logic to blink the warnings element was based on whether batteryState was either BATTERY_WARNING or BATTERY_CRITICAL. The problem is that the warning element might be displaying a higher priority message that shouldn't blink.

Changes the logic to have the blinking based on the actual warning message displayed.

In addition to the battery warning/critical cases, added blinking for some other critical warnings like failsafe, CPU core temp warning, ESC sensor warnings, HEADFREE mode active, and RC smoothing not initialized.