### PR TITLE
[ADC] Configurable ADC internal sensor calibration values

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -44,7 +44,7 @@ volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
 #ifdef USE_ADC_INTERNAL
 uint16_t adcTSCAL1;
 uint16_t adcTSCAL2;
-uint16_t adcTSSlopeK;
+int16_t  adcTSSlopeK;
 uint16_t adcVREFINTCAL;
 #endif
 

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -83,7 +83,7 @@ uint16_t adcGetChannel(uint8_t channel);
 extern uint16_t adcVREFINTCAL;
 extern uint16_t adcTSCAL1;
 extern uint16_t adcTSCAL2;
-extern uint16_t adcTSSlopeK;
+extern int16_t  adcTSSlopeK;
 
 bool adcInternalIsBusy(void);
 void adcInternalStartConversion(void);

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -133,7 +133,7 @@ void adcInitDevice(ADC_TypeDef *adcdev, int channelCount)
 }
 
 #ifdef USE_ADC_INTERNAL
-void adcInitInternalInjected(void)
+void adcInitInternalInjected(const adcConfig_t *config)
 {
     ADC_TempSensorVrefintCmd(ENABLE);
     ADC_InjectedDiscModeCmd(ADC1, DISABLE);
@@ -141,9 +141,10 @@ void adcInitInternalInjected(void)
     ADC_InjectedChannelConfig(ADC1, ADC_Channel_Vrefint, 1, ADC_SampleTime_480Cycles);
     ADC_InjectedChannelConfig(ADC1, ADC_Channel_TempSensor, 2, ADC_SampleTime_480Cycles);
 
-    adcVREFINTCAL = *(uint16_t *)VREFINT_CAL_ADDR;
-    adcTSCAL1 = *(uint16_t *)TS_CAL1_ADDR;
-    adcTSCAL2 = *(uint16_t *)TS_CAL2_ADDR;
+    adcVREFINTCAL = config->vrefIntCalibration ? config->vrefIntCalibration : *(uint16_t *)VREFINT_CAL_ADDR;
+    adcTSCAL1 = config->tempSensorCalibration1 ? config->tempSensorCalibration1 : *(uint16_t *)TS_CAL1_ADDR;
+    adcTSCAL2 = config->tempSensorCalibration2 ? config->tempSensorCalibration2 : *(uint16_t *)TS_CAL2_ADDR;
+
     adcTSSlopeK = (110 - 30) * 1000 / (adcTSCAL2 - adcTSCAL1);
 }
 
@@ -258,7 +259,7 @@ void adcInit(const adcConfig_t *config)
     }
 
     // Initialize for injected conversion
-    adcInitInternalInjected();
+    adcInitInternalInjected(config);
 
     if (!adcActive) {
         return;

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -646,6 +646,9 @@ const clivalue_t valueTable[] = {
 // PG_ADC_CONFIG
 #if defined(USE_ADC)
     { "adc_device",                 VAR_INT8   | MASTER_VALUE, .config.minmax = { 0, ADCDEV_COUNT }, PG_ADC_CONFIG, offsetof(adcConfig_t, device) },
+    { "adc_vrefint_calibration",    VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 2000 }, PG_ADC_CONFIG, offsetof(adcConfig_t, vrefIntCalibration) },
+    { "adc_tempsensor_calibration30", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 2000 }, PG_ADC_CONFIG, offsetof(adcConfig_t, tempSensorCalibration1) },
+    { "adc_tempsensor_calibration110", VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 2000 }, PG_ADC_CONFIG, offsetof(adcConfig_t, tempSensorCalibration2) },
 #endif
 
 // PG_PWM_CONFIG

--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -60,5 +60,8 @@ void pgResetFn_adcConfig(adcConfig_t *adcConfig)
     adcConfig->rssi.ioTag = IO_TAG(RSSI_ADC_PIN);
 #endif
 
+    adcConfig->vrefIntCalibration = 0;
+    adcConfig->tempSensorCalibration1 = 0;
+    adcConfig->tempSensorCalibration2 = 0;
 }
 #endif // USE_ADC

--- a/src/main/pg/adc.h
+++ b/src/main/pg/adc.h
@@ -37,6 +37,10 @@ typedef struct adcConfig_s {
     adcChannelConfig_t current;
     adcChannelConfig_t external1;
     int8_t device; // ADCDevice
+
+    uint16_t vrefIntCalibration;
+    uint16_t tempSensorCalibration1;
+    uint16_t tempSensorCalibration2;
 } adcConfig_t;
 
 PG_DECLARE(adcConfig_t, adcConfig);


### PR DESCRIPTION
There are MCUs without calibration values for VREFINT and temperature sensors.

- Added configurable calibration values for vrefint, tscal1 and tscal2 with CLI variables `adc_vrefint_calibration`, `adc_tempsensor_calibration30` and `adc_tempsensor_calibration110` respectively.

- Value of zero instruct reading the corresponding value from the pre-defined memory location.

- Also changed adcTSSlopeK to signed, to handle negative slope case.
