### PR TITLE
Limit aux channel servo forwarding by max_aux_channels setting

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -300,7 +300,8 @@ STATIC_UNIT_TESTED void forwardAuxChannelsToServos(uint8_t firstServoIndex)
 {
     // start forwarding from this channel
     int channelOffset = servoConfig()->channelForwardingStartChannel;
-    for (int servoOffset = 0; servoOffset < MAX_AUX_CHANNEL_COUNT && channelOffset < MAX_SUPPORTED_RC_CHANNEL_COUNT; servoOffset++) {
+    const int maxAuxChannelCount = MIN(MAX_AUX_CHANNEL_COUNT, rxConfig()->max_aux_channel);
+    for (int servoOffset = 0; servoOffset < maxAuxChannelCount && channelOffset < MAX_SUPPORTED_RC_CHANNEL_COUNT; servoOffset++) {
         pwmWriteServo(firstServoIndex + servoOffset, rcData[channelOffset++]);
     }
 }


### PR DESCRIPTION
No reason process forwarding for channels that aren't going to be active from the RX.
