### PR TITLE
Set TPA default to D only, increase D about 10%

### DIFF
--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -45,8 +45,8 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
         RESET_CONFIG(controlRateConfig_t, &controlRateConfig[i],
             .thrMid8 = 50,
             .thrExpo8 = 0,
-            .dynThrPID = 10,
-            .tpa_breakpoint = 1650,
+            .dynThrPID = 50,
+            .tpa_breakpoint = 1500,
             .rates_type = RATES_TYPE_BETAFLIGHT,
             .rcRates[FD_ROLL] = 100,
             .rcRates[FD_PITCH] = 100,
@@ -62,7 +62,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_ROLL] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .rate_limit[FD_PITCH] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
-            .tpaMode = TPA_MODE_PD,
+            .tpaMode = TPA_MODE_D,
         );
     }
 }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -118,8 +118,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
 {
     RESET_CONFIG(pidProfile_t, pidProfile,
         .pid = {
-            [PID_ROLL] =  { 46, 65, 25, 60 },
-            [PID_PITCH] = { 50, 75, 27, 60 },
+            [PID_ROLL] =  { 46, 65, 30, 60 },
+            [PID_PITCH] = { 50, 75, 32, 60 },
             [PID_YAW] =   { 45, 100, 0, 100 },
             [PID_LEVEL] = { 50, 50, 75, 0 },
             [PID_MAG] =   { 40, 0, 0, 0 },


### PR DESCRIPTION
The new dynamic lowpass filtering in Betaflight 4.0 will by default allow quite a lot more D through.  The biquad filters attenuate D very steeply above cutoff, but attenuate less below cutoff.  The dynamic D filter will by default go as high as 250Hz.  The combination of both effects allows quite a lot more D through on mid to full throttle, which is useful to minimise prop wash.  

Inevitably this allows more noise through on D at high throttle values.  Rather than filtering this noise out, which adds delay, attenuating it achieves good results without additional delay.  

So we tested the idea of applying TPA, lots of it, to D alone, and not attenuating P and D together, as was done in the past.

The results were very positive.  The quad was more stable on full throttle, with less instability / wobble in the FPV feed, less noise in Plasmatree logs, and cooler motors, while also being more responsive to stick inputs at full throttle.  The improved stick response at full throttle actually just made the quad feel more 'normal'.  This was because there was less D 'damping' and no P attenuation.   

The dynamic filtering changes also allowed about a 15% increase in the default value of D at low throttle.  The end result is less D noise at low throttle, more effective D at mid throttle, where prop wash is often worst, a bit more D at low throttle, and a bit less on full throttle. 

Overall this improves significantly over the stock TPA and D settings.

Thanks to eTracer for making TPA configurable from P+D to D only in #7062.  This PR changes that PR to filter D only from 1500 at 50%, and increases D a bit, from my closed concept PR #7013.