### PR TITLE
[FLASHFS] Avoid calling flashIsReady when flash chip is non-existent

### DIFF
--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -110,7 +110,9 @@ void flashfsEraseRange(uint32_t start, uint32_t end)
  */
 bool flashfsIsReady(void)
 {
-    return flashIsReady();
+    // Check for flash chip existence first, then check if ready.
+
+    return (flashfsIsSupported() && flashIsReady());
 }
 
 bool flashfsIsSupported(void)


### PR DESCRIPTION
Fixes #7079.

Ideally, the flashfs driver should keep track of information regarding underlying flash chip device, but the driver is nearly stateless.

A workaround is to check the chip existence by calling `flashfsIsSupported` before calling `flashIsReady`.

Another possible workaround is to check NULL vtable in `flashIsReady`.

Thoughts?