### PR TITLE
[F4] System clock refactor to support configurable HSE crystal frequency

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -85,7 +85,8 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .task_statistics = true,
     .cpu_overclock = 0,
     .powerOnArmingGraceTime = 5,
-    .boardIdentifier = TARGET_BOARD_IDENTIFIER
+    .boardIdentifier = TARGET_BOARD_IDENTIFIER,
+    .hseMhz = SYSTEM_HSE_VALUE,  // Not used for non-F4 targets
 );
 
 uint8_t getCurrentPidProfileIndex(void)

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -42,6 +42,7 @@ typedef struct systemConfig_s {
     uint8_t cpu_overclock;
     uint8_t powerOnArmingGraceTime; // in seconds
     char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER) + 1];
+    uint8_t hseMhz; // Not used for non-F4 targets
 } systemConfig_t;
 
 PG_DECLARE(systemConfig_t, systemConfig);

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3594,6 +3594,22 @@ static void cliStatus(char *cmdline)
 
     cliPrintf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
 
+#ifdef STM32F4
+    // Only F4 is capable of switching between HSE/HSI (for now)
+    int sysclkSource = SystemSYSCLKSource();
+
+    const char *SYSCLKSource[] = { "HSI", "HSE", "PLLP", "PLLR" };
+    const char *PLLSource[] = { "-HSI", "-HSE" };
+
+    int pllSource;
+
+    if (sysclkSource >= 2) {
+        pllSource = SystemPLLSource();
+    }
+
+    cliPrintf(" (%s%s)", SYSCLKSource[sysclkSource], (sysclkSource < 2) ? "" : PLLSource[pllSource]);
+#endif
+
 #ifdef USE_ADC_INTERNAL
     uint16_t vrefintMv = getVrefMv();
     int16_t coretemp = getCoreTemperatureCelsius();

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -1112,6 +1112,7 @@ const clivalue_t valueTable[] = {
 #endif
 
 // PG_SYSTEM_CONFIG
+    { "system_hse_mhz",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, hseMhz) },
 #if defined(USE_TASK_STATISTICS)
     { "task_statistics",            VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, task_statistics) },
 #endif

--- a/src/main/target/STM32F7X2/config/NERO.config
+++ b/src/main/target/STM32F7X2/config/NERO.config
@@ -6,6 +6,9 @@
 
 defaults nosave
 
+# External crystal frequency
+set system_hse_mhz = 8
+
 # Basic I/O
 resource LED 1 B06
 resource LED 2 B05

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -204,3 +204,15 @@
 #if defined(USE_RX_CX10)
 #define USE_RX_XN297
 #endif
+
+// Setup crystal frequency for backward compatibility
+// Should be set to zero for generic targets and set with CLI variable set system_hse_value.
+#ifdef GENERIC_TARGET
+#define SYSTEM_HSE_VALUE 0
+#else
+#ifdef TARGET_XTAL_MHZ
+#define SYSTEM_HSE_VALUE TARGET_XTAL_MHZ
+#else
+#define SYSTEM_HSE_VALUE (HSE_VALUE/1000000U)
+#endif
+#endif

--- a/src/main/target/system_stm32f4xx.h
+++ b/src/main/target/system_stm32f4xx.h
@@ -36,6 +36,9 @@ extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Cloc
 extern void SystemInit(void);
 extern void SystemCoreClockUpdate(void);
 extern void OverclockRebootIfNecessary(uint32_t overclockLevel);
+extern void systemClockSetHSEValue(uint32_t frequency);
+extern int SystemSYSCLKSource(void);
+extern int SystemPLLSource(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
An experimental system clock initialization that gives partial solution to #7069.

`SetSysClock` will resort to HSI sourced PLL until CLI variable `system_hse_mhz` variable is set to a non-zero value. Upon the first reboot after the variable is set to reflect the actual board Xtal frequency, the board will reboot again to move to HSE sourced PLL.
