### PR TITLE
Remove duplicated throttle max in MSP_GPS_RESCUE

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1050,7 +1050,6 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, gpsRescueConfig()->throttleMin);
         sbufWriteU16(dst, gpsRescueConfig()->throttleMax);
         sbufWriteU16(dst, gpsRescueConfig()->throttleHover);
-        sbufWriteU16(dst, gpsRescueConfig()->throttleMax);
         sbufWriteU8(dst,  gpsRescueConfig()->sanityChecks);
         sbufWriteU8(dst,  gpsRescueConfig()->minSats);
         break;


### PR DESCRIPTION
Fixes a duplicated parameter in MSP command for MSP_GPS_RESCUE.

This command is new for version 4.0, so I think that we can simply remove it.