### PR TITLE
[DASHBOARD] Fix buffer overruns

### DIFF
--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -317,6 +317,11 @@ static void showProfilePage(void)
         i2c_OLED_set_line(bus, rowIndex++);
         i2c_OLED_send_string(bus, lineBuffer);
     }
+}
+
+static void showRateProfilePage(void)
+{
+    uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
 
     const uint8_t currentRateProfileIndex = getCurrentControlRateProfileIndex();
     tfp_sprintf(lineBuffer, "Rate profile: %d", currentRateProfileIndex);
@@ -324,7 +329,13 @@ static void showProfilePage(void)
     i2c_OLED_send_string(bus, lineBuffer);
 
     const controlRateConfig_t *controlRateConfig = controlRateProfiles(currentRateProfileIndex);
-    tfp_sprintf(lineBuffer, "RRr:%d PRR:%d YRR:%d",
+
+    tfp_sprintf(lineBuffer, "         R   P   Y");
+    padLineBuffer();
+    i2c_OLED_set_line(bus, rowIndex++);
+    i2c_OLED_send_string(bus, lineBuffer);
+
+    tfp_sprintf(lineBuffer, "RcRate %3d %3d %3d",
         controlRateConfig->rcRates[FD_ROLL],
         controlRateConfig->rcRates[FD_PITCH],
         controlRateConfig->rcRates[FD_YAW]
@@ -333,16 +344,7 @@ static void showProfilePage(void)
     i2c_OLED_set_line(bus, rowIndex++);
     i2c_OLED_send_string(bus, lineBuffer);
 
-    tfp_sprintf(lineBuffer, "RE:%d PE:%d YE:%d",
-        controlRateConfig->rcExpo[FD_ROLL],
-        controlRateConfig->rcExpo[FD_PITCH],
-        controlRateConfig->rcExpo[FD_YAW]
-    );
-    padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
-
-    tfp_sprintf(lineBuffer, "RR:%d PR:%d YR:%d",
+    tfp_sprintf(lineBuffer, "Super  %3d %3d %3d",
         controlRateConfig->rates[FD_ROLL],
         controlRateConfig->rates[FD_PITCH],
         controlRateConfig->rates[FD_YAW]
@@ -350,7 +352,17 @@ static void showProfilePage(void)
     padLineBuffer();
     i2c_OLED_set_line(bus, rowIndex++);
     i2c_OLED_send_string(bus, lineBuffer);
+
+    tfp_sprintf(lineBuffer, "Expo   %3d %3d %3d",
+        controlRateConfig->rcExpo[FD_ROLL],
+        controlRateConfig->rcExpo[FD_PITCH],
+        controlRateConfig->rcExpo[FD_YAW]
+    );
+    padLineBuffer();
+    i2c_OLED_set_line(bus, rowIndex++);
+    i2c_OLED_send_string(bus, lineBuffer);
 }
+
 #define SATELLITE_COUNT (sizeof(GPS_svinfo_cno) / sizeof(GPS_svinfo_cno[0]))
 #define SATELLITE_GRAPH_LEFT_OFFSET ((SCREEN_CHARACTER_COLUMN_COUNT - SATELLITE_COUNT) / 2)
 
@@ -451,7 +463,9 @@ static void showBatteryPage(void)
     if (batteryConfig()->currentMeterSource != CURRENT_METER_NONE) {
 
         int32_t amperage = getAmperage();
-        tfp_sprintf(lineBuffer, "Amps: %d.%2d mAh: %d", amperage / 100, amperage % 100, getMAhDrawn());
+        // 123456789012345678901
+        // Amp: DDD.D mAh: DDDDD
+        tfp_sprintf(lineBuffer, "Amp: %d.%d mAh: %d", amperage / 100, (amperage % 100) / 10, getMAhDrawn());
         padLineBuffer();
         i2c_OLED_set_line(bus, rowIndex++);
         i2c_OLED_send_string(bus, lineBuffer);
@@ -570,6 +584,7 @@ static const pageEntry_t pages[PAGE_COUNT] = {
     { PAGE_WELCOME, FC_FIRMWARE_NAME,  showWelcomePage,    PAGE_FLAGS_SKIP_CYCLING },
     { PAGE_ARMED,   "ARMED",           showArmedPage,      PAGE_FLAGS_SKIP_CYCLING },
     { PAGE_PROFILE, "PROFILE",         showProfilePage,    PAGE_FLAGS_NONE },
+    { PAGE_RPROF,   "RATE PROFILE",    showRateProfilePage,PAGE_FLAGS_NONE },
 #ifdef USE_GPS
     { PAGE_GPS,     "GPS",             showGpsPage,        PAGE_FLAGS_NONE },
 #endif

--- a/src/main/io/dashboard.h
+++ b/src/main/io/dashboard.h
@@ -43,7 +43,8 @@ typedef enum {
     PAGE_SENSORS,
     PAGE_RX,
     PAGE_PROFILE,
-#if defined(USE_TASK_STATISTICS)
+    PAGE_RPROF,
+#ifndef SKIP_TASK_STATISTICS
     PAGE_TASKS,
 #endif
 #ifdef USE_GPS

--- a/src/main/io/dashboard.h
+++ b/src/main/io/dashboard.h
@@ -44,7 +44,7 @@ typedef enum {
     PAGE_RX,
     PAGE_PROFILE,
     PAGE_RPROF,
-#ifndef SKIP_TASK_STATISTICS
+#if defined(USE_TASK_STATISTICS)
     PAGE_TASKS,
 #endif
 #ifdef USE_GPS


### PR DESCRIPTION
Fixes two buffer overrun conditions.

As described by @etracer65 in https://github.com/betaflight/betaflight/issues/7042#issuecomment-438441670

---
`static char lineBuffer[SCREEN_CHARACTER_COLUMN_COUNT + 1];`

`SCREEN_CHARACTER_COLUMN_COUNT` is 21 (128 / 6).

There's a buffer overflow generated here when displaying the rcRates. Default rates would use 23 characters and look like:
```
RRr:100 PRR:100 YRR:100
```
https://github.com/betaflight/betaflight/blob/a2cfa7b1f08aebe8d74b2518cc960460078638ca/src/main/io/dashboard.c#L327-L331

Also a potential buffer overflow here if current was over 99A and > 999mah drawn.

https://github.com/betaflight/betaflight/blob/a2cfa7b1f08aebe8d74b2518cc960460078638ca/src/main/io/dashboard.c#L454

---

The first case was causing `max7456Lock` which is immediately behind the `lineBuffer` to spontaneously become `true` (non-zero) and causing MAX driver from updating the screen.

The profile page was overflowing by one line anyway, so I created the rate profile page and did a table like formatting to save column widths.

Fixes #7042 