### PR TITLE
[MAX7456] Protect MAX7456 driver from unconfigured SPI

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -415,7 +415,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
 {
     max7456HardwareReset();
 
-    if (!max7456Config->csTag) {
+    if (!max7456Config->csTag || !max7456Config->spiDevice) {
         return false;
     }
 


### PR DESCRIPTION
Fixes the hard fault case when OSD is enabled without configuring SPI for MAX7456.