### PR TITLE
GPS Rescue: Add GPS LOST to Sanity Checks

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -71,6 +71,7 @@ typedef enum {
 typedef enum {
     RESCUE_HEALTHY,
     RESCUE_FLYAWAY,
+    RESCUE_GPSLOST,
     RESCUE_LOWSATS,
     RESCUE_CRASH_FLIP_DETECTED,
     RESCUE_STALLED,
@@ -97,6 +98,7 @@ typedef struct {
     float zVelocityAvg; // Up/down average in cm/s
     float accMagnitude;
     float accMagnitudeAvg;
+    bool healthy;
 } rescueSensorData_s;
 
 typedef struct {
@@ -337,6 +339,11 @@ static void performSanityChecks()
         rescueState.failure = RESCUE_CRASH_FLIP_DETECTED;
     }
 
+    // Check if GPS comms are healthy
+    if (!rescueState.sensor.healthy) {
+        rescueState.failure = RESCUE_GPSLOST;
+    }
+
     //  Things that should run at a low refresh rate (such as flyaway detection, etc)
     //  This runs at ~1hz
 
@@ -372,6 +379,7 @@ static void performSanityChecks()
 static void sensorUpdate()
 {
     rescueState.sensor.currentAltitudeCm = getEstimatedAltitudeCm();
+    rescueState.sensor.healthy = gpsIsHealthy();
 
     // Calculate altitude velocity
     static uint32_t previousTimeUs;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -591,6 +591,11 @@ bool gpsNewFrame(uint8_t c)
     return false;
 }
 
+// Check for healthy communications
+bool gpsIsHealthy()
+{
+    return (gpsData.state == GPS_RECEIVING_DATA);
+}
 
 /* This is a light implementation of a GPS frame decoding
    This should work with most of modern GPS devices configured to output 5 frames.

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -162,6 +162,7 @@ extern uint8_t GPS_svinfo_cno[16];         // Carrier to Noise Ratio (Signal Str
 void gpsInit(void);
 void gpsUpdate(timeUs_t currentTimeUs);
 bool gpsNewFrame(uint8_t c);
+bool gpsIsHealthy(void); // Check for healthy communications
 struct serialPort_s;
 void gpsEnablePassthrough(struct serialPort_s *gpsPassthroughPort);
 void onGpsNewData(void);


### PR DESCRIPTION
Before this change, if GPS connection was lost during or before GPS Rescue started, it would take between 5 and 10 seconds for the Sanity Check LOWSATS to kick in. Meanwhile, the quad would be flying without control.

With this change, depending on when the GPS connection is lost, this would be the behaviour of the quad:

- GPS stops sending data just before Rescue activation: quad will get set to 0 angle, with last throttle value commanded by RC. 2.5 seconds after that, if GPS connection is not yet restored, Sanity check will drop the quad
- GPS stops sending data 2.5s or more before Rescue activation: Sanity check will drop the quad immediately
- GPS stops sending data after Rescue activation: quad will keep the last throttle/attitude calculated by Rescue, and 2.5s later if the GPS connection is not yet restored, the quad will be dropped by Sanity check