### PR TITLE
Total Distance is reset on re-arming

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -277,7 +277,7 @@ void updateArmingStatus(void)
 
 #ifdef USE_GPS_RESCUE
         if (isModeActivationConditionPresent(BOXGPSRESCUE)) {
-            if (!gpsRescueConfig()->minSats || STATE(GPS_FIX_HOME) || ARMING_FLAG(WAS_EVER_ARMED)) {
+            if (!gpsRescueConfig()->minSats || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {
                 setArmingDisabled(ARMING_DISABLED_GPS);

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -158,8 +158,6 @@ rescueState_s rescueState;
 */
 void rescueNewGpsData(void)
 {
-    if (!ARMING_FLAG(ARMED))
-	GPS_reset_home_position();
     newGPSData = true;
 }
 


### PR DESCRIPTION
Total Distance is currently reset on disarm, so it shows 0 on stats. Created proper logic for resetting on re-arming, so it shows properly during stats screen.

I previously overlooked that GPS_reset_home_position was reset on disarm, because this logic is included in gps_rescue.c:

void rescueNewGpsData(void)
{
    if (!ARMING_FLAG(ARMED))
	GPS_reset_home_position();
    newGPSData = true;
}

I suggest this particular logic should go into onGpsNewData() in gps.c, making the reset home position on disarm a general behaviour of GPS (why not?), and not a particular case of GPS Rescue.