### PR TITLE
Total Ascent added to OSD and Stats

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -88,6 +88,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"HOME DIR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIR], 0},
     {"HOME DIST",          OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIST], 0},
     {"TOTAL DIST",         OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_TOTAL_DIST], 0},
+    {"TOTAL ASCENT",       OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_TOTAL_ASCENT], 0},
 #endif // GPS
     {"COMPASS BAR",        OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_COMPASS_BAR], 0},
     {"ALTITUDE",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ALTITUDE], 0},

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -1056,6 +1056,7 @@ const clivalue_t valueTable[] = {
     { "osd_home_dir_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_HOME_DIR]) },
     { "osd_home_dist_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_HOME_DIST]) },
     { "osd_total_dist_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_TOTAL_DIST]) },
+    { "osd_total_ascent_pos",       VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_TOTAL_ASCENT]) },
     { "osd_compass_bar_pos",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_COMPASS_BAR]) },
     { "osd_altitude_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ALTITUDE]) },
     { "osd_pid_roll_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ROLL_PIDS]) },
@@ -1107,6 +1108,7 @@ const clivalue_t valueTable[] = {
     { "osd_stat_max_esc_rpm",       VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_MAX_ESC_RPM,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
     { "osd_stat_min_link_quality",  VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_MIN_LINK_QUALITY,PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
     { "osd_stat_total_dist",        VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_TOTAL_DISTANCE,  PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
+    { "osd_stat_total_ascent",      VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_TOTAL_ASCENT,    PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
 
 #endif
 

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -126,10 +126,10 @@ extern int32_t GPS_home[2];
 extern uint16_t GPS_distanceToHome;        // distance to home point in meters
 extern int16_t GPS_directionToHome;        // direction to home or hol point in degrees
 extern uint32_t GPS_distanceFlownInCm;     // distance flown since armed in centimeters
+extern uint32_t GPS_heightAscendedInCm;    // height ascended since armed in centimeters
 extern int16_t GPS_angle[ANGLE_INDEX_COUNT];                // it's the angles that must be applied for GPS correction
 extern float dTnav;             // Delta Time in milliseconds for navigation computations, updated with every good GPS read
 extern float GPS_scaleLonDown;  // this is used to offset the shrinking longitude as we go towards the poles
-extern int16_t actual_speed[2];
 extern int16_t nav_takeoff_bearing;
 // navigation mode
 typedef enum {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -618,6 +618,18 @@ static bool osdDrawSingleElement(uint8_t item)
         }
         break;
 
+    case OSD_TOTAL_ASCENT:
+        if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
+            osdFormatAltitudeString(buff, GPS_heightAscendedInCm);
+        } else {
+            // We use this symbol when we don't have a FIX
+            buff[0] = SYM_COLON;
+            // overwrite any previous distance with blanks
+            memset(buff + 1, SYM_BLANK, 6);
+            buff[7] = '\0';
+        }
+        break;
+
 #endif // GPS
 
     case OSD_COMPASS_BAR:
@@ -1182,6 +1194,7 @@ static void osdDrawElements(void)
         osdDrawSingleElement(OSD_HOME_DIST);
         osdDrawSingleElement(OSD_HOME_DIR);
         osdDrawSingleElement(OSD_TOTAL_DIST);
+        osdDrawSingleElement(OSD_TOTAL_ASCENT);
     }
 #endif // GPS
 
@@ -1663,8 +1676,12 @@ static void osdShowStats(uint16_t endBatteryVoltage)
         tfp_sprintf(buff, "%d%c", osdGetMetersToSelectedUnit(distanceFlown), osdGetMetersToSelectedUnitSymbol());
         osdDisplayStatisticLabel(top++, "TOTAL DISTANCE", buff);
     }
-#endif
 
+    if (osdStatGetState(OSD_STAT_TOTAL_ASCENT) && featureIsEnabled(FEATURE_GPS)) {
+        osdFormatAltitudeString(buff, GPS_heightAscendedInCm);
+        osdDisplayStatisticLabel(top++, "TOTAL ASCENT", buff);
+    }
+#endif
 }
 
 static void osdShowArmed(void)

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -101,6 +101,7 @@ typedef enum {
     OSD_FLIP_ARROW,
     OSD_LINK_QUALITY,
     OSD_TOTAL_DIST,
+    OSD_TOTAL_ASCENT,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -133,6 +134,7 @@ typedef enum {
     OSD_STAT_MAX_ESC_RPM,
     OSD_STAT_MIN_LINK_QUALITY,
     OSD_STAT_TOTAL_DISTANCE,
+    OSD_STAT_TOTAL_ASCENT,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -72,6 +72,7 @@ extern "C" {
     uint16_t GPS_distanceToHome;
     int16_t GPS_directionToHome;
     uint32_t GPS_distanceFlownInCm;
+    uint32_t GPS_heightAscendedInCm;
     int32_t GPS_coord[2];
     gpsSolutionData_t gpsSol;
     float motor[8];
@@ -314,6 +315,7 @@ TEST(OsdTest, TestStatsImperial)
     osdStatSetState(OSD_STAT_RTC_DATE_TIME, true);
     osdStatSetState(OSD_STAT_MAX_DISTANCE, true);
     osdStatSetState(OSD_STAT_TOTAL_DISTANCE, true);
+    osdStatSetState(OSD_STAT_TOTAL_ASCENT, true);
     osdStatSetState(OSD_STAT_BLACKBOX_NUMBER, false);
     osdStatSetState(OSD_STAT_MAX_G_FORCE, false);
     osdStatSetState(OSD_STAT_MAX_ESC_TEMP, false);
@@ -357,6 +359,7 @@ TEST(OsdTest, TestStatsImperial)
     gpsSol.groundSpeed = 500;
     GPS_distanceToHome = 20;
     GPS_distanceFlownInCm = 2000;
+    GPS_heightAscendedInCm = 100;
     simulationBatteryVoltage = 158;
     simulationAltitude = 100;
     simulationTime += 1e6;
@@ -366,6 +369,7 @@ TEST(OsdTest, TestStatsImperial)
     gpsSol.groundSpeed = 800;
     GPS_distanceToHome = 50;
     GPS_distanceFlownInCm = 10000;
+    GPS_heightAscendedInCm = 150;
     simulationBatteryVoltage = 147;
     simulationAltitude = 150;
     simulationTime += 1e6;
@@ -375,6 +379,7 @@ TEST(OsdTest, TestStatsImperial)
     gpsSol.groundSpeed = 200;
     GPS_distanceToHome = 100;
     GPS_distanceFlownInCm = 20000;
+    GPS_heightAscendedInCm = 200;
     simulationBatteryVoltage = 152;
     simulationAltitude = 200;
     simulationTime += 1e6;
@@ -397,6 +402,7 @@ TEST(OsdTest, TestStatsImperial)
     displayPortTestBufferSubstring(2, row++, "MIN RSSI          : 25%%");
     displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      :    6.5%c", SYM_FT);
     displayPortTestBufferSubstring(2, row++, "TOTAL DISTANCE    : 656%c", SYM_FT);
+    displayPortTestBufferSubstring(2, row++, "TOTAL ASCENT      :    6.5%c", SYM_FT);
 }
 
 /*
@@ -423,6 +429,7 @@ TEST(OsdTest, TestStatsMetric)
     gpsSol.groundSpeed = 800;
     GPS_distanceToHome = 100;
     GPS_distanceFlownInCm = 10000;
+    GPS_heightAscendedInCm = 200;
     simulationBatteryVoltage = 147;
     simulationAltitude = 200;
     simulationTime += 1e6;
@@ -450,6 +457,7 @@ TEST(OsdTest, TestStatsMetric)
     displayPortTestBufferSubstring(2, row++, "MIN RSSI          : 25%%");
     displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      :    2.0%c", SYM_M);
     displayPortTestBufferSubstring(2, row++, "TOTAL DISTANCE    : 100%c", SYM_M);
+    displayPortTestBufferSubstring(2, row++, "TOTAL ASCENT      :    2.0%c", SYM_M);
 }
 
 /*


### PR DESCRIPTION
Total Ascent calculated accumulating positive differences in height. Available both for OSD and Stats.

Height is specially jittery when coming from GPS, so calculation is done on a 5s interval. This mitigates accumulating excessive loss of precision. Total Distance is now calculated on 5s interval as well, for the same reason.

While cleaning up some code, I've noted that actual_speed was not used anywhere in the code. It seems to have been superseded by groundSpeed, so I've removed that chunk of code.

Tradeoffs:
- I've chosen the wording for Total Ascent to reflect the calculation only takes care of positive differences, in opposition to what could be Total Descent. Assuming you're landing in the same place where you started flying, it shouldn't matter. The way to account for both ascent and descent would be "max height difference", but I think it's unneededly complex from the user pov.
- I was unsure of calculating Total Ascent outside of gps.c, as the feature only requires a barometer to work. On the other hand, I'm unsure of how accurate is to integrate changes coming from the barometer. From the code perspective, I've tried to include the calculation in osd.c but the result was quite messy, so I've left it in gps.c for now. The downside is that it currently requires GPS to be available and enabled. I'm open to move it somewhere else if it makes more sense.