### PR TITLE
[CLI] Refactor status command to print things in more sensible order

### DIFF
--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -106,6 +106,44 @@
 #error "Invalid chipset specified. Update platform.h"
 #endif
 
+// MCU type names and IDs.
+// IDs are permanent as it has dependency to configurator through MSP reporting
+
+#if defined(SIMULATOR_BUILD)
+#define MCU_TYPE_ID   0
+#define MCU_TYPE_NAME "SIMULATOR"
+#elif defined(STM32F1)
+#define MCU_TYPE_ID   1
+#define MCU_TYPE_NAME "F103"
+#elif defined(STM32F3)
+#define MCU_TYPE_ID   2
+#define MCU_TYPE_NAME "F303"
+#elif defined(STM32F40_41xxx)
+#define MCU_TYPE_ID   3
+#define MCU_TYPE_NAME "F40X"
+#elif defined(STM32F411xE)
+#define MCU_TYPE_ID   4
+#define MCU_TYPE_NAME "F411"
+#elif defined(STM32F446)
+#define MCU_TYPE_ID   5
+#define MCU_TYPE_NAME "F446"
+#elif defined(STM32F722xx)
+#define MCU_TYPE_ID   6
+#define MCU_TYPE_NAME "F722"
+#elif defined(STM32F745xx)
+#define MCU_TYPE_ID   7
+#define MCU_TYPE_NAME "F745"
+#elif defined(STM32F746xx)
+#define MCU_TYPE_ID   8
+#define MCU_TYPE_NAME "F746"
+#elif defined(STM32F765xx)
+#define MCU_TYPE_ID   9
+#define MCU_TYPE_NAME "F765"
+#else
+#define MCU_TYPE_ID   255
+#define MCU_TYPE_NAME "Unknown MCU"
+#endif
+
 #include "target/common_pre.h"
 #include "target.h"
 #include "target/common_post.h"

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -108,6 +108,9 @@ typedef struct
 #define WS2811_DMA_HANDLER_IDENTIFER 0
 #define NVIC_PriorityGroup_2 0x500
 
+#define MCU_TYPE_ID   99
+#define MCU_TYPE_NAME "UNIT_TEST"
+
 #include "target.h"
 
 #include "target/common_defaults_post.h"


### PR DESCRIPTION
Reorder printed items in more sensible way.

Current
```
# status
System Uptime: 31 seconds
Current Time: 0000-01-01T00:00:00.000+00:00
Voltage: 0 * 0.1V (0S battery - NOT PRESENT)
CPU Clock=168MHz, Vref=3.29V, Core temp=40degC, GYRO=MPU6000, ACC=MPU6000, BARO=BMP280
SD card: Startup failed
Stack size: 2048, Stack address: 0x1000fff0
I2C Errors: 0, config size: 2798, max available config: 16384
CPU:29%, cycle time: 125, GYRO rate: 8000, RX rate: 33, System rate: 9
Arming disable flags: RXLOSS CLI MSP GPS
```

New
```
# status
MCU F405 Clock=168MHz (PLLP-HSE), Vref=3.29V, Core temp=39degC
Stack size: 2048, Stack address: 0x1000fff0
Config size: 2860, Max available config: 16384
GYRO=MPU6000, ACC=MPU6000, BARO=BMP280
System Uptime: 8 seconds, Current Time: 0000-01-01T00:00:00.000+00:00
CPU:6%, cycle time: 128, GYRO rate: 7812, RX rate: 33, System rate: 9
Voltage: 0 * 0.1V (0S battery - NOT PRESENT)
I2C Errors: 0
SD card: Manufacturer 0x1d, 30882816kB, 09/2015, v0.2, 'SD '
Filesystem: Ready
Arming disable flags: RXLOSS CLI MSP
```