### PR TITLE
[BLUEJAYF4,YUPIF4] Move BEEPER_OPT out of target.h

### DIFF
--- a/src/main/target/BLUEJAYF4/config.c
+++ b/src/main/target/BLUEJAYF4/config.c
@@ -40,6 +40,9 @@
 
 #include "hardware_revision.h"
 
+// BEEPER_OPT will be handled by post-flash configuration
+#define BEEPER_OPT              PB7
+
 // alternative defaults settings for BlueJayF4 targets
 void targetConfiguration(void)
 {

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -37,7 +37,6 @@
 
 #define USE_BEEPER
 #define BEEPER_PIN              PC1
-#define BEEPER_OPT              PB7
 #define BEEPER_INVERTED
 
 #define INVERTER_PIN_UART6      PB15

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -28,7 +28,6 @@
 
 #define USE_BEEPER
 #define BEEPER_PIN              PA15
-#define BEEPER_OPT              PA2
 
 #define USE_EXTI
 #define USE_GYRO_EXTI

--- a/src/main/target/YUPIF4/config.c
+++ b/src/main/target/YUPIF4/config.c
@@ -35,7 +35,8 @@
 
 #include "hardware_revision.h"
 
-
+// BEEPER_OPT will be handled by post-flash configuration
+#define BEEPER_OPT              PB14
 
 // alternative defaults settings for YuPiF4 targets
 void targetConfiguration(void)

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -32,7 +32,6 @@
 
 #define USE_BEEPER
 #define BEEPER_PIN              PC9
-#define BEEPER_OPT              PB14
 #define BEEPER_PWM_HZ           3150 // Beeper PWM frequency in Hz
 
 // Gyro interrupt


### PR DESCRIPTION
A preparation for generic target.

For BLUEJAYF4 and YUPIF4, it was moved to `config.c`.
For CC3D, it was simply removed, as it was not used.