### PR TITLE
Remove (literal) target dependency from "TARGET_DEFAULT_MIXER"

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -66,15 +66,11 @@
 
 PG_REGISTER_WITH_RESET_TEMPLATE(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
 
-#ifndef TARGET_DEFAULT_MIXER
-#define TARGET_DEFAULT_MIXER    MIXER_QUADX
-#endif
-
 #define DYN_LPF_THROTTLE_STEPS           100
 #define DYN_LPF_THROTTLE_UPDATE_DELAY_US 5000 // minimum of 5ms between updates
 
 PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
-    .mixerMode = TARGET_DEFAULT_MIXER,
+    .mixerMode = DEFAULT_MIXER,
     .yaw_motors_reversed = false,
     .crashflip_motor_percent = 0,
 );

--- a/src/main/target/KISSFC/target.h
+++ b/src/main/target/KISSFC/target.h
@@ -52,7 +52,7 @@
 #define USE_ACC_MPU6050
 #define ACC_1_ALIGN             CW90_DEG
 
-#define TARGET_DEFAULT_MIXER    MIXER_QUADX_1234
+#define DEFAULT_MIXER           MIXER_QUADX_1234
 
 #undef USE_LED_STRIP
 #else

--- a/src/main/target/REVOLT/target.h
+++ b/src/main/target/REVOLT/target.h
@@ -30,7 +30,7 @@
 #endif
 
 
-#define TARGET_DEFAULT_MIXER    MIXER_QUADX_1234
+#define DEFAULT_MIXER           MIXER_QUADX_1234
 
 
 

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -332,3 +332,7 @@
 #define USE_INVERTER
 #endif
 #endif
+
+#ifndef DEFAULT_MIXER
+#define DEFAULT_MIXER    MIXER_QUADX
+#endif


### PR DESCRIPTION
A preparation for generic target.

Just removed `TARGET` part of the symbol, moved default value definition to `common_defaults_post.h`.