### PR TITLE
Increase DSHOT digital idle default value

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -105,7 +105,7 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
 #endif
     motorConfig->maxthrottle = 2000;
     motorConfig->mincommand = 1000;
-    motorConfig->digitalIdleOffsetValue = 450;
+    motorConfig->digitalIdleOffsetValue = 550;
 #ifdef USE_DSHOT_DMAR
     motorConfig->dev.useBurstDshot = ENABLE_DSHOT_DMAR;
 #endif


### PR DESCRIPTION
The DSHOT digital idle value is quite low (4.5%) and is often the cause of support issues as users are unaware that they may have to adjust this based on their motor/ESC requirements - leading to de-syncs and "death rolls" or other flip-outs.

While DSHOT capable ESC's (BLHeli_S & BLHeli32) have faster MCU's and are often capable of smoother low speed idling, 4.5% is still quite low. For comparison the `min_throttle` default is 1070 equating to a 7% idle.

I propose raising the digital idle to 5.5% to reduce occurrences of de-syncs from too low idle speed.
