### PR TITLE
Fixes to allow the MSC command with on-board flash to work on MacOS.

### DIFF
--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -335,7 +335,6 @@ static int8_t SCSI_ReadFormatCapacity(uint8_t lun, uint8_t *params)
 static int8_t SCSI_ModeSense6 (uint8_t lun, uint8_t *params)
 {
   UNUSED(params);
-  UNUSED(lun);
   uint16_t len = 8 ;
   MSC_BOT_DataLen = len;
 
@@ -343,6 +342,11 @@ static int8_t SCSI_ModeSense6 (uint8_t lun, uint8_t *params)
   {
     len--;
     MSC_BOT_Data[len] = MSC_Mode_Sense6_data[len];
+  }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (USBD_STORAGE_fops->IsWriteProtected(lun) != 0) {
+    MSC_BOT_Data[2] = MSC_BOT_Data[2] | (1 << 7);
   }
   return 0;
 }
@@ -357,7 +361,6 @@ static int8_t SCSI_ModeSense6 (uint8_t lun, uint8_t *params)
 static int8_t SCSI_ModeSense10 (uint8_t lun, uint8_t *params)
 {
  UNUSED(params);
- UNUSED(lun);
  uint16_t len = 8;
 
  MSC_BOT_DataLen = len;
@@ -366,6 +369,11 @@ static int8_t SCSI_ModeSense10 (uint8_t lun, uint8_t *params)
   {
     len--;
     MSC_BOT_Data[len] = MSC_Mode_Sense10_data[len];
+  }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (USBD_STORAGE_fops->IsWriteProtected(lun) != 0) {
+    MSC_BOT_Data[3] = MSC_BOT_Data[3] | (1 << 7);
   }
   return 0;
 }


### PR DESCRIPTION
Fixed a bug in the STM libraries to set the write protected bit in the device config for the mass storage SCSI sense code 6 and 10. Previously the `isWriteProtected()` result was only being examined during write attempts and they correctly failed and returned a `NOT_READY` response (we don't support writes for SPIFLASH). Unfortunately since the device was not flagged as write protected on MacOS the operating system would try to write to the device and this would fail causing the operating system to think the device wasn't ready and refuse to mount it.

General fixes (affecting all operating systems):

Ensured that the filesystem appears to be at least 256MB so that the volume will be treated as FAT32 instead of FAT16. A hidden "padding.txt" file is created to represent the extra space.

Fix the directory structure to only create the "btfl_all.bbl" file if there were any logs found. Previously it would always be created and this would lead to directory corruption.

Fix the size calculation for the  "btfl_all.bbl" file. Previously it was being set to the total flash size rather than the used space.
