### PR TITLE
MSC on-board flash: Persist RTC across reboot and use as file timestamp

### DIFF
--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -40,6 +40,9 @@ typedef uint32_t timeUs_t;
 #define TIMEUS_MAX UINT32_MAX
 #endif
 
+#define TIMEZONE_OFFSET_MINUTES_MIN -780  // -13 hours
+#define TIMEZONE_OFFSET_MINUTES_MAX 780   // +13 hours
+
 static inline timeDelta_t cmpTimeUs(timeUs_t a, timeUs_t b) { return (timeDelta_t)(a - b); }
 
 #define FORMATTED_DATE_TIME_BUFSIZE 30
@@ -95,4 +98,6 @@ bool rtcSet(rtcTime_t *t);
 bool rtcGetDateTime(dateTime_t *dt);
 bool rtcSetDateTime(dateTime_t *dt);
 
+void rtcPersistWrite(int16_t offsetMinutes);
+bool rtcPersistRead(rtcTime_t *t);
 #endif

--- a/src/main/drivers/persistent.h
+++ b/src/main/drivers/persistent.h
@@ -30,6 +30,8 @@ typedef enum {
     PERSISTENT_OBJECT_HSE_VALUE,
     PERSISTENT_OBJECT_OVERCLOCK_LEVEL,
     PERSISTENT_OBJECT_BOOTLOADER_REQUEST,
+    PERSISTENT_OBJECT_RTC_HIGH,           // high 32 bits of rtcTime_t
+    PERSISTENT_OBJECT_RTC_LOW,            // low 32 bits of rtcTime_t
     PERSISTENT_OBJECT_COUNT,
 } persistentObjectId_e;
 

--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -31,4 +31,4 @@ bool mscCheckBoot(void);
 uint8_t mscStart(void);
 bool mscCheckButton(void);
 void mscWaitForButton(void);
-void systemResetToMsc(void);
+void systemResetToMsc(int timezoneOffsetMinutes);

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -159,11 +159,18 @@ void mscWaitForButton(void)
     }
 }
 
-void systemResetToMsc(void)
+void systemResetToMsc(int timezoneOffsetMinutes)
 {
     *((uint32_t *)0x2001FFF0) = MSC_MAGIC;
 
     __disable_irq();
+
+    // Persist the RTC across the reboot to use as the file timestamp
+#ifdef USE_PERSISTENT_MSC_RTC
+    rtcPersistWrite(timezoneOffsetMinutes);
+#else
+    UNUSED(timezoneOffsetMinutes);
+#endif
     NVIC_SystemReset();
 }
 #endif

--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -164,11 +164,18 @@ void mscWaitForButton(void)
     }
 }
 
-void systemResetToMsc(void)
+void systemResetToMsc(int timezoneOffsetMinutes)
 {
     *((__IO uint32_t*) BKPSRAM_BASE + 16) = MSC_MAGIC;
 
     __disable_irq();
+
+    // Persist the RTC across the reboot to use as the file timestamp
+#ifdef USE_PERSISTENT_MSC_RTC
+    rtcPersistWrite(timezoneOffsetMinutes);
+#else
+    UNUSED(timezoneOffsetMinutes);
+#endif
     NVIC_SystemReset();
 }
 #endif

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -58,6 +58,7 @@
 #include "drivers/light_led.h"
 #include "drivers/mco.h"
 #include "drivers/nvic.h"
+#include "drivers/persistent.h"
 #include "drivers/pwm_esc_detect.h"
 #include "drivers/pwm_output.h"
 #include "drivers/rx/rx_pwm.h"
@@ -88,6 +89,10 @@
 
 #include "interface/cli.h"
 #include "interface/msp.h"
+
+#ifdef USE_PERSISTENT_MSC_RTC
+#include "msc/usbd_storage.h"
+#endif
 
 #include "msp/msp_serial.h"
 
@@ -426,6 +431,12 @@ void init(void)
              NVIC_SystemReset();
         }
     }
+#endif
+
+#ifdef USE_PERSISTENT_MSC_RTC
+    // if we didn't enter MSC mode then clear the persistent RTC value
+    persistentObjectWrite(PERSISTENT_OBJECT_RTC_HIGH, 0);
+    persistentObjectWrite(PERSISTENT_OBJECT_RTC_LOW, 0);
 #endif
 
 #ifdef USE_I2C

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -138,6 +138,7 @@ enum {
     MSP_REBOOT_FIRMWARE = 0,
     MSP_REBOOT_BOOTLOADER,
     MSP_REBOOT_MSC,
+    MSP_REBOOT_MSC_UTC,
     MSP_REBOOT_COUNT,
 };
 
@@ -253,8 +254,14 @@ static void mspRebootFn(serialPort_t *serialPort)
         break;
 #if defined(USE_USB_MSC)
     case MSP_REBOOT_MSC:
-        systemResetToMsc();
-
+    case MSP_REBOOT_MSC_UTC: {
+#ifdef USE_RTC_TIME
+        const int16_t timezoneOffsetMinutes = (rebootMode == MSP_REBOOT_MSC) ? timeConfig()->tz_offsetMinutes : 0;
+        systemResetToMsc(timezoneOffsetMinutes);
+#else
+        systemResetToMsc(0);
+#endif
+        }
         break;
 #endif
     default:

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -30,6 +30,7 @@
 #include "cms/cms.h"
 
 #include "common/utils.h"
+#include "common/time.h"
 
 #include "drivers/adc.h"
 #include "drivers/bus_i2c.h"
@@ -1265,6 +1266,11 @@ const clivalue_t valueTable[] = {
     { "spektrum_spi_protocol",     VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 255 }, PG_RX_SPEKTRUM_SPI_CONFIG, offsetof(spektrumConfig_t, protocol) },
     { "spektrum_spi_mfg_id",       VAR_UINT8 | MASTER_VALUE | MODE_ARRAY, .config.array.length = 4, PG_RX_SPEKTRUM_SPI_CONFIG, offsetof(spektrumConfig_t, mfgId) },
     { "spektrum_spi_num_channels", VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, DSM_MAX_CHANNEL_COUNT }, PG_RX_SPEKTRUM_SPI_CONFIG, offsetof(spektrumConfig_t, numChannels) },
+#endif
+
+// PG_TIMECONFIG
+#ifdef USE_RTC_TIME
+    { "timezone_offset_minutes",  VAR_INT16 | MASTER_VALUE, .config.minmax = { TIMEZONE_OFFSET_MINUTES_MIN, TIMEZONE_OFFSET_MINUTES_MAX }, PG_TIME_CONFIG, offsetof(timeConfig_t, tz_offsetMinutes) },
 #endif
 };
 

--- a/src/main/msc/usbd_storage.c
+++ b/src/main/msc/usbd_storage.c
@@ -21,6 +21,9 @@
 /*
  * Author: jflyper (https://github.com/jflyper)
  */
+ 
+#include "platform.h"
+#include "common/time.h"
 
 #ifdef USE_HAL_DRIVER
 #include "usbd_msc.h"

--- a/src/main/msc/usbd_storage.h
+++ b/src/main/msc/usbd_storage.h
@@ -27,6 +27,8 @@
 #include "usbd_msc_core.h"
 #endif
 
+#include "common/time.h"
+
 #ifdef USE_HAL_DRIVER
 extern USBD_StorageTypeDef *USBD_STORAGE_fops;
 #ifdef USE_SDCARD_SDIO

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -223,3 +223,7 @@
 #define SPI_PREINIT_COUNT 16 // 2 x 8 (GYROx2, BARO, MAG, MAX, FLASHx2, RX)
 #endif
 #endif
+
+#if (!defined(USE_FLASHFS) || !defined(USE_RTC_TIME) || !defined(USE_USB_MSC))
+#undef USE_PERSISTENT_MSC_RTC
+#endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -59,6 +59,7 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
+#define USE_PERSISTENT_MSC_RTC
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)
 #define USE_OVERCLOCK
@@ -78,6 +79,7 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
+#define USE_PERSISTENT_MSC_RTC
 #define USE_MCO
 #endif
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -37,6 +37,7 @@ extern "C" {
     #include "common/time.h"
 
     #include "drivers/max7456_symbols.h"
+    #include "drivers/persistent.h"
     #include "drivers/serial.h"
 
     #include "fc/config.h"
@@ -1080,4 +1081,6 @@ extern "C" {
     bool failsafeIsActive(void) { return false; }
     bool gpsRescueIsConfigured(void) { return false; }
     int8_t calculateThrottlePercent(void) { return 0; }
+    uint32_t persistentObjectRead(persistentObjectId_e) { return 0; }
+    void persistentObjectWrite(persistentObjectId_e, uint32_t) {}
 }


### PR DESCRIPTION
NOTE: Requires development version of Configurator 10.5 for proper RTC clock operation. Changes were made for API version 1.41 that effect the setting of the RTC and it will not work properly with older versions of the Configurator (changes are unrelated to this PR).

Adds support to persist the RTC (if set) across the reboot if entering mass storage mode for on-board flash. The value is then used as the timestamp for the files exposed in the virtual FAT32 filesystem. The files will then have reasonable creation dates when copied to the host computer.

The RTC is set when the Configurator connects to the firmware. So the RTC value is available when the user reboots the flight controller in to mass storage mode using the `msc` command.

If the RTC is not set (or supported), then the default timestamp of 2018-01-01 will be used (unchanged from previous).

Also stubbed in support for `PERSISTENT` memory region on F7. So the feature will work once `PERSISTENT` support is fully added.

Included some improvements to the RTC functions and exposed the `tz_offset_minutes` in the `timeConfig` PG. Support already existed for timezone offsets but the parameter wasn't exposed to the user and couldn't be set.
