### PR TITLE
Fix SmartAudio 'looping' after vtx_freq in MHz set

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -585,6 +585,9 @@ static void saDoDevSetFreq(uint16_t freq)
         switchBuf[6] = CRC8(switchBuf, 6);
 
         saQueueCmd(switchBuf, 7);
+
+        // need to do a 'get' between the 'set' commands to keep tracking vars in sync
+        saGetSettings();
     }
 
     saQueueCmd(buf, 7);


### PR DESCRIPTION
This fixes an issue with the BF SmartAudio implementation where, if the VTX is in band/channel mode, and then a VTX frequency in MHz is configured, the system gets stuck in a constant 'looping' condition where the VTX freq-set command is sent over and over again.  While this is happening, VTX transmission blips on and off.

This issue happens regardless of how the VTX is configured  -- via the Taranis 'lua' scripts, the OSD, or via the CLI ("set vtx_band=0", "set vtx_freq=MMMM", "save").  When using a TBS Unify VTX, doing a reboot of the flight controller tends to clear it up.  When using an AKK VTX, the 'looping' resumes even after a reboot.

The fix I found is to add a call to 'saGetSettings()' in the 'saDoDevSetFreq()' function in 'vtx_smartaudio.c' where the set-frequency-in-MHz command is queued.  This reverts the command sequence to how it used to be before the queuing was implemented (and the 'looping' wouldn't happen). See [here](https://github.com/codecae/betaflight/blob/ed68e57d48da080a6a40509c9852e6fb8a22646f/src/main/io/vtx_smartaudio.c#L592) for how it used to be, and [here](https://github.com/betaflight/betaflight/pull/4636) for how is was changed.

I've tested this with SPRACINGF3, BETAFLIGHTF3 and FRSKYF3 boards running TBS Unify Pro HV Race, TBS Unify Nano, and AKK Nano2 VTXs.  In all of my testing it fixes the issue and causes no problems.

--ET