### PR TITLE
Arm prevention if Rescue is activated

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -282,6 +282,11 @@ void updateArmingStatus(void)
             } else {
                 setArmingDisabled(ARMING_DISABLED_GPS);
             }
+            if (IS_RC_MODE_ACTIVE(BOXGPSRESCUE)) {
+                setArmingDisabled(ARMING_DISABLED_RESC);
+            } else {
+                unsetArmingDisabled(ARMING_DISABLED_RESC);
+            }
         }
 #endif
 
@@ -828,7 +833,7 @@ bool processRx(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_GPS_RESCUE
-    if (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE)) {
+    if (ARMING_FLAG(ARMED) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
         if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -53,7 +53,8 @@ const char *armingDisableFlagNames[]= {
     "MSP",
     "PARALYZE",
     "GPS",
-    "ARMSWITCH"
+    "RESCUE SW",
+    "ARMSWITCH",
 };
 
 static armingDisableFlags_e armingDisableFlags = 0;

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -57,10 +57,11 @@ typedef enum {
     ARMING_DISABLED_MSP             = (1 << 16),
     ARMING_DISABLED_PARALYZE        = (1 << 17),
     ARMING_DISABLED_GPS             = (1 << 18),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 19), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_RESC            = (1 << 19),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 20), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
-#define ARMING_DISABLE_FLAGS_COUNT 20
+#define ARMING_DISABLE_FLAGS_COUNT 21
 
 extern const char *armingDisableFlagNames[ARMING_DISABLE_FLAGS_COUNT];
 

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -427,17 +427,17 @@ void updateGPSRescueState(void)
             hoverThrottle = gpsRescueConfig()->throttleHover;
         }
 
-        // Minimum distance detection.  Disarm regardless of sanity check configuration.  Rescue too close is never a good idea.
+        // Minimum distance detection.
         if (rescueState.sensor.distanceToHomeM < gpsRescueConfig()->minRescueDth) {
-            // Never allow rescue mode to engage as a failsafe when too close or when disarmed.
-            if (rescueState.isFailsafe || !ARMING_FLAG(ARMED)) {
-                rescueState.failure = RESCUE_TOO_CLOSE;
+            rescueState.failure = RESCUE_TOO_CLOSE;
+            
+            // Never allow rescue mode to engage as a failsafe when too close.
+            if (rescueState.isFailsafe) {
                 setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
                 disarm();
-            } else {
-                // Leave it up to the sanity check setting
-                rescueState.failure = RESCUE_TOO_CLOSE;
             }
+            
+            // When not in failsafe mode: leave it up to the sanity check setting.
         }
 
         rescueState.phase = RESCUE_ATTAIN_ALT;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -39,6 +39,9 @@ arming_prevention_unittest_SRC := \
 		$(USER_DIR)/fc/runtime_config.c \
 		$(USER_DIR)/common/bitarray.c
 
+arming_prevention_unittest_DEFINES := \
+            USE_GPS_RESCUE=
+
 atomic_unittest_SRC := \
 		$(USER_DIR)/build/atomic.c \
 		$(TEST_DIR)/atomic_unittest_c.c


### PR DESCRIPTION
If Rescue mode is activated (via switch) when disarmed, arming is disabled as it doesn't make sense. I also simplified the minimum distance handling code.