### PR TITLE
GPS Rescue: check failsafe procedure when preventing arming

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -276,7 +276,7 @@ void updateArmingStatus(void)
         }
 
 #ifdef USE_GPS_RESCUE
-        if (isModeActivationConditionPresent(BOXGPSRESCUE)) {
+        if (gpsRescueIsConfigured()) {
             if (!gpsRescueConfig()->minSats || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {


### PR DESCRIPTION
Previous code was preventing arming only if GPS Rescue was configured on a switch. Now the condition is extended to also check if failsafe procedure is set to Rescue. In that case, when there is no GPS Fix, arming is prevented. Note that the arming prevention can be disabled by setting gps_rescue_min_sats to 0.
