### PR TITLE
[SYSTEM] Use RTC backup register for persistent storage

### DIFF
--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -37,7 +37,6 @@ EXCLUDES        = stm32f4xx_crc.c \
                   stm32f4xx_cryp_aes.c \
                   stm32f4xx_hash_md5.c \
                   stm32f4xx_cryp_des.c \
-                  stm32f4xx_rtc.c \
                   stm32f4xx_hash.c \
                   stm32f4xx_dbgmcu.c \
                   stm32f4xx_cryp_tdes.c \
@@ -183,7 +182,8 @@ MCU_COMMON_SRC = \
             drivers/serial_uart_init.c \
             drivers/serial_uart_stm32f4xx.c \
             drivers/system_stm32f4xx.c \
-            drivers/timer_stm32f4xx.c
+            drivers/timer_stm32f4xx.c \
+            drivers/persistent.c
 
 ifeq ($(PERIPH_DRIVER), HAL)
 VCP_SRC = \

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -41,8 +41,6 @@ EXCLUDES        = stm32f7xx_hal_can.c \
                   stm32f7xx_hal_nor.c \
                   stm32f7xx_hal_qspi.c \
                   stm32f7xx_hal_rng.c \
-                  stm32f7xx_hal_rtc.c \
-                  stm32f7xx_hal_rtc_ex.c \
                   stm32f7xx_hal_sai.c \
                   stm32f7xx_hal_sai_ex.c \
                   stm32f7xx_hal_sd.c \
@@ -179,6 +177,7 @@ MCU_COMMON_SRC = \
             drivers/light_ws2811strip_hal.c \
             drivers/transponder_ir_io_hal.c \
             drivers/bus_spi_ll.c \
+            drivers/persistent.c \
             drivers/pwm_output_dshot_hal.c \
             drivers/timer_hal.c \
             drivers/timer_stm32f7xx.c \

--- a/src/main/drivers/persistent.c
+++ b/src/main/drivers/persistent.c
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * An implementation of persistent data storage utilizing RTC backup data register.
+ * Retains values written across software resets and boot loader activities.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+
+#include "drivers/persistent.h"
+
+#define PERSISTENT_OBJECT_MAGIC_VALUE (('B' << 24)|('e' << 16)|('f' << 8)|('1' << 0))
+
+#ifdef USE_HAL_DRIVER
+
+static RTC_HandleTypeDef rtcHandle = { .Instance = RTC } ;
+
+uint32_t persistentObjectRead(persistentObjectId_e id)
+{
+    uint32_t value = HAL_RTCEx_BKUPRead(&rtcHandle, id);
+
+    return value;
+}
+
+void persistentObjectWrite(persistentObjectId_e id, uint32_t value)
+{
+    HAL_RTCEx_BKUPWrite(&rtcHandle, id, value);
+}
+
+void persistentObjectRTCEnable(void)
+{
+    __HAL_RCC_PWR_CLK_ENABLE();
+    HAL_PWR_EnableBkUpAccess();
+
+    __HAL_RCC_LSI_ENABLE();
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) == RESET);
+
+    __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
+    __HAL_RCC_RTC_ENABLE();
+
+    __HAL_RTC_WRITEPROTECTION_ENABLE(&rtcHandle);
+    __HAL_RTC_WRITEPROTECTION_DISABLE(&rtcHandle);
+}
+
+#else
+uint32_t persistentObjectRead(persistentObjectId_e id)
+{
+    uint32_t value = RTC_ReadBackupRegister(id); 
+
+    return value;
+}
+
+void persistentObjectWrite(persistentObjectId_e id, uint32_t value)
+{
+    RTC_WriteBackupRegister(id, value);
+}
+
+void persistentObjectRTCEnable(void)
+{
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR, ENABLE);
+    PWR_BackupAccessCmd(ENABLE);
+
+    RCC_LSICmd(ENABLE);
+    while (RCC_GetFlagStatus(RCC_FLAG_LSIRDY) == RESET);
+
+    RCC_RTCCLKConfig(RCC_RTCCLKSource_LSI);
+    RCC_RTCCLKCmd(ENABLE);
+
+    RTC_WriteProtectionCmd(ENABLE);
+    RTC_WriteProtectionCmd(DISABLE);
+}
+#endif
+
+void persistentObjectInit(void)
+{
+    // Configure and enable RTC for backup register access
+
+    persistentObjectRTCEnable();
+
+    // Magic value checking may be sufficient
+
+    if (!(RCC->CSR & RCC_CSR_SFTRSTF) || (persistentObjectRead(PERSISTENT_OBJECT_MAGIC) != PERSISTENT_OBJECT_MAGIC_VALUE)) {
+        for (int i = 1; i < PERSISTENT_OBJECT_COUNT; i++) {
+            persistentObjectWrite(i, 0);
+        }
+        persistentObjectWrite(PERSISTENT_OBJECT_MAGIC, PERSISTENT_OBJECT_MAGIC_VALUE);
+    }
+}

--- a/src/main/drivers/persistent.c
+++ b/src/main/drivers/persistent.c
@@ -32,10 +32,10 @@
 
 #ifdef USE_HAL_DRIVER
 
-static RTC_HandleTypeDef rtcHandle = { .Instance = RTC } ;
-
 uint32_t persistentObjectRead(persistentObjectId_e id)
 {
+    RTC_HandleTypeDef rtcHandle = { .Instance = RTC };
+
     uint32_t value = HAL_RTCEx_BKUPRead(&rtcHandle, id);
 
     return value;
@@ -43,11 +43,15 @@ uint32_t persistentObjectRead(persistentObjectId_e id)
 
 void persistentObjectWrite(persistentObjectId_e id, uint32_t value)
 {
+    RTC_HandleTypeDef rtcHandle = { .Instance = RTC };
+
     HAL_RTCEx_BKUPWrite(&rtcHandle, id, value);
 }
 
 void persistentObjectRTCEnable(void)
 {
+    RTC_HandleTypeDef rtcHandle = { .Instance = RTC };
+
     __HAL_RCC_PWR_CLK_ENABLE();
     HAL_PWR_EnableBkUpAccess();
 

--- a/src/main/drivers/persistent.h
+++ b/src/main/drivers/persistent.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Available RTC backup registers (4-byte words) per MCU type
+// F4: 20 words
+// F7: 32 words
+// H7: 32 words
+
+typedef enum {
+    PERSISTENT_OBJECT_MAGIC = 0,
+    PERSISTENT_OBJECT_HSE_VALUE,
+    PERSISTENT_OBJECT_OVERCLOCK_LEVEL,
+    PERSISTENT_OBJECT_BOOTLOADER_REQUEST,
+    PERSISTENT_OBJECT_COUNT,
+} persistentObjectId_e;
+
+void persistentObjectInit(void);
+uint32_t persistentObjectRead(persistentObjectId_e id);
+void persistentObjectWrite(persistentObjectId_e id, uint32_t value);

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -52,6 +52,8 @@ void checkForBootLoaderRequest(void);
 bool isMPUSoftReset(void);
 void cycleCounterInit(void);
 
+#define BOOTLOADER_REQUEST_COOKIE 0xDEADBEEF
+
 void enableGPIOPowerUsageAndNoiseReductions(void);
 // current crystal frequency - 8 or 12MHz
 

--- a/src/main/drivers/system_stm32f4xx.c
+++ b/src/main/drivers/system_stm32f4xx.c
@@ -27,6 +27,7 @@
 #include "drivers/exti.h"
 #include "drivers/nvic.h"
 #include "drivers/system.h"
+#include "drivers/persistent.h"
 
 
 #define AIRCR_VECTKEY_MASK    ((uint32_t)0x05FA0000)
@@ -38,12 +39,11 @@ void systemReset(void)
     NVIC_SystemReset();
 }
 
-PERSISTENT uint32_t bootloaderRequest = 0;
 #define BOOTLOADER_REQUEST_COOKIE 0xDEADBEEF
 
 void systemResetToBootloader(void)
 {
-    bootloaderRequest = BOOTLOADER_REQUEST_COOKIE;
+    persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, BOOTLOADER_REQUEST_COOKIE);
 
     __disable_irq();
     NVIC_SystemReset();
@@ -58,11 +58,13 @@ typedef struct isrVector_s {
 
 void checkForBootLoaderRequest(void)
 {
+    uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_BOOTLOADER_REQUEST);
+
+    persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, 0);
+
     if (bootloaderRequest != BOOTLOADER_REQUEST_COOKIE) {
         return;
     }
-
-    bootloaderRequest = 0;
 
     extern isrVector_t system_isr_vector_table_base;
 

--- a/src/main/drivers/system_stm32f4xx.c
+++ b/src/main/drivers/system_stm32f4xx.c
@@ -39,8 +39,6 @@ void systemReset(void)
     NVIC_SystemReset();
 }
 
-#define BOOTLOADER_REQUEST_COOKIE 0xDEADBEEF
-
 void systemResetToBootloader(void)
 {
     persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, BOOTLOADER_REQUEST_COOKIE);

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -45,7 +45,7 @@ void systemReset(void)
 
 void systemResetToBootloader(void)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, 0xDEADBEEF);
+    persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, BOOTLOADER_REQUEST_COOKIE);
     __disable_irq();
     NVIC_SystemReset();
 }
@@ -195,7 +195,7 @@ void checkForBootLoaderRequest(void)
 
     persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, 0xCAFEFEED);
 
-    if (bootloaderRequest != 0xDEADBEEF) {
+    if (bootloaderRequest != BOOTLOADER_REQUEST_COOKIE) {
         return;
     }
 

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -154,6 +154,8 @@ bool isMPUSoftReset(void)
 
 void systemInit(void)
 {
+    checkForBootLoaderRequest();
+
     //  Mark ITCM-RAM as read-only
     LL_MPU_ConfigRegion(LL_MPU_REGION_NUMBER0, 0, RAMITCM_BASE, LL_MPU_REGION_SIZE_16KB | LL_MPU_REGION_PRIV_RO_URO);
     LL_MPU_Enable(LL_MPU_CTRL_PRIVILEGED_DEFAULT);
@@ -198,11 +200,16 @@ void checkForBootLoaderRequest(void)
     }
 
     void (*SysMemBootJump)(void);
+
     __SYSCFG_CLK_ENABLE();
     SYSCFG->MEMRMP |= SYSCFG_MEM_BOOT_ADD0 ;
+
     uint32_t p =  (*((uint32_t *) 0x1ff00000));
-    __set_MSP(p); //Set the main stack pointer to its defualt values
+
+    __set_MSP(p); //Set the main stack pointer to its default values
+
     SysMemBootJump = (void (*)(void)) (*((uint32_t *) 0x1ff00004)); // Point the PC to the System Memory reset vector (+4)
     SysMemBootJump();
+
     while (1);
 }

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -193,7 +193,7 @@ void checkForBootLoaderRequest(void)
 {
     uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_BOOTLOADER_REQUEST);
 
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, 0xCAFEFEED);
+    persistentObjectWrite(PERSISTENT_OBJECT_BOOTLOADER_REQUEST, 0);
 
     if (bootloaderRequest != BOOTLOADER_REQUEST_COOKIE) {
         return;

--- a/src/main/startup/startup_stm32f40xx.s
+++ b/src/main/startup/startup_stm32f40xx.s
@@ -84,6 +84,7 @@ Reset_Handler:
   dsb
 
   // Defined in C code
+  bl persistentObjectInit
   bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  

--- a/src/main/startup/startup_stm32f411xe.s
+++ b/src/main/startup/startup_stm32f411xe.s
@@ -72,6 +72,7 @@ defined in linker script */
   .type  Reset_Handler, %function
 Reset_Handler: 
   // Defined in C code
+  bl persistentObjectInit
   bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  

--- a/src/main/startup/startup_stm32f446xx.s
+++ b/src/main/startup/startup_stm32f446xx.s
@@ -71,13 +71,9 @@ defined in linker script */
   .weak  Reset_Handler
   .type  Reset_Handler, %function
 Reset_Handler: 
-  // Check for bootloader reboot
-  ldr r0, =0x2001FFFC         // mj666
-  ldr r1, =0xDEADBEEF         // mj666
-  ldr r2, [r0, #0]            // mj666
-  str r0, [r0, #0]            // mj666
-  cmp r2, r1                  // mj666
-  beq Reboot_Loader           // mj666
+  // Defined in C code
+  bl persistentObjectInit
+  bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0

--- a/src/main/startup/startup_stm32f722xx.s
+++ b/src/main/startup/startup_stm32f722xx.s
@@ -83,6 +83,9 @@ defined in linker script */
 Reset_Handler:  
   ldr   sp, =_estack      /* set stack pointer */
 
+  bl persistentObjectInit
+  bl checkForBootLoaderRequest
+
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0
   b  LoopCopyDataInit

--- a/src/main/startup/startup_stm32f722xx.s
+++ b/src/main/startup/startup_stm32f722xx.s
@@ -84,7 +84,6 @@ Reset_Handler:
   ldr   sp, =_estack      /* set stack pointer */
 
   bl persistentObjectInit
-  bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0

--- a/src/main/startup/startup_stm32f745xx.s
+++ b/src/main/startup/startup_stm32f745xx.s
@@ -83,6 +83,9 @@ defined in linker script */
 Reset_Handler:  
   ldr   sp, =_estack      /* set stack pointer */
 
+  bl persistentObjectInit
+  bl checkForBootLoaderRequest
+
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0
   b  LoopCopyDataInit

--- a/src/main/startup/startup_stm32f745xx.s
+++ b/src/main/startup/startup_stm32f745xx.s
@@ -84,7 +84,6 @@ Reset_Handler:
   ldr   sp, =_estack      /* set stack pointer */
 
   bl persistentObjectInit
-  bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0

--- a/src/main/startup/startup_stm32f746xx.s
+++ b/src/main/startup/startup_stm32f746xx.s
@@ -83,6 +83,9 @@ defined in linker script */
 Reset_Handler:  
   ldr   sp, =_estack      /* set stack pointer */
 
+  bl persistentObjectInit
+  bl checkForBootLoaderRequest
+
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0
   b  LoopCopyDataInit

--- a/src/main/startup/startup_stm32f746xx.s
+++ b/src/main/startup/startup_stm32f746xx.s
@@ -84,7 +84,6 @@ Reset_Handler:
   ldr   sp, =_estack      /* set stack pointer */
 
   bl persistentObjectInit
-  bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0

--- a/src/main/startup/startup_stm32f765xx.s
+++ b/src/main/startup/startup_stm32f765xx.s
@@ -83,6 +83,9 @@ defined in linker script */
 Reset_Handler:  
   ldr   sp, =_estack      /* set stack pointer */
 
+  bl persistentObjectInit
+  bl checkForBootLoaderRequest
+
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0
   b  LoopCopyDataInit

--- a/src/main/startup/startup_stm32f765xx.s
+++ b/src/main/startup/startup_stm32f765xx.s
@@ -84,7 +84,6 @@ Reset_Handler:
   ldr   sp, =_estack      /* set stack pointer */
 
   bl persistentObjectInit
-  bl checkForBootLoaderRequest
 
 /* Copy the data segment initializers from flash to SRAM */  
   movs  r1, #0

--- a/src/main/target/stm32f7xx_hal_conf.h
+++ b/src/main/target/stm32f7xx_hal_conf.h
@@ -69,7 +69,7 @@
 /* #define HAL_LTDC_MODULE_ENABLED   */
 /* #define HAL_QSPI_MODULE_ENABLED   */
 /* #define HAL_RNG_MODULE_ENABLED   */
-/* #define HAL_RTC_MODULE_ENABLED   */
+#define HAL_RTC_MODULE_ENABLED
 /* #define HAL_SAI_MODULE_ENABLED   */
 /* #define HAL_SD_MODULE_ENABLED   */
 /* #define HAL_MMC_MODULE_ENABLED   */

--- a/src/main/target/system_stm32f7xx.c
+++ b/src/main/target/system_stm32f7xx.c
@@ -66,6 +66,7 @@
 #include "stm32f7xx.h"
 #include "system_stm32f7xx.h"
 #include "platform.h"
+#include "drivers/persistent.h"
 
 #if !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz */
@@ -259,30 +260,32 @@ static const pllConfig_t overclockLevels[] = {
   { 480, RCC_PLLP_DIV2, 10 }, // 240 MHz
 };
 
+#if 0
 // 8 bytes of memory located at the very end of RAM, expected to be unoccupied
 #define REQUEST_OVERCLOCK               (*(__IO uint32_t *) (BKPSRAM_BASE + 8))
 #define CURRENT_OVERCLOCK_LEVEL         (*(__IO uint32_t *) (BKPSRAM_BASE + 12))
 #define REQUEST_OVERCLOCK_MAGIC_COOKIE  0xBABEFACE
+#endif
 
 void SystemInitOC(void) {
+#if 0
     __PWR_CLK_ENABLE();
     __BKPSRAM_CLK_ENABLE();
     HAL_PWR_EnableBkUpAccess();
+#endif
 
-    if (REQUEST_OVERCLOCK_MAGIC_COOKIE == REQUEST_OVERCLOCK) {
-      const uint32_t overclockLevel = CURRENT_OVERCLOCK_LEVEL;
+    uint32_t currentOverclockLevel = persistentObjectRead(PERSISTENT_OBJECT_OVERCLOCK_LEVEL);
 
-      /* PLL setting for overclocking */
-      if (overclockLevel < ARRAYLEN(overclockLevels)) {
-        const pllConfig_t * const pll = overclockLevels + overclockLevel;
-
-        pll_n = pll->n;
-        pll_p = pll->p;
-        pll_q = pll->q;
-      }
-
-      REQUEST_OVERCLOCK = 0;
+    if (currentOverclockLevel >= ARRAYLEN(overclockLevels)) {
+      return;
     }
+
+    /* PLL setting for overclocking */
+    const pllConfig_t * const pll = overclockLevels + currentOverclockLevel;
+
+    pll_n = pll->n;
+    pll_p = pll->p;
+    pll_q = pll->q;
 }
 
 void OverclockRebootIfNecessary(uint32_t overclockLevel)
@@ -295,8 +298,7 @@ void OverclockRebootIfNecessary(uint32_t overclockLevel)
 
     // Reboot to adjust overclock frequency
     if (SystemCoreClock != (pll->n / pll->p) * 1000000U) {
-        REQUEST_OVERCLOCK = REQUEST_OVERCLOCK_MAGIC_COOKIE;
-        CURRENT_OVERCLOCK_LEVEL = overclockLevel;
+        persistentObjectWrite(PERSISTENT_OBJECT_OVERCLOCK_LEVEL, overclockLevel);
         __disable_irq();
         NVIC_SystemReset();
     }

--- a/src/main/target/system_stm32f7xx.c
+++ b/src/main/target/system_stm32f7xx.c
@@ -260,20 +260,7 @@ static const pllConfig_t overclockLevels[] = {
   { 480, RCC_PLLP_DIV2, 10 }, // 240 MHz
 };
 
-#if 0
-// 8 bytes of memory located at the very end of RAM, expected to be unoccupied
-#define REQUEST_OVERCLOCK               (*(__IO uint32_t *) (BKPSRAM_BASE + 8))
-#define CURRENT_OVERCLOCK_LEVEL         (*(__IO uint32_t *) (BKPSRAM_BASE + 12))
-#define REQUEST_OVERCLOCK_MAGIC_COOKIE  0xBABEFACE
-#endif
-
 void SystemInitOC(void) {
-#if 0
-    __PWR_CLK_ENABLE();
-    __BKPSRAM_CLK_ENABLE();
-    HAL_PWR_EnableBkUpAccess();
-#endif
-
     uint32_t currentOverclockLevel = persistentObjectRead(PERSISTENT_OBJECT_OVERCLOCK_LEVEL);
 
     if (currentOverclockLevel >= ARRAYLEN(overclockLevels)) {

--- a/src/main/vcpf4/usb_bsp.c
+++ b/src/main/vcpf4/usb_bsp.c
@@ -83,9 +83,6 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
     RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE) ;
 
-    /* enable the PWR clock */
-    RCC_APB1PeriphResetCmd(RCC_APB1Periph_PWR, ENABLE);
-
     EXTI_ClearITPendingBit(EXTI_Line0);
 }
 /**


### PR DESCRIPTION
Yet another alternative to #7152 and #7155; an implementation of persistent data storage that utilizes RTC backup registers.

#7155 probably is a correct solution for F40x and F446, but not for F411 that does not have backup SRAM.

This PR provides persistent storage inside RTC's backup registers in units of `uint32_t`.

The facility is universal across all F4 variants.

Capacity of the storage is 20 objects at the most (number of registers available in F4s), but it should be  sufficient as current use case only use half a dozen of them at the most.

It can also be extended to include F7  (HAL version of the persistentObject driver itself is also included in this PR but not used and tested yet).
