### PR TITLE
Fixed arming prevention unittest.

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -26,6 +26,7 @@
 
 #include "common/axis.h"
 #include "common/maths.h"
+#include "common/utils.h"
 
 #include "drivers/time.h"
 
@@ -352,20 +353,20 @@ static void performSanityChecks()
 
     previousTimeUs = currentTimeUs;
 
-    secondsStalled = constrain(secondsStalled + (rescueState.sensor.groundSpeed < 150) ? 1 : -1, 0, 20);
+    secondsStalled = constrain(secondsStalled + ((rescueState.sensor.groundSpeed < 150) ? 1 : -1), 0, 20);
 
     if (secondsStalled == 20) {
         rescueState.failure = RESCUE_STALLED;
     }
 
-    secondsFlyingAway = constrain(secondsFlyingAway + (lastDistanceToHomeM < rescueState.sensor.distanceToHomeM) ? 1 : -1, 0, 10);
+    secondsFlyingAway = constrain(secondsFlyingAway + ((lastDistanceToHomeM < rescueState.sensor.distanceToHomeM) ? 1 : -1), 0, 10);
     lastDistanceToHomeM = rescueState.sensor.distanceToHomeM;
 
     if (secondsFlyingAway == 10) {
         rescueState.failure = RESCUE_FLYAWAY;
     }
 
-    secondsLowSats = constrain(secondsLowSats + (rescueState.sensor.numSat < gpsRescueConfig()->minSats) ? 1 : -1, 0, 10);
+    secondsLowSats = constrain(secondsLowSats + ((rescueState.sensor.numSat < gpsRescueConfig()->minSats) ? 1 : -1), 0, 10);
 
     if (secondsLowSats == 10) {
         rescueState.failure = RESCUE_LOWSATS;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -37,6 +37,7 @@ arming_prevention_unittest_SRC := \
 		$(USER_DIR)/fc/rc_controls.c \
 		$(USER_DIR)/fc/rc_modes.c \
 		$(USER_DIR)/fc/runtime_config.c \
+		$(USER_DIR)/flight/gps_rescue.c \
 		$(USER_DIR)/common/bitarray.c
 
 arming_prevention_unittest_DEFINES := \

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -55,7 +55,6 @@ extern "C" {
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 0);
     PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
     PG_REGISTER(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 0);
-    PG_REGISTER(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 0);
 
     float rcCommand[4];
     int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
@@ -71,6 +70,9 @@ extern "C" {
     bool cmsInMenu = false;
     float axisPID_P[3], axisPID_I[3], axisPID_D[3], axisPIDSum[3];
     rxRuntimeConfig_t rxRuntimeConfig = {};
+    uint16_t GPS_distanceToHome = 0;
+    int16_t GPS_directionToHome = 0;
+    acc_t acc = {};
 }
 
 uint32_t simulationFeatureFlags = 0;
@@ -966,4 +968,10 @@ extern "C" {
     bool usbVcpIsConnected(void) { return false; }
     void pidSetAntiGravityState(bool) {}
     void osdSuppressStats(bool) {}
+    float scaleRangef(float, float, float, float, float) { return 0.0f; }
+    bool crashRecoveryModeActive(void) { return false; }
+    int32_t getEstimatedAltitudeCm(void) { return 0; }
+    bool gpsIsHealthy() { return false; }
+    bool isAltitudeOffset(void) { return false; }
+    float getCosTiltAngle(void) { return 0.0f; }
 }


### PR DESCRIPTION
Required as a result of the unit test breaking by a combination of #7158 and #7159.