### PR TITLE
[F411,SYSTEM] Delete bogus clock PLL parameter table entry

### DIFF
--- a/src/main/target/system_stm32f4xx.c
+++ b/src/main/target/system_stm32f4xx.c
@@ -440,7 +440,6 @@ static const pllConfig_t overclockLevels[] = {
   { 216, 432, 2,  9 },  // 216 MHz
   { 240, 480, 2,  10 }  // 240 MHz
 #elif defined(STM32F411xE)
-  {  84, 336, 4,  7 },  // 84 MHz
   {  96, 384, 4,  8 },  // 96 MHz
   { 108, 432, 4,  9 },  // 108 MHz
   { 120, 480, 4, 10 },  // 120 MHz


### PR DESCRIPTION
Delete an artifact of #7081.