### PR TITLE
fix writeGpsPositionPrameToBST

### DIFF
--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -797,7 +797,7 @@ static uint8_t numOfSat = 0;
 #ifdef USE_GPS
 bool writeGpsPositionPrameToBST(void)
 {
-    if ((lat != gpsSol.llh.lat) || (lon != gpsSol.llh.lon) || (alt != (gpsSol.llh.altCm / 100)) || (numOfSat != gpsSol.numSat)) {
+    if ((lat != gpsSol.llh.lat) || (lon != gpsSol.llh.lon) || (altM != (gpsSol.llh.altCm / 100)) || (numOfSat != gpsSol.numSat)) {
         lat = gpsSol.llh.lat;
         lon = gpsSol.llh.lon;
         altM = gpsSol.llh.altCm / 100;


### PR DESCRIPTION
back in https://github.com/betaflight/betaflight/commit/0e52e21524aa5de816f28530c5880af853338379 `static uint16_t alt = 0;` got renamed to `static uint16_t altM = 0;` also every appearance from `alt` got renamed to `altM` beside the one in the if.

this did not get noticed for a long time since gps is not added to f3 targets and bst only is used by COLIBRI. so this bug only got visible when people build a custom colibri target with gps enabled. e.g for GPS_RESCUE_MODE. there are binarys around but this bug never got reported. just noticed in today.

