### PR TITLE
OSD GPS indicator blinks when numSats is below 5

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1372,7 +1372,7 @@ void osdUpdateAlarms(void)
     }
 
 #ifdef USE_GPS
-    if ((STATE(GPS_FIX) == 0) || ((gpsSol.numSat < gpsRescueConfig()->minSats) && gpsRescueIsConfigured())) {
+    if ((STATE(GPS_FIX) == 0) || (gpsSol.numSat < 5) || ((gpsSol.numSat < gpsRescueConfig()->minSats) && gpsRescueIsConfigured())) {
         SET_BLINK(OSD_GPS_SATS);
     } else {
         CLR_BLINK(OSD_GPS_SATS);


### PR DESCRIPTION
After considering the suggestion by @etracer65 and reviewing the code, I think the best action is to add a hardcoded condition.

Full reasoning:

gps.c is filtering out fixes when num sats is lower than 5, see onGpsNewData()

When feature_gps is enabled, we have a fix, num sats are higher than 5 and the quad is armed, a special beep is emitted.

Adding a gps_min_sats parameter to control both behaviours plus the osd blinking would be certainly possible, but it would have to be limited to a minimum of 5. Increasing the value just for osd blinking would not be possible if all of them are tied together.

Adding a osd_min_sats_alarm and keeping the hardcoded 5 numbers seems to be a bit cumbersome because you will have the hardcoded 5 for some things, a configurable alarm for non-gps rescue, and then the gps_rescue_min_sats. IMHO: unneededly complex.

Maybe a better alternative would be to add a parameter: gps_min_sats_alarm, so it controls both the beeper and osd blinking. But I think this option does not give enough value to be exposed as a parameter, as people flying with GPS (without GPS Rescue) is probably more interested in having HDOP exposed instead.

Keeping a separate gps_rescue_min_sats still makes sense in order to provide a higher accuracy requirement for the gps rescue to operate properly.

So in the end, keeping the hardcoded 5 in the existing code is good enough to avoid complicating things, so the only change I propose to do is to blink when num sats is below a hardcoded 5, regardless of gps rescue.