### PR TITLE
Fix MSP flash read

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -375,6 +375,8 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, const uin
 #endif
 
     if (compressionMethod == NO_COMPRESSION) {
+
+        uint16_t *readLenPtr = (uint16_t *)sbufPtr(dst);
         if (!useLegacyFormat) {
             // new format supports variable read lengths
             sbufWriteU16(dst, readLen);
@@ -382,6 +384,11 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, const uin
         }
 
         const int bytesRead = flashfsReadAbs(address, sbufPtr(dst), readLen);
+
+        if (!useLegacyFormat) {
+            // update the 'read length' with the actual amount read from flash.
+            *readLenPtr = (uint16_t)bytesRead;
+        }
 
         sbufAdvance(dst, bytesRead);
 

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -387,7 +387,7 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, const uin
 
         if (!useLegacyFormat) {
             // update the 'read length' with the actual amount read from flash.
-            *readLenPtr = (uint16_t)bytesRead;
+            *readLenPtr = bytesRead;
         }
 
         sbufAdvance(dst, bytesRead);


### PR DESCRIPTION
Fix MSP flash read so it returns the actual bytes read from the flash and not the amount of bytes requested, which may be different depending on the constraints of the flash chip used.

Tested on development hardware using W25N01G flash chip which was returning 2048 bytes instead of the requested 4096 bytes.

See also https://github.com/betaflight/betaflight-configurator/issues/1245 and https://github.com/betaflight/betaflight-configurator/pull/1246 which was what lead to this discovery.
