### PR TITLE
Skip smartport/fport telemetry requests after eeprom write

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -112,7 +112,7 @@ bool handleCrsfMspFrameBuffer(uint8_t payloadSize, mspResponseFnPtr responseFn)
     int pos = 0;
     while (true) {
         const int mspFrameLength = mspRxBuffer.bytes[pos];
-        if (handleMspFrame(&mspRxBuffer.bytes[CRSF_MSP_LENGTH_OFFSET + pos], mspFrameLength)) {
+        if (handleMspFrame(&mspRxBuffer.bytes[CRSF_MSP_LENGTH_OFFSET + pos], mspFrameLength, NULL)) {
             requestHandled |= sendMspReply(payloadSize, responseFn);
         }
         pos += CRSF_MSP_LENGTH_OFFSET + mspFrameLength;

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -172,7 +172,7 @@ bool handleMspFrame(uint8_t *frameStart, int frameLength, uint8_t *skipsBeforeRe
             return true;
         }
     }
-    
+
     // Skip a few telemetry requests if command is MSP_EEPROM_WRITE
     if (packet->cmd == MSP_EEPROM_WRITE) {
         *skipsBeforeResponse = TELEMETRY_REQUEST_SKIPS_AFTER_EEPROMWRITE;

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -31,6 +31,7 @@
 #include "common/utils.h"
 
 #include "interface/msp.h"
+#include "interface/msp_protocol.h"
 
 #include "telemetry/crsf.h"
 #include "telemetry/msp_shared.h"
@@ -43,6 +44,8 @@
 #define TELEMETRY_MSP_START_FLAG (1 << 4)
 #define TELEMETRY_MSP_SEQ_MASK   0x0F
 #define TELEMETRY_MSP_RES_ERROR (-10)
+
+#define TELEMETRY_REQUEST_SKIPS_AFTER_EEPROMWRITE 5
 
 enum {
     TELEMETRY_MSP_VER_MISMATCH=0,
@@ -98,7 +101,7 @@ void sendMspErrorResponse(uint8_t error, int16_t cmd)
     sbufSwitchToReader(&mspPackage.responsePacket->buf, mspPackage.responseBuffer);
 }
 
-bool handleMspFrame(uint8_t *frameStart, int frameLength)
+bool handleMspFrame(uint8_t *frameStart, int frameLength, uint8_t *skipsBeforeResponse)
 {
     static uint8_t mspStarted = 0;
     static uint8_t lastSeq = 0;
@@ -169,7 +172,12 @@ bool handleMspFrame(uint8_t *frameStart, int frameLength)
             return true;
         }
     }
-
+    
+    // Skip a few telemetry requests if command is MSP_EEPROM_WRITE
+    if (packet->cmd == MSP_EEPROM_WRITE) {
+        *skipsBeforeResponse = TELEMETRY_REQUEST_SKIPS_AFTER_EEPROMWRITE;
+    }
+    
     mspStarted = 0;
     sbufSwitchToReader(rxBuf, mspPackage.requestBuffer);
     processMspPacket();

--- a/src/main/telemetry/msp_shared.h
+++ b/src/main/telemetry/msp_shared.h
@@ -46,5 +46,5 @@ typedef union mspTxBuffer_u {
 } mspTxBuffer_t;
 
 void initSharedMsp(void);
-bool handleMspFrame(uint8_t *frameStart, int frameLength);
+bool handleMspFrame(uint8_t *frameStart, int frameLength, uint8_t *skipsBeforeResponse);
 bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -507,22 +507,21 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 #if defined(USE_MSP_OVER_TELEMETRY)
     if (skipRequests) {
         skipRequests--;
-    }
-    else if (payload && smartPortPayloadContainsMSP(payload)) {
+    } else if (payload && smartPortPayloadContainsMSP(payload)) {
         // Do not check the physical ID here again
         // unless we start receiving other sensors' packets
         // Pass only the payload: skip frameId
-         uint8_t *frameStart = (uint8_t *)&payload->valueId;
-         smartPortMspReplyPending = handleMspFrame(frameStart, SMARTPORT_MSP_PAYLOAD_SIZE);
+        uint8_t *frameStart = (uint8_t *)&payload->valueId;
+        smartPortMspReplyPending = handleMspFrame(frameStart, SMARTPORT_MSP_PAYLOAD_SIZE);
          
-         //Don't send MSP response if MSP command is MSP_EEPROM_WRITE
-         //CPU just got out of suspended state after writeEEPROM()
-         //We don't know if the receiver is listening again
-         //Skip a few telemetry requests before sending response
-         if (cmdIsEepromWrite(payload) && smartPortMspReplyPending) {
+        // Don't send MSP response if MSP command is MSP_EEPROM_WRITE
+        // CPU just got out of suspended state after writeEEPROM()
+        // We don't know if the receiver is listening again
+        // Skip a few telemetry requests before sending response
+        if (cmdIsEepromWrite(payload) && smartPortMspReplyPending) {
             skipRequests = SMARTPORT_REQUEST_SKIPS_AFTER_EEPROMWRITE;
             *clearToSend = false;
-         }
+        }
     }
 #else
     UNUSED(payload);

--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -76,3 +76,4 @@ struct serialPort_s;
 void smartPortWriteFrameSerial(const smartPortPayload_t *payload, struct serialPort_s *port, uint16_t checksum);
 void smartPortSendByte(uint8_t c, uint16_t *checksum, struct serialPort_s *port);
 bool smartPortPayloadContainsMSP(const smartPortPayload_t *payload);
+bool cmdIsEepromWrite(const smartPortPayload_t *payload);

--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -76,4 +76,3 @@ struct serialPort_s;
 void smartPortWriteFrameSerial(const smartPortPayload_t *payload, struct serialPort_s *port, uint16_t checksum);
 void smartPortSendByte(uint8_t c, uint16_t *checksum, struct serialPort_s *port);
 bool smartPortPayloadContainsMSP(const smartPortPayload_t *payload);
-bool cmdIsEepromWrite(const smartPortPayload_t *payload);


### PR DESCRIPTION
Skips smartport/fport telemetry requests after eeprom write. Fixes lua script save retries caused by ``eepromWrite`` response getting lost. More details here: https://github.com/betaflight/betaflight-tx-lua-scripts/issues/151#issuecomment-444653333. 

Note: This is only implemented for sport/fport telemetry. If someone with knowledge can implement it for crossfire too, that would be great.