### PR TITLE
TARGET: Add support code for EXF405DUAL board.

### DIFF
--- a/src/main/target/EXF405DUAL/config.c
+++ b/src/main/target/EXF405DUAL/config.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_TARGET_CONFIG
+
+#include "pg/pg.h"
+#include "drivers/max7456.h"
+#include "io/serial.h"
+
+#include "config_helper.h"
+
+static targetSerialPortFunction_t targetSerialPortFunction[] = {
+    { SERIAL_PORT_USART6, FUNCTION_RX_SERIAL },
+    { SERIAL_PORT_UART4, FUNCTION_ESC_SENSOR },    
+};
+
+void targetConfiguration(void)
+{
+    targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+}
+#endif

--- a/src/main/target/EXF405DUAL/target.c
+++ b/src/main/target/EXF405DUAL/target.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    // Motors
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,           0, 0), // D(1,7) U(1,2)
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,           0, 0), // D(1,2) U(1,2)
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,           0, 1), // D(1,6) U(1,7)
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR,           0, 0),
+
+    // Other functions
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,             0, 0), // D(1,0)
+    DEF_TIM(TIM10, CH1, PB8,  TIM_USE_PPM,             0, 0), // PPM
+    DEF_TIM(TIM11, CH1, PB9,  TIM_USE_CAMERA_CONTROL,  0, 0), // CAM_CTL
+};

--- a/src/main/target/EXF405DUAL/target.h
+++ b/src/main/target/EXF405DUAL/target.h
@@ -1,0 +1,159 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER "EX4D"
+
+#define USBD_PRODUCT_STRING     "EXF405DUAL"
+
+#define LED0_PIN                PB5
+
+#define USE_BEEPER
+#define BEEPER_PIN              PB4
+#define BEEPER_INVERTED
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_MPU6500
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_MPU6500
+
+#define USE_DUAL_GYRO
+
+#define GYRO_1_CS_PIN           PD2
+#define GYRO_1_SPI_INSTANCE     SPI3
+
+#define GYRO_2_CS_PIN           PA4
+#define GYRO_2_SPI_INSTANCE     SPI1
+
+#define GYRO_1_ALIGN            CW90_DEG
+#define ACC_1_ALIGN             CW90_DEG
+
+#define GYRO_2_ALIGN            CW270_DEG
+#define ACC_2_ALIGN             CW270_DEG
+
+#define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_1
+
+// MPU6000 interrupts
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PC4
+#define GYRO_2_EXTI_PIN         PC13
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define USE_BARO
+#define USE_BARO_SPI_BMP280
+#define BMP280_SPI_INSTANCE     SPI3
+#define BMP280_CS_PIN           PB3
+#define DEFAULT_BARO_SPI_BMP280
+
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PA15
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define FLASH_SPI_INSTANCE      SPI2
+#define FLASH_CS_PIN            PB12
+
+#define INVERTER_PIN_UART6      PC8
+
+#define USE_VCP
+#define VBUS_SENSING_PIN        PC5
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            NONE
+#define UART2_TX_PIN            PA2   // Half-duplex
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11  // Shared with I2C2 (SDA)
+#define UART3_TX_PIN            PB10  // Shared with I2C2 (SCL)
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1   // Simplex RX, ESC telemetry
+#define UART4_TX_PIN            NONE
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+#define SERIAL_PORT_COUNT       8 // VCP, UART1,2,3,4,6, SOFTSERIAL x 2
+
+#define USE_ESCSERIAL
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PA15
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC2
+#define CURRENT_METER_ADC_PIN   PC1  // Direct from CRNT pad (part of onboard sensor for Pro)
+#define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
+#define RSSI_ADC_PIN            PA0  // Direct from RSSI pad
+
+#define CURRENT_METER_SCALE_DEFAULT  100
+
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+
+#define USE_TRANSPONDER
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+
+#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_LED_STRIP)
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
+#define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
+#define TARGET_IO_PORTC (0xffff & ~(BIT(15)))
+#define TARGET_IO_PORTD BIT(2)
+
+#define USABLE_TIMER_CHANNEL_COUNT 7
+#define USED_TIMERS ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(10) | TIM_N(11))

--- a/src/main/target/EXF405DUAL/target.mk
+++ b/src/main/target/EXF405DUAL/target.mk
@@ -1,0 +1,10 @@
+F405_TARGETS  += $(TARGET)
+
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/max7456.c


### PR DESCRIPTION
### Hardware
- MCU: STM32F405RGT6
- IMU1: ICM20608 (SPI1)
- IMU2: MPU6000 (SPI1)
- OSD: AT7456E (SPI2)
- Blackbox: Micron M25P16VP (SPI3)

### Feature
- High-performance and DSP with FPU, ARM Cortex-M7 MCU with 512 Kbytes Flash. 
- DUAL gyro MPU6000 and ICM20608, could choose mpu6000, more stable and smooth. Or choose ICM20608, higher rate(32K/32K). Choose on CLI mode,experience different feature gyro on same board
- The 16M byte SPI flash for data logging
- USB VCP and boot select button on board(for DFU)
- Serial LED interface(LED_STRIP)
- VBAT/CURR/RSSI sensors input
- Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry.

### Photos
![image](https://user-images.githubusercontent.com/10217966/49683467-72d60300-fb00-11e8-9a50-4e68b66155dd.png)

![image](https://user-images.githubusercontent.com/10217966/49683470-7bc6d480-fb00-11e8-8927-b2bc21bb99a4.png)

### Manufacturer
- EXUAV FPV
- FaceBook: https://www.facebook.com/profile.php?id=100013651722728
- wiki: https://github.com/betaflight/betaflight/wiki/Board---EXF405DUAL

### The mass production version will be available soon.......