### PR TITLE
TARGET: Add support code for EXF722AIO board.

### DIFF
--- a/src/main/target/EXF722AIO/target.c
+++ b/src/main/target/EXF722AIO/target.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM5, CH2, PA1, TIM_USE_PPM,   0, 0),   // PPM
+
+    DEF_TIM(TIM8, CH1, PC6, TIM_USE_MOTOR, 0, 0),   // S1   DMA1_ST4
+    DEF_TIM(TIM8, CH2, PC7, TIM_USE_MOTOR, 0, 0),   // S2   DMA2_ST3
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MOTOR, 0, 0),   // S3   DMA2_ST4
+    DEF_TIM(TIM8, CH4, PC9, TIM_USE_MOTOR, 0, 0),   // S4   DMA2_ST7
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0),   // S5   DMA1_ST2
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MOTOR, 0, 0),   // S6   DMA2_ST6
+
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,  0, 0),   // LED STRIP  DMA1_ST5
+};

--- a/src/main/target/EXF722AIO/target.h
+++ b/src/main/target/EXF722AIO/target.h
@@ -1,0 +1,143 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "EX7A"
+
+#define USBD_PRODUCT_STRING  	"EXF722AIO"
+
+#define ENABLE_DSHOT_DMAR       true
+
+#define LED0_PIN                PB9
+
+#define USE_BEEPER
+#define BEEPER_PIN              PC13
+#define BEEPER_INVERTED
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PC3
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define GYRO_1_CS_PIN           PC2
+#define GYRO_1_SPI_INSTANCE     SPI1
+
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM20689
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_1_ALIGN            CW90_DEG
+
+#define USE_ACC
+#define USE_ACC_SPI_ICM20689
+#define USE_ACC_SPI_MPU6000
+#define ACC_1_ALIGN             CW90_DEG
+
+// *************** FLASH **************************
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define FLASH_CS_PIN            PC1
+#define FLASH_SPI_INSTANCE      SPI3
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+
+// *************** OSD *****************************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI2
+#define MAX7456_SPI_CS_PIN      PB10
+
+// *************** IIC *****************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+// *************** UART *****************************
+#define USE_VCP
+#define USB_DETECT_PIN          PB12
+#define USE_USB_DETECT
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PC11
+#define UART3_TX_PIN            PC10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            PC12
+
+#define SERIAL_PORT_COUNT       6
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_UART4
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC1_DMA_STREAM         DMA2_Stream0
+#define VBAT_ADC_PIN            PC0
+#define CURRENT_METER_ADC_PIN   PC4
+#define RSSI_ADC_PIN            PB0
+
+#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_LED_STRIP)
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define CURRENT_METER_SCALE_DEFAULT 100
+
+#define USE_ESCSERIAL
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 8
+#define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8))

--- a/src/main/target/EXF722AIO/target.mk
+++ b/src/main/target/EXF722AIO/target.mk
@@ -1,0 +1,10 @@
+F7X2RE_TARGETS += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+        drivers/accgyro/accgyro_mpu.c \
+        drivers/accgyro/accgyro_spi_mpu6000.c \
+        drivers/accgyro/accgyro_spi_icm20689.c \
+        drivers/light_ws2811strip.c \
+        drivers/light_ws2811strip_hal.c \
+        drivers/max7456.c


### PR DESCRIPTION
### Hardware
- MCU: STM32F722RET6
- IMU: ICM20689 or MPU6000
- OSD: AT7456E (SPI2)
- Blackbox: Micron M25P16VP (SPI3)

### Feature
- High-performance and DSP with FPU, ARM Cortex-M7 MCU with 512 Kbytes Flash. 
- The 16M byte SPI flash for data logging
- USB VCP and boot select button on board(for DFU)
- Serial LED interface(LED_STRIP)
- VBAT/CURR/RSSI sensors input
- Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry.

### Photos
![image](https://user-images.githubusercontent.com/10217966/49683449-24286900-fb00-11e8-95e1-2533286cfa57.png)

![image](https://user-images.githubusercontent.com/10217966/49683455-30142b00-fb00-11e8-8dad-bac67bf6120e.png)

### Manufacturer
- EXUAV FPV
- FaceBook: https://www.facebook.com/profile.php?id=100013651722728
- wiki: https://github.com/betaflight/betaflight/wiki/Board---EXF722AIO

### The mass production version will be available soon.......