### PR TITLE
Fix OSD throttle position element calculation and add 3D support

### DIFF
--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -68,7 +68,8 @@ void updateArmingStatus(void);
 void taskMainPidLoop(timeUs_t currentTimeUs);
 
 bool isFlipOverAfterCrashActive(void);
-
+int8_t calculateThrottlePercent(void);
+uint8_t calculateThrottlePercentAbs(void);
 void runawayTakeoffTemporaryDisable(uint8_t disableFlag);
 bool isAirmodeActivated();
 timeUs_t getLastDisarmTimeUs(void);
@@ -78,4 +79,3 @@ void resetTryingToArm();
 void subTaskTelemetryPollSensors(timeUs_t currentTimeUs);
 
 bool isLaunchControlActive(void);
-

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -764,7 +764,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_THROTTLE_POS:
         buff[0] = SYM_THR;
         buff[1] = SYM_THR1;
-        tfp_sprintf(buff + 2, "%3d", (constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN));
+        tfp_sprintf(buff + 2, "%3d", calculateThrottlePercent());
         break;
 
 #if defined(USE_VTX_COMMON)

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1079,4 +1079,5 @@ extern "C" {
     bool pidOsdAntiGravityActive(void) { return false; }
     bool failsafeIsActive(void) { return false; }
     bool gpsRescueIsConfigured(void) { return false; }
+    int8_t calculateThrottlePercent(void) { return 0; }
 }


### PR DESCRIPTION
Previously the Throttle Position element calculation was based solely on the raw rcCommand value and didn't take into account the `min_check` deadzone so the resulting displayed percentage was incorrect. Also 3D throttle handling was not considered.

Corrected the calculation and added support for 3D throttle modes. Reversed thrust will be represented with negative throttle percentages and the 3D throttle deadzone is considered.