### PR TITLE
Speed up the first boot on generic firmware

### DIFF
--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -43,6 +43,7 @@ typedef struct systemConfig_s {
     uint8_t powerOnArmingGraceTime; // in seconds
     char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER) + 1];
     uint8_t hseMhz; // Not used for non-F4 targets
+    uint8_t configured;
 } systemConfig_t;
 
 PG_DECLARE(systemConfig_t, systemConfig);
@@ -75,3 +76,5 @@ uint16_t getCurrentMinthrottle(void);
 void resetConfigs(void);
 void targetConfiguration(void);
 void targetValidateConfiguration(void);
+
+bool isSystemConfigured(void);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -503,7 +503,9 @@ void init(void)
 
     if (!sensorsAutodetect()) {
         // if gyro was not detected due to whatever reason, notify and don't arm.
-        indicateFailure(FAILURE_MISSING_ACC, 2);
+        if (isSystemConfigured()) {
+            indicateFailure(FAILURE_MISSING_ACC, 2);
+        }
         setArmingDisabled(ARMING_DISABLED_NO_GYRO);
     }
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -205,9 +205,11 @@
 #define USE_RX_XN297
 #endif
 
+#ifdef GENERIC_TARGET
+#define USE_CONFIGURATION_STATE
+
 // Setup crystal frequency for backward compatibility
 // Should be set to zero for generic targets and set with CLI variable set system_hse_value.
-#ifdef GENERIC_TARGET
 #define SYSTEM_HSE_VALUE 0
 #else
 #ifdef TARGET_XTAL_MHZ
@@ -215,7 +217,7 @@
 #else
 #define SYSTEM_HSE_VALUE (HSE_VALUE/1000000U)
 #endif
-#endif
+#endif // GENERIC_TARGET
 
 // Number of pins that needs pre-init
 #ifdef USE_SPI


### PR DESCRIPTION
Add `configured` member to `systemConfig` that is set upon first explicit config write. It is set by default for non generic targets.

Boards, when flashed with generic firmware, will remain silent for little less than 10 seconds while invisible "no acc" failure code is played. The `configured` flag can be used to bypass the failure notification.

It is actually better to skip all initialization except those required for CLI, MSP, UART and/or VCP, but looks like it requires either a careful reordering of init sequence or a special init block with minimal sequence.