### PR TITLE
Fix smartport GPS altitude

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -824,7 +824,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 break;
             case FSSP_DATAID_GPS_ALT    :
                 if (STATE(GPS_FIX)) {
-                    smartPortSendPackage(id, gpsSol.llh.altCm * 10); // given in 0.01m , requested in 10 = 1m (should be in mm, probably a bug in opentx, tested on 2.0.1.7)
+                    smartPortSendPackage(id, gpsSol.llh.altCm); // given in 0.01m
                     *clearToSend = false;
                 }
                 break;


### PR DESCRIPTION
Fixes #7194 

Value sent was erroneously scaled up by a factor of 10.

Note that this can't be directly applied to 3.5 maintenance as that version has a different bug.