### PR TITLE
Moved Default RX_SPI_LED_PIN definition to common_default_post.h

### DIFF
--- a/src/main/pg/rx_spi.c
+++ b/src/main/pg/rx_spi.c
@@ -31,10 +31,6 @@
 
 #include "rx/rx_spi.h"
 
-#ifndef RX_SPI_LED_PIN
-#define RX_SPI_LED_PIN NONE
-#endif
-
 PG_REGISTER_WITH_RESET_FN(rxSpiConfig_t, rxSpiConfig, PG_RX_SPI_CONFIG, 0);
 
 void pgResetFn_rxSpiConfig(rxSpiConfig_t *rxSpiConfig)

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -249,6 +249,12 @@
 #define BINDPLUG_PIN NONE
 #endif
 
+#ifdef USE_RX_SPI
+#ifndef RX_SPI_LED_PIN
+#define RX_SPI_LED_PIN NONE
+#endif
+#endif
+
 // F4 and F7 single gyro boards
 #if defined(USE_MULTI_GYRO) && !defined(GYRO_2_SPI_INSTANCE)
 #define GYRO_2_SPI_INSTANCE     GYRO_1_SPI_INSTANCE


### PR DESCRIPTION
As discussed in https://github.com/betaflight/betaflight/pull/7210