### PR TITLE
Do call gyroPreInitsensor for gyro 2 even if it is not activated

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -495,13 +495,9 @@ static bool gyroInitSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t *c
 
 void gyroPreInit(void)
 {
-    if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
-        gyroPreInitSensor(gyroDeviceConfig(0));
-    }
+    gyroPreInitSensor(gyroDeviceConfig(0));
 #ifdef USE_MULTI_GYRO
-    if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
-        gyroPreInitSensor(gyroDeviceConfig(1));
-    }
+    gyroPreInitSensor(gyroDeviceConfig(1));
 #endif
 }
 


### PR DESCRIPTION
Fixes #7225 

`gyroPreInitSensor` (and consequently `spiPreinitRegister`) must be called for second SPI gyro even if it is not activated.

DALRCF722DUAL revealed this bug as it uses two gyros on the same SPI bus 😭 

