### PR TITLE
Fix OMNIBUSF4V6 Gyro2(External) align

### DIFF
--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -79,8 +79,8 @@
 #define ACC_1_ALIGN             CW180_DEG
 
 #if defined(OMNIBUSF4V6)
-#define GYRO_2_ALIGN            CW180_DEG
-#define ACC_2_ALIGN             CW180_DEG
+#define GYRO_2_ALIGN            CW0_DEG
+#define ACC_2_ALIGN             CW0_DEG
 #else
 #define GYRO_2_ALIGN            CW0_DEG_FLIP
 #define ACC_2_ALIGN             CW0_DEG_FLIP


### PR DESCRIPTION
Fixed OmnibusF4 V6 Gyro2(External gyro box) orientation to same as Gyro1, now compatible with Gyro BOTH