### PR TITLE
Update L3GD20 gyro to modern gyro API.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -52,6 +52,7 @@
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
+#include "drivers/accgyro/accgyro_spi_l3gd20.h"
 #include "drivers/accgyro/accgyro_mpu.h"
 
 #include "pg/pg.h"
@@ -211,6 +212,9 @@ static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
 #endif
 #ifdef USE_ACCGYRO_BMI160
     bmi160Detect,
+#endif
+#ifdef USE_GYRO_L3GD20
+    l3gd20Detect,
 #endif
     NULL // Avoid an empty array
 };

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -205,6 +205,7 @@ typedef enum {
     ICM_20649_SPI,
     ICM_20689_SPI,
     BMI_160_SPI,
+    L3GD20_SPI,
 } mpuSensor_e;
 
 typedef enum {

--- a/src/main/drivers/accgyro/accgyro_spi_l3gd20.h
+++ b/src/main/drivers/accgyro/accgyro_spi_l3gd20.h
@@ -20,4 +20,5 @@
 
 #pragma once
 
-bool l3gd20Detect(gyroDev_t *gyro);
+uint8_t l3gd20Detect(const busDevice_t *bus);
+bool l3gd20GyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_legacy/accgyro_lsm303dlhc.c
+++ b/src/main/drivers/accgyro_legacy/accgyro_lsm303dlhc.c
@@ -151,12 +151,6 @@ static bool lsm303dlhcAccRead(accDev_t *acc)
     acc->ADCRaw[Y] = (int16_t)((buf[3] << 8) | buf[2]) / 2;
     acc->ADCRaw[Z] = (int16_t)((buf[5] << 8) | buf[4]) / 2;
 
-#if 0
-    debug[0] = (int16_t)((buf[1] << 8) | buf[0]);
-    debug[1] = (int16_t)((buf[3] << 8) | buf[2]);
-    debug[2] = (int16_t)((buf[5] << 8) | buf[4]);
-#endif
-
     return true;
 }
 
@@ -166,8 +160,9 @@ bool lsm303dlhcAccDetect(accDev_t *acc)
     uint8_t status;
 
     ack = i2cRead(MPU_I2C_INSTANCE, LSM303DLHC_ACCEL_ADDRESS, LSM303DLHC_STATUS_REG_A, 1, &status);
-    if (!ack)
+    if (!ack) {
         return false;
+    }
 
     acc->initFn = lsm303dlhcAccInit;
     acc->readFn = lsm303dlhcAccRead;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -51,12 +51,12 @@
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
 
-#ifdef USE_GYRO_L3G4200D
-#include "drivers/accgyro_legacy/accgyro_l3g4200d.h"
+#ifdef USE_GYRO_L3GD20
+#include "drivers/accgyro/accgyro_spi_l3gd20.h"
 #endif
 
-#ifdef USE_GYRO_L3GD20
-#include "drivers/accgyro_legacy/accgyro_l3gd20.h"
+#ifdef USE_GYRO_L3G4200D
+#include "drivers/accgyro_legacy/accgyro_l3g4200d.h"
 #endif
 
 #include "drivers/accgyro/gyro_sync.h"
@@ -296,7 +296,7 @@ STATIC_UNIT_TESTED gyroHardware_e gyroDetect(gyroDev_t *dev)
 
 #ifdef USE_GYRO_L3GD20
     case GYRO_L3GD20:
-        if (l3gd20Detect(dev)) {
+        if (l3gd20GyroDetect(dev)) {
             gyroHardware = GYRO_L3GD20;
             break;
         }
@@ -418,7 +418,7 @@ static bool gyroInitSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t *c
     gyroSensor->gyroDev.mpuIntExtiTag = config->extiTag;
 
 #if defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6500) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU6000) \
- || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20601) || defined(USE_GYRO_SPI_ICM20649) || defined(USE_GYRO_SPI_ICM20689)
+ || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20601) || defined(USE_GYRO_SPI_ICM20649) || defined(USE_GYRO_SPI_ICM20689) || defined(USE_GYRO_L3GD20)
 
     mpuDetect(&gyroSensor->gyroDev, config);
 #endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -192,11 +192,11 @@
 #endif
 
 // Generate USE_SPI_GYRO or USE_I2C_GYRO
-#if defined(USE_GYRO_L3G4200D) || defined(USE_GYRO_L3GD20) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6000) || defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU6500)
+#if defined(USE_GYRO_L3G4200D) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6000) || defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU6500)
 #define USE_I2C_GYRO
 #endif
 
-#if defined(USE_GYRO_SPI_ICM20689) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250)
+#if defined(USE_GYRO_SPI_ICM20689) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_L3GD20)
 #define USE_SPI_GYRO
 #endif
 


### PR DESCRIPTION
This is in preparation for adding this gyro back to the STM32F3DISCOVERY target, as it is the on-board gyro on this board.

The LSM303DLHC acc that is paired with the gyro was not updated to the new API since this one is I2C, and the new API does not support gyro / acc combinations that use different buses.
