### PR TITLE
Remove deprecated PERSISTENT macro

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -113,11 +113,6 @@
 #define FAST_RAM
 #endif // USE_FAST_RAM
 
-#ifdef STM32F4
-// Data in RAM which is guaranteed to not be reset on hot reboot
-#define PERSISTENT                  __attribute__ ((section(".persistent_data"), aligned(4)))
-#endif
-
 #ifdef USE_SRAM2
 #define SRAM2                       __attribute__ ((section(".sram2"), aligned(4)))
 #else


### PR DESCRIPTION
Replaced by persistence layer in drivers/persistent.c
