### PR TITLE
Added 'small_angle' indicator to OSD flip arrow.

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -519,8 +519,9 @@ void updateMagHold(void)
         if (dif >= +180)
             dif -= 360;
         dif *= -GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
-        if (STATE(SMALL_ANGLE))
+        if (STATE(SMALL_ANGLE)) {
             rcCommand[YAW] -= dif * currentPidProfile->pid[PID_MAG].P / 30;    // 18 deg
+        }
     } else
         magHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -157,7 +157,8 @@ void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correctio
 {
     imuRuntimeConfig.dcm_kp = imuConfig()->dcm_kp / 10000.0f;
     imuRuntimeConfig.dcm_ki = imuConfig()->dcm_ki / 10000.0f;
-    imuRuntimeConfig.small_angle = imuConfig()->small_angle;
+
+    smallAngleCosZ = cos_approx(degreesToRadians(imuConfig()->small_angle));
 
     fc_acc = calculateAccZLowPassFilterRCTimeConstant(5.0f); // Set to fix value
     throttleAngleScale = calculateThrottleAngleScale(throttle_correction_angle);
@@ -167,7 +168,6 @@ void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correctio
 
 void imuInit(void)
 {
-    smallAngleCosZ = cos_approx(degreesToRadians(imuRuntimeConfig.small_angle));
     accVelScale = 9.80665f * acc.dev.acc_1G_rec / 10000.0f;
 
 #ifdef USE_GPS

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -67,7 +67,6 @@ PG_DECLARE(imuConfig_t, imuConfig);
 typedef struct imuRuntimeConfig_s {
     float dcm_ki;
     float dcm_kp;
-    uint8_t small_angle;
 } imuRuntimeConfig_t;
 
 void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correction_value);

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -89,6 +89,7 @@ extern "C" {
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 0);
     PG_REGISTER(pilotConfig_t, pilotConfig, PG_PILOT_CONFIG, 0);
     PG_REGISTER(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 0);
+    PG_REGISTER(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
 
     timeUs_t simulationTime = 0;
     batteryState_e simulationBatteryState;


### PR DESCRIPTION
This allows the 'crash flip arrow' to be used as an indicator for a tilted craft as well - the arrow will show when disarmed (only if `small_angle` isn't set to 180) if the tilt angle is exceeded. When in crash flip mode, the arrow will only show when the tilt angle is exceeded.

Also, cleaned up the calculation to use the proper quadrants, and cleaned up an unnecessary buffer variable in the small angle calculation.