### PR TITLE
Activate internal I2C pullups for generic targets

### DIFF
--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -74,6 +74,7 @@
 #define USE_MAX7456
 
 #define USE_I2C
+#define USE_I2C_PULLUP
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
 #define USE_I2C_DEVICE_3

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -74,6 +74,7 @@
 #define USE_MAX7456
 
 #define USE_I2C
+#define USE_I2C_PULLUP
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
 #define USE_I2C_DEVICE_3


### PR DESCRIPTION
Many FC' are using internal I2C pullups. I think activating them for the generic targets will not hurt and allow save operation. Another option is to make pullups configurable in the driver. Likely an overkill here. Looking for your feedback.