### PR TITLE
add support for BERGMICRO_W25Q32

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -65,6 +65,7 @@
 #define JEDEC_ID_WINBOND_W25Q64        0xEF4017
 #define JEDEC_ID_WINBOND_W25Q128       0xEF4018
 #define JEDEC_ID_CYPRESS_S25FL128L     0x016018
+#define JEDEC_ID_BERGMICRO_W25Q32      0xE04016
 
 // The timeout we expect between being able to issue page program instructions
 #define DEFAULT_TIMEOUT_MILLIS       6
@@ -165,6 +166,10 @@ bool m25p16_detect(flashDevice_t *fdevice, uint32_t chipID)
     case JEDEC_ID_MICRON_M25P16:
         fdevice->geometry.sectors = 32;
         fdevice->geometry.pagesPerSector = 256;
+        break;
+    case JEDEC_ID_BERGMICRO_W25Q32:
+        fdevice->geometry.sectors = 1024;
+        fdevice->geometry.pagesPerSector = 16;
         break;
     case JEDEC_ID_WINBOND_W25Q32:
     case JEDEC_ID_MACRONIX_MX25L3206E:


### PR DESCRIPTION
This adds support for blackbox logging to the obscure BergMicro W25Q32 chip which can be harvested from various ESP8266 modules.