### PR TITLE
Fixed MATEKF411RX after #7263.

### DIFF
--- a/src/main/target/MATEKF411RX/target.h
+++ b/src/main/target/MATEKF411RX/target.h
@@ -80,6 +80,13 @@
 #define MAX7456_SPI_INSTANCE    SPI2
 #define MAX7456_SPI_CS_PIN      PB12
 
+#if defined(CRAZYBEEF4DX)
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SPEKTRUM2048
+#define SERIALRX_UART           SERIAL_PORT_USART2
+#define RX_CHANNELS_TAER
+
+#else
 // *************** SPI3 CC2500 ***************************
 #define USE_SPI_DEVICE_3
 #define SPI3_SCK_PIN            PB3
@@ -87,59 +94,53 @@
 #define SPI3_MOSI_PIN           PB5
 #define RX_NSS_PIN              PA15
 
-#if defined(CRAZYBEEF4FS)
-#define USE_LED_STRIP
 #define USE_RX_SPI
+#define RX_SPI_INSTANCE         SPI3
+
+#define BINDPLUG_PIN            PB2
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
+
+#if defined(CRAZYBEEF4FS)
 #define USE_RX_FLYSKY
 #define RX_CHANNELS_AETR
-#define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
 #define RX_SPI_DEFAULT_PROTOCOL RX_SPI_A7105_FLYSKY_2A
 #define FLYSKY_2A_CHANNEL_COUNT 14
-#define RX_SPI_INSTANCE         SPI3
 #define RX_IRQ_PIN              PA14
-#define BINDPLUG_PIN            PB2
 #define USE_RX_FLYSKY_SPI_LED
 #define RX_FLYSKY_SPI_LED_PIN   PB9
-#elif defined(CRAZYBEEF4DX)
-#define USE_LED_STRIP
-#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
-#define SERIALRX_PROVIDER       SERIALRX_SPEKTRUM2048
-#define SERIALRX_UART           SERIAL_PORT_USART2
-#define RX_CHANNELS_TAER
+
 #elif defined(CRAZYBEEF4FR)
-#define USE_LED_STRIP
-#define USE_RX_SPI
-#define RX_SPI_INSTANCE         SPI3
 #define RX_CC2500_SPI_DISABLE_CHIP_DETECTION
 #define RX_CC2500_SPI_GDO_0_PIN     PC14
-#define RX_CC2500_SPI_LED_PIN       PB9
-#define BINDPLUG_PIN            PB2
+#define RX_SPI_LED_PIN              PB9
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X
 #define USE_RX_SFHSS_SPI
-#define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
 #define RX_SPI_DEFAULT_PROTOCOL RX_SPI_FRSKY_X
 #define USE_RX_FRSKY_SPI_TELEMETRY
-#else
-#define USE_RX_SPI
-#define RX_SPI_INSTANCE         SPI3
+
+#else // MATEKF411RX
 #define RX_CC2500_SPI_DISABLE_CHIP_DETECTION
 #define RX_CC2500_SPI_GDO_0_PIN     PC14
-#define RX_CC2500_SPI_LED_PIN       PB9
-#define RX_CC2500_SPI_LED_PIN_INVERTED
+#define RX_SPI_LED_PIN              PB9
+#define RX_SPI_LED_INVERTED
+
 #define USE_RX_CC2500_SPI_PA_LNA
 #define RX_CC2500_SPI_TX_EN_PIN      PA8
 #define RX_CC2500_SPI_LNA_EN_PIN     PA13
+
 #define USE_RX_CC2500_SPI_DIVERSITY
 #define RX_CC2500_SPI_ANT_SEL_PIN    PA14
-#define BINDPLUG_PIN            PB2
+
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X
 #define USE_RX_SFHSS_SPI
-#define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
 #define RX_SPI_DEFAULT_PROTOCOL RX_SPI_FRSKY_X
 #define USE_RX_FRSKY_SPI_TELEMETRY
 #endif
+#endif // CRAZYBEEF4DX
+
 // *************** UART *****************************
 #define USE_VCP
 
@@ -173,8 +174,6 @@
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         (BIT(2))
-
-//#define  USE_DSHOT_DMA
 
 #define USABLE_TIMER_CHANNEL_COUNT 9
 #define USED_TIMERS             ( TIM_N(1)|TIM_N(2)|TIM_N(4)|TIM_N(5)|TIM_N(9))


### PR DESCRIPTION
@githubDLG: I also reorganised the target definitions to make them a bit more wieldy, plus I fixed the broken RX LED definition for CRAZYBEEF4FR. @githubDLG can you please test these targets on the hardware to make sure they are working ok?