### PR TITLE
Fix CLI allowed range display for VAR_UINT32 type

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -608,7 +608,11 @@ static void cliPrintVarRange(const clivalue_t *var)
 {
     switch (var->type & VALUE_MODE_MASK) {
     case (MODE_DIRECT): {
-        cliPrintLinef("Allowed range: %d - %d", var->config.minmax.min, var->config.minmax.max);
+        if ((var->type & VALUE_TYPE_MASK) == VAR_UINT32) {
+            cliPrintLinef("Allowed range: %d - %d", 0, var->config.u32_max);
+        } else {
+            cliPrintLinef("Allowed range: %d - %d", var->config.minmax.min, var->config.minmax.max);
+        }
     }
     break;
     case (MODE_LOOKUP): {


### PR DESCRIPTION
Previous:
```
telemetry_disabled_sensors = 491520
Allowed range: -1 - 7
```

Fixed:
```
telemetry_disabled_sensors = 491520
Allowed range: 0 - 524287
```