### PR TITLE
[VTX] Convert direct reference to string and freq table to vtxCommon services

### DIFF
--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -44,9 +44,9 @@ static uint8_t cmsx_vtxBand;
 static uint8_t cmsx_vtxChannel;
 static uint8_t cmsx_vtxPower;
 
-static OSD_TAB_t entryVtxBand =         {&cmsx_vtxBand, VTX_RTC6705_BAND_COUNT - 1, &vtx58BandNames[1]};
-static OSD_UINT8_t entryVtxChannel =    {&cmsx_vtxChannel, 1, VTX_SETTINGS_CHANNEL_COUNT, 1};
-static OSD_TAB_t entryVtxPower =        {&cmsx_vtxPower, VTX_RTC6705_POWER_COUNT - 1 - VTX_RTC6705_MIN_POWER, &rtc6705PowerNames[VTX_RTC6705_MIN_POWER]};
+static OSD_TAB_t entryVtxBand;
+static OSD_UINT8_t entryVtxChannel;
+static OSD_TAB_t entryVtxPower;
 
 static void cmsx_Vtx_ConfigRead(void)
 {
@@ -61,7 +61,7 @@ static void cmsx_Vtx_ConfigWriteback(void)
     vtxSettingsConfigMutable()->band = cmsx_vtxBand + 1;
     vtxSettingsConfigMutable()->channel = cmsx_vtxChannel;
     vtxSettingsConfigMutable()->power = cmsx_vtxPower + VTX_RTC6705_MIN_POWER;
-    vtxSettingsConfigMutable()->freq = vtx58_Bandchan2Freq(cmsx_vtxBand + 1, cmsx_vtxChannel);
+    vtxSettingsConfigMutable()->freq = vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand + 1, cmsx_vtxChannel);
 
     saveConfigAndNotify();
 }
@@ -69,6 +69,21 @@ static void cmsx_Vtx_ConfigWriteback(void)
 static long cmsx_Vtx_onEnter(void)
 {
     cmsx_Vtx_ConfigRead();
+
+    vtxDevice_t *device = vtxCommonDevice();
+
+    entryVtxBand.val = &cmsx_vtxBand;
+    entryVtxBand.max = device->capability.bandCount - 1;
+    entryVtxBand.names = &device->bandNames[1];
+
+    entryVtxChannel.val = &cmsx_vtxChannel;
+    entryVtxChannel.min = 1;
+    entryVtxChannel.max = device->capability.channelCount;
+    entryVtxChannel.step = 1;
+
+    entryVtxPower.val = &cmsx_vtxPower;
+    entryVtxPower.max = device->capability.powerCount - 1;
+    entryVtxPower.names = device->powerNames;
 
     return 0;
 }

--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -126,4 +126,63 @@ bool vtxCommonGetDeviceCapability(const vtxDevice_t *vtxDevice, vtxDeviceCapabil
     return true;
 }
 
+const char *vtxCommonLookupBandName(const vtxDevice_t *vtxDevice, int band)
+{
+    return vtxDevice->bandNames[band];
+}
+
+char vtxCommonLookupBandLetter(const vtxDevice_t *vtxDevice, int band)
+{
+    return vtxDevice->bandLetters[band];
+}
+
+const char *vtxCommonLookupChannelName(const vtxDevice_t *vtxDevice, int channel)
+{
+    return vtxDevice->channelNames[channel];
+}
+
+//Converts frequency (in MHz) to band and channel values.
+bool vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
+{
+    // Use reverse lookup order so that 5880Mhz
+    // get Raceband 7 instead of Fatshark 8.
+    for (int band = vtxDevice->capability.bandCount - 1 ; band >= 0 ; band--) {
+        for (int channel = 0 ; channel < vtxDevice->capability.channelCount ; channel++) {
+            if (vtxDevice->frequencyTable[band * vtxDevice->capability.channelCount + channel] == freq) {
+                *pBand = band + 1;
+                *pChannel = channel + 1;
+                return true;
+            }
+        }
+    }
+
+    *pBand = 0;
+    *pChannel = 0;
+
+    return false;
+}
+
+//Converts band and channel values to a frequency (in MHz) value.
+// band:  Band value (1 to 5).
+// channel:  Channel value (1 to 8).
+// Returns frequency value (in MHz), or 0 if band/channel out of range.
+uint16_t vtxCommonLookupFrequency(const vtxDevice_t *vtxDevice, int band, int channel)
+{
+    if (band > 0 && band <= vtxDevice->capability.bandCount &&
+                          channel > 0 && channel <= vtxDevice->capability.channelCount) {
+        return vtxDevice->frequencyTable[(band - 1) * vtxDevice->capability.channelCount + (channel - 1)];
+
+    }
+    return 0;
+}
+
+const char *vtxCommonLookupPowerName(const vtxDevice_t *vtxDevice, int index)
+{
+    return vtxDevice->powerNames[index];
+}
+
+uint16_t vtxCommonLookupPowerValue(const vtxDevice_t *vtxDevice, int index)
+{
+    return vtxDevice->powerValues[index];
+}
 #endif

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -121,10 +121,12 @@ typedef struct vtxDevice_s {
 
     vtxDeviceCapability_t capability;
 
-    uint16_t *frequencyTable;  // Array of [bandCount][channelCount]
-    char **bandNames;    // char *bandNames[bandCount]
-    char **channelNames;    // char *channelNames[channelCount]
-    char **powerNames;   // char *powerNames[powerCount]
+    const uint16_t *frequencyTable;  // Array of [bandCount][channelCount]
+    const char **bandNames;          // char *bandNames[bandCount + 1]
+    const char **channelNames;       // char *channelNames[channelCount + 1]
+    const char *bandLetters;         // char bandLetters[bandCount + 1]
+    const uint16_t *powerValues;     // uint16 powerValues[powerCount]
+    const char **powerNames;         // char *powerNames[powerCount + 1]
 
     uint16_t frequency;
     uint8_t band; // Band = 1, 1-based
@@ -176,3 +178,11 @@ bool vtxCommonGetPowerIndex(const vtxDevice_t *vtxDevice, uint8_t *pIndex);
 bool vtxCommonGetPitMode(const vtxDevice_t *vtxDevice, uint8_t *pOnOff);
 bool vtxCommonGetFrequency(const vtxDevice_t *vtxDevice, uint16_t *pFreq);
 bool vtxCommonGetDeviceCapability(const vtxDevice_t *vtxDevice, vtxDeviceCapability_t *pDeviceCapability);
+const char *vtxCommonLookupBandName(const vtxDevice_t *vtxDevice, int band);
+char vtxCommonLookupBandLetter(const vtxDevice_t *vtxDevice, int band);
+char vtxCommonGetBandLetter(const vtxDevice_t *vtxDevice, int band);
+const char *vtxCommonLookupChannelName(const vtxDevice_t *vtxDevice, int channel);
+uint16_t vtxCommonLookupFrequency(const vtxDevice_t *vtxDevice, int band, int channel);
+bool vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_t *pBand, uint8_t *pChannel);
+const char *vtxCommonLookupPowerName(const vtxDevice_t *vtxDevice, int index);
+uint16_t vtxCommonLookupPowerValue(const vtxDevice_t *vtxDevice, int index);

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -2003,7 +2003,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                 const uint8_t newChannel = (newFrequency % 8) + 1;
                 vtxSettingsConfigMutable()->band = newBand;
                 vtxSettingsConfigMutable()->channel = newChannel;
-                vtxSettingsConfigMutable()->freq = vtx58_Bandchan2Freq(newBand, newChannel);
+                vtxSettingsConfigMutable()->freq = vtxCommonLookupFrequency(vtxDevice, newBand, newChannel);
             } else if (newFrequency <= VTX_SETTINGS_MAX_FREQUENCY_MHZ) { // Value is frequency in MHz
                 vtxSettingsConfigMutable()->band = 0;
                 vtxSettingsConfigMutable()->channel = 0;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -611,8 +611,8 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
         vtxCommonGetPowerIndex(vtxDevice, &power);
         vtxCommonGetPitMode(vtxDevice, &pit);
 
-        frequency = vtx58frequencyTable[band - 1][channel - 1]; //subtracting 1 from band and channel so that correct frequency is returned.
-                                                                //might not be correct for tramp but should fix smart audio.
+        frequency = vtxCommonLookupFrequency(vtxDevice, band, channel);
+
         // check if last vtx values have changed.
         check = pit + (power << 1) + (band << 4) + (channel << 8);
         if (!showSettings && check != lastCheck) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -811,10 +811,10 @@ static bool osdDrawSingleElement(uint8_t item)
 #if defined(USE_VTX_COMMON)
     case OSD_VTX_CHANNEL:
         {
-            const char vtxBandLetter = vtx58BandLetter[vtxSettingsConfig()->band];
-            const char *vtxChannelName = vtx58ChannelNames[vtxSettingsConfig()->channel];
-            uint8_t vtxPower = vtxSettingsConfig()->power;
             const vtxDevice_t *vtxDevice = vtxCommonDevice();
+            const char vtxBandLetter = vtxCommonLookupBandLetter(vtxDevice, vtxSettingsConfig()->band);
+            const char *vtxChannelName = vtxCommonLookupChannelName(vtxDevice, vtxSettingsConfig()->channel);
+            uint8_t vtxPower = vtxSettingsConfig()->power;
             if (vtxDevice && vtxSettingsConfig()->lowPowerDisarm) {
                 vtxCommonGetPowerIndex(vtxDevice, &vtxPower);
             }

--- a/src/main/io/spektrum_vtx_control.c
+++ b/src/main/io/spektrum_vtx_control.c
@@ -200,7 +200,7 @@ void spektrumVtxControl(void)
         if ((prevSettings.band != band) || (prevSettings.channel != channel)) {
             newSettings.band    = band;
             newSettings.channel = channel;
-            newSettings.freq    = vtx58_Bandchan2Freq(band, channel);
+            newSettings.freq    = vtxCommonLookupFrequency(vtxDevice, band, channel);
         }
 #endif
         // Seems to be no unified internal VTX API standard for power levels/indexes, VTX device brand specific.

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -70,7 +70,7 @@ void vtxInit(void)
     bool settingsUpdated = false;
 
     // sync frequency in parameter group when band/channel are specified
-    const uint16_t freq = vtx58_Bandchan2Freq(vtxSettingsConfig()->band, vtxSettingsConfig()->channel);
+    const uint16_t freq = vtxCommonLookupFrequency(vtxCommonDevice(), vtxSettingsConfig()->band, vtxSettingsConfig()->channel);
     if (vtxSettingsConfig()->band && freq != vtxSettingsConfig()->freq) {
         vtxSettingsConfigMutable()->freq = freq;
         settingsUpdated = true;

--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -41,7 +41,7 @@
 
 
 #if defined(USE_CMS) || defined(USE_VTX_COMMON)
-const char * const rtc6705PowerNames[] = {
+const char * rtc6705PowerNames[] = {
     "OFF", "MIN", "MAX"
 };
 #endif
@@ -50,12 +50,6 @@ const char * const rtc6705PowerNames[] = {
 static vtxVTable_t rtc6705VTable;    // Forward
 static vtxDevice_t vtxRTC6705 = {
     .vTable = &rtc6705VTable,
-    .capability.bandCount = VTX_SETTINGS_BAND_COUNT,
-    .capability.channelCount = VTX_SETTINGS_CHANNEL_COUNT,
-    .capability.powerCount = VTX_RTC6705_POWER_COUNT,
-    .bandNames = (char **)vtx58BandNames,
-    .channelNames = (char **)vtx58ChannelNames,
-    .powerNames = (char **)rtc6705PowerNames,
 };
 #endif
 
@@ -64,6 +58,15 @@ static void vtxRTC6705SetFrequency(vtxDevice_t *vtxDevice, uint16_t frequency);
 
 bool vtxRTC6705Init(void)
 {
+    vtxRTC6705.capability.bandCount = VTX_SETTINGS_BAND_COUNT,
+    vtxRTC6705.capability.channelCount = VTX_SETTINGS_CHANNEL_COUNT,
+    vtxRTC6705.capability.powerCount = VTX_RTC6705_POWER_COUNT,
+    vtxRTC6705.frequencyTable = vtxStringFrequencyTable();
+    vtxRTC6705.bandNames = vtxStringBandNames();
+    vtxRTC6705.bandLetters = vtxStringBandLetters();
+    vtxRTC6705.channelNames = vtxStringChannelNames();
+    vtxRTC6705.powerNames = rtc6705PowerNames,
+
     vtxCommonSetDevice(&vtxRTC6705);
 
     return true;
@@ -126,7 +129,7 @@ static void vtxRTC6705SetBandAndChannel(vtxDevice_t *vtxDevice, uint8_t band, ui
         if (vtxDevice->powerIndex > 0) {
             vtxDevice->band = band;
             vtxDevice->channel = channel;
-            vtxRTC6705SetFrequency(vtxDevice, vtx58frequencyTable[band-1][channel-1]);
+            vtxRTC6705SetFrequency(vtxDevice, vtxCommonLookupFrequency(vtxDevice, band, channel));
         }
     }
 }

--- a/src/main/io/vtx_rtc6705.h
+++ b/src/main/io/vtx_rtc6705.h
@@ -25,7 +25,5 @@
 
 #include "platform.h"
 
-extern const char * const rtc6705PowerNames[];
-
 bool vtxRTC6705CanUpdate(void);
 bool vtxRTC6705Init(void);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -63,8 +63,10 @@ serialPort_t *debugSerialPort = NULL;
 
 static serialPort_t *smartAudioSerialPort = NULL;
 
+smartAudioDevice_t saDevice;
+
 #if defined(USE_CMS) || defined(USE_VTX_COMMON)
-const char * const saPowerNames[VTX_SMARTAUDIO_POWER_COUNT+1] = {
+const char * saPowerNames[VTX_SMARTAUDIO_POWER_COUNT+1] = {
     "---", "25 ", "200", "500", "800",
 };
 #endif
@@ -73,12 +75,6 @@ const char * const saPowerNames[VTX_SMARTAUDIO_POWER_COUNT+1] = {
 static const vtxVTable_t saVTable;    // Forward
 static vtxDevice_t vtxSmartAudio = {
     .vTable = &saVTable,
-    .capability.bandCount = VTX_SMARTAUDIO_BAND_COUNT,
-    .capability.channelCount = VTX_SMARTAUDIO_CHANNEL_COUNT,
-    .capability.powerCount = VTX_SMARTAUDIO_POWER_COUNT,
-    .bandNames = (char **)vtx58BandNames,
-    .channelNames = (char **)vtx58ChannelNames,
-    .powerNames = (char **)saPowerNames,
 };
 #endif
 
@@ -125,6 +121,10 @@ saPowerTable_t saPowerTable[VTX_SMARTAUDIO_POWER_COUNT] = {
     { 200,  16,   1 },
     { 500,  25,   2 },
     { 800,  40,   3 },
+};
+
+uint16_t saPowerValues[VTX_SMARTAUDIO_POWER_COUNT] = {
+    25, 200, 500, 800
 };
 
 // Last received device ('hard') states
@@ -694,6 +694,16 @@ bool vtxSmartAudioInit(void)
         return false;
     }
 
+    vtxSmartAudio.capability.bandCount = VTX_SMARTAUDIO_BAND_COUNT;
+    vtxSmartAudio.capability.channelCount = VTX_SMARTAUDIO_CHANNEL_COUNT;
+    vtxSmartAudio.capability.powerCount = VTX_SMARTAUDIO_POWER_COUNT;
+    vtxSmartAudio.frequencyTable = vtxStringFrequencyTable();
+    vtxSmartAudio.bandNames = vtxStringBandNames();
+    vtxSmartAudio.bandLetters = vtxStringBandLetters();
+    vtxSmartAudio.channelNames = vtxStringChannelNames();
+    vtxSmartAudio.powerNames = saPowerNames;
+    vtxSmartAudio.powerValues = saPowerValues;
+
     vtxCommonSetDevice(&vtxSmartAudio);
 
     return true;
@@ -885,8 +895,9 @@ static bool vtxSAGetFreq(const vtxDevice_t *vtxDevice, uint16_t *pFreq)
 
     // if not in user-freq mode then convert band/chan to frequency
     *pFreq = (saDevice.mode & SA_MODE_GET_FREQ_BY_FREQ) ? saDevice.freq :
-        vtx58_Bandchan2Freq(SA_DEVICE_CHVAL_TO_BAND(saDevice.channel) + 1,
-        SA_DEVICE_CHVAL_TO_CHANNEL(saDevice.channel) + 1);
+        vtxCommonLookupFrequency(&vtxSmartAudio,
+                SA_DEVICE_CHVAL_TO_BAND(saDevice.channel) + 1,
+                SA_DEVICE_CHVAL_TO_CHANNEL(saDevice.channel) + 1);
     return true;
 }
 

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -88,8 +88,6 @@ typedef struct smartAudioStat_s {
 } smartAudioStat_t;
 
 extern smartAudioDevice_t saDevice;
-extern saPowerTable_t saPowerTable[];
-extern const char * const saPowerNames[];
 extern smartAudioStat_t saStat;
 
 extern uint16_t sa_smartbaud;

--- a/src/main/io/vtx_string.c
+++ b/src/main/io/vtx_string.c
@@ -32,7 +32,7 @@
 #define VTX_STRING_BAND_COUNT 5
 #define VTX_STRING_CHAN_COUNT 8
 
-const uint16_t vtx58frequencyTable[VTX_STRING_BAND_COUNT][VTX_STRING_CHAN_COUNT] =
+static const uint16_t vtx58frequencyTable[VTX_STRING_BAND_COUNT][VTX_STRING_CHAN_COUNT] =
 {
     { 5865, 5845, 5825, 5805, 5785, 5765, 5745, 5725 }, // Boscam A
     { 5733, 5752, 5771, 5790, 5809, 5828, 5847, 5866 }, // Boscam B
@@ -41,7 +41,7 @@ const uint16_t vtx58frequencyTable[VTX_STRING_BAND_COUNT][VTX_STRING_CHAN_COUNT]
     { 5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917 }, // RaceBand
 };
 
-const char * const vtx58BandNames[] = {
+static const char * vtx58BandNames[] = {
     "--------",
     "BOSCAM A",
     "BOSCAM B",
@@ -50,44 +50,30 @@ const char * const vtx58BandNames[] = {
     "RACEBAND",
 };
 
-const char vtx58BandLetter[] = "-ABEFR";
+static char const vtx58BandLetter[] = "-ABEFR";
 
-const char * const vtx58ChannelNames[] = {
+static char const * vtx58ChannelNames[] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",
 };
 
-//Converts frequency (in MHz) to band and channel values.
-bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
+const uint16_t *vtxStringFrequencyTable(void)
 {
-    // Use reverse lookup order so that 5880Mhz
-    // get Raceband 7 instead of Fatshark 8.
-    for (int band = VTX_STRING_BAND_COUNT - 1 ; band >= 0 ; band--) {
-        for (int channel = 0 ; channel < VTX_STRING_CHAN_COUNT ; channel++) {
-            if (vtx58frequencyTable[band][channel] == freq) {
-                *pBand = band + 1;
-                *pChannel = channel + 1;
-                return true;
-            }
-        }
-    }
-
-    *pBand = 0;
-    *pChannel = 0;
-
-    return false;
+    return &vtx58frequencyTable[0][0];
 }
 
-//Converts band and channel values to a frequency (in MHz) value.
-// band:  Band value (1 to 5).
-// channel:  Channel value (1 to 8).
-// Returns frequency value (in MHz), or 0 if band/channel out of range.
-uint16_t vtx58_Bandchan2Freq(uint8_t band, uint8_t channel)
+const char **vtxStringBandNames(void)
 {
-    if (band > 0 && band <= VTX_STRING_BAND_COUNT &&
-                          channel > 0 && channel <= VTX_STRING_CHAN_COUNT) {
-        return vtx58frequencyTable[band - 1][channel - 1];
-    }
-    return 0;
+    return vtx58BandNames;
+}
+
+const char **vtxStringChannelNames(void)
+{
+    return vtx58ChannelNames;
+}
+
+const char *vtxStringBandLetters(void)
+{
+    return vtx58BandLetter;
 }
 
 #endif

--- a/src/main/io/vtx_string.h
+++ b/src/main/io/vtx_string.h
@@ -25,11 +25,10 @@
 #include "platform.h"
 #include "drivers/vtx_common.h"
 
+bool _vtxStringFreq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel);
+uint16_t _vtxStringBandchan2Freq(uint8_t band, uint8_t channel);
 
-extern const uint16_t vtx58frequencyTable[VTX_SETTINGS_BAND_COUNT][VTX_SETTINGS_CHANNEL_COUNT];
-extern const char * const vtx58BandNames[];
-extern const char * const vtx58ChannelNames[];
-extern const char vtx58BandLetter[];
-
-bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel);
-uint16_t vtx58_Bandchan2Freq(uint8_t band, uint8_t channel);
+const uint16_t * vtxStringFrequencyTable(void);
+const char ** vtxStringBandNames(void);
+const char ** vtxStringChannelNames(void);
+const char * vtxStringBandLetters(void);

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -49,7 +49,7 @@ const uint16_t trampPowerTable[VTX_TRAMP_POWER_COUNT] = {
     25, 100, 200, 400, 600
 };
 
-const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1] = {
+const char * trampPowerNames[VTX_TRAMP_POWER_COUNT+1] = {
     "---", "25 ", "100", "200", "400", "600"
 };
 #endif
@@ -58,12 +58,6 @@ const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1] = {
 static const vtxVTable_t trampVTable; // forward
 static vtxDevice_t vtxTramp = {
     .vTable = &trampVTable,
-    .capability.bandCount = VTX_TRAMP_BAND_COUNT,
-    .capability.channelCount = VTX_TRAMP_CHANNEL_COUNT,
-    .capability.powerCount = sizeof(trampPowerTable),
-    .bandNames = (char **)vtx58BandNames,
-    .channelNames = (char **)vtx58ChannelNames,
-    .powerNames = (char **)trampPowerNames,
 };
 #endif
 
@@ -167,7 +161,7 @@ static bool trampValidateBandAndChannel(uint8_t band, uint8_t channel)
 
 static void trampDevSetBandAndChannel(uint8_t band, uint8_t channel)
 {
-    trampDevSetFreq(vtx58_Bandchan2Freq(band, channel));
+    trampDevSetFreq(vtxCommonLookupFrequency(vtxCommonDevice(), band, channel));
 }
 
 void trampSetBandAndChannel(uint8_t band, uint8_t channel)
@@ -246,7 +240,7 @@ static char trampHandleResponse(void)
                 trampPower = trampRespBuffer[8]|(trampRespBuffer[9] << 8);
 
                 // if no band/chan match then make sure set-by-freq mode is flagged
-                if (!vtx58_Freq2Bandchan(trampCurFreq, &trampBand, &trampChannel)) {
+                if (!vtxCommonLookupBandChan(vtxCommonDevice(), trampCurFreq, &trampBand, &trampChannel)) {
                     trampSetByFreqFlag = true;
                 }
 
@@ -621,6 +615,16 @@ bool vtxTrampInit(void)
     }
 
 #if defined(USE_VTX_COMMON)
+    vtxTramp.capability.bandCount = VTX_TRAMP_BAND_COUNT;
+    vtxTramp.capability.channelCount = VTX_TRAMP_CHANNEL_COUNT;
+    vtxTramp.capability.powerCount = sizeof(trampPowerTable),
+    vtxTramp.frequencyTable = vtxStringFrequencyTable();
+    vtxTramp.bandNames = vtxStringBandNames();
+    vtxTramp.bandLetters = vtxStringBandLetters();
+    vtxTramp.channelNames = vtxStringChannelNames();
+    vtxTramp.powerNames = trampPowerNames;
+    vtxTramp.powerValues = trampPowerTable;
+
     vtxCommonSetDevice(&vtxTramp);
 #endif
 

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -36,9 +36,6 @@
 #define VTX_TRAMP_MIN_FREQUENCY_MHZ 5000             //min freq in MHz
 #define VTX_TRAMP_MAX_FREQUENCY_MHZ 5999             //max freq in MHz
 
-extern const uint16_t trampPowerTable[VTX_TRAMP_POWER_COUNT];
-extern const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1];
-
 extern uint8_t trampBand;
 extern uint8_t trampChannel;
 extern uint16_t trampPower;       // Actual transmitting power

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -314,13 +314,13 @@ static void convertVtxPower(spektrumVtx_t * vtx)
 #if defined(USE_VTX_TRAMP)
         case VTXDEV_TRAMP:
             powerIndexTable = vtxTrampPi;
-            vtx->powerValue = trampPowerTable[vtx->power -1];      // Lookup the device power value, 0-based table vs 1-based index. Doh.
+            vtx->powerValue = vtxCommonLookupPowerValue(vtxCommonDevice(), vtx->power - 1);  // Lookup the device power value, 0-based table vs 1-based index. Doh.
             break;
 #endif
 #if defined(USE_VTX_SMARTAUDIO)
         case VTXDEV_SMARTAUDIO:
             powerIndexTable = vtxSaPi;
-            vtx->powerValue = saPowerTable[vtx->power -1].rfpower;
+            vtx->powerValue = vtxCommonLookupPowerValue(vtxCommonDevice(), vtx->power - 1);  // Lookup the device power value, 0-based table vs 1-based index. Doh.
             break;
 #endif
 #if defined(USE_VTX_RTC6705)


### PR DESCRIPTION
In preparation of `vtxTable` facility, existing code is refactored not to reference static string and frequency tables but call `vtxCommon` services instead to get a desired lookups.

- `vtx58_XXX` tables are now referenced from drivers and `vtxCommon` by calling corresponding `vtxStringXXX`. This will make transition to `vtxTable` facility easier (just replace `vtxStringXXX` to return `vtxTableXXX`).
- Frequency and band & channel lookups are replaced with new set of `vtxCommon` services that honor `vtxDevice` (which holds band and channel counts and pointer to actual tables).

- Tramp and RTC6705 should be tested by a device user.