### PR TITLE
Update target HAKRC405,modify the name of gyro interface definition

### DIFF
--- a/src/main/target/HAKRCF405/target.h
+++ b/src/main/target/HAKRCF405/target.h
@@ -49,29 +49,28 @@
 #define SPI1_MOSI_PIN           PA7
 
 #define USE_EXTI
-#define MPU_INT_EXTI            PC4
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_GYRO
 #define USE_ACC
 
-#define ICM20689_CS_PIN          PA4 
-#define ICM20689_SPI_INSTANCE    SPI1
+#define GYRO_1_CS_PIN           PA4
+#define GYRO_1_SPI_INSTANCE     SPI1
 
 #define USE_GYRO_SPI_ICM20689
-#define GYRO_ICM20689_ALIGN      CW270_DEG
+#define GYRO_1_ALIGN      CW270_DEG
 
 #define USE_ACC_SPI_ICM20689
-#define ACC_ICM20689_ALIGN       CW270_DEG
+#define ACC_1_ALIGN       CW270_DEG
 
-#define MPU6000_CS_PIN           PA4 
-#define MPU6000_SPI_INSTANCE     SPI1
+#define GYRO_1_CS_PIN           PA4
+#define GYRO_1_SPI_INSTANCE     SPI1
 
 #define USE_GYRO_SPI_MPU6000
-#define GYRO_MPU6000_ALIGN      CW270_DEG
 
 #define USE_ACC_SPI_MPU6000
-#define ACC_MPU6000_ALIGN       CW270_DEG
 
 #define LED0_PIN                PC13
 


### PR DESCRIPTION
For target of HAKRCF405:
1) The Gyro interface defined code  is unmatched the 4.0.0 . 
2) Modify Gryo cs pin/ spi pin and so on .