### PR TITLE
Add STM32F411DISCOVERY target

### DIFF
--- a/docs/boards/Board - STM32Discovery.md
+++ b/docs/boards/Board - STM32Discovery.md
@@ -1,0 +1,86 @@
+# Boards - STM32Discovery
+
+STM32Discovery boards are relatively cheap boards featuring STM32 MCUs manufactured and distributed by [STMicroelectronics](https://www.st.com/). They are known as "tinkerer boards", not specifically as flight controllers, as they can be used for a variety of things. They are bigger and heavier than standard flight controllers, feature plug pins for ease of use and quick changes, no soldering required.
+
+They come with different MCUs and in different sizes, however pin-outs are very similar for compatibility with external boards which can be used as extensions.
+
+Solid documentation is provided by STMicroelectronics.
+
+
+## Targets
+
+| Target               | MCU           | Documentation |
+| ---                  | ---           | --- |
+| `STM32F3DISCOVERY`   | `STM32F303VC` | [User Manual](https://www.st.com/content/ccc/resource/technical/document/user_manual/8a/56/97/63/8d/56/41/73/DM00063382.pdf/files/DM00063382.pdf/jcr:content/translations/en.DM00063382.pdf) \| [MCU Datasheet](www.st.com/resource/en/datasheet/stm32f303vc.pdf) |
+| `STM32F4DISCOVERY`   | `STM32F407VG` | [User Manual](https://www.st.com/content/ccc/resource/technical/document/user_manual/70/fe/4a/3f/e7/e1/4f/7d/DM00039084.pdf/files/DM00039084.pdf/jcr:content/translations/en.DM00039084.pdf) \| [MCU Datasheet](https://www.st.com/resource/en/datasheet/stm32f407vg.pdf) |
+| `STM32F411DISCOVERY` | `STM32F411VE` | [User Manual](https://www.st.com/content/ccc/resource/technical/document/user_manual/e9/d2/00/5e/15/46/44/0e/DM00148985.pdf/files/DM00148985.pdf/jcr:content/translations/en.DM00148985.pdf) \| [MCU Datasheet](https://www.st.com/resource/en/datasheet/stm32f411re.pdf) |
+
+Hardware specifications, peripherals, pinouts and all other data can be found in above User Manuals. Rest of this document is instead going to focus on setup of the board for Betaflight and example assemblies/wirings.
+
+_Note: Not all pin-outs seem to be listed in the User Manual, double-checking in MCU Datasheet is recommended._
+
+### Pins
+
+| Function       | F3   | F4   | F411 |
+| ---            | ---  | ---  | ---  |
+| PPM Receiver   | PB8  | PB9  | PB8  |
+| Motor 1        | PA8  | PB1  | PD12 |
+| Motor 2        | PC6  | PB0  | PB1  |
+| Motor 3        | PC7  | PA2  | PB0  |
+| Motor 4        | PC8  | PA3  | PA2  |
+| Motor 5        | /    | PA10 | PA3  |
+| Motor 6        | /    | PA8  | PA10 |
+| Beeper         | PD12 | /    | PA8  |
+| USART1 TX      | PA9  | PB6  | PA15 |
+| USART1 RX      | PA10 | PB7  | PA10 |
+| USART2 TX      | PD5  | PA2  | PA2  |
+| USART2 RX      | PD6  | PA3  | PA3  |
+| USART3 TX      | PB10 | PB10 | /    |
+| USART3 RX      | PB11 | PB11 | /    |
+| USART4 TX      | PC10 | PA0  | /    |
+| USART4 RX      | PC11 | PA1  | /    |
+| USART5 TX      | PC12 | /    | /    |
+| USART5 RX      | PD2  | /    | /    |
+| USART6 TX      | /    | PC6  | PC6  |
+| USART6 RX      | /    | PC7  | PC7  |
+| HCSR04 Trigger | PB0  | /    | /    |
+| HCSR04 Echo    | PB1  | /    | /    |
+
+_Note: `/` means not supported or configured._
+
+
+## Setup
+
+### Flash
+
+- Connect board using `ST-LINK` labelled port (usually Mini-B USB connector)
+
+**Linux & Mac:**
+- Install [stlink](https://github.com/texane/stlink)
+- `$ st-flash --format ihex write program.hex`
+
+**Windows:**
+- Install and use [STM32 ST-LINK utility](https://www.st.com/en/development-tools/stsw-link004.html)
+
+### Connect Configurator
+
+- Connect board using `USER` labelled port (usually Micro-AB or secondary Mini-B USB connector)
+
+
+## Example Assembly
+
+As an example of full assembly, [feriCopterV1](https://github.com/Nailim/feriCopterV1) is completely custom built drone as part of a student project. Includes simple 3D printed frame, parts list, assembly and pin connection instructions, providing a great entry-point to anyone who wants to assemble their own little drone cheaply and learn more about how everything works.
+
+It is based on `STM32F3DISCOVERY` target, required changes in Configurator are noted below. Also refer to [Target Pins](#pins) table for other Discovery boards. Additional non-pin changes are noted below.
+
+**Configurator:**
+
+| Setting  | Value |
+| ---      | ---   |
+| Mixer    | Quad X 1234 |
+| Receiver | PPM RX input |
+
+### F411 Changes
+
+- Inversed Front/Back (Front is Back and Back is Front).
+- Frame requires minor incision to fit different jumper location.

--- a/src/main/target/STM32F411DISCOVERY/target.c
+++ b/src/main/target/STM32F411DISCOVERY/target.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM4, CH3, PB8,  TIM_USE_PPM | TIM_USE_LED, 0, 0), // PPM IN
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_BEEPER           , 0, 0), // BEEPER OUT
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR            , 0, 0), // S1_OUT
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR            , 0, 0), // S2_OUT
+    DEF_TIM(TIM2, CH3, PA2,  TIM_USE_MOTOR            , 0, 0), // S3_OUT
+    DEF_TIM(TIM2, CH4, PA3,  TIM_USE_MOTOR            , 0, 1), // S4_OUT
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MOTOR            , 0, 1), // S5_OUT
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MOTOR            , 0, 1), // S6_OUT
+};

--- a/src/main/target/STM32F411DISCOVERY/target.h
+++ b/src/main/target/STM32F411DISCOVERY/target.h
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "S411" // STM Discovery F411
+#define USBD_PRODUCT_STRING     "DISCF411"
+
+#define USE_SENSOR_NAMES
+
+#define LED0_PIN                PD15 // Blue
+#define LED1_PIN                PD13 // Orange
+
+#define USE_BEEPER
+#define BEEPER_PIN              PD12 // Green LED
+#define BEEPER_PWM_HZ           2000 // Beeper PWM frequency in Hz
+
+// Gyro
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_GYRO
+
+#define USE_GYRO_L3GD20
+#define GYRO_1_SPI_INSTANCE     SPI1
+#define GYRO_1_CS_PIN           PE3
+#define GYRO_1_ALIGN            CW180_DEG
+
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PE1
+#define USE_MPU_DATA_READY_SIGNAL
+
+// Acc
+#define USE_ACC
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB9
+
+#define MPU_I2C_INSTANCE        (I2CDEV_1)
+#define USE_ACC_LSM303DLHC
+#define ACC_1_ALIGN             CW0_DEG
+
+#define USE_MAG
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+
+// Serial
+#define USE_VCP
+#define USE_USB_DETECT
+#define USB_DETECT_PIN          PA9
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA15
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       4 // VCP, USART1, USART2, USART6
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+
+// ADC
+#define USE_ADC
+#define VBAT_ADC_PIN            PC1
+#define CURRENT_METER_ADC_PIN   PC2
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  PB8
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+// Buses & Timers
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+#define TARGET_IO_PORTE         0xffff
+#define TARGET_IO_PORTH         0xffff
+
+#define USABLE_TIMER_CHANNEL_COUNT 8
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) )
+

--- a/src/main/target/STM32F411DISCOVERY/target.mk
+++ b/src/main/target/STM32F411DISCOVERY/target.mk
@@ -1,0 +1,9 @@
+F411_TARGETS    += $(TARGET)
+FEATURES        += VCP SDCARD_SPI ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_spi_l3gd20.c \
+            drivers/accgyro_legacy/accgyro_lsm303dlhc.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c
+


### PR DESCRIPTION
This pull request adds STM32F411DISCO target for STM32F411Discovery board
- ~~Has "DISCO" appended to work around the target independent code test~~
  - ~~Can name it "STM32F411DISCOVERY" if that would fit the others better?~~
  - Has been renamed to "STM32F411DISCOVERY" to fit other Discovery boards
- Relies on #7240 for gyro/acc sensor driver

Thanks to everyone on Slack for the help, especially @mikeller for updating the gyro/acc driver!

Review appreciated! :)
More pull requests likely coming as we find bugs/misconfiguration in the target.

~ by [Team13](https://github.com/T-13), work done as part of a Drone student project