### PR TITLE
Mag heading ignored while GPS Rescue is running

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -140,6 +140,7 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .minSats = 8,
     .minRescueDth = 100,
     .allowArmingWithoutFix = false,
+    .useMag = true
 );
 
 static uint16_t rescueThrottle;
@@ -150,6 +151,7 @@ uint16_t      hoverThrottle = 0;
 float         averageThrottle = 0.0;
 float         altitudeError = 0.0;
 uint32_t      throttleSamples = 0;
+bool          magForceDisable = false;
 
 static bool newGPSData = false;
 
@@ -368,7 +370,14 @@ static void performSanityChecks()
         lastDistanceToHomeM = rescueState.sensor.distanceToHomeM;
 
         if (secondsFlyingAway == 10) {
-            rescueState.failure = RESCUE_FLYAWAY;
+            //If there is a mag and has not been disabled, we have to assume is healthy and has been used in imu.c
+            if (sensors(SENSOR_MAG) && gpsRescueConfig()->useMag && !magForceDisable) {
+                //Try again with mag disabled
+                magForceDisable = true;
+                secondsFlyingAway = 0;
+            } else {
+                rescueState.failure = RESCUE_FLYAWAY;
+            }
         }
     }
 
@@ -414,7 +423,7 @@ static void sensorUpdate()
 // 3. GPS number of satellites is less than the minimum configured for GPS rescue.
 // Note: this function does not take into account the distance from homepoint etc. (gps_rescue_min_dth) and
 // is also independent of the gps_rescue_sanity_checks configuration
-static bool gpsRescueIsAvailable(void)
+static bool checkGPSRescueIsAvailable(void)
 {
     static uint32_t previousTimeUs = 0; // Last time LowSat was checked
     const uint32_t currentTimeUs = micros();
@@ -473,7 +482,7 @@ void updateGPSRescueState(void)
 
     sensorUpdate();
 
-    rescueState.isAvailable = gpsRescueIsAvailable();
+    rescueState.isAvailable = checkGPSRescueIsAvailable();
 
     switch (rescueState.phase) {
     case RESCUE_IDLE:
@@ -604,9 +613,14 @@ bool gpsRescueIsConfigured(void)
     return failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE || isModeActivationConditionPresent(BOXGPSRESCUE);
 }
 
-bool isGPSRescueAvailable(void)
+bool gpsRescueIsAvailable(void)
 {
     return rescueState.isAvailable;
+}
+
+bool gpsRescueDisableMag(void)
+{
+    return ((!gpsRescueConfig()->useMag || magForceDisable) && (rescueState.phase >= RESCUE_INITIALIZE) && (rescueState.phase <= RESCUE_LANDING));
 }
 #endif
 

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -34,6 +34,7 @@ typedef struct gpsRescue_s {
     uint16_t minRescueDth; //meters
     uint8_t sanityChecks;
     uint8_t allowArmingWithoutFix;
+    uint8_t useMag;
 } gpsRescueConfig_t;
 
 PG_DECLARE(gpsRescueConfig_t, gpsRescueConfig);
@@ -46,4 +47,5 @@ void rescueNewGpsData(void);
 float gpsRescueGetYawRate(void);
 float gpsRescueGetThrottle(void);
 bool gpsRescueIsConfigured(void);
-bool isGPSRescueAvailable(void);
+bool gpsRescueIsAvailable(void);
+bool gpsRescueDisableMag(void);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -851,6 +851,7 @@ const clivalue_t valueTable[] = {
     { "gps_rescue_min_sats",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 5, 50 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minSats) },
     { "gps_rescue_min_dth",         VAR_UINT16  | MASTER_VALUE, .config.minmax = { 50, 1000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDth) },
     { "gps_rescue_allow_arming_without_fix", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, allowArmingWithoutFix) },
+    { "gps_rescue_use_mag",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, useMag) },
 #endif
 #endif
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -996,7 +996,7 @@ static bool osdDrawSingleElement(uint8_t item)
             if (osdWarnGetState(OSD_WARNING_GPS_RESCUE_UNAVAILABLE) &&
                ARMING_FLAG(ARMED) &&
                gpsRescueIsConfigured() &&
-               !isGPSRescueAvailable()) {
+               !gpsRescueIsAvailable()) {
                 osdFormatMessage(buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "NO GPS RESC");
                 SET_BLINK(OSD_WARNINGS);
                 break;

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -245,4 +245,5 @@ int32_t baroCalculateAltitude(void) { return 0; }
 bool gyroGetAccumulationAverage(float *) { return false; }
 bool accGetAccumulationAverage(float *) { return false; }
 void mixerSetThrottleAngleCorrection(int) {};
+bool gpsRescueIsRunning(void) { return false; }
 }


### PR DESCRIPTION
According to the Wiki, GPS Rescue was supposed to ignore the magnetometer, but it turns out it's not the case. If a magnetometer is malfunctioning/not calibrated/whatever, the quad is not going to point home during GPS Rescue. This in turn will probably trigger the FLY_AWAY/STALLED sanity check, so the quad will drop even if it could have flown home. I propose the drastic measure of ignoring the magnetometer during normal GPS Rescue operation.

I've also removed an unused extern in imu.c (canUseGPSHeading), and renamed the extern isGPSRescueAvailable to gpsRescueIsAvailable in order to match the convention used for the other externs. As a result I also had to rename gpsRescueIsAvailable (a previously existing function) to something else to avoid collision, in this case I've chosen checkIsAvailable. 