### PR TITLE
[TELEMETRY] Move bracketing endif to the end

### DIFF
--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -225,9 +225,9 @@ void telemetryProcess(uint32_t currentTime)
     handleIbusTelemetry();
 #endif
 }
-#endif
 
 bool telemetryIsSensorEnabled(sensor_e sensor)
 {
     return ~(telemetryConfigMutable()->disabledSensors) & sensor;
 }
+#endif


### PR DESCRIPTION
Wouldn’t build if USE_TELEMETRY is dropped.
