### PR TITLE
Allow arming without GPS

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -279,7 +279,7 @@ void updateArmingStatus(void)
 
 #ifdef USE_GPS_RESCUE
         if (gpsRescueIsConfigured()) {
-            if (!gpsRescueConfig()->minSats || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED)) {
+            if (gpsRescueConfig()->allowArmingWithoutFix || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {
                 setArmingDisabled(ARMING_DISABLED_GPS);
@@ -447,8 +447,10 @@ void tryArm(void)
 
         lastArmingDisabledReason = 0;
 
-        //beep to indicate arming
 #ifdef USE_GPS
+        GPS_reset_home_position();
+
+        //beep to indicate arming
         if (featureIsEnabled(FEATURE_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 5) {
             beeper(BEEPER_ARMING_GPS_FIX);
         } else {
@@ -1118,7 +1120,6 @@ FAST_CODE void taskMainPidLoop(timeUs_t currentTimeUs)
         debug[1] = averageSystemLoadPercent;
     }
 }
-
 
 bool isFlipOverAfterCrashActive(void)
 {

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -138,7 +138,8 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .throttleHover = 1280,
     .sanityChecks = RESCUE_SANITY_ON,
     .minSats = 8,
-    .minRescueDth = 100
+    .minRescueDth = 100,
+    .allowArmingWithoutFix = false,
 );
 
 static uint16_t rescueThrottle;
@@ -422,7 +423,7 @@ static bool gpsRescueIsAvailable(void)
     static bool noGPSfix = false;
     bool result = true;
 
-    if (!gpsIsHealthy() ) {
+    if (!gpsIsHealthy() || !STATE(GPS_FIX_HOME)) {
         return false;
     }
 
@@ -481,6 +482,11 @@ void updateGPSRescueState(void)
     case RESCUE_INITIALIZE:
         if (hoverThrottle == 0) { //no actual throttle data yet, let's use the default.
             hoverThrottle = gpsRescueConfig()->throttleHover;
+        }
+
+        if (!STATE(GPS_FIX_HOME)) {
+            setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+            disarm();
         }
 
         // Minimum distance detection.

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -33,6 +33,7 @@ typedef struct gpsRescue_s {
     uint8_t minSats;
     uint16_t minRescueDth; //meters
     uint8_t sanityChecks;
+    uint8_t allowArmingWithoutFix;
 } gpsRescueConfig_t;
 
 PG_DECLARE(gpsRescueConfig_t, gpsRescueConfig);

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -843,8 +843,9 @@ const clivalue_t valueTable[] = {
     { "gps_rescue_throttle_max",    VAR_UINT16 | MASTER_VALUE, .config.minmax = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMax) },
     { "gps_rescue_throttle_hover",  VAR_UINT16 | MASTER_VALUE, .config.minmax = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleHover) },
     { "gps_rescue_sanity_checks",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, sanityChecks) },
-    { "gps_rescue_min_sats",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 50 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minSats) },
+    { "gps_rescue_min_sats",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 5, 50 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minSats) },
     { "gps_rescue_min_dth",         VAR_UINT16  | MASTER_VALUE, .config.minmax = { 50, 1000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDth) },
+    { "gps_rescue_allow_arming_without_fix", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, allowArmingWithoutFix) },
 #endif
 #endif
 


### PR DESCRIPTION
A bit of context before explaining this PR:
- Before GPS Rescue, the quad could not be armed unless a valid GPS Fix was received
- GPS Rescue introduced the parameter gps_rescue_min_sats that could be set to 0 to allow arming even if there were no sats
- GPS Rescue initially forced a home point reset when the quad was disarmed. Quickly rearming the quad in a different location could miss updating the home point, so this home point reset was moved again to be done just after arming.

This PR allows arming the quad without a GPS Fix, then:
- if a valid GPS Fix is received for the next 3 seconds, the home point will be updated
- otherwise, the home point will not be updated, so:
 + home distance and direction will not show up in OSD
 + if GPS Rescue is enabled, a warning (NO GPS RESC) will show up

Notes:
- flying without waiting GPS to produce valid fixes is now possible without messing with gps_rescue_min_sats (which was a bad practice as it required the pilot to be aware of the risk) and it now shows a clear warning (GPS not available) so the pilot is totally aware at all times of what is happening.
- arming with a valid GPS_FIX and 5 or more sats will still produce a special arming beep, that's a good indication that home point will very likely be initialized properly afterwards
- gps_rescue_min_sats range has been modified to a minimum of 5 which makes more sense from the point of view of gps_rescue operation itself
- lat/lon coordinates will show up on the OSD as soon as they're available, regardless of home point having been updated

I've not been able to test this change on the field (yet), so I'm submitting the PR just to check if there is any concern preventing the PR to be accepted. Testing is so time consuming for me that I prefer to defer it until the PR is greenlighted.