### PR TITLE
Smartport missing sensors fix

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -799,7 +799,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 #if defined(USE_ADC_INTERNAL)
             case FSSP_DATAID_T11        :
                 smartPortSendPackage(id, getCoreTemperatureCelsius());
-
+                *clearToSend = false;
                 break;
 #endif
 #ifdef USE_GPS


### PR DESCRIPTION
Fixes the issues described in #7273, #7319 and #7316. Sensors go missing when the new core temperature sensor is enabled. It's caused by a missing ``*clearToSend = false;``.  Have tested it, and it works as it should now. 
