### PR TITLE
Move QMC5883 sensor detectoin to the end to avoid wrong detection as much as posible

### DIFF
--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -205,22 +205,6 @@ bool compassDetect(magDev_t *dev)
 #endif
         FALLTHROUGH;
 
-    case MAG_QMC5883:
-#ifdef USE_MAG_QMC5883
-        if (busdev->bustype == BUSTYPE_I2C) {
-                busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
-        }
-
-        if (qmc5883lDetect(dev)) {
-#ifdef MAG_QMC5883L_ALIGN
-            dev->magAlign = MAG_QMC5883L_ALIGN;
-#endif
-            magHardware = MAG_QMC5883;
-            break;
-        }
-#endif
-        FALLTHROUGH;
-
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
         if (busdev->bustype == BUSTYPE_I2C) {
@@ -253,6 +237,22 @@ bool compassDetect(magDev_t *dev)
             dev->magAlign = MAG_AK8963_ALIGN;
 #endif
             magHardware = MAG_AK8963;
+            break;
+        }
+#endif
+        FALLTHROUGH;
+
+    case MAG_QMC5883:
+#ifdef USE_MAG_QMC5883
+        if (busdev->bustype == BUSTYPE_I2C) {
+                busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+        }
+
+        if (qmc5883lDetect(dev)) {
+#ifdef MAG_QMC5883L_ALIGN
+            dev->magAlign = MAG_QMC5883L_ALIGN;
+#endif
+            magHardware = MAG_QMC5883;
             break;
         }
 #endif

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -176,7 +176,7 @@ bool compassDetect(magDev_t *dev)
     case MAG_HMC5883:
 #if defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883)
         if (busdev->bustype == BUSTYPE_I2C) {
-                busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
 
         if (hmc5883lDetect(dev)) {
@@ -192,7 +192,7 @@ bool compassDetect(magDev_t *dev)
     case MAG_LIS3MDL:
 #if defined(USE_MAG_LIS3MDL)
         if (busdev->bustype == BUSTYPE_I2C) {
-                busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
 
         if (lis3mdlDetect(dev)) {
@@ -208,7 +208,7 @@ bool compassDetect(magDev_t *dev)
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
         if (busdev->bustype == BUSTYPE_I2C) {
-                busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
 
         if (ak8975Detect(dev)) {
@@ -245,7 +245,7 @@ bool compassDetect(magDev_t *dev)
     case MAG_QMC5883:
 #ifdef USE_MAG_QMC5883
         if (busdev->bustype == BUSTYPE_I2C) {
-                busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
 
         if (qmc5883lDetect(dev)) {


### PR DESCRIPTION
Looks to be we still have wrong QMC5883 mag detections. Some AFNG F7 boards have an AK8963 on SPI wich is sometimes wrongly detected as QMC5883. #6121 has not fixed this completely.