### PR TITLE
ignore failsafe packets in rx_spi_frskyx

### DIFF
--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -196,9 +196,9 @@ static bool tuneRx(uint8_t *packet)
             if (packet[ccLen - 1] & 0x80) {
                 if (packet[2] == 0x01) {
                     uint8_t Lqi = packet[ccLen - 1] & 0x7F;
-                    if (Lqi < 50) {
+                    // higher lqi represent better link quality
+                    if (Lqi > 50) {
                         rxFrSkySpiConfigMutable()->bindOffset = bindOffset;
-
                         return true;
                     }
                 }

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -274,6 +274,10 @@ static void frSkyXTelemetryWriteFrame(const smartPortPayload_t *payload)
 void frSkyXSetRcData(uint16_t *rcData, const uint8_t *packet)
 {
     uint16_t c[8];
+    // ignore failsafe packet
+    if (packet[7] != 0) {
+        return;
+    }
     c[0] = (uint16_t)((packet[10] << 8) & 0xF00) | packet[9];
     c[1] = (uint16_t)((packet[11] << 4) & 0xFF0) | (packet[10] >> 4);
     c[2] = (uint16_t)((packet[13] << 8) & 0xF00) | packet[12];


### PR DESCRIPTION
Small fix to prevent failsafe packets from the tx to cause twitching during flight and arming an unarmed quad. See https://github.com/betaflight/betaflight/issues/5576.