### PR TITLE
Fix stage 1 failsafe throttle "auto" setting for switched 3D modes

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -470,10 +470,11 @@ static uint16_t getRxfailValue(uint8_t channel)
         case YAW:
             return rxConfig()->midrc;
         case THROTTLE:
-            if (featureIsEnabled(FEATURE_3D))
+            if (featureIsEnabled(FEATURE_3D) && !IS_RC_MODE_ACTIVE(BOX3D) && !flight3DConfig()->switched_mode3d) {
                 return rxConfig()->midrc;
-            else
+            } else {
                 return rxConfig()->rx_min_usec;
+            }
         }
         /* no break */
 

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -37,6 +37,9 @@ extern "C" {
 #include "gtest/gtest.h"
 
 extern "C" {
+
+PG_REGISTER(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
+
 boxBitmask_t rcModeActivationMask;
 int16_t debug[DEBUG16_VALUE_COUNT];
 uint8_t debugMode = 0;

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -26,6 +26,7 @@ extern "C" {
     #include "pg/rx.h"
     #include "build/debug.h"
     #include "drivers/io.h"
+    #include "fc/rc_controls.h"
     #include "rx/rx.h"
     #include "fc/rc_modes.h"
     #include "common/maths.h"
@@ -44,6 +45,8 @@ extern "C" {
     PG_RESET_TEMPLATE(featureConfig_t, featureConfig,
         .enabledFeatures = 0
     );
+
+    PG_REGISTER(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
 }
 
 #include "unittest_macros.h"


### PR DESCRIPTION
The logic did not support the switched 3D modes and would always set the throttle to `mid_rc`. This is appropriate for normal 3D mode, but for switched 3D modes this would lead to 50% throttle (either positive or negative depending on the switched mode settings).
