### PR TITLE
Added spektrum SPI driver to OMNIBUSF4 target

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -165,16 +165,24 @@
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define FLASH_CS_PIN            PB12
 #define FLASH_SPI_INSTANCE      SPI2
-#define USE_FLASHFS
-#define USE_FLASH_M25P16
 
 #else
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define FLASH_CS_PIN            SPI3_NSS_PIN
 #define FLASH_SPI_INSTANCE      SPI3
-#define USE_FLASHFS
-#define USE_FLASH_M25P16
 #endif // OMNIBUSF4
+
+#ifdef OMNIBUSF4BASE
+#define USE_RX_SPI
+#define USE_RX_SPEKTRUM
+#define USE_RX_SPEKTRUM_TELEMETRY
+#define RX_CHANNELS_TAER
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
+#define RX_SPI_DEFAULT_PROTOCOL RX_SPI_CYRF6936_DSM
+#define RX_SPI_INSTANCE         SPI3
+#define RX_NSS_PIN              PD2
+#define RX_IRQ_PIN              PA0 // instead of rssi input
+#endif
 
 #define USE_VCP
 #define USE_USB_DETECT
@@ -256,6 +264,8 @@
 #define VBAT_ADC_PIN            PC2  // 11:1 (10K + 1K) divider
 #ifdef DYSF4PRO
 #define RSSI_ADC_PIN            PC3  // Direct from RSSI pad
+#elif defined(OMNIBUSF4BASE)
+#define RSSI_ADC_PIN            NONE
 #else
 #define RSSI_ADC_PIN            PA0  // Direct from RSSI pad
 #endif

--- a/src/main/target/OMNIBUSF4/target.mk
+++ b/src/main/target/OMNIBUSF4/target.mk
@@ -10,5 +10,7 @@ TARGET_SRC = \
             drivers/compass/compass_hmc5883l.c \
             drivers/compass/compass_qmc5883l.c \
             drivers/compass/compass_lis3mdl.c \
-            drivers/max7456.c
+            drivers/max7456.c \
+            drivers/rx/rx_cyrf6936.c \
+            rx/cyrf6936_spektrum.c
 			


### PR DESCRIPTION
OMNIBUSF4 has an SPI3 port with PD2 as CS exposed. This port can be used to hook up CYRF6936 and have a DSMX receiver.
It is a temporary solution until a proper BF target is designed and manufactured. It allows for CI checking of spektrum spi rx code after each commit.
