### PR TITLE
Fixed order of rx spi protocols in rx_spi_protocol_e

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -228,12 +228,12 @@ static const char * const lookupTableRxSpi[] = {
     "INAV",
     "FRSKY_D",
     "FRSKY_X",
-    "FRSKY_X_LBT",
     "FLYSKY",
     "FLYSKY_2A",
     "KN",
     "SFHSS",
-    "SPEKTRUM"
+    "SPEKTRUM",
+    "FRSKY_X_LBT"
 };
 #endif
 

--- a/src/main/rx/rx_spi.h
+++ b/src/main/rx/rx_spi.h
@@ -36,12 +36,12 @@ typedef enum {
     RX_SPI_NRF24_INAV,
     RX_SPI_FRSKY_D,
     RX_SPI_FRSKY_X,
-    RX_SPI_FRSKY_X_LBT,
     RX_SPI_A7105_FLYSKY,
     RX_SPI_A7105_FLYSKY_2A,
     RX_SPI_NRF24_KN,
     RX_SPI_SFHSS,
     RX_SPI_CYRF6936_DSM,
+    RX_SPI_FRSKY_X_LBT,
     RX_SPI_PROTOCOL_COUNT
 } rx_spi_protocol_e;
 


### PR DESCRIPTION
This is my bad, sorry.
Noticed when implementing https://github.com/betaflight/betaflight-configurator/pull/1268 .