### PR TITLE
From cleanflight: Fix broken stick configuration documentation links.

### DIFF
--- a/docs/Controls.md
+++ b/docs/Controls.md
@@ -53,8 +53,14 @@ The stick positions are combined to activate different functions:
 
 ![Stick Positions](assets/images/StickPositions.png)
 
-Download a graphic [cheat sheet](https://multiwii.googlecode.com/svn/branches/Hamburger/MultiWii-StickConfiguration-23_v0-5772156649.pdf) with Tx stick commands (the latest version can always be found
-[here](https://code.google.com/p/multiwii/source/browse/#svn%2Fbranches%2FHamburger)).
+### History
+
+Intial stick commands, came from MultiWII but the original code no-longer has direct links.
+
+The original documents as listed below can be found here https://code.google.com/archive/p/multiwii/source/default/source 
+
+* `svn/branches/Hamburger/MultiWii-StickConfiguration-23_v0-5772156649.pdf`
+* `multiwii/branches/Hamburger/MultiWii-StickConfiguration-23_v0-5772156649.odp`
 
 ## Yaw control
 


### PR DESCRIPTION
See cleanflight/cleanflight#3074.