### PR TITLE
Allow "set" option on all channels for stage 1 failsafe (rxfail)

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -222,7 +222,7 @@ static const char * const featureNames[] = {
 static const char rxFailsafeModeCharacters[] = "ahs";
 
 static const rxFailsafeChannelMode_e rxFailsafeModesTable[RX_FAILSAFE_TYPE_COUNT][RX_FAILSAFE_MODE_COUNT] = {
-    { RX_FAILSAFE_MODE_AUTO, RX_FAILSAFE_MODE_HOLD, RX_FAILSAFE_MODE_INVALID },
+    { RX_FAILSAFE_MODE_AUTO, RX_FAILSAFE_MODE_HOLD, RX_FAILSAFE_MODE_SET },
     { RX_FAILSAFE_MODE_INVALID, RX_FAILSAFE_MODE_HOLD, RX_FAILSAFE_MODE_SET }
 };
 


### PR DESCRIPTION
Previously the "set" option was only available for aux channels and roll/pitch/yaw/throttle only allowed "auto" (R/P/Y centered, throttle min) and "hold" (hold all channels at previous values). The problem with this is that many pilots wil set the throttle channel to "hold" to avoid a complete drop (and possible motor _stop if configured). This could lead to undesirable behavior if the throttle happened to be at a high value when the signal drop occurred.

With this change the user can set the control channels to a preset value as appropriate during a stage 1 failsafe. For example it may make sense to set the throttle channel to an approximate "hover" value appropriate for that quad to avoid gaining/losing altitude during the initial stage 1 portion of a failsafe.

No changes are made to stage 2 and the existing behavior of DROP, AUTO-LAND, or GPS-RESCUE (if configured) still apply.
