### PR TITLE
CMS exit/save popup menu

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -126,6 +126,7 @@ COMMON_SRC = \
             cms/cms_menu_misc.c \
             cms/cms_menu_osd.c \
             cms/cms_menu_power.c \
+            cms/cms_menu_saveexit.c \
             cms/cms_menu_vtx_rtc6705.c \
             cms/cms_menu_vtx_smartaudio.c \
             cms/cms_menu_vtx_tramp.c \
@@ -302,6 +303,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             cms/cms_menu_misc.c \
             cms/cms_menu_osd.c \
             cms/cms_menu_power.c \
+            cms/cms_menu_saveexit.c \
             cms/cms_menu_vtx_rtc6705.c \
             cms/cms_menu_vtx_smartaudio.c \
             cms/cms_menu_vtx_tramp.c \

--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -32,6 +32,7 @@ typedef enum {
     CMS_KEY_RIGHT,
     CMS_KEY_ESC,
     CMS_KEY_MENU,
+    CMS_KEY_SAVEMENU,
 } cms_key_e;
 
 extern bool cmsInMenu;
@@ -60,3 +61,6 @@ void cmsSetExternKey(cms_key_e extKey);
 #define CMS_EXIT             (0)
 #define CMS_EXIT_SAVE        (1)
 #define CMS_EXIT_SAVEREBOOT  (2)
+#define CMS_POPUP_SAVE       (3)
+#define CMS_POPUP_SAVEREBOOT (4)
+

--- a/src/main/cms/cms_menu_saveexit.c
+++ b/src/main/cms/cms_menu_saveexit.c
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "platform.h"
+
+#ifdef USE_CMS
+#include "cms/cms.h"
+#include "cms/cms_types.h"
+#include "cms/cms_menu_saveexit.h"
+
+#include "config/feature.h"
+
+#include "fc/config.h"
+
+static OSD_Entry cmsx_menuSaveExitEntries[] =
+{
+    { "-- SAVE/EXIT --", OME_Label, NULL, NULL, 0},
+    {"EXIT",        OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT, 0},
+    {"SAVE&EXIT",   OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVE, 0},
+    {"SAVE&REBOOT", OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT, 0},
+    { "BACK", OME_Back, NULL, NULL, 0 },
+    { NULL, OME_END, NULL, NULL, 0 }
+};
+
+CMS_Menu cmsx_menuSaveExit = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "MENUSAVE",
+    .GUARD_type = OME_MENU,
+#endif
+    .entries = cmsx_menuSaveExitEntries
+};
+
+#endif

--- a/src/main/cms/cms_menu_saveexit.h
+++ b/src/main/cms/cms_menu_saveexit.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+extern CMS_Menu cmsx_menuSaveExit;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -106,6 +106,7 @@ cli_unittest_DEFINES := \
 
 cms_unittest_SRC := \
 		$(USER_DIR)/cms/cms.c \
+		$(USER_DIR)/cms/cms_menu_saveexit.c \
 		$(USER_DIR)/common/typeconversion.c \
 		$(USER_DIR)/drivers/display.c
 


### PR DESCRIPTION
Adds a new exit/save menu that can be displayed at any time using the yaw-right stick command. Yaw-left still functions as "back".

Allows the user to save their settings even while nested deep in multiple menus. Previously the user was required to back up all the way to the top level menu to save or exit.

Example video:

https://youtu.be/73DD9IwWASo