### PR TITLE
Parameter for updating GPS Home point once

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -829,6 +829,7 @@ const clivalue_t valueTable[] = {
     { "gps_auto_config",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, autoConfig) },
     { "gps_auto_baud",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, autoBaud) },
     { "gps_ublox_use_galileo",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_ublox_use_galileo) },
+    { "gps_set_home_point_once",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_set_home_point_once) },
 
 #ifdef USE_GPS_RESCUE
     // PG_GPS_RESCUE

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -74,6 +74,7 @@ typedef struct gpsConfig_s {
     gpsAutoConfig_e autoConfig;
     gpsAutoBaud_e autoBaud;
     uint8_t gps_ublox_use_galileo;
+    uint8_t gps_set_home_point_once;
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);


### PR DESCRIPTION
The default behavior of updating the Home point on every rearm is undesired (imho) when combined with GPS Rescue.
For users not using GPS Rescue, there is no reason to change this behavior, and I think it might be confusing to change the behavior only if GPS Rescue mode is enabled.
So I'm proposing a new parameter (gps_set_home_point_once, default off) so users can choose.

Note: I haven't been able to test this change on the field, yet.
