### PR TITLE
Fix race condition between DSHOT beacon and bidirectional telemetry

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -382,14 +382,6 @@ void tryArm(void)
         const timeUs_t currentTimeUs = micros();
 
 #ifdef USE_DSHOT
-#ifdef USE_DSHOT_TELEMETRY
-        pwmWriteDshotCommand(
-            255, getMotorCount(),
-            motorConfig()->dev.useDshotTelemetry ?
-            DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY :
-            DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE, true);
-#endif
-
         if (currentTimeUs - getLastDshotBeaconCommandTimeUs() < DSHOT_BEACON_GUARD_DELAY_US) {
             if (tryingToArm == ARMING_DELAYED_DISARMED) {
                 if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
@@ -404,6 +396,14 @@ void tryArm(void)
             }
             return;
         }
+
+#ifdef USE_DSHOT_TELEMETRY
+        // send the command to enable DSHOT telemetry
+        if (isMotorProtocolDshot() && motorConfig()->dev.useDshotTelemetry) {
+            pwmWriteDshotCommand(255, getMotorCount(), DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY, true);
+        }
+#endif
+
         if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
             if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
                 flipOverAfterCrashActive = false;

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -243,3 +243,7 @@
 #undef USE_DSHOT_TELEMETRY
 #undef USE_RPM_FILTER
 #endif
+
+#ifndef USE_DSHOT_TELEMETRY
+#undef USE_RPM_FILTER
+#endif


### PR DESCRIPTION
Fixes #7360 

If DSHOT beacon was enabled when arming, the guard time delay would defer the arming as is normal. However the extra DSHOT command to enable telemetry was using the blocking method so this would temporarily cause a 100% CPU load which then triggered the arming disable flag.

The command to enable DSHOT telemetry needed to be after the guard period. Also needed some additional conditionals to ensure DSHOT was enabled and that the user has the bidirectional telemetry enabled.

Also fixed some conditional compilation that was failing if `USE_DSHOT_TELEMETRY` was not defined.
