### PR TITLE
Fix race condition between DSHOT beacon and bidirectional telemetry #7372

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -237,6 +237,7 @@ void pwmStartDshotMotorUpdate(uint8_t motorCount);
 #endif
 void pwmCompleteDshotMotorUpdate(uint8_t motorCount);
 
+void pwmDshotCommandQueueUpdate(void);
 bool pwmDshotCommandIsQueued(void);
 bool pwmDshotCommandIsProcessing(void);
 uint8_t pwmGetDshotCommand(uint8_t index);

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -324,6 +324,7 @@ void pwmCompleteDshotMotorUpdate(uint8_t motorCount)
             dmaMotorTimers[i].timerDmaSources = 0;
         }
     }
+    pwmDshotCommandQueueUpdate();
 }
 
 static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -120,6 +120,7 @@ FAST_CODE void pwmCompleteDshotMotorUpdate(uint8_t motorCount)
             dmaMotorTimers[i].timerDmaSources = 0;
         }
     }
+    pwmDshotCommandQueueUpdate();
 }
 
 static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -382,14 +382,6 @@ void tryArm(void)
         const timeUs_t currentTimeUs = micros();
 
 #ifdef USE_DSHOT
-#ifdef USE_DSHOT_TELEMETRY
-        pwmWriteDshotCommand(
-            255, getMotorCount(),
-            motorConfig()->dev.useDshotTelemetry ?
-            DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY :
-            DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE, true);
-#endif
-
         if (currentTimeUs - getLastDshotBeaconCommandTimeUs() < DSHOT_BEACON_GUARD_DELAY_US) {
             if (tryingToArm == ARMING_DELAYED_DISARMED) {
                 if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
@@ -404,6 +396,15 @@ void tryArm(void)
             }
             return;
         }
+
+#ifdef USE_DSHOT_TELEMETRY
+        if (isMotorProtocolDshot()) {
+            pwmWriteDshotCommand(
+                255, getMotorCount(), motorConfig()->dev.useDshotTelemetry ?
+                DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY : DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE, false);
+        }
+#endif
+
         if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
             if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
                 flipOverAfterCrashActive = false;

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -214,10 +214,8 @@ void activateDshotTelemetry(struct dispatchEntry_s* self)
     if (!ARMING_FLAG(ARMED))
     {
         pwmWriteDshotCommand(
-            255, getMotorCount(),
-            motorConfig()->dev.useDshotTelemetry ?
-            DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY :
-            DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE, true);
+            255, getMotorCount(), motorConfig()->dev.useDshotTelemetry ?
+            DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY : DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE, false);
     }
 }
 
@@ -772,8 +770,10 @@ void init(void)
 
 // TODO: potentially delete when feature is stable. Activation when arming is enough for flight.
 #if defined(USE_DSHOT) && defined(USE_DSHOT_TELEMETRY)
-    dispatchEnable();
-    dispatchAdd(&activateDshotTelemetryEntry, 5000000);
+    if (motorConfig()->dev.useDshotTelemetry) {
+        dispatchEnable();
+        dispatchAdd(&activateDshotTelemetryEntry, 5000000);
+    }
 #endif
 
     fcTasksInit();

--- a/src/main/sensors/rpm_filter.c
+++ b/src/main/sensors/rpm_filter.c
@@ -177,6 +177,9 @@ void rpmFilterUpdate()
                 frequency = currentFilter->minHz;
             }
         }
+        if (frequency > deactivateFreq) {
+            frequency = deactivateFreq;
+        }
 
         biquadFilter_t* template = &currentFilter->notch[0][motor][harmonic];
         // uncomment below to debug filter stepping. Need to also comment out motor rpm DEBUG_SET above

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -247,3 +247,7 @@
 #ifndef USE_CMS
 #undef USE_CMS_FAILSAFE_MENU
 #endif
+
+#ifndef USE_DSHOT_TELEMETRY
+#undef USE_RPM_FILTER
+#endif


### PR DESCRIPTION
This builds on @etracers fix, but adds a dshot command queue and limits max rpm notch filter frequency.

Fixes #7360

If DSHOT beacon was enabled when arming, the guard time delay would defer the arming as is normal. However the extra DSHOT command to enable telemetry was using the blocking method so this would temporarily cause a 100% CPU load which then triggered the arming disable flag.

The command to enable DSHOT telemetry needed to be after the guard period. Also needed some additional conditionals to ensure DSHOT was enabled and that the user has the bidirectional telemetry enabled.

Also fixed some conditional compilation that was failing if USE_DSHOT_TELEMETRY was not defined.