### PR TITLE
Check that flash device is selected for blackbox before msc CLI reboot

### DIFF
--- a/src/main/io/usb_msc.c
+++ b/src/main/io/usb_msc.c
@@ -22,6 +22,8 @@
 
 #include "platform.h"
 
+#include "blackbox/blackbox.h"
+
 #include "drivers/sdcard.h"
 
 #include "io/flashfs.h"
@@ -32,10 +34,10 @@ bool mscCheckFilesystemReady(void)
 {
     return false
 #if defined(USE_SDCARD)
-        || sdcard_isFunctional()
+        || (blackboxConfig()->device == BLACKBOX_DEVICE_SDCARD && sdcard_isFunctional())
 #endif
 #if defined(USE_FLASHFS)
-        || flashfsGetSize() > 0
+        || (blackboxConfig()->device == BLACKBOX_DEVICE_FLASH && flashfsGetSize() > 0)
 #endif
         ;
 }


### PR DESCRIPTION
Previously the logic would only validate whether one or more of the defined flash device types was ready and not examine the user selected blackbox device. Then on reboot during `mscStart()` the logic there would use the selected blackbox device type to decide which mode to operate in. If a flash device wasn't selected the msc initialization failed (like if serial port or "no logging" were selected).

This change only checks the status of the selected blackbox device to ensure that a reboot will properly start mass storage mode.
