### PR TITLE
Fix boot loop if mass storage mode init fails

### DIFF
--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -32,3 +32,4 @@ uint8_t mscStart(void);
 bool mscCheckButton(void);
 void mscWaitForButton(void);
 void systemResetToMsc(int timezoneOffsetMinutes);
+void systemResetFromMsc(void);

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -152,9 +152,7 @@ void mscWaitForButton(void)
     while (true) {
         asm("NOP");
         if (mscCheckButton()) {
-            *((uint32_t *)0x2001FFF0) = 0xFFFFFFFF;
-            delay(1);
-            NVIC_SystemReset();
+            systemResetFromMsc();
         }
     }
 }
@@ -173,4 +171,13 @@ void systemResetToMsc(int timezoneOffsetMinutes)
 #endif
     NVIC_SystemReset();
 }
+
+void systemResetFromMsc(void)
+{
+    *((uint32_t *)0x2001FFF0) = 0xFFFFFFFF;
+    delay(1);
+    __disable_irq();
+    NVIC_SystemReset();
+}
+
 #endif

--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -157,9 +157,7 @@ void mscWaitForButton(void)
     while (true) {
         asm("NOP");
         if (mscCheckButton()) {
-            *((uint32_t *)0x2001FFF0) = 0xFFFFFFFF;
-            delay(1);
-            NVIC_SystemReset();
+            systemResetFromMsc();
         }
     }
 }
@@ -178,4 +176,13 @@ void systemResetToMsc(int timezoneOffsetMinutes)
 #endif
     NVIC_SystemReset();
 }
+
+void systemResetFromMsc(void)
+{
+    *((__IO uint32_t*) BKPSRAM_BASE + 16) = 0xFFFFFFFF;
+    delay(1);
+    __disable_irq();
+    NVIC_SystemReset();
+}
+
 #endif

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -447,7 +447,7 @@ void init(void)
         if (mscStart() == 0) {
              mscWaitForButton();
         } else {
-             NVIC_SystemReset();
+            systemResetFromMsc();
         }
     }
 #endif


### PR DESCRIPTION
The logic already performed a reboot if mass storage init failed, but it never reset the boot vector value so it continued to contain the `MSC_MAGIC` value leading to a boot loop.

Also fixed fixed the F7 version of `mscWaitForButton()` as it was using the F4 vector.
