### PR TITLE
Increase voltage/current cutoff frequencies

### DIFF
--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -86,7 +86,7 @@ void currentMeterReset(currentMeter_t *meter)
 // ADC/Virtual shared
 //
 
-#define IBAT_LPF_FREQ  0.4f
+#define IBAT_LPF_FREQ  2.0f
 static biquadFilter_t adciBatFilter;
 
 #ifndef CURRENT_METER_SCALE_DEFAULT

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -67,7 +67,7 @@ typedef enum {
 #define VBAT_MULTIPLIER_MIN 1
 #define VBAT_MULTIPLIER_MAX 255
 
-#define VBAT_LPF_FREQ  0.1f
+#define VBAT_LPF_FREQ  0.5f
 
 #ifndef MAX_VOLTAGE_SENSOR_ADC
 #define MAX_VOLTAGE_SENSOR_ADC 1 // VBAT - some boards have external, 12V, 9V and 5V meters.


### PR DESCRIPTION
Since #6452/#6466(which are perfectly fine and correct) the filtered voltage and current have been painfully slow. Peak currents when doing short punchouts/sharp moves are filtered away and the battery voltage takes approximately 10 seconds to settle when plugging in the battery. 

The cutoffs for these filters are 0.4Hz for current and 0.1Hz for voltage. Before the ``refreshRate`` was corrected from 50000us to 20000us, the cutoffs were effectively 1Hz for current and 0.25Hz for voltage. These values were probably set by feel to give good results, but still they are a little slow IMO. 

Personally i have been increasing both by a factor of 10 for a fast response. 
As a compromise i suggest increasing the cutoffs by a factor of 5 so that we get cutoffs of 2Hz for current and 0.5Hz for voltage. This should give a good balance between response time and filtering. It would probably help with the issue described in #6448 too. 