### PR TITLE
Enable Pin A14 for pinio use

### DIFF
--- a/src/main/target/PYRODRONEF4/target.h
+++ b/src/main/target/PYRODRONEF4/target.h
@@ -110,7 +110,7 @@
 #define DEFAULT_FEATURES            FEATURE_OSD
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
-#define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
+#define TARGET_IO_PORTA (0xffff & ~(BIT(13)))
 #define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
 #define TARGET_IO_PORTC (0xffff & ~(BIT(15)|BIT(14)|BIT(13)))
 #define TARGET_IO_PORTD BIT(2)


### PR DESCRIPTION
enable PA14 for IO usage on the board, use as vtx kill switch.

