### PR TITLE
Target: Add support for JHEF7DUAL Board.

### DIFF
--- a/docs/boards/Board - JHEF7DUAL.md
+++ b/docs/boards/Board - JHEF7DUAL.md
@@ -1,0 +1,112 @@
+# Board - JHEF7DUAL
+
+## Features
+
+* Processors and Sensors
+  * *MCU:* STM32F722RET6
+  * *IMU:* ICM20689(Gyro1) & MPU6000(Gyro2) connected via SPI1
+  * *Baro:* BMP280 (connected via I2C1)
+  * *OSD:* BetaFlight OSD (AT7456E connected via SPI2)
+* *Blackbox:* FLASH M25P16 (connected via SPI3)
+* 6 UARTs (1,2,3,4,5,6)
+* 8 Dshot outputs
+* 2 PINIO (VTX power switcher/user1 and 2 camera switcher/user2)
+* USB VCP and boot select button on board (for DFU) 
+* Serial LED interface(LED_STRIP)
+* VBAT / CURR / RSSI sensors input
+* Suppose IRC Tramp / Smart audio / FPV Camera Control / FPORT/telemetry
+* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
+* Supports I2C device extend(Compass / OLED etc)
+* Supports GPS
+
+## Pinout
+
+### All uarts have pad on board 
+
+| Value | Identifier |  RX  |  TX  |             Notes              |
+| :---: | :--------: | :--: | :--: | :----------------------------: |
+|   1   |   USART1   | PA10 | PA9  | FOR SBUS IN(inverter build in) |
+|   2   |   USART2   | PA3  | PA2  |   USE FOR TRAMP/smart audio    |
+|   3   |   USART3   | PB11 | PB10 |          USE FOR GPS           |
+|   4   |   USART4   | PA1  | PA0  | PAD USE FOR TRAMP/smart audio  |
+|   5   |   USART5   | PD2  | PC12 |         PAD ESC sensor         |
+|   6   |   USART6   | PC7  | PC6  |              PAD               |
+
+### I2C with GPS port together.Use for BARO or compass etc 
+
+| Value | Identifier | function | pin  | Notes |
+| :---: | :--------: | :------: | :--: | :---: |
+|   1   |    I2C1    |   SDA    | PB7  |       |
+|   2   |    I2C1    |   SCL    | PB6  |       |
+
+### Buzzer/LED output 
+
+| Value | Identifier | function | pin  | Notes |
+| :---: | :--------: | :------: | :--: | :---: |
+|   1   |    LED0    |   LED    | PA15 |       |
+|   2   |   BEEPER   |   BEE    | PC15 |       |
+
+### VBAT input, Current input, Analog RSSI input
+
+| Value | Identifier | function | pin  |    Notes     |
+| :---: | :--------: | :------: | :--: | :----------: |
+|   1   |    ADC1    |   VBAT   | PC2  | DMA2_Stream0 |
+|   2   |    ADC1    |   CURR   | PC1  | DMA2_Stream0 |
+|   3   |    ADC1    |   RSSI   | PC0  | DMA2_Stream0 |
+
+### PWM Input & PWM Output 
+
+| Value | Identifier | function | pin  |    Notes     |
+| :---: | :--------: | :------: | :--: | :----------: |
+|   1   |  TIM9_CH2  |   PPM    | PA3  |     PPM      |
+|   2   |  TIM3_CH3  |  Motor1  | PB0  | DMA1_Stream2 |
+|   3   |  TIM3_CH4  |  Motor2  | PB1  | DMA1_Stream2 |
+|   4   |  TIM3_CH1  |  Motor3  | PB4  | DMA1_Stream4 |
+|   5   |  TIM2_CH2  |  Motor4  | PB3  | DMA1_Stream6 |
+|   7   |  TIM8_CH4  |  Motor5  | PC9  | DMA2_Stream1 |
+|   8   |  TIM8_CH3  |  Motor6  | PC8  | DMA2_Stream4 |
+|   9   |  TIM1_CH1  |   LED    | PA8  |  LED STRIP   |
+|  10   |  TIM4_CH3  |   ANY    | PB8  |    FC CAM    |
+
+### Gyro & ACC  ICM20689
+
+| Value | Identifier | function | pin  |       Notes        |
+| :---: | :--------: | :------: | :--: | :----------------: |
+|   1   |    SPI1    |   SCK    | PA5  | MPU6000 & ICM20689 |
+|   2   |    SPI1    |   MISO   | PA6  | MPU6000 & ICM20689 |
+|   3   |    SPI1    |   MOSI   | PA7  | MPU6000 & ICM20689 |
+|   4   |    SPI1    |   CS2    | PA4  |      MPU6000       |
+|   5   |    SPI1    |   CS1    | PB2  |      ICM20689      |
+|   6   |    SPI1    |   INT2   | PC3  |      MPU6000       |
+|   7   |    SPI1    |   INT1   | PC4  |      ICM20689      |
+
+### OSD MAX7456
+
+| Value | Identifier | function | pin  | Notes |
+| :---: | :--------: | :------: | :--: | :---: |
+|   1   |    SPI2    |   SCK    | PB13 |       |
+|   2   |    SPI2    |   MISO   | PB14 |       |
+|   3   |    SPI2    |   MOSI   | PB15 |       |
+|   4   |    SPI2    |    CS    | PB12 |       |
+
+### 2MB FLash
+
+| Value | Identifier | function | pin  | Notes |
+| :---: | :--------: | :------: | :--: | :---: |
+|   1   |    SPI3    |   SCK    | PC10 |       |
+|   2   |    SPI3    |   MISO   | PC11 |       |
+|   3   |    SPI3    |   MOSI   | PB5  |       |
+|   4   |    SPI3    |    CS    | PC13 |       |
+
+### SWD
+
+| Pin  | Function | Notes |
+| :--: | :------: | :---: |
+|  1   |  SWCLK   |  PAD  |
+|  2   |  Ground  |  PAD  |
+|  3   |  SWDIO   |  PAD  |
+|  4   |   3V3    |  PAD  |
+
+## Designers
+
+- JHE_FPV

--- a/src/main/target/JHEF7DUAL/config.c
+++ b/src/main/target/JHEF7DUAL/config.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "io/serial.h"
+#include "pg/piniobox.h"
+#include "target.h"
+
+#ifdef USE_TARGET_CONFIG
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = 40;
+    pinioBoxConfigMutable()->permanentId[1] = 41;
+}
+
+#endif

--- a/src/main/target/JHEF7DUAL/target.c
+++ b/src/main/target/JHEF7DUAL/target.c
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM9, CH2, PA3,  TIM_USE_PPM,   0, 0),   // PPM
+
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0),   // S1
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0),   // S2
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_MOTOR, 0, 0),   // S3
+    DEF_TIM(TIM2, CH2, PB3,  TIM_USE_MOTOR, 0, 0),   // S4
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_MOTOR, 0, 0),   // S5
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_MOTOR, 0, 0),   // S6
+
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_LED, 0, 0),     // LED STRIP
+    DEF_TIM(TIM4, CH3, PB8,  TIM_USE_ANY, 0, 0),     // FC CAM
+};

--- a/src/main/target/JHEF7DUAL/target.h
+++ b/src/main/target/JHEF7DUAL/target.h
@@ -1,0 +1,174 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER "JH7D"
+#define USBD_PRODUCT_STRING     "JHEF7DUAL"
+
+#define CAMERA_CONTROL_PIN      PB8
+
+#define ENABLE_DSHOT_DMAR       true
+
+#define LED0_PIN                PA15
+
+#define USE_BEEPER
+#define BEEPER_PIN              PC15
+#define BEEPER_INVERTED
+
+#define USE_DUAL_GYRO
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PC4
+#define GYRO_2_EXTI_PIN         PC3
+
+#define GYRO_1_CS_PIN           PB2
+#define GYRO_1_SPI_INSTANCE     SPI1
+
+#define GYRO_2_CS_PIN           PA4
+#define GYRO_2_SPI_INSTANCE     SPI1
+
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM20689
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM20689
+
+#define ACC_ICM20689_1_ALIGN    CW90_DEG
+#define GYRO_ICM20689_1_ALIGN   CW90_DEG
+#define GYRO_1_ALIGN            GYRO_ICM20689_1_ALIGN 
+#define ACC_1_ALIGN             ACC_ICM20689_1_ALIGN
+
+#define ACC_MPU6000_2_ALIGN     CW90_DEG
+#define GYRO_MPU6000_2_ALIGN    CW90_DEG
+#define GYRO_2_ALIGN            GYRO_MPU6000_2_ALIGN
+#define ACC_2_ALIGN             ACC_MPU6000_2_ALIGN
+
+#define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_1
+
+// *************** Baro **************************
+#define USE_I2C
+
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB6        // SCL pad
+#define I2C1_SDA                PB7        // SDA pad
+#define BARO_I2C_INSTANCE       (I2CDEV_1)
+
+#define USE_BARO
+#define USE_BARO_BMP280
+
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PB10
+#define UART3_RX_PIN            PB11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define SERIAL_PORT_COUNT       7
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI2
+#define MAX7456_SPI_CS_PIN      SPI2_NSS_PIN
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PB5
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define FLASH_CS_PIN            PC13
+#define FLASH_SPI_INSTANCE      SPI3
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC3
+#define ADC3_DMA_OPT            0  // DMA 2 Stream 0 Channel 2 
+
+#define CURRENT_METER_ADC_PIN   PC1
+#define VBAT_ADC_PIN            PC2
+#define RSSI_ADC_PIN            PC0
+
+#define CURRENT_METER_SCALE_DEFAULT         450
+#define DEFAULT_VOLTAGE_METER_SOURCE        VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE        CURRENT_METER_ADC
+
+#define DEFAULT_RX_FEATURE                  FEATURE_RX_SERIAL
+#define DEFAULT_FEATURES                    (FEATURE_RSSI_ADC | FEATURE_TELEMETRY | FEATURE_OSD | FEATURE_LED_STRIP)
+#define SERIALRX_UART                       SERIAL_PORT_USART2
+#define SERIALRX_PROVIDER                   SERIALRX_SBUS
+
+#define USE_LED_STRIP
+
+#define USE_ESCSERIAL
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define USE_PINIO
+#define PINIO1_PIN              PC14 // VTX power switcher
+#define PINIO2_PIN              PB9  // 2xCamera switcher
+#define USE_PINIOBOX
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 9
+#define USED_TIMERS  (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(9))

--- a/src/main/target/JHEF7DUAL/target.mk
+++ b/src/main/target/JHEF7DUAL/target.mk
@@ -1,0 +1,12 @@
+F7X2RE_TARGETS += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_icm20689.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/compass/compass_fake.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_hal.c \
+            drivers/max7456.c


### PR DESCRIPTION
## Features
* Processors and Sensors
  * *MCU:* STM32F722RET6
  * *IMU:* ICM20689(Gyro1) & MPU6000(Gyro2) connected via SPI1
  * *Baro:* BMP280 (connected via I2C1)
  * *OSD:* BetaFlight OSD (AT7456E connected via SPI2)
* *Blackbox:* FLASH M25P16 (connected via SPI3)
* 6 UARTs (1,2,3,4,5,6)
* 8 Dshot outputs
* 2 PINIO (VTX power switcher/user1 and 2 camera switcher/user2)
* USB VCP and boot select button on board (for DFU) 
* Serial LED interface(LED_STRIP)
* VBAT / CURR / RSSI sensors input
* Suppose IRC Tramp / Smart audio / FPV Camera Control / FPORT/telemetry
* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
* Supports I2C device extend(Compass / OLED etc)
* Supports GPS