### PR TITLE
Validate and reset invalid blackbox device selections

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -25,6 +25,8 @@
 
 #include "platform.h"
 
+#include "blackbox/blackbox.h"
+
 #include "build/debug.h"
 
 #include "config/config_eeprom.h"
@@ -520,6 +522,20 @@ void validateAndFixGyroConfig(void)
             pidConfigMutable()->pid_process_denom = MAX(pidConfigMutable()->pid_process_denom, minPidProcessDenom);
         }
     }
+
+#ifdef USE_BLACKBOX
+#ifndef USE_FLASHFS
+    if (blackboxConfig()->device == 1) {  // BLACKBOX_DEVICE_FLASH (but not defined)
+        blackboxConfigMutable()->device = BLACKBOX_DEVICE_NONE;
+    }
+#endif // USE_FLASHFS
+
+#ifndef USE_SDCARD
+    if (blackboxConfig()->device == 2) {  // BLACKBOX_DEVICE_SDCARD (but not defined)
+        blackboxConfigMutable()->device = BLACKBOX_DEVICE_NONE;
+    }
+#endif // USE_SDCARD
+#endif // USE_BLACKBOX
 }
 
 bool readEEPROM(void)


### PR DESCRIPTION
Since we really can't conditionally build the list of options, it's possible to select an invalid blackbox device type using CLI `set blackbox_device =`. This change validates that the selected device type is included in the code and if not resets to "no logging".

And yes, the hardcoded 1 for flash type and 2 for SD card type is ugly. But we can't use the enumeration because it's conditional constructed based on the defines.