### PR TITLE
Lower D values if D_Cut is not defined for a target

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -197,6 +197,10 @@ void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->dterm_filter_type = FILTER_BIQUAD;
     pidProfile->dterm_filter2_type = FILTER_BIQUAD;
 #endif
+#ifndef USE_D_CUT
+    pidProfile->pid[PID_ROLL].D = 30;
+    pidProfile->pid[PID_PITCH].D = 32;
+#endif
 }
 
 void pgResetFn_pidProfiles(pidProfile_t *pidProfiles)


### PR DESCRIPTION
At compile time, if D_CUT is not defined for a given target, the user will get lower default D values of 30/32.

Thanks to eTracer for pointing out that otherwise targets where D_CUT is not enabled would get D values of 40/44 which might be a little bit too high.
