### PR TITLE
Extend OSD warnings storage to 32bits; add count to MSP

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -766,7 +766,11 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         }
 
         // Enabled warnings
-        sbufWriteU16(dst, osdConfig()->enabledWarnings);
+        // Send low word first for backwards compatibility (API < 1.41)
+        sbufWriteU16(dst, (uint16_t)(osdConfig()->enabledWarnings & 0xFFFF));
+        // API >= 1.41; send the count and 32bit warnings
+        sbufWriteU8(dst, OSD_WARNING_COUNT);
+        sbufWriteU32(dst, osdConfig()->enabledWarnings);
 #endif
         break;
     }
@@ -2493,7 +2497,13 @@ static mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPos
 
                 if (sbufBytesRemaining(src) >= 2) {
                     /* Enabled warnings */
+                    // API < 1.41 supports only the low 16 bits
                     osdConfigMutable()->enabledWarnings = sbufReadU16(src);
+                }
+                
+                if (sbufBytesRemaining(src) >= 4) {
+                    // 32bit version of enabled warnings (API >= 1.41)
+                    osdConfigMutable()->enabledWarnings = sbufReadU32(src);
                 }
 #endif
             } else if ((int8_t)addr == -2) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -256,7 +256,7 @@ static const uint8_t osdElementDisplayOrder[] = {
 #endif
 };
 
-PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 4);
+PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 5);
 
 /**
  * Gets the correct altitude symbol for the current unit system

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -205,8 +205,8 @@ typedef enum {
     OSD_WARNING_COUNT // MUST BE LAST
 } osdWarningsFlags_e;
 
-// Make sure the number of warnings do not exceed the available 16bit storage
-STATIC_ASSERT(OSD_WARNING_COUNT <= 16, osdwarnings_overflow);
+// Make sure the number of warnings do not exceed the available 32bit storage
+STATIC_ASSERT(OSD_WARNING_COUNT <= 32, osdwarnings_overflow);
 
 #define ESC_RPM_ALARM_OFF -1
 #define ESC_TEMP_ALARM_OFF INT8_MIN
@@ -225,7 +225,7 @@ typedef struct osdConfig_s {
     osd_unit_e units;
 
     uint16_t timers[OSD_TIMER_COUNT];
-    uint16_t enabledWarnings;
+    uint32_t enabledWarnings;
 
     uint8_t ahMaxPitch;
     uint8_t ahMaxRoll;


### PR DESCRIPTION
Extends the possible OSD warnings elements from 16 to 32.

Adds a warnings count to MSP data to enable improved handling of warnings added to the firmware but not in the Configurator. Incremental Configurator development required.

Related to https://github.com/betaflight/betaflight-configurator/pull/1278
