### PR TITLE
[F4] Make USE_SPI_TRANSACTION generic feature for F4

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -63,10 +63,10 @@
 #define USE_USB_MSC
 #define USE_PERSISTENT_MSC_RTC
 #define USE_DMA_SPEC
+#define USE_SPI_TRANSACTION
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)
 #define USE_OVERCLOCK
-#define USE_SPI_TRANSACTION
 #endif
 
 #endif // STM32F4


### PR DESCRIPTION
The `USE_SPI_TRANSACTION` was incorrectly conditionalized for `defined(STM32F40_41xxx) || defined(STM32F411xE)`; should be applied for all F4s.