### PR TITLE
Fixed incorrect enum value being used for GetITStatus on F4

### DIFF
--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -289,7 +289,7 @@ void uartIrqHandler(uartPort_t *s)
         }
     }
 
-    if (USART_GetITStatus(s->USARTx, USART_FLAG_ORE) == SET)
+    if (USART_GetITStatus(s->USARTx, USART_IT_ORE) == SET)
     {
         USART_ClearITPendingBit (s->USARTx, USART_IT_ORE);
     }


### PR DESCRIPTION
```c
/**
  * @brief  Checks whether the specified USART interrupt has occurred or not.
  * @param  USARTx: where x can be 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
  *         UART peripheral.
  * @param  USART_IT: specifies the USART interrupt source to check.
  *          This parameter can be one of the following values:
  * ...
  *            @arg USART_IT_RXNE: Receive Data register not empty interrupt
  *            @arg USART_IT_IDLE: Idle line detection interrupt
  *            @arg **USART_IT_ORE** : OverRun Error interrupt if the RXNEIE bit is set
  * ...
  * @retval The new state of USART_IT (SET or RESET).
  */
ITStatus USART_GetITStatus(USART_TypeDef* USARTx, uint16_t USART_IT)
```