### PR TITLE
Add FEATURE_CUT_LEVEL to the cli version command output

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3811,7 +3811,7 @@ static void cliVersion(char *cmdline)
 {
     UNUSED(cmdline);
 
-    cliPrintLinef("# %s / %s (%s) %s %s / %s (%s) MSP API: %s",
+    cliPrintf("# %s / %s (%s) %s %s / %s (%s) MSP API: %s",
         FC_FIRMWARE_NAME,
         targetName,
         systemConfig()->boardIdentifier,
@@ -3821,6 +3821,11 @@ static void cliVersion(char *cmdline)
         shortGitRevision,
         MSP_API_VERSION_STRING
     );
+#ifdef FEATURE_CUT_LEVEL
+    cliPrintLinef(" / FEATURE CUT LEVEL %d", FEATURE_CUT_LEVEL);
+#else
+    cliPrintLinefeed();
+#endif
 }
 
 #ifdef USE_RC_SMOOTHING_FILTER


### PR DESCRIPTION
Some people have already starting to ask what the level is for their particular flight controller.

Example output for SPRACINGF3:
```
# version
# Betaflight / SPRACINGF3 (SRF3) 4.0.0 Jan 19 2019 / 11:39:29 (628fdb8) MSP API: 1.41 / FEATURE CUT LEVEL 3
```