### PR TITLE
Fix LEDSTRIP defines to prevent compilation errors

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -341,7 +341,7 @@ static const char * const lookupOverclock[] = {
 };
 #endif
 
-#ifdef USE_LED_STRIP_STATUS_MODE
+#ifdef USE_LED_STRIP
     static const char * const lookupLedStripFormatRGB[] = {
         "GRB", "RGB"
     };
@@ -522,7 +522,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef USE_OVERCLOCK
     LOOKUP_TABLE_ENTRY(lookupOverclock),
 #endif
-#ifdef USE_LED_STRIP_STATUS_MODE
+#ifdef USE_LED_STRIP
     LOOKUP_TABLE_ENTRY(lookupLedStripFormatRGB),
 #endif
 #ifdef USE_MULTI_GYRO

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -92,7 +92,7 @@ typedef enum {
 #ifdef USE_OVERCLOCK
     TABLE_OVERCLOCK,
 #endif
-#ifdef USE_LED_STRIP_STATUS_MODE
+#ifdef USE_LED_STRIP
     TABLE_RGB_GRB,
 #endif
 #ifdef USE_MULTI_GYRO


### PR DESCRIPTION
Fixes #7434 

Compile would fail if `USE_LED_STRIP` was defined but `USE_LED_STRIP_STATUS_MODE` wasn't.

Introduced in #7303 