### PR TITLE
[SDCARD] Quick fix: Discard excess/bogus data in DR at prologue of spiTransferByte

### DIFF
--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -55,8 +55,10 @@
 #define PP_CALL(macro, ...) macro(__VA_ARGS__)
 
 #if !defined(UNUSED)
-#define UNUSED(x) (void)(x)
+#define UNUSED(x) (void)(x) // Variables and parameters that are not used
 #endif
+
+#define DISCARD(x) (void)(x) // To explicitly ignore result of x (usually an I/O register access).
 
 #define STATIC_ASSERT(condition, name) _Static_assert((condition), #name)
 

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -113,7 +113,7 @@ uint8_t spiTransferByte(SPI_TypeDef *instance, uint8_t txByte)
 {
     uint16_t spiTimeout = 1000;
 
-    instance->DR;
+    DISCARD(instance->DR);
 
     while (SPI_I2S_GetFlagStatus(instance, SPI_I2S_FLAG_TXE) == RESET)
         if ((spiTimeout--) == 0)
@@ -154,7 +154,7 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     uint16_t spiTimeout = 1000;
 
     uint8_t b;
-    instance->DR;
+    DISCARD(instance->DR);
     while (len--) {
         b = txData ? *(txData++) : 0xFF;
         while (SPI_I2S_GetFlagStatus(instance, SPI_I2S_FLAG_TXE) == RESET) {

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -113,6 +113,8 @@ uint8_t spiTransferByte(SPI_TypeDef *instance, uint8_t txByte)
 {
     uint16_t spiTimeout = 1000;
 
+    instance->DR;
+
     while (SPI_I2S_GetFlagStatus(instance, SPI_I2S_FLAG_TXE) == RESET)
         if ((spiTimeout--) == 0)
             return spiTimeoutUserCallback(instance);


### PR DESCRIPTION
Fixes #7408 

This non-intrusive fix provides a quick and pragmatic fix for SD card not recognized after shared SPI code merge.

It appears that how SD card driver under shared SPI code interact with the card leaves one extra data byte in receive data register (`(SPI_TypeDef *)instance->DR`) which causes immediate return of `sdcard_waitForIdle` and `sdcard_waitForNonIdleByte` to malfunction.

A root cause of this phenomena is yet unknown, but clearing the extra data by dummy reading the `DR` at the beginning o f`spiTransferByte` seems to solve the problem. The exact same code is already in use by `spiTransfer`.

Further investigation is necessary, but the PR allows other projects, especially flight behavior related ones to proceed with SD card based blackbox.