### PR TITLE
Refactor ledstrip profiles to fix excessive cpu load

### DIFF
--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -45,7 +45,6 @@
 
 #ifdef USE_LED_STRIP
 
-static bool featureRead = false;
 static uint8_t cmsx_FeatureLedstrip;
 static uint8_t cmsx_LedProfile;
 static uint8_t cmsx_RaceColor;
@@ -59,34 +58,26 @@ const char * const ledProfileNames[LED_PROFILE_COUNT] = {
 
 static long cmsx_Ledstrip_OnEnter(void)
 {
-    if (!featureRead) {
-        cmsx_FeatureLedstrip = featureIsEnabled(FEATURE_LED_STRIP) ? 1 : 0;
-        featureRead = true;
-    }
-
-#ifdef USE_LED_STRIP
+    cmsx_FeatureLedstrip = featureIsEnabled(FEATURE_LED_STRIP) ? 1 : 0;
     cmsx_LedProfile = getLedProfile();
     cmsx_RaceColor = getLedRaceColor();
-#endif
+
     return 0;
 }
 
 static long cmsx_Ledstrip_OnExit(const OSD_Entry *self)
 {
     UNUSED(self);
-    if (featureRead) {
-        if (cmsx_FeatureLedstrip)
-            featureEnable(FEATURE_LED_STRIP);
-        else {
-            ledStripDisable();
-            featureDisable(FEATURE_LED_STRIP);
-        }
+
+    if (cmsx_FeatureLedstrip) {
+        featureEnable(FEATURE_LED_STRIP);
+    } else {
+        ledStripDisable();
+        featureDisable(FEATURE_LED_STRIP);
     }
 
-#ifdef USE_LED_STRIP
     setLedProfile(cmsx_LedProfile);
     setLedRaceColor(cmsx_RaceColor);
-#endif
 
     return 0;
 }


### PR DESCRIPTION
Fixes #7437 

Previous logic bypassed optimizations and updated the ws2811 on every task execution - leading to an average of 92us task execution time. Restored the previous optimizations and additionally optimized the new "RACE" and "BEACON" modes so that they only update the led's when there's an actual state change. Task time for these modes is now in the 2-4us range for F405. For the normal "STATUS" profile the performance has been restored to previous optimized levels and typical configurations will generally have task times in the 8-14us range.

Revised the LEDLOW disable mode to function all the time and disable the ledstrip completely. Previously if visual beeper was enabled that would partially override the disable state and the ledstrip would display whatever would be otherwise displayed but only during the duration of the beep. The resulted to a very inconsistent behavior depending on the user's settings.

Added visual beeper support to the new "RACE" and "BEACON" profile modes.

General cleanup and refactoring.
