### PR TITLE
Fix array overflow/wedge after multiple entries into CMS

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -81,6 +81,8 @@
 #define CMS_MAX_DEVICE 4
 #endif
 
+#define CMS_MENU_STACK_LIMIT 10
+
 displayPort_t *pCurrentDisplay;
 
 static displayPort_t *cmsDisplayPorts[CMS_MAX_DEVICE];
@@ -175,7 +177,7 @@ typedef struct cmsCtx_s {
     int8_t cursorRow;             // cursorRow in the page
 } cmsCtx_t;
 
-static cmsCtx_t menuStack[10];
+static cmsCtx_t menuStack[CMS_MENU_STACK_LIMIT];
 static uint8_t menuStackIdx = 0;
 
 static int8_t pageCount;         // Number of pages in the current menu
@@ -633,6 +635,10 @@ long cmsMenuChange(displayPort_t *pDisplay, const void *ptr)
 
     if (pMenu != currentCtx.menu) {
         // Stack the current menu and move to a new menu.
+        if (menuStackIdx >= CMS_MENU_STACK_LIMIT - 1) {
+            // menu stack limit reached - prevent array overflow
+            return 0;
+        }
 
         menuStack[menuStackIdx++] = currentCtx;
 
@@ -691,6 +697,7 @@ void cmsMenuOpen(void)
             return;
         cmsInMenu = true;
         currentCtx = (cmsCtx_t){ &menuMain, 0, 0 };
+        menuStackIdx = 0;
         setArmingDisabled(ARMING_DISABLED_CMS_MENU);
     } else {
         // Switch display


### PR DESCRIPTION
The menu stack counter was not being reset when CMS was initially entered and multiple entries can cause an array overflow/memory corruption and wedge.

Previosuly the problem was accidentally prevented because the user was required to "back out" through the menus to exit which decremented the array index. However with the addition of the popup exit/save menu it became possible to exit without traversing back through the menu structure and this bug was exposed.

Also added logic to prevent the array overflow in case we eventually have a structure that's more than 10 levels deep.