### PR TITLE
Remove the OSD_MENU arming disabled flag, as it is redundant to the CMS_MENU flag.

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -48,7 +48,6 @@ const char *armingDisableFlagNames[]= {
     "CALIB",
     "CLI",
     "CMS",
-    "OSD",
     "BST",
     "MSP",
     "PARALYZE",

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -52,13 +52,12 @@ typedef enum {
     ARMING_DISABLED_CALIBRATING     = (1 << 11),
     ARMING_DISABLED_CLI             = (1 << 12),
     ARMING_DISABLED_CMS_MENU        = (1 << 13),
-    ARMING_DISABLED_OSD_MENU        = (1 << 14),
-    ARMING_DISABLED_BST             = (1 << 15),
-    ARMING_DISABLED_MSP             = (1 << 16),
-    ARMING_DISABLED_PARALYZE        = (1 << 17),
-    ARMING_DISABLED_GPS             = (1 << 18),
-    ARMING_DISABLED_RESC            = (1 << 19),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 20), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_BST             = (1 << 14),
+    ARMING_DISABLED_MSP             = (1 << 15),
+    ARMING_DISABLED_PARALYZE        = (1 << 16),
+    ARMING_DISABLED_GPS             = (1 << 17),
+    ARMING_DISABLED_RESC            = (1 << 18),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 19), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
 #define ARMING_DISABLE_FLAGS_COUNT 21

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2042,15 +2042,6 @@ void osdUpdate(timeUs_t currentTimeUs)
         displayDrawScreen(osdDisplayPort);
     }
     ++counter;
-
-#ifdef USE_CMS
-    // do not allow ARM if we are in menu
-    if (displayIsGrabbed(osdDisplayPort)) {
-        setArmingDisabled(ARMING_DISABLED_OSD_MENU);
-    } else {
-        unsetArmingDisabled(ARMING_DISABLED_OSD_MENU);
-    }
-#endif
 }
 
 void osdSuppressStats(bool flag)


### PR DESCRIPTION
OSD_MENU as an arming disabled reason can be eliminated:

https://github.com/betaflight/betaflight/blob/e020bcca9ef83b2cfad4df3812dabed552ae3bfd/src/main/io/osd.c@e020bcc#L2048-L2052

means that arming is only disabled with `ARMING_DISABLED_OSD_MENU` when `displayIsGrabbed(osdDisplayPort)`.

https://github.com/betaflight/betaflight/blob/e020bcca9ef83b2cfad4df3812dabed552ae3bfd/src/main/drivers/display.c@e020bcc#L67-L70

and

https://github.com/betaflight/betaflight/blob/e020bcca9ef83b2cfad4df3812dabed552ae3bfd/src/main/drivers/display.c@e020bcc#L48-L53

mean we need to call `displayGrab()` for this.

And

https://github.com/betaflight/betaflight/blob/e020bcca9ef83b2cfad4df3812dabed552ae3bfd/src/main/cms/cms.c@e020bcc#L687-L708

means that we only ever do that when arming is already disabled.

@etracer65, @jflyper: What's your thoughts on this?

See also betaflight/betaflight-configurator#1275.