### PR TITLE
Fixed position calculation for OSD stick position elements.

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -106,6 +106,10 @@
 #define VIDEO_BUFFER_CHARS_PAL    480
 #define FULL_CIRCLE 360
 
+// Stick overlay size
+#define OSD_STICK_OVERLAY_WIDTH 7
+#define OSD_STICK_OVERLAY_HEIGHT 7
+
 #define STICK_OVERLAY_HORIZONTAL_CHAR   '-'
 #define STICK_OVERLAY_VERTICAL_CHAR     '|'
 #define STICK_OVERLAY_CROSS_CHAR        '+'
@@ -1335,8 +1339,8 @@ static void osdDrawStickOverlayCursor(osd_items_e osd_item)
         horizontal_channel = radioModes[osdConfig()->overlay_radio_mode-1].right_horizontal;
     }
 
-    uint8_t x_pos =  (uint8_t)scaleRange(constrain(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
-    uint8_t y_pos =  (uint8_t)scaleRange(PWM_RANGE_MAX - constrain(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_HEIGHT) + OSD_STICK_OVERLAY_HEIGHT - 1;
+    uint8_t x_pos =  (uint8_t)constrain(scaleRange(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH), 0, OSD_STICK_OVERLAY_WIDTH - 1);
+    uint8_t y_pos =  OSD_STICK_OVERLAY_HEIGHT - 1 - (uint8_t)constrain(scaleRange(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_HEIGHT), 0, OSD_STICK_OVERLAY_HEIGHT - 1);
 
     osdDrawStickOverlayPos(osd_item, x_pos, y_pos);
 }

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -58,10 +58,6 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_X(x)      (x & OSD_POSITION_XY_MASK)
 #define OSD_Y(x)      ((x >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
 
-// Stick overlay size
-#define OSD_STICK_OVERLAY_WIDTH 7
-#define OSD_STICK_OVERLAY_HEIGHT 7
-
 // Timer configuration
 // Stored as 15[alarm:8][precision:4][source:4]0
 #define OSD_TIMER(src, prec, alarm) ((src & 0x0F) | ((prec & 0x0F) << 4) | ((alarm & 0xFF ) << 8))


### PR DESCRIPTION
The existing scaling allows overruns at the top and right:

https://www.youtube.com/watch?v=on7hkKS8lx4

This pull request fixes this:

https://www.youtube.com/watch?v=b8rbmsg5h1s