### PR TITLE
Change OSD stick overlays to be more square.

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1343,25 +1343,21 @@ static void osdDrawStickOverlayCursor(osd_items_e osd_item)
         horizontal_channel = radioModes[osdConfig()->overlay_radio_mode-1].right_horizontal;
     }
 
-    const uint8_t x_pos = constrain(scaleRange(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH), 0, OSD_STICK_OVERLAY_WIDTH - 1);
-    const uint8_t y_pos = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - constrain(scaleRange(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS), 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1);
+    const uint8_t x_pos = scaleRange(constrain(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
+    const uint8_t y_pos = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - scaleRange(constrain(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS);
 
     char cursor;
     switch (y_pos % OSD_STICK_OVERLAY_CHARACTER_HEIGHT) {
-    case 2:
-        if (rcData[vertical_channel] < PWM_RANGE_MAX) {
-            cursor = STICK_OVERLAY_CURSOR_LOW_CHAR;
-
-            break;
-        }
-
-        FALLTHROUGH;
     case 0:
         cursor = STICK_OVERLAY_CURSOR_HIGH_CHAR;
 
         break;
     case 1:
         cursor = STICK_OVERLAY_CURSOR_MID_CHAR;
+
+        break;
+    case 2:
+        cursor = STICK_OVERLAY_CURSOR_LOW_CHAR;
 
         break;
     }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -109,16 +109,15 @@
 // Stick overlay size
 #define OSD_STICK_OVERLAY_WIDTH 7
 #define OSD_STICK_OVERLAY_HEIGHT 5
+#define OSD_STICK_OVERLAY_CHARACTER_HEIGHT 3
+#define OSD_STICK_OVERLAY_VERTICAL_POSITIONS (OSD_STICK_OVERLAY_HEIGHT * OSD_STICK_OVERLAY_CHARACTER_HEIGHT)
 
 #define STICK_OVERLAY_HORIZONTAL_CHAR   '-'
 #define STICK_OVERLAY_VERTICAL_CHAR     '|'
 #define STICK_OVERLAY_CROSS_CHAR        '+'
-#define STICK_OVERLAY_CURSOR_CHAR       0x84
 #define STICK_OVERLAY_CURSOR_LOW_CHAR   0x86
+#define STICK_OVERLAY_CURSOR_MID_CHAR   0x84
 #define STICK_OVERLAY_CURSOR_HIGH_CHAR  0x82
-
-#define OSD_STICK_OVERLAY_VERT_MID_ROW ((OSD_STICK_OVERLAY_HEIGHT - 1) / 2)
-#define OSD_STICK_OVERLAY_VERT_ROW_HEIGHT ((PWM_RANGE_MAX - PWM_RANGE_MIN) / OSD_STICK_OVERLAY_HEIGHT)
 
 const char * const osdTimerSourceNames[] = {
     "ON TIME  ",
@@ -1345,21 +1344,29 @@ static void osdDrawStickOverlayCursor(osd_items_e osd_item)
     }
 
     const uint8_t x_pos = constrain(scaleRange(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH), 0, OSD_STICK_OVERLAY_WIDTH - 1);
-    const uint8_t y_pos = OSD_STICK_OVERLAY_HEIGHT - 1 - constrain(scaleRange(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_HEIGHT), 0, OSD_STICK_OVERLAY_HEIGHT - 1);
+    const uint8_t y_pos = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - constrain(scaleRange(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS), 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1);
 
     char cursor;
-    if (y_pos != OSD_STICK_OVERLAY_VERT_MID_ROW) {
-        const uint16_t yPosInRow = (constrain(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) % OSD_STICK_OVERLAY_VERT_ROW_HEIGHT;
-        if (yPosInRow < OSD_STICK_OVERLAY_VERT_ROW_HEIGHT / 2 && rcData[vertical_channel] < PWM_RANGE_MAX) {
+    switch (y_pos % OSD_STICK_OVERLAY_CHARACTER_HEIGHT) {
+    case 2:
+        if (rcData[vertical_channel] < PWM_RANGE_MAX) {
             cursor = STICK_OVERLAY_CURSOR_LOW_CHAR;
-        } else {
-            cursor = STICK_OVERLAY_CURSOR_HIGH_CHAR;
+
+            break;
         }
-    } else {
-        cursor = STICK_OVERLAY_CURSOR_CHAR;
+
+        FALLTHROUGH;
+    case 0:
+        cursor = STICK_OVERLAY_CURSOR_HIGH_CHAR;
+
+        break;
+    case 1:
+        cursor = STICK_OVERLAY_CURSOR_MID_CHAR;
+
+        break;
     }
 
-    osdDrawStickOverlayPos(osd_item, x_pos, y_pos, cursor);
+    osdDrawStickOverlayPos(osd_item, x_pos, y_pos / OSD_STICK_OVERLAY_CHARACTER_HEIGHT, cursor);
 }
 #endif
 


### PR DESCRIPTION
Based on #7449.

Taking into consideration that the characters on the OSD are not square, the current stick overlay implementation, using a 7 x 7 grid is rectangular and not square as it appears on the screen:

https://www.youtube.com/watch?v=b8rbmsg5h1s

This change changes the grid to be 7 x 5 (w x h), giving it a more square shape. To compensate for the loss of vertical resolution, two symbols for 'low' and 'high' stick position inside every character (outside of the center row) are used:

https://www.youtube.com/watch?v=25W4clMaBtE

This also makes the footprint of the stick overlays on the screen a bit more manageable.