### PR TITLE
Split Baro task into four, rather than two states to reduce max task duration

### DIFF
--- a/src/main/drivers/barometer/barometer.h
+++ b/src/main/drivers/barometer/barometer.h
@@ -26,6 +26,7 @@
 struct baroDev_s;
 
 typedef void (*baroOpFuncPtr)(struct baroDev_s *baro);                       // baro start operation
+typedef bool (*baroGetFuncPtr)(struct baroDev_s *baro);                       // baro read/get operation
 typedef void (*baroCalculateFuncPtr)(int32_t *pressure, int32_t *temperature); // baro calculation (filled params are pressure and temperature)
 
 // the 'u' in these variable names means 'uncompensated', 't' is temperature, 'p' pressure.
@@ -34,11 +35,14 @@ typedef struct baroDev_s {
 #ifdef USE_EXTI
     extiCallbackRec_t exti;
 #endif
+    bool combined_read;
     uint16_t ut_delay;
     uint16_t up_delay;
     baroOpFuncPtr start_ut;
-    baroOpFuncPtr get_ut;
+    baroGetFuncPtr read_ut;
+    baroGetFuncPtr get_ut;
     baroOpFuncPtr start_up;
-    baroOpFuncPtr get_up;
+    baroGetFuncPtr read_up;
+    baroGetFuncPtr get_up;
     baroCalculateFuncPtr calculate;
 } baroDev_t;

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -41,6 +41,10 @@
 
 static bool isConversionComplete = false;
 static bool isEOCConnected = false;
+#define BMP085_DATA_TEMP_SIZE 2
+#define BMP085_DATA_PRES_SIZE 3
+#define BMP085_DATA_FRAME_SIZE 3
+static uint8_t sensor_data[BMP085_DATA_FRAME_SIZE];
 
 #ifdef USE_EXTI
 static IO_t eocIO;
@@ -122,9 +126,11 @@ STATIC_UNIT_TESTED uint32_t bmp085_up;  // static result of pressure measurement
 
 static void bmp085ReadCalibrarionParameters(busDevice_t *busdev);
 static void bmp085StartUT(baroDev_t *baro);
-static void bmp085GetUT(baroDev_t *baro);
+static bool bmp085ReadUT(baroDev_t *baro);
+static bool bmp085GetUT(baroDev_t *baro);
 static void bmp085StartUP(baroDev_t *baro);
-static void bmp085GetUP(baroDev_t *baro);
+static bool bmp085ReadUP(baroDev_t *baro);
+static bool bmp085GetUP(baroDev_t *baro);
 static int32_t bmp085GetTemperature(uint32_t ut);
 static int32_t bmp085GetPressure(uint32_t up);
 STATIC_UNIT_TESTED void bmp085Calculate(int32_t *pressure, int32_t *temperature);
@@ -189,8 +195,10 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro)
             baro->ut_delay = UT_DELAY;
             baro->up_delay = UP_DELAY;
             baro->start_ut = bmp085StartUT;
+            baro->read_ut = bmp085ReadUT;
             baro->get_ut = bmp085GetUT;
             baro->start_up = bmp085StartUP;
+            baro->read_up = bmp085ReadUP;
             baro->get_up = bmp085GetUP;
             baro->calculate = bmp085Calculate;
 
@@ -274,20 +282,34 @@ static void bmp085StartUT(baroDev_t *baro)
 {
     isConversionComplete = false;
 
-    busWriteRegister(&baro->busdev, BMP085_CTRL_MEAS_REG, BMP085_T_MEASURE);
+    busWriteRegisterStart(&baro->busdev, BMP085_CTRL_MEAS_REG, BMP085_T_MEASURE);
 }
 
-static void bmp085GetUT(baroDev_t *baro)
+static bool bmp085ReadUT(baroDev_t *baro)
 {
-    uint8_t data[2];
-
-    // return old baro value if conversion time exceeds datasheet max when EOC is connected
-    if ((isEOCConnected) && (!isConversionComplete)) {
-        return;
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
     }
 
-    busReadRegisterBuffer(&baro->busdev, BMP085_ADC_OUT_MSB_REG, data, 2);
-    bmp085_ut = (data[0] << 8) | data[1];
+    // return old baro value if conversion time exceeds datasheet max when EOC is connected
+    if (isEOCConnected && !isConversionComplete) {
+        return false;
+    }
+
+    busReadRegisterBufferStart(&baro->busdev, BMP085_ADC_OUT_MSB_REG, sensor_data, BMP085_DATA_TEMP_SIZE);
+
+    return true;
+}
+
+static bool bmp085GetUT(baroDev_t *baro)
+{
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
+    }
+
+    bmp085_ut = sensor_data[0] << 8 | sensor_data[1];
+
+    return true;
 }
 
 static void bmp085StartUP(baroDev_t *baro)
@@ -298,25 +320,39 @@ static void bmp085StartUP(baroDev_t *baro)
 
     isConversionComplete = false;
 
-    busWriteRegister(&baro->busdev, BMP085_CTRL_MEAS_REG, ctrl_reg_data);
+    busWriteRegisterStart(&baro->busdev, BMP085_CTRL_MEAS_REG, ctrl_reg_data);
+}
+
+static bool bmp085ReadUP(baroDev_t *baro)
+{
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
+    }
+
+    // return old baro value if conversion time exceeds datasheet max when EOC is connected
+    if (isEOCConnected && !isConversionComplete) {
+        return false;
+    }
+
+    busReadRegisterBufferStart(&baro->busdev, BMP085_ADC_OUT_MSB_REG, sensor_data, BMP085_DATA_PRES_SIZE);
+
+    return true;
 }
 
 /** read out up for pressure conversion
  depending on the oversampling ratio setting up can be 16 to 19 bit
  \return up parameter that represents the uncompensated pressure value
  */
-static void bmp085GetUP(baroDev_t *baro)
+static bool bmp085GetUP(baroDev_t *baro)
 {
-    uint8_t data[3];
-
-    // return old baro value if conversion time exceeds datasheet max when EOC is connected
-    if ((isEOCConnected) && (!isConversionComplete)) {
-        return;
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
     }
 
-    busReadRegisterBuffer(&baro->busdev, BMP085_ADC_OUT_MSB_REG, data, 3);
-    bmp085_up = (((uint32_t) data[0] << 16) | ((uint32_t) data[1] << 8) | (uint32_t) data[2])
+    bmp085_up = (uint32_t)(sensor_data[0] << 16 | sensor_data[1] << 8 | sensor_data[2])
             >> (8 - bmp085.oversampling_setting);
+
+    return true;
 }
 
 STATIC_UNIT_TESTED void bmp085Calculate(int32_t *pressure, int32_t *temperature)
@@ -337,21 +373,21 @@ static void bmp085ReadCalibrarionParameters(busDevice_t *busdev)
     busReadRegisterBuffer(busdev, BMP085_PROM_START__ADDR, data, BMP085_PROM_DATA__LEN);
 
     /*parameters AC1-AC6*/
-    bmp085.cal_param.ac1 = (data[0] << 8) | data[1];
-    bmp085.cal_param.ac2 = (data[2] << 8) | data[3];
-    bmp085.cal_param.ac3 = (data[4] << 8) | data[5];
-    bmp085.cal_param.ac4 = (data[6] << 8) | data[7];
-    bmp085.cal_param.ac5 = (data[8] << 8) | data[9];
-    bmp085.cal_param.ac6 = (data[10] << 8) | data[11];
+    bmp085.cal_param.ac1 = data[0] << 8 | data[1];
+    bmp085.cal_param.ac2 = data[2] << 8 | data[3];
+    bmp085.cal_param.ac3 = data[4] << 8 | data[5];
+    bmp085.cal_param.ac4 = data[6] << 8 | data[7];
+    bmp085.cal_param.ac5 = data[8] << 8 | data[9];
+    bmp085.cal_param.ac6 = data[10] << 8 | data[11];
 
     /*parameters B1,B2*/
-    bmp085.cal_param.b1 = (data[12] << 8) | data[13];
-    bmp085.cal_param.b2 = (data[14] << 8) | data[15];
+    bmp085.cal_param.b1 = data[12] << 8 | data[13];
+    bmp085.cal_param.b2 = data[14] << 8 | data[15];
 
     /*parameters MB,MC,MD*/
-    bmp085.cal_param.mb = (data[16] << 8) | data[17];
-    bmp085.cal_param.mc = (data[18] << 8) | data[19];
-    bmp085.cal_param.md = (data[20] << 8) | data[21];
+    bmp085.cal_param.mb = data[16] << 8 | data[17];
+    bmp085.cal_param.mc = data[18] << 8 | data[19];
+    bmp085.cal_param.md = data[20] << 8 | data[21];
 }
 
 static bool bmp085TestEOCConnected(baroDev_t *baro, const bmp085Config_t *config)

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -99,7 +99,7 @@
 #define BMP388_TEMP_LSB_15_8_REG                        BMP388_DATA_4_REG
 #define BMP388_TEMP_XLSB_7_0_REG                        BMP388_DATA_3_REG
 
-#define BMP388_DATA_FRAME_LENGTH                        ((BMP388_DATA_5_REG - BMP388_DATA_0_REG) + 1) // +1 for inclusive
+#define BMP388_DATA_FRAME_SIZE                          ((BMP388_DATA_5_REG - BMP388_DATA_0_REG) + 1) // +1 for inclusive
 
 // from Datasheet 3.3
 #define BMP388_MODE_SLEEP                               (0x00)
@@ -112,8 +112,6 @@
 #define BMP388_CALIRATION_UPPER_REG                     (0x57)
 
 #define BMP388_TRIMMING_DATA_LENGTH                     ((BMP388_TRIMMING_NVM_PAR_P11_REG - BMP388_TRIMMING_NVM_PAR_T1_LSB_REG) + 1) // +1 for inclusive
-
-#define BMP388_DATA_FRAME_SIZE               (6)
 
 #define BMP388_OVERSAMP_1X               (0x00)
 #define BMP388_OVERSAMP_2X               (0x01)
@@ -167,12 +165,16 @@ STATIC_UNIT_TESTED bmp388_calib_param_t bmp388_cal;
 // uncompensated pressure and temperature
 uint32_t bmp388_up = 0;
 uint32_t bmp388_ut = 0;
+static uint8_t sensor_data[BMP388_DATA_FRAME_SIZE];
+
 STATIC_UNIT_TESTED int64_t t_lin = 0;
 
 static void bmp388StartUT(baroDev_t *baro);
-static void bmp388GetUT(baroDev_t *baro);
+static bool bmp388GetUT(baroDev_t *baro);
+static bool bmp388ReadUT(baroDev_t *baro);
 static void bmp388StartUP(baroDev_t *baro);
-static void bmp388GetUP(baroDev_t *baro);
+static bool bmp388GetUP(baroDev_t *baro);
+static bool bmp388ReadUP(baroDev_t *baro);
 
 STATIC_UNIT_TESTED void bmp388Calculate(int32_t *pressure, int32_t *temperature);
 
@@ -220,8 +222,8 @@ void bmp388BusDeinit(busDevice_t *busdev)
 void bmp388BeginForcedMeasurement(busDevice_t *busdev)
 {
     // enable pressure measurement, temperature measurement, set power mode and start sampling
-    uint8_t mode = (BMP388_MODE_FORCED << 4) | (1 << 1) | (1 << 0);
-    busWriteRegister(busdev, BMP388_PWR_CTRL_REG, mode);
+    uint8_t mode = BMP388_MODE_FORCED << 4 | 1 << 1 | 1 << 0;
+    busWriteRegisterStart(busdev, BMP388_PWR_CTRL_REG, mode);
 }
 
 bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
@@ -263,7 +265,12 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
 
 #ifdef USE_EXTI
     if (baroIntIO) {
-        uint8_t intCtrlValue = (1 << BMP388_INT_DRDY_EN_BIT) | (0 << BMP388_INT_FFULL_EN_BIT) | (0 << BMP388_INT_FWTM_EN_BIT) | (0 << BMP388_INT_LATCH_BIT) | (1 << BMP388_INT_LEVEL_BIT) | (0 << BMP388_INT_OD_BIT);
+        uint8_t intCtrlValue = 1 << BMP388_INT_DRDY_EN_BIT |
+                               0 << BMP388_INT_FFULL_EN_BIT |
+                               0 << BMP388_INT_FWTM_EN_BIT |
+                               0 << BMP388_INT_LATCH_BIT |
+                               1 << BMP388_INT_LEVEL_BIT |
+                               0 << BMP388_INT_OD_BIT;
         busWriteRegister(busdev, BMP388_INT_CTRL_REG, intCtrlValue);
     }
 #endif
@@ -282,11 +289,13 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
 
     // these are dummy as temperature is measured as part of pressure
     baro->ut_delay = 0;
-    baro->get_ut = bmp388GetUT;
     baro->start_ut = bmp388StartUT;
+    baro->get_ut = bmp388GetUT;
+    baro->read_ut = bmp388ReadUT;
     // only _up part is executed, and gets both temperature and pressure
     baro->start_up = bmp388StartUP;
     baro->get_up = bmp388GetUP;
+    baro->read_up = bmp388ReadUP;
 
     // See datasheet 3.9.2 "Measurement rate in forced mode and normal mode"
     baro->up_delay = 234 +
@@ -294,6 +303,8 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
         (313 + (powerf(2, BMP388_TEMPERATURE_OSR + 1) * 2000));
 
     baro->calculate = bmp388Calculate;
+
+    while (busBusy(&baro->busdev, NULL));
 
     return true;
 }
@@ -304,10 +315,18 @@ static void bmp388StartUT(baroDev_t *baro)
     // dummy
 }
 
-static void bmp388GetUT(baroDev_t *baro)
+static bool bmp388ReadUT(baroDev_t *baro)
 {
     UNUSED(baro);
     // dummy
+    return true;
+}
+
+static bool bmp388GetUT(baroDev_t *baro)
+{
+    UNUSED(baro);
+    // dummy
+    return true;
 }
 
 static void bmp388StartUP(baroDev_t *baro)
@@ -316,15 +335,27 @@ static void bmp388StartUP(baroDev_t *baro)
     bmp388BeginForcedMeasurement(&baro->busdev);
 }
 
-static void bmp388GetUP(baroDev_t *baro)
+static bool bmp388ReadUP(baroDev_t *baro)
 {
-    uint8_t dataFrame[BMP388_DATA_FRAME_LENGTH];
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
+    }
 
     // read data from sensor
-    busReadRegisterBuffer(&baro->busdev, BMP388_DATA_0_REG, dataFrame, BMP388_DATA_FRAME_LENGTH);
+    busReadRegisterBufferStart(&baro->busdev, BMP388_DATA_0_REG, sensor_data, BMP388_DATA_FRAME_SIZE);
 
-    bmp388_up = ((uint32_t)(dataFrame[0]) << 0) | ((uint32_t)(dataFrame[1]) << 8) | ((uint32_t)(dataFrame[2]) << 16);
-    bmp388_ut = ((uint32_t)(dataFrame[3]) << 0) | ((uint32_t)(dataFrame[4]) << 8) | ((uint32_t)(dataFrame[5]) << 16);
+    return true;
+}
+
+static bool bmp388GetUP(baroDev_t *baro)
+{
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
+    }
+
+    bmp388_up = sensor_data[0] << 0 | sensor_data[1] << 8 | sensor_data[2] << 16;
+    bmp388_ut = sensor_data[3] << 0 | sensor_data[4] << 8 | sensor_data[5] << 16;
+    return true;
 }
 
 // Returns temperature in DegC, resolution is 0.01 DegC. Output value of "5123" equals 51.23 DegC

--- a/src/main/drivers/barometer/barometer_fake.c
+++ b/src/main/drivers/barometer/barometer_fake.c
@@ -35,9 +35,16 @@ static int32_t fakePressure;
 static int32_t fakeTemperature;
 
 
-static void fakeBaroStartGet(baroDev_t *baro)
+static void fakeBaroStart(baroDev_t *baro)
 {
     UNUSED(baro);
+}
+
+static bool fakeBaroReadGet(baroDev_t *baro)
+{
+    UNUSED(baro);
+
+    return true;
 }
 
 static void fakeBaroCalculate(int32_t *pressure, int32_t *temperature)
@@ -60,14 +67,17 @@ bool fakeBaroDetect(baroDev_t *baro)
     fakeTemperature = 2500;   // temperature in 0.01 C = 25 deg
 
     // these are dummy as temperature is measured as part of pressure
+    baro->combined_read = true;
     baro->ut_delay = 10000;
-    baro->get_ut = fakeBaroStartGet;
-    baro->start_ut = fakeBaroStartGet;
+    baro->get_ut = fakeBaroReadGet;
+    baro->read_ut = fakeBaroReadGet;
+    baro->start_ut = fakeBaroStart;
 
     // only _up part is executed, and gets both temperature and pressure
     baro->up_delay = 10000;
-    baro->start_up = fakeBaroStartGet;
-    baro->get_up = fakeBaroStartGet;
+    baro->start_up = fakeBaroStart;
+    baro->read_up = fakeBaroReadGet;
+    baro->get_up = fakeBaroReadGet;
     baro->calculate = fakeBaroCalculate;
 
     return true;

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -225,7 +225,13 @@ static void lpsNothing(baroDev_t *baro)
     return;
 }
 
-static void lpsRead(baroDev_t *baro)
+static bool lpsNothingBool(baroDev_t *baro)
+{
+    UNUSED(baro);
+    return true;
+}
+
+static bool lpsRead(baroDev_t *baro)
 {
     uint8_t status = 0x00;
     lpsReadCommand(&baro->busdev, LPS_STATUS, &status, 1);
@@ -240,6 +246,8 @@ static void lpsRead(baroDev_t *baro)
         rawP = 0;
         rawT = 0;
     }
+
+    return true;
 }
 
 static void lpsCalculate(int32_t *pressure, int32_t *temperature)
@@ -282,12 +290,15 @@ bool lpsDetect(baroDev_t *baro)
 
     lpsReadCommand(busdev, LPS_CTRL1, &temp, 1);
 
+    baro->combined_read = true;
     baro->ut_delay = 1;
     baro->up_delay = 1000000 / 24;
     baro->start_ut = lpsNothing;
-    baro->get_ut = lpsNothing;
+    baro->get_ut = lpsNothingBool;
+    baro->read_ut = lpsNothingBool;
     baro->start_up = lpsNothing;
     baro->get_up = lpsRead;
+    baro->read_up = lpsNothingBool;
     baro->calculate = lpsCalculate;
     uint32_t timeout = millis();
     do {

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -37,39 +37,39 @@
 
 #if defined(USE_BARO) && (defined(USE_BARO_QMP6988) || defined(USE_BARO_SPI_QMP6988))
 
-#define QMP6988_I2C_ADDR					(0x70)
-#define QMP6988_DEFAULT_CHIP_ID			(0x5c)
-#define QMP6988_CHIP_ID_REG				(0xD1)  /* Chip ID Register */
+#define QMP6988_I2C_ADDR                0x70
+#define QMP6988_DEFAULT_CHIP_ID         0x5c
+#define QMP6988_CHIP_ID_REG             0xD1  /* Chip ID Register */
 
-#define QMP6988_IO_SETUP_REG				(0xF5)
-#define QMP6988_SET_IIR_REG				(0xF1)
-#define QMP6988_CTRL_MEAS_REG				(0xF4)
-#define QMP6988_COE_B00_1_REG				(0xA0)
-#define QMP6988_PRESSURE_MSB_REG			(0xF7)  /* Pressure MSB Register */
-#define QMP6988_PRESSURE_LSB_REG			(0xF8)  /* Pressure LSB Register */
-#define QMP6988_PRESSURE_XLSB_REG		(0xF9)  /* Pressure XLSB Register */
-#define QMP6988_TEMPERATURE_MSB_REG		(0xFA)  /* Temperature MSB Reg */
-#define QMP6988_TEMPERATURE_LSB_REG		(0xFB)  /* Temperature LSB Reg */
-#define QMP6988_TEMPERATURE_XLSB_REG		(0xFC)  /* Temperature XLSB Reg */
-#define QMP6988_DATA_FRAME_SIZE			6
-#define QMP6988_FORCED_MODE				(0x01)
-#define QMP6988_PWR_SAMPLE_MODE			(0x7B)
+#define QMP6988_IO_SETUP_REG            0xF5
+#define QMP6988_SET_IIR_REG             0xF1
+#define QMP6988_CTRL_MEAS_REG           0xF4
+#define QMP6988_COE_B00_1_REG           0xA0
+#define QMP6988_PRESSURE_MSB_REG        0xF7  /* Pressure MSB Register */
+#define QMP6988_PRESSURE_LSB_REG        0xF8  /* Pressure LSB Register */
+#define QMP6988_PRESSURE_XLSB_REG       0xF9  /* Pressure XLSB Register */
+#define QMP6988_TEMPERATURE_MSB_REG     0xFA  /* Temperature MSB Reg */
+#define QMP6988_TEMPERATURE_LSB_REG     0xFB  /* Temperature LSB Reg */
+#define QMP6988_TEMPERATURE_XLSB_REG    0xFC  /* Temperature XLSB Reg */
+#define QMP6988_DATA_FRAME_SIZE         6
+#define QMP6988_FORCED_MODE             0x01
+#define QMP6988_PWR_SAMPLE_MODE         0x7B
 
-#define QMP6988_OVERSAMP_SKIPPED			(0x00)
-#define QMP6988_OVERSAMP_1X 				(0x01)
-#define QMP6988_OVERSAMP_2X				(0x02)
-#define QMP6988_OVERSAMP_4X				(0x03)
-#define QMP6988_OVERSAMP_8X				(0x04)
-#define QMP6988_OVERSAMP_16X				(0x05)
+#define QMP6988_OVERSAMP_SKIPPED        0x00
+#define QMP6988_OVERSAMP_1X             0x01
+#define QMP6988_OVERSAMP_2X             0x02
+#define QMP6988_OVERSAMP_4X             0x03
+#define QMP6988_OVERSAMP_8X             0x04
+#define QMP6988_OVERSAMP_16X            0x05
 
 // configure pressure and temperature oversampling, forced sampling mode
-#define QMP6988_PRESSURE_OSR              			(QMP6988_OVERSAMP_8X)
-#define QMP6988_TEMPERATURE_OSR           		(QMP6988_OVERSAMP_1X)
-#define QMP6988_MODE                      				(QMP6988_PRESSURE_OSR << 2 | QMP6988_TEMPERATURE_OSR << 5 | QMP6988_FORCED_MODE)
+#define QMP6988_PRESSURE_OSR            QMP6988_OVERSAMP_8X
+#define QMP6988_TEMPERATURE_OSR         QMP6988_OVERSAMP_1X
+#define QMP6988_MODE                    (QMP6988_PRESSURE_OSR << 2 | QMP6988_TEMPERATURE_OSR << 5 | QMP6988_FORCED_MODE)
 
-#define T_INIT_MAX                       					(20)
-#define T_MEASURE_PER_OSRS_MAX           			(37)
-#define T_SETUP_PRESSURE_MAX             			(10)
+#define T_INIT_MAX                      20
+#define T_MEASURE_PER_OSRS_MAX          37
+#define T_SETUP_PRESSURE_MAX            10
 
 typedef struct qmp6988_calib_param_s {
     float Coe_a0;
@@ -91,11 +91,14 @@ STATIC_UNIT_TESTED qmp6988_calib_param_t qmp6988_cal;
 // uncompensated pressure and temperature
 int32_t qmp6988_up = 0;
 int32_t qmp6988_ut = 0;
+static uint8_t sensor_data[QMP6988_DATA_FRAME_SIZE];
 
 static void qmp6988StartUT(baroDev_t *baro);
-static void qmp6988GetUT(baroDev_t *baro);
+static bool qmp6988ReadUT(baroDev_t *baro);
+static bool qmp6988GetUT(baroDev_t *baro);
 static void qmp6988StartUP(baroDev_t *baro);
-static void qmp6988GetUP(baroDev_t *baro);
+static bool qmp6988ReadUP(baroDev_t *baro);
+static bool qmp6988GetUP(baroDev_t *baro);
 
 STATIC_UNIT_TESTED void qmp6988Calculate(int32_t *pressure, int32_t *temperature);
 
@@ -103,7 +106,7 @@ void qmp6988BusInit(busDevice_t *busdev)
 {
 #ifdef USE_BARO_SPI_QMP6988
     if (busdev->bustype == BUSTYPE_SPI) {
-        IOHi(busdev->busdev_u.spi.csnPin); 
+        IOHi(busdev->busdev_u.spi.csnPin);
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
 #ifdef USE_SPI_TRANSACTION
@@ -171,100 +174,103 @@ bool qmp6988Detect(baroDev_t *baro)
     }
 
     // SetIIR
-    busWriteRegister(busdev, QMP6988_SET_IIR_REG, 0x05);	
-    
-    //read OTP 
+    busWriteRegister(busdev, QMP6988_SET_IIR_REG, 0x05);
+
+    //read OTP
     busReadRegisterBuffer(busdev, QMP6988_COE_B00_1_REG, databuf, 25);
-    
+
     //algo OTP
     hw = databuf[0];
-    lw =  databuf[1];	
-    temp1 = (hw<<12) | (lw<<4);	
-    
+    lw =  databuf[1];
+    temp1 = hw<<12 | lw<<4;
+
     hb = databuf[2];
-    lb = databuf[3];	
-    Coe_bt1_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[3];
+    Coe_bt1_ = hb<<8 | lb;
+
     hb = databuf[4];
-    lb = databuf[5];	
-    Coe_bt2_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[5];
+    Coe_bt2_ = hb<<8 | lb;
+
     hb = databuf[6];
-    lb = databuf[7];	
-    Coe_bp1_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[7];
+    Coe_bp1_ = hb<<8 | lb;
+
     hb = databuf[8];
-    lb = databuf[9];	
-    Coe_b11_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[9];
+    Coe_b11_ = hb<<8 | lb;
+
     hb = databuf[10];
-    lb = databuf[11];	
-    Coe_bp2_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[11];
+    Coe_bp2_ = hb<<8 | lb;
+
     hb = databuf[12];
-    lb = databuf[13];	
-    Coe_b12_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[13];
+    Coe_b12_ = hb<<8 | lb;
+
     hb = databuf[14];
-    lb = databuf[15];	
-    Coe_b21_ = (short)((hb<<8) | lb);
-	
+    lb = databuf[15];
+    Coe_b21_ = hb<<8 | lb;
+
     hb = databuf[16];
-    lb = databuf[17];	
-    Coe_bp3_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[17];
+    Coe_bp3_ = hb<<8 | lb;
+
     hw = databuf[18];
-    lw = databuf[19];	
-    temp2 = (hw<<12) | (lw<<4);	
-    
+    lw = databuf[19];
+    temp2 = hw<<12 | lw<<4;
+
     hb = databuf[20];
-    lb = databuf[21];	
-    Coe_a1_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[21];
+    Coe_a1_ = hb<<8 | lb;
+
     hb = databuf[22];
-    lb = databuf[23];	
-    Coe_a2_ = (short)((hb<<8) | lb);
-    
+    lb = databuf[23];
+    Coe_a2_ = hb<<8 | lb;
+
     hb = databuf[24];
-    
+
     temp1 = temp1|((hb&0xf0)>>4);
     if(temp1&0x80000)
-       Coe_b00_ = ((int)temp1 - (int)0x100000);	
+       Coe_b00_ = ((int)temp1 - (int)0x100000);
     else
        Coe_b00_ = temp1;
-    
+
     temp2 = temp2|(hb&0x0f);
     if(temp2&0x80000)
-    	Coe_a0_  = ((int)temp2 - (int)0x100000);
+        Coe_a0_  = ((int)temp2 - (int)0x100000);
     else
         Coe_a0_ = temp2;
-    
+
     qmp6988_cal.Coe_a0=(float)Coe_a0_/16.0;
     qmp6988_cal.Coe_a1=(-6.30E-03)+(4.30E-04)*(float)Coe_a1_/32767.0;
     qmp6988_cal.Coe_a2=(-1.9E-11)+(1.2E-10)*(float)Coe_a2_/32767.0;
-    
+
     qmp6988_cal.Coe_b00 = Coe_b00_/16.0;
     qmp6988_cal.Coe_bt1 = (1.00E-01)+(9.10E-02)*(float)Coe_bt1_/32767.0;
     qmp6988_cal.Coe_bt2= (1.20E-08)+(1.20E-06)*(float)Coe_bt2_/32767.0;
-    
+
     qmp6988_cal.Coe_bp1 = (3.30E-02)+(1.90E-02)*(float)Coe_bp1_/32767.0;
     qmp6988_cal.Coe_b11= (2.10E-07)+(1.40E-07)*(float)Coe_b11_/32767.0;
-    
+
     qmp6988_cal.Coe_bp2 = (-6.30E-10)+(3.50E-10)*(float)Coe_bp2_/32767.0;
     qmp6988_cal.Coe_b12= (2.90E-13)+(7.60E-13)*(float)Coe_b12_/32767.0;
-    
+
     qmp6988_cal.Coe_b21 = (2.10E-15)+(1.20E-14)*(float)Coe_b21_/32767.0;
-    qmp6988_cal.Coe_bp3= (1.30E-16)+(7.90E-17)*(float)Coe_bp3_/32767.0;	
-    
+    qmp6988_cal.Coe_bp3= (1.30E-16)+(7.90E-17)*(float)Coe_bp3_/32767.0;
+
     // Set power mode and sample times
-    busWriteRegister(busdev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);	
+    busWriteRegister(busdev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);
 
     // these are dummy as temperature is measured as part of pressure
+    baro->combined_read = true;
     baro->ut_delay = 0;
-    baro->get_ut = qmp6988GetUT;
     baro->start_ut = qmp6988StartUT;
+    baro->read_ut = qmp6988ReadUT;
+    baro->get_ut = qmp6988GetUT;
     // only _up part is executed, and gets both temperature and pressure
     baro->start_up = qmp6988StartUP;
+    baro->read_up = qmp6988ReadUP;
     baro->get_up = qmp6988GetUP;
     baro->up_delay = ((T_INIT_MAX + T_MEASURE_PER_OSRS_MAX * (((1 << QMP6988_TEMPERATURE_OSR) >> 1) + ((1 << QMP6988_PRESSURE_OSR) >> 1)) + (QMP6988_PRESSURE_OSR ? T_SETUP_PRESSURE_MAX : 0) + 15) / 16) * 1000;
     baro->calculate = qmp6988Calculate;
@@ -278,26 +284,48 @@ static void qmp6988StartUT(baroDev_t *baro)
     // dummy
 }
 
-static void qmp6988GetUT(baroDev_t *baro)
+static bool qmp6988ReadUT(baroDev_t *baro)
 {
     UNUSED(baro);
     // dummy
+    return true;
+}
+
+static bool qmp6988GetUT(baroDev_t *baro)
+{
+    UNUSED(baro);
+    // dummy
+    return true;
 }
 
 static void qmp6988StartUP(baroDev_t *baro)
 {
     // start measurement
-    busWriteRegister(&baro->busdev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);	
+    busWriteRegister(&baro->busdev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);
 }
 
-static void qmp6988GetUP(baroDev_t *baro)
+static bool qmp6988ReadUP(baroDev_t *baro)
 {
-    uint8_t data[QMP6988_DATA_FRAME_SIZE];
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
+    }
 
     // read data from sensor
-    busReadRegisterBuffer(&baro->busdev, QMP6988_PRESSURE_MSB_REG, data, QMP6988_DATA_FRAME_SIZE);
-    qmp6988_up = (int32_t)((((uint32_t)(data[0])) << 16) | (((uint32_t)(data[1])) << 8) | ((uint32_t)data[2] ));
-    qmp6988_ut = (int32_t)((((uint32_t)(data[3])) << 16) | (((uint32_t)(data[4])) << 8) | ((uint32_t)data[5]));
+    busReadRegisterBufferStart(&baro->busdev, QMP6988_PRESSURE_MSB_REG, sensor_data, QMP6988_DATA_FRAME_SIZE);
+
+    return true;
+}
+
+static bool qmp6988GetUP(baroDev_t *baro)
+{
+    if (busBusy(&baro->busdev, NULL)) {
+        return false;
+    }
+
+    qmp6988_up = sensor_data[0] << 16 | sensor_data[1] << 8 | sensor_data[2];
+    qmp6988_ut = sensor_data[3] << 16 | sensor_data[4] << 8 | sensor_data[5];
+
+    return true;
 }
 
 // Returns temperature in DegC, resolution is 0.01 DegC. Output value of "5123" equals 51.23 DegC
@@ -306,8 +334,8 @@ static float qmp6988CompensateTemperature(int32_t adc_T)
 {
     int32_t var1;
     float T;
-    
-    var1=adc_T-1024*1024*8;	
+
+    var1=adc_T-1024*1024*8;
     T= qmp6988_cal.Coe_a0+qmp6988_cal.Coe_a1*var1+qmp6988_cal.Coe_a2*var1*var1;
 
     return T;
@@ -319,13 +347,13 @@ STATIC_UNIT_TESTED void qmp6988Calculate(int32_t *pressure, int32_t *temperature
 {
     float tr,pr;
     int32_t Dp;
-    
+
     tr = qmp6988CompensateTemperature(qmp6988_ut);
-    Dp = qmp6988_up - 1024*1024*8;	
-    
+    Dp = qmp6988_up - 1024*1024*8;
+
     pr = qmp6988_cal.Coe_b00+qmp6988_cal.Coe_bt1*tr+qmp6988_cal.Coe_bp1*Dp+qmp6988_cal.Coe_b11*tr*Dp+qmp6988_cal.Coe_bt2*tr*tr+qmp6988_cal.Coe_bp2*Dp*Dp+qmp6988_cal.Coe_b12*Dp*tr*tr
     +qmp6988_cal.Coe_b21*Dp*Dp*tr+qmp6988_cal.Coe_bp3*Dp*Dp*Dp;
-      
+
     if (pr)
     *pressure = (int32_t)(pr);
     if (tr)

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -52,6 +52,31 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
     }
 }
 
+bool busWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data)
+{
+#if !defined(USE_SPI) && !defined(USE_I2C)
+    UNUSED(reg);
+    UNUSED(data);
+#endif
+    switch (busdev->bustype) {
+#ifdef USE_SPI
+    case BUSTYPE_SPI:
+#ifdef USE_SPI_TRANSACTION
+        // XXX Watch out fastpath users, if any
+        return spiBusTransactionWriteRegister(busdev, reg & 0x7f, data);
+#else
+        return spiBusWriteRegister(busdev, reg & 0x7f, data);
+#endif
+#endif
+#ifdef USE_I2C
+    case BUSTYPE_I2C:
+        return i2cBusWriteRegisterStart(busdev, reg, data);
+#endif
+    default:
+        return false;
+    }
+}
+
 bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
 {
 #if !defined(USE_SPI) && !defined(USE_I2C)
@@ -72,6 +97,58 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
 #ifdef USE_I2C
     case BUSTYPE_I2C:
         return i2cBusReadRegisterBuffer(busdev, reg, data, length);
+#endif
+    default:
+        return false;
+    }
+}
+
+// Start the I2C read, but do not wait for completion
+bool busReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
+{
+#if !defined(USE_SPI) && !defined(USE_I2C)
+    UNUSED(reg);
+    UNUSED(data);
+    UNUSED(length);
+#endif
+    switch (busdev->bustype) {
+#ifdef USE_SPI
+    case BUSTYPE_SPI:
+        // For SPI allow the transaction to complete
+#ifdef USE_SPI_TRANSACTION
+        // XXX Watch out fastpath users, if any
+        return spiBusTransactionReadRegisterBuffer(busdev, reg | 0x80, data, length);
+#else
+        return spiBusReadRegisterBuffer(busdev, reg | 0x80, data, length);
+#endif
+#endif
+#ifdef USE_I2C
+    case BUSTYPE_I2C:
+        // Initiate the read access
+        return i2cBusReadRegisterBufferStart(busdev, reg, data, length);
+#endif
+    default:
+        return false;
+    }
+}
+
+// Returns true if bus is still busy
+bool busBusy(const busDevice_t *busdev, bool *error)
+{
+#if !defined(USE_I2C)
+    UNUSED(error);
+#endif
+    switch (busdev->bustype) {
+#ifdef USE_SPI
+    case BUSTYPE_SPI:
+        // No waiting on SPI
+#ifdef USE_SPI_TRANSACTION
+        return false;
+#endif
+#endif
+#ifdef USE_I2C
+    case BUSTYPE_I2C:
+        return i2cBusBusy(busdev, error);
 #endif
     default:
         return false;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -66,5 +66,8 @@ void targetBusInit(void);
 #endif
 
 bool busWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool busWriteRegisterStart(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool busReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t busReadRegister(const busDevice_t *bus, uint8_t reg);
+bool busReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
+bool busBusy(const busDevice_t *busdev, bool *error);

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -60,6 +60,8 @@ void i2cHardwareConfigure(const struct i2cConfig_s *i2cConfig);
 void i2cInit(I2CDevice device);
 bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data);
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
 bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
+bool i2cBusy(I2CDevice device, bool *error);
 
 uint16_t i2cGetErrorCounter(void);

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -34,6 +34,16 @@ bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
     return i2cWrite(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, data);
 }
 
+bool i2cBusWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data)
+{
+    // Need a static value, not on the stack
+    static uint8_t byte;
+
+    byte = data;
+
+    return i2cWriteBuffer(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, sizeof (byte), &byte);
+}
+
 bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
 {
     return i2cRead(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, length, data);
@@ -45,4 +55,15 @@ uint8_t i2cBusReadRegister(const busDevice_t *busdev, uint8_t reg)
     i2cRead(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, 1, &data);
     return data;
 }
+
+bool i2cBusReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
+{
+    return i2cReadBuffer(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, length, data);
+}
+
+bool i2cBusBusy(const busDevice_t *busdev, bool *error)
+{
+    return i2cBusy(busdev->busdev_u.i2c.device, error);
+}
+
 #endif

--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -21,5 +21,8 @@
 #pragma once
 
 bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data);
+bool i2cBusWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data);
 bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t i2cBusReadRegister(const busDevice_t *bus, uint8_t reg);
+bool i2cBusReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
+bool i2cBusBusy(const busDevice_t *busdev, bool *error);

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -174,6 +174,10 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
     }
 
     i2cState_t *state = &i2cDevice[device].state;
+    if (state->busy) {
+        return false;
+    }
+
     uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
     state->addr = addr_ << 1;
@@ -196,32 +200,52 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
         I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
     }
 
-    timeout = I2C_DEFAULT_TIMEOUT;
+    return true;
+}
+
+bool i2cBusy(I2CDevice device, bool *error)
+{
+    i2cState_t *state = &i2cDevice[device].state;
+
+    if (error) {
+        *error = state->error;
+    }
+    return state->busy;
+}
+
+bool i2cWait(I2CDevice device)
+{
+    i2cState_t *state = &i2cDevice[device].state;
+    uint32_t timeout = I2C_DEFAULT_TIMEOUT;
+
     while (state->busy && --timeout > 0) {; }
     if (timeout == 0)
-        return i2cHandleHardwareFailure(device);
+        return i2cHandleHardwareFailure(device) && i2cWait(device);
 
     return !(state->error);
 }
 
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
 {
-    return i2cWriteBuffer(device, addr_, reg_, 1, &data);
+    return i2cWriteBuffer(device, addr_, reg_, 1, &data) && i2cWait(device);
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device > I2CDEV_COUNT) {
         return false;
     }
 
     I2C_TypeDef *I2Cx = i2cDevice[device].reg;
-
     if (!I2Cx) {
         return false;
     }
 
     i2cState_t *state = &i2cDevice[device].state;
+    if (state->busy) {
+        return false;
+    }
+
     uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
     state->addr = addr_ << 1;
@@ -244,12 +268,12 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
         I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
     }
 
-    timeout = I2C_DEFAULT_TIMEOUT;
-    while (state->busy && --timeout > 0) {; }
-    if (timeout == 0)
-        return i2cHandleHardwareFailure(device);
+    return true;
+}
 
-    return !(state->error);
+bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+{
+    return i2cReadBuffer(device, addr_, reg_, len, buf) && i2cWait(device);
 }
 
 static void i2c_er_handler(I2CDevice device) {

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -284,4 +284,27 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
     return true;
 }
 
+bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+{
+    bool status = true;
+
+    for (uint8_t i = 0; i < len_; i++) {
+        status &= i2cWrite(device, addr_, reg_ + i, data[i]);
+    }
+
+    return status;
+}
+
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
+{
+    return i2cRead(device, addr_, reg, len, buf);
+}
+
+bool i2cBusy(I2CDevice device, bool *error)
+{
+    UNUSED(device);
+    UNUSED(error);
+
+    return false;
+}
 #endif

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -250,7 +250,7 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse)
         }
 #endif
         FALLTHROUGH;
-    
+
      case BARO_QMP6988:
 #if defined(USE_BARO_QMP6988) || defined(USE_BARO_SPI_QMP6988)
         if (qmp6988Detect(dev)) {

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -33,10 +33,6 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
-#include "drivers/bus.h"
-#include "drivers/bus_spi.h"
-#include "drivers/io.h"
-
 #include "drivers/barometer/barometer.h"
 #include "drivers/barometer/barometer_bmp085.h"
 #include "drivers/barometer/barometer_bmp280.h"
@@ -45,6 +41,10 @@
 #include "drivers/barometer/barometer_fake.h"
 #include "drivers/barometer/barometer_ms5611.h"
 #include "drivers/barometer/barometer_lps.h"
+#include "drivers/bus.h"
+#include "drivers/bus_spi.h"
+#include "drivers/io.h"
+#include "drivers/time.h"
 
 #include "fc/runtime_config.h"
 
@@ -250,15 +250,15 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse)
         }
 #endif
         FALLTHROUGH;
-	
-	 case BARO_QMP6988:
+    
+     case BARO_QMP6988:
 #if defined(USE_BARO_QMP6988) || defined(USE_BARO_SPI_QMP6988)
         if (qmp6988Detect(dev)) {
             baroHardware = BARO_QMP6988;
             break;
         }
 #endif
-		FALLTHROUGH;
+        FALLTHROUGH;
     case BARO_NONE:
         baroHardware = BARO_NONE;
         break;
@@ -336,8 +336,12 @@ static uint32_t recalculateBarometerTotal(uint8_t baroSampleCount, uint32_t pres
 }
 
 typedef enum {
-    BAROMETER_NEEDS_SAMPLES = 0,
-    BAROMETER_NEEDS_CALCULATION
+    BAROMETER_NEEDS_TEMPERATURE_READ = 0,
+    BAROMETER_NEEDS_TEMPERATURE_SAMPLE,
+    BAROMETER_NEEDS_PRESSURE_START,
+    BAROMETER_NEEDS_PRESSURE_READ,
+    BAROMETER_NEEDS_PRESSURE_SAMPLE,
+    BAROMETER_NEEDS_TEMPERATURE_START
 } barometerState_e;
 
 
@@ -347,7 +351,8 @@ bool isBaroReady(void) {
 
 uint32_t baroUpdate(void)
 {
-    static barometerState_e state = BAROMETER_NEEDS_SAMPLES;
+    static barometerState_e state = BAROMETER_NEEDS_PRESSURE_START;
+    timeUs_t sleepTime = 1000; // Wait 1ms between states
 
     if (debugMode == DEBUG_BARO) {
         debug[0] = state;
@@ -355,20 +360,50 @@ uint32_t baroUpdate(void)
 
     switch (state) {
         default:
-        case BAROMETER_NEEDS_SAMPLES:
-            baro.dev.get_ut(&baro.dev);
-            baro.dev.start_up(&baro.dev);
-            state = BAROMETER_NEEDS_CALCULATION;
-            return baro.dev.up_delay;
+        case BAROMETER_NEEDS_TEMPERATURE_START:
+            baro.dev.start_ut(&baro.dev);
+            state = BAROMETER_NEEDS_TEMPERATURE_READ;
+            sleepTime = baro.dev.ut_delay;
+            break;
+
+        case BAROMETER_NEEDS_TEMPERATURE_READ:
+            if (baro.dev.read_ut(&baro.dev)) {
+                state = BAROMETER_NEEDS_TEMPERATURE_SAMPLE;
+            }
         break;
 
-        case BAROMETER_NEEDS_CALCULATION:
-            baro.dev.get_up(&baro.dev);
-            baro.dev.start_ut(&baro.dev);
+        case BAROMETER_NEEDS_TEMPERATURE_SAMPLE:
+            if (baro.dev.get_ut(&baro.dev)) {
+                state = BAROMETER_NEEDS_PRESSURE_START;
+            }
+        break;
+
+        case BAROMETER_NEEDS_PRESSURE_START:
+            baro.dev.start_up(&baro.dev);
+            state = BAROMETER_NEEDS_PRESSURE_READ;
+            sleepTime = baro.dev.up_delay;
+        break;
+
+        case BAROMETER_NEEDS_PRESSURE_READ:
+            if (baro.dev.read_up(&baro.dev)) {
+                state = BAROMETER_NEEDS_PRESSURE_SAMPLE;
+            }
+        break;
+
+        case BAROMETER_NEEDS_PRESSURE_SAMPLE:
+            if (!baro.dev.get_up(&baro.dev)) {
+                break;
+            }
+
             baro.dev.calculate(&baroPressure, &baroTemperature);
             baro.baroPressure = baroPressure;
             baro.baroTemperature = baroTemperature;
             baroPressureSum = recalculateBarometerTotal(barometerConfig()->baro_sample_count, baroPressureSum, baroPressure);
+            if (baro.dev.combined_read) {
+                state = BAROMETER_NEEDS_PRESSURE_START;
+            } else {
+                state = BAROMETER_NEEDS_TEMPERATURE_START;
+            }
 
             if (debugMode == DEBUG_BARO) {
                 debug[1] = baroTemperature;
@@ -376,10 +411,11 @@ uint32_t baroUpdate(void)
                 debug[3] = baroPressureSum;
             }
 
-            state = BAROMETER_NEEDS_SAMPLES;
-            return baro.dev.ut_delay;
+            sleepTime = baro.dev.ut_delay;
         break;
     }
+
+    return sleepTime;
 }
 
 int32_t baroCalculateAltitude(void)

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -147,8 +147,11 @@ TEST(baroBmp280Test, TestBmp280CalculateZeroP)
 extern "C" {
 
 void delay(uint32_t) {}
+bool busBusy(const busDevice_t*, bool*) {return false;}
 bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
 bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
 
 void spiBusSetDivisor() {
 }

--- a/src/test/unit/baro_bmp388_unittest.cc
+++ b/src/test/unit/baro_bmp388_unittest.cc
@@ -143,8 +143,11 @@ TEST(baroBmp388Test, TestBmp388CalculateWithSampleCalibration)
 extern "C" {
 
 void delay(uint32_t) {}
+bool busBusy(const busDevice_t*, bool*) {return false;}
 bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
 bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
 
 void spiBusSetDivisor() {
 }

--- a/src/test/unit/baro_ms5611_unittest.cc
+++ b/src/test/unit/baro_ms5611_unittest.cc
@@ -146,8 +146,11 @@ extern "C" {
 void delay(uint32_t) {}
 void delayMicroseconds(uint32_t) {}
 
+bool busBusy(const busDevice_t*, bool*) {return false;}
 bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
 bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
 
 void spiBusSetDivisor() {
 }


### PR DESCRIPTION
See https://github.com/betaflight/betaflight/issues/7453 for the background investigation into loop jitter. This pull request breaks the barometer task from two parts into four to cut down the time spent on each pass through the scheduler and reduce loop time jitter.