### PR TITLE
Modify CPU load calculations to not assume constant task duration

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3775,7 +3775,7 @@ static void cliTasks(char *cmdline)
                     cliPrintf("%02d - (%11s/%3s) ", taskId, taskInfo.subTaskName, taskInfo.taskName);
                 }
             } else {
-                taskFrequency = taskInfo.latestDeltaTime == 0 ? 0 : (int)(1000000.0f / ((float)taskInfo.latestDeltaTime));
+                taskFrequency = taskInfo.averageDeltaTime == 0 ? 0 : (int)(1000000.0f / ((float)taskInfo.averageDeltaTime));
                 cliPrintf("%02d - (%15s) ", taskId, taskInfo.taskName);
             }
             const int maxLoad = taskInfo.maxExecutionTime == 0 ? 0 :(taskInfo.maxExecutionTime * taskFrequency + 5000) / 1000;

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -144,12 +144,14 @@ void taskSystemLoad(timeUs_t currentTimeUs)
 timeUs_t checkFuncMaxExecutionTime;
 timeUs_t checkFuncTotalExecutionTime;
 timeUs_t checkFuncMovingSumExecutionTime;
+timeUs_t checkFuncMovingSumDeltaTime;
 
 void getCheckFuncInfo(cfCheckFuncInfo_t *checkFuncInfo)
 {
     checkFuncInfo->maxExecutionTime = checkFuncMaxExecutionTime;
     checkFuncInfo->totalExecutionTime = checkFuncTotalExecutionTime;
     checkFuncInfo->averageExecutionTime = checkFuncMovingSumExecutionTime / MOVING_SUM_COUNT;
+    checkFuncInfo->averageDeltaTime = checkFuncMovingSumDeltaTime / MOVING_SUM_COUNT;
 }
 #endif
 
@@ -164,6 +166,7 @@ void getTaskInfo(cfTaskId_e taskId, cfTaskInfo_t * taskInfo)
     taskInfo->maxExecutionTime = cfTasks[taskId].maxExecutionTime;
     taskInfo->totalExecutionTime = cfTasks[taskId].totalExecutionTime;
     taskInfo->averageExecutionTime = cfTasks[taskId].movingSumExecutionTime / MOVING_SUM_COUNT;
+    taskInfo->averageDeltaTime = cfTasks[taskId].movingSumDeltaTime / MOVING_SUM_COUNT;
     taskInfo->latestDeltaTime = cfTasks[taskId].taskLatestDeltaTime;
     taskInfo->movingAverageCycleTime = cfTasks[taskId].movingAverageCycleTime;
 #endif
@@ -213,10 +216,12 @@ void schedulerResetTaskStatistics(cfTaskId_e taskId)
 #if defined(USE_TASK_STATISTICS)
     if (taskId == TASK_SELF) {
         currentTask->movingSumExecutionTime = 0;
+        currentTask->movingSumDeltaTime = 0;
         currentTask->totalExecutionTime = 0;
         currentTask->maxExecutionTime = 0;
     } else if (taskId < TASK_COUNT) {
         cfTasks[taskId].movingSumExecutionTime = 0;
+        cfTasks[taskId].movingSumDeltaTime = 0;
         cfTasks[taskId].totalExecutionTime = 0;
         cfTasks[taskId].maxExecutionTime = 0;
     }
@@ -297,6 +302,7 @@ FAST_CODE void scheduler(void)
                 if (calculateTaskStatistics) {
                     const uint32_t checkFuncExecutionTime = micros() - currentTimeBeforeCheckFuncCall;
                     checkFuncMovingSumExecutionTime += checkFuncExecutionTime - checkFuncMovingSumExecutionTime / MOVING_SUM_COUNT;
+                    checkFuncMovingSumDeltaTime += task->taskLatestDeltaTime - checkFuncMovingSumDeltaTime / MOVING_SUM_COUNT;
                     checkFuncTotalExecutionTime += checkFuncExecutionTime;   // time consumed by scheduler + task
                     checkFuncMaxExecutionTime = MAX(checkFuncMaxExecutionTime, checkFuncExecutionTime);
                 }
@@ -350,6 +356,7 @@ FAST_CODE void scheduler(void)
             selectedTask->taskFunc(currentTimeBeforeTaskCall);
             const timeUs_t taskExecutionTime = micros() - currentTimeBeforeTaskCall;
             selectedTask->movingSumExecutionTime += taskExecutionTime - selectedTask->movingSumExecutionTime / MOVING_SUM_COUNT;
+            selectedTask->movingSumDeltaTime += selectedTask->taskLatestDeltaTime - selectedTask->movingSumDeltaTime / MOVING_SUM_COUNT;
             selectedTask->totalExecutionTime += taskExecutionTime;   // time consumed by scheduler + task
             selectedTask->maxExecutionTime = MAX(selectedTask->maxExecutionTime, taskExecutionTime);
             selectedTask->movingAverageCycleTime += 0.05f * (period - selectedTask->movingAverageCycleTime);

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -42,6 +42,7 @@ typedef struct {
     timeUs_t     maxExecutionTime;
     timeUs_t     totalExecutionTime;
     timeUs_t     averageExecutionTime;
+    timeUs_t     averageDeltaTime;
 } cfCheckFuncInfo_t;
 
 typedef struct {
@@ -54,6 +55,7 @@ typedef struct {
     timeUs_t     maxExecutionTime;
     timeUs_t     totalExecutionTime;
     timeUs_t     averageExecutionTime;
+    timeUs_t     averageDeltaTime;
     float        movingAverageCycleTime;
 } cfTaskInfo_t;
 
@@ -165,6 +167,7 @@ typedef struct {
     // Statistics
     float    movingAverageCycleTime;
     timeUs_t movingSumExecutionTime;  // moving sum over 32 samples
+    timeUs_t movingSumDeltaTime;  // moving sum over 32 samples
     timeUs_t maxExecutionTime;
     timeUs_t totalExecutionTime;    // total time consumed by task since boot
 #endif


### PR DESCRIPTION
As highlighted in https://github.com/betaflight/betaflight/pull/7455 the CLI tasks command did a poor job of calculating CPU load as it used the average task duration, but the last delta time. It now uses a delta time averaged over the same time as the task duration.