### PR TITLE
Fix color range for ledstrip battery and rssi layers

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -492,12 +492,12 @@ static void applyLedFixedLayers(void)
 
         case LED_FUNCTION_BATTERY:
             color = HSV(RED);
-            hOffset += scaleRange(calculateBatteryPercentageRemaining(), 0, 100, -30, 120);
+            hOffset += MAX(scaleRange(calculateBatteryPercentageRemaining(), 0, 100, -30, 120), 0);
             break;
 
         case LED_FUNCTION_RSSI:
             color = HSV(RED);
-            hOffset += scaleRange(getRssiPercent(), 0, 100, -30, 120);
+            hOffset += MAX(scaleRange(getRssiPercent(), 0, 100, -30, 120), 0);
             break;
 
         default:


### PR DESCRIPTION
The range was underflowing the calculated hue value causing it to loop back to other colors. For example when battery ranged from below 20% the color would shift from red (the correct color for minimum battery) to shades of magenta. RSSI had the same problem.

Now the logic reserves the base color (red in these cases) for the minimum 20% of the range. From 20-100% the color will scale from red through to green.
