### PR TITLE
Fix mixer throttle calculation

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -402,7 +402,7 @@ void initEscEndpoints(void)
         break;
     }
 
-    rcCommandThrottleRange = PWM_RANGE_MAX - rxConfig()->mincheck;
+    rcCommandThrottleRange = PWM_RANGE_MAX - PWM_RANGE_MIN;
 }
 
 void mixerInit(mixerMode_e mixerMode)
@@ -642,7 +642,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             pidResetIterm();
         }
     } else {
-        throttle = rcCommand[THROTTLE] - rxConfig()->mincheck + throttleAngleCorrection;
+        throttle = rcCommand[THROTTLE] - PWM_RANGE_MIN + throttleAngleCorrection;
         currentThrottleInputRange = rcCommandThrottleRange;
         motorRangeMin = motorOutputLow;
         motorRangeMax = motorOutputHigh;


### PR DESCRIPTION
The calculation used to transform the `rcCommand[THROTTLE]` value to a throttle value used in the mixer was incorrectly applying the `min_check` range a second time. This leads to the mixer throttle value scaling incorrectly and adds an additional deadzone at the low range that basically doubles the `min_check` range.  The `rcCommand[THROTTLE]` value is already reduced by `min_check` and then scaled to 1000 - 2000. So the mixer doesn't need to reapply `min_check`.

During analysis and subsequent fix testing, added the following debugging (not included in PR):
```
        DEBUG_SET(DEBUG_MIXER_THROTTLE, 0, rcData[THROTTLE]);
        DEBUG_SET(DEBUG_MIXER_THROTTLE, 1, rcCommand[THROTTLE]);
        throttle = rcCommand[THROTTLE] - rxConfig()->mincheck + throttleAngleCorrection;
        DEBUG_SET(DEBUG_MIXER_THROTTLE, 2, throttle);
        currentThrottleInputRange = rcCommandThrottleRange;
        motorRangeMin = motorOutputLow;
        motorRangeMax = motorOutputHigh;
        motorOutputMin = motorOutputLow;
        motorOutputRange = motorOutputHigh - motorOutputLow;
        motorOutputMixSign = 1;
    }

    throttle = constrainf(throttle / currentThrottleInputRange, 0.0f, 1.0f);
    DEBUG_SET(DEBUG_MIXER_THROTTLE, 3, throttle * 100);
```
The debugging is:
```
debug[0] == raw rcData[THROTTLE]
debug[1] == rcCommand[THROTTLE]
debug[2] == the initial throttle calc where min_check is subtracted
debug[3] == the final float mixer throttle scaled from 0.0 - 1.0
```
Here's the results before the fix (`min_check` setting is default 1050):

![incorrect_mixer_throttle](https://user-images.githubusercontent.com/17088539/51775047-657dd380-20c2-11e9-8a8e-ea9812192dab.png)

Note the red section showing the throttle value going negative because we're subtracting `min_check` (1050) from the `rcCommand` values starting at 1000. After the scaling to a float (again with the wrong range), the value is constrained to the range 0.0 - 1.0.  This prevents the negative throttle, but the net effect is additional deadzone as indicated by the blue section.

Next is the same logging after the fix:

![fixed_mixer_throttle](https://user-images.githubusercontent.com/17088539/51775297-43388580-20c3-11e9-9bee-b616f2f08b73.png)

Note that the mixer throttle values become non-zero as soon as the raw `rcData` values reach 1050 (`min_check`). No additional deadzone and the throttle values are calculated correctly.