### PR TITLE
Support split, non-blocking I2C transactions

### DIFF
--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -52,6 +52,31 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
     }
 }
 
+bool busWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data)
+{
+#if !defined(USE_SPI) && !defined(USE_I2C)
+    UNUSED(reg);
+    UNUSED(data);
+#endif
+    switch (busdev->bustype) {
+#ifdef USE_SPI
+    case BUSTYPE_SPI:
+#ifdef USE_SPI_TRANSACTION
+        // XXX Watch out fastpath users, if any
+        return spiBusTransactionWriteRegister(busdev, reg & 0x7f, data);
+#else
+        return spiBusWriteRegister(busdev, reg & 0x7f, data);
+#endif
+#endif
+#ifdef USE_I2C
+    case BUSTYPE_I2C:
+        return i2cBusWriteRegisterStart(busdev, reg, data);
+#endif
+    default:
+        return false;
+    }
+}
+
 bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
 {
 #if !defined(USE_SPI) && !defined(USE_I2C)
@@ -72,6 +97,58 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
 #ifdef USE_I2C
     case BUSTYPE_I2C:
         return i2cBusReadRegisterBuffer(busdev, reg, data, length);
+#endif
+    default:
+        return false;
+    }
+}
+
+// Start the I2C read, but do not wait for completion
+bool busReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
+{
+#if !defined(USE_SPI) && !defined(USE_I2C)
+    UNUSED(reg);
+    UNUSED(data);
+    UNUSED(length);
+#endif
+    switch (busdev->bustype) {
+#ifdef USE_SPI
+    case BUSTYPE_SPI:
+    	// For SPI allow the transaction to complete
+#ifdef USE_SPI_TRANSACTION
+        // XXX Watch out fastpath users, if any
+        return spiBusTransactionReadRegisterBuffer(busdev, reg | 0x80, data, length);
+#else
+        return spiBusReadRegisterBuffer(busdev, reg | 0x80, data, length);
+#endif
+#endif
+#ifdef USE_I2C
+    case BUSTYPE_I2C:
+    	// Initiate the read access
+        return i2cBusReadRegisterBufferStart(busdev, reg, data, length);
+#endif
+    default:
+        return false;
+    }
+}
+
+// Returns true if bus is still busy
+bool busBusy(const busDevice_t *busdev, bool *error)
+{
+#if !defined(USE_I2C)
+    UNUSED(error);
+#endif
+    switch (busdev->bustype) {
+#ifdef USE_SPI
+    case BUSTYPE_SPI:
+    	// No waiting on SPI
+#ifdef USE_SPI_TRANSACTION
+        return false;
+#endif
+#endif
+#ifdef USE_I2C
+    case BUSTYPE_I2C:
+        return i2cBusBusy(busdev, error);
 #endif
     default:
         return false;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -66,5 +66,8 @@ void targetBusInit(void);
 #endif
 
 bool busWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool busWriteRegisterStart(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool busReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t busReadRegister(const busDevice_t *bus, uint8_t reg);
+bool busReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
+bool busBusy(const busDevice_t *busdev, bool *error);

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -60,6 +60,8 @@ void i2cHardwareConfigure(const struct i2cConfig_s *i2cConfig);
 void i2cInit(I2CDevice device);
 bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data);
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
 bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
+bool i2cBusy(I2CDevice device, bool *error);
 
 uint16_t i2cGetErrorCounter(void);

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -34,6 +34,16 @@ bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
     return i2cWrite(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, data);
 }
 
+bool i2cBusWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data)
+{
+	// Need a static value, not on the stack
+	static uint8_t byte;
+
+	byte = data;
+
+    return i2cWriteBuffer(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, sizeof (byte), &byte);
+}
+
 bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
 {
     return i2cRead(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, length, data);
@@ -45,4 +55,15 @@ uint8_t i2cBusReadRegister(const busDevice_t *busdev, uint8_t reg)
     i2cRead(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, 1, &data);
     return data;
 }
+
+bool i2cBusReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
+{
+    return i2cReadBuffer(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, length, data);
+}
+
+bool i2cBusBusy(const busDevice_t *busdev, bool *error)
+{
+	return i2cBusy(busdev->busdev_u.i2c.device, error);
+}
+
 #endif

--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -21,5 +21,8 @@
 #pragma once
 
 bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data);
+bool i2cBusWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data);
 bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t i2cBusReadRegister(const busDevice_t *bus, uint8_t reg);
+bool i2cBusReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
+bool i2cBusBusy(const busDevice_t *busdev, bool *error);

--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -193,6 +193,8 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
     return i2cWriteBuffer(device, addr_, reg_, 1, &data);
 }
 
+
+// Blocking read
 bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device > I2CDEV_COUNT) {
@@ -216,6 +218,21 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
         return i2cHandleHardwareFailure(device);
 
     return true;
+}
+
+// TODO This should be a non-blocking read.
+// This is only important if an F7 card uses an I2C device in it's main loop
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+{
+    return i2cRead(device, addr_, reg_, len, buf);
+}
+
+bool i2cBusy(I2CDevice device, bool *error)
+{
+	UNUSED(device);
+	UNUSED(error);
+
+    return false;
 }
 
 void i2cInit(I2CDevice device)

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -168,12 +168,15 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
     }
 
     I2C_TypeDef *I2Cx = i2cDevice[device].reg;
-
     if (!I2Cx) {
         return false;
     }
 
     i2cState_t *state = &i2cDevice[device].state;
+    if (state->busy) {
+        return false;
+    }
+
     uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
     state->addr = addr_ << 1;
@@ -196,32 +199,52 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
         I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
     }
 
-    timeout = I2C_DEFAULT_TIMEOUT;
+    return true;
+}
+
+bool i2cBusy(I2CDevice device, bool *error)
+{
+    i2cState_t *state = &i2cDevice[device].state;
+
+    if (error) {
+    	*error = state->error;
+    }
+    return state->busy;
+}
+
+bool i2cWait(I2CDevice device)
+{
+    i2cState_t *state = &i2cDevice[device].state;
+    uint32_t timeout = I2C_DEFAULT_TIMEOUT;
+
     while (state->busy && --timeout > 0) {; }
     if (timeout == 0)
-        return i2cHandleHardwareFailure(device);
+        return i2cHandleHardwareFailure(device) && i2cWait(device);
 
     return !(state->error);
 }
 
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
 {
-    return i2cWriteBuffer(device, addr_, reg_, 1, &data);
+    return i2cWriteBuffer(device, addr_, reg_, 1, &data) && i2cWait(device);
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device > I2CDEV_COUNT) {
         return false;
     }
 
     I2C_TypeDef *I2Cx = i2cDevice[device].reg;
-
     if (!I2Cx) {
         return false;
     }
 
     i2cState_t *state = &i2cDevice[device].state;
+    if (state->busy) {
+        return false;
+    }
+
     uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
     state->addr = addr_ << 1;
@@ -244,13 +267,14 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
         I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
     }
 
-    timeout = I2C_DEFAULT_TIMEOUT;
-    while (state->busy && --timeout > 0) {; }
-    if (timeout == 0)
-        return i2cHandleHardwareFailure(device);
-
-    return !(state->error);
+    return true;
 }
+
+bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+{
+    return i2cReadBuffer(device, addr_, reg_, len, buf) && i2cWait(device);
+}
+
 
 static void i2c_er_handler(I2CDevice device) {
 

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -284,4 +284,27 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
     return true;
 }
 
+bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+{
+	bool status = true;
+
+	for (uint8_t i = 0; i < len_; i++) {
+		status &= i2cWrite(device, addr_, reg_ + i, data[i]);
+	}
+
+	return status;
+}
+
+bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
+{
+	return i2cRead(device, addr_, reg, len, buf);
+}
+
+bool i2cBusy(I2CDevice device, bool *error)
+{
+	UNUSED(device);
+	UNUSED(error);
+
+    return false;
+}
 #endif


### PR DESCRIPTION
The MS5611 baro used on a number of FCs needs to be read using the BARO task and takes well over 100us. This is too slow and causes delays/jitter in the PID loop. To solution to this is addressed in https://github.com/betaflight/betaflight/pull/7455, but it requires I2C bus driver changes to support non-blocking transfers. Hence this PR.