### PR TITLE
Support for swapping USART RX and TX pins on F3, F7

### DIFF
--- a/make/mcu/STM32F3.mk
+++ b/make/mcu/STM32F3.mk
@@ -85,6 +85,7 @@ MCU_COMMON_SRC = \
             drivers/pwm_output_dshot.c \
             drivers/serial_uart_init.c \
             drivers/serial_uart_stm32f30x.c \
+            drivers/serial_uart_pinselect_generic.c \
             drivers/system_stm32f30x.c \
             drivers/timer_stm32f30x.c
 

--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -181,6 +181,7 @@ MCU_COMMON_SRC = \
             drivers/pwm_output_dshot.c \
             drivers/serial_uart_init.c \
             drivers/serial_uart_stm32f4xx.c \
+            drivers/serial_uart_pinselect_f4.c \
             drivers/system_stm32f4xx.c \
             drivers/timer_stm32f4xx.c \
             drivers/persistent.c

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -183,7 +183,8 @@ MCU_COMMON_SRC = \
             drivers/timer_stm32f7xx.c \
             drivers/system_stm32f7xx.c \
             drivers/serial_uart_stm32f7xx.c \
-            drivers/serial_uart_hal.c
+            drivers/serial_uart_hal.c \
+            drivers/serial_uart_pinselect_generic.c
 
 MCU_EXCLUDES = \
             drivers/bus_i2c.c \

--- a/src/main/drivers/serial_uart_pinconfig.c
+++ b/src/main/drivers/serial_uart_pinconfig.c
@@ -44,24 +44,20 @@
 FAST_RAM_ZERO_INIT uartDevice_t uartDevice[UARTDEV_COUNT];      // Only those configured in target.h
 FAST_RAM_ZERO_INIT uartDevice_t *uartDevmap[UARTDEV_COUNT_MAX]; // Full array
 
+
+void uartPinSelect(uartDevice_t *device, const uartHardware_t *hardware, ioTag_t requestedRxTag, ioTag_t requestedTxTag);
+
 void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig)
 {
     uartDevice_t *uartdev = uartDevice;
 
     for (size_t hindex = 0; hindex < UARTDEV_COUNT; hindex++) {
-
         const uartHardware_t *hardware = &uartHardware[hindex];
         const UARTDevice_e device = hardware->device;
+        const ioTag_t requestedRxTag = pSerialPinConfig->ioTagRx[device];
+        const ioTag_t requestedTxTag = pSerialPinConfig->ioTagTx[device];
 
-        for (int pindex = 0 ; pindex < UARTHARDWARE_MAX_PINS ; pindex++) {
-            if (hardware->rxPins[pindex].pin == pSerialPinConfig->ioTagRx[device]) {
-                uartdev->rx = hardware->rxPins[pindex];
-            }
-
-            if (hardware->txPins[pindex].pin == pSerialPinConfig->ioTagTx[device]) {
-                uartdev->tx = hardware->txPins[pindex];
-            }
-        }
+        uartPinSelect(uartdev, hardware, requestedRxTag, requestedTxTag);
 
         if (uartdev->rx.pin || uartdev->tx.pin) {
             uartdev->hardware = hardware;

--- a/src/main/drivers/serial_uart_pinselect_f4.c
+++ b/src/main/drivers/serial_uart_pinselect_f4.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#ifdef USE_UART
+
+#include "drivers/rcc.h"
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
+#include "drivers/serial_uart_impl.h"
+
+void uartPinSelect(
+    uartDevice_t *device, const uartHardware_t *hardware, ioTag_t requestedRxTag, ioTag_t requestedTxTag)
+{
+    for (int pindex = 0; pindex < UARTHARDWARE_MAX_PINS; pindex++) {
+        const uartPinDef_t hardwareRxPin = hardware->rxPins[pindex];
+        const uartPinDef_t hardwareTxPin = hardware->txPins[pindex];
+
+        if (hardwareRxPin.pin == requestedRxTag) {
+            device->rx = hardwareRxPin;
+        }
+
+        if (hardwareTxPin.pin == requestedTxTag) {
+            device->tx = hardwareTxPin;
+        }
+
+        // STM32F4xx does not support RX and TX pin swapping
+    }
+}
+
+#endif

--- a/src/main/drivers/serial_uart_pinselect_generic.c
+++ b/src/main/drivers/serial_uart_pinselect_generic.c
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#ifdef USE_UART
+
+#include "drivers/rcc.h"
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
+#include "drivers/serial_uart_impl.h"
+
+void uartPinSelect(
+    uartDevice_t *device, const uartHardware_t *hardware, ioTag_t requestedRxTag, ioTag_t requestedTxTag)
+{
+    bool swapRequired = false;
+
+    for (int pindex = 0; pindex < UARTHARDWARE_MAX_PINS; pindex++) {
+        const uartPinDef_t hardwareRxPin = hardware->rxPins[pindex];
+        const uartPinDef_t hardwareTxPin = hardware->txPins[pindex];
+
+        if (hardwareRxPin.pin == requestedRxTag) {
+            device->rx = hardwareRxPin;
+        }
+
+        if (hardwareTxPin.pin == requestedTxTag) {
+            device->tx = hardwareTxPin;
+        }
+
+        // STM32F30x and STM32F7xx support RX and TX pin swapping
+        if (hardwareTxPin.pin == requestedRxTag) {
+            device->rx = hardwareTxPin;
+            swapRequired = true;
+        }
+
+        if (hardwareRxPin.pin == requestedTxTag) {
+            device->tx = hardwareRxPin;
+            swapRequired = true;
+        }
+    }
+
+    if (swapRequired) {
+        SET_BIT(hardware->reg->CR2, USART_CR2_SWAP);
+    } else {
+        CLEAR_BIT(hardware->reg->CR2, USART_CR2_SWAP);
+    }
+}
+
+#endif


### PR DESCRIPTION
With configurable USART inversion on F3/F7/H7 came the ability to swap RX and TX functions, allowing for either cross-wired USART communication.
There are FCs and RTF drones which have only the RX pin broken out for receiver, making it impossible to connect new half-duplex receivers running FPORT or SRXL protocols.

With this feature, users can now reassign RX pin resource as TX, enabling them to run bidirectional one-wire protocols.

Tested on an OMNIBUS, will test on a NERO later.