### PR TITLE
Changed OSD stick overlay to use custom symbols.

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -37,11 +37,13 @@
 #define SYM_HOME                    0x04
 #define SYM_AIRCRAFT                0x05
 
-// Unit Icon´s (Metric)
+// Unit Icons (Metric)
 #define SYM_M                       0x0C
+#define SYM_C                       0x0E
 
-// Unit Icon´s (Imperial)
+// Unit Icons (Imperial)
 #define SYM_FT                      0x0F
+#define SYM_F                       0x0D
 
 // Heading Graphics
 #define SYM_HEADING_N               0x18
@@ -124,3 +126,11 @@
 
 // Menu cursor
 #define SYM_CURSOR                  SYM_AH_LEFT
+
+// Stick overlays
+#define SYM_STICK_OVERLAY_SPRITE_HIGH 0x08
+#define SYM_STICK_OVERLAY_SPRITE_MID  0x09
+#define SYM_STICK_OVERLAY_SPRITE_LOW  0x0A
+#define SYM_STICK_OVERLAY_CENTER      0x0B
+#define SYM_STICK_OVERLAY_VERTICAL    0x16
+#define SYM_STICK_OVERLAY_HORIZONTAL  0x17

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -109,15 +109,8 @@
 // Stick overlay size
 #define OSD_STICK_OVERLAY_WIDTH 7
 #define OSD_STICK_OVERLAY_HEIGHT 5
-#define OSD_STICK_OVERLAY_CHARACTER_HEIGHT 3
-#define OSD_STICK_OVERLAY_VERTICAL_POSITIONS (OSD_STICK_OVERLAY_HEIGHT * OSD_STICK_OVERLAY_CHARACTER_HEIGHT)
-
-#define STICK_OVERLAY_HORIZONTAL_CHAR   '-'
-#define STICK_OVERLAY_VERTICAL_CHAR     '|'
-#define STICK_OVERLAY_CROSS_CHAR        '+'
-#define STICK_OVERLAY_CURSOR_LOW_CHAR   0x86
-#define STICK_OVERLAY_CURSOR_MID_CHAR   0x84
-#define STICK_OVERLAY_CURSOR_HIGH_CHAR  0x82
+#define OSD_STICK_OVERLAY_SPRITE_HEIGHT 3
+#define OSD_STICK_OVERLAY_VERTICAL_POSITIONS (OSD_STICK_OVERLAY_HEIGHT * OSD_STICK_OVERLAY_SPRITE_HEIGHT)
 
 const char * const osdTimerSourceNames[] = {
     "ON TIME  ",
@@ -326,9 +319,9 @@ static char osdGetTemperatureSymbolForSelectedUnit(void)
 {
     switch (osdConfig()->units) {
     case OSD_UNIT_IMPERIAL:
-        return 'F';
+        return SYM_F;
     default:
-        return 'C';
+        return SYM_C;
     }
 }
 #endif
@@ -1306,11 +1299,11 @@ static void osdDrawStickOverlayAxis(uint8_t xpos, uint8_t ypos)
         for (unsigned  y = 0; y < OSD_STICK_OVERLAY_HEIGHT; y++) {
             // draw the axes, vertical and horizonal
             if ((x == ((OSD_STICK_OVERLAY_WIDTH - 1) / 2)) && (y == (OSD_STICK_OVERLAY_HEIGHT - 1) / 2)) {
-                displayWriteChar(osdDisplayPort, xpos + x, ypos + y, STICK_OVERLAY_CROSS_CHAR);
+                displayWriteChar(osdDisplayPort, xpos + x, ypos + y, SYM_STICK_OVERLAY_CENTER);
             } else if (x == ((OSD_STICK_OVERLAY_WIDTH - 1) / 2)) {
-                displayWriteChar(osdDisplayPort, xpos + x, ypos + y, STICK_OVERLAY_VERTICAL_CHAR);
+                displayWriteChar(osdDisplayPort, xpos + x, ypos + y, SYM_STICK_OVERLAY_VERTICAL);
             } else if (y == ((OSD_STICK_OVERLAY_HEIGHT - 1) / 2)) {
-                displayWriteChar(osdDisplayPort, xpos + x, ypos + y, STICK_OVERLAY_HORIZONTAL_CHAR);
+                displayWriteChar(osdDisplayPort, xpos + x, ypos + y, SYM_STICK_OVERLAY_HORIZONTAL);
             }
         }
     }
@@ -1346,23 +1339,9 @@ static void osdDrawStickOverlayCursor(osd_items_e osd_item)
     const uint8_t x_pos = scaleRange(constrain(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
     const uint8_t y_pos = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - scaleRange(constrain(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS);
 
-    char cursor;
-    switch (y_pos % OSD_STICK_OVERLAY_CHARACTER_HEIGHT) {
-    case 0:
-        cursor = STICK_OVERLAY_CURSOR_HIGH_CHAR;
+    const char cursor = SYM_STICK_OVERLAY_SPRITE_HIGH + (y_pos % OSD_STICK_OVERLAY_SPRITE_HEIGHT);
 
-        break;
-    case 1:
-        cursor = STICK_OVERLAY_CURSOR_MID_CHAR;
-
-        break;
-    case 2:
-        cursor = STICK_OVERLAY_CURSOR_LOW_CHAR;
-
-        break;
-    }
-
-    osdDrawStickOverlayPos(osd_item, x_pos, y_pos / OSD_STICK_OVERLAY_CHARACTER_HEIGHT, cursor);
+    osdDrawStickOverlayPos(osd_item, x_pos, y_pos / OSD_STICK_OVERLAY_SPRITE_HEIGHT, cursor);
 }
 #endif
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -811,7 +811,7 @@ TEST(OsdTest, TestElementCoreTemperature)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 8, "  0C");
+    displayPortTestBufferSubstring(1, 8, "  0%c", SYM_C);
 
     // given
     simulationCoreTemperature = 33;
@@ -821,7 +821,7 @@ TEST(OsdTest, TestElementCoreTemperature)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 8, " 33C");
+    displayPortTestBufferSubstring(1, 8, " 33%c", SYM_C);
 
     // given
     osdConfigMutable()->units = OSD_UNIT_IMPERIAL;
@@ -831,7 +831,7 @@ TEST(OsdTest, TestElementCoreTemperature)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(1, 8, " 91F");
+    displayPortTestBufferSubstring(1, 8, " 91%c", SYM_F);
 }
 
 /*


### PR DESCRIPTION
Relies on the updated fonts supplied in betaflight/betaflight-configurator#1285, and on the user uploading an updated font before using it.

The updated fonts have 6 currently unused symbols replaced with the symbols used for the overlay, allowing the use of optimised symbols for the sprite used for vertical movement of the sticks.