### PR TITLE
Airmode noise fix

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1012,6 +1012,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_THRUST_LINEARIZATION
     { "thrust_linear",              VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearization) },
 #endif
+#ifdef USE_AIRMODE_LPF
+    { "transient_throttle_limit",   VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },
+#endif
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -117,6 +117,10 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 #define ACRO_TRAINER_SETPOINT_LIMIT       1000.0f // Limit the correcting setpoint
 #endif // USE_ACRO_TRAINER
 
+#ifdef USE_AIRMODE_LPF
+static FAST_RAM_ZERO_INIT float airmodeThrottleOffsetLimit;
+#endif
+
 #define ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF 15  // The anti gravity throttle highpass filter cutoff
 
 #define CRASH_RECOVERY_DETECTION_DELAY_US 1000000  // 1 second delay before crash recovery detection is active after entering a self-level mode
@@ -196,6 +200,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .d_min_advance = 20,
         .motor_output_limit = 100,
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
+        .transient_throttle_limit = 0,
     );
 #ifdef USE_DYN_LPF
     pidProfile->dterm_lowpass_hz = 150;
@@ -286,6 +291,11 @@ static FAST_RAM_ZERO_INIT bool setpointDerivativeLpfInitialized;
 static FAST_RAM_ZERO_INIT uint8_t rcSmoothingDebugAxis;
 static FAST_RAM_ZERO_INIT uint8_t rcSmoothingFilterType;
 #endif // USE_RC_SMOOTHING_FILTER
+
+#ifdef USE_AIRMODE_LPF
+static FAST_RAM_ZERO_INIT pt1Filter_t airmodeThrottleLpf1;
+static FAST_RAM_ZERO_INIT pt1Filter_t airmodeThrottleLpf2;
+#endif
 
 static FAST_RAM_ZERO_INIT pt1Filter_t antiGravityThrottleLpf;
 
@@ -414,6 +424,12 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         biquadFilterInitLPF(&dMinRange[axis], D_MIN_RANGE_HZ, targetPidLooptime);
         pt1FilterInit(&dMinLowpass[axis], pt1FilterGain(D_MIN_LOWPASS_HZ, dT));
      }
+#endif
+#if defined(USE_AIRMODE_LPF)
+    if (pidProfile->transient_throttle_limit) {
+        pt1FilterInit(&airmodeThrottleLpf1, pt1FilterGain(7.0f, dT));
+        pt1FilterInit(&airmodeThrottleLpf2, pt1FilterGain(20.0f, dT));
+    }
 #endif
 
     pt1FilterInit(&antiGravityThrottleLpf, pt1FilterGain(ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF, dT));
@@ -673,6 +689,9 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     dMinGyroGain = pidProfile->d_min_gain * D_MIN_GAIN_FACTOR / D_MIN_LOWPASS_HZ;
     dMinSetpointGain = pidProfile->d_min_gain * D_MIN_SETPOINT_GAIN_FACTOR * pidProfile->d_min_advance * pidFrequency / (100 * D_MIN_LOWPASS_HZ);
     // lowpass included inversely in gain since stronger lowpass decreases peak effect
+#endif
+#if defined(USE_AIRMODE_LPF)
+    airmodeThrottleOffsetLimit = pidProfile->transient_throttle_limit / 100.0f;
 #endif
 }
 
@@ -1114,6 +1133,31 @@ STATIC_UNIT_TESTED void applyItermRelax(const int axis, const float iterm,
         applyAbsoluteControl(axis, gyroRate, currentPidSetpoint, itermErrorRate);
 #endif
     }
+}
+#endif
+
+#ifdef USE_AIRMODE_LPF
+void pidUpdateAirmodeLpf(float currentOffset)
+{
+    if (airmodeThrottleOffsetLimit == 0.0f) {
+        return;
+    }
+
+    float offsetHpf = currentOffset * 2.5f;
+    offsetHpf = offsetHpf - pt1FilterApply(&airmodeThrottleLpf2, offsetHpf);
+
+    // During high frequency oscillation 2 * currentOffset averages to the offset required to avoid mirroring of the waveform
+    pt1FilterApply(&airmodeThrottleLpf1, offsetHpf);
+    // Bring offset up immediately so the filter only applies to the decline
+    if (currentOffset * airmodeThrottleLpf1.state >= 0 && fabsf(currentOffset) > airmodeThrottleLpf1.state) {
+        airmodeThrottleLpf1.state = currentOffset;
+    }
+    airmodeThrottleLpf1.state = constrainf(airmodeThrottleLpf1.state, -airmodeThrottleOffsetLimit, airmodeThrottleOffsetLimit);
+}
+
+float pidGetAirmodeThrottleOffset()
+{
+    return airmodeThrottleLpf1.state;
 }
 #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -165,6 +165,7 @@ typedef struct pidProfile_s {
     uint8_t d_min_advance;                  // Percentage multiplier for setpoint input to boost algorithm
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
+    uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -219,6 +220,10 @@ bool pidAntiGravityEnabled(void);
 #ifdef USE_THRUST_LINEARIZATION
 float pidApplyThrustLinearization(float motorValue);
 float pidCompensateThrustLinearization(float throttle);
+#endif
+#ifdef USE_AIRMODE_LPF
+void pidUpdateAirmodeLpf(float currentOffset);
+float pidGetAirmodeThrottleOffset();
 #endif
 
 #ifdef UNIT_TEST

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -258,6 +258,7 @@
 #endif // FLASH_SIZE > 128
 
 #if (FLASH_SIZE > 256)
+#define USE_AIRMODE_LPF
 #define USE_DASHBOARD
 #define USE_GPS
 #define USE_GPS_NMEA


### PR DESCRIPTION
When air mode increases or decreases throttle near idle or max throttle it often increases noise as it leads to motor waveforms that are not c1 continuous. This PR fixes this problem by raising or lowering airmode for a bit longer than immediately necessary to be able to fit an entire period of pid output without modifying throttle again. 

Here's an example. Note how throttle lifts to fit the whole noise waveform without locking one motor at zero.
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/18134492/51798207-6a9c6900-220f-11e9-8144-3524810bffbb.png">

Idle without fix:

<img width="1782" alt="image" src="https://user-images.githubusercontent.com/18134492/51798285-bd2a5500-2210-11e9-9d84-815940b67347.png">

Idle with fix:

<img width="1782" alt="image" src="https://user-images.githubusercontent.com/18134492/51798293-cddacb00-2210-11e9-8bc5-ca1b73b3787c.png">

Parameter is airmode_noise_reduction which limits how much throttle change is allowed. 15 is default which means airmode throttle changes of up to 15% are used in the calculations.