### PR TITLE
Added 'test-representative' make target to run a representative subset of the unit tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,9 +532,10 @@ targets-f7:
 targets-f7-print:
 	$(V1) $(MAKE) -s targets-by-mcu MCU_TYPE=STM32F7
 
-## test              : run the cleanflight test suite
-## junittest         : run the cleanflight test suite, producing Junit XML result files.
-test junittest:
+## test              : run the Betaflight test suite
+## junittest         : run the Betaflight test suite, producing Junit XML result files.
+## test-representative: run a representative subset of the Betaflight test suite (i.e. run all tests, but run each expanded test only for one target)
+test junittest test-representative:
 	$(V0) cd src/test && $(MAKE) $@
 
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -426,6 +426,8 @@ TEST_SRCS = $(sort $(wildcard $(TEST_DIR)/*.cc))
 TEST_BASENAMES = $(TEST_SRCS:$(TEST_DIR)/%.cc=%)
 TESTS = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),$(foreach \
 		target,$(filter-out $($(test)_BLACKLIST),$(VALID_TARGETS)),$(test).$(target)),$(test)))
+TESTS_REPRESENTATIVE = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),$(test).$(word \
+		1,$(filter-out $($(test)_BLACKLIST),$(VALID_TARGETS))),$(test)))
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -440,6 +442,9 @@ include ../../make/build_verbosity.mk
 
 ## test        : Build and run the Unit Tests (default goal)
 test: $(TESTS:%=test_%)
+
+## test-representative : Build and run a representative subset of the Unit Tests (i.e. run every expanded test only for the first target)
+test-representative: $(TESTS_REPRESENTATIVE:%=test_%)
 
 ## junittest   : Build and run the Unit Tests, producing Junit XML result files."
 junittest: EXEC_OPTS = "--gtest_output=xml:$<_results.xml"


### PR DESCRIPTION
This intended to be used by developers verifying that their changes do not break any tests, and not wanting to spend the extra minutes for the tests against 150+ targets to run if their changes do not contain target changes.