### PR TITLE
NAZE: remove USE_LED_STRIP to fit flash

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -119,6 +119,8 @@
 //#define RANGEFINDER_HCSR04_TRIGGER_PIN_PWM   PB8
 //#define RANGEFINDER_HCSR04_ECHO_PIN_PWM      PB9
 
+#undef USE_LED_STRIP
+
 #define USE_UART1
 #define USE_UART2
 /* only 2 uarts available on the NAZE, add ifdef here if present on other boards */


### PR DESCRIPTION
This PR removes the USE_LED_STRIP feature from the NAZE target to make it fit into flash.
I know that NAZE isn't supported anymore but I hope that this small change is still considered since it allows to build the NAZE target again and doesn't effect other targets.

(PR resubmitted to master branch as requested in https://github.com/betaflight/betaflight/pull/7477#issuecomment-457882970.)