### PR TITLE
[PINIO] Add initial state feature

### DIFF
--- a/src/main/drivers/pinio.h
+++ b/src/main/drivers/pinio.h
@@ -27,7 +27,8 @@
 #endif
 
 #define PINIO_CONFIG_OUT_INVERTED 0x80
-#define PINIO_CONFIG_MODE_MASK    0x7F
+#define PINIO_CONFIG_INIT_STATE   0x40  // 0 = logic low, 1 = logic high
+#define PINIO_CONFIG_MODE_MASK    0x3F
 #define PINIO_CONFIG_MODE_OUT_PP  0x01
 
 struct pinioConfig_s;


### PR DESCRIPTION
There are three points in the boot timeline that may cause a pin controlled by pinio facility to go up and down (or vice versa):

1. When a pin is initialized during reset handling. The pin is reset to input floating to input pull-up, so low to high level transition is observed. This process may be repeated few times due to soft resetting by low level startup code.

2. When the pin is initialized by `pinioInit`. The pin is set to logic false. Actual output depends on inversion configuration for the pin.

3. When the pin is set to some logic level through piniobox facility. Actual output depends on on/off state of the box.

While up-down/down-up by 1 and 2 are inevitable with current startup code, they occur in msec order, so they are least harmful in an actual application. However, interval between 2 and 3 may be sub-second order, this may cause a problem.

~This PR provides a new pinio config variable `pinio_init`, which specifies initial logic level of a pin.~
~

6th bit of `pinio_config` determines initial logic state at pinio initialization.