### PR TITLE
Expand Crossfire telemetry to include additional modes and unarmed/arming disabled status

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -266,31 +266,33 @@ void crsfFrameFlightMode(sbuf_t *dst)
     uint8_t *lengthPtr = sbufPtr(dst);
     sbufWriteU8(dst, 0);
     sbufWriteU8(dst, CRSF_FRAMETYPE_FLIGHT_MODE);
-
-    // Acro is the default mode
-    const char *flightMode = "ACRO";
-
+    const char *flightMode = "";
+    
+    if (ARMING_FLAG(ARMED)) {
+        // Armed flight modes in decreasing order of importance
+        if (FLIGHT_MODE(FAILSAFE_MODE)) {
+            flightMode = "!FS!";
+        } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+            flightMode = "RTH";
+        } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
+            flightMode = "MANU";
+        } else if (FLIGHT_MODE(ANGLE_MODE)) {
+            flightMode = "STAB";
+        } else if (FLIGHT_MODE(HORIZON_MODE)) {
+            flightMode = "HOR";
+        } else if (airmodeIsEnabled()) {
+            flightMode = "AIR";
+        } else {
+            flightMode = "ACRO";
+        }
 #ifdef USE_GPS
-    if (!ARMING_FLAG(ARMED) && featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
+    } else if (featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
         flightMode = "WAIT"; // Waiting for GPS lock
-    } else
 #endif
-
-    // Flight modes in decreasing order of importance
-    if (FLIGHT_MODE(FAILSAFE_MODE)) {
-        flightMode = "!FS!";
     } else if (isArmingDisabled()) {
         flightMode = "!ERR";
-    } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-        flightMode = "RTH";
-    } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
-        flightMode = "MANU";
-    } else if (FLIGHT_MODE(ANGLE_MODE)) {
-        flightMode = "STAB";
-    } else if (FLIGHT_MODE(HORIZON_MODE)) {
-        flightMode = "HOR";
-    } else if (airmodeIsEnabled()) {
-        flightMode = "AIR";
+    } else {
+        flightMode = "OK"; // Ready to arm
     }
 
     sbufWriteString(dst, flightMode);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -268,11 +268,13 @@ void crsfFrameFlightMode(sbuf_t *dst)
     sbufWriteU8(dst, CRSF_FRAMETYPE_FLIGHT_MODE);
     const char *flightMode = "";
     
-    if (ARMING_FLAG(ARMED)) {
+    if (FLIGHT_MODE(FAILSAFE_MODE)) {
+        flightMode = "!FS!";
+    } else if (isArmingDisabled()) {
+        flightMode = "!ERR";
+    } else if (ARMING_FLAG(ARMED)) {
         // Armed flight modes in decreasing order of importance
-        if (FLIGHT_MODE(FAILSAFE_MODE)) {
-            flightMode = "!FS!";
-        } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+        } if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
             flightMode = "RTH";
         } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
             flightMode = "MANU";
@@ -289,8 +291,6 @@ void crsfFrameFlightMode(sbuf_t *dst)
     } else if (featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
         flightMode = "WAIT"; // Waiting for GPS lock
 #endif
-    } else if (isArmingDisabled()) {
-        flightMode = "!ERR";
     } else {
         flightMode = "OK"; // Ready to arm
     }

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -267,17 +267,30 @@ void crsfFrameFlightMode(sbuf_t *dst)
     sbufWriteU8(dst, 0);
     sbufWriteU8(dst, CRSF_FRAMETYPE_FLIGHT_MODE);
 
-    // use same logic as OSD, so telemetry displays same flight text as OSD
-    const char *flightMode = "ACRO";
-    if (airmodeIsEnabled()) {
-        flightMode = "AIR";
-    }
-    if (FLIGHT_MODE(FAILSAFE_MODE)) {
-        flightMode = "!FS";
-    } else if (FLIGHT_MODE(ANGLE_MODE)) {
-        flightMode = "STAB";
-    } else if (FLIGHT_MODE(HORIZON_MODE)) {
-        flightMode = "HOR";
+    // just do "OK" for the moment as a placeholder
+    const char *flightMode = "OK";
+    if (ARMING_FLAG(ARMED)) {
+        if (FLIGHT_MODE(FAILSAFE_MODE)) {
+            flightMode = "!FS!";
+        } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+            flightMode = "RTH";
+        } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
+            flightMode = "MANU";
+        } else if (FLIGHT_MODE(ANGLE_MODE)) {
+            flightMode = "STAB";
+        } else if (FLIGHT_MODE(HORIZON_MODE)) {
+            flightMode = "HOR";
+        } else if (airmodeIsEnabled()) {
+            flightMode = "AIR";
+        } else {
+            flightMode = "ACRO";
+        }
+#ifdef USE_GPS
+    } else if (featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
+        flightMode = "WAIT"; // Waiting for GPS lock
+#endif
+    } else if (isArmingDisabled()) {
+        flightMode = "!ERR";
     }
     sbufWriteString(dst, flightMode);
     sbufWriteU8(dst, '\0');     // zero-terminate string

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -267,31 +267,32 @@ void crsfFrameFlightMode(sbuf_t *dst)
     sbufWriteU8(dst, 0);
     sbufWriteU8(dst, CRSF_FRAMETYPE_FLIGHT_MODE);
 
-    // just do "OK" for the moment as a placeholder
-    const char *flightMode = "OK";
-    if (ARMING_FLAG(ARMED)) {
-        if (FLIGHT_MODE(FAILSAFE_MODE)) {
-            flightMode = "!FS!";
-        } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-            flightMode = "RTH";
-        } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
-            flightMode = "MANU";
-        } else if (FLIGHT_MODE(ANGLE_MODE)) {
-            flightMode = "STAB";
-        } else if (FLIGHT_MODE(HORIZON_MODE)) {
-            flightMode = "HOR";
-        } else if (airmodeIsEnabled()) {
-            flightMode = "AIR";
-        } else {
-            flightMode = "ACRO";
-        }
+    // Acro is the default mode
+    const char *flightMode = "ACRO";
+
 #ifdef USE_GPS
-    } else if (featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
+    if (!ARMING_FLAG(ARMED) && featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
         flightMode = "WAIT"; // Waiting for GPS lock
+    } else
 #endif
+
+    // Flight modes in decreasing order of importance
+    if (FLIGHT_MODE(FAILSAFE_MODE)) {
+        flightMode = "!FS!";
     } else if (isArmingDisabled()) {
         flightMode = "!ERR";
+    } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+        flightMode = "RTH";
+    } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
+        flightMode = "MANU";
+    } else if (FLIGHT_MODE(ANGLE_MODE)) {
+        flightMode = "STAB";
+    } else if (FLIGHT_MODE(HORIZON_MODE)) {
+        flightMode = "HOR";
+    } else if (airmodeIsEnabled()) {
+        flightMode = "AIR";
     }
+
     sbufWriteString(dst, flightMode);
     sbufWriteU8(dst, '\0');     // zero-terminate string
     // write in the frame length

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -215,6 +215,8 @@ TEST(TelemetryCrsfTest, TestAttitude)
 TEST(TelemetryCrsfTest, TestFlightMode)
 {
     uint8_t frame[CRSF_FRAME_SIZE_MAX];
+    ENABLE_STATE(GPS_FIX);
+    ENABLE_STATE(GPS_FIX_HOME);
 
     // nothing set, so ACRO mode
     airMode = false;


### PR DESCRIPTION
Bonus: Allows Betaflight to work with https://github.com/iNavFlight/LuaTelemetry when using Crossfire