### PR TITLE
add support for built in bluetooth uart config

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -147,6 +147,14 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
     }
 #endif
 
+#if defined(BLUETOOTH_MSP_UART) && defined(BLUETOOTH_MSP_BAUDRATE)
+    serialPortConfig_t *bluetoothUartConfig = serialFindPortConfiguration(BLUETOOTH_MSP_UART);
+    if (bluetoothUartConfig) {
+        bluetoothUartConfig->functionMask = FUNCTION_MSP;
+        bluetoothUartConfig->msp_baudrateIndex = BLUETOOTH_MSP_BAUDRATE;
+    }
+#endif
+
     serialConfig->reboot_character = 'R';
     serialConfig->serial_update_rate_hz = 100;
 }


### PR DESCRIPTION
Hi,

Since we release the flight controller with built in bluetooth chip, there are some customer met a problem they can't connect FC with bluetooth. We figure out that the UART5(used for the serial passthrough with BLE) setting was lost, and the msp setting of UART5 is lost due to the invalid serial config setting.

So we want to add a default config for the bluetooth UART in the 'pgResetFn_serialConfig', then when FC received a invalid serial config, the bluetooth UART won't reset.

