### PR TITLE
Fix RealPit Inverted pinIO

### DIFF
--- a/src/main/drivers/pinio.c
+++ b/src/main/drivers/pinio.c
@@ -63,7 +63,7 @@ void pinioInit(const pinioConfig_t *pinioConfig)
         if (pinioConfig->config[i] & PINIO_CONFIG_OUT_INVERTED)
         {
             pinioRuntime[i].inverted = true;
-            IOHi(io);
+            IOLo(io);
             pinioRuntime[i].state = true;
         } else {
             pinioRuntime[i].inverted = false;

--- a/src/main/drivers/pinio.c
+++ b/src/main/drivers/pinio.c
@@ -52,9 +52,9 @@ void pinioInit(const pinioConfig_t *pinioConfig)
         switch (pinioConfig->config[i] & PINIO_CONFIG_MODE_MASK) {
         case PINIO_CONFIG_MODE_OUT_PP:
             // Initial state after reset is input, pull-up.
-            // Avoid momentary off by presetting the output to hi.
+            // Avoid momentary off by presetting the output to low.
             if (pinioConfig->config[i] & PINIO_CONFIG_OUT_INVERTED) {
-                IOHi(io);
+                IOLo(io);
             }
             IOConfigGPIO(io, IOCFG_OUT_PP);
             break;
@@ -63,11 +63,9 @@ void pinioInit(const pinioConfig_t *pinioConfig)
         if (pinioConfig->config[i] & PINIO_CONFIG_OUT_INVERTED)
         {
             pinioRuntime[i].inverted = true;
-            IOLo(io);
             pinioRuntime[i].state = true;
         } else {
             pinioRuntime[i].inverted = false;
-            IOLo(io);
             pinioRuntime[i].state = false;
         }
         pinioRuntime[i].io = io;


### PR DESCRIPTION
When VTX Pit Mode is inverted the VTX is on momentarily during boot. Changing the pin to low decreases the amount of time the vtx is on. Preventing it from transmitting before I/O Initialization.