### PR TITLE
Reduce airmode activation percent to 25

### DIFF
--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -59,7 +59,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .rcInterpolationChannels = INTERPOLATION_CHANNELS_RPYT,
         .rcInterpolationInterval = 19,
         .fpvCamAngleDegrees = 0,
-        .airModeActivateThreshold = 32,
+        .airModeActivateThreshold = 25,
         .max_aux_channel = DEFAULT_AUX_CHANNEL_COUNT,
         .rc_smoothing_type = RC_SMOOTHING_TYPE_FILTER,
         .rc_smoothing_input_cutoff = 0,      // automatically calculate the cutoff by default


### PR DESCRIPTION
In recognition of a more appropriate value based on the average hardware in use today.
