### PR TITLE
Enable FEATURE_AIRMODE by default

### DIFF
--- a/src/main/config/feature.c
+++ b/src/main/config/feature.c
@@ -32,7 +32,7 @@
 PG_REGISTER_WITH_RESET_TEMPLATE(featureConfig_t, featureConfig, PG_FEATURE_CONFIG, 0);
 
 PG_RESET_TEMPLATE(featureConfig_t, featureConfig,
-    .enabledFeatures = DEFAULT_FEATURES | DEFAULT_RX_FEATURE | FEATURE_DYNAMIC_FILTER | FEATURE_ANTI_GRAVITY,
+    .enabledFeatures = DEFAULT_FEATURES | DEFAULT_RX_FEATURE | FEATURE_DYNAMIC_FILTER | FEATURE_ANTI_GRAVITY | FEATURE_AIRMODE,
 );
 
 void featureSet(const uint32_t mask, uint32_t *features)


### PR DESCRIPTION
It's long past time for this! The vast majority of airmode related support issues we encounter involve people forgetting to enable airmode.

For the tiny percentage that still (mistakenly) believe they don't want to enable airmode, they can disable if they desire.
