### PR TITLE
Separate out target specific tests into the 'test-all' goal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 #  - PUBLISHMETA=True
 #  - PUBLISHDOCS=True
 # Specify the main Mafile supported goals.
-  - GOAL=test
+  - GOAL=test-all
   - GOAL=targets-group-1
   - GOAL=targets-group-2
   - GOAL=targets-group-3

--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,8 @@ targets-f7-print:
 ## test              : run the Betaflight test suite
 ## junittest         : run the Betaflight test suite, producing Junit XML result files.
 ## test-representative: run a representative subset of the Betaflight test suite (i.e. run all tests, but run each expanded test only for one target)
-test junittest test-representative:
+## test-all: run the Betaflight test suite including all per-target expanded tests
+test junittest test-all test-representative:
 	$(V0) cd src/test && $(MAKE) $@
 
 ## test_help         : print the help message for the test suite (including a list of the available tests)

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -424,10 +424,14 @@ endif
 # Gather up all of the tests.
 TEST_SRCS = $(sort $(wildcard $(TEST_DIR)/*.cc))
 TEST_BASENAMES = $(TEST_SRCS:$(TEST_DIR)/%.cc=%)
-TESTS = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),$(foreach \
-		target,$(filter-out $($(test)_BLACKLIST),$(VALID_TARGETS)),$(test).$(target)),$(test)))
-TESTS_REPRESENTATIVE = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),$(test).$(word \
-		1,$(filter-out $($(test)_BLACKLIST),$(VALID_TARGETS))),$(test)))
+TESTS_TARGET_SPECIFIC = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),$(test)))
+TESTS_TARGET_SPECIFIC_EXPANDED = $(foreach test,$(TESTS_TARGET_SPECIFIC),$(foreach \
+		target,$(filter-out $($(test)_BLACKLIST),$(VALID_TARGETS)),$(test).$(target)))
+
+TESTS = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),,$(test)))
+TESTS_ALL = $(TESTS) $(TESTS_TARGET_SPECIFIC_EXPANDED)
+TESTS_REPRESENTATIVE = $(TESTS) $(foreach test,$(TEST_TARGET_SPECIFIC), \
+		$(test).$(word 1,$(filter-out $($(test)_BLACKLIST),$(VALID_TARGETS))))
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -440,8 +444,11 @@ include ../../make/build_verbosity.mk
 
 # House-keeping build targets.
 
-## test        : Build and run the Unit Tests (default goal)
+## test        : Build and run the non target specific Unit Tests (default goal)
 test: $(TESTS:%=test_%)
+
+## test-all : Build and run all Unit Tests
+test-all: $(TESTS_ALL:%=test_%)
 
 ## test-representative : Build and run a representative subset of the Unit Tests (i.e. run every expanded test only for the first target)
 test-representative: $(TESTS_REPRESENTATIVE:%=test_%)
@@ -469,7 +476,7 @@ help what usage: Makefile
 	@echo "Any of the Unit Test programs can be used as goals to build:"
 	@$(foreach test, $(TESTS), echo "    $(OBJECT_DIR)/$(test)/$(test)";)
 	@echo ""
-	@echo "Any of the Unit Test programs can be used as goals to build and run:"
+	@echo "Any of the Unit Test programs (except for target specific unit tests) can be used as goals to build and run:"
 	@$(foreach test, $(TESTS), echo "    test_$(test)";)
 
 ## clean       : Cleanup the UnitTest binaries.
@@ -605,11 +612,15 @@ test_$1: $(OBJECT_DIR)/$1/$(basename $1)
 endef
 
 
-$(eval $(foreach test,$(TESTS),$(call test-specific-stuff,$(test))))
+ifeq ($(MAKECMDGOALS),test-all)
+    $(eval $(foreach test,$(TESTS_ALL),$(call test-specific-stuff,$(test))))
+else
+    $(eval $(foreach test,$(TESTS),$(call test-specific-stuff,$(test))))
+endif
 
-$(foreach test,$(TESTS),$(if $($(basename $(test))_SRC),,$(error \
+$(foreach test,$(TESTS_ALL),$(if $($(basename $(test))_SRC),,$(error \
 	Test 'unit/$(basename $(test)).cc' has no '$(basename $(test))_SRC' variable defined)))
-$(foreach var,$(filter-out TARGET_SRC,$(filter %_SRC,$(.VARIABLES))),$(if $(filter $(var:_SRC=)%,$(TESTS)),,$(error \
+$(foreach var,$(filter-out TARGET_SRC,$(filter %_SRC,$(.VARIABLES))),$(if $(filter $(var:_SRC=)%,$(TESTS_ALL)),,$(error \
 	Variable '$(var)' has no 'unit/$(var:_SRC=).cc' test)))
 
 


### PR DESCRIPTION
Reasons:
- removes the slowdown when running individual / commonly used tests that was introduced when target specific tests were added;
- target specific tests are unlikely candidates to be run individually;
- @etracer65's dream comes true. :wink: