### PR TITLE
[PERSISTENT OBJECT] Refactor / rename boot loader request object

### DIFF
--- a/src/main/drivers/persistent.h
+++ b/src/main/drivers/persistent.h
@@ -29,11 +29,18 @@ typedef enum {
     PERSISTENT_OBJECT_MAGIC = 0,
     PERSISTENT_OBJECT_HSE_VALUE,
     PERSISTENT_OBJECT_OVERCLOCK_LEVEL,
-    PERSISTENT_OBJECT_BOOTMODE_REQUEST,
+    PERSISTENT_OBJECT_RESET_REASON,
     PERSISTENT_OBJECT_RTC_HIGH,           // high 32 bits of rtcTime_t
     PERSISTENT_OBJECT_RTC_LOW,            // low 32 bits of rtcTime_t
     PERSISTENT_OBJECT_COUNT,
 } persistentObjectId_e;
+
+// Values for PERSISTENT_OBJECT_RESET_REASON
+#define RESET_NONE               0
+#define RESET_BOOTLOADER_REQUEST 1  // Boot loader invocation was requested
+#define RESET_BOOTLOADER_POST    2  // Reset after boot loader activity
+#define RESET_MSC_REQUEST        3  // MSC invocation was requested
+#define RESET_FORCED             4  // Reset due to unknown reset reason
 
 void persistentObjectInit(void);
 uint32_t persistentObjectRead(persistentObjectId_e id);

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -52,9 +52,6 @@ void checkForBootLoaderRequest(void);
 bool isMPUSoftReset(void);
 void cycleCounterInit(void);
 
-#define BOOTLOADER_REQUEST_COOKIE 0xDEADBEEF
-#define MSC_REQUEST_COOKIE 0xDDDD1010
-
 void enableGPIOPowerUsageAndNoiseReductions(void);
 // current crystal frequency - 8 or 12MHz
 

--- a/src/main/drivers/system_stm32f4xx.c
+++ b/src/main/drivers/system_stm32f4xx.c
@@ -41,7 +41,7 @@ void systemReset(void)
 
 void systemResetToBootloader(void)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, BOOTLOADER_REQUEST_COOKIE);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_BOOTLOADER_REQUEST);
 
     __disable_irq();
     NVIC_SystemReset();
@@ -56,12 +56,12 @@ typedef struct isrVector_s {
 
 void checkForBootLoaderRequest(void)
 {
-    uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_BOOTMODE_REQUEST);
+    uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_RESET_REASON);
 
-    if (bootloaderRequest != BOOTLOADER_REQUEST_COOKIE) {
+    if (bootloaderRequest != RESET_BOOTLOADER_REQUEST) {
         return;
     }
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, 0);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
 
     extern isrVector_t system_isr_vector_table_base;
 

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -45,7 +45,7 @@ void systemReset(void)
 
 void systemResetToBootloader(void)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, BOOTLOADER_REQUEST_COOKIE);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_BOOTLOADER_REQUEST);
     __disable_irq();
     NVIC_SystemReset();
 }
@@ -191,12 +191,12 @@ void(*bootJump)(void);
 
 void checkForBootLoaderRequest(void)
 {
-    uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_BOOTMODE_REQUEST);
+    uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_RESET_REASON);
 
-    if (bootloaderRequest != BOOTLOADER_REQUEST_COOKIE) {
+    if (bootloaderRequest != RESET_BOOTLOADER_REQUEST) {
         return;
     }
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, 0);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
 
     void (*SysMemBootJump)(void);
 

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -125,8 +125,8 @@ uint8_t mscStart(void)
 
 bool mscCheckBoot(void)
 {
-    const uint32_t bootModeRequest = persistentObjectRead(PERSISTENT_OBJECT_BOOTMODE_REQUEST);
-    return bootModeRequest == MSC_REQUEST_COOKIE;
+    const uint32_t bootModeRequest = persistentObjectRead(PERSISTENT_OBJECT_RESET_REASON);
+    return bootModeRequest == RESET_MSC_REQUEST;
     // Note that we can't clear the persisent object after checking here. This is because
     // this function is called multiple times during initialization. So we clear on a reset
     // out of MSC mode.
@@ -162,7 +162,7 @@ void mscWaitForButton(void)
 
 void systemResetToMsc(int timezoneOffsetMinutes)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, MSC_REQUEST_COOKIE);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_MSC_REQUEST);
 
     __disable_irq();
 
@@ -177,7 +177,7 @@ void systemResetToMsc(int timezoneOffsetMinutes)
 
 void systemResetFromMsc(void)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, 0);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
     __disable_irq();
     NVIC_SystemReset();
 }

--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -130,8 +130,8 @@ uint8_t mscStart(void)
 
 bool mscCheckBoot(void)
 {
-    const uint32_t bootModeRequest = persistentObjectRead(PERSISTENT_OBJECT_BOOTMODE_REQUEST);
-    return bootModeRequest == MSC_REQUEST_COOKIE;
+    const uint32_t bootModeRequest = persistentObjectRead(PERSISTENT_OBJECT_RESET_REASON);
+    return bootModeRequest == RESET_MSC_REQUEST;
     // Note that we can't clear the persisent object after checking here. This is because
     // this function is called multiple times during initialization. So we clear on a reset
     // out of MSC mode.
@@ -167,7 +167,7 @@ void mscWaitForButton(void)
 
 void systemResetToMsc(int timezoneOffsetMinutes)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, MSC_REQUEST_COOKIE);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_MSC_REQUEST);
 
     __disable_irq();
 
@@ -182,7 +182,7 @@ void systemResetToMsc(int timezoneOffsetMinutes)
 
 void systemResetFromMsc(void)
 {
-    persistentObjectWrite(PERSISTENT_OBJECT_BOOTMODE_REQUEST, 0);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
     __disable_irq();
     NVIC_SystemReset();
 }


### PR DESCRIPTION
The object name `PERSISTENT_OBJECT_BOOTLOADER_REQUEST` is not appropriate as it is used for booting into MSC mode also. Future MCU may use this facility for other reset modes. Hence it is renamed to `PERSISTENT_OBJECT_RESET_REASON`.  Values are defined as `RESET_XXX`.  Bye-bye hexspeak 😭 