### PR TITLE
Improve RSSI handling on link loss for Spektrum SRXL

### DIFF
--- a/src/main/io/spektrum_rssi.c
+++ b/src/main/io/spektrum_rssi.c
@@ -107,21 +107,35 @@ static int8_t dBm2range (int8_t dBm) {
 void spektrumHandleRSSI(volatile uint8_t spekFrame[]) {
 #ifdef USE_SPEKTRUM_REAL_RSSI
     static int8_t spek_last_rssi = SPEKTRUM_RSSI_MAX;
+    static uint8_t spek_fade_count = 0;
 
     // Fetch RSSI
     if (srxlEnabled) {
-        // Real RSSI reported omly by SRXL Telemetry Rx, in dBm.
+        // Real RSSI reported only by SRXL Telemetry Rx, in dBm.
         int8_t rssi = spekFrame[0];
 
         if (rssi <= SPEKTRUM_RSSI_FADE_LIMIT ) {
-        // If Rx reports -100 dBm or less, it is a fade out and frame loss.
-        // If it is a temporary fade, real RSSI will come back in the next frame, in that case.
-        // we should not report 0% back as OSD keeps a "minimum RSSI" value. Instead keep last good report
-        // If it is a total link loss, failsafe will kick in.
-        // We could count the fades here, but currentlly to no use
+            // If Rx reports -100 dBm or less, it is a fade out and frame
+            // loss.
+            // If it is a temporary fade, real RSSI will come back in the
+            // next frame, in that case
+            // we should not report 0% back as OSD keeps a "minimum RSSI"
+            // value. Instead keep last good report.
+            // If it is a total link loss, failsafe will kick in.
+            // The number of fades are counted and if it is equal or above
+            // SPEKTRUM_RSSI_LINK_LOSS_FADES a link loss is assumed and
+            // RSSI is set to Spektrums minimum RSSI value.
 
-        // Ignore report and Keep last known good value
-        rssi = spek_last_rssi;
+            spek_fade_count++;
+            if (spek_fade_count < SPEKTRUM_RSSI_LINK_LOSS_FADES) {
+                // Ignore report and keep last known good value
+                rssi = spek_last_rssi;
+            } else {
+                // Link loss assumed, set RSSI to minimum value
+                rssi = SPEKTRUM_RSSI_MIN;
+            }
+        } else {
+            spek_fade_count = 0;
         }
 
         if(rssi_channel != 0) {

--- a/src/main/io/spektrum_rssi.c
+++ b/src/main/io/spektrum_rssi.c
@@ -35,6 +35,8 @@
 #include "rx/spektrum.h"
 #include "io/spektrum_rssi.h"
 
+// Number of fade outs counted as a link loss when using USE_SPEKTRUM_REAL_RSSI
+#define SPEKTRUM_RSSI_LINK_LOSS_FADES 5
 
 #ifdef USE_SPEKTRUM_FAKE_RSSI
 // Spektrum Rx type. Determined by bind method.

--- a/src/main/io/spektrum_rssi.h
+++ b/src/main/io/spektrum_rssi.h
@@ -28,9 +28,6 @@
 #define SPEKTRUM_MAX_FADE_PER_SEC       40
 #define SPEKTRUM_FADE_REPORTS_PER_SEC   2
 
-// Number of fade outs counted as a link loss
-#define SPEKTRUM_RSSI_LINK_LOSS_FADES 5
-
 typedef struct dbm_table_s
 {
     int8_t  dBm;

--- a/src/main/io/spektrum_rssi.h
+++ b/src/main/io/spektrum_rssi.h
@@ -28,6 +28,9 @@
 #define SPEKTRUM_MAX_FADE_PER_SEC       40
 #define SPEKTRUM_FADE_REPORTS_PER_SEC   2
 
+// Number of fade outs counted as a link loss
+#define SPEKTRUM_RSSI_LINK_LOSS_FADES 5
+
 typedef struct dbm_table_s
 {
     int8_t  dBm;


### PR DESCRIPTION
This PR contains a small improvement in handling the RSSI for link losses of Spektrum SRXL connections (e.g. SPM4649T).
The original inline comment says that a fade out is detected if the RSSI is equal or below SPEKTRUM_RSSI_FADE_LIMIT. As this can happen temporarily the last known good RSSI value is used in this cases. According to the comment a link loss will trigger failsafe. I like the solution for the handling of temporary dropouts but what is missing is the handling of link losses regarding RSSI. In link loss situations the RSSI is set to the last known good value with the original code which in my opinion is wrong. If a link loss or longer fade out occurs the RSSI should drop to the minimum value to give proper feedback for the user.
You can easily simulate the behaviour at home with shutting off your receiver. The RSSI value is then sticking to the last value instead of dropping.
I added some code to check if a longer fade out happened and in this cases sets the RSSI to its minimum value (SPEKTRUM_RSSI_MIN). I've introduced a new constant (SPEKTRUM_RSSI_LINK_LOSS_FADES) for this. The value of 5 is just an assumption but was working very well for me. I had no false alert during some test flights. Also I did some testing like turning off transmitter during flight and flying far away until failsafe kicked in and there was no issue.