### PR TITLE
Added single colour mode to WS2811 driver for RAM savings.

### DIFF
--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -20,16 +20,26 @@
 
 #pragma once
 
+#include "platform.h"
+
 #include "drivers/io_types.h"
 
 #define WS2811_LED_STRIP_LENGTH    32
+
 #define WS2811_BITS_PER_LED        24
+
+#if defined(USE_WS2811_SINGLE_COLOUR)
+#define WS2811_DATA_BUFFER_SIZE    1
+#define WS2811_DMA_BUFFER_SIZE     (WS2811_DATA_BUFFER_SIZE * WS2811_BITS_PER_LED)
+// Do 2 extra iterations of the DMA transfer with the ouptut set to low to generate the > 50us delay.
+#define WS2811_DELAY_ITERATIONS    2
+#else
+#define WS2811_DATA_BUFFER_SIZE    WS2811_LED_STRIP_LENGTH
 // for 50us delay
 #define WS2811_DELAY_BUFFER_LENGTH 42
-
-#define WS2811_DATA_BUFFER_SIZE    (WS2811_BITS_PER_LED * WS2811_LED_STRIP_LENGTH)
 // number of bytes needed is #LEDs * 24 bytes + 42 trailing bytes)
-#define WS2811_DMA_BUFFER_SIZE     (WS2811_DATA_BUFFER_SIZE + WS2811_DELAY_BUFFER_LENGTH)
+#define WS2811_DMA_BUFFER_SIZE     (WS2811_DATA_BUFFER_SIZE * WS2811_BITS_PER_LED + WS2811_DELAY_BUFFER_LENGTH)
+#endif
 
 #define WS2811_TIMER_MHZ           48
 #define WS2811_CARRIER_HZ          800000

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -94,10 +94,6 @@ static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 #define BEACON_FAILSAFE_PERIOD_US 250      // 2Hz
 #define BEACON_FAILSAFE_ON_PERCENT 50      // 50% duty cycle
 
-#if LED_MAX_STRIP_LENGTH > WS2811_LED_STRIP_LENGTH
-# error "Led strip length must match driver"
-#endif
-
 const hsvColor_t hsv[] = {
     //                        H    S    V
     [COLOR_BLACK] =        {  0,   0,   0},
@@ -140,6 +136,11 @@ void pgResetFn_ledStripConfig(ledStripConfig_t *ledStripConfig)
 }
 
 #ifdef USE_LED_STRIP_STATUS_MODE
+
+#if LED_MAX_STRIP_LENGTH > WS2811_LED_STRIP_LENGTH
+# error "Led strip length must match driver"
+#endif
+
 const hsvColor_t *colors;
 const modeColorIndexes_t *modeColors;
 specialColorIndexes_t specialColors;

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -244,6 +244,10 @@
 #undef USE_LED_STRIP_STATUS_MODE
 #endif
 
+#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_STATUS_MODE)
+#define USE_WS2811_SINGLE_COLOUR
+#endif
+
 #if defined(SIMULATOR_BUILD) || defined(UNIT_TEST)
 // This feature uses 'arm_math.h', which does not exist for x86.
 #undef USE_GYRO_DATA_ANALYSE

--- a/src/test/unit/ws2811_unittest.cc
+++ b/src/test/unit/ws2811_unittest.cc
@@ -33,8 +33,7 @@ extern "C" {
 extern "C" {
 STATIC_UNIT_TESTED extern uint16_t dmaBufferOffset;
 
-STATIC_UNIT_TESTED void fastUpdateLEDDMABuffer(rgbColor24bpp_t *color);
-STATIC_UNIT_TESTED void updateLEDDMABuffer(uint8_t componentValue);
+STATIC_UNIT_TESTED void updateLEDDMABuffer(rgbColor24bpp_t *color);
 }
 
 TEST(WS2812, updateDMABuffer) {
@@ -45,13 +44,7 @@ TEST(WS2812, updateDMABuffer) {
     dmaBufferOffset = 0;
 
     // when
-#if 0
-    updateLEDDMABuffer(color1.rgb.g);
-    updateLEDDMABuffer(color1.rgb.r);
-    updateLEDDMABuffer(color1.rgb.b);
-#else
-    fastUpdateLEDDMABuffer(&color1);
-#endif
+    updateLEDDMABuffer(&color1);
 
     // then
     EXPECT_EQ(24, dmaBufferOffset);


### PR DESCRIPTION
After the small savings achieved in #7530, this cuts down on the RAM guzzling done in the WS2811 driver:

From:
```
Linking AIORACERF3
Memory region         Used Size  Region Size  %age Used
           FLASH:      257168 B       252 KB     99.66%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       40352 B        40 KB     98.52%
             CCM:          2 KB         8 KB     25.00%
       MEMORY_B1:          0 GB         0 GB      -nan%
   text    data     bss     dec     hex filename
 248908    8260   34140  291308   471ec ./obj/main/betaflight_AIORACERF3.elf
```

To:
```
Linking AIORACERF3
Memory region         Used Size  Region Size  %age Used
           FLASH:      257104 B       252 KB     99.63%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       39448 B        40 KB     96.31%
             CCM:          2 KB         8 KB     25.00%
       MEMORY_B1:          0 GB         0 GB      -nan%
   text    data     bss     dec     hex filename
 248844    8260   33236  290340   46e24 ./obj/main/betaflight_AIORACERF3.elf
```

Side note: We should probably consider changing the non-single-colour WS2811 driver to use circular DMA as well - allocating 810 bytes RAM just for the LED_STRIP DMA seems to be such a waste.

Also removed the unused legacy DMA pattern generator from the driver.