### PR TITLE
Update D_CUT to D_MIN, add setpoint input, change nomenclature

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -81,5 +81,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RX_SPEKTRUM_SPI",
     "DSHOT_RPM_TELEMETRY",
     "RPM_FILTER",
-    "D_CUT",
+    "D_MIN",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -98,7 +98,7 @@ typedef enum {
     DEBUG_RX_SPEKTRUM_SPI,
     DEBUG_DSHOT_RPM_TELEMETRY,
     DEBUG_RPM_FILTER,
-    DEBUG_D_CUT,
+    DEBUG_D_MIN,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1002,19 +1002,20 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_INTEGRATED_YAW_CONTROL
-    { "use_integrated_yaw",    VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = {TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, use_integrated_yaw) },
-    { "integrated_yaw_relax",    VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, integrated_yaw_relax) },
+    { "use_integrated_yaw",         VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = {TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, use_integrated_yaw) },
+    { "integrated_yaw_relax",       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, integrated_yaw_relax) },
 #endif
 
-#ifdef USE_D_CUT
-    { "dterm_cut_percent",          VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_cut_percent) },
-    { "dterm_cut_gain",             VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_cut_gain) },
-    { "dterm_cut_range_hz",         VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 10, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_cut_range_hz) },
-    { "dterm_cut_lowpass_hz",       VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 20 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_cut_lowpass_hz) },
+#ifdef USE_D_MIN
+    { "d_min_roll",                 VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_roll) },
+    { "d_min_pitch",                VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_pitch) },
+    { "d_min_yaw",                  VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_yaw) },
+    { "d_min_boost_gain",           VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_gain) },
+    { "d_min_advance",              VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_advance) },
 #endif
 
-    { "motor_output_limit",       VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { MOTOR_OUTPUT_LIMIT_PERCENT_MIN, MOTOR_OUTPUT_LIMIT_PERCENT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, motor_output_limit) },
-    { "auto_profile_cell_count",   VAR_INT8 | PROFILE_VALUE,  .config.minmax = { AUTO_PROFILE_CELL_COUNT_CHANGE, MAX_AUTO_DETECT_CELL_COUNT }, PG_PID_PROFILE, offsetof(pidProfile_t, auto_profile_cell_count) },
+    { "motor_output_limit",         VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { MOTOR_OUTPUT_LIMIT_PERCENT_MIN, MOTOR_OUTPUT_LIMIT_PERCENT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, motor_output_limit) },
+    { "auto_profile_cell_count",    VAR_INT8 | PROFILE_VALUE,  .config.minmax = { AUTO_PROFILE_CELL_COUNT_CHANGE, MAX_AUTO_DETECT_CELL_COUNT }, PG_PID_PROFILE, offsetof(pidProfile_t, auto_profile_cell_count) },
 
 #ifdef USE_LAUNCH_CONTROL
     { "launch_control_mode",        VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_LAUNCH_CONTROL_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, launchControlMode) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -560,8 +560,10 @@ static uint16_t cmsx_dterm_lowpass_hz;
 static uint16_t cmsx_dterm_lowpass2_hz;
 static uint16_t cmsx_dterm_notch_hz;
 static uint16_t cmsx_dterm_notch_cutoff;
-#ifdef USE_D_CUT
-static uint8_t  cmsx_dterm_cut_percent;
+#ifdef USE_D_MIN
+static uint8_t  cmsx_d_min_roll;
+static uint8_t  cmsx_d_min_pitch;
+static uint8_t  cmsx_d_min_yaw;
 #endif
 static uint16_t cmsx_yaw_lowpass_hz;
 
@@ -573,8 +575,10 @@ static long cmsx_FilterPerProfileRead(void)
     cmsx_dterm_lowpass2_hz  = pidProfile->dterm_lowpass2_hz;
     cmsx_dterm_notch_hz     = pidProfile->dterm_notch_hz;
     cmsx_dterm_notch_cutoff = pidProfile->dterm_notch_cutoff;
-#ifdef USE_D_CUT
-    cmsx_dterm_cut_percent  = pidProfile->dterm_cut_percent;
+#ifdef USE_D_MIN
+    cmsx_d_min_roll     = pidProfile->d_min_roll;
+    cmsx_d_min_pitch    = pidProfile->d_min_pitch;
+    cmsx_d_min_yaw    = pidProfile->d_min_yaw;
 #endif
     cmsx_yaw_lowpass_hz     = pidProfile->yaw_lowpass_hz;
 
@@ -591,8 +595,10 @@ static long cmsx_FilterPerProfileWriteback(const OSD_Entry *self)
     pidProfile->dterm_lowpass2_hz  = cmsx_dterm_lowpass2_hz;
     pidProfile->dterm_notch_hz     = cmsx_dterm_notch_hz;
     pidProfile->dterm_notch_cutoff = cmsx_dterm_notch_cutoff;
-#ifdef USE_D_CUT
-    pidProfile->dterm_cut_percent  = cmsx_dterm_cut_percent;
+#ifdef USE_D_MIN
+    pidProfile->d_min_roll  = cmsx_d_min_roll;
+    pidProfile->d_min_pitch = cmsx_d_min_pitch;
+    pidProfile->d_min_yaw   = cmsx_d_min_yaw;
 #endif
     pidProfile->yaw_lowpass_hz     = cmsx_yaw_lowpass_hz;
 
@@ -607,8 +613,10 @@ static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
     { "DTERM LPF2", OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_dterm_lowpass2_hz,    0, 500, 1 }, 0 },
     { "DTERM NF",   OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_dterm_notch_hz,       0, 500, 1 }, 0 },
     { "DTERM NFCO", OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_dterm_notch_cutoff,   0, 500, 1 }, 0 },
-#ifdef USE_D_CUT
-    { "DTERM CUT",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_dterm_cut_percent,    0, 100, 1 }, 0 },
+#ifdef USE_D_MIN
+    { "D_MIN_ROLL",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_d_min_roll,      0, 100, 1 }, 0 },
+    { "D_MIN_PITCH", OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_d_min_pitch,     0, 100, 1 }, 0 },
+    { "D_MIN_YAW",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_d_min_yaw,       0, 100, 1 }, 0 },
 #endif
     { "YAW LPF",    OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_yaw_lowpass_hz,       0, 500, 1 }, 0 },
     { "BACK", OME_Back, NULL, NULL, 0 },

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -160,10 +160,11 @@ typedef struct pidProfile_s {
     uint8_t use_integrated_yaw;             // Selects whether the yaw pidsum should integrated
     uint8_t integrated_yaw_relax;           // Specifies how much integrated yaw should be reduced to offset the drag based yaw component
     uint8_t thrustLinearization;            // Compensation factor for pid linearization
-    uint8_t dterm_cut_percent;              // Amount to cut D by with no gyro activity, zero disables, 20 means cut 20%, 50 means cut 50%
-    uint8_t dterm_cut_gain;                 // Gain factor for amount of gyro activity required to remove the dterm cut
-    uint8_t dterm_cut_range_hz;             // Biquad to prevent high frequency gyro noise from removing the dterm cut
-    uint8_t dterm_cut_lowpass_hz;           // First order lowpass to delay and smooth dterm cut factor
+    uint8_t d_min_roll;                     // Minimum D value on roll axis
+    uint8_t d_min_pitch;                    // Minimum D value on pitch axis
+    uint8_t d_min_yaw;                      // Minimum D value on yaw axis
+    uint8_t d_min_gain;                     // Gain factor for amount of gyro / setpoint activity required to boost D
+    uint8_t d_min_advance;                  // Percentage multiplier for setpoint input to boost algorithm
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
 } pidProfile_t;

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -199,7 +199,7 @@
 #if ((FLASH_SIZE > 256) || (FEATURE_CUT_LEVEL < 8))
 #define USE_LAUNCH_CONTROL
 #define USE_DYN_LPF
-#define USE_D_CUT
+#define USE_D_MIN
 #endif
 
 #if ((FLASH_SIZE > 256) || (FEATURE_CUT_LEVEL < 7))


### PR DESCRIPTION
This is an incremental improvement to the original D_Cut proposal, based on user feedback.

Lots of thanks and full credit to JoeLucid for the original boost ideas and his ongoing support and encouragement.

Changes:

- D boost cannot exceed the user's set D value; that D value becomes a 'max'
- User can directly and easily set their intended minimum value for D on pitch and roll.  
- Boost to the primary D setting is generated from gyro or setpoint input, whichever is higher.
- Setpoint input is stick derived, faster by 10ms approx, and does not respond to propwash.
- Gyro input is motor derived and slower, but responds to propwash
- Code boosts by max of setpoint or gyro input
- `d_min_advance` value is a percentage setpoint multiplier, sets how much can be added
- `d_min_boost_gain` value sets overall sensitivity
- default D mins are 20 roll 22 pitch
- default D is 35 38, if undefined then normal D values
- previous range and smoothing lowpass values are now constants in pid.c

Tuning:
- adjust D value for desired overshoot control; higher P and D than usual can be used if needed
- tune D min to a lower value to control noise, noting that lower values mean cooler motors but perhaps more propwash.
- in propwash, boost typically allows an increase to about ⅓ way towards max D.  The d_min value, primarily, dictates propwash.  
- higher d_min_advance values will bring the D boost in earlier.  Usually only needed for very high rate overshoot (ie >1300 deg/sec), or overshoot in heavier freestyle builds, e.g. where there is a significant delay between setpoint change and motor response.  

Logging
- `set debug_mode = D_MIN` logs the boost factor for gyro and setpoint into debug 0 and 1, and logs the actual 'realtime' D value (times 10), into debug 2 and 3. 

Disabling / rendering ineffective
- D_min >= Dmax
- D_min = 0