### PR TITLE
[VTX] Convert Tramp driver to use VTX table facility

### DIFF
--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -38,6 +38,10 @@
 
 #include "drivers/vtx_common.h"
 
+#ifdef USE_VTX_TABLE
+#include "drivers/vtx_table.h"
+#endif
+
 #include "io/serial.h"
 #include "io/vtx_tramp.h"
 #include "io/vtx_control.h"
@@ -616,6 +620,17 @@ bool vtxTrampInit(void)
 
     // XXX Effect of USE_VTX_COMMON should be reviewed, as following call to vtxInit will do nothing if vtxCommonSetDevice is not called.
 #if defined(USE_VTX_COMMON)
+#if defined(USE_VTX_TABLE)
+    vtxTramp.capability.bandCount = vtxTableBandCount;
+    vtxTramp.capability.channelCount = vtxTableChannelCount;
+    vtxTramp.capability.powerCount = vtxTablePowerLevels;
+    vtxTramp.frequencyTable = (uint16_t *)vtxTableFrequency;
+    vtxTramp.bandNames = vtxTableBandNames;
+    vtxTramp.bandLetters = vtxTableBandLetters;
+    vtxTramp.channelNames = vtxTableChannelNames;
+    vtxTramp.powerNames = vtxTablePowerLabels;
+    vtxTramp.powerValues = vtxTablePowerValues;
+#else
     vtxTramp.capability.bandCount = VTX_TRAMP_BAND_COUNT;
     vtxTramp.capability.channelCount = VTX_TRAMP_CHANNEL_COUNT;
     vtxTramp.capability.powerCount = sizeof(trampPowerTable),
@@ -625,6 +640,7 @@ bool vtxTrampInit(void)
     vtxTramp.channelNames = vtxStringChannelNames();
     vtxTramp.powerNames = trampPowerNames;
     vtxTramp.powerValues = trampPowerTable;
+#endif
 
     vtxCommonSetDevice(&vtxTramp);
 


### PR DESCRIPTION
Requires #7251.

The Tramp driver is converted to use VTX table facility implemented by #7251, and the driver should be compatible with 2.4GHz VTX by FuriousFPV as well as the original 5.8GHz part by IRC.

Owners of these parts are invited to participate in testing this new facility.

`vtxtable` commands that delivers full compatibility for 5.8GHz part is as follows.
```
vtxtable bands 5
vtxtable channels 8
vtxtable band 1 BOSCAM_A A 5865 5845 5825 5805 5785 5765 5745 5725
vtxtable band 2 BOSCAM_B B 5733 5752 5771 5790 5809 5828 5847 5866
vtxtable band 3 BOSCAM_E E 5705 5685 5665 5645 5885 5905 5925 5945
vtxtable band 4 FATSHARK F 5740 5760 5780 5800 5820 5840 5860 5880
vtxtable band 5 RACEBAND R 5658 5695 5732 5769 5806 5843 5880 5917
vtxtable powerlevels 5
vtxtable powervalues 25 100 200 400 600
vtxtable powerlabels 25 100 200 400 600
```

FuriousFPV 2.4GHz part should be handled with the following `vtxtable` commands
```
vtxtable bands 2
vtxtable channels 8
vtxtable band 1 BAND_A A 2410 2430 2450 2470 2370 2390 2490 2510
vtxtable band 2 BAND_B B 2414 2432 2450 2468 2411 2433 2453 2473
vtxtable powerlevels 4
vtxtable powervalues 25 200 500 800
vtxtable powerlabels 25 200 500 800
```

The VTX table facility provides users to freely modify the frequency table, so those users interested and/or have requested a support for LoRace band can now so by defining the band.

**_Remember that users now take full responsibility of conforming to respective local regulations.
Above vtxtable commands are provided to give backward compatibility with existing operation, and they are not recommended in any means by the author of this PR or by the Betaflight project._**