### PR TITLE
Enabled PC15 for the new Airbot Omnibus NanoV7

### DIFF
--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -171,14 +171,13 @@
 #define SPI3_MISO_PIN           PC11
 #define SPI3_MOSI_PIN           PC12
 
-#if defined(OMNIBUSF4V6)
 #define USE_I2C
+#if defined(OMNIBUSF4V6)
 #define USE_I2C_DEVICE_1
 #define I2C1_SCL                PB8 // SCL PIN,alt MST8
 #define I2C1_SDA                PB9 // SDA PIN,alt MST7
 #define I2C_DEVICE              (I2CDEV_1)
 #else
-#define USE_I2C
 #define USE_I2C_DEVICE_2
 #define I2C2_SCL                NONE // PB10, shared with UART3TX
 #define I2C2_SDA                NONE // PB11, shared with UART3RX
@@ -193,8 +192,10 @@
 #define RSSI_ADC_PIN            PA0  // Direct from RSSI pad
 
 // Allegro Systems ACS781KLRTR-150U-T
+#if !defined(OMNIBUSF4V6)
 #define CURRENT_METER_SCALE_DEFAULT  176
 #define CURRENT_METER_OFFSET_DEFAULT -18500
+#endif
 
 #define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
@@ -209,7 +210,7 @@
 
 #define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
 #define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
-#define TARGET_IO_PORTC (0xffff & ~(BIT(15)))
+#define TARGET_IO_PORTC  0xffff
 #define TARGET_IO_PORTD BIT(2)
 
 #define USABLE_TIMER_CHANNEL_COUNT 15


### PR DESCRIPTION
With the new entry of Airbot Omnibus NanoV7, OSD works in PC15, so it has been enabled. Taking advantage of I have set CURRENT_METER by default from OmnibusF4 V6.