### PR TITLE
Fixed battery filtering when period is not a multiple of 10.

### DIFF
--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -32,7 +32,7 @@
 
 #define MAX_AUTO_DETECT_CELL_COUNT 8
 
-#define GET_BATTERY_LPF_FREQUENCY(period) (1.0f / (period / 10))
+#define GET_BATTERY_LPF_FREQUENCY(period) (1 / (period / 10.0f))
 
 enum {
     AUTO_PROFILE_CELL_COUNT_STAY = 0, // Stay on this profile irrespective of the detected cell count. Use this profile if no other profile matches (default, i.e. auto profile switching is off)


### PR DESCRIPTION
Fixes a problem introduced by #7447.

@klutvott123: Can you test please?