### PR TITLE
Fix OMINBUSF4 target USE_ACC define

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -73,7 +73,7 @@
 
 #define USE_EXTI
 
-//#define USE_ACC
+#define USE_ACC
 #define USE_ACC_SPI_MPU6000
 
 #define USE_GYRO


### PR DESCRIPTION
The `#define USE_ACC` was indavertantly left commented out from #7529
