### PR TITLE
Fix compiliation for F1 targets

### DIFF
--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -24,8 +24,6 @@
 
 #include "pg/pg.h"
 
-#define CONTROL_RATE_PROFILE_COUNT  6
-
 typedef enum {
     RATES_TYPE_BETAFLIGHT = 0,
     RATES_TYPE_RACEFLIGHT,

--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -41,8 +41,10 @@ void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
     adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
     adcConfig->dmaopt[ADCDEV_1] = ADC1_DMA_OPT;
+#ifndef STM32F1
     adcConfig->dmaopt[ADCDEV_2] = ADC2_DMA_OPT;
     adcConfig->dmaopt[ADCDEV_3] = ADC3_DMA_OPT;
+#endif
 
 #ifdef VBAT_ADC_PIN
     adcConfig->vbat.enabled = true;

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -145,10 +145,12 @@
 #define USE_SERIALRX_SPEKTRUM   // SRXL, DSM2 and DSMX protocol
 #define USE_SERIALRX_SUMD       // Graupner Hott protocol
 
-#if (FLASH_SIZE > 64)
+#if (FLASH_SIZE > 128)
 #define PID_PROFILE_COUNT 3
+#define CONTROL_RATE_PROFILE_COUNT  6
 #else
 #define PID_PROFILE_COUNT 2
+#define CONTROL_RATE_PROFILE_COUNT  3
 #endif
 
 #if (FLASH_SIZE > 64)

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -33,6 +33,7 @@
 #define FAST_RAM
 
 #define PID_PROFILE_COUNT 3
+#define CONTROL_RATE_PROFILE_COUNT  6
 #define USE_MAG
 #define USE_BARO
 #define USE_GPS


### PR DESCRIPTION
Fix a missing MCU check for ADC devices and reduce the number of profiles/rateprofiles to 2 and 3 respectively to get the config under 2K.

Tested on a NAZE target (Naze32 rev5).