### PR TITLE
VCP HAL transmit buffer fixes

### DIFF
--- a/src/main/vcp_hal/usbd_cdc_interface.h
+++ b/src/main/vcp_hal/usbd_cdc_interface.h
@@ -65,7 +65,7 @@
 
 /* Periodically, the state of the buffer "UserTxBuffer" is checked.
    The period depends on CDC_POLLING_INTERVAL */
-#define CDC_POLLING_INTERVAL             10 /* in ms. The max is 65 and the min is 1 */
+#define CDC_POLLING_INTERVAL             5 /* in ms. The max is 65 and the min is 1 */
 
 /* Exported typef ------------------------------------------------------------*/
 /* The following structures groups all needed parameters to be configured for the


### PR DESCRIPTION
Fixes #7448 

Fixes issues that could cause the tail of the ring buffer to be moved before data transmission is complete thus allowing the head to overwrite unsent data. Also adds 512 byte blocking when queueing the output data with the endpoint (helps with slow receivers).

Fixes a bug in the transmit buffer logic if the TX and RX buffers were different sizes.