### PR TITLE
Change battery filters from biquad to pt1

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -44,7 +44,7 @@ FAST_CODE float nullFilterApply(filter_t *filter, float input)
 
 // PT1 Low Pass filter
 
-float pt1FilterGain(uint16_t f_cut, float dT)
+float pt1FilterGain(float f_cut, float dT)
 {
     float RC = 1 / ( 2 * M_PI_FLOAT * f_cut);
     return dT / (RC + dT);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -76,7 +76,7 @@ float filterGetNotchQ(float centerFreq, float cutoffFreq);
 void laggedMovingAverageInit(laggedMovingAverage_t *filter, uint16_t windowSize, float *buf);
 float laggedMovingAverageUpdate(laggedMovingAverage_t *filter, float input);
 
-float pt1FilterGain(uint16_t f_cut, float dT);
+float pt1FilterGain(float f_cut, float dT);
 void pt1FilterInit(pt1Filter_t *filter, float k);
 void pt1FilterUpdateCutoff(pt1Filter_t *filter, float k);
 float pt1FilterApply(pt1Filter_t *filter, float input);

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -57,6 +57,7 @@
 
 #define Q12 (1 << 12)
 
+#define HZ_TO_INTERVAL(x) (1.0f / (x))
 #define HZ_TO_INTERVAL_US(x) (1000000 / (x))
 
 typedef int32_t fix12_t;

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -88,7 +88,7 @@ void currentMeterReset(currentMeter_t *meter)
 // ADC/Virtual shared
 //
 
-static biquadFilter_t adciBatFilter;
+static pt1Filter_t adciBatFilter;
 
 #ifndef CURRENT_METER_SCALE_DEFAULT
 #define CURRENT_METER_SCALE_DEFAULT 400 // for Allegro ACS758LCB-100U (40mV/A)
@@ -141,7 +141,7 @@ currentMeterADCState_t currentMeterADCState;
 void currentMeterADCInit(void)
 {
     memset(&currentMeterADCState, 0, sizeof(currentMeterADCState_t));
-    biquadFilterInitLPF(&adciBatFilter, GET_BATTERY_LPF_FREQUENCY(batteryConfig()->ibatLpfPeriod), HZ_TO_INTERVAL_US(50));
+    pt1FilterInit(&adciBatFilter, pt1FilterGain(GET_BATTERY_LPF_FREQUENCY(batteryConfig()->ibatLpfPeriod), HZ_TO_INTERVAL(50)));
 }
 
 void currentMeterADCRefresh(int32_t lastUpdateAt)
@@ -149,7 +149,7 @@ void currentMeterADCRefresh(int32_t lastUpdateAt)
 #ifdef USE_ADC
     const uint16_t iBatSample = adcGetChannel(ADC_CURRENT);
     currentMeterADCState.amperageLatest = currentMeterADCToCentiamps(iBatSample);
-    currentMeterADCState.amperage = currentMeterADCToCentiamps(biquadFilterApply(&adciBatFilter, iBatSample));
+    currentMeterADCState.amperage = currentMeterADCToCentiamps(pt1FilterApply(&adciBatFilter, iBatSample));
 
     updateCurrentmAhDrawnState(&currentMeterADCState.mahDrawnState, currentMeterADCState.amperageLatest, lastUpdateAt);
 #else

--- a/src/test/unit/common_filter_unittest.cc
+++ b/src/test/unit/common_filter_unittest.cc
@@ -41,15 +41,15 @@ TEST(FilterUnittest, TestPt1FilterInit)
 
 TEST(FilterUnittest, TestPt1FilterGain)
 {
-    EXPECT_FLOAT_EQ(0.999949, pt1FilterGain(100, 31.25f));
+    EXPECT_FLOAT_EQ(0.999949, pt1FilterGain(100.0f, 31.25f));
     // handle cases over uint8_t boundary
-    EXPECT_FLOAT_EQ(0.99998301, pt1FilterGain(300, 31.25f));
+    EXPECT_FLOAT_EQ(0.99998301, pt1FilterGain(300.0f, 31.25f));
 }
 
 TEST(FilterUnittest, TestPt1FilterApply)
 {
     pt1Filter_t filter;
-    pt1FilterInit(&filter, pt1FilterGain(100, 31.25f));
+    pt1FilterInit(&filter, pt1FilterGain(100.0f, 31.25f));
     EXPECT_EQ(0, filter.state);
 
     pt1FilterApply(&filter, 1800.0f);


### PR DESCRIPTION
I suggest changing the battery filters from biquad to pt1. Mainly to get rid of the 2nd order Butterworth overshoot, and also because I think pt1 is perfectly adequate for this application. 2nd order Butterworth with Q = 0.707 gives 4% overshoot. You can see this when plugging in a battery. The current probably overshoots while doing punchouts too, but i haven't tested that. 

Another option is to use biquad lowpass with Q = 0.5. Then it behaves like two cascaded 1st order lowpass filters and eliminates the overshoot. 

Here's a step response that simulates plugging in a 4S battery. 
![step_response](https://user-images.githubusercontent.com/41271048/52588913-e0bee380-2e3d-11e9-99d4-aa1cf17ea7ae.png)

Let me know what you guys think.