### PR TITLE
Ensure all timer channels are initialized when using dshot burst #7548

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -467,11 +467,9 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
         motor->timer->dmaBurstRef = dmaRef;
-
-        if (!configureTimer) {
-            motor->configured = true;
-            return;
-        }
+#ifdef USE_DSHOT_TELEMETRY
+        motor->dmaRef = dmaRef;
+#endif
     } else
 #endif
     {


### PR DESCRIPTION
This PR fixes at least some issues described in #7548: dshot burst would sometimes not initialize all timers correctly.