### PR TITLE
[SDIO, DMA] Fix dmaopt for SDIO DMA

### DIFF
--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -71,13 +71,6 @@ void pgResetFn_sdcardConfig(sdcardConfig_t *config)
     config->dmaIdentifier = (uint8_t)dmaGetIdentifier(SDCARD_DMA_CHANNEL_TX);
 #endif
 #endif
-
-#ifdef USE_SDCARD_SDIO
-#if defined(SDIO_DMA)
-    config->dmaIdentifier = (uint8_t)dmaGetIdentifier(SDIO_DMA);
-    config->useDma = true;
-#endif
-#endif
 #endif // !USE_DMA_SPEC
 }
 #endif

--- a/src/main/target/NUCLEOF722/target.h
+++ b/src/main/target/NUCLEOF722/target.h
@@ -133,7 +133,7 @@
 //#define SPI4_TX_DMA_OPT                     0     // DMA 2 Stream 1 Channel 4
 #define USE_SDCARD_SDIO
 
-#define SDIO_DMA_OPT            0  // DMA 2 Stream 3 Chanel 4
+#define SDCARD_SDIO_DMA_OPT     0   // DMA 2 Stream 3 Chanel 4
 #define SDCARD_SPI_CS_PIN NONE //This is not used on SDIO, has to be kept for now to keep compiler happy
 
 #define USE_I2C

--- a/src/main/target/WORMFC/target.h
+++ b/src/main/target/WORMFC/target.h
@@ -194,7 +194,7 @@
 #define USE_SDCARD
 #define USE_SDCARD_SDIO
 
-#define SDIO_DMA_OPT            0  // DMA 2 Stream 3 Channel 4
+#define SDCARD_SDIO_DMA_OPT     0  // DMA 2 Stream 3 Channel 4
 #define SDCARD_SPI_CS_PIN NONE //This is not used on SDIO, has to be kept for now to keep compiler happy
 #if defined(PIRXF4)
 #define SDCARD_DETECT_PIN PC15


### PR DESCRIPTION
- SDIO DMA is corrected to use correct symbol `SDCARD_SDIO_DMA_OPT`.

- SPI side is no longer processed here; it is part of the SPI now.