### PR TITLE
make LEDs work on NOX again and move bidir support to separate branch

### DIFF
--- a/src/main/target/NOX/target.c
+++ b/src/main/target/NOX/target.c
@@ -31,12 +31,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2,  CH3,  PB10, TIM_USE_PPM,   0,     0), // T2C3
 
     DEF_TIM(TIM5,  CH2,  PA1,  TIM_USE_MOTOR, 0, 0), // T2C2(1,6,3), T5C2(1,4,6)
-    // Use T3C2 instead of T1C1N to enable DSHOT telemetry
-#ifdef USE_DSHOT_TELEMETRY
-    DEF_TIM(TIM3,  CH2, PA7,  TIM_USE_MOTOR, 0, 0), // T1C1N(2,3,6), T3C2(1,5,5)
-#else
     DEF_TIM(TIM1,  CH1N, PA7,  TIM_USE_MOTOR, 0, 0), // T1C1N(2,3,6), T3C2(1,5,5)
-#endif
     DEF_TIM(TIM4,  CH3,  PB8,  TIM_USE_MOTOR, 0, 0), // T4C3(1,7,2), T10C1(X)
     DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_MOTOR, 0, 0), // T1C3N(2,6,6), T3C4(1,7,5)
 


### PR DESCRIPTION
This PR removes bidir support from NOX boards so that LED functionality works again. NOX will in the future be supported via a separate branch like our other special bidir configs.