### PR TITLE
CMS memory optimizations 1

### DIFF
--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -195,7 +195,7 @@ static long cmsx_Blackbox_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuBlackboxEntries[] =
+static const OSD_Entry cmsx_menuBlackboxEntries[] =
 {
     { "-- BLACKBOX --", OME_Label, NULL, NULL, 0},
     { "DEVICE",      OME_TAB,     NULL,            &cmsx_BlackboxDeviceTable,                                 0 },

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -78,7 +78,7 @@ static long cmsx_InfoInit(void)
     return 0;
 }
 
-static OSD_Entry menuInfoEntries[] = {
+static const OSD_Entry menuInfoEntries[] = {
     { "--- INFO ---", OME_Label, NULL, NULL, 0 },
     { "FWID", OME_String, NULL, BETAFLIGHT_IDENTIFIER, 0 },
     { "FWVER", OME_String, NULL, FC_VERSION_STRING, 0 },
@@ -100,7 +100,7 @@ static CMS_Menu menuInfo = {
 
 // Features
 
-static OSD_Entry menuFeaturesEntries[] =
+static const OSD_Entry menuFeaturesEntries[] =
 {
     {"--- FEATURES ---", OME_Label, NULL, NULL, 0},
 
@@ -141,7 +141,7 @@ static CMS_Menu menuFeatures = {
 
 // Main
 
-static OSD_Entry menuMainEntries[] =
+static const OSD_Entry menuMainEntries[] =
 {
     {"-- MAIN --",  OME_Label, NULL, NULL, 0},
 

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -65,7 +65,7 @@ static long cmsx_Failsafe_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuFailsafeEntries[] =
+static const OSD_Entry cmsx_menuFailsafeEntries[] =
 {
     { "-- FAILSAFE --", OME_Label, NULL, NULL, 0},
 

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -161,7 +161,7 @@ static long cmsx_PidWriteback(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPidEntries[] =
+static const OSD_Entry cmsx_menuPidEntries[] =
 {
     { "-- PID --", OME_Label, NULL, pidProfileIndexString, 0},
 
@@ -223,7 +223,7 @@ static long cmsx_RateProfileOnEnter(void)
     return 0;
 }
 
-static OSD_Entry cmsx_menuRateProfileEntries[] =
+static const OSD_Entry cmsx_menuRateProfileEntries[] =
 {
     { "-- RATE --", OME_Label, NULL, rateProfileIndexString, 0 },
 
@@ -296,7 +296,7 @@ static long cmsx_launchControlOnExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuLaunchControlEntries[] = {
+static const OSD_Entry cmsx_menuLaunchControlEntries[] = {
     { "-- LAUNCH CONTROL --", OME_Label, NULL, pidProfileIndexString, 0 },
 
     { "MODE",             OME_TAB,   NULL, &(OSD_TAB_t)   { &cmsx_launchControlMode, LAUNCH_CONTROL_MODE_COUNT - 1, osdLaunchControlModeNames}, 0 },
@@ -388,7 +388,7 @@ static long cmsx_profileOtherOnExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuProfileOtherEntries[] = {
+static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "-- OTHER PP --", OME_Label, NULL, pidProfileIndexString, 0 },
 
     { "FF TRANS",    OME_FLOAT,  NULL, &(OSD_FLOAT_t)  { &cmsx_feedForwardTransition,  0,    100,   1, 10 }, 0 },
@@ -461,7 +461,7 @@ static long cmsx_menuGyro_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuFilterGlobalEntries[] =
+static const OSD_Entry cmsx_menuFilterGlobalEntries[] =
 {
     { "-- FILTER GLB  --", OME_Label, NULL, NULL, 0 },
 
@@ -543,7 +543,7 @@ static long cmsx_menuDynFilt_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuDynFiltEntries[] =
+static const OSD_Entry cmsx_menuDynFiltEntries[] =
 {
     { "-- DYN FILT --", OME_Label, NULL, NULL, 0 },
 
@@ -611,7 +611,7 @@ static long cmsx_FilterPerProfileWriteback(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
+static const OSD_Entry cmsx_menuFilterPerProfileEntries[] =
 {
     { "-- FILTER PP  --", OME_Label, NULL, NULL, 0 },
 
@@ -681,7 +681,7 @@ static long cmsx_CopyControlRateProfile(displayPort_t *pDisplay, const void *ptr
     return 0;
 }
 
-static OSD_Entry cmsx_menuCopyProfileEntries[] =
+static const OSD_Entry cmsx_menuCopyProfileEntries[] =
 {
     { "-- COPY PROFILE --", OME_Label, NULL, NULL, 0},
 
@@ -706,7 +706,7 @@ CMS_Menu cmsx_menuCopyProfile = {
 
 #endif
 
-static OSD_Entry cmsx_menuImuEntries[] =
+static const OSD_Entry cmsx_menuImuEntries[] =
 {
     { "-- PROFILE --", OME_Label, NULL, NULL, 0},
 

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -104,7 +104,7 @@ static long cmsx_Ledstrip_OnExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuLedstripEntries[] =
+static const OSD_Entry cmsx_menuLedstripEntries[] =
 {
     { "-- LED STRIP --",  OME_Label, NULL, NULL, 0 },
     { "ENABLED",          OME_Bool,  NULL, &cmsx_FeatureLedstrip, 0 },

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -67,7 +67,7 @@ static long cmsx_menuRcConfirmBack(const OSD_Entry *self)
 //
 // RC preview
 //
-static OSD_Entry cmsx_menuRcEntries[] =
+static const OSD_Entry cmsx_menuRcEntries[] =
 {
     { "-- RC PREV --", OME_Label, NULL, NULL, 0},
 
@@ -119,7 +119,7 @@ static long cmsx_menuMiscOnExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry menuMiscEntries[]=
+static const OSD_Entry menuMiscEntries[]=
 {
     { "-- MISC --", OME_Label, NULL, NULL, 0 },
 

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -59,7 +59,7 @@ static long menuOsdActiveElemsOnExit(const OSD_Entry *self)
     return 0;
 }
 
-OSD_Entry menuOsdActiveElemsEntries[] =
+const OSD_Entry menuOsdActiveElemsEntries[] =
 {
     {"--- ACTIV ELEM ---", OME_Label,   NULL, NULL, 0},
     {"RSSI",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], DYNAMIC},
@@ -171,7 +171,7 @@ static long menuAlarmsOnExit(const OSD_Entry *self)
     return 0;
 }
 
-OSD_Entry menuAlarmsEntries[] =
+const OSD_Entry menuAlarmsEntries[] =
 {
     {"--- ALARMS ---", OME_Label, NULL, NULL, 0},
     {"RSSI",     OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_rssi_alarm, 5, 90, 5}, 0},
@@ -220,7 +220,7 @@ static long menuTimersOnExit(const OSD_Entry *self)
 
 static const char * osdTimerPrecisionNames[] = {"SCND", "HDTH"};
 
-OSD_Entry menuTimersEntries[] =
+const OSD_Entry menuTimersEntries[] =
 {
     {"--- TIMERS ---", OME_Label, NULL, NULL, 0},
     {"1 SRC",          OME_TAB,   NULL, &(OSD_TAB_t){&timerSource[OSD_TIMER_1], OSD_TIMER_SRC_COUNT - 1, osdTimerSourceNames}, 0 },
@@ -287,7 +287,7 @@ static long cmsx_menuOsdOnExit(const OSD_Entry *self)
   return 0;
 }
 
-OSD_Entry cmsx_menuOsdEntries[] =
+const OSD_Entry cmsx_menuOsdEntries[] =
 {
     {"---OSD---",   OME_Label,   NULL,          NULL,                0},
 #ifdef USE_OSD_PROFILES

--- a/src/main/cms/cms_menu_power.c
+++ b/src/main/cms/cms_menu_power.c
@@ -96,7 +96,7 @@ static long cmsx_Power_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPowerEntries[] =
+static const OSD_Entry cmsx_menuPowerEntries[] =
 {
     { "-- POWER --", OME_Label, NULL, NULL, 0},
 

--- a/src/main/cms/cms_menu_saveexit.c
+++ b/src/main/cms/cms_menu_saveexit.c
@@ -34,7 +34,7 @@
 
 #include "fc/config.h"
 
-static OSD_Entry cmsx_menuSaveExitEntries[] =
+static const OSD_Entry cmsx_menuSaveExitEntries[] =
 {
     { "-- SAVE/EXIT --", OME_Label, NULL, NULL, 0},
     {"EXIT",        OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT, 0},

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -98,7 +98,7 @@ static long cmsx_Vtx_onExit(const OSD_Entry *self)
 }
 
 
-static OSD_Entry cmsx_menuVtxEntries[] =
+static const OSD_Entry cmsx_menuVtxEntries[] =
 {
     {"--- VTX ---", OME_Label, NULL, NULL, 0},
     {"BAND", OME_TAB, NULL, &entryVtxBand, 0},

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -339,7 +339,7 @@ static const char * const saCmsDeviceStatusNames[] = {
 
 static OSD_TAB_t saCmsEntOnline = { &saCmsDeviceStatus, 2, saCmsDeviceStatusNames };
 
-static OSD_Entry saCmsMenuStatsEntries[] = {
+static const OSD_Entry saCmsMenuStatsEntries[] = {
     { "- SA STATS -", OME_Label, NULL, NULL, 0 },
     { "STATUS",   OME_TAB,    NULL, &saCmsEntOnline,                              DYNAMIC },
     { "BAUDRATE", OME_UINT16, NULL, &(OSD_UINT16_t){ &sa_smartbaud, 0, 0, 0 },    DYNAMIC },
@@ -536,7 +536,7 @@ static long saCmsConfigUserFreq(displayPort_t *pDisp, const void *self)
     return MENU_CHAIN_BACK;
 }
 
-static OSD_Entry saCmsMenuPORFreqEntries[] = {
+static const OSD_Entry saCmsMenuPORFreqEntries[] = {
     { "- POR FREQ -", OME_Label,   NULL,             NULL,                                                 0 },
 
     { "CUR FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreq, 5000, 5999, 0 },       DYNAMIC },
@@ -558,7 +558,7 @@ static CMS_Menu saCmsMenuPORFreq =
     .entries = saCmsMenuPORFreqEntries,
 };
 
-static OSD_Entry saCmsMenuUserFreqEntries[] = {
+static const OSD_Entry saCmsMenuUserFreqEntries[] = {
     { "- USER FREQ -", OME_Label,   NULL,             NULL,                                                0 },
 
     { "CUR FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5999, 0 },    DYNAMIC },
@@ -582,7 +582,7 @@ static CMS_Menu saCmsMenuUserFreq =
 
 static OSD_TAB_t saCmsEntFselMode = { &saCmsFselModeNew, 1, saCmsFselModeNames };
 
-static OSD_Entry saCmsMenuConfigEntries[] = {
+static const OSD_Entry saCmsMenuConfigEntries[] = {
     { "- SA CONFIG -", OME_Label, NULL, NULL, 0 },
 
     { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
@@ -607,7 +607,7 @@ static CMS_Menu saCmsMenuConfig = {
     .entries = saCmsMenuConfigEntries
 };
 
-static OSD_Entry saCmsMenuCommenceEntries[] = {
+static const OSD_Entry saCmsMenuCommenceEntries[] = {
     { "CONFIRM", OME_Label,   NULL,          NULL, 0 },
 
     { "YES",     OME_Funcall, saCmsCommence, NULL, 0 },
@@ -626,7 +626,7 @@ static CMS_Menu saCmsMenuCommence = {
     .entries = saCmsMenuCommenceEntries,
 };
 
-static OSD_Entry saCmsMenuFreqModeEntries[] = {
+static const OSD_Entry saCmsMenuFreqModeEntries[] = {
     { "- SMARTAUDIO -", OME_Label, NULL, NULL, 0 },
 
     { "",       OME_Label,   NULL,                                     saCmsStatusString,  DYNAMIC },
@@ -639,7 +639,7 @@ static OSD_Entry saCmsMenuFreqModeEntries[] = {
     { NULL, OME_END, NULL, NULL, 0 }
 };
 
-static OSD_Entry saCmsMenuChanModeEntries[] =
+static const OSD_Entry saCmsMenuChanModeEntries[] =
 {
     { "- SMARTAUDIO -", OME_Label, NULL, NULL, 0 },
 
@@ -655,7 +655,7 @@ static OSD_Entry saCmsMenuChanModeEntries[] =
     { NULL,     OME_END, NULL, NULL, 0 }
 };
 
-static OSD_Entry saCmsMenuOfflineEntries[] =
+static const OSD_Entry saCmsMenuOfflineEntries[] =
 {
     { "- VTX SMARTAUDIO -", OME_Label, NULL, NULL, 0 },
 

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -207,7 +207,7 @@ static long trampCmsOnEnter(void)
     return 0;
 }
 
-static OSD_Entry trampCmsMenuCommenceEntries[] = {
+static const OSD_Entry trampCmsMenuCommenceEntries[] = {
     { "CONFIRM", OME_Label,   NULL,          NULL, 0 },
     { "YES",     OME_Funcall, trampCmsCommence, NULL, 0 },
     { "BACK",    OME_Back, NULL, NULL, 0 },
@@ -224,7 +224,7 @@ static CMS_Menu trampCmsMenuCommence = {
     .entries = trampCmsMenuCommenceEntries,
 };
 
-static OSD_Entry trampMenuEntries[] =
+static const OSD_Entry trampMenuEntries[] =
 {
     { "- TRAMP -", OME_Label, NULL, NULL, 0 },
 

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -63,7 +63,7 @@ typedef struct
     const CMSEntryFuncPtr func;
     void *data;
     const uint8_t flags;
-} OSD_Entry;
+} __attribute__((packed)) OSD_Entry;
 
 // Bits in flags
 #define PRINT_VALUE    0x01  // Value has been changed, need to redraw

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -62,7 +62,7 @@ typedef struct
     const OSD_MenuElement type;
     const CMSEntryFuncPtr func;
     void *data;
-    uint8_t flags;
+    const uint8_t flags;
 } OSD_Entry;
 
 // Bits in flags
@@ -71,13 +71,13 @@ typedef struct
 #define DYNAMIC        0x04  // Value should be updated dynamically
 #define OPTSTRING      0x08  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 
-#define IS_PRINTVALUE(p) ((p)->flags & PRINT_VALUE)
-#define SET_PRINTVALUE(p) { (p)->flags |= PRINT_VALUE; }
-#define CLR_PRINTVALUE(p) { (p)->flags &= ~PRINT_VALUE; }
+#define IS_PRINTVALUE(x) ((x) & PRINT_VALUE)
+#define SET_PRINTVALUE(x) { (x) |= PRINT_VALUE; }
+#define CLR_PRINTVALUE(x) { (x) &= ~PRINT_VALUE; }
 
-#define IS_PRINTLABEL(p) ((p)->flags & PRINT_LABEL)
-#define SET_PRINTLABEL(p) { (p)->flags |= PRINT_LABEL; }
-#define CLR_PRINTLABEL(p) { (p)->flags &= ~PRINT_LABEL; }
+#define IS_PRINTLABEL(x) ((x) & PRINT_LABEL)
+#define SET_PRINTLABEL(x) { (x) |= PRINT_LABEL; }
+#define CLR_PRINTLABEL(x) { (x) &= ~PRINT_LABEL; }
 
 #define IS_DYNAMIC(p) ((p)->flags & DYNAMIC)
 
@@ -104,7 +104,7 @@ typedef struct
 #endif
     const CMSMenuFuncPtr onEnter;
     const CMSMenuOnExitPtr onExit;
-    OSD_Entry *entries;
+    const OSD_Entry *entries;
 } CMS_Menu;
 
 typedef struct

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -72,12 +72,12 @@ typedef struct
 #define OPTSTRING      0x08  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 
 #define IS_PRINTVALUE(x) ((x) & PRINT_VALUE)
-#define SET_PRINTVALUE(x) { (x) |= PRINT_VALUE; }
-#define CLR_PRINTVALUE(x) { (x) &= ~PRINT_VALUE; }
+#define SET_PRINTVALUE(x) do { (x) |= PRINT_VALUE; } while (0)
+#define CLR_PRINTVALUE(x) do { (x) &= ~PRINT_VALUE; } while (0)
 
 #define IS_PRINTLABEL(x) ((x) & PRINT_LABEL)
-#define SET_PRINTLABEL(x) { (x) |= PRINT_LABEL; }
-#define CLR_PRINTLABEL(x) { (x) &= ~PRINT_LABEL; }
+#define SET_PRINTLABEL(x) do { (x) |= PRINT_LABEL; } while (0)
+#define CLR_PRINTLABEL(x) do { (x) &= ~PRINT_LABEL; } while (0)
 
 #define IS_DYNAMIC(p) ((p)->flags & DYNAMIC)
 


### PR DESCRIPTION
The OSD entry structure violates the single responsibility principle.

```
typedef struct
{
    const char * const text;
    const OSD_MenuElement type;
    const CMSEntryFuncPtr func;
    void *data;
    uint8_t flags;
} OSD_Entry;
```

it's a concern of the menu system drawing the display to manage the run-time state.
it's a concern of the menu layout designers to say what a menu entry should be.
the two concerns are couple in `OSD_Entry` right now, in the `flags` member.

This PR copies the flags value into a runtime state and uses it from there, this means the `OSD_Entry` based menu definitions can become constant, and stay in flash.

Saves about 8KB ram and 3KB flash.

The 3KB flash saving is a one-line code change on the structure - it's now packed.

The structure packing by itself would save 3KB RAM without the other commit since the flash savings are mirrored in RAM when the structures are copied from flash to ram.

I started the ram saving work and then was informed that an almost identical change was done in INAV with regards to the 8KB ram. https://github.com/iNavFlight/inav/pull/2881/







