### PR TITLE
Added target config for ELINF722 target. Also added list of manufacturer ids.

### DIFF
--- a/unified_targets/configs/ELINF722.config
+++ b/unified_targets/configs/ELINF722.config
@@ -1,0 +1,76 @@
+# Betaflight / STM32F7X2 (S7X2) 4.0.0 Feb 17 2019 / 12:47:46 (fefa2a83e) MSP API: 1.41
+
+board_name ELINF722
+manufacturer_id DRCL
+
+# resources
+resource BEEPER 1 B04
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 A03
+resource MOTOR 4 A02
+resource MOTOR 5 A08
+resource MOTOR 6 C09
+resource LED_STRIP 1 B06
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 B05
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 C06
+resource ADC_BATT 1 C02
+resource ADC_CURR 1 C01
+resource PINIO 1 C13
+resource PINIO 2 C14
+resource FLASH_CS 1 B03
+resource OSD_CS 1 C08
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+
+# timer list
+timer B09 1
+timer B00 2
+timer B01 2
+
+# dmaopt
+dmaopt ADC 1 1 # DMA2 Stream 4 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+
+# master
+set serialrx_provider = SBUS
+set serialrx_halfduplex = ON
+set dshot_burst = ON
+set motor_pwm_protocol = ONESHOT125
+set current_meter = ADC
+set battery_meter = ADC
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set pinio_box = 40,41,255,255
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0
+set gyro_2_spibus = 1

--- a/unified_targets/docs/Manufacturers.md
+++ b/unified_targets/docs/Manufacturers.md
@@ -1,0 +1,11 @@
+Last updated: 17/02/2019
+
+|Manufacturer Id|Name|Contact|
+|-|-|-|
+|CUST|'Custom', to be used for homebrew targets||
+|AFNG|AlienFlight NG|https://www.alienflightng.com/|
+|BKMN|Jason Blackman|https://github.com/blckmn|
+|DRCL|dronercland|https://www.instagram.com/dronercland/|
+|FFPV|Furious FPV|https://furiousfpv.com/|
+
+This is the official list of manufacturer ids (`manufacturer_id` in the target config) that will be supported for loading onto unified targets by Betaflight configurator.


### PR DESCRIPTION
- I created a new directory `unified_targets` to allow a move of files pertaining to unified targets into a different repository at a later stage;
- keeping the header line generated by a CLI `diff` (`# Betaflight / STM32F7X2 (S7X2) 4.0.0 Feb 17 2019 / 12:47:46 (fefa2a83e) MSP API: 1.41`) in the config file allows the identification of the unified target / version that this config applies to, thus removing the need to keep it close to the actual target definition. Allowing different formats for this meta information should be investigated;
- I created a master list of manufacturer ids (they need to be unique per manufacturer) under `unified_targets/docs/`;
- the target config is still missing the correct timer configs, I'll add them when I get them from @elin-neo.