### PR TITLE
Fix UNUSED() macro conflict with STM libraries

### DIFF
--- a/lib/main/STM32F1/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_hal_def.h
+++ b/lib/main/STM32F1/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_hal_def.h
@@ -85,7 +85,9 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0U)
 
+#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/lib/main/STM32F3/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_hal_def.h
+++ b/lib/main/STM32F3/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_hal_def.h
@@ -83,7 +83,9 @@ typedef enum
                               (__DMA_HANDLE_).Parent = (__HANDLE__);               \
                           } while(0U)
 
+#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
+#endif
                          
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__ specifies the Peripheral Handle.

--- a/lib/main/STM32F4/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_def.h
+++ b/lib/main/STM32F4/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_def.h
@@ -83,7 +83,9 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0)
 
+#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
+++ b/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
@@ -82,7 +82,9 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0)
 
+#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_bot.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_bot.c
@@ -31,7 +31,9 @@
 #include "usbd_ioreq.h"
 #include "usbd_msc_mem.h"
 
+#if !defined(UNUSED)
 #define UNUSED(x) (void)(x)
+#endif
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
   * @{

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_core.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_core.c
@@ -46,7 +46,9 @@
 #include "usbd_msc_bot.h"
 #include "usbd_req.h"
 
+#if !defined(UNUSED)
 #define UNUSED(x) (void)(x)
+#endif
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
   * @{

--- a/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/lib/main/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -31,7 +31,9 @@
 #include "usbd_msc_mem.h"
 #include "usbd_msc_data.h"
 
+#if !defined(UNUSED)
 #define UNUSED(x) (void)(x)
+#endif
 
 
 

--- a/src/test/unit/unittest_macros.h
+++ b/src/test/unit/unittest_macros.h
@@ -18,4 +18,6 @@
 #pragma once
 
 
+#if !defined(UNUSED)
 #define UNUSED(x) (void)(x)
+#endif


### PR DESCRIPTION
Added `#if !defined(` blocks around the `UNUSED()` definitions in the libraries to prevent conflicts.