### PR TITLE
SmartAudio Lite compatibility: Send 0x00 bit(s) (always) even with Soft Serial.

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -450,14 +450,7 @@ static void saReceiveFrame(uint8_t c)
 static void saSendFrame(uint8_t *buf, int len)
 {
     if (!IS_RC_MODE_ACTIVE(BOXVTXCONTROLDISABLE)) {
-        switch (smartAudioSerialPort->identifier) {
-            case SERIAL_PORT_SOFTSERIAL1:
-            case SERIAL_PORT_SOFTSERIAL2:
-                break;
-            default:
-                serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start bit
-                break;
-        }
+        serialWrite(smartAudioSerialPort, 0x00); // Ensure line is low regardless of hardware pull-down capabilities.
 
         for (int i = 0 ; i < len ; i++) {
             serialWrite(smartAudioSerialPort, buf[i]);
@@ -468,6 +461,7 @@ static void saSendFrame(uint8_t *buf, int len)
         sa_outstanding = SA_CMD_NONE;
     }
 
+    serialWrite(smartAudioSerialPort, 0x00); // Pull the line low again after sending frame.
     sa_lastTransmissionMs = millis();
 }
 


### PR DESCRIPTION
I've been sitting on this for a while. Basically, I noticed that with the my AIKONF4's which expose a 'vtx' control pad on SoftSerial with SmartAudio Lite on the TBS Unify Nano (genuine), that it would sit in autobaud state.

I hacked this up to send the extra 0x00's all the flippin time, and it seems to work enough to be usable. As the configurable UART support we have discussed (inversion, pull-down/pull-up, baud, stopbits, blahblah) internally has not yet surfaced.. here's a hack instead.

I'm personally not in favour of a 10k hard pull down workaround - I have always run the patch to avoid it - and the latest revision of TBS SA spec document calls for the host MCU to pull the line low if the hard pull down can not be 100% guaranteed. One could make the argument that the host should also be SA protocol-standards compliant to best effort: we cannot ensure the hard-pull down, i.e. we must pull the line low (as even if a hard pull-down existed, it would effectively be idempotent) in all configurations.

The major downside of this change is that it obviously 💇‍♂️ supports their license non-compliant competitor e.g. early AKK/Mach2 drama-llama variants.