### PR TITLE
[CMS, TRAMP] One level back if Tramp is not configured

### DIFF
--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -172,8 +172,14 @@ static long trampCmsCommence(displayPort_t *pDisp, const void *self)
     return MENU_CHAIN_BACK;
 }
 
-static void trampCmsInitSettings(void)
+static bool trampCmsInitSettings(void)
 {
+    vtxDevice_t *device = vtxCommonDevice();
+
+    if (!device) {
+        return false;
+    }
+
     if (trampBand > 0) trampCmsBand = trampBand;
     if (trampChannel > 0) trampCmsChan = trampChannel;
 
@@ -186,8 +192,6 @@ static void trampCmsInitSettings(void)
         }
     }
 
-    vtxDevice_t *device = vtxCommonDevice();
-
     trampCmsEntBand.val = &trampCmsBand;
     trampCmsEntBand.max = device->capability.bandCount;
     trampCmsEntBand.names = device->bandNames;
@@ -199,11 +203,16 @@ static void trampCmsInitSettings(void)
     trampCmsEntPower.val = &trampCmsPower;
     trampCmsEntPower.max = device->capability.powerCount;
     trampCmsEntPower.names = device->powerNames;
+
+    return true;
 }
 
 static long trampCmsOnEnter(void)
 {
-    trampCmsInitSettings();
+    if (!trampCmsInitSettings()) {
+        return MENU_CHAIN_BACK;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Fixes #7575

Entering VTX_TR menu when tramp device is not initialized or configured, `vtxDevice` returns `NULL` and causes hard fault at some point in subsequent menu processing.

This PR fixes it by jumping back to where `trampCmsOnEnter` was called (features menu).

A drawback of this handling is that the transition is not visible, and the screen stays at features menu.
This might be confusing for users trying to make Tramp work. Before VTX TABLE change, VTX_TR menu screen presented default strings for non-existent/non-online device.

Thoughts?