### PR TITLE
Update activation masks with linked mode

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -338,6 +338,16 @@ static void validateAndFixConfig(void)
     }
 #endif
 
+    for (int i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
+        const modeActivationCondition_t *mac = modeActivationConditions(i);
+
+        if (mac->linkedTo) {
+            if (mac->modeId == BOXARM || isModeActivationConditionLinked(mac->linkedTo)) {
+                removeModeActivationCondition(mac->modeId);
+            }
+        }
+    }
+
 // clear features that are not supported.
 // I have kept them all here in one place, some could be moved to sections of code above.
 

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -129,6 +129,7 @@ bool airmodeIsEnabled(void);
 bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range);
 void updateActivatedModes(void);
 bool isModeActivationConditionPresent(boxId_e modeId);
+bool isModeActivationConditionLinked(boxId_e modeId);
 void removeModeActivationCondition(boxId_e modeId);
 bool isModeActivationConditionConfigured(const modeActivationCondition_t *mac, const modeActivationCondition_t *emptyMac);
 void analyzeModeActivationConditions(void);


### PR DESCRIPTION
Delays linked mode activation by 1 cycle but allows for combining ranges and links in a single mode for logical operations. Also allows to link to other linked modes.