### PR TITLE
Toggle all LEDs for hard-faults.

### DIFF
--- a/src/main/fc/hardfaults.c
+++ b/src/main/fc/hardfaults.c
@@ -125,6 +125,8 @@ void hard_fault_handler_c(unsigned long *hardfault_args)
 #else
 void HardFault_Handler(void)
 {
+    LED0_ON;
+    LED1_ON;
     LED2_ON;
 
     // fall out of the sky
@@ -141,11 +143,14 @@ void HardFault_Handler(void)
     }
 #endif
 
-    LED1_OFF;
     LED0_OFF;
+    LED1_OFF;
+    LED2_OFF;
 
     while (1) {
         delay(50);
+        LED0_TOGGLE;
+        LED1_TOGGLE;
         LED2_TOGGLE;
     }
 }


### PR DESCRIPTION
* If they all flash yo have a better chance of finding it.
* Boards with only 1 LED (LED0) had no indication of failure.
