### PR TITLE
Ensure target is rebuilt if ANY of the make files changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,7 +574,7 @@ check-fastram-usage-correctness:
 	fi;
 
 # rebuild everything when makefile changes
-$(TARGET_OBJS): Makefile $(TARGET_DIR)/target.mk
+$(TARGET_OBJS): Makefile $(TARGET_DIR)/target.mk $(wildcard make/*)
 
 
 # include auto-generated dependencies


### PR DESCRIPTION
Prior to this, editing say make/source.mk didn't cause a rebuild.
