### PR TITLE
Move memory section initialisation earlier into the init sequence.

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -20,6 +20,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "platform.h"
 
@@ -202,5 +203,24 @@ void failureMode(failureMode_e mode)
     systemReset();
 #else
     systemResetToBootloader();
+#endif
+}
+
+void initialiseMemorySections(void)
+{
+#ifdef USE_ITCM_RAM
+    /* Load functions into ITCM RAM */
+    extern uint8_t tcm_code_start;
+    extern uint8_t tcm_code_end;
+    extern uint8_t tcm_code;
+    memcpy(&tcm_code_start, &tcm_code, (size_t) (&tcm_code_end - &tcm_code_start));
+#endif
+
+#ifdef USE_FAST_RAM
+    /* Load FAST_RAM variable intializers into DTCM RAM */
+    extern uint8_t _sfastram_data;
+    extern uint8_t _efastram_data;
+    extern uint8_t _sfastram_idata;
+    memcpy(&_sfastram_data, &_sfastram_idata, (size_t) (&_efastram_data - &_sfastram_data));
 #endif
 }

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -52,6 +52,8 @@ void checkForBootLoaderRequest(void);
 bool isMPUSoftReset(void);
 void cycleCounterInit(void);
 
+void initialiseMemorySections(void);
+
 void enableGPIOPowerUsageAndNoiseReductions(void);
 // current crystal frequency - 8 or 12MHz
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -229,22 +229,6 @@ dispatchEntry_t activateDshotTelemetryEntry =
 
 void init(void)
 {
-#ifdef USE_ITCM_RAM
-    /* Load functions into ITCM RAM */
-    extern uint8_t tcm_code_start;
-    extern uint8_t tcm_code_end;
-    extern uint8_t tcm_code;
-    memcpy(&tcm_code_start, &tcm_code, (size_t) (&tcm_code_end - &tcm_code_start));
-#endif
-
-#ifdef USE_FAST_RAM
-    /* Load FAST_RAM variable intializers into DTCM RAM */
-    extern uint8_t _sfastram_data;
-    extern uint8_t _efastram_data;
-    extern uint8_t _sfastram_idata;
-    memcpy(&_sfastram_data, &_sfastram_idata, (size_t) (&_efastram_data - &_sfastram_data));
-#endif
-
 #ifdef USE_HAL_DRIVER
     HAL_Init();
 #endif

--- a/src/main/startup/system_stm32f30x.c
+++ b/src/main/startup/system_stm32f30x.c
@@ -102,6 +102,7 @@
 #include "platform.h"
 
 #include "stm32f30x.h"
+#include "drivers/system.h"
 
 uint32_t hse_value = HSE_VALUE;
 
@@ -160,6 +161,8 @@ void SetSysClock(void);
   */
 void SystemInit(void)
 {
+  initialiseMemorySections();
+
   /* FPU settings ------------------------------------------------------------*/
   #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
     SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */

--- a/src/main/startup/system_stm32f4xx.c
+++ b/src/main/startup/system_stm32f4xx.c
@@ -316,6 +316,7 @@
 
 #include <string.h>
 #include "stm32f4xx.h"
+#include "drivers/system.h"
 #include "system_stm32f4xx.h"
 #include "platform.h"
 #include "drivers/persistent.h"
@@ -506,6 +507,8 @@ void systemClockSetHSEValue(uint32_t frequency)
 
 void SystemInit(void)
 {
+  initialiseMemorySections();
+
   /* FPU settings ------------------------------------------------------------*/
   #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
     SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */

--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -64,6 +64,7 @@
   */
 
 #include "stm32f7xx.h"
+#include "drivers/system.h"
 #include "system_stm32f7xx.h"
 #include "platform.h"
 #include "drivers/persistent.h"
@@ -308,6 +309,8 @@ void OverclockRebootIfNecessary(uint32_t overclockLevel)
   */
 void SystemInit(void)
 {
+    initialiseMemorySections();
+
     SystemInitOC();
 
     SystemCoreClock = (pll_n / pll_p) * 1000000;


### PR DESCRIPTION
Allows startup-code/libs/etc to be moved into different memory regions.
