### PR TITLE
Fix `UNUSED redefined` warnings.

### DIFF
--- a/lib/main/STM32F1/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_hal_def.h
+++ b/lib/main/STM32F1/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_hal_def.h
@@ -85,9 +85,7 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0U)
 
-#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
-#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/lib/main/STM32F3/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_hal_def.h
+++ b/lib/main/STM32F3/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_hal_def.h
@@ -83,9 +83,7 @@ typedef enum
                               (__DMA_HANDLE_).Parent = (__HANDLE__);               \
                           } while(0U)
 
-#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
-#endif
                          
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__ specifies the Peripheral Handle.

--- a/lib/main/STM32F4/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_def.h
+++ b/lib/main/STM32F4/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_def.h
@@ -83,9 +83,7 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0)
 
-#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
-#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
+++ b/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
@@ -82,9 +82,7 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0)
 
-#if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
-#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -24,6 +24,8 @@
 #include <math.h>
 #include <limits.h>
 
+#include "platform.h"
+
 #include "build/debug.h"
 
 #include "common/maths.h"


### PR DESCRIPTION
Caused by missing platform.h inclusion in position.c.
platform.c included runtime_config.h which included build/utils.h which defines `UNUSED` if it's not already defined.  UNUSED was then later redefined by the HAL libraries.

Solution is to include HAL libraries first, via platform.h.

platform.h WAS eventually included, by common/time.h, but UNUSED was already defined at this point.