### PR TITLE
Put display name in CLI 'diff' in a better position.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5029,11 +5029,6 @@ static void printConfig(char *cmdline, bool doDiff)
         cliPrintHashLine("name");
         printName(dumpMask, &pilotConfig_Copy);
 
-#ifdef USE_OSD
-        cliPrintHashLine("display_name");
-        printDisplayName(dumpMask, &pilotConfig_Copy);
-#endif
-
 #ifdef USE_RESOURCE_MGMT
         cliPrintHashLine("resources");
         printResource(dumpMask);
@@ -5116,6 +5111,11 @@ static void printConfig(char *cmdline, bool doDiff)
 
         cliPrintHashLine("rxfail");
         printRxFailsafe(dumpMask, rxFailsafeChannelConfigs_CopyArray, rxFailsafeChannelConfigs(0));
+
+#ifdef USE_OSD
+        cliPrintHashLine("display_name");
+        printDisplayName(dumpMask, &pilotConfig_Copy);
+#endif
 
         cliPrintHashLine("master");
         dumpAllValues(MASTER_VALUE, dumpMask);


### PR DESCRIPTION
It makes sense to have `name` as the identifying name of the craft (in log files / diffs / ...) at the top. `display_name` should go below important information like resource / timer / DMA assignments.