### PR TITLE
Fix rpm telemetry pre-filtering

### DIFF
--- a/src/main/sensors/rpm_filter.c
+++ b/src/main/sensors/rpm_filter.c
@@ -116,7 +116,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config)
     }
 
     for (int i = 0; i < getMotorCount(); i++) {
-        pt1FilterInit(&rpmFilters[i], pt1FilterGain(config->rpm_lpf, pidLooptime));
+        pt1FilterInit(&rpmFilters[i], pt1FilterGain(config->rpm_lpf, pidLooptime * 1e-6f));
     }
 
     erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE  / (motorConfig()->motorPoleCount / 2.0f);
@@ -125,7 +125,8 @@ void rpmFilterInit(const rpmFilterConfig_t *config)
     numberFilters = getMotorCount() * (filters[0].harmonics + filters[1].harmonics);
     const float filtersPerLoopIteration = numberFilters / loopIterationsPerUpdate;
     filterUpdatesPerIteration = rintf(filtersPerLoopIteration + 0.49f);
-    maxFrequency = 0.5f / (gyro.targetLooptime * 1e-6f);
+    // don't go quite to nyquist to avoid oscillations
+    maxFrequency = 0.48f / (gyro.targetLooptime * 1e-6f);
 }
 
 static float applyFilter(rpmNotchFilter_t* filter, int axis, float value)


### PR DESCRIPTION
The data received from escs are very noisy. The rpm filter has a pt1 filter to smooth it. It's frequency was set to rpm_notch_lpf * 1e6 due to a unit mismatch. This PR fixes that.

Additionally this PR sets the upper limit for the notch filters separately for dterm and gyro, adjusting to the respective sampling rates and reduces by 4% to avoid oscillations on the bench.

I decided not to introduce a similar limit to the notch filter in filter.c for now since filter initialization is called on every update of the filter parameters. Which is called 36x per ms by the rpm filter. One could consider splitting the initialization into a wrapper that does the max frequency check and a bare function that only does the parameter update calculation.