### PR TITLE
Fix compile warnings when USE_BEEPER is not defined

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -267,3 +267,8 @@
 #undef USE_GPS_RESCUE
 #undef USE_ACRO_TRAINER
 #endif
+
+#ifndef USE_BEEPER
+#undef BEEPER_PIN
+#undef BEEPER_PWM_HZ
+#endif


### PR DESCRIPTION
If `USE_BEEPER` is undefined but the `BEEPER_PIN` or `BEEPER_PWM_HZ` are defined then there were compile warnings because they get redefined in `beeper.c`.
