### PR TITLE
Fix missing 'platform.h' includes in compilation units, and make them stay away.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -69,6 +69,7 @@ elif [ $GOAL ] ; then
     if [ "test" == "$GOAL" ] ; then
         $MAKE check-target-independence || exit $?
         $MAKE check-fastram-usage-correctness || exit $?
+        $MAKE check-platform-included || exit $?
     fi
 
     $MAKE $GOAL || exit $?

--- a/Makefile
+++ b/Makefile
@@ -572,7 +572,15 @@ check-fastram-usage-correctness:
 		echo "Trivially initialized FAST_RAM variables found, use FAST_RAM_ZERO_INIT instead to save FLASH:"; \
 		echo "$${TRIVIALLY_INITIALIZED}\n$${EXPLICITLY_TRIVIALLY_INITIALIZED}"; \
 		exit 1; \
-	fi;
+	fi
+
+check-platform-included:
+	$(V1) PLATFORM_NOT_INCLUDED=$$(find src/main -type d -name target -prune -o -type f -name \*.c -exec grep -L "^#include \"platform.h\"" {} \;); \
+	if [ "$$(echo $${PLATFORM_NOT_INCLUDED} | grep -v -e '^$$' | wc -l)" -ne 0 ]; then \
+		echo "The following compilation units do not include the required target specific configuration provided by 'platform.h':"; \
+		echo "$${PLATFORM_NOT_INCLUDED}"; \
+		exit 1; \
+	fi
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS): Makefile $(TARGET_DIR)/target.mk $(wildcard make/*)

--- a/src/main/build/atomic.c
+++ b/src/main/build/atomic.c
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "atomic.h"
 
 #if defined(UNIT_TEST)

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -18,8 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "stdint.h"
+#include <stdint.h>
 
+#include "platform.h"
 
 #include "debug.h"
 

--- a/src/main/build/version.c
+++ b/src/main/build/version.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
+
 #include "version.h"
 
 const char * const targetName = __TARGET__;

--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -22,6 +22,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "platform.h"
+
 #include "bitarray.h"
 
 #define BITARRAY_BIT_OP(array, bit, op) ((array)[(bit) / (sizeof((array)[0]) * 8)] op (1 << ((bit) % (sizeof((array)[0]) * 8))))

--- a/src/main/common/colorconversion.c
+++ b/src/main/common/colorconversion.c
@@ -18,7 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "stdint.h"
+#include <stdint.h>
+
+#include "platform.h"
 
 #include "color.h"
 #include "colorconversion.h"

--- a/src/main/common/crc.c
+++ b/src/main/common/crc.c
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "streambuf.h"
 
 

--- a/src/main/common/encoding.c
+++ b/src/main/common/encoding.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
+
 #include "encoding.h"
 
 /**

--- a/src/main/common/explog_approx.c
+++ b/src/main/common/explog_approx.c
@@ -30,6 +30,8 @@ Stripped down for BF use
 #include <math.h>
 #include <stdint.h>
 
+#include "platform.h"
+
 /* Workaround a lack of optimization in gcc */
 float exp_cst1 = 2139095040.f;
 float exp_cst2 = 0.f;

--- a/src/main/common/huffman_table.c
+++ b/src/main/common/huffman_table.c
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "huffman.h"
 
 /*

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <math.h>
 
+#include "platform.h"
+
 #include "axis.h"
 #include "maths.h"
 

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -21,6 +21,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "streambuf.h"
 
 sbuf_t *sbufInit(sbuf_t *sbuf, uint8_t *ptr, uint8_t *end)

--- a/src/main/common/string_light.c
+++ b/src/main/common/string_light.c
@@ -22,6 +22,8 @@
 #include <ctype.h>
 #include <string.h>
 
+#include "platform.h"
+
 #include "typeconversion.h"
 
 int isalnum(int c)

--- a/src/main/common/strtol.c
+++ b/src/main/common/strtol.c
@@ -23,6 +23,8 @@
 #include <ctype.h>
 #include <limits.h>
 
+#include "platform.h"
+
 #include "common/utils.h"
 
 #define _STRTO_ENDPTR 1

--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -26,6 +26,8 @@
 
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "common/maths.h"
 #include "common/printf.h"
 #include "common/time.h"

--- a/src/main/common/typeconversion.c
+++ b/src/main/common/typeconversion.c
@@ -21,6 +21,9 @@
 #include <stdint.h>
 #include <string.h>
 #include <math.h>
+
+#include "platform.h"
+
 #include "build/build_config.h"
 #include "maths.h"
 

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -17,7 +17,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <platform.h>
+
+#include "platform.h"
+
 #include "build/build_config.h"
 #include "build/debug.h"
 #include "barometer.h"

--- a/src/main/drivers/buf_writer.c
+++ b/src/main/drivers/buf_writer.c
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "buf_writer.h"
 
 bufWriter_t *bufWriterInit(uint8_t *b, int total_size, bufWrite_t writer, void *arg)

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
+
 #include "resource.h"
 
 const char * const ownerNames[OWNER_TOTAL_COUNT] = {

--- a/src/main/drivers/sdcard_standard.c
+++ b/src/main/drivers/sdcard_standard.c
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "sdcard_standard.h"
 #include "common/maths.h"
 

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -18,8 +18,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
+
 #include "drivers/io.h"
 #include "timer.h"
+
 #ifdef USE_TIMER_MGMT
 #include "pg/timerio.h"
 #endif

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -24,6 +24,8 @@
 #include <math.h>
 #include <limits.h>
 
+#include "platform.h"
+
 #include "build/debug.h"
 
 #include "common/maths.h"

--- a/src/main/io/asyncfatfs/fat_standard.c
+++ b/src/main/io/asyncfatfs/fat_standard.c
@@ -20,6 +20,8 @@
 
 #include <ctype.h>
 
+#include "platform.h"
+
 #include "fat_standard.h"
 
 bool fat16_isEndOfChainMarker(uint16_t clusterNumber)

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -36,6 +36,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "platform.h"
+
 #include "drivers/flash.h"
 
 #include "io/flashfs.h"

--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "platform.h"
+
 #include "common/crc.h"
 #include "common/maths.h"
 #include "common/streambuf.h"

--- a/src/main/msc/emfat.c
+++ b/src/main/msc/emfat.c
@@ -28,6 +28,8 @@
  * SOFTWARE.
  */
 
+#include "platform.h"
+
 #include "common/utils.h"
 
 #include "emfat.h"

--- a/src/main/pg/rcdevice.c
+++ b/src/main/pg/rcdevice.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
+
 #include "pg/pg_ids.h"
 #include "pg/rcdevice.h"
 

--- a/src/main/startup/system_stm32f30x.c
+++ b/src/main/startup/system_stm32f30x.c
@@ -99,6 +99,8 @@
   * @{
   */
 
+#include "platform.h"
+
 #include "stm32f30x.h"
 
 uint32_t hse_value = HSE_VALUE;

--- a/src/main/vcp/stm32_it.c
+++ b/src/main/vcp/stm32_it.c
@@ -28,6 +28,9 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "hw_config.h"
 #include "stm32_it.h"
 #include "usb_lib.h"

--- a/src/main/vcp/usb_desc.c
+++ b/src/main/vcp/usb_desc.c
@@ -26,6 +26,9 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usb_lib.h"
 #include "usb_desc.h"
 

--- a/src/main/vcp/usb_endp.c
+++ b/src/main/vcp/usb_endp.c
@@ -26,6 +26,9 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usb_lib.h"
 #include "usb_desc.h"
 #include "usb_mem.h"

--- a/src/main/vcp/usb_istr.c
+++ b/src/main/vcp/usb_istr.c
@@ -26,6 +26,9 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usb_lib.h"
 #include "usb_prop.h"
 #include "usb_pwr.h"

--- a/src/main/vcp/usb_prop.c
+++ b/src/main/vcp/usb_prop.c
@@ -26,6 +26,9 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usb_lib.h"
 #include "usb_conf.h"
 #include "usb_prop.h"

--- a/src/main/vcp/usb_pwr.c
+++ b/src/main/vcp/usb_pwr.c
@@ -26,6 +26,9 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usb_lib.h"
 #include "usb_conf.h"
 #include "usb_pwr.h"

--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -46,6 +46,9 @@
   */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "drivers/serial_usb_vcp.h"
 #include "drivers/time.h"
 

--- a/src/main/vcpf4/stm32f4xx_it.c
+++ b/src/main/vcpf4/stm32f4xx_it.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
+
 #include "stm32f4xx_it.h"
 #include "stm32f4xx_conf.h"
 

--- a/src/main/vcpf4/usb_bsp.c
+++ b/src/main/vcpf4/usb_bsp.c
@@ -21,6 +21,9 @@
   */
 
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usb_bsp.h"
 #include "usbd_conf.h"
 #include "stm32f4xx_conf.h"

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -19,15 +19,18 @@
  ******************************************************************************
  */
 
-#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
-#pragma     data_alignment = 4
-#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
-
 /* Includes ------------------------------------------------------------------*/
+
+#include "platform.h"
+
 #include "usbd_cdc_vcp.h"
 #include "stm32f4xx_conf.h"
 #include "stdbool.h"
 #include "drivers/time.h"
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+#pragma     data_alignment = 4
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
 
 __ALIGN_BEGIN USB_OTG_CORE_HANDLE USB_OTG_dev __ALIGN_END;
 

--- a/src/main/vcpf4/usbd_usr.c
+++ b/src/main/vcpf4/usbd_usr.c
@@ -19,6 +19,8 @@
   ******************************************************************************
   */
 
+#include "platform.h"
+
 #include "usbd_usr.h"
 #include "usbd_ioreq.h"
 


### PR DESCRIPTION
Supersedes #7630.