### PR TITLE
Fix logic for tramp CMS "PLEASE CONFIGURE VTXTABLE" message

### DIFF
--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -49,7 +49,7 @@ void trampCmsUpdateStatusString(void)
 {
     vtxDevice_t *vtxDevice = vtxCommonDevice();
 
-    if (vtxDevice->capability.bandCount == 0 || vtxDevice->capability.powerCount) {
+    if (vtxDevice->capability.bandCount == 0 || vtxDevice->capability.powerCount == 0) {
         strncpy(trampCmsStatusString, "PLEASE CONFIGURE VTXTABLE", sizeof(trampCmsStatusString));
         return;
     }


### PR DESCRIPTION
Message was incorrectly displaying even when `vtx table` was properly configured.