### PR TITLE
iTermRelaxFactor fixed to only attenuate amount added to I each loop

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -44,6 +44,7 @@
 // This value gives the same "feel" as the previous Kd default of 26 (26 * DTERM_SCALE)
 #define FEEDFORWARD_SCALE 0.013754f
 
+// Full iterm suppression at 40deg/sec * default cutoff of 20
 #define ITERM_RELAX_SETPOINT_THRESHOLD 30.0f
 
 typedef enum {

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -129,7 +129,7 @@ void setDefaultTestSettings(void) {
     pidProfile->iterm_rotation = false;
     pidProfile->smart_feedforward = false,
     pidProfile->iterm_relax = ITERM_RELAX_OFF,
-    pidProfile->iterm_relax_cutoff = 20,
+    pidProfile->iterm_relax_cutoff = 11,
     pidProfile->iterm_relax_type = ITERM_RELAX_SETPOINT,
     pidProfile->abs_control_gain = 0,
     pidProfile->launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,
@@ -529,12 +529,12 @@ TEST(pidControllerTest, testItermRelax) {
 
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
 
-    ASSERT_NEAR(-6.66, itermErrorRate, calculateTolerance(-6.66));
+    ASSERT_NEAR(-8.16, itermErrorRate, calculateTolerance(-6.66));
     currentPidSetpoint += ITERM_RELAX_SETPOINT_THRESHOLD;
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    EXPECT_FLOAT_EQ(itermErrorRate, 0);
+    ASSERT_NEAR(-2.17, itermErrorRate, calculateTolerance(-2.17));
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    EXPECT_FLOAT_EQ(itermErrorRate, 0);
+    ASSERT_NEAR(-0.58, itermErrorRate, calculateTolerance(-0.58));
 
     pidProfile->iterm_relax_type = ITERM_RELAX_GYRO;
     pidInit(pidProfile);
@@ -578,7 +578,7 @@ TEST(pidControllerTest, testItermRelax) {
     pidProfile->iterm_relax = ITERM_RELAX_RPY;
     pidInit(pidProfile);
     applyItermRelax(FD_YAW, pidData[FD_YAW].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    ASSERT_NEAR(-3.6, itermErrorRate, calculateTolerance(-3.6));
+    ASSERT_NEAR(-6.46, itermErrorRate, calculateTolerance(-3.6));
 }
 
 // TODO - Add more tests

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -129,7 +129,7 @@ void setDefaultTestSettings(void) {
     pidProfile->iterm_rotation = false;
     pidProfile->smart_feedforward = false,
     pidProfile->iterm_relax = ITERM_RELAX_OFF,
-    pidProfile->iterm_relax_cutoff = 11,
+    pidProfile->iterm_relax_cutoff = 20,
     pidProfile->iterm_relax_type = ITERM_RELAX_SETPOINT,
     pidProfile->abs_control_gain = 0,
     pidProfile->launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,


### PR DESCRIPTION
The original setpoint based iTerm Relax code attenuated the amount of iTerm added per loop by a relax factor based on an HPF of setpoint.  This reduced I accumulation during faster inputs but retained I accumulation for slower inputs.  The transition was smooth, and the total accumulated amount of I was never zeroed out, it only reduced the rate of change of I.

At some point the code was re-factored and the relax factor became applied to the whole accumulating iterm error, not the amount added per loop.  The result was that almost any relax factor below 1.0 would quickly zero out iTerm.

This was bad because when making tight turns that required I, such as spirals around a pole or other tight fast racing turns, if the input was such that the setpoint was close to the relax point, I would be abruptly be zeroed, causing the quad to run wide, often making it very difficult to maintain a constant turn radius.

This was never the intention of the original proposal, which was for a smoother attenuation of iTerm, and for retention of some accumulation of iTerm during spirals around poles etc.

I've made one other change, that being to introduce a form of simple cutoff independence.  In the initial form, lowering cutoff would cause smoothing that would reduce the amplitude of the cutoff factor.  With this modification, cutoff changes now only affect onset and duration; lower cutoff values are better for quads with greater motor delay, faster values are better for quicker quads.  For most of my quads a cutoff of 30-40 is good.

I've also removed newlines to improve readability.

Could reviewers please also look generally at the code in this area, perhaps from an efficiency perspective.  That's not a strong point of mine.  Thanks