### PR TITLE
Add new target FLYWOOF411 board

### DIFF
--- a/docs/boards/Board - FLYWOOF411.md
+++ b/docs/boards/Board - FLYWOOF411.md
@@ -1,0 +1,96 @@
+# Board - FLYWOOF411
+
+This board use the STM32F411CEU6 microcontroller and have the following features:
+
+* The 16M byte SPI flash for data logging
+* USB VCP and boot select button on board(for DFU)
+* Stable voltage regulation,9V/1.5A DCDC BEC for VTX/camera etc.And could select 5v/9v with pad
+* Serial LED interface(LED_STRIP)
+* VBAT/CURR/RSSI sensors input
+* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
+* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
+* Supports I2C device extend(baro/compass/OLED etc)
+* Supports GPS 
+
+### All uarts have pad on board 
+| Value | Identifier   | RX   | TX   | Notes                                                                                       |
+| ----- | ------------ | -----| -----| ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PB7 |  PB6 | FOR SBUS IN(inverter build in)                                                      |
+| 2     | USART2       | PA3 |  PA2|  FOR VTX SM/IRC ETC                                                                                    |
+
+
+### I2C with GPS port together.Use for BARO or compass etc 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | I2C1         |    SDA   |  PB9   | with GPS outlet
+| 2     | I2C1         |    SCL   |  PB8   | with GPS outlet
+
+
+### Buzzer/LED output 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | LED0         |    LED   |  PC13  | 
+| 2     | BEEPER       |    BEE   |  PC14  | 
+
+
+### VBAT input with 1/10 divider ratio,Current signal input,Analog/digit RSSI input
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | ADC1         |    VBAT   |  PA0  |  DMA2_Stream0
+| 2     | ADC1         |    CURR   |  PA1  |  DMA2_Stream0
+| 3     | ADC1         |    RSSI   |  PB1  |  DMA2_Stream0
+
+
+### 8 Outputs, 1 PPM input 
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | TIM9_CH1     |    PPM    |  PA2  |  PPM
+| 2     | TIM1_CH1     |    OUPUT1 |  PA8  |  DMA2_Stream1
+| 3     | TIM1_CH2     |    OUPUT2 |  PA9  |  DMA2_Stream2
+| 4     | TIM1_CH3     |    OUPUT3 |  PA10 |  DMA2_Stream6
+| 5     | TIM3_CH3     |    OUPUT4 |  PB0  |  DMA1_Stream7
+| 6     | TIM3_CH1     |    OUPUT5 |  PB4  |  DMA1_Stream4
+| 7     | TIM3_CH4     |    ANY    |  PB1  |  DMA1_Stream2
+| 8     | TIM5_CH4     |    ANY    |  PA3  |  DMA1_Stream3   
+| 9     | TIM2_CH3     |    CAM_C  |  PB10 |  DMA1_Stream1   
+| 10    | TIM2_CH4     |    LED    |  PB11 |  DMA1_Stream6
+
+
+### Gyro & ACC  ICM20689
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI1         |    SCK   |  PA5   | 
+| 2     | SPI1         |    MISO  |  PA6   | 
+| 3     | SPI1         |    MOSI  |  PA7   | 
+| 4     | SPI1         |    CS    |  PA4   | 
+
+### OSD MAX7456
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI3         |    SCK   |  PB13  | 
+| 2     | SPI3         |    MISO  |  PB14  | 
+| 3     | SPI3         |    MOSI  |  PB15   | 
+| 4     | SPI3         |    CS    |  PB12  |
+
+### 16Mbyte flash
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI3         |    SCK   |  PB13  | 
+| 2     | SPI3         |    MISO  |  PB14  | 
+| 3     | SPI3         |    MOSI  |  PB15   | 
+| 4     | SPI3         |    CS    |  PB2  | 
+
+### SWD
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | SWCLK          | PAD                                          |
+| 2   | Ground         | PAD                                          |
+| 3   | SWDIO          | PAD                                          |
+| 4   | 3V3            | PAD                                          |
+
+* FLYWOO TECH
+
+
+
+
+

--- a/src/main/target/FLYWOOF411/config.c
+++ b/src/main/target/FLYWOOF411/config.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "io/serial.h"
+#include "pg/piniobox.h"
+#include "target.h"
+
+#define USE_TARGET_CONFIG
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = 40;
+    pinioBoxConfigMutable()->permanentId[1] = 41;
+    
+}
+

--- a/src/main/target/FLYWOOF411/target.c
+++ b/src/main/target/FLYWOOF411/target.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM9, CH1, PA2,   TIM_USE_PPM,   0, 0), // PPM IN
+
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MOTOR,  0, 1), // S1_OUT 2,1
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_MOTOR,  0, 1), // S2_OUT 2,2
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MOTOR,  0, 0), // S3_OUT 2,6
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR,  0, 0), // S4_OUT 1,7
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_MOTOR, 0, 0), //  S5_OUT 1,4
+    //DEF_TIM(TIM3, CH2, PB5,  TIM_USE_MOTOR, 0, 0), //  S6_OUT 1,5
+	
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_ANY,   0, 0), //  RSSI   1,2
+    DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2    1,0
+    DEF_TIM(TIM2, CH3, PB10, TIM_USE_CAMERA_CONTROL,   0, 0), //  CAM CC 1,1
+    DEF_TIM(TIM2, CH4, PB11, TIM_USE_LED,   0, 0), //  LED    1,6
+};

--- a/src/main/target/FLYWOOF411/target.h
+++ b/src/main/target/FLYWOOF411/target.h
@@ -1,0 +1,148 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER "FW41"
+#define USBD_PRODUCT_STRING     "FLYWOOF411"
+
+#define LED0_PIN                PC13
+
+#define USE_BEEPER
+#define BEEPER_PIN              PC14
+#define BEEPER_INVERTED
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define GYRO_1_CS_PIN           PA4
+#define GYRO_1_SPI_INSTANCE     SPI1
+
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PB3
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM20689
+#define GYRO_1_ALIGN            CW180_DEG
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM20689
+#define ACC_1_ALIGN             CW180_DEG
+
+// *************** Baro **************************
+#define USE_I2C
+
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE              (I2CDEV_1)
+#define I2C1_SCL                PB8        // SCL pad
+#define I2C1_SDA                PB9        // SDA pad
+#define BARO_I2C_INSTANCE       (I2CDEV_1)
+
+#define USE_BARO                          //External, connect to I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+
+#define USE_MAG
+#define USE_MAG_HMC5883                   //External, connect to I2C1
+#define USE_MAG_QMC5883
+
+// *************** UART *****************************
+#define USE_VCP
+#define USB_DETECT_PIN          PC15
+#define USE_USB_DETECT
+
+#define USE_UART1
+#define UART1_RX_PIN            PB7
+#define UART1_TX_PIN            PB6
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+#define SERIAL_PORT_COUNT       5
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART1
+
+// *************** OSD/FLASH *****************************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI2
+#define MAX7456_SPI_CS_PIN      PB12
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define FLASH_CS_PIN            PB2
+#define FLASH_SPI_INSTANCE      SPI2
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE         ADC1  
+#define ADC1_DMA_OPT            0  // DMA 2 Stream 0 Channel 0 
+
+#define VBAT_ADC_PIN            PA0
+#define CURRENT_METER_ADC_PIN   PA1
+#define RSSI_ADC_PIN            PB1
+//#define EXTERNAL1_ADC_PIN       PA4
+
+#define USE_ESCSERIAL
+
+#define USE_LED_STRIP
+
+#define USE_PINIO
+#define PINIO1_PIN              PB5  // VTX  switcher
+#define PINIO2_PIN              PA15 // Camera switcher
+#define USE_PINIOBOX
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL | FEATURE_LED_STRIP)
+#define CURRENT_METER_SCALE_DEFAULT         170
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 10
+#define USED_TIMERS             ( TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(5)|TIM_N(9) )
+

--- a/src/main/target/FLYWOOF411/target.mk
+++ b/src/main/target/FLYWOOF411/target.mk
@@ -1,0 +1,13 @@
+F411_TARGETS    += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_icm20689.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms5611.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
+            drivers/max7456.c


### PR DESCRIPTION
# Board - FLYWOOF411

This board use the STM32F411CEU6 microcontroller and have the following features:
* The 16M byte SPI flash for data logging
* USB VCP and boot select button on board(for DFU)
* Stable voltage regulation,9V/2A DCDC BEC for VTX/camera etc.And could select 5v/9v with pad
* Serial LED interface(LED_STRIP)
* VBAT/CURR/RSSI sensors input
* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
* Supports I2C device extend(baro/compass/OLED etc)
* Supports GPS 
* Supports VTX  switcher /Camera switcher