### PR TITLE
set usbDetectPin to input pull down

### DIFF
--- a/src/main/drivers/usb_io.c
+++ b/src/main/drivers/usb_io.c
@@ -49,7 +49,7 @@ void usbCableDetectInit(void)
     usbDetectPin = IOGetByTag(IO_TAG(USB_DETECT_PIN));
 
     IOInit(usbDetectPin, OWNER_USB_DETECT, 0);
-    IOConfigGPIO(usbDetectPin, IOCFG_OUT_PP);
+    IOConfigGPIO(usbDetectPin, IOCFG_IPD);
 #endif
 }
 


### PR DESCRIPTION
`usbDetectPin` is used for USB plug-in detection, better to set it to input mode with internal pull down. 

Set to `IOCFG_OUT_PP` will make it unpredictable and may damage the pin if connected 5V to without external resistor. 