### PR TITLE
Revert "iTermRelaxFactor now only attenuates amount added"

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -44,7 +44,6 @@
 // This value gives the same "feel" as the previous Kd default of 26 (26 * DTERM_SCALE)
 #define FEEDFORWARD_SCALE 0.013754f
 
-// Full iterm suppression at 40deg/sec * default cutoff of 20
 #define ITERM_RELAX_SETPOINT_THRESHOLD 30.0f
 
 typedef enum {


### PR DESCRIPTION
This reverts commit 1d998ea4041088293433cf0f301bca53867e525d.

Back to drawing table...

Let's better rethink desired behaviour
