### PR TITLE
iterm_relax setpoint mode update

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -621,6 +621,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     itermRelax = pidProfile->iterm_relax;
     itermRelaxType = pidProfile->iterm_relax_type;
     itermRelaxCutoff = pidProfile->iterm_relax_cutoff;
+    // 20.0f below is current default itermRelaxCutoff value, to adapt setpoint to change from cutoff
     itermRelaxSetpointThreshold = ITERM_RELAX_SETPOINT_THRESHOLD * 20.0f / itermRelaxCutoff;
 #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -170,7 +170,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .iterm_rotation = true,
         .smart_feedforward = false,
         .iterm_relax = ITERM_RELAX_RP,
-        .iterm_relax_cutoff = 20,
+        .iterm_relax_cutoff = ITERM_RELAX_CUTOFF_DEFAULT,
         .iterm_relax_type = ITERM_RELAX_SETPOINT,
         .acro_trainer_angle_limit = 20,
         .acro_trainer_lookahead_ms = 50,
@@ -621,8 +621,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     itermRelax = pidProfile->iterm_relax;
     itermRelaxType = pidProfile->iterm_relax_type;
     itermRelaxCutoff = pidProfile->iterm_relax_cutoff;
-    // 20.0f below is current default itermRelaxCutoff value, to adapt setpoint to change from cutoff
-    itermRelaxSetpointThreshold = ITERM_RELAX_SETPOINT_THRESHOLD * 20.0f / itermRelaxCutoff;
+    // adapt setpoint threshold to user changes from default cutoff value
+    itermRelaxSetpointThreshold = ITERM_RELAX_SETPOINT_THRESHOLD * ITERM_RELAX_CUTOFF_DEFAULT / itermRelaxCutoff;
 #endif
 
 #ifdef USE_ACRO_TRAINER

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -46,6 +46,7 @@
 
 // Full iterm suppression in setpoint mode at high-passed setpoint rate > 40deg/sec
 #define ITERM_RELAX_SETPOINT_THRESHOLD 40.0f
+#define ITERM_RELAX_CUTOFF_DEFAULT 20
 
 typedef enum {
     PID_ROLL,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -44,8 +44,8 @@
 // This value gives the same "feel" as the previous Kd default of 26 (26 * DTERM_SCALE)
 #define FEEDFORWARD_SCALE 0.013754f
 
-// Full iterm suppression at 40deg/sec * default cutoff of 20
-#define ITERM_RELAX_SETPOINT_THRESHOLD 30.0f
+// Full iterm suppression in setpoint mode at high-passed setpoint rate > 40deg/sec
+#define ITERM_RELAX_SETPOINT_THRESHOLD 40.0f
 
 typedef enum {
     PID_ROLL,

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -529,12 +529,12 @@ TEST(pidControllerTest, testItermRelax) {
 
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
 
-    ASSERT_NEAR(-8.16, itermErrorRate, calculateTolerance(-6.66));
+    ASSERT_NEAR(-8.16, itermErrorRate, calculateTolerance(-8.16));
     currentPidSetpoint += ITERM_RELAX_SETPOINT_THRESHOLD;
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    ASSERT_NEAR(-2.17, itermErrorRate, calculateTolerance(-2.17));
+    ASSERT_NEAR(-2.69, itermErrorRate, calculateTolerance(-2.69));
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    ASSERT_NEAR(-0.58, itermErrorRate, calculateTolerance(-0.58));
+    ASSERT_NEAR(-0.84, itermErrorRate, calculateTolerance(-0.84));
 
     pidProfile->iterm_relax_type = ITERM_RELAX_GYRO;
     pidInit(pidProfile);


### PR DESCRIPTION
This PR is to update and clarify issues arising from the earlier PR [https://github.com/betaflight/pull/7652] that has been previously committed to master.

Summary of changes:

Default full relax threshold increased from 30 to 40 deg/sec
Anotations provided to explain
- cutoff independence factor when calculating itermRelaxSetpointThreshold
- meaning of ITERM_RELAX_SETPOINT_THRESHOLD
Notation as to intent of previous PR and likely unit test failure of this PR.