### PR TITLE
allow use of dshot bidir on targets without burst

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -722,9 +722,9 @@ const clivalue_t valueTable[] = {
     { "dshot_idle_value",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 2000 }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, digitalIdleOffsetValue) },
 #ifdef USE_DSHOT_DMAR
     { "dshot_burst",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useBurstDshot) },
+#endif
 #ifdef USE_DSHOT_TELEMETRY
     { "dshot_bidir",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotTelemetry) },
-#endif
 #endif
 #endif
     { "use_unsynced_pwm",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useUnsyncedPwm) },

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -208,6 +208,22 @@
 #define DEFAULT_FEATURES        (FEATURE_RSSI_ADC | FEATURE_TELEMETRY)
 #endif
 
+#undef USE_OSD
+#undef USE_ACRO_TRAINER
+#undef USE_PPM
+#undef SERIAL_RX_IBUS
+#undef USE_GYRO_REGISTER_DUMP
+#undef USE_SERIALRX_SUMD
+#undef USE_LED_STRIP
+#undef USE_DSHOT_DMAR
+#undef USE_SERVOS
+#define USE_ABSOLUTE_CONTROL
+#define USE_DSHOT_TELEMETRY
+#define USE_RPM_FILTER
+#define USE_AIRMODE_LPF
+
+
+
 // IO - stm32f303cc in 48pin package
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -208,22 +208,6 @@
 #define DEFAULT_FEATURES        (FEATURE_RSSI_ADC | FEATURE_TELEMETRY)
 #endif
 
-#undef USE_OSD
-#undef USE_ACRO_TRAINER
-#undef USE_PPM
-#undef SERIAL_RX_IBUS
-#undef USE_GYRO_REGISTER_DUMP
-#undef USE_SERIALRX_SUMD
-#undef USE_LED_STRIP
-#undef USE_DSHOT_DMAR
-#undef USE_SERVOS
-#define USE_ABSOLUTE_CONTROL
-#define USE_DSHOT_TELEMETRY
-#define USE_RPM_FILTER
-#define USE_AIRMODE_LPF
-
-
-
 // IO - stm32f303cc in 48pin package
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff


### PR DESCRIPTION
Trivial fix to allow configuring dshot bidir on targets that don't support dshot burst.