### PR TITLE
Place ADC DMA buffer in DTCM RAM

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -39,7 +39,7 @@
 //#define DEBUG_ADC_CHANNELS
 
 adcOperatingConfig_t adcOperatingConfig[ADC_CHANNEL_COUNT];
-volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
+volatile FAST_RAM_ZERO_INIT uint16_t adcValues[ADC_CHANNEL_COUNT];
 
 #ifdef USE_ADC_INTERNAL
 uint16_t adcTSCAL1;


### PR DESCRIPTION
Places adcValues in non cached DTCM RAM to avoid problems when D-cache is enabled for F7 mcus.
Should fix #7579.
