### PR TITLE
Fix SmartAudio 'looping' after vtx_freq in MHz set on AKK

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -584,6 +584,9 @@ static void saDoDevSetFreq(uint16_t freq)
         switchBuf[6] = CRC8(switchBuf, 6);
 
         saQueueCmd(switchBuf, 7);
+
+        // need to do a 'get' between the 'set' commands to keep tracking vars in sync
+        saGetSettings();
     }
 
     saQueueCmd(buf, 7);


### PR DESCRIPTION
This is to apply PR #7157 to the AKK-3.5.x branch.  I see the SmartAudio 'looping' issue on my AKK VTXs, so this fix is needed on the AKK branch.

--ET
