### PR TITLE
Make placing ADC DMA buffer in FAST RAM conditional to F7

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -39,7 +39,12 @@
 //#define DEBUG_ADC_CHANNELS
 
 adcOperatingConfig_t adcOperatingConfig[ADC_CHANNEL_COUNT];
+
+#if defined(STM32F7)
 volatile FAST_RAM_ZERO_INIT uint16_t adcValues[ADC_CHANNEL_COUNT];
+#else
+volatile uint16_t adcValues[ADC_CHANNEL_COUNT];
+#endif
 
 #ifdef USE_ADC_INTERNAL
 uint16_t adcTSCAL1;


### PR DESCRIPTION
Follow up to #7687 which makes voltage/current readings stop working for some F4 mcus. This was an oversight on my part, and i apologize. 🙁 I just assumed that ``FAST_RAM_ZERO_INIT`` was only defined for F7 mcus, which is not the case. 
This places the ADC DMA buffer in FAST RAM for F7 only.
