### PR TITLE
Fix SmartAudio 'looping' after vtx_freq in MHz set 3.5.x

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -576,6 +576,9 @@ static void saDoDevSetFreq(uint16_t freq)
         switchBuf[6] = CRC8(switchBuf, 6);
 
         saQueueCmd(switchBuf, 7);
+
+        // need to do a 'get' between the 'set' commands to keep tracking vars in sync
+        saGetSettings();
     }
 
     saQueueCmd(buf, 7);


### PR DESCRIPTION
This is to apply PR #7157 to the '3.5.x-maintenance' branch. I see the SmartAudio 'looping' issue on my AKK VTXs, so this fix is needed on the '3.5.x-maintenance' branch.

(As of https://github.com/betaflight/betaflight/commit/0ba0dc8bb94dd6b00645623f6f022dca3e94b4d5 the '3.5.x-maintenance' branch supports AKK and TBS Unify nano VTXs.)

--ET