### PR TITLE
Added custom names for pid and rate profiles for display on osd

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -844,7 +844,7 @@ const clivalue_t valueTable[] = {
     { "roll_rate_limit",            VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_ROLL]) },
     { "pitch_rate_limit",           VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_PITCH]) },
     { "yaw_rate_limit",             VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_YAW]) },
-
+	{ "rate_name",					VAR_CHAR   | PROFILE_RATE_VALUE | MODE_ARRAY, .config.array.length = MAX_RATE_PROFILE_NAME_LENGTH, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, name) },
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },
     { "serial_update_rate_hz",      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 2000 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, serial_update_rate_hz) },
@@ -931,6 +931,8 @@ const clivalue_t valueTable[] = {
     { "crash_recovery",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRASH_RECOVERY }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_recovery) },
 
     { "iterm_rotation",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_rotation) },
+	{ "profile_name",				VAR_CHAR   | PROFILE_VALUE | MODE_ARRAY, .config.array.length = MAX_PROFILE_NAME_LENGTH, PG_PID_PROFILE, offsetof(pidProfile_t, name) },
+
 #if defined(USE_SMART_FEEDFORWARD)
     { "smart_feedforward",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, smart_feedforward) },
 #endif

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -147,12 +147,13 @@ typedef struct lookupTableEntry_s {
 #define VALUE_MODE_OFFSET 5
 
 typedef enum {
-    // value type, bits 0-2
-    VAR_UINT8 = (0 << VALUE_TYPE_OFFSET),
-    VAR_INT8 = (1 << VALUE_TYPE_OFFSET),
-    VAR_UINT16 = (2 << VALUE_TYPE_OFFSET),
-    VAR_INT16 = (3 << VALUE_TYPE_OFFSET),
-    VAR_UINT32 = (4 << VALUE_TYPE_OFFSET),
+	// value type, bits 0-2
+	VAR_UINT8 = (0 << VALUE_TYPE_OFFSET),
+	VAR_INT8 = (1 << VALUE_TYPE_OFFSET),
+	VAR_UINT16 = (2 << VALUE_TYPE_OFFSET),
+	VAR_INT16 = (3 << VALUE_TYPE_OFFSET),
+	VAR_UINT32 = (4 << VALUE_TYPE_OFFSET),
+	VAR_CHAR = (5 << VALUE_TYPE_OFFSET),
 
     // value section, bits 3-4
     MASTER_VALUE = (0 << VALUE_SECTION_OFFSET),

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -66,6 +66,7 @@
 #include "sensors/rpm_filter.h"
 
 #include "scheduler/scheduler.h"
+#include "common/typeconversion.h"
 
 pidProfile_t *currentPidProfile;
 
@@ -102,6 +103,17 @@ uint8_t getCurrentPidProfileIndex(void)
     return systemConfig()->pidProfileIndex;
 }
 
+char* getCurrentPidProfileName(void)
+{
+	if (strlen(currentPidProfile->name) > 0)
+	{
+		return currentPidProfile->name;
+	}
+	char buffer[2];
+	return itoa(getCurrentPidProfileIndex() + 1, buffer, 10);
+}
+
+
 static void loadPidProfile(void)
 {
     currentPidProfile = pidProfilesMutable(systemConfig()->pidProfileIndex);
@@ -110,6 +122,16 @@ static void loadPidProfile(void)
 uint8_t getCurrentControlRateProfileIndex(void)
 {
     return systemConfig()->activeRateProfile;
+}
+
+char* getCurrentControlRateProfileName(void)
+{
+	if (strlen(currentControlRateProfile->name) > 0)
+	{
+		return currentControlRateProfile->name;
+	}
+	char buffer[2];
+	return itoa(getCurrentControlRateProfileIndex() + 1, buffer, 10);
 }
 
 uint16_t getCurrentMinthrottle(void)

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -64,12 +64,15 @@ void saveConfigAndNotify(void);
 void validateAndFixGyroConfig(void);
 
 uint8_t getCurrentPidProfileIndex(void);
+char* getCurrentPidProfileName(void);
 void changePidProfile(uint8_t pidProfileIndex);
 void changePidProfileFromCellCount(uint8_t cellCount);
 struct pidProfile_s;
 void resetPidProfile(struct pidProfile_s *profile);
 
 uint8_t getCurrentControlRateProfileIndex(void);
+char* getCurrentControlRateProfileName(void);
+
 void changeControlRateProfile(uint8_t profileIndex);
 
 bool canSoftwareSerialBeUsed(void);

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -37,7 +37,7 @@
 
 controlRateConfig_t *currentControlRateProfile;
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 2);
 
 void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
 {
@@ -63,6 +63,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_PITCH] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .tpaMode = TPA_MODE_D,
+		    .name[0] = '\0',
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -24,6 +24,8 @@
 
 #include "pg/pg.h"
 
+#define MAX_RATE_PROFILE_NAME_LENGTH 8u
+
 typedef enum {
     RATES_TYPE_BETAFLIGHT = 0,
     RATES_TYPE_RACEFLIGHT,
@@ -55,6 +57,7 @@ typedef struct controlRateConfig_s {
     uint8_t throttle_limit_percent;         // Sets the maximum pilot commanded throttle limit
     uint16_t rate_limit[3];                 // Sets the maximum rate for the axes
     uint8_t tpaMode;                        // Controls which PID terms TPA effects
+	char name[MAX_RATE_PROFILE_NAME_LENGTH];
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -83,7 +83,7 @@ static FAST_RAM float antiGravityOsdCutoff = 1.0f;
 static FAST_RAM_ZERO_INIT bool antiGravityEnabled;
 static FAST_RAM_ZERO_INIT bool zeroThrottleItermReset;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
 
 #ifdef STM32F10X
 #define PID_PROCESS_DENOM_DEFAULT       1
@@ -201,6 +201,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .motor_output_limit = 100,
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
         .transient_throttle_limit = 0,
+		.name[0] = '\0',
     );
 #ifdef USE_DYN_LPF
     pidProfile->dterm_lowpass_hz = 150;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -47,6 +47,8 @@
 // Full iterm suppression at 40deg/sec * default cutoff of 20
 #define ITERM_RELAX_SETPOINT_THRESHOLD 30.0f
 
+#define MAX_PROFILE_NAME_LENGTH 8u
+
 typedef enum {
     PID_ROLL,
     PID_PITCH,
@@ -167,6 +169,7 @@ typedef struct pidProfile_s {
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
+	char name[MAX_PROFILE_NAME_LENGTH];
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -827,7 +827,23 @@ static void osdElementNumericalVario(osdElementParms_t *element)
 
 static void osdElementPidRateProfile(osdElementParms_t *element)
 {
-    tfp_sprintf(element->buff, "%d-%d", getCurrentPidProfileIndex() + 1, getCurrentControlRateProfileIndex() + 1);
+	char *profileName = getCurrentControlRateProfileName();
+	char *pidName = getCurrentPidProfileName();
+	unsigned int i = 0;
+	while (pidName[i])
+	{
+		element->buff[i] = toupper((unsigned char)pidName[i]);
+		++i;
+	}
+	element->buff[i] = '-';
+	++i;
+	unsigned int j = 0;
+	while (profileName[j])
+	{
+		element->buff[i + j] = toupper((unsigned char)profileName[j]);
+		j++;
+	}
+	element->buff[i + j] = '\0';
 }
 
 static void osdElementPidsPitch(osdElementParms_t *element)


### PR DESCRIPTION
I added names for pid profiles and rates profiles, names can be set in cli. If no profile name is set profiles names are displayed as numbers, like before. 
Names can be changed by set profile_name = "new_name" or set rate_name = "new_name" 
