### PR TITLE
removed sbus stateflags and associated debug_set

### DIFF
--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -102,7 +102,6 @@ typedef union sbusFrame_u {
 typedef struct sbusFrameData_s {
     sbusFrame_t frame;
     uint32_t startAtUs;
-    uint16_t stateFlags;
     uint8_t position;
     bool done;
 } sbusFrameData_t;
@@ -148,17 +147,6 @@ static uint8_t sbusFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
     sbusFrameData->done = false;
 
     DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_FRAME_FLAGS, sbusFrameData->frame.frame.channels.flags);
-
-    if (sbusFrameData->frame.frame.channels.flags & SBUS_FLAG_SIGNAL_LOSS) {
-        sbusFrameData->stateFlags |= SBUS_STATE_SIGNALLOSS;
-        DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_STATE_FLAGS, sbusFrameData->stateFlags);
-    }
-    if (sbusFrameData->frame.frame.channels.flags & SBUS_FLAG_FAILSAFE_ACTIVE) {
-        sbusFrameData->stateFlags |= SBUS_STATE_FAILSAFE;
-        DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_STATE_FLAGS, sbusFrameData->stateFlags);
-    }
-
-    DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_STATE_FLAGS, sbusFrameData->stateFlags);
 
     return sbusChannelsDecode(rxRuntimeConfig, &sbusFrameData->frame.frame.channels);
 }


### PR DESCRIPTION
Removed sbus stateflags and associated debug_set as this provides nothing above what can be obtained from the frame flags apart from latched state information as the stateflags are not cleared down at any point.

Provides a small reduction in code.


