### PR TITLE
add a new target KakuteF7mini

### DIFF
--- a/src/main/target/KAKUTEF7/KAKUTEF7MINI.mk
+++ b/src/main/target/KAKUTEF7/KAKUTEF7MINI.mk
@@ -1,0 +1,1 @@
+#KAKUTEF7MINI.mk file

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -21,9 +21,13 @@
 #pragma once
 
 //#define USE_TARGET_CONFIG
-
+#if defined(KAKUTEF7MINI)
+#define TARGET_BOARD_IDENTIFIER "KF7M"
+#define USBD_PRODUCT_STRING "KakuteF7-Mini"
+#else
 #define TARGET_BOARD_IDENTIFIER "KTF7"
 #define USBD_PRODUCT_STRING "KakuteF7"
+#endif
 
 #define LED0_PIN                PA2
 
@@ -115,6 +119,13 @@
 #define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD) // 10MHz
 #define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
 
+#if defined(KAKUTEF7MINI)
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define FLASH_CS_PIN            SPI1_NSS_PIN
+#define FLASH_SPI_INSTANCE      SPI1
+#else
 #define USE_SDCARD
 #define SDCARD_DETECT_INVERTED
 #define SDCARD_DETECT_PIN                   PD8
@@ -128,6 +139,7 @@
 
 #define SDCARD_DMA_STREAM_TX_FULL             DMA2_Stream5
 #define SDCARD_DMA_CHANNEL                    3
+#endif
 
 #define USE_I2C
 #define USE_I2C_DEVICE_1

--- a/src/main/target/KAKUTEF7/target.mk
+++ b/src/main/target/KAKUTEF7/target.mk
@@ -1,5 +1,9 @@
 F7X5XG_TARGETS += $(TARGET)
+ifeq ($(TARGET), KAKUTEF7MINI)
+FEATURES       += VCP ONBOARDFLASH
+else
 FEATURES       += SDCARD VCP
+endif
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \


### PR DESCRIPTION
KakuteF7mini has a small size of 27*27mm. There is no space to place a TF connector onboard. So I have to change the blackbox to onboard SPI flash. This makes it different from KakuteF7. It is a new target.
