### PR TITLE
[BARO, LPS] Don't fiddle with SPI if the device is not on SPI bus

### DIFF
--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -252,6 +252,11 @@ bool lpsDetect(baroDev_t *baro)
 {
     //Detect
     busDevice_t *busdev = &baro->busdev;
+
+    if (busdev->bustype != BUSTYPE_SPI) {
+        return false;
+    }
+
     IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
     IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
     IOHi(busdev->busdev_u.spi.csnPin); // Disable


### PR DESCRIPTION
Fixes #7708.

`lpsDetect` hard faults while fiddling with SPI divider when `baro_bustype` set to `BUSTYPE_I2C` (no valid SPI device set up.)