### PR TITLE
Add integrated yaw to MSP

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1484,6 +1484,14 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
 #endif
+#if defined(USE_INTEGRATED_YAW_CONTROL)
+        sbufWriteU8(dst, currentPidProfile->use_integrated_yaw);
+        sbufWriteU8(dst, currentPidProfile->integrated_yaw_relax);
+#else
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+#endif
+
         break;
     case MSP_SENSOR_CONFIG:
 #if defined(USE_ACC)
@@ -2147,6 +2155,15 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             sbufReadU8(src);
             sbufReadU8(src);
             sbufReadU8(src);
+            sbufReadU8(src);
+            sbufReadU8(src);
+#endif
+        }
+        if (sbufBytesRemaining(src) >= 2) {
+#if defined(USE_INTEGRATED_YAW_CONTROL)
+            currentPidProfile->use_integrated_yaw = sbufReadU8(src);
+            currentPidProfile->integrated_yaw_relax = sbufReadU8(src);
+#else
             sbufReadU8(src);
             sbufReadU8(src);
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2144,7 +2144,8 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 
             currentPidProfile->antiGravityMode = sbufReadU8(src);
         }
-        if (sbufBytesRemaining(src) >= 5) {
+        if (sbufBytesRemaining(src) >= 7) {
+            // Added in MSP API 1.41
 #if defined(USE_D_MIN)
             currentPidProfile->d_min[PID_ROLL] = sbufReadU8(src);
             currentPidProfile->d_min[PID_PITCH] = sbufReadU8(src);
@@ -2158,8 +2159,6 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             sbufReadU8(src);
             sbufReadU8(src);
 #endif
-        }
-        if (sbufBytesRemaining(src) >= 2) {
 #if defined(USE_INTEGRATED_YAW_CONTROL)
             currentPidProfile->use_integrated_yaw = sbufReadU8(src);
             currentPidProfile->integrated_yaw_relax = sbufReadU8(src);


### PR DESCRIPTION
Adds the integrated yaw feature to MSP, in this way we can add it to the Configurator. 

@joelucid if I'm not wrong, we have only two variables in integrated yaw. Right?

