### PR TITLE
init led and bind IOs for sfhss

### DIFF
--- a/src/main/rx/cc2500_sfhss.c
+++ b/src/main/rx/cc2500_sfhss.c
@@ -425,7 +425,7 @@ rx_spi_received_e sfhssSpiDataReceived(uint8_t *packet)
 
 bool sfhssSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
-    UNUSED(rxSpiConfig);
+    rxSpiCommonIOInit(rxSpiConfig);
 
     cc2500SpiInit();
 


### PR DESCRIPTION
Init led and bind IOs for SFHSS as they are used in this protocol. 