### PR TITLE
Fix timed GPS RESCUE OFF message condition

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1054,7 +1054,7 @@ static void osdElementWarnings(osdElementParms_t *element)
        gpsRescueIsConfigured() &&
        !gpsRescueIsDisabled() &&
        !gpsRescueIsAvailable()) {
-        osdFormatMessage(element->buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "NO GPS RESC");
+        osdFormatMessage(element->buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "RESCUE N/A");
         SET_BLINK(OSD_WARNINGS);
         return;
     }
@@ -1065,8 +1065,8 @@ static void osdElementWarnings(osdElementParms_t *element)
        gpsRescueIsDisabled()) {
 
         statistic_t *stats = osdGetStats();
-        if (!cmpTimeUs(stats->armed_time, OSD_GPS_RESCUE_DISABLED_WARNING_DURATION_US)) {
-            osdFormatMessage(element->buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "RESC OFF!!!");
+        if (cmpTimeUs(stats->armed_time, OSD_GPS_RESCUE_DISABLED_WARNING_DURATION_US) < 0) {
+            osdFormatMessage(element->buff, OSD_FORMAT_MESSAGE_BUFFER_SIZE, "RESCUE OFF");
             SET_BLINK(OSD_WARNINGS);
             return;
         }


### PR DESCRIPTION
Fix for https://github.com/betaflight/betaflight/issues/7726 and also fix for the message to use supported characters.
It's amazing how I got confused with the "NO GPS RESC" message to almost entirely miss the point of my previous PR, which was obviously not working when I tested it. O:-) But honestly, it's difficult to fit "Gps Rescue Disabled" and "Gps Rescue Unavailable" in 11 chars without being ambiguous and confusing. Now the permanently disabled message is "GPS RESC OFF" (small cheat: GPS is a two char symbol). Maybe the unavailable message can be changed to "GPS RESC N/A"?
Last but not least, I wanted to add a test case to the osd unit tests, but I'm not familiar enough with the testing framework to add all the missing code for arming and config, so I leave this pending for the future.
