### PR TITLE
OSD tweaks : Adding km/h, MPH, home flag, general OSD symbols cleanup.

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -21,116 +21,134 @@
 
 #pragma once
 
-//Misc
-#define SYM_END_OF_FONT             0xFF
-#define SYM_BLANK                   0x20
+//                                  0x00 // Blank
+#define SYM_RSSI                    0x01 // 001 RSSI
+#define SYM_AH_RIGHT                0x02 // 002 Arrow left
+#define SYM_AH_LEFT                 0x03 // 003 Arrow right
+#define SYM_THR                     0x04 // 004 Throttle
+#define SYM_THR1                    0x05 // 005 Arrow up AHI
+#define SYM_VOLT                    0x06 // 006 V
+#define SYM_MAH                     0x07 // 007 MAH
+
+#define SYM_STICK_OVERLAY_SPRITE_HIGH 0x08 // 008 Stick overlay
+#define SYM_STICK_OVERLAY_SPRITE_MID  0x09 // 009 Stick overlay
+#define SYM_STICK_OVERLAY_SPRITE_LOW  0x0A // 010 Stick overlay
+#define SYM_STICK_OVERLAY_CENTER      0x0B // 011 Stick overlay
+
+#define SYM_M                       0x0C // 012 m
+#define SYM_F                       0x0D // 013 °F
+#define SYM_C                       0x0E // 014 °C
+#define SYM_FT                      0x0F // 015 ft
+
+//                                  0x10 // 016 Scrolling bar
+//                                  0x11 // 017 Scrolling bar
+//                                  0x12 // 018 Scrolling bar
+#define SYM_AH_DECORATION           0x13 // 013 -
+//                                  0x14 // 020 Scrolling bar
+//                                  0x15 // 021 Scrolling bar
+
+#define SYM_STICK_OVERLAY_VERTICAL    0x16 // 022 Stick overlay 
+#define SYM_STICK_OVERLAY_HORIZONTAL  0x17 // 023 Stick overlay
+
+#define SYM_HEADING_N               0x18 // 024 Compass
+#define SYM_HEADING_S               0x19 // 025 Compass
+#define SYM_HEADING_E               0x1A // 026 Compass
+#define SYM_HEADING_W               0x1B // 027 Compass
+#define SYM_HEADING_DIVIDED_LINE    0x1C // 028 Compass
+#define SYM_HEADING_LINE            0x1D // 029 Compass
+
+#define SYM_SAT_L                   0x1E // 030 Sats left
+#define SYM_SAT_R                   0x1F // 031 Sats right
+
+#define SYM_BLANK                   0x20 // 032 Blank (space)
+
+//                                  0x21 // 033 -----------
+//                                  0x22 // 034 -----------
+//                                  0x23 // 035 -----------
+//                                  0x24 // 036 -----------
+
+//                                  0x25 // 037 Ascii %
+
+#define SYM_AH_CENTER_LINE          0x26 // 038 Crossair left
+#define SYM_AH_CENTER_LINE_RIGHT    0x27 // 039 Crossair right
+
+//                                  0x28 // 040 to 062 ASCII
+
 #define SYM_COLON                   0x2D
 
-// RSSI
-#define SYM_RSSI                    0x01
+//                                  0x3F // 063 -----------
 
-// Throttle Position (%)
-#define SYM_THR                     0x04
-#define SYM_THR1                    0x05
+//                                  0x40 // 064 to 095 ASCII
 
-// Map mode
-#define SYM_HOME                    0x04
-#define SYM_AIRCRAFT                0x05
+#define SYM_ARROW_SOUTH             0x60 // 096 Directional arrow
+#define SYM_ARROW_2                 0x61 // 097 Directional arrow
+#define SYM_ARROW_3                 0x62 // 098 Directional arrow
+#define SYM_ARROW_4                 0x63 // 099 Directional arrow
+#define SYM_ARROW_EAST              0x64 // 100 Directional arrow
+#define SYM_ARROW_6                 0x65 // 101 Directional arrow
+#define SYM_ARROW_7                 0x66 // 102 Directional arrow
+#define SYM_ARROW_8                 0x67 // 103 Directional arrow
+#define SYM_ARROW_NORTH             0x68 // 104 Directional arrow
+#define SYM_ARROW_10                0x69 // 105 Directional arrow
+#define SYM_ARROW_11                0x6A // 106 Directional arrow
+#define SYM_ARROW_12                0x6B // 107 Directional arrow
+#define SYM_ARROW_WEST              0x6C // 108 Directional arrow
+#define SYM_ARROW_14                0x6D // 109 Directional arrow
+#define SYM_ARROW_15                0x6E // 110 Directional arrow
+#define SYM_ARROW_16                0x6F // 111 Directional arrow
 
-// Unit Icons (Metric)
-#define SYM_M                       0x0C
-#define SYM_C                       0x0E
+//                                  0x70 // 112 -----------
+//                                  0x71 // 113 -----------
 
-// Unit Icons (Imperial)
-#define SYM_FT                      0x0F
-#define SYM_F                       0x0D
+#define SYM_DIRECTION               0x72 // 114 to 121, directional little arrows
 
-// Heading Graphics
-#define SYM_HEADING_N               0x18
-#define SYM_HEADING_S               0x19
-#define SYM_HEADING_E               0x1A
-#define SYM_HEADING_W               0x1B
-#define SYM_HEADING_DIVIDED_LINE    0x1C
-#define SYM_HEADING_LINE            0x1D
+//                                  0x7A // 122 -----------
 
-// AH Center screen Graphics
-#define SYM_AH_CENTER_LINE          0x26
-#define SYM_AH_CENTER_LINE_RIGHT    0x27
-#define SYM_AH_CENTER               0x7E
-#define SYM_AH_RIGHT                0x02
-#define SYM_AH_LEFT                 0x03
-#define SYM_AH_DECORATION           0x13
+//                                  0x7B // 123 to 125 ASCII
 
-// Satellite Graphics
-#define SYM_SAT_L                   0x1E
-#define SYM_SAT_R                   0x1F
+#define SYM_AH_CENTER               0x7E // 126 Crossair center
 
-// Direction arrows
-#define SYM_ARROW_SOUTH             0x60
-#define SYM_ARROW_2                 0x61
-#define SYM_ARROW_3                 0x62
-#define SYM_ARROW_4                 0x63
-#define SYM_ARROW_EAST              0x64
-#define SYM_ARROW_6                 0x65
-#define SYM_ARROW_7                 0x66
-#define SYM_ARROW_8                 0x67
-#define SYM_ARROW_NORTH             0x68
-#define SYM_ARROW_10                0x69
-#define SYM_ARROW_11                0x6A
-#define SYM_ARROW_12                0x6B
-#define SYM_ARROW_WEST              0x6C
-#define SYM_ARROW_14                0x6D
-#define SYM_ARROW_15                0x6E
-#define SYM_ARROW_16                0x6F
+//                                  0x7F // 127 -----------
 
-// AH Bars
-#define SYM_AH_BAR9_0               0x80
-#define SYM_AH_BAR9_1               0x81
-#define SYM_AH_BAR9_2               0x82
-#define SYM_AH_BAR9_3               0x83
-#define SYM_AH_BAR9_4               0x84
-#define SYM_AH_BAR9_5               0x85
-#define SYM_AH_BAR9_6               0x86
-#define SYM_AH_BAR9_7               0x87
-#define SYM_AH_BAR9_8               0x88
+#define SYM_AH_BAR9_0               0x80 // 128 AHI
+#define SYM_AH_BAR9_1               0x81 // 129 AHI
+#define SYM_AH_BAR9_2               0x82 // 130 AHI
+#define SYM_AH_BAR9_3               0x83 // 131 AHI
+#define SYM_AH_BAR9_4               0x84 // 132 AHI
+#define SYM_AH_BAR9_5               0x85 // 133 AHI
+#define SYM_AH_BAR9_6               0x86 // 134 AHI
+#define SYM_AH_BAR9_7               0x87 // 135 AHI
+#define SYM_AH_BAR9_8               0x88 // 136 AHI
 
-// Progress bar
-#define SYM_PB_START                0x8A
-#define SYM_PB_FULL                 0x8B
-#define SYM_PB_HALF                 0x8C
-#define SYM_PB_EMPTY                0x8D
-#define SYM_PB_END                  0x8E
-#define SYM_PB_CLOSE                0x8F
+#define SYM_HOME                    0x89 // 137 Home flag NEW IN 4.0
 
-// Batt evolution
-#define SYM_BATT_FULL               0x90
-#define SYM_BATT_5                  0x91
-#define SYM_BATT_4                  0x92
-#define SYM_BATT_3                  0x93
-#define SYM_BATT_2                  0x94
-#define SYM_BATT_1                  0x95
-#define SYM_BATT_EMPTY              0x96
+#define SYM_PB_START                0x8A // 138 Progress bar
+#define SYM_PB_FULL                 0x8B // 139 Progress bar
+#define SYM_PB_HALF                 0x8C // 140 Progress bar
+#define SYM_PB_EMPTY                0x8D // 141 Progress bar
+#define SYM_PB_END                  0x8E // 142 Progress bar
+#define SYM_PB_CLOSE                0x8F // 143 Progress bar
 
-// Batt Icon´s
-#define SYM_MAIN_BATT               0x97
+#define SYM_BATT_FULL               0x90 // 144 Battery full
+#define SYM_BATT_5                  0x91 // 145 Battery
+#define SYM_BATT_4                  0x92 // 146 Battery
+#define SYM_BATT_3                  0x93 // 147 Battery
+#define SYM_BATT_2                  0x94 // 148 Battery
+#define SYM_BATT_1                  0x95 // 149 Battery
+#define SYM_BATT_EMPTY              0x96 // 150 Battery empty
 
-// Voltage and amperage
-#define SYM_VOLT                    0x06
-#define SYM_AMP                     0x9A
-#define SYM_MAH                     0x07
-#define SYM_WATT                    0x57
+#define SYM_MAIN_BATT               0x97 // 151 Battery 
 
-// Time
-#define SYM_ON_M                    0x9B
-#define SYM_FLY_M                   0x9C
+//                                  0x98 // 152 -----------
 
-// Menu cursor
-#define SYM_CURSOR                  SYM_AH_LEFT
+#define SYM_FTS                     0x99 // 153 FT/S NEW IN 4.0
+#define SYM_AMP                     0x9A // 154 A
+#define SYM_ON_M                    0x9B // 155 On MN
+#define SYM_FLY_M                   0x9C // 156 FL MN
 
-// Stick overlays
-#define SYM_STICK_OVERLAY_SPRITE_HIGH 0x08
-#define SYM_STICK_OVERLAY_SPRITE_MID  0x09
-#define SYM_STICK_OVERLAY_SPRITE_LOW  0x0A
-#define SYM_STICK_OVERLAY_CENTER      0x0B
-#define SYM_STICK_OVERLAY_VERTICAL    0x16
-#define SYM_STICK_OVERLAY_HORIZONTAL  0x17
+#define SYM_KMH                     0x9D // 157 KM/H -- NEW IN 4.0
+#define SYM_MPH                     0x9E // 158 MP/H -- NEW IN 4.0
+#define SYM_MS                      0x9F // 159 M/S
+
+#define SYM_LOGO_START	            0xA0 // 160 to 256 BF logo
+#define SYM_LOGO_END                0xFF // 255 End of the logo

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -257,10 +257,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 static void osdDrawLogo(int x, int y)
 {
     // display logo and help
-    int fontOffset = 160;
+    int fontOffset = SYM_LOGO_START;
     for (int row = 0; row < 4; row++) {
         for (int column = 0; column < 24; column++) {
-            if (fontOffset <= SYM_END_OF_FONT)
+            if (fontOffset <= SYM_LOGO_END)
                 displayWriteChar(osdDisplayPort, x + column, y + row, fontOffset++);
         }
     }

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -686,13 +686,14 @@ static void osdElementGpsSats(osdElementParms_t *element)
 
 static void osdElementGpsSpeed(osdElementParms_t *element)
 {
-    // FIXME ideally we want to use SYM_KMH symbol but it's not in the font any more, so we use K (M for MPH)
     switch (osdConfig()->units) {
     case OSD_UNIT_IMPERIAL:
-        tfp_sprintf(element->buff, "%3dM", CM_S_TO_MPH(gpsSol.groundSpeed));
+        tfp_sprintf(element->buff, "%3d", CM_S_TO_MPH(gpsSol.groundSpeed));
+		element->buff[3] = SYM_MPH;
         break;
     default:
-        tfp_sprintf(element->buff, "%3dK", CM_S_TO_KM_H(gpsSol.groundSpeed));
+        tfp_sprintf(element->buff, "%3d", CM_S_TO_KM_H(gpsSol.groundSpeed));
+		element->buff[3] = SYM_KMH;
         break;
     }
 }

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -671,14 +671,12 @@ static void osdElementGpsHomeDistance(osdElementParms_t *element)
 
 static void osdElementGpsLatitude(osdElementParms_t *element)
 {
-    // The SYM_LAT symbol in the actual font contains only blank, so we use the SYM_ARROW_NORTH
-    osdFormatCoordinate(element->buff, SYM_ARROW_NORTH, gpsSol.llh.lat);
+    osdFormatCoordinate(element->buff, SYM_DIRECTION, gpsSol.llh.lat);
 }
 
 static void osdElementGpsLongitude(osdElementParms_t *element)
 {
-    // The SYM_LON symbol in the actual font contains only blank, so we use the SYM_ARROW_EAST
-    osdFormatCoordinate(element->buff, SYM_ARROW_EAST, gpsSol.llh.lon);
+    osdFormatCoordinate(element->buff, SYM_DIRECTION+2, gpsSol.llh.lon);
 }
 
 static void osdElementGpsSats(osdElementParms_t *element)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -640,12 +640,11 @@ static void osdElementGpsFlightDistance(osdElementParms_t *element)
 static void osdElementGpsHomeDirection(osdElementParms_t *element)
 {
     if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
-        if (GPS_distanceToHome > 0) {
+        if (GPS_distanceToHome > 5) {
             const int h = GPS_directionToHome - DECIDEGREES_TO_DEGREES(attitude.values.yaw);
             element->buff[0] = osdGetDirectionSymbolFromHeading(h);
         } else {
-            // We don't have a HOME symbol in the font, by now we use this
-            element->buff[0] = SYM_THR1;
+            element->buff[0] = SYM_HOME;
         }
 
     } else {
@@ -653,7 +652,7 @@ static void osdElementGpsHomeDirection(osdElementParms_t *element)
         element->buff[0] = SYM_COLON;
     }
 
-    element->buff[1] = 0;
+    element->buff[1] = '\0';
 }
 
 static void osdElementGpsHomeDistance(osdElementParms_t *element)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -810,7 +810,7 @@ static void osdElementNumericalVario(osdElementParms_t *element)
 #endif // USE_GPS
     if (haveBaro || haveGps) {
         const int verticalSpeed = osdGetMetersToSelectedUnit(getEstimatedVario());
-        const char directionSymbol = verticalSpeed < 0 ? SYM_ARROW_SOUTH : SYM_ARROW_NORTH;
+        const char directionSymbol = verticalSpeed < 0 ? SYM_DIRECTION+4 : SYM_DIRECTION;
         tfp_sprintf(element->buff, "%c%01d.%01d", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10));
     } else {
         // We use this symbol when we don't have a valid measure

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -676,7 +676,7 @@ static void osdElementGpsLatitude(osdElementParms_t *element)
 
 static void osdElementGpsLongitude(osdElementParms_t *element)
 {
-    osdFormatCoordinate(element->buff, SYM_DIRECTION+2, gpsSol.llh.lon);
+    osdFormatCoordinate(element->buff, SYM_DIRECTION + 2, gpsSol.llh.lon);
 }
 
 static void osdElementGpsSats(osdElementParms_t *element)
@@ -688,12 +688,10 @@ static void osdElementGpsSpeed(osdElementParms_t *element)
 {
     switch (osdConfig()->units) {
     case OSD_UNIT_IMPERIAL:
-        tfp_sprintf(element->buff, "%3d", CM_S_TO_MPH(gpsSol.groundSpeed));
-		element->buff[3] = SYM_MPH;
+        tfp_sprintf(element->buff, "%3d%c", CM_S_TO_MPH(gpsSol.groundSpeed), SYM_MPH);
         break;
     default:
-        tfp_sprintf(element->buff, "%3d", CM_S_TO_KM_H(gpsSol.groundSpeed));
-		element->buff[3] = SYM_KMH;
+        tfp_sprintf(element->buff, "%3d%c", CM_S_TO_KM_H(gpsSol.groundSpeed), SYM_KMH);
         break;
     }
 }
@@ -811,7 +809,7 @@ static void osdElementNumericalVario(osdElementParms_t *element)
 #endif // USE_GPS
     if (haveBaro || haveGps) {
         const int verticalSpeed = osdGetMetersToSelectedUnit(getEstimatedVario());
-        const char directionSymbol = verticalSpeed < 0 ? SYM_DIRECTION+4 : SYM_DIRECTION;
+        const char directionSymbol = verticalSpeed < 0 ? SYM_DIRECTION + 4 : SYM_DIRECTION;
         tfp_sprintf(element->buff, "%c%01d.%01d", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10));
     } else {
         // We use this symbol when we don't have a valid measure


### PR DESCRIPTION
General cleanup of the OSD chars (max7456_symbols).
Removed symbols not in use, now there's 9 free slots
Added : KM/H, MPH, FT/S, Home flag when dist to home <6m
Less intrusive arrows for LAT and LON
Less intrusive arrows for up/down arrows on the vario 

![osd_bf4](https://user-images.githubusercontent.com/25566932/53946322-cafeb000-40c3-11e9-91ae-b39105e4fb1f.jpg)
