### PR TITLE
support JEDEC_ID_WINBOND_W25Q128_DTR flash

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -64,6 +64,7 @@
 #define JEDEC_ID_WINBOND_W25Q32        0xEF4016
 #define JEDEC_ID_WINBOND_W25Q64        0xEF4017
 #define JEDEC_ID_WINBOND_W25Q128       0xEF4018
+#define JEDEC_ID_WINBOND_W25Q128_DTR   0xEF7018
 #define JEDEC_ID_CYPRESS_S25FL128L     0x016018
 #define JEDEC_ID_BERGMICRO_W25Q32      0xE04016
 
@@ -192,6 +193,7 @@ bool m25p16_detect(flashDevice_t *fdevice, uint32_t chipID)
         break;
     case JEDEC_ID_MICRON_N25Q128:
     case JEDEC_ID_WINBOND_W25Q128:
+    case JEDEC_ID_WINBOND_W25Q128_DTR:
     case JEDEC_ID_CYPRESS_S25FL128L:
         fdevice->geometry.sectors = 256;
         fdevice->geometry.pagesPerSector = 256;


### PR DESCRIPTION
Support WINBOND_W25Q128_DTR flash which uses a different jedec id.