### PR TITLE
Fix CLI beacon dump output

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -165,7 +165,6 @@ extern uint8_t __config_end;
 
 #include "cli.h"
 
-
 static serialPort_t *cliPort;
 
 #ifdef STM32F1
@@ -2969,15 +2968,17 @@ static void cliFeature(char *cmdline)
 }
 
 #if defined(USE_BEEPER)
-static void printBeeper(uint8_t dumpMask, const uint32_t offFlags, const uint32_t offFlagsDefault, const char *name)
+static void printBeeper(uint8_t dumpMask, const uint32_t offFlags, const uint32_t offFlagsDefault, const char *name, const uint32_t allowedFlags)
 {
     const uint8_t beeperCount = beeperTableEntryCount();
     for (int32_t i = 0; i < beeperCount - 1; i++) {
-        const char *formatOff = "%s -%s";
-        const char *formatOn = "%s %s";
-        const uint32_t beeperModeMask = beeperModeMaskForTableIndex(i);
-        cliDefaultPrintLinef(dumpMask, ~(offFlags ^ offFlagsDefault) & beeperModeMask, offFlags & beeperModeMask ? formatOn : formatOff, name, beeperNameForTableIndex(i));
-        cliDumpPrintLinef(dumpMask, ~(offFlags ^ offFlagsDefault) & beeperModeMask, offFlags & beeperModeMask ? formatOff : formatOn, name, beeperNameForTableIndex(i));
+        if (beeperModeMaskForTableIndex(i) & allowedFlags) {
+            const char *formatOff = "%s -%s";
+            const char *formatOn = "%s %s";
+            const uint32_t beeperModeMask = beeperModeMaskForTableIndex(i);
+            cliDefaultPrintLinef(dumpMask, ~(offFlags ^ offFlagsDefault) & beeperModeMask, offFlags & beeperModeMask ? formatOn : formatOff, name, beeperNameForTableIndex(i));
+            cliDumpPrintLinef(dumpMask, ~(offFlags ^ offFlagsDefault) & beeperModeMask, offFlags & beeperModeMask ? formatOff : formatOn, name, beeperNameForTableIndex(i));
+        }
     }
 }
 
@@ -5353,11 +5354,11 @@ static void printConfig(char *cmdline, bool doDiff)
 
 #if defined(USE_BEEPER)
             cliPrintHashLine("beeper");
-            printBeeper(dumpMask, beeperConfig_Copy.beeper_off_flags, beeperConfig()->beeper_off_flags, "beeper");
+            printBeeper(dumpMask, beeperConfig_Copy.beeper_off_flags, beeperConfig()->beeper_off_flags, "beeper", BEEPER_ALLOWED_MODES);
 
 #if defined(USE_DSHOT)
             cliPrintHashLine("beacon");
-            printBeeper(dumpMask, beeperConfig_Copy.dshotBeaconOffFlags, beeperConfig()->dshotBeaconOffFlags, "beacon");
+            printBeeper(dumpMask, beeperConfig_Copy.dshotBeaconOffFlags, beeperConfig()->dshotBeaconOffFlags, "beacon", DSHOT_BEACON_ALLOWED_MODES);
 #endif
 #endif // USE_BEEPER
 


### PR DESCRIPTION
Previously the `beacon` portion of a `dump` would display the flags associated with `beeper` rather then only the limited set for `beacon`. This would result in output that would cause errors if copy/pasted back in as commands. Now the output only includes the options applicable to `beacon`.

Example output:
```
# beeper
beeper GYRO_CALIBRATED
beeper RX_LOST
beeper RX_LOST_LANDING
beeper DISARMING
beeper ARMING
beeper ARMING_GPS_FIX
beeper ARMING_GPS_NO_FIX
beeper BAT_CRIT_LOW
beeper BAT_LOW
beeper GPS_STATUS
beeper RX_SET
beeper ACC_CALIBRATION
beeper ACC_CALIBRATION_FAIL
beeper READY_BEEP
beeper MULTI_BEEPS
beeper DISARM_REPEAT
beeper ARMED
beeper SYSTEM_INIT
beeper ON_USB
beeper BLACKBOX_ERASE
beeper CRASH_FLIP
beeper CAM_CONNECTION_OPEN
beeper CAM_CONNECTION_CLOSE
beeper RC_SMOOTHING_INIT_FAIL

# beacon
beacon -RX_LOST
beacon -RX_SET
```
