### PR TITLE
Spektrum TM, remove useless RPM field.

### DIFF
--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -158,14 +158,6 @@ typedef struct
 
 bool srxlFrameRpm(sbuf_t *dst, timeUs_t currentTimeUs)
 {
-    uint16_t period_us = SPEKTRUM_RPM_UNUSED;
-#ifdef USE_ESC_SENSOR_TELEMETRY
-    escSensorData_t *escData = getEscSensorData(ESC_SENSOR_COMBINED);
-    if (escData != NULL && escData->rpm > 0) {
-        period_us = 60000000 / escData->rpm; // revs/minute -> microSeconds
-    }
-#endif
-
     int16_t coreTemp = SPEKTRUM_TEMP_UNUSED;
 #if defined(USE_ADC_INTERNAL)
     coreTemp = getCoreTemperatureCelsius();
@@ -176,7 +168,7 @@ bool srxlFrameRpm(sbuf_t *dst, timeUs_t currentTimeUs)
 
     sbufWriteU8(dst, SRXL_FRAMETYPE_TELE_RPM);
     sbufWriteU8(dst, SRXL_FRAMETYPE_SID);
-    sbufWriteU16BigEndian(dst, period_us);                  // pulse leading edges
+    sbufWriteU16BigEndian(dst, SPEKTRUM_RPM_UNUSED);                  // pulse leading edges
     if (telemetryConfig()->report_cell_voltage) {
         sbufWriteU16BigEndian(dst, getBatteryAverageCellVoltage()); // Cell voltage is in units of 0.01V
     } else {


### PR DESCRIPTION
Finally come around to actually test RPM via Spektrum telemetry. Replaced BlHeli_S with BlHeli32 ESCs on an old DYSF4PRO rig to be able to test using BiDir Dshot. And what a disappointment. BiDir Dshot as such is brilliant, but the problem is the Spektrum period_us field in the RPM frame. It is a 16 bit int, giving a value range of 1uS to 65534uS, corresponding to a RPM value range of 915RPM to 60000000RPM. Yes, 60MegaRPM. Main problem is the low end and the minimum RPM possible to report, 915. This is not practically usable at all. We have motors idling well below that.

I did some tests trying to scale RPM into milliRPM ( factor 1000), giving a more reasonable value range of 1RPM to 60kRPM. But that looks horrible and weird on the iX12 screen. Test code is here if anyone is interested in having a look: https://github.com/AndersHoglund/betaflight/tree/spektrum_tm_dshot_rpm_sensor
I was thinking of making a PR adding the ESC bidir Dshot sensor based on that code, but no. It does not work in practice. Better just to clean up and forget the whole thing.

So sorry, I should have done the math and checked value ranges before submitting the previous PRs adding RPM. And done some real practicality tests. This PR will however clean up my mess.

While doing this, I could not help but noticing the inconsistency in naming ESC items. for example the "classic" UART connected ESC sensor is correctly called a "sensor", as in `USE_ESC_SENSOR` and as a "ESC_SENSOR" feature etc. The new BiDir Dshot connected ESC sensor is called "telemetry" in many places, as in `USE_DSHOT_TELEMETRY` etc. The later is currently used for filtering and OSD, not for telemetry at all. Those two are two different kinds of ESC sensors, what functions that are using their data is another matter. Just an observation. I know, naming is hard.  
