### PR TITLE
Move enabling of caches for F7

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -249,6 +249,22 @@ void init(void)
     HAL_Init();
 #endif
 
+#if defined(STM32F7)   
+    /* Enable I-Cache */
+    if (INSTRUCTION_CACHE_ENABLE) {
+        SCB_EnableICache();
+    }
+
+    /* Enable D-Cache */
+    if (DATA_CACHE_ENABLE) {
+        SCB_EnableDCache();
+    }
+
+    if (PREFETCH_ENABLE) {
+        LL_FLASH_EnablePrefetch();
+    }
+#endif
+
     printfSupportInit();
 
     systemInit();

--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -345,20 +345,6 @@ void SystemInit(void)
     }
     SCB->VTOR = vtorOffset;
 
-    /* Enable I-Cache */
-    if (INSTRUCTION_CACHE_ENABLE) {
-        SCB_EnableICache();
-    }
-
-    /* Enable D-Cache */
-    if (DATA_CACHE_ENABLE) {
-        SCB_EnableDCache();
-    }
-
-    if (PREFETCH_ENABLE) {
-        LL_FLASH_EnablePrefetch();
-    }
-
     /* Configure the system clock to specified frequency */
     SystemClock_Config();
 


### PR DESCRIPTION
Moves cache enabling from SystemInit() to init() as it is not recommended to enable caches before entering main function. 

Might help with the issues in #7413 or it might not. It might be worth doing anyway since it could potentially prevent problems in the future. 

I also moved the enabling of prefetch since I see no reason to leave it behind. Prefetch enabling is a part of what should take place in ``HAL_Init``so we might as well place it after that. Why are we enabling prefetch? Are we even accessing flash through ITCM interface? If not, could we maybe disable prefetch and save some power? From what i can tell, flash is accessed through AXIM interface with caches enabled for all F7 mcus. Then ART-accelerator/prefetch shouldn't be needed? The ART-accelerator isn't enabled either since ``HAL_Init`` will never run. Or maybe I'm missing something.