### PR TITLE
Added Unified Target configuration for SPRACINGF7DUAL.

### DIFF
--- a/unified_targets/configs/SPRACINGF7DUAL.config
+++ b/unified_targets/configs/SPRACINGF7DUAL.config
@@ -1,0 +1,130 @@
+# Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar 11 2019 / 22:28:27 (c2b7e5273) MSP API: 1.41
+
+board_name SPRACINGF7DUAL
+manufacturer_id SPRO
+
+# resources
+resource BEEPER 1 C15
+resource MOTOR 1 C08
+resource MOTOR 2 C06
+resource MOTOR 3 C09
+resource MOTOR 4 C07
+resource MOTOR 5 B06
+resource MOTOR 6 B07
+resource MOTOR 7 B01
+resource MOTOR 8 B00
+resource SERVO 1 A09
+resource SERVO 2 A10
+resource PPM 1 A03
+resource PWM 1 A03
+resource PWM 2 A02
+resource PWM 3 A09
+resource PWM 4 A10
+resource LED_STRIP 1 A01
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 C10
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 C11
+resource SERIAL_RX 5 D02
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C04
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource CAMERA_CONTROL 1 A00
+resource ADC_BATT 1 C01
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C02
+resource SDCARD_CS 1 C03
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C13
+resource GYRO_EXTI 2 C14
+resource GYRO_CS 1 A15
+resource GYRO_CS 2 B02
+
+# timer
+timer A00 1
+timer A03 2
+timer A02 2
+timer C08 1
+timer C06 1
+timer C09 1
+timer C07 1
+timer B06 0
+timer B07 0
+timer B01 1
+timer B00 1
+timer A01 0
+timer B10 0
+timer B11 0
+timer A08 0
+timer A09 0
+timer A10 0
+
+# dma
+dma SPI_TX 3 1
+# SPI_TX 3: DMA1 Stream 7 Channel 0
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
+dma pin C06 0
+# pin C06: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C07 1
+# pin C07: DMA2 Stream 3 Channel 7
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin A01 0
+# pin A01: DMA1 Stream 6 Channel 3
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin B11 0
+# pin B11: DMA1 Stream 7 Channel 3
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin A09 1
+# pin A09: DMA2 Stream 2 Channel 6
+dma pin A10 1
+# pin A10: DMA2 Stream 6 Channel 6
+
+# master
+set gyro_to_use = BOTH
+set adc_device = 3
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 300
+set beeper_inversion = ON
+set beeper_od = OFF
+set sdcard_mode = SPI
+set sdcard_spi_bus = 3
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = CW270

--- a/unified_targets/docs/Manufacturers.md
+++ b/unified_targets/docs/Manufacturers.md
@@ -16,3 +16,4 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |HBRO|Holybro|http://www.holybro.com/index.html|
 |MTKS|Matek Systems|http://www.mateksys.com/|
 |RCTI|RCTimer|http://rctimer.com/|
+|SPRO|Seriously Pro Racing (SP Racing)|http://seriouslypro.com/|


### PR DESCRIPTION
Like for other F7 based flight controllers, this is without I2C based BARO / MAG at the moment, as having an I2C BARO present makes the Unified Target wedge on boot otherwise.