### PR TITLE
Disable DSHOT Telemetry if motor protocol is not DSHOT or PROSHOT

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -441,7 +441,21 @@ static void validateAndFixConfig(void)
 #endif
 
 #if defined(USE_DSHOT_TELEMETRY)
-    if ((motorConfig()->dev.useBurstDshot || !systemConfig()->schedulerOptimizeRate)
+    bool usingDshotProtocol;
+    switch (motorConfig()->dev.motorPwmProtocol) {
+    case PWM_TYPE_PROSHOT1000:
+    case PWM_TYPE_DSHOT1200:
+    case PWM_TYPE_DSHOT600:
+    case PWM_TYPE_DSHOT300:
+    case PWM_TYPE_DSHOT150:
+        usingDshotProtocol = true;
+        break;
+    default:
+        usingDshotProtocol = false;
+        break;
+    }
+
+    if ((!usingDshotProtocol || motorConfig()->dev.useBurstDshot || !systemConfig()->schedulerOptimizeRate)
         && motorConfig()->dev.useDshotTelemetry) {
         motorConfigMutable()->dev.useDshotTelemetry = false;
     }


### PR DESCRIPTION
Avoids settings confusion as DSHOT telemetry won't function unless the motor PWM protocol is DSHOT or PROSHOT.

Note that it's not possible to use `isMotorProtocolDshot()` as that's based on the motor initialization and would represent only the boot state of the pwm protocol.