### PR TITLE
assign pin SDA2,SCL2 to none

### DIFF
--- a/src/main/target/CLRACINGF7/target.h
+++ b/src/main/target/CLRACINGF7/target.h
@@ -103,6 +103,8 @@
 #define USE_I2C
 #define USE_I2C_DEVICE_2       // External I2C
 #define I2C_DEVICE               (I2CDEV_2)
+#define I2C2_SCL                NONE        // PB10 (UART3_TX)
+#define I2C2_SDA                NONE        // PB11 (UART3_RX)
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1


### PR DESCRIPTION
   as default If I don't use #define I2C2_SCL  NONE and #define I2C2_SDA   NONE in the target.h.
it will assign pin B10 B11 to the I2C bus, witch is conflicts to the UART 3. when the fc boot up. it try to  scan I2C bus device, causing the boot up delay.
