### PR TITLE
Add unified target for MATEKF722SE

### DIFF
--- a/unified_targets/configs/MATEKF722SE.config
+++ b/unified_targets/configs/MATEKF722SE.config
@@ -1,0 +1,122 @@
+# Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar 15 2019 / 08:10:21 (d50e721) MSP API: 1.41
+
+board_name MATEKF722SE
+manufacturer_id MTKS
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 B04
+resource MOTOR 2 B05
+resource MOTOR 3 B00
+resource MOTOR 4 B01
+resource MOTOR 5 A15
+resource MOTOR 6 B03
+resource MOTOR 7 B06
+resource MOTOR 8 B07
+resource PPM 1 A03
+resource PWM 1 A02
+resource PWM 2 A01
+resource PWM 3 A00
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 A14
+resource LED 2 A13
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource ADC_BATT 1 C02
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C01
+resource ADC_EXT 1 A04
+resource SDCARD_CS 1 D02
+resource PINIO 1 C08
+resource PINIO 2 C09
+resource FLASH_CS 1 D02
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 C03
+resource GYRO_CS 1 B02
+resource GYRO_CS 2 C15
+resource USB_DETECT 1 C14
+
+# timer
+timer B04 0
+timer B05 0
+timer B00 0
+timer B01 1
+timer A15 0
+timer B03 0
+timer B06 0
+timer B07 0
+timer A08 0
+timer A03 2
+timer A02 2
+timer A01 1
+timer A00 1
+
+# dma
+dma SPI_TX 3 0
+# SPI_TX 3: DMA1 Stream 5 Channel 0
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B00 0
+# pin B00: DMA2 Stream 6 Channel 0
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A08 2
+# pin A08: DMA2 Stream 3 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set sdcard_mode = SPI
+set sdcard_spi_bus = 3
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180FLIP
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = CW90

--- a/unified_targets/configs/MATEKF722SE.config
+++ b/unified_targets/configs/MATEKF722SE.config
@@ -59,7 +59,7 @@ resource USB_DETECT 1 C14
 # timer
 timer B04 0
 timer B05 0
-timer B00 0
+timer B00 1
 timer B01 1
 timer A15 0
 timer B03 0


### PR DESCRIPTION
Unified target config file for MATEKF722SE. My only doubt is if I must remove (or maybe comment with an explanation) the `resource ESCSERIAL 1 none` command, that does not work in the actual firmware version.