### PR TITLE
Fix memory corruption in USB code.

### DIFF
--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
@@ -398,7 +398,7 @@ uint8_t USBD_HID_SendReport     (USBD_HandleTypeDef  *pdev,
 {
   USBD_HID_HandleTypeDef     *hhid = (USBD_HID_HandleTypeDef*)pdev->pHID_ClassData;
 
-  if (pdev->dev_state == USBD_STATE_CONFIGURED )
+  if (pdev->dev_state == USBD_STATE_CONFIGURED && hhid)
   {
     if(hhid->state == HID_IDLE)
     {


### PR DESCRIPTION
Crash occurs on my machine shortly after power up.  `hhid` is null at
the time it occurs so the change to `hhid->state` causes a crash.

SPRacingF7DUAL.