### PR TITLE
Add arming disabled check if RPM filter enabled but DSHOT telemetry not working

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -146,6 +146,7 @@ typedef struct {
     volatile bool isInput;
     volatile bool hasTelemetry;
     uint16_t dshotTelemetryValue;
+    bool dshotTelemetryActive;
 #ifdef USE_HAL_DRIVER
     LL_TIM_OC_InitTypeDef ocInitStruct;
     LL_TIM_IC_InitTypeDef icInitStruct;
@@ -253,6 +254,7 @@ bool pwmDshotCommandIsProcessing(void);
 uint8_t pwmGetDshotCommand(uint8_t index);
 bool pwmDshotCommandOutputIsEnabled(uint8_t motorCount);
 uint16_t getDshotTelemetry(uint8_t index);
+bool isDshotTelemetryActive(uint8_t index);
 
 #endif
 

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -223,6 +223,7 @@ void pwmStartDshotMotorUpdate(uint8_t motorCount)
                 }
                 if (value != 0xffff) {
                     dmaMotors[i].dshotTelemetryValue = value;
+                    dmaMotors[i].dshotTelemetryActive = true;
                     if (i < 4) {
                         DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, i, value);
                     }
@@ -244,6 +245,11 @@ void pwmStartDshotMotorUpdate(uint8_t motorCount)
         }
         dshotEnableChannels(motorCount);
     }
+}
+
+bool isDshotTelemetryActive(uint8_t index)
+{
+    return dmaMotors[index].dshotTelemetryActive;
 }
 
 #endif

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -53,6 +53,7 @@ const char *armingDisableFlagNames[]= {
     "PARALYZE",
     "GPS",
     "RESCUE SW",
+    "RPMFILTER",
     "ARMSWITCH",
 };
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -59,7 +59,8 @@ typedef enum {
     ARMING_DISABLED_PARALYZE        = (1 << 16),
     ARMING_DISABLED_GPS             = (1 << 17),
     ARMING_DISABLED_RESC            = (1 << 18),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 19), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_RPMFILTER       = (1 << 19),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 20), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
 #define ARMING_DISABLE_FLAGS_COUNT (LOG2(ARMING_DISABLED_ARM_SWITCH) + 1)


### PR DESCRIPTION
If the RPM filter is enabled, requires all motors to have received a valid DSHOT telemetry frame before arming is allowed. Otherwise sets the arming disabled reason `ARMING_DISABLED_RPMFILTER`.

Results in an additional safety check to ensure the user has everything properly configured and has updated the ESC's with a compatible firmware version. If RPM filtering is enabled and the ESC's are not providing telemetry then there's a risk of a flyaway or other bad things happening due to the reduced lowpass filter settings typical of the RPM filtering setup.

Tested to ensure arming functions as expected when the ESC's are properly supplying telemetry. Also tested scenarios where one or more ESC's are not supplying telemetry.  This is the most likely failure scenario with the user neglecting to update the firmware on the ESC's with a compatible version.

NOTE:
There is a regression in the unusual circumstances of the user first booting the flight controller on USB and then later connecting the battery (and subsequently disconnecting USB). In this case the ESC's wouldn't have received the command to enable bidirectional telemetry as it was sent at boot. This will result in an arming disabled situation. Previously this would be addressed by again sending the DSHOT command to enable bidirectional telemetry at arming so it would have actually been ok. The tradeoff is we can't differentiate whether this was caused by being not powered at boot or due to the ESC's not supporting DSHOT telemetry.

The plan is to address this issue separately with a fix to detect that the ESC's were not configured for bidirectional telemetry at boot and periodically try to enable it while disarmed. This is designed to catch the above case of the battery connected after boot.