### PR TITLE
Created configurable pull for SALite compatibility for softserial

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1264,6 +1264,7 @@ const clivalue_t valueTable[] = {
 // PG_VTX_CONFIG
 #if defined(USE_VTX_CONTROL) && defined(USE_VTX_COMMON)
     { "vtx_halfduplex",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_CONFIG, offsetof(vtxConfig_t, halfDuplex) },
+    { "vtx_halfduplex_rx_pull",     VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_CONFIG, offsetof(vtxConfig_t, haflDuplexRxPull) },
 #endif
 
 // PG_VCD_CONFIG

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -52,6 +52,7 @@ typedef enum {
     SERIAL_BIDIR_OD        = 0 << 4,
     SERIAL_BIDIR_PP        = 1 << 4,
     SERIAL_BIDIR_NOPULL    = 1 << 5, // disable pulls in BIDIR RX mode
+    SERIAL_BIDIR_RXPULL    = 1 << 6, // configured inverse pull in BIDIR RX mode (SALite Workaround)
 } portOptions_e;
 
 // Define known line control states which may be passed up by underlying serial driver callback

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -135,14 +135,16 @@ static void serialInputPortActivate(softSerial_t *softSerial)
 #ifdef STM32F1
         IOConfigGPIO(softSerial->rxIO, IOCFG_IPD);
 #else
-        const uint8_t pinConfig = (softSerial->port.options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_PP : IOCFG_AF_PP_PD;
+        const uint8_t pinPullConfig = (softSerial->port.options & SERIAL_BIDIR_RXPULL) ? IOCFG_AF_PP_UP : IOCFG_AF_PP_PD;
+        const uint8_t pinConfig = (softSerial->port.options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_PP : pinPullConfig;
         IOConfigGPIOAF(softSerial->rxIO, pinConfig, softSerial->timerHardware->alternateFunction);
 #endif
     } else {
 #ifdef STM32F1
         IOConfigGPIO(softSerial->rxIO, IOCFG_IPU);
 #else
-        const uint8_t pinConfig = (softSerial->port.options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_PP : IOCFG_AF_PP_UP;
+        const uint8_t pinPullConfig = (softSerial->port.options & SERIAL_BIDIR_RXPULL) ? IOCFG_AF_PP_PD : IOCFG_AF_PP_UP;
+        const uint8_t pinConfig = (softSerial->port.options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_PP : pinPullConfig;
         IOConfigGPIOAF(softSerial->rxIO, pinConfig, softSerial->timerHardware->alternateFunction);
 #endif
     }

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -51,7 +51,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(vtxConfig_t, vtxConfig, PG_VTX_CONFIG, 1);
 
 PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
 //    .vtxChannelActivationConditions = { 0 },
-    .halfDuplex = true
+    .halfDuplex = true,
+    .haflDuplexRxPull = false
 );
 
 static uint8_t locked = 0;

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -40,6 +40,7 @@ typedef struct vtxChannelActivationCondition_s {
 typedef struct vtxConfig_s {
     vtxChannelActivationCondition_t vtxChannelActivationConditions[MAX_CHANNEL_ACTIVATION_CONDITION_COUNT];
     uint8_t halfDuplex;
+    uint8_t haflDuplexRxPull;
 } vtxConfig_t;
 
 PG_DECLARE(vtxConfig_t, vtxConfig);


### PR DESCRIPTION
CLI-configurable pull in BIDIR RX mode for SmartAudio using softserial.  Hoping this will help resolve issues with SALite and restore any current loss in functionality on standard uarts.

To test the SALite workaround, set up smartaudio using softserial and enable the feature in cli using "set vtx_halfduplex_rx_pull=ON"

The fix for standard uarts does not require any cli options.  Simply flash and test.  This part of the fix is expected to restore previous functionality and is not intended to enable SALite on standard uarts.

-- NEEDS TESTING BY 3rd PARTIES -- SHOULD BE CONDUCTED ON VARIOUS AFFECTED HARDWARE --

I have some test artifacts available for review [here (4950 baud - faster/more reliable in testing)](http://jenkins.komp.rest/job/SmartAudio%20Lite%20-%20SoftSerial%20Pulldown/lastSuccessfulBuild/artifact/obj/) and [here (4800 baud - spec)](http://jenkins.komp.rest/job/SmartAudio%20Lite%20-%20SoftSerial%20Pulldown%20(4800)/lastSuccessfulBuild/artifact/obj/)