### PR TITLE
DSHOT command non-blocking motor selection fix

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -544,7 +544,7 @@ void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command, bo
                 if (index == i || index == ALL_MOTORS) {
                     commandControl->command[i] = command;
                 } else {
-                    commandControl->command[i] = command;
+                    commandControl->command[i] = DSHOT_CMD_MOTOR_STOP;
                 }
             }
             commandControl->waitingForIdle = !allMotorsAreIdle(motorCount);


### PR DESCRIPTION
Fixes a logic error that would send non-blocking DSHOT commands to all motors regardless of the selected motor index.
