### PR TITLE
Added manufacturer id for TransTEC.

### DIFF
--- a/unified_targets/docs/Manufacturers.md
+++ b/unified_targets/docs/Manufacturers.md
@@ -19,3 +19,4 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |MTKS|Matek Systems|http://www.mateksys.com/|
 |RCTI|RCTimer|http://rctimer.com/|
 |SPRO|Seriously Pro Racing (SP Racing)|http://seriouslypro.com/|
+|TTRH|TransTEC|http://www.transtechobby.com/|


### PR DESCRIPTION
N.b: Manufacturer id is `TTRH` (4 characters).

Fixes #7825.