### PR TITLE
Fixed warnings.

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -216,9 +216,9 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #define DMAINIT dmaInitStruct
 #endif
 
-    dmaStream_t *dmaRef;
+    dmaStream_t *dmaRef = NULL;
 #if defined(STM32F4)
-    uint32_t dmaChannel;
+    uint32_t dmaChannel = 0;
 #endif
 #if defined(USE_DMA_SPEC)
     const dmaChannelSpec_t *dmaSpec = dmaGetChannelSpecByTimer(timerHardware);

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -200,8 +200,8 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #define DMAINIT dmaInitStruct
 #endif
 
-    DMA_Stream_TypeDef *dmaRef;
-    uint32_t dmaChannel;
+    DMA_Stream_TypeDef *dmaRef = NULL;
+    uint32_t dmaChannel = 0;
 #if defined(USE_DMA_SPEC)
     const dmaChannelSpec_t *dmaSpec = dmaGetChannelSpecByTimer(timerHardware);
 
@@ -286,7 +286,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->icInitStruct.ICFilter = 0; //2;
 #endif
 
-    uint32_t channel;
+    uint32_t channel = 0;
     switch (timerHardware->channel) {
     case TIM_CHANNEL_1: channel = LL_TIM_CHANNEL_CH1; break;
     case TIM_CHANNEL_2: channel = LL_TIM_CHANNEL_CH2; break;

--- a/src/main/msc/emfat_file.c
+++ b/src/main/msc/emfat_file.c
@@ -296,9 +296,9 @@ static void emfat_add_log(emfat_entry_t *entry, int number, uint32_t offset, uin
 
 static int emfat_find_log(emfat_entry_t *entry, int maxCount)
 {
-    uint32_t limit  = flashfsIdentifyStartOfFreeSpace();
-    uint32_t lastOffset = 0;
-    uint32_t currOffset = 0;
+    int limit = flashfsIdentifyStartOfFreeSpace();
+    int lastOffset = 0;
+    int currOffset = 0;
     int fileNumber = 0;
     uint8_t buffer[18];
     int logCount = 0;


### PR DESCRIPTION
Fixed 3 warnings I get when building KAKUTEF4.

> warning: 'dmaChannel' may be used uninitialized in this function [-Wmaybe-uninitialized]
> warning: 'dmaRef' may be used uninitialized in this function [-Wmaybe-uninitialized]
> warning: missed loop optimization, the loop counter may overflow [-Wunsafe-loop-optimizations]