### PR TITLE
Arbitrary Gyro and Sensor alignment

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -161,18 +161,6 @@ static const char * const lookupTableUnit[] = {
     "IMPERIAL", "METRIC"
 };
 
-static const char * const lookupTableAlignment[] = {
-    "DEFAULT",
-    "CW0",
-    "CW90",
-    "CW180",
-    "CW270",
-    "CW0FLIP",
-    "CW90FLIP",
-    "CW180FLIP",
-    "CW270FLIP"
-};
-
 #ifdef USE_MULTI_GYRO
 static const char * const lookupTableGyro[] = {
     "FIRST", "SECOND", "BOTH"
@@ -470,7 +458,6 @@ static const char * const lookupTablePositionAltSource[] = {
 const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOffOn),
     LOOKUP_TABLE_ENTRY(lookupTableUnit),
-    LOOKUP_TABLE_ENTRY(lookupTableAlignment),
 #ifdef USE_GPS
     LOOKUP_TABLE_ENTRY(lookupTableGPSProvider),
     LOOKUP_TABLE_ENTRY(lookupTableGPSSBASMode),
@@ -642,7 +629,9 @@ const clivalue_t valueTable[] = {
 
 // PG_COMPASS_CONFIG
 #ifdef USE_MAG
-    { "align_mag",                  VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_align) },
+    { "mag_align_roll",             VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_alignment.values.roll) },
+    { "mag_align_pitch",            VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_alignment.values.pitch) },
+    { "mag_align_yaw",              VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_alignment.values.yaw) },
     { "mag_bustype",                VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BUS_TYPE }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_bustype) },
     { "mag_i2c_device",             VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_i2c_device) },
     { "mag_i2c_address",            VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_i2c_address) },
@@ -1432,13 +1421,17 @@ const clivalue_t valueTable[] = {
     { "gyro_1_spibus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, SPIDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, spiBus) },
     { "gyro_1_i2cBus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, i2cBus) },
     { "gyro_1_i2c_address", VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, i2cAddress) },
-    { "gyro_1_sensor_align", VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, align) },
+    { "gyro_1_align_roll", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, alignment.values.roll) },
+    { "gyro_1_align_pitch", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, alignment.values.pitch) },
+    { "gyro_1_align_yaw", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, alignment.values.yaw) },
 #ifdef USE_MULTI_GYRO
     { "gyro_2_bustype", VAR_UINT8 | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BUS_TYPE }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, bustype) },
     { "gyro_2_spibus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, SPIDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, spiBus) },
     { "gyro_2_i2cBus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, i2cBus) },
     { "gyro_2_i2c_address", VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, i2cAddress) },
-    { "gyro_2_sensor_align", VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, align) },
+    { "gyro_2_align_roll", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, alignment.values.roll) },
+    { "gyro_2_align_pitch", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, alignment.values.pitch) },
+    { "gyro_2_align_yaw", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -360, 360 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, alignment.values.yaw) },
 #endif
 #ifdef I2C_FULL_RECONFIGURABILITY
 #ifdef USE_I2C_DEVICE_1

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -28,7 +28,6 @@
 typedef enum {
     TABLE_OFF_ON = 0,
     TABLE_UNIT,
-    TABLE_ALIGNMENT,
 #ifdef USE_GPS
     TABLE_GPS_PROVIDER,
     TABLE_GPS_SBAS_MODE,

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -197,7 +197,7 @@ void normalizeV(struct fp_vector *src, struct fp_vector *dest)
     }
 }
 
-void buildRotationMatrix(fp_angles_t *delta, float matrix[3][3])
+void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation)
 {
     float cosx, sinx, cosy, siny, cosz, sinz;
     float coszcosx, sinzcosx, coszsinx, sinzsinx;
@@ -214,15 +214,15 @@ void buildRotationMatrix(fp_angles_t *delta, float matrix[3][3])
     coszsinx = sinx * cosz;
     sinzsinx = sinx * sinz;
 
-    matrix[0][X] = cosz * cosy;
-    matrix[0][Y] = -cosy * sinz;
-    matrix[0][Z] = siny;
-    matrix[1][X] = sinzcosx + (coszsinx * siny);
-    matrix[1][Y] = coszcosx - (sinzsinx * siny);
-    matrix[1][Z] = -sinx * cosy;
-    matrix[2][X] = (sinzsinx) - (coszcosx * siny);
-    matrix[2][Y] = (coszsinx) + (sinzcosx * siny);
-    matrix[2][Z] = cosy * cosx;
+    rotation->m[0][X] = cosz * cosy;
+    rotation->m[0][Y] = -cosy * sinz;
+    rotation->m[0][Z] = siny;
+    rotation->m[1][X] = sinzcosx + (coszsinx * siny);
+    rotation->m[1][Y] = coszcosx - (sinzsinx * siny);
+    rotation->m[1][Z] = -sinx * cosy;
+    rotation->m[2][X] = (sinzsinx) - (coszcosx * siny);
+    rotation->m[2][Y] = (coszsinx) + (sinzcosx * siny);
+    rotation->m[2][Z] = cosy * cosx;
 }
 
 // Rotate a vector *v by the euler angles defined by the 3-vector *delta.
@@ -230,13 +230,13 @@ void rotateV(struct fp_vector *v, fp_angles_t *delta)
 {
     struct fp_vector v_tmp = *v;
 
-    float matrix[3][3];
+    fp_rotationMatrix_t rotation;
 
-    buildRotationMatrix(delta, matrix);
+    buildRotationMatrix(delta, &rotation);
 
-    v->X = v_tmp.X * matrix[0][X] + v_tmp.Y * matrix[1][X] + v_tmp.Z * matrix[2][X];
-    v->Y = v_tmp.X * matrix[0][Y] + v_tmp.Y * matrix[1][Y] + v_tmp.Z * matrix[2][Y];
-    v->Z = v_tmp.X * matrix[0][Z] + v_tmp.Y * matrix[1][Z] + v_tmp.Z * matrix[2][Z];
+    v->X = v_tmp.X * rotation.m[0][X] + v_tmp.Y * rotation.m[1][X] + v_tmp.Z * rotation.m[2][X];
+    v->Y = v_tmp.X * rotation.m[0][Y] + v_tmp.Y * rotation.m[1][Y] + v_tmp.Z * rotation.m[2][Y];
+    v->Z = v_tmp.X * rotation.m[0][Z] + v_tmp.Y * rotation.m[1][Z] + v_tmp.Z * rotation.m[2][Z];
 }
 
 // Quick median filter implementation

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -93,6 +93,10 @@ typedef union {
     fp_angles_def angles;
 } fp_angles_t;
 
+typedef struct fp_rotationMatrix_s {
+    float m[3][3];              // matrix
+} fp_rotationMatrix_t;
+
 int gcd(int num, int denom);
 float powerf(float base, int exp);
 int32_t applyDeadband(int32_t value, int32_t deadband);
@@ -110,7 +114,7 @@ float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float des
 void normalizeV(struct fp_vector *src, struct fp_vector *dest);
 
 void rotateV(struct fp_vector *v, fp_angles_t *delta);
-void buildRotationMatrix(fp_angles_t *delta, float matrix[3][3]);
+void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation);
 
 int32_t quickMedianFilter3(int32_t * v);
 int32_t quickMedianFilter5(int32_t * v);

--- a/src/main/common/sensor_alignment.c
+++ b/src/main/common/sensor_alignment.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#include "common/sensor_alignment.h"
+
+
+void buildRotationMatrixFromAlignment(const sensorAlignment_t* sensorAlignment, fp_rotationMatrix_t* rm)
+{
+    fp_angles_t rotationAngles;
+    rotationAngles.angles.roll  = DEGREES_TO_RADIANS(sensorAlignment->values.roll);
+    rotationAngles.angles.pitch = DEGREES_TO_RADIANS(sensorAlignment->values.pitch);
+    rotationAngles.angles.yaw   = DEGREES_TO_RADIANS(sensorAlignment->values.yaw);
+
+    buildRotationMatrix(&rotationAngles, rm);
+}
+
+void buildAlignmentFromRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation)
+{
+    *sensorAlignment = CW0_DEG;
+
+    switch (rotation) {
+    default:
+    case LEGACY_ALIGN_CW0_DEG:
+        break;
+    case LEGACY_ALIGN_CW90_DEG:
+        sensorAlignment->values.yaw += 90;
+        break;
+    case LEGACY_ALIGN_CW180_DEG:
+        sensorAlignment->values.yaw += 180;
+        break;
+    case LEGACY_ALIGN_CW270_DEG:
+        sensorAlignment->values.yaw += 270;
+        break;
+    case LEGACY_ALIGN_CW0_DEG_FLIP:
+        sensorAlignment->values.pitch += 180;
+        break;
+    case LEGACY_ALIGN_CW90_DEG_FLIP:
+        sensorAlignment->values.yaw += 90;
+        sensorAlignment->values.pitch += 180;
+        break;
+    case LEGACY_ALIGN_CW180_DEG_FLIP:
+        sensorAlignment->values.yaw += 180;
+        sensorAlignment->values.pitch += 180;
+        break;
+    case LEGACY_ALIGN_CW270_DEG_FLIP:
+        sensorAlignment->values.yaw += 270;
+        sensorAlignment->values.pitch += 180;
+        break;
+    }
+}

--- a/src/main/common/sensor_alignment.c
+++ b/src/main/common/sensor_alignment.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "stdbool.h"
+
 #include "platform.h"
 
 #include "common/sensor_alignment.h"
@@ -33,7 +35,31 @@ void buildRotationMatrixFromAlignment(const sensorAlignment_t* sensorAlignment, 
     buildRotationMatrix(&rotationAngles, rm);
 }
 
-void buildAlignmentFromRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation)
+bool isSensorAlignmentStandard(sensorAlignment_t* sensorAlignment)
+{
+    bool nonStandardAlignmentDetected = false;
+
+    for (int i = 0; i < XYZ_AXIS_COUNT && !nonStandardAlignmentDetected; i++) {
+        nonStandardAlignmentDetected = (int)sensorAlignment->raw[i] % 90 != 0;
+    }
+
+    return !nonStandardAlignmentDetected;
+}
+
+void updateStandardAlignmentFromNonDefaultLegacyRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation)
+{
+    if (rotation == LEGACY_ALIGN_DEFAULT) {
+        return;
+    }
+
+    if (!isSensorAlignmentStandard(sensorAlignment)) {
+        return;
+    }
+
+    buildAlignmentFromLegacyRotation(sensorAlignment, rotation);
+}
+
+void buildAlignmentFromLegacyRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation)
 {
     *sensorAlignment = CW0_DEG;
 

--- a/src/main/common/sensor_alignment.h
+++ b/src/main/common/sensor_alignment.h
@@ -39,7 +39,7 @@ typedef enum {
 typedef union sensorAlignment_u {
     // value order is the same as axis_e
 
-    uint16_t raw[XYZ_AXIS_COUNT];
+    int16_t raw[XYZ_AXIS_COUNT];
     struct {
         int16_t roll;
         int16_t pitch;
@@ -58,4 +58,7 @@ typedef union sensorAlignment_u {
 #define CW270_DEG_FLIP  ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 180, .yaw = 270  }})
 
 void buildRotationMatrixFromAlignment(const sensorAlignment_t* alignment, fp_rotationMatrix_t* rm);
-void buildAlignmentFromRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation);
+void buildAlignmentFromLegacyRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation);
+
+bool isSensorAlignmentStandard(sensorAlignment_t* sensorAlignment);
+void updateStandardAlignmentFromNonDefaultLegacyRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation);

--- a/src/main/common/sensor_alignment.h
+++ b/src/main/common/sensor_alignment.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "axis.h"
+#include "maths.h"
+
+// Legacy alignment values
+typedef enum {
+    LEGACY_ALIGN_DEFAULT = 0,
+    LEGACY_ALIGN_CW0_DEG = 1,
+    LEGACY_ALIGN_CW90_DEG = 2,
+    LEGACY_ALIGN_CW180_DEG = 3,
+    LEGACY_ALIGN_CW270_DEG = 4,
+    LEGACY_ALIGN_CW0_DEG_FLIP = 5,
+    LEGACY_ALIGN_CW90_DEG_FLIP = 6,
+    LEGACY_ALIGN_CW180_DEG_FLIP = 7,
+    LEGACY_ALIGN_CW270_DEG_FLIP = 8
+} legacy_sensor_align_e;
+
+typedef union sensorAlignment_u {
+    // value order is the same as axis_e
+
+    uint16_t raw[XYZ_AXIS_COUNT];
+    struct {
+        int16_t roll;
+        int16_t pitch;
+        int16_t yaw;
+    } values;
+} sensorAlignment_t;
+
+
+#define CW0_DEG         ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 0,   .yaw = 0    }})
+#define CW90_DEG        ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 0,   .yaw = 90   }})
+#define CW180_DEG       ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 0,   .yaw = 180  }})
+#define CW270_DEG       ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 0,   .yaw = 270  }})
+#define CW0_DEG_FLIP    ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 180, .yaw = 0    }})
+#define CW90_DEG_FLIP   ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 180, .yaw = 90   }})
+#define CW180_DEG_FLIP  ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 180, .yaw = 180  }})
+#define CW270_DEG_FLIP  ((sensorAlignment_t){ .values = { .roll = 0, .pitch = 180, .yaw = 270  }})
+
+void buildRotationMatrixFromAlignment(const sensorAlignment_t* alignment, fp_rotationMatrix_t* rm);
+void buildAlignmentFromRotation(sensorAlignment_t* sensorAlignment, legacy_sensor_align_e rotation);

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -23,6 +23,7 @@
 #include "platform.h"
 
 #include "common/axis.h"
+#include "common/maths.h"
 #include "drivers/exti.h"
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
@@ -92,8 +93,8 @@ typedef struct gyroDev_s {
     int32_t gyroADCRawPrevious[XYZ_AXIS_COUNT];
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     int16_t temperature;
+    fp_rotationMatrix_t rotationMatrix;
     mpuDetectionResult_t mpuDetectionResult;
-    sensor_align_e gyroAlign;
     gyroRateKHz_e gyroRateKHz;
     bool dataReady;
     bool gyro_high_fsr;
@@ -103,6 +104,7 @@ typedef struct gyroDev_s {
     ioTag_t mpuIntExtiTag;
     uint8_t gyroHasOverflowProtection;
     gyroHardware_e gyroHardware;
+    uint8_t filler[1];
 } gyroDev_t;
 
 typedef struct accDev_s {
@@ -115,12 +117,12 @@ typedef struct accDev_s {
     busDevice_t bus;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
+    fp_rotationMatrix_t rotationMatrix;
     mpuDetectionResult_t mpuDetectionResult;
-    sensor_align_e accAlign;
     bool dataReady;
     bool acc_high_fsr;
     char revisionCode;                                      // a revision code for the sensor, if known
-    uint8_t filler[2];
+    uint8_t filler[3];
 } accDev_t;
 
 static inline void accDevLock(accDev_t *acc)

--- a/src/main/drivers/compass/compass.h
+++ b/src/main/drivers/compass/compass.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "common/sensor_alignment.h"
+
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
 #include "drivers/exti.h"
@@ -29,7 +31,7 @@ typedef struct magDev_s {
     sensorMagReadFuncPtr read;                              // read 3 axis data function
     extiCallbackRec_t exti;
     busDevice_t busdev;
-    sensor_align_e magAlign;
+    fp_rotationMatrix_t rotationMatrix;
     ioTag_t magIntExtiTag;
     int16_t magGain[3];
 } magDev_t;

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -23,18 +23,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef enum {
-    ALIGN_DEFAULT = 0,                                      // driver-provided alignment
-    CW0_DEG = 1,
-    CW90_DEG = 2,
-    CW180_DEG = 3,
-    CW270_DEG = 4,
-    CW0_DEG_FLIP = 5,
-    CW90_DEG_FLIP = 6,
-    CW180_DEG_FLIP = 7,
-    CW270_DEG_FLIP = 8
-} sensor_align_e;
-
 typedef bool (*sensorInterruptFuncPtr)(void);
 struct magDev_s;
 typedef bool (*sensorMagInitFuncPtr)(struct magDev_s *magdev);

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#include "common/sensor_alignment.h"
+
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/gyrodev.h"
@@ -36,30 +38,30 @@
 ioTag_t selectMPUIntExtiConfigByHardwareRevision(void); // XXX Should be gone
 
 #if defined(USE_SPI_GYRO) || defined(USE_I2C_GYRO)
-static void gyroResetCommonDeviceConfig(gyroDeviceConfig_t *devconf, ioTag_t extiTag, uint8_t align)
+static void gyroResetCommonDeviceConfig(gyroDeviceConfig_t *devconf, ioTag_t extiTag, sensorAlignment_t alignment)
 {
     devconf->extiTag = extiTag;
-    devconf->align = align;
+    devconf->alignment = alignment;
 }
 #endif
 
 #ifdef USE_SPI_GYRO
-static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *instance, ioTag_t csnTag, ioTag_t extiTag, uint8_t align)
+static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *instance, ioTag_t csnTag, ioTag_t extiTag, sensorAlignment_t alignment)
 {
     devconf->bustype = BUSTYPE_SPI;
     devconf->spiBus = SPI_DEV_TO_CFG(spiDeviceByInstance(instance));
     devconf->csnTag = csnTag;
-    gyroResetCommonDeviceConfig(devconf, extiTag, align);
+    gyroResetCommonDeviceConfig(devconf, extiTag, alignment);
 }
 #endif
 
 #if defined(USE_I2C_GYRO) && !defined(USE_MULTI_GYRO)
-static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cbus, ioTag_t extiTag, uint8_t align)
+static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cbus, ioTag_t extiTag, sensorAlignment_t alignment)
 {
     devconf->bustype = BUSTYPE_I2C;
     devconf->i2cBus = I2C_DEV_TO_CFG(i2cbus);
     devconf->i2cAddress = GYRO_I2C_ADDRESS;
-    gyroResetCommonDeviceConfig(devconf, extiTag, align);
+    gyroResetCommonDeviceConfig(devconf, extiTag, alignment);
 }
 #endif
 

--- a/src/main/pg/gyrodev.h
+++ b/src/main/pg/gyrodev.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "pg/pg.h"
+#include "common/sensor_alignment.h"
 #include "drivers/io_types.h"
 
 typedef struct gyroDeviceConfig_s {
@@ -34,7 +35,7 @@ typedef struct gyroDeviceConfig_s {
     uint8_t i2cBus;
     uint8_t i2cAddress;
     ioTag_t extiTag;
-    uint8_t align;        // sensor_align_e
+    sensorAlignment_t alignment;
 } gyroDeviceConfig_t;
 
 PG_DECLARE_ARRAY(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDeviceConfig);

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -320,12 +320,14 @@ bool accInit(uint32_t gyroSamplingInverval)
     // Copy alignment from active gyro, as all production boards use acc-gyro-combi chip.
     // Exceptions are STM32F3DISCOVERY and STM32F411DISCOVERY, and (may be) handled in future enhancement.
 
-    acc.dev.accAlign = gyroDeviceConfig(0)->align;
+    const sensorAlignment_t* alignment = &gyroDeviceConfig(0)->alignment;
+
 #ifdef USE_MULTI_GYRO
     if (gyroConfig()->gyro_to_use == GYRO_CONFIG_USE_GYRO_2) {
-        acc.dev.accAlign = gyroDeviceConfig(1)->align;
+        alignment = &gyroDeviceConfig(1)->alignment;
     }
 #endif
+    buildRotationMatrixFromAlignment(alignment, &acc.dev.rotationMatrix);
 
     if (!accDetect(&acc.dev, accelerometerConfig()->acc_hardware)) {
         return false;
@@ -485,7 +487,7 @@ void accUpdate(timeUs_t currentTimeUs, rollAndPitchTrims_t *rollAndPitchTrims)
         }
     }
 
-    alignSensors(acc.accADC, acc.dev.accAlign);
+    alignSensor(acc.accADC, &acc.dev.rotationMatrix);
 
     if (!accIsCalibrationComplete()) {
         performAcclerationCalibration(rollAndPitchTrims);

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -96,7 +96,7 @@ FAST_CODE void alignSensors(float *dest, uint8_t rotation)
 
     sensorAlignment_t sensorAlignment;
 
-    buildAlignmentFromRotation(&sensorAlignment, rotation);
+    buildAlignmentFromLegacyRotation(&sensorAlignment, rotation);
 
     buildRotationMatrixFromAlignment(&sensorAlignment, &sensorRotationMatrix);
 

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -25,8 +25,10 @@
 
 #include "platform.h"
 
+#include "common/utils.h"
 #include "common/maths.h"
 #include "common/axis.h"
+#include "common/sensor_alignment.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -36,7 +38,7 @@
 #include "boardalignment.h"
 
 static bool standardBoardAlignment = true;     // board orientation correction
-static float boardRotation[3][3];              // matrix
+static fp_rotationMatrix_t boardRotation;
 
 // no template required since defaults are zero
 PG_REGISTER(boardAlignment_t, boardAlignment, PG_BOARD_ALIGNMENT, 0);
@@ -59,69 +61,46 @@ void initBoardAlignment(const boardAlignment_t *boardAlignment)
     rotationAngles.angles.pitch = degreesToRadians(boardAlignment->pitchDegrees);
     rotationAngles.angles.yaw   = degreesToRadians(boardAlignment->yawDegrees  );
 
-    buildRotationMatrix(&rotationAngles, boardRotation);
+    buildRotationMatrix(&rotationAngles, &boardRotation);
 }
 
-static void alignBoard(float *vec)
+FAST_CODE static void applyRotation(float *vec, fp_rotationMatrix_t *rotationMatrix)
 {
     float x = vec[X];
     float y = vec[Y];
     float z = vec[Z];
 
-    vec[X] = (boardRotation[0][X] * x + boardRotation[1][X] * y + boardRotation[2][X] * z);
-    vec[Y] = (boardRotation[0][Y] * x + boardRotation[1][Y] * y + boardRotation[2][Y] * z);
-    vec[Z] = (boardRotation[0][Z] * x + boardRotation[1][Z] * y + boardRotation[2][Z] * z);
+    vec[X] = (rotationMatrix->m[0][X] * x + rotationMatrix->m[1][X] * y + rotationMatrix->m[2][X] * z);
+    vec[Y] = (rotationMatrix->m[0][Y] * x + rotationMatrix->m[1][Y] * y + rotationMatrix->m[2][Y] * z);
+    vec[Z] = (rotationMatrix->m[0][Z] * x + rotationMatrix->m[1][Z] * y + rotationMatrix->m[2][Z] * z);
+
 }
 
+FAST_CODE static void alignBoard(float *vec)
+{
+    applyRotation(vec, &boardRotation);
+}
+
+FAST_CODE void alignSensor(float *dest, fp_rotationMatrix_t* sensorRotationMatrix)
+{
+    applyRotation(dest, sensorRotationMatrix);
+
+    if (!standardBoardAlignment)
+        alignBoard(dest);
+}
+
+// deprecated
 FAST_CODE void alignSensors(float *dest, uint8_t rotation)
 {
-    const float x = dest[X];
-    const float y = dest[Y];
-    const float z = dest[Z];
+    fp_rotationMatrix_t sensorRotationMatrix;
 
-    switch (rotation) {
-    default:
-    case CW0_DEG:
-        dest[X] = x;
-        dest[Y] = y;
-        dest[Z] = z;
-        break;
-    case CW90_DEG:
-        dest[X] = y;
-        dest[Y] = -x;
-        dest[Z] = z;
-        break;
-    case CW180_DEG:
-        dest[X] = -x;
-        dest[Y] = -y;
-        dest[Z] = z;
-        break;
-    case CW270_DEG:
-        dest[X] = -y;
-        dest[Y] = x;
-        dest[Z] = z;
-        break;
-    case CW0_DEG_FLIP:
-        dest[X] = -x;
-        dest[Y] = y;
-        dest[Z] = -z;
-        break;
-    case CW90_DEG_FLIP:
-        dest[X] = y;
-        dest[Y] = x;
-        dest[Z] = -z;
-        break;
-    case CW180_DEG_FLIP:
-        dest[X] = x;
-        dest[Y] = -y;
-        dest[Z] = -z;
-        break;
-    case CW270_DEG_FLIP:
-        dest[X] = -y;
-        dest[Y] = -x;
-        dest[Z] = -z;
-        break;
-    }
+    sensorAlignment_t sensorAlignment;
+
+    buildAlignmentFromRotation(&sensorAlignment, rotation);
+
+    buildRotationMatrixFromAlignment(&sensorAlignment, &sensorRotationMatrix);
+
+    applyRotation(dest, &sensorRotationMatrix);
 
     if (!standardBoardAlignment)
         alignBoard(dest);

--- a/src/main/sensors/boardalignment.h
+++ b/src/main/sensors/boardalignment.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include "common/axis.h"
+#include "common/maths.h"
+
 #include "pg/pg.h"
 
 typedef struct boardAlignment_s {
@@ -30,5 +33,6 @@ typedef struct boardAlignment_s {
 
 PG_DECLARE(boardAlignment_t, boardAlignment);
 
-void alignSensors(float *dest, uint8_t rotation);
+void alignSensor(float *dest, fp_rotationMatrix_t* rotationMatrix);
+void alignSensors(float *dest, uint8_t rotation); // deprecated
 void initBoardAlignment(const boardAlignment_t *boardAlignment);

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "common/time.h"
+#include "common/sensor_alignment.h"
 #include "drivers/io_types.h"
 #include "drivers/sensor.h"
 #include "pg/pg.h"
@@ -48,7 +49,7 @@ extern mag_t mag;
 typedef struct compassConfig_s {
     int16_t mag_declination;                // Get your magnetic decliniation from here : http://magnetic-declination.com/
                                             // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
-    sensor_align_e mag_align;               // mag alignment
+    sensorAlignment_t mag_alignment;
     uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
     uint8_t mag_bustype;
     uint8_t mag_i2c_device;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -433,7 +433,7 @@ static void gyroInitSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t *c
 {
     gyroSensor->gyroDebugAxis = gyroConfig()->gyro_filter_debug_axis;
     gyroSensor->gyroDev.gyro_high_fsr = gyroConfig()->gyro_high_fsr;
-    gyroSensor->gyroDev.gyroAlign = config->align;
+    buildRotationMatrixFromAlignment(&config->alignment, &gyroSensor->gyroDev.rotationMatrix);
     gyroSensor->gyroDev.mpuIntExtiTag = config->extiTag;
 
     // Must set gyro targetLooptime before gyroDev.init and initialisation of filters
@@ -1037,7 +1037,7 @@ static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSens
         gyroSensor->gyroDev.gyroADC[Z] = gyroSensor->gyroDev.gyroADCRaw[Z] - gyroSensor->gyroDev.gyroZero[Z];
 #endif
 
-        alignSensors(gyroSensor->gyroDev.gyroADC, gyroSensor->gyroDev.gyroAlign);
+        alignSensor(gyroSensor->gyroDev.gyroADC, &gyroSensor->gyroDev.rotationMatrix);
     } else {
         performGyroCalibration(gyroSensor, gyroConfig()->gyroMovementCalibrationThreshold);
         // still calibrating, so no need to further process gyro data

--- a/src/main/target/BLUEJAYF4/config.c
+++ b/src/main/target/BLUEJAYF4/config.c
@@ -47,7 +47,7 @@
 void targetConfiguration(void)
 {
     if (hardwareRevision == BJF4_REV1 || hardwareRevision == BJF4_REV2) {
-        gyroDeviceConfigMutable(0)->align = CW180_DEG;
+        gyroDeviceConfigMutable(0)->alignment = CW180_DEG;
         beeperDevConfigMutable()->ioTag = IO_TAG(BEEPER_OPT);
     }
 

--- a/src/main/target/FF_RACEPIT/config.c
+++ b/src/main/target/FF_RACEPIT/config.c
@@ -39,10 +39,10 @@
 void targetConfiguration(void)
 {	
     if (hardwareRevision == FF_RACEPIT_REV_1) {
-        gyroDeviceConfigMutable(0)->align = CW180_DEG;
+        gyroDeviceConfigMutable(0)->alignment = CW180_DEG;
     }
     else {
-        gyroDeviceConfigMutable(0)->align = CW90_DEG_FLIP;
+        gyroDeviceConfigMutable(0)->alignment = CW90_DEG_FLIP;
     }
 
     telemetryConfigMutable()->halfDuplex = false;

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -113,7 +113,6 @@
 // Dummy defines
 #define GYRO_2_SPI_INSTANCE     GYRO_1_SPI_INSTANCE
 #define GYRO_2_CS_PIN           NONE
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define GYRO_2_EXTI_PIN         NONE
 
 #if !defined(SYNERGYF4) //No mag sensor on SYNERGYF4

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -62,7 +62,7 @@
 #define GYRO_2_SPI_INSTANCE     SPI1
 #define GYRO_2_CS_PIN           PA4
 #define GYRO_1_ALIGN            CW90_DEG
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
+#define GYRO_2_ALIGN            CW0_DEG
 #define GYRO_1_EXTI_PIN         PD0           // MPU6000
 #define GYRO_2_EXTI_PIN         PE8           // ICM20608
 
@@ -81,8 +81,8 @@
 #define GYRO_1_CS_PIN           PA15
 #define GYRO_2_SPI_INSTANCE     SPI1
 #define GYRO_2_CS_PIN           PA4
-#define GYRO_1_ALIGN            ALIGN_DEFAULT
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
+#define GYRO_1_ALIGN            CW0_DEG
+#define GYRO_2_ALIGN            CW0_DEG
 #define GYRO_1_EXTI_PIN         PE8           // ICM20608
 #define GYRO_2_EXTI_PIN         PD0           // MPU6000
 #endif

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -316,6 +316,13 @@
 #endif
 #endif
 
+// F4 and F7 single gyro boards
+#if defined(USE_MULTI_GYRO) && !defined(GYRO_2_SPI_INSTANCE)
+#define GYRO_2_SPI_INSTANCE     GYRO_1_SPI_INSTANCE
+#define GYRO_2_CS_PIN           NONE
+#define GYRO_2_EXTI_PIN         NONE
+#endif
+
 #if !defined(GYRO_1_SPI_INSTANCE)
 #define GYRO_1_SPI_INSTANCE     NULL
 #endif
@@ -329,16 +336,13 @@
 #endif
 
 #if !defined(GYRO_1_ALIGN)
-#define GYRO_1_ALIGN            ALIGN_DEFAULT
+#define GYRO_1_ALIGN            CW0_DEG
 #endif
 
-// F4 and F7 single gyro boards
-#if defined(USE_MULTI_GYRO) && !defined(GYRO_2_SPI_INSTANCE)
-#define GYRO_2_SPI_INSTANCE     GYRO_1_SPI_INSTANCE
-#define GYRO_2_CS_PIN           NONE
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
-#define GYRO_2_EXTI_PIN         NONE
+#if !defined(GYRO_2_ALIGN)
+#define GYRO_2_ALIGN            CW0_DEG
 #endif
+
 
 #if defined(MPU_ADDRESS)
 #define GYRO_I2C_ADDRESS MPU_ADDRESS

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -32,6 +32,7 @@ VPATH := $(VPATH):$(USER_DIR):$(TEST_DIR)
 
 alignsensor_unittest_SRC := \
 		$(USER_DIR)/sensors/boardalignment.c \
+		$(USER_DIR)/common/sensor_alignment.c \
 		$(USER_DIR)/common/maths.c
 
 arming_prevention_unittest_SRC := \
@@ -270,6 +271,7 @@ sensor_gyro_unittest_SRC := \
 		$(USER_DIR)/sensors/boardalignment.c \
 		$(USER_DIR)/common/filter.c \
 		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/sensor_alignment.c \
 		$(USER_DIR)/drivers/accgyro/accgyro_fake.c \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
 		$(USER_DIR)/pg/pg.c \

--- a/src/test/unit/alignsensor_unittest.cc
+++ b/src/test/unit/alignsensor_unittest.cc
@@ -21,6 +21,7 @@
 
 extern "C" {
 #include "common/axis.h"
+#include "common/sensor_alignment.h"
 #include "drivers/sensor.h"
 #include "sensors/boardalignment.h"
 #include "sensors/sensors.h"
@@ -33,7 +34,7 @@ extern "C" {
  * The output of alignSensor() is compared to the output of the test
  * rotation method.
  *
- * For each alignment condition (CW0, CW90, etc) the source vector under
+ * For each alignment condition (LEGACY_ALIGN_CW0, CW90, etc) the source vector under
  * test is set to a unit vector along each axis (x-axis, y-axis, z-axis)
  * plus one additional random vector is tested.
  */
@@ -96,7 +97,9 @@ static void initZAxisRotation(int32_t mat[][3], int32_t angle)
     mat[2][2] =  1;
 }
 
-static void testCW(sensor_align_e rotation, int32_t angle)
+#define TOL 1e-5 // TOLERANCE
+
+static void testCW(legacy_sensor_align_e rotation, int32_t angle)
 {
     float src[XYZ_AXIS_COUNT];
     float test[XYZ_AXIS_COUNT];
@@ -111,9 +114,9 @@ static void testCW(sensor_align_e rotation, int32_t angle)
     rotateVector(matrix, src, test);
 
     alignSensors(src, rotation);
-    EXPECT_EQ(test[X], src[X]) << "X-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "X-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "X-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "X-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "X-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "X-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 
     // unit vector along y-axis
     src[X] = 0;
@@ -122,9 +125,9 @@ static void testCW(sensor_align_e rotation, int32_t angle)
 
     rotateVector(matrix, src, test);
     alignSensors(src, rotation);
-    EXPECT_EQ(test[X], src[X]) << "Y-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "Y-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "Y-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "Y-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "Y-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "Y-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 
     // unit vector along z-axis
     src[X] = 0;
@@ -133,9 +136,9 @@ static void testCW(sensor_align_e rotation, int32_t angle)
 
     rotateVector(matrix, src, test);
     alignSensors(src, rotation);
-    EXPECT_EQ(test[X], src[X]) << "Z-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "Z-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "Z-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "Z-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "Z-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "Z-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 
     // random vector to test
     src[X] = rand() % 5;
@@ -144,16 +147,16 @@ static void testCW(sensor_align_e rotation, int32_t angle)
 
     rotateVector(matrix, src, test);
     alignSensors(src,  rotation);
-    EXPECT_EQ(test[X], src[X]) << "Random alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "Random alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "Random alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "Random alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "Random alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "Random alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 }
 
 /*
  * Since the order of flip and rotation matters, these tests make the
  * assumption that the 'flip' occurs first, followed by clockwise rotation
  */
-static void testCWFlip(sensor_align_e rotation, int32_t angle)
+static void testCWFlip(legacy_sensor_align_e rotation, int32_t angle)
 {
     float src[XYZ_AXIS_COUNT];
     float test[XYZ_AXIS_COUNT];
@@ -171,9 +174,9 @@ static void testCWFlip(sensor_align_e rotation, int32_t angle)
 
     alignSensors(src, rotation);
 
-    EXPECT_EQ(test[X], src[X]) << "X-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "X-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "X-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "X-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "X-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "X-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 
     // unit vector along y-axis
     src[X] = 0;
@@ -187,9 +190,9 @@ static void testCWFlip(sensor_align_e rotation, int32_t angle)
 
     alignSensors(src, rotation);
 
-    EXPECT_EQ(test[X], src[X]) << "Y-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "Y-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "Y-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "Y-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "Y-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "Y-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 
     // unit vector along z-axis
     src[X] = 0;
@@ -203,9 +206,9 @@ static void testCWFlip(sensor_align_e rotation, int32_t angle)
 
     alignSensors(src, rotation);
 
-    EXPECT_EQ(test[X], src[X]) << "Z-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "Z-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "Z-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "Z-Unit alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "Z-Unit alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "Z-Unit alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 
      // random vector to test
     src[X] = rand() % 5;
@@ -219,49 +222,49 @@ static void testCWFlip(sensor_align_e rotation, int32_t angle)
 
     alignSensors(src, rotation);
 
-    EXPECT_EQ(test[X], src[X]) << "Random alignment does not match in X-Axis. " << test[X] << " " << src[X];
-    EXPECT_EQ(test[Y], src[Y]) << "Random alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
-    EXPECT_EQ(test[Z], src[Z]) << "Random alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
+    EXPECT_NEAR(test[X], src[X], TOL) << "Random alignment does not match in X-Axis. " << test[X] << " " << src[X];
+    EXPECT_NEAR(test[Y], src[Y], TOL) << "Random alignment does not match in Y-Axis. " << test[Y] << " " << src[Y];
+    EXPECT_NEAR(test[Z], src[Z], TOL) << "Random alignment does not match in Z-Axis. " << test[Z] << " " << src[Z];
 }
 
 
 TEST(AlignSensorTest, ClockwiseZeroDegrees)
 {
     srand(time(NULL));
-    testCW(CW0_DEG, 0);
+    testCW(LEGACY_ALIGN_CW0_DEG, 0);
 }
 
 TEST(AlignSensorTest, ClockwiseNinetyDegrees)
 {
-    testCW(CW90_DEG, 90);
+    testCW(LEGACY_ALIGN_CW90_DEG, 90);
 }
 
 TEST(AlignSensorTest, ClockwiseOneEightyDegrees)
 {
-    testCW(CW180_DEG, 180);
+    testCW(LEGACY_ALIGN_CW180_DEG, 180);
 }
 
 TEST(AlignSensorTest, ClockwiseTwoSeventyDegrees)
 {
-    testCW(CW270_DEG, 270);
+    testCW(LEGACY_ALIGN_CW270_DEG, 270);
 }
 
 TEST(AlignSensorTest, ClockwiseZeroDegreesFlip)
 {
-    testCWFlip(CW0_DEG_FLIP, 0);
+    testCWFlip(LEGACY_ALIGN_CW0_DEG_FLIP, 0);
 }
 
 TEST(AlignSensorTest, ClockwiseNinetyDegreesFlip)
 {
-    testCWFlip(CW90_DEG_FLIP, 90);
+    testCWFlip(LEGACY_ALIGN_CW90_DEG_FLIP, 90);
 }
 
 TEST(AlignSensorTest, ClockwiseOneEightyDegreesFlip)
 {
-    testCWFlip(CW180_DEG_FLIP, 180);
+    testCWFlip(LEGACY_ALIGN_CW180_DEG_FLIP, 180);
 }
 
 TEST(AlignSensorTest, ClockwiseTwoSeventyDegreesFlip)
 {
-    testCWFlip(CW270_DEG_FLIP, 270);
+    testCWFlip(LEGACY_ALIGN_CW270_DEG_FLIP, 270);
 }

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -144,9 +144,9 @@ TEST(SensorGyro, Update)
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Z]);
     fakeGyroSet(gyroDevPtr, 15, 26, 97);
     gyroUpdate(currentTimeUs);
-    EXPECT_FLOAT_EQ(10 * gyroDevPtr->scale, gyro.gyroADCf[X]); // gyroADCf values are scaled
-    EXPECT_FLOAT_EQ(20 * gyroDevPtr->scale, gyro.gyroADCf[Y]);
-    EXPECT_FLOAT_EQ(90 * gyroDevPtr->scale, gyro.gyroADCf[Z]);
+    EXPECT_NEAR(10 * gyroDevPtr->scale, gyro.gyroADCf[X], 1e-3); // gyroADCf values are scaled
+    EXPECT_NEAR(20 * gyroDevPtr->scale, gyro.gyroADCf[Y], 1e-3);
+    EXPECT_NEAR(90 * gyroDevPtr->scale, gyro.gyroADCf[Z], 1e-3);
 }
 
 // STUBS


### PR DESCRIPTION
Allow arbitrary gyro and compass alignment.

* Rotation matrix is pre-computed, after sensor detection completes.
* Supports dual gyro boards with offsets other than 90 degrees.
* Supports external compasses mounted at any angle.
* MSP support included, backwards compatible where possible.
* Alignment values are now OFFSETS from target/sensor defaults, previous
alignment values overrode driver defaults.
* Required for SPRacingH7EXTREME - http://seriouslypro.com/spracingh7extreme

MSP clients can detect arbitrary alignment by looking at the
'multi-gyro' value which now uses another bit to indicate arbitrary
alignment, also the size of the SENSOR_ALIGNMENT is now 18 bytes longer.

* Initial testing done on SPRacingF7DUAL.
* Flight tested on the SPRacingH7EXTREME which has second gyro at 45 degrees.
* No noticeable change to PID loop speed, see results below.

before:
```
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       15528 B        16 KB     94.78%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        8274 B        16 KB     50.50%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      388968 B       480 KB     79.14%
        DTCM_RAM:       24920 B        64 KB     38.02%
           SRAM1:       42744 B       176 KB     23.72%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 391246	   5996	  61668	 458910	  7009e	./obj/main/betaflight_SPRACINGF7DUAL.elf

Task list             rate/hz  max/us  avg/us maxload avgload     total/ms
00 - (         SYSTEM)      9       2       1    0.5%    0.5%         0
01 - (         SYSTEM)    990     324       2   32.5%    0.6%       495
02 - (            PID)   1982      69      32   14.1%    6.8%     13433
   - (           GYRO)   7931
03 - (            ACC)    990      21       9    2.5%    1.3%       466
04 - (       ATTITUDE)     99      17      10    0.6%    0.5%        56
05 - (             RX)     32      50      34    0.6%    0.6%        66
06 - (         SERIAL)     99     128       2    1.7%    0.5%       143
08 - (BATTERY_VOLTAGE)     49       4       2    0.5%    0.5%         5
09 - (BATTERY_CURRENT)     49       3       1    0.5%    0.5%         2
10 - ( BATTERY_ALERTS)      5       3       2    0.5%    0.5%         0
11 - (         BEEPER)     99       6       1    0.5%    0.5%         6
14 - (           BARO)     43     112      67    0.9%    0.7%       163
15 - (       ALTITUDE)     39       9       6    0.5%    0.5%        11
17 - (      TELEMETRY)    249      80       0    2.4%    0.0%       896
18 - (       LEDSTRIP)     99      64       5    1.1%    0.5%        35
19 - (    TRANSPONDER)    248      10       1    0.7%    0.5%         9
20 - (            OSD)     59     477      13    3.3%    0.5%        43
22 - (            CMS)     59       2       1    0.5%    0.5%         3
23 - (        VTXCTRL)      5  401006       7  201.0%    0.5%       504
24 - (        CAMCTRL)      4       1       1    0.5%    0.5%         0
26 - (    ADCINTERNAL)      1       4       3    0.5%    0.5%         0
27 - (       PINIOBOX)     19       2       1    0.5%    0.5%         0
RX Check Function                   9       1                         1
Total (excluding SERIAL)                       264.7%   17.5%
```

after:

```
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       15448 B        16 KB     94.29%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        8274 B        16 KB     50.50%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      389632 B       480 KB     79.27%
        DTCM_RAM:       25028 B        64 KB     38.19%
           SRAM1:       42816 B       176 KB     23.76%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 391910	   5996	  61848	 459754	  703ea	./obj/main/betaflight_SPRACINGF7DUAL.elf

Task list             rate/hz  max/us  avg/us maxload avgload     total/ms
00 - (         SYSTEM)      9       1       0    0.5%    0.0%         0
01 - (         SYSTEM)    991     325       1   32.7%    0.5%       436
02 - (            PID)   1980      69      32   14.1%    6.8%      4597
   - (           GYRO)   7921
03 - (            ACC)    991      17       8    2.1%    1.2%       164
04 - (       ATTITUDE)     99      12      10    0.6%    0.5%        19
05 - (             RX)     32      50      35    0.6%    0.6%        23
06 - (         SERIAL)     99     367       2    4.1%    0.5%        31
08 - (BATTERY_VOLTAGE)     49       4       2    0.5%    0.5%         2
09 - (BATTERY_CURRENT)     49       1       1    0.5%    0.5%         0
10 - ( BATTERY_ALERTS)      5       3       2    0.5%    0.5%         0
11 - (         BEEPER)     99       6       1    0.5%    0.5%         2
14 - (           BARO)     43     103      69    0.9%    0.7%        59
15 - (       ALTITUDE)     39       7       5    0.5%    0.5%         4
17 - (      TELEMETRY)    248      81       1    2.5%    0.5%       218
18 - (       LEDSTRIP)     99      63       8    1.1%    0.5%        13
19 - (    TRANSPONDER)    248       2       1    0.5%    0.5%         3
20 - (            OSD)     59     477      12    3.3%    0.5%        16
22 - (            CMS)     59       2       1    0.5%    0.5%         1
23 - (        VTXCTRL)      5  401007     643  201.0%    0.8%       503
24 - (        CAMCTRL)      5       1       1    0.5%    0.5%         0
26 - (    ADCINTERNAL)      1       4       1    0.5%    0.5%         0
27 - (       PINIOBOX)     19       2       1    0.5%    0.5%         0
RX Check Function                   3       1                         0
Total (excluding SERIAL)                       264.4%   17.6%
```


