### PR TITLE
Fix remaining cases of `USE_DUAL_GYRO`.

### DIFF
--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -73,7 +73,7 @@ static FAST_RAM_ZERO_INIT float hanningWindow[FFT_WINDOW_SIZE];
 
 void gyroDataAnalyseInit(uint32_t targetLooptimeUs)
 {
-#ifdef USE_DUAL_GYRO
+#ifdef USE_MULTI_GYRO
     static bool gyroAnalyseInitialized;
     if (gyroAnalyseInitialized) {
         return;

--- a/src/main/target/DALRCF722DUAL/target.h
+++ b/src/main/target/DALRCF722DUAL/target.h
@@ -30,7 +30,7 @@
 #define BEEPER_PIN              PC13
 #define BEEPER_INVERTED
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PB10

--- a/src/main/target/EXF722DUAL/target.h
+++ b/src/main/target/EXF722DUAL/target.h
@@ -24,7 +24,7 @@
 
 #define USBD_PRODUCT_STRING     "EXF722DUAL"
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 
 #define ENABLE_DSHOT_DMAR       true
 

--- a/src/main/target/FLYWOOF7DUAL/target.h
+++ b/src/main/target/FLYWOOF7DUAL/target.h
@@ -31,7 +31,7 @@
 #define BEEPER_PIN              PC14
 #define BEEPER_INVERTED
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC3

--- a/src/main/target/FOXEERF722DUAL/target.h
+++ b/src/main/target/FOXEERF722DUAL/target.h
@@ -30,7 +30,7 @@
 #define BEEPER_PIN              PA4
 #define BEEPER_INVERTED
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4

--- a/src/main/target/MATEKF722SE/target.h
+++ b/src/main/target/MATEKF722SE/target.h
@@ -42,7 +42,7 @@
 #define SPI1_MISO_PIN           PA6
 #define SPI1_MOSI_PIN           PA7
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4

--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -61,7 +61,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_SPI_MPU6500
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 
 #if defined(OMNIBUSF4V6)
 #define GYRO_1_CS_PIN           PA4   // Onboard IMU  

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -44,7 +44,7 @@
 //GYRO & ACC--------------------------------
 #define USE_ACC
 #define USE_GYRO
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 // ICM-20608-G
 #define USE_ACC_SPI_MPU6500
 #define USE_GYRO_SPI_MPU6500

--- a/src/main/target/SPRACINGF7DUAL/target.h
+++ b/src/main/target/SPRACINGF7DUAL/target.h
@@ -31,7 +31,7 @@
 
 #define TEST_SOUND // for factory testing audio output
 
-#define USE_DUAL_GYRO
+#define USE_MULTI_GYRO
 //#define DEBUG_MODE DEBUG_DUAL_GYRO_DIFF
 
 #define ENABLE_DSHOT_DMAR       true


### PR DESCRIPTION
* The `USE_DUAL_GYRO` define was replaced with `USE_MULTI_GYRO` a while
ago.
