### PR TITLE
Avoid dshot collisions

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -224,9 +224,10 @@ bool pwmAreMotorsEnabled(void)
 }
 
 #ifdef USE_DSHOT_TELEMETRY
-static void pwmStartWriteUnused(uint8_t motorCount)
+static bool pwmStartWriteUnused(uint8_t motorCount)
 {
     UNUSED(motorCount);
+    return true;
 }
 #endif
 
@@ -253,9 +254,9 @@ void pwmCompleteMotorUpdate(uint8_t motorCount)
 }
 
 #ifdef USE_DSHOT_TELEMETRY
-void pwmStartMotorUpdate(uint8_t motorCount)
+bool pwmStartMotorUpdate(uint8_t motorCount)
 {
-    pwmStartWrite(motorCount);
+    return pwmStartWrite(motorCount);
 }
 #endif
 
@@ -521,7 +522,9 @@ void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command, bo
             delayMicroseconds(DSHOT_COMMAND_DELAY_US);
 
 #ifdef USE_DSHOT_TELEMETRY
-            pwmStartDshotMotorUpdate(motorCount);
+            timeUs_t currentTimeUs = micros();
+            while (!pwmStartDshotMotorUpdate(motorCount) &&
+                   cmpTimeUs(micros(), currentTimeUs) < 1000);
 #endif
             for (uint8_t i = 0; i < motorCount; i++) {
                 if ((i == index) || (index == ALL_MOTORS)) {

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -22,6 +22,8 @@
 
 #include "platform.h"
 
+#include "common/time.h"
+
 #include "drivers/io_types.h"
 #include "drivers/pwm_output_counts.h"
 #include "drivers/timer.h"
@@ -112,6 +114,8 @@ typedef enum {
 #define PROSHOT_BASE_SYMBOL          24 // 1uS
 #define PROSHOT_BIT_WIDTH            3
 #define MOTOR_NIBBLE_LENGTH_PROSHOT  96 // 4uS
+
+#define DSHOT_TELEMETRY_DEADTIME_US   (2 * 30 + 10) // 2 * 30uS to switch lines plus 10us grace period
 #endif
 
 
@@ -128,6 +132,7 @@ typedef struct {
 #endif
     uint16_t dmaBurstLength;
     uint32_t dmaBurstBuffer[DSHOT_DMA_BUFFER_SIZE * 4];
+    timeUs_t inputDirectionStampUs;
 #endif
     uint16_t timerDmaSources;
 } motorDmaTimer_t;
@@ -146,6 +151,7 @@ typedef struct {
     volatile bool isInput;
     volatile bool hasTelemetry;
     uint16_t dshotTelemetryValue;
+    timeDelta_t dshotTelemetryDeadtimeUs;
     bool dshotTelemetryActive;
 #ifdef USE_HAL_DRIVER
     LL_TIM_OC_InitTypeDef ocInitStruct;
@@ -183,7 +189,7 @@ motorDmaOutput_t *getMotorDmaOutput(uint8_t index);
 struct timerHardware_s;
 typedef void pwmWriteFn(uint8_t index, float value);  // function pointer used to write motors
 typedef void pwmCompleteWriteFn(uint8_t motorCount);   // function pointer used after motors are written
-typedef void pwmStartWriteFn(uint8_t motorCount);   // function pointer used before motors are written
+typedef bool pwmStartWriteFn(uint8_t motorCount);   // function pointer used before motors are written
 
 typedef struct {
     volatile timCCR_t *ccr;
@@ -244,7 +250,7 @@ void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command, bo
 void pwmWriteDshotInt(uint8_t index, uint16_t value);
 void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, motorPwmProtocolTypes_e pwmProtocolType, uint8_t output);
 #ifdef USE_DSHOT_TELEMETRY
-void pwmStartDshotMotorUpdate(uint8_t motorCount);
+bool pwmStartDshotMotorUpdate(uint8_t motorCount);
 #endif
 void pwmCompleteDshotMotorUpdate(uint8_t motorCount);
 
@@ -268,7 +274,7 @@ void pwmOutConfig(timerChannel_t *channel, const timerHardware_t *timerHardware,
 void pwmWriteMotor(uint8_t index, float value);
 void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
 void pwmCompleteMotorUpdate(uint8_t motorCount);
-void pwmStartMotorUpdate(uint8_t motorCount);
+bool pwmStartMotorUpdate(uint8_t motorCount);
 
 void pwmWriteServo(uint8_t index, float value);
 

--- a/src/main/drivers/pwm_output_dshot_shared.h
+++ b/src/main/drivers/pwm_output_dshot_shared.h
@@ -66,7 +66,7 @@ FAST_CODE void pwmDshotSetDirectionOutput(
 #endif
 );
 
-void pwmStartDshotMotorUpdate(uint8_t motorCount);
+bool pwmStartDshotMotorUpdate(uint8_t motorCount);
 
 #endif
 #endif

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -518,7 +518,9 @@ void writeMotors(void)
 {
     if (pwmAreMotorsEnabled()) {
 #if defined(USE_DSHOT) && defined(USE_DSHOT_TELEMETRY)
-        pwmStartMotorUpdate(motorCount);
+        if (!pwmStartMotorUpdate(motorCount)) {
+            return;
+        }
 #endif
         for (int i = 0; i < motorCount; i++) {
             pwmWriteMotor(i, motor[i]);


### PR DESCRIPTION
This PR provides a fix for collisions between dshot frames from the FC and telemetry frames from the ESC. If telemetry is still in progress at the time a new frame is to be sent the frame gets ignored so telemetry can get through. 