### PR TITLE
Revert "SmartAudio Lite compatibility: Send 0x00 bit(s) (always) even with Soft Serial."

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -450,7 +450,14 @@ static void saReceiveFrame(uint8_t c)
 static void saSendFrame(uint8_t *buf, int len)
 {
     if (!IS_RC_MODE_ACTIVE(BOXVTXCONTROLDISABLE)) {
-        serialWrite(smartAudioSerialPort, 0x00); // Ensure line is low regardless of hardware pull-down capabilities.
+        switch (smartAudioSerialPort->identifier) {
+            case SERIAL_PORT_SOFTSERIAL1:
+            case SERIAL_PORT_SOFTSERIAL2:
+                break;
+            default:
+                serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start bit
+                break;
+        }
 
         for (int i = 0 ; i < len ; i++) {
             serialWrite(smartAudioSerialPort, buf[i]);
@@ -461,7 +468,6 @@ static void saSendFrame(uint8_t *buf, int len)
         sa_outstanding = SA_CMD_NONE;
     }
 
-    serialWrite(smartAudioSerialPort, 0x00); // Pull the line low again after sending frame.
     sa_lastTransmissionMs = millis();
 }
 


### PR DESCRIPTION
Reverts betaflight/betaflight#7603

This should give us SA2.0, SA2.1 working again in master for RC4?, but SA2.0lite will be busted (still).

Sorry. 😔 