### PR TITLE
Fix OSD stats alignment and formatting

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -124,6 +124,10 @@
 #define SYM_ON_M                    0x9B
 #define SYM_FLY_M                   0x9C
 
+// Speed
+#define SYM_KPH                     0x4B  // we don't have a KPH symbol so use 'K'
+#define SYM_MPH                     0x4D  // we don't have a MPH symbol so use 'M'
+
 // Menu cursor
 #define SYM_CURSOR                  SYM_AH_LEFT
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -335,19 +335,13 @@ static void osdResetStats(void)
 static void osdUpdateStats(void)
 {
     int16_t value = 0;
+
 #ifdef USE_GPS
-    switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
-        value = CM_S_TO_MPH(gpsSol.groundSpeed);
-        break;
-    default:
-        value = CM_S_TO_KM_H(gpsSol.groundSpeed);
-        break;
-    }
-#endif
+    value = gpsSol.groundSpeed;
     if (stats.max_speed < value) {
         stats.max_speed = value;
     }
+#endif
 
     value = getBatteryVoltage();
     if (stats.min_voltage > value) {
@@ -499,14 +493,15 @@ static void osdShowStats(uint16_t endBatteryVoltage)
     }
 
     if (osdStatGetState(OSD_STAT_MAX_ALTITUDE)) {
-        osdFormatAltitudeString(buff, stats.max_altitude);
+        const int alt = osdGetMetersToSelectedUnit(stats.max_altitude) / 10;
+        tfp_sprintf(buff, "%d.%d%c", alt / 10, alt % 10, osdGetMetersToSelectedUnitSymbol());
         osdDisplayStatisticLabel(top++, "MAX ALTITUDE", buff);
     }
 
 #ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)) {
         if (osdStatGetState(OSD_STAT_MAX_SPEED)) {
-            itoa(stats.max_speed, buff, 10);    
+            tfp_sprintf(buff, "%d%c", osdGetSpeedToSelectedUnit(stats.max_speed), osdGetSpeedToSelectedUnitSymbol());
             osdDisplayStatisticLabel(top++, "MAX SPEED", buff);
         }
 
@@ -579,7 +574,7 @@ static void osdShowStats(uint16_t endBatteryVoltage)
 
 #ifdef USE_ESC_SENSOR
     if (osdStatGetState(OSD_STAT_MAX_ESC_TEMP)) {
-        tfp_sprintf(buff, "%3d%c", osdConvertTemperatureToSelectedUnit(stats.max_esc_temp), osdGetTemperatureSymbolForSelectedUnit());
+        tfp_sprintf(buff, "%d%c", osdConvertTemperatureToSelectedUnit(stats.max_esc_temp), osdGetTemperatureSymbolForSelectedUnit());
         osdDisplayStatisticLabel(top++, "MAX ESC TEMP", buff);
     }
 

--- a/src/main/osd/osd_elements.h
+++ b/src/main/osd/osd_elements.h
@@ -36,12 +36,13 @@ typedef struct osdElementParms_s {
 typedef void (*osdElementDrawFn)(osdElementParms_t *element);
 
 int osdConvertTemperatureToSelectedUnit(int tempInDegreesCelcius);
-void osdFormatAltitudeString(char * buff, int32_t altitudeCm);
 bool osdFormatRtcDateTime(char *buffer);
 void osdFormatTime(char * buff, osd_timer_precision_e precision, timeUs_t time);
 void osdFormatTimer(char *buff, bool showSymbol, bool usePrecision, int timerIndex);
 int32_t osdGetMetersToSelectedUnit(int32_t meters);
 char osdGetMetersToSelectedUnitSymbol(void);
+int32_t osdGetSpeedToSelectedUnit(int32_t value);
+char osdGetSpeedToSelectedUnitSymbol(void);
 char osdGetTemperatureSymbolForSelectedUnit(void);
 void osdAnalyzeActiveElements(void);
 void osdDrawActiveElements(displayPort_t *osdDisplayPort, timeUs_t currentTimeUs);

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -395,7 +395,7 @@ TEST(OsdTest, TestStatsImperial)
     displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:05.00");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:03");
-    displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      :    6.5%c", SYM_FT);
+    displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      : 6.5%c", SYM_FT);
     displayPortTestBufferSubstring(2, row++, "MAX SPEED         : 17");
     displayPortTestBufferSubstring(2, row++, "MAX DISTANCE      : 328%c", SYM_FT);
     displayPortTestBufferSubstring(2, row++, "FLIGHT DISTANCE   : 656%c", SYM_FT);
@@ -448,7 +448,7 @@ TEST(OsdTest, TestStatsMetric)
     displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:07.50");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:02");
-    displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      :    2.0%c", SYM_M);
+    displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      : 2.0%c", SYM_M);
     displayPortTestBufferSubstring(2, row++, "MAX SPEED         : 28");
     displayPortTestBufferSubstring(2, row++, "MAX DISTANCE      : 100%c", SYM_M);
     displayPortTestBufferSubstring(2, row++, "FLIGHT DISTANCE   : 100%c", SYM_M);


### PR DESCRIPTION
Fixes #7876 

Corrects the alignment and formatting of the following stats:
* Max altitude
* Max speed
* Max ESC temperature

