### PR TITLE
Fix GPS Rescue throttle PID calculation

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -299,7 +299,7 @@ static void rescueAttainPosition()
 
     previousAltitudeError = altitudeError;
 
-    const int16_t altitudeAdjustment = (gpsRescueConfig()->throttleP * altitudeError + (gpsRescueConfig()->throttleI * altitudeIntegral) / 10 *  + gpsRescueConfig()->throttleD * altitudeDerivative) / ct / 20;
+    const int16_t altitudeAdjustment = (gpsRescueConfig()->throttleP * altitudeError + (gpsRescueConfig()->throttleI * altitudeIntegral) / 10 + gpsRescueConfig()->throttleD * altitudeDerivative) / ct / 20;
     const int16_t hoverAdjustment = (hoverThrottle - 1000) / ct;
 
     rescueThrottle = constrain(1000 + altitudeAdjustment + hoverAdjustment, gpsRescueConfig()->throttleMin, gpsRescueConfig()->throttleMax);


### PR DESCRIPTION
Fixes an extraneous "*" in the throttle PID calculation that caused the integral portion to be multiplied by the derivative calc instead of adding it.

Credit to @IllusionFpv for noticing.

