### PR TITLE
Fixed PWM beeper.

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -792,7 +792,7 @@ const clivalue_t valueTable[] = {
 // PG_BEEPER_DEV_CONFIG
     { "beeper_inversion",           VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, isInverted) },
     { "beeper_od",                  VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, isOpenDrain) },
-    { "beeper_frequency",           VAR_INT16  | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, frequency) },
+    { "beeper_frequency",           VAR_INT16  | HARDWARE_VALUE, .config.minmax = { 0, 16000 }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, frequency) },
 
 // PG_BEEPER_CONFIG
 #ifdef USE_DSHOT

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -687,11 +687,7 @@ void beeperPwmInit(const ioTag_t tag, uint16_t frequency)
     if (beeperIO && timer) {
         beeperPwm.io = beeperIO;
         IOInit(beeperPwm.io, OWNER_BEEPER, RESOURCE_INDEX(0));
-#if defined(USE_HAL_DRIVER)
         IOConfigGPIOAF(beeperPwm.io, IOCFG_AF_PP, timer->alternateFunction);
-#else
-        IOConfigGPIO(beeperPwm.io, IOCFG_AF_PP);
-#endif
         freqBeep = frequency;
         pwmOutConfig(&beeperPwm.channel, timer, PWM_TIMER_1MHZ, PWM_TIMER_1MHZ / freqBeep, (PWM_TIMER_1MHZ / freqBeep) / 2, 0);
 

--- a/unified_targets/configs/CLRACINGF4.config
+++ b/unified_targets/configs/CLRACINGF4.config
@@ -1,0 +1,88 @@
+# Betaflight / STM32F405 (S405) 4.0.0 Mar 29 2019 / 01:35:03 (9b08bdcd5) MSP API: 1.41
+
+board_name CLRACINGF4
+manufacturer_id CLRA
+
+# resources
+resource BEEPER 1 B04
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 A03
+resource MOTOR 4 A02
+resource MOTOR 5 B08
+resource LED_STRIP 1 B08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource INVERTER 1 C00
+resource LED 1 B05
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource CAMERA_CONTROL 1 B09
+resource ADC_BATT 1 C02
+resource ADC_RSSI 1 C03
+resource ADC_CURR 1 C01
+resource SDCARD_CS 1 B12
+resource SDCARD_DETECT 1 B07
+resource FLASH_CS 1 B03
+resource OSD_CS 1 A15
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 C05
+
+# timer
+timer B09 1
+timer B00 0
+timer B01 2
+timer A03 0
+timer A02 0
+timer B04 0
+timer B08 0
+
+# dma
+dma SPI_TX 2 0
+# SPI_TX 2: DMA1 Stream 4 Channel 0
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin B00 0
+# pin B00: DMA2 Stream 6 Channel 0
+dma pin B01 0
+# pin B01: DMA2 Stream 2 Channel 0
+dma pin A03 1
+# pin A03: DMA1 Stream 6 Channel 3
+dma pin A02 0
+# pin A02: DMA1 Stream 1 Channel 3
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+
+# master
+set blackbox_device = SDCARD
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 250
+set beeper_inversion = ON
+set beeper_od = OFF
+set beeper_frequency = 3800
+set sdcard_mode = SPI
+set sdcard_spi_bus = 2
+set system_hse_mhz = 8
+set max7456_spi_bus = 3
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0
+set gyro_2_spibus = 1

--- a/unified_targets/configs/CLRACINGF7.config
+++ b/unified_targets/configs/CLRACINGF7.config
@@ -1,7 +1,7 @@
 # Betaflight / STM32F745 (S745) 4.0.0 Mar 10 2019 / 21:49:53 (d6138c41e) MSP API: 1.41
 
 board_name CLRACINGF7
-manufacturer_id CLRC
+manufacturer_id CLRA
 
 # BEEPER
 resource BEEPER 1 PB4

--- a/unified_targets/docs/Manufacturers.md
+++ b/unified_targets/docs/Manufacturers.md
@@ -6,6 +6,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |Manufacturer Id|Name|Contact|
 |-|-|-|
 |CUST|'Custom', to be used for homebrew targets||
+|CLRA|CLRACING LLC|https://cl-racing.myshopify.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|
 |AIRB|Airbot|https://store.myairbot.com/|
 |BKMN|Jason Blackman|https://github.com/blckmn|


### PR DESCRIPTION
Also added `beeper_frequency` as a `HARDWARE_VALUE`, since this is required to make PWM beepers work (and avoid running DC through them).

Also added the Unified Target config for the CLRACINGF4, and a manufacturer id for CLRACING.

@jflyper: Turns out this was caused by PWM beeper having been missed for #6681, which took me a bisect between 3.5 and 4.0 to find. :sweat_smile: