### PR TITLE
Revise ESCSERIAL to work with unified targets

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3581,7 +3581,9 @@ static void cliEscPassthrough(char *cmdline)
         pch = strtok_r(NULL, " ", &saveptr);
     }
 
-    escEnablePassthrough(cliPort, escIndex, mode);
+    if (!escEnablePassthrough(cliPort, &motorConfig()->dev, escIndex, mode)) {
+        cliPrintErrorLinef("Error starting ESC connection");
+    }
 }
 #endif
 

--- a/src/main/drivers/serial_escserial.h
+++ b/src/main/drivers/serial_escserial.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/pwm_output.h"
+
 #define ESCSERIAL_BUFFER_SIZE 1024
 
 typedef enum {
@@ -37,7 +39,7 @@ typedef enum {
 } escProtocol_e;
 
 // serialPort API
-void escEnablePassthrough(serialPort_t *escPassthroughPort, uint16_t output, uint8_t mode);
+bool escEnablePassthrough(serialPort_t *escPassthroughPort, const motorDevConfig_t *motorConfig, uint16_t escIndex, uint8_t mode);
 
 typedef struct escSerialConfig_s {
     ioTag_t ioTag;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -190,7 +190,7 @@ uint8_t escPortIndex;
 #ifdef USE_ESCSERIAL
 static void mspEscPassthroughFn(serialPort_t *serialPort)
 {
-    escEnablePassthrough(serialPort, escPortIndex, escMode);
+    escEnablePassthrough(serialPort, &motorConfig()->dev, escPortIndex, escMode);
 }
 #endif
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -303,3 +303,8 @@
 #undef USE_RANGEFINDER_UIB
 #undef USE_RANGEFINDER_TF
 #endif
+
+// TODO: Remove this once HAL support is fixed for ESCSERIAL
+#ifdef STM32F7
+#undef USE_ESCSERIAL
+#endif

--- a/src/main/target/common_unified.h
+++ b/src/main/target/common_unified.h
@@ -95,8 +95,7 @@
 
 #define USE_USB_DETECT
 
-//TODO: Re-enable this after it's been fixed to work with unified targets
-//#define USE_ESCSERIAL
+#define USE_ESCSERIAL
 
 #define USE_ADC
 


### PR DESCRIPTION
Remove dependencies on timer definition order and base on the pins assigned as motor resources.
