### PR TITLE
adjust Ki to keep total i action the same and reduce abs control defa…

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -176,7 +176,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .acro_trainer_lookahead_ms = 50,
         .acro_trainer_debug_axis = FD_ROLL,
         .acro_trainer_gain = 75,
-        .abs_control_gain = 0,
+        .abs_control_gain = 5,
         .abs_control_limit = 90,
         .abs_control_error_limit = 20,
         .abs_control_cutoff = 11,
@@ -638,6 +638,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     acLimit = (float)pidProfile->abs_control_limit;
     acErrorLimit = (float)pidProfile->abs_control_error_limit;
     acCutoff = (float)pidProfile->abs_control_cutoff;
+    for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
+        float iCorrection = -acGain * PTERM_SCALE / ITERM_SCALE * pidCoefficient[axis].Kp;
+        pidCoefficient[axis].Ki = MAX(0.0f, pidCoefficient[axis].Ki + iCorrection);
+    }
 #endif
 
 #ifdef USE_DYN_LPF


### PR DESCRIPTION
We have found abs control to cause wobbles in some quads. The are generally very slow and look like I wobbles caused by the iterm and abs control acting in concert and providing a stronger I action than necessary. It's easy to show that to get the same I action for a given acGain and Kp you have to modify I like this:
```
KiChange = -acGain x PTERM_SCALE x Kp / ITERM_SCALE
```

This PR reduces the acGain to 5 and automatically makes the Ki adjustment to compensate for the ac action.

Compare to https://github.com/betaflight/betaflight/pull/7901. Both are possible directions for our last RC.