### PR TITLE
Use dynamic lpf min as the default for lowpass 1 cutoffs if dynamic is enabled

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -202,8 +202,12 @@ static void validateAndFixConfig(void)
             pidProfilesMutable(i)->dyn_lpf_dterm_min_hz = 0;
         }
 
+        // Dterm lowpass 1 cutoff is not used when dynamic lowpass is enabled, but setting to 0 is the indicator
+        // to older configurators that lowpass 1 is disabled which results in resetting the type to PT1.
+        // This causes problems then because the dynamic lowpass still uses the type which has been incorrectly changed.
+        // So use the dyn_lpf_dterm_min_hz instead if it's enabled as a slightly less confusing (but unused) default.
         if (pidProfilesMutable(i)->dyn_lpf_dterm_min_hz > 0) {
-            pidProfilesMutable(i)->dterm_lowpass_hz = 0;
+            pidProfilesMutable(i)->dterm_lowpass_hz = pidProfilesMutable(i)->dyn_lpf_dterm_min_hz;
         }
 #endif
 
@@ -492,8 +496,12 @@ void validateAndFixGyroConfig(void)
         gyroConfigMutable()->dyn_lpf_gyro_min_hz = 0;
     }
 
+    // Gyro lowpass 1 cutoff is not used when dynamic lowpass is enabled, but setting to 0 is the indicator
+    // to older configurators that lowpass 1 is disabled which results in resetting the type to PT1.
+    // This causes problems then because the dynamic lowpass still uses the type which has been incorrectly changed.
+    // So use the dyn_lpf_gyro_min_hz instead if it's enabled as a slightly less confusing (but unused) default.
     if (gyroConfig()->dyn_lpf_gyro_min_hz > 0) {
-        gyroConfigMutable()->gyro_lowpass_hz = 0;
+        gyroConfigMutable()->gyro_lowpass_hz = gyroConfigMutable()->dyn_lpf_gyro_min_hz;
     }
 #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -203,9 +203,13 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .transient_throttle_limit = 15,
     );
 #ifdef USE_DYN_LPF
-    pidProfile->dterm_lowpass_hz = 0;
-    pidProfile->dterm_lowpass2_hz = 150;
+    // Dterm lowpass 1 cutoff is not used when dynamic lowpass is enabled, but setting to 0 is the indicator
+    // to older configurators that lowpass 1 is disabled which results in resetting the type to PT1.
+    // This causes problems then because the dynamic lowpass still uses the type which has been incorrectly changed.
+    // So use the dyn_lpf_dterm_min_hz instead as a slightly less confusing (but unused) default.
+    pidProfile->dterm_lowpass_hz = pidProfile->dyn_lpf_dterm_min_hz;
     pidProfile->dterm_filter_type = FILTER_BIQUAD;
+    pidProfile->dterm_lowpass2_hz = 150;
     pidProfile->dterm_filter2_type = FILTER_BIQUAD;
 #endif
 #ifndef USE_D_MIN

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -222,7 +222,11 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->dyn_notch_q = 120;
     gyroConfig->dyn_notch_min_hz = 150;
 #ifdef USE_DYN_LPF
-    gyroConfig->gyro_lowpass_hz = 0;
+    // Gyro lowpass 1 cutoff is not used when dynamic lowpass is enabled, but setting to 0 is the indicator
+    // to older configurators that lowpass 1 is disabled which results in resetting the type to PT1.
+    // This causes problems then because the dynamic lowpass still uses the type which has been incorrectly changed.
+    // So use the dyn_lpf_gyro_min_hz instead as a slightly less confusing (but unused) default.
+    gyroConfig->gyro_lowpass_hz = gyroConfig->dyn_lpf_gyro_min_hz;
     gyroConfig->gyro_lowpass_type = FILTER_BIQUAD;
     gyroConfig->gyro_lowpass2_hz = 0;
 #endif


### PR DESCRIPTION
Even though the cutoffs for gyro and dterm lowpass 1 are not used if dynamic lpf is enabled, setting them to 0 results in bad behavior in older configurators. The configuator considers a cutoff of 0 to be the indicator that the lowpass is disabled and as such it resets the related elements to default values.

Unfortunately this results in the lowpass 1 filter type being reset to PT1 inappropriately. Since the dynamic lpf still uses the filter type, it's now set to an incompatible value for the default dynamic range which is tuned for BIQUAD.

So now we default to the dynamic lpf min cutoff for the lowpass 1 cutoffs if dynamic lpf is enabled. It's not ideal as it's still a slightly confusing result, but avoids the bad behavior in pre 10.4 configurators.
