### PR TITLE
Unify lowpass settings regardless of whether USE_DYN_LPF is defined

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -201,10 +201,6 @@ static void validateAndFixConfig(void)
         if (pidProfilesMutable(i)->dyn_lpf_dterm_min_hz > pidProfilesMutable(i)->dyn_lpf_dterm_max_hz) {
             pidProfilesMutable(i)->dyn_lpf_dterm_min_hz = 0;
         }
-
-        if (pidProfilesMutable(i)->dyn_lpf_dterm_min_hz > 0) {
-            pidProfilesMutable(i)->dterm_lowpass_hz = 0;
-        }
 #endif
 
         if (pidProfilesMutable(i)->motor_output_limit > 100 || pidProfilesMutable(i)->motor_output_limit == 0) {
@@ -490,10 +486,6 @@ void validateAndFixGyroConfig(void)
     //Prevent invalid dynamic lowpass filter
     if (gyroConfig()->dyn_lpf_gyro_min_hz > gyroConfig()->dyn_lpf_gyro_max_hz) {
         gyroConfigMutable()->dyn_lpf_gyro_min_hz = 0;
-    }
-
-    if (gyroConfig()->dyn_lpf_gyro_min_hz > 0) {
-        gyroConfigMutable()->gyro_lowpass_hz = 0;
     }
 #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -181,10 +181,13 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .abs_control_error_limit = 20,
         .abs_control_cutoff = 11,
         .antiGravityMode = ANTI_GRAVITY_SMOOTH,
-        .dterm_lowpass_hz = 100,    // dual PT1 filtering ON by default
-        .dterm_lowpass2_hz = 200,   // second Dterm LPF ON by default
-        .dterm_filter_type = FILTER_PT1,
-        .dterm_filter2_type = FILTER_PT1,
+        .dterm_lowpass_hz = 150,    // NOTE: dynamic lpf is enabled by default so this setting is actually
+                                    // overridden and the static lowpass 1 is disabled. We can't set this
+                                    // value to 0 otherwise Configurator versions 10.4 and earlier will also
+                                    // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
+        .dterm_lowpass2_hz = 150,   // second Dterm LPF ON by default
+        .dterm_filter_type = FILTER_BIQUAD,
+        .dterm_filter2_type = FILTER_BIQUAD,
         .dyn_lpf_dterm_min_hz = 150,
         .dyn_lpf_dterm_max_hz = 250,
         .launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,
@@ -202,12 +205,6 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
         .transient_throttle_limit = 15,
     );
-#ifdef USE_DYN_LPF
-    pidProfile->dterm_lowpass_hz = 0;
-    pidProfile->dterm_lowpass2_hz = 150;
-    pidProfile->dterm_filter_type = FILTER_BIQUAD;
-    pidProfile->dterm_filter2_type = FILTER_BIQUAD;
-#endif
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;
     pidProfile->pid[PID_PITCH].D = 32;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -201,10 +201,13 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyroMovementCalibrationThreshold = 48;
     gyroConfig->gyro_sync_denom = GYRO_SYNC_DENOM_DEFAULT;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
-    gyroConfig->gyro_lowpass_type = FILTER_PT1;
-    gyroConfig->gyro_lowpass_hz = 100;
-    gyroConfig->gyro_lowpass2_type = FILTER_PT1;
-    gyroConfig->gyro_lowpass2_hz = 300;
+    gyroConfig->gyro_lowpass_type = FILTER_BIQUAD;
+    gyroConfig->gyro_lowpass_hz = 150;  // NOTE: dynamic lpf is enabled by default so this setting is actually
+                                        // overridden and the static lowpass 1 is disabled. We can't set this
+                                        // value to 0 otherwise Configurator versions 10.4 and earlier will also
+                                        // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
+    gyroConfig->gyro_lowpass2_type = FILTER_BIQUAD;
+    gyroConfig->gyro_lowpass2_hz = 0;
     gyroConfig->gyro_high_fsr = false;
     gyroConfig->gyro_to_use = GYRO_CONFIG_USE_GYRO_DEFAULT;
     gyroConfig->gyro_soft_notch_hz_1 = 0;
@@ -221,11 +224,6 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->dyn_notch_width_percent = 8;
     gyroConfig->dyn_notch_q = 120;
     gyroConfig->dyn_notch_min_hz = 150;
-#ifdef USE_DYN_LPF
-    gyroConfig->gyro_lowpass_hz = 0;
-    gyroConfig->gyro_lowpass_type = FILTER_BIQUAD;
-    gyroConfig->gyro_lowpass2_hz = 0;
-#endif
     gyroConfig->gyro_filter_debug_axis = FD_ROLL;
 }
 


### PR DESCRIPTION
Defaults will be the same regardless of whether the target has `USE_DYN_LPF` included. Previously the defaults would vary and it wouldn't be obvious why.

Also fixes the filter type reset problem in older Configurator versions by no longer setting the lowpass cutoffs to 0 when dynamic lpf is enabled.

Defaults are as follows:
gyro lowpass 1: 150/BIQUAD
gyro lowpass 2: OFF
dterm lowpass 1: 150/BIQUAD
dterm lowpass 2: 150/BIQUAD

For all F3 that included `USE_DYN_LPF` and F4+ there are no changes. For F3 that previously didn't include `USE_DYN_LPF` they will use the new defaults.

Nothing has changed in the dynamic lowpass logic. If it's enabled those settings will be used in place of the static lowpass cutoff.

Needs coordination with the Configurator to change the defaults used when re-eanbling the lowpass filters as they are currently based on previous version settings and will dfault to inappropriate values.
