### PR TITLE
Refactor dshot command output scheduling logic

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -254,14 +254,13 @@ bool pwmStartDshotMotorUpdate(uint8_t motorCount);
 #endif
 void pwmCompleteDshotMotorUpdate(uint8_t motorCount);
 
-void pwmDshotCommandQueueUpdate(void);
 bool pwmDshotCommandIsQueued(void);
 bool pwmDshotCommandIsProcessing(void);
 uint8_t pwmGetDshotCommand(uint8_t index);
 bool pwmDshotCommandOutputIsEnabled(uint8_t motorCount);
 uint16_t getDshotTelemetry(uint8_t index);
 bool isDshotMotorTelemetryActive(uint8_t motorIndex);
-
+void setDshotPidLoopTime(uint32_t pidLoopTime);
 #endif
 
 #ifdef USE_BEEPER

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -169,7 +169,6 @@ void pwmCompleteDshotMotorUpdate(uint8_t motorCount)
             dmaMotorTimers[i].timerDmaSources = 0;
         }
     }
-    pwmDshotCommandQueueUpdate();
 }
 
 static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -153,7 +153,6 @@ FAST_CODE void pwmCompleteDshotMotorUpdate(uint8_t motorCount)
             dmaMotorTimers[i].timerDmaSources = 0;
         }
     }
-    pwmDshotCommandQueueUpdate();
 }
 
 static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -34,6 +34,7 @@
 
 #include "config/config_reset.h"
 
+#include "drivers/pwm_output.h"
 #include "drivers/sound_beeper.h"
 #include "drivers/time.h"
 
@@ -223,6 +224,9 @@ static void pidSetTargetLooptime(uint32_t pidLooptime)
     targetPidLooptime = pidLooptime;
     dT = targetPidLooptime * 1e-6f;
     pidFrequency = 1.0f / dT;
+#ifdef USE_DSHOT
+    setDshotPidLoopTime(targetPidLooptime);
+#endif
 }
 
 static FAST_RAM float itermAccelerator = 1.0f;


### PR DESCRIPTION
Change to a state machine that tracks the progress of each dshot command in the queue as it moves through the various phases. Simplifies the code to make it easier to understand and maintain.

Transition to timing based on motor output cycle counts calculated from desired delays instead of using direct time comparisons. Since the output timing is always based on the motor update schedule, there were cases where if the time between motor updates was a significant percentage of the desired dshot command timing, then the output could get irregular and skip cycles. This would get worse at slower loop times - particularly at 2K or less.

Examples:

Normal 4.0 arming with crash-flip enabled @ 8KHz PID loop. "0" motor stop at 125us timing, 10ms command initial delay, enable telemetry command sent 10 times at 1ms delay, 1ms delay after dshot command, motor direction command sent 10 times at 1ms delay, 1ms delay after dshot command, motor outputs start at 125us timing:

![8k 2 commands](https://user-images.githubusercontent.com/17088539/55689320-17ead600-5951-11e9-863a-ccd65dbf3385.png)

Same but with PID loop at 2KHz:

![2k 2 commands](https://user-images.githubusercontent.com/17088539/55689326-2933e280-5951-11e9-8604-8070a2eaf22b.png)

Single command at arming with 8KHz PID loop:

![8k 1 command](https://user-images.githubusercontent.com/17088539/55689341-4bc5fb80-5951-11e9-8697-a01b14cd339f.png)

Demonstrating commands having different `delayAfterCommandUs`. 8KHz PID loop with first command having a 3ms delay after and the second command having a 2ms delay:

![8k 2 command variable](https://user-images.githubusercontent.com/17088539/55689367-87f95c00-5951-11e9-9c73-4bbd228c484c.png)

Same but with PID loop at 2KHz:

![2k 2 command variable](https://user-images.githubusercontent.com/17088539/55689372-947db480-5951-11e9-8533-3f3994652f2f.png)