### PR TITLE
Avoid altitude to blink if its value exceeds the alarm threshold when…

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1559,7 +1559,7 @@ void osdUpdateAlarms(void)
         CLR_BLINK(OSD_REMAINING_TIME_ESTIMATE);
     }
 
-    if (alt >= osdConfig()->alt_alarm) {
+    if ((alt >= osdConfig()->alt_alarm) && ARMING_FLAG(ARMED)) {
         SET_BLINK(OSD_ALTITUDE);
     } else {
         CLR_BLINK(OSD_ALTITUDE);


### PR DESCRIPTION
… not armed, as it's showing altitude over sea level instead of flight altitude.
