### PR TITLE
Add MCO2 output support for F4

### DIFF
--- a/src/main/drivers/mco.c
+++ b/src/main/drivers/mco.c
@@ -38,8 +38,15 @@ void mcoInit(const mcoConfig_t *mcoConfig)
     if (mcoConfig->enabled[1]) {
         IO_t io = IOGetByTag(DEFIO_TAG_E(PC9));
         IOInit(io, OWNER_MCO, 2);
+#if defined(STM32F7)
         HAL_RCC_MCOConfig(RCC_MCO2, RCC_MCO2SOURCE_PLLI2SCLK, RCC_MCODIV_4);
         IOConfigGPIOAF(io, IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH,  GPIO_NOPULL), GPIO_AF0_MCO);
+#elif defined(STM32F40_41xxx) || defined(STM32F411xE) || defined(STM32F446xx)
+        RCC_MCO2Config(RCC_MCO2Source_PLLI2SCLK, RCC_MCO2Div_4);
+        IOConfigGPIOAF(io, IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL), GPIO_AF_MCO);
+#else
+#error Unsupported MCU
+#endif
     }
 }
 #endif

--- a/src/main/startup/system_stm32f4xx.c
+++ b/src/main/startup/system_stm32f4xx.c
@@ -854,6 +854,28 @@ uint32_t pllsai_m;
 #undef  RCC_PLLSAI_GET_FLAG
 #endif /* STM32F446xx */
 
+    // Configure PLLI2S for 27MHz operation
+    // Use pll_input (1 or 2) to derive multiplier N for
+    // 108MHz (27 * 4) PLLI2SCLK with R divider fixed at 2.
+    // 108MHz will further be prescaled by 4 by mcoInit.
+
+#define PLLI2S_TARGET_FREQ_MHZ (27 * 4)
+#define PLLI2S_R               2
+
+    uint32_t plli2s_n = (PLLI2S_TARGET_FREQ_MHZ * PLLI2S_R) / pll_input;
+
+#ifdef STM32F40_41xxx
+    RCC_PLLI2SConfig(plli2s_n, PLLI2S_R);
+#elif defined(STM32F411xE)
+    RCC_PLLI2SConfig(plli2s_n, PLLI2S_R, pll_m);
+#elif defined(STM32F446xx)
+    RCC_PLLI2SConfig(pll_m, plli2s_n, 2, 2, PLLI2S_R); // M, N, P, Q, R
+#else
+#error Unsupported MCU
+#endif
+
+    RCC_PLLI2SCmd(ENABLE);
+
     SystemCoreClockUpdate();
 }
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -62,6 +62,7 @@
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
 #define USE_PERSISTENT_MSC_RTC
+#define USE_MCO
 #define USE_DMA_SPEC
 #define USE_TIMER_MGMT
 // Re-enable this after 4.0 has been released, and remove the define from STM32F4DISCOVERY


### PR DESCRIPTION
As suggested by https://github.com/betaflight/betaflight/pull/6163#issuecomment-432231045 in #6163, this is an addition of F4 support for 27MHz output on MCO2.

Tested on
- Nucleo-F405RG (Nucleo-F401RE transplanted with F405RG) with OMNIBUSF4SD target
- Nucleo-F411CE with MATEKF411 target
- Nucleo-F446RE with NUCLEOF446RE target

Overclock case was also tested with Nucleo-F405RG.
