### PR TITLE
Change serial port config validation to require MSP on VCP port

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -275,6 +275,9 @@ bool isSerialConfigValid(const serialConfig_t *serialConfigToCheck)
 
         if (portConfig->functionMask & FUNCTION_MSP) {
             mspPortCount++;
+        } else if (portConfig->identifier == SERIAL_PORT_USB_VCP) {
+            // Require MSP to be enabled for the VCP port
+            return false;
         }
 
         uint8_t bitCount = BITCOUNT(portConfig->functionMask);


### PR DESCRIPTION
Will hopefully reduce the number of cases where users incorrectly disable MSP on the VCP port and then can no longer connect.

Should be supplemented with changes to the configurator that prevents turning off MSP on the VCP port.
