### PR TITLE
Add target HGLRCF745 to 4.0. Also add Unified Target configuration.

### DIFF
--- a/unified_targets/CONFIGS/HGLRCF745.config
+++ b/unified_targets/CONFIGS/HGLRCF745.config
@@ -1,0 +1,230 @@
+# Betaflight / STM32F745 (S745) 4.0.0 Apr  3 2019 / 14:32:23 (22b9f3453) MSP API: 1.41
+
+# start the command batch
+batch start
+
+board_name HGLRCF745
+manufacturer_id HGL
+
+# resources
+resource BEEPER 1 D15
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 E09
+resource MOTOR 4 E11
+resource MOTOR 5 NONE
+resource MOTOR 6 NONE
+resource MOTOR 7 NONE
+resource MOTOR 8 NONE
+resource SERVO 1 NONE
+resource SERVO 2 NONE
+resource SERVO 3 NONE
+resource SERVO 4 NONE
+resource SERVO 5 NONE
+resource SERVO 6 NONE
+resource SERVO 7 NONE
+resource SERVO 8 NONE
+resource PPM 1 A03
+resource PWM 1 NONE
+resource PWM 2 NONE
+resource PWM 3 NONE
+resource PWM 4 NONE
+resource PWM 5 NONE
+resource PWM 6 NONE
+resource PWM 7 NONE
+resource PWM 8 NONE
+resource SONAR_TRIGGER 1 B10
+resource SONAR_ECHO 1 B11
+resource LED_STRIP 1 D12
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 NONE
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 NONE
+resource SERIAL_TX 5 NONE
+resource SERIAL_TX 6 C06
+resource SERIAL_TX 7 NONE
+resource SERIAL_TX 8 NONE
+resource SERIAL_TX 9 NONE
+resource SERIAL_TX 10 NONE
+resource SERIAL_TX 11 NONE
+resource SERIAL_TX 12 NONE
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 NONE
+resource SERIAL_RX 5 NONE
+resource SERIAL_RX 6 C07
+resource SERIAL_RX 7 E07
+resource SERIAL_RX 8 NONE
+resource SERIAL_RX 9 NONE
+resource SERIAL_RX 10 NONE
+resource SERIAL_RX 11 NONE
+resource SERIAL_RX 12 NONE
+resource I2C_SCL 1 NONE
+resource I2C_SCL 2 NONE
+resource I2C_SCL 3 NONE
+resource I2C_SCL 4 NONE
+resource I2C_SDA 1 NONE
+resource I2C_SDA 2 NONE
+resource I2C_SDA 3 NONE
+resource I2C_SDA 4 NONE
+resource LED 1 E00
+resource LED 2 NONE
+resource LED 3 NONE
+resource RX_BIND 1 NONE
+resource RX_BIND_PLUG 1 NONE
+resource TRANSPONDER 1 NONE
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_SCK 4 E02
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MISO 4 E05
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource SPI_MOSI 4 E06
+resource CAMERA_CONTROL 1 NONE
+resource ADC_BATT 1 C03
+resource ADC_RSSI 1 C05
+resource ADC_CURR 1 C02
+resource ADC_EXT 1 NONE
+resource BARO_CS 1 A01
+resource COMPASS_CS 1 NONE
+resource COMPASS_EXTI 1 NONE
+resource SDCARD_CS 1 E04
+resource SDCARD_DETECT 1 E03
+resource PINIO 1 NONE
+resource PINIO 2 NONE
+resource PINIO 3 NONE
+resource PINIO 4 NONE
+resource USB_MSC_PIN 1 NONE
+resource FLASH_CS 1 NONE
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 D00
+resource GYRO_EXTI 2 E08
+resource GYRO_CS 1 A15
+resource GYRO_CS 2 A04
+resource USB_DETECT 1 C04
+
+# timer
+timer E13 0
+timer B00 1
+timer B01 1
+timer E09 0
+timer E11 0
+timer D12 0
+timer B10 0
+timer B11 0
+timer C06 1
+timer C07 1
+timer A03 0
+timer A02 2
+
+# dma
+dma SPI_TX 1 NONE
+dma SPI_TX 2 NONE
+dma SPI_TX 3 NONE
+dma SPI_TX 4 0
+# SPI_TX 4: DMA2 Stream 1 Channel 4
+dma SPI_RX 1 NONE
+dma SPI_RX 2 NONE
+dma SPI_RX 3 NONE
+dma SPI_RX 4 NONE
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma ADC 2 NONE
+dma ADC 3 NONE
+dma UART_TX 1 NONE
+dma UART_TX 2 NONE
+dma UART_TX 3 NONE
+dma UART_TX 4 NONE
+dma UART_TX 5 NONE
+dma UART_TX 6 NONE
+dma UART_TX 7 NONE
+dma UART_TX 8 NONE
+dma UART_RX 1 NONE
+dma UART_RX 2 NONE
+dma UART_RX 3 NONE
+dma UART_RX 4 NONE
+dma UART_RX 5 NONE
+dma UART_RX 6 NONE
+dma UART_RX 7 NONE
+dma UART_RX 8 NONE
+dma pin E13 1
+# pin E13: DMA2 Stream 6 Channel 6
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin E09 2
+# pin E09: DMA2 Stream 3 Channel 6
+dma pin E11 1
+# pin E11: DMA2 Stream 2 Channel 6
+dma pin D12 0
+# pin D12: DMA1 Stream 0 Channel 2
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin B11 0
+# pin B11: DMA1 Stream 7 Channel 3
+dma pin C06 0
+# pin C06: DMA2 Stream 2 Channel 0
+dma pin C07 1
+# pin C07: DMA2 Stream 3 Channel 7
+dma pin A03 0
+# pin A03: DMA1 Stream 7 Channel 3
+dma pin A02 NONE
+
+# master
+set gyro_to_use = FIRST
+set align_mag = DEFAULT
+set mag_bustype = I2C
+set mag_i2c_device = 2
+set mag_i2c_address = 0
+set mag_spi_device = 0
+set baro_bustype = SPI
+set baro_spi_device = 1
+set baro_i2c_device = 0
+set baro_i2c_address = 0
+set adc_device = 1
+set blackbox_device = SDCARD
+set dshot_burst = OFF
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 400
+set beeper_inversion = ON
+set beeper_od = OFF
+set beeper_frequency = 0
+set sdcard_detect_inverted = ON
+set sdcard_mode = SPI
+set sdcard_spi_bus = 4
+set system_hse_mhz = 8
+set max7456_clock = DEFAULT
+set max7456_spi_bus = 2
+set max7456_preinit_opu = OFF
+set led_inversion = 0
+set dashboard_i2c_bus = 2
+set dashboard_i2c_addr = 60
+set usb_msc_pin_pullup = ON
+set flash_spi_bus = 0
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 3
+set gyro_1_i2cBus = 0
+set gyro_1_i2c_address = 0
+set gyro_1_sensor_align = CW90
+set gyro_2_bustype = SPI
+set gyro_2_spibus = 1
+set gyro_2_i2cBus = 0
+set gyro_2_i2c_address = 0
+set gyro_2_sensor_align = DEFAULT
+set i2c1_pullup = OFF
+set i2c1_overclock = ON
+set i2c2_pullup = OFF
+set i2c2_overclock = ON
+set i2c3_pullup = OFF
+set i2c3_overclock = ON
+set i2c4_pullup = OFF
+set i2c4_overclock = ON
+set mco2_on_pc9 = OFF

--- a/unified_targets/CONFIGS/HGLRCF745.config
+++ b/unified_targets/CONFIGS/HGLRCF745.config
@@ -1,10 +1,7 @@
 # Betaflight / STM32F745 (S745) 4.0.0 Apr  3 2019 / 14:32:23 (22b9f3453) MSP API: 1.41
 
-# start the command batch
-batch start
-
 board_name HGLRCF745
-manufacturer_id HGL
+manufacturer_id HGLR
 
 # resources
 resource BEEPER 1 D15
@@ -12,68 +9,19 @@ resource MOTOR 1 B00
 resource MOTOR 2 B01
 resource MOTOR 3 E09
 resource MOTOR 4 E11
-resource MOTOR 5 NONE
-resource MOTOR 6 NONE
-resource MOTOR 7 NONE
-resource MOTOR 8 NONE
-resource SERVO 1 NONE
-resource SERVO 2 NONE
-resource SERVO 3 NONE
-resource SERVO 4 NONE
-resource SERVO 5 NONE
-resource SERVO 6 NONE
-resource SERVO 7 NONE
-resource SERVO 8 NONE
 resource PPM 1 A03
-resource PWM 1 NONE
-resource PWM 2 NONE
-resource PWM 3 NONE
-resource PWM 4 NONE
-resource PWM 5 NONE
-resource PWM 6 NONE
-resource PWM 7 NONE
-resource PWM 8 NONE
 resource SONAR_TRIGGER 1 B10
 resource SONAR_ECHO 1 B11
 resource LED_STRIP 1 D12
 resource SERIAL_TX 1 A09
-resource SERIAL_TX 2 NONE
 resource SERIAL_TX 3 B10
-resource SERIAL_TX 4 NONE
-resource SERIAL_TX 5 NONE
 resource SERIAL_TX 6 C06
-resource SERIAL_TX 7 NONE
-resource SERIAL_TX 8 NONE
-resource SERIAL_TX 9 NONE
-resource SERIAL_TX 10 NONE
-resource SERIAL_TX 11 NONE
-resource SERIAL_TX 12 NONE
 resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
 resource SERIAL_RX 3 B11
-resource SERIAL_RX 4 NONE
-resource SERIAL_RX 5 NONE
 resource SERIAL_RX 6 C07
 resource SERIAL_RX 7 E07
-resource SERIAL_RX 8 NONE
-resource SERIAL_RX 9 NONE
-resource SERIAL_RX 10 NONE
-resource SERIAL_RX 11 NONE
-resource SERIAL_RX 12 NONE
-resource I2C_SCL 1 NONE
-resource I2C_SCL 2 NONE
-resource I2C_SCL 3 NONE
-resource I2C_SCL 4 NONE
-resource I2C_SDA 1 NONE
-resource I2C_SDA 2 NONE
-resource I2C_SDA 3 NONE
-resource I2C_SDA 4 NONE
 resource LED 1 E00
-resource LED 2 NONE
-resource LED 3 NONE
-resource RX_BIND 1 NONE
-resource RX_BIND_PLUG 1 NONE
-resource TRANSPONDER 1 NONE
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13
 resource SPI_SCK 3 C10
@@ -86,22 +34,12 @@ resource SPI_MOSI 1 A07
 resource SPI_MOSI 2 B15
 resource SPI_MOSI 3 C12
 resource SPI_MOSI 4 E06
-resource CAMERA_CONTROL 1 NONE
 resource ADC_BATT 1 C03
 resource ADC_RSSI 1 C05
 resource ADC_CURR 1 C02
-resource ADC_EXT 1 NONE
 resource BARO_CS 1 A01
-resource COMPASS_CS 1 NONE
-resource COMPASS_EXTI 1 NONE
 resource SDCARD_CS 1 E04
 resource SDCARD_DETECT 1 E03
-resource PINIO 1 NONE
-resource PINIO 2 NONE
-resource PINIO 3 NONE
-resource PINIO 4 NONE
-resource USB_MSC_PIN 1 NONE
-resource FLASH_CS 1 NONE
 resource OSD_CS 1 B12
 resource GYRO_EXTI 1 D00
 resource GYRO_EXTI 2 E08
@@ -124,35 +62,10 @@ timer A03 0
 timer A02 2
 
 # dma
-dma SPI_TX 1 NONE
-dma SPI_TX 2 NONE
-dma SPI_TX 3 NONE
 dma SPI_TX 4 0
 # SPI_TX 4: DMA2 Stream 1 Channel 4
-dma SPI_RX 1 NONE
-dma SPI_RX 2 NONE
-dma SPI_RX 3 NONE
-dma SPI_RX 4 NONE
 dma ADC 1 1
 # ADC 1: DMA2 Stream 4 Channel 0
-dma ADC 2 NONE
-dma ADC 3 NONE
-dma UART_TX 1 NONE
-dma UART_TX 2 NONE
-dma UART_TX 3 NONE
-dma UART_TX 4 NONE
-dma UART_TX 5 NONE
-dma UART_TX 6 NONE
-dma UART_TX 7 NONE
-dma UART_TX 8 NONE
-dma UART_RX 1 NONE
-dma UART_RX 2 NONE
-dma UART_RX 3 NONE
-dma UART_RX 4 NONE
-dma UART_RX 5 NONE
-dma UART_RX 6 NONE
-dma UART_RX 7 NONE
-dma UART_RX 8 NONE
 dma pin E13 1
 # pin E13: DMA2 Stream 6 Channel 6
 dma pin B00 0
@@ -175,7 +88,6 @@ dma pin C07 1
 # pin C07: DMA2 Stream 3 Channel 7
 dma pin A03 0
 # pin A03: DMA1 Stream 7 Channel 3
-dma pin A02 NONE
 
 # master
 set gyro_to_use = FIRST


### PR DESCRIPTION
# Manufacturer Ids

This is the official list of manufacturer ids (`manufacturer_id` in the target config) that will be supported for loading onto unified targets by Betaflight configurator.


|Manufacturer Id|Name|Contact|
|-|-|-|
|CUST|'Custom', to be used for homebrew targets||
|CLRA|CLRACING LLC|https://cl-racing.myshopify.com/|
|AFNG|AlienFlight NG|https://www.alienflightng.com/|
|AIRB|Airbot|https://store.myairbot.com/|
|BKMN|Jason Blackman|https://github.com/blckmn|
|DRCL|dronercland|https://www.instagram.com/dronercland/|
|DYST|DongYang Smart Technology Co.,Ltd (dys)|http://www.dys.hk/|
|FFPV|Furious FPV|https://furiousfpv.com/|
|FLWO|Flywoo|https://flywoo.net/|
|FOXE|Foxeer|http://www.foxeer.com/|
|HAMO|Happymodel|http://www.happymodel.cn/|
|HBRO|Holybro|http://www.holybro.com/index.html|
|HGLC|HGLRC|https://www.hglrc.com/|
|IFRC|iFlight Innovation Technology Ltd.|https://www.iflight-rc.com/|
|JHEF|JHE\_FPV|https://github.com/atgfpeyv|
|KLEE|Kevin Lee (WhitenoiseFPV)|https://whitenoisefpv.com/|
|MTKS|Matek Systems|http://www.mateksys.com/|
|RCTI|RCTimer|http://rctimer.com/|
|RUSH|FPV Racing Rush|http://www.rushfpv.com/|
|SPRO|Seriously Pro Racing (SP Racing)|http://seriouslypro.com/|
|TTRH|TransTEC|http://www.transtechobby.com/|