### PR TITLE
add KakuteF7-mini to unified_targets

### DIFF
--- a/unified_targets/configs/KAKUTEF7MINI.config
+++ b/unified_targets/configs/KAKUTEF7MINI.config
@@ -1,0 +1,93 @@
+# Betaflight / STM32F745 (S745) 4.0.0 Mar 10 2019 / 21:49:53 (d6138c41e) MSP API: 1.41
+
+board_name KAKUTEF7MINI
+manufacturer_id HBRO
+
+# resources
+resource BEEPER 1 D15
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 E09
+resource MOTOR 4 E11
+resource MOTOR 5 C09
+resource MOTOR 6 A03
+resource PPM 1 E13
+resource LED_STRIP 1 D12
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 D05
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 D06
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource SERIAL_RX 7 E07
+resource I2C_SCL 1 B06
+resource I2C_SDA 1 B07
+resource LED 1 A02
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 4 E02
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 4 E05
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 4 E06
+resource ADC_BATT 1 C03
+resource ADC_RSSI 1 C05
+resource ADC_CURR 1 C02
+resource FLASH_CS 1 A04
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 E01
+resource GYRO_CS 1 E04
+resource USB_DETECT 1 A08
+
+# timer
+timer E13 0
+timer B00 1
+timer B01 1
+timer E09 0
+timer E11 0
+timer C09 1
+timer A03 1
+timer D12 0
+
+# dma
+dma SPI_TX 1 1
+# SPI_TX 1: DMA2 Stream 5 Channel 3
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin E13 1
+# pin E13: DMA2 Stream 6 Channel 6
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin E09 2
+# pin E09: DMA2 Stream 3 Channel 6
+dma pin E11 1
+# pin E11: DMA2 Stream 2 Channel 6
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin A03 0
+# pin A03: DMA1 Stream 1 Channel 6
+dma pin D12 0
+# pin D12: DMA1 Stream 0 Channel 2
+
+# master
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set flash_spi_bus = 1
+set blackbox_device = SPIFLASH
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 4
+set gyro_1_sensor_align = CW270
+set gyro_2_spibus = 4


### PR DESCRIPTION
Add kakuteF7-mini to unified_targets. I have test it on a  kakuteF7-mini board.
