### PR TITLE
set dyn_notch_min_hz minimum to 60hz

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -605,7 +605,7 @@ const clivalue_t valueTable[] = {
     { "dyn_notch_range",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DYNAMIC_FILTER_RANGE }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_range) },
     { "dyn_notch_width_percent",   VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 20 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_width_percent) },
     { "dyn_notch_q",               VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_q) },
-    { "dyn_notch_min_hz",          VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 100, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_min_hz) },
+    { "dyn_notch_min_hz",          VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 60, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_min_hz) },
 #endif
 #ifdef USE_DYN_LPF
     { "dyn_lpf_gyro_min_hz",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_gyro_min_hz) },


### PR DESCRIPTION
For 4.01 please

dyn_notch_min_hz provides a lower frequency limit below which the dynamic notch cannot go.
The current minimum is 100hz.

For low rpm quads (>7" to X class), when the dynamic notch mode is 'LOW', we should allow the user to enter the lowest possible value that can be detected by the FFT, because these quads sometimes get very low frequency prop resonance at idle.

The lowest detectible value is theoretically the centre frequency of the second FFT bin.  In low mode that is half-way between 31 and 63hz.  In practice, that value will be biased upwards a little bit by the upper shoulder of bins above the peak.  In practice, the lowest value is likely no less than 60hz.

This PR lowers the limit from 100hz to 60hz, allowing access to the full range of possible FFT tracking frequencies in LOW mode for low rpm quads.