### PR TITLE
OSD: combined ON/ARM timer

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -93,7 +93,8 @@
 const char * const osdTimerSourceNames[] = {
     "ON TIME  ",
     "TOTAL ARM",
-    "LAST ARM "
+    "LAST ARM ",
+    "ON/ARM   "
 };
 
 // Things in both OSD and CMS

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -26,7 +26,7 @@
 
 #include "sensors/esc_sensor.h"
 
-#define OSD_NUM_TIMER_TYPES 3
+#define OSD_NUM_TIMER_TYPES 4
 extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 
 #define OSD_ELEMENT_BUFFER_LENGTH 32
@@ -180,6 +180,7 @@ typedef enum {
     OSD_TIMER_SRC_ON,
     OSD_TIMER_SRC_TOTAL_ARMED,
     OSD_TIMER_SRC_LAST_ARMED,
+    OSD_TIMER_SRC_ON_OR_ARMED,
     OSD_TIMER_SRC_COUNT
 } osd_timer_source_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -296,6 +296,8 @@ static char osdGetTimerSymbol(osd_timer_source_e src)
     case OSD_TIMER_SRC_TOTAL_ARMED:
     case OSD_TIMER_SRC_LAST_ARMED:
         return SYM_FLY_M;
+    case OSD_TIMER_SRC_ON_OR_ARMED:
+        return ARMING_FLAG(ARMED) ? SYM_FLY_M : SYM_ON_M;
     default:
         return ' ';
     }
@@ -312,6 +314,8 @@ static timeUs_t osdGetTimerValue(osd_timer_source_e src)
         statistic_t *stats = osdGetStats();
         return stats->armed_time;
     }
+    case OSD_TIMER_SRC_ON_OR_ARMED:
+        return ARMING_FLAG(ARMED) ? osdFlyTime : micros();
     default:
         return 0;
     }


### PR DESCRIPTION
Added new OSD timer mode - combined ON/ARM timer.

This allows to have a single timer configured in OSD, showing all interesting information:
- ON time until the system is armed
- ARM time when flying

How it looks like: https://www.dropbox.com/s/5jr2hbkpgu1b9g2/on-arm-timer.AVI?dl=0

Useful feature borrowed from inav.
