### PR TITLE
Allocating OSD_CS resource for MATEKF411 unified config

### DIFF
--- a/unified_targets/configs/MATEKF411.config
+++ b/unified_targets/configs/MATEKF411.config
@@ -25,6 +25,7 @@ resource SPI_MOSI 1 A07
 resource SPI_MOSI 2 B15
 resource ADC_BATT 1 B00
 resource ADC_CURR 1 B01
+resource OSD_CS 1 B12
 resource GYRO_EXTI 1 A01
 resource GYRO_EXTI 2 NONE
 resource GYRO_CS 1 A04


### PR DESCRIPTION
Hi, for unified targets MATEKF411.config enables the OSD feature, but it doesn't work, because `resource OSD_CS 1` isn't allocated. 

I grepped the rest of the configs, I don't see any other ones doing `FEATURE OSD` without a `resource OSD_CS 1` line. 