### PR TITLE
OSD timers safety checks

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -205,6 +205,10 @@ static long menuTimersOnEnter(void)
         timerSource[i] = OSD_TIMER_SRC(timer);
         timerPrecision[i] = OSD_TIMER_PRECISION(timer);
         timerAlarm[i] = OSD_TIMER_ALARM(timer);
+        if ((int)timerSource[i] >= (int)OSD_TIMER_SRC_COUNT)
+            timerSource[i] = OSD_TIMER_SRC_ON;
+        if ((int)timerPrecision[i] >= (int)OSD_TIMER_PREC_COUNT)
+            timerPrecision[i] = OSD_TIMER_PREC_SECOND;
     }
 
     return 0;

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -205,10 +205,6 @@ static long menuTimersOnEnter(void)
         timerSource[i] = OSD_TIMER_SRC(timer);
         timerPrecision[i] = OSD_TIMER_PRECISION(timer);
         timerAlarm[i] = OSD_TIMER_ALARM(timer);
-        if ((int)timerSource[i] >= (int)OSD_TIMER_SRC_COUNT)
-            timerSource[i] = OSD_TIMER_SRC_ON;
-        if ((int)timerPrecision[i] >= (int)OSD_TIMER_PREC_COUNT)
-            timerPrecision[i] = OSD_TIMER_PREC_SECOND;
     }
 
     return 0;

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -52,6 +52,8 @@
 #include "io/serial.h"
 #include "io/gps.h"
 
+#include "osd/osd.h"
+
 #include "pg/beeper.h"
 #include "pg/beeper_dev.h"
 #include "pg/rx.h"
@@ -465,6 +467,21 @@ static void validateAndFixConfig(void)
 
 #if defined(TARGET_VALIDATECONFIG)
     targetValidateConfiguration();
+#endif
+
+#if defined(USE_OSD)
+    for (int i = 0; i < OSD_TIMER_COUNT; i++) {
+         const uint16_t timer = osdConfig()->timers[i];
+         int src = OSD_TIMER_SRC(timer);
+         int prc = OSD_TIMER_PRECISION(timer);
+         if (src >= OSD_TIMER_SRC_COUNT) {
+             src = 0;
+         }
+         if (prc >= OSD_TIMER_PREC_COUNT) {
+             prc = OSD_TIMER_PREC_COUNT;
+         }
+         osdConfigMutable()->timers[i] = OSD_TIMER(src, prc, OSD_TIMER_ALARM(timer));
+     }
 #endif
 }
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -471,16 +471,11 @@ static void validateAndFixConfig(void)
 
 #if defined(USE_OSD)
     for (int i = 0; i < OSD_TIMER_COUNT; i++) {
-         const uint16_t timer = osdConfig()->timers[i];
-         int src = OSD_TIMER_SRC(timer);
-         int prc = OSD_TIMER_PRECISION(timer);
-         if (src >= OSD_TIMER_SRC_COUNT) {
-             src = 0;
+         const uint16_t t = osdConfig()->timers[i];
+         if (OSD_TIMER_SRC(t) >= OSD_TIMER_SRC_COUNT ||
+                 OSD_TIMER_PRECISION(t) >= OSD_TIMER_PREC_COUNT) {
+             osdConfigMutable()->timers[i] = osdTimerDefault[i];
          }
-         if (prc >= OSD_TIMER_PREC_COUNT) {
-             prc = 0;
-         }
-         osdConfigMutable()->timers[i] = OSD_TIMER(src, prc, OSD_TIMER_ALARM(timer));
      }
 #endif
 }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -465,10 +465,6 @@ static void validateAndFixConfig(void)
     }
 #endif
 
-#if defined(TARGET_VALIDATECONFIG)
-    targetValidateConfiguration();
-#endif
-
 #if defined(USE_OSD)
     for (int i = 0; i < OSD_TIMER_COUNT; i++) {
          const uint16_t t = osdConfig()->timers[i];
@@ -477,6 +473,10 @@ static void validateAndFixConfig(void)
              osdConfigMutable()->timers[i] = osdTimerDefault[i];
          }
      }
+#endif
+
+#if defined(TARGET_VALIDATECONFIG)
+    targetValidateConfiguration();
 #endif
 }
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -478,7 +478,7 @@ static void validateAndFixConfig(void)
              src = 0;
          }
          if (prc >= OSD_TIMER_PREC_COUNT) {
-             prc = OSD_TIMER_PREC_COUNT;
+             prc = 0;
          }
          osdConfigMutable()->timers[i] = OSD_TIMER(src, prc, OSD_TIMER_ALARM(timer));
      }

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -197,6 +197,11 @@ static void osdDrawElements(timeUs_t currentTimeUs)
     osdDrawActiveElements(osdDisplayPort, currentTimeUs);
 }
 
+const uint16_t osdTimerDefault[OSD_TIMER_COUNT] = {
+        OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10),
+        OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10)
+};
+
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 {
     // Position elements near centre of screen and disabled by default
@@ -234,8 +239,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
         osdWarnSetState(i, true);
     }
 
-    osdConfig->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10);
-    osdConfig->timers[OSD_TIMER_2] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10);
+    osdConfig->timers[OSD_TIMER_1] = osdTimerDefault[OSD_TIMER_1];
+    osdConfig->timers[OSD_TIMER_2] = osdTimerDefault[OSD_TIMER_2];
 
     osdConfig->overlay_radio_mode = 2;
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -483,19 +483,13 @@ static void osdShowStats(uint16_t endBatteryVoltage)
     }
 
     if (osdStatGetState(OSD_STAT_TIMER_1)) {
-        int src = OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1]);
-        if (src >= OSD_TIMER_SRC_COUNT)
-            src = 0;
-        osdFormatTimer(buff, false, (src == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_1);
-        osdDisplayStatisticLabel(top++, osdTimerSourceNames[src], buff);
+        osdFormatTimer(buff, false, (OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1]) == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_1);
+        osdDisplayStatisticLabel(top++, osdTimerSourceNames[OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1])], buff);
     }
 
     if (osdStatGetState(OSD_STAT_TIMER_2)) {
-        int src = OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_2]);
-        if (src >= OSD_TIMER_SRC_COUNT)
-            src = 0;
-        osdFormatTimer(buff, false, (src == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_2);
-        osdDisplayStatisticLabel(top++, osdTimerSourceNames[src], buff);
+        osdFormatTimer(buff, false, (OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_2]) == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_2);
+        osdDisplayStatisticLabel(top++, osdTimerSourceNames[OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_2])], buff);
     }
 
     if (osdStatGetState(OSD_STAT_MAX_ALTITUDE)) {

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -483,13 +483,19 @@ static void osdShowStats(uint16_t endBatteryVoltage)
     }
 
     if (osdStatGetState(OSD_STAT_TIMER_1)) {
-        osdFormatTimer(buff, false, (OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1]) == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_1);
-        osdDisplayStatisticLabel(top++, osdTimerSourceNames[OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1])], buff);
+        int src = OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1]);
+        if (src >= OSD_TIMER_SRC_COUNT)
+            src = 0;
+        osdFormatTimer(buff, false, (src == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_1);
+        osdDisplayStatisticLabel(top++, osdTimerSourceNames[src], buff);
     }
 
     if (osdStatGetState(OSD_STAT_TIMER_2)) {
-        osdFormatTimer(buff, false, (OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_2]) == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_2);
-        osdDisplayStatisticLabel(top++, osdTimerSourceNames[OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_2])], buff);
+        int src = OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_2]);
+        if (src >= OSD_TIMER_SRC_COUNT)
+            src = 0;
+        osdFormatTimer(buff, false, (src == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_2);
+        osdDisplayStatisticLabel(top++, osdTimerSourceNames[src], buff);
     }
 
     if (osdStatGetState(OSD_STAT_MAX_ALTITUDE)) {

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -215,6 +215,8 @@ STATIC_ASSERT(OSD_WARNING_COUNT <= 32, osdwarnings_overflow);
 
 #define OSD_GPS_RESCUE_DISABLED_WARNING_DURATION_US 3000000 // 3 seconds
 
+extern const uint16_t osdTimerDefault[OSD_TIMER_COUNT];
+
 typedef struct osdConfig_s {
     uint16_t item_pos[OSD_ITEM_COUNT];
 


### PR DESCRIPTION
OSD timers configuration provided by MSP and CLI just sets 16-bit timer config, not checking if fields are in range.
This patch adds range checking where values are used to index string arrays.