### PR TITLE
OSD: allow up to 12 elements in post flight stats

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -90,6 +90,9 @@
 #include "hardware_revision.h"
 #endif
 
+#define VIDEO_BUFFER_CHARS_PAL    480
+#define IS_DISPLAY_PAL (displayScreenSize(osdDisplayPort) == VIDEO_BUFFER_CHARS_PAL)
+
 const char * const osdTimerSourceNames[] = {
     "ON TIME  ",
     "TOTAL ARM",
@@ -464,11 +467,13 @@ static bool isSomeStatEnabled(void)
 
 static void osdShowStats(uint16_t endBatteryVoltage)
 {
-    uint8_t top = 2;
+    uint8_t top = 1;    /* first fully visible line */
     char buff[OSD_ELEMENT_BUFFER_LENGTH];
 
     displayClearScreen(osdDisplayPort);
-    displayWrite(osdDisplayPort, 2, top++, "  --- STATS ---");
+
+    if (IS_DISPLAY_PAL)
+        displayWrite(osdDisplayPort, 2, top++, "  --- STATS ---");
 
     if (osdStatGetState(OSD_STAT_RTC_DATE_TIME)) {
         bool success = false;

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -185,7 +185,7 @@ void doTestDisarm()
     // then
     // post flight statistics displayed
     if (isSomeStatEnabled()) {
-        displayPortTestBufferSubstring(2, 2, "  --- STATS ---");
+        displayPortTestBufferSubstring(2, 1, "  --- STATS ---");
     }
 }
 
@@ -391,7 +391,7 @@ TEST(OsdTest, TestStatsImperial)
 
     // then
     // statistics screen should display the following
-    int row = 3;
+    int row = IS_DISPLAY_PAL ? 2 : 1;
     displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:05.00");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:03");
@@ -444,7 +444,7 @@ TEST(OsdTest, TestStatsMetric)
 
     // then
     // statistics screen should display the following
-    int row = 3;
+    int row = IS_DISPLAY_PAL ? 2 : 1;
     displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:07.50");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:02");

--- a/src/test/unit/unittest_displayport.h
+++ b/src/test/unit/unittest_displayport.h
@@ -32,6 +32,8 @@ void displayPortTestBufferSubstring(int x, int y, const char * expectedFormat, .
 #define UNITTEST_DISPLAYPORT_COLS 30
 #define UNITTEST_DISPLAYPORT_BUFFER_LEN (UNITTEST_DISPLAYPORT_ROWS * UNITTEST_DISPLAYPORT_COLS)
 
+#define IS_DISPLAY_PAL true
+
 char testDisplayPortBuffer[UNITTEST_DISPLAYPORT_BUFFER_LEN];
 
 static displayPort_t testDisplayPort;
@@ -64,7 +66,7 @@ static int displayPortTestDrawScreen(displayPort_t *displayPort)
 static int displayPortTestScreenSize(const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
-    return 0;
+    return 480 /* VIDEO_BUFFER_CHARS_PAL */;
 }
 
 static int displayPortTestWriteString(displayPort_t *displayPort, uint8_t x, uint8_t y, const char *s)


### PR DESCRIPTION
As we have quite a lot of possible post-flight stats:

- all are moved one line up
- the "--- STATS ---" header is not displayed in NTSC mode

This allows for up to 12 elements visible in NTSC mode:
![Zrzut ekranu 2019-04-14 o 23 26 50](https://user-images.githubusercontent.com/16244785/56153473-874a7080-5fb6-11e9-9718-01cbba150171.png)
