### PR TITLE
Override RSSI_ADC feature when RSSI Channel is selected

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -271,8 +271,9 @@ static void validateAndFixConfig(void)
 #endif // USE_SOFTSPI
 
 #if defined(USE_ADC)
-    if (featureIsEnabled(FEATURE_RSSI_ADC)) {
-        rxConfigMutable()->rssi_channel = 0;
+    if (featureIsEnabled(FEATURE_RSSI_ADC) && rxConfig()->rssi_channel) {
+        featureDisable(FEATURE_RSSI_ADC);
+        rxUpdateRssiSource();
         rxConfigMutable()->rssi_src_frame_errors = false;
     } else
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2345,7 +2345,6 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         if (!featureMaskIsCopied) {
             featureMaskIsCopied = true;
         }
-
         break;
 
 #ifdef USE_BEEPER

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -238,6 +238,18 @@ bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
 }
 #endif
 
+void rxUpdateRssiSource(void)
+{
+#if defined(USE_ADC)
+    if (featureIsEnabled(FEATURE_RSSI_ADC)) {
+        rssiSource = RSSI_SOURCE_ADC;
+    } else
+#endif
+    if (rxConfig()->rssi_channel > 0) {
+        rssiSource = RSSI_SOURCE_RX_CHANNEL;
+    }
+}
+
 void rxInit(void)
 {
     rxRuntimeConfig.rcReadRawFn = nullReadRawRC;
@@ -303,14 +315,7 @@ void rxInit(void)
     }
 #endif
 
-#if defined(USE_ADC)
-    if (featureIsEnabled(FEATURE_RSSI_ADC)) {
-        rssiSource = RSSI_SOURCE_ADC;
-    } else
-#endif
-    if (rxConfig()->rssi_channel > 0) {
-        rssiSource = RSSI_SOURCE_RX_CHANNEL;
-    }
+    rxUpdateRssiSource();
 
     rxChannelCount = MIN(rxConfig()->max_aux_channel + NON_AUX_CHANNEL_COUNT, rxRuntimeConfig.channelCount);
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -167,6 +167,7 @@ void updateRSSI(timeUs_t currentTimeUs);
 uint16_t getRssi(void);
 uint8_t getRssiPercent(void);
 bool isRssiConfigured(void);
+void rxUpdateRssiSource(void);
 
 #define LINK_QUALITY_MAX_VALUE 255
 


### PR DESCRIPTION
Removes feature flag for RSSI_ADC when a RSSI RX Channel is configured.

Fixes: #8028 