### PR TITLE
For Discussion: modify filter defaults to reduce risk of flyaways

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -185,9 +185,9 @@ void resetPidProfile(pidProfile_t *pidProfile)
                                     // overridden and the static lowpass 1 is disabled. We can't set this
                                     // value to 0 otherwise Configurator versions 10.4 and earlier will also
                                     // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
-        .dterm_lowpass2_hz = 150,   // second Dterm LPF ON by default
+        .dterm_lowpass2_hz = 100,   // second Dterm LPF ON by default
         .dterm_filter_type = FILTER_BIQUAD,
-        .dterm_filter2_type = FILTER_BIQUAD,
+        .dterm_filter2_type = FILTER_PT1,
         .dyn_lpf_dterm_min_hz = 150,
         .dyn_lpf_dterm_max_hz = 250,
         .launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -208,8 +208,8 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
                                         // overridden and the static lowpass 1 is disabled. We can't set this
                                         // value to 0 otherwise Configurator versions 10.4 and earlier will also
                                         // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
-    gyroConfig->gyro_lowpass2_type = FILTER_BIQUAD;
-    gyroConfig->gyro_lowpass2_hz = 0;
+    gyroConfig->gyro_lowpass2_type = FILTER_PT1;
+    gyroConfig->gyro_lowpass2_hz = 150;
     gyroConfig->gyro_high_fsr = false;
     gyroConfig->gyro_to_use = GYRO_CONFIG_USE_GYRO_DEFAULT;
     gyroConfig->gyro_soft_notch_hz_1 = 0;


### PR DESCRIPTION
Some users have reported flyaways on arming/throttling up with betaflight 4.0, in quads that fly alright on 3.5.

This PR changes the default filtering so that D transmission more closely approximates that of 3.5.

With these defaults, quads that fly OK on 3.5 should not take-off vertically due to uncontrolled D oscillation.

The downside is a bit more filter delay in 4.0 than previously.

The only changes are:

- enable a PT1 at 150hz on gyro lowpass2
- change the D lowpass2 from biquad at 150hz to PT1 at 100hz

This code snippet can be applied over 4.0 defaults for testing purposes:

```
set gyro_lowpass2_type = PT1
set gyro_lowpass2_hz = 150
set dterm_lowpass2_type = PT1
set dterm_lowpass2_hz = 100
```

PS: If the quad flies well like this, these changes could be reversed in the following sequence:

- gyro lowpass 2 value could be shifted up to 300; iif still OK
- gyro lowpass 2 removed entirely; if still OK
- D lowpass 2 could be moved up to 150hz and left as a PT1

