### PR TITLE
prevent max7456 screen_buffer from overflow

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -571,14 +571,16 @@ uint8_t* max7456GetScreenBuffer(void)
 
 void max7456WriteChar(uint8_t x, uint8_t y, uint8_t c)
 {
-    screenBuffer[y*CHARS_PER_LINE+x] = c;
+    if (x < CHARS_PER_LINE && y < VIDEO_LINES_PAL) {
+        screenBuffer[y * CHARS_PER_LINE + x] = c;
+    }
 }
 
 void max7456Write(uint8_t x, uint8_t y, const char *buff)
 {
-    for (int i = 0; *(buff+i); i++) {
-        if (x+i < CHARS_PER_LINE) {// Do not write over screen
-            screenBuffer[y*CHARS_PER_LINE+x+i] = *(buff+i);
+    if (y < VIDEO_LINES_PAL) {
+        for (int i = 0; buff[i] && x + i < CHARS_PER_LINE; i++) {
+            screenBuffer[y * CHARS_PER_LINE + x + i] = buff[i];
         }
     }
 }


### PR DESCRIPTION
Hi, this should fix #8053 

Since it is preventing an overflow of a buffer, I figure it should be closest to where the buffer is written to. 

However my particular drone is short an item or two to properly test...
![image](https://user-images.githubusercontent.com/190571/56476013-7df15600-6445-11e9-8c4a-df0810069bfc.png)


