### PR TITLE
show power level in the smartaudio cms menu

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -179,7 +179,7 @@ if (saDevice.version == 2) {
         saCmsStatusString[13] = 0;
     } else {
         int index = (saDevice.version == 2) ? saDevice.power : saDacToPowerIndex(saDevice.power);
-        tfp_sprintf(&saCmsStatusString[10], "%3d", vtxCommonLookupPowerName(vtxCommonDevice(), index + 1));
+        tfp_sprintf(&saCmsStatusString[10], "%s", vtxCommonLookupPowerName(vtxCommonDevice(), index + 1));
     }
 }
 


### PR DESCRIPTION
Just a quick fix so that I see `F F1 5740 25` instead of `F F1 5740 1231231123`

Printing the string should be okay, the possible values are all 3 characters long, and we've got room to spare in `saCmsStatusString`

https://github.com/betaflight/betaflight/blob/94ddf5aceb1b7f67a418bfbc254fa000646c7472/src/main/io/vtx_smartaudio.c#L69-L71