### PR TITLE
Reduce feature cut for BFF3

### DIFF
--- a/src/main/target/BETAFLIGHTF3/target.mk
+++ b/src/main/target/BETAFLIGHTF3/target.mk
@@ -2,7 +2,7 @@ F3_TARGETS   += $(TARGET)
 
 FEATURES     = VCP SDCARD_SPI
 
-FEATURE_CUT_LEVEL = 10
+FEATURE_CUT_LEVEL = 7
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \


### PR DESCRIPTION
Reducing the feature cut for BFF3 from 10 to 7 will bring some newer and older useful features back to the BFF3 board without overflowing flash space. As the F3 boards are now seen as unsupported, this change can be made as a maintenance patch at the final supported level.

Notable features:
USE_SERIAL_4WAY_BLHELI_BOOTLOADER, USE_GYRO_LPF2, USE_DYN_LPF, USE_D_MIN

```
Linking BETAFLIGHTF3
Memory region         Used Size  Region Size  %age Used
           FLASH:      257640 B       252 KB     99.84%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       34788 B        40 KB     84.93%
             CCM:          2 KB         8 KB     25.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text    data     bss     dec     hex filename
 253920    3720   33116  290756   46fc4 ./obj/main/betaflight_BETAFLIGHTF3.elf
```