### PR TITLE
[BARO] Add debug mode BARO

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -87,4 +87,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "AC_ERROR",
     "DUAL_GYRO_SCALED",
     "DSHOT_RPM_ERRORS",
+    "BARO",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -103,6 +103,7 @@ typedef enum {
     DEBUG_AC_ERROR,
     DEBUG_DUAL_GYRO_SCALED,
     DEBUG_DSHOT_RPM_ERRORS,
+    DEBUG_BARO,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -24,6 +24,8 @@
 
 #include "platform.h"
 
+#include "build/debug.h"
+
 #include "common/maths.h"
 
 #include "pg/pg.h"
@@ -324,6 +326,10 @@ uint32_t baroUpdate(void)
 {
     static barometerState_e state = BAROMETER_NEEDS_SAMPLES;
 
+    if (debugMode == DEBUG_BARO) {
+        debug[0] = state;
+    }
+
     switch (state) {
         default:
         case BAROMETER_NEEDS_SAMPLES:
@@ -340,6 +346,13 @@ uint32_t baroUpdate(void)
             baro.baroPressure = baroPressure;
             baro.baroTemperature = baroTemperature;
             baroPressureSum = recalculateBarometerTotal(barometerConfig()->baro_sample_count, baroPressureSum, baroPressure);
+
+            if (debugMode == DEBUG_BARO) {
+                debug[1] = baroTemperature;
+                debug[2] = baroPressure;
+                debug[3] = baroPressureSum;
+            }
+
             state = BAROMETER_NEEDS_SAMPLES;
             return baro.dev.ut_delay;
         break;


### PR DESCRIPTION
A commit originally done by @hydra.

Add BARO to debug mode, in coordination with several fixes to BMP085 and BMP280 drivers, and introduction of new BMP388 driver.