### PR TITLE
[BARO] BMP280 - Move t_fine out of the calibration data

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -52,8 +52,9 @@ typedef struct bmp280_calib_param_s {
     int16_t dig_P7; /* calibration P7 data */
     int16_t dig_P8; /* calibration P8 data */
     int16_t dig_P9; /* calibration P9 data */
-    int32_t t_fine; /* calibration t_fine data */
-} bmp280_calib_param_t;
+} __attribute__((packed)) bmp280_calib_param_t; // packed as we read directly from the device into this structure.
+
+STATIC_UNIT_TESTED int32_t t_fine; /* calibration t_fine data */
 
 static uint8_t bmp280_chip_id = 0;
 STATIC_UNIT_TESTED bmp280_calib_param_t bmp280_cal;
@@ -125,7 +126,9 @@ bool bmp280Detect(baroDev_t *baro)
     }
 
     // read calibration
-    busReadRegisterBuffer(busdev, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, (uint8_t *)&bmp280_cal, 24);
+    STATIC_ASSERT(sizeof(bmp280_calib_param_t) == BMP280_PRESSURE_TEMPERATURE_CALIB_DATA_LENGTH, bmp280_calibration_structure_incorrectly_packed);
+
+    busReadRegisterBuffer(busdev, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, (uint8_t *)&bmp280_cal, sizeof(bmp280_calib_param_t));
 
     // set oversampling + power mode (forced), and start sampling
     busWriteRegister(busdev, BMP280_CTRL_MEAS_REG, BMP280_MODE);
@@ -180,8 +183,8 @@ static int32_t bmp280_compensate_T(int32_t adc_T)
 
     var1 = ((((adc_T >> 3) - ((int32_t)bmp280_cal.dig_T1 << 1))) * ((int32_t)bmp280_cal.dig_T2)) >> 11;
     var2  = (((((adc_T >> 4) - ((int32_t)bmp280_cal.dig_T1)) * ((adc_T >> 4) - ((int32_t)bmp280_cal.dig_T1))) >> 12) * ((int32_t)bmp280_cal.dig_T3)) >> 14;
-    bmp280_cal.t_fine = var1 + var2;
-    T = (bmp280_cal.t_fine * 5 + 128) >> 8;
+    t_fine = var1 + var2;
+    T = (t_fine * 5 + 128) >> 8;
 
     return T;
 }
@@ -191,7 +194,7 @@ static int32_t bmp280_compensate_T(int32_t adc_T)
 static uint32_t bmp280_compensate_P(int32_t adc_P)
 {
     int64_t var1, var2, p;
-    var1 = ((int64_t)bmp280_cal.t_fine) - 128000;
+    var1 = ((int64_t)t_fine) - 128000;
     var2 = var1 * var1 * (int64_t)bmp280_cal.dig_P6;
     var2 = var2 + ((var1*(int64_t)bmp280_cal.dig_P5) << 17);
     var2 = var2 + (((int64_t)bmp280_cal.dig_P4) << 35);

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -27,6 +27,7 @@ void bmp280_calculate(int32_t *pressure, int32_t *temperature);
 
 extern uint32_t bmp280_up;
 extern uint32_t bmp280_ut;
+extern int32_t t_fine; /* calibration t_fine data */
 
 typedef struct bmp280_calib_param_s {
     uint16_t dig_T1; /* calibration T1 data */
@@ -41,8 +42,7 @@ typedef struct bmp280_calib_param_s {
     int16_t dig_P7; /* calibration P7 data */
     int16_t dig_P8; /* calibration P8 data */
     int16_t dig_P9; /* calibration P9 data */
-    int32_t t_fine; /* calibration t_fine data */
-} bmp280_calib_param_t;
+} __attribute__((packed)) bmp280_calib_param_t; // packed as we read directly from the device into this structure.
 
 bmp280_calib_param_t bmp280_cal;
 }
@@ -58,6 +58,7 @@ TEST(baroBmp280Test, TestBmp280Calculate)
     int32_t pressure, temperature;
     bmp280_up = 415148; // Digital pressure value
     bmp280_ut = 519888; // Digital temperature value
+    t_fine = 0;
 
     // and
     bmp280_cal.dig_T1 = 27504;
@@ -87,6 +88,7 @@ TEST(baroBmp280Test, TestBmp280CalculateHighP)
     int32_t pressure, temperature;
     bmp280_up = 215148; // Digital pressure value
     bmp280_ut = 519888; // Digital temperature value
+    t_fine = 0;
 
     // and
     bmp280_cal.dig_T1 = 27504;
@@ -116,6 +118,7 @@ TEST(baroBmp280Test, TestBmp280CalculateZeroP)
     int32_t pressure, temperature;
     bmp280_up = 415148; // Digital pressure value
     bmp280_ut = 519888; // Digital temperature value
+    t_fine = 0;
 
     // and
     bmp280_cal.dig_T1 = 27504;


### PR DESCRIPTION
Move t_fine out of the calibration data, since their usage is mixed.

A commit by @hydra.
