### PR TITLE
CMS Debug Mode fix

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1369,7 +1369,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE("motor_pwm_protocol", "%d",              motorConfig()->dev.motorPwmProtocol);
         BLACKBOX_PRINT_HEADER_LINE("motor_pwm_rate", "%d",                  motorConfig()->dev.motorPwmRate);
         BLACKBOX_PRINT_HEADER_LINE("dshot_idle_value", "%d",                motorConfig()->digitalIdleOffsetValue);
-        BLACKBOX_PRINT_HEADER_LINE("debug_mode", "%d",                      systemConfig()->debug_mode);
+        BLACKBOX_PRINT_HEADER_LINE("debug_mode", "%d",                      debugMode);
         BLACKBOX_PRINT_HEADER_LINE("features", "%d",                        featureConfig()->enabledFeatures);
 
 #ifdef USE_RC_SMOOTHING_FILTER


### PR DESCRIPTION
When editing the `debug_mode` through OSD/CMS the change is reflected in `systemConfigMutable()` but not in the `debugMode` global.

`debugMode` is only set on system boot in `init()`.

The `DEBUG_SET` macro checks against `debugMode`. Blackbox code reads `systemConfig()`. The result is that if we change the debug mode from OSD/CMS _without save and reboot_, blackbox will place in the header the _new_ mode, but the actual logging will be with with the _old_ mode.