### PR TITLE
Fixed assignment of random timer for pins without configured timer option.

### DIFF
--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -81,7 +81,11 @@ const timerHardware_t *timerGetByTag(ioTag_t ioTag)
 {
     uint8_t timerIndex = timerIndexByTag(ioTag);
 
-    return timerGetByTagAndIndex(ioTag, timerIndex);
+    if (timerIndex) {
+        return timerGetByTagAndIndex(ioTag, timerIndex);
+    } else {
+        return NULL;
+    }
 }
 
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index)


### PR DESCRIPTION
Fixes #8066, #8071.