### PR TITLE
Call initEscEndPoints after changing profiles.

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -48,6 +48,7 @@
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
+#include "flight/mixer.h"
 #include "flight/pid.h"
 
 #include "pg/pg.h"
@@ -385,6 +386,7 @@ static long cmsx_profileOtherOnExit(const OSD_Entry *self)
     }
 #endif
 
+    initEscEndpoints();
     return 0;
 }
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -715,6 +715,7 @@ void changePidProfile(uint8_t pidProfileIndex)
         loadPidProfile();
 
         pidInit(currentPidProfile);
+        initEscEndpoints();
     }
 
     beeperConfirmationBeeps(pidProfileIndex + 1);

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -115,6 +115,7 @@ float getMotorMixRange(void);
 bool areMotorsRunning(void);
 
 void mixerLoadMix(int index, motorMixer_t *customMixers);
+void initEscEndpoints(void);
 void mixerInit(mixerMode_e mixerMode);
 
 void mixerConfigureOutput(void);


### PR DESCRIPTION
This PR fixes an issue with motor_output_limit not being applied after changing profiles.  Requiring the quad to be power cycled with the selected profile for the correct motor limit to be active.