### PR TITLE
Moved up serialWrite(0) line

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -463,12 +463,12 @@ static void saSendFrame(uint8_t *buf, int len)
             serialWrite(smartAudioSerialPort, buf[i]);
         }
 
+        serialWrite(smartAudioSerialPort, 0x00);
+
         saStat.pktsent++;
     } else {
         sa_outstanding = SA_CMD_NONE;
     }
-
-    serialWrite(smartAudioSerialPort, 0x00);
 
     sa_lastTransmissionMs = millis();
 }


### PR DESCRIPTION
Moved up "serialWrite(smartAudioSerialPort, 0x00)" fix line in 'saSendFrame()' in "io/vtx_smartaudio.c" for the 'akk_vtx_fix' branch, as per https://github.com/betaflight/betaflight/issues/8030#issuecomment-487313211

--ET