### PR TITLE
Report NONE for baro and mag MSP requests if not USE_ed.

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1504,12 +1504,12 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
 #ifdef USE_BARO
         sbufWriteU8(dst, barometerConfig()->baro_hardware);
 #else
-        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, BARO_NONE);
 #endif
 #ifdef USE_MAG
         sbufWriteU8(dst, compassConfig()->mag_hardware);
 #else
-        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, MAG_NONE);
 #endif
         break;
 


### PR DESCRIPTION
It was erroneously introduced by #8121.

Responding with zero (BARO_DEFAULT and MAG_DEFAULT) will cause configurator to display these sensors enabled, and since write (set) side is ignored, they can never be displayed as disabled.
