### PR TITLE
Add SPI RX to STM32F7xx unified targets

### DIFF
--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -407,7 +407,9 @@ void nextChannel(uint8_t skip)
 bool frSkySpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     rxSpiCommonIOInit(rxSpiConfig);
-    cc2500SpiInit();
+    if (!cc2500SpiInit()) {
+        return false;
+    }
 
     spiProtocol = rxSpiConfig->rx_spi_protocol;
 

--- a/src/main/target/STM32F745/target.mk
+++ b/src/main/target/STM32F745/target.mk
@@ -5,4 +5,14 @@ TARGET_SRC = \
 	$(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
 	$(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
 	$(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
-	drivers/max7456.c
+	drivers/max7456.c \
+	rx/cc2500_common.c \
+	rx/cc2500_frsky_shared.c \
+	rx/cc2500_frsky_d.c \
+	rx/cc2500_frsky_x.c \
+	rx/cc2500_sfhss.c \
+	rx/a7105_flysky.c \
+	rx/cyrf6936_spektrum.c \
+	drivers/rx/rx_cc2500.c \
+	drivers/rx/rx_a7105.c \
+	drivers/rx/rx_cyrf6936.c

--- a/src/main/target/STM32F7X2/target.mk
+++ b/src/main/target/STM32F7X2/target.mk
@@ -5,4 +5,14 @@ TARGET_SRC = \
 	$(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
 	$(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
 	$(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
-	drivers/max7456.c
+	drivers/max7456.c \
+	rx/cc2500_common.c \
+	rx/cc2500_frsky_shared.c \
+	rx/cc2500_frsky_d.c \
+	rx/cc2500_frsky_x.c \
+	rx/cc2500_sfhss.c \
+	rx/a7105_flysky.c \
+	rx/cyrf6936_spektrum.c \
+	drivers/rx/rx_cc2500.c \
+	drivers/rx/rx_a7105.c \
+	drivers/rx/rx_cyrf6936.c

--- a/src/main/target/common_unified.h
+++ b/src/main/target/common_unified.h
@@ -99,9 +99,6 @@
 
 #define USE_ADC
 
-#if defined(STM32F4)
-//We currently only have stdperiph drivers for this
-
 #define USE_RX_SPI
 
 #define USE_RX_FRSKY_SPI_D
@@ -113,4 +110,3 @@
 
 #define USE_RX_FLYSKY
 #define USE_RX_FLYSKY_SPI_LED
-#endif


### PR DESCRIPTION
Add SPI RX to STM32F7xx unified targets
Avoid crash if CC2500 is not present on unified targets

This is successfully tested on AlienflightNG F7 development target with the CC2500 module from link below.

https://www.aliexpress.com/item/CC2500-PA-LNA-2-4G-high-power-long-distance-dual-antenna-wireless-communication-transceiver-module-serial/32945151938.html

This is the config i have used during testing:

```
# SPI RX
resource RX_SPI_CS 1 A15
resource RX_SPI_EXTI 1 B15             # GDO0
resource RX_SPI_BIND 1 B02
resource RX_SPI_LED 1 B09
resource RX_SPI_CC2500_TX_EN 1 B06     # CTX
resource RX_SPI_CC2500_LNA_EN 1 B07    # CPS
resource RX_SPI_CC2500_ANT_SEL 1 B08   # SEL
set rx_spi_bus = 3
```

CSD of the RX module is connected to VDD (3.3V). The SPI bus is connected as usual.