### PR TITLE
Dshot bidir inverted

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -673,8 +673,11 @@ FAST_CODE uint16_t prepareDshotPacket(motorDmaOutput_t *const motor)
         csum ^=  csum_data;   // xor data by nibbles
         csum_data >>= 4;
     }
-    csum &= 0xf;
     // append checksum
+    if (useDshotTelemetry) {
+        csum = ~csum;
+    }
+    csum &= 0xf;
     packet = (packet << 4) | csum;
 
     return packet;

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -269,14 +269,12 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     const bool configureTimer = (timerIndex == dmaMotorTimerCount-1);
 
     uint8_t pupMode = 0;
+    pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP;
 #ifdef USE_DSHOT_TELEMETRY
-    if (!useDshotTelemetry) {
-        pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP;
-    } else
-#endif
-    {
-        pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PuPd_UP : GPIO_PuPd_DOWN;
+    if (useDshotTelemetry) {
+        output ^= TIMER_OUTPUT_INVERTED;
     }
+#endif
 
     IOConfigGPIOAF(motorIO, IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_PP, pupMode), timerHardware->alternateFunction);
 

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -393,6 +393,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         ( 2 + (motor->useProshot ? 4 * MOTOR_NIBBLE_LENGTH_PROSHOT : 16 * MOTOR_BITLENGTH))
         / getDshotHz(pwmProtocolType);
     pwmDshotSetDirectionOutput(motor, true);
+    if (useDshotTelemetry) {
+        // avoid high line during startup to prevent bootloader activation
+        *timerChCCR(timerHardware) = 0xffff;
+    }
 #else
     pwmDshotSetDirectionOutput(motor, true, &OCINIT, &DMAINIT);
 #endif

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -354,6 +354,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         ( 2 + (motor->useProshot ? 4 * MOTOR_NIBBLE_LENGTH_PROSHOT : 16 * MOTOR_BITLENGTH))
         / getDshotHz(pwmProtocolType);
     pwmDshotSetDirectionOutput(motor, true);
+    if (useDshotTelemetry) {
+        // avoid high line during startup to prevent bootloader activation
+        *timerChCCR(timerHardware) = 0xffff;
+    }
 #else
     pwmDshotSetDirectionOutput(motor, true, &OCINIT, &DMAINIT);
 #endif

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -241,16 +241,12 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     const uint8_t timerIndex = getTimerIndex(timer);
     const bool configureTimer = (timerIndex == dmaMotorTimerCount - 1);
 
-    uint8_t pupMode = 0;
+    uint8_t pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PULLDOWN : GPIO_PULLUP;
 #ifdef USE_DSHOT_TELEMETRY
-    if (!useDshotTelemetry) {
-        pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PULLDOWN : GPIO_PULLUP;
-    } else
-#endif
-    {
-        pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PULLUP : GPIO_PULLDOWN;
+    if (useDshotTelemetry) {
+        output ^= TIMER_OUTPUT_INVERTED;
     }
-
+#endif
 
     IOConfigGPIOAF(motorIO, IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, pupMode), timerHardware->alternateFunction);
 

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -150,7 +150,7 @@ static uint16_t decodeDshotPacket(uint32_t buffer[])
     csum = csum ^ (csum >> 8); // xor bytes
     csum = csum ^ (csum >> 4); // xor nibbles
 
-    if ((csum & 0xf) != 0) {
+    if ((csum & 0xf) != 0xf) {
         return 0xffff;
     }
     return value >> 4;
@@ -176,7 +176,7 @@ static uint16_t decodeProshotPacket(uint32_t buffer[])
     csum = csum ^ (csum >> 8); // xor bytes
     csum = csum ^ (csum >> 4); // xor nibbles
 
-    if ((csum & 0xf) != 0) {
+    if ((csum & 0xf) != 0xf) {
         return 0xffff;
     }
     return value >> 4;

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -150,7 +150,7 @@ static uint16_t decodeDshotPacket(uint32_t buffer[])
     csum = csum ^ (csum >> 8); // xor bytes
     csum = csum ^ (csum >> 4); // xor nibbles
 
-    if (csum & 0xf) {
+    if ((csum & 0xf) != 0) {
         return 0xffff;
     }
     return value >> 4;
@@ -176,7 +176,7 @@ static uint16_t decodeProshotPacket(uint32_t buffer[])
     csum = csum ^ (csum >> 8); // xor bytes
     csum = csum ^ (csum >> 4); // xor nibbles
 
-    if (csum & 0xf) {
+    if ((csum & 0xf) != 0) {
         return 0xffff;
     }
     return value >> 4;

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -414,14 +414,6 @@ void tryArm(void)
             return;
         }
 
-#ifdef USE_DSHOT_TELEMETRY
-        if (isMotorProtocolDshot()) {
-            pwmWriteDshotCommand(
-                255, getMotorCount(), motorConfig()->dev.useDshotTelemetry ?
-                DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY : DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE, false);
-        }
-#endif
-
         if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
             if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
                 flipOverAfterCrashActive = false;

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -209,20 +209,6 @@ static IO_t busSwitchResetPin        = IO_NONE;
 }
 #endif
 
-#ifdef USE_DSHOT_TELEMETRY
-void activateDshotTelemetry(struct dispatchEntry_s* self)
-{
-    if (!ARMING_FLAG(ARMED) && !isDshotTelemetryActive()) {
-        pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY, false);
-        dispatchAdd(self, 1e6); // check again in 1 second
-    }
-}
-
-dispatchEntry_t activateDshotTelemetryEntry =
-{
-    activateDshotTelemetry, 0, NULL, false
-};
-#endif
 
 void init(void)
 {
@@ -793,13 +779,6 @@ void init(void)
     pwmEnableMotors();
 
     setArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
-
-#ifdef USE_DSHOT_TELEMETRY
-    if (motorConfig()->dev.useDshotTelemetry) {
-        dispatchEnable();
-        dispatchAdd(&activateDshotTelemetryEntry, 5000000);
-    }
-#endif
 
     fcTasksInit();
 


### PR DESCRIPTION
This change modifies dshot bidir to use an inverted dshot signal with inverted checksum. The benefit is that the FC doesn't have to enable bidir on the esc via dshot command which makes the feature much more robust. This will be a more effective way to avoid motor spin-ups than the workarounds currently used in blheli32 and will allow turtle mode to work again since the motor startup delay in blheli32 will be eliminated.  