### PR TITLE
[LED_STRIP] Protect against null timerHardware

### DIFF
--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -58,6 +58,11 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     }
 
     const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+
+    if (timerHardware == NULL) {
+        return false;
+    }
+
     TIM_TypeDef *timer = timerHardware->tim;
     timerChannel = timerHardware->channel;
 

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -86,6 +86,11 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     DMA_InitTypeDef DMA_InitStructure;
 
     const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+
+    if (timerHardware == NULL) {
+        return false;
+    }
+
     timer = timerHardware->tim;
 
 #if defined(USE_DMA_SPEC)


### PR DESCRIPTION
Found during `timerGetByTag` debugging.