### PR TITLE
Reset d_min to 0 if >= D gain for a given axis

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -214,6 +214,13 @@ static void validateAndFixConfig(void)
         if (pidProfilesMutable(i)->auto_profile_cell_count > MAX_AUTO_DETECT_CELL_COUNT || pidProfilesMutable(i)->auto_profile_cell_count < AUTO_PROFILE_CELL_COUNT_CHANGE) {
             pidProfilesMutable(i)->auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY;
         }
+
+        // If the d_min value for any axis is >= the D gain then reset d_min to 0 for consistent Configurator behavior
+        for (unsigned axis = 0; axis <= FD_YAW; axis++) {
+            if (pidProfilesMutable(i)->d_min[axis] >= pidProfilesMutable(i)->pid[axis].D) {
+                pidProfilesMutable(i)->d_min[axis] = 0;
+            }
+        }
     }
 
     if (motorConfig()->dev.motorPwmProtocol == PWM_TYPE_BRUSHED) {


### PR DESCRIPTION
Eliminates the dual-mode disabled logic for d_min for consistency. Previously d_min would logically be disabled if set to 0, or if >= the related D gain. This produces an inconsistent behavior with the Configurator in that it applies validation and will reset d_min to 0 in this case - causing an unexpected settings change just by saving on the PID Tuning tab.

This change aligns the validation in the firmware and Configurator.
