### PR TITLE
Change scheduler_optimze_rate to only affect realtime tasks

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -257,7 +257,11 @@ void schedulerOptimizeRate(bool optimizeRate)
 
 inline static timeUs_t getPeriodCalculationBasis(const cfTask_t* task)
 {
-    return *(timeUs_t*)((uint8_t*)task + periodCalculationBasisOffset);
+    if (task->staticPriority == TASK_PRIORITY_REALTIME) {
+        return *(timeUs_t*)((uint8_t*)task + periodCalculationBasisOffset);
+    } else {
+        return task->lastExecutedAt;
+    }
 }
 
 FAST_CODE void scheduler(void)


### PR DESCRIPTION
Reduces CPU load by not rate optimizing non timing-critical tasks.

Makes RPM filter more viable on slower MCUs without overclocking. Also opens more opportunities to run 8KHz gyro sampling with RPM filtering.