### PR TITLE
[H7] RCC and IO

### DIFF
--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -80,6 +80,18 @@ const struct ioPortDef_s ioPortDefs[] = {
     { RCC_AHB1(GPIOE) },
     { RCC_AHB1(GPIOF) },
 };
+#elif defined(STM32H7)
+const struct ioPortDef_s ioPortDefs[] = {
+    { RCC_AHB4(GPIOA) },
+    { RCC_AHB4(GPIOB) },
+    { RCC_AHB4(GPIOC) },
+    { RCC_AHB4(GPIOD) },
+    { RCC_AHB4(GPIOE) },
+    { RCC_AHB4(GPIOF) },
+    { RCC_AHB4(GPIOG) },
+    { RCC_AHB4(GPIOH) },
+    { RCC_AHB4(GPIOI) },
+};
 #endif
 
 ioRec_t* IO_Rec(IO_t io)
@@ -151,6 +163,8 @@ uint32_t IO_EXTI_Line(IO_t io)
     return 1 << IO_GPIOPinIdx(io);
 #elif defined(STM32F7)
     return 1 << IO_GPIOPinIdx(io);
+#elif defined(STM32H7)
+    return 1 << IO_GPIOPinIdx(io);
 #elif defined(SIMULATOR_BUILD)
     return 0;
 #else
@@ -163,8 +177,10 @@ bool IORead(IO_t io)
     if (!io) {
         return false;
     }
-#if defined(USE_HAL_DRIVER)
+#if defined(USE_FULL_LL_DRIVER)
     return (LL_GPIO_ReadInputPort(IO_GPIO(io)) & IO_Pin(io));
+#elif defined(USE_HAL_DRIVER)
+    return !! HAL_GPIO_ReadPin(IO_GPIO(io), IO_Pin(io));
 #else
     return (IO_GPIO(io)->IDR & IO_Pin(io));
 #endif
@@ -175,13 +191,18 @@ void IOWrite(IO_t io, bool hi)
     if (!io) {
         return;
     }
-#if defined(USE_HAL_DRIVER)
+#if defined(USE_FULL_LL_DRIVER)
     LL_GPIO_SetOutputPin(IO_GPIO(io), IO_Pin(io) << (hi ? 0 : 16));
+#elif defined(USE_HAL_DRIVER)
+    if (hi) {
+        HAL_GPIO_WritePin(IO_GPIO(io), IO_Pin(io), GPIO_PIN_SET);
+    } else {
+        HAL_GPIO_WritePin(IO_GPIO(io), IO_Pin(io), GPIO_PIN_RESET);
+    }
 #elif defined(STM32F4)
     if (hi) {
         IO_GPIO(io)->BSRRL = IO_Pin(io);
-    }
-    else {
+    } else {
         IO_GPIO(io)->BSRRH = IO_Pin(io);
     }
 #else
@@ -194,8 +215,10 @@ void IOHi(IO_t io)
     if (!io) {
         return;
     }
-#if defined(USE_HAL_DRIVER)
+#if defined(USE_FULL_LL_DRIVER)
     LL_GPIO_SetOutputPin(IO_GPIO(io), IO_Pin(io));
+#elif defined(USE_HAL_DRIVER)
+    HAL_GPIO_WritePin(IO_GPIO(io), IO_Pin(io), GPIO_PIN_SET);
 #elif defined(STM32F4)
     IO_GPIO(io)->BSRRL = IO_Pin(io);
 #else
@@ -208,8 +231,10 @@ void IOLo(IO_t io)
     if (!io) {
         return;
     }
-#if defined(USE_HAL_DRIVER)
+#if defined(USE_FULL_LL_DRIVER)
     LL_GPIO_ResetOutputPin(IO_GPIO(io), IO_Pin(io));
+#elif defined(USE_HAL_DRIVER)
+    HAL_GPIO_WritePin(IO_GPIO(io), IO_Pin(io), GPIO_PIN_RESET);
 #elif defined(STM32F4)
     IO_GPIO(io)->BSRRH = IO_Pin(io);
 #else
@@ -227,11 +252,14 @@ void IOToggle(IO_t io)
     // Read pin state from ODR but write to BSRR because it only changes the pins
     // high in the mask value rather than all pins. XORing ODR directly risks
     // setting other pins incorrectly because it change all pins' state.
-#if defined(USE_HAL_DRIVER)
+#if defined(USE_FULL_LL_DRIVER)
     if (LL_GPIO_ReadOutputPort(IO_GPIO(io)) & mask) {
         mask <<= 16;   // bit is set, shift mask to reset half
     }
     LL_GPIO_SetOutputPin(IO_GPIO(io), mask);
+#elif defined(USE_HAL_DRIVER)
+    UNUSED(mask);
+    HAL_GPIO_TogglePin(IO_GPIO(io), IO_Pin(io));
 #elif defined(STM32F4)
     if (IO_GPIO(io)->ODR & mask) {
         IO_GPIO(io)->BSRRH = mask;
@@ -303,6 +331,47 @@ void IOConfigGPIO(IO_t io, ioConfig_t cfg)
         .GPIO_Mode = cfg & 0x7c,
     };
     GPIO_Init(IO_GPIO(io), &init);
+}
+
+#elif defined(STM32H7)
+
+void IOConfigGPIO(IO_t io, ioConfig_t cfg)
+{
+    if (!io) {
+        return;
+    }
+
+    rccPeriphTag_t rcc = ioPortDefs[IO_GPIOPortIdx(io)].rcc;
+    RCC_ClockCmd(rcc, ENABLE);
+
+    GPIO_InitTypeDef init = {
+        .Pin = IO_Pin(io),
+        .Mode = (cfg >> 0) & 0x13,
+        .Speed = (cfg >> 2) & 0x03,
+        .Pull = (cfg >> 5) & 0x03,
+    };
+
+    HAL_GPIO_Init(IO_GPIO(io), &init);
+}
+
+void IOConfigGPIOAF(IO_t io, ioConfig_t cfg, uint8_t af)
+{
+    if (!io) {
+        return;
+    }
+
+    rccPeriphTag_t rcc = ioPortDefs[IO_GPIOPortIdx(io)].rcc;
+    RCC_ClockCmd(rcc, ENABLE);
+
+    GPIO_InitTypeDef init = {
+        .Pin = IO_Pin(io),
+        .Mode = (cfg >> 0) & 0x13,
+        .Speed = (cfg >> 2) & 0x03,
+        .Pull = (cfg >> 5) & 0x03,
+        .Alternate = af
+    };
+
+    HAL_GPIO_Init(IO_GPIO(io), &init);
 }
 
 #elif defined(STM32F7)

--- a/src/main/drivers/io.h
+++ b/src/main/drivers/io.h
@@ -49,6 +49,24 @@
 #define IOCFG_IPU            IO_CONFIG(GPIO_Mode_IPU,         GPIO_Speed_2MHz)
 #define IOCFG_IN_FLOATING    IO_CONFIG(GPIO_Mode_IN_FLOATING, GPIO_Speed_2MHz)
 
+#elif defined(STM32H7)
+// Copied from F7. Need Review
+//speed is packed inside modebits 5 and 2,
+#define IO_CONFIG(mode, speed, pupd) ((mode) | ((speed) << 2) | ((pupd) << 5))
+
+#define IOCFG_OUT_PP         IO_CONFIG(GPIO_MODE_OUTPUT_PP, GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
+#define IOCFG_OUT_PP_UP      IO_CONFIG(GPIO_MODE_OUTPUT_PP, GPIO_SPEED_FREQ_LOW,  GPIO_PULLUP)
+#define IOCFG_OUT_PP_25      IO_CONFIG(GPIO_MODE_OUTPUT_PP, GPIO_SPEED_FREQ_HIGH, GPIO_NOPULL)
+#define IOCFG_OUT_OD         IO_CONFIG(GPIO_MODE_OUTPUT_OD, GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
+#define IOCFG_AF_PP          IO_CONFIG(GPIO_MODE_AF_PP,     GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
+#define IOCFG_AF_PP_PD       IO_CONFIG(GPIO_MODE_AF_PP,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLDOWN)
+#define IOCFG_AF_PP_UP       IO_CONFIG(GPIO_MODE_AF_PP,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLUP)
+#define IOCFG_AF_OD          IO_CONFIG(GPIO_MODE_AF_OD,     GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
+#define IOCFG_IPD            IO_CONFIG(GPIO_MODE_INPUT,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLDOWN)
+#define IOCFG_IPU            IO_CONFIG(GPIO_MODE_INPUT,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLUP)
+#define IOCFG_IN_FLOATING    IO_CONFIG(GPIO_MODE_INPUT,     GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
+#define IOCFG_IPU_25         IO_CONFIG(GPIO_MODE_INPUT,     GPIO_SPEED_FREQ_HIGH, GPIO_PULLUP)
+
 #elif defined(STM32F7)
 
 //speed is packed inside modebits 5 and 2,
@@ -122,7 +140,7 @@ bool IOIsFreeOrPreinit(IO_t io);
 IO_t IOGetByTag(ioTag_t tag);
 
 void IOConfigGPIO(IO_t io, ioConfig_t cfg);
-#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
 void IOConfigGPIOAF(IO_t io, ioConfig_t cfg, uint8_t af);
 #endif
 

--- a/src/main/drivers/rcc.h
+++ b/src/main/drivers/rcc.h
@@ -22,12 +22,29 @@
 
 #include "rcc_types.h"
 
+// XXX rcc module is not actively used by HAL based platforms (F7 and H7),
+// XXX as peripherals are turned on statically in enableGPIOPowerUsageAndNoiseReductions()
+// XXX during initialization.
+
 enum rcc_reg {
     RCC_EMPTY = 0,   // make sure that default value (0) does not enable anything
+#ifdef STM32H7
+    RCC_AHB,
+    RCC_APB2,
+    RCC_APB1L,
+    RCC_APB1H,
+    RCC_AHB1,
+    RCC_AHB2,
+    RCC_AHB3,
+    RCC_APB3,
+    RCC_AHB4,
+    RCC_APB4,
+#else
     RCC_AHB,
     RCC_APB2,
     RCC_APB1,
-    RCC_AHB1
+    RCC_AHB1,
+#endif
 };
 
 #define RCC_ENCODE(reg, mask) (((reg) << 5) | LOG2_32BIT(mask))
@@ -35,6 +52,17 @@ enum rcc_reg {
 #define RCC_APB2(periph) RCC_ENCODE(RCC_APB2, RCC_APB2ENR_ ## periph ## EN)
 #define RCC_APB1(periph) RCC_ENCODE(RCC_APB1, RCC_APB1ENR_ ## periph ## EN)
 #define RCC_AHB1(periph) RCC_ENCODE(RCC_AHB1, RCC_AHB1ENR_ ## periph ## EN)
+
+#ifdef STM32H7
+#define RCC_AHB2(periph) RCC_ENCODE(RCC_AHB2, RCC_AHB2ENR_ ## periph ## EN)
+#define RCC_AHB3(periph) RCC_ENCODE(RCC_AHB3, RCC_AHB3ENR_ ## periph ## EN)
+#define RCC_APB3(periph) RCC_ENCODE(RCC_APB3, RCC_APB3ENR_ ## periph ## EN)
+#define RCC_AHB4(periph) RCC_ENCODE(RCC_AHB4, RCC_AHB4ENR_ ## periph ## EN)
+#define RCC_APB4(periph) RCC_ENCODE(RCC_APB4, RCC_APB4ENR_ ## periph ## EN)
+#undef  RCC_APB1
+#define RCC_APB1L(periph) RCC_ENCODE(RCC_APB1L, RCC_APB1LENR_ ## periph ## EN)
+#define RCC_APB1H(periph) RCC_ENCODE(RCC_APB1H, RCC_APB1HENR_ ## periph ## EN)
+#endif
 
 void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState);
 void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState);

--- a/src/main/drivers/rcc_types.h
+++ b/src/main/drivers/rcc_types.h
@@ -20,4 +20,8 @@
 
 #pragma once
 
+#if defined(STM32H7)
+typedef uint16_t rccPeriphTag_t;
+#else
 typedef uint8_t rccPeriphTag_t;
+#endif


### PR DESCRIPTION
`USE_HAL_LIBRARY` for F7 had to be replaced with `USE_FULL_LL_LIBRARY` to distinguish from H7 which uses non-LL HAL. Otherwise, changes are least intrusive.