### PR TITLE
RMS Error debug mode

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1015,6 +1015,7 @@ const clivalue_t valueTable[] = {
     { "d_min_boost_gain",           VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_gain) },
     { "d_min_advance",              VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, d_min_advance) },
 #endif
+    { "rms_error_lpf_period",       VAR_UINT8  | MASTER_VALUE,  .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, rms_error_lpf_period) },
 
     { "motor_output_limit",         VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { MOTOR_OUTPUT_LIMIT_PERCENT_MIN, MOTOR_OUTPUT_LIMIT_PERCENT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, motor_output_limit) },
     { "auto_profile_cell_count",    VAR_INT8 | PROFILE_VALUE,  .config.minmax = { AUTO_PROFILE_CELL_COUNT_CHANGE, MAX_AUTO_DETECT_CELL_COUNT }, PG_PID_PROFILE, offsetof(pidProfile_t, auto_profile_cell_count) },
@@ -1234,6 +1235,8 @@ const clivalue_t valueTable[] = {
     { "osd_pid_profile_name_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_PID_PROFILE_NAME]) },
 #endif
 
+    { "osd_rms_error_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RMS_ERROR_POS]) },
+
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users
     { "osd_stat_rtc_date_time",     VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_RTC_DATE_TIME,   PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
@@ -1263,6 +1266,8 @@ const clivalue_t valueTable[] = {
     { "osd_stat_total_time",        VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_TOTAL_TIME,    PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
     { "osd_stat_total_dist",        VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_TOTAL_DIST,    PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
 #endif
+
+    { "osd_stat_rms_error",         VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_RMS_ERROR,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
 
 #ifdef USE_OSD_PROFILES
     { "osd_profile",                VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, OSD_PROFILE_COUNT }, PG_OSD_CONFIG, offsetof(osdConfig_t, osdProfileIndex) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -334,6 +334,7 @@ static uint8_t  cmsx_d_min[XYZ_AXIS_COUNT];
 static uint8_t  cmsx_d_min_gain;
 static uint8_t  cmsx_d_min_advance;
 #endif
+static uint8_t  cmsx_rms_error_lpf_period;
 
 static long cmsx_profileOtherOnEnter(void)
 {
@@ -361,6 +362,8 @@ static long cmsx_profileOtherOnEnter(void)
     cmsx_d_min_gain = pidProfile->d_min_gain;
     cmsx_d_min_advance = pidProfile->d_min_advance;
 #endif
+
+    cmsx_rms_error_lpf_period = pidProfile->rms_error_lpf_period;
 
     return 0;
 }
@@ -392,6 +395,8 @@ static long cmsx_profileOtherOnExit(const OSD_Entry *self)
     pidProfile->d_min_advance = cmsx_d_min_advance;
 #endif
 
+    pidProfile->rms_error_lpf_period = cmsx_rms_error_lpf_period;
+
     initEscEndpoints();
     return 0;
 }
@@ -422,6 +427,8 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "D_MIN GAIN",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_d_min_gain,          0, 100, 1 }, 0 },
     { "D_MIN ADV",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_d_min_advance,       0, 200, 1 }, 0 },
 #endif
+
+    { "RMS_ERROR_LPF", OME_UINT8, NULL, &(OSD_UINT8_t) { &cmsx_rms_error_lpf_period, 0, 255, 1}, 0 },
 
     { "BACK", OME_Back, NULL, NULL, 0 },
     { NULL, OME_END, NULL, NULL, 0 }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -168,6 +168,7 @@ typedef struct pidProfile_s {
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
+    uint8_t rms_error_lpf_period;           // Period of the LPF for RMS Error in 1/10s
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -243,3 +244,6 @@ void dynLpfDTermUpdate(float throttle);
 void pidSetItermReset(bool enabled);
 float pidGetPreviousSetpoint(int axis);
 
+float pidGetRmsError(int axis);
+void pidRmsErrorStatReset();
+float pidGetRmsErrorStat(int axis);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -67,6 +67,7 @@
 #endif
 #include "flight/imu.h"
 #include "flight/position.h"
+#include "flight/pid.h"
 
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/beeper.h"
@@ -409,6 +410,7 @@ static void osdUpdateStats(void)
         }
     }
 #endif
+    pidRmsErrorStatReset();
 }
 
 #ifdef USE_BLACKBOX
@@ -627,6 +629,14 @@ static uint8_t osdShowStats(uint16_t endBatteryVoltage, int statsRowCount)
         }
     }
 #endif
+
+    if (osdStatGetState(OSD_STAT_RMS_ERROR)) {
+        int rollErr = lrintf(pidGetRmsErrorStat(ROLL) * 10);
+        int pitchErr = lrintf(pidGetRmsErrorStat(PITCH) * 10);
+        int yawErr = lrintf(pidGetRmsErrorStat(YAW) * 10);
+        tfp_sprintf(buff, "RMSE: %3d.%01d %3d.%01d %3d.%01d", rollErr / 10, rollErr % 10, pitchErr / 10, pitchErr % 10, yawErr / 10, yawErr % 10);
+        displayWrite(osdDisplayPort, 2, top++, buff);
+    }
 
 #ifdef USE_PERSISTENT_STATS
     if (osdStatGetState(OSD_STAT_TOTAL_FLIGHTS)) {

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -128,6 +128,7 @@ typedef enum {
     OSD_ESC_RPM_FREQ,
     OSD_RATE_PROFILE_NAME,
     OSD_PID_PROFILE_NAME,
+    OSD_RMS_ERROR_POS,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -164,6 +165,7 @@ typedef enum {
     OSD_STAT_TOTAL_FLIGHTS,
     OSD_STAT_TOTAL_TIME,
     OSD_STAT_TOTAL_DIST,
+    OSD_STAT_RMS_ERROR,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -708,6 +708,16 @@ static void osdElementEscRpmFreq(osdElementParms_t *element)
 }
 #endif
 
+static void osdElementRmsError(osdElementParms_t *element)
+{
+    if (currentPidProfile->rms_error_lpf_period) {
+        int rollErr = lrintf(pidGetRmsError(ROLL) * 10);
+        int pitchErr = lrintf(pidGetRmsError(PITCH) * 10);
+        int yawErr = lrintf(pidGetRmsError(YAW) * 10);
+        tfp_sprintf(element->buff, "RMSE: %3d.%01d %3d.%01d %3d.%01d", rollErr / 10, rollErr % 10, pitchErr / 10, pitchErr % 10, yawErr / 10, yawErr % 10);
+    }
+}
+
 static void osdElementFlymode(osdElementParms_t *element)
 {
     // Note that flight mode display has precedence in what to display.
@@ -1334,6 +1344,7 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_ROLL_PIDS,
     OSD_PITCH_PIDS,
     OSD_YAW_PIDS,
+    OSD_RMS_ERROR_POS,
     OSD_POWER,
     OSD_PIDRATE_PROFILE,
     OSD_WARNINGS,
@@ -1477,6 +1488,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
     [OSD_PID_PROFILE_NAME]        = osdElementPidProfileName,
 #endif
 
+    [OSD_RMS_ERROR_POS]           = osdElementRmsError,
 };
 
 static void osdAddActiveElement(osd_items_e element)


### PR DESCRIPTION
This adds a new debug mode `RMS_ERROR` which reflects the root-mean-squared error of the roll, pitch and yaw axis.

`rms_error_lpf_period` sets the period of the LPF used in 1/10s of a second.

Primary purpose is so that the values can be viewed during flight using the `Debug` OSD element.  This allows quick iterative PID tuning.  Logging to blackbox may not be valuable, so perhaps this would be better implemented as a new OSD element rather than piggy-backing on the debug system.