### PR TITLE
Revise data structures for DSHOT telemetry stats to avoid high CPU load

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -122,22 +122,6 @@ typedef enum {
 #define DSHOT_DMA_BUFFER_SIZE   18 /* resolution + frame reset (2us) */
 #define PROSHOT_DMA_BUFFER_SIZE 6  /* resolution + frame reset (2us) */
 
-#ifdef USE_DSHOT_TELEMETRY
-#ifdef USE_DSHOT_TELEMETRY_STATS
-#define DSHOT_TELEMETRY_QUALITY_WINDOW 1       // capture a rolling 1 second of packet stats
-#define DSHOT_TELEMETRY_QUALITY_BUCKET_MS 100  // determines the granularity of the stats and the overall number of rolling buckets
-#define DSHOT_TELEMETRY_QUALITY_BUCKET_COUNT (DSHOT_TELEMETRY_QUALITY_WINDOW * 1000 / DSHOT_TELEMETRY_QUALITY_BUCKET_MS)
-
-typedef struct dshotTelemetryQuality_s {
-    uint32_t packetCountSum;
-    uint32_t invalidCountSum;
-    uint32_t packetCountArray[DSHOT_TELEMETRY_QUALITY_BUCKET_COUNT];
-    uint32_t invalidCountArray[DSHOT_TELEMETRY_QUALITY_BUCKET_COUNT];
-    uint8_t lastBucketIndex;
-}  dshotTelemetryQuality_t;
-#endif // USE_DSHOT_TELEMETRY_STATS
-#endif // USE_DSHOT_TELEMETRY
-
 typedef struct {
     TIM_TypeDef *timer;
 #if defined(USE_DSHOT) && defined(USE_DSHOT_DMAR)
@@ -169,9 +153,6 @@ typedef struct {
     uint16_t dshotTelemetryValue;
     timeDelta_t dshotTelemetryDeadtimeUs;
     bool dshotTelemetryActive;
-#ifdef USE_DSHOT_TELEMETRY_STATS
-    dshotTelemetryQuality_t dshotTelemetryQuality;
-#endif
 #ifdef USE_HAL_DRIVER
     LL_TIM_OC_InitTypeDef ocInitStruct;
     LL_TIM_IC_InitTypeDef icInitStruct;


### PR DESCRIPTION
Having the stats data structures incorporated into the `dmaMotors[]` array structure was causing excessive CPU load on F4. The actual cause is unknown, but likely some kind of negative cache interaction. Moving the stats to a standalone array separate from `dmaMotors[]` solves the problem.

As a simple test case, try before/after with this config:
```
defaults nosave
set dshot_burst = OFF
set dshot_bidir = ON
set motor_pwm_protocol = DSHOT600
set gyro_sync_denom = 1
set pid_process_denom = 1
set debug_mode = RPM_FILTER
set scheduler_optimize_rate = ON
```
This just sets the bare minimum to enable bidirectional DSHOT telemetry. On a F405-based with no OSD, before this PR the CPU load will be ~60%. With this PR it will be ~20%.