### PR TITLE
Remove CLI "display_name" and notify that "name" will be removed

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2724,42 +2724,28 @@ static void cliVtxTable(char *cmdline)
 }
 #endif // USE_VTX_TABLE
 
-#ifdef USE_OSD
-static void printDisplayName(dumpFlags_t dumpMask, const pilotConfig_t *pilotConfig)
-{
-    const bool equalsDefault = strlen(pilotConfig->displayName) == 0;
-    cliDumpPrintLinef(dumpMask, equalsDefault, "display_name %s", equalsDefault ? emptyName : pilotConfig->displayName);
-}
-
-static void cliDisplayName(char *cmdline)
-{
-    const unsigned int len = strlen(cmdline);
-    if (len > 0) {
-        memset(pilotConfigMutable()->displayName, 0, ARRAYLEN(pilotConfig()->displayName));
-        if (strncmp(cmdline, emptyName, len)) {
-            strncpy(pilotConfigMutable()->displayName, cmdline, MIN(len, MAX_NAME_LENGTH));
-        }
-    }
-    printDisplayName(DUMP_MASTER, pilotConfig());
-}
-#endif
-
 static void printName(dumpFlags_t dumpMask, const pilotConfig_t *pilotConfig)
 {
     const bool equalsDefault = strlen(pilotConfig->name) == 0;
-    cliDumpPrintLinef(dumpMask, equalsDefault, "name %s", equalsDefault ? emptyName : pilotConfig->name);
+    cliDumpPrintLinef(dumpMask, equalsDefault, "\r\n# name: %s", equalsDefault ? emptyName : pilotConfig->name);
 }
 
 static void cliName(char *cmdline)
 {
     const unsigned int len = strlen(cmdline);
+    bool updated = false;
     if (len > 0) {
         memset(pilotConfigMutable()->name, 0, ARRAYLEN(pilotConfig()->name));
         if (strncmp(cmdline, emptyName, len)) {
             strncpy(pilotConfigMutable()->name, cmdline, MIN(len, MAX_NAME_LENGTH));
         }
+        updated = true;
     }
     printName(DUMP_MASTER, pilotConfig());
+    if (updated) {
+        cliPrintLine("###WARNING: This command will be removed. Use 'set name = ' instead.###");
+    }
+
 }
 
 #if defined(USE_BOARD_INFO)
@@ -5436,7 +5422,6 @@ static void printConfig(char *cmdline, bool doDiff)
         }
 
         if (!(dumpMask & HARDWARE_ONLY)) {
-            cliPrintHashLine("name");
             printName(dumpMask, &pilotConfig_Copy);
         }
 
@@ -5527,11 +5512,6 @@ static void printConfig(char *cmdline, bool doDiff)
 
             cliPrintHashLine("rxfail");
             printRxFailsafe(dumpMask, rxFailsafeChannelConfigs_CopyArray, rxFailsafeChannelConfigs(0));
-
-#ifdef USE_OSD
-            cliPrintHashLine("display_name");
-            printDisplayName(dumpMask, &pilotConfig_Copy);
-#endif
         }
 
         cliPrintHashLine("master");
@@ -5692,9 +5672,6 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", "[nosave]", cliDefaults),
     CLI_COMMAND_DEF("diff", "list configuration changes from default", "[master|profile|rates|hardware|all] {defaults|bare}", cliDiff),
-#ifdef USE_OSD
-    CLI_COMMAND_DEF("display_name", "display name of craft", NULL, cliDisplayName),
-#endif
 #ifdef USE_RESOURCE_MGMT
 #ifdef USE_DMA_SPEC
     CLI_COMMAND_DEF("dma", "show/set DMA assignments", "<> | <device> <index> list | <device> <index> [<option>|none] | list | show", cliDma),


### PR DESCRIPTION
These parameters can now be configured directly with the set/get commands.

The `name` command will still function to ease the transition, but presents a warning that it will be removed and to use "set name = " instead.

The `name` will still be output at the top of a diff/dump, but as a comment rather than a command.