### PR TITLE
avoid double esc startup sounds on f7

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -393,10 +393,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         ( 2 + (motor->useProshot ? 4 * MOTOR_NIBBLE_LENGTH_PROSHOT : 16 * MOTOR_BITLENGTH))
         / getDshotHz(pwmProtocolType);
     pwmDshotSetDirectionOutput(motor, true);
-    if (useDshotTelemetry) {
-        // avoid high line during startup to prevent bootloader activation
-        *timerChCCR(timerHardware) = 0xffff;
-    }
 #else
     pwmDshotSetDirectionOutput(motor, true, &OCINIT, &DMAINIT);
 #endif
@@ -420,6 +416,12 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         TIM_CtrlPWMOutputs(timer, ENABLE);
         TIM_Cmd(timer, ENABLE);
     }
+#ifdef USE_DSHOT_TELEMETRY
+    if (useDshotTelemetry) {
+        // avoid high line during startup to prevent bootloader activation
+        *timerChCCR(timerHardware) = 0xffff;
+    }
+#endif
     motor->configured = true;
 }
 

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -354,10 +354,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         ( 2 + (motor->useProshot ? 4 * MOTOR_NIBBLE_LENGTH_PROSHOT : 16 * MOTOR_BITLENGTH))
         / getDshotHz(pwmProtocolType);
     pwmDshotSetDirectionOutput(motor, true);
-    if (useDshotTelemetry) {
-        // avoid high line during startup to prevent bootloader activation
-        *timerChCCR(timerHardware) = 0xffff;
-    }
 #else
     pwmDshotSetDirectionOutput(motor, true, &OCINIT, &DMAINIT);
 #endif
@@ -386,6 +382,12 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         LL_TIM_EnableARRPreload(timer);
         LL_TIM_EnableCounter(timer);
     }
+#ifdef USE_DSHOT_TELEMETRY
+    if (useDshotTelemetry) {
+        // avoid high line during startup to prevent bootloader activation
+        *timerChCCR(timerHardware) = 0xffff;
+    }
+#endif
     motor->configured = true;
 }
 #endif


### PR DESCRIPTION
This PR ensures that the dshot lines are pushed low until dshot traffic starts with inverted dshot bidirectional on f7.