### PR TITLE
Fix MODE_STRING blank value output and improve validation messages

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -542,7 +542,7 @@ static void printValuePointer(const clivalue_t *var, const void *valuePointer, b
             }
             break;
         case MODE_STRING:
-            cliPrintf("%s", (char *)valuePointer);
+            cliPrintf("%s", (strlen((char *)valuePointer) == 0) ? "-" : (char *)valuePointer);
             break;
         }
 
@@ -4162,6 +4162,8 @@ STATIC_UNIT_TESTED void cliSet(char *cmdline)
                         strncpy((char *)cliGetValuePointer(val), valPtr, len);
                     }
                     valueChanged = true;
+                } else {
+                    cliPrintErrorLinef("STRING MUST BE 1-%d CHARACTERS OR '-' FOR EMPTY", max);
                 }
             }
             break;


### PR DESCRIPTION
Emptry MODE_STRING paramaters would produce CLI output that would then generate errors if reapplied using a `diff` or `dump`. Fixed the output for blank values to be compatible with setting an empty string (clearing a previous value).

Previously blank values would output as:
```
set name =
set display_name =
```
These would cause errors if applied:
```
# set name =
###ERROR: INVALID VALUE###
```
Now they will output as:
```
set name = -
```
Which has the effect of clearing the value (setting to blank).

Also improve the length validation to report the allowed character range.
```
# set name = sdflsdjflsjflsdjflsdfjlsdfj
###ERROR: STRING MUST BE 1-16 CHARACTERS###
###ERROR: INVALID VALUE###
```