### PR TITLE
[H7] STM32H750 - Fix CPU crash on cold boot when VCP is enabled.

### DIFF
--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -265,9 +265,13 @@ serialPort_t *usbVcpOpen(void)
 
     /* Start Device Process */
     USBD_Start(&USBD_Device);
+
 #ifdef STM32H7
     HAL_PWREx_EnableUSBVoltageDetector();
+    delay(100); // Cold boot failures observed without this, even when USB cable is not connected
 #endif
+
+
 #else
     Set_System();
     Set_USBClock();


### PR DESCRIPTION
Crash doesn't occur when VCP is disabled.

It was observed that shortly after the VCP port was enabled a crash
would occur in unrelated code.  e.g. in `rxInit()`

Moving the delay before the call to HAL_PWREx_EnableUSBVoltageDetector
does not fix the issue - tested by moving the delay up one line and
doing many cold boots until a crash was observed.  Crash un-repeatable
once delay is added.

Note: exact cause is unknown, behaviour occurs on some boards more frequently than others.