### PR TITLE
Fix pageMaxRow use before update

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -250,13 +250,13 @@ static void cmsPageSelect(displayPort_t *instance, int8_t newpage)
 {
     currentCtx.page = (newpage + pageCount) % pageCount;
     pageTop = &currentCtx.menu->entries[currentCtx.page * maxMenuItems];
-
+    cmsUpdateMaxRow(instance);
+ 
     const OSD_Entry *p;
     int i;
     for (p = pageTop, i = 0; (p <= pageTop + pageMaxRow); p++, i++) {
         runtimeEntryFlags[i] = p->flags;
     }
-    cmsUpdateMaxRow(instance);
     displayClearScreen(instance);
 }
 


### PR DESCRIPTION
After commit d2e7abd the for loop following my change use pageMaxRow to determine which flags to clear.
But this pageMaxRow value is updated after the loop, which caused a crash in a very specific circumstance:

1 open the CMS OSD menu and go to profile

2 close the profile by yaw right, select exit

3 open CMS OSD menu and go to profile again

This caused a crash as runtimeEntryFlags wasn't cleared properly and the Copy Profile entry's flags still indicated OPTSTRING somehow.
which caused it's CMSEntryFuncPtr function to be cast to OPTSTRING and called without arguments.
