### PR TITLE
Revise PID/Rate profile names to use get/set and eliminate extra PG's

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -671,58 +671,9 @@ static const char *dumpPgValue(const clivalue_t *value, dumpFlags_t dumpMask, co
     return headingStr;
 }
 
-#ifdef USE_PROFILE_NAMES
-static void printRateProfileName(uint8_t dumpMask, const profileName_t *rateProfileNameConfig)
-{
-    const bool equalsDefault = strlen(rateProfileNameConfig->name) == 0;
-    cliDumpPrintLinef(dumpMask, equalsDefault, "rateprofile_name %s", equalsDefault ? emptyName : rateProfileNameConfig->name);
-}
-
-static void cliRateProfileName(char *cmdline)
-{
-    const unsigned int len = strlen(cmdline);
-    uint8_t profileIndex =  getCurrentControlRateProfileIndex();
-    if (len > 0) {
-        memset(rateProfileNameMutable()->profile[profileIndex].name, 0, ARRAYLEN(rateProfileNameMutable()->profile[profileIndex].name));
-        if (strncmp(cmdline, emptyName, len)) {
-            strncpy(rateProfileNameMutable()->profile[profileIndex].name, cmdline, MIN(len, MAX_PROFILE_NAME_LENGTH));
-        }
-    }
-    printRateProfileName(DUMP_MASTER, &rateProfileName()->profile[profileIndex]);
-}
-
-static void printPidProfileName(uint8_t dumpMask, const profileName_t *pidProfileNameConfig)
-{
-    const bool equalsDefault = strlen(pidProfileNameConfig->name) == 0;
-    cliDumpPrintLinef(dumpMask, equalsDefault, "profile_name %s", equalsDefault ? emptyName : pidProfileNameConfig->name);
-}
-
-static void cliPidProfileName(char *cmdline)
-{
-    const unsigned int len = strlen(cmdline);
-    uint8_t profileIndex =  getCurrentPidProfileIndex();
-    if (len > 0) {
-        memset(pidProfileNameMutable()->profile[profileIndex].name, 0, ARRAYLEN(pidProfileNameMutable()->profile[profileIndex].name));
-        if (strncmp(cmdline, emptyName, len)) {
-            strncpy(pidProfileNameMutable()->profile[profileIndex].name, cmdline, MIN(len, MAX_PROFILE_NAME_LENGTH));
-        }
-    }
-    printPidProfileName(DUMP_MASTER, &pidProfileName()->profile[profileIndex]);
-}
-#endif
-
 static void dumpAllValues(uint16_t valueSection, dumpFlags_t dumpMask, const char *headingStr)
 {
     headingStr = cliPrintSectionHeading(dumpMask, false, headingStr);
-#ifdef USE_PROFILE_NAMES
-    if (valueSection == PROFILE_VALUE) {
-        printPidProfileName(DUMP_MASTER, &pidProfileName()->profile[getPidProfileIndexToUse()]);
-    }
-
-    if (valueSection == PROFILE_RATE_VALUE) {
-        printRateProfileName(DUMP_MASTER, &rateProfileName()->profile[getRateProfileIndexToUse()]);
-    }
-#endif
 
     for (uint32_t i = 0; i < valueTableEntryCount; i++) {
         const clivalue_t *value = &valueTable[i];
@@ -5864,13 +5815,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("play_sound", NULL, "[<index>]", cliPlaySound),
 #endif
     CLI_COMMAND_DEF("profile", "change profile", "[<index>]", cliProfile),
-#ifdef USE_PROFILE_NAMES
-        CLI_COMMAND_DEF("profile_name", "name of pid profile", NULL, cliPidProfileName),
-#endif
     CLI_COMMAND_DEF("rateprofile", "change rate profile", "[<index>]", cliRateProfile),
-#ifdef USE_PROFILE_NAMES
-    CLI_COMMAND_DEF("rateprofile_name", "name of rate profile", NULL, cliRateProfileName),
-#endif
 #ifdef USE_RC_SMOOTHING_FILTER
     CLI_COMMAND_DEF("rc_smoothing_info", "show rc_smoothing operational settings", NULL, cliRcSmoothing),
 #endif // USE_RC_SMOOTHING_FILTER

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -619,8 +619,6 @@ const clivalue_t valueTable[] = {
 #ifdef USE_DYN_LPF
     { "dyn_lpf_gyro_min_hz",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_gyro_min_hz) },
     { "dyn_lpf_gyro_max_hz",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_gyro_max_hz) },
-    { "dyn_lpf_dterm_min_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_min_hz) },
-    { "dyn_lpf_dterm_max_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_max_hz) },
 #endif
     { "gyro_filter_debug_axis",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_FILTER_DEBUG }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_debug_axis) },
 
@@ -837,6 +835,9 @@ const clivalue_t valueTable[] = {
 #endif
 
 // PG_CONTROLRATE_PROFILES
+#ifdef USE_PROFILE_NAMES
+    { "rateprofile_name",           VAR_UINT8  | PROFILE_RATE_VALUE | MODE_STRING, .config.string = { 1, MAX_RATE_PROFILE_NAME_LENGTH, STRING_FLAGS_NONE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, profileName) },
+#endif
     { "thr_mid",                    VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, thrMid8) },
     { "thr_expo",                   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, thrExpo8) },
     { "rates_type",                 VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RATES_TYPE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rates_type) },
@@ -925,6 +926,13 @@ const clivalue_t valueTable[] = {
 #endif
 
 // PG_PID_PROFILE
+#ifdef USE_PROFILE_NAMES
+    { "profile_name",               VAR_UINT8  | PROFILE_VALUE | MODE_STRING, .config.string = { 1, MAX_PROFILE_NAME_LENGTH, STRING_FLAGS_NONE }, PG_PID_PROFILE, offsetof(pidProfile_t, profileName) },
+#endif
+#ifdef USE_DYN_LPF
+    { "dyn_lpf_dterm_min_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_min_hz) },
+    { "dyn_lpf_dterm_max_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_max_hz) },
+#endif
     { "dterm_lowpass_type",         VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DTERM_LOWPASS_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_filter_type) },
     { "dterm_lowpass_hz",           VAR_INT16  | PROFILE_VALUE, .config.minmax = { 0, 16000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_lowpass_hz) },
     { "dterm_lowpass2_type",        VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DTERM_LOWPASS_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_filter2_type) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -62,13 +62,13 @@
 //
 static uint8_t tmpPidProfileIndex;
 static uint8_t pidProfileIndex;
-static char pidProfileIndexString[] = " p";
+static char pidProfileIndexString[MAX_PROFILE_NAME_LENGTH + 5];
 static uint8_t tempPid[3][3];
 static uint16_t tempPidF[3];
 
 static uint8_t tmpRateProfileIndex;
 static uint8_t rateProfileIndex;
-static char rateProfileIndexString[] = " p-r";
+static char rateProfileIndexString[MAX_RATE_PROFILE_NAME_LENGTH + 5];
 static controlRateConfig_t rateProfile;
 
 static const char * const osdTableThrottleLimitType[] = {
@@ -80,6 +80,29 @@ static const char * const osdTableDynNotchRangeType[] = {
     "HIGH", "MED", "LOW", "AUTO"
 };
 #endif
+
+static void setProfileIndexString(char *profileString, int profileIndex, char *profileName)
+{
+    int charIndex = 0;
+    profileString[charIndex++] = '1' + profileIndex;
+
+#ifdef USE_PROFILE_NAMES
+    const int profileNameLen = strlen(profileName);
+
+    if (profileNameLen > 0) {
+        profileString[charIndex++] = ' ';
+        profileString[charIndex++] = '(';
+        for (int i = 0; i < profileNameLen; i++) {
+            profileString[charIndex++] = toupper(profileName[i]);
+        }
+        profileString[charIndex++] = ')';
+    }
+#else
+    UNUSED(profileName);
+#endif
+
+    profileString[charIndex] = '\0';
+}
 
 static long cmsx_menuImu_onEnter(void)
 {
@@ -140,7 +163,7 @@ static long cmsx_PidRead(void)
 
 static long cmsx_PidOnEnter(void)
 {
-    pidProfileIndexString[1] = '0' + tmpPidProfileIndex;
+    setProfileIndexString(pidProfileIndexString, pidProfileIndex, currentPidProfile->profileName);
     cmsx_PidRead();
 
     return 0;
@@ -217,8 +240,7 @@ static long cmsx_RateProfileWriteback(const OSD_Entry *self)
 
 static long cmsx_RateProfileOnEnter(void)
 {
-    rateProfileIndexString[1] = '0' + tmpPidProfileIndex;
-    rateProfileIndexString[3] = '0' + tmpRateProfileIndex;
+    setProfileIndexString(rateProfileIndexString, rateProfileIndex, controlRateProfilesMutable(rateProfileIndex)->profileName);
     cmsx_RateProfileRead();
 
     return 0;
@@ -337,7 +359,7 @@ static uint8_t  cmsx_d_min_advance;
 
 static long cmsx_profileOtherOnEnter(void)
 {
-    pidProfileIndexString[1] = '0' + tmpPidProfileIndex;
+    setProfileIndexString(pidProfileIndexString, pidProfileIndex, currentPidProfile->profileName);
 
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -87,10 +87,6 @@ PG_RESET_TEMPLATE(pilotConfig_t, pilotConfig,
     .displayName = { 0 },
 );
 
-PG_REGISTER_WITH_RESET_FN(rateProfileNameConfig_t, rateProfileName, PG_RATE_PROFILE_NAMES_CONFIG, 1);
-
-PG_REGISTER_WITH_RESET_FN(pidProfileNameConfig_t, pidProfileName, PG_PID_PROFILE_NAMES_CONFIG, 1);
-
 PG_REGISTER_WITH_RESET_TEMPLATE(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);
 
 PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
@@ -124,22 +120,6 @@ uint8_t getCurrentControlRateProfileIndex(void)
 uint16_t getCurrentMinthrottle(void)
 {
     return motorConfig()->minthrottle;
-}
-
-void pgResetFn_rateProfileName(rateProfileNameConfig_t *rateProfileName)
-{
-
-    for (int i = 0; i < CONTROL_RATE_PROFILE_COUNT; i++) {
-        tfp_sprintf(rateProfileName->profile[i].name, "RATE %u", i+1, MAX_PROFILE_NAME_LENGTH);
-    }
-}
-
-void pgResetFn_pidProfileName(pidProfileNameConfig_t *pidProfileName)
-{
-
-    for (int i = 0; i < PID_PROFILE_COUNT; i++) {
-        tfp_sprintf(pidProfileName->profile[i].name, "PID %u", i+1, MAX_PROFILE_NAME_LENGTH);
-    }
 }
 
 void resetConfigs(void)

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -36,22 +36,6 @@ typedef struct pilotConfig_s {
 
 PG_DECLARE(pilotConfig_t, pilotConfig);
 
-typedef struct profileName_s {
-    char name[MAX_PROFILE_NAME_LENGTH + 1];
-} profileName_t;
-
-typedef struct rateProfileNameConfig_s {
-    profileName_t profile[CONTROL_RATE_PROFILE_COUNT];
-} rateProfileNameConfig_t;
-
-PG_DECLARE(rateProfileNameConfig_t, rateProfileName);
-
-typedef struct pidProfileNameConfig_s {
-    profileName_t profile[PID_PROFILE_COUNT];
-} pidProfileNameConfig_t;
-
-PG_DECLARE(pidProfileNameConfig_t, pidProfileName);
-
 typedef struct systemConfig_s {
     uint8_t pidProfileIndex;
     uint8_t activeRateProfile;

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -37,7 +37,7 @@
 
 controlRateConfig_t *currentControlRateProfile;
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 2);
 
 void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
 {
@@ -63,6 +63,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_PITCH] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .tpaMode = TPA_MODE_D,
+            .profileName = { 0 },
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -36,11 +36,12 @@ typedef enum {
     THROTTLE_LIMIT_TYPE_COUNT   // must be the last entry
 } throttleLimitType_e;
 
-
 typedef enum {
     TPA_MODE_PD,
     TPA_MODE_D
 } tpaMode_e;
+
+#define MAX_RATE_PROFILE_NAME_LENGTH 8u
 
 typedef struct controlRateConfig_s {
     uint8_t thrMid8;
@@ -55,6 +56,7 @@ typedef struct controlRateConfig_s {
     uint8_t throttle_limit_percent;         // Sets the maximum pilot commanded throttle limit
     uint16_t rate_limit[3];                 // Sets the maximum rate for the axes
     uint8_t tpaMode;                        // Controls which PID terms TPA effects
+    char profileName[MAX_RATE_PROFILE_NAME_LENGTH + 1]; // Descriptive name for rate profile
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -128,7 +128,7 @@ static FAST_RAM_ZERO_INIT float airmodeThrottleOffsetLimit;
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 10);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 11);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -204,6 +204,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .motor_output_limit = 100,
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
         .transient_throttle_limit = 15,
+        .profileName = { 0 },
     );
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -100,6 +100,8 @@ typedef enum {
     ITERM_RELAX_SETPOINT
 } itermRelaxType_e;
 
+#define MAX_PROFILE_NAME_LENGTH 8u
+
 typedef struct pidProfile_s {
     uint16_t yaw_lowpass_hz;                // Additional yaw filter when yaw axis too noisy
     uint16_t dterm_lowpass_hz;              // Delta Filter in hz
@@ -168,6 +170,7 @@ typedef struct pidProfile_s {
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
+    char profileName[MAX_PROFILE_NAME_LENGTH + 1]; // Descriptive name for profile
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -68,6 +68,7 @@
 #include "drivers/vtx_common.h"
 
 #include "fc/config.h"
+#include "fc/controlrate_profile.h"
 #include "fc/core.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
@@ -650,15 +651,13 @@ static void osdElementDisplayName(osdElementParms_t *element)
 #ifdef USE_PROFILE_NAMES
 static void osdElementRateProfileName(osdElementParms_t *element)
 {
-    uint8_t rateProfileIndex = getCurrentControlRateProfileIndex();
-
-    if (strlen(rateProfileName()->profile[rateProfileIndex].name) == 0) {
-        tfp_sprintf(element->buff, "RATE_%u", rateProfileIndex);
+    if (strlen(currentControlRateProfile->profileName) == 0) {
+        tfp_sprintf(element->buff, "RATE_%u", getCurrentControlRateProfileIndex() + 1);
     } else {
         unsigned i;
         for (i = 0; i < MAX_PROFILE_NAME_LENGTH; i++) {
-            if (rateProfileName()->profile[rateProfileIndex].name[i]) {
-                element->buff[i] = toupper((unsigned char)rateProfileName()->profile[rateProfileIndex].name[i]);
+            if (currentControlRateProfile->profileName[i]) {
+                element->buff[i] = toupper((unsigned char)currentControlRateProfile->profileName[i]);
             } else {
                 break;
             }
@@ -669,15 +668,13 @@ static void osdElementRateProfileName(osdElementParms_t *element)
 
 static void osdElementPidProfileName(osdElementParms_t *element)
 {
-    uint8_t pidProfileIndex = getCurrentPidProfileIndex();
-
-    if (strlen(pidProfileName()->profile[pidProfileIndex].name) == 0) {
-        tfp_sprintf(element->buff, "PID_%u", pidProfileIndex);
+    if (strlen(currentPidProfile->profileName) == 0) {
+        tfp_sprintf(element->buff, "PID_%u", getCurrentPidProfileIndex() + 1);
     } else {
         unsigned i;
         for (i = 0; i < MAX_PROFILE_NAME_LENGTH; i++) {
-            if (pidProfileName()->profile[pidProfileIndex].name[i]) {
-                element->buff[i] = toupper((unsigned char)pidProfileName()->profile[pidProfileIndex].name[i]);
+            if (currentPidProfile->profileName[i]) {
+                element->buff[i] = toupper((unsigned char)currentPidProfile->profileName[i]);
             } else {
                 break;
             }

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -81,8 +81,6 @@
 #define PG_GPS_RESCUE 55 // struct OK
 #define PG_POSITION 56
 #define PG_VTX_IO_CONFIG 57
-#define PG_RATE_PROFILE_NAMES_CONFIG 58
-#define PG_PID_PROFILE_NAMES_CONFIG  59
 
 // Driver configuration
 #define PG_DRIVER_PWM_RX_CONFIG 100 // does not exist in betaflight


### PR DESCRIPTION
Removes the custom CLI commands to update or display the PID and Rate profile names. Moves the storage into the pidProfile and controlRateProfile PG's.

Names can now be set with:
set profile_name = NAME
set rate_profile_name = NAME

Example:
```
# set profile_name = profname
profile_name set to profname
# set rateprofile_name = ratename
rateprofile_name set to ratename

# diff

# version
# Betaflight / REVO (REVO) 4.1.0 May  8 2019 / 08:50:29 (8af39e7) MSP API: 1.42

# start the command batch
batch start

board_name REVO

profile 0

# profile 0
set profile_name = profname

rateprofile 0

# rateprofile 0
set rateprofile_name = ratename

# end the command batch
batch end
```

Also added profile name display to the profile and rate CMS menus.