### PR TITLE
[FLASHFS] Reinitialise flashFs after erasing flash chip.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2288,6 +2288,7 @@ static void cliFlashErase(char *cmdline)
 
     bufWriterFlush(cliWriter);
     flashfsEraseCompletely();
+    flashfsInit();
 
     while (!flashfsIsReady()) {
 #ifndef MINIMAL_CLI

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2342,6 +2342,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 #ifdef USE_FLASHFS
     case MSP_DATAFLASH_ERASE:
         flashfsEraseCompletely();
+        flashfsInit();
         break;
 #endif
 


### PR DESCRIPTION
Ensures erase actually worked rather than assuming it did.