### PR TITLE
[FLASH] Allow flash initialisation without flashfs support.

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -693,11 +693,11 @@ void init(void)
     }
 #endif
 
-#ifdef USE_FLASHFS
-#if defined(USE_FLASH_CHIP)
+#ifdef USE_FLASH_CHIP
     flashInit(flashConfig());
-#endif
+#ifdef USE_FLASHFS
     flashfsInit();
+#endif
 #endif
 
 #ifdef USE_BLACKBOX


### PR DESCRIPTION
There are reasons to enable flash hardware support other than just
flashfs.  e.g. config and alternative firmware storage, debugging, etc.