### PR TITLE
Add TRANSTECF7 target

### DIFF
--- a/src/main/target/TRANSTECF7/config.c
+++ b/src/main/target/TRANSTECF7/config.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_TARGET_CONFIG
+
+#include "pg/pinio.h"
+#include "pg/piniobox.h"
+
+void targetConfiguration(void)
+{	
+    pinioConfigMutable()->config[1] = PINIO_CONFIG_OUT_INVERTED | PINIO_CONFIG_MODE_OUT_PP;
+    pinioBoxConfigMutable()->permanentId[0] = 40;
+}
+#endif

--- a/src/main/target/TRANSTECF7/target.c
+++ b/src/main/target/TRANSTECF7/target.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0),   // S1
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0),   // S2
+    DEF_TIM(TIM8, CH1, PC6, TIM_USE_MOTOR, 0, 0),   // S3
+    DEF_TIM(TIM8, CH2, PC7, TIM_USE_MOTOR, 0, 0),   // S4
+
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_PWM, 0, 0),     // S5
+    DEF_TIM(TIM3, CH1, PB4, TIM_USE_PWM, 0, 0),     // S6
+
+    DEF_TIM(TIM4, CH3, PB8, TIM_USE_PWM, 0, 0),     // Cam Control
+
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED, 0, 0),    // LED STRIP
+};

--- a/src/main/target/TRANSTECF7/target.h
+++ b/src/main/target/TRANSTECF7/target.h
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER         "TTF7"
+#define USBD_PRODUCT_STRING             "TransTECF7"
+#define TARGET_MANUFACTURER_IDENTIFIER  "TTRH"
+
+#define USE_TARGET_CONFIG
+
+#define ENABLE_DSHOT_DMAR               true
+
+#define LED0_PIN                        PA14
+
+#define USE_PINIO
+#define PINIO1_PIN                      PB12        //VTX Power Switch
+#define USE_PINIOBOX
+
+#define CAMERA_CONTROL_PIN              PB8         //Camera OSD
+
+#define USE_BEEPER
+
+// *************** Gyro & ACC ***************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN                    PA5
+#define SPI1_MISO_PIN                   PA6
+#define SPI1_MOSI_PIN                   PA7
+
+#define USE_GYRO
+#define USE_ACC
+
+#define GYRO_1_CS_PIN                   PC2
+#define GYRO_1_SPI_INSTANCE             SPI1
+
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN                 PC3
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define USE_GYRO_MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_1_ALIGN                    CW180_DEG_FLIP
+
+#define USE_ACC_MPU6000
+#define USE_ACC_SPI_MPU6000
+#define ACC_1_ALIGN                     CW180_DEG_FLIP
+
+// *************** I2C ***************
+#define USE_I2C
+
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE                      (I2CDEV_1)
+#define I2C1_SCL                        PB6         // SCL pad
+#define I2C1_SDA                        PB7         // SDA pad
+#define USE_I2C_PULLUP
+
+// *************** OSD ***************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN                    PB13
+#define SPI2_MISO_PIN                   PB14
+#define SPI2_MOSI_PIN                   PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE            SPI2
+#define MAX7456_SPI_CS_PIN              PB10
+
+// *************** UART ***************
+#define USE_VCP
+#define USB_DETECT_PIN                  PA4
+#define USE_USB_DETECT
+
+#define USE_UART1
+#define UART1_RX_PIN                    PA10
+#define UART1_TX_PIN                    PA9
+
+#define USE_UART2
+#define UART2_RX_PIN                    PA3
+#define UART2_TX_PIN                    PA2
+
+#define USE_UART3
+#define UART3_RX_PIN                    PC11
+#define UART3_TX_PIN                    PC10
+
+#define USE_UART4
+#define UART4_RX_PIN                    PA1
+#define UART4_TX_PIN                    PA0
+
+#define USE_UART5
+#define UART5_RX_PIN                    PD2
+#define UART5_TX_PIN                    PC12
+
+#define SERIAL_PORT_COUNT               6
+
+#define DEFAULT_RX_FEATURE              FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER               SERIALRX_SBUS
+#define SERIALRX_UART                   SERIAL_PORT_USART1
+
+// *************** ADC ****************************
+#define USE_ADC
+#define ADC_INSTANCE                    ADC1    // Default added
+#define ADC1_DMA_OPT                    0       // DMA 2 Stream 0 Channel 0
+
+#define VBAT_ADC_PIN                    PC0
+#define CURRENT_METER_ADC_PIN           PC1
+#define RSSI_ADC_PIN                    PB5
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_AIRMODE )
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+#define USE_ESCSERIAL
+
+#define TARGET_IO_PORTA                 0xffff
+#define TARGET_IO_PORTB                 0xffff
+#define TARGET_IO_PORTC                 0xffff
+#define TARGET_IO_PORTD                 0xffff
+
+#define USABLE_TIMER_CHANNEL_COUNT      8
+#define USED_TIMERS                     (TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(8))

--- a/src/main/target/TRANSTECF7/target.mk
+++ b/src/main/target/TRANSTECF7/target.mk
@@ -1,0 +1,7 @@
+F7X2RE_TARGETS += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/max7456.c \
+            drivers/pinio.c

--- a/unified_targets/configs/TRANSTECF7.config
+++ b/unified_targets/configs/TRANSTECF7.config
@@ -1,0 +1,102 @@
+# version
+# Betaflight / STM32F7X2 (S7X2) 4.0.2 May  5 2019 / 12:20:37 (56bdc8d26) MSP API: 1.41
+
+board_name TRANSTECF7
+manufacturer_id TTRH
+
+# name
+
+# resources
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 C06
+resource MOTOR 4 C07
+resource MOTOR 5 B03
+resource MOTOR 6 B04
+resource CAMERA_CONTROL 1 B08
+resource LED_STRIP 1 A15
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource I2C_SCL 1 B06
+resource I2C_SDA 1 B07
+resource LED 1 A14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource ADC_BATT 1 C00
+resource ADC_RSSI 1 B05
+resource ADC_CURR 1 C01
+resource PINIO 1 B12
+resource OSD_CS 1 B10
+resource GYRO_EXTI 1 C03
+resource GYRO_CS 1 C02
+resource USB_DETECT 1 A04
+
+# timer
+timer B00 1
+timer B01 1
+timer C06 1
+timer C07 1
+timer B03 0
+timer B04 0
+timer B08 0
+timer A15 0
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin C06 0
+# pin C06: DMA2 Stream 2 Channel 0
+dma pin C07 0
+# pin C07: DMA2 Stream 2 Channel 0
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 4 2048 115200 57600 0 115200
+
+# display_name
+display_name = TransTEC
+
+# master
+set mag_hardware = NONE
+set baro_hardware = NONE
+set serialrx_provider = SBUS
+set blackbox_device = NONE
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180FLIP
+set gyro_2_spibus = 1
+set pinio_box = 40,0,0,0


### PR DESCRIPTION
Add TransTECF7 target
F7 board with single plane design, which can directly solder
DSMX receiver(Lemon RX) on it, or paste other receiver.

- MCU : STM32F722

- GYRO : MPU6000

- OSD

- Camera OSD control

- Vtx power switch

- 5V Bec

- VBat power LC filter