### PR TITLE
Use distance to home symbol into the OSD

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -26,7 +26,7 @@
 #define SYM_BLANK                   0x20
 #define SYM_COLON                   0x2D
 #define SYM_BBLOG                   0x10
-//#define SYM_HOMEFLAG                0x11
+#define SYM_HOMEFLAG                0x11
 //#define SYM_RPM                     0x12
 #define SYM_ROLL                    0x14
 #define SYM_PITCH                   0x15

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -784,9 +784,7 @@ static void osdElementGpsHomeDistance(osdElementParms_t *element)
         element->buff[0] = SYM_HOMEFLAG;
         // We use this symbol when we don't have a FIX
         element->buff[1] = SYM_COLON;
-        // overwrite any previous distance with blanks
-        memset(element->buff + 2, SYM_BLANK, 6);
-        element->buff[8] = '\0';
+        element->buff[2] = '\0';
     }
 }
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -779,13 +779,14 @@ static void osdElementGpsHomeDistance(osdElementParms_t *element)
 {
     if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
         const int32_t distance = osdGetMetersToSelectedUnit(GPS_distanceToHome);
-        tfp_sprintf(element->buff, "%d%c", distance, osdGetMetersToSelectedUnitSymbol());
+        tfp_sprintf(element->buff, "%c%d%c", SYM_HOMEFLAG, distance, osdGetMetersToSelectedUnitSymbol());
     } else {
+        element->buff[0] = SYM_HOMEFLAG;
         // We use this symbol when we don't have a FIX
-        element->buff[0] = SYM_COLON;
+        element->buff[1] = SYM_COLON;
         // overwrite any previous distance with blanks
-        memset(element->buff + 1, SYM_BLANK, 6);
-        element->buff[7] = '\0';
+        memset(element->buff + 2, SYM_BLANK, 6);
+        element->buff[8] = '\0';
     }
 }
 


### PR DESCRIPTION
Uses the new Home Symbol before the distance to home OSD element.