### PR TITLE
Prevent flashfs from initializing in absence of a flash device

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -716,9 +716,11 @@ void init(void)
 #endif
 
 #ifdef USE_FLASH_CHIP
-    flashInit(flashConfig());
+    bool haveFlash = flashInit(flashConfig());
 #ifdef USE_FLASHFS
-    flashfsInit();
+    if (haveFlash) {
+        flashfsInit();
+    }
 #endif
 #endif
 


### PR DESCRIPTION
Follow up to #8238.

I should have melted this change into #8238, but found it as a part of coming up large commit set.