### PR TITLE
[H7] USB LIB Middlewares change: Avoid null hhid from being deferenced

### DIFF
--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
@@ -400,7 +400,7 @@ uint8_t USBD_HID_SendReport     (USBD_HandleTypeDef  *pdev,
 {
   USBD_HID_HandleTypeDef     *hhid = (USBD_HID_HandleTypeDef*)pdev->pHID_ClassData;
 
-  if (pdev->dev_state == USBD_STATE_CONFIGURED )
+  if (pdev->dev_state == USBD_STATE_CONFIGURED && hhid)
   {
     if(hhid->state == HID_IDLE)
     {


### PR DESCRIPTION
This check is available in the current F7 counterpart.