### PR TITLE
Update 4.0x filters

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -185,11 +185,11 @@ void resetPidProfile(pidProfile_t *pidProfile)
                                     // overridden and the static lowpass 1 is disabled. We can't set this
                                     // value to 0 otherwise Configurator versions 10.4 and earlier will also
                                     // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
-        .dterm_lowpass2_hz = 100,   // second Dterm LPF ON by default
+        .dterm_lowpass2_hz = 150,   // second Dterm LPF ON by default
         .dterm_filter_type = FILTER_BIQUAD,
         .dterm_filter2_type = FILTER_PT1,
-        .dyn_lpf_dterm_min_hz = 150,
-        .dyn_lpf_dterm_max_hz = 250,
+        .dyn_lpf_dterm_min_hz = 70,
+        .dyn_lpf_dterm_max_hz = 170,
         .launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,
         .launchControlThrottlePercent = 20,
         .launchControlAngleLimit = 0,

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -204,13 +204,13 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyroMovementCalibrationThreshold = 48;
     gyroConfig->gyro_sync_denom = GYRO_SYNC_DENOM_DEFAULT;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
-    gyroConfig->gyro_lowpass_type = FILTER_BIQUAD;
+    gyroConfig->gyro_lowpass_type = FILTER_PT1;
     gyroConfig->gyro_lowpass_hz = 150;  // NOTE: dynamic lpf is enabled by default so this setting is actually
                                         // overridden and the static lowpass 1 is disabled. We can't set this
                                         // value to 0 otherwise Configurator versions 10.4 and earlier will also
                                         // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
     gyroConfig->gyro_lowpass2_type = FILTER_PT1;
-    gyroConfig->gyro_lowpass2_hz = 150;
+    gyroConfig->gyro_lowpass2_hz = 250;
     gyroConfig->gyro_high_fsr = false;
     gyroConfig->gyro_to_use = GYRO_CONFIG_USE_GYRO_DEFAULT;
     gyroConfig->gyro_soft_notch_hz_1 = 0;
@@ -221,8 +221,8 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyro_offset_yaw = 0;
     gyroConfig->yaw_spin_recovery = true;
     gyroConfig->yaw_spin_threshold = 1950;
-    gyroConfig->dyn_lpf_gyro_min_hz = 150;
-    gyroConfig->dyn_lpf_gyro_max_hz = 450;
+    gyroConfig->dyn_lpf_gyro_min_hz = 200;
+    gyroConfig->dyn_lpf_gyro_max_hz = 500;
     gyroConfig->dyn_notch_range = DYN_NOTCH_RANGE_AUTO;
     gyroConfig->dyn_notch_width_percent = 8;
     gyroConfig->dyn_notch_q = 120;


### PR DESCRIPTION
Evolutionary changes to the original 4.0 defaults...

Intended to reduce chance of D-mediated flyaways on arming and tested to show improved flight performance due to reduced gyro delay.

Changes:

- Gyro filtering dynamic reverts back to PT1, to provide less delay, and in recognition that gyro filtering was more than required with the biquad.  Dynamic gyro lowpass setpoints are higher (200->500 vs 150->450) due to lower reach with the PT1.  The static gyro biquad at 150 was lower than needed, and has been increased to 250.  Markedly less gyro delay as a result.  Dynamic Notch FFT still tracks well, however, and overall gyro noise goes up, but not to unreasonable levels.

- Significantly stronger D term filtering, especially at low throttle, to markedly reduce the risk of arming flyaways, and deal with the greater incoming gyro noise.  The Dynamic D biquad is now set almost twice as low (70-170 vs 150-250).  This provides strong cut at 100hz where D resonance flyaways seemed to often be driven from.  The 'safety' lowpass2 PT1 can now go up to 150hz from 100hz.  These changes results in a D noise contribution that is typically not much greater than the P contribution, keeping very cool motors despite the lesser gyro filters.  

These changes have been well tested using PID Toolbox on a range of quads.

Flight behaviour is very good; although there is more delay in D, this is offset by the reduced gyro delay.

credit to Mark Spatz for the biquad 70-170 idea, and to the many individual testers.