### PR TITLE
[VTX] SmartAudio conversion to VTX table and V2.1 implementation

### DIFF
--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -207,8 +207,8 @@ const char *vtxCommonLookupPowerName(const vtxDevice_t *vtxDevice, int index)
 
 uint16_t vtxCommonLookupPowerValue(const vtxDevice_t *vtxDevice, int index)
 {
-    if (vtxDevice) {
-        return vtxDevice->powerValues[index];
+    if (vtxDevice && index > 0) {
+        return vtxDevice->powerValues[index - 1];
     } else {
         return 0;
     }

--- a/src/main/drivers/vtx_table.c
+++ b/src/main/drivers/vtx_table.c
@@ -69,7 +69,7 @@ void vtxTableInit(void)
     }
     vtxTableChannelNames[0] = "-";
 
-    for (int level = 0; level < config->powerLevels; level++) {
+    for (int level = 0; level < VTX_TABLE_MAX_POWER_LEVELS; level++) {
         vtxTablePowerValues[level] = config->powerValues[level];
         vtxTablePowerLabels[level + 1] = config->powerLabels[level];
     }

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -25,6 +25,13 @@
 
 #include "platform.h"
 
+//#define USE_SMARTAUDIO_DPRINTF
+#ifdef USE_SMARTAUDIO_DPRINTF
+#include "io/serial.h"
+#include "common/printf.h"
+#include "common/printf_serial.h"
+#endif
+
 #define VTX_SMARTAUDIO_MIN_BAND 1
 #define VTX_SMARTAUDIO_MAX_BAND 5
 #define VTX_SMARTAUDIO_MIN_CHANNEL 1
@@ -69,13 +76,8 @@ typedef struct smartAudioDevice_s {
     int8_t mode;
     uint16_t freq;
     uint16_t orfreq;
+    bool willBootIntoPitMode;
 } smartAudioDevice_t;
-
-typedef struct saPowerTable_s {
-    int rfpower;
-    int16_t valueV1;
-    int16_t valueV2;
-} saPowerTable_t;
 
 typedef struct smartAudioStat_s {
     uint16_t pktsent;
@@ -93,17 +95,16 @@ extern smartAudioStat_t saStat;
 extern uint16_t sa_smartbaud;
 extern bool saDeferred;
 
-int saDacToPowerIndex(int dac);
 void saSetBandAndChannel(uint8_t band, uint8_t channel);
 void saSetMode(int mode);
-void saSetPowerByIndex(uint8_t index);
 void saSetFreq(uint16_t freq);
 void saSetPitFreq(uint16_t freq);
 bool vtxSmartAudioInit(void);
 
 #ifdef USE_SMARTAUDIO_DPRINTF
+#define DPRINTF_SERIAL_PORT SERIAL_PORT_USART3
 extern serialPort_t *debugSerialPort;
-#define dprintf(x) if (debugSerialPort) printf x
+#define dprintf(x) if (debugSerialPort) tfp_printf x
 #else
 #define dprintf(x)
 #endif // USE_SMARTAUDIO_DPRINTF


### PR DESCRIPTION
This PR aims to further issue #7299 by transitioning SmartAudio to use the new VTX table facility introduced in #7251 and using it to implement SmartAudio V2.1. It should also fix #7979 and #7336.

The following features have been implemented:
- PIT mode enable and disable without power cycle
- dbm-based power selection
- persistant RACE and FREE opmodels that cause the vtx to power up in PIT mode or normal mode

At this time, vtxtables are NOT set up automatically. Therefore the user has to manually set them correctly.

For TBS Unify Pro32 Nano 5G8:

```
vtxtable bands 5
vtxtable channels 8
vtxtable band 1 BOSCAM_A  A 5865 5845 5825 5805 5785 5765 5745 5725
vtxtable band 2 BOSCAM_B  B 5733 5752 5771 5790 5809 5828 5847 5866
vtxtable band 3 BOSCAM_E  E 5705 5685 5665 5645 5885 5905 5925 5945
vtxtable band 4 FATSHARK F 5740 5760 5780 5800 5820 5840 5860 5880
vtxtable band 5 RACEBAND R 5658 5695 5732 5769 5806 5843 5880 5917
vtxtable powerlevels 3
vtxtable powervalues  14 20 26
vtxtable powerlabels 25 100 400
```

SmartAudio V1.0 devices should use the same except for the following:
```
vtxtable powerlevels 4
vtxtable powervalues 7 16 25 40
vtxtable powerlabels 25 200 500 800
```

And SmartAudio V2.0:
```
vtxtable powerlevels 4
vtxtable powervalues 0 1 2 3
vtxtable powerlabels 25 200 500 800
```

Other SmartAudio V2.1 devices should use whatever fits them. For example the TBS Unify EVO:
```
vtxtable powerlevels 4
vtxtable powervalues  14 20 26 29
vtxtable powerlabels 25 100 400 800
```
Please note that the band setup is essentially ignored by SmartAudio and it just transmits the selected band and channel indices, which are then translated by the vtx using its own frequency table. This could be changed in the future by always running the vtx in user freq mode. However, this would break channel displays of the vtx such as leds, built-in osd or CRSF telemetry.
Also note that Lua script for will be out of sync if they embed a fixed power table. This problem is also present on tramp devices (see #7540).

The code has been developed and tested with a TBS Unify Pro32 Nano 5G8 and a MATEKF722SE. Unfortunately, i don't have any other vtxes so i cannot test any other ones.
Testing especially with SmartAudio V1 and V2.0 devices would be good.