### PR TITLE
Update flash drivers to support QuadSPI

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -33,6 +33,7 @@
 #include "flash_w25n01g.h"
 #include "flash_w25m.h"
 #include "drivers/bus_spi.h"
+#include "drivers/bus_quadspi.h"
 #include "drivers/io.h"
 #include "drivers/time.h"
 
@@ -41,15 +42,49 @@ static busDevice_t *busdev;
 
 static flashDevice_t flashDevice;
 
+#define FLASH_INSTRUCTION_RDID 0x9F
+
+#ifdef USE_QUADSPI
+static bool flashQuadSpiInit(const flashConfig_t *flashConfig)
+{
+    QUADSPI_TypeDef *quadSpiInstance = quadSpiInstanceByDevice(QUADSPI_CFG_TO_DEV(flashConfig->quadSpiDevice));
+    quadSpiSetDivisor(quadSpiInstance, QUADSPI_CLOCK_INITIALISATION);
+
+    uint8_t readIdResponse[4];
+    bool status = quadSpiReceive1LINE(quadSpiInstance, FLASH_INSTRUCTION_RDID, 8, readIdResponse, sizeof(readIdResponse));
+    if (!status) {
+        return false;
+    }
+
+    flashDevice.io.mode = FLASHIO_QUADSPI;
+    flashDevice.io.handle.quadSpi = quadSpiInstance;
+
+    // Manufacturer, memory type, and capacity
+    uint32_t chipID = (readIdResponse[0] << 16) | (readIdResponse[1] << 8) | (readIdResponse[2]);
+
+#ifdef USE_FLASH_W25N01G
+    quadSpiSetDivisor(quadSpiInstance, QUADSPI_CLOCK_ULTRAFAST);
+
+    if (w25n01g_detect(&flashDevice, chipID)) {
+        return true;
+    }
+#endif
+
+    return false;
+}
+#endif  // USE_QUADSPI
+
+#ifdef USE_SPI
+
 void flashPreInit(const flashConfig_t *flashConfig)
 {
     spiPreinitRegister(flashConfig->csTag, IOCFG_IPU, 1);
 }
 
-// Read chip identification and send it to device detect
-
-bool flashInit(const flashConfig_t *flashConfig)
+static bool flashSpiInit(const flashConfig_t *flashConfig)
 {
+    // Read chip identification and send it to device detect
+
     busdev = &busInstance;
 
     if (flashConfig->csTag) {
@@ -85,11 +120,10 @@ bool flashInit(const flashConfig_t *flashConfig)
 #endif
 #endif
 
-    flashDevice.busdev = busdev;
+    flashDevice.io.mode = FLASHIO_SPI;
+    flashDevice.io.handle.busdev = busdev;
 
-#define SPIFLASH_INSTRUCTION_RDID 0x9F
-
-    const uint8_t out[] = { SPIFLASH_INSTRUCTION_RDID, 0, 0, 0, 0 };
+    const uint8_t out[] = { FLASH_INSTRUCTION_RDID, 0, 0, 0, 0 };
 
     delay(50); // short delay required after initialisation of SPI device instance.
 
@@ -97,18 +131,18 @@ bool flashInit(const flashConfig_t *flashConfig)
      * Some newer chips require one dummy byte to be read; we can read
      * 4 bytes for these chips while retaining backward compatibility.
      */
-    uint8_t in[5];
-    in[1] = in[2] = 0;
+    uint8_t readIdResponse[5];
+    readIdResponse[1] = readIdResponse[2] = 0;
 
     // Clearing the CS bit terminates the command early so we don't have to read the chip UID:
 #ifdef USE_SPI_TRANSACTION
-    spiBusTransactionTransfer(busdev, out, in, sizeof(out));
+    spiBusTransactionTransfer(busdev, out, readIdResponse, sizeof(out));
 #else
-    spiBusTransfer(busdev, out, in, sizeof(out));
+    spiBusTransfer(busdev, out, readIdResponse, sizeof(out));
 #endif
 
     // Manufacturer, memory type, and capacity
-    uint32_t chipID = (in[1] << 16) | (in[2] << 8) | (in[3]);
+    uint32_t chipID = (readIdResponse[1] << 16) | (readIdResponse[2] << 8) | (readIdResponse[3]);
 
 #ifdef USE_FLASH_M25P16
     if (m25p16_detect(&flashDevice, chipID)) {
@@ -123,7 +157,7 @@ bool flashInit(const flashConfig_t *flashConfig)
 #endif
 
     // Newer chips
-    chipID = (in[2] << 16) | (in[3] << 8) | (in[4]);
+    chipID = (readIdResponse[2] << 16) | (readIdResponse[3] << 8) | (readIdResponse[4]);
 
 #ifdef USE_FLASH_W25N01G
     if (w25n01g_detect(&flashDevice, chipID)) {
@@ -138,6 +172,27 @@ bool flashInit(const flashConfig_t *flashConfig)
 #endif
 
     spiPreinitByTag(flashConfig->csTag);
+
+    return false;
+}
+#endif // USE_SPI
+
+bool flashInit(const flashConfig_t *flashConfig)
+{
+#ifdef USE_SPI
+    bool useSpi = (SPI_CFG_TO_DEV(flashConfig->spiDevice) != SPIINVALID);
+
+    if (useSpi) {
+        return flashSpiInit(flashConfig);
+    }
+#endif
+
+#ifdef USE_QUADSPI
+    bool useQuadSpi = (QUADSPI_CFG_TO_DEV(flashConfig->quadSpiDevice) != QUADSPIINVALID);
+    if (useQuadSpi) {
+        return flashQuadSpiInit(flashConfig);
+    }
+#endif
 
     return false;
 }

--- a/src/main/drivers/flash_impl.h
+++ b/src/main/drivers/flash_impl.h
@@ -28,8 +28,23 @@
 
 struct flashVTable_s;
 
+typedef enum {
+    FLASHIO_NONE = 0,
+    FLASHIO_SPI,
+    FLASHIO_QUADSPI
+} flashDeviceIoMode_e;
+
+typedef struct flashDeviceIO_s {
+    union {
+        busDevice_t *busdev; // Device interface dependent handle (spi/i2c)
+    #ifdef USE_QUADSPI
+        QUADSPI_TypeDef *quadSpi;
+    #endif
+    } handle;
+    flashDeviceIoMode_e mode;
+} flashDeviceIO_t;
+
 typedef struct flashDevice_s {
-    busDevice_t *busdev;
     const struct flashVTable_s *vTable;
     flashGeometry_t geometry;
     uint32_t currentWriteAddress;
@@ -38,6 +53,7 @@ typedef struct flashDevice_s {
     // for writes. This allows us to avoid polling for writable status
     // when it is definitely ready already.
     bool couldBeBusy;
+    flashDeviceIO_t io;
 } flashDevice_t;
 
 typedef struct flashVTable_s {

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -84,7 +84,7 @@ static bool w25m_isReady(flashDevice_t *fdevice)
 
     for (int die = 0 ; die < dieCount ; die++) {
         if (dieDevice[die].couldBeBusy) {
-            w25m_dieSelect(fdevice->busdev, die);
+            w25m_dieSelect(fdevice->io.handle.busdev, die);
             if (!dieDevice[die].vTable->isReady(&dieDevice[die])) {
                 return false;
             }
@@ -115,8 +115,9 @@ bool w25m_detect(flashDevice_t *fdevice, uint32_t chipID)
         dieCount = 2;
 
         for (int die = 0 ; die < dieCount ; die++) {
-            w25m_dieSelect(fdevice->busdev, die);
-            dieDevice[die].busdev = fdevice->busdev;
+            w25m_dieSelect(fdevice->io.handle.busdev, die);
+            dieDevice[die].io.handle.busdev = fdevice->io.handle.busdev;
+            dieDevice[die].io.mode = fdevice->io.mode;
             m25p16_detect(&dieDevice[die], JEDEC_ID_WINBOND_W25Q256);
         }
 
@@ -147,7 +148,7 @@ void w25m_eraseSector(flashDevice_t *fdevice, uint32_t address)
 {
     int dieNumber = address / dieSize;
 
-    w25m_dieSelect(fdevice->busdev, dieNumber);
+    w25m_dieSelect(fdevice->io.handle.busdev, dieNumber);
 
     dieDevice[dieNumber].vTable->eraseSector(&dieDevice[dieNumber], address % dieSize);
 }
@@ -155,7 +156,7 @@ void w25m_eraseSector(flashDevice_t *fdevice, uint32_t address)
 void w25m_eraseCompletely(flashDevice_t *fdevice)
 {
     for (int dieNumber = 0 ; dieNumber < dieCount ; dieNumber++) {
-        w25m_dieSelect(fdevice->busdev, dieNumber);
+        w25m_dieSelect(fdevice->io.handle.busdev, dieNumber);
         dieDevice[dieNumber].vTable->eraseCompletely(&dieDevice[dieNumber]);
     }
 }
@@ -168,7 +169,7 @@ void w25m_pageProgramBegin(flashDevice_t *fdevice, uint32_t address)
     UNUSED(fdevice);
 
     currentWriteDie = address / dieSize;
-    w25m_dieSelect(fdevice->busdev, currentWriteDie);
+    w25m_dieSelect(fdevice->io.handle.busdev, currentWriteDie);
     currentWriteAddress = address % dieSize;
     dieDevice[currentWriteDie].vTable->pageProgramBegin(&dieDevice[currentWriteDie], currentWriteAddress);
 }
@@ -210,7 +211,7 @@ int w25m_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer, in
         uint32_t dieAddress = address % dieSize;
         tlen = MIN(dieAddress + rlen, dieSize) - dieAddress;
 
-        w25m_dieSelect(fdevice->busdev, dieNumber);
+        w25m_dieSelect(fdevice->io.handle.busdev, dieNumber);
 
         rbytes = dieDevice[dieNumber].vTable->readBytes(&dieDevice[dieNumber], dieAddress, buffer, tlen);
 

--- a/src/main/pg/flash.c
+++ b/src/main/pg/flash.c
@@ -26,6 +26,7 @@
 #ifdef USE_FLASH_CHIP
 
 #include "drivers/bus_spi.h"
+#include "drivers/bus_quadspi.h"
 #include "drivers/io.h"
 
 #include "pg/pg.h"
@@ -33,11 +34,20 @@
 
 #include "flash.h"
 
+#ifndef FLASH_CS_PIN
+#define FLASH_CS_PIN NONE
+#endif
+
 PG_REGISTER_WITH_RESET_FN(flashConfig_t, flashConfig, PG_FLASH_CONFIG, 0);
 
 void pgResetFn_flashConfig(flashConfig_t *flashConfig)
 {
     flashConfig->csTag = IO_TAG(FLASH_CS_PIN);
+#if defined(USE_SPI) && defined(FLASH_SPI_INSTANCE)
     flashConfig->spiDevice = SPI_DEV_TO_CFG(spiDeviceByInstance(FLASH_SPI_INSTANCE));
+#endif
+#if defined(USE_QUADSPI) && defined(FLASH_QUADSPI_INSTANCE)
+    flashConfig->quadSpiDevice = QUADSPI_DEV_TO_CFG(quadSpiDeviceByInstance(FLASH_QUADSPI_INSTANCE));
+#endif
 }
 #endif

--- a/src/main/pg/flash.h
+++ b/src/main/pg/flash.h
@@ -29,6 +29,7 @@
 typedef struct flashConfig_s {
     ioTag_t csTag;
     uint8_t spiDevice;
+    uint8_t quadSpiDevice;
 } flashConfig_t;
 
 PG_DECLARE(flashConfig_t, flashConfig);


### PR DESCRIPTION
Update flash drivers to support QuadSPI:
- flash_w25n01g update for QuadSPI support
- flash_m25p16 update for QuadSPI support
- w25m driver update for QuadSPI support

Additional changes:
- Use 100Mhz (ULTRAFAST) clock for QuadSPI w25n01
- Conditionalize QUADSPI code in w25n01g driver
