### PR TITLE
Remove deprecated ACC_ALIGN on Airbot F7

### DIFF
--- a/src/main/target/AIRBOTF7/target.h
+++ b/src/main/target/AIRBOTF7/target.h
@@ -59,8 +59,6 @@
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_MPU6500
-#define ACC_1_ALIGN             CW90_DEG
-#define ACC_2_ALIGN             CW0_DEG
 
 // *************** OSD **************************
 


### PR DESCRIPTION
Removed deprecated ACC_ALIGN for this new merged target