### PR TITLE
Remove deprecated USE_MULTI_GYRO

### DIFF
--- a/src/main/target/AG3X/target.h
+++ b/src/main/target/AG3X/target.h
@@ -49,8 +49,6 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_SPI_MPU6500
 
-#define USE_MULTI_GYRO
-
 #define GYRO_1_SPI_INSTANCE     SPI1
 #define GYRO_1_CS_PIN           PA4
 #define GYRO_1_EXTI_PIN         NONE

--- a/src/main/target/AIRBOTF7/target.h
+++ b/src/main/target/AIRBOTF7/target.h
@@ -41,7 +41,6 @@
 #define SPI3_NSS_PIN            PD2
 
 #define USE_GYRO
-#define USE_MULTI_GYRO
 #define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_SPI_MPU6500
 

--- a/src/main/target/DALRCF722DUAL/target.h
+++ b/src/main/target/DALRCF722DUAL/target.h
@@ -30,7 +30,6 @@
 #define BEEPER_PIN              PC13
 #define BEEPER_INVERTED
 
-#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PB10

--- a/src/main/target/EXF722DUAL/target.h
+++ b/src/main/target/EXF722DUAL/target.h
@@ -24,8 +24,6 @@
 
 #define USBD_PRODUCT_STRING     "EXF722DUAL"
 
-#define USE_MULTI_GYRO
-
 #define ENABLE_DSHOT_DMAR       true
 
 #define LED0_PIN                PC4

--- a/src/main/target/FLYWOOF7DUAL/target.h
+++ b/src/main/target/FLYWOOF7DUAL/target.h
@@ -31,7 +31,6 @@
 #define BEEPER_PIN              PC14
 #define BEEPER_INVERTED
 
-#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC3

--- a/src/main/target/FOXEERF722DUAL/target.h
+++ b/src/main/target/FOXEERF722DUAL/target.h
@@ -30,7 +30,6 @@
 #define BEEPER_PIN              PA4
 #define BEEPER_INVERTED
 
-#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4

--- a/src/main/target/MATEKF722SE/target.h
+++ b/src/main/target/MATEKF722SE/target.h
@@ -42,7 +42,6 @@
 #define SPI1_MISO_PIN           PA6
 #define SPI1_MOSI_PIN           PA7
 
-#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4

--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -61,8 +61,6 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_SPI_MPU6500
 
-#define USE_MULTI_GYRO
-
 #if defined(OMNIBUSF4V6)
 #define GYRO_1_CS_PIN           PA4   // Onboard IMU  
 #define GYRO_1_SPI_INSTANCE     SPI1

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -44,7 +44,6 @@
 //GYRO & ACC--------------------------------
 #define USE_ACC
 #define USE_GYRO
-#define USE_MULTI_GYRO
 // ICM-20608-G
 #define USE_ACC_SPI_MPU6500
 #define USE_GYRO_SPI_MPU6500

--- a/src/main/target/SPRACINGF7DUAL/target.h
+++ b/src/main/target/SPRACINGF7DUAL/target.h
@@ -31,7 +31,6 @@
 
 #define TEST_SOUND // for factory testing audio output
 
-#define USE_MULTI_GYRO
 //#define DEBUG_MODE DEBUG_DUAL_GYRO_DIFF
 
 #define ENABLE_DSHOT_DMAR       true


### PR DESCRIPTION
`USE_MULTI_GYRO` is defined in `common_pre.h `, then all definitions of targets  are deprecated. I have removed it.