### PR TITLE
Increase async FAT filesystem cache sectors to prevent blackbox header corruption

### DIFF
--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -58,7 +58,7 @@
     #define ONLY_EXPOSE_FOR_TESTING static
 #endif
 
-#define AFATFS_NUM_CACHE_SECTORS 8
+#define AFATFS_NUM_CACHE_SECTORS 10
 
 // FAT filesystems are allowed to differ from these parameters, but we choose not to support those weird filesystems:
 #define AFATFS_SECTOR_SIZE  512


### PR DESCRIPTION
Fixes #6490 

In testing I found that once the blackbox header exceeded 3072 bytes (3K) it would be truncated and overwritten with logging data. 3K would be 6 sectors and it looks like when it tried to flow over into 7 sectors the previous cache of 8 sectors was insufficient when considering the other FAT filesystem overhead. Increased the cache to 10 sectors (1K extra memory usage) and the problem is resolved. If the blackbox header continues to expand in size this will have to be revisited.
