### PR TITLE
Add tenths of a second OSD timer precision option

### DIFF
--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -192,6 +192,7 @@ typedef enum {
 typedef enum {
     OSD_TIMER_PREC_SECOND,
     OSD_TIMER_PREC_HUNDREDTHS,
+    OSD_TIMER_PREC_TENTHS,
     OSD_TIMER_PREC_COUNT
 } osd_timer_precision_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -286,6 +286,12 @@ void osdFormatTime(char * buff, osd_timer_precision_e precision, timeUs_t time)
             tfp_sprintf(buff, "%02d:%02d.%02d", minutes, seconds, hundredths);
             break;
         }
+    case OSD_TIMER_PREC_TENTHS:
+        {
+            const int tenths = (time / 100000) % 10;
+            tfp_sprintf(buff, "%02d:%02d.%01d", minutes, seconds, tenths);
+            break;
+        }
     }
 }
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -414,6 +414,9 @@ TEST(OsdTest, TestStatsMetric)
     // using metric unit system
     osdConfigMutable()->units = OSD_UNIT_METRIC;
 
+    // set timer 1 configuration to tenths precision
+    osdConfigMutable()->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_TENTHS, 0);
+
     // and
     // default state values are set
     setDefaultSimulationState();
@@ -446,7 +449,7 @@ TEST(OsdTest, TestStatsMetric)
     // statistics screen should display the following
     int row = 3;
     displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
-    displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:07.50");
+    displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:07.5");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:02");
     displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      : 2.0%c", SYM_M);
     displayPortTestBufferSubstring(2, row++, "MAX SPEED         : 28");


### PR DESCRIPTION
Currently the timers support full second and hundredth of a second display precision. This adds a tenth of a second option.

Related Configurator PR: https://github.com/betaflight/betaflight-configurator/pull/1443