### PR TITLE
Add common_deprecated_post.h to flag deprecated target defines

### DIFF
--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -146,5 +146,6 @@
 
 #include "target/common_pre.h"
 #include "target.h"
+#include "target/common_deprecated_post.h"
 #include "target/common_post.h"
 #include "target/common_defaults_post.h"

--- a/src/main/target/AIRBOTF7/target.h
+++ b/src/main/target/AIRBOTF7/target.h
@@ -144,7 +144,6 @@
 #define CURRENT_METER_SCALE_DEFAULT 179
 
 #define USE_ESCSERIAL
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff

--- a/src/main/target/FF_RACEPIT/target.h
+++ b/src/main/target/FF_RACEPIT/target.h
@@ -148,7 +148,6 @@
 /*---------------------------------*/
 
 /*-------------ESCs----------------*/
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN   PB0  // (HARDWARE=0)
 /*---------------------------------*/

--- a/src/main/target/FLYWOOF7DUAL/target.h
+++ b/src/main/target/FLYWOOF7DUAL/target.h
@@ -52,13 +52,9 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_ICM20689
 
-#define ACC_MPU6000_1_ALIGN           CW270_DEG
-#define GYRO_MPU6000_1_ALIGN          CW270_DEG
-#define GYRO_1_ALIGN                GYRO_MPU6000_1_ALIGN
+#define GYRO_1_ALIGN                CW270_DEG
 
-#define ACC_ICM20689_2_ALIGN         CW270_DEG
-#define GYRO_ICM20689_2_ALIGN        CW270_DEG
-#define GYRO_2_ALIGN                GYRO_ICM20689_2_ALIGN 
+#define GYRO_2_ALIGN                CW270_DEG 
 
 #define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_2
 

--- a/src/main/target/JHEF7DUAL/target.h
+++ b/src/main/target/JHEF7DUAL/target.h
@@ -33,7 +33,6 @@
 #define BEEPER_PIN              PC15
 #define BEEPER_INVERTED
 
-#define USE_DUAL_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4
@@ -56,13 +55,9 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_ICM20689
 
-#define ACC_ICM20689_1_ALIGN    CW90_DEG
-#define GYRO_ICM20689_1_ALIGN   CW90_DEG
-#define GYRO_1_ALIGN            GYRO_ICM20689_1_ALIGN 
+#define GYRO_1_ALIGN            CW90_DEG 
 
-#define ACC_MPU6000_2_ALIGN     CW90_DEG
-#define GYRO_MPU6000_2_ALIGN    CW90_DEG
-#define GYRO_2_ALIGN            GYRO_MPU6000_2_ALIGN
+#define GYRO_2_ALIGN            CW90_DEG
 
 #define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_1
 
@@ -154,7 +149,6 @@
 #define USE_LED_STRIP
 
 #define USE_ESCSERIAL
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define USE_PINIO
 #define PINIO1_PIN              PC14 // VTX power switcher

--- a/src/main/target/OMNIBUSF4NANOV7/target.h
+++ b/src/main/target/OMNIBUSF4NANOV7/target.h
@@ -137,7 +137,6 @@
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PA3
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff

--- a/src/main/target/OMNIBUSF7NANOV7/target.h
+++ b/src/main/target/OMNIBUSF7NANOV7/target.h
@@ -130,7 +130,6 @@
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PA3
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff

--- a/src/main/target/RUSHCORE7/target.h
+++ b/src/main/target/RUSHCORE7/target.h
@@ -129,10 +129,6 @@
 #define SERIALRX_UART                       SERIAL_PORT_USART2
 #define SERIALRX_PROVIDER                   SERIALRX_SBUS
 
-
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
-
-
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff

--- a/src/main/target/UAVPNG030MINI/target.h
+++ b/src/main/target/UAVPNG030MINI/target.h
@@ -70,7 +70,6 @@
 #define SDCARD_SPI_CS_PIN               SPI2_NSS_PIN
 #warning Missing channel for F4/F7 spec dma 1 stream 4; DMA_OPT assumed as 0
 #define SPI2_TX_DMA_OPT                         0     // DMA 1 Stream 4 Channel unknown
-#define SDCARD_DMA_CHANNEL                      DMA_Channel_0
 #endif
 
 #define USE_VCP

--- a/src/main/target/VGOODRCF4/target.h
+++ b/src/main/target/VGOODRCF4/target.h
@@ -37,7 +37,6 @@
 
 #define USE_EXTI
 #define USE_GYRO_EXTI
-//#define MPU_INT_EXTI
 #define GYRO_1_EXTI_PIN      	PC3 
 
 #define USE_MPU_DATA_READY_SIGNAL
@@ -176,7 +175,6 @@
 #define CURRENT_METER_SCALE_DEFAULT 179
 
 #define USE_ESCSERIAL
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 //--------------------------------BOARD RESOURCES-----------------------------
 #define TARGET_IO_PORTA 0xffff

--- a/src/main/target/XILOF4/target.h
+++ b/src/main/target/XILOF4/target.h
@@ -141,7 +141,6 @@
 
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_PIN  PA3
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff

--- a/src/main/target/common_deprecated_post.h
+++ b/src/main/target/common_deprecated_post.h
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Flag any deprecated defines with compile errors so they
+// can be cleaned up and not further propagated.
+
+#pragma once
+
+#ifdef ACC_1_ALIGN
+#error "The ACC_1_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_2_ALIGN
+#error "The ACC_2_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_ICM20689_ALIGN
+#error "The ACC_ICM20689_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_MPU6000_1_ALIGN
+#error "The ACC_MPU6000_1_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_MPU6000_2_ALIGN
+#error "The ACC_MPU6000_2_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_MPU6000_ALIGN
+#error "The ACC_MPU6000_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_MPU6500_1_ALIGN
+#error "The ACC_MPU6500_1_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_MPU6500_2_ALIGN
+#error "The ACC_MPU6500_2_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ACC_MPU6500_ALIGN
+#error "The ACC_MPU6500_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_ICM20689_ALIGN
+#error "The GYRO_ICM20689_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_MPU6000_1_ALIGN
+#error "The GYRO_MPU6000_1_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_MPU6000_2_ALIGN
+#error "The GYRO_MPU6000_2_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_MPU6000_ALIGN
+#error "The GYRO_MPU6000_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_MPU6500_1_ALIGN
+#error "The GYRO_MPU6500_1_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_MPU6500_2_ALIGN
+#error "The GYRO_MPU6500_2_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef GYRO_MPU6500_ALIGN
+#error "The GYRO_MPU6000_ALIGN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ICM20689_CS_PIN
+#error "The ICM20689_CS_PIN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef ICM20689_SPI_INSTANCE
+#error "The ICM20689_SPI_INSTANCE define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef MPU_INT_EXTI
+#error "The MPU_INT_EXTI define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef MPU6000_CS_PIN
+#error "The MPU6000_CS_PIN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef MPU6000_SPI_INSTANCE
+#error "The MPU6000_SPI_INSTANCE define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef MPU6500_CS_PIN
+#error "The MPU6500_CS_PIN define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef MPU6500_SPI_INSTANCE
+#error "The MPU6500_SPI_INSTANCE define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef SDCARD_DMA_CHANNEL
+#error "The SDCARD_DMA_CHANNEL define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER
+#error "The SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER define should not be part of the target definition"
+#endif
+
+#ifdef SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER
+#error "The SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER define should not be part of the target definition"
+#endif
+
+#ifdef USE_DUAL_GYRO
+#error "The USE_DUAL_GYRO define has been deprecated - please remove from the target definition"
+#endif
+
+#ifdef USE_SERIAL_4WAY_BLHELI_INTERFACE
+#error "The USE_SERIAL_4WAY_BLHELI_INTERFACE define should not be part of the target definition"
+#endif
+


### PR DESCRIPTION
Checks for deprecated target defines and generates an error with message at compile time. Will hopefully limit the regurgitation of old defines as new targets are created (and copied from old versions).

I had hoped to do a macro solution rather than hardcoding the specific messages but I don't see any way to do that. The C preprocessor only makes one macro expansion - unless I'm missing something.

The list currently included was generated by comparing `target.h` files for a number of targets to their 3.5 versions looking for defines that were removed.