### PR TITLE
Really fixed flash erasing.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2239,7 +2239,6 @@ static void cliFlashErase(char *cmdline)
 
     bufWriterFlush(cliWriter);
     flashfsEraseCompletely();
-    flashfsInit();
 
     while (!flashfsIsReady()) {
 #ifndef MINIMAL_CLI

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2342,7 +2342,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
 #ifdef USE_FLASHFS
     case MSP_DATAFLASH_ERASE:
         flashfsEraseCompletely();
-        flashfsInit();
+
         break;
 #endif
 


### PR DESCRIPTION
Before:

```
Entering CLI Mode, type 'exit' to return, or 'help'

# flash_info 
Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216, usedSize=416022

# flash_erase 
Erasing, please wait ... 
..........................................................................................................................
..........................................................................................................................
..........................................................................................................................
..........................................................................................................................
.....................................
Done.

# flash_info
Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216, usedSize=16777216
```

=> storing more data without a reboot does not work because the flash storage is reported as full
(Also, the behaviour in the GUI is the same, with the flash storage being reported as full after erasing it.)

After:

```
Entering CLI Mode, type 'exit' to return, or 'help'

# flash_info
Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216, usedSize=310021

# flash_erase
Erasing, please wait ... 
..........................................................................................................................
..........................................................................................................................
..........................................................................................................................
..........................................................................................................................
.....................................
Done.

# flash_info
Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216, usedSize=0
```

This change enables storing of new logs right after erasing the flash storage, without a reboot.

Fixes the problem introduced by #8237.
