### PR TITLE
Changed 'timer' output to list timers based on alternate function.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5108,27 +5108,28 @@ static void cliDmaopt(char *cmdline)
         }
 
         char optvalString[DMA_OPT_STRING_BUFSIZE];
-        char orgvalString[DMA_OPT_STRING_BUFSIZE];
         optToString(optval, optvalString);
+
+        char orgvalString[DMA_OPT_STRING_BUFSIZE];
         optToString(orgval, orgvalString);
 
         if (optval != orgval) {
             if (entry) {
                 *optaddr = optval;
 
-                cliPrintLinef("dma %s %d: changed from %s to %s", entry->device, DMA_OPT_UI_INDEX(index), orgvalString, optvalString);
+                cliPrintLinef("# dma %s %d: changed from %s to %s", entry->device, DMA_OPT_UI_INDEX(index), orgvalString, optvalString);
             } else {
 #if defined(USE_TIMER_MGMT)
                 timerIoConfig->dmaopt = optval;
 #endif
 
-                cliPrintLinef("dma pin %c%02d: changed from %s to %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag), orgvalString, optvalString);
+                cliPrintLinef("# dma pin %c%02d: changed from %s to %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag), orgvalString, optvalString);
             }
         } else {
             if (entry) {
-                cliPrintLinef("dma %s %d: no change: %s", entry->device, DMA_OPT_UI_INDEX(index), orgvalString);
+                cliPrintLinef("# dma %s %d: no change: %s", entry->device, DMA_OPT_UI_INDEX(index), orgvalString);
             } else {
-                cliPrintLinef("dma %c%02d: no change: %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag),orgvalString);
+                cliPrintLinef("# dma %c%02d: no change: %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag),orgvalString);
             }
         }
     }
@@ -5250,17 +5251,17 @@ static void cliResource(char *cmdline)
 #ifdef USE_TIMER_MGMT
 static void printTimerDetails(const ioTag_t ioTag, const unsigned timerIndex, const bool equalsDefault, const dumpFlags_t dumpMask, printFn *printValue)
 {
-    const char *format = "timer %c%02d %d";
+    const char *format = "timer %c%02d af%d";
     const char *emptyFormat = "timer %c%02d NONE";
 
     if (timerIndex > 0) {
+        const timerHardware_t *timer = timerGetByTagAndIndex(ioTag, timerIndex);
         const bool printDetails = printValue(dumpMask, equalsDefault, format,
             IO_GPIOPortIdxByTag(ioTag) + 'A',
             IO_GPIOPinIdxByTag(ioTag),
-            timerIndex - 1
+            timer->alternateFunction
         );
         if (printDetails) {
-            const timerHardware_t *timer = timerGetByTagAndIndex(ioTag, timerIndex);
             printValue(dumpMask, false,
                 "# pin %c%02d: TIM%d CH%d%s (AF%d)",
                 IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag),
@@ -5337,6 +5338,17 @@ static void printTimer(dumpFlags_t dumpMask, const char *headingStr)
 }
 
 #define TIMER_INDEX_UNDEFINED -1
+#define TIMER_AF_STRING_BUFSIZE 5
+
+static void alternateFunctionToString(const ioTag_t ioTag, const int index, char *buf)
+{
+    const timerHardware_t *timer = timerGetByTagAndIndex(ioTag, index + 1);
+    if (!timer) {
+        memcpy(buf, "NONE", TIMER_AF_STRING_BUFSIZE);
+    } else {
+        tfp_sprintf(buf, "af%d", timer->alternateFunction);
+    }
+}
 
 static void cliTimer(char *cmdline)
 {
@@ -5401,12 +5413,11 @@ static void cliTimer(char *cmdline)
             /* output the list of available options */
             const timerHardware_t *timer;
             for (unsigned index = 0; (timer = timerGetByTagAndIndex(ioTag, index + 1)); index++) {
-                cliPrintLinef("# %d: TIM%d CH%d%s (AF%d)",
-                    index,
+                cliPrintLinef("# af%d: TIM%d CH%d%s",
+                    timer->alternateFunction,
                     timerGetTIMNumber(timer->tim),
                     CC_INDEX_FROM_CHANNEL(timer->channel) + 1,
-                    timer->output & TIMER_OUTPUT_N_CHANNEL ? "N" : "",
-                    timer->alternateFunction
+                    timer->output & TIMER_OUTPUT_N_CHANNEL ? "N" : ""
                 );
             }
 
@@ -5448,15 +5459,15 @@ static void cliTimer(char *cmdline)
         timerIOConfigMutable(timerIOIndex)->dmaopt = DMA_OPT_UNUSED;
 
         char optvalString[DMA_OPT_STRING_BUFSIZE];
-        optToString(timerIndex, optvalString);
+        alternateFunctionToString(ioTag, timerIndex, optvalString);
 
         char orgvalString[DMA_OPT_STRING_BUFSIZE];
-        optToString(oldTimerIndex, orgvalString);
+        alternateFunctionToString(ioTag, oldTimerIndex, orgvalString);
 
         if (timerIndex == oldTimerIndex) {
-            cliPrintLinef("timer %c%02d: no change: %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag), orgvalString);
+            cliPrintLinef("# timer %c%02d: no change: %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag), orgvalString);
         } else {
-            cliPrintLinef("timer %c%02d: changed from %s to %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag), orgvalString, optvalString);
+            cliPrintLinef("# timer %c%02d: changed from %s to %s", IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag), orgvalString, optvalString);
         }
 
         return;
@@ -5924,7 +5935,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("tasks", "show task stats", NULL, cliTasks),
 #endif
 #ifdef USE_TIMER_MGMT
-    CLI_COMMAND_DEF("timer", "show/set timers", "<> | <pin> list | <pin> [<option>|af<altenate function>|none] | list | show", cliTimer),
+    CLI_COMMAND_DEF("timer", "show/set timers", "<> | <pin> list | <pin> [af<altenate function>|none|<option(deprecated)>] | list | show", cliTimer),
 #endif
     CLI_COMMAND_DEF("version", "show version", NULL, cliVersion),
 #ifdef USE_VTX_CONTROL

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5251,7 +5251,7 @@ static void cliResource(char *cmdline)
 #ifdef USE_TIMER_MGMT
 static void printTimerDetails(const ioTag_t ioTag, const unsigned timerIndex, const bool equalsDefault, const dumpFlags_t dumpMask, printFn *printValue)
 {
-    const char *format = "timer %c%02d af%d";
+    const char *format = "timer %c%02d AF%d";
     const char *emptyFormat = "timer %c%02d NONE";
 
     if (timerIndex > 0) {
@@ -5346,7 +5346,7 @@ static void alternateFunctionToString(const ioTag_t ioTag, const int index, char
     if (!timer) {
         memcpy(buf, "NONE", TIMER_AF_STRING_BUFSIZE);
     } else {
-        tfp_sprintf(buf, "af%d", timer->alternateFunction);
+        tfp_sprintf(buf, "AF%d", timer->alternateFunction);
     }
 }
 
@@ -5413,7 +5413,7 @@ static void cliTimer(char *cmdline)
             /* output the list of available options */
             const timerHardware_t *timer;
             for (unsigned index = 0; (timer = timerGetByTagAndIndex(ioTag, index + 1)); index++) {
-                cliPrintLinef("# af%d: TIM%d CH%d%s",
+                cliPrintLinef("# AF%d: TIM%d CH%d%s",
                     timer->alternateFunction,
                     timerGetTIMNumber(timer->tim),
                     CC_INDEX_FROM_CHANNEL(timer->channel) + 1,

--- a/unified_targets/configs/AIRBOTF7.config
+++ b/unified_targets/configs/AIRBOTF7.config
@@ -40,17 +40,17 @@ resource GYRO_CS 1 D02
 resource GYRO_CS 2 C04
 
 # timer
-timer A15 af1
+timer A15 AF1
 # pin A15: TIM2 CH1 (AF1)
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer C08 af3
+timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
-timer B06 af2
+timer B06 AF2
 # pin B06: TIM4 CH1 (AF2)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-timer B07 af2
+timer B07 AF2
 # pin B07: TIM4 CH2 (AF2)
 
 # dma

--- a/unified_targets/configs/AIRBOTF7.config
+++ b/unified_targets/configs/AIRBOTF7.config
@@ -40,12 +40,18 @@ resource GYRO_CS 1 D02
 resource GYRO_CS 2 C04
 
 # timer
-timer A15 0
-timer A08 0
-timer C08 1
-timer B06 0
-timer C09 1
-timer B07 0
+timer A15 af1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer C08 af3
+# pin C08: TIM8 CH3 (AF3)
+timer B06 af2
+# pin B06: TIM4 CH1 (AF2)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
+timer B07 af2
+# pin B07: TIM4 CH2 (AF2)
 
 # dma
 dma pin A15 0

--- a/unified_targets/configs/ALIENFLIGHTF4.config
+++ b/unified_targets/configs/ALIENFLIGHTF4.config
@@ -60,31 +60,31 @@ resource FLASH_CS 1 B12
 set flash_spi_bus = 2
 
 # Timers
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer B00 af2
+timer B00 AF2
 # pin B00: TIM3 CH3 (AF2)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer B14 af1
+timer B14 AF1
 # pin B14: TIM1 CH2N (AF1)
-timer B15 af1
+timer B15 AF1
 # pin B15: TIM1 CH3N (AF1)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
-timer B09 af2
+timer B09 AF2
 # pin B09: TIM4 CH4 (AF2)
-timer A00 af2
+timer A00 AF2
 # pin A00: TIM5 CH1 (AF2)
-timer A01 af2
+timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
-timer C06 af3
+timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
-timer C07 af3
+timer C07 AF3
 # pin C07: TIM8 CH2 (AF3)
-timer C08 af3
+timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
 resource MOTOR 1 B08
 resource MOTOR 2 B09

--- a/unified_targets/configs/ALIENFLIGHTF4.config
+++ b/unified_targets/configs/ALIENFLIGHTF4.config
@@ -60,20 +60,32 @@ resource FLASH_CS 1 B12
 set flash_spi_bus = 2
 
 # Timers
-# timer is zero origin
-timer A08 0
-timer B00 1
-timer B01 1
-timer B14 0
-timer B15 0
-timer B08 0
-timer B09 0
-timer A00 1
-timer A01 1
-timer C06 1
-timer C07 1
-timer C08 1
-timer C09 1
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer B00 af2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
+timer B14 af1
+# pin B14: TIM1 CH2N (AF1)
+timer B15 af1
+# pin B15: TIM1 CH3N (AF1)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
+timer B09 af2
+# pin B09: TIM4 CH4 (AF2)
+timer A00 af2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 af2
+# pin A01: TIM5 CH2 (AF2)
+timer C06 af3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 af3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 af3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
 resource MOTOR 1 B08
 resource MOTOR 2 B09
 resource MOTOR 3 A00

--- a/unified_targets/configs/ALIENFLIGHTNGF7.config
+++ b/unified_targets/configs/ALIENFLIGHTNGF7.config
@@ -66,20 +66,32 @@ resource OSD_CS 1 B12
 set max7456_spi_bus = 3
 
 # Timers
-# timer is zero origin
-timer A08 0
-timer C06 1
-timer C07 0
-timer B14 1
-timer B00 0
-timer A00 1
-timer C08 1
-timer A01 1
-timer C09 1
-timer B01 1
-timer B15 0
-timer B08 0
-timer B09 0
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer C06 af3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 af2
+# pin C07: TIM3 CH2 (AF2)
+timer B14 af3
+# pin B14: TIM8 CH2N (AF3)
+timer B00 af1
+# pin B00: TIM1 CH2N (AF1)
+timer A00 af2
+# pin A00: TIM5 CH1 (AF2)
+timer C08 af3
+# pin C08: TIM8 CH3 (AF3)
+timer A01 af2
+# pin A01: TIM5 CH2 (AF2)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
+timer B15 af1
+# pin B15: TIM1 CH3N (AF1)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
+timer B09 af2
+# pin B09: TIM4 CH4 (AF2)
 resource MOTOR 1 C06
 resource MOTOR 2 C07
 resource MOTOR 3 B14

--- a/unified_targets/configs/ALIENFLIGHTNGF7.config
+++ b/unified_targets/configs/ALIENFLIGHTNGF7.config
@@ -66,31 +66,31 @@ resource OSD_CS 1 B12
 set max7456_spi_bus = 3
 
 # Timers
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer C06 af3
+timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
-timer C07 af2
+timer C07 AF2
 # pin C07: TIM3 CH2 (AF2)
-timer B14 af3
+timer B14 AF3
 # pin B14: TIM8 CH2N (AF3)
-timer B00 af1
+timer B00 AF1
 # pin B00: TIM1 CH2N (AF1)
-timer A00 af2
+timer A00 AF2
 # pin A00: TIM5 CH1 (AF2)
-timer C08 af3
+timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
-timer A01 af2
+timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer B15 af1
+timer B15 AF1
 # pin B15: TIM1 CH3N (AF1)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
-timer B09 af2
+timer B09 AF2
 # pin B09: TIM4 CH4 (AF2)
 resource MOTOR 1 C06
 resource MOTOR 2 C07

--- a/unified_targets/configs/ALIENFLIGHTNGF7_Dual.config
+++ b/unified_targets/configs/ALIENFLIGHTNGF7_Dual.config
@@ -56,20 +56,32 @@ resource OSD_CS 1 B12
 set max7456_spi_bus = 3
 
 # Timers
-# timer is zero origin
-timer A08 0
-timer C06 1
-timer C07 0
-timer B14 1
-timer B00 0
-timer A00 1
-timer C08 1
-timer A01 1
-timer C09 1
-timer B01 1
-timer B15 0
-timer B08 0
-timer B09 0
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer C06 af3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 af2
+# pin C07: TIM3 CH2 (AF2)
+timer B14 af3
+# pin B14: TIM8 CH2N (AF3)
+timer B00 af1
+# pin B00: TIM1 CH2N (AF1)
+timer A00 af2
+# pin A00: TIM5 CH1 (AF2)
+timer C08 af3
+# pin C08: TIM8 CH3 (AF3)
+timer A01 af2
+# pin A01: TIM5 CH2 (AF2)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
+timer B15 af1
+# pin B15: TIM1 CH3N (AF1)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
+timer B09 af2
+# pin B09: TIM4 CH4 (AF2)
 resource MOTOR 1 C06
 resource MOTOR 2 C07
 resource MOTOR 3 B14

--- a/unified_targets/configs/ALIENFLIGHTNGF7_Dual.config
+++ b/unified_targets/configs/ALIENFLIGHTNGF7_Dual.config
@@ -56,31 +56,31 @@ resource OSD_CS 1 B12
 set max7456_spi_bus = 3
 
 # Timers
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer C06 af3
+timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
-timer C07 af2
+timer C07 AF2
 # pin C07: TIM3 CH2 (AF2)
-timer B14 af3
+timer B14 AF3
 # pin B14: TIM8 CH2N (AF3)
-timer B00 af1
+timer B00 AF1
 # pin B00: TIM1 CH2N (AF1)
-timer A00 af2
+timer A00 AF2
 # pin A00: TIM5 CH1 (AF2)
-timer C08 af3
+timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
-timer A01 af2
+timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer B15 af1
+timer B15 AF1
 # pin B15: TIM1 CH3N (AF1)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
-timer B09 af2
+timer B09 AF2
 # pin B09: TIM4 CH4 (AF2)
 resource MOTOR 1 C06
 resource MOTOR 2 C07

--- a/unified_targets/configs/BEEROTORF4.config
+++ b/unified_targets/configs/BEEROTORF4.config
@@ -1,4 +1,4 @@
-# Betaflight / BEEROTORF4 (BRF4) 4.0.0 Mar  3 2019 / 15:29:39 (f4cbe85a2) MSP API: 1.41
+# Betaflight / STM32F405 (S405) 4.1.0 May 26 2019 / 13:44:05 (00969f3ba) MSP API: 1.42
 
 board_name BEEROTORF4
 manufacturer_id RCTI
@@ -26,7 +26,6 @@ resource INVERTER 3 C14
 resource I2C_SCL 1 B06
 resource I2C_SDA 1 B07
 resource LED 1 B04
-resource RX_BIND_PLUG 1 NONE
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13
 resource SPI_SCK 3 C10
@@ -45,27 +44,28 @@ resource SDCARD_DETECT 1 C03
 resource OSD_CS 1 A15
 resource GYRO_EXTI 1 A08
 resource GYRO_CS 1 A04
-resource GYRO_CS 2 NONE
 resource USB_DETECT 1 C05
 
 # timer
-timer B00 af1
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B00 AF1
 # pin B00: TIM1 CH2N (AF1)
-timer B01 af1
+timer B01 AF1
 # pin B01: TIM1 CH3N (AF1)
-timer A01 af1
+timer A01 AF1
 # pin A01: TIM2 CH2 (AF1)
-timer A00 af1
+timer A00 AF1
 # pin A00: TIM2 CH1 (AF1)
-timer C06 af3
+timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
-timer C07 af3
+timer C07 AF3
 # pin C07: TIM8 CH2 (AF3)
-timer B05 af2
+timer B05 AF2
 # pin B05: TIM3 CH2 (AF2)
-timer B09 af2
+timer B09 AF2
 # pin B09: TIM4 CH4 (AF2)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
 
 # dma
@@ -94,21 +94,11 @@ dma pin B05 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
-# feature
-feature -RX_PARALLEL_PWM
-feature RX_SERIAL
-feature OSD
-
-serial 1 64 115200 57600 0 115200
-
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1
-set baro_i2c_address = 0
-set serialrx_provider = SBUS
-set adc_device = 1
+set blackbox_device = SDCARD
 set dshot_burst = ON
-set motor_pwm_protocol = ONESHOT125
 set current_meter = ADC
 set battery_meter = ADC
 set beeper_inversion = ON
@@ -118,6 +108,8 @@ set sdcard_mode = SPI
 set sdcard_spi_bus = 2
 set system_hse_mhz = 8
 set max7456_spi_bus = 3
+set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270
+set gyro_2_spibus = 1

--- a/unified_targets/configs/BEEROTORF4.config
+++ b/unified_targets/configs/BEEROTORF4.config
@@ -49,16 +49,24 @@ resource GYRO_CS 2 NONE
 resource USB_DETECT 1 C05
 
 # timer
-timer A03 2
-timer B00 0
-timer B01 0
-timer A01 0
-timer A00 0
-timer C06 1
-timer C07 1
-timer B05 0
-timer B09 0
-timer B08 0
+timer B00 af1
+# pin B00: TIM1 CH2N (AF1)
+timer B01 af1
+# pin B01: TIM1 CH3N (AF1)
+timer A01 af1
+# pin A01: TIM2 CH2 (AF1)
+timer A00 af1
+# pin A00: TIM2 CH1 (AF1)
+timer C06 af3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 af3
+# pin C07: TIM8 CH2 (AF3)
+timer B05 af2
+# pin B05: TIM3 CH2 (AF2)
+timer B09 af2
+# pin B09: TIM4 CH4 (AF2)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
 
 # dma
 dma SPI_TX 2 0

--- a/unified_targets/configs/CLRACINGF4.config
+++ b/unified_targets/configs/CLRACINGF4.config
@@ -43,13 +43,20 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B09 1
-timer B00 0
-timer B01 2
-timer A03 0
-timer A02 0
-timer B04 0
-timer B08 0
+timer B09 af3
+# pin B09: TIM11 CH1 (AF3)
+timer B00 af1
+# pin B00: TIM1 CH2N (AF1)
+timer B01 af3
+# pin B01: TIM8 CH3N (AF3)
+timer A03 af1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 af1
+# pin A02: TIM2 CH3 (AF1)
+timer B04 af2
+# pin B04: TIM3 CH1 (AF2)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
 
 # dma
 dma SPI_TX 2 0

--- a/unified_targets/configs/CLRACINGF4.config
+++ b/unified_targets/configs/CLRACINGF4.config
@@ -43,19 +43,19 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B09 af3
+timer B09 AF3
 # pin B09: TIM11 CH1 (AF3)
-timer B00 af1
+timer B00 AF1
 # pin B00: TIM1 CH2N (AF1)
-timer B01 af3
+timer B01 AF3
 # pin B01: TIM8 CH3N (AF3)
-timer A03 af1
+timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
-timer A02 af1
+timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
-timer B04 af2
+timer B04 AF2
 # pin B04: TIM3 CH1 (AF2)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
 
 # dma

--- a/unified_targets/configs/CLRACINGF7.config
+++ b/unified_targets/configs/CLRACINGF7.config
@@ -67,17 +67,17 @@ set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
 
 # timer
-timer B03 af1
+timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
-timer B06 af2
+timer B06 AF2
 # pin B06: TIM4 CH1 (AF2)
-timer B07 af2
+timer B07 AF2
 # pin B07: TIM4 CH2 (AF2)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
-timer B09 af2
+timer B09 AF2
 # pin B09: TIM4 CH4 (AF2)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
 
 # dma

--- a/unified_targets/configs/CLRACINGF7.config
+++ b/unified_targets/configs/CLRACINGF7.config
@@ -67,12 +67,18 @@ set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
 
 # timer
-timer B03 0
-timer B06 0
-timer B07 0
-timer B08 0
-timer B09 0
-timer B01 1
+timer B03 af1
+# pin B03: TIM2 CH2 (AF1)
+timer B06 af2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 af2
+# pin B07: TIM4 CH2 (AF2)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
+timer B09 af2
+# pin B09: TIM4 CH4 (AF2)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
 
 # dma
 dma ADC 1 1        # ADC 1: DMA2 Stream 4 Channel 0

--- a/unified_targets/configs/CRAZYBEEF4FR.config
+++ b/unified_targets/configs/CRAZYBEEF4FR.config
@@ -40,23 +40,23 @@ resource GYRO_EXTI 1 A01
 resource GYRO_CS 1 A04
 
 # timer
-timer A03 af3
+timer A03 AF3
 # pin A03: TIM9 CH2 (AF3)
-timer B10 af1
+timer B10 AF1
 # pin B10: TIM2 CH3 (AF1)
-timer B06 af2
+timer B06 AF2
 # pin B06: TIM4 CH1 (AF2)
-timer B07 af2
+timer B07 AF2
 # pin B07: TIM4 CH2 (AF2)
-timer B08 af2
+timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
-timer A00 af2
+timer A00 AF2
 # pin A00: TIM5 CH1 (AF2)
-timer A02 af3
+timer A02 AF3
 # pin A02: TIM9 CH1 (AF3)
-timer A09 af1
+timer A09 AF1
 # pin A09: TIM1 CH2 (AF1)
-timer A10 af1
+timer A10 AF1
 # pin A10: TIM1 CH3 (AF1)
 
 # dma

--- a/unified_targets/configs/CRAZYBEEF4FR.config
+++ b/unified_targets/configs/CRAZYBEEF4FR.config
@@ -40,15 +40,24 @@ resource GYRO_EXTI 1 A01
 resource GYRO_CS 1 A04
 
 # timer
-timer A03 2
-timer B10 0
-timer B06 0
-timer B07 0
-timer B08 0
-timer A00 1
-timer A02 2
-timer A09 0
-timer A10 0
+timer A03 af3
+# pin A03: TIM9 CH2 (AF3)
+timer B10 af1
+# pin B10: TIM2 CH3 (AF1)
+timer B06 af2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 af2
+# pin B07: TIM4 CH2 (AF2)
+timer B08 af2
+# pin B08: TIM4 CH3 (AF2)
+timer A00 af2
+# pin A00: TIM5 CH1 (AF2)
+timer A02 af3
+# pin A02: TIM9 CH1 (AF3)
+timer A09 af1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 af1
+# pin A10: TIM1 CH3 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/DYSF4PRO.config
+++ b/unified_targets/configs/DYSF4PRO.config
@@ -46,33 +46,33 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B14 af9
+timer B14 AF9
 # pin B14: TIM12 CH1 (AF9)
-timer B15 af9
+timer B15 AF9
 # pin B15: TIM12 CH2 (AF9)
-timer C06 af3
+timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
-timer C07 af3
+timer C07 AF3
 # pin C07: TIM8 CH2 (AF3)
-timer C08 af3
+timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-timer B00 af2
+timer B00 AF2
 # pin B00: TIM3 CH3 (AF2)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer A03 af1
+timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
-timer A02 af1
+timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
-timer A01 af2
+timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer A09 af1
+timer A09 AF1
 # pin A09: TIM1 CH2 (AF1)
-timer A10 af1
+timer A10 AF1
 # pin A10: TIM1 CH3 (AF1)
 
 # dma

--- a/unified_targets/configs/DYSF4PRO.config
+++ b/unified_targets/configs/DYSF4PRO.config
@@ -46,20 +46,34 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B14 2
-timer B15 2
-timer C06 1
-timer C07 1
-timer C08 1
-timer C09 1
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer A01 1
-timer A08 0
-timer A09 0
-timer A10 0
+timer B14 af9
+# pin B14: TIM12 CH1 (AF9)
+timer B15 af9
+# pin B15: TIM12 CH2 (AF9)
+timer C06 af3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 af3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 af3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
+timer B00 af2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 af1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 af1
+# pin A02: TIM2 CH3 (AF1)
+timer A01 af2
+# pin A01: TIM5 CH2 (AF2)
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 af1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 af1
+# pin A10: TIM1 CH3 (AF1)
 
 # dma
 dma ADC 2 1

--- a/unified_targets/configs/ELINF405.config
+++ b/unified_targets/configs/ELINF405.config
@@ -48,21 +48,21 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B00 af2
+timer B00 AF2
 # pin B00: TIM3 CH3 (AF2)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer A03 af1
+timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
-timer A02 af1
+timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-timer B06 af2
+timer B06 AF2
 # pin B06: TIM4 CH1 (AF2)
-timer B07 af2
+timer B07 AF2
 # pin B07: TIM4 CH2 (AF2)
 
 # dma

--- a/unified_targets/configs/ELINF405.config
+++ b/unified_targets/configs/ELINF405.config
@@ -48,14 +48,22 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer A08 0
-timer C09 1
-timer B06 0
-timer B07 0
+timer B00 af2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 af1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 af1
+# pin A02: TIM2 CH3 (AF1)
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 af2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 af2
+# pin B07: TIM4 CH2 (AF2)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/ELINF722.config
+++ b/unified_targets/configs/ELINF722.config
@@ -47,14 +47,22 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C15
 
 # timer
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer A08 0
-timer C09 1
-timer B06 0
-timer B07 0
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/EXF722DUAL.config
+++ b/unified_targets/configs/EXF722DUAL.config
@@ -49,17 +49,28 @@ resource GYRO_CS 1 A15
 resource GYRO_CS 2 C03
 
 # timer
-timer A00 1
-timer A03 2
-timer C08 1
-timer C06 1
-timer C09 1
-timer C07 1
-timer B06 0
-timer B07 0
-timer B01 1
-timer B00 1
-timer A01 0
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer A01 AF1
+# pin A01: TIM2 CH2 (AF1)
 
 # dma
 dma ADC 3 0

--- a/unified_targets/configs/FF_RACEPIT.config
+++ b/unified_targets/configs/FF_RACEPIT.config
@@ -51,12 +51,18 @@ set max7456_spi_bus = 2
 
 # Timers
 # timer is zero origin
-timer B00 1
-timer B01 1
-timer B11 0
-timer B10 0
-timer A10 0
-timer B06 0
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
 resource MOTOR 1 B00
 resource MOTOR 2 B01
 resource MOTOR 3 B11

--- a/unified_targets/configs/FLYWOOF405.config
+++ b/unified_targets/configs/FLYWOOF405.config
@@ -46,17 +46,16 @@ resource GYRO_CS 1 C04
 resource USB_DETECT 1 A08
 
 # timer
-timer B08 2
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer B05 1
-timer B07 1
-timer C09 2
-timer B04 1
-timer C08 2
-timer A09 0
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/FLYWOOF411.config
+++ b/unified_targets/configs/FLYWOOF411.config
@@ -40,16 +40,24 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C15
 
 # timer
-timer A02 2
-timer A08 0
-timer A09 0
-timer A10 0
-timer B00 1
-timer B04 1
-timer B01 1
-timer A03 1
-timer B10 0
-timer B11 0
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/FLYWOOF7DUAL.config
+++ b/unified_targets/configs/FLYWOOF7DUAL.config
@@ -54,18 +54,22 @@ resource GYRO_CS 1 A04
 resource GYRO_CS 2 B02
 
 # timer
-timer C06 2
-timer B01 1
-timer B04 1
-timer B03 0
-timer A15 0
-timer C08 2
-timer C09 2
-timer A08 0
-timer B08 1
-timer B10 0
-timer A02 1
-timer A03 1
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
 
 # dma
 dma ADC 3 0

--- a/unified_targets/configs/FOXEERF722DUAL.config
+++ b/unified_targets/configs/FOXEERF722DUAL.config
@@ -47,15 +47,24 @@ resource GYRO_CS 1 B02
 resource GYRO_CS 2 B01
 
 # timer
-timer B07 0
-timer A09 0
-timer A08 0
-timer C09 1
-timer C08 1
-timer C06 1
-timer C07 1
-timer A15 0
-timer B03 0
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
 
 # dma
 dma ADC 3 0

--- a/unified_targets/configs/FURYF4OSD.config
+++ b/unified_targets/configs/FURYF4OSD.config
@@ -43,13 +43,20 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer C09 1
-timer A03 0
-timer B00 1
-timer B01 0
-timer A02 0
-timer A00 1
-timer B09 1
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF1
+# pin B01: TIM1 CH3N (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/HGLRCF405.config
+++ b/unified_targets/configs/HGLRCF405.config
@@ -44,20 +44,34 @@ resource GYRO_CS 1 A04
 resource GYRO_CS 2 C14
 
 # timer
-timer B00 1
-timer B01 1
-timer A03 0
-timer B05 0
-timer C08 1
-timer C09 1
-timer B06 0
-timer B08 1
-timer C06 1
-timer C07 1
-timer A09 0
-timer A10 0
-timer A01 1
-timer A02 2
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
 
 # dma
 dma ADC 2 1

--- a/unified_targets/configs/HGLRCF411.config
+++ b/unified_targets/configs/HGLRCF411.config
@@ -38,16 +38,26 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C15
 		
 # timer list
-timer A03 2
-timer B04 0
-timer B05 0
-timer B06 0
-timer B07 0
-timer B03 0
-timer B10 0
-timer A00 1
-timer A02 1
-timer A08 0
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/HGLRCF745.config
+++ b/unified_targets/configs/HGLRCF745.config
@@ -48,18 +48,30 @@ resource GYRO_CS 2 A04
 resource USB_DETECT 1 C04
 
 # timer
-timer E13 0
-timer B00 1
-timer B01 1
-timer E09 0
-timer E11 0
-timer D12 0
-timer B10 0
-timer B11 0
-timer C06 1
-timer C07 1
-timer A03 0
-timer A02 2
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
 
 # dma
 dma SPI_TX 4 0

--- a/unified_targets/configs/IFLIGHTF4_TWIN_G.config
+++ b/unified_targets/configs/IFLIGHTF4_TWIN_G.config
@@ -48,13 +48,20 @@ resource GYRO_CS 2 C03
 resource USB_DETECT 1 C05
 
 # timer
-timer A03 0
-timer B00 1
-timer B01 1
-timer C09 1
-timer C08 1
-timer B06 0
-timer A00 0
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A00 AF1
+# pin A00: TIM2 CH1 (AF1)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/IFLIGHT_F411_PRO.config
+++ b/unified_targets/configs/IFLIGHT_F411_PRO.config
@@ -35,12 +35,18 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C15
 
 # timer
-timer A03 2
-timer A00 0
-timer B10 0
-timer B06 0
-timer B07 0
-timer A08 0
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A00 AF1
+# pin A00: TIM2 CH1 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/JHEF7DUAL.config
+++ b/unified_targets/configs/JHEF7DUAL.config
@@ -51,15 +51,24 @@ resource GYRO_CS 1 B02
 resource GYRO_CS 2 A04
 
 # timer
-timer A03 2
-timer B00 1
-timer B01 1
-timer B04 0
-timer B03 0
-timer C09 1
-timer C08 1
-timer A08 0
-timer B08 0
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
 
 # dma
 dma ADC 3 0

--- a/unified_targets/configs/KAKUTEF7.config
+++ b/unified_targets/configs/KAKUTEF7.config
@@ -47,14 +47,22 @@ resource GYRO_CS 1 E04
 resource USB_DETECT 1 A08
 
 # timer
-timer E13 0
-timer B00 1
-timer B01 1
-timer E09 0
-timer E11 0
-timer C09 1
-timer A03 1
-timer D12 0
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
 
 # dma
 dma SPI_TX 1 1

--- a/unified_targets/configs/KAKUTEF7MINI.config
+++ b/unified_targets/configs/KAKUTEF7MINI.config
@@ -46,14 +46,22 @@ resource GYRO_CS 1 E04
 resource USB_DETECT 1 A08
 
 # timer
-timer E13 0
-timer B00 1
-timer B01 1
-timer E09 0
-timer E11 0
-timer C09 1
-timer A03 1
-timer D12 0
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/MAMBAF722.config
+++ b/unified_targets/configs/MAMBAF722.config
@@ -64,13 +64,20 @@ resource SERIAL_TX 6 C06
 resource SERIAL_RX 6 C07
 
 # TIMERS
-timer B09 1
-timer C08 1
-timer C09 1
-timer A08 0
-timer A09 0
-timer B08 0
-timer B03 0
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
 resource MOTOR 1 C08
 resource MOTOR 2 C09
 resource MOTOR 3 A08

--- a/unified_targets/configs/MATEKF405.config
+++ b/unified_targets/configs/MATEKF405.config
@@ -52,18 +52,30 @@ resource GYRO_CS 1 C02
 resource USB_DETECT 1 B12
 
 # timer
-timer A03 1
-timer C06 0
-timer C07 1
-timer C08 1
-timer C09 1
-timer A15 0
-timer A08 0
-timer B08 0
-timer B06 0
-timer A00 1
-timer A01 1
-timer A02 2
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
 
 # dma
 dma SPI_TX 3 1

--- a/unified_targets/configs/MATEKF411.config
+++ b/unified_targets/configs/MATEKF411.config
@@ -32,16 +32,26 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C15
 
 # timer list
-timer A03 2
-timer B04 0
-timer B05 0
-timer B06 0
-timer B07 0
-timer B03 0
-timer B10 0
-timer A00 1
-timer A02 1
-timer A08 0
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/MATEKF722.config
+++ b/unified_targets/configs/MATEKF722.config
@@ -50,18 +50,30 @@ resource GYRO_CS 1 C02
 resource USB_DETECT 1 B12
 
 # timer
-timer A03 2
-timer C06 1
-timer C07 1
-timer C08 1
-timer C09 1
-timer B01 1
-timer A08 0
-timer B08 0
-timer A02 1
-timer A00 1
-timer A01 1
-timer A15 0
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
 
 # dma
 dma SPI_TX 3 1

--- a/unified_targets/configs/MATEKF722SE.config
+++ b/unified_targets/configs/MATEKF722SE.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar 18 2019 / 08:19:06 (4c62d362e) MSP API: 1.41
+# Betaflight / STM32F7X2 (S7X2) 4.1.0 May 26 2019 / 14:00:17 (f81d01e2d) MSP API: 1.42
 
 board_name MATEKF722SE
 manufacturer_id MTKS
@@ -57,19 +57,32 @@ resource GYRO_CS 2 C15
 resource USB_DETECT 1 C14
 
 # timer
-timer B04 0
-timer B05 0
-timer B00 1
-timer B01 1
-timer A15 0
-timer B03 0
-timer B06 0
-timer B07 0
-timer A08 0
-timer A03 2
-timer A02 2
-timer A01 1
-timer A00 1
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
 
 # dma
 dma SPI_TX 3 0

--- a/unified_targets/configs/NERO.config
+++ b/unified_targets/configs/NERO.config
@@ -50,10 +50,24 @@ setsdcard_spi_bus = 3
 # Timers
 # First four timers
 # timer is zero origin
-timer A0 1
-timer A1 1
-timer A2 1
-timer A3 1
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
 resource MOTOR 1 A0
 resource MOTOR 2 A1
 resource MOTOR 3 A2
@@ -64,11 +78,6 @@ resource MOTOR 4 A3
 set dshot_burst = ON
 
 # Remaining timers
-timer B0 1
-timer B1 1
-timer C7 1
-timer C8 1
-timer C9 1
 resource LED_STRIP B0
 resource PPM C7
 

--- a/unified_targets/configs/OMNIBUSF4.config
+++ b/unified_targets/configs/OMNIBUSF4.config
@@ -47,33 +47,33 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B14 af9
+timer B14 AF9
 # pin B14: TIM12 CH1 (AF9)
-timer B15 af9
+timer B15 AF9
 # pin B15: TIM12 CH2 (AF9)
-timer C06 af3
+timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
-timer C07 af3
+timer C07 AF3
 # pin C07: TIM8 CH2 (AF3)
-timer C08 af3
+timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
-timer C09 af3
+timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-timer B00 af2
+timer B00 AF2
 # pin B00: TIM3 CH3 (AF2)
-timer B01 af2
+timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer A03 af1
+timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
-timer A02 af1
+timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
-timer A01 af2
+timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
-timer A08 af1
+timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer A09 af1
+timer A09 AF1
 # pin A09: TIM1 CH2 (AF1)
-timer A10 af1
+timer A10 AF1
 # pin A10: TIM1 CH3 (AF1)
 
 # dma

--- a/unified_targets/configs/OMNIBUSF4.config
+++ b/unified_targets/configs/OMNIBUSF4.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F405 (S405) 4.0.0 Mar  7 2019 / 06:40:55 (fee4ee5e0) MSP API: 1.41
+# Betaflight / STM32F405 (S405) 4.1.0 May 22 2019 / 02:24:46 (1541466da) MSP API: 1.42
 
 board_name OMNIBUSF4
 manufacturer_id AIRB
@@ -35,6 +35,7 @@ resource SPI_MISO 1 A06
 resource SPI_MISO 3 C11
 resource SPI_MOSI 1 A07
 resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 B14
 resource ADC_BATT 1 C02
 resource ADC_CURR 1 C01
 resource FLASH_CS 1 B03
@@ -46,20 +47,34 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B14 2
-timer B15 2
-timer C06 1
-timer C07 1
-timer C08 1
-timer C09 1
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer A01 1
-timer A08 0
-timer A09 0
-timer A10 0
+timer B14 af9
+# pin B14: TIM12 CH1 (AF9)
+timer B15 af9
+# pin B15: TIM12 CH2 (AF9)
+timer C06 af3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 af3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 af3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 af3
+# pin C09: TIM8 CH4 (AF3)
+timer B00 af2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 af2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 af1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 af1
+# pin A02: TIM2 CH3 (AF1)
+timer A01 af2
+# pin A01: TIM5 CH2 (AF2)
+timer A08 af1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 af1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 af1
+# pin A10: TIM1 CH3 (AF1)
 
 # dma
 dma ADC 2 1
@@ -96,6 +111,7 @@ set baro_bustype = I2C
 set baro_i2c_device = 2
 set rx_spi_bus = 3
 set adc_device = 2
+set blackbox_device = SPIFLASH
 set current_meter = ADC
 set battery_meter = ADC
 set beeper_inversion = ON

--- a/unified_targets/configs/OMNIBUSF4FW.config
+++ b/unified_targets/configs/OMNIBUSF4FW.config
@@ -41,21 +41,36 @@ resource GYRO_CS 1 D02
 resource GYRO_CS 2 A04
 
 # timer
-timer B00 1
-timer B01 1
-timer A03 0
-timer B05 0
-timer C08 1
-timer C09 1
-timer B06 0
-timer B08 1
-timer B09 1
-timer C06 1
-timer C07 1
-timer A09 0
-timer A10 0
-timer A01 1
-timer A02 2
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
 
 # dma
 dma ADC 2 1

--- a/unified_targets/configs/OMNIBUSF4NANOV7.config
+++ b/unified_targets/configs/OMNIBUSF4NANOV7.config
@@ -40,12 +40,18 @@ resource GYRO_CS 1 D02
 resource GYRO_CS 2 C04
 
 # timer
-timer A15 0
-timer A08 0
-timer C09 1
-timer B06 0
-timer C08 1
-timer B07 0
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/OMNIBUSF4SD.config
+++ b/unified_targets/configs/OMNIBUSF4SD.config
@@ -52,21 +52,36 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B08 1
-timer B09 0
-timer C06 1
-timer C07 1
-timer C08 1
-timer C09 1
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer A01 1
-timer B06 0
-timer A08 0
-timer A09 0
-timer A10 0
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer B09 AF2
+# pin B09: TIM4 CH4 (AF2)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
 
 # dma
 dma SPI_TX 2 0

--- a/unified_targets/configs/OMNIBUSF4V6.config
+++ b/unified_targets/configs/OMNIBUSF4V6.config
@@ -43,20 +43,34 @@ resource GYRO_CS 1 A04
 resource GYRO_CS 2 C14
 
 # timer
-timer B00 1
-timer B01 1
-timer A03 0
-timer B05 0
-timer C08 1
-timer C09 1
-timer B06 0
-timer B08 1
-timer C06 1
-timer C07 1
-timer A09 0
-timer A10 0
-timer A01 1
-timer A02 2
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
 
 # dma
 dma ADC 2 1

--- a/unified_targets/configs/OMNIBUSF7NANOV7.config
+++ b/unified_targets/configs/OMNIBUSF7NANOV7.config
@@ -39,12 +39,18 @@ resource OSD_CS 1 C15
 resource GYRO_CS 1 D02
 
 # timer
-timer A15 0
-timer A08 0
-timer C09 1
-timer B06 0
-timer C08 1
-timer B07 0
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/OMNIBUSF7V2.config
+++ b/unified_targets/configs/OMNIBUSF7V2.config
@@ -48,18 +48,30 @@ resource GYRO_CS 2 A04
 resource USB_DETECT 1 C04
 
 # timer
-timer E13 0
-timer B00 1
-timer B01 1
-timer E09 0
-timer E11 0
-timer D12 0
-timer B10 0
-timer B11 0
-timer C06 1
-timer C07 1
-timer A03 0
-timer A02 2
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
 
 # dma
 dma SPI_TX 4 0

--- a/unified_targets/configs/RUSHCORE7.config
+++ b/unified_targets/configs/RUSHCORE7.config
@@ -44,15 +44,24 @@ resource OSD_CS 1 B12
 resource GYRO_CS 1 A04
 
 # timer
-timer A03 2
-timer C08 1
-timer C06 1
-timer C09 1
-timer C07 1
-timer A08 0
-timer A09 0
-timer B11 0
-timer B00 1
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
 
 # dma
 dma pin C08 0

--- a/unified_targets/configs/SPRACINGF7DUAL.config
+++ b/unified_targets/configs/SPRACINGF7DUAL.config
@@ -55,23 +55,40 @@ resource GYRO_CS 1 A15
 resource GYRO_CS 2 B02
 
 # timer
-timer A00 1
-timer A03 2
-timer A02 2
-timer C08 1
-timer C06 1
-timer C09 1
-timer C07 1
-timer B06 0
-timer B07 0
-timer B01 1
-timer B00 1
-timer A01 0
-timer B10 0
-timer B11 0
-timer A08 0
-timer A09 0
-timer A10 0
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer A01 AF1
+# pin A01: TIM2 CH2 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
 
 # dma
 dma SPI_TX 3 1

--- a/unified_targets/configs/SYNERGYF4.config
+++ b/unified_targets/configs/SYNERGYF4.config
@@ -46,20 +46,34 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
 
 # timer
-timer B14 2
-timer B15 2
-timer C06 1
-timer C07 1
-timer C08 1
-timer C09 1
-timer B00 1
-timer B01 1
-timer A03 0
-timer A02 0
-timer A01 1
-timer A08 0
-timer A09 0
-timer A10 0
+timer B14 AF9
+# pin B14: TIM12 CH1 (AF9)
+timer B15 AF9
+# pin B15: TIM12 CH2 (AF9)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
 
 # dma
 dma ADC 2 1

--- a/unified_targets/configs/TRANSTECF7.config
+++ b/unified_targets/configs/TRANSTECF7.config
@@ -44,14 +44,22 @@ resource GYRO_CS 1 C02
 resource USB_DETECT 1 A04
 
 # timer
-timer B00 1
-timer B01 1
-timer C06 1
-timer C07 1
-timer B03 0
-timer B04 0
-timer B08 0
-timer A15 0
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
 
 # dma
 dma ADC 1 0

--- a/unified_targets/configs/VGOODRCF4.config
+++ b/unified_targets/configs/VGOODRCF4.config
@@ -55,13 +55,20 @@ resource GYRO_CS 1 A15
 resource USB_DETECT 1 C04
 
 # timer
-timer C07 1
-timer A09 0
-timer B00 1
-timer B01 1
-timer C08 1
-timer C09 1
-timer A08 0
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
 
 # dma
 dma ADC 2 1

--- a/unified_targets/configs/VIVAF4AIO.config
+++ b/unified_targets/configs/VIVAF4AIO.config
@@ -46,15 +46,24 @@ resource GYRO_EXTI 1 C04
 resource GYRO_CS 1 A04
 
 # timer
-timer B15 2
-timer B00 1
-timer C06 1
-timer A10 0
-timer A08 0
-timer C08 1
-timer B01 1
-timer B06 0
-timer A05 0
+timer B15 AF9
+# pin B15: TIM12 CH2 (AF9)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A05 AF1
+# pin A05: TIM2 CH1 (AF1)
 
 # dma
 dma ADC 1 1

--- a/unified_targets/configs/XILOF4.config
+++ b/unified_targets/configs/XILOF4.config
@@ -42,12 +42,18 @@ resource OSD_CS 1 D02
 resource GYRO_CS 1 C04
 
 # timer
-timer A15 0
-timer A08 0
-timer C08 1
-timer B06 0
-timer C09 1
-timer B07 0
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
 
 # dma
 dma ADC 1 1


### PR DESCRIPTION
Proposing to put this into `4.0.x-maintenance` so that we can switch over to alternate function based timer selection with 4.1.
Now seems the best time to do it, as the number of unified targets that need to be changed is still small.