### PR TITLE
SPRacingF3NEO - Add BARO support.

### DIFF
--- a/src/main/target/SPRACINGF3NEO/target.h
+++ b/src/main/target/SPRACINGF3NEO/target.h
@@ -45,6 +45,10 @@
 #define USE_ACC
 #define USE_ACC_SPI_MPU6500
 
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+
 #define GYRO_1_ALIGN            CW0_DEG
 
 #define USE_VCP

--- a/src/main/target/SPRACINGF3NEO/target.mk
+++ b/src/main/target/SPRACINGF3NEO/target.mk
@@ -8,5 +8,7 @@ TARGET_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms5611.c \
             drivers/max7456.c \
             drivers/vtx_rtc6705.c


### PR DESCRIPTION
when compiling master a linker error occurs due some baro code referenced somewhere (baroConfig_System undefined) but the defines and src definitions were missing.

F3/F4 NEO targets should have BARO code enabled as they feature a 8 pin IO port specifically designed for GPS IO board connection.