### PR TITLE
Fix copy of profiles with last index

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -741,9 +741,8 @@ float pidApplyThrustLinearization(float motorOutput)
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)
 {
-    if ((dstPidProfileIndex < PID_PROFILE_COUNT-1 && srcPidProfileIndex < PID_PROFILE_COUNT-1)
-        && dstPidProfileIndex != srcPidProfileIndex
-    ) {
+    if (dstPidProfileIndex < PID_PROFILE_COUNT && srcPidProfileIndex < PID_PROFILE_COUNT
+        && dstPidProfileIndex != srcPidProfileIndex) {
         memcpy(pidProfilesMutable(dstPidProfileIndex), pidProfilesMutable(srcPidProfileIndex), sizeof(pidProfile_t));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1370 , a problem when copying a profile to the latest index. Detected as issue in the Configurator but in the end was the firmware.