### PR TITLE
Fix VTX chan to 0 via SetFreqByMHz

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2289,7 +2289,6 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                 vtxSettingsConfigMutable()->freq = vtxCommonLookupFrequency(vtxDevice, newBand, newChannel);
             } else if (newFrequency <= VTX_SETTINGS_MAX_FREQUENCY_MHZ) { // Value is frequency in MHz
                 vtxSettingsConfigMutable()->band = 0;
-                vtxSettingsConfigMutable()->channel = 0;
                 vtxSettingsConfigMutable()->freq = newFrequency;
             }
 


### PR DESCRIPTION
When a VTX is set to a frequency in MHz (via MSP_SET_VTX_CONFIG in 'msp.c'), the vtx-settings 'vtx_channel' value is set to 0, which is an illegal value.  This results in the Taranis VTX 'lua' script showing bad values and becoming non-operational, and the CLI dump shows "ERROR: CORRUPTED CONFIG: vtx_channel = 0".

The "vtxSettingsConfigMutable()->channel = 0" line in 'msp.c' was added in BF v4.0.0, so the fix is to remove it.  The 'vtx_channel' setting is not used when vtx_band==0 (SetFreqByMHz mode), so there's no reason to modify it.

This mod should also be applied to the 'v4.0.x-maintenance' and 'akk_vtx_fix' branches.  Should I post additional PRs for those?