### PR TITLE
Fix flash m25p16 driver sector erase

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -250,7 +250,7 @@ static void m25p16_eraseSector(flashDevice_t *fdevice, uint32_t address)
 
     m25p16_writeEnable(fdevice);
 
-    m25p16_transfer(fdevice->io.handle.busdev, out, NULL, sizeof(out));
+    m25p16_transfer(fdevice->io.handle.busdev, out, NULL, fdevice->isLargeFlash ? 5 : 4);
 }
 
 static void m25p16_eraseCompletely(flashDevice_t *fdevice)


### PR DESCRIPTION
The sector erase function was not taking into account the address size when sending the command to the device and the erase was failing for devices using 24bit addressing.
