### PR TITLE
Use full erase when possible for FLASHFS erase - fixes single partition targets

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -395,4 +395,9 @@ bool flashInit(const flashConfig_t *flashConfig)
 
     return haveFlash;
 }
+
+int flashPartitionCount(void)
+{
+    return flashPartitions;
+}
 #endif // USE_FLASH_CHIP

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -94,3 +94,4 @@ void flashPartitionSet(uint8_t index, uint32_t startSector, uint32_t endSector);
 flashPartition_t *flashPartitionFindByType(flashPartitionType_e type);
 const flashPartition_t *flashPartitionFindByIndex(uint8_t index);
 const char *flashPartitionGetTypeName(flashPartitionType_e type);
+int flashPartitionCount(void);


### PR DESCRIPTION
If there is only a single partition, its type is FLASHFS, and it uses the entire geometry, then perform a full rather than a sector-based erase. This restores functionality for targets that use a single FLASHFS partition (everything except for H750).

Also the full erase is significantly faster than erasing by individual sectors.

**NOTE!!**

Multi-partition flash erase support (currently on on H7) needs to be redesigned as it will break in all cases except for CLI `flash_erase` usage. The problem is that all current logic expects the erase to run asynchronously and the call to `flashfsEraseCompletely()` to return immediately. This was previously the case before partitions were added to flash structure. However the partition structure requires erasing a section of flash using a sector-based approach. In this case the process runs synchronously and the call to `flashfsEraseCompletely()` doesn't return until completed. This breaks MSP and runtime mode-based blackbox flash erase.