### PR TITLE
Use the new Speed and Flight Distance OSD symbols

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -34,6 +34,7 @@
 #define SYM_LAT                     0x89
 #define SYM_LON                     0x98
 #define SYM_ALTITUDE                0x7F
+#define SYM_TOTAL_DISTANCE          0x71
 
 // RSSI
 #define SYM_RSSI                    0x01
@@ -134,6 +135,7 @@
 #define SYM_FLY_M                   0x9C
 
 // Speed
+#define SYM_SPEED                   0x70
 #define SYM_KPH                     0x9E
 #define SYM_MPH                     0x9D
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -776,13 +776,10 @@ static void osdElementGpsFlightDistance(osdElementParms_t *element)
 {
     if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
         const int32_t distance = osdGetMetersToSelectedUnit(GPS_distanceFlownInCm / 100);
-        tfp_sprintf(element->buff, "%d%c", distance, osdGetMetersToSelectedUnitSymbol());
+        tfp_sprintf(element->buff, "%c%d%c", SYM_TOTAL_DISTANCE, distance, osdGetMetersToSelectedUnitSymbol());
     } else {
         // We use this symbol when we don't have a FIX
-        element->buff[0] = SYM_COLON;
-        // overwrite any previous distance with blanks
-        memset(element->buff + 1, SYM_BLANK, 6);
-        element->buff[7] = '\0';
+        tfp_sprintf(element->buff, "%c%c", SYM_TOTAL_DISTANCE, SYM_COLON);
     }
 }
 
@@ -835,7 +832,7 @@ static void osdElementGpsSats(osdElementParms_t *element)
 
 static void osdElementGpsSpeed(osdElementParms_t *element)
 {
-    tfp_sprintf(element->buff, "%3d%c", osdGetSpeedToSelectedUnit(gpsSol.groundSpeed), osdGetSpeedToSelectedUnitSymbol());
+    tfp_sprintf(element->buff, "%c%d%c", SYM_SPEED, osdGetSpeedToSelectedUnit(gpsSol.groundSpeed), osdGetSpeedToSelectedUnitSymbol());
 }
 #endif // USE_GPS
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -832,7 +832,7 @@ static void osdElementGpsSats(osdElementParms_t *element)
 
 static void osdElementGpsSpeed(osdElementParms_t *element)
 {
-    tfp_sprintf(element->buff, "%c%d%c", SYM_SPEED, osdGetSpeedToSelectedUnit(gpsSol.groundSpeed), osdGetSpeedToSelectedUnitSymbol());
+    tfp_sprintf(element->buff, "%c%3d%c", SYM_SPEED, osdGetSpeedToSelectedUnit(gpsSol.groundSpeed), osdGetSpeedToSelectedUnitSymbol());
 }
 #endif // USE_GPS
 


### PR DESCRIPTION
To go after https://github.com/betaflight/betaflight-configurator/pull/1466

This adds a prefix symbol to the Speed and Flight Distance OSD elements.

I will push another PR to update the Configurator OSD preview