### PR TITLE
[H7] Remove excess member from timerHardware_s

### DIFF
--- a/src/main/drivers/pwm_output_dshot_hal_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal_hal.c
@@ -402,8 +402,9 @@ P    -    High -     High -
     } else
 #endif
     {
-        dmaInit(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
-        dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
+        dmaIdentifier_e identifier = dmaGetIdentifier(timerHardware->dmaRef);
+        dmaInit(identifier, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+        dmaSetHandler(identifier, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
     }
 
     // Start the timer channel now.

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -127,7 +127,6 @@ typedef struct timerHardware_s {
 #elif defined(STM32H7)
     DMA_Stream_TypeDef *dmaRef;
     uint8_t dmaRequest;
-    uint8_t dmaIrqHandler; // XXX Should be gone (can be substituted by dmaGetIdentifier)
 #else
     DMA_Channel_TypeDef *dmaRef;
 #endif

--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -723,8 +723,7 @@
     DEF_TIM_AF(TCH_## tim ## _ ## chan, pin)                            \
     DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_STREAM(dmaopt, TCH_## tim ## _ ## chan),            \
-        DEF_TIM_DMA_REQUEST(TCH_## tim ## _ ## chan),                   \
-        DEF_TIM_DMA_HANDLER(dmaopt, TCH_## tim ## _ ## chan)            \
+        DEF_TIM_DMA_REQUEST(TCH_## tim ## _ ## chan)                    \
     )                                                                   \
     DEF_TIM_DMA_COND(/* add comma */ ,                                  \
         DEF_TIM_DMA_STREAM(upopt, TCH_## tim ## _UP),                   \


### PR DESCRIPTION
Remove the `dmaIrqHandler` member was introduced temporary as a part of the porting process.