### PR TITLE
Removed 'slots' from the adjustment range configuration.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1368,7 +1368,7 @@ static void cliSerialPassthrough(char *cmdline)
 
 static void printAdjustmentRange(dumpFlags_t dumpMask, const adjustmentRange_t *adjustmentRanges, const adjustmentRange_t *defaultAdjustmentRanges, const char *headingStr)
 {
-    const char *format = "adjrange %u %u %u %u %u %u %u %u %u";
+    const char *format = "adjrange %u 0 %u %u %u %u %u %u %u";
     // print out adjustment ranges channel settings
     headingStr = cliPrintSectionHeading(dumpMask, false, headingStr);
     for (uint32_t i = 0; i < MAX_ADJUSTMENT_RANGE_COUNT; i++) {
@@ -1380,7 +1380,6 @@ static void printAdjustmentRange(dumpFlags_t dumpMask, const adjustmentRange_t *
             headingStr = cliPrintSectionHeading(dumpMask, !equalsDefault, headingStr);
             cliDefaultPrintLinef(dumpMask, equalsDefault, format,
                 i,
-                arDefault->adjustmentIndex,
                 arDefault->auxChannelIndex,
                 MODE_STEP_TO_CHANNEL_VALUE(arDefault->range.startStep),
                 MODE_STEP_TO_CHANNEL_VALUE(arDefault->range.endStep),
@@ -1392,7 +1391,6 @@ static void printAdjustmentRange(dumpFlags_t dumpMask, const adjustmentRange_t *
         }
         cliDumpPrintLinef(dumpMask, equalsDefault, format,
             i,
-            ar->adjustmentIndex,
             ar->auxChannelIndex,
             MODE_STEP_TO_CHANNEL_VALUE(ar->range.startStep),
             MODE_STEP_TO_CHANNEL_VALUE(ar->range.endStep),
@@ -1406,7 +1404,7 @@ static void printAdjustmentRange(dumpFlags_t dumpMask, const adjustmentRange_t *
 
 static void cliAdjustmentRange(char *cmdline)
 {
-    const char *format = "adjrange %u %u %u %u %u %u %u %u %u";
+    const char *format = "adjrange %u 0 %u %u %u %u %u %u %u";
     int i, val = 0;
     const char *ptr;
 
@@ -1422,10 +1420,7 @@ static void cliAdjustmentRange(char *cmdline)
             ptr = nextArg(ptr);
             if (ptr) {
                 val = atoi(ptr);
-                if (val >= 0 && val < MAX_SIMULTANEOUS_ADJUSTMENT_COUNT) {
-                    ar->adjustmentIndex = val;
-                    validArgumentCount++;
-                }
+                validArgumentCount++;
             }
             ptr = nextArg(ptr);
             if (ptr) {
@@ -1482,7 +1477,6 @@ static void cliAdjustmentRange(char *cmdline)
 
             cliDumpPrintLinef(0, false, format,
                 i,
-                ar->adjustmentIndex,
                 ar->auxChannelIndex,
                 MODE_STEP_TO_CHANNEL_VALUE(ar->range.startStep),
                 MODE_STEP_TO_CHANNEL_VALUE(ar->range.endStep),
@@ -5804,7 +5798,7 @@ static void cliHelp(char *cmdline);
 
 // should be sorted a..z for bsearch()
 const clicmd_t cmdTable[] = {
-    CLI_COMMAND_DEF("adjrange", "configure adjustment ranges", NULL, cliAdjustmentRange),
+    CLI_COMMAND_DEF("adjrange", "configure adjustment ranges", "<index> <unused> <range channel> <start> <end> <function> <select channel> [<center> <scale>]", cliAdjustmentRange),
     CLI_COMMAND_DEF("aux", "configure modes", "<index> <mode> <aux> <start> <end> <logic>", cliAux),
 #ifdef USE_CLI_BATCH
     CLI_COMMAND_DEF("batch", "start or end a batch of commands", "start | end", cliBatch),

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1420,6 +1420,8 @@ static void cliAdjustmentRange(char *cmdline)
             ptr = nextArg(ptr);
             if (ptr) {
                 val = atoi(ptr);
+		// Was: slot
+		// Keeping the parameter to retain backwards compatibility for the command format.
                 validArgumentCount++;
             }
             ptr = nextArg(ptr);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -142,7 +142,7 @@ static void activateConfig(void)
 
     initRcProcessing();
 
-    resetAdjustmentStates();
+    activeAdjustmentRangeReset();
 
     pidInit(currentPidProfile);
 

--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -21,8 +21,10 @@
 #pragma once
 
 #include <stdbool.h>
-#include "pg/pg.h"
+
 #include "fc/rc_modes.h"
+
+#include "pg/pg.h"
 
 typedef enum {
     ADJUSTMENT_NONE = 0,
@@ -90,27 +92,23 @@ typedef struct adjustmentRange_s {
     uint8_t adjustmentConfig;
     uint8_t auxSwitchChannelIndex;
 
-    // ... via slot
-    uint8_t adjustmentIndex;
     uint16_t adjustmentCenter;
     uint16_t adjustmentScale;
 } adjustmentRange_t;
 
 PG_DECLARE_ARRAY(adjustmentRange_t, MAX_ADJUSTMENT_RANGE_COUNT, adjustmentRanges);
 
-#define ADJUSTMENT_INDEX_OFFSET 1
-
-typedef struct adjustmentState_s {
-    uint8_t auxChannelIndex;
-    const adjustmentConfig_t *config;
+typedef struct timedAdjustmentState_s {
     uint32_t timeoutAt;
-} adjustmentState_t;
+    uint8_t adjustmentRangeIndex;
+    bool ready;
+} timedAdjustmentState_t;
 
-#ifndef MAX_SIMULTANEOUS_ADJUSTMENT_COUNT
-#define MAX_SIMULTANEOUS_ADJUSTMENT_COUNT 4 // enough for 4 x 3position switches / 4 aux channel
-#endif
+typedef struct continuosAdjustmentState_s {
+    uint8_t adjustmentRangeIndex;
+    int16_t lastRcData;
+} continuosAdjustmentState_t;
 
-void resetAdjustmentStates(void);
 struct controlRateConfig_s;
 void processRcAdjustments(struct controlRateConfig_s *controlRateConfig);
 const char *getAdjustmentsRangeName(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1082,7 +1082,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
     case MSP_ADJUSTMENT_RANGES:
         for (int i = 0; i < MAX_ADJUSTMENT_RANGE_COUNT; i++) {
             const adjustmentRange_t *adjRange = adjustmentRanges(i);
-            sbufWriteU8(dst, adjRange->adjustmentIndex);
+            sbufWriteU8(dst, 0); // was adjRange->adjustmentIndex
             sbufWriteU8(dst, adjRange->auxChannelIndex);
             sbufWriteU8(dst, adjRange->range.startStep);
             sbufWriteU8(dst, adjRange->range.endStep);
@@ -1826,17 +1826,13 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         i = sbufReadU8(src);
         if (i < MAX_ADJUSTMENT_RANGE_COUNT) {
             adjustmentRange_t *adjRange = adjustmentRangesMutable(i);
-            i = sbufReadU8(src);
-            if (i < MAX_SIMULTANEOUS_ADJUSTMENT_COUNT) {
-                adjRange->adjustmentIndex = i;
-                adjRange->auxChannelIndex = sbufReadU8(src);
-                adjRange->range.startStep = sbufReadU8(src);
-                adjRange->range.endStep = sbufReadU8(src);
-                adjRange->adjustmentConfig = sbufReadU8(src);
-                adjRange->auxSwitchChannelIndex = sbufReadU8(src);
-            } else {
-                return MSP_RESULT_ERROR;
-            }
+            sbufReadU8(src); // was adjRange->adjustmentIndex
+            adjRange->auxChannelIndex = sbufReadU8(src);
+            adjRange->range.startStep = sbufReadU8(src);
+            adjRange->range.endStep = sbufReadU8(src);
+            adjRange->adjustmentConfig = sbufReadU8(src);
+            adjRange->auxSwitchChannelIndex = sbufReadU8(src);
+
             activeAdjustmentRangeReset();
         } else {
             return MSP_RESULT_ERROR;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -455,8 +455,9 @@ char osdGetTemperatureSymbolForSelectedUnit(void)
 #ifdef USE_OSD_ADJUSTMENTS
 static void osdElementAdjustmentRange(osdElementParms_t *element)
 {
-    if (getAdjustmentsRangeName()) {
-        tfp_sprintf(element->buff, "%s: %3d", getAdjustmentsRangeName(), getAdjustmentsRangeValue());
+    const char *name = getAdjustmentsRangeName();
+    if (name) {
+        tfp_sprintf(element->buff, "%s: %3d", name, getAdjustmentsRangeValue());
     }
 }
 #endif // USE_OSD_ADJUSTMENTS

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -242,14 +242,13 @@ void resetMillis(void) {
 extern "C" {
     PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
 
-    /*
-    static const adjustmentConfig_t rateAdjustmentConfig = {
-        .adjustmentFunction = ADJUSTMENT_RC_RATE,
-        .mode = ADJUSTMENT_MODE_STEP,
-        .data = { 1 }
-    };
-    */
+    extern int stepwiseAdjustmentCount;
+    extern timedAdjustmentState_t stepwiseAdjustments[MAX_ADJUSTMENT_RANGE_COUNT];
+
+    extern int continuosAdjustmentCount;
+    extern continuosAdjustmentState_t continuosAdjustments[MAX_ADJUSTMENT_RANGE_COUNT];
 }
+
 class RcControlsAdjustmentsTest : public ::testing::Test {
 protected:
     controlRateConfig_t controlRateConfig = {
@@ -264,6 +263,13 @@ protected:
             .rcExpo[FD_YAW] = 0,
             .tpa_breakpoint = 0
     };
+
+    channelRange_t fullRange = {
+        .startStep = MIN_MODE_RANGE_STEP,
+        .endStep = MAX_MODE_RANGE_STEP
+    };
+
+    int adjustmentRangesIndex;
 
     virtual void SetUp() {
         PG_RESET(rxConfig);
@@ -284,13 +290,50 @@ protected:
         controlRateConfig.dynThrPID = 0;
         controlRateConfig.tpa_breakpoint = 0;
 
+        PG_RESET(adjustmentRanges);
+        adjustmentRangesIndex = 0;
+
+        stepwiseAdjustmentCount = 0;
+        continuosAdjustmentCount = 0;
+    }
+
+    int configureAdjustmentRange(uint8_t switchChannelIndex, uint8_t adjustmentConfigIndex) {
+        adjustmentRange_t *adjustmentRange = adjustmentRangesMutable(adjustmentRangesIndex);
+        adjustmentRange->auxChannelIndex = AUX1 - NON_AUX_CHANNEL_COUNT;
+        adjustmentRange->range = fullRange;
+
+        adjustmentRange->adjustmentConfig = adjustmentConfigIndex;
+        adjustmentRange->auxSwitchChannelIndex = switchChannelIndex;
+
+        return adjustmentRangesIndex++;
+    }
+
+    timedAdjustmentState_t *configureStepwiseAdjustment(uint8_t switchChannelIndex, uint8_t adjustmentConfigIndex) {
+        int adjustmentRangeIndex = configureAdjustmentRange(switchChannelIndex, adjustmentConfigIndex);
+
+        timedAdjustmentState_t *adjustmentState = &stepwiseAdjustments[stepwiseAdjustmentCount++];
+        adjustmentState->adjustmentRangeIndex = adjustmentRangeIndex;
+        adjustmentState->timeoutAt = 0;
+        adjustmentState->ready = true;
+
+        return adjustmentState;
+    }
+
+    void configureContinuosAdjustment(uint8_t switchChannelIndex, uint8_t adjustmentConfigIndex) {
+        int adjustmentRangeIndex = configureAdjustmentRange(switchChannelIndex, adjustmentConfigIndex);
+
+        continuosAdjustmentState_t *adjustmentState = &continuosAdjustments[continuosAdjustmentCount++];
+        adjustmentState->adjustmentRangeIndex = adjustmentRangeIndex;
+        adjustmentState->lastRcData = 0;
     }
 };
+
+#define ADJUSTMENT_CONFIG_RATE_INDEX 1
 
 TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsSticksInMiddle)
 {
     // given
-    //configureAdjustment(0, AUX3 - NON_AUX_CHANNEL_COUNT, &rateAdjustmentConfig);
+    const timedAdjustmentState_t *adjustmentState = configureStepwiseAdjustment(AUX3 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_CONFIG_RATE_INDEX);
 
     // and
     for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
@@ -305,13 +348,12 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsSticksInMiddle)
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 90);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 90);
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 0);
-    //EXPECT_EQ(adjustmentStateMask, 0);
+    EXPECT_EQ(90, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(90, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(0, CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP));
+    EXPECT_EQ(true, adjustmentState->ready);
 }
 
-/*
 TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp)
 {
     // given
@@ -335,9 +377,7 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     rxConfigMutable()->midrc = 1500;
 
     // and
-    adjustmentStateMask = 0;
-    memset(&adjustmentStates, 0, sizeof(adjustmentStates));
-    configureAdjustment(0, AUX3 - NON_AUX_CHANNEL_COUNT, &rateAdjustmentConfig);
+    const timedAdjustmentState_t *adjustmentState = configureStepwiseAdjustment(AUX3 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_CONFIG_RATE_INDEX);
 
     // and
     for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
@@ -352,20 +392,16 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     rcData[AUX3] = PWM_RANGE_MAX;
 
     // and
-    uint8_t expectedAdjustmentStateMask =
-            (1 << 0);
-
-    // and
     fixedMillis = 496;
 
     // when
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 91);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 91);
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 1);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(91, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(91, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(1, CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP));
+    EXPECT_EQ(false, adjustmentState->ready);
 
     //
     // now pretend a short amount of time has passed, but not enough time to allow the value to have been increased
@@ -377,9 +413,9 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     // when
     processRcAdjustments(&controlRateConfig);
 
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 91);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 91);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(91, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(91, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(false, adjustmentState->ready);
 
 
     //
@@ -393,16 +429,12 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     // and
     fixedMillis = 498;
 
-    // and
-    expectedAdjustmentStateMask = adjustmentStateMask &
-            ~(1 << 0);
-
     // when
     processRcAdjustments(&controlRateConfig);
 
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 91);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 91);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(91, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(91, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(true, adjustmentState->ready);
 
 
     //
@@ -412,20 +444,16 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     rcData[AUX3] = PWM_RANGE_MAX;
 
     // and
-    expectedAdjustmentStateMask =
-            (1 << 0);
-
-    // and
     fixedMillis = 499;
 
     // when
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 92);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 92);
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 2);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(92, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(92, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(2, CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP));
+    EXPECT_EQ(false, adjustmentState->ready);
 
     //
     // leaving the switch up, after the original timer would have reset the state should now NOT cause
@@ -439,9 +467,9 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 92);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 92);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(92, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(92, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(false, adjustmentState->ready);
 
     //
     // should still not be able to be increased
@@ -454,9 +482,9 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 92);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 92);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(92, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(92, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(false, adjustmentState->ready);
 
     //
     // 500ms has now passed since the switch was returned to the middle, now that
@@ -471,23 +499,18 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 93);
-    EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 93);
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 3);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(93, controlRateConfig.rcRates[FD_ROLL]);
+    EXPECT_EQ(93, controlRateConfig.rcRates[FD_PITCH]);
+    EXPECT_EQ(3, CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP));
+    EXPECT_EQ(false, adjustmentState->ready);
 }
 
-static const adjustmentConfig_t rateProfileAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_RATE_PROFILE,
-    .mode = ADJUSTMENT_MODE_SELECT,
-    .data = { 3 }
-};
+#define ADJUSTMENT_RATE_PROFILE_INDEX 12
 
 TEST_F(RcControlsAdjustmentsTest, processRcRateProfileAdjustments)
 {
     // given
-    int adjustmentIndex = 3;
-    configureAdjustment(adjustmentIndex, AUX4 - NON_AUX_CHANNEL_COUNT, &rateProfileAdjustmentConfig);
+    configureContinuosAdjustment(AUX4 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_RATE_PROFILE_INDEX);
 
     // and
     for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
@@ -501,54 +524,20 @@ TEST_F(RcControlsAdjustmentsTest, processRcRateProfileAdjustments)
     // and
     rcData[AUX4] = PWM_RANGE_MAX;
 
-    // and
-    uint8_t expectedAdjustmentStateMask =
-            (1 << adjustmentIndex);
-
     // when
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 1);
-    EXPECT_EQ(CALL_COUNTER(COUNTER_CHANGE_CONTROL_RATE_PROFILE), 1);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(1, CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP));
+    EXPECT_EQ(1, CALL_COUNTER(COUNTER_CHANGE_CONTROL_RATE_PROFILE));
 }
 
-static const adjustmentConfig_t pidPitchAndRollPAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_PITCH_ROLL_P,
-    .mode = ADJUSTMENT_MODE_STEP,
-    .data = { 1 }
-};
-
-static const adjustmentConfig_t pidPitchAndRollIAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_PITCH_ROLL_I,
-    .mode = ADJUSTMENT_MODE_STEP,
-    .data = { 1 }
-};
-
-static const adjustmentConfig_t pidPitchAndRollDAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_PITCH_ROLL_D,
-    .mode = ADJUSTMENT_MODE_STEP,
-    .data = { 1 }
-};
-
-static const adjustmentConfig_t pidYawPAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_YAW_P,
-    .mode = ADJUSTMENT_MODE_STEP,
-    .data = { 1 }
-};
-
-static const adjustmentConfig_t pidYawIAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_YAW_I,
-    .mode = ADJUSTMENT_MODE_STEP,
-    .data = { 1 }
-};
-
-static const adjustmentConfig_t pidYawDAdjustmentConfig = {
-    .adjustmentFunction = ADJUSTMENT_YAW_D,
-    .mode = ADJUSTMENT_MODE_STEP,
-    .data = { 1 }
-};
+#define ADJUSTMENT_PITCH_ROLL_P_INDEX 6
+#define ADJUSTMENT_PITCH_ROLL_I_INDEX 7
+#define ADJUSTMENT_PITCH_ROLL_D_INDEX 8
+#define ADJUSTMENT_YAW_P_INDEX 9
+#define ADJUSTMENT_YAW_I_INDEX 10
+#define ADJUSTMENT_YAW_D_INDEX 11
 
 TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController0)
 {
@@ -568,12 +557,12 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController0)
     controlRateConfig_t controlRateConfig;
     memset(&controlRateConfig, 0, sizeof (controlRateConfig));
 
-    configureAdjustment(0, AUX1 - NON_AUX_CHANNEL_COUNT, &pidPitchAndRollPAdjustmentConfig);
-    configureAdjustment(1, AUX2 - NON_AUX_CHANNEL_COUNT, &pidPitchAndRollIAdjustmentConfig);
-    configureAdjustment(2, AUX3 - NON_AUX_CHANNEL_COUNT, &pidPitchAndRollDAdjustmentConfig);
-    configureAdjustment(3, AUX1 - NON_AUX_CHANNEL_COUNT, &pidYawPAdjustmentConfig);
-    configureAdjustment(4, AUX2 - NON_AUX_CHANNEL_COUNT, &pidYawIAdjustmentConfig);
-    configureAdjustment(5, AUX3 - NON_AUX_CHANNEL_COUNT, &pidYawDAdjustmentConfig);
+    const timedAdjustmentState_t *adjustmentState1 = configureStepwiseAdjustment(AUX1 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_PITCH_ROLL_P_INDEX);
+    const timedAdjustmentState_t *adjustmentState2 = configureStepwiseAdjustment(AUX2 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_PITCH_ROLL_I_INDEX);
+    const timedAdjustmentState_t *adjustmentState3 = configureStepwiseAdjustment(AUX3 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_PITCH_ROLL_D_INDEX);
+    const timedAdjustmentState_t *adjustmentState4 = configureStepwiseAdjustment(AUX1 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_YAW_P_INDEX);
+    const timedAdjustmentState_t *adjustmentState5 = configureStepwiseAdjustment(AUX2 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_YAW_I_INDEX);
+    const timedAdjustmentState_t *adjustmentState6 = configureStepwiseAdjustment(AUX3 - NON_AUX_CHANNEL_COUNT, ADJUSTMENT_YAW_D_INDEX);
 
     // and
     for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
@@ -589,23 +578,19 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController0)
     rcData[AUX2] = PWM_RANGE_MAX;
     rcData[AUX3] = PWM_RANGE_MAX;
 
-    // and
-    uint8_t expectedAdjustmentStateMask =
-            (1 << 0) |
-            (1 << 1) |
-            (1 << 2) |
-            (1 << 3) |
-            (1 << 4) |
-            (1 << 5);
-
     // when
     currentPidProfile = &pidProfile;
     rcControlsInit();
     processRcAdjustments(&controlRateConfig);
 
     // then
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 6);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
+    EXPECT_EQ(6, CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP));
+    EXPECT_EQ(false, adjustmentState1->ready);
+    EXPECT_EQ(false, adjustmentState2->ready);
+    EXPECT_EQ(false, adjustmentState3->ready);
+    EXPECT_EQ(false, adjustmentState4->ready);
+    EXPECT_EQ(false, adjustmentState5->ready);
+    EXPECT_EQ(false, adjustmentState6->ready);
 
     // and
     EXPECT_EQ(1,  pidProfile.pid[PID_PITCH].P);
@@ -618,83 +603,6 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController0)
     EXPECT_EQ(18, pidProfile.pid[PID_YAW].I);
     EXPECT_EQ(28, pidProfile.pid[PID_YAW].D);
 }
-*/
-
-#if 0 // only one PID controller
-
-TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController2)
-{
-    // given
-    pidProfile_t pidProfile;
-    memset(&pidProfile, 0, sizeof (pidProfile));
-    pidProfile.pidController = 2;
-    pidProfile.P_f[PIDPITCH] = 0.0f;
-    pidProfile.P_f[PIDROLL] = 5.0f;
-    pidProfile.P_f[PIDYAW] = 7.0f;
-    pidProfile.I_f[PIDPITCH] = 10.0f;
-    pidProfile.I_f[PIDROLL] = 15.0f;
-    pidProfile.I_f[PIDYAW] = 17.0f;
-    pidProfile.D_f[PIDPITCH] = 20.0f;
-    pidProfile.D_f[PIDROLL] = 25.0f;
-    pidProfile.D_f[PIDYAW] = 27.0f;
-
-    // and
-    controlRateConfig_t controlRateConfig;
-    memset(&controlRateConfig, 0, sizeof (controlRateConfig));
-
-    configureAdjustment(0, AUX1 - NON_AUX_CHANNEL_COUNT, &pidPitchAndRollPAdjustmentConfig);
-    configureAdjustment(1, AUX2 - NON_AUX_CHANNEL_COUNT, &pidPitchAndRollIAdjustmentConfig);
-    configureAdjustment(2, AUX3 - NON_AUX_CHANNEL_COUNT, &pidPitchAndRollDAdjustmentConfig);
-    configureAdjustment(3, AUX1 - NON_AUX_CHANNEL_COUNT, &pidYawPAdjustmentConfig);
-    configureAdjustment(4, AUX2 - NON_AUX_CHANNEL_COUNT, &pidYawIAdjustmentConfig);
-    configureAdjustment(5, AUX3 - NON_AUX_CHANNEL_COUNT, &pidYawDAdjustmentConfig);
-
-    // and
-    for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
-        rcData[index] = PWM_RANGE_MIDDLE;
-    }
-
-    // and
-    resetCallCounters();
-    resetMillis();
-
-    // and
-    rcData[AUX1] = PWM_RANGE_MAX;
-    rcData[AUX2] = PWM_RANGE_MAX;
-    rcData[AUX3] = PWM_RANGE_MAX;
-
-    // and
-    uint8_t expectedAdjustmentStateMask =
-            (1 << 0) |
-            (1 << 1) |
-            (1 << 2) |
-            (1 << 3) |
-            (1 << 4) |
-            (1 << 5);
-
-    // when
-    currentPidProfile = &pidProfile;
-    rcControlsInit();
-    processRcAdjustments(&controlRateConfig, &rxConfig);
-
-    // then
-    EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 6);
-    EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
-
-    // and
-    EXPECT_EQ(0.01f, pidProfile.P_f[PIDPITCH]);
-    EXPECT_EQ(5.01f, pidProfile.P_f[PIDROLL]);
-    EXPECT_EQ(7.01f, pidProfile.P_f[PIDYAW]);
-    EXPECT_EQ(10.01f, pidProfile.I_f[PIDPITCH]);
-    EXPECT_EQ(15.01f, pidProfile.I_f[PIDROLL]);
-    EXPECT_EQ(17.01f, pidProfile.I_f[PIDYAW]);
-    EXPECT_EQ(20.001f, pidProfile.D_f[PIDPITCH]);
-    EXPECT_EQ(25.001f, pidProfile.D_f[PIDROLL]);
-    EXPECT_EQ(27.001f, pidProfile.D_f[PIDYAW]);
-
-}
-
-#endif
 
 extern "C" {
 void setConfigDirty(void) {}

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -241,16 +241,14 @@ void resetMillis(void) {
 
 extern "C" {
     PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
-    void configureAdjustment(uint8_t index, uint8_t auxSwitchChannelIndex, const adjustmentConfig_t *adjustmentConfig);
 
-    extern uint8_t adjustmentStateMask;
-    extern adjustmentState_t adjustmentStates[MAX_SIMULTANEOUS_ADJUSTMENT_COUNT];
-
+    /*
     static const adjustmentConfig_t rateAdjustmentConfig = {
         .adjustmentFunction = ADJUSTMENT_RC_RATE,
         .mode = ADJUSTMENT_MODE_STEP,
         .data = { 1 }
     };
+    */
 }
 class RcControlsAdjustmentsTest : public ::testing::Test {
 protected:
@@ -268,9 +266,6 @@ protected:
     };
 
     virtual void SetUp() {
-        adjustmentStateMask = 0;
-        memset(&adjustmentStates, 0, sizeof(adjustmentStates));
-
         PG_RESET(rxConfig);
         rxConfigMutable()->mincheck = DEFAULT_MIN_CHECK;
         rxConfigMutable()->maxcheck = DEFAULT_MAX_CHECK;
@@ -295,7 +290,7 @@ protected:
 TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsSticksInMiddle)
 {
     // given
-    configureAdjustment(0, AUX3 - NON_AUX_CHANNEL_COUNT, &rateAdjustmentConfig);
+    //configureAdjustment(0, AUX3 - NON_AUX_CHANNEL_COUNT, &rateAdjustmentConfig);
 
     // and
     for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
@@ -313,9 +308,10 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsSticksInMiddle)
     EXPECT_EQ(controlRateConfig.rcRates[FD_ROLL], 90);
     EXPECT_EQ(controlRateConfig.rcRates[FD_PITCH], 90);
     EXPECT_EQ(CALL_COUNTER(COUNTER_QUEUE_CONFIRMATION_BEEP), 0);
-    EXPECT_EQ(adjustmentStateMask, 0);
+    //EXPECT_EQ(adjustmentStateMask, 0);
 }
 
+/*
 TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp)
 {
     // given
@@ -622,6 +618,7 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController0)
     EXPECT_EQ(18, pidProfile.pid[PID_YAW].I);
     EXPECT_EQ(28, pidProfile.pid[PID_YAW].D);
 }
+*/
 
 #if 0 // only one PID controller
 


### PR DESCRIPTION
This gets rid of the concept of 'slots' in the adjustment range configuration, as they don't seem to serve any purpose, and make the configuration more convoluted than it needs to be. This means that now any number of adjustment ranges can be active simultaneously, and it is up to the user to set up a meaningful configuration.

The syntax for CLI `adjrange` has been left as it is - since the 'slot' parameter is in the middle of the command, and since it already has a variable length, there is no backwards compatible way of removing it except for the introduction of a new command in parallel to the old one, which seems to be of relatively little value.

The OSD element that is used to display adjustment changes was also overhauled. It now appears whenever an adjustment is changed, and stays on until no changes were made for 2 seconds.

The tests still need to be overhauled, with a new way to mock test data for adjustment ranges to be introduced.