### PR TITLE
Remove second symbol in the Throttle OSD element

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -35,7 +35,6 @@
 #define SYM_LON                     0x98
 #define SYM_ALTITUDE                0x7F
 #define SYM_TOTAL_DISTANCE          0x71
-#define SYM_TRIANGLE                0x05
 
 // RSSI
 #define SYM_RSSI                    0x01

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -35,13 +35,13 @@
 #define SYM_LON                     0x98
 #define SYM_ALTITUDE                0x7F
 #define SYM_TOTAL_DISTANCE          0x71
+#define SYM_TRIANGLE                0x05
 
 // RSSI
 #define SYM_RSSI                    0x01
 
 // Throttle Position (%)
 #define SYM_THR                     0x04
-#define SYM_THR1                    0x05
 
 // Map mode
 #define SYM_HOME                    0x04

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -791,7 +791,7 @@ static void osdElementGpsHomeDirection(osdElementParms_t *element)
             element->buff[0] = osdGetDirectionSymbolFromHeading(h);
         } else {
             // We don't have a HOME symbol in the font, by now we use this
-            element->buff[0] = SYM_THR1;
+            element->buff[0] = SYM_TRIANGLE;
         }
 
     } else {
@@ -1076,9 +1076,7 @@ static void osdElementStickOverlay(osdElementParms_t *element)
 
 static void osdElementThrottlePosition(osdElementParms_t *element)
 {
-    element->buff[0] = SYM_THR;
-    element->buff[1] = SYM_THR1;
-    tfp_sprintf(element->buff + 2, "%3d", calculateThrottlePercent());
+    tfp_sprintf(element->buff, "%c%3d", SYM_THR, calculateThrottlePercent());
 }
 
 static void osdElementTimer(osdElementParms_t *element)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -790,8 +790,8 @@ static void osdElementGpsHomeDirection(osdElementParms_t *element)
             const int h = GPS_directionToHome - DECIDEGREES_TO_DEGREES(attitude.values.yaw);
             element->buff[0] = osdGetDirectionSymbolFromHeading(h);
         } else {
-            // We don't have a HOME symbol in the font, by now we use this
-            element->buff[0] = SYM_TRIANGLE;
+            // We use this symbol when we are at HOME position
+            element->buff[0] = '#';
         }
 
     } else {


### PR DESCRIPTION
The throttle OSD element uses two prefix symbol, but the second does not serve as nothing. Maybe in the past it changed under some circumstances, but now is only a static element. Sample:

![image](https://user-images.githubusercontent.com/2673520/58781573-93c56f80-85dc-11e9-9f94-363bfa708f62.png)

This PR removes it.

The symbol was used too in the direction to home element, when the distance is zero, to show that you are at "home". Maybe in this case is better to use another symbol and in this way we can free the space in the font to be used for other elements. I was thinking maybe in `#` or `=` symbol. The distance to home symbol is a good candidate too, but usually distance and direction are near in the OSD and I don't think it will get good aesthetically.