### PR TITLE
[ADC] Remove bogus inclusion of drivers/accgyro/accgyro.h

### DIFF
--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -28,7 +28,6 @@
 
 #include "build/build_config.h"
 
-#include "drivers/accgyro/accgyro.h"
 #include "drivers/sensor.h"
 #include "adc.h"
 #include "adc_impl.h"

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -28,7 +28,6 @@
 
 #include "common/utils.h"
 
-#include "drivers/accgyro/accgyro.h"
 #include "drivers/adc_impl.h"
 #include "drivers/dma.h"
 #include "drivers/dma_reqmap.h"

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -28,9 +28,7 @@
 
 #include "build/debug.h"
 
-#include "drivers/accgyro/accgyro.h"
 #include "drivers/dma_reqmap.h"
-#include "drivers/system.h"
 
 #include "drivers/io.h"
 #include "io_impl.h"

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -26,14 +26,12 @@
 
 #ifdef USE_ADC
 
-#include "drivers/accgyro/accgyro.h"
 #include "drivers/dma.h"
 #include "drivers/dma_reqmap.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/rcc.h"
 #include "drivers/sensor.h"
-#include "drivers/system.h"
 
 #include "drivers/adc.h"
 #include "drivers/adc_impl.h"

--- a/src/main/drivers/adc_stm32h7xx.c
+++ b/src/main/drivers/adc_stm32h7xx.c
@@ -28,9 +28,6 @@
 
 #include "build/debug.h"
 
-#include "drivers/accgyro/accgyro.h"
-#include "drivers/system.h"
-
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/rcc.h"


### PR DESCRIPTION
In addition to the obvious bogus inclusion of `drivers/accgyro/accgyro.h`, some of these files had `drivers/system.h` which also was bogus.