### PR TITLE
Allow the use of EEPROM_IN_RAM on MCUs.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -31,10 +31,6 @@
 // FIXME remove this for targets that don't need a CLI.  Perhaps use a no-op macro when USE_CLI is not enabled
 // signal that we're in cli mode
 uint8_t cliMode = 0;
-#ifndef EEPROM_IN_RAM
-extern uint8_t __config_start;   // configured via linker script when building binaries.
-extern uint8_t __config_end;
-#endif
 
 #ifdef USE_CLI
 
@@ -4280,12 +4276,7 @@ static void cliStatus(char *cmdline)
 #endif
     cliPrintLinefeed();
 
-#ifdef EEPROM_IN_RAM
-#define CONFIG_SIZE EEPROM_SIZE
-#else
-#define CONFIG_SIZE (&__config_end - &__config_start)
-#endif
-    cliPrintLinef("Config size: %d, Max available config: %d", getEEPROMConfigSize(), CONFIG_SIZE);
+    cliPrintLinef("Config size: %d, Max available config: %d", getEEPROMConfigSize(), getEEPROMStorageSize());
 
     // Sensors
 

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -88,10 +88,8 @@ void initEEPROM(void)
     STATIC_ASSERT(sizeof(configFooter_t) == 2, footer_size_failed);
     STATIC_ASSERT(sizeof(configRecord_t) == 6, record_size_failed);
 
-#ifdef TARGET_EEPROM_INIT
-    void targetEEPROMInit(void);
-
-    targetEEPROMInit();
+#ifdef EEPROM_IN_FILE
+    FLASH_Unlock(); // load existing config file into eepromData
 #endif
 }
 

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -36,11 +36,6 @@
 
 #include "drivers/system.h"
 
-#ifndef EEPROM_IN_RAM
-extern uint8_t __config_start;   // configured via linker script when building binaries.
-extern uint8_t __config_end;
-#endif
-
 static uint16_t eepromConfigSize;
 
 typedef enum {
@@ -92,6 +87,12 @@ void initEEPROM(void)
 
     STATIC_ASSERT(sizeof(configFooter_t) == 2, footer_size_failed);
     STATIC_ASSERT(sizeof(configRecord_t) == 6, record_size_failed);
+
+#ifdef TARGET_EEPROM_INIT
+    void targetEEPROMInit(void);
+
+    targetEEPROMInit();
+#endif
 }
 
 bool isEEPROMVersionValid(void)
@@ -156,6 +157,15 @@ bool isEEPROMStructureValid(void)
 uint16_t getEEPROMConfigSize(void)
 {
     return eepromConfigSize;
+}
+
+size_t getEEPROMStorageSize(void)
+{
+#ifdef EEPROM_IN_RAM
+    return EEPROM_SIZE;
+#else
+    return &__config_end - &__config_start;
+#endif
 }
 
 // find config record for reg + classification (profile info) in EEPROM

--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -29,4 +29,6 @@ bool isEEPROMVersionValid(void);
 bool isEEPROMStructureValid(void);
 bool loadEEPROM(void);
 void writeConfigToEEPROM(void);
+
 uint16_t getEEPROMConfigSize(void);
+size_t getEEPROMStorageSize(void);

--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -26,11 +26,6 @@
 
 #include "config/config_streamer.h"
 
-#ifndef EEPROM_IN_RAM
-extern uint8_t __config_start;   // configured via linker script when building binaries.
-extern uint8_t __config_end;
-#endif
-
 // @todo this is not strictly correct for F4/F7, where sector sizes are variable
 #if !defined(FLASH_PAGE_SIZE)
 // F1
@@ -83,7 +78,9 @@ void config_streamer_start(config_streamer_t *c, uintptr_t base, int size)
     c->address = base;
     c->size = size;
     if (!c->unlocked) {
-#if defined(STM32F7) || defined(STM32H7)
+#if defined(EEPROM_IN_RAM)
+        // NOP
+#elif defined(STM32F7) || defined(STM32H7)
         HAL_FLASH_Unlock();
 #else
         FLASH_Unlock();
@@ -91,7 +88,9 @@ void config_streamer_start(config_streamer_t *c, uintptr_t base, int size)
         c->unlocked = true;
     }
 
-#if defined(STM32F10X)
+#if defined(EEPROM_IN_RAM) || defined(EEPROM_IN_FILE)
+    // NOP
+#elif defined(STM32F10X)
     FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPRTERR);
 #elif defined(STM32F303)
     FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR);
@@ -109,7 +108,9 @@ void config_streamer_start(config_streamer_t *c, uintptr_t base, int size)
     c->err = 0;
 }
 
-#if defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx)
+#if defined(EEPROM_IN_RAM)
+// No flash sector method required.
+#elif defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx)
 /*
 Sector 0    0x08000000 - 0x08007FFF 32 Kbytes
 Sector 1    0x08008000 - 0x0800FFFF 32 Kbytes
@@ -339,7 +340,20 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
     if (c->err != 0) {
         return c->err;
     }
-#if defined(STM32H7)
+#if defined(EEPROM_IN_RAM)
+    if (c->address == (uintptr_t)&eepromData[0]) {
+        memset(eepromData, 0, sizeof(eepromData));
+    }
+
+    uint64_t *dest_addr = (uint64_t *)c->address;
+    uint64_t *src_addr = (uint64_t*)buffer;
+    uint8_t row_index = 4;
+    /* Program the 256 bits flash word */
+    do
+    {
+      *dest_addr++ = *src_addr++;
+    } while (--row_index != 0);
+#elif defined(STM32H7)
     if (c->address % FLASH_PAGE_SIZE == 0) {
         FLASH_EraseInitTypeDef EraseInitStruct = {
             .TypeErase     = FLASH_TYPEERASE_SECTORS,
@@ -385,7 +399,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
     if (c->address % FLASH_PAGE_SIZE == 0) {
 #if defined(STM32F4)
         const FLASH_Status status = FLASH_EraseSector(getFLASHSectorForEEPROM(), VoltageRange_3); //0x08080000 to 0x080A0000
-#else // STM32F3 or STM32F1
+#else // STM32F3, STM32F1 or EEPROM_IN_FILE
         const FLASH_Status status = FLASH_ErasePage(c->address);
 #endif
         if (status != FLASH_COMPLETE) {
@@ -432,7 +446,9 @@ int config_streamer_flush(config_streamer_t *c)
 int config_streamer_finish(config_streamer_t *c)
 {
     if (c->unlocked) {
-#if defined(STM32F7) || defined(STM32H7)
+#if defined(EEPROM_IN_RAM)
+        // NOP
+#elif defined(STM32F7) || defined(STM32H7)
         HAL_FLASH_Lock();
 #else
         FLASH_Lock();

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -204,11 +204,6 @@ static void* tcpThread(void* data) {
     return NULL;
 }
 
-void targetEEPROMInit(void)
-{
-    FLASH_Unlock(); // load existing config file into eepromData
-}
-
 // system
 void systemInit(void) {
     int ret;

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -204,6 +204,11 @@ static void* tcpThread(void* data) {
     return NULL;
 }
 
+void targetEEPROMInit(void)
+{
+    FLASH_Unlock(); // load existing config file into eepromData
+}
+
 // system
 void systemInit(void) {
     int ret;
@@ -212,7 +217,6 @@ void systemInit(void) {
     printf("[system]Init...\n");
 
     SystemCoreClock = 500 * 1e6; // fake 500MHz
-    FLASH_Unlock();
 
     if (pthread_mutex_init(&updateLock, NULL) != 0) {
         printf("Create updateLock error!\n");

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -254,3 +254,5 @@ uint64_t micros64(void);
 uint64_t millis64(void);
 
 int lockMainPID(void);
+
+

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -42,7 +42,7 @@
 
 // file name to save config
 #define EEPROM_FILENAME "eeprom.bin"
-#define EEPROM_IN_RAM
+#define EEPROM_IN_FILE
 #define EEPROM_SIZE     32768
 
 #define U_ID_0 0
@@ -144,13 +144,10 @@
 
 extern uint32_t SystemCoreClock;
 
-#ifdef EEPROM_IN_RAM
+#ifdef EEPROM_IN_FILE
 extern uint8_t eepromData[EEPROM_SIZE];
 #define __config_start (*eepromData)
 #define __config_end (*ARRAYEND(eepromData))
-#else
-extern uint8_t __config_start;   // configured via linker script when building binaries.
-extern uint8_t __config_end;
 #endif
 
 typedef enum

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -144,12 +144,6 @@
 
 extern uint32_t SystemCoreClock;
 
-#ifdef EEPROM_IN_FILE
-extern uint8_t eepromData[EEPROM_SIZE];
-#define __config_start (*eepromData)
-#define __config_end (*ARRAYEND(eepromData))
-#endif
-
 typedef enum
 {
     Mode_TEST = 0x0,

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -337,3 +337,8 @@
 #ifdef STM32F7
 #undef USE_ESCSERIAL
 #endif
+
+#if !defined(EEPROM_IN_RAM) && !defined(EEPROM_IN_FILE)
+extern uint8_t __config_start;   // configured via linker script when building binaries.
+extern uint8_t __config_end;
+#endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -338,7 +338,17 @@
 #undef USE_ESCSERIAL
 #endif
 
-#if !defined(EEPROM_IN_RAM) && !defined(EEPROM_IN_FILE)
+#if defined(EEPROM_IN_RAM) || defined(EEPROM_IN_FILE)
+#ifndef EEPROM_SIZE
+#define EEPROM_SIZE     4096
+#endif
+extern uint8_t eepromData[EEPROM_SIZE];
+#define __config_start (*eepromData)
+#define __config_end (*ARRAYEND(eepromData))
+#else
+#ifndef EEPROM_IN_FLASH
+#define EEPROM_IN_FLASH
+#endif
 extern uint8_t __config_start;   // configured via linker script when building binaries.
 extern uint8_t __config_end;
 #endif

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -225,6 +225,10 @@ uint8_t getMotorCount() {
     return 4;
 }
 
+size_t getEEPROMStorageSize() {
+    return 0;
+}
+
 
 void setPrintfSerialPort(struct serialPort_s) {}
 


### PR DESCRIPTION
This PR is a prerequisite to the PR to support 'EEPROM' on EXTERNAL FLASH (#8378) and SD CARD (#8379)

Reviewers: 
* Please see #8378 and #8379 regarding potential refactoring/cleanup work so that you understand the big-picture.

This mode of 'EEPROM' is very helpful in porting BF onto new CPUs - you can defer implementation of an 'EEPROM' storage solution.

If the MCU also supports PERSISTENT ram (not erased on a warm boot) it
allows testing of config changes without wearing out your flash but support for PERSISTENT is not required to allow BF to boot.

instructions for use:

linker script
-------------
comment out `__config_start/__config_end`

target.c
--------
add 
`PERSISTENT uint8_t eepromData[EEPROM_SIZE]; // persistent, so it survives warm boots.`

target.h
--------
add
`extern uint8_t eepromData[EEPROM_SIZE];`

Note:
SITL actually keeps the EEPROM in a FILE, loaded into RAM using alternate FLASH_* implementation.
