### PR TITLE
[H7] Use channel member for H7 DMA request

### DIFF
--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -63,12 +63,9 @@ typedef struct adcDevice_s {
     ADC_TypeDef* ADCx;
     rccPeriphTag_t rccADC;
 #if !defined(USE_DMA_SPEC)
-#if defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
     DMA_Stream_TypeDef* DMAy_Streamx;
     uint32_t channel;
-#elif defined(STM32H7)
-    DMA_Stream_TypeDef* DMAy_Streamx;
-    uint32_t request;
 #else
     DMA_Channel_TypeDef* DMAy_Channelx;
 #endif

--- a/src/main/drivers/adc_stm32h7xx.c
+++ b/src/main/drivers/adc_stm32h7xx.c
@@ -83,19 +83,19 @@ const adcDevice_t adcHardware[ADCDEV_COUNT] = {
         .ADCx = ADC1_INSTANCE,
         .rccADC = RCC_AHB1(ADC12),
         .DMAy_Streamx = ADC1_DMA_STREAM,
-        .request = DMA_REQUEST_ADC1,
+        .channel = DMA_REQUEST_ADC1,
     },
     { .ADCx = ADC2_INSTANCE,
         .rccADC = RCC_AHB1(ADC12),
         .DMAy_Streamx = ADC2_DMA_STREAM,
-        .request = DMA_REQUEST_ADC2,
+        .channel = DMA_REQUEST_ADC2,
     },
     // ADC3 can be serviced by BDMA also, but we settle for DMA1 or 2 (for now).
     {
         .ADCx = ADC3_INSTANCE,
         .rccADC = RCC_AHB4(ADC3),
         .DMAy_Streamx = ADC3_DMA_STREAM,
-        .request = DMA_REQUEST_ADC3,
+        .channel = DMA_REQUEST_ADC3,
     }
 };
 
@@ -361,7 +361,7 @@ void adcInit(const adcConfig_t *config)
         dmaInit(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev));
 
         adc->DmaHandle.Instance                 = adc->DMAy_Streamx;
-        adc->DmaHandle.Init.Request             = adc->request;
+        adc->DmaHandle.Init.Request             = adc->channel;
         adc->DmaHandle.Init.Direction           = DMA_PERIPH_TO_MEMORY;
         adc->DmaHandle.Init.PeriphInc           = DMA_PINC_DISABLE;
         adc->DmaHandle.Init.MemInc              = DMA_MINC_ENABLE;

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -77,13 +77,8 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     uint32_t dmaChannel = dmaSpec->channel;
 #else
     dmaStream_t *dmaRef = timerHardware->dmaRef;
-#ifdef STM32H7
-    uint32_t dmaChannel = timerHardware->dmaRequest;
-#else
     uint32_t dmaChannel = timerHardware->dmaChannel;
 #endif
-#endif
-
 
     if (dmaRef == NULL) {
         return false;

--- a/src/main/drivers/pwm_output_dshot_hal_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal_hal.c
@@ -380,7 +380,7 @@ P    -    High -     High -
         motor->dmaBuffer[DSHOT_DMA_BUFFER_SIZE-1] = 0; // XXX Is this necessary?
 
         motor->hdma_tim.Instance = timerHardware->dmaRef;
-        motor->hdma_tim.Init.Request = timerHardware->dmaRequest;
+        motor->hdma_tim.Init.Request = timerHardware->dmaChannel;
 
         /* Link hdma_tim to hdma[x] (channelx) */
         __HAL_LINKDMA(&motor->TimHandle, hdma[motor->timerDmaIndex], motor->hdma_tim);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -121,12 +121,13 @@ typedef struct timerHardware_s {
     DMA_Channel_TypeDef *dmaRefConfigured;
 #endif
 #else
-#if defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
     DMA_Stream_TypeDef *dmaRef;
-    uint32_t dmaChannel;
-#elif defined(STM32H7)
-    DMA_Stream_TypeDef *dmaRef;
-    uint8_t dmaRequest;
+
+    // For F4 and F7, dmaChannel is channel for DMA1 or DMA2.
+    // For H7, dmaChannel is DMA request number for DMAMUX
+
+    uint32_t dmaChannel; // XXX Can be much smaller (e.g. uint8_t)
 #else
     DMA_Channel_TypeDef *dmaRef;
 #endif

--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -89,11 +89,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
     uint32_t dmaChannel = dmaSpec->channel;
 #else
     dmaStream_t *dmaRef = timerHardware->dmaRef;
-#ifdef STM32H7
-    uint32_t dmaChannel = timerHardware->dmaRequest;
-#else
     uint32_t dmaChannel = timerHardware->dmaChannel;
-#endif
 #endif
 
     if (dmaRef == NULL) {


### PR DESCRIPTION
In preparation for addition of `USE_DMA_SPEC` and `USE_TIMER_MGMT` to H7, I've decided to use DMA "channel" member in various objects for DMA "request" of H7 MCUs to reduce conditionals.