### PR TITLE
Fixed absolute adjustments processing without RX input.

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -820,6 +820,10 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig)
         MARK_ADJUSTMENT_FUNCTION_AS_BUSY(adjustmentIndex);
     }
 
+    if (!canUseRxData) {
+        return;
+    }
+
     // Process Absolute adjustments
     for (int i = 0; i < activeAbsoluteAdjustmentCount; i++) {
         static int16_t lastRcData[MAX_ADJUSTMENT_RANGE_COUNT] = { 0 };


### PR DESCRIPTION
This is a bug for a missing check for valid (non-failsafe) RC data in the processing of adjustment ranges. The same bug was fixed by a far reaching rewrite in `master` (#8369), making it impossible to fix this in `master` and then cherry-pick it into `4.0.x-maintenance`. Nonetheless this should be fixed in the maintenance branch.