### PR TITLE
Fix Flash API timeout issues.

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -205,9 +205,9 @@ bool flashIsReady(void)
     return flashDevice.vTable->isReady(&flashDevice);
 }
 
-bool flashWaitForReady(uint32_t timeoutMillis)
+bool flashWaitForReady(void)
 {
-    return flashDevice.vTable->waitForReady(&flashDevice, timeoutMillis);
+    return flashDevice.vTable->waitForReady(&flashDevice);
 }
 
 void flashEraseSector(uint32_t address)
@@ -247,7 +247,9 @@ int flashReadBytes(uint32_t address, uint8_t *buffer, int length)
 
 void flashFlush(void)
 {
-    flashDevice.vTable->flush(&flashDevice);
+    if (flashDevice.vTable->flush) {
+        flashDevice.vTable->flush(&flashDevice);
+    }
 }
 
 static const flashGeometry_t noFlashGeometry = {

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -51,7 +51,7 @@ void flashPreInit(const flashConfig_t *flashConfig);
 bool flashInit(const flashConfig_t *flashConfig);
 
 bool flashIsReady(void);
-bool flashWaitForReady(uint32_t timeoutMillis);
+bool flashWaitForReady(void);
 void flashEraseSector(uint32_t address);
 void flashEraseCompletely(void);
 void flashPageProgramBegin(uint32_t address);

--- a/src/main/drivers/flash_impl.h
+++ b/src/main/drivers/flash_impl.h
@@ -53,12 +53,13 @@ typedef struct flashDevice_s {
     // for writes. This allows us to avoid polling for writable status
     // when it is definitely ready already.
     bool couldBeBusy;
+    uint32_t timeoutAt;
     flashDeviceIO_t io;
 } flashDevice_t;
 
 typedef struct flashVTable_s {
     bool (*isReady)(flashDevice_t *fdevice);
-    bool (*waitForReady)(flashDevice_t *fdevice, uint32_t timeoutMillis);
+    bool (*waitForReady)(flashDevice_t *fdevice);
     void (*eraseSector)(flashDevice_t *fdevice, uint32_t address);
     void (*eraseCompletely)(flashDevice_t *fdevice);
     void (*pageProgramBegin)(flashDevice_t *fdevice, uint32_t address);

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -68,12 +68,14 @@
 #define JEDEC_ID_CYPRESS_S25FL128L     0x016018
 #define JEDEC_ID_BERGMICRO_W25Q32      0xE04016
 
+// IMPORTANT: Timeout values are currently required to be set to the highest value required by any of the supported flash chips by this driver.
+
 // The timeout we expect between being able to issue page program instructions
 #define DEFAULT_TIMEOUT_MILLIS       6
-
-// These take sooooo long:
 #define SECTOR_ERASE_TIMEOUT_MILLIS  5000
-#define BULK_ERASE_TIMEOUT_MILLIS    21000
+
+// etracer65 notes: For bulk erase The 25Q16 takes about 3 seconds and the 25Q128 takes about 49
+#define BULK_ERASE_TIMEOUT_MILLIS    50000
 
 #define M25P16_PAGESIZE 256
 

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -80,8 +80,6 @@ static void w25m_dieSelect(busDevice_t *busdev, int die)
 
 static bool w25m_isReady(flashDevice_t *fdevice)
 {
-    UNUSED(fdevice);
-
     for (int die = 0 ; die < dieCount ; die++) {
         if (dieDevice[die].couldBeBusy) {
             w25m_dieSelect(fdevice->io.handle.busdev, die);
@@ -94,11 +92,11 @@ static bool w25m_isReady(flashDevice_t *fdevice)
     return true;
 }
 
-static bool w25m_waitForReady(flashDevice_t *fdevice, uint32_t timeoutMillis)
+static bool w25m_waitForReady(flashDevice_t *fdevice)
 {
-    uint32_t time = millis();
-    while (!w25m_isReady(fdevice)) {
-        if (millis() - time > timeoutMillis) {
+    for (int die = 0 ; die < dieCount ; die++) {
+        w25m_dieSelect(fdevice->io.handle.busdev, die);
+        if (!dieDevice[die].vTable->waitForReady(&dieDevice[die])) {
             return false;
         }
     }

--- a/src/main/drivers/flash_w25n01g.c
+++ b/src/main/drivers/flash_w25n01g.c
@@ -122,6 +122,8 @@ serialPort_t *debugSerialPort = NULL;
 #define W25N01G_BLOCK_TO_PAGE(block) ((block) * W25N01G_PAGES_PER_BLOCK)
 #define W25N01G_BLOCK_TO_LINEAR(block) (W25N01G_BLOCK_TO_PAGE(block) * W25N01G_PAGE_SIZE)
 
+// IMPORTANT: Timeout values are currently required to be set to the highest value required by any of the supported flash chips by this driver
+
 // The timeout values (2ms minimum to avoid 1 tick advance in consecutive calls to millis).
 #define W25N01G_TIMEOUT_PAGE_READ_MS        2   // tREmax = 60us (ECC enabled)
 #define W25N01G_TIMEOUT_PAGE_PROGRAM_MS     2   // tPPmax = 700us


### PR DESCRIPTION
Flash operations can specify how long to wait before the next operation is issued.

Prior to this the amount of time waited, and when, was wrong. e.g.

m25p16_eraseCompletely - possibly waits ages TO START, starts, exits.
m25p16_pageProgramContinue - waits DEFAULT_TIMEOUT_MILLIS to START,
starts, exits.

m25p16_pageProgramContinue would fail to write to the flash as the
device was still busy erasing and didn't wait long enough.

what happens now is:
m25p16_eraseCompletely - waits using the current timeout, starts, sets
timeout to be `now + BULK_ERASE_TIMEOUT_MILLIS`, exits.
m25p16_pageProgramContinue - waits using the current
`BULK_ERASE_TIMEOUT_MILLIS`, starts, exists, sets timeout to be `now +
DEFAULT_TIMEOUT_MILLIS`.

There were other similar incorrect timeout/wait operations in the w25n01g driver.

Since the timeout value is now stored in the flashDevice_t the solution also works for multi-die devices which use an instance of flashDevice_t for each die.
