### PR TITLE
Fix F1/F3 OPBL targets using wrong linker script.

### DIFF
--- a/make/mcu/STM32F1.mk
+++ b/make/mcu/STM32F1.mk
@@ -38,7 +38,10 @@ DEVICE_STDPERIPH_SRC := $(DEVICE_STDPERIPH_SRC) \
 
 endif
 
+ifeq ($(LD_SCRIPT),)
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f103_$(FLASH_SIZE)k.ld
+endif
+
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m3
 
 ifeq ($(DEVICE_FLAGS),)

--- a/make/mcu/STM32F3.mk
+++ b/make/mcu/STM32F3.mk
@@ -57,7 +57,9 @@ INCLUDE_DIRS    := $(INCLUDE_DIRS) \
 VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
+ifeq ($(LD_SCRIPT),)
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f303_$(FLASH_SIZE)k.ld
+endif
 
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
 DEVICE_FLAGS    = -DSTM32F303xC -DSTM32F303


### PR DESCRIPTION
OPBL build support is broken in master for F1/F3.

the linker script is configured at the top of STM32F1.mk/F3.mk for OPBL targets, then overridden at around line 41.

```... obj/main/CC3D_OPBL/drivers/usb_io.o -lm -nostartfiles --specs=nano.specs -lc -lnosys -mthumb -mcpu=cortex-m3 -flto -fuse-linker-plugin -ffast-math -Os  -static -Wl,-gc-sections,-Map,./obj/main/betaflight_CC3D_OPBL.map -Wl,-L./src/link -Wl,--cref -Wl,--no-wchar-size-warning -Wl,--print-memory-usage -T./src/link/stm32_flash_f103_128k.ld```

you can see the wrong linker script used above.

fixing it causes flash overflow for CC3D_OPBL target.
