### PR TITLE
Fix compile error if USE_ESC_SENSOR is not defined

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -64,6 +64,7 @@
 
 #include "drivers/display.h"
 #include "drivers/max7456_symbols.h"
+#include "drivers/pwm_output.h"
 #include "drivers/time.h"
 #include "drivers/vtx_common.h"
 
@@ -82,7 +83,6 @@
 #include "flight/imu.h"
 #include "flight/mixer.h"
 #include "flight/pid.h"
-#include "flight/rpm_filter.h"
 
 #include "io/beeper.h"
 #include "io/gps.h"
@@ -158,21 +158,22 @@ static uint32_t blinkBits[(OSD_ITEM_COUNT + 31) / 32];
 #define IS_BLINK(item) (blinkBits[(item) / 32] & (1 << ((item) % 32)))
 #define BLINK(item) (IS_BLINK(item) && blinkState)
 
-#if defined(USE_ESC_SENSOR) || defined(USE_RPM_FILTER)
+#if defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
 typedef int (*getEscRpmOrFreqFnPtr)(int i);
 
 static int getEscRpm(int i)
 {
-#ifdef USE_RPM_FILTER
+#ifdef USE_DSHOT_TELEMETRY
     if (motorConfig()->dev.useDshotTelemetry) {
         return 100.0f / (motorConfig()->motorPoleCount / 2.0f) * getDshotTelemetry(i);
     }
 #endif
+#ifdef USE_ESC_SENSOR
     if (featureIsEnabled(FEATURE_ESC_SENSOR)) {
         return calcEscRpm(getEscSensorData(i)->rpm);
-    } else {
-        return 0;
     }
+#endif
+    return 0;
 }
 
 static int getEscRpmFreq(int i)
@@ -720,7 +721,7 @@ static void osdElementEscTemperature(osdElementParms_t *element)
 }
 #endif // USE_ESC_SENSOR
 
-#if defined(USE_ESC_SENSOR) || defined(USE_RPM_FILTER)
+#if defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
 static void osdElementEscRpm(osdElementParms_t *element)
 {
     renderOsdEscRpmOrFreq(&getEscRpm,element);
@@ -1478,7 +1479,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #ifdef USE_ESC_SENSOR
     [OSD_ESC_TMP]                 = osdElementEscTemperature,
 #endif
-#if defined(USE_RPM_FILTER) || defined(USE_ESC_SENSOR)
+#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
     [OSD_ESC_RPM]                 = osdElementEscRpm,
 #endif
     [OSD_REMAINING_TIME_ESTIMATE] = osdElementRemainingTimeEstimate,
@@ -1513,7 +1514,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
     [OSD_STICK_OVERLAY_RIGHT]     = osdElementStickOverlay,
 #endif
     [OSD_DISPLAY_NAME]            = osdElementDisplayName,
-#if defined(USE_RPM_FILTER) || defined(USE_ESC_SENSOR)
+#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
     [OSD_ESC_RPM_FREQ]            = osdElementEscRpmFreq,
 #endif
 #ifdef USE_PROFILE_NAMES
@@ -1570,7 +1571,7 @@ void osdAnalyzeActiveElements(void)
     }
 #endif
 
-#if defined(USE_RPM_FILTER) || defined(USE_ESC_SENSOR)
+#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
     if ((featureIsEnabled(FEATURE_ESC_SENSOR)) || (motorConfig()->dev.useDshotTelemetry)) {
         osdAddActiveElement(OSD_ESC_RPM);
         osdAddActiveElement(OSD_ESC_RPM_FREQ);


### PR DESCRIPTION
Also correct dependencies to USE_DSHOT_TELEMETRY instead of USE_RPM_FILTER.