### PR TITLE
Some fixes for persistent stats.

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -984,11 +984,6 @@ bool processRx(timeUs_t currentTimeUs)
 
     pidSetAntiGravityState(IS_RC_MODE_ACTIVE(BOXANTIGRAVITY) || featureIsEnabled(FEATURE_ANTI_GRAVITY));
 
-#ifdef USE_PERSISTENT_STATS
-    /* allow the stats collector to do periodic tasks */
-    statsOnLoop();
-#endif
-
     return true;
 }
 

--- a/src/main/fc/stats.h
+++ b/src/main/fc/stats.h
@@ -1,4 +1,24 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 void statsOnArm(void);
 void statsOnDisarm(void);
-void statsOnLoop(void);


### PR DESCRIPTION
Couple of changes here:
- the stats functionality is rewritten from polling on the RX loop to using dispatch to effect a delayed config write;
- in the case of select / absolute adjustment ranges that are permanently enabled, the config is written even if the adjustment range effected other changes in it - the changed values will never be used anyway, as the adjustment range will override them right from the start.