### PR TITLE
Set line endings for the .config files for unified targets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ Makefile text eol=lf
 *.bat eol=crlf
 *.txt text eol=lf
 *.sh text eol=lf
+*.config text eol=lf


### PR DESCRIPTION
I was wondering why a diff on a unified target changed the entire file, this PR is the result of that. 