### PR TITLE
Add units symbol to the vario OSD element

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -91,6 +91,9 @@
 #define SYM_ARROW_15                0x6E
 #define SYM_ARROW_16                0x6F
 
+#define SYM_ARROW_SMALL_UP          0x75
+#define SYM_ARROW_SMALL_DOWN        0x76
+
 // AH Bars
 #define SYM_AH_BAR9_0               0x80
 #define SYM_AH_BAR9_1               0x81

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -136,6 +136,8 @@
 #define SYM_SPEED                   0x70
 #define SYM_KPH                     0x9E
 #define SYM_MPH                     0x9D
+#define SYM_MPS                     0x9F
+#define SYM_FTPS                    0x99
 
 // Menu cursor
 #define SYM_CURSOR                  SYM_AH_LEFT

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -425,6 +425,16 @@ char osdGetSpeedToSelectedUnitSymbol(void)
     }
 }
 
+char osdGetVarioToSelectedUnitSymbol(void)
+{
+    switch (osdConfig()->units) {
+    case OSD_UNIT_IMPERIAL:
+        return SYM_FTPS;
+    default:
+        return SYM_MPS;
+    }
+}
+
 #if defined(USE_ADC_INTERNAL) || defined(USE_ESC_SENSOR)
 char osdGetTemperatureSymbolForSelectedUnit(void)
 {
@@ -937,7 +947,7 @@ static void osdElementNumericalVario(osdElementParms_t *element)
     if (haveBaro || haveGps) {
         const int verticalSpeed = osdGetMetersToSelectedUnit(getEstimatedVario());
         const char directionSymbol = verticalSpeed < 0 ? SYM_ARROW_SOUTH : SYM_ARROW_NORTH;
-        tfp_sprintf(element->buff, "%c%01d.%01d", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10));
+        tfp_sprintf(element->buff, "%c%01d.%01d%c", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10), osdGetVarioToSelectedUnitSymbol());
     } else {
         // We use this symbol when we don't have a valid measure
         element->buff[0] = SYM_COLON;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -946,7 +946,7 @@ static void osdElementNumericalVario(osdElementParms_t *element)
 #endif // USE_GPS
     if (haveBaro || haveGps) {
         const int verticalSpeed = osdGetMetersToSelectedUnit(getEstimatedVario());
-        const char directionSymbol = verticalSpeed < 0 ? SYM_ARROW_SOUTH : SYM_ARROW_NORTH;
+        const char directionSymbol = verticalSpeed < 0 ? SYM_ARROW_SMALL_DOWN : SYM_ARROW_SMALL_UP;
         tfp_sprintf(element->buff, "%c%01d.%01d%c", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10), osdGetVarioToSelectedUnitSymbol());
     } else {
         // We use this symbol when we don't have a valid measure


### PR DESCRIPTION
As discussed here: https://github.com/betaflight/betaflight/pull/8414 this adds unit symbol (`m/s` or `ft/s`) to the vario OSD element.

I will push the Configurator part in some minutes.