### PR TITLE
Added a gyro sensitivity channel 

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -930,6 +930,7 @@ const clivalue_t valueTable[] = {
     { "runaway_takeoff_deactivate_delay",  VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 100, 1000 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_delay) },           // deactivate time in ms
     { "runaway_takeoff_deactivate_throttle_percent",  VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_throttle) }, // minimum throttle percentage during deactivation phase
 #endif
+    { "pid_adjust_aux_channel",     VAR_UINT8  | MASTER_VALUE,  .config.minmaxUnsigned = { 0, MAX_AUX_CHANNEL_COUNT }, PG_PID_CONFIG, offsetof(pidConfig_t, pid_adjust_aux_channel) },
 
 // PG_PID_PROFILE
 #ifdef USE_PROFILE_NAMES

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -180,6 +180,7 @@ typedef struct pidConfig_s {
     uint8_t runaway_takeoff_prevention;          // off, on - enables pidsum runaway disarm logic
     uint16_t runaway_takeoff_deactivate_delay;   // delay in ms for "in-flight" conditions before deactivation (successful flight)
     uint8_t runaway_takeoff_deactivate_throttle; // minimum throttle percent required during deactivation phase
+    uint8_t pid_adjust_aux_channel;              // AUX channel-No (0:off / 1-n:AUX1-AUXn) used to adjust PID according to the flight mode (helicopter like vehicles)
 } pidConfig_t;
 
 PG_DECLARE(pidConfig_t, pidConfig);

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -61,6 +61,10 @@ extern "C" {
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
 
+    #include "rx/rx.h"
+
+    int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+
     gyro_t gyro;
     attitudeEulerAngles_t attitude;
 

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -60,8 +60,6 @@ extern "C" {
 
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
-    
-    #include "rx/rx.h"
 
     gyro_t gyro;
     attitudeEulerAngles_t attitude;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -60,6 +60,8 @@ extern "C" {
 
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
+    
+    #include "rx/rx.h"
 
     gyro_t gyro;
     attitudeEulerAngles_t attitude;


### PR DESCRIPTION
Intended for use in fixed speed variable pitch vehicles and helicopters.

`cli/settings.c`
- added cli variable `pid_adjust_aux_channel` to configure an AUX channel for PID adjustments according to the headspeed.

`flight/pid.h`, `flight/pid.c`
- code for the gyro sensitivity channel.

The history can be read here: 
https://github.com/betaflight/betaflight/pull/8385

