### PR TITLE
Fix missing VARIO OSD element without baro (using GPS)

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -60,7 +60,7 @@
 #endif
 #endif
 
-#if !defined(USE_BARO)
+#if !defined(USE_BARO) && !defined(USE_GPS)
 #undef USE_VARIO
 #endif
 


### PR DESCRIPTION
Fixes a missing VARIO element in the OSD when the target does not support a baro as discussed here: https://github.com/betaflight/betaflight/pull/8419. The VARIO elements works too with a GPS.