### PR TITLE
Refactored arbitrary gyro and mag alignment.

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -171,7 +171,8 @@ static const char * const lookupTableAlignment[] = {
     "CW0FLIP",
     "CW90FLIP",
     "CW180FLIP",
-    "CW270FLIP"
+    "CW270FLIP",
+    "CUSTOM",
 };
 
 #ifdef USE_MULTI_GYRO
@@ -643,7 +644,10 @@ const clivalue_t valueTable[] = {
 
 // PG_COMPASS_CONFIG
 #ifdef USE_MAG
-    { "align_mag",                  VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_align) },
+    { "align_mag",                  VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_alignment) },
+    { "mag_align_roll",             VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_customAlignment.roll) },
+    { "mag_align_pitch",            VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_customAlignment.pitch) },
+    { "mag_align_yaw",              VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_customAlignment.yaw) },
     { "mag_bustype",                VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BUS_TYPE }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_bustype) },
     { "mag_i2c_device",             VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_i2c_device) },
     { "mag_i2c_address",            VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_COMPASS_CONFIG, offsetof(compassConfig_t, mag_i2c_address) },
@@ -1436,13 +1440,19 @@ const clivalue_t valueTable[] = {
     { "gyro_1_spibus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, SPIDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, spiBus) },
     { "gyro_1_i2cBus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, i2cBus) },
     { "gyro_1_i2c_address", VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, i2cAddress) },
-    { "gyro_1_sensor_align", VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, align) },
+    { "gyro_1_sensor_align", VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, alignment) },
+    { "gyro_1_align_roll", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, customAlignment.roll) },
+    { "gyro_1_align_pitch", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, customAlignment.pitch) },
+    { "gyro_1_align_yaw", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 0, customAlignment.yaw) },
 #ifdef USE_MULTI_GYRO
     { "gyro_2_bustype", VAR_UINT8 | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BUS_TYPE }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, bustype) },
     { "gyro_2_spibus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, SPIDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, spiBus) },
     { "gyro_2_i2cBus",  VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, i2cBus) },
     { "gyro_2_i2c_address", VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, i2cAddress) },
-    { "gyro_2_sensor_align", VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, align) },
+    { "gyro_2_sensor_align", VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, alignment) },
+    { "gyro_2_align_roll", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, customAlignment.roll) },
+    { "gyro_2_align_pitch", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, customAlignment.pitch) },
+    { "gyro_2_align_yaw", VAR_INT16  | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, customAlignment.yaw) },
 #endif
 #ifdef I2C_FULL_RECONFIGURABILITY
 #ifdef USE_I2C_DEVICE_1

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -93,6 +93,10 @@ typedef union {
     fp_angles_def angles;
 } fp_angles_t;
 
+typedef struct fp_rotationMatrix_s {
+    float m[3][3];              // matrix
+} fp_rotationMatrix_t;
+
 int gcd(int num, int denom);
 float powerf(float base, int exp);
 int32_t applyDeadband(int32_t value, int32_t deadband);
@@ -110,7 +114,8 @@ float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float des
 void normalizeV(struct fp_vector *src, struct fp_vector *dest);
 
 void rotateV(struct fp_vector *v, fp_angles_t *delta);
-void buildRotationMatrix(fp_angles_t *delta, float matrix[3][3]);
+void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation);
+void applyRotation(float *v, fp_rotationMatrix_t *rotationMatrix);
 
 int32_t quickMedianFilter3(int32_t * v);
 int32_t quickMedianFilter5(int32_t * v);

--- a/src/main/common/sensor_alignment.c
+++ b/src/main/common/sensor_alignment.c
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stdbool.h"
+#include "string.h"
+
+#include "platform.h"
+
+#include "build/build_config.h"
+
+#include "common/sensor_alignment.h"
+#include "common/sensor_alignment_impl.h"
+
+void buildRotationMatrixFromAlignment(const sensorAlignment_t* sensorAlignment, fp_rotationMatrix_t* rm)
+{
+    fp_angles_t rotationAngles;
+    rotationAngles.angles.roll  = DECIDEGREES_TO_RADIANS(sensorAlignment->roll);
+    rotationAngles.angles.pitch = DECIDEGREES_TO_RADIANS(sensorAlignment->pitch);
+    rotationAngles.angles.yaw   = DECIDEGREES_TO_RADIANS(sensorAlignment->yaw);
+
+    buildRotationMatrix(&rotationAngles, rm);
+}
+
+
+void buildAlignmentFromStandardAlignment(sensorAlignment_t* sensorAlignment, sensor_align_e alignment)
+{
+    if (alignment == ALIGN_CUSTOM || alignment == ALIGN_DEFAULT) {
+        return;
+    }
+
+    uint8_t alignmentBits = ALIGNMENT_TO_BITMASK(alignment);
+
+    memset(sensorAlignment, 0x00, sizeof(sensorAlignment_t));
+
+    for (int axis = 0; axis < FLIGHT_DYNAMICS_INDEX_COUNT; axis++) {
+        sensorAlignment->raw[axis] = DEGREES_TO_DECIDEGREES(90) * ALIGNMENT_AXIS_ROTATIONS(alignmentBits, axis);
+    }
+}

--- a/src/main/common/sensor_alignment.h
+++ b/src/main/common/sensor_alignment.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "axis.h"
+#include "maths.h"
+
+typedef enum {
+    ALIGN_DEFAULT = 0, // driver-provided alignment
+
+    // the order of these 8 values also correlate to corresponding code in ALIGNMENT_TO_BITMASK.
+
+                            // R, P, Y
+    CW0_DEG = 1,            // 00,00,00
+    CW90_DEG = 2,           // 00,00,01
+    CW180_DEG = 3,          // 00,00,10
+    CW270_DEG = 4,          // 00,00,11
+    CW0_DEG_FLIP = 5,       // 00,10,00 // _FLIP = 2x90 degree PITCH rotations
+    CW90_DEG_FLIP = 6,      // 00,10,01
+    CW180_DEG_FLIP = 7,     // 00,10,10
+    CW270_DEG_FLIP = 8,     // 00,10,11
+
+    ALIGN_CUSTOM = 9,    // arbitrary sensor angles, e.g. for external sensors
+} sensor_align_e;
+
+typedef union sensorAlignment_u {
+    // value order is the same as axis_e
+
+    // values are in DECIDEGREES, and should be limited to +/- 3600
+
+    int16_t raw[XYZ_AXIS_COUNT];
+    struct {
+        int16_t roll;
+        int16_t pitch;
+        int16_t yaw;
+    };
+} sensorAlignment_t;
+
+#define SENSOR_ALIGNMENT(ROLL, PITCH, YAW) ((sensorAlignment_t){\
+    .roll = DEGREES_TO_DECIDEGREES(ROLL), \
+    .pitch = DEGREES_TO_DECIDEGREES(PITCH), \
+    .yaw = DEGREES_TO_DECIDEGREES(YAW), \
+})
+
+#define CUSTOM_ALIGN_CW0_DEG         SENSOR_ALIGNMENT(  0,   0,   0)
+#define CUSTOM_ALIGN_CW90_DEG        SENSOR_ALIGNMENT(  0,   0,  90)
+#define CUSTOM_ALIGN_CW180_DEG       SENSOR_ALIGNMENT(  0,   0, 180)
+#define CUSTOM_ALIGN_CW270_DEG       SENSOR_ALIGNMENT(  0,   0, 270)
+#define CUSTOM_ALIGN_CW0_DEG_FLIP    SENSOR_ALIGNMENT(  0, 180,   0)
+#define CUSTOM_ALIGN_CW90_DEG_FLIP   SENSOR_ALIGNMENT(  0, 180,  90)
+#define CUSTOM_ALIGN_CW180_DEG_FLIP  SENSOR_ALIGNMENT(  0, 180, 180)
+#define CUSTOM_ALIGN_CW270_DEG_FLIP  SENSOR_ALIGNMENT(  0, 180, 270)
+
+void buildRotationMatrixFromAlignment(const sensorAlignment_t* alignment, fp_rotationMatrix_t* rm);
+void buildAlignmentFromStandardAlignment(sensorAlignment_t* sensorAlignment, sensor_align_e alignment);

--- a/src/main/common/sensor_alignment_impl.h
+++ b/src/main/common/sensor_alignment_impl.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+//
+// alignment bitmasks
+//
+
+#define ALIGNMENT_ROTATION_WIDTH 2
+
+#define ALIGNMENT_YAW_ROTATIONS_POSITION   (0 * ALIGNMENT_ROTATION_WIDTH)
+#define ALIGNMENT_PITCH_ROTATIONS_POSITION (1 * ALIGNMENT_ROTATION_WIDTH)
+#define ALIGNMENT_ROLL_ROTATIONS_POSITION  (2 * ALIGNMENT_ROTATION_WIDTH)
+
+#define ALIGNMENT_YAW_ROTATIONS_MASK (0x3 << ALIGNMENT_YAW_ROTATIONS_POSITION)
+#define ALIGNMENT_PITCH_ROTATIONS_MASK (0x3 << ALIGNMENT_PITCH_ROTATIONS_POSITION)
+#define ALIGNMENT_ROLL_ROTATIONS_MASK (0x3 << ALIGNMENT_ROLL_ROTATIONS_POSITION)
+
+#define ALIGNMENT_AXIS_ROTATIONS_MASK(axis) (0x3 << ((FD_YAW - axis) * ALIGNMENT_ROTATION_WIDTH))
+
+#define ALIGNMENT_YAW_ROTATIONS(bits) ((bits & ALIGNMENT_YAW_ROTATIONS_MASK) >> ALIGNMENT_YAW_ROTATIONS_POSITION)
+#define ALIGNMENT_PITCH_ROTATIONS(bits) ((bits & ALIGNMENT_PITCH_ROTATIONS_MASK) >> ALIGNMENT_PITCH_ROTATIONS_POSITION)
+#define ALIGNMENT_ROLL_ROTATIONS(bits) ((bits & ALIGNMENT_ROLL_ROTATIONS_MASK) >> ALIGNMENT_ROLL_ROTATIONS_POSITION)
+
+#define ALIGNMENT_AXIS_ROTATIONS(bits, axis) ((bits & ALIGNMENT_AXIS_ROTATIONS_MASK(axis)) >> ((FD_YAW - axis) * ALIGNMENT_ROTATION_WIDTH))
+
+// [1:0] count of 90 degree rotations from 0
+// [3:2] indicates 90 degree rotations on pitch
+// [5:4] indicates 90 degree rotations on roll
+#define ALIGNMENT_TO_BITMASK(alignment) ((alignment - CW0_DEG) & 0x3) | (((alignment - CW0_DEG) & 0x4) << 1)

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -23,6 +23,8 @@
 #include "platform.h"
 
 #include "common/axis.h"
+#include "common/maths.h"
+#include "common/sensor_alignment.h"
 #include "drivers/exti.h"
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
@@ -103,6 +105,7 @@ typedef struct gyroDev_s {
     ioTag_t mpuIntExtiTag;
     uint8_t gyroHasOverflowProtection;
     gyroHardware_e gyroHardware;
+    fp_rotationMatrix_t rotationMatrix;
 } gyroDev_t;
 
 typedef struct accDev_s {
@@ -121,6 +124,7 @@ typedef struct accDev_s {
     bool acc_high_fsr;
     char revisionCode;                                      // a revision code for the sensor, if known
     uint8_t filler[2];
+    fp_rotationMatrix_t rotationMatrix;
 } accDev_t;
 
 static inline void accDevLock(accDev_t *acc)

--- a/src/main/drivers/compass/compass.h
+++ b/src/main/drivers/compass/compass.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "common/sensor_alignment.h"
+
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
 #include "drivers/exti.h"
@@ -29,7 +31,8 @@ typedef struct magDev_s {
     sensorMagReadFuncPtr read;                              // read 3 axis data function
     extiCallbackRec_t exti;
     busDevice_t busdev;
-    sensor_align_e magAlign;
+    sensor_align_e magAlignment;
+    fp_rotationMatrix_t rotationMatrix;
     ioTag_t magIntExtiTag;
     int16_t magGain[3];
 } magDev_t;

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -23,18 +23,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef enum {
-    ALIGN_DEFAULT = 0,                                      // driver-provided alignment
-    CW0_DEG = 1,
-    CW90_DEG = 2,
-    CW180_DEG = 3,
-    CW270_DEG = 4,
-    CW0_DEG_FLIP = 5,
-    CW90_DEG_FLIP = 6,
-    CW180_DEG_FLIP = 7,
-    CW270_DEG_FLIP = 8
-} sensor_align_e;
-
 typedef bool (*sensorInterruptFuncPtr)(void);
 struct magDev_s;
 typedef bool (*sensorMagInitFuncPtr)(struct magDev_s *magdev);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -63,6 +63,7 @@
 #include "pg/pg_ids.h"
 #include "pg/motor.h"
 #include "pg/rx.h"
+#include "pg/gyrodev.h"
 
 #include "rx/rx.h"
 
@@ -71,6 +72,9 @@
 #include "sensors/acceleration.h"
 #include "sensors/battery.h"
 #include "sensors/gyro.h"
+#include "sensors/compass.h"
+
+#include "common/sensor_alignment.h"
 
 static bool configIsDirty; /* someone indicated that the config is modified and it is not yet saved */
 
@@ -255,6 +259,12 @@ static void validateAndFixConfig(void)
     }
 
     validateAndFixGyroConfig();
+
+    buildAlignmentFromStandardAlignment(&compassConfigMutable()->mag_customAlignment, compassConfig()->mag_alignment);
+    buildAlignmentFromStandardAlignment(&gyroDeviceConfigMutable(0)->customAlignment, gyroDeviceConfig(0)->alignment);
+#if defined(USE_MULTI_GYRO)
+    buildAlignmentFromStandardAlignment(&gyroDeviceConfigMutable(1)->customAlignment, gyroDeviceConfig(1)->alignment);
+#endif
 
     if (!(featureIsEnabled(FEATURE_RX_PARALLEL_PWM) || featureIsEnabled(FEATURE_RX_PPM) || featureIsEnabled(FEATURE_RX_SERIAL) || featureIsEnabled(FEATURE_RX_MSP) || featureIsEnabled(FEATURE_RX_SPI))) {
         featureEnable(DEFAULT_RX_FEATURE);

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#include "common/sensor_alignment.h"
+
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/gyrodev.h"
@@ -36,30 +38,31 @@
 ioTag_t selectMPUIntExtiConfigByHardwareRevision(void); // XXX Should be gone
 
 #if defined(USE_SPI_GYRO) || defined(USE_I2C_GYRO)
-static void gyroResetCommonDeviceConfig(gyroDeviceConfig_t *devconf, ioTag_t extiTag, uint8_t align)
+static void gyroResetCommonDeviceConfig(gyroDeviceConfig_t *devconf, ioTag_t extiTag, uint8_t alignment, sensorAlignment_t customAlignment)
 {
     devconf->extiTag = extiTag;
-    devconf->align = align;
+    devconf->alignment = alignment;
+    devconf->customAlignment = customAlignment;
 }
 #endif
 
 #ifdef USE_SPI_GYRO
-static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *instance, ioTag_t csnTag, ioTag_t extiTag, uint8_t align)
+static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *instance, ioTag_t csnTag, ioTag_t extiTag, uint8_t alignment, sensorAlignment_t customAlignment)
 {
     devconf->bustype = BUSTYPE_SPI;
     devconf->spiBus = SPI_DEV_TO_CFG(spiDeviceByInstance(instance));
     devconf->csnTag = csnTag;
-    gyroResetCommonDeviceConfig(devconf, extiTag, align);
+    gyroResetCommonDeviceConfig(devconf, extiTag, alignment, customAlignment);
 }
 #endif
 
 #if defined(USE_I2C_GYRO) && !defined(USE_MULTI_GYRO)
-static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cbus, ioTag_t extiTag, uint8_t align)
+static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cbus, ioTag_t extiTag, uint8_t alignment, sensorAlignment_t customAlignment)
 {
     devconf->bustype = BUSTYPE_I2C;
     devconf->i2cBus = I2C_DEV_TO_CFG(i2cbus);
     devconf->i2cAddress = GYRO_I2C_ADDRESS;
-    gyroResetCommonDeviceConfig(devconf, extiTag, align);
+    gyroResetCommonDeviceConfig(devconf, extiTag, alignment, customAlignment);
 }
 #endif
 
@@ -71,17 +74,17 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
 
     // All multi-gyro boards use SPI based gyros.
 #ifdef USE_SPI_GYRO
-    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN);
+    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, GYRO_1_CUSTOM_ALIGN);
 #ifdef USE_MULTI_GYRO
     devconf[1].index = 1;
-    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), GYRO_2_ALIGN);
+    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), GYRO_2_ALIGN, GYRO_2_CUSTOM_ALIGN);
 #endif
 #endif
 
     // I2C gyros appear as a sole gyro in single gyro boards.
 #if defined(USE_I2C_GYRO) && !defined(USE_MULTI_GYRO)
     devconf[0].i2cBus = I2C_DEV_TO_CFG(I2CINVALID); // XXX Not required?
-    gyroResetI2cDeviceConfig(&devconf[0], I2C_DEVICE, IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN);
+    gyroResetI2cDeviceConfig(&devconf[0], I2C_DEVICE, IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, GYRO_1_CUSTOM_ALIGN);
 #endif
 
 // Special treatment for very rare F3 targets with variants having either I2C or SPI acc/gyro chip; mark it for run time detection.

--- a/src/main/pg/gyrodev.h
+++ b/src/main/pg/gyrodev.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "pg/pg.h"
+#include "common/sensor_alignment.h"
 #include "drivers/io_types.h"
 
 typedef struct gyroDeviceConfig_s {
@@ -34,7 +35,8 @@ typedef struct gyroDeviceConfig_s {
     uint8_t i2cBus;
     uint8_t i2cAddress;
     ioTag_t extiTag;
-    uint8_t align;        // sensor_align_e
+    uint8_t alignment;        // sensor_align_e
+    sensorAlignment_t customAlignment;
 } gyroDeviceConfig_t;
 
 PG_DECLARE_ARRAY(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDeviceConfig);

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -25,8 +25,10 @@
 
 #include "platform.h"
 
+#include "common/utils.h"
 #include "common/maths.h"
 #include "common/axis.h"
+#include "common/sensor_alignment.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -36,7 +38,7 @@
 #include "boardalignment.h"
 
 static bool standardBoardAlignment = true;     // board orientation correction
-static float boardRotation[3][3];              // matrix
+static fp_rotationMatrix_t boardRotation;
 
 // no template required since defaults are zero
 PG_REGISTER(boardAlignment_t, boardAlignment, PG_BOARD_ALIGNMENT, 0);
@@ -59,21 +61,24 @@ void initBoardAlignment(const boardAlignment_t *boardAlignment)
     rotationAngles.angles.pitch = degreesToRadians(boardAlignment->pitchDegrees);
     rotationAngles.angles.yaw   = degreesToRadians(boardAlignment->yawDegrees  );
 
-    buildRotationMatrix(&rotationAngles, boardRotation);
+    buildRotationMatrix(&rotationAngles, &boardRotation);
 }
 
-static void alignBoard(float *vec)
+FAST_CODE static void alignBoard(float *vec)
 {
-    float x = vec[X];
-    float y = vec[Y];
-    float z = vec[Z];
-
-    vec[X] = (boardRotation[0][X] * x + boardRotation[1][X] * y + boardRotation[2][X] * z);
-    vec[Y] = (boardRotation[0][Y] * x + boardRotation[1][Y] * y + boardRotation[2][Y] * z);
-    vec[Z] = (boardRotation[0][Z] * x + boardRotation[1][Z] * y + boardRotation[2][Z] * z);
+    applyRotation(vec, &boardRotation);
 }
 
-FAST_CODE void alignSensors(float *dest, uint8_t rotation)
+FAST_CODE void alignSensorViaMatrix(float *dest, fp_rotationMatrix_t* sensorRotationMatrix)
+{
+    applyRotation(dest, sensorRotationMatrix);
+
+    if (!standardBoardAlignment) {
+        alignBoard(dest);
+    }
+}
+
+FAST_CODE void alignSensorViaRotation(float *dest, uint8_t rotation)
 {
     const float x = dest[X];
     const float y = dest[Y];
@@ -123,6 +128,7 @@ FAST_CODE void alignSensors(float *dest, uint8_t rotation)
         break;
     }
 
-    if (!standardBoardAlignment)
+    if (!standardBoardAlignment) {
         alignBoard(dest);
+    }
 }

--- a/src/main/sensors/boardalignment.h
+++ b/src/main/sensors/boardalignment.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include "common/axis.h"
+#include "common/maths.h"
+
 #include "pg/pg.h"
 
 typedef struct boardAlignment_s {
@@ -30,5 +33,7 @@ typedef struct boardAlignment_s {
 
 PG_DECLARE(boardAlignment_t, boardAlignment);
 
-void alignSensors(float *dest, uint8_t rotation);
+void alignSensorViaMatrix(float *dest, fp_rotationMatrix_t* rotationMatrix);
+void alignSensorViaRotation(float *dest, uint8_t rotation);
+
 void initBoardAlignment(const boardAlignment_t *boardAlignment);

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -20,6 +20,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "platform.h"
 
@@ -61,7 +62,8 @@ PG_REGISTER_WITH_RESET_FN(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 1);
 
 void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 {
-    compassConfig->mag_align = ALIGN_DEFAULT;
+    compassConfig->mag_alignment = ALIGN_DEFAULT;
+    memset(&compassConfig->mag_customAlignment, 0x00, sizeof(compassConfig->mag_customAlignment));
     compassConfig->mag_declination = 0;
     compassConfig->mag_hardware = MAG_DEFAULT;
 
@@ -115,8 +117,10 @@ void compassPreInit(void)
 }
 
 #if !defined(SIMULATOR_BUILD)
-bool compassDetect(magDev_t *dev)
+bool compassDetect(magDev_t *dev, uint8_t *alignment)
 {
+    *alignment = ALIGN_DEFAULT;  // may be overridden if target specifies MAG_*_ALIGN
+
     magSensor_e magHardware = MAG_NONE;
 
     busDevice_t *busdev = &dev->busdev;
@@ -167,8 +171,6 @@ bool compassDetect(magDev_t *dev)
         return false;
     }
 
-    dev->magAlign = ALIGN_DEFAULT;
-
     switch (compassConfig()->mag_hardware) {
     case MAG_DEFAULT:
         FALLTHROUGH;
@@ -181,7 +183,7 @@ bool compassDetect(magDev_t *dev)
 
         if (hmc5883lDetect(dev)) {
 #ifdef MAG_HMC5883_ALIGN
-            dev->magAlign = MAG_HMC5883_ALIGN;
+            *alignment = MAG_HMC5883_ALIGN;
 #endif
             magHardware = MAG_HMC5883;
             break;
@@ -197,7 +199,7 @@ bool compassDetect(magDev_t *dev)
 
         if (lis3mdlDetect(dev)) {
 #ifdef MAG_LIS3MDL_ALIGN
-            dev->magAlign = MAG_LIS3MDL_ALIGN;
+            *alignment = MAG_LIS3MDL_ALIGN;
 #endif
             magHardware = MAG_LIS3MDL;
             break;
@@ -213,7 +215,7 @@ bool compassDetect(magDev_t *dev)
 
         if (ak8975Detect(dev)) {
 #ifdef MAG_AK8975_ALIGN
-            dev->magAlign = MAG_AK8975_ALIGN;
+            *alignment = MAG_AK8975_ALIGN;
 #endif
             magHardware = MAG_AK8975;
             break;
@@ -234,7 +236,7 @@ bool compassDetect(magDev_t *dev)
 
         if (ak8963Detect(dev)) {
 #ifdef MAG_AK8963_ALIGN
-            dev->magAlign = MAG_AK8963_ALIGN;
+            *alignment = MAG_AK8963_ALIGN;
 #endif
             magHardware = MAG_AK8963;
             break;
@@ -250,7 +252,7 @@ bool compassDetect(magDev_t *dev)
 
         if (qmc5883lDetect(dev)) {
 #ifdef MAG_QMC5883L_ALIGN
-            dev->magAlign = MAG_QMC5883L_ALIGN;
+            *alignment = MAG_QMC5883L_ALIGN;
 #endif
             magHardware = MAG_QMC5883;
             break;
@@ -272,9 +274,10 @@ bool compassDetect(magDev_t *dev)
     return true;
 }
 #else
-bool compassDetect(magDev_t *dev)
+bool compassDetect(magDev_t *dev, sensor_align_e *alignment)
 {
     UNUSED(dev);
+    UNUSED(alignment);
 
     return false;
 }
@@ -286,7 +289,9 @@ bool compassInit(void)
     // calculate magnetic declination
     mag.magneticDeclination = 0.0f; // TODO investigate if this is actually needed if there is no mag sensor or if the value stored in the config should be used.
 
-    if (!compassDetect(&magDev)) {
+    sensor_align_e alignment;
+
+    if (!compassDetect(&magDev, &alignment)) {
         return false;
     }
 
@@ -297,9 +302,15 @@ bool compassInit(void)
     magDev.init(&magDev);
     LED1_OFF;
     magInit = 1;
-    if (compassConfig()->mag_align != ALIGN_DEFAULT) {
-        magDev.magAlign = compassConfig()->mag_align;
+
+    magDev.magAlignment = alignment;
+
+    if (compassConfig()->mag_alignment != ALIGN_DEFAULT) {
+        magDev.magAlignment = compassConfig()->mag_alignment;
     }
+    
+    buildRotationMatrixFromAlignment(&compassConfig()->mag_customAlignment, &magDev.rotationMatrix);
+
     return true;
 }
 
@@ -318,7 +329,11 @@ void compassUpdate(timeUs_t currentTimeUs)
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         mag.magADC[axis] = magADCRaw[axis];
     }
-    alignSensors(mag.magADC, magDev.magAlign);
+    if (magDev.magAlignment == ALIGN_CUSTOM) {
+        alignSensorViaMatrix(mag.magADC, &magDev.rotationMatrix);
+    } else {
+        alignSensorViaRotation(mag.magADC, magDev.magAlignment);
+    }
 
     flightDynamicsTrims_t *magZero = &compassConfigMutable()->magZero;
     if (STATE(CALIBRATE_MAG)) {

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "common/time.h"
+#include "common/sensor_alignment.h"
 #include "drivers/io_types.h"
 #include "drivers/sensor.h"
 #include "pg/pg.h"
@@ -48,7 +49,7 @@ extern mag_t mag;
 typedef struct compassConfig_s {
     int16_t mag_declination;                // Get your magnetic decliniation from here : http://magnetic-declination.com/
                                             // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
-    sensor_align_e mag_align;               // mag alignment
+    uint8_t mag_alignment;                  // mag alignment
     uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
     uint8_t mag_bustype;
     uint8_t mag_i2c_device;
@@ -57,6 +58,7 @@ typedef struct compassConfig_s {
     ioTag_t mag_spi_csn;
     ioTag_t interruptTag;
     flightDynamicsTrims_t magZero;
+    sensorAlignment_t mag_customAlignment;
 } compassConfig_t;
 
 PG_DECLARE(compassConfig_t, compassConfig);

--- a/src/main/target/BLUEJAYF4/config.c
+++ b/src/main/target/BLUEJAYF4/config.c
@@ -47,7 +47,7 @@
 void targetConfiguration(void)
 {
     if (hardwareRevision == BJF4_REV1 || hardwareRevision == BJF4_REV2) {
-        gyroDeviceConfigMutable(0)->align = CW180_DEG;
+        gyroDeviceConfigMutable(0)->alignment = CW180_DEG;
         beeperDevConfigMutable()->ioTag = IO_TAG(BEEPER_OPT);
     }
 

--- a/src/main/target/FF_RACEPIT/config.c
+++ b/src/main/target/FF_RACEPIT/config.c
@@ -39,10 +39,10 @@
 void targetConfiguration(void)
 {	
     if (hardwareRevision == FF_RACEPIT_REV_1) {
-        gyroDeviceConfigMutable(0)->align = CW180_DEG;
+        gyroDeviceConfigMutable(0)->alignment = CW180_DEG;
     }
     else {
-        gyroDeviceConfigMutable(0)->align = CW90_DEG_FLIP;
+        gyroDeviceConfigMutable(0)->alignment = CW90_DEG_FLIP;
     }
 
     telemetryConfigMutable()->halfDuplex = false;

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -113,7 +113,6 @@
 // Dummy defines
 #define GYRO_2_SPI_INSTANCE     GYRO_1_SPI_INSTANCE
 #define GYRO_2_CS_PIN           NONE
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define GYRO_2_EXTI_PIN         NONE
 
 #if !defined(SYNERGYF4) //No mag sensor on SYNERGYF4

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -62,7 +62,6 @@
 #define GYRO_2_SPI_INSTANCE     SPI1
 #define GYRO_2_CS_PIN           PA4
 #define GYRO_1_ALIGN            CW90_DEG
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define GYRO_1_EXTI_PIN         PD0           // MPU6000
 #define GYRO_2_EXTI_PIN         PE8           // ICM20608
 
@@ -81,8 +80,6 @@
 #define GYRO_1_CS_PIN           PA15
 #define GYRO_2_SPI_INSTANCE     SPI1
 #define GYRO_2_CS_PIN           PA4
-#define GYRO_1_ALIGN            ALIGN_DEFAULT
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define GYRO_1_EXTI_PIN         PE8           // ICM20608
 #define GYRO_2_EXTI_PIN         PD0           // MPU6000
 #endif

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -320,6 +320,8 @@
 #endif
 #endif
 
+// gyro hardware
+
 #if !defined(GYRO_1_SPI_INSTANCE)
 #define GYRO_1_SPI_INSTANCE     NULL
 #endif
@@ -332,15 +334,10 @@
 #define GYRO_1_EXTI_PIN         NONE
 #endif
 
-#if !defined(GYRO_1_ALIGN)
-#define GYRO_1_ALIGN            ALIGN_DEFAULT
-#endif
-
 // F4 and F7 single gyro boards
 #if defined(USE_MULTI_GYRO) && !defined(GYRO_2_SPI_INSTANCE)
 #define GYRO_2_SPI_INSTANCE     NULL
 #define GYRO_2_CS_PIN           NONE
-#define GYRO_2_ALIGN            ALIGN_DEFAULT
 #define GYRO_2_EXTI_PIN         NONE
 #endif
 
@@ -356,6 +353,24 @@
 #else
 #define MAX_GYRODEV_COUNT 1
 #define MAX_ACCDEV_COUNT 1
+#endif
+
+// gyro alignments
+
+#if !defined(GYRO_1_ALIGN)
+#define GYRO_1_ALIGN            CW0_DEG
+#endif
+
+#if !defined(GYRO_2_ALIGN)
+#define GYRO_2_ALIGN            CW0_DEG
+#endif
+
+#if !defined(GYRO_1_CUSTOM_ALIGN)
+#define GYRO_1_CUSTOM_ALIGN            CUSTOM_ALIGN_CW0_DEG
+#endif
+
+#if !defined(GYRO_2_CUSTOM_ALIGN)
+#define GYRO_2_CUSTOM_ALIGN            CUSTOM_ALIGN_CW0_DEG
 #endif
 
 #ifdef USE_VCP

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -32,6 +32,7 @@ VPATH := $(VPATH):$(USER_DIR):$(TEST_DIR)
 
 alignsensor_unittest_SRC := \
 		$(USER_DIR)/sensors/boardalignment.c \
+		$(USER_DIR)/common/sensor_alignment.c \
 		$(USER_DIR)/common/maths.c
 
 arming_prevention_unittest_SRC := \
@@ -279,6 +280,7 @@ sensor_gyro_unittest_SRC := \
 		$(USER_DIR)/sensors/boardalignment.c \
 		$(USER_DIR)/common/filter.c \
 		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/sensor_alignment.c \
 		$(USER_DIR)/drivers/accgyro/accgyro_fake.c \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
 		$(USER_DIR)/pg/pg.c \

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -144,9 +144,9 @@ TEST(SensorGyro, Update)
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Z]);
     fakeGyroSet(gyroDevPtr, 15, 26, 97);
     gyroUpdate(currentTimeUs);
-    EXPECT_FLOAT_EQ(10 * gyroDevPtr->scale, gyro.gyroADCf[X]); // gyroADCf values are scaled
-    EXPECT_FLOAT_EQ(20 * gyroDevPtr->scale, gyro.gyroADCf[Y]);
-    EXPECT_FLOAT_EQ(90 * gyroDevPtr->scale, gyro.gyroADCf[Z]);
+    EXPECT_NEAR(10 * gyroDevPtr->scale, gyro.gyroADCf[X], 1e-3); // gyroADCf values are scaled
+    EXPECT_NEAR(20 * gyroDevPtr->scale, gyro.gyroADCf[Y], 1e-3);
+    EXPECT_NEAR(90 * gyroDevPtr->scale, gyro.gyroADCf[Z], 1e-3);
 }
 
 // STUBS


### PR DESCRIPTION
Allow arbitrary gyro and compass alignment.

* Rotation matrix is pre-computed, after sensor detection completes.
* Supports dual gyro boards with offsets other than 90 degrees.
* Supports external compasses mounted at any angle.
* No MSP support yet, planned for a future BF release.
* Required for SPRacingH7EXTREME - http://seriouslypro.com/spracingh7extreme
* Two code-paths, existing path for 90 degree increments, another for finer-grained settings (aka CUSTOM)
* Initial testing done on SPRacingF7DUAL.
* No noticeable change to PID loop speed for arbitrary alignment.

This is the refactored version of PR #7845 for discussion and comparison.

* The refactored changes to the pid-loop and config are done
* MSP is reverted
* Settings updated so that `CUSTOM` is available along with 3 new settings for each sensor (gyro and mag, roll/pitch/yaw)
* Code to reset the custom settings based on the value of the enum alignment values is done, allowing a staged migration plan.
* Resolution is now 0.1 degrees (aka decidegrees)
