### PR TITLE
Unified target config for KAKUTEF4V2

### DIFF
--- a/unified_targets/configs/KAKUTEF4V2.config
+++ b/unified_targets/configs/KAKUTEF4V2.config
@@ -1,0 +1,104 @@
+# Betaflight / STM32F405 (S405) 4.1.0 Jun 25 2019 / 10:41:09 (2a6e94d03) MSP API: 1.42
+
+board_name KAKUTEF4V2
+manufacturer_id HBRO
+
+# resources
+resource BEEPER 1 C09
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 A03
+resource MOTOR 4 A02
+resource PPM 1 C07
+resource LED_STRIP 1 C08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource INVERTER 3 B15
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 B05
+resource LED 2 B04
+resource LED 3 B06
+resource SPI_SCK 1 A05
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 C07
+resource ADC_BATT 1 C03
+resource ADC_RSSI 1 C01
+resource ADC_CURR 1 C02
+resource FLASH_CS 1 B03
+resource OSD_CS 1 B14
+resource GYRO_EXTI 1 C05
+resource GYRO_CS 1 C04
+resource USB_DETECT 1 A08
+
+# timer
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin C07 0
+# pin C07: DMA2 Stream 2 Channel 0
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A03 1
+# pin A03: DMA1 Stream 6 Channel 3
+dma pin A02 0
+# pin A02: DMA1 Stream 1 Channel 3
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature OSD
+
+# serial
+serial 0 32 115200 57600 0 115200
+serial 2 64 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set serialrx_provider = SBUS
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set tlm_inverted = ON
+set tlm_halfduplex = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 3
+set max7456_preinit_opu = ON
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270
+set gyro_2_spibus = 1


### PR DESCRIPTION
The manual http://www.holybro.com/manual/KakuteF4V2Manual.pdf does a good job of describing the setup, But I've done my best to make sure that the default settings are the same as on 4.0.3 (UART3 set for SBUS receiver, and UART1 doing Smartport etc etc)
