### PR TITLE
Update NUCLEOH743 target for ZI2 version of the board

### DIFF
--- a/src/main/target/NUCLEOH743/target.h
+++ b/src/main/target/NUCLEOH743/target.h
@@ -26,7 +26,7 @@
 #define USE_TARGET_CONFIG
 
 #define LED0_PIN                PB0
-#define LED1_PIN                PB7
+#define LED1_PIN                PB7 // PE1 on NUCLEO-H743ZI2 (may collide with UART8_TX)
 //#define LED2_PIN                PB14 // SDMMC2_D0
 
 // Nucleo-H743 has one button (The blue USER button).


### PR DESCRIPTION
A new version of the H743 Nucleo, Nucleo-H743ZI2, seems to be slightly different from the original Nucleo-H743ZI. The 2nd LED (LD2) is the first I've found.

The new assignment is not activated, but added as a comment just in case someone came to notice that LEDs don't blink in the same way between these two versions.