### PR TITLE
CLRACING F7 target update

### DIFF
--- a/src/main/target/CLRACINGF7/config.c
+++ b/src/main/target/CLRACINGF7/config.c
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#ifdef USE_TARGET_CONFIG
+#include "pg/pinio.h"
+#include "pg/piniobox.h"
+
+void targetConfiguration(void)
+{	
+    pinioBoxConfigMutable()->permanentId[0] = 39;
+}
+#endif

--- a/src/main/target/CLRACINGF7/target.c
+++ b/src/main/target/CLRACINGF7/target.c
@@ -30,12 +30,15 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 
     DEF_TIM(TIM2,  CH2,   PB3, TIM_USE_CAMERA_CONTROL,     0, 0), // USE FOR CAMERA CONTROL
 
-    DEF_TIM(TIM4,  CH1,  PB6, TIM_USE_MOTOR,               0, 0), // D1-ST6
-    DEF_TIM(TIM4,  CH2,  PB7, TIM_USE_MOTOR,               0, 0), // D1-ST6
-    DEF_TIM(TIM4,  CH3,  PB8, TIM_USE_MOTOR,               0, 0), // D1-ST6
-    DEF_TIM(TIM4,  CH4,  PB9, TIM_USE_MOTOR,               0, 0), // D1-ST6
+    DEF_TIM(TIM4,  CH1,  PB6, TIM_USE_MOTOR,               0, 0), // D1-ST0                   MOTOR1
+    DEF_TIM(TIM4,  CH2,  PB7, TIM_USE_MOTOR,               0, 0), // D1-ST3                   MOTOR2
+    DEF_TIM(TIM4,  CH3,  PB8, TIM_USE_MOTOR,               0, 0), // D1-ST7                   MOTOR3
+    DEF_TIM(TIM4,  CH4,  PB9, TIM_USE_MOTOR,               0, 0), // NONE  TIM4_UP_D1-ST6     MOTOR4
+    DEF_TIM(TIM5,  CH2,  PA1, TIM_USE_MOTOR,               0, 0), // D1-ST4                   MOTOR5
+    DEF_TIM(TIM8,  CH3,  PC8, TIM_USE_MOTOR,               0, 0), // D2-ST2/D2-ST4            MOTOR6
+    DEF_TIM(TIM8,  CH4,  PC9, TIM_USE_MOTOR,               0, 0), // D2-ST7                   MOTOR7
 
-    DEF_TIM(TIM3,  CH4, PB1, TIM_USE_MOTOR | TIM_USE_LED,  0, 0), // D1-ST2
+    DEF_TIM(TIM3,  CH4, PB1, TIM_USE_MOTOR | TIM_USE_LED,  0, 0), // D1-ST2                   LED/MOTOR5
 
 
 };

--- a/src/main/target/CLRACINGF7/target.h
+++ b/src/main/target/CLRACINGF7/target.h
@@ -21,17 +21,20 @@
 #pragma once
 #define TARGET_BOARD_IDENTIFIER "CLR7"
 #define USBD_PRODUCT_STRING "CLRACINGF7"
+#define USE_TARGET_CONFIG
 
 #define ENABLE_DSHOT_DMAR       true
 
 #define LED0_PIN                PB0
 #define USE_BEEPER
-#define BEEPER_PIN                  PB4
+#define BEEPER_PIN              PB4
 #define BEEPER_INVERTED
 
+#define USE_MULTI_GYRO
 #define USE_EXTI
 #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4
+#define GYRO_2_EXTI_PIN         PC14
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_ACC
@@ -47,8 +50,14 @@
 
 #define GYRO_1_CS_PIN           PA4
 #define GYRO_1_SPI_INSTANCE     SPI1
-
 #define GYRO_1_ALIGN            CW0_DEG
+
+#define GYRO_2_CS_PIN            PC13
+#define GYRO_2_SPI_INSTANCE     SPI1
+#define GYRO_2_ALIGN            CW90_DEG
+//#define ACC_2_ALIGN             CW90_DEG
+
+#define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_BOTH
 
 #define USE_MAG
 #define USE_MAG_HMC5883
@@ -63,6 +72,8 @@
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
+#define USE_FLASH_W25M
+#define USE_FLASH_W25N01G          // 1G NAND flash support
 #define FLASH_CS_PIN            PB12
 #define FLASH_SPI_INSTANCE      SPI2
 
@@ -100,7 +111,7 @@
 
 #define USE_I2C
 #define USE_I2C_DEVICE_2       // External I2C
-#define I2C_DEVICE               (I2CDEV_2)
+#define I2C_DEVICE              (I2CDEV_2)
 #define I2C2_SCL                NONE        // PB10 (UART3_TX)
 #define I2C2_SDA                NONE        // PB11 (UART3_RX)
 
@@ -133,6 +144,11 @@
 
 #define CURRENT_METER_SCALE_DEFAULT 250                     // 3.3/120A  = 25mv/A
 
+// real pit
+#define USE_PINIO
+#define PINIO1_PIN              PA14  // VTX power switcher
+#define USE_PINIOBOX
+
 #define BINDPLUG_PIN            PB2
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
 #define SERIALRX_UART           SERIAL_PORT_UART5
@@ -143,6 +159,6 @@
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         (BIT(2))
 
-#define USABLE_TIMER_CHANNEL_COUNT      6
-#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(4)  )
+#define USABLE_TIMER_CHANNEL_COUNT      9
+#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5)  | TIM_N(8)   )
 

--- a/src/main/target/common_unified.h
+++ b/src/main/target/common_unified.h
@@ -70,8 +70,8 @@
 
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-
-#define USE_MAX7456
+#define USE_FLASH_W25M
+#define USE_FLASH_W25N01G          // 1G NAND flash support
 
 #define USE_TRANSPONDER
 

--- a/unified_targets/configs/CLRACINGF7.config
+++ b/unified_targets/configs/CLRACINGF7.config
@@ -3,23 +3,17 @@
 board_name CLRACINGF7
 manufacturer_id CLRA
 
-# BEEPER
-resource BEEPER 1 PB4
-set beeper_inversion = ON
-set beeper_od = OFF
-
-# INDICATOR LED
-resource LED 1 B00
-
-#MOTOR AND LED
+# resources
+resource BEEPER 1 B04
 resource MOTOR 1 B06
 resource MOTOR 2 B07
 resource MOTOR 3 B08
 resource MOTOR 4 B09
-resource MOTOR 5 B01
+resource MOTOR 5 A01
+resource MOTOR 6 C08
+resource MOTOR 7 C09
+resource MOTOR 8 B01
 resource LED_STRIP 1 B01
-
-# UARTS 
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
 resource SERIAL_TX 3 B10
@@ -32,8 +26,8 @@ resource SERIAL_RX 3 B11
 resource SERIAL_RX 4 A01
 resource SERIAL_RX 5 D02
 resource SERIAL_RX 6 C07
-
-#SPI BUS
+resource LED 1 B00
+resource RX_BIND 1 B02
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13
 resource SPI_SCK 3 C10
@@ -43,52 +37,64 @@ resource SPI_MISO 3 C11
 resource SPI_MOSI 1 A07
 resource SPI_MOSI 2 B15
 resource SPI_MOSI 3 B05
-
-#ADC
+resource CAMERA_CONTROL 1 B03
 resource ADC_BATT 1 C02
 resource ADC_RSSI 1 C03
 resource ADC_CURR 1 C01
+resource PINIO 1 A14
+resource FLASH_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 C14
+resource GYRO_CS 1 A04
+resource GYRO_CS 2 C13
+
+# timer
+timer B03 AF1 # pin B03: TIM2 CH2 (AF1)
+timer B06 AF2 # pin B06: TIM4 CH1 (AF2)
+timer B07 AF2 # pin B07: TIM4 CH2 (AF2)
+timer B08 AF2 # pin B08: TIM4 CH3 (AF2)
+timer B09 AF2 # pin B09: TIM4 CH4 (AF2)
+timer A01 AF2 # pin A01: TIM5 CH2 (AF2)
+timer C08 AF3 # pin C08: TIM8 CH3 (AF3)
+timer C09 AF3 # pin C09: TIM8 CH4 (AF3)
+timer B01 AF2 # pin B01: TIM3 CH4 (AF2)
+
+# dma
+dma ADC 1 1      # ADC 1: DMA2 Stream 4 Channel 0
+dma pin B03 0    # pin B03: DMA1 Stream 6 Channel 3
+dma pin B06 0    # pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0    # pin B07: DMA1 Stream 3 Channel 2
+dma pin B08 0    # pin B08: DMA1 Stream 7 Channel 2
+dma pin A01 0    # pin A01: DMA1 Stream 4 Channel 6
+dma pin C08 0    # pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0    # pin C09: DMA2 Stream 7 Channel 7
+dma pin B01 0    # pin B01: DMA1 Stream 2 Channel 5
+
+# feature
+feature RX_SERIAL
+feature OSD
+
+# serial
+serial 4 64 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 2
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set motor_pwm_protocol = DSHOT600
 set current_meter = ADC
 set battery_meter = ADC
-
-#SPI FLASH
-resource FLASH_CS 1 B03
+set ibata_scale = 250
+set beeper_inversion = ON
+set beeper_od = OFF
+set pid_process_denom = 1
+set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
-
-#OSD
-resource OSD_CS 1 A15
-set max7456_spi_bus = 3
-
-#GYRO
-resource GYRO_EXTI 1 C04
-resource GYRO_CS 1 A04
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
-
-# timer
-timer B03 AF1
-# pin B03: TIM2 CH2 (AF1)
-timer B06 AF2
-# pin B06: TIM4 CH1 (AF2)
-timer B07 AF2
-# pin B07: TIM4 CH2 (AF2)
-timer B08 AF2
-# pin B08: TIM4 CH3 (AF2)
-timer B09 AF2
-# pin B09: TIM4 CH4 (AF2)
-timer B01 AF2
-# pin B01: TIM3 CH4 (AF2)
-
-# dma
-dma ADC 1 1        # ADC 1: DMA2 Stream 4 Channel 0
-dma pin B03 0      # pin B03: DMA1 Stream 6 Channel 3
-dma pin B06 0      # pin B06: DMA1 Stream 0 Channel 2
-dma pin B07 0      # pin B07: DMA1 Stream 3 Channel 2
-dma pin B08 0      # pin B08: DMA1 Stream 7 Channel 2
-dma pin B01 0      # pin B01: DMA1 Stream 2 Channel 5
-
-# master
-set dashboard_i2c_bus = 1
-resource RX_BIND_PLUG 1 B02
-resource CAMERA_CONTROL 1 B03
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = CW90
+set gyro_to_use = BOTH


### PR DESCRIPTION
CLRACING F7 target update for upcoming F7 FC.

1. add dual gyro support.
2. 1 G flash chip update.
3. add motor 5,6,7 timers for RPM filtering usage.
4. add pinio define for VTX switch.
5. update unified target. 

also update the common_unified.h, add USE_FLASH_W25M and USE_FLASH_W25N01G    to support 512M and 1G nand flash chip.