### PR TITLE
Fix headers in unified target configs

### DIFF
--- a/unified_targets/configs/ALIENFLIGHTF4.config
+++ b/unified_targets/configs/ALIENFLIGHTF4.config
@@ -1,5 +1,3 @@
-# Description: ALIENFLIGHTF4 Standard target configuration
-
 # Betaflight / STM32F405 (S405) 4.0.0 Mar  2 2019 / 07:01:01 (29db27584) MSP API: 1.41
 
 board_name ALIENFLIGHTF4

--- a/unified_targets/configs/ALIENFLIGHTNGF7.config
+++ b/unified_targets/configs/ALIENFLIGHTNGF7.config
@@ -1,5 +1,3 @@
-# Description: ALIENFLIGHTNGF7 Standard target configuration
-
 # Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar  2 2019 / 07:04:57 (29db27584) MSP API: 1.41
 
 board_name ALIENFLIGHTNGF7

--- a/unified_targets/configs/ALIENFLIGHTNGF7_Dual.config
+++ b/unified_targets/configs/ALIENFLIGHTNGF7_Dual.config
@@ -1,5 +1,3 @@
-# Description: ALIENFLIGHTNGF7 dual gyro target configuration
-
 # Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar  2 2019 / 07:04:57 (29db27584) MSP API: 1.41
 
 board_name ALIENFLIGHTNGF7_DUAL

--- a/unified_targets/configs/CRAZYBEEF4FR.config
+++ b/unified_targets/configs/CRAZYBEEF4FR.config
@@ -1,4 +1,4 @@
-# Betaflight / CRAZYBEEF4FR (C4FR) 4.0.0 Mar  2 2019 / 21:03:37 (48d32d8b1) MSP API: 1.41
+# Betaflight / STM32F411 (S411) 4.0.0 Mar  2 2019 / 21:03:37 (48d32d8b1) MSP API: 1.41
 
 board_name CRAZYBEEF4FR
 manufacturer_id HAMO

--- a/unified_targets/configs/EXF722DUAL.config
+++ b/unified_targets/configs/EXF722DUAL.config
@@ -1,4 +1,3 @@
-# version
 # Betaflight / STM32F7X2 (S7X2) 4.0.3 Jun  1 2019 / 11:59:57 (094cfc956) MSP API: 1.41
 
 board_name EXF722DUAL

--- a/unified_targets/configs/FF_RACEPIT.config
+++ b/unified_targets/configs/FF_RACEPIT.config
@@ -1,6 +1,3 @@
-# Name: FF_RACEPIT
-# Description: FuriousFPV RACEPIT with Blackbox Standard target configuration
-
 # Betaflight / STM32F405 (S405) 4.0.0 Mar  2 2019 / 07:01:01 (29db27584) MSP API: 1.4
 
 board_name FF_RACEPIT

--- a/unified_targets/configs/FF_RACEPIT_mini.config
+++ b/unified_targets/configs/FF_RACEPIT_mini.config
@@ -1,6 +1,3 @@
-# Name: FF_RACEPIT_mini
-# Description: FuriousFPV RACEPIT with Blackbox Standard target configuration
-
 # Betaflight / STM32F405 (S405) 4.0.0 Mar  2 2019 / 07:01:01 (29db27584) MSP API: 1.4
 
 board_name FF_RACEPIT

--- a/unified_targets/configs/FLYWOOF405.config
+++ b/unified_targets/configs/FLYWOOF405.config
@@ -1,4 +1,4 @@
-# Betaflight / FLYWOOF405 (FWF4) 4.0.0 Mar 17 2019 / 10:22:16 (81536e07f) MSP API: 1.41
+# Betaflight / STM32F405 (S405) 4.0.0 Mar 17 2019 / 10:22:16 (81536e07f) MSP API: 1.41
 
 board_name FLYWOOF405
 manufacturer_id FLWO

--- a/unified_targets/configs/FLYWOOF411.config
+++ b/unified_targets/configs/FLYWOOF411.config
@@ -1,4 +1,4 @@
-# Betaflight / FLYWOOF411 (FW41) 4.0.0 Mar 17 2019 / 09:53:07 (81536e07f) MSP API: 1.41
+# Betaflight / STM32F411 (S411) 4.0.0 Mar 17 2019 / 09:53:07 (81536e07f) MSP API: 1.41
 
 board_name FLYWOOF411
 manufacturer_id FLWO

--- a/unified_targets/configs/FLYWOOF7DUAL.config
+++ b/unified_targets/configs/FLYWOOF7DUAL.config
@@ -1,4 +1,4 @@
-# Betaflight / FLYWOOF7DUAL (FWF7) 4.0.0 Mar 16 2019 / 15:35:55 (81536e07f) MSP API: 1.41
+# Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar 16 2019 / 15:35:55 (81536e07f) MSP API: 1.41
 
 board_name FLYWOOF7DUAL
 manufacturer_id FLWO

--- a/unified_targets/configs/IFLIGHT_F411_PRO.config
+++ b/unified_targets/configs/IFLIGHT_F411_PRO.config
@@ -1,3 +1,4 @@
+# Betaflight / STM32F411 (S411) 4.0.0
 board_name IFF411PRO
 manufacturer_id IFRC
 

--- a/unified_targets/configs/MATEKF411.config
+++ b/unified_targets/configs/MATEKF411.config
@@ -1,3 +1,5 @@
+# Betaflight / STM32F411 (S411) 4.1.0 Jun 25 2019 / 10:27:57 (2a6e94d03) MSP API: 1.42
+
 board_name MATEKF411
 manufacturer_id MTKS
 
@@ -94,9 +96,7 @@ set current_meter = ADC
 set battery_meter = ADC
 set vbat_detect_cell_voltage = 300
 set system_hse_mhz = 8
-set max7456_clock = DEFAULT
 set max7456_spi_bus = 2
-set max7456_preinit_opu = OFF
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/unified_targets/configs/NERO.config
+++ b/unified_targets/configs/NERO.config
@@ -1,6 +1,4 @@
-# Usual lawyer stuff here?
-
-# Description: NERO Standard target configuration
+# Betaflight / STM32F7X2 (S7X2) 4.0.0
 
 board_name NERO
 manufacturer_id BKMN

--- a/unified_targets/configs/TRANSTECF7.config
+++ b/unified_targets/configs/TRANSTECF7.config
@@ -1,4 +1,3 @@
-# version
 # Betaflight / STM32F7X2 (S7X2) 4.0.2 May  5 2019 / 12:20:37 (56bdc8d26) MSP API: 1.41
 
 board_name TRANSTECF7

--- a/unified_targets/configs/VGOODRCF4.config
+++ b/unified_targets/configs/VGOODRCF4.config
@@ -1,4 +1,4 @@
-# Betaflight / VGOODRCF4 (VGF4) 4.1.0 Apr 30 2019 / 09:30:28 () MSP API: 1.42
+# Betaflight / STM32F405 (S405) 4.1.0 Apr 30 2019 / 09:30:28 () MSP API: 1.42
 
 board_name VGOODRCF4
 manufacturer_id VGRC


### PR DESCRIPTION
Unified Targets need a way to specify the CPU used, so the thought is to use the `# Betaflight ...` banner in the configuration files to hold that information. I've gone through the current unified configs and made corrections where necessary.

Also going forward I plan on nagging people to submit unified target configs with the correct header.

Now I can stop wondering about which CPU a given target uses.