### PR TITLE
Disable use_unsynced_pwm if using DSHOT or PROSHOT

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -452,7 +452,7 @@ static void validateAndFixConfig(void)
 #endif
 #endif
 
-#if defined(USE_DSHOT_TELEMETRY)
+#if defined(USE_DSHOT)
     bool usingDshotProtocol;
     switch (motorConfig()->dev.motorPwmProtocol) {
     case PWM_TYPE_PROSHOT1000:
@@ -467,11 +467,18 @@ static void validateAndFixConfig(void)
         break;
     }
 
+    // If using DSHOT protocol disable unsynched PWM as it's meaningless
+    if (usingDshotProtocol) {
+        motorConfigMutable()->dev.useUnsyncedPwm = false;
+    }
+
+#if defined(USE_DSHOT_TELEMETRY)
     if ((!usingDshotProtocol || motorConfig()->dev.useBurstDshot || !systemConfig()->schedulerOptimizeRate)
         && motorConfig()->dev.useDshotTelemetry) {
         motorConfigMutable()->dev.useDshotTelemetry = false;
     }
-#endif
+#endif // USE_DSHOT_TELEMETRY
+#endif // USE_DSHOT
 
     // Temporary workaround until RPM Filter supports dual-gyro using both sensors
     // Once support is added remove this block


### PR DESCRIPTION
The digital protocols are always synchronized to the PID loop. People are setting the `use_unsynced_pwm` option mistakingly thinking it has some effect and using that to perpetuate misinformation.
