### PR TITLE
H7 SDIO/SDCARD fixes/cleanups.

### DIFF
--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -60,7 +60,7 @@ typedef struct dmaTimerMapping_s {
 #define REQMAP(periph, device) { DMA_PERIPH_ ## periph, periph ## DEV_ ## device, DMA_REQUEST_ ## periph ## device }
 #define REQMAP_DIR(periph, device, dir) { DMA_PERIPH_ ## periph ## _ ## dir, periph ## DEV_ ## device, DMA_REQUEST_ ## periph ## device ## _ ## dir }
 
-// Resolve UART/UART mess
+// Resolve UART/USART mess
 #define DMA_REQUEST_UART1_RX DMA_REQUEST_USART1_RX
 #define DMA_REQUEST_UART1_TX DMA_REQUEST_USART1_TX
 #define DMA_REQUEST_UART2_RX DMA_REQUEST_USART2_RX
@@ -92,10 +92,6 @@ static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
     REQMAP(ADC, 3),
 #endif
 
-#ifdef USE_SDCARD_SDIO
-    REQMAP_SGL(SDIO),
-#endif
-    
 #ifdef USE_UART
     REQMAP_DIR(UART, 1, TX),
     REQMAP_DIR(UART, 1, RX),

--- a/src/main/drivers/sdcard_sdio_baremetal.c
+++ b/src/main/drivers/sdcard_sdio_baremetal.c
@@ -202,6 +202,7 @@ static void sdcardSdio_init(const sdcardConfig_t *config, const spiPinConfig_t *
     }
 
 #ifdef USE_DMA_SPEC
+#if !defined(STM32H7) // H7 uses IDMA
     const dmaChannelSpec_t *dmaChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SDIO, 0, sdioConfig()->dmaopt);
 
     if (!dmaChannelSpec) {
@@ -215,6 +216,7 @@ static void sdcardSdio_init(const sdcardConfig_t *config, const spiPinConfig_t *
         sdcard.state = SDCARD_STATE_NOT_PRESENT;
         return;
     }
+#endif
 #endif
     if (config->cardDetectTag) {
         sdcard.cardDetectPin = IOGetByTag(config->cardDetectTag);
@@ -230,7 +232,11 @@ static void sdcardSdio_init(const sdcardConfig_t *config, const spiPinConfig_t *
         sdcard.useCache = 0;
     }
 #ifdef USE_DMA_SPEC
+#if defined(STM32H7) // H7 uses IDMA
+    SD_Initialize_LL(0);
+#else
     SD_Initialize_LL(dmaChannelSpec->ref);
+#endif
 #else
     SD_Initialize_LL(SDCARD_SDIO_DMA_OPT);
 #endif

--- a/src/main/msc/usbd_storage_sdio.c
+++ b/src/main/msc/usbd_storage_sdio.c
@@ -32,6 +32,8 @@
 
 #include "platform.h"
 
+#ifdef USE_SDCARD
+
 #include "common/utils.h"
 #include "drivers/dma.h"
 #include "drivers/dma_reqmap.h"
@@ -308,3 +310,4 @@ static int8_t STORAGE_GetMaxLun (void)
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 
+#endif // USE_SDCARD


### PR DESCRIPTION
Extracted from #8482

As noted in commit messages comments in the code, H7 uses IDMA for SDCARD.