### PR TITLE
Move HAL_Init call for F3/F4/F7/H7.

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -259,26 +259,6 @@ void sdCardAndFSInit()
 
 void init(void)
 {
-#ifdef USE_HAL_DRIVER
-    HAL_Init();
-#endif
-
-#if defined(STM32F7)   
-    /* Enable I-Cache */
-    if (INSTRUCTION_CACHE_ENABLE) {
-        SCB_EnableICache();
-    }
-
-    /* Enable D-Cache */
-    if (DATA_CACHE_ENABLE) {
-        SCB_EnableDCache();
-    }
-
-    if (PREFETCH_ENABLE) {
-        LL_FLASH_EnablePrefetch();
-    }
-#endif
-
 #ifdef SERIAL_PORT_COUNT
     printfSerialInit();
 #endif

--- a/src/main/startup/system_stm32f30x.c
+++ b/src/main/startup/system_stm32f30x.c
@@ -202,6 +202,10 @@ void SystemInit(void)
 #else
   SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH. */
 #endif
+
+#ifdef USE_HAL_DRIVER
+    HAL_Init();
+#endif
 }
 
 /**

--- a/src/main/startup/system_stm32f4xx.c
+++ b/src/main/startup/system_stm32f4xx.c
@@ -557,6 +557,10 @@ void SystemInit(void)
   SCB->VTOR = (uint32_t)&isr_vector_table_flash_base;
 #endif
 
+#ifdef USE_HAL_DRIVER
+    HAL_Init();
+#endif
+
     SystemCoreClockUpdate();
 }
 

--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -348,6 +348,24 @@ void SystemInit(void)
     }
     SCB->VTOR = vtorOffset;
 
+#ifdef USE_HAL_DRIVER
+    HAL_Init();
+#endif
+
+    /* Enable I-Cache */
+    if (INSTRUCTION_CACHE_ENABLE) {
+        SCB_EnableICache();
+    }
+
+    /* Enable D-Cache */
+    if (DATA_CACHE_ENABLE) {
+        SCB_EnableDCache();
+    }
+
+    if (PREFETCH_ENABLE) {
+        LL_FLASH_EnablePrefetch();
+    }
+
     /* Configure the system clock to specified frequency */
     SystemClock_Config();
 

--- a/src/main/startup/system_stm32h7xx.c
+++ b/src/main/startup/system_stm32h7xx.c
@@ -683,6 +683,10 @@ void SystemInit (void)
     SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET;       /* Vector Table Relocation in Internal FLASH */
 #endif
 
+#ifdef USE_HAL_DRIVER
+    HAL_Init();
+#endif
+
     SystemClock_Config();
     SystemCoreClockUpdate();
 


### PR DESCRIPTION
Extracted from #8482 

* HAL_Delay() was being used before HAL_Init() was called, see SystemClock_Config()
* Brings it in-line with ST examples which follow this call order:
CubeMX generated code goes startup_xxx.s (asm) -> SystemInit(), then
main(), HAL_Init(), SystemClock_Config()

Boot-tested on:
* SPRacingF4NEO
* SPRacingF7DUAL
Flight-tested on:
* SPRacingH7ZERO
* SPRacingH7EXTREME
* SPRacingH7NANO


