### PR TITLE
Add link quality symbol to OSD

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -41,6 +41,7 @@
 
 // RSSI
 #define SYM_RSSI                    0x01
+#define SYM_LINK_QUALITY            0x7B
 
 // Throttle Position (%)
 #define SYM_THR                     0x04

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -847,13 +847,13 @@ static void osdElementLinkQuality(osdElementParms_t *element)
     uint16_t osdLinkQuality = 0;
     if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) { // 0-300
         osdLinkQuality = rxGetLinkQuality()  / 3.41;
-        tfp_sprintf(element->buff, "%3d", osdLinkQuality);
+        tfp_sprintf(element->buff, "%c%3d", SYM_LINK_QUALITY, osdLinkQuality);
     } else { // 0-9
         osdLinkQuality = rxGetLinkQuality() * 10 / LINK_QUALITY_MAX_VALUE;
         if (osdLinkQuality >= 10) {
             osdLinkQuality = 9;
         }
-        tfp_sprintf(element->buff, "%1d", osdLinkQuality);
+        tfp_sprintf(element->buff, "%c%1d", SYM_LINK_QUALITY, osdLinkQuality);
     }
 }
 #endif // USE_RX_LINK_QUALITY_INFO

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -244,7 +244,7 @@ TEST(LQTest, TestElement_LQ_SOURCE_NONE_SAMPLES)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(8, 1, "9");
+    displayPortTestBufferSubstring(8, 1, "%c9", SYM_LINK_QUALITY);
 
     // when  updateLinkQualitySamples used   50% rounds to 4
     for (int x = 0; x < LINK_QUALITY_SAMPLE_COUNT; x++) {
@@ -256,7 +256,7 @@ TEST(LQTest, TestElement_LQ_SOURCE_NONE_SAMPLES)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(8, 1, "4");
+    displayPortTestBufferSubstring(8, 1, "%c4", SYM_LINK_QUALITY);
 
 }
 /*
@@ -286,9 +286,9 @@ TEST(LQTest, TestElement_LQ_SOURCE_NONE_VALUES)
 #endif
         // then
         if (testdigit >= 10){
-            displayPortTestBufferSubstring(7, 1," 9");
+            displayPortTestBufferSubstring(8, 1,"%c9", SYM_LINK_QUALITY);
         }else{
-            displayPortTestBufferSubstring(7, 1," %1d", testdigit - 1);
+            displayPortTestBufferSubstring(8, 1,"%c%1d", SYM_LINK_QUALITY, testdigit - 1);
         }
     }
 }
@@ -316,7 +316,7 @@ TEST(LQTest, TestElementLQ_PROTOCOL_CRSF_VALUES)
         // then rxGetLinkQuality Osd should be x
         displayClearScreen(&testDisplayPort);
         osdRefresh(simulationTime);
-        displayPortTestBufferSubstring(8, 1,"%3d", x);
+        displayPortTestBufferSubstring(8, 1,"%c%3d", SYM_LINK_QUALITY, x);
 
     }
 }
@@ -367,7 +367,7 @@ TEST(LQTest, TestLQAlarm)
 #ifdef DEBUG_OSD
         printf("%d\n", i);
 #endif
-        displayPortTestBufferSubstring(8,  1, "9");
+        displayPortTestBufferSubstring(8,  1, "%c9", SYM_LINK_QUALITY);
 
     }
 
@@ -387,7 +387,7 @@ TEST(LQTest, TestLQAlarm)
         displayPortTestPrint();
 #endif
         if (i % 2 == 0) {
-            displayPortTestBufferSubstring(8,  1, "5");
+            displayPortTestBufferSubstring(8,  1, "%c5", SYM_LINK_QUALITY);
         } else {
             displayPortTestBufferIsEmpty();
         }


### PR DESCRIPTION
Adds the symbol of Link Quality to the OSD. This new symbol was published here: https://github.com/betaflight/betaflight-configurator/pull/1504