### PR TITLE
Make 'make <target>_flash' build the hex file as well.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,11 +468,10 @@ TARGETS_FLASH = $(addsuffix _flash,$(VALID_TARGETS) )
 
 ## <TARGET>_flash    : build and flash a target
 $(TARGETS_FLASH):
-ifneq (,$(findstring /dev/ttyUSB,$(SERIAL_DEVICE)))
 	$(V0) $(MAKE) -j hex TARGET=$(subst _flash,,$@)
+ifneq (,$(findstring /dev/ttyUSB,$(SERIAL_DEVICE)))
 	$(V0) $(MAKE) tty_flash TARGET=$(subst _flash,,$@)
 else
-	$(V0) $(MAKE) -j binary TARGET=$(subst _flash,,$@)
 	$(V0) $(MAKE) dfu_flash TARGET=$(subst _flash,,$@)
 endif
 


### PR DESCRIPTION
The hex file is not strictly needed when flashing with `dfu-util`, but in order to be able to flash the same target again it is more convenient to build it as a by-product.