### PR TITLE
Adding length to PG registry (to begin the process of setting up prefix and indexes on settings entries)

### DIFF
--- a/src/main/pg/pg.h
+++ b/src/main/pg/pg.h
@@ -45,6 +45,7 @@ typedef void (pgResetFunc)(void * /* base */);
 
 typedef struct pgRegistry_s {
     pgn_t pgn;             // The parameter group number, the top 4 bits are reserved for version
+    uint8_t length;        // The number of elements in the group 
     uint16_t size;         // Size of the group in RAM, the top 4 bits are reserved for flags
     uint8_t *address;      // Address of the group in RAM.
     uint8_t *copy;         // Address of the copy in RAM.
@@ -58,6 +59,7 @@ typedef struct pgRegistry_s {
 static inline uint16_t pgN(const pgRegistry_t* reg) {return reg->pgn & PGR_PGN_MASK;}
 static inline uint8_t pgVersion(const pgRegistry_t* reg) {return (uint8_t)(reg->pgn >> 12);}
 static inline uint16_t pgSize(const pgRegistry_t* reg) {return reg->size & PGR_SIZE_MASK;}
+static inline uint16_t pgElementSize(const pgRegistry_t* reg) {return (reg->size & PGR_SIZE_MASK) / reg->length;}
 
 #define PG_PACKED __attribute__((packed))
 
@@ -103,12 +105,12 @@ extern const uint8_t __pg_resetdata_end[];
     /**/
 
 // Declare system config array
-#define PG_DECLARE_ARRAY(_type, _size, _name)                           \
-    extern _type _name ## _SystemArray[_size];                          \
-    extern _type _name ## _CopyArray[_size];                            \
+#define PG_DECLARE_ARRAY(_type, _length, _name)                         \
+    extern _type _name ## _SystemArray[_length];                        \
+    extern _type _name ## _CopyArray[_length];                          \
     static inline const _type* _name(int _index) { return &_name ## _SystemArray[_index]; } \
     static inline _type* _name ## Mutable(int _index) { return &_name ## _SystemArray[_index]; } \
-    static inline _type (* _name ## _array(void))[_size] { return &_name ## _SystemArray; } \
+    static inline _type (* _name ## _array(void))[_length] { return &_name ## _SystemArray; } \
     struct _dummy                                                       \
     /**/
 
@@ -120,6 +122,7 @@ extern const uint8_t __pg_resetdata_end[];
     extern const pgRegistry_t _name ## _Registry;                       \
     const pgRegistry_t _name ##_Registry PG_REGISTER_ATTRIBUTES = {     \
         .pgn = _pgn | (_version << 12),                                 \
+        .length = 1,                                                    \
         .size = sizeof(_type) | PGR_SIZE_SYSTEM_FLAG,                   \
         .address = (uint8_t*)&_name ## _System,                         \
         .copy = (uint8_t*)&_name ## _Copy,                              \
@@ -143,13 +146,14 @@ extern const uint8_t __pg_resetdata_end[];
     /**/
 
 // Register system config array
-#define PG_REGISTER_ARRAY_I(_type, _size, _name, _pgn, _version, _reset)  \
-    _type _name ## _SystemArray[_size];                                 \
-    _type _name ## _CopyArray[_size];                                   \
+#define PG_REGISTER_ARRAY_I(_type, _length, _name, _pgn, _version, _reset)  \
+    _type _name ## _SystemArray[_length];                               \
+    _type _name ## _CopyArray[_length];                                 \
     extern const pgRegistry_t _name ##_Registry;                        \
     const pgRegistry_t _name ## _Registry PG_REGISTER_ATTRIBUTES = {    \
         .pgn = _pgn | (_version << 12),                                 \
-        .size = (sizeof(_type) * _size) | PGR_SIZE_SYSTEM_FLAG,         \
+        .length = _length,                                              \
+        .size = (sizeof(_type) * _length) | PGR_SIZE_SYSTEM_FLAG,       \
         .address = (uint8_t*)&_name ## _SystemArray,                    \
         .copy = (uint8_t*)&_name ## _CopyArray,                         \
         .ptr = 0,                                                       \
@@ -157,20 +161,20 @@ extern const uint8_t __pg_resetdata_end[];
     }                                                                   \
     /**/
 
-#define PG_REGISTER_ARRAY(_type, _size, _name, _pgn, _version)            \
-    PG_REGISTER_ARRAY_I(_type, _size, _name, _pgn, _version, .reset = {.ptr = 0}) \
+#define PG_REGISTER_ARRAY(_type, _length, _name, _pgn, _version)        \
+    PG_REGISTER_ARRAY_I(_type, _length, _name, _pgn, _version, .reset = {.ptr = 0}) \
     /**/
 
-#define PG_REGISTER_ARRAY_WITH_RESET_FN(_type, _size, _name, _pgn, _version) \
+#define PG_REGISTER_ARRAY_WITH_RESET_FN(_type, _length, _name, _pgn, _version) \
     extern void pgResetFn_ ## _name(_type *);    \
-    PG_REGISTER_ARRAY_I(_type, _size, _name, _pgn, _version, .reset = {.fn = (pgResetFunc*)&pgResetFn_ ## _name}) \
+    PG_REGISTER_ARRAY_I(_type, _length, _name, _pgn, _version, .reset = {.fn = (pgResetFunc*)&pgResetFn_ ## _name}) \
     /**/
 
 #if 0
 // ARRAY reset mechanism is not implemented yet, only few places in code would benefit from it - See pgResetInstance
-#define PG_REGISTER_ARRAY_WITH_RESET_TEMPLATE(_type, _size, _name, _pgn, _version) \
+#define PG_REGISTER_ARRAY_WITH_RESET_TEMPLATE(_type, _length, _name, _pgn, _version) \
     extern const _type pgResetTemplate_ ## _name;                       \
-    PG_REGISTER_ARRAY_I(_type, _size, _name, _pgn, _version, .reset = {.ptr = (void*)&pgResetTemplate_ ## _name}) \
+    PG_REGISTER_ARRAY_I(_type, _length, _name, _pgn, _version, .reset = {.ptr = (void*)&pgResetTemplate_ ## _name}) \
     /**/
 #endif
 


### PR DESCRIPTION
Simplified this PR to just adding the length to the PG registry. Will add PREFIX and index in subsequent PRs.

e.g. going with `set gyro.1.bustype = I2C`


Old notes:
--//--

The index is specified in set as [x] appended to the name.

e.g. 

```
# get gyro_bus
set gyro_bustype[0] = I2C
set gyro_bustype[1] = SPI
# Allowed values: NONE, I2C, SPI, SLAVE
# Default value: SPI
```
This could allow for cleanup of the setting of Rate and PID profiles in CLI too. Note that I have not touched those yet - and they may well be broken - will await feed back first.

EDIT: removed some of the profile differences. Not we can probably consolidate the profiles / rates in CLI now and remove the specific setting.