### PR TITLE
set throttle boost to zero

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -166,7 +166,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .horizon_tilt_expert_mode = false,
         .crash_limit_yaw = 200,
         .itermLimit = 400,
-        .throttle_boost = 5,
+        .throttle_boost = 0,
         .throttle_boost_cutoff = 15,
         .iterm_rotation = false,
         .iterm_relax = ITERM_RELAX_RP,


### PR DESCRIPTION
Throttle boost is useful in low powered quads but not needed in most mainstream machines.  

Default should remain zero imho for 4.1.