### PR TITLE
Add FF to yaw, reduce yaw P and I

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -136,7 +136,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .pid = {
             [PID_ROLL] =  { 42, 60, 35, 70 },
             [PID_PITCH] = { 46, 70, 38, 75 },
-            [PID_YAW] =   { 35, 100, 0, 0 },
+            [PID_YAW] =   { 30, 80, 0, 70 },
             [PID_LEVEL] = { 50, 50, 75, 0 },
             [PID_MAG] =   { 40, 0, 0, 0 },
         },


### PR DESCRIPTION
FF improves yaw performance, reducing the need for yaw P and reducing the amount of I that accumulates, leading to less yaw bounce-back.

Several users noticed I mediated yaw bounce-back and these settings generally fix that issue.

Large quads have weaker yaw authority and need a different yaw paradigm with more FF and P and less I.