### PR TITLE
Add ARMING_DISABLED_FILTERING for filter config errors and completely disabled gyro filtering

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -56,6 +56,7 @@ const char *armingDisableFlagNames[]= {
     "RESCUE_SW",
     "RPMFILTER",
     "REBOOT_REQD",
+    "FILTERING",
     "ARMSWITCH",
 };
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -62,7 +62,8 @@ typedef enum {
     ARMING_DISABLED_RESC            = (1 << 19),
     ARMING_DISABLED_RPMFILTER       = (1 << 20),
     ARMING_DISABLED_REBOOT_REQUIRED = (1 << 21),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 22), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_FILTERING       = (1 << 22),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 23), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
 #define ARMING_DISABLE_FLAGS_COUNT (LOG2(ARMING_DISABLED_ARM_SWITCH) + 1)

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -222,4 +222,9 @@ bool isRpmFilterEnabled(void)
     return (motorConfig()->dev.useDshotTelemetry && (rpmFilterConfig()->gyro_rpm_notch_harmonics || rpmFilterConfig()->dterm_rpm_notch_harmonics));
 }
 
+bool isRpmGyroFilterEnabled(void)
+{
+    return (motorConfig()->dev.useDshotTelemetry && rpmFilterConfig()->gyro_rpm_notch_harmonics);
+}
+
 #endif

--- a/src/main/flight/rpm_filter.h
+++ b/src/main/flight/rpm_filter.h
@@ -43,3 +43,4 @@ float rpmFilterGyro(int axis, float values);
 float rpmFilterDterm(int axis, float values);
 void  rpmFilterUpdate();
 bool isRpmFilterEnabled(void);
+bool isRpmGyroFilterEnabled(void);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -663,7 +663,7 @@ void gyroInitLowpassFilterLpf(gyroSensor_t *gyroSensor, int slot, int type, uint
     }
 }
 
-static uint16_t calculateNyquistAdjustedNotchHz(uint16_t notchHz, uint16_t notchCutoffHz)
+uint16_t calculateNyquistAdjustedNotchHz(uint16_t notchHz, uint16_t notchCutoffHz)
 {
     const uint32_t gyroFrequencyNyquist = 1000000 / 2 / gyro.targetLooptime;
     if (notchHz > gyroFrequencyNyquist) {

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -142,3 +142,4 @@ gyroDetectionFlags_t getGyroDetectionFlags(void);
 float dynThrottle(float throttle);
 void dynLpfGyroUpdate(float throttle);
 #endif
+uint16_t calculateNyquistAdjustedNotchHz(uint16_t notchHz, uint16_t notchCutoffHz);

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -72,6 +72,7 @@ extern "C" {
     bool cmsInMenu = false;
     float axisPID_P[3], axisPID_I[3], axisPID_D[3], axisPIDSum[3];
     rxRuntimeConfig_t rxRuntimeConfig = {};
+    gyro_t gyro = {};
 }
 
 uint32_t simulationFeatureFlags = 0;
@@ -178,4 +179,6 @@ extern "C" {
     void osdSuppressStats(bool) {}
     void pidSetItermReset(bool) {}
     void applyAccelerometerTrimsDelta(rollAndPitchTrims_t*) {}
+    bool isRpmGyroFilterEnabled(void) { return false; }
+    uint16_t calculateNyquistAdjustedNotchHz(uint16_t, uint16_t) { return 0; }
 }


### PR DESCRIPTION
Will set an arming disabled flag if any filters are implicitly disabled by nyquist limit rules. This is most likely to occur if the user decreased their loop times (which also lowers the nyquist limit) without adjusting their filter settings.

Also disable arming if **all gyro filtering is disabled**.

If additional "sanity check" rules can be developed for filtering settings then these can later be added. Requiring that at least one form of gyro filter is enabled is a reasonable check at this point. The same can't be said for dterm filtering as there are people running with no dterm filtering and just gyro filtering (particularly with RPM filter).

Includes unit test support.

Needs coordination with Configurator to add support for new arming disabled reason. https://github.com/betaflight/betaflight-configurator/pull/1518
