### PR TITLE
Added RTC6705 driver to Unified Targets.

### DIFF
--- a/src/main/target/STM32F405/target.mk
+++ b/src/main/target/STM32F405/target.mk
@@ -2,10 +2,12 @@ F405_TARGETS += $(TARGET)
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
 TARGET_SRC = \
-	$(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
-	$(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
-	$(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
-	drivers/max7456.c \
+    $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+    $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
+    $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
+    drivers/max7456.c \
+    drivers/vtx_rtc6705.c \
+    drivers/vtx_rtc6705_soft_spi.c \
     rx/cc2500_common.c \
     rx/cc2500_frsky_shared.c \
     rx/cc2500_frsky_d.c \

--- a/src/main/target/STM32F411/target.mk
+++ b/src/main/target/STM32F411/target.mk
@@ -7,6 +7,8 @@ TARGET_SRC = \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
     $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
     drivers/max7456.c \
+    drivers/vtx_rtc6705.c \
+    drivers/vtx_rtc6705_soft_spi.c \
     rx/cc2500_common.c \
     rx/cc2500_frsky_shared.c \
     rx/cc2500_frsky_d.c \

--- a/src/main/target/STM32F745/target.mk
+++ b/src/main/target/STM32F745/target.mk
@@ -2,17 +2,19 @@ F7X5XG_TARGETS += $(TARGET)
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
 TARGET_SRC = \
-	$(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
-	$(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
-	$(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
-	drivers/max7456.c \
-	rx/cc2500_common.c \
-	rx/cc2500_frsky_shared.c \
-	rx/cc2500_frsky_d.c \
-	rx/cc2500_frsky_x.c \
-	rx/cc2500_sfhss.c \
-	rx/a7105_flysky.c \
-	rx/cyrf6936_spektrum.c \
-	drivers/rx/rx_cc2500.c \
-	drivers/rx/rx_a7105.c \
-	drivers/rx/rx_cyrf6936.c
+    $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+    $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
+    $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
+    drivers/max7456.c \
+    drivers/vtx_rtc6705.c \
+    drivers/vtx_rtc6705_soft_spi.c \
+    rx/cc2500_common.c \
+    rx/cc2500_frsky_shared.c \
+    rx/cc2500_frsky_d.c \
+    rx/cc2500_frsky_x.c \
+    rx/cc2500_sfhss.c \
+    rx/a7105_flysky.c \
+    rx/cyrf6936_spektrum.c \
+    drivers/rx/rx_cc2500.c \
+    drivers/rx/rx_a7105.c \
+    drivers/rx/rx_cyrf6936.c

--- a/src/main/target/STM32F7X2/target.mk
+++ b/src/main/target/STM32F7X2/target.mk
@@ -2,17 +2,19 @@ F7X2RE_TARGETS += $(TARGET)
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
 TARGET_SRC = \
-	$(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
-	$(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
-	$(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
-	drivers/max7456.c \
-	rx/cc2500_common.c \
-	rx/cc2500_frsky_shared.c \
-	rx/cc2500_frsky_d.c \
-	rx/cc2500_frsky_x.c \
-	rx/cc2500_sfhss.c \
-	rx/a7105_flysky.c \
-	rx/cyrf6936_spektrum.c \
-	drivers/rx/rx_cc2500.c \
-	drivers/rx/rx_a7105.c \
-	drivers/rx/rx_cyrf6936.c
+    $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+    $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
+    $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
+    drivers/max7456.c \
+    drivers/vtx_rtc6705.c \
+    drivers/vtx_rtc6705_soft_spi.c \
+    rx/cc2500_common.c \
+    rx/cc2500_frsky_shared.c \
+    rx/cc2500_frsky_d.c \
+    rx/cc2500_frsky_x.c \
+    rx/cc2500_sfhss.c \
+    rx/a7105_flysky.c \
+    rx/cyrf6936_spektrum.c \
+    drivers/rx/rx_cc2500.c \
+    drivers/rx/rx_a7105.c \
+    drivers/rx/rx_cyrf6936.c

--- a/src/main/target/common_unified.h
+++ b/src/main/target/common_unified.h
@@ -77,6 +77,9 @@
 
 #define USE_MAX7456
 
+#define USE_VTX_RTC6705
+#define USE_VTX_RTC6705_SOFTSPI
+
 #define USE_TRANSPONDER
 
 //TODO: Make this actually work by making the pins configurable

--- a/unified_targets/configs/SPRACINGF7DUAL.config
+++ b/unified_targets/configs/SPRACINGF7DUAL.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F7X2 (S7X2) 4.0.0 Mar 11 2019 / 22:28:27 (c2b7e5273) MSP API: 1.41
+# Betaflight / STM32F7X2 (S7X2) 4.1.0 Jul  3 2019 / 00:11:51 (095b2e543) MSP API: 1.42
 
 board_name SPRACINGF7DUAL
 manufacturer_id SPRO
@@ -34,6 +34,7 @@ resource SERIAL_RX 5 D02
 resource I2C_SCL 1 B08
 resource I2C_SDA 1 B09
 resource LED 1 C04
+resource TRANSPONDER 1 A08
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13
 resource SPI_SCK 3 B03
@@ -53,6 +54,10 @@ resource GYRO_EXTI 1 C13
 resource GYRO_EXTI 2 C14
 resource GYRO_CS 1 A15
 resource GYRO_CS 2 B02
+resource VTX_POWER 1 B07
+resource VTX_CS 1 B06
+resource VTX_DATA 1 B00
+resource VTX_CLK 1 B01
 
 # timer
 timer A00 AF2
@@ -128,7 +133,12 @@ dma pin A10 1
 
 # master
 set gyro_to_use = BOTH
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
 set adc_device = 3
+set blackbox_device = SDCARD
 set dshot_burst = ON
 set current_meter = ADC
 set battery_meter = ADC


### PR DESCRIPTION
This currently only supports the soft SPI version - 'proper' SPI will require a little bit more work to make it configurable at runtime.