### PR TITLE
Fix beeper support for general board target.

### DIFF
--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -39,6 +39,8 @@
 
 #define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 6)
 
+#define USE_BEEPER
+
 #define USE_INVERTER
 
 #define USE_SPI_DEVICE_1

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -34,6 +34,8 @@
 #define USE_UART2
 #define USE_UART6
 
+#define USE_BEEPER
+
 #define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 3)
 
 #define USE_INVERTER

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -42,6 +42,8 @@
 
 #define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 8)
 
+#define USE_BEEPER
+
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
 #define USE_SPI_DEVICE_3

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -39,6 +39,8 @@
 
 #define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 6) 
 
+#define USE_BEEPER
+
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
 #define USE_SPI_DEVICE_3


### PR DESCRIPTION
This commit was initially fixed, the buzzer support for the generic target hardware, the buzzer is not compiled in the current code.