### PR TITLE
Fix beeper support for IF_F411_PRO and IF_F405_TWING unified targets

### DIFF
--- a/unified_targets/configs/IFLIGHTF4_TWIN_G.config
+++ b/unified_targets/configs/IFLIGHTF4_TWIN_G.config
@@ -126,3 +126,5 @@ set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
 set gyro_2_spibus = 1
 set gyro_2_sensor_align = CW90
+set beeper_inversion = ON
+set beeper_od = OFF

--- a/unified_targets/configs/IFLIGHT_F411_PRO.config
+++ b/unified_targets/configs/IFLIGHT_F411_PRO.config
@@ -75,3 +75,5 @@ set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
+set beeper_inversion = ON
+set beeper_od = OFF


### PR DESCRIPTION
Base on https://github.com/betaflight/betaflight/pull/8548. I found the problems and fixed it for them. Thanks @mikeller 