### PR TITLE
Expose camera control button resistance values

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1395,6 +1395,7 @@ const clivalue_t valueTable[] = {
     { "camera_control_ref_voltage", VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 200, 400 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, refVoltage) },
     { "camera_control_key_delay", VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 500 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, keyDelayMs) },
     { "camera_control_internal_resistance", VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 1000 }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, internalResistance) },
+    { "camera_control_button_resistance",   VAR_UINT16 | MASTER_VALUE | MODE_ARRAY, .config.array.length = CAMERA_CONTROL_KEYS_COUNT, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, buttonResistanceValues) },
     { "camera_control_inverted", VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CAMERA_CONTROL_CONFIG, offsetof(cameraControlConfig_t, inverted) },
 #endif
 

--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -69,6 +69,11 @@ void pgResetFn_cameraControlConfig(cameraControlConfig_t *cameraControlConfig)
     cameraControlConfig->internalResistance = 470;
     cameraControlConfig->ioTag = timerioTagGetByUsage(TIM_USE_CAMERA_CONTROL, 0);
     cameraControlConfig->inverted = 0;   // Output is inverted externally
+    cameraControlConfig->buttonResistanceValues[CAMERA_CONTROL_KEY_ENTER] = 450;
+    cameraControlConfig->buttonResistanceValues[CAMERA_CONTROL_KEY_LEFT]  = 270;
+    cameraControlConfig->buttonResistanceValues[CAMERA_CONTROL_KEY_UP]    = 150;
+    cameraControlConfig->buttonResistanceValues[CAMERA_CONTROL_KEY_RIGHT] = 68;
+    cameraControlConfig->buttonResistanceValues[CAMERA_CONTROL_KEY_DOWN]  = 0;
 }
 
 static struct {
@@ -184,11 +189,9 @@ void cameraControlProcess(uint32_t currentTimeUs)
     }
 }
 
-static const int buttonResistanceValues[] = { 45000, 27000, 15000, 6810, 0 };
-
 static float calculateKeyPressVoltage(const cameraControlKey_e key)
 {
-    const int buttonResistance = buttonResistanceValues[key];
+    const int buttonResistance = cameraControlConfig()->buttonResistanceValues[key] * 100;
     return 1.0e-2f * cameraControlConfig()->refVoltage * buttonResistance / (100 * cameraControlConfig()->internalResistance + buttonResistance);
 }
 

--- a/src/main/drivers/camera_control.h
+++ b/src/main/drivers/camera_control.h
@@ -49,6 +49,7 @@ typedef struct cameraControlConfig_s {
 
     ioTag_t ioTag;
     uint8_t inverted;
+    uint16_t buttonResistanceValues[CAMERA_CONTROL_KEYS_COUNT]; // resistance in 100ohm steps
 } cameraControlConfig_t;
 
 PG_DECLARE(cameraControlConfig_t, cameraControlConfig);


### PR DESCRIPTION
Allows fine tuning of the voltage divider resistance values for each button to account for slight variances amongst cameras. Also allows manual configuration for non-standard cameras.

Resistance values are in 100ohm steps.