### PR TITLE
Dshot bidir blhelis support

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -261,7 +261,7 @@ static const char * const *sensorHardwareNames[] = {
 
 #if defined(USE_DSHOT) && defined(USE_DSHOT_TELEMETRY)
 extern uint32_t readDoneCount;
-extern uint32_t inputBuffer[DSHOT_TELEMETRY_INPUT_LEN];
+extern uint32_t inputBuffer[GCR_TELEMETRY_INPUT_LEN];
 extern uint32_t setDirectionMicros;
 #endif
 
@@ -5680,15 +5680,13 @@ static void cliDshotTelemetryInfo(char *cmdline)
         }
         cliPrintLinefeed();
 
-        const bool proshot = (motorConfig()->dev.motorPwmProtocol == PWM_TYPE_PROSHOT1000);
-        const int modulo = proshot ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH;
-        const int len = proshot ? 8 : DSHOT_TELEMETRY_INPUT_LEN;
+        const int len = MAX_GCR_EDGES;
         for (int i = 0; i < len; i++) {
             cliPrintf("%u ", (int)inputBuffer[i]);
         }
         cliPrintLinefeed();
-        for (int i = 1; i < len; i+=2) {
-            cliPrintf("%u ", (int)(inputBuffer[i] + modulo - inputBuffer[i-1]) % modulo);
+        for (int i = 1; i < len; i++) {
+            cliPrintf("%u ", (int)(inputBuffer[i]  - inputBuffer[i-1]));
         }
         cliPrintLinefeed();
     } else {

--- a/src/main/drivers/dshot_dpwm.c
+++ b/src/main/drivers/dshot_dpwm.c
@@ -112,6 +112,12 @@ static void dshotPwmDisableMotors(void)
 
 static bool dshotPwmEnableMotors(void)
 {
+    for (int i = 0; i < dshotPwmDevice.count; i++) {
+        motorDmaOutput_t *motor = getMotorDmaOutput(i);
+        const IO_t motorIO = IOGetByTag(motor->timerHardware->tag);
+        IOConfigGPIOAF(motorIO, motor->iocfg, motor->timerHardware->alternateFunction);
+    }
+
     // No special processing required
     return true;
 }

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -53,23 +53,6 @@
 
 #ifdef USE_DSHOT_TELEMETRY
 
-static void processInputIrq(motorDmaOutput_t * const motor)
-{
-    motor->hasTelemetry = true;
-
-#ifdef USE_DSHOT_DMAR
-    if (useBurstDshot) {
-        xLL_EX_DMA_DisableResource(motor->timerHardware->dmaTimUPRef);
-        LL_TIM_DisableDMAReq_UPDATE(motor->timerHardware->tim);
-    } else
-#endif
-    {
-        xLL_EX_DMA_DisableResource(motor->dmaRef);
-        LL_EX_TIM_DisableIT(motor->timerHardware->tim, motor->timerDmaSource);
-    }
-    readDoneCount++;
-}
-
 void dshotEnableChannels(uint8_t motorCount)
 {
     for (int i = 0; i < motorCount; i++) {
@@ -82,7 +65,6 @@ void dshotEnableChannels(uint8_t motorCount)
 }
 
 #endif
-
 
 static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor);
 
@@ -106,7 +88,11 @@ void pwmDshotSetDirectionOutput(
 #ifdef USE_DSHOT_TELEMETRY
     if (!output) {
         motor->isInput = true;
-        motor->timer->inputDirectionStampUs = micros();
+        if (!inputStampUs) {
+            inputStampUs = micros();
+        }
+        LL_TIM_EnableARRPreload(timer); // Only update the period once all channels are done
+        timer->ARR = 0xffffffff;
         LL_TIM_IC_Init(timer, motor->llChannel, &motor->icInitStruct);
         motor->dmaInitStruct.Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
     } else
@@ -124,7 +110,9 @@ void pwmDshotSetDirectionOutput(
         motor->dmaInitStruct.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
     }
     xLL_EX_DMA_Init(motor->dmaRef, pDmaInit);
-    xLL_EX_DMA_EnableIT_TC(motor->dmaRef);
+    if (output) {
+        xLL_EX_DMA_EnableIT_TC(motor->dmaRef);
+    }
 }
 
 
@@ -148,6 +136,9 @@ FAST_CODE void pwmCompleteDshotMotorUpdate(void)
         } else
 #endif
         {
+            LL_TIM_DisableARRPreload(dmaMotorTimers[i].timer);
+            dmaMotorTimers[i].timer->ARR = dmaMotorTimers[i].outputPeriod;
+
             /* Reset timer counter */
             LL_TIM_SetCounter(dmaMotorTimers[i].timer, 0);
             /* Enable channel DMA requests */
@@ -161,13 +152,10 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
 {
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         motorDmaOutput_t * const motor = &dmaMotors[descriptor->userParam];
+        if (!motor->isInput) {
 #ifdef USE_DSHOT_TELEMETRY
-        uint32_t irqStart = micros();
-        if (motor->isInput) {
-            processInputIrq(motor);
-        } else
+            uint32_t irqStartUs = micros();
 #endif
-        {
 #ifdef USE_DSHOT_DMAR
             if (useBurstDshot) {
                 xLL_EX_DMA_DisableResource(motor->timerHardware->dmaTimUPRef);
@@ -182,10 +170,10 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
 #ifdef USE_DSHOT_TELEMETRY
             if (useDshotTelemetry) {
                 pwmDshotSetDirectionOutput(motor, false);
-                xLL_EX_DMA_SetDataLength(motor->dmaRef, motor->dmaInputLen);
+                xLL_EX_DMA_SetDataLength(motor->dmaRef, GCR_TELEMETRY_INPUT_LEN);
                 xLL_EX_DMA_EnableResource(motor->dmaRef);
                 LL_EX_TIM_EnableIT(motor->timerHardware->tim, motor->timerDmaSource);
-                setDirectionMicros = micros() - irqStart;
+                setDirectionMicros = micros() - irqStartUs;
             }
 #endif
         }
@@ -231,26 +219,27 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     }
 
     motorDmaOutput_t * const motor = &dmaMotors[motorIndex];
-#ifdef USE_DSHOT_TELEMETRY
-    motor->useProshot = (pwmProtocolType == PWM_TYPE_PROSHOT1000);
-#endif
-    motor->timerHardware = timerHardware;
     motor->dmaRef = dmaRef;
 
     TIM_TypeDef *timer = timerHardware->tim;
-    const IO_t motorIO = IOGetByTag(timerHardware->tag);
 
     const uint8_t timerIndex = getTimerIndex(timer);
     const bool configureTimer = (timerIndex == dmaMotorTimerCount - 1);
 
+    motor->timer = &dmaMotorTimers[timerIndex];
+    motor->index = motorIndex;
+
+    const IO_t motorIO = IOGetByTag(timerHardware->tag);
     uint8_t pupMode = (output & TIMER_OUTPUT_INVERTED) ? GPIO_PULLDOWN : GPIO_PULLUP;
 #ifdef USE_DSHOT_TELEMETRY
     if (useDshotTelemetry) {
         output ^= TIMER_OUTPUT_INVERTED;
     }
 #endif
+    motor->timerHardware = timerHardware;
 
-    IOConfigGPIOAF(motorIO, IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, pupMode), timerHardware->alternateFunction);
+    motor->iocfg = IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, pupMode);
+    IOConfigGPIOAF(motorIO, motor->iocfg, timerHardware->alternateFunction);
 
     if (configureTimer) {
         LL_TIM_InitTypeDef init;
@@ -284,7 +273,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     LL_TIM_IC_StructInit(&motor->icInitStruct);
     motor->icInitStruct.ICPolarity = LL_TIM_IC_POLARITY_BOTHEDGE;
     motor->icInitStruct.ICPrescaler = LL_TIM_ICPSC_DIV1;
-    motor->icInitStruct.ICFilter = 0; //2;
+    motor->icInitStruct.ICFilter = 2;
 #endif
 
     uint32_t channel = 0;
@@ -295,8 +284,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     case TIM_CHANNEL_4: channel = LL_TIM_CHANNEL_CH4; break;
     }
     motor->llChannel = channel;
-    motor->timer = &dmaMotorTimers[timerIndex];
-    motor->index = motorIndex;
 
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
@@ -355,10 +342,9 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->dmaRef = dmaRef;
 
 #ifdef USE_DSHOT_TELEMETRY
-    motor->dmaInputLen = motor->useProshot ? PROSHOT_TELEMETRY_INPUT_LEN : DSHOT_TELEMETRY_INPUT_LEN;
     motor->dshotTelemetryDeadtimeUs = DSHOT_TELEMETRY_DEADTIME_US + 1000000 *
-        ( 2 + (motor->useProshot ? 4 * MOTOR_NIBBLE_LENGTH_PROSHOT : 16 * MOTOR_BITLENGTH))
-        / getDshotHz(pwmProtocolType);
+        ( 16 * MOTOR_BITLENGTH) / getDshotHz(pwmProtocolType);
+    motor->timer->outputPeriod = (pwmProtocolType == PWM_TYPE_PROSHOT1000 ? (MOTOR_NIBBLE_LENGTH_PROSHOT) : MOTOR_BITLENGTH) - 1;
     pwmDshotSetDirectionOutput(motor, true);
 #else
     pwmDshotSetDirectionOutput(motor, true, &OCINIT, &DMAINIT);

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -251,7 +251,7 @@ void updateDshotTelemetryQuality(dshotTelemetryQuality_t *qualityStats, bool pac
 }
 #endif // USE_DSHOT_TELEMETRY_STATS
 
-NOINLINE bool pwmStartDshotMotorUpdate(void)
+FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
 {
     if (!useDshotTelemetry) {
         return true;

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -79,8 +79,9 @@ uint32_t readDoneCount;
 
 // TODO remove once debugging no longer needed
 FAST_RAM_ZERO_INIT uint32_t dshotInvalidPacketCount;
-FAST_RAM_ZERO_INIT uint32_t inputBuffer[DSHOT_TELEMETRY_INPUT_LEN];
+FAST_RAM_ZERO_INIT uint32_t inputBuffer[GCR_TELEMETRY_INPUT_LEN];
 FAST_RAM_ZERO_INIT uint32_t setDirectionMicros;
+FAST_RAM_ZERO_INIT uint32_t inputStampUs;
 #endif
 
 motorDmaOutput_t *getMotorDmaOutput(uint8_t index)
@@ -152,55 +153,64 @@ FAST_CODE void pwmWriteDshotInt(uint8_t index, uint16_t value)
 
 void dshotEnableChannels(uint8_t motorCount);
 
-static uint16_t decodeDshotPacket(uint32_t buffer[])
+static uint32_t decodeTelemetryPacket(uint32_t buffer[], uint32_t count)
 {
+    uint32_t start = micros();
     uint32_t value = 0;
-    for (int i = 1; i < DSHOT_TELEMETRY_INPUT_LEN; i += 2) {
-        int diff = buffer[i] - buffer[i-1];
-        value <<= 1;
-        if (diff > 0) {
-            if (diff >= 11) value |= 1;
+    uint32_t oldValue = buffer[0];
+    int bits = 0;
+    int len;
+    for (uint32_t i = 1; i <= count; i++) {
+        if (i < count) {
+            int diff = buffer[i] - oldValue;
+            if (bits >= 21) {
+                break;
+            }
+            len = (diff + 8) / 16;
         } else {
-            if (diff >= -9) value |= 1;
+            len = 21 - bits;
         }
+
+        value <<= len;
+        value |= 1 << (len - 1);
+        oldValue = buffer[i];
+        bits += len;
+    }
+    if (bits != 21) {
+        return 0xffff;
     }
 
-    uint32_t csum = value;
+    static const uint32_t decode[32] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 10, 11, 0, 13, 14, 15,
+        0, 0, 2, 3, 0, 5, 6, 7, 0, 0, 8, 1, 0, 4, 12, 0 };
+
+    uint32_t decodedValue = decode[value & 0x1f];
+    decodedValue |= decode[(value >> 5) & 0x1f] << 4;
+    decodedValue |= decode[(value >> 10) & 0x1f] << 8;
+    decodedValue |= decode[(value >> 15) & 0x1f] << 12;
+
+    uint32_t csum = decodedValue;
     csum = csum ^ (csum >> 8); // xor bytes
     csum = csum ^ (csum >> 4); // xor nibbles
 
     if ((csum & 0xf) != 0xf) {
+        setDirectionMicros = micros() - start;
         return 0xffff;
     }
-    return value >> 4;
-}
+    decodedValue >>= 4;
 
-static uint16_t decodeProshotPacket(uint32_t buffer[])
-{
-    uint32_t value = 0;
-    for (int i = 1; i < PROSHOT_TELEMETRY_INPUT_LEN; i += 2) {
-        const int proshotModulo = MOTOR_NIBBLE_LENGTH_PROSHOT;
-        int diff = ((buffer[i] + proshotModulo - buffer[i-1]) % proshotModulo) - PROSHOT_BASE_SYMBOL;
-        int nibble;
-        if (diff < 0) {
-            nibble = 0;
-        } else {
-            nibble = (diff + PROSHOT_BIT_WIDTH / 2) / PROSHOT_BIT_WIDTH;
-        }
-        value <<= 4;
-        value |= (nibble & 0xf);
+    if (decodedValue == 0x0fff) {
+        setDirectionMicros = micros() - start;
+        return 0;
     }
-
-    uint32_t csum = value;
-    csum = csum ^ (csum >> 8); // xor bytes
-    csum = csum ^ (csum >> 4); // xor nibbles
-
-    if ((csum & 0xf) != 0xf) {
+    decodedValue = (decodedValue & 0x000001ff) << ((decodedValue & 0xfffffe00) >> 9);
+    if (!decodedValue) {
         return 0xffff;
     }
-    return value >> 4;
+    uint32_t ret = (1000000 * 60 / 100 + decodedValue / 2) / decodedValue;
+    setDirectionMicros = micros() - start;
+    return ret;
 }
-
 
 uint16_t getDshotTelemetry(uint8_t index)
 {
@@ -241,7 +251,7 @@ void updateDshotTelemetryQuality(dshotTelemetryQuality_t *qualityStats, bool pac
 }
 #endif // USE_DSHOT_TELEMETRY_STATS
 
-bool pwmStartDshotMotorUpdate(void)
+NOINLINE bool pwmStartDshotMotorUpdate(void)
 {
     if (!useDshotTelemetry) {
         return true;
@@ -249,56 +259,57 @@ bool pwmStartDshotMotorUpdate(void)
 #ifdef USE_DSHOT_TELEMETRY_STATS
     const timeMs_t currentTimeMs = millis();
 #endif
+    const timeUs_t currentUs = micros();
     for (int i = 0; i < dshotPwmDevice.count; i++) {
-        if (dmaMotors[i].hasTelemetry) {
+        timeDelta_t usSinceInput = cmpTimeUs(currentUs, inputStampUs);
+        if (usSinceInput >= 0 && usSinceInput < dmaMotors[i].dshotTelemetryDeadtimeUs) {
+            return false;
+        }
+        if (dmaMotors[i].isInput) {
 #ifdef USE_FULL_LL_DRIVER
-            uint32_t edges = xLL_EX_DMA_GetDataLength(dmaMotors[i].dmaRef);
+            uint32_t edges = GCR_TELEMETRY_INPUT_LEN - xLL_EX_DMA_GetDataLength(dmaMotors[i].dmaRef);
 #else
-            uint32_t edges = xDMA_GetCurrDataCounter(dmaMotors[i].dmaRef);
+            uint32_t edges = GCR_TELEMETRY_INPUT_LEN - xDMA_GetCurrDataCounter(dmaMotors[i].dmaRef);
 #endif
-            uint16_t value = 0xffff;
-            if (edges == 0) {
-                if (dmaMotors[i].useProshot) {
-                    value = decodeProshotPacket(dmaMotors[i].dmaBuffer);
-                } else {
-                    value = decodeDshotPacket(dmaMotors[i].dmaBuffer);
-                }
-            }
-#ifdef USE_DSHOT_TELEMETRY_STATS
-            bool validTelemetryPacket = false;
-#endif
-            if (value != 0xffff) {
-                dmaMotors[i].dshotTelemetryValue = value;
-                dmaMotors[i].dshotTelemetryActive = true;
-                if (i < 4) {
-                    DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, i, value);
-                }
-#ifdef USE_DSHOT_TELEMETRY_STATS
-                validTelemetryPacket = true;
-#endif
-            } else {
-                dshotInvalidPacketCount++;
-                if (i == 0) {
-                    memcpy(inputBuffer,dmaMotors[i].dmaBuffer,sizeof(inputBuffer));
-                }
-            }
-            dmaMotors[i].hasTelemetry = false;
-#ifdef USE_DSHOT_TELEMETRY_STATS
-            updateDshotTelemetryQuality(&dshotTelemetryQuality[i], validTelemetryPacket, currentTimeMs);
-#endif
-        } else {
-            timeDelta_t usSinceInput = cmpTimeUs(micros(), dmaMotors[i].timer->inputDirectionStampUs);
-            if (usSinceInput >= 0 && usSinceInput < dmaMotors[i].dshotTelemetryDeadtimeUs) {
-                return false;
-            }
+
 #ifdef USE_FULL_LL_DRIVER
             LL_EX_TIM_DisableIT(dmaMotors[i].timerHardware->tim, dmaMotors[i].timerDmaSource);
 #else
             TIM_DMACmd(dmaMotors[i].timerHardware->tim, dmaMotors[i].timerDmaSource, DISABLE);
 #endif
+
+            uint16_t value = 0xffff;
+
+            if (edges > MIN_GCR_EDGES) {
+                readDoneCount++;
+                value = decodeTelemetryPacket(dmaMotors[i].dmaBuffer, edges);
+                
+#ifdef USE_DSHOT_TELEMETRY_STATS
+                bool validTelemetryPacket = false;
+#endif
+                if (value != 0xffff) {
+                    dmaMotors[i].dshotTelemetryValue = value;
+                    dmaMotors[i].dshotTelemetryActive = true;
+                    if (i < 4) {
+                        DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, i, value);
+                    }
+#ifdef USE_DSHOT_TELEMETRY_STATS
+                    validTelemetryPacket = true;
+#endif
+                } else {
+                    dshotInvalidPacketCount++;
+                    if (i == 0) {
+                        memcpy(inputBuffer,dmaMotors[i].dmaBuffer,sizeof(inputBuffer));
+                    }
+                }
+#ifdef USE_DSHOT_TELEMETRY_STATS
+                updateDshotTelemetryQuality(&dshotTelemetryQuality[i], validTelemetryPacket, currentTimeMs);
+            }
+#endif
         }
         pwmDshotSetDirectionOutput(&dmaMotors[i], true);
     }
+    inputStampUs = 0;
     dshotEnableChannels(dshotPwmDevice.count);
     return true;
 }

--- a/src/main/drivers/pwm_output_dshot_shared.h
+++ b/src/main/drivers/pwm_output_dshot_shared.h
@@ -45,8 +45,9 @@ extern uint32_t readDoneCount;
 
 // TODO remove once debugging no longer needed
 FAST_RAM_ZERO_INIT extern uint32_t dshotInvalidPacketCount;
-FAST_RAM_ZERO_INIT extern uint32_t inputBuffer[DSHOT_TELEMETRY_INPUT_LEN];
+FAST_RAM_ZERO_INIT extern uint32_t inputBuffer[GCR_TELEMETRY_INPUT_LEN];
 FAST_RAM_ZERO_INIT extern uint32_t setDirectionMicros;
+FAST_RAM_ZERO_INIT extern uint32_t inputStampUs;
 #endif
 
 uint8_t getTimerIndex(TIM_TypeDef *timer);

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -31,10 +31,13 @@
 #ifdef  USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #include "drivers/buf_writer.h"
+#include "drivers/pwm_output.h"
+#include "drivers/dshot.h"
+#include "drivers/dshot_dpwm.h"
 #include "drivers/io.h"
 #include "drivers/serial.h"
+#include "drivers/time.h"
 #include "drivers/timer.h"
-#include "drivers/pwm_output.h"
 #include "drivers/light_led.h"
 
 #include "flight/mixer.h"
@@ -76,9 +79,9 @@
 // *** change to adapt Revision
 #define SERIAL_4WAY_VER_MAIN 20
 #define SERIAL_4WAY_VER_SUB_1 (uint8_t) 0
-#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 03
+#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 04
 
-#define SERIAL_4WAY_PROTOCOL_VER 107
+#define SERIAL_4WAY_PROTOCOL_VER 108
 // *** end
 
 #if (SERIAL_4WAY_VER_MAIN > 24)
@@ -139,7 +142,6 @@ uint8_t esc4wayInit(void)
     // StopPwmAllMotors();
     // XXX Review effect of motor refactor
     //pwmDisableMotors();
-    motorDisable();
     escCount = 0;
     memset(&escHardware, 0, sizeof(escHardware));
     pwmOutputPort_t *pwmMotors = pwmGetMotors();
@@ -153,6 +155,7 @@ uint8_t esc4wayInit(void)
             }
         }
     }
+    motorDisable();
     return escCount;
 }
 
@@ -566,9 +569,13 @@ void esc4wayProcess(serialPort_t *mspPort)
 
                 case cmd_DeviceReset:
                 {
+                    bool rebootEsc = false;
                     if (ParamBuf[0] < escCount) {
                         // Channel may change here
                         selected_esc = ParamBuf[0];
+                        if (ioMem.D_FLASH_ADDR_L == 1) {
+                            rebootEsc = true;
+                        }
                     }
                     else {
                         ACK_OUT = ACK_I_INVALID_CHANNEL;
@@ -582,6 +589,14 @@ void esc4wayProcess(serialPort_t *mspPort)
                         case imARM_BLB:
                         {
                             BL_SendCMDRunRestartBootloader(&DeviceInfo);
+                            if (rebootEsc) {
+                                ESC_OUTPUT;
+                                setEscLo(selected_esc);
+                                timeMs_t m = millis();
+                                while (millis() - m < 300);
+                                setEscHi(selected_esc);
+                                ESC_INPUT;
+                            }
                             break;
                         }
                         #endif


### PR DESCRIPTION
This PR adds support for a modified dshot bidir protocol which can be supported by blheli_s hw. The main changes are (a) erpm periods instead of frequencies are reported to avoid the need for a division on efm8bb2 hw and (b) a line protocol with lower resolution is used for the backchannel, allowing blheli_s hw to bitbang the protocol since no additional hw timers are available.

The type of protocol is auto-detected using the number of level changes in the packet.

Here's a flight demo of rpm filter running on a blheli_s esc: https://youtu.be/6XwTDUYOJfY