### PR TITLE
COLIBRI_RACE: BST GPS fix

### DIFF
--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -786,8 +786,8 @@ static void bstMasterWrite16(uint16_t data)
 #ifdef USE_GPS
 static void bstMasterWrite32(uint32_t data)
 {
-    bstMasterWrite16((uint8_t)(data >> 16));
-    bstMasterWrite16((uint8_t)(data >> 0));
+    bstMasterWrite16((uint16_t)(data >> 16));
+    bstMasterWrite16((uint16_t)(data >> 0));
 }
 
 static int32_t lat = 0;


### PR DESCRIPTION
Note: Clearly a (copy and paste) bug, but maybe an irrelevant fix for the public, because this only affects custom COLIBRI_RACE F3 target builds (GPS ON, other stuff off to fit memory). Maybe something for the maintenance branch?

3rd party GPS does now send correct long/lat coordinates to bst bus. FPVision OSD is now working correctly.
