### PR TITLE
Fix use of sdcard.cardDetectPin before it is initialised.

### DIFF
--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -75,8 +75,16 @@ void sdcardInsertionDetectDeinit(void)
     }
 }
 
-void sdcardInsertionDetectInit(void)
+void sdcardInsertionDetectInit(const sdcardConfig_t *config)
 {
+    if (config->cardDetectTag) {
+        sdcard.cardDetectPin = IOGetByTag(config->cardDetectTag);
+        sdcard.detectionInverted = config->cardDetectInverted;
+    } else {
+        sdcard.cardDetectPin = IO_NONE;
+        sdcard.detectionInverted = false;
+    }
+
     if (sdcard.cardDetectPin) {
         IOInit(sdcard.cardDetectPin, OWNER_SDCARD_DETECT, 0);
         IOConfigGPIO(sdcard.cardDetectPin, IOCFG_IPU);

--- a/src/main/drivers/sdcard.h
+++ b/src/main/drivers/sdcard.h
@@ -66,7 +66,7 @@ sdcardOperationStatus_e sdcard_beginWriteBlocks(uint32_t blockIndex, uint32_t bl
 sdcardOperationStatus_e sdcard_writeBlock(uint32_t blockIndex, uint8_t *buffer, sdcard_operationCompleteCallback_c callback, uint32_t callbackData);
 
 void sdcardInsertionDetectDeinit(void);
-void sdcardInsertionDetectInit(void);
+void sdcardInsertionDetectInit(const sdcardConfig_t *config);
 
 bool sdcard_isInserted(void);
 bool sdcard_isInitialized(void);

--- a/src/main/drivers/sdcard_impl.h
+++ b/src/main/drivers/sdcard_impl.h
@@ -107,7 +107,7 @@ extern sdcard_t sdcard;
 
 STATIC_ASSERT(sizeof(sdcardCSD_t) == 16, sdcard_csd_bitfields_didnt_pack_properly);
 
-void sdcardInsertionDetectInit(void);
+void sdcardInsertionDetectInit(const sdcardConfig_t *config);
 void sdcardInsertionDetectDeinit(void);
 bool sdcard_isInserted(void);
 

--- a/src/main/drivers/sdcard_sdio_baremetal.c
+++ b/src/main/drivers/sdcard_sdio_baremetal.c
@@ -217,14 +217,6 @@ static void sdcardSdio_init(const sdcardConfig_t *config, const spiPinConfig_t *
     }
 #endif
 #endif
-    if (config->cardDetectTag) {
-        sdcard.cardDetectPin = IOGetByTag(config->cardDetectTag);
-    } else {
-        sdcard.cardDetectPin = IO_NONE;
-    }
-    if (config->cardDetectInverted) {
-    	sdcard.detectionInverted = 1;
-    }
     if (sdioConfig()->useCache) {
         sdcard.useCache = 1;
     } else {

--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -542,14 +542,6 @@ static void sdcardSpi_init(const sdcardConfig_t *config, const spiPinConfig_t *s
     }
     sdcard.busdev.busdev_u.spi.csnPin = chipSelectIO;
 
-    if (config->cardDetectTag) {
-        sdcard.cardDetectPin = IOGetByTag(config->cardDetectTag);
-        sdcard.detectionInverted = config->cardDetectInverted;
-    } else {
-        sdcard.cardDetectPin = IO_NONE;
-        sdcard.detectionInverted = false;
-    }
-
     // Max frequency is initially 400kHz
 
 #ifdef USE_SPI_TRANSACTION

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -252,7 +252,7 @@ static void configureSPIAndQuadSPI(void)
 
 void sdCardAndFSInit()
 {
-    sdcardInsertionDetectInit();
+    sdcardInsertionDetectInit(sdcardConfig());
     sdcard_init(sdcardConfig());
     afatfs_init();
 }


### PR DESCRIPTION
* de-duplicate some SDIO/SPI sd-card detection code.
* ensure detectionInverted is set to false for SDIO case where
`cardDetectTag` is not configured.
