### PR TITLE
add launch configuration directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ mcu.mak
 mcu.mak.old
 stm32.mak
 
+# eclipse launch configurations
+/support/eclipse
+
 # artefacts for Visual Studio Code
 /.vscode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ stm32.mak
 # eclipse launch configurations
 /support/eclipse
 
+# ozone launch configurations
+/support/ozone
+
 # artefacts for Visual Studio Code
 /.vscode/
 


### PR DESCRIPTION
When developing BF using tools such as Eclipse and OZone, various user-files need to be created _within_ the project structure.  This presents an issue with git since as the files are marked as untracked and produce unnecessary noise when preparing commits, this noise can often lead to modified files not being included in a new commit.

This PR adds two commits that allow the user to store their eclipse and ozone launch configurations in `/support/eclipse` and `/support/ozone` respectively.