### PR TITLE
ff_boost

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1050,6 +1050,8 @@ const clivalue_t valueTable[] = {
 #ifdef USE_AIRMODE_LPF
     { "transient_throttle_limit",   VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },
 #endif
+    { "ff_boost",                   VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost) },
+    { "ff_boost_hz",                VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost_hz) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1050,8 +1050,8 @@ const clivalue_t valueTable[] = {
 #ifdef USE_AIRMODE_LPF
     { "transient_throttle_limit",   VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },
 #endif
-    { "ff_boost",                   VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost) },
-    { "ff_boost_hz",                VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost_hz) },
+    { "ff_boost",                   VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost) },
+    { "ff_boost_hz",                VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost_hz) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -205,7 +205,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
         .transient_throttle_limit = 15,
         .profileName = { 0 },
-        .ff_boost = 150,
+        .ff_boost = 15,
         .ff_boost_hz = 20,
     );
 #ifndef USE_D_MIN
@@ -303,8 +303,8 @@ static FAST_RAM_ZERO_INIT pt1Filter_t airmodeThrottleLpf2;
 
 static FAST_RAM_ZERO_INIT pt1Filter_t antiGravityThrottleLpf;
 
-static FAST_RAM_ZERO_INIT pt1Filter_t ff_lpf[XYZ_AXIS_COUNT];
-static FAST_RAM_ZERO_INIT float ff_boost_factor;
+static FAST_RAM_ZERO_INIT pt1Filter_t ffLpf[XYZ_AXIS_COUNT];
+static FAST_RAM_ZERO_INIT float ffBoostFactor;
 
 void pidInitFilters(const pidProfile_t *pidProfile)
 {
@@ -444,12 +444,12 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     pt1FilterInit(&antiGravityThrottleLpf, pt1FilterGain(ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF, dT));
 
     for (int axis = 0; axis < (XYZ_AXIS_COUNT - 1); axis++){
-        pt1FilterInit(&ff_lpf[axis], pt1FilterGain((float)pidProfile->ff_boost_hz, dT) );
+        pt1FilterInit(&ffLpf[axis], pt1FilterGain((float)pidProfile->ff_boost_hz, dT) );
     }
     if (pidProfile->ff_boost > 0 ){
-        ff_boost_factor = (float)pidProfile->ff_boost / 100.0f;
+        ffBoostFactor = (float)pidProfile->ff_boost / 10.0f;
     } else {
-        ff_boost_factor = 0;
+        ffBoostFactor = 0;
     }
 
 }
@@ -1431,9 +1431,9 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             // no transition if feedForwardTransition == 0
             float transition = feedForwardTransition > 0 ? MIN(1.f, getRcDeflectionAbs(axis) * feedForwardTransition) : 1;
             pidData[axis].F = feedforwardGain * transition * pidSetpointDelta * pidFrequency;
-            if (ff_boost_factor && (axis <= FD_PITCH)) {
-                const float F_hpf = pidData[axis].F - pt1FilterApply(&ff_lpf[axis], pidData[axis].F);
-                pidData[axis].F += F_hpf * ff_boost_factor;
+            if (ffBoostFactor && (axis <= FD_PITCH)) {
+                const float ffHpf = pidData[axis].F - pt1FilterApply(&ffLpf[axis], pidData[axis].F);
+                pidData[axis].F += ffHpf * ffBoostFactor;
             }
         } else {
             pidData[axis].F = 0;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -170,6 +170,8 @@ typedef struct pidProfile_s {
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
+    uint8_t ff_boost;                       // amount of high-pass filtered FF to add to FF, 100 means 100% added
+    uint16_t ff_boost_hz;                   // high-pass filter value for FF boost
     char profileName[MAX_PROFILE_NAME_LENGTH + 1]; // Descriptive name for profile
 } pidProfile_t;
 


### PR DESCRIPTION
Adds to the normal feedforward (FF) PID element, an additional high-passed  FF component.  Sort of like 'jerk' or 'acceleration' or second derivative of stick input.

It works a bit like throttle boost, resulting in a quicker rise in FF at the start of a move, an earlier pull-back to zero FF as the sticks slow down, and a a stronger drop, even a negative FF pulse, when the sticks stop moving entirely.  

These changes compensate for motor delays, improve tracking accuracy, and reduce overshoot.

Default boost amount of 15 adds significantly to FF at the start of a move.  10 means 'add 100% of the high-passed FF data to the normal FF values'.  Default of 15 means 'add 150% of the high-passed value'.  FF steps are smoothed by RC filtering/smoothing, so the typical amount of boost that actually added is not as much as that (see diagrams below).  15 is a good starting point for most quads.  Boost values above 20 may cause too much negative in the FF value when the sticks stop, but may be useful  when the motor lag is greater than normal.

The cutoff value of 20hz has a time constant of about 8ms, matching typical motor responsiveness delays.  For pilots who make slower inputs, or where the motor response time  is not as quick as a modern quad, the cutoff could be lowered to say 15 or even 10.

This is a bit like throttle boost, but for FF, hence the name.  

I think this will prove to be very useful and should default to on.  I didn't put it within defines since it uses little CPU and I think should be always on.  After testing confirms its usefulness, perhaps it could be removed from the profile, since for most users no tuning is required.  

More FF than usual can be applied without adding overshoot.  I would probably raise FF default from 70/75 to 100/110 with this.  When testing it out, please add about 50% more FF than your current tune.  

The coding can, I'm sure, be improved, as you know I'm not a great coder  :-)