### PR TITLE
we got moved from travis-ci.org to travis-ci.com awhile back

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Before starting to write code, please read our [development guidelines](docs/dev
 
 TravisCI is used to run automatic builds
 
-https://travis-ci.org/betaflight/betaflight
+https://travis-ci.com/betaflight/betaflight
 
-[![Build Status](https://travis-ci.org/betaflight/betaflight.svg?branch=master)](https://travis-ci.org/betaflight/betaflight)
+[![Build Status](https://travis-ci.com/betaflight/betaflight.svg?branch=master)](https://travis-ci.com/betaflight/betaflight)
 
 ## Betaflight Releases
 


### PR DESCRIPTION
![Betaflight logo](https://github.com/betaflight/betaflight/raw/master/docs/assets/images/bf_logo.png)
Flight: [![Build Status](https://travis-ci.com/betaflight/betaflight.svg?branch=master)](https://travis-ci.com/betaflight/betaflight) Configurator: [![Crowdin](https://d322cqt584bo4o.cloudfront.net/betaflight-configurator/localized.svg)](https://crowdin.com/project/betaflight-configurator) [![Build Status](https://travis-ci.com/betaflight/betaflight-configurator.svg?branch=master)](https://travis-ci.com/betaflight/betaflight-configurator)

---------------------------
After looking at a bunch of npm modules something like the above starts to seem like a good idea to submit. But don't worry, this PR just fixes the references to travis-ci down under `Development`