### PR TITLE
Set the filesystem timestamps of Blackbox files using the local timezone

### DIFF
--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -2636,6 +2636,7 @@ static void afatfs_createFileContinue(afatfsFile_t *file)
                 dateTime_t dt, local_dt;
                 rtcGetDateTime(&dt);
                 if (dt.year != 0) {
+                    // By tradition, FAT filesystem timestamps use local time.
                     dateTimeUTCToLocal(&dt, &local_dt);
                     fileDate = FAT_MAKE_DATE(local_dt.year, local_dt.month, local_dt.day);
                     fileTime = FAT_MAKE_TIME(local_dt.hours, local_dt.minutes, local_dt.seconds);

--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -2633,11 +2633,12 @@ static void afatfs_createFileContinue(afatfsFile_t *file)
                 #ifdef USE_RTC_TIME
                 // rtcGetDateTime will fill dt with 0000-01-01T00:00:00
                 // when time is not known.
-                dateTime_t dt;
+                dateTime_t dt, local_dt;
                 rtcGetDateTime(&dt);
                 if (dt.year != 0) {
-                    fileDate = FAT_MAKE_DATE(dt.year, dt.month, dt.day);
-                    fileTime = FAT_MAKE_TIME(dt.hours, dt.minutes, dt.seconds);
+                    dateTimeUTCToLocal(&dt, &local_dt);
+                    fileDate = FAT_MAKE_DATE(local_dt.year, local_dt.month, local_dt.day);
+                    fileTime = FAT_MAKE_TIME(local_dt.hours, local_dt.minutes, local_dt.seconds);
                 }
                 #endif
 


### PR DESCRIPTION
See issue #8539.  On aircraft that have a valid real-time clock,
"timezone_offset_minutes" can be set appropriately to record real times in the local
timezone.  It affects, for example, the real time displayed in the OSD and the log start
time recorded in Blackbox files.  This commit extends that functionality to the FAT
filesystem timestamps of Blackbox files.  According to Microsoft, FAT timestamps are
supposed to reflect the local time where the files were created or modified.  See, for example:

https://docs.microsoft.com/en-us/windows/win32/sysinfo/file-times

Both Windows and Mac OS adhere to the local timezone convention.  Linux does not; however, I
believe this is best viewed as a bug in Linux, since Microsoft owns the FAT filesystem.