### PR TITLE
Allow resorting to fake gyro if USE_FAKE_GYRO is defined

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -422,6 +422,8 @@ static bool gyroDetectSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t 
     if (!gyroFound) {
         return false;
     }
+#else
+    UNUSED(gyroFound);
 #endif
 #else
     UNUSED(config);
@@ -832,6 +834,12 @@ static bool isOnFirstGyroCalibrationCycle(const gyroCalibration_t *gyroCalibrati
 
 static void gyroSetCalibrationCycles(gyroSensor_t *gyroSensor)
 {
+#if defined(USE_FAKE_GYRO) && !defined(UNIT_TEST)
+    if (gyroSensor->gyroDev.gyroHardware == GYRO_FAKE) {
+        gyroSensor->calibration.cyclesRemaining = 0;
+        return;
+    }
+#endif
     gyroSensor->calibration.cyclesRemaining = gyroCalculateCalibratingCycles();
 }
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -416,9 +416,13 @@ static bool gyroDetectSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t 
 #if defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6500) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU6000) \
  || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20601) || defined(USE_GYRO_SPI_ICM20649) || defined(USE_GYRO_SPI_ICM20689) || defined(USE_GYRO_L3GD20)
 
-    if (!mpuDetect(&gyroSensor->gyroDev, config)) {
+    bool gyroFound = mpuDetect(&gyroSensor->gyroDev, config);
+
+#if !defined(USE_FAKE_GYRO) // Allow resorting to fake accgyro if defined
+    if (!gyroFound) {
         return false;
     }
+#endif
 #else
     UNUSED(config);
 #endif


### PR DESCRIPTION
Allow `gyroDetectSensor` to call `gyroDetect` even when no hardware gyro is found when `USE_FAKE_GYRO` is defined to resort to fake gyro.

Comes in handy when debugging actual targets with a bare dev board; don't have to disable all `USE_GYRO_xxx` line.