### PR TITLE
Unify DMA stream and channel handling

### DIFF
--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "drivers/adc.h"
+#include "drivers/dma.h"
 #include "drivers/io_types.h"
 #include "drivers/rcc_types.h"
 
@@ -63,11 +64,9 @@ typedef struct adcDevice_s {
     ADC_TypeDef* ADCx;
     rccPeriphTag_t rccADC;
 #if !defined(USE_DMA_SPEC)
+    dmaResource_t* dmaResource;
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    DMA_Stream_TypeDef* DMAy_Streamx;
     uint32_t channel;
-#else
-    DMA_Channel_TypeDef* DMAy_Channelx;
 #endif
 #endif // !defined(USE_DMA_SPEC)
 #if defined(STM32F7) || defined(STM32H7)

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -39,7 +39,7 @@
 
 
 const adcDevice_t adcHardware[] = {
-    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Channelx = DMA1_Channel1 }
+    { .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .dmaResource = (dmaResource_t *)DMA1_Channel1 }
 };
 
 const adcTagMap_t adcTagMap[] = {
@@ -115,9 +115,9 @@ void adcInit(const adcConfig_t *config)
     RCC_ADCCLKConfig(RCC_PCLK2_Div8);  // 9MHz from 72MHz APB2 clock(HSE), 8MHz from 64MHz (HSI)
     RCC_ClockCmd(adc.rccADC, ENABLE);
 
-    dmaInit(dmaGetIdentifier(adc.DMAy_Channelx), OWNER_ADC, 0);
+    dmaInit(dmaGetIdentifier(adc.dmaResource), OWNER_ADC, 0);
 
-    DMA_DeInit(adc.DMAy_Channelx);
+    xDMA_DeInit(adc.dmaResource);
     DMA_InitTypeDef DMA_InitStructure;
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&adc.ADCx->DR;
@@ -131,8 +131,8 @@ void adcInit(const adcConfig_t *config)
     DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;
     DMA_InitStructure.DMA_Priority = DMA_Priority_High;
     DMA_InitStructure.DMA_M2M = DMA_M2M_Disable;
-    DMA_Init(adc.DMAy_Channelx, &DMA_InitStructure);
-    DMA_Cmd(adc.DMAy_Channelx, ENABLE);
+    xDMA_Init(adc.dmaResource, &DMA_InitStructure);
+    xDMA_Cmd(adc.dmaResource, ENABLE);
 
     ADC_InitTypeDef ADC_InitStructure;
     ADC_StructInit(&ADC_InitStructure);

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -43,25 +43,25 @@
 const adcDevice_t adcHardware[] = {
     { .ADCx = ADC1, .rccADC = RCC_AHB(ADC12),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Channelx = DMA1_Channel1,
+        .dmaResource = (dmaResource_t *)DMA1_Channel1,
 #endif
     },
 #ifdef ADC24_DMA_REMAP
     { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Channelx = DMA2_Channel3,
+        .dmaResource = (dmaResource_t *)DMA2_Channel3,
 #endif
     },
 #else
     { .ADCx = ADC2, .rccADC = RCC_AHB(ADC12),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Channelx = DMA2_Channel1,
+        .dmaResource = (dmaResource_t *)DMA2_Channel1,
 #endif
     },
 #endif
     { .ADCx = ADC3, .rccADC = RCC_AHB(ADC34),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Channelx = DMA2_Channel5,
+        .dmaResource = (dmaResource_t *)DMA2_Channel5,
 #endif
     }
 };
@@ -184,9 +184,9 @@ void adcInit(const adcConfig_t *config)
 
     DMA_DeInit(dmaSpec->ref);
 #else
-    dmaInit(dmaGetIdentifier(adc.DMAy_Channelx), OWNER_ADC, 0);
+    dmaInit(dmaGetIdentifier(adc.dmaResource), OWNER_ADC, 0);
 
-    DMA_DeInit(adc.DMAy_Channelx);
+    xDMA_DeInit(adc.dmaResource);
 #endif
 
     DMA_StructInit(&DMA_InitStructure);
@@ -203,11 +203,11 @@ void adcInit(const adcConfig_t *config)
     DMA_InitStructure.DMA_M2M = DMA_M2M_Disable;
 
 #if defined(USE_DMA_SPEC)
-    DMA_Init(dmaSpec->ref, &DMA_InitStructure);
-    DMA_Cmd(dmaSpec->ref, ENABLE);
+    xDMA_Init(dmaSpec->ref, &DMA_InitStructure);
+    xDMA_Cmd(dmaSpec->ref, ENABLE);
 #else
-    DMA_Init(adc.DMAy_Channelx, &DMA_InitStructure);
-    DMA_Cmd(adc.DMAy_Channelx, ENABLE);
+    xDMA_Init(adc.dmaResource, &DMA_InitStructure);
+    xDMA_Cmd(adc.dmaResource, ENABLE);
 #endif
 
     // calibrate

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -52,7 +52,7 @@ const adcDevice_t adcHardware[] = {
         .ADCx = ADC1,
         .rccADC = RCC_APB2(ADC1),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC1_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC1_DMA_STREAM,
         .channel = DMA_Channel_0
 #endif
     },
@@ -61,7 +61,7 @@ const adcDevice_t adcHardware[] = {
         .ADCx = ADC2,
         .rccADC = RCC_APB2(ADC2),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC2_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC2_DMA_STREAM,
         .channel = DMA_Channel_1
 #endif
     },
@@ -69,7 +69,7 @@ const adcDevice_t adcHardware[] = {
         .ADCx = ADC3,
         .rccADC = RCC_APB2(ADC3),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC3_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC3_DMA_STREAM,
         .channel = DMA_Channel_2
 #endif
     }
@@ -310,11 +310,11 @@ void adcInit(const adcConfig_t *config)
 
     dmaInit(dmaGetIdentifier(dmaSpec->ref), OWNER_ADC, RESOURCE_INDEX(device));
 
-    DMA_DeInit(dmaSpec->ref);
+    xDMA_DeInit(dmaSpec->ref);
 #else
-    dmaInit(dmaGetIdentifier(adc.DMAy_Streamx), OWNER_ADC, 0);
+    dmaInit(dmaGetIdentifier(adc.dmaResource), OWNER_ADC, 0);
 
-    DMA_DeInit(adc.DMAy_Streamx);
+    xDMA_DeInit(adc.dmaResource);
 #endif
 
     DMA_InitTypeDef DMA_InitStructure;
@@ -339,11 +339,11 @@ void adcInit(const adcConfig_t *config)
     DMA_InitStructure.DMA_Priority = DMA_Priority_High;
 
 #ifdef USE_DMA_SPEC
-    DMA_Init(dmaSpec->ref, &DMA_InitStructure);
-    DMA_Cmd(dmaSpec->ref, ENABLE);
+    xDMA_Init(dmaSpec->ref, &DMA_InitStructure);
+    xDMA_Cmd(dmaSpec->ref, ENABLE);
 #else
-    DMA_Init(adc.DMAy_Streamx, &DMA_InitStructure);
-    DMA_Cmd(adc.DMAy_Streamx, ENABLE);
+    xDMA_Init(adc.dmaResource, &DMA_InitStructure);
+    xDMA_Cmd(adc.dmaResource, ENABLE);
 #endif
 
     ADC_SoftwareStartConv(adc.ADCx);

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -63,7 +63,7 @@ const adcDevice_t adcHardware[] = {
         .ADCx = ADC1,
         .rccADC = RCC_APB2(ADC1),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC1_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC1_DMA_STREAM,
         .channel = DMA_CHANNEL_0
 #endif
     },
@@ -71,7 +71,7 @@ const adcDevice_t adcHardware[] = {
         .ADCx = ADC2,
         .rccADC = RCC_APB2(ADC2),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC2_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC2_DMA_STREAM,
         .channel = DMA_CHANNEL_1
 #endif
     },
@@ -79,7 +79,7 @@ const adcDevice_t adcHardware[] = {
         .ADCx = ADC3,
         .rccADC = RCC_APB2(ADC3),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC3_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC3_DMA_STREAM,
         .channel = DMA_CHANNEL_2
 #endif
     }
@@ -314,11 +314,11 @@ void adcInit(const adcConfig_t *config)
 
     dmaInit(dmaGetIdentifier(dmaspec->ref), OWNER_ADC, 0);
     adc.DmaHandle.Init.Channel = dmaspec->channel;
-    adc.DmaHandle.Instance = dmaspec->ref;
+    adc.DmaHandle.Instance = (DMA_ARCH_TYPE *)dmaspec->ref;
 #else
-    dmaInit(dmaGetIdentifier(adc.DMAy_Streamx), OWNER_ADC, 0);
+    dmaInit(dmaGetIdentifier(adc.dmaResource), OWNER_ADC, 0);
     adc.DmaHandle.Init.Channel = adc.channel;
-    adc.DmaHandle.Instance = adc.DMAy_Streamx;
+    adc.DmaHandle.Instance = (DMA_ARCH_TYPE *)adc.dmaResource;
 #endif
 
     adc.DmaHandle.Init.Direction = DMA_PERIPH_TO_MEMORY;

--- a/src/main/drivers/adc_stm32h7xx.c
+++ b/src/main/drivers/adc_stm32h7xx.c
@@ -68,14 +68,14 @@ const adcDevice_t adcHardware[ADCDEV_COUNT] = {
         .ADCx = ADC1_INSTANCE,
         .rccADC = RCC_AHB1(ADC12),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC1_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC1_DMA_STREAM,
         .channel = DMA_REQUEST_ADC1,
 #endif
     },
     { .ADCx = ADC2_INSTANCE,
         .rccADC = RCC_AHB1(ADC12),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC2_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC2_DMA_STREAM,
         .channel = DMA_REQUEST_ADC2,
 #endif
     },
@@ -84,7 +84,7 @@ const adcDevice_t adcHardware[ADCDEV_COUNT] = {
         .ADCx = ADC3_INSTANCE,
         .rccADC = RCC_AHB4(ADC3),
 #if !defined(USE_DMA_SPEC)
-        .DMAy_Streamx = ADC3_DMA_STREAM,
+        .dmaResource = (dmaResource_t *)ADC3_DMA_STREAM,
         .channel = DMA_REQUEST_ADC3,
 #endif
     }
@@ -283,7 +283,7 @@ void adcInit(const adcConfig_t *config)
             for (dev = 0; dev < ADCDEV_COUNT; dev++) {
                 if (!adcDevice[dev].ADCx 
 #ifndef USE_DMA_SPEC
-                     || !adcDevice[dev].DMAy_Streamx
+                     || !adcDevice[dev].dmaResource
 #endif
                    ) {
                     // Instance not activated
@@ -388,8 +388,8 @@ void adcInit(const adcConfig_t *config)
         adc->DmaHandle.Init.Request             = dmaSpec->channel;
         dmaIdentifier = dmaGetIdentifier(dmaSpec->ref);
 #else
-        dmaIdentifier = dmaGetIdentifier(adc->DMAy_Streamx);
-        adc->DmaHandle.Instance                 = adc->DMAy_Streamx;
+        dmaIdentifier = dmaGetIdentifier(adc->dmaResource);
+        adc->DmaHandle.Instance                 = (DMA_ARCH_TYPE *)adc->dmaResource;
         adc->DmaHandle.Init.Request             = adc->channel;
 #endif
         adc->DmaHandle.Init.Direction           = DMA_PERIPH_TO_MEMORY;

--- a/src/main/drivers/dma.c
+++ b/src/main/drivers/dma.c
@@ -70,20 +70,20 @@ DEFINE_DMA_IRQ_HANDLER(2, 5, DMA2_CH5_HANDLER)
 
 #define RETURN_TCIF_FLAG(s, d, n) if (s == DMA ## d ## _Channel ## n) return DMA ## d ## _FLAG_TC ## n
 
-uint32_t dmaFlag_IT_TCIF(const DMA_Channel_TypeDef *channel)
+uint32_t dmaFlag_IT_TCIF(const dmaResource_t *channel)
 {
-    RETURN_TCIF_FLAG(channel, 1, 1);
-    RETURN_TCIF_FLAG(channel, 1, 2);
-    RETURN_TCIF_FLAG(channel, 1, 3);
-    RETURN_TCIF_FLAG(channel, 1, 4);
-    RETURN_TCIF_FLAG(channel, 1, 5);
-    RETURN_TCIF_FLAG(channel, 1, 6);
-    RETURN_TCIF_FLAG(channel, 1, 7);
-    RETURN_TCIF_FLAG(channel, 2, 1);
-    RETURN_TCIF_FLAG(channel, 2, 2);
-    RETURN_TCIF_FLAG(channel, 2, 3);
-    RETURN_TCIF_FLAG(channel, 2, 4);
-    RETURN_TCIF_FLAG(channel, 2, 5);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 1);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 2);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 3);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 4);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 5);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 6);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 1, 7);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 2, 1);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 2, 2);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 2, 3);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 2, 4);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)channel, 2, 5);
     return 0;
 }
 
@@ -125,7 +125,7 @@ uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
-dmaIdentifier_e dmaGetIdentifier(const DMA_Channel_TypeDef* channel)
+dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* channel)
 {
     for (int i = 0; i < DMA_LAST_HANDLER; i++) {
         if (dmaDescriptors[i].ref == channel) {
@@ -135,7 +135,7 @@ dmaIdentifier_e dmaGetIdentifier(const DMA_Channel_TypeDef* channel)
     return 0;
 }
 
-DMA_Channel_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
+dmaResource_t *dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
 {
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -22,16 +22,31 @@
 
 #include "resource.h"
 
+// dmaResource_t is a opaque data type which represents a single DMA engine,
+// called and implemented differently in different families of STM32s.
+// The opaque data type provides uniform handling of the engine in source code.
+// The engines are referenced by dmaResource_t through out the Betaflight code,
+// and then converted back to DMA_ARCH_TYPE which is a native type for
+// the particular MCU type when calling library functions.
+
+typedef struct dmaResource_s dmaResource_t;
+
+#if defined(STM32F4) || defined(STM32F7)
+#define DMA_ARCH_TYPE DMA_Stream_TypeDef
+#elif defined(STM32H7)
+#define DMA_ARCH_TYPE void
+#else
+#define DMA_ARCH_TYPE DMA_Channel_TypeDef
+#endif
+
 struct dmaChannelDescriptor_s;
 typedef void (*dmaCallbackHandlerFuncPtr)(struct dmaChannelDescriptor_s *channelDescriptor);
 
 typedef struct dmaChannelDescriptor_s {
     DMA_TypeDef*                dma;
+    dmaResource_t               *ref;
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    DMA_Stream_TypeDef*         ref;
     uint8_t                     stream;
-#else
-    DMA_Channel_TypeDef*        ref;
 #endif
     dmaCallbackHandlerFuncPtr   irqHandlerCallback;
     uint8_t                     flagsShift;
@@ -81,7 +96,7 @@ typedef enum {
 
 #define DEFINE_DMA_CHANNEL(d, s, f) { \
     .dma = d, \
-    .ref = d ## _Stream ## s, \
+    .ref = (dmaResource_t *)d ## _Stream ## s, \
     .stream = s, \
     .irqHandlerCallback = NULL, \
     .flagsShift = f, \
@@ -107,9 +122,9 @@ typedef enum {
 #define DMA_IT_DMEIF        ((uint32_t)0x00000004)
 #define DMA_IT_FEIF         ((uint32_t)0x00000001)
 
-dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream);
-dmaChannelDescriptor_t* dmaGetDmaDescriptor(const DMA_Stream_TypeDef* stream);
-DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier);
+dmaIdentifier_e dmaGetIdentifier(const dmaResource_t *stream);
+dmaChannelDescriptor_t* dmaGetDmaDescriptor(const dmaResource_t *stream);
+dmaResource_t *dmaGetRefByIdentifier(const dmaIdentifier_e identifier);
 uint32_t dmaGetChannel(const uint8_t channel);
 
 #else
@@ -143,7 +158,7 @@ typedef enum {
 
 #define DEFINE_DMA_CHANNEL(d, c, f) { \
     .dma = d, \
-    .ref = d ## _Channel ## c, \
+    .ref = (dmaResource_t *)d ## _Channel ## c, \
     .irqHandlerCallback = NULL, \
     .flagsShift = f, \
     .irqN = d ## _Channel ## c ## _IRQn, \
@@ -165,9 +180,33 @@ typedef enum {
 #define DMA_IT_HTIF         ((uint32_t)0x00000004)
 #define DMA_IT_TEIF         ((uint32_t)0x00000008)
 
-dmaIdentifier_e dmaGetIdentifier(const DMA_Channel_TypeDef* channel);
-DMA_Channel_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier);
+dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* channel);
+dmaResource_t* dmaGetRefByIdentifier(const dmaIdentifier_e identifier);
 
+#endif
+
+// Macros to avoid direct register and register bit access
+
+#if defined(STM32F4) || defined(STM32F7)
+#define IS_DMA_ENABLED(reg) (((DMA_ARCH_TYPE *)(reg))->CR & DMA_SxCR_EN)
+#define REG_NDTR NDTR
+#elif defined(STM32H7)
+// For H7, we have to differenciate DMA1/2 and BDMA for access to the control register.
+// HAL library has a macro for this, but it is extremely inefficient in that it compares
+// the address against all possible values.
+// Here, we just compare the address against regions of memory.
+// If it's not in D3 peripheral area, then it's DMA1/2 and it's stream based.
+// If not, it's BDMA and it's channel based.
+#define IS_DMA_ENABLED(reg) \
+    ((uint32_t)(reg) < D3_AHB1PERIPH_BASE) ? \
+        (((DMA_Stream_TypeDef *)(reg))->CR & DMA_SxCR_EN) : \
+        (((BDMA_Channel_TypeDef *)(reg))->CCR & BDMA_CCR_EN)
+#else
+#if defined(STM32F1)
+#define DMA_CCR_EN 1 // Not defined anywhere ...
+#endif
+#define IS_DMA_ENABLED(reg) (((DMA_ARCH_TYPE *)(reg))->CCR & DMA_CCR_EN)
+#define DMAx_SetMemoryAddress(reg, address) ((DMA_ARCH_TYPE *)(reg))->CMAR = (uint32_t)&s->port.txBuffer[s->port.txBufferTail]
 #endif
 
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);
@@ -176,3 +215,33 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
 resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier);
 uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier);
 dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier);
+
+//
+// Wrapper macros to cast dmaResource_t back into DMA_ARCH_TYPE
+//
+
+#ifdef USE_HAL_DRIVER
+
+// We actually need these LL case only
+
+#define xLL_EX_DMA_DeInit(dmaResource) LL_EX_DMA_DeInit((DMA_ARCH_TYPE *)(dmaResource))
+#define xLL_EX_DMA_Init(dmaResource, initstruct) LL_EX_DMA_Init((DMA_ARCH_TYPE *)(dmaResource), initstruct)
+#define xLL_EX_DMA_DisableStream(dmaResource) LL_EX_DMA_DisableStream((DMA_ARCH_TYPE *)(dmaResource))
+#define xLL_EX_DMA_EnableStream(dmaResource) LL_EX_DMA_EnableStream((DMA_ARCH_TYPE *)(dmaResource))
+#define xLL_EX_DMA_GetDataLength(dmaResource) LL_EX_DMA_GetDataLength((DMA_ARCH_TYPE *)(dmaResource))
+#define xLL_EX_DMA_SetDataLength(dmaResource, length) LL_EX_DMA_SetDataLength((DMA_ARCH_TYPE *)(dmaResource), length)
+#define xLL_EX_DMA_EnableIT_TC(dmaResource) LL_EX_DMA_EnableIT_TC((DMA_ARCH_TYPE *)(dmaResource))
+
+#else
+
+#define xDMA_Init(dmaResource, initStruct) DMA_Init((DMA_ARCH_TYPE *)(dmaResource), initStruct)
+#define xDMA_DeInit(dmaResource) DMA_DeInit((DMA_ARCH_TYPE *)(dmaResource))
+#define xDMA_Cmd(dmaResource, newState) DMA_Cmd((DMA_ARCH_TYPE *)(dmaResource), newState)
+#define xDMA_ITConfig(dmaResource, flags, newState) DMA_ITConfig((DMA_ARCH_TYPE *)(dmaResource), flags, newState)
+#define xDMA_GetCurrDataCounter(dmaResource) DMA_GetCurrDataCounter((DMA_ARCH_TYPE *)(dmaResource))
+#define xDMA_SetCurrDataCounter(dmaResource, count) DMA_SetCurrDataCounter((DMA_ARCH_TYPE *)(dmaResource), count)
+#define xDMA_GetFlagStatus(dmaResource, flags) DMA_GetFlagStatus((DMA_ARCH_TYPE *)(dmaResource), flags)
+#define xDMA_ClearFlag(dmaResource, flags) DMA_ClearFlag((DMA_ARCH_TYPE *)(dmaResource), flags)
+#define xDMA_MemoryTargetConfig(dmaResource, address, target) DMA_MemoryTargetConfig((DMA_ARCH_TYPE *)(dmaResource), address, target)
+
+#endif

--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -169,7 +169,7 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
 #undef TC
 #undef REQMAP_TIM
 
-#define DMA(d, s) { DMA_CODE(d, s, 0), DMA ## d ## _Stream ## s, 0 }
+#define DMA(d, s) { DMA_CODE(d, s, 0), (dmaResource_t *)DMA ## d ## _Stream ## s, 0 }
 
 static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
     DMA(1, 0),
@@ -195,9 +195,9 @@ static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
 #elif defined(STM32F4) || defined(STM32F7)
 
 #if defined(STM32F4)
-#define DMA(d, s, c) { DMA_CODE(d, s, c), DMA ## d ## _Stream ## s, DMA_Channel_ ## c }
+#define DMA(d, s, c) { DMA_CODE(d, s, c), (dmaResource_t *)DMA ## d ## _Stream ## s, DMA_Channel_ ## c }
 #elif defined(STM32F7)
-#define DMA(d, s, c) { DMA_CODE(d, s, c), DMA ## d ## _Stream ## s, DMA_CHANNEL_ ## c }
+#define DMA(d, s, c) { DMA_CODE(d, s, c), (dmaResource_t *)DMA ## d ## _Stream ## s, DMA_CHANNEL_ ## c }
 #endif
 
 static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
@@ -291,7 +291,7 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
 #else // STM32F3
     // The embedded ADC24_DMA_REMAP conditional should be removed
     // when (and if) F3 is going generic.
-#define DMA(d, c) { DMA_CODE(d, 0, c), DMA ## d ## _Channel ## c }
+#define DMA(d, c) { DMA_CODE(d, 0, c), (dmaResource_t *)DMA ## d ## _Channel ## c }
 static const dmaPeripheralMapping_t dmaPeripheralMapping[17] = {
 #ifdef USE_SPI
     { DMA_PERIPH_SPI_TX,  1, { DMA(1, 3) } },

--- a/src/main/drivers/dma_reqmap.h
+++ b/src/main/drivers/dma_reqmap.h
@@ -22,17 +22,16 @@
 
 #include "platform.h"
 
+#include "drivers/dma.h"
 #include "drivers/timer.h"
 
 typedef uint16_t dmaCode_t;
 
 typedef struct dmaChannelSpec_s {
     dmaCode_t             code;
+    dmaResource_t         *ref;
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    DMA_Stream_TypeDef    *ref;
     uint32_t              channel;
-#else
-    DMA_Channel_TypeDef   *ref;
 #endif
 } dmaChannelSpec_t;
 

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -84,16 +84,16 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
 
 #define RETURN_TCIF_FLAG(s, n) if (s == DMA1_Stream ## n || s == DMA2_Stream ## n) return DMA_IT_TCIF ## n
 
-uint32_t dmaFlag_IT_TCIF(const DMA_Stream_TypeDef *stream)
+uint32_t dmaFlag_IT_TCIF(const dmaResource_t *stream)
 {
-    RETURN_TCIF_FLAG(stream, 0);
-    RETURN_TCIF_FLAG(stream, 1);
-    RETURN_TCIF_FLAG(stream, 2);
-    RETURN_TCIF_FLAG(stream, 3);
-    RETURN_TCIF_FLAG(stream, 4);
-    RETURN_TCIF_FLAG(stream, 5);
-    RETURN_TCIF_FLAG(stream, 6);
-    RETURN_TCIF_FLAG(stream, 7);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 0);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 1);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 2);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 3);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 4);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 5);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 6);
+    RETURN_TCIF_FLAG((DMA_ARCH_TYPE *)stream, 7);
     return 0;
 }
 
@@ -125,27 +125,27 @@ uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
-dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
+dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* instance)
 {
     for (int i = 0; i < DMA_LAST_HANDLER; i++) {
-        if (dmaDescriptors[i].ref == stream) {
+        if (dmaDescriptors[i].ref == instance) {
             return i + 1;
         }
     }
     return 0;
 }
 
-dmaChannelDescriptor_t* dmaGetDescriptor(const DMA_Stream_TypeDef* stream)
+dmaChannelDescriptor_t* dmaGetDescriptor(const dmaResource_t* instance)
 {
     for (int i = 0; i < DMA_LAST_HANDLER; i++) {
-        if (dmaDescriptors[i].ref == stream) {
+        if (dmaDescriptors[i].ref == instance) {
             return &dmaDescriptors[i];
         }
     }
     return NULL;
 }
 
-DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
+dmaResource_t* dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
 {
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -117,7 +117,7 @@ uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
-dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
+dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* stream)
 {
     for (int i = 0; i < DMA_LAST_HANDLER; i++) {
         if (dmaDescriptors[i].ref == stream) {
@@ -127,7 +127,7 @@ dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
     return 0;
 }
 
-DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
+dmaResource_t *dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
 {
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }

--- a/src/main/drivers/dma_stm32h7xx.c
+++ b/src/main/drivers/dma_stm32h7xx.c
@@ -121,7 +121,7 @@ uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
-dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
+dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* stream)
 {
     for (int i = 0; i < DMA_LAST_HANDLER; i++) {
         if (dmaDescriptors[i].ref == stream) {
@@ -131,7 +131,7 @@ dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream)
     return 0;
 }
 
-DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
+dmaResource_t* dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
 {
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }

--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -93,11 +93,7 @@ typedef struct {
     TIM_HandleTypeDef timHandle;
     DMA_HandleTypeDef hdma_tim;
 #endif
-#ifdef STM32F3
-    DMA_Channel_TypeDef *dmaBurstRef;
-#else
-    DMA_Stream_TypeDef *dmaBurstRef;
-#endif
+    dmaResource_t *dmaBurstRef;
     uint16_t dmaBurstLength;
     uint32_t *dmaBurstBuffer;
     timeUs_t inputDirectionStampUs;
@@ -138,11 +134,7 @@ typedef struct motorDmaOutput_s {
 #endif
     uint8_t dmaInputLen;
 #endif
-#ifdef STM32F3
-    DMA_Channel_TypeDef *dmaRef;
-#else
-    DMA_Stream_TypeDef *dmaRef;
-#endif
+    dmaResource_t *dmaRef;
 #endif
     motorDmaTimer_t *timer;
     DSHOT_DMA_BUFFER_UNIT *dmaBuffer;

--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -59,8 +59,10 @@ motorDevice_t *dshotPwmDevInit(const struct motorDevConfig_s *motorConfig, uint1
 #define PROSHOT_TELEMETRY_INPUT_LEN 8
 
 // For H7, DMA buffer is placed in a dedicated segment for coherency management
-#ifdef STM32H7
+#if defined(STM32H7)
 #define DSHOT_DMA_BUFFER_ATTRIBUTE DMA_RAM
+#elif defined(STM32F7)
+#define DSHOT_DMA_BUFFER_ATTRIBUTE FAST_RAM_ZERO_INIT
 #else
 #define DSHOT_DMA_BUFFER_ATTRIBUTE // None
 #endif

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -66,6 +66,8 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_TypeDef *timer = timerHardware->tim;
     timerChannel = timerHardware->channel;
 
+    dmaResource_t *dmaRef;
+
 #if defined(USE_DMA_SPEC)
     const dmaChannelSpec_t *dmaSpec = dmaGetChannelSpecByTimer(timerHardware);
 
@@ -73,10 +75,10 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
         return false;
     }
 
-    dmaStream_t *dmaRef = dmaSpec->ref;
+    dmaRef = dmaSpec->ref;
     uint32_t dmaChannel = dmaSpec->channel;
 #else
-    dmaStream_t *dmaRef = timerHardware->dmaRef;
+    dmaRef = timerHardware->dmaRef;
     uint32_t dmaChannel = timerHardware->dmaChannel;
 #endif
 
@@ -129,7 +131,7 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     hdma_tim.Init.PeriphBurst = DMA_PBURST_SINGLE;
 
     /* Set hdma_tim instance */
-    hdma_tim.Instance = dmaRef;
+    hdma_tim.Instance = (DMA_ARCH_TYPE *)dmaRef;
 
     uint16_t dmaIndex = timerDmaIndex(timerChannel);
 

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -40,10 +40,8 @@
 #include "light_ws2811strip.h"
 
 static IO_t ws2811IO = IO_NONE;
-#if defined(STM32F4)
-static DMA_Stream_TypeDef *dmaRef = NULL;
-#elif defined(STM32F3) || defined(STM32F1)
-static DMA_Channel_TypeDef *dmaRef = NULL;
+#if defined(STM32F4) || defined(STM32F3) || defined(STM32F1)
+static dmaResource_t *dmaRef = NULL;
 #else
 #error "No MCU definition in light_ws2811strip_stdperiph.c"
 #endif
@@ -64,11 +62,11 @@ static void WS2811_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
         } else if (counter == (WS2811_LED_STRIP_LENGTH + WS2811_DELAY_ITERATIONS)) {
             counter = 0;
             ws2811LedDataTransferInProgress = false;
-            DMA_Cmd(descriptor->ref, DISABLE);
+            xDMA_Cmd(descriptor->ref, DISABLE);
         }
 #else
         ws2811LedDataTransferInProgress = false;
-        DMA_Cmd(descriptor->ref, DISABLE);
+        xDMA_Cmd(descriptor->ref, DISABLE);
 #endif
 
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
@@ -176,11 +174,11 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     dmaInit(dmaGetIdentifier(dmaRef), OWNER_LED_STRIP, 0);
     dmaSetHandler(dmaGetIdentifier(dmaRef), WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, 0);
 
-    DMA_DeInit(dmaRef);
+    xDMA_DeInit(dmaRef);
 
     /* configure DMA */
-    DMA_Cmd(dmaRef, DISABLE);
-    DMA_DeInit(dmaRef);
+    xDMA_Cmd(dmaRef, DISABLE);
+    xDMA_DeInit(dmaRef);
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)timerCCR(timer, timerHardware->channel);
     DMA_InitStructure.DMA_BufferSize = WS2811_DMA_BUFFER_SIZE;
@@ -209,18 +207,18 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     DMA_InitStructure.DMA_Mode = DMA_Mode_Normal;
 #endif
 
-    DMA_Init(dmaRef, &DMA_InitStructure);
+    xDMA_Init(dmaRef, &DMA_InitStructure);
     TIM_DMACmd(timer, timerDmaSource(timerHardware->channel), ENABLE);
-    DMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
+    xDMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
 
     return true;
 }
 
 void ws2811LedStripDMAEnable(void)
 {
-    DMA_SetCurrDataCounter(dmaRef, WS2811_DMA_BUFFER_SIZE);  // load number of bytes to be transferred
+    xDMA_SetCurrDataCounter(dmaRef, WS2811_DMA_BUFFER_SIZE);  // load number of bytes to be transferred
     TIM_SetCounter(timer, 0);
     TIM_Cmd(timer, ENABLE);
-    DMA_Cmd(dmaRef, ENABLE);
+    xDMA_Cmd(dmaRef, ENABLE);
 }
 #endif

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -24,6 +24,7 @@
 
 #include "common/time.h"
 
+#include "drivers/dma.h"
 #include "drivers/io_types.h"
 #include "drivers/motor.h"
 #include "drivers/timer.h"

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -53,7 +53,7 @@
 static void processInputIrq(motorDmaOutput_t * const motor)
 {
     motor->hasTelemetry = true;
-    DMA_Cmd(motor->dmaRef, DISABLE);
+    xDMA_Cmd(motor->dmaRef, DISABLE);
     TIM_DMACmd(motor->timerHardware->tim, motor->timerDmaSource, DISABLE);
     readDoneCount++;
 }
@@ -88,7 +88,7 @@ FAST_CODE void pwmDshotSetDirectionOutput(
     const timerHardware_t * const timerHardware = motor->timerHardware;
     TIM_TypeDef *timer = timerHardware->tim;
 
-    dmaStream_t *dmaRef = motor->dmaRef;
+    dmaResource_t *dmaRef = motor->dmaRef;
 
 #if defined(USE_DSHOT_DMAR) && !defined(USE_DSHOT_TELEMETRY)
     if (useBurstDshot) {
@@ -96,7 +96,7 @@ FAST_CODE void pwmDshotSetDirectionOutput(
     }
 #endif
 
-    DMA_DeInit(dmaRef);
+    xDMA_DeInit(dmaRef);
 
 #ifdef USE_DSHOT_TELEMETRY
     if (!output) {
@@ -141,8 +141,8 @@ FAST_CODE void pwmDshotSetDirectionOutput(
         }
     }
 
-    DMA_Init(dmaRef, pDmaInit);
-    DMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
+    xDMA_Init(dmaRef, pDmaInit);
+    xDMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
 }
 
 
@@ -158,8 +158,8 @@ void pwmCompleteDshotMotorUpdate(void)
     for (int i = 0; i < dmaMotorTimerCount; i++) {
 #ifdef USE_DSHOT_DMAR
         if (useBurstDshot) {
-            DMA_SetCurrDataCounter(dmaMotorTimers[i].dmaBurstRef, dmaMotorTimers[i].dmaBurstLength);
-            DMA_Cmd(dmaMotorTimers[i].dmaBurstRef, ENABLE);
+            xDMA_SetCurrDataCounter(dmaMotorTimers[i].dmaBurstRef, dmaMotorTimers[i].dmaBurstLength);
+            xDMA_Cmd(dmaMotorTimers[i].dmaBurstRef, ENABLE);
             TIM_DMAConfig(dmaMotorTimers[i].timer, TIM_DMABase_CCR1, TIM_DMABurstLength_4Transfers);
             TIM_DMACmd(dmaMotorTimers[i].timer, TIM_DMA_Update, ENABLE);
         } else
@@ -185,20 +185,20 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
         {
 #ifdef USE_DSHOT_DMAR
             if (useBurstDshot) {
-                DMA_Cmd(motor->timerHardware->dmaTimUPRef, DISABLE);
+                xDMA_Cmd(motor->timerHardware->dmaTimUPRef, DISABLE);
                 TIM_DMACmd(motor->timerHardware->tim, TIM_DMA_Update, DISABLE);
             } else
 #endif
             {
-                DMA_Cmd(motor->dmaRef, DISABLE);
+                xDMA_Cmd(motor->dmaRef, DISABLE);
                 TIM_DMACmd(motor->timerHardware->tim, motor->timerDmaSource, DISABLE);
             }
 
 #ifdef USE_DSHOT_TELEMETRY
             if (useDshotTelemetry) {
                 pwmDshotSetDirectionOutput(motor, false);
-                DMA_SetCurrDataCounter(motor->dmaRef, motor->dmaInputLen);
-                DMA_Cmd(motor->dmaRef, ENABLE);
+                xDMA_SetCurrDataCounter(motor->dmaRef, motor->dmaInputLen);
+                xDMA_Cmd(motor->dmaRef, ENABLE);
                 TIM_DMACmd(motor->timerHardware->tim, motor->timerDmaSource, ENABLE);
                 setDirectionMicros = micros() - irqStart;
             }
@@ -220,7 +220,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #define DMAINIT dmaInitStruct
 #endif
 
-    dmaStream_t *dmaRef = NULL;
+    dmaResource_t *dmaRef = NULL;
 #if defined(STM32F4)
     uint32_t dmaChannel = 0;
 #endif
@@ -329,8 +329,8 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }
 
-    DMA_Cmd(dmaRef, DISABLE);
-    DMA_DeInit(dmaRef);
+    xDMA_Cmd(dmaRef, DISABLE);
+    xDMA_DeInit(dmaRef);
     DMA_StructInit(&DMAINIT);
 
 #ifdef USE_DSHOT_DMAR

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -59,12 +59,12 @@ static void processInputIrq(motorDmaOutput_t * const motor)
 
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        LL_EX_DMA_DisableStream(motor->timerHardware->dmaTimUPRef);
+        xLL_EX_DMA_DisableStream(motor->timerHardware->dmaTimUPRef);
         LL_TIM_DisableDMAReq_UPDATE(motor->timerHardware->tim);
     } else
 #endif
     {
-        LL_EX_DMA_DisableStream(motor->dmaRef);
+        xLL_EX_DMA_DisableStream(motor->dmaRef);
         LL_EX_TIM_DisableIT(motor->timerHardware->tim, motor->timerDmaSource);
     }
     readDoneCount++;
@@ -101,7 +101,7 @@ void pwmDshotSetDirectionOutput(
     const timerHardware_t * const timerHardware = motor->timerHardware;
     TIM_TypeDef *timer = timerHardware->tim;
 
-    LL_EX_DMA_DeInit(motor->dmaRef);
+    xLL_EX_DMA_DeInit(motor->dmaRef);
 
 #ifdef USE_DSHOT_TELEMETRY
     if (!output) {
@@ -123,8 +123,8 @@ void pwmDshotSetDirectionOutput(
 
         motor->dmaInitStruct.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
     }
-    LL_EX_DMA_Init(motor->dmaRef, pDmaInit);
-    LL_EX_DMA_EnableIT_TC(motor->dmaRef);
+    xLL_EX_DMA_Init(motor->dmaRef, pDmaInit);
+    xLL_EX_DMA_EnableIT_TC(motor->dmaRef);
 }
 
 
@@ -138,8 +138,8 @@ FAST_CODE void pwmCompleteDshotMotorUpdate(void)
     for (int i = 0; i < dmaMotorTimerCount; i++) {
 #ifdef USE_DSHOT_DMAR
         if (useBurstDshot) {
-            LL_EX_DMA_SetDataLength(dmaMotorTimers[i].dmaBurstRef, dmaMotorTimers[i].dmaBurstLength);
-            LL_EX_DMA_EnableStream(dmaMotorTimers[i].dmaBurstRef);
+            xLL_EX_DMA_SetDataLength(dmaMotorTimers[i].dmaBurstRef, dmaMotorTimers[i].dmaBurstLength);
+            xLL_EX_DMA_EnableStream(dmaMotorTimers[i].dmaBurstRef);
 
             /* configure the DMA Burst Mode */
             LL_TIM_ConfigDMABurst(dmaMotorTimers[i].timer, LL_TIM_DMABURST_BASEADDR_CCR1, LL_TIM_DMABURST_LENGTH_4TRANSFERS);
@@ -170,20 +170,20 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
         {
 #ifdef USE_DSHOT_DMAR
             if (useBurstDshot) {
-                LL_EX_DMA_DisableStream(motor->timerHardware->dmaTimUPRef);
+                xLL_EX_DMA_DisableStream(motor->timerHardware->dmaTimUPRef);
                 LL_TIM_DisableDMAReq_UPDATE(motor->timerHardware->tim);
             } else
 #endif
             {
-                LL_EX_DMA_DisableStream(motor->dmaRef);
+                xLL_EX_DMA_DisableStream(motor->dmaRef);
                 LL_EX_TIM_DisableIT(motor->timerHardware->tim, motor->timerDmaSource);
             }
 
 #ifdef USE_DSHOT_TELEMETRY
             if (useDshotTelemetry) {
                 pwmDshotSetDirectionOutput(motor, false);
-                LL_EX_DMA_SetDataLength(motor->dmaRef, motor->dmaInputLen);
-                LL_EX_DMA_EnableStream(motor->dmaRef);
+                xLL_EX_DMA_SetDataLength(motor->dmaRef, motor->dmaInputLen);
+                xLL_EX_DMA_EnableStream(motor->dmaRef);
                 LL_EX_TIM_EnableIT(motor->timerHardware->tim, motor->timerDmaSource);
                 setDirectionMicros = micros() - irqStart;
             }
@@ -205,7 +205,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #define DMAINIT dmaInitStruct
 #endif
 
-    DMA_Stream_TypeDef *dmaRef = NULL;
+    dmaResource_t *dmaRef = NULL;
     uint32_t dmaChannel = 0;
 #if defined(USE_DMA_SPEC)
     const dmaChannelSpec_t *dmaSpec = dmaGetChannelSpecByTimer(timerHardware);
@@ -311,8 +311,8 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }
 
-    LL_EX_DMA_DisableStream(dmaRef);
-    LL_EX_DMA_DeInit(dmaRef);
+    xLL_EX_DMA_DisableStream(dmaRef);
+    xLL_EX_DMA_DeInit(dmaRef);
     LL_DMA_StructInit(&DMAINIT);
 
 #ifdef USE_DSHOT_DMAR
@@ -350,8 +350,8 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     DMAINIT.Mode = LL_DMA_MODE_NORMAL;
     DMAINIT.Priority = LL_DMA_PRIORITY_HIGH;
 
-    LL_EX_DMA_Init(dmaRef, &DMAINIT);
-    LL_EX_DMA_EnableIT_TC(dmaRef);
+    xLL_EX_DMA_Init(dmaRef, &DMAINIT);
+    xLL_EX_DMA_EnableIT_TC(dmaRef);
     motor->dmaRef = dmaRef;
 
 #ifdef USE_DSHOT_TELEMETRY

--- a/src/main/drivers/pwm_output_dshot_hal_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal_hal.c
@@ -235,7 +235,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
 
 void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, motorPwmProtocolTypes_e pwmProtocolType, uint8_t output)
 {
-    DMA_Stream_TypeDef *dmaRef = NULL;
+    dmaResource_t *dmaRef = NULL;
     uint32_t dmaChannel;
 
 #ifdef USE_DMA_SPEC

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -138,11 +138,11 @@ FAST_CODE void pwmWriteDshotInt(uint8_t index, uint16_t value)
         bufferSize = loadDmaBuffer(motor->dmaBuffer, 1, packet);
         motor->timer->timerDmaSources |= motor->timerDmaSource;
 #ifdef STM32F7
-        LL_EX_DMA_SetDataLength(motor->dmaRef, bufferSize);
-        LL_EX_DMA_EnableStream(motor->dmaRef);
+        xLL_EX_DMA_SetDataLength(motor->dmaRef, bufferSize);
+        xLL_EX_DMA_EnableStream(motor->dmaRef);
 #else
-        DMA_SetCurrDataCounter(motor->dmaRef, bufferSize);
-        DMA_Cmd(motor->dmaRef, ENABLE);
+        xDMA_SetCurrDataCounter(motor->dmaRef, bufferSize);
+        xDMA_Cmd(motor->dmaRef, ENABLE);
 #endif
     }
 }
@@ -252,9 +252,9 @@ bool pwmStartDshotMotorUpdate(void)
     for (int i = 0; i < dshotPwmDevice.count; i++) {
         if (dmaMotors[i].hasTelemetry) {
 #ifdef STM32F7
-            uint32_t edges = LL_EX_DMA_GetDataLength(dmaMotors[i].dmaRef);
+            uint32_t edges = xLL_EX_DMA_GetDataLength(dmaMotors[i].dmaRef);
 #else
-            uint32_t edges = DMA_GetCurrDataCounter(dmaMotors[i].dmaRef);
+            uint32_t edges = xDMA_GetCurrDataCounter(dmaMotors[i].dmaRef);
 #endif
             uint16_t value = 0xffff;
             if (edges == 0) {

--- a/src/main/drivers/sdcard_sdio_baremetal.c
+++ b/src/main/drivers/sdcard_sdio_baremetal.c
@@ -226,7 +226,7 @@ static void sdcardSdio_init(const sdcardConfig_t *config, const spiPinConfig_t *
 #if defined(STM32H7) // H7 uses IDMA
     SD_Initialize_LL(0);
 #else
-    SD_Initialize_LL(dmaChannelSpec->ref);
+    SD_Initialize_LL((DMA_ARCH_TYPE *)dmaChannelSpec->ref);
 #endif
 #else
     SD_Initialize_LL(SDCARD_SDIO_DMA_OPT);

--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -389,10 +389,10 @@ static void sdcard_sendDataBlockBegin(const uint8_t *buffer, bool multiBlockWrit
         init.DMA_BufferSize = SDCARD_BLOCK_SIZE;
         init.DMA_Mode = DMA_Mode_Normal;
 
-        DMA_DeInit(sdcard.dma->ref);
-        DMA_Init(sdcard.dma->ref, &init);
+        xDMA_DeInit(sdcard.dma->ref);
+        xDMA_Init(sdcard.dma->ref, &init);
 
-        DMA_Cmd(sdcard.dma->ref, ENABLE);
+        xDMA_Cmd(sdcard.dma->ref, ENABLE);
 
         SPI_I2S_DMACmd(sdcard.busdev.busdev_u.spi.instance, SPI_I2S_DMAReq_Tx, ENABLE);
 #endif
@@ -749,14 +749,14 @@ static bool sdcardSpi_poll(void)
             }
 #else
 #ifdef STM32F4
-            if (sdcard.useDMAForTx && DMA_GetFlagStatus(sdcard.dma->ref, sdcard.dma->completeFlag) == SET) {
-                DMA_ClearFlag(sdcard.dma->ref, sdcard.dma->completeFlag);
+            if (sdcard.useDMAForTx && xDMA_GetFlagStatus(sdcard.dma->ref, sdcard.dma->completeFlag) == SET) {
+                xDMA_ClearFlag(sdcard.dma->ref, sdcard.dma->completeFlag);
 #else
             if (sdcard.useDMAForTx && DMA_GetFlagStatus(sdcard.dma->completeFlag) == SET) {
                 DMA_ClearFlag(sdcard.dma->completeFlag);
 #endif
 
-                DMA_Cmd(sdcard.dma->ref, DISABLE);
+                xDMA_Cmd(sdcard.dma->ref, DISABLE);
 
                 // Drain anything left in the Rx FIFO (we didn't read it during the write)
                 while (SPI_I2S_GetFlagStatus(sdcard.busdev.busdev_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {

--- a/src/main/drivers/sdio_f4xx.c
+++ b/src/main/drivers/sdio_f4xx.c
@@ -1625,8 +1625,8 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma)
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream3->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream3), OWNER_SDCARD, 0);
-        dmaSetHandler(dmaGetIdentifier(DMA2_Stream3), SDIO_DMA_ST3_IRQHandler, 1, 0);
+        dmaInit(dmaGetIdentifier((dmaResource_t *)DMA2_Stream3), OWNER_SDCARD, 0);
+        dmaSetHandler(dmaGetIdentifier((dmaResource_t *)DMA2_Stream3), SDIO_DMA_ST3_IRQHandler, 1, 0);
     } else {
         // Initialize DMA2 channel 6
         DMA2_Stream6->CR   = 0;                                                 // Reset DMA Stream control register
@@ -1638,8 +1638,8 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma)
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream6->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream6), OWNER_SDCARD, 0);
-        dmaSetHandler(dmaGetIdentifier(DMA2_Stream6), SDIO_DMA_ST6_IRQHandler, 1, 0);
+        dmaInit(dmaGetIdentifier((dmaResource_t *)DMA2_Stream6), OWNER_SDCARD, 0);
+        dmaSetHandler(dmaGetIdentifier((dmaResource_t *)DMA2_Stream6), SDIO_DMA_ST6_IRQHandler, 1, 0);
     }
 }
 

--- a/src/main/drivers/sdio_f7xx.c
+++ b/src/main/drivers/sdio_f7xx.c
@@ -1624,8 +1624,8 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma)
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream3->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream3), OWNER_SDCARD, 0);
-        dmaSetHandler(dmaGetIdentifier(DMA2_Stream3), SDMMC_DMA_ST3_IRQHandler, 1, 0);
+        dmaInit(dmaGetIdentifier((dmaResource_t *)DMA2_Stream3), OWNER_SDCARD, 0);
+        dmaSetHandler(dmaGetIdentifier((dmaResource_t *)DMA2_Stream3), SDMMC_DMA_ST3_IRQHandler, 1, 0);
     } else {
         // Initialize DMA2 channel 6
         DMA2_Stream6->CR   = 0;                                                 // Reset DMA Stream control register
@@ -1637,8 +1637,8 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma)
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream6->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream6), OWNER_SDCARD, 0);
-        dmaSetHandler(dmaGetIdentifier(DMA2_Stream6), SDMMC_DMA_ST6_IRQHandler, 1, 0);
+        dmaInit(dmaGetIdentifier((dmaResource_t *)DMA2_Stream6), OWNER_SDCARD, 0);
+        dmaSetHandler(dmaGetIdentifier((dmaResource_t *)DMA2_Stream6), SDMMC_DMA_ST6_IRQHandler, 1, 0);
     }
 }
 

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/dma.h" // For dmaResource_t
+
 // Since serial ports can be used for any function these buffer sizes should be equal
 // The two largest things that need to be sent are: 1, MSP responses, 2, UBLOX SVINFO packet.
 
@@ -50,19 +52,14 @@ typedef struct uartPort_s {
     DMA_HandleTypeDef txDMAHandle;
 #endif
 
+    dmaResource_t *rxDMAResource;
+    dmaResource_t *txDMAResource;
 #if defined(STM32F4) || defined(STM32F7)
-    DMA_Stream_TypeDef *rxDMAStream;
-    DMA_Stream_TypeDef *txDMAStream;
     uint32_t rxDMAChannel;
     uint32_t txDMAChannel;
 #elif defined(STM32H7)
-    DMA_Stream_TypeDef *rxDMAStream;
-    DMA_Stream_TypeDef *txDMAStream;
     uint8_t rxDMARequest;
     uint8_t txDMARequest;
-#elif defined(STM32F1) || defined(STM32F3)
-    DMA_Channel_TypeDef *rxDMAChannel;
-    DMA_Channel_TypeDef *txDMAChannel;
 #endif
 
     uint32_t rxDMAIrq;

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -118,9 +118,9 @@ void uartReconfigure(uartPort_t *uartPort)
     if (uartPort->port.mode & MODE_RX)
     {
 #ifdef USE_DMA
-        if (uartPort->rxDMAStream)
+        if (uartPort->rxDMAResource)
         {
-            uartPort->rxDMAHandle.Instance = uartPort->rxDMAStream;
+            uartPort->rxDMAHandle.Instance = (DMA_ARCH_TYPE *)uartPort->rxDMAResource;
 #if !defined(STM32H7)
             uartPort->rxDMAHandle.Init.Channel = uartPort->rxDMAChannel;
 #else 
@@ -165,8 +165,8 @@ void uartReconfigure(uartPort_t *uartPort)
     // Transmit DMA or IRQ
     if (uartPort->port.mode & MODE_TX) {
 #ifdef USE_DMA
-        if (uartPort->txDMAStream) {
-            uartPort->txDMAHandle.Instance = uartPort->txDMAStream;
+        if (uartPort->txDMAResource) {
+            uartPort->txDMAHandle.Instance = (DMA_ARCH_TYPE *)uartPort->txDMAResource;
 #if !defined(STM32H7)
             uartPort->txDMAHandle.Init.Channel = uartPort->txDMAChannel;
 #else 
@@ -251,7 +251,7 @@ void uartSetMode(serialPort_t *instance, portMode_e mode)
 void uartTryStartTxDMA(uartPort_t *s)
 {
     ATOMIC_BLOCK(NVIC_PRIO_SERIALUART_TXDMA) {
-        if (s->txDMAStream->CR & 1) {
+        if (IS_DMA_ENABLED(s->txDMAResource)) {
             // DMA is already in progress
             return;
         }
@@ -289,7 +289,7 @@ uint32_t uartTotalRxBytesWaiting(const serialPort_t *instance)
     uartPort_t *s = (uartPort_t*)instance;
 
 #ifdef USE_DMA
-    if (s->rxDMAStream) {
+    if (s->rxDMAResource) {
         uint32_t rxDMAHead = __HAL_DMA_GET_COUNTER(s->Handle.hdmarx);
 
         if (rxDMAHead >= s->rxDMAPos) {
@@ -320,7 +320,7 @@ uint32_t uartTotalTxBytesFree(const serialPort_t *instance)
     }
 
 #ifdef USE_DMA
-    if (s->txDMAStream) {
+    if (s->txDMAResource) {
         /*
          * When we queue up a DMA request, we advance the Tx buffer tail before the transfer finishes, so we must add
          * the remaining size of that in-progress transfer here instead:
@@ -348,7 +348,7 @@ bool isUartTransmitBufferEmpty(const serialPort_t *instance)
 {
     const uartPort_t *s = (uartPort_t *)instance;
 #ifdef USE_DMA
-    if (s->txDMAStream)
+    if (s->txDMAResource)
         return s->txDMAEmpty;
     else
 #endif
@@ -361,7 +361,7 @@ uint8_t uartRead(serialPort_t *instance)
     uartPort_t *s = (uartPort_t *)instance;
 
 #ifdef USE_DMA
-    if (s->rxDMAStream) {
+    if (s->rxDMAResource) {
         ch = s->port.rxBuffer[s->port.rxBufferSize - s->rxDMAPos];
         if (--s->rxDMAPos == 0)
             s->rxDMAPos = s->port.rxBufferSize;
@@ -392,7 +392,7 @@ void uartWrite(serialPort_t *instance, uint8_t ch)
     }
 
 #ifdef USE_DMA
-    if (s->txDMAStream) {
+    if (s->txDMAResource) {
         uartTryStartTxDMA(s);
     } else
 #endif

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -135,19 +135,14 @@ typedef struct uartHardware_s {
     USART_TypeDef* reg;
 
 #ifdef USE_DMA
+    dmaResource_t *txDMAResource;
+    dmaResource_t *rxDMAResource;
 #if defined(STM32F4) || defined(STM32F7)
     uint32_t DMAChannel;
-    DMA_Stream_TypeDef *txDMAStream;
-    DMA_Stream_TypeDef *rxDMAStream;
 #elif defined(STM32H7)
     // DMAMUX input from peripherals (DMA_REQUEST_xxx); RM0433 Table 110.
     uint8_t txDMARequest;
     uint8_t rxDMARequest;
-    DMA_Stream_TypeDef *txDMAStream;
-    DMA_Stream_TypeDef *rxDMAStream;
-#elif defined(STM32F1) || defined(STM32F3)
-    DMA_Channel_TypeDef *txDMAChannel;
-    DMA_Channel_TypeDef *rxDMAChannel;
 #endif
 #endif // USE_DMA
 

--- a/src/main/drivers/serial_uart_init.c
+++ b/src/main/drivers/serial_uart_init.c
@@ -141,7 +141,7 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
     DMA_InitTypeDef DMA_InitStructure;
     if (mode & MODE_RX) {
 #ifdef STM32F4
-        if (s->rxDMAStream) {
+        if (s->rxDMAResource) {
             DMA_StructInit(&DMA_InitStructure);
             DMA_InitStructure.DMA_PeripheralBaseAddr = s->rxDMAPeripheralBaseAddr;
             DMA_InitStructure.DMA_Priority = DMA_Priority_Medium;
@@ -154,7 +154,7 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
             DMA_InitStructure.DMA_MemoryBurst = DMA_MemoryBurst_Single ;
             DMA_InitStructure.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
 #else
-        if (s->rxDMAChannel) {
+        if (s->rxDMAResource) {
             DMA_StructInit(&DMA_InitStructure);
             DMA_InitStructure.DMA_PeripheralBaseAddr = s->rxDMAPeripheralBaseAddr;
             DMA_InitStructure.DMA_Priority = DMA_Priority_Medium;
@@ -171,20 +171,20 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
             DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
             DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;
             DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)s->port.rxBuffer;
-            DMA_DeInit(s->rxDMAStream);
-            DMA_Init(s->rxDMAStream, &DMA_InitStructure);
-            DMA_Cmd(s->rxDMAStream, ENABLE);
+            xDMA_DeInit(s->rxDMAResource);
+            xDMA_Init(s->rxDMAResource, &DMA_InitStructure);
+            xDMA_Cmd(s->rxDMAResource, ENABLE);
             USART_DMACmd(s->USARTx, USART_DMAReq_Rx, ENABLE);
-            s->rxDMAPos = DMA_GetCurrDataCounter(s->rxDMAStream);
+            s->rxDMAPos = xDMA_GetCurrDataCounter(s->rxDMAResource);
 #else
             DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralSRC;
             DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;
             DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t)s->port.rxBuffer;
-            DMA_DeInit(s->rxDMAChannel);
-            DMA_Init(s->rxDMAChannel, &DMA_InitStructure);
-            DMA_Cmd(s->rxDMAChannel, ENABLE);
+            xDMA_DeInit(s->rxDMAResource);
+            xDMA_Init(s->rxDMAResource, &DMA_InitStructure);
+            xDMA_Cmd(s->rxDMAResource, ENABLE);
             USART_DMACmd(s->USARTx, USART_DMAReq_Rx, ENABLE);
-            s->rxDMAPos = DMA_GetCurrDataCounter(s->rxDMAChannel);
+            s->rxDMAPos = xDMA_GetCurrDataCounter(s->rxDMAResource);
 #endif
         } else {
             USART_ClearITPendingBit(s->USARTx, USART_IT_RXNE);
@@ -195,7 +195,7 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
     // Transmit DMA or IRQ
     if (mode & MODE_TX) {
 #ifdef STM32F4
-        if (s->txDMAStream) {
+        if (s->txDMAResource) {
             DMA_StructInit(&DMA_InitStructure);
             DMA_InitStructure.DMA_PeripheralBaseAddr = s->txDMAPeripheralBaseAddr;
             DMA_InitStructure.DMA_Priority = DMA_Priority_Medium;
@@ -208,7 +208,7 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
             DMA_InitStructure.DMA_MemoryBurst = DMA_MemoryBurst_Single ;
             DMA_InitStructure.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
 #else
-        if (s->txDMAChannel) {
+        if (s->txDMAResource) {
             DMA_StructInit(&DMA_InitStructure);
             DMA_InitStructure.DMA_PeripheralBaseAddr = s->txDMAPeripheralBaseAddr;
             DMA_InitStructure.DMA_Priority = DMA_Priority_Medium;
@@ -224,18 +224,17 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
             DMA_InitStructure.DMA_Channel = s->txDMAChannel;
             DMA_InitStructure.DMA_DIR = DMA_DIR_MemoryToPeripheral;
             DMA_InitStructure.DMA_Mode = DMA_Mode_Normal;
-            DMA_DeInit(s->txDMAStream);
-            DMA_Init(s->txDMAStream, &DMA_InitStructure);
-            DMA_ITConfig(s->txDMAStream, DMA_IT_TC | DMA_IT_FE | DMA_IT_TE | DMA_IT_DME, ENABLE);
-            DMA_SetCurrDataCounter(s->txDMAStream, 0);
+            xDMA_DeInit(s->txDMAResource);
+            xDMA_Init(s->txDMAResource, &DMA_InitStructure);
+            xDMA_ITConfig(s->txDMAResource, DMA_IT_TC | DMA_IT_FE | DMA_IT_TE | DMA_IT_DME, ENABLE);
+            xDMA_SetCurrDataCounter(s->txDMAResource, 0);
 #else
             DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralDST;
             DMA_InitStructure.DMA_Mode = DMA_Mode_Normal;
-            DMA_DeInit(s->txDMAChannel);
-            DMA_Init(s->txDMAChannel, &DMA_InitStructure);
-            DMA_ITConfig(s->txDMAChannel, DMA_IT_TC, ENABLE);
-            DMA_SetCurrDataCounter(s->txDMAChannel, 0);
-            s->txDMAChannel->CNDTR = 0;
+            xDMA_DeInit(s->txDMAResource);
+            xDMA_Init(s->txDMAResource, &DMA_InitStructure);
+            xDMA_ITConfig(s->txDMAResource, DMA_IT_TC, ENABLE);
+            xDMA_SetCurrDataCounter(s->txDMAResource, 0);
 #endif
             USART_DMACmd(s->USARTx, USART_DMAReq_Tx, ENABLE);
         } else {

--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -65,8 +65,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_1,
         .reg = USART1,
-        .rxDMAChannel = UART1_RX_DMA_CHANNEL,
-        .txDMAChannel = UART1_TX_DMA_CHANNEL,
+        .rxDMAResource = (dmaResource_t *)UART1_RX_DMA_CHANNEL,
+        .txDMAResource = (dmaResource_t *)UART1_TX_DMA_CHANNEL,
         .rxPins = { { DEFIO_TAG_E(PA10) }, { DEFIO_TAG_E(PB7) } },
         .txPins = { { DEFIO_TAG_E(PA9) }, { DEFIO_TAG_E(PB6) } },
         //.af = GPIO_AF_USART1,
@@ -80,8 +80,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_2,
         .reg = USART2,
-        .rxDMAChannel = UART2_RX_DMA_CHANNEL,
-        .txDMAChannel = UART2_TX_DMA_CHANNEL,
+        .rxDMAResource = (dmaResource_t *)UART2_RX_DMA_CHANNEL,
+        .txDMAResource = (dmaResource_t *)UART2_TX_DMA_CHANNEL,
         .rxPins = { { DEFIO_TAG_E(PA3) }, { DEFIO_TAG_E(PD6) } },
         .txPins = { { DEFIO_TAG_E(PA2) }, { DEFIO_TAG_E(PD5) } },
         //.af = GPIO_AF_USART2,
@@ -95,8 +95,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_3,
         .reg = USART3,
-        .rxDMAChannel = UART3_RX_DMA_CHANNEL,
-        .txDMAChannel = UART3_TX_DMA_CHANNEL,
+        .rxDMAResource = (dmaResource_t *)UART3_RX_DMA_CHANNEL,
+        .txDMAResource = (dmaResource_t *)UART3_TX_DMA_CHANNEL,
         .rxPins = { { DEFIO_TAG_E(PB11) }, { DEFIO_TAG_E(PD9) }, { DEFIO_TAG_E(PC11) } },
         .txPins = { { DEFIO_TAG_E(PB10) }, { DEFIO_TAG_E(PD8) }, { DEFIO_TAG_E(PC10) } },
         //.af = GPIO_AF_USART3,
@@ -112,7 +112,7 @@ void uart_tx_dma_IRQHandler(dmaChannelDescriptor_t* descriptor)
 {
     uartPort_t *s = (uartPort_t*)(descriptor->userParam);
     DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-    DMA_Cmd(descriptor->ref, DISABLE); // XXX F1 needs this!!!
+    xDMA_Cmd(descriptor->ref, DISABLE); // XXX F1 needs this!!!
 
     uartTryStartTxDMA(s);
 }
@@ -143,17 +143,17 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     RCC_ClockCmd(hardware->rcc, ENABLE);
 
-    if (hardware->rxDMAChannel) {
-        dmaInit(dmaGetIdentifier(hardware->rxDMAChannel), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
-        s->rxDMAChannel = hardware->rxDMAChannel;
+    if (hardware->rxDMAResource) {
+        dmaInit(dmaGetIdentifier(hardware->rxDMAResource), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
+        s->rxDMAResource = hardware->rxDMAResource;
         s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
     }
 
-    if (hardware->txDMAChannel) {
-        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAChannel);
+    if (hardware->txDMAResource) {
+        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAResource);
         dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         dmaSetHandler(identifier, uart_tx_dma_IRQHandler, hardware->txPriority, (uint32_t)s);
-        s->txDMAChannel = hardware->txDMAChannel;
+        s->txDMAResource = hardware->txDMAResource;
         s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
     }
 
@@ -176,7 +176,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     }
 
     // RX/TX Interrupt
-    if (!hardware->rxDMAChannel || !hardware->txDMAChannel) {
+    if (!hardware->rxDMAResource || !hardware->txDMAResource) {
         NVIC_InitTypeDef NVIC_InitStructure;
 
         NVIC_InitStructure.NVIC_IRQChannel = hardware->irqn;
@@ -193,7 +193,7 @@ void uartIrqHandler(uartPort_t *s)
 {
     uint16_t SR = s->USARTx->SR;
 
-    if (SR & USART_FLAG_RXNE && !s->rxDMAChannel) {
+    if (SR & USART_FLAG_RXNE && !s->rxDMAResource) {
         // If we registered a callback, pass crap there
         if (s->port.rxCallback) {
             s->port.rxCallback(s->USARTx->DR, s->port.rxCallbackData);

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -88,8 +88,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_1,
         .reg = USART1,
-        .rxDMAChannel = UART1_RX_DMA,
-        .txDMAChannel = UART1_TX_DMA,
+        .rxDMAResource = (dmaResource_t *)UART1_RX_DMA,
+        .txDMAResource = (dmaResource_t *)UART1_TX_DMA,
         .rxPins = { { DEFIO_TAG_E(PA10) }, { DEFIO_TAG_E(PB7) }, { DEFIO_TAG_E(PC5) }, { DEFIO_TAG_E(PE1) } },
         .txPins = { { DEFIO_TAG_E(PA9) }, { DEFIO_TAG_E(PB6) }, { DEFIO_TAG_E(PC4) }, { DEFIO_TAG_E(PE0) } },
         .rcc = RCC_APB2(USART1),
@@ -104,8 +104,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_2,
         .reg = USART2,
-        .rxDMAChannel = UART2_RX_DMA,
-        .txDMAChannel = UART2_TX_DMA,
+        .rxDMAResource = (dmaResource_t *)UART2_RX_DMA,
+        .txDMAResource = (dmaResource_t *)UART2_TX_DMA,
         .rxPins = { { DEFIO_TAG_E(PA15) }, { DEFIO_TAG_E(PA3) }, { DEFIO_TAG_E(PB4) }, { DEFIO_TAG_E(PD6) } },
         .txPins = { { DEFIO_TAG_E(PA14) }, { DEFIO_TAG_E(PA2) }, { DEFIO_TAG_E(PB3) }, { DEFIO_TAG_E(PD5) } },
         .rcc = RCC_APB1(USART2),
@@ -120,8 +120,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_3,
         .reg = USART3,
-        .rxDMAChannel = UART3_RX_DMA,
-        .txDMAChannel = UART3_TX_DMA,
+        .rxDMAResource = (dmaResource_t *)UART3_RX_DMA,
+        .txDMAResource = (dmaResource_t *)UART3_TX_DMA,
         .rxPins = { { DEFIO_TAG_E(PB11) }, { DEFIO_TAG_E(PC11) }, { DEFIO_TAG_E(PD9) } },
         .txPins = { { DEFIO_TAG_E(PB10) }, { DEFIO_TAG_E(PC10) }, { DEFIO_TAG_E(PD8) } },
         .rcc = RCC_APB1(USART3),
@@ -137,8 +137,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_4,
         .reg = UART4,
-        .rxDMAChannel = 0, // XXX UART4_RX_DMA !?
-        .txDMAChannel = 0, // XXX UART4_TX_DMA !?
+        .rxDMAResource = (dmaResource_t *)0, // XXX UART4_RX_DMA !?
+        .txDMAResource = (dmaResource_t *)0, // XXX UART4_TX_DMA !?
         .rxPins = { { DEFIO_TAG_E(PC11) } },
         .txPins = { { DEFIO_TAG_E(PC10) } },
         .rcc = RCC_APB1(UART4),
@@ -154,8 +154,8 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_5,
         .reg = UART5,
-        .rxDMAChannel = 0,
-        .txDMAChannel = 0,
+        .rxDMAResource = (dmaResource_t *)0,
+        .txDMAResource = (dmaResource_t *)0,
         .rxPins = { { DEFIO_TAG_E(PD2) } },
         .txPins = { { DEFIO_TAG_E(PC12) } },
         .rcc = RCC_APB1(UART5),
@@ -171,7 +171,7 @@ static void handleUsartTxDma(dmaChannelDescriptor_t* descriptor)
 {
     uartPort_t *s = (uartPort_t*)(descriptor->userParam);
     DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-    DMA_Cmd(descriptor->ref, DISABLE);
+    xDMA_Cmd(descriptor->ref, DISABLE);
 
     uartTryStartTxDMA(s);
 }
@@ -228,23 +228,23 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     RCC_ClockCmd(hardware->rcc, ENABLE);
 
-    if (hardware->rxDMAChannel) {
-        dmaInit(dmaGetIdentifier(hardware->rxDMAChannel), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
-        s->rxDMAChannel = hardware->rxDMAChannel;
+    if (hardware->rxDMAResource) {
+        dmaInit(dmaGetIdentifier(hardware->rxDMAResource), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
+        s->rxDMAResource = hardware->rxDMAResource;
         s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->RDR;
     }
 
-    if (hardware->txDMAChannel) {
-        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAChannel);
+    if (hardware->txDMAResource) {
+        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAResource);
         dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         dmaSetHandler(identifier, handleUsartTxDma, hardware->txPriority, (uint32_t)s);
-        s->txDMAChannel = hardware->txDMAChannel;
+        s->txDMAResource = hardware->txDMAResource;
         s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->TDR;
     }
 
     serialUARTInitIO(IOGetByTag(uartDev->tx.pin), IOGetByTag(uartDev->rx.pin), mode, options, hardware->af, device);
 
-    if (!s->rxDMAChannel || !s->txDMAChannel) {
+    if (!s->rxDMAResource || !s->txDMAResource) {
         NVIC_InitTypeDef NVIC_InitStructure;
 
         NVIC_InitStructure.NVIC_IRQChannel = hardware->irqn;
@@ -261,7 +261,7 @@ void uartIrqHandler(uartPort_t *s)
 {
     uint32_t ISR = s->USARTx->ISR;
 
-    if (!s->rxDMAChannel && (ISR & USART_FLAG_RXNE)) {
+    if (!s->rxDMAResource && (ISR & USART_FLAG_RXNE)) {
         if (s->port.rxCallback) {
             s->port.rxCallback(s->USARTx->RDR, s->port.rxCallbackData);
         } else {
@@ -272,7 +272,7 @@ void uartIrqHandler(uartPort_t *s)
         }
     }
 
-    if (!s->txDMAChannel && (ISR & USART_FLAG_TXE)) {
+    if (!s->txDMAResource && (ISR & USART_FLAG_TXE)) {
         if (s->port.txBufferTail != s->port.txBufferHead) {
             USART_SendData(s->USARTx, s->port.txBuffer[s->port.txBufferTail++]);
             if (s->port.txBufferTail >= s->port.txBufferSize) {

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -46,10 +46,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART1,
         .DMAChannel = DMA_Channel_4,
 #ifdef USE_UART1_RX_DMA
-        .rxDMAStream = DMA2_Stream5,
+        .rxDMAResource = (dmaResource_t *)DMA2_Stream5,
 #endif
 #ifdef USE_UART1_TX_DMA
-        .txDMAStream = DMA2_Stream7,
+        .txDMAResource = (dmaResource_t *)DMA2_Stream7,
 #endif
         .rxPins = { { DEFIO_TAG_E(PA10) }, { DEFIO_TAG_E(PB7) } },
         .txPins = { { DEFIO_TAG_E(PA9) }, { DEFIO_TAG_E(PB6) } },
@@ -67,10 +67,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART2,
         .DMAChannel = DMA_Channel_4,
 #ifdef USE_UART2_RX_DMA
-        .rxDMAStream = DMA1_Stream5,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream5,
 #endif
 #ifdef USE_UART2_TX_DMA
-        .txDMAStream = DMA1_Stream6,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream6,
 #endif
         .rxPins = { { DEFIO_TAG_E(PA3) }, { DEFIO_TAG_E(PD6) } },
         .txPins = { { DEFIO_TAG_E(PA2) }, { DEFIO_TAG_E(PD5) } },
@@ -88,10 +88,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART3,
         .DMAChannel = DMA_Channel_4,
 #ifdef USE_UART3_RX_DMA
-        .rxDMAStream = DMA1_Stream1,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream1,
 #endif
 #ifdef USE_UART3_TX_DMA
-        .txDMAStream = DMA1_Stream3,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream3,
 #endif
         .rxPins = { { DEFIO_TAG_E(PB11) }, { DEFIO_TAG_E(PC11) }, { DEFIO_TAG_E(PD9) } },
         .txPins = { { DEFIO_TAG_E(PB10) }, { DEFIO_TAG_E(PC10) }, { DEFIO_TAG_E(PD8) } },
@@ -109,10 +109,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART4,
         .DMAChannel = DMA_Channel_4,
 #ifdef USE_UART4_RX_DMA
-        .rxDMAStream = DMA1_Stream2,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream2,
 #endif
 #ifdef USE_UART4_TX_DMA
-        .txDMAStream = DMA1_Stream4,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream4,
 #endif
         .rxPins = { { DEFIO_TAG_E(PA1) }, { DEFIO_TAG_E(PC11) } },
         .txPins = { { DEFIO_TAG_E(PA0) }, { DEFIO_TAG_E(PC10) } },
@@ -130,10 +130,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART5,
         .DMAChannel = DMA_Channel_4,
 #ifdef USE_UART5_RX_DMA
-        .rxDMAStream = DMA1_Stream0,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream0,
 #endif
 #ifdef USE_UART5_TX_DMA
-        .txDMAStream = DMA1_Stream7,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream7,
 #endif
         .rxPins = { { DEFIO_TAG_E(PD2) } },
         .txPins = { { DEFIO_TAG_E(PC12) } },
@@ -151,10 +151,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART6,
         .DMAChannel = DMA_Channel_5,
 #ifdef USE_UART6_RX_DMA
-        .rxDMAStream = DMA2_Stream1,
+        .rxDMAResource = (dmaResource_t *)DMA2_Stream1,
 #endif
 #ifdef USE_UART6_TX_DMA
-        .txDMAStream = DMA2_Stream6,
+        .txDMAResource = (dmaResource_t *)DMA2_Stream6,
 #endif
         .rxPins = { { DEFIO_TAG_E(PC7) }, { DEFIO_TAG_E(PG9) } },
         .txPins = { { DEFIO_TAG_E(PC6) }, { DEFIO_TAG_E(PG14) } },
@@ -218,19 +218,19 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     s->USARTx = hardware->reg;
 
-    if (hardware->rxDMAStream) {
-        dmaInit(dmaGetIdentifier(hardware->rxDMAStream), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
+    if (hardware->rxDMAResource) {
+        dmaInit(dmaGetIdentifier(hardware->rxDMAResource), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
         s->rxDMAChannel = hardware->DMAChannel;
-        s->rxDMAStream = hardware->rxDMAStream;
+        s->rxDMAResource = hardware->rxDMAResource;
         s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
     }
 
-    if (hardware->txDMAStream) {
-        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
+    if (hardware->txDMAResource) {
+        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAResource);
         dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uart);
         s->txDMAChannel = hardware->DMAChannel;
-        s->txDMAStream = hardware->txDMAStream;
+        s->txDMAResource = hardware->txDMAResource;
         s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
     }
 
@@ -271,7 +271,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
 void uartIrqHandler(uartPort_t *s)
 {
-    if (!s->rxDMAStream && (USART_GetITStatus(s->USARTx, USART_IT_RXNE) == SET)) {
+    if (!s->rxDMAResource && (USART_GetITStatus(s->USARTx, USART_IT_RXNE) == SET)) {
         if (s->port.rxCallback) {
             s->port.rxCallback(s->USARTx->DR, s->port.rxCallbackData);
         } else {
@@ -280,7 +280,7 @@ void uartIrqHandler(uartPort_t *s)
         }
     }
 
-    if (!s->txDMAStream && (USART_GetITStatus(s->USARTx, USART_IT_TXE) == SET)) {
+    if (!s->txDMAResource && (USART_GetITStatus(s->USARTx, USART_IT_TXE) == SET)) {
         if (s->port.txBufferTail != s->port.txBufferHead) {
             USART_SendData(s->USARTx, s->port.txBuffer[s->port.txBufferTail]);
             s->port.txBufferTail = (s->port.txBufferTail + 1) % s->port.txBufferSize;

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -48,10 +48,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART1,
         .DMAChannel = DMA_CHANNEL_4,
 #ifdef USE_UART1_RX_DMA
-        .rxDMAStream = DMA2_Stream5,
+        .rxDMAResource = (dmaResource_t *)DMA2_Stream5,
 #endif
 #ifdef USE_UART1_TX_DMA
-        .txDMAStream = DMA2_Stream7,
+        .txDMAResource = (dmaResource_t *)DMA2_Stream7,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA10), GPIO_AF7_USART1 },
@@ -83,10 +83,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART2,
         .DMAChannel = DMA_CHANNEL_4,
 #ifdef USE_UART2_RX_DMA
-        .rxDMAStream = DMA1_Stream5,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream5,
 #endif
 #ifdef USE_UART2_TX_DMA
-        .txDMAStream = DMA1_Stream6,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream6,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA3), GPIO_AF7_USART2 },
@@ -112,10 +112,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART3,
         .DMAChannel = DMA_CHANNEL_4,
 #ifdef USE_UART3_RX_DMA
-        .rxDMAStream = DMA1_Stream1,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream1,
 #endif
 #ifdef USE_UART3_TX_DMA
-        .txDMAStream = DMA1_Stream3,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream3,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PB11), GPIO_AF7_USART3 },
@@ -143,10 +143,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART4,
         .DMAChannel = DMA_CHANNEL_4,
 #ifdef USE_UART4_RX_DMA
-        .rxDMAStream = DMA1_Stream2,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream2,
 #endif
 #ifdef USE_UART4_TX_DMA
-        .txDMAStream = DMA1_Stream4,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream4,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA1), GPIO_AF8_UART4 },
@@ -180,10 +180,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART5,
         .DMAChannel = DMA_CHANNEL_4,
 #ifdef USE_UART5_RX_DMA
-        .rxDMAStream = DMA1_Stream0,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream0,
 #endif
 #ifdef USE_UART5_TX_DMA
-        .txDMAStream = DMA1_Stream7,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream7,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PD2), GPIO_AF8_UART5 },
@@ -217,10 +217,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART6,
         .DMAChannel = DMA_CHANNEL_5,
 #ifdef USE_UART6_RX_DMA
-        .rxDMAStream = DMA2_Stream1,
+        .rxDMAResource = (dmaResource_t *)DMA2_Stream1,
 #endif
 #ifdef USE_UART6_TX_DMA
-        .txDMAStream = DMA2_Stream6,
+        .txDMAResource = (dmaResource_t *)DMA2_Stream6,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PC7), GPIO_AF8_USART6  },
@@ -246,10 +246,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART7,
         .DMAChannel = DMA_CHANNEL_5,
 #ifdef USE_UART7_RX_DMA
-        .rxDMAStream = DMA1_Stream3,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream3,
 #endif
 #ifdef USE_UART7_TX_DMA
-        .txDMAStream = DMA1_Stream1,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream1,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PE7), GPIO_AF8_UART7 },
@@ -283,10 +283,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART8,
         .DMAChannel = DMA_CHANNEL_5,
 #ifdef USE_UART8_RX_DMA
-        .rxDMAStream = DMA1_Stream6,
+        .rxDMAResource = (dmaResource_t *)DMA1_Stream6,
 #endif
 #ifdef USE_UART8_TX_DMA
-        .txDMAStream = DMA1_Stream0,
+        .txDMAResource = (dmaResource_t *)DMA1_Stream0,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PE0), GPIO_AF8_UART8 }
@@ -347,7 +347,7 @@ void uartIrqHandler(uartPort_t *s)
     }
 
     /* UART in mode Transmitter ------------------------------------------------*/
-    if (!s->txDMAStream && (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET)) {
+    if (!s->txDMAResource && (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET)) {
         /* Check that a Tx process is ongoing */
         if (huart->gState != HAL_UART_STATE_BUSY_TX) {
             if (s->port.txBufferTail == s->port.txBufferHead) {
@@ -368,7 +368,7 @@ void uartIrqHandler(uartPort_t *s)
     /* UART in mode Transmitter (transmission end) -----------------------------*/
     if ((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
         HAL_UART_IRQHandler(huart);
-        if (s->txDMAStream) {
+        if (s->txDMAResource) {
             handleUsartTxDma(s);
         }
     }
@@ -409,17 +409,17 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     s->USARTx = hardware->reg;
 
-    if (hardware->rxDMAStream) {
+    if (hardware->rxDMAResource) {
         s->rxDMAChannel = hardware->DMAChannel;
-        s->rxDMAStream = hardware->rxDMAStream;
+        s->rxDMAResource = hardware->rxDMAResource;
     }
 
-    if (hardware->txDMAStream) {
+    if (hardware->txDMAResource) {
         s->txDMAChannel = hardware->DMAChannel;
-        s->txDMAStream = hardware->txDMAStream;
+        s->txDMAResource = hardware->txDMAResource;
 
         // DMA TX Interrupt
-        dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
+        dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAResource);
         dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
     }

--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -133,9 +133,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART1,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_USART1_RX,
-        .rxDMAStream = UART1_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART1_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_USART1_TX,
-        .txDMAStream = UART1_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART1_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA10), GPIO_AF7_USART1 },
@@ -164,9 +164,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART2,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_USART2_RX,
-        .rxDMAStream = UART2_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART2_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_USART2_TX,
-        .txDMAStream = UART2_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART2_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA3), GPIO_AF7_USART2 },
@@ -193,9 +193,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART3,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_USART3_RX,
-        .rxDMAStream = UART3_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART3_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_USART3_TX,
-        .txDMAStream = UART3_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART3_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PB11), GPIO_AF7_USART3 },
@@ -224,9 +224,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART4,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_UART4_RX,
-        .rxDMAStream = UART4_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART4_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_UART4_TX,
-        .txDMAStream = UART4_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART4_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA1),  GPIO_AF8_UART4 },
@@ -259,9 +259,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART5,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_UART5_RX,
-        .rxDMAStream = UART5_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART5_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_UART5_TX,
-        .txDMAStream = UART5_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART5_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PB5),  GPIO_AF14_UART5 },
@@ -290,9 +290,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = USART6,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_USART6_RX,
-        .rxDMAStream = UART6_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART6_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_USART6_TX,
-        .txDMAStream = UART6_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART6_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PC7), GPIO_AF7_USART6  },
@@ -319,9 +319,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART7,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_UART7_RX,
-        .rxDMAStream = UART7_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART7_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_UART7_TX,
-        .txDMAStream = UART7_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART7_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA8), GPIO_AF11_UART7 },
@@ -352,9 +352,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .reg = UART8,
 #ifdef USE_DMA
         .rxDMARequest = DMA_REQUEST_UART8_RX,
-        .rxDMAStream = UART8_RX_DMA_STREAM,
+        .rxDMAResource = (dmaResource_t *)UART8_RX_DMA_STREAM,
         .txDMARequest = DMA_REQUEST_UART8_TX,
-        .txDMAStream = UART8_TX_DMA_STREAM,
+        .txDMAResource = (dmaResource_t *)UART8_TX_DMA_STREAM,
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PE0), GPIO_AF8_UART8 }
@@ -422,7 +422,7 @@ void uartIrqHandler(uartPort_t *s)
     /* UART in mode Transmitter ------------------------------------------------*/
     if (
 #ifdef USE_DMA
-        !s->txDMAStream &&
+        !s->txDMAResource &&
 #endif
         (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET)) {
         /* Check that a Tx process is ongoing */
@@ -446,7 +446,7 @@ void uartIrqHandler(uartPort_t *s)
     if ((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
         HAL_UART_IRQHandler(huart);
 #ifdef USE_DMA
-        if (s->txDMAStream) {
+        if (s->txDMAResource) {
             handleUsartTxDma(s);
         }
 #endif
@@ -493,8 +493,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 #endif
 
 #ifdef USE_DMA
-    if (hardware->rxDMAStream) {
-        s->rxDMAStream = hardware->rxDMAStream;
+    if (hardware->rxDMAResource) {
+        s->rxDMAResource = hardware->rxDMAResource;
 #if defined(STM32H7)
         s->rxDMARequest = hardware->rxDMARequest;
 #else // F4 & F7
@@ -502,8 +502,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 #endif
     }
 
-    if (hardware->txDMAStream) {
-        s->txDMAStream = hardware->txDMAStream;
+    if (hardware->txDMAResource) {
+        s->txDMAResource = hardware->txDMAResource;
 #if defined(STM32H7)
         s->txDMARequest = hardware->txDMARequest;
 #else // F4 & F7
@@ -511,7 +511,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 #endif
 
         // DMA TX Interrupt
-        dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
+        dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAResource);
         dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
     }
@@ -548,7 +548,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
 #ifdef USE_DMA
 #if defined(STM32H7)
-    if (!s->rxDMAStream)
+    if (!s->rxDMAResource)
 #else
     if (!s->rxDMAChannel)
 #endif

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "drivers/dma.h"
 #include "drivers/io_types.h"
 #include "drivers/rcc_types.h"
 #include "drivers/timer_def.h"
@@ -112,37 +113,25 @@ typedef struct timerHardware_s {
 #if defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
     uint8_t alternateFunction;
 #endif
-#if defined(USE_TIMER_DMA)
-#if defined(USE_DMA_SPEC)
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    DMA_Stream_TypeDef *dmaRefConfigured;
-    uint32_t dmaChannelConfigured;
-#else
-    DMA_Channel_TypeDef *dmaRefConfigured;
-#endif
-#else
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    DMA_Stream_TypeDef *dmaRef;
-    // For F4 and F7, dmaChannel is channel for DMA1 or DMA2.
-    // For H7, dmaChannel is DMA request number for DMAMUX
-    uint32_t dmaChannel; // XXX Can be much smaller (e.g. uint8_t)
-#else
-    DMA_Channel_TypeDef *dmaRef;
-#endif
-#endif
 
-#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    // TIMUP
-#ifdef STM32F3
-    DMA_Channel_TypeDef *dmaTimUPRef;
-#else
-    DMA_Stream_TypeDef *dmaTimUPRef;
-    // For F4 and F7, dmaTimUpChannel is channel for DMA1 or DMA2.
-    // For H7, dmaTimUpChannel is DMA request number for DMAMUX
+#if defined(USE_TIMER_DMA)
+
+#if defined(USE_DMA_SPEC)
+    dmaResource_t *dmaRefConfigured;
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
+    uint32_t dmaChannelConfigured;
+#endif
+#else // USE_DMA_SPEC
+    dmaResource_t *dmaRef;
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
+    uint32_t dmaChannel; // XXX Can be much smaller (e.g. uint8_t)
+#endif
+#endif // USE_DMA_SPEC
+    dmaResource_t *dmaTimUPRef;
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
     uint32_t dmaTimUPChannel;
 #endif
     uint8_t dmaTimUPIrqHandler;
-#endif
 #endif
 } timerHardware_t;
 

--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -203,7 +203,7 @@
 #define DEF_TIM_AF__D(af_n) GPIO_AF_ ## af_n
 
 #define DEF_TIM_DMA_CHANNEL(timch) CONCAT(DEF_TIM_DMA_CHANNEL__, DEF_TIM_DMA_GET(0, timch))
-#define DEF_TIM_DMA_CHANNEL__D(dma_n, chan_n) DMA ## dma_n ## _Channel ## chan_n
+#define DEF_TIM_DMA_CHANNEL__D(dma_n, chan_n) (dmaResource_t *)DMA ## dma_n ## _Channel ## chan_n
 #define DEF_TIM_DMA_CHANNEL__NONE NULL
 
 #define DEF_TIM_DMA_HANDLER(timch) CONCAT(DEF_TIM_DMA_HANDLER__, DEF_TIM_DMA_GET(0, timch))
@@ -427,7 +427,7 @@
 
 #define DEF_TIM_DMA_STREAM(variant, timch)                              \
     CONCAT(DEF_TIM_DMA_STREAM__, DEF_TIM_DMA_GET(variant, timch))
-#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n, chan_n)  DMA ## dma_n ## _Stream ## stream_n
+#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n, chan_n)  (dmaResource_t *)DMA ## dma_n ## _Stream ## stream_n
 #define DEF_TIM_DMA_STREAM__NONE                        NULL
 
 #define DEF_TIM_DMA_HANDLER(variant, timch) \
@@ -532,7 +532,7 @@
 
 #define DEF_TIM_DMA_STREAM(variant, timch)                              \
     CONCAT(DEF_TIM_DMA_STREAM__, DEF_TIM_DMA_GET(variant, timch))
-#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n, chan_n)  DMA ## dma_n ## _Stream ## stream_n
+#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n, chan_n)  (dmaResource_t *)DMA ## dma_n ## _Stream ## stream_n
 #define DEF_TIM_DMA_STREAM__NONE                        NULL
 
 #define DEF_TIM_DMA_HANDLER(variant, timch) \
@@ -743,7 +743,7 @@
 
 #define DEF_TIM_DMA_STREAM(variant, timch)                              \
     CONCAT(DEF_TIM_DMA_STREAM__, DEF_TIM_DMA_GET(variant, timch))
-#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n)  DMA ## dma_n ## _Stream ## stream_n
+#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n)  (dmaResource_t *)DMA ## dma_n ## _Stream ## stream_n
 #define DEF_TIM_DMA_STREAM__NONE                        NULL
 
 // XXX This is awful. There must be some smart way of doing this ...

--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -85,10 +85,10 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
         return;
     }
 
-    dmaStream_t *dmaRef = dmaSpec->ref;
+    dmaResource_t *dmaRef = dmaSpec->ref;
     uint32_t dmaChannel = dmaSpec->channel;
 #else
-    dmaStream_t *dmaRef = timerHardware->dmaRef;
+    dmaResource_t *dmaRef = timerHardware->dmaRef;
     uint32_t dmaChannel = timerHardware->dmaChannel;
 #endif
 
@@ -144,7 +144,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
     hdma_tim.Init.PeriphBurst = DMA_PBURST_SINGLE;
 
     /* Set hdma_tim instance */
-    hdma_tim.Instance = dmaRef;
+    hdma_tim.Instance = (DMA_ARCH_TYPE *)dmaRef;
 
     uint16_t dmaIndex = timerDmaIndex(timerChannel);
 

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -43,13 +43,7 @@ volatile uint8_t transponderIrDataTransferInProgress = 0;
 static IO_t transponderIO = IO_NONE;
 static TIM_TypeDef *timer = NULL;
 uint8_t alternateFunction;
-#if defined(STM32F3)
-static DMA_Channel_TypeDef *dmaRef = NULL;
-#elif defined(STM32F4)
-static DMA_Stream_TypeDef *dmaRef = NULL;
-#else
-#error "Transponder not supported on this MCU."
-#endif
+static dmaResource_t *dmaRef = NULL;
 
 transponder_t transponder;
 
@@ -58,7 +52,7 @@ static void TRANSPONDER_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         transponderIrDataTransferInProgress = 0;
 
-        DMA_Cmd(descriptor->ref, DISABLE);
+        xDMA_Cmd(descriptor->ref, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
     }
 }
@@ -139,8 +133,8 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
     TIM_CtrlPWMOutputs(timer, ENABLE);
 
     /* configure DMA */
-    DMA_Cmd(dmaRef, DISABLE);
-    DMA_DeInit(dmaRef);
+    xDMA_Cmd(dmaRef, DISABLE);
+    xDMA_DeInit(dmaRef);
 
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)timerCCR(timer, timerHardware->channel);
@@ -167,11 +161,11 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
     DMA_InitStructure.DMA_Mode = DMA_Mode_Normal;
     DMA_InitStructure.DMA_Priority = DMA_Priority_High;
 
-    DMA_Init(dmaRef, &DMA_InitStructure);
+    xDMA_Init(dmaRef, &DMA_InitStructure);
 
     TIM_DMACmd(timer, timerDmaSource(timerHardware->channel), ENABLE);
 
-    DMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
+    xDMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
 }
 
 bool transponderIrInit(const ioTag_t ioTag, const transponderProvider_e provider)
@@ -225,15 +219,15 @@ void transponderIrUpdateData(const uint8_t* transponderData)
 
 void transponderIrDMAEnable(transponder_t *transponder)
 {
-    DMA_SetCurrDataCounter(dmaRef, transponder->dma_buffer_size);  // load number of bytes to be transferred
+    xDMA_SetCurrDataCounter(dmaRef, transponder->dma_buffer_size);  // load number of bytes to be transferred
     TIM_SetCounter(timer, 0);
     TIM_Cmd(timer, ENABLE);
-    DMA_Cmd(dmaRef, ENABLE);
+    xDMA_Cmd(dmaRef, ENABLE);
 }
 
 void transponderIrDisable(void)
 {
-    DMA_Cmd(dmaRef, DISABLE);
+    xDMA_Cmd(dmaRef, DISABLE);
     TIM_Cmd(timer, DISABLE);
 
     IOInit(transponderIO, OWNER_TRANSPONDER, 0);

--- a/src/main/msc/usbd_storage_sdio.c
+++ b/src/main/msc/usbd_storage_sdio.c
@@ -171,7 +171,7 @@ static int8_t STORAGE_Init (uint8_t lun)
         	return 1;
         }
 
-	SD_Initialize_LL(dmaChannelSpec->ref);
+	SD_Initialize_LL((DMA_ARCH_TYPE *)dmaChannelSpec->ref);
 #else
 	SD_Initialize_LL(SDCARD_SDIO_DMA_OPT);
 #endif


### PR DESCRIPTION
Initial cut of DMA stream and channel unification, per #8550 .

Some comments atm:
- An opaque type for unification is ~`dmaInstance_t`~ `dmaResource_t`.
- There are lots of visual disturbance as ~`dmaInstance_t`~ `dmaResource_t` must be casted back to an actual type for the MCU architecture (casting by ~`DMA_INSTANCE_TYPE`~ `DMA_ARCH_TYPE`).
- Although I've spotted there are many opportunities for code unification, I didn't work on it for this cut except for obvious case of structures with both `DMA_Stream_TypeDef` and `DMA_Channel_TypeDef`.
- ~Target OMNIBUS (and possibly others) is overflowing by 3KB. I'm not sure what triggered the sudden increase in the size...~ Seems okay according to Travis...