### PR TITLE
Spektrum SRXL2 implementation

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -110,6 +110,7 @@ COMMON_SRC = \
             rx/sbus.c \
             rx/sbus_channels.c \
             rx/spektrum.c \
+            rx/srxlv2.c \
             io/spektrum_vtx_control.c \
             io/spektrum_rssi.c \
             rx/sumd.c \
@@ -249,6 +250,7 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             rx/sbus.c \
             rx/sbus_channels.c \
             rx/spektrum.c \
+            rx/srxlv2.c \
             rx/sumd.c \
             rx/xbus.c \
             rx/fport.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -224,6 +224,7 @@ static const char * const lookupTableSerialRX[] = {
     "CUSTOM",
     "FPORT",
     "DJI_HDL",
+    "SRXLv2",
 };
 #endif
 
@@ -468,6 +469,19 @@ static const char * const lookupTablePositionAltSource[] = {
     "DEFAULT", "BARO_ONLY", "GPS_ONLY"
 };
 
+#ifdef USE_SERIALRX_SRXLv2
+static const char * const lookupTableSrxlv2BaudRates[] = {
+    "115k", "400k"
+};
+#endif
+
+static const char * const lookupTableHalfDuplex[] = {
+    "OFF", "ON",
+#ifdef STM32F3
+    "RX"
+#endif
+};
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -582,6 +596,11 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableGyroFilterDebug),
 
     LOOKUP_TABLE_ENTRY(lookupTablePositionAltSource),
+
+#ifdef USE_SERIALRX_SRXLv2
+    LOOKUP_TABLE_ENTRY(lookupTableSrxlv2BaudRates),
+#endif
+    LOOKUP_TABLE_ENTRY(lookupTableHalfDuplex),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -704,10 +723,14 @@ const clivalue_t valueTable[] = {
     { "spektrum_sat_bind",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { SPEKTRUM_SAT_BIND_DISABLED, SPEKTRUM_SAT_BIND_MAX}, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind) },
     { "spektrum_sat_bind_autoreset",VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind_autoreset) },
 #endif
+#ifdef USE_SERIALRX_SRXLv2
+    { "srxlv2_unit_id",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 0xf }, PG_RX_CONFIG, offsetof(rxConfig_t, srxlv2_unit_id) },
+    { "srxlv2_baud_rate",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SRXLv2_BAUD_RATES }, PG_RX_CONFIG, offsetof(rxConfig_t, srxlv2_baud_rate) },
+#endif
     { "airmode_start_throttle_percent",     VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RX_CONFIG, offsetof(rxConfig_t, airModeActivateThreshold) },
     { "rx_min_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_min_usec) },
     { "rx_max_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_max_usec) },
-    { "serialrx_halfduplex",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, halfDuplex) },
+    { "serialrx_halfduplex",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_HALF_DUPLEX }, PG_RX_CONFIG, offsetof(rxConfig_t, halfDuplex) },
 #ifdef USE_RX_SPI
     { "rx_spi_protocol",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RX_SPI }, PG_RX_SPI_CONFIG, offsetof(rxSpiConfig_t, rx_spi_protocol) },
     { "rx_spi_bus",                 VAR_UINT8   | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, SPIDEV_COUNT }, PG_RX_SPI_CONFIG, offsetof(rxSpiConfig_t, spibus) },

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -136,6 +136,10 @@ typedef enum {
     TABLE_GYRO_FILTER_DEBUG,
     TABLE_POSITION_ALT_SOURCE,
 
+#ifdef USE_SERIALRX_SRXLv2
+    TABLE_SRXLv2_BAUD_RATES,
+#endif
+    TABLE_HALF_DUPLEX,
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -52,6 +52,7 @@ typedef enum {
     SERIAL_BIDIR_OD        = 0 << 4,
     SERIAL_BIDIR_PP        = 1 << 4,
     SERIAL_BIDIR_NOPULL    = 1 << 5, // disable pulls in BIDIR RX mode
+    SERIAL_SWAP_RX_TX      = 1 << 6, // swap TX and RX pins, not supported on F4
 } portOptions_e;
 
 // Define known line control states which may be passed up by underlying serial driver callback
@@ -59,6 +60,7 @@ typedef enum {
 #define CTRL_LINE_STATE_RTS (1 << 1)
 
 typedef void (*serialReceiveCallbackPtr)(uint16_t data, void *rxCallbackData);   // used by serial drivers to return frames to app
+typedef void (*serialIdleCallbackPtr)();
 
 typedef struct serialPort_s {
 
@@ -80,6 +82,8 @@ typedef struct serialPort_s {
 
     serialReceiveCallbackPtr rxCallback;
     void *rxCallbackData;
+
+    serialIdleCallbackPtr idleCallback;
 
     uint8_t identifier;
 } serialPort_t;

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -147,7 +147,6 @@ void uartReconfigure(uartPort_t *uartPort)
             HAL_UART_Receive_DMA(&uartPort->Handle, (uint8_t*)uartPort->port.rxBuffer, uartPort->port.rxBufferSize);
 
             uartPort->rxDMAPos = __HAL_DMA_GET_COUNTER(&uartPort->rxDMAHandle);
-
         } else
 #endif
         {
@@ -159,6 +158,9 @@ void uartReconfigure(uartPort_t *uartPort)
 
             /* Enable the UART Data Register not empty Interrupt */
             SET_BIT(uartPort->USARTx->CR1, USART_CR1_RXNEIE);
+
+            /* Enable Idle Line detection */
+            SET_BIT(uartPort->USARTx->CR1, USART_CR1_IDLEIE);
         }
     }
 

--- a/src/main/drivers/serial_uart_init.c
+++ b/src/main/drivers/serial_uart_init.c
@@ -189,6 +189,7 @@ serialPort_t *uartOpen(UARTDevice_e device, serialReceiveCallbackPtr rxCallback,
         } else {
             USART_ClearITPendingBit(s->USARTx, USART_IT_RXNE);
             USART_ITConfig(s->USARTx, USART_IT_RXNE, ENABLE);
+            USART_ITConfig(s->USARTx, USART_IT_IDLE, ENABLE);
         }
     }
 

--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -214,5 +214,13 @@ void uartIrqHandler(uartPort_t *s)
             USART_ITConfig(s->USARTx, USART_IT_TXE, DISABLE);
         }
     }
+    if (SR & USART_FLAG_IDLE) {
+        if (s->port.idleCallback) {
+            s->port.idleCallback();
+        }
+
+        const uint32_t read_to_clear = s->USARTx->DR;
+        (void) read_to_clear;
+    }
 }
 #endif // USE_UART

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -289,9 +289,18 @@ void uartIrqHandler(uartPort_t *s)
         }
     }
 
-    if (USART_GetITStatus(s->USARTx, USART_IT_ORE) == SET)
-    {
-        USART_ClearITPendingBit (s->USARTx, USART_IT_ORE);
+    if (USART_GetITStatus(s->USARTx, USART_IT_ORE) == SET) {
+        USART_ClearITPendingBit(s->USARTx, USART_IT_ORE);
+    }
+
+    if (USART_GetITStatus(s->USARTx, USART_IT_IDLE) == SET) {
+        if (s->port.idleCallback) {
+            s->port.idleCallback();
+        }
+
+        // clear
+        (void) s->USARTx->SR;
+        (void) s->USARTx->DR;
     }
 }
 #endif

--- a/src/main/drivers/time.h
+++ b/src/main/drivers/time.h
@@ -31,5 +31,8 @@ timeUs_t micros(void);
 timeUs_t microsISR(void);
 timeMs_t millis(void);
 
+uint32_t nanosISR();
+uint32_t nanos();
+
 uint32_t ticks(void);
 timeDelta_t ticks_diff_us(uint32_t begin, uint32_t end);

--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -55,24 +55,24 @@ static int srxlWriteChar(displayPort_t *displayPort, uint8_t col, uint8_t row, u
 static int srxlWriteString(displayPort_t *displayPort, uint8_t col, uint8_t row, const char *s)
 {
     while (*s) {
-        srxlWriteChar(displayPort,  col++, row, *(s++));
+        srxlWriteChar(displayPort, col++, row, *(s++));
     }
     return 0;
 }
 
 static int srxlClearScreen(displayPort_t *displayPort)
 {
-    for (int row = 0;  row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS; row++) {
+    for (int row = 0; row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS; row++) {
         for (int col= 0; col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS; col++) {
             srxlWriteChar(displayPort, col, row, ' ');
         }
     }
-    srxlWriteString(displayPort, 1, 0,  "BETAFLIGHT");
+    srxlWriteString(displayPort, 1, 0, "BETAFLIGHT");
 
-    if ( displayPort->grabCount == 0 ) {
-        srxlWriteString(displayPort, 0, 2,  CMS_STARTUP_HELP_TEXT1);
-        srxlWriteString(displayPort, 2, 3,  CMS_STARTUP_HELP_TEXT2);
-        srxlWriteString(displayPort, 2, 4,  CMS_STARTUP_HELP_TEXT3);
+    if (displayPort->grabCount == 0) {
+        srxlWriteString(displayPort, 0, 2, CMS_STARTUP_HELP_TEXT1);
+        srxlWriteString(displayPort, 2, 3, CMS_STARTUP_HELP_TEXT2);
+        srxlWriteString(displayPort, 2, 4, CMS_STARTUP_HELP_TEXT3);
     }
     return 0;
 }

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -69,6 +69,8 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .rc_smoothing_input_type = RC_SMOOTHING_INPUT_BIQUAD,
         .rc_smoothing_derivative_type = RC_SMOOTHING_DERIVATIVE_BIQUAD,
         .rc_smoothing_auto_factor = 10,
+        .srxlv2_unit_id = 1,
+        .srxlv2_baud_rate = 1,
     );
 
 #ifdef RX_CHANNELS_TAER

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -61,6 +61,9 @@ typedef struct rxConfig_s {
     uint8_t rc_smoothing_derivative_type;   // Derivative filter type (0 = OFF, 1 = PT1, 2 = BIQUAD)
     uint8_t rc_smoothing_auto_factor;       // Used to adjust the "smoothness" determined by the auto cutoff calculations
     uint8_t rssi_src_frame_lpf_period;      // Period of the cutoff frequency for the source frame RSSI filter (in 0.1 s)
+
+    uint8_t srxlv2_unit_id;
+    uint8_t srxlv2_baud_rate;
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -58,6 +58,7 @@
 #include "rx/fport.h"
 #include "rx/sbus.h"
 #include "rx/spektrum.h"
+#include "rx/srxlv2.h"
 #include "rx/sumd.h"
 #include "rx/sumh.h"
 #include "rx/msp.h"
@@ -183,6 +184,11 @@ bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
 {
     bool enabled = false;
     switch (rxConfig->serialrx_provider) {
+#ifdef USE_SERIALRX_SRXLv2
+    case SERIALRX_SRXLv2:
+        enabled = srxlv2RxInit(rxConfig, rxRuntimeConfig);
+        break;
+#endif
 #ifdef USE_SERIALRX_SPEKTRUM
     case SERIALRX_SRXL:
     case SERIALRX_SPEKTRUM1024:

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -67,6 +67,7 @@ typedef enum {
     SERIALRX_TARGET_CUSTOM = 11,
     SERIALRX_FPORT = 12,
     SERIALRX_DJI_HDL_7MS = 13,
+    SERIALRX_SRXLv2 = 14,
 } SerialRXType;
 
 #define MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT          12

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -33,6 +33,8 @@
 #include "drivers/light_led.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
 
 #include "io/serial.h"
 
@@ -393,8 +395,11 @@ bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
         NULL,
         SPEKTRUM_BAUDRATE,
         portShared || srxlEnabled ? MODE_RXTX : MODE_RX,
-        (rxConfig->serialrx_inverted ? SERIAL_INVERTED : 0) | ((srxlEnabled || rxConfig->halfDuplex) ? SERIAL_BIDIR : 0)
+        (rxConfig->serialrx_inverted ? SERIAL_INVERTED : 0) |
+        ((srxlEnabled || rxConfig->halfDuplex) ? SERIAL_BIDIR : 0) |
+        (rxConfig->halfDuplex == 2 ? SERIAL_SWAP_RX_TX : 0)
         );
+
 #if defined(USE_TELEMETRY_SRXL)
     if (portShared) {
         telemetrySharedPort = serialPort;

--- a/src/main/rx/srxlv2.c
+++ b/src/main/rx/srxlv2.c
@@ -1,0 +1,637 @@
+#include "platform.h"
+
+#include "common/crc.h"
+#include "common/maths.h"
+#include "common/streambuf.h"
+
+#include "drivers/exti.h"
+#include "drivers/nvic.h"
+#include "drivers/time.h"
+
+#include "io/serial.h"
+
+#include "rx/srxlv2.h"
+#include "rx/srxlv2_types.h"
+#include "io/spektrum_vtx_control.h"
+
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
+
+#include <string.h>
+
+#ifndef SRXLv2_DEBUG
+#define SRXLv2_DEBUG 0
+#endif
+
+#if SRXLv2_DEBUG
+void cliPrintf(const char *format, ...);
+#define DEBUG(format, ...) cliPrintf(format, __VA_ARGS__)
+#else
+#define DEBUG(...)
+#endif
+
+#define USE_SERIALRX_SRXLv2
+#ifdef USE_SERIALRX_SRXLv2
+
+#define SRXLv2_MAX_CHANNELS             32
+#define SRXLv2_TIME_BETWEEN_FRAMES_US   11000 // 5500 for DSMR
+#define SRXLv2_CHANNEL_SHIFT            5
+#define SRXLv2_CHANNEL_CENTER           0x8000
+
+#define SRXLv2_PORT_BAUDRATE_DEFAULT    115200
+#define SRXLv2_PORT_BAUDRATE_HIGH       400000
+#define SRXLv2_PORT_OPTIONS             (SERIAL_STOPBITS_1 | SERIAL_PARITY_NO | SERIAL_BIDIR)
+#define SRXLv2_PORT_MODE                MODE_RXTX
+
+#define SRXLv2_REPLY_QUIESCENCE         (2 * 10 * 1000000 / SRXLv2_PORT_BAUDRATE_DEFAULT) /*2 * (last_idle_timestamp - last_receive_timestamp)*/
+
+#define SRXLv2_ID                       0xA6
+#define SRXLv2_MAX_PACKET_LENGTH        80
+#define SRXLv2_DEVICE_ID_BROADCAST      0xFF
+
+#define SRXLv2_FRAME_TIMEOUT_US         50000
+
+#define SRXLv2_LISTEN_FOR_ACTIVITY_TIMEOUT 50000
+#define SRXLv2_SEND_HANDSHAKE_TIMEOUT 50000
+#define SRXLv2_LISTEN_FOR_HANDSHAKE_TIMEOUT 200000
+
+
+static uint8_t unit_id = 0;
+static uint8_t baud_rate = 0;
+
+static srxlv2State state = Disabled;
+static volatile uint32_t timeout_timestamp = 0;
+static volatile uint32_t full_timeout_timestamp = 0;
+static volatile uint32_t last_receive_timestamp = 0;
+static volatile uint32_t last_valid_packet_timestamp = 0;
+
+static volatile uint8_t read_buffer[2 * SRXLv2_MAX_PACKET_LENGTH];
+static volatile uint8_t read_buffer_idx = 0;
+static volatile uint8_t read_buffer_read_idx = 0;
+static uint8_t write_buffer[SRXLv2_MAX_PACKET_LENGTH];
+static uint8_t write_buffer_idx = 0;
+
+static serialPort_t *serialPort;
+
+static uint8_t bus_master_device_id = 0xFF;
+static bool telemetry_requested = false;
+
+static uint8_t telemetryFrame[22];
+
+uint8_t global_result = 0;
+bool srxlv2ProcessHandshake(const srxlv2Header* header, const srxlv2HandshakeSubHeader* handshake)
+{
+    if (handshake->destination_device_id == Broadcast) {
+        DEBUG("broadcast handshake from %x\r\n", handshake->source_device_id);
+        bus_master_device_id = handshake->source_device_id;
+
+        if (handshake->baud_supported == 1) {
+            serialPort->vTable->serialSetBaudRate(serialPort, SRXLv2_PORT_BAUDRATE_HIGH);
+            DEBUG("switching to %d baud\r\n", SRXLv2_PORT_BAUDRATE_HIGH);
+        }
+
+        state = Running;
+
+        return true;
+    }
+
+    if (((handshake->destination_device_id >> 4) & 0xF) != FlightController ||
+        (handshake->destination_device_id & 0xF) != unit_id) {
+        return true;
+    }
+
+    DEBUG("FC handshake from %x\r\n", handshake->source_device_id);
+
+    srxlv2HandshakeFrame response = {
+        .header = *header,
+        .payload = {
+            handshake->destination_device_id,
+            handshake->source_device_id,
+            /* priority */ 10,
+            /* baud_supported*/ baud_rate,
+            /* info */ 0,
+            U_ID_2
+        }
+    };
+
+    const uint16_t crc = crc16_ccitt_update(0, &response, sizeof(response) - 2);
+    response.crc_high = ((uint8_t *) &crc)[1];
+    response.crc_low = ((uint8_t *) &crc)[0];
+
+    srxlv2RxWriteData(&response, sizeof(response));
+
+    return true;
+}
+
+void srxlv2ProcessChannelData(const srxlv2ChannelDataHeader* channel_data, rxRuntimeConfig_t *rxRuntimeConfig) {
+    if (channel_data->rssi >= 0) {
+        const int rssi_percent = channel_data->rssi;
+        setRssi(scaleRange(rssi_percent, 0, 100, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_PROTOCOL);
+    } else {
+        const int rssi_dbm = channel_data->rssi;
+        (void) rssi_dbm;
+        // @todo come up with a scheme to scale power values to 0-1023 range
+        setRssi(RSSI_MAX_VALUE / 2, RSSI_SOURCE_RX_PROTOCOL);
+    }
+
+    if (channel_data->rssi == 0) {
+        global_result = RX_FRAME_FAILSAFE;
+    } else {
+        global_result = RX_FRAME_COMPLETE;
+    }
+
+    const uint16_t *frame_channels = (const uint16_t *) (channel_data + 1);
+
+    if (channel_data->channel_mask.u8.channels_0_7) {
+        for (size_t i = 0; i < 8; ++i) {
+            if (channel_data->channel_mask.u8.channels_0_7 >> i & 1) {
+                rxRuntimeConfig->channelData[i] = *frame_channels++;
+            }
+        }
+    }
+
+    if (channel_data->channel_mask.u8.channels_8_15) {
+        for (size_t i = 0; i < 8; ++i) {
+            if (channel_data->channel_mask.u8.channels_8_15 >> i & 1) {
+                rxRuntimeConfig->channelData[8 + i] = *frame_channels++;
+            }
+        }
+    }
+
+    if (channel_data->channel_mask.u8.channels_16_23) {
+        for (size_t i = 0; i < 8; ++i) {
+            if (channel_data->channel_mask.u8.channels_16_23 >> i & 1) {
+                rxRuntimeConfig->channelData[16 + i] = *frame_channels++;
+            }
+        }
+    }
+
+    if (channel_data->channel_mask.u8.channels_24_31) {
+        for (size_t i = 0; i < 8; ++i) {
+            if (channel_data->channel_mask.u8.channels_24_31 >> i & 1) {
+                rxRuntimeConfig->channelData[24 + i] = *frame_channels++;
+            }
+        }
+    }
+
+    // DEBUG("channel data: %d %d %x\r\n",
+    //     channel_data_header->rssi, channel_data_header->frame_losses, channel_data_header->channel_mask.u32);
+}
+
+bool srxlv2ProcessControlData(const srxlv2ControlDataSubHeader* control_data, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    const uint8_t own_id = FlightController << 4 | unit_id;
+    if (control_data->reply_id == own_id) {
+        telemetry_requested = true;
+//        DEBUG("command: %x reply_id: %x own_id: %x\r\n", control_data->command, control_data->reply_id, own_id);
+    }
+
+    switch (control_data->command) {
+        case ChannelData: {
+            srxlv2ProcessChannelData((const srxlv2ChannelDataHeader *) (control_data + 1), rxRuntimeConfig);
+        } break;
+
+        case FailsafeChannelData: {
+            srxlv2ProcessChannelData((const srxlv2ChannelDataHeader *) (control_data + 1), rxRuntimeConfig);
+            setRssiDirect(0, RSSI_SOURCE_RX_PROTOCOL);
+            // DEBUG("fs channel data\r\n");
+        } break;
+
+        case VTXData: {
+            #if defined(USE_SPEKTRUM_VTX_CONTROL) && defined(USE_VTX_COMMON)
+            //DEBUG("vtx data\r\n");
+            srxlv2VtxData *vtxData = (srxlv2VtxData*)(control_data + 1);
+            //DEBUG("vtx band: %x\r\n", vtxData->band);
+            //DEBUG("vtx channel: %x\r\n", vtxData->channel);
+            //DEBUG("vtx pit: %x\r\n", vtxData->pit);
+            //DEBUG("vtx power: %x\r\n", vtxData->power);
+            //DEBUG("vtx powerDec: %x\r\n", vtxData->powerDec);
+            //DEBUG("vtx region: %x\r\n", vtxData->region);
+            // Pack data as it was used before srxlv2 to use existing functions.
+            // Get the VTX control bytes in a frame
+            uint32_t vtxControl =   (0xE0 << 24) | (0xE0 << 8) |
+                                    ((vtxData->band & 0x07) << 21) |
+                                    ((vtxData->channel & 0x0F) << 16) |
+                                    ((vtxData->pit & 0x01) << 4) |
+                                    ((vtxData->region & 0x01) << 3) |
+                                    ((vtxData->power & 0x07));
+            spektrumHandleVtxControl(vtxControl);
+            #endif
+        } break;
+    }
+
+    return true;
+}
+
+bool srxlv2ProcessPacket(const srxlv2Header* header, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    switch (header->packet_type) {
+    case Handshake: return srxlv2ProcessHandshake(header, (const srxlv2HandshakeSubHeader *) (header + 1));
+    case ControlData: return srxlv2ProcessControlData((const srxlv2ControlDataSubHeader *) (header + 1), rxRuntimeConfig);
+    default: break;
+    }
+
+    return false;
+}
+
+// @note assumes packet is fully there
+void srxlv2Process(rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    union {
+        uint8_t local_buffer[SRXLv2_MAX_PACKET_LENGTH];
+        srxlv2Header header;
+    } anonymous;
+
+    uint32_t bytes_copied = 0;
+    while (bytes_copied < sizeof(srxlv2Header)) {
+        anonymous.local_buffer[bytes_copied++] = read_buffer[read_buffer_read_idx++];
+
+        if (read_buffer_read_idx == sizeof(read_buffer)) {
+            read_buffer_read_idx = 0;
+        }
+    }
+
+    // @todo find out why it happens
+    if (anonymous.header.id != SRXLv2_ID) {
+      read_buffer_read_idx = read_buffer_idx;
+      global_result = RX_FRAME_DROPPED;
+      return;
+    }
+
+    //    cliPrintf("> %d %d %x\r\n", read_buffer_idx, read_buffer_read_idx, anonymous.header.id);
+
+    const uint8_t bytes_to_read = anonymous.header.length;
+    if (bytes_to_read > sizeof(anonymous)) {
+      read_buffer_read_idx = read_buffer_idx;
+      global_result = RX_FRAME_DROPPED;
+      return;
+    }
+
+    while (bytes_copied < bytes_to_read) {
+        anonymous.local_buffer[bytes_copied++] = read_buffer[read_buffer_read_idx++];
+
+        if (read_buffer_read_idx == sizeof(read_buffer)) {
+            read_buffer_read_idx = 0;
+        }
+    }
+
+    //    cliPrintf("- %d %d %x\r\n", read_buffer_idx, read_buffer_read_idx, anonymous.header.id);
+
+    if (anonymous.header.id != SRXLv2_ID ||
+        bytes_copied != anonymous.header.length) {
+        read_buffer_read_idx = read_buffer_idx;
+        global_result = RX_FRAME_DROPPED;
+        return;
+    }
+
+    const uint16_t calculated_crc = crc16_ccitt_update(0, anonymous.local_buffer, anonymous.header.length - 2);
+    //    cliPrintf("< %d %d %x %x\r\n", read_buffer_idx, read_buffer_read_idx, anonymous.header.id, calculated_crc);
+
+    const uint16_t received_crc =
+        (anonymous.local_buffer[anonymous.header.length - 2] << 8) |
+        (anonymous.local_buffer[anonymous.header.length - 1]);
+
+    if (calculated_crc != received_crc) {
+        read_buffer_read_idx = read_buffer_idx;
+        global_result = RX_FRAME_DROPPED;
+        //        DEBUG("crc mismatch %x vs %x\r\n", calculated_crc, received_crc);
+        return;
+    }
+
+    //Packet is valid only after ID and CRC check out
+    last_valid_packet_timestamp = micros();
+
+    if (srxlv2ProcessPacket(&anonymous.header, rxRuntimeConfig)) {
+        return;
+    }
+
+    // @todo reset
+    //    DEBUG("could not parse packet: %x\r\n", anonymous.header.packet_type);
+    global_result = RX_FRAME_DROPPED;
+}
+
+
+static void srxlv2DataReceive(uint16_t character, void *data)
+{
+    UNUSED(data);
+
+    last_receive_timestamp = microsISR();
+
+    // circular buffer depleted and waiting for sync character
+    if (read_buffer_read_idx == read_buffer_idx && character != SRXLv2_ID) {
+        return;
+    }
+
+    read_buffer[read_buffer_idx] = character;
+    read_buffer_idx = read_buffer_idx + 1;
+    if (read_buffer_idx == sizeof(read_buffer)) {
+      read_buffer_idx = 0;
+    }
+}
+
+static volatile uint32_t last_idle_timestamp = 0;
+
+static void srxlv2Idle()
+{
+    last_idle_timestamp = microsISR();
+}
+
+uint32_t autobaud_timeout = 0;
+static uint8_t srxlv2FrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    UNUSED(rxRuntimeConfig);
+
+    global_result = RX_FRAME_PENDING;
+
+    const uint32_t bytes_available =
+        read_buffer_read_idx > read_buffer_idx
+            ? read_buffer_idx + (uint8_t) sizeof(read_buffer) - read_buffer_read_idx
+            : read_buffer_idx - read_buffer_read_idx;
+
+    if (bytes_available >= sizeof(srxlv2Header)) {
+        union {
+            uint8_t local_buffer[sizeof(srxlv2Header)];
+            srxlv2Header header;
+        } anonymous;
+
+        uint32_t bytes_copied = 0;
+        uint32_t index = read_buffer_read_idx;
+        while (bytes_copied < sizeof(srxlv2Header)) {
+            anonymous.local_buffer[bytes_copied++] = read_buffer[index++];
+
+            if (index == sizeof(read_buffer)) {
+                index = 0;
+            }
+        }
+
+        if (anonymous.header.id != SRXLv2_ID) {
+            // @todo reset
+          //            DEBUG("invalid header id: %x\r\n", anonymous.header.id);
+            // @todo maybe scan data for SRXLv2_ID
+            read_buffer_read_idx = read_buffer_idx;
+            return RX_FRAME_DROPPED;
+        }
+
+        if (bytes_available < anonymous.header.length) {
+            return RX_FRAME_PENDING;
+        }
+
+        //        cliPrintf("id %x %x %x\r\n", anonymous.header.id, anonymous.header.packet_type, anonymous.header.length);
+
+        srxlv2Process(rxRuntimeConfig);
+    }
+
+    uint8_t result = global_result;
+
+    const uint32_t now = micros();
+
+    switch (state) {
+    case Disabled: break;
+
+    case ListenForActivity: {
+        // activity detected
+        if (last_valid_packet_timestamp != 0) {
+            // as ListenForActivity is done at default baud-rate, we don't need to change anything
+            // @todo if there were non-handshake packets - go to running,
+            // if there were - go to either Send Handshake or Listen For Handshake
+            state = Running;
+        } else if (last_idle_timestamp > last_receive_timestamp) {
+            if (baud_rate != 0) {
+                uint32_t currentBaud = serialGetBaudRate(serialPort);
+
+                if(currentBaud == SRXLv2_PORT_BAUDRATE_DEFAULT)
+                    serialPort->vTable->serialSetBaudRate(serialPort, SRXLv2_PORT_BAUDRATE_HIGH);
+                else
+                    serialPort->vTable->serialSetBaudRate(serialPort, SRXLv2_PORT_BAUDRATE_DEFAULT);
+            }
+        } else if (now >= timeout_timestamp) {
+            // @todo if there was activity - detect baudrate and ListenForHandshake
+
+            if (unit_id == 0) {
+                state = SendHandshake;
+                timeout_timestamp = now + SRXLv2_SEND_HANDSHAKE_TIMEOUT;
+                full_timeout_timestamp = now + SRXLv2_LISTEN_FOR_HANDSHAKE_TIMEOUT;
+            } else {
+                state = ListenForHandshake;
+                timeout_timestamp = now + SRXLv2_LISTEN_FOR_HANDSHAKE_TIMEOUT;
+            }
+        }
+    } break;
+
+    case SendHandshake: {
+        if (now >= timeout_timestamp) {
+            // @todo set another timeout for 50ms tries
+            // fill write buffer with handshake frame
+            result |= RX_FRAME_PROCESSING_REQUIRED;
+        }
+        // else if (handshake_received) {
+        //  set baud rate accordingly
+        //  state = Running
+        // }
+
+        if (now >= full_timeout_timestamp) {
+            serialPort->vTable->serialSetBaudRate(serialPort, SRXLv2_PORT_BAUDRATE_DEFAULT);
+            //DEBUG("case SendHandshake: switching to %d baud\r\n", SRXLv2_PORT_BAUDRATE_DEFAULT);
+            timeout_timestamp = now + SRXLv2_LISTEN_FOR_ACTIVITY_TIMEOUT;
+            result = (result & ~RX_FRAME_PENDING) | RX_FRAME_FAILSAFE;
+
+            state = ListenForActivity;
+            last_receive_timestamp = 0;
+        }
+    } break;
+
+    case ListenForHandshake: {
+        if (now >= timeout_timestamp)  {
+            serialPort->vTable->serialSetBaudRate(serialPort, SRXLv2_PORT_BAUDRATE_DEFAULT);
+            //DEBUG("case ListenForHandshake: switching to %d baud\r\n", SRXLv2_PORT_BAUDRATE_DEFAULT);
+            timeout_timestamp = now + SRXLv2_LISTEN_FOR_ACTIVITY_TIMEOUT;
+            result = (result & ~RX_FRAME_PENDING) | RX_FRAME_FAILSAFE;
+
+            state = ListenForActivity;
+            last_receive_timestamp = 0;
+        }
+    } break;
+
+    case Running: {
+        // frame timed out, reset state
+        if (last_valid_packet_timestamp < now && now - last_valid_packet_timestamp >= SRXLv2_FRAME_TIMEOUT_US) {
+            serialPort->vTable->serialSetBaudRate(serialPort, SRXLv2_PORT_BAUDRATE_DEFAULT);
+            //DEBUG("case Running: switching to %d baud: %d %d\r\n", SRXLv2_PORT_BAUDRATE_DEFAULT, now, last_valid_packet_timestamp);
+            timeout_timestamp = now + SRXLv2_LISTEN_FOR_ACTIVITY_TIMEOUT;
+            result = (result & ~RX_FRAME_PENDING) | RX_FRAME_FAILSAFE;
+
+            state = ListenForActivity;
+            last_receive_timestamp = 0;
+            last_valid_packet_timestamp = 0;
+        }
+    } break;
+    };
+
+    if (write_buffer_idx) {
+        result |= RX_FRAME_PROCESSING_REQUIRED;
+    }
+
+    return result;
+}
+
+static bool srxlv2ProcessFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    UNUSED(rxRuntimeConfig);
+
+    if (write_buffer_idx == 0) {
+        return true;
+    }
+
+    const uint32_t now = micros();
+
+    if (last_idle_timestamp > last_receive_timestamp) {
+        // time sufficient for at least 2 characters has passed
+        if (now - last_receive_timestamp > SRXLv2_REPLY_QUIESCENCE) {
+            serialWriteBuf(serialPort, write_buffer, write_buffer_idx);
+            write_buffer_idx = 0;
+        } else {
+          //            DEBUG("not enough time to send 2 characters passed yet, %d us since last receive, %d required\r\n", now - last_receive_timestamp, SRXLv2_REPLY_QUIESCENCE);
+        }
+    } else {
+        // DEBUG("still receiving a frame, %d %d\r\n", last_idle_timestamp, last_receive_timestamp);
+    }
+
+    return true;
+}
+
+static uint16_t srxlv2ReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t channel_idx)
+{
+    if (channel_idx >= rxRuntimeConfig->channelCount) {
+        return 0;
+    }
+
+    return 988 + ((rxRuntimeConfig->channelData[channel_idx] >> SRXLv2_CHANNEL_SHIFT) >> 1);
+}
+
+void srxlv2RxWriteData(const void *data, int len)
+{
+    len = MIN(len, (int)sizeof(write_buffer));
+    memcpy(write_buffer, data, len);
+    write_buffer_idx = len;
+}
+
+bool srxlv2RxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    static uint16_t channelData[SRXLv2_MAX_CHANNELS];
+    for (size_t i = 0; i < SRXLv2_MAX_CHANNELS; ++i) {
+        channelData[i] = SRXLv2_CHANNEL_CENTER;
+    }
+
+    unit_id = rxConfig->srxlv2_unit_id;
+    baud_rate = rxConfig->srxlv2_baud_rate;
+
+    rxRuntimeConfig->channelData = channelData;
+    rxRuntimeConfig->channelCount = SRXLv2_MAX_CHANNELS;
+    rxRuntimeConfig->rxRefreshRate = SRXLv2_TIME_BETWEEN_FRAMES_US;
+
+    rxRuntimeConfig->rcReadRawFn = srxlv2ReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = srxlv2FrameStatus;
+    rxRuntimeConfig->rcProcessFrameFn = srxlv2ProcessFrame;
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+    portOptions_e options = SRXLv2_PORT_OPTIONS;
+    if (rxConfig->serialrx_inverted) {
+        options |= SERIAL_INVERTED;
+    }
+    if (rxConfig->halfDuplex) {
+        options |= SERIAL_BIDIR;
+    }
+    if (rxConfig->halfDuplex == 2) {
+        options |= SERIAL_SWAP_RX_TX;
+    }
+
+    serialPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, srxlv2DataReceive,
+        NULL, SRXLv2_PORT_BAUDRATE_DEFAULT, SRXLv2_PORT_MODE, options);
+
+    if (serialPort) {
+        serialPort->idleCallback = srxlv2Idle;
+
+        state = ListenForActivity;
+        timeout_timestamp = micros() + SRXLv2_LISTEN_FOR_ACTIVITY_TIMEOUT;
+
+        if (rssiSource == RSSI_SOURCE_NONE) {
+            rssiSource = RSSI_SOURCE_RX_PROTOCOL;
+        }
+    }
+
+    /* handshake protocol
+    1. listen for 50ms for serial activity and go to State::Running if found, autobaud may be necessary
+    2. if srxlv2_unit_id = 0:
+            send a Handshake with destination_device_id = 0 every 50ms for at least 200ms
+        else:
+            listen for Handshake for at least 200ms
+    3.  respond to Handshake as currently implemented in process if rePst received
+    4.  respond to broadcast Handshake
+    */
+
+    // if 50ms with not activity, go to default baudrate and to step 1
+
+    return serialPort;
+}
+
+bool srxlv2RxIsActive(void)
+{
+    return serialPort;
+}
+
+bool srxlv2TelemetryRequested(void)
+{
+    return telemetry_requested;
+}
+
+void srxlv2InitializeFrame(sbuf_t *dst)
+{
+    dst->ptr = telemetryFrame;
+    dst->end = ARRAYEND(telemetryFrame);
+
+    sbufWriteU8(dst, SRXLv2_ID);
+    sbufWriteU8(dst, TelemetrySensorData);
+    sbufWriteU8(dst, ARRAYLEN(telemetryFrame));
+    sbufWriteU8(dst, bus_master_device_id);
+}
+
+void srxlv2FinalizeFrame(sbuf_t *dst)
+{
+  const uint16_t crc = crc16_ccitt_update(0, telemetryFrame, sbufPtr(dst) - telemetryFrame);
+  sbufWriteU16BigEndian(dst, crc);
+
+  sbufSwitchToReader(dst, telemetryFrame);
+  srxlv2RxWriteData(sbufPtr(dst), sbufBytesRemaining(dst));
+  telemetry_requested = false;
+}
+
+void srxlv2Bind(void)
+{
+    const size_t length = sizeof(srxlv2BindInfoFrame);
+
+    srxlv2BindInfoFrame bind = {
+        .header = {
+            .id = SRXLv2_ID,
+            .packet_type = BindInfo,
+            .length = length
+        },
+        .payload = {
+            .request = EnterBindMode,
+            .device_id = bus_master_device_id,
+            .bind_type = DMSX_11ms,
+            .options = SRXL_BIND_OPT_TELEM_TX_ENABLE | SRXL_BIND_OPT_BIND_TX_ENABLE,
+        }
+    };
+
+    const uint16_t crc = crc16_ccitt_update(0, &bind, length - 2);
+    bind.crc_high = ((uint8_t *) &crc)[1];
+    bind.crc_low = ((uint8_t *) &crc)[0];
+
+    srxlv2RxWriteData(&bind, length);
+}
+
+#endif

--- a/src/main/rx/srxlv2.h
+++ b/src/main/rx/srxlv2.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pg/rx.h"
+
+#include "rx/rx.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+
+struct sbuf_s;
+
+bool srxlv2RxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
+bool srxlv2RxIsActive(void);
+void srxlv2RxWriteData(const void *data, int len);
+bool srxlv2TelemetryRequested(void);
+void srxlv2InitializeFrame(struct sbuf_s *dst);
+void srxlv2FinalizeFrame(struct sbuf_s *dst);
+void srxlv2Bind(void);

--- a/src/main/rx/srxlv2_types.h
+++ b/src/main/rx/srxlv2_types.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#define PACKED __attribute__((packed))
+
+typedef enum {
+    Disabled,
+    ListenForActivity,
+    SendHandshake,
+    ListenForHandshake,
+    Running
+} srxlv2State;
+
+typedef enum {
+    Handshake = 0x21,
+    BindInfo = 0x41,
+    ParameterConfiguration = 0x50,
+    SignalQuality = 0x55,
+    TelemetrySensorData = 0x80,
+    ControlData = 0xCD,
+} srxlv2PacketType;
+
+typedef struct {
+    uint8_t id;
+    uint8_t packet_type;
+    uint8_t length;
+} PACKED srxlv2Header;
+
+typedef struct {
+    uint8_t source_device_id;
+    uint8_t destination_device_id;
+    uint8_t priority;
+    uint8_t baud_supported;
+    uint8_t info;
+    uint32_t unique_id;
+} PACKED srxlv2HandshakeSubHeader;
+
+typedef struct {
+    uint8_t command;
+    uint8_t reply_id;
+} PACKED srxlv2ControlDataSubHeader;
+
+typedef enum {
+    ChannelData = 0x00,
+    FailsafeChannelData = 0x01,
+    VTXData = 0x02,
+} srxlv2ControlDataCommand;
+
+typedef struct {
+    int8_t rssi;
+    uint16_t frame_losses;
+    union {
+        struct {
+            uint8_t channels_0_7;
+            uint8_t channels_8_15;
+            uint8_t channels_16_23;
+            uint8_t channels_24_31;
+        } u8;
+        uint32_t u32;
+    } channel_mask;
+} PACKED srxlv2ChannelDataHeader;
+
+typedef enum {
+    NoDevice = 0,
+    RemoteReceiver = 1,
+    Receiver = 2,
+    FlightController = 3,
+    ESC = 4,
+    Reserved = 5,
+    SRXLServo = 6,
+    SRXLServo_2 = 7,
+    VTX = 8,
+} srxlV2DeviceType;
+
+typedef enum {
+    FlightControllerDefault = 0x30,
+    FlightControllerMax = 0x3F,
+    Broadcast = 0xFF,
+} srxlv2DeviceId;
+
+typedef struct {
+    srxlv2Header header;
+    srxlv2HandshakeSubHeader payload;
+    uint8_t crc_high;
+    uint8_t crc_low;
+} PACKED srxlv2HandshakeFrame;
+
+typedef enum {
+    EnterBindMode = 0xEB,
+    RequestBindStatus = 0xB5,
+    BoundDataReport = 0xDB,
+    SetBindInfo = 0x5B,
+} srxlv2BindRequest;
+
+typedef enum {
+    NotBound = 0x0,
+    DSM2_1024_22ms = 0x01,
+    DSM2_1024_MC24 = 0x02,
+    DMS2_2048_11ms = 0x12,
+    DMSX_22ms = 0xA2,
+    DMSX_11ms = 0xB2,
+    Surface_DSM2_16_5ms = 0x63,
+    DSMR_11ms_22ms = 0xE2,
+    DSMR_5_5ms = 0xE4,
+} srxlv2BindType;
+
+// Bit masks for Options byte
+#define SRXL_BIND_OPT_NONE              (0x00)
+#define SRXL_BIND_OPT_TELEM_TX_ENABLE   (0x01)  // Set if this device should be enabled as the current telemetry device to tx over RF
+#define SRXL_BIND_OPT_BIND_TX_ENABLE    (0x02)  // Set if this device should reply to a bind request with a Discover packet over RF
+
+typedef struct {
+  uint8_t request;
+  uint8_t device_id;
+  uint8_t bind_type;
+  uint8_t options;
+  uint64_t guid;
+  uint32_t uid;
+} PACKED srxlv2BindInfoPayload;
+
+typedef struct {
+  srxlv2Header header;
+  srxlv2BindInfoPayload payload;
+  uint8_t crc_high;
+  uint8_t crc_low;
+} PACKED srxlv2BindInfoFrame;
+
+// VTX Data
+typedef struct
+{
+  uint8_t   band;     // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A)
+  uint8_t   channel;  // VTX Channel (0-7)
+  uint8_t   pit;      // Pit/Race mode (0 = Race, 1 = Pit). Race = (normal operating) mode. Pit = (reduced power) mode.
+  uint8_t   power;    // VTX Power (0 = Off, 1 = 1mw to 14mW, 2 = 15mW to 25mW, 3 = 26mW to 99mW, 4 = 100mW to 299mW, 5 = 300mW to 600mW, 6 = 601mW+, 7 = manual control)
+  uint16_t  powerDec; // VTX Power as a decimal 1mw/unit
+  uint8_t   region;   // Region (0 = USA, 1 = EU)
+} PACKED srxlv2VtxData;
+
+#undef PACKED

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -175,6 +175,10 @@
 #define USE_SERIALRX_SPEKTRUM   // SRXL, DSM2 and DSMX protocol
 #define USE_SERIALRX_SUMD       // Graupner Hott protocol
 
+#ifndef STM32F3 //Not enough space for F3 support
+#define USE_SERIALRX_SRXLv2     // Spektrum SRXL2 protocol
+#endif // STM32F3
+
 #if (FLASH_SIZE > 128)
 #define PID_PROFILE_COUNT 3
 #define CONTROL_RATE_PROFILE_COUNT  6

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -54,6 +54,7 @@
 
 #include "rx/rx.h"
 #include "rx/spektrum.h"
+#include "rx/srxlv2.h"
 #include "io/spektrum_vtx_control.h"
 
 #include "sensors/battery.h"
@@ -83,24 +84,33 @@
 #define SRXL_FRAMETYPE_GPS_STAT     0x17
 
 static bool srxlTelemetryEnabled;
+static bool srxlv2 = false;
 static uint8_t srxlFrame[SRXL_FRAME_SIZE_MAX];
 
 static void srxlInitializeFrame(sbuf_t *dst)
 {
-    dst->ptr = srxlFrame;
-    dst->end = ARRAYEND(srxlFrame);
+    if (srxlv2) {
+      srxlv2InitializeFrame(dst);
+    } else {
+        dst->ptr = srxlFrame;
+        dst->end = ARRAYEND(srxlFrame);
 
-    sbufWriteU8(dst, SRXL_ADDRESS_FIRST);
-    sbufWriteU8(dst, SRXL_ADDRESS_SECOND);
-    sbufWriteU8(dst, SRXL_PACKET_LENGTH);
+        sbufWriteU8(dst, SRXL_ADDRESS_FIRST);
+        sbufWriteU8(dst, SRXL_ADDRESS_SECOND);
+        sbufWriteU8(dst, SRXL_PACKET_LENGTH);
+    }
 }
 
 static void srxlFinalize(sbuf_t *dst)
 {
-    crc16_ccitt_sbuf_append(dst, &srxlFrame[3]); // start at byte 3, since CRC does not include device address and packet length
-    sbufSwitchToReader(dst, srxlFrame);
-    // write the telemetry frame to the receiver.
-    srxlRxWriteTelemetryData(sbufPtr(dst), sbufBytesRemaining(dst));
+    if (srxlv2) {
+      srxlv2FinalizeFrame(dst);
+    } else {
+        crc16_ccitt_sbuf_append(dst, &srxlFrame[3]); // start at byte 3, since CRC does not include device address and packet length
+        sbufSwitchToReader(dst, srxlFrame);
+        // write the telemetry frame to the receiver.
+        srxlRxWriteTelemetryData(sbufPtr(dst), sbufBytesRemaining(dst));
+    }
 }
 
 /*
@@ -757,7 +767,16 @@ void initSrxlTelemetry(void)
 {
     // check if there is a serial port open for SRXL telemetry (ie opened by the SRXL RX)
     // and feature is enabled, if so, set SRXL telemetry enabled
-    srxlTelemetryEnabled = srxlRxIsActive();
+  if (srxlRxIsActive()) {
+    srxlTelemetryEnabled = true;
+    srxlv2 = false;
+  } else if (srxlv2RxIsActive()) {
+    srxlTelemetryEnabled = true;
+    srxlv2 = true;
+  } else {
+    srxlTelemetryEnabled = false;
+    srxlv2 = false;
+  }
  }
 
 bool checkSrxlTelemetryState(void)
@@ -770,8 +789,14 @@ bool checkSrxlTelemetryState(void)
  */
 void handleSrxlTelemetry(timeUs_t currentTimeUs)
 {
-  if (srxlTelemetryBufferEmpty()) {
-      processSrxl(currentTimeUs);
+  if (srxlv2) {
+      if (srxlv2TelemetryRequested()) {
+          processSrxl(currentTimeUs);
+      }
+  } else {
+      if (srxlTelemetryBufferEmpty()) {
+          processSrxl(currentTimeUs);
+      }
   }
 }
 #endif


### PR DESCRIPTION
This commit includes SRXL2 support for F4/F7 targets, as there is not enough memory to include F3 support unless other serial protocols are disabled.
In addition, there is support included for a third option on "serialrx_halfduplex" which allows the user to use a UART RX pin in F3 and F7 FC's. Please let me know if this should be included in a separate commit/merge request instead. It was included in this development in order to test on some minimal FC's that only had an exposed RX pin. Fixes #7469 

A lot of this was made possible by @DieHertz , so I think most of it follows betaflight code guidelines. I have also made some cleanup/fixes to the code though, so I may have missed some formatting guidelines. I'm open to any suggestions for corrections!