### PR TITLE
Fix default axis values for arbitrary gyro alignment

### DIFF
--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -71,20 +71,32 @@ PG_REGISTER_ARRAY_WITH_RESET_FN(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDevic
 void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
 {
     devconf[0].index = 0;
+    sensorAlignment_t customAlignment1 = CUSTOM_ALIGN_CW0_DEG;
+#ifdef GYRO_1_CUSTOM_ALIGN
+    customAlignment1 = GYRO_1_CUSTOM_ALIGN;
+#else
+    buildAlignmentFromStandardAlignment(&customAlignment1, GYRO_1_ALIGN);
+#endif // GYRO_1_CUSTOM_ALIGN
 
     // All multi-gyro boards use SPI based gyros.
 #ifdef USE_SPI_GYRO
-    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, GYRO_1_CUSTOM_ALIGN);
+    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, customAlignment1);
 #ifdef USE_MULTI_GYRO
     devconf[1].index = 1;
-    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), GYRO_2_ALIGN, GYRO_2_CUSTOM_ALIGN);
-#endif
-#endif
+    sensorAlignment_t customAlignment2 = CUSTOM_ALIGN_CW0_DEG;
+#ifdef GYRO_2_CUSTOM_ALIGN
+    customAlignment2 = GYRO_2_CUSTOM_ALIGN;
+#else
+    buildAlignmentFromStandardAlignment(&customAlignment2, GYRO_2_ALIGN);
+#endif // GYRO_2_CUSTOM_ALIGN
+    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), GYRO_2_ALIGN, customAlignment2);
+#endif // USE_MULTI_GYRO
+#endif // USE_SPI_GYRO
 
     // I2C gyros appear as a sole gyro in single gyro boards.
 #if defined(USE_I2C_GYRO) && !defined(USE_MULTI_GYRO)
     devconf[0].i2cBus = I2C_DEV_TO_CFG(I2CINVALID); // XXX Not required?
-    gyroResetI2cDeviceConfig(&devconf[0], I2C_DEVICE, IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, GYRO_1_CUSTOM_ALIGN);
+    gyroResetI2cDeviceConfig(&devconf[0], I2C_DEVICE, IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, customAlignment1);
 #endif
 
 // Special treatment for very rare F3 targets with variants having either I2C or SPI acc/gyro chip; mark it for run time detection.

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -365,13 +365,10 @@
 #define GYRO_2_ALIGN            CW0_DEG
 #endif
 
-#if !defined(GYRO_1_CUSTOM_ALIGN)
-#define GYRO_1_CUSTOM_ALIGN            CUSTOM_ALIGN_CW0_DEG
-#endif
-
-#if !defined(GYRO_2_CUSTOM_ALIGN)
-#define GYRO_2_CUSTOM_ALIGN            CUSTOM_ALIGN_CW0_DEG
-#endif
+// Previously there was logic here to default GYRO_1_CUSTOM_ALIGN and GYRO_2_CUSTOM_ALIGN
+// to CUSTOM_ALIGN_CW0_DEG if they weren't defined in the target. The defaulting logic
+// has been moved to pg/gyrodev.c to set the custom alignment based on the sensor alignment
+// if a custom alignment is not applied in the target.
 
 #ifdef USE_VCP
 #ifndef USB_DETECT_PIN


### PR DESCRIPTION
Prevents clean installs from displaying the sensor alignment as changed values in the `diff`.

Sets the default values for the sensor alignment axes to match the selected sensor alignment. Previously the axis values defaulted to 0 so when the active value was set based on the sensor alignment these values would appear as changes in the `diff` even though they were actually the default values. Corrected the default values to be based on the selected sensor alignment default.
