### PR TITLE
[F7] Set DShot DMA buffer attribute to FAST_RAM_ZERO_INIT

### DIFF
--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -59,8 +59,10 @@ motorDevice_t *dshotPwmDevInit(const struct motorDevConfig_s *motorConfig, uint1
 #define PROSHOT_TELEMETRY_INPUT_LEN 8
 
 // For H7, DMA buffer is placed in a dedicated segment for coherency management
-#ifdef STM32H7
+#if defined(STM32H7)
 #define DSHOT_DMA_BUFFER_ATTRIBUTE DMA_RAM
+#elif defined(STM32F7)
+#define DSHOT_DMA_BUFFER_ATTRIBUTE FAST_RAM_ZERO_INIT
 #else
 #define DSHOT_DMA_BUFFER_ATTRIBUTE // None
 #endif


### PR DESCRIPTION
The buffer was originally a part of motorDmaOutput_s structure which resided in the FAST_RAM_ZERO_INIT(DTCM RAM). The buffer was separated from this structure as a part of the motor refactor #8534, for provisioning to use MPU for DMA buffer coherence management (like H7 do), but wasn’t properly attributed and caused F7 Dshot to malfunction (#8589).

In the future, DMA buffer coherence will be maintained by the MPU and the DShot buffer will be moved there to save the scarce DTCM resource.
