### PR TITLE
KakuteF4V2 config for tricopters

### DIFF
--- a/src/main/target/KAKUTEF4/KAKUTEF4V2TRI.mk
+++ b/src/main/target/KAKUTEF4/KAKUTEF4V2TRI.mk
@@ -1,0 +1,1 @@
+#KAKUTEF4V2TRI.mk file

--- a/src/main/target/KAKUTEF4/target.c
+++ b/src/main/target/KAKUTEF4/target.c
@@ -27,6 +27,7 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    #if !defined(KAKUTEF4V2TRI)
     #if defined(FLYWOOF405)
     DEF_TIM(TIM10, CH1, PB8, TIM_USE_PPM,   0, 0), // PPM IN
     DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0), // S1_OUT - DMA1_ST7
@@ -45,7 +46,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR, 0, 1), // S3_OUT - DMA1_ST6
     DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR, 0, 0), // S4_OUT - DMA1_ST1
     #endif
-    #if defined(KAKUTEF4V2)														   
+    #if defined(KAKUTEF4V2)
     DEF_TIM(TIM8, CH3, PC8, TIM_USE_LED,   0, 0), // LED_STRIP - DMA2_ST2
     #elif defined(FLYWOOF405)
     DEF_TIM(TIM1, CH2, PA9,  TIM_USE_PWM, 0, 0),     // FC CAM	
@@ -53,5 +54,15 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM5, CH1, PA0, TIM_USE_MOTOR, 0, 0), // S5_OUT - DMA1_ST2
     DEF_TIM(TIM8, CH3, PC8, TIM_USE_MOTOR, 0, 1), // S6_OUT - DMA2_ST4
     DEF_TIM(TIM5, CH2, PA1, TIM_USE_LED,   0, 0), // LED_STRIP - DMA1_ST4
+    #endif
+    #else // defined(KAKUTEF4V2TRI)
+    // Timer definition for tricopter on KakuteF4V2
+    // Swaps function of M4 and LED pads
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0), // S1_OUT - DMA1_ST7
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0), // S2_OUT - DMA1_ST2
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR, 0, 1), // S3_OUT - DMA1_ST6
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_SERVO, 0, 0), // S4_OUT - DMA2_ST2     LED pad on KakuteF4V2 used for tricopter tail servo
+
+    DEF_TIM(TIM5, CH3, PA2, TIM_USE_LED,   0, 0), // LED_STRIP - DMA1_ST0  M4 pad on KakuteF4V2
     #endif
 };

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -19,7 +19,7 @@
  */
 
 #pragma once
-#if defined(KAKUTEF4V2)
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI)
 #define TARGET_BOARD_IDENTIFIER "KTV2"
 #define USBD_PRODUCT_STRING "KakuteF4-V2"
 #elif defined(FLYWOOF405)
@@ -78,7 +78,7 @@
 #define USE_ACC_SPI_MPU6000								  
 #endif
 
-#if defined(KAKUTEF4V2) || defined(FLYWOOF405)       // There is invertor on RXD3(PB11), so PB10/PB11 can't be used as I2C2.
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI) ||defined(FLYWOOF405)  // There is inverter on RXD3(PB11), so PB10/PB11 can't be used as I2C2.
 #define USE_I2C          //No other I2C pins are  fanned out, So V1 don't support I2C  peripherals.
 #define USE_I2C_DEVICE_1
 #define I2C_DEVICE              (I2CDEV_1)
@@ -129,7 +129,7 @@
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 
-#if defined (KAKUTEF4V2) || defined(FLYWOOF405)               // Uart4 and Uart5 are fanned out on v2
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI) || defined(FLYWOOF405)  // Uart4 and Uart5 are fanned out on v2
 #define USE_UART4                // Uart4 can be used for GPS or  RunCam Split
 #define UART4_RX_PIN            PA1
 #define UART4_TX_PIN            PA0
@@ -186,7 +186,7 @@
 #define TARGET_IO_PORTC 0xffff
 #define TARGET_IO_PORTD        (BIT(2))
 
-#if defined (KAKUTEF4V2)
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI)
 #define USABLE_TIMER_CHANNEL_COUNT 6
 #define USED_TIMERS  ( TIM_N(2) | TIM_N(3) |  TIM_N(8))
 #elif defined(FLYWOOF405)

--- a/unified_targets/configs/KAKUTEF4V2TRI..config
+++ b/unified_targets/configs/KAKUTEF4V2TRI..config
@@ -1,0 +1,104 @@
+# Betaflight / STM32F405 (S405) 4.1.0 Jun 25 2019 / 10:41:09 (2a6e94d03) MSP API: 1.42
+
+board_name KAKUTEF4V2
+manufacturer_id HBRO
+
+# resources
+resource BEEPER 1 C09
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 A03
+resource MOTOR 4 C08
+resource PPM 1 C07
+resource LED_STRIP 1 A02
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource INVERTER 3 B15
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 B05
+resource LED 2 B04
+resource LED 3 B06
+resource SPI_SCK 1 A05
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 C07
+resource ADC_BATT 1 C03
+resource ADC_RSSI 1 C01
+resource ADC_CURR 1 C02
+resource FLASH_CS 1 B03
+resource OSD_CS 1 B14
+resource GYRO_EXTI 1 C05
+resource GYRO_CS 1 C04
+resource USB_DETECT 1 A08
+
+# timer
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin C07 0
+# pin C07: DMA2 Stream 2 Channel 0
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A03 1
+# pin A03: DMA1 Stream 6 Channel 3
+dma pin A02 0
+# pin A02: DMA1 Stream 1 Channel 3
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature OSD
+
+# serial
+serial 0 32 115200 57600 0 115200
+serial 2 64 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set serialrx_provider = SBUS
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set tlm_inverted = ON
+set tlm_halfduplex = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 3
+set max7456_preinit_opu = ON
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270
+set gyro_2_spibus = 1


### PR DESCRIPTION
Using the "stock" KakuteF4V2 firmware and resource mapping, the KakuteF4V2 can be used for tricopters, swapping the S4 and LED output pins such that the tail servo is connected to the LED pin and can have a separate output protocol from the motors.  This works at the expense of losing the LED strip functionality due to the timer definitions/limitations.

The KakuteF4V2Tri firmware redefines the timer usage such that no resource mapping is required.  The tail servo is connected to the LED output and the LED strip is functional on the S4 output.

Flight testing was performed on an RCExplorer tricopter LR, and it flew as expected.  I don't have any LED strips, but the signal was checked to be S4 with a logic analyzer and appears to be correct.
