### PR TITLE
Clear reset reason also upon button initiated EEPROM reset

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -443,6 +443,7 @@ void init(void)
             if (bothButtonsHeld) {
                 if (--secondsRemaining == 0) {
                     resetEEPROM();
+                    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
                     systemReset();
                 }
                 delay(1000);


### PR DESCRIPTION
In the button initiated EEPROM reset context, `PERSISTENT_OBJECT_RESET_REASON` should also be cleared to `RESET_NONE`, for a fresh start.