### PR TITLE
Feedforward 2.0

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -90,6 +90,7 @@ COMMON_SRC = \
             flight/gps_rescue.c \
             flight/gyroanalyse.c \
             flight/imu.c \
+            flight/interpolated_setpoint.c \
             flight/mixer.c \
             flight/mixer_tricopter.c \
             flight/pid.c \

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -93,4 +93,6 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "BARO",
     "GPS_RESCUE_THROTTLE_PID",
     "DYN_IDLE",
+    "FF_LIMIT",
+    "FF_INTERPOLATED",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -109,6 +109,8 @@ typedef enum {
     DEBUG_BARO,
     DEBUG_GPS_RESCUE_THROTTLE_PID,
     DEBUG_DYN_IDLE,
+    DEBUG_FF_LIMIT,
+    DEBUG_FF_INTERPOLATED,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1060,6 +1060,13 @@ const clivalue_t valueTable[] = {
 #ifdef USE_AIRMODE_LPF
     { "transient_throttle_limit",   VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },
 #endif
+#ifdef USE_INTERPOLATED_SP
+    { "ff_interpolate_sp",          VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = {TABLE_OFF_ON}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_interpolate_sp) },
+    { "ff_spread",                  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 50}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_spread) },
+    { "ff_max_rate_limit",          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 150}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_max_rate_limit) },
+    { "ff_lookahead_limit",         VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 255}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_lookahead_limit) },
+#endif
+    { "ff_boost",                   VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost) },
 
 #ifdef USE_DYN_IDLE
     { "idle_min_rpm",               VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_min_rpm) },

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -53,6 +53,12 @@
 
 typedef float (applyRatesFn)(const int axis, float rcCommandf, const float rcCommandfAbs);
 
+#ifdef USE_INTERPOLATED_SP
+// Setpoint in degrees/sec before RC-Smoothing is applied
+static float rawSetpoint[XYZ_AXIS_COUNT];
+// Stick deflection [-1.0, 1.0] before RC-Smoothing is applied
+static float rawDeflection[XYZ_AXIS_COUNT];
+#endif
 static float setpointRate[3], rcDeflection[3], rcDeflectionAbs[3];
 static float throttlePIDAttenuation;
 static bool reverseMotors = false;
@@ -60,6 +66,7 @@ static applyRatesFn *applyRates;
 uint16_t currentRxRefreshRate;
 
 FAST_RAM_ZERO_INIT uint8_t interpolationChannels;
+static FAST_RAM_ZERO_INIT uint32_t rcFrameNumber;
 
 enum {
     ROLL_FLAG = 1 << ROLL,
@@ -82,6 +89,11 @@ enum {
 static FAST_RAM_ZERO_INIT rcSmoothingFilter_t rcSmoothingData;
 #endif // USE_RC_SMOOTHING_FILTER
 
+uint32_t getRcFrameNumber() 
+{
+    return rcFrameNumber;
+}
+
 float getSetpointRate(int axis)
 {
     return setpointRate[axis];
@@ -101,6 +113,18 @@ float getThrottlePIDAttenuation(void)
 {
     return throttlePIDAttenuation;
 }
+
+#ifdef USE_INTERPOLATED_SP
+float getRawSetpoint(int axis)
+{
+    return rawSetpoint[axis];
+}
+
+float getRawDeflection(int axis)
+{
+    return rawDeflection[axis];
+}
+#endif
 
 #define THROTTLE_LOOKUP_LENGTH 12
 static int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];    // lookup table for expo & mid THROTTLE
@@ -152,11 +176,16 @@ float applyKissRates(const int axis, float rcCommandf, const float rcCommandfAbs
 {
     const float rcCurvef = currentControlRateProfile->rcExpo[axis] / 100.0f;
 
-    float kissRpyUseRates = 1.0f / (constrainf(1.0f - (rcCommandfAbs * (currentControlRateProfile->rates[axis] / 100.0f)), 0.01f, 1.00f));    
+    float kissRpyUseRates = 1.0f / (constrainf(1.0f - (rcCommandfAbs * (currentControlRateProfile->rates[axis] / 100.0f)), 0.01f, 1.00f));
     float kissRcCommandf = (power3(rcCommandf) * rcCurvef + rcCommandf * (1 - rcCurvef)) * (currentControlRateProfile->rcRates[axis] / 1000.0f);
     float kissAngle = constrainf(((2000.0f * kissRpyUseRates) * kissRcCommandf), -SETPOINT_RATE_LIMIT, SETPOINT_RATE_LIMIT);
 
     return kissAngle;
+}
+
+float applyCurve(int axis, float deflection)
+{
+    return applyRates(axis, deflection, fabsf(deflection));
 }
 
 static void calculateSetpointRate(int axis)
@@ -561,9 +590,24 @@ FAST_CODE void processRcCommand(void)
 {
     uint8_t updatedChannel;
 
+    if (isRXDataNew) {
+        rcFrameNumber++;
+    }
+
     if (isRXDataNew && pidAntiGravityEnabled()) {
         checkForThrottleErrorResetState(currentRxRefreshRate);
     }
+
+#ifdef USE_INTERPOLATED_SP
+    if (isRXDataNew) {
+        for (int i = FD_ROLL; i <= FD_YAW; i++) {
+            const float rcCommandf = rcCommand[i] / 500.0f;
+            const float rcCommandfAbs = fabsf(rcCommandf);
+            rawSetpoint[i] = applyRates(i, rcCommandf, rcCommandfAbs);
+            rawDeflection[i] = rcCommandf;
+        }
+    }
+#endif
 
     switch (rxConfig()->rc_smoothing_type) {
 #ifdef USE_RC_SMOOTHING_FILTER

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -45,3 +45,7 @@ bool rcSmoothingIsEnabled(void);
 rcSmoothingFilter_t *getRcSmoothingData(void);
 bool rcSmoothingAutoCalculate(void);
 bool rcSmoothingInitializationComplete(void);
+float getRawSetpoint(int axis);
+float getRawDeflection(int axis);
+float applyCurve(int axis, float deflection);
+uint32_t getRcFrameNumber();

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -18,10 +18,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <math.h>
 #include "platform.h"
 
 #ifdef USE_INTERPOLATED_SP
-#include <math.h>
 
 #include "build/debug.h"
 #include "common/maths.h"
@@ -113,7 +113,7 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, float pidFrequency, bool 
     return pidSetpointDelta;
 }
 
-FAST_CODE_NOINLINE float applyFFLimit(int axis, float value, float Kp, float currentPidSetpoint) {
+FAST_CODE_NOINLINE float applyFfLimit(int axis, float value, float Kp, float currentPidSetpoint) {
     if (axis == FD_ROLL) {
         DEBUG_SET(DEBUG_FF_LIMIT, 0, value);
     }
@@ -142,7 +142,7 @@ FAST_CODE_NOINLINE float applyFFLimit(int axis, float value, float Kp, float cur
     return value;
 }
 
-bool shouldApplyFFLimits(int axis)
+bool shouldApplyFfLimits(int axis)
 {
     return ffLookaheadLimit != 0.0f || ffMaxRateLimit[axis] != 0.0f;
 }

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#ifdef USE_INTERPOLATED_SP
+#include <math.h>
+
+#include "build/debug.h"
+#include "common/maths.h"
+#include "fc/rc.h"
+#include "flight/interpolated_setpoint.h"
+
+static float projectedSetpoint[XYZ_AXIS_COUNT];
+static float prevSetpointSpeed[XYZ_AXIS_COUNT];
+static float prevRawSetpoint[XYZ_AXIS_COUNT];
+static float prevRawDeflection[XYZ_AXIS_COUNT];
+static uint16_t interpolationSteps[XYZ_AXIS_COUNT];
+static float setpointChangePerIteration[XYZ_AXIS_COUNT];
+static float deflectionChangePerIteration[XYZ_AXIS_COUNT];
+static float setpointReservoir[XYZ_AXIS_COUNT];
+static float deflectionReservoir[XYZ_AXIS_COUNT];
+
+// Configuration
+static float ffLookaheadLimit;
+static float ffSpread;
+static float ffMaxRateLimit[XYZ_AXIS_COUNT];
+static float ffMaxRate[XYZ_AXIS_COUNT];
+
+void interpolatedSpInit(const pidProfile_t *pidProfile) {
+    const float ffMaxRateScale = pidProfile->ff_max_rate_limit * 0.01f;
+    ffLookaheadLimit = pidProfile->ff_lookahead_limit * 0.0001f;
+    ffSpread = pidProfile->ff_spread;
+    for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
+        ffMaxRate[i] = applyCurve(i, 1.0f);
+        ffMaxRateLimit[i] = ffMaxRate[i] * ffMaxRateScale;
+    }
+}
+
+FAST_CODE_NOINLINE float interpolatedSpApply(int axis, float pidFrequency, bool newRcFrame) {
+    const float rawSetpoint = getRawSetpoint(axis);
+    const float rawDeflection = getRawDeflection(axis);
+
+    float pidSetpointDelta = 0.0f;
+    static int iterationsSinceLastUpdate[XYZ_AXIS_COUNT];
+    if (newRcFrame) {
+
+        setpointReservoir[axis] -= iterationsSinceLastUpdate[axis] * setpointChangePerIteration[axis];
+        deflectionReservoir[axis] -= iterationsSinceLastUpdate[axis] * deflectionChangePerIteration[axis];
+        iterationsSinceLastUpdate[axis] = 0;
+
+        // get the number of interpolation steps either dynamically based on RX refresh rate
+        // or manually based on ffSpread configuration property
+        if (ffSpread) {
+            interpolationSteps[axis] = (uint16_t) ((ffSpread + 1.0f) * 0.001f * pidFrequency);
+        } else {
+            interpolationSteps[axis] = (uint16_t) ((currentRxRefreshRate + 1000) * pidFrequency * 1e-6f + 0.5f);
+        }
+
+        // interpolate stick deflection
+        deflectionReservoir[axis] += rawDeflection - prevRawDeflection[axis];
+        deflectionChangePerIteration[axis] = deflectionReservoir[axis] / interpolationSteps[axis];
+        const float projectedStickPos =
+            rawDeflection + deflectionChangePerIteration[axis] * pidFrequency * ffLookaheadLimit;
+        projectedSetpoint[axis] = applyCurve(axis, projectedStickPos);
+        prevRawDeflection[axis] = rawDeflection;
+
+        // apply linear interpolation on setpoint
+        setpointReservoir[axis] += rawSetpoint - prevRawSetpoint[axis];
+        const float ffBoostFactor = pidGetFfBoostFactor();
+        if (ffBoostFactor != 0.0f) {
+            const float speed = rawSetpoint - prevRawSetpoint[axis];
+            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis] || fabsf(3.0f * speed) > fabsf(prevSetpointSpeed[axis])) {
+                const float setpointAcc = speed - prevSetpointSpeed[axis];
+                setpointReservoir[axis] += ffBoostFactor * setpointAcc;
+            }
+            prevSetpointSpeed[axis] = speed;
+        }
+
+        setpointChangePerIteration[axis] = setpointReservoir[axis] / interpolationSteps[axis];
+
+        prevRawSetpoint[axis] = rawSetpoint;
+        
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 0, rawDeflection * 100);
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 1, projectedStickPos * 100);
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 2, projectedSetpoint[axis]);
+        }
+    }
+
+    if (iterationsSinceLastUpdate[axis] < interpolationSteps[axis]) {
+        iterationsSinceLastUpdate[axis]++;
+        pidSetpointDelta = setpointChangePerIteration[axis];
+    }
+
+    return pidSetpointDelta;
+}
+
+FAST_CODE_NOINLINE float applyFFLimit(int axis, float value, float Kp, float currentPidSetpoint) {
+    if (axis == FD_ROLL) {
+        DEBUG_SET(DEBUG_FF_LIMIT, 0, value);
+    }
+
+    if (ffLookaheadLimit) {
+        const float limit = fabsf((projectedSetpoint[axis] - prevRawSetpoint[axis]) * Kp);
+        value = constrainf(value, -limit, limit);
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 3, projectedSetpoint[axis]);
+        }
+    }
+    if (axis == FD_ROLL) {
+        DEBUG_SET(DEBUG_FF_LIMIT, 1, value);
+    }
+
+    if (ffMaxRateLimit[axis]) {
+        if (fabsf(currentPidSetpoint) <= ffMaxRateLimit[axis]) {
+            value = constrainf(value, (-ffMaxRateLimit[axis] - currentPidSetpoint) * Kp, (ffMaxRateLimit[axis] - currentPidSetpoint) * Kp);
+        } else {
+            value = 0;
+        }
+    }
+    if (axis == FD_ROLL) {
+        DEBUG_SET(DEBUG_FF_LIMIT, 2, value);
+    }
+    return value;
+}
+
+bool shouldApplyFFLimits(int axis)
+{
+    return ffLookaheadLimit != 0.0f || ffMaxRateLimit[axis] != 0.0f;
+}
+
+
+#endif

--- a/src/main/flight/interpolated_setpoint.h
+++ b/src/main/flight/interpolated_setpoint.h
@@ -27,5 +27,5 @@
 
 void interpolatedSpInit(const pidProfile_t *pidProfile);
 float interpolatedSpApply(int axis, float pidFrequency, bool newRcFrame);
-float applyFFLimit(int axis, float value, float Kp, float currentPidSetpoint);
-bool shouldApplyFFLimits(int axis);
+float applyFfLimit(int axis, float value, float Kp, float currentPidSetpoint);
+bool shouldApplyFfLimits(int axis);

--- a/src/main/flight/interpolated_setpoint.h
+++ b/src/main/flight/interpolated_setpoint.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "common/axis.h"
+#include "flight/pid.h"
+
+void interpolatedSpInit(const pidProfile_t *pidProfile);
+float interpolatedSpApply(int axis, float pidFrequency, bool newRcFrame);
+float applyFFLimit(int axis, float value, float Kp, float currentPidSetpoint);
+bool shouldApplyFFLimits(int axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -49,6 +49,7 @@
 #include "flight/imu.h"
 #include "flight/mixer.h"
 #include "flight/rpm_filter.h"
+#include "flight/interpolated_setpoint.h"
 
 #include "io/gps.h"
 
@@ -211,6 +212,11 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .idle_p = 50,
         .idle_pid_limit = 200,
         .idle_max_increase = 150,
+        .ff_interpolate_sp = 0,
+        .ff_spread = 0,
+        .ff_max_rate_limit = 0,
+        .ff_lookahead_limit = 0,
+        .ff_boost = 15,
     );
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;
@@ -285,6 +291,7 @@ static FAST_RAM_ZERO_INIT float acLimit;
 static FAST_RAM_ZERO_INIT float acErrorLimit;
 static FAST_RAM_ZERO_INIT float acCutoff;
 static FAST_RAM_ZERO_INIT pt1Filter_t acLpf[XYZ_AXIS_COUNT];
+static FAST_RAM_ZERO_INIT float oldSetpointCorrection[XYZ_AXIS_COUNT];
 #endif
 
 #if defined(USE_D_MIN)
@@ -306,6 +313,14 @@ static FAST_RAM_ZERO_INIT pt1Filter_t airmodeThrottleLpf2;
 #endif
 
 static FAST_RAM_ZERO_INIT pt1Filter_t antiGravityThrottleLpf;
+
+static FAST_RAM_ZERO_INIT float ffBoostFactor;
+
+float pidGetFfBoostFactor()
+{
+    return ffBoostFactor;
+}
+
 
 void pidInitFilters(const pidProfile_t *pidProfile)
 {
@@ -443,6 +458,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 #endif
 
     pt1FilterInit(&antiGravityThrottleLpf, pt1FilterGain(ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF, dT));
+
+    ffBoostFactor = (float)pidProfile->ff_boost / 10.0f;
 }
 
 #ifdef USE_RC_SMOOTHING_FILTER
@@ -563,6 +580,10 @@ static FAST_RAM_ZERO_INIT uint16_t dynLpfMax;
 static FAST_RAM_ZERO_INIT float dMinPercent[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT float dMinGyroGain;
 static FAST_RAM_ZERO_INIT float dMinSetpointGain;
+#endif
+
+#ifdef USE_INTERPOLATED_SP
+static FAST_RAM_ZERO_INIT bool ffFromInterpolatedSetpoint;
 #endif
 
 void pidInitConfig(const pidProfile_t *pidProfile)
@@ -707,6 +728,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 #if defined(USE_AIRMODE_LPF)
     airmodeThrottleOffsetLimit = pidProfile->transient_throttle_limit / 100.0f;
+#endif
+#ifdef USE_INTERPOLATED_SP
+    ffFromInterpolatedSetpoint = pidProfile->ff_interpolate_sp;
+    interpolatedSpInit(pidProfile);
 #endif
 }
 
@@ -1212,6 +1237,9 @@ static float applyLaunchControl(int axis, const rollAndPitchTrims_t *angleTrim)
 void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTimeUs)
 {
     static float previousGyroRateDterm[XYZ_AXIS_COUNT];
+#ifdef USE_INTERPOLATED_SP
+    static FAST_RAM_ZERO_INIT uint32_t lastFrameNumber;
+#endif
 
 #if defined(USE_ACC)
     static timeUs_t levelModeStartTimeUs = 0;
@@ -1286,6 +1314,13 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     rpmFilterUpdate();
 #endif
 
+#ifdef USE_INTERPOLATED_SP
+    bool newRcFrame = false;
+    if (lastFrameNumber != getRcFrameNumber()) {
+        lastFrameNumber = getRcFrameNumber();
+        newRcFrame = true;
+    }
+#endif
 
     // ----------PID controller----------
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
@@ -1336,12 +1371,16 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
         const float previousIterm = pidData[axis].I;
         float itermErrorRate = errorRate;
+        float uncorrectedSetpoint = currentPidSetpoint;
 
 #if defined(USE_ITERM_RELAX)
         if (!launchControlActive && !inCrashRecoveryMode) {
             applyItermRelax(axis, previousIterm, gyroRate, &itermErrorRate, &currentPidSetpoint);
             errorRate = currentPidSetpoint - gyroRate;
         }
+#endif
+#ifdef USE_ABSOLUTE_CONTROL
+        float setpointCorrection = currentPidSetpoint - uncorrectedSetpoint;
 #endif
 
         // --------low-level gyro-based PID based on 2DOF PID controller. ----------
@@ -1365,8 +1404,17 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
         // -----calculate pidSetpointDelta
         float pidSetpointDelta = 0;
+#ifdef USE_INTERPOLATED_SP
+        if (ffFromInterpolatedSetpoint) {
+            pidSetpointDelta = interpolatedSpApply(axis, pidFrequency, newRcFrame);
+        } else {
+            pidSetpointDelta = currentPidSetpoint - previousPidSetpoint[axis];
+        }
+#else
         pidSetpointDelta = currentPidSetpoint - previousPidSetpoint[axis];
+#endif
         previousPidSetpoint[axis] = currentPidSetpoint;
+
 
 #ifdef USE_RC_SMOOTHING_FILTER
         pidSetpointDelta = applyRcSmoothingDerivativeFilter(axis, pidSetpointDelta);
@@ -1416,12 +1464,25 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         previousGyroRateDterm[axis] = gyroRateDterm[axis];
 
         // -----calculate feedforward component
+#ifdef USE_ABSOLUTE_CONTROL
+        // include abs control correction in FF
+        pidSetpointDelta += setpointCorrection - oldSetpointCorrection[axis];
+        oldSetpointCorrection[axis] = setpointCorrection;
+#endif
+
         // Only enable feedforward for rate mode and if launch control is inactive
         const float feedforwardGain = (flightModeFlags || launchControlActive) ? 0.0f : pidCoefficient[axis].Kf;
         if (feedforwardGain > 0) {
             // no transition if feedForwardTransition == 0
             float transition = feedForwardTransition > 0 ? MIN(1.f, getRcDeflectionAbs(axis) * feedForwardTransition) : 1;
-            pidData[axis].F = feedforwardGain * transition * pidSetpointDelta * pidFrequency;
+            float feedForward = feedforwardGain * transition * pidSetpointDelta * pidFrequency;
+
+#ifdef USE_INTERPOLATED_SP
+            pidData[axis].F = shouldApplyFFLimits(axis) ?
+                applyFFLimit(axis, feedForward, pidCoefficient[axis].Kp, currentPidSetpoint) : feedForward;
+#else
+            pidData[axis].F = feedForward;
+#endif
         } else {
             pidData[axis].F = 0;
         }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1478,8 +1478,8 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             float feedForward = feedforwardGain * transition * pidSetpointDelta * pidFrequency;
 
 #ifdef USE_INTERPOLATED_SP
-            pidData[axis].F = shouldApplyFFLimits(axis) ?
-                applyFFLimit(axis, feedForward, pidCoefficient[axis].Kp, currentPidSetpoint) : feedForward;
+            pidData[axis].F = shouldApplyFfLimits(axis) ?
+                applyFfLimit(axis, feedForward, pidCoefficient[axis].Kp, currentPidSetpoint) : feedForward;
 #else
             pidData[axis].F = feedForward;
 #endif

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -170,6 +170,7 @@ typedef struct pidProfile_s {
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
+    uint8_t ff_boost;                       // amount of high-pass filtered FF to add to FF, 100 means 100% added
     char profileName[MAX_PROFILE_NAME_LENGTH + 1]; // Descriptive name for profile
 
     uint8_t idle_min_rpm;                   // minimum motor speed enforced by integrating p controller
@@ -178,7 +179,10 @@ typedef struct pidProfile_s {
     uint8_t idle_pid_limit;                 // max P 
     uint8_t idle_max_increase;              // max integrated correction
     
-    
+    uint8_t ff_interpolate_sp;              // Calculate FF from interpolated setpoint
+    uint8_t ff_spread;                      // Spread ff out over at least min spread ms
+    uint8_t ff_max_rate_limit;              // Maximum setpoint rate percentage for FF
+    uint8_t ff_lookahead_limit;             // FF stick extrapolation lookahead period in ms
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -255,4 +259,4 @@ void pidSetItermReset(bool enabled);
 float pidGetPreviousSetpoint(int axis);
 float pidGetDT();
 float pidGetPidFrequency();
-
+float pidGetFfBoostFactor();

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -612,7 +612,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 
         // battery alerts
         sbufWriteU8(dst, (uint8_t)getBatteryState());
-		
+
         sbufWriteU16(dst, getBatteryVoltage()); // in 0.01V steps
         break;
     }

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -334,4 +334,5 @@
 #define USE_PERSISTENT_STATS
 #define USE_PROFILE_NAMES
 #define USE_SERIALRX_SRXL2     // Spektrum SRXL2 protocol
+#define USE_INTERPOLATED_SP
 #endif

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -80,6 +80,12 @@ extern "C" {
     void beeperConfirmationBeeps(uint8_t) { }
     bool isLaunchControlActive(void) {return unitLaunchControlActive; }
     void disarm(void) { }
+    float applyFFLimit(int axis, float value, float Kp, float currentPidSetpoint) {
+        UNUSED(axis);
+        UNUSED(Kp);
+        UNUSED(currentPidSetpoint);
+        return value;
+    }
 }
 
 pidProfile_t *pidProfile;


### PR DESCRIPTION
This PR implements a major change in our feedforward implementation. It incorporates https://github.com/betaflight/betaflight/pull/8560 and https://github.com/betaflight/betaflight/pull/8450 - thanks to @ctzsnooze and @Balint134 for those. I've addressed the main concerns in the code review of https://github.com/betaflight/betaflight/pull/8450 in this PR.

To review the current state of affairs: we run rc filters on rc setpoint, then calculate the derivative, filter it using a second set of rc filters and use the result for calculation of feedforward. This approach has a couple of significant disadvantages: 

- Each filter causes a delay relative to the original signal, leading to an ff signal that's significantly delayed. 
- Due to the exponential rate to stick curves a linear move of the sticks between two rc frames leads to a much smaller initial rate speed than towards the end of the inter packet interval. We already know that ff will get much larger so there's an opportunity to front load the application to improve quad response.
- Additionally the filtering we apply attenuates the frequency content of the setpoint path, manipulating the energy put to the motors due to ff in potentially harmful ways.

Let's think about how to best apply ff to the motors. We want a motor signal that is as early as possible but does not have saw teeth or local minima so ideally the ff applied to the motors between two rc data points is constant, with the discontinuities between rc interval smoothed by modest filtering.

Let's look at the ff to be applied during an rc interval. We know the starting and ending setpoint values ``s1`` and ``s2``. At each loop interval ``dT`` we need to apply an amount proportional to ``ds / dT``. If we integrate over the time interval the total amount of ff applied during the interval is proportional to ``s2 - s1`` then. Using our ideal step style ff we apply this amount equally during the rc interval.

Another way to look at it is as interpolating the setpoint change rate linearly over the rc interval instead of deriving the setpoint change rate from the filtered setpoint. Hence the name ``ff_interpolate_setpoint``.

Now ff provides energy to the motors to effect a change in rotational speed. It needs to be sized to match the moment of intertia of the quad. It cannot however provide the energy required to accelerate the motors to the higher rpm differential needed to effect the move. This is because a constant rate of change setpoint move leads to constant ff. What we need to effect this move quickly though is an initial boost to the motors to accelerate them to the differential required to then maintain the constant rate of change setpoint move, and then a boost in the other direction to slow them down again.

FF 2.0 addresses this need by introducing ``ff_boost``, a similarly linearly interpolated 2nd stick derivative added to ff. This allows significantly better quad response without overshoot.

There is however a limit in what ``ff_boost`` can accomplish at max stick deflection. When the stick hits max deflection during a full rate roll it is brought to a stop immediately. Clearly even ``ff_boost`` cannot prevent overshoot in this situation. 

We provide a different mechanism to avoid max deflection overshoot. We note that a quad that is tuned for a pilot's overshoot tolerance without FF would not have an issue when the stick hits max deflection. D would dampen the move and let the rate approach its target smoothly. The overshoot problem exists due to the added FF. Working back from this insight we limit FF such that P + FF are no bigger than P if the sticks were already at max deflection. This mechanism is set via ``ff_max_rate_limit``. 100 means the limit is calculated relative to max deflection and works well with well tuned quads - different values can be set to change the maximum allowed FF.

A different perspective on ``ff_max_rate_limit`` is that FF is effectively a prediction of how far the stick move will extend. FF can only be added since sticks don't usually revert suddenly. This prediction is wrong at max deflection and ``ff_max_rate_limit`` corrects the prediction for that singularity.

``ff_lookahead_limit`` provides a very similar correction to the setpoint prediction outside of max deflection. It extrapolates stick movement into the future and checks whether P + FF is larger than P would be at the extrapolated stick position and limits FF in that case. This may no longer be required with ``ff_boost`` but is left in the PR to allow experimentation.

The full set of parameters are:
- ``ff_interpolate_sp`` - enable the ff2.0 style ff calculation. ``On`` or ``Off``.
- ``ff_max_rate_limit`` - activate the max stick deflection limit. Specify a percentage here. ``100`` should be ideal in most cases.
- ``ff_spread`` - allows ff to be linearly interpolated over a period larger than one rc interval. This is useful if the radio skips many frames or to address some OpenTx issues that are fixed in OpenTx 2.3 which we recommend to use instead.
- ``ff_lookahead_limit`` - specifies the time in ms that stick should be linearly extrapolated to calculate the lookahead limit.
- ``ff_boost`` - specifies the amount of interpolated 2nd stick derivative to add to ff. Remember that the physical correlates of ff and boost are different - ff is proportional to quad moment of inertia and boost is proportional to rotor moment of inertia. So when you change ff you might need to adjust ``ff_boost``.

Taranis users not yet on OpenTx 2.3 should likely use ``ff_spread`` of ``18``. We recommend ``ff_lookahead_limit`` to be off initially and ``ff_boost`` to be set to ``15`` to start with. ``ff_max_rate_limit`` should be at ``100``.

