### PR TITLE
Fix H7 crashing on boot due to #8599

### DIFF
--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -451,6 +451,15 @@ void uartIrqHandler(uartPort_t *s)
         }
 #endif
     }
+
+    if (__HAL_UART_GET_IT(huart, UART_IT_IDLE)) {
+        if (s->port.idleCallback) {
+            s->port.idleCallback();
+        }
+
+        __HAL_UART_CLEAR_IDLEFLAG(huart);
+    }
+
 }
 
 #ifdef USE_DMA


### PR DESCRIPTION
With reference to 38013a8253ea0841da254b3bf5ed73c680da771d and 
https://github.com/betaflight/betaflight/pull/8599#issuecomment-516168033

The PR didn't include changes to the H7 uart driver which caused the MCU to segfault in the uart irq handler on boot.

This PR seems to fix the crashing, code change based on the F7 code changes from #8599.
