### PR TITLE
Prevent calls to presistent object functions for unsupported MCU

### DIFF
--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -266,6 +266,7 @@ bool rtcSetDateTime(dateTime_t *dt)
     return rtcSet(&t);
 }
 
+#if defined(USE_PERSISTENT_OBJECTS)
 void rtcPersistWrite(int16_t offsetMinutes)
 {
     rtcTime_t workTime;
@@ -292,5 +293,5 @@ bool rtcPersistRead(rtcTime_t *t)
         return false;
     }
 }
-
 #endif
+#endif // USE_RTC_TIME

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -443,7 +443,9 @@ void init(void)
             if (bothButtonsHeld) {
                 if (--secondsRemaining == 0) {
                     resetEEPROM();
+#ifdef USE_PERSISTENT_OBJECTS
                     persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
+#endif
                     systemReset();
                 }
                 delay(1000);

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -254,7 +254,7 @@
 #undef USE_USB_MSC
 #endif
 
-#if (!defined(USE_FLASHFS) || !defined(USE_RTC_TIME) || !defined(USE_USB_MSC))
+#if (!defined(USE_FLASHFS) || !defined(USE_RTC_TIME) || !defined(USE_USB_MSC) || !defined(USE_PERSISTENT_OBJECTS))
 #undef USE_PERSISTENT_MSC_RTC
 #endif
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -65,6 +65,7 @@
 #define USE_MCO
 #define USE_DMA_SPEC
 #define USE_TIMER_MGMT
+#define USE_PERSISTENT_OBJECTS
 // Re-enable this after 4.0 has been released, and remove the define from STM32F4DISCOVERY
 //#define USE_SPI_TRANSACTION
 
@@ -93,6 +94,7 @@
 #define USE_MCO
 #define USE_DMA_SPEC
 #define USE_TIMER_MGMT
+#define USE_PERSISTENT_OBJECTS
 // Re-enable this after 4.0 has been released, and remove the define from STM32F4DISCOVERY
 //#define USE_SPI_TRANSACTION
 #endif // STM32F7
@@ -106,6 +108,7 @@
 #define USE_USB_CDC_HID
 #define USE_DMA_SPEC
 #define USE_TIMER_MGMT
+#define USE_PERSISTENT_OBJECTS
 #endif
 
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)


### PR DESCRIPTION
Fixes for #8619

Prevents compilation errors for F3 targets which don't support persistent objects.