### PR TITLE
DMA Stream/Channel unification on LL-DShot

### DIFF
--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -226,8 +226,8 @@ dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e ident
 
 #define xLL_EX_DMA_DeInit(dmaResource) LL_EX_DMA_DeInit((DMA_ARCH_TYPE *)(dmaResource))
 #define xLL_EX_DMA_Init(dmaResource, initstruct) LL_EX_DMA_Init((DMA_ARCH_TYPE *)(dmaResource), initstruct)
-#define xLL_EX_DMA_DisableStream(dmaResource) LL_EX_DMA_DisableStream((DMA_ARCH_TYPE *)(dmaResource))
-#define xLL_EX_DMA_EnableStream(dmaResource) LL_EX_DMA_EnableStream((DMA_ARCH_TYPE *)(dmaResource))
+#define xLL_EX_DMA_DisableResource(dmaResource) LL_EX_DMA_DisableResource((DMA_ARCH_TYPE *)(dmaResource))
+#define xLL_EX_DMA_EnableResource(dmaResource) LL_EX_DMA_EnableResource((DMA_ARCH_TYPE *)(dmaResource))
 #define xLL_EX_DMA_GetDataLength(dmaResource) LL_EX_DMA_GetDataLength((DMA_ARCH_TYPE *)(dmaResource))
 #define xLL_EX_DMA_SetDataLength(dmaResource, length) LL_EX_DMA_SetDataLength((DMA_ARCH_TYPE *)(dmaResource), length)
 #define xLL_EX_DMA_EnableIT_TC(dmaResource) LL_EX_DMA_EnableIT_TC((DMA_ARCH_TYPE *)(dmaResource))

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -59,12 +59,12 @@ static void processInputIrq(motorDmaOutput_t * const motor)
 
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        xLL_EX_DMA_DisableStream(motor->timerHardware->dmaTimUPRef);
+        xLL_EX_DMA_DisableResource(motor->timerHardware->dmaTimUPRef);
         LL_TIM_DisableDMAReq_UPDATE(motor->timerHardware->tim);
     } else
 #endif
     {
-        xLL_EX_DMA_DisableStream(motor->dmaRef);
+        xLL_EX_DMA_DisableResource(motor->dmaRef);
         LL_EX_TIM_DisableIT(motor->timerHardware->tim, motor->timerDmaSource);
     }
     readDoneCount++;
@@ -139,7 +139,7 @@ FAST_CODE void pwmCompleteDshotMotorUpdate(void)
 #ifdef USE_DSHOT_DMAR
         if (useBurstDshot) {
             xLL_EX_DMA_SetDataLength(dmaMotorTimers[i].dmaBurstRef, dmaMotorTimers[i].dmaBurstLength);
-            xLL_EX_DMA_EnableStream(dmaMotorTimers[i].dmaBurstRef);
+            xLL_EX_DMA_EnableResource(dmaMotorTimers[i].dmaBurstRef);
 
             /* configure the DMA Burst Mode */
             LL_TIM_ConfigDMABurst(dmaMotorTimers[i].timer, LL_TIM_DMABURST_BASEADDR_CCR1, LL_TIM_DMABURST_LENGTH_4TRANSFERS);
@@ -170,12 +170,12 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
         {
 #ifdef USE_DSHOT_DMAR
             if (useBurstDshot) {
-                xLL_EX_DMA_DisableStream(motor->timerHardware->dmaTimUPRef);
+                xLL_EX_DMA_DisableResource(motor->timerHardware->dmaTimUPRef);
                 LL_TIM_DisableDMAReq_UPDATE(motor->timerHardware->tim);
             } else
 #endif
             {
-                xLL_EX_DMA_DisableStream(motor->dmaRef);
+                xLL_EX_DMA_DisableResource(motor->dmaRef);
                 LL_EX_TIM_DisableIT(motor->timerHardware->tim, motor->timerDmaSource);
             }
 
@@ -183,7 +183,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
             if (useDshotTelemetry) {
                 pwmDshotSetDirectionOutput(motor, false);
                 xLL_EX_DMA_SetDataLength(motor->dmaRef, motor->dmaInputLen);
-                xLL_EX_DMA_EnableStream(motor->dmaRef);
+                xLL_EX_DMA_EnableResource(motor->dmaRef);
                 LL_EX_TIM_EnableIT(motor->timerHardware->tim, motor->timerDmaSource);
                 setDirectionMicros = micros() - irqStart;
             }
@@ -311,7 +311,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }
 
-    xLL_EX_DMA_DisableStream(dmaRef);
+    xLL_EX_DMA_DisableResource(dmaRef);
     xLL_EX_DMA_DeInit(dmaRef);
     LL_DMA_StructInit(&DMAINIT);
 

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -137,9 +137,9 @@ FAST_CODE void pwmWriteDshotInt(uint8_t index, uint16_t value)
     {
         bufferSize = loadDmaBuffer(motor->dmaBuffer, 1, packet);
         motor->timer->timerDmaSources |= motor->timerDmaSource;
-#ifdef STM32F7
+#ifdef USE_FULL_LL_DRIVER
         xLL_EX_DMA_SetDataLength(motor->dmaRef, bufferSize);
-        xLL_EX_DMA_EnableStream(motor->dmaRef);
+        xLL_EX_DMA_EnableResource(motor->dmaRef);
 #else
         xDMA_SetCurrDataCounter(motor->dmaRef, bufferSize);
         xDMA_Cmd(motor->dmaRef, ENABLE);
@@ -212,7 +212,7 @@ uint16_t getDshotTelemetry(uint8_t index)
 FAST_CODE void pwmDshotSetDirectionOutput(
     motorDmaOutput_t * const motor, bool output
 #ifndef USE_DSHOT_TELEMETRY
-#ifdef STM32F7
+#ifdef USE_FULL_LL_DRIVER
     , LL_TIM_OC_InitTypeDef* pOcInit, LL_DMA_InitTypeDef* pDmaInit
 #else
     , TIM_OCInitTypeDef *pOcInit, DMA_InitTypeDef* pDmaInit
@@ -251,7 +251,7 @@ bool pwmStartDshotMotorUpdate(void)
 #endif
     for (int i = 0; i < dshotPwmDevice.count; i++) {
         if (dmaMotors[i].hasTelemetry) {
-#ifdef STM32F7
+#ifdef USE_FULL_LL_DRIVER
             uint32_t edges = xLL_EX_DMA_GetDataLength(dmaMotors[i].dmaRef);
 #else
             uint32_t edges = xDMA_GetCurrDataCounter(dmaMotors[i].dmaRef);
@@ -291,7 +291,7 @@ bool pwmStartDshotMotorUpdate(void)
             if (usSinceInput >= 0 && usSinceInput < dmaMotors[i].dshotTelemetryDeadtimeUs) {
                 return false;
             }
-#ifdef STM32F7
+#ifdef USE_FULL_LL_DRIVER
             LL_EX_TIM_DisableIT(dmaMotors[i].timerHardware->tim, dmaMotors[i].timerDmaSource);
 #else
             TIM_DMACmd(dmaMotors[i].timerHardware->tim, dmaMotors[i].timerDmaSource, DISABLE);

--- a/src/main/drivers/stm32f7xx_ll_ex.h
+++ b/src/main/drivers/stm32f7xx_ll_ex.h
@@ -67,12 +67,12 @@ __STATIC_INLINE void LL_EX_DMA_SetChannelSelection(DMA_Stream_TypeDef *DMAx_Stre
 	MODIFY_REG(DMAx_Streamy->CR, DMA_SxCR_CHSEL, Channel);
 }
 
-__STATIC_INLINE void LL_EX_DMA_EnableStream(DMA_Stream_TypeDef *DMAx_Streamy)
+__STATIC_INLINE void LL_EX_DMA_EnableResource(DMA_Stream_TypeDef *DMAx_Streamy)
 {
 	SET_BIT(DMAx_Streamy->CR, DMA_SxCR_EN);
 }
 
-__STATIC_INLINE void LL_EX_DMA_DisableStream(DMA_Stream_TypeDef *DMAx_Streamy)
+__STATIC_INLINE void LL_EX_DMA_DisableResource(DMA_Stream_TypeDef *DMAx_Streamy)
 {
 	CLEAR_BIT(DMAx_Streamy->CR, DMA_SxCR_EN);
 }


### PR DESCRIPTION
Apply DMA Stream/Channel unification introduced by #8586 on LL-DShot.

This change will further increase portability of LL-DShot, which will account for H7 migrationto LL-DShot (and G4 Porting).