### PR TITLE
Fix vtx_freq default value when USE_VTX_TABLES is defined

### DIFF
--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -51,13 +51,16 @@ PG_REGISTER_WITH_RESET_FN(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTING
 
 void pgResetFn_vtxSettingsConfig(vtxSettingsConfig_t *vtxSettingsConfig)
 {
-    vtxSettingsConfig->band = VTX_TABLE_DEFAULT_BAND;
-    vtxSettingsConfig->channel = VTX_TABLE_DEFAULT_CHANNEL;
-    vtxSettingsConfig->power = VTX_TABLE_DEFAULT_POWER;
 #ifdef USE_VTX_TABLE
+    vtxSettingsConfig->band = 0;
+    vtxSettingsConfig->channel = 0;
+    vtxSettingsConfig->power = 0;
     vtxSettingsConfig->freq = 0;
 #else
     vtxSettingsConfig->freq = VTX_TABLE_DEFAULT_FREQ;
+    vtxSettingsConfig->band = VTX_TABLE_DEFAULT_BAND;
+    vtxSettingsConfig->channel = VTX_TABLE_DEFAULT_CHANNEL;
+    vtxSettingsConfig->power = VTX_TABLE_DEFAULT_POWER;
 #endif
     vtxSettingsConfig->pitModeFreq = VTX_TABLE_DEFAULT_PITMODE_FREQ;
     vtxSettingsConfig->lowPowerDisarm = VTX_LOW_POWER_DISARM_OFF;

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -47,16 +47,21 @@
 #include "vtx.h"
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTINGS_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTINGS_CONFIG, 0);
 
-PG_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig,
-                  .band = VTX_TABLE_DEFAULT_BAND,
-                  .channel = VTX_TABLE_DEFAULT_CHANNEL,
-                  .power = VTX_TABLE_DEFAULT_POWER,
-                  .freq = VTX_TABLE_DEFAULT_FREQ,
-                  .pitModeFreq = VTX_TABLE_DEFAULT_PITMODE_FREQ,
-                  .lowPowerDisarm = VTX_LOW_POWER_DISARM_OFF,
-                 );
+void pgResetFn_vtxSettingsConfig(vtxSettingsConfig_t *vtxSettingsConfig)
+{
+    vtxSettingsConfig->band = VTX_TABLE_DEFAULT_BAND;
+    vtxSettingsConfig->channel = VTX_TABLE_DEFAULT_CHANNEL;
+    vtxSettingsConfig->power = VTX_TABLE_DEFAULT_POWER;
+#ifdef USE_VTX_TABLE
+    vtxSettingsConfig->freq = 0;
+#else
+    vtxSettingsConfig->freq = VTX_TABLE_DEFAULT_FREQ;
+#endif
+    vtxSettingsConfig->pitModeFreq = VTX_TABLE_DEFAULT_PITMODE_FREQ;
+    vtxSettingsConfig->lowPowerDisarm = VTX_LOW_POWER_DISARM_OFF;
+}
 
 typedef enum {
     VTX_PARAM_POWER = 0,


### PR DESCRIPTION
When a `vtxDevice` was active (like if `USE_VTX_RTC6705` is defined for the target) then the initialization logic would try to look up the frequency based on the band/channel and update the `vtx_freq` setting. The problem is that initially the `vtxtable` is not defined so the frequency lookup fails and returns 0. This resulted in a defaults difference since the default value was 5740 which would have matched the default band and channel if the "standard" bands/channels were set up with `vtxtable`. So instead set the default value to 0 unless legacy built-in frequencies are used (`USE_VTX_TABLES` not defined).

Also default `vtx_band`, `vtx_channel` and `vtx_power` to 0 if `USE_VTX_TABLE` is defined.