### PR TITLE
Fix I2C4 on STM32H7xx.

### DIFF
--- a/src/main/drivers/bus_i2c_config.c
+++ b/src/main/drivers/bus_i2c_config.c
@@ -39,23 +39,6 @@
 
 #include "pg/bus_i2c.h"
 
-// Backward compatibility for overclocking and internal pullup.
-// These will eventually be configurable through PG-based configurator
-// (and/or probably through some cli extension).
-
-#ifndef I2C1_OVERCLOCK
-#define I2C1_OVERCLOCK false
-#endif
-#ifndef I2C2_OVERCLOCK
-#define I2C2_OVERCLOCK false
-#endif
-#ifndef I2C3_OVERCLOCK
-#define I2C3_OVERCLOCK false
-#endif
-#ifndef I2C4_OVERCLOCK
-#define I2C4_OVERCLOCK false
-#endif
-
 void i2cHardwareConfigure(const i2cConfig_t *i2cConfig)
 {
     for (int index = 0 ; index < I2CDEV_COUNT ; index++) {

--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -141,7 +141,7 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
         .reg = I2C4,
         .sclPins = { I2CPINDEF(PD12, GPIO_AF4_I2C4), I2CPINDEF(PF14, GPIO_AF4_I2C4), I2CPINDEF(PB6, GPIO_AF6_I2C4), I2CPINDEF(PB8, GPIO_AF6_I2C4) },
         .sdaPins = { I2CPINDEF(PD13, GPIO_AF4_I2C4), I2CPINDEF(PF15, GPIO_AF4_I2C4), I2CPINDEF(PB7, GPIO_AF6_I2C4), I2CPINDEF(PB9, GPIO_AF6_I2C4) },
-        .rcc = RCC_APB1L(I2C4),
+        .rcc = RCC_APB4(I2C4),
         .ev_irq = I2C4_EV_IRQn,
         .er_irq = I2C4_ER_IRQn,
     },

--- a/src/main/target/SPRACINGH7ZERO/target.c
+++ b/src/main/target/SPRACINGH7ZERO/target.c
@@ -41,8 +41,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM5,  CH3, PA2,  TIM_USE_MOTOR,               0,  2,  0 ),
     DEF_TIM(TIM5,  CH4, PA3,  TIM_USE_MOTOR,               0,  3,  0 ), // M4
 
-    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_MOTOR,               0,  4,  1 ), // M5
-    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_MOTOR,               0,  5,  1 ), // M6
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_MOTOR,               0,  4,  1 ), // M5 / I2C4_SCL
+    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_MOTOR,               0,  5,  1 ), // M6 / I2C4_SDA
 
     DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_MOTOR,               0,  6,  2 ), // M7
     DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR,               0,  7,  2 ), // M8

--- a/src/main/target/SPRACINGH7ZERO/target.h
+++ b/src/main/target/SPRACINGH7ZERO/target.h
@@ -124,10 +124,14 @@
 #define SPI4_NSS_PIN            PE11
 
 #define USE_I2C
-#define USE_I2C_DEVICE_1
+#define USE_I2C_DEVICE_1        // Connected to BMP388 only
 #define I2C1_SCL                PB8
 #define I2C1_SDA                PB9
 #define I2C_DEVICE              (I2CDEV_1)
+
+#define USE_I2C_DEVICE_4        // Shared with motor outputs 5/6
+#define I2C4_SCL                PB6
+#define I2C4_SDA                PB7
 
 #define USE_MAG
 #define USE_MAG_HMC5883

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -177,6 +177,19 @@
 
 #endif // I2C_FULL_RECONFIGURABILITY
 
+#ifndef I2C1_OVERCLOCK
+#define I2C1_OVERCLOCK false
+#endif
+#ifndef I2C2_OVERCLOCK
+#define I2C2_OVERCLOCK false
+#endif
+#ifndef I2C3_OVERCLOCK
+#define I2C3_OVERCLOCK false
+#endif
+#ifndef I2C4_OVERCLOCK
+#define I2C4_OVERCLOCK false
+#endif
+
 // Default values for internal pullup
 
 #if defined(USE_I2C_PULLUP)


### PR DESCRIPTION
Currently adding this results in multiple compilation errors
```
#define USE_I2C_DEVICE_4
#define I2C4_SCL                PB6
#define I2C4_SDA                PB7
```

Also adds support to the SPRacingH7ZERO as a supported use-case and for CI visibility.
