### PR TITLE
[F7] Use MPU service to attribute DMA buffers

### DIFF
--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -125,7 +125,7 @@ endif
 #Flags
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant -Wdouble-promotion
 
-DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER
+DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER -DMAX_MPU_REGIONS=16 -DUSE_DMA_RAM
 ifeq ($(TARGET),$(filter $(TARGET),$(F7X5XI_TARGETS)))
 DEVICE_FLAGS   += -DSTM32F765xx
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f765.ld
@@ -171,6 +171,8 @@ MCU_COMMON_SRC = \
             drivers/bus_i2c_hal.c \
             drivers/dma_stm32f7xx.c \
             drivers/light_ws2811strip_hal.c \
+            drivers/memprot_hal.c \
+            drivers/memprot_stm32f7xx.c \
             drivers/transponder_ir_io_hal.c \
             drivers/bus_spi_ll.c \
             drivers/persistent.c \

--- a/src/link/stm32_flash_f7_split.ld
+++ b/src/link/stm32_flash_f7_split.ld
@@ -166,6 +166,42 @@ SECTIONS
     __fastram_bss_end__ = _efastram_bss;
   } >FASTRAM
 
+  .DMA_RAM_RW (NOLOAD) :
+  {
+    . = ALIGN(32);
+    PROVIDE(dmaram_rw_start = .);
+    _sdmaram_rw = .;
+    _dmaram_rw_start__ = _sdmaram_rw;
+    KEEP(*(.DMA_RAM_RW))
+    PROVIDE(dmaram_rw_end = .);
+    _edmaram_rw = .;
+    _dmaram_rw_end__ = _edmaram_rw;
+  } >RAM
+
+  .DMA_RAM_W (NOLOAD) :
+  {
+    . = ALIGN(32);
+    PROVIDE(dmaram_w_start = .);
+    _sdmaram_w = .;
+    _dmaram_w_start__ = _sdmaram_w;
+    KEEP(*(.DMA_RAM_W))
+    PROVIDE(dmaram_w_end = .);
+    _edmaram_w = .;
+    _dmaram_w_end__ = _edmaram_w;
+  } >RAM
+
+  .DMA_RAM_R (NOLOAD) :
+  {
+    . = ALIGN(32);
+    PROVIDE(dmaram_r_start = .);
+    _sdmaram_r = .;
+    _dmaram_r_start__ = _sdmaram_r;
+    KEEP(*(.DMA_RAM_R))
+    PROVIDE(dmaram_r_end = .);
+    _edmaram_r = .;
+    _dmaram_r_end__ = _edmaram_r;
+  } >RAM
+
   /* User_heap_stack section, used to check that there is enough RAM left */
   _heap_stack_end = ORIGIN(STACKRAM)+LENGTH(STACKRAM) - 8; /* 8 bytes to allow for alignment */
   _heap_stack_begin = _heap_stack_end - _Min_Stack_Size  - _Min_Heap_Size;

--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -62,7 +62,7 @@ motorDevice_t *dshotPwmDevInit(const struct motorDevConfig_s *motorConfig, uint1
 #if defined(STM32H7)
 #define DSHOT_DMA_BUFFER_ATTRIBUTE DMA_RAM
 #elif defined(STM32F7)
-#define DSHOT_DMA_BUFFER_ATTRIBUTE FAST_RAM_ZERO_INIT
+#define DSHOT_DMA_BUFFER_ATTRIBUTE DMA_RAM_RW
 #else
 #define DSHOT_DMA_BUFFER_ATTRIBUTE // None
 #endif

--- a/src/main/drivers/memprot_hal.c
+++ b/src/main/drivers/memprot_hal.c
@@ -61,6 +61,10 @@ void memProtConfigure(mpuRegion_t *regions, unsigned regionCount)
             uint32_t start = region->start & ~0x1F;
             uint32_t length = region->end - start;
 
+            if (length == 0) {
+                continue;
+            }
+
             if (length < 32) {
                 // This will also prevent flsl from returning negative (case length == 0)
                 length = 32;

--- a/src/main/drivers/memprot_stm32f7xx.c
+++ b/src/main/drivers/memprot_stm32f7xx.c
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#include "memprot.h"
+
+// Defined in linker script
+extern uint8_t dmaram_rw_start;
+extern uint8_t dmaram_rw_end;
+
+extern uint8_t dmaram_w_start;
+extern uint8_t dmaram_w_end;
+
+extern uint8_t dmaram_r_start;
+extern uint8_t dmaram_r_end;
+
+mpuRegion_t mpuRegions[] = {
+#ifdef USE_ITCM_RAM
+    {
+        //  Mark ITCM-RAM as read-only
+        // "For Cortex®-M7, TCMs memories always behave as Non-cacheable, Non-shared normal memories, irrespectiveof the memory type attributes defined in the MPU for a memory region containing addresses held in the TCM"
+        // See AN4838
+        .start      = 0x00000000,
+        .end        = 0, // Size defined by "size"
+        .size       = MPU_REGION_SIZE_16KB,
+        .perm       = MPU_REGION_PRIV_RO_URO,
+        .exec       = MPU_INSTRUCTION_ACCESS_ENABLE,
+        .shareable  = MPU_ACCESS_NOT_SHAREABLE,
+        .cacheable  = MPU_ACCESS_NOT_CACHEABLE,
+        .bufferable = MPU_ACCESS_BUFFERABLE,
+    },
+#endif
+    {
+        // DMA transmit and receive buffer in SRAM
+        .start      = (uint32_t)&dmaram_rw_start,
+        .end        = (uint32_t)&dmaram_rw_end,
+        .size       = 0,  // Size determined by ".end"
+        .perm       = MPU_REGION_FULL_ACCESS,
+        .exec       = MPU_INSTRUCTION_ACCESS_ENABLE,
+        .shareable  = MPU_ACCESS_SHAREABLE,
+        .cacheable  = MPU_ACCESS_NOT_CACHEABLE,
+        .bufferable = MPU_ACCESS_NOT_BUFFERABLE,
+    },
+    {
+        // DMA transmit buffer in SRAM
+        // Reading needs cache coherence operation
+        .start      = (uint32_t)&dmaram_w_start,
+        .end        = (uint32_t)&dmaram_w_end,
+        .size       = 0,  // Size determined by ".end"
+        .perm       = MPU_REGION_FULL_ACCESS,
+        .exec       = MPU_INSTRUCTION_ACCESS_ENABLE,
+        .shareable  = MPU_ACCESS_SHAREABLE,
+        .cacheable  = MPU_ACCESS_CACHEABLE,
+        .bufferable = MPU_ACCESS_NOT_BUFFERABLE,
+    },
+    {
+        // DMA receive buffer in SRAM
+        .start      = (uint32_t)&dmaram_r_start,
+        .end        = (uint32_t)&dmaram_r_end,
+        .size       = 0,  // Size determined by ".end"
+        .perm       = MPU_REGION_FULL_ACCESS,
+        .exec       = MPU_INSTRUCTION_ACCESS_ENABLE,
+        .shareable  = MPU_ACCESS_SHAREABLE,
+        .cacheable  = MPU_ACCESS_NOT_CACHEABLE,
+        .bufferable = MPU_ACCESS_BUFFERABLE,
+    },
+};
+
+unsigned mpuRegionCount = ARRAYLEN(mpuRegions);
+
+STATIC_ASSERT(ARRAYLEN(mpuRegions) <= MAX_MPU_REGIONS, MPU_region_count_exceeds_limit);

--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -64,6 +64,7 @@
   */
 
 #include "stm32f7xx.h"
+#include "drivers/memprot.h"
 #include "drivers/system.h"
 #include "system_stm32f7xx.h"
 #include "platform.h"
@@ -309,6 +310,8 @@ void OverclockRebootIfNecessary(uint32_t overclockLevel)
   */
 void SystemInit(void)
 {
+    memProtReset();
+
     initialiseMemorySections();
 
     SystemInitOC();
@@ -351,6 +354,8 @@ void SystemInit(void)
 #ifdef USE_HAL_DRIVER
     HAL_Init();
 #endif
+
+    memProtConfigure(mpuRegions, mpuRegionCount);
 
     /* Enable I-Cache */
     if (INSTRUCTION_CACHE_ENABLE) {

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -149,12 +149,24 @@
 #define SRAM2
 #endif
 
+#if defined(STM32H7)
 #ifdef USE_DMA_RAM
 #define DMA_RAM __attribute__((section(".DMA_RAM")))
 #define DMA_RW_AXI __attribute__((section(".DMA_AXI_RW")))
 #else
 #define DMA_RAM
 #define DMA_RW_AXI
+#endif
+#elif defined(STM32F7)
+#ifdef USE_DMA_RAM
+#define DMA_RAM_RW __attribute__((section(".DMA_RAM_RW")))
+#define DMA_RAM_W __attribute__((section(".DMA_RAM_W")))
+#define DMA_RAM_R __attribute__((section(".DMA_RAM_R")))
+#else
+#define DMA_RAM_RW
+#define DMA_RAM_W
+#define DMA_RAM_R
+#endif
 #endif
 
 #define USE_BRUSHED_ESC_AUTODETECT  // Detect if brushed motors are connected and set defaults appropriately to avoid motors spinning on boot


### PR DESCRIPTION
Use MPU service introduced by #8595 to handle DMA coherency.

Currently, F7 port use DTCM_RAM (aka `FAST_RAM*`) to deal with DMA coherency issues. While this approach effectively works, it has several problems.

1. DMA transfer cycles may interfere with DTCM_RAM access by CPU, slowing down access to the "supposed to be FAST" memory.

2. It is not clear that DMA buffers should be attributed as `FAST_RAM*`, causing a problem like #8589 (fixed in #8610) .

3. While usage of DTCM_RAM is not under pressure, it is not a very good practice to use scarce resource.

---

Ref:
AN4839 Level 1 cache on STM32F7 Series and STM32H7 Series
https://www.st.com/content/ccc/resource/technical/document/application_note/group0/08/dd/25/9c/4d/83/43/12/DM00272913/files/DM00272913.pdf/jcr:content/translations/en.DM00272913.pdf

---
Todo:
Review correct attributes of each buffer region based on the above AN4839. (H7 case, too)