### PR TITLE
Fix CLI vtxtable powervalue output formatting

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2598,7 +2598,7 @@ static char *formatVtxTablePowerValues(const uint16_t *levels, int count)
 
 static const char *printVtxTablePowerValues(dumpFlags_t dumpMask, const vtxTableConfig_t *currentConfig, const vtxTableConfig_t *defaultConfig, const char *headingStr)
 {
-    char *fmt = "vtxtable powervalues %s";
+    char *fmt = "vtxtable powervalues%s";
     bool equalsDefault = false;
     if (defaultConfig) {
         equalsDefault = true;


### PR DESCRIPTION
Just a small alignment fix for the `vtxtable` powervalue output to remove extra whitespace.

Old:
```
vtxtable powerlevels 3
vtxtable powervalues  25 200 400
vtxtable powerlabels 25 200 500
```
Fixed:
```
vtxtable powerlevels 3
vtxtable powervalues 25 200 400
vtxtable powerlabels 25 200 500
```
