### PR TITLE
Fix typo vtxtable cli description

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6119,7 +6119,7 @@ const clicmd_t cmdTable[] = {
 #endif
 #endif
 #ifdef USE_VTX_TABLE
-    CLI_COMMAND_DEF("vtxtable", "vtx frequency able", "<band> <bandname> <bandletter> [FACTORY|CUSTOM] <freq> ... <freq>\r\n", cliVtxTable),
+    CLI_COMMAND_DEF("vtxtable", "vtx frequency table", "<band> <bandname> <bandletter> [FACTORY|CUSTOM] <freq> ... <freq>\r\n", cliVtxTable),
 #endif
 };
 


### PR DESCRIPTION
Fixes a little typo in the `vtxtable` CLI description.