### PR TITLE
Added 'timer show' command to CLI.

### DIFF
--- a/.github/ISSUE_TEMPLATE/firmware-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/firmware-bug-report.md
@@ -16,6 +16,8 @@ A clear and concise description of what you expected to happen.
 **Flight controller configuration**
 Create a `diff` and post it here in a code block. Put ``` (three backticks) at the start and end of the `diff` block (instructions  on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/)
 
+Use `resource show all` to create a resource allocation list and post it here in a code block. Put ``` (three backticks) at the start and end of the output block.
+
 **Setup / Versions**
  - Flight controller [what type is it, where was it bought from];
  - Other components [RX, VTX, brand / model for all of them, firmware version where applicable];

--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -131,7 +131,7 @@ void cameraControlInit(void)
 
     if (CAMERA_CONTROL_MODE_HARDWARE_PWM == cameraControlConfig()->mode) {
 #ifdef CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
-        const timerHardware_t *timerHardware = timerGetByTag(cameraControlConfig()->ioTag);
+        const timerHardware_t *timerHardware = timerAllocate(cameraControlConfig()->ioTag, OWNER_CAMERA_CONTROL);
 
         if (!timerHardware) {
             return;

--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -131,7 +131,7 @@ void cameraControlInit(void)
 
     if (CAMERA_CONTROL_MODE_HARDWARE_PWM == cameraControlConfig()->mode) {
 #ifdef CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
-        const timerHardware_t *timerHardware = timerAllocate(cameraControlConfig()->ioTag, OWNER_CAMERA_CONTROL);
+        const timerHardware_t *timerHardware = timerAllocate(cameraControlConfig()->ioTag, OWNER_CAMERA_CONTROL, 0);
 
         if (!timerHardware) {
             return;

--- a/src/main/drivers/dma.c
+++ b/src/main/drivers/dma.c
@@ -93,8 +93,8 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
 
     RCC_AHBPeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);
-    dmaDescriptors[index].owner = owner;
-    dmaDescriptors[index].resourceIndex = resourceIndex;
+    dmaDescriptors[index].owner.owner = owner;
+    dmaDescriptors[index].owner.resourceIndex = resourceIndex;
 }
 
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
@@ -115,14 +115,9 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
     NVIC_Init(&NVIC_InitStructure);
 }
 
-resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+const resourceOwner_t *dmaGetOwner(dmaIdentifier_e identifier)
 {
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
-}
-
-uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
-{
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
+    return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* channel)

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "resource.h"
+#include "drivers/resource.h"
 
 // dmaResource_t is a opaque data type which represents a single DMA engine,
 // called and implemented differently in different families of STM32s.
@@ -52,7 +52,7 @@ typedef struct dmaChannelDescriptor_s {
     uint8_t                     flagsShift;
     IRQn_Type                   irqN;
     uint32_t                    userParam;
-    resourceOwner_e             owner;
+    resourceOwner_t             owner;
     uint8_t                     resourceIndex;
     uint32_t                    completeFlag;
 } dmaChannelDescriptor_t;
@@ -102,8 +102,8 @@ typedef enum {
     .flagsShift = f, \
     .irqN = d ## _Stream ## s ## _IRQn, \
     .userParam = 0, \
-    .owner = 0, \
-    .resourceIndex = 0 \
+    .owner.owner = 0, \
+    .owner.resourceIndex = 0 \
     } 
 
 #define DEFINE_DMA_IRQ_HANDLER(d, s, i) void DMA ## d ## _Stream ## s ## _IRQHandler(void) {\
@@ -163,8 +163,8 @@ typedef enum {
     .flagsShift = f, \
     .irqN = d ## _Channel ## c ## _IRQn, \
     .userParam = 0, \
-    .owner = 0, \
-    .resourceIndex = 0 \
+    .owner.owner = 0, \
+    .owner.resourceIndex = 0 \
     }
 
 #define DEFINE_DMA_IRQ_HANDLER(d, c, i) void DMA ## d ## _Channel ## c ## _IRQHandler(void) {\
@@ -212,8 +212,7 @@ dmaResource_t* dmaGetRefByIdentifier(const dmaIdentifier_e identifier);
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam);
 
-resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier);
-uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier);
+const resourceOwner_t *dmaGetOwner(dmaIdentifier_e identifier);
 dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier);
 
 //

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -78,8 +78,8 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
 {
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     RCC_AHB1PeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);
-    dmaDescriptors[index].owner = owner;
-    dmaDescriptors[index].resourceIndex = resourceIndex;
+    dmaDescriptors[index].owner.owner = owner;
+    dmaDescriptors[index].owner.resourceIndex = resourceIndex;
 }
 
 #define RETURN_TCIF_FLAG(s, n) if (s == DMA1_Stream ## n || s == DMA2_Stream ## n) return DMA_IT_TCIF ## n
@@ -115,14 +115,9 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
     NVIC_Init(&NVIC_InitStructure);
 }
 
-resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+const resourceOwner_t *dmaGetOwner(dmaIdentifier_e identifier)
 {
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
-}
-
-uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
-{
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
+    return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* instance)

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -91,8 +91,8 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
 
     enableDmaClock(index);
-    dmaDescriptors[index].owner = owner;
-    dmaDescriptors[index].resourceIndex = resourceIndex;
+    dmaDescriptors[index].owner.owner = owner;
+    dmaDescriptors[index].owner.resourceIndex = resourceIndex;
 }
 
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
@@ -107,14 +107,9 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
     HAL_NVIC_EnableIRQ(dmaDescriptors[index].irqN);
 }
 
-resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+const resourceOwner_t *dmaGetOwner(dmaIdentifier_e identifier)
 {
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
-}
-
-uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
-{
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
+    return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* stream)

--- a/src/main/drivers/dma_stm32h7xx.c
+++ b/src/main/drivers/dma_stm32h7xx.c
@@ -95,8 +95,8 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
 
     enableDmaClock(index);
-    dmaDescriptors[index].owner = owner;
-    dmaDescriptors[index].resourceIndex = resourceIndex;
+    dmaDescriptors[index].owner.owner = owner;
+    dmaDescriptors[index].owner.resourceIndex = resourceIndex;
 }
 
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
@@ -111,14 +111,9 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
     HAL_NVIC_EnableIRQ(dmaDescriptors[index].irqN);
 }
 
-resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
+const resourceOwner_t *dmaGetOwner(dmaIdentifier_e identifier)
 {
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
-}
-
-uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
-{
-    return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
+    return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* stream)

--- a/src/main/drivers/dshot_dpwm.c
+++ b/src/main/drivers/dshot_dpwm.c
@@ -177,7 +177,7 @@ motorDevice_t *dshotPwmDevInit(const motorDevConfig_t *motorConfig, uint16_t idl
 
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
         const ioTag_t tag = motorConfig->ioTags[motorIndex];
-        const timerHardware_t *timerHardware = timerGetByTag(tag);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
 
         if (timerHardware == NULL) {
             /* not enough motors initialised for the mixer or a break in the motors */

--- a/src/main/drivers/dshot_dpwm.c
+++ b/src/main/drivers/dshot_dpwm.c
@@ -177,7 +177,7 @@ motorDevice_t *dshotPwmDevInit(const motorDevConfig_t *motorConfig, uint16_t idl
 
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
         const ioTag_t tag = motorConfig->ioTags[motorIndex];
-        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
 
         if (timerHardware == NULL) {
             /* not enough motors initialised for the mixer or a break in the motors */

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -55,7 +55,7 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
         return false;
     }
 
-    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP, 0);
 
     if (timerHardware == NULL) {
         return false;

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -55,7 +55,7 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
         return false;
     }
 
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP);
 
     if (timerHardware == NULL) {
         return false;

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -83,7 +83,7 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_OCInitTypeDef  TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
 
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP);
 
     if (timerHardware == NULL) {
         return false;

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -83,7 +83,7 @@ bool ws2811LedStripHardwareInit(ioTag_t ioTag)
     TIM_OCInitTypeDef  TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
 
-    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP, 0);
 
     if (timerHardware == NULL) {
         return false;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -213,7 +213,7 @@ motorDevice_t *motorPwmDevInit(const motorDevConfig_t *motorConfig, uint16_t idl
 
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
         const ioTag_t tag = motorConfig->ioTags[motorIndex];
-        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
 
         if (timerHardware == NULL) {
             /* not enough motors initialised for the mixer or a break in the motors */
@@ -294,7 +294,7 @@ void servoDevInit(const servoDevConfig_t *servoConfig)
 
         IOInit(servos[servoIndex].io, OWNER_SERVO, RESOURCE_INDEX(servoIndex));
 
-        const timerHardware_t *timer = timerAllocate(tag, OWNER_SERVO);
+        const timerHardware_t *timer = timerAllocate(tag, OWNER_SERVO, RESOURCE_INDEX(servoIndex));
 
         if (timer == NULL) {
             /* flag failure and disable ability to arm */

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -213,7 +213,7 @@ motorDevice_t *motorPwmDevInit(const motorDevConfig_t *motorConfig, uint16_t idl
 
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
         const ioTag_t tag = motorConfig->ioTags[motorIndex];
-        const timerHardware_t *timerHardware = timerGetByTag(tag);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
 
         if (timerHardware == NULL) {
             /* not enough motors initialised for the mixer or a break in the motors */
@@ -294,7 +294,7 @@ void servoDevInit(const servoDevConfig_t *servoConfig)
 
         IOInit(servos[servoIndex].io, OWNER_SERVO, RESOURCE_INDEX(servoIndex));
 
-        const timerHardware_t *timer = timerGetByTag(tag);
+        const timerHardware_t *timer = timerAllocate(tag, OWNER_SERVO);
 
         if (timer == NULL) {
             /* flag failure and disable ability to arm */

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -100,6 +100,11 @@ typedef enum {
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 
+typedef struct resourceOwner_s {
+    resourceOwner_e owner;
+    uint8_t resourceIndex;
+} resourceOwner_t;
+
 extern const char * const ownerNames[OWNER_TOTAL_COUNT];
 
 #define RESOURCE_INDEX(x) (x + 1)

--- a/src/main/drivers/rx/rx_pwm.c
+++ b/src/main/drivers/rx/rx_pwm.c
@@ -371,7 +371,7 @@ void pwmRxInit(const pwmConfig_t *pwmConfig)
 
         pwmInputPort_t *port = &pwmInputPorts[channel];
 
-        const timerHardware_t *timer = timerAllocate(pwmConfig->ioTags[channel], OWNER_PWMINPUT);
+        const timerHardware_t *timer = timerAllocate(pwmConfig->ioTags[channel], OWNER_PWMINPUT, RESOURCE_INDEX(channel));
 
         if (!timer) {
             /* TODO: maybe fail here if not enough channels? */
@@ -428,7 +428,7 @@ void ppmRxInit(const ppmConfig_t *ppmConfig)
 
     pwmInputPort_t *port = &pwmInputPorts[FIRST_PWM_PORT];
 
-    const timerHardware_t *timer = timerAllocate(ppmConfig->ioTag, OWNER_PPMINPUT);
+    const timerHardware_t *timer = timerAllocate(ppmConfig->ioTag, OWNER_PPMINPUT, 0);
     if (!timer) {
         /* TODO: fail here? */
         return;

--- a/src/main/drivers/rx/rx_pwm.c
+++ b/src/main/drivers/rx/rx_pwm.c
@@ -371,7 +371,7 @@ void pwmRxInit(const pwmConfig_t *pwmConfig)
 
         pwmInputPort_t *port = &pwmInputPorts[channel];
 
-        const timerHardware_t *timer = timerGetByTag(pwmConfig->ioTags[channel]);
+        const timerHardware_t *timer = timerAllocate(pwmConfig->ioTags[channel], OWNER_PWMINPUT);
 
         if (!timer) {
             /* TODO: maybe fail here if not enough channels? */
@@ -428,7 +428,7 @@ void ppmRxInit(const ppmConfig_t *ppmConfig)
 
     pwmInputPort_t *port = &pwmInputPorts[FIRST_PWM_PORT];
 
-    const timerHardware_t *timer = timerGetByTag(ppmConfig->ioTag);
+    const timerHardware_t *timer = timerAllocate(ppmConfig->ioTag, OWNER_PPMINPUT);
     if (!timer) {
         /* TODO: fail here? */
         return;

--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -668,7 +668,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
     }
     if (mode != PROTOCOL_KISSALL) {
         const ioTag_t tag = motorConfig->ioTags[output];
-        const timerHardware_t *timerHardware = timerGetByTag(tag);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
 
         if (timerHardware == NULL) {
             return NULL;
@@ -686,7 +686,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
     }
 
     escSerial->mode = mode;
-    escSerial->txTimerHardware = timerGetByTag(escSerialConfig()->ioTag);
+    escSerial->txTimerHardware = timerAllocate(escSerialConfig()->ioTag, OWNER_MOTOR);
     if (escSerial->txTimerHardware == NULL) {
         return NULL;
     }
@@ -745,7 +745,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
             if (pwmMotors[i].enabled && pwmMotors[i].io != IO_NONE) {
                 const ioTag_t tag = motorConfig->ioTags[i];
                 if (tag != IO_TAG_NONE) {
-                    const timerHardware_t *timerHardware = timerGetByTag(tag);
+                    const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
                     if (timerHardware) {
                         escSerialOutputPortConfig(timerHardware);
                         escOutputs[escSerial->outputCount].io = pwmMotors[i].io;

--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -668,7 +668,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
     }
     if (mode != PROTOCOL_KISSALL) {
         const ioTag_t tag = motorConfig->ioTags[output];
-        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, 0);
 
         if (timerHardware == NULL) {
             return NULL;
@@ -686,7 +686,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
     }
 
     escSerial->mode = mode;
-    escSerial->txTimerHardware = timerAllocate(escSerialConfig()->ioTag, OWNER_MOTOR);
+    escSerial->txTimerHardware = timerAllocate(escSerialConfig()->ioTag, OWNER_MOTOR, 0);
     if (escSerial->txTimerHardware == NULL) {
         return NULL;
     }
@@ -745,7 +745,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
             if (pwmMotors[i].enabled && pwmMotors[i].io != IO_NONE) {
                 const ioTag_t tag = motorConfig->ioTags[i];
                 if (tag != IO_TAG_NONE) {
-                    const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR);
+                    const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, 0);
                     if (timerHardware) {
                         escSerialOutputPortConfig(timerHardware);
                         escOutputs[escSerial->outputCount].io = pwmMotors[i].io;

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -242,8 +242,8 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     ioTag_t tagRx = serialPinConfig()->ioTagRx[pinCfgIndex];
     ioTag_t tagTx = serialPinConfig()->ioTagTx[pinCfgIndex];
 
-    const timerHardware_t *timerRx = timerGetByTag(tagRx);
-    const timerHardware_t *timerTx = timerGetByTag(tagTx);
+    const timerHardware_t *timerRx = timerAllocate(tagRx, OWNER_SERIAL_RX);
+    const timerHardware_t *timerTx = timerAllocate(tagTx, OWNER_SERIAL_TX);
 
     IO_t rxIO = IOGetByTag(tagRx);
     IO_t txIO = IOGetByTag(tagTx);

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -242,8 +242,8 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     ioTag_t tagRx = serialPinConfig()->ioTagRx[pinCfgIndex];
     ioTag_t tagTx = serialPinConfig()->ioTagTx[pinCfgIndex];
 
-    const timerHardware_t *timerRx = timerAllocate(tagRx, OWNER_SERIAL_RX);
-    const timerHardware_t *timerTx = timerAllocate(tagTx, OWNER_SERIAL_TX);
+    const timerHardware_t *timerRx = timerAllocate(tagRx, OWNER_SERIAL_RX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
+    const timerHardware_t *timerTx = timerAllocate(tagTx, OWNER_SERIAL_TX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
 
     IO_t rxIO = IOGetByTag(tagRx);
     IO_t txIO = IOGetByTag(tagTx);

--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -61,7 +61,7 @@ static void pwmToggleBeeper(void)
 
 static void beeperPwmInit(const ioTag_t tag, uint16_t frequency)
 {
-    const timerHardware_t *timer = timerGetByTag(tag);
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_BEEPER);
     IO_t beeperIO = IOGetByTag(tag);
 
     if (beeperIO && timer) {

--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -61,12 +61,12 @@ static void pwmToggleBeeper(void)
 
 static void beeperPwmInit(const ioTag_t tag, uint16_t frequency)
 {
-    const timerHardware_t *timer = timerAllocate(tag, OWNER_BEEPER);
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_BEEPER, 0);
     IO_t beeperIO = IOGetByTag(tag);
 
     if (beeperIO && timer) {
         beeperPwm.io = beeperIO;
-        IOInit(beeperPwm.io, OWNER_BEEPER, RESOURCE_INDEX(0));
+        IOInit(beeperPwm.io, OWNER_BEEPER, 0);
 #if defined(STM32F1)
         IOConfigGPIO(beeperPwm.io, IOCFG_AF_PP);
 #else

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -257,15 +257,20 @@ const int8_t timerNumbers[USED_TIMER_COUNT] = {
 #undef _DEF
 };
 
-int8_t timerGetTIMNumber(const TIM_TypeDef *tim)
+int8_t timerGetNumberByIndex(uint8_t index)
 {
-    uint8_t index = lookupTimerIndex(tim);
-
     if (index < USED_TIMER_COUNT) {
         return timerNumbers[index];
     } else {
         return 0;
     }
+}
+
+int8_t timerGetTIMNumber(const TIM_TypeDef *tim)
+{
+    const uint8_t index = lookupTimerIndex(tim);
+
+    return timerGetNumberByIndex(index);
 }
 
 static inline uint8_t lookupChannelIndex(const uint16_t channel)

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -270,8 +270,10 @@ uint8_t timerInputIrq(TIM_TypeDef *tim);
 
 #if defined(USE_TIMER_MGMT)
 timerIOConfig_t *timerIoConfigByTag(ioTag_t ioTag);
+resourceOwner_e timerGetOwner(int8_t timerNumber, uint16_t timerChannel);
 #endif
 const timerHardware_t *timerGetByTag(ioTag_t ioTag);
+const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner);
 const timerHardware_t *timerGetByTagAndIndex(ioTag_t ioTag, unsigned timerIndex);
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index);
 
@@ -292,5 +294,6 @@ uint16_t timerGetPrescalerByDesiredHertz(TIM_TypeDef *tim, uint32_t hz);
 uint16_t timerGetPrescalerByDesiredMhz(TIM_TypeDef *tim, uint16_t mhz);
 uint16_t timerGetPeriodByPrescaler(TIM_TypeDef *tim, uint16_t prescaler, uint32_t hz);
 
+int8_t timerGetNumberByIndex(uint8_t index);
 int8_t timerGetTIMNumber(const TIM_TypeDef *tim);
 uint8_t timerLookupChannelIndex(const uint16_t channel);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -26,6 +26,7 @@
 #include "drivers/dma.h"
 #include "drivers/io_types.h"
 #include "drivers/rcc_types.h"
+#include "drivers/resource.h"
 #include "drivers/timer_def.h"
 
 #include "pg/timerio.h"
@@ -270,10 +271,10 @@ uint8_t timerInputIrq(TIM_TypeDef *tim);
 
 #if defined(USE_TIMER_MGMT)
 timerIOConfig_t *timerIoConfigByTag(ioTag_t ioTag);
-resourceOwner_e timerGetOwner(int8_t timerNumber, uint16_t timerChannel);
+const resourceOwner_t *timerGetOwner(int8_t timerNumber, uint16_t timerChannel);
 #endif
 const timerHardware_t *timerGetByTag(ioTag_t ioTag);
-const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner);
+const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex);
 const timerHardware_t *timerGetByTagAndIndex(ioTag_t ioTag, unsigned timerIndex);
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index);
 

--- a/src/main/drivers/timer_hal.c
+++ b/src/main/drivers/timer_hal.c
@@ -264,15 +264,20 @@ const int8_t timerNumbers[USED_TIMER_COUNT] = {
 #undef _DEF
 };
 
-int8_t timerGetTIMNumber(const TIM_TypeDef *tim)
+int8_t timerGetNumberByIndex(uint8_t index)
 {
-    uint8_t index = lookupTimerIndex(tim);
-
     if (index < USED_TIMER_COUNT) {
         return timerNumbers[index];
     } else {
         return 0;
     }
+}
+
+int8_t timerGetTIMNumber(const TIM_TypeDef *tim)
+{
+    uint8_t index = lookupTimerIndex(tim);
+
+    return timerGetNumberByIndex(index);
 }
 
 static inline uint8_t lookupChannelIndex(const uint16_t channel)

--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -72,7 +72,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
         return;
     }
 
-    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER, 0);
     TIM_TypeDef *timer = timerHardware->tim;
     timerChannel = timerHardware->channel;
     output = timerHardware->output;

--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -72,7 +72,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
         return;
     }
 
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER);
     TIM_TypeDef *timer = timerHardware->tim;
     timerChannel = timerHardware->channel;
     output = timerHardware->output;

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -67,7 +67,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
     TIM_OCInitTypeDef  TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
 
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER);
     timer = timerHardware->tim;
     alternateFunction = timerHardware->alternateFunction;
 

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -67,7 +67,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder)
     TIM_OCInitTypeDef  TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
 
-    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER, 0);
     timer = timerHardware->tim;
     alternateFunction = timerHardware->alternateFunction;
 


### PR DESCRIPTION
This adds a `timer show` and an extended `resource show all` commands (example see below), for convenient analysis of the current resource allocation.

Another change is that, since this introduces tracking of allocation of timers, attempts to allocate / initialise a timer for a second time in the case of resource conflicts is now prevented.

Also includes an amendment to the GitHub issue submission instructions asking the user to provide the output of `resource show all`.


```
# resource show all
Currently active IO resource assignments:
(reboot to update)
--------------------
A00: FREE
A01: LED_STRIP
A02: MOTOR 4
A03: MOTOR 3
A04: GYRO_CS 1
A05: SPI_SCK 1
A06: SPI_MISO 1
A07: SPI_MOSI 1
A08: FREE
A09: FREE
A10: FREE
A11: USB
A12: USB
A13: FREE
A14: FREE
A15: PREINIT 4
B00: MOTOR 1
B01: MOTOR 2
B02: FREE
B03: FLASH_CS
B04: BEEPER
B05: LED 1
B06: FREE
B07: FREE
B08: FREE
B09: FREE
B10: FREE
B11: FREE
B12: FREE
B13: FREE
B14: PWM 1
B15: PWM 2
C00: INVERTER 1
C01: ADC_CURR
C02: ADC_BATT
C03: FREE
C04: GYRO_EXTI
C05: FREE
C06: PWM 3
C07: PWM 4
C08: PWM 5
C09: PWM 6
C10: SPI_SCK 3
C11: SPI_MISO 3
C12: SPI_MOSI 3
C13: FREE
C14: FREE
C15: FREE
D00: FREE
D01: FREE
D02: PREINIT 3
D03: FREE
D04: FREE
D05: FREE
D06: FREE
D07: FREE
D08: FREE
D09: FREE
D10: FREE
D11: FREE
D12: FREE
D13: FREE
D14: FREE
D15: FREE
E00: FREE
E01: FREE
E02: FREE
E03: FREE
E04: FREE
E05: FREE
E06: FREE
E07: FREE
E08: FREE
E09: FREE
E10: FREE
E11: FREE
E12: FREE
E13: FREE
E14: FREE
E15: FREE
F00: FREE
F01: FREE
F02: FREE
F03: FREE
F04: FREE
F05: FREE
F06: FREE
F07: FREE
F08: FREE
F09: FREE
F10: FREE
F11: FREE
F12: FREE
F13: FREE
F14: FREE
F15: FREE

Currently active Timers:
-----------------------
TIM1: FREE
TIM2:
    CH3: MOTOR
    CH4: MOTOR
TIM3:
    CH3: MOTOR
    CH4: MOTOR
TIM4: FREE
TIM5:
    CH2: LED_STRIP
TIM6: FREE
TIM7: FREE
TIM8:
    CH1: PWM
    CH2: PWM
    CH3: PWM
    CH4: PWM
TIM9: FREE
TIM10: FREE
TIM11: FREE
TIM12:
    CH1: PWM
    CH2: PWM
TIM13: FREE
TIM14: FREE

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: MOTOR 4
DMA1 Stream 2: MOTOR 2
DMA1 Stream 3: FREE
DMA1 Stream 4: LED_STRIP
DMA1 Stream 5: FREE
DMA1 Stream 6: MOTOR 3
DMA1 Stream 7: MOTOR 1
DMA2 Stream 0: FREE
DMA2 Stream 1: FREE
DMA2 Stream 2: FREE
DMA2 Stream 3: ADC 2
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```