### PR TITLE
Allow MSP clients to know if the target has a flash bootloer.

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -515,6 +515,7 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 #define TARGET_HAS_VCP_BIT 0
 #define TARGET_HAS_SOFTSERIAL_BIT 1
 #define TARGET_IS_UNIFIED_BIT 2
+#define TARGET_HAS_FLASH_BOOTLOADER_BIT 3
 
         uint8_t targetCapabilities = 0;
 #ifdef USE_VCP
@@ -526,7 +527,9 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 #if defined(USE_UNIFIED_TARGET)
         targetCapabilities |= 1 << TARGET_IS_UNIFIED_BIT;
 #endif
-
+#if defined(USE_FLASH_BOOT_LOADER)
+        targetCapabilities |= 1 << TARGET_HAS_FLASH_BOOTLOADER_BIT;
+#endif
         sbufWriteU8(dst, targetCapabilities);
 
         // Target name with explicit length


### PR DESCRIPTION
Targets with flash bootloaders need a different reboot sequence for firmware updates.

Note: as the default was changed from 'reboot to DFU that allows for firmware flashing' of the original EXST code to 'always reboot to ROM dfu mode' in PR https://github.com/betaflight/betaflight/pull/8429 this is knock-on effect which involves further changes to the firmware and additional client/configurator changes.