### PR TITLE
Fix invalid H7 EXST targert invalid load addresses (Solution B)

### DIFF
--- a/src/link/stm32_flash_h750_exst.ld
+++ b/src/link/stm32_flash_h750_exst.ld
@@ -20,8 +20,8 @@ ENTRY(Reset_Handler)
 
 /*
 0x00000000 to 0x0000FFFF   64K ITCM
-0x20000000 to 0x2001FFFF  128K DTCM
-0x24000000 to 0x2407FFFF  512K AXI SRAM, D1 domain, main RAM
+0x20000000 to 0x2001FFFF  128K DTCM, main RAM
+0x24000000 to 0x2407FFFF  512K AXI SRAM, D1 domain
 0x30000000 to 0x3001FFFF  128K SRAM1, D2 domain, unused
 0x30020000 to 0x3003FFFF  128K SRAM2, D2 domain, unused
 0x30040000 to 0x30047FFF   32K SRAM3, D2 domain, unused
@@ -178,7 +178,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >RAM AT >CODE_RAM
+  } >DTCM_RAM AT >CODE_RAM
 
   /* Uninitialized data section */
   . = ALIGN(4);

--- a/src/link/stm32_flash_h750_exst.ld
+++ b/src/link/stm32_flash_h750_exst.ld
@@ -58,9 +58,9 @@ MEMORY
 {
     ITCM_RAM (rwx)    : ORIGIN = 0x00000000, LENGTH = 64K
     DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
-    RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 128K
-    CODE_RAM (rx)     : ORIGIN = 0x24020000, LENGTH = 384K - _exst_hash_size
-    EXST_HASH (rx)    : ORIGIN = 0x24020000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
+    RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 64K
+    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _exst_hash_size
+    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
 
     D2_RAM (rwx)      : ORIGIN = 0x30000000, LENGTH = 256K /* SRAM1 + SRAM2 */
 


### PR DESCRIPTION
This fix reverts #8668 which was incorrect. As an alternative solution to the ram overflow issue this PR moves initialized data to DTCM RAM.

Note: Making the DTCM_RAM default for uninitialised data resulted in a boot loop and requires investigation.

```
Linking SPRACINGH7EXTREME 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       10472 B        64 KB     15.98%
        DTCM_RAM:         22 KB       128 KB     17.19%
             RAM:       54112 B        64 KB     82.57%
        CODE_RAM:      344764 B     458688 B     75.16%
       EXST_HASH:          64 B         64 B    100.00%
          D2_RAM:       11776 B       256 KB      4.49%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
         QUADSPI:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 333452	  11376	  77096	 421924	  67024	./obj/main/betaflight_SPRACINGH7EXTREME.elf
```

This is an alternative to #8675