### PR TITLE
Fix compilation errors if USE_ABSOLUTE_CONTROL if defined but USE_ITERM_RELAX is not

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -368,3 +368,7 @@ extern uint8_t __config_end;
 #if !defined(USE_RPM_FILTER)
 #undef USE_DYN_IDLE
 #endif
+
+#ifndef USE_ITERM_RELAX
+#undef USE_ABSOLUTE_CONTROL
+#endif


### PR DESCRIPTION
Applies to 4.0 as well.