### PR TITLE
Dynamic gyro and dterm lowpass filters based on rpm data

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -93,4 +93,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "DYN_IDLE",
     "FF_LIMIT",
     "FF_INTERPOLATED",
+    "RPM_LPF",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -109,6 +109,7 @@ typedef enum {
     DEBUG_DYN_IDLE,
     DEBUG_FF_LIMIT,
     DEBUG_FF_INTERPOLATED,
+    DEBUG_RPM_LPF,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -592,9 +592,7 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableLEDProfile),
     LOOKUP_TABLE_ENTRY(lookupTableLedstripColors),
 #endif
-
     LOOKUP_TABLE_ENTRY(lookupTableGyroFilterDebug),
-
     LOOKUP_TABLE_ENTRY(lookupTablePositionAltSource),
     LOOKUP_TABLE_ENTRY(lookupTableOffOnAuto),
     LOOKUP_TABLE_ENTRY(lookupTableInterpolatedSetpoint),
@@ -645,6 +643,8 @@ const clivalue_t valueTable[] = {
 #ifdef USE_DYN_LPF
     { "dyn_lpf_gyro_min_hz",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_gyro_min_hz) },
     { "dyn_lpf_gyro_max_hz",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_gyro_max_hz) },
+    { "dyn_lpf_rpm_mode",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_rpm_mode) },
+    { "dyn_lpf_rpm_gyro_cutoff",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 50, 200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_rpm_gyro_cutoff) },
 #endif
     { "gyro_filter_debug_axis",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_FILTER_DEBUG }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_debug_axis) },
 
@@ -976,6 +976,7 @@ const clivalue_t valueTable[] = {
 #ifdef USE_DYN_LPF
     { "dyn_lpf_dterm_min_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_min_hz) },
     { "dyn_lpf_dterm_max_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_max_hz) },
+    { "dyn_lpf_rpm_dterm_cutoff",   VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 50, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_rpm_dterm_cutoff) },
 #endif
     { "dterm_lowpass_type",         VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DTERM_LOWPASS_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_filter_type) },
     { "dterm_lowpass_hz",           VAR_INT16  | PROFILE_VALUE, .config.minmax = { 0, FILTER_FREQUENCY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_lowpass_hz) },

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -184,6 +184,8 @@ typedef struct pidProfile_s {
     uint8_t ff_interpolate_sp;              // Calculate FF from interpolated setpoint
     uint8_t ff_max_rate_limit;              // Maximum setpoint rate percentage for FF
     uint8_t ff_spike_limit;                 // FF stick extrapolation lookahead period in ms
+    uint8_t ff_lookahead_limit;             // FF stick extrapolation lookahead period in ms
+    uint8_t dyn_lpf_rpm_dterm_cutoff;
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -66,6 +66,7 @@ typedef struct rpmNotchFilter_s
 FAST_RAM_ZERO_INIT static float   erpmToHz;
 FAST_RAM_ZERO_INIT static float   filteredMotorErpm[MAX_SUPPORTED_MOTORS];
 FAST_RAM_ZERO_INIT static float   minMotorFrequency;
+FAST_RAM_ZERO_INIT static float   avgMotorFrequency;
 FAST_RAM_ZERO_INIT static uint8_t numberFilters;
 FAST_RAM_ZERO_INIT static uint8_t numberRpmNotchFilters;
 FAST_RAM_ZERO_INIT static uint8_t filterUpdatesPerIteration;
@@ -248,5 +249,18 @@ float rpmMinMotorFrequency()
     return minMotorFrequency;
 }
 
+void rpmAvgMotorFrequency() {
+    avgMotorFrequency = 0;
+    for (int i = 0; i < getMotorCount(); i++) {
+        avgMotorFrequency += motorFrequency[i];
+    }
+    avgMotorFrequency = avgMotorFrequency / getMotorCount();
+}
+
+float getCutoffFrequency(uint8_t cutoffPercent) {
+    const float percent = cutoffPercent / 100.0f;
+    DEBUG_SET(DEBUG_RPM_LPF, 0, avgMotorFrequency);
+    return avgMotorFrequency * percent;
+}
 
 #endif

--- a/src/main/flight/rpm_filter.h
+++ b/src/main/flight/rpm_filter.h
@@ -44,3 +44,5 @@ float rpmFilterDterm(int axis, float values);
 void  rpmFilterUpdate();
 bool isRpmFilterEnabled(void);
 float rpmMinMotorFrequency();
+float getCutoffFrequency(uint8_t cutoffPercent);
+void rpmAvgMotorFrequency();

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -108,6 +108,11 @@ enum {
     FILTER_LOWPASS2
 };
 
+enum {
+    OFF = 0,
+    ON
+};
+
 typedef enum gyroDetectionFlags_e {
     NO_GYROS_DETECTED = 0,
     DETECTED_GYRO_1 = (1 << 0),
@@ -152,6 +157,8 @@ typedef struct gyroConfig_s {
     uint16_t dyn_notch_q;
     uint16_t dyn_notch_min_hz;
     uint8_t  gyro_filter_debug_axis;
+    uint8_t  dyn_lpf_rpm_mode;
+    uint8_t  dyn_lpf_rpm_gyro_cutoff;
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);


### PR DESCRIPTION
This PR adds an option to use rpm data for setting dynamic gyro and dterm lowpass filters.
To use it, set dyn_lpf_rpm_mode = ON
Gyro cutoff percent can be set with dyn_lpf_rpm_gyro_cutoff (50 - 200, internally scaled to 0.5 - 2).
Dterm cutoff percent can be set with dyn_lpf_rpm_dterm_cutoff (50-100, internally scaled to 0.5 - 1).
