### PR TITLE
Change lowpass 1 on D from biquad to pt1

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -188,7 +188,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
                                     // value to 0 otherwise Configurator versions 10.4 and earlier will also
                                     // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
         .dterm_lowpass2_hz = 150,   // second Dterm LPF ON by default
-        .dterm_filter_type = FILTER_BIQUAD,
+        .dterm_filter_type = FILTER_PT1,
         .dterm_filter2_type = FILTER_PT1,
         .dyn_lpf_dterm_min_hz = 70,
         .dyn_lpf_dterm_max_hz = 170,


### PR DESCRIPTION
4.1 has already moved the settings for the dynamic D lowpass to the range 70-170hz, and the type is biquad.  The second D lowpass is at 150hz PT1.

There isn't really a need, noise wise, for third order filtering on D if we have, preceding it, second order filtering on gyro.  

By changing this last biquad back to a PT1 we save delay and still maintain the same cut at 70hz.  This means flyaways at idle won't be any more likely.

I have had extensive experience now helping people with issues relating to 4.0 filtering in Facebook, and almost overwhelmingly they do better with four PT1 filters than biquad setups.  I don't know exactly why but they just do.  Many pilots reported that 3.5 filtering worked better than 4.0 filtering no matter what they did, and 3.5 filters were just four static PT1's.  

Anyway I have some very beat up flexy quads and they all run fine with this change, as do the people who had issues with other filter setups.

I think that with this change the 4.1 filtering will be very, very good, by default.  It has similarities in delay and cutoff characteristics to the 3.5 filters that have been acclaimed as trouble free by most people, but with less delay from the dynamic elements, and stronger filtering at idle.