### PR TITLE
 Fixed lockups in FrSky SPI RX.

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1135,7 +1135,6 @@ static FAST_CODE_NOINLINE void subTaskRcCommand(timeUs_t currentTimeUs)
     }
 
     processRcCommand();
-
 }
 
 // Function for loop trigger

--- a/src/main/rx/cc2500_frsky_common.h
+++ b/src/main/rx/cc2500_frsky_common.h
@@ -24,4 +24,5 @@
 
 bool frSkySpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeConfig_t *rxRuntimeConfig);
 rx_spi_received_e frSkySpiDataReceived(uint8_t *packet);
+rx_spi_received_e frSkySpiProcessFrame(uint8_t *packet);
 void frSkySpiSetRcData(uint16_t *rcData, const uint8_t *payload);

--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -194,7 +194,7 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
     switch (*protocolState) {
     case STATE_STARTING:
         listLength = 47;
-        initialiseData(0);
+        initialiseData(false);
         *protocolState = STATE_UPDATE;
         nextChannel(1);
         cc2500Strobe(CC2500_SRX);
@@ -218,9 +218,11 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
     case STATE_DATA:
         if (cc2500getGdo()) {
             uint8_t ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
+            bool packetOk = false;
             if (ccLen >= 20) {
                 cc2500ReadFifo(packet, 20);
                 if (packet[19] & 0x80) {
+                    packetOk = true;
                     missingPackets = 0;
                     timeoutUs = 1;
                     if (packet[0] == 0x11) {
@@ -245,6 +247,9 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
                         }
                     }
                 }
+            }
+            if (!packetOk) {
+                cc2500Strobe(CC2500_SRX);
             }
         }
 

--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -152,13 +152,16 @@ static void initialise() {
     }
 }
 
-void initialiseData(uint8_t adr)
+void initialiseData(bool inBindState)
 {
     cc2500WriteReg(CC2500_0C_FSCTRL0, (uint8_t)rxCc2500SpiConfig()->bindOffset);
     cc2500WriteReg(CC2500_18_MCSM0, 0x8);
-    cc2500WriteReg(CC2500_09_ADDR, adr ? 0x03 : rxCc2500SpiConfig()->bindTxId[0]);
+    cc2500WriteReg(CC2500_09_ADDR, inBindState ? 0x03 : rxCc2500SpiConfig()->bindTxId[0]);
     cc2500WriteReg(CC2500_07_PKTCTRL1, 0x0D);
     cc2500WriteReg(CC2500_19_FOCCFG, 0x16);
+    if (!inBindState) {
+        cc2500WriteReg(CC2500_03_FIFOTHR,  0x14);
+    }
     delay(10);
 }
 
@@ -334,7 +337,7 @@ rx_spi_received_e frSkySpiDataReceived(uint8_t *packet)
     case STATE_BIND_TUNING:
        if (tuneRx(packet)) {
             initGetBind();
-            initialiseData(1);
+            initialiseData(true);
 
             protocolState = STATE_BIND_BINDING1;
         }

--- a/src/main/rx/cc2500_frsky_shared.h
+++ b/src/main/rx/cc2500_frsky_shared.h
@@ -51,6 +51,6 @@ extern uint8_t listLength;
 extern uint32_t missingPackets;
 extern timeDelta_t timeoutUs;
 
-void initialiseData(uint8_t adr);
+void initialiseData(bool inBindState);
 
 void nextChannel(uint8_t skip);

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -346,7 +346,7 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
     switch (*protocolState) {
     case STATE_STARTING:
         listLength = 47;
-        initialiseData(0);
+        initialiseData(false);
         *protocolState = STATE_UPDATE;
         nextChannel(1);
         cc2500Strobe(CC2500_SRX);
@@ -369,10 +369,12 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
         // here FS code could be
     case STATE_DATA:
         if (cc2500getGdo() && (frameReceived == false)){
+            bool packetOk = false;
             uint8_t ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
             if (ccLen >= packetLength) {
                 cc2500ReadFifo(packet, packetLength);
                 if (isValidPacket(packet)) {
+                    packetOk = true;
                     missingPackets = 0;
                     timeoutUs = 1;
                     receiveDelayUs = 0;
@@ -446,6 +448,9 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
                     packetErrors++;
                     DEBUG_SET(DEBUG_RX_FRSKY_SPI, DEBUG_DATA_BAD_FRAME, packetErrors);
                 }
+            }
+            if (!packetOk) {
+                cc2500Strobe(CC2500_SRX);
             }
         }
         if (telemetryReceived) {

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -141,16 +141,21 @@ typedef struct telemetryPayload_s {
 static telemetryData_t telemetryTxBuffer[TELEMETRY_SEQUENCE_LENGTH];
 #endif
 
+static telemetryBuffer_t telemetryRxBuffer[TELEMETRY_SEQUENCE_LENGTH];
+
 static telemetrySequenceMarker_t responseToSend;
 
 #if defined(USE_RX_FRSKY_SPI_TELEMETRY)
 static uint8_t frame[20];
+
 #if defined(USE_TELEMETRY_SMARTPORT)
 static uint8_t telemetryOutWriter;
 
 static uint8_t telemetryOutBuffer[TELEMETRY_OUT_BUFFER_SIZE];
 
 static bool telemetryEnabled = false;
+
+static uint8_t remoteProcessedId = 0;
 #endif
 #endif // USE_RX_FRSKY_SPI_TELEMETRY
 
@@ -320,13 +325,9 @@ bool isValidPacket(const uint8_t *packet)
 rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const protocolState)
 {
     static unsigned receiveTelemetryRetryCount = 0;
-    static timeMs_t pollingTimeMs = 0;
     static bool skipChannels = true;
 
-    static uint8_t remoteProcessedId = 0;
     static uint8_t remoteAckId = 0;
-
-    static uint8_t remoteToProcessIndex = 0;
 
     static timeUs_t packetTimerUs;
 
@@ -334,8 +335,6 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
     static timeDelta_t receiveDelayUs;
     static uint8_t channelsToSkip = 1;
     static uint32_t packetErrors = 0;
-
-    static telemetryBuffer_t telemetryRxBuffer[TELEMETRY_SEQUENCE_LENGTH];
 
 #if defined(USE_RX_FRSKY_SPI_TELEMETRY)
     static bool telemetryReceived = false;
@@ -432,7 +431,9 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
                     }
 
                     if (receiveTelemetryRetryCount >= 5) {
+#if defined(USE_RX_FRSKY_SPI_TELEMETRY) && defined(USE_TELEMETRY_SMARTPORT)
                          remoteProcessedId = TELEMETRY_SEQUENCE_LENGTH - 1;
+#endif
                          remoteAckId = TELEMETRY_SEQUENCE_LENGTH - 1;
                          for (unsigned i = 0; i < TELEMETRY_SEQUENCE_LENGTH; i++) {
                              telemetryRxBuffer[i].needsProcessing = false;
@@ -483,35 +484,12 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
 
 #if defined(USE_TELEMETRY_SMARTPORT)
             if (telemetryEnabled) {
-                bool clearToSend = false;
-                timeMs_t now = millis();
-                smartPortPayload_t *payload = NULL;
-                if ((now - pollingTimeMs) > 24) {
-                    pollingTimeMs = now;
-
-                    clearToSend = true;
-                } else {
-                    uint8_t remoteToProcessId = (remoteProcessedId + 1) % TELEMETRY_SEQUENCE_LENGTH;
-                    while (telemetryRxBuffer[remoteToProcessId].needsProcessing && !payload) {
-                        while (remoteToProcessIndex < telemetryRxBuffer[remoteToProcessId].data.dataLength && !payload) {
-                            payload = smartPortDataReceive(telemetryRxBuffer[remoteToProcessId].data.data[remoteToProcessIndex], &clearToSend, frSkyXCheckQueueEmpty, false);
-                            remoteToProcessIndex = remoteToProcessIndex + 1;
-                        }
-
-                        if (remoteToProcessIndex == telemetryRxBuffer[remoteToProcessId].data.dataLength) {
-                            remoteToProcessIndex = 0;
-                            telemetryRxBuffer[remoteToProcessId].needsProcessing = false;
-                            remoteProcessedId = remoteToProcessId;
-                            remoteToProcessId = (remoteProcessedId + 1) % TELEMETRY_SEQUENCE_LENGTH;
-                        }
-                    }
-                }
-                processSmartPortTelemetry(payload, &clearToSend, NULL);
+                ret |= RX_SPI_ROCESSING_REQUIRED;
             }
 #endif
             *protocolState = STATE_RESUME;
             if (frameReceived) {
-                ret = RX_SPI_RECEIVED_DATA;
+                ret |= RX_SPI_RECEIVED_DATA;
             }
         }
 
@@ -548,6 +526,44 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
 
     return ret;
 }
+
+#if defined(USE_RX_FRSKY_SPI_TELEMETRY) && defined(USE_TELEMETRY_SMARTPORT)
+rx_spi_received_e frSkyXProcessFrame(uint8_t * const packet)
+{
+    static timeMs_t pollingTimeMs = 0;
+    static uint8_t remoteToProcessIndex = 0;
+
+    UNUSED(packet);
+
+    bool clearToSend = false;
+    timeMs_t now = millis();
+    smartPortPayload_t *payload = NULL;
+    if ((now - pollingTimeMs) > 24) {
+        pollingTimeMs = now;
+
+        clearToSend = true;
+    } else {
+        uint8_t remoteToProcessId = (remoteProcessedId + 1) % TELEMETRY_SEQUENCE_LENGTH;
+        while (telemetryRxBuffer[remoteToProcessId].needsProcessing && !payload) {
+            while (remoteToProcessIndex < telemetryRxBuffer[remoteToProcessId].data.dataLength && !payload) {
+                payload = smartPortDataReceive(telemetryRxBuffer[remoteToProcessId].data.data[remoteToProcessIndex], &clearToSend, frSkyXCheckQueueEmpty, false);
+                remoteToProcessIndex = remoteToProcessIndex + 1;
+            }
+
+            if (remoteToProcessIndex == telemetryRxBuffer[remoteToProcessId].data.dataLength) {
+                remoteToProcessIndex = 0;
+                telemetryRxBuffer[remoteToProcessId].needsProcessing = false;
+                remoteProcessedId = remoteToProcessId;
+                remoteToProcessId = (remoteProcessedId + 1) % TELEMETRY_SEQUENCE_LENGTH;
+            }
+        }
+    }
+
+    processSmartPortTelemetry(payload, &clearToSend, NULL);
+
+    return RX_SPI_RECEIVED_NONE;
+}
+#endif
 
 void frSkyXInit(const rx_spi_protocol_e spiProtocol)
 {

--- a/src/main/rx/cc2500_frsky_x.h
+++ b/src/main/rx/cc2500_frsky_x.h
@@ -29,3 +29,4 @@ void frSkyXSetRcData(uint16_t *rcData, const uint8_t *payload);
 
 void frSkyXInit(const rx_spi_protocol_e spiProtocol);
 rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const protocolState);
+rx_spi_received_e frSkyXProcessFrame(uint8_t * const packet);

--- a/src/main/rx/rx_spi.h
+++ b/src/main/rx/rx_spi.h
@@ -47,8 +47,9 @@ typedef enum {
 
 typedef enum {
     RX_SPI_RECEIVED_NONE = 0,
-    RX_SPI_RECEIVED_BIND,
-    RX_SPI_RECEIVED_DATA
+    RX_SPI_RECEIVED_BIND = (1 << 0),
+    RX_SPI_RECEIVED_DATA = (1 << 1),
+    RX_SPI_ROCESSING_REQUIRED = (1 << 2),
 } rx_spi_received_e;
 
 // RC channels in AETR order


### PR DESCRIPTION
This should hopefully fix the firmware lock-ups experienced when using FrSky X with telemetry.

Two parts to this:
- clear the FIFO when the received data's CRC is invalid (thanks @joelucid);
- run the telemetry code outside of the real time 'frame status' function;

Confirmed to be working in some short test flights, but more testing would be nice.
Confirmed to work for MSP over SmartPort.