### PR TITLE
SPRACINGH7 targets - Update debug mode in unified target config.

### DIFF
--- a/unified_targets/configs/SPRACINGH7EXTREME.config
+++ b/unified_targets/configs/SPRACINGH7EXTREME.config
@@ -188,3 +188,4 @@ set gyro_2_sensor_align = CUSTOM
 set gyro_2_align_roll = 0
 set gyro_2_align_pitch = 0
 set gyro_2_align_yaw = 2250
+set debug_mode = DUAL_GYRO_DIFF

--- a/unified_targets/configs/SPRACINGH7NANO.config
+++ b/unified_targets/configs/SPRACINGH7NANO.config
@@ -171,5 +171,6 @@ set gyro_1_sensor_align = CW0FLIP
 set gyro_2_bustype = SPI
 set gyro_2_spibus = 3
 set gyro_2_sensor_align = CW0FLIP
+set debug_mode = ADC_INTERNAL
 
 # 

--- a/unified_targets/configs/SPRACINGH7ZERO.config
+++ b/unified_targets/configs/SPRACINGH7ZERO.config
@@ -180,3 +180,4 @@ set gyro_2_bustype = SPI
 set gyro_2_spibus = 2
 set gyro_2_sensor_align = CW90
 set gyro_2_align_yaw = 900
+set debug_mode = ADC_INTERNAL


### PR DESCRIPTION
See #8700 and #8718.

The SPRacingH7 boards are automatically tested and require these settings.  Any removal or change to the debug mode setting should be scheduled so that updates to the test software can also be scheduled.