### PR TITLE
Fix incorrect attribute name for DMA_RW_AXI.

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -158,7 +158,7 @@
 
 #ifdef USE_DMA_RAM
 #define DMA_RAM __attribute__((section(".DMA_RAM")))
-#define DMA_RW_AXI __attribute__((section(".DMA_AXI_RW")))
+#define DMA_RW_AXI __attribute__((section(".DMA_RW_AXI")))
 #else
 #define DMA_RAM
 #define DMA_RW_AXI


### PR DESCRIPTION
This caused SD card to break in EXST targets, was found when testing #8697 - details here: https://github.com/betaflight/betaflight/pull/8697#issuecomment-521979732

The attribute name was wrong.

linker scripts use `DMA_RW_AXI`, e.g.

```
  .DMA_RW_AXI (NOLOAD) :
  {
```
vs
```
#define DMA_RW_AXI __attribute__((section(".DMA_AXI_RW")))
```


Note: Since the `DMA_RW_AXI` define is ONLY used on H7 and ONLY for the `afatfs_cache` variable, there is no impact on F1-F7 targets.