### PR TITLE
report erpm, rpm and hz for convenience in dshot_telemetry_info

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5840,14 +5840,17 @@ static void cliDshotTelemetryInfo(char *cmdline)
         cliPrintLinefeed();
 
 #ifdef USE_DSHOT_TELEMETRY_STATS
-        cliPrintLine("Motor     RPM   Invalid");
-        cliPrintLine("=====   =====   =======");
+        cliPrintLine("Motor      eRPM      RPM      Hz   Invalid");
+        cliPrintLine("=====   =======   ======   =====   =======");
 #else
-        cliPrintLine("Motor     RPM");
-        cliPrintLine("=====   =====");
+        cliPrintLine("Motor      eRPM      RPM      Hz");
+        cliPrintLine("=====   =======   ======   =====");
 #endif
         for (uint8_t i = 0; i < getMotorCount(); i++) {
-            cliPrintf("%5d   %5d   ", i, (int)getDshotTelemetry(i));
+            cliPrintf("%5d   %7d   %6d   %5d   ", i,
+                      (int)getDshotTelemetry(i) * 100,
+                      (int)getDshotTelemetry(i) * 100 * 2 / motorConfig()->motorPoleCount,
+                      (int)getDshotTelemetry(i) * 100 * 2 / motorConfig()->motorPoleCount / 60);
 #ifdef USE_DSHOT_TELEMETRY_STATS
             if (isDshotMotorTelemetryActive(i)) {
                 const int calcPercent = getDshotTelemetryMotorInvalidPercent(i);


### PR DESCRIPTION
Currently dshot_telemetry_info displays erpm/100. This has caused confusion. This PR changes it to report eRPM, RPM and HZ.