### PR TITLE
Refactor DSHOT 1

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -66,7 +66,7 @@ void dshotEnableChannels(uint8_t motorCount)
 static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor);
 
 FAST_CODE void pwmDshotSetDirectionOutput(
-    motorDmaOutput_t * const motor, bool output
+    motorDmaOutput_t * const motor
 #ifndef USE_DSHOT_TELEMETRY
     ,TIM_OCInitTypeDef *pOcInit, DMA_InitTypeDef* pDmaInit
 #endif
@@ -91,58 +91,68 @@ FAST_CODE void pwmDshotSetDirectionOutput(
     xDMA_DeInit(dmaRef);
 
 #ifdef USE_DSHOT_TELEMETRY
-    if (!output) {
-        motor->isInput = true;
-        if (!inputStampUs) {
-            inputStampUs = micros();
-        }
-        TIM_ARRPreloadConfig(timer, ENABLE);
-        timer->ARR = 0xffffffff;
-
-        TIM_ICInit(timer, &motor->icInitStruct);
-
-#if defined(STM32F3)
-        motor->dmaInitStruct.DMA_DIR = DMA_DIR_PeripheralSRC;
-        motor->dmaInitStruct.DMA_M2M = DMA_M2M_Disable;
-#elif defined(STM32F4)
-        motor->dmaInitStruct.DMA_DIR = DMA_DIR_PeripheralToMemory;
+    motor->isInput = false;
 #endif
-    } else
-#else
-    UNUSED(output);
-#endif
-    {
-#ifdef USE_DSHOT_TELEMETRY
-        motor->isInput = false;
-#endif
-        timerOCPreloadConfig(timer, timerHardware->channel, TIM_OCPreload_Disable);
-        timerOCInit(timer, timerHardware->channel, pOcInit);
-        timerOCPreloadConfig(timer, timerHardware->channel, TIM_OCPreload_Enable);
+    timerOCPreloadConfig(timer, timerHardware->channel, TIM_OCPreload_Disable);
+    timerOCInit(timer, timerHardware->channel, pOcInit);
+    timerOCPreloadConfig(timer, timerHardware->channel, TIM_OCPreload_Enable);
 
 #ifdef USE_DSHOT_DMAR
-        if (useBurstDshot) {
+    if (useBurstDshot) {
 #if defined(STM32F3)
-            pDmaInit->DMA_DIR = DMA_DIR_PeripheralDST;
+        pDmaInit->DMA_DIR = DMA_DIR_PeripheralDST;
 #else
-            pDmaInit->DMA_DIR = DMA_DIR_MemoryToPeripheral;
+        pDmaInit->DMA_DIR = DMA_DIR_MemoryToPeripheral;
 #endif
-        } else
+    } else
 #endif
-        {
+    {
 #if defined(STM32F3)
-            pDmaInit->DMA_DIR = DMA_DIR_PeripheralDST;
-            pDmaInit->DMA_M2M = DMA_M2M_Disable;
+        pDmaInit->DMA_DIR = DMA_DIR_PeripheralDST;
+        pDmaInit->DMA_M2M = DMA_M2M_Disable;
 #elif defined(STM32F4)
-            pDmaInit->DMA_DIR = DMA_DIR_MemoryToPeripheral;
+        pDmaInit->DMA_DIR = DMA_DIR_MemoryToPeripheral;
 #endif
-        }
     }
 
     xDMA_Init(dmaRef, pDmaInit);
-    if (output) {
-        xDMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
-    }
+    xDMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
 }
+
+
+#ifdef USE_DSHOT_TELEMETRY
+FAST_CODE void pwmDshotSetDirectionInput(
+    motorDmaOutput_t * const motor
+)
+{
+    DMA_InitTypeDef* pDmaInit = &motor->dmaInitStruct;
+
+    const timerHardware_t * const timerHardware = motor->timerHardware;
+    TIM_TypeDef *timer = timerHardware->tim;
+
+    dmaResource_t *dmaRef = motor->dmaRef;
+
+    xDMA_DeInit(dmaRef);
+
+    motor->isInput = true;
+    if (!inputStampUs) {
+        inputStampUs = micros();
+    }
+    TIM_ARRPreloadConfig(timer, ENABLE);
+    timer->ARR = 0xffffffff;
+
+    TIM_ICInit(timer, &motor->icInitStruct);
+
+#if defined(STM32F3)
+    motor->dmaInitStruct.DMA_DIR = DMA_DIR_PeripheralSRC;
+    motor->dmaInitStruct.DMA_M2M = DMA_M2M_Disable;
+#elif defined(STM32F4)
+    motor->dmaInitStruct.DMA_DIR = DMA_DIR_PeripheralToMemory;
+#endif
+
+    xDMA_Init(dmaRef, pDmaInit);
+}
+#endif
 
 
 void pwmCompleteDshotMotorUpdate(void)
@@ -194,7 +204,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
 
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {
-            pwmDshotSetDirectionOutput(motor, false);
+            pwmDshotSetDirectionInput(motor);
             xDMA_SetCurrDataCounter(motor->dmaRef, GCR_TELEMETRY_INPUT_LEN);
             xDMA_Cmd(motor->dmaRef, ENABLE);
             TIM_DMACmd(motor->timerHardware->tim, motor->timerDmaSource, ENABLE);
@@ -392,9 +402,9 @@ bool pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->dshotTelemetryDeadtimeUs = DSHOT_TELEMETRY_DEADTIME_US + 1000000 *
         (16 * MOTOR_BITLENGTH) / getDshotHz(pwmProtocolType);
     motor->timer->outputPeriod = (pwmProtocolType == PWM_TYPE_PROSHOT1000 ? (MOTOR_NIBBLE_LENGTH_PROSHOT) : MOTOR_BITLENGTH) - 1;
-    pwmDshotSetDirectionOutput(motor, true);
+    pwmDshotSetDirectionOutput(motor);
 #else
-    pwmDshotSetDirectionOutput(motor, true, &OCINIT, &DMAINIT);
+    pwmDshotSetDirectionOutput(motor, &OCINIT, &DMAINIT);
 #endif
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -219,17 +219,6 @@ uint16_t getDshotTelemetry(uint8_t index)
 
 #endif
 
-FAST_CODE void pwmDshotSetDirectionOutput(
-    motorDmaOutput_t * const motor, bool output
-#ifndef USE_DSHOT_TELEMETRY
-#ifdef USE_FULL_LL_DRIVER
-    , LL_TIM_OC_InitTypeDef* pOcInit, LL_DMA_InitTypeDef* pDmaInit
-#else
-    , TIM_OCInitTypeDef *pOcInit, DMA_InitTypeDef* pDmaInit
-#endif
-#endif
-);
-
 #ifdef USE_DSHOT_TELEMETRY
 #ifdef USE_DSHOT_TELEMETRY_STATS
 void updateDshotTelemetryQuality(dshotTelemetryQuality_t *qualityStats, bool packetValid, timeMs_t currentTimeMs)
@@ -307,7 +296,7 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
             }
 #endif
         }
-        pwmDshotSetDirectionOutput(&dmaMotors[i], true);
+        pwmDshotSetDirectionOutput(&dmaMotors[i]);
     }
     inputStampUs = 0;
     dshotEnableChannels(dshotPwmDevice.count);

--- a/src/main/drivers/pwm_output_dshot_shared.h
+++ b/src/main/drivers/pwm_output_dshot_shared.h
@@ -57,7 +57,7 @@ void dshotEnableChannels(uint8_t motorCount);
 #ifdef USE_DSHOT_TELEMETRY
 
 FAST_CODE void pwmDshotSetDirectionOutput(
-    motorDmaOutput_t * const motor, bool output
+    motorDmaOutput_t * const motor
 #ifndef USE_DSHOT_TELEMETRY
 #if defined(STM32F7) || defined(STM32H7)
     , LL_TIM_OC_InitTypeDef* pOcInit, LL_DMA_InitTypeDef* pDmaInit
@@ -66,6 +66,10 @@ FAST_CODE void pwmDshotSetDirectionOutput(
 #endif
 #endif
 );
+
+#ifdef USE_DSHOT_TELEMETRY
+FAST_CODE void pwmDshotSetDirectionInput(motorDmaOutput_t * const motor);
+#endif
 
 bool pwmStartDshotMotorUpdate(void);
 


### PR DESCRIPTION
Improve code readability and maintainability by removing the `output` boolean argument from `pwmDshotSetDirectionOutput` and splitting it into two separate methods `pwmDshotSetDirectionOutput` and `pwmDshotSetDirectionInput`.

Note the things that are currently improved:
* no hanging conditional `} else` with no opening `{`
* fewer `#ifdef`s
* easier to follow code.
* methods do what they say on the tin
* fewer arguments.
* no need for `pOcInit` argument on the `pwmDshotSetDirectionInput` method.
* no `UNUSED(output)` when `USE_DSHOT_TELEMETRY` is not used.
* no calls to `pwmDshotSetDirectionInput` when ``USE_DSHOT_TELEMETRY` was not enabled.
* since `pwmDshotSetDirectionInput` is only used by `USE_DSHOT_TELEMETRY` the `#ifdef` gating could be externalized from the method and unused parameters removed.
* removed code paths that would never be compiled.

On the targets I was testing with, the resulting code size is negligible.

Before (2b1d256396986b7db8e042cd1e09042a247406d8):
```
Linking SPRACINGF4EVO 
Memory region         Used Size  Region Size  %age Used
           FLASH:        8488 B        10 KB     82.89%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      404180 B       992 KB     39.79%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB     -1.#J%
   SYSTEM_MEMORY:          0 GB        29 KB      0.00%
             RAM:       56472 B       128 KB     43.08%
             CCM:       16440 B        64 KB     25.09%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 406788	   5888	  66636	 479312	  75050	./obj/main/betaflight_SPRACINGF4EVO.elf
Creating HEX ./obj/betaflight_4.1.0_SPRACINGF4EVO.hex 

Linking SPRACINGF7DUAL 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       16280 B        16 KB     99.37%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        9038 B        10 KB     88.26%
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      424656 B       480 KB     86.40%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB     -1.#J%
        DTCM_RAM:       27068 B        64 KB     41.30%
           SRAM1:       46944 B       176 KB     26.05%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 427406	   6296	  67720	 501422	  7a6ae	./obj/main/betaflight_SPRACINGF7DUAL.elf
Creating HEX ./obj/betaflight_4.1.0_SPRACINGF7DUAL.hex 
```

After (5474c81f0ec5f761c03dee4479fc0c4374517d19):
```
Linking SPRACINGF4EVO 
Memory region         Used Size  Region Size  %age Used
           FLASH:        8488 B        10 KB     82.89%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      404668 B       992 KB     39.84%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB     -1.#J%
   SYSTEM_MEMORY:          0 GB        29 KB      0.00%
             RAM:       56472 B       128 KB     43.08%
             CCM:       16440 B        64 KB     25.09%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 407276	   5888	  66636	 479800	  75238	./obj/main/betaflight_SPRACINGF4EVO.elf
Creating HEX ./obj/betaflight_4.1.0_SPRACINGF4EVO.hex 
make[1]: Leaving directory '/cygdrive/d/My Documents/dev/embedded/betaflight'


Linking SPRACINGF7DUAL 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       16280 B        16 KB     99.37%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        9038 B        10 KB     88.26%
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      424888 B       480 KB     86.44%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB     -1.#J%
        DTCM_RAM:       27068 B        64 KB     41.30%
           SRAM1:       46944 B       176 KB     26.05%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 427638	   6296	  67720	 501654	  7a796	./obj/main/betaflight_SPRACINGF7DUAL.elf
Creating HEX ./obj/betaflight_4.1.0_SPRACINGF7DUAL.hex 
```
