### PR TITLE
Use microsISR inside `motor_DMA_IRQHandler`.

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -179,7 +179,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         motorDmaOutput_t * const motor = &dmaMotors[descriptor->userParam];
 #ifdef USE_DSHOT_TELEMETRY
-        uint32_t irqStart = micros();
+        uint32_t irqStart = microsISR();
 #endif
 #ifdef USE_DSHOT_DMAR
         if (useBurstDshot) {
@@ -198,7 +198,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
             xDMA_SetCurrDataCounter(motor->dmaRef, GCR_TELEMETRY_INPUT_LEN);
             xDMA_Cmd(motor->dmaRef, ENABLE);
             TIM_DMACmd(motor->timerHardware->tim, motor->timerDmaSource, ENABLE);
-            setDirectionMicros = micros() - irqStart;
+            setDirectionMicros = microsISR() - irqStart;
         }
 #endif
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -154,7 +154,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
         motorDmaOutput_t * const motor = &dmaMotors[descriptor->userParam];
         if (!motor->isInput) {
 #ifdef USE_DSHOT_TELEMETRY
-            uint32_t irqStartUs = micros();
+            uint32_t irqStartUs = microsISR();
 #endif
 #ifdef USE_DSHOT_DMAR
             if (useBurstDshot) {
@@ -173,7 +173,7 @@ static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
                 xLL_EX_DMA_SetDataLength(motor->dmaRef, GCR_TELEMETRY_INPUT_LEN);
                 xLL_EX_DMA_EnableResource(motor->dmaRef);
                 LL_EX_TIM_EnableIT(motor->timerHardware->tim, motor->timerDmaSource);
-                setDirectionMicros = micros() - irqStartUs;
+                setDirectionMicros = microsISR() - irqStartUs;
             }
 #endif
         }


### PR DESCRIPTION
Shaves a few clock cycles, micros() was used twice inside the IRQ handler so the logic in `micros` is avoided twice per motor, or 16 times for 4 motors.