### PR TITLE
Reduce CPU usage in dshot motor handler to reduce DSHOT telemetry errors.

### DIFF
--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -108,8 +108,9 @@ typedef enum {
 
 #define DEFINE_DMA_IRQ_HANDLER(d, s, i) void DMA ## d ## _Stream ## s ## _IRQHandler(void) {\
                                                                 const uint8_t index = DMA_IDENTIFIER_TO_INDEX(i); \
-                                                                if (dmaDescriptors[index].irqHandlerCallback)\
-                                                                    dmaDescriptors[index].irqHandlerCallback(&dmaDescriptors[index]);\
+                                                                dmaCallbackHandlerFuncPtr handler = dmaDescriptors[index].irqHandlerCallback; \
+                                                                if (handler) \
+                                                                    handler(&dmaDescriptors[index]); \
                                                             }
 
 #define DMA_CLEAR_FLAG(d, flag) if (d->flagsShift > 31) d->dma->HIFCR = (flag << (d->flagsShift - 32)); else d->dma->LIFCR = (flag << d->flagsShift)
@@ -169,8 +170,9 @@ typedef enum {
 
 #define DEFINE_DMA_IRQ_HANDLER(d, c, i) void DMA ## d ## _Channel ## c ## _IRQHandler(void) {\
                                                                         const uint8_t index = DMA_IDENTIFIER_TO_INDEX(i); \
-                                                                        if (dmaDescriptors[index].irqHandlerCallback)\
-                                                                            dmaDescriptors[index].irqHandlerCallback(&dmaDescriptors[index]);\
+                                                                        dmaCallbackHandlerFuncPtr handler = dmaDescriptors[index].irqHandlerCallback; \
+                                                                        if (handler) \
+                                                                            handler(&dmaDescriptors[index]); \
                                                                     }
 
 #define DMA_CLEAR_FLAG(d, flag) d->dma->IFCR = (flag << d->flagsShift)

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -80,8 +80,10 @@ uint32_t readDoneCount;
 // TODO remove once debugging no longer needed
 FAST_RAM_ZERO_INIT uint32_t dshotInvalidPacketCount;
 FAST_RAM_ZERO_INIT uint32_t inputBuffer[GCR_TELEMETRY_INPUT_LEN];
-FAST_RAM_ZERO_INIT uint32_t setDirectionMicros;
+FAST_RAM_ZERO_INIT uint32_t decodePacketDurationUs;
 FAST_RAM_ZERO_INIT uint32_t inputStampUs;
+
+FAST_RAM_ZERO_INIT dshotDMAHandlerCycleCounters_t dshotDMAHandlerCycleCounters;
 #endif
 
 motorDmaOutput_t *getMotorDmaOutput(uint8_t index)
@@ -194,13 +196,13 @@ static uint32_t decodeTelemetryPacket(uint32_t buffer[], uint32_t count)
     csum = csum ^ (csum >> 4); // xor nibbles
 
     if ((csum & 0xf) != 0xf) {
-        setDirectionMicros = micros() - start;
+        decodePacketDurationUs = micros() - start;
         return 0xffff;
     }
     decodedValue >>= 4;
 
     if (decodedValue == 0x0fff) {
-        setDirectionMicros = micros() - start;
+        decodePacketDurationUs = micros() - start;
         return 0;
     }
     decodedValue = (decodedValue & 0x000001ff) << ((decodedValue & 0xfffffe00) >> 9);
@@ -208,7 +210,7 @@ static uint32_t decodeTelemetryPacket(uint32_t buffer[], uint32_t count)
         return 0xffff;
     }
     uint32_t ret = (1000000 * 60 / 100 + decodedValue / 2) / decodedValue;
-    setDirectionMicros = micros() - start;
+    decodePacketDurationUs = micros() - start;
     return ret;
 }
 

--- a/src/main/drivers/pwm_output_dshot_shared.h
+++ b/src/main/drivers/pwm_output_dshot_shared.h
@@ -46,8 +46,16 @@ extern uint32_t readDoneCount;
 // TODO remove once debugging no longer needed
 FAST_RAM_ZERO_INIT extern uint32_t dshotInvalidPacketCount;
 FAST_RAM_ZERO_INIT extern uint32_t inputBuffer[GCR_TELEMETRY_INPUT_LEN];
-FAST_RAM_ZERO_INIT extern uint32_t setDirectionMicros;
+FAST_RAM_ZERO_INIT extern uint32_t decodePacketDurationUs;
 FAST_RAM_ZERO_INIT extern uint32_t inputStampUs;
+
+typedef struct dshotDMAHandlerCycleCounters_s {
+    uint32_t irqAt;
+    uint32_t changeDirectionCompletedAt;
+} dshotDMAHandlerCycleCounters_t;
+
+FAST_RAM_ZERO_INIT extern dshotDMAHandlerCycleCounters_t dshotDMAHandlerCycleCounters;
+
 #endif
 
 uint8_t getTimerIndex(TIM_TypeDef *timer);
@@ -66,10 +74,6 @@ FAST_CODE void pwmDshotSetDirectionOutput(
 #endif
 #endif
 );
-
-#ifdef USE_DSHOT_TELEMETRY
-FAST_CODE void pwmDshotSetDirectionInput(motorDmaOutput_t * const motor);
-#endif
 
 bool pwmStartDshotMotorUpdate(void);
 

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -64,9 +64,12 @@ void systemReset(void);
 void systemResetToBootloader(bootloaderRequestType_e requestType);
 bool isMPUSoftReset(void);
 void cycleCounterInit(void);
+uint32_t clockCyclesToMicros(uint32_t clockCycles);
+uint32_t getCycleCounter(void);
 #if defined(STM32H7)
 void systemCheckResetReason(void);
 #endif
+
 
 void initialiseMemorySections(void);
 


### PR DESCRIPTION
On an F3 motor 1 gets 100% invalid telemetry packets:

```
Motor      eRPM      RPM      Hz   Invalid
=====   =======   ======   =====   =======
    0     33500     5583      93   100.00%
    1     10000     1666      27     0.25%
    2     10100     1683      28     3.67%
    3     10400     1733      28     0.00%
```

As @joelucid noted the time taken to switch from output to input is critical.

After looking at the `motor_DMA_IRQHandler()` I noticed that `micros()` was being used, using `microsISR()` in PR #8766 improves things a little, but not enough.

As noted via slack:
In motor_DMA_IRQHandler you record the micros on irq start then update 'setDirectionMicros' by loading the value of the stored number, getting updated micros time, and subtracting the previously stored number, then storing the result in setDirectionMicros this means you are doing the subtraction every single call to motor_DMA_IRQHandler, this will be 4 subtractions per motor update that perhaps can be avoided.

Since the value is only used in the cli, it might make sense to just store entry/exit micros() result in two values, then perform the subtraction as needed in the cli.
also, since this code is time-critical, using micros is probably a) overkill and b) doesn't have the resolution required to know if changes you're making have any effect when the changes don't cause a different in MICROS.  Better, would be to record the CPU cycle counter.  Then in the CLI code show the cycle counter and calculate how micros based on this value.
that would mean there'd be no expensive call to micros too.

And that is what this PR does.

The result is now this:

396 / 72Mhz = 5.5us, vs 581 / 72 = 8.06us.

```
Dshot reads: 131995
Dshot invalid pkts: 850
Dshot directionChange cycles: 396, micros: 5
Dshot packet decode micros: 8

Motor      eRPM      RPM      Hz   Invalid
=====   =======   ======   =====   =======
    0      9900     1650      27     3.54%
    1     10700     1783      29     0.00%
    2      9900     1650      27     0.00%
    3      9700     1616      26     0.00%

154 199 213 244 258 271 285 315 330 343 356 387 402 431 444 7 0 0 0 0 0 0 
45 14 31 14 13 14 30 15 13 13 31 15 29 13 4294966859 4294967289 0 0 0 0 0 
```

Since this is critical inner-loop stuff which is called thousands of times per second this a a good CPU usage saving.

Additonally this PR fixes the variable re-use of `setDirectionMicros` which was being overwritten with the time taken to decode a telemetry packet.  This is now stored in a different variable, `decodePacketDurationUs`.  Also note that `decodePacketDurationUs` is created using `micros`, twice per motor so the method of timing that can also be replaced by storing cycle counters and calculating the result in the cli as-needed.  That's not done in this PR yet as it's not as critical as the other change.

Note, this PR builds on PR #8763 and can be rebased when that is merged.  It will also replace #8766 
