### PR TITLE
Fix F3 DMA request mapping when using `USE_DMA_SPEC`.

### DIFF
--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -292,36 +292,41 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
     // The embedded ADC24_DMA_REMAP conditional should be removed
     // when (and if) F3 is going generic.
 #define DMA(d, c) { DMA_CODE(d, 0, c), (dmaResource_t *)DMA ## d ## _Channel ## c }
-static const dmaPeripheralMapping_t dmaPeripheralMapping[17] = {
+static const dmaPeripheralMapping_t dmaPeripheralMapping[18] = {
 #ifdef USE_SPI
-    { DMA_PERIPH_SPI_TX,  1, { DMA(1, 3) } },
-    { DMA_PERIPH_SPI_RX,  1, { DMA(1, 2) } },
-    { DMA_PERIPH_SPI_TX,  2, { DMA(1, 5) } },
-    { DMA_PERIPH_SPI_RX,  2, { DMA(1, 4) } },
-    { DMA_PERIPH_SPI_TX,  3, { DMA(2, 2) } },
-    { DMA_PERIPH_SPI_RX,  3, { DMA(2, 1) } },
+    { DMA_PERIPH_SPI_TX,  SPIDEV_1, { DMA(1, 3) } },
+    { DMA_PERIPH_SPI_RX,  SPIDEV_1, { DMA(1, 2) } },
+    { DMA_PERIPH_SPI_TX,  SPIDEV_2, { DMA(1, 5) } },
+    { DMA_PERIPH_SPI_RX,  SPIDEV_2, { DMA(1, 4) } },
+    { DMA_PERIPH_SPI_TX,  SPIDEV_3, { DMA(2, 2) } },
+    { DMA_PERIPH_SPI_RX,  SPIDEV_3, { DMA(2, 1) } },
 #endif
 
 #ifdef USE_ADC
-    { DMA_PERIPH_ADC,     1, { DMA(1, 1) } },
+    { DMA_PERIPH_ADC,     ADCDEV_1, { DMA(1, 1) } },
 #ifdef ADC24_DMA_REMAP
-    { DMA_PERIPH_ADC,     2, { DMA(2, 3) } },
+    { DMA_PERIPH_ADC,     ADCDEV_2, { DMA(2, 3) } },
 #else
-    { DMA_PERIPH_ADC,     2, { DMA(2, 1) } },
+    { DMA_PERIPH_ADC,     ADCDEV_2, { DMA(2, 1) } },
 #endif
-    { DMA_PERIPH_ADC,     3, { DMA(2, 5) } },
+    { DMA_PERIPH_ADC,     ADCDEV_3, { DMA(2, 5) } },
+#ifdef ADC24_DMA_REMAP
+    { DMA_PERIPH_ADC,     ADCDEV_4, { DMA(2, 4) } },
+#else
+    { DMA_PERIPH_ADC,     ADCDEV_4, { DMA(2, 2) } },
+#endif
 #endif
 
 #ifdef USE_UART
-    { DMA_PERIPH_UART_TX, 1, { DMA(1, 4) } },
-    { DMA_PERIPH_UART_RX, 1, { DMA(1, 5) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_1, { DMA(1, 4) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_1, { DMA(1, 5) } },
 
-    { DMA_PERIPH_UART_TX, 2, { DMA(1, 7) } },
-    { DMA_PERIPH_UART_RX, 2, { DMA(1, 6) } },
-    { DMA_PERIPH_UART_TX, 3, { DMA(1, 2) } },
-    { DMA_PERIPH_UART_RX, 3, { DMA(1, 3) } },
-    { DMA_PERIPH_UART_TX, 4, { DMA(2, 5) } },
-    { DMA_PERIPH_UART_RX, 4, { DMA(2, 3) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_2, { DMA(1, 7) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_2, { DMA(1, 6) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_3, { DMA(1, 2) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_3, { DMA(1, 3) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_4, { DMA(2, 5) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_4, { DMA(2, 3) } },
 };
 #endif
 

--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -39,11 +39,16 @@ PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);
 
 void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
+    STATIC_ASSERT(MAX_ADC_SUPPORTED <= ADC_DEV_TO_CFG(ADCDEV_COUNT) || MAX_ADC_SUPPORTED != 4, adc_count_mismatch);
+
     adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
     adcConfig->dmaopt[ADCDEV_1] = ADC1_DMA_OPT;
 #ifndef STM32F1
     adcConfig->dmaopt[ADCDEV_2] = ADC2_DMA_OPT;
     adcConfig->dmaopt[ADCDEV_3] = ADC3_DMA_OPT;
+#endif
+#ifdef STM32F3
+    adcConfig->dmaopt[ADCDEV_4] = ADC4_DMA_OPT;
 #endif
 
 #ifdef VBAT_ADC_PIN

--- a/src/main/pg/adc.h
+++ b/src/main/pg/adc.h
@@ -24,7 +24,10 @@
 #include <stdbool.h>
 
 #include "pg/pg.h"
+#include "drivers/adc.h"
 #include "drivers/io_types.h"
+
+#define MAX_ADC_SUPPORTED 4
 
 typedef struct adcChannelConfig_t {
     bool enabled;
@@ -42,7 +45,7 @@ typedef struct adcConfig_s {
     uint16_t tempSensorCalibration1;
     uint16_t tempSensorCalibration2;
 
-    uint8_t dmaopt[3]; // One per ADCDEV_x
+    int8_t dmaopt[MAX_ADC_SUPPORTED]; // One per ADCDEV_x
 } adcConfig_t;
 
 PG_DECLARE(adcConfig_t, adcConfig);

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -522,6 +522,9 @@
 #if !defined(ADC3_DMA_OPT)
 #define ADC3_DMA_OPT (-1)
 #endif
+#if !defined(ADC4_DMA_OPT)
+#define ADC4_DMA_OPT (-1)
+#endif
 
 #endif // USE_ADC
 


### PR DESCRIPTION
This PR fixes the issues with DMA request mapping when using `USE_DMA_SPEC`

See individual commits for details.

All DMA mappings were out-by one and of course things didn't work, like battery voltage reading.  e.g.

Before:
```
# dma ADC 1 list

# dma ADC 2 list
# 0: DMA1 Stream 0 Channel 1

# dma ADC 3 list
# 0: DMA2 Stream 0 Channel 1

# dma ADC 4 list
# 0: DMA2 Stream 0 Channel 5
```

after:
```
# dma ADC 1 list
# 0: DMA1 Stream 0 Channel 1

# dma ADC 2 list
# 0: DMA2 Stream 0 Channel 1

# dma ADC 3 list
# 0: DMA2 Stream 0 Channel 5

# dma ADC 4 list
# 0: DMA2 Stream 0 Channel 2
```

Same applied to UART and SPI too.
