### PR TITLE
Keep `updateRcCommand` out of FAST_CODE.

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -647,7 +647,7 @@ FAST_CODE void processRcCommand(void)
     }
 }
 
-FAST_CODE FAST_CODE_NOINLINE void updateRcCommands(void)
+FAST_CODE_NOINLINE void updateRcCommands(void)
 {
     // PITCH & ROLL only dynamic PID adjustment,  depending on throttle value
     int32_t prop;


### PR DESCRIPTION
It's event driven or called at 33hz.

Keeping `updateRcCommand` out of FAST_CODE allows for more important code to be
placed in FAST_CODE.

On F7 ITCM_RAM section is almost overflowing.

Before (4f923e4827d2595881a9eed7c933d1c84817053c):
```
Linking SPRACINGF7DUAL 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       16280 B        16 KB     99.37%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        9038 B        10 KB     88.26%
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      425912 B       480 KB     86.65%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB     -1.#J%
        DTCM_RAM:       27068 B        64 KB     41.30%
           SRAM1:       46944 B       176 KB     26.05%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 428662	   6296	  67720	 502678	  7ab96	./obj/main/betaflight_SPRACINGF7DUAL.elf
```

After (0baed339e6deb1c5b2aa28bdb7bca1a29760d7a8):
```
Linking SPRACINGF7DUAL 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       15040 B        16 KB     91.80%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        9038 B        10 KB     88.26%
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      425904 B       480 KB     86.65%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB     -1.#J%
        DTCM_RAM:       27068 B        64 KB     41.30%
           SRAM1:       46944 B       176 KB     26.05%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
   text	   data	    bss	    dec	    hex	filename
 428654	   6296	  67720	 502670	  7ab8e	./obj/main/betaflight_SPRACINGF7DUAL.elf
```

The RX task, which is the only method to call `updateRcCommand` takes 36us (average) to run, before and after.