### PR TITLE
Set default static lowpass1 gyro value to the same as default gyro lowpass1 min

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -204,7 +204,7 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyro_sync_denom = GYRO_SYNC_DENOM_DEFAULT;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
     gyroConfig->gyro_lowpass_type = FILTER_PT1;
-    gyroConfig->gyro_lowpass_hz = 150;  // NOTE: dynamic lpf is enabled by default so this setting is actually
+    gyroConfig->gyro_lowpass_hz = 200;  // NOTE: dynamic lpf is enabled by default so this setting is actually
                                         // overridden and the static lowpass 1 is disabled. We can't set this
                                         // value to 0 otherwise Configurator versions 10.4 and earlier will also
                                         // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.


### PR DESCRIPTION
In 4.0, the dynamic gyro lowpass1 min and the static gyro lowpass1 alternative were the same values (150, biquad), so that if the dynamic lowpass was not active, we would get conservative static filtering.

In moving to 4.1 with PT1 filtering we have raised the dynamic gyro lowpass1 min to 200, but we have not raised the static gyro lowpass1 value, which is still at 150.  This is quite low.

We probably should make them both the same, as in 4.0x.

There is a fairly reasonable argument that 250 might make a more suitable static gyro lowpass1 value.  I leave that open for discussion, but personally am happy to set it to 200 by default.