### PR TITLE
Fixed start / end addresses for custom defaults.

### DIFF
--- a/src/link/stm32_flash_f7_split.ld
+++ b/src/link/stm32_flash_f7_split.ld
@@ -34,13 +34,6 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH AT >AXIM_FLASH
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    *(.custom_defaults_address)
-  } >FLASH1 AT >AXIM_FLASH1
-
   /* The program code and other data goes into FLASH */
   .text :
   {
@@ -103,7 +96,9 @@ SECTIONS
   .custom_defaults :
   {
     . = ALIGN(4);
-    KEEP (*(.custom_defaults_address))
+    KEEP (*(.custom_defaults_start_address))
+    . = ALIGN(4);
+    KEEP (*(.custom_defaults_end_address))
     . = ALIGN(4);
     __custom_defaults_internal_start = .;
     *(.custom_defaults);

--- a/src/link/stm32_flash_split.ld
+++ b/src/link/stm32_flash_split.ld
@@ -120,14 +120,16 @@ SECTIONS
   .custom_defaults :
   {
     . = ALIGN(4);
-    KEEP (*(.custom_defaults_address))
+    KEEP (*(.custom_defaults_start_address))
+    . = ALIGN(4);
+    KEEP (*(.custom_defaults_end_address))
     . = ALIGN(4);
     __custom_defaults_internal_start = .;
     *(.custom_defaults);
   } >FLASH_CUSTOM_DEFAULTS
 
     PROVIDE_HIDDEN (__custom_defaults_start = DEFINED(USE_CUSTOM_DEFAULTS_EXTENDED) ? ORIGIN(FLASH_CUSTOM_DEFAULTS_EXTENDED) : __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = DEFINED(USE_CUSTOM_DEFAULTS_EXTENDED) ? ORIGIN(FLASH_CUSTOM_DEFAULTS_EXTENDED) + LENGTH(FLASH_CUSTOM_DEFAULTS_EXTENDED) : ORIGIN(FLASH_CUSTOM_DEFAULTS) + LENGTH(FLASH_CUSTOM_DEFAULTS));
+    PROVIDE_HIDDEN (__custom_defaults_end = DEFINED(USE_CUSTOM_DEFAULTS_EXTENDED) ? ORIGIN(FLASH_CUSTOM_DEFAULTS_EXTENDED) + LENGTH(FLASH_CUSTOM_DEFAULTS_EXTENDED) : ORIGIN(FLASH_CUSTOM_DEFAULTS) + LENGTH(FLASH_CUSTOM_DEFAULTS));
 
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -228,8 +228,8 @@ static char cliBufferTemp[CLI_IN_BUFFER_SIZE];
 #endif
 
 #if defined(USE_CUSTOM_DEFAULTS_ADDRESS)
-static char __attribute__ ((section(".custom_defaults_address"))) *customDefaultsStart = CUSTOM_DEFAULTS_START;
-static char __attribute__ ((section(".custom_defaults_address"))) *customDefaultsEnd = CUSTOM_DEFAULTS_END;
+static char __attribute__ ((section(".custom_defaults_start_address"))) *customDefaultsStart = CUSTOM_DEFAULTS_START;
+static char __attribute__ ((section(".custom_defaults_end_address"))) *customDefaultsEnd = CUSTOM_DEFAULTS_END;
 #endif
 
 #ifndef USE_QUAD_MIXER_ONLY


### PR DESCRIPTION
Turns out `ld` does not retain the order of definition for symbols, even if there is no reason to reorder them.