### PR TITLE
Set default dyanmic notch range to medium

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -191,7 +191,7 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->yaw_spin_threshold = 1950;
     gyroConfig->dyn_lpf_gyro_min_hz = 200;
     gyroConfig->dyn_lpf_gyro_max_hz = 500;
-    gyroConfig->dyn_notch_range = DYN_NOTCH_RANGE_AUTO;
+    gyroConfig->dyn_notch_range = DYN_NOTCH_RANGE_MEDIUM;
     gyroConfig->dyn_notch_width_percent = 8;
     gyroConfig->dyn_notch_q = 120;
     gyroConfig->dyn_notch_min_hz = 150;


### PR DESCRIPTION
In 4.0x the dynamic notch range was set by default to AUTO mode.

AUTO mode used the dynamic gyro lowpass max value to select the dynamic notch range to either of low, medium or high.  For this to work, the user was supposed to configure `dyn_lpf_gyro_max_hz` to suit the maximum rpm of the quad.

In 4.1 the snippets for filter performance optimisation with the rpm filter are moving the maximum value of the dynamic gyro lowpass quite high.  This has been found to be an effective way to modify the filters even in non-rpm mode.  

Unfortunately most users won't realise that when they move the dynamic lowpass up to higher values, they may end up with the unintended side-effect of having their dynamic notch being shifted into high mode.  Once in high mode, the dynamic notch may not reach low enough to deal with common frame and prop resonances.  This has caused unexpected noise issues on some rpm-filtered quads.

I think it will be better if, by default, the dynamic notch range is set to MEDIUM mode for 4.1.  This works best for most quads out of the box, and won't arbitrarily get driven too high when tweaking the other filters. 

Users of very high RPM quads can choose HIGH range.   It can also be chosen, in association with an increased value of `dyn_notch_min_hz`, to restrict the range of the dynamic notch filter to specific higher frequency ranges only.  

XClass quads or machines with low frequency resonance should choose LOW range, and should reduce the dyn_notch_min_hz value low enough to reach the resonant peak.