### PR TITLE
Changed Unified Target custom defaults to use sector 0 memory.

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -56,8 +56,6 @@
 #define USBD_PRODUCT_STRING "OmnibusF4"
 #endif
 
-#define USE_CUSTOM_DEFAULTS
-
 #define LED0_PIN                PB5
 #define USE_BEEPER
 #define BEEPER_PIN              PB4

--- a/src/main/target/STM32F405/target.mk
+++ b/src/main/target/STM32F405/target.mk
@@ -2,6 +2,8 @@ F405_TARGETS += $(TARGET)
 
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
+# Use a full block (16 kB) of flash for custom defaults - with 1 MB flash we have more than we know how to use anyway
+
 CUSTOM_DEFAULTS_EXTENDED = yes
 
 TARGET_SRC = \

--- a/src/main/target/STM32F411/target.mk
+++ b/src/main/target/STM32F411/target.mk
@@ -2,8 +2,6 @@ F411_TARGETS += $(TARGET)
 
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
-CUSTOM_DEFAULTS_EXTENDED = yes
-
 TARGET_SRC = \
     $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \

--- a/src/main/target/STM32F745/target.mk
+++ b/src/main/target/STM32F745/target.mk
@@ -2,8 +2,6 @@ F7X5XG_TARGETS += $(TARGET)
 
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
-CUSTOM_DEFAULTS_EXTENDED = yes
-
 TARGET_SRC = \
     $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \

--- a/src/main/target/STM32F7X2/target.mk
+++ b/src/main/target/STM32F7X2/target.mk
@@ -2,8 +2,6 @@ F7X2RE_TARGETS += $(TARGET)
 
 FEATURES       += SDCARD_SPI VCP ONBOARDFLASH
 
-CUSTOM_DEFAULTS_EXTENDED = yes
-
 TARGET_SRC = \
     $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \

--- a/src/utils/make_config_hex.sh
+++ b/src/utils/make_config_hex.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+# Create hex file from custom defaults in order to flash separately
+#
+# This will only work if the target was built with 'CUSTOM_DEFAULTS_EXTENDED'
+#
+# Usage: make_config_hex <input file> <output directory> <config area start address>
+# Choose the config area start address from:
+#
+# STM32F405: 0x080FC000
+# STM32F411 / STM32F7X2: 0x0807C000
+# STM32F74X: 0x080F8000
+
 INPUT_FILE=$1
 DESTINATION_DIR=$2
-
-TARGET_ADDRESS=0x080FC000
+TARGET_ADDRESS=$3
 
 srec_cat ${INPUT_FILE} -binary -offset ${TARGET_ADDRESS} \
     -generate '(' -maximum-address ${INPUT_FILE} -binary -maximum-address ${INPUT_FILE} -binary -offset 1 ')' \


### PR DESCRIPTION
Custom defaults were put in a separate block of flash to make it possible to flash them independently during development.

Now that configurator has the capability to modify the firmware to be flashed, and inject the custom defaults on the fly, this is no longer needed and can be disabled.

Leaving extended custom defaults on for STM32F405 - with 1MB flash we are nowhere near to running out of flash, so we may as well use a separate block for the custom defaults.