### PR TITLE
Use `DMA_OPT_UNUSED` in `common_defaults_post.h`.

### DIFF
--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -292,36 +292,41 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
     // The embedded ADC24_DMA_REMAP conditional should be removed
     // when (and if) F3 is going generic.
 #define DMA(d, c) { DMA_CODE(d, 0, c), (dmaResource_t *)DMA ## d ## _Channel ## c }
-static const dmaPeripheralMapping_t dmaPeripheralMapping[17] = {
+static const dmaPeripheralMapping_t dmaPeripheralMapping[18] = {
 #ifdef USE_SPI
-    { DMA_PERIPH_SPI_TX,  1, { DMA(1, 3) } },
-    { DMA_PERIPH_SPI_RX,  1, { DMA(1, 2) } },
-    { DMA_PERIPH_SPI_TX,  2, { DMA(1, 5) } },
-    { DMA_PERIPH_SPI_RX,  2, { DMA(1, 4) } },
-    { DMA_PERIPH_SPI_TX,  3, { DMA(2, 2) } },
-    { DMA_PERIPH_SPI_RX,  3, { DMA(2, 1) } },
+    { DMA_PERIPH_SPI_TX,  SPIDEV_1, { DMA(1, 3) } },
+    { DMA_PERIPH_SPI_RX,  SPIDEV_1, { DMA(1, 2) } },
+    { DMA_PERIPH_SPI_TX,  SPIDEV_2, { DMA(1, 5) } },
+    { DMA_PERIPH_SPI_RX,  SPIDEV_2, { DMA(1, 4) } },
+    { DMA_PERIPH_SPI_TX,  SPIDEV_3, { DMA(2, 2) } },
+    { DMA_PERIPH_SPI_RX,  SPIDEV_3, { DMA(2, 1) } },
 #endif
 
 #ifdef USE_ADC
-    { DMA_PERIPH_ADC,     1, { DMA(1, 1) } },
+    { DMA_PERIPH_ADC,     ADCDEV_1, { DMA(1, 1) } },
 #ifdef ADC24_DMA_REMAP
-    { DMA_PERIPH_ADC,     2, { DMA(2, 3) } },
+    { DMA_PERIPH_ADC,     ADCDEV_2, { DMA(2, 3) } },
 #else
-    { DMA_PERIPH_ADC,     2, { DMA(2, 1) } },
+    { DMA_PERIPH_ADC,     ADCDEV_2, { DMA(2, 1) } },
 #endif
-    { DMA_PERIPH_ADC,     3, { DMA(2, 5) } },
+    { DMA_PERIPH_ADC,     ADCDEV_3, { DMA(2, 5) } },
+#ifdef ADC24_DMA_REMAP
+    { DMA_PERIPH_ADC,     ADCDEV_4, { DMA(2, 4) } },
+#else
+    { DMA_PERIPH_ADC,     ADCDEV_4, { DMA(2, 2) } },
+#endif
 #endif
 
 #ifdef USE_UART
-    { DMA_PERIPH_UART_TX, 1, { DMA(1, 4) } },
-    { DMA_PERIPH_UART_RX, 1, { DMA(1, 5) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_1, { DMA(1, 4) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_1, { DMA(1, 5) } },
 
-    { DMA_PERIPH_UART_TX, 2, { DMA(1, 7) } },
-    { DMA_PERIPH_UART_RX, 2, { DMA(1, 6) } },
-    { DMA_PERIPH_UART_TX, 3, { DMA(1, 2) } },
-    { DMA_PERIPH_UART_RX, 3, { DMA(1, 3) } },
-    { DMA_PERIPH_UART_TX, 4, { DMA(2, 5) } },
-    { DMA_PERIPH_UART_RX, 4, { DMA(2, 3) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_2, { DMA(1, 7) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_2, { DMA(1, 6) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_3, { DMA(1, 2) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_3, { DMA(1, 3) } },
+    { DMA_PERIPH_UART_TX, UARTDEV_4, { DMA(2, 5) } },
+    { DMA_PERIPH_UART_RX, UARTDEV_4, { DMA(2, 3) } },
 };
 #endif
 

--- a/src/main/drivers/dma_reqmap.h
+++ b/src/main/drivers/dma_reqmap.h
@@ -18,7 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-//#pragma once
+#pragma once
 
 #include "platform.h"
 
@@ -63,9 +63,11 @@ typedef int8_t dmaoptValue_t;
 #define MAX_TIMER_DMA_OPTIONS 3
 #endif
 
+struct timerHardware_s;
+
 dmaoptValue_t dmaoptByTag(ioTag_t ioTag);
 const dmaChannelSpec_t *dmaGetChannelSpecByPeripheral(dmaPeripheral_e device, uint8_t index, int8_t opt);
 const dmaChannelSpec_t *dmaGetChannelSpecByTimerValue(TIM_TypeDef *tim, uint8_t channel, dmaoptValue_t dmaopt);
-const dmaChannelSpec_t *dmaGetChannelSpecByTimer(const timerHardware_t *timer);
-dmaoptValue_t dmaGetOptionByTimer(const timerHardware_t *timer);
-dmaoptValue_t dmaGetUpOptionByTimer(const timerHardware_t *timer);
+const dmaChannelSpec_t *dmaGetChannelSpecByTimer(const struct timerHardware_s *timer);
+dmaoptValue_t dmaGetOptionByTimer(const struct timerHardware_s *timer);
+dmaoptValue_t dmaGetUpOptionByTimer(const struct timerHardware_s *timer);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -284,7 +284,9 @@ uint8_t timerInputIrq(TIM_TypeDef *tim);
 #if defined(USE_TIMER_MGMT)
 extern const resourceOwner_t freeOwner;
 
-timerIOConfig_t *timerIoConfigByTag(ioTag_t ioTag);
+struct timerIOConfig_s;
+
+struct timerIOConfig_s *timerIoConfigByTag(ioTag_t ioTag);
 const resourceOwner_t *timerGetOwner(int8_t timerNumber, uint16_t timerChannel);
 #endif
 const timerHardware_t *timerGetByTag(ioTag_t ioTag);

--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -39,11 +39,16 @@ PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);
 
 void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
+    STATIC_ASSERT(MAX_ADC_SUPPORTED <= ADC_DEV_TO_CFG(ADCDEV_COUNT) || MAX_ADC_SUPPORTED != 4, adc_count_mismatch);
+
     adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
     adcConfig->dmaopt[ADCDEV_1] = ADC1_DMA_OPT;
 #ifndef STM32F1
     adcConfig->dmaopt[ADCDEV_2] = ADC2_DMA_OPT;
     adcConfig->dmaopt[ADCDEV_3] = ADC3_DMA_OPT;
+#endif
+#ifdef STM32F3
+    adcConfig->dmaopt[ADCDEV_4] = ADC4_DMA_OPT;
 #endif
 
 #ifdef VBAT_ADC_PIN

--- a/src/main/pg/adc.h
+++ b/src/main/pg/adc.h
@@ -24,7 +24,11 @@
 #include <stdbool.h>
 
 #include "pg/pg.h"
+#include "drivers/adc.h"
 #include "drivers/io_types.h"
+#include "drivers/dma_reqmap.h"
+
+#define MAX_ADC_SUPPORTED 4
 
 typedef struct adcChannelConfig_t {
     bool enabled;
@@ -42,7 +46,7 @@ typedef struct adcConfig_s {
     uint16_t tempSensorCalibration1;
     uint16_t tempSensorCalibration2;
 
-    uint8_t dmaopt[3]; // One per ADCDEV_x
+    int8_t dmaopt[MAX_ADC_SUPPORTED]; // One per ADCDEV_x
 } adcConfig_t;
 
 PG_DECLARE(adcConfig_t, adcConfig);

--- a/src/main/pg/bus_spi.h
+++ b/src/main/pg/bus_spi.h
@@ -22,6 +22,7 @@
 
 #include "drivers/bus_spi.h"
 #include "drivers/io_types.h"
+#include "drivers/dma_reqmap.h"
 
 #include "pg/pg.h"
 

--- a/src/main/pg/sdio.h
+++ b/src/main/pg/sdio.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "drivers/dma_reqmap.h"
 #include "drivers/io_types.h"
 #include "pg/pg.h"
 

--- a/src/main/pg/serial_uart.h
+++ b/src/main/pg/serial_uart.h
@@ -25,6 +25,7 @@
 
 #include "pg/pg.h"
 #include "drivers/io_types.h"
+#include "drivers/dma_reqmap.h"
 
 #define UARTDEV_CONFIG_MAX 8 // Alternative to UARTDEV_COUNT_MAX, which requires serial_uart_imp.h
 

--- a/src/main/pg/timerio.h
+++ b/src/main/pg/timerio.h
@@ -23,6 +23,7 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
+#include "drivers/dma_reqmap.h"
 #include "drivers/io.h"
 
 #ifdef USE_TIMER_MGMT

--- a/src/main/pg/timerup.h
+++ b/src/main/pg/timerup.h
@@ -23,6 +23,7 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
+#include "drivers/dma_reqmap.h"
 #include "drivers/io.h"
 #include "drivers/timer.h" // For HARDWARE_TIMER_DEFINITION_COUNT
 

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -420,7 +420,7 @@
 #endif // USE_SDCARD_SPI
 #ifdef USE_SDCARD_SDIO
 #ifndef SDCARD_SDIO_DMA_OPT
-#define SDCARD_SDIO_DMA_OPT (-1)
+#define SDCARD_SDIO_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef SDIO_DEVICE
 #define SDIO_DEVICE SDIOINVALID
@@ -514,13 +514,16 @@
 #endif
 
 #if !defined(ADC1_DMA_OPT)
-#define ADC1_DMA_OPT (-1)
+#define ADC1_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #if !defined(ADC2_DMA_OPT)
-#define ADC2_DMA_OPT (-1)
+#define ADC2_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #if !defined(ADC3_DMA_OPT)
-#define ADC3_DMA_OPT (-1)
+#define ADC3_DMA_OPT (DMA_OPT_UNUSED)
+#endif
+#if !defined(ADC4_DMA_OPT)
+#define ADC4_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 
 #endif // USE_ADC
@@ -528,107 +531,107 @@
 #ifdef USE_SPI
 #ifdef USE_SPI_DEVICE_1
 #ifndef SPI1_TX_DMA_OPT
-#define SPI1_TX_DMA_OPT (-1)
+#define SPI1_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef SPI1_RX_DMA_OPT
-#define SPI1_RX_DMA_OPT (-1)
+#define SPI1_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 #ifdef USE_SPI_DEVICE_2
 #ifndef SPI2_TX_DMA_OPT
-#define SPI2_TX_DMA_OPT (-1)
+#define SPI2_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef SPI2_RX_DMA_OPT
-#define SPI2_RX_DMA_OPT (-1)
+#define SPI2_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 #ifdef USE_SPI_DEVICE_3
 #ifndef SPI3_TX_DMA_OPT
-#define SPI3_TX_DMA_OPT (-1)
+#define SPI3_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef SPI3_RX_DMA_OPT
-#define SPI3_RX_DMA_OPT (-1)
+#define SPI3_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 #ifdef USE_SPI_DEVICE_4
 #ifndef SPI4_TX_DMA_OPT
-#define SPI4_TX_DMA_OPT (-1)
+#define SPI4_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef SPI4_RX_DMA_OPT
-#define SPI4_RX_DMA_OPT (-1)
+#define SPI4_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 #endif
 
 #ifdef USE_UART1
 #ifndef UART1_TX_DMA_OPT
-#define UART1_TX_DMA_OPT (-1)
+#define UART1_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART1_RX_DMA_OPT
-#define UART1_RX_DMA_OPT (-1)
+#define UART1_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART2
 #ifndef UART2_TX_DMA_OPT
-#define UART2_TX_DMA_OPT (-1)
+#define UART2_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART2_RX_DMA_OPT
-#define UART2_RX_DMA_OPT (-1)
+#define UART2_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART3
 #ifndef UART3_TX_DMA_OPT
-#define UART3_TX_DMA_OPT (-1)
+#define UART3_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART3_RX_DMA_OPT
-#define UART3_RX_DMA_OPT (-1)
+#define UART3_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART4
 #ifndef UART4_TX_DMA_OPT
-#define UART4_TX_DMA_OPT (-1)
+#define UART4_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART4_RX_DMA_OPT
-#define UART4_RX_DMA_OPT (-1)
+#define UART4_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART5
 #ifndef UART5_TX_DMA_OPT
-#define UART5_TX_DMA_OPT (-1)
+#define UART5_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART5_RX_DMA_OPT
-#define UART5_RX_DMA_OPT (-1)
+#define UART5_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART6
 #ifndef UART6_TX_DMA_OPT
-#define UART6_TX_DMA_OPT (-1)
+#define UART6_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART6_RX_DMA_OPT
-#define UART6_RX_DMA_OPT (-1)
+#define UART6_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART7
 #ifndef UART7_TX_DMA_OPT
-#define UART7_TX_DMA_OPT (-1)
+#define UART7_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART7_RX_DMA_OPT
-#define UART7_RX_DMA_OPT (-1)
+#define UART7_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 
 #ifdef USE_UART8
 #ifndef UART8_TX_DMA_OPT
-#define UART8_TX_DMA_OPT (-1)
+#define UART8_TX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #ifndef UART8_RX_DMA_OPT
-#define UART8_RX_DMA_OPT (-1)
+#define UART8_RX_DMA_OPT (DMA_OPT_UNUSED)
 #endif
 #endif
 


### PR DESCRIPTION
This PR builds on #8744 and contains the same commits except for one new commit that uses `DMA_OPT_UNUSED` in `common_defaults_post.h`.

There were however issues with doing this, which are out of scope for #8744 and should not block the fixes in #8744 from being merged while we address the changes in 
86e7a4b14abc765ea00e698324dc8054daa149f0

Reviewers: just review 
86e7a4b14abc765ea00e698324dc8054daa149f0 and ignore the other changes.

