### PR TITLE
change transient throttle limit default to 0

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -205,7 +205,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .d_min_advance = 20,
         .motor_output_limit = 100,
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
-        .transient_throttle_limit = 15,
+        .transient_throttle_limit = 0,
         .profileName = { 0 },
         .idle_min_rpm = 0,
         .idle_adjustment_speed = 50,


### PR DESCRIPTION
Transient throttle limit was added to remove what we thought was noise generated near zero and max throttle due to motor mirroring because of air-mode. We later found out that the artifacts we had seen were actually rpm notch filter transients due to fast frequency change. 

Hence this feature should no longer be on by default.