### PR TITLE
Add RC channel values to OSD

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1294,6 +1294,8 @@ const clivalue_t valueTable[] = {
     { "osd_profile_name_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_PROFILE_NAME]) },
 #endif
 
+    { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RC_CHANNELS]) },
+
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users
     { "osd_stat_rtc_date_time",     VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_STAT_RTC_DATE_TIME,   PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
@@ -1335,6 +1337,8 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_gps_sats_show_hdop",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, gps_sats_show_hdop) },
 #endif
+
+    { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
 
 // PG_SYSTEM_CONFIG
 #if defined(STM32F4)

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -303,6 +303,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     }
     osdConfig->rssi_dbm_alarm = 60;
     osdConfig->gps_sats_show_hdop = false;
+
+    for (int i = 0; i < OSD_RCCHANNELS_COUNT; i++) {
+        osdConfig->rcChannels[i] = -1;
+    }
 }
 
 static void osdDrawLogo(int x, int y)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -39,6 +39,8 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_PROFILE_COUNT 1
 #endif
 
+#define OSD_RCCHANNELS_COUNT 4
+
 #define OSD_PROFILE_BITS_POS 11
 #define OSD_PROFILE_MASK    (((1 << OSD_PROFILE_COUNT) - 1) << OSD_PROFILE_BITS_POS)
 #define OSD_POS_MAX   0x3FF
@@ -132,6 +134,7 @@ typedef enum {
     OSD_PID_PROFILE_NAME,
     OSD_PROFILE_NAME,
     OSD_RSSI_DBM_VALUE,
+    OSD_RC_CHANNELS,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -258,6 +261,7 @@ typedef struct osdConfig_s {
     uint16_t link_quality_alarm;
     uint8_t rssi_dbm_alarm;
     uint8_t gps_sats_show_hdop;
+    int8_t rcChannels[OSD_RCCHANNELS_COUNT];           // RC channel values to display, -1 if none
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1017,6 +1017,26 @@ static void osdElementPower(osdElementParms_t *element)
     tfp_sprintf(element->buff, "%4dW", getAmperage() * getBatteryVoltage() / 10000);
 }
 
+static void osdElementRcChannels(osdElementParms_t *element)
+{
+    const uint8_t xpos = element->elemPosX;
+    const uint8_t ypos = element->elemPosY;
+
+    for (int i = 0; i < OSD_RCCHANNELS_COUNT; i++) {
+        if (osdConfig()->rcChannels[i] >= 0) {
+            // Translate (1000, 2000) to (-1000, 1000)
+            int data = scaleRange(rcData[osdConfig()->rcChannels[i]], PWM_RANGE_MIN, PWM_RANGE_MAX, -1000, 1000);
+            // Opt for the simplest formatting for now.
+            // Decimal notation can be added when tfp_sprintf supports float among fancy options.
+            char fmtbuf[6];
+            tfp_sprintf(fmtbuf, "%5d", data);
+            displayWrite(element->osdDisplayPort, xpos, ypos + i, fmtbuf);
+        }
+    }
+
+    element->drawElement = false;  // element already drawn
+}
+
 static void osdElementRemainingTimeEstimate(osdElementParms_t *element)
 {
     const int mAhDrawn = getMAhDrawn();
@@ -1457,7 +1477,7 @@ static const uint8_t osdElementDisplayOrder[] = {
 #ifdef USE_OSD_PROFILES
     OSD_PROFILE_NAME,
 #endif
-
+    OSD_RC_CHANNELS,
 };
 
 // Define the mapping between the OSD element id and the function to draw it
@@ -1563,6 +1583,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #ifdef USE_RX_RSSI_DBM
     [OSD_RSSI_DBM_VALUE]          = osdElementRssiDbm,
 #endif
+    [OSD_RC_CHANNELS]             = osdElementRcChannels,
 };
 
 static void osdAddActiveElement(osd_items_e element)


### PR DESCRIPTION
Per #8795 and #8810

---
New spec

Display at most 4 RC channels values vertically, right aligned.

Use
- `osd_rcchannels` array variable to specify source RC channel (zero origin, -1 if not specified).

Values from channels are assumed to be in full RC range (0~2000), so they are decremented by 1000 before being displayed.

Decimal numbers, if any, must be read by imagination of users of this facility.

---
The original spec

Display at most 4 RC channels values vertically.

I think it has enough support for displaying channel values between 0~9999 with decimal scaling. May even be overkill...

Use
- `osd_rcchannels` array variable to specify source RC channel (zero origin, -1 if not specified).
- `osd_rcchannel_offsets` array variable to specify offset for channel values when displaying (defaults to -1000). Negative values after offset compensation will be forced to zero.
- `osd_rcchannel_decimals` array variable to specify decimal digits (defaults to zero).

An example usage
```
# set osd_rcchan
osd_rcchannels_pos = 2155
Allowed range: 0 - 15359
Default value: 234

osd_rcchannels = 4,5,6,7
Array length: 4
Default value: 255,255,255,255

osd_rcchannel_offsets = -1000,-1000,-1000,-1000
Array length: 4

osd_rcchannel_decimals = 0,1,2,3
Array length: 4
Default value: 0,0,0,0
```
This setting will provide a display like this.
![betaflight-configurator_and_VideoGlide_and_Betaflight_Configurator](https://user-images.githubusercontent.com/14850998/64228343-7bd5f280-cf21-11e9-818d-b9361eaf7a6d.jpg)