### PR TITLE
Provide isMotorEnabled function for motorNullDevice

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -140,6 +140,13 @@ static void motorDisableNull(void)
 {
 }
 
+static bool motorIsEnabledNull(uint8_t index)
+{
+    UNUSED(index);
+
+    return false;
+}
+
 bool motorUpdateStartNull(void)
 {
     return true;
@@ -181,6 +188,7 @@ static const motorVTable_t motorNullVTable = {
     .postInit = motorPostInitNull,
     .enable = motorEnableNull,
     .disable = motorDisableNull,
+    .isMotorEnabled = motorIsEnabledNull,
     .updateStart = motorUpdateStartNull,
     .write = motorWriteNull,
     .writeInt = motorWriteIntNull,

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -990,7 +990,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
     case MSP_MOTOR:
         for (unsigned i = 0; i < 8; i++) {
 #ifdef USE_MOTOR
-            if (i >= MAX_SUPPORTED_MOTORS || !motorIsMotorEnabled(i)) {
+            if (!motorIsEnabled() || i >= MAX_SUPPORTED_MOTORS || !motorIsMotorEnabled(i)) {
                 sbufWriteU16(dst, 0);
                 continue;
             }


### PR DESCRIPTION
Provides pragmatic fix for #8823 

#8823 was caused by two reasons

- `isMotorEnabled` in `vTable` for `motorNullDevice` was not initialized.
- `MSP_MOTOR` is not checking for `motorIsEnabled()` (motor subsystem status; whereas `motorIsMotorEnabled()` is individual motor status) first.

This PR fixes both of these.

Fixes #8823 
