### PR TITLE
Optimize ledstrip DMA buffer update and bug fix

### DIFF
--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -67,6 +67,8 @@ void setLedValue(uint16_t index, const uint8_t value);
 void setStripColor(const hsvColor_t *color);
 void setStripColors(const hsvColor_t *colors);
 
+void setUsedLedCount(unsigned ledCount);
+
 bool isWS2811LedStripReady(void);
 
 #if defined(STM32F1) || defined(STM32F3)

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -269,6 +269,7 @@ STATIC_UNIT_TESTED void updateLedCount(void)
     ledCounts.count = count;
     ledCounts.ring = countRing;
     ledCounts.larson = countScanner;
+    setUsedLedCount(ledCounts.count);
 }
 
 void reevaluateLedConfig(void)

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -394,4 +394,7 @@ uint8_t getRssiPercent(void) { return 0; }
 bool isFlipOverAfterCrashActive(void) { return false; }
 
 void ws2811LedStripEnable(void) { }
+
+void setUsedLedCount(unsigned) { };
+
 }


### PR DESCRIPTION
Previous logic was updating updating the DMA buffer for all possible LED positions (32) regardless of how many were used. Since there are 24 bytes per LED, this performed a lot of unnecessary processing in cases where the user had less than 32 LEDs configured.

Also includes a bug fix in that if the LED count was decreased (like making changed using the Configurator LED tab), the now unused LEDs at the end of the string would remain on at the last color applied. Now they will be properly turned off. The bug was minor as it was resolved by a reboot, but made setup using the Configurator confusing since changes made are reflected when the user clicked the "Save" button (which does not reboot). So if the user removed LEDs the change would not be reflected on the quad.

Performance improvement - 4 LEDs configured, single color (SPEEDYBEEF4 F405):

**Before**
```
Task list             rate/hz  max/us  avg/us maxload avgload     total/ms
18 - (       LEDSTRIP)     99     112       7    1.6%    0.5%        44
```

**After**
```
Task list             rate/hz  max/us  avg/us maxload avgload     total/ms
18 - (       LEDSTRIP)     99      26       4    0.7%    0.5%        16
```

The key difference is the `max/us` - note the decrease from 112us to 26us. The 112us is nearly equal to a 8K gyro loop interval so this would lead to loop time jitter when the ledstrip task was run. This time is mostly representative of when the DMA buffer is getting populated based on the color data. Previously the time would remain nearly constant regardless of whether 1 LED was configured or 32 because all bytes of the DMA buffer would be updated. Now the time is proportional to the configured LEDs and since it's common for users to have only a few LEDs it will save substantial processing time. In the worst case of 32 LEDs configured there is no penalty - the time would just be equivalent to before. 

Also tested on F722 to ensure there was no impact on the HAL version.