### PR TITLE
Fix problem with empty string set as 'manufacturer_id'.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3017,12 +3017,14 @@ static void printBoardName(dumpFlags_t dumpMask)
 static void cliBoardName(char *cmdline)
 {
     const unsigned int len = strlen(cmdline);
-    if (len > 0 && boardInformationIsSet() && (len != strlen(getBoardName()) || strncmp(getBoardName(), cmdline, len))) {
-        cliPrintErrorLinef(ERROR_MESSAGE, "BOARD_NAME", getBoardName());
+    const char *boardName = getBoardName();
+    if (len > 0 && strlen(boardName) != 0 && boardInformationIsSet() && (len != strlen(boardName) || strncmp(boardName, cmdline, len))) {
+        cliPrintErrorLinef(ERROR_MESSAGE, "BOARD_NAME", boardName);
     } else {
-        if (len > 0) {
-            setBoardName(cmdline);
+        if (len > 0 && !configIsInCopy && setBoardName(cmdline)) {
             boardInformationUpdated = true;
+
+            cliPrintHashLine("Set board_name.");
         }
         printBoardName(DUMP_ALL);
     }
@@ -3038,12 +3040,14 @@ static void printManufacturerId(dumpFlags_t dumpMask)
 static void cliManufacturerId(char *cmdline)
 {
     const unsigned int len = strlen(cmdline);
-    if (len > 0 && boardInformationIsSet() && (len != strlen(getManufacturerId()) || strncmp(getManufacturerId(), cmdline, len))) {
-        cliPrintErrorLinef(ERROR_MESSAGE, "MANUFACTURER_ID", getManufacturerId());
+    const char *manufacturerId = getManufacturerId();
+    if (len > 0 && boardInformationIsSet() && strlen(manufacturerId) != 0 && (len != strlen(manufacturerId) || strncmp(manufacturerId, cmdline, len))) {
+        cliPrintErrorLinef(ERROR_MESSAGE, "MANUFACTURER_ID", manufacturerId);
     } else {
-        if (len > 0) {
-            setManufacturerId(cmdline);
+        if (len > 0 && !configIsInCopy && setManufacturerId(cmdline)) {
             boardInformationUpdated = true;
+
+            cliPrintHashLine("Set manufacturer_id.");
         }
         printManufacturerId(DUMP_ALL);
     }
@@ -3092,12 +3096,12 @@ static void cliSignature(char *cmdline)
         writeSignature(signatureStr, getSignature());
         cliPrintErrorLinef(ERROR_MESSAGE, "SIGNATURE", signatureStr);
     } else {
-        if (len > 0) {
-            setSignature(signature);
-
+        if (len > 0 && !configIsInCopy && setSignature(signature)) {
             signatureUpdated = true;
 
             writeSignature(signatureStr, getSignature());
+
+            cliPrintHashLine("Set signature.");
         } else if (signatureUpdated || signatureIsSet()) {
             writeSignature(signatureStr, getSignature());
         }

--- a/src/main/fc/board_info.c
+++ b/src/main/fc/board_info.c
@@ -29,6 +29,7 @@
 static bool boardInformationSet = false;
 static char manufacturerId[MAX_MANUFACTURER_ID_LENGTH + 1];
 static char boardName[MAX_BOARD_NAME_LENGTH + 1];
+static bool boardInformationWasUpdated = false;
 
 static bool signatureSet = false;
 static uint8_t signature[SIGNATURE_LENGTH];
@@ -64,8 +65,10 @@ bool boardInformationIsSet(void)
 
 bool setManufacturerId(const char *newManufacturerId)
 {
-    if (!boardInformationSet) {
+    if (!boardInformationSet || strlen(manufacturerId) == 0) {
         strncpy(manufacturerId, newManufacturerId, MAX_MANUFACTURER_ID_LENGTH);
+
+        boardInformationWasUpdated = true;
 
         return true;
     } else {
@@ -75,8 +78,10 @@ bool setManufacturerId(const char *newManufacturerId)
 
 bool setBoardName(const char *newBoardName)
 {
-    if (!boardInformationSet) {
+    if (!boardInformationSet || strlen(boardName) == 0) {
         strncpy(boardName, newBoardName, MAX_BOARD_NAME_LENGTH);
+
+        boardInformationWasUpdated = true;
 
         return true;
     } else {
@@ -86,7 +91,7 @@ bool setBoardName(const char *newBoardName)
 
 bool persistBoardInformation(void)
 {
-    if (!boardInformationSet) {
+    if (boardInformationWasUpdated) {
         strncpy(boardConfigMutable()->manufacturerId, manufacturerId, MAX_MANUFACTURER_ID_LENGTH);
         strncpy(boardConfigMutable()->boardName, boardName, MAX_BOARD_NAME_LENGTH);
         boardConfigMutable()->boardInformationSet = true;


### PR DESCRIPTION
This fixes the problem of `manufacturer_id` having been persisted as '' in non-unified targets by making it possible to set `manufacturer_id` and `board_name` if they are empty strings.
The plan is to use these parameters to detect and pre-select the correct target in the firmware flasher in configurator, and warn users when they try to flash a configuration that is for different target to the existing one.