### PR TITLE
Fix the problem of multiple timer allocations with bitbanged Dshot.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5616,28 +5616,12 @@ static void showTimers(void)
     cliRepeat('-', 23);
 #endif
 
-#ifdef USE_DSHOT_BITBANG
-    resourceOwner_t bitbangOwner = { OWNER_DSHOT_BITBANG, 0 };
-#endif
     int8_t timerNumber;
     for (int i = 0; (timerNumber = timerGetNumberByIndex(i)); i++) {
         cliPrintf("TIM%d:", timerNumber);
         bool timerUsed = false;
         for (unsigned timerIndex = 0; timerIndex < CC_CHANNELS_PER_TIMER; timerIndex++) {
             const resourceOwner_t *timerOwner = timerGetOwner(timerNumber, CC_CHANNEL_FROM_INDEX(timerIndex));
-#ifdef USE_DSHOT_BITBANG
-            if (!timerOwner->owner) {
-                const timerHardware_t* timer;
-                int pacerIndex = 0;
-                while ((timer = dshotBitbangGetPacerTimer(pacerIndex++))) {
-                    if (timerGetTIMNumber(timer->tim) == timerNumber && timer->channel == CC_CHANNEL_FROM_INDEX(timerIndex)) {
-                        timerOwner = &bitbangOwner;
-                        bitbangOwner.resourceIndex++;
-                        break;
-                    }
-                }
-            }
-#endif
             if (timerOwner->owner) {
                 if (!timerUsed) {
                     timerUsed = true;

--- a/src/main/drivers/dshot_bitbang.h
+++ b/src/main/drivers/dshot_bitbang.h
@@ -38,4 +38,4 @@ struct motorDevConfig_s;
 struct motorDevice_s;
 struct motorDevice_s *dshotBitbangDevInit(const struct motorDevConfig_s *motorConfig, uint8_t motorCount);
 dshotBitbangStatus_e dshotBitbangGetStatus();
-const timerHardware_t* dshotBitbangGetPacerTimer(int index);
+const resourceOwner_t *dshotBitbangTimerGetOwner(int8_t timerNumber, uint16_t timerChannel);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -274,6 +274,8 @@ rccPeriphTag_t timerRCC(TIM_TypeDef *tim);
 uint8_t timerInputIrq(TIM_TypeDef *tim);
 
 #if defined(USE_TIMER_MGMT)
+extern const resourceOwner_t freeOwner;
+
 timerIOConfig_t *timerIoConfigByTag(ioTag_t ioTag);
 const resourceOwner_t *timerGetOwner(int8_t timerNumber, uint16_t timerChannel);
 #endif

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -22,11 +22,14 @@
 
 #ifdef USE_TIMER
 
+#include "drivers/dshot_bitbang.h"
 #include "drivers/io.h"
 #include "timer.h"
 
 #ifdef USE_TIMER_MGMT
 #include "pg/timerio.h"
+
+const resourceOwner_t freeOwner = { .owner = OWNER_FREE, .resourceIndex = 0 };
 
 static resourceOwner_t timerOwners[MAX_TIMER_PINMAP_COUNT];
 
@@ -80,16 +83,23 @@ const timerHardware_t *timerGetByTag(ioTag_t ioTag)
 
 const resourceOwner_t *timerGetOwner(int8_t timerNumber, uint16_t timerChannel)
 {
-    static resourceOwner_t freeOwner = { .owner = OWNER_FREE, .resourceIndex = 0 };
-
+    const resourceOwner_t *timerOwner = &freeOwner;
     for (unsigned i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
         const timerHardware_t *timer = timerGetByTagAndIndex(timerIOConfig(i)->ioTag, timerIOConfig(i)->index);
         if (timer && timerGetTIMNumber(timer->tim) == timerNumber && timer->channel == timerChannel) {
-            return &timerOwners[i];
+            timerOwner = &timerOwners[i];
+
+            break;
         }
     }
 
-    return &freeOwner;
+#if defined(USE_DSHOT_BITBANG)
+    if (!timerOwner->owner) {
+        timerOwner = dshotBitbangTimerGetOwner(timerNumber, timerChannel);
+    }
+#endif
+
+    return timerOwner;
 }
 
 const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex)


### PR DESCRIPTION
This addresses some aspects of the problems raised in #8840, namely the problems resulting from functions trying to access timer 1 or timer 8 after the initialisation, and after they have been allocated by the auto-detection used for bitbanged Dshot. With this fix, these functions will fail to allocate a timer, and fail to work, as opposed to double allocating a timer and wedging the firmware.

This is not a complete fix, as these functions will obviously fail to work without a change to their timer assignment, which might not always be an option.

What we need is a way to configure what timers are used for bitbanged Dshot. This could be:
- extra entries in the `timerIO` parameter group for bitbanged Dshot - this is probably overkill;
- a parameter that allows pre-selection of either timer 1 or timer 8 for (or auto) for bitbanged Dshot - this is inconsistent with how timers are configured for everything else, but it is relatively straightforward.

@joelucid: What are your thoughts?

I also could not figure out how timer / DMA resources are indexed for bitbanged Dshot, so I left the index out for now. @joelucid maybe you can help?