### PR TITLE
OSD: user defined amount of decimals for selected items

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1178,6 +1178,13 @@ const clivalue_t valueTable[] = {
 // PG_OSD_CONFIG
 #ifdef USE_OSD
     { "osd_units",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_UNIT }, PG_OSD_CONFIG, offsetof(osdConfig_t, units) },
+    { "osd_current_draw_decimals",  VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 2 }, PG_OSD_CONFIG, offsetof(osdConfig_t, current_draw_decimals) },
+#if defined(USE_BARO) || defined(USE_GPS)
+    { "osd_altitude_decimals",      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1 }, PG_OSD_CONFIG, offsetof(osdConfig_t, altitude_decimals) },
+#endif
+#ifdef USE_GPS
+    { "osd_gps_coordinates_decimals", VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 4, 7 }, PG_OSD_CONFIG, offsetof(osdConfig_t, gps_coordinates_decimals) },
+#endif
 
 // Please try to keep the OSD warnings in the same order as presented in the Configurator.
 // This makes it easier for the user to relate the CLI output as warnings are in the same relative

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -296,6 +296,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->ahMaxPitch = 20; // 20 degrees
     osdConfig->ahMaxRoll = 40; // 40 degrees
 
+    osdConfig->current_draw_decimals = 2;
+    osdConfig->altitude_decimals = 1;
+    osdConfig->gps_coordinates_decimals = 7;
+
     osdConfig->osdProfileIndex = 1;
     osdConfig->ahInvert = false;
     for (int i=0; i < OSD_PROFILE_COUNT; i++) {

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -240,6 +240,9 @@ typedef struct osdConfig_s {
     uint8_t rssi_alarm;
 
     osd_unit_e units;
+    uint8_t current_draw_decimals;
+    uint8_t altitude_decimals;
+    uint8_t gps_coordinates_decimals;
 
     uint16_t timers[OSD_TIMER_COUNT];
     uint32_t enabledWarnings;


### PR DESCRIPTION
Some people including myself get easily distracted by rapidly changing numbers on the OSD. Users preferring a 'more calm' OSD can now **adjust the amount of decimals displayed** for the following three, in my opinion most "nervous" items:

- Current amp draw: permitted range 0-2, default is 2 as before
- Altitude: permitted range 0-1, default is 1 as before
- GPS Coordinates (Latitude and Longitude items): permitted range 4-7, default is 7 as before

I have only changed the way the items are displayed on the OSD, all calculations within the code remain at the same resolution as before.

First discussion here in (https://github.com/betaflight/betaflight/issues/8362)

modified:   src/main/cli/settings.c
modified:   src/main/osd/osd.c
modified:   src/main/osd/osd.h
modified:   src/main/osd/osd_elements.c

Edit: fixed link
