### PR TITLE
Adding limit distance - first step to complete volume limitation

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -904,6 +904,7 @@ const clivalue_t valueTable[] = {
     { "gps_ublox_use_galileo",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_ublox_use_galileo) },
     { "gps_set_home_point_once",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_set_home_point_once) },
     { "gps_use_3d_speed",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_use_3d_speed) },
+    { "gps_distance_limit",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 500 }, PG_GPS_CONFIG, offsetof(gpsConfig_t, distanceLimit) },
 
 #ifdef USE_GPS_RESCUE
     // PG_GPS_RESCUE
@@ -1079,7 +1080,7 @@ const clivalue_t valueTable[] = {
     { "idle_pid_limit",             VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_pid_limit) },
     { "idle_max_increase",          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_max_increase) },
 #endif
-    
+
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY
     { "tlm_inverted",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, telemetry_inverted) },

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -900,10 +900,10 @@ if(isLimitDistanceReach()){
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }
     } else {
-      if(!limitDistanceReach || FLIGHT_MODE(ANGLE_MODE)){
+  //    if(!limitDistanceReach || FLIGHT_MODE(ANGLE_MODE)){
       DISABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
       limitDistanceReach = false;
-    }
+//    }
     }
 #endif
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -900,10 +900,8 @@ if(isLimitDistanceReach()){
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }
     } else {
-  //    if(!limitDistanceReach || FLIGHT_MODE(ANGLE_MODE)){
       DISABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
       limitDistanceReach = false;
-//    }
     }
 #endif
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -233,7 +233,8 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .autoBaud = GPS_AUTOBAUD_OFF,
     .gps_ublox_use_galileo = false,
     .gps_set_home_point_once = false,
-    .gps_use_3d_speed = false
+    .gps_use_3d_speed = false,
+    .distanceLimit = 0
 );
 
 static void shiftPacketLog(void)
@@ -273,7 +274,7 @@ void gpsInit(void)
     gpsSetState(GPS_UNKNOWN);
 
     gpsData.lastMessage = millis();
-    
+
     if (gpsConfig()->provider == GPS_MSP) { // no serial ports used when GPS_MSP is configured
         gpsSetState(GPS_INITIALIZED);
         return;
@@ -1382,5 +1383,15 @@ void onGpsNewData(void)
     rescueNewGpsData();
 #endif
 }
+
+bool isLimitDistanceReach(void){
+
+  if(gpsConfig()->distanceLimit > 0 && GPS_distanceToHome >= gpsConfig()->distanceLimit){
+      return true;
+    }else{
+      return false;
+    }
+}
+
 
 #endif

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -76,6 +76,7 @@ typedef struct gpsConfig_s {
     uint8_t gps_ublox_use_galileo;
     uint8_t gps_set_home_point_once;
     uint8_t gps_use_3d_speed;
+    int16_t distanceLimit;
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);
@@ -167,4 +168,4 @@ void onGpsNewData(void);
 void GPS_reset_home_position(void);
 void GPS_calc_longitude_scaling(int32_t lat);
 void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, int32_t *destinationLat2, int32_t *destinationLon2, uint32_t *dist, int32_t *bearing);
-
+bool isLimitDistanceReach(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1227,6 +1227,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, gpsConfig()->sbasMode);
         sbufWriteU8(dst, gpsConfig()->autoConfig);
         sbufWriteU8(dst, gpsConfig()->autoBaud);
+        sbufWriteU16(dst, gpsConfig()->distanceLimit);
         break;
 
     case MSP_RAW_GPS:
@@ -2129,6 +2130,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gpsConfigMutable()->sbasMode = sbufReadU8(src);
         gpsConfigMutable()->autoConfig = sbufReadU8(src);
         gpsConfigMutable()->autoBaud = sbufReadU8(src);
+        gpsConfigMutable()->distanceLimit = sbufReadU16(src);
         break;
 
 #ifdef USE_GPS_RESCUE
@@ -2221,7 +2223,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
     case MSP_SET_RESET_CURR_PID:
         resetPidProfile(currentPidProfile);
         break;
-        
+
     case MSP_SET_SENSOR_ALIGNMENT: {
         // maintain backwards compatibility for API < 1.41
         const uint8_t gyroAlignment = sbufReadU8(src);


### PR DESCRIPTION
i think the possibility to  add some goefencing will be more compliant to match with DGAC requirement if we want to fly racers for some Scenarios (S1-S3)

what i did is that i added the possibility to put gps_distance_limit value by cli  or osd 

requirements : need a switch for ANGLE_MOD to be set .

how it works : 
if the value of distanceLimit  has been set - and you reach it - it start GPS_RESCUE procedure .
it stays in this state untill you active ANGLE mode .. (give you back control on the kwad ) 



