### PR TITLE
Add OSD distance from home alarm

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1227,6 +1227,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },
     { "osd_alt_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 10000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, alt_alarm) },
+    { "osd_distance_alarm",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, distance_alarm) },
     { "osd_esc_temp_alarm",         VAR_INT8   | MASTER_VALUE, .config.minmax = { INT8_MIN, INT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_temp_alarm) },
     { "osd_esc_rpm_alarm",          VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_RPM_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_rpm_alarm) },
     { "osd_esc_current_alarm",      VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_CURRENT_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_current_alarm) },

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -166,6 +166,7 @@ static uint16_t osdConfig_link_quality_alarm;
 static uint8_t osdConfig_rssi_dbm_alarm;
 static uint16_t osdConfig_cap_alarm;
 static uint16_t osdConfig_alt_alarm;
+static uint16_t osdConfig_distance_alarm;
 static uint8_t batteryConfig_vbatDurationForWarning;
 static uint8_t batteryConfig_vbatDurationForCritical;
 
@@ -176,6 +177,7 @@ static long menuAlarmsOnEnter(void)
     osdConfig_rssi_dbm_alarm = osdConfig()->rssi_dbm_alarm;
     osdConfig_cap_alarm = osdConfig()->cap_alarm;
     osdConfig_alt_alarm = osdConfig()->alt_alarm;
+    osdConfig_distance_alarm = osdConfig()->distance_alarm;
     batteryConfig_vbatDurationForWarning = batteryConfig()->vbatDurationForWarning;
     batteryConfig_vbatDurationForCritical = batteryConfig()->vbatDurationForCritical;
 
@@ -191,6 +193,7 @@ static long menuAlarmsOnExit(const OSD_Entry *self)
     osdConfigMutable()->rssi_dbm_alarm = osdConfig_rssi_dbm_alarm;
     osdConfigMutable()->cap_alarm = osdConfig_cap_alarm;
     osdConfigMutable()->alt_alarm = osdConfig_alt_alarm;
+    osdConfigMutable()->distance_alarm = osdConfig_distance_alarm;
     batteryConfigMutable()->vbatDurationForWarning = batteryConfig_vbatDurationForWarning;
     batteryConfigMutable()->vbatDurationForCritical = batteryConfig_vbatDurationForCritical;
 
@@ -205,6 +208,7 @@ const OSD_Entry menuAlarmsEntries[] =
     {"RSSI DBM", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_rssi_dbm_alarm, 5, 130, 5}, 0},
     {"MAIN BAT", OME_UINT16, NULL, &(OSD_UINT16_t){&osdConfig_cap_alarm, 50, 30000, 50}, 0},
     {"MAX ALT",  OME_UINT16, NULL, &(OSD_UINT16_t){&osdConfig_alt_alarm, 1, 200, 1}, 0},
+    {"MAX DISTANCE", OME_UINT16, NULL, &(OSD_UINT16_t){&osdConfig_distance_alarm, 0, UINT16_MAX, 10}, 0},
     {"VBAT WARN DUR", OME_UINT8, NULL, &(OSD_UINT8_t){ &batteryConfig_vbatDurationForWarning, 0, 200, 1 }, 0 },
     {"VBAT CRIT DUR", OME_UINT8, NULL, &(OSD_UINT8_t){ &batteryConfig_vbatDurationForCritical, 0, 200, 1 }, 0 },
     {"BACK", OME_Back, NULL, NULL, 0},

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -309,6 +309,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     }
 
     osdConfig->displayPortDevice = OSD_DISPLAYPORT_DEVICE_AUTO;
+
+    osdConfig->distance_alarm = 0;
 }
 
 static void osdDrawLogo(int x, int y)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -270,6 +270,7 @@ typedef struct osdConfig_s {
     uint8_t gps_sats_show_hdop;
     int8_t rcChannels[OSD_RCCHANNELS_COUNT];  // RC channel values to display, -1 if none
     uint8_t displayPortDevice;                // osdDisplayPortDevice_e
+    uint16_t distance_alarm;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1755,6 +1755,18 @@ void osdUpdateAlarms(void)
         CLR_BLINK(OSD_ALTITUDE);
     }
 
+#ifdef USE_GPS
+    if (sensors(SENSOR_GPS) && ARMING_FLAG(ARMED) && STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
+        if (osdConfig()->distance_alarm && GPS_distanceToHome >= osdConfig()->distance_alarm) {
+            SET_BLINK(OSD_HOME_DIST);
+        } else {
+            CLR_BLINK(OSD_HOME_DIST);
+        }
+    } else {
+        CLR_BLINK(OSD_HOME_DIST);;
+    }
+#endif
+
 #ifdef USE_ESC_SENSOR
     if (featureIsEnabled(FEATURE_ESC_SENSOR)) {
         // This works because the combined ESC data contains the maximum temperature seen amongst all ESCs


### PR DESCRIPTION
Adds `osd_distance_alarm` (defaulting to 0 for OFF) which behaves similarly to `osd_alt_alarm`. Causes the OSD distance to home element to blink if the alarm setting is exceeded.

Also added to the CMS menu for consistency with the altitude alarm.
