### PR TITLE
improvements to ff_boost for 4.1 RC's 

### DIFF
--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -62,26 +62,23 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
         const float setpointAcceleration = (setpointSpeed - prevSetpointSpeed[axis]) * pidGetDT();
 
         setpointDeltaImpl[axis] = setpointSpeed * pidGetDT();
-        
+
         const float ffBoostFactor = pidGetFfBoostFactor();
         float clip = 1.0f;
         float boostAmount = 0.0f;
-        if ((axis == FD_ROLL)||(axis == FD_PITCH)) {
-            if (ffBoostFactor != 0.0f) {
-                if (pidGetSpikeLimitInverse()) {
-                    clip = 1 / (1 + (setpointAcceleration * setpointAcceleration * pidGetSpikeLimitInverse()));
-                    clip *= clip;
-                }
-                // prevent kick-back spike at max deflection
-                if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis]) {
-                   boostAmount = ffBoostFactor * setpointAcceleration;
-                }
+        if (axis != FD_YAW && ffBoostFactor != 0.0f) {
+            if (pidGetSpikeLimitInverse()) {
+                clip = 1 / (1 + (setpointAcceleration * setpointAcceleration * pidGetSpikeLimitInverse()));
+                clip *= clip;
+            }
+            // prevent kick-back spike at max deflection
+            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis]) {
+                boostAmount = ffBoostFactor * setpointAcceleration;
             }
         }
         prevSetpointSpeed[axis] = setpointSpeed;
         prevSetpointAcceleration[axis] = setpointAcceleration;
         prevRawSetpoint[axis] = rawSetpoint;
-        
         if (axis == FD_ROLL) {
             DEBUG_SET(DEBUG_FF_INTERPOLATED, 0, setpointDeltaImpl[axis] * 1000);
             DEBUG_SET(DEBUG_FF_INTERPOLATED, 1, boostAmount * 1000);

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -66,15 +66,16 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
         const float ffBoostFactor = pidGetFfBoostFactor();
         float clip = 1.0f;
         float boostAmount = 0.0f;
-        if (ffBoostFactor != 0.0f) {
-            if (pidGetSpikeLimitInverse()) {
-                clip = 1 / (1 + fabsf(setpointAcceleration * pidGetSpikeLimitInverse()));
-                clip *= clip;
-            }
-
-            // prevent kick-back spike at max deflection
-            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis] || fabsf(setpointSpeed) > 3.0f * fabsf(prevSetpointSpeed[axis])) {
-                boostAmount = ffBoostFactor * setpointAcceleration;
+        if ((axis == FD_ROLL)||(axis == FD_PITCH)) {
+            if (ffBoostFactor != 0.0f) {
+                if (pidGetSpikeLimitInverse()) {
+                    clip = 1 / (1 + (setpointAcceleration * setpointAcceleration * pidGetSpikeLimitInverse()));
+                    clip *= clip;
+                }
+                // prevent kick-back spike at max deflection
+                if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis]) {
+                   boostAmount = ffBoostFactor * setpointAcceleration;
+                }
             }
         }
         prevSetpointSpeed[axis] = setpointSpeed;

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -72,7 +72,7 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
                 clip *= clip;
             }
             // prevent kick-back spike at max deflection
-            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis]) {
+            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis] || fabsf(setpointSpeed) > 3.0f * fabsf(prevSetpointSpeed[axis])) {
                 boostAmount = ffBoostFactor * setpointAcceleration;
             }
         }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -213,7 +213,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .idle_pid_limit = 200,
         .idle_max_increase = 150,
         .ff_interpolate_sp = FF_INTERPOLATE_AVG,
-        .ff_spike_limit = 40,
+        .ff_spike_limit = 60,
         .ff_max_rate_limit = 100,
         .ff_boost = 15,
     );


### PR DESCRIPTION
Please note my apologies for even more changes.  There are three.  After this no more.

1.  Exclude yaw from ff_boost.

Our standard yaw code performs worse if ff_boost is applied to yaw.  `Integrated_yaw` may work better with ff_boost, I don't know; it may not - this should be tested.  But I know for sure that normal yaw is worse.  For now I think we should just exclude yaw from ff_boost.

The code here is the simplest way I could see to exclude yaw.  It works.  I am sure it  is not the best approach and appreciate advice on how to better to code this.

2.  Removes suppression of 3x greater up-steps in FF (edit: NOT)

Where `ff_max_rate_limit` attenuates FF, there is another bit of code that attenuates FF whenever there is more than a threefold increase in FF.  I have found that this causes glitches in the boost signal around zero FF periods, ie when the sticks first start moving after being still.  I can't find any situations in my logs where this would be useful, particularly as large steps are now dealt with by the clipping approach.  <edit>: embarrassingly this shows how I misinterpreted this bit of code.  My apologies to @joelucid.  He explained that we needed a way to stop a big negative acceleration spike when the stick hit the limit; hence the blocking of boost when sticks are >95% deflected.  However we want the boost on the return, so this blocking is 'un-blocked' by the 'or', since any return from stable full deflection would result in a more than 3x step up in boost.  Too clever :-)

3.  Improve spike rejection.

Spike detection input value (boost) is now squared.  This results in a cleaner passband and tighter rejection above threshold.  A higher threshold is now possible with better suppression of large spikes.  I've noted that with the initial code there still was more spiking than anticipated and found that the rejection isn't strong enough.  By squaring the input, we get a cleaner passband.  

This graphic shows the rejection and passband characteristics of the existing vs proposed new code:

![Screen Shot 2019-09-10 at 19 40 09](https://user-images.githubusercontent.com/11737748/64602904-e6e06700-d402-11e9-8ce5-6c5a7dea11f9.jpg)