### PR TITLE
Add missing boundary checks in vtx_common for band, channel and powerlevel index

### DIFF
--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -148,7 +148,7 @@ bool vtxCommonGetStatus(const vtxDevice_t *vtxDevice, unsigned *status)
 
 const char *vtxCommonLookupBandName(const vtxDevice_t *vtxDevice, int band)
 {
-    if (vtxDevice) {
+    if (vtxDevice && band > 0 && band <= vtxTableBandCount) {
         return vtxTableBandNames[band];
     } else {
         return "?";
@@ -157,7 +157,7 @@ const char *vtxCommonLookupBandName(const vtxDevice_t *vtxDevice, int band)
 
 char vtxCommonLookupBandLetter(const vtxDevice_t *vtxDevice, int band)
 {
-    if (vtxDevice) {
+    if (vtxDevice && band > 0 && band <= vtxTableBandCount) {
         return vtxTableBandLetters[band];
     } else {
         return '?';
@@ -166,7 +166,7 @@ char vtxCommonLookupBandLetter(const vtxDevice_t *vtxDevice, int band)
 
 const char *vtxCommonLookupChannelName(const vtxDevice_t *vtxDevice, int channel)
 {
-    if (vtxDevice) {
+    if (vtxDevice && channel > 0 && channel <= vtxTableChannelCount) {
         return vtxTableChannelNames[channel];
     } else {
         return "?";
@@ -214,7 +214,7 @@ uint16_t vtxCommonLookupFrequency(const vtxDevice_t *vtxDevice, int band, int ch
 
 const char *vtxCommonLookupPowerName(const vtxDevice_t *vtxDevice, int index)
 {
-    if (vtxDevice) {
+    if (vtxDevice && index > 0 && index <= vtxTablePowerLevels) {
         return vtxTablePowerLabels[index];
     } else {
         return "?";


### PR DESCRIPTION
Fixes #8805 
Fixes #8846 

Previously there were cases where the input was not compared to the currently defined `vtxtable` limits and this could lead to a wedge as code referenced the uninitialize string arrays.

Seemed to only affect F7 and was difficult to trace due to the way the code was optimized (inlined, etc.). But the scenario was if smart audio was configured on a UART, vtx connected and powered, but `vtxtable` not defined, then the firmware would wedge shortly after initialization. I think what was happening is that communication with the vtx was initialized and successful and the current channel and powerlevel were retrieved via smart audio. Then calls were made to the vtx_common routines to translate this into powerlevel values, name, band names, band letter, channel names, etc. So the data retrieved from the vtx would indicate values outside the defined data range in `vtxtable` probably pointing to an uninitialized string for one of the names leading to the wedge.

The fix is just to make sure that all the lookups are constrained by valid ranges in the currently configured `vtxtable`.