### PR TITLE
Add missing vtxStatus variable initialization in MSP_VTX_CONFIG

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1676,7 +1676,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
     case MSP_VTX_CONFIG:
         {
             const vtxDevice_t *vtxDevice = vtxCommonDevice();
-            unsigned vtxStatus;
+            unsigned vtxStatus = 0;
             vtxDevType_e vtxType = VTXDEV_UNKNOWN;
             uint8_t deviceIsReady = 0;
             if (vtxDevice) {


### PR DESCRIPTION
Fixes #8868 

If the `vtxDevice` was not valid then the `vtxStatus` variable never got initialized but was still used in the pit mode flag determination - leading to random behavior.
