### PR TITLE
Prevent runaway takeoff detection during GPS Rescue flight mode

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1017,6 +1017,7 @@ static FAST_CODE void subTaskPidController(timeUs_t currentTimeUs)
         && !runawayTakeoffCheckDisabled
         && !flipOverAfterCrashActive
         && !runawayTakeoffTemporarilyDisabled
+        && !FLIGHT_MODE(GPS_RESCUE_MODE)   // disable Runaway Takeoff triggering if GPS Rescue is active
         && (!featureIsEnabled(FEATURE_MOTOR_STOP) || airmodeIsEnabled() || (calculateThrottleStatus() != THROTTLE_LOW))) {
 
         if (((fabsf(pidData[FD_PITCH].Sum) >= RUNAWAY_TAKEOFF_PIDSUM_THRESHOLD)


### PR DESCRIPTION
Addresses the possible edge case of runaway takeoff detection still being active and getting triggered by the quick yaw turn when GPS Rescue is activated.
