### PR TITLE
feed forward 2 to 4 point smoothing options

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -474,7 +474,7 @@ static const char * const lookupTableOffOnAuto[] = {
 };
 
 static const char* const lookupTableInterpolatedSetpoint[] = {
-    "OFF", "ON", "AVERAGED"
+    "OFF", "ON", "AVERAGE2", "AVERAGE3", "AVERAGE4"
 };
 
 static const char* const lookupTableDshotBitbangedTimer[] = {

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -30,6 +30,8 @@
 
 static float setpointDeltaImpl[XYZ_AXIS_COUNT];
 static float prevSetpointDeltaImpl[XYZ_AXIS_COUNT];
+static float prevSetpointDeltaImpl2[XYZ_AXIS_COUNT];
+static float prevSetpointDeltaImpl3[XYZ_AXIS_COUNT];
 static float setpointDelta[XYZ_AXIS_COUNT];
 
 
@@ -89,11 +91,18 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
         if (type == FF_INTERPOLATE_ON) {
             setpointDelta[axis] = setpointDeltaImpl[axis];
         } else {
-            setpointDelta[axis] = 0.5f * (setpointDeltaImpl[axis] + prevSetpointDeltaImpl[axis]);
-            prevSetpointDeltaImpl[axis] = setpointDeltaImpl[axis];
+            if (type == FF_INTERPOLATE_AVG4) {
+                setpointDelta[axis] = 0.25f * (setpointDeltaImpl[axis] + prevSetpointDeltaImpl[axis] + prevSetpointDeltaImpl2[axis] + prevSetpointDeltaImpl3[axis]);
+            } else if (type == FF_INTERPOLATE_AVG3) {
+                setpointDelta[axis] = 0.33f * (setpointDeltaImpl[axis] + prevSetpointDeltaImpl[axis] + prevSetpointDeltaImpl2[axis]);
+            } else if (type == FF_INTERPOLATE_AVG2) {
+                setpointDelta[axis] = 0.5f * (setpointDeltaImpl[axis] + prevSetpointDeltaImpl[axis]);
+            }
+        prevSetpointDeltaImpl3[axis] = prevSetpointDeltaImpl2[axis];
+        prevSetpointDeltaImpl2[axis] = prevSetpointDeltaImpl[axis];
+        prevSetpointDeltaImpl[axis] = setpointDeltaImpl[axis];
         }
     }
-    
     return setpointDelta[axis];
 }
 

--- a/src/main/flight/interpolated_setpoint.h
+++ b/src/main/flight/interpolated_setpoint.h
@@ -28,7 +28,9 @@
 typedef enum ffInterpolationType_e {
     FF_INTERPOLATE_OFF,
     FF_INTERPOLATE_ON,
-    FF_INTERPOLATE_AVG
+    FF_INTERPOLATE_AVG2,
+    FF_INTERPOLATE_AVG3,
+    FF_INTERPOLATE_AVG4
 } ffInterpolationType_t;
 
 void interpolatedSpInit(const pidProfile_t *pidProfile);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -212,7 +212,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .idle_p = 50,
         .idle_pid_limit = 200,
         .idle_max_increase = 150,
-        .ff_interpolate_sp = FF_INTERPOLATE_AVG,
+        .ff_interpolate_sp = FF_INTERPOLATE_AVG2,
         .ff_spike_limit = 60,
         .ff_max_rate_limit = 100,
         .ff_boost = 15,


### PR DESCRIPTION
Allows user to choose between two, three or four moving averages for the feed forward and boost signal.

Currently feed forward interpolation can be `OFF` (lowpass smoothing on 'analog' derivative only), `ON` (interpolation with no moving average smoothing), and `AVERAGED` (two point moving average smoothing.

I've seen in logs from R9 and CRSF radios that in their 150hz modes they have peculiar regular repeating patterns in the RC steps.  Crossfire gets 3-step cycles up and down, and R9 gets particularly bad 4-step cycles where one step is a duplicate.  Both these cause significant wobbling and variability in the feed forward trace.  This still happens even with OpenTx 2.3.  The variability is large and frequency low, so it can't be effectively lowpass filtered away.

I realised that 3-point linear moving average should totally eliminate the CRSF cyclic variability, and 4-point linear moving average should do the same for R9.

Testing has demonstrated a massive benefit, mostly for R9.

I would be grateful if this could be considered a bug fix for 4.1 since otherwise these users will complain about super erratic feed forward traces, especially with boost and high FF.
