### PR TITLE
prevent using same timer channel twice

### DIFF
--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -328,7 +328,8 @@ static void bbFindPacerTimer(void)
             }
 
             for (int index = 0; index < bbPortIndex; index++) {
-                if (bbPorts[index].timhw == timer) {
+                const timerHardware_t* t = bbPorts[index].timhw;
+                if (timerGetTIMNumber(t->tim) == timNumber && timer->channel == t->channel) {
                     timerConflict = true;
                     break;
                 }


### PR DESCRIPTION
This fixes the problem https://github.com/betaflight/betaflight/issues/8880 introduced in https://github.com/betaflight/betaflight/pull/8865.

Fixes #8878.
Fixes #8879.
Fixes #8880.