### PR TITLE
default f411 boards with timer 1 use to timer dshot

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -766,7 +766,7 @@ const clivalue_t valueTable[] = {
 #ifdef USE_DSHOT
     { "dshot_idle_value",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 2000 }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, digitalIdleOffsetValue) },
 #ifdef USE_DSHOT_DMAR
-    { "dshot_burst",                VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useBurstDshot) },
+    { "dshot_burst",                VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useBurstDshot) },
 #endif
 #ifdef USE_DSHOT_TELEMETRY
     { "dshot_bidir",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotTelemetry) },

--- a/src/main/drivers/dshot_dpwm.c
+++ b/src/main/drivers/dshot_dpwm.c
@@ -172,9 +172,8 @@ motorDevice_t *dshotPwmDevInit(const motorDevConfig_t *motorConfig, uint16_t idl
     case PWM_TYPE_DSHOT150:
         loadDmaBuffer = loadDmaBufferDshot;
 #ifdef USE_DSHOT_DMAR
-        if (motorConfig->useBurstDshot) {
-            useBurstDshot = true;
-        }
+        useBurstDshot = motorConfig->useBurstDshot == DSHOT_DMAR_ON ||
+            (motorConfig->useBurstDshot == DSHOT_DMAR_AUTO && !motorConfig->useDshotTelemetry);
 #endif
         break;
     }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -510,7 +510,7 @@ static void validateAndFixConfig(void)
     }
 
 #if defined(USE_DSHOT_TELEMETRY)
-    if ((!usingDshotProtocol || (motorConfig()->dev.useDshotBitbang == DSHOT_BITBANG_OFF && motorConfig()->dev.useBurstDshot) || systemConfig()->schedulerOptimizeRate == SCHEDULER_OPTIMIZE_RATE_OFF)
+    if ((!usingDshotProtocol || (motorConfig()->dev.useDshotBitbang == DSHOT_BITBANG_OFF && motorConfig()->dev.useBurstDshot == DSHOT_DMAR_ON) || systemConfig()->schedulerOptimizeRate == SCHEDULER_OPTIMIZE_RATE_OFF)
         && motorConfig()->dev.useDshotTelemetry) {
         motorConfigMutable()->dev.useDshotTelemetry = false;
     }

--- a/src/main/pg/motor.h
+++ b/src/main/pg/motor.h
@@ -31,6 +31,12 @@ typedef enum {
     DSHOT_BITBANGED_TIMER_TIM8,
 } dshotBitbangedTimer_e;
 
+typedef enum {
+    DSHOT_DMAR_OFF,
+    DSHOT_DMAR_ON,
+    DSHOT_DMAR_AUTO
+} dshotDmar_e;
+
 typedef struct motorDevConfig_s {
     uint16_t motorPwmRate;                  // The update rate of motor outputs (50-498Hz)
     uint8_t  motorPwmProtocol;              // Pwm Protocol

--- a/src/main/target/MAMBAF411/target.h
+++ b/src/main/target/MAMBAF411/target.h
@@ -32,7 +32,8 @@
 #define BEEPER_PIN              PB2
 #define BEEPER_INVERTED
 
-#define ENABLE_DSHOT_DMAR       true
+#undef  ENABLE_DSHOT_DMAR
+#define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_OFF
 
 // ******* INVERTER PIN ********
 

--- a/src/main/target/MAMBAF411/target.h
+++ b/src/main/target/MAMBAF411/target.h
@@ -32,7 +32,7 @@
 #define BEEPER_PIN              PB2
 #define BEEPER_INVERTED
 
-#undef  ENABLE_DSHOT_DMAR
+#define ENABLE_DSHOT_DMAR       DSHOT_DMAR_AUTO
 #define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_OFF
 
 // ******* INVERTER PIN ********

--- a/src/main/target/MATEKF411/target.h
+++ b/src/main/target/MATEKF411/target.h
@@ -30,7 +30,7 @@
 #define BEEPER_PIN              PB2
 #define BEEPER_INVERTED
 
-#undef  ENABLE_DSHOT_DMAR
+#define ENABLE_DSHOT_DMAR       DSHOT_DMAR_AUTO
 #define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_OFF
 
 // *************** Gyro & ACC **********************

--- a/src/main/target/MATEKF411/target.h
+++ b/src/main/target/MATEKF411/target.h
@@ -30,6 +30,9 @@
 #define BEEPER_PIN              PB2
 #define BEEPER_INVERTED
 
+#undef  ENABLE_DSHOT_DMAR
+#define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_OFF
+
 // *************** Gyro & ACC **********************
 #define USE_SPI
 #define USE_SPI_DEVICE_1
@@ -122,4 +125,3 @@
 
 #define USABLE_TIMER_CHANNEL_COUNT 10
 #define USED_TIMERS             ( TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(5)|TIM_N(9) )
-

--- a/src/main/target/MATEKF411RX/target.h
+++ b/src/main/target/MATEKF411RX/target.h
@@ -42,6 +42,9 @@
 
 #define USE_SPI
 
+#undef  ENABLE_DSHOT_DMAR
+#define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_OFF
+
 // *************** SPI1 Gyro & ACC **********************
 #define USE_SPI_DEVICE_1
 #define SPI1_SCK_PIN            PA5

--- a/src/main/target/MATEKF411RX/target.h
+++ b/src/main/target/MATEKF411RX/target.h
@@ -42,7 +42,7 @@
 
 #define USE_SPI
 
-#undef  ENABLE_DSHOT_DMAR
+#define ENABLE_DSHOT_DMAR       DSHOT_DMAR_AUTO
 #define DSHOT_BITBANG_DEFAULT   DSHOT_BITBANG_OFF
 
 // *************** SPI1 Gyro & ACC **********************


### PR DESCRIPTION
This PR fixes https://github.com/betaflight/betaflight/issues/8847 by defaulting dshot_burst to off and dshot_bitbang to off on MATEKF411, MATEKF411RX and MAMBAF411. I've double checked the dma stream mapping and these three target have no dma stream conflicts without dshot_burst. They also don't use n-timer channels.