### PR TITLE
prefer timer 8 for dshot_bitbang

### DIFF
--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -87,17 +87,17 @@ FAST_RAM_ZERO_INIT timeUs_t dshotFrameUs;
 
 const timerHardware_t bbTimerHardware[] = {
 #if defined(STM32F4) || defined(STM32F7)
-    DEF_TIM(TIM1,  CH1, NONE,  TIM_USE_NONE, 0, 1),
-    DEF_TIM(TIM1,  CH1, NONE,  TIM_USE_NONE, 0, 2),
-    DEF_TIM(TIM1,  CH2, NONE,  TIM_USE_NONE, 0, 1),
-    DEF_TIM(TIM1,  CH3, NONE,  TIM_USE_NONE, 0, 1),
-    DEF_TIM(TIM1,  CH4, NONE,  TIM_USE_NONE, 0, 0),
 #if !defined(STM32F411xE)
     DEF_TIM(TIM8,  CH1, NONE,  TIM_USE_NONE, 0, 1),
     DEF_TIM(TIM8,  CH2, NONE,  TIM_USE_NONE, 0, 1),
     DEF_TIM(TIM8,  CH3, NONE,  TIM_USE_NONE, 0, 1),
     DEF_TIM(TIM8,  CH4, NONE,  TIM_USE_NONE, 0, 0),
 #endif
+    DEF_TIM(TIM1,  CH1, NONE,  TIM_USE_NONE, 0, 1),
+    DEF_TIM(TIM1,  CH1, NONE,  TIM_USE_NONE, 0, 2),
+    DEF_TIM(TIM1,  CH2, NONE,  TIM_USE_NONE, 0, 1),
+    DEF_TIM(TIM1,  CH3, NONE,  TIM_USE_NONE, 0, 1),
+    DEF_TIM(TIM1,  CH4, NONE,  TIM_USE_NONE, 0, 0),
 #endif
 };
 


### PR DESCRIPTION
The main problem for dshot_bitbang timer auto-detection is the late initialization of telemetry soft-serial ports which leads to timer conflicts with very common configurations. The vast majority of rx telemetry soft-serial ports with conflicts use timer 1, not timer 8. This PR lets dshot_bitbang prefer timer 8 so that these conflicts only surface if timer 8 also hosts a late initialized function.