### PR TITLE
Removed usage of UNUSED macro for motorCount as motorCount is used now

### DIFF
--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -152,8 +152,6 @@ static bool allMotorsAreIdle(void)
 
 void dshotCommandWrite(uint8_t index, uint8_t motorCount, uint8_t command, bool blocking)
 {
-    UNUSED(motorCount);
-
     if (!isMotorProtocolDshot() || (command > DSHOT_MAX_COMMAND) || dshotCommandQueueFull()) {
         return;
     }


### PR DESCRIPTION
Removed usage of UNUSED macro for motorCount as motorCount is used in line 213 since commit ccf7ce964a0ad6bba3765d173c6777eafece1090

