### PR TITLE
Increase Tramp retry count and fix lockup if VTX out-of-sync with band/channel settings

### DIFF
--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -119,16 +119,11 @@ bool vtxCommonGetBandAndChannel(const vtxDevice_t *vtxDevice, uint8_t *pBand, ui
         && !vtxTableIsFactoryBand[selectedBand - 1]) {
         uint16_t freq;
         result = vtxCommonGetFrequency(vtxDevice, &freq);
-        if (!result || freq != vtxCommonLookupFrequency(vtxDevice, selectedBand, selectedChannel)) {
-            return false;
-        } else {
-            *pBand = selectedBand;
-            *pChannel = selectedChannel;
-            return true;
+        if (result) {
+            vtxCommonLookupBandChan(vtxDevice, freq, pBand, pChannel);
         }
-    } else {
-        return result;
     }
+    return result;
 }
 
 bool vtxCommonGetPowerIndex(const vtxDevice_t *vtxDevice, uint8_t *pIndex)
@@ -174,8 +169,11 @@ const char *vtxCommonLookupChannelName(const vtxDevice_t *vtxDevice, int channel
 }
 
 //Converts frequency (in MHz) to band and channel values.
-bool vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
+//If frequency not found in the vtxtable then band and channel will return 0
+void vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
 {
+    *pBand = 0;
+    *pChannel = 0;
     if (vtxDevice) {
         // Use reverse lookup order so that 5880Mhz
         // get Raceband 7 instead of Fatshark 8.
@@ -184,16 +182,11 @@ bool vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_
                 if (vtxTableFrequency[band][channel] == freq) {
                     *pBand = band + 1;
                     *pChannel = channel + 1;
-                    return true;
+                    return;
                 }
             }
         }
     }
-
-    *pBand = 0;
-    *pChannel = 0;
-
-    return false;
 }
 
 //Converts band and channel values to a frequency (in MHz) value.

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -140,6 +140,6 @@ char vtxCommonLookupBandLetter(const vtxDevice_t *vtxDevice, int band);
 char vtxCommonGetBandLetter(const vtxDevice_t *vtxDevice, int band);
 const char *vtxCommonLookupChannelName(const vtxDevice_t *vtxDevice, int channel);
 uint16_t vtxCommonLookupFrequency(const vtxDevice_t *vtxDevice, int band, int channel);
-bool vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_t *pBand, uint8_t *pChannel);
+void vtxCommonLookupBandChan(const vtxDevice_t *vtxDevice, uint16_t freq, uint8_t *pBand, uint8_t *pChannel);
 const char *vtxCommonLookupPowerName(const vtxDevice_t *vtxDevice, int index);
 bool vtxCommonLookupPowerValue(const vtxDevice_t *vtxDevice, int index, uint16_t *pPowerValue);

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -92,7 +92,9 @@ static uint8_t trampControlMode = 0;
 #define TRAMP_CONTROL_RACE_LOCK 0x01
 
 // Maximum number of requests sent to try a config change
-#define TRAMP_MAX_RETRIES 2
+// Some VTX fail to respond to every request (like Matek FCHUB-VTX) so
+// we sometimes need multiple retries to get the VTX to respond.
+#define TRAMP_MAX_RETRIES 20
 
 uint32_t trampConfFreq = 0;
 uint8_t  trampFreqRetries = 0;


### PR DESCRIPTION
Fixes #8888 

Some VTX don't respond to every request so it's necessary to retransmit. A previous PR fixed a bug that caused more retries than expected and made the actual retries only be 2 as configured. Unfortunately this exposed the problem with the non-responding VTX with cases where it failed to respond to both retries. The problem was accidentally masked by a previous bug with the retry counter causing many extra retries to actually occur.

This then exposed a secondary problem in `vtx_common` that lead to a "lockup" condition if the actual VTX channel didn't match our expectation of what the channel should be based on the settings. We were getting into this state because of the (now working) retry limit and cases where the VTX didn't respond and change channels as expected.

Increased the retry count to 20.

Fixed the logic that would prevent subsequent channel changes if the actual VTX channel didn't match the expected value based on the settings. Also fixed a problem where the channel change would not work if the VTX was on a frequency that was not defined in `vtxtable`.
