### PR TITLE
Revert Tramp power max check when setting power

### DIFF
--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -519,7 +519,7 @@ static void vtxTrampSetBandAndChannel(vtxDevice_t *vtxDevice, uint8_t band, uint
 static void vtxTrampSetPowerByIndex(vtxDevice_t *vtxDevice, uint8_t index)
 {
     uint16_t powerValue = 0;
-    if (vtxCommonLookupPowerValue(vtxDevice, index, &powerValue) && (trampRFPowerMax == 0 || powerValue <= trampRFPowerMax)) {
+    if (vtxCommonLookupPowerValue(vtxDevice, index, &powerValue)) {
         trampSetRFPower(powerValue);
         trampCommitChanges();
     }


### PR DESCRIPTION
The maximum power capability supplied from different VTX models is inconsistent. Sometimes correctly representing the VTX's capabilities, while for others not accurate or misrepresentative. So the previously added check is preventing accessing power levels in cases where the VTX doesn't properly report its max limit.

Examples include the SpeedyBee TX500 which only reports 200 even though it actually supports 500mw. Also the Matek FCHUB-VTX which reports 600 while it only actually supports 500mw max (and warns against using the 600 tramp value).