### PR TITLE
STM32F745 Do not define USE_SPI_DEVICE_5 and USE_SPI_DEVICE_6

### DIFF
--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -46,8 +46,6 @@
 #define USE_SPI_DEVICE_2
 #define USE_SPI_DEVICE_3
 #define USE_SPI_DEVICE_4
-#define USE_SPI_DEVICE_5
-#define USE_SPI_DEVICE_6
 
 #define TARGET_IO_PORTA 0xffff
 #define TARGET_IO_PORTB 0xffff


### PR DESCRIPTION
Fixes #8908

STM32F745 target defines USE_SPI_DEVICE_5 and USE_SPI_DEVICE_6, but SPI5 and SPI6 are only available in packages >= LQFP-144, and these are not defined in bus_spi_pinconfig.c either.
Accessing spiInitDevice() with SPIDEV_5 or SPIDEV_6 would cause hard fault.
