### PR TITLE
UART buffers for F4 should not be in CCM DATA RAM for DMA to work

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -170,7 +170,7 @@ typedef struct uartHardware_s {
     uint8_t txPriority;
     uint8_t rxPriority;
 
-#ifdef STM32H7
+#if defined(STM32H7) || defined(STM32F4)
     volatile uint8_t *txBuffer;
     volatile uint8_t *rxBuffer;
     uint16_t txBufferSize;
@@ -188,8 +188,9 @@ typedef struct uartDevice_s {
     const uartHardware_t *hardware;
     uartPinDef_t rx;
     uartPinDef_t tx;
-#ifdef STM32H7
+#if defined(STM32H7) || defined(STM32F4)
     // For H7, buffers with possible DMA access is placed in D2 SRAM.
+    // For F4, buffers should NOT be in CCM DATA RAM (uartDevice is).
     volatile uint8_t *rxBuffer;
     volatile uint8_t *txBuffer;
 #else

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -39,6 +39,36 @@
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
 
+#define UART_BUFFERS(n) \
+  volatile uint8_t uart ## n ## RxBuffer[UART_RX_BUFFER_SIZE]; \
+  volatile uint8_t uart ## n ## TxBuffer[UART_TX_BUFFER_SIZE]; struct dummy_s
+
+#ifdef USE_UART1
+UART_BUFFERS(1);
+#endif
+
+#ifdef USE_UART2
+UART_BUFFERS(2);
+#endif
+
+#ifdef USE_UART3
+UART_BUFFERS(3);
+#endif
+
+#ifdef USE_UART4
+UART_BUFFERS(4);
+#endif
+
+#ifdef USE_UART5
+UART_BUFFERS(5);
+#endif
+
+#ifdef USE_UART6
+UART_BUFFERS(6);
+#endif
+
+#undef UART_BUFFERS
+
 const uartHardware_t uartHardware[UARTDEV_COUNT] = {
 #ifdef USE_UART1
     {
@@ -65,7 +95,11 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc = RCC_APB2(USART1),
         .irqn = USART1_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
-        .rxPriority = NVIC_PRIO_SERIALUART1
+        .rxPriority = NVIC_PRIO_SERIALUART1,
+        .txBuffer = uart1TxBuffer,
+        .rxBuffer = uart1RxBuffer,
+        .txBufferSize = sizeof(uart1TxBuffer),
+        .rxBufferSize = sizeof(uart1RxBuffer),
     },
 #endif
 
@@ -86,7 +120,11 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc = RCC_APB1(USART2),
         .irqn = USART2_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
-        .rxPriority = NVIC_PRIO_SERIALUART2
+        .rxPriority = NVIC_PRIO_SERIALUART2,
+        .txBuffer = uart2TxBuffer,
+        .rxBuffer = uart2RxBuffer,
+        .txBufferSize = sizeof(uart2TxBuffer),
+        .rxBufferSize = sizeof(uart2RxBuffer),
     },
 #endif
 
@@ -107,7 +145,11 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc = RCC_APB1(USART3),
         .irqn = USART3_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
-        .rxPriority = NVIC_PRIO_SERIALUART3
+        .rxPriority = NVIC_PRIO_SERIALUART3,
+        .txBuffer = uart3TxBuffer,
+        .rxBuffer = uart3RxBuffer,
+        .txBufferSize = sizeof(uart3TxBuffer),
+        .rxBufferSize = sizeof(uart3RxBuffer),
     },
 #endif
 
@@ -128,7 +170,11 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc = RCC_APB1(UART4),
         .irqn = UART4_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
-        .rxPriority = NVIC_PRIO_SERIALUART4
+        .rxPriority = NVIC_PRIO_SERIALUART4,
+        .txBuffer = uart4TxBuffer,
+        .rxBuffer = uart4RxBuffer,
+        .txBufferSize = sizeof(uart4TxBuffer),
+        .rxBufferSize = sizeof(uart4RxBuffer),
     },
 #endif
 
@@ -149,7 +195,11 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc = RCC_APB1(UART5),
         .irqn = UART5_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
-        .rxPriority = NVIC_PRIO_SERIALUART5
+        .rxPriority = NVIC_PRIO_SERIALUART5,
+        .txBuffer = uart5TxBuffer,
+        .rxBuffer = uart5RxBuffer,
+        .txBufferSize = sizeof(uart5TxBuffer),
+        .rxBufferSize = sizeof(uart5RxBuffer),
     },
 #endif
 
@@ -182,7 +232,11 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc = RCC_APB2(USART6),
         .irqn = USART6_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
-        .rxPriority = NVIC_PRIO_SERIALUART6
+        .rxPriority = NVIC_PRIO_SERIALUART6,
+        .txBuffer = uart6TxBuffer,
+        .rxBuffer = uart6RxBuffer,
+        .txBufferSize = sizeof(uart6TxBuffer),
+        .rxBufferSize = sizeof(uart6RxBuffer),
     },
 #endif
 };
@@ -231,10 +285,10 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     s->port.baudRate = baudRate;
 
-    s->port.rxBuffer = uart->rxBuffer;
-    s->port.txBuffer = uart->txBuffer;
-    s->port.rxBufferSize = sizeof(uart->rxBuffer);
-    s->port.txBufferSize = sizeof(uart->txBuffer);
+    s->port.rxBuffer = hardware->rxBuffer;
+    s->port.txBuffer = hardware->txBuffer;
+    s->port.rxBufferSize = hardware->rxBufferSize;
+    s->port.txBufferSize = hardware->txBufferSize;
 
     s->USARTx = hardware->reg;
 


### PR DESCRIPTION
F4's UART DMA has been broken for one and half years. This happened in #5674 when `uartDevice[]` array with embedded buffers was designated as `FAST_RAM` (CCM DATA RAM) where DMA streams can not access.

While there are no direct influence of this bug as none of F4 targets use UART DMA facility at the moment, I think this fix is better be included as a bug fix in 4.1 for a better integrity of the code base  (and in case someone decides to use UART DMA for a custom build).

There will be some code duplication, but it will be cleaned up in a separate UART code refactor PR which is being prepared and submitted after 4.1 release.