### PR TITLE
IBUS telemetry for GPS combined frames fixed, IBUS telemetry code simplified.

### DIFF
--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -131,12 +131,14 @@ static uint8_t sendBuffer[IBUS_BUFFSIZE];
 
 static void setValue(uint8_t* bufferPtr, uint8_t sensorType, uint8_t length);
 
-static uint8_t getSensorType(ibusAddress_t address)
+static uint8_t getSensorID(ibusAddress_t address)
 {
     //all checks are done in theAddressIsWithinOurRange
     uint32_t index = address - ibusBaseAddress;
     return telemetryConfig()->flysky_sensors[index];
 }
+
+#if defined(USE_TELEMETRY_IBUS_EXTENDED)
 static const uint8_t* getSensorStruct(uint8_t sensorType, uint8_t* itemCount){
     const uint8_t* structure = 0;
     if (sensorType == IBUS_SENSOR_TYPE_GPS_FULL) {
@@ -153,6 +155,8 @@ static const uint8_t* getSensorStruct(uint8_t sensorType, uint8_t* itemCount){
     }
     return structure;
 }
+#endif //defined(USE_TELEMETRY_IBUS_EXTENDED)
+
 static uint8_t getSensorLength(uint8_t sensorType)
 {
     if (sensorType == IBUS_SENSOR_TYPE_PRES || (sensorType >= IBUS_SENSOR_TYPE_GPS_LAT && sensorType <= IBUS_SENSOR_TYPE_ALT_MAX)) {
@@ -168,7 +172,7 @@ static uint8_t getSensorLength(uint8_t sensorType)
         }
         return size;
     }
-#endif
+#endif //defined(USE_TELEMETRY_IBUS_EXTENDED)
     return IBUS_2BYTE_SESNSOR;
 }
 
@@ -196,11 +200,11 @@ static void setIbusDiscoverSensorReply(ibusAddress_t address)
 
 static void setIbusSensorType(ibusAddress_t address)
 {
-    uint8_t sensorType = getSensorType(address);
-    uint8_t sensorLength = getSensorLength(sensorType);
+    uint8_t sensorID = getSensorID(address);
+    uint8_t sensorLength = getSensorLength(sensorID);
     sendBuffer[0] = IBUS_HEADER_FOOTER_SIZE + 2;
     sendBuffer[1] = IBUS_COMMAND_SENSOR_TYPE | address;
-    sendBuffer[2] = sensorType;
+    sendBuffer[2] = sensorID;
     sendBuffer[3] = sensorLength;
 }
 
@@ -290,51 +294,59 @@ static void setCombinedFrame(uint8_t* bufferPtr, const uint8_t* structure, uint8
 }
 #endif
 
+
+
 #if defined(USE_GPS)
-static bool getGPSsensor(uint8_t sensorType, ibusTelemetry_s* value)
+static bool setGPS(uint8_t sensorType, ibusTelemetry_s* value)
 {
-    bool isGPSsensor = false;
+    bool result = false;
     for (unsigned i = 0; i < sizeof(GPS_IDS); i++) {
         if (sensorType == GPS_IDS[i]) {
-            isGPSsensor = true;
+            result = true;
             break;
         }
     }
-    if (!isGPSsensor) return false;
-    if (!sensors(SENSOR_GPS)) return true;
+    if (!result) return result;
 
-    if (sensorType == IBUS_SENSOR_TYPE_GPS_STATUS) {
-        value->byte[0] = !STATE(GPS_FIX) ? 1 : (gpsSol.numSat < 5 ? 2 : 3);
-        value->byte[1] = gpsSol.numSat;
+    uint16_t gpsFixType = 0;
+    uint16_t sats = 0;
+    if (sensors(SENSOR_GPS)) {
+        gpsFixType = !STATE(GPS_FIX) ? 1 : (gpsSol.numSat < 5 ? 2 : 3);
+        sats = gpsSol.numSat;
+        if (STATE(GPS_FIX) || sensorType == IBUS_SENSOR_TYPE_GPS_STATUS) {
+            result = true;
+            switch (sensorType) {
+            case IBUS_SENSOR_TYPE_SPE:
+                value->uint16 = gpsSol.groundSpeed * 36 / 100;
+                break;
+            case IBUS_SENSOR_TYPE_GPS_LAT:
+                value->int32 = gpsSol.llh.lat;
+                break;
+            case IBUS_SENSOR_TYPE_GPS_LON:
+                value->int32 = gpsSol.llh.lon;
+                break;
+            case IBUS_SENSOR_TYPE_GPS_ALT:
+                value->int32 = (int32_t)gpsSol.llh.altCm;
+                break;
+            case IBUS_SENSOR_TYPE_GROUND_SPEED:
+                value->uint16 = gpsSol.groundSpeed;
+                break;
+            case IBUS_SENSOR_TYPE_ODO1:
+            case IBUS_SENSOR_TYPE_ODO2:
+            case IBUS_SENSOR_TYPE_GPS_DIST:
+                value->uint16 = GPS_distanceToHome;
+                break;
+            case IBUS_SENSOR_TYPE_COG:
+                value->uint16 = gpsSol.groundCourse * 100;
+                break;
+            case IBUS_SENSOR_TYPE_GPS_STATUS:
+                value->byte[0] = gpsFixType;
+                value->byte[1] = sats;
+                break;
+            }
+        }
     }
-    if (!STATE(GPS_FIX)) return true;
-    
-    switch (sensorType) {
-    case IBUS_SENSOR_TYPE_SPE:
-        value->uint16 = gpsSol.groundSpeed * 36 / 100;
-        break;
-    case IBUS_SENSOR_TYPE_GPS_LAT:
-        value->int32 = gpsSol.llh.lat;
-        break;
-    case IBUS_SENSOR_TYPE_GPS_LON:
-        value->int32 = gpsSol.llh.lon;
-        break;
-    case IBUS_SENSOR_TYPE_GPS_ALT:
-        value->int32 = (int32_t)gpsSol.llh.altCm;
-        break;
-    case IBUS_SENSOR_TYPE_GROUND_SPEED:
-        value->uint16 = gpsSol.groundSpeed;
-        break;
-    case IBUS_SENSOR_TYPE_ODO1:
-    case IBUS_SENSOR_TYPE_ODO2:
-    case IBUS_SENSOR_TYPE_GPS_DIST:
-        value->uint16 = GPS_distanceToHome;
-        break;
-    case IBUS_SENSOR_TYPE_COG:
-        value->uint16 = gpsSol.groundCourse * 100;
-        break;
-    }
-    return true;
+    return result;
 }
 #endif //defined(USE_GPS)
 
@@ -355,7 +367,7 @@ static void setValue(uint8_t* bufferPtr, uint8_t sensorType, uint8_t length)
         bufferPtr[i] = value.byte[i] = 0;
     }
 #if defined(USE_GPS)
-    if (getGPSsensor(sensorType, &value)) {
+    if (setGPS(sensorType, &value)) {
         for (unsigned i = 0; i < length; i++) {
             bufferPtr[i] = value.byte[i];
         }
@@ -429,11 +441,11 @@ static void setValue(uint8_t* bufferPtr, uint8_t sensorType, uint8_t length)
 }
 static void setIbusMeasurement(ibusAddress_t address)
 {
-    uint8_t sensorType = getSensorType(address);
-    uint8_t sensorLength = getSensorLength(sensorType);
+    uint8_t sensorID = getSensorID(address);
+    uint8_t sensorLength = getSensorLength(sensorID);
     sendBuffer[0] = IBUS_HEADER_FOOTER_SIZE + sensorLength;
     sendBuffer[1] = IBUS_COMMAND_MEASUREMENT | address;
-    setValue(sendBuffer + 2, sensorType, sensorLength);
+    setValue(sendBuffer + 2, sensorID, sensorLength);
 }
 
 static bool isCommand(ibusCommand_e expected, const uint8_t *ibusPacket)


### PR DESCRIPTION
During work with @pascallanger on bringing IBUS telemetry via Multiprotocol to OpenTX we discovered few issues with telemetry provider from BF. Sending not initialized variables in case of missing GPS sensor was fixed. Logic for GPS becomes more transparent.

Additionally we used same method to get combined sensor structure in case of sensor length calculation and sensor value calumniation. The variable "sensorID" was renamed to "sensorType" and unified across file.

It was tested with OpenTX 2.3 on Jumper T16 - https://github.com/pascallanger/opentx/tree/sweet-pascal and on FlySky I6 where initially sensors were implemented.