### PR TITLE
exclude yaw from ff_max_rate_limit

### DIFF
--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -98,24 +98,27 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
 }
 
 FAST_CODE_NOINLINE float applyFfLimit(int axis, float value, float Kp, float currentPidSetpoint) {
-    if (axis == FD_ROLL) {
+    switch (axis) {
+    case FD_ROLL:
         DEBUG_SET(DEBUG_FF_LIMIT, 0, value);
-    }
 
-    if (axis == FD_PITCH) {
+        break;
+    case FD_PITCH:
         DEBUG_SET(DEBUG_FF_LIMIT, 1, value);
+
+        break;
     }
 
-    if (ffMaxRateLimit[axis]) {
-        if (fabsf(currentPidSetpoint) <= ffMaxRateLimit[axis]) {
-            value = constrainf(value, (-ffMaxRateLimit[axis] - currentPidSetpoint) * Kp, (ffMaxRateLimit[axis] - currentPidSetpoint) * Kp);
-        } else {
-            value = 0;
-        }
+    if (fabsf(currentPidSetpoint) <= ffMaxRateLimit[axis]) {
+        value = constrainf(value, (-ffMaxRateLimit[axis] - currentPidSetpoint) * Kp, (ffMaxRateLimit[axis] - currentPidSetpoint) * Kp);
+    } else {
+        value = 0;
     }
+
     if (axis == FD_ROLL) {
         DEBUG_SET(DEBUG_FF_LIMIT, 2, value);
     }
+
     return value;
 }
 
@@ -123,6 +126,4 @@ bool shouldApplyFfLimits(int axis)
 {
     return ffMaxRateLimit[axis] != 0.0f && axis < FD_YAW;
 }
-
-
 #endif

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -102,11 +102,11 @@ FAST_CODE_NOINLINE float applyFfLimit(int axis, float value, float Kp, float cur
         DEBUG_SET(DEBUG_FF_LIMIT, 0, value);
     }
 
-    if (axis == FD_ROLL) {
+    if (axis == FD_PITCH) {
         DEBUG_SET(DEBUG_FF_LIMIT, 1, value);
     }
 
-    if (ffMaxRateLimit[axis]) {
+    if (ffMaxRateLimit[axis] && (axis < FD_YAW)) {
         if (fabsf(currentPidSetpoint) <= ffMaxRateLimit[axis]) {
             value = constrainf(value, (-ffMaxRateLimit[axis] - currentPidSetpoint) * Kp, (ffMaxRateLimit[axis] - currentPidSetpoint) * Kp);
         } else {

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -106,7 +106,7 @@ FAST_CODE_NOINLINE float applyFfLimit(int axis, float value, float Kp, float cur
         DEBUG_SET(DEBUG_FF_LIMIT, 1, value);
     }
 
-    if (ffMaxRateLimit[axis] && (axis < FD_YAW)) {
+    if (ffMaxRateLimit[axis]) {
         if (fabsf(currentPidSetpoint) <= ffMaxRateLimit[axis]) {
             value = constrainf(value, (-ffMaxRateLimit[axis] - currentPidSetpoint) * Kp, (ffMaxRateLimit[axis] - currentPidSetpoint) * Kp);
         } else {
@@ -121,7 +121,7 @@ FAST_CODE_NOINLINE float applyFfLimit(int axis, float value, float Kp, float cur
 
 bool shouldApplyFfLimits(int axis)
 {
-    return ffMaxRateLimit[axis] != 0.0f;
+    return ffMaxRateLimit[axis] != 0.0f && axis < FD_YAW;
 }
 
 


### PR DESCRIPTION
There is a small bug in 4.1 RC's where yaw was accidentally included in ff_max_rate_limit.

This PR excludes yaw from ff_max_rate_limit, so that full feed forward drive is applied, as it should be, to full rate yaw spins, even if the sticks are rapidly approaching maximum rate.

Additionally, when debug_mode is DEBUG_FF_LIMIT, Debug 1 is now assigned to pitch, since otherwise it was just a duplicate of debug 0.  Including pitch for debugging may be useful.