### PR TITLE
Prevent DSHOT commands during protocol initialization/detection

### DIFF
--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -37,6 +37,7 @@
 #include "drivers/dshot_command.h"
 #include "drivers/pwm_output.h"
 
+#define DSHOT_PROTOCOL_DETECTION_DELAY_MS 3000
 #define DSHOT_INITIAL_DELAY_US 10000
 #define DSHOT_COMMAND_DELAY_US 1000
 #define DSHOT_ESCINFO_DELAY_US 12000
@@ -150,9 +151,18 @@ static bool allMotorsAreIdle(void)
     return true;
 }
 
+bool dshotCommandsAreEnabled(void)
+{
+    if (motorIsEnabled() && motorGetMotorEnableTimeMs() && millis() > motorGetMotorEnableTimeMs() + DSHOT_PROTOCOL_DETECTION_DELAY_MS) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 void dshotCommandWrite(uint8_t index, uint8_t motorCount, uint8_t command, bool blocking)
 {
-    if (!isMotorProtocolDshot() || (command > DSHOT_MAX_COMMAND) || dshotCommandQueueFull()) {
+    if (!isMotorProtocolDshot() || !dshotCommandsAreEnabled() || (command > DSHOT_MAX_COMMAND) || dshotCommandQueueFull()) {
         return;
     }
 

--- a/src/main/drivers/dshot_command.h
+++ b/src/main/drivers/dshot_command.h
@@ -68,3 +68,4 @@ bool dshotCommandQueueEmpty(void);
 bool dshotCommandIsProcessing(void);
 uint8_t dshotCommandGetCurrent(uint8_t index);
 bool dshotCommandOutputIsEnabled(uint8_t motorCount);
+bool dshotCommandsAreEnabled(void);

--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -50,6 +50,7 @@ void motorShutdown(void)
 {
     motorDevice->vTable.shutdown();
     motorDevice->enabled = false;
+    motorDevice->motorEnableTimeMs = 0;
     motorDevice->initialized = false;
     delayMicroseconds(1500);
 }
@@ -246,6 +247,7 @@ void motorDevInit(const motorDevConfig_t *motorConfig, uint16_t idlePulse, uint8
     if (motorDevice) {
         motorDevice->count = motorCount;
         motorDevice->initialized = true;
+        motorDevice->motorEnableTimeMs = 0;
         motorDevice->enabled = false;
     } else {
         motorNullDevice.vTable = motorNullVTable;
@@ -257,12 +259,14 @@ void motorDisable(void)
 {
     motorDevice->vTable.disable();
     motorDevice->enabled = false;
+    motorDevice->motorEnableTimeMs = 0;
 }
 
 void motorEnable(void)
 {
     if (motorDevice->initialized && motorDevice->vTable.enable()) {
         motorDevice->enabled = true;
+        motorDevice->motorEnableTimeMs = millis();
     }
 }
 
@@ -280,6 +284,13 @@ bool isMotorProtocolDshot(void)
 {
     return isDshot;
 }
+
+#ifdef USE_DSHOT
+timeMs_t motorGetMotorEnableTimeMs(void)
+{
+    return motorDevice->motorEnableTimeMs;
+}
+#endif
 
 #ifdef USE_DSHOT_BITBANG
 bool isDshotBitbangActive(const motorDevConfig_t *motorConfig) {

--- a/src/main/drivers/motor.h
+++ b/src/main/drivers/motor.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 typedef enum {
     PWM_TYPE_STANDARD = 0,
     PWM_TYPE_ONESHOT125,
@@ -62,6 +64,7 @@ typedef struct motorDevice_s {
     uint8_t       count;
     bool          initialized;
     bool          enabled;
+    timeMs_t      motorEnableTimeMs;
 } motorDevice_t;
 
 void motorPostInitNull();
@@ -85,6 +88,7 @@ void motorDisable(void);
 void motorEnable(void);
 bool motorIsEnabled(void);
 bool motorIsMotorEnabled(uint8_t index);
+timeMs_t motorGetMotorEnableTimeMs(void);
 void motorShutdown(void); // Replaces stopPwmAllMotors
 
 #ifdef USE_DSHOT_BITBANG

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -220,7 +220,14 @@ void updateArmingStatus(void)
         LED0_ON;
     } else {
         // Check if the power on arming grace time has elapsed
-        if ((getArmingDisableFlags() & ARMING_DISABLED_BOOT_GRACE_TIME) && (millis() >= systemConfig()->powerOnArmingGraceTime * 1000)) {
+        if ((getArmingDisableFlags() & ARMING_DISABLED_BOOT_GRACE_TIME) && (millis() >= systemConfig()->powerOnArmingGraceTime * 1000)
+#ifdef USE_DSHOT
+            // We also need to prevent arming until it's possible to send DSHOT commands.
+            // Otherwise if the initial arming is in crash-flip the motor direction commands
+            // might not be sent.
+            && dshotCommandsAreEnabled()
+#endif
+        ) {
             // If so, unset the grace time arming disable flag
             unsetArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
         }


### PR DESCRIPTION
Fixes #8922 

Adds a fixed delay after the motors are enabled before DSHOT commands can be sent. Fixes a problem caused by sending DSHOT commands too soon and prevent the ESC from properly detecting the protocol.

The scenario is having DSHOT commands sent very early in the startup phase. Like for example having `beacon RX_SET` and the beeper mode active on power.

Currently the delay is hardcoded to 3 seconds which experimentally seems appropriate. But waiting for some feedback from the BLHeli dev for confirmation.

This is really a generalized bug as we can't be sending DSHOT commands with the 10ms start delay and 1ms inter-command delay during the ESC protocol detection . The line being held low during these delays would look like a firmware request to the ESC. Run detecting inverted DSHOT the BLHeli32 firmware seems to take longer than with traditional non-inverted. This is contributing to a higher failure rate.

The logic changes to the boot grace period arming disabled are necessary to ensure that the user can't arm until DSHOT commands are enabled. Otherwise there's a risk if the user arms too quickly and is arming into crash-flip then the motor direction DSHOT commands may not be sent. We probably need to think about the `pwr_on_arm_grace` setting range. The default is 5 seconds which will be greater than the DSHOT command enable delay - so no change will be noticed. However the user can set this value lower - including 0. In this case arming will still be prevented unto the DSHOT commands are enabled, but there's some level of confusion. But realistically very low values are not a good scenario anyway as the pilot could technically arm before ESC protocol detection completed. This is not a new problem. Maybe we should consider changing the minimum boot grace period to be a more reasonable value like 3 seconds.