### PR TITLE
Add board name to CLI version command output for unified targets

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4769,11 +4769,30 @@ static void cliVersion(char *cmdline)
         shortGitRevision,
         MSP_API_VERSION_STRING
     );
+
 #ifdef FEATURE_CUT_LEVEL
     cliPrintLinef(" / FEATURE CUT LEVEL %d", FEATURE_CUT_LEVEL);
 #else
     cliPrintLinefeed();
 #endif
+
+#ifdef USE_UNIFIED_TARGET
+    cliPrint("# ");
+#ifdef USE_BOARD_INFO
+    if (strlen(getManufacturerId())) {
+        cliPrintf("manufacturer_id: %s   ", getManufacturerId());
+    }
+    if (strlen(getBoardName())) {
+        cliPrintf("board_name: %s   ", getBoardName());
+    }
+#endif // USE_BOARD_INFO
+
+#ifdef USE_CUSTOM_DEFAULTS
+    cliPrintf("custom defaults: %s", hasCustomDefaults() ? "YES" : "NO");
+#endif // USE_CUSTOM_DEFAULTS
+
+    cliPrintLinefeed();
+#endif // USE_UNIFIED_TARGET
 }
 
 #ifdef USE_RC_SMOOTHING_FILTER


### PR DESCRIPTION
Will help improve support efforts by more clearly indicating which board's target config was applied to the underlying unified target base. Previously only the base unified target info was displayed (ie. STM32F05).

```
# version
# Betaflight / STM32F7X2 (S7X2) 4.1.0 Sep 24 2019 / 18:06:20 (df57ef2) MSP API: 1.42
# manufacturer_id: CLRA   board_name: CLRACINGF7   custom defaults: YES
```
