### PR TITLE
[VTX] RTC6705 power down is now controlled by pitmode rather than powervalue

### DIFF
--- a/docs/VTX.md
+++ b/docs/VTX.md
@@ -269,9 +269,9 @@ vtxtable band 2 BOSCAM_B B CUSTOM 5733 5752 5771 5790 5809 5828 5847 5866
 vtxtable band 3 BOSCAM_E E CUSTOM 5705 5685 5665 5645 5885 5905 5925 5945
 vtxtable band 4 FATSHARK F CUSTOM 5740 5760 5780 5800 5820 5840 5860 5880
 vtxtable band 5 RACEBAND R CUSTOM 5658 5695 5732 5769 5806 5843 5880 5917
-vtxtable powerlevels 3
-vtxtable powervalues 0 1 2
-vtxtable powerlabels OFF MIN MAX
+vtxtable powerlevels 2
+vtxtable powervalues 1 2
+vtxtable powerlabels MIN MAX
 ```
 
 ### Pitmode

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -43,15 +43,28 @@
 static uint8_t cmsx_vtxBand;
 static uint8_t cmsx_vtxChannel;
 static uint8_t cmsx_vtxPower;
+static uint8_t cmsx_vtxPit;
 
 static OSD_TAB_t entryVtxBand;
 static OSD_TAB_t entryVtxChannel;
 static OSD_TAB_t entryVtxPower;
+static const char * const cmsxCmsPitNames[] = {
+        "---",
+        "OFF",
+        "ON ",
+};
+static OSD_TAB_t entryVtxPit = {&cmsx_vtxPit, 2, cmsxCmsPitNames};
 
 static void cmsx_Vtx_ConfigRead(void)
 {
     vtxCommonGetBandAndChannel(vtxCommonDevice(), &cmsx_vtxBand, &cmsx_vtxChannel);
     vtxCommonGetPowerIndex(vtxCommonDevice(), &cmsx_vtxPower);
+    unsigned status;
+    if(vtxCommonGetStatus(vtxCommonDevice(), &status)){
+        cmsx_vtxPit = status & VTX_STATUS_PIT_MODE ? 2 : 1;
+    } else {
+        cmsx_vtxPit = 0;
+    }
 }
 
 static void cmsx_Vtx_ConfigWriteback(void)
@@ -88,6 +101,7 @@ static long cmsx_Vtx_onExit(const OSD_Entry *self)
 {
     UNUSED(self);
 
+    vtxCommonSetPitMode(vtxCommonDevice(), cmsx_vtxPit);
     cmsx_Vtx_ConfigWriteback();
 
     return 0;
@@ -123,11 +137,22 @@ static long cmsx_Vtx_onPowerChange(displayPort_t *pDisp, const void *self)
     return 0;
 }
 
+static long cmsx_Vtx_onPitChange(displayPort_t *pDisp, const void *self)
+{
+    UNUSED(pDisp);
+    UNUSED(self);
+    if (cmsx_vtxPit == 0) {
+        cmsx_vtxPit = 1;
+    }
+    return 0;
+}
+
 static const OSD_Entry cmsx_menuVtxEntries[] = {
     {"--- VTX ---", OME_Label, NULL, NULL, 0},
     {"BAND", OME_TAB, cmsx_Vtx_onBandChange, &entryVtxBand, 0},
     {"CHANNEL", OME_TAB, cmsx_Vtx_onChanChange, &entryVtxChannel, 0},
     {"POWER", OME_TAB, cmsx_Vtx_onPowerChange, &entryVtxPower, 0},
+    {"PIT", OME_TAB, cmsx_Vtx_onPitChange, &entryVtxPit, 0},
     {"BACK", OME_Back, NULL, NULL, 0},
     {NULL, OME_END, NULL, NULL, 0}
 };

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -62,10 +62,9 @@ typedef enum {
 #define VTX_COMMON_BAND_FS        4
 #define VTX_COMMON_BAND_RACE      5
 
-// RTC6705 RF Power index "---", 25 or 200 mW
-#define VTX_6705_POWER_OFF     1
-#define VTX_6705_POWER_25      2
-#define VTX_6705_POWER_200     3
+// RTC6705 RF Power index 25 or 200 mW
+#define VTX_6705_POWER_25      1
+#define VTX_6705_POWER_200     2
 
 // SmartAudio "---", 25, 200, 500, 800 mW
 #define VTX_SA_POWER_OFF          1 //1 goes to min power whereas 0 doesnt do anything (illegal index).

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -187,6 +187,7 @@ void rtc6705SetFrequency(uint16_t frequency)
 
 void rtc6705SetRFPower(uint8_t rf_power)
 {
+    rf_power = constrain(rf_power, 1, 2);
 #if defined(USE_VTX_RTC6705_SOFTSPI)
     if (!busdev) {
         rtc6705SoftSpiSetRFPower(rf_power);
@@ -194,8 +195,6 @@ void rtc6705SetRFPower(uint8_t rf_power)
         return;
     }
 #endif
-
-    rf_power = constrain(rf_power, VTX_RTC6705_MIN_POWER_VALUE, VTX_RTC6705_POWER_COUNT - 1);
 
     uint32_t val_hex = RTC6705_RW_CONTROL_BIT; // write
     val_hex |= RTC6705_ADDRESS; // address

--- a/src/main/drivers/vtx_rtc6705.h
+++ b/src/main/drivers/vtx_rtc6705.h
@@ -31,14 +31,7 @@
 
 #include "pg/vtx_io.h"
 
-#define VTX_RTC6705_POWER_COUNT           3
-#define VTX_RTC6705_DEFAULT_POWER_INDEX   2
-
-#if defined(RTC6705_POWER_PIN)
-#define VTX_RTC6705_MIN_POWER_VALUE   0
-#else
-#define VTX_RTC6705_MIN_POWER_VALUE   1
-#endif
+#define VTX_RTC6705_POWER_COUNT           2
 
 #define VTX_RTC6705_FREQ_MIN    5600
 #define VTX_RTC6705_FREQ_MAX    5950

--- a/src/main/drivers/vtx_table.h
+++ b/src/main/drivers/vtx_table.h
@@ -49,11 +49,7 @@
 #define VTX_TABLE_DEFAULT_CHANNEL       1
 #define VTX_TABLE_DEFAULT_FREQ          5740
 #define VTX_TABLE_DEFAULT_PITMODE_FREQ  0
-#ifdef USE_VTX_RTC6705
-#define VTX_TABLE_DEFAULT_POWER         VTX_RTC6705_DEFAULT_POWER_INDEX
-#else
-#define VTX_TABLE_DEFAULT_POWER         1 //lowest actual power mode
-#endif
+#define VTX_TABLE_DEFAULT_POWER         1 //1-based indexing. 0 means unknown and 1 is the lowest actual power mode
 
 struct vtxTableConfig_s;
 void vtxTableInit(void);

--- a/src/main/io/spektrum_vtx_control.c
+++ b/src/main/io/spektrum_vtx_control.c
@@ -69,12 +69,12 @@ const uint8_t vtxTrampPi[SPEKTRUM_VTX_POWER_COUNT] = {
     VTX_TRAMP_POWER_200                // Manual               -           -        -     -
 };
 #endif // USE_VTX_TRAMP
-
+//todo: enable pit mode where appropriate, for all protcols
 #ifdef USE_VTX_RTC6705
 // RTC6705 "---", 25 or 200 mW
 const uint8_t vtxRTC6705Pi[SPEKTRUM_VTX_POWER_COUNT] = {
-    VTX_6705_POWER_OFF,                // Off
-    VTX_6705_POWER_OFF,                //   1 -  14mW
+    VTX_6705_POWER_25,                // Off
+    VTX_6705_POWER_25,                //   1 -  14mW
     VTX_6705_POWER_25,                 //  15 -  25mW
     VTX_6705_POWER_25,                 //  26 -  99mW
     VTX_6705_POWER_200,                // 100 - 299mW

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -180,7 +180,7 @@ void vtxCyclePower(const uint8_t powerStep)
 
         int newPower = power + powerStep;
         if (newPower >= vtxTablePowerLevels) {
-            newPower = 0;
+            newPower = 1;
         } else if (newPower < 0) {
             newPower = vtxTablePowerLevels;
         }

--- a/src/main/io/vtx_rtc6705.c
+++ b/src/main/io/vtx_rtc6705.c
@@ -43,7 +43,7 @@
 
 #if (defined(USE_CMS) || defined(USE_VTX_COMMON)) && !defined(USE_VTX_TABLE)
 const char *rtc6705PowerNames[VTX_RTC6705_POWER_COUNT + 1] = {
-    "---", "OFF", "MIN", "MAX"
+    "---", "MIN", "MAX"
 };
 #endif
 
@@ -56,6 +56,7 @@ static vtxDevice_t vtxRTC6705 = {
 
 static uint16_t rtc6705Frequency;
 static int8_t rtc6705PowerIndex;
+static bool rtc6705PitModeActive;
 
 static void vtxRTC6705SetBandAndChannel(vtxDevice_t *vtxDevice, uint8_t band, uint8_t channel);
 static void vtxRTC6705SetFrequency(vtxDevice_t *vtxDevice, uint16_t frequency);
@@ -147,14 +148,19 @@ static void vtxRTC6705SetPowerByIndex(vtxDevice_t *vtxDevice, uint8_t index)
     if (!vtxCommonLookupPowerValue(vtxDevice, index, &newPowerValue)) {
         return;
     }
-    uint16_t currentPowerValue = 0;
-    vtxCommonLookupPowerValue(vtxDevice, rtc6705PowerIndex, &currentPowerValue);
+    rtc6705PowerIndex = index;
+    rtc6705SetRFPower(newPowerValue);
+}
+
+static void vtxRTC6705SetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
+{
+    UNUSED(vtxDevice);
 #ifdef RTC6705_POWER_PIN
-    if (newPowerValue == 0) {
+    if (onoff) {
         // power device off
-        if (currentPowerValue > 0) {
+        if (!rtc6705PitModeActive) {
             // on, power it off
-            rtc6705PowerIndex = index;
+            rtc6705PitModeActive = onoff;
             rtc6705Disable();
             return;
         } else {
@@ -162,27 +168,18 @@ static void vtxRTC6705SetPowerByIndex(vtxDevice_t *vtxDevice, uint8_t index)
         }
     } else {
         // change rf power and maybe turn the device on first
-        if (currentPowerValue == 0) {
+        if (rtc6705PitModeActive) {
             // if it's powered down, power it up, wait and configure channel, band and power.
-            rtc6705PowerIndex = index;
+            rtc6705PitModeActive = onoff;
             vtxRTC6705EnableAndConfigure(vtxDevice);
             return;
         } else {
-            // if it's powered up, just set the rf power
-            rtc6705PowerIndex = index;
-            rtc6705SetRFPower(newPowerValue);
+            //already on
         }
     }
 #else
-    rtc6705PowerIndex = index;
-    rtc6705SetRFPower(MAX(newPowerValue, VTX_RTC6705_MIN_POWER_VALUE);
-#endif
-}
-
-static void vtxRTC6705SetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
-{
-    UNUSED(vtxDevice);
     UNUSED(onoff);
+#endif
 }
 
 static void vtxRTC6705SetFrequency(vtxDevice_t *vtxDevice, uint16_t frequency)
@@ -222,8 +219,8 @@ static bool vtxRTC6705GetFreq(const vtxDevice_t *vtxDevice, uint16_t *pFrequency
 static bool vtxRTC6705GetStatus(const vtxDevice_t *vtxDevice, unsigned *status)
 {
     UNUSED(vtxDevice);
-    UNUSED(status);
-    return false;
+    *status = rtc6705PitModeActive ? VTX_STATUS_PIT_MODE : 0;
+    return true;
 }
 
 static vtxVTable_t rtc6705VTable = {


### PR DESCRIPTION
Including rtc6705 (as is done in unified targets) caused `VTX_TABLE_DEFAULT_POWER` to be setup wrong. This PR fixes that by introducing pitmode for rtc6705. The previously lowest power mode at index 2 is now moved to index 1, matching SmartAudio and Tramp protocols.
Fixes https://github.com/betaflight/betaflight/issues/8934.
This PR is an **incompatible** alternative to https://github.com/betaflight/betaflight/pull/8936 and **implements the suggestion @etracer65 described as ideal**.

Testers with rtc6705 hardware are welcome to test!