### PR TITLE
Handle a lack of trailing newline in config file.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6547,6 +6547,10 @@ bool cliProcessCustomDefaults(void)
         processCharacter(*customDefaultsPtr++);
     }
 
+    // Process a newline at the very end so that the last command gets executed,
+    // even when the file did not contain a trailing newline
+    processCharacter('\r');
+
     processingCustomDefaults = false;
 #if !defined(DEBUG_CUSTOM_DEFAULTS)
     cliWriter = cliWriterTemp;


### PR DESCRIPTION
The configurator properly checks that the config data fits, so there is no risk of a command being cut off.
