### PR TITLE
Fixed hanging on 'defaults nosave' when RX_SERIAL is enabled.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3335,8 +3335,13 @@ static void cliBeeper(char *cmdline)
 #if defined(USE_RX_SPI) || defined (USE_SERIALRX_SRXL2)
 void cliRxBind(char *cmdline){
     UNUSED(cmdline);
-    if (featureIsEnabled(FEATURE_RX_SERIAL)) {
-        switch (rxConfig()->serialrx_provider) {
+    switch (rxRuntimeConfig.rxProvider) {
+    default:
+        cliPrint("Not supported.");
+
+        break;
+    case RX_PROVIDER_SERIAL:
+        switch (rxRuntimeConfig.serialrxProvider) {
         default:
             cliPrint("Not supported.");
             break;
@@ -3347,9 +3352,10 @@ void cliRxBind(char *cmdline){
             break;
 #endif
         }
-    } 
+
+        break;
 #if defined(USE_RX_SPI)
-    else if (featureIsEnabled(FEATURE_RX_SPI)) {
+    case RX_PROVIDER_SPI:
         switch (rxSpiConfig()->rx_spi_protocol) {
         default:
             cliPrint("Not supported.");
@@ -3379,9 +3385,10 @@ void cliRxBind(char *cmdline){
             break;
 #endif
         }
-    
-    }
+
+        break;
 #endif
+    }
 }
 #endif
 

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -293,10 +293,10 @@ void fcTasksInit(void)
 #ifdef USE_TELEMETRY
     if (featureIsEnabled(FEATURE_TELEMETRY)) {
         setTaskEnabled(TASK_TELEMETRY, true);
-        if (rxConfig()->serialrx_provider == SERIALRX_JETIEXBUS) {
+        if (rxRuntimeConfig.serialrxProvider == SERIALRX_JETIEXBUS) {
             // Reschedule telemetry to 500hz for Jeti Exbus
             rescheduleTask(TASK_TELEMETRY, TASK_PERIOD_HZ(500));
-        } else if (rxConfig()->serialrx_provider == SERIALRX_CRSF) {
+        } else if (rxRuntimeConfig.serialrxProvider == SERIALRX_CRSF) {
             // Reschedule telemetry to 500hz, 2ms for CRSF
             rescheduleTask(TASK_TELEMETRY, TASK_PERIOD_HZ(500));
         }

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -60,12 +60,20 @@ void rxPwmInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
     rxRuntimeConfig->rxRefreshRate = 20000;
 
     // configure PWM/CPPM read function and max number of channels. serial rx below will override both of these, if enabled
-    if (featureIsEnabled(FEATURE_RX_PARALLEL_PWM)) {
+    switch (rxRuntimeConfig->rxProvider) {
+    default:
+
+        break;
+    case RX_PROVIDER_PARALLEL_PWM:
         rxRuntimeConfig->channelCount = MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT;
         rxRuntimeConfig->rcReadRawFn = pwmReadRawRC;
-    } else if (featureIsEnabled(FEATURE_RX_PPM)) {
+
+        break;
+    case RX_PROVIDER_PPM:
         rxRuntimeConfig->channelCount = MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT;
         rxRuntimeConfig->rcReadRawFn = ppmReadRawRC;
+
+        break;
     }
 }
 #endif

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -126,7 +126,18 @@ typedef uint16_t (*rcReadRawDataFnPtr)(const struct rxRuntimeConfig_s *rxRuntime
 typedef uint8_t (*rcFrameStatusFnPtr)(struct rxRuntimeConfig_s *rxRuntimeConfig);
 typedef bool (*rcProcessFrameFnPtr)(const struct rxRuntimeConfig_s *rxRuntimeConfig);
 
+typedef enum {
+    RX_PROVIDER_NONE = 0,
+    RX_PROVIDER_PARALLEL_PWM,
+    RX_PROVIDER_PPM,
+    RX_PROVIDER_SERIAL,
+    RX_PROVIDER_MSP,
+    RX_PROVIDER_SPI,
+} rxProvider_t;
+
 typedef struct rxRuntimeConfig_s {
+    rxProvider_t        rxProvider;
+    SerialRXType        serialrxProvider;
     uint8_t             channelCount; // number of RC channels as reported by current input driver
     uint16_t            rxRefreshRate;
     rcReadRawDataFnPtr  rcReadRawFn;

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -242,7 +242,7 @@ void spektrumBind(rxConfig_t *rxConfig)
         ioTag_t rxPin = serialPinConfig()->ioTagRx[index];
 
         // Take care half-duplex case
-        switch (rxConfig->serialrx_provider) {
+        switch (rxRuntimeConfig.serialrxProvider) {
         case SERIALRX_SRXL:
 #if defined(USE_TELEMETRY_SRXL)
             if (featureIsEnabled(FEATURE_TELEMETRY) && !telemetryCheckRxPortShared(portConfig)) {
@@ -357,7 +357,10 @@ bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
     bool portShared = false;
 #endif
 
-    switch (rxConfig->serialrx_provider) {
+    switch (rxRuntimeConfig->serialrxProvider) {
+    default:
+
+        break;
     case SERIALRX_SRXL:
 #if defined(USE_TELEMETRY_SRXL)
         srxlEnabled = (featureIsEnabled(FEATURE_TELEMETRY) && !portShared);

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -266,7 +266,7 @@ bool xBusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     uint32_t baudRate;
 
-    switch (rxConfig->serialrx_provider) {
+    switch (rxRuntimeConfig->serialrxProvider) {
     case SERIALRX_XBUS_MODE_B:
         rxRuntimeConfig->channelCount = XBUS_CHANNEL_COUNT;
         xBusFrameReceived = false;

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -136,21 +136,21 @@ bool telemetryDetermineEnabledState(portSharing_e portSharing)
 bool telemetryCheckRxPortShared(const serialPortConfig_t *portConfig)
 {
     if (portConfig->functionMask & FUNCTION_RX_SERIAL && portConfig->functionMask & TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK &&
-        (rxConfig()->serialrx_provider == SERIALRX_SPEKTRUM1024 ||
-        rxConfig()->serialrx_provider == SERIALRX_SPEKTRUM2048 ||
-        rxConfig()->serialrx_provider == SERIALRX_SBUS ||
-        rxConfig()->serialrx_provider == SERIALRX_SUMD ||
-        rxConfig()->serialrx_provider == SERIALRX_SUMH ||
-        rxConfig()->serialrx_provider == SERIALRX_XBUS_MODE_B ||
-        rxConfig()->serialrx_provider == SERIALRX_XBUS_MODE_B_RJ01 ||
-        rxConfig()->serialrx_provider == SERIALRX_IBUS)) {
+        (rxRuntimeConfig.serialrxProvider == SERIALRX_SPEKTRUM1024 ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_SPEKTRUM2048 ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_SBUS ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_SUMD ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_SUMH ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_XBUS_MODE_B ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_XBUS_MODE_B_RJ01 ||
+        rxRuntimeConfig.serialrxProvider == SERIALRX_IBUS)) {
 
         return true;
     }
 #ifdef USE_TELEMETRY_IBUS
     if (   portConfig->functionMask & FUNCTION_TELEMETRY_IBUS
         && portConfig->functionMask & FUNCTION_RX_SERIAL
-        && rxConfig()->serialrx_provider == SERIALRX_IBUS) {
+        && rxRuntimeConfig.serialrxProvider == SERIALRX_IBUS) {
         // IBUS serial RX & telemetry
         return true;
     }


### PR DESCRIPTION
Fixes #8919.

The issue that this fixes is that the RX stack is initialised only on startup, based on the configuration at the time. But the RX stack and some other systems (telemetry) use bits of configuration (`RX_...` features, `serialrx_provider`) at runtime as well. When this configuration is changed at runtime, the resulting discrepancy can cause issues, including the lockup observed in #8919.

This fixes it by copying these bits of configuration into `rxRuntimeConfig` when the RX stack is initialised, and then using it from there.