### PR TITLE
Fix "BIT_GYRO" definition error.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -78,9 +78,9 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro);
 #define BIT_RAW_RDY_EN              0x01
 #define BIT_I2C_IF_DIS              0x10
 #define BIT_INT_STATUS_DATA         0x01
-#define BIT_GYRO                    3
-#define BIT_ACC                     2
-#define BIT_TEMP                    1
+#define BIT_GYRO                    0x04
+#define BIT_ACC                     0x02
+#define BIT_TEMP                    0x01
 
 // Product ID Description for MPU6000
 // high 4 bits low 4 bits
@@ -195,7 +195,7 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiBusWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
     delayMicroseconds(15);
 
-    // Gyro +/- 1000 DPS Full Scale
+    // Gyro +/- 2000 DPS Full Scale
     spiBusWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 


### PR DESCRIPTION
"Register 104" bits 2 to 0 are used to reset the analog and digital signal paths of the gyroscope, accelerometer, and temperature sensors. so that 'BIT_GYRO' should be 0x04 instead of 3.

reference: https://www.invensense.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf @4.27 Register 104 – Signal Path Reset SIGNAL_PATH_RESET