### PR TITLE
H7 - Fix bi-directional DSHOT

### DIFF
--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -116,6 +116,7 @@ typedef struct motorDmaOutput_s {
 #ifdef STM32H7
     TIM_HandleTypeDef TimHandle;
     DMA_HandleTypeDef hdma_tim;
+    IO_t io;
 #endif
     uint8_t output;
     uint8_t index;


### PR DESCRIPTION
Fix for DSHOT signal artifacts on H7 when switching between output and input mode.

For artifact scope trace see https://github.com/betaflight/betaflight/issues/8836#issuecomment-534027871

Confirmed fixed by at least one user - https://github.com/betaflight/betaflight/issues/8836#issuecomment-535538177

Fixes #8836 
