### PR TITLE
Add deprecated checking for CAMERA_CONTROL_PIN

### DIFF
--- a/src/main/target/AIRBOTF7/target.c
+++ b/src/main/target/AIRBOTF7/target.c
@@ -30,7 +30,7 @@
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,           0, 0), // ONBOARD LED
 
-    DEF_TIM(TIM1, CH1, PA8, TIM_USE_ANY,            0, 0), // CAM CONTROL
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_CAMERA_CONTROL,0, 0), // CAM CONTROL
 
     // MOTORS
 

--- a/src/main/target/AIRBOTF7/target.h
+++ b/src/main/target/AIRBOTF7/target.h
@@ -120,10 +120,6 @@
 #define SERIALRX_PROVIDER       SERIALRX_SBUS
 #define SERIALRX_UART           SERIAL_PORT_USART6
 
-// *************** CAM *****************************
-
-#define CAMERA_CONTROL_PIN      PA8
-
 // *************** I2C *****************************
 
 #define USE_I2C

--- a/src/main/target/CLRACINGF4/target.h
+++ b/src/main/target/CLRACINGF4/target.h
@@ -36,8 +36,6 @@
 
 #define INVERTER_PIN_UART1        PC0 // PC0 used as inverter select GPIO
 
-#define CAMERA_CONTROL_PIN        PB9    // define dedicated camera_osd_control pin
-
 
 #define USE_EXTI
 #define USE_GYRO_EXTI

--- a/src/main/target/HAKRCF405/target.h
+++ b/src/main/target/HAKRCF405/target.h
@@ -39,7 +39,9 @@
 #define BARO_I2C_INSTANCE       (I2CDEV_1)
 #define DEFAULT_BARO_QMP6988
 
-#define CAMERA_CONTROL_PIN PA5
+// XXX CAMERA_CONTROL_PIN is deprecated.
+// XXX Target maintainer must create a valid timerHardware[] array entry for PA5 with TIM_USE_CAMERA_CONTROL
+//#define CAMERA_CONTROL_PIN PA5
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1

--- a/src/main/target/HAKRCF411/target.h
+++ b/src/main/target/HAKRCF411/target.h
@@ -40,7 +40,9 @@
 #define BARO_I2C_INSTANCE       (I2CDEV_1)
 #define DEFAULT_BARO_QMP6988
 
-#define CAMERA_CONTROL_PIN 	PB5
+// XXX CAMERA_CONTROL_PIN is deprecated.
+// XXX Target maintainer must create a valid timerHardware[] array entry for PB5 with TIM_USE_CAMERA_CONTROL
+//#define CAMERA_CONTROL_PIN 	PB5
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -44,8 +44,6 @@
 #define USE_BEEPER
 
 #if defined(FLYWOOF405)
-//define camera control
-#define CAMERA_CONTROL_PIN      PA9
 #define BEEPER_PIN              PC13
 #else
 #define BEEPER_PIN              PC9

--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -28,7 +28,9 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,   0, 1), // PPM, DMA2_ST6
+    // XXX TIM_USE_CAMERA_CONTROL is added to handle deprecated CAMERA_CONTROL_PIN def in target.h
+    // XXX Target maintainer must confirm intended operation after this change.
+    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM|TIM_USE_CAMERA_CONTROL,   0, 1), // PPM, DMA2_ST6
 
     DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // M1 , DMA1_ST7
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // M2 , DMA1_ST2

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -39,8 +39,11 @@
 #define BEEPER_PIN              PD15
 #define BEEPER_INVERTED
 
+// XXX CAMERA_CONTROL_PIN is deprecated, so it was moved to PE13 entry in timerHardware[] array,
+// XXX where it is shared with PPM.
+// XXX Target maintainer must confirm intended operation under this change.
 //define camera control
-#define CAMERA_CONTROL_PIN      PE13
+//#define CAMERA_CONTROL_PIN      PE13
 
 #define USE_ACC
 #define USE_GYRO

--- a/src/main/target/TRANSTECF7/target.h
+++ b/src/main/target/TRANSTECF7/target.h
@@ -34,7 +34,9 @@
 #define PINIO1_PIN                      PB12        //VTX Power Switch
 #define USE_PINIOBOX
 
-#define CAMERA_CONTROL_PIN              PB8         //Camera OSD
+// XXX CAMERA_CONTROL_PIN is deprecated.
+// XXX Target maintainer must create a valid timerHardware[] array entry for PB8 with TIM_USE_CAMERA_CONTROL
+//#define CAMERA_CONTROL_PIN              PB8         //Camera OSD
 
 #define USE_BEEPER
 

--- a/src/main/target/WORMFC/target.h
+++ b/src/main/target/WORMFC/target.h
@@ -45,8 +45,9 @@
 
 //define camera control
 #if defined(PIRXF4)
-#define USE_CAMERA_CONTROL
-#define CAMERA_CONTROL_PIN PA4
+// XXX CAMERA_CONTROL_PIN is deprecated.
+// XXX Target maintainer must create a valid timerHardware[] array entry for PA4 with TIM_USE_CAMERA_CONTROL
+//#define CAMERA_CONTROL_PIN PA4
 #endif
 
 //BEEPER

--- a/src/main/target/XILOF4/target.c
+++ b/src/main/target/XILOF4/target.c
@@ -30,7 +30,7 @@
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,           0, 0), // ONBOARD LED
 
-    DEF_TIM(TIM1, CH1, PA8, TIM_USE_ANY,            0, 0), // CAM CONTROL
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_CAMERA_CONTROL,0, 0), // CAM CONTROL
 
     // MOTORS
 

--- a/src/main/target/XILOF4/target.h
+++ b/src/main/target/XILOF4/target.h
@@ -112,10 +112,6 @@
 #define SERIALRX_PROVIDER       SERIALRX_SBUS
 #define SERIALRX_UART           SERIAL_PORT_USART1
 
-// *************** CAM *****************************
-
-#define CAMERA_CONTROL_PIN      PA8
-
 // *************** PIN *****************************
 
 #define PINIO1_PIN             PB1

--- a/src/main/target/common_deprecated_post.h
+++ b/src/main/target/common_deprecated_post.h
@@ -147,3 +147,7 @@
 #if DMARXCAT(ENABLE_DSHOT_DMAR) == 1 || DMARXCAT(ENABLE_DSHOT_DMAR) == 1
 #error "Use DSHOT_DMAR_ON or DSHOT_DMAR_OFF instead of boolean values for ENABLE_DSHOT_DMAR"
 #endif
+
+#ifdef CAMERA_CONTROL_PIN
+#error "The CAMERA_CONTROL_PIN define in target.h is deprecated. Use timerHardware[] array entry with TIM_USE_CAMERA_CONTROL"
+#endif


### PR DESCRIPTION
Add deprecated CAMERA_CONTROL_PIN checking.

Also handles targets that currently define CAMERA_CONTROL_PIN:

- Targets with a valid timer entry for the pin: Def is just deleted.

- Targets without a valid timer entry for the pin: Def is commented out and additional comment is added. The camera control function must have not being working for a long timer for the target anyway.
