### PR TITLE
Implement lipo continuation

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -149,6 +149,7 @@ COMMON_SRC = \
             drivers/serial_escserial.c \
             drivers/vtx_common.c \
             drivers/vtx_table.c \
+            io/battery_continue.c \
             io/dashboard.c \
             io/displayport_max7456.c \
             io/displayport_msp.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -846,6 +846,11 @@ const clivalue_t valueTable[] = {
     { "ibatv_offset",               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, offset) },
 #endif
 
+#ifdef USE_BATTERY_CONTINUE
+    { "battery_continue",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, isBatteryContinueEnabled) },
+    { "battery_continue_period",       VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, batteryContinuePeriod) },
+#endif
+
 #ifdef USE_BEEPER
 // PG_BEEPER_DEV_CONFIG
     { "beeper_inversion",           VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, isInverted) },
@@ -1321,6 +1326,10 @@ const clivalue_t valueTable[] = {
 #endif
 
     { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RC_CHANNELS]) },
+
+#ifdef USE_BATTERY_CONTINUE
+    { "osd_battery_continue_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_BATTERY_CONTINUE]) },
+#endif
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -146,6 +146,9 @@ const OSD_Entry menuOsdActiveElemsEntries[] =
     {"STICK OVERLAY LEFT", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_STICK_OVERLAY_LEFT], DYNAMIC},
     {"STICK OVERLAY RIGHT",OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_STICK_OVERLAY_RIGHT], DYNAMIC},
 #endif
+#ifdef USE_BATTERY_CONTINUE
+    {"BATTERY CONTINUE",   OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_BATTERY_CONTINUE], DYNAMIC},
+#endif
     {"DISPLAY NAME",       OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_DISPLAY_NAME], 0},
     {"BACK",               OME_Back,    NULL, NULL, 0},
     {NULL,                 OME_END,     NULL, NULL, 0}

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -70,6 +70,9 @@
 #include "flight/rpm_filter.h"
 #include "flight/servos.h"
 
+#ifdef USE_BATTERY_CONTINUE
+#include "io/battery_continue.h"
+#endif
 #include "io/beeper.h"
 #include "io/gps.h"
 #include "io/motors.h"
@@ -367,6 +370,10 @@ void updateArmingStatus(void)
     }
 }
 
+#ifdef USE_BATTERY_CONTINUE
+extern bool saveMAhDrawn;
+#endif
+
 void disarm(void)
 {
     if (ARMING_FLAG(ARMED)) {
@@ -400,6 +407,11 @@ void disarm(void)
         if (!(getArmingDisableFlags() & (ARMING_DISABLED_RUNAWAY_TAKEOFF | ARMING_DISABLED_CRASH_DETECTED))) {
             beeper(BEEPER_DISARMING);      // emit disarm tone
         }
+#ifdef USE_BATTERY_CONTINUE
+        if (batteryConfig()->isBatteryContinueEnabled == 1 && batContinueReadMAh() != getMAhDrawn()) {
+            saveMAhDrawn = true;
+        }
+#endif
     }
 }
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -873,6 +873,26 @@ void init(void)
     blackboxInit();
 #endif
 
+#ifdef USE_BATTERY_CONTINUE
+    if (batteryConfig()->isBatteryContinueEnabled == 1) {
+#ifdef USE_BLACKBOX
+        // If blackbox isn't configured to use the sdcard, try to initialize it for battery continuation
+        if (blackboxConfig()->device != BLACKBOX_DEVICE_SDCARD
+            && sdcardConfig()->mode) {
+            if (!(initFlags & SD_INIT_ATTEMPTED)) {
+                initFlags |= SD_INIT_ATTEMPTED;
+                sdCardAndFSInit();
+            }
+        }
+#else
+        if (!(initFlags & SD_INIT_ATTEMPTED)) {
+            initFlags |= SD_INIT_ATTEMPTED;
+            sdCardAndFSInit();
+        }
+#endif
+    }
+#endif
+
 #ifdef USE_ACC
     if (mixerConfig()->mixerMode == MIXER_GIMBAL) {
         accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);

--- a/src/main/io/battery_continue.c
+++ b/src/main/io/battery_continue.c
@@ -1,0 +1,171 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform.h"
+
+#include "common/maths.h"
+#include "common/printf.h"
+
+#include "io/asyncfatfs/asyncfatfs.h"
+
+#include "osd/osd.h"
+
+enum {
+    FILE_STATE_NONE = 0,
+    FILE_STATE_WRITING,
+    FILE_STATE_READING,
+    FILE_STATE_FAILED,
+    FILE_STATE_COMPLETE,
+};
+
+uint8_t fileState = FILE_STATE_NONE;
+
+union {
+    int32_t i;
+    unsigned char b[4];
+} mahDrawn;
+
+bool isBatteryContinueActive = false;
+
+static void fileCloseContinue(void)
+{
+    if (fileState != FILE_STATE_FAILED) {
+        fileState = FILE_STATE_COMPLETE;
+    }
+}
+
+static void fileWriteContinue(afatfsFilePtr_t file)
+{
+    if (!file) {
+        fileState = FILE_STATE_FAILED;
+        return;
+    }
+
+    uint32_t bytesToWrite = 4;
+
+    uint32_t totalBytesWritten = 0;
+    uint32_t bytesWritten = 0;
+    bool success;
+
+    do {
+        bytesWritten = afatfs_fwrite(file, &mahDrawn.b[totalBytesWritten], bytesToWrite - totalBytesWritten);
+        totalBytesWritten += bytesWritten;
+        success = (totalBytesWritten == bytesToWrite);
+
+        afatfs_poll();
+    } while (!success && afatfs_getLastError() == AFATFS_ERROR_NONE);
+
+    if (!success) {
+        fileState = FILE_STATE_FAILED;
+    }
+
+    while (!afatfs_fclose(file, fileCloseContinue)) {
+        afatfs_poll();
+    }
+}
+
+static void fileReadContinue(afatfsFilePtr_t file)
+{
+    if (!file) {
+        fileState = FILE_STATE_FAILED;
+        return;
+    }
+
+    uint32_t bytesToRead = 4;
+
+    uint32_t totalBytesRead = 0;
+    uint32_t bytesRead = 0;
+    bool success;
+
+    if (!afatfs_feof(file)) {
+
+        do {
+            bytesRead = afatfs_fread(file, &mahDrawn.b[totalBytesRead], bytesToRead - totalBytesRead);
+            totalBytesRead += bytesRead;
+            success = (totalBytesRead == bytesToRead);
+
+            afatfs_poll();
+        } while (!success && afatfs_getLastError() == AFATFS_ERROR_NONE);
+    }
+
+    if (!success) {
+        fileState = FILE_STATE_FAILED;
+    }
+
+    while (!afatfs_fclose(file, fileCloseContinue)) {
+        afatfs_poll();
+    }
+
+    return;
+}
+
+bool batContinueWriteMAh(int32_t mah)
+{
+    fileState = FILE_STATE_WRITING;
+
+    mahDrawn.i = mah;
+
+    // Go to the root directory
+    if (!afatfs_chdir(NULL)) {
+        return false;
+    }
+
+    bool result = afatfs_fopen("DRAWN.MAH", "w+", fileWriteContinue);
+    if (!result) {
+        return false;
+    }
+
+    while (fileState == FILE_STATE_WRITING) {
+        afatfs_poll();
+    }
+
+    while (!afatfs_flush()) {
+        afatfs_poll();
+    };
+
+    return (fileState == FILE_STATE_COMPLETE);
+}
+
+int32_t batContinueReadMAh()
+{
+    if (mahDrawn.i > 0) {
+        return mahDrawn.i;
+    }
+
+    if (fileState == FILE_STATE_FAILED) {
+        return 0;
+    }
+
+    fileState = FILE_STATE_READING;
+
+    bool result = afatfs_fopen("DRAWN.MAH", "r", fileReadContinue);
+    if (!result) {
+        return 0;
+    }
+
+    while (fileState == FILE_STATE_READING) {
+        afatfs_poll();
+    }
+
+    return mahDrawn.i;
+}

--- a/src/main/io/battery_continue.h
+++ b/src/main/io/battery_continue.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+bool batContinueWriteMAh(uint32_t mahDrawn);
+int32_t batContinueReadMAh();

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -135,6 +135,7 @@ typedef enum {
     OSD_PROFILE_NAME,
     OSD_RSSI_DBM_VALUE,
     OSD_RC_CHANNELS,
+    OSD_BATTERY_CONTINUE,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -65,6 +65,9 @@ typedef struct batteryConfig_s {
     uint8_t ibatLpfPeriod;                  // Period of the cutoff frequency for the Ibat filter (in 0.1 s)
     uint8_t vbatDurationForWarning;      // Period voltage has to sustain before the battery state is set to BATTERY_WARNING (in 0.1 s)
     uint8_t vbatDurationForCritical;         // Period voltage has to sustain before the battery state is set to BATTERY_CRIT (in 0.1 s)
+
+    uint8_t isBatteryContinueEnabled;           // Save and offer lipo mah continuation
+    uint8_t batteryContinuePeriod;              // Period to offer the lipo continuation question
 } batteryConfig_t;
 
 PG_DECLARE(batteryConfig_t, batteryConfig);
@@ -110,6 +113,9 @@ bool isAmperageConfigured(void);
 int32_t getAmperage(void);
 int32_t getAmperageLatest(void);
 int32_t getMAhDrawn(void);
+#ifdef USE_BATTERY_CONTINUE
+void setMAhDrawn(uint32_t mAhDrawn);
+#endif
 
 void batteryUpdateCurrentMeter(timeUs_t currentTimeUs);
 

--- a/src/main/sensors/current.h
+++ b/src/main/sensors/current.h
@@ -38,6 +38,7 @@ typedef struct currentMeter_s {
     int32_t amperage;           // current read by current sensor in centiampere (1/100th A)
     int32_t amperageLatest;     // current read by current sensor in centiampere (1/100th A) (unfiltered)
     int32_t mAhDrawn;           // milliampere hours drawn from the battery since start
+    int32_t mAhDrawnOffset;     // mAh offset
 } currentMeter_t;
 
 // WARNING - do not mix usage of CURRENT_SENSOR_* and CURRENT_METER_*, they are separate concerns.

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -374,3 +374,7 @@ extern uint8_t __config_end;
 #if defined(USE_CUSTOM_DEFAULTS)
 #define USE_CUSTOM_DEFAULTS_ADDRESS
 #endif
+
+#if defined(USE_BATTERY_CONTINUE) && !defined(USE_SDCARD)
+#undef USE_BATTERY_CONTINUE
+#endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -353,4 +353,5 @@
 #define USE_PROFILE_NAMES
 #define USE_SERIALRX_SRXL2     // Spektrum SRXL2 protocol
 #define USE_INTERPOLATED_SP
+#define USE_BATTERY_CONTINUE
 #endif


### PR DESCRIPTION
Add a OSD element and input handling to accept/reject the saved mah drawn from the previous battery if the battery isn't full and battery_continue is ON.

When battery_continue = ON the mah drawn is saved to the sd-card on disarm (after blackbox is done if it's running).
The user sees the "restore mah?" question before the first arm if there's a saved amount and the lipo is detected as not full. The user can answer (if the OSD element is setup, won't work otherwise) with THR_HI + YAW_LO + PIT_HI and ROL_LO or ROL_HI.
The question is visible for 15 seconds by default, this is configurable with battery_continue_period.

It looks like this:
![vlcsnap-2019-10-21-20h13m54s803](https://user-images.githubusercontent.com/509294/67233796-34a9af80-f444-11e9-82bc-2641a875567d.png)

Compared to the previous version this

- Doesn't abuse the warnings OSD element (it has its own)
- The stick commands don't overlap with any existing commands
- Is based on the sd-card and doesn't save more than it needs to