### PR TITLE
Fix W25M (stacked die SPI flash) support

### DIFF
--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -43,12 +43,14 @@
 
 #include "flash_m25p16.h"
 #include "flash_w25m.h"
+#include "flash_w25n01g.h"
 
 #include "pg/flash.h"
 
 #define W25M_INSTRUCTION_SOFTWARE_DIE_SELECT         0xC2
 
 #define JEDEC_ID_WINBOND_W25M512                     0xEF7119 // W25Q256 x 2
+#define JEDEC_ID_WINBOND_W25M02G                     0xEFAB21 // W25N01G x 2
 
 static const flashVTable_t w25m_vTable;
 
@@ -108,6 +110,7 @@ bool w25m_detect(flashDevice_t *fdevice, uint32_t chipID)
 {
 
     switch (chipID) {
+#ifdef USE_FLASH_W25M512
     case JEDEC_ID_WINBOND_W25M512:
         // W25Q256 x 2
         dieCount = 2;
@@ -121,6 +124,23 @@ bool w25m_detect(flashDevice_t *fdevice, uint32_t chipID)
 
         fdevice->geometry.flashType = FLASH_TYPE_NOR;
         break;
+#endif
+
+#ifdef USE_FLASH_W25M02G
+    case JEDEC_ID_WINBOND_W25M02G:
+        // W25N01G x 2
+        dieCount = 2;
+
+        for (int die = 0 ; die < dieCount ; die++) {
+            w25m_dieSelect(fdevice->io.handle.busdev, die);
+            dieDevice[die].io.handle.busdev = fdevice->io.handle.busdev;
+            dieDevice[die].io.mode = fdevice->io.mode;
+            w25n01g_detect(&dieDevice[die], JEDEC_ID_WINBOND_W25N01GV);
+        }
+
+        fdevice->geometry.flashType = FLASH_TYPE_NAND;
+        break;
+#endif
 
     default:
         // Not a valid W25M series device
@@ -131,7 +151,7 @@ bool w25m_detect(flashDevice_t *fdevice, uint32_t chipID)
         return false;
     }
 
-    fdevice->geometry.sectors = dieDevice[0].geometry.sectors;
+    fdevice->geometry.sectors = dieDevice[0].geometry.sectors * dieCount;
     fdevice->geometry.sectorSize = dieDevice[0].geometry.sectorSize;
     fdevice->geometry.pagesPerSector = dieDevice[0].geometry.pagesPerSector;
     fdevice->geometry.pageSize = dieDevice[0].geometry.pageSize;

--- a/src/main/drivers/flash_w25n01g.c
+++ b/src/main/drivers/flash_w25n01g.c
@@ -50,9 +50,6 @@ serialPort_t *debugSerialPort = NULL;
 #define DPRINTF(x)
 #endif
 
-// JEDEC ID
-#define JEDEC_ID_WINBOND_W25N01GV    0xEFAA21
-
 // Device size parameters
 #define W25N01G_PAGE_SIZE         2048
 #define W25N01G_PAGES_PER_BLOCK   64

--- a/src/main/drivers/flash_w25n01g.h
+++ b/src/main/drivers/flash_w25n01g.h
@@ -22,4 +22,7 @@
 
 #pragma once
 
+// JEDEC ID
+#define JEDEC_ID_WINBOND_W25N01GV    0xEFAA21
+
 bool w25n01g_detect(flashDevice_t *fdevice, uint32_t chipID);

--- a/src/main/target/NUCLEOF7/target.h
+++ b/src/main/target/NUCLEOF7/target.h
@@ -133,6 +133,16 @@
 #define SDCARD_SPI_CS_PIN                   SPI4_NSS_PIN
 #define SPI4_TX_DMA_OPT                     0     // DMA 2 Stream 1 Channel 4
 
+#define USE_FLASHFS
+#define USE_FLASH_CHIP
+#define USE_FLASH_M25P16
+#define USE_FLASH_W25N01G          // 1Gb NAND flash support
+#define USE_FLASH_W25M             // Stacked die support
+#define USE_FLASH_W25M512          // 512Kb (256Kb x 2 stacked) NOR flash support
+#define USE_FLASH_W25M02G          // 2Gb (1Gb x 2 stacked) NAND flash support
+#define FLASH_SPI_INSTANCE      SPI4
+#define FLASH_CS_PIN            PE10
+
 #define USE_I2C
 #define USE_I2C_DEVICE_1
 #define I2C_DEVICE                  (I2CDEV_1)

--- a/src/main/target/NUCLEOF7/target.mk
+++ b/src/main/target/NUCLEOF7/target.mk
@@ -1,5 +1,5 @@
 F7X6XG_TARGETS += $(TARGET)
-FEATURES       += SDCARD_SPI VCP
+FEATURES       += SDCARD_SPI ONBOARDFLASH VCP
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_fake.c \

--- a/src/main/target/common_unified.h
+++ b/src/main/target/common_unified.h
@@ -72,8 +72,10 @@
 
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-#define USE_FLASH_W25M
-#define USE_FLASH_W25N01G          // 1G NAND flash support
+#define USE_FLASH_W25N01G          // 1Gb NAND flash support
+#define USE_FLASH_W25M             // Stacked die support
+#define USE_FLASH_W25M512          // 512Kb (256Kb x 2 stacked) NOR flash support
+#define USE_FLASH_W25M02G          // 2Gb (1Gb x 2 stacked) NAND flash support
 
 #define USE_MAX7456
 


### PR DESCRIPTION
Stimulated by #9007 ...

The W25M (Winbond stacked die SPI flash) support is broken; total sector was only set to that of a single die. It was okay when I first submitted #5722, as no other code looked at the sector count. Then the bug appeared as the partitioning code was introduced in #8297 .

The PR fixes the incorrect total sector calculation for stacked die flash chips, and fixes some feature conditionals so that W25M chip support could be enabled.

Note that W25M02G is detected, but it is not in a full working state, as described in #9016 (It will work as 1G-bit part).