### PR TITLE
Add missing ARMING_DISABLED_DSHOT_BITBANG name string

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -56,6 +56,7 @@ const char *armingDisableFlagNames[]= {
     "RESCUE_SW",
     "RPMFILTER",
     "REBOOT_REQD",
+    "DSHOT_BBANG",
     "ARMSWITCH",
 };
 


### PR DESCRIPTION
Would caouse display problems in the OSD with `ARMING_DISABLED_DSHOT_BITBANG` showing up as `ARMSWITCH` and any real cases of `ARMING_DISABLED_ARM_SWITCH` display garbage or possibly cause a wedge.
