### PR TITLE
Add MSP allowArmingWithoutFix

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1297,6 +1297,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         // Added in API version 1.43
         sbufWriteU16(dst, gpsRescueConfig()->ascendRate);
         sbufWriteU16(dst, gpsRescueConfig()->descendRate);
+        sbufWriteU8(dst,  gpsRescueConfig()->allowArmingWithoutFix);
         break;
 
     case MSP_GPS_RESCUE_PIDS:
@@ -2196,6 +2197,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
             // Added in API version 1.43
             gpsRescueConfigMutable()->ascendRate = sbufReadU16(src);
             gpsRescueConfigMutable()->descendRate = sbufReadU16(src);
+        if (sbufBytesRemaining(src) >= 1) {
+            // Added in API version 1.43
+            gpsRescueConfigMutable()->allowArmingWithoutFix = sbufReadU8(src);
         }
         break;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1297,7 +1297,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         // Added in API version 1.43
         sbufWriteU16(dst, gpsRescueConfig()->ascendRate);
         sbufWriteU16(dst, gpsRescueConfig()->descendRate);
-        sbufWriteU8(dst,  gpsRescueConfig()->allowArmingWithoutFix);
+        sbufWriteU8(dst, gpsRescueConfig()->allowArmingWithoutFix);
         break;
 
     case MSP_GPS_RESCUE_PIDS:
@@ -2193,12 +2193,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
         gpsRescueConfigMutable()->throttleHover = sbufReadU16(src);
         gpsRescueConfigMutable()->sanityChecks = sbufReadU8(src);
         gpsRescueConfigMutable()->minSats = sbufReadU8(src);
-        if (sbufBytesRemaining(src) >= 4) {
+        if (sbufBytesRemaining(src) >= 5) {
             // Added in API version 1.43
             gpsRescueConfigMutable()->ascendRate = sbufReadU16(src);
             gpsRescueConfigMutable()->descendRate = sbufReadU16(src);
-        if (sbufBytesRemaining(src) >= 1) {
-            // Added in API version 1.43
             gpsRescueConfigMutable()->allowArmingWithoutFix = sbufReadU8(src);
         }
         break;


### PR DESCRIPTION
Added possibility to change gps_rescue_allow_arming_without_fix through MSP / lua scripts

Required for https://github.com/betaflight/betaflight-tx-lua-scripts/pull/256 to work