### PR TITLE
Support per MSP client arming disable

### DIFF
--- a/src/main/msp/msp.h
+++ b/src/main/msp/msp.h
@@ -54,12 +54,16 @@ typedef struct mspPacket_s {
     uint8_t direction;
 } mspPacket_t;
 
+typedef int mspDescriptor_t;
+
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.
-typedef mspResult_e (*mspProcessCommandFnPtr)(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
+typedef mspResult_e (*mspProcessCommandFnPtr)(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
 typedef void (*mspProcessReplyFnPtr)(mspPacket_t *cmd);
 
 
 void mspInit(void);
-mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
+mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
 void mspFcProcessReply(mspPacket_t *reply);
+
+mspDescriptor_t mspDescriptorAlloc(void);

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -48,6 +48,7 @@ static void resetMspPort(mspPort_t *mspPortToReset, serialPort_t *serialPort, bo
 
     mspPortToReset->port = serialPort;
     mspPortToReset->sharedWithTelemetry = sharedWithTelemetry;
+    mspPortToReset->descriptor = mspDescriptorAlloc();
 }
 
 void mspSerialAllocatePorts(void)
@@ -413,7 +414,7 @@ static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspPr
     };
 
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    const mspResult_e status = mspProcessCommandFn(&command, &reply, &mspPostProcessFn);
+    const mspResult_e status = mspProcessCommandFn(msp->descriptor, &command, &reply, &mspPostProcessFn);
 
     if (status != MSP_RESULT_NO_REPLY) {
         sbufSwitchToReader(&reply.buf, outBufHead); // change streambuf direction

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -110,6 +110,7 @@ typedef struct mspPort_s {
     uint8_t checksum1;
     uint8_t checksum2;
     bool sharedWithTelemetry;
+    mspDescriptor_t descriptor;
 } mspPort_t;
 
 void mspSerialInit(void);

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -59,6 +59,7 @@ static mspRxBuffer_t mspRxBuffer;
 static mspTxBuffer_t mspTxBuffer;
 static mspPacket_t mspRxPacket;
 static mspPacket_t mspTxPacket;
+static mspDescriptor_t mspSharedDescriptor;
 
 void initSharedMsp(void)
 {
@@ -71,6 +72,8 @@ void initSharedMsp(void)
     mspPackage.responsePacket = &mspTxPacket;
     mspPackage.responsePacket->buf.ptr = mspPackage.responseBuffer;
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
+
+    mspSharedDescriptor = mspDescriptorAlloc();
 }
 
 static void processMspPacket(void)
@@ -80,7 +83,7 @@ static void processMspPacket(void)
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
 
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    if (mspFcProcessCommand(mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
+    if (mspFcProcessCommand(mspSharedDescriptor, mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
         sbufWriteU8(&mspPackage.responsePacket->buf, TELEMETRY_MSP_ERROR);
     }
     if (mspPostProcessFn) {

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -284,8 +284,11 @@ extern "C" {
 
     bool airmodeIsEnabled(void) {return true;}
 
-    mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+    mspDescriptor_t mspDescriptorAlloc(void) {return 0;}
 
+    mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+
+        UNUSED(srcDesc);
         UNUSED(mspPostProcessFn);
 
         sbuf_t *dst = &reply->buf;


### PR DESCRIPTION
Fixes #8909

~PoC code for supporting~ Implements "Per MSP client arming disable control".

`MSP_SET_ARMING_DISABLE` has been used exclusively by configurator to prevent accidental arming by sending `MSP_SET_ARMING_DISABLE(disable)` upon connection to an FC, and releasing the disable state by sending `MSP_SET_ARMING_ENABLE(enable)` upon disconnection from the FC, thus providing "The craft does not arm while connected from the configurator (except when explicitly instructed)" property.

However, recent introduction of non-configurator MSP client such as an external OSD with a local menu system trying to prevent arming with `MSP_SET_ARMING_DISABLE` facility while the local menu is active was found to produce safety hazard when such client is connected side-by-side with the configurator. In such case, any second client toggling the flag would clear global disable state and the safety property is not valid anymore.

This PR introduces a concept of "MSP descriptor" which describes the source (which port or facility they came from) of MSP messages. A descriptor is assigned when a serial MSP ports is open (MSP over telemetry also assigns a descriptor during initialization). Descriptor is carried around and used to identify sources of messages. `MSP_SET_ARMING_DISABLE` handling use the descriptor to manage  per client arming flag state through `mspArming{Enable,Disable}ByDescriptor()`, and only clears global arming disable flag (`ARMING_DISABLE_MSP`) when all client have cleared corresponding flags, which can be tested by `mspIsMspArmingEnabled()`.