### PR TITLE
Add W25N01G driver to AlienFlightNG F7 target

### DIFF
--- a/src/main/target/ALIENFLIGHTNGF7/target.h
+++ b/src/main/target/ALIENFLIGHTNGF7/target.h
@@ -89,7 +89,10 @@
 #define FLASH_SPI_INSTANCE   SPI2
 
 #define USE_FLASHFS
+#define USE_FLASH_TOOLS
 #define USE_FLASH_M25P16
+#define USE_FLASH_W25N01G
+#define USE_FLASH_W25M02G
 
 #define USE_VCP
 


### PR DESCRIPTION
Update W25N01G driver to work with floating /WP pin in SPI mode

Not sure why we actually need /WP pin of the W25N01G flash chip pulled up to 3.3V. Is there any reason for keep it as it is? Having the WP-E bit in the protection register at 0 will make flash writing independent from der /WP pin status. The AlienFlightNG F7 Osiris20 does have this pin unconnected and was working with very early versions of the driver but is not working since a while in latest releases. Looking forward to your thoughts.