### PR TITLE
Add debug code for blackbox output bandwidth measurement

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -28,6 +28,17 @@
 
 #ifdef USE_BLACKBOX
 
+#include "build/debug.h"
+
+// Debugging code that occasionally become useful when users start to complain broken log output.
+// Enable DEBUG_BB_OUTPUT and set debug_mode = BLACKBOX_OUTPUT to see debug values.
+// (Note that bandwidth usage slightly uincrease as it will include debug variables themselves).
+//
+// 0: Average output bandwidth in last 100ms
+// 1: Maximum hold of above.
+// 2: Bytes dropped due to output buffer full.
+//#define DEBUG_BB_OUTPUT
+
 #include "blackbox.h"
 #include "blackbox_io.h"
 
@@ -87,8 +98,19 @@ void blackboxOpen(void)
     }
 }
 
+#ifdef DEBUG_BB_OUTPUT
+static uint32_t bbBits;
+static timeMs_t bbLastclearMs;
+static uint16_t bbRateMax;
+static uint32_t bbDrops;
+#endif
+
 void blackboxWrite(uint8_t value)
 {
+#ifdef DEBUG_BB_OUTPUT
+    bbBits += 8;
+#endif
+
     switch (blackboxConfig()->device) {
 #ifdef USE_FLASHFS
     case BLACKBOX_DEVICE_FLASH:
@@ -102,9 +124,32 @@ void blackboxWrite(uint8_t value)
 #endif
     case BLACKBOX_DEVICE_SERIAL:
     default:
+#ifdef DEBUG_BB_OUTPUT
+        bbBits += 2;
+        if (serialTxBytesFree(blackboxPort) == 0) {
+            ++bbDrops;
+            DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 2, bbDrops);
+            return;
+        }
+#endif
         serialWrite(blackboxPort, value);
         break;
     }
+
+#ifdef DEBUG_BB_OUTPUT
+    timeMs_t now = millis();
+
+    if (now > bbLastclearMs + 100) {  // Debug log every 100[msec]
+        uint16_t bbRate = ((bbBits * 10 + 5) / (now - bbLastclearMs)) / 10; // In unit of [Kbps]
+        DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 0, bbRate);
+        if (bbRate > bbRateMax) {
+            bbRateMax = bbRate;
+            DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 1, bbRateMax);
+        }
+        bbLastclearMs = now;
+        bbBits = 0;
+    }
+#endif
 }
 
 // Print the null-terminated string 's' to the blackbox device and return the number of bytes written

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -30,14 +30,17 @@
 
 #include "build/debug.h"
 
-// Debugging code that occasionally become useful when users start to complain broken log output.
-// Enable DEBUG_BB_OUTPUT and set debug_mode = BLACKBOX_OUTPUT to see debug values.
-// (Note that bandwidth usage slightly uincrease as it will include debug variables themselves).
+// Debugging code that become useful when output bandwidth saturation is suspected.
+// Set debug_mode = BLACKBOX_OUTPUT to see following debug values.
 //
 // 0: Average output bandwidth in last 100ms
 // 1: Maximum hold of above.
 // 2: Bytes dropped due to output buffer full.
-//#define DEBUG_BB_OUTPUT
+//
+// Note that bandwidth usage slightly increases when DEBUG_BB_OUTPUT is enabled,
+// as output will include debug variables themselves.
+
+#define DEBUG_BB_OUTPUT
 
 #include "blackbox.h"
 #include "blackbox_io.h"

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -93,4 +93,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "DYN_IDLE",
     "FF_LIMIT",
     "FF_INTERPOLATED",
+    "BLACKBOX_OUTPUT",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -109,6 +109,7 @@ typedef enum {
     DEBUG_DYN_IDLE,
     DEBUG_FF_LIMIT,
     DEBUG_FF_INTERPOLATED,
+    DEBUG_BLACKBOX_OUTPUT,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -20,6 +20,8 @@
 extern "C" {
     #include "platform.h"
 
+    #include "build/debug.h"
+
     #include "blackbox/blackbox.h"
     #include "common/utils.h"
 
@@ -362,7 +364,8 @@ uint8_t armingFlags;
 uint8_t stateFlags;
 const uint32_t baudRates[] = {0, 9600, 19200, 38400, 57600, 115200, 230400, 250000,
         400000, 460800, 500000, 921600, 1000000, 1500000, 2000000, 2470000}; // see baudRate_e
-uint8_t debugMode;
+uint8_t debugMode = 0;
+int16_t debug[DEBUG16_VALUE_COUNT];
 int32_t blackboxHeaderBudget;
 gpsSolutionData_t gpsSol;
 int32_t GPS_home[2];


### PR DESCRIPTION
A piece of code for blackbox output bandwidth measurement. Useful for checking when users started to complain broken log, especially on serially connected logging devices (such as #9043).

I'm wondering if the code should always be compiled in, or enabled only when this code is necessary.