### PR TITLE
Stamp out use of box 39 for pinio, use 40 USER1 instead

### DIFF
--- a/src/main/target/CLRACINGF4/config.c
+++ b/src/main/target/CLRACINGF4/config.c
@@ -46,7 +46,7 @@
 
 void targetConfiguration(void)
 {
-    pinioBoxConfigMutable()->permanentId[0] = 39;
+    pinioBoxConfigMutable()->permanentId[0] = 40;
     motorConfigMutable()->dev.motorPwmProtocol = PWM_TYPE_DSHOT600;
     gyroConfigMutable()->gyro_sync_denom = 1;  // 8kHz gyro
     pidConfigMutable()->pid_process_denom = 1; // 8kHz PID

--- a/src/main/target/CLRACINGF7/config.c
+++ b/src/main/target/CLRACINGF7/config.c
@@ -27,6 +27,6 @@
 
 void targetConfiguration(void)
 {	
-    pinioBoxConfigMutable()->permanentId[0] = 39;
+    pinioBoxConfigMutable()->permanentId[0] = 40;
 }
 #endif


### PR DESCRIPTION
Effects legacy targets: CLRACINGF4 CLRACINGF7

Using box 39 for VTX power switch is GREAT until you want to use the real pit mode on a VTX.