### PR TITLE
Stamp out use of "VTX PIT MODE" for VTX power switches - SYNERGYF4

### DIFF
--- a/src/main/target/OMNIBUSF4/config.c
+++ b/src/main/target/OMNIBUSF4/config.c
@@ -70,7 +70,7 @@ void targetConfiguration(void)
     targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
 #endif
 #ifdef SYNERGYF4
-    pinioBoxConfigMutable()->permanentId[0] = 39;
+    pinioBoxConfigMutable()->permanentId[0] = 40;
     vtxSettingsConfigMutable()->pitModeFreq = 0;
     ledStripStatusModeConfigMutable()->ledConfigs[0] = DEFINE_LED(0, 0, 0, 0, LF(COLOR), LO(VTX), 0);
     targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));


### PR DESCRIPTION
Effects legacy target: SYNERGYF4
Separated from #9062 for manufacturer coordination/comment

https://github.com/betaflight/unified-targets/pull/77 is the matching unified target PR
