### PR TITLE
Fix CLI task output header alignment

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4683,7 +4683,7 @@ static void cliTasks(char *cmdline)
 
 #ifndef MINIMAL_CLI
     if (systemConfig()->task_statistics) {
-        cliPrintLine("Task list             rate/hz  max/us  avg/us maxload avgload     total/ms");
+        cliPrintLine("Task list             rate/hz  max/us  avg/us maxload avgload  total/ms");
     } else {
         cliPrintLine("Task list");
     }


### PR DESCRIPTION
Before:
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload     total/ms
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0
01 - (         SYSTEM)    983       3       0    0.7%    0.0%         2
02 - (       GYRO/PID)   7878      67      56   53.2%   44.6%      2147
03 - (            ACC)    983      17       8    2.1%    1.2%        47
```
After:
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms
00 - (         SYSTEM)      9       1       1    0.5%    0.5%         0
01 - (         SYSTEM)    984       2       1    0.6%    0.5%        13
02 - (       GYRO/PID)   7858      70      57   55.5%   45.2%     14812
03 - (            ACC)    984      18       8    2.2%    1.2%       272
```