### PR TITLE
Fix ESC_SENSOR blackbox debug array overflow for more than 4 motors

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -270,8 +270,10 @@ static uint8_t decodeEscFrame(void)
 
         frameStatus = ESC_SENSOR_FRAME_COMPLETE;
 
-        DEBUG_SET(DEBUG_ESC_SENSOR_RPM, escSensorMotor, calcEscRpm(escSensorData[escSensorMotor].rpm) / 10); // output actual rpm/10 to fit in 16bit signed.
-        DEBUG_SET(DEBUG_ESC_SENSOR_TMP, escSensorMotor, escSensorData[escSensorMotor].temperature);
+        if (escSensorMotor < 4) {
+            DEBUG_SET(DEBUG_ESC_SENSOR_RPM, escSensorMotor, calcEscRpm(escSensorData[escSensorMotor].rpm) / 10); // output actual rpm/10 to fit in 16bit signed.
+            DEBUG_SET(DEBUG_ESC_SENSOR_TMP, escSensorMotor, escSensorData[escSensorMotor].temperature);
+        }
     } else {
         frameStatus = ESC_SENSOR_FRAME_FAILED;
     }


### PR DESCRIPTION
Would cause an array index overflow if more than 4 motors and `debug_mode` `ESC_SENSOR_RPM` or `ESC_SENSOR_TMP` were used.
