### PR TITLE
amend notes in make_config_hex.sh for what released

### DIFF
--- a/src/utils/make_config_hex.sh
+++ b/src/utils/make_config_hex.sh
@@ -7,9 +7,12 @@
 # Usage: make_config_hex <input file> <output directory> <config area start address>
 # Choose the config area start address from:
 #
+# 4.1.0 released with the config area at the following offsets
 # STM32F405: 0x080FC000
-# STM32F411 / STM32F7X2: 0x0807C000
-# STM32F74X: 0x080F8000
+# STM32F411: 0x08002808
+# STM32F7X2: 0x08002808
+# STM32F745: 0x08002808
+# STM32F405 uses a separate flash page for its unified config, so if a user flashes STM32F405 without 'Full Chip Erase' the unified target configuration will stay put.
 
 INPUT_FILE=$1
 DESTINATION_DIR=$2


### PR DESCRIPTION
Working on the wiki a little bit today, noticed that the offsets in `make_config_hex.sh needed updating a wee bit