### PR TITLE
QUADSPI - Fix quadSpiTransmit1LINE when writing 1 or more bytes of data.

### DIFF
--- a/src/main/drivers/bus_quadspi_hal.c
+++ b/src/main/drivers/bus_quadspi_hal.c
@@ -232,7 +232,7 @@ bool quadSpiTransmit1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_
     status = HAL_QSPI_Command(&quadSpiDevice[device].hquadSpi, &cmd, QUADSPI_DEFAULT_TIMEOUT);
     bool timeout = (status != HAL_OK);
     if (!timeout) {
-        if (out && length == 0) {
+        if (out && length > 0) {
             status = HAL_QSPI_Transmit(&quadSpiDevice[device].hquadSpi, (uint8_t *)out, QUADSPI_DEFAULT_TIMEOUT);
             timeout = (status != HAL_OK);
         }


### PR DESCRIPTION
command was sent, but data was not due to logic issue.

the code path is unused in all current targets.

