### PR TITLE
Handle MSP based external sensor in mspSerialPush

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -80,6 +80,7 @@
 #include "pg/max7456.h"
 #include "pg/mco.h"
 #include "pg/motor.h"
+#include "pg/msp_port.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/pinio.h"
@@ -1424,7 +1425,14 @@ const clivalue_t valueTable[] = {
 #ifdef USE_MSP_DISPLAYPORT
     { "displayport_msp_col_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -6, 0 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, colAdjust) },
     { "displayport_msp_row_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -3, 0 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, rowAdjust) },
-    { "displayport_msp_serial",     VAR_INT8    | MASTER_VALUE, .config.minmax = { SERIAL_PORT_NONE, SERIAL_PORT_IDENTIFIER_MAX }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, displayPortSerial) },
+#endif
+
+// PG_MSP_PORT_CONFIG
+#ifdef USE_MSP_DISPLAYPORT
+    { "displayport_msp_serial",     VAR_INT8    | MASTER_VALUE, .config.minmax = { SERIAL_PORT_NONE, SERIAL_PORT_IDENTIFIER_MAX }, PG_MSP_PORT_CONFIG, offsetof(mspPortConfig_t, displayPortSerial) },
+#endif
+#ifdef USE_MSP_CURRENT_METER
+    { "msp_sensor_serial",          VAR_INT8    | MASTER_VALUE, .config.minmax = { SERIAL_PORT_NONE, SERIAL_PORT_IDENTIFIER_MAX }, PG_MSP_PORT_CONFIG, offsetof(mspPortConfig_t, mspSensorSerial) },
 #endif
 
 // PG_DISPLAY_PORT_MSP_CONFIG

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -112,6 +112,7 @@ typedef struct mspPort_s {
     bool sharedWithTelemetry;
     mspDescriptor_t descriptor;
     bool isDisplayPort;
+    bool isSensorPort;
 } mspPort_t;
 
 void mspSerialInit(void);

--- a/src/main/pg/msp_port.c
+++ b/src/main/pg/msp_port.c
@@ -23,35 +23,14 @@
 
 #include "platform.h"
 
-#ifdef USE_TARGET_CONFIG
-
 #include "io/serial.h"
 
 #include "pg/msp_port.h"
-#include "pg/rx.h"
+#include "pg/pg_ids.h"
 
-#include "rx/rx.h"
+PG_REGISTER_WITH_RESET_TEMPLATE(mspPortConfig_t, mspPortConfig, PG_MSP_PORT_CONFIG, 0);
 
-#include "sensors/barometer.h"
-
-#include "telemetry/telemetry.h"
-
-#include "config_helper.h"
-
-#define TELEMETRY_UART                      SERIAL_PORT_UART5
-
-static targetSerialPortFunction_t targetSerialPortFunction[] = {
-    { SERIAL_PORT_USART1, FUNCTION_MSP                 },  // So SPRacingF3OSD users don't have to change anything.
-    { TELEMETRY_UART,     FUNCTION_TELEMETRY_SMARTPORT },
-};
-
-void targetConfiguration(void)
-{
-    barometerConfigMutable()->baro_hardware = BARO_DEFAULT;
-    targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
-    telemetryConfigMutable()->halfDuplex = 0;
-    telemetryConfigMutable()->telemetry_inverted = true;
-
-    mspPortConfigMutable()->mspSensorSerial = SERIAL_PORT_USART1;
-}
-#endif
+PG_RESET_TEMPLATE(mspPortConfig_t, mspPortConfig,
+    .displayPortSerial = SERIAL_PORT_NONE,
+    .mspSensorSerial = SERIAL_PORT_NONE,
+);

--- a/src/main/pg/msp_port.h
+++ b/src/main/pg/msp_port.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "pg/pg.h"
+
+typedef struct mspPortConfig_s {
+    int8_t displayPortSerial;
+    int8_t mspSensorSerial;
+} mspPortConfig_t;
+
+PG_DECLARE(mspPortConfig_t, mspPortConfig);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -149,7 +149,8 @@
 #define PG_SDIO_PIN_CONFIG 550
 #define PG_PULLUP_CONFIG 551
 #define PG_PULLDOWN_CONFIG 552
-#define PG_BETAFLIGHT_END 552
+#define PG_MSP_PORT_CONFIG 553
+#define PG_BETAFLIGHT_END 553
 
 
 // OSD configuration (subject to change)


### PR DESCRIPTION
Alternative to #9104 .

Introduces a concept of "MSP sensor port serial", just like "DisplayPort MSP serial" was introduced in #9013.

- Added `PG_MSP_PORT_CONFIG` along with `mspPortConfig_t` with new `mspSensorSerial`, and `displayPortSerial` was moved from `displayPortProfile_t`.
- Added `isSensorPort` to `mspPort_t` along with corresponding changes in `setting.c` and `mspPortAllocate()`.
- `mspSerialPush()` was modified to check `isSensorPort` also.

A caveat with this approach is that DisplayPort MSP messages are sent to MSP sensor ports and vice versa.