### PR TITLE
[Clean-up]Remove redundant 'MAX_ADC_SUPPORTED' def in pg/adc.h

### DIFF
--- a/src/main/pg/adc.h
+++ b/src/main/pg/adc.h
@@ -30,8 +30,6 @@
 
 #define MAX_ADC_SUPPORTED 4
 
-#define MAX_ADC_SUPPORTED 4
-
 typedef struct adcChannelConfig_t {
     bool enabled;
     ioTag_t ioTag;


### PR DESCRIPTION
Whilst looking into pg/adc.h, observed double-definition of "MAX_ADC_SUPPORTED" ;)