### PR TITLE
Add rxrange set/get to MSP protocol 

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2848,6 +2848,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
         rxConfigMutable()->maxcheck = sbufReadU16(src);
         rxConfigMutable()->midrc = sbufReadU16(src);
         rxConfigMutable()->mincheck = sbufReadU16(src);
+        rxConfigMutable()->spektrum_sat_bind = sbufReadU8(src);
         if (sbufBytesRemaining(src) >= 4) {
             rxConfigMutable()->rx_min_usec = sbufReadU16(src);
             rxConfigMutable()->rx_max_usec = sbufReadU16(src);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1361,7 +1361,9 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
 #endif
         break;
 
+        // Added in MSP API 1.43
     case MSP_RXRANGE_CONFIG:
+        sbufWriteU8(dst, NON_AUX_CHANNEL_COUNT);
         for (int i = 0; i < NON_AUX_CHANNEL_COUNT; i++) {
             sbufWriteU16(dst, rxChannelRangeConfigs(i)->min);
             sbufWriteU16(dst, rxChannelRangeConfigs(i)->max);
@@ -2908,10 +2910,14 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
         }
         break;
 
+        // Added in MSP API 1.43
     case MSP_SET_RXRANGE_CONFIG:
-        for (int i = 0; i < NON_AUX_CHANNEL_COUNT; i++) {
-            rxChannelRangeConfigsMutable(0)[i].min = sbufReadU16(src);
-            rxChannelRangeConfigsMutable(0)[i].max = sbufReadU16(src);
+        {
+            uint8_t length = sbufReadU8(src);
+            for (int i = 0; i < length; i++) {
+                rxChannelRangeConfigsMutable(0)[i].min = sbufReadU16(src);
+                rxChannelRangeConfigsMutable(0)[i].max = sbufReadU16(src);
+            }
         }
         break;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1360,6 +1360,15 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, 0);
 #endif
         break;
+
+    case MSP_RXRANGE_CONFIG:
+        for (int i = 0; i < NON_AUX_CHANNEL_COUNT; i++) {
+            sbufWriteU16(dst, rxChannelRangeConfigs(i)->min);
+            sbufWriteU16(dst, rxChannelRangeConfigs(i)->max);
+        }
+
+        break;
+
     case MSP_FAILSAFE_CONFIG:
         sbufWriteU8(dst, failsafeConfig()->failsafe_delay);
         sbufWriteU8(dst, failsafeConfig()->failsafe_off_delay);
@@ -2839,7 +2848,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
         rxConfigMutable()->maxcheck = sbufReadU16(src);
         rxConfigMutable()->midrc = sbufReadU16(src);
         rxConfigMutable()->mincheck = sbufReadU16(src);
-        rxConfigMutable()->spektrum_sat_bind = sbufReadU8(src);
         if (sbufBytesRemaining(src) >= 4) {
             rxConfigMutable()->rx_min_usec = sbufReadU16(src);
             rxConfigMutable()->rx_max_usec = sbufReadU16(src);
@@ -2897,8 +2905,15 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
             sbufReadU8(src);
 #endif
         }
-
         break;
+
+    case MSP_SET_RXRANGE_CONFIG:
+        for (int i = 0; i < NON_AUX_CHANNEL_COUNT; i++) {
+            rxChannelRangeConfigsMutable(0)[i].min = sbufReadU16(src);
+            rxChannelRangeConfigsMutable(0)[i].max = sbufReadU16(src);
+        }
+        break;
+
     case MSP_SET_FAILSAFE_CONFIG:
         failsafeConfigMutable()->failsafe_delay = sbufReadU8(src);
         failsafeConfigMutable()->failsafe_off_delay = sbufReadU8(src);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -341,3 +341,5 @@
 #define MSP_RTC                  247    //out message         Gets the RTC clock
 #define MSP_SET_BOARD_INFO       248    //in message          Sets the board information for this board
 #define MSP_SET_SIGNATURE        249    //in message          Sets the signature of the board and serial number
+#define MSP_RXRANGE_CONFIG       250    //out message
+#define MSP_SET_RXRANGE_CONFIG   251    //in message

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -341,5 +341,7 @@
 #define MSP_RTC                  247    //out message         Gets the RTC clock
 #define MSP_SET_BOARD_INFO       248    //in message          Sets the board information for this board
 #define MSP_SET_SIGNATURE        249    //in message          Sets the signature of the board and serial number
-#define MSP_RXRANGE_CONFIG       243    //out message
-#define MSP_SET_RXRANGE_CONFIG   244    //in message
+#define MSP_RXRANGE_CONFIG       231    //out message
+#define MSP_SET_RXRANGE_CONFIG   232    //in message
+
+#define MSP_SET_1WIRE            243

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -341,5 +341,5 @@
 #define MSP_RTC                  247    //out message         Gets the RTC clock
 #define MSP_SET_BOARD_INFO       248    //in message          Sets the board information for this board
 #define MSP_SET_SIGNATURE        249    //in message          Sets the signature of the board and serial number
-#define MSP_RXRANGE_CONFIG       250    //out message
-#define MSP_SET_RXRANGE_CONFIG   251    //in message
+#define MSP_RXRANGE_CONFIG       243    //out message
+#define MSP_SET_RXRANGE_CONFIG   244    //in message


### PR DESCRIPTION
This change is to support a RX calibration feature in BF configurator ([See PR here](https://github.com/betaflight/betaflight-configurator/pull/1769))

Add  new msp codes:
```
#define MSP_RXRANGE_CONFIG       231
#define MSP_SET_RXRANGE_CONFIG   232
```