### PR TITLE
reduce antigravity gain default to 3.5

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -155,7 +155,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .yawRateAccelLimit = 0,
         .rateAccelLimit = 0,
         .itermThrottleThreshold = 250,
-        .itermAcceleratorGain = 5000,
+        .itermAcceleratorGain = 3500,
         .crash_time = 500,          // ms
         .crash_delay = 0,           // ms
         .crash_recovery_angle = 10, // degrees


### PR DESCRIPTION
In recent releases we have been increasing PID I.

We haven't reduced the antigravity gain value in the same proportion.

Low authority / low P quads can get I wobbles  that are apparent on throttling up.

A lower default anti-gravity gain is likely to work alright and be a fraction less likely to cause I wobbles.

I'm not sure if 3.5 or 4.0 is best for a new anti-gravity gain value, but somewhere in that range is likely better than 5.  

Hopefully some user testing can be done on this.  The only problem is that nose up/down bobble with throttle pumps is very variable quad to quad, so this default value is never perfect for any particular machine.