### PR TITLE
Blink the Launch Control warning element when throttle is within 10% of the trigger setting

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1274,6 +1274,11 @@ static void osdElementWarnings(osdElementParms_t *element)
         {
             tfp_sprintf(element->buff, "LAUNCH");
         }
+
+        // Blink the message if the throttle is within 10% of the launch setting
+        if ( calculateThrottlePercent() >= MAX(currentPidProfile->launchControlThrottlePercent - 10, 0)) {
+            SET_BLINK(OSD_WARNINGS);
+        }
         return;
     }
 #endif // USE_LAUNCH_CONTROL


### PR DESCRIPTION
Fixes #9138 

Provides a visual indication that throttle is close to the trigger limit.
