### PR TITLE
Change virtual current meter to use setpoint rather than rcCommand throttle

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1035,7 +1035,7 @@ static void loadMainState(timeUs_t currentTimeUs)
         blackboxCurrent->setpoint[i] = lrintf(pidGetPreviousSetpoint(i));
     }
     // log the final throttle value used in the mixer
-    blackboxCurrent->setpoint[3] = lrintf(mixerGetLoggingThrottle() * 1000);
+    blackboxCurrent->setpoint[3] = lrintf(mixerGetThrottle() * 1000);
 
     for (int i = 0; i < DEBUG16_VALUE_COUNT; i++) {
         blackboxCurrent->debug[i] = debug[i];

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -472,7 +472,7 @@ void stopMotors(void)
 }
 
 static FAST_RAM_ZERO_INIT float throttle = 0;
-static FAST_RAM_ZERO_INIT float loggingThrottle = 0;
+static FAST_RAM_ZERO_INIT float mixerThrottle = 0;
 static FAST_RAM_ZERO_INIT float motorOutputMin;
 static FAST_RAM_ZERO_INIT float motorRangeMin;
 static FAST_RAM_ZERO_INIT float motorRangeMax;
@@ -891,7 +891,7 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensa
     throttle += pidGetAirmodeThrottleOffset();
     float airmodeThrottleChange = 0;
 #endif
-    loggingThrottle = throttle;
+    mixerThrottle = throttle;
 
     motorMixRange = motorMixMax - motorMixMin;
     if (motorMixRange > 1.0f) {
@@ -934,7 +934,7 @@ void mixerSetThrottleAngleCorrection(int correctionValue)
     throttleAngleCorrection = correctionValue;
 }
 
-float mixerGetLoggingThrottle(void)
+float mixerGetThrottle(void)
 {
-    return loggingThrottle;
+    return mixerThrottle;
 }

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -111,4 +111,4 @@ void writeMotors(void);
 bool mixerIsTricopter(void);
 
 void mixerSetThrottleAngleCorrection(int correctionValue);
-float mixerGetLoggingThrottle(void);
+float mixerGetThrottle(void);

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -20,6 +20,7 @@
 
 #include "stdbool.h"
 #include "stdint.h"
+#include "math.h"
 
 #include "platform.h"
 
@@ -29,17 +30,20 @@
 #include "common/maths.h"
 #include "common/utils.h"
 
+#include "config/config.h"
 #include "config/feature.h"
-#include "pg/pg.h"
-#include "pg/pg_ids.h"
 
 #include "drivers/adc.h"
 
 #include "fc/runtime_config.h"
-#include "config/config.h"
 #include "fc/rc_controls.h"
 
+#include "flight/mixer.h"
+
 #include "io/beeper.h"
+
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
 
 #include "sensors/battery.h"
 
@@ -427,7 +431,7 @@ void batteryUpdateCurrentMeter(timeUs_t currentTimeUs)
 #ifdef USE_VIRTUAL_CURRENT_METER
             throttleStatus_e throttleStatus = calculateThrottleStatus();
             bool throttleLowAndMotorStop = (throttleStatus == THROTTLE_LOW && featureIsEnabled(FEATURE_MOTOR_STOP));
-            int32_t throttleOffset = (int32_t)rcCommand[THROTTLE] - 1000;
+            const int32_t throttleOffset = lrintf(mixerGetThrottle() * 1000);
 
             currentMeterVirtualRefresh(lastUpdateAt, ARMING_FLAG(ARMED), throttleLowAndMotorStop, throttleOffset);
             currentMeterVirtualRead(&currentMeter);


### PR DESCRIPTION
Fixes #9137

Use the final calculated throttle value used in the mixer which may be affected by throttle limiting, throttle boost, etc. instead of the rcCommand input when calculating the virtual current meter.

NOTE: The calculation for the virtual current meter hasn't changed, just the source for the throttle value used as input for the calculation has changed. In cases where modifiers like throttle limit, etc. are not used the new method will be equivalent to the previous calculation.

For debugging the setpoint[throttle] can be used in the logs as the basis rather than the previous rcCommand[throttle].