### PR TITLE
Prevent font upload if max7456 is not detected

### DIFF
--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -37,7 +37,7 @@ bool    max7456Init(const struct max7456Config_s *max7456Config, const struct vc
 void    max7456Invert(bool invert);
 void    max7456Brightness(uint8_t black, uint8_t white);
 void    max7456DrawScreen(void);
-void    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
+bool    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
 uint8_t max7456GetRowsCount(void);
 void    max7456Write(uint8_t x, uint8_t y, const char *buff);
 void    max7456WriteChar(uint8_t x, uint8_t y, uint8_t c);
@@ -48,3 +48,4 @@ bool    max7456BuffersSynced(void);
 bool    max7456LayerSupported(displayPortLayer_e layer);
 bool    max7456LayerSelect(displayPortLayer_e layer);
 bool    max7456LayerCopy(displayPortLayer_e destLayer, displayPortLayer_e sourceLayer);
+bool    max7456IsDeviceDetected(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -44,6 +44,7 @@
 #include "common/streambuf.h"
 #include "common/utils.h"
 
+#include "config/config.h"
 #include "config/config_eeprom.h"
 #include "config/feature.h"
 
@@ -67,7 +68,6 @@
 #include "drivers/vtx_table.h"
 
 #include "fc/board_info.h"
-#include "config/config.h"
 #include "fc/controlrate_profile.h"
 #include "fc/core.h"
 #include "fc/rc.h"
@@ -110,6 +110,7 @@
 #include "pg/beeper.h"
 #include "pg/board.h"
 #include "pg/gyrodev.h"
+#include "pg/max7456.h"
 #include "pg/motor.h"
 #include "pg/rx.h"
 #include "pg/rx_spi.h"
@@ -796,13 +797,19 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
 #define OSD_FLAGS_RESERVED_1            (1 << 2)
 #define OSD_FLAGS_RESERVED_2            (1 << 3)
 #define OSD_FLAGS_OSD_HARDWARE_MAX_7456 (1 << 4)
+#define OSD_FLAGS_MAX7456_DETECTED      (1 << 5)
 
         uint8_t osdFlags = 0;
 #if defined(USE_OSD)
         osdFlags |= OSD_FLAGS_OSD_FEATURE;
 #endif
 #ifdef USE_MAX7456
-        osdFlags |= OSD_FLAGS_OSD_HARDWARE_MAX_7456;
+        if (max7456Config()->csTag && max7456Config()->spiDevice) {
+            osdFlags |= OSD_FLAGS_OSD_HARDWARE_MAX_7456;
+            if (max7456IsDeviceDetected()) {
+                osdFlags |= OSD_FLAGS_MAX7456_DETECTED;
+            }
+        }
 #endif
 
         sbufWriteU8(dst, osdFlags);
@@ -3281,7 +3288,9 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cm
                 font_data[i] = sbufReadU8(src);
             }
             // !!TODO - replace this with a device independent implementation
-            max7456WriteNvm(addr, font_data);
+            if (!max7456WriteNvm(addr, font_data)) {
+                return MSP_RESULT_ERROR;
+            }
         }
         break;
 #else


### PR DESCRIPTION
Fixes #9155 

Prevents wedge if a font upload is attempted but the max7456 device wasn't detected during initialization.

As part of #9013 logic was added to detect whether or not the max7456 was actually detected. If not then configuration of the SPI bus was not completed. Unfortunately the font upload process didn't consider whether the max7456 was available and always tried to communicate with the device. Since the SPI bus configuration wasn't completed this led to a wedge.

This problem could be replicated by using any flight controller that doesn't properly power the max7456 when on USB only. An example is the DALRCF722DUAL. Now for devices like this the font upload will be prevented and the font manager button in the Configurator will be hidden.

Tested with a variety of boards that properly power the max7456 on USB such as OMNIBUSF4SD, SPRACINGF7DUAL, MATEKF722SE.

Tested on a DALRCF722DUAL board that **does not** power the max7456 from USB. When only connected to USB the "Font Manager" functionality is hidden. When connected to battery power then the device is detected and fonts can be uploaded normally.