### PR TITLE
Fixed potentially incorrect calculation in ACC calibration if non-default cycle number is used.

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -164,7 +164,6 @@
 #include "sensors/esc_sensor.h"
 #include "sensors/gyro.h"
 #include "sensors/initialisation.h"
-#include "sensors/sensors.h"
 
 #include "telemetry/telemetry.h"
 
@@ -875,7 +874,7 @@ void init(void)
 
 #ifdef USE_ACC
     if (mixerConfig()->mixerMode == MIXER_GIMBAL) {
-        accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
+        accStartCalibration();
     }
 #endif
     gyroStartCalibration(false);

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -63,7 +63,6 @@
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/gyro.h"
-#include "sensors/sensors.h"
 
 #include "rc_controls.h"
 
@@ -278,7 +277,7 @@ void processRcStickPositions()
 #ifdef USE_ACC
     if (rcSticks == THR_HI + YAW_LO + PIT_LO + ROL_CE) {
         // Calibrating Acc
-        accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
+        accStartCalibration();
         return;
     }
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -123,16 +123,14 @@
 
 #include "scheduler/scheduler.h"
 
-#include "sensors/battery.h"
-
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
+#include "sensors/battery.h"
 #include "sensors/boardalignment.h"
-#include "sensors/esc_sensor.h"
 #include "sensors/compass.h"
+#include "sensors/esc_sensor.h"
 #include "sensors/gyro.h"
 #include "sensors/rangefinder.h"
-#include "sensors/sensors.h"
 
 #include "telemetry/telemetry.h"
 
@@ -2532,7 +2530,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, 
 #ifdef USE_ACC
     case MSP_ACC_CALIBRATION:
         if (!ARMING_FLAG(ARMED))
-            accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
+            accStartCalibration();
         break;
 #endif
 

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -80,11 +80,9 @@
 #include "sensors/gyro.h"
 #include "sensors/sensors.h"
 
-#ifdef USE_HARDWARE_REVISION_DETECTION
-#include "hardware_revision.h"
-#endif
-
 #include "acceleration.h"
+
+#define CALIBRATING_ACC_CYCLES              400
 
 FAST_RAM_ZERO_INIT acc_t acc;                       // acc access functions
 
@@ -360,9 +358,9 @@ bool accInit(uint32_t gyroSamplingInverval)
     return true;
 }
 
-void accSetCalibrationCycles(uint16_t calibrationCyclesRequired)
+void accStartCalibration(void)
 {
-    calibratingA = calibrationCyclesRequired;
+    calibratingA = CALIBRATING_ACC_CYCLES;
 }
 
 bool accIsCalibrationComplete(void)

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -79,7 +79,7 @@ PG_DECLARE(accelerometerConfig_t, accelerometerConfig);
 
 bool accInit(uint32_t gyroTargetLooptime);
 bool accIsCalibrationComplete(void);
-void accSetCalibrationCycles(uint16_t calibrationCyclesRequired);
+void accStartCalibration(void);
 void resetRollAndPitchTrims(rollAndPitchTrims_t *rollAndPitchTrims);
 void accUpdate(timeUs_t currentTimeUs, rollAndPitchTrims_t *rollAndPitchTrims);
 bool accGetAccumulationAverage(float *accumulation);

--- a/src/main/sensors/sensors.h
+++ b/src/main/sensors/sensors.h
@@ -44,7 +44,6 @@ typedef union flightDynamicsTrims_u {
     flightDynamicsTrims_def_t values;
 } flightDynamicsTrims_t;
 
-#define CALIBRATING_ACC_CYCLES              400
 #define CALIBRATING_BARO_CYCLES             200 // 10 seconds init_delay + 200 * 25 ms = 15 seconds before ground pressure settles
 
 typedef enum {

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -536,7 +536,7 @@ static bool bstSlaveProcessWriteCommand(uint8_t bstWriteCommand)
 #if defined(USE_ACC)
         case BST_ACC_CALIBRATION:
            if (!ARMING_FLAG(ARMED))
-               accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
+               accStartCalibration();
            break;
 #endif
         case BST_MAG_CALIBRATION:

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1070,7 +1070,7 @@ extern "C" {
     void blackboxUpdate(timeUs_t) {}
     void transponderUpdate(timeUs_t) {}
     void GPS_reset_home_position(void) {}
-    void accSetCalibrationCycles(uint16_t) {}
+    void accStartCalibration(void) {}
     void baroSetCalibrationCycles(uint16_t) {}
     void changePidProfile(uint8_t) {}
     void changeControlRateProfile(uint8_t) {}

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -610,7 +610,7 @@ void saveConfigAndNotify(void) {}
 void initRcProcessing(void) {}
 void changePidProfile(uint8_t) {}
 void pidInitConfig(const pidProfile_t *) {}
-void accSetCalibrationCycles(uint16_t) {}
+void accStartCalibration(void) {}
 void gyroStartCalibration(bool isFirstArmingCalibration)
 {
     UNUSED(isFirstArmingCalibration);

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -164,7 +164,7 @@ extern "C" {
     void blackboxUpdate(timeUs_t) {}
     void transponderUpdate(timeUs_t) {}
     void GPS_reset_home_position(void) {}
-    void accSetCalibrationCycles(uint16_t) {}
+    void accStartCalibration(void) {}
     void baroSetCalibrationCycles(uint16_t) {}
     void changePidProfile(uint8_t) {}
     void changeControlRateProfile(uint8_t) {}


### PR DESCRIPTION
Solves the problem of `CALIBRATING_ACC_CYCLES` being hard coded into the calculation of the calibration results.