### PR TITLE
Improved compass calibration.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -268,7 +268,9 @@ static void validateAndFixConfig(void)
 
     validateAndFixGyroConfig();
 
+#if defined(USE_MAG)
     buildAlignmentFromStandardAlignment(&compassConfigMutable()->mag_customAlignment, compassConfig()->mag_alignment);
+#endif
     buildAlignmentFromStandardAlignment(&gyroDeviceConfigMutable(0)->customAlignment, gyroDeviceConfig(0)->alignment);
 #if defined(USE_MULTI_GYRO)
     buildAlignmentFromStandardAlignment(&gyroDeviceConfigMutable(1)->customAlignment, gyroDeviceConfig(1)->alignment);

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -98,8 +98,8 @@
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/boardalignment.h"
+#include "sensors/compass.h"
 #include "sensors/gyro.h"
-#include "sensors/sensors.h"
 
 #include "telemetry/telemetry.h"
 
@@ -177,21 +177,17 @@ PG_RESET_TEMPLATE(throttleCorrectionConfig_t, throttleCorrectionConfig,
 
 static bool isCalibrating(void)
 {
-#ifdef USE_BARO
-    if (sensors(SENSOR_BARO) && !isBaroCalibrationComplete()) {
-        return true;
-    }
-#endif
-
-    // Note: compass calibration is handled completely differently, outside of the main loop, see f.CALIBRATE_MAG
-
-    return (
+    return !isGyroCalibrationComplete()
 #ifdef USE_ACC
-        !accIsCalibrationComplete()
-#else
-        false
+        || (sensors(SENSOR_ACC) && !accIsCalibrationComplete())
 #endif
-            && sensors(SENSOR_ACC)) || (!isGyroCalibrationComplete());
+#ifdef USE_BARO
+        || (sensors(SENSOR_BARO) && !isBaroCalibrationComplete())
+#endif
+#ifdef USE_MAG
+        || (sensors(SENSOR_MAG) && !isCompassCalibrationComplete())
+#endif
+        ;
 }
 
 #ifdef USE_LAUNCH_CONTROL

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -62,6 +62,7 @@
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
+#include "sensors/compass.h"
 #include "sensors/gyro.h"
 
 #include "rc_controls.h"
@@ -283,11 +284,14 @@ void processRcStickPositions()
     }
 #endif
 
+#if defined(USE_MAG)
     if (rcSticks == THR_HI + YAW_HI + PIT_LO + ROL_CE) {
         // Calibrating Mag
-        ENABLE_STATE(CALIBRATE_MAG);
+        compassStartCalibration();
+
         return;
     }
+#endif
 
 
     if (FLIGHT_MODE(ANGLE_MODE|HORIZON_MODE)) {

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -113,7 +113,6 @@ extern uint16_t flightModeFlags;
 typedef enum {
     GPS_FIX_HOME   = (1 << 0),
     GPS_FIX        = (1 << 1),
-    CALIBRATE_MAG  = (1 << 2),
 } stateFlags_t;
 
 #define DISABLE_STATE(mask) (stateFlags &= ~(mask))

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -67,3 +67,6 @@ bool compassIsHealthy(void);
 void compassUpdate(timeUs_t currentTime);
 bool compassInit(void);
 void compassPreInit(void);
+void compassStartCalibration(void);
+bool isCompassCalibrationComplete(void);
+

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -539,9 +539,14 @@ static bool bstSlaveProcessWriteCommand(uint8_t bstWriteCommand)
                accStartCalibration();
            break;
 #endif
+
+#if defined(USE_MAG)
         case BST_MAG_CALIBRATION:
-           if (!ARMING_FLAG(ARMED))
-               ENABLE_STATE(CALIBRATE_MAG);
+           if (!ARMING_FLAG(ARMED)) {
+               compassStartCalibration();
+           }
+#endif
+
            break;
         case BST_EEPROM_WRITE:
             if (ARMING_FLAG(ARMED)) {

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1092,5 +1092,7 @@ extern "C" {
     void pidSetItermReset(bool) {}
     void applyAccelerometerTrimsDelta(rollAndPitchTrims_t*) {}
     bool isFixedWing(void) { return false; }
+    void compassStartCalibration(void) {}
+    bool isCompassCalibrationComplete(void) { return true; }
     bool isUpright(void) { return mockIsUpright; }
 }

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -654,4 +654,5 @@ bool isTryingToArm(void) { return false; }
 void resetTryingToArm(void) {}
 void setLedProfile(uint8_t profile) { UNUSED(profile); }
 uint8_t getLedProfile(void) { return 0; }
+void compassStartCalibration(void) {}
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -179,5 +179,7 @@ extern "C" {
     void pidSetItermReset(bool) {}
     void applyAccelerometerTrimsDelta(rollAndPitchTrims_t*) {}
     bool isFixedWing(void) { return false; }
+    void compassStartCalibration(void) {}
+    bool isCompassCalibrationComplete(void) { return true; }
     bool isUpright(void) { return true; }
 }


### PR DESCRIPTION
There is no reason to use a global state flag for this. Also, this brings the API in line with the API for calibrating the other sensors.