### PR TITLE
Disable stick arming by default, require settings change to enable

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1384,6 +1384,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "pwr_on_arm_grace",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, powerOnArmingGraceTime) },
     { "scheduler_optimize_rate",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, schedulerOptimizeRate) },
+    { "enable_stick_arming",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, enableStickArming) },
 
 // PG_VTX_CONFIG
 #ifdef USE_VTX_COMMON

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -114,6 +114,7 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .hseMhz = SYSTEM_HSE_VALUE,  // Not used for non-F4 targets
     .configurationState = CONFIGURATION_STATE_DEFAULTS_BARE,
     .schedulerOptimizeRate = SCHEDULER_OPTIMIZE_RATE_AUTO,
+    .enableStickArming = false,
 );
 
 uint8_t getCurrentPidProfileIndex(void)

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -60,6 +60,7 @@ typedef struct systemConfig_s {
     uint8_t hseMhz; // Not used for non-F4 targets
     uint8_t configurationState; // The state of the configuration (defaults / configured)
     uint8_t schedulerOptimizeRate;
+    uint8_t enableStickArming; // boolean that determines whether stick arming can be used
 } systemConfig_t;
 
 PG_DECLARE(systemConfig_t, systemConfig);

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -396,5 +396,5 @@ int32_t getRcStickDeflection(int32_t axis, uint16_t midrc) {
 void rcControlsInit(void)
 {
     analyzeModeActivationConditions();
-    isUsingSticksToArm = !isModeActivationConditionPresent(BOXARM);
+    isUsingSticksToArm = !isModeActivationConditionPresent(BOXARM) && systemConfig()->enableStickArming;
 }


### PR DESCRIPTION
Previously stick arming was assumed to be the case if an arming switch was not configured. This is a less safe default state and can lead to beginners thinking that stick arming is the default.

This change adds an `enable_stick_arming` setting which defaults to `OFF`. For stick arming to function the user must actively change this setting. The previous condition about there not being an arming switch configured still applies.
