### PR TITLE
Improve RX inter-frame timing measurement by calculating in the protocol layer

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -166,8 +166,12 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
         return;
     }
 
-    currentRxRefreshRate = constrain(currentTimeUs - lastRxTimeUs, 1000, 30000);
+    timeDelta_t rxFrameDeltaUs;
+    if (!rxGetFrameDelta(&rxFrameDeltaUs)) {
+        rxFrameDeltaUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
+    }
     lastRxTimeUs = currentTimeUs;
+    currentRxRefreshRate = constrain(rxFrameDeltaUs, 1000, 30000);
     isRXDataNew = true;
 
 #ifdef USE_USB_CDC_HID

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -862,3 +862,12 @@ bool isRssiConfigured(void)
 {
     return rssiSource != RSSI_SOURCE_NONE;
 }
+
+bool rxGetFrameDelta(timeDelta_t *deltaUs)
+{
+    if (rxRuntimeState.rcFrameDeltaFn) {
+        *deltaUs = rxRuntimeState.rcFrameDeltaFn();
+        return true;
+    }
+    return false;  // No frame delta function available for protocol type
+}

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -125,6 +125,7 @@ struct rxRuntimeState_s;
 typedef uint16_t (*rcReadRawDataFnPtr)(const struct rxRuntimeState_s *rxRuntimeState, uint8_t chan); // used by receiver driver to return channel data
 typedef uint8_t (*rcFrameStatusFnPtr)(struct rxRuntimeState_s *rxRuntimeState);
 typedef bool (*rcProcessFrameFnPtr)(const struct rxRuntimeState_s *rxRuntimeState);
+typedef timeDelta_t (*rcGetFrameDeltaFnPtr)(void);  // used to retrieve the time interval in microseconds for the last channel data frame
 
 typedef enum {
     RX_PROVIDER_NONE = 0,
@@ -143,6 +144,7 @@ typedef struct rxRuntimeState_s {
     rcReadRawDataFnPtr  rcReadRawFn;
     rcFrameStatusFnPtr  rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
+    rcGetFrameDeltaFnPtr rcFrameDeltaFn;
     uint16_t            *channelData;
     void                *frameData;
 } rxRuntimeState_t;
@@ -204,3 +206,5 @@ void suspendRxPwmPpmSignal(void);
 void resumeRxPwmPpmSignal(void);
 
 uint16_t rxGetRefreshRate(void);
+
+bool rxGetFrameDelta(timeDelta_t *deltaUs);


### PR DESCRIPTION
Adds accuracy to the frame rate measurements used to configure RC smoothing by capturing the timing at the lowest level possible in the protocol. Prevents looptime delays and jitter from affecting the calculations previously performed at a high level in the RX "check" task. Significantly improves the accuracy of the measurement in cases where CPU load is high.

Implemented so that each protocol can individually provide the functionality if appropriate. If a protocol doesn't support the more granular measurement then the system will fallback to the original measurement calculated in the RX task.

Currently implemented and tested for SBUS and CRSF protocols. The plan is to include additional protocols as possible in separate PR's to allow more focused testing. Any protocols not yet implemented will behave now worse than currently, they just won't yet have the benefit of the improvements.

Here is an example of Frsky-X SBUS (9ms) captured before the improvements. The flight controller was a F4 with enough features enabled to get approximately 25% CPU load (higher load causes more jitter). The receiver is a XSR running normal SBUS firmware (not Fport). The graphing ranges from 8500us to 9500us (ideal is 9000us) for consistent scale.

![sbus before](https://user-images.githubusercontent.com/17088539/69249498-f7882880-0b7b-11ea-817d-806e2a7e58cf.png)

Here is the same flight controller, receiver, same CPU load, same graph scale/range, etc. after the improvements.

![sbus after](https://user-images.githubusercontent.com/17088539/69249612-27cfc700-0b7c-11ea-9ea7-258c028fe1f1.png)
