### PR TITLE
Add protocol level receiver frame rate measurement for IBUS

### DIFF
--- a/src/test/unit/rx_ibus_unittest.cc
+++ b/src/test/unit/rx_ibus_unittest.cc
@@ -67,6 +67,10 @@ uint32_t micros(void)
 {
     return microseconds_stub_value;
 }
+uint32_t microsISR(void)
+{
+    return micros();
+}
 
 #define SERIAL_BUFFER_SIZE 256
 #define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x1234


### PR DESCRIPTION
Testers appreciated as I don't have any Flysky equipment.

To test: Start with defaults and do a minimal setup necessary to get your receiver recognized on  the Receiver tab. With receiver and transmitter powered, go to the CLI and report the output of the `rc_smoothing_info` command. We will be looking at the "Detected RX frame rate:" value which should be close to 7ms for IBUS.