### PR TITLE
Update SBUS and CRSF to use microsISR() in the interrupt handler

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -233,7 +233,7 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
     UNUSED(data);
 
     static uint8_t crsfFramePosition = 0;
-    const timeUs_t currentTimeUs = micros();
+    const timeUs_t currentTimeUs = microsISR();
     static timeUs_t lastRcFrameCompleteTimeUs = 0;
 
 #ifdef DEBUG_CRSF_PACKETS

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -116,7 +116,7 @@ static void sbusDataReceive(uint16_t c, void *data)
     static timeUs_t lastFrameCompleteTimeUs = 0;
     sbusFrameData_t *sbusFrameData = data;
 
-    const timeUs_t nowUs = micros();
+    const timeUs_t nowUs = microsISR();
 
     const timeDelta_t sbusFrameTime = cmpTimeUs(nowUs, sbusFrameData->startAtUs);
 

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -406,6 +406,10 @@ extern "C" {
         return simulationTime;
     }
 
+    uint32_t microsISR() {
+        return micros();
+    }
+
     uint32_t millis() {
         return micros() / 1000;
     }

--- a/src/test/unit/rx_crsf_unittest.cc
+++ b/src/test/unit/rx_crsf_unittest.cc
@@ -289,6 +289,7 @@ extern "C" {
 
 int16_t debug[DEBUG16_VALUE_COUNT];
 uint32_t micros(void) {return dummyTimeUs;}
+uint32_t microsISR(void) {return micros();}
 serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e, serialReceiveCallbackPtr, void *, uint32_t, portMode_e, portOptions_e) {return NULL;}
 serialPortConfig_t *findSerialPortConfig(serialPortFunction_e ) {return NULL;}
 bool telemetryCheckRxPortShared(const serialPortConfig_t *) {return false;}

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -255,6 +255,7 @@ extern "C" {
     attitudeEulerAngles_t attitude = { { 0, 0, 0 } };
 
     uint32_t micros(void) {return dummyTimeUs;}
+    uint32_t microsISR(void) {return micros();}
     serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e, serialReceiveCallbackPtr, void *, uint32_t, portMode_e, portOptions_e) {return NULL;}
     serialPortConfig_t *findSerialPortConfig(serialPortFunction_e ) {return NULL;}
     bool isBatteryVoltageConfigured(void) { return true; }

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -313,6 +313,7 @@ gpsSolutionData_t gpsSol;
 void beeperConfirmationBeeps(uint8_t beepCount) {UNUSED(beepCount);}
 
 uint32_t micros(void) {return 0;}
+uint32_t microsISR(void) {return micros();}
 
 bool featureIsEnabled(uint32_t) {return true;}
 


### PR DESCRIPTION
Use `microsISR()` instead of `micros()` in the interrupt handler.