### PR TITLE
Fixed exiting from CMS menu.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -541,8 +541,9 @@ STATIC_UNIT_TESTED long cmsMenuBack(displayPort_t *pDisplay); // Forward; will b
 
 static void cmsDrawMenu(displayPort_t *pDisplay, uint32_t currentTimeUs)
 {
-    if (!pageTop)
+    if (!pageTop || !cmsInMenu) {
         return;
+    }
 
     uint8_t i;
     const OSD_Entry *p;

--- a/src/main/cms/cms_menu_main.c
+++ b/src/main/cms/cms_menu_main.c
@@ -115,7 +115,7 @@ static const OSD_Entry menuMainEntries[] =
     {"FC&FIRMWARE", OME_Submenu,  cmsMenuChange, &cmsx_menuFirmware, 0},
     {"MISC",        OME_Submenu,  cmsMenuChange, &cmsx_menuMisc, 0},
     {"SAVE/EXIT",   OME_Funcall,  cmsx_SaveExitMenu, NULL, 0},
-    {NULL,OME_END, NULL, NULL, 0},
+    {NULL, OME_END, NULL, NULL, 0},
 };
 
 CMS_Menu cmsx_menuMain = {


### PR DESCRIPTION
Exiting without saving / reboot was broken after #9179 because a redraw of the menu was attempted after `cmsMenuExit()` was called.