### PR TITLE
Refactored CMS VTX menu selection to not use 'checkRedirect'.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -669,13 +669,6 @@ long cmsMenuChange(displayPort_t *pDisplay, const void *ptr)
             return 0;
         }
 
-        if (pMenu->checkRedirect) {
-            const CMS_Menu *pRedirectMenu = (const CMS_Menu *)pMenu->checkRedirect();
-            if (pRedirectMenu) {
-                return cmsMenuChange(pDisplay, pRedirectMenu);
-            }
-        }
-
         menuStack[menuStackIdx++] = currentCtx;
 
         currentCtx.menu = pMenu;

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -221,7 +221,6 @@ CMS_Menu cmsx_menuBlackbox = {
 #endif
     .onEnter = cmsx_Blackbox_onEnter,
     .onExit = cmsx_Blackbox_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuBlackboxEntries
 };

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -91,7 +91,6 @@ CMS_Menu cmsx_menuFailsafe = {
 #endif
     .onEnter = cmsx_Failsafe_onEnter,
     .onExit = cmsx_Failsafe_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuFailsafeEntries
 };

--- a/src/main/cms/cms_menu_firmware.c
+++ b/src/main/cms/cms_menu_firmware.c
@@ -140,7 +140,6 @@ static CMS_Menu cmsx_menuCalibration = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = cmsx_CalibrationOnDisplayUpdate,
     .entries = menuCalibrationEntries
 };
@@ -185,7 +184,6 @@ CMS_Menu cmsx_menuFirmware = {
 #endif
     .onEnter = cmsx_FirmwareInit,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuFirmwareEntries
 };

--- a/src/main/cms/cms_menu_gps_rescue.c
+++ b/src/main/cms/cms_menu_gps_rescue.c
@@ -117,7 +117,6 @@ CMS_Menu cms_menuGpsRescuePid = {
 #endif
     .onEnter = cms_menuGpsRescuePidOnEnter,
     .onExit = cms_menuGpsRescuePidOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cms_menuGpsRescuePidEntries,
 };
@@ -200,7 +199,6 @@ CMS_Menu cmsx_menuGpsRescue = {
 #endif
     .onEnter = cmsx_menuGpsRescueOnEnter,
     .onExit = cmsx_menuGpsRescueOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuGpsRescueEntries,
 };

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -223,7 +223,6 @@ static CMS_Menu cmsx_menuPid = {
 #endif
     .onEnter = cmsx_PidOnEnter,
     .onExit = cmsx_PidWriteback,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuPidEntries
 };
@@ -291,7 +290,6 @@ static CMS_Menu cmsx_menuRateProfile = {
 #endif
     .onEnter = cmsx_RateProfileOnEnter,
     .onExit = cmsx_RateProfileWriteback,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuRateProfileEntries
 };
@@ -351,7 +349,6 @@ static CMS_Menu cmsx_menuLaunchControl = {
 #endif
     .onEnter = cmsx_launchControlOnEnter,
     .onExit = cmsx_launchControlOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuLaunchControlEntries,
 };
@@ -498,7 +495,6 @@ static CMS_Menu cmsx_menuProfileOther = {
 #endif
     .onEnter = cmsx_profileOtherOnEnter,
     .onExit = cmsx_profileOtherOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuProfileOtherEntries,
 };
@@ -567,7 +563,6 @@ static CMS_Menu cmsx_menuFilterGlobal = {
 #endif
     .onEnter = cmsx_menuGyro_onEnter,
     .onExit = cmsx_menuGyro_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuFilterGlobalEntries,
 };
@@ -656,7 +651,6 @@ static CMS_Menu cmsx_menuDynFilt = {
 #endif
     .onEnter = cmsx_menuDynFilt_onEnter,
     .onExit = cmsx_menuDynFilt_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuDynFiltEntries,
 };
@@ -718,7 +712,6 @@ static CMS_Menu cmsx_menuFilterPerProfile = {
 #endif
     .onEnter = cmsx_FilterPerProfileRead,
     .onExit = cmsx_FilterPerProfileWriteback,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuFilterPerProfileEntries,
 };
@@ -790,7 +783,6 @@ CMS_Menu cmsx_menuCopyProfile = {
 #endif
     .onEnter = cmsx_menuCopyProfile_onEnter,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuCopyProfileEntries,
 };
@@ -829,7 +821,6 @@ CMS_Menu cmsx_menuImu = {
 #endif
     .onEnter = cmsx_menuImu_onEnter,
     .onExit = cmsx_menuImu_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuImuEntries,
 };

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -127,7 +127,6 @@ CMS_Menu cmsx_menuLedstrip = {
 #endif
     .onEnter = cmsx_Ledstrip_OnEnter,
     .onExit = cmsx_Ledstrip_OnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuLedstripEntries
 };

--- a/src/main/cms/cms_menu_main.c
+++ b/src/main/cms/cms_menu_main.c
@@ -63,7 +63,7 @@ static const OSD_Entry menuFeaturesEntries[] =
 #endif
 #if defined(USE_VTX_CONTROL)
 #if defined(USE_VTX_RTC6705) || defined(USE_VTX_SMARTAUDIO) || defined(USE_VTX_TRAMP)
-    {"VTX", OME_Submenu, cmsMenuChange, &cmsx_menuVtxRedirect, 0},
+    {"VTX", OME_Funcall, cmsSelectVtx, NULL, 0},
 #endif
 #endif // VTX_CONTROL
 #ifdef USE_LED_STRIP

--- a/src/main/cms/cms_menu_main.c
+++ b/src/main/cms/cms_menu_main.c
@@ -84,7 +84,6 @@ static CMS_Menu cmsx_menuFeatures = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuFeaturesEntries,
 };
@@ -125,7 +124,6 @@ CMS_Menu cmsx_menuMain = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuMainEntries,
 };

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -96,7 +96,6 @@ CMS_Menu cmsx_menuRcPreview = {
 #endif
     .onEnter = NULL,
     .onExit = cmsx_menuRcConfirmBack,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuRcEntries
 };
@@ -149,7 +148,6 @@ CMS_Menu cmsx_menuMisc = {
 #endif
     .onEnter = cmsx_menuMiscOnEnter,
     .onExit = cmsx_menuMiscOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuMiscEntries
 };

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -158,7 +158,6 @@ static CMS_Menu menuOsdActiveElems = {
 #endif
     .onEnter = menuOsdActiveElemsOnEnter,
     .onExit = menuOsdActiveElemsOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuOsdActiveElemsEntries
 };
@@ -224,7 +223,6 @@ static CMS_Menu menuAlarms = {
 #endif
     .onEnter = menuAlarmsOnEnter,
     .onExit = menuAlarmsOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuAlarmsEntries,
 };
@@ -278,7 +276,6 @@ static CMS_Menu menuTimers = {
 #endif
     .onEnter = menuTimersOnEnter,
     .onExit = menuTimersOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = menuTimersEntries,
 };
@@ -353,7 +350,6 @@ CMS_Menu cmsx_menuOsd = {
 #endif
     .onEnter = cmsx_menuOsdOnEnter,
     .onExit = cmsx_menuOsdOnExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuOsdEntries
 };

--- a/src/main/cms/cms_menu_power.c
+++ b/src/main/cms/cms_menu_power.c
@@ -126,7 +126,6 @@ CMS_Menu cmsx_menuPower = {
 #endif
     .onEnter = cmsx_Power_onEnter,
     .onExit = cmsx_Power_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuPowerEntries
 };

--- a/src/main/cms/cms_menu_saveexit.c
+++ b/src/main/cms/cms_menu_saveexit.c
@@ -51,7 +51,6 @@ CMS_Menu cmsx_menuSaveExit = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuSaveExitEntries
 };
@@ -72,7 +71,6 @@ CMS_Menu cmsx_menuSaveExitReboot = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuSaveExitRebootEntries
 };

--- a/src/main/cms/cms_menu_vtx_common.c
+++ b/src/main/cms/cms_menu_vtx_common.c
@@ -64,11 +64,34 @@ static long setStatusMessage(void)
     return 0;
 }
 
+static const OSD_Entry vtxErrorMenuEntries[] =
+{
+    { "",     OME_Label, NULL, statusLine1,  DYNAMIC },
+    { "",     OME_Label, NULL, statusLine2,  DYNAMIC },
+    { "",     OME_Label, NULL, NULL, 0 },
+    { "BACK", OME_Back,  NULL, NULL, 0 },
+    { NULL,   OME_END,   NULL, NULL, 0 }
+};
+
+static CMS_Menu cmsx_menuVtxError = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "XVTXERROR",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = setStatusMessage,
+    .onExit = NULL,
+    .checkRedirect = NULL,
+    .onDisplayUpdate = NULL,
+    .entries = vtxErrorMenuEntries,
+};
+
 // Redirect to the proper menu based on the vtx device type
 // If device isn't valid or not a supported type then don't
 // redirect and instead display a local informational menu.
-static const void *vtxMenuRedirect(void)
+long cmsSelectVtx(displayPort_t *pDisplay, const void *ptr)
 {
+    UNUSED(ptr);
+
     vtxDevice_t *device = vtxCommonDevice();
 
     if (device) {
@@ -78,44 +101,32 @@ static const void *vtxMenuRedirect(void)
         
 #if defined(USE_VTX_RTC6705)
         case VTXDEV_RTC6705:
-            return &cmsx_menuVtxRTC6705;
+            cmsMenuChange(pDisplay, &cmsx_menuVtxRTC6705);
+
+            break;
 #endif
 #if defined(USE_VTX_SMARTAUDIO)
         case VTXDEV_SMARTAUDIO:
-            return &cmsx_menuVtxSmartAudio;
+            cmsMenuChange(pDisplay, &cmsx_menuVtxSmartAudio);
+
+            break;
 #endif
 #if defined(USE_VTX_TRAMP)
         case VTXDEV_TRAMP:
-            return &cmsx_menuVtxTramp;
+            cmsMenuChange(pDisplay, &cmsx_menuVtxTramp);
+
+            break;
 #endif
 
         default:
-            return NULL;
+            cmsMenuChange(pDisplay, &cmsx_menuVtxError);
+
+            break;
         }
+    } else {
+        cmsMenuChange(pDisplay, &cmsx_menuVtxError);
     }
 
-    return NULL;
+    return 0;
 }
-
-static const OSD_Entry vtxRedirectMenuEntries[] =
-{
-    { "",     OME_Label, NULL, statusLine1,  DYNAMIC },
-    { "",     OME_Label, NULL, statusLine2,  DYNAMIC },
-    { "",     OME_Label, NULL, NULL, 0 },
-    { "BACK", OME_Back,  NULL, NULL, 0 },
-    { NULL,   OME_END,   NULL, NULL, 0 }
-};
-
-CMS_Menu cmsx_menuVtxRedirect = {
-#ifdef CMS_MENU_DEBUG
-    .GUARD_text = "XVTXREDIRECT",
-    .GUARD_type = OME_MENU,
-#endif
-    .onEnter = setStatusMessage,
-    .onExit = NULL,
-    .checkRedirect = vtxMenuRedirect,
-    .onDisplayUpdate = NULL,
-    .entries = vtxRedirectMenuEntries,
-};
-
 #endif

--- a/src/main/cms/cms_menu_vtx_common.c
+++ b/src/main/cms/cms_menu_vtx_common.c
@@ -80,7 +80,6 @@ static CMS_Menu cmsx_menuVtxError = {
 #endif
     .onEnter = setStatusMessage,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = vtxErrorMenuEntries,
 };

--- a/src/main/cms/cms_menu_vtx_common.h
+++ b/src/main/cms/cms_menu_vtx_common.h
@@ -23,4 +23,4 @@
 #include "cms/cms.h"
 #include "cms/cms_types.h"
 
-extern CMS_Menu cmsx_menuVtxRedirect;
+long cmsSelectVtx(displayPort_t *pDisplay, const void *ptr);

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -164,7 +164,6 @@ CMS_Menu cmsx_menuVtxRTC6705 = {
 #endif
     .onEnter = cmsx_Vtx_onEnter,
     .onExit = cmsx_Vtx_onExit,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuVtxEntries
 };

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -416,7 +416,6 @@ static CMS_Menu saCmsMenuStats = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = saCmsMenuStatsEntries
 };
@@ -615,7 +614,6 @@ static CMS_Menu saCmsMenuPORFreq =
 #endif
     .onEnter = saCmsSetPORFreqOnEnter,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = saCmsMenuPORFreqEntries,
 };
@@ -639,7 +637,6 @@ static CMS_Menu saCmsMenuUserFreq =
 #endif
     .onEnter = saCmsSetUserFreqOnEnter,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = saCmsMenuUserFreqEntries,
 };
@@ -668,7 +665,6 @@ static CMS_Menu saCmsMenuConfig = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = saCmsMenuConfigEntries
 };
@@ -689,7 +685,6 @@ static CMS_Menu saCmsMenuCommence = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = saCmsMenuCommenceEntries,
 };
@@ -763,7 +758,6 @@ CMS_Menu cmsx_menuVtxSmartAudio = {
 #endif
     .onEnter = sacms_SetupTopMenu,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = saCmsMenuOfflineEntries,
 };

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -243,7 +243,6 @@ static CMS_Menu trampCmsMenuCommence = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = trampCmsMenuCommenceEntries,
 };
@@ -272,7 +271,6 @@ CMS_Menu cmsx_menuVtxTramp = {
 #endif
     .onEnter = trampCmsOnEnter,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .onDisplayUpdate = NULL,
     .entries = trampMenuEntries,
 };

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -109,7 +109,6 @@ typedef struct
 #endif
     const CMSMenuFuncPtr onEnter;
     const CMSMenuOnExitPtr onExit;
-    const CMSMenuCheckRedirectPtr checkRedirect;
     const CMSMenuOnDisplayUpdatePtr onDisplayUpdate;
     const OSD_Entry *entries;
 } CMS_Menu;

--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -132,7 +132,6 @@ CMS_Menu cmsx_menuMain = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
-    .checkRedirect = NULL,
     .entries = menuMainEntries,
 };
 uint8_t armingFlags;


### PR DESCRIPTION
@etracer65: Have a look at this - I figured out that we can do the VTX menu selection by calling a function instead of opening a menu, and can thus remove the need for the `checkRedirect` pointer. The 'Save & Exit' menu is already using this facility, and it's working fine there.