### PR TITLE
Update gcc to 9.2.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,8 @@ CC_NO_OPTIMISATION      :=
 #
 TEMPORARY_FLAGS := -Wno-attributes \
               -Wno-cast-function-type \
-              -Wno-address-of-packed-member
+              -Wno-address-of-packed-member \
+              -Wno-absolute-value
 
 CFLAGS     += $(ARCH_FLAGS) \
               $(addprefix -D,$(OPTIONS)) \

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,8 @@ CC_NO_OPTIMISATION      :=
 # Added after GCC version update, remove once the warnings have been fixed
 #
 TEMPORARY_FLAGS := -Wno-attributes \
-              -Wno-cast-function-type
+              -Wno-cast-function-type \
+              -Wno-address-of-packed-member
 
 CFLAGS     += $(ARCH_FLAGS) \
               $(addprefix -D,$(OPTIONS)) \

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -14,9 +14,9 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-8-2019-q3-update
+ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-9-2019-q4-major
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
-GCC_REQUIRED_VERSION ?= 8.3.1
+GCC_REQUIRED_VERSION ?= 9.2.1
 
 .PHONY: arm_sdk_version
 
@@ -26,7 +26,7 @@ arm_sdk_version:
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
-ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update
+ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64
 
 # source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifdef LINUX

--- a/src/link/stm32_flash_h750_exst.ld
+++ b/src/link/stm32_flash_h750_exst.ld
@@ -61,10 +61,7 @@ MEMORY
     DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
     RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 64K
     CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    /*EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size*/
-/* Workaround for https://sourceware.org/bugzilla/show_bug.cgi?id=24289,
- * revert after this has been fixed in the ARM gcc. */
-    EXST_HASH (rx)    : ORIGIN = 0x2407FFC0, LENGTH = _exst_hash_size
+    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
 
     D2_RAM (rwx)      : ORIGIN = 0x30000000, LENGTH = 256K /* SRAM1 + SRAM2 */
 


### PR DESCRIPTION
This should fix the problem of the slow builds introduced by gcc 8.3. (https://community.arm.com/developer/tools-software/oss-platforms/f/gnu-toolchain-forum/13503/gcc-g-version-8-very-slow-to-compile).