### PR TITLE
Un-ignore 'address-of-packed-member' warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,7 @@ CC_NO_OPTIMISATION      :=
 #
 # Added after GCC version update, remove once the warnings have been fixed
 #
-TEMPORARY_FLAGS := -Wno-address-of-packed-member \
-              -Wno-absolute-value
+TEMPORARY_FLAGS := -Wno-absolute-value
 
 CFLAGS     += $(ARCH_FLAGS) \
               $(addprefix -D,$(OPTIONS)) \


### PR DESCRIPTION
Follow-up to #9293.