### PR TITLE
Fix download URLs for gcc 9.2.1

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -26,11 +26,11 @@ arm_sdk_version:
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
-ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64
+ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major
 
 # source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifdef LINUX
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-linux.tar.bz2
+  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-x86_64-linux.tar.bz2
 endif
 
 ifdef MACOSX
@@ -38,7 +38,7 @@ ifdef MACOSX
 endif
 
 ifdef WINDOWS
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip
+  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip.bz2
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))


### PR DESCRIPTION
Tested on MacOS and Linux.

I'm not sure the Windows version is going to work. The file will download fine, but it now has a ".bz2" (ie. `gcc-arm-none-eabi-9-2019-q4-major-win32.zip.bz2`) instead of ".zip". I'm not sure if this will expand properly. With Windows Linux subsystem I'm guessing it will be ok as `unzip` seems to handle this fine on Linux. But I don't have a setup to test on Windows.