### PR TITLE
Refactored 'WAS_EVER_ARMED' arming flag to be only enabled on first disarm.

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -425,6 +425,7 @@ void updateArmingStatus(void)
 void disarm(void)
 {
     if (ARMING_FLAG(ARMED)) {
+        ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
         DISABLE_ARMING_FLAG(ARMED);
         lastDisarmTimeUs = micros();
 
@@ -519,7 +520,6 @@ void tryArm(void)
         osdSuppressStats(false);
 #endif
         ENABLE_ARMING_FLAG(ARMED);
-        ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
 
         resetTryingToArm();
 

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -209,7 +209,7 @@ void failsafeUpdateState(void)
     }
 
     // Beep RX lost only if we are not seeing data and we have been armed earlier
-    if (!receivingRxData && ARMING_FLAG(WAS_EVER_ARMED)) {
+    if (!receivingRxData && (armed || ARMING_FLAG(WAS_EVER_ARMED))) {
         beeperMode = BEEPER_RX_LOST;
     }
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -816,18 +816,18 @@ static void osdRefreshStats(void)
 
 static timeDelta_t osdShowArmed(void)
 {
-    static bool everArmed = false;
     timeDelta_t ret;
 
     displayClearScreen(osdDisplayPort);
-    if ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_ON) || ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_FIRST) && !everArmed)) {
+
+    if ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_ON) || ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_FIRST) && !ARMING_FLAG(WAS_EVER_ARMED))) {
         osdDrawLogo(3, 1);
         ret = osdConfig()->logo_on_arming_duration * 1e5;
     } else {
         ret = (REFRESH_1S / 2);
     }
     displayWrite(osdDisplayPort, 12, 7, DISPLAYPORT_ATTR_NONE, "ARMED");
-    everArmed = true;
+
     return ret;
 }
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1445,7 +1445,7 @@ static void osdElementWarnings(osdElementParms_t *element)
 #endif // USE_RC_SMOOTHING_FILTER
 
     // Show warning if battery is not fresh
-    if (osdWarnGetState(OSD_WARNING_BATTERY_NOT_FULL) && !ARMING_FLAG(WAS_EVER_ARMED) && (getBatteryState() == BATTERY_OK)
+    if (osdWarnGetState(OSD_WARNING_BATTERY_NOT_FULL) && !(ARMING_FLAG(ARMED) || ARMING_FLAG(WAS_EVER_ARMED)) && (getBatteryState() == BATTERY_OK)
           && getBatteryAverageCellVoltage() < batteryConfig()->vbatfullcellvoltage) {
         tfp_sprintf(element->buff, "BATT < FULL");
         element->attr = DISPLAYPORT_ATTR_INFO;


### PR DESCRIPTION
This makes it possible to detect if we are armed for the first time (`ARMING_FLAG(ARMED)  && !ARMING_FLAG(WAS_EVER_ARMED)`), as used in #9244.