### PR TITLE
Add optional search string support for CLI "help" command

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6315,7 +6315,7 @@ const clicmd_t cmdTable[] = {
 #if defined(USE_GYRO_REGISTER_DUMP) && !defined(SIMULATOR_BUILD)
     CLI_COMMAND_DEF("gyroregisters", "dump gyro config registers contents", NULL, cliDumpGyroRegisters),
 #endif
-    CLI_COMMAND_DEF("help", NULL, NULL, cliHelp),
+    CLI_COMMAND_DEF("help", "display command help", "[search string]", cliHelp),
 #ifdef USE_LED_STRIP_STATUS_MODE
         CLI_COMMAND_DEF("led", "configure leds", NULL, cliLed),
 #endif
@@ -6400,19 +6400,38 @@ const clicmd_t cmdTable[] = {
 
 static void cliHelp(char *cmdline)
 {
-    UNUSED(cmdline);
+    bool anyMatches = false;
 
     for (uint32_t i = 0; i < ARRAYLEN(cmdTable); i++) {
-        cliPrint(cmdTable[i].name);
+        bool printEntry = false;
+        if (isEmpty(cmdline)) {
+            printEntry = true;
+        } else {
+            if (strcasestr(cmdTable[i].name, cmdline)
 #ifndef MINIMAL_CLI
-        if (cmdTable[i].description) {
-            cliPrintf(" - %s", cmdTable[i].description);
-        }
-        if (cmdTable[i].args) {
-            cliPrintf("\r\n\t%s", cmdTable[i].args);
-        }
+                || strcasestr(cmdTable[i].description, cmdline)
 #endif
-        cliPrintLinefeed();
+               ) {
+                printEntry = true;
+            }
+        } 
+
+        if (printEntry) {
+            anyMatches = true;
+            cliPrint(cmdTable[i].name);
+#ifndef MINIMAL_CLI
+            if (cmdTable[i].description) {
+                cliPrintf(" - %s", cmdTable[i].description);
+            }
+            if (cmdTable[i].args) {
+                cliPrintf("\r\n\t%s", cmdTable[i].args);
+            }
+#endif
+            cliPrintLinefeed();
+        }
+    }
+    if (!isEmpty(cmdline) && !anyMatches) {
+        cliPrintErrorLinef("NO MATCHES FOR '%s'", cmdline);
     }
 }
 


### PR DESCRIPTION
Helps users locate CLI commands by searching both the command name and description.

Examples:
```
# help vtx
vtx - vtx channels on switch
	<index> <aux_channel> <vtx_band> <vtx_channel> <vtx_power> <start_range> <end_range>
vtx_info - vtx power config dump
vtxtable - vtx frequency table
	<band> <bandname> <bandletter> [FACTORY|CUSTOM] <freq> ... <freq>
```

```
# help bind
bind_rx - initiate binding for RX SPI or SRXL2
```

```
# help serial
escprog - passthrough esc to serial
	<mode [sk/bl/ki/cc]> <index>
gpspassthrough - passthrough gps to serial
serial - configure serial ports
serialpassthrough - passthrough serial data data from port 1 to VCP / port 2
	<id1> [<baud1>] [<mode>1] [none|<dtr pinio>|reset] [<id2>] [<baud2>] [<mode2>]
```

```
# help dsfhksdhfk
###ERROR: NO MATCHES FOR 'dsfhksdhfk'###
```