### PR TITLE
Restructure flashfs MSC to prevent device timeout on MacOS

### DIFF
--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -76,8 +76,6 @@ void mscInit(void)
 
 uint8_t mscStart(void)
 {
-    ledInit(statusLedConfig());
-
     //Start USB
     usbGenerateDisconnectPulse();
 

--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -74,8 +74,6 @@ void mscInit(void)
 
 uint8_t mscStart(void)
 {
-    ledInit(statusLedConfig());
-
     //Start USB
     usbGenerateDisconnectPulse();
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -122,6 +122,7 @@
 #include "io/vtx_smartaudio.h"
 #include "io/vtx_tramp.h"
 
+#include "msc/emfat_file.h"
 #ifdef USE_PERSISTENT_MSC_RTC
 #include "msc/usbd_storage.h"
 #endif
@@ -611,6 +612,16 @@ void init(void)
  *  so there is no bottleneck in reading and writing data */
     mscInit();
     if (mscCheckBoot() || mscCheckButton()) {
+        ledInit(statusLedConfig());
+
+#if defined(USE_FLASHFS) && defined(USE_FLASH_CHIP)
+        // If the blackbox device is onboard flash, then initialize and scan
+        // it to identify the log files *before* starting the USB device to
+        // prevent timeouts of the mass storage device.
+        if (blackboxConfig()->device == BLACKBOX_DEVICE_FLASH) {
+            emfat_init_files();
+        }
+#endif
         if (mscStart() == 0) {
              mscWaitForButton();
         } else {

--- a/src/main/msc/emfat_file.c
+++ b/src/main/msc/emfat_file.c
@@ -31,7 +31,13 @@
 #include "common/time.h"
 #include "common/utils.h"
 
+#include "drivers/flash.h"
+#include "drivers/light_led.h"
+#include "drivers/time.h"
+
 #include "io/flashfs.h"
+
+#include "pg/flash.h"
 
 #include "msc/usbd_storage.h"
 
@@ -300,9 +306,18 @@ static void emfat_add_log(emfat_entry_t *entry, int number, uint32_t offset, uin
     entry->cma_time[2] = entry->cma_time[0];
 }
 
-static int emfat_find_log(emfat_entry_t *entry, int maxCount)
+static void blinkStatusLed(void)
 {
-    int limit = flashfsIdentifyStartOfFreeSpace();
+    static timeMs_t nextToggleMs = 0;
+    const timeMs_t nowMs = millis();
+    if (nowMs > nextToggleMs) {
+        LED0_TOGGLE;
+        nextToggleMs = nowMs + 50; // toggle the status LED every 50ms
+    }
+}
+
+static int emfat_find_log(emfat_entry_t *entry, int maxCount, int flashfsUsedSpace)
+{
     int lastOffset = 0;
     int currOffset = 0;
     int buffOffset;
@@ -316,8 +331,9 @@ static int emfat_find_log(emfat_entry_t *entry, int maxCount)
     int lenTimeHeader = strlen(timeHeader);
     int timeHeaderMatched = 0;
 
-    for ( ; currOffset < limit ; currOffset += 2048) { // XXX 2048 = FREE_BLOCK_SIZE in io/flashfs.c
+    for ( ; currOffset < flashfsUsedSpace ; currOffset += 2048) { // XXX 2048 = FREE_BLOCK_SIZE in io/flashfs.c
 
+        blinkStatusLed();
         flashfsReadAbs(currOffset, buffer, HDR_BUF_SIZE);
 
         if (strncmp((char *)buffer, logHeader, lenLogHeader)) {
@@ -373,7 +389,7 @@ static int emfat_find_log(emfat_entry_t *entry, int maxCount)
                 hdrOffset += HDR_BUF_SIZE;
 
                 // Check for flash overflow
-                if (hdrOffset > limit) {
+                if (hdrOffset > flashfsUsedSpace) {
                     break;
                 }
 
@@ -411,6 +427,12 @@ void emfat_init_files(void)
     }
 #endif
 
+    flashInit(flashConfig());
+    flashfsInit();
+    LED0_OFF;
+
+    const int flashfsUsedSpace = flashfsIdentifyStartOfFreeSpace();
+
     for (size_t i = 0 ; i < PREDEFINED_ENTRY_COUNT ; i++) {
         entries[i] = entriesPredefined[i];
         // These entries have timestamps corresponding to when the filesystem is mounted
@@ -418,17 +440,16 @@ void emfat_init_files(void)
     }
 
     // Detect and create entries for each individual log
-    const int logCount = emfat_find_log(&entries[PREDEFINED_ENTRY_COUNT], EMFAT_MAX_LOG_ENTRY);
+    const int logCount = emfat_find_log(&entries[PREDEFINED_ENTRY_COUNT], EMFAT_MAX_LOG_ENTRY, flashfsUsedSpace);
 
     int entryIndex = PREDEFINED_ENTRY_COUNT + logCount;
-    const int usedSpace = flashfsIdentifyStartOfFreeSpace();
 
     if (logCount > 0) {
         // Create the all logs entry that represents all used flash space to
         // allow downloading the entire log in one file
         entries[entryIndex] = entriesPredefined[PREDEFINED_ENTRY_COUNT];
         entry = &entries[entryIndex];
-        entry->curr_size = usedSpace;
+        entry->curr_size = flashfsUsedSpace;
         entry->max_size = entry->curr_size;
         // This entry has timestamps corresponding to when the filesystem is mounted
         emfat_set_entry_cma(entry);
@@ -436,15 +457,16 @@ void emfat_init_files(void)
     }
 
     // Padding file to fill out the filesystem size to FILESYSTEM_SIZE_MB
-    if (usedSpace * 2 < FILESYSTEM_SIZE_MB * 1024 * 1024) {
+    if (flashfsUsedSpace * 2 < FILESYSTEM_SIZE_MB * 1024 * 1024) {
         entries[entryIndex] = entriesPredefined[PREDEFINED_ENTRY_COUNT + 1];
         entry = &entries[entryIndex];
         // used space is doubled because of the individual files plus the single complete file
-        entry->curr_size = (FILESYSTEM_SIZE_MB * 1024 * 1024) - (usedSpace * 2);
+        entry->curr_size = (FILESYSTEM_SIZE_MB * 1024 * 1024) - (flashfsUsedSpace * 2);
         entry->max_size = entry->curr_size;
         // This entry has timestamps corresponding to when the filesystem is mounted
         emfat_set_entry_cma(entry);
     }
 
     emfat_init(&emfat, "BETAFLT", entries);
+    LED0_OFF;
 }

--- a/src/main/msc/usbd_storage_emfat.c
+++ b/src/main/msc/usbd_storage_emfat.c
@@ -33,16 +33,9 @@
 #include "common/utils.h"
 
 #include "drivers/light_led.h"
-#include "drivers/time.h"
-#include "drivers/flash.h"
 
-#include "io/flashfs.h"
-
-#include "pg/flash.h"
-
-#include "usbd_storage.h"
-#include "usbd_storage_emfat.h"
-#include "emfat_file.h"
+#include "msc/usbd_storage.h"
+#include "msc/usbd_storage_emfat.h"
 
 
 #define STORAGE_LUN_NBR 1
@@ -65,18 +58,6 @@ static const uint8_t STORAGE_Inquirydata[] =
 static int8_t STORAGE_Init(uint8_t lun)
 {
     UNUSED(lun);
-
-    LED0_ON;
-
-#ifdef USE_FLASHFS 
-#ifdef USE_FLASH_CHIP
-    flashInit(flashConfig());
-#endif
-    flashfsInit();
-#endif
-    emfat_init_files();
-
-    delay(1000);
 
     LED0_OFF;
 


### PR DESCRIPTION
Fixes #9005 

For devices using the 1Gb NAND flash the scanning phase that discovers the individual logs was taking to long resulting in the operating system thinking the mass storage device had become unresponsive. It is simply a factor of the larger flash size and the amount of time needed to scan all 2K blocks.

Restructured to scan the flash **before** initializing and starting the USB device. That way the mass storage device can start quickly and be immediately ready for operating system requests.

Tested on MacOS and Windows 10.