### PR TITLE
Add camera frame OSD element

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1336,6 +1336,7 @@ const clivalue_t valueTable[] = {
 #endif
 
     { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RC_CHANNELS]) },
+    { "osd_camera_frame_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CAMERA_FRAME]) },
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users
@@ -1381,6 +1382,8 @@ const clivalue_t valueTable[] = {
 #endif
 
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
+    { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
+    { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
 
 // PG_SYSTEM_CONFIG
 #if defined(STM32F4)

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -878,6 +878,11 @@ static bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, 0);
 #endif // USE_OSD_STICK_OVERLAY
 
+        // API >= 1.43
+        // Add the camera frame element width/height
+        sbufWriteU8(dst, osdConfig()->camera_frame_width);
+        sbufWriteU8(dst, osdConfig()->camera_frame_height);
+
 #endif // USE_OSD
         break;
     }
@@ -3258,6 +3263,13 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cm
                     sbufReadU8(src);
 #endif // USE_OSD_STICK_OVERLAY
 
+                }
+
+                if (sbufBytesRemaining(src) >= 2) {
+                    // API >= 1.43
+                    // OSD camera frame element width/height
+                    osdConfigMutable()->camera_frame_width = sbufReadU8(src);
+                    osdConfigMutable()->camera_frame_height = sbufReadU8(src);
                 }
 #endif
             } else if ((int8_t)addr == -2) {

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -286,6 +286,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_CROSSHAIRS]         = OSD_POS(13, 6);
     osdConfig->item_pos[OSD_ARTIFICIAL_HORIZON] = OSD_POS(14, 2);
     osdConfig->item_pos[OSD_HORIZON_SIDEBARS]   = OSD_POS(14, 6);
+    osdConfig->item_pos[OSD_CAMERA_FRAME]       = OSD_POS(3, 1);
 
     // Enable the default stats
     osdConfig->enabled_stats = 0; // reset all to off and enable only a few initially
@@ -343,6 +344,9 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->distance_alarm = 0;
     osdConfig->logo_on_arming = OSD_LOGO_ARMING_OFF;
     osdConfig->logo_on_arming_duration = 5;  // 0.5 seconds
+
+    osdConfig->camera_frame_width = 24;
+    osdConfig->camera_frame_height = 11;
 }
 
 static void osdDrawLogo(int x, int y)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -41,6 +41,11 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 
 #define OSD_RCCHANNELS_COUNT 4
 
+#define OSD_CAMERA_FRAME_MIN_WIDTH  2
+#define OSD_CAMERA_FRAME_MAX_WIDTH  30    // Characters per row supportes by MAX7456
+#define OSD_CAMERA_FRAME_MIN_HEIGHT 2
+#define OSD_CAMERA_FRAME_MAX_HEIGHT 16    // Rows supported by MAX7456 (PAL)
+
 #define OSD_PROFILE_BITS_POS 11
 #define OSD_PROFILE_MASK    (((1 << OSD_PROFILE_COUNT) - 1) << OSD_PROFILE_BITS_POS)
 #define OSD_POS_MAX   0x3FF
@@ -135,6 +140,7 @@ typedef enum {
     OSD_PROFILE_NAME,
     OSD_RSSI_DBM_VALUE,
     OSD_RC_CHANNELS,
+    OSD_CAMERA_FRAME,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -274,6 +280,8 @@ typedef struct osdConfig_s {
     uint16_t distance_alarm;
     uint8_t logo_on_arming;                   // show the logo on arming
     uint8_t logo_on_arming_duration;          // display duration in 0.1s units
+    uint8_t camera_frame_width;               // The width of the box for the camera frame element
+    uint8_t camera_frame_height;              // The height of the box for the camera frame element
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
Adds an adjustable outline element designed to represent the field of view of the pilot's HD camera for visual framing. The width, height and position of the frame are adjustable. Uses characters from the stick overlay for the frame.

![camera_frame_element](https://user-images.githubusercontent.com/17088539/70159940-b1f15280-1687-11ea-92b1-4d7cf06994d9.png)

The normal OSD element position is used for the top-left of the frame. New parameters are available for the width/height.
```
osd_camera_frame_width
osd_camera_frame_height
```
The width/height are added to the `MSP_SET_CONFIG` and `MSP_SET_OSD_CONFIG` MSP messages to support configuring the frame size in the Configurator.

