### PR TITLE
Add no-RX option for broken Tramp implementations on some VTX

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1117,7 +1117,7 @@ const clivalue_t valueTable[] = {
     { "idle_pid_limit",             VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_pid_limit) },
     { "idle_max_increase",          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_max_increase) },
 #endif
-    
+
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY
     { "tlm_inverted",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, telemetry_inverted) },
@@ -1413,6 +1413,7 @@ const clivalue_t valueTable[] = {
 // PG_VTX_CONFIG
 #if defined(USE_VTX_CONTROL) && defined(USE_VTX_COMMON)
     { "vtx_halfduplex",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_CONFIG, offsetof(vtxConfig_t, halfDuplex) },
+    { "vtx_tramp_norx",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_CONFIG, offsetof(vtxConfig_t, trampNoRx) },
 #endif
 
 // PG_VTX_IO

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -48,11 +48,12 @@
 #include "pg/pg_ids.h"
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(vtxConfig_t, vtxConfig, PG_VTX_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(vtxConfig_t, vtxConfig, PG_VTX_CONFIG, 2);
 
 PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
 //    .vtxChannelActivationConditions = { 0 },
-    .halfDuplex = true
+    .halfDuplex = true,
+    .trampNoRx = false
 );
 
 static uint8_t locked = 0;

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -41,6 +41,7 @@ typedef struct vtxChannelActivationCondition_s {
 typedef struct vtxConfig_s {
     vtxChannelActivationCondition_t vtxChannelActivationConditions[MAX_CHANNEL_ACTIVATION_CONDITION_COUNT];
     uint8_t halfDuplex;
+    uint8_t trampNoRx;
 } vtxConfig_t;
 
 PG_DECLARE(vtxConfig_t, vtxConfig);


### PR DESCRIPTION
The serial data from my VTX (eachine nano - known problem, see: https://www.banggood.com/Eachine-NANO-VTX-5_8GHz-48CH-25100200400mW-Switchable-FPV-Transmitter-Support-OSDPitmodeIRC-Tramp-for-RC-Drone-Tiny-whoop-p-1525228.html?cur_warehouse=UK) is either too weak or the timing not accurate enough to register with my FC (F4 NOX). The data from FC to VTX works fine though. With this new cli option "vtx_tramp_norx" you can disable checking for responses and control frequency and power of the vtx instead of just pit mode (which was unidirectional already). This also means the vtx will always show as ready, even if it isn't connected.