### PR TITLE
Fixed 'back' command for CMS menus.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -550,9 +550,11 @@ static void cmsMenuCountPage(displayPort_t *pDisplay)
 STATIC_UNIT_TESTED const void *cmsMenuBack(displayPort_t *pDisplay)
 {
     // Let onExit function decide whether to allow exit or not.
-
     if (currentCtx.menu->onExit) {
-        return currentCtx.menu->onExit(pageTop + currentCtx.cursorRow);
+        const void *result = currentCtx.menu->onExit(pageTop + currentCtx.cursorRow);
+        if (result == MENU_CHAIN_BACK) {
+            return result;
+        }
     }
 
     if (!menuStackIdx) {


### PR DESCRIPTION
Kudos to @Asizon for identifying and reporting this in https://github.com/betaflight/betaflight/pull/9221#issuecomment-562818886.
