### PR TITLE
Inhibit 'Save & Exit' menu when in RC preview.

### DIFF
--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -51,6 +51,7 @@ void cmsMenuOpen(void);
 const void *cmsMenuChange(displayPort_t *pPort, const void *ptr);
 const void *cmsMenuExit(displayPort_t *pPort, const void *ptr);
 void cmsSetExternKey(cms_key_e extKey);
+void inhibitSaveMenu(void);
 
 #define CMS_STARTUP_HELP_TEXT1 "MENU:THR MID"
 #define CMS_STARTUP_HELP_TEXT2     "+ YAW LEFT"

--- a/src/main/cms/cms_menu_main.c
+++ b/src/main/cms/cms_menu_main.c
@@ -92,11 +92,8 @@ static const void *cmsx_SaveExitMenu(displayPort_t *pDisplay, const void *ptr)
 {
     UNUSED(ptr);
 
-    if (getRebootRequired()) {
-        cmsMenuChange(pDisplay, &cmsx_menuSaveExitReboot);
-    } else {
-        cmsMenuChange(pDisplay, &cmsx_menuSaveExit);
-    }
+    cmsMenuChange(pDisplay, getSaveExitMenu());
+
     return NULL;
 }
 

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -60,12 +60,20 @@
 // Misc
 //
 
+static const void *cmsx_menuRcOnEnter(void)
+{
+    inhibitSaveMenu();
+
+    return NULL;
+}
+
 static const void *cmsx_menuRcConfirmBack(const OSD_Entry *self)
 {
-    if (self && self->type == OME_Back)
+    if (self && self->type == OME_Back) {
         return NULL;
-    else
+    } else {
         return MENU_CHAIN_BACK;
+    }
 }
 
 //
@@ -94,7 +102,7 @@ CMS_Menu cmsx_menuRcPreview = {
     .GUARD_text = "XRCPREV",
     .GUARD_type = OME_MENU,
 #endif
-    .onEnter = NULL,
+    .onEnter = cmsx_menuRcOnEnter,
     .onExit = cmsx_menuRcConfirmBack,
     .onDisplayUpdate = NULL,
     .entries = cmsx_menuRcEntries

--- a/src/main/cms/cms_menu_saveexit.c
+++ b/src/main/cms/cms_menu_saveexit.c
@@ -44,7 +44,7 @@ static const OSD_Entry cmsx_menuSaveExitEntries[] =
     { NULL, OME_END, NULL, NULL, 0 }
 };
 
-CMS_Menu cmsx_menuSaveExit = {
+static CMS_Menu cmsx_menuSaveExit = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUSAVE",
     .GUARD_type = OME_MENU,
@@ -64,7 +64,7 @@ static const OSD_Entry cmsx_menuSaveExitRebootEntries[] =
     { NULL, OME_END, NULL, NULL, 0 }
 };
 
-CMS_Menu cmsx_menuSaveExitReboot = {
+static CMS_Menu cmsx_menuSaveExitReboot = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUSAVE",
     .GUARD_type = OME_MENU,
@@ -75,5 +75,12 @@ CMS_Menu cmsx_menuSaveExitReboot = {
     .entries = cmsx_menuSaveExitRebootEntries
 };
 
-
+CMS_Menu *getSaveExitMenu(void)
+{
+   if (getRebootRequired()) {
+        return &cmsx_menuSaveExitReboot;
+    } else {
+        return &cmsx_menuSaveExit;
+    }
+}
 #endif

--- a/src/main/cms/cms_menu_saveexit.h
+++ b/src/main/cms/cms_menu_saveexit.h
@@ -20,5 +20,4 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuSaveExit;
-extern CMS_Menu cmsx_menuSaveExitReboot;
+CMS_Menu *getSaveExitMenu(void);


### PR DESCRIPTION
Adding a way to programmatically inhibit displaying of the 'Save & Exit' menu in any given menu until the menu is changed.
This is required for the 'RC preview' menu, as the 'Save & Exit' menu popping up makes it impossible to determine the maximum yaw stick limit.