### PR TITLE
Unify rx spi exti handling

### DIFF
--- a/src/main/drivers/rx/rx_a7105.h
+++ b/src/main/drivers/rx/rx_a7105.h
@@ -97,7 +97,7 @@ typedef enum {
 #define A7105_MODE_TRSR        0x02    // [0]: RX state. [1]: TX state. Serviceable if TRER=1 (TRX is enable).
 #define A7105_MODE_TRER        0x01    // [0]: TRX is disabled. [1]: TRX is enabled.
 
-void A7105Init(uint32_t id, IO_t extiPin, IO_t txEnPin);
+void A7105Init(uint32_t id, IO_t txEnPin);
 void A7105SoftReset(void);
 void A7105Config(const uint8_t *regsTable, uint8_t size);
 

--- a/src/main/drivers/rx/rx_cyrf6936.h
+++ b/src/main/drivers/rx/rx_cyrf6936.h
@@ -201,9 +201,9 @@ enum {
 };
 #define CYRF6936_DATA_CODE_LENGTH (1<<5)
 
-extern volatile bool isError;
+extern bool isError;
 
-bool cyrf6936Init(IO_t extiPin);
+bool cyrf6936Init(void);
 
 bool cyrf6936RxFinished(uint32_t *timeStamp);
 

--- a/src/main/drivers/rx/rx_spi.h
+++ b/src/main/drivers/rx/rx_spi.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+#include "common/time.h"
+
+#include "drivers/exti.h"
+
 #define RX_SPI_MAX_PAYLOAD_SIZE 35
 
 struct rxSpiConfig_s;
@@ -34,3 +38,9 @@ void rxSpiWriteCommand(uint8_t command, uint8_t data);
 void rxSpiWriteCommandMulti(uint8_t command, const uint8_t *data, uint8_t length);
 uint8_t rxSpiReadCommand(uint8_t command, uint8_t commandData);
 void rxSpiReadCommandMulti(uint8_t command, uint8_t commandData, uint8_t *retData, uint8_t length);
+void rxSpiExtiInit(ioConfig_t rxSpiExtiPinConfig, extiTrigger_t rxSpiExtiPinTrigger);
+bool rxSpiExtiConfigured(void);
+bool rxSpiGetExtiState(void);
+bool rxSpiPollExti(void);
+void rxSpiResetExti(void);
+timeUs_t rxSpiGetLastExtiTimeUs(void);

--- a/src/main/rx/a7105_flysky.h
+++ b/src/main/rx/a7105_flysky.h
@@ -32,6 +32,6 @@ PG_DECLARE(flySkyConfig_t, flySkyConfig);
 
 struct rxSpiConfig_s;
 struct rxRuntimeState_s;
-bool flySkyInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool flySkyInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void flySkySetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e flySkyDataReceived(uint8_t *payload);

--- a/src/main/rx/cc2500_common.c
+++ b/src/main/rx/cc2500_common.c
@@ -28,6 +28,7 @@
 
 #include "drivers/io.h"
 #include "drivers/rx/rx_cc2500.h"
+#include "drivers/rx/rx_spi.h"
 #include "drivers/time.h"
 
 #include "config/config.h"
@@ -43,7 +44,6 @@
 
 #include "cc2500_common.h"
 
-static IO_t gdoPin;
 #if defined(USE_RX_CC2500_SPI_PA_LNA)
 static IO_t txEnPin;
 static IO_t rxLnaEnPin;
@@ -67,11 +67,6 @@ void cc2500setRssiDbm(uint8_t value)
     }
 
     setRssi(rssiDbm << 3, RSSI_SOURCE_RX_PROTOCOL);
-}
-
-bool cc2500getGdo(void)
-{
-    return IORead(gdoPin);
 }
 
 #if defined(USE_RX_CC2500_SPI_PA_LNA) && defined(USE_RX_CC2500_SPI_DIVERSITY)
@@ -122,15 +117,10 @@ bool cc2500SpiInit(void)
         return false;
     }
 
-    // gpio init here
-    gdoPin = IOGetByTag(rxSpiConfig()->extiIoTag);
-
-    if (!gdoPin) {
+    if (!rxSpiExtiConfigured()) {
         return false;
     }
 
-    IOInit(gdoPin, OWNER_RX_SPI_EXTI, 0);
-    IOConfigGPIO(gdoPin, IOCFG_IN_FLOATING);
 #if defined(USE_RX_CC2500_SPI_PA_LNA)
     if (rxCc2500SpiConfig()->lnaEnIoTag) {
         rxLnaEnPin = IOGetByTag(rxCc2500SpiConfig()->lnaEnIoTag);

--- a/src/main/rx/cc2500_common.h
+++ b/src/main/rx/cc2500_common.h
@@ -24,7 +24,6 @@
 
 uint16_t cc2500getRssiDbm(void);
 void cc2500setRssiDbm(uint8_t value);
-bool cc2500getGdo(void);
 #if defined(USE_RX_CC2500_SPI_PA_LNA) && defined(USE_RX_CC2500_SPI_DIVERSITY)
 void cc2500switchAntennae(void);
 #endif

--- a/src/main/rx/cc2500_frsky_common.h
+++ b/src/main/rx/cc2500_frsky_common.h
@@ -22,7 +22,7 @@
 
 #include "rx/rx_spi.h"
 
-bool frSkySpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState);
+bool frSkySpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 rx_spi_received_e frSkySpiDataReceived(uint8_t *packet);
 rx_spi_received_e frSkySpiProcessFrame(uint8_t *packet);
 void frSkySpiSetRcData(uint16_t *rcData, const uint8_t *payload);

--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -36,8 +36,9 @@
 #include "config/feature.h"
 
 #include "drivers/adc.h"
-#include "drivers/rx/rx_cc2500.h"
 #include "drivers/io.h"
+#include "drivers/rx/rx_cc2500.h"
+#include "drivers/rx/rx_spi.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
 
@@ -216,7 +217,7 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
         FALLTHROUGH; //!!TODO -check this fall through is correct
     // here FS code could be
     case STATE_DATA:
-        if (cc2500getGdo()) {
+        if (rxSpiGetExtiState()) {
             uint8_t ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
             bool packetOk = false;
             if (ccLen >= 20) {

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -33,11 +33,12 @@
 #include "config/feature.h"
 
 #include "drivers/adc.h"
-#include "drivers/rx/rx_cc2500.h"
 #include "drivers/io.h"
 #include "drivers/io_def.h"
 #include "drivers/io_types.h"
 #include "drivers/resource.h"
+#include "drivers/rx/rx_cc2500.h"
+#include "drivers/rx/rx_spi.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
 
@@ -368,7 +369,7 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
         FALLTHROUGH;
         // here FS code could be
     case STATE_DATA:
-        if (cc2500getGdo() && (frameReceived == false)){
+        if (rxSpiGetExtiState() && (frameReceived == false)){
             uint8_t ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
             if (ccLen >= packetLength) {
                 cc2500ReadFifo(packet, packetLength);

--- a/src/main/rx/cc2500_sfhss.c
+++ b/src/main/rx/cc2500_sfhss.c
@@ -29,8 +29,9 @@
 
 #include "common/maths.h"
 
-#include "drivers/rx/rx_cc2500.h"
 #include "drivers/io.h"
+#include "drivers/rx/rx_cc2500.h"
+#include "drivers/rx/rx_spi.h"
 #include "drivers/time.h"
 
 #include "config/config.h"
@@ -138,7 +139,7 @@ static bool sfhssRecv(uint8_t *packet)
 {
     uint8_t ccLen;
 
-    if (!(cc2500getGdo())) {
+    if (!(rxSpiGetExtiState())) {
         return false;
     }
     ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
@@ -423,8 +424,10 @@ rx_spi_received_e sfhssSpiDataReceived(uint8_t *packet)
     return ret;
 }
 
-bool sfhssSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState)
+bool sfhssSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxSpiCommonIOInit(rxSpiConfig);
 
     cc2500SpiInit();

--- a/src/main/rx/cc2500_sfhss.h
+++ b/src/main/rx/cc2500_sfhss.h
@@ -48,7 +48,7 @@ typedef struct rxSfhssSpiConfig_s {
 
 PG_DECLARE(rxSfhssSpiConfig_t, rxSfhssSpiConfig);
 
-bool sfhssSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState);
+bool sfhssSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 rx_spi_received_e sfhssSpiDataReceived(uint8_t *packet);
 void sfhssSpiSetRcData(uint16_t *rcData, const uint8_t *payload);
 

--- a/src/main/rx/cyrf6936_spektrum.c
+++ b/src/main/rx/cyrf6936_spektrum.c
@@ -27,6 +27,7 @@
 
 #include "drivers/io.h"
 #include "drivers/rx/rx_cyrf6936.h"
+#include "drivers/rx/rx_spi.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
 
@@ -372,18 +373,23 @@ static void dsmReceiverStartTransfer(void)
     cyrf6936StartRecv();
 }
 
-bool spektrumSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState)
+bool spektrumSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
-    IO_t extiPin = IOGetByTag(rxConfig->extiIoTag);
-    if (!extiPin) {
+    UNUSED(extiConfig);
+
+    if (!rxSpiExtiConfigured()) {
         return false;
     }
 
     rxSpiCommonIOInit(rxConfig);
 
+
     rxRuntimeState->channelCount = DSM_MAX_CHANNEL_COUNT;
 
-    if (!cyrf6936Init(extiPin)) {
+    extiConfig->ioConfig = IOCFG_IPD;
+    extiConfig->trigger = EXTI_TRIGGER_FALLING;
+
+    if (!cyrf6936Init()) {
         return false;
     }
 
@@ -453,6 +459,7 @@ void spektrumSpiSetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload)
 static bool isValidPacket(const uint8_t *packet)
 {
     DEBUG_SET(DEBUG_RX_SPEKTRUM_SPI, 1, isError);
+
     if (isError) {
         if (dsmReceiver.status != DSM_RECEIVER_RECV && (cyrf6936GetRxStatus() & CYRF6936_BAD_CRC)) {
             dsmReceiver.crcSeed = ~dsmReceiver.crcSeed;

--- a/src/main/rx/cyrf6936_spektrum.h
+++ b/src/main/rx/cyrf6936_spektrum.h
@@ -48,6 +48,6 @@ typedef struct spektrumConfig_s {
 
 PG_DECLARE(spektrumConfig_t, spektrumConfig);
 
-bool spektrumSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool spektrumSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void spektrumSpiSetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e spektrumSpiDataReceived(uint8_t *payload);

--- a/src/main/rx/nrf24_cx10.c
+++ b/src/main/rx/nrf24_cx10.c
@@ -299,8 +299,10 @@ static void cx10Nrf24Setup(rx_spi_protocol_e protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-bool cx10Nrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState)
+bool cx10Nrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxRuntimeState->channelCount = RC_CHANNEL_COUNT;
     cx10Nrf24Setup((rx_spi_protocol_e)rxSpiConfig->rx_spi_protocol);
 

--- a/src/main/rx/nrf24_cx10.h
+++ b/src/main/rx/nrf24_cx10.h
@@ -25,6 +25,6 @@
 
 struct rxSpiConfig_s;
 struct rxRuntimeState_s;
-bool cx10Nrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool cx10Nrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void cx10Nrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e cx10Nrf24DataReceived(uint8_t *payload);

--- a/src/main/rx/nrf24_h8_3d.c
+++ b/src/main/rx/nrf24_h8_3d.c
@@ -283,8 +283,10 @@ static void h8_3dNrf24Setup(rx_spi_protocol_e protocol, const uint32_t *rxSpiId)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-bool h8_3dNrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState)
+bool h8_3dNrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxRuntimeState->channelCount = RC_CHANNEL_COUNT;
     h8_3dNrf24Setup((rx_spi_protocol_e)rxSpiConfig->rx_spi_protocol, &rxSpiConfig->rx_spi_id);
 

--- a/src/main/rx/nrf24_h8_3d.h
+++ b/src/main/rx/nrf24_h8_3d.h
@@ -25,6 +25,6 @@
 
 struct rxSpiConfig_s;
 struct rxRuntimeState_s;
-bool h8_3dNrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool h8_3dNrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void h8_3dNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e h8_3dNrf24DataReceived(uint8_t *payload);

--- a/src/main/rx/nrf24_inav.c
+++ b/src/main/rx/nrf24_inav.c
@@ -424,8 +424,10 @@ static void inavNrf24Setup(rx_spi_protocol_e protocol, const uint32_t *rxSpiId, 
     writeAckPayload(ackPayload, payloadSize);
 }
 
-bool inavNrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState)
+bool inavNrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxRuntimeState->channelCount = RC_CHANNEL_COUNT_MAX;
     inavNrf24Setup((rx_spi_protocol_e)rxSpiConfig->rx_spi_protocol, &rxSpiConfig->rx_spi_id, rxSpiConfig->rx_spi_rf_channel_count);
 

--- a/src/main/rx/nrf24_inav.h
+++ b/src/main/rx/nrf24_inav.h
@@ -25,7 +25,7 @@
 
 struct rxSpiConfig_s;
 struct rxRuntimeState_s;
-bool inavNrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool inavNrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void inavNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e inavNrf24DataReceived(uint8_t *payload);
 

--- a/src/main/rx/nrf24_kn.c
+++ b/src/main/rx/nrf24_kn.c
@@ -204,8 +204,10 @@ static void knNrf24Setup(rx_spi_protocol_e protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-bool knNrf24Init(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
+bool knNrf24Init(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxRuntimeState->channelCount = KN_RC_CHANNEL_COUNT;
     knNrf24Setup((rx_spi_protocol_e)rxConfig->rx_spi_protocol);
 

--- a/src/main/rx/nrf24_kn.h
+++ b/src/main/rx/nrf24_kn.h
@@ -25,6 +25,6 @@
 
 struct rxConfig_s;
 struct rxRuntimeState_s;
-bool knNrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool knNrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void knNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e knNrf24DataReceived(uint8_t *payload);

--- a/src/main/rx/nrf24_syma.c
+++ b/src/main/rx/nrf24_syma.c
@@ -299,8 +299,10 @@ static void symaNrf24Setup(rx_spi_protocol_e protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-bool symaNrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState)
+bool symaNrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxRuntimeState->channelCount = RC_CHANNEL_COUNT;
     symaNrf24Setup((rx_spi_protocol_e)rxSpiConfig->rx_spi_protocol);
 

--- a/src/main/rx/nrf24_syma.h
+++ b/src/main/rx/nrf24_syma.h
@@ -25,7 +25,7 @@
 
 struct rxSpiConfig_s;
 struct rxRuntimeState_s;
-bool symaNrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool symaNrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void symaNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e symaNrf24DataReceived(uint8_t *payload);
 

--- a/src/main/rx/nrf24_v202.c
+++ b/src/main/rx/nrf24_v202.c
@@ -259,8 +259,10 @@ static void v202Nrf24Setup(rx_spi_protocol_e protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-bool v202Nrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState)
+bool v202Nrf24Init(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeState, rxSpiExtiConfig_t *extiConfig)
 {
+    UNUSED(extiConfig);
+
     rxRuntimeState->channelCount = V2X2_RC_CHANNEL_COUNT;
     v202Nrf24Setup((rx_spi_protocol_e)rxSpiConfig->rx_spi_protocol);
 

--- a/src/main/rx/nrf24_v202.h
+++ b/src/main/rx/nrf24_v202.h
@@ -25,6 +25,6 @@
 
 struct rxSpiConfig_s;
 struct rxRuntimeState_s;
-bool v202Nrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState);
+bool v202Nrf24Init(const struct rxSpiConfig_s *rxSpiConfig, struct rxRuntimeState_s *rxRuntimeState, rxSpiExtiConfig_t *extiConfig);
 void v202Nrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 rx_spi_received_e v202Nrf24DataReceived(uint8_t *payload);

--- a/src/main/rx/rx_spi.h
+++ b/src/main/rx/rx_spi.h
@@ -20,9 +20,12 @@
 
 #pragma once
 
+#include "drivers/exti.h"
+
 #include "pg/rx.h"
-#include "rx/rx.h"
 #include "pg/rx_spi.h"
+
+#include "rx/rx.h"
 
 // Used in MSP. Append at end.
 typedef enum {
@@ -73,6 +76,11 @@ typedef enum {
     RC_SPI_AUX13,
     RC_SPI_AUX14
 } rc_spi_aetr_e;
+
+typedef struct {
+    ioConfig_t ioConfig;
+    extiTrigger_t trigger;
+} rxSpiExtiConfig_t;
 
 // RC channels as used by deviation
 #define RC_CHANNEL_RATE        RC_SPI_AUX1

--- a/src/test/unit/rx_spi_spektrum_unittest.cc
+++ b/src/test/unit/rx_spi_spektrum_unittest.cc
@@ -86,6 +86,7 @@ extern "C" {
 
     static const dsmReceiver_t empty = dsmReceiver_t();
     static rxRuntimeState_t config = rxRuntimeState_t();
+    static rxSpiExtiConfig_t extiConfig;
     static uint8_t packetLen;
     static uint8_t packet[16];
     static uint16_t rssi = 0;
@@ -142,7 +143,7 @@ extern "C" {
 TEST(RxSpiSpektrumUnitTest, TestInitUnbound)
 {
     dsmReceiver = empty;
-    spektrumSpiInit(&injectedConfig, &config);
+    spektrumSpiInit(&injectedConfig, &config, &extiConfig);
     EXPECT_FALSE(dsmReceiver.bound);
     EXPECT_EQ(DSM_RECEIVER_BIND, dsmReceiver.status);
     EXPECT_EQ(DSM_INITIAL_BIND_CHANNEL, dsmReceiver.rfChannel);
@@ -160,7 +161,7 @@ TEST(RxSpiSpektrumUnitTest, TestInitBound)
 
     spektrumConfigMutable()->protocol = DSMX_11;
 
-    bool result = spektrumSpiInit(&injectedConfig, &config);
+    bool result = spektrumSpiInit(&injectedConfig, &config, &extiConfig);
 
     EXPECT_TRUE(result);
     EXPECT_TRUE(dsmReceiver.bound);
@@ -180,7 +181,7 @@ TEST(RxSpiSpektrumUnitTest, TestInitBound)
     dsmReceiver = empty;
     spektrumConfigMutable()->protocol = DSM2_11;
 
-    spektrumSpiInit(&injectedConfig, &config);
+    spektrumSpiInit(&injectedConfig, &config, &extiConfig);
 
     EXPECT_TRUE(dsmReceiver.bound);
     EXPECT_EQ(DSM2_11, dsmReceiver.protocol);
@@ -388,8 +389,9 @@ extern "C" {
     void rxSpiCommonIOInit(const rxSpiConfig_t *) {}
     void rxSpiLedBlinkRxLoss(rx_spi_received_e ) {}
     void rxSpiLedBlinkBind(void) {};
-    bool rxSpiCheckBindRequested(bool )
+    bool rxSpiCheckBindRequested(bool)
     {
         return false;
     }
+    bool rxSpiExtiConfigured(void) { return true; }
 }


### PR DESCRIPTION
Also adds support for protocol level receiver frame rate measurement.

Tested with FrSky, needs testing for FlySky, Spektrum.