### PR TITLE
Add support for exiting serial passthrough mode

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -58,6 +58,7 @@ COMMON_SRC = \
             io/beeper.c \
             io/piniobox.c \
             io/serial.c \
+            io/serial_command_interpreter.c \
             io/smartaudio_protocol.c \
             io/statusindicator.c \
             io/tramp_protocol.c \

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1500,10 +1500,10 @@ static void cliSerialPassthrough(char *cmdline)
 
     char *resetMessage = "";
     if (port1ResetOnDtr && ports[1].id == SERIAL_PORT_USB_VCP) {
-        resetMessage = "or drop DTR ";
+        resetMessage = ", or drop DTR ";
     }
 
-    cliPrintLinef("Forwarding, power cycle %sto exit.", resetMessage);
+    cliPrintLinef("Forwarding. Power cycle, or use +++ (pause) ATH %sto exit.", resetMessage);
 
     if ((ports[1].id == SERIAL_PORT_USB_VCP) && (port1ResetOnDtr
 #ifdef USE_PINIO
@@ -1541,6 +1541,7 @@ static void cliSerialPassthrough(char *cmdline)
 #endif
 
     serialPassthrough(ports[0].port, ports[1].port, NULL, NULL);
+    cliPrintLinef("Exited serial passthrough");
 }
 #endif
 

--- a/src/main/io/serial_command_interpreter.c
+++ b/src/main/io/serial_command_interpreter.c
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Cleanflight, Betaflight and INAV
+ *
+ * Cleanflight, Betaflight and INAV are free software. You can
+ * redistribute this software and/or modify this software under
+ * the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Cleanflight, Betaflight and INAV are distributed in the hope that
+ * they will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ctype.h>
+
+#include "platform.h"
+
+#include "io/serial_command_interpreter.h"
+
+#define PAUSE_INTERVAL_MS_MIN 1000
+
+void serialCommandInterpreterInit(serialCommandInterpreter_t *interpreter)
+{
+    interpreter->lastByteMs = 0;
+    interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_IDLE;
+}
+
+serialCommandInterpreterResult_e serialCommandInterpreterUpdate(serialCommandInterpreter_t *interpreter, uint8_t c)
+{
+    serialCommandInterpreterResult_e result = SERIAL_COMMAND_INTERPRETER_RESULT_NONE;
+    timeMs_t now = millis();
+    switch (interpreter->state) {
+    case SERIAL_COMMAND_INTERPRETER_STATE_IDLE:
+        if (c == '+' && now - interpreter->lastByteMs >= PAUSE_INTERVAL_MS_MIN) {
+            interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_PLUS_ONE;
+        }
+        break;
+    case SERIAL_COMMAND_INTERPRETER_STATE_PLUS_ONE:
+    case SERIAL_COMMAND_INTERPRETER_STATE_PLUS_TWO:
+        if (c == '+' && now - interpreter->lastByteMs < PAUSE_INTERVAL_MS_MIN) {
+            interpreter->state++;
+            break;
+        }
+        interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_IDLE;
+        break;
+    case SERIAL_COMMAND_INTERPRETER_STATE_PLUS_THREE:
+    case SERIAL_COMMAND_INTERPRETER_STATE_PLUS_THREE_WHITESPACE:
+        // We might be in command mode here. Ignore one whitespace to let the user
+        // input the command via the configurator CLI.
+        if (isspace(c) && interpreter->state == SERIAL_COMMAND_INTERPRETER_STATE_PLUS_THREE) {
+            interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_PLUS_THREE_WHITESPACE;
+            break;
+        }
+        if (now - interpreter->lastByteMs >= PAUSE_INTERVAL_MS_MIN) {
+            if (c == 'A') {
+                interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_A;
+                result = SERIAL_COMMAND_INTERPRETER_RESULT_USED;
+                break;
+            }
+        }
+        interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_IDLE;
+        break;
+    case SERIAL_COMMAND_INTERPRETER_STATE_A:
+        if (c == 'T') {
+            interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_T;
+            result = SERIAL_COMMAND_INTERPRETER_RESULT_USED;
+            break;
+        }
+        interpreter->state = SERIAL_COMMAND_INTERPRETER_STATE_IDLE;
+        break;
+    case SERIAL_COMMAND_INTERPRETER_STATE_T:
+        switch (c) {
+        case 'H':
+            result = SERIAL_COMMAND_INTERPRETER_RESULT_HANG;
+            break;
+        }
+        break;
+    }
+    interpreter->lastByteMs = now;
+    return result;
+}

--- a/src/main/io/serial_command_interpreter.h
+++ b/src/main/io/serial_command_interpreter.h
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Cleanflight, Betaflight and INAV
+ *
+ * Cleanflight, Betaflight and INAV are free software. You can
+ * redistribute this software and/or modify this software under
+ * the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Cleanflight, Betaflight and INAV are distributed in the hope that
+ * they will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "drivers/time.h"
+
+typedef enum {
+    SERIAL_COMMAND_INTERPRETER_STATE_IDLE,
+    SERIAL_COMMAND_INTERPRETER_STATE_PLUS_ONE,
+    SERIAL_COMMAND_INTERPRETER_STATE_PLUS_TWO,
+    SERIAL_COMMAND_INTERPRETER_STATE_PLUS_THREE,
+    SERIAL_COMMAND_INTERPRETER_STATE_PLUS_THREE_WHITESPACE,
+    SERIAL_COMMAND_INTERPRETER_STATE_A,
+    SERIAL_COMMAND_INTERPRETER_STATE_T,
+} serialCommandInterpreterState_e;
+
+typedef enum {
+    SERIAL_COMMAND_INTERPRETER_RESULT_NONE,
+    SERIAL_COMMAND_INTERPRETER_RESULT_USED,
+    SERIAL_COMMAND_INTERPRETER_RESULT_HANG,
+} serialCommandInterpreterResult_e;
+
+typedef struct serialCommandInterpreter_s {
+    timeMs_t lastByteMs;
+    serialCommandInterpreterState_e state;
+} serialCommandInterpreter_t;
+
+void serialCommandInterpreterInit(serialCommandInterpreter_t *interpreter);
+serialCommandInterpreterResult_e serialCommandInterpreterUpdate(serialCommandInterpreter_t *interpreter, uint8_t c);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -165,6 +165,7 @@ gps_conversion_unittest_SRC := \
 
 io_serial_unittest_SRC := \
 		$(USER_DIR)/io/serial.c \
+		$(USER_DIR)/io/serial_command_interpreter.c \
 		$(USER_DIR)/drivers/serial_pinconfig.c
 
 

--- a/src/test/unit/io_serial_unittest.cc
+++ b/src/test/unit/io_serial_unittest.cc
@@ -26,6 +26,7 @@ extern "C" {
     #include "drivers/serial.h"
     #include "drivers/serial_softserial.h"
     #include "drivers/serial_uart.h"
+    #include "drivers/time.h"
 
     #include "io/serial.h"
 
@@ -56,6 +57,8 @@ TEST(IoSerialTest, TestFindPortConfig)
 
 // STUBS
 extern "C" {
+    timeMs_t millis(void) { return 0; }
+
     void delay(uint32_t) {}
 
     bool isSerialTransmitBufferEmpty(const serialPort_t *) { return true; }


### PR DESCRIPTION
Use the hayes escape sequence +++ (sent with at least one second
of line silence before and after) to trigger command mode.

For now, only the ATH command is supported, which stops the serial
passthrough and returns to what started it.

e.g. to exit serial passthrough a client must send the following
sequence:

(wait >= 1s)'+++'(wait >= 1s) 'ATH'

This sequence can be manually entered easily.