### PR TITLE
Add support for serial passthrough via MSP

### DIFF
--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -336,7 +336,7 @@
 #define MSP_SET_ACC_TRIM         239    //in message          set acc angle trim values
 #define MSP_SERVO_MIX_RULES      241    //out message         Returns servo mixer configuration
 #define MSP_SET_SERVO_MIX_RULE   242    //in message          Sets servo mixer configuration
-#define MSP_SET_4WAY_IF          245    //in message          Sets 4way interface
+#define MSP_SET_PASSTHROUGH      245    //in message          Sets up passthrough to different peripherals (4way interface, uart, etc...)
 #define MSP_SET_RTC              246    //in message          Sets the RTC clock
 #define MSP_RTC                  247    //out message         Gets the RTC clock
 #define MSP_SET_BOARD_INFO       248    //in message          Sets the board information for this board


### PR DESCRIPTION
- Rename MSP_SET_4WAY_IF to MSP_SET_PASSTHROUGH
- Keep backwards compatibility with existing uses of the command
- Add 2 new values for the passthrough mode: one that sets up
a serial port given its ID and another one that sets it up from
a function ID.