### PR TITLE
Fix ESC protocol startup after rearranging MSP/OSD/CMS init

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -904,11 +904,6 @@ void init(void)
     rcdeviceInit();
 #endif // USE_RCDEVICE
 
-#ifdef USE_MOTOR
-    motorPostInit();
-    motorEnable();
-#endif
-
 #ifdef USE_PERSISTENT_STATS
     statsInit();
 #endif
@@ -1001,6 +996,11 @@ void init(void)
 #endif
 
     setArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
+
+#ifdef USE_MOTOR
+    motorPostInit();
+    motorEnable();
+#endif
 
     tasksInit();
 


### PR DESCRIPTION
Fixes double ESC initialization caused by signal interruptions inadvertently caused by reordering the startup processing in #9258 
