### PR TITLE
Reset protocol level RX frame delta after reading

### DIFF
--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -91,7 +91,7 @@ static uint8_t jetiExBusChannelFrame[EXBUS_MAX_CHANNEL_FRAME_SIZE];
 uint8_t jetiExBusRequestFrame[EXBUS_MAX_REQUEST_FRAME_SIZE];
 
 static uint16_t jetiExBusChannelData[JETIEXBUS_CHANNEL_COUNT];
-static timeDelta_t lastFrameDelta = 0;
+static timeUs_t lastRcFrameTimeUs = 0;
 
 // Jeti Ex Bus CRC calculations for a frame
 uint16_t jetiExBusCalcCRC16(uint8_t *pt, uint8_t msgLen)
@@ -154,7 +154,6 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
 
     static timeUs_t jetiExBusTimeLast = 0;
     static uint8_t *jetiExBusFrame;
-    static timeUs_t lastFrameCompleteTimeUs = 0;
     const timeUs_t now = microsISR();
 
     // Check if we shall reset frame position due to time
@@ -211,8 +210,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
         if (jetiExBusFrameState == EXBUS_STATE_IN_PROGRESS)
             jetiExBusFrameState = EXBUS_STATE_RECEIVED;
         if (jetiExBusRequestState == EXBUS_STATE_IN_PROGRESS) {
-            lastFrameDelta = cmpTimeUs(now, lastFrameCompleteTimeUs);
-            lastFrameCompleteTimeUs = now;
+            lastRcFrameTimeUs = now;
             jetiExBusRequestState = EXBUS_STATE_RECEIVED;
             jetiTimeStampRequest = now;
         }
@@ -226,17 +224,19 @@ static uint8_t jetiExBusFrameStatus(rxRuntimeState_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
 
-    if (jetiExBusFrameState != EXBUS_STATE_RECEIVED)
-        return RX_FRAME_PENDING;
+    uint8_t frameStatus = RX_FRAME_PENDING;
 
-    if (jetiExBusCalcCRC16(jetiExBusChannelFrame, jetiExBusChannelFrame[EXBUS_HEADER_MSG_LEN]) == 0) {
-        jetiExBusDecodeChannelFrame(jetiExBusChannelFrame);
+    if (jetiExBusFrameState == EXBUS_STATE_RECEIVED) {
+        if (jetiExBusCalcCRC16(jetiExBusChannelFrame, jetiExBusChannelFrame[EXBUS_HEADER_MSG_LEN]) == 0) {
+            jetiExBusDecodeChannelFrame(jetiExBusChannelFrame);
+            frameStatus = RX_FRAME_COMPLETE;
+        } else {
+            lastRcFrameTimeUs = 0;  // We received a frame but it wasn't valid new channel data
+        }
         jetiExBusFrameState = EXBUS_STATE_ZERO;
-        return RX_FRAME_COMPLETE;
-    } else {
-        jetiExBusFrameState = EXBUS_STATE_ZERO;
-        return RX_FRAME_PENDING;
     }
+
+    return frameStatus;
 }
 
 static uint16_t jetiExBusReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan)
@@ -247,9 +247,11 @@ static uint16_t jetiExBusReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8
     return (jetiExBusChannelData[chan]);
 }
 
-static timeDelta_t jetiExBusFrameDelta(void)
+static timeUs_t jetiExBusFrameTimeUs(void)
 {
-    return lastFrameDelta;
+    const timeUs_t result = lastRcFrameTimeUs;
+    lastRcFrameTimeUs = 0;
+    return result;
 }
 
 bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
@@ -261,7 +263,7 @@ bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = jetiExBusReadRawRC;
     rxRuntimeState->rcFrameStatusFn = jetiExBusFrameStatus;
-    rxRuntimeState->rcFrameDeltaFn = jetiExBusFrameDelta;
+    rxRuntimeState->rcFrameTimeUsFn = jetiExBusFrameTimeUs;
 
     jetiExBusFrameReset();
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -865,9 +865,19 @@ bool isRssiConfigured(void)
 
 bool rxGetFrameDelta(timeDelta_t *deltaUs)
 {
-    if (rxRuntimeState.rcFrameDeltaFn) {
-        *deltaUs = rxRuntimeState.rcFrameDeltaFn();
-        return true;
+    static timeUs_t previousFrameTimeUs = 0;
+    bool result = false;
+
+    *deltaUs = 0;
+    if (rxRuntimeState.rcFrameTimeUsFn) {
+        const timeUs_t frameTimeUs = rxRuntimeState.rcFrameTimeUsFn();
+        if (frameTimeUs) {
+            if (previousFrameTimeUs) {
+                *deltaUs = cmpTimeUs(frameTimeUs, previousFrameTimeUs);
+                result = true;
+            }
+            previousFrameTimeUs = frameTimeUs;
+        }
     }
-    return false;  // No frame delta function available for protocol type
+    return result;  // No frame delta function available for protocol type or frames have stopped
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -125,7 +125,7 @@ struct rxRuntimeState_s;
 typedef uint16_t (*rcReadRawDataFnPtr)(const struct rxRuntimeState_s *rxRuntimeState, uint8_t chan); // used by receiver driver to return channel data
 typedef uint8_t (*rcFrameStatusFnPtr)(struct rxRuntimeState_s *rxRuntimeState);
 typedef bool (*rcProcessFrameFnPtr)(const struct rxRuntimeState_s *rxRuntimeState);
-typedef timeDelta_t (*rcGetFrameDeltaFnPtr)(void);  // used to retrieve the time interval in microseconds for the last channel data frame
+typedef timeUs_t (*rcGetFrameTimeUsFnPtr)(void);  // used to retrieve the timestamp in microseconds for the last channel data frame
 
 typedef enum {
     RX_PROVIDER_NONE = 0,
@@ -144,7 +144,7 @@ typedef struct rxRuntimeState_s {
     rcReadRawDataFnPtr  rcReadRawFn;
     rcFrameStatusFnPtr  rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
-    rcGetFrameDeltaFnPtr rcFrameDeltaFn;
+    rcGetFrameTimeUsFnPtr rcFrameTimeUsFn;
     uint16_t            *channelData;
     void                *frameData;
 } rxRuntimeState_t;

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -108,12 +108,11 @@ typedef struct sbusFrameData_s {
     bool done;
 } sbusFrameData_t;
 
-static timeDelta_t lastFrameDelta = 0;
+static timeUs_t lastRcFrameTimeUs = 0;
 
 // Receive ISR callback
 static void sbusDataReceive(uint16_t c, void *data)
 {
-    static timeUs_t lastFrameCompleteTimeUs = 0;
     sbusFrameData_t *sbusFrameData = data;
 
     const timeUs_t nowUs = microsISR();
@@ -136,8 +135,7 @@ static void sbusDataReceive(uint16_t c, void *data)
         if (sbusFrameData->position < SBUS_FRAME_SIZE) {
             sbusFrameData->done = false;
         } else {
-            lastFrameDelta = cmpTimeUs(nowUs, lastFrameCompleteTimeUs);
-            lastFrameCompleteTimeUs = nowUs;
+            lastRcFrameTimeUs = nowUs;
             sbusFrameData->done = true;
             DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_FRAME_TIME, sbusFrameTime);
         }
@@ -154,12 +152,19 @@ static uint8_t sbusFrameStatus(rxRuntimeState_t *rxRuntimeState)
 
     DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_FRAME_FLAGS, sbusFrameData->frame.frame.channels.flags);
 
-    return sbusChannelsDecode(rxRuntimeState, &sbusFrameData->frame.frame.channels);
+    const uint8_t frameStatus = sbusChannelsDecode(rxRuntimeState, &sbusFrameData->frame.frame.channels);
+
+    if (frameStatus != RX_FRAME_COMPLETE) {
+        lastRcFrameTimeUs = 0;  // We received a frame but it wasn't valid new channel data
+    }
+    return frameStatus;
 }
 
-static timeDelta_t sbusFrameDelta(void)
+static timeUs_t sbusFrameTimeUs(void)
 {
-    return lastFrameDelta;
+    const timeUs_t result = lastRcFrameTimeUs;
+    lastRcFrameTimeUs = 0;
+    return result;
 }
 
 bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
@@ -183,7 +188,7 @@ bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     }
 
     rxRuntimeState->rcFrameStatusFn = sbusFrameStatus;
-    rxRuntimeState->rcFrameDeltaFn = sbusFrameDelta;
+    rxRuntimeState->rcFrameTimeUsFn = sbusFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -75,7 +75,7 @@ static uint16_t crc;
 
 static uint8_t sumd[SUMD_BUFFSIZE] = { 0, };
 static uint8_t sumdChannelCount;
-static timeDelta_t lastFrameDelta = 0;
+static timeUs_t lastRcFrameTimeUs = 0;
 
 // Receive ISR callback
 static void sumdDataReceive(uint16_t c, void *data)
@@ -84,7 +84,6 @@ static void sumdDataReceive(uint16_t c, void *data)
 
     static timeUs_t sumdTimeLast;
     static uint8_t sumdIndex;
-    static timeUs_t lastFrameCompleteTimeUs = 0;
 
     const timeUs_t sumdTime = microsISR();
     if (cmpTimeUs(sumdTime, sumdTimeLast) > SUMD_TIME_NEEDED_PER_FRAME) {
@@ -111,8 +110,7 @@ static void sumdDataReceive(uint16_t c, void *data)
     if (sumdIndex <= sumdChannelCount * SUMD_BYTES_PER_CHANNEL + SUMD_HEADER_LENGTH) {
         crc = crc16_ccitt(crc, (uint8_t)c);
     } else if (sumdIndex == sumdChannelCount * SUMD_BYTES_PER_CHANNEL + SUMD_HEADER_LENGTH + SUMD_CRC_LENGTH) {
-        lastFrameDelta = cmpTimeUs(sumdTime, lastFrameCompleteTimeUs);
-        lastFrameCompleteTimeUs = sumdTime;
+        lastRcFrameTimeUs = sumdTime;
         sumdIndex = 0;
         sumdFrameDone = true;
     }
@@ -131,31 +129,35 @@ static uint8_t sumdFrameStatus(rxRuntimeState_t *rxRuntimeState)
     sumdFrameDone = false;
 
     // verify CRC
-    if (crc != ((sumd[SUMD_BYTES_PER_CHANNEL * sumdChannelCount + SUMD_OFFSET_CHANNEL_1_HIGH] << 8) |
+    if (crc == ((sumd[SUMD_BYTES_PER_CHANNEL * sumdChannelCount + SUMD_OFFSET_CHANNEL_1_HIGH] << 8) |
             (sumd[SUMD_BYTES_PER_CHANNEL * sumdChannelCount + SUMD_OFFSET_CHANNEL_1_LOW]))) {
-        return frameStatus;
+
+        switch (sumd[1]) {
+        case SUMD_FRAME_STATE_FAILSAFE:
+            frameStatus = RX_FRAME_COMPLETE | RX_FRAME_FAILSAFE;
+            break;
+        case SUMDV1_FRAME_STATE_OK:
+        case SUMDV3_FRAME_STATE_OK:
+            frameStatus = RX_FRAME_COMPLETE;
+            break;
+        }
+
+        if (frameStatus & RX_FRAME_COMPLETE) {
+            const unsigned channelsToProcess = MIN(sumdChannelCount, MAX_SUPPORTED_RC_CHANNEL_COUNT);
+
+            for (unsigned channelIndex = 0; channelIndex < channelsToProcess; channelIndex++) {
+                sumdChannels[channelIndex] = (
+                    (sumd[SUMD_BYTES_PER_CHANNEL * channelIndex + SUMD_OFFSET_CHANNEL_1_HIGH] << 8) |
+                    sumd[SUMD_BYTES_PER_CHANNEL * channelIndex + SUMD_OFFSET_CHANNEL_1_LOW]
+                );
+            }
+        }
     }
 
-    switch (sumd[1]) {
-    case SUMD_FRAME_STATE_FAILSAFE:
-        frameStatus = RX_FRAME_COMPLETE | RX_FRAME_FAILSAFE;
-        break;
-    case SUMDV1_FRAME_STATE_OK:
-    case SUMDV3_FRAME_STATE_OK:
-        frameStatus = RX_FRAME_COMPLETE;
-        break;
-    default:
-        return frameStatus;
+    if (frameStatus != RX_FRAME_COMPLETE) {
+        lastRcFrameTimeUs = 0;  // We received a frame but it wasn't valid new channel data
     }
 
-    const unsigned channelsToProcess = MIN(sumdChannelCount, MAX_SUPPORTED_RC_CHANNEL_COUNT);
-
-    for (unsigned channelIndex = 0; channelIndex < channelsToProcess; channelIndex++) {
-        sumdChannels[channelIndex] = (
-            (sumd[SUMD_BYTES_PER_CHANNEL * channelIndex + SUMD_OFFSET_CHANNEL_1_HIGH] << 8) |
-            sumd[SUMD_BYTES_PER_CHANNEL * channelIndex + SUMD_OFFSET_CHANNEL_1_LOW]
-        );
-    }
     return frameStatus;
 }
 
@@ -165,9 +167,11 @@ static uint16_t sumdReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t ch
     return sumdChannels[chan] / 8;
 }
 
-static timeDelta_t sumdFrameDelta(void)
+static timeUs_t sumdFrameTimeUs(void)
 {
-    return lastFrameDelta;
+    const timeUs_t result = lastRcFrameTimeUs;
+    lastRcFrameTimeUs = 0;
+    return result;
 }
 
 bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
@@ -179,7 +183,7 @@ bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = sumdReadRawRC;
     rxRuntimeState->rcFrameStatusFn = sumdFrameStatus;
-    rxRuntimeState->rcFrameDeltaFn = sumdFrameDelta;
+    rxRuntimeState->rcFrameTimeUsFn = sumdFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {


### PR DESCRIPTION
Handle cases where the protocol stops processing valid frames. Before this fix the last valid frame interval would continue to be reported if no more valid frames were received. No calculation will fallback to the interval measured in the RX task which will ultimately get set to the max task interval (when no data is received) or 30ms.
