### PR TITLE
Fix undefined reference to mag when USE_MAG isn't defined

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -216,7 +216,7 @@ static float invSqrt(float x)
 
 static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
                                 bool useAcc, float ax, float ay, float az,
-                                bool useMag, float mx, float my, float mz,
+                                bool useMag,
                                 bool useCOG, float courseOverGround, const float dcmKpGain)
 {
     static float integralFBx = 0.0f,  integralFBy = 0.0f, integralFBz = 0.0f;    // integral error terms scaled by Ki
@@ -244,6 +244,9 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
 
 #ifdef USE_MAG
     // Use measured magnetic field vector
+    float mx = mag.magADC[X];
+    float my = mag.magADC[Y];
+    float mz = mag.magADC[Z];
     float recipMagNorm = sq(mx) + sq(my) + sq(mz);
     if (useMag && recipMagNorm > 0.01f) {
         // Normalise magnetometer measurement
@@ -271,9 +274,6 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
     }
 #else
     UNUSED(useMag);
-    UNUSED(mx);
-    UNUSED(my);
-    UNUSED(mz);
 #endif
 
     // Use measured acceleration vector
@@ -553,7 +553,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     imuMahonyAHRSupdate(deltaT * 1e-6f,
                         DEGREES_TO_RADIANS(gyroAverage[X]), DEGREES_TO_RADIANS(gyroAverage[Y]), DEGREES_TO_RADIANS(gyroAverage[Z]),
                         useAcc, accAverage[X], accAverage[Y], accAverage[Z],
-                        useMag, mag.magADC[X], mag.magADC[Y], mag.magADC[Z],
+                        useMag,
                         useCOG, courseOverGround,  imuCalcKpGain(currentTimeUs, useAcc, gyroAverage));
 
     imuUpdateEulerAngles();


### PR DESCRIPTION
The `mag` variable is defined as an `extern` in compass.h but the implementation in compass.c is bounded by `#ifdef USE_MAG`. So if `USE_MAG` is not defined then the `mag` variable is an undefined reference.

In imu.c the `imuMahonyAHRSupdate()` function was being passed the elements of `mag` unconditionally like `mag.magADC[X]` so in the case that `USE_MAG` wasn't defined these were invalid null references. Luckily the logic in `imuMahonyAHRSupdate()` was properly bounded so that it never tried to access these variables. But in the case of a debug build the linker is unable to build a reference to these variables since they're never defined and the compile fails.

Credit to @kmitchel for finding.
