### PR TITLE
SRXL2 frame drops reported more appropriately

### DIFF
--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -177,7 +177,7 @@ void srxl2ProcessChannelData(const Srxl2ChannelDataHeader* channelData, rxRuntim
 
     //If receiver is in a connected state, and a packet is missed, the channel mask will be 0.
     if (!channelData->channelMask.u32) {
-        globalResult |= RX_FRAME_FAILSAFE;
+        globalResult |= RX_FRAME_DROPPED;
         return;
     }
 


### PR DESCRIPTION
Was discussing with @etracer65 , and  he pointed out that frame drops should be reported as drops instead of failsafe. After some review, we determined that this technically didn't have any adverse effects on the FC behavior, but it would be better either way to distinguish between receiver frame drops and failsafe properly.