### PR TITLE
Fix "may be used uninitialized" debug build warnings

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5737,7 +5737,7 @@ static void cliTimer(char *cmdline)
 
     pch = strtok_r(NULL, " ", &saveptr);
     if (pch) {
-        int timerIndex;
+        int timerIndex = TIMER_INDEX_UNDEFINED;
         if (strcasecmp(pch, "list") == 0) {
             /* output the list of available options */
             const timerHardware_t *timer;
@@ -5751,8 +5751,6 @@ static void cliTimer(char *cmdline)
             }
 
             return;
-        } else if (strcasecmp(pch, "none") == 0) {
-            timerIndex = TIMER_INDEX_UNDEFINED;
         } else if (strncasecmp(pch, "af", 2) == 0) {
             unsigned alternateFunction = atoi(&pch[2]);
 
@@ -5770,7 +5768,7 @@ static void cliTimer(char *cmdline)
 
                 return;
             }
-        } else {
+        } else if (strcasecmp(pch, "none") != 0) {
             timerIndex = atoi(pch);
 
             const timerHardware_t *timer = timerGetByTagAndIndex(ioTag, timerIndex + 1);

--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -117,14 +117,15 @@ static void buildTelemetryFrame(uint8_t *packet)
 {
     uint8_t a1Value;
     switch (rxCc2500SpiConfig()->a1Source) {
-    case FRSKY_SPI_A1_SOURCE_VBAT:
-        a1Value = (getBatteryVoltage() / 5) & 0xff;
-        break;
     case FRSKY_SPI_A1_SOURCE_EXTADC:
         a1Value = (adcGetChannel(ADC_EXTERNAL1) & 0xff0) >> 4;
         break;
     case FRSKY_SPI_A1_SOURCE_CONST:
         a1Value = A1_CONST_D & 0xff;
+        break;
+    case FRSKY_SPI_A1_SOURCE_VBAT:
+    default:
+        a1Value = (getBatteryVoltage() / 5) & 0xff;
         break;
     }
     const uint8_t a2Value = (adcGetChannel(ADC_RSSI)) >> 4;

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -206,14 +206,15 @@ static void buildTelemetryFrame(uint8_t *packet)
     } else {
         uint8_t a1Value;
         switch (rxCc2500SpiConfig()->a1Source) {
-        case FRSKY_SPI_A1_SOURCE_VBAT:
-            a1Value = getLegacyBatteryVoltage() & 0x7f;
-            break;
         case FRSKY_SPI_A1_SOURCE_EXTADC:
             a1Value = (uint8_t)((adcGetChannel(ADC_EXTERNAL1) & 0xfe0) >> 5);
             break;
         case FRSKY_SPI_A1_SOURCE_CONST:
             a1Value = A1_CONST_X & 0x7f;
+            break;
+        case FRSKY_SPI_A1_SOURCE_VBAT:
+        default:
+            a1Value = getLegacyBatteryVoltage() & 0x7f;
             break;
         }
         frame[4] = a1Value;


### PR DESCRIPTION
None of the warnings were actual problems - just false alarms.