### PR TITLE
set gps-rescue altitude to FIXED_ALT

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -174,7 +174,7 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .useMag = GPS_RESCUE_USE_MAG,
     .targetLandingAltitudeM = 5,
     .targetLandingDistanceM = 10,
-    .altitudeMode = MAX_ALT,
+    .altitudeMode = FIXED_ALT,
     .ascendRate = 500,
     .descendRate = 150,
 );


### PR DESCRIPTION
Many users expect that the quad returns to the altitude set with `gps_rescue_initial_alt`