### PR TITLE
[MSP] Add support for MSP2_COMMON_SERIAL_CONFIG / MSP2_COMMON_SET_SERIAL_CONFIG

### DIFF
--- a/src/main/msp/msp_protocol_v2_common.h
+++ b/src/main/msp/msp_protocol_v2_common.h
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Cleanflight, Betaflight and INAV.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight, Betaflight and INAV are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define MSP2_COMMON_SERIAL_CONFIG       0x1009
+#define MSP2_COMMON_SET_SERIAL_CONFIG   0x100A


### PR DESCRIPTION
This allows retrieving ports with functionMask with values >= (1 << 16)
while still keeping MSP_CF_SERIAL_CONFIG / MSP_SET_CF_SERIAL_CONFIG
backwards compatible.

The new handler includes the port count at the start of the frame, so
the per-port data size can be extended in a backwards compatible way
in the future.