### PR TITLE
[MSP] Correctly report the configured and active OSD type

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -921,6 +921,7 @@ void init(void)
 
 #if (defined(USE_OSD) || (defined(USE_MSP_DISPLAYPORT) && defined(USE_CMS)))
     displayPort_t *osdDisplayPort = NULL;
+    osdDisplayPortDevice_e osdDisplayPortDevice = OSD_DISPLAYPORT_DEVICE_NONE;
 #endif
 
 #if defined(USE_OSD)
@@ -941,6 +942,7 @@ void init(void)
         case OSD_DISPLAYPORT_DEVICE_FRSKYOSD:
             osdDisplayPort = frskyOsdDisplayPortInit(vcdProfile()->video_system);
             if (osdDisplayPort || device == OSD_DISPLAYPORT_DEVICE_FRSKYOSD) {
+                osdDisplayPortDevice = OSD_DISPLAYPORT_DEVICE_FRSKYOSD;
                 break;
             }
             FALLTHROUGH;
@@ -951,6 +953,7 @@ void init(void)
             // If there is a max7456 chip for the OSD configured and detectd then use it.
             osdDisplayPort = max7456DisplayPortInit(vcdProfile());
             if (osdDisplayPort || device == OSD_DISPLAYPORT_DEVICE_MAX7456) {
+                osdDisplayPortDevice = OSD_DISPLAYPORT_DEVICE_MAX7456;
                 break;
             }
             FALLTHROUGH;
@@ -960,6 +963,7 @@ void init(void)
         case OSD_DISPLAYPORT_DEVICE_MSP:
             osdDisplayPort = displayPortMspInit();
             if (osdDisplayPort || device == OSD_DISPLAYPORT_DEVICE_MSP) {
+                osdDisplayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
                 break;
             }
             FALLTHROUGH;
@@ -973,7 +977,7 @@ void init(void)
         }
 
         // osdInit will register with CMS by itself.
-        osdInit(osdDisplayPort);
+        osdInit(osdDisplayPort, osdDisplayPortDevice);
     }
 #endif // USE_OSD
 

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -164,6 +164,13 @@ static bool writeFontCharacter(displayPort_t *instance, uint16_t addr, const osd
     return max7456WriteNvm(addr, (const uint8_t *)chr);
 }
 
+static bool isReady(displayPort_t *instance)
+{
+    UNUSED(instance);
+
+    return max7456IsDeviceDetected();
+}
+
 static const displayPortVTable_t max7456VTable = {
     .grab = grab,
     .release = release,
@@ -181,6 +188,7 @@ static const displayPortVTable_t max7456VTable = {
     .layerSelect = layerSelect,
     .layerCopy = layerCopy,
     .writeFontCharacter = writeFontCharacter,
+    .isReady = isReady,
 };
 
 displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile)

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -126,6 +126,7 @@ static uint8_t armState;
 static uint8_t osdProfile = 1;
 #endif
 static displayPort_t *osdDisplayPort;
+static osdDisplayPortDevice_e osdDisplayPortDevice;
 static bool osdIsReady;
 
 static bool suppressStatsDisplay = false;
@@ -408,13 +409,14 @@ static void osdCompleteInitialization(void)
     osdIsReady = true;
 }
 
-void osdInit(displayPort_t *osdDisplayPortToUse)
+void osdInit(displayPort_t *osdDisplayPortToUse, osdDisplayPortDevice_e displayPortDeviceToUse)
 {
     if (!osdDisplayPortToUse) {
         return;
     }
 
     osdDisplayPort = osdDisplayPortToUse;
+    osdDisplayPortDevice = displayPortDeviceToUse;
 #ifdef USE_CMS
     cmsDisplayPortRegister(osdDisplayPort);
 #endif
@@ -1042,8 +1044,11 @@ bool osdNeedsAccelerometer(void)
 }
 #endif // USE_ACC
 
-displayPort_t *osdGetDisplayPort(void)
+displayPort_t *osdGetDisplayPort(osdDisplayPortDevice_e *displayPortDevice)
 {
+    if (displayPortDevice) {
+        *displayPortDevice = osdDisplayPortDevice;
+    }
     return osdDisplayPort;
 }
 

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -320,7 +320,7 @@ extern escSensorData_t *osdEscDataCombined;
 #endif
 
 struct displayPort_s;
-void osdInit(struct displayPort_s *osdDisplayPort);
+void osdInit(struct displayPort_s *osdDisplayPort, osdDisplayPortDevice_e displayPortDevice);
 bool osdInitialized(void);
 void osdUpdate(timeUs_t currentTimeUs);
 void osdStatSetState(uint8_t statIndex, bool enabled);
@@ -336,4 +336,4 @@ bool osdElementVisible(uint16_t value);
 bool osdGetVisualBeeperState(void);
 statistic_t *osdGetStats(void);
 bool osdNeedsAccelerometer(void);
-struct displayPort_s *osdGetDisplayPort(void);
+struct displayPort_s *osdGetDisplayPort(osdDisplayPortDevice_e *displayPortDevice);

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -200,7 +200,7 @@ TEST(LQTest, TestInit)
 
     // when
     // OSD is initialised
-    osdInit(&testDisplayPort);
+    osdInit(&testDisplayPort, OSD_DISPLAYPORT_DEVICE_AUTO);
 
     // then
     // display buffer should contain splash screen

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -223,7 +223,7 @@ TEST(OsdTest, TestInit)
 
     // when
     // OSD is initialised
-    osdInit(&testDisplayPort);
+    osdInit(&testDisplayPort, OSD_DISPLAYPORT_DEVICE_AUTO);
 
     // then
     // display buffer should contain splash screen


### PR DESCRIPTION
- Tell the OSD driver the type of displayPort, so it can be retrieved
later.
- Use OSD driver code instead of device specific code to handle
MSP_OSD_CONFIG response while minimizing driver specific code.
- Add flag for signaling the use of FrSky OSD (bit 3).
- Rename OSD_FLAGS_MAX7456_DETECTED to OSD_FLAGS_OSD_DEVICE_DETECTED.
Since we only support one OSD device type at a time, we can use the
same bit to signal wether the hardware has been detected.