### PR TITLE
fixed CLI segfault when no USE_OSD is set

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1379,11 +1379,11 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_gps_sats_show_hdop",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, gps_sats_show_hdop) },
     { "osd_displayport_device",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OSD_DISPLAYPORT_DEVICE }, PG_OSD_CONFIG, offsetof(osdConfig_t, displayPortDevice) },
-#endif
 
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
     { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
     { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
+#endif // end of #ifdef USE_OSD
 
 // PG_SYSTEM_CONFIG
 #if defined(STM32F4)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -56,6 +56,7 @@
     If the new element utilizes the accelerometer, add it to the osdElementsNeedAccelerometer() function.
 
     Finally add a CLI parameter for the new element in cli/settings.c.
+    CLI parameters should be added before line #endif // end of #ifdef USE_OSD
 */
 
 #include <stdbool.h>


### PR DESCRIPTION
Some OSD-related cli settings was not placed under #ifdef USE_OSD and caused segfault in SITL target when entering CLI tab in configurator.


