### PR TITLE
Dterm dynamic lowpass filter configurable curve

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -994,6 +994,7 @@ const clivalue_t valueTable[] = {
 #ifdef USE_DYN_LPF
     { "dyn_lpf_dterm_min_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_min_hz) },
     { "dyn_lpf_dterm_max_hz",       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_dterm_max_hz) },
+    { "dyn_lpf_dterm_curve_expo",   VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 10 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_lpf_curve_expo) },
 #endif
     { "dterm_lowpass_type",         VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DTERM_LOWPASS_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_filter_type) },
     { "dterm_lowpass_hz",           VAR_INT16  | PROFILE_VALUE, .config.minmax = { 0, FILTER_FREQUENCY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_lowpass_hz) },

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -185,6 +185,7 @@ typedef struct pidProfile_s {
     uint8_t ff_max_rate_limit;              // Maximum setpoint rate percentage for FF
     uint8_t ff_spike_limit;                 // FF stick extrapolation lookahead period in ms
     uint8_t ff_smooth_factor;               // Amount of smoothing for interpolated FF steps
+    uint8_t dyn_lpf_curve_expo;             // set the curve for dynamic dterm lowpass filter
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -264,3 +265,4 @@ float pidGetPidFrequency();
 float pidGetFfBoostFactor();
 float pidGetFfSmoothFactor();
 float pidGetSpikeLimitInverse();
+float dynDtermLpfCutoffFreq(float throttle, uint16_t dynLpfMin, uint16_t dynLpfMax, uint8_t expo);


### PR DESCRIPTION
This PR adds a configurable curve to calculate the dynamic dterm cutoff frequency.
In detail it applies a curve to the throttle and then scales the result between minimum and maximum lowpass frequency, in my tests this allows to increase  the cutoff frequency earlier and decrease the overall latency for better propwash handling even at low throttle (compared to current code).

It is enabled with `dyn_lpf_dterm_curve_expo = 1 - 10`

This is how current curve works(with default filter settings):
![current](https://user-images.githubusercontent.com/25136267/72378535-e25def00-3711-11ea-8204-1d5556f1f23c.jpg)

this is with curve enabled with 1:
![min](https://user-images.githubusercontent.com/25136267/72378583-f6a1ec00-3711-11ea-9551-25254bfcce17.jpg)

this is with medium setting:
![medium](https://user-images.githubusercontent.com/25136267/72378595-002b5400-3712-11ea-95fc-b9b924933934.jpg)
this is at max setting:
![max](https://user-images.githubusercontent.com/25136267/72378618-07eaf880-3712-11ea-9ab7-9d1e01b382e6.jpg)


