### PR TITLE
[H7] Fix ADC DMA buffer transposing bug

### DIFF
--- a/src/main/drivers/adc_stm32h7xx.c
+++ b/src/main/drivers/adc_stm32h7xx.c
@@ -453,7 +453,9 @@ void adcGetChannelValues(void)
     // Cache coherency should be maintained by MPU facility
 
     for (int i = 0; i < ADC_CHANNEL_INTERNAL; i++) {
-        adcValues[i] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
+        if (adcOperatingConfig[i].enabled) {
+            adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #9344

EDIT
This bug probably needs some explanation.
As H7's DMA buffer coherency management is done with MPU regions, it is necessary to attribute DMA buffer as appropriate. When I've done this, I somehow came to believe that `drivers/adc.c` should be free from DMA details and decided NOT to attribute `adcValues` as DMA buffers, and transposing be done in H7 specific code (hence the current implementation of `adcGetChannelValues()` that transpose elements). The actual transposing is done in `adcGetChannel()` in `drivers/adc.c`, which resulted in extra transposing. This PR removes the extra transposing in `adcGetChannelValues()` and just do a active element transfer, but a better solution may be to attribute `adcValues` as DMA buffer and remove `adcGetChannelValues()` woes (which actually is inefficient as it is called for each separate value is requested by `adcGetChannel()`).