### PR TITLE
[G4] Handle symbol collisions for universal EXTI wrapper

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -138,7 +138,7 @@ static void mpuIntExtiInit(gyroDev_t *gyro)
 
     IOInit(mpuIntIO, OWNER_GYRO_EXTI, 0);
     EXTIHandlerInit(&gyro->exti, mpuIntExtiHandler);
-    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_RISING);
+    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO, true);
 }
 #endif // USE_GYRO_EXTI

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -252,7 +252,7 @@ static void bmi160IntExtiInit(gyroDev_t *gyro)
 
     IOInit(mpuIntIO, OWNER_GYRO_EXTI, 0);
     EXTIHandlerInit(&gyro->exti, bmi160ExtiHandler);
-    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_RISING); // TODO - maybe pullup / pulldown ?
+    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING); // TODO - maybe pullup / pulldown ?
     EXTIEnable(mpuIntIO, true);
 }
 #endif

--- a/src/main/drivers/accgyro/accgyro_spi_l3gd20.c
+++ b/src/main/drivers/accgyro/accgyro_spi_l3gd20.c
@@ -91,7 +91,7 @@ static void l3gd20IntExtiInit(gyroDev_t *gyro)
 
     IOInit(mpuIntIO, OWNER_GYRO_EXTI, 0);
     EXTIHandlerInit(&gyro->exti, l3gd20ExtiHandler);
-    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_RISING);
+    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO, true);
 }
 #endif

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -166,7 +166,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro)
     eocIO = IOGetByTag(config->eocTag);
     IOInit(eocIO, OWNER_BARO_EOC, 0);
     EXTIHandlerInit(&exti, bmp085ExtiHandler);
-    EXTIConfig(eocIO, &exti, NVIC_PRIO_BARO_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_RISING);
+    EXTIConfig(eocIO, &exti, NVIC_PRIO_BARO_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(eocIO, true);
 #else
     UNUSED(config);

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -235,7 +235,7 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
     if (baroIntIO) {
         IOInit(baroIntIO, OWNER_BARO_EOC, 0);
         EXTIHandlerInit(&baro->exti, bmp388_extiHandler);
-        EXTIConfig(baroIntIO, &baro->exti, NVIC_PRIO_BARO_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_RISING);
+        EXTIConfig(baroIntIO, &baro->exti, NVIC_PRIO_BARO_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
         EXTIEnable(baroIntIO, true);
     }
 #else

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -174,7 +174,7 @@ static void hmc5883lConfigureDataReadyInterruptHandling(magDev_t* mag)
 
     IOInit(magIntIO, OWNER_COMPASS_EXTI, 0);
     EXTIHandlerInit(&mag->exti, hmc5883_extiHandler);
-    EXTIConfig(magIntIO, &mag->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_RISING);
+    EXTIConfig(magIntIO, &mag->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(magIntIO, true);
     EXTIEnable(magIntIO, true);
 #else

--- a/src/main/drivers/exti.c
+++ b/src/main/drivers/exti.c
@@ -68,13 +68,13 @@ static const uint8_t extiGroupIRQn[EXTI_IRQ_GROUPS] = {
 
 static uint32_t triggerLookupTable[] = {
 #if defined(STM32F7) || defined(STM32H7)
-    [EXTI_TRIGGER_RISING] = GPIO_MODE_IT_RISING,
-    [EXTI_TRIGGER_FALLING] = GPIO_MODE_IT_FALLING,
-    [EXTI_TRIGGER_BOTH] = GPIO_MODE_IT_RISING_FALLING
+    [BETAFLIGHT_EXTI_TRIGGER_RISING] = GPIO_MODE_IT_RISING,
+    [BETAFLIGHT_EXTI_TRIGGER_FALLING] = GPIO_MODE_IT_FALLING,
+    [BETAFLIGHT_EXTI_TRIGGER_BOTH] = GPIO_MODE_IT_RISING_FALLING
 #elif defined(STM32F1) || defined(STM32F3) || defined(STM32F4)
-    [EXTI_TRIGGER_RISING] = EXTI_Trigger_Rising,
-    [EXTI_TRIGGER_FALLING] = EXTI_Trigger_Falling,
-    [EXTI_TRIGGER_BOTH] = EXTI_Trigger_Rising_Falling
+    [BETAFLIGHT_EXTI_TRIGGER_RISING] = EXTI_Trigger_Rising,
+    [BETAFLIGHT_EXTI_TRIGGER_FALLING] = EXTI_Trigger_Falling,
+    [BETAFLIGHT_EXTI_TRIGGER_BOTH] = EXTI_Trigger_Rising_Falling
 #else
 # warning "Unknown CPU"
 #endif

--- a/src/main/drivers/exti.h
+++ b/src/main/drivers/exti.h
@@ -25,9 +25,9 @@
 #include "drivers/io_types.h"
 
 typedef enum {
-    EXTI_TRIGGER_RISING = 0,
-    EXTI_TRIGGER_FALLING = 1,
-    EXTI_TRIGGER_BOTH = 2
+    BETAFLIGHT_EXTI_TRIGGER_RISING = 0,
+    BETAFLIGHT_EXTI_TRIGGER_FALLING = 1,
+    BETAFLIGHT_EXTI_TRIGGER_BOTH = 2
 } extiTrigger_t;
 
 typedef struct extiCallbackRec_s extiCallbackRec_t;

--- a/src/main/drivers/rangefinder/rangefinder_hcsr04.c
+++ b/src/main/drivers/rangefinder/rangefinder_hcsr04.c
@@ -203,7 +203,7 @@ bool hcsr04Detect(rangefinderDev_t *dev, const sonarConfig_t * rangefinderHardwa
         // Hardware detected - configure the driver
 #ifdef USE_EXTI
         EXTIHandlerInit(&hcsr04_extiCallbackRec, hcsr04_extiHandler);
-        EXTIConfig(echoIO, &hcsr04_extiCallbackRec, NVIC_PRIO_SONAR_EXTI, IOCFG_IN_FLOATING, EXTI_TRIGGER_BOTH); // TODO - priority!
+        EXTIConfig(echoIO, &hcsr04_extiCallbackRec, NVIC_PRIO_SONAR_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_BOTH); // TODO - priority!
         EXTIEnable(echoIO, true);
 #endif
 

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -107,7 +107,7 @@ bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig)
 void rxSpiExtiInit(ioConfig_t rxSpiExtiPinConfig, extiTrigger_t rxSpiExtiPinTrigger)
 {
     if (extiPin) {
-        if (rxSpiExtiPinTrigger == EXTI_TRIGGER_FALLING) {
+        if (rxSpiExtiPinTrigger == BETAFLIGHT_EXTI_TRIGGER_FALLING) {
             extiLevel = false;
         }
         EXTIHandlerInit(&rxSpiExtiCallbackRec, rxSpiExtiHandler);

--- a/src/main/rx/a7105_flysky.c
+++ b/src/main/rx/a7105_flysky.c
@@ -366,7 +366,7 @@ bool flySkyInit(const rxSpiConfig_t *rxSpiConfig, struct rxRuntimeState_s *rxRun
     rxSpiCommonIOInit(rxSpiConfig);
 
     extiConfig->ioConfig = IOCFG_IPD;
-    extiConfig->trigger = EXTI_TRIGGER_RISING;
+    extiConfig->trigger = BETAFLIGHT_EXTI_TRIGGER_RISING;
 
     uint8_t startRxChannel;
 

--- a/src/main/rx/cyrf6936_spektrum.c
+++ b/src/main/rx/cyrf6936_spektrum.c
@@ -387,7 +387,7 @@ bool spektrumSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeState
     rxRuntimeState->channelCount = DSM_MAX_CHANNEL_COUNT;
 
     extiConfig->ioConfig = IOCFG_IPD;
-    extiConfig->trigger = EXTI_TRIGGER_FALLING;
+    extiConfig->trigger = BETAFLIGHT_EXTI_TRIGGER_FALLING;
 
     if (!cyrf6936Init()) {
         return false;

--- a/src/main/rx/rx_spi.c
+++ b/src/main/rx/rx_spi.c
@@ -233,7 +233,7 @@ bool rxSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeStat
 
     rxSpiExtiConfig_t extiConfig = {
         .ioConfig = IOCFG_IN_FLOATING,
-        .trigger = EXTI_TRIGGER_RISING,
+        .trigger = BETAFLIGHT_EXTI_TRIGGER_RISING,
     };
 
     ret = protocolInit(rxSpiConfig, rxRuntimeState, &extiConfig);


### PR DESCRIPTION
Symbols `EXTI_TRIGGER_xxx` are now used in HAL libraries.
Replacing them with `UEXTI_TRIGGER_xxx`.

Any good idea to prevent users of `EXTIxxx` services from mistakenly use `EXTI_TRIGGER_xxx`?