### PR TITLE
Fix CMS Menu Navigation

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -902,11 +902,10 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, cms_key_e key)
     if ((key == CMS_KEY_UP) && (!osdElementEditing)) {
         currentCtx.cursorRow--;
 
-        // Skip non-title labels
-        if ((pageTop + currentCtx.cursorRow)->type == OME_Label && currentCtx.cursorRow > 0) {
+        // Skip non-title labels and strings
+        while (((pageTop + currentCtx.cursorRow)->type == OME_Label || (pageTop + currentCtx.cursorRow)->type == OME_String) && currentCtx.cursorRow > 0) {
             currentCtx.cursorRow--;
         }
-
         if (currentCtx.cursorRow == -1 || (pageTop + currentCtx.cursorRow)->type == OME_Label) {
             // Goto previous page
             cmsPagePrev(pDisplay);


### PR DESCRIPTION
I have fixed a navigation bug through the CMS menu, located in the UP skipment of Labels or Strings. The loop created for `KEY_DOWN` requires a loop in `KEY_UP` to work correctly. Thanks @mikeller for guiding me with this fix.