### PR TITLE
Handle unused pin state at the end of initialization

### DIFF
--- a/src/main/drivers/system_stm32f10x.c
+++ b/src/main/drivers/system_stm32f10x.c
@@ -67,16 +67,6 @@ static void checkForBootLoaderRequest(void)
 
 void enableGPIOPowerUsageAndNoiseReductions(void)
 {
-    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC, ENABLE);
-
-    GPIO_InitTypeDef GPIO_InitStructure = {
-        .GPIO_Mode = GPIO_Mode_AIN,
-        .GPIO_Pin = GPIO_Pin_All
-    };
-
-    GPIO_Init(GPIOA, &GPIO_InitStructure);
-    GPIO_Init(GPIOB, &GPIO_InitStructure);
-    GPIO_Init(GPIOC, &GPIO_InitStructure);
 }
 
 bool isMPUSoftReset(void)

--- a/src/main/drivers/system_stm32f30x.c
+++ b/src/main/drivers/system_stm32f30x.c
@@ -57,31 +57,6 @@ void systemResetToBootloader(bootloaderRequestType_e requestType)
 
 void enableGPIOPowerUsageAndNoiseReductions(void)
 {
-    RCC_AHBPeriphClockCmd(
-        RCC_AHBPeriph_GPIOA |
-        RCC_AHBPeriph_GPIOB |
-        RCC_AHBPeriph_GPIOC |
-        RCC_AHBPeriph_GPIOD |
-        RCC_AHBPeriph_GPIOE |
-        RCC_AHBPeriph_GPIOF,
-        ENABLE
-    );
-
-    GPIO_InitTypeDef GPIO_InitStructure = {
-        .GPIO_Mode = GPIO_Mode_AN,
-        .GPIO_OType = GPIO_OType_OD,
-        .GPIO_PuPd = GPIO_PuPd_NOPULL
-    };
-
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_All & ~(GPIO_Pin_13 | GPIO_Pin_14 | GPIO_Pin_15);  // Leave JTAG pins alone
-    GPIO_Init(GPIOA, &GPIO_InitStructure);
-
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_All;
-    GPIO_Init(GPIOB, &GPIO_InitStructure);
-    GPIO_Init(GPIOC, &GPIO_InitStructure);
-    GPIO_Init(GPIOD, &GPIO_InitStructure);
-    GPIO_Init(GPIOE, &GPIO_InitStructure);
-    GPIO_Init(GPIOF, &GPIO_InitStructure);
 }
 
 bool isMPUSoftReset(void)

--- a/src/main/drivers/system_stm32f4xx.c
+++ b/src/main/drivers/system_stm32f4xx.c
@@ -81,19 +81,6 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
 {
 
     RCC_AHB1PeriphClockCmd(
-        RCC_AHB1Periph_GPIOA |
-        RCC_AHB1Periph_GPIOB |
-        RCC_AHB1Periph_GPIOC |
-        RCC_AHB1Periph_GPIOD |
-        RCC_AHB1Periph_GPIOE |
-#ifdef STM32F40_41xxx
-        RCC_AHB1Periph_GPIOF |
-        RCC_AHB1Periph_GPIOG |
-        RCC_AHB1Periph_GPIOH |
-        RCC_AHB1Periph_GPIOI |
-#endif
-        RCC_AHB1Periph_CRC |
-        RCC_AHB1Periph_FLITF |
         RCC_AHB1Periph_SRAM1 |
         RCC_AHB1Periph_SRAM2 |
         RCC_AHB1Periph_BKPSRAM |
@@ -148,32 +135,6 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
         RCC_APB2Periph_TIM10 |
         RCC_APB2Periph_TIM11 |
         0, ENABLE);
-
-    GPIO_InitTypeDef GPIO_InitStructure;
-    GPIO_StructInit(&GPIO_InitStructure);
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP; // default is un-pulled input
-
-    GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
-    GPIO_InitStructure.GPIO_Pin &= ~(GPIO_Pin_11 | GPIO_Pin_12); // leave USB D+/D- alone
-
-    GPIO_InitStructure.GPIO_Pin &= ~(GPIO_Pin_13 | GPIO_Pin_14); // leave JTAG pins alone
-    GPIO_Init(GPIOA, &GPIO_InitStructure);
-
-    GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
-    GPIO_Init(GPIOB, &GPIO_InitStructure);
-
-    GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
-    GPIO_Init(GPIOC, &GPIO_InitStructure);
-    GPIO_Init(GPIOD, &GPIO_InitStructure);
-    GPIO_Init(GPIOE, &GPIO_InitStructure);
-
-#ifdef STM32F40_41xxx
-    GPIO_Init(GPIOF, &GPIO_InitStructure);
-    GPIO_Init(GPIOG, &GPIO_InitStructure);
-    GPIO_Init(GPIOH, &GPIO_InitStructure);
-    GPIO_Init(GPIOI, &GPIO_InitStructure);
-#endif
-
 }
 
 bool isMPUSoftReset(void)


### PR DESCRIPTION
Treatment of unused pins are moved to the end of system initialization for F4 (and F1 and F3). This will help peripherals that are sensitive to pin levels being high for a while during power on initialization period.

F7 and H7 actually did not have any pin initialization at the beginning of the system initialization, so this PR will add it.