### PR TITLE
Antigravity gain decoupled from Iterm

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -274,7 +274,7 @@ static void checkForThrottleErrorResetState(uint16_t rxRefreshRate)
         if (ABS(rcCommandSpeed) > throttleVelocityThreshold) {
             pidSetItermAccelerator(CONVERT_PARAMETER_TO_FLOAT(currentPidProfile->itermAcceleratorGain));
         } else {
-            pidSetItermAccelerator(1.0f);
+            pidSetItermAccelerator(0.0f);
         }
     }
 }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -82,7 +82,7 @@ static FAST_RAM_ZERO_INIT float pidFrequency;
 static FAST_RAM_ZERO_INIT uint8_t antiGravityMode;
 static FAST_RAM_ZERO_INIT float antiGravityThrottleHpf;
 static FAST_RAM_ZERO_INIT uint16_t itermAcceleratorGain;
-static FAST_RAM float antiGravityOsdCutoff = 0.0f;
+static FAST_RAM_ZERO_INIT float antiGravityOsdCutoff;
 static FAST_RAM_ZERO_INIT bool antiGravityEnabled;
 static FAST_RAM_ZERO_INIT bool zeroThrottleItermReset;
 
@@ -242,7 +242,7 @@ static void pidSetTargetLooptime(uint32_t pidLooptime)
 #endif
 }
 
-static FAST_RAM float itermAccelerator = 0.0f;
+static FAST_RAM_ZERO_INIT float itermAccelerator;
 
 void pidSetItermAccelerator(float newItermAccelerator)
 {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1422,7 +1422,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 #else
         const float Ki = pidCoefficient[axis].Ki;
 #endif
-        pidData[axis].I = constrainf(previousIterm + Ki * itermErrorRate * dynCi + agGain * itermErrorRate, -itermLimit, itermLimit);
+        pidData[axis].I = constrainf(previousIterm + (Ki * dynCi + agGain) * itermErrorRate, -itermLimit, itermLimit);
 
         // -----calculate pidSetpointDelta
         float pidSetpointDelta = 0;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -48,6 +48,9 @@
 #define ITERM_RELAX_SETPOINT_THRESHOLD 40.0f
 #define ITERM_RELAX_CUTOFF_DEFAULT 20
 
+// Anti gravity I constant
+#define AG_KI 21.586988f;
+
 typedef enum {
     PID_ROLL,
     PID_PITCH,


### PR DESCRIPTION
As requested https://github.com/betaflight/betaflight/issues/9283 antigravity decoupled from iterm, `AG_KI` is calculated from current default iterm (85,90,90 averaged and multiplied per `ITERM_SCALE`)