### PR TITLE
Improve duplicate packet handling

### DIFF
--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -90,7 +90,8 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
                     holdCount[axis] = 1;
                 } else {
                     // type 2 = small change, no interpolation needed
-                    setpointSpeedModified = prevSetpointSpeed[axis];
+                    setpointSpeedModified = 0.0f;
+                    setpointSpeed = setpointSpeed / 2.0f;
                     holdCount[axis] = 2;
                 }
             } else {
@@ -106,12 +107,11 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
                     // interpolation was applied
                     // raw setpoint speed of next 'good' packet is twice what it should be
                     setpointSpeedModified = setpointSpeed / 2.0f;
+                    setpointSpeed = setpointSpeedModified;
                     // empirically this works best
                     setpointAccelerationModified = (prevAcceleration[axis] + setpointAcceleration) / 2.0f;
                 } else if (holdCount[axis] == 2) {
                     // interpolation was not applied
-                    setpointSpeedModified = setpointSpeed / 2.0f;
-                    setpointAccelerationModified = prevAcceleration[axis] / 2.0f;
                 } else if (holdCount[axis] == 3) {
                     // after persistent flat period or recent big step up, no boost
                     // reduces jitter from boost when flying smoothly

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -28,8 +28,6 @@
 #include "fc/rc.h"
 #include "flight/interpolated_setpoint.h"
 
-#define PREV_BIG_STEP 1000.0f //threshold for size of jump of packet before the identical data packet
-
 static float setpointDeltaImpl[XYZ_AXIS_COUNT];
 static float setpointDelta[XYZ_AXIS_COUNT];
 static uint8_t holdCount[XYZ_AXIS_COUNT];
@@ -65,67 +63,95 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
 
     if (newRcFrame) {
         float rawSetpoint = getRawSetpoint(axis); 
-        
+
         const float rxInterval = currentRxRefreshRate * 1e-6f;
         const float rxRate = 1.0f / rxInterval;
-
         float setpointSpeed = (rawSetpoint - prevRawSetpoint[axis]) * rxRate;
         float setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];
-        const uint8_t holdSteps = 2;
+        float setpointSpeedModified = setpointSpeed;
+        float setpointAccelerationModified = setpointAcceleration;
 
         // Glitch reduction code for identical packets
+        if (fabsf(setpointAcceleration) > 3.0f * fabsf(prevAcceleration[axis])) {
+            bigStep[axis] = true;
+        } else {
+            bigStep[axis] = false;
+        }
+
         if (setpointSpeed == 0 && fabsf(rawSetpoint) < 0.98f * ffMaxRate[axis]) {
-            // identical packets, not at full deflection
-            if (holdCount[axis] < holdSteps && fabsf(rawSetpoint) > 2.0f && !bigStep[axis]) {
-                // holding the entire previous speed is best for missed packets, but bad for early packets
-                setpointSpeed = prevSetpointSpeed[axis] + prevAcceleration[axis];
-                setpointAcceleration = prevAcceleration[axis];
-                holdCount[axis] += 1;
+            // identical packet detected, not at full deflection.  
+            // first packet on leaving full deflection always gets full FF
+            if (holdCount[axis] == 0) {
+                // previous packet had movement
+                if (bigStep[axis]) {
+                    // type 1 = interpolate forward where acceleration change is large
+                    setpointSpeedModified = prevSetpointSpeed[axis];
+                    setpointAccelerationModified = prevAcceleration[axis];
+                    holdCount[axis] = 1;
+                } else {
+                    // type 2 = small change, no interpolation needed
+                    setpointSpeedModified = prevSetpointSpeed[axis];
+                    holdCount[axis] = 2;
+                }
             } else {
-                // identical packets for more than hold steps, or prev big step
-                // lock acceleration to zero and don't interpolate forward until sticks move again
-                holdCount[axis] = holdSteps + 1;
-                setpointAcceleration = 0.0f;
+                // it is an unchanged packet after previous unchanged packet
+                // speed and acceleration will be zero, no need to change anything
+                holdCount[axis] = 3;
             }
         } else {
             // we're moving, or sticks are at max
-            if (holdCount[axis] == 2) {
-                // we are after an identical packet, and the one before was a normal step up,
-                // so raw step speed and acceleration of next 'good' packet is twice what it should be
-                setpointSpeed /= 2.0f;
-                setpointAcceleration /= 2.0f;
-            }
-            if (holdCount[axis] == 3) {
-                // we are starting to move after a gap after a big step up, or persistent flat period, so accelerate gently
-                setpointAcceleration = 0.0f;
-            }
-            holdCount[axis] = 1;
-            if (fabsf(setpointAcceleration - prevAcceleration[axis]) > PREV_BIG_STEP) {
-                bigStep[axis] = true;
-            } else {
-                bigStep[axis] = false;
+            if (holdCount[axis] != 0) {
+                // previous step was a duplicate, handle each type differently
+                if (holdCount[axis] == 1) {
+                    // interpolation was applied
+                    // raw setpoint speed of next 'good' packet is twice what it should be
+                    setpointSpeedModified = setpointSpeed / 2.0f;
+                    // empirically this works best
+                    setpointAccelerationModified = (prevAcceleration[axis] + setpointAcceleration) / 2.0f;
+                } else if (holdCount[axis] == 2) {
+                    // interpolation was not applied
+                    setpointSpeedModified = setpointSpeed / 2.0f;
+                    setpointAccelerationModified = prevAcceleration[axis] / 2.0f;
+                } else if (holdCount[axis] == 3) {
+                    // after persistent flat period or recent big step up, no boost
+                    // reduces jitter from boost when flying smoothly
+                    // WARNING: this means no boost if ADC is active on FrSky radios
+                    setpointAccelerationModified = 0.0f;
+                }
+                holdCount[axis] = 0;
             }
         }
 
+        // smooth deadband type suppression of FF when sticks are centred.
+        const float rawSetpointCentred = fabsf(rawSetpoint) / 2.0f;
+        if (rawSetpointCentred < 1.0f) {
+            // force zero FF when sticks are centred for smoothness
+            setpointSpeedModified *= rawSetpointCentred;
+            setpointAccelerationModified *= rawSetpointCentred;
+        }
+
+        setpointDeltaImpl[axis] = setpointSpeedModified * pidGetDT();
         prevAcceleration[axis] = setpointAcceleration;
+
         setpointAcceleration *= pidGetDT();
-        setpointDeltaImpl[axis] = setpointSpeed * pidGetDT();
+        setpointAccelerationModified *= pidGetDT();
 
         const float ffBoostFactor = pidGetFfBoostFactor();
         float clip = 1.0f;
         float boostAmount = 0.0f;
-        if (axis != FD_YAW && ffBoostFactor != 0.0f) {
+        if (ffBoostFactor != 0.0f) {
+            //calculate clip factor to reduce boost on big spikes
             if (pidGetSpikeLimitInverse()) {
                 clip = 1 / (1 + (setpointAcceleration * setpointAcceleration * pidGetSpikeLimitInverse()));
                 clip *= clip;
             }
-            // prevent kick-back spike at max deflection
-            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis] || fabsf(setpointSpeed) > 3.0f * fabsf(prevSetpointSpeed[axis])) {
-                boostAmount = ffBoostFactor * setpointAcceleration;
-            }
-            // no clip for first step inwards from max deflection
+            // don't clip first step inwards from max deflection
             if (fabsf(prevRawSetpoint[axis]) > 0.95f * ffMaxRate[axis] && fabsf(setpointSpeed) > 3.0f * fabsf(prevSetpointSpeed[axis])) {
                 clip = 1.0f;
+            }
+            // calculate boost and prevent kick-back spike at max deflection
+            if (fabsf(rawSetpoint) < 0.95f * ffMaxRate[axis] || fabsf(setpointSpeed) > 3.0f * fabsf(prevSetpointSpeed[axis])) {
+                boostAmount = ffBoostFactor * setpointAccelerationModified;
             }
         }
 
@@ -133,14 +159,15 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
         prevRawSetpoint[axis] = rawSetpoint;
 
         if (axis == FD_ROLL) {
-            DEBUG_SET(DEBUG_FF_INTERPOLATED, 0, setpointDeltaImpl[axis] * 1000);
-            DEBUG_SET(DEBUG_FF_INTERPOLATED, 1, boostAmount * 1000);
-            DEBUG_SET(DEBUG_FF_INTERPOLATED, 2, bigStep[axis]);
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 0, lrintf(setpointDeltaImpl[axis] * 100));
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 1, lrintf(setpointAccelerationModified * 100));
+            DEBUG_SET(DEBUG_FF_INTERPOLATED, 2, lrintf(setpointAcceleration * 100));
             DEBUG_SET(DEBUG_FF_INTERPOLATED, 3, holdCount[axis]);
         }
 
         setpointDeltaImpl[axis] += boostAmount * clip;
-        // first order filter FF
+
+        // first order (kind of) smoothing of FF
         const float ffSmoothFactor = pidGetFfSmoothFactor();
         setpointDeltaImpl[axis] = prevDeltaImpl[axis] + ffSmoothFactor * (setpointDeltaImpl[axis] - prevDeltaImpl[axis]);
         prevDeltaImpl[axis] = setpointDeltaImpl[axis];

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -128,6 +128,7 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
             // force zero FF when sticks are centred for smoothness
             setpointSpeedModified *= rawSetpointCentred;
             setpointAccelerationModified *= rawSetpointCentred;
+            holdCount[axis] = 4;
         }
 
         setpointDeltaImpl[axis] = setpointSpeedModified * pidGetDT();


### PR DESCRIPTION
This is a set of small changes and a code tidy up for interpolated feed forward.

The main intent was to reduce feed forward amplification of errors arising from duplicate packets.  The previous code wasn't ideal and led to amplification of RC jitter in some situations.

I have recently done a lot of testing both on CRSF and FrSky setups and there is no doubt that these changes are a small but useful improvement.

Overall result is a smoother and more appropriate interpolated FF response.

Summary of changes:
- identify different types of duplicate packets
- handle each error differently
- respond to a duplicate packet and the packet after that.
- careful empirical checking that the responses are optimal and neutral
- provide boost for yaw
- smoothly attenuate FF to zero when sticks are very close to centre
- updated code annotations for clarity

The debug remains FF_INTERPOLATED.  In the debug:

`holdCount`is currently indicated as 'Clip' in BBE, and is as follows:
0 = RC packet data changed this packet, ie normal
1 = RC packet has data identical to previous packet.  Benefits from forward interpolation because it is likely a simple miss.
2 = Identical RC data.  Isn't interpolated because it is likely an excessively large 'early' packet
3 = multiple duplicate RC packets.

`Setpoint Delta Impl` holds the setpoint derivative value (simple FF) before adding boost or smoothing.

Debugs 1 and 2 hold modified and un-modified boost amounts, showing how the glitch attenuation methods vary the amount of boost.