### PR TITLE
Fix tasks check function max time not being reset along with other stats

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4762,6 +4762,7 @@ static void cliTasks(char *cmdline)
         getCheckFuncInfo(&checkFuncInfo);
         cliPrintLinef("RX Check Function %19d %7d %25d", checkFuncInfo.maxExecutionTime, checkFuncInfo.averageExecutionTime, checkFuncInfo.totalExecutionTime / 1000);
         cliPrintLinef("Total (excluding SERIAL) %25d.%1d%% %4d.%1d%%", maxLoadSum/10, maxLoadSum%10, averageLoadSum/10, averageLoadSum%10);
+        schedulerResetCheckFunctionMaxExecutionTime();
     }
 }
 #endif

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -243,6 +243,13 @@ void schedulerResetTaskMaxExecutionTime(cfTaskId_e taskId)
 #endif
 }
 
+#if defined(USE_TASK_STATISTICS)
+void schedulerResetCheckFunctionMaxExecutionTime(void)
+{
+    checkFuncMaxExecutionTime = 0;
+}
+#endif
+
 void schedulerInit(void)
 {
     calculateTaskStatistics = true;

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -184,6 +184,7 @@ timeDelta_t getTaskDeltaTime(cfTaskId_e taskId);
 void schedulerSetCalulateTaskStatistics(bool calculateTaskStatistics);
 void schedulerResetTaskStatistics(cfTaskId_e taskId);
 void schedulerResetTaskMaxExecutionTime(cfTaskId_e taskId);
+void schedulerResetCheckFunctionMaxExecutionTime(void);
 
 void schedulerInit(void);
 void scheduler(void);

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -310,6 +310,7 @@ const char *armingDisableFlagNames[]= {
 void getTaskInfo(cfTaskId_e, cfTaskInfo_t *) {}
 void getCheckFuncInfo(cfCheckFuncInfo_t *) {}
 void schedulerResetTaskMaxExecutionTime(cfTaskId_e) {}
+void schedulerResetCheckFunctionMaxExecutionTime(void) {}
 
 const char * const targetName = "UNITTEST";
 const char* const buildDate = "Jan 01 2017";


### PR DESCRIPTION
Each time the `tasks` CLI command is executed the task stats are reset to allow the max to represent the data since the last `tasks` command. However the task check function stats were not being reset so the "max" for the RX check function would represent the maximum value since boot.

Example before:
```
23 - (       PINIOBOX)     19       2       1    0.5%    0.5%         0
RX Check Function              234211       5                       235
```

Example after:
```
23 - (       PINIOBOX)     19       2       1    0.5%    0.5%         0
RX Check Function                  15       5                       239
```
