### PR TITLE
Fixed initialisation of unused pins on STM32F411.

### DIFF
--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -154,8 +154,10 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM9, CH2, PE6, TIM_USE_ANY, 0, 0),
 
 //PORTF
+#if !defined(STM32F411xE)
     DEF_TIM(TIM10, CH1, PF6, TIM_USE_ANY, 0, 0),
     DEF_TIM(TIM11, CH1, PF7, TIM_USE_ANY, 0, 0),
+#endif
 
 //PORTH
 // Port H is not available for LPQFP-100 or 144 package

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -47,4 +47,3 @@
 #define TARGET_IO_PORTC 0xffff
 #define TARGET_IO_PORTD 0xffff
 #define TARGET_IO_PORTE 0xffff
-#define TARGET_IO_PORTF 0xffff


### PR DESCRIPTION
:sweat_smile:

Turns out initialising pins that are not even supported by the MCU type is not a good idea.