### PR TITLE
Exclude SWD pins from being initialised as pull up if unused.

### DIFF
--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -108,4 +108,5 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "PULLUP",
     "PULLDOWN",
     "DSHOT_BITBANG",
+    "SWD",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -106,6 +106,7 @@ typedef enum {
     OWNER_PULLUP,
     OWNER_PULLDOWN,
     OWNER_DSHOT_BITBANG,
+    OWNER_SWD,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -273,14 +273,14 @@ void initialiseMemorySections(void)
 #endif
 }
 
-static void initializeUnusedPin(IO_t io)
+static void unusedPinInit(IO_t io)
 {
     if (IOGetOwner(io) == OWNER_FREE) {
         IOConfigGPIO(io, IOCFG_IPU);
     }
 }
 
-void initializeUnusedPins(void)
+void unusedPinsInit(void)
 {
-    IOTraversePins(initializeUnusedPin);
+    IOTraversePins(unusedPinInit);
 }

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -83,4 +83,4 @@ typedef void extiCallbackHandlerFunc(void);
 
 void registerExtiCallbackHandler(IRQn_Type irqn, extiCallbackHandlerFunc *fn);void unregisterExtiCallbackHandler(IRQn_Type irqn, extiCallbackHandlerFunc *fn);
 
-void initializeUnusedPins(void);
+void unusedPinsInit(void);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -285,12 +285,24 @@ static void configureSPIAndQuadSPI(void)
 }
 
 #ifdef USE_SDCARD
-void sdCardAndFSInit()
+static void sdCardAndFSInit()
 {
     sdcard_init(sdcardConfig());
     afatfs_init();
 }
 #endif
+
+static void swdPinsInit(void)
+{
+    IO_t io = IOGetByTag(DEFIO_TAG_E(PA13)); // SWDIO
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
+    io = IOGetByTag(DEFIO_TAG_E(PA14)); // SWCLK
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
+}
 
 void init(void)
 {
@@ -1006,7 +1018,9 @@ void init(void)
     motorEnable();
 #endif
 
-    initializeUnusedPins();
+    swdPinsInit();
+
+    unusedPinsInit();
 
     tasksInit();
 

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -593,7 +593,7 @@ void spektrumBind(rxConfig_t *rxConfig)
     printf("spektrumBind\n");
 }
 
-void initializeUnusedPins(void)
+void unusedPinsInit(void)
 {
-    printf("initializeUnusedPins\n");
+    printf("unusedPinsInit\n");
 }


### PR DESCRIPTION
This restores the functionality to what it was before #9398: No pull up is configured for the SWD pins if they are unused.