### PR TITLE
Fix GPS Rescue altitude mode behavior

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -192,7 +192,6 @@ bool          magForceDisable = false;
 static bool newGPSData = false;
 
 rescueState_s rescueState;
-altitudeMode_e altitudeMode;
 throttle_s throttle;
 
 /*
@@ -602,15 +601,16 @@ void updateGPSRescueState(void)
             newDescentDistanceM = gpsRescueConfig()->descentDistanceM;
         }
         
-        switch (altitudeMode) {
-            case MAX_ALT:
-                newAltitude = MAX(gpsRescueConfig()->initialAltitudeM * 100, rescueState.sensor.maxAltitudeCm + 1500);
-                break;
+        switch (gpsRescueConfig()->altitudeMode) {
             case FIXED_ALT:
                 newAltitude = gpsRescueConfig()->initialAltitudeM * 100;
                 break;
             case CURRENT_ALT:
                 newAltitude = rescueState.sensor.currentAltitudeCm;
+                break;
+            case MAX_ALT:
+            default:
+                newAltitude = MAX(gpsRescueConfig()->initialAltitudeM * 100, rescueState.sensor.maxAltitudeCm + 1500);
                 break;
         }
 


### PR DESCRIPTION
Fixes #9434 

Fixed unassigned variable controlling the altitude mode. Unassigned value was defaulting to 0 forcing `MAX_ALT` mode at all times instead of the user setting.
