### PR TITLE
Fix dashboard initialization order

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -901,17 +901,6 @@ void init(void)
 
     batteryInit(); // always needs doing, regardless of features.
 
-#ifdef USE_DASHBOARD
-    if (featureIsEnabled(FEATURE_DASHBOARD)) {
-#ifdef USE_OLED_GPS_DEBUG_PAGE_ONLY
-        dashboardShowFixedPage(PAGE_GPS);
-#else
-        dashboardResetPageCycling();
-        dashboardEnablePageCycling();
-#endif
-    }
-#endif
-
 #ifdef USE_RCDEVICE
     rcdeviceInit();
 #endif // USE_RCDEVICE
@@ -1003,6 +992,12 @@ void init(void)
     // Dashbord will register with CMS by itself.
     if (featureIsEnabled(FEATURE_DASHBOARD)) {
         dashboardInit();
+#ifdef USE_OLED_GPS_DEBUG_PAGE_ONLY
+        dashboardShowFixedPage(PAGE_GPS);
+#else
+        dashboardResetPageCycling();
+        dashboardEnablePageCycling();
+#endif
     }
 #endif
 


### PR DESCRIPTION
Move dashboard operational configuration after device initialization.

At some time in the past (probably #9258), order of dashboard device initialization
https://github.com/betaflight/betaflight/blob/a573c8972a8257fae80ef8f9fa04878ada7caf61/src/main/fc/init.c#L1002-L1007
and operational configuration
https://github.com/betaflight/betaflight/blob/a573c8972a8257fae80ef8f9fa04878ada7caf61/src/main/fc/init.c#L904-L913
were swapped, and this caused dashboard pages not to cycle at all, as device initialization `dashboardInit` resets page flag set either by `dashboardEnablePageCycling` or `dashboardShowFixedPage`.

