### PR TITLE
Gyro native rate sampling, filtering, and scheduler restructuring

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1270,9 +1270,9 @@ static bool blackboxWriteSysinfo(void)
             }
             );
 
-        BLACKBOX_PRINT_HEADER_LINE("looptime", "%d",                        gyro.targetLooptime);
-        BLACKBOX_PRINT_HEADER_LINE("gyro_sync_denom", "%d",                 gyroConfig()->gyro_sync_denom);
-        BLACKBOX_PRINT_HEADER_LINE("pid_process_denom", "%d",               pidConfig()->pid_process_denom);
+        BLACKBOX_PRINT_HEADER_LINE("looptime", "%d",                        gyro.sampleLooptime);
+        BLACKBOX_PRINT_HEADER_LINE("gyro_sync_denom", "%d",                 1);
+        BLACKBOX_PRINT_HEADER_LINE("pid_process_denom", "%d",               activePidLoopDenom);
         BLACKBOX_PRINT_HEADER_LINE("thr_mid", "%d",                         currentControlRateProfile->thrMid8);
         BLACKBOX_PRINT_HEADER_LINE("thr_expo", "%d",                        currentControlRateProfile->thrExpo8);
         BLACKBOX_PRINT_HEADER_LINE("tpa_rate", "%d",                        currentControlRateProfile->dynThrPID);

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -94,4 +94,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "FF_LIMIT",
     "FF_INTERPOLATED",
     "BLACKBOX_OUTPUT",
+    "GYRO_SAMPLE",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -110,6 +110,7 @@ typedef enum {
     DEBUG_FF_LIMIT,
     DEBUG_FF_INTERPOLATED,
     DEBUG_BLACKBOX_OUTPUT,
+    DEBUG_GYRO_SAMPLE,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -54,6 +54,7 @@ bool cliMode = false;
 #include "common/typeconversion.h"
 #include "common/utils.h"
 
+#include "config/config.h"
 #include "config/config_eeprom.h"
 #include "config/feature.h"
 
@@ -94,7 +95,6 @@ bool cliMode = false;
 #include "drivers/vtx_table.h"
 
 #include "fc/board_info.h"
-#include "config/config.h"
 #include "fc/controlrate_profile.h"
 #include "fc/core.h"
 #include "fc/rc.h"
@@ -4680,11 +4680,11 @@ static void cliStatus(char *cmdline)
 
     // Run status
 
-    const int gyroRate = getTaskDeltaTime(TASK_GYROPID) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_GYROPID)));
+    const int gyroRate = getTaskDeltaTime(TASK_GYRO) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_GYRO)));
     const int rxRate = currentRxRefreshRate == 0 ? 0 : (int)(1000000.0f / ((float)currentRxRefreshRate));
     const int systemRate = getTaskDeltaTime(TASK_SYSTEM) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_SYSTEM)));
     cliPrintLinef("CPU:%d%%, cycle time: %d, GYRO rate: %d, RX rate: %d, System rate: %d",
-            constrain(averageSystemLoadPercent, 0, 100), getTaskDeltaTime(TASK_GYROPID), gyroRate, rxRate, systemRate);
+            constrain(averageSystemLoadPercent, 0, 100), getTaskDeltaTime(TASK_GYRO), gyroRate, rxRate, systemRate);
 
     // Battery meter
 
@@ -4731,21 +4731,8 @@ static void cliTasks(char *cmdline)
         cfTaskInfo_t taskInfo;
         getTaskInfo(taskId, &taskInfo);
         if (taskInfo.isEnabled) {
-            int taskFrequency;
-            int subTaskFrequency = 0;
-            if (taskId == TASK_GYROPID) {
-                subTaskFrequency = taskInfo.movingAverageCycleTime == 0.0f ? 0.0f : (int)(1000000.0f / (taskInfo.movingAverageCycleTime));
-                taskFrequency = subTaskFrequency / pidConfig()->pid_process_denom;
-                if (pidConfig()->pid_process_denom > 1) {
-                    cliPrintf("%02d - (%15s) ", taskId, taskInfo.taskName);
-                } else {
-                    taskFrequency = subTaskFrequency;
-                    cliPrintf("%02d - (%11s/%3s) ", taskId, taskInfo.subTaskName, taskInfo.taskName);
-                }
-            } else {
-                taskFrequency = taskInfo.averageDeltaTime == 0 ? 0 : (int)(1000000.0f / ((float)taskInfo.averageDeltaTime));
-                cliPrintf("%02d - (%15s) ", taskId, taskInfo.taskName);
-            }
+            int taskFrequency = taskInfo.averageDeltaTime == 0 ? 0 : lrintf(1e6f / taskInfo.averageDeltaTime);
+            cliPrintf("%02d - (%15s) ", taskId, taskInfo.taskName);
             const int maxLoad = taskInfo.maxExecutionTime == 0 ? 0 :(taskInfo.maxExecutionTime * taskFrequency + 5000) / 1000;
             const int averageLoad = taskInfo.averageExecutionTime == 0 ? 0 : (taskInfo.averageExecutionTime * taskFrequency + 5000) / 1000;
             if (taskId != TASK_SERIAL) {
@@ -4758,9 +4745,6 @@ static void cliTasks(char *cmdline)
                         maxLoad/10, maxLoad%10, averageLoad/10, averageLoad%10, taskInfo.totalExecutionTime / 1000);
             } else {
                 cliPrintLinef("%6d", taskFrequency);
-            }
-            if (taskId == TASK_GYROPID && pidConfig()->pid_process_denom > 1) {
-                cliPrintLinef("   - (%15s) %6d", taskInfo.subTaskName, subTaskFrequency);
             }
 
             schedulerResetTaskMaxExecutionTime(taskId);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -258,7 +258,6 @@ static const char * const lookupTableRxSpi[] = {
 
 static const char * const lookupTableGyroHardwareLpf[] = {
     "NORMAL",
-    "1KHZ_SAMPLING",
 #ifdef USE_GYRO_DLPF_EXPERIMENTAL
     "EXPERIMENTAL"
 #endif
@@ -621,7 +620,6 @@ const clivalue_t valueTable[] = {
 #if defined(USE_GYRO_SPI_ICM20649)
     { "gyro_high_range",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_high_fsr) },
 #endif
-    { "gyro_sync_denom",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 32 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_sync_denom) },
 
     { "gyro_lowpass_type",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_LOWPASS_TYPE }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lowpass_type) },
     { "gyro_lowpass_hz",            VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lowpass_hz) },

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -26,14 +26,12 @@
 cfTask_t *unittest_scheduler_selectedTask;
 uint8_t unittest_scheduler_selectedTaskDynamicPriority;
 uint16_t unittest_scheduler_waitingTasks;
-bool unittest_outsideRealtimeGuardInterval;
 
 #define GET_SCHEDULER_LOCALS() \
     { \
     unittest_scheduler_selectedTask = selectedTask; \
     unittest_scheduler_selectedTaskDynamicPriority = selectedTaskDynamicPriority; \
     unittest_scheduler_waitingTasks = waitingTasks; \
-    unittest_outsideRealtimeGuardInterval = outsideRealtimeGuardInterval; \
     }
 
 #else

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -59,16 +59,10 @@ typedef enum {
 
 typedef enum {
     GYRO_HARDWARE_LPF_NORMAL,
-    GYRO_HARDWARE_LPF_1KHZ_SAMPLE,
 #ifdef USE_GYRO_DLPF_EXPERIMENTAL
     GYRO_HARDWARE_LPF_EXPERIMENTAL
 #endif
 } gyroHardwareLpf_e;
-
-typedef enum {
-    GYRO_32KHZ_HARDWARE_LPF_NORMAL,
-    GYRO_32KHZ_HARDWARE_LPF_EXPERIMENTAL
-} gyro32khzHardwareLpf;
 
 typedef enum {
     GYRO_RATE_1_kHz,
@@ -106,6 +100,8 @@ typedef struct gyroDev_s {
     uint8_t gyroHasOverflowProtection;
     gyroHardware_e gyroHardware;
     fp_rotationMatrix_t rotationMatrix;
+    uint16_t gyroSampleRateHz;
+    uint16_t accSampleRateHz;
 } gyroDev_t;
 
 typedef struct accDev_s {

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -350,10 +350,6 @@ uint8_t mpuGyroDLPF(gyroDev_t *gyro)
                 break;
 #endif
 
-            case GYRO_HARDWARE_LPF_1KHZ_SAMPLE:
-                ret = 1;
-                break;
-
             case GYRO_HARDWARE_LPF_NORMAL:
             default:
                 ret = 0;

--- a/src/main/drivers/accgyro/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu3050.c
@@ -53,17 +53,6 @@
 #define MPU3050_USER_RESET      0x01
 #define MPU3050_CLK_SEL_PLL_GX  0x01
 
-static uint8_t mpu3050GetDLPF(uint8_t lpf)
-{
-    uint8_t ret;
-    if (lpf == GYRO_HARDWARE_LPF_1KHZ_SAMPLE) {
-        ret = MPU3050_DLPF_188HZ;
-    } else {
-        ret = MPU3050_DLPF_256HZ;
-    }
-    return ret;
-}
-
 static void mpu3050Init(gyroDev_t *gyro)
 {
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
@@ -73,7 +62,7 @@ static void mpu3050Init(gyroDev_t *gyro)
         failureMode(FAILURE_ACC_INIT);
     }
 
-    busWriteRegister(&gyro->bus, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | mpu3050GetDLPF(gyro->hardware_lpf));
+    busWriteRegister(&gyro->bus, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | MPU3050_DLPF_256HZ);
     busWriteRegister(&gyro->bus, MPU3050_INT_CFG, 0);
     busWriteRegister(&gyro->bus, MPU3050_USER_CTRL, MPU3050_USER_RESET);
     busWriteRegister(&gyro->bus, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);

--- a/src/main/drivers/accgyro/gyro_sync.c
+++ b/src/main/drivers/accgyro/gyro_sync.c
@@ -47,41 +47,30 @@ bool gyroSyncCheckUpdate(gyroDev_t *gyro)
     return ret;
 }
 
-uint32_t gyroSetSampleRate(gyroDev_t *gyro, uint8_t lpf, uint8_t gyroSyncDenominator)
+uint16_t gyroSetSampleRate(gyroDev_t *gyro)
 {
-    float gyroSamplePeriod;
+    uint16_t gyroSampleRateHz;
+    uint16_t accSampleRateHz;
 
-    if (lpf != GYRO_HARDWARE_LPF_1KHZ_SAMPLE) {
-        switch (gyro->mpuDetectionResult.sensor) {
-            case BMI_160_SPI:
-                gyro->gyroRateKHz = GYRO_RATE_3200_Hz;
-                gyroSamplePeriod = 312.0f;
-                break;
-            case ICM_20649_SPI:
-                gyro->gyroRateKHz = GYRO_RATE_9_kHz;
-                gyroSamplePeriod = 1000000.0f / 9000.0f;
-                break;
-            default:
-                gyro->gyroRateKHz = GYRO_RATE_8_kHz;
-                gyroSamplePeriod = 125.0f;
-                break;
-        }
-    } else {
-        switch (gyro->mpuDetectionResult.sensor) {
+    switch (gyro->mpuDetectionResult.sensor) {
+        case BMI_160_SPI:
+            gyro->gyroRateKHz = GYRO_RATE_3200_Hz;
+            gyroSampleRateHz = 3200;
+            accSampleRateHz = 800;
+            break;
         case ICM_20649_SPI:
-            gyro->gyroRateKHz = GYRO_RATE_1100_Hz;
-            gyroSamplePeriod = 1000000.0f / 1100.0f;
+            gyro->gyroRateKHz = GYRO_RATE_9_kHz;
+            gyroSampleRateHz = 9000;
+            accSampleRateHz = 1125;
             break;
         default:
-            gyro->gyroRateKHz = GYRO_RATE_1_kHz;
-            gyroSamplePeriod = 1000.0f;
+            gyro->gyroRateKHz = GYRO_RATE_8_kHz;
+            gyroSampleRateHz = 8000;
+            accSampleRateHz = 1000;
             break;
-        }
-        gyroSyncDenominator = 1; // Always full Sampling 1khz
     }
 
-    // calculate gyro divider and targetLooptime (expected cycleTime)
-    gyro->mpuDividerDrops  = gyroSyncDenominator - 1;
-    const uint32_t targetLooptime = (uint32_t)(gyroSyncDenominator * gyroSamplePeriod);
-    return targetLooptime;
+    gyro->mpuDividerDrops  = 0; // we no longer use the gyro's sample divider
+    gyro->accSampleRateHz = accSampleRateHz;
+    return gyroSampleRateHz;
 }

--- a/src/main/drivers/accgyro/gyro_sync.h
+++ b/src/main/drivers/accgyro/gyro_sync.h
@@ -30,4 +30,4 @@
 #include "drivers/accgyro/accgyro.h"
 
 bool gyroSyncCheckUpdate(gyroDev_t *gyro);
-uint32_t gyroSetSampleRate(gyroDev_t *gyro, uint8_t lpf, uint8_t gyroSyncDenominator);
+uint16_t gyroSetSampleRate(gyroDev_t *gyro);

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -80,6 +80,10 @@ void tryArm(void);
 bool processRx(timeUs_t currentTimeUs);
 void updateArmingStatus(void);
 
+void taskGyroSample(timeUs_t currentTimeUs);
+bool gyroFilterReady(void);
+bool pidLoopReady(void);
+void taskFiltering(timeUs_t currentTimeUs);
 void taskMainPidLoop(timeUs_t currentTimeUs);
 
 bool isFlipOverAfterCrashActive(void);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -724,13 +724,19 @@ void init(void)
 
     systemState |= SYSTEM_STATE_SENSORS_READY;
 
-    // gyro.targetLooptime set in sensorsAutodetect(),
-    // so we are ready to call validateAndFixGyroConfig(), pidInit(), and setAccelerationFilter()
+    // Set the targetLooptime based on the detected gyro sampleRateHz and pid_process_denom
+    gyroSetTargetLooptime(pidConfig()->pid_process_denom);
+
+    // Validate and correct the gyro config or PID loop time if needed
     validateAndFixGyroConfig();
+
+    // Now reset the targetLooptime as it's possible for the validation to change the pid_process_denom
+    gyroSetTargetLooptime(pidConfig()->pid_process_denom);
+
+    // Finally initialize the gyro filtering
+    gyroInitFilters();
+
     pidInit(currentPidProfile);
-#ifdef USE_ACC
-    accInitFilters();
-#endif
 
 #ifdef USE_PID_AUDIO
     pidAudioInit();

--- a/src/main/fc/tasks.h
+++ b/src/main/fc/tasks.h
@@ -20,6 +20,4 @@
 
 #pragma once
 
-#define LOOPTIME_SUSPEND_TIME 3  // Prevent too long busy wait times
-
 void tasksInit(void);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -755,7 +755,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
 void pidInit(const pidProfile_t *pidProfile)
 {
-    pidSetTargetLooptime(gyro.targetLooptime * pidConfig()->pid_process_denom); // Initialize pid looptime
+    pidSetTargetLooptime(gyro.targetLooptime); // Initialize pid looptime
     pidInitFilters(pidProfile);
     pidInitConfig(pidProfile);
 #ifdef USE_RPM_FILTER
@@ -857,7 +857,10 @@ STATIC_UNIT_TESTED float calcHorizonLevelStrength(void)
     return constrainf(horizonLevelStrength, 0, 1);
 }
 
-STATIC_UNIT_TESTED float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint) {
+// Use the FAST_CODE_NOINLINE directive to avoid this code from being inlined into ITCM RAM to avoid overflow.
+// The impact is possibly slightly slower performance on F7/H7 but they have more than enough
+// processing power that it should be a non-issue.
+STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint) {
     // calculate error angle and limit the angle to the max inclination
     // rcDeflection is in range [-1.0, 1.0]
     float angle = pidProfile->levelAngleLimit * getRcDeflection(axis);
@@ -1215,7 +1218,10 @@ float pidGetAirmodeThrottleOffset()
 #define LAUNCH_CONTROL_MIN_RATE 5.0f
 #define LAUNCH_CONTROL_ANGLE_WINDOW 10.0f  // The remaining angle degrees where rate dampening starts
 
-static float applyLaunchControl(int axis, const rollAndPitchTrims_t *angleTrim)
+// Use the FAST_CODE_NOINLINE directive to avoid this code from being inlined into ITCM RAM to avoid overflow.
+// The impact is possibly slightly slower performance on F7/H7 but they have more than enough
+// processing power that it should be a non-issue.
+static FAST_CODE_NOINLINE float applyLaunchControl(int axis, const rollAndPitchTrims_t *angleTrim)
 {
     float ret = 0.0f;
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -124,7 +124,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config)
         return;
     }
 
-    pidLooptime = gyro.targetLooptime * pidConfig()->pid_process_denom;
+    pidLooptime = gyro.targetLooptime;
     if (config->gyro_rpm_notch_harmonics) {
         gyroFilter = &filters[numberRpmNotchFilters++];
         rpmNotchFilterInit(gyroFilter, config->gyro_rpm_notch_harmonics,

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -655,6 +655,9 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         // Added in API version 1.42
         sbufWriteU8(dst, systemConfig()->configurationState);
 
+        //Added in API version 1.43
+        sbufWriteU16(dst, gyro.sampleRateHz); // informational so the configurator can display the correct gyro/pid frequencies in the drop-down
+
         break;
     }
 
@@ -971,7 +974,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
             boxBitmask_t flightModeFlags;
             const int flagBits = packFlightModeFlags(&flightModeFlags);
 
-            sbufWriteU16(dst, getTaskDeltaTime(TASK_GYROPID));
+            sbufWriteU16(dst, getTaskDeltaTime(TASK_PID));
 #ifdef USE_I2C
             sbufWriteU16(dst, i2cGetErrorCounter());
 #else
@@ -1634,7 +1637,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         break;
     }
     case MSP_ADVANCED_CONFIG:
-        sbufWriteU8(dst, gyroConfig()->gyro_sync_denom);
+        sbufWriteU8(dst, 1);  // was gyroConfig()->gyro_sync_denom - removed in API 1.43
         sbufWriteU8(dst, pidConfig()->pid_process_denom);
         sbufWriteU8(dst, motorConfig()->dev.useUnsyncedPwm);
         sbufWriteU8(dst, motorConfig()->dev.motorPwmProtocol);
@@ -2424,7 +2427,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
     }
 
     case MSP_SET_ADVANCED_CONFIG:
-        gyroConfigMutable()->gyro_sync_denom = sbufReadU8(src);
+        sbufReadU8(src); // was gyroConfigMutable()->gyro_sync_denom - removed in API 1.43
         pidConfigMutable()->pid_process_denom = sbufReadU8(src);
         motorConfigMutable()->dev.useUnsyncedPwm = sbufReadU8(src);
 #ifdef USE_DSHOT

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -49,7 +49,7 @@ typedef enum {
 
 typedef struct acc_s {
     accDev_t dev;
-    uint32_t accSamplingInterval;
+    uint16_t sampleRateHz;
     float accADC[XYZ_AXIS_COUNT];
     bool isAccelUpdatedAtLeastOnce;
 } acc_t;
@@ -78,7 +78,7 @@ typedef struct accelerometerConfig_s {
 PG_DECLARE(accelerometerConfig_t, accelerometerConfig);
 #endif
 
-bool accInit(uint32_t gyroTargetLooptime);
+bool accInit(uint16_t accSampleRateHz);
 bool accIsCalibrationComplete(void);
 bool accHasBeenCalibrated(void);
 void accStartCalibration(void);

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -33,6 +33,8 @@
 #include "config/config.h"
 #include "fc/runtime_config.h"
 
+#include "flight/pid.h"
+
 #include "sensors/sensors.h"
 #include "sensors/adcinternal.h"
 #include "sensors/acceleration.h"
@@ -68,7 +70,7 @@ bool sensorsAutodetect(void)
 
 #ifdef USE_ACC
     if (gyroDetected) {
-        accInit(gyro.targetLooptime);
+        accInit(gyro.accSampleRateHz);
     }
 #endif
 

--- a/src/main/target/ALIENFLIGHTF3/config.c
+++ b/src/main/target/ALIENFLIGHTF3/config.c
@@ -90,8 +90,7 @@ void targetConfiguration(void)
         statusLedConfigMutable()->ioTags[2] = IO_TAG(LED2_A);
 #endif
     } else {
-        gyroConfigMutable()->gyro_sync_denom = 2;
-        pidConfigMutable()->pid_process_denom = 2;
+        pidConfigMutable()->pid_process_denom = 4;
     }
 
     if (!haveFrSkyRX) {

--- a/src/main/target/CLRACINGF4/config.c
+++ b/src/main/target/CLRACINGF4/config.c
@@ -48,7 +48,6 @@ void targetConfiguration(void)
 {
     pinioBoxConfigMutable()->permanentId[0] = 40;
     motorConfigMutable()->dev.motorPwmProtocol = PWM_TYPE_DSHOT600;
-    gyroConfigMutable()->gyro_sync_denom = 1;  // 8kHz gyro
     pidConfigMutable()->pid_process_denom = 1; // 8kHz PID
 }
 #endif

--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -279,7 +279,7 @@ static bool bstSlaveProcessFeedbackCommand(uint8_t bstRequest)
             }
             break;
         case BST_STATUS:
-            bstWrite16(getTaskDeltaTime(TASK_GYROPID));
+            bstWrite16(getTaskDeltaTime(TASK_PID));
 #ifdef USE_I2C
             bstWrite16(i2cGetErrorCounter());
 #else
@@ -314,7 +314,7 @@ static bool bstSlaveProcessFeedbackCommand(uint8_t bstRequest)
             bstWrite8(getCurrentPidProfileIndex());
             break;
         case BST_LOOP_TIME:
-            bstWrite16(getTaskDeltaTime(TASK_GYROPID));
+            bstWrite16(getTaskDeltaTime(TASK_PID));
             break;
         case BST_RC_TUNING:
             bstWrite8(currentControlRateProfile->rcRates[FD_ROLL]);
@@ -420,14 +420,7 @@ static bool bstSlaveProcessFeedbackCommand(uint8_t bstRequest)
             bstWrite8(rcControlsConfig()->yaw_deadband);
             break;
         case BST_FC_FILTERS:
-            switch (gyroConfig()->gyro_hardware_lpf) { // Extra safety to prevent OSD setting corrupt values
-                case GYRO_HARDWARE_LPF_1KHZ_SAMPLE:
-                    bstWrite16(1);
-                    break;
-                default:
-                    bstWrite16(0);
-                    break;
-            }
+            bstWrite16(0);
             break;
         default:
             // we do not know how to handle the (valid) message, indicate error BST
@@ -628,14 +621,7 @@ static bool bstSlaveProcessWriteCommand(uint8_t bstWriteCommand)
             rcControlsConfigMutable()->yaw_deadband = bstRead8();
             break;
         case BST_SET_FC_FILTERS:
-            switch (bstRead16()) {
-                case 1:
-                    gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_1KHZ_SAMPLE;
-                    break;
-                default:
-                    gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
-                    break;
-            }
+            bstRead16(); // 1KHz sampling no longer supported
             break;
 
         default:

--- a/src/main/target/MOTOLAB/config.c
+++ b/src/main/target/MOTOLAB/config.c
@@ -34,7 +34,6 @@
 // Motolab target supports 2 different type of boards Tornado / Cyclone.
 void targetConfiguration(void)
 {
-    gyroConfigMutable()->gyro_sync_denom = 4;
-    pidConfigMutable()->pid_process_denom = 1;
+    pidConfigMutable()->pid_process_denom = 4;
 }
 #endif

--- a/src/main/target/MULTIFLITEPICO/config.c
+++ b/src/main/target/MULTIFLITEPICO/config.c
@@ -81,8 +81,7 @@ void targetConfiguration(void)
 
     motorConfigMutable()->dev.motorPwmRate = 17000;
 
-    gyroConfigMutable()->gyro_sync_denom = 4;
-    pidConfigMutable()->pid_process_denom = 1;
+    pidConfigMutable()->pid_process_denom = 4;
 
     for (uint8_t pidProfileIndex = 0; pidProfileIndex < PID_PROFILE_COUNT; pidProfileIndex++) {
         pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);

--- a/src/main/target/NAZE/config.c
+++ b/src/main/target/NAZE/config.c
@@ -63,7 +63,6 @@ void targetConfiguration(void)
 
     gyroDeviceConfigMutable()->extiTag = selectMPUIntExtiConfigByHardwareRevision();
 
-    gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_1KHZ_SAMPLE;
     gyroConfigMutable()->gyro_soft_lpf_hz = 100;
     gyroConfigMutable()->gyro_soft_notch_hz_1 = 0;
     gyroConfigMutable()->gyro_soft_notch_hz_2 = 0;

--- a/src/main/target/OMNIBUSF4/config.c
+++ b/src/main/target/OMNIBUSF4/config.c
@@ -75,7 +75,6 @@ void targetConfiguration(void)
     ledStripStatusModeConfigMutable()->ledConfigs[0] = DEFINE_LED(0, 0, 0, 0, LF(COLOR), LO(VTX), 0);
     targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
     motorConfigMutable()->dev.motorPwmProtocol = PWM_TYPE_DSHOT600;
-    gyroConfigMutable()->gyro_sync_denom = 1;  // 8kHz gyro
     pidConfigMutable()->pid_process_denom = 1; // 8kHz PID
 #endif
 }

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -137,6 +137,14 @@
 #define DEFAULT_AUX_CHANNEL_COUNT       6
 #endif
 
+// Set the default cpu_overclock to the first level (108MHz) for F411
+// Helps with looptime stability as the CPU is borderline when running native gyro sampling
+#if defined(USE_OVERCLOCK) && defined(STM32F411xE)
+#define DEFAULT_CPU_OVERCLOCK 1
+#else
+#define DEFAULT_CPU_OVERCLOCK 0
+#endif
+
 
 #ifdef USE_ITCM_RAM
 #define FAST_CODE                   __attribute__((section(".tcm_code")))

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -74,6 +74,7 @@ extern "C" {
     int16_t GPS_directionToHome = 0;
     acc_t acc = {};
     bool mockIsUpright = false;
+    uint8_t activePidLoopDenom = 1;
 }
 
 uint32_t simulationFeatureFlags = 0;
@@ -1049,7 +1050,7 @@ extern "C" {
     void writeServos(void) {};
     bool calculateRxChannelsAndUpdateFailsafe(timeUs_t) { return true; }
     bool isMixerUsingServos(void) { return false; }
-    void gyroUpdate(timeUs_t) {}
+    void gyroUpdate(void) {}
     timeDelta_t getTaskDeltaTime(cfTaskId_e) { return 0; }
     void updateRSSI(timeUs_t) {}
     bool failsafeIsMonitoring(void) { return false; }
@@ -1099,4 +1100,5 @@ extern "C" {
     bool compassIsCalibrationComplete(void) { return true; }
     bool isUpright(void) { return mockIsUpright; }
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
+    void gyroFiltering(timeUs_t) {};
 }

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -75,14 +75,6 @@ TEST(BlackboxTest, TestInitIntervals)
     EXPECT_EQ(0, blackboxPInterval);
     EXPECT_EQ(4096, blackboxSInterval);
 
-    // 1kHz PIDloop
-    gyro.targetLooptime = gyroSetSampleRate(&gyroDev, GYRO_HARDWARE_LPF_1KHZ_SAMPLE, 1);
-    targetPidLooptime = gyro.targetLooptime * 1;
-    blackboxInit();
-    EXPECT_EQ(32, blackboxIInterval);
-    EXPECT_EQ(1, blackboxPInterval);
-    EXPECT_EQ(8192, blackboxSInterval);
-
     // 2kHz PIDloop
     targetPidLooptime = 500;
     blackboxInit();

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -144,7 +144,7 @@ void setDefaultTestSettings(void) {
     pidProfile->launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,
     pidProfile->launchControlGain = 40,
 
-    gyro.targetLooptime = 4000;
+    gyro.targetLooptime = 8000;
 }
 
 timeUs_t currentTestTime(void) {

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -85,6 +85,7 @@ TEST(SensorGyro, Calibrate)
 {
     pgResetAll();
     gyroInit();
+    gyroSetTargetLooptime(1);
     fakeGyroSet(gyroDevPtr, 5, 6, 7);
     const bool read = gyroDevPtr->readFn(gyroDevPtr);
     EXPECT_TRUE(read);
@@ -119,16 +120,16 @@ TEST(SensorGyro, Update)
     gyroConfigMutable()->gyro_soft_notch_hz_1 = 0;
     gyroConfigMutable()->gyro_soft_notch_hz_2 = 0;
     gyroInit();
+    gyroSetTargetLooptime(1);
     gyroDevPtr->readFn = fakeGyroRead;
     gyroStartCalibration(false);
     EXPECT_FALSE(gyroIsCalibrationComplete());
 
-    timeUs_t currentTimeUs = 0;
     fakeGyroSet(gyroDevPtr, 5, 6, 7);
-    gyroUpdate(currentTimeUs);
+    gyroUpdate();
     while (!gyroIsCalibrationComplete()) {
         fakeGyroSet(gyroDevPtr, 5, 6, 7);
-        gyroUpdate(currentTimeUs);
+        gyroUpdate();
     }
     EXPECT_TRUE(gyroIsCalibrationComplete());
     EXPECT_EQ(5, gyroDevPtr->gyroZero[X]);
@@ -137,16 +138,16 @@ TEST(SensorGyro, Update)
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[X]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Y]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Z]);
-    gyroUpdate(currentTimeUs);
+    gyroUpdate();
     // expect zero values since gyro is calibrated
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[X]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Y]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Z]);
     fakeGyroSet(gyroDevPtr, 15, 26, 97);
-    gyroUpdate(currentTimeUs);
-    EXPECT_NEAR(10 * gyroDevPtr->scale, gyro.gyroADCf[X], 1e-3); // gyroADCf values are scaled
-    EXPECT_NEAR(20 * gyroDevPtr->scale, gyro.gyroADCf[Y], 1e-3);
-    EXPECT_NEAR(90 * gyroDevPtr->scale, gyro.gyroADCf[Z], 1e-3);
+    gyroUpdate();
+    EXPECT_NEAR(10 * gyroDevPtr->scale, gyro.gyroADC[X], 1e-3); // gyro.gyroADC values are scaled
+    EXPECT_NEAR(20 * gyroDevPtr->scale, gyro.gyroADC[Y], 1e-3);
+    EXPECT_NEAR(90 * gyroDevPtr->scale, gyro.gyroADC[Z], 1e-3);
 }
 
 // STUBS

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -113,6 +113,7 @@ TEST(VtxTest, PitMode)
 
 // STUBS
 extern "C" {
+    uint8_t activePidLoopDenom = 1;
     uint32_t micros(void) { return simulationTime; }
     uint32_t millis(void) { return micros() / 1000; }
     bool rxIsReceivingSignal(void) { return simulationHaveRx; }
@@ -141,7 +142,7 @@ extern "C" {
     void writeServos(void) {};
     bool calculateRxChannelsAndUpdateFailsafe(timeUs_t) { return true; }
     bool isMixerUsingServos(void) { return false; }
-    void gyroUpdate(timeUs_t) {}
+    void gyroUpdate() {}
     timeDelta_t getTaskDeltaTime(cfTaskId_e) { return 0; }
     void updateRSSI(timeUs_t) {}
     bool failsafeIsMonitoring(void) { return false; }
@@ -184,4 +185,5 @@ extern "C" {
     bool compassIsCalibrationComplete(void) { return true; }
     bool isUpright(void) { return true; }
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
+    void gyroFiltering(timeUs_t) {};
 }


### PR DESCRIPTION
Restructures the gyro and PID loops to be driven by the native sampling rate for the detected gyro. So for a common Invensense gyro the sampling will always run at 8000hz, for a Bosch BMI160 it will be 3200hz, and so on. Running at the native rate ensures we use all gyro samples to reduce aliasing caused by skipping samples. Since the gyro always samples at the native rate for the sensor, the `gyro_sync_denom` setting has been removed.

Filtering has been moved to the PID loop rate. The gyro reads every sample and will "downsample" the data to the PID loop if it's running at a lower multiple (using `pid_process_denom`). So if the user has set the PID loop to 4000 then the PID loop will run every two gyro samples for example. Moving the filtering into the PID loop rate saves processing time as it will now run at a lower rate. The gyro lowpass 2 has been repurposed and used as the initial downsampling filter. The behavior and user settings remain unchanged and we just take advantage of the existing filter by moving it earlier in the chain and using that to anti-alias the samples. If the user has disabled the gyro lowpass 2 then we revert to a simple averaging filter during downsampling. No user changes to filtering are required.

The scheduler has been significantly reworked to be completely driven by the realtime gyro sampling. Many changes to optimize loop stability and allow tasks to stay more on their scheduled execution times. This results in a lower reported CPU load % as that's a measure of how effectively tasks are staying on schedule. The scheduling will intelligently look-ahead when processing tasks to predict whether it will interfere with the next scheduled gyro/filter/pid cycle and defer to optimize loop stability.

For better visibility the `tasks` output has been enhanced to display the `GYRO` (sampling), `FILTER`, and `PID` as separate tasks. For example:
```
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms
00 - (         SYSTEM)     10       1       1    0.5%    0.5%         0
01 - (         SYSTEM)   1000       6       1    1.0%    0.5%        10
02 - (           GYRO)   8000      14       8   11.7%    6.9%      1510
03 - (         FILTER)   4000      17      11    7.3%    4.9%      1029
04 - (            PID)   4000      49      38   20.1%   15.7%      3635
05 - (            ACC)   1000      14       9    1.8%    1.3%       204
```
Improved the `ACCEL` task to be driven by the sensor's native ACC sample rate. Previously it was hardcoded to 1000hz which was only appropriate for some sensors.

Significantly enhanced the scheduler unit test to exercise the new realtime task scheduling.

1KHz gyro sampling has been removed. This was mainly a legacy item that's always been poorly supported and really no longer used. It would be very difficult to support and even less useful in the new structure.

I2C connected gyros will not be supported as they are unable to sample at the native rate. This should only affect F3 and older which are no longer supported anyway. We can consider removing I2C gyro support completely.

For F411 MCU the default `cpu_overclock` has been enabled and set to the lowest value of 108MHz. F411 is borderline for processing power and loop stability is greatly improved with this small overclock. User can still override and increase or disable as desired.

Needs coordination with the Configurator to improve the display and selection of the gyro and PID loop rates.

Also the "Cycle time" that displays at the bottom of the Configurator will now be the PID loop time rather than the gyro sample interval. Since the gyro rate is now fixed it makes more sense for this to display the user's configure loop time. So there may be some initial confusion since before running at 8/4 would have displayed 125 (from the 8K gyro) and now it will display 250 (based on the 4KHz PID loop). But overall I think this more useful and accurate as a "cycle time" indicator.