### PR TITLE
Fixed default for 'sdcard_mode' to 'none'.

### DIFF
--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -47,16 +47,12 @@ void pgResetFn_sdcardConfig(sdcardConfig_t *config)
     config->device = SPI_DEV_TO_CFG(SPIINVALID);
     config->mode = SDCARD_MODE_NONE;
 
-#ifdef USE_SDCARD_SDIO
-    config->mode = SDCARD_MODE_SDIO;
-    config->useDma = true;
-#endif
-
 #ifdef USE_SDCARD_SPI
+    // These settings do not work for Unified Targets
+    // They are only left in place to support legacy targets
     SPIDevice spidevice = spiDeviceByInstance(SDCARD_SPI_INSTANCE);
     config->device = SPI_DEV_TO_CFG(spidevice);
     config->chipSelectTag = IO_TAG(SDCARD_SPI_CS_PIN);
-    config->useDma = false;
 
     if (spidevice != SPIINVALID && config->chipSelectTag) {
         config->mode = SDCARD_MODE_SPI;

--- a/src/main/target/NUCLEOH743/config.c
+++ b/src/main/target/NUCLEOH743/config.c
@@ -28,7 +28,8 @@
 #include "config_helper.h"
 
 #include "io/serial.h"
-#include "pg/pg.h"
+
+#include "pg/sdcard.h"
 
 static targetSerialPortFunction_t targetSerialPortFunction[] = {
     { SERIAL_PORT_USART1, FUNCTION_MSP },
@@ -38,5 +39,9 @@ static targetSerialPortFunction_t targetSerialPortFunction[] = {
 void targetConfiguration(void)
 {
     targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+#if !defined(NUCLEOH743_RAMBASED)
+    sdcardConfigMutable()->mode = SDCARD_MODE_SDIO;
+    sdcardConfigMutable()->useDma = true;
+#endif
 }
 #endif

--- a/src/main/target/NUCLEOH743/target.mk
+++ b/src/main/target/NUCLEOH743/target.mk
@@ -1,9 +1,11 @@
 H743xI_TARGETS += $(TARGET)
 
-FEATURES       += VCP ONBOARDFLASH SDCARD_SDIO
 
 ifeq ($(TARGET), NUCLEOH743_RAMBASED)
+FEATURES       += VCP ONBOARDFLASH
 RAM_BASED = yes
+else
+FEATURES       += VCP ONBOARDFLASH SDCARD_SDIO
 endif
 
 # Top level Makefile adds, if not defined, HSE_VALUE, as default for F4 targets.
@@ -31,7 +33,3 @@ TARGET_SRC = \
             drivers/barometer/barometer_ms5611.c \
             drivers/compass/compass_hmc5883l.c \
             drivers/max7456.c \
-
-#            drivers/accgyro/accgyro_fake.c \
-#            drivers/barometer/barometer_fake.c \
-#            drivers/compass/compass_fake.c \

--- a/src/main/target/SPRACINGH7EXTREME/config.c
+++ b/src/main/target/SPRACINGH7EXTREME/config.c
@@ -28,8 +28,10 @@
 #include "config_helper.h"
 
 #include "io/serial.h"
+
 #include "osd/osd.h"
-#include "pg/pg.h"
+
+#include "pg/sdcard.h"
 
 static targetSerialPortFunction_t targetSerialPortFunction[] = {
     { SERIAL_PORT_USART1, FUNCTION_MSP },
@@ -40,5 +42,7 @@ void targetConfiguration(void)
 {
     osdConfigMutable()->core_temp_alarm = 85;
     targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+    sdcardConfigMutable()->mode = SDCARD_MODE_SDIO;
+    sdcardConfigMutable()->useDma = true;
 }
 #endif

--- a/src/main/target/SPRACINGH7NANO/target.h
+++ b/src/main/target/SPRACINGH7NANO/target.h
@@ -170,17 +170,8 @@
 // SD card not present on hardware, but pins are reserved.
 //#define USE_SDCARD
 #ifdef USE_SDCARD
-#define USE_SDCARD_SDIO
 #define SDCARD_DETECT_PIN PD10
 #define SDCARD_DETECT_INVERTED
-#define SDIO_DEVICE             SDIODEV_1
-#define SDIO_USE_4BIT           true
-#define SDIO_CK_PIN             PC12
-#define SDIO_CMD_PIN            PD2
-#define SDIO_D0_PIN             PC8
-#define SDIO_D1_PIN             PC9
-#define SDIO_D2_PIN             PC10
-#define SDIO_D3_PIN             PC11
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 #else
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT

--- a/src/main/target/SPRACINGH7ZERO/config.c
+++ b/src/main/target/SPRACINGH7ZERO/config.c
@@ -28,8 +28,10 @@
 #include "config_helper.h"
 
 #include "io/serial.h"
+
 #include "osd/osd.h"
-#include "pg/pg.h"
+
+#include "pg/sdcard.h"
 
 static targetSerialPortFunction_t targetSerialPortFunction[] = {
     { SERIAL_PORT_USART1, FUNCTION_MSP },
@@ -40,5 +42,7 @@ void targetConfiguration(void)
 {
     osdConfigMutable()->core_temp_alarm = 85;
     targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+    sdcardConfigMutable()->mode = SDCARD_MODE_SDIO;
+    sdcardConfigMutable()->useDma = true;
 }
 #endif

--- a/src/main/target/WORMFC/config.c
+++ b/src/main/target/WORMFC/config.c
@@ -19,26 +19,17 @@
  */
 
 #include <stdbool.h>
-#include <stdint.h>
 
 #include "platform.h"
 
-#ifdef USE_TARGET_CONFIG
+#if defined(USE_TARGET_CONFIG)
 
-#include "config_helper.h"
-
-#include "io/serial.h"
-
-#include "osd/osd.h"
-
-static targetSerialPortFunction_t targetSerialPortFunction[] = {
-    { SERIAL_PORT_USART1, FUNCTION_MSP },
-    { SERIAL_PORT_USART2, FUNCTION_MSP },
-};
+#include "pg/sdcard.h"
 
 void targetConfiguration(void)
 {
-    osdConfigMutable()->core_temp_alarm = 85;
-    targetSerialPortFunctionConfig(targetSerialPortFunction, ARRAYLEN(targetSerialPortFunction));
+
+    sdcardConfigMutable()->mode = SDCARD_MODE_SDIO;
+    sdcardConfigMutable()->useDma = true;
 }
 #endif

--- a/src/main/target/WORMFC/target.h
+++ b/src/main/target/WORMFC/target.h
@@ -32,6 +32,8 @@
 
 #endif
 
+#define USE_TARGET_CONFIGURATION
+
 //LEDs
 #if defined(PIRXF4)
 #define LED0_PIN                PC13


### PR DESCRIPTION
Fixes betaflight/unified-targets#196.

Fix for the default for 'sdcard_mode' being accidentally changed to 'sdio' on Unified Targets by #9436.