### PR TITLE
Add "auto" mode to yaw spin recovery

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -639,8 +639,8 @@ const clivalue_t valueTable[] = {
     { "gyro_overflow_detect",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_OVERFLOW_CHECK }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, checkOverflow) },
 #endif
 #ifdef USE_YAW_SPIN_RECOVERY
-    { "yaw_spin_recovery",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_recovery) },
-    { "yaw_spin_threshold",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 500,  1950 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_threshold) },
+    { "yaw_spin_recovery",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_recovery) },
+    { "yaw_spin_threshold",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { YAW_SPIN_RECOVERY_THRESHOLD_MIN,  YAW_SPIN_RECOVERY_THRESHOLD_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_threshold) },
 #endif
 
 #ifdef USE_MULTI_GYRO

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -53,6 +53,7 @@
 #include "rx/rx.h"
 
 #include "sensors/battery.h"
+#include "sensors/gyro.h"
 
 #include "rc.h"
 
@@ -841,6 +842,11 @@ void initRcProcessing(void)
 
         break;
     }
+
+#ifdef USE_YAW_SPIN_RECOVERY
+    const int maxYawRate = (int)applyRates(FD_YAW, 1.0f, 1.0f);
+    initYawSpinRecovery(maxYawRate);
+#endif
 }
 
 bool rcSmoothingIsEnabled(void)

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -38,6 +38,11 @@
 
 #define FILTER_FREQUENCY_MAX 4000 // maximum frequency for filter cutoffs (nyquist limit of 8K max sampling)
 
+#ifdef USE_YAW_SPIN_RECOVERY
+#define YAW_SPIN_RECOVERY_THRESHOLD_MIN 500
+#define YAW_SPIN_RECOVERY_THRESHOLD_MAX 1950
+#endif
+
 typedef union gyroLowpassFilter_u {
     pt1Filter_t pt1FilterState;
     biquadFilter_t biquadFilterState;
@@ -97,6 +102,12 @@ enum {
     DYN_LPF_PT1,
     DYN_LPF_BIQUAD
 };
+
+typedef enum {
+    YAW_SPIN_RECOVERY_OFF,
+    YAW_SPIN_RECOVERY_ON,
+    YAW_SPIN_RECOVERY_AUTO
+} yawSpinRecoveryMode_e;
 
 #define GYRO_CONFIG_USE_GYRO_1      0
 #define GYRO_CONFIG_USE_GYRO_2      1
@@ -180,4 +191,7 @@ gyroDetectionFlags_t getGyroDetectionFlags(void);
 #ifdef USE_DYN_LPF
 float dynThrottle(float throttle);
 void dynLpfGyroUpdate(float throttle);
+#endif
+#ifdef USE_YAW_SPIN_RECOVERY
+void initYawSpinRecovery(int maxYawRate);
 #endif


### PR DESCRIPTION
Changes yaw spin recovery from a simple on/off to on/off/auto. In auto mode the triggering threshold is automatically calculated based on the user's current max yaw rate.

So `yaw_spin_recovery` has the following options:
* `OFF`: Feature is disabled - unchanged
* `ON`: Feature is enabled with a manually configured `yaw_spin_threshold` - unchanged
* `AUTO`: Feature is enabled and the trigger threshold is automatically calculated.

The auto calculation of the trigger threshold is:
```
MAX(yawRate * 0.25, 200)
```
The 25% of the user's rate is to provide a buffer for yaw overshoots during normal flight. Overall the threshold is constrained between 500 - 1950 to match the manual selection range.

**The default is changed from `ON` to `AUTO` so that users will get protection without needing to configure the threshold manually.**

In `AUTO` mode the threshold is calculated dynamically so rate changes in flight (like rateprofile change) will set a new trigger threshold.
