### PR TITLE
Add ACC calibration stick command help to OSD boot splash screen when calibration is needed

### DIFF
--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -25,6 +25,13 @@
 #include "common/filter.h"
 #include "pg/pg.h"
 
+#ifdef USE_ACC
+#define ACC_CALIB_HELP_TEXT1 "ACC_CAL:THR HI"
+#define ACC_CALIB_HELP_TEXT2     "+ YAW LEFT"
+#define ACC_CALIB_HELP_TEXT3     "+ PITCH DN"
+#define ACC_CALIB_HELP_TEXT4     "+ ROLL MID"
+#endif
+
 typedef enum rc_alias {
     ROLL = 0,
     PITCH,

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -58,6 +58,7 @@
 #include "drivers/sdcard.h"
 #include "drivers/time.h"
 
+#include "fc/core.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
@@ -384,10 +385,34 @@ static void osdCompleteInitialization(void)
     char string_buffer[30];
     tfp_sprintf(string_buffer, "V%s", FC_VERSION_STRING);
     displayWrite(osdDisplayPort, 20, 6, DISPLAYPORT_ATTR_NONE, string_buffer);
+
+    uint8_t cmsHelpCol = 7;
+    uint8_t cmsHelpOffset = 4;
+
+#ifdef USE_ACC
+    updateArmingStatus();
+    if (sensors(SENSOR_ACC) && (getArmingDisableFlags() & ARMING_DISABLED_ACC_CALIBRATION)) {
+        cmsHelpCol = 1;
+        cmsHelpOffset = 3;
 #ifdef USE_CMS
-    displayWrite(osdDisplayPort, 7, 8,  DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT1);
-    displayWrite(osdDisplayPort, 11, 9, DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT2);
-    displayWrite(osdDisplayPort, 11, 10, DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT3);
+        const uint8_t accHelpCol = 15;
+#else
+        const uint8_t accHelpCol = 7;
+#endif
+        displayWrite(osdDisplayPort, accHelpCol, 8,  DISPLAYPORT_ATTR_NONE, ACC_CALIB_HELP_TEXT1);
+        displayWrite(osdDisplayPort, accHelpCol + 4, 9,  DISPLAYPORT_ATTR_NONE, ACC_CALIB_HELP_TEXT2);
+        displayWrite(osdDisplayPort, accHelpCol + 4, 10, DISPLAYPORT_ATTR_NONE, ACC_CALIB_HELP_TEXT3);
+        displayWrite(osdDisplayPort, accHelpCol + 4, 11, DISPLAYPORT_ATTR_NONE, ACC_CALIB_HELP_TEXT4);
+    }
+#endif // USE_ACC
+
+#ifdef USE_CMS
+    displayWrite(osdDisplayPort, cmsHelpCol, 8,  DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT1);
+    displayWrite(osdDisplayPort, cmsHelpCol + cmsHelpOffset, 9, DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT2);
+    displayWrite(osdDisplayPort, cmsHelpCol + cmsHelpOffset, 10, DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT3);
+#else
+    UNUSED(cmsHelpCol);
+    UNUSED(cmsHelpOffset);
 #endif
 
 #ifdef USE_RTC_TIME

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -454,6 +454,7 @@ extern "C" {
     void resetPPMDataReceivedState(void){ }
     void failsafeOnValidDataReceived(void) { }
     void failsafeOnValidDataFailed(void) { }
+    void updateArmingStatus(void) { }
 
     void rxPwmInit(rxRuntimeState_t *rxRuntimeState, rcReadRawDataFnPtr *callback)
     {

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1244,4 +1244,5 @@ extern "C" {
     uint32_t persistentObjectRead(persistentObjectId_e) { return 0; }
     void persistentObjectWrite(persistentObjectId_e, uint32_t) {}
     bool isUpright(void) { return true; }
+    void updateArmingStatus(void) { }
 }


### PR DESCRIPTION
Adds the stick commands to calibrate the ACC whenever the `NO_ACC_CAL` arming disabled is active.

![osd_splash](https://user-images.githubusercontent.com/17088539/73986441-a0d4f400-490b-11ea-8f40-7df8616d6baf.png)

If the ACC calibration is not required then the splash screen reverts to only showing the stick commands to enter the CMS.
