### PR TITLE
Add FF Interpolate options to MSP

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2672,6 +2672,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             currentPidProfile->motor_output_limit = sbufReadU8(src);
             currentPidProfile->auto_profile_cell_count = sbufReadU8(src);
             currentPidProfile->idle_min_rpm = sbufReadU8(src);
+        }
         if (sbufBytesRemaining(src) >= 3) {
             // Added in MSP API 1.44
 #if defined(USE_INTERPOLATED_SP)

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1816,6 +1816,15 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, currentPidProfile->motor_output_limit);
         sbufWriteU8(dst, currentPidProfile->auto_profile_cell_count);
         sbufWriteU8(dst, currentPidProfile->idle_min_rpm);
+        // Added in MSP API 1.44
+#if defined(USE_INTERPOLATED_SP)
+        sbufWriteU8(dst, currentPidProfile->ff_interpolate_sp);
+        sbufWriteU8(dst, currentPidProfile->ff_smooth_factor);
+#else
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+#endif
+        sbufWriteU8(dst, currentPidProfile->ff_boost);
 
         break;
     case MSP_SENSOR_CONFIG:
@@ -2663,6 +2672,16 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             currentPidProfile->motor_output_limit = sbufReadU8(src);
             currentPidProfile->auto_profile_cell_count = sbufReadU8(src);
             currentPidProfile->idle_min_rpm = sbufReadU8(src);
+        if (sbufBytesRemaining(src) >= 3) {
+            // Added in MSP API 1.44
+#if defined(USE_INTERPOLATED_SP)
+            currentPidProfile->ff_interpolate_sp = sbufReadU8(src);
+            currentPidProfile->ff_smooth_factor = sbufReadU8(src);
+#else
+            sbufReadU8(src);
+            sbufReadU8(src);
+#endif
+            currentPidProfile->ff_boost = sbufReadU8(src);
         }
         pidInitConfig(currentPidProfile);
 


### PR DESCRIPTION
Added `ff_interpolate_sp` `ff_smooth_factor` and `ff_boost` to MSP API 1.43. Working on it to add these configurable parameters in to `Pid Controller Settings`  Betaflight Configurator tab.