### PR TITLE
More aggresive FF for no or 2 point averaging; default to 2 point averaging

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -212,7 +212,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .idle_p = 50,
         .idle_pid_limit = 200,
         .idle_max_increase = 150,
-        .ff_interpolate_sp = FF_INTERPOLATE_ON,
+        .ff_interpolate_sp = FF_INTERPOLATE_AVG2,
         .ff_spike_limit = 60,
         .ff_max_rate_limit = 100,
         .ff_smooth_factor = 37,


### PR DESCRIPTION
My earlier PR made extensive changes to feed forward.

I and some other race pilots felt that there was a need to have the ability to maintain as much aggression in feed forward as possible.

AVERAGED_3 and AVERAGED_4 brought great smoothness improvements and this PR won't take that away.

This PR:

- Removes the centre stick attenuation of FF for ON and AVERAGED_2, enabling this only for AVERAGED_3 and AVERAGED_4.  

- When set ON (no averaging), the pilot gets full boost when a valid packet arrives after a no-change period.  This makes small corrections very precise, but increases jitter sensitivity.  AVERAGED_2 gets half the boost, AVERAGED_3 one third the boost, and AVERAGED_4 one-quarter the boost.  Higher averaging settings will therefore not only be smoother from greater averaging, but in particular will be more jitter free when the sticks are moving slowly from the reduction in boost amount due to intermittent RC packet changes.  

The intent is to make it so that:

- ON is used by race pilots with good radio links who want the sharpest handling
- AVERAGED_2 is best for race pilots with 'average' radio links, for aggressive/modern freestyle and for general use.
- AVERAGED_3 is best for smooth freestyle, especially with HD cameras, but will be noticeably less aggressive than ON or AVERAGED_2.
- AVERAGED_4 is intended for cinematic HD and will feel very smooth.