### PR TITLE
Adds CRSF rf_mode parameter to linkquality OSD element

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -945,9 +945,10 @@ static void osdBackgroundHorizonSidebars(osdElementParms_t *element)
 static void osdElementLinkQuality(osdElementParms_t *element)
 {
     uint16_t osdLinkQuality = 0;
-    if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) { // 0-300
-        osdLinkQuality = rxGetLinkQuality()  / 3.41;
-        tfp_sprintf(element->buff, "%c%3d", SYM_LINK_QUALITY, osdLinkQuality);
+    if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) { // 0-99
+        osdLinkQuality = rxGetLinkQuality();
+        const uint8_t osdRfMode = rxGetRfMode();
+        tfp_sprintf(element->buff, "%c%1d:%2d", SYM_LINK_QUALITY, osdRfMode, osdLinkQuality);
     } else { // 0-9
         osdLinkQuality = rxGetLinkQuality() * 10 / LINK_QUALITY_MAX_VALUE;
         if (osdLinkQuality >= 10) {

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -152,11 +152,6 @@ typedef struct crsfPayloadLinkstatistics_s {
 
 static timeUs_t lastLinkStatisticsFrameUs;
 
-#ifdef USE_RX_LINK_QUALITY_INFO
-STATIC_UNIT_TESTED uint16_t scaleCrsfLq(uint16_t lqvalue) {
-  return (lqvalue % 100) ? ((lqvalue * 3.41) + 1) : (lqvalue * 3.41);
-}
-#endif
 static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, timeUs_t currentTimeUs)
 {
     const crsfLinkStatistics_t stats = *statsPtr;
@@ -172,7 +167,8 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
 
 #ifdef USE_RX_LINK_QUALITY_INFO
     if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) {
-        setLinkQualityDirect(scaleCrsfLq((stats.rf_Mode * 100) + stats.uplink_Link_quality));
+        setLinkQualityDirect(stats.uplink_Link_quality);
+        rxSetRfMode(stats.rf_Mode);
     }
 #endif
 
@@ -211,6 +207,7 @@ static void crsfCheckRssi(uint32_t currentTimeUs) {
 #ifdef USE_RX_LINK_QUALITY_INFO
         if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) {
             setLinkQualityDirect(0);
+            rxSetRfMode(0);            
         }
 #endif
     }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -79,6 +79,7 @@ static pt1Filter_t frameErrFilter;
 
 #ifdef USE_RX_LINK_QUALITY_INFO
 static uint16_t linkQuality = 0;
+static uint8_t rfMode = 0;
 #endif
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
@@ -402,6 +403,11 @@ STATIC_UNIT_TESTED uint16_t updateLinkQualitySamples(uint16_t value)
     samples[sampleIndex] = value;
     sampleIndex = (sampleIndex + 1) % LINK_QUALITY_SAMPLE_COUNT;
     return sum / LINK_QUALITY_SAMPLE_COUNT;
+}
+
+void rxSetRfMode(uint8_t rfModeValue)
+{
+    rfMode = rfModeValue;
 }
 #endif
 
@@ -846,9 +852,14 @@ uint16_t rxGetLinkQuality(void)
     return linkQuality;
 }
 
+uint8_t rxGetRfMode(void)
+{
+    return rfMode;
+}
+
 uint16_t rxGetLinkQualityPercent(void)
 {
-    return (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) ?  (linkQuality / 3.41) : scaleRange(linkQuality, 0, LINK_QUALITY_MAX_VALUE, 0, 100);
+    return (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) ?  linkQuality : scaleRange(linkQuality, 0, LINK_QUALITY_MAX_VALUE, 0, 100);
 }
 #endif
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -200,6 +200,9 @@ uint8_t getRssiDbm(void);
 void setRssiDbm(uint8_t newRssiDbm, rssiSource_e source);
 void setRssiDbmDirect(uint8_t newRssiDbm, rssiSource_e source);
 
+void rxSetRfMode(uint8_t rfModeValue);
+uint8_t rxGetRfMode(void);
+
 void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRangeConfig);
 
 void suspendRxPwmPpmSignal(void);

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -89,7 +89,6 @@ extern "C" {
 
     void osdRefresh(timeUs_t currentTimeUs);
     uint16_t updateLinkQualitySamples(uint16_t value);
-    uint16_t scaleCrsfLq(uint16_t lqvalue);
 #define LINK_QUALITY_SAMPLE_COUNT 16
 }
 
@@ -311,16 +310,19 @@ TEST(LQTest, TestElementLQ_PROTOCOL_CRSF_VALUES)
 
     // crsf setLinkQualityDirect 0-300;
 
-    for (uint16_t x = 0; x <= 300; x++) {
-        // when x scaled
-        setLinkQualityDirect(scaleCrsfLq(x));
-        // then rxGetLinkQuality Osd should be x
-        displayClearScreen(&testDisplayPort);
-        osdRefresh(simulationTime);
-        displayPortTestBufferSubstring(8, 1,"%c%3d", SYM_LINK_QUALITY, x);
-
+    for (uint8_t x = 0; x <= 99; x++) {
+        for (uint8_t m = 0; m <= 4; m++) {
+            // when x scaled
+            setLinkQualityDirect(x);
+            rxSetRfMode(m);
+            // then rxGetLinkQuality Osd should be x
+            // and RfMode should be m
+            displayClearScreen(&testDisplayPort);
+            osdRefresh(simulationTime);
+                displayPortTestBufferSubstring(8, 1, "%c%1d:%2d", SYM_LINK_QUALITY, m, x);
+            }
+        }
     }
-}
 /*
  * Tests the LQ Alarms
  *


### PR DESCRIPTION
As per title, allows the user to see which rf_mode the link is running at.
![image](https://user-images.githubusercontent.com/22009829/74250670-ad57b300-4d36-11ea-937e-c273d8ea12e8.png)

