### PR TITLE
Restore proper behaviour of iterm_relax_cutoff in setpoint mode

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1020,7 +1020,7 @@ const clivalue_t valueTable[] = {
 #if defined(USE_ITERM_RELAX)
     { "iterm_relax",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ITERM_RELAX }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax) },
     { "iterm_relax_type",           VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ITERM_RELAX_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_type) },
-    { "iterm_relax_cutoff",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff) },
+    { "iterm_relax_cutoff",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff) },
 #endif
     { "iterm_windup",               VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -461,7 +461,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
 #ifdef USE_ITERM_RELAX
     { "I_RELAX",         OME_TAB,    NULL, &(OSD_TAB_t)     { &cmsx_iterm_relax,        ITERM_RELAX_COUNT - 1,      lookupTableItermRelax       }, 0 },
     { "I_RELAX TYPE",    OME_TAB,    NULL, &(OSD_TAB_t)     { &cmsx_iterm_relax_type,   ITERM_RELAX_TYPE_COUNT - 1, lookupTableItermRelaxType   }, 0 },
-    { "I_RELAX CUTOFF",  OME_UINT8,  NULL, &(OSD_UINT8_t)   { &cmsx_iterm_relax_cutoff, 1, 100, 1 }, 0 },
+    { "I_RELAX CUTOFF",  OME_UINT8,  NULL, &(OSD_UINT8_t)   { &cmsx_iterm_relax_cutoff, 1, 50, 1 }, 0 },
 #endif
 #ifdef USE_LAUNCH_CONTROL
     {"LAUNCH CONTROL", OME_Submenu, cmsMenuChange, &cmsx_menuLaunchControl, 0 },

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -282,7 +282,6 @@ static FAST_RAM_ZERO_INIT pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT uint8_t itermRelax;
 static FAST_RAM_ZERO_INIT uint8_t itermRelaxType;
 static uint8_t itermRelaxCutoff;
-static FAST_RAM_ZERO_INIT float itermRelaxSetpointThreshold;
 #endif
 
 #if defined(USE_ABSOLUTE_CONTROL)
@@ -665,7 +664,6 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     itermRelax = pidProfile->iterm_relax;
     itermRelaxType = pidProfile->iterm_relax_type;
     itermRelaxCutoff = pidProfile->iterm_relax_cutoff;
-    itermRelaxSetpointThreshold = ITERM_RELAX_SETPOINT_THRESHOLD;
 #endif
 
 #ifdef USE_ACRO_TRAINER
@@ -1160,7 +1158,7 @@ STATIC_UNIT_TESTED void applyItermRelax(const int axis, const float iterm,
 
     if (itermRelax) {
         if (axis < FD_YAW || itermRelax == ITERM_RELAX_RPY || itermRelax == ITERM_RELAX_RPY_INC) {
-            const float itermRelaxFactor = MAX(0, 1 - setpointHpf / itermRelaxSetpointThreshold);
+            const float itermRelaxFactor = MAX(0, 1 - setpointHpf / ITERM_RELAX_SETPOINT_THRESHOLD);
             const bool isDecreasingI =
                 ((iterm > 0) && (*itermErrorRate < 0)) || ((iterm < 0) && (*itermErrorRate > 0));
             if ((itermRelax >= ITERM_RELAX_RP_INC) && isDecreasingI) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -665,8 +665,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     itermRelax = pidProfile->iterm_relax;
     itermRelaxType = pidProfile->iterm_relax_type;
     itermRelaxCutoff = pidProfile->iterm_relax_cutoff;
-    // adapt setpoint threshold to user changes from default cutoff value
-    itermRelaxSetpointThreshold = ITERM_RELAX_SETPOINT_THRESHOLD * ITERM_RELAX_CUTOFF_DEFAULT / itermRelaxCutoff;
+    itermRelaxSetpointThreshold = ITERM_RELAX_SETPOINT_THRESHOLD;
 #endif
 
 #ifdef USE_ACRO_TRAINER

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -541,9 +541,9 @@ TEST(pidControllerTest, testItermRelax) {
     EXPECT_NEAR(-8.16, itermErrorRate, calculateTolerance(-8.16));
     currentPidSetpoint += ITERM_RELAX_SETPOINT_THRESHOLD;
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    EXPECT_NEAR(-2.69, itermErrorRate, calculateTolerance(-2.69));
+    EXPECT_NEAR(0, itermErrorRate, calculateTolerance(0));
     applyItermRelax(FD_PITCH, pidData[FD_PITCH].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    EXPECT_NEAR(-0.84, itermErrorRate, calculateTolerance(-0.84));
+    EXPECT_NEAR(0, itermErrorRate, calculateTolerance(0));
 
     pidProfile->iterm_relax_type = ITERM_RELAX_GYRO;
     pidInit(pidProfile);
@@ -587,7 +587,7 @@ TEST(pidControllerTest, testItermRelax) {
     pidProfile->iterm_relax = ITERM_RELAX_RPY;
     pidInit(pidProfile);
     applyItermRelax(FD_YAW, pidData[FD_YAW].I, gyroRate, &itermErrorRate, &currentPidSetpoint);
-    EXPECT_NEAR(-6.46, itermErrorRate, calculateTolerance(-3.6));
+    EXPECT_NEAR(-3.6, itermErrorRate, calculateTolerance(-3.6));
 }
 
 // TODO - Add more tests


### PR DESCRIPTION
Fixes a bug in setpoint-moue iterm_relax, introduced I think in [#7652](https://github.com/betaflight/betaflight/pull/7652), Feb 2019, that resulted in iterm relax not changing as expected when `iterm_relax_cutoff` was changed from the default value of 20 to some other value.

Background: In the original setpoint based iterm_relax code, changing `iterm_relax_cutoff` did not change the threshold used to determine whether or not I should be suppressed.  `iterm_relax_cutoff` only changed the high-pass filter that allowed more, or less, of the setpoint input signal through to be compared to a fixed value threshold.  

If the user lowered `iterm_relax_cutoff`, the high-passed signal became larger, because more would be let through, and would last for a longer duration, so the suppression was stronger and lasted longer.  This was good for freestyle.

Racers, however, wanted to increase `iterm_relax_cutoff`, to improve tight turn performance.  When the highness was increased, however, the amount of iterm_relax often became very small.   

#7562 introduced a compensating factor that changed the threshold in inverse proportion to how much the `iterm_relax_cutoff` changed, compared to defaults.  

Although that seemed to work well for racers, when they *increased* `iterm_relax_cutoff`, I recently found out that it attenuated the beneficial changes that freestylers wanted when they *decreased* `iterm_relax_cutoff`.  

I apologise that I didn't realise this until just now.  I have to thank @Bizmar for getting me to think about this again because he was finding that lowering `iterm_relax_cutoff` just didn't seem to work as expected.

This PR restores the 'original' behaviour when `iterm_relax_cutoff` is set below default of 20, resulting in less bounce back (like before) when set to 5 or 10, for example.  Freestyle pilots who used `iterm_relax_cutoff` of 10, say, should find it works properly now.

The PR also ensures that values above 20 will reduce the amount of itermRelax.  Racers who used higher than default `iterm_relax_cutoff` to tighten turns may find that a value of 30 is about as high as is needed.

The PR reduces the maximum configurable value of `iterm_relax_cutoff` value to 50, since above 50 just adds noise to the I signal, and any higher functionally disables iTermRelax, anyway.