### PR TITLE
Updated DLPF curve

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1632,7 +1632,7 @@ void dynLpfDTermUpdate(float throttle)
 float dynDtermLpfCutoffFreq(float throttle, uint16_t dynLpfMin, uint16_t dynLpfMax, uint8_t expo) {
     const float expof = expo / 10.0f;
     static float curve;
-    curve = 2 * throttle * (1 - throttle) * expof + powerf(throttle, 2);
+    curve = throttle * (1 - throttle) * expof + throttle;
     return (dynLpfMax - dynLpfMin) * curve + dynLpfMin;
 }
 


### PR DESCRIPTION
After further tests with https://github.com/betaflight/betaflight/pull/9365, setting the curve lower that 5 doesn't produces improvements so with this PR we use the 5-10 range of the previous one. Here a graph of how it works compared to the default dyn dterm lpf code.
![update expo curve](https://user-images.githubusercontent.com/25136267/74596886-962a0580-5055-11ea-8632-e34cab1cc1ac.png)
