### PR TITLE
Support RCC_ClockCmd and RCC_ResetCmd for HAL

### DIFF
--- a/src/main/drivers/adc_stm32g4xx.c
+++ b/src/main/drivers/adc_stm32g4xx.c
@@ -433,10 +433,12 @@ void adcInit(const adcConfig_t *config)
 
         // Deinitialize  & Initialize the DMA for new transfer
 
+        // dmaInit must be called before calling HAL_DMA_Init,
+        // to enable clock for associated DMA if not already done so.
+        dmaInit(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev));
+
         HAL_DMA_DeInit(&adc->DmaHandle);
         HAL_DMA_Init(&adc->DmaHandle);
-
-        dmaInit(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev));
 
         // Associate the DMA handle
 

--- a/src/main/drivers/adc_stm32h7xx.c
+++ b/src/main/drivers/adc_stm32h7xx.c
@@ -402,10 +402,12 @@ void adcInit(const adcConfig_t *config)
 
         // Deinitialize  & Initialize the DMA for new transfer
 
+        // dmaInit must be called before calling HAL_DMA_Init,
+        // to enable clock for associated DMA if not already done so.
+        dmaInit(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev));
+
         HAL_DMA_DeInit(&adc->DmaHandle);
         HAL_DMA_Init(&adc->DmaHandle);
-
-        dmaInit(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev));
 
         // Associate the DMA handle
 

--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -358,6 +358,8 @@ void i2cInit(I2CDevice device)
     IO_t scl = pDev->scl;
     IO_t sda = pDev->sda;
 
+    RCC_ClockCmd(hardware->rcc, ENABLE);
+
     IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(device));
     IOInit(sda, OWNER_I2C_SDA, RESOURCE_INDEX(device));
 

--- a/src/main/drivers/pwm_output_dshot_hal_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal_hal.c
@@ -364,6 +364,18 @@ P    -    High -     High -
         motor->timerDmaIndex = timerDmaIndex(timerHardware->channel);
     }
 
+    dmaIdentifier_e identifier = dmaGetIdentifier(dmaRef);
+
+#ifdef USE_DSHOT_DMAR
+    if (useBurstDshot) {
+        dmaInit(identifier, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim));
+        dmaSetHandler(identifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, timerIndex);
+    } else
+#endif
+    {
+        dmaInit(identifier, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+        dmaSetHandler(identifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, motorIndex);
+    }
 
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
@@ -426,18 +438,6 @@ P    -    High -     High -
     if (result != HAL_OK) {
         /* Initialization Error */
         return false;
-    }
-
-    dmaIdentifier_e identifier = dmaGetIdentifier(dmaRef);
-#ifdef USE_DSHOT_DMAR
-    if (useBurstDshot) {
-        dmaInit(identifier, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim));
-        dmaSetHandler(identifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, timerIndex);
-    } else
-#endif
-    {
-        dmaInit(identifier, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
-        dmaSetHandler(identifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, motorIndex);
     }
 
     // Start the timer channel now.

--- a/src/main/drivers/rcc.c
+++ b/src/main/drivers/rcc.c
@@ -25,10 +25,72 @@ void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 {
     int tag = periphTag >> 5;
     uint32_t mask = 1 << (periphTag & 0x1f);
+
 #if defined(USE_HAL_DRIVER)
-    (void)tag;
-    (void)mask;
-    (void)NewState;
+
+#define __HAL_RCC_CLK_ENABLE(bus, enbit)   do {          \
+        __IO uint32_t tmpreg;                              \
+        SET_BIT(RCC->bus ## ENR, enbit);                 \
+        /* Delay after an RCC peripheral clock enabling */ \
+        tmpreg = READ_BIT(RCC->bus ## ENR, enbit);       \
+        UNUSED(tmpreg);                                    \
+    } while(0)
+
+#define __HAL_RCC_CLK_DISABLE(bus, enbit) (RCC->bus ## ENR &= ~(enbit))
+
+#define __HAL_RCC_CLK(enreg, enbit, newState) \
+    if (newState == ENABLE) {                 \
+        __HAL_RCC_CLK_ENABLE(enreg, enbit);   \
+    } else {                                  \
+        __HAL_RCC_CLK_DISABLE(enreg, enbit);  \
+    }
+
+    switch (tag) {
+    case RCC_AHB1:
+        __HAL_RCC_CLK(AHB1, mask, NewState);
+        break;
+
+    case RCC_AHB2:
+        __HAL_RCC_CLK(AHB2, mask, NewState);
+        break;
+
+#ifndef STM32H7
+    case RCC_APB1:
+        __HAL_RCC_CLK(APB1, mask, NewState);
+        break;
+#endif
+
+    case RCC_APB2:
+        __HAL_RCC_CLK(APB2, mask, NewState);
+        break;
+
+#ifdef STM32H7
+
+    case RCC_AHB3:
+        __HAL_RCC_CLK(AHB3, mask, NewState);
+        break;
+
+    case RCC_AHB4:
+        __HAL_RCC_CLK(AHB4, mask, NewState);
+        break;
+
+    case RCC_APB1L:
+        __HAL_RCC_CLK(APB1L, mask, NewState);
+        break;
+
+    case RCC_APB1H:
+        __HAL_RCC_CLK(APB1H, mask, NewState);
+        break;
+
+    case RCC_APB3:
+        __HAL_RCC_CLK(APB3, mask, NewState);
+        break;
+
+    case RCC_APB4:
+        __HAL_RCC_CLK(APB4, mask, NewState);
+        break;
+#endif
+    }
 #else
     switch (tag) {
 #if defined(STM32F3) || defined(STM32F1)
@@ -55,11 +117,68 @@ void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 {
     int tag = periphTag >> 5;
     uint32_t mask = 1 << (periphTag & 0x1f);
+
+// Peripheral reset control relies on RSTR bits are identical to ENR bits where applicable
+#define __HAL_RCC_FORCE_RESET(bus, enbit) (RCC->bus ## RSTR &= ~(enbit))
+#define __HAL_RCC_RELEASE_RESET(bus, enbit) (RCC->bus ## RSTR &= ~(enbit))
+#define __HAL_RCC_RESET(bus, enbit, NewState) \
+    if (NewState == ENABLE) {                    \
+        __HAL_RCC_RELEASE_RESET(bus, enbit);  \
+    } else {                                     \
+        __HAL_RCC_FORCE_RESET(bus, enbit);    \
+    }
+
 #if defined(USE_HAL_DRIVER)
-    (void)tag;
-    (void)mask;
-    (void)NewState;
+
+    switch (tag) {
+    case RCC_AHB1:
+        __HAL_RCC_RESET(AHB1, mask, NewState);
+        break;
+
+    case RCC_AHB2:
+        __HAL_RCC_RESET(AHB2, mask, NewState);
+        break;
+
+#ifndef STM32H7
+    case RCC_APB1:
+        __HAL_RCC_RESET(APB1, mask, NewState);
+        break;
+#endif
+
+    case RCC_APB2:
+        __HAL_RCC_RESET(APB2, mask, NewState);
+        break;
+
+#ifdef STM32H7
+
+    case RCC_AHB3:
+        __HAL_RCC_RESET(AHB3, mask, NewState);
+        break;
+
+    case RCC_AHB4:
+        __HAL_RCC_RESET(AHB4, mask, NewState);
+        break;
+
+    case RCC_APB1L:
+        __HAL_RCC_RESET(APB1L, mask, NewState);
+        break;
+
+    case RCC_APB1H:
+        __HAL_RCC_RESET(APB1H, mask, NewState);
+        break;
+
+    case RCC_APB3:
+        __HAL_RCC_RESET(APB3, mask, NewState);
+        break;
+
+    case RCC_APB4:
+        __HAL_RCC_RESET(APB4, mask, NewState);
+        break;
+#endif
+    }
+
 #else
+
     switch (tag) {
 #if defined(STM32F3) || defined(STM32F10X_CL)
     case RCC_AHB:

--- a/src/main/drivers/rcc.c
+++ b/src/main/drivers/rcc.c
@@ -28,21 +28,21 @@ void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 
 #if defined(USE_HAL_DRIVER)
 
-#define __HAL_RCC_CLK_ENABLE(bus, enbit)   do {          \
+#define __HAL_RCC_CLK_ENABLE(bus, enbit)   do {            \
         __IO uint32_t tmpreg;                              \
-        SET_BIT(RCC->bus ## ENR, enbit);                 \
+        SET_BIT(RCC->bus ## ENR, enbit);                   \
         /* Delay after an RCC peripheral clock enabling */ \
-        tmpreg = READ_BIT(RCC->bus ## ENR, enbit);       \
+        tmpreg = READ_BIT(RCC->bus ## ENR, enbit);         \
         UNUSED(tmpreg);                                    \
     } while(0)
 
 #define __HAL_RCC_CLK_DISABLE(bus, enbit) (RCC->bus ## ENR &= ~(enbit))
 
-#define __HAL_RCC_CLK(enreg, enbit, newState) \
-    if (newState == ENABLE) {                 \
-        __HAL_RCC_CLK_ENABLE(enreg, enbit);   \
-    } else {                                  \
-        __HAL_RCC_CLK_DISABLE(enreg, enbit);  \
+#define __HAL_RCC_CLK(bus, enbit, newState) \
+    if (newState == ENABLE) {               \
+        __HAL_RCC_CLK_ENABLE(bus, enbit);   \
+    } else {                                \
+        __HAL_RCC_CLK_DISABLE(bus, enbit);  \
     }
 
     switch (tag) {
@@ -119,12 +119,12 @@ void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
     uint32_t mask = 1 << (periphTag & 0x1f);
 
 // Peripheral reset control relies on RSTR bits are identical to ENR bits where applicable
-#define __HAL_RCC_FORCE_RESET(bus, enbit) (RCC->bus ## RSTR &= ~(enbit))
+#define __HAL_RCC_FORCE_RESET(bus, enbit) (RCC->bus ## RSTR |= (enbit))
 #define __HAL_RCC_RELEASE_RESET(bus, enbit) (RCC->bus ## RSTR &= ~(enbit))
 #define __HAL_RCC_RESET(bus, enbit, NewState) \
-    if (NewState == ENABLE) {                    \
+    if (NewState == ENABLE) {                 \
         __HAL_RCC_RELEASE_RESET(bus, enbit);  \
-    } else {                                     \
+    } else {                                  \
         __HAL_RCC_FORCE_RESET(bus, enbit);    \
     }
 

--- a/src/main/drivers/rcc.h
+++ b/src/main/drivers/rcc.h
@@ -22,10 +22,6 @@
 
 #include "rcc_types.h"
 
-// XXX rcc module is not actively used by HAL based platforms (F7 and H7),
-// XXX as peripherals are turned on statically in enableGPIOPowerUsageAndNoiseReductions()
-// XXX during initialization.
-
 enum rcc_reg {
     RCC_EMPTY = 0,   // make sure that default value (0) does not enable anything
 #ifdef STM32H7
@@ -39,7 +35,7 @@ enum rcc_reg {
     RCC_APB3,
     RCC_AHB4,
     RCC_APB4,
-#elif defined(STM32G4)
+#elif defined(STM32G4) || defined(STM32F7)
     RCC_AHB2,
     RCC_APB2,
     RCC_APB1,
@@ -75,6 +71,13 @@ enum rcc_reg {
 #define RCC_APB12(periph) RCC_ENCODE(RCC_APB1, RCC_APB1ENR2_ ## periph ## EN)
 #define RCC_AHB1(periph) RCC_ENCODE(RCC_AHB1, RCC_AHB1ENR_ ## periph ## EN)
 #define RCC_AHB2(periph) RCC_ENCODE(RCC_AHB2, RCC_AHB2ENR_ ## periph ## EN)
+#endif
+
+#ifdef STM32F7
+#define RCC_AHB1(periph) RCC_ENCODE(RCC_AHB1, RCC_AHB1ENR_ ## periph ## EN)
+#define RCC_AHB2(periph) RCC_ENCODE(RCC_AHB2, RCC_AHB2ENR_ ## periph ## EN)
+#define RCC_APB1(periph) RCC_ENCODE(RCC_APB1, RCC_APB1ENR_ ## periph ## EN)
+#define RCC_APB2(periph) RCC_ENCODE(RCC_APB2, RCC_APB2ENR_ ## periph ## EN)
 #endif
 
 void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState);

--- a/src/main/drivers/sdio_f7xx.c
+++ b/src/main/drivers/sdio_f7xx.c
@@ -1641,6 +1641,8 @@ bool SD_Init(void)
 {
     SD_Error_t ErrorState;
 
+    __HAL_RCC_SDMMC1_CLK_ENABLE();
+
     // Initialize SDMMC1 peripheral interface with default configuration for SD card initialization
     MODIFY_REG(SDMMC1->CLKCR, CLKCR_CLEAR_MASK, (uint32_t) SDMMC_INIT_CLK_DIV);
 

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -155,13 +155,7 @@ typedef struct uartHardware_s {
     uartPinDef_t rxPins[UARTHARDWARE_MAX_PINS];
     uartPinDef_t txPins[UARTHARDWARE_MAX_PINS];
 
-#if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
-    uint32_t rcc_ahb1;
-    rccPeriphTag_t rcc_apb2;
-    rccPeriphTag_t rcc_apb1;
-#else
     rccPeriphTag_t rcc;
-#endif
 
 #if !defined(STM32F7)
     uint8_t af;

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -68,10 +68,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PB14), GPIO_AF4_USART1 }
 #endif
         },
-#ifdef UART1_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART1_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb2 = RCC_APB2(USART1),
+        .rcc = RCC_APB2(USART1),
         .rxIrq = USART1_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1,
@@ -102,10 +99,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PA2), GPIO_AF7_USART2 },
             { DEFIO_TAG_E(PD5), GPIO_AF7_USART2 }
         },
-#ifdef UART2_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART2_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb1 = RCC_APB1(USART2),
+        .rcc = RCC_APB1(USART2),
         .rxIrq = USART2_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2,
@@ -138,10 +132,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PC10), GPIO_AF7_USART3 },
             { DEFIO_TAG_E(PD8), GPIO_AF7_USART3 }
         },
-#ifdef UART3_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART3_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb1 = RCC_APB1(USART3),
+        .rcc = RCC_APB1(USART3),
         .rxIrq = USART3_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3,
@@ -180,10 +171,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PD1), GPIO_AF8_UART4 }
 #endif
         },
-#ifdef UART4_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART4_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb1 = RCC_APB1(UART4),
+        .rcc = RCC_APB1(UART4),
         .rxIrq = UART4_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4,
@@ -222,10 +210,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PB13), GPIO_AF8_UART5 }
 #endif
         },
-#ifdef UART5_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART5_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb1 = RCC_APB1(UART5),
+        .rcc = RCC_APB1(UART5),
         .rxIrq = UART5_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART5,
@@ -256,10 +241,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PC6), GPIO_AF8_USART6 },
             { DEFIO_TAG_E(PG14), GPIO_AF8_USART6 }
         },
-#ifdef UART6_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART6_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb2 = RCC_APB2(USART6),
+        .rcc = RCC_APB2(USART6),
         .rxIrq = USART6_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6,
@@ -298,10 +280,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PB4), GPIO_AF12_UART7 }
 #endif
         },
-#ifdef UART7_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART7_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb1 = RCC_APB1(UART7),
+        .rcc = RCC_APB1(UART7),
         .rxIrq = UART7_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART7_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART7,
@@ -330,10 +309,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPins = {
             { DEFIO_TAG_E(PE1), GPIO_AF8_UART8 }
         },
-#ifdef UART8_AHB1_PERIPHERALS
-        .rcc_ahb1 = UART8_AHB1_PERIPHERALS,
-#endif
-        .rcc_apb1 = RCC_APB1(UART8),
+        .rcc = RCC_APB1(UART8),
         .rxIrq = UART8_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART8_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART8,
@@ -374,6 +350,10 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 #endif
 
     s->Handle.Instance = hardware->reg;
+
+    if (hardware->rcc) {
+        RCC_ClockCmd(hardware->rcc, ENABLE);
+    }
 
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);

--- a/src/main/drivers/serial_uart_stm32g4xx.c
+++ b/src/main/drivers/serial_uart_stm32g4xx.c
@@ -286,6 +286,10 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     s->Handle.Instance = hardware->reg;
 
+    if (hardware->rcc) {
+        RCC_ClockCmd(hardware->rcc, ENABLE);
+    }
+
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);
 

--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -109,7 +109,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PB6),  GPIO_AF4_USART1 },
             { DEFIO_TAG_E(PB14), GPIO_AF4_USART1 },
         },
-        .rcc_apb2 = RCC_APB2(USART1),
+        .rcc = RCC_APB2(USART1),
         .rxIrq = USART1_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1,
@@ -138,7 +138,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PA2), GPIO_AF7_USART2 },
             { DEFIO_TAG_E(PD5), GPIO_AF7_USART2 }
         },
-        .rcc_apb1 = RCC_APB1L(USART2),
+        .rcc = RCC_APB1L(USART2),
         .rxIrq = USART2_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2,
@@ -169,7 +169,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PC10), GPIO_AF7_USART3 },
             { DEFIO_TAG_E(PD8), GPIO_AF7_USART3 }
         },
-        .rcc_apb1 = RCC_APB1L(USART3),
+        .rcc = RCC_APB1L(USART3),
         .rxIrq = USART3_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3,
@@ -204,7 +204,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PC10), GPIO_AF8_UART4 },
             { DEFIO_TAG_E(PD1),  GPIO_AF8_UART4 }
         },
-        .rcc_apb1 = RCC_APB1L(UART4),
+        .rcc = RCC_APB1L(UART4),
         .rxIrq = UART4_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4,
@@ -235,7 +235,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PB13), GPIO_AF14_UART5 },
             { DEFIO_TAG_E(PC12), GPIO_AF8_UART5 },
         },
-        .rcc_apb1 = RCC_APB1L(UART5),
+        .rcc = RCC_APB1L(UART5),
         .rxIrq = UART5_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART5,
@@ -264,7 +264,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PC6), GPIO_AF7_USART6 },
             { DEFIO_TAG_E(PG14), GPIO_AF7_USART6 }
         },
-        .rcc_apb2 = RCC_APB2(USART6),
+        .rcc = RCC_APB2(USART6),
         .rxIrq = USART6_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6,
@@ -297,7 +297,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PE8),  GPIO_AF7_UART7 },
             { DEFIO_TAG_E(PF7),  GPIO_AF7_UART7 },
         },
-        .rcc_apb1 = RCC_APB1L(UART7),
+        .rcc = RCC_APB1L(UART7),
         .rxIrq = UART7_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART7_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART7,
@@ -324,7 +324,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPins = {
             { DEFIO_TAG_E(PE1), GPIO_AF8_UART8 }
         },
-        .rcc_apb1 = RCC_APB1L(UART8),
+        .rcc = RCC_APB1L(UART8),
         .rxIrq = UART8_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART8_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART8,
@@ -365,6 +365,10 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 #endif
 
     s->Handle.Instance = hardware->reg;
+
+    if (hardware->rcc) {
+        RCC_ClockCmd(hardware->rcc, ENABLE);
+    }
 
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -61,82 +61,6 @@ void systemResetToBootloader(bootloaderRequestType_e requestType)
     NVIC_SystemReset();
 }
 
-void enableGPIOPowerUsageAndNoiseReductions(void)
-{
-
-    // AHB1
-    __HAL_RCC_BKPSRAM_CLK_ENABLE();
-    __HAL_RCC_DTCMRAMEN_CLK_ENABLE();
-    __HAL_RCC_DMA2_CLK_ENABLE();
-    __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
-    __HAL_RCC_USB_OTG_HS_ULPI_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOD_CLK_ENABLE();
-    __HAL_RCC_GPIOE_CLK_ENABLE();
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    __HAL_RCC_GPIOG_CLK_ENABLE();
-    __HAL_RCC_GPIOH_CLK_ENABLE();
-    __HAL_RCC_GPIOI_CLK_ENABLE();
-#ifndef STM32F722xx
-    __HAL_RCC_DMA2D_CLK_ENABLE();
-    __HAL_RCC_GPIOJ_CLK_ENABLE();
-    __HAL_RCC_GPIOK_CLK_ENABLE();
-#endif
-
-    //APB1
-    __HAL_RCC_TIM2_CLK_ENABLE();
-    __HAL_RCC_TIM3_CLK_ENABLE();
-    __HAL_RCC_TIM4_CLK_ENABLE();
-    __HAL_RCC_TIM5_CLK_ENABLE();
-    __HAL_RCC_TIM6_CLK_ENABLE();
-    __HAL_RCC_TIM7_CLK_ENABLE();
-    __HAL_RCC_TIM12_CLK_ENABLE();
-    __HAL_RCC_TIM13_CLK_ENABLE();
-    __HAL_RCC_TIM14_CLK_ENABLE();
-    __HAL_RCC_LPTIM1_CLK_ENABLE();
-    __HAL_RCC_SPI2_CLK_ENABLE();
-    __HAL_RCC_SPI3_CLK_ENABLE();
-    __HAL_RCC_USART2_CLK_ENABLE();
-    __HAL_RCC_USART3_CLK_ENABLE();
-    __HAL_RCC_UART4_CLK_ENABLE();
-    __HAL_RCC_UART5_CLK_ENABLE();
-    __HAL_RCC_I2C1_CLK_ENABLE();
-    __HAL_RCC_I2C2_CLK_ENABLE();
-    __HAL_RCC_I2C3_CLK_ENABLE();
-    __HAL_RCC_CAN1_CLK_ENABLE();
-    __HAL_RCC_DAC_CLK_ENABLE();
-    __HAL_RCC_UART7_CLK_ENABLE();
-    __HAL_RCC_UART8_CLK_ENABLE();
-#ifndef STM32F722xx
-    __HAL_RCC_I2C4_CLK_ENABLE();
-    __HAL_RCC_CAN2_CLK_ENABLE();
-    __HAL_RCC_CEC_CLK_ENABLE();
-#endif
-
-    //APB2
-    __HAL_RCC_TIM1_CLK_ENABLE();
-    __HAL_RCC_TIM8_CLK_ENABLE();
-    __HAL_RCC_USART1_CLK_ENABLE();
-    __HAL_RCC_USART6_CLK_ENABLE();
-    __HAL_RCC_ADC1_CLK_ENABLE();
-    __HAL_RCC_ADC2_CLK_ENABLE();
-    __HAL_RCC_ADC3_CLK_ENABLE();
-    __HAL_RCC_SDMMC1_CLK_ENABLE();
-    __HAL_RCC_SPI1_CLK_ENABLE();
-    __HAL_RCC_SPI4_CLK_ENABLE();
-    __HAL_RCC_TIM9_CLK_ENABLE();
-    __HAL_RCC_TIM10_CLK_ENABLE();
-    __HAL_RCC_TIM11_CLK_ENABLE();
-    __HAL_RCC_SPI5_CLK_ENABLE();
-    __HAL_RCC_SAI1_CLK_ENABLE();
-    __HAL_RCC_SAI2_CLK_ENABLE();
-#ifndef STM32F722xx
-    __HAL_RCC_SPI6_CLK_ENABLE();
-#endif
-}
-
 bool isMPUSoftReset(void)
 {
     if (cachedRccCsrValue & RCC_CSR_SFTRSTF)
@@ -186,8 +110,6 @@ void systemInit(void)
     //__HAL_RCC_USB_OTG_FS_CLK_DISABLE;
 
     //RCC_ClearFlag();
-
-    enableGPIOPowerUsageAndNoiseReductions();
 
     // Init cycle counter
     cycleCounterInit();

--- a/src/main/drivers/system_stm32h7xx.c
+++ b/src/main/drivers/system_stm32h7xx.c
@@ -31,95 +31,6 @@
 
 void SystemClock_Config(void);
 
-
-void enablePeripherialClocks(void)
-{
-    __HAL_RCC_MDMA_CLK_ENABLE();
-    __HAL_RCC_QSPI_CLK_ENABLE();
-
-    // AHB1
-    __HAL_RCC_DMA1_CLK_ENABLE();
-    __HAL_RCC_DMA2_CLK_ENABLE();
-    __HAL_RCC_ADC12_CLK_ENABLE();
-    // USB clock will be enabled by vcpXXX/usbd_conf.c
-    // Note that enabling both ULPI and non-ULPI does not work.
-
-    // AHB2
-    __HAL_RCC_D2SRAM1_CLK_ENABLE();
-    __HAL_RCC_D2SRAM2_CLK_ENABLE();
-    __HAL_RCC_D2SRAM3_CLK_ENABLE();
-
-    // AHB4
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOD_CLK_ENABLE();
-    __HAL_RCC_GPIOE_CLK_ENABLE();
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    __HAL_RCC_GPIOG_CLK_ENABLE();
-    __HAL_RCC_GPIOH_CLK_ENABLE();
-    __HAL_RCC_GPIOI_CLK_ENABLE();
-    __HAL_RCC_GPIOJ_CLK_ENABLE();
-    __HAL_RCC_GPIOK_CLK_ENABLE();
-    __HAL_RCC_BDMA_CLK_ENABLE();
-    __HAL_RCC_ADC3_CLK_ENABLE();
-
-    // APB3
-
-    // APB1
-    __HAL_RCC_TIM2_CLK_ENABLE();
-    __HAL_RCC_TIM3_CLK_ENABLE();
-    __HAL_RCC_TIM4_CLK_ENABLE();
-    __HAL_RCC_TIM5_CLK_ENABLE();
-    __HAL_RCC_TIM6_CLK_ENABLE();
-    __HAL_RCC_TIM7_CLK_ENABLE();
-    __HAL_RCC_TIM12_CLK_ENABLE();
-    __HAL_RCC_TIM13_CLK_ENABLE();
-    __HAL_RCC_TIM14_CLK_ENABLE();
-    __HAL_RCC_LPTIM1_CLK_ENABLE();
-    __HAL_RCC_SPI2_CLK_ENABLE();
-    __HAL_RCC_SPI3_CLK_ENABLE();
-    __HAL_RCC_USART2_CLK_ENABLE();
-    __HAL_RCC_USART3_CLK_ENABLE();
-    __HAL_RCC_UART4_CLK_ENABLE();
-    __HAL_RCC_UART5_CLK_ENABLE();
-    __HAL_RCC_I2C1_CLK_ENABLE();
-    __HAL_RCC_I2C2_CLK_ENABLE();
-    __HAL_RCC_I2C3_CLK_ENABLE();
-    __HAL_RCC_DAC12_CLK_ENABLE();
-    __HAL_RCC_UART7_CLK_ENABLE();
-    __HAL_RCC_UART8_CLK_ENABLE();
-    __HAL_RCC_CRS_CLK_ENABLE();
-
-    // APB2
-    __HAL_RCC_TIM1_CLK_ENABLE();
-    __HAL_RCC_TIM8_CLK_ENABLE();
-    __HAL_RCC_USART1_CLK_ENABLE();
-    __HAL_RCC_USART6_CLK_ENABLE();
-    __HAL_RCC_SPI1_CLK_ENABLE();
-    __HAL_RCC_SPI4_CLK_ENABLE();
-    __HAL_RCC_TIM15_CLK_ENABLE();
-    __HAL_RCC_TIM16_CLK_ENABLE();
-    __HAL_RCC_TIM17_CLK_ENABLE();
-    __HAL_RCC_SPI5_CLK_ENABLE();
-
-    // APB4
-    __HAL_RCC_SYSCFG_CLK_ENABLE();
-    __HAL_RCC_LPUART1_CLK_ENABLE();
-    __HAL_RCC_SPI6_CLK_ENABLE();
-    __HAL_RCC_I2C4_CLK_ENABLE();
-    __HAL_RCC_LPTIM2_CLK_ENABLE();
-    __HAL_RCC_LPTIM3_CLK_ENABLE();
-    __HAL_RCC_LPTIM4_CLK_ENABLE();
-    __HAL_RCC_LPTIM5_CLK_ENABLE();
-    __HAL_RCC_COMP12_CLK_ENABLE();
-    __HAL_RCC_VREF_CLK_ENABLE();
-}
-
-void enableGPIOPowerUsageAndNoiseReductions(void)
-{
-}
-
 void configureMasterClockOutputs(void)
 {
     // Initialize pins for MCO1 and MCO2 for clock testing/verification
@@ -166,9 +77,9 @@ void systemInit(void)
 
     //RCC_ClearFlag();
 
-    enablePeripherialClocks();
-
-    enableGPIOPowerUsageAndNoiseReductions();
+    __HAL_RCC_D2SRAM1_CLK_ENABLE();
+    __HAL_RCC_D2SRAM2_CLK_ENABLE();
+    __HAL_RCC_D2SRAM3_CLK_ENABLE();
 
 #ifdef USE_MCO_OUTPUTS
     configureMasterClockOutputs();


### PR DESCRIPTION
`RCC_ClockCmd` (and `RCC_ResetCmd`) is now properly supported for HAL based targets (F7, H7 and G4), and peripheral clock enabling were removed from startup procedure. Should save some power.
