### PR TITLE
New Actual Rates model : set rates in deg/s, independently of each other

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -336,7 +336,7 @@ static const char * const lookupTableGyroOverflowCheck[] = {
 #endif
 
 static const char * const lookupTableRatesType[] = {
-    "BETAFLIGHT", "RACEFLIGHT", "KISS"
+    "BETAFLIGHT", "RACEFLIGHT", "KISS", "ACTUAL"
 };
 
 #ifdef USE_OVERCLOCK

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -28,6 +28,7 @@ typedef enum {
     RATES_TYPE_BETAFLIGHT = 0,
     RATES_TYPE_RACEFLIGHT,
     RATES_TYPE_KISS,
+    RATES_TYPE_ACTUAL,
 } ratesType_e;
 
 typedef enum {

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -198,7 +198,7 @@ float applyActualRates(const int axis, float rcCommandf, const float rcCommandfA
     float expof = currentControlRateProfile->rcExpo[axis] / 100.0f;
     expof = rcCommandfAbs * (powerf(rcCommandf, 5) * expof + rcCommandf * (1 - expof));
 
-    const float centerSensitivity = currentControlRateProfile->rcRates[axis];
+    const float centerSensitivity = currentControlRateProfile->rcRates[axis] * 10.0f;
     const float stickMovement = MAX(0, currentControlRateProfile->rates[axis] * 10.0f - centerSensitivity);
     const float angleRate = rcCommandf * centerSensitivity + stickMovement * expof;
 

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -193,6 +193,18 @@ float applyKissRates(const int axis, float rcCommandf, const float rcCommandfAbs
     return kissAngle;
 }
 
+float applyActualRates(const int axis, float rcCommandf, const float rcCommandfAbs)
+{
+    float expof = currentControlRateProfile->rcExpo[axis] / 100.0f;
+    expof = rcCommandfAbs * (powerf(rcCommandf, 5) * expof + rcCommandf * (1 - expof));
+
+    const float centerSensitivity = currentControlRateProfile->rcRates[axis];
+    const float stickMovement = MAX(0, currentControlRateProfile->rates[axis] * 10.0f - centerSensitivity);
+    const float angleRate = rcCommandf * centerSensitivity + stickMovement * expof;
+
+    return angleRate;
+}
+
 float applyCurve(int axis, float deflection)
 {
     return applyRates(axis, deflection, fabsf(deflection));
@@ -815,6 +827,10 @@ void initRcProcessing(void)
         break;
     case RATES_TYPE_KISS:
         applyRates = applyKissRates;
+
+        break;
+    case RATES_TYPE_ACTUAL:
+        applyRates = applyActualRates;
 
         break;
     }


### PR DESCRIPTION
This PR proposes the introduction of a new method for configuring Rates, based on ideas I've had for quite a long time.  Big THANK YOU to IllusionFPV for providing me with the impetus to actually do something, and for his coding assistance.

The classic Betaflight rates model uses three 8 bit parameters:

- rcRrate, which returns a linear relationship between stick position and rate, such that the maximum rate in deg/s, at full stick, is 200 times the Configurator value (twice the CLI number).

- SRate, which exponentially increases the preceding linear rate as the sticks move out from centre. It has little or no effect at centre position. The inflexion point of the curve cannot be changed.  Adding more SRate will make for a steeper looking curve because the maximum rate increases a lot at maximum stick deflection.  An SRate value of 0.5 in Configurator (50 in CLI) will double the rate at maximum stick position.

- Expo, which adds a second 'curve' on top of the preceding values, with greater effect around centre stick position, and no effect on maximum rate.  The inflexion point of the curve is a bit different from the SRate curve, and changes with the amount of expo.  An expo value of 0.5 in Configurator will flatten the rate curve around centre stick by a factor of 2x, but will not change maximum rate.

When we configure our rates, we primarily care about three things:

- centre stick 'sensitivity', or, how 'twitchy' is the centre stick responsiveness?  Technically, this is determined by the rate change of rate per unit stick deflection around centre position.  

- the maximum roll rate at full stick deflection, i.e., how fast will it spin when we do a flip.

- how quickly the responsiveness changes as we move the stick from centre to full deflection, or 'expo inflexion point', meaning, whether the change in responsiveness increases steadily and smoothly as the sticks move further out (low expo, as used by racers), or whether we get a wide range of relatively low responsiveness and then a sudden increase at max rates (high expo, as often used in freestyle).  

While Betaflight rates have been around a long time, the method has some drawbacks:

- cannot set centre sensitivity or max rate in degrees/s
- each parameter interacts with another in terms of its effect
- limited control over the expo transition point
- weird config numbers that don't directly relate to outcomes
- config numbers that are different in CLI and Configurator

This summarises the interactions between Betaflight rate settings and outcomes:

- centre 'sensitivity' is affected by both rcRate and expo
- max roll rate is affected by both rcRate and SRate
- expo inflexion point is affected by both SRate and expo

This PR proposes the eventual replacement of the current Betaflight rates configuration paradigm with a different method.  The goals are:

- let the user set centre sensitivity, max roll rate and expo inflexion directly
- ensure that value is independent of any other
- set centre sensitivity and max roll rate in deg/s
- ultimately, show the same number in CLI and Configurator (requires 16bit values)

The way the code works is:

- first, use the value for 'centre sensitivity' to directly configure a 'baseline' linear response to stick movement.  The value entered for 'centre sensitivity' represents the actual stick sensitivity at centre in degrees/sec. The number entered is the centre 'feel' you'd get for a linear rate configured at the set deg/s.  This is the kind of 'base' responsiveness.

- let the user set their desired max turn rate in deg/s, and make a 'wedge shaped' linear ramp of the extra rate amount, above baseline, that is needed to get to that max rate at full deflection.

- apply an expo factor that changes the inflexion point of that ramped quantity from nearly linear to rising sharply at extreme stick deflection.  

Ideally, the centre sensitivity and max rate would be entered directly as deg/s.  For example, a freestyle setup might be centre sensitivity of 120 deg/s and max rate of 800 deg/s, and a race setup might range from 150 to 500.  In this PR, I have to re-use the rcRate and Rate 8 bit values.

To enter values as per this PR, we have to use 8 bit numbers, as follows:

- Centre sensitivity: for 150, set rcRate to 0.15 in Configurator,  or 15 in CLI.
- Max Rate: for 800, set SRate to 0.8 in Configurator, or 80 in CLI.
- Expo: set the same as before.  0.5 in Configurator, or 50 in CLI.

To determine your current centre sensitivity from the classic Betaflight rates:

- if you have no expo, it is rcRate * 200
- if you ave expo, it is rcRate * 200, attenuatedby (1-expo). 

So if you had an rcRate of 0.75 and no expo, your current centre sensitivity is 150.  If you have rcRate of 1.0, and 0.5 of expo, your current centre sensitivity is 100.

Your max rate is shown by the Rates curve in Configurator.

Once you know your current centre sensitivity and max rate, you can switch to the new `ACTUAL` rates method, and enter these values directly.

The new expo factor is a true inflexion point curve adjustment, and can't be directly translated from any previous Betaflight settings since they have complex interactions.  A starting value of 0.5 is fairly typical.  When set to 0, the stick responsiveness changes more smoothly than is possible currently.  When set to 1, the expo is quite extreme.  

Note that changing expo will not change your centre sensitivity or your max rate.  Centre feel will differ with low expo because we get a greater increase in rates around centre than with higher expo, but the actual dead centre sensititity to fine inputs will not change.