### PR TITLE
CLI: Print range info for strings

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -839,6 +839,10 @@ static void cliPrintVarRange(const clivalue_t *var)
         cliPrintLinef("Array length: %d", var->config.array.length);
     }
     break;
+    case (MODE_STRING): {
+        cliPrintLinef("String length: %d - %d", var->config.string.minlength, var->config.string.maxlength);
+    }
+    break;
     case (MODE_BITSET): {
         cliPrintLinef("Allowed values: OFF, ON");
     }


### PR DESCRIPTION
When using the CLI `get` command, info is displayed about allowed values, range, etc.
There were no info for string variables, so I added it.