### PR TITLE
Motor_output_limit settings to msp

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1793,6 +1793,9 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 #else
         sbufWriteU8(dst, 0);
 #endif
+        // Added in MSP API 1.43
+        sbufWriteU8(dst, currentPidProfile->motor_output_limit);
+        sbufWriteU8(dst, currentPidProfile->auto_profile_cell_count);
 
         break;
     case MSP_SENSOR_CONFIG:
@@ -2633,6 +2636,11 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #else
             sbufReadU8(src);
 #endif
+        }
+        if(sbufBytesRemaining(src) >= 2) {
+            // Added in MSP API 1.43
+            currentPidProfile->motor_output_limit = sbufReadU8(src);
+            currentPidProfile->auto_profile_cell_count = sbufReadU8(src);
         }
         pidInitConfig(currentPidProfile);
 


### PR DESCRIPTION
Adding `motor_output_limit` and `auto_profile_cell_count` to includes in 10.7.0 Configurator.