### PR TITLE
[H7] Refactor enableDmaClock with RCC_ClockCmd

### DIFF
--- a/src/main/drivers/dma_stm32h7xx.c
+++ b/src/main/drivers/dma_stm32h7xx.c
@@ -28,7 +28,8 @@
 
 #include "drivers/nvic.h"
 #include "drivers/dma.h"
-#include "resource.h"
+#include "drivers/rcc.h"
+#include "drivers/resource.h"
 
 /*
  * DMA descriptors.
@@ -51,7 +52,6 @@ static dmaChannelDescriptor_t dmaDescriptors[DMA_LAST_HANDLER] = {
     DEFINE_DMA_CHANNEL(DMA2, 5, 38),
     DEFINE_DMA_CHANNEL(DMA2, 6, 48),
     DEFINE_DMA_CHANNEL(DMA2, 7, 54),
-
 };
 
 /*
@@ -76,18 +76,8 @@ DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
 static void enableDmaClock(int index)
 {
-    // This is essentially copies of __HAL_RCC_DMA{1,2}_CLK_ENABLE macros
-    // squashed into one.
-
-    const uint32_t rcc = dmaDescriptors[index].dma == DMA1 ? RCC_AHB1ENR_DMA1EN : RCC_AHB1ENR_DMA2EN;
-
-    do {
-        __IO uint32_t tmpreg;
-        SET_BIT(RCC->AHB1ENR, rcc);
-        /* Delay after an RCC peripheral clock enabling */
-        tmpreg = READ_BIT(RCC->AHB1ENR, rcc);
-        UNUSED(tmpreg);
-    } while (0);
+    RCC_ClockCmd(dmaDescriptors[index].dma == DMA1 ? RCC_AHB1(DMA1) : RCC_AHB1(DMA2), ENABLE);
+    // There seems to be no explicit control for DMAMUX1 clocking
 }
 
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)


### PR DESCRIPTION
We can now use `RCC_ClockCmd` in `enableDmaClock`.