### PR TITLE
quick rates system

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -336,7 +336,7 @@ static const char * const lookupTableGyroOverflowCheck[] = {
 #endif
 
 static const char * const lookupTableRatesType[] = {
-    "BETAFLIGHT", "RACEFLIGHT", "KISS", "ACTUAL"
+    "BETAFLIGHT", "RACEFLIGHT", "KISS", "ACTUAL", "QUICK"
 };
 
 #ifdef USE_OVERCLOCK

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -29,6 +29,7 @@ typedef enum {
     RATES_TYPE_RACEFLIGHT,
     RATES_TYPE_KISS,
     RATES_TYPE_ACTUAL,
+    RATES_TYPE_QUICK,
 } ratesType_e;
 
 typedef enum {


### PR DESCRIPTION
This rate system allows you to independently set the feeling in the center stick, the maximum degrees and the shape of the curve. rcRate is used in the same way as the current betaflight rates, the max rate sets the maximum revolutions per second and the curve regulates the way the setpoint rises at the end of the stick. With this system it is very easy to change rates on the field without having to carry a notebook with you. Charts will follow shortly to show the behavior.

