### PR TITLE
Fix "may be used uninitialized" warnings

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -321,7 +321,7 @@ FAST_CODE void scheduler(void)
     uint16_t selectedTaskDynamicPriority = 0;
     uint16_t waitingTasks = 0;
     bool realtimeTaskRan = false;
-    timeDelta_t gyroTaskDelayUs;
+    timeDelta_t gyroTaskDelayUs = 0;
 
     if (gyroEnabled) {
         // Realtime gyro/filtering/PID tasks get complete priority

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -1320,10 +1320,6 @@ void initYawSpinRecovery(int maxYawRate)
     int threshold;
 
     switch (gyroConfig()->yaw_spin_recovery) {
-    case YAW_SPIN_RECOVERY_OFF:
-        enabledFlag = false;
-        threshold = YAW_SPIN_RECOVERY_THRESHOLD_MAX;
-        break;
     case YAW_SPIN_RECOVERY_ON:
         enabledFlag = true;
         threshold = gyroConfig()->yaw_spin_threshold;
@@ -1332,6 +1328,11 @@ void initYawSpinRecovery(int maxYawRate)
         enabledFlag = true;
         const int overshootAllowance = MAX(maxYawRate / 4, 200); // Allow a 25% or minimum 200dps overshoot tolerance
         threshold = constrain(maxYawRate + overshootAllowance, YAW_SPIN_RECOVERY_THRESHOLD_MIN, YAW_SPIN_RECOVERY_THRESHOLD_MAX);
+        break;
+    case YAW_SPIN_RECOVERY_OFF:
+    default:
+        enabledFlag = false;
+        threshold = YAW_SPIN_RECOVERY_THRESHOLD_MAX;
         break;
     }
 


### PR DESCRIPTION
Prevent the false warnings when compiled for debugging
