### PR TITLE
Added protocol level RX frame rate measurement for FrSky FPort.

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -95,4 +95,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "FF_INTERPOLATED",
     "BLACKBOX_OUTPUT",
     "GYRO_SAMPLE",
+    "RX_TIMING",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -111,6 +111,7 @@ typedef enum {
     DEBUG_FF_INTERPOLATED,
     DEBUG_BLACKBOX_OUTPUT,
     DEBUG_GYRO_SAMPLE,
+    DEBUG_RX_TIMING,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -742,6 +742,12 @@ bool processRx(timeUs_t currentTimeUs)
     static bool sharedPortTelemetryEnabled = false;
 #endif
 
+    timeDelta_t frameAgeUs;
+    timeDelta_t frameDeltaUs = rxGetFrameDelta(&frameAgeUs);
+
+    DEBUG_SET(DEBUG_RX_TIMING, 0, MIN(frameDeltaUs / 10, INT16_MAX));
+    DEBUG_SET(DEBUG_RX_TIMING, 1, MIN(frameAgeUs / 10, INT16_MAX));
+
     if (!calculateRxChannelsAndUpdateFailsafe(currentTimeUs)) {
         return false;
     }

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -167,7 +167,7 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
     }
 
     timeDelta_t rxFrameDeltaUs;
-    if (!rxGetFrameDelta(&rxFrameDeltaUs)) {
+    if (!rxTryGetFrameDelta(&rxFrameDeltaUs)) {
         rxFrameDeltaUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
     }
     lastRxTimeUs = currentTimeUs;

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -166,9 +166,12 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
         return;
     }
 
-    timeDelta_t refreshRateUs;
-    if (!rxTryGetFrameDeltaOrZero(&refreshRateUs)) {
-        refreshRateUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
+    timeDelta_t frameAgeUs;
+    timeDelta_t refreshRateUs = rxGetFrameDelta(&frameAgeUs);
+    if (!refreshRateUs || cmpTimeUs(currentTimeUs, lastRxTimeUs) <= frameAgeUs) {
+        if (!rxTryGetFrameDeltaOrZero(&refreshRateUs)) {
+            refreshRateUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
+        }
     }
     lastRxTimeUs = currentTimeUs;
     currentRxRefreshRate = constrain(refreshRateUs, 1000, 30000);

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -166,12 +166,12 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
         return;
     }
 
-    timeDelta_t rxFrameDeltaUs;
-    if (!rxTryGetFrameDelta(&rxFrameDeltaUs)) {
-        rxFrameDeltaUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
+    timeDelta_t refreshRateUs;
+    if (!rxTryGetFrameDeltaOrZero(&refreshRateUs)) {
+        refreshRateUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
     }
     lastRxTimeUs = currentTimeUs;
-    currentRxRefreshRate = constrain(rxFrameDeltaUs, 1000, 30000);
+    currentRxRefreshRate = constrain(refreshRateUs, 1000, 30000);
     isRXDataNew = true;
 
 #ifdef USE_USB_CDC_HID

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -369,7 +369,7 @@ void crsfRxSendTelemetryData(void)
     }
 }
 
-static timeUs_t crsfFrameTimeUs(void)
+static timeUs_t crsfFrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -387,7 +387,7 @@ bool crsfRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = crsfReadRawRC;
     rxRuntimeState->rcFrameStatusFn = crsfFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = crsfFrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = crsfFrameTimeUsOrZeroFn;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -130,6 +130,8 @@ static const smartPortPayload_t emptySmartPortFrame = { .frameId = 0, .valueId =
 typedef struct fportBuffer_s {
     uint8_t data[BUFFER_SIZE];
     uint8_t length;
+    timeUs_t frameStartTimeUsOrZero;
+    timeUs_t frameStartTimeUs;
 } fportBuffer_t;
 
 static fportBuffer_t rxBuffer[NUM_RX_BUFFERS];
@@ -150,6 +152,9 @@ static serialPort_t *fportPort;
 static bool telemetryEnabled = false;
 #endif
 
+static timeUs_t lastRcFrameTimeUsOrZero = 0;
+static timeUs_t lastRcFrameTimeUs = 0;
+
 static void reportFrameError(uint8_t errorReason) {
     static volatile uint16_t frameErrors = 0;
 
@@ -169,7 +174,7 @@ static void fportDataReceive(uint16_t c, void *data)
     static timeUs_t lastFrameReceivedUs = 0;
     static bool telemetryFrame = false;
 
-    const timeUs_t currentTimeUs = micros();
+    const timeUs_t currentTimeUs = microsISR();
 
     clearToSend = false;
 
@@ -177,6 +182,7 @@ static void fportDataReceive(uint16_t c, void *data)
         reportFrameError(DEBUG_FPORT_ERROR_TIMEOUT);
 
         framePosition = 0;
+        rxBuffer[rxBufferWriteIndex].frameStartTimeUsOrZero = 0;
      }
 
     uint8_t val = (uint8_t)c;
@@ -203,9 +209,14 @@ static void fportDataReceive(uint16_t c, void *data)
 
         frameStartAt = currentTimeUs;
         framePosition = 1;
+
+        rxBuffer[rxBufferWriteIndex].frameStartTimeUsOrZero = currentTimeUs;
+        rxBuffer[rxBufferWriteIndex].frameStartTimeUs = currentTimeUs;
     } else if (framePosition > 0) {
         if (framePosition >= BUFFER_SIZE + 1) {
                 framePosition = 0;
+
+                rxBuffer[rxBufferWriteIndex].frameStartTimeUsOrZero = 0;
 
                 reportFrameError(DEBUG_FPORT_ERROR_OVERSIZE);
         } else {
@@ -286,6 +297,11 @@ static uint8_t fportFrameStatus(rxRuntimeState_t *rxRuntimeState)
                         setRssi(scaleRange(frame->data.controlData.rssi, 0, 100, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_PROTOCOL);
 
                         lastRcFrameReceivedMs = millis();
+
+                        if (!(result & (RX_FRAME_FAILSAFE | RX_FRAME_DROPPED))) {
+                            lastRcFrameTimeUsOrZero = rxBuffer[rxBufferReadIndex].frameStartTimeUsOrZero;
+                            lastRcFrameTimeUs = rxBuffer[rxBufferReadIndex].frameStartTimeUs;
+                        }
                     }
 
                     break;
@@ -390,6 +406,19 @@ static bool fportProcessFrame(const rxRuntimeState_t *rxRuntimeState)
     return true;
 }
 
+static timeUs_t fportFrameTimeUsOrZero(void)
+{
+    const timeUs_t result = lastRcFrameTimeUsOrZero;
+    lastRcFrameTimeUsOrZero = 0;
+
+    return result;
+}
+
+static timeUs_t fportFrameTimeUs(void)
+{
+    return lastRcFrameTimeUs;
+}
+
 bool fportRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 {
     static uint16_t sbusChannelData[SBUS_MAX_CHANNEL];
@@ -401,6 +430,8 @@ bool fportRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcFrameStatusFn = fportFrameStatus;
     rxRuntimeState->rcProcessFrameFn = fportProcessFrame;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = fportFrameTimeUsOrZero;
+    rxRuntimeState->rcFrameTimeUsFn = fportFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -206,7 +206,7 @@ static uint16_t ibusReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t ch
     return ibusChannelData[chan];
 }
 
-static timeUs_t ibusFrameTimeUs(void)
+static timeUs_t ibusFrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -223,7 +223,7 @@ bool ibusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = ibusReadRawRC;
     rxRuntimeState->rcFrameStatusFn = ibusFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = ibusFrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = ibusFrameTimeUsOrZeroFn;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -247,7 +247,7 @@ static uint16_t jetiExBusReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8
     return (jetiExBusChannelData[chan]);
 }
 
-static timeUs_t jetiExBusFrameTimeUs(void)
+static timeUs_t jetiExBusFrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -263,7 +263,7 @@ bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = jetiExBusReadRawRC;
     rxRuntimeState->rcFrameStatusFn = jetiExBusFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = jetiExBusFrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = jetiExBusFrameTimeUsOrZeroFn;
 
     jetiExBusFrameReset();
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -873,20 +873,20 @@ bool isRssiConfigured(void)
     return rssiSource != RSSI_SOURCE_NONE;
 }
 
-bool rxGetFrameDelta(timeDelta_t *deltaUs)
+bool rxTryGetFrameDelta(timeDelta_t *deltaUs)
 {
-    static timeUs_t previousFrameTimeUs = 0;
+    static timeUs_t previousFrameTimeUsOrZero = 0;
     bool result = false;
 
     *deltaUs = 0;
-    if (rxRuntimeState.rcFrameTimeUsFn) {
-        const timeUs_t frameTimeUs = rxRuntimeState.rcFrameTimeUsFn();
-        if (frameTimeUs) {
-            if (previousFrameTimeUs) {
-                *deltaUs = cmpTimeUs(frameTimeUs, previousFrameTimeUs);
+    if (rxRuntimeState.rcFrameTimeUsOrZeroFn) {
+        const timeUs_t frameTimeUsOrZero = rxRuntimeState.rcFrameTimeUsOrZeroFn();
+        if (frameTimeUsOrZero) {
+            if (previousFrameTimeUsOrZero) {
+                *deltaUs = cmpTimeUs(frameTimeUsOrZero, previousFrameTimeUsOrZero);
                 result = true;
             }
-            previousFrameTimeUs = frameTimeUs;
+            previousFrameTimeUsOrZero = frameTimeUsOrZero;
         }
     }
     return result;  // No frame delta function available for protocol type or frames have stopped

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -126,6 +126,7 @@ typedef uint16_t (*rcReadRawDataFnPtr)(const struct rxRuntimeState_s *rxRuntimeS
 typedef uint8_t (*rcFrameStatusFnPtr)(struct rxRuntimeState_s *rxRuntimeState);
 typedef bool (*rcProcessFrameFnPtr)(const struct rxRuntimeState_s *rxRuntimeState);
 typedef timeUs_t (*rcGetFrameTimeUsOrZeroFnPtr)(void);  // used to retrieve the timestamp in microseconds for the last channel data frame, or 0, depending on suitablilty of the value for RC smoothing
+typedef timeUs_t rcGetFrameTimeUsFn(void);  // used to retrieve the timestamp in microseconds for the last channel data frame
 
 typedef enum {
     RX_PROVIDER_NONE = 0,
@@ -145,6 +146,7 @@ typedef struct rxRuntimeState_s {
     rcFrameStatusFnPtr  rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
     rcGetFrameTimeUsOrZeroFnPtr rcFrameTimeUsOrZeroFn;
+    rcGetFrameTimeUsFn *rcFrameTimeUsFn;
     uint16_t            *channelData;
     void                *frameData;
 } rxRuntimeState_t;
@@ -210,4 +212,5 @@ void resumeRxPwmPpmSignal(void);
 
 uint16_t rxGetRefreshRate(void);
 
-bool rxTryGetFrameDelta(timeDelta_t *deltaUs);
+bool rxTryGetFrameDeltaOrZero(timeDelta_t *deltaUs);
+timeDelta_t rxGetFrameDelta(timeDelta_t *frameAgeUs);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -125,7 +125,7 @@ struct rxRuntimeState_s;
 typedef uint16_t (*rcReadRawDataFnPtr)(const struct rxRuntimeState_s *rxRuntimeState, uint8_t chan); // used by receiver driver to return channel data
 typedef uint8_t (*rcFrameStatusFnPtr)(struct rxRuntimeState_s *rxRuntimeState);
 typedef bool (*rcProcessFrameFnPtr)(const struct rxRuntimeState_s *rxRuntimeState);
-typedef timeUs_t (*rcGetFrameTimeUsFnPtr)(void);  // used to retrieve the timestamp in microseconds for the last channel data frame
+typedef timeUs_t (*rcGetFrameTimeUsOrZeroFnPtr)(void);  // used to retrieve the timestamp in microseconds for the last channel data frame, or 0, depending on suitablilty of the value for RC smoothing
 
 typedef enum {
     RX_PROVIDER_NONE = 0,
@@ -144,7 +144,7 @@ typedef struct rxRuntimeState_s {
     rcReadRawDataFnPtr  rcReadRawFn;
     rcFrameStatusFnPtr  rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
-    rcGetFrameTimeUsFnPtr rcFrameTimeUsFn;
+    rcGetFrameTimeUsOrZeroFnPtr rcFrameTimeUsOrZeroFn;
     uint16_t            *channelData;
     void                *frameData;
 } rxRuntimeState_t;
@@ -210,4 +210,4 @@ void resumeRxPwmPpmSignal(void);
 
 uint16_t rxGetRefreshRate(void);
 
-bool rxGetFrameDelta(timeDelta_t *deltaUs);
+bool rxTryGetFrameDelta(timeDelta_t *deltaUs);

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -160,7 +160,7 @@ static uint8_t sbusFrameStatus(rxRuntimeState_t *rxRuntimeState)
     return frameStatus;
 }
 
-static timeUs_t sbusFrameTimeUs(void)
+static timeUs_t sbusFrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -188,7 +188,7 @@ bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     }
 
     rxRuntimeState->rcFrameStatusFn = sbusFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = sbusFrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = sbusFrameTimeUsOrZeroFn;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -343,7 +343,7 @@ void srxlRxWriteTelemetryData(const void *data, int len)
 }
 #endif
 
-static timeUs_t spektrumFrameTimeUs(void)
+static timeUs_t spektrumFrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -397,7 +397,7 @@ bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = spektrumReadRawRC;
     rxRuntimeState->rcFrameStatusFn = spektrumFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = spektrumFrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = spektrumFrameTimeUsOrZeroFn;
 #if defined(USE_TELEMETRY_SRXL)
     rxRuntimeState->rcProcessFrameFn = spektrumProcessFrame;
 #endif

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -480,7 +480,7 @@ void srxl2RxWriteData(const void *data, int len)
     writeBufferIdx = len;
 }
 
-static timeUs_t srxl2FrameTimeUs(void)
+static timeUs_t srxl2FrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -503,7 +503,7 @@ bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = srxl2ReadRawRC;
     rxRuntimeState->rcFrameStatusFn = srxl2FrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = srxl2FrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = srxl2FrameTimeUsOrZeroFn;
     rxRuntimeState->rcProcessFrameFn = srxl2ProcessFrame;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -167,7 +167,7 @@ static uint16_t sumdReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t ch
     return sumdChannels[chan] / 8;
 }
 
-static timeUs_t sumdFrameTimeUs(void)
+static timeUs_t sumdFrameTimeUsOrZeroFn(void)
 {
     const timeUs_t result = lastRcFrameTimeUs;
     lastRcFrameTimeUs = 0;
@@ -183,7 +183,7 @@ bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = sumdReadRawRC;
     rxRuntimeState->rcFrameStatusFn = sumdFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = sumdFrameTimeUs;
+    rxRuntimeState->rcFrameTimeUsOrZeroFn = sumdFrameTimeUsOrZeroFn;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1101,4 +1101,5 @@ extern "C" {
     bool isUpright(void) { return mockIsUpright; }
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
     void gyroFiltering(timeUs_t) {};
+    timeDelta_t rxGetFrameDelta(timeDelta_t *) { return 0; }
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -186,4 +186,5 @@ extern "C" {
     bool isUpright(void) { return true; }
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
     void gyroFiltering(timeUs_t) {};
+    timeDelta_t rxGetFrameDelta(timeDelta_t *) { return 0; }
 }


### PR DESCRIPTION
This adds a framework for measuring and tracking actual RX frame intervals based on when the RC frame was recieved by the firmware.

Tested on FrSky r-XSR with FPort.

Counter-proposal to #9510.  

Benefits:
- returns actual data that can be used to diagnose RX behaviour (it was already used to discover that the r-XSR is sending failsafe frames every ~30 ms, a fact that was missed in #9510, making it buggy and misleading);
- can probably used to replace the tracking of 'FrameTimeUsOrZero' for RC smoothing - we can determine high up in the stack if `frameAge` is greater than the interval since the last time `processRx()` has been run, and in that case we know that the periodic update on missing input has kicked in.
