### PR TITLE
Update RCC_ClockCmd related macros to accomodate G4 register naming convention

### DIFF
--- a/src/main/drivers/rcc.c
+++ b/src/main/drivers/rcc.c
@@ -28,67 +28,87 @@ void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 
 #if defined(USE_HAL_DRIVER)
 
-#define __HAL_RCC_CLK_ENABLE(bus, enbit)   do {            \
-        __IO uint32_t tmpreg;                              \
-        SET_BIT(RCC->bus ## ENR, enbit);                   \
-        /* Delay after an RCC peripheral clock enabling */ \
-        tmpreg = READ_BIT(RCC->bus ## ENR, enbit);         \
-        UNUSED(tmpreg);                                    \
+// Note on "suffix" macro parameter:
+// ENR and RSTR naming conventions for buses with multiple registers per bus differs among MCU types.
+// ST decided to use AxBn{L,H}ENR convention for H7 which can be handled with simple "ENR" (or "RSTR") contatenation,
+// while use AxBnENR{1,2} convention for G4 which requires extra "suffix" to be concatenated.
+// Here, we use "suffix" for all MCU types and leave it as empty where not applicable.
+
+#define NOSUFFIX // Empty
+
+#define __HAL_RCC_CLK_ENABLE(bus, suffix, enbit)   do {      \
+        __IO uint32_t tmpreg;                                \
+        SET_BIT(RCC->bus ## ENR ## suffix, enbit);           \
+        /* Delay after an RCC peripheral clock enabling */   \
+        tmpreg = READ_BIT(RCC->bus ## ENR ## suffix, enbit); \
+        UNUSED(tmpreg);                                      \
     } while(0)
 
-#define __HAL_RCC_CLK_DISABLE(bus, enbit) (RCC->bus ## ENR &= ~(enbit))
+#define __HAL_RCC_CLK_DISABLE(bus, suffix, enbit) (RCC->bus ## ENR ## suffix &= ~(enbit))
 
-#define __HAL_RCC_CLK(bus, enbit, newState) \
-    if (newState == ENABLE) {               \
-        __HAL_RCC_CLK_ENABLE(bus, enbit);   \
-    } else {                                \
-        __HAL_RCC_CLK_DISABLE(bus, enbit);  \
+#define __HAL_RCC_CLK(bus, suffix, enbit, newState) \
+    if (newState == ENABLE) {                       \
+        __HAL_RCC_CLK_ENABLE(bus, suffix, enbit);   \
+    } else {                                        \
+        __HAL_RCC_CLK_DISABLE(bus, suffix, enbit);  \
     }
 
     switch (tag) {
     case RCC_AHB1:
-        __HAL_RCC_CLK(AHB1, mask, NewState);
+        __HAL_RCC_CLK(AHB1, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_AHB2:
-        __HAL_RCC_CLK(AHB2, mask, NewState);
+        __HAL_RCC_CLK(AHB2, NOSUFFIX, mask, NewState);
         break;
 
-#ifndef STM32H7
+#if !(defined(STM32H7) || defined(STM32G4))
     case RCC_APB1:
-        __HAL_RCC_CLK(APB1, mask, NewState);
+        __HAL_RCC_CLK(APB1, NOSUFFIX, mask, NewState);
         break;
 #endif
 
     case RCC_APB2:
-        __HAL_RCC_CLK(APB2, mask, NewState);
+        __HAL_RCC_CLK(APB2, NOSUFFIX, mask, NewState);
         break;
 
 #ifdef STM32H7
 
     case RCC_AHB3:
-        __HAL_RCC_CLK(AHB3, mask, NewState);
+        __HAL_RCC_CLK(AHB3, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_AHB4:
-        __HAL_RCC_CLK(AHB4, mask, NewState);
+        __HAL_RCC_CLK(AHB4, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB1L:
-        __HAL_RCC_CLK(APB1L, mask, NewState);
+        __HAL_RCC_CLK(APB1L, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB1H:
-        __HAL_RCC_CLK(APB1H, mask, NewState);
+        __HAL_RCC_CLK(APB1H, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB3:
-        __HAL_RCC_CLK(APB3, mask, NewState);
+        __HAL_RCC_CLK(APB3, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB4:
-        __HAL_RCC_CLK(APB4, mask, NewState);
+        __HAL_RCC_CLK(APB4, NOSUFFIX, mask, NewState);
         break;
+#endif
+
+#ifdef STM32G4
+
+    case RCC_APB11:
+        __HAL_RCC_CLK(APB1, 1, mask, NewState);
+        break;
+
+    case RCC_APB12:
+        __HAL_RCC_CLK(APB1, 2, mask, NewState);
+        break;
+
 #endif
     }
 #else
@@ -119,61 +139,74 @@ void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
     uint32_t mask = 1 << (periphTag & 0x1f);
 
 // Peripheral reset control relies on RSTR bits are identical to ENR bits where applicable
-#define __HAL_RCC_FORCE_RESET(bus, enbit) (RCC->bus ## RSTR |= (enbit))
-#define __HAL_RCC_RELEASE_RESET(bus, enbit) (RCC->bus ## RSTR &= ~(enbit))
-#define __HAL_RCC_RESET(bus, enbit, NewState) \
-    if (NewState == ENABLE) {                 \
-        __HAL_RCC_RELEASE_RESET(bus, enbit);  \
-    } else {                                  \
-        __HAL_RCC_FORCE_RESET(bus, enbit);    \
+
+#define __HAL_RCC_FORCE_RESET(bus, suffix, enbit) (RCC->bus ## RSTR ## suffix |= (enbit))
+#define __HAL_RCC_RELEASE_RESET(bus, suffix, enbit) (RCC->bus ## RSTR ## suffix &= ~(enbit))
+#define __HAL_RCC_RESET(bus, suffix, enbit, NewState) \
+    if (NewState == ENABLE) {                         \
+        __HAL_RCC_RELEASE_RESET(bus, suffix, enbit);  \
+    } else {                                          \
+        __HAL_RCC_FORCE_RESET(bus, suffix, enbit);    \
     }
 
 #if defined(USE_HAL_DRIVER)
 
     switch (tag) {
     case RCC_AHB1:
-        __HAL_RCC_RESET(AHB1, mask, NewState);
+        __HAL_RCC_RESET(AHB1, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_AHB2:
-        __HAL_RCC_RESET(AHB2, mask, NewState);
+        __HAL_RCC_RESET(AHB2, NOSUFFIX, mask, NewState);
         break;
 
-#ifndef STM32H7
+#if !(defined(STM32H7) || defined(STM32G4))
     case RCC_APB1:
-        __HAL_RCC_RESET(APB1, mask, NewState);
+        __HAL_RCC_RESET(APB1, NOSUFFIX, mask, NewState);
         break;
 #endif
 
     case RCC_APB2:
-        __HAL_RCC_RESET(APB2, mask, NewState);
+        __HAL_RCC_RESET(APB2, NOSUFFIX, mask, NewState);
         break;
 
 #ifdef STM32H7
 
     case RCC_AHB3:
-        __HAL_RCC_RESET(AHB3, mask, NewState);
+        __HAL_RCC_RESET(AHB3, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_AHB4:
-        __HAL_RCC_RESET(AHB4, mask, NewState);
+        __HAL_RCC_RESET(AHB4, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB1L:
-        __HAL_RCC_RESET(APB1L, mask, NewState);
+        __HAL_RCC_RESET(APB1L, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB1H:
-        __HAL_RCC_RESET(APB1H, mask, NewState);
+        __HAL_RCC_RESET(APB1H, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB3:
-        __HAL_RCC_RESET(APB3, mask, NewState);
+        __HAL_RCC_RESET(APB3, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB4:
-        __HAL_RCC_RESET(APB4, mask, NewState);
+        __HAL_RCC_RESET(APB4, NOSUFFIX, mask, NewState);
         break;
+#endif
+
+#ifdef STM32G4
+
+    case RCC_APB11:
+        __HAL_RCC_CLK(APB1, 1, mask, NewState);
+        break;
+
+    case RCC_APB12:
+        __HAL_RCC_CLK(APB1, 2, mask, NewState);
+        break;
+
 #endif
     }
 

--- a/src/main/drivers/rcc.h
+++ b/src/main/drivers/rcc.h
@@ -35,10 +35,16 @@ enum rcc_reg {
     RCC_APB3,
     RCC_AHB4,
     RCC_APB4,
-#elif defined(STM32G4) || defined(STM32F7)
+#elif defined(STM32F7)
     RCC_AHB2,
     RCC_APB2,
     RCC_APB1,
+    RCC_AHB1,
+#elif defined(STM32G4)
+    RCC_AHB2,
+    RCC_APB2,
+    RCC_APB11,
+    RCC_APB12,
     RCC_AHB1,
 #else
     RCC_AHB,
@@ -67,8 +73,8 @@ enum rcc_reg {
 
 #ifdef STM32G4
 #undef  RCC_APB1
-#define RCC_APB11(periph) RCC_ENCODE(RCC_APB1, RCC_APB1ENR1_ ## periph ## EN)
-#define RCC_APB12(periph) RCC_ENCODE(RCC_APB1, RCC_APB1ENR2_ ## periph ## EN)
+#define RCC_APB11(periph) RCC_ENCODE(RCC_APB11, RCC_APB1ENR1_ ## periph ## EN)
+#define RCC_APB12(periph) RCC_ENCODE(RCC_APB12, RCC_APB1ENR2_ ## periph ## EN)
 #define RCC_AHB1(periph) RCC_ENCODE(RCC_AHB1, RCC_AHB1ENR_ ## periph ## EN)
 #define RCC_AHB2(periph) RCC_ENCODE(RCC_AHB2, RCC_AHB2ENR_ ## periph ## EN)
 #endif


### PR DESCRIPTION
ENR and RSTR naming conventions for buses with multiple registers per bus differs among MCU types. ST decided to use AxBn{L,H}ENR convention for H7 which can be handled with simple "ENR" (or "RSTR") contatenation, while use AxBnENR{1,2} convention for G4 which requires extra "suffix" to be concatenated.

Here, we use "suffix" for all MCU types and leave it as empty where not applicable, to keep switch cases clean and readable by avoiding two types macros and associated conditionals.