### PR TITLE
Throttle limitation based on battery voltage

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -914,6 +914,7 @@ const clivalue_t valueTable[] = {
     { "roll_rate_limit",            VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_ROLL]) },
     { "pitch_rate_limit",           VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_PITCH]) },
     { "yaw_rate_limit",             VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_YAW]) },
+    { "throttle_vbat_limit_percent", VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, throttle_vbat_limit_percent) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -271,7 +271,8 @@ static const OSD_Entry cmsx_menuRateProfileEntries[] =
     { "TPA BRKPT",   OME_UINT16, NULL, &(OSD_UINT16_t){ &rateProfile.tpa_breakpoint, 1000, 2000, 10}, 0 },
 
     { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, osdTableThrottleLimitType}, 0 },
-    { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 25,  100,  1}, 0 },
+    { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 0,  100,  1}, 0 },
+    { "THR VBAT %",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_vbat_limit_percent, 0,  100,  1}, 0 },
 
     { "BACK", OME_Back, NULL, NULL, 0 },
     { NULL, OME_END, NULL, NULL, 0 }

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -64,6 +64,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .tpaMode = TPA_MODE_D,
             .profileName = { 0 },
+            .throttle_vbat_limit_percent = 0,
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -58,6 +58,7 @@ typedef struct controlRateConfig_s {
     uint16_t rate_limit[3];                 // Sets the maximum rate for the axes
     uint8_t tpaMode;                        // Controls which PID terms TPA effects
     char profileName[MAX_RATE_PROFILE_NAME_LENGTH + 1]; // Descriptive name for rate profile
+    uint8_t throttle_vbat_limit_percent;    // Sets the level of battery voltage dependent throttle limit
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -755,6 +755,16 @@ static float applyThrottleLimit(float throttle)
     return throttle;
 }
 
+static float applyThrottleVbatLimit(float throttle)
+{
+    if (currentControlRateProfile->throttle_vbat_limit_percent > 0) {
+        const float throttleVbatLimitFactor = calculateThrottleVbatLimitFactor();
+        throttle *= scaleRangef(currentControlRateProfile->throttle_vbat_limit_percent, 0.0f, 100.0f, 1.0f, throttleVbatLimitFactor);
+    }
+
+    return throttle;
+}
+
 static void applyMotorStop(void)
 {
     for (int i = 0; i < motorCount; i++) {
@@ -826,6 +836,8 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensa
 
     // Calculate voltage compensation
     const float vbatCompensationFactor = vbatPidCompensation ? calculateVbatPidCompensation() : 1.0f;
+
+    throttle = applyThrottleVbatLimit(throttle);
 
     // Apply the throttle_limit_percent to scale or limit the throttle based on throttle_limit_type
     if (currentControlRateProfile->throttle_limit_type != THROTTLE_LIMIT_TYPE_OFF) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -757,7 +757,7 @@ static float applyThrottleLimit(float throttle)
 
 static float applyThrottleVbatLimit(float throttle)
 {
-    if (currentControlRateProfile->throttle_vbat_limit_percent > 0) {
+    if (currentControlRateProfile->throttle_vbat_limit_percent) {
         const float throttleVbatLimitFactor = calculateThrottleVbatLimitFactor();
         throttle *= scaleRangef(currentControlRateProfile->throttle_vbat_limit_percent, 0.0f, 100.0f, 1.0f, throttleVbatLimitFactor);
     }

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1225,9 +1225,6 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, currentControlRateProfile->rate_limit[FD_PITCH]);
         sbufWriteU16(dst, currentControlRateProfile->rate_limit[FD_YAW]);
 
-        // added in TODO
-        sbufWriteU8(dst, currentControlRateProfile->throttle_vbat_limit_percent);
-
         break;
 
     case MSP_PID:
@@ -2261,11 +2258,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 currentControlRateProfile->rate_limit[FD_ROLL] = sbufReadU16(src);
                 currentControlRateProfile->rate_limit[FD_PITCH] = sbufReadU16(src);
                 currentControlRateProfile->rate_limit[FD_YAW] = sbufReadU16(src);
-            }
-
-            // version TODO
-            if (sbufBytesRemaining(src) >= 1) {
-                currentControlRateProfile->throttle_vbat_limit_percent = sbufReadU8(src);
             }
 
             initRcProcessing();

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1225,6 +1225,9 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, currentControlRateProfile->rate_limit[FD_PITCH]);
         sbufWriteU16(dst, currentControlRateProfile->rate_limit[FD_YAW]);
 
+        // added in TODO
+        sbufWriteU8(dst, currentControlRateProfile->throttle_vbat_limit_percent);
+
         break;
 
     case MSP_PID:
@@ -2258,6 +2261,11 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 currentControlRateProfile->rate_limit[FD_ROLL] = sbufReadU16(src);
                 currentControlRateProfile->rate_limit[FD_PITCH] = sbufReadU16(src);
                 currentControlRateProfile->rate_limit[FD_YAW] = sbufReadU16(src);
+            }
+
+            // version TODO
+            if (sbufBytesRemaining(src) >= 1) {
+                currentControlRateProfile->throttle_vbat_limit_percent = sbufReadU8(src);
             }
 
             initRcProcessing();

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -470,6 +470,16 @@ float calculateVbatPidCompensation(void) {
     return batteryScaler;
 }
 
+float calculateThrottleVbatLimitFactor(void)
+{
+    float factor =  1.0f;
+    if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && batteryCellCount > 0) {
+        float vbat = (float) voltageMeter.filtered / batteryCellCount;
+        factor = constrainf((float) batteryConfig()->vbatwarningcellvoltage / vbat, 0.0f, 1.0f);
+    }
+    return factor;
+}
+
 uint8_t calculateBatteryPercentageRemaining(void)
 {
     uint8_t batteryPercentage = 0;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -98,6 +98,7 @@ void batteryUpdateAlarms(void);
 struct rxConfig_s;
 
 float calculateVbatPidCompensation(void);
+float calculateThrottleVbatLimitFactor(void);
 uint8_t calculateBatteryPercentageRemaining(void);
 bool isBatteryVoltageConfigured(void);
 uint16_t getBatteryVoltage(void);


### PR DESCRIPTION
In order to obtain a more constant throttle feeling through battery discharge a variable limit depending on battery voltage can be applied to the throttle value.

The maximum amount of limit will be applied when the battery is full charged and dynamically decreased until reached the warning voltage: limit = Vwarn / Vbat

From some first tests the hovering throttle variation between 4.1 V and 3.3 V is reduced of 60% circa

I tested my idea with a couple of packs with and without leveling, on 1S and 2S, and to resume the results I had (hovering throttle at 4.1V and 3.3V):

On 1S:
 - without leveling: 30% - 39% (23% delta)
 - with leveling: 36.5% - 40% (9% delta)

On 2S:
 - without leveling: 9.5% - 14% (32% delta)
 - with leveling: 12.5% - 14.5% (14% delta)