### PR TITLE
Show errors when resetting to custom defaults.

### DIFF
--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -27,6 +27,8 @@
 
 #ifdef USE_MSP_DISPLAYPORT
 
+#include "cli/cli.h"
+
 #include "common/utils.h"
 
 #include "drivers/display.h"
@@ -38,10 +40,6 @@
 #include "msp/msp_serial.h"
 
 static displayPort_t mspDisplayPort;
-
-#ifdef USE_CLI
-extern uint8_t cliMode;
-#endif
 
 static int output(displayPort_t *displayPort, uint8_t cmd, uint8_t *buf, int len)
 {


### PR DESCRIPTION
For this input

```
mikeller@pc:~/git/unified-targets$ git diff configs/default/SPBE-SPEEDYBEEF4.config
diff --git a/configs/default/SPBE-SPEEDYBEEF4.config b/configs/default/SPBE-SPEEDYBEEF4.config
index 964b8fc..6f590e6 100644
--- a/configs/default/SPBE-SPEEDYBEEF4.config
+++ b/configs/default/SPBE-SPEEDYBEEF4.config
@@ -1,5 +1,7 @@
 # Betaflight / STM32F405 (S405) 4.1.0 Aug 13 2019 / 22:54:29 (52173c798) MSP API: 1.42
 
+batch start
+
 board_name SPEEDYBEEF4
 manufacturer_id SPBE
 
@@ -13,7 +15,7 @@ resource MOTOR 5 A15
 resource MOTOR 6 A08
 resource MOTOR 7 B08
 resource PPM 1 A03
-resource LED_STRIP 1 B06
+resourc LED_STRIP 1 B06
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
 resource SERIAL_TX 3 C10
@@ -90,7 +92,7 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature OSD
+feature OSD FOO
 
 # serial
 serial 4 1 19200 57600 0 115200
@@ -100,7 +102,7 @@ set mag_bustype = I2C
 set mag_i2c_device = 1
 set baro_bustype = I2C
 set baro_i2c_device = 1
-set blackbox_device = SPIFLASH
+set blackbox_device = BAR
 set dshot_burst = ON
 set current_meter = ADC
 set battery_meter = ADC
```

this will return this output:

```
# defaults

# resetting to defaults
###ERROR: UNKNOWN COMMAND, TRY 'HELP'###
###ERROR: INVALID NAME###
###ERROR: INVALID VALUE###
###ERROR: ERRORS WERE DETECTED - PLEASE REVIEW BEFORE CONTINUING###
###ERROR: PLEASE FIX ERRORS THEN 'SAVE'###
```

The error messages are a bit nonspecific and not helpful without context, but context can easily be added in a future step.
