### PR TITLE
Remove unused typedefs for DMA stream/channel

### DIFF
--- a/src/main/drivers/pwm_output_dshot_shared.h
+++ b/src/main/drivers/pwm_output_dshot_shared.h
@@ -25,12 +25,6 @@
 #include <string.h>
 #endif
 
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-typedef DMA_Stream_TypeDef dmaStream_t;
-#else
-typedef DMA_Channel_TypeDef dmaStream_t;
-#endif
-
 extern FAST_RAM_ZERO_INIT uint8_t dmaMotorTimerCount;
 #if defined(STM32F7) || defined(STM32H7)
 extern FAST_RAM_ZERO_INIT motorDmaTimer_t dmaMotorTimers[MAX_DMA_TIMERS];

--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -38,8 +38,6 @@
 
 #include "transponder_ir.h"
 
-typedef DMA_Stream_TypeDef dmaStream_t;
-
 volatile uint8_t transponderIrDataTransferInProgress = 0;
 
 static IO_t transponderIO = IO_NONE;


### PR DESCRIPTION
Remove additional overlooked stale and unused typedefs which are probably artifacts from DMA stream/channel unification (#8634, #8638).