### PR TITLE
For discussion: Add rx snr dbm display

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -105,6 +105,7 @@
 #include "rx/spektrum.h"
 #include "rx/cyrf6936_spektrum.h"
 #include "rx/a7105_flysky.h"
+#include "rx/crsf.h"
 
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
@@ -1238,6 +1239,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_RX_RSSI_DBM
     { "osd_rssi_dbm_alarm",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 130 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_dbm_alarm) },
 #endif
+#ifdef USE_RX_SNR_DBM
+    { "osd_snr_dbm_alarm",          VAR_INT8   | MASTER_VALUE, .config.minmax = { CRSF_MIN_SNR, CRSF_MAX_SNR }, PG_OSD_CONFIG, offsetof(osdConfig_t, snr_dbm_alarm) },
+#endif
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },
     { "osd_alt_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 10000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, alt_alarm) },
     { "osd_distance_alarm",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, distance_alarm) },
@@ -1264,6 +1268,9 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef USE_RX_RSSI_DBM
     { "osd_rssi_dbm_pos",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_RSSI_DBM_VALUE]) },
+#endif
+#ifdef USE_RX_SNR_DBM
+    { "osd_snr_dbm_pos",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_SNR_DBM_VALUE]) },
 #endif
     { "osd_tim_1_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_ITEM_TIMER_1]) },
     { "osd_tim_2_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_ITEM_TIMER_2]) },

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -70,6 +70,9 @@ const OSD_Entry menuOsdActiveElemsEntries[] =
 #ifdef USE_RX_RSSI_DBM
     {"RSSI DBM",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_DBM_VALUE], DYNAMIC},
 #endif
+#ifdef USE_RX_SNR_DBM
+    {"SNR DBM",            OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_SNR_DBM_VALUE], DYNAMIC},
+#endif
     {"BATTERY VOLTAGE",    OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], DYNAMIC},
     {"BATTERY USAGE",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_USAGE], DYNAMIC},
     {"AVG CELL VOLTAGE",   OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], DYNAMIC},

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -140,7 +140,7 @@ escSensorData_t *osdEscDataCombined;
 
 STATIC_ASSERT(OSD_POS_MAX == OSD_POS(31,31), OSD_POS_MAX_incorrect);
 
-PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 7);
+PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 8);
 
 PG_REGISTER_WITH_RESET_FN(osdElementConfig_t, osdElementConfig, PG_OSD_ELEMENT_CONFIG, 0);
 
@@ -179,6 +179,7 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
     OSD_STAT_TOTAL_FLIGHTS,
     OSD_STAT_TOTAL_TIME,
     OSD_STAT_TOTAL_DIST,
+    OSD_STAT_MIN_SNR_DBM,
 };
 
 void osdStatSetState(uint8_t statIndex, bool enabled)
@@ -504,6 +505,12 @@ static void osdUpdateStats(void)
         stats.min_rssi_dbm = value;
     }
 #endif
+#ifdef USE_RX_SNR_DBM
+    value = getSnrDbm();
+    if (value < stats.min_snr_dbm) {
+        stats.min_snr_dbm = value;
+    }
+#endif
 
 #ifdef USE_GPS
     if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) {
@@ -762,6 +769,13 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
     case OSD_STAT_MIN_RSSI_DBM:
         tfp_sprintf(buff, "%3d", stats.min_rssi_dbm * -1);
         osdDisplayStatisticLabel(displayRow, "MIN RSSI DBM", buff);
+        return true;
+#endif
+
+#ifdef USE_RX_SNR_DBM
+    case OSD_STAT_MIN_SNR_DBM:
+        tfp_sprintf(buff, "%3d", stats.min_snr_dbm);
+        osdDisplayStatisticLabel(displayRow, "MIN SNR DBM", buff);
         return true;
 #endif
 

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -143,6 +143,7 @@ typedef enum {
     OSD_RSSI_DBM_VALUE,
     OSD_RC_CHANNELS,
     OSD_CAMERA_FRAME,
+    OSD_SNR_DBM_VALUE,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -182,6 +183,7 @@ typedef enum {
     OSD_STAT_TOTAL_TIME,
     OSD_STAT_TOTAL_DIST,
     OSD_STAT_MIN_RSSI_DBM,
+    OSD_STAT_MIN_SNR_DBM,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 
@@ -232,6 +234,7 @@ typedef enum {
     OSD_WARNING_LINK_QUALITY,
     OSD_WARNING_RSSI_DBM,
     OSD_WARNING_OVER_CAP,
+    OSD_WARNING_SNR_DBM,
     OSD_WARNING_COUNT // MUST BE LAST
 } osdWarningsFlags_e;
 
@@ -279,6 +282,9 @@ typedef struct osdConfig_s {
     char profile[OSD_PROFILE_COUNT][OSD_PROFILE_NAME_LENGTH + 1];
     uint16_t link_quality_alarm;
     uint8_t rssi_dbm_alarm;
+    #ifdef USE_RX_SNR_DBM
+    int8_t snr_dbm_alarm;
+    #endif
     uint8_t gps_sats_show_hdop;
     int8_t rcChannels[OSD_RCCHANNELS_COUNT];  // RC channel values to display, -1 if none
     uint8_t displayPortDevice;                // osdDisplayPortDevice_e
@@ -311,6 +317,9 @@ typedef struct statistic_s {
     int32_t max_esc_rpm;
     uint16_t min_link_quality;
     uint8_t min_rssi_dbm;
+    #ifdef USE_RX_SNR_DBM
+    int8_t min_snr_dbm;
+    #endif
 } statistic_t;
 
 extern timeUs_t resumeRefreshAt;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1146,6 +1146,14 @@ static void osdElementRssiDbm(osdElementParms_t *element)
 }
 #endif // USE_RX_RSSI_DBM
 
+#ifdef USE_RX_SNR_DBM
+static void osdElementSnrDbm(osdElementParms_t *element)
+{
+    // no dedicated symbold for SNR so use RSSi in the mean time.
+    tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, getSnrDbm());
+}
+#endif
+
 #ifdef USE_OSD_STICK_OVERLAY
 static void osdBackgroundStickOverlay(osdElementParms_t *element)
 {
@@ -1356,7 +1364,14 @@ static void osdElementWarnings(osdElementParms_t *element)
         return;
     }
 #endif // USE_RX_RSSI_DBM
-
+#ifdef USE_RX_SNR_DBM
+    if (osdWarnGetState(OSD_WARNING_SNR_DBM) && (getSnrDbm() < osdConfig()->snr_dbm_alarm)) {
+        tfp_sprintf(element->buff, "SNR DBM");
+        element->attr = DISPLAYPORT_ATTR_WARNING;
+        SET_BLINK(OSD_WARNINGS);
+        return;
+    }
+#endif // USE_RX_SNR_DBM
 #ifdef USE_RX_LINK_QUALITY_INFO
     // Link Quality
     if (osdWarnGetState(OSD_WARNING_LINK_QUALITY) && (rxGetLinkQualityPercent() < osdConfig()->link_quality_alarm)) {
@@ -1577,6 +1592,9 @@ static const uint8_t osdElementDisplayOrder[] = {
 #ifdef USE_RX_RSSI_DBM
     OSD_RSSI_DBM_VALUE,
 #endif
+#ifdef USE_RX_SNR_DBM
+    OSD_SNR_DBM_VALUE,
+#endif
 #ifdef USE_OSD_STICK_OVERLAY
     OSD_STICK_OVERLAY_LEFT,
     OSD_STICK_OVERLAY_RIGHT,
@@ -1695,6 +1713,9 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #endif
 #ifdef USE_RX_RSSI_DBM
     [OSD_RSSI_DBM_VALUE]          = osdElementRssiDbm,
+#endif
+#ifdef USE_RX_SNR_DBM
+    [OSD_SNR_DBM_VALUE]           = osdElementSnrDbm,
 #endif
     [OSD_RC_CHANNELS]             = osdElementRcChannels,
 };

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -161,6 +161,10 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
 #ifdef USE_RX_RSSI_DBM
         setRssiDbm(rssiDbm, RSSI_SOURCE_RX_PROTOCOL_CRSF);
 #endif
+#ifdef USE_RX_SNR_DBM
+        const int8_t snrDbm = stats.uplink_SNR;
+        setSnrDbm(snrDbm);
+#endif
         const uint16_t rssiPercentScaled = scaleRange(rssiDbm, 130, 0, 0, RSSI_MAX_VALUE);
         setRssi(rssiPercentScaled, RSSI_SOURCE_RX_PROTOCOL_CRSF);
     }
@@ -177,7 +181,7 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
         DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 0, stats.uplink_RSSI_1);
         DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 1, stats.uplink_RSSI_2);
         DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 2, stats.uplink_Link_quality);
-        DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 3, stats.rf_Mode);
+        DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 3, stats.uplink_SNR);
         break;
     case DEBUG_CRSF_LINK_STATISTICS_PWR:
         DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_PWR, 0, stats.active_antenna);
@@ -202,6 +206,9 @@ static void crsfCheckRssi(uint32_t currentTimeUs) {
             setRssiDirect(0, RSSI_SOURCE_RX_PROTOCOL_CRSF);
 #ifdef USE_RX_RSSI_DBM
             setRssiDbmDirect(130, RSSI_SOURCE_RX_PROTOCOL_CRSF);
+#endif
+#ifdef USE_RX_SNR_DBM
+            setSnrDbmDirect(CRSF_MIN_SNR);
 #endif
         }
 #ifdef USE_RX_LINK_QUALITY_INFO

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -28,6 +28,9 @@
 
 #define CRSF_MAX_CHANNEL        16
 
+#define CRSF_MIN_SNR            -30
+#define CRSF_MAX_SNR            20
+
 typedef struct crsfFrameDef_s {
     uint8_t deviceAddress;
     uint8_t frameLength;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -73,6 +73,9 @@ const char rcChannelLetters[] = "AERT12345678abcdefgh";
 
 static uint16_t rssi = 0;                  // range: [0;1023]
 static uint8_t rssi_dbm = 130;             // range: [0;130] display 0 to -130
+#ifdef USE_RX_SNR_DBM
+static int8_t snr_dbm = CRSF_MIN_SNR;
+#endif
 static timeUs_t lastMspRssiUpdateUs = 0;
 
 static pt1Filter_t frameErrFilter;
@@ -845,6 +848,25 @@ void setRssiDbmDirect(uint8_t newRssiDbm, rssiSource_e source)
 
     rssi_dbm = newRssiDbm;
 }
+
+#ifdef USE_RX_SNR_DBM
+int8_t getSnrDbm(void)
+{
+    return snr_dbm;
+}
+
+void setSnrDbm(int8_t newSnrDbm)
+{
+    snr_dbm = newSnrDbm;
+    // no filtering as yet
+    // rssi_dbm = updateRssiDbmSamples(rssiDbmValue);
+}
+
+void setSnrDbmDirect(int8_t newSnrDbm)
+{
+    snr_dbm = newSnrDbm;
+}
+#endif
 
 #ifdef USE_RX_LINK_QUALITY_INFO
 uint16_t rxGetLinkQuality(void)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -200,6 +200,12 @@ uint8_t getRssiDbm(void);
 void setRssiDbm(uint8_t newRssiDbm, rssiSource_e source);
 void setRssiDbmDirect(uint8_t newRssiDbm, rssiSource_e source);
 
+#ifdef USE_RX_SNR_DBM
+int8_t getSnrDbm(void);
+void setSnrDbm(int8_t newSnrDbm);
+void setSnrDbmDirect(int8_t newSnrDbm);
+#endif
+
 void rxSetRfMode(uint8_t rfModeValue);
 uint8_t rxGetRfMode(void);
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -98,6 +98,7 @@
 #undef USE_TELEMETRY_CRSF
 #undef USE_CRSF_LINK_STATISTICS
 #undef USE_RX_RSSI_DBM
+#undef USE_RX_SNR_DBM
 #endif
 
 #if !defined(USE_TELEMETRY_CRSF) || !defined(USE_CMS)

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -320,6 +320,7 @@
 #define USE_CRSF_CMS_TELEMETRY
 #define USE_CRSF_LINK_STATISTICS
 #define USE_RX_RSSI_DBM
+#define USE_RX_SNR_DBM
 #endif
 
 #endif // TARGET_FLASH_SIZE > 128


### PR DESCRIPTION
The crsf protocol provides information on the signal noise ratio, this PR allows the display of this information.

I'm using this during the development of my own TX/RX and find it quite useful. Personally I find a LQ that stays at 99 and barely moves gives me no warning when I'm nearing the limit of my setup.
Knowledge of the SNR dBm along side the RSSI dBm  does. 

Unfortunately to correctly use the SNR you ideally need to know how the radio is configured, this maybe an issue with crsf.
 
Would BF find this a useful addition?
