### PR TITLE
Fix CLI LED command validation

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1908,7 +1908,7 @@ static void cliLed(char *cmdline)
     } else {
         ptr = cmdline;
         i = atoi(ptr);
-        if (i < LED_MAX_STRIP_LENGTH) {
+        if (i > 0 && i < LED_MAX_STRIP_LENGTH) {
             ptr = nextArg(cmdline);
             if (parseLedStripConfig(i, ptr)) {
                 generateLedConfig((ledConfig_t *)&ledStripStatusModeConfig()->ledConfigs[i], ledConfigBuffer, sizeof(ledConfigBuffer));


### PR DESCRIPTION
Previous validation failed to catch negative numbers for the LED index. For example:
```
# led -1 0,0::c:0
led 4294967295 0,0:WU:C:0
```

After the fix:
```
# led -1 0,0::c:0
###ERROR: INDEX NOT BETWEEN 0 AND 31###
```