### PR TITLE
[G4] I2C support

### DIFF
--- a/src/main/drivers/bus_i2c_config.c
+++ b/src/main/drivers/bus_i2c_config.c
@@ -56,13 +56,13 @@ void i2cHardwareConfigure(const i2cConfig_t *i2cConfig)
         for (int pindex = 0 ; pindex < I2C_PIN_SEL_MAX ; pindex++) {
             if (i2cConfig[device].ioTagScl == hardware->sclPins[pindex].ioTag) {
                 pDev->scl = IOGetByTag(i2cConfig[device].ioTagScl);
-#if defined(STM32F4) || defined(STM32H7)
+#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4)
                 pDev->sclAF = hardware->sclPins[pindex].af;
 #endif
             }
             if (i2cConfig[device].ioTagSda == hardware->sdaPins[pindex].ioTag) {
                 pDev->sda = IOGetByTag(i2cConfig[device].ioTagSda);
-#if defined(STM32F4) || defined(STM32H7)
+#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4)
                 pDev->sdaAF = hardware->sdaPins[pindex].af;
 #endif
             }

--- a/src/main/drivers/bus_i2c_hal_init.c
+++ b/src/main/drivers/bus_i2c_hal_init.c
@@ -144,6 +144,51 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
         .er_irq = I2C4_ER_IRQn,
     },
 #endif
+#elif defined(STM32G4)
+#ifdef USE_I2C_DEVICE_1
+    {
+        .device = I2CDEV_1,
+        .reg = I2C1,
+        .sclPins = { I2CPINDEF(PA15, GPIO_AF4_I2C1), I2CPINDEF(PB6,  GPIO_AF4_I2C1), I2CPINDEF(PB8,  GPIO_AF4_I2C1), },
+        .sdaPins = { I2CPINDEF(PB7,  GPIO_AF4_I2C1), I2CPINDEF(PB9,  GPIO_AF4_I2C1), },
+        .rcc = RCC_APB11(I2C1),
+        .ev_irq = I2C1_EV_IRQn,
+        .er_irq = I2C1_ER_IRQn,
+    },
+#endif
+#ifdef USE_I2C_DEVICE_2
+    {
+        .device = I2CDEV_2,
+        .reg = I2C2,
+        .sclPins = { I2CPINDEF(PA9,  GPIO_AF4_I2C2), },
+        .sdaPins = { I2CPINDEF(PA10, GPIO_AF4_I2C2), },
+        .rcc = RCC_APB11(I2C2),
+        .ev_irq = I2C2_EV_IRQn,
+        .er_irq = I2C2_ER_IRQn,
+    },
+#endif
+#ifdef USE_I2C_DEVICE_3
+    {
+        .device = I2CDEV_3,
+        .reg = I2C3,
+        .sclPins = { I2CPINDEF(PA10, GPIO_AF2_I2C3), I2CPINDEF(PC8,  GPIO_AF8_I2C3), },
+        .sdaPins = { I2CPINDEF(PB5,  GPIO_AF8_I2C3), I2CPINDEF(PC9,  GPIO_AF8_I2C3), I2CPINDEF(PC11, GPIO_AF8_I2C3), },
+        .rcc = RCC_APB11(I2C3),
+        .ev_irq = I2C3_EV_IRQn,
+        .er_irq = I2C3_ER_IRQn,
+    },
+#endif
+#ifdef USE_I2C_DEVICE_4
+    {
+        .device = I2CDEV_4,
+        .reg = I2C4,
+        .sclPins = { I2CPINDEF(PB6,  GPIO_AF3_I2C4), I2CPINDEF(PC6,  GPIO_AF8_I2C4), },
+        .sdaPins = { I2CPINDEF(PB7,  GPIO_AF4_I2C4), I2CPINDEF(PC7,  GPIO_AF8_I2C4), },
+        .rcc = RCC_APB12(I2C4),
+        .ev_irq = I2C4_EV_IRQn,
+        .er_irq = I2C4_ER_IRQn,
+    },
+#endif
 #endif
 };
 
@@ -264,7 +309,7 @@ void i2cInit(I2CDevice device)
 #if defined(STM32F7)
     IOConfigGPIOAF(scl, pDev->pullUp ? IOCFG_I2C_PU : IOCFG_I2C, GPIO_AF4_I2C);
     IOConfigGPIOAF(sda, pDev->pullUp ? IOCFG_I2C_PU : IOCFG_I2C, GPIO_AF4_I2C);
-#elif defined(STM32H7)
+#elif defined(STM32H7) || defined(STM32G4)
     IOConfigGPIOAF(scl, pDev->pullUp ? IOCFG_I2C_PU : IOCFG_I2C, pDev->sclAF);
     IOConfigGPIOAF(sda, pDev->pullUp ? IOCFG_I2C_PU : IOCFG_I2C, pDev->sdaAF);
 #else
@@ -284,8 +329,10 @@ void i2cInit(I2CDevice device)
 
     uint32_t i2cPclk;
 
-#if defined(STM32F7)
-    // Clock source configured in startup/system_stm32f7xx.c as:
+#if defined(STM32F7) || defined(STM32G4)
+    // F7 Clock source configured in startup/system_stm32f7xx.c as:
+    //   I2C1234 : PCLK1
+    // G4 Clock source configured in startup/system_stm32g4xx.c as:
     //   I2C1234 : PCLK1
     i2cPclk = HAL_RCC_GetPCLK1Freq();
 #elif defined(STM32H7)

--- a/src/main/drivers/bus_i2c_impl.h
+++ b/src/main/drivers/bus_i2c_impl.h
@@ -33,12 +33,12 @@
 
 typedef struct i2cPinDef_s {
     ioTag_t ioTag;
-#if defined(STM32F4) || defined(STM32H7)
+#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4)
     uint8_t af;
 #endif
 } i2cPinDef_t;
 
-#if defined(STM32F4) || defined(STM32H7)
+#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4)
 #define I2CPINDEF(pin, af) { DEFIO_TAG_E(pin), af }
 #elif defined(STM32F1)
 #define I2CPINDEF(pin, af) { DEFIO_TAG_E(pin) }
@@ -79,7 +79,7 @@ typedef struct i2cDevice_s {
     I2C_TypeDef *reg;
     IO_t scl;
     IO_t sda;
-#if defined(STM32F4) || defined(STM32H7)
+#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4)
     uint8_t sclAF;
     uint8_t sdaAF;
 #endif


### PR DESCRIPTION
For discussion.

For G4 I2C support, I've came up with a code to compute value of TIMINGR in two different ways, a computational method based on peripheral clock and desired I2C speed, and another one that use table of precomputed values for different peripheral clocks and desired speeds, instead of relying on a single constant value.

While the table based method is simpler and less space hungry (saves about 380 bytes against the computational method), we have a burden of table maintenance and possible introduction of different tables for different MCU types.

I would like to know how people think about pros and cons of the two methods before dropping unused one.
