### PR TITLE
Added option to display RX SNR dB for CRSF instead of RSSI dBm.

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -99,12 +99,13 @@
 #include "pg/stats.h"
 #include "pg/board.h"
 
-#include "rx/rx.h"
+#include "rx/a7105_flysky.h"
 #include "rx/cc2500_frsky_common.h"
 #include "rx/cc2500_sfhss.h"
-#include "rx/spektrum.h"
+#include "rx/crsf.h"
 #include "rx/cyrf6936_spektrum.h"
-#include "rx/a7105_flysky.h"
+#include "rx/rx.h"
+#include "rx/spektrum.h"
 
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
@@ -741,6 +742,9 @@ const clivalue_t valueTable[] = {
 #if defined(USE_SERIALRX_SBUS)
     { "sbus_baud_fast",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, sbus_baud_fast) },
 #endif
+#if defined(USE_SERIALRX_CRSF)
+    { "crsf_use_rx_snr",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, crsf_use_rx_snr) },
+#endif
     { "airmode_start_throttle_percent",     VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RX_CONFIG, offsetof(rxConfig_t, airModeActivateThreshold) },
     { "rx_min_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_min_usec) },
     { "rx_max_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_max_usec) },
@@ -1236,7 +1240,7 @@ const clivalue_t valueTable[] = {
     { "osd_link_quality_alarm",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, link_quality_alarm) },
 #endif
 #ifdef USE_RX_RSSI_DBM
-    { "osd_rssi_dbm_alarm",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 130 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_dbm_alarm) },
+    { "osd_rssi_dbm_alarm",         VAR_INT16   | MASTER_VALUE, .config.minmaxUnsigned = { CRSF_RSSI_MIN, CRSF_SNR_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_dbm_alarm) },
 #endif
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },
     { "osd_alt_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 10000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, alt_alarm) },

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -278,7 +278,7 @@ typedef struct osdConfig_s {
     uint8_t overlay_radio_mode;
     char profile[OSD_PROFILE_COUNT][OSD_PROFILE_NAME_LENGTH + 1];
     uint16_t link_quality_alarm;
-    uint8_t rssi_dbm_alarm;
+    int16_t rssi_dbm_alarm;
     uint8_t gps_sats_show_hdop;
     int8_t rcChannels[OSD_RCCHANNELS_COUNT];  // RC channel values to display, -1 if none
     uint8_t displayPortDevice;                // osdDisplayPortDevice_e
@@ -310,7 +310,7 @@ typedef struct statistic_s {
     int16_t max_esc_temp;
     int32_t max_esc_rpm;
     uint16_t min_link_quality;
-    uint8_t min_rssi_dbm;
+    int16_t min_rssi_dbm;
 } statistic_t;
 
 extern timeUs_t resumeRefreshAt;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1142,7 +1142,7 @@ static void osdElementRtcTime(osdElementParms_t *element)
 #ifdef USE_RX_RSSI_DBM
 static void osdElementRssiDbm(osdElementParms_t *element)
 {
-    tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, getRssiDbm() * -1);
+    tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, getRssiDbm());
 }
 #endif // USE_RX_RSSI_DBM
 
@@ -1349,7 +1349,7 @@ static void osdElementWarnings(osdElementParms_t *element)
     }
 #ifdef USE_RX_RSSI_DBM
     // rssi dbm
-    if (osdWarnGetState(OSD_WARNING_RSSI_DBM) && (getRssiDbm() > osdConfig()->rssi_dbm_alarm)) {
+    if (osdWarnGetState(OSD_WARNING_RSSI_DBM) && (getRssiDbm() < osdConfig()->rssi_dbm_alarm)) {
         tfp_sprintf(element->buff, "RSSI DBM");
         element->attr = DISPLAYPORT_ATTR_WARNING;
         SET_BLINK(OSD_WARNINGS);

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -72,6 +72,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .srxl2_unit_id = 1,
         .srxl2_baud_fast = true,
         .sbus_baud_fast = false,
+        .crsf_use_rx_snr = false,
     );
 
 #ifdef RX_CHANNELS_TAER

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -65,6 +65,7 @@ typedef struct rxConfig_s {
     uint8_t srxl2_unit_id; // Spektrum SRXL2 RX unit id
     uint8_t srxl2_baud_fast; // Select Spektrum SRXL2 fast baud rate
     uint8_t sbus_baud_fast; // Select SBus fast baud rate
+    uint8_t crsf_use_rx_snr; // Use RX SNR (in dB) instead of RSSI dBm for CRSF
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/rx/a7105_flysky.h
+++ b/src/main/rx/a7105_flysky.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "rx/rx_spi.h"
+
 typedef struct flySkyConfig_s {
     uint32_t txId;
     uint8_t rfChannelMap[16];

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -157,12 +157,15 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
     const crsfLinkStatistics_t stats = *statsPtr;
     lastLinkStatisticsFrameUs = currentTimeUs;
     if (rssiSource == RSSI_SOURCE_RX_PROTOCOL_CRSF) {
-        const uint8_t rssiDbm = stats.active_antenna ? stats.uplink_RSSI_2 : stats.uplink_RSSI_1;
+        int16_t rssiDbm = -1 * (stats.active_antenna ? stats.uplink_RSSI_2 : stats.uplink_RSSI_1);
+        const uint16_t rssiPercentScaled = scaleRange(rssiDbm, CRSF_RSSI_MIN, 0, 0, RSSI_MAX_VALUE);
+        setRssi(rssiPercentScaled, RSSI_SOURCE_RX_PROTOCOL_CRSF);
 #ifdef USE_RX_RSSI_DBM
+        if (rxConfig()->crsf_use_rx_snr) {
+            rssiDbm = stats.uplink_SNR;
+        }
         setRssiDbm(rssiDbm, RSSI_SOURCE_RX_PROTOCOL_CRSF);
 #endif
-        const uint16_t rssiPercentScaled = scaleRange(rssiDbm, 130, 0, 0, RSSI_MAX_VALUE);
-        setRssi(rssiPercentScaled, RSSI_SOURCE_RX_PROTOCOL_CRSF);
     }
 
 #ifdef USE_RX_LINK_QUALITY_INFO
@@ -201,7 +204,11 @@ static void crsfCheckRssi(uint32_t currentTimeUs) {
         if (rssiSource == RSSI_SOURCE_RX_PROTOCOL_CRSF) {
             setRssiDirect(0, RSSI_SOURCE_RX_PROTOCOL_CRSF);
 #ifdef USE_RX_RSSI_DBM
-            setRssiDbmDirect(130, RSSI_SOURCE_RX_PROTOCOL_CRSF);
+            if (rxConfig()->crsf_use_rx_snr) {
+                setRssiDbmDirect(CRSF_SNR_MIN, RSSI_SOURCE_RX_PROTOCOL_CRSF);
+            } else {
+                setRssiDbmDirect(CRSF_RSSI_MIN, RSSI_SOURCE_RX_PROTOCOL_CRSF);
+            }
 #endif
         }
 #ifdef USE_RX_LINK_QUALITY_INFO

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -28,6 +28,11 @@
 
 #define CRSF_MAX_CHANNEL        16
 
+#define CRSF_RSSI_MIN (-130)
+#define CRSF_RSSI_MAX 0
+#define CRSF_SNR_MIN (-30)
+#define CRSF_SNR_MAX 20
+
 typedef struct crsfFrameDef_s {
     uint8_t deviceAddress;
     uint8_t frameLength;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -72,7 +72,7 @@
 const char rcChannelLetters[] = "AERT12345678abcdefgh";
 
 static uint16_t rssi = 0;                  // range: [0;1023]
-static uint8_t rssi_dbm = 130;             // range: [0;130] display 0 to -130
+static int16_t rssiDbm = CRSF_RSSI_MIN;    // range: [-130,20]
 static timeUs_t lastMspRssiUpdateUs = 0;
 
 static pt1Filter_t frameErrFilter;
@@ -809,18 +809,18 @@ uint8_t getRssiPercent(void)
     return scaleRange(getRssi(), 0, RSSI_MAX_VALUE, 0, 100);
 }
 
-uint8_t getRssiDbm(void)
+int16_t getRssiDbm(void)
 {
-    return rssi_dbm;
+    return rssiDbm;
 }
 
 #define RSSI_SAMPLE_COUNT_DBM 16
 
-static uint8_t updateRssiDbmSamples(uint8_t value)
+static int16_t updateRssiDbmSamples(int16_t value)
 {
-    static uint16_t samplesdbm[RSSI_SAMPLE_COUNT_DBM];
+    static int16_t samplesdbm[RSSI_SAMPLE_COUNT_DBM];
     static uint8_t sampledbmIndex = 0;
-    static unsigned sumdbm = 0;
+    static int sumdbm = 0;
 
     sumdbm += value - samplesdbm[sampledbmIndex];
     samplesdbm[sampledbmIndex] = value;
@@ -828,22 +828,22 @@ static uint8_t updateRssiDbmSamples(uint8_t value)
     return sumdbm / RSSI_SAMPLE_COUNT_DBM;
 }
 
-void setRssiDbm(uint8_t rssiDbmValue, rssiSource_e source)
+void setRssiDbm(int16_t rssiDbmValue, rssiSource_e source)
 {
     if (source != rssiSource) {
         return;
     }
 
-    rssi_dbm = updateRssiDbmSamples(rssiDbmValue);
+    rssiDbm = updateRssiDbmSamples(rssiDbmValue);
 }
 
-void setRssiDbmDirect(uint8_t newRssiDbm, rssiSource_e source)
+void setRssiDbmDirect(int16_t newRssiDbm, rssiSource_e source)
 {
     if (source != rssiSource) {
         return;
     }
 
-    rssi_dbm = newRssiDbm;
+    rssiDbm = newRssiDbm;
 }
 
 #ifdef USE_RX_LINK_QUALITY_INFO

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -196,9 +196,9 @@ uint16_t rxGetLinkQuality(void);
 void setLinkQualityDirect(uint16_t linkqualityValue);
 uint16_t rxGetLinkQualityPercent(void);
 
-uint8_t getRssiDbm(void);
-void setRssiDbm(uint8_t newRssiDbm, rssiSource_e source);
-void setRssiDbmDirect(uint8_t newRssiDbm, rssiSource_e source);
+int16_t getRssiDbm(void);
+void setRssiDbm(int16_t newRssiDbm, rssiSource_e source);
+void setRssiDbmDirect(int16_t newRssiDbm, rssiSource_e source);
 
 void rxSetRfMode(uint8_t rfModeValue);
 uint8_t rxGetRfMode(void);


### PR DESCRIPTION
Alternative to #9540. 

Allows CRSF users to have 'RSSI dBm' display and monitor the RX SNR (in dB) instead.
Changes how RSSI dBm is stored internally, now it is tracked as the negative number that it actually is, meaning that the minimum alarm has to be set as a negative value as well, or it will be always on.

Uses only 16 bytes extra flash, as opposed to 224 bytes used by #9540.