### PR TITLE
Battery sag compensation by varying motor output

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -840,7 +840,7 @@ const clivalue_t valueTable[] = {
     { "cbat_alert_percent",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, consumptionWarningPercentage) },
     { "vbat_cutoff_percent",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
     { "force_battery_cell_count",   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 24 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, forceBatteryCellCount) },
-    { "vbat_display_lpf_period",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatDisplayLpfPeriod) },
+    { "vbat_display_lpf_period",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatDisplayLpfPeriod) },
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     { "vbat_sag_lpf_period",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatSagLpfPeriod) },
 #endif

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -840,10 +840,13 @@ const clivalue_t valueTable[] = {
     { "cbat_alert_percent",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, consumptionWarningPercentage) },
     { "vbat_cutoff_percent",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
     { "force_battery_cell_count",   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 24 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, forceBatteryCellCount) },
-    { "vbat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatLpfPeriod) },
+    { "vbat_display_lpf_period",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatDisplayLpfPeriod) },
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+    { "vbat_sag_lpf_period",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatSagLpfPeriod) },
+#endif
     { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) },
     { "vbat_duration_for_warning",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatDurationForWarning) },
-    { "vbat_duration_for_critical",  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatDurationForCritical) },
+    { "vbat_duration_for_critical", VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 150 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatDurationForCritical) },
 
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },
@@ -1006,6 +1009,9 @@ const clivalue_t valueTable[] = {
     { "dterm_notch_hz",             VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_notch_hz) },
     { "dterm_notch_cutoff",         VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_notch_cutoff) },
     { "vbat_pid_gain",              VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, vbatPidCompensation) },
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+    { "vbat_sag_compensation",      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, vbat_sag_compensation) },
+#endif
     { "pid_at_min_throttle",        VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, pidAtMinThrottle) },
     { "anti_gravity_mode",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ANTI_GRAVITY_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, antiGravityMode) },
     { "anti_gravity_threshold",     VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 20, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermThrottleThreshold) },

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -261,6 +261,12 @@ static void validateAndFixConfig(void)
                 pidProfilesMutable(i)->d_min[axis] = 0;
             }
         }
+
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+        if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_ADC) {
+            pidProfilesMutable(i)->vbat_sag_compensation = 0;
+        }
+#endif
     }
 
     if (motorConfig()->dev.motorPwmProtocol == PWM_TYPE_BRUSHED) {

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -232,7 +232,9 @@ void tasksInit(void)
 
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     // If vbat motor output compensation is used, use fast vbat samplingTime
-    rescheduleTask(TASK_BATTERY_VOLTAGE, TASK_PERIOD_HZ(getBatteryVoltageTaskFrequencyHz()));
+    if (isSagCompensationConfigured()) {
+        rescheduleTask(TASK_BATTERY_VOLTAGE, TASK_PERIOD_HZ(FAST_VOLTAGE_TASK_FREQ_HZ));
+    }
 #endif
 
     const bool useBatteryCurrent = batteryConfig()->currentMeterSource != CURRENT_METER_NONE;

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -229,6 +229,12 @@ void tasksInit(void)
 
     const bool useBatteryVoltage = batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE;
     setTaskEnabled(TASK_BATTERY_VOLTAGE, useBatteryVoltage);
+
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+    // If vbat motor output compensation is used, use fast vbat samplingTime
+    rescheduleTask(TASK_BATTERY_VOLTAGE, TASK_PERIOD_HZ(getBatteryVoltageTaskFrequencyHz()));
+#endif
+
     const bool useBatteryCurrent = batteryConfig()->currentMeterSource != CURRENT_METER_NONE;
     setTaskEnabled(TASK_BATTERY_CURRENT, useBatteryCurrent);
     const bool useBatteryAlerts = batteryConfig()->useVBatAlerts || batteryConfig()->useConsumptionAlerts || featureIsEnabled(FEATURE_OSD);
@@ -378,7 +384,7 @@ task_t tasks[TASK_COUNT] = {
     [TASK_MAIN] = DEFINE_TASK("SYSTEM", "UPDATE", NULL, taskMain, TASK_PERIOD_HZ(1000), TASK_PRIORITY_MEDIUM_HIGH),
     [TASK_SERIAL] = DEFINE_TASK("SERIAL", NULL, NULL, taskHandleSerial, TASK_PERIOD_HZ(100), TASK_PRIORITY_LOW), // 100 Hz should be enough to flush up to 115 bytes @ 115200 baud
     [TASK_BATTERY_ALERTS] = DEFINE_TASK("BATTERY_ALERTS", NULL, NULL, taskBatteryAlerts, TASK_PERIOD_HZ(5), TASK_PRIORITY_MEDIUM),
-    [TASK_BATTERY_VOLTAGE] = DEFINE_TASK("BATTERY_VOLTAGE", NULL, NULL, batteryUpdateVoltage, TASK_PERIOD_HZ(50), TASK_PRIORITY_MEDIUM),
+    [TASK_BATTERY_VOLTAGE] = DEFINE_TASK("BATTERY_VOLTAGE", NULL, NULL, batteryUpdateVoltage, TASK_PERIOD_HZ(SLOW_VOLTAGE_TASK_FREQ_HZ), TASK_PRIORITY_MEDIUM), // Freq may be updated in tasksInit
     [TASK_BATTERY_CURRENT] = DEFINE_TASK("BATTERY_CURRENT", NULL, NULL, batteryUpdateCurrentMeter, TASK_PERIOD_HZ(50), TASK_PRIORITY_MEDIUM),
 
 #ifdef USE_TRANSPONDER

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -363,6 +363,7 @@ void mixerInitProfile(void)
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     vbatSagCompensationFactor = 0.0f;
     if (currentPidProfile->vbat_sag_compensation > 0) {
+        //TODO: Make this voltage user configurable
         vbatFull = CELL_VOLTAGE_FULL_CV;
         vbatRangeToCompensate = vbatFull - batteryConfig()->vbatwarningcellvoltage;
         if (vbatRangeToCompensate >= 0) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -296,7 +296,11 @@ static FAST_RAM_ZERO_INIT float idleThrottleOffset;
 static FAST_RAM_ZERO_INIT float idleMinMotorRps;
 static FAST_RAM_ZERO_INIT float idleP;
 #endif
-
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+static FAST_RAM_ZERO_INIT float vbatSagCompensationFactor;
+static FAST_RAM_ZERO_INIT float vbatFull;
+static FAST_RAM_ZERO_INIT float vbatRangeToCompensate;
+#endif
 
 uint8_t getMotorCount(void)
 {
@@ -354,6 +358,17 @@ void mixerInitProfile(void)
     idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
     idleMaxIncrease = currentPidProfile->idle_max_increase * 0.001f;
     idleP = currentPidProfile->idle_p * 0.0001f;
+#endif
+
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+    vbatSagCompensationFactor = 0.0f;
+    if (currentPidProfile->vbat_sag_compensation > 0) {
+        vbatFull = CELL_VOLTAGE_FULL_CV;
+        vbatRangeToCompensate = vbatFull - batteryConfig()->vbatwarningcellvoltage;
+        if (vbatRangeToCompensate >= 0) {
+            vbatSagCompensationFactor = ((float)currentPidProfile->vbat_sag_compensation) / 100.0f;
+        }
+    }
 #endif
 }
 
@@ -623,11 +638,27 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
 
         }
 #endif
+
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+        float motorRangeAttenuationFactor = 0;
+        // reduce motorRangeMax when battery is full
+        if (vbatSagCompensationFactor > 0.0f) {
+            const uint16_t currentCellVoltage = getBatterySagCellVoltage();
+            // batteryGoodness = 1 when voltage is above vbatFull, and 0 when voltage is below vbatLow
+            float batteryGoodness = 1.0f - constrainf((vbatFull - currentCellVoltage) / vbatRangeToCompensate, 0.0f, 1.0f);
+            motorRangeAttenuationFactor = (vbatRangeToCompensate / vbatFull) * batteryGoodness * vbatSagCompensationFactor;
+            DEBUG_SET(DEBUG_BATTERY, 2, batteryGoodness * 100);
+            DEBUG_SET(DEBUG_BATTERY, 3, motorRangeAttenuationFactor * 1000);
+        }
+        motorRangeMax = motorOutputHigh - motorRangeAttenuationFactor * (motorOutputHigh - motorOutputLow);
+#else
+        motorRangeMax = motorOutputHigh;
+#endif
+
         currentThrottleInputRange = rcCommandThrottleRange;
         motorRangeMin = motorOutputLow + motorRangeMinIncrease * (motorOutputHigh - motorOutputLow);
-        motorRangeMax = motorOutputHigh;
         motorOutputMin = motorRangeMin;
-        motorOutputRange = motorOutputHigh - motorOutputMin;
+        motorOutputRange = motorRangeMax - motorRangeMin;
         motorOutputMixSign = 1;
     }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -135,7 +135,7 @@ static FAST_RAM_ZERO_INIT float airmodeThrottleOffsetLimit;
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 14);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 15);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -224,6 +224,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .ff_boost = 15,
         .dyn_lpf_curve_expo = 0,
         .level_race_mode = false,
+        .vbat_sag_compensation = 0,
     );
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -190,6 +190,7 @@ typedef struct pidProfile_s {
     uint8_t ff_smooth_factor;               // Amount of smoothing for interpolated FF steps
     uint8_t dyn_lpf_curve_expo;             // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calcualtion is gyro based in level mode
+    uint8_t vbat_sag_compensation;          // Reduce motor output by this percentage of the maximum compensation amount
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -742,7 +742,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
             voltageMeterRead(id, &meter);
 
             sbufWriteU8(dst, id);
-            sbufWriteU8(dst, (uint8_t)constrain((meter.filtered + 5) / 10, 0, 255));
+            sbufWriteU8(dst, (uint8_t)constrain((meter.displayFiltered + 5) / 10, 0, 255));
         }
         break;
     }

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -358,6 +358,8 @@ void batteryInit(void)
     lowVoltageCutoff.startTime = 0;
 
     voltageMeterReset(&voltageMeter);
+
+    voltageMeterGenericInit();
     switch (batteryConfig()->voltageMeterSource) {
         case VOLTAGE_METER_ESC:
 #ifdef USE_ESC_SENSOR

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -118,7 +118,8 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
 
     .vbatfullcellvoltage = 410,
 
-    .vbatLpfPeriod = 30,
+    .vbatDisplayLpfPeriod = 30,
+    .vbatSagLpfPeriod = 2,
     .ibatLpfPeriod = 10,
     .vbatDurationForWarning = 0,
     .vbatDurationForCritical = 0,
@@ -148,10 +149,8 @@ void batteryUpdateVoltage(timeUs_t currentTimeUs)
             break;
     }
 
-    if (debugMode == DEBUG_BATTERY) {
-        debug[0] = voltageMeter.unfiltered;
-        debug[1] = voltageMeter.filtered;
-    }
+    DEBUG_SET(DEBUG_BATTERY, 0, voltageMeter.unfiltered);
+    DEBUG_SET(DEBUG_BATTERY, 1, voltageMeter.displayFiltered);
 }
 
 static void updateBatteryBeeperAlert(void)
@@ -172,18 +171,20 @@ static void updateBatteryBeeperAlert(void)
     }
 }
 
+//TODO: make all of these independent of voltage filtering for display
+
 static bool isVoltageStable(void)
 {
-    return ABS(voltageMeter.filtered - voltageMeter.unfiltered) <= VBAT_STABLE_MAX_DELTA;
+    return ABS(voltageMeter.displayFiltered - voltageMeter.unfiltered) <= VBAT_STABLE_MAX_DELTA;
 }
 
 static bool isVoltageFromBat(void)
 {
     // We want to disable battery getting detected around USB voltage or 0V
 
-    return (voltageMeter.filtered >= batteryConfig()->vbatnotpresentcellvoltage  // Above ~0V
-        && voltageMeter.filtered <= batteryConfig()->vbatmaxcellvoltage)  // 1s max cell voltage check
-        || voltageMeter.filtered > batteryConfig()->vbatnotpresentcellvoltage * 2; // USB voltage - 2s or more check
+    return (voltageMeter.displayFiltered >= batteryConfig()->vbatnotpresentcellvoltage  // Above ~0V
+        && voltageMeter.displayFiltered <= batteryConfig()->vbatmaxcellvoltage)  // 1s max cell voltage check
+        || voltageMeter.displayFiltered > batteryConfig()->vbatnotpresentcellvoltage * 2; // USB voltage - 2s or more check
 }
 
 void batteryUpdatePresence(void)
@@ -199,7 +200,7 @@ void batteryUpdatePresence(void)
         if (batteryConfig()->forceBatteryCellCount != 0) {
             batteryCellCount = batteryConfig()->forceBatteryCellCount;
         } else {
-            unsigned cells = (voltageMeter.filtered / batteryConfig()->vbatmaxcellvoltage) + 1;
+            unsigned cells = (voltageMeter.displayFiltered / batteryConfig()->vbatmaxcellvoltage) + 1;
             if (cells > MAX_AUTO_DETECT_CELL_COUNT) {
                 // something is wrong, we expect MAX_CELL_COUNT cells maximum (and autodetection will be problematic at 6+ cells)
                 cells = MAX_AUTO_DETECT_CELL_COUNT;
@@ -225,10 +226,6 @@ void batteryUpdatePresence(void)
         batteryWarningVoltage = 0;
         batteryCriticalVoltage = 0;
     }
-    if (debugMode == DEBUG_BATTERY) {
-        debug[2] = batteryCellCount;
-        debug[3] = isVoltageStable();
-    }
 }
 
 static void batteryUpdateVoltageState(void)
@@ -237,7 +234,7 @@ static void batteryUpdateVoltageState(void)
     static uint32_t lastVoltageChangeMs;
     switch (voltageState) {
         case BATTERY_OK:
-            if (voltageMeter.filtered <= (batteryWarningVoltage - batteryConfig()->vbathysteresis)) {
+            if (voltageMeter.displayFiltered <= (batteryWarningVoltage - batteryConfig()->vbathysteresis)) {
                 if (cmp32(millis(), lastVoltageChangeMs) >= batteryConfig()->vbatDurationForWarning * 100) {
                     voltageState = BATTERY_WARNING;
                 }
@@ -247,12 +244,12 @@ static void batteryUpdateVoltageState(void)
             break;
 
         case BATTERY_WARNING:
-            if (voltageMeter.filtered <= (batteryCriticalVoltage - batteryConfig()->vbathysteresis)) {
+            if (voltageMeter.displayFiltered <= (batteryCriticalVoltage - batteryConfig()->vbathysteresis)) {
                 if (cmp32(millis(), lastVoltageChangeMs) >= batteryConfig()->vbatDurationForCritical * 100) {
                     voltageState = BATTERY_CRITICAL;
                 }
             } else {
-                if (voltageMeter.filtered > batteryWarningVoltage) {
+                if (voltageMeter.displayFiltered > batteryWarningVoltage) {
                     voltageState = BATTERY_OK;
                 }
                 lastVoltageChangeMs = millis();
@@ -260,7 +257,7 @@ static void batteryUpdateVoltageState(void)
             break;
 
         case BATTERY_CRITICAL:
-            if (voltageMeter.filtered > batteryCriticalVoltage) {
+            if (voltageMeter.displayFiltered > batteryCriticalVoltage) {
                 voltageState = BATTERY_WARNING;
                 lastVoltageChangeMs = millis();
             }
@@ -465,7 +462,7 @@ float calculateVbatPidCompensation(void) {
     float batteryScaler =  1.0f;
     if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && batteryCellCount > 0) {
         // Up to 33% PID gain. Should be fine for 4,2to 3,3 difference
-        batteryScaler =  constrainf((( (float)batteryConfig()->vbatmaxcellvoltage * batteryCellCount ) / (float) voltageMeter.filtered), 1.0f, 1.33f);
+        batteryScaler =  constrainf((( (float)batteryConfig()->vbatmaxcellvoltage * batteryCellCount ) / (float) voltageMeter.displayFiltered), 1.0f, 1.33f);
     }
     return batteryScaler;
 }
@@ -479,7 +476,7 @@ uint8_t calculateBatteryPercentageRemaining(void)
         if (batteryCapacity > 0) {
             batteryPercentage = constrain(((float)batteryCapacity - currentMeter.mAhDrawn) * 100 / batteryCapacity, 0, 100);
         } else {
-            batteryPercentage = constrain((((uint32_t)voltageMeter.filtered - (batteryConfig()->vbatmincellvoltage * batteryCellCount)) * 100) / ((batteryConfig()->vbatmaxcellvoltage - batteryConfig()->vbatmincellvoltage) * batteryCellCount), 0, 100);
+            batteryPercentage = constrain((((uint32_t)voltageMeter.displayFiltered - (batteryConfig()->vbatmincellvoltage * batteryCellCount)) * 100) / ((batteryConfig()->vbatmaxcellvoltage - batteryConfig()->vbatmincellvoltage) * batteryCellCount), 0, 100);
         }
     }
 
@@ -501,12 +498,12 @@ bool isBatteryVoltageConfigured(void)
 
 uint16_t getBatteryVoltage(void)
 {
-    return voltageMeter.filtered;
+    return voltageMeter.displayFiltered;
 }
 
 uint16_t getLegacyBatteryVoltage(void)
 {
-    return (voltageMeter.filtered + 5) / 10;
+    return (voltageMeter.displayFiltered + 5) / 10;
 }
 
 uint16_t getBatteryVoltageLatest(void)
@@ -521,8 +518,15 @@ uint8_t getBatteryCellCount(void)
 
 uint16_t getBatteryAverageCellVoltage(void)
 {
-    return voltageMeter.filtered / batteryCellCount;
+    return voltageMeter.displayFiltered / batteryCellCount;
 }
+
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+uint16_t getBatterySagCellVoltage(void)
+{
+    return voltageMeter.sagFiltered / batteryCellCount;
+}
+#endif
 
 bool isAmperageConfigured(void)
 {

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -27,6 +27,9 @@
 #include "sensors/current.h"
 #include "sensors/voltage.h"
 
+//TODO: Make the 'cell full' voltage user adjustble
+#define CELL_VOLTAGE_FULL_CV 420
+
 #define VBAT_CELL_VOTAGE_RANGE_MIN 100
 #define VBAT_CELL_VOTAGE_RANGE_MAX 500
 
@@ -61,10 +64,11 @@ typedef struct batteryConfig_s {
     uint16_t vbatfullcellvoltage;           // Cell voltage at which the battery is deemed to be "full" 0.01V units, default is 410 (4.1V)
 
     uint8_t forceBatteryCellCount;          // Number of cells in battery, used for overwriting auto-detected cell count if someone has issues with it.
-    uint8_t vbatLpfPeriod;                  // Period of the cutoff frequency for the Vbat filter (in 0.1 s)
+    uint8_t vbatDisplayLpfPeriod;           // Period of the cutoff frequency for the Vbat filter for display and startup (in 0.1 s)
     uint8_t ibatLpfPeriod;                  // Period of the cutoff frequency for the Ibat filter (in 0.1 s)
-    uint8_t vbatDurationForWarning;      // Period voltage has to sustain before the battery state is set to BATTERY_WARNING (in 0.1 s)
-    uint8_t vbatDurationForCritical;         // Period voltage has to sustain before the battery state is set to BATTERY_CRIT (in 0.1 s)
+    uint8_t vbatDurationForWarning;         // Period voltage has to sustain before the battery state is set to BATTERY_WARNING (in 0.1 s)
+    uint8_t vbatDurationForCritical;        // Period voltage has to sustain before the battery state is set to BATTERY_CRIT (in 0.1 s)
+    uint8_t vbatSagLpfPeriod;               // Period of the cutoff frequency for the Vbat sag and PID compensation filter (in 0.1 s)
 } batteryConfig_t;
 
 PG_DECLARE(batteryConfig_t, batteryConfig);
@@ -105,6 +109,7 @@ uint16_t getLegacyBatteryVoltage(void);
 uint16_t getBatteryVoltageLatest(void);
 uint8_t getBatteryCellCount(void);
 uint16_t getBatteryAverageCellVoltage(void);
+uint16_t getBatterySagCellVoltage(void);
 
 bool isAmperageConfigured(void);
 int32_t getAmperage(void);

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -89,7 +89,9 @@ void voltageMeterReset(voltageMeter_t *meter)
 {
     meter->displayFiltered = 0;
     meter->unfiltered = 0;
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     meter->sagFiltered = 0;
+#endif
 }
 //
 // ADC
@@ -117,9 +119,9 @@ typedef struct voltageMeterADCState_s {
 #endif
 } voltageMeterADCState_t;
 
-extern voltageMeterADCState_t voltageMeterADCStates[MAX_VOLTAGE_SENSOR_ADC];
-
 voltageMeterADCState_t voltageMeterADCStates[MAX_VOLTAGE_SENSOR_ADC];
+
+static bool sagCompensationConfigured;
 
 voltageMeterADCState_t *getVoltageMeterADC(uint8_t index)
 {
@@ -208,16 +210,7 @@ void voltageMeterADCRead(voltageSensorADC_e adcChannel, voltageMeter_t *voltageM
 
 bool isSagCompensationConfigured(void)
 {
-    bool isConfigured = false;
-#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
-    for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {
-        if (pidProfiles(i)->vbat_sag_compensation > 0) {
-            isConfigured = true;
-        }
-    }
-#endif
-
-    return isConfigured;
+    return sagCompensationConfigured;
 }
 
 void voltageMeterADCInit(void)
@@ -235,6 +228,18 @@ void voltageMeterADCInit(void)
         }
 #endif
     }
+}
+
+void voltageMeterGenericInit(void)
+{
+    sagCompensationConfigured = false;
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+    for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {
+        if (pidProfiles(i)->vbat_sag_compensation > 0) {
+            sagCompensationConfigured = true;
+        }
+    }
+#endif
 }
 
 //

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -100,6 +100,8 @@ PG_DECLARE_ARRAY(voltageSensorADCConfig_t, MAX_VOLTAGE_SENSOR_ADC, voltageSensor
 //
 void voltageMeterReset(voltageMeter_t *voltageMeter);
 
+void voltageMeterGenericInit(void);
+
 void voltageMeterADCInit(void);
 void voltageMeterADCRefresh(void);
 void voltageMeterADCRead(voltageSensorADC_e adcChannel, voltageMeter_t *voltageMeter);

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -22,6 +22,9 @@
 
 #include "voltage_ids.h"
 
+#define SLOW_VOLTAGE_TASK_FREQ_HZ 50
+#define FAST_VOLTAGE_TASK_FREQ_HZ 200
+
 //
 // meters
 //
@@ -38,8 +41,11 @@ extern const char * const voltageMeterSourceNames[VOLTAGE_METER_COUNT];
 // WARNING - do not mix usage of VOLTAGE_METER_* and VOLTAGE_SENSOR_*, they are separate concerns.
 
 typedef struct voltageMeter_s {
-    uint16_t filtered;                      // voltage in 0.01V steps
+    uint16_t displayFiltered;                      // voltage in 0.01V steps
     uint16_t unfiltered;                    // voltage in 0.01V steps
+#if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
+    uint16_t sagFiltered;                   // voltage in 0.01V steps
+#endif
     bool lowVoltageCutoff;
 } voltageMeter_t;
 
@@ -112,3 +118,5 @@ extern const uint8_t voltageMeterADCtoIDMap[MAX_VOLTAGE_SENSOR_ADC];
 extern const uint8_t supportedVoltageMeterCount;
 extern const uint8_t voltageMeterIds[];
 void voltageMeterRead(voltageMeterId_e id, voltageMeter_t *voltageMeter);
+
+uint16_t getBatteryVoltageTaskFrequencyHz(void);

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -119,4 +119,4 @@ extern const uint8_t supportedVoltageMeterCount;
 extern const uint8_t voltageMeterIds[];
 void voltageMeterRead(voltageMeterId_e id, voltageMeter_t *voltageMeter);
 
-uint16_t getBatteryVoltageTaskFrequencyHz(void);
+bool isSagCompensationConfigured(void);

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -367,4 +367,5 @@
 #define USE_SERIALRX_SRXL2     // Spektrum SRXL2 protocol
 #define USE_INTERPOLATED_SP
 #define USE_CUSTOM_BOX_NAMES
+#define USE_BATTERY_VOLTAGE_SAG_COMPENSATION
 #endif


### PR DESCRIPTION
This PR applies an initial motor output reduction when the battery is full, and boosts motor output upwards from that value, during the flight, to compensate for sagging battery voltage as it happens.

This provides a more consistent stick feel, both for throttle and PID, over the usable battery voltage range, compensating for loss of performance as the battery sags.  The quad will not feel super aggressive at the start of a flight, or dull at the end.

It is enabled by setting `vbat_sag_compensation` to a non-zero value.  We recommend starting at 100, which means '100% compensation for voltage sag'.

**NOTE:** The quad must have an on-board battery voltage sensor.  Sag compensation options will not be available when ESC based serial voltage telemetry is active, because the voltage data is delayed too much.

This method may eventually replace the old `vbat_pid_gain` method of battery sag compensation.  Both should not be used at the same time.

**WARNING**:  Only use this if you have active battery monitoring via telemetry or OSD!  **When it’s working well, you may not be able tell that the battery is getting low by ‘how the quad feels’**.  You will only start to get significant loss of 'stick feel' once the battery starts falling below 3.5V.

**Detailed tuning notes:**

**1. Quick Setup**
For quick responses, including to transient falls, for most quads, paste this into CLI and save:

```
set vbat_sag_compensation = 100
```

**2. Explanations**
The code compensates for voltage changes over the range between 'cell maximum voltage' (minus 0.1V) and 'cell warning voltage'.  With normal default values, this means a range of 0.7V, from 4.2V down to 3.5V.

A fall from 4.2V to 3.5V is about a 16% reduction in voltage.  Assuming the user wants 100% compensation, a motor output reduction of about 16% would be applied when the battery is full.  With a full battery, the motor output would therefore start at about 84%.  As the battery voltage falls, motor output is dynamically boosted back towards normal.  Once the battery falls to 3.5V or lower, motor output will be normal, or 100%, and no further compensation is possible.  

If you already have a static `motor_output_limit` value below 100, the code operates by further reducing motor output below that value.  It will not boost above that limit (see below).

The `vbat_sag_lpf_period` value determines how quickly the battery compensation responds to battery sags (see below for more detail).


**3. Compensation amount**
The normal starting point would be full compensation, eg `set vbat_sag_compensation = 100`.

To  keep a bit more aggression at the start, at the cost of having a bit more 'sag' during the flight, apply less than full compensation, eg 50% compensation.

If, despite 100% compensation, there seems to be still and element of reduced stick feel as the battery sags, try a faster response time so that the quad can respond more quickly.  Using more than 100% compensation can help whoops that sag really badly, but usually isn't needed.


**4. Response time**
There are two kinds of battery sags:

- Slow falls, over minutes, as the battery loses capacity
- Quick dips due to transient high current loads during throttle blips

To only cover the slow fall, set `vbat_sag_lpf_period` to 200 (20 seconds period, or a time constant of about 3.3 seconds).  This will not compensate for quick transient drops.  High values make sense for slow flyers or cinematic type flying, and may be 'better than nothing' for ESC based serial voltage measurements.

To respond quickly, use the default `vbat_sag_lpf_period` of 2, or 200ms.  This has a time constant of about 33ms, fast enough to respond very quickly for fast throttle blips and quick split-S turn type sags.  A value of 1 can be used for extremely quick responses but may add some noise to the motor traces if the electrical filtering isn't much good.  Fast responses require that the flight controller has on-board voltage sensor.

**5.  Voltage limits**

The warning voltage should be set at your usual value.  It indicates the value that you don't ordinarily want to fly under.  Whoops tend to be flown at lower voltages than mini quads, so the warning voltage is often set lower, eg 3.3V.  In this case, the attenuation range, and the maximum motor output suppression value, will be a bit bigger.  You may want to slightly reduce the compensation amount in this case, eg to say 80%, if that wider range makes it feel just a bit too dull overall.

When using HV cells, no adjustments are required.  The code will not compensate for in-flight cell voltages above 4.2V, but holding above 4.2 in flight is unusual, even for HV's.  HV cells should 'feel' much the same as normal cells.

**6.  I already have a throttle limit or a motor output limit...**

If you previously used a scaled throttle limit, most likely there is no need to change it.  Fly the quad at your normal throttle limit value, then adjust it, if necessary.  

If you are already using motor output limiting, eg on a 6S mid KV racer, that is a kind of static battery compensation factor.  vbat sag compensation adds additional attenuation on top of the static element.  In most cases, it is best to remove some of that static limiting when vbat sag compensation is active.  For example, if you were running 85% motor_output_imit before adding sag compensation, a value of 90-95% may well feel good with the extra sag compensation. 

**7.  Monitoring, Debugs**
Enabling the `BATTERY` debug can show the compensation amounts live in the OSD or recorded in a log.

Battery debug 2 carries the 'batteryGoodness' or 'compensationStrength' value, which ranges between 0 and 100.  When 0, you're at the low end of the battery range, and no further compensation is available.  When it's 100, you've got a fresh battery and your maximum configured compensation is active.  

Battery debug 3 carries the actual percentage reduction applied to  motor output.  A normal value for a full battery would be about 160 (16%).  If you were to apply only 50% compensation, your would see only about 8% attenuation when full.

Thanks to Tyler for [his recent PR](https://github.com/betaflight/betaflight/pull/9525), which really got me thinking about this, James for coding assistance, Mike for his advice, guidance and near total late rewrite, eTracer for his improvements, all the test pilots who gave me such useful feedback, and jRod and iCr4sh for all your enthusiasm, assistance, and support!