### PR TITLE
Fixed frame handling for FrSky SPI RX.

### DIFF
--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -370,7 +370,7 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
         FALLTHROUGH;
         // here FS code could be
     case STATE_DATA:
-        if (rxSpiGetExtiState() && (frameReceived == false)) {
+        if (rxSpiGetExtiState() && (!frameReceived)) {
             uint8_t ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
             if (ccLen >= packetLength) {
                 cc2500ReadFifo(packet, packetLength);
@@ -470,6 +470,8 @@ rx_spi_received_e frSkyXHandlePacket(uint8_t * const packet, uint8_t * const pro
         }
         if (frameReceived) {
             ret |= RX_SPI_RECEIVED_DATA;
+
+            frameReceived = false;
         }
 
         break;


### PR DESCRIPTION
Fixes #9467.

A bug in the FrSky X SPI code caused new RC frames to be recognised / handled multiple times, leading to jittery behaviour when RC smoothing was enabled.
This fixes it:

![image](https://user-images.githubusercontent.com/4742747/76156937-ad48a880-6166-11ea-8c94-660ca681ad65.png)
