### PR TITLE
Cleaned up the RX handler some.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4670,7 +4670,10 @@ static void cliStatus(char *cmdline)
     // Run status
 
     const int gyroRate = getTaskDeltaTime(TASK_GYRO) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_GYRO)));
-    const int rxRate = currentRxRefreshRate == 0 ? 0 : (int)(1000000.0f / ((float)currentRxRefreshRate));
+    int rxRate = getCurrentRxRefreshRate();
+    if (rxRate != 0) {
+        rxRate = (int)(1000000.0f / ((float)rxRate));
+    }
     const int systemRate = getTaskDeltaTime(TASK_SYSTEM) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_SYSTEM)));
     cliPrintLinef("CPU:%d%%, cycle time: %d, GYRO rate: %d, RX rate: %d, System rate: %d",
             constrain(averageSystemLoadPercent, 0, 100), getTaskDeltaTime(TASK_GYRO), gyroRate, rxRate, systemRate);

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -149,7 +149,6 @@ static bool flipOverAfterCrashActive = false;
 
 static timeUs_t disarmAt;     // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
 
-bool isRXDataNew;
 static int lastArmingDisabledReason = 0;
 static timeUs_t lastDisarmTimeUs;
 static int tryingToArm = ARMING_DELAYED_DISARMED;
@@ -751,6 +750,8 @@ bool processRx(timeUs_t currentTimeUs)
     if (!calculateRxChannelsAndUpdateFailsafe(currentTimeUs)) {
         return false;
     }
+
+    updateRcRefreshRate(currentTimeUs);
 
     // in 3D mode, we need to be able to disarm by switch at any time
     if (featureIsEnabled(FEATURE_3D)) {

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -27,8 +27,6 @@
 extern int16_t magHold;
 #endif
 
-extern bool isRXDataNew;
-
 typedef struct throttleCorrectionConfig_s {
     uint16_t throttle_correction_angle;     // the angle when the throttle correction is maximal. in 0.1 degres, ex 225 = 22.5 ,30.0, 450 = 45.0 deg
     uint8_t throttle_correction_value;      // the correction that will be applied at throttle_correction_angle.

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/time.h"
+
 #include "fc/rc_controls.h"
 
 typedef enum {
@@ -29,8 +31,6 @@ typedef enum {
     INTERPOLATION_CHANNELS_T,
     INTERPOLATION_CHANNELS_RPT,
 } interpolationChannels_e;
-
-extern uint16_t currentRxRefreshRate;
 
 #ifdef USE_RC_SMOOTHING_FILTER
 #define RC_SMOOTHING_AUTO_FACTOR_MIN 0
@@ -55,3 +55,5 @@ float getRawDeflection(int axis);
 float applyCurve(int axis, float deflection);
 uint32_t getRcFrameNumber();
 float getRcCurveSlope(int axis, float deflection);
+void updateRcRefreshRate(timeUs_t currentTimeUs);
+uint16_t getCurrentRxRefreshRate(void);

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -160,32 +160,19 @@ static void taskUpdateAccelerometer(timeUs_t currentTimeUs)
 
 static void taskUpdateRxMain(timeUs_t currentTimeUs)
 {
-    static timeUs_t lastRxTimeUs;
-
     if (!processRx(currentTimeUs)) {
         return;
     }
 
-    timeDelta_t frameAgeUs;
-    timeDelta_t refreshRateUs = rxGetFrameDelta(&frameAgeUs);
-    if (!refreshRateUs || cmpTimeUs(currentTimeUs, lastRxTimeUs) <= frameAgeUs) {
-        if (!rxTryGetFrameDeltaOrZero(&refreshRateUs)) {
-            refreshRateUs = cmpTimeUs(currentTimeUs, lastRxTimeUs); // calculate a delta here if not supplied by the protocol
-        }
-    }
-    lastRxTimeUs = currentTimeUs;
-    currentRxRefreshRate = constrain(refreshRateUs, 1000, 30000);
-    isRXDataNew = true;
+    // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState
+    updateRcCommands();
+    updateArmingStatus();
 
 #ifdef USE_USB_CDC_HID
     if (!ARMING_FLAG(ARMED)) {
         sendRcDataToHid();
     }
 #endif
-
-    // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState
-    updateRcCommands();
-    updateArmingStatus();
 }
 
 #ifdef USE_BARO

--- a/src/main/flight/interpolated_setpoint.c
+++ b/src/main/flight/interpolated_setpoint.c
@@ -65,7 +65,7 @@ FAST_CODE_NOINLINE float interpolatedSpApply(int axis, bool newRcFrame, ffInterp
     if (newRcFrame) {
         float rawSetpoint = getRawSetpoint(axis);
 
-        const float rxInterval = currentRxRefreshRate * 1e-6f;
+        const float rxInterval = getCurrentRxRefreshRate() * 1e-6f;
         const float rxRate = 1.0f / rxInterval;
         float setpointSpeed = (rawSetpoint - prevRawSetpoint[axis]) * rxRate;
         float setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1102,4 +1102,5 @@ extern "C" {
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
     void gyroFiltering(timeUs_t) {};
     timeDelta_t rxGetFrameDelta(timeDelta_t *) { return 0; }
+    void updateRcRefreshRate(timeUs_t) {};
 }

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -359,4 +359,5 @@ bool isModeActivationConditionConfigured(const modeActivationCondition_t *, cons
 void delay(uint32_t) {}
 displayPort_t *osdGetDisplayPort(osdDisplayPortDevice_e *) { return NULL; }
 mcuTypeId_e getMcuTypeId(void) { return MCU_TYPE_UNKNOWN; }
+uint16_t getCurrentRxRefreshRate(void) { return 0; }
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -187,4 +187,5 @@ extern "C" {
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
     void gyroFiltering(timeUs_t) {};
     timeDelta_t rxGetFrameDelta(timeDelta_t *) { return 0; }
+    void updateRcRefreshRate(timeUs_t) {};
 }


### PR DESCRIPTION
I came up with this when digging around for a fix to #9563, which turned out to be in a completely different area.

But it's a nice win as well, moving bits of code to where they belong. And moving the calculation of the RC refresh rate to earlier in the RC handler task should result in a more accurate refresh rate for RX protocols that do not support protocol level measurement.