### PR TITLE
Cleaned up the inclusion of the microcode for BMI270.

### DIFF
--- a/lib/main/BoschSensortec/BMI270-Sensor-API/betaflight_info.txt
+++ b/lib/main/BoschSensortec/BMI270-Sensor-API/betaflight_info.txt
@@ -4,10 +4,3 @@ Library download location:
     https://github.com/BoschSensortec/BMI270-Sensor-API
 
 The only file that is compiled as part of Betaflight is bmi270.c. This file contains the device microcode that must be uploaded during initialization. 
-
-When upgrading this library the bmi270.h header must have the following code block added:
-
-// Betaflight modifications begin
-#define BMI270_CONFIG_SIZE 8192
-extern const uint8_t bmi270_config_file[BMI270_CONFIG_SIZE];
-// Betaflight modifications end

--- a/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.h
+++ b/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.h
@@ -130,8 +130,3 @@ int8_t bmi270_init(struct bmi2_dev *dev);
 #endif /* End of CPP guard */
 
 #endif /* BMI270_H_ */
-
-// Betaflight modifications begin
-#define BMI270_CONFIG_SIZE 8192
-extern const uint8_t bmi270_config_file[BMI270_CONFIG_SIZE];
-// Betaflight modifications end

--- a/make/source.mk
+++ b/make/source.mk
@@ -189,7 +189,6 @@ COMMON_SRC = \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \
             io/vtx_control.c \
-            ./lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c
 
 COMMON_DEVICE_SRC = \
             $(CMSIS_SRC) \

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -35,11 +35,15 @@
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
-// Include the device config (microcode) that must be uploaded to the sensor
-#include "../../../../lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.h"
-
 #define BMI270_SPI_DIVISOR 16
 #define BMI270_FIFO_FRAME_SIZE 6
+
+#define BMI270_CONFIG_SIZE 8192
+
+// Declaration for the device config (microcode) that must be uploaded to the sensor
+extern const uint8_t bmi270_config_file[BMI270_CONFIG_SIZE];
+
+#define BMI270_CHIP_ID 0x24
 
 // BMI270 registers (not the complete list)
 typedef enum {
@@ -168,7 +172,7 @@ static void bmi270UploadConfig(const busDevice_t *bus)
     // Transfer the config file
     IOLo(bus->busdev_u.spi.csnPin);
     spiTransferByte(bus->busdev_u.spi.instance, BMI270_REG_INIT_DATA);
-    spiTransfer(bus->busdev_u.spi.instance, bmi270_config_file, NULL, BMI270_CONFIG_SIZE);
+    spiTransfer(bus->busdev_u.spi.instance, bmi270_config_file, NULL, sizeof(bmi270_config_file));
     IOHi(bus->busdev_u.spi.csnPin);
 
     delay(10);

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -26,6 +26,8 @@
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F405"
 
+#define USE_ACCGYRO_BMI270
+
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
 #define USE_I2C_DEVICE_3

--- a/src/main/target/STM32F405/target.mk
+++ b/src/main/target/STM32F405/target.mk
@@ -8,6 +8,7 @@ CUSTOM_DEFAULTS_EXTENDED = yes
 
 TARGET_SRC = \
     $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+	$(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
     $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
     drivers/max7456.c \

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -26,6 +26,8 @@
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F745"
 
+#define USE_ACCGYRO_BMI270
+
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
 #define USE_I2C_DEVICE_3

--- a/src/main/target/STM32F745/target.mk
+++ b/src/main/target/STM32F745/target.mk
@@ -4,6 +4,7 @@ FEATURES       += VCP SDCARD_SPI SDCARD_SDIO ONBOARDFLASH
 
 TARGET_SRC = \
     $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+	$(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
     $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
     $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
     drivers/max7456.c \

--- a/src/main/target/common_unified.h
+++ b/src/main/target/common_unified.h
@@ -44,9 +44,6 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_ACC_SPI_ICM20689
 #define USE_GYRO_SPI_ICM20689
-#if (TARGET_FLASH_SIZE > 512)
-#define USE_ACCGYRO_BMI270
-#endif
 // Other USE_ACCs and USE_GYROs should follow
 
 #define USE_MAG


### PR DESCRIPTION
@etracer65: My proposal for how to make the inclusion of the microcode a bit cleaner:
- no changes needed to the sources provided by Bosch, as the microcode uses an `extern` declaration in the driver;
- adding the build for the file with the microcode at the level of individual targets using it, and moving the define for the BMI270 into these files as well.