### PR TITLE
CMS dynamic setup popup menu

### DIFF
--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -24,6 +24,8 @@
 
 #include "common/time.h"
 
+#include "cms/cms_types.h"
+
 typedef enum {
     CMS_KEY_NONE,
     CMS_KEY_UP,
@@ -52,6 +54,7 @@ const void *cmsMenuChange(displayPort_t *pPort, const void *ptr);
 const void *cmsMenuExit(displayPort_t *pPort, const void *ptr);
 void cmsSetExternKey(cms_key_e extKey);
 void inhibitSaveMenu(void);
+void cmsAddMenuEntry(OSD_Entry *menuEntry, char *text, OSD_MenuElement type, CMSEntryFuncPtr func, void *data, uint8_t flags);
 
 #define CMS_STARTUP_HELP_TEXT1 "MENU:THR MID"
 #define CMS_STARTUP_HELP_TEXT2     "+ YAW LEFT"

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -178,8 +178,10 @@ static const void *cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
 }
 #endif // USE_FLASHFS
 
-static const void *cmsx_Blackbox_onEnter(void)
+static const void *cmsx_Blackbox_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     cmsx_Blackbox_GetDeviceStatus();
     cmsx_BlackboxDevice = blackboxConfig()->device;
 
@@ -188,8 +190,9 @@ static const void *cmsx_Blackbox_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_Blackbox_onExit(const OSD_Entry *self)
+static const void *cmsx_Blackbox_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     if (blackboxMayEditConfig()) {

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -48,8 +48,10 @@ uint8_t failsafeConfig_failsafe_delay;
 uint8_t failsafeConfig_failsafe_off_delay;
 uint16_t failsafeConfig_failsafe_throttle;
 
-static const void *cmsx_Failsafe_onEnter(void)
+static const void *cmsx_Failsafe_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     failsafeConfig_failsafe_procedure = failsafeConfig()->failsafe_procedure;
     failsafeConfig_failsafe_delay = failsafeConfig()->failsafe_delay;
     failsafeConfig_failsafe_off_delay = failsafeConfig()->failsafe_off_delay;
@@ -58,8 +60,9 @@ static const void *cmsx_Failsafe_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_Failsafe_onExit(const OSD_Entry *self)
+static const void *cmsx_Failsafe_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     failsafeConfigMutable()->failsafe_procedure = failsafeConfig_failsafe_procedure;

--- a/src/main/cms/cms_menu_firmware.c
+++ b/src/main/cms/cms_menu_firmware.c
@@ -65,8 +65,9 @@ static char accCalibrationStatus[CALIBRATION_STATUS_MAX_LENGTH];
 static char baroCalibrationStatus[CALIBRATION_STATUS_MAX_LENGTH];
 #endif
 
-static const void *cmsx_CalibrationOnDisplayUpdate(const OSD_Entry *selected)
+static const void *cmsx_CalibrationOnDisplayUpdate(displayPort_t *pDisp, const OSD_Entry *selected)
 {
+    UNUSED(pDisp);
     UNUSED(selected);
 
     tfp_sprintf(gyroCalibrationStatus, sensors(SENSOR_GYRO) ? gyroIsCalibrationComplete() ? CALIBRATION_STATUS_OK : CALIBRATION_STATUS_WAIT: CALIBRATION_STATUS_OFF);
@@ -131,7 +132,7 @@ static const OSD_Entry menuCalibrateAccEntries[] = {
     { NULL, OME_END, NULL, NULL, 0 }
 };
 
-static CMS_Menu cmsx_menuCalibrateAcc = {
+CMS_Menu cmsx_menuCalibrateAcc = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "ACCCALIBRATION",
     .GUARD_type = OME_MENU,
@@ -142,7 +143,7 @@ static CMS_Menu cmsx_menuCalibrateAcc = {
     .entries = menuCalibrateAccEntries
 };
 
-static const void *cmsCalibrateAccMenu(displayPort_t *pDisp, const void *self)
+const void *cmsCalibrateAccMenu(displayPort_t *pDisp, const void *self)
 {
     UNUSED(self);
 
@@ -184,8 +185,10 @@ static CMS_Menu cmsx_menuCalibration = {
 static char infoGitRev[GIT_SHORT_REVISION_LENGTH + 1];
 static char infoTargetName[] = __TARGET__;
 
-static const void *cmsx_FirmwareInit(void)
+static const void *cmsx_FirmwareInit(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     unsigned i;
     for (i = 0 ; i < GIT_SHORT_REVISION_LENGTH ; i++) {
         if (shortGitRevision[i] >= 'a' && shortGitRevision[i] <= 'f') {

--- a/src/main/cms/cms_menu_firmware.h
+++ b/src/main/cms/cms_menu_firmware.h
@@ -23,3 +23,6 @@
 #include "cms/cms_types.h"
 
 extern CMS_Menu cmsx_menuFirmware;
+extern CMS_Menu cmsx_menuCalibrateAcc;
+
+const void *cmsCalibrateAccMenu(displayPort_t *pDisp, const void *self);

--- a/src/main/cms/cms_menu_gps_rescue.c
+++ b/src/main/cms/cms_menu_gps_rescue.c
@@ -59,8 +59,9 @@ static uint8_t gpsRescueConfig_altitudeMode;
 static uint16_t gpsRescueConfig_ascendRate;
 static uint16_t gpsRescueConfig_descendRate;
 
-static const void *cms_menuGpsRescuePidOnEnter(void)
+static const void *cms_menuGpsRescuePidOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
 
     gpsRescueConfig_throttleP = gpsRescueConfig()->throttleP;
     gpsRescueConfig_throttleI = gpsRescueConfig()->throttleI;
@@ -75,8 +76,9 @@ static const void *cms_menuGpsRescuePidOnEnter(void)
     return NULL;
 }
 
-static const void *cms_menuGpsRescuePidOnExit(const OSD_Entry *self)
+static const void *cms_menuGpsRescuePidOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     gpsRescueConfigMutable()->throttleP = gpsRescueConfig_throttleP;
@@ -121,8 +123,9 @@ CMS_Menu cms_menuGpsRescuePid = {
     .entries = cms_menuGpsRescuePidEntries,
 };
 
-static const void *cmsx_menuGpsRescueOnEnter(void)
+static const void *cmsx_menuGpsRescueOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
 
     gpsRescueConfig_angle = gpsRescueConfig()->angle;
     gpsRescueConfig_initialAltitudeM = gpsRescueConfig()->initialAltitudeM;
@@ -143,10 +146,10 @@ static const void *cmsx_menuGpsRescueOnEnter(void)
     return NULL;
 }
 
-static const void *cmsx_menuGpsRescueOnExit(const OSD_Entry *self)
+static const void *cmsx_menuGpsRescueOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
-
 
     gpsRescueConfigMutable()->angle = gpsRescueConfig_angle;
     gpsRescueConfigMutable()->initialAltitudeM = gpsRescueConfig_initialAltitudeM;

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -106,8 +106,10 @@ static void setProfileIndexString(char *profileString, int profileIndex, char *p
     profileString[charIndex] = '\0';
 }
 
-static const void *cmsx_menuImu_onEnter(void)
+static const void *cmsx_menuImu_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     pidProfileIndex = getCurrentPidProfileIndex();
     tmpPidProfileIndex = pidProfileIndex + 1;
 
@@ -117,8 +119,9 @@ static const void *cmsx_menuImu_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_menuImu_onExit(const OSD_Entry *self)
+static const void *cmsx_menuImu_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     changePidProfile(pidProfileIndex);
@@ -163,16 +166,19 @@ static const void *cmsx_PidRead(void)
     return NULL;
 }
 
-static const void *cmsx_PidOnEnter(void)
+static const void *cmsx_PidOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     setProfileIndexString(pidProfileIndexString, pidProfileIndex, currentPidProfile->profileName);
     cmsx_PidRead();
 
     return NULL;
 }
 
-static const void *cmsx_PidWriteback(const OSD_Entry *self)
+static const void *cmsx_PidWriteback(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     pidProfile_t *pidProfile = currentPidProfile;
@@ -232,8 +238,9 @@ static const void *cmsx_RateProfileRead(void)
     return NULL;
 }
 
-static const void *cmsx_RateProfileWriteback(const OSD_Entry *self)
+static const void *cmsx_RateProfileWriteback(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     memcpy(controlRateProfilesMutable(rateProfileIndex), &rateProfile, sizeof(controlRateConfig_t));
@@ -241,8 +248,10 @@ static const void *cmsx_RateProfileWriteback(const OSD_Entry *self)
     return NULL;
 }
 
-static const void *cmsx_RateProfileOnEnter(void)
+static const void *cmsx_RateProfileOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     setProfileIndexString(rateProfileIndexString, rateProfileIndex, controlRateProfilesMutable(rateProfileIndex)->profileName);
     cmsx_RateProfileRead();
 
@@ -295,8 +304,10 @@ static uint8_t cmsx_launchControlThrottlePercent;
 static uint8_t cmsx_launchControlAngleLimit;
 static uint8_t cmsx_launchControlGain;
 
-static const void *cmsx_launchControlOnEnter(void)
+static const void *cmsx_launchControlOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
 
     cmsx_launchControlMode  = pidProfile->launchControlMode;
@@ -308,8 +319,9 @@ static const void *cmsx_launchControlOnEnter(void)
     return NULL;
 }
 
-static const void *cmsx_launchControlOnExit(const OSD_Entry *self)
+static const void *cmsx_launchControlOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);
@@ -375,8 +387,10 @@ static uint8_t cmsx_ff_interpolate_sp;
 static uint8_t cmsx_ff_smooth_factor;
 #endif
 
-static const void *cmsx_profileOtherOnEnter(void)
+static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     setProfileIndexString(pidProfileIndexString, pidProfileIndex, currentPidProfile->profileName);
 
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
@@ -417,8 +431,9 @@ static const void *cmsx_profileOtherOnEnter(void)
     return NULL;
 }
 
-static const void *cmsx_profileOtherOnExit(const OSD_Entry *self)
+static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);
@@ -521,8 +536,10 @@ static uint16_t gyroConfig_gyro_soft_notch_hz_2;
 static uint16_t gyroConfig_gyro_soft_notch_cutoff_2;
 static uint8_t  gyroConfig_gyro_to_use;
 
-static const void *cmsx_menuGyro_onEnter(void)
+static const void *cmsx_menuGyro_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     gyroConfig_gyro_lowpass_hz =  gyroConfig()->gyro_lowpass_hz;
     gyroConfig_gyro_lowpass2_hz =  gyroConfig()->gyro_lowpass2_hz;
     gyroConfig_gyro_soft_notch_hz_1 = gyroConfig()->gyro_soft_notch_hz_1;
@@ -534,8 +551,9 @@ static const void *cmsx_menuGyro_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_menuGyro_onExit(const OSD_Entry *self)
+static const void *cmsx_menuGyro_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     gyroConfigMutable()->gyro_lowpass_hz =  gyroConfig_gyro_lowpass_hz;
@@ -596,8 +614,10 @@ static uint16_t dynFiltDtermMax;
 static uint8_t dynFiltDtermExpo;
 #endif
 
-static const void *cmsx_menuDynFilt_onEnter(void)
+static const void *cmsx_menuDynFilt_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
 #ifdef USE_GYRO_DATA_ANALYSE
     dynFiltNotchMaxHz   = gyroConfig()->dyn_notch_max_hz;
     dynFiltWidthPercent = gyroConfig()->dyn_notch_width_percent;
@@ -616,8 +636,9 @@ static const void *cmsx_menuDynFilt_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_menuDynFilt_onExit(const OSD_Entry *self)
+static const void *cmsx_menuDynFilt_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
 #ifdef USE_GYRO_DATA_ANALYSE
@@ -680,8 +701,10 @@ static uint16_t cmsx_dterm_notch_hz;
 static uint16_t cmsx_dterm_notch_cutoff;
 static uint16_t cmsx_yaw_lowpass_hz;
 
-static const void *cmsx_FilterPerProfileRead(void)
+static const void *cmsx_FilterPerProfileRead(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
 
     cmsx_dterm_lowpass_hz   = pidProfile->dterm_lowpass_hz;
@@ -693,8 +716,9 @@ static const void *cmsx_FilterPerProfileRead(void)
     return NULL;
 }
 
-static const void *cmsx_FilterPerProfileWriteback(const OSD_Entry *self)
+static const void *cmsx_FilterPerProfileWriteback(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     pidProfile_t *pidProfile = currentPidProfile;
@@ -748,8 +772,10 @@ static const char * const cmsx_ProfileNames[] = {
 static OSD_TAB_t cmsx_PidProfileTable = { &cmsx_dstPidProfile, 3, cmsx_ProfileNames };
 static OSD_TAB_t cmsx_ControlRateProfileTable = { &cmsx_dstControlRateProfile, 3, cmsx_ProfileNames };
 
-static const void *cmsx_menuCopyProfile_onEnter(void)
+static const void *cmsx_menuCopyProfile_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     cmsx_dstPidProfile = 0;
     cmsx_dstControlRateProfile = 0;
 

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -65,8 +65,10 @@ const char * const ledProfileNames[LED_PROFILE_COUNT] = {
 #endif
 };
 
-static const void *cmsx_Ledstrip_OnEnter(void)
+static const void *cmsx_Ledstrip_OnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     cmsx_FeatureLedstrip = featureIsEnabled(FEATURE_LED_STRIP) ? 1 : 0;
     cmsx_ledProfile = getLedProfile();
     cmsx_ledRaceColor = ledStripConfig()->ledstrip_race_color;
@@ -80,8 +82,9 @@ static const void *cmsx_Ledstrip_OnEnter(void)
     return NULL;
 }
 
-static const void *cmsx_Ledstrip_OnExit(const OSD_Entry *self)
+static const void *cmsx_Ledstrip_OnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     if (cmsx_FeatureLedstrip) {

--- a/src/main/cms/cms_menu_main.h
+++ b/src/main/cms/cms_menu_main.h
@@ -23,3 +23,4 @@
 #include "cms/cms_types.h"
 
 extern CMS_Menu cmsx_menuMain;
+extern CMS_Menu cmsx_menuSetupPopup;

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -59,15 +59,19 @@
 // Misc
 //
 
-static const void *cmsx_menuRcOnEnter(void)
+static const void *cmsx_menuRcOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     inhibitSaveMenu();
 
     return NULL;
 }
 
-static const void *cmsx_menuRcConfirmBack(const OSD_Entry *self)
+static const void *cmsx_menuRcConfirmBack(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
+
     if (self && self->type == OME_Back) {
         return NULL;
     } else {
@@ -111,8 +115,10 @@ static uint16_t motorConfig_minthrottle;
 static uint8_t motorConfig_digitalIdleOffsetValue;
 static uint8_t rxConfig_fpvCamAngleDegrees;
 
-static const void *cmsx_menuMiscOnEnter(void)
+static const void *cmsx_menuMiscOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     motorConfig_minthrottle = motorConfig()->minthrottle;
     motorConfig_digitalIdleOffsetValue = motorConfig()->digitalIdleOffsetValue / 10;
     rxConfig_fpvCamAngleDegrees = rxConfig()->fpvCamAngleDegrees;
@@ -120,8 +126,9 @@ static const void *cmsx_menuMiscOnEnter(void)
     return NULL;
 }
 
-static const void *cmsx_menuMiscOnExit(const OSD_Entry *self)
+static const void *cmsx_menuMiscOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     motorConfigMutable()->minthrottle = motorConfig_minthrottle;

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -48,14 +48,17 @@
 #ifdef USE_EXTENDED_CMS_MENUS
 static uint16_t osdConfig_item_pos[OSD_ITEM_COUNT];
 
-static const void *menuOsdActiveElemsOnEnter(void)
+static const void *menuOsdActiveElemsOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     memcpy(&osdConfig_item_pos[0], &osdElementConfig()->item_pos[0], sizeof(uint16_t) * OSD_ITEM_COUNT);
     return NULL;
 }
 
-static const void *menuOsdActiveElemsOnExit(const OSD_Entry *self)
+static const void *menuOsdActiveElemsOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     memcpy(&osdElementConfigMutable()->item_pos[0], &osdConfig_item_pos[0], sizeof(uint16_t) * OSD_ITEM_COUNT);
@@ -171,8 +174,10 @@ static uint16_t osdConfig_distance_alarm;
 static uint8_t batteryConfig_vbatDurationForWarning;
 static uint8_t batteryConfig_vbatDurationForCritical;
 
-static const void *menuAlarmsOnEnter(void)
+static const void *menuAlarmsOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     osdConfig_rssi_alarm = osdConfig()->rssi_alarm;
     osdConfig_link_quality_alarm = osdConfig()->link_quality_alarm;
     osdConfig_rssi_dbm_alarm = osdConfig()->rssi_dbm_alarm;
@@ -185,8 +190,9 @@ static const void *menuAlarmsOnEnter(void)
     return NULL;
 }
 
-static const void *menuAlarmsOnExit(const OSD_Entry *self)
+static const void *menuAlarmsOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     osdConfigMutable()->rssi_alarm = osdConfig_rssi_alarm;
@@ -231,8 +237,10 @@ osd_timer_source_e timerSource[OSD_TIMER_COUNT];
 osd_timer_precision_e timerPrecision[OSD_TIMER_COUNT];
 uint8_t timerAlarm[OSD_TIMER_COUNT];
 
-static const void *menuTimersOnEnter(void)
+static const void *menuTimersOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     for (int i = 0; i < OSD_TIMER_COUNT; i++) {
         const uint16_t timer = osdConfig()->timers[i];
         timerSource[i] = OSD_TIMER_SRC(timer);
@@ -243,8 +251,9 @@ static const void *menuTimersOnEnter(void)
     return NULL;
 }
 
-static const void *menuTimersOnExit(const OSD_Entry *self)
+static const void *menuTimersOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     for (int i = 0; i < OSD_TIMER_COUNT; i++) {
@@ -291,8 +300,10 @@ static uint8_t displayPortProfileMax7456_whiteBrightness;
 static uint8_t osdConfig_osdProfileIndex;
 #endif
 
-static const void *cmsx_menuOsdOnEnter(void)
+static const void *cmsx_menuOsdOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
 #ifdef USE_OSD_PROFILES
     osdConfig_osdProfileIndex = osdConfig()->osdProfileIndex;
 #endif
@@ -306,8 +317,9 @@ static const void *cmsx_menuOsdOnEnter(void)
     return NULL;
 }
 
-static const void *cmsx_menuOsdOnExit(const OSD_Entry *self)
+static const void *cmsx_menuOsdOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
 #ifdef USE_OSD_PROFILES

--- a/src/main/cms/cms_menu_power.c
+++ b/src/main/cms/cms_menu_power.c
@@ -54,8 +54,10 @@ int16_t currentSensorVirtualConfig_scale;
 int16_t currentSensorVirtualConfig_offset;
 #endif
 
-static const void *cmsx_Power_onEnter(void)
+static const void *cmsx_Power_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     batteryConfig_voltageMeterSource = batteryConfig()->voltageMeterSource;
     batteryConfig_currentMeterSource = batteryConfig()->currentMeterSource;
 
@@ -74,8 +76,9 @@ static const void *cmsx_Power_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_Power_onExit(const OSD_Entry *self)
+static const void *cmsx_Power_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     batteryConfigMutable()->voltageMeterSource = batteryConfig_voltageMeterSource;

--- a/src/main/cms/cms_menu_vtx_common.c
+++ b/src/main/cms/cms_menu_vtx_common.c
@@ -43,8 +43,10 @@
 static char statusLine1[MAX_STATUS_LINE_LENGTH] = "";
 static char statusLine2[MAX_STATUS_LINE_LENGTH] = "";
 
-static const void *setStatusMessage(void)
+static const void *setStatusMessage(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     vtxDevice_t *device = vtxCommonDevice();
 
     statusLine1[0] = 0;

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -78,8 +78,10 @@ static void cmsx_Vtx_ConfigWriteback(void)
     saveConfigAndNotify();
 }
 
-static const void *cmsx_Vtx_onEnter(void)
+static const void *cmsx_Vtx_onEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     cmsx_Vtx_ConfigRead();
 
     entryVtxBand.val = &cmsx_vtxBand;
@@ -97,8 +99,9 @@ static const void *cmsx_Vtx_onEnter(void)
     return NULL;
 }
 
-static const void *cmsx_Vtx_onExit(const OSD_Entry *self)
+static const void *cmsx_Vtx_onExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
+    UNUSED(pDisp);
     UNUSED(self);
 
     vtxCommonSetPitMode(vtxCommonDevice(), cmsx_vtxPit);

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -468,7 +468,7 @@ static const char * const saCmsPitNames[] = {
 static OSD_TAB_t saCmsEntPitFMode = { &saCmsPitFMode, 1, saCmsPitFModeNames };
 static OSD_TAB_t saCmsEntPit = {&saCmsPit, 2, saCmsPitNames};
 
-static const void *sacms_SetupTopMenu(void); // Forward
+static const void *sacms_SetupTopMenu(displayPort_t *pDisp); // Forward
 
 static const void *saCmsConfigFreqModeByGvar(displayPort_t *pDisp, const void *self)
 {
@@ -484,7 +484,7 @@ static const void *saCmsConfigFreqModeByGvar(displayPort_t *pDisp, const void *s
     // don't call 'saSetBandAndChannel()' / 'saSetFreq()' here,
     // wait until SET / 'saCmsCommence()' is activated
 
-    sacms_SetupTopMenu();
+    sacms_SetupTopMenu(pDisp);
 
     return NULL;
 }
@@ -540,8 +540,10 @@ static const void *saCmsCommence(displayPort_t *pDisp, const void *self)
     return MENU_CHAIN_BACK;
 }
 
-static const void *saCmsSetPORFreqOnEnter(void)
+static const void *saCmsSetPORFreqOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     if (saDevice.version == 1)
         return MENU_CHAIN_BACK;
 
@@ -584,8 +586,10 @@ static const char *saCmsUserFreqGetString(displayPort_t *pDisp, const void *self
     return pbuf;
 }
 
-static const void *saCmsSetUserFreqOnEnter(void)
+static const void *saCmsSetUserFreqOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     saCmsUserFreqNew = saCmsUserFreq;
 
     return NULL;
@@ -741,8 +745,10 @@ static const OSD_Entry saCmsMenuOfflineEntries[] =
 
 CMS_Menu cmsx_menuVtxSmartAudio; // Forward
 
-static const void *sacms_SetupTopMenu(void)
+static const void *sacms_SetupTopMenu(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     if (saCmsDeviceStatus) {
         if (saCmsFselModeNew == 0)
             cmsx_menuVtxSmartAudio.entries = saCmsMenuChanModeEntries;

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -220,8 +220,10 @@ static bool trampCmsInitSettings(void)
     return true;
 }
 
-static const void *trampCmsOnEnter(void)
+static const void *trampCmsOnEnter(displayPort_t *pDisp)
 {
+    UNUSED(pDisp);
+
     if (!trampCmsInitSettings()) {
         return MENU_CHAIN_BACK;
     }

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -58,11 +58,11 @@ typedef const void *(*CMSEntryFuncPtr)(displayPort_t *displayPort, const void *p
 
 typedef struct
 {
-    const char * const text;
-    const OSD_MenuElement type;
+    const char * text;
+    OSD_MenuElement type;
     CMSEntryFuncPtr func;
     void *data;
-    const uint8_t flags;
+    uint8_t flags;
 } __attribute__((packed)) OSD_Entry;
 
 // Bits in flags
@@ -82,7 +82,7 @@ typedef struct
 
 #define IS_DYNAMIC(p) ((p)->flags & DYNAMIC)
 
-typedef const void *(*CMSMenuFuncPtr)(void);
+typedef const void *(*CMSMenuFuncPtr)(displayPort_t *pDisp);
 
 // Special return value(s) for function chaining by CMSMenuFuncPtr
 extern int menuChainBack;
@@ -95,11 +95,9 @@ onExit function is called with self:
 (2) NULL if called from menu exit (forced exit at top level).
 */
 
-typedef const void *(*CMSMenuOnExitPtr)(const OSD_Entry *self);
+typedef const void *(*CMSMenuOnExitPtr)(displayPort_t *pDisp, const OSD_Entry *self);
 
-typedef const void * (*CMSMenuCheckRedirectPtr)(void);
-
-typedef const void *(*CMSMenuOnDisplayUpdatePtr)(const OSD_Entry *selected);
+typedef const void *(*CMSMenuOnDisplayUpdatePtr)(displayPort_t *pDisp, const OSD_Entry *selected);
 
 typedef struct
 {

--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -118,7 +118,7 @@ TEST(CMSUnittest, TestCmsMenuKey)
 // STUBS
 
 extern "C" {
-static OSD_Entry menuMainEntries[] =
+static const OSD_Entry menuMainEntries[] =
 {
     {"-- MAIN MENU --", OME_Label, NULL, NULL, 0},
     {"SAVE&REBOOT", OME_OSD_Exit, cmsMenuExit, (void*)1, 0},


### PR DESCRIPTION
Adds a dynamically constructed menu that will appear before the main menu when the user enters CMS if there are any outstanding setup items to complete. Currently only includes entry to calibrate the ACC if required, but provides a framework for other setup reminders to be added as needed. The user can choose to exit this menu without remedying the problems, but the menu will reappear when they next enter CMS. If there are no required setup items then the menu will be skipped and the user will go straight to the main menu.

Additional fixes/improvements:
- Fixed missing support for the main menu `onEnter` function.
- Normalized all the menu functions (`onEnter`, `onExit`, etc.) to include access to the `displayPort`.

Example showing an arming failure because the accelerometer wasn't calibrated. When entering the CMS menu the new Setup menu displays instead, notifying that the ACC calibration is required. Calibrate the ACC, exit, then arm successfully. When reentering the CMS the Setup menu is skipped as there are no outstanding setup items.

![OSD Setup Popup](https://user-images.githubusercontent.com/17088539/76567073-67505500-6484-11ea-8084-1ae377b3be7b.gif)
