### PR TITLE
Reduce gyro temperature read rate from 250hz to every 3 seconds

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1157,12 +1157,16 @@ static FAST_CODE_NOINLINE void subTaskPidSubprocesses(timeUs_t currentTimeUs)
 }
 
 #ifdef USE_TELEMETRY
+#define GYRO_TEMP_READ_DELAY_US 3e6    // Only read the gyro temp every 3 seconds
 void subTaskTelemetryPollSensors(timeUs_t currentTimeUs)
 {
-    UNUSED(currentTimeUs);
+    static timeUs_t lastGyroTempTimeUs = 0;
 
-    // Read out gyro temperature if used for telemmetry
-    gyroReadTemperature();
+    if (cmpTimeUs(currentTimeUs, lastGyroTempTimeUs) >= GYRO_TEMP_READ_DELAY_US) {
+        // Read out gyro temperature if used for telemmetry
+        gyroReadTemperature();
+        lastGyroTempTimeUs = currentTimeUs;
+    }
 }
 #endif
 


### PR DESCRIPTION
If the gyro supports it, the temperature is read as part of the telemetry task to be supplied in several protocols. There's absolutely no reason to read the gyro temperature at 250hz for this purpose and the temperature shouldn't be changing rapidly anyway. Revise to read a new temperature every 3 seconds which should be more than sufficient.

Has no impact at the moment as no actively used gyro supports temperature reads but may be used in the future.
