### PR TITLE
Show blackbox OSD status when using a mode or when no mode is configured.

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -962,7 +962,7 @@ static void osdElementLinkQuality(osdElementParms_t *element)
 #ifdef USE_BLACKBOX
 static void osdElementLogStatus(osdElementParms_t *element)
 {
-    if (IS_RC_MODE_ACTIVE(BOXBLACKBOX)) {
+    if (IS_RC_MODE_ACTIVE(BOXBLACKBOX) || !isModeActivationConditionPresent(BOXBLACKBOX)) {
         if (!isBlackboxDeviceWorking()) {
             tfp_sprintf(element->buff, "%c!", SYM_BBLOG);
         } else if (isBlackboxDeviceFull()) {


### PR DESCRIPTION
Previous behavior was only to show it when using the mode.

Now, if you log every flight (e.g. when using SD card, big flash, etc) you can see the status, previously you could not.
This also helps to know if your SD card is physically present.
