### PR TITLE
Fixed CRSF RF mode indication on link loss.

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -214,7 +214,6 @@ static void crsfCheckRssi(uint32_t currentTimeUs) {
 #ifdef USE_RX_LINK_QUALITY_INFO
         if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) {
             setLinkQualityDirect(0);
-            rxSetRfMode(0);
         }
 #endif
     }

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -33,6 +33,14 @@
 #define CRSF_SNR_MIN (-30)
 #define CRSF_SNR_MAX 20
 
+/* For documentation purposes
+typedef enum {
+    CRSF_RF_MODE_4_FPS = 0,
+    CRSF_RF_MODE_50_FPS,
+    CRSF_RF_MODE_150_FPS,
+} crsfRfMode_e;
+*/
+
 typedef struct crsfFrameDef_s {
     uint8_t deviceAddress;
     uint8_t frameLength;


### PR DESCRIPTION
Prevent the RF mode readout to switch to mode 0 on link loss.