### PR TITLE
Added EXTI based frame timing measuring for RX SPI receivers.

### DIFF
--- a/src/main/rx/rx_spi.c
+++ b/src/main/rx/rx_spi.c
@@ -240,7 +240,10 @@ bool rxSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeStat
 
     if (rxSpiExtiConfigured()) {
         rxSpiExtiInit(extiConfig.ioConfig, extiConfig.trigger);
+
+        rxRuntimeState->rcFrameTimeUsFn = rxSpiGetLastExtiTimeUs;
     }
+
     rxSpiNewPacketAvailable = false;
     rxRuntimeState->rxRefreshRate = 20000;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4742747/76701401-b23cc780-6725-11ea-8c2d-b1c43e0c59d4.png)
