### PR TITLE
Efficiency OSD element in mAh/km or mAh/mi

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1342,6 +1342,7 @@ const clivalue_t valueTable[] = {
 
     { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_RC_CHANNELS]) },
     { "osd_camera_frame_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CAMERA_FRAME]) },
+    { "osd_efficiency_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_EFFICIENCY]) },
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -143,6 +143,7 @@ typedef enum {
     OSD_RSSI_DBM_VALUE,
     OSD_RC_CHANNELS,
     OSD_CAMERA_FRAME,
+    OSD_EFFICIENCY,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
I've been using this OSD element for a while and continue to find it useful when doing longer range flights.

It simply displays the instantaneous energy consumption over distance.  While arguments could be made for other units such as `Watts/distance` or `distance/Ah`, I've found `mAh/km` or `mAh/mile` to be most useful.  With it I can mentally multiply this value with `distance to home` and see if I'll have the battery capacity to make it home.

Please excuse the font issues, it should say 4.82km & 79 kph here
![image](https://user-images.githubusercontent.com/6344319/76736402-f75ffa00-6723-11ea-9f01-567ddcc84c91.png)
_"250 mAh/km * 5 km = 1250 mAh to get home. 
1500 mAh already used = 2750 mAh total.
Battery capacity is 3300 mAh
Should be OK..."_

DVR: [https://www.youtube.com/watch?v=hy-3jNerfxA](https://www.youtube.com/watch?v=hy-3jNerfxA)

To save me having to always compile my own firmware for my LR rigs, I hope this can be merged :)  I'd be happy to make changes/improvements as requested by the devs or community.