### PR TITLE
Fix initialization of mixer related pidProfile settings

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -814,6 +814,7 @@ void changePidProfile(uint8_t pidProfileIndex)
 
         pidInit(currentPidProfile);
         initEscEndpoints();
+        mixerInitProfile();
     }
 
     beeperConfirmationBeeps(pidProfileIndex + 1);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -347,6 +347,16 @@ void initEscEndpoints(void)
     rcCommandThrottleRange = PWM_RANGE_MAX - PWM_RANGE_MIN;
 }
 
+// Initialize pidProfile related mixer settings
+void mixerInitProfile(void)
+{
+#ifdef USE_DYN_IDLE
+    idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
+    idleMaxIncrease = currentPidProfile->idle_max_increase * 0.001f;
+    idleP = currentPidProfile->idle_p * 0.0001f;
+#endif
+}
+
 void mixerInit(mixerMode_e mixerMode)
 {
     currentMixerMode = mixerMode;
@@ -357,12 +367,12 @@ void mixerInit(mixerMode_e mixerMode)
         mixerTricopterInit();
     }
 #endif
+
 #ifdef USE_DYN_IDLE
-    idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
-    idleMaxIncrease = currentPidProfile->idle_max_increase * 0.001f;
     idleThrottleOffset = motorConfig()->digitalIdleOffsetValue * 0.0001f;
-    idleP = currentPidProfile->idle_p * 0.0001f;
 #endif
+
+    mixerInitProfile();
 }
 
 #ifdef USE_LAUNCH_CONTROL

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -101,6 +101,7 @@ bool areMotorsRunning(void);
 void mixerLoadMix(int index, motorMixer_t *customMixers);
 void initEscEndpoints(void);
 void mixerInit(mixerMode_e mixerMode);
+void mixerInitProfile(void);
 
 void mixerConfigureOutput(void);
 


### PR DESCRIPTION
Previously the variables were only initialized at boot and were not updated when the pidProfile changed.
