### PR TITLE
[H7] Add missing SPI1_MOSI pin

### DIFF
--- a/src/main/drivers/bus_spi_pinconfig.c
+++ b/src/main/drivers/bus_spi_pinconfig.c
@@ -294,6 +294,7 @@ const spiHardware_t spiHardware[] = {
         .mosiPins = {
             { DEFIO_TAG_E(PA7), GPIO_AF5_SPI1 },
             { DEFIO_TAG_E(PB5), GPIO_AF5_SPI1 },
+            { DEFIO_TAG_E(PD7), GPIO_AF5_SPI1 },
         },
         .rcc = RCC_APB2(SPI1),
         //.dmaIrqHandler = DMA2_ST3_HANDLER,


### PR DESCRIPTION
Overlooked pin def. Thanks to Sampson@Mateksys for finding this.

As MacOS's Preview fails to find most occurrences of  `SPI1_MOSI` from data sheet, there may be others like this 😩 