### PR TITLE
cc2500: Use array-based register initialization

### DIFF
--- a/src/main/rx/cc2500_common.c
+++ b/src/main/rx/cc2500_common.c
@@ -160,3 +160,12 @@ bool cc2500SpiInit(void)
     return true;
 }
 #endif
+
+void cc2500ApplyRegisterConfig(const cc2500RegisterConfigElement_t *configArrayPtr, int configSize)
+{
+    const int entryCount = configSize / sizeof(cc2500RegisterConfigElement_t);
+    for (int i = 0; i < entryCount; i++) {
+        cc2500WriteReg(configArrayPtr->registerID, configArrayPtr->registerValue);
+        configArrayPtr++;
+    }
+}

--- a/src/main/rx/cc2500_common.h
+++ b/src/main/rx/cc2500_common.h
@@ -22,6 +22,11 @@
 
 #include "rx/rx_spi.h"
 
+typedef struct cc2500RegisterConfigElement_s {
+    uint8_t registerID;
+    uint8_t registerValue;
+} cc2500RegisterConfigElement_t;
+
 uint16_t cc2500getRssiDbm(void);
 void cc2500setRssiDbm(uint8_t value);
 #if defined(USE_RX_CC2500_SPI_PA_LNA) && defined(USE_RX_CC2500_SPI_DIVERSITY)
@@ -32,3 +37,4 @@ void cc2500TxEnable(void);
 void cc2500TxDisable(void);
 #endif
 bool cc2500SpiInit(void);
+void cc2500ApplyRegisterConfig(const cc2500RegisterConfigElement_t *configArrayPtr, int configSize);

--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -70,72 +70,93 @@ static handlePacketFn *handlePacket;
 static processFrameFn *processFrame;
 static setRcDataFn *setRcData;
 
+const cc2500RegisterConfigElement_t cc2500FrskyBaseConfig[] =
+{
+    { CC2500_02_IOCFG0,   0x01 },
+    { CC2500_18_MCSM0,    0x18 },
+    { CC2500_07_PKTCTRL1, 0x04 },
+    { CC2500_3E_PATABLE,  0xFF },
+    { CC2500_0C_FSCTRL0,  0x00 },
+    { CC2500_0D_FREQ2,    0x5C },
+    { CC2500_13_MDMCFG1,  0x23 },
+    { CC2500_14_MDMCFG0,  0x7A },
+    { CC2500_19_FOCCFG,   0x16 },
+    { CC2500_1A_BSCFG,    0x6C },
+    { CC2500_1B_AGCCTRL2, 0x03 },
+    { CC2500_1C_AGCCTRL1, 0x40 },
+    { CC2500_1D_AGCCTRL0, 0x91 },
+    { CC2500_21_FREND1,   0x56 },
+    { CC2500_22_FREND0,   0x10 },
+    { CC2500_23_FSCAL3,   0xA9 },
+    { CC2500_24_FSCAL2,   0x0A },
+    { CC2500_25_FSCAL1,   0x00 },
+    { CC2500_26_FSCAL0,   0x11 },
+    { CC2500_29_FSTEST,   0x59 },
+    { CC2500_2C_TEST2,    0x88 },
+    { CC2500_2D_TEST1,    0x31 },
+    { CC2500_2E_TEST0,    0x0B },
+    { CC2500_03_FIFOTHR,  0x07 },
+    { CC2500_09_ADDR,     0x00 }
+};
+
+const cc2500RegisterConfigElement_t cc2500FrskyDConfig[] =
+{
+    { CC2500_17_MCSM1,    0x0C },
+    { CC2500_0E_FREQ1,    0x76 },
+    { CC2500_0F_FREQ0,    0x27 },
+    { CC2500_06_PKTLEN,   0x19 },
+    { CC2500_08_PKTCTRL0, 0x05 },
+    { CC2500_0B_FSCTRL1,  0x08 },
+    { CC2500_10_MDMCFG4,  0xAA },
+    { CC2500_11_MDMCFG3,  0x39 },
+    { CC2500_12_MDMCFG2,  0x11 },
+    { CC2500_15_DEVIATN,  0x42 }
+};
+
+const cc2500RegisterConfigElement_t cc2500FrskyXConfig[] =
+{
+    { CC2500_17_MCSM1,    0x0C },
+    { CC2500_0E_FREQ1,    0x76 },
+    { CC2500_0F_FREQ0,    0x27 },
+    { CC2500_06_PKTLEN,   0x1E },
+    { CC2500_08_PKTCTRL0, 0x01 },
+    { CC2500_0B_FSCTRL1,  0x0A },
+    { CC2500_10_MDMCFG4,  0x7B },
+    { CC2500_11_MDMCFG3,  0x61 },
+    { CC2500_12_MDMCFG2,  0x13 },
+    { CC2500_15_DEVIATN,  0x51 }
+};
+
+const cc2500RegisterConfigElement_t cc2500FrskyXLbtConfig[] =
+{
+    { CC2500_17_MCSM1,    0x0E },
+    { CC2500_0E_FREQ1,    0x80 },
+    { CC2500_0F_FREQ0,    0x00 },
+    { CC2500_06_PKTLEN,   0x23 },
+    { CC2500_08_PKTCTRL0, 0x01 },
+    { CC2500_0B_FSCTRL1,  0x08 },
+    { CC2500_10_MDMCFG4,  0x7B },
+    { CC2500_11_MDMCFG3,  0xF8 },
+    { CC2500_12_MDMCFG2,  0x03 },
+    { CC2500_15_DEVIATN,  0x53 }
+};
+
 static void initialise() {
     cc2500Reset();
-    cc2500WriteReg(CC2500_02_IOCFG0,   0x01);
-    cc2500WriteReg(CC2500_18_MCSM0,    0x18);
-    cc2500WriteReg(CC2500_07_PKTCTRL1, 0x04);
-    cc2500WriteReg(CC2500_3E_PATABLE,  0xFF);
-    cc2500WriteReg(CC2500_0C_FSCTRL0,  0x00);
-    cc2500WriteReg(CC2500_0D_FREQ2,    0x5C);
-    cc2500WriteReg(CC2500_13_MDMCFG1,  0x23);
-    cc2500WriteReg(CC2500_14_MDMCFG0,  0x7A);
-    cc2500WriteReg(CC2500_19_FOCCFG,   0x16);
-    cc2500WriteReg(CC2500_1A_BSCFG,    0x6C);
-    cc2500WriteReg(CC2500_1B_AGCCTRL2, 0x03);
-    cc2500WriteReg(CC2500_1C_AGCCTRL1, 0x40);
-    cc2500WriteReg(CC2500_1D_AGCCTRL0, 0x91);
-    cc2500WriteReg(CC2500_21_FREND1,   0x56);
-    cc2500WriteReg(CC2500_22_FREND0,   0x10);
-    cc2500WriteReg(CC2500_23_FSCAL3,   0xA9);
-    cc2500WriteReg(CC2500_24_FSCAL2,   0x0A);
-    cc2500WriteReg(CC2500_25_FSCAL1,   0x00);
-    cc2500WriteReg(CC2500_26_FSCAL0,   0x11);
-    cc2500WriteReg(CC2500_29_FSTEST,   0x59);
-    cc2500WriteReg(CC2500_2C_TEST2,    0x88);
-    cc2500WriteReg(CC2500_2D_TEST1,    0x31);
-    cc2500WriteReg(CC2500_2E_TEST0,    0x0B);
-    cc2500WriteReg(CC2500_03_FIFOTHR,  0x07);
-    cc2500WriteReg(CC2500_09_ADDR,     0x00);
+
+    cc2500ApplyRegisterConfig(cc2500FrskyBaseConfig, sizeof(cc2500FrskyBaseConfig));
 
     switch (spiProtocol) {
     case RX_SPI_FRSKY_D:
-        cc2500WriteReg(CC2500_17_MCSM1,    0x0C);
-        cc2500WriteReg(CC2500_0E_FREQ1,    0x76);
-        cc2500WriteReg(CC2500_0F_FREQ0,    0x27);
-        cc2500WriteReg(CC2500_06_PKTLEN,   0x19);
-        cc2500WriteReg(CC2500_08_PKTCTRL0, 0x05);
-        cc2500WriteReg(CC2500_0B_FSCTRL1,  0x08);
-        cc2500WriteReg(CC2500_10_MDMCFG4,  0xAA);
-        cc2500WriteReg(CC2500_11_MDMCFG3,  0x39);
-        cc2500WriteReg(CC2500_12_MDMCFG2,  0x11);
-        cc2500WriteReg(CC2500_15_DEVIATN,  0x42);
+        cc2500ApplyRegisterConfig(cc2500FrskyDConfig, sizeof(cc2500FrskyDConfig));
 
         break;
     case RX_SPI_FRSKY_X:
-        cc2500WriteReg(CC2500_17_MCSM1,    0x0C);
-        cc2500WriteReg(CC2500_0E_FREQ1,    0x76);
-        cc2500WriteReg(CC2500_0F_FREQ0,    0x27);
-        cc2500WriteReg(CC2500_06_PKTLEN,   0x1E);
-        cc2500WriteReg(CC2500_08_PKTCTRL0, 0x01);
-        cc2500WriteReg(CC2500_0B_FSCTRL1,  0x0A);
-        cc2500WriteReg(CC2500_10_MDMCFG4,  0x7B);
-        cc2500WriteReg(CC2500_11_MDMCFG3,  0x61);
-        cc2500WriteReg(CC2500_12_MDMCFG2,  0x13);
-        cc2500WriteReg(CC2500_15_DEVIATN,  0x51);
+        cc2500ApplyRegisterConfig(cc2500FrskyXConfig, sizeof(cc2500FrskyXConfig));
 
         break;
     case RX_SPI_FRSKY_X_LBT:
-        cc2500WriteReg(CC2500_17_MCSM1,    0x0E);
-        cc2500WriteReg(CC2500_0E_FREQ1,    0x80);
-        cc2500WriteReg(CC2500_0F_FREQ0,    0x00);
-        cc2500WriteReg(CC2500_06_PKTLEN,   0x23);
-        cc2500WriteReg(CC2500_08_PKTCTRL0, 0x01);
-        cc2500WriteReg(CC2500_0B_FSCTRL1,  0x08);
-        cc2500WriteReg(CC2500_10_MDMCFG4,  0x7B);
-        cc2500WriteReg(CC2500_11_MDMCFG3,  0xF8);
-        cc2500WriteReg(CC2500_12_MDMCFG2,  0x03);
-        cc2500WriteReg(CC2500_15_DEVIATN,  0x53);
+        cc2500ApplyRegisterConfig(cc2500FrskyXLbtConfig, sizeof(cc2500FrskyXLbtConfig));
 
         break;
     default:

--- a/src/main/rx/cc2500_redpine.c
+++ b/src/main/rx/cc2500_redpine.c
@@ -91,77 +91,92 @@ static void nextChannel();
 static bool redpineRxPacketBind(uint8_t *packet);
 static bool isRedpineFast(void);
 
+const cc2500RegisterConfigElement_t cc2500RedPineBaseConfig[] =
+{
+    { CC2500_02_IOCFG0, 0x01 },
+    { CC2500_03_FIFOTHR, 0x07 },
+    { CC2500_06_PKTLEN, REDPINE_PACKET_SIZE },
+    { CC2500_07_PKTCTRL1, 0x0C },
+    { CC2500_08_PKTCTRL0, 0x05 },
+    { CC2500_09_ADDR, 0x00 }
+};
+
+const cc2500RegisterConfigElement_t cc2500RedPineFastConfig[] =
+{
+    { CC2500_0B_FSCTRL1, 0x0A },
+    { CC2500_0C_FSCTRL0, 0x00 },
+    { CC2500_0D_FREQ2, 0x5D },
+    { CC2500_0E_FREQ1, 0x93 },
+    { CC2500_0F_FREQ0, 0xB1 },
+    { CC2500_10_MDMCFG4, 0x2D },
+    { CC2500_11_MDMCFG3, 0x3B },
+    { CC2500_12_MDMCFG2, 0x73 },
+    { CC2500_13_MDMCFG1, 0x23 },
+    { CC2500_14_MDMCFG0, 0x56 },
+    { CC2500_15_DEVIATN, 0x00 },
+    { CC2500_17_MCSM1, 0x0C },
+    { CC2500_18_MCSM0, 0x08 },
+    { CC2500_19_FOCCFG, 0x1D },
+    { CC2500_1A_BSCFG, 0x1C },
+    { CC2500_1B_AGCCTRL2, 0xC7 },
+    { CC2500_1C_AGCCTRL1, 0x00 },
+    { CC2500_1D_AGCCTRL0, 0xB0 },
+    { CC2500_21_FREND1, 0xB6 },
+    { CC2500_22_FREND0, 0x10 },
+    { CC2500_23_FSCAL3, 0xEA },
+    { CC2500_24_FSCAL2, 0x0A },
+    { CC2500_25_FSCAL1, 0x00 },
+    { CC2500_26_FSCAL0, 0x11 },
+    { CC2500_29_FSTEST, 0x59 },
+    { CC2500_2C_TEST2, 0x88 },
+    { CC2500_2D_TEST1, 0x31 },
+    { CC2500_2E_TEST0, 0x0B },
+    { CC2500_3E_PATABLE, 0xFF }
+};
+
+const cc2500RegisterConfigElement_t cc2500RedPineConfig[] =
+{
+    { CC2500_0B_FSCTRL1, 0x06 },
+    { CC2500_0C_FSCTRL0, 0x00 },
+    { CC2500_0D_FREQ2, 0x5D },
+    { CC2500_0E_FREQ1, 0x93 },
+    { CC2500_0F_FREQ0, 0xB1 },
+    { CC2500_10_MDMCFG4, 0x78 },
+    { CC2500_11_MDMCFG3, 0x93 },
+    { CC2500_12_MDMCFG2, 0x03 },
+    { CC2500_13_MDMCFG1, 0x22 },
+    { CC2500_14_MDMCFG0, 0xF8 },
+    { CC2500_15_DEVIATN, 0x44 },
+    { CC2500_17_MCSM1, 0x0C },
+    { CC2500_18_MCSM0, 0x08 },
+    { CC2500_19_FOCCFG, 0x16 },
+    { CC2500_1A_BSCFG, 0x6C },
+    { CC2500_1B_AGCCTRL2, 0x43 },
+    { CC2500_1C_AGCCTRL1, 0x40 },
+    { CC2500_1D_AGCCTRL0, 0x91 },
+    { CC2500_21_FREND1, 0x56 },
+    { CC2500_22_FREND0, 0x10 },
+    { CC2500_23_FSCAL3, 0xA9 },
+    { CC2500_24_FSCAL2, 0x0A },
+    { CC2500_25_FSCAL1, 0x00 },
+    { CC2500_26_FSCAL0, 0x11 },
+    { CC2500_29_FSTEST, 0x59 },
+    { CC2500_2C_TEST2, 0x88 },
+    { CC2500_2D_TEST1, 0x31 },
+    { CC2500_2E_TEST0, 0x0B },
+    { CC2500_3E_PATABLE, 0xFF }
+};
+
 static void initialise()
 {
     cc2500Reset();
 
-    cc2500WriteReg(CC2500_02_IOCFG0, 0x01);
-    cc2500WriteReg(CC2500_03_FIFOTHR, 0x07);
-    cc2500WriteReg(CC2500_06_PKTLEN, REDPINE_PACKET_SIZE);
-    cc2500WriteReg(CC2500_07_PKTCTRL1, 0x0C);
-    cc2500WriteReg(CC2500_08_PKTCTRL0, 0x05);
-    cc2500WriteReg(CC2500_09_ADDR, 0x00);
+    cc2500ApplyRegisterConfig(cc2500RedPineBaseConfig, sizeof(cc2500RedPineBaseConfig));
 
     if (isRedpineFast()) {
-        cc2500WriteReg(CC2500_0B_FSCTRL1, 0x0A);
-        cc2500WriteReg(CC2500_0C_FSCTRL0, 0x00);
-        cc2500WriteReg(CC2500_0D_FREQ2, 0x5D);
-        cc2500WriteReg(CC2500_0E_FREQ1, 0x93);
-        cc2500WriteReg(CC2500_0F_FREQ0, 0xB1);
-        cc2500WriteReg(CC2500_10_MDMCFG4, 0x2D);
-        cc2500WriteReg(CC2500_11_MDMCFG3, 0x3B);
-        cc2500WriteReg(CC2500_12_MDMCFG2, 0x73);
-        cc2500WriteReg(CC2500_13_MDMCFG1, 0x23);
-        cc2500WriteReg(CC2500_14_MDMCFG0, 0x56);
-        cc2500WriteReg(CC2500_15_DEVIATN, 0x00);
-        cc2500WriteReg(CC2500_17_MCSM1, 0x0C);
-        cc2500WriteReg(CC2500_18_MCSM0, 0x08);
-        cc2500WriteReg(CC2500_19_FOCCFG, 0x1D);
-        cc2500WriteReg(CC2500_1A_BSCFG, 0x1C);
-        cc2500WriteReg(CC2500_1B_AGCCTRL2, 0xC7);
-        cc2500WriteReg(CC2500_1C_AGCCTRL1, 0x00);
-        cc2500WriteReg(CC2500_1D_AGCCTRL0, 0xB0);
-        cc2500WriteReg(CC2500_21_FREND1, 0xB6);
-        cc2500WriteReg(CC2500_22_FREND0, 0x10);
-        cc2500WriteReg(CC2500_23_FSCAL3, 0xEA);
-        cc2500WriteReg(CC2500_24_FSCAL2, 0x0A);
-        cc2500WriteReg(CC2500_25_FSCAL1, 0x00);
-        cc2500WriteReg(CC2500_26_FSCAL0, 0x11);
-        cc2500WriteReg(CC2500_29_FSTEST, 0x59);
-        cc2500WriteReg(CC2500_2C_TEST2, 0x88);
-        cc2500WriteReg(CC2500_2D_TEST1, 0x31);
-        cc2500WriteReg(CC2500_2E_TEST0, 0x0B);
-        cc2500WriteReg(CC2500_3E_PATABLE, 0xFF);
+        cc2500ApplyRegisterConfig(cc2500RedPineFastConfig, sizeof(cc2500RedPineFastConfig));
     } else {
-        cc2500WriteReg(CC2500_0B_FSCTRL1, 0x06);
-        cc2500WriteReg(CC2500_0C_FSCTRL0, 0x00);
-        cc2500WriteReg(CC2500_0D_FREQ2, 0x5D);
-        cc2500WriteReg(CC2500_0E_FREQ1, 0x93);
-        cc2500WriteReg(CC2500_0F_FREQ0, 0xB1);
-        cc2500WriteReg(CC2500_10_MDMCFG4, 0x78);
-        cc2500WriteReg(CC2500_11_MDMCFG3, 0x93);
-        cc2500WriteReg(CC2500_12_MDMCFG2, 0x03);
-        cc2500WriteReg(CC2500_13_MDMCFG1, 0x22);
-        cc2500WriteReg(CC2500_14_MDMCFG0, 0xF8);
-        cc2500WriteReg(CC2500_15_DEVIATN, 0x44);
-        cc2500WriteReg(CC2500_17_MCSM1, 0x0C);
-        cc2500WriteReg(CC2500_18_MCSM0, 0x08);
-        cc2500WriteReg(CC2500_19_FOCCFG, 0x16);
-        cc2500WriteReg(CC2500_1A_BSCFG, 0x6C);
-        cc2500WriteReg(CC2500_1B_AGCCTRL2, 0x43);
-        cc2500WriteReg(CC2500_1C_AGCCTRL1, 0x40);
-        cc2500WriteReg(CC2500_1D_AGCCTRL0, 0x91);
-        cc2500WriteReg(CC2500_21_FREND1, 0x56);
-        cc2500WriteReg(CC2500_22_FREND0, 0x10);
-        cc2500WriteReg(CC2500_23_FSCAL3, 0xA9);
-        cc2500WriteReg(CC2500_24_FSCAL2, 0x0A);
-        cc2500WriteReg(CC2500_25_FSCAL1, 0x00);
-        cc2500WriteReg(CC2500_26_FSCAL0, 0x11);
-        cc2500WriteReg(CC2500_29_FSTEST, 0x59);
-        cc2500WriteReg(CC2500_2C_TEST2, 0x88);
-        cc2500WriteReg(CC2500_2D_TEST1, 0x31);
-        cc2500WriteReg(CC2500_2E_TEST0, 0x0B);
-        cc2500WriteReg(CC2500_3E_PATABLE, 0xFF);
+        cc2500ApplyRegisterConfig(cc2500RedPineConfig, sizeof(cc2500RedPineConfig));
     }
 
     for (unsigned c = 0; c < 0xFF; c++) {  // calibrate all channels

--- a/src/main/rx/cc2500_sfhss.c
+++ b/src/main/rx/cc2500_sfhss.c
@@ -81,47 +81,59 @@ static timeMs_t timeTunedMs;
 static int8_t bindOffset_max = 0;
 static int8_t bindOffset_min = 0;
 
+const cc2500RegisterConfigElement_t cc2500SfhssConfigPart1[] =
+{
+    { CC2500_02_IOCFG0,   0x01 },
+    { CC2500_03_FIFOTHR,  0x07 },
+    { CC2500_04_SYNC1,    0xD3 },
+    { CC2500_05_SYNC0,    0x91 },
+    { CC2500_06_PKTLEN,   0x0D },
+    { CC2500_07_PKTCTRL1, 0x04 },
+    { CC2500_08_PKTCTRL0, 0x0C },
+    { CC2500_09_ADDR,     0x29 },
+    { CC2500_0B_FSCTRL1,  0x06 }
+};
+
+const cc2500RegisterConfigElement_t cc2500SfhssConfigPart2[] =
+{
+    { CC2500_0D_FREQ2,    0x5C },
+    { CC2500_0E_FREQ1,    0x4E },
+    { CC2500_0F_FREQ0,    0xC4 },
+    { CC2500_10_MDMCFG4,  0x7C },
+    { CC2500_11_MDMCFG3,  0x43 },
+    { CC2500_12_MDMCFG2,  0x03 },
+    { CC2500_13_MDMCFG1,  0x23 },
+    { CC2500_14_MDMCFG0,  0x3B },
+    { CC2500_15_DEVIATN,  0x44 },
+    { CC2500_17_MCSM1,    0x0F },
+    { CC2500_18_MCSM0,    0x08 },
+    { CC2500_19_FOCCFG,   0x1D },
+    { CC2500_1A_BSCFG,    0x6C },
+    { CC2500_1B_AGCCTRL2, 0x03 },
+    { CC2500_1C_AGCCTRL1, 0x40 },
+    { CC2500_1D_AGCCTRL0, 0x91 },
+    { CC2500_21_FREND1,   0x56 },
+    { CC2500_22_FREND0,   0x10 },
+    { CC2500_23_FSCAL3,   0xA9 },
+    { CC2500_24_FSCAL2,   0x0A },
+    { CC2500_25_FSCAL1,   0x00 },
+    { CC2500_26_FSCAL0,   0x11 },
+    { CC2500_29_FSTEST,   0x59 },
+    { CC2500_2C_TEST2,    0x88 },
+    { CC2500_2D_TEST1,    0x31 },
+    { CC2500_2E_TEST0,    0x0B },
+    { CC2500_3E_PATABLE,  0xFF }
+};
+
 static void initialise()
 {
     cc2500Reset();
 
-    cc2500WriteReg(CC2500_02_IOCFG0,   0x01);
-    cc2500WriteReg(CC2500_03_FIFOTHR,  0x07);
-    cc2500WriteReg(CC2500_04_SYNC1,    0xD3);
-    cc2500WriteReg(CC2500_05_SYNC0,    0x91);
-    cc2500WriteReg(CC2500_06_PKTLEN,   0x0D);
-    cc2500WriteReg(CC2500_07_PKTCTRL1, 0x04);
-    cc2500WriteReg(CC2500_08_PKTCTRL0, 0x0C);
-    cc2500WriteReg(CC2500_09_ADDR,     0x29);
-    cc2500WriteReg(CC2500_0B_FSCTRL1,  0x06);
+    cc2500ApplyRegisterConfig(cc2500SfhssConfigPart1, sizeof(cc2500SfhssConfigPart1));
+
     cc2500WriteReg(CC2500_0C_FSCTRL0,  rxCc2500SpiConfig()->bindOffset);
-    cc2500WriteReg(CC2500_0D_FREQ2,    0x5C);
-    cc2500WriteReg(CC2500_0E_FREQ1,    0x4E);
-    cc2500WriteReg(CC2500_0F_FREQ0,    0xC4);
-    cc2500WriteReg(CC2500_10_MDMCFG4,  0x7C);
-    cc2500WriteReg(CC2500_11_MDMCFG3,  0x43);
-    cc2500WriteReg(CC2500_12_MDMCFG2,  0x03);
-    cc2500WriteReg(CC2500_13_MDMCFG1,  0x23);
-    cc2500WriteReg(CC2500_14_MDMCFG0,  0x3B);
-    cc2500WriteReg(CC2500_15_DEVIATN,  0x44);
-    cc2500WriteReg(CC2500_17_MCSM1,    0x0F);
-    cc2500WriteReg(CC2500_18_MCSM0,    0x08);
-    cc2500WriteReg(CC2500_19_FOCCFG,   0x1D);
-    cc2500WriteReg(CC2500_1A_BSCFG,    0x6C);
-    cc2500WriteReg(CC2500_1B_AGCCTRL2, 0x03);
-    cc2500WriteReg(CC2500_1C_AGCCTRL1, 0x40);
-    cc2500WriteReg(CC2500_1D_AGCCTRL0, 0x91);
-    cc2500WriteReg(CC2500_21_FREND1,   0x56);
-    cc2500WriteReg(CC2500_22_FREND0,   0x10);
-    cc2500WriteReg(CC2500_23_FSCAL3,   0xA9);
-    cc2500WriteReg(CC2500_24_FSCAL2,   0x0A);
-    cc2500WriteReg(CC2500_25_FSCAL1,   0x00);
-    cc2500WriteReg(CC2500_26_FSCAL0,   0x11);
-    cc2500WriteReg(CC2500_29_FSTEST,   0x59);
-    cc2500WriteReg(CC2500_2C_TEST2,    0x88);
-    cc2500WriteReg(CC2500_2D_TEST1,    0x31);
-    cc2500WriteReg(CC2500_2E_TEST0,    0x0B);
-    cc2500WriteReg(CC2500_3E_PATABLE,  0xFF);
+
+    cc2500ApplyRegisterConfig(cc2500SfhssConfigPart2, sizeof(cc2500SfhssConfigPart2));
 
     for (unsigned c = 0; c < 30; c++) {
         //calibrate all channels


### PR DESCRIPTION
Store and process the register initializations in a `const` array and process iteratively instead of individual register write calls.

Saves 712 bytes for STM32F7X2 target.

Tested with spi FrSky-X