### PR TITLE
Set default gps provider to UBLOX

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -227,7 +227,7 @@ gpsData_t gpsData;
 PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
-    .provider = GPS_NMEA,
+    .provider = GPS_UBLOX,
     .sbasMode = SBAS_AUTO,
     .autoConfig = GPS_AUTOCONFIG_ON,
     .autoBaud = GPS_AUTOBAUD_OFF,


### PR DESCRIPTION
Most people is using UBLOX devices, so it makes more sense to default to its native protocol.