### PR TITLE
Absolute altitude before arming is now correct when using GPS and Baro

### DIFF
--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -146,7 +146,11 @@ void calculateEstimatedAltitude(timeUs_t currentTimeUs)
 
 
     if (haveGpsAlt && haveBaroAlt && positionConfig()->altSource == DEFAULT) {
-        estimatedAltitudeCm = gpsAlt * gpsTrust + baroAlt * (1 - gpsTrust);
+        if (ARMING_FLAG(ARMED)) {
+            estimatedAltitudeCm = gpsAlt * gpsTrust + baroAlt * (1 - gpsTrust);
+        } else {
+            estimatedAltitudeCm = gpsAlt; //absolute altitude is shown before arming, ignore baro
+        }
 #ifdef USE_VARIO
         // baro is a better source for vario, so ignore gpsVertSpeed
         estimatedVario = calculateEstimatedVario(baroAlt, dTime);


### PR DESCRIPTION
Previous behaviour:
Before arming, OSD was showing the relative altitude from the Baro, but as soon as the GPS was locked, its absolute altitude was mixed with the relative altitude from the Baro so a non-sense altitude number was shown (except when powering the quad at sea level).
Current behaviour:
Before arming, OSD will show the relative altitude from the Baro, then as soon as the GPS is locked, it will only show the absolute altitude from the GPS.
Unchanged:
After arming, the relative altitude to the home point is shown using Baro/GPS as before.