### PR TITLE
[ADC] Fix reversed STATIC_ASSERT logic

### DIFF
--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -39,7 +39,7 @@ PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);
 
 void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
-    STATIC_ASSERT(MAX_ADC_SUPPORTED <= ADC_DEV_TO_CFG(ADCDEV_COUNT) || MAX_ADC_SUPPORTED != 4, adc_count_mismatch);
+    STATIC_ASSERT((MAX_ADC_SUPPORTED == 4) && (MAX_ADC_SUPPORTED >= ADC_DEV_TO_CFG(ADCDEV_COUNT)), adc_count_mismatch);
 
     adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
     adcConfig->dmaopt[ADCDEV_1] = ADC1_DMA_OPT;

--- a/src/main/target/NAZE/initialisation.c
+++ b/src/main/target/NAZE/initialisation.c
@@ -38,12 +38,14 @@
 
 void targetBusInit(void)
 {
+#if 0
 #ifdef USE_SPI
     spiPinConfigure(spiPinConfig(0));
     sensorsPreInit();
     spiPreinit();
 #ifdef USE_SPI_DEVICE_2
     spiInit(SPIDEV_2);
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This `STATIC_ASSERT` in `src/pg/adc.c` fails unless `ADCDEV_COUNT` is not 3 or more..
https://github.com/betaflight/betaflight/blob/9c3d4603b739e4f301ea422ab43472fff2ce6da7/src/main/pg/adc.c#L40-L42

This assertion was introduced in #8774 by @hydra, but looks like it survived for all currently active MCU cases.