### PR TITLE
Added Azure build for pull requests.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,10 +65,13 @@ stages:
           $(Build.Repository.Name)
 
           ### Pull request branch:
-          $(Build.SourceBranchName) [link]($(Build.Repository.Uri)/tree/$(Build.SourceBranchName))
+          $(Build.SourceBranchName) ([link]($(Build.Repository.Uri)/tree/$(Build.SourceBranchName)))
 
           ### Author:
           $(Build.RequestedFor)
+
+          ### Latest changeset:
+          $(Build.SourceVersion) ([link]($(Build.Repository.Uri)/commit/$(Build.SourceVersion)))
 
           Build.SourceBranchName
           $(Build.SourceBranchName)
@@ -93,5 +96,5 @@ stages:
         githubReuseRelease: true
         githubReuseDraftOnly: false
         githubSkipDuplicatedAssets: false
-        githubEditRelease: false
+        githubEditRelease: true
         githubDeleteEmptyTag: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,97 @@
+# Builds the Betaflight firmware
+#
+# After building, artifacts are released to a seperate repository.
+#
+# Azure Pipelines requires the following extensions to be installed:
+# - GitHub Tool: https://marketplace.visualstudio.com/items?itemName=marcelo-formentao.github-tools
+#
+# You'll also need to setup the follwing pipeline variables: 
+#     "releaseNotes" - This is used to add the release notes in the windows job in the build stage so they can be published as part of the github release in the release stage
+#     "endpoint" - The name of the github endpoint link setup in AzDo - setup when linking AzDo and GitHub
+#     "owner" - The owner of the repository to release to e.g. betaflight
+#     "repoName" - The name of the repository to release to e.g. betaflight-configurator-nightly
+
+
+variables:
+  owner: betaflight
+  repoName: betaflight-pull-requests
+  releaseNotes: This is a build of a community provided pull request. It may be unstable and result in corrupted configurations or data loss. **Use only for testing.**
+
+name: $(Build.RequestedFor)_$(Build.SourceBranchName)_$(BuildID)
+
+trigger: none
+
+stages:
+- stage: Build
+  jobs:
+  - job: 'Linux'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+    - script: make arm_sdk_install
+      displayName: 'Install the build toolchain'
+    - script: make unified
+      displayName: 'Build the Unified Targets'
+    - script: mkdir release; cp obj/*.hex release/
+      displayName: 'Copy artefacts'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Linux release'
+      inputs: 
+        artifactName: betaflight
+        targetPath: '$(System.DefaultWorkingDirectory)/release/'
+
+- stage: Release
+  jobs:
+  - job: Release
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: 'current'
+        targetPath: '$(Pipeline.Workspace)'
+    - powershell: Write-Output ("##vso[task.setvariable variable=today;]$(Get-Date -Format yyyyMMdd)")
+    - task: GitHubReleasePublish@1
+      inputs:
+        githubEndpoint: '$(endpoint)'
+        manuallySetRepository: true
+        githubOwner: '$(owner)'
+        githubRepositoryName: '$(repoName)'
+        githubTag: $(today).$(Build.Repository.Name).$(Build.SourceBranchName)
+        githubReleaseTitle: '$(Build.Repository.Name): $(Build.SourceBranchName) ($(today))'
+        githubReleaseNotes: |+
+          $(releaseNotes)
+
+          ### Repository:
+          [$(Build.Repository.Name)]($(Build.Repository.Uri)/tree/$(Build.SourceBranchName))
+
+          ### Pull request branch:
+          $(Build.SourceBranchName)
+
+          ### Author:
+          $(Build.RequestedFor)
+
+          Build.SourceBranchName
+          $(Build.SourceBranchName)
+          Build.Repository.Name
+          $(Build.Repository.Name)
+          Build.Repository.ID
+          $(Build.Repository.ID)
+          Build.Repository.Uri
+          $(Build.Repository.Uri)
+          Build.RequestedFor
+          $(Build.RequestedFor)
+          Build.QueuedBy
+          $(Build.QueuedBy)
+
+          ### Changes:
+          $(Build.SourceVersionMessage)
+        githubReleaseDraft: false
+        githubReleasePrerelease: false
+        githubIgnoreAssets: false
+        githubReleaseAsset: |
+          $(Pipeline.Workspace)/betaflight/**
+        githubReuseRelease: true
+        githubReuseDraftOnly: false
+        githubSkipDuplicatedAssets: false
+        githubEditRelease: false
+        githubDeleteEmptyTag: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,10 +62,10 @@ stages:
           $(releaseNotes)
 
           ### Repository:
-          [$(Build.Repository.Name)]($(Build.Repository.Uri)/tree/$(Build.SourceBranchName))
+          $(Build.Repository.Name)
 
           ### Pull request branch:
-          $(Build.SourceBranchName)
+          $(Build.SourceBranchName) [link]($(Build.Repository.Uri)/tree/$(Build.SourceBranchName))
 
           ### Author:
           $(Build.RequestedFor)


### PR DESCRIPTION
Pull request build results (Unified Targets only) will be published into https://github.com/betaflight/betaflight-pull-requests/releases, ordered by day of the last push, then by fork name.