### PR TITLE
[ADC] Remove MAX_ADC_SUPPORTED and related assertion

### DIFF
--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -41,7 +41,8 @@ void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
     adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
     adcConfig->dmaopt[ADCDEV_1] = ADC1_DMA_OPT;
-#ifndef STM32F1
+// These conditionals need to match the ones used in 'src/main/drivers/adc.h'.
+#if defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
     adcConfig->dmaopt[ADCDEV_2] = ADC2_DMA_OPT;
     adcConfig->dmaopt[ADCDEV_3] = ADC3_DMA_OPT;
 #endif

--- a/src/main/pg/adc.c
+++ b/src/main/pg/adc.c
@@ -39,16 +39,17 @@ PG_REGISTER_WITH_RESET_FN(adcConfig_t, adcConfig, PG_ADC_CONFIG, 0);
 
 void pgResetFn_adcConfig(adcConfig_t *adcConfig)
 {
-    STATIC_ASSERT(MAX_ADC_SUPPORTED <= ADC_DEV_TO_CFG(ADCDEV_COUNT) || MAX_ADC_SUPPORTED != 4, adc_count_mismatch);
-
     adcConfig->device = ADC_DEV_TO_CFG(adcDeviceByInstance(ADC_INSTANCE));
     adcConfig->dmaopt[ADCDEV_1] = ADC1_DMA_OPT;
 #ifndef STM32F1
     adcConfig->dmaopt[ADCDEV_2] = ADC2_DMA_OPT;
     adcConfig->dmaopt[ADCDEV_3] = ADC3_DMA_OPT;
 #endif
-#ifdef STM32F3
+#if defined(STM32F3) || defined(STM32G4)
     adcConfig->dmaopt[ADCDEV_4] = ADC4_DMA_OPT;
+#endif
+#if defined(STM32G4)
+    adcConfig->dmaopt[ADCDEV_5] = ADC5_DMA_OPT;
 #endif
 
 #ifdef VBAT_ADC_PIN

--- a/src/main/pg/adc.h
+++ b/src/main/pg/adc.h
@@ -28,8 +28,6 @@
 #include "drivers/io_types.h"
 #include "drivers/dma_reqmap.h"
 
-#define MAX_ADC_SUPPORTED 4
-
 typedef struct adcChannelConfig_t {
     bool enabled;
     ioTag_t ioTag;
@@ -46,7 +44,7 @@ typedef struct adcConfig_s {
     uint16_t tempSensorCalibration1;
     uint16_t tempSensorCalibration2;
 
-    int8_t dmaopt[MAX_ADC_SUPPORTED]; // One per ADCDEV_x
+    int8_t dmaopt[ADCDEV_COUNT]; // One per ADCDEV_x
 } adcConfig_t;
 
 PG_DECLARE(adcConfig_t, adcConfig);


### PR DESCRIPTION
Supecedes #9621

Seems like `ADC_MAX_SUPPORTED` is not serving any purposes.