### PR TITLE
Add osd element showing percentage of mah used

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1344,6 +1344,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_RC_CHANNELS]) },
     { "osd_camera_frame_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CAMERA_FRAME]) },
     { "osd_efficiency_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_EFFICIENCY]) },
+    { "osd_mah_percent_pos",    VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_MAH_PERCENT]) },
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -144,6 +144,7 @@ typedef enum {
     OSD_RC_CHANNELS,
     OSD_CAMERA_FRAME,
     OSD_EFFICIENCY,
+    OSD_MAH_PERCENT,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1041,6 +1041,13 @@ static void osdElementMainBatteryVoltage(osdElementParms_t *element)
     }
 }
 
+static void osdElementMahPercent(osdElementParms_t *element)
+{
+    const uint16_t mAhUsedPercent = ceilf(getMAhDrawn() / (batteryConfig()->batteryCapacity / 100.0f));
+
+    tfp_sprintf(element->buff, "%3d%%", mAhUsedPercent);
+}
+
 static void osdElementMotorDiagnostics(osdElementParms_t *element)
 {
     int i = 0;
@@ -1568,6 +1575,7 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_PITCH_ANGLE,
     OSD_ROLL_ANGLE,
     OSD_MAIN_BATT_USAGE,
+    OSD_MAH_PERCENT,
     OSD_DISARMED,
     OSD_NUMERICAL_HEADING,
 #ifdef USE_VARIO
@@ -1721,6 +1729,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #ifdef USE_GPS
     [OSD_EFFICIENCY]              = osdElementEfficiency,
 #endif
+    [OSD_MAH_PERCENT]             = osdElementMahPercent,
 };
 
 // Define the mapping between the OSD element id and the function to draw its background (static part)


### PR DESCRIPTION
Implements #9496 to show the percentage of mah used, based on the configured batteryCapacity and the mah drawn.

It's intentionally not constrained to 100% to give an indication of how much you're over your usual capacity.

I added it as "%mah" to make it as clear as possible, could just as well be "96%" if people prefer that. I thought it would conflict with throttle percentage but that seems to have its own symbol.

![vlcsnap-2020-03-24-19h43m07s004_3](https://user-images.githubusercontent.com/509294/77465382-cdd05e00-6e08-11ea-8aa2-5a55d623a61a.png)