### PR TITLE
Change pidloop constraint when dshot bidir is enabled

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -657,6 +657,9 @@ void validateAndFixGyroConfig(void)
             }
         } else {
             const float pidLooptime = samplingTime * pidConfig()->pid_process_denom;
+            if (motorConfig()->dev.useDshotTelemetry) {
+                motorUpdateRestriction *= 2;
+            }
             if (pidLooptime < motorUpdateRestriction) {
                 uint8_t minPidProcessDenom = motorUpdateRestriction / samplingTime;
                 if (motorUpdateRestriction / samplingTime > minPidProcessDenom) {


### PR DESCRIPTION
Current code dosn't take in account that with bidirectional dshot enabled escs can handle half of pidloop time.

dshot **without** bidirectional enabled:
dshot150 -> 4k max pidloop
dshot300 -> 8k max pidlopp
dshot600 -> 16k max pidloop

dshot **with** bidirectional enabled:
dshot150 -> 2k max pidloop
dshot300 -> 4k max pidloop
dshot600 -> 8k max pidloop
