### PR TITLE
Fix division by 0 risk in mixer vbat sag compensation

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -366,7 +366,7 @@ void mixerInitProfile(void)
         //TODO: Make this voltage user configurable
         vbatFull = CELL_VOLTAGE_FULL_CV;
         vbatRangeToCompensate = vbatFull - batteryConfig()->vbatwarningcellvoltage;
-        if (vbatRangeToCompensate >= 0) {
+        if (vbatRangeToCompensate > 0) {
             vbatSagCompensationFactor = ((float)currentPidProfile->vbat_sag_compensation) / 100.0f;
         }
     }


### PR DESCRIPTION
Fix division by zero if `batteryConfig()->vbatwarningcellvoltage` was set to 420 (4.2v).

In:
```
        vbatRangeToCompensate = vbatFull - batteryConfig()->vbatwarningcellvoltage;
        if (vbatRangeToCompensate >= 0) {
            vbatSagCompensationFactor = ((float)currentPidProfile->vbat_sag_compensation) / 100.0f;
        }
```
`vbatFull` is hardcoded to 420. If `batteryConfig()->vbatwarningcellvoltage` is also set to 420 (4.2v) then `vbatRangeToCompensate` will be 0. The test `vbatRangeToCompensate >= 0` will be true and `vbatSagCompensationFactor` will be initialized to a non-zero value.

Later since `vbatSagCompensationFactor` is > 0, the following will execute:
```
        if (vbatSagCompensationFactor > 0.0f) {
            const uint16_t currentCellVoltage = getBatterySagCellVoltage();
            // batteryGoodness = 1 when voltage is above vbatFull, and 0 when voltage is below vbatLow
            float batteryGoodness = 1.0f - constrainf((vbatFull - currentCellVoltage) / vbatRangeToCompensate, 0.0f, 1.0f);
```
This last line will cause a division by zero since `vbatRangeToCompensate == 0`.

The fix is to change the comparison during initialization from:
```
        if (vbatRangeToCompensate >= 0) {
```
to:
```
        if (vbatRangeToCompensate > 0) {
```