### PR TITLE
Fix division by zero in mixer crashflip

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -699,7 +699,7 @@ static void applyFlipOverAfterCrashModeToMotors(void)
             signYaw = 0;
         }
 
-        const float cosPhi = (stickDeflectionPitchAbs + stickDeflectionRollAbs) / (sqrtf(2.0f) * stickDeflectionLength);
+        const float cosPhi = (stickDeflectionLength > 0) ? (stickDeflectionPitchAbs + stickDeflectionRollAbs) / (sqrtf(2.0f) * stickDeflectionLength) : 0;
         const float cosThreshold = sqrtf(3.0f)/2.0f; // cos(PI/6.0f)
 
         if (cosPhi < cosThreshold) {


### PR DESCRIPTION
Divide by zero whenever the sticks were centered. When sticks centered, `stickDeflectionLength` would be calculated to zero leading to a div by 0. Since the underlying calculation to determine the `stickDeflectionLength` is all floats, the value wouldn't always sit at zero but rather jump to/from 0 and small values due to jitter in the RC channels. But I confirmed that it does in fact become `== 0` quite frequently.