### PR TITLE
Fixed inconsistent CR/LF

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1511,10 +1511,10 @@ static void cliSerialPassthrough(const char *cmdName, char *cmdline)
             // leave the mode unchanged. serialPassthrough() handles one-way ports.
             // Set the baud rate if specified
             if (ports[i].baud) {
-                cliPrintf("Port%d is already open, setting baud = %d.\n\r", portIndex, ports[i].baud);
+                cliPrintf("Port%d is already open, setting baud = %d.\r\n", portIndex, ports[i].baud);
                 serialSetBaudRate(*port, ports[i].baud);
             } else {
-                cliPrintf("Port%d is already open, baud = %d.\n\r", portIndex, (*port)->baudRate);
+                cliPrintf("Port%d is already open, baud = %d.\r\n", portIndex, (*port)->baudRate);
             }
 
             if (ports[i].mode && (*port)->mode != ports[i].mode) {
@@ -6545,7 +6545,7 @@ static void processCharacterInteractive(const char c)
         }
         if (!bufferIndex || pstart != pend) {
             /* Print list of ambiguous matches */
-            cliPrint("\r\033[K");
+            cliPrint("\r\n\033[K");
             for (cmd = pstart; cmd <= pend; cmd++) {
                 cliPrint(cmd->name);
                 cliWrite('\t');

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1511,10 +1511,10 @@ static void cliSerialPassthrough(const char *cmdName, char *cmdline)
             // leave the mode unchanged. serialPassthrough() handles one-way ports.
             // Set the baud rate if specified
             if (ports[i].baud) {
-                cliPrintf("Port%d is already open, setting baud = %d.\r\n", portIndex, ports[i].baud);
+                cliPrintf("Port%d is already open, setting baud = %d.\n\r", portIndex, ports[i].baud);
                 serialSetBaudRate(*port, ports[i].baud);
             } else {
-                cliPrintf("Port%d is already open, baud = %d.\r\n", portIndex, (*port)->baudRate);
+                cliPrintf("Port%d is already open, baud = %d.\n\r", portIndex, (*port)->baudRate);
             }
 
             if (ports[i].mode && (*port)->mode != ports[i].mode) {
@@ -6545,7 +6545,7 @@ static void processCharacterInteractive(const char c)
         }
         if (!bufferIndex || pstart != pend) {
             /* Print list of ambiguous matches */
-            cliPrint("\r\n\033[K");
+            cliPrint("\r\033[K");
             for (cmd = pstart; cmd <= pend; cmd++) {
                 cliPrint(cmd->name);
                 cliWrite('\t');


### PR DESCRIPTION
- 2 lines used "\n\r" instead of "\r\n". Consistent use of "\r\n" will allow the Configurator CLI code to be simplified.

- This PR is in preparation for some changes and enhancements in the Configurator CLI that I am currently working on.

- The Configurator CLI code currently has code that is interned to treat carriage returns and line feeds differently, depending on the CR/LF semantics of the operating system. This is actually irrelevant because the firmware CLI code is entirely agnostic about those semantics, and also treats CR and LF identically when processing input characters.

- This change makes it easier for the Configurator CLI to process serial reads in chunks, instead character by character, which dramatically reduces CPU usage. On the very old laptop I am currently using, a `dump all` can take up to 20 - 30 seconds, but is near instantaneous when processing serials reads in chunks.