### PR TITLE
Increase D_Min gain to improve D behaviour on most quads

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -206,7 +206,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .integrated_yaw_relax = 200,
         .thrustLinearization = 0,
         .d_min = { 20, 22, 0 },      // roll, pitch, yaw
-        .d_min_gain = 27,
+        .d_min_gain = 37,
         .d_min_advance = 20,
         .motor_output_limit = 100,
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,


### PR DESCRIPTION
D_Min has been contentious, with a number of people finding that the boost strength isn't enough to have D stay high long enough to adequately dampen flips and rolls.

Increasing the D_Min gain has been widely tested now.  

In the vast majority of logs, it works better, closer to how it was intended, with a value around 35-40.

This PR proposes changing the default gain to 37, up from 27.