### PR TITLE
increase dMin values 20,22 to 23,25

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -205,7 +205,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .use_integrated_yaw = false,
         .integrated_yaw_relax = 200,
         .thrustLinearization = 0,
-        .d_min = { 20, 22, 0 },      // roll, pitch, yaw
+        .d_min = { 23, 25, 0 },      // roll, pitch, yaw
         .d_min_gain = 37,
         .d_min_advance = 20,
         .motor_output_limit = 100,


### PR DESCRIPTION
While considering the Dmin Configurator fix, https://github.com/betaflight/betaflight-configurator/pull/1949, maybe now would be good time to update the Dmin values themselves.

There is a strong general consensus that the Dmin default values of 20 on roll and 22 on pitch are a bit on the low side, especially for the typical freestyle user.  

Bringing these numbers up up a little, in association with the higher Dmin_gain PR, should improve propwash handling and simple straight ahead stability.

I think that 4.1 perhaps was a bit light on D and these changes should redress that imbalance in the defaults.