### PR TITLE
Fixed unnecessarily long startup time due to gyro detection.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4644,6 +4644,19 @@ static void cliStatus(const char *cmdName, char *cmdline)
     cliPrintLinef("Config size: %d, Max available config: %d", getEEPROMConfigSize(), getEEPROMStorageSize());
 
     // Sensors
+    cliPrint("Gyros detected:");
+    bool found = false;
+    for (unsigned pos = 0; pos < 7; pos++) {
+        if (gyroConfig()->gyrosDetected & BIT(pos)) {
+            if (found) {
+                cliPrint(",");
+            } else {
+                found = true;
+            }
+            cliPrintf(" gyro %d", pos + 1);
+        }
+    }
+    cliPrintLinefeed();
 
 #if defined(USE_SENSOR_NAMES)
     const uint32_t detectedSensorsMask = sensorsMask();

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -49,12 +49,12 @@ typedef union gyroLowpassFilter_u {
 } gyroLowpassFilter_t;
 
 typedef enum gyroDetectionFlags_e {
-    NO_GYROS_DETECTED = 0,
-    DETECTED_GYRO_1 = (1 << 0),
+    GYRO_NONE_MASK = 0,
+    GYRO_1_MASK = BIT(0),
 #if defined(USE_MULTI_GYRO)
-    DETECTED_GYRO_2 = (1 << 1),
-    DETECTED_BOTH_GYROS = (DETECTED_GYRO_1 | DETECTED_GYRO_2),
-    DETECTED_DUAL_GYROS = (1 << 7), // All gyros are of the same hardware type
+    GYRO_2_MASK = BIT(1),
+    GYRO_ALL_MASK = (GYRO_1_MASK | GYRO_2_MASK),
+    GYRO_IDENTICAL_MASK = BIT(7), // All gyros are of the same hardware type
 #endif
 } gyroDetectionFlags_t;
 
@@ -195,6 +195,8 @@ typedef struct gyroConfig_s {
     uint16_t dyn_notch_min_hz;
 
     uint8_t  gyro_filter_debug_axis;
+
+    uint8_t gyrosDetected; // What gyros should detection be attempted for on startup. Automatically set on first startup.
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -52,6 +52,7 @@ extern "C" {
     #include "rx/rx.h"
     #include "scheduler/scheduler.h"
     #include "sensors/battery.h"
+    #include "sensors/gyro.h"
 
     void cliSet(const char *cmdName, char *cmdline);
     int cliGetSettingIndex(char *name, uint8_t length);
@@ -85,6 +86,7 @@ extern "C" {
     PG_REGISTER_ARRAY(rxChannelRangeConfig_t, NON_AUX_CHANNEL_COUNT, rxChannelRangeConfigs, PG_RX_CHANNEL_RANGE_CONFIG, 0);
     PG_REGISTER_ARRAY(rxFailsafeChannelConfig_t, MAX_SUPPORTED_RC_CHANNEL_COUNT, rxFailsafeChannelConfigs, PG_RX_FAILSAFE_CHANNEL_CONFIG, 0);
     PG_REGISTER(pidConfig_t, pidConfig, PG_PID_CONFIG, 0);
+    PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
 
     PG_REGISTER_WITH_RESET_FN(int8_t, unitTestData, PG_RESERVED_FOR_TESTING_1, 0);
 }

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -162,4 +162,5 @@ timeDelta_t getGyroUpdateRate(void) {return gyro.targetLooptime;}
 void sensorsSet(uint32_t) {}
 void schedulerResetTaskStatistics(taskId_e) {}
 int getArmingDisableFlags(void) {return 0;}
+void writeEEPROM(void) {}
 }


### PR DESCRIPTION
On targets that come in single- and dual gyro configurations, startup can take a very long time for boards sold with a single gyro due to the time taken by the attempted detection of the second gyro.

This fix introduces a configuration setting to store a flagset of the gyros that are to be detected on startup. When 0 (the default), detection for all gyros will be attempted. During the first startup, flag set for the gyros that were actually found will be stored in the configuration setting, and from there on detection will be attempted for only these gyros, reducing the amount of time it takes to complete detection:

Before:
- all: ~13.4 s
- with gyro 2 disabled: ~9.6 s

After:
- after reset to defaults: ~13.7 s
- every subsequent time: ~7.8 s


CLI:

```
# status
MCU F745 Clock=216MHz, Vref=3.29V, Core temp=53degC
Stack size: 2048, Stack address: 0x20010000
Config size: 3986, Max available config: 32768
Gyros detected: 1, 2
GYRO=ICM20608G, ACC=ICM20608G, BARO=BMP280
AG3XF7 with single MPU6000, cold start until USB ready:
[...]
```
