### PR TITLE
Only enable PINIOBOX task when needed

### DIFF
--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -24,21 +24,25 @@
 
 #include "platform.h"
 
-#include "rc_modes.h"
-
 #include "common/bitarray.h"
 #include "common/maths.h"
+
 #include "drivers/time.h"
 
+#include "config/config.h"
 #include "config/feature.h"
+
+#include "fc/rc_controls.h"
+
+#include "io/piniobox.h"
+
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/rx.h"
 
-#include "config/config.h"
-#include "fc/rc_controls.h"
-
 #include "rx/rx.h"
+
+#include "rc_modes.h"
 
 #define STICKY_MODE_BOOT_DELAY_US 5e6
 
@@ -249,4 +253,7 @@ void analyzeModeActivationConditions(void)
             activeMacArray[activeMacCount++] = i;
         }
     }
+#ifdef USE_PINIOBOX
+    pinioBoxTaskControl();
+#endif
 }

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -336,7 +336,7 @@ void tasksInit(void)
 #endif
 
 #ifdef USE_PINIOBOX
-    setTaskEnabled(TASK_PINIOBOX, true);
+    pinioBoxTaskControl();
 #endif
 
 #ifdef USE_CMS

--- a/src/main/io/piniobox.c
+++ b/src/main/io/piniobox.c
@@ -26,13 +26,15 @@
 
 #include "build/debug.h"
 
-#include "common/utils.h"
 #include "common/time.h"
+#include "common/utils.h"
 
 #include "msp/msp_box.h"
 
 #include "pg/pinio.h"
 #include "pg/piniobox.h"
+
+#include "scheduler/scheduler.h"
 
 #include "piniobox.h"
 
@@ -64,4 +66,15 @@ void pinioBoxUpdate(timeUs_t currentTimeUs)
     }
 }
 
+void pinioBoxTaskControl(void)
+{
+    bool enableTask = false;
+    for (int i = 0; i < PINIO_COUNT; i++) {
+        if (pinioBoxRuntimeConfig.boxId[i] != BOXID_NONE && isModeActivationConditionPresent(pinioBoxRuntimeConfig.boxId[i])) {
+            enableTask = true;
+            break;
+        }
+    }
+    setTaskEnabled(TASK_PINIOBOX, enableTask);
+}
 #endif

--- a/src/main/io/piniobox.h
+++ b/src/main/io/piniobox.h
@@ -22,3 +22,4 @@
 
 void pinioBoxInit(const pinioBoxConfig_t *pinioBoxConfig);
 void pinioBoxUpdate(timeUs_t currentTimeUs);
+void pinioBoxTaskControl(void);

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1107,4 +1107,5 @@ extern "C" {
     void updateRcRefreshRate(timeUs_t) {};
     uint16_t getAverageSystemLoadPercent(void) { return 0; }
     bool isMotorProtocolEnabled(void) { return true; }
+    void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -598,4 +598,5 @@ bool areSticksActive(uint8_t stickPercentLimit) {
 void beeperConfirmationBeeps(uint8_t beepCount) { UNUSED(beepCount); }
 
 bool crashRecoveryModeActive(void) { return false; }
+void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -249,4 +249,5 @@ bool accGetAccumulationAverage(float *) { return false; }
 void mixerSetThrottleAngleCorrection(int) {};
 bool gpsRescueIsRunning(void) { return false; }
 bool isFixedWing(void) { return false; }
+void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -396,5 +396,5 @@ bool isFlipOverAfterCrashActive(void) { return false; }
 void ws2811LedStripEnable(void) { }
 
 void setUsedLedCount(unsigned) { };
-
+void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -456,6 +456,7 @@ extern "C" {
     void resetPPMDataReceivedState(void){ }
     void failsafeOnValidDataReceived(void) { }
     void failsafeOnValidDataFailed(void) { }
+    void pinioBoxTaskControl(void) { }
 
     void rxPwmInit(rxRuntimeState_t *rxRuntimeState, rcReadRawDataFnPtr *callback)
     {

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -655,4 +655,5 @@ void resetTryingToArm(void) {}
 void setLedProfile(uint8_t profile) { UNUSED(profile); }
 uint8_t getLedProfile(void) { return 0; }
 void compassStartCalibration(void) {}
+void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/rcdevice_unittest.cc
+++ b/src/test/unit/rcdevice_unittest.cc
@@ -994,4 +994,5 @@ extern "C" {
     bool cmsInMenu;
     uint32_t resumeRefreshAt = 0;
     int getArmingDisableFlags(void) {return 0;}
+    void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -243,4 +243,6 @@ float pt1FilterApply(pt1Filter_t *filter, float input)
     return 0.0;
 }
 
+void pinioBoxTaskControl(void) {}
+
 }

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -254,4 +254,6 @@ extern "C" {
         UNUSED(input);
         return 0.0;
     }
+
+    void pinioBoxTaskControl(void) {}
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -192,4 +192,5 @@ extern "C" {
     void updateRcRefreshRate(timeUs_t) {};
     uint16_t getAverageSystemLoadPercent(void) { return 0; }
     bool isMotorProtocolEnabled(void) { return false; }
+    void pinioBoxTaskControl(void) {}
 }


### PR DESCRIPTION
Previously the task was always enabled and there's no reason for it to be running if there are no boxID associations.

Saves a few cycles by not running. But has a bigger effect on the scheduler by minimizing the number of active tasks when possible.
