### PR TITLE
Show configuration status in CLI.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -303,6 +303,8 @@ static const char *mcuTypeNames[] = {
     "H743 (Rev.V)",
 };
 
+static const char *configurationStates[] = { "UNCONFIGURED", "CUSTOM DEFAULTS", "CONFIGURED" };
+
 typedef enum dumpFlags_e {
     DUMP_MASTER = (1 << 0),
     DUMP_PROFILE = (1 << 1),
@@ -4702,7 +4704,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
 #endif
     cliPrintLinefeed();
 
-    cliPrintLinef("Config size: %d, Max available config: %d", getEEPROMConfigSize(), getEEPROMStorageSize());
+    cliPrintLinef("Configuration: %s, size: %d, max available: %d", configurationStates[systemConfigMutable()->configurationState], getEEPROMConfigSize(), getEEPROMStorageSize());
 
     // Sensors
     cliPrint("Gyros detected:");


### PR DESCRIPTION
```
# status
MCU F40X Clock=168MHz (PLLP-HSE), Vref=3.32V, Core temp=46degC
Stack size: 2048, Stack address: 0x1000fff0
Configuration: CONFIGURED, size: 3960, max available: 16384
Gyros detected: gyro 1
[...]
```