### PR TITLE
Added missing linefeed after version in CLI.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4850,13 +4850,12 @@ static void cliTasks(const char *cmdName, char *cmdline)
 }
 #endif
 
-static void cliVersion(const char *cmdName, char *cmdline)
+static void printVersion(const char *cmdName, bool printBoardInfo)
 {
-    UNUSED(cmdline);
 #if !(defined(USE_CUSTOM_DEFAULTS) && defined(USE_UNIFIED_TARGET))
     UNUSED(cmdName);
+    UNUSED(printBoardInfo);
 #endif
-
 
     cliPrintf("# %s / %s (%s) %s %s / %s (%s) MSP API: %s",
         FC_FIRMWARE_NAME,
@@ -4897,10 +4896,17 @@ static void cliVersion(const char *cmdName, char *cmdline)
 #endif // USE_CUSTOM_DEFAULTS
 
 #if defined(USE_UNIFIED_TARGET) && defined(USE_BOARD_INFO)
-    if (strlen(getManufacturerId()) && strlen(getBoardName())) {
-        cliPrintf("# board: manufacturer_id: %s, board_name: %s", getManufacturerId(), getBoardName());
+    if (printBoardInfo && strlen(getManufacturerId()) && strlen(getBoardName())) {
+        cliPrintLinef("# board: manufacturer_id: %s, board_name: %s", getManufacturerId(), getBoardName());
     }
 #endif
+}
+
+static void cliVersion(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdline);
+
+    printVersion(cmdName, true);
 }
 
 #ifdef USE_RC_SMOOTHING_FILTER
@@ -6107,7 +6113,7 @@ static void printConfig(const char *cmdName, char *cmdline, bool doDiff)
 #endif
     if ((dumpMask & DUMP_MASTER) || (dumpMask & DUMP_ALL)) {
         cliPrintHashLine("version");
-        cliVersion(cmdName, "");
+        printVersion(cmdName, false);
 
         if (!(dumpMask & BARE)) {
 #ifdef USE_CLI_BATCH


### PR DESCRIPTION
Missed in #9653.

```
# diff

# version
# Betaflight / STM32F405 (S405) 4.2.0 Apr 12 2020 / 01:17:31 (norevision) MSP API: 1.43
# config: manufacturer_id: AIRB, board_name: OMNIBUSF4, version: 3a35e73b, date: 2019-09-30T05:46:12Z
# board: manufacturer_id: AIRB, board_name: OMNIBUSF4

# start the command batch
batch start
[...]
```
