### PR TITLE
Remove non-functional rangefinder support from unified targets

### DIFF
--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -211,9 +211,9 @@
 #define USE_TRANSPONDER
 
 //TODO: Make this actually work by making the pins configurable
-#define USE_RANGEFINDER
-#define USE_RANGEFINDER_HCSR04
-#define USE_RANGEFINDER_TF
+//#define USE_RANGEFINDER
+//#define USE_RANGEFINDER_HCSR04
+//#define USE_RANGEFINDER_TF
 
 #define USE_SPI
 #define SPI_FULL_RECONFIGURABILITY


### PR DESCRIPTION
Saves 1248 bytes on STM32F7X2
