### PR TITLE
Revise pid_process_denom default logic - 2nd try

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -96,8 +96,12 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);
 
 #if defined(STM32F1)
 #define PID_PROCESS_DENOM_DEFAULT       8
-#else
+#elif defined(STM32F3)
 #define PID_PROCESS_DENOM_DEFAULT       4
+#elif defined(STM32F411xE)
+#define PID_PROCESS_DENOM_DEFAULT       2
+#else
+#define PID_PROCESS_DENOM_DEFAULT       1
 #endif
 
 #if defined(USE_D_MIN)


### PR DESCRIPTION
Now with the motor protocol defaulting to DISABLED we can reimplement this.

Remove dependence on gyro type and base on MCU type.

The previous logic was based on expecting an 8K sampling gyro and would set an inappropriate loop time for other gyro types.

Change the logic to be based on the capabilities of the MCU which is more appropriate. We set the pid_process_denom default to the maximum recommended value for a given MCU.

The `pid_process_denom` will be defaulted as follows (assuming a 8khz gyro) based on MCU type:
```
MCU	pid_process_denom
F1:	8 (1khz)
F3:	4 (2khz)
F411:	2 (4khz)
Others:	1 (8khz)
```

F405/F446/F7/H7 can all run 8/8 with no problems. If using RPM Filtering the user may have to adjust to 8/4 for F405/F446, but that's no different then before. And actually it will be fine in most cases on BF4.2.

Of course the final PID loop rate will be based on the native sample rate of the gyro. For for example a F446/BMI160 board would default to 3.2/3.2.
