### PR TITLE
Fix I2C2 SDA pin def for F446

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -86,12 +86,12 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
             I2CPINDEF(PF1,  GPIO_AF_I2C2),
         },
         .sdaPins = {
-            I2CPINDEF(PB11, GPIO_AF_I2C2),
-            I2CPINDEF(PF0,  GPIO_AF_I2C2),
-
 #if defined(STM32F446xx)
-            I2CPINDEF(PC12,  GPIO_AF_I2C2),
+            I2CPINDEF(PC12, GPIO_AF_I2C2),
+#else
+            I2CPINDEF(PB11, GPIO_AF_I2C2),
 #endif
+            I2CPINDEF(PF0,  GPIO_AF_I2C2),
 
 #if defined(STM32F40_41xxx) || defined (STM32F411xE)
             // STM32F401xx/STM32F410xx/STM32F411xE/STM32F412xG


### PR DESCRIPTION
This is a follow up PR to #9662 

It turned out that F446 does not provide PB11 for I2C2_SDA. In fact, PB11 pin itself is non-existent for most small packages, and this is probably why PC12 was assigned as I2C2_SDA. Hence, the conditional for I2C2_SDA selection is if-then-else as proposed in this PR.
