### PR TITLE
Make sure function declaration and definition are equal

### DIFF
--- a/src/main/flight/gyroanalyse.h
+++ b/src/main/flight/gyroanalyse.h
@@ -52,8 +52,8 @@ typedef struct gyroAnalyseState_s {
 
 STATIC_ASSERT(FFT_WINDOW_SIZE <= (uint8_t) -1, window_size_greater_than_underlying_type);
 
-void gyroDataAnalyseStateInit(gyroAnalyseState_t *gyroAnalyse, uint32_t targetLooptime);
-void gyroDataAnalysePush(gyroAnalyseState_t *gyroAnalyse, int axis, float sample);
-void gyroDataAnalyse(gyroAnalyseState_t *gyroAnalyse, biquadFilter_t *notchFilterDyn, biquadFilter_t *notchFilterDyn2);
+void gyroDataAnalyseStateInit(gyroAnalyseState_t *state, uint32_t targetLooptimeUs);
+void gyroDataAnalysePush(gyroAnalyseState_t *state, const int axis, const float sample);
+void gyroDataAnalyse(gyroAnalyseState_t *state, biquadFilter_t *notchFilterDyn, biquadFilter_t *notchFilterDyn2);
 uint16_t getMaxFFT(void);
 void resetMaxFFT(void);


### PR DESCRIPTION
Simple fix to make sure function declaration and definition of functions:
* gyroDataAnalyseStateInit
* gyroDataAnalysePush
* gyroDataAnalyse
are equal in gyroanalyse.h and gyroanalyse.c