### PR TITLE
Increase default Yaw P to 45

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -147,7 +147,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .pid = {
             [PID_ROLL] =  { 42, 85, 35, 90 },
             [PID_PITCH] = { 46, 90, 38, 95 },
-            [PID_YAW] =   { 30, 90, 0, 90 },
+            [PID_YAW] =   { 45, 90, 0, 90 },
             [PID_LEVEL] = { 50, 50, 75, 0 },
             [PID_MAG] =   { 40, 0, 0, 0 },
         },


### PR DESCRIPTION
Lots of people complained that yaw P was a bit too low by default in 4.1, and we had indeed dropped it from 70 to 30.

I have done a lot of testing and checking with a variety of users, and found that 45 works OK without obvious oscillation on most setups that would otherwise use default PIDs. Anything much higher tends to result in fine P oscillation, and noise, on yaw.  30 is a bit low perhaps for freestyle rigs.

There is a matching pull request in Configurator.