### PR TITLE
Enable expo on the D lowpass filter at 5

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -226,7 +226,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .ff_max_rate_limit = 100,
         .ff_smooth_factor = 37,
         .ff_boost = 15,
-        .dyn_lpf_curve_expo = 0,
+        .dyn_lpf_curve_expo = 5,
         .level_race_mode = false,
         .vbat_sag_compensation = 0,
     );


### PR DESCRIPTION
Most people who have tested @IllusionFpv's expo on the dynamic D lowpass filter have found it to improve propwash without adverse effects.

It achieves this reducing D lowpass delay more quickly on throttling up.

This allows us to retain, at idle, the strong lowpass filtering we currently have, but quickly reduce lowpass delay and improve propwash by mid throttle.

A value of 5-7 is OK I'm proposing 5 as a conservative start.

I know this is a new feature but it is really good .  It would be great if it could be made active by default, if possible, in 4.2.

See [PR 9475](https://github.com/betaflight/betaflight/pull/9475).