### PR TITLE
Fix dynamic idle safety issues

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -355,7 +355,11 @@ void initEscEndpoints(void)
 void mixerInitProfile(void)
 {
 #ifdef USE_DYN_IDLE
-    idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
+    if (motorConfig()->dev.useDshotTelemetry) {
+        idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
+    } else {
+        idleMinMotorRps = 0;
+    }
     idleMaxIncrease = currentPidProfile->idle_max_increase * 0.001f;
     idleP = currentPidProfile->idle_p * 0.0001f;
 #endif
@@ -620,9 +624,10 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
         }
     } else {
         throttle = rcCommand[THROTTLE] - PWM_RANGE_MIN + throttleAngleCorrection;
+        float appliedMotorOutputLow = motorOutputLow;
 #ifdef USE_DYN_IDLE
         if (idleMinMotorRps > 0.0f) {
-            motorOutputLow = DSHOT_MIN_THROTTLE;
+            appliedMotorOutputLow = DSHOT_MIN_THROTTLE;
             const float maxIncrease = isAirmodeActivated() ? idleMaxIncrease : 0.04f;
             const float minRps = rpmMinMotorFrequency();
             const float targetRpsChangeRate = (idleMinMotorRps - minRps) * currentPidProfile->idle_adjustment_speed;
@@ -636,7 +641,9 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             DEBUG_SET(DEBUG_DYN_IDLE, 1, targetRpsChangeRate);
             DEBUG_SET(DEBUG_DYN_IDLE, 2, error);
             DEBUG_SET(DEBUG_DYN_IDLE, 3, minRps);
-
+        } else {
+            motorRangeMinIncrease = 0;
+            oldMinRps = 0;
         }
 #endif
 
@@ -657,7 +664,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
 #endif
 
         currentThrottleInputRange = rcCommandThrottleRange;
-        motorRangeMin = motorOutputLow + motorRangeMinIncrease * (motorOutputHigh - motorOutputLow);
+        motorRangeMin = appliedMotorOutputLow + motorRangeMinIncrease * (motorOutputHigh - appliedMotorOutputLow);
         motorOutputMin = motorRangeMin;
         motorOutputRange = motorRangeMax - motorRangeMin;
         motorOutputMixSign = 1;


### PR DESCRIPTION
Fixes #9713 

Fixes a problem with dynamic idle not checking for bidirectional DSHOT being enabled. So the code would run but have no RPM data available leading to elevated motor idle.

Fixes a problem with dynamic idle not resetting accumulated static variables that continue to be used when dynamic idle is switched off via a PID profile change. Depending on the state of the variables this could cause excessive motor idle speed. In some cases enough to cause the quad to spontaneously take off on arming or be unable to descend in flight.

Fixes a problem with dynamic idle inappropriately modifying the static `motorOutputLow` that is set based on the chosen motor protocol. Downstream code that relies on this value to determine the actual motor output range was adversely affected.
