### PR TITLE
Zero the movingSum and buffer for laggedMovingAverage to fix ff_interpolate_sp switches

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -208,6 +208,8 @@ void laggedMovingAverageInit(laggedMovingAverage_t *filter, uint16_t windowSize,
     filter->movingWindowIndex = 0;
     filter->windowSize = windowSize;
     filter->buf = buf;
+    filter->movingSum = 0;
+    memset(filter->buf, 0, windowSize * sizeof(float));
     filter->primed = false;
 }
 


### PR DESCRIPTION
Fixes the other issue found in #9713 by resetting the movingSum and buffer in laggedMovingAverageInit to prevent persistent error from being introduced on re-initialization.

The lagged moving average for `ff_interpolate_sp` assumes that the same values are added and subtracted. When going back from e.g. `AVERAGED_4` to `AVERAGED_2` the last two values in the buffer would not be subtracted but still be present in the movingSum, resulting in a error that would only disappear when selecting `AVERAGED_4` again.

Only happens when switching pid profiles between profiles with averaging enabled with different sizes so it's not easy to run into, but I have seen motors being driven at 12% at idle because of this.