### PR TITLE
Correct gyro scaling factors

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -37,6 +37,9 @@
 #pragma GCC diagnostic warning "-Wpadded"
 #endif
 
+#define GYRO_SCALE_2000DPS (2000.0f / (1 << 15))   // 16.384 dps/lsb scalefactor for 2000dps sensors
+#define GYRO_SCALE_4000DPS (4000.0f / (1 << 15))   //  8.192 dps/lsb scalefactor for 4000dps sensors
+
 typedef enum {
     GYRO_NONE = 0,
     GYRO_DEFAULT,

--- a/src/main/drivers/accgyro/accgyro_fake.c
+++ b/src/main/drivers/accgyro/accgyro_fake.c
@@ -94,7 +94,7 @@ bool fakeGyroDetect(gyroDev_t *gyro)
     gyro->readFn = fakeGyroRead;
     gyro->temperatureFn = fakeGyroReadTemperature;
 #if defined(SIMULATOR_BUILD)
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 #else
     gyro->scale = 1.0f;
 #endif

--- a/src/main/drivers/accgyro/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu3050.c
@@ -105,8 +105,7 @@ bool mpu3050Detect(gyroDev_t *gyro)
     gyro->readFn = mpu3050GyroRead;
     gyro->temperatureFn = mpu3050ReadTemperature;
 
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6050.c
@@ -107,8 +107,7 @@ bool mpu6050GyroDetect(gyroDev_t *gyro)
     gyro->initFn = mpu6050GyroInit;
     gyro->readFn = mpuGyroRead;
 
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6500.c
@@ -104,8 +104,7 @@ bool mpu6500GyroDetect(gyroDev_t *gyro)
     gyro->initFn = mpu6500GyroInit;
     gyro->readFn = mpuGyroRead;
 
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -350,7 +350,7 @@ bool bmi160SpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = bmi160SpiGyroInit;
     gyro->readFn = bmi160GyroRead;
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -440,7 +440,7 @@ bool bmi270SpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = bmi270SpiGyroInit;
     gyro->readFn = bmi270GyroRead;
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -164,9 +164,9 @@ bool icm20649SpiGyroDetect(gyroDev_t *gyro)
     gyro->initFn = icm20649GyroInit;
     gyro->readFn = icm20649GyroReadSPI;
 
-    // 16.4 dps/lsb 2kDps
-    //  8.2 dps/lsb 4kDps
-    gyro->scale = 1.0f / (gyro->gyro_high_fsr ? 8.2f : 16.4f);
+    // 16.384 dps/lsb scalefactor for 2000dps sensors
+    //  8.192 dps/lsb scalefactor for 4000dps sensors
+    gyro->scale = (gyro->gyro_high_fsr ? GYRO_SCALE_4000DPS : GYRO_SCALE_2000DPS);
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -166,8 +166,7 @@ bool icm20689SpiGyroDetect(gyroDev_t *gyro)
     gyro->initFn = icm20689GyroInit;
     gyro->readFn = mpuGyroReadSPI;
 
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm42605.c
@@ -276,8 +276,7 @@ bool icm42605SpiGyroDetect(gyroDev_t *gyro)
     gyro->initFn = icm42605GyroInit;
     gyro->readFn = icm42605GyroReadSPI;
 
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -235,8 +235,7 @@ bool mpu6000SpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = mpu6000SpiGyroInit;
     gyro->readFn = mpuGyroReadSPI;
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -126,11 +126,10 @@ bool mpu6500SpiGyroDetect(gyroDev_t *gyro)
     case MPU_9250_SPI:
     case ICM_20608_SPI:
     case ICM_20602_SPI:
-        // 16.4 dps/lsb scalefactor
-        gyro->scale = 1.0f / 16.4f;
+        gyro->scale = GYRO_SCALE_2000DPS;
         break;
     case ICM_20601_SPI:
-        gyro->scale = 1.0f / (gyro->gyro_high_fsr ? 8.2f : 16.4f);
+        gyro->scale = (gyro->gyro_high_fsr ? GYRO_SCALE_4000DPS : GYRO_SCALE_2000DPS);
         break;
     default:
         return false;

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -186,8 +186,7 @@ bool mpu9250SpiGyroDetect(gyroDev_t *gyro)
     gyro->initFn = mpu9250SpiGyroInit;
     gyro->readFn = mpuGyroReadSPI;
 
-    // 16.4 dps/lsb scalefactor
-    gyro->scale = 1.0f / 16.4f;
+    gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;
 }


### PR DESCRIPTION
Just a very minor correction to the gyro scaling factor. All gyro drivers were using the hardcoded value of 16.4 msb/dps which is actually a rounded value of the true factor of 16.384 msb/dps. This value actually comes from the `abs(INT16)` range divided by the full scale. So 32768 / 2000. To be fair the Invensense gyro datasheets list this 16.4 rounded value so they're the cause of the mistake. Other manufacturers correctly list the scale as `(1 << 15) / 2000`.

The actual variance is trivial (about 0.1%) and only accounts for 2dps error at full scale so the situation is not dire. This variance is the reason we only see +-1998dps maximum rate in logging for example. But since we're already using a float for the scaling factor there's no reason not to use the more accurate value.

Also refactored using defines so that the calculation is maintained centrally.