### PR TITLE
Disable dynmaic idle if RPM filter is not enabled

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -522,6 +522,14 @@ static void validateAndFixConfig(void)
         && motorConfig()->dev.useDshotTelemetry) {
         motorConfigMutable()->dev.useDshotTelemetry = false;
     }
+
+#if defined(USE_DYN_IDLE)
+    if (!isRpmFilterEnabled()) {
+        for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {
+            pidProfilesMutable(i)->idle_min_rpm = 0;
+        }
+    }
+#endif // USE_DYN_IDLE
 #endif // USE_DSHOT_TELEMETRY
 #endif // USE_DSHOT
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -355,11 +355,7 @@ void initEscEndpoints(void)
 void mixerInitProfile(void)
 {
 #ifdef USE_DYN_IDLE
-    if (motorConfig()->dev.useDshotTelemetry) {
-        idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
-    } else {
-        idleMinMotorRps = 0;
-    }
+    idleMinMotorRps = currentPidProfile->idle_min_rpm * 100.0f / 60.0f;
     idleMaxIncrease = currentPidProfile->idle_max_increase * 0.001f;
     idleP = currentPidProfile->idle_p * 0.0001f;
 #endif


### PR DESCRIPTION
The addition of previous checks of bidirectional DSHOT being enabled were not sufficient. Additionally RPM filter must also be active (harmonics > 0) for dynamic idle to determine the minimum motor RPM and function correctly.
