### PR TITLE
Fix ARMING_DISABLED_RPMFILTER when DSHOT bitbang is enabled

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -73,7 +73,7 @@ void motorWriteAll(float *values)
 #endif
 }
 
-int motorCount(void)
+int motorDeviceCount(void)
 {
     return motorDevice->count;
 }

--- a/src/main/drivers/motor.h
+++ b/src/main/drivers/motor.h
@@ -83,6 +83,7 @@ uint16_t motorConvertToExternal(float motorValue);
 
 struct motorDevConfig_s; // XXX Shouldn't be needed once pwm_output* is really cleaned up.
 void motorDevInit(const struct motorDevConfig_s *motorConfig, uint16_t idlePulse, uint8_t motorCount);
+int motorDeviceCount(void);
 bool checkMotorProtocolEnabled(const motorDevConfig_t *motorConfig, bool *protocolIsDshot);
 bool isMotorProtocolDshot(void);
 bool isMotorProtocolEnabled(void);

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -46,6 +46,7 @@
 #include "drivers/dshot.h"
 #include "drivers/dshot_dpwm.h"
 #include "drivers/dshot_command.h"
+#include "drivers/motor.h"
 
 #include "pwm_output_dshot_shared.h"
 
@@ -264,12 +265,16 @@ bool isDshotMotorTelemetryActive(uint8_t motorIndex)
 
 bool isDshotTelemetryActive(void)
 {
-    for (unsigned i = 0; i < dshotPwmDevice.count; i++) {
-        if (!isDshotMotorTelemetryActive(i)) {
-            return false;
+    const unsigned motorCount = motorDeviceCount();
+    if (motorCount) {
+        for (unsigned i = 0; i < motorCount; i++) {
+            if (!isDshotMotorTelemetryActive(i)) {
+                return false;
+            }
         }
+        return true;
     }
-    return true;
+    return false;
 }
 
 #ifdef USE_DSHOT_TELEMETRY_STATS


### PR DESCRIPTION
Fixes #9729 

The function that checks for every motor having valid telemetry broke with the implementation of bitbang. Effectively the motor count was zero and this caused the logic to fall through with a false-positive. The check relied on a local motor count that was set when the PWM dshot was initialized. When bitbang is active this initialization no longer runs and the motor count was defaulting to zero. This was missed in the bitbang implementation.

Fixed to get the motor count from a common source initialized by both timer and bitbang dshot.

Also changed the logic to prevent a false-positive fallthrough if the motor count is zero (shouldn't happen).
