### PR TITLE
Fixed the MS5611 baro in SPI mode.

### DIFF
--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -27,6 +27,21 @@
 #include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
 
+bool busRawWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
+{
+#ifdef USE_SPI
+    if (busdev->bustype ==  BUSTYPE_SPI) {
+#ifdef USE_SPI_TRANSACTION
+        spiBusTransactionSetup(busdev);
+#endif
+        return spiBusWriteRegister(busdev, reg, data);
+    } else
+#endif
+    {
+        return busWriteRegister(busdev, reg, data);
+    }
+}
+
 bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
 {
 #if !defined(USE_SPI) && !defined(USE_I2C)
@@ -49,6 +64,21 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
 #endif
     default:
         return false;
+    }
+}
+
+bool busRawWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data)
+{
+#ifdef USE_SPI
+    if (busdev->bustype ==  BUSTYPE_SPI) {
+#ifdef USE_SPI_TRANSACTION
+        spiBusTransactionSetup(busdev);
+#endif
+        return spiBusWriteRegister(busdev, reg, data);
+    } else
+#endif
+    {
+        return busWriteRegisterStart(busdev, reg, data);
     }
 }
 
@@ -77,6 +107,21 @@ bool busWriteRegisterStart(const busDevice_t *busdev, uint8_t reg, uint8_t data)
     }
 }
 
+bool busRawReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
+{
+#ifdef USE_SPI
+    if (busdev->bustype ==  BUSTYPE_SPI) {
+#ifdef USE_SPI_TRANSACTION
+        spiBusTransactionSetup(bus);
+#endif
+        return spiBusRawReadRegisterBuffer(busdev, reg, data, length);
+    } else
+#endif
+    {
+        return busReadRegisterBuffer(busdev, reg, data, length);
+    }
+}
+
 bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
 {
 #if !defined(USE_SPI) && !defined(USE_I2C)
@@ -100,6 +145,21 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
 #endif
     default:
         return false;
+    }
+}
+
+bool busRawReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length)
+{
+#ifdef USE_SPI
+    if (busdev->bustype ==  BUSTYPE_SPI) {
+#ifdef USE_SPI_TRANSACTION
+        spiBusTransactionSetup(bus);
+#endif
+        return spiBusRawReadRegisterBuffer(busdev, reg, data, length);
+    } else
+#endif
+    {
+        return busReadRegisterBufferStart(busdev, reg, data, length);
     }
 }
 

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -65,9 +65,13 @@ typedef struct busDevice_s {
 void targetBusInit(void);
 #endif
 
+bool busRawWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool busWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool busRawWriteRegisterStart(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool busWriteRegisterStart(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool busRawReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
 bool busReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t busReadRegister(const busDevice_t *bus, uint8_t reg);
+bool busRawReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 bool busReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 bool busBusy(const busDevice_t *busdev, bool *error);

--- a/src/test/unit/baro_ms5611_unittest.cc
+++ b/src/test/unit/baro_ms5611_unittest.cc
@@ -147,10 +147,10 @@ void delay(uint32_t) {}
 void delayMicroseconds(uint32_t) {}
 
 bool busBusy(const busDevice_t*, bool*) {return false;}
-bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
-bool busReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
-bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
-bool busWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busRawReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busRawReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busRawWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busRawWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
 
 void spiBusSetDivisor() {
 }


### PR DESCRIPTION
Fixes #9611.

The MS5611 gyro requires raw reads / writes when used over SPI. This pull request adds functions to do this to `src/main/drivers/bus.c`.

![image](https://user-images.githubusercontent.com/4742747/80300430-e3161f00-87f0-11ea-9679-209dc76dac02.png)

It also cleans up the ordering of functions in the MS5611 driver to get rid of forward declarations.