### PR TITLE
Fix BOOTGRACE arming disabled reset when motor protocol is DISABLED

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -277,7 +277,7 @@ void updateArmingStatus(void)
             // We also need to prevent arming until it's possible to send DSHOT commands.
             // Otherwise if the initial arming is in crash-flip the motor direction commands
             // might not be sent.
-            && dshotCommandsAreEnabled(DSHOT_CMD_TYPE_INLINE)
+            && (!isMotorProtocolDshot() || dshotCommandsAreEnabled(DSHOT_CMD_TYPE_INLINE))
 #endif
         ) {
             // If so, unset the grace time arming disable flag


### PR DESCRIPTION
When the motor protocol defaults to `DISABLED` the `BOOTGRACE` arming disabled reason would never reset because DSHOT commands would never be enabled (because protocol wasn't DSHOT). The motor protocol has it's own arming disabled so it should not block the boot grace period timeout.