### PR TITLE
Thrust linearisation changes

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1112,7 +1112,7 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_THRUST_LINEARIZATION
-    { "thrust_linear",              VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearization) },
+    { "thrust_linear",              VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearization) },
 #endif
 #ifdef USE_AIRMODE_LPF
     { "transient_throttle_limit",   VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -290,7 +290,10 @@ void pidAcroTrainerInit(void)
 float pidCompensateThrustLinearization(float throttle)
 {
     if (pidRuntime.thrustLinearization != 0.0f) {
-        throttle = throttle * (throttle * pidRuntime.thrustLinearization + 1.0f - pidRuntime.thrustLinearization);
+        // for whoops where a lot of TL is needed, allow more throttle boost
+        const float throttleCompensateAmount = (1.0f - 0.5f * thrustLinearization);
+        const float throttleReversed = (1.0f - throttle);
+        throttle /= 1.0f + throttleCompensateAmount * throttleReversed  * throttleReversed * thrustLinearization;
     }
     return throttle;
 }
@@ -299,8 +302,8 @@ float pidApplyThrustLinearization(float motorOutput)
 {
     if (pidRuntime.thrustLinearization != 0.0f) {
         if (motorOutput > 0.0f) {
-            motorOutput = sqrtf(motorOutput * pidRuntime.thrustLinearizationReciprocal +
-                                pidRuntime.thrustLinearizationB * pidRuntime.thrustLinearizationB) - pidRuntime.thrustLinearizationB;
+            const float motorOutputReversed = (1.0f - motorOutput);
+            motorOutput *= 1.0f + motorOutputReversed  * motorOutputReversed * thrustLinearization;
         }
     }
     return motorOutput;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -291,9 +291,9 @@ float pidCompensateThrustLinearization(float throttle)
 {
     if (pidRuntime.thrustLinearization != 0.0f) {
         // for whoops where a lot of TL is needed, allow more throttle boost
-        const float throttleCompensateAmount = (1.0f - 0.5f * thrustLinearization);
+        const float throttleCompensateAmount = (1.0f - 0.5f * pidRuntime.thrustLinearization);
         const float throttleReversed = (1.0f - throttle);
-        throttle /= 1.0f + throttleCompensateAmount * throttleReversed  * throttleReversed * thrustLinearization;
+        throttle /= 1.0f + throttleCompensateAmount * powerf(throttleReversed, 2) * pidRuntime.thrustLinearization;
     }
     return throttle;
 }
@@ -303,7 +303,7 @@ float pidApplyThrustLinearization(float motorOutput)
     if (pidRuntime.thrustLinearization != 0.0f) {
         if (motorOutput > 0.0f) {
             const float motorOutputReversed = (1.0f - motorOutput);
-            motorOutput *= 1.0f + motorOutputReversed  * motorOutputReversed * thrustLinearization;
+            motorOutput *= 1.0f + powerf(motorOutputReversed, 2) * pidRuntime.thrustLinearization;
         }
     }
     return motorOutput;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -352,8 +352,6 @@ typedef struct pidRuntime_s {
 
 #ifdef USE_THRUST_LINEARIZATION
     float thrustLinearization;
-    float thrustLinearizationReciprocal;
-    float thrustLinearizationB;
 #endif
 
 #ifdef USE_AIRMODE_LPF

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -375,10 +375,6 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
 #ifdef USE_THRUST_LINEARIZATION
     pidRuntime.thrustLinearization = pidProfile->thrustLinearization / 100.0f;
-    if (pidRuntime.thrustLinearization != 0.0f) {
-        pidRuntime.thrustLinearizationReciprocal = 1.0f / pidRuntime.thrustLinearization;
-        pidRuntime.thrustLinearizationB = (1.0f - pidRuntime.thrustLinearization) / (2.0f * pidRuntime.thrustLinearization);
-    }
 #endif
 #if defined(USE_D_MIN)
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {


### PR DESCRIPTION
This PR changes how thrust linear #7304 operates, making the following changes:

- consistent curvature of the thrust linear boost vs motor drive relationship, regardless of the magnitude of the selected thrust linear amount.  Previously, when low levels of thrust linear (20 or less) were selected, there was almost no curvature, which could not correct for non-linear thrust issues.  This code always uses the same curve mathematics, and the amount of thrust linear acts as a multiplier or 'gain' value.

- provides intrinsic throttle boost at low throttle when stronger amounts of thrust linear are configured.  This is useful for whoops, where their low thrust authority (at low throttle)requires not just thrust linear to normalise PID control, but also some throttle boost to normalise throttle response.  Higher power quads which only need a little Thrust Linear will get very little throttle increase.

- the configured thrust linear value now directly relates to the amount of motor boost at zero throttle.  For example, thrust linear of 50 results in a 50% increase of motor drive at zero throttle, thrust linear of 100 results in a 100% increase of motor drive at zero throttle.

- the 'strength' of the thrust linear effect, for a given amount of configured thrust linear, is reduced by about half, so the maximum allowed value is increased from 100 to 150.

A comprehensive online calculator is available to visualise how thrust linear affects motor outputs, including a comparison with the original method, here:   https://www.desmos.com/calculator/vxkvjz1n6b

The intent is to:

- allow application of small amounts (eg 20) of thrust linear on 'normal 5 inch' quads to overcome a tendency for reduced thrust at low rpm, using an effective boost curve.  This may provide a subtle improvement in PID behaviour when one or more motors are driven low.

- significantly improve low throttle behaviour, both PID and throttle responsiveness, for machines with significantly less thrust at low rpm compared to high rpm, eg whoops.  Typical values here may be in the range of 70-100.

Technically, applying thrust linear will:

- boost motor drive, on a per-motor basis, by a percentage that gets greater as motor drive decreases.  There is very little effect above 50% motor drive, and most effect, in percentage terms, at zero throttle.  This image shows the old and new motor boost curves when the maximum effect is 50%.

![TL curve](https://user-images.githubusercontent.com/11737748/80667567-dd675480-8ae2-11ea-8c12-533814c4727e.jpg)

- provide a compensatory reduction in throttle to offset the increase that would otherwise occur.  The end result is a small net boost in throttle at hover values.  At TL of 20, at idle of 5%, for example, the net throttle increase is 1.5%.  With TL of 50 it is 9%.  For a whoop, at 100, it is 33%.  At hover throttle the effect is less obvious.

The actual outcome on PIDs is a bit complex and depends on the motor states.

Because the boost effect is a applied as a percentage of the actual motor drive value, applying TL of 100 to a motor drive value of 1% will double it to 2%, but only provide an absolute increase of 1%.  In contrast, at the same TL, a motor getting 20% drive will increase that motor by 66% to 33% a much greater absolute increase, even though the percent increase is less.  

Hence, TL increases PID authority considerably in the lower throttle range.  

When throttle is higher, this increased PID authority is reduced.  

Hence TL can be thought of as a kind of PID authority booster at low throttle, based on a drive vs throttle curve applied on a per motor basis.  When set to 100, PID authority at idle is almost doubled.

TL should only be applied in significant amounts (>20) when the quad demonstrates markedly less PID authority at low throttle than at high.  This may be manifest by weak wobbly behaviour at low throttle and good control at higher throttle, typically in association with poor throttle response also at low throttle (indicated by high throttle stick position to hover, and stronger throttle responses once the quad 'gets going').  These symptoms are not uncommon in low powered ducted whoop designs.

CAUTION:  Increasing D authority via TL can cause flyaways on arming if TL is configured too high, due to excessive D resonance at idle.  