### PR TITLE
I2C3_SCL and I2C3_SDA pins are mixed up

### DIFF
--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -76,8 +76,8 @@
 #define USE_I2C_DEVICE_3
 
 #define I2C_DEVICE              (I2CDEV_3)
-#define I2C3_SCL                PC9        // S4 pad
-#define I2C3_SDA                PA8        // S6 pad
+#define I2C3_SCL                PA8        // S4 pad
+#define I2C3_SDA                PC9        // S6 pad
 #define BARO_I2C_INSTANCE       (I2CDEV_3)
 #else
 #define USE_I2C_DEVICE_1


### PR DESCRIPTION
according to datasheet of STM32F405xx chip PA8 is I2C3_SCL and PC9 is I2C3_SDA 
Currently they are mixed up. 
I use MATEK F405-OSD with external barometer and this fix solves my issues

![datasheet](https://user-images.githubusercontent.com/1381776/80852207-64294800-8c2f-11ea-899e-16ae9b2d60b2.png)

