### PR TITLE
Fixed the display of lowercase characters in the git revision string in CMS.

### DIFF
--- a/src/main/cms/cms_menu_firmware.c
+++ b/src/main/cms/cms_menu_firmware.c
@@ -22,6 +22,8 @@
 // Firmware related menu contents and support functions
 //
 
+#include <ctype.h>
+
 #include <stdbool.h>
 
 #include "platform.h"
@@ -191,11 +193,7 @@ static const void *cmsx_FirmwareInit(displayPort_t *pDisp)
 
     unsigned i;
     for (i = 0 ; i < GIT_SHORT_REVISION_LENGTH ; i++) {
-        if (shortGitRevision[i] >= 'a' && shortGitRevision[i] <= 'f') {
-            infoGitRev[i] = shortGitRevision[i] - 'a' + 'A';
-        } else {
-            infoGitRev[i] = shortGitRevision[i];
-        }
+        infoGitRev[i] = toupper(shortGitRevision[i]);
     }
 
     infoGitRev[i] = 0x0; // Terminate string

--- a/src/main/ctype.h
+++ b/src/main/ctype.h
@@ -19,7 +19,7 @@
  */
 
 /*
- * Replacemnet for system header file <ctype.h> to avoid macro definitions
+ * Replacement for system header file <ctype.h> to avoid macro definitions
  * Functions are implemented in common/string_light.c
  */
 


### PR DESCRIPTION
Before:

![vlcsnap-2020-05-02-17h17m40s385](https://user-images.githubusercontent.com/4742747/80855880-16e1c080-8c99-11ea-9e6f-f991ed096326.png)

After:

![vlcsnap-2020-05-02-17h20m24s002](https://user-images.githubusercontent.com/4742747/80855895-44c70500-8c99-11ea-9c62-bb1238b09a81.png)
