### PR TITLE
Added metric for consumption in mAh to LTM telemetry.

### DIFF
--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -188,8 +188,8 @@ static void ltm_sframe(void)
     if (failsafeIsActive())
         lt_statemode |= 2;
     ltm_initialise_packet('S');
-    ltm_serialise_16(getBatteryVoltage() * 10);    //vbat converted to mV
-    ltm_serialise_16(0);             //  current, not implemented
+    ltm_serialise_16(getBatteryVoltage() * 10); // vbat converted to mV
+    ltm_serialise_16((uint16_t)constrain(getMAhDrawn(), 0, UINT16_MAX)); // consumption in mAh (65535 mAh max)
     ltm_serialise_8(constrain(scaleRange(getRssi(), 0, RSSI_MAX_VALUE, 0, 255), 0, 255));        // scaled RSSI (uchar)
     ltm_serialise_8(0);              // no airspeed
     ltm_serialise_8((lt_flightmode << 2) | lt_statemode);


### PR DESCRIPTION
According to the specification in https://github.com/iNavFlight/inav/wiki/Lightweight-Telemetry-(LTM)#status-frame-s.

Test firmware:
[betaflight_4.2.0_STM32F745_f8d17032cf.zip](https://github.com/betaflight/betaflight/files/4569567/betaflight_4.2.0_STM32F745_f8d17032cf.zip)
[betaflight_4.2.0_STM32F7X2_f8d17032cf.zip](https://github.com/betaflight/betaflight/files/4569568/betaflight_4.2.0_STM32F7X2_f8d17032cf.zip)
[betaflight_4.2.0_STM32F411_f8d17032cf.zip](https://github.com/betaflight/betaflight/files/4569569/betaflight_4.2.0_STM32F411_f8d17032cf.zip)
[betaflight_4.2.0_STM32F405_f8d17032cf.zip](https://github.com/betaflight/betaflight/files/4569570/betaflight_4.2.0_STM32F405_f8d17032cf.zip)
(installation instructions: https://youtu.be/I1uN9CN30gw)
