### PR TITLE
Change gyro driver initialize-only files to size-optimized

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -220,14 +220,8 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             common/typeconversion.c \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_mpu3050.c \
-            drivers/accgyro/accgyro_mpu6050.c \
-            drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_bmi160.c \
             drivers/accgyro/accgyro_spi_bmi270.c \
-            drivers/accgyro/accgyro_spi_icm20689.c \
-            drivers/accgyro/accgyro_spi_mpu6000.c \
-            drivers/accgyro/accgyro_spi_mpu6500.c \
-            drivers/accgyro/accgyro_spi_mpu9250.c \
             drivers/accgyro_legacy/accgyro_adxl345.c \
             drivers/accgyro_legacy/accgyro_bma280.c \
             drivers/accgyro_legacy/accgyro_l3g4200d.c \
@@ -351,6 +345,16 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             osd/osd_elements.c \
             rx/rx_bind.c \
             sensors/gyro_init.c
+
+# Gyro driver files that only contain initialization and configuration code - not runtime code
+SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
+            drivers/accgyro/accgyro_mpu6050.c \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu9250.c \
+            drivers/accgyro/accgyro_spi_icm20689.c
+
 
 # F4 and F7 optimizations
 ifneq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))

--- a/src/main/drivers/accgyro/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu3050.c
@@ -25,6 +25,8 @@
 
 #include "platform.h"
 
+#ifdef USE_GYRO_MPU3050
+
 #include "common/maths.h"
 #include "common/utils.h"
 
@@ -110,3 +112,4 @@ bool mpu3050Detect(gyroDev_t *gyro)
 
     return true;
 }
+#endif

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -24,6 +24,8 @@
 
 #include "platform.h"
 
+#ifdef USE_GYRO_SPI_ICM20649
+
 #include "common/axis.h"
 #include "common/maths.h"
 
@@ -203,3 +205,4 @@ bool icm20649AccRead(accDev_t *acc)
 
     return true;
 }
+#endif

--- a/src/main/drivers/accgyro/accgyro_spi_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm42605.c
@@ -28,6 +28,8 @@
 
 #include "platform.h"
 
+#ifdef USE_GYRO_SPI_ICM42605
+
 #include "common/axis.h"
 #include "common/maths.h"
 #include "build/debug.h"
@@ -281,3 +283,4 @@ bool icm42605SpiGyroDetect(gyroDev_t *gyro)
 
     return true;
 }
+#endif

--- a/src/main/drivers/accgyro_legacy/accgyro_adxl345.c
+++ b/src/main/drivers/accgyro_legacy/accgyro_adxl345.c
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#ifdef USE_ACC_ADXL345
+
 #include "drivers/bus_i2c.h"
 
 #include "drivers/sensor.h"
@@ -134,3 +136,4 @@ bool adxl345Detect(drv_adxl345_config_t *init, accDev_t *acc)
     acc->readFn = adxl345Read;
     return true;
 }
+#endif

--- a/src/main/drivers/accgyro_legacy/accgyro_bma280.c
+++ b/src/main/drivers/accgyro_legacy/accgyro_bma280.c
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#ifdef USE_ACC_BMA280
+
 #include "drivers/bus_i2c.h"
 
 #include "drivers/sensor.h"
@@ -71,3 +73,4 @@ bool bma280Detect(accDev_t *acc)
     acc->readFn = bma280Read;
     return true;
 }
+#endif

--- a/src/main/drivers/accgyro_legacy/accgyro_l3g4200d.c
+++ b/src/main/drivers/accgyro_legacy/accgyro_l3g4200d.c
@@ -25,6 +25,8 @@
 
 #include "platform.h"
 
+#ifdef USE_GYRO_L3G4200D
+
 #include "drivers/accgyro/accgyro.h"
 #include "accgyro_l3g4200d.h"
 
@@ -115,3 +117,4 @@ bool l3g4200dDetect(gyroDev_t *gyro)
 
     return true;
 }
+#endif

--- a/src/main/drivers/accgyro_legacy/accgyro_mma845x.c
+++ b/src/main/drivers/accgyro_legacy/accgyro_mma845x.c
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#ifdef USE_ACC_MMA8452
+
 #include "drivers/io.h"
 #include "drivers/bus_i2c.h"
 
@@ -139,3 +141,4 @@ bool mma8452Detect(accDev_t *acc)
     device_id = sig;
     return true;
 }
+#endif


### PR DESCRIPTION
The following driver files only contain initialization and configuration fuctions and were erroneously set up for speed-optimization. Moving them to size-optimization saves significant space. They all share common runtime functions contained in `drivers/accgyro/accgyro_mpu.c` which is correctly speed-optimized.

```
drivers/accgyro/accgyro_mpu6050.c
drivers/accgyro/accgyro_mpu6500.c
drivers/accgyro/accgyro_spi_mpu6000.c
drivers/accgyro/accgyro_spi_mpu6500.c
drivers/accgyro/accgyro_spi_mpu9250.c
drivers/accgyro/accgyro_spi_icm20689.c
```

Also added explicit `#ifdef USE_` around the code of some of the drivers missing it. Doesn't result in any space savings as the compiler optimizes out the unused functions. But better in the long-term as it will flag any cases where the code might be called without proper bounding.

Saves 10704 bytes on STM32F7X2.