### PR TITLE
Fix CRC algo for FrSky S.Port and F.Port

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -107,6 +107,7 @@ COMMON_SRC = \
             rx/jetiexbus.c \
             rx/msp.c \
             rx/pwm.c \
+            rx/frsky_crc.c \
             rx/rx.c \
             rx/rx_bind.c \
             rx/rx_spi.c \
@@ -261,6 +262,7 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             rx/rx.c \
             rx/rx_spi.c \
             rx/crsf.c \
+            rx/frsky_crc.c \
             rx/sbus.c \
             rx/sbus_channels.c \
             rx/spektrum.c \
@@ -357,6 +359,7 @@ ifneq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))
 SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             drivers/bus_i2c_hal.c \
             drivers/bus_spi_ll.c \
+            rx/frsky_crc.c \
             drivers/max7456.c \
             drivers/pwm_output_dshot.c \
             drivers/pwm_output_dshot_shared.c \

--- a/src/main/rx/frsky_crc.c
+++ b/src/main/rx/frsky_crc.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "rx/frsky_crc.h"
+
+void frskyCheckSumStep(uint16_t *checksum, uint8_t byte)
+{
+    *checksum += byte;
+}
+
+void frskyCheckSumFini(uint16_t *checksum)
+{
+    while (*checksum > 0xFF) {
+        *checksum = (*checksum & 0xFF) + (*checksum >> 8);
+    }
+
+    *checksum = 0xFF - *checksum;
+}
+
+static uint8_t frskyCheckSum(uint8_t *data, uint8_t length)
+{
+    uint16_t checksum = 0;
+    for (unsigned i = 0; i < length; i++) {
+        frskyCheckSumStep(&checksum, *data++);
+    }
+    frskyCheckSumFini(&checksum);
+    return checksum;
+}
+
+bool frskyCheckSumIsGood(uint8_t *data, uint8_t length)
+{
+    uint16_t checksum = frskyCheckSum(data, length);
+    return checksum == 0xFF;
+}

--- a/src/main/rx/frsky_crc.h
+++ b/src/main/rx/frsky_crc.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool frskyCheckSumIsGood(uint8_t *data, uint8_t length);
+void frskyCheckSumStep(uint16_t *checksum, uint8_t byte);   // Add byte to checksum
+void frskyCheckSumFini(uint16_t *checksum);                 // Finalize checksum

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -39,6 +39,8 @@
 
 #include "config/feature.h"
 
+#include "rx/frsky_crc.h"
+
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/compass/compass.h"
 #include "drivers/sensor.h"
@@ -285,7 +287,7 @@ void smartPortSendByte(uint8_t c, uint16_t *checksum, serialPort_t *port)
     }
 
     if (checksum != NULL) {
-        *checksum += c;
+        frskyCheckSumStep(checksum, c);
     }
 }
 
@@ -300,8 +302,8 @@ void smartPortWriteFrameSerial(const smartPortPayload_t *payload, serialPort_t *
     for (unsigned i = 0; i < sizeof(smartPortPayload_t); i++) {
         smartPortSendByte(*data++, &checksum, port);
     }
-    checksum = 0xff - ((checksum & 0xff) + (checksum >> 8));
-    smartPortSendByte((uint8_t)checksum, NULL, port);
+    frskyCheckSumFini(&checksum);
+    smartPortSendByte(checksum, NULL, port);
 }
 
 static void smartPortWriteFrameInternal(const smartPortPayload_t *payload)


### PR DESCRIPTION
The CRC algo used now for S.Port and F.Port is wrong. It is calculating the right value in most cases but still it is wrong and sometimes calculate a wrong CRC leading to lost control and telemetry frames.