### PR TITLE
Added QMC-5883 magnetometer support to SPRACING H7 NANO / ZERO targets

### DIFF
--- a/src/main/target/SPRACINGH7NANO/target.h
+++ b/src/main/target/SPRACINGH7NANO/target.h
@@ -129,6 +129,7 @@
 
 #define USE_MAG
 #define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
 
 #define USE_BARO
 #define USE_BARO_BMP388

--- a/src/main/target/SPRACINGH7NANO/target.mk
+++ b/src/main/target/SPRACINGH7NANO/target.mk
@@ -15,6 +15,7 @@ TARGET_SRC += \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6500.c \
             drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
             drivers/barometer/barometer_bmp085.c \
             drivers/barometer/barometer_bmp280.c \
             drivers/barometer/barometer_bmp388.c \

--- a/src/main/target/SPRACINGH7ZERO/target.h
+++ b/src/main/target/SPRACINGH7ZERO/target.h
@@ -133,6 +133,7 @@
 
 #define USE_MAG
 #define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
 
 #define USE_BARO
 #define USE_BARO_BMP388

--- a/src/main/target/SPRACINGH7ZERO/target.mk
+++ b/src/main/target/SPRACINGH7ZERO/target.mk
@@ -15,4 +15,5 @@ TARGET_SRC += \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6500.c \
             drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
             drivers/barometer/barometer_bmp388.c \


### PR DESCRIPTION
Added QMC-5883 magnetometer support to SPRACING H7 NANO target. Duplicating pull request #9531