### PR TITLE
Fix HAL USB vcp serial 64 byte packet receive bug

### DIFF
--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -299,6 +299,12 @@ static int8_t CDC_Itf_Receive(uint8_t* Buf, uint32_t *Len)
 {
     rxAvailable = *Len;
     rxBuffPtr = Buf;
+    if (!rxAvailable) {
+        // Received an empty packet, trigger receiving the next packet.
+        // This will happen after a packet that's exactly 64 bytes is received.
+        // The USB protocol requires that an empty (0 byte) packet immediately follow.
+        USBD_CDC_ReceivePacket(&USBD_Device);
+    }
     return (USBD_OK);
 }
 


### PR DESCRIPTION
Fixes #9761 
Fixes https://github.com/betaflight/betaflight-configurator/issues/2006

Fixes a bug in the HAL USP vcp serial logic that would cause communication to hang after receiving a packet containing exactly 64 bytes.

When a packet is exactly 64 bytes the USB specification requires an empty (0 byte) pack to be additionally sent. The receiving logic was not handling this 0 byte packet properly. The logic error would cause it to not trigger receiving the next packet and communication would stop.
