### PR TITLE
Disabling FrSky OSD.

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -381,3 +381,7 @@ extern uint8_t __config_end;
 #if defined(USE_RX_SPI) || defined (USE_SERIALRX_SRXL2)
 #define USE_RX_BIND
 #endif
+
+
+// Disable FrSky OSD as there was no payment from FrSky to have this added to Betaflight
+#undef USE_FRSKYOSD


### PR DESCRIPTION
The author of this is taking a stance that support for new hardware should only be added to the firmware if the manufacturer pays for this (https://github.com/iNavFlight/inav/pull/5632#issuecomment-629096154), and using this as an argument to prevent other manufacturers from getting support for their hardware added to iNav.

This fixes the problem that the author did not apply this rule to this.