### PR TITLE
Fixed pin ownership checks for I2C.

### DIFF
--- a/src/main/drivers/bus_i2c_hal_init.c
+++ b/src/main/drivers/bus_i2c_hal_init.c
@@ -287,15 +287,12 @@ void i2cInit(I2CDevice device)
     i2cDevice_t *pDev = &i2cDevice[device];
 
     const i2cHardware_t *hardware = pDev->hardware;
+    const IO_t scl = pDev->scl;
+    const IO_t sda = pDev->sda;
 
-    if (!hardware) {
+    if (!hardware || IOGetOwner(scl) || IOGetOwner(sda)) {
         return;
     }
-
-    IO_t scl = pDev->scl;
-    IO_t sda = pDev->sda;
-
-    RCC_ClockCmd(hardware->rcc, ENABLE);
 
     IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(device));
     IOInit(sda, OWNER_I2C_SDA, RESOURCE_INDEX(device));

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -435,8 +435,10 @@ void i2cInit(I2CDevice device)
 
     i2cDevice_t *pDev = &i2cDevice[device];
     const i2cHardware_t *hw = pDev->hardware;
+    const IO_t scl = pDev->scl;
+    const IO_t sda = pDev->sda;
 
-    if (!hw) {
+    if (!hw || IOGetOwner(scl) || IOGetOwner(sda)) {
         return;
     }
 
@@ -446,9 +448,6 @@ void i2cInit(I2CDevice device)
 
     NVIC_InitTypeDef nvic;
     I2C_InitTypeDef i2cInit;
-
-    IO_t scl = pDev->scl;
-    IO_t sda = pDev->sda;
 
     IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(device));
     IOInit(sda, OWNER_I2C_SDA, RESOURCE_INDEX(device));


### PR DESCRIPTION
Fixes #9806.

This fixes the problem that currently, `IOInit()` does not check if a pin is already used (i.e. has an owner assigned) before setting the owner. This leads to cases where a pin is successfully assigned and a pin function started, but then the pin gets re-assigned to a different function, leaving artefacts:

Setup:

```
# resource

[...]

resource MOTOR 4 C09

[...]

resource I2C_SDA 3 C09

[...]
```


Before:

```
# resource show all

[...]

C09: I2C_SDA 3

[...]

Currently active Timers:
-----------------------
TIM1: FREE
TIM2: FREE
TIM3:
    CH1: MOTOR 1
TIM4: FREE
TIM5: FREE
TIM6: FREE
TIM7: FREE
TIM8:
    CH2: MOTOR 2
    CH3: MOTOR 3
    CH4: MOTOR 4

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: TIMUP 3
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: FREE
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC 1
DMA2 Stream 1: TIMUP 8
DMA2 Stream 2: FREE
DMA2 Stream 3: FREE
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

After:

```
# resource show all

[...]

C09: MOTOR 4

[...]

Currently active Timers:
-----------------------
TIM1: FREE
TIM2: FREE
TIM3:
    CH1: MOTOR 1
TIM4: FREE
TIM5: FREE
TIM6: FREE
TIM7: FREE
TIM8:
    CH2: MOTOR 2
    CH3: MOTOR 3
    CH4: MOTOR 4

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: TIMUP 3
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: FREE
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC 1
DMA2 Stream 1: TIMUP 8
DMA2 Stream 2: FREE
DMA2 Stream 3: FREE
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

This is just one fix to solve a problem that is currently breaking configurations for users. A comprehensive switch to replace `IOInit()` with functionality that checks resource ownership is needed, and is currently work in progress, to be added after 4.2 has been released.

Also removing a duplicate `RCC_ClockCmd()` line.

Test firmware:

[betaflight_4.2.0_STM32F745_37209b4826.zip](https://github.com/betaflight/betaflight/files/4639441/betaflight_4.2.0_STM32F745_37209b4826.zip)
[betaflight_4.2.0_STM32F7X2_37209b4826.zip](https://github.com/betaflight/betaflight/files/4639443/betaflight_4.2.0_STM32F7X2_37209b4826.zip)
[betaflight_4.2.0_STM32F411_37209b4826.zip](https://github.com/betaflight/betaflight/files/4639444/betaflight_4.2.0_STM32F411_37209b4826.zip)
[betaflight_4.2.0_STM32F405_37209b4826.zip](https://github.com/betaflight/betaflight/files/4639445/betaflight_4.2.0_STM32F405_37209b4826.zip)

(installation instructions: youtu.be/I1uN9CN30gw)
