### PR TITLE
Smooth ANGLE mode

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -68,7 +68,7 @@ static float oldRcCommand[XYZ_AXIS_COUNT];
 static float setpointRate[3], rcDeflection[3], rcDeflectionAbs[3];
 static float throttlePIDAttenuation;
 static bool reverseMotors = false;
-static applyRatesFn *applyRates;
+applyRatesFn *applyRates;
 static uint16_t currentRxRefreshRate;
 static bool isRxDataNew = false;
 static float rcCommandDivider = 500.0f;

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -37,6 +37,10 @@ typedef enum {
 #define RC_SMOOTHING_AUTO_FACTOR_MAX 50
 #endif
 
+typedef float (applyRatesFn)(const int axis, float rcCommandf, const float rcCommandfAbs);
+
+extern applyRatesFn *applyRates;
+
 void processRcCommand(void);
 float getSetpointRate(int axis);
 float getRcDeflection(int axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -883,7 +883,8 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
     const float errorAngle = angle - ((attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f);
     if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
         // ANGLE mode - control is angle based
-        currentPidSetpoint = errorAngle * levelGain;
+        float errorRate = constrainf(errorAngle / (pidProfile->levelAngleLimit), -1.0f, 1.0f);
+        currentPidSetpoint = applyRates(axis, errorRate, fabsf(errorRate)) * (levelGain / 5.0f); // levelGain default is 5.0f
     } else {
         // HORIZON mode - mix of ANGLE and ACRO modes
         // mix in errorAngle to currentPidSetpoint to add a little auto-level feel


### PR DESCRIPTION
In Angle mode, roll and pitch are directly commanded by angle_level_strength, which is effectively a P-controller. High values of strength allow for a tight control feel, while low values lead to a loose control. This PR attempts to find a balance, getting very smooth control on slow stick movements, while still retaining some control on fast stick movements.

In order to do so, strength is dynamically adjusted between smooth_angle_min_strength and angle_level_strength. How fast it changes from one to the other value is controlled by smooth_angle_boost. The higher the boost value, the more control on fast movements. A boost value of 0 disables the Smooth Angle Mode.

Recommended settings:
smooth_angle_min_strength = 10
angle_level_strength = 50
smooth_angle_boost = 15 to 25

Notes:
- boost range depends on strength values. With min_strength=10 and strength=100, a good boost value would be around 5.
- in angle mode, yaw control is using the rate system, so it already has some expo by default, and throttle is inherently smooth. In my tests, I've got super smooth flying just with the above smooth angle values and default yaw/throttle expo.
