### PR TITLE
Don't allow gyro_rpm_notch_q to be set below default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Because of this, the following embargo is put in place:
 
 1. Pull requests will only be accepted if they are opened against the `master` branch. Pull requests opened against other branches without prior consent from the maintainers will be closed;
 
-2. Please follow the coding style guidlines: https://github.com/cleanflight/cleanflight/blob/master/docs/development/CodingStyle.md
+2. Please follow the coding style guidlines: https://github.com/betaflight/betaflight/blob/master/docs/development/CodingStyle.md
 
 3. Keep your pull requests as small and concise as possible. One pull request should only ever add / update one feature. If the change that you are proposing has a wider scope, consider splitting it over multiple pull requests. In particular, pull requests that combine changes to features and one or more new targets are not acceptable.
 


### PR DESCRIPTION
Gyro_rpm_notch_q shouldn't be allowed to be set below the default of 500. I've had it on three occasions now where either I'm typing too quickly in the CLI or saving too quickly but the last zero isn't recognized and I accidentally save this parameter as 80....

This causes an instant fly away and will almost melt your motors...  I found that out the hard way...  