### PR TITLE
Add DEBUG_D_LPF

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -96,4 +96,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "BLACKBOX_OUTPUT",
     "GYRO_SAMPLE",
     "RX_TIMING",
+    "D_LPF",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -112,6 +112,7 @@ typedef enum {
     DEBUG_BLACKBOX_OUTPUT,
     DEBUG_GYRO_SAMPLE,
     DEBUG_RX_TIMING,
+    DEBUG_D_LPF,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -225,6 +225,10 @@ void pgResetFn_pidProfiles(pidProfile_t *pidProfiles)
     }
 }
 
+// Scale factors to make best use of range with D_LPF debugging, aiming for max +/-16K as debug values are 16 bit
+#define D_LPF_RAW_SCALE 25
+#define D_LPF_FILT_SCALE 22
+
 
 void pidSetItermAccelerator(float newItermAccelerator)
 {
@@ -769,6 +773,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 #ifdef USE_INTERPOLATED_SP
     static FAST_RAM_ZERO_INIT uint32_t lastFrameNumber;
 #endif
+    static float previousRawGyroRateDterm[XYZ_AXIS_COUNT];
 
 #if defined(USE_ACC)
     static timeUs_t levelModeStartTimeUs = 0;
@@ -841,6 +846,24 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     float gyroRateDterm[XYZ_AXIS_COUNT];
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
         gyroRateDterm[axis] = gyro.gyroADCf[axis];
+        // -----calculate raw, unfiltered D component
+
+        // Divide rate change by dT to get differential (ie dr/dt).
+        // dT is fixed and calculated from the target PID loop time
+        // This is done to avoid DTerm spikes that occur with dynamically
+        // calculated deltaT whenever another task causes the PID
+        // loop execution to be delayed.
+        const float delta =
+            - (gyroRateDterm[axis] - previousRawGyroRateDterm[axis]) * pidRuntime.pidFrequency / D_LPF_RAW_SCALE;
+        previousRawGyroRateDterm[axis] = gyroRateDterm[axis];
+
+        // Log the unfiltered D
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_D_LPF, 0, lrintf(delta));
+        } else if (axis == FD_PITCH) {
+            DEBUG_SET(DEBUG_D_LPF, 1, lrintf(delta));
+        }
+
 #ifdef USE_RPM_FILTER
         gyroRateDterm[axis] = rpmFilterDterm(axis,gyroRateDterm[axis]);
 #endif
@@ -957,7 +980,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         if (launchControlActive) {
             Ki = pidRuntime.launchControlKi;
             axisDynCi = dynCi;
-        } else 
+        } else
 #endif
         {
             Ki = pidRuntime.pidCoefficient[axis].Ki;
@@ -995,6 +1018,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             // loop execution to be delayed.
             const float delta =
                 - (gyroRateDterm[axis] - previousGyroRateDterm[axis]) * pidRuntime.pidFrequency;
+            float preTpaData = pidRuntime.pidCoefficient[axis].Kd * delta;
 
 #if defined(USE_ACC)
             if (cmpTimeUs(currentTimeUs, levelModeStartTimeUs) > CRASH_RECOVERY_DETECTION_DELAY_US) {
@@ -1002,8 +1026,8 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             }
 #endif
 
-            float dMinFactor = 1.0f;
 #if defined(USE_D_MIN)
+            float dMinFactor = 1.0f;
             if (pidRuntime.dMinPercent[axis] > 0) {
                 float dMinGyroFactor = biquadFilterApply(&pidRuntime.dMinRange[axis], delta);
                 dMinGyroFactor = fabsf(dMinGyroFactor) * pidRuntime.dMinGyroGain;
@@ -1020,11 +1044,30 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
                     DEBUG_SET(DEBUG_D_MIN, 3, lrintf(pidRuntime.pidCoefficient[axis].Kd * dMinFactor * 10 / DTERM_SCALE));
                 }
             }
+
+            // Apply the dMinFactor
+            preTpaData *= dMinFactor;
 #endif
-            pidData[axis].D = pidRuntime.pidCoefficient[axis].Kd * delta * tpaFactor * dMinFactor;
+            pidData[axis].D = preTpaData * tpaFactor;
+
+            // Log the value of D pre application of TPA
+            preTpaData *= D_LPF_FILT_SCALE;
+
+            if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_D_LPF, 2, lrintf(preTpaData));
+            } else if (axis == FD_PITCH) {
+                DEBUG_SET(DEBUG_D_LPF, 3, lrintf(preTpaData));
+            }
         } else {
             pidData[axis].D = 0;
+
+            if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_D_LPF, 2, 0);
+            } else if (axis == FD_PITCH) {
+                DEBUG_SET(DEBUG_D_LPF, 3, 0);
+            }
         }
+
         previousGyroRateDterm[axis] = gyroRateDterm[axis];
 
         // -----calculate feedforward component


### PR DESCRIPTION
This PR adds a debug mode which logs the following:

- [0] = Unfiltered Roll D Component 
- [1] = Unfiltered Pitch D Component 
- [2] = Filtered Roll D Component, pre application of TPA
- [3] = Filtered Pitch D Component, pre application of TPA

This greatly aid setting D filtering by allowing the effect of the filtering to be clearly seen.

For example, the image below shows the `Debug[0]` frequency/throttle plot showing evidence of noise centred around 363Hz.
![image](https://user-images.githubusercontent.com/11480839/82596818-e27a6980-9b9f-11ea-8176-237d07cd944b.png)

And the following image shows the effect of the application of the dynamic D LPF filter, set to 75-150Hz.
![image](https://user-images.githubusercontent.com/11480839/82596924-10f84480-9ba0-11ea-8a88-9f94158df6f8.png)

The corresponding images in the frequency domain are shown below.

![image](https://user-images.githubusercontent.com/11480839/82597000-31280380-9ba0-11ea-97fe-20f3a46de52f.png)
![image](https://user-images.githubusercontent.com/11480839/82597039-43a23d00-9ba0-11ea-975e-85bdda314d90.png)

Setting the filter to 75-125Hz gives the following plots in the corresponding order.
![image](https://user-images.githubusercontent.com/11480839/82597253-95e35e00-9ba0-11ea-8a1d-5ccafc8cd0fb.png)
![image](https://user-images.githubusercontent.com/11480839/82597296-a693d400-9ba0-11ea-8137-32ab39b3da75.png)
![image](https://user-images.githubusercontent.com/11480839/82597370-c5926600-9ba0-11ea-8561-f225f5b383c4.png)
![image](https://user-images.githubusercontent.com/11480839/82597413-d3e08200-9ba0-11ea-9851-a874ec0c5cfa.png)

Such debug information reveals issues not previously visible. For example, the `Debug[1]` trace shows there to be variable frequency noise on the raw pitch D term which may mean that D performance could be improved. Should we make the Q of the D RPM filter tuneable?
![image](https://user-images.githubusercontent.com/11480839/82597665-3e91bd80-9ba1-11ea-8df8-d6a3fdd176ec.png)

This is even more evident in 4/4 of the attached log with the filter set to 75-130Hz.
![image](https://user-images.githubusercontent.com/11480839/82598178-24a4aa80-9ba2-11ea-8cfc-5abdf064e0cc.png)

The effect of TPA can also be explored. Below is the `Debug[3]` trace showing the filtered pitch D from log 3/4 prior to the application of TPA.
![image](https://user-images.githubusercontent.com/11480839/82598730-03908980-9ba3-11ea-82de-6820ffde9e23.png)

And below is the corresponding `PID D [pitch]` plot with the gain/brightness adjusted so the range below 20% is much the same.
![image](https://user-images.githubusercontent.com/11480839/82598872-3e92bd00-9ba3-11ea-8194-5df8885f823c.png)

See the black box log below for reference.

[200521_DEBUG_D_LPF.bbl.zip](https://github.com/betaflight/betaflight/files/4664335/200521_DEBUG_D_LPF.bbl.zip)
