### PR TITLE
Blackbox flush SD card sector cache after writing header and before logging starts

### DIFF
--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -46,6 +46,8 @@ int blackboxWriteString(const char *s);
 
 void blackboxDeviceFlush(void);
 bool blackboxDeviceFlushForce(void);
+bool blackboxDeviceFlushForceComplete(void);
+
 bool blackboxDeviceOpen(void);
 void blackboxDeviceClose(void);
 

--- a/src/main/io/asyncfatfs/asyncfatfs.h
+++ b/src/main/io/asyncfatfs/asyncfatfs.h
@@ -93,3 +93,4 @@ bool afatfs_isFull(void);
 
 afatfsFilesystemState_e afatfs_getFilesystemState(void);
 afatfsError_e afatfs_getLastError(void);
+bool afatfs_sectorCacheInSync(void);


### PR DESCRIPTION
Fixes #9856 

The normal "flush" for SD card only queues a cache sector for writing and the actual sync to the media happens asynchronously. During this period the cache entry is not available until the write completes sometime later. So as the blackbox header fields were written they end up consuming the majority of the cache. A "flush" was made before actual logging starts, but the async writes were not completing fast enough to ensure available cache sectors for the actual logging. This resulted in the cache getting overwritten and corrupting the header.

Changed to wait until the sector cache completes writing to the media before starting the actual logging. This ensures that the logging has ample cache sectors.

Changes only affect SD card logging.

Test firmware:
[betaflight_4.2.0_STM32F745_51f3146.zip](https://github.com/betaflight/betaflight/files/4698033/betaflight_4.2.0_STM32F745_51f3146.zip)
[betaflight_4.2.0_STM32F7X2_51f3146.zip](https://github.com/betaflight/betaflight/files/4698034/betaflight_4.2.0_STM32F7X2_51f3146.zip)
[betaflight_4.2.0_STM32F411_51f3146.zip](https://github.com/betaflight/betaflight/files/4698035/betaflight_4.2.0_STM32F411_51f3146.zip)
[betaflight_4.2.0_STM32F405_51f3146.zip](https://github.com/betaflight/betaflight/files/4698036/betaflight_4.2.0_STM32F405_51f3146.zip)

(installation instructions: https://youtu.be/I1uN9CN30gw)
