### PR TITLE
Moved custom defaults to dedicated block for STM32F745.

### DIFF
--- a/src/main/target/STM32_UNIFIED/target.mk
+++ b/src/main/target/STM32_UNIFIED/target.mk
@@ -1,10 +1,6 @@
 ifeq ($(TARGET), STM32F405)
 F405_TARGETS += $(TARGET)
 
-# Use a full block (16 kB) of flash for custom defaults - with 1 MB flash we have more than we know how to use anyway
-
-CUSTOM_DEFAULTS_EXTENDED = yes
-
 else
 ifeq ($(TARGET), STM32F411)
 F411_TARGETS += $(TARGET)
@@ -19,6 +15,13 @@ F7X5XG_TARGETS += $(TARGET)
 endif
 endif
 endif
+
+ifeq ($(TARGET), $(filter $(TARGET), STM32F405 STM32F745))
+# Use a full block (16 kB) of flash for custom defaults - with 1 MB flash we have more than we know how to use anyway
+
+CUSTOM_DEFAULTS_EXTENDED = yes
+endif
+
 
 FEATURES       += VCP SDCARD_SPI SDCARD_SDIO ONBOARDFLASH
 


### PR DESCRIPTION
Rationale: Makes it easier to debug with STM32F745 targets. Currently there is a lot of unused flash on this target, so we may as well use it to make debugging easier (i.e. flashing with `make STM32F745_flash` without losing custom defaults).

Before:

```
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B        22 KB      0.04%
AXIM_FLASH_CONFIG:          0 GB        32 KB      0.00%
     AXIM_FLASH1:      503864 B       960 KB     51.26%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB      -nan%
```

After:

```
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B        22 KB      0.04%
AXIM_FLASH_CONFIG:          0 GB        32 KB      0.00%
     AXIM_FLASH1:      503864 B       928 KB     53.02%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB        32 KB      0.00%
```