### PR TITLE
Fixed pin id parsing in CLI.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5201,24 +5201,27 @@ static void resourceCheck(uint8_t resourceIndex, uint8_t index, ioTag_t newTag)
     }
 }
 
-static bool strToPin(char *pch, ioTag_t *tag)
+static bool strToPin(char *ptr, ioTag_t *tag)
 {
-    if (strcasecmp(pch, "NONE") == 0) {
+    if (strcasecmp(ptr, "NONE") == 0) {
         *tag = IO_TAG_NONE;
+
         return true;
     } else {
-        unsigned pin = 0;
-        unsigned port = (*pch >= 'a') ? *pch - 'a' : *pch - 'A';
-
+        const unsigned port = (*ptr >= 'a') ? *ptr - 'a' : *ptr - 'A';
         if (port < 8) {
-            pch++;
-            pin = atoi(pch);
-            if (pin < 16) {
+            ptr++;
+
+            char *end;
+            const long pin = strtol(ptr, &end, 10);
+            if (end != ptr && pin >= 0 && pin < 16) {
                 *tag = DEFIO_TAG_MAKE(port, pin);
+
                 return true;
             }
         }
     }
+
     return false;
 }
 


### PR DESCRIPTION
Fixes this behaviour:

```
# resource motor 5 free

Resource is set to F00
```

After:

```
# resource motor 5 free
###ERROR: resource: PARSING FAILED###

# resource motor 5 f0

Resource is set to F00

# resource motor 5 f1

Resource is set to F01

# resource motor 5 f+1

Resource is set to F01

# resource motor 5 f-0

Resource is set to F00

# resource motor 5 f-1
###ERROR: resource: PARSING FAILED###
```

There are about 50 more cases of use of `atoi()` in `cli.c`, most of them probably problematic due to `atoi()` defaulting to return `0` if no number at all is found. This, and probably a more appropriate error message for out of bounds pin indexes, should be done for 4.3.