### PR TITLE
Fixed parsing of over length custom default headers.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -228,12 +228,15 @@ static char cliBufferTemp[CLI_IN_BUFFER_SIZE];
 #define CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX ", version: "
 #define CUSTOM_DEFAULTS_DATE_PREFIX ", date: "
 
+#define MAX_CHANGESET_ID_LENGTH 8
+#define MAX_DATE_LENGTH 20
+
 static bool customDefaultsHeaderParsed = false;
 static bool customDefaultsFound = false;
 static char customDefaultsManufacturerId[MAX_MANUFACTURER_ID_LENGTH + 1] = { 0 };
 static char customDefaultsBoardName[MAX_BOARD_NAME_LENGTH + 1] = { 0 };
-static char customDefaultsChangesetId[9] = { 0 };
-static char customDefaultsDate[21] = { 0 };
+static char customDefaultsChangesetId[MAX_CHANGESET_ID_LENGTH + 1] = { 0 };
+static char customDefaultsDate[MAX_DATE_LENGTH + 1] = { 0 };
 #endif
 
 #if defined(USE_CUSTOM_DEFAULTS_ADDRESS)
@@ -4252,7 +4255,7 @@ static bool customDefaultsHasNext(const char *customDefaultsPtr)
     return *customDefaultsPtr && *customDefaultsPtr != 0xFF && customDefaultsPtr < customDefaultsEnd;
 }
 
-static const char *parseCustomDefaultsHeaderElement(char *dest, const char *customDefaultsPtr, const char *prefix, char terminator)
+static const char *parseCustomDefaultsHeaderElement(char *dest, const char *customDefaultsPtr, const char *prefix, const char terminator, const unsigned maxLength)
 {
     char *endPtr = NULL;
     unsigned len = strlen(prefix);
@@ -4263,7 +4266,7 @@ static const char *parseCustomDefaultsHeaderElement(char *dest, const char *cust
 
     if (endPtr && customDefaultsHasNext(endPtr)) {
         len = endPtr - customDefaultsPtr;
-        memcpy(dest, customDefaultsPtr, len);
+        memcpy(dest, customDefaultsPtr, MIN(len, maxLength));
 
         customDefaultsPtr += len;
 
@@ -4284,13 +4287,13 @@ static void parseCustomDefaultsHeader(void)
             customDefaultsPtr++;
         }
 
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsManufacturerId, customDefaultsPtr, CUSTOM_DEFAULTS_MANUFACTURER_ID_PREFIX, CUSTOM_DEFAULTS_BOARD_NAME_PREFIX[0]);
+        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsManufacturerId, customDefaultsPtr, CUSTOM_DEFAULTS_MANUFACTURER_ID_PREFIX, CUSTOM_DEFAULTS_BOARD_NAME_PREFIX[0], MAX_MANUFACTURER_ID_LENGTH);
 
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsBoardName, customDefaultsPtr, CUSTOM_DEFAULTS_BOARD_NAME_PREFIX, CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX[0]);
+        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsBoardName, customDefaultsPtr, CUSTOM_DEFAULTS_BOARD_NAME_PREFIX, CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX[0], MAX_BOARD_NAME_LENGTH);
 
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsChangesetId, customDefaultsPtr, CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX, CUSTOM_DEFAULTS_DATE_PREFIX[0]);
+        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsChangesetId, customDefaultsPtr, CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX, CUSTOM_DEFAULTS_DATE_PREFIX[0], MAX_CHANGESET_ID_LENGTH);
 
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsDate, customDefaultsPtr, CUSTOM_DEFAULTS_DATE_PREFIX, '\n');
+        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsDate, customDefaultsPtr, CUSTOM_DEFAULTS_DATE_PREFIX, '\n', MAX_DATE_LENGTH);
     }
 
     customDefaultsHeaderParsed = true;


### PR DESCRIPTION
```
# defaults show
# Betaflight / STM32F745 (S745) 4.2.0 Feb  2 2020 / 16:59:28 (norevision) MSP API: 1.43
# config: manufacturer_id: UNKN, board_name: AIRB-OMNIBUSF7.config, version: unknown, date: 2020-04-06T04:26:30.196Z
```

yields

```
# diff

# version
# Betaflight / STM32F745 (S745) 4.2.0 Jun  1 2020 / 23:03:58 (norevision) MSP API: 1.43
# config: manufacturer_id: UNKN, board_name: AIRB-OMNIBUSF7.confi, version: unknown, date: 2020-04-06T04:26:30.
```
