### PR TITLE
Added cell voltage in summary at end of flight

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1396,6 +1396,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
     { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
     { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
+    { "osd_stat_show_cell_value",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, stat_show_cell_value) },
 #endif // end of #ifdef USE_OSD
 
 // PG_SYSTEM_CONFIG

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -288,6 +288,7 @@ typedef struct osdConfig_s {
     uint8_t logo_on_arming_duration;          // display duration in 0.1s units
     uint8_t camera_frame_width;               // The width of the box for the camera frame element
     uint8_t camera_frame_height;              // The height of the box for the camera frame element
+    bool stat_show_cell_value;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
According to issue [#9858](https://github.com/betaflight/betaflight/issues/9858).
After-flight stats for a cell instead of the stats of a whole battery are more appropriate for some users (including me :) ).
Here is feature to enable it. All the user needs is to enable this flag: `osd_stat_show_cell_value = ON`, and stats are displayed as in the screen in the attachment. The default is OFF, and shows up values as before this edit. 

![cli](https://user-images.githubusercontent.com/7397515/83427618-4cf99800-a431-11ea-9cd9-36180681a9db.PNG)
![PICT0012](https://user-images.githubusercontent.com/7397515/83427620-4cf99800-a431-11ea-9a19-281e8dd5925b.JPG)
