### PR TITLE
Added option to show cell value instead of batt value at stats screen

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1476,6 +1476,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
     { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
     { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
+    { "osd_stat_avg_cell_value",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, stat_show_cell_value) },
     { "osd_task_frequency",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { OSD_TASK_FREQUENCY_MIN, OSD_TASK_FREQUENCY_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, task_frequency) },
     { "osd_menu_background",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CMS_BACKGROUND }, PG_OSD_CONFIG, offsetof(osdConfig_t, cms_background_type) },
 #endif // end of #ifdef USE_OSD

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -301,6 +301,7 @@ typedef struct osdConfig_s {
     uint8_t camera_frame_height;              // The height of the box for the camera frame element
     uint16_t task_frequency;
     uint8_t cms_background_type;              // For supporting devices, determines whether the CMS background is transparent or opaque
+    uint8_t stat_show_cell_value;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
According to issue [#9858](https://github.com/betaflight/betaflight/issues/9858).
After-flight stats for a cell instead of the stats of a whole battery are more appropriate for some users (including me :).
Here is the feature to enable it. All the user needs is to enable this flag:
`osd_stat_avg_cell_value = ON`

Fixes: #9858

| `Variable`                                    | Description/Units                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Min    | Max    | Default          | Type         | Datatype |
|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|--------|------------------|--------------|----------|
|`osd_stat_avg_cell_value`|At the 'Stats' screen, this option enables a voltage display of average cell value (new feature) rather than the total battery voltage value.|OFF|ON|OFF|Master|UINT8

![image](https://user-images.githubusercontent.com/7397515/108131546-bdc10d00-70b1-11eb-89ed-41e9044882bd.png)

For the test, download appropriate firmware  from here:
[betaflight_4.3.0_STM32F7X2_f1bad4fa6.zip](https://github.com/betaflight/betaflight/files/5992080/betaflight_4.3.0_STM32F7X2_f1bad4fa6.zip)
[betaflight_4.3.0_STM32F405_f1bad4fa6.zip](https://github.com/betaflight/betaflight/files/5992082/betaflight_4.3.0_STM32F405_f1bad4fa6.zip)
[betaflight_4.3.0_STM32F411_f1bad4fa6.zip](https://github.com/betaflight/betaflight/files/5992083/betaflight_4.3.0_STM32F411_f1bad4fa6.zip)
[betaflight_4.3.0_STM32F745_f1bad4fa6.zip](https://github.com/betaflight/betaflight/files/5992084/betaflight_4.3.0_STM32F745_f1bad4fa6.zip)


... and follow installation instructions from here: https://youtu.be/I1uN9CN30gw