### PR TITLE
Fixed modes missing on startup.

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3596,4 +3596,5 @@ void mspFcProcessReply(mspPacket_t *reply)
 
 void mspInit(void)
 {
+    initActiveBoxIds();
 }


### PR DESCRIPTION
Fixes #9883.

This is fallout from #9875. The problem is that `initActiveBoxIds()` was run too early during startup before the sensors were detected. Reinstating `initActiveBoxIds()` in `mspInit()` to fix this.