### PR TITLE
Removed broken 'srec' build target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,6 @@ TARGET_BASENAME = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET)_$(REVISION)
 #
 # Things we will build
 #
-TARGET_S19      = $(TARGET_BASENAME).s19
 TARGET_BIN      = $(TARGET_BASENAME).bin
 TARGET_HEX      = $(TARGET_BASENAME).hex
 TARGET_DFU      = $(TARGET_BASENAME).dfu
@@ -336,11 +335,6 @@ $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
 $(TARGET_LST): $(TARGET_ELF)
 	$(V0) $(OBJDUMP) -S --disassemble $< > $@
-
-
-$(TARGET_S19): $(TARGET_ELF)
-	@echo "Creating srec/S19 $(TARGET_S19)" "$(STDOUT)"
-	$(V1) $(OBJCOPY) --output-target=srec $(TARGET_S19)
 
 ifeq ($(EXST),no)
 $(TARGET_BIN): $(TARGET_ELF)
@@ -562,9 +556,6 @@ zip:
 
 binary:
 	$(V0) $(MAKE) -j $(TARGET_BIN)
-
-srec:
-	$(V0) $(MAKE) -j $(TARGET_S19)
 
 hex:
 	$(V0) $(MAKE) -j $(TARGET_HEX)


### PR DESCRIPTION
Apparently this is not used, as it has been broken for almost 2 years and was not noticed.