### PR TITLE
MAX7456: Support delayed initialization

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -450,7 +450,7 @@ void max7456PreInit(const max7456Config_t *max7456Config)
 // Here we init only CS and try to init MAX for first time.
 // Also detect device type (MAX v.s. AT)
 
-bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdProfile, bool cpuOverclock)
+max7456InitStatus_e max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdProfile, bool cpuOverclock)
 {
     max7456DeviceDetected = false;
 
@@ -462,13 +462,13 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     max7456HardwareReset();
 
     if (!max7456Config->csTag || !max7456Config->spiDevice) {
-        return false;
+        return MAX7456_INIT_NOT_CONFIGURED;
     }
 
     busdev->busdev_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
 
     if (!IOIsFreeOrPreinit(busdev->busdev_u.spi.csnPin)) {
-        return false;
+        return MAX7456_INIT_NOT_CONFIGURED;
     }
 
     IOInit(busdev->busdev_u.spi.csnPin, OWNER_OSD_CS, 0);
@@ -492,7 +492,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
 
     if (osdm != 0x1B) {
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_IPU);
-        return false;
+        return MAX7456_INIT_NOT_FOUND;
     }
 
     // At this point, we can claim the ownership of the CS pin
@@ -560,7 +560,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
 #endif
 
     // Real init will be made later when driver detect idle.
-    return true;
+    return MAX7456_INIT_OK;
 }
 
 /**

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "drivers/display.h"
 
 /** PAL or NTSC, value is number of chars total */
@@ -28,12 +30,23 @@
 #define VIDEO_LINES_NTSC          13
 #define VIDEO_LINES_PAL           16
 
+typedef enum {
+    // IO defined and MAX7456 was detected
+    MAX7456_INIT_OK = 0,
+    // IO defined, but MAX7456 could not be detected (maybe not yet
+    // powered on)
+    MAX7456_INIT_NOT_FOUND = -1,
+    // No MAX7456 IO defined, which means either the we don't have it or
+    // it's not properly configured
+    MAX7456_INIT_NOT_CONFIGURED = -2,
+} max7456InitStatus_e;
+
 extern uint16_t maxScreenSize;
 struct vcdProfile_s;
 void    max7456HardwareReset(void);
 struct max7456Config_s;
 void    max7456PreInit(const struct max7456Config_s *max7456Config);
-bool    max7456Init(const struct max7456Config_s *max7456Config, const struct vcdProfile_s *vcdProfile, bool cpuOverclock);
+max7456InitStatus_e max7456Init(const struct max7456Config_s *max7456Config, const struct vcdProfile_s *vcdProfile, bool cpuOverclock);
 void    max7456Invert(bool invert);
 void    max7456Brightness(uint8_t black, uint8_t white);
 void    max7456DrawScreen(void);


### PR DESCRIPTION
MAX7456: Support delayed initialization
    
This allows the init sequence to correctly determine and store that
the selected display device after autoselection was MAX7456 but it
hasn't been yet initialized, and allows us to properly transmit this
information to the configurator.
    
This also lets the display subsystem initialize the MAX7456 at any
time, so for example in flight controllers that require battery power
in order to turn on the MAX7456, the user can plug the battery after
powering the system up via USB and the MAX7456 will be detected shortly
after without having to reboot.