### PR TITLE
OSD: Move crosshair to active elements and not background

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -702,7 +702,7 @@ static void osdElementCrashFlipArrow(osdElementParms_t *element)
 }
 #endif // USE_ACC
 
-static void osdBackgroundCrosshairs(osdElementParms_t *element)
+static void osdElementCrosshairs(osdElementParms_t *element)
 {
     element->buff[0] = SYM_AH_CENTER_LINE;
     element->buff[1] = SYM_AH_CENTER;
@@ -1619,7 +1619,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
     [OSD_CAMERA_FRAME]            = NULL,  // only has background. Added first so it's the lowest "layer" and doesn't cover other elements
     [OSD_RSSI_VALUE]              = osdElementRssi,
     [OSD_MAIN_BATT_VOLTAGE]       = osdElementMainBatteryVoltage,
-    [OSD_CROSSHAIRS]              = NULL,  // only has background
+    [OSD_CROSSHAIRS]              = osdElementCrosshairs,  // only has background, but needs to be over other elements (like artificial horizon)
 #ifdef USE_ACC
     [OSD_ARTIFICIAL_HORIZON]      = osdElementArtificialHorizon,
 #endif
@@ -1728,7 +1728,6 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 
 const osdElementDrawFn osdElementBackgroundFunction[OSD_ITEM_COUNT] = {
     [OSD_CAMERA_FRAME]            = osdBackgroundCameraFrame,
-    [OSD_CROSSHAIRS]              = osdBackgroundCrosshairs,
     [OSD_HORIZON_SIDEBARS]        = osdBackgroundHorizonSidebars,
     [OSD_CRAFT_NAME]              = osdBackgroundCraftName,
 #ifdef USE_OSD_STICK_OVERLAY


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/9940

Moves the crosshair to "active" element and not "background" element. Maybe is not the better solution, but is an easy fix. I don't know if @etracer65 have a better solution for this.

~~*I have not tested it. At this moment I don't have any FC available for testing that.*~~ Tested and it works. If someone wants to help testing and confirm the solution, here you have the hex:

[betaflight_4.3.0_STM32F7X2_10a67e3a1a.zip](https://github.com/betaflight/betaflight/files/4831064/betaflight_4.3.0_STM32F7X2_10a67e3a1a.zip)
[betaflight_4.3.0_STM32F405_10a67e3a1a.zip](https://github.com/betaflight/betaflight/files/4831065/betaflight_4.3.0_STM32F405_10a67e3a1a.zip)
[betaflight_4.3.0_STM32F411_10a67e3a1a.zip](https://github.com/betaflight/betaflight/files/4831066/betaflight_4.3.0_STM32F411_10a67e3a1a.zip)
[betaflight_4.3.0_STM32F745_10a67e3a1a.zip](https://github.com/betaflight/betaflight/files/4831067/betaflight_4.3.0_STM32F745_10a67e3a1a.zip)

Installation instructions: https://youtu.be/I1uN9CN30gw