### PR TITLE
Fix baroCalculateAltitude

### DIFF
--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -428,14 +428,18 @@ uint32_t baroUpdate(void)
     return sleepTime;
 }
 
+static float pressureToAltitude(const float pressure)
+{
+    return (1.0f - powf(pressure / 101325.0f, 0.190295f)) * 4433000.0f;
+}
+
 int32_t baroCalculateAltitude(void)
 {
     int32_t BaroAlt_tmp;
 
     // calculates height from ground via baro readings
-    // see: https://github.com/diydrones/ardupilot/blob/master/libraries/AP_Baro/AP_Baro.cpp#L140
     if (baroIsCalibrationComplete()) {
-        BaroAlt_tmp = lrintf((1.0f - pow_approx((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT) / 101325.0f, 0.190259f)) * 4433000.0f); // in cm
+        BaroAlt_tmp = lrintf(pressureToAltitude((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT)));
         BaroAlt_tmp -= baroGroundAltitude;
         baro.BaroAlt = lrintf((float)baro.BaroAlt * CONVERT_PARAMETER_TO_FLOAT(barometerConfig()->baro_noise_lpf) + (float)BaroAlt_tmp * (1.0f - CONVERT_PARAMETER_TO_FLOAT(barometerConfig()->baro_noise_lpf))); // additional LPF to reduce baro noise
     }


### PR DESCRIPTION
`baroCalculateAltitude` is fixed to compute the correct (expected) altitude.

The original `baroCalculateAltitude` was broken in that there is a round up somewhere which caused changes less than 4 on input are ignored (or at least it looks like it at sea level pressure input), and results were bit lower than it should be.

E.g.
```
{{pressurePa = 101325, altitudeCm = 0},
{pressurePa = 101324, altitudeCm = 0},
{pressurePa = 101323, altitudeCm = 0},
{pressurePa = 101322, altitudeCm = 23},
{pressurePa = 101321, altitudeCm = 23},
{pressurePa = 101320, altitudeCm = 23},
{pressurePa = 101319, altitudeCm = 47},
{pressurePa = 101318, altitudeCm = 47},
{pressurePa = 101317, altitudeCm = 47},
{pressurePa = 101316, altitudeCm = 70}}
```

The core computation was replaced by `pressureToAltitude` taken from iNav, to produce the correct result.
```
{{pressurePa = 101325, altitudeCm = 0},
{pressurePa = 101324, altitudeCm = 8},
{pressurePa = 101323, altitudeCm = 16},
{pressurePa = 101322, altitudeCm = 25},
{pressurePa = 101321, altitudeCm = 33},
{pressurePa = 101320, altitudeCm = 41},
{pressurePa = 101319, altitudeCm = 49},
{pressurePa = 101318, altitudeCm = 58},
{pressurePa = 101317, altitudeCm = 66},
{pressurePa = 101316, altitudeCm = 75}}
```