### PR TITLE
Refresh OSD background after MSP change to craft name

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3250,6 +3250,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         for (unsigned int i = 0; i < MIN(MAX_NAME_LENGTH, dataSize); i++) {
             pilotConfigMutable()->name[i] = sbufReadU8(src);
         }
+#ifdef USE_OSD
+        osdAnalyzeActiveElements();
+#endif
         break;
 
 #ifdef USE_RTC_TIME


### PR DESCRIPTION
Fixes #9954 (even though that's using the field in an unintended way)

The OSD element "Craft name" is part of the OSD background so it's normally only rendered once. However that field can technically be updated at runtime using `MSP_SET_NAME`. Re-render the background as a result of this MSP command.

Reenables previously unexpected use of the Craft name field as a way to display updated data via Lua MSP messaging (see #9954).