### PR TITLE
Fixed disabling of OSD feature when OSD is disabled.

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -984,6 +984,10 @@ void init(void)
 
         // osdInit will register with CMS by itself.
         osdInit(osdDisplayPort, osdDisplayPortDevice);
+
+        if (osdDisplayPortDevice == OSD_DISPLAYPORT_DEVICE_NONE) {
+            featureDisableImmediate(FEATURE_OSD);
+        }
     }
 #endif // USE_OSD
 


### PR DESCRIPTION
If OSD output is disabled with `osd_displayport_device = none`, disable the OSD feature.