### PR TITLE
refactor Thrust Linear to initialise throttleCompensateAmount in pid_…

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -295,7 +295,7 @@ float pidCompensateThrustLinearization(float throttle)
     if (pidRuntime.thrustLinearization != 0.0f) {
         // for whoops where a lot of TL is needed, allow more throttle boost
         const float throttleReversed = (1.0f - throttle);
-        throttle /= 1.0f + pidRuntime.throttleCompensateAmount * powerf(throttleReversed, 2) * pidRuntime.thrustLinearization;
+        throttle /= 1.0f + pidRuntime.throttleCompensateAmount * powerf(throttleReversed, 2);
     }
     return throttle;
 }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -294,9 +294,8 @@ float pidCompensateThrustLinearization(float throttle)
 {
     if (pidRuntime.thrustLinearization != 0.0f) {
         // for whoops where a lot of TL is needed, allow more throttle boost
-        const float throttleCompensateAmount = (1.0f - 0.5f * pidRuntime.thrustLinearization);
         const float throttleReversed = (1.0f - throttle);
-        throttle /= 1.0f + throttleCompensateAmount * powerf(throttleReversed, 2) * pidRuntime.thrustLinearization;
+        throttle /= 1.0f + pidRuntime.throttleCompensateAmount * powerf(throttleReversed, 2) * pidRuntime.thrustLinearization;
     }
     return throttle;
 }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -351,6 +351,7 @@ typedef struct pidRuntime_s {
 
 #ifdef USE_THRUST_LINEARIZATION
     float thrustLinearization;
+    float throttleCompensateAmount;
 #endif
 
 #ifdef USE_AIRMODE_LPF

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -375,6 +375,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
 #ifdef USE_THRUST_LINEARIZATION
     pidRuntime.thrustLinearization = pidProfile->thrustLinearization / 100.0f;
+    pidRuntime.throttleCompensateAmount = (1.0f - 0.5f * pidRuntime.thrustLinearization);
 #endif
 #if defined(USE_D_MIN)
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -375,7 +375,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
 #ifdef USE_THRUST_LINEARIZATION
     pidRuntime.thrustLinearization = pidProfile->thrustLinearization / 100.0f;
-    pidRuntime.throttleCompensateAmount = (1.0f - 0.5f * pidRuntime.thrustLinearization);
+    pidRuntime.throttleCompensateAmount = pidRuntime.thrustLinearization - 0.5f * powerf(pidRuntime.thrustLinearization, 2);
 #endif
 #if defined(USE_D_MIN)
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {


### PR DESCRIPTION
Maybe this could avoid recaculating throttleCompensateAmount every PID loop?
