### PR TITLE
Added registration for bus devices.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -61,6 +61,7 @@ bool cliMode = false;
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/adc.h"
 #include "drivers/buf_writer.h"
+#include "drivers/bus_i2c.h"
 #include "drivers/bus_spi.h"
 #include "drivers/dma.h"
 #include "drivers/dma_reqmap.h"
@@ -4705,6 +4706,21 @@ static void cliStatus(const char *cmdName, char *cmdline)
     cliPrintLinefeed();
 
     cliPrintLinef("Configuration: %s, size: %d, max available: %d", configurationStates[systemConfigMutable()->configurationState], getEEPROMConfigSize(), getEEPROMStorageSize());
+
+    // Devices
+#if defined(USE_SPI) || defined(USE_I2C)
+    cliPrint("Devices detected:");
+#if defined(USE_SPI)
+    cliPrintf(" SPI:%d", spiGetRegisteredDeviceCount());
+#if defined(USE_I2C)
+    cliPrint(",");
+#endif
+#endif
+#if defined(USE_I2C)
+    cliPrintf(" I2C:%d", i2cGetRegisteredDeviceCount());
+#endif
+    cliPrintLinefeed();
+#endif
 
     // Sensors
     cliPrint("Gyros detected:");

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -255,6 +255,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const gyro
         sensor = (gyroSpiDetectFnTable[index])(&gyro->bus);
         if (sensor != MPU_NONE) {
             gyro->mpuDetectionResult.sensor = sensor;
+            busDeviceRegister(&gyro->bus);
 
             return true;
         }
@@ -301,6 +302,7 @@ bool mpuDetect(gyroDev_t *gyro, const gyroDeviceConfig_t *config)
         bool ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_WHO_AM_I, &sig, 1);
 
         if (ack) {
+            busDeviceRegister(&gyro->bus);
             // If an MPU3050 is connected sig will contain 0.
             uint8_t inquiryResult;
             ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_WHO_AM_I_LEGACY, &inquiryResult, 1);

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -154,8 +154,9 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro)
     bool ack;
     bool defaultAddressApplied = false;
 
-    if (bmp085InitDone)
+    if (bmp085InitDone) {
         return true;
+    }
 
     bmp085InitXclrIO(config);
     BMP085_ON;   // enable baro
@@ -188,6 +189,8 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro)
         bmp085.oversampling_setting = 3;
 
         if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
+            busDeviceRegister(busdev);
+
             busReadRegisterBuffer(busdev, BMP085_VERSION_REG, &data, 1); /* read Version reg */
             bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
             bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -171,6 +171,8 @@ bool bmp280Detect(baroDev_t *baro)
         return false;
     }
 
+    busDeviceRegister(busdev);
+
     // read calibration
     busReadRegisterBuffer(busdev, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, (uint8_t *)&bmp280_cal, sizeof(bmp280_calib_param_t));
 

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -263,6 +263,8 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
         return false;
     }
 
+    busDeviceRegister(busdev);
+
 #ifdef USE_EXTI
     if (baroIntIO) {
         uint8_t intCtrlValue = 1 << BMP388_INT_DRDY_EN_BIT |

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -373,6 +373,8 @@ bool baroDPS310Detect(baroDev_t *baro)
         return false;
     }
 
+    busDeviceRegister(busdev);
+
     const uint32_t baroDelay = 1000000 / 32 / 2;      // twice the sample rate to capture all new data
 
     baro->ut_delay = 0;

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -258,6 +258,8 @@ bool ms5611Detect(baroDev_t *baro)
         goto fail;
     }
 
+    busDeviceRegister(busdev);
+
     // TODO prom + CRC
     baro->ut_delay = 10000;
     baro->up_delay = 10000;

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -173,6 +173,8 @@ bool qmp6988Detect(baroDev_t *baro)
         return false;
     }
 
+    busDeviceRegister(busdev);
+
     // SetIIR
     busWriteRegister(busdev, QMP6988_SET_IIR_REG, 0x05);
 

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -227,3 +227,27 @@ uint8_t busReadRegister(const busDevice_t *busdev, uint8_t reg)
     return data;
 #endif
 }
+
+void busDeviceRegister(const busDevice_t *busdev)
+{
+#if !defined(USE_SPI) && !defined(USE_I2C)
+    UNUSED(busdev);
+#endif
+
+    switch (busdev->bustype) {
+#if defined(USE_SPI)
+    case BUSTYPE_SPI:
+        spiBusDeviceRegister(busdev);
+
+        break;
+#endif
+#if defined(USE_I2C)
+    case BUSTYPE_I2C:
+        i2cBusDeviceRegister(busdev);
+
+        break;
+#endif
+    default:
+        break;
+    }
+}

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -75,3 +75,4 @@ uint8_t busReadRegister(const busDevice_t *bus, uint8_t reg);
 bool busRawReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 bool busReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 bool busBusy(const busDevice_t *busdev, bool *error);
+void busDeviceRegister(const busDevice_t *busdev);

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -65,3 +65,4 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
 bool i2cBusy(I2CDevice device, bool *error);
 
 uint16_t i2cGetErrorCounter(void);
+uint8_t i2cGetRegisteredDeviceCount(void);

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -29,6 +29,8 @@
 #include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 
+static uint8_t i2cRegisteredDeviceCount = 0;
+
 bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data)
 {
     return i2cWrite(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, data);
@@ -66,4 +68,15 @@ bool i2cBusBusy(const busDevice_t *busdev, bool *error)
     return i2cBusy(busdev->busdev_u.i2c.device, error);
 }
 
+void i2cBusDeviceRegister(const busDevice_t *busdev)
+{
+    UNUSED(busdev);
+
+    i2cRegisteredDeviceCount++;
+}
+
+uint8_t i2cGetRegisteredDeviceCount(void)
+{
+    return i2cRegisteredDeviceCount;
+}
 #endif

--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -26,3 +26,4 @@ bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *d
 uint8_t i2cBusReadRegister(const busDevice_t *bus, uint8_t reg);
 bool i2cBusReadRegisterBufferStart(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
 bool i2cBusBusy(const busDevice_t *busdev, bool *error);
+void i2cBusDeviceRegister(const busDevice_t *busdev);

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -33,6 +33,8 @@
 #include "drivers/io.h"
 #include "drivers/rcc.h"
 
+static uint8_t spiRegisteredDeviceCount = 0;
+
 spiDevice_t spiDevice[SPIDEV_COUNT];
 
 SPIDevice spiDeviceByInstance(SPI_TypeDef *instance)
@@ -282,4 +284,16 @@ bool spiBusTransactionReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, ui
     return spiBusReadRegisterBuffer(bus, reg, data, length);
 }
 #endif // USE_SPI_TRANSACTION
+
+void spiBusDeviceRegister(const busDevice_t *bus)
+{
+    UNUSED(bus);
+
+    spiRegisteredDeviceCount++;
+}
+
+uint8_t spiGetRegisteredDeviceCount(void)
+{
+    return spiRegisteredDeviceCount;
+}
 #endif

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -177,3 +177,5 @@ bool spiBusTransactionTransfer(const busDevice_t *bus, const uint8_t *txData, ui
 
 struct spiPinConfig_s;
 void spiPinConfigure(const struct spiPinConfig_s *pConfig);
+void spiBusDeviceRegister(const busDevice_t *bus);
+uint8_t spiGetRegisteredDeviceCount(void);

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -347,6 +347,8 @@ static bool ak8963Init(magDev_t *mag)
 
     const busDevice_t *busdev = &mag->busdev;
 
+    busDeviceRegister(busdev);
+
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down before entering fuse mode
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_FUSE_ROM);                 // Enter Fuse ROM access mode
     ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ASAX, asa, sizeof(asa));                // Read the x-, y-, and z-axis calibration values

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -79,6 +79,8 @@
 
 static bool ak8975Init(magDev_t *mag)
 {
+    busDeviceRegister(busdev);
+
     uint8_t asa[3];
     uint8_t status;
 
@@ -163,8 +165,9 @@ bool ak8975Detect(magDev_t *mag)
 
     bool ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_WIA, &sig, 1);
 
-    if (!ack || sig != AK8975_DEVICE_ID) // 0x48 / 01001000 / 'H'
+    if (!ack || sig != AK8975_DEVICE_ID) { // 0x48 / 01001000 / 'H'
         return false;
+    }
 
     mag->init = ak8975Init;
     mag->read = ak8975Read;

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -185,6 +185,8 @@ static void hmc5883lConfigureDataReadyInterruptHandling(magDev_t* mag)
 #ifdef USE_MAG_SPI_HMC5883
 static void hmc5883SpiInit(busDevice_t *busdev)
 {
+    busDeviceRegister(busdev);
+
     IOHi(busdev->busdev_u.spi.csnPin); // Disable
 
     IOInit(busdev->busdev_u.spi.csnPin, OWNER_COMPASS_CS, 0);
@@ -221,7 +223,6 @@ static bool hmc5883lInit(magDev_t *mag)
 {
 
     busDevice_t *busdev = &mag->busdev;
-
 
     // leave test mode
     busWriteRegister(busdev, HMC58X3_REG_CONFA, HMC_CONFA_8_SAMLES | HMC_CONFA_DOR_15HZ | HMC_CONFA_NORMAL);    // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -124,6 +124,8 @@ static bool lis3mdlInit(magDev_t *mag)
 {
     busDevice_t *busdev = &mag->busdev;
 
+    busDeviceRegister(busdev);
+
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG2, LIS3MDL_FS_4GAUSS);
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG1, LIS3MDL_TEMP_EN | LIS3MDL_OM_ULTRA_HI_PROF | LIS3MDL_DO_80);
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG5, LIS3MDL_BDU);

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -79,6 +79,8 @@ static bool qmc5883lInit(magDev_t *magDev)
     bool ack = true;
     busDevice_t *busdev = &magDev->busdev;
 
+    busDeviceRegister(busdev);
+
     ack = ack && busWriteRegister(busdev, 0x0B, 0x01);
     ack = ack && busWriteRegister(busdev, QMC5883L_REG_CONF1, QMC5883L_MODE_CONTINUOUS | QMC5883L_ODR_200HZ | QMC5883L_OSR_512 | QMC5883L_RNG_8G);
 

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -168,6 +168,4 @@ ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index)
 #endif
     return IO_TAG_NONE;
 }
-
 #endif
-

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -50,6 +50,7 @@
 
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/bus_i2c.h"
+#include "drivers/bus_spi.h"
 #include "drivers/camera_control.h"
 #include "drivers/compass/compass.h"
 #include "drivers/display.h"
@@ -685,6 +686,18 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         }
 
         sbufWriteU32(dst, configurationProblems);
+
+        // Added in MSP API 1.44
+#if defined(USE_SPI)
+        sbufWriteU8(dst, spiGetRegisteredDeviceCount());
+#else
+        sbufWriteU8(dst, 0);
+#endif
+#if defined(USE_I2C)
+        sbufWriteU8(dst, i2cGetRegisteredDeviceCount());
+#else
+        sbufWriteU8(dst, 0);
+#endif
 
         break;
     }

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -152,6 +152,7 @@ bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {retu
 bool busReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
 bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
 bool busWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
+void busDeviceRegister(const busDevice_t*) {}
 
 void spiBusSetDivisor() {
 }

--- a/src/test/unit/baro_bmp388_unittest.cc
+++ b/src/test/unit/baro_bmp388_unittest.cc
@@ -148,6 +148,7 @@ bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {retu
 bool busReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
 bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
 bool busWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
+void busDeviceRegister(const busDevice_t*) {}
 
 void spiBusSetDivisor() {
 }

--- a/src/test/unit/baro_ms5611_unittest.cc
+++ b/src/test/unit/baro_ms5611_unittest.cc
@@ -151,6 +151,7 @@ bool busRawReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {r
 bool busRawReadRegisterBufferStart(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
 bool busRawWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
 bool busRawWriteRegisterStart(const busDevice_t*, uint8_t, uint8_t) {return true;}
+void busDeviceRegister(const busDevice_t*) {}
 
 void spiBusSetDivisor() {
 }


### PR DESCRIPTION
The main purpose of this is to enable configurator to check if there are any I2C bus devices detected, and if not hide the 'I2C errors: <x>' display - users are getting confused by this and are opening issues about it.

![image](https://user-images.githubusercontent.com/4742747/86857545-d9733680-c112-11ea-845d-30a64c24bb1a.png)
