### PR TITLE
Ignore GPS arming disabled when arming in crash flip mode

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -344,7 +344,7 @@ void updateArmingStatus(void)
 
 #ifdef USE_GPS_RESCUE
         if (gpsRescueIsConfigured()) {
-            if (gpsRescueConfig()->allowArmingWithoutFix || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED)) {
+            if (gpsRescueConfig()->allowArmingWithoutFix || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED) || IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {
                 setArmingDisabled(ARMING_DISABLED_GPS);


### PR DESCRIPTION
While craft is upside down the GPS receiver may not be able to maintain a fix. As a result the `ARMING_DISABLED_GPS` reason could prevent arming in crash-flip mode preventing the user from flipping back over.
