### PR TITLE
Prevent crash flip from setting WAS_EVER_ARMED arming flag

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -433,7 +433,9 @@ void updateArmingStatus(void)
 void disarm(flightLogDisarmReason_e reason)
 {
     if (ARMING_FLAG(ARMED)) {
-        ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+        if (!flipOverAfterCrashActive) {
+            ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+        }
         DISABLE_ARMING_FLAG(ARMED);
         lastDisarmTimeUs = micros();
 


### PR DESCRIPTION
Previously if the first "arming" was in crash-flip mode then the various features that rely on "first arming" logic would be defeated. While arming in crash-flip mode is technically "arming", it shouldn't disable features that rely on the first "real" arming. For example, vtx low-power disarm, GPS fix arming disabled, `BATT < FULL` warning, etc.
