### PR TITLE
MSP: Change MSP_VOLTAGE_METERS info.

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -758,7 +758,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
             voltageMeterRead(id, &meter);
 
             sbufWriteU8(dst, id);
-            sbufWriteU8(dst, (uint8_t)constrain((meter.displayFiltered + 5) / 10, 0, 255));
+            sbufWriteU16(dst, (uint16_t)constrain((meter.displayFiltered + 5) / 10, 0, 0xFFFF));
         }
         break;
     }


### PR DESCRIPTION
To make esc voltage show voltage >25.5v.

Now when I use the 8S or 12S BLHeli_32 ESC, the bf configurator only showed max 25.5V. So I change the MSP protocol api to make it adjust max 6553.5V