### PR TITLE
Update Rssi.md formula for rssi_offset

### DIFF
--- a/docs/Rssi.md
+++ b/docs/Rssi.md
@@ -71,7 +71,7 @@ To calculate the rssi offset and scale, check the rc value at full signal (`rssi
 Then, calculate the offset and scale values using the following formula:
 
 ```
-rssi_offset = 1000-(rssi_nosig) / 10
+rssi_offset = (1000-rssi_nosig) / 10
 rssi_scale = 100 * 1000 / (rssi_fullsig - rssi_nosig)
 ```
 


### PR DESCRIPTION
Fixing the formula  rssi_offset = (1000-rssi_nosig) / 10  which is now in line with the example.

The previous formula  rssi_offset = 1000- (rssi_nosig) / 10  was first not in line with the example, second the resulting rssi_offset would have been out of range of possible values.