### PR TITLE
Fix build for statistics-disabled DSHOT telemetry

### DIFF
--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -248,8 +248,8 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
                 }
 #ifdef USE_DSHOT_TELEMETRY_STATS
                 updateDshotTelemetryQuality(&dshotTelemetryQuality[i], validTelemetryPacket, currentTimeMs);
-            }
 #endif
+            }
         }
         pwmDshotSetDirectionOutput(&dmaMotors[i]);
     }


### PR DESCRIPTION
The USE_DSHOT_TELEMETRY_STATS define was is gating a closing bracket '}',
so that the scopes are breaking in case telemetry stats are not enabled.

This commit fixes this behaviour by moving the closing bracket out of the
ifdef.


Signed-off-by: Mimoja <git@mimoja.de>
