### PR TITLE
4.2 maintenance - OSD - Add an element that allows you to see the throttle scale.. [feature request]

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -371,7 +371,7 @@ static void validateAndFixConfig(void)
 #endif
 
     if (
-        featureIsConfigured(FEATURE_3D) || !featureIsConfigured(FEATURE_GPS)
+        featureIsConfigured(FEATURE_3D) || !featureIsConfigured(FEATURE_GPS) || mixerModeIsFixedWing(mixerConfig()->mixerMode)
 #if !defined(USE_GPS) || !defined(USE_GPS_RESCUE)
         || true
 #endif

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -248,8 +248,8 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
                 }
 #ifdef USE_DSHOT_TELEMETRY_STATS
                 updateDshotTelemetryQuality(&dshotTelemetryQuality[i], validTelemetryPacket, currentTimeMs);
-            }
 #endif
+            }
         }
         pwmDshotSetDirectionOutput(&dmaMotors[i]);
     }

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -434,7 +434,9 @@ void updateArmingStatus(void)
 void disarm(flightLogDisarmReason_e reason)
 {
     if (ARMING_FLAG(ARMED)) {
-        ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+        if (!flipOverAfterCrashActive) {
+            ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+        }
         DISABLE_ARMING_FLAG(ARMED);
         lastDisarmTimeUs = micros();
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -345,7 +345,7 @@ void updateArmingStatus(void)
 
 #ifdef USE_GPS_RESCUE
         if (gpsRescueIsConfigured()) {
-            if (gpsRescueConfig()->allowArmingWithoutFix || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED)) {
+            if (gpsRescueConfig()->allowArmingWithoutFix || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED) || IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {
                 setArmingDisabled(ARMING_DISABLED_GPS);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -999,10 +999,9 @@ mixerMode_e getMixerMode(void)
     return currentMixerMode;
 }
 
-
-bool isFixedWing(void)
+bool mixerModeIsFixedWing(mixerMode_e mixerMode)
 {
-    switch (currentMixerMode) {
+    switch (mixerMode) {
     case MIXER_FLYING_WING:
     case MIXER_AIRPLANE:
     case MIXER_CUSTOM_AIRPLANE:
@@ -1014,4 +1013,9 @@ bool isFixedWing(void)
 
         break;
     }
+}
+
+bool isFixedWing(void)
+{
+    return mixerModeIsFixedWing(currentMixerMode);
 }

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -115,4 +115,5 @@ bool mixerIsTricopter(void);
 void mixerSetThrottleAngleCorrection(int correctionValue);
 float mixerGetThrottle(void);
 mixerMode_e getMixerMode(void);
+bool mixerModeIsFixedWing(mixerMode_e mixerMode);
 bool isFixedWing(void);

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -213,7 +213,7 @@ void initActiveBoxIds(void)
 #ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)) {
 #ifdef USE_GPS_RESCUE
-        if (!featureIsEnabled(FEATURE_3D)) {
+        if (!featureIsEnabled(FEATURE_3D) && !isFixedWing()) {
             BME(BOXGPSRESCUE);
         }
 #endif

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -428,14 +428,18 @@ uint32_t baroUpdate(void)
     return sleepTime;
 }
 
+static float pressureToAltitude(const float pressure)
+{
+    return (1.0f - powf(pressure / 101325.0f, 0.190295f)) * 4433000.0f;
+}
+
 int32_t baroCalculateAltitude(void)
 {
     int32_t BaroAlt_tmp;
 
     // calculates height from ground via baro readings
-    // see: https://github.com/diydrones/ardupilot/blob/master/libraries/AP_Baro/AP_Baro.cpp#L140
     if (baroIsCalibrationComplete()) {
-        BaroAlt_tmp = lrintf((1.0f - pow_approx((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT) / 101325.0f, 0.190259f)) * 4433000.0f); // in cm
+        BaroAlt_tmp = lrintf(pressureToAltitude((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT)));
         BaroAlt_tmp -= baroGroundAltitude;
         baro.BaroAlt = lrintf((float)baro.BaroAlt * CONVERT_PARAMETER_TO_FLOAT(barometerConfig()->baro_noise_lpf) + (float)BaroAlt_tmp * (1.0f - CONVERT_PARAMETER_TO_FLOAT(barometerConfig()->baro_noise_lpf))); // additional LPF to reduce baro noise
     }


### PR DESCRIPTION
We are seeing more an more spec races that require the pilots to use a throttle cap.  Most racers do this in the radio and as a result the throttle position OSD element will clearly reflect that their throttle has been limited as they cap has been applied in the radio.  But, if you fly with a Futaba settings caps in the radio is a pain in the ass and as a result I use the throttle scale feature to cap my throttle.  The cap feels a little stronger than if I did it in the radio, but I prefer this as I can simply change it via OSD.

The problem that this poses is that the throttle position "S" OSD indicator does not correctly reflect that I have say a 50% cap.  If we had an OSD indicator that displayed the throttle % value this would allow the race directors to clearly see that you have the correct cap set via your video feed.

I do not set caps in the radio as I run a Futaba and I prefer to use the pot to set the cap and on the futaba the indents are in 7 step increments and as a result I use the BF Throttle scale to set my caps.  If I ran a Jumper or Taranis I would likely use the radio to set the cap and this would not pose a problem.

So, the feature request would help anyone that uses Throttle Scale as they could easily verify the cap is set correctly without having to go into the OSD.

* I plead with you to add this feature.  *  