### PR TITLE
Disable GPS RESCUE if mixer is fixed-wing type

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -372,7 +372,7 @@ static void validateAndFixConfig(void)
 #endif
 
     if (
-        featureIsConfigured(FEATURE_3D) || !featureIsConfigured(FEATURE_GPS)
+        featureIsConfigured(FEATURE_3D) || !featureIsConfigured(FEATURE_GPS) || mixerModeIsFixedWing(mixerConfig()->mixerMode)
 #if !defined(USE_GPS) || !defined(USE_GPS_RESCUE)
         || true
 #endif

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -992,10 +992,9 @@ mixerMode_e getMixerMode(void)
     return currentMixerMode;
 }
 
-
-bool isFixedWing(void)
+bool mixerModeIsFixedWing(mixerMode_e mixerMode)
 {
-    switch (currentMixerMode) {
+    switch (mixerMode) {
     case MIXER_FLYING_WING:
     case MIXER_AIRPLANE:
     case MIXER_CUSTOM_AIRPLANE:
@@ -1007,4 +1006,9 @@ bool isFixedWing(void)
 
         break;
     }
+}
+
+bool isFixedWing(void)
+{
+    return mixerModeIsFixedWing(currentMixerMode);
 }

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -115,4 +115,5 @@ bool mixerIsTricopter(void);
 void mixerSetThrottleAngleCorrection(int correctionValue);
 float mixerGetThrottle(void);
 mixerMode_e getMixerMode(void);
+bool mixerModeIsFixedWing(mixerMode_e mixerMode);
 bool isFixedWing(void);

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -214,7 +214,7 @@ void initActiveBoxIds(void)
 #ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)) {
 #ifdef USE_GPS_RESCUE
-        if (!featureIsEnabled(FEATURE_3D)) {
+        if (!featureIsEnabled(FEATURE_3D) && !isFixedWing()) {
             BME(BOXGPSRESCUE);
         }
 #endif


### PR DESCRIPTION
GPS Rescue flight control logic only knows how to fly multirotors and engaging GPS Rescue on a fixed-wing craft would result in an immediate loss of control and crash. For example, when GPS Rescue is engaged it attempts to yaw to the home direction heading and this won't work on fixed wing (particularly the flying wing mixer with no rudder). Next it tries to attain the target altitude exclusively with throttle control - not how altitude is controlled with a fix-wing aircraft.
