### PR TITLE
Add support for British units in OSD

### DIFF
--- a/docs/Units.md
+++ b/docs/Units.md
@@ -1,0 +1,30 @@
+# Units
+
+This document describes the current variables used to configure specific elements depending on the measurement unit applied.
+
+### Units
+| Unit     | Speed | Distance | Temperature |
+| -------- | ----- | -------- | ----------- |
+| Imperial | MPH   | Miles    | Fahrenheit  |
+| Metric   | KPH   | KM       | Celcius     |
+| British  | MPH   | KM       | Celcius     |
+
+### Affected OSD Elements
+| OSD Element      | Imperial | Metric | British |
+| ---------------- | -------- | ------ | ------- |
+| Altitude         | Feet     | Metre  | Metre   |
+| GPS Speed        | MPH      | KPH    | MPH     |
+| Home Distance    | Feet     | Metre  | Metre   |
+| Numerical Vario  | FTPS     | MPS    | MPS     |
+| Flight Distance  | Feet     | Metre  | Metre   |
+| OSD Efficiency   | Miles    | KM     | KM      |
+
+Note: Configuration is done in cli with `set osd_units = <UNIT>` or in the OSD tab in the Betaflight Configurator. For example `set osd_units = BRITISH`
+
+### Affected FrSky Hub Telemetry Elements
+| Element | Imperial   | Metric  | British |
+| ------- | ---------- | ------- | ------- |
+| HDOP    | Fahrenheit | Celcius | Celcius |
+
+The FrSky hub telemetry setting can be changed in cli by `set frsky_unit = <UNIT>`.
+For example `set frsky_unit = METRIC`

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -167,7 +167,7 @@ static const char * const lookupTableCrashRecovery[] = {
 };
 
 static const char * const lookupTableUnit[] = {
-    "IMPERIAL", "METRIC"
+    "IMPERIAL", "METRIC", "BRITISH"
 };
 
 static const char * const lookupTableAlignment[] = {

--- a/src/main/common/unit.h
+++ b/src/main/common/unit.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+typedef enum {
+    UNIT_IMPERIAL = 0,
+    UNIT_METRIC,
+    UNIT_BRITISH
+} unit_e;

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -49,6 +49,7 @@
 #include "common/printf.h"
 #include "common/typeconversion.h"
 #include "common/utils.h"
+#include "common/unit.h"
 
 #include "config/feature.h"
 
@@ -144,7 +145,7 @@ escSensorData_t *osdEscDataCombined;
 
 STATIC_ASSERT(OSD_POS_MAX == OSD_POS(31,31), OSD_POS_MAX_incorrect);
 
-PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 8);
+PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 9);
 
 PG_REGISTER_WITH_RESET_FN(osdElementConfig_t, osdElementConfig, PG_OSD_ELEMENT_CONFIG, 0);
 
@@ -288,7 +289,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdStatSetState(OSD_STAT_BLACKBOX_NUMBER, true);
     osdStatSetState(OSD_STAT_TIMER_2, true);
 
-    osdConfig->units = OSD_UNIT_METRIC;
+    osdConfig->units = UNIT_METRIC;
 
     // Enable all warnings by default
     for (int i=0; i < OSD_WARNING_COUNT; i++) {
@@ -809,7 +810,7 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
     case OSD_STAT_TOTAL_DIST:
         #define METERS_PER_KILOMETER 1000
         #define METERS_PER_MILE      1609
-        if (osdConfig()->units == OSD_UNIT_IMPERIAL) {
+        if (osdConfig()->units == UNIT_IMPERIAL) {
             tfp_sprintf(buff, "%d%c", statsConfig()->stats_total_dist_m / METERS_PER_MILE, SYM_MILES);
         } else {
             tfp_sprintf(buff, "%d%c", statsConfig()->stats_total_dist_m / METERS_PER_KILOMETER, SYM_KM);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "common/time.h"
+#include "common/unit.h"
 
 #include "drivers/display.h"
 
@@ -190,11 +191,6 @@ typedef enum {
 STATIC_ASSERT(OSD_STAT_COUNT <= 32, osdstats_overflow);
 
 typedef enum {
-    OSD_UNIT_IMPERIAL,
-    OSD_UNIT_METRIC
-} osd_unit_e;
-
-typedef enum {
     OSD_TIMER_1,
     OSD_TIMER_2,
     OSD_TIMER_COUNT
@@ -262,7 +258,7 @@ typedef struct osdConfig_s {
     uint16_t alt_alarm;
     uint8_t rssi_alarm;
 
-    osd_unit_e units;
+    uint8_t units;
 
     uint16_t timers[OSD_TIMER_COUNT];
     uint32_t enabledWarnings;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -81,6 +81,7 @@
 #include "common/printf.h"
 #include "common/typeconversion.h"
 #include "common/utils.h"
+#include "common/unit.h"
 
 #include "config/config.h"
 #include "config/feature.h"
@@ -242,7 +243,7 @@ static void renderOsdEscRpmOrFreq(getEscRpmOrFreqFnPtr escFnPtr, osdElementParms
 int osdConvertTemperatureToSelectedUnit(int tempInDegreesCelcius)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
         return lrintf(((tempInDegreesCelcius * 9.0f) / 5) + 32);
     default:
         return tempInDegreesCelcius;
@@ -291,7 +292,7 @@ void osdFormatDistanceString(char *ptr, int distance, char leadingSymbol)
         *ptr++ = leadingSymbol;
     }
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
         unitTransition = 5280;
         unitSymbol = SYM_FT;
         unitSymbolExtended = SYM_MILES;
@@ -453,7 +454,7 @@ static uint8_t osdGetDirectionSymbolFromHeading(int heading)
 int32_t osdGetMetersToSelectedUnit(int32_t meters)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
         return (meters * 328) / 100; // Convert to feet / 100
     default:
         return meters;               // Already in metre / 100
@@ -466,7 +467,7 @@ int32_t osdGetMetersToSelectedUnit(int32_t meters)
 char osdGetMetersToSelectedUnitSymbol(void)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
         return SYM_FT;
     default:
         return SYM_M;
@@ -480,7 +481,8 @@ char osdGetMetersToSelectedUnitSymbol(void)
 int32_t osdGetSpeedToSelectedUnit(int32_t value)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
+    case UNIT_BRITISH:
         return CM_S_TO_MPH(value);
     default:
         return CM_S_TO_KM_H(value);
@@ -493,7 +495,8 @@ int32_t osdGetSpeedToSelectedUnit(int32_t value)
 char osdGetSpeedToSelectedUnitSymbol(void)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
+    case UNIT_BRITISH:
         return SYM_MPH;
     default:
         return SYM_KPH;
@@ -503,7 +506,7 @@ char osdGetSpeedToSelectedUnitSymbol(void)
 char osdGetVarioToSelectedUnitSymbol(void)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
         return SYM_FTPS;
     default:
         return SYM_MPS;
@@ -514,7 +517,7 @@ char osdGetVarioToSelectedUnitSymbol(void)
 char osdGetTemperatureSymbolForSelectedUnit(void)
 {
     switch (osdConfig()->units) {
-    case OSD_UNIT_IMPERIAL:
+    case UNIT_IMPERIAL:
         return SYM_F;
     default:
         return SYM_C;
@@ -936,7 +939,7 @@ static void osdElementEfficiency(osdElementParms_t *element)
         }
     }
 
-    const char unitSymbol = osdConfig()->units == OSD_UNIT_IMPERIAL ? SYM_MILES : SYM_KM;
+    const char unitSymbol = osdConfig()->units == UNIT_IMPERIAL ? SYM_MILES : SYM_KM;
     if (efficiency > 0 && efficiency <= 9999) {
         tfp_sprintf(element->buff, "%4d%c/%c", efficiency, SYM_MAH, unitSymbol);
     } else {

--- a/src/main/telemetry/frsky_hub.c
+++ b/src/main/telemetry/frsky_hub.c
@@ -289,13 +289,13 @@ static void sendSatalliteSignalQualityAsTemperature2(uint8_t cycleNum)
         satellite = constrain(gpsSol.hdop, 0, GPS_MAX_HDOP_VAL);
     }
     int16_t data;
-    if (telemetryConfig()->frsky_unit == FRSKY_UNIT_METRICS) {
-        data = satellite;
-    } else {
+    if (telemetryConfig()->frsky_unit == UNIT_IMPERIAL) {
         float tmp = (satellite - 32) / 1.8f;
         // Round the value
         tmp += (tmp < 0) ? -0.5f : 0.5f;
         data = tmp;
+    } else {
+        data = satellite;
     }
     frSkyHubWriteFrame(ID_TEMPRATURE2, data);
 }

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -27,6 +27,7 @@
 #ifdef USE_TELEMETRY
 
 #include "common/utils.h"
+#include "common/unit.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -58,7 +59,7 @@
 #include "telemetry/ibus.h"
 #include "telemetry/msp_shared.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 4);
 
 PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     .telemetry_inverted = false,
@@ -66,7 +67,7 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     .gpsNoFixLatitude = 0,
     .gpsNoFixLongitude = 0,
     .frsky_coordinate_format = FRSKY_FORMAT_DMS,
-    .frsky_unit = FRSKY_UNIT_METRICS,
+    .frsky_unit = UNIT_METRIC,
     .frsky_vfas_precision = 0,
     .hottAlarmSoundInterval = 5,
     .pidValuesAsTelemetry = 0,

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "common/unit.h"
+
 #include "io/serial.h"
 
 #include "pg/pg.h"
@@ -39,11 +41,6 @@ typedef enum {
     FRSKY_FORMAT_DMS = 0,
     FRSKY_FORMAT_NMEA
 } frskyGpsCoordFormat_e;
-
-typedef enum {
-    FRSKY_UNIT_METRICS = 0,
-    FRSKY_UNIT_IMPERIALS
-} frskyUnit_e;
 
 typedef enum {
     SENSOR_VOLTAGE         = 1 << 0,
@@ -78,8 +75,8 @@ typedef struct telemetryConfig_s {
     int16_t gpsNoFixLongitude;
     uint8_t telemetry_inverted;
     uint8_t halfDuplex;
-    frskyGpsCoordFormat_e frsky_coordinate_format;
-    frskyUnit_e frsky_unit;
+    uint8_t frsky_coordinate_format;
+    uint8_t frsky_unit;
     uint8_t frsky_vfas_precision;
     uint8_t hottAlarmSoundInterval;
     uint8_t pidValuesAsTelemetry;


### PR DESCRIPTION
On slack there was a demand for a British unit for speed and distance related elements in OSD and FrSky hub telemetry.
It's tested on a IFLIGHT SUCCEX-D F7 TWING with DJI goggles. 

**Units**
| Unit | Speed | Distance |
| ---- | ------- | ---------- |
| Imperial | MPH | Miles |
| Metric | KPH | KM |
| British | MPH | KM |

**Affected OSD Elements**
| OSD Element | Imperial | Metric | British |
| --- | --- | --- | --- |
| Altitude | Feet | Metre | Metre |
| GPS Speed | MPH | KPH | MPH |
| Home Distance | Feet | Metre | Metre |
| Numerical Vario | FTPS | MPS | MPS |
| Flight Distance | Feet | Metre | Metre |
| OSD Efficiency | Miles | KM | KM |

**Affected FrSky Hub Telemetry Elements**
| Element | Imperial | Metric | British |
| --------- | ----------- | -------- | -------- |
| HDOP    | Fahrenheit | Celcius | Celcius |

This is the FW part. Configuration is done in cli with `set osd_units = BRITISH` or in the OSD tab in upcoming Configurator.
The FrSky hub telemetry setting can be changed in cli with `set frsky_unit = BRITISH`.