### PR TITLE
Fix CLI range check error message formatting

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -981,7 +981,7 @@ static void cliShowInvalidArgumentCountError(const char *cmdName)
 static void cliShowArgumentRangeError(const char *cmdName, char *name, int min, int max)
 {
     if (name) {
-        cliPrintErrorLinef(cmdName, "%s: %s NOT BETWEEN %d AND %d", name, min, max);
+        cliPrintErrorLinef(cmdName, "%s NOT BETWEEN %d AND %d", name, min, max);
     } else {
         cliPrintErrorLinef(cmdName, "ARGUMENT OUT OF RANGE");
     }


### PR DESCRIPTION
Fixes a string formatting and parameter mismatch in `cliShowArgumentRangeError()`.

Before:
```
# vtxtable bands 9
###ERROR: vtxtable: BAND COUNT: ðÿ NOT BETWEEN 8 AND 134727376###
```

After
```
# vtxtable bands 9
###ERROR IN vtxtable: BAND COUNT NOT BETWEEN 0 AND 8###
```

