### PR TITLE
Disable stick commands when HID is active and USB is connected

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -61,21 +61,15 @@
 #include "flight/mixer.h"
 
 #include "io/rcdevice_cam.h"
+#include "io/usb_cdc_hid.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/rx.h"
-#ifdef USE_USB_CDC_HID
-#include "pg/usb.h"
-#endif
 
 #include "osd/osd.h"
 
 #include "rx/rx.h"
-
-#ifdef USE_USB_CDC_HID
-#include "sensors/battery.h"
-#endif
 
 // DisplayPort management
 
@@ -1202,7 +1196,7 @@ static void cmsUpdate(uint32_t currentTimeUs)
         || rcdeviceInMenu
 #endif
 #ifdef USE_USB_CDC_HID
-        || (getBatteryCellCount() == 0 && usbDevConfig()->type == COMPOSITE)
+        || cdcDeviceIsMayBeActive() // If this target is used as a joystick, we should leave here.
 #endif
        ) {
         return;

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -46,6 +46,7 @@
 #include "flight/failsafe.h"
 
 #include "io/beeper.h"
+#include "io/usb_cdc_hid.h"
 #include "io/dashboard.h"
 #include "io/gps.h"
 #include "io/vtx_control.h"
@@ -227,6 +228,13 @@ void processRcStickPositions()
         return;
     }
     doNotRepeat = true;
+
+    #ifdef USE_USB_CDC_HID
+    // If this target is used as a joystick, we should leave here.
+    if (cdcDeviceIsMayBeActive()) {
+        return;
+    }
+    #endif
 
     // actions during not armed
 

--- a/src/main/io/usb_cdc_hid.c
+++ b/src/main/io/usb_cdc_hid.c
@@ -18,6 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+#include <stdbool.h>
+
 #include "platform.h"
 
 #ifdef USE_USB_CDC_HID
@@ -27,6 +30,10 @@
 #include "fc/rc_controls.h"
 
 #include "rx/rx.h"
+
+#include "pg/usb.h"
+
+#include "sensors/battery.h"
 
 //TODO: Make it platform independent in the future
 #if defined(STM32F4)
@@ -74,5 +81,10 @@ void sendRcDataToHid(void)
 #else
 # error "MCU does not support USB HID."
 #endif
+}
+
+bool cdcDeviceIsMayBeActive()
+{
+    return usbDevConfig()->type == COMPOSITE && usbIsConnected() && (getBatteryState() == BATTERY_NOT_PRESENT || batteryConfig()->voltageMeterSource == VOLTAGE_METER_NONE);
 }
 #endif

--- a/src/main/io/usb_cdc_hid.h
+++ b/src/main/io/usb_cdc_hid.h
@@ -21,3 +21,4 @@
 #pragma once
 
 void sendRcDataToHid(void);
+bool cdcDeviceIsMayBeActive();


### PR DESCRIPTION
When USB_HID_CDC (FC as a joystick) is active, stick commands are still enabled. This can result in accidentally mess in PID profiles, rate profiles, gyro|acc|mag|baro calibration, acc trims, etc.

This PR contains code which detects USB connection and USB_CDC_HID state. If the FC is connected to the USB AND the joystick is enabled - then a stick commands are disabled.

Tested it with F405, F411, F722 - all good.
