### PR TITLE
Fix underflow in channel based RSSI calculations for out of range values

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -757,7 +757,7 @@ static void updateRSSIPWM(void)
     int16_t pwmRssi = rcData[rxConfig()->rssi_channel - 1];
 
     // Range of rawPwmRssi is [1000;2000]. rssi should be in [0;1023];
-    setRssiDirect(scaleRange(pwmRssi, PWM_RANGE_MIN, PWM_RANGE_MAX, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_CHANNEL);
+    setRssiDirect(scaleRange(constrain(pwmRssi, PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_CHANNEL);
 }
 
 static void updateRSSIADC(timeUs_t currentTimeUs)


### PR DESCRIPTION
Fixes #10096 

If the RSSI channel PWM values were outside the expected 1000-2000 range, the `scaleRange()` function does not work properly. In particular if the value was below the minimum the result would be negative. Then this would cause an underflow when applied as a `uint16` to `setRssiDirect()`. This fix constrains the input range from 1000 to 2000.

Example with RSSI channel set to aux1 for testing:

![Screen Shot 2020-08-14 at 6 50 59 PM](https://user-images.githubusercontent.com/17088539/90298654-11337380-de61-11ea-9c41-e86983502907.png)

Channel value (just slightly below 1000):

![Screen Shot 2020-08-14 at 6 51 09 PM](https://user-images.githubusercontent.com/17088539/90298674-201a2600-de61-11ea-9e12-45e8d1d2460c.png)

Resulting RSSI calc:

![Screen Shot 2020-08-14 at 6 51 26 PM 2](https://user-images.githubusercontent.com/17088539/90298681-28726100-de61-11ea-954a-cc3971bd30bd.png)

