### PR TITLE
Fixed output range calculation for Vbat sag compensation when dynamic idle is enabled.

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -652,7 +652,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             DEBUG_SET(DEBUG_BATTERY, 2, batteryGoodness * 100);
             DEBUG_SET(DEBUG_BATTERY, 3, motorRangeAttenuationFactor * 1000);
         }
-        motorRangeMax = motorOutputHigh - motorRangeAttenuationFactor * (motorOutputHigh - motorOutputLow);
+        motorRangeMax = motorOutputHigh - motorRangeAttenuationFactor * (motorOutputHigh - appliedMotorOutputLow);
 #else
         motorRangeMax = motorOutputHigh;
 #endif


### PR DESCRIPTION
In the case of having dynamic idle activated, `motorOutputLow` is not actually used for anything meaningful, and the actual lowest limit of the motor output range is in `appliedMotorOutputLow`.