### PR TITLE
Fix bug that causes uartTotalRxBytesWaiting() to return incorrect value when DMA is used

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -156,10 +156,12 @@ static uint32_t uartTotalRxBytesWaiting(const serialPort_t *instance)
         uint32_t rxDMAHead = xDMA_GetCurrDataCounter(s->rxDMAResource);
 #endif
 
-        if (rxDMAHead >= s->rxDMAPos) {
-            return rxDMAHead - s->rxDMAPos;
+        // s->rxDMAPos and rxDMAHead represent distances from the end
+        // of the buffer.  They count DOWN as they advance.
+        if (s->rxDMAPos >= rxDMAHead) {
+            return s->rxDMAPos - rxDMAHead;
         } else {
-            return s->port.rxBufferSize + rxDMAHead - s->rxDMAPos;
+            return s->port.rxBufferSize + s->rxDMAPos - rxDMAHead;
         }
     }
 #endif


### PR DESCRIPTION
On targets that use DMA for serial RX, `uartTotalRxBytesWaiting()`, which is called by `serialRxBytesWaiting()`, returned a value that was grossly incorrect.  For example, if one byte was waiting, the function returned one less than the size of the buffer.  This bug was apparently caused by not understanding that the DMA data count register (NDTR) and the software tail index `s->rxDMAPos` both measure the distance from the **end** of the buffer, not from the beginning.

The reason the bug didn't cause serious problems is that almost all calls to this function check only whether the returned value is zero or not.  (The only exceptions I found were in "src/main/telemetry/hott.c".  Perhaps that code was tested on a target that did not use DMA.)  The case of zero bytes waiting was the only case in which the correct result was returned; therefore the existence of the bug was not obvious.

