### PR TITLE
Fix default baro handling and address for DPS310

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -44,7 +44,7 @@
 
 #if defined(USE_BARO) && defined(USE_BARO_DPS310)
 
-#define DPS310_I2C_ADDR             0x77
+#define DPS310_I2C_ADDR             0x76
 
 #define DPS310_REG_PSR_B2           0x00
 #define DPS310_REG_PSR_B1           0x01

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -116,7 +116,7 @@ void pgResetFn_barometerConfig(barometerConfig_t *barometerConfig)
     barometerConfig->baro_spi_csn = IO_TAG(BARO_CS_PIN);
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
-#elif defined(DEFAULT_BARO_MS5611) || defined(DEFAULT_BARO_BMP388) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_BMP085) ||defined(DEFAULT_BARO_QMP6988)
+#elif defined(DEFAULT_BARO_MS5611) || defined(DEFAULT_BARO_BMP388) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_BMP085) ||defined(DEFAULT_BARO_QMP6988) || defined(DEFAULT_BARO_DPS310)
     // All I2C devices shares a default config with address = 0 (per device default)
     barometerConfig->baro_bustype = BUSTYPE_I2C;
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(BARO_I2C_INSTANCE);


### PR DESCRIPTION
Current DPS310 default I2C address is set to 0x77, which is the device's default.
However, as this chip is drop-in compatible with BMP280 which uses driver default address of 0x76, it would be better if it is also software transparent.

Missing default baro handling in `sensors/baromenter.c` is added also.