### PR TITLE
Rename + Consolidate USE_CCM_*/ITCM_*

### DIFF
--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -199,8 +199,8 @@ typedef enum {
     .owner.resourceIndex = 0 \
     }
 
-#if defined(USE_CCM_CODE) && defined(STM32F3)
-#define DMA_HANDLER_CODE CCM_CODE
+#if defined(USE_CCM) && defined(STM32F3)
+#define DMA_HANDLER_CODE FAST_CODE
 #else
 #define DMA_HANDLER_CODE
 #endif

--- a/src/main/drivers/memprot_stm32h7xx.c
+++ b/src/main/drivers/memprot_stm32h7xx.c
@@ -30,7 +30,7 @@ extern uint8_t dmarwaxi_start;
 extern uint8_t dmarwaxi_end;
 
 mpuRegion_t mpuRegions[] = {
-#ifdef USE_ITCM_RAM
+#ifdef USE_ITCM
     {
         //  Mark ITCM-RAM as read-only
         // "For Cortex®-M7, TCMs memories always behave as Non-cacheable, Non-shared normal memories, irrespective of the memory type attributes defined in the MPU for a memory region containing addresses held in the TCM"

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -248,7 +248,7 @@ void failureMode(failureMode_e mode)
 
 void initialiseMemorySections(void)
 {
-#ifdef USE_ITCM_RAM
+#ifdef USE_ITCM
     /* Load functions into ITCM RAM */
     extern uint8_t tcm_code_start;
     extern uint8_t tcm_code_end;
@@ -256,7 +256,7 @@ void initialiseMemorySections(void)
     memcpy(&tcm_code_start, &tcm_code, (size_t) (&tcm_code_end - &tcm_code_start));
 #endif
 
-#ifdef USE_CCM_CODE
+#ifdef USE_CCM
     /* Load functions into RAM */
     extern uint8_t ccm_code_start;
     extern uint8_t ccm_code_end;

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -153,11 +153,11 @@
 
 #if defined(USE_ITCM)
 #define TCM_CODE                    __attribute__((section(".tcm_code")))
-#define FAST_CODE 					TCM_CODE 
+#define FAST_CODE                   TCM_CODE 
 #define FAST_CODE_NOINLINE          NOINLINE
 #elif defined(USE_CCM)
 #define CCM_CODE                    __attribute__((section(".ccm_code")))
-#define FAST_CODE					CCM_CODE
+#define FAST_CODE                   CCM_CODE
 #define FAST_CODE_NOINLINE          NOINLINE
 #else
 #define FAST_CODE

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -44,7 +44,7 @@
 #define MINIMAL_CLI
 #define USE_DSHOT
 #define USE_GYRO_DATA_ANALYSE
-#define USE_CCM_CODE
+#define USE_CCM
 #endif
 
 #ifdef STM32F4
@@ -81,7 +81,7 @@
 
 #ifdef STM32F7
 #define USE_SRAM2
-#define USE_ITCM_RAM
+#define USE_ITCM
 #define USE_FAST_RAM
 #define USE_DSHOT
 #define USE_DSHOT_BITBANG
@@ -107,7 +107,7 @@
 #endif // STM32F7
 
 #ifdef STM32H7
-#define USE_ITCM_RAM
+#define USE_ITCM
 #define USE_FAST_RAM
 #define USE_DSHOT
 #define USE_DSHOT_TELEMETRY
@@ -147,19 +147,21 @@
 #define DEFAULT_CPU_OVERCLOCK 0
 #endif
 
+#if defined(USE_ITCM) && defined(USE_CCM)
+#error "ITCM and CCM are mutually exclusive. F3 has Instruction CCM, F7 has ITCM. F4 CCM is data only."
+#endif
 
-#ifdef USE_ITCM_RAM
-#define FAST_CODE                   __attribute__((section(".tcm_code")))
+#if defined(USE_ITCM)
+#define TCM_CODE                    __attribute__((section(".tcm_code")))
+#define FAST_CODE 					TCM_CODE 
+#define FAST_CODE_NOINLINE          NOINLINE
+#elif defined(USE_CCM)
+#define CCM_CODE                    __attribute__((section(".ccm_code")))
+#define FAST_CODE					CCM_CODE
 #define FAST_CODE_NOINLINE          NOINLINE
 #else
 #define FAST_CODE
 #define FAST_CODE_NOINLINE
-#endif // USE_ITCM_RAM
-
-#ifdef USE_CCM_CODE
-#define CCM_CODE              __attribute__((section(".ccm_code")))
-#else
-#define CCM_CODE
 #endif
 
 #ifdef USE_FAST_RAM


### PR DESCRIPTION
Split 3 of #10116 
CCM and ITCM are target specific core-coupled memories with different characteristics. As they are target specific they should be united into a single macro. 