### PR TITLE
Fixed the check if only documentation was changed in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
       COMMIT_RANGE="$TRAVIS_COMMIT_RANGE"
     fi
     FILE_LIST=$(git diff --name-only $COMMIT_RANGE)
-    echo $FILE_LIST | grep -qvE '(\.md$)|(^(docs|support))/' || {
+    echo "$FILE_LIST" | grep -qvE '(\.md$)|(^(docs|support))/' || {
       echo "Only files not used in the build process were updated, aborting."
       exit
     }


### PR DESCRIPTION
Fixes the problem that a mix of documentation and non-documentation changes is detected as 'documentation changes only' and results in Travis not running, like what lead to #10134.