### PR TITLE
seting custom mavlink streams rates

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1184,6 +1184,12 @@ const clivalue_t valueTable[] = {
     // Set to 10 to show a tenth of your capacity drawn.
     // Set to $size_of_battery to get a percentage of battery used.
     { "mavlink_mah_as_heading_divisor", VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 30000 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_mah_as_heading_divisor) },
+    // rates for sending different types of mavlink streams, to make possible working with low bandwidth telemetry solutions
+    { "mavlink_rate_stream_extended_status", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_rate_stream_extended_status) },
+    { "mavlink_rate_stream_rc_channels", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_rate_stream_rc_channels) },
+    { "mavlink_rate_stream_position", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_rate_stream_position) },
+    { "mavlink_rate_stream_extra1", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_rate_stream_extra1) },
+    { "mavlink_rate_stream_extra2", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, mavlink_rate_stream_extra2) },
 #endif
 #ifdef USE_TELEMETRY_SENSORS_DISABLED_DETAILS
     { "telemetry_disabled_voltage",         VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_VOLTAGE),         PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, disabledSensors)},

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -81,6 +81,7 @@
 #define TELEMETRY_MAVLINK_INITIAL_PORT_MODE MODE_TX
 #define TELEMETRY_MAVLINK_MAXRATE 50
 #define TELEMETRY_MAVLINK_DELAY ((1000 * 1000) / TELEMETRY_MAVLINK_MAXRATE)
+#define TELEMETRY_MAVLINK_DEFAULT_RATE  2 // default rate fall all the streams
 
 extern uint16_t rssi; // FIXME dependency on mw.c
 
@@ -91,12 +92,12 @@ static bool mavlinkTelemetryEnabled =  false;
 static portSharing_e mavlinkPortSharing;
 
 /* MAVLink datastream rates in Hz */
-static const uint8_t mavRates[] = {
-    [MAV_DATA_STREAM_EXTENDED_STATUS] = 2, //2Hz
-    [MAV_DATA_STREAM_RC_CHANNELS] = 5, //5Hz
-    [MAV_DATA_STREAM_POSITION] = 2, //2Hz
-    [MAV_DATA_STREAM_EXTRA1] = 10, //10Hz
-    [MAV_DATA_STREAM_EXTRA2] = 10 //2Hz
+static uint8_t mavRates[] = {
+    [MAV_DATA_STREAM_EXTENDED_STATUS] = TELEMETRY_MAVLINK_DEFAULT_RATE,
+    [MAV_DATA_STREAM_RC_CHANNELS] = TELEMETRY_MAVLINK_DEFAULT_RATE,
+    [MAV_DATA_STREAM_POSITION] = TELEMETRY_MAVLINK_DEFAULT_RATE,
+    [MAV_DATA_STREAM_EXTRA1] = TELEMETRY_MAVLINK_DEFAULT_RATE,
+    [MAV_DATA_STREAM_EXTRA2] = TELEMETRY_MAVLINK_DEFAULT_RATE,
 };
 
 #define MAXSTREAMS (sizeof(mavRates) / sizeof(mavRates[0]))
@@ -157,6 +158,12 @@ void initMAVLinkTelemetry(void)
 {
     portConfig = findSerialPortConfig(FUNCTION_TELEMETRY_MAVLINK);
     mavlinkPortSharing = determinePortSharing(portConfig, FUNCTION_TELEMETRY_MAVLINK);
+    // setup mavlink streams rates based on user's choice 
+    mavRates[MAV_DATA_STREAM_EXTENDED_STATUS] = telemetryConfig()->mavlink_rate_stream_extended_status;
+    mavRates[MAV_DATA_STREAM_RC_CHANNELS] = telemetryConfig()->mavlink_rate_stream_rc_channels;
+    mavRates[MAV_DATA_STREAM_POSITION] = telemetryConfig()->mavlink_rate_stream_position;
+    mavRates[MAV_DATA_STREAM_EXTRA1] = telemetryConfig()->mavlink_rate_stream_extra1;
+    mavRates[MAV_DATA_STREAM_EXTRA2] = telemetryConfig()->mavlink_rate_stream_extra2; 
 }
 
 void configureMAVLinkTelemetryPort(void)

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -79,6 +79,11 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     },
     .disabledSensors = ESC_SENSOR_ALL,
     .mavlink_mah_as_heading_divisor = 0,
+    .mavlink_rate_stream_extended_status = 2,   // 2Hz
+    .mavlink_rate_stream_rc_channels = 5,       // 5Hz
+    .mavlink_rate_stream_position = 2,          // 2Hz
+    .mavlink_rate_stream_extra1 = 10,           // 10Hz
+    .mavlink_rate_stream_extra2 = 10,           // 10Hz
 );
 
 void telemetryInit(void)

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -84,6 +84,11 @@ typedef struct telemetryConfig_s {
     uint8_t flysky_sensors[IBUS_SENSOR_COUNT];
     uint16_t mavlink_mah_as_heading_divisor;
     uint32_t disabledSensors; // bit flags
+    uint8_t mavlink_rate_stream_extended_status;
+    uint8_t mavlink_rate_stream_rc_channels;
+    uint8_t mavlink_rate_stream_position;
+    uint8_t mavlink_rate_stream_extra1;
+    uint8_t mavlink_rate_stream_extra2;
 } telemetryConfig_t;
 
 PG_DECLARE(telemetryConfig_t, telemetryConfig);


### PR DESCRIPTION
Hi,
It's just about making possible adjusting mavlink streams rates. It's useful for low speed telemetry solutions.
You can control stream rates using following parameters:
- mavlink_rate_stream_extended_status
- mavlink_rate_stream_rc_channels
- mavlink_rate_stream_position
- mavlink_rate_stream_extra1
- mavlink_rate_stream_extra2

It was tested by me and seems to be working fine.

[betaflight_4.3.0_STM32F411_e3bb91c9c.zip](https://github.com/betaflight/betaflight/files/5143885/betaflight_4.3.0_STM32F411_e3bb91c9c.zip)
[betaflight_4.3.0_STM32F745_e3bb91c9c.zip](https://github.com/betaflight/betaflight/files/5143886/betaflight_4.3.0_STM32F745_e3bb91c9c.zip)
[betaflight_4.3.0_STM32F7X2_e3bb91c9c.zip](https://github.com/betaflight/betaflight/files/5143887/betaflight_4.3.0_STM32F7X2_e3bb91c9c.zip)
[betaflight_4.3.0_STM32F405_e3bb91c9c.zip](https://github.com/betaflight/betaflight/files/5143888/betaflight_4.3.0_STM32F405_e3bb91c9c.zip)

