### PR TITLE
Fixed misaligned report 'usages' and added more channels to HID joystick

### DIFF
--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -37,7 +37,11 @@ typedef enum rc_alias {
     AUX5,
     AUX6,
     AUX7,
-    AUX8
+    AUX8,
+    AUX9,
+    AUX10,
+    AUX11,
+    AUX12
 } rc_alias_e;
 
 #define PRIMARY_CHANNEL_COUNT (THROTTLE + 1)


### PR DESCRIPTION
According to issue #10140.
There was a bug in the aligning of report 'usages' in `usb_cdc_hid.c`. That's why two of eight channels didn't work in the Windows joystick. 
This is the Properties Windows of the joystick **before** changes:
![BF_Before](https://user-images.githubusercontent.com/7397515/91608678-4c13cc00-e976-11ea-84ca-57f357296b25.png)

I refactored `HID_MOUSE_ReportDesc` to match with order of the 'usages' type and got all channels working.
So, this is the same window **after** code refactoring:
![BF_After](https://user-images.githubusercontent.com/7397515/91609559-e88a9e00-e977-11ea-939e-c746428e701a.png)


Also, there is now set of 8 buttons, mapped to 8 added channels. Each button represents one bit in one byte of the packet data, so no bytes are wasted. This set of controls is similar as one in the OpenTX Joystick:
![OpenTX](https://user-images.githubusercontent.com/7397515/91609216-4965a680-e977-11ea-922f-f2a5e18fa906.png)
 

For the test, please download appropriate firmware from here:
[betaflight_4.3.0_STM32F405_norevision.zip](https://github.com/betaflight/betaflight/files/5143926/betaflight_4.3.0_STM32F405_norevision.zip)
[betaflight_4.3.0_STM32F411_norevision.zip](https://github.com/betaflight/betaflight/files/5143927/betaflight_4.3.0_STM32F411_norevision.zip)
[betaflight_4.3.0_STM32F7X2_norevision.zip](https://github.com/betaflight/betaflight/files/5143928/betaflight_4.3.0_STM32F7X2_norevision.zip)
[betaflight_4.3.0_STM32F745_norevision.zip](https://github.com/betaflight/betaflight/files/5143929/betaflight_4.3.0_STM32F745_norevision.zip)

... and follow installation instructions from here: https://youtu.be/I1uN9CN30gw