### PR TITLE
Add late P boost to antigravity

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -270,7 +270,24 @@ void pidResetIterm(void)
 void pidUpdateAntiGravityThrottleFilter(float throttle)
 {
     if (pidRuntime.antiGravityMode == ANTI_GRAVITY_SMOOTH) {
-        pidRuntime.antiGravityThrottleHpf = throttle - pt1FilterApply(&pidRuntime.antiGravityThrottleLpf, throttle);
+        // calculate a boost factor for P in the same way as for I when throttle changes quickly
+        // at this point the variable antiGravityThrottleHpf is the lowpass of throttle
+        pidRuntime.antiGravityThrottleHpf = pt1FilterApply(&pidRuntime.antiGravityThrottleLpf, throttle);
+        // focus P boost on low throttle range only
+        if (throttle < 0.5f) {
+            pidRuntime.antiGravityPBoost = 0.5f - throttle;
+        } else {
+            pidRuntime.antiGravityPBoost = 0.0f;
+        }
+        // use lowpass to identify start of a throttle up, use this to reduce boost at start by half
+        if (pidRuntime.antiGravityThrottleHpf < throttle) {
+            pidRuntime.antiGravityPBoost *= 0.5f;
+        }
+        // high-passed throttle focuses boost on faster throttle changes
+        pidRuntime.antiGravityThrottleHpf = fabsf(throttle - pidRuntime.antiGravityThrottleHpf);
+        pidRuntime.antiGravityPBoost = pidRuntime.antiGravityPBoost * pidRuntime.antiGravityThrottleHpf;
+        // smooth the P boost at 3hz to remove the jagged edges and prolong the effect after throttle stops
+        pidRuntime.antiGravityPBoost = pt1FilterApply(&pidRuntime.antiGravitySmoothLpf, pidRuntime.antiGravityPBoost);
     }
 }
 
@@ -823,10 +840,19 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
     // Dynamic i component,
     if ((pidRuntime.antiGravityMode == ANTI_GRAVITY_SMOOTH) && pidRuntime.antiGravityEnabled) {
-        pidRuntime.itermAccelerator = fabsf(pidRuntime.antiGravityThrottleHpf) * 0.01f * (pidRuntime.itermAcceleratorGain - 1000);
-        DEBUG_SET(DEBUG_ANTI_GRAVITY, 1, lrintf(pidRuntime.antiGravityThrottleHpf * 1000));
+        // traditional itermAccelerator factor for iTerm
+        pidRuntime.itermAccelerator = pidRuntime.antiGravityThrottleHpf * 0.01f * pidRuntime.itermAcceleratorGain;
+        DEBUG_SET(DEBUG_ANTI_GRAVITY, 0, lrintf(pidRuntime.itermAccelerator * 1000));
+        // users AG Gain changes P boost
+        pidRuntime.antiGravityPBoost *= pidRuntime.itermAcceleratorGain;
+        // add some percentage of that slower, longer acting P boost factor to prolong AG effect on iTerm
+        pidRuntime.itermAccelerator += pidRuntime.antiGravityPBoost * 0.05f;
+        // set the final P boost amount
+        pidRuntime.antiGravityPBoost *= 0.02f;
+    } else {
+        pidRuntime.antiGravityPBoost = 0.0f;
     }
-    DEBUG_SET(DEBUG_ANTI_GRAVITY, 0, lrintf(pidRuntime.itermAccelerator * 1000));
+    DEBUG_SET(DEBUG_ANTI_GRAVITY, 1, lrintf(pidRuntime.itermAccelerator * 1000));
 
     float agGain = pidRuntime.dT * pidRuntime.itermAccelerator * AG_KI;
 
@@ -1117,6 +1143,22 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
 #endif
         // calculating the PID sum
+
+        // P boost at the end of throttle chop
+        // attenuate effect if turning more than 50 deg/s, half at 100 deg/s
+        float agBoostAttenuator = fabsf(currentPidSetpoint) / 50.0f;
+        if (agBoostAttenuator < 1.0f) {
+            agBoostAttenuator = 1.0f;
+        }
+        const float agBoost = 1.0f + (pidRuntime.antiGravityPBoost / agBoostAttenuator);
+        pidData[axis].P *= agBoost;
+        if (axis == FD_ROLL){
+            DEBUG_SET(DEBUG_ANTI_GRAVITY, 2, lrintf(agBoost * 1000));
+        }
+        if (axis == FD_PITCH){
+            DEBUG_SET(DEBUG_ANTI_GRAVITY, 3, lrintf(agBoost * 1000));
+        }
+
         const float pidSum = pidData[axis].P + pidData[axis].I + pidData[axis].D + pidData[axis].F;
 #ifdef USE_INTEGRATED_YAW_CONTROL
         if (axis == FD_YAW && pidRuntime.useIntegratedYaw) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1149,10 +1149,10 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         agBoostAttenuator = MAX(agBoostAttenuator, 1.0f);
         const float agBoost = 1.0f + (pidRuntime.antiGravityPBoost / agBoostAttenuator);
         pidData[axis].P *= agBoost;
-        if (axis == FD_ROLL){
+        if (axis == FD_ROLL) {
             DEBUG_SET(DEBUG_ANTI_GRAVITY, 2, lrintf(agBoost * 1000));
         }
-        if (axis == FD_PITCH){
+        if (axis == FD_PITCH) {
             DEBUG_SET(DEBUG_ANTI_GRAVITY, 3, lrintf(agBoost * 1000));
         }
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -253,8 +253,10 @@ typedef struct pidRuntime_s {
     bool antiGravityEnabled;
     uint8_t antiGravityMode;
     pt1Filter_t antiGravityThrottleLpf;
+    pt1Filter_t antiGravitySmoothLpf;
     float antiGravityOsdCutoff;
     float antiGravityThrottleHpf;
+    float antiGravityPBoost;
     float ffBoostFactor;
     float itermAccelerator;
     uint16_t itermAcceleratorGain;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -54,6 +54,7 @@
 #endif
 
 #define ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF 15  // The anti gravity throttle highpass filter cutoff
+#define ANTI_GRAVITY_SMOOTH_FILTER_CUTOFF 3  // The anti gravity P smoothing filter cutoff
 
 static void pidSetTargetLooptime(uint32_t pidLooptime)
 {
@@ -202,6 +203,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 #endif
 
     pt1FilterInit(&pidRuntime.antiGravityThrottleLpf, pt1FilterGain(ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF, pidRuntime.dT));
+    pt1FilterInit(&pidRuntime.antiGravitySmoothLpf, pt1FilterGain(ANTI_GRAVITY_SMOOTH_FILTER_CUTOFF, pidRuntime.dT));
 
     pidRuntime.ffBoostFactor = (float)pidProfile->ff_boost / 10.0f;
 }
@@ -309,7 +311,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     // of AG activity without excessive display.
     pidRuntime.antiGravityOsdCutoff = 0.0f;
     if (pidRuntime.antiGravityMode == ANTI_GRAVITY_SMOOTH) {
-        pidRuntime.antiGravityOsdCutoff += ((pidRuntime.itermAcceleratorGain - 1000) / 1000.0f) * 0.25f;
+        pidRuntime.antiGravityOsdCutoff += (pidRuntime.itermAcceleratorGain / 1000.0f) * 0.25f;
     }
 
 #if defined(USE_ITERM_RELAX)


### PR DESCRIPTION
AntiGravity is primarily intended to reduce variations in pitch attitude when throttle is increased or decreased suddenly.

The root cause was thought to be changes in drag on the pitch axis as the airspeed changes.  iTerm is the primary factor that accumulates to deal with drag induced pitch errors.  In previous versions of betaflight, AntiGravity calculated a factor based on the rate of change of throttle, using a high-pass filter, and used that to boost I so that it could change to the new drag environment more quickly.

Video and log analysis shows that there is an abrupt pitch error late in a sudden throttle cut that occurs after the throttle stops moving.  The root cause of this is unknown.

The iTerm based AntiGravity signal works quite well while the throttle is moving fast.  Hence, during the throttle reduction period - while the throttle is being moved quickly - pitch remains quite stable.  

But once the throttle hits zero, iTerm is no longer boosted, and then we get a fast pitch wobble soon afterwards. 

This PR minimises this by boosting P in the late part of a throttle chop, and for a short time afterwards.  At this point the PID system appears to lack authority and performs much better if P is higher for a short period of time.

The code in the PR uses the high-pass throttle signal, but most strongly at zero throttle, reducing to nil at 50% throttle or higher.  Hence P will be boosted only when throttle leaves or returns to zero.  To prolong the P boost effect, and smooth it, a 3hz first order lowpass filter is applied to the P boost signal. 

Additionally, when throttle is suddenly pushed up hard from zero, especially repetitively at speed, there is a similar wobble, and this PR boosts P a little at that time and in a similar way, but the amount is reduced to only half that which would apply during a chop, to minimised the risk of P wobble on throttling up hard.

Some of the delayed boost from the P factor is added to the iTerm factor to prolong the classic iTerm effect.

The P boost factor is smoothly attenuated for turn rates over 50 deg/s, to avoid changing turn radius when changing throttle rapidly during a turn, but none the less does seem to improve control during turns, something a race pilot will notice.

It has been tested on a variety of builds and works very well.  

To me it seems like a lot of cumbersome code but it really does work.

The code requires a lot of  'cleaning up', because I simply wasn't clean about how best to implement it.

There are some 'fudge factors' that set the time constants and P gain factors.  

I was going to make the amount of P gain adjustable, but since the amount of P gain depends on the chosen amount if AntiGravity, and the default amount seems to work very well, I think it isn't needed.

Debug 0 = 'classic' iTerm Boost factor
Debug 1 = 'new', actual iTerm Boost amount
Debug 2 = pTerm boost for roll
Debug 3 = pTerm boost for pitch

