### PR TITLE
Allow exit from VTX pitmode when arming craft

### DIFF
--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -185,16 +185,11 @@ static bool vtxProcessPower(vtxDevice_t *vtxDevice)
 
 static bool vtxProcessPitMode(vtxDevice_t *vtxDevice)
 {
-    static bool prevPmSwitchState = false;
-
     unsigned vtxStatus;
-    if (!ARMING_FLAG(ARMED) && vtxCommonGetStatus(vtxDevice, &vtxStatus)) {
+    if (vtxCommonGetStatus(vtxDevice, &vtxStatus)) {
         bool currPmSwitchState = IS_RC_MODE_ACTIVE(BOXVTXPITMODE);
-
-        if (currPmSwitchState != prevPmSwitchState) {
-            prevPmSwitchState = currPmSwitchState;
-
-            if (currPmSwitchState) {
+        if (currPmSwitchState) {
+            if (!ARMING_FLAG(ARMED)) {
 #if defined(VTX_SETTINGS_FREQCMD)
                 if (vtxSettingsConfig()->pitModeFreq) {
                     return false;
@@ -205,12 +200,12 @@ static bool vtxProcessPitMode(vtxDevice_t *vtxDevice)
 
                     return true;
                 }
-            } else {
-                if (vtxStatus & VTX_STATUS_PIT_MODE) {
-                    vtxCommonSetPitMode(vtxDevice, false);
+            }
+        } else {
+            if (vtxStatus & VTX_STATUS_PIT_MODE) {
+                vtxCommonSetPitMode(vtxDevice, false);
 
-                    return true;
-                }
+                return true;
             }
         }
     }

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -918,7 +918,7 @@ static void vtxSASetPowerByIndex(vtxDevice_t *vtxDevice, uint8_t index)
 
 static void vtxSASetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
 {
-    static bool bLastOnOff = false;
+    static bool lastOnOff = false;
 
     if (!vtxSAIsReady(vtxDevice) || saDevice.version < 2) {
         return;
@@ -930,10 +930,10 @@ static void vtxSASetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
     }
 
     // Only issue pit mode commands on status change
-    if (bLastOnOff == onoff) {
+    if (lastOnOff == onoff) {
         return;
     }
-    bLastOnOff = onoff;
+    lastOnOff = onoff;
 
     if (saDevice.version >= 3 && !saDevice.willBootIntoPitMode) {
         if (onoff) {

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -918,6 +918,8 @@ static void vtxSASetPowerByIndex(vtxDevice_t *vtxDevice, uint8_t index)
 
 static void vtxSASetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
 {
+    static bool bLastOnOff = false;
+
     if (!vtxSAIsReady(vtxDevice) || saDevice.version < 2) {
         return;
     }
@@ -926,6 +928,12 @@ static void vtxSASetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
         // Smart Audio prior to V2.1 can not turn pit mode on by software.
         return;
     }
+
+    // Only issue pit mode commands on status change
+    if (bLastOnOff == onoff) {
+        return;
+    }
+    bLastOnOff = onoff;
 
     if (saDevice.version >= 3 && !saDevice.willBootIntoPitMode) {
         if (onoff) {


### PR DESCRIPTION
Hi,

I fly recreationally and use pit mode to help keep my vtx temperature down when not flying.

I was therefore hoping to tie the "VTX pit mode" and "arm" modes together, such that arming my quad disables pit mode and vice versa.

Following a previous pull request from myself for general improvements to the tramp implementation this configuration works around 50% of the time.

I've finally got around to looking at why.

VTX processing is locked out while armed, presumably to reduce unnecessary CPU load, unless there are configuration changes pending.

Currently pit mode configuration changes are only considered if not armed. Additionally the need for a pit mode status change (by comparison of pit mode status reported by device to pit mode status set in RC modes) is only considered when there's a change in pit mode status in RC modes.

This logic of only considering pit mode changes on RC mode changes, previously lead to the tramp module having to "lie" about its current pit mode status. Reporting its last configured mode, instead of the mode last reported by the device. In order to allow pit mode to be toggled in a short time frame.

This change corrects this, while respecting other VTX implementations (RTC6705 / SmartAudio). RTC6705 is totally unaffected. SmartAudio would be and as such the logic removed from vtxProcessPitMode has been added to vtxSASetPitMode. 

Additionally the change allows for the potential multiple processing calls required by the vtx module to achieve the desired pit mode. The tramp for example needs several calls in order to issue the new pit mode status and confirm its application via a follow up device query.

Additionally the change supports my goal my allowing exit from pit mode while armed, while still preventing accidental entry.

I would have submitted two separate pull requests but they're so closely related I would have found it hard to explain the need for the pit mode logic change without explaining the goal....let me know if I should split them.

I've tested fully with my IRC tramp however don't have access to a SmartAudio enabled VTX to test with.

I've attached the unified builds produced with "make unified_zip" which can be programmed for testing by following the guide here: https://youtu.be/I1uN9CN30gw

[betaflight_4.3.0_STM32F7X2_0fe69169b.zip](https://github.com/betaflight/betaflight/files/5179747/betaflight_4.3.0_STM32F7X2_0fe69169b.zip)

[betaflight_4.3.0_STM32F405_0fe69169b.zip](https://github.com/betaflight/betaflight/files/5179748/betaflight_4.3.0_STM32F405_0fe69169b.zip)

[betaflight_4.3.0_STM32F411_0fe69169b.zip](https://github.com/betaflight/betaflight/files/5179749/betaflight_4.3.0_STM32F411_0fe69169b.zip)

[betaflight_4.3.0_STM32F745_0fe69169b.zip](https://github.com/betaflight/betaflight/files/5179751/betaflight_4.3.0_STM32F745_0fe69169b.zip)

Thanks,

Phil

@jsworks - Could you give this a try at some point and see if it resolved your pitmode issues at power up?