### PR TITLE
Show stopped motors in Motor Diagnostic OSD element

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -139,6 +139,8 @@
 #define FULL_CIRCLE 360
 #define EFFICIENCY_MINIMUM_SPEED_CM_S 100
 
+#define MOTOR_STOPPED_THRESHOLD_RPM 1000
+
 #ifdef USE_OSD_STICK_OVERLAY
 typedef struct radioControls_s {
     uint8_t left_vertical;
@@ -1051,6 +1053,12 @@ static void osdElementMotorDiagnostics(osdElementParms_t *element)
     for (; i < getMotorCount(); i++) {
         if (motorsRunning) {
             element->buff[i] =  0x88 - scaleRange(motor[i], getMotorOutputLow(), getMotorOutputHigh(), 0, 8);
+#if defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
+            if (getEscRpm(i) < MOTOR_STOPPED_THRESHOLD_RPM) {
+                // Motor is not spinning properly. Mark as Stopped
+                element->buff[i] = 'S';
+            }
+#endif
         } else {
             element->buff[i] =  0x88;
         }


### PR DESCRIPTION
Problem: After landing in grass, a soft crash or during turtle mode, one or more motors can get stuck (tall grass, branches, etc). It would be useful to be told in OSD when this happens in order to stop trying to take off and not overload the ESC.

In this PR, I'm hijacking the motor diagnostics element to display 'S' when motor is stopped.

currently motor diagnostics displays this element:  `_ _ _ _` 
If one motor is stopped, following is shown: `_ _ S _`

I have a feeling there are better ways to get this functionality, like in warning message. (there's something similar in warnings if ESC_SENSOR is enabled, but it doesn't work for dshot_telemetry).



