### PR TITLE
Removed DPS310 baro from IFLIGHT_H743_AIO for maintenance branch.

### DIFF
--- a/src/main/target/IFLIGHT_H743_AIO/target.h
+++ b/src/main/target/IFLIGHT_H743_AIO/target.h
@@ -99,8 +99,8 @@
 #define USE_MAG
 #define USE_MAG_HMC5883
 
-#define USE_BARO
-#define USE_BARO_DPS310
+//#define USE_BARO
+//#define USE_BARO_DPS310
 
 #define USE_GYRO
 #define USE_ACC

--- a/src/main/target/IFLIGHT_H743_AIO/target.mk
+++ b/src/main/target/IFLIGHT_H743_AIO/target.mk
@@ -11,4 +11,3 @@ TARGET_SRC += \
             $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270.c \
             drivers/accgyro/accgyro_spi_bmi270.c \
             drivers/compass/compass_hmc5883l.c \
-            drivers/barometer/barometer_dps310.c \


### PR DESCRIPTION
@Linjieqiang: The DPS310 baro will only be available in 4.3. We can either add this flight controller to 4.2 without baro support, or we can wait with adding it until 4.3. Let me know which one you prefer.