### PR TITLE
Add VGRC-VGOODRCF405DJI targets config

### DIFF
--- a/unified_targets/configs/VGRC-VGOODRCF405DJI
+++ b/unified_targets/configs/VGRC-VGOODRCF405DJI
@@ -1,0 +1,126 @@
+board_name VGOODRCF405DJI
+manufacturer_id VGRC
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 A09
+resource MOTOR 2 A08
+resource MOTOR 3 C09
+resource MOTOR 4 C08
+resource PPM 1 B09
+resource LED_STRIP 1 B03
+resource SERIAL_TX 1 B06
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 B07
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource INVERTER 1 C00
+resource LED 1 C15
+resource LED 2 C14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ESCSERIAL 1 B09
+resource CAMERA_CONTROL 1 B08
+resource ADC_BATT 1 C01
+resource ADC_RSSI 1 C02
+resource ADC_CURR 1 C03
+resource PINIO 1 B00
+resource FLASH_CS 1 A15
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+
+# timer
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+
+# dma
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
+dma pin A09 0
+# pin A09: DMA2 Stream 6 Channel 0
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature MOTOR_STOP
+feature SOFTSERIAL
+feature TELEMETRY
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 3 1 115200 57600 0 115200
+
+# led
+led 0 0,15::ATI:0
+led 1 1,15::ATI:0
+led 2 2,15::ATI:0
+led 3 3,15::ATI:0
+led 4 4,15::ATI:0
+led 5 5,15::ATI:0
+
+# aux
+aux 0 0 0 1700 2100 0 0
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 2
+set baro_bustype = I2C
+set baro_i2c_device = 2
+set serialrx_provider = SBUS
+set adc_device = 3
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set dshot_bidir = ON
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set osd_vbat_pos = 14434
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 2
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
Hi Mikeller,
For the  safety about default with Dshot 600:
We sell this controller with our latest BLHeli_32 ESC and our ESC default also with Dshot600, at the same time, we will write and enhance this safety instruction in our FC manual. We will take responsibility for any safety issue if there. tks.

