### PR TITLE
Remove unnecessary drawScreen() calls for MSP displayPort OSD

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1032,8 +1032,18 @@ void osdUpdate(timeUs_t currentTimeUs)
         osdRefresh(currentTimeUs);
         showVisualBeeper = false;
     } else {
-        // rest of time redraw screen 10 chars per idle so it doesn't lock the main idle
-        displayDrawScreen(osdDisplayPort);
+        bool doDrawScreen = true;
+#if defined(USE_CMS) && defined(USE_MSP_DISPLAYPORT) && defined(USE_OSD_OVER_MSP_DISPLAYPORT)
+        // For the MSP displayPort device only do the drawScreen once per
+        // logical OSD cycle as there is no output buffering needing to be flushed.
+        if (osdDisplayPortDeviceType == OSD_DISPLAYPORT_DEVICE_MSP) {
+            doDrawScreen = (counter % DRAW_FREQ_DENOM == 1);
+        }
+#endif
+        // Redraw a portion of the chars per idle to spread out the load and SPI bus utilization
+        if (doDrawScreen) {
+            displayDrawScreen(osdDisplayPort);
+        }
     }
     ++counter;
 }


### PR DESCRIPTION
The previous logic runs the OSD task at 60hz with a logical update rate of 12hz. The structure is based around an "update" (draw the elements) phase followed by 4 "drawScreen" phases that are designed to spread out the flushing of the screen buffer over SPI and reduce the OSD task delay.

The problem with MSP displayport is that is has no buffering aspect. The data is sent immediately to the external device as the elements are "drawn". Later only a single "drawScreen" call is needed to tell the external device to render. So because the same logical structure was used as for the max7456, there were 3 unnecessary drawScreen calls resulting in 36 messages and ~250 bytes sent over the serial line every second.

Discovered while testing with an external application that emulates a MSP displayPort serial device (reads the serial data, renders the OSD). Found the application was needing excessively high processing power because it was being told to render the display 4 times too often.