### PR TITLE
Add compile-time option to enable MSP push messages over the VCP port

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -562,7 +562,11 @@ int mspSerialPush(serialPortIdentifier_e port, uint8_t cmd, uint8_t *data, int d
         mspPort_t * const mspPort = &mspPorts[portIndex];
 
         // XXX Kludge!!! Avoid zombie VCP port (avoid VCP entirely for now)
-        if (!mspPort->port || mspPort->port->identifier == SERIAL_PORT_USB_VCP || (port != SERIAL_PORT_NONE && mspPort->port->identifier != port)) {
+        if (!mspPort->port
+#ifndef USE_MSP_PUSH_OVER_VCP
+            || mspPort->port->identifier == SERIAL_PORT_USB_VCP
+#endif
+            || (port != SERIAL_PORT_NONE && mspPort->port->identifier != port)) {
             continue;
         }
 


### PR DESCRIPTION
Enables easier development and testing of MSP displayPort devices as the existing VCP connection to a computer can be used.

To use, define `USE_MSP_PUSH_OVER_VCP` either in the code or when compiling like:
```
make TARGET=STM32F405 OPTIONS=USE_MSP_PUSH_OVER_VCP
```

The existing code has the VCP blocked for MSP push serial as it can cause a number of problems. If there is no consumer then the USB endpoint will quickly fill its buffer and start flow-controlling. This leads to the the STM libraries blocking and the firmware wedges until data is read. So it's only appropriate that this is used for development testing.
