### PR TITLE
Detect duplicated RC frames in input filtering

### DIFF
--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -137,11 +137,14 @@ typedef struct rcSmoothingFilter_s {
     uint8_t autoSmoothnessFactor;
 } rcSmoothingFilter_t;
 
+#define DUPLICATION_MIN_STREAK_LENGTH  4
+#define DUPLICATION_STREAKS_TO_TRIGGER 10
 typedef struct rcDuplicationDetector_s {
     uint8_t framerateDivider;   // how many rc frames should count as one logical frame
     float lastRxData;           // the last raw RX value on the channel we are testing for duplicated frames
     uint8_t currentStepLength;  // length of the current streak in number of frames
-    uint8_t detectedStepCount;  // how many times did we detect 2 frame long streaks
+    uint8_t detectedStepCount;  // how many times did we detect 2 frame long consecutive steps in this streak
+    uint8_t totalStreaksFound;  // number of streaks matching being at least DUPLICATION_MIN_STREAK_LENGTH long
 } rcDuplicationDetector_t;
 
 typedef struct rcControlsConfig_s {

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -137,6 +137,13 @@ typedef struct rcSmoothingFilter_s {
     uint8_t autoSmoothnessFactor;
 } rcSmoothingFilter_t;
 
+typedef struct rcDuplicationDetector_s {
+    uint8_t framerateDivider;   // how many rc frames should count as one logical frame
+    float lastRxData;           // the last raw RX value on the channel we are testing for duplicated frames
+    uint8_t currentStepLength;  // length of the current streak in number of frames
+    uint8_t detectedStepCount;  // how many times did we detect 2 frame long streaks
+} rcDuplicationDetector_t;
+
 typedef struct rcControlsConfig_s {
     uint8_t deadband;                       // introduce a deadband around the stick center for pitch and roll axis. Must be greater than zero.
     uint8_t yaw_deadband;                   // introduce a deadband around the stick center for yaw axis. Must be greater than zero.


### PR DESCRIPTION
This is a proof-of-concept change for issue #10233, so please forgive me, if it does not yet meet the standards for merge. My intent to start a discussion about this way of solving the issue. I'm open for comments and alternative ideas.

My goal with this change is to add a small and lightweight feature to detect Frsky D16 style frame duplication in the RC signal, and adapt the filter in auto mode to this. In D16 mode the receiver updates half of the channels in every odd frame the other half in every even frame. Also some more sophisticated algorithms is also possible.

The idea is to look for a distinctive pattern in the signal that would give away this kind of behavior, and if it has been seen enough times, then adapt the filter to this. The pattern I'm looking for is a "staircase" like change in the input, where every value is sent exactly two times. Something like this: `20 20 32 32 44 44 41 41` etc. If we see shorter changes, like `21 32 38 39 23 12` then we ignore those. Also longer streaks like `20 20 20 20 20 44 44 32 32 32` are ignored, even if there is an occasional duplication. To avoid false positives the staircase should have a minimal number of steps (currently set to 4), and we have to see a significant amount of these patterns (now set to 10) to trigger the "repeating frames mode". With these limits it took 1-2 seconds of input to trigger filtering with D16 protocol, but had zero pattern detection with D8 under a significant time.

Once turned on I see no reason to turn it off, so the current implementation will stay there until the FC is reset.


I tried to think over if this solution had potential problems:

- what if it gives us a false positive? Well I think it's very unlikely to get a false positive, unless the RX produces staircased output. Even if that happened for some weird reason, I believe it isn't a bad thing to smooth those out as well. Also this is only applied to channels that the user selected.

 - what if the algorithm does not trigger where it should? That would be the same outcome that we have currently, so in that case nothing happens.

 - Does this take a lot of resources? I don't think so, it requires a few bytes of ram, and simple comparison and addition. If that's an issue, then a time limit could also be added, after that the whole thing can be skipped from the loop.

- currently it checks the ROLL channel, because hardwiring was easier and this axis receives a lot of input with most aircraft types. But it could be rewritten to analyse any of the channels where smoothing has been set up.

 - the code looks for a very specific kind of behavior. It does not handle if the RX send every frame 3, 4, or more times. If that issue exists then it could be generalized to detect such issues as well. 

 - the change currently affects only the RC smoothing in filtered mode, so it's handled during that phase. But maybe this information could be useful for other parts of the code as well (for example in interpolation mode). In that case it could be moved somewhere else, and made the outcome more visible.

Please let me know what do you think?  I have a limited knowledge about radio protocols, so I would be glad to get feedback to you guys who can judge these things better.

Thank you for your help.