### PR TITLE
Add optional high framerate OSD

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1426,6 +1426,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
     { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
     { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
+    { "osd_high_framerate",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, high_framerate) },
 #endif // end of #ifdef USE_OSD
 
 // PG_SYSTEM_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1426,7 +1426,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
     { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
     { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
-    { "osd_high_framerate",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, high_framerate) },
+    { "osd_task_frequency",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_TASK_FREQUENCY_MIN, OSD_TASK_FREQUENCY_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, task_frequency) },
 #endif // end of #ifdef USE_OSD
 
 // PG_SYSTEM_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1426,7 +1426,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },
     { "osd_camera_frame_width",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_WIDTH, OSD_CAMERA_FRAME_MAX_WIDTH }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_width) },
     { "osd_camera_frame_height",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_CAMERA_FRAME_MIN_HEIGHT, OSD_CAMERA_FRAME_MAX_HEIGHT }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_frame_height) },
-    { "osd_task_frequency",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { OSD_TASK_FREQUENCY_MIN, OSD_TASK_FREQUENCY_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, task_frequency) },
+    { "osd_task_frequency",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { OSD_TASK_FREQUENCY_MIN, OSD_TASK_FREQUENCY_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, task_frequency) },
 #endif // end of #ifdef USE_OSD
 
 // PG_SYSTEM_CONFIG

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -335,6 +335,7 @@ void tasksInit(void)
 #endif
 
 #ifdef USE_OSD
+    rescheduleTask(TASK_OSD, TASK_PERIOD_HZ(osdConfig()->task_frequency));
     setTaskEnabled(TASK_OSD, featureIsEnabled(FEATURE_OSD) && osdGetDisplayPort(NULL));
 #endif
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -56,7 +56,6 @@
 #include "drivers/display.h"
 #include "drivers/dshot.h"
 #include "drivers/flash.h"
-#include "drivers/osd.h"
 #include "drivers/osd_symbols.h"
 #include "drivers/sdcard.h"
 #include "drivers/time.h"
@@ -64,7 +63,6 @@
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
-#include "fc/tasks.h"
 
 #if defined(USE_GYRO_DATA_ANALYSE)
 #include "flight/gyroanalyse.h"
@@ -85,7 +83,6 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/stats.h"
-#include "pg/vcd.h"
 
 #include "rx/crsf.h"
 #include "rx/rx.h"
@@ -417,12 +414,6 @@ static void osdCompleteInitialization(void)
     osdElementsInit(backgroundLayerSupported);
     osdAnalyzeActiveElements();
     displayCommitTransaction(osdDisplayPort);
-
-#if defined(USE_MAX7456) || defined(USE_FRSKYOSD)
-    task_t *taskOsd;
-    taskOsd = getTask(TASK_OSD);
-    taskOsd->desiredPeriodUs = TASK_PERIOD_HZ(osdConfig()->task_frequency);
-#endif
 
     osdIsReady = true;
 }

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -343,7 +343,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->camera_frame_width = 24;
     osdConfig->camera_frame_height = 11;
 
-    osdConfig->high_framerate = 0;
+    osdConfig->task_frequency = 60;
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)
@@ -421,17 +421,7 @@ static void osdCompleteInitialization(void)
 #if defined(USE_MAX7456) || defined(USE_FRSKYOSD)
     task_t *taskOsd;
     taskOsd = getTask(TASK_OSD);
-    if (osdConfig()->high_framerate) { 
-      switch (vcdProfile()->video_system) {
-      case VIDEO_SYSTEM_PAL:
-        taskOsd->desiredPeriodUs = TASK_PERIOD_HZ(125);
-        break;
-      case VIDEO_SYSTEM_NTSC:
-      default:
-        taskOsd->desiredPeriodUs = TASK_PERIOD_HZ(150);
-        break;
-      }
-    }
+    taskOsd->desiredPeriodUs = TASK_PERIOD_HZ(osdConfig()->task_frequency);
 #endif
 
     osdIsReady = true;

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -287,7 +287,7 @@ typedef struct osdConfig_s {
     uint8_t logo_on_arming_duration;          // display duration in 0.1s units
     uint8_t camera_frame_width;               // The width of the box for the camera frame element
     uint8_t camera_frame_height;              // The height of the box for the camera frame element
-    uint8_t task_frequency;
+    uint16_t task_frequency;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -49,6 +49,9 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_CAMERA_FRAME_MIN_HEIGHT 2
 #define OSD_CAMERA_FRAME_MAX_HEIGHT 16    // Rows supported by MAX7456 (PAL)
 
+#define OSD_TASK_FREQUENCY_MIN 30
+#define OSD_TASK_FREQUENCY_MAX 300
+
 #define OSD_PROFILE_BITS_POS 11
 #define OSD_PROFILE_MASK    (((1 << OSD_PROFILE_COUNT) - 1) << OSD_PROFILE_BITS_POS)
 #define OSD_POS_MAX   0x3FF
@@ -284,7 +287,7 @@ typedef struct osdConfig_s {
     uint8_t logo_on_arming_duration;          // display duration in 0.1s units
     uint8_t camera_frame_width;               // The width of the box for the camera frame element
     uint8_t camera_frame_height;              // The height of the box for the camera frame element
-    uint8_t high_framerate;
+    uint8_t task_frequency;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -284,6 +284,7 @@ typedef struct osdConfig_s {
     uint8_t logo_on_arming_duration;          // display duration in 0.1s units
     uint8_t camera_frame_width;               // The width of the box for the camera frame element
     uint8_t camera_frame_height;              // The height of the box for the camera frame element
+    uint8_t high_framerate;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
OSD refresh rate is 12 Hz in Betaflight now. This may be not enough for some users.

Me and my racing team always enable hundredths precision on timer, on our practice sessions. So when we analyse our DVR recordings we can find out, which way of passing the element is faster, find a way to gain hundredths of second on a track.

Currently, timer value does not change every frame. This makes our analysis more difficult.

This PR introduces an `osd_high_framerate` cli option.
Disabled by default. If enabled, the period of OSD task is increased from 60 to 125 or 150 Hz depending on PAL/NTSC video system.

Here is a slowmo demo: https://www.youtube.com/watch?v=SN8LKib5JW0
Timer is highlighted with arrow.