### PR TITLE
Enable BMP085/BMP180 for F405 and F745 unified targets

### DIFF
--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -25,7 +25,9 @@
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F405"
 
+// Additional drivers included for targets with > 512KB of flash
 #define USE_ACCGYRO_BMI270
+#define USE_BARO_BMP085
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
@@ -114,7 +116,9 @@
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F745"
 
+// Additional drivers included for targets with > 512KB of flash
 #define USE_ACCGYRO_BMI270
+#define USE_BARO_BMP085
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2


### PR DESCRIPTION
Adds support for these older devices in targets that have lots of available flash space.
