### PR TITLE
Fix dfuse and python check

### DIFF
--- a/make/linux.mk
+++ b/make/linux.mk
@@ -6,30 +6,26 @@
 #   and the ARM toolchain installed to either the Taulabs/tools directory, their
 #   respective default installation locations, or made available on the system path.
 
-# Check for and find Python 2
-
-# Get Python version, separate major/minor/patch, then put into wordlist
-PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
-# Get major version from aforementioned list
-PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))
-# Just in case Make has some weird scope stuff
-PYTHON=0
-# If the major Python version is the one we want..
-ifeq ($(PYTHON_MAJOR_VERSION_),2)
-	# Then we can just use the normal Python executable
-	PYTHON:=python
+# First look for `python3`. If `which` doesn't return a null value, then it exists!
+ifneq ($(shell which python3), "")
+    PYTHON:=python3
 else
-	# However, this isn't always the case..
-	# Let's look for `python2`. If `which` doesn't return a null value, then
-	#  it exists!
-	ifneq ($(shell which python2), "")
-		PYTHON:=python2
-	else
-		# And if it doesn't exist, let's use the default Python, and warn the user.
-		# PYTHON NOT FOUND.
-		PYTHON:=python
-		echo "Python not found."
-	endif
+    # Get Python version, separate major/minor/patch, then put into wordlist
+    PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
+    # Get major version from aforementioned list
+    PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))
+    # Just in case Make has some weird scope stuff
+    PYTHON=0
+    # If the major Python version is the one we want..
+    ifeq ($(PYTHON_MAJOR_VERSION_),3)
+	    # Then we can just use the normal Python executable
+        PYTHON:=python
+    else
+	    # And if it doesn't exist, let's use the default Python, and warn the user.
+	    # PYTHON NOT FOUND.
+        PYTHON:=python
+        echo "Python not found."
+    endif
 endif
 
 export PYTHON

--- a/make/macosx.mk
+++ b/make/macosx.mk
@@ -6,30 +6,26 @@
 #   ARM toolchain installed to either their respective default installation
 #   locations, the tools directory or made available on the system path.
 
-# Check for and find Python 2
-
-# Get Python version, separate major/minor/patch, then put into wordlist
-PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
-# Get major version from aforementioned list
-PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))
-# Just in case Make has some weird scope stuff
-PYTHON=0
-# If the major Python version is the one we want..
-ifeq ($(PYTHON_MAJOR_VERSION_),2)
-	# Then we can just use the normal Python executable
-	PYTHON:=python
+# First look for `python3`. If `which` doesn't return a null value, then it exists!
+ifneq ($(shell which python3), "")
+    PYTHON:=python3
 else
-	# However, this isn't always the case..
-	# Let's look for `python2`. If `which` doesn't return a null value, then
-	#  it exists!
-	ifneq ($(shell which python2), "")
-		PYTHON:=python2
-	else
-		# And if it doesn't exist, let's use the default Python, and warn the user.
-		# PYTHON NOT FOUND.
-		PYTHON:=python
-		echo "Python not found."
-	endif
+    # Get Python version, separate major/minor/patch, then put into wordlist
+    PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
+    # Get major version from aforementioned list
+    PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))
+    # Just in case Make has some weird scope stuff
+    PYTHON=0
+    # If the major Python version is the one we want..
+    ifeq ($(PYTHON_MAJOR_VERSION_),3)
+	    # Then we can just use the normal Python executable
+        PYTHON:=python
+    else
+	    # And if it doesn't exist, let's use the default Python, and warn the user.
+	    # PYTHON NOT FOUND.
+        PYTHON:=python
+        echo "Python not found."
+    endif
 endif
 
 export PYTHON

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -196,38 +196,6 @@ stm32flash_clean:
 	@echo " CLEAN        $(STM32FLASH_DIR)"
 	$(V1) [ ! -d "$(STM32FLASH_DIR)" ] || $(RM) -r "$(STM32FLASH_DIR)"
 
-DFUUTIL_DIR := $(TOOLS_DIR)/dfu-util
-
-.PHONY: dfuutil_install
-dfuutil_install: DFUUTIL_URL  := http://dfu-util.sourceforge.net/releases/dfu-util-0.8.tar.gz
-dfuutil_install: DFUUTIL_FILE := $(notdir $(DFUUTIL_URL))
-dfuutil_install: | $(DL_DIR) $(TOOLS_DIR)
-dfuutil_install: dfuutil_clean
-        # download the source
-	@echo " DOWNLOAD     $(DFUUTIL_URL)"
-	$(V1) curl -L -k -o "$(DL_DIR)/$(DFUUTIL_FILE)" "$(DFUUTIL_URL)"
-
-        # extract the source
-	@echo " EXTRACT      $(DFUUTIL_FILE)"
-	$(V1) [ ! -d "$(DL_DIR)/dfuutil-build" ] || $(RM) -r "$(DL_DIR)/dfuutil-build"
-	$(V1) mkdir -p "$(DL_DIR)/dfuutil-build"
-	$(V1) tar -C $(DL_DIR)/dfuutil-build -xf "$(DL_DIR)/$(DFUUTIL_FILE)"
-
-        # build
-	@echo " BUILD        $(DFUUTIL_DIR)"
-	$(V1) mkdir -p "$(DFUUTIL_DIR)"
-	$(V1) ( \
-	  cd $(DL_DIR)/dfuutil-build/dfu-util-0.8 ; \
-	  ./configure --prefix="$(DFUUTIL_DIR)" ; \
-	  $(MAKE) ; \
-	  $(MAKE) install ; \
-	)
-
-.PHONY: dfuutil_clean
-dfuutil_clean:
-	@echo " CLEAN        $(DFUUTIL_DIR)"
-	$(V1) [ ! -d "$(DFUUTIL_DIR)" ] || $(RM) -r "$(DFUUTIL_DIR)"
-
 # Set up uncrustify tools
 UNCRUSTIFY_DIR := $(TOOLS_DIR)/uncrustify-0.61
 UNCRUSTIFY_BUILD_DIR := $(DL_DIR)/uncrustify

--- a/src/utils/dfuse-pack.py
+++ b/src/utils/dfuse-pack.py
@@ -135,7 +135,7 @@ if __name__=="__main__":
           try:
             address = address & 0xFFFFFFFF
           except ValueError:
-            print "Address %s invalid." % address
+            print("Address %s invalid." % address)
             sys.exit(1)
           target.append({ 'address': address, 'data': ih.tobinstr(start=address, end=end-1)})
 


### PR DESCRIPTION

- Fixes installation of `make dfu_flash TARGET=TARGET`
- Add checking for `python3`
- Needs makefile change in #10266
- Some investigation and updates / fixes:

`make/linux.mk` is looking for python 2. It does not work if there is only python3 installed (default in Ubuntu 20.04). Changed it to first look for python3 command and after that it checks if the python command is using version 3. The file `dfuse-pack.py` is using python 3 syntax? (PR9217 does mention python 2.8 requirement but it runs on python3 now)

Install requirements:
```
sudo apt install dfu-util python-pip3
pip3 install IntelHex
```
Almost working (FC is in DFU mode using boot button):
```
mark@HP:~/dev/betaflight$ make dfu_flash TARGET=MATEKF411
make ./obj/betaflight_4.3.0_MATEKF411_5669e4421.dfu
make[1]: Entering directory '/home/mark/dev/betaflight'
make[1]: 'obj/betaflight_4.3.0_MATEKF411_5669e4421.dfu' is up to date.
make[1]: Leaving directory '/home/mark/dev/betaflight'
dfu-util -a 0 -D ./obj/betaflight_4.3.0_MATEKF411_5669e4421.dfu -s :leave
dfu-util 0.9

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2016 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Match vendor ID from file: 0483
Match product ID from file: df11
dfu-util: No DFU capable USB device available
make: *** [Makefile:534: dfu_flash] Error 74
```