### PR TITLE
Make the MPU6050 (I2C) driver only build on Unified Targets with 1MB flash.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6050.c
@@ -24,6 +24,8 @@
 
 #include "platform.h"
 
+#if defined(USE_ACC_MPU6050) || defined(USE_GYRO_MPU6050)
+
 #include "build/debug.h"
 
 #include "common/maths.h"
@@ -111,3 +113,4 @@ bool mpu6050GyroDetect(gyroDev_t *gyro)
 
     return true;
 }
+#endif

--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -155,8 +155,6 @@
 #define USE_ACC
 #define USE_GYRO
 
-#define USE_ACC_MPU6050
-#define USE_GYRO_MPU6050
 #define USE_ACC_MPU6500
 #define USE_GYRO_MPU6500
 #define USE_ACC_SPI_MPU6000
@@ -253,6 +251,9 @@
 
 // Additional drivers included for targets with > 512KB of flash
 #if (TARGET_FLASH_SIZE > 512)
+#define USE_ACC_MPU6050
+#define USE_GYRO_MPU6050
 #define USE_ACCGYRO_BMI270
+
 #define USE_BARO_BMP085
 #endif


### PR DESCRIPTION
Frees ~ 300 bytes, makes STM32F7X2 build again.