### PR TITLE
Improve smartport GPS logic to make sensor detection easier

### DIFF
--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -114,6 +114,7 @@ extern uint16_t flightModeFlags;
 typedef enum {
     GPS_FIX_HOME   = (1 << 0),
     GPS_FIX        = (1 << 1),
+    GPS_FIX_EVER   = (1 << 2),
 } stateFlags_t;
 
 #define DISABLE_STATE(mask) (stateFlags &= ~(mask))

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -950,11 +950,7 @@ static bool gpsNewFrameNMEA(char c)
                                 gps_Msg.longitude *= -1;
                             break;
                         case 6:
-                            if (string[0] > '0') {
-                                ENABLE_STATE(GPS_FIX);
-                            } else {
-                                DISABLE_STATE(GPS_FIX);
-                            }
+                            gpsSetFixState(string[0] > '0');
                             break;
                         case 7:
                             gps_Msg.numSat = grab_fields(string, 0);
@@ -1277,11 +1273,7 @@ static bool UBLOX_parse_gps(void)
         gpsSol.llh.lon = _buffer.posllh.longitude;
         gpsSol.llh.lat = _buffer.posllh.latitude;
         gpsSol.llh.altCm = _buffer.posllh.altitudeMslMm / 10;  //alt in cm
-        if (next_fix) {
-            ENABLE_STATE(GPS_FIX);
-        } else {
-            DISABLE_STATE(GPS_FIX);
-        }
+        gpsSetFixState(next_fix);
         _new_position = true;
         break;
     case MSG_STATUS:
@@ -1583,6 +1575,16 @@ void onGpsNewData(void)
 #ifdef USE_GPS_RESCUE
     rescueNewGpsData();
 #endif
+}
+
+void gpsSetFixState(bool state)
+{
+    if (state) {
+        ENABLE_STATE(GPS_FIX);
+        ENABLE_STATE(GPS_FIX_EVER);
+    } else {
+        DISABLE_STATE(GPS_FIX);
+    }
 }
 
 #endif

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -188,4 +188,5 @@ void onGpsNewData(void);
 void GPS_reset_home_position(void);
 void GPS_calc_longitude_scaling(int32_t lat);
 void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, int32_t *destinationLat2, int32_t *destinationLon2, uint32_t *dist, int32_t *bearing);
+void gpsSetFixState(bool state);
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3055,11 +3055,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 
 #ifdef USE_GPS
     case MSP_SET_RAW_GPS:
-        if (sbufReadU8(src)) {
-            ENABLE_STATE(GPS_FIX);
-        } else {
-            DISABLE_STATE(GPS_FIX);
-        }
+        gpsSetFixState(sbufReadU8(src));
         gpsSol.numSat = sbufReadU8(src);
         gpsSol.llh.lat = sbufReadU32(src);
         gpsSol.llh.lon = sbufReadU32(src);


### PR DESCRIPTION
Allows the user to "discover" the GPS sensors without having to wait for a GPS fix.

Problem: The previous logic would not send the smartport GPS sensors until there was a valid GPS fix. This made configuration extremely difficult on the bench - requiring long waits for satellites which may not even be possible indoors.

However there was also a (likely accidental) benefit in the previous logic in that if the GPS fix was lost (like after crashing upside down) the sensor would no longer be sent and the radio would continue to display the "last" valid position.

So we want to improve the detection, but not break the "lost fix" behavior. The new logic will send the sensors under the following conditions:

1. Have a valid GPS fix (just like the previous logic).
2. The GPS is functioning (feature enabled and communicating with the module) but has never had a valid fix.

So the logic will send the sensors with empty (0) values until a fix is obtained (making it easy for users to discover the sensors), then continue to send the sensors while the GPS fix is valid (with real GPS data). If the fix is lost then the sensors will not be sent (preserving the "lost fix" behavior).