### PR TITLE
Add target-level compiler optimization - reduce F722 optimization to save space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,15 @@ ifeq ($(DEBUG),INFO)
 DEBUG_FLAGS            = -ggdb3
 endif
 OPTIMISATION_BASE     := -flto -fuse-linker-plugin -ffast-math
+ifeq ($(OPTIMISE_DEFAULT),)
 OPTIMISE_DEFAULT      := -O2
+endif
+ifeq ($(OPTIMISE_SPEED),)
 OPTIMISE_SPEED        := -Ofast
+endif
+ifeq ($(OPTIMISE_SIZE),)
 OPTIMISE_SIZE         := -Os
+endif
 
 LTO_FLAGS             := $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
 endif

--- a/src/main/target/STM32_UNIFIED/STM32F7X2.mk
+++ b/src/main/target/STM32_UNIFIED/STM32F7X2.mk
@@ -1,0 +1,3 @@
+# Override the OPTIMISE_SPEED compiler setting to save flash space on this 512KB target.
+# Performance is only slightly affected but a very large amount of flash is saved.
+OPTIMISE_SPEED = -O2


### PR DESCRIPTION
Adds option to set the compiler optimizations in the target `.mk` file to tailor the settings to a particular architecture.

STM32F7X2 unified target "speed" optimized code changed from `-Ofast` to `-O2` compiler optimization level. Saves ~50KB of flash and ~3400 bytes of ITCM RAM. Performance impact is minimal (particularly in relation to the huge space savings) and users won't notice any difference. CPU% is unchanged for the same configuration. Tasks show minor performance loss but there is plenty of processing power still available on F722. For example running at 8/8/DSHOT600 w/bidirectional DSHOT:

Before:
```
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0
01 - (         SYSTEM)    999       3       1    0.7%    0.5%        47
02 - (           GYRO)   8000      18       8   14.9%    6.9%      2795
03 - (         FILTER)   8000      16      13   13.3%   10.9%      4848
04 - (            PID)   8000      50      38   40.5%   30.9%     14873
05 - (            ACC)    999      11       9    1.5%    1.3%       434
06 - (       ATTITUDE)    100      11      10    0.6%    0.6%        45
07 - (             RX)     33      37      36    0.6%    0.6%        58
08 - (         SERIAL)    100     847       2    8.9%    0.5%       691
09 - (       DISPATCH)    997       2       0    0.6%    0.0%        26
10 - (BATTERY_VOLTAGE)     50       3       1    0.5%    0.5%         4
11 - (BATTERY_CURRENT)     50       2       0    0.5%    0.0%         1
12 - ( BATTERY_ALERTS)      5       2       1    0.5%    0.5%         0
13 - (         BEEPER)    100       3       2    0.5%    0.5%         7
23 - (            OSD)     60      21      10    0.6%    0.5%        31
25 - (            CMS)     20       2       2    0.5%    0.5%         1
26 - (        VTXCTRL)      5       1       0    0.5%    0.0%         0
27 - (        CAMCTRL)      5       1       0    0.5%    0.0%         0
29 - (    ADCINTERNAL)      1       4       3    0.5%    0.5%         0
RX Check Function                   2       1                         2
Total (excluding SERIAL)                        77.8%   54.7%
```

After:
```
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0
01 - (         SYSTEM)    997       2       1    0.6%    0.5%        61
02 - (           GYRO)   8000       9       8    7.7%    6.9%      3869
03 - (         FILTER)   8000      21      16   17.3%   13.3%      8873
04 - (            PID)   8000      53      40   42.9%   32.5%     21651
05 - (            ACC)    999      11       8    1.5%    1.2%       597
06 - (       ATTITUDE)    100      12      11    0.6%    0.6%        69
07 - (             RX)     33      44      41    0.6%    0.6%        90
08 - (         SERIAL)    100     906       2    9.5%    0.5%       696
09 - (       DISPATCH)    998       2       1    0.6%    0.5%        40
10 - (BATTERY_VOLTAGE)     50       3       2    0.5%    0.5%         6
11 - (BATTERY_CURRENT)     50       2       1    0.5%    0.5%         2
12 - ( BATTERY_ALERTS)      5       2       2    0.5%    0.5%         0
13 - (         BEEPER)    100       2       1    0.5%    0.5%         6
23 - (            OSD)     60      22      10    0.6%    0.5%        42
25 - (            CMS)     20       3       1    0.5%    0.5%         2
26 - (        VTXCTRL)      5       1       1    0.5%    0.5%         0
27 - (        CAMCTRL)      5       1       1    0.5%    0.5%         0
29 - (    ADCINTERNAL)      1       4       3    0.5%    0.5%         0
RX Check Function                   2       2                         2
Total (excluding SERIAL)                        76.9%   60.6%
```

The things to focus on are the `GYRO`, `FILTER` and `PID` tasks and in particular if their average execution times summed begin to threaten the 125us window for 8K loop time. Before the changes the consolidated task time was 59us, after is 64us. Still only using 50% of the available processing window.