### PR TITLE
[H7] Remove USB_USB_ID from target.h

### DIFF
--- a/src/main/target/IFLIGHT_H743_AIO/target.h
+++ b/src/main/target/IFLIGHT_H743_AIO/target.h
@@ -60,7 +60,6 @@
 #define UART8_TX_PIN            PE1
 
 #define USE_VCP
-#define USE_USB_ID
 
 #define SERIAL_PORT_COUNT       8
 

--- a/src/main/target/IFLIGHT_H7_TWING/target.h
+++ b/src/main/target/IFLIGHT_H7_TWING/target.h
@@ -87,7 +87,6 @@
 #define UART8_TX_PIN            PE1
 
 #define USE_VCP
-#define USE_USB_ID
 
 #define SERIAL_PORT_COUNT       9
 


### PR DESCRIPTION
Defining USB_USB_ID causes PA10 to be configured as USB ID pin, and renders function that use this pin for other purpose, such as UART1_RX, to stop as soon as USB is initialized.

Some H7 targets (namely IFLIGHT_H7_TWING and IFLIGHT_H743_AIO) suffered from this behavior since 4.2.0.
SPRacing H7 series do not explicitly use PA10, so it probably does not have PA10 connected or USB ID is actually in effect (don't care anyways).

The root cause for this bug to surface with 4.2.0 is unknown. I suspect some change in USB driver code (inside Middlewares) that started to actively use this pin for the ID function.

Tested with IFLIGHT_H7_TWING and IFLIGHT_H743_AIO.