### PR TITLE
Sets antigravity gain to 0 when the user wants none.

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -52,7 +52,7 @@
 // Anti gravity I constant
 #define AG_KI 21.586988f;
 
-#define ITERM_ACCELERATOR_GAIN_OFF 1000
+#define ITERM_ACCELERATOR_GAIN_OFF 0
 #define ITERM_ACCELERATOR_GAIN_MAX 30000
 typedef enum {
     PID_ROLL,


### PR DESCRIPTION
In the recent [PR10163 that added P to antigravity](https://github.com/betaflight/betaflight/pull/10163), the P and I boost factors are now added, not multiplied, to P and I.  Hence he default system was changed so that zero would mean no antigravity, to be consistent with other factors where zero meant zero.  Previously, 1000 meant no antigravity.  

Unfortunately, `ITERM_ACCELERATOR_GAIN_OFF` remained at 1000.  It should have been changed to zero.

This was an oversight, and resulted in AntiGravity always being active (fairly weakly) even when set to 1000.

This PR is a bug fix which allows the user to set antigravity down to zero.  Zero now means 'no antigravity effect'.  The strength of the effect is now linearly proportional to the value entered, ie 3000 means twice as much antigravity effect as 1500.  This was not the case before, where 1500 added 50% to I while 3000 added 200% to I.

Note that now a value of 1000 means '1 unit of antigravity effect', which is approximately what we previously got when anti_gravity_gain was set to 2000.

Hence the default value of 3500 now results in more antigravity effect than previously; it is roughly equivalent to 4500 in the old system.  In most cases this gives better results.  

In some quads with highly tuned P values, and if in addition thrust linear is used, the new antigravity system and default behaviour may result in brief P oscillation during throttle chops to zero throttle.  This can be attenuated by using less antigravity gain, reducing thrust linear, or reducing P on the axis that oscillates transiently.

Thanks to @klutvott123 for the logs that identified this problem.