### PR TITLE
Dynamic idle and idle related mixer changes

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1476,7 +1476,7 @@ static bool blackboxWriteSysinfo(void)
 #endif
 
 #if defined(USE_DYN_IDLE)
-        BLACKBOX_PRINT_HEADER_LINE("dynamic_idle_min_rpm", "%d",            currentPidProfile->idle_min_rpm);
+        BLACKBOX_PRINT_HEADER_LINE("dynamic_idle_min_rpm", "%d",            currentPidProfile->dyn_idle_min_rpm);
 #endif
 
         default:

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1142,9 +1142,11 @@ const clivalue_t valueTable[] = {
 #ifdef USE_THRUST_LINEARIZATION
     { "thrust_linear",              VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearization) },
 #endif
+
 #ifdef USE_AIRMODE_LPF
     { "transient_throttle_limit",   VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },
 #endif
+
 #ifdef USE_INTERPOLATED_SP
     { "ff_interpolate_sp",          VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = {TABLE_INTERPOLATED_SP}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_interpolate_sp) },
     { "ff_max_rate_limit",          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 150}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_max_rate_limit) },
@@ -1153,11 +1155,11 @@ const clivalue_t valueTable[] = {
     { "ff_boost",                   VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost) },
 
 #ifdef USE_DYN_IDLE
-    { "idle_min_rpm",               VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_min_rpm) },
-    { "idle_adjustment_speed",      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 25, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_adjustment_speed) },
-    { "idle_p",                     VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_p) },
-    { "idle_pid_limit",             VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_pid_limit) },
-    { "idle_max_increase",          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, idle_max_increase) },
+    { "dyn_idle_min_rpm",           VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_min_rpm) },
+    { "dyn_idle_p_gain",            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_p_gain) },
+    { "dyn_idle_i_gain",            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_i_gain) },
+    { "dyn_idle_d_gain",            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_d_gain) },
+    { "dyn_idle_max_increase",      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_max_increase) },
 #endif
     { "level_race_mode",            VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, level_race_mode) },
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -533,7 +533,7 @@ static void validateAndFixConfig(void)
 #if defined(USE_DYN_IDLE)
     if (!isRpmFilterEnabled()) {
         for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {
-            pidProfilesMutable(i)->idle_min_rpm = 0;
+            pidProfilesMutable(i)->dyn_idle_min_rpm = 0;
         }
     }
 #endif // USE_DYN_IDLE

--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -330,6 +330,6 @@ bool isDshotBitbangActive(const motorDevConfig_t *motorDevConfig)
 
 float getDigitalIdleOffset(const motorConfig_t *motorConfig)
 {
-	return CONVERT_PARAMETER_TO_PERCENT(motorConfig->digitalIdleOffsetValue * 0.01f);
+    return CONVERT_PARAMETER_TO_PERCENT(motorConfig->digitalIdleOffsetValue * 0.01f);
 }
 #endif // USE_MOTOR

--- a/src/main/flight/mixer_init.h
+++ b/src/main/flight/mixer_init.h
@@ -38,11 +38,15 @@ typedef struct mixerRuntime_s {
     float deadbandMotor3dHigh;
     float deadbandMotor3dLow;
 #ifdef USE_DYN_IDLE
-    float idleMaxIncrease;
+    float dynIdleMaxIncrease;
     float idleThrottleOffset;
-    float idleMinMotorRps;
-    float idleP;
-    float oldMinRps;
+    float dynIdleMinRps;
+    float dynIdlePGain;
+    float prevMinRps;
+    float dynIdleIGain;
+    float dynIdleDGain;
+    float dynIdleI;
+    float minRpsDelayK;
 #endif
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     float vbatSagCompensationFactor;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -121,7 +121,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 2);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -197,11 +197,11 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
         .transient_throttle_limit = 0,
         .profileName = { 0 },
-        .idle_min_rpm = 0,
-        .idle_adjustment_speed = 50,
-        .idle_p = 50,
-        .idle_pid_limit = 200,
-        .idle_max_increase = 150,
+        .dyn_idle_min_rpm = 0,
+        .dyn_idle_p_gain = 50,
+        .dyn_idle_i_gain = 50,
+        .dyn_idle_d_gain = 50,
+        .dyn_idle_max_increase = 150,
         .ff_interpolate_sp = FF_INTERPOLATE_ON,
         .ff_max_rate_limit = 100,
         .ff_smooth_factor = 37,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -188,11 +188,11 @@ typedef struct pidProfile_s {
     uint8_t ff_boost;                       // amount of high-pass filtered FF to add to FF, 100 means 100% added
     char profileName[MAX_PROFILE_NAME_LENGTH + 1]; // Descriptive name for profile
 
-    uint8_t idle_min_rpm;                   // minimum motor speed enforced by integrating p controller
-    uint8_t idle_adjustment_speed;          // how quickly the integrating p controller tries to correct
-    uint8_t idle_p;                         // kP
-    uint8_t idle_pid_limit;                 // max P
-    uint8_t idle_max_increase;              // max integrated correction
+    uint8_t dyn_idle_min_rpm;                   // minimum motor speed enforced by the dynamic idle controller
+    uint8_t dyn_idle_p_gain;                // P gain during active control of rpm
+    uint8_t dyn_idle_i_gain;                // I gain during active control of rpm
+    uint8_t dyn_idle_d_gain;                // D gain for corrections around rapid changes in rpm
+    uint8_t dyn_idle_max_increase;          // limit on maximum possible increase in motor idle drive during active control
 
     uint8_t ff_interpolate_sp;              // Calculate FF from interpolated setpoint
     uint8_t ff_max_rate_limit;              // Maximum setpoint rate percentage for FF
@@ -386,10 +386,12 @@ bool pidOsdAntiGravityActive(void);
 bool pidOsdAntiGravityMode(void);
 void pidSetAntiGravityState(bool newState);
 bool pidAntiGravityEnabled(void);
+
 #ifdef USE_THRUST_LINEARIZATION
 float pidApplyThrustLinearization(float motorValue);
 float pidCompensateThrustLinearization(float throttle);
 #endif
+
 #ifdef USE_AIRMODE_LPF
 void pidUpdateAirmodeLpf(float currentOffset);
 float pidGetAirmodeThrottleOffset();

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -170,6 +170,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 #if defined(USE_THROTTLE_BOOST)
     pt1FilterInit(&throttleLpf, pt1FilterGain(pidProfile->throttle_boost_cutoff, pidRuntime.dT));
 #endif
+
 #if defined(USE_ITERM_RELAX)
     if (pidRuntime.itermRelax) {
         for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
@@ -177,6 +178,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         }
     }
 #endif
+
 #if defined(USE_ABSOLUTE_CONTROL)
     if (pidRuntime.itermRelax) {
         for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
@@ -184,8 +186,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         }
     }
 #endif
-#if defined(USE_D_MIN)
 
+#if defined(USE_D_MIN)
     // Initialize the filters for all axis even if the d_min[axis] value is 0
     // Otherwise if the pidProfile->d_min_xxx parameters are ever added to
     // in-flight adjustments and transition from 0 to > 0 in flight the feature
@@ -195,6 +197,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         pt1FilterInit(&pidRuntime.dMinLowpass[axis], pt1FilterGain(D_MIN_LOWPASS_HZ, pidRuntime.dT));
      }
 #endif
+
 #if defined(USE_AIRMODE_LPF)
     if (pidProfile->transient_throttle_limit) {
         pt1FilterInit(&pidRuntime.airmodeThrottleLpf1, pt1FilterGain(7.0f, pidRuntime.dT));
@@ -274,7 +277,6 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     {
         pidRuntime.pidCoefficient[FD_YAW].Ki *= 2.5f;
     }
-
     pidRuntime.levelGain = pidProfile->pid[PID_LEVEL].P / 10.0f;
     pidRuntime.horizonGain = pidProfile->pid[PID_LEVEL].I / 10.0f;
     pidRuntime.horizonTransition = (float)pidProfile->pid[PID_LEVEL].D;
@@ -378,6 +380,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.thrustLinearization = pidProfile->thrustLinearization / 100.0f;
     pidRuntime.throttleCompensateAmount = pidRuntime.thrustLinearization - 0.5f * powerf(pidRuntime.thrustLinearization, 2);
 #endif
+
 #if defined(USE_D_MIN)
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
         const uint8_t dMin = pidProfile->d_min[axis];
@@ -391,9 +394,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.dMinSetpointGain = pidProfile->d_min_gain * D_MIN_SETPOINT_GAIN_FACTOR * pidProfile->d_min_advance * pidRuntime.pidFrequency / (100 * D_MIN_LOWPASS_HZ);
     // lowpass included inversely in gain since stronger lowpass decreases peak effect
 #endif
+
 #if defined(USE_AIRMODE_LPF)
     pidRuntime.airmodeThrottleOffsetLimit = pidProfile->transient_throttle_limit / 100.0f;
 #endif
+
 #ifdef USE_INTERPOLATED_SP
     pidRuntime.ffFromInterpolatedSetpoint = pidProfile->ff_interpolate_sp;
     pidRuntime.ffSmoothFactor = 1.0f - ((float)pidProfile->ff_smooth_factor) / 100.0f;

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -173,6 +173,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate()
         if (motor < 4) {
             DEBUG_SET(DEBUG_RPM_FILTER, motor, motorFrequency[motor]);
         }
+        motorFrequency[motor] = erpmToHz * filteredMotorErpm[motor];
     }
 
     for (int i = 0; i < filterUpdatesPerIteration; i++) {
@@ -202,7 +203,6 @@ FAST_CODE_NOINLINE void rpmFilterUpdate()
                 if (++currentMotor == getMotorCount()) {
                     currentMotor = 0;
                 }
-                motorFrequency[currentMotor] = erpmToHz * filteredMotorErpm[currentMotor];
                 minMotorFrequency = 0.0f;
             }
             currentFilter = &filters[currentFilterNumber];

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1844,7 +1844,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, currentPidProfile->motor_output_limit);
         sbufWriteU8(dst, currentPidProfile->auto_profile_cell_count);
 #if defined(USE_DYN_IDLE)
-        sbufWriteU8(dst, currentPidProfile->idle_min_rpm);
+        sbufWriteU8(dst, currentPidProfile->dyn_idle_min_rpm);
 #else
         sbufWriteU8(dst, 0);
 #endif
@@ -2714,7 +2714,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             currentPidProfile->motor_output_limit = sbufReadU8(src);
             currentPidProfile->auto_profile_cell_count = sbufReadU8(src);
 #if defined(USE_DYN_IDLE)
-            currentPidProfile->idle_min_rpm = sbufReadU8(src);
+            currentPidProfile->dyn_idle_min_rpm = sbufReadU8(src);
 #else
             sbufReadU8(src);
 #endif


### PR DESCRIPTION
This PR improves idle and throttle behaviour, with particular relevance to dynamic idle and its interactions with throttle scaling and the other throttle related bits of code.

Here is a summary of the changes:

- the DShot idle value that is sent to the motors now stays the same regardless of dynamic idle on/off when linear throttle scaling is active.  Previously the user's idle value would fall when dynamic idle was activated in association with linear throttle scaling.  This has been fixed by re-ordering the throttle adjustments.

- dynamic idle offset is now applied only when needed, instead of being a constant offset, to prevent the deadband that previously occurred at full throttle.  

- the setpoint throttle value sent to the Blackbox records zero throttle when the stick is at zero position, whether dynamic idle is active or not.  The dynamic idle throttle offset is not shown, since it is an internal, technical adjustment required only to make the dynamic idle code work, and doesn't reflect any real change in throttle setpoint.  

- the throttle value sent to the antigravity and dynamic lowpass code now include throttle scaling, but not throttle boost or dynamic idle, to avoid false elevation of the apparent throttle position from dynamic idle that would lead to unnecessary transient changes in thethe AG and lowpass filter cutoffs.

- The dynamic Idle code now uses a modified PID controller during active rpm control phase, with improved performance, and the incoming rpm data is now returned each loop, improving the derivative quality.  In this controller:

-- Smoothed dyn idle D detects the rapid fall in rpm and provides a transient push that is needed in hard chops.  It is filtered heavily and does not add meaningful noise to the motors traces.  Inadequate D may allow a transient drop in rpm immediately after cutting throttle.  Default is 50.
-- The dyn idle P value provides fast control of rpm during the active control phase.  Too much may cause oscillation when dynamic idle is actively controlling the motor rpm.  Not enough may result in rpm drooping below the configured minimum, or slow wobbles from I, just like when P is too low in any PID controller.  In this setting, not enough P is particularly obvious with slow throttle cuts where D isn't strong.  Default is 50.  
-- The dyn idle I value prevents enduring offsets from the set rpm.  It has high 'upwards' gain and falls much more slowly.  Too little and there may be slow rpm wobble during the control phase, or the idle value may rise too slowly; too much may cause a noisy motors trace.  Default is 50.
-- In general, if the control is good but there is noise on the motors trace during the active control phase, the P and I gains can be lowered.  If stronger control is needed and the motors traces are clean, eg with large props, the P and I gains can be increased.

- All the variables used by Dynamic Idle have been re-named with dyn_idle in the name to make it easier to search for them in the code. 

The main benefit of the new dynamic idle control code is that it is more likely than before to prevent desyncs.  For instance, my normal race quad can fly without desync on an idle_min_rpm of only 800rpm (13 rotations a second) and only 1% Dshot idle. 

With this code, when the rpm are not below the minimum, the average motor drive will be set to the DShot idle value.  The `dyn_idle_min_rpm` value is what sets the actual lowest rpm you'll get, not the DShot idle value.  With this code it is quite OK to run the DShot idle value at very low values if you like.

For setups that are not particularly prone to desync, this code lets us use extremely low idle values to enhance hang time, especially inverted hang time, if that is desirable.  The settings mentioned above give great inverted hang time, and the quad bleeds speed off more rapidly in a race setting.  Motors can be slower to start up from lower rpm, so experiment a bit.  The benefit of active control of idle rpm isn't known for sure at this time.