### PR TITLE
Move GitHub configuration issues to link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Configuration and other support questions
+    url: https://github.com/betaflight/betaflight#support-and-developers-channel
+    about: Official Slack chat channel and Facebook group about Betaflight

--- a/.github/ISSUE_TEMPLATE/configuration-issue.md
+++ b/.github/ISSUE_TEMPLATE/configuration-issue.md
@@ -1,9 +1,0 @@
----
-name: Configuration Issue
-about: Find help if you are struggling with configuring Betaflight
-
----
-
-**Important: This is not the right place to get help with configuration issues. Your issue will be closed without further comment.**
-
-Please get help from other user support options such as asking the manufacturer of the hardware you are using, RCGroups: https://rcgroups.com/forums/showthread.php?t=2464844, or Slack (registration at https://slack.betaflight.com/) or other user support forums & groups (e.g. Facebook).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ There's a dedicated Slack chat channel here:
 
 https://slack.betaflight.com/
 
+We also have a Facebook Group. Join us to get a place to talk about Betaflight, ask configuration questions, or just hang out with fellow pilots.
+
+https://www.facebook.com/groups/betaflightgroup/
+
 Etiquette: Don't ask to ask and please wait around long enough for a reply - sometimes people are out flying, asleep or at work and can't answer immediately.
 
 ## Configuration Tool


### PR DESCRIPTION
This changes the template that appears when a user clicks in configuration issues by a link to the Slack or to Facebook, some uses do not read the template that appears:

![image](https://user-images.githubusercontent.com/2673520/96736853-502ff900-13bd-11eb-8d4a-92fce461ac29.png)
