### PR TITLE
Total flights stats for OSD (firmware part)

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1381,6 +1381,7 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_RC_CHANNELS]) },
     { "osd_camera_frame_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CAMERA_FRAME]) },
     { "osd_efficiency_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_EFFICIENCY]) },
+    { "osd_total_flights_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_TOTAL_FLIGHTS]) },
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
     // It is recommended to keep the settings order the same as the enumeration. This way the settings are displayed in the cli in the same order making it easier on the users

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -155,6 +155,7 @@ const OSD_Entry menuOsdActiveElemsEntries[] =
     {"DISPLAY NAME",       OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_DISPLAY_NAME], DYNAMIC},
     {"RC CHANNELS",        OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RC_CHANNELS], DYNAMIC},
     {"CAMERA FRAME",       OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CAMERA_FRAME], DYNAMIC},
+    {"TOTAL FLIGHTS",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_TOTAL_FLIGHTS], DYNAMIC},
     {"BACK",               OME_Back,    NULL, NULL, 0},
     {NULL,                 OME_END,     NULL, NULL, 0}
 };

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -462,11 +462,13 @@ void disarm(flightLogDisarmReason_e reason)
             dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, DSHOT_CMD_TYPE_INLINE);
         }
 #endif
-        flipOverAfterCrashActive = false;
-
 #ifdef USE_PERSISTENT_STATS
-        statsOnDisarm();
+        if (!flipOverAfterCrashActive) {
+            statsOnDisarm();
+        }
 #endif
+
+        flipOverAfterCrashActive = false;
 
         // if ARMING_DISABLED_RUNAWAY_TAKEOFF is set then we want to play it's beep pattern instead
         if (!(getArmingDisableFlags() & (ARMING_DISABLED_RUNAWAY_TAKEOFF | ARMING_DISABLED_CRASH_DETECTED))) {

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -148,6 +148,7 @@ typedef enum {
     OSD_RC_CHANNELS,
     OSD_CAMERA_FRAME,
     OSD_EFFICIENCY,
+    OSD_TOTAL_FLIGHTS,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -115,6 +115,7 @@
 #include "osd/osd_elements.h"
 
 #include "pg/motor.h"
+#include "pg/stats.h"
 
 #include "rx/rx.h"
 
@@ -749,6 +750,14 @@ static void osdBackgroundDisplayName(osdElementParms_t *element)
         element->buff[i] = '\0';
     }
 }
+
+#ifdef USE_PERSISTENT_STATS
+static void osdElementTotalFlights(osdElementParms_t *element)
+{
+    const int32_t total_flights = statsConfig()->stats_total_flights;
+    tfp_sprintf(element->buff, "#%d", total_flights);
+}
+#endif
 
 #ifdef USE_PROFILE_NAMES
 static void osdElementRateProfileName(osdElementParms_t *element)
@@ -1622,6 +1631,9 @@ static const uint8_t osdElementDisplayOrder[] = {
 #endif
     OSD_RC_CHANNELS,
     OSD_CAMERA_FRAME,
+#ifdef USE_PERSISTENT_STATS
+    OSD_TOTAL_FLIGHTS,
+#endif
 };
 
 // Define the mapping between the OSD element id and the function to draw it
@@ -1732,6 +1744,9 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #ifdef USE_GPS
     [OSD_EFFICIENCY]              = osdElementEfficiency,
 #endif
+#ifdef USE_PERSISTENT_STATS
+    [OSD_TOTAL_FLIGHTS]   = osdElementTotalFlights,
+#endif
 };
 
 // Define the mapping between the OSD element id and the function to draw its background (static part)
@@ -1796,6 +1811,10 @@ void osdAddActiveElements(void)
         osdAddActiveElement(OSD_ESC_RPM);
         osdAddActiveElement(OSD_ESC_RPM_FREQ);
     }
+#endif
+
+#ifdef USE_PERSISTENT_STATS
+    osdAddActiveElement(OSD_TOTAL_FLIGHTS);
 #endif
 }
 


### PR DESCRIPTION
Adding total flights count from persistent stats to OSD.
Firmware part
Feature request: #10215 

Pull request for configurator part: https://github.com/betaflight/betaflight-configurator/pull/2254

Fixes #10215.