### PR TITLE
Fix cc2500_common define block

### DIFF
--- a/src/main/rx/cc2500_common.c
+++ b/src/main/rx/cc2500_common.c
@@ -50,6 +50,7 @@ static IO_t rxLnaEnPin;
 #if defined(USE_RX_CC2500_SPI_DIVERSITY)
 static IO_t antSelPin;
 #endif
+#endif
 
 static int16_t rssiDbm;
 
@@ -159,7 +160,6 @@ bool cc2500SpiInit(void)
 
     return true;
 }
-#endif
 
 void cc2500ApplyRegisterConfig(const cc2500RegisterConfigElement_t *configArrayPtr, int configSize)
 {


### PR DESCRIPTION
Define block had its #endif in the wrong place causing most of the code to be excluded if `USE_RX_CC2500_SPI_PA_LNA` wasn't defined.

Also fixes compilation errors for CRAZYBEEF4FR legacy target.

Unified targets weren't affected as they define `USE_RX_CC2500_SPI_PA_LNA` so the error wasn't visible.
