### PR TITLE
Enabled SPI Transaction support for F4 and F7.

### DIFF
--- a/src/main/target/STM32F4DISCOVERY/target.h
+++ b/src/main/target/STM32F4DISCOVERY/target.h
@@ -24,7 +24,6 @@
 #define USBD_PRODUCT_STRING     "STM32F4DISCOVERY"
 
 // These features are in here to get coverage in CI builds
-#define USE_SPI_TRANSACTION
 #define USE_STACK_CHECK
 
 #if defined(STM32F4DISCOVERY_DEBUG)

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -69,8 +69,7 @@
 #define USE_TIMER_MGMT
 #define USE_PERSISTENT_OBJECTS
 #define USE_CUSTOM_DEFAULTS_ADDRESS
-// Re-enable this after 4.0 has been released, and remove the define from STM32F4DISCOVERY
-//#define USE_SPI_TRANSACTION
+#define USE_SPI_TRANSACTION
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)
 #define USE_OVERCLOCK
@@ -100,8 +99,7 @@
 #define USE_TIMER_MGMT
 #define USE_PERSISTENT_OBJECTS
 #define USE_CUSTOM_DEFAULTS_ADDRESS
-// Re-enable this after 4.0 has been released, and remove the define from STM32F4DISCOVERY
-//#define USE_SPI_TRANSACTION
+#define USE_SPI_TRANSACTION
 #endif // STM32F7
 
 #ifdef STM32H7


### PR DESCRIPTION
Fixes #10330. 

Brought on by changes in #10303, which exposed an ugly 'workaround' for setting the SPI clock to a constant speed after every MAX7456 transaction, discussed in #10330. 

@jflyper, do you see any reason to not do this? I think we are better off to enable this now and fix any remaining bugs, instead of tweaking 'workarounds' like the one exposed in #10330. 

Test targets:

[betaflight_4.3.0_STM32F745_266264262.zip](https://github.com/betaflight/betaflight/files/5506232/betaflight_4.3.0_STM32F745_266264262.zip)
[betaflight_4.3.0_STM32F7X2_266264262.zip](https://github.com/betaflight/betaflight/files/5506233/betaflight_4.3.0_STM32F7X2_266264262.zip)
[betaflight_4.3.0_STM32F411_266264262.zip](https://github.com/betaflight/betaflight/files/5506234/betaflight_4.3.0_STM32F411_266264262.zip)
[betaflight_4.3.0_STM32F405_266264262.zip](https://github.com/betaflight/betaflight/files/5506235/betaflight_4.3.0_STM32F405_266264262.zip)

(how to install the test firmware: https://youtu.be/I1uN9CN30gw)
