### PR TITLE
Future proof GHST driver

### DIFF
--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -241,6 +241,7 @@ static bool ghstProcessFrame(const rxRuntimeState_t *rxRuntimeState)
             break;
 
             default:
+                return true;
                 break;
         }
     }


### PR DESCRIPTION
Fix issue #10332, GHST driver causes high CPU load as new frame types are introduced.