### PR TITLE
Fixed compiler warnings in FrSky OSD code.

### DIFF
--- a/src/main/io/displayport_frsky_osd.c
+++ b/src/main/io/displayport_frsky_osd.c
@@ -235,14 +235,14 @@ static void setLineOutlineType(displayCanvas_t *displayCanvas, displayCanvasOutl
 {
     UNUSED(displayCanvas);
 
-    frskyOsdSetLineOutlineType(outlineType);
+    frskyOsdSetLineOutlineType((frskyOsdLineOutlineType_e)outlineType);
 }
 
 static void setLineOutlineColor(displayCanvas_t *displayCanvas, displayCanvasColor_e outlineColor)
 {
     UNUSED(displayCanvas);
 
-    frskyOsdSetLineOutlineColor(outlineColor);
+    frskyOsdSetLineOutlineColor((frskyOsdColor_e)outlineColor);
 }
 
 static void clipToRect(displayCanvas_t *displayCanvas, int x, int y, int w, int h)


### PR DESCRIPTION
Required to make SITL build with gcc 10.2.0 without warnings.