### PR TITLE
Fix SCB_CleanDCache_by_Addr to be based on portOutputBuffer

### DIFF
--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -595,7 +595,7 @@ static void bbUpdateComplete(void)
         // Only clean the buffer once. If all motors are on a common port they'll share a buffer.
         bool clean = false;
         for (int i = 0; i < motorIndex; i++) {
-            if (bbMotors[motorIndex].bbPort->portInputBuffer == bbMotors[i].bbPort->portInputBuffer) {
+            if (bbMotors[motorIndex].bbPort->portOutputBuffer == bbMotors[i].bbPort->portOutputBuffer) {
                 clean = true;
             }
         }


### PR DESCRIPTION
Check to see if SCB_CleanDCache_by_Addr was being based on portInputBuffer, not portOutputBuffer. Happens to be OK as the buffers are paired, but not clear and not the intent.