### PR TITLE
New linear mixer (credits to @tylercorleone)

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -907,6 +907,7 @@ const clivalue_t valueTable[] = {
 
 // PG_MIXER_CONFIG
     { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
+    { "linear_mixer",               VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, linear_mixer) },
     { "crashflip_motor_percent",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_motor_percent) },
     { "crashflip_expo",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_expo) },
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -501,6 +501,10 @@ static const char * const lookupTableOsdLogoOnArming[] = {
 };
 #endif
 
+static const char* const lookupTableMixerType[] = {
+    "LEGACY", "LINEAR", "DYNAMIC",
+};
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -622,6 +626,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef USE_OSD
     LOOKUP_TABLE_ENTRY(lookupTableOsdLogoOnArming),
 #endif
+    LOOKUP_TABLE_ENTRY(lookupTableMixerType),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -907,7 +912,7 @@ const clivalue_t valueTable[] = {
 
 // PG_MIXER_CONFIG
     { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
-    { "linear_mixer",               VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, linear_mixer) },
+    { "mixer_type",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_MIXER_TYPE }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, mixer_type) },
     { "crashflip_motor_percent",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_motor_percent) },
     { "crashflip_expo",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_expo) },
 

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -141,6 +141,7 @@ typedef enum {
 #ifdef USE_OSD
     TABLE_OSD_LOGO_ON_ARMING,
 #endif
+    TABLE_MIXER_TYPE,
 
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -425,6 +425,47 @@ static void updateDynLpfCutoffs(timeUs_t currentTimeUs, float throttle)
 }
 #endif
 
+static void applyLinearMixerAdjustment(float *motorMix, float motorMixRange, bool airmodeEnabled) {
+    float motorMixNormalizationFactor = motorMixRange > 1.0f ? motorMixRange : 1.0f;
+    float motorMixDelta = 0.5f * motorMixRange;
+
+    for (int i = 0; i < mixerRuntime.motorCount; ++i) {
+        if (airmodeEnabled || throttle > 0.5f) {
+            motorMix[i] = scaleRangef(throttle, 0.0f, 1.0f, motorMix[i] + motorMixDelta, motorMix[i] - motorMixDelta);
+        }
+        motorMix[i] /= motorMixNormalizationFactor;
+    }
+}
+
+static void applyMixerAdjustment(float *motorMix, float motorMixMin, float motorMixMax, float motorMixRange, bool airmodeEnabled) {
+#ifdef USE_AIRMODE_LPF
+    const float unadjustedThrottle = throttle;
+    throttle += pidGetAirmodeThrottleOffset();
+    float airmodeThrottleChange = 0;
+#endif
+
+    if (motorMixRange > 1.0f) {
+        for (int i = 0; i < mixerRuntime.motorCount; i++) {
+            motorMix[i] /= motorMixRange;
+        }
+        // Get the maximum correction by setting offset to center when airmode enabled
+        if (airmodeEnabled) {
+            throttle = 0.5f;
+        }
+    } else {
+        if (airmodeEnabled || throttle > 0.5f) {
+            throttle = constrainf(throttle, -motorMixMin, 1.0f - motorMixMax);
+#ifdef USE_AIRMODE_LPF
+            airmodeThrottleChange = constrainf(unadjustedThrottle, -motorMixMin, 1.0f - motorMixMax) - unadjustedThrottle;
+#endif
+        }
+    }
+
+#ifdef USE_AIRMODE_LPF
+    pidUpdateAirmodeLpf(airmodeThrottleChange);
+#endif
+}
+
 FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
 {
     // Find min and max throttle based on conditions. Throttle has to be known before mixing
@@ -549,34 +590,12 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
     }
 #endif
 
-#ifdef USE_AIRMODE_LPF
-    const float unadjustedThrottle = throttle;
-    throttle += pidGetAirmodeThrottleOffset();
-    float airmodeThrottleChange = 0;
-#endif
-
-    // apply airmode
     motorMixRange = motorMixMax - motorMixMin;
-    if (motorMixRange > 1.0f) {
-        for (int i = 0; i < mixerRuntime.motorCount; i++) {
-            motorMix[i] /= motorMixRange;
-        }
-        // Get the maximum correction by setting offset to center when airmode enabled
-        if (airmodeEnabled) {
-            throttle = 0.5f;
-        }
+    if (mixerConfig()->linear_mixer) {
+        applyLinearMixerAdjustment(motorMix, motorMixRange, airmodeEnabled);
     } else {
-        if (airmodeEnabled || throttle > 0.5f) {  // Only automatically adjust throttle when airmode enabled. Airmode logic is always active on high throttle
-            throttle = constrainf(throttle, -motorMixMin, 1.0f - motorMixMax);
-#ifdef USE_AIRMODE_LPF
-            airmodeThrottleChange = constrainf(unadjustedThrottle, -motorMixMin, 1.0f - motorMixMax) - unadjustedThrottle;
-#endif
-        }
+        applyMixerAdjustment(motorMix, motorMixMin, motorMixMax, motorMixRange, airmodeEnabled);
     }
-
-#ifdef USE_AIRMODE_LPF
-    pidUpdateAirmodeLpf(airmodeThrottleChange);
-#endif
 
     if (featureIsEnabled(FEATURE_MOTOR_STOP)
         && ARMING_FLAG(ARMED)

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -82,6 +82,7 @@ typedef struct mixerConfig_s {
     bool yaw_motors_reversed;
     uint8_t crashflip_motor_percent;
     uint8_t crashflip_expo;
+    uint8_t linear_mixer;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -60,6 +60,13 @@ typedef enum mixerMode
     MIXER_QUADX_1234 = 26
 } mixerMode_e;
 
+typedef enum mixerType
+{
+    MIXER_LEGACY = 0,
+    MIXER_LINEAR = 1,
+    MIXER_DYNAMIC = 2,
+} mixerType_e;
+
 // Custom mixer data per motor
 typedef struct motorMixer_s {
     float throttle;
@@ -82,7 +89,7 @@ typedef struct mixerConfig_s {
     bool yaw_motors_reversed;
     uint8_t crashflip_motor_percent;
     uint8_t crashflip_expo;
-    uint8_t linear_mixer;
+    uint8_t mixer_type;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -51,7 +51,7 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .yaw_motors_reversed = false,
     .crashflip_motor_percent = 0,
     .crashflip_expo = 35,
-    .linear_mixer = false,
+    .mixer_type = MIXER_LEGACY,
 );
 
 PG_REGISTER_ARRAY(motorMixer_t, MAX_SUPPORTED_MOTORS, customMotorMixer, PG_MOTOR_MIXER, 0);

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -50,7 +50,8 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .mixerMode = DEFAULT_MIXER,
     .yaw_motors_reversed = false,
     .crashflip_motor_percent = 0,
-    .crashflip_expo = 35
+    .crashflip_expo = 35,
+    .linear_mixer = false,
 );
 
 PG_REGISTER_ARRAY(motorMixer_t, MAX_SUPPORTED_MOTORS, customMotorMixer, PG_MOTOR_MIXER, 0);


### PR DESCRIPTION
This PR is inspired on PR in emuflight code by @tylercorleone
https://github.com/emuflight/EmuFlight/pull/398
Both mixer types implemented called LINEAR and DYNAMIC

All graphs below are representing AIRMODE enabled scenarios. When AIRMODE is disabled, regular mixer clipping on low throttle range will happen.

### **Mixer type: LEGACY (Current mixer)**
**set mixer_type = LEGACY**   <--- enabled by default
![image](https://user-images.githubusercontent.com/10757508/100614257-294ad800-3316-11eb-9ccf-d260d03e541e.png)


### **Mixer type: LINEAR**
**set mixer_type = LINEAR**   <--- to enable
![image](https://user-images.githubusercontent.com/10757508/100615013-49c76200-3317-11eb-877d-f0f181dcb204.png)


### **Mixer type DYNAMIC:**
**set mixer_type = DYNAMIC**   <--- to enable
![image](https://user-images.githubusercontent.com/10757508/100614211-120bea80-3316-11eb-8510-8d58d0c69c38.png)
_Note: The above graph is the ideal scenario of dynamic mixer, but the actual result depends of PIDsum contribution from other axes. If only 1 axis asks for full authority the result will be exactly same like with LINEAR mixer. The optimal results are achieved, when multiple axes are requesting authority._


**Short summary of differences between mixers:**
**LEGACY** tries to keep requested throttle position as long as possible, till the point where it cannot maintain current throttle position it will drastically start to change throttle to still get desired authority. That is also the reason of sharper transition.
**LINEAR** will start changing throttle earlier in order to prevent these steep transitions at the end. In other words it smooths out the thrust increase/decrease for desired correction.
**DYNAMIC** This is another experimental mixer variation of mixer from tylercorleone. It behaves very similar to linear mixer, but much smarter. When all of the PIDsum comes from single axis it will behave exactly same as linear mixer, but when PIDsum to mixer is combined from other axes the mixer will adapt itself to stay closer to requested throttle level.

TODO:
MSP etc... also something for other PR, when fully tested
For now let's focus on some real flight testing. I did have a couple LOS flights to verify it all works.

unified targets for testing:
[betaflight_4.3.0_STM32F7X2_df340893f.zip](https://github.com/betaflight/betaflight/files/5618351/betaflight_4.3.0_STM32F7X2_df340893f.zip)
[betaflight_4.3.0_STM32F405_df340893f.zip](https://github.com/betaflight/betaflight/files/5618352/betaflight_4.3.0_STM32F405_df340893f.zip)
[betaflight_4.3.0_STM32F411_df340893f.zip](https://github.com/betaflight/betaflight/files/5618353/betaflight_4.3.0_STM32F411_df340893f.zip)
[betaflight_4.3.0_STM32F745_df340893f.zip](https://github.com/betaflight/betaflight/files/5618354/betaflight_4.3.0_STM32F745_df340893f.zip)



