### PR TITLE
H7 LED strip

### DIFF
--- a/src/link/stm32_flash_h750_128k.ld
+++ b/src/link/stm32_flash_h750_128k.ld
@@ -50,8 +50,6 @@ REGION_ALIAS("STACKRAM", DTCM_RAM)
 REGION_ALIAS("FASTRAM", DTCM_RAM)
 REGION_ALIAS("MAIN", FLASH)
 
-INCLUDE "stm32_h750_common.ld"
-
 SECTIONS
 {
   .DMA_RAM (NOLOAD) :
@@ -91,4 +89,5 @@ SECTIONS
   } >RAM
   }
 
+INCLUDE "stm32_h750_common.ld"
 INCLUDE "stm32_h750_common_post.ld"

--- a/src/link/stm32_flash_h750_1m.ld
+++ b/src/link/stm32_flash_h750_1m.ld
@@ -50,8 +50,6 @@ REGION_ALIAS("STACKRAM", DTCM_RAM)
 REGION_ALIAS("FASTRAM", DTCM_RAM)
 REGION_ALIAS("MAIN", FLASH)
 
-INCLUDE "stm32_h750_common.ld"
-
 SECTIONS
 {
   .DMA_RAM (NOLOAD) :
@@ -91,4 +89,5 @@ SECTIONS
   } >RAM
 }
 
+INCLUDE "stm32_h750_common.ld"
 INCLUDE "stm32_h750_common_post.ld"

--- a/src/link/stm32_ram_h750_exst.ld
+++ b/src/link/stm32_ram_h750_exst.ld
@@ -73,8 +73,6 @@ REGION_ALIAS("STACKRAM", DTCM_RAM)
 REGION_ALIAS("FASTRAM", DTCM_RAM)
 REGION_ALIAS("MAIN", CODE_RAM)
 
-INCLUDE "stm32_h750_common.ld"
-
 SECTIONS
 {
   .DMA_RAM (NOLOAD) :
@@ -114,6 +112,7 @@ SECTIONS
   } >RAM
 }
 
+INCLUDE "stm32_h750_common.ld"
 INCLUDE "stm32_h750_common_post.ld"
 INCLUDE "stm32_ram_h750_exst_post.ld"
 

--- a/src/main/drivers/memprot_hal.c
+++ b/src/main/drivers/memprot_hal.c
@@ -68,7 +68,7 @@ void memProtConfigure(mpuRegion_t *regions, unsigned regionCount)
 
             int msbpos = flsl(length) - 1;
 
-            if (length == (1U << msbpos)) {
+            if (length != (1U << msbpos)) {
                 msbpos += 1;
             }
 

--- a/src/main/target/NUCLEOH743/target.h
+++ b/src/main/target/NUCLEOH743/target.h
@@ -29,12 +29,15 @@
 #define LED1_PIN                PB7 // PE1 on NUCLEO-H743ZI2 (may collide with UART8_TX)
 //#define LED2_PIN                PB14 // SDMMC2_D0
 
+// Use explicit cache management as per https://github.com/betaflight/betaflight/pull/10378
+#define USE_LEDSTRIP_CACHE_MGMT
+
 // Nucleo-H743 has one button (The blue USER button).
 // Force two buttons to look at the single button so config reset on button works
 #define USE_BUTTONS
-#define	BUTTON_A_PIN            PC13
+#define BUTTON_A_PIN            PC13
 #define BUTTON_A_PIN_INVERTED // Active high
-#define	BUTTON_B_PIN            PC13
+#define BUTTON_B_PIN            PC13
 #define BUTTON_B_PIN_INVERTED // Active high
 
 #define USE_BEEPER


### PR DESCRIPTION
Shareable memory isn't working on the H7. Need to figure out why, but in the meantime, this is the same fix as used for DSHOT, using manual cache cleaning (flushing). Define USE_LEDSTRIP_CACHE_MGMT to use.