### PR TITLE
Add action to close issues that don't follow any template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,19 +1,21 @@
 ---
 name: Feature Request
 about: Suggest an idea for for a new feature for Betaflight
-
+labels: "Template: Feature Request"
 ---
+<!-- This is a template that you must fill. If not, the message will be closed. So don't erase any subtitle in this template (they start with ###)
+and complete all of them -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- Please note that feature requests are not 'fire and forget'. It is a lot more likely that the feature you would like to have will be implemented if you keep watching your feature request, and provide more details to developers looking into implementing your feature, and help them with testing. -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+### Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-Please note that feature requests are not 'fire and forget'. It is a lot more likely that the feature you would like to have will be implemented if you keep watching your feature request, and provide more details to developers looking into implementing your feature, and help them with testing.
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/firmware-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/firmware-bug-report.md
@@ -1,27 +1,37 @@
 ---
 name: Firmware Bug Report
 about: Create a report to help us fix bugs in the Betaflight firmware
-
+labels: "Template: Bug"
 ---
+<!-- This is a template that you must fill. If not, the message will be closed. So don't erase any subtitle in this template (they start with ###)
+and complete all of them -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### To Reproduce
+<!-- Steps to reproduce the behavior -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Flight controller configuration**
-Create a `diff` and post it here in a code block. Put ``` (three backticks) at the start and end of the `diff` block (instructions  on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/)
+### Flight controller configuration
+<!-- Create a diff and post it here in a code block. Put (three backticks) at the start and end of the diff block (instructions  on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/)
+Use resource show all to create a resource allocation list and post it here in a code block. Put (three backticks) at the start and end of the output block. -->
+```
+PASTE diff HERE
+```
+```
+PASTE resource show all HERE
+```
 
-Use `resource show all` to create a resource allocation list and post it here in a code block. Put ``` (three backticks) at the start and end of the output block.
+### Setup / Versions
+ <!-- Specify your flight controller model (what type is it, where was it bought from, ...) -->
+ - Flight controller: 
+ <!-- Specify other components attached to the flight controller (RX, VTX, brand / model for all of them, firmware version where applicable...) -->
+ - Other components:
+ <!-- Details about how all is wired -->
+ - How are the different components wired up:
 
-**Setup / Versions**
- - Flight controller [what type is it, where was it bought from];
- - Other components [RX, VTX, brand / model for all of them, firmware version where applicable];
- - how are the different components wired up.
-
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,22 @@
+name: Issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  auto_close_issues:
+    name: Check if issues follow the templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout templates
+        uses: actions/checkout@v2.3.4
+      - name: Automatically close issues that don't follow the templates
+        uses: ergo720/auto-close-issues@v1.0.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-close-message: >
+            @${issue.user.login}: This issue is being automatically closed because it does not follow the template.\n\n
+            **When you open an issue or feature request you are presented with a template. Follow the guidelines**.\n\n
+            You can edit your message to fix this and the issue will be automatically reopened.
+          closed-issues-label: Not following template


### PR DESCRIPTION
This PR adds a GitHub action to close any issue/feature request opened that don't follow any template.

This has a little risk that we close some interesting issue, but it minimizes the time that we spent reading issues incomplete.

This PR does the next changes:
- Changes a little the templates, but without modifying any of the current fields asked.
- Adds the `BUG` or `Feature Request` label to the issue being opened, depending on the template chosen by the user
- After each issue, it checkouts our templates and looks for ALL the headers in the new issue. If the new issue does not have all the headers of a template it closes it adding a label `Not following template`. 

![image](https://user-images.githubusercontent.com/2673520/101049977-4edd1900-3584-11eb-9684-2150f9819146.png)


For this PR to work, we need to create too the `Not following template` tag (or change the tag in this PR for some other that exists, like the `Missing Information` one).