### PR TITLE
Optimize pin reconfiguration in DSHOT ISR for H7

### DIFF
--- a/src/main/drivers/io.h
+++ b/src/main/drivers/io.h
@@ -131,3 +131,6 @@ void IOInitGlobal(void);
 typedef void (*IOTraverseFuncPtr_t)(IO_t io);
 
 void IOTraversePins(IOTraverseFuncPtr_t func);
+
+GPIO_TypeDef* IO_GPIO(IO_t io);
+uint16_t IO_Pin(IO_t io);

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -117,13 +117,25 @@ FAST_CODE static void pwmDshotSetDirectionInput(
     timer->ARR = 0xffffffff;
 
 #ifdef STM32H7
-    IOConfigGPIO(motor->io, GPIO_MODE_OUTPUT_PP);
+    // Configure pin as GPIO output to avoid glitch during timer configuration
+    uint32_t pin = IO_Pin(motor->io);
+    LL_GPIO_SetPinMode(IO_GPIO(motor->io), pin, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinSpeed(IO_GPIO(motor->io), pin, LL_GPIO_SPEED_FREQ_LOW); // Needs to be low
+    LL_GPIO_SetPinPull(IO_GPIO(motor->io), pin, LL_GPIO_PULL_NO);
+    LL_GPIO_SetPinOutputType(IO_GPIO(motor->io), pin, LL_GPIO_OUTPUT_PUSHPULL);
 #endif
 
     LL_TIM_IC_Init(timer, motor->llChannel, &motor->icInitStruct);
 
 #ifdef STM32H7
-    IOConfigGPIOAF(motor->io, motor->iocfg, timerHardware->alternateFunction);
+    // Configure pin back to timer
+    LL_GPIO_SetPinMode(IO_GPIO(motor->io), IO_Pin(motor->io), LL_GPIO_MODE_ALTERNATE);
+    if (IO_Pin(motor->io) & 0xFF) {
+        LL_GPIO_SetAFPin_0_7(IO_GPIO(motor->io), IO_Pin(motor->io), timerHardware->alternateFunction);
+    }
+    else {
+        LL_GPIO_SetAFPin_8_15(IO_GPIO(motor->io), IO_Pin(motor->io), timerHardware->alternateFunction);
+    }
 #endif
 
     motor->dmaInitStruct.Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -132,8 +132,7 @@ FAST_CODE static void pwmDshotSetDirectionInput(
     LL_GPIO_SetPinMode(IO_GPIO(motor->io), IO_Pin(motor->io), LL_GPIO_MODE_ALTERNATE);
     if (IO_Pin(motor->io) & 0xFF) {
         LL_GPIO_SetAFPin_0_7(IO_GPIO(motor->io), IO_Pin(motor->io), timerHardware->alternateFunction);
-    }
-    else {
+    } else {
         LL_GPIO_SetAFPin_8_15(IO_GPIO(motor->io), IO_Pin(motor->io), timerHardware->alternateFunction);
     }
 #endif


### PR DESCRIPTION
I found that I would sometimes get DSHOT telemetry errors with an H750 based flight controller and octo copter configurations. Upon investigation, I found that the headroom between the last call of `motor_DMA_IRQHandler` and the DSHOT telemetry response was only about 4 us. 

This shows the timing. The debug pin is H during the execution of the `motor_DMA_IRQHandler`
![image](https://user-images.githubusercontent.com/647005/101062576-a8265780-3546-11eb-812f-3ba2c4997922.png)

In order to fix this problem, I optimized the pin-reconfiguration in the `pwmDshotSetDirectionInput` function. I first thought that the re-configuration may not even be needed, but @hydra pointed out the glitch that happens during the timer configuration (see #8836). To reduce the time spent in the ISR, I use LL library calls instead. 

With the new code, the ISR takes about 1.6 us (from 2.7 us) and the headroom increases from 4 us to about 12 us, which avoids the DSHOT telemetry errors.

![image](https://user-images.githubusercontent.com/647005/101063308-837eaf80-3547-11eb-8da1-10e04f66e845.png)

Also, I confirmed that the glitch at the output still doesn't happen. 

![image](https://user-images.githubusercontent.com/647005/101063572-cb053b80-3547-11eb-8d09-e7061e8cf465.png)


