### PR TITLE
Add debug support to GHST protocol driver

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -98,5 +98,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RX_TIMING",
     "D_LPF",
     "VTX_TRAMP",
-    "GHST"
+    "GHST",
 };

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -98,4 +98,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RX_TIMING",
     "D_LPF",
     "VTX_TRAMP",
+    "GHST"
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -25,7 +25,6 @@ extern int16_t debug[DEBUG16_VALUE_COUNT];
 extern uint8_t debugMode;
 
 #define DEBUG_SET(mode, index, value) {if (debugMode == (mode)) {debug[(index)] = (value);}}
-#define DEBUG_INCR(mode, index) {if (debugMode == (mode)) {++debug[(index)];}}
 
 #define DEBUG_SECTION_TIMES
 

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -25,6 +25,7 @@ extern int16_t debug[DEBUG16_VALUE_COUNT];
 extern uint8_t debugMode;
 
 #define DEBUG_SET(mode, index, value) {if (debugMode == (mode)) {debug[(index)] = (value);}}
+#define DEBUG_INCR(mode, index) {if (debugMode == (mode)) {++debug[(index)];}}
 
 #define DEBUG_SECTION_TIMES
 
@@ -114,6 +115,7 @@ typedef enum {
     DEBUG_RX_TIMING,
     DEBUG_D_LPF,
     DEBUG_VTX_TRAMP,
+    DEBUG_GHST,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -78,7 +78,7 @@ enum {
     DEBUG_GHST_CRC_ERRORS = 0,
     DEBUG_GHST_UNKNOWN_FRAMES,
     DEBUG_GHST_RX_RSSI,
-    DEBUG_GHST_RX_LQ
+    DEBUG_GHST_RX_LQ,
 };
 
 static serialPort_t *serialPort;
@@ -199,7 +199,7 @@ STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
             return RX_FRAME_COMPLETE | RX_FRAME_PROCESSING_REQUIRED;            // request callback through ghstProcessFrame to do the decoding  work
         }
 
-        if(crc != ghstValidatedFrame.bytes[fullFrameLength - 1] ) {
+        if (crc != ghstValidatedFrame.bytes[fullFrameLength - 1]) {
             DEBUG_SET(DEBUG_GHST, DEBUG_GHST_CRC_ERRORS, ++crcErrorCount);
         }
 

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -187,6 +187,7 @@ static bool shouldSendTelemetryFrame(void)
 STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
+    static int16_t crcErrorCount = 0;
 
     if (ghstFrameAvailable) {
         ghstFrameAvailable = false;
@@ -199,7 +200,7 @@ STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
         }
 
         if(crc != ghstValidatedFrame.bytes[fullFrameLength - 1] ) {
-            DEBUG_INCR(DEBUG_GHST, DEBUG_GHST_CRC_ERRORS);
+            DEBUG_SET(DEBUG_GHST, DEBUG_GHST_CRC_ERRORS, ++crcErrorCount);
         }
 
         return RX_FRAME_DROPPED;                            // frame was invalid
@@ -218,6 +219,8 @@ static bool ghstProcessFrame(const rxRuntimeState_t *rxRuntimeState)
     // is correct, and the message was actually for us.
 
     UNUSED(rxRuntimeState);
+
+    static int16_t unknownFrameCount = 0;
 
     // do we have a telemetry buffer to send?
     if (shouldSendTelemetryFrame()) {
@@ -267,7 +270,7 @@ static bool ghstProcessFrame(const rxRuntimeState_t *rxRuntimeState)
                 case GHST_UL_RC_CHANS_HS4_9TO12:    startIdx = 8;  break;
                 case GHST_UL_RC_CHANS_HS4_13TO16:   startIdx = 12; break;
                 default:
-                    DEBUG_INCR(DEBUG_GHST, DEBUG_GHST_UNKNOWN_FRAMES);
+                    DEBUG_SET(DEBUG_GHST, DEBUG_GHST_UNKNOWN_FRAMES, ++unknownFrameCount);
                     break;
             }
 


### PR DESCRIPTION
Add ability for pilots to log CRC errors, unknown frames, LQ, and RSSI. 
Added macro to debug.h to simplify incrementing debug values without the need for local statics in client code.
