### PR TITLE
unittest: fix potential segfault in cli nextArg function.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -989,8 +989,12 @@ static void cliShowArgumentRangeError(const char *cmdName, char *name, int min, 
     }
 }
 
-static const char *nextArg(const char *currentArg)
+STATIC_UNIT_TESTED const char *nextArg(const char *currentArg)
 {
+    if (!currentArg) {
+        // if currentArg is null or empty, return to avoid segfault
+        return currentArg;
+    }
     const char *ptr = strchr(currentArg, ' ');
     while (ptr && *ptr == ' ') {
         ptr++;

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -57,6 +57,8 @@ extern "C" {
     void cliSet(const char *cmdName, char *cmdline);
     int cliGetSettingIndex(char *name, uint8_t length);
     void *cliGetValuePointer(const clivalue_t *value);
+
+    char *nextArg(const char *currentArg);
     
     const clivalue_t valueTable[] = {
         { "array_unit_test",   VAR_INT8  | MODE_ARRAY  | MASTER_VALUE, .config.array.length = 3,      PG_RESERVED_FOR_TESTING_1, 0 },
@@ -191,6 +193,24 @@ TEST(CLIUnittest, TestCliSetStringWriteOnce)
     EXPECT_EQ(0,   data[6]);
 
     printf("\n");
+}
+
+TEST(CLIUnittest, TestNextArgShouldNotSegfault)
+{
+    char *cmdLine = (char *)"1 2 3";
+    ASSERT_EQ('1', *cmdLine);
+
+    const char *ptr;
+    ptr = nextArg(cmdLine);
+    ASSERT_EQ('2', *ptr);
+    ptr = nextArg(ptr);
+    ASSERT_EQ('3', *ptr);
+    ptr = nextArg(ptr);
+    ASSERT_EQ(NULL, ptr);
+
+    // ptr is now null, this call should NOT cause segfaul
+    ptr = nextArg(ptr);
+    ASSERT_EQ(NULL, ptr);
 }
 
 // STUBS


### PR DESCRIPTION
when given a null pointer, nextArg() will segfault.
This can happen in cases when fewer arguments are provided than
expected.

Add unittest to validate expected behaviour