### PR TITLE
Removed deprecated Dshot commands to enable / disable bidirectional Dshot.

### DIFF
--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -194,8 +194,6 @@ void dshotCommandWrite(uint8_t index, uint8_t motorCount, uint8_t command, dshot
     case DSHOT_CMD_SAVE_SETTINGS:
     case DSHOT_CMD_SPIN_DIRECTION_NORMAL:
     case DSHOT_CMD_SPIN_DIRECTION_REVERSED:
-    case DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE:
-    case DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY:
         repeats = 10;
         break;
     case DSHOT_CMD_BEACON1:

--- a/src/main/drivers/dshot_command.h
+++ b/src/main/drivers/dshot_command.h
@@ -57,8 +57,6 @@ typedef enum {
     DSHOT_CMD_LED3_OFF, // BLHeli32 only
     DSHOT_CMD_AUDIO_STREAM_MODE_ON_OFF = 30, // KISS audio Stream mode on/Off
     DSHOT_CMD_SILENT_MODE_ON_OFF = 31, // KISS silent Mode on/Off
-    DSHOT_CMD_SIGNAL_LINE_TELEMETRY_DISABLE = 32,
-    DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY = 33,
     DSHOT_CMD_MAX = 47
 } dshotCommands_e;
 

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -95,13 +95,6 @@ FAST_CODE void pwmWriteDshotInt(uint8_t index, uint16_t value)
     /*If there is a command ready to go overwrite the value and send that instead*/
     if (dshotCommandIsProcessing()) {
         value = dshotCommandGetCurrent(index);
-#ifdef USE_DSHOT_TELEMETRY
-        // reset telemetry debug statistics every time telemetry is enabled
-        if (value == DSHOT_CMD_SIGNAL_LINE_CONTINUOUS_ERPM_TELEMETRY) {
-            dshotTelemetryState.invalidPacketCount = 0;
-            dshotTelemetryState.readCount = 0;
-        }
-#endif
         if (value) {
             motor->protocolControl.requestTelemetry = true;
         }


### PR DESCRIPTION
These are not needed in the current bidirectional Dshot protocol specification, as the idle level is used to detect if RPM feedback. According to @4712 these commands were never implemented in BLHeli_32.