### PR TITLE
Fixed MSP command to send Dshot commands.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3850,12 +3850,6 @@ static void cliDshotProg(const char *cmdName, char *cmdline)
                         // pwmDisableMotors();
                         motorDisable();
 
-                        if (command == DSHOT_CMD_ESC_INFO) {
-                            delay(5); // Wait for potential ESC telemetry transmission to finish
-                        } else {
-                            delay(1);
-                        }
-
                         firstCommand = false;
                     }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3020,7 +3020,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 for (uint8_t i = 0; i < commandCount; i++) {
                     const uint8_t commandIndex = sbufReadU8(src);
                     dshotCommandWrite(motorIndex, getMotorCount(), commandIndex, commandType);
-                    delay(1);
                 }
 
                 if (DSHOT_CMD_TYPE_BLOCKING == commandType) {


### PR DESCRIPTION
Remove delays around the invocation of `dshotCommandWrite()` as these delays are baked into the function now.

Tested in CLI.