### PR TITLE
fixed problem msp_displayport send lost when serial port buffer full

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -29,11 +29,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#ifdef USE_MSP_DISPLAYPORT
-#define UART_TX_BUFFER_SIZE     1280
-#else
 #define UART_TX_BUFFER_SIZE     256
-#endif
 #endif
 #elif defined(STM32F3)
 #define UARTDEV_COUNT_MAX 5
@@ -42,11 +38,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#ifdef USE_MSP_DISPLAYPORT
-#define UART_TX_BUFFER_SIZE     1280
-#else
 #define UART_TX_BUFFER_SIZE     256
-#endif
 #endif
 #elif defined(STM32F4)
 #define UARTDEV_COUNT_MAX 6

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -29,7 +29,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     1024
 #endif
 #elif defined(STM32F3)
 #define UARTDEV_COUNT_MAX 5
@@ -38,7 +38,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     1024
 #endif
 #elif defined(STM32F4)
 #define UARTDEV_COUNT_MAX 6
@@ -47,7 +47,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     1024
 #endif
 #elif defined(STM32F7)
 #define UARTDEV_COUNT_MAX 8
@@ -56,7 +56,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     1024
 #endif
 #elif defined(STM32H7)
 #define UARTDEV_COUNT_MAX 8
@@ -65,7 +65,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     1024
 #endif
 #elif defined(STM32G4)
 #define UARTDEV_COUNT_MAX 9  // UART1~5 + UART9 (Implemented with LPUART1)
@@ -74,7 +74,7 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     256
+#define UART_TX_BUFFER_SIZE     1024
 #endif
 #else
 #error unknown MCU family

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -29,7 +29,11 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     1024
+#ifdef USE_MSP_DISPLAYPORT
+#define UART_TX_BUFFER_SIZE     1280
+#else
+#define UART_TX_BUFFER_SIZE     256
+#endif
 #endif
 #elif defined(STM32F3)
 #define UARTDEV_COUNT_MAX 5
@@ -38,7 +42,11 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     1024
+#ifdef USE_MSP_DISPLAYPORT
+#define UART_TX_BUFFER_SIZE     1280
+#else
+#define UART_TX_BUFFER_SIZE     256
+#endif
 #endif
 #elif defined(STM32F4)
 #define UARTDEV_COUNT_MAX 6
@@ -47,7 +55,11 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     1024
+#ifdef USE_MSP_DISPLAYPORT
+#define UART_TX_BUFFER_SIZE     1280
+#else
+#define UART_TX_BUFFER_SIZE     256
+#endif
 #endif
 #elif defined(STM32F7)
 #define UARTDEV_COUNT_MAX 8
@@ -56,7 +68,11 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     1024
+#ifdef USE_MSP_DISPLAYPORT
+#define UART_TX_BUFFER_SIZE     1280
+#else
+#define UART_TX_BUFFER_SIZE     256
+#endif
 #endif
 #elif defined(STM32H7)
 #define UARTDEV_COUNT_MAX 8
@@ -65,7 +81,11 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     1024
+#ifdef USE_MSP_DISPLAYPORT
+#define UART_TX_BUFFER_SIZE     1280
+#else
+#define UART_TX_BUFFER_SIZE     256
+#endif
 #endif
 #elif defined(STM32G4)
 #define UARTDEV_COUNT_MAX 9  // UART1~5 + UART9 (Implemented with LPUART1)
@@ -74,7 +94,11 @@
 #define UART_RX_BUFFER_SIZE     128
 #endif
 #ifndef UART_TX_BUFFER_SIZE
-#define UART_TX_BUFFER_SIZE     1024
+#ifdef USE_MSP_DISPLAYPORT
+#define UART_TX_BUFFER_SIZE     1280
+#else
+#define UART_TX_BUFFER_SIZE     256
+#endif
 #endif
 #else
 #error unknown MCU family

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -40,8 +40,6 @@
 
 #include "msp_serial.h"
 
-#include "drivers/time.h"
-
 static mspPort_t mspPorts[MAX_MSP_PORT_COUNT];
 
 static void resetMspPort(mspPort_t *mspPortToReset, serialPort_t *serialPort, bool sharedWithTelemetry)
@@ -292,13 +290,7 @@ static int mspSerialSendFrame(mspPort_t *msp, const uint8_t * hdr, int hdrLen, c
     //  b) Response fits into TX buffer
     const int totalFrameLength = hdrLen + dataLen + crcLen;
     if (!isSerialTransmitBufferEmpty(msp->port) && ((int)serialTxBytesFree(msp->port) < totalFrameLength)) {
-#ifdef USE_MSP_DISPLAYPORT
-        //Currently TxBuffer free space is not enough, Wait for TxBuffer empty
-        const int perByteCostUs = (1000000 / (msp->port->baudRate / 10));
-        delayMicroseconds((int)serialTxBytesFree(msp->port) * perByteCostUs);
-#else
         return 0;
-#endif
     }
 
     // Transmit frame

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -291,10 +291,13 @@ static int mspSerialSendFrame(mspPort_t *msp, const uint8_t * hdr, int hdrLen, c
     //     this allows us to transmit jumbo frames bigger than TX buffer (serialWriteBuf will block, but for jumbo frames we don't care)
     //  b) Response fits into TX buffer
     const int totalFrameLength = hdrLen + dataLen + crcLen;
-    const int perByteCostUs = (1000000 / (msp->port->baudRate / 10));
     if (!isSerialTransmitBufferEmpty(msp->port) && ((int)serialTxBytesFree(msp->port) < totalFrameLength)) {
+#ifdef USE_MSP_DISPLAYPORT
         //Currently TxBuffer free space is not enough, Wait for TxBuffer empty
+        const int perByteCostUs = (1000000 / (msp->port->baudRate / 10));
         delayMicroseconds((int)serialTxBytesFree(msp->port) * perByteCostUs);
+#else
+        return 0;
     }
 
     // Transmit frame

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -312,6 +312,7 @@ static int mspSerialEncode(mspPort_t *msp, mspPacket_t *packet, mspVersion_e msp
     uint8_t checksum;
     int hdrLen = 3;
     int crcLen = 0;
+    int ret = 0;
 
     #define V1_CHECKSUM_STARTPOS 3
     if (mspVersion == MSP_V1) {
@@ -388,7 +389,10 @@ static int mspSerialEncode(mspPort_t *msp, mspPacket_t *packet, mspVersion_e msp
     }
 
     // Send the frame
-    return mspSerialSendFrame(msp, hdrBuf, hdrLen, sbufPtr(&packet->buf), dataLen, crcBuf, crcLen);
+	// If it fails, resend until success
+    while (ret==0)
+        ret = mspSerialSendFrame(msp, hdrBuf, hdrLen, sbufPtr(&packet->buf), dataLen, crcBuf, crcLen);
+    return ret;
 }
 
 static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspProcessCommandFnPtr mspProcessCommandFn)

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -298,6 +298,7 @@ static int mspSerialSendFrame(mspPort_t *msp, const uint8_t * hdr, int hdrLen, c
         delayMicroseconds((int)serialTxBytesFree(msp->port) * perByteCostUs);
 #else
         return 0;
+#endif
     }
 
     // Transmit frame


### PR DESCRIPTION
This change is mainly for the MSP_DISPLAYPORT function. The main problem that currently exists is that when the instantaneous speed of the osd elements data is too high, the serial buffer in mspSerialSendFrame() may overflow, and the data transmission may not be executed.

My idea is to check whether it returns a failure to re-request.

I am not sure if the MCU load caused by too many requests is acceptable.