### PR TITLE
Fix multiple div-by-zero related to battery cell count

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -511,13 +511,13 @@ uint8_t getBatteryCellCount(void)
 
 uint16_t getBatteryAverageCellVoltage(void)
 {
-    return voltageMeter.displayFiltered / batteryCellCount;
+    return (batteryCellCount ? voltageMeter.displayFiltered / batteryCellCount : 0);
 }
 
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
 uint16_t getBatterySagCellVoltage(void)
 {
-    return voltageMeter.sagFiltered / batteryCellCount;
+    return (batteryCellCount ? voltageMeter.sagFiltered / batteryCellCount : 0);
 }
 #endif
 

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -210,11 +210,7 @@ static void setIbusSensorType(ibusAddress_t address)
 
 static uint16_t getVoltage()
 {
-    uint16_t voltage = getBatteryVoltage();
-    if (telemetryConfig()->report_cell_voltage) {
-        voltage /= getBatteryCellCount();
-    }
-    return voltage;
+    return (telemetryConfig()->report_cell_voltage ? getBatteryAverageCellVoltage() : getBatteryVoltage());
 }
 
 static uint16_t getTemperature()

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -602,7 +602,6 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
         int32_t tmpi;
         uint32_t tmp2 = 0;
         uint16_t vfasVoltage;
-        uint8_t cellCount;
 
 #ifdef USE_ESC_SENSOR_TELEMETRY
         escSensorData_t *escData;
@@ -610,11 +609,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 
         switch (id) {
             case FSSP_DATAID_VFAS       :
-                vfasVoltage = getBatteryVoltage();
-                if (telemetryConfig()->report_cell_voltage) {
-                    cellCount = getBatteryCellCount();
-                    vfasVoltage = cellCount ? getBatteryVoltage() / cellCount : 0;
-                }
+                vfasVoltage = telemetryConfig()->report_cell_voltage ? getBatteryAverageCellVoltage() : getBatteryVoltage();
                 smartPortSendPackage(id, vfasVoltage); // in 0.01V according to SmartPort spec
                 *clearToSend = false;
                 break;
@@ -873,8 +868,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 break;
 #endif
             case FSSP_DATAID_A4         :
-                cellCount = getBatteryCellCount();
-                vfasVoltage = cellCount ? (getBatteryVoltage() / cellCount) : 0; // in 0.01V according to SmartPort spec
+                vfasVoltage = getBatteryAverageCellVoltage(); // in 0.01V according to SmartPort spec
                 smartPortSendPackage(id, vfasVoltage);
                 *clearToSend = false;
                 break;

--- a/src/test/unit/telemetry_ibus_unittest.cc
+++ b/src/test/unit/telemetry_ibus_unittest.cc
@@ -72,11 +72,10 @@ extern "C" {
 static int32_t amperage = 100;
 static int32_t estimatedVario = 0;
 static uint8_t batteryRemaining = 0;
-static uint16_t avgCellVoltage = vbat/testBatteryCellCount;
 static throttleStatus_e throttleStatus = THROTTLE_HIGH;
 static uint32_t definedFeatures = 0;
 static uint32_t definedSensors = SENSOR_GYRO | SENSOR_ACC | SENSOR_MAG | SENSOR_SONAR | SENSOR_GPS | SENSOR_GPSMAG;
-
+static uint16_t testBatteryVoltage = 1000;
 
 int32_t getAmperage(void)
 {
@@ -95,7 +94,7 @@ uint8_t calculateBatteryPercentageRemaining(void)
 
 uint16_t getBatteryAverageCellVoltage(void)
 {
-    return avgCellVoltage;
+    return testBatteryVoltage / testBatteryCellCount;
 }
 
 int32_t getMAhDrawn(void)
@@ -128,7 +127,6 @@ typedef struct serialPortStub_s {
 } serialPortStub_t;
 
 
-static uint16_t testBatteryVoltage = 1000;
 uint16_t getBatteryVoltage(void)
 {
     return testBatteryVoltage;


### PR DESCRIPTION
Battery cell count will be 0 if the battery is not detected or the voltage meter is not configured. This exposed multiple div-by-zero risks.
