### PR TITLE
Fix logic error for RACEFLIGHT and KISS rates range checks

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -104,7 +104,7 @@ pidProfile_t *currentPidProfile;
 #define DYNAMIC_FILTER_MAX_SUPPORTED_LOOP_TIME HZ_TO_INTERVAL_US(2000)
 
 #define BETAFLIGHT_MAX_SRATE  100
-#define KISS_MAX_SRATE        100
+#define KISS_MAX_SRATE        99
 #define QUICK_MAX_RATE        200
 #define ACTUAL_MAX_RATE       200
 
@@ -580,6 +580,8 @@ static void validateAndFixConfig(void)
             }
 
             break;
+        case RATES_TYPE_RACEFLIGHT:
+            break;   // no range constraint is necessary - allows 0 - 255
         case RATES_TYPE_KISS:
             for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
                 controlRateProfilesMutable(i)->rates[axis] = constrain(controlRateProfilesMutable(i)->rates[axis], 0, KISS_MAX_SRATE);
@@ -596,6 +598,8 @@ static void validateAndFixConfig(void)
             for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
                 controlRateProfilesMutable(i)->rates[axis] = constrain(controlRateProfilesMutable(i)->rates[axis], 0, QUICK_MAX_RATE);
             }
+
+            break;
         }
     }
 


### PR DESCRIPTION
Fixes logic errors in #9574

For RACEFLIGHT rates the applicable `case` was missing so the logic defaulted to the BETAFLIGHT rates logic which incorrectly limited the maximum rate value to 100. RACEFLIGHT values range to 255.

For KISS rates the limit was set to 100 but the Configurator constrains to 99.
