### PR TITLE
Improve rate settings range checking

### DIFF
--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -69,6 +69,14 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
     }
 }
 
+const ratesSettingsLimits_t ratesSettingLimits[RATES_TYPE_COUNT] = {
+    [RATES_TYPE_BETAFLIGHT] = { 255, 100, 100 },
+    [RATES_TYPE_RACEFLIGHT] = { 200, 255, 100 },
+    [RATES_TYPE_KISS]       = { 255,  99, 100 },
+    [RATES_TYPE_ACTUAL]     = { 200, 200, 100 },
+    [RATES_TYPE_QUICK]      = { 255, 200, 100 },
+};
+
 void loadControlRateProfile(void)
 {
     currentControlRateProfile = controlRateProfilesMutable(systemConfig()->activeRateProfile);

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -30,7 +30,14 @@ typedef enum {
     RATES_TYPE_KISS,
     RATES_TYPE_ACTUAL,
     RATES_TYPE_QUICK,
+    RATES_TYPE_COUNT    // must be the final entry
 } ratesType_e;
+
+typedef struct ratesSettingsLimits_s {
+    uint8_t rc_rate_limit;
+    uint8_t srate_limit;
+    uint8_t expo_limit;
+} ratesSettingsLimits_t;
 
 typedef enum {
     THROTTLE_LIMIT_TYPE_OFF = 0,
@@ -66,6 +73,7 @@ typedef struct controlRateConfig_s {
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);
 
 extern controlRateConfig_t *currentControlRateProfile;
+extern const ratesSettingsLimits_t ratesSettingLimits[RATES_TYPE_COUNT];
 
 void loadControlRateProfile(void);
 void changeControlRateProfile(uint8_t controlRateProfileIndex);


### PR DESCRIPTION
Improve the logic to be table-based and add validation of the rc_rates and expo values. The previous logic only validated the super-rates and the rc_rates can also be out-of-range when changing rates types. The expo values are also checked but currently all the rates types have the same constraints so there's no possibility currently of them being out of range. But this will allow for possible new rates types in the future that may have different constraints.

The limits are as follows:

|rates_type|rc_rate|srate|expo|
|---|---|---|---|
|BETAFLIGHT|255|100|100|
|RACEFLIGHT|200|255|100|
|KISS|255|99|100|
|ACTUAL|200|200|100|
|QUICK|255|200|100|