### PR TITLE
Crashflip output power control

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -911,10 +911,11 @@ const clivalue_t valueTable[] = {
 #endif // USE_BEEPER
 
 // PG_MIXER_CONFIG
-    { "yaw_motors_reversed",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
-    { "mixer_type",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_MIXER_TYPE }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, mixer_type) },
+    { "yaw_motors_reversed",        VAR_INT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, yaw_motors_reversed) },
+    { "mixer_type",                 VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_MIXER_TYPE }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, mixer_type) },
     { "crashflip_motor_percent",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_motor_percent) },
-    { "crashflip_expo",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_expo) },
+    { "crashflip_expo",             VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_expo) },
+    { "crashflip_output_percent",   VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_output_percent) },
 
 // PG_MOTOR_3D_CONFIG
     { "3d_deadband_low",            VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_RANGE_MIDDLE }, PG_MOTOR_3D_CONFIG, offsetof(flight3DConfig_t, deadband3d_low) },

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -90,6 +90,7 @@ typedef struct mixerConfig_s {
     uint8_t crashflip_motor_percent;
     uint8_t crashflip_expo;
     uint8_t mixer_type;
+    uint8_t crashflip_output_percent;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -52,6 +52,7 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .crashflip_motor_percent = 0,
     .crashflip_expo = 35,
     .mixer_type = MIXER_LEGACY,
+    .crashflip_output_percent = 0,
 );
 
 PG_REGISTER_ARRAY(motorMixer_t, MAX_SUPPORTED_MOTORS, customMotorMixer, PG_MOTOR_MIXER, 0);


### PR DESCRIPTION
This feature is mainly targeted towards low power 1s machines.

**Motivation:** Currently crashflip output power at max stick deflection is restricted by motor output range. Motor output range can be influenced by motor output limit, VBAT sag compensation, etc.. In low power 1s machines crash flip can be unreliable when motor output is limited.

I implemented a new crash flip parameter, that controls the output power of crashflip at max stick deflection. To enable it simply type: `set crashflip_output_percent = X` in CLI.
By default, when set to 0 the behavior of crash flip is unchanged.
When set to a value greater than 0, crashflip maximum output power will be based on maximum available motor output power (DSHOT_MAX_THROTTLE or maxthrottle for non-dshot protocol) multiplied by the value set by the user, i.e crashflip_output_percent = 50 will equal in 50% of maximum motor output power.

Test files are attached below.
[betaflight_4.3.0_STM32F7X2_norevision.zip](https://github.com/betaflight/betaflight/files/5751662/betaflight_4.3.0_STM32F7X2_norevision.zip)
[betaflight_4.3.0_STM32F405_norevision.zip](https://github.com/betaflight/betaflight/files/5751663/betaflight_4.3.0_STM32F405_norevision.zip)
[betaflight_4.3.0_STM32F411_norevision.zip](https://github.com/betaflight/betaflight/files/5751664/betaflight_4.3.0_STM32F411_norevision.zip)
[betaflight_4.3.0_STM32F745_norevision.zip](https://github.com/betaflight/betaflight/files/5751665/betaflight_4.3.0_STM32F745_norevision.zip)





