### PR TITLE
Refactor SD_Init() to return proper SD_Error_t code.

### DIFF
--- a/src/main/drivers/sdio_f7xx.c
+++ b/src/main/drivers/sdio_f7xx.c
@@ -1637,41 +1637,50 @@ bool SD_GetState(void)
 
 
 /** -----------------------------------------------------------------------------------------------------------------*/
-bool SD_Init(void)
+SD_Error_t SD_Init(void)
 {
-    SD_Error_t ErrorState;
+    SD_Error_t errorState;
 
     __HAL_RCC_SDMMC1_CLK_ENABLE();
 
-    // Initialize SDMMC1 peripheral interface with default configuration for SD card initialization
+    // Initialize SDMMC1 peripheral interface with default configuration for SD card initialization.
     MODIFY_REG(SDMMC1->CLKCR, CLKCR_CLEAR_MASK, (uint32_t) SDMMC_INIT_CLK_DIV);
 
-    if((ErrorState = SD_PowerON()) == SD_OK)                    // Identify card operating voltage
-    {
-        if((ErrorState = SD_InitializeCard()) == SD_OK)         // Initialize the present card and put them in idle state
-        {
-            if((ErrorState = SD_GetCardInfo()) == SD_OK)        // Read CSD/CID MSD registers
-            {
-                // Select the Card - Send CMD7 SDMMC_SEL_DESEL_CARD
-                ErrorState = SD_TransmitCommand((SD_CMD_SEL_DESEL_CARD | SD_CMD_RESPONSE_SHORT), SD_CardRCA, 1);
-                MODIFY_REG(SDMMC1->CLKCR, CLKCR_CLEAR_MASK, (uint32_t) SDMMC_CLK_DIV); // Configure SDMMC1 peripheral interface
-            }
-        }
+    // Identify card operating voltage.
+    errorState = SD_PowerON();
+    if (errorState != SD_OK) {
+        return errorState;
     }
 
-    // Configure SD Bus width
-    if(ErrorState == SD_OK)
+    // Initialize the present card and put them in idle state.
+    errorState = SD_InitializeCard();
+    if (errorState != SD_OK) {
+        return errorState;
+    }
+
+    // Read CSD/CID MSD registers.
+    errorState = SD_GetCardInfo();
+    if (errorState != SD_OK) {
+        return errorState;
+    }
+
+    // Select the Card - Send CMD7 SDMMC_SEL_DESEL_CARD.
+    errorState = SD_TransmitCommand((SD_CMD_SEL_DESEL_CARD | SD_CMD_RESPONSE_SHORT), SD_CardRCA, 1);
+    // Configure SDMMC1 peripheral interface.
+    MODIFY_REG(SDMMC1->CLKCR, CLKCR_CLEAR_MASK, (uint32_t) SDMMC_CLK_DIV);
+
+    // Configure SD Bus width.
+    if (errorState == SD_OK)
     {
-        // Enable wide operation
+        // Enable wide operation.
         if (sdioConfig()->use4BitWidth) {
-            ErrorState = SD_WideBusOperationConfig(SD_BUS_WIDE_4B);
+            errorState = SD_WideBusOperationConfig(SD_BUS_WIDE_4B);
         } else {
-            ErrorState = SD_WideBusOperationConfig(SD_BUS_WIDE_1B);
+            errorState = SD_WideBusOperationConfig(SD_BUS_WIDE_1B);
         }
     }
 
-    // Configure the SDCARD device
-    return ErrorState;
+    return errorState;
 }
 
 /** -----------------------------------------------------------------------------------------------------------------*/

--- a/src/main/drivers/sdio_h7xx.c
+++ b/src/main/drivers/sdio_h7xx.c
@@ -254,16 +254,8 @@ bool SD_GetState(void)
     return (cardState == HAL_SD_CARD_TRANSFER);
 }
 
-/*
- * return FALSE for OK!
- * The F4/F7 code actually returns an SD_Error_t if the card is detected
- * SD_OK == 0, SD_* are non-zero and indicate errors.  e.g. SD_ERROR = 42
- */
-bool SD_Init(void)
+SD_Error_t SD_Init(void)
 {
-    bool failureResult = SD_ERROR; // FIXME fix the calling code, this false for success is bad.
-    bool successResult = false;
-
     HAL_StatusTypeDef status;
 
     memset(&hsd1, 0, sizeof(hsd1));
@@ -283,7 +275,7 @@ bool SD_Init(void)
     status = HAL_SD_Init(&hsd1); // Will call HAL_SD_MspInit
 
     if (status != HAL_OK) {
-        return failureResult;
+        return SD_ERROR;
     }
 
     switch(hsd1.SdCard.CardType) {
@@ -296,7 +288,7 @@ bool SD_Init(void)
             SD_CardType = SD_STD_CAPACITY_V2_0;
             break;
         default:
-            return failureResult;
+            return SD_ERROR;
         }
         break;
 
@@ -305,7 +297,7 @@ bool SD_Init(void)
         break;
 
     default:
-        return failureResult;
+        return SD_ERROR;
     }
 
     STATIC_ASSERT(sizeof(SD_Handle.CSD) == sizeof(hsd1.CSD), hal-csd-size-error);
@@ -314,7 +306,7 @@ bool SD_Init(void)
     STATIC_ASSERT(sizeof(SD_Handle.CID) == sizeof(hsd1.CID), hal-cid-size-error);
     memcpy(&SD_Handle.CID, &hsd1.CID, sizeof(SD_Handle.CID));
 
-    return successResult;
+    return SD_OK;
 }
 
 SD_Error_t SD_GetCardInfo(void)

--- a/src/main/drivers/sdmmc_sdio.h
+++ b/src/main/drivers/sdmmc_sdio.h
@@ -220,7 +220,7 @@ extern           SD_CardInfo_t               SD_CardInfo;
 extern           SD_CardType_t               SD_CardType;
 
 void             SD_Initialize_LL            (DMA_Stream_TypeDef *dma);
-bool             SD_Init                     (void);
+SD_Error_t       SD_Init                     (void);
 bool             SD_IsDetected				(void);
 bool             SD_GetState                 (void);
 SD_Error_t       SD_GetCardInfo              (void);


### PR DESCRIPTION
Function SD_Init() is called as follows:

```
./main/msc/usbd_storage_sdio.c:         if (SD_Init() != 0) {
./main/drivers/sdcard_sdio_baremetal.c: if (SD_Init() != 0) {
./main/drivers/sdcard_sdio_baremetal.c: if (SD_Init() != 0) {
```

and checks whether return value is != 0, that is != SD_OK.
Previous implementation is working, however, cannot handle proper
SD_Error_t handling. In addition the code was refactored and simplified.