### PR TITLE
Fixed CLI parameter for simplified gyro filters.

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1188,8 +1188,8 @@ const clivalue_t valueTable[] = {
     { "simplified_dterm_filter",            VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, simplified_dterm_filter) },
     { "simplified_dterm_filter_multiplier", VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { SIMPLIFIED_TUNING_MIN, SIMPLIFIED_TUNING_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, simplified_dterm_filter_multiplier) },
 
-    { "simplified_gyro_filter",             VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, simplified_gyro_filter) },
-    { "simplified_gyro_filter_multiplier",  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { SIMPLIFIED_TUNING_MIN, SIMPLIFIED_TUNING_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, simplified_gyro_filter_multiplier) },
+    { "simplified_gyro_filter",             VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, simplified_gyro_filter) },
+    { "simplified_gyro_filter_multiplier",  VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { SIMPLIFIED_TUNING_MIN, SIMPLIFIED_TUNING_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, simplified_gyro_filter_multiplier) },
 #endif
 
 // PG_TELEMETRY_CONFIG


### PR DESCRIPTION
Fixes #10457.

Test targets:

[betaflight_4.3.0_STM32F745_55fe3bb8f.zip](https://github.com/betaflight/betaflight/files/5789911/betaflight_4.3.0_STM32F745_55fe3bb8f.zip)
[betaflight_4.3.0_STM32F7X2_55fe3bb8f.zip](https://github.com/betaflight/betaflight/files/5789912/betaflight_4.3.0_STM32F7X2_55fe3bb8f.zip)
[betaflight_4.3.0_STM32F411_55fe3bb8f.zip](https://github.com/betaflight/betaflight/files/5789913/betaflight_4.3.0_STM32F411_55fe3bb8f.zip)
[betaflight_4.3.0_STM32F405_55fe3bb8f.zip](https://github.com/betaflight/betaflight/files/5789914/betaflight_4.3.0_STM32F405_55fe3bb8f.zip)

(how to install the test firmware: https://youtu.be/I1uN9CN30gw)