### PR TITLE
Exclude yaw from AntiGravity generated P boost

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1159,12 +1159,9 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         float agBoostAttenuator = fabsf(currentPidSetpoint) / 50.0f;
         agBoostAttenuator = MAX(agBoostAttenuator, 1.0f);
         const float agBoost = 1.0f + (pidRuntime.antiGravityPBoost / agBoostAttenuator);
-        pidData[axis].P *= agBoost;
-        if (axis == FD_ROLL) {
-            DEBUG_SET(DEBUG_ANTI_GRAVITY, 2, lrintf(agBoost * 1000));
-        }
-        if (axis == FD_PITCH) {
-            DEBUG_SET(DEBUG_ANTI_GRAVITY, 3, lrintf(agBoost * 1000));
+        if (axis != FD_YAW) {
+            pidData[axis].P *= agBoost;
+            DEBUG_SET(DEBUG_ANTI_GRAVITY, axis + 2, lrintf(agBoost * 1000));
         }
 
         const float pidSum = pidData[axis].P + pidData[axis].I + pidData[axis].D + pidData[axis].F;


### PR DESCRIPTION
Including P boost in AntiGravity has worked well, except that some quads with marginally high P on yaw would get transient yaw oscillation when adding or cutting throttle.

This PR provides a simple fix, by excluding yaw from the P boost element of AntiGravity in 4.3.

Most issues for which AntiGravity was intended arise on Pitch, and occasionally roll.  Yaw events on throttle cut are relatively unusual.  Hence it is not likely that excluding yaw from the P boost is likely to be an issue.  

Yaw I is still boosted, as it always was.