### PR TITLE
Fix compile errors for ak8975 magnetometer driver

### DIFF
--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -79,12 +79,12 @@
 
 static bool ak8975Init(magDev_t *mag)
 {
-    busDeviceRegister(busdev);
-
     uint8_t asa[3];
     uint8_t status;
 
-    busDevice_t *busdev = &mag->busdev;
+    const busDevice_t *busdev = &mag->busdev;
+
+    busDeviceRegister(busdev);
 
     busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down before entering fuse mode
     delay(20);
@@ -122,7 +122,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData)
     uint8_t status;
     uint8_t buf[6];
 
-    busDevice_t *busdev = &mag->busdev;
+    const busDevice_t *busdev = &mag->busdev;
 
     ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST1, &status, 1);
     if (!ack || (status & ST1_REG_DATA_READY) == 0) {


### PR DESCRIPTION
Not used in any current release targets so not noticed. However is included in a number of legacy targets which currently won't compile.

Driver should probably be added to some target that's part of the builds to prevent the code from getting stale.