### PR TITLE
Added AK8975 magnetometer driver to Unified Targets.

### DIFF
--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -174,6 +174,7 @@
 #define USE_MAG_AK8963
 #define USE_MAG_MPU925X_AK8963
 #define USE_MAG_SPI_AK8963
+#define USE_MAG_AK8975
 
 #define USE_BARO
 #define USE_BARO_MS5611


### PR DESCRIPTION
Follow-up to #10464. Not sure why this driver wasn't included when the Unified Targets where created, considering some legacy F4 / F7 targets include it, and the aim is to have feature parity.