### PR TITLE
Make MSP displayPort respect the NTSC/PAL setting

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1516,7 +1516,7 @@ const clivalue_t valueTable[] = {
 #endif
 
 // PG_VCD_CONFIG
-#if defined(USE_MAX7456) || defined(USE_FRSKYOSD)
+#if defined(USE_MAX7456) || defined(USE_FRSKYOSD) || defined(USE_MSP_DISPLAYPORT)
     { "vcd_video_system",           VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_VIDEO_SYSTEM }, PG_VCD_CONFIG, offsetof(vcdProfile_t, video_system) },
     { "vcd_h_offset",               VAR_INT8    | MASTER_VALUE, .config.minmax = { -32, 31 }, PG_VCD_CONFIG, offsetof(vcdProfile_t, h_offset) },
     { "vcd_v_offset",               VAR_INT8    | MASTER_VALUE, .config.minmax = { -15, 16 }, PG_VCD_CONFIG, offsetof(vcdProfile_t, v_offset) },

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -32,12 +32,15 @@
 #include "common/utils.h"
 
 #include "drivers/display.h"
+#include "drivers/osd.h"
 
 #include "io/displayport_msp.h"
 
 #include "msp/msp.h"
 #include "msp/msp_protocol.h"
 #include "msp/msp_serial.h"
+
+#include "pg/vcd.h"
 
 static displayPort_t mspDisplayPort;
 
@@ -141,7 +144,8 @@ static bool isSynced(const displayPort_t *displayPort)
 
 static void redraw(displayPort_t *displayPort)
 {
-    displayPort->rows = 13 + displayPortProfileMsp()->rowAdjust; // XXX Will reflect NTSC/PAL in the future
+    const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? 16 : 13;
+    displayPort->rows = displayRows + displayPortProfileMsp()->rowAdjust;
     displayPort->cols = 30 + displayPortProfileMsp()->colAdjust;
     drawScreen(displayPort);
 }


### PR DESCRIPTION
Previously the display rows was hardcoded to 13 (NTSC). Now it will use 16 if the user has explicitly selected PAL. This allows the display to fully use the screen - particularly when in the CMS menus. Since there is no device to "AUTO" detect, this will still default to safer value of 13 rows as NTSC.

Eventually we may want to extend MSP displayPort to add an auto-detect capability. But since the protocol is a one-way "push" from the firmware to the device that's somewhat difficult. Will probably need a MSP message that the displayPort device can use to "register" its capabilities.
