### PR TITLE
Fix incorrect displayport_msp_serial default and add validation

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -68,6 +68,7 @@
 #include "pg/adc.h"
 #include "pg/beeper.h"
 #include "pg/beeper_dev.h"
+#include "pg/displayport_profiles.h"
 #include "pg/gyrodev.h"
 #include "pg/motor.h"
 #include "pg/pg.h"
@@ -596,6 +597,18 @@ static void validateAndFixConfig(void)
     if (batteryConfig()->vbatmincellvoltage >=  batteryConfig()->vbatmaxcellvoltage) {
         batteryConfigMutable()->vbatmincellvoltage = VBAT_CELL_VOLTAGE_DEFAULT_MIN;
         batteryConfigMutable()->vbatmaxcellvoltage = VBAT_CELL_VOLTAGE_DEFAULT_MAX;
+    }
+
+    // validate that displayport_msp_serial is referencing a valid UART that actually has MSP enabled
+    if (displayPortProfileMsp()->displayPortSerial != SERIAL_PORT_NONE) {
+        const serialPortConfig_t *portConfig = serialFindPortConfiguration(displayPortProfileMsp()->displayPortSerial);
+        if (!portConfig || !(portConfig->functionMask & FUNCTION_MSP)
+#ifndef USE_MSP_PUSH_OVER_VCP
+            || (portConfig->identifier == SERIAL_PORT_USB_VCP)
+#endif
+            ) {
+            displayPortProfileMspMutable()->displayPortSerial = SERIAL_PORT_NONE;
+        }
     }
 
 #if defined(TARGET_VALIDATECONFIG)

--- a/src/main/pg/displayport_profiles.c
+++ b/src/main/pg/displayport_profiles.c
@@ -22,13 +22,20 @@
 
 #include "platform.h"
 
+#include "io/serial.h"
+
 #include "pg/displayport_profiles.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
 #if defined(USE_MSP_DISPLAYPORT)
 
-PG_REGISTER(displayPortProfile_t, displayPortProfileMsp, PG_DISPLAY_PORT_MSP_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(displayPortProfile_t, displayPortProfileMsp, PG_DISPLAY_PORT_MSP_CONFIG, 0);
+
+void pgResetFn_displayPortProfileMsp(displayPortProfile_t *displayPortProfile)
+{
+    displayPortProfile->displayPortSerial = SERIAL_PORT_NONE;
+}
 
 #endif
 


### PR DESCRIPTION
Was incorrectly defaulting to 0 which is UART1. Should be -1 (`SERIAL_PORT_NONE`).

Added validation to ensure the selected UART exists, has MSP enabled, and is appropriate (not VCP).
