### PR TITLE
black box dashboard OLED page

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -745,4 +745,21 @@ blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes)
         return BLACKBOX_RESERVE_PERMANENT_FAILURE;
     }
 }
+
+int8_t blackboxGetLogFileNo(void)
+{   
+#ifdef USE_BLACKBOX
+#ifdef USE_SDCARD
+    // return current file number or -1 
+    if (blackboxSDCard.state == BLACKBOX_SDCARD_READY_TO_LOG) {
+        return blackboxSDCard.largestLogFileNumber;
+    } else {
+        return -1;
+    }
+#else
+    // will be implemented later for flash based storage
+    return -1;
+#endif
+#endif    
+}
 #endif // BLACKBOX

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -63,3 +63,5 @@ int32_t blackboxGetLogNumber(void);
 
 void blackboxReplenishHeaderBudget(void);
 blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes);
+int8_t blackboxGetLogFileNo(void);
+

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -63,6 +63,9 @@
 #include "io/dashboard.h"
 #include "io/displayport_oled.h"
 
+#include "blackbox/blackbox_io.h"
+#include "blackbox/blackbox.h"
+
 #include "rx/rx.h"
 
 #include "scheduler/scheduler.h"
@@ -567,6 +570,35 @@ static void showTasksPage(void)
 }
 #endif
 
+#ifdef USE_BLACKBOX
+static void showBBPage(void)
+{
+    uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
+    int8_t fileNo;
+    if (isBlackboxDeviceWorking()) {
+        switch (blackboxConfig()->device) {
+        case BLACKBOX_DEVICE_SDCARD:
+            fileNo = blackboxGetLogFileNo();
+            if( fileNo > 0) {
+                tfp_sprintf(lineBuffer, "File no: %d", fileNo);
+            } else {
+                tfp_sprintf(lineBuffer, "Not ready yet");
+            }
+            break;
+        default:
+            tfp_sprintf(lineBuffer, "Not supp. dev.");
+            break;
+        }
+    } else {
+        tfp_sprintf(lineBuffer, "BB not working");
+    }
+
+    padLineBuffer();
+    i2c_OLED_set_line(bus, rowIndex++);
+    i2c_OLED_send_string(bus, lineBuffer);
+}
+#endif
+
 #ifdef ENABLE_DEBUG_DASHBOARD_PAGE
 
 static void showDebugPage(void)
@@ -593,6 +625,9 @@ static const pageEntry_t pages[PAGE_COUNT] = {
     { PAGE_SENSORS, "SENSORS",         showSensorsPage,    PAGE_FLAGS_NONE },
 #if defined(USE_TASK_STATISTICS)
     { PAGE_TASKS,   "TASKS",           showTasksPage,      PAGE_FLAGS_NONE },
+#endif
+#ifdef USE_BLACKBOX
+    { PAGE_BB,      "BLACK BOX",       showBBPage,         PAGE_FLAGS_NONE },
 #endif
 #ifdef ENABLE_DEBUG_DASHBOARD_PAGE
     { PAGE_DEBUG,   "DEBUG",           showDebugPage,      PAGE_FLAGS_NONE },

--- a/src/main/io/dashboard.h
+++ b/src/main/io/dashboard.h
@@ -53,7 +53,9 @@ typedef enum {
 #ifdef ENABLE_DEBUG_DASHBOARD_PAGE
     PAGE_DEBUG,
 #endif
-
+#ifdef USE_BLACKBOX
+    PAGE_BB,
+#endif
     PAGE_COUNT
 } pageId_e;
 


### PR DESCRIPTION
It contains new dashboard page, which shows current number of black log file stored in SD card. It's usefull to match bb gyro log with video footage, for later stabilization.
It includes all cosmetic remarks from https://github.com/betaflight/betaflight/pull/10486 
Also checked if compilation works for board not having black box on board.
Hope it will be ok now :)
![IMG_20210116_203422](https://user-images.githubusercontent.com/1246883/105013231-5165d600-5a3f-11eb-9b23-3dc484c096b1.jpg)
[betaflight_4.3.0_CRAZYBEEF4FR_norevision.zip](https://github.com/betaflight/betaflight/files/5834856/betaflight_4.3.0_CRAZYBEEF4FR_norevision.zip)
[betaflight_4.3.0_STM32F745_dd499ffe3.zip](https://github.com/betaflight/betaflight/files/5834857/betaflight_4.3.0_STM32F745_dd499ffe3.zip)
[betaflight_4.3.0_STM32F7X2_dd499ffe3.zip](https://github.com/betaflight/betaflight/files/5834858/betaflight_4.3.0_STM32F7X2_dd499ffe3.zip)
[betaflight_4.3.0_STM32F411_dd499ffe3.zip](https://github.com/betaflight/betaflight/files/5834859/betaflight_4.3.0_STM32F411_dd499ffe3.zip)
[betaflight_4.3.0_STM32F405_dd499ffe3.zip](https://github.com/betaflight/betaflight/files/5834860/betaflight_4.3.0_STM32F405_dd499ffe3.zip)

Kris
