### PR TITLE
Stats ON by default with 30 seconds min armed time

### DIFF
--- a/src/main/pg/stats.c
+++ b/src/main/pg/stats.c
@@ -30,7 +30,7 @@
 PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 2);
 
 PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
-    .stats_min_armed_time_s = STATS_OFF,
+    .stats_min_armed_time_s = 30,
     .stats_total_flights = 0,
     .stats_total_time_s = 0,
     .stats_total_dist_m = 0,


### PR DESCRIPTION
Turning stats ON by default.
Feature request by @MBoerlage
https://github.com/betaflight/betaflight/issues/10504

People who use it will not have to go to CLI / OSD unless they want to change "30 seconds".
Will not harm the people who not use it.