### PR TITLE
Revert default dyn_lpf_expo_curve value for gyro

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -133,7 +133,7 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->dyn_notch_q = 120;
     gyroConfig->dyn_notch_min_hz = 150;
     gyroConfig->gyro_filter_debug_axis = FD_ROLL;
-    gyroConfig->dyn_lpf_curve_expo = 0;
+    gyroConfig->dyn_lpf_curve_expo = 5;
 	gyroConfig->simplified_gyro_filter = false;
 	gyroConfig->simplified_gyro_filter_multiplier = SIMPLIFIED_TUNING_DEFAULT;
 }


### PR DESCRIPTION
In https://github.com/betaflight/betaflight/pull/9119 gyro dyn lpf curve expo was reverted to zero.
Thanks @Asizon for noticing that
