### PR TITLE
Check pull request with astyle for proper code style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     - lcov
     - libc6-i386
     - libblocksruntime-dev
+    - astyle
 
 before_install:
   - |
@@ -52,6 +53,7 @@ before_install:
       echo "Only files not used in the build process were updated, aborting."
       exit
     }
+    for f in "${FILE_LIST[@]}"; do src/utils/check_cstyle.sh "${f}"; done
   - pip install --user cpp-coveralls
   - gem install coveralls-lcov
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,14 @@ pr:
 stages:
 - stage: Build
   jobs:
+  - job: 'Precheck'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+    - script: sudo apt-get install -y astyle
+      displayName: 'Install extra package'
+    - bash: for f in `git diff --name-only origin/master`; do src/utils/check_cstyle.sh "${f}"; done
+      displayName: 'C style check'
   - job: 'Linux'
     pool:
       vmImage: 'ubuntu-16.04'

--- a/src/utils/check_cstyle.sh
+++ b/src/utils/check_cstyle.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+FILE_TO_CHECK=${1}
+RC=0
+
+# Make sure file exists and has proper suffix.
+if [[ ! -f "${FILE_TO_CHECK}" ]] || [[ ! "${FILE_TO_CHECK##*\.}" =~ ^[c,h,C,H]$ ]]; then
+    exit ${RC}
+fi
+
+TMP_FILE_DIFF=$(mktemp /tmp/betaflight.diff.XXXXXXXXX)
+TMP_FILE_ASTYLE=$(mktemp /tmp/betaflight.astyle.XXXXXXXXX)
+TMP_FILE_WARNINGS=$(mktemp /tmp/betaflight.warning.XXXXXXXXX)
+ASTYLE_OPTIONS="--style=kr
+		--indent=spaces=4
+		--min-conditional-indent=0
+		--max-instatement-indent=80
+		--pad-header
+		--pad-oper
+		--align-pointer=name
+		--align-reference=name
+		--max-code-length=120
+		--convert-tabs
+		--preserve-date
+		--suffix=none
+		--mode=c"
+
+git diff --function-context --unified=1 HEAD ${FILE_TO_CHECK} | sed -e '/diff --git/,+3d;/^@@/d;/^-/d;s/^+/ /' | cut -d' ' -f2- > ${TMP_FILE_DIFF}
+astyle ${ASTYLE_OPTIONS} -n < ${TMP_FILE_DIFF} > ${TMP_FILE_ASTYLE}
+diff -u ${TMP_FILE_DIFF} ${TMP_FILE_ASTYLE} | tail -n +3 | sed -e '/^-/d;/^@@/d;s/^+/[STYLE WARNING] /' > ${TMP_FILE_WARNINGS}
+
+if [[ -s ${TMP_FILE_WARNINGS} ]]; then
+    cat ${TMP_FILE_WARNINGS}
+    RC=1
+fi
+
+if [[ ${RC} -eq 1 ]]; then
+    echo -e "File ${FILE_TO_CHECK} has style warning(s), see" \
+	 "https://github.com/betaflight/betaflight/blob/master/docs/development/CodingStyle.md"
+fi
+
+rm -f ${TMP_FILE_DIFF} ${TMP_FILE_ASTYLE} ${TMP_FILE_WARNINGS}
+
+exit ${RC}


### PR DESCRIPTION
Leverage astyle source code indenter and formatter for pre-checking pull request code style.
If code style is in agreement with settings listed in .astylerc, continue with additional pull request handling, otherwise
terminate with warning of style warning.
