### PR TITLE
Added optimised SPI DMA support for F4/F7/H7 access to FLASH for BB

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -374,6 +374,11 @@ void blackboxEraseAll(void)
 {
     switch (blackboxConfig()->device) {
     case BLACKBOX_DEVICE_FLASH:
+        /* Stop the recorder as if blackbox_mode = ALWAYS it will attempt to resume writing after
+         * the erase and leave a corrupted first log.
+         * Possible enhancement here is to restart logging after erase.
+         */
+        blackboxInit();
         flashfsEraseCompletely();
         break;
     default:

--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -389,6 +389,8 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
 
     uint32_t flashSectorSize = flashGeometry->sectorSize;
     uint32_t flashPageSize = flashGeometry->pageSize;
+    const uint8_t *buffers[1];
+    uint32_t bufferSizes[1];
 
     bool onPageBoundary = (flashAddress % flashPageSize == 0);
     if (onPageBoundary) {
@@ -402,10 +404,13 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
             flashEraseSector(flashAddress);
         }
 
-        flashPageProgramBegin(flashAddress);
+        flashPageProgramBegin(flashAddress, NULL);
     }
 
-    flashPageProgramContinue((uint8_t *)buffer, CONFIG_STREAMER_BUFFER_SIZE);
+    buffers[0] = (uint8_t *)buffer;
+    bufferSizes[0] = CONFIG_STREAMER_BUFFER_SIZE;
+
+    flashPageProgramContinue(buffers, bufferSizes, 1);
 
 #elif defined(CONFIG_IN_RAM) || defined(CONFIG_IN_SDCARD)
     if (c->address == (uintptr_t)&eepromData[0]) {

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -54,11 +54,11 @@ bool flashIsReady(void);
 bool flashWaitForReady(void);
 void flashEraseSector(uint32_t address);
 void flashEraseCompletely(void);
-void flashPageProgramBegin(uint32_t address);
-void flashPageProgramContinue(const uint8_t *data, int length);
+void flashPageProgramBegin(uint32_t address, void (*callback)(uint32_t arg));
+uint32_t flashPageProgramContinue(const uint8_t **buffers, uint32_t *bufferSizes, uint32_t bufferCount);
 void flashPageProgramFinish(void);
-void flashPageProgram(uint32_t address, const uint8_t *data, int length);
-int flashReadBytes(uint32_t address, uint8_t *buffer, int length);
+void flashPageProgram(uint32_t address, const uint8_t *data, uint32_t length, void (*callback)(uint32_t length));
+int flashReadBytes(uint32_t address, uint8_t *buffer, uint32_t length);
 void flashFlush(void);
 const flashGeometry_t *flashGetGeometry(void);
 

--- a/src/main/drivers/flash_impl.h
+++ b/src/main/drivers/flash_impl.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "drivers/bus.h"
+#include "drivers/dma.h"
 
 struct flashVTable_s;
 
@@ -64,11 +65,11 @@ typedef struct flashVTable_s {
     bool (*waitForReady)(flashDevice_t *fdevice);
     void (*eraseSector)(flashDevice_t *fdevice, uint32_t address);
     void (*eraseCompletely)(flashDevice_t *fdevice);
-    void (*pageProgramBegin)(flashDevice_t *fdevice, uint32_t address);
-    void (*pageProgramContinue)(flashDevice_t *fdevice, const uint8_t *data, int length);
+    void (*pageProgramBegin)(flashDevice_t *fdevice, uint32_t address, void (*callback)(uint32_t length));
+    uint32_t (*pageProgramContinue)(flashDevice_t *fdevice, uint8_t const **buffers, uint32_t *bufferSizes, uint32_t bufferCount);
     void (*pageProgramFinish)(flashDevice_t *fdevice);
-    void (*pageProgram)(flashDevice_t *fdevice, uint32_t address, const uint8_t *data, int length);
+    void (*pageProgram)(flashDevice_t *fdevice, uint32_t address, const uint8_t *data, uint32_t length, void (*callback)(uint32_t length));
     void (*flush)(flashDevice_t *fdevice);
-    int (*readBytes)(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer, int length);
+    int (*readBytes)(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer, uint32_t length);
     const flashGeometry_t *(*getGeometry)(flashDevice_t *fdevice);
 } flashVTable_t;

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -55,8 +55,33 @@ static DMA_DATA_ZERO_INIT uint8_t flashWriteBuffer[FLASHFS_WRITE_BUFFER_SIZE];
  * oldest byte that has yet to be written to flash.
  *
  * When the circular buffer is empty, head == tail
+ *
+ * The tail is advanced once a write is complete up to the location behind head. The tail is advanced
+ * by a callback from the FLASH write routine. This prevents data being overwritten whilst a write is in progress.
  */
-static uint8_t bufferHead = 0, bufferTail = 0;
+static uint8_t bufferHead = 0;
+static volatile uint8_t bufferTail = 0;
+
+/* Track if there is new data to write. Until the contents of the buffer have been completely
+ * written flashfsFlushAsync() will be repeatedly called. The tail pointer is only updated
+ * once an asynchronous write has completed. To do so any earlier could result in data being
+ * overwritten in the ring buffer. This routine checks that flashfsFlushAsync() should attempt
+ * to write new data and avoids it writing old data during the race condition that occurs if
+ * its called again before the previous write to FLASH has completed.
+  */
+static volatile bool dataWritten = true;
+
+//#define CHECK_FLASH
+
+#ifdef CHECK_FLASH
+// Write an incrementing sequence of bytes instead of the requested data and verify
+DMA_DATA uint8_t checkFlashBuffer[FLASHFS_WRITE_BUFFER_SIZE];
+uint32_t checkFlashPtr = 0;
+uint32_t checkFlashLen = 0;
+uint8_t checkFlashWrite = 0x00;
+uint8_t checkFlashExpected = 0x00;
+uint32_t checkFlashErrors = 0;
+#endif
 
 // The position of the buffer's tail in the overall flash address space:
 static uint32_t tailAddress = 0;
@@ -174,6 +199,19 @@ uint32_t flashfsGetWriteBufferFreeSpace(void)
 }
 
 /**
+ * Called after bytes have been written from the buffer to advance the position of the tail by the given amount.
+ */
+static void flashfsAdvanceTailInBuffer(uint32_t delta)
+{
+    bufferTail += delta;
+
+    // Wrap tail around the end of the buffer
+    if (bufferTail >= FLASHFS_WRITE_BUFFER_SIZE) {
+        bufferTail -= FLASHFS_WRITE_BUFFER_SIZE;
+    }
+}
+
+/**
  * Write the given buffers to flash sequentially at the current tail address, advancing the tail address after
  * each write.
  *
@@ -192,89 +230,58 @@ uint32_t flashfsGetWriteBufferFreeSpace(void)
  *
  * Returns the number of bytes written
  */
+void flashfsWriteCallback(uint32_t arg)
+{
+    // Advance the cursor in the file system to match the bytes we wrote
+    flashfsSetTailAddress(tailAddress + arg);
+
+    // Free bytes in the ring buffer
+    flashfsAdvanceTailInBuffer(arg);
+
+    // Mark that data has been written from the buffer
+    dataWritten = true;
+}
+
 static uint32_t flashfsWriteBuffers(uint8_t const **buffers, uint32_t *bufferSizes, int bufferCount, bool sync)
 {
-    uint32_t bytesTotal = 0;
+    uint32_t bytesWritten;
 
-    int i;
+    // It's OK to overwrite the buffer addresses/lengths being passed in
 
-    for (i = 0; i < bufferCount; i++) {
-        bytesTotal += bufferSizes[i];
+    // If sync is true, block until the FLASH device is ready, otherwise return 0 if the device isn't ready
+    if (sync) {
+        while (!flashIsReady());
+    } else {
+        if (!flashIsReady()) {
+            return 0;
+        }
     }
 
-    if (!sync && !flashIsReady()) {
+    // Are we at EOF already? Abort.
+    if (flashfsIsEOF()) {
         return 0;
     }
 
-    uint32_t bytesTotalRemaining = bytesTotal;
+#ifdef CHECK_FLASH
+    checkFlashPtr = tailAddress;
+#endif
 
-    uint16_t pageSize = flashGeometry->pageSize;
+    flashPageProgramBegin(tailAddress, flashfsWriteCallback);
 
-    while (bytesTotalRemaining > 0) {
-        uint32_t bytesTotalThisIteration;
-        uint32_t bytesRemainThisIteration;
+    /* Mark that data has yet to be written. There is no race condition as the DMA engine is known
+     * to be idle at this point
+     */
+    dataWritten = false;
 
-        /*
-         * Each page needs to be saved in a separate program operation, so
-         * if we would cross a page boundary, only write up to the boundary in this iteration:
-         */
-        if (tailAddress % pageSize + bytesTotalRemaining > pageSize) {
-            bytesTotalThisIteration = pageSize - tailAddress % pageSize;
-        } else {
-            bytesTotalThisIteration = bytesTotalRemaining;
-        }
+    bytesWritten = flashPageProgramContinue(buffers, bufferSizes, bufferCount);
 
-        // Are we at EOF already? Abort.
-        if (flashfsIsEOF()) {
-            // May as well throw away any buffered data
-            flashfsClearBuffer();
+#ifdef CHECK_FLASH
+    checkFlashLen = bytesWritten;
+#endif
 
-            break;
-        }
+    flashPageProgramFinish();
 
-        flashPageProgramBegin(tailAddress);
-
-        bytesRemainThisIteration = bytesTotalThisIteration;
-
-        for (i = 0; i < bufferCount; i++) {
-            if (bufferSizes[i] > 0) {
-                // Is buffer larger than our write limit? Write our limit out of it
-                if (bufferSizes[i] >= bytesRemainThisIteration) {
-                    flashPageProgramContinue(buffers[i], bytesRemainThisIteration);
-
-                    buffers[i] += bytesRemainThisIteration;
-                    bufferSizes[i] -= bytesRemainThisIteration;
-
-                    bytesRemainThisIteration = 0;
-                    break;
-                } else {
-                    // We'll still have more to write after finishing this buffer off
-                    flashPageProgramContinue(buffers[i], bufferSizes[i]);
-
-                    bytesRemainThisIteration -= bufferSizes[i];
-
-                    buffers[i] += bufferSizes[i];
-                    bufferSizes[i] = 0;
-                }
-            }
-        }
-
-        flashPageProgramFinish();
-
-        bytesTotalRemaining -= bytesTotalThisIteration;
-
-        // Advance the cursor in the file system to match the bytes we wrote
-        flashfsSetTailAddress(tailAddress + bytesTotalThisIteration);
-
-        /*
-         * We'll have to wait for that write to complete before we can issue the next one, so if
-         * the user requested asynchronous writes, break now.
-         */
-        if (!sync)
-            break;
-    }
-
-    return bytesTotal - bytesTotalRemaining;
+    return bytesWritten;
 }
 
 /*
@@ -283,19 +290,37 @@ static uint32_t flashfsWriteBuffers(uint8_t const **buffers, uint32_t *bufferSiz
  *
  * This routine will fill the details of those buffers into the provided arrays, which must be at least 2 elements long.
  */
-static void flashfsGetDirtyDataBuffers(uint8_t const *buffers[], uint32_t bufferSizes[])
+static int flashfsGetDirtyDataBuffers(uint8_t const *buffers[], uint32_t bufferSizes[])
 {
     buffers[0] = flashWriteBuffer + bufferTail;
     buffers[1] = flashWriteBuffer + 0;
 
-    if (bufferHead >= bufferTail) {
+    if (bufferHead > bufferTail) {
         bufferSizes[0] = bufferHead - bufferTail;
         bufferSizes[1] = 0;
-    } else {
+        return 1;
+    } else if (bufferHead < bufferTail) {
         bufferSizes[0] = FLASHFS_WRITE_BUFFER_SIZE - bufferTail;
         bufferSizes[1] = bufferHead;
+        if (bufferSizes[1] == 0) {
+            return 1;
+        } else {
+            return 2;
+        }
     }
+
+    bufferSizes[0] = 0;
+    bufferSizes[1] = 0;
+
+    return 0;
 }
+
+
+static bool flashfsNewData()
+{
+    return dataWritten;
+}
+
 
 /**
  * Get the current offset of the file pointer within the volume.
@@ -313,23 +338,6 @@ uint32_t flashfsGetOffset(void)
 }
 
 /**
- * Called after bytes have been written from the buffer to advance the position of the tail by the given amount.
- */
-static void flashfsAdvanceTailInBuffer(uint32_t delta)
-{
-    bufferTail += delta;
-
-    // Wrap tail around the end of the buffer
-    if (bufferTail >= FLASHFS_WRITE_BUFFER_SIZE) {
-        bufferTail -= FLASHFS_WRITE_BUFFER_SIZE;
-    }
-
-    if (flashfsBufferIsEmpty()) {
-        flashfsClearBuffer(); // Bring buffer pointers back to the start to be tidier
-    }
-}
-
-/**
  * If the flash is ready to accept writes, flush the buffer to it.
  *
  * Returns true if all data in the buffer has been flushed to the device, or false if
@@ -337,17 +345,37 @@ static void flashfsAdvanceTailInBuffer(uint32_t delta)
  */
 bool flashfsFlushAsync(void)
 {
+    uint8_t const * buffers[2];
+    uint32_t bufferSizes[2];
+    int bufCount;
+
     if (flashfsBufferIsEmpty()) {
         return true; // Nothing to flush
     }
 
-    uint8_t const * buffers[2];
-    uint32_t bufferSizes[2];
-    uint32_t bytesWritten;
+    if (!flashfsNewData()) {
+        // The previous write has yet to complete
+        return false;
+    }
 
-    flashfsGetDirtyDataBuffers(buffers, bufferSizes);
-    bytesWritten = flashfsWriteBuffers(buffers, bufferSizes, 2, false);
-    flashfsAdvanceTailInBuffer(bytesWritten);
+#ifdef CHECK_FLASH
+    // Verify the data written last time
+    if (checkFlashLen) {
+        while (!flashIsReady());
+        flashReadBytes(checkFlashPtr, checkFlashBuffer, checkFlashLen);
+
+        for (uint32_t i = 0; i < checkFlashLen; i++) {
+            if (checkFlashBuffer[i] != checkFlashExpected++) {
+                checkFlashErrors++; // <-- insert breakpoint here to catch errors
+            }
+        }
+    }
+#endif
+
+    bufCount = flashfsGetDirtyDataBuffers(buffers, bufferSizes);
+    if (bufCount) {
+        flashfsWriteBuffers(buffers, bufferSizes, bufCount, false);
+    }
 
     return flashfsBufferIsEmpty();
 }
@@ -360,18 +388,20 @@ bool flashfsFlushAsync(void)
  */
 void flashfsFlushSync(void)
 {
+    uint8_t const * buffers[2];
+    uint32_t bufferSizes[2];
+    int bufCount;
+
     if (flashfsBufferIsEmpty()) {
         return; // Nothing to flush
     }
 
-    uint8_t const * buffers[2];
-    uint32_t bufferSizes[2];
+    bufCount = flashfsGetDirtyDataBuffers(buffers, bufferSizes);
+    if (bufCount) {
+        flashfsWriteBuffers(buffers, bufferSizes, bufCount, true);
+    }
 
-    flashfsGetDirtyDataBuffers(buffers, bufferSizes);
-    flashfsWriteBuffers(buffers, bufferSizes, 2, true);
-
-    // We've written our entire buffer now:
-    flashfsClearBuffer();
+    while (!flashIsReady());
 }
 
 void flashfsSeekAbs(uint32_t offset)
@@ -381,18 +411,15 @@ void flashfsSeekAbs(uint32_t offset)
     flashfsSetTailAddress(offset);
 }
 
-void flashfsSeekRel(int32_t offset)
-{
-    flashfsFlushSync();
-
-    flashfsSetTailAddress(tailAddress + offset);
-}
-
 /**
  * Write the given byte asynchronously to the flash. If the buffer overflows, data is silently discarded.
  */
 void flashfsWriteByte(uint8_t byte)
 {
+#ifdef CHECK_FLASH
+    byte = checkFlashWrite++;
+#endif
+
     flashWriteBuffer[bufferHead++] = byte;
 
     if (bufferHead >= FLASHFS_WRITE_BUFFER_SIZE) {
@@ -412,79 +439,26 @@ void flashfsWriteByte(uint8_t byte)
  */
 void flashfsWrite(const uint8_t *data, unsigned int len, bool sync)
 {
-    uint8_t const * buffers[3];
-    uint32_t bufferSizes[3];
+    uint8_t const * buffers[2];
+    uint32_t bufferSizes[2];
+    int bufCount;
+    uint32_t totalBufSize;
+
+    // Buffer up the data the user supplied instead of writing it right away
+    for (unsigned int i = 0; i < len; i++) {
+        flashfsWriteByte(data[i]);
+    }
 
     // There could be two dirty buffers to write out already:
-    flashfsGetDirtyDataBuffers(buffers, bufferSizes);
-
-    // Plus the buffer the user supplied:
-    buffers[2] = data;
-    bufferSizes[2] = len;
+    bufCount = flashfsGetDirtyDataBuffers(buffers, bufferSizes);
+    totalBufSize = bufferSizes[0] + bufferSizes[1];
 
     /*
      * Would writing this data to our buffer cause our buffer to reach the flush threshold? If so try to write through
      * to the flash now
      */
-    if (bufferSizes[0] + bufferSizes[1] + bufferSizes[2] >= FLASHFS_WRITE_BUFFER_AUTO_FLUSH_LEN) {
-        uint32_t bytesWritten;
-
-        // Attempt to write all three buffers through to the flash asynchronously
-        bytesWritten = flashfsWriteBuffers(buffers, bufferSizes, 3, false);
-
-        if (bufferSizes[0] == 0 && bufferSizes[1] == 0) {
-            // We wrote all the data that was previously buffered
-            flashfsClearBuffer();
-
-            if (bufferSizes[2] == 0) {
-                // And we wrote all the data the user supplied! Job done!
-                return;
-            }
-        } else {
-            // We only wrote a portion of the old data, so advance the tail to remove the bytes we did write from the buffer
-            flashfsAdvanceTailInBuffer(bytesWritten);
-        }
-
-        // Is the remainder of the data to be written too big to fit in the buffers?
-        if (bufferSizes[0] + bufferSizes[1] + bufferSizes[2] > FLASHFS_WRITE_BUFFER_USABLE) {
-            if (sync) {
-                // Write it through synchronously
-                flashfsWriteBuffers(buffers, bufferSizes, 3, true);
-                flashfsClearBuffer();
-            } else {
-                /*
-                 * Silently drop the data the user asked to write (i.e. no-op) since we can't buffer it and they
-                 * requested async.
-                 */
-            }
-
-            return;
-        }
-
-        // Fall through and add the remainder of the incoming data to our buffer
-        data = buffers[2];
-        len = bufferSizes[2];
-    }
-
-    // Buffer up the data the user supplied instead of writing it right away
-
-    // First write the portion before we wrap around the end of the circular buffer
-    unsigned int bufferBytesBeforeWrap = FLASHFS_WRITE_BUFFER_SIZE - bufferHead;
-
-    unsigned int firstPortion = len < bufferBytesBeforeWrap ? len : bufferBytesBeforeWrap;
-
-    memcpy(flashWriteBuffer + bufferHead, data, firstPortion);
-
-    bufferHead += firstPortion;
-
-    data += firstPortion;
-    len -= firstPortion;
-
-    // If we wrap the head around, write the remainder to the start of the buffer (if any)
-    if (bufferHead == FLASHFS_WRITE_BUFFER_SIZE) {
-        memcpy(flashWriteBuffer + 0, data, len);
-
-        bufferHead = len;
+    if (bufCount && (totalBufSize >= FLASHFS_WRITE_BUFFER_AUTO_FLUSH_LEN)) {
+        flashfsWriteBuffers(buffers, bufferSizes, bufCount, sync);
     }
 }
 

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -38,7 +38,6 @@ struct flashGeometry_s;
 const struct flashGeometry_s* flashfsGetGeometry(void);
 
 void flashfsSeekAbs(uint32_t offset);
-void flashfsSeekRel(int32_t offset);
 
 void flashfsWriteByte(uint8_t byte);
 void flashfsWrite(const uint8_t *data, unsigned int len, bool sync);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -29,6 +29,7 @@
 #include "platform.h"
 
 #include "blackbox/blackbox.h"
+#include "blackbox/blackbox_io.h"
 
 #include "build/build_config.h"
 #include "build/debug.h"
@@ -3177,7 +3178,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 
 #ifdef USE_FLASHFS
     case MSP_DATAFLASH_ERASE:
-        flashfsEraseCompletely();
+        blackboxEraseAll();
 
         break;
 #endif


### PR DESCRIPTION
This PR adds a new SPI  bus API supporting non-blocking DMAs and modifies the black box FLASH writing code to be non-blocking.

The new SPI API supports the old register read/write operations, but also allows a sequence of accesses, each with optional callback and chip select negation, which once triggered will be processed entirely under interrupt/DMA control. Accesses can be blocking or non-blocking as needed.

For example the following definition from `m25p16_readBytes` defines a set of three segments making up the complete SPI transaction, which will poll the device until it is ready, then issue a read command, and finally read the data, all under interrupt/DMA control.

```
    busSegment_t segments[] = {
            {readStatus, readyStatus, sizeof (readStatus), true, m25p16_callbackReady},
            {readBytes, NULL, fdevice->isLargeFlash ? 5 : 4, false, NULL},
            {NULL, buffer, length, true, NULL},
            {NULL, NULL, 0, true, NULL},
    };
```

The driver model introduces the concept of a bus device and an external device. Multiple external devices may share a common bus, and all independently use different bus clock speeds.

All drivers using SPI have been ported to the new API, including gyro, baro, FLASH, MAX7456 and SD card drivers. The MAX7456 and SD card have previously used independent DMA code; they now use the common bus driver facilities. The driver now correctly handles switching between the bus speed used by the MAX7456 and other devices on the same bus which had previously been rather untidy. DMAs are also used in USB MSC mode providing an approx. 10% improvement in the read speed of BB logs.

The SPI driver can operate in polled or DMA mode. During device initialisation polled mode is used exclusively, and only once all devices have claimed their required DMA descriptors will the bus driver code attempt to claim descriptors to allow DMA driven access to be used. No conflicts arise therefore in the use of descriptors. The bus driver correctly handles cache coherency for all processor types, and will only attempt a DMA to a memory type that supports it. Also the bus driver will only use DMAs where they would be faster than polled access; polled is quicker for short accesses, and this polled code is faster than the code in master currently so both polled and DMA accesses are now faster.

In order to support the optimal use of memory supporting DMA the linker scripts have been modified, along with the definition of their associated device type specifiers (e.g. DMA_DATA_AUTO) to use memory as close as possible to the processor. For example the H7 builds no longer use D2 ram to hold data to be DMAed, but rather use AXI RAM, both cached or uncached as desired.

The onboard FLASH driver will now gather up to three buffers (old data in the circular buffer at the tail and start, plus new data, see `flashfsWrite`) into a single write whereas the current code would do three separate writes to do this, thus improving efficiency of the write operations.

Some other processor specific changes have also been made associated with the change in memory section usage, including a workaround for the SPRACINGH7 bootloader quirk that previously prevented putting the .data segment in to DTCM.

The H7 code now uses LL rather than HAL library code for SPI access as this is much more lightweight and faster and similar to the F7 code.

There are a number of future enhancements that this code now enables such as initiating reads from multiple gyros on independent busses at the same time and processing the DMAed data once the transfer completions are indicated using callbacks from the bus driver.