### PR TITLE
Add target board "NEUTRONRC_H743"

### DIFF
--- a/src/main/target/IFLIGHT_H743_AIO/target.h
+++ b/src/main/target/IFLIGHT_H743_AIO/target.h
@@ -20,8 +20,13 @@
 
 #pragma once
 
+#ifdef NEUTRONRC_H743
+#define TARGET_BOARD_IDENTIFIER "NTH7"
+#define USBD_PRODUCT_STRING     "NEUTRONRC_H743"
+#else
 #define TARGET_BOARD_IDENTIFIER "IF7A"
 #define USBD_PRODUCT_STRING     "IFLIGHT_H743_AIO"
+#endif
 
 #define LED0_PIN                PC13
 


### PR DESCRIPTION
A new brand, as a clone of iFlight_H743, is just a different name.

https://www.facebook.com/Neutronrc-575638996448880

![image](https://user-images.githubusercontent.com/10217966/107136966-da877300-6942-11eb-9571-189145519858.png)
