### PR TITLE
Fix out of range in serialPortIdentifier_e enumeration

### DIFF
--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -78,6 +78,7 @@ extern const uint32_t baudRates[];
 
 // serial port identifiers are now fixed, these values are used by MSP commands.
 typedef enum {
+    SERIAL_PORT_ALL = -2,
     SERIAL_PORT_NONE = -1,
     SERIAL_PORT_USART1 = 0,
     SERIAL_PORT_USART2,
@@ -92,7 +93,6 @@ typedef enum {
     SERIAL_PORT_SOFTSERIAL1 = 30,
     SERIAL_PORT_SOFTSERIAL2,
     SERIAL_PORT_IDENTIFIER_MAX = SERIAL_PORT_SOFTSERIAL2,
-    SERIAL_PORT_ALL = 255,
 } serialPortIdentifier_e;
 
 extern const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT];


### PR DESCRIPTION
Corrects the inadvertent out of range enumeration entry I added in #10490. I didn't realize the underlying code using this enumeration was all `int8` and adding the "255" value caused the enumeration to implicitly convert to `int16`. I guess it would be nice if enumerations could be explicitly typed, but that seems to be a limitation.

Tested on F411 and F722 using the 4.2.7 and 4.3.0 versions below.

4.2.7 test versions:
[betaflight_4.2.7_STM32F411_norevision.hex.zip](https://github.com/betaflight/betaflight/files/5978736/betaflight_4.2.7_STM32F411_norevision.hex.zip)
[betaflight_4.2.7_STM32F405_norevision.hex.zip](https://github.com/betaflight/betaflight/files/5978737/betaflight_4.2.7_STM32F405_norevision.hex.zip)
[betaflight_4.2.7_STM32F7X2_norevision.hex.zip](https://github.com/betaflight/betaflight/files/5978738/betaflight_4.2.7_STM32F7X2_norevision.hex.zip)
[betaflight_4.2.7_STM32F745_norevision.hex.zip](https://github.com/betaflight/betaflight/files/5978739/betaflight_4.2.7_STM32F745_norevision.hex.zip)

4.3.0 test versions:
[betaflight_4.3.0_STM32F411_0a673b6.hex.zip](https://github.com/betaflight/betaflight/files/5978741/betaflight_4.3.0_STM32F411_0a673b6.hex.zip)
[betaflight_4.3.0_STM32F405_0a673b6.hex.zip](https://github.com/betaflight/betaflight/files/5978742/betaflight_4.3.0_STM32F405_0a673b6.hex.zip)
[betaflight_4.3.0_STM32F7X2_0a673b6.hex.zip](https://github.com/betaflight/betaflight/files/5978743/betaflight_4.3.0_STM32F7X2_0a673b6.hex.zip)
[betaflight_4.3.0_STM32F745_0a673b6.hex.zip](https://github.com/betaflight/betaflight/files/5978744/betaflight_4.3.0_STM32F745_0a673b6.hex.zip)


Sorry for causing the problem.
