### PR TITLE
Fixed use of an enum type in a parameter group.

### DIFF
--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -117,7 +117,7 @@ serialPort_t *findSharedSerialPort(uint16_t functionMask, serialPortFunction_e s
 //
 typedef struct serialPortConfig_s {
     uint32_t functionMask;
-    serialPortIdentifier_e identifier;
+    int8_t identifier;
     uint8_t msp_baudrateIndex;
     uint8_t gps_baudrateIndex;
     uint8_t blackbox_baudrateIndex;

--- a/src/test/unit/rx_ibus_unittest.cc
+++ b/src/test/unit/rx_ibus_unittest.cc
@@ -73,7 +73,7 @@ uint32_t microsISR(void)
 }
 
 #define SERIAL_BUFFER_SIZE 256
-#define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x1234
+#define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x12
 
 typedef struct serialPortStub_s {
     uint8_t buffer[SERIAL_BUFFER_SIZE];

--- a/src/test/unit/rx_sumd_unittest.cc
+++ b/src/test/unit/rx_sumd_unittest.cc
@@ -75,7 +75,7 @@ uint32_t microsISR(void)
 }
 
 #define SERIAL_BUFFER_SIZE 256
-#define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x1234
+#define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x12
 
 typedef struct serialPortStub_s {
     uint8_t buffer[SERIAL_BUFFER_SIZE];

--- a/src/test/unit/telemetry_ibus_unittest.cc
+++ b/src/test/unit/telemetry_ibus_unittest.cc
@@ -139,7 +139,7 @@ uint8_t getBatteryCellCount(void) {
 static serialPortStub_t serialWriteStub;
 static serialPortStub_t serialReadStub;
 
-#define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x1234
+#define SERIAL_PORT_DUMMY_IDENTIFIER  (serialPortIdentifier_e)0x12
 serialPort_t serialTestInstance;
 serialPortConfig_t serialTestInstanceConfig = {
     .identifier = SERIAL_PORT_DUMMY_IDENTIFIER,


### PR DESCRIPTION
This will reduce the potential for problems coming from bugs like https://github.com/betaflight/betaflight/pull/10550.