### PR TITLE
Add a common function used to print formatted floats in the OSD

### DIFF
--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -354,3 +354,4 @@ bool osdElementVisible(uint16_t value);
 bool osdGetVisualBeeperState(void);
 statistic_t *osdGetStats(void);
 bool osdNeedsAccelerometer(void);
+int osdPrintFloat(char *buffer, char leadingSymbol, float value, char *formatString, unsigned decimalPlaces, bool round, char trailingSymbol);

--- a/src/main/osd/osd_elements.h
+++ b/src/main/osd/osd_elements.h
@@ -49,7 +49,7 @@ void osdFormatDistanceString(char *result, int distance, char leadingSymbol);
 bool osdFormatRtcDateTime(char *buffer);
 void osdFormatTime(char * buff, osd_timer_precision_e precision, timeUs_t time);
 void osdFormatTimer(char *buff, bool showSymbol, bool usePrecision, int timerIndex);
-int32_t osdGetMetersToSelectedUnit(int32_t meters);
+float osdGetMetersToSelectedUnit(int32_t meters);
 char osdGetMetersToSelectedUnitSymbol(void);
 int32_t osdGetSpeedToSelectedUnit(int32_t value);
 char osdGetSpeedToSelectedUnitSymbol(void);

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -263,7 +263,7 @@ void simulateFlight(void)
     GPS_distanceToHome = 100;
     GPS_distanceFlownInCm = 10000;
     simulationBatteryVoltage = 1470;
-    simulationAltitude = 200;
+    simulationAltitude = 200; // converts to 6.56168 feet which rounds to 6.6 in imperial units stats test
     simulationTime += 1e6;
     osdRefresh(simulationTime);
 
@@ -501,7 +501,7 @@ TEST_F(OsdTest, TestStatsImperial)
     // then
     // statistics screen should display the following
     int row = 5;
-    displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      : 6.5%c", SYM_FT);
+    displayPortTestBufferSubstring(2, row++, "MAX ALTITUDE      : 6.6%c", SYM_FT);
     displayPortTestBufferSubstring(2, row++, "MAX SPEED         : 17");
     displayPortTestBufferSubstring(2, row++, "MAX DISTANCE      : 3772%c", SYM_FT);
     displayPortTestBufferSubstring(2, row++, "FLIGHT DISTANCE   : 6.52%c", SYM_MILES);
@@ -905,28 +905,28 @@ TEST_F(OsdTest, TestElementAltitude)
     displayPortTestBufferSubstring(23, 7, "%c0.0%c", SYM_ALTITUDE, SYM_M);
 
     // when
-    simulationAltitude = 247;
+    simulationAltitude = 247;  // rounds to 2.5m
     displayClearScreen(&testDisplayPort);
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(23, 7, "%c2.4%c", SYM_ALTITUDE, SYM_M);
+    displayPortTestBufferSubstring(23, 7, "%c2.5%c", SYM_ALTITUDE, SYM_M);
 
     // when
-    simulationAltitude = 4247;
+    simulationAltitude = 4247;  // rounds to 42.5m
     displayClearScreen(&testDisplayPort);
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(23, 7, "%c42.4%c", SYM_ALTITUDE, SYM_M);
+    displayPortTestBufferSubstring(23, 7, "%c42.5%c", SYM_ALTITUDE, SYM_M);
 
     // when
-    simulationAltitude = -247;
+    simulationAltitude = -247;  // rounds to -2.5m
     displayClearScreen(&testDisplayPort);
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(23, 7, "%c-2.4%c", SYM_ALTITUDE, SYM_M);
+    displayPortTestBufferSubstring(23, 7, "%c-2.5%c", SYM_ALTITUDE, SYM_M);
 
     // when
     simulationAltitude = -70;


### PR DESCRIPTION
Updated the OSD element and stats rendering code to use this fuction to print floating point values of varying precisions.

Will make adding OSD element variants that provide different decimal precisions (like voltage, amperage, etc.) easy to implement since all that needs to change is the `decimalPlaces` passed to the function. As an example, see the `osdFormatAltitudeString()` function.

If at some later date a more capable `printf` package is inplemented, then the guts of the `osdPrintFloat()` function could just be simplified while leaving the abstraction in place.