### PR TITLE
Fix disabled disarm when Paralyze is activated in armed state

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -936,7 +936,7 @@ bool processRx(timeUs_t currentTimeUs)
         disarmAt = currentTimeUs + autoDisarmDelayUs;  // extend auto-disarm timer
     }
 
-    if (!IS_RC_MODE_ACTIVE(BOXPARALYZE)
+    if (!(IS_RC_MODE_ACTIVE(BOXPARALYZE) && !ARMING_FLAG(ARMED))
 #ifdef USE_CMS
         && !cmsInMenu
 #endif

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -957,7 +957,7 @@ bool processRx(timeUs_t currentTimeUs)
     }
 #endif
 
-    if (!cliMode && !IS_RC_MODE_ACTIVE(BOXPARALYZE)) {
+    if (!cliMode && !(IS_RC_MODE_ACTIVE(BOXPARALYZE) && !ARMING_FLAG(ARMED))) {
         processRcAdjustments(currentControlRateProfile);
     }
 


### PR DESCRIPTION
If user turns on PARALYZE mode during the flight in armed state, he cannot disarm with the switch anymore. 
Motors keep on spinning until battery is disconnected. This situation can be dangerous.
We should be checking arm-switch position until quad is disarmed.