### PR TITLE
setting simplified_dterm_filters to off by defaults

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -218,7 +218,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .simplified_pd_gain = SIMPLIFIED_TUNING_DEFAULT,
         .simplified_dmin_ratio = SIMPLIFIED_TUNING_DEFAULT,
         .simplified_ff_gain = SIMPLIFIED_TUNING_DEFAULT,
-        .simplified_dterm_filter = true,
+        .simplified_dterm_filter = false,
         .simplified_dterm_filter_multiplier = SIMPLIFIED_TUNING_DEFAULT,
     );
 #ifndef USE_D_MIN


### PR DESCRIPTION
all over simplified tuning settings also set to off by defaults

in addition, the configurator always sets this to off, although I only use the `simplified_pids_mode`