### PR TITLE
Fix G473 AF5 Timers

### DIFF
--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -176,7 +176,7 @@ extern const timerHardware_t timerHardware[];
 
 #elif defined(STM32G4)
 
-#define FULL_TIMER_CHANNEL_COUNT 91 // XXX Need review
+#define FULL_TIMER_CHANNEL_COUNT 93 // XXX Need review
 
 #endif
 

--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -1288,6 +1288,8 @@
 
 #define DEF_TIM_AF__PA7__TCH_TIM8_CH1N    D(4, 8)
 
+#define DEF_TIM_AF__PA14__TCH_TIM8_CH2     D(5, 8)
+
 #define DEF_TIM_AF__PA7__TCH_TIM1_CH1N    D(6, 1)
 #define DEF_TIM_AF__PA8__TCH_TIM1_CH1     D(6, 1)
 #define DEF_TIM_AF__PA9__TCH_TIM1_CH2     D(6, 1)
@@ -1338,6 +1340,8 @@
 #define DEF_TIM_AF__PB3__TCH_TIM8_CH1N    D(4, 8)
 #define DEF_TIM_AF__PB4__TCH_TIM8_CH2N    D(4, 8)
 #define DEF_TIM_AF__PB15__TCH_TIM1_CH3N   D(4, 1)
+
+#define DEF_TIM_AF__PB6__TCH_TIM8_CH1     D(5, 8)
 
 #define DEF_TIM_AF__PB0__TCH_TIM1_CH2N    D(6, 1)
 #define DEF_TIM_AF__PB0__TCH_TIM1_CH3N    D(6, 1)

--- a/src/main/drivers/timer_stm32g4xx.c
+++ b/src/main/drivers/timer_stm32g4xx.c
@@ -74,6 +74,8 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
 
     DEF_TIM(TIM8, CH1N, PA7, TIM_USE_ANY, 0, 0, 0),
 
+    DEF_TIM(TIM8, CH2, PA14, TIM_USE_ANY, 0, 0, 0),
+    
     DEF_TIM(TIM1, CH1N, PA7, TIM_USE_ANY, 0, 0, 0),
     DEF_TIM(TIM1, CH1, PA8, TIM_USE_ANY, 0, 0, 0),
     DEF_TIM(TIM1, CH2, PA9, TIM_USE_ANY, 0, 0, 0),
@@ -124,6 +126,8 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM8, CH1N, PB3, TIM_USE_ANY, 0, 0, 0),
     DEF_TIM(TIM8, CH2N, PB4, TIM_USE_ANY, 0, 0, 0),
     DEF_TIM(TIM1, CH3N, PB15, TIM_USE_ANY, 0, 0, 0),
+    
+    DEF_TIM(TIM8, CH1, PB6, TIM_USE_ANY, 0, 0, 0),
 
     DEF_TIM(TIM1, CH2N, PB0, TIM_USE_ANY, 0, 0, 0),
     DEF_TIM(TIM1, CH3N, PB0, TIM_USE_ANY, 0, 0, 0),


### PR DESCRIPTION
Doing some G473 testing and found a couple timers not defined.  Not sure if they are intentionally left out, but here it is for consideration.

![image](https://user-images.githubusercontent.com/15166352/108398253-6e2c2f80-71de-11eb-835b-aa45550a24bc.png)

![image](https://user-images.githubusercontent.com/15166352/108398340-8439f000-71de-11eb-8fcc-4cdad316767b.png)
