### PR TITLE
Adding gyro temperature for MPU6000 & manual only gyro calibration mode

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -99,4 +99,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "D_LPF",
     "VTX_TRAMP",
     "GHST",
+    "GYRO_TMP"
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -115,6 +115,7 @@ typedef enum {
     DEBUG_D_LPF,
     DEBUG_VTX_TRAMP,
     DEBUG_GHST,
+    DEBUG_GYRO_TMP,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -690,6 +690,7 @@ const clivalue_t valueTable[] = {
     { "dyn_lpf_gyro_curve_expo",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 10 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_curve_expo) },
 #endif
     { "gyro_filter_debug_axis",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_FILTER_DEBUG }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_debug_axis) },
+    { "gyro_cal_manual",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_cal_manual) },
 
 // PG_ACCELEROMETER_CONFIG
 #if defined(USE_ACC)

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -225,6 +225,20 @@ bool mpu6000SpiAccDetect(accDev_t *acc)
     return true;
 }
 
+#define MPU60x0_TEMP_OUT        0x41
+
+bool mpu6000ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
+{
+    uint8_t buf[2];
+    if (!spiBusReadRegisterBuffer(&gyro->bus, MPU60x0_TEMP_OUT, buf, 2)) {
+        return false;
+    }
+
+    *tempData = 36 + (180 + (int16_t)((uint16_t)buf[0] << 8 | buf[1]) + 170) / 340;
+
+    return true;
+}
+
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro)
 {
     if (gyro->mpuDetectionResult.sensor != MPU_60x0_SPI) {
@@ -233,6 +247,7 @@ bool mpu6000SpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = mpu6000SpiGyroInit;
     gyro->readFn = mpuGyroReadSPI;
+    gyro->temperatureFn = mpu6000ReadTemperature;
     gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1174,6 +1174,8 @@ void subTaskTelemetryPollSensors(timeUs_t currentTimeUs)
         // Read out gyro temperature if used for telemmetry
         gyroReadTemperature();
         lastGyroTempTimeUs = currentTimeUs;
+
+        DEBUG_SET(DEBUG_GYRO_TMP, 0, gyroGetTemperature());
     }
 }
 #endif

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -858,7 +858,13 @@ void init(void)
         accStartCalibration();
     }
 #endif
-    gyroStartCalibration(false);
+    if (gyroConfig()->gyro_cal_manual
+    &&  gyroConfig()->gyroCalibrated) {
+        gyroSetCalibration();
+    } else {
+        gyroStartCalibration(false);
+    }
+
 #ifdef USE_BARO
     baroStartCalibration();
 #endif

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -206,6 +206,12 @@ typedef struct gyroConfig_s {
     uint8_t dyn_lpf_curve_expo; // set the curve for dynamic gyro lowpass filter
     uint8_t  simplified_gyro_filter;
     uint8_t  simplified_gyro_filter_multiplier;
+
+    uint8_t gyro_cal_manual;
+    uint8_t gyroCalibrated;
+    float gyroZeroX;
+    float gyroZeroY;
+    float gyroZeroZ;
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);
@@ -214,8 +220,10 @@ void gyroUpdate(void);
 void gyroFiltering(timeUs_t currentTimeUs);
 bool gyroGetAccumulationAverage(float *accumulation);
 void gyroStartCalibration(bool isFirstArmingCalibration);
+void gyroSetCalibration(void);
 bool isFirstArmingGyroCalibrationRunning(void);
 bool gyroIsCalibrationComplete(void);
+bool gyroHasTemperatureSensor(void);
 void gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 bool gyroOverflowDetected(void);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -136,6 +136,7 @@ enum
 #endif
     FSSP_DATAID_T1         = 0x0400 ,
     FSSP_DATAID_T11        = 0x0401 ,
+    FSSP_DATAID_T1GYRO     = 0x0402 ,
     FSSP_DATAID_T2         = 0x0410 ,
     FSSP_DATAID_HOME_DIST  = 0x0420 ,
     FSSP_DATAID_GPS_ALT    = 0x0820 ,
@@ -336,6 +337,12 @@ static void initSmartPortSensors(void)
 #if defined(USE_ADC_INTERNAL)
     if (telemetryIsSensorEnabled(SENSOR_TEMPERATURE)) {
         ADD_SENSOR(FSSP_DATAID_T11);
+    }
+#endif
+
+#if defined(USE_GYRO)
+    if (gyroHasTemperatureSensor() && telemetryIsSensorEnabled(SENSOR_TEMPERATURE)) {
+        ADD_SENSOR(FSSP_DATAID_T1GYRO);
     }
 #endif
 
@@ -838,6 +845,12 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 #if defined(USE_ADC_INTERNAL)
             case FSSP_DATAID_T11        :
                 smartPortSendPackage(id, getCoreTemperatureCelsius());
+                *clearToSend = false;
+                break;
+#endif
+#if defined(USE_GYRO)
+            case FSSP_DATAID_T1GYRO        :
+                smartPortSendPackage(id, gyroGetTemperature());
                 *clearToSend = false;
                 break;
 #endif


### PR DESCRIPTION
Added gyro temperature readings for MPU6000.
Added gyro temperature debug output (debug_mode = GYRO_TMP) and a SmartPort telemetry sensor (sensorId = 0x0402), currently available for MPU3050 and MPU6000.
Added the manual only gyro calibration mode (option gyro_cal_manual, avialible in CLI).
This mode should help with the gyro temperature drift, allowing to calibrate a gyro when it is at its working temperature, and not during the power-up (as usual).
Tiny Whoops are expected to be the most affected by the gyro temperature drift due to their tight layout and the thermal interference from CPU, ESCs and VTX.
When this mode is activated (gyro_cal_manual = ON), the automatic gyro calibration procedure during power-up is disabled.
The gyro calibration data is saved to EEPROM after the manual gyro calibration (via the stick command or OSD menu).
This calibration data is used on the subsequent boots instead of the actual automatic gyro calibration.
(The gyro_cal_manual mode can also help with launching drones from moving pads (such as boats), when the gyro calibration is complicated.)
To properly calibrate a gyro in this mode, set gyro_cal_manual = ON, save, launch the drone and wait until the gyro is heated to its typical in-flight temperature (check it via the FrSky SmartPort telemetry sensor (it may also be available via FlySky's iBUS and the old FrSky telemetry), or just wait a few minutes after take-off).
Then land, disarm, perform the manual gyro calibration, then (if you are using a level mode) perform the accelerometer calibration (perform the accelerometer trim later, if necessary).
The gyro calibration data is saved in EEPROM and used until the next manual gyro recalibration.
When a gyro is properly calibrated in the gyro_cal_manual mode, a user may only experience a gyro temperature drift during a short period at the beginning of the flight (when the gyro is warming up) and not for the rest of the flight (when the gyro temperature is rather stable).