### PR TITLE
Fixed initialisation of DPS310 when used over I2C.

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -165,8 +165,16 @@ static bool deviceConfigure(busDevice_t * busDev)
 
     // 1. Read the pressure calibration coefficients (c00, c10, c20, c30, c01, c11, and c21) from the Calibration Coefficient register.
     //   Note: The coefficients read from the coefficient register are 2's complement numbers.
-    uint8_t coef[18];
-    if (!busReadBuf(busDev, DPS310_REG_COEF, coef, sizeof(coef))) {
+
+    // Do the read of the coefficients in multiple parts, as the chip will return a read failure when trying to read all at once over I2C.
+#define COEFFICIENT_LENGTH 18
+#define READ_LENGTH (COEFFICIENT_LENGTH / 2)
+
+    uint8_t coef[COEFFICIENT_LENGTH];
+    if (!busReadBuf(busDev, DPS310_REG_COEF, coef, READ_LENGTH)) {
+        return false;
+    }
+     if (!busReadBuf(busDev, DPS310_REG_COEF + READ_LENGTH, coef + READ_LENGTH, COEFFICIENT_LENGTH - READ_LENGTH)) {
         return false;
     }
 


### PR DESCRIPTION
Fixes #10041.
