### PR TITLE
Add gyro temperature telemetry & debug output for MPU6000

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -99,4 +99,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "D_LPF",
     "VTX_TRAMP",
     "GHST",
+    "GYRO_TMP"
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -115,6 +115,7 @@ typedef enum {
     DEBUG_D_LPF,
     DEBUG_VTX_TRAMP,
     DEBUG_GHST,
+    DEBUG_GYRO_TMP,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -225,6 +225,20 @@ bool mpu6000SpiAccDetect(accDev_t *acc)
     return true;
 }
 
+#define MPU60x0_TEMP_OUT        0x41
+
+bool mpu6000ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
+{
+    uint8_t buf[2];
+    if (!spiBusReadRegisterBuffer(&gyro->bus, MPU60x0_TEMP_OUT, buf, 2)) {
+        return false;
+    }
+
+    *tempData = 36 + (180 + (int16_t)((uint16_t)buf[0] << 8 | buf[1]) + 170) / 340;
+
+    return true;
+}
+
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro)
 {
     if (gyro->mpuDetectionResult.sensor != MPU_60x0_SPI) {
@@ -233,6 +247,7 @@ bool mpu6000SpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = mpu6000SpiGyroInit;
     gyro->readFn = mpuGyroReadSPI;
+    gyro->temperatureFn = mpu6000ReadTemperature;
     gyro->scale = GYRO_SCALE_2000DPS;
 
     return true;

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -234,7 +234,11 @@ bool mpu6000ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
         return false;
     }
 
-    *tempData = 36 + (180 + (int16_t)((uint16_t)buf[0] << 8 | buf[1]) + 170) / 340;
+    // tempData = 36.53 + TEMP_OUT / 340
+    // tempData = 36 + (TEMP_OUT + 180) / 340
+    int16_t t = (int16_t)((uint16_t)buf[0] << 8 | buf[1]) + 180;
+    t += t >= 0 ? 170 : - 170; // round to the nearest integer even for the negative values
+    *tempData = 36 + t / 340;
 
     return true;
 }

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1174,6 +1174,8 @@ void subTaskTelemetryPollSensors(timeUs_t currentTimeUs)
         // Read out gyro temperature if used for telemmetry
         gyroReadTemperature();
         lastGyroTempTimeUs = currentTimeUs;
+
+        DEBUG_SET(DEBUG_GYRO_TMP, 0, gyroGetTemperature());
     }
 }
 #endif

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -594,6 +594,23 @@ void gyroReadTemperature(void)
     }
 }
 
+bool gyroHasTemperatureSensor(void)
+{
+    switch (gyro.gyroToUse) {
+    case GYRO_CONFIG_USE_GYRO_1:
+        return gyro.gyroSensor1.gyroDev.temperatureFn != NULL;
+
+#ifdef USE_MULTI_GYRO
+    case GYRO_CONFIG_USE_GYRO_2:
+        return gyro.gyroSensor2.gyroDev.temperatureFn != NULL;
+
+    case GYRO_CONFIG_USE_GYRO_BOTH:
+        return gyro.gyroSensor1.gyroDev.temperatureFn != NULL || gyro.gyroSensor2.gyroDev.temperatureFn != NULL;
+#endif // USE_MULTI_GYRO
+    }
+    return false;
+}
+
 int16_t gyroGetTemperature(void)
 {
     return gyroSensorTemperature;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -216,6 +216,7 @@ bool gyroGetAccumulationAverage(float *accumulation);
 void gyroStartCalibration(bool isFirstArmingCalibration);
 bool isFirstArmingGyroCalibrationRunning(void);
 bool gyroIsCalibrationComplete(void);
+bool gyroHasTemperatureSensor(void);
 void gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 bool gyroOverflowDetected(void);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -136,6 +136,7 @@ enum
 #endif
     FSSP_DATAID_T1         = 0x0400 ,
     FSSP_DATAID_T11        = 0x0401 ,
+    FSSP_DATAID_T1GYRO     = 0x0402 ,
     FSSP_DATAID_T2         = 0x0410 ,
     FSSP_DATAID_HOME_DIST  = 0x0420 ,
     FSSP_DATAID_GPS_ALT    = 0x0820 ,
@@ -336,6 +337,12 @@ static void initSmartPortSensors(void)
 #if defined(USE_ADC_INTERNAL)
     if (telemetryIsSensorEnabled(SENSOR_TEMPERATURE)) {
         ADD_SENSOR(FSSP_DATAID_T11);
+    }
+#endif
+
+#if defined(USE_GYRO)
+    if (gyroHasTemperatureSensor() && telemetryIsSensorEnabled(SENSOR_TEMPERATURE)) {
+        ADD_SENSOR(FSSP_DATAID_T1GYRO);
     }
 #endif
 
@@ -838,6 +845,12 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 #if defined(USE_ADC_INTERNAL)
             case FSSP_DATAID_T11        :
                 smartPortSendPackage(id, getCoreTemperatureCelsius());
+                *clearToSend = false;
+                break;
+#endif
+#if defined(USE_GYRO)
+            case FSSP_DATAID_T1GYRO        :
+                smartPortSendPackage(id, gyroGetTemperature());
                 *clearToSend = false;
                 break;
 #endif

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1007,7 +1007,7 @@ TEST(ArmingPreventionTest, Paralyze)
     // expect
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXVTXPITMODE));
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXBEEPERON));
-    
+
     // given
     // try exiting paralyze mode and ensure arming and pit mode are still disabled
     rcData[AUX2] = 1000;
@@ -1067,6 +1067,7 @@ extern "C" {
     void telemetryCheckState(void) {}
     void mspSerialAllocatePorts(void) {}
     void gyroReadTemperature(void) {}
+    int16_t gyroGetTemperature(void) { return 0; }
     void updateRcCommands(void) {}
     void applyAltHold(void) {}
     void resetYawAxis(void) {}

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -160,6 +160,7 @@ extern "C" {
     void telemetryCheckState(void) {}
     void mspSerialAllocatePorts(void) {}
     void gyroReadTemperature(void) {}
+    int16_t gyroGetTemperature(void) { return 0; }
     void updateRcCommands(void) {}
     void applyAltHold(void) {}
     void resetYawAxis(void) {}


### PR DESCRIPTION
I have extracted the changes concerning the gyro temperature telemetry from #10570 to this separate PR.

This PR adds:
 - MPU6000 gyro temperature function;
 - Gyro temperature debug output (debug_mode = GYRO_TMP);
 - FrSky SmartPort gyro temperature telemetry sensor (sensorId = 0x0402).