### PR TITLE
Add the manual only gyro calibration mode

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -664,6 +664,9 @@ const clivalue_t valueTable[] = {
     { "gyro_notch2_hz",             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_hz_2) },
     { "gyro_notch2_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_2) },
 
+    // 4 elements are output for the GYRO calibration - The 3 axis values and the 4th representing whether calibration has been performed
+    { "gyro_calibration",           VAR_INT16  | MASTER_VALUE | MODE_ARRAY, .config.array.length = GYRO_CNT_MAX * 4, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroTrims[0].raw) },
+
     { "gyro_calib_duration",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 50,  3000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroCalibrationDuration) },
     { "gyro_calib_noise_limit",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,  200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold) },
     { "gyro_offset_yaw",            VAR_INT16  | MASTER_VALUE, .config.minmax = { -1000, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_offset_yaw) },
@@ -690,6 +693,7 @@ const clivalue_t valueTable[] = {
     { "dyn_lpf_gyro_curve_expo",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 10 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_curve_expo) },
 #endif
     { "gyro_filter_debug_axis",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_FILTER_DEBUG }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_debug_axis) },
+    { "gyro_cal_manual",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_cal_manual) },
 
 // PG_ACCELEROMETER_CONFIG
 #if defined(USE_ACC)

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -401,6 +401,7 @@ void updateArmingStatus(void)
 
             /* Ignore ARMING_DISABLED_CALIBRATING if we are going to calibrate gyro on first arm */
             bool ignoreGyro = armingConfig()->gyro_cal_on_first_arm
+                && !gyroConfig()->gyro_cal_manual // gyro_cal_manual overrides gyro_cal_on_first_arm
                 && !(getArmingDisableFlags() & ~(ARMING_DISABLED_ARM_SWITCH | ARMING_DISABLED_CALIBRATING));
 
             /* Ignore ARMING_DISABLED_THROTTLE (once arm switch is on) if we are in 3D mode */
@@ -479,7 +480,8 @@ void disarm(flightLogDisarmReason_e reason)
 
 void tryArm(void)
 {
-    if (armingConfig()->gyro_cal_on_first_arm) {
+    if (armingConfig()->gyro_cal_on_first_arm
+    && !gyroConfig()->gyro_cal_manual) { // gyro_cal_manual overrides gyro_cal_on_first_arm
         gyroStartCalibration(true);
     }
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -858,7 +858,13 @@ void init(void)
         accStartCalibration();
     }
 #endif
-    gyroStartCalibration(false);
+    if (gyroConfig()->gyro_cal_manual
+    &&  gyroIsCalibrationConfigValid()) {
+        gyroSetCalibration();
+    } else {
+        gyroStartCalibration(false);
+    }
+
 #ifdef USE_BARO
     baroStartCalibration();
 #endif

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -113,12 +113,12 @@ void accResetRollAndPitchTrims(void)
     resetRollAndPitchTrims(&accelerometerConfigMutable()->accelerometerTrims);
 }
 
-static void resetFlightDynamicsTrims(flightDynamicsTrims_t *accZero)
+void resetFlightDynamicsTrims(flightDynamicsTrims_t *trims)
 {
-    accZero->values.roll = 0;
-    accZero->values.pitch = 0;
-    accZero->values.yaw = 0;
-    accZero->values.calibrationCompleted = 0;
+    trims->values.roll = 0;
+    trims->values.pitch = 0;
+    trims->values.yaw = 0;
+    trims->values.calibrationCompleted = 0;
 }
 
 void pgResetFn_accelerometerConfig(accelerometerConfig_t *instance)

--- a/src/main/sensors/acceleration_init.h
+++ b/src/main/sensors/acceleration_init.h
@@ -38,3 +38,4 @@ extern accelerationRuntime_t accelerationRuntime;
 
 void performAcclerationCalibration(rollAndPitchTrims_t *rollAndPitchTrims);
 void performInflightAccelerationCalibration(rollAndPitchTrims_t *rollAndPitchTrims);
+void resetFlightDynamicsTrims(flightDynamicsTrims_t *trims);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -58,6 +58,7 @@
 #include "sensors/boardalignment.h"
 #include "sensors/gyro.h"
 #include "sensors/gyro_init.h"
+#include "sensors/acceleration_init.h"
 
 #if ((TARGET_FLASH_SIZE > 128) && (defined(USE_GYRO_SPI_ICM20601) || defined(USE_GYRO_SPI_ICM20689) || defined(USE_GYRO_SPI_MPU6500)))
 #define USE_GYRO_SLEW_LIMITER
@@ -133,9 +134,16 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->dyn_notch_q = 120;
     gyroConfig->dyn_notch_min_hz = 150;
     gyroConfig->gyro_filter_debug_axis = FD_ROLL;
+    gyroConfig->gyrosDetected = 0;
     gyroConfig->dyn_lpf_curve_expo = 5;
 	gyroConfig->simplified_gyro_filter = false;
 	gyroConfig->simplified_gyro_filter_multiplier = SIMPLIFIED_TUNING_DEFAULT;
+
+    gyroConfig->gyro_cal_manual = 0;
+    resetFlightDynamicsTrims(&gyroConfig->gyroTrims[0]);
+#ifdef USE_MULTI_GYRO
+    resetFlightDynamicsTrims(&gyroConfig->gyroTrims[1]);
+#endif
 }
 
 #ifdef USE_GYRO_DATA_ANALYSE
@@ -208,6 +216,59 @@ void gyroStartCalibration(bool isFirstArmingCalibration)
     if (isFirstArmingCalibration) {
         firstArmingCalibrationWasStarted = true;
     }
+}
+
+bool gyroIsCalibrationConfigValid(void)
+{
+    switch (gyro.gyroToUse) {
+    case GYRO_CONFIG_USE_GYRO_1:
+        return gyroConfig()->gyroTrims[0].values.calibrationCompleted;
+
+#ifdef USE_MULTI_GYRO
+    case GYRO_CONFIG_USE_GYRO_2:
+        return gyroConfig()->gyroTrims[1].values.calibrationCompleted;
+
+    case GYRO_CONFIG_USE_GYRO_BOTH:
+        return gyroConfig()->gyroTrims[0].values.calibrationCompleted
+            && gyroConfig()->gyroTrims[1].values.calibrationCompleted;
+#endif
+    }
+    return false;
+}
+
+void gyroSetTrims(float gyroZero[XYZ_AXIS_COUNT], const flightDynamicsTrims_t *gyroTrims)
+{
+    if (gyroTrims->values.calibrationCompleted) {
+        gyroZero[X] = gyroTrims->raw[X];
+        gyroZero[Y] = gyroTrims->raw[Y];
+        gyroZero[Z] = gyroTrims->raw[Z];
+    }
+}
+
+void gyroSetCalibration(void)
+{
+    switch (gyro.gyroToUse) {
+    case GYRO_CONFIG_USE_GYRO_1:
+        gyroSetTrims(gyro.gyroSensor1.gyroDev.gyroZero, &gyroConfig()->gyroTrims[0]);
+        break;
+#ifdef USE_MULTI_GYRO
+    case GYRO_CONFIG_USE_GYRO_2:
+        gyroSetTrims(gyro.gyroSensor2.gyroDev.gyroZero, &gyroConfig()->gyroTrims[1]);
+        break;
+    case GYRO_CONFIG_USE_GYRO_BOTH:
+        gyroSetTrims(gyro.gyroSensor1.gyroDev.gyroZero, &gyroConfig()->gyroTrims[0]);
+        gyroSetTrims(gyro.gyroSensor2.gyroDev.gyroZero, &gyroConfig()->gyroTrims[1]);
+        break;
+#endif
+    }
+}
+
+void gyroGetTrims(flightDynamicsTrims_t *gyroTrims, const float gyroZero[XYZ_AXIS_COUNT])
+{
+    gyroTrims->raw[X] = (int16_t)lrintf(gyroZero[X]);
+    gyroTrims->raw[Y] = (int16_t)lrintf(gyroZero[Y]);
+    gyroTrims->raw[Z] = (int16_t)lrintf(gyroZero[Z]);
+    gyroTrims->values.calibrationCompleted = 1;
 }
 
 bool isFirstArmingGyroCalibrationRunning(void)
@@ -412,11 +473,29 @@ static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSens
     }
 }
 
+// Update gyro and if the calibration is complete then update the gyro config and save it if allowed
+void gyroUpdateSensorAndCalibration(gyroSensor_t *gyroSensor, flightDynamicsTrims_t *gyroTrims, bool saveConfig)
+{
+    if (isOnFinalGyroCalibrationCycle(&gyroSensor->calibration) && gyroConfig()->gyro_cal_manual) {
+        gyroUpdateSensor(gyroSensor);
+        if (isGyroSensorCalibrationComplete(gyroSensor)) {
+            gyroGetTrims(gyroTrims, gyroSensor->gyroDev.gyroZero);
+            if (saveConfig) {
+                saveConfigAndNotify();
+            }
+        }
+        return;
+    }
+
+    gyroUpdateSensor(gyroSensor);
+}
+
 FAST_CODE void gyroUpdate(void)
 {
     switch (gyro.gyroToUse) {
     case GYRO_CONFIG_USE_GYRO_1:
-        gyroUpdateSensor(&gyro.gyroSensor1);
+        gyroUpdateSensorAndCalibration(&gyro.gyroSensor1, &gyroConfigMutable()->gyroTrims[0], true);
+
         if (isGyroSensorCalibrationComplete(&gyro.gyroSensor1)) {
             gyro.gyroADC[X] = gyro.gyroSensor1.gyroDev.gyroADC[X] * gyro.gyroSensor1.gyroDev.scale;
             gyro.gyroADC[Y] = gyro.gyroSensor1.gyroDev.gyroADC[Y] * gyro.gyroSensor1.gyroDev.scale;
@@ -425,7 +504,8 @@ FAST_CODE void gyroUpdate(void)
         break;
 #ifdef USE_MULTI_GYRO
     case GYRO_CONFIG_USE_GYRO_2:
-        gyroUpdateSensor(&gyro.gyroSensor2);
+        gyroUpdateSensorAndCalibration(&gyro.gyroSensor2, &gyroConfigMutable()->gyroTrims[1], true);
+
         if (isGyroSensorCalibrationComplete(&gyro.gyroSensor2)) {
             gyro.gyroADC[X] = gyro.gyroSensor2.gyroDev.gyroADC[X] * gyro.gyroSensor2.gyroDev.scale;
             gyro.gyroADC[Y] = gyro.gyroSensor2.gyroDev.gyroADC[Y] * gyro.gyroSensor2.gyroDev.scale;
@@ -433,8 +513,10 @@ FAST_CODE void gyroUpdate(void)
         }
         break;
     case GYRO_CONFIG_USE_GYRO_BOTH:
-        gyroUpdateSensor(&gyro.gyroSensor1);
-        gyroUpdateSensor(&gyro.gyroSensor2);
+        // Use calibrationCompleted of the other gyro as saveConfig parameter to save both gyro configs only at once
+        gyroUpdateSensorAndCalibration(&gyro.gyroSensor1, &gyroConfigMutable()->gyroTrims[0], gyroConfig()->gyroTrims[1].values.calibrationCompleted);
+        gyroUpdateSensorAndCalibration(&gyro.gyroSensor2, &gyroConfigMutable()->gyroTrims[1], gyroConfig()->gyroTrims[0].values.calibrationCompleted);
+
         if (isGyroSensorCalibrationComplete(&gyro.gyroSensor1) && isGyroSensorCalibrationComplete(&gyro.gyroSensor2)) {
             gyro.gyroADC[X] = ((gyro.gyroSensor1.gyroDev.gyroADC[X] * gyro.gyroSensor1.gyroDev.scale) + (gyro.gyroSensor2.gyroDev.gyroADC[X] * gyro.gyroSensor2.gyroDev.scale)) / 2.0f;
             gyro.gyroADC[Y] = ((gyro.gyroSensor1.gyroDev.gyroADC[Y] * gyro.gyroSensor1.gyroDev.scale) + (gyro.gyroSensor2.gyroDev.gyroADC[Y] * gyro.gyroSensor2.gyroDev.scale)) / 2.0f;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -27,6 +27,7 @@
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
+#include "sensors/sensors.h"
 
 #ifdef USE_GYRO_DATA_ANALYSE
 #include "flight/gyroanalyse.h"
@@ -161,6 +162,12 @@ typedef enum {
 #define GYRO_CONFIG_USE_GYRO_2      1
 #define GYRO_CONFIG_USE_GYRO_BOTH   2
 
+#ifdef USE_MULTI_GYRO
+#define GYRO_CNT_MAX 2
+#else
+#define GYRO_CNT_MAX 1
+#endif
+
 enum {
     FILTER_LOWPASS = 0,
     FILTER_LOWPASS2
@@ -206,6 +213,9 @@ typedef struct gyroConfig_s {
     uint8_t dyn_lpf_curve_expo; // set the curve for dynamic gyro lowpass filter
     uint8_t  simplified_gyro_filter;
     uint8_t  simplified_gyro_filter_multiplier;
+
+    uint8_t gyro_cal_manual;
+    flightDynamicsTrims_t gyroTrims[GYRO_CNT_MAX];
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);
@@ -214,8 +224,11 @@ void gyroUpdate(void);
 void gyroFiltering(timeUs_t currentTimeUs);
 bool gyroGetAccumulationAverage(float *accumulation);
 void gyroStartCalibration(bool isFirstArmingCalibration);
+void gyroSetCalibration(void);
 bool isFirstArmingGyroCalibrationRunning(void);
+bool gyroIsCalibrationConfigValid(void);
 bool gyroIsCalibrationComplete(void);
+bool gyroHasTemperatureSensor(void);
 void gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 bool gyroOverflowDetected(void);

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -163,4 +163,6 @@ void sensorsSet(uint32_t) {}
 void schedulerResetTaskStatistics(taskId_e) {}
 int getArmingDisableFlags(void) {return 0;}
 void writeEEPROM(void) {}
+void saveConfigAndNotify(void) {}
+void resetFlightDynamicsTrims(flightDynamicsTrims_t) {}
 }


### PR DESCRIPTION
I have extracted the changes concerning the manual only gyro calibration mode from #10570 to this separate PR.
This PR has additional changes compared to #10570:
 - Export/import gyro calibration via `diff`;
 - Support of `BOTH` gyro manual calibration, `SECOND` gyro now has separate calibration config;
 - `gyro_cal_manual` now overrides `gyro_cal_on_first_arm`.
