### PR TITLE
Display late execution stats in tasks command

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4839,7 +4839,11 @@ static void cliTasks(const char *cmdName, char *cmdline)
 
 #ifndef MINIMAL_CLI
     if (systemConfig()->task_statistics) {
+#if defined(USE_LATE_TASK_STATISTICS)
+        cliPrintLine("Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us");
+#else
         cliPrintLine("Task list             rate/hz  max/us  avg/us maxload avgload  total/ms");
+#endif
     } else {
         cliPrintLine("Task list");
     }
@@ -4857,9 +4861,18 @@ static void cliTasks(const char *cmdName, char *cmdline)
                 averageLoadSum += averageLoad;
             }
             if (systemConfig()->task_statistics) {
+#if defined(USE_LATE_TASK_STATISTICS)
+                cliPrintLinef("%6d %7d %7d %4d.%1d%% %4d.%1d%% %9d %6d %6d %7d",
+                        taskFrequency, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTimeUs,
+                        maxLoad/10, maxLoad%10, averageLoad/10, averageLoad%10,
+                        taskInfo.totalExecutionTimeUs / 1000,
+                        taskInfo.lateCount, taskInfo.runCount, taskInfo.execTime);
+#else
                 cliPrintLinef("%6d %7d %7d %4d.%1d%% %4d.%1d%% %9d",
                         taskFrequency, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTimeUs,
-                        maxLoad/10, maxLoad%10, averageLoad/10, averageLoad%10, taskInfo.totalExecutionTimeUs / 1000);
+                        maxLoad/10, maxLoad%10, averageLoad/10, averageLoad%10,
+                        taskInfo.totalExecutionTimeUs / 1000);
+#endif
             } else {
                 cliPrintLinef("%6d", taskFrequency);
             }

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -173,6 +173,11 @@ void getTaskInfo(taskId_e taskId, taskInfo_t * taskInfo)
     taskInfo->averageDeltaTimeUs = getTask(taskId)->movingSumDeltaTimeUs / TASK_STATS_MOVING_SUM_COUNT;
     taskInfo->latestDeltaTimeUs = getTask(taskId)->taskLatestDeltaTimeUs;
     taskInfo->movingAverageCycleTimeUs = getTask(taskId)->movingAverageCycleTimeUs;
+#if defined(USE_LATE_TASK_STATISTICS)
+    taskInfo->lateCount = getTask(taskId)->lateCount;
+    taskInfo->runCount = getTask(taskId)->runCount;
+    taskInfo->execTime = getTask(taskId)->execTime;
+#endif
 #endif
 }
 
@@ -240,7 +245,12 @@ void schedulerResetTaskMaxExecutionTime(taskId_e taskId)
     if (taskId == TASK_SELF) {
         currentTask->maxExecutionTimeUs = 0;
     } else if (taskId < TASK_COUNT) {
-        getTask(taskId)->maxExecutionTimeUs = 0;
+        task_t *task = getTask(taskId);
+        task->maxExecutionTimeUs = 0;
+#if defined(USE_LATE_TASK_STATISTICS)
+        task->lateCount = 0;
+        task->runCount = 0;
+#endif
     }
 #else
     UNUSED(taskId);
@@ -300,6 +310,9 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
             selectedTask->totalExecutionTimeUs += taskExecutionTimeUs;   // time consumed by scheduler + task
             selectedTask->maxExecutionTimeUs = MAX(selectedTask->maxExecutionTimeUs, taskExecutionTimeUs);
             selectedTask->movingAverageCycleTimeUs += 0.05f * (period - selectedTask->movingAverageCycleTimeUs);
+#if defined(USE_LATE_TASK_STATISTICS)
+            selectedTask->runCount++;
+#endif
         } else
 #endif
         {
@@ -325,6 +338,9 @@ static void readSchedulerLocals(task_t *selectedTask, uint8_t selectedTaskDynami
 
 FAST_CODE void scheduler(void)
 {
+#if defined(USE_LATE_TASK_STATISTICS)
+    static task_t *lastTask;
+#endif
     // Cache currentTime
     const timeUs_t schedulerStartTimeUs = micros();
     timeUs_t currentTimeUs = schedulerStartTimeUs;
@@ -340,7 +356,7 @@ FAST_CODE void scheduler(void)
         task_t *gyroTask = getTask(TASK_GYRO);
         const timeUs_t gyroExecuteTimeUs = getPeriodCalculationBasis(gyroTask) + gyroTask->desiredPeriodUs;
         gyroTaskDelayUs = cmpTimeUs(gyroExecuteTimeUs, currentTimeUs);  // time until the next expected gyro sample
-        if (cmpTimeUs(currentTimeUs, gyroExecuteTimeUs) >= 0) {
+        if (gyroTaskDelayUs <= 0) {
             taskExecutionTimeUs = schedulerExecuteTask(gyroTask, currentTimeUs);
             if (gyroFilterReady()) {
                 taskExecutionTimeUs += schedulerExecuteTask(getTask(TASK_FILTER), currentTimeUs);
@@ -350,6 +366,16 @@ FAST_CODE void scheduler(void)
             }
             currentTimeUs = micros();
             realtimeTaskRan = true;
+
+#if defined(USE_LATE_TASK_STATISTICS)
+           // Late, so make a note of the offending task
+            if (gyroTaskDelayUs < -1) {
+                if (lastTask) {
+                    lastTask->lateCount++;
+                }
+            }
+            lastTask = NULL;
+#endif
         }
     }
 
@@ -416,6 +442,9 @@ FAST_CODE void scheduler(void)
 #if defined(USE_TASK_STATISTICS)
             if (calculateTaskStatistics) {
                 taskRequiredTimeUs = selectedTask->movingSumExecutionTimeUs / TASK_STATS_MOVING_SUM_COUNT + TASK_AVERAGE_EXECUTE_PADDING_US;
+#if defined(USE_LATE_TASK_STATISTICS)
+                selectedTask->execTime = taskRequiredTimeUs;
+#endif
             }
 #endif
             // Add in the time spent so far in check functions and the scheduler logic
@@ -425,6 +454,10 @@ FAST_CODE void scheduler(void)
             } else {
                 selectedTask = NULL;
             }
+
+#if defined(USE_LATE_TASK_STATISTICS)
+            lastTask = selectedTask;
+#endif
         }
     }
 

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -64,6 +64,11 @@ typedef struct {
     timeUs_t     averageExecutionTimeUs;
     timeUs_t     averageDeltaTimeUs;
     float        movingAverageCycleTimeUs;
+#if defined(USE_LATE_TASK_STATISTICS)
+    uint32_t     runCount;
+    uint32_t     lateCount;
+    timeUs_t     execTime;
+#endif
 } taskInfo_t;
 
 typedef enum {
@@ -179,6 +184,11 @@ typedef struct {
     timeUs_t movingSumDeltaTimeUs;  // moving sum over 32 samples
     timeUs_t maxExecutionTimeUs;
     timeUs_t totalExecutionTimeUs;    // total time consumed by task since boot
+#if defined(USE_LATE_TASK_STATISTICS)
+    uint32_t runCount;
+    uint32_t lateCount;
+    timeUs_t execTime;
+#endif
 #endif
 } task_t;
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -124,6 +124,7 @@
 #define USE_RTC_TIME
 #define USE_PERSISTENT_MSC_RTC
 #define USE_DSHOT_CACHE_MGMT
+#define USE_LATE_TASK_STATISTICS
 #endif
 
 #ifdef STM32G4
@@ -184,7 +185,7 @@
 #endif
 
 #ifdef USE_FAST_DATA
-#define FAST_DATA_ZERO_INIT             __attribute__ ((section(".fastram_bss"), aligned(4)))
+#define FAST_DATA_ZERO_INIT          __attribute__ ((section(".fastram_bss"), aligned(4)))
 #define FAST_DATA                    __attribute__ ((section(".fastram_data"), aligned(4)))
 #else
 #define FAST_DATA_ZERO_INIT


### PR DESCRIPTION
Cycle time jitter is being caused by some tasks which don't complete in time and thus results in the following execution of the gyroTask being late.

This PR adds the following columns to the CLI `tasks` command.

| Column | Meaning |
|---|---|
| late | The number of times this task has resulted in a cycle time violation of > 1us |
| run | The number of times this task has run |
| reqd | Estimated time required for task to run |
| max | Max time task has taken to run |

The `late`, `run` and `max` stats are reset each time the tasks command is run.

The dumps below show that we need to break some of the tasks down into state machines and call them more frequently in order to maintain the integrity of the scheduler. This is only of any use to developers, but arguably the `tasks` command is already.

Example dump from STM32F405 (REVO) running with 4kHz PID loop.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run   reqd    max
00 - (         SYSTEM)     10       1       1    0.5%    0.5%         0     22     77      6      1
01 - (         SYSTEM)    996       2       0    0.6%    0.0%         9   1660   7593      6      2
02 - (           GYRO)   8000      19      11   15.7%    9.3%      1844      0  60974      0     19
03 - (         FILTER)   4000      23      17    9.7%    7.3%      1512      0  30487      0     23
04 - (            PID)   4000      67      59   27.3%   24.1%      5342      0  30487      0     67
05 - (            ACC)    996      15      11    1.9%    1.5%       239   1675   7588     16     15
06 - (       ATTITUDE)    100      13       9    0.6%    0.5%        19    129    762     14     13
07 - (             RX)     33      44      42    0.6%    0.6%        31     69    251     48     44
08 - (         SERIAL)    100    5332       2   53.8%    0.5%       977    185    762      7   5332
09 - (       DISPATCH)    995       2       1    0.6%    0.5%        13   1533   7593      6      2
11 - (BATTERY_CURRENT)     50       1       1    0.5%    0.5%         0     68    381      5      1
12 - ( BATTERY_ALERTS)      5       2       1    0.5%    0.5%         0     12     38      6      2
13 - (         BEEPER)    100       2       1    0.5%    0.5%         2    169    762      6      2
15 - (        COMPASS)     10     110     108    0.6%    0.6%        24     77     77    113    110
16 - (           BARO)    186       5       2    0.5%    0.5%        10    381   1384      7      5
17 - (       ALTITUDE)     40      10       8    0.5%    0.5%         6     32    305     13     10
24 - (            CMS)     20       2       1    0.5%    0.5%         0     20    153      7      2
25 - (        VTXCTRL)      5       1       1    0.5%    0.5%         0      3     38      5      1
26 - (        CAMCTRL)      5       1       0    0.5%    0.0%         0      6     38      6      1
28 - (    ADCINTERNAL)      2       2       1    0.5%    0.5%         0      4      8      6      2
RX Check Function                   6       2                         1
Total (excluding SERIAL)                        62.6%   48.9%
```

Example dump from STM32F722 (TMOTORF7) running with 8kHz PID loop. This clearly shows that we have a problem with the RX task (with a connected Crossfire Rx using CRSF).

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run   reqd    max
00 - (         SYSTEM)     10       2       0    0.5%    0.0%         0      0     84      6      2
01 - (         SYSTEM)    988       3       1    0.7%    0.5%         7      0   8352      6      3
02 - (           GYRO)   8000      12       7   10.1%    6.1%      1144      0  67519      0     12
03 - (         FILTER)   8000      32      26   26.1%   21.3%      4075      0  67519      0     32
04 - (            PID)   8000      60      46   48.5%   37.3%      7247      0  67519      0     60
05 - (            ACC)    989      13      11    1.7%    1.5%       199     31   8338     15     13
06 - (       ATTITUDE)    495      15      11    1.2%    1.0%       110      1   4173     16     15
07 - (             RX)     33      59      57    0.6%    0.6%        36    278    278     61     59
08 - (         SERIAL)    100    5445       2   54.9%    0.5%       625      1    841      7   5445
09 - (       DISPATCH)    993       4       0    0.8%    0.0%        14      2   8366      5      4
13 - (         BEEPER)    100       3       2    0.5%    0.5%         2      0    841      7      3
16 - (           BARO)    123      16       9    0.6%    0.6%        21      0   1011     14     16
17 - (       ALTITUDE)     40      14      12    0.5%    0.5%         7      0    337     16     14
19 - (      TELEMETRY)    495       3       0    0.6%    0.0%        14      1   4170      6      3
20 - (       LEDSTRIP)     99      15       3    0.6%    0.5%         6      4    840      8     15
21 - (            OSD)     60      21       5    0.6%    0.5%         5      5    504     10     21
23 - (            CMS)     20       4       2    0.5%    0.5%         0      0    169      7      4
24 - (        VTXCTRL)      5       1       1    0.5%    0.5%         0      0     42      5      1
25 - (        CAMCTRL)      5       3       1    0.5%    0.5%         0      0     42      6      3
27 - (    ADCINTERNAL)      2       4       1    0.5%    0.5%         0      0      9      6      4
RX Check Function                   3       2                         1
Total (excluding SERIAL)                        95.6%   72.9%
```

Example dump from a STM32H743 (IFLIGHT_H743_AIO) running with 8kHz PID loop. This shows a clear issue with the BARO task.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run   reqd    max
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0      0    112      6      1
01 - (         SYSTEM)    999       2       0    0.6%    0.0%         4      0  11154      6      2
02 - (           GYRO)   8000       7       6    6.1%    5.3%      1043      0  89319      0      7
03 - (         FILTER)   8000       7       5    6.1%    4.5%       847      0  89319      0      7
04 - (            PID)   8000      22      16   18.1%   13.3%      2917      0  89319      0     22
05 - (            ACC)    999      10       8    1.4%    1.2%       177      0  11154     13     10
06 - (       ATTITUDE)    100       5       3    0.5%    0.5%         7      0   1117      8      5
07 - (             RX)     33      16      15    0.5%    0.5%        11      0    369     20     16
08 - (         SERIAL)    100   16615       1  166.6%    0.5%      1246      1   1117      6  16615
09 - (       DISPATCH)    999       2       0    0.6%    0.0%         6      1  11154      5      2
10 - (BATTERY_VOLTAGE)     50       2       1    0.5%    0.5%         0      0    559      5      2
11 - (BATTERY_CURRENT)     50       2       1    0.5%    0.5%         0      0    559      6      2
12 - ( BATTERY_ALERTS)      5       1       1    0.5%    0.5%         0      0     56      5      1
13 - (         BEEPER)    100       2       0    0.5%    0.0%         0      0   1117      5      2
16 - (           BARO)    787     138      39   11.3%    3.5%       622    240   7663     45    138
17 - (       ALTITUDE)     40       5       3    0.5%    0.5%         2      0    447      8      5
19 - (      TELEMETRY)    500       2       0    0.6%    0.0%         7      0   5579      5      2
20 - (       LEDSTRIP)    100       5       1    0.5%    0.5%         2      0   1117      6      5
21 - (            OSD)     60      18       4    0.6%    0.5%         7      1    670      9     18
23 - (            CMS)     20       1       0    0.5%    0.0%         0      0    224      5      1
24 - (        VTXCTRL)      5       1       1    0.5%    0.5%         0      0     56      5      1
25 - (        CAMCTRL)      5       1       0    0.5%    0.0%         0      0     56      5      1
27 - (    ADCINTERNAL)      2       1       0    0.5%    0.0%         0      0     12      5      1
RX Check Function                   1       0                         0
Total (excluding SERIAL)                        51.9%   32.3%
```