### PR TITLE
Fix RX processing impact on cycle time

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -744,11 +744,6 @@ bool isAirmodeActivated()
  */
 bool processRx(timeUs_t currentTimeUs)
 {
-    static bool armedBeeperOn = false;
-#ifdef USE_TELEMETRY
-    static bool sharedPortTelemetryEnabled = false;
-#endif
-
     timeDelta_t frameAgeUs;
     timeDelta_t frameDeltaUs = rxGetFrameDelta(&frameAgeUs);
 
@@ -890,6 +885,17 @@ bool processRx(timeUs_t currentTimeUs)
         }
     }
 #endif
+
+    return true;
+}
+
+void processRxModes(timeUs_t currentTimeUs)
+{
+    static bool armedBeeperOn = false;
+#ifdef USE_TELEMETRY
+    static bool sharedPortTelemetryEnabled = false;
+#endif
+    const throttleStatus_e throttleStatus = calculateThrottleStatus();
 
     // When armed and motors aren't spinning, do beeps and then disarm
     // board after delay so users without buzzer won't lose fingers.
@@ -1082,8 +1088,6 @@ bool processRx(timeUs_t currentTimeUs)
 #endif
 
     pidSetAntiGravityState(IS_RC_MODE_ACTIVE(BOXANTIGRAVITY) || featureIsEnabled(FEATURE_ANTI_GRAVITY));
-
-    return true;
 }
 
 static FAST_CODE void subTaskPidController(timeUs_t currentTimeUs)

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -76,6 +76,7 @@ void disarm(flightLogDisarmReason_e reason);
 void tryArm(void);
 
 bool processRx(timeUs_t currentTimeUs);
+void processRxModes(timeUs_t currentTimeUs);
 void updateArmingStatus(void);
 
 void taskGyroSample(timeUs_t currentTimeUs);

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -158,22 +158,53 @@ static void taskUpdateAccelerometer(timeUs_t currentTimeUs)
 }
 #endif
 
+static enum {
+    CHECK, PROCESS, MODES, UPDATE
+} rxState = CHECK;
+
+bool taskUpdateRxMainInProgress()
+{
+    return (rxState != CHECK);
+}
+
 static void taskUpdateRxMain(timeUs_t currentTimeUs)
 {
-    if (!processRx(currentTimeUs)) {
-        return;
-    }
+    switch (rxState) {
+    default:
+    case CHECK:
+        ignoreTaskTime();
+        rxState = PROCESS;
+        break;
 
-    // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState
-    updateRcCommands();
-    updateArmingStatus();
+    case PROCESS:
+        ignoreTaskTime();
+        if (!processRx(currentTimeUs)) {
+            break;
+        }
+        rxState = MODES;
+        break;
+
+    case MODES:
+        processRxModes(currentTimeUs);
+        rxState = UPDATE;
+        break;
+
+    case UPDATE:
+        ignoreTaskTime();
+        // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState
+        updateRcCommands();
+        updateArmingStatus();
 
 #ifdef USE_USB_CDC_HID
-    if (!ARMING_FLAG(ARMED)) {
-        sendRcDataToHid();
-    }
+        if (!ARMING_FLAG(ARMED)) {
+            sendRcDataToHid();
+        }
 #endif
+        rxState = CHECK;
+        break;
+    }
 }
+
 
 #ifdef USE_BARO
 static void taskUpdateBaro(timeUs_t currentTimeUs)

--- a/src/main/fc/tasks.h
+++ b/src/main/fc/tasks.h
@@ -24,3 +24,6 @@
 
 void tasksInit(void);
 task_t *getTask(unsigned taskId);
+
+bool taskUpdateRxMainInProgress();
+

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -43,6 +43,7 @@
 
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
+#include "fc/tasks.h"
 
 #include "flight/failsafe.h"
 
@@ -458,6 +459,11 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
     bool signalReceived = false;
     bool useDataDrivenProcessing = true;
+
+    if (taskUpdateRxMainInProgress()) {
+        // There are more states to process
+        return true;
+    }
 
     switch (rxRuntimeState.rxProvider) {
     default:

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -187,6 +187,7 @@ void getTaskInfo(taskId_e taskId, taskInfo_t *taskInfo);
 void rescheduleTask(taskId_e taskId, timeDelta_t newPeriodUs);
 void setTaskEnabled(taskId_e taskId, bool newEnabledState);
 timeDelta_t getTaskDeltaTimeUs(taskId_e taskId);
+void ignoreTaskTime();
 void schedulerSetCalulateTaskStatistics(bool calculateTaskStatistics);
 void schedulerResetTaskStatistics(taskId_e taskId);
 void schedulerResetTaskMaxExecutionTime(taskId_e taskId);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -51,6 +51,8 @@
 
 #include "sensors/sensors.h"
 
+#include "scheduler/scheduler.h"
+
 #include "barometer.h"
 
 baro_t baro;                        // barometer access functions
@@ -349,7 +351,7 @@ static uint32_t recalculateBarometerTotal(uint32_t pressureTotal, int32_t newPre
         nextSampleIndex = 0;
         baroReady = true;
     } else {
-	    nextSampleIndex = (currentSampleIndex + 1);
+        nextSampleIndex = (currentSampleIndex + 1);
     }
     barometerSamples[currentSampleIndex] = applyBarometerMedianFilter(newPressureReading);
 
@@ -385,6 +387,12 @@ uint32_t baroUpdate(void)
         debug[0] = state;
     }
 
+    // Tell the scheduler to ignore how long this task takes unless the pressure is being read
+    // as that takes the longest
+    if (state != BAROMETER_NEEDS_PRESSURE_READ) {
+           ignoreTaskTime();
+    }
+
     switch (state) {
         default:
         case BAROMETER_NEEDS_TEMPERATURE_START:
@@ -414,6 +422,8 @@ uint32_t baroUpdate(void)
         case BAROMETER_NEEDS_PRESSURE_READ:
             if (baro.dev.read_up(&baro.dev)) {
                 state = BAROMETER_NEEDS_PRESSURE_SAMPLE;
+            } else {
+                ignoreTaskTime();
             }
         break;
 

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -459,6 +459,7 @@ extern "C" {
     void failsafeOnValidDataReceived(void) { }
     void failsafeOnValidDataFailed(void) { }
     void pinioBoxTaskControl(void) { }
+    bool taskUpdateRxMainInProgress() { return true; }
 
     void rxPwmInit(rxRuntimeState_t *rxRuntimeState, rcReadRawDataFnPtr *callback)
     {

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -107,6 +107,7 @@ extern "C" {
 
 void failsafeOnRxSuspend(uint32_t ) {}
 void failsafeOnRxResume(void) {}
+bool taskUpdateRxMainInProgress() { return true; }
 
 uint32_t micros(void) { return 0; }
 uint32_t millis(void) { return 0; }

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -235,6 +235,7 @@ extern "C" {
     void xBusInit(const rxConfig_t *, rxRuntimeState_t *) {}
     void rxMspInit(const rxConfig_t *, rxRuntimeState_t *) {}
     void rxPwmInit(const rxConfig_t *, rxRuntimeState_t *) {}
+    bool taskUpdateRxMainInProgress() { return true; }
     float pt1FilterGain(float f_cut, float dT)
     {
         UNUSED(f_cut);


### PR DESCRIPTION
As demonstrated in https://github.com/betaflight/betaflight/pull/10605 the RX task results in the scheduler calling the gyro/filter/pid tasks late which will impact the regularity of the motor updates.

The RX task currently takes approx 55us (measured on an F722) with Crossfire CRSF. As processing of the gyro/filter/pid tasks takes between 85 and 90us it is not possible to execute both within a 125us cycle and consequently the duration of the call to taskUpdateRxMain() results in a 158us cycle, followed by a 110us cycle.

![image](https://user-images.githubusercontent.com/11480839/110375425-d9348d80-8049-11eb-8554-cdd4622aafb1.png)

By splitting this 55us task into three all such impact on the cycle time is eliminated at the cost of 250us of additional processing latency.

![image](https://user-images.githubusercontent.com/11480839/110375459-e6517c80-8049-11eb-8427-c4e34fdd5d9c.png)

This PR includes the code from https://github.com/betaflight/betaflight/pull/10605 to facilitate showing that there is no longer any RX task induced lateness.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0      0     78       6
01 - (         SYSTEM)    997       3       0    0.7%    0.0%         9      2   7765       5
02 - (           GYRO)   8000      10       7    8.5%    6.1%      1389      0  62378       0
03 - (         FILTER)   8000      24      16   19.7%   13.3%      3281      0  62378       0
04 - (            PID)   8000      58      44   46.9%   35.7%      9073      0  62378       0
05 - (            ACC)    988      13      10    1.7%    1.4%       240      0   7742      15
06 - (       ATTITUDE)    100      13      10    0.6%    0.6%        45      0    779      15
07 - (             RX)    102      24      17    0.7%    0.6%        70      0    771      23
08 - (         SERIAL)    100    1128       2   11.7%    0.5%       635      1    779       7
09 - (       DISPATCH)    994       3       0    0.7%    0.0%        16      0   7764       6
13 - (         BEEPER)    100       4       1    0.5%    0.5%         2      0    779       6
16 - (           BARO)    123      15       8    0.6%    0.5%        24      0    936      13
17 - (       ALTITUDE)     40      13      10    0.5%    0.5%         9      0    312      15
19 - (      TELEMETRY)    495       3       1    0.6%    0.5%        28      0   3881       6
20 - (       LEDSTRIP)    100      14       3    0.6%    0.5%         8      4    779       9
23 - (            CMS)     20       4       2    0.5%    0.5%         0      0    156       7
24 - (        VTXCTRL)      5       1       1    0.5%    0.5%         0      0     39       5
25 - (        CAMCTRL)      5       2       1    0.5%    0.5%         0      0     39       6
27 - (    ADCINTERNAL)      2       4       2    0.5%    0.5%         0      0      8       7
RX Check Function                   4       1                         8
Total (excluding SERIAL)                        84.8%   62.2%
```