### PR TITLE
new rc_smoothing defaults, set PT1 and biquad rc smoothing to the same frequency

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4962,11 +4962,6 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
             cliPrintLine("(manual)");
         }
         cliPrintf("# Derivative filter type: %s", lookupTables[TABLE_RC_SMOOTHING_DERIVATIVE_TYPE].values[rcSmoothingData->derivativeFilterType]);
-        if (rcSmoothingData->derivativeFilterTypeSetting == RC_SMOOTHING_DERIVATIVE_AUTO) {
-            cliPrintLine(" (auto)");
-        } else {
-            cliPrintLinefeed();
-        }
         cliPrintf("# Active derivative cutoff: %dhz (", rcSmoothingData->derivativeCutoffFrequency);
         if (rcSmoothingData->derivativeFilterType == RC_SMOOTHING_DERIVATIVE_OFF) {
             cliPrintLine("off)");

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -34,7 +34,7 @@ typedef enum {
 
 #ifdef USE_RC_SMOOTHING_FILTER
 #define RC_SMOOTHING_AUTO_FACTOR_MIN 0
-#define RC_SMOOTHING_AUTO_FACTOR_MAX 50
+#define RC_SMOOTHING_AUTO_FACTOR_MAX 75
 #endif
 
 void processRcCommand(void);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -79,7 +79,6 @@ typedef enum {
     RC_SMOOTHING_DERIVATIVE_OFF,
     RC_SMOOTHING_DERIVATIVE_PT1,
     RC_SMOOTHING_DERIVATIVE_BIQUAD,
-    RC_SMOOTHING_DERIVATIVE_AUTO,
 } rcSmoothingDerivativeFilter_e;
 
 #define ROL_LO (1 << (2 * ROLL))

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -67,8 +67,8 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .rc_smoothing_derivative_cutoff = 0, // automatically calculate the cutoff by default
         .rc_smoothing_debug_axis = ROLL,     // default to debug logging for the roll axis
         .rc_smoothing_input_type = RC_SMOOTHING_INPUT_BIQUAD,
-        .rc_smoothing_derivative_type = RC_SMOOTHING_DERIVATIVE_AUTO, // automatically choose type based on feedforward method
-        .rc_smoothing_auto_factor = 10,
+        .rc_smoothing_derivative_type = RC_SMOOTHING_INPUT_BIQUAD,
+        .rc_smoothing_auto_factor = 0,
         .srxl2_unit_id = 1,
         .srxl2_baud_fast = true,
         .sbus_baud_fast = false,


### PR DESCRIPTION
This PR changes the defaults for RC smoothing so that:

- the default is biquad for both input and derivative
- the default is to zero smoothing
- the auto-smoothing derived cutoff for PT1 will be the same as for biquad

In reviewing the rc.c code, I looked at the auto rc_smoothing filter cutoff setpoint maths, and modelled the biquad and PT1 responses using exact emulations of our code.

The auto smoothing cutoff code calculated the biquad cutoff very effectively; the values were very good.

Those biquad cutoffs were converted to 'equivalent' PT1 cutoffs.  That transformation resulted in much lower PT1 cutoffs at low RC link speeds, and higher cutoffs at high link speeds, than would be desirable.  There would be a great deal of delay from rcSmoothing when PT1 was selected at low RC link speeds, especially with high levels of auto smoothing.

The image below shows how PT1 delay gets really massive at 50hz under max smoothing with the current maths.

![RC Smoothing existing cutoffs](https://user-images.githubusercontent.com/11737748/112084776-81675c00-8bdd-11eb-860b-51bf745a2cde.jpg)

This image shows the PT1 delay being much more comparable when set to the same frequency as the biquad, as in this PR.

![RC Smoothing equal cutoffs](https://user-images.githubusercontent.com/11737748/112084941-bffd1680-8bdd-11eb-9678-521cb5efe508.jpg)

Note that the relative smoothing is less with PT1, but so it its delay; the degree of peak smoothing is about the same.
This is kind of how it should be, I think; PT1 should be spikier but respond faster, earlier, as for racers, but the overall relative delay should be similar.

As to the change in default type to biquad on both....

As can be seen from those images, PT1 doesn't smooth the initial step up very well; biquad seems a much better choice overall for RC step smoothing since it rounds off that initial rise much better.  

This would apply also to the derivative or FF steps.  So I think it would be best to apply the biquad on derivative / FF also.  

And about the extension of the available smoothing to 75....

The auto smoothing factor is tied to the RC interval.  As can be seen from the preceding diagrams, at higher data rates, the cutoffs move upwards.  

The result is that at zero auto smoothing, to track the input really well, to get all the way to the end of each input step within the step time.  Or, in other words, with zero auto smoothing, we smooth off the corners but always get to the end of each individual step.  

This is the way it should be.  In fact it looks like the default max auto smoothing incurs a maximum delay approximating one RC step time, in biquad mode.  

However at high RC link rates, the cutoffs then get quite high.  So the absolute amount of smoothing (for gimbal or finger jitter) will not be nearly as strong, even with max smoothing, for an RC link at 250hz.  It may simply not be enough, or not be perceived to be much smoothing at all.  

Users of very high data rates may then want more smoothing than we can currently provide with the maximum auto smoothing of 50.

This PR suggests increasing the max auto smoothing limit to 75.  Going from an auto smoothing of 50 to 75 will halve the calculated cutoffs and result in approximately a 2 rc step delay, but return extremely smooth rc signals, and take out some of the jitter from high RC rate links while still not incurring a ton of delay.  Its likely that using all 75 of smoothing on low data rates may cause noticeable lag, but it isn't likely needed there, it's intended for high speed links.

 Also sets default rc smoothing filter type to biquad for all rc smoothing filters when automatic selection of filter type is selected.
