### PR TITLE
Fix I2C timeout

### DIFF
--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -115,9 +115,9 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
     HAL_StatusTypeDef status;
 
     if (reg_ == 0xFF)
-        status = HAL_I2C_Master_Transmit(pHandle ,addr_ << 1, &data, 1, I2C_DEFAULT_TIMEOUT);
+        status = HAL_I2C_Master_Transmit(pHandle ,addr_ << 1, &data, 1, I2C_TIMEOUT_SYS_TICKS);
     else
-        status = HAL_I2C_Mem_Write(pHandle ,addr_ << 1, reg_, I2C_MEMADD_SIZE_8BIT, &data, 1, I2C_DEFAULT_TIMEOUT);
+        status = HAL_I2C_Mem_Write(pHandle ,addr_ << 1, reg_, I2C_MEMADD_SIZE_8BIT, &data, 1, I2C_TIMEOUT_SYS_TICKS);
 
     if (status != HAL_OK)
         return i2cHandleHardwareFailure(device);
@@ -170,9 +170,9 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
     HAL_StatusTypeDef status;
 
     if (reg_ == 0xFF)
-        status = HAL_I2C_Master_Receive(pHandle ,addr_ << 1, buf, len, I2C_DEFAULT_TIMEOUT);
+        status = HAL_I2C_Master_Receive(pHandle ,addr_ << 1, buf, len, I2C_TIMEOUT_SYS_TICKS);
     else
-        status = HAL_I2C_Mem_Read(pHandle, addr_ << 1, reg_, I2C_MEMADD_SIZE_8BIT,buf, len, I2C_DEFAULT_TIMEOUT);
+        status = HAL_I2C_Mem_Read(pHandle, addr_ << 1, reg_, I2C_MEMADD_SIZE_8BIT,buf, len, I2C_TIMEOUT_SYS_TICKS);
 
     if (status != HAL_OK) {
         return i2cHandleHardwareFailure(device);

--- a/src/main/drivers/bus_i2c_impl.h
+++ b/src/main/drivers/bus_i2c_impl.h
@@ -25,9 +25,8 @@
 #include "drivers/io_types.h"
 #include "drivers/rcc_types.h"
 
-#define I2C_SHORT_TIMEOUT            ((uint32_t)0x1000)
-#define I2C_LONG_TIMEOUT             ((uint32_t)(10 * I2C_SHORT_TIMEOUT))
-#define I2C_DEFAULT_TIMEOUT          I2C_SHORT_TIMEOUT
+#define I2C_TIMEOUT_US          10000
+#define I2C_TIMEOUT_SYS_TICKS   (I2C_TIMEOUT_US / 1000)
 
 #define I2C_PIN_SEL_MAX 4
 

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -32,6 +32,7 @@
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/rcc.h"
+#include "drivers/time.h"
 
 #include "drivers/bus_i2c.h"
 #include "drivers/bus_i2c_impl.h"
@@ -43,8 +44,6 @@
 #define I2C_STANDARD_TIMING   0x00E0257A  // 400 Khz, 72Mhz Clock, Analog Filter Delay ON, Rise 100, Fall 10.
 
 #define I2C_GPIO_AF         GPIO_AF_4
-
-static uint32_t i2cTimeout;
 
 static volatile uint16_t i2cErrorCount = 0;
 
@@ -144,10 +143,12 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
 
     addr_ <<= 1;
 
+    timeUs_t timeoutStartUs;
+
     /* Test on BUSY Flag */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_BUSY) != RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -156,9 +157,9 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
     I2C_TransferHandling(I2Cx, addr_, 1, I2C_Reload_Mode, I2C_Generate_Start_Write);
 
     /* Wait until TXIS flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -167,10 +168,9 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
     I2C_SendData(I2Cx, (uint8_t) reg);
 
     /* Wait until TCR flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TCR) == RESET)
-    {
-        if ((i2cTimeout--) == 0) {
+    timeoutStartUs = microsISR();
+    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TCR) == RESET) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -179,9 +179,9 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
     I2C_TransferHandling(I2Cx, addr_, 1, I2C_AutoEnd_Mode, I2C_No_StartStop);
 
     /* Wait until TXIS flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -190,9 +190,9 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
     I2C_SendData(I2Cx, data);
 
     /* Wait until STOPF flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_STOPF) == RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -217,10 +217,12 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
 
     addr_ <<= 1;
 
+    timeUs_t timeoutStartUs;
+
     /* Test on BUSY Flag */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_BUSY) != RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -229,9 +231,9 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
     I2C_TransferHandling(I2Cx, addr_, 1, I2C_SoftEnd_Mode, I2C_Generate_Start_Write);
 
     /* Wait until TXIS flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -240,9 +242,9 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
     I2C_SendData(I2Cx, (uint8_t) reg);
 
     /* Wait until TC flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TC) == RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }
@@ -253,9 +255,9 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
     /* Wait until all data are received */
     while (len) {
         /* Wait until RXNE flag is set */
-        i2cTimeout = I2C_LONG_TIMEOUT;
+        timeoutStartUs = microsISR();
         while (I2C_GetFlagStatus(I2Cx, I2C_ISR_RXNE) == RESET) {
-            if ((i2cTimeout--) == 0) {
+            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
                 return i2cTimeoutUserCallback();
             }
         }
@@ -270,9 +272,9 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t*
     }
 
     /* Wait until STOPF flag is set */
-    i2cTimeout = I2C_LONG_TIMEOUT;
+    timeoutStartUs = microsISR();
     while (I2C_GetFlagStatus(I2Cx, I2C_ISR_STOPF) == RESET) {
-        if ((i2cTimeout--) == 0) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
             return i2cTimeoutUserCallback();
         }
     }


### PR DESCRIPTION
Makes I2C timeout independent of system clock speed.
Timeout is now in microseconds and is set to 10000us(same as in INAV).

Currently the i2c timeout is just a number with no unit. The timeout is done by decrementing this number in a while loop. This makes the actual timeout entirely dependent on the system clock speed. This was probably fine for the slow F1 MCUs but with the clockspeeds of the MCUs we're using now the timeout can become too short. 
Another thing is that the timeout would be different depending on the SMT32 libraries used. For MCUs using HAL and the HAL functions for transmit and receive a ```I2C_DEFAULT_TIMEOUT``` of 4096 would result in a timeout of over 4 seconds while for F4s for example this would give a timeout of something like this  ```while (I2Cx->CR1 & I2C_CR1_STOP && --timeout > 0) {; }``` which is probably just a few microseconds.

With this PR the timeout will be the same for all MCUs and clock speeds. 

Probably fixes https://github.com/betaflight/betaflight/issues/10600
