### PR TITLE
Add gyro temperature telemetry & debug output for MPU6000

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -99,4 +99,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "D_LPF",
     "VTX_TRAMP",
     "GHST",
+    "GYRO_TMP"
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -115,6 +115,7 @@ typedef enum {
     DEBUG_D_LPF,
     DEBUG_VTX_TRAMP,
     DEBUG_GHST,
+    DEBUG_GYRO_TMP,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1174,6 +1174,8 @@ void subTaskTelemetryPollSensors(timeUs_t currentTimeUs)
         // Read out gyro temperature if used for telemmetry
         gyroReadTemperature();
         lastGyroTempTimeUs = currentTimeUs;
+
+        DEBUG_SET(DEBUG_GYRO_TMP, 0, gyroGetTemperature());
     }
 }
 #endif

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -594,6 +594,23 @@ void gyroReadTemperature(void)
     }
 }
 
+bool gyroHasTemperatureSensor(void)
+{
+    switch (gyro.gyroToUse) {
+    case GYRO_CONFIG_USE_GYRO_1:
+        return gyro.gyroSensor1.gyroDev.temperatureFn != NULL;
+
+#ifdef USE_MULTI_GYRO
+    case GYRO_CONFIG_USE_GYRO_2:
+        return gyro.gyroSensor2.gyroDev.temperatureFn != NULL;
+
+    case GYRO_CONFIG_USE_GYRO_BOTH:
+        return gyro.gyroSensor1.gyroDev.temperatureFn != NULL || gyro.gyroSensor2.gyroDev.temperatureFn != NULL;
+#endif // USE_MULTI_GYRO
+    }
+    return false;
+}
+
 int16_t gyroGetTemperature(void)
 {
     return gyroSensorTemperature;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -215,6 +215,7 @@ bool gyroGetAccumulationAverage(float *accumulation);
 void gyroStartCalibration(bool isFirstArmingCalibration);
 bool isFirstArmingGyroCalibrationRunning(void);
 bool gyroIsCalibrationComplete(void);
+bool gyroHasTemperatureSensor(void);
 void gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 bool gyroOverflowDetected(void);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -136,6 +136,7 @@ enum
 #endif
     FSSP_DATAID_T1         = 0x0400 ,
     FSSP_DATAID_T11        = 0x0401 ,
+    FSSP_DATAID_T1GYRO     = 0x0402 ,
     FSSP_DATAID_T2         = 0x0410 ,
     FSSP_DATAID_HOME_DIST  = 0x0420 ,
     FSSP_DATAID_GPS_ALT    = 0x0820 ,
@@ -336,6 +337,12 @@ static void initSmartPortSensors(void)
 #if defined(USE_ADC_INTERNAL)
     if (telemetryIsSensorEnabled(SENSOR_TEMPERATURE)) {
         ADD_SENSOR(FSSP_DATAID_T11);
+    }
+#endif
+
+#if defined(USE_GYRO)
+    if (gyroHasTemperatureSensor() && telemetryIsSensorEnabled(SENSOR_TEMPERATURE)) {
+        ADD_SENSOR(FSSP_DATAID_T1GYRO);
     }
 #endif
 
@@ -838,6 +845,12 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
 #if defined(USE_ADC_INTERNAL)
             case FSSP_DATAID_T11        :
                 smartPortSendPackage(id, getCoreTemperatureCelsius());
+                *clearToSend = false;
+                break;
+#endif
+#if defined(USE_GYRO)
+            case FSSP_DATAID_T1GYRO        :
+                smartPortSendPackage(id, gyroGetTemperature());
                 *clearToSend = false;
                 break;
 #endif

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1007,7 +1007,7 @@ TEST(ArmingPreventionTest, Paralyze)
     // expect
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXVTXPITMODE));
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXBEEPERON));
-    
+
     // given
     // try exiting paralyze mode and ensure arming and pit mode are still disabled
     rcData[AUX2] = 1000;
@@ -1067,6 +1067,7 @@ extern "C" {
     void telemetryCheckState(void) {}
     void mspSerialAllocatePorts(void) {}
     void gyroReadTemperature(void) {}
+    int16_t gyroGetTemperature(void) { return 0; }
     void updateRcCommands(void) {}
     void applyAltHold(void) {}
     void resetYawAxis(void) {}

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -160,6 +160,7 @@ extern "C" {
     void telemetryCheckState(void) {}
     void mspSerialAllocatePorts(void) {}
     void gyroReadTemperature(void) {}
+    int16_t gyroGetTemperature(void) { return 0; }
     void updateRcCommands(void) {}
     void applyAltHold(void) {}
     void resetYawAxis(void) {}


### PR DESCRIPTION
Add MPU6000 gyro temperature telemetry function.
Add gyro temperature telemetry debug output (debug_mode = GYRO_TMP).
Add FrSky SmartPort gyro temperature telemetry sensor (sensor id = 0x0402).