### PR TITLE
Add the manual only gyro calibration mode

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -664,6 +664,9 @@ const clivalue_t valueTable[] = {
     { "gyro_notch2_hz",             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_hz_2) },
     { "gyro_notch2_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_2) },
 
+    // 4 elements are output for the GYRO calibration - The 3 axis values and the 4th representing whether calibration has been performed
+    { "gyro_calibration",           VAR_INT16  | MASTER_VALUE | MODE_ARRAY, .config.array.length = GYRO_CNT_MAX * 4, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroTrims[0].raw) },
+
     { "gyro_calib_duration",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 50,  3000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroCalibrationDuration) },
     { "gyro_calib_noise_limit",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,  200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold) },
     { "gyro_offset_yaw",            VAR_INT16  | MASTER_VALUE, .config.minmax = { -1000, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_offset_yaw) },
@@ -690,6 +693,7 @@ const clivalue_t valueTable[] = {
     { "dyn_lpf_gyro_curve_expo",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 10 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_lpf_curve_expo) },
 #endif
     { "gyro_filter_debug_axis",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_FILTER_DEBUG }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_filter_debug_axis) },
+    { "gyro_cal_manual",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_cal_manual) },
 
 // PG_ACCELEROMETER_CONFIG
 #if defined(USE_ACC)

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -401,6 +401,7 @@ void updateArmingStatus(void)
 
             /* Ignore ARMING_DISABLED_CALIBRATING if we are going to calibrate gyro on first arm */
             bool ignoreGyro = armingConfig()->gyro_cal_on_first_arm
+                && !gyroConfig()->gyro_cal_manual // gyro_cal_manual overrides gyro_cal_on_first_arm
                 && !(getArmingDisableFlags() & ~(ARMING_DISABLED_ARM_SWITCH | ARMING_DISABLED_CALIBRATING));
 
             /* Ignore ARMING_DISABLED_THROTTLE (once arm switch is on) if we are in 3D mode */
@@ -479,7 +480,8 @@ void disarm(flightLogDisarmReason_e reason)
 
 void tryArm(void)
 {
-    if (armingConfig()->gyro_cal_on_first_arm) {
+    if (armingConfig()->gyro_cal_on_first_arm
+    && !gyroConfig()->gyro_cal_manual) { // gyro_cal_manual overrides gyro_cal_on_first_arm
         gyroStartCalibration(true);
     }
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -858,7 +858,13 @@ void init(void)
         accStartCalibration();
     }
 #endif
-    gyroStartCalibration(false);
+    if (gyroConfig()->gyro_cal_manual
+    &&  gyroIsCalibrationConfigValid()) {
+        gyroSetCalibration();
+    } else {
+        gyroStartCalibration(false);
+    }
+
 #ifdef USE_BARO
     baroStartCalibration();
 #endif

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -113,12 +113,12 @@ void accResetRollAndPitchTrims(void)
     resetRollAndPitchTrims(&accelerometerConfigMutable()->accelerometerTrims);
 }
 
-static void resetFlightDynamicsTrims(flightDynamicsTrims_t *accZero)
+void resetFlightDynamicsTrims(flightDynamicsTrims_t *trims)
 {
-    accZero->values.roll = 0;
-    accZero->values.pitch = 0;
-    accZero->values.yaw = 0;
-    accZero->values.calibrationCompleted = 0;
+    trims->values.roll = 0;
+    trims->values.pitch = 0;
+    trims->values.yaw = 0;
+    trims->values.calibrationCompleted = 0;
 }
 
 void pgResetFn_accelerometerConfig(accelerometerConfig_t *instance)

--- a/src/main/sensors/acceleration_init.h
+++ b/src/main/sensors/acceleration_init.h
@@ -38,3 +38,4 @@ extern accelerationRuntime_t accelerationRuntime;
 
 void performAcclerationCalibration(rollAndPitchTrims_t *rollAndPitchTrims);
 void performInflightAccelerationCalibration(rollAndPitchTrims_t *rollAndPitchTrims);
+void resetFlightDynamicsTrims(flightDynamicsTrims_t *trims);

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -27,6 +27,7 @@
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
+#include "sensors/sensors.h"
 
 #ifdef USE_GYRO_DATA_ANALYSE
 #include "flight/gyroanalyse.h"
@@ -160,6 +161,12 @@ typedef enum {
 #define GYRO_CONFIG_USE_GYRO_2      1
 #define GYRO_CONFIG_USE_GYRO_BOTH   2
 
+#ifdef USE_MULTI_GYRO
+#define GYRO_CNT_MAX 2
+#else
+#define GYRO_CNT_MAX 1
+#endif
+
 enum {
     FILTER_LOWPASS = 0,
     FILTER_LOWPASS2
@@ -205,6 +212,9 @@ typedef struct gyroConfig_s {
     uint8_t dyn_lpf_curve_expo; // set the curve for dynamic gyro lowpass filter
     uint8_t  simplified_gyro_filter;
     uint8_t  simplified_gyro_filter_multiplier;
+
+    uint8_t gyro_cal_manual;
+    flightDynamicsTrims_t gyroTrims[GYRO_CNT_MAX];
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);
@@ -213,8 +223,11 @@ void gyroUpdate(void);
 void gyroFiltering(timeUs_t currentTimeUs);
 bool gyroGetAccumulationAverage(float *accumulation);
 void gyroStartCalibration(bool isFirstArmingCalibration);
+void gyroSetCalibration(void);
 bool isFirstArmingGyroCalibrationRunning(void);
+bool gyroIsCalibrationConfigValid(void);
 bool gyroIsCalibrationComplete(void);
+bool gyroHasTemperatureSensor(void);
 void gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 bool gyroOverflowDetected(void);

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -163,4 +163,6 @@ void sensorsSet(uint32_t) {}
 void schedulerResetTaskStatistics(taskId_e) {}
 int getArmingDisableFlags(void) {return 0;}
 void writeEEPROM(void) {}
+void saveConfigAndNotify(void) {}
+void resetFlightDynamicsTrims(flightDynamicsTrims_t) {}
 }


### PR DESCRIPTION
Add the manual only gyro calibration mode (option gyro_cal_manual, avialible in CLI).
This mode should help with the gyro temperature drift, allowing to calibrate a gyro when it is at its working temperature, and not during the power-up (as usual).
Tiny Whoops are expected to be the most affected by the gyro temperature drift due to their tight layout and the thermal interference from CPU, ESCs and VTX.
When this mode is activated (gyro_cal_manual = ON), the automatic gyro calibration procedure during power-up is disabled.
The gyro calibration data is saved to EEPROM after the manual gyro calibration (via the stick command or OSD menu).
This calibration data is used on the subsequent boots instead of the actual automatic gyro calibration.
(The gyro_cal_manual mode can also help with launching drones from moving pads (such as boats), when the gyro calibration is complicated.)
To properly calibrate a gyro in this mode, set gyro_cal_manual = ON, save, launch the drone and wait until the gyro is heated to its typical in-flight temperature (check it via the FrSky SmartPort telemetry sensor (it may also be available via FlySky's iBUS and the old FrSky telemetry), or just wait a few minutes after take-off).
Then land, disarm, perform the manual gyro calibration, then (if you are using a level mode) perform the accelerometer calibration (perform the accelerometer trim later, if necessary).
The gyro calibration data is saved in EEPROM and used until the next manual gyro recalibration.
When a gyro is properly calibrated in the gyro_cal_manual mode, a user may only experience a gyro temperature drift during a short period at the beginning of the flight (when the gyro is warming up) and not for the rest of the flight (when the gyro temperature is rather stable).