### PR TITLE
Fixed RX task check.

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -179,6 +179,8 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
     case PROCESS:
         ignoreTaskTime();
         if (!processRx(currentTimeUs)) {
+            rxState = CHECK;
+            
             break;
         }
         rxState = MODES;


### PR DESCRIPTION
Fixes #10647.

We need to run the entire task check every time, to avoid losing status updates while waiting for the main task to be scheduled.
