### PR TITLE
Fix bug in RX state machine and telemetry timeouts

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -179,6 +179,7 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
     case PROCESS:
         ignoreTaskTime();
         if (!processRx(currentTimeUs)) {
+            rxState = CHECK;
             break;
         }
         rxState = MODES;


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/10609 introduced a bug, with a fix suggested by @mikeller.

Testing also showed telemetry to be stalling shortly after reset when using the FW-RXSR-v2.1.1 and FW-XJT-v2.1.0 firmwares.

After reset `processSmartPortTelemetry()` is called and the receiver responds two frames later with a `FPORT_FRAME_ID_DATA` packet. This disables timed telemetry output as the receiver has indicated that is it supporting this alternate flow control mechanism. After 19 packets the receiver requests no more telemetry information and telemetry stops working.

![image](https://user-images.githubusercontent.com/11480839/113218444-719fe580-9277-11eb-827a-e7f0168dd2a3.png)

The telemetry packet from the receiver is shown more clearly here, starting at the 0s:287ms mark with 0x08 (length), 0x01 (master) and 0x10 (`FPORT_FRAME_ID_DATA` packet type indicator). What follows after a short delay is the BF response starting 0x08 (length), 0x81 (slave), 0x10 (`FPORT_FRAME_ID_DATA` packet type indicator).

![image](https://user-images.githubusercontent.com/11480839/113218534-97c58580-9277-11eb-8e31-deeb599e7cf0.png)

This PR adds a timeout so that the `FPORT_FRAME_ID_DATA` flow control mechanism will be disabled if no telemetry is seen within 100ms. This can be seen working below, maintaining the telemetry stream.

![image](https://user-images.githubusercontent.com/11480839/113219013-787b2800-9278-11eb-8f05-69714a404864.png)
