### PR TITLE
Fix SPI timeout

### DIFF
--- a/src/main/drivers/bus_spi_impl.h
+++ b/src/main/drivers/bus_spi_impl.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#define SPI_TIMEOUT_US  10000
+
 #if defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32G4)
 #define MAX_SPI_PIN_SEL 2
 #elif defined(STM32F7)

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -36,6 +36,7 @@
 #include "drivers/io.h"
 #include "drivers/nvic.h"
 #include "drivers/rcc.h"
+#include "drivers/time.h"
 
 #ifndef SPI2_SCK_PIN
 #define SPI2_NSS_PIN    PB12
@@ -71,8 +72,6 @@
 #define SPI4_NSS_PIN NONE
 #endif
 
-#define SPI_DEFAULT_TIMEOUT 10
-
 static LL_SPI_InitTypeDef defaultInit =
 {
     .TransferDirection = SPI_DIRECTION_2LINES,
@@ -107,10 +106,12 @@ void spiInitDevice(SPIDevice device, bool leadingEdge)
     IOInit(IOGetByTag(spi->miso), OWNER_SPI_MISO, RESOURCE_INDEX(device));
     IOInit(IOGetByTag(spi->mosi), OWNER_SPI_MOSI, RESOURCE_INDEX(device));
 
-    if (spi->leadingEdge == true)
+    if (spi->leadingEdge == true) {
         IOConfigGPIOAF(IOGetByTag(spi->sck), SPI_IO_AF_SCK_CFG_LOW, spi->sckAF);
-    else
+    } else {
         IOConfigGPIOAF(IOGetByTag(spi->sck), SPI_IO_AF_SCK_CFG_HIGH, spi->sckAF);
+    }
+
     IOConfigGPIOAF(IOGetByTag(spi->miso), SPI_IO_AF_MISO_CFG, spi->misoAF);
     IOConfigGPIOAF(IOGetByTag(spi->mosi), SPI_IO_AF_CFG, spi->mosiAF);
 
@@ -136,18 +137,21 @@ void spiInitDevice(SPIDevice device, bool leadingEdge)
 
 uint8_t spiTransferByte(SPI_TypeDef *instance, uint8_t txByte)
 {
-    uint16_t spiTimeout = 1000;
+    timeUs_t timeoutStartUs = microsISR();
 
-    while (!LL_SPI_IsActiveFlag_TXE(instance))
-        if ((spiTimeout--) == 0)
+    while (!LL_SPI_IsActiveFlag_TXE(instance)) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= SPI_TIMEOUT_US) {
             return spiTimeoutUserCallback(instance);
-
+        }
+    }
     LL_SPI_TransmitData8(instance, txByte);
 
-    spiTimeout = 1000;
-    while (!LL_SPI_IsActiveFlag_RXNE(instance))
-        if ((spiTimeout--) == 0)
+    timeoutStartUs = microsISR();
+    while (!LL_SPI_IsActiveFlag_RXNE(instance)) {
+        if (cmpTimeUs(microsISR(), timeoutStartUs) >= SPI_TIMEOUT_US) {
             return spiTimeoutUserCallback(instance);
+        }
+    }
 
     return (uint8_t)LL_SPI_ReceiveData8(instance);
 }
@@ -163,12 +167,14 @@ bool spiIsBusBusy(SPI_TypeDef *instance)
 
 bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, int len)
 {
+    timeUs_t timeoutStartUs;
+    
     // set 16-bit transfer
     CLEAR_BIT(instance->CR2, SPI_RXFIFO_THRESHOLD);
     while (len > 1) {
-        int spiTimeout = 1000;
+        timeoutStartUs = microsISR();
         while (!LL_SPI_IsActiveFlag_TXE(instance)) {
-            if ((spiTimeout--) == 0) {
+            if (cmpTimeUs(microsISR(), timeoutStartUs) >= SPI_TIMEOUT_US) {
                 return spiTimeoutUserCallback(instance);
             }
         }
@@ -181,9 +187,9 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
         }
         LL_SPI_TransmitData16(instance, w);
 
-        spiTimeout = 1000;
+        timeoutStartUs = microsISR();
         while (!LL_SPI_IsActiveFlag_RXNE(instance)) {
-            if ((spiTimeout--) == 0) {
+            if (cmpTimeUs(microsISR(), timeoutStartUs) >= SPI_TIMEOUT_US) {
                 return spiTimeoutUserCallback(instance);
             }
         }
@@ -197,18 +203,18 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     // set 8-bit transfer
     SET_BIT(instance->CR2, SPI_RXFIFO_THRESHOLD);
     if (len) {
-        int spiTimeout = 1000;
+        timeoutStartUs = microsISR();
         while (!LL_SPI_IsActiveFlag_TXE(instance)) {
-            if ((spiTimeout--) == 0) {
+            if (cmpTimeUs(microsISR(), timeoutStartUs) >= SPI_TIMEOUT_US) {
                 return spiTimeoutUserCallback(instance);
             }
         }
         uint8_t b = txData ? *(txData++) : 0xFF;
         LL_SPI_TransmitData8(instance, b);
 
-        spiTimeout = 1000;
+        timeoutStartUs = microsISR();
         while (!LL_SPI_IsActiveFlag_RXNE(instance)) {
-            if ((spiTimeout--) == 0) {
+            if (cmpTimeUs(microsISR(), timeoutStartUs) >= SPI_TIMEOUT_US) {
                 return spiTimeoutUserCallback(instance);
             }
         }


### PR DESCRIPTION
For ll and stdperiph drivers. Currently we're just decrementing a variable in a while loop so we don't really know how long the timeout is. It will also vary with system clock speed. As the clock speed goes up we risk that the timeout becomes too short.
This changes it so that the timeout is always 10ms like it already is for the hal driver.