### PR TITLE
Fix tasks reporting of rate/Hz

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -170,18 +170,20 @@ bool taskUpdateRxMainInProgress()
 
 static void taskUpdateRxMain(timeUs_t currentTimeUs)
 {
+    // Where we are using a state machine call ignoreTaskTime() for all states bar one
+    if (rxState != MODES) {
+        ignoreTaskTime();
+    }
+
     switch (rxState) {
     default:
     case CHECK:
-        ignoreTaskTime();
         rxState = PROCESS;
         break;
 
     case PROCESS:
-        ignoreTaskTime();
         if (!processRx(currentTimeUs)) {
             rxState = CHECK;
-            
             break;
         }
         rxState = MODES;
@@ -193,7 +195,6 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
         break;
 
     case UPDATE:
-        ignoreTaskTime();
         // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState
         updateRcCommands();
         updateArmingStatus();

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -299,7 +299,6 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
     if (selectedTask) {
         currentTask = selectedTask;
         ignoreCurrentTaskTime = false;
-        selectedTask->taskLatestDeltaTimeUs = cmpTimeUs(currentTimeUs, selectedTask->lastExecutedAtUs);
 #if defined(USE_TASK_STATISTICS)
         float period = currentTimeUs - selectedTask->lastExecutedAtUs;
 #endif
@@ -314,6 +313,8 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
             selectedTask->taskFunc(currentTimeBeforeTaskCallUs);
             taskExecutionTimeUs = micros() - currentTimeBeforeTaskCallUs;
             if (!ignoreCurrentTaskTime) {
+                selectedTask->taskLatestDeltaTimeUs = cmpTimeUs(currentTimeUs, selectedTask->lastStatsAtUs);
+                selectedTask->lastStatsAtUs = currentTimeUs;
                 selectedTask->movingSumExecutionTimeUs += taskExecutionTimeUs - selectedTask->movingSumExecutionTimeUs / TASK_STATS_MOVING_SUM_COUNT;
                 selectedTask->movingSumDeltaTimeUs += selectedTask->taskLatestDeltaTimeUs - selectedTask->movingSumDeltaTimeUs / TASK_STATS_MOVING_SUM_COUNT;
                 selectedTask->maxExecutionTimeUs = MAX(selectedTask->maxExecutionTimeUs, taskExecutionTimeUs);
@@ -326,6 +327,7 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
         } else
 #endif
         {
+            selectedTask->taskLatestDeltaTimeUs = cmpTimeUs(currentTimeUs, selectedTask->lastExecutedAtUs);
             selectedTask->taskFunc(currentTimeUs);
         }
     }

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -170,24 +170,25 @@ typedef struct {
 #endif
     bool (*checkFunc)(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
     void (*taskFunc)(timeUs_t currentTimeUs);
-    timeDelta_t desiredPeriodUs;      // target period of execution
-    const int8_t staticPriority;    // dynamicPriority grows in steps of this size
+    timeDelta_t desiredPeriodUs;        // target period of execution
+    const int8_t staticPriority;        // dynamicPriority grows in steps of this size
 
     // Scheduling
-    uint16_t dynamicPriority;       // measurement of how old task was last executed, used to avoid task starvation
+    uint16_t dynamicPriority;           // measurement of how old task was last executed, used to avoid task starvation
     uint16_t taskAgeCycles;
     timeDelta_t taskLatestDeltaTimeUs;
-    timeUs_t lastExecutedAtUs;        // last time of invocation
-    timeUs_t lastSignaledAtUs;        // time of invocation event for event-driven tasks
-    timeUs_t lastDesiredAt;         // time of last desired execution
+    timeUs_t lastExecutedAtUs;          // last time of invocation
+    timeUs_t lastSignaledAtUs;          // time of invocation event for event-driven tasks
+    timeUs_t lastDesiredAt;             // time of last desired execution
 
 #if defined(USE_TASK_STATISTICS)
     // Statistics
     float    movingAverageCycleTimeUs;
     timeUs_t movingSumExecutionTimeUs;  // moving sum over 32 samples
-    timeUs_t movingSumDeltaTimeUs;  // moving sum over 32 samples
+    timeUs_t movingSumDeltaTimeUs;      // moving sum over 32 samples
     timeUs_t maxExecutionTimeUs;
-    timeUs_t totalExecutionTimeUs;    // total time consumed by task since boot
+    timeUs_t totalExecutionTimeUs;      // total time consumed by task since boot
+    timeUs_t lastStatsAtUs;             // time of last stats gathering for rate calculation
 #if defined(USE_LATE_TASK_STATISTICS)
     uint32_t runCount;
     uint32_t lateCount;

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -353,6 +353,7 @@ TEST(SchedulerUnittest, TestSingleTask)
     }
     setTaskEnabled(TASK_ACCEL, true);
     tasks[TASK_ACCEL].lastExecutedAtUs = 1000;
+    tasks[TASK_ACCEL].lastStatsAtUs = 1000;
     simulatedTime = 2050;
     // run the scheduler and check the task has executed
     scheduler();


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/10609 introduced the use of a state machine for the RX task so as not to break the determinism of the 8kHz cycle. This change did not address the reporting of the `rate/Hz` column in the `tasks` CLI command, nor the associated CPU load figures.

This PR addresses this, reporting 33Hz correctly for the RX with no active radio link:

```# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0      0     20       6
01 - (         SYSTEM)    999       2       0    0.6%    0.0%        17      0   2051       6
02 - (           GYRO)   8000       8       6    6.9%    5.3%      5775      0  16421       0
03 - (         FILTER)   8000      14      12   11.7%   10.1%     10491      0  16421       0
04 - (            PID)   8000      23      19   18.9%   15.7%     17591      0  16421       0
05 - (            ACC)    999      11       8    1.5%    1.2%       949      0   2051      13
06 - (       ATTITUDE)    100       5       4    0.5%    0.5%        39      0    206       9
07 - (             RX)     33       1       0    0.5%    0.0%        83      0    272       5
08 - (         SERIAL)    100   12663       1  127.1%    0.5%      1433      1    206       6
09 - (       DISPATCH)    999       2       0    0.6%    0.0%        22      0   2051       5
10 - (BATTERY_VOLTAGE)     50       2       1    0.5%    0.5%         5      0    103       6
11 - (BATTERY_CURRENT)     50       1       0    0.5%    0.0%         1      0    103       5
12 - ( BATTERY_ALERTS)      5       1       0    0.5%    0.0%         0      0     10       6
13 - (         BEEPER)    100       2       1    0.5%    0.5%         5      0    205       5
16 - (           BARO)     20      26      25    0.5%    0.5%        69      0    246      30
17 - (       ALTITUDE)     40       5       3    0.5%    0.5%        16      0     82       8
19 - (      TELEMETRY)    250       1       0    0.5%    0.0%         5      1    513       6
20 - (       LEDSTRIP)    100       5       1    0.5%    0.5%        11      0    205       5
21 - (            OSD)     60      18       5    0.6%    0.5%        33      0    123      10
23 - (            CMS)     20       1       1    0.5%    0.5%         1      0     42       5
24 - (        VTXCTRL)      5       1       0    0.5%    0.0%         0      0     10       5
25 - (        CAMCTRL)      5       1       0    0.5%    0.0%         0      0     10       6
27 - (    ADCINTERNAL)      1       1       0    0.5%    0.0%         0      0      3       6
RX Check Function                   2       1                        15
Total (excluding SERIAL)                        48.3%   36.3%
```

and the increased rate when a radio link is present, 111Hz below for an FrSky R-XSR receiver.

```
07 - (             RX)    111       2       0    0.5%    0.0%       314      0  62306       5
```

@TheIsotopes I hope this fixes the issues you were seeing. This also fixes the Modes processing.

Unfortunately this PR tips the STMF411 unified build over the edge due to the addition of another task variable.