### PR TITLE
MSP fix bytes remaining check

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2660,7 +2660,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU8(src);
 #endif
         }
-        if (sbufBytesRemaining(src) >= 1) {
+        if (sbufBytesRemaining(src) >= 2) {
 #if defined(USE_GYRO_DATA_ANALYSE)
             // Added in MSP API 1.43
             gyroConfigMutable()->dyn_notch_max_hz = sbufReadU16(src);


### PR DESCRIPTION
We need at least 2 bytes for dyn_notch_max_hz.
