### PR TITLE
[H7][LIB] Remove duplicate definition of assert_param from LL spi

### DIFF
--- a/lib/main/STM32H7/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_spi.c
+++ b/lib/main/STM32H7/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_spi.c
@@ -25,11 +25,6 @@
 #ifdef GENERATOR_I2S_PRESENT
 #include "stm32h7xx_ll_rcc.h"
 #endif /* GENERATOR_I2S_PRESENT*/
-#ifdef  USE_FULL_ASSERT
-#include "stm32_assert.h"
-#else
-#define assert_param(expr) ((void)0U)
-#endif
 
 /** @addtogroup STM32H7xx_LL_Driver
   * @{


### PR DESCRIPTION
Same change was applied in c3f2632 for LL dma and tim. Now needed for SPI.