### PR TITLE
reduce FF jitter from duplicates

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1164,6 +1164,7 @@ const clivalue_t valueTable[] = {
     { "ff_interpolate_sp",          VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = {TABLE_INTERPOLATED_SP}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_interpolate_sp) },
     { "ff_max_rate_limit",          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 150}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_max_rate_limit) },
     { "ff_smooth_factor",           VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 75}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_smooth_factor) },
+    { "ff_jitter_reduction",        VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, ff_jitter_factor) },
 #endif
     { "ff_boost",                   VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ff_boost) },
 

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -519,6 +519,7 @@ static uint8_t cmsx_iterm_relax_cutoff;
 #ifdef USE_INTERPOLATED_SP
 static uint8_t cmsx_ff_interpolate_sp;
 static uint8_t cmsx_ff_smooth_factor;
+static uint8_t cmsx_ff_jitter_factor;
 #endif
 
 static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
@@ -561,6 +562,7 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 #ifdef USE_INTERPOLATED_SP
     cmsx_ff_interpolate_sp = pidProfile->ff_interpolate_sp;
     cmsx_ff_smooth_factor = pidProfile->ff_smooth_factor;
+    cmsx_ff_jitter_factor = pidProfile->ff_jitter_factor;
 #endif
 
 #ifdef USE_BATTERY_VOLTAGE_SAG_COMPENSATION
@@ -608,6 +610,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
 #ifdef USE_INTERPOLATED_SP
     pidProfile->ff_interpolate_sp = cmsx_ff_interpolate_sp;
     pidProfile->ff_smooth_factor = cmsx_ff_smooth_factor;
+    pidProfile->ff_jitter_factor = cmsx_ff_jitter_factor;
 #endif
 
 #ifdef USE_BATTERY_VOLTAGE_SAG_COMPENSATION
@@ -625,6 +628,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
 #ifdef USE_INTERPOLATED_SP
     { "FF MODE",       OME_TAB,    NULL, &(OSD_TAB_t)    { &cmsx_ff_interpolate_sp,  4, lookupTableInterpolatedSetpoint}, 0 },
     { "FF SMOOTHNESS", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_ff_smooth_factor,     0,     75,   1  }   , 0 },
+    { "FF JITTER",     OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_ff_jitter_factor,     0,     20,   1  }   , 0 },
 #endif
     { "FF BOOST",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_ff_boost,               0,     50,   1  }   , 0 },
     { "ANGLE STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleStrength,          0,    200,   1  }   , 0 },

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -61,7 +61,11 @@ typedef float (applyRatesFn)(const int axis, float rcCommandf, const float rcCom
 #ifdef USE_INTERPOLATED_SP
 // Setpoint in degrees/sec before RC-Smoothing is applied
 static float rawSetpoint[XYZ_AXIS_COUNT];
+static float oldRcCommand[XYZ_AXIS_COUNT];
+static bool isDuplicate[XYZ_AXIS_COUNT];
+float rcCommandDelta[XYZ_AXIS_COUNT];
 #endif
+
 static float setpointRate[3], rcDeflection[3], rcDeflectionAbs[3];
 static float throttlePIDAttenuation;
 static bool reverseMotors = false;
@@ -130,6 +134,11 @@ float getThrottlePIDAttenuation(void)
 float getRawSetpoint(int axis)
 {
     return rawSetpoint[axis];
+}
+
+float getRcCommandDelta(int axis)
+{
+    return rcCommandDelta[axis];
 }
 
 #endif
@@ -636,6 +645,9 @@ FAST_CODE void processRcCommand(void)
 #ifdef USE_INTERPOLATED_SP
     if (isRxDataNew) {
         for (int i = FD_ROLL; i <= FD_YAW; i++) {
+            isDuplicate[i] = (oldRcCommand[i] == rcCommand[i]);
+            rcCommandDelta[i] = fabsf(rcCommand[i] - oldRcCommand[i]);
+            oldRcCommand[i] = rcCommand[i];
             float rcCommandf;
             if (i == FD_YAW) {
                 rcCommandf = rcCommand[i] / rcCommandYawDivider;

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -51,6 +51,7 @@ rcSmoothingFilter_t *getRcSmoothingData(void);
 bool rcSmoothingAutoCalculate(void);
 bool rcSmoothingInitializationComplete(void);
 float getRawSetpoint(int axis);
+float getRcCommandDelta(int axis);
 float applyCurve(int axis, float deflection);
 bool getShouldUpdateFf();
 void updateRcRefreshRate(timeUs_t currentTimeUs);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -205,7 +205,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dyn_idle_max_increase = 150,
         .ff_interpolate_sp = FF_INTERPOLATE_ON,
         .ff_max_rate_limit = 100,
-        .ff_smooth_factor = 0,
+        .ff_smooth_factor = 37,
+        .ff_jitter_factor = 7,
         .ff_boost = 15,
         .dyn_lpf_curve_expo = 5,
         .level_race_mode = false,
@@ -265,6 +266,11 @@ float pidGetFfBoostFactor()
 float pidGetFfSmoothFactor()
 {
     return pidRuntime.ffSmoothFactor;
+}
+
+float pidGetFfJitterFactor()
+{
+    return pidRuntime.ffJitterFactor;
 }
 #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -210,6 +210,7 @@ typedef struct pidProfile_s {
     uint8_t ff_interpolate_sp;              // Calculate FF from interpolated setpoint
     uint8_t ff_max_rate_limit;              // Maximum setpoint rate percentage for FF
     uint8_t ff_smooth_factor;               // Amount of smoothing for interpolated FF steps
+    uint8_t ff_jitter_factor;               // Number of RC steps below which to attenuate FF
     uint8_t dyn_lpf_curve_expo;             // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calcualtion is gyro based in level mode
     uint8_t vbat_sag_compensation;          // Reduce motor output by this percentage of the maximum compensation amount
@@ -385,6 +386,7 @@ typedef struct pidRuntime_s {
 #ifdef USE_INTERPOLATED_SP
     ffInterpolationType_t ffFromInterpolatedSetpoint;
     float ffSmoothFactor;
+    float ffJitterFactor;
 #endif
 } pidRuntime_t;
 
@@ -439,4 +441,5 @@ float pidGetDT();
 float pidGetPidFrequency();
 float pidGetFfBoostFactor();
 float pidGetFfSmoothFactor();
+float pidGetFfJitterFactor();
 float dynLpfCutoffFreq(float throttle, uint16_t dynLpfMin, uint16_t dynLpfMax, uint8_t expo);

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -392,6 +392,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
         // set automatically according to boost amount, limit to 0.5 for auto
         pidRuntime.ffSmoothFactor = MAX(0.5f, 1.0f - ((float)pidProfile->ff_boost) * 2.0f / 100.0f);
     }
+    pidRuntime.ffJitterFactor = pidProfile->ff_jitter_factor;
     interpolatedSpInit(pidProfile);
 #endif
 


### PR DESCRIPTION
This is a very big improvement to feed forward, reducing jitter and improving duplicate packet handling.

It is primarily intended to address jitter in the feed forward signal, especially at slow rates of stick movement.  This is a particular issue with 250hz radio links, which have frequent duplicates and significant jitter from inadequate sampling resolution, but also affects people with tremor, poor gimbals and so on.

There is a new feed forward jitter reduction value in the CLI - `ff_jitter_reduction`.  Default is 7.  

When the average of the most recent two RC packet differences are under this threshold, and duplicate interpolation and feed forward boost will be attenuated.  The greatest attenuation will be applied to the smallest steps, in a non-linear fashion.  

The changes include: 

- when a duplicate appears, the 'gap' in setpoint is fixed by interpolating forward from the previous setpoint value, considering previous derivative and acceleration.  The new setpoint data is not currently sent back to rc.c to fix setpoint itself, but this could be done in future.  The feed forward values are then simply calculated from the newly derived interpolated setpoint.

- The average value of the current and previous RC packet derivatives (ie, the average recent rate of change in RC command) is used to attenuate the feed forward boost component, and attenuate the aggressiveness of the duplicate interpolation when sticks are moving slowly.  This markedly reduces the exaggeration due to interpolating jitter to cover duplicates that often occur at low stick rates, and to reduce boost generally at low stick rates.
 
 - changed the debugs to display the newly calculated interpolated setpoint line, and to show the actual rcCommand delta values.  The duplicate counter debug is removed and replaced with the rcCommand delta values.

These changes have two primary benefits.

- significantly improves signal to noise ratio in feed forward due to jitter and duplicate packets at low rates of stick movement, especially at higher Rx packet rates, eg 250hz or higher.

- provides a kind of alternative to feed forward transition, for freestyle pilots.  Feed forward is overall attenuated whenever the sticks are moving slowly - not just at centre.  Any smooth arc or steady flying will experience reduced feed forward jitter, but as soon as the sticks are moved, feed forward will operate normally.  Pilots may be able to use feed forward and boost for active freestyle moves, but not have the excess twitchiness that it otherwise would cause while flying smooth arcs (even tight smooth arcs) or straight smooth flying.  

- the debugs show the actual newly interpolated setpoint.  The result is good enough to consider moving the code to rc.c and actually interpolating duplicates in setpoint there.

The `ff_interpolated` debug parameters are as follows:
 
| value | meaning |
| ----- | ------ |
| 0 | packet to packet setpoint derivative, incorporating interpolation, attenuation and smoothing |
| 1 | boost amount, after attenuation and smoothing |
| 2 | new setpoint values |
| 3 | rcCommand delta|
