### PR TITLE
Remove Dynamic Notch from "Features"

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -265,7 +265,7 @@ static const char * const featureNames[] = {
     "RANGEFINDER", "TELEMETRY", "", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "OSD",
     "", "CHANNEL_FORWARDING", "TRANSPONDER", "AIRMODE",
-    "", "", "RX_SPI", "", "ESC_SENSOR", "ANTI_GRAVITY", "DYNAMIC_FILTER", NULL
+    "", "", "RX_SPI", "", "ESC_SENSOR", "ANTI_GRAVITY", "", NULL
 };
 
 // sync this with rxFailsafeChannelMode_e

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -662,7 +662,7 @@ const clivalue_t valueTable[] = {
     { "gyro_to_use",                VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_to_use) },
 #endif
 #if defined(USE_DYN_NOTCH_FILTER)
-    { "dyn_notch_count",            VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 1, DYN_NOTCH_COUNT_MAX }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_count) },
+    { "dyn_notch_count",            VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, DYN_NOTCH_COUNT_MAX }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_count) },
     { "dyn_notch_q",                VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 1000 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_q) },
     { "dyn_notch_min_hz",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 60, 250 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_min_hz) },
     { "dyn_notch_max_hz",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 200, 1000 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_max_hz) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -827,10 +827,10 @@ static const OSD_Entry cmsx_menuDynFiltEntries[] =
     { "-- DYN FILT --", OME_Label, NULL, NULL, 0 },
 
 #ifdef USE_DYN_NOTCH_FILTER
-    { "NOTCH COUNT",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &dynFiltNotchCount,   1, DYN_NOTCH_COUNT_MAX, 1 }, 0 },
+    { "NOTCH COUNT",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &dynFiltNotchCount,   0, DYN_NOTCH_COUNT_MAX, 1 }, 0 },
     { "NOTCH Q",        OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchQ,       1, 1000, 1 }, 0 },
-    { "NOTCH MIN HZ",   OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchMinHz,   0, 1000, 1 }, 0 },
-    { "NOTCH MAX HZ",   OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchMaxHz,   0, 1000, 1 }, 0 },
+    { "NOTCH MIN HZ",   OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchMinHz,   60, 250, 1 }, 0 },
+    { "NOTCH MAX HZ",   OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchMaxHz,   200, 1000, 1 }, 0 },
 #endif
 
 #ifdef USE_DYN_LPF

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -102,8 +102,6 @@ pidProfile_t *currentPidProfile;
 #define RX_SPI_DEFAULT_PROTOCOL 0
 #endif
 
-#define DYNAMIC_FILTER_MAX_SUPPORTED_LOOP_TIME HZ_TO_INTERVAL_US(2000)
-
 PG_REGISTER_WITH_RESET_TEMPLATE(pilotConfig_t, pilotConfig, PG_PILOT_CONFIG, 1);
 
 PG_RESET_TEMPLATE(pilotConfig_t, pilotConfig,
@@ -466,10 +464,6 @@ static void validateAndFixConfig(void)
     featureDisableImmediate(FEATURE_ESC_SENSOR);
 #endif
 
-#ifndef USE_DYN_NOTCH_FILTER
-    featureDisableImmediate(FEATURE_DYNAMIC_FILTER);
-#endif
-
 #if !defined(USE_ADC)
     featureDisableImmediate(FEATURE_RSSI_ADC);
 #endif
@@ -681,14 +675,6 @@ void validateAndFixGyroConfig(void)
             }
         }
     }
-
-#ifdef USE_DYN_NOTCH_FILTER
-    // Disable dynamic filter if gyro loop is less than 2KHz
-    const uint32_t configuredLooptime = (gyro.sampleRateHz > 0) ? (pidConfig()->pid_process_denom * 1e6 / gyro.sampleRateHz) : 0;
-    if (configuredLooptime > DYNAMIC_FILTER_MAX_SUPPORTED_LOOP_TIME) {
-        featureDisableImmediate(FEATURE_DYNAMIC_FILTER);
-    }
-#endif
 
 #ifdef USE_BLACKBOX
 #ifndef USE_FLASHFS

--- a/src/main/config/feature.c
+++ b/src/main/config/feature.c
@@ -29,10 +29,10 @@
 #include "pg/pg_ids.h"
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(featureConfig_t, featureConfig, PG_FEATURE_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(featureConfig_t, featureConfig, PG_FEATURE_CONFIG, 1);
 
 PG_RESET_TEMPLATE(featureConfig_t, featureConfig,
-    .enabledFeatures = DEFAULT_FEATURES | DEFAULT_RX_FEATURE | FEATURE_DYNAMIC_FILTER | FEATURE_ANTI_GRAVITY | FEATURE_AIRMODE,
+    .enabledFeatures = DEFAULT_FEATURES | DEFAULT_RX_FEATURE | FEATURE_ANTI_GRAVITY | FEATURE_AIRMODE,
 );
 
 static uint32_t runtimeFeatureMask;

--- a/src/main/config/feature.h
+++ b/src/main/config/feature.h
@@ -53,7 +53,7 @@ typedef enum {
     //FEATURE_SOFTSPI = 1 << 26, (removed)
     FEATURE_ESC_SENSOR = 1 << 27,
     FEATURE_ANTI_GRAVITY = 1 << 28,
-    FEATURE_DYNAMIC_FILTER = 1 << 29,
+    //FEATURE_DYNAMIC_FILTER = 1 << 29, (removed)
 } features_e;
 
 typedef struct featureConfig_s {

--- a/src/main/flight/dyn_notch_filter.h
+++ b/src/main/flight/dyn_notch_filter.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <stdbool.h>
 
 #include "common/time.h"
 
@@ -32,6 +32,6 @@ void dynNotchInit(const dynNotchConfig_t *config, const timeUs_t targetLooptimeU
 void dynNotchPush(const int axis, const float sample);
 void dynNotchUpdate(void);
 float dynNotchFilter(const int axis, float value);
-bool isDynamicFilterActive(void);
-uint16_t getMaxFFT(void);
+bool isDynNotchActive(void);
+int getMaxFFT(void);
 void resetMaxFFT(void);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -827,7 +827,7 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
 
 #if defined(USE_DYN_NOTCH_FILTER)
     case OSD_STAT_MAX_FFT:
-        if (featureIsEnabled(FEATURE_DYNAMIC_FILTER)) {
+        if (isDynNotchActive()) {
             int value = getMaxFFT();
             if (value > 0) {
                 tfp_sprintf(buff, "%dHZ", value);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -473,7 +473,7 @@ FAST_CODE void gyroFiltering(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_DYN_NOTCH_FILTER
-    if (isDynamicFilterActive()) {
+    if (isDynNotchActive()) {
         dynNotchUpdate();
     }
 #endif

--- a/src/main/sensors/gyro_filter_impl.c
+++ b/src/main/sensors/gyro_filter_impl.c
@@ -65,7 +65,7 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(void)
         GYRO_FILTER_AXIS_DEBUG_SET(axis, DEBUG_GYRO_SAMPLE, 3, lrintf(gyroADCf));
 
 #ifdef USE_DYN_NOTCH_FILTER
-        if (isDynamicFilterActive()) {
+        if (isDynNotchActive()) {
             if (axis == gyro.gyroDebugAxis) {
                 GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 0, lrintf(gyroADCf));
                 GYRO_FILTER_DEBUG_SET(DEBUG_FFT_FREQ, 3, lrintf(gyroADCf));

--- a/src/main/target/ALIENWHOOP/config.c
+++ b/src/main/target/ALIENWHOOP/config.c
@@ -103,7 +103,7 @@ void targetConfiguration(void)
 
     pidConfigMutable()->runaway_takeoff_prevention = false;
 
-    featureConfigSet((FEATURE_DYNAMIC_FILTER | FEATURE_AIRMODE | FEATURE_ANTI_GRAVITY) ^ FEATURE_RX_PARALLEL_PWM);
+    featureConfigSet((FEATURE_AIRMODE | FEATURE_ANTI_GRAVITY) ^ FEATURE_RX_PARALLEL_PWM);
 
     /* AlienWhoop PIDs tested with 6mm and 7mm motors on most frames */
     for (uint8_t pidProfileIndex = 0; pidProfileIndex < PID_PROFILE_COUNT; pidProfileIndex++) {


### PR DESCRIPTION
# General

This is the counterpart to PR https://github.com/betaflight/betaflight-configurator/pull/2653

- **Removed Dynamic Notch from features**
Now we can get rid of the "DYNAMIC_FILTER" switch in the "Configuration" tab of the configurator. Instead we can now introduce an on/off switch in the filters tab, so finally all filters can be enabled and disabled from this tab alone.

- **Dynamic Notch can be enabled / disabled on the fly**
I expanded the minimal possible value for `dyn_notch_count` to `0` and disabled updating the dynamic notch in case `dyn_notch_count == 0`.
We can now turn the dynamic notch on and off on the fly by setting an appropriate `dyn_notch_count` value.

- **Little fix for the OSD menu**
I corrected the limits for `NOTCH MIN HZ` and `NOTCH MAX HZ` to the appropriate ones.

# Preview

![features](https://user-images.githubusercontent.com/19867640/144315983-93352e6a-1761-4a76-b615-7c3c787878a2.png)

![dynNotchSwitch](https://user-images.githubusercontent.com/19867640/144316021-ca2b50d6-ece0-4015-afcf-82a82e512467.png)