### PR TITLE
Fix infinite loop in SD card initialisation failure when CONFIG_IN_SDCARD is used.

### DIFF
--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -45,7 +45,17 @@ void pgResetFn_sdcardConfig(sdcardConfig_t *config)
     // On generic targets, SPI has precedence over SDIO; SDIO must be post-flash configured.
     config->useDma = false;
     config->device = SPI_DEV_TO_CFG(SPIINVALID);
+
+#ifdef CONFIG_IN_SDCARD
+    // CONFIG_ID_SDDCARD requires a default mode.
+#if defined(USE_SDCARD_SDIO)
+    config->mode = SDCARD_MODE_SDIO;
+#elif defined(USE_SDCARD_SPI)
+    config->mode = SDCARD_MODE_SPI;
+#endif
+#else
     config->mode = SDCARD_MODE_NONE;
+#endif
 
 #ifdef USE_SDCARD_SPI
     // These settings do not work for Unified Targets


### PR DESCRIPTION
Caused by there being no default for the SDCard config resulting in an empty sdcard vtable.
