### PR TITLE
Small doc enhancements

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -175,6 +175,16 @@ amperage_meter_scale = (Imax - Imin) * 100000 / (Tmax + (Tmax * Tmax / 50))
                     = 205
 amperage_meter_offset = Imin * 100 = 280
 ```
+Measuring Imax requires a battery and an ESC that can both deliver and support max current for the duration of the measurement, so it's prone to big inaccuracies. Alternatively, current can be measured at a much lower throttle position and be taken into account in the calculations.
+
+Following the previous example, if we measured an Ibench current of 6A at 30% of throttle (1255 in the motors tab because (0.3*(max_throttle-1000))+1000))
+```
+Tbench = Tmax * bench_throttle = 850 * 0.3 = 255
+amperage_meter_scale = (Ibench - Imin) * 100000 / (Tbench + (Tbench * Tbench / 50))
+                    = (6 - 2.8) * 100000 / (255 + (255 * 255 / 50))
+                    = 205
+amperage_meter_offset = Imin * 100 = 280
+```
 #### Tuning Using Battery Charger Measurement
 If you cannot measure current draw directly, you can approximate it indirectly using your battery charger.  
 However, note it may be difficult to adjust `amperage_meter_offset` using this method unless you can 

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -191,7 +191,7 @@ void currentMeterVirtualRefresh(int32_t lastUpdateAt, bool armed, bool throttleL
             throttleOffset = 0;
         }
 
-        int throttleFactor = throttleOffset + (throttleOffset * throttleOffset / 50); // FIXME magic number 50,  50hz?
+        int throttleFactor = throttleOffset + (throttleOffset * throttleOffset / 50); // FIXME magic number 50. Possibly use thrustLinearization if configured.
         currentMeterVirtualState.amperage += throttleFactor * (int32_t)currentSensorVirtualConfig()->scale / 1000;
     }
     updateCurrentmAhDrawnState(&currentMeterVirtualState.mahDrawnState, currentMeterVirtualState.amperage, lastUpdateAt);


### PR DESCRIPTION
While trying to calibrate the virtual current sensor following the example at Battery.md, I found that my Imax measure was very inaccurate and this was resulting in a very bad calibration. So I did a measure at a much smaller throttle and then the calibration turned out to be as good as one could expect. Then I thought it would be good to update the docs to include this option as a suggestion. Also I clarified the comment regarding the magic number in the code.

Note: it would be really useful to put this (very vaulable) Battery.md info on the BF wiki as well. Happy to do it myself if required.