### PR TITLE
add W25Q64JVXGIM flash support

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -89,7 +89,8 @@ struct {
     { 0xEF4016, 133, 50, 64, 256 },
     // Winbond W25Q64
     // Datasheet: https://www.winbond.com/resource-files/w25q64jv%20spi%20%20%20revc%2006032016%20kms.pdf
-    { 0xEF4017, 133, 50, 128, 256 },
+    { 0xEF4017, 133, 50, 128, 256 }, // W25Q64JV-IQ/JQ 
+    { 0xEF7017, 133, 50, 128, 256 }, // W25Q64JV-IM/JM*
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     { 0xEF4018, 104, 50, 256, 256 },


### PR DESCRIPTION
Add W25Q64JVXGIM flash support, it's basically the same as the W25Q64 in the code, just the device id difference.

here is the datasheet of W25Q64JV
https://www.winbond.com/resource-files/W25Q64JV%20RevK%2003102021%20Plus.pdf
![image](https://user-images.githubusercontent.com/1505751/114981044-f0279480-9ebf-11eb-8fd8-2ab74f634579.png)

Thanks