### PR TITLE
Cleaned up matrix rotation.

### DIFF
--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -186,19 +186,6 @@ float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float des
     return (a / b) + destFrom;
 }
 
-// Normalize a vector
-void normalizeV(struct fp_vector *src, struct fp_vector *dest)
-{
-    float length;
-
-    length = sqrtf(src->X * src->X + src->Y * src->Y + src->Z * src->Z);
-    if (length != 0) {
-        dest->X = src->X / length;
-        dest->Y = src->Y / length;
-        dest->Z = src->Z / length;
-    }
-}
-
 void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation)
 {
     float cosx, sinx, cosy, siny, cosz, sinz;
@@ -227,7 +214,7 @@ void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation)
     rotation->m[2][Z] = cosy * cosx;
 }
 
-FAST_CODE void applyRotation(float *v, fp_rotationMatrix_t *rotationMatrix)
+void applyMatrixRotation(float *v, fp_rotationMatrix_t *rotationMatrix)
 {
     struct fp_vector *vDest = (struct fp_vector *)v;
     struct fp_vector vTmp = *vDest;
@@ -235,18 +222,6 @@ FAST_CODE void applyRotation(float *v, fp_rotationMatrix_t *rotationMatrix)
     vDest->X = (rotationMatrix->m[0][X] * vTmp.X + rotationMatrix->m[1][X] * vTmp.Y + rotationMatrix->m[2][X] * vTmp.Z);
     vDest->Y = (rotationMatrix->m[0][Y] * vTmp.X + rotationMatrix->m[1][Y] * vTmp.Y + rotationMatrix->m[2][Y] * vTmp.Z);
     vDest->Z = (rotationMatrix->m[0][Z] * vTmp.X + rotationMatrix->m[1][Z] * vTmp.Y + rotationMatrix->m[2][Z] * vTmp.Z);
-}
-
-// Rotate a vector *v by the euler angles defined by the 3-vector *delta.
-void rotateV(struct fp_vector *v, fp_angles_t *delta)
-{
-    struct fp_vector v_tmp = *v;
-
-    fp_rotationMatrix_t rotationMatrix;
-
-    buildRotationMatrix(delta, &rotationMatrix);
-
-    applyRotation((float *)&v_tmp, &rotationMatrix);
 }
 
 // Quick median filter implementation

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -114,11 +114,8 @@ float degreesToRadians(int16_t degrees);
 int scaleRange(int x, int srcFrom, int srcTo, int destFrom, int destTo);
 float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float destTo);
 
-void normalizeV(struct fp_vector *src, struct fp_vector *dest);
-
-void rotateV(struct fp_vector *v, fp_angles_t *delta);
 void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation);
-void applyRotation(float *v, fp_rotationMatrix_t *rotationMatrix);
+void applyMatrixRotation(float *v, fp_rotationMatrix_t *rotationMatrix);
 
 int32_t quickMedianFilter3(int32_t * v);
 int32_t quickMedianFilter5(int32_t * v);

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -64,14 +64,14 @@ void initBoardAlignment(const boardAlignment_t *boardAlignment)
     buildRotationMatrix(&rotationAngles, &boardRotation);
 }
 
-static FAST_CODE void alignBoard(float *vec)
+static void alignBoard(float *vec)
 {
-    applyRotation(vec, &boardRotation);
+    applyMatrixRotation(vec, &boardRotation);
 }
 
 FAST_CODE_NOINLINE void alignSensorViaMatrix(float *dest, fp_rotationMatrix_t* sensorRotationMatrix)
 {
-    applyRotation(dest, sensorRotationMatrix);
+    applyMatrixRotation(dest, sensorRotationMatrix);
 
     if (!standardBoardAlignment) {
         alignBoard(dest);

--- a/src/test/unit/maths_unittest.cc
+++ b/src/test/unit/maths_unittest.cc
@@ -202,29 +202,6 @@ void expectVectorsAreEqual(struct fp_vector *a, struct fp_vector *b, float absTo
     EXPECT_NEAR(a->Z, b->Z, absTol);
 }
 
-TEST(MathsUnittest, TestRotateVectorWithNoAngle)
-{
-    fp_vector vector = {1.0f, 0.0f, 0.0f};
-    fp_angles_t euler_angles = {.raw={0.0f, 0.0f, 0.0f}};
-
-    rotateV(&vector, &euler_angles);
-    fp_vector expected_result = {1.0f, 0.0f, 0.0f};
-
-    expectVectorsAreEqual(&vector, &expected_result, 1e-5);
-}
-
-TEST(MathsUnittest, TestRotateVectorAroundAxis)
-{
-    // Rotate a vector <1, 0, 0> around an each axis x y and z.
-    fp_vector vector = {1.0f, 0.0f, 0.0f};
-    fp_angles_t euler_angles = {.raw={90.0f, 0.0f, 0.0f}};
-
-    rotateV(&vector, &euler_angles);
-    fp_vector expected_result = {1.0f, 0.0f, 0.0f};
-
-    expectVectorsAreEqual(&vector, &expected_result, 1e-5);
-}
-
 #if defined(FAST_MATH) || defined(VERY_FAST_MATH)
 TEST(MathsUnittest, TestFastTrigonometrySinCos)
 {


### PR DESCRIPTION
This is mostly about removing the use of `FAST_CODE` from `src/main/commont/maths.c` to avoid auxiliary functions from being inlined.
Also removed some unused functions from maths.c.