### PR TITLE
Added MCU id / name for STM32G474.

### DIFF
--- a/src/main/build/build_config.c
+++ b/src/main/build/build_config.c
@@ -76,6 +76,8 @@ mcuTypeId_e getMcuTypeId(void)
     return MCU_TYPE_H7A3;
 #elif defined(STM32H723xx) || defined(STM32H725xx)
     return MCU_TYPE_H723_725;
+#elif defined(STM32G474xx)
+    return MCU_TYPE_G474;
 #else
     return MCU_TYPE_UNKNOWN;
 #endif

--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -59,6 +59,7 @@ typedef enum {
     MCU_TYPE_H743_REV_V,
     MCU_TYPE_H7A3,
     MCU_TYPE_H723_725,
+    MCU_TYPE_G474,
     MCU_TYPE_UNKNOWN = 255,
 } mcuTypeId_e;
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -308,6 +308,7 @@ static const char *mcuTypeNames[] = {
     "H743 (Rev.V)",
     "H7A3",
     "H723/H725",
+    "G474",
 };
 
 static const char *configurationStates[] = { "UNCONFIGURED", "CUSTOM DEFAULTS", "CONFIGURED" };
@@ -4664,7 +4665,7 @@ STATIC_UNIT_TESTED void cliSet(const char *cmdName, char *cmdline)
     }
 }
 
-const char *getMcuTypeById(mcuTypeId_e id)
+static const char *getMcuTypeById(mcuTypeId_e id)
 {
     if (id < MCU_TYPE_UNKNOWN) {
         return mcuTypeNames[id];


### PR DESCRIPTION
Looks like this was forgotten when G4 support was added.