### PR TITLE
fix for msp to cleanly remove rc smoothing filter types

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1505,8 +1505,10 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, rxConfig()->rc_smoothing_type);
         sbufWriteU8(dst, rxConfig()->rc_smoothing_input_cutoff);
         sbufWriteU8(dst, rxConfig()->rc_smoothing_derivative_cutoff);
-        sbufWriteU8(dst, rxConfig()->rc_smoothing_input_type);
-        sbufWriteU8(dst, rxConfig()->rc_smoothing_derivative_type);
+        // was used for rc_smoothing_input_type, not required in 4.3
+        sbufWriteU8(dst, 0);
+        // was used for rc_smoothing_derivative_type, not required in 4.3
+        sbufWriteU8(dst, 0);
 #else
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
@@ -3259,8 +3261,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             configRebootUpdateCheckU8(&rxConfigMutable()->rc_smoothing_type, sbufReadU8(src));
             configRebootUpdateCheckU8(&rxConfigMutable()->rc_smoothing_input_cutoff, sbufReadU8(src));
             configRebootUpdateCheckU8(&rxConfigMutable()->rc_smoothing_derivative_cutoff, sbufReadU8(src));
-            configRebootUpdateCheckU8(&rxConfigMutable()->rc_smoothing_input_type, sbufReadU8(src));
-            configRebootUpdateCheckU8(&rxConfigMutable()->rc_smoothing_derivative_type, sbufReadU8(src));
+            // was used for rc_smoothing_input_type, not required in 4.3
+            sbufReadU8(src);
+            // was used for rc_smoothing_derivative_type, not required in 4.3
+            sbufReadU8(src);
 #else
             sbufReadU8(src);
             sbufReadU8(src);

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -57,8 +57,6 @@ typedef struct rxConfig_s {
     uint8_t rc_smoothing_input_cutoff;      // Filter cutoff frequency for the input filter (0 = auto)
     uint8_t rc_smoothing_derivative_cutoff; // Filter cutoff frequency for the setpoint weight derivative filter (0 = auto)
     uint8_t rc_smoothing_debug_axis;        // Axis to log as debug values when debug_mode = RC_SMOOTHING
-    uint8_t rc_smoothing_input_type;        // Input filter type (0 = PT1, 1 = BIQUAD)
-    uint8_t rc_smoothing_derivative_type;   // Derivative filter type (0 = OFF, 1 = PT1, 2 = BIQUAD)
     uint8_t rc_smoothing_auto_factor;       // Used to adjust the "smoothness" determined by the auto cutoff calculations
     uint8_t rssi_src_frame_lpf_period;      // Period of the cutoff frequency for the source frame RSSI filter (in 0.1 s)
 


### PR DESCRIPTION
In #10650 I failed to fully remove the rc smoothing filter types parameters, `rc_smoothing_input_type` and `rc_smoothing_derivative_type`.
This PR removes them fully and updates msp accordingly.
My apologies for not getting it right first time.