### PR TITLE
Fix STM32G474 RAM overflow

### DIFF
--- a/src/link/stm32_flash_g474.ld
+++ b/src/link/stm32_flash_g474.ld
@@ -20,9 +20,14 @@ MEMORY
 
 
     SYSTEM_MEMORY (r) : ORIGIN = 0x1FFF0000, LENGTH = 64K
-
-    RAM (xrw)         : ORIGIN = 0x20000000, LENGTH = 96K
-    CCM (xrw)         : ORIGIN = 0x20018000, LENGTH = 32K
+/* Below are the true lengths for normal and close coupled RAM
+ *    RAM (xrw)         : ORIGIN = 0x20000000, LENGTH = 96K
+ *    CCM (xrw)         : ORIGIN = 0x20018000, LENGTH = 32K
+ * Allow normal RAM overflow to occupy start of CCM, and only reserve 2560 bytes for  vector table and stack in CCM
+ * CCM is aligned to a 512 byte boundary
+ */
+    RAM (xrw)         : ORIGIN = 0x20000000, LENGTH = 128512
+    CCM (xrw)         : ORIGIN = 0x2001F600, LENGTH = 2560
     MEMORY_B1 (rx)    : ORIGIN = 0x60000000, LENGTH = 0K
 }
 


### PR DESCRIPTION
STM32G474 has 96K of normal RAM and 32K or CCM (Core Coupled Memory). Fortunately as can be seen below, the CCM is mapped twice into memory, the second time immediately after  normal RAM making them contiguous.

> https://www.st.com/resource/en/reference_manual/dm00355726-stm32g4-series-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf
> ![image](https://user-images.githubusercontent.com/11480839/116743837-657f8300-a9f1-11eb-80e0-333a7ac9b71f.png)

Therefore we can allow normal RAM overflow to occupy the start of CCM. This fix extends RAM by 24K into CCM and only reserves 8K for explicitly requested CCM.