### PR TITLE
Crossfire RSNR used for RSSI calculation

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -234,15 +234,15 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
             //  41dB of SNR mapped to 99 RSSI (SNR can climb to around 60, but showing that is not very meaningful)
             const uint16_t rsnrPercentScaled = constrain((stats.uplink_SNR + 10) * 20, 0, RSSI_MAX_VALUE);
             setRssi(rsnrPercentScaled, RSSI_SOURCE_RX_PROTOCOL_CRSF);
+#ifdef USE_RX_RSSI_DBM
+            rssiDbm = stats.uplink_SNR;
+#endif
         } else {
             const uint16_t rssiPercentScaled = scaleRange(rssiDbm, CRSF_RSSI_MIN, 0, 0, RSSI_MAX_VALUE);
             setRssi(rssiPercentScaled, RSSI_SOURCE_RX_PROTOCOL_CRSF);
         }
     }
 #ifdef USE_RX_RSSI_DBM
-    if (rxConfig()->crsf_use_rx_snr) {
-        rssiDbm = stats.uplink_SNR;
-    }
     setRssiDbm(rssiDbm, RSSI_SOURCE_RX_PROTOCOL_CRSF);
 #endif
 


### PR DESCRIPTION
I think "crsf_use_rx_snr" should update both RSSI dBm and normal RSSI indicators based on RSNR.
TBS says Crossfire can receive signals down to -6dB. In my experience, I've been able to go close to -10dBm before fail safe. In any case, going below 0dB is really bad, so I've mapped it to 20 RSSI, which is the default alarm value.
