### PR TITLE
OSD Fix: show hyphen when no sats

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1058,7 +1058,7 @@ static void osdElementGpsCoordinate(osdElementParms_t *element)
 static void osdElementGpsSats(osdElementParms_t *element)
 {
     if (!gpsIsHealthy()) {
-        tfp_sprintf(element->buff, "%c%c%c", SYM_SAT_L, SYM_SAT_R, SYM_HYPHEN);
+        tfp_sprintf(element->buff, "%c%cNC", SYM_SAT_L, SYM_SAT_R);
     } else {
         int pos = tfp_sprintf(element->buff, "%c%c%2d", SYM_SAT_L, SYM_SAT_R, gpsSol.numSat);
         if (osdConfig()->gps_sats_show_hdop) { // add on the GPS module HDOP estimate

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1057,16 +1057,24 @@ static void osdElementGpsCoordinate(osdElementParms_t *element)
 
 static void osdElementGpsSats(osdElementParms_t *element)
 {
-    int pos = tfp_sprintf(element->buff, "%c%c%2d", SYM_SAT_L, SYM_SAT_R, gpsSol.numSat);
-    if (osdConfig()->gps_sats_show_hdop) { // add on the GPS module HDOP estimate
-        element->buff[pos++] = ' ';
-        osdPrintFloat(element->buff + pos, SYM_NONE, gpsSol.hdop / 100.0f, "", 1, true, SYM_NONE);
+    if (!gpsIsHealthy()) {
+        tfp_sprintf(element->buff, "%c%c%c", SYM_SAT_L, SYM_SAT_R, SYM_HYPHEN);
+    } else {
+        int pos = tfp_sprintf(element->buff, "%c%c%2d", SYM_SAT_L, SYM_SAT_R, gpsSol.numSat);
+        if (osdConfig()->gps_sats_show_hdop) { // add on the GPS module HDOP estimate
+            element->buff[pos++] = ' ';
+            osdPrintFloat(element->buff + pos, SYM_NONE, gpsSol.hdop / 100.0f, "", 1, true, SYM_NONE);
+        }
     }
 }
 
 static void osdElementGpsSpeed(osdElementParms_t *element)
 {
-    tfp_sprintf(element->buff, "%c%3d%c", SYM_SPEED, osdGetSpeedToSelectedUnit(gpsConfig()->gps_use_3d_speed ? gpsSol.speed3d : gpsSol.groundSpeed), osdGetSpeedToSelectedUnitSymbol());
+    if (STATE(GPS_FIX)) {
+        tfp_sprintf(element->buff, "%c%3d%c", SYM_SPEED, osdGetSpeedToSelectedUnit(gpsConfig()->gps_use_3d_speed ? gpsSol.speed3d : gpsSol.groundSpeed), osdGetSpeedToSelectedUnitSymbol());
+    } else {
+        tfp_sprintf(element->buff, "%c%c%c", SYM_SPEED, SYM_HYPHEN, osdGetSpeedToSelectedUnitSymbol());
+    }
 }
 
 static void osdElementEfficiency(osdElementParms_t *element)

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -445,6 +445,7 @@ extern "C" {
     bool areMotorsRunning(void){ return true; }
     bool pidOsdAntiGravityActive(void) { return false; }
     bool failsafeIsActive(void) { return false; }
+    bool gpsIsHealthy(void) { return true; }
     bool gpsRescueIsConfigured(void) { return false; }
     int8_t calculateThrottlePercent(void) { return 0; }
     uint32_t persistentObjectRead(persistentObjectId_e) { return 0; }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1242,6 +1242,7 @@ extern "C" {
     bool pidOsdAntiGravityActive(void) { return false; }
     bool failsafeIsActive(void) { return false; }
     bool gpsRescueIsConfigured(void) { return false; }
+    bool gpsIsHealthy(void) { return true; }
     int8_t calculateThrottlePercent(void) { return 0; }
     uint32_t persistentObjectRead(persistentObjectId_e) { return 0; }
     void persistentObjectWrite(persistentObjectId_e, uint32_t) {}

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1152,7 +1152,18 @@ TEST_F(OsdTest, TestGpsElements)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(2, 4, "%c%cNC", SYM_SAT_L, SYM_SAT_R);
+    // Sat indicator should blink and show "NC"
+    for (int i = 0; i < 15; i++) {
+        // Blinking should happen at 5Hz
+        simulationTime += 0.2e6;
+        osdRefresh(simulationTime);
+
+        if (i % 2 == 0) {
+            displayPortTestBufferSubstring(2, 4, "%c%cNC", SYM_SAT_L, SYM_SAT_R);
+        } else {
+            displayPortTestBufferIsEmpty();
+        }
+    }
 
     // when
     simulationGpsHealthy = true;
@@ -1162,7 +1173,18 @@ TEST_F(OsdTest, TestGpsElements)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(2, 4, "%c%c%2d", SYM_SAT_L, SYM_SAT_R, 0);
+    // Sat indicator should blink and show "0"
+    for (int i = 0; i < 15; i++) {
+        // Blinking should happen at 5Hz
+        simulationTime += 0.2e6;
+        osdRefresh(simulationTime);
+
+        if (i % 2 == 0) {
+            displayPortTestBufferSubstring(2, 4, "%c%c 0", SYM_SAT_L, SYM_SAT_R);
+        } else {
+            displayPortTestBufferIsEmpty();
+        }
+    }
 
     // when
     simulationGpsHealthy = true;
@@ -1172,8 +1194,14 @@ TEST_F(OsdTest, TestGpsElements)
     osdRefresh(simulationTime);
 
     // then
-    displayPortTestBufferSubstring(2, 4, "%c%c%2d", SYM_SAT_L, SYM_SAT_R, 10);
+    // Sat indicator should show "10" without flashing
+    for (int i = 0; i < 15; i++) {
+        // Blinking should happen at 5Hz
+        simulationTime += 0.2e6;
+        osdRefresh(simulationTime);
 
+        displayPortTestBufferSubstring(2, 4, "%c%c10", SYM_SAT_L, SYM_SAT_R);
+    }
 }
 
 // STUBS


### PR DESCRIPTION
When the serial communication with the GPS is affected, due to noise or bad contact, the OSD indicator for the number of satellites will show a '-' instead of a '0', so it's easy to tell when there has been a sat drop or a communication problem.
Other elements show a hyphen when there is no gps fix, but the Sats indicator is special as you want to see how sats are acquired before a fix is found.
Actually, the gps speed was missing the no gps fix check, and that's been fixed as well in this PR.