### PR TITLE
Prioritize pitmode on boot

### DIFF
--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -67,9 +67,9 @@ void pgResetFn_vtxSettingsConfig(vtxSettingsConfig_t *vtxSettingsConfig)
 }
 
 typedef enum {
-    VTX_PARAM_POWER = 0,
+    VTX_PARAM_PITMODE = 0,
     VTX_PARAM_BANDCHAN,
-    VTX_PARAM_PITMODE,
+    VTX_PARAM_POWER,
     VTX_PARAM_CONFIRM,
     VTX_PARAM_COUNT
 } vtxScheduleParams_e;


### PR DESCRIPTION
Fixes #10731

Changing the order of vtxScheduleParams_e to prioritise pitmode first minimises/removes a high power blip from the VTx before being place into pitmode.