### PR TITLE
Fix name clashes in FAT filesystem

### DIFF
--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -2615,8 +2615,18 @@ static void afatfs_createFileContinue(afatfsFile_t *file)
                                 opState->phase = AFATFS_CREATEFILE_PHASE_FAILURE;
                                 goto doMore;
                             }
+                        } else if (entry->attrib & FAT_FILE_ATTRIBUTE_VOLUME_ID) {
+                            break;
                         } else if (strncmp(entry->filename, (char*) opState->filename, FAT_FILENAME_LENGTH) == 0) {
-                            // We found a file with this name!
+                            // We found a file or directory with this name!
+
+                            // Do not open file as dir or dir as file
+                            if (((entry->attrib ^ file->attrib) & FAT_FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                                afatfs_findLast(&afatfs.currentDirectory);
+                                opState->phase = AFATFS_CREATEFILE_PHASE_FAILURE;
+                                goto doMore;
+                            }
+
                             afatfs_fileLoadDirectoryEntry(file, entry);
 
                             afatfs_findLast(&afatfs.currentDirectory);


### PR DESCRIPTION
Check attributes to resolve conflicts between identical names for directory volume label, subdirectories, and files.
- Skip directory volume label when searching for file or directory.
- Ensure directory entry type matches requested type (file or directory). Prevents opening existing "logs" file as a directory.

Ran across this issue when using a FC with on-board SD card for the first time.  Thought LOGS would be a good SD card volume name, but then no LOGS directory was created by blackbox.