### PR TITLE
Small filter efficiency improvements

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -34,8 +34,6 @@
 // Use floating point M_PI instead explicitly.
 #define M_PIf       3.14159265358979323846f
 #define M_EULERf    2.71828182845904523536f
-#define M_SQRT2f    1.41421356237309504880f
-#define M_LN2f      0.69314718055994530942f
 
 #define RAD    (M_PIf / 180.0f)
 #define DEGREES_TO_DECIDEGREES(angle) ((angle) * 10)


### PR DESCRIPTION
# Biquad filter
Restructured `biquadFilterInit()` and `biquadFilterUpdate()` functions for slightly more efficient updates. This is useful because `biquadFilterUpdate()` gets called several times per PID loop.

### CPU cycle improvements

CPU cycles | master | PR | diff | diff %
----- | ----- | ----- | ----- | -----
DYN NOTCH UPDATE | 1090 | 925 | -165 | -15.14%
RPM FILTER UPDATE | 1116 | 1080 | -36 | -3.23%

Btw. there might be more improvements to biquads I didn't measure. I just checked dyn notch and RPM filter update functions because I thought this is where the biggest improvements show up.

- - - - -

# PTn filter
Replaced PT2 and PT3 cutoff correction caluclation by constants. Also simplified corresponding comments. It should be clear where the constants are coming from. This change is very important for runtime efficiency as otherwise there needs to be an (unneeded) calculation for a square root and a power every time a PTn update function is called (could be called several times per loop).

#### Edit
No need to replace `sqrtf()` and `powf()` by hand. Turns out the compiler already optimizes `pt2FilterGain()` and `pt3FilterGain()` to the max, even though there are runtime functions involved.

**The compiler correctly recognizes referential transparency inside `sqrtf()` and `powf()` and replaces them with constants at compile time.**