### PR TITLE
Allow FlightMode telemetry to be disabled on CRSF

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -518,7 +518,9 @@ void initCrsfTelemetry(void)
         || (isAmperageConfigured() && telemetryIsSensorEnabled(SENSOR_CURRENT | SENSOR_FUEL))) {
         crsfSchedule[index++] = BV(CRSF_FRAME_BATTERY_SENSOR_INDEX);
     }
-    crsfSchedule[index++] = BV(CRSF_FRAME_FLIGHT_MODE_INDEX);
+    if (telemetryIsSensorEnabled(SENSOR_MODE)) {
+        crsfSchedule[index++] = BV(CRSF_FRAME_FLIGHT_MODE_INDEX);
+    }
 #ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)
        && telemetryIsSensorEnabled(SENSOR_ALTITUDE | SENSOR_LAT_LONG | SENSOR_GROUND_SPEED | SENSOR_HEADING)) {


### PR DESCRIPTION
The CRSF telemetry implementation currently allows users to disable all the different types of telemetry:
* Battery / current stats
* Attitude
* GPS

However it also includes a FlightMode telemetry item that can not be disabled. There is a betaflight flag for it already, it just doesn't check it before building its schedule. This small PR simply adds the check to disable it properly.

Tested on OMNIBUSF4SD target with Crossfire module and ExpressLRS module, both with `set telemetry_disabled_mode = ON` and `set telemetry_disabled_mode = OFF` and does just what you'd expect.

I've also checked #10675 (CRSF V3 Support) and it does not include this change, so this will benefit both the existing CRSF V2 and upcoming CRSF V3 systems.