### PR TITLE
New memory section types for DMA

### DIFF
--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -264,9 +264,7 @@ __ALIGN_BEGIN static uint8_t USBD_MSC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_
   * @}
   */
 
-
-// Buffer must be aligned for DMAs
-static DMA_RW_AXI USBD_MSC_BOT_HandleTypeDef ClassData __attribute__((aligned(32)));
+static DMA_DATA_ZERO_INIT USBD_MSC_BOT_HandleTypeDef ClassData;
 
 /** @defgroup MSC_CORE_Private_Functions
   * @{

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -192,6 +192,23 @@
 #define FAST_DATA
 #endif // USE_FAST_DATA
 
+#if defined(STM32F4)
+// F4 can't DMA to/from CCM (core coupled memory) SRAM (where the stack lives)
+#define DMA_DATA_ZERO_INIT
+#define DMA_DATA
+#define DMA_DATA_AUTO               static
+#elif defined (STM32F7)
+// F7 has no cache coherency issues DMAing to/from DTCM, otherwise buffers must be cache aligned
+#define DMA_DATA_ZERO_INIT          FAST_DATA_ZERO_INIT
+#define DMA_DATA                    FAST_DATA
+#define DMA_DATA_AUTO               static DMA_DATA
+#else
+// DMA to/from any memory
+#define DMA_DATA_ZERO_INIT          __attribute__ ((section(".dmaram_bss"), aligned(32)))
+#define DMA_DATA                    __attribute__ ((section(".dmaram_data"), aligned(32)))
+#define DMA_DATA_AUTO               static DMA_DATA
+#endif
+
 #if defined(STM32F4) || defined (STM32H7)
 // Data in RAM which is guaranteed to not be reset on hot reboot
 #define PERSISTENT                  __attribute__ ((section(".persistent_data"), aligned(4)))
@@ -199,8 +216,10 @@
 
 #ifdef USE_DMA_RAM
 #if defined(STM32H7)
-#define DMA_RAM __attribute__((section(".DMA_RAM")))
-#define DMA_RW_AXI __attribute__((section(".DMA_RW_AXI")))
+#define DMA_RAM __attribute__((section(".DMA_RAM"), aligned(32)))
+#define DMA_RW_AXI __attribute__((section(".DMA_RW_AXI"), aligned(32)))
+extern uint8_t _dmaram_start__;
+extern uint8_t _dmaram_end__;
 #elif defined(STM32G4)
 #define DMA_RAM_R __attribute__((section(".DMA_RAM_R")))
 #define DMA_RAM_W __attribute__((section(".DMA_RAM_W")))


### PR DESCRIPTION
In preparation for https://github.com/betaflight/betaflight/pull/10705 some new memory section type qualifiers are defined and the USB MSC driver uses this to ensure that SPI DMA reads from FLASH can be transferred into the data buffer for subsequent transfer over USB.