### PR TITLE
Separate LAND NOW OSD element (firmware part)

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1381,6 +1381,7 @@ const clivalue_t valueTable[] = {
     { "osd_power_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_POWER]) },
     { "osd_pidrate_profile_pos",    VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_PIDRATE_PROFILE]) },
     { "osd_warnings_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_WARNINGS]) },
+    { "osd_land_now_warning_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_LAND_NOW_WARNING]) },
     { "osd_avg_cell_voltage_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_AVG_CELL_VOLTAGE]) },
     { "osd_pit_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_PITCH_ANGLE]) },
     { "osd_rol_ang_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_ROLL_ANGLE]) },

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -161,6 +161,7 @@ typedef enum {
     OSD_TOTAL_FLIGHTS,
     OSD_UP_DOWN_REFERENCE,
     OSD_TX_UPLINK_POWER,
+    OSD_LAND_NOW_WARNING,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1466,6 +1466,17 @@ static void osdElementWarnings(osdElementParms_t *element)
     }
 }
 
+static void osdElementWarningLandNow(osdElementParms_t *element)
+{
+    bool elementBlinking = false;
+    renderOsdWarningLandNow(element->buff, &elementBlinking, &element->attr);
+    if (elementBlinking) {
+        SET_BLINK(OSD_LAND_NOW_WARNING);
+    } else {
+        CLR_BLINK(OSD_LAND_NOW_WARNING);
+    }
+}
+
 // Define the order in which the elements are drawn.
 // Elements positioned later in the list will overlay the earlier
 // ones if their character positions overlap
@@ -1548,6 +1559,7 @@ static const uint8_t osdElementDisplayOrder[] = {
 #ifdef USE_PERSISTENT_STATS
     OSD_TOTAL_FLIGHTS,
 #endif
+    OSD_LAND_NOW_WARNING,
 };
 
 // Define the mapping between the OSD element id and the function to draw it
@@ -1663,8 +1675,9 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
     [OSD_EFFICIENCY]              = osdElementEfficiency,
 #endif
 #ifdef USE_PERSISTENT_STATS
-    [OSD_TOTAL_FLIGHTS]   = osdElementTotalFlights,
+    [OSD_TOTAL_FLIGHTS]           = osdElementTotalFlights,
 #endif
+    [OSD_LAND_NOW_WARNING]        = osdElementWarningLandNow,
 };
 
 // Define the mapping between the OSD element id and the function to draw its background (static part)
@@ -1735,6 +1748,7 @@ void osdAddActiveElements(void)
 #ifdef USE_PERSISTENT_STATS
     osdAddActiveElement(OSD_TOTAL_FLIGHTS);
 #endif
+    osdAddActiveElement(OSD_LAND_NOW_WARNING);
 }
 
 static void osdDrawSingleElement(displayPort_t *osdDisplayPort, uint8_t item)

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -63,6 +63,20 @@
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
 
+bool renderOsdWarningLandNow(char *warningText, bool *blinking, uint8_t *displayAttr)
+{
+    const batteryState_e batteryState = getBatteryState();
+
+    if (osdWarnGetState(OSD_WARNING_BATTERY_CRITICAL) && batteryState == BATTERY_CRITICAL) {
+        tfp_sprintf(warningText, " LAND NOW");
+        *displayAttr = DISPLAYPORT_ATTR_CRITICAL;
+        *blinking = true;
+        return true;
+    }
+
+    return false;
+}
+
 void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 {
     const batteryState_e batteryState = getBatteryState();
@@ -188,10 +202,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     }
 #endif // USE_RX_LINK_QUALITY_INFO
 
-    if (osdWarnGetState(OSD_WARNING_BATTERY_CRITICAL) && batteryState == BATTERY_CRITICAL) {
-        tfp_sprintf(warningText, " LAND NOW");
-        *displayAttr = DISPLAYPORT_ATTR_CRITICAL;
-        *blinking = true;;
+    if (renderOsdWarningLandNow(warningText, blinking, displayAttr)) {
         return;
     }
 

--- a/src/main/osd/osd_warnings.h
+++ b/src/main/osd/osd_warnings.h
@@ -26,3 +26,4 @@
 STATIC_ASSERT(OSD_FORMAT_MESSAGE_BUFFER_SIZE <= OSD_ELEMENT_BUFFER_LENGTH, osd_warnings_size_exceeds_buffer_size);
 
 void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr);
+bool renderOsdWarningLandNow(char *warningText, bool *blinking, uint8_t *displayAttr);


### PR DESCRIPTION
By feature request #10667

A separate `LAND NOW` OSD element in addition to OSD warnings.

Configurator part PR:
https://github.com/betaflight/betaflight-configurator/pull/2492