### PR TITLE
Added resetting to defaults for individual parameter groups.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -679,9 +679,11 @@ static void backupPgConfig(const pgRegistry_t *pg)
     memcpy(pg->copy, pg->address, pg->size);
 }
 
-static void restorePgConfig(const pgRegistry_t *pg)
+static void restorePgConfig(const pgRegistry_t *pg, uint16_t notToRestoreGroupId)
 {
-    memcpy(pg->address, pg->copy, pg->size);
+    if (!notToRestoreGroupId || pgN(pg) != notToRestoreGroupId) {
+        memcpy(pg->address, pg->copy, pg->size);
+    }
 }
 
 static void backupConfigs(void)
@@ -690,7 +692,6 @@ static void backupConfigs(void)
         return;
     }
 
-    // make copies of configs to do differencing
     PG_FOREACH(pg) {
         backupPgConfig(pg);
     }
@@ -698,14 +699,14 @@ static void backupConfigs(void)
     configIsInCopy = true;
 }
 
-static void restoreConfigs(void)
+static void restoreConfigs(uint16_t notToRestoreGroupId)
 {
     if (!configIsInCopy) {
         return;
     }
 
     PG_FOREACH(pg) {
-        restorePgConfig(pg);
+        restorePgConfig(pg, notToRestoreGroupId);
     }
 
     configIsInCopy = false;
@@ -4325,6 +4326,7 @@ bool hasCustomDefaults(void)
 static void cliDefaults(const char *cmdName, char *cmdline)
 {
     bool saveConfigs = true;
+    uint16_t parameterGroupId = 0;
 #if defined(USE_CUSTOM_DEFAULTS)
     bool useCustomDefaults = true;
 #elif defined(USE_CUSTOM_DEFAULTS_ADDRESS)
@@ -4334,36 +4336,68 @@ static void cliDefaults(const char *cmdName, char *cmdline)
     }
 #endif
 
-    if (isEmpty(cmdline)) {
-    } else if (strncasecmp(cmdline, "nosave", 6) == 0) {
-        saveConfigs = false;
-#if defined(USE_CUSTOM_DEFAULTS)
-    } else if (strncasecmp(cmdline, "bare", 4) == 0) {
-        useCustomDefaults = false;
-    } else if (strncasecmp(cmdline, "show", 4) == 0) {
-        if (hasCustomDefaults()) {
-            char *customDefaultsPtr = customDefaultsStart;
-            while (customDefaultsHasNext(customDefaultsPtr)) {
-                if (*customDefaultsPtr != '\n') {
-                    cliPrintf("%c", *customDefaultsPtr++);
-                } else {
-                    cliPrintLinefeed();
-                    customDefaultsPtr++;
-                }
+    char *saveptr;
+    char* tok = strtok_r(cmdline, " ", &saveptr);
+    int index = 0;
+    bool expectParameterGroupId = false;
+    while (tok != NULL) {
+        if (expectParameterGroupId) {
+            parameterGroupId = atoi(tok);
+            expectParameterGroupId = false;
+
+            if (!parameterGroupId) {
+                cliShowParseError(cmdName);
+                
+                return;
             }
+        } else if (strcasestr(tok, "group_id")) {
+            expectParameterGroupId = true;
+        } else if (strcasestr(tok, "nosave")) {
+            saveConfigs = false;
+#if defined(USE_CUSTOM_DEFAULTS)
+        } else if (strcasestr(tok, "bare")) {
+            useCustomDefaults = false;
+        } else if (strcasestr(tok, "show")) {
+            if (index != 0) {
+                cliShowParseError(cmdName);
+            } else if (hasCustomDefaults()) {
+                char *customDefaultsPtr = customDefaultsStart;
+                while (customDefaultsHasNext(customDefaultsPtr)) {
+                    if (*customDefaultsPtr != '\n') {
+                        cliPrintf("%c", *customDefaultsPtr++);
+                    } else {
+                        cliPrintLinefeed();
+                        customDefaultsPtr++;
+                    }
+                }
+            } else {
+                cliPrintError(cmdName, "NO CUSTOM DEFAULTS FOUND");
+            }
+
+            return;
+#endif
         } else {
-            cliPrintError(cmdName, "NO CUSTOM DEFAULTS FOUND");
+            cliShowParseError(cmdName);
+
+            return;
         }
 
-        return;
-#endif
-    } else {
-        cliPrintError(cmdName, "INVALID OPTION");
+        index++;
+        tok = strtok_r(NULL, " ", &saveptr);
+    }
+
+    if (expectParameterGroupId) {
+        cliShowParseError(cmdName);
 
         return;
     }
 
-    cliPrintHashLine("resetting to defaults");
+    if (parameterGroupId) {
+        cliPrintLinef("\r\n# resetting group %d to defaults", parameterGroupId);
+        backupConfigs();
+    } else {
+        cliPrintHashLine("resetting to defaults");
+    }
 
     resetConfig();
 
@@ -4380,6 +4414,10 @@ static void cliDefaults(const char *cmdName, char *cmdline)
         cliProcessCustomDefaults(false);
     }
 #endif
+
+    if (parameterGroupId) {
+        restoreConfigs(parameterGroupId);
+    }
 
     if (saveConfigs && tryPrepareSave(cmdName)) {
         writeUnmodifiedConfigToEEPROM();
@@ -4442,7 +4480,7 @@ STATIC_UNIT_TESTED void cliGet(const char *cmdName, char *cmdline)
         }
     }
 
-    restoreConfigs();
+    restoreConfigs(0);
 
     pidProfileIndexToUse = CURRENT_PROFILE_INDEX;
     rateProfileIndexToUse = CURRENT_PROFILE_INDEX;
@@ -6325,7 +6363,7 @@ static void printConfig(const char *cmdName, char *cmdline, bool doDiff)
 #endif
 
     // restore configs from copies
-    restoreConfigs();
+    restoreConfigs(0);
 }
 
 static void cliDump(const char *cmdName, char *cmdline)
@@ -6430,9 +6468,9 @@ const clicmd_t cmdTable[] = {
         CLI_COMMAND_DEF("color", "configure colors", NULL, cliColor),
 #endif
 #if defined(USE_CUSTOM_DEFAULTS)
-    CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", "[nosave|bare|show]", cliDefaults),
+    CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", "{show} {nosave} {bare} {group_id <id>}", cliDefaults),
 #else
-    CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", "[nosave|show]", cliDefaults),
+    CLI_COMMAND_DEF("defaults", "reset to defaults and reboot", "{nosave}", cliDefaults),
 #endif
     CLI_COMMAND_DEF("diff", "list configuration changes from default", "[master|profile|rates|hardware|all] {defaults|bare}", cliDiff),
 #ifdef USE_RESOURCE_MGMT


### PR DESCRIPTION
This adds the capability to reset individual parameter groups to their defaults with `defaults group_id <id>` in CLI. It can be combined with other command options like `nosave` to allow multiple parameter groups to be reset before the configuration is saved.

This is intended as an improvement for the work being done in https://github.com/betaflight/firmware-presets/pull/11.


```
# diff

# version
# Betaflight / STM32F405 (S405) 4.3.0 May 23 2021 / 00:22:54 (norevision) MSP API: 1.44
# config: manufacturer_id: MTKS, board_name: MATEKF405SE, version: 42dd44a1, date: 2020-07-24T06:02:46Z

# start the command batch
batch start

board_name MATEKF405SE
manufacturer_id MTKS

# master
set baro_hardware = NONE
set cc2500_spi_chip_detect = OFF
set camera_control_mode = SOFTWARE_PWM
set gyro_1_align_yaw = 2700

profile 0

rateprofile 0

# end the command batch
batch end

# defaults group_id 522 nosave

# resetting group 522 to defaults

# defaults group_id 523 nosave

# resetting group 523 to defaults

# diff

# version
# Betaflight / STM32F405 (S405) 4.3.0 May 23 2021 / 00:22:54 (norevision) MSP API: 1.44
# config: manufacturer_id: MTKS, board_name: MATEKF405SE, version: 42dd44a1, date: 2020-07-24T06:02:46Z

# start the command batch
batch start

board_name MATEKF405SE
manufacturer_id MTKS

# master
set baro_hardware = NONE
set gyro_1_align_yaw = 2700

profile 0

rateprofile 0

# end the command batch
batch end
```

From `src/main/pg/pg_ids.h`:

```
#define PG_CAMERA_CONTROL_CONFIG 522
#define PG_RX_CC2500_SPI_CONFIG 523
```
