### PR TITLE
cli: fix baudrate reconfigure based on USB VCP baudrate

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1559,7 +1559,7 @@ static void cliSerialPassthrough(const char *cmdName, char *cmdline)
         cliPrintLine("Port1 baud rate change over USB enabled.");
         // Register the right side baud rate setting routine with the left side which allows setting of the UART
         // baud rate over USB without setting it using the serialpassthrough command
-        serialSetBaudRateCb(ports[0].port, serialSetBaudRate, ports[1].port);
+        serialSetBaudRateCb(ports[1].port, serialSetBaudRate, ports[0].port);
     }
 
     char *resetMessage = "";


### PR DESCRIPTION
Fixes the issue with automatic UART baud rate reconfiguration based on USB VCP baud rate when serial passthrough commanded using rate `0`. 
Problem was that code tries to reconfigure USB VCP baud rate instead of the passthrough target UART.