### PR TITLE
Fix the RESET_FORCED case not being used.

### DIFF
--- a/src/main/drivers/system_stm32h7xx.c
+++ b/src/main/drivers/system_stm32h7xx.c
@@ -110,10 +110,8 @@ void systemReset(void)
     NVIC_SystemReset();
 }
 
-void forcedSystemResetWithoutDisablingCaches(void)
+void systemResetWithoutDisablingCaches(void)
 {
-    // Don't overwrite the PERSISTENT_OBJECT_RESET_REASON; just make another attempt
-
     __disable_irq();
     NVIC_SystemReset();
 }
@@ -184,7 +182,8 @@ void systemCheckResetReason(void)
     case RESET_BOOTLOADER_POST:
         // Boot loader activity magically prevents SysTick from interrupting.
         // Issue a soft reset to prevent the condition.
-        forcedSystemResetWithoutDisablingCaches(); // observed that disabling dcache after cold boot with BOOT pin high causes segfault.
+        persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_FORCED);
+        systemResetWithoutDisablingCaches(); // observed that disabling dcache after cold boot with BOOT pin high causes segfault.
 
     case RESET_MSC_REQUEST:
     case RESET_NONE:

--- a/src/main/startup/system_stm32h7xx.c
+++ b/src/main/startup/system_stm32h7xx.c
@@ -69,7 +69,7 @@
 
 #include "build/debug.h"
 
-void forcedSystemResetWithoutDisablingCaches(void);
+void systemResetWithoutDisablingCaches(void);
 
 #if !defined  (HSE_VALUE)
 #define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
@@ -179,7 +179,7 @@ void HandleStuckSysTick(void)
     }
 
     if (tickStart == tickEnd) {
-        forcedSystemResetWithoutDisablingCaches();
+        systemResetWithoutDisablingCaches();
     }
 }
 
@@ -389,7 +389,7 @@ static void SystemClockHSE_Config(void)
 
 #ifdef USE_H7_HSE_TIMEOUT_WORKAROUND
     if (status == HAL_TIMEOUT) {
-        forcedSystemResetWithoutDisablingCaches(); // DC - sometimes HSERDY gets stuck, waiting longer doesn't help.
+        systemResetWithoutDisablingCaches(); // DC - sometimes HSERDY gets stuck, waiting longer doesn't help.
     }
 #endif
 


### PR DESCRIPTION
Fix the RESET_FORCED case not being used and not being able to correctly determine the reason for the reset when the reset is forced.

Before 31b06cd7d20bf93d3820a6e99ea70725c25b20b2 it was possible for early init code to overwrite the reset reason, however this commit also broke the code that allows the system, and developer, to determine the reason for the reset when the reset was forced.  It also left the `RESET_FORCED` unused, it was never set by the firmware.

This PR reinstates the `RESET_FORCED` reason, without re-introducing the issue of early init code needing resets and overwriting the reset reason.
