### PR TITLE
Dynamic notch changes

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1422,7 +1422,7 @@ static bool blackboxWriteSysinfo(void)
 #ifdef USE_GYRO_DATA_ANALYSE
         BLACKBOX_PRINT_HEADER_LINE("dyn_notch_max_hz", "%d",                gyroConfig()->dyn_notch_max_hz);
         BLACKBOX_PRINT_HEADER_LINE("dyn_notch_count", "%d",                 gyroConfig()->dyn_notch_count);
-        BLACKBOX_PRINT_HEADER_LINE("dyn_notch_bandwidth_hz", "%d",          gyroConfig()->dyn_notch_bandwidth_hz);
+        BLACKBOX_PRINT_HEADER_LINE("dyn_notch_q", "%d",                     gyroConfig()->dyn_notch_q);
         BLACKBOX_PRINT_HEADER_LINE("dyn_notch_min_hz", "%d",                gyroConfig()->dyn_notch_min_hz);
 #endif
 #ifdef USE_DSHOT_TELEMETRY

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -662,7 +662,7 @@ const clivalue_t valueTable[] = {
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
     { "dyn_notch_count",            VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 1, DYN_NOTCH_COUNT_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_count) },
-    { "dyn_notch_bandwidth_hz",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_bandwidth_hz) },
+    { "dyn_notch_q",                VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_q) },
     { "dyn_notch_min_hz",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 60, 250 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_min_hz) },
     { "dyn_notch_max_hz",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 200, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_max_hz) },
 #endif

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -757,7 +757,7 @@ static CMS_Menu cmsx_menuFilterGlobal = {
 #ifdef USE_GYRO_DATA_ANALYSE
 static uint16_t dynFiltNotchMaxHz;
 static uint8_t  dynFiltCount;
-static uint16_t dynFiltBandwidthHz;
+static uint16_t dynFiltNotchQ;
 static uint16_t dynFiltNotchMinHz;
 #endif
 #ifdef USE_DYN_LPF
@@ -776,7 +776,7 @@ static const void *cmsx_menuDynFilt_onEnter(displayPort_t *pDisp)
 #ifdef USE_GYRO_DATA_ANALYSE
     dynFiltNotchMaxHz   = gyroConfig()->dyn_notch_max_hz;
     dynFiltCount        = gyroConfig()->dyn_notch_count;
-    dynFiltBandwidthHz  = gyroConfig()->dyn_notch_bandwidth_hz;
+    dynFiltNotchQ       = gyroConfig()->dyn_notch_q;
     dynFiltNotchMinHz   = gyroConfig()->dyn_notch_min_hz;
 #endif
 #ifdef USE_DYN_LPF
@@ -800,7 +800,7 @@ static const void *cmsx_menuDynFilt_onExit(displayPort_t *pDisp, const OSD_Entry
 #ifdef USE_GYRO_DATA_ANALYSE
     gyroConfigMutable()->dyn_notch_max_hz        = dynFiltNotchMaxHz;
     gyroConfigMutable()->dyn_notch_count         = dynFiltCount;
-    gyroConfigMutable()->dyn_notch_bandwidth_hz  = dynFiltBandwidthHz;
+    gyroConfigMutable()->dyn_notch_q             = dynFiltNotchQ;
     gyroConfigMutable()->dyn_notch_min_hz        = dynFiltNotchMinHz;
 #endif
 #ifdef USE_DYN_LPF
@@ -822,7 +822,7 @@ static const OSD_Entry cmsx_menuDynFiltEntries[] =
 
 #ifdef USE_GYRO_DATA_ANALYSE
     { "NOTCH COUNT",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &dynFiltCount,        1, DYN_NOTCH_COUNT_MAX, 1 }, 0 },
-    { "NOTCH WIDTH HZ", OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltBandwidthHz,  1, 1000, 1 }, 0 },
+    { "NOTCH Q",        OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchQ,       1, 1000, 1 }, 0 },
     { "NOTCH MIN HZ",   OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchMinHz,   0, 1000, 1 }, 0 },
     { "NOTCH MAX HZ",   OME_UINT16, NULL, &(OSD_UINT16_t) { &dynFiltNotchMaxHz,   0, 1000, 1 }, 0 },
 #endif

--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -35,13 +35,13 @@ static FAST_DATA_ZERO_INIT complex_t twiddle[SDFT_BIN_COUNT];
 static void applySqrt(const sdft_t *sdft, float *data);
 
 
-void sdftInit(sdft_t *sdft, const uint8_t startBin, const uint8_t endBin, const uint8_t numBatches)
+void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numBatches)
 {
     if (!isInitialized) {
         rPowerN = powf(SDFT_R, SDFT_SAMPLE_SIZE);
         const float c = 2.0f * M_PIf / (float)SDFT_SAMPLE_SIZE;
         float phi = 0.0f;
-        for (uint8_t i = 0; i < SDFT_BIN_COUNT; i++) {
+        for (int i = 0; i < SDFT_BIN_COUNT; i++) {
             phi = c * i;
             twiddle[i] = SDFT_R * (cos_approx(phi) + _Complex_I * sin_approx(phi));
         }
@@ -54,47 +54,47 @@ void sdftInit(sdft_t *sdft, const uint8_t startBin, const uint8_t endBin, const 
     sdft->numBatches = numBatches;
     sdft->batchSize = (sdft->endBin - sdft->startBin + 1) / sdft->numBatches + 1;
 
-    for (uint8_t i = 0; i < SDFT_SAMPLE_SIZE; i++) {
+    for (int i = 0; i < SDFT_SAMPLE_SIZE; i++) {
         sdft->samples[i] = 0.0f;
     }
 
-    for (uint8_t i = 0; i < SDFT_BIN_COUNT; i++) {
+    for (int i = 0; i < SDFT_BIN_COUNT; i++) {
         sdft->data[i] = 0.0f;
     }
 }
 
 
 // Add new sample to frequency spectrum
-FAST_CODE void sdftPush(sdft_t *sdft, const float *sample)
+FAST_CODE void sdftPush(sdft_t *sdft, const float sample)
 {
-    const float delta = *sample - rPowerN * sdft->samples[sdft->idx];
+    const float delta = sample - rPowerN * sdft->samples[sdft->idx];
     
-    sdft->samples[sdft->idx] = *sample;
+    sdft->samples[sdft->idx] = sample;
     sdft->idx = (sdft->idx + 1) % SDFT_SAMPLE_SIZE;
 
-    for (uint8_t i = sdft->startBin; i <= sdft->endBin; i++) {
+    for (int i = sdft->startBin; i <= sdft->endBin; i++) {
         sdft->data[i] = twiddle[i] * (sdft->data[i] + delta);
     }
 }
 
 
 // Add new sample to frequency spectrum in parts
-FAST_CODE void sdftPushBatch(sdft_t* sdft, const float *sample, const uint8_t *batchIdx)
+FAST_CODE void sdftPushBatch(sdft_t* sdft, const float sample, const int batchIdx)
 {
-    const uint8_t batchStart = sdft->batchSize * *batchIdx;
-    uint8_t batchEnd = batchStart;
+    const int batchStart = sdft->batchSize * batchIdx;
+    int batchEnd = batchStart;
 
-    const float delta = *sample - rPowerN * sdft->samples[sdft->idx];
+    const float delta = sample - rPowerN * sdft->samples[sdft->idx];
 
-    if (*batchIdx == sdft->numBatches - 1) {
-        sdft->samples[sdft->idx] = *sample;
+    if (batchIdx == sdft->numBatches - 1) {
+        sdft->samples[sdft->idx] = sample;
         sdft->idx = (sdft->idx + 1) % SDFT_SAMPLE_SIZE;
         batchEnd += sdft->endBin - batchStart + 1;
     } else {
         batchEnd += sdft->batchSize;
     }
 
-    for (uint8_t i = batchStart; i < batchEnd; i++) {
+    for (int i = batchStart; i < batchEnd; i++) {
         sdft->data[i] = twiddle[i] * (sdft->data[i] + delta);
     }
 }
@@ -106,7 +106,7 @@ FAST_CODE void sdftMagSq(const sdft_t *sdft, float *output)
     float re;
     float im;
 
-    for (uint8_t i = sdft->startBin; i <= sdft->endBin; i++) {
+    for (int i = sdft->startBin; i <= sdft->endBin; i++) {
         re = crealf(sdft->data[i]);
         im = cimagf(sdft->data[i]);
         output[i] = re * re + im * im;
@@ -130,7 +130,7 @@ FAST_CODE void sdftWinSq(const sdft_t *sdft, float *output)
     float re;
     float im;
 
-    for (uint8_t i = (sdft->startBin + 1); i < sdft->endBin; i++) {
+    for (int i = (sdft->startBin + 1); i < sdft->endBin; i++) {
         val = sdft->data[i] - 0.5f * (sdft->data[i - 1] + sdft->data[i + 1]); // multiply by 2 to save one multiplication
         re = crealf(val);
         im = cimagf(val);
@@ -150,7 +150,7 @@ FAST_CODE void sdftWindow(const sdft_t *sdft, float *output)
 // Apply square root to the whole sdft range
 static FAST_CODE void applySqrt(const sdft_t *sdft, float *data)
 {
-    for (uint8_t i = sdft->startBin; i <= sdft->endBin; i++) {
+    for (int i = sdft->startBin; i <= sdft->endBin; i++) {
         data[i] = sqrtf(data[i]);
     }
 }

--- a/src/main/common/sdft.h
+++ b/src/main/common/sdft.h
@@ -33,11 +33,11 @@ typedef float complex complex_t; // Better readability for type "float complex"
 
 typedef struct sdft_s {
 
-    uint8_t idx;                       // circular buffer index
-    uint8_t startBin;
-    uint8_t endBin;
-    uint8_t batchSize;
-    uint8_t numBatches;
+    int idx;                           // circular buffer index
+    int startBin;
+    int endBin;
+    int batchSize;
+    int numBatches;
     float samples[SDFT_SAMPLE_SIZE];   // circular buffer
     complex_t data[SDFT_BIN_COUNT];    // complex frequency spectrum
 
@@ -45,9 +45,9 @@ typedef struct sdft_s {
 
 STATIC_ASSERT(SDFT_SAMPLE_SIZE <= (uint8_t)-1, window_size_greater_than_underlying_type);
 
-void sdftInit(sdft_t *sdft, const uint8_t startBin, const uint8_t endBin, const uint8_t numBatches);
-void sdftPush(sdft_t *sdft, const float *sample);
-void sdftPushBatch(sdft_t *sdft, const float *sample, const uint8_t *batchIdx);
+void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numBatches);
+void sdftPush(sdft_t *sdft, const float sample);
+void sdftPushBatch(sdft_t *sdft, const float sample, const int batchIdx);
 void sdftMagSq(const sdft_t *sdft, float *output);
 void sdftMagnitude(const sdft_t *sdft, float *output);
 void sdftWinSq(const sdft_t *sdft, float *output);

--- a/src/main/common/sdft.h
+++ b/src/main/common/sdft.h
@@ -43,8 +43,6 @@ typedef struct sdft_s {
 
 } sdft_t;
 
-STATIC_ASSERT(SDFT_SAMPLE_SIZE <= (uint8_t)-1, window_size_greater_than_underlying_type);
-
 void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numBatches);
 void sdftPush(sdft_t *sdft, const float sample);
 void sdftPushBatch(sdft_t *sdft, const float sample, const int batchIdx);

--- a/src/main/flight/gyroanalyse.c
+++ b/src/main/flight/gyroanalyse.c
@@ -113,7 +113,7 @@ static float FAST_DATA_ZERO_INIT      sdftMeanSq;
 static float FAST_DATA_ZERO_INIT      dynNotchQ;
 static float FAST_DATA_ZERO_INIT      dynNotchMinHz;
 static float FAST_DATA_ZERO_INIT      dynNotchMaxHz;
-static int FAST_DATA_ZERO_INIT        dynNotchMaxFFT;
+static uint16_t FAST_DATA_ZERO_INIT   dynNotchMaxFFT;
 static float FAST_DATA_ZERO_INIT      gain;
 static int FAST_DATA_ZERO_INIT        numSamples;
 
@@ -343,7 +343,7 @@ static FAST_CODE_NOINLINE void gyroDataAnalyseUpdate(gyroAnalyseState_t *state)
 }
 
 
-int getMaxFFT(void) {
+uint16_t getMaxFFT(void) {
     return dynNotchMaxFFT;
 }
 

--- a/src/main/flight/gyroanalyse.h
+++ b/src/main/flight/gyroanalyse.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include "common/axis.h"
+
 #define DYN_NOTCH_COUNT_MAX 5
 
 typedef struct gyroAnalyseState_s {
@@ -42,8 +46,8 @@ typedef struct gyroAnalyseState_s {
 
 } gyroAnalyseState_t;
 
-void gyroDataAnalyseInit(gyroAnalyseState_t *state, uint32_t targetLooptimeUs);
-void gyroDataAnalysePush(gyroAnalyseState_t *state, const uint8_t axis, const float sample);
+void gyroDataAnalyseInit(gyroAnalyseState_t *state, const uint32_t targetLooptimeUs);
+void gyroDataAnalysePush(gyroAnalyseState_t *state, const int axis, const float sample);
 void gyroDataAnalyse(gyroAnalyseState_t *state);
-uint16_t getMaxFFT(void);
+int getMaxFFT(void);
 void resetMaxFFT(void);

--- a/src/main/flight/gyroanalyse.h
+++ b/src/main/flight/gyroanalyse.h
@@ -49,5 +49,5 @@ typedef struct gyroAnalyseState_s {
 void gyroDataAnalyseInit(gyroAnalyseState_t *state, const uint32_t targetLooptimeUs);
 void gyroDataAnalysePush(gyroAnalyseState_t *state, const int axis, const float sample);
 void gyroDataAnalyse(gyroAnalyseState_t *state);
-int getMaxFFT(void);
+uint16_t getMaxFFT(void);
 void resetMaxFFT(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1780,7 +1780,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 #if defined(USE_GYRO_DATA_ANALYSE)
         sbufWriteU8(dst, 0);  // DEPRECATED 1.43: dyn_notch_range
         sbufWriteU8(dst, 0);  // DEPRECATED 1.44: dyn_notch_width_percent
-        sbufWriteU16(dst, 0); // DEPRECATED 1.44: dyn_notch_q
+        sbufWriteU16(dst, gyroConfig()->dyn_notch_q);
         sbufWriteU16(dst, gyroConfig()->dyn_notch_min_hz);
 #else
         sbufWriteU8(dst, 0);
@@ -1809,10 +1809,8 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
         sbufWriteU8(dst, gyroConfig()->dyn_notch_count);
-        sbufWriteU16(dst, gyroConfig()->dyn_notch_bandwidth_hz);
 #else
         sbufWriteU8(dst, 0);
-        sbufWriteU16(dst, 0);
 #endif
 
         break;
@@ -2656,7 +2654,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #if defined(USE_GYRO_DATA_ANALYSE)
             sbufReadU8(src); // DEPRECATED 1.43: dyn_notch_range
             sbufReadU8(src); // DEPRECATED 1.44: dyn_notch_width_percent
-            sbufReadU16(src); // DEPRECATED 1.44: dyn_notch_q
+            gyroConfigMutable()->dyn_notch_q = sbufReadU16(src);
             gyroConfigMutable()->dyn_notch_min_hz = sbufReadU16(src);
 #else
             sbufReadU8(src);
@@ -2680,7 +2678,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU16(src);
 #endif
         }
-        if (sbufBytesRemaining(src) >= 4) {
+        if (sbufBytesRemaining(src) >= 2) {
             // Added in MSP API 1.44
 #if defined(USE_DYN_LPF)
             currentPidProfile->dyn_lpf_curve_expo = sbufReadU8(src);
@@ -2689,10 +2687,8 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
             gyroConfigMutable()->dyn_notch_count = sbufReadU8(src);
-            gyroConfigMutable()->dyn_notch_bandwidth_hz = sbufReadU16(src);
 #else
             sbufReadU8(src);
-            sbufReadU16(src);
 #endif
         }
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -129,8 +129,8 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->dyn_lpf_gyro_min_hz = DYN_LPF_GYRO_MIN_HZ_DEFAULT;
     gyroConfig->dyn_lpf_gyro_max_hz = DYN_LPF_GYRO_MAX_HZ_DEFAULT;
     gyroConfig->dyn_notch_max_hz = 600;
-    gyroConfig->dyn_notch_count = 1;
-    gyroConfig->dyn_notch_bandwidth_hz = 45;
+    gyroConfig->dyn_notch_count = 3;
+    gyroConfig->dyn_notch_q = 300;
     gyroConfig->dyn_notch_min_hz = 150;
     gyroConfig->gyro_filter_debug_axis = FD_ROLL;
     gyroConfig->dyn_lpf_curve_expo = 5;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -200,7 +200,7 @@ typedef struct gyroConfig_s {
 
     uint16_t dyn_notch_max_hz;
     uint8_t dyn_notch_count;
-    uint16_t dyn_notch_bandwidth_hz;
+    uint16_t dyn_notch_q;
     uint16_t dyn_notch_min_hz;
 
     uint8_t gyro_filter_debug_axis;


### PR DESCRIPTION
# Dynamic Notch Q
This PR reverts the changes to the dynamic notch Q value.

It turned out that using a constant width for the notches didn't give enough benefits. Using constant bandwidth makes sure notches don't get too narrow at low frequencies. Turns out we don't go so low as to get a real benefit from that. Also, at low frequencies wide notches are greatly contributing to propwash.

**We are looking at another way to improve the notch filter capabilities at low frequencies without latency costs.**

Reverting back to constant Q value gives the following benefits:

- notches get wider at higher freqs without contributing much to filter latency
- which means slightly less propwash at lower frequencies (tested and confirmed)
- and a bit more overall filter capabilities (tested and confirmed)
- people are used to Q value. They have a "feeling" for it
- less maintenance work for intercompatibility of different versions

## Tuning

The standard bandwidth value was pretty slim at 45Hz. That corresponds to a Q value of about 500. We can do that because the dynamic notch is pretty precise at double the frequency resolution thanks to the SDFT.

**Dynamic notch settings:**
```
set dyn_notch_count = 3
set dyn_notch_q = 300
```

**Dynamic notch settings with RPM filter:**
```
set dyn_notch_count = 1..2
set dyn_notch_q = 500
```

# Frequency estimation
In addition the frequency estimation algorithm got simplified. Everything still works just as expected.

I designed this algorithm independently but the same method (and more) is described in great detail in a paper from CERN called "[IMPROVING FFT FREQUENCY MEASUREMENT RESOLUTION  BY PARABOLIC AND GAUSSIAN INTERPOLATION](https://mgasior.web.cern.ch/pap/FFT_resol_note.pdf)".

## Fun(?) fact
Btw. for gaussian interpolation instead of parabolic interpolation we just need to calculate the natural log of y0, y1 and y2 before estimating meanBin (because a gauss curve looks like a parabola on log scale). Easy!

```c
float meanBin = peaks[p].bin;

const float y0 = sdftData[peaks[p].bin - 1];
const float y1 = sdftData[peaks[p].bin];
const float y2 = sdftData[peaks[p].bin + 1];

// Fit gauss curve instead of parabola
y0 = log_approx(y0);
y1 = log_approx(y1);
y2 = log_approx(y2);

// Estimate true peak position aka. meanBin (fit parabola y(x) over y0, y1 and y2, solve dy/dx=0 for x)
const float denom = 2.0f * (y0 - 2 * y1 + y2);
if (denom != 0.0f) {
    meanBin += (y0 - y2) / denom;
}
```

This improves the frequency estimation 4 times but the algorithm gets very inefficient, which is not worth it for "just" 4x less error.

Linked PRs:
https://github.com/betaflight/betaflight-configurator/pull/2504