### PR TITLE
restore rc smoothing to level and horizon modes

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5018,7 +5018,7 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
             cliPrintLine("(auto)");
         }
         cliPrintf("# Active throttle cutoff: %dhz ", rcSmoothingData->throttleCutoffFrequency);
-        if (rcSmoothingData->ffCutoffSetting) {
+        if (rcSmoothingData->throttleCutoffSetting) {
             cliPrintLine("(manual)");
         } else {
             cliPrintLine("(auto)");

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -95,6 +95,7 @@ typedef struct rcSmoothingFilterTraining_s {
 typedef struct rcSmoothingFilter_s {
     bool filterInitialized;
     pt3Filter_t filter[4];
+    pt3Filter_t filterDeflection[2];
     uint8_t setpointCutoffSetting;
     uint8_t throttleCutoffSetting;
     uint16_t setpointCutoffFrequency;


### PR DESCRIPTION
#10727 resulted in a loss of RC smoothing for level and horizon modes.  This restores the smoothing.  However it will affect level mode sensitivity around centre stick, and hence may not be an ideal solution.

Previously, in level mode, there was no expo on the requested angle for pitch and roll, unless the user set non-zero values for `roll_level_expo` or `pitch_level_expo`.  We had no expo because we were using rcCommand to set the requested angle; that's always been the way it has been.  We lost smoothing because rcCommand is not smoothed after #10727.

In Horizon mode, standard rates expo take over after the transition to acro at higher rate values.  

In this PR, setpoint divided by max rate is used to indicate stick position.  Both Level mode and Horizon mode are driven with the normal expo of the user's rates curve.  

It could be that this is a better way of doing level mode, but I'm not sure.  If existing level mode users are unhappy with the reduced sensitivity around centre stick,  applying rcSmoothing to rcCommand in these modes will be needed.