### PR TITLE
move transition to feedforward

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1384,16 +1384,16 @@ static bool blackboxWriteSysinfo(void)
 #ifdef USE_INTEGRATED_YAW_CONTROL
         BLACKBOX_PRINT_HEADER_LINE("use_integrated_yaw", "%d",              currentPidProfile->use_integrated_yaw);
 #endif
-        BLACKBOX_PRINT_HEADER_LINE("ff_transition", "%d",                   currentPidProfile->feedforwardTransition);
         BLACKBOX_PRINT_HEADER_LINE("ff_weight", "%d,%d,%d",                 currentPidProfile->pid[PID_ROLL].F,
                                                                             currentPidProfile->pid[PID_PITCH].F,
                                                                             currentPidProfile->pid[PID_YAW].F);
 #ifdef USE_FEEDFORWARD
+        BLACKBOX_PRINT_HEADER_LINE("ff_transition", "%d",                   currentPidProfile->feedforward_transition);
         BLACKBOX_PRINT_HEADER_LINE("ff_averaging", "%d",                    currentPidProfile->feedforward_averaging);
-        BLACKBOX_PRINT_HEADER_LINE("ff_max_rate_limit", "%d",               currentPidProfile->feedforward_max_rate_limit);
         BLACKBOX_PRINT_HEADER_LINE("ff_smooth_factor", "%d",                currentPidProfile->feedforward_smooth_factor);
         BLACKBOX_PRINT_HEADER_LINE("ff_jitter_factor", "%d",                currentPidProfile->feedforward_jitter_factor);
         BLACKBOX_PRINT_HEADER_LINE("ff_boost", "%d",                        currentPidProfile->feedforward_boost);
+        BLACKBOX_PRINT_HEADER_LINE("ff_max_rate_limit", "%d",               currentPidProfile->feedforward_max_rate_limit);
 #endif
 
         BLACKBOX_PRINT_HEADER_LINE("acc_limit_yaw", "%d",                   currentPidProfile->yawRateAccelLimit);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1149,7 +1149,7 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_FEEDFORWARD
-    { "feedforward_transition",       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforwardTransition) },
+    { "feedforward_transition",       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_transition) },
     { "feedforward_averaging",        VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FEEDFORWARD_AVERAGING }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_averaging) },
     { "feedforward_smoothing",        VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 75}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_smooth_factor) },
     { "feedforward_jitter_reduction", VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1051,7 +1051,6 @@ const clivalue_t valueTable[] = {
     { "anti_gravity_mode",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ANTI_GRAVITY_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, antiGravityMode) },
     { "anti_gravity_threshold",     VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 20, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermThrottleThreshold) },
     { "anti_gravity_gain",          VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, itermAcceleratorGain) },
-    { "feedforward_transition",     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforwardTransition) },
     { "acc_limit_yaw",              VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yawRateAccelLimit) },
     { "acc_limit",                  VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, rateAccelLimit) },
     { "crash_dthreshold",           VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_dthreshold) },
@@ -1150,12 +1149,13 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_FEEDFORWARD
+    { "feedforward_transition",       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforwardTransition) },
     { "feedforward_averaging",        VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FEEDFORWARD_AVERAGING }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_averaging) },
     { "feedforward_smoothing",        VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 75}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_smooth_factor) },
     { "feedforward_jitter_reduction", VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
+    { "feedforward_boost",            VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { "feedforward_max_rate_limit",   VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 150}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
 #endif
-    { "feedforward_boost",            VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
 
 #ifdef USE_DYN_IDLE
     { "dyn_idle_min_rpm",           VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_min_rpm) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -489,8 +489,6 @@ static CMS_Menu cmsx_menuLaunchControl = {
 };
 #endif
 
-static uint8_t  cmsx_feedforwardTransition;
-static uint8_t  cmsx_feedforward_boost;
 static uint8_t  cmsx_angleStrength;
 static uint8_t  cmsx_horizonStrength;
 static uint8_t  cmsx_horizonTransition;
@@ -517,6 +515,8 @@ static uint8_t cmsx_iterm_relax_cutoff;
 #endif
 
 #ifdef USE_FEEDFORWARD
+static uint8_t cmsx_feedforward_transition;
+static uint8_t cmsx_feedforward_boost;
 static uint8_t cmsx_feedforward_averaging;
 static uint8_t cmsx_feedforward_smooth_factor;
 static uint8_t cmsx_feedforward_jitter_factor;
@@ -529,9 +529,6 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     setProfileIndexString(pidProfileIndexString, pidProfileIndex, currentPidProfile->profileName);
 
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
-
-    cmsx_feedforwardTransition  = pidProfile->feedforwardTransition;
-    cmsx_feedforward_boost = pidProfile->feedforward_boost;
 
     cmsx_angleStrength =     pidProfile->pid[PID_LEVEL].P;
     cmsx_horizonStrength =   pidProfile->pid[PID_LEVEL].I;
@@ -560,7 +557,9 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 #endif
 
 #ifdef USE_FEEDFORWARD
+    cmsx_feedforward_transition  = pidProfile->feedforward_transition;
     cmsx_feedforward_averaging = pidProfile->feedforward_averaging;
+    cmsx_feedforward_boost = pidProfile->feedforward_boost;
     cmsx_feedforward_smooth_factor = pidProfile->feedforward_smooth_factor;
     cmsx_feedforward_jitter_factor = pidProfile->feedforward_jitter_factor;
 #endif
@@ -577,9 +576,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     UNUSED(self);
 
     pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);
-    pidProfile->feedforwardTransition = cmsx_feedforwardTransition;
     pidInitConfig(currentPidProfile);
-    pidProfile->feedforward_boost = cmsx_feedforward_boost;
 
     pidProfile->pid[PID_LEVEL].P = cmsx_angleStrength;
     pidProfile->pid[PID_LEVEL].I = cmsx_horizonStrength;
@@ -608,7 +605,9 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
 #endif
 
 #ifdef USE_FEEDFORWARD
+    pidProfile->feedforward_transition = cmsx_feedforward_transition;
     pidProfile->feedforward_averaging = cmsx_feedforward_averaging;
+    pidProfile->feedforward_boost = cmsx_feedforward_boost;
     pidProfile->feedforward_smooth_factor = cmsx_feedforward_smooth_factor;
     pidProfile->feedforward_jitter_factor = cmsx_feedforward_jitter_factor;
 #endif
@@ -624,13 +623,13 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
 static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "-- OTHER PP --", OME_Label, NULL, pidProfileIndexString, 0 },
 
-    { "FF TRANSITION", OME_FLOAT,  NULL, &(OSD_FLOAT_t)  { &cmsx_feedforwardTransition,  0,    100,   1, 10 }, 0 },
 #ifdef USE_FEEDFORWARD
+    { "FF TRANSITION", OME_FLOAT,  NULL, &(OSD_FLOAT_t)  { &cmsx_feedforward_transition,        0,    100,   1, 10 }, 0 },
     { "FF AVERAGING",  OME_TAB,    NULL, &(OSD_TAB_t)    { &cmsx_feedforward_averaging,         4, lookupTableFeedforwardAveraging}, 0 },
     { "FF SMOOTHNESS", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_smooth_factor,     0,     75,   1  }   , 0 },
     { "FF JITTER",     OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_jitter_factor,     0,     20,   1  }   , 0 },
+    { "FF BOOST",      OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_boost,             0,     50,   1  }   , 0 },
 #endif
-    { "FF BOOST",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_boost,               0,     50,   1  }   , 0 },
     { "ANGLE STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleStrength,          0,    200,   1  }   , 0 },
     { "HORZN STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonStrength,        0,    200,   1  }   , 0 },
     { "HORZN TRS",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonTransition,      0,    200,   1  }   , 0 },

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -416,11 +416,13 @@ static int applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t a
         currentPidProfile->pid[PID_YAW].F = newValue;
         blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_F, newValue);
         break;
+#if defined(USE_FEEDFORWARD)
     case ADJUSTMENT_FEEDFORWARD_TRANSITION:
-        newValue = constrain(currentPidProfile->feedforwardTransition + delta, 1, 100); // FIXME magic numbers repeated in cli.c
-        currentPidProfile->feedforwardTransition = newValue;
+        newValue = constrain(currentPidProfile->feedforward_transition + delta, 1, 100); // FIXME magic numbers repeated in cli.c
+        currentPidProfile->feedforward_transition = newValue;
         blackboxLogInflightAdjustmentEvent(ADJUSTMENT_FEEDFORWARD_TRANSITION, newValue);
         break;
+#endif
     default:
         newValue = -1;
         break;
@@ -577,11 +579,13 @@ static int applyAbsoluteAdjustment(controlRateConfig_t *controlRateConfig, adjus
         currentPidProfile->pid[PID_YAW].F = newValue;
         blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_F, newValue);
         break;
+#if defined(USE_FEEDFORWARD)
     case ADJUSTMENT_FEEDFORWARD_TRANSITION:
         newValue = constrain(value, 1, 100); // FIXME magic numbers repeated in cli.c
-        currentPidProfile->feedforwardTransition = newValue;
+        currentPidProfile->feedforward_transition = newValue;
         blackboxLogInflightAdjustmentEvent(ADJUSTMENT_FEEDFORWARD_TRANSITION, newValue);
         break;
+#endif
     default:
         newValue = -1;
         break;

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -75,11 +75,11 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
         const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
         float feedforward;
 
-        // calculate an attenuator from average of two most recent rcCommand deltas vs jitter threshold
         if (axis == FD_ROLL) {
             DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 100.0f)); // rcCommand packet difference = steps of 50 mean 2000 RC steps
         }
         rcCommandDelta = fabsf(rcCommandDelta);
+        // calculate the jitter attenuator from average of two most recent abs rcCommand deltas vs jitter threshold
         float jitterAttenuator = 1.0f;
         if (feedforwardJitterFactor) {
             if (rcCommandDelta < feedforwardJitterFactor) {
@@ -161,6 +161,10 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
         } else {
             setpointDelta[axis] = feedforward;
         }
+
+        // apply feedforward transition
+        setpointDelta[axis] *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1.0f;
+
     }
     return setpointDelta[axis];
 }

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -71,6 +71,7 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
         float setpointSpeed = (setpoint - prevSetpoint[axis]) * rxRate;
         float absPrevSetpointSpeed = fabsf(prevSetpointSpeed[axis]);
         float setpointAcceleration = 0.0f;
+        const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
         const float feedforwardSmoothFactor = pidGetFeedforwardSmoothFactor();
         const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
         float feedforward;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -256,12 +256,12 @@ void pidStabilisationState(pidStabilisationState_e pidControllerState)
 
 const angle_index_t rcAliasToAngleIndexMap[] = { AI_ROLL, AI_PITCH };
 
-float pidGetFeedforwardBoostFactor()
+#ifdef USE_FEEDFORWARD
+float pidGetFeedforwardTransitionFactor()
 {
-    return pidRuntime.feedforwardBoostFactor;
+    return pidRuntime.feedforwardTransitionFactor;
 }
 
-#ifdef USE_FEEDFORWARD
 float pidGetFeedforwardSmoothFactor()
 {
     return pidRuntime.feedforwardSmoothFactor;
@@ -270,6 +270,11 @@ float pidGetFeedforwardSmoothFactor()
 float pidGetFeedforwardJitterFactor()
 {
     return pidRuntime.feedforwardJitterFactor;
+}
+
+float pidGetFeedforwardBoostFactor()
+{
+    return pidRuntime.feedforwardBoostFactor;
 }
 #endif
 
@@ -1105,9 +1110,8 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         if (feedforwardGain > 0) {
             // halve feedforward in Level mode since stick sensitivity is weaker by about half
             feedforwardGain *= FLIGHT_MODE(ANGLE_MODE) ? 0.5f : 1.0f;
-            // no transition if feedforwardTransition == 0
-            float transition = pidRuntime.feedforwardTransition > 0 ? MIN(1.f, getRcDeflectionAbs(axis) * pidRuntime.feedforwardTransition) : 1;
-            float feedForward = feedforwardGain * transition * pidSetpointDelta * pidRuntime.pidFrequency;
+            // transition now calculated in feedforward.c when new RC data arrives 
+            float feedForward = feedforwardGain * pidSetpointDelta * pidRuntime.pidFrequency;
 
 #ifdef USE_FEEDFORWARD
             pidData[axis].F = shouldApplyFeedforwardLimits(axis) ?

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -87,7 +87,7 @@ FAST_DATA_ZERO_INIT float throttleBoost;
 pt1Filter_t throttleLpf;
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
 
 #if defined(STM32F1)
 #define PID_PROCESS_DENOM_DEFAULT       8
@@ -141,7 +141,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .itermWindupPointPercent = 100,
         .pidAtMinThrottle = PID_STABILISATION_ON,
         .levelAngleLimit = 55,
-        .feedforwardTransition = 0,
+        .feedforward_transition = 0,
         .yawRateAccelLimit = 0,
         .rateAccelLimit = 0,
         .itermThrottleThreshold = 250,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -161,7 +161,6 @@ typedef struct pidProfile_s {
     uint16_t crash_delay;                   // ms
     uint8_t crash_recovery_angle;           // degrees
     uint8_t crash_recovery_rate;            // degree/second
-    uint8_t feedforwardTransition;          // Feedforward attenuation around centre sticks
     uint16_t crash_limit_yaw;               // limits yaw errorRate, so crashes don't cause huge throttle increase
     uint16_t itermLimit;
     uint16_t dterm_lowpass2_hz;             // Extra PT1 Filter on D in hz
@@ -197,7 +196,6 @@ typedef struct pidProfile_s {
     uint8_t motor_output_limit;             // Upper limit of the motor output (percent)
     int8_t auto_profile_cell_count;         // Cell count for this profile to be used with if auto PID profile switching is used
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
-    uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
     char profileName[MAX_PROFILE_NAME_LENGTH + 1]; // Descriptive name for profile
 
     uint8_t dyn_idle_min_rpm;                   // minimum motor speed enforced by the dynamic idle controller
@@ -206,10 +204,13 @@ typedef struct pidProfile_s {
     uint8_t dyn_idle_d_gain;                // D gain for corrections around rapid changes in rpm
     uint8_t dyn_idle_max_increase;          // limit on maximum possible increase in motor idle drive during active control
 
+    uint8_t feedforwardTransition;          // Feedforward attenuation around centre sticks
     uint8_t feedforward_averaging;          // Number of packets to average when averaging is on
-    uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
     uint8_t feedforward_smooth_factor;      // Amount of lowpass type smoothing for feedforward steps
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward
+    uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
+    uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
+
     uint8_t dyn_lpf_curve_expo;             // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calcualtion is gyro based in level mode
     uint8_t vbat_sag_compensation;          // Reduce motor output by this percentage of the maximum compensation amount
@@ -284,10 +285,8 @@ typedef struct pidRuntime_s {
     float antiGravityOsdCutoff;
     float antiGravityThrottleHpf;
     float antiGravityPBoost;
-    float feedforwardBoostFactor;
     float itermAccelerator;
     uint16_t itermAcceleratorGain;
-    float feedforwardTransition;
     pidCoefficient_t pidCoefficient[XYZ_AXIS_COUNT];
     float levelGain;
     float horizonGain;
@@ -385,9 +384,11 @@ typedef struct pidRuntime_s {
 #endif
 
 #ifdef USE_FEEDFORWARD
+    float feedforwardTransitionFactor;
     feedforwardAveraging_t feedforwardAveraging;
     float feedforwardSmoothFactor;
     float feedforwardJitterFactor;
+    float feedforwardBoostFactor;
 #endif
 } pidRuntime_t;
 
@@ -443,4 +444,5 @@ float pidGetPidFrequency();
 float pidGetFeedforwardBoostFactor();
 float pidGetFeedforwardSmoothFactor();
 float pidGetFeedforwardJitterFactor();
+float pidGetFeedforwardTransitionFactor();
 float dynLpfCutoffFreq(float throttle, uint16_t dynLpfMin, uint16_t dynLpfMax, uint8_t expo);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -204,7 +204,7 @@ typedef struct pidProfile_s {
     uint8_t dyn_idle_d_gain;                // D gain for corrections around rapid changes in rpm
     uint8_t dyn_idle_max_increase;          // limit on maximum possible increase in motor idle drive during active control
 
-    uint8_t feedforwardTransition;          // Feedforward attenuation around centre sticks
+    uint8_t feedforward_transition;          // Feedforward attenuation around centre sticks
     uint8_t feedforward_averaging;          // Number of packets to average when averaging is on
     uint8_t feedforward_smooth_factor;      // Amount of lowpass type smoothing for feedforward steps
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -276,11 +276,6 @@ void pidUpdateFeedforwardLpf(uint16_t filterCutoff)
 
 void pidInitConfig(const pidProfile_t *pidProfile)
 {
-    if (pidProfile->feedforwardTransition == 0) {
-        pidRuntime.feedforwardTransition = 0;
-    } else {
-        pidRuntime.feedforwardTransition = 100.0f / pidProfile->feedforwardTransition;
-    }
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
         pidRuntime.pidCoefficient[axis].Kp = PTERM_SCALE * pidProfile->pid[axis].P;
         pidRuntime.pidCoefficient[axis].Ki = ITERM_SCALE * pidProfile->pid[axis].I;
@@ -428,6 +423,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
         pidRuntime.feedforwardSmoothFactor = 1.0f - ((float)pidProfile->feedforward_smooth_factor) / 100.0f;
     }
     pidRuntime.feedforwardJitterFactor = pidProfile->feedforward_jitter_factor;
+    if (pidProfile->feedforwardTransition == 0) {
+        pidRuntime.feedforwardTransitionFactor = 0;
+    } else {
+        pidRuntime.feedforwardTransitionFactor = 100.0f / pidProfile->feedforwardTransition;
+    }
     feedforwardInit(pidProfile);
 #endif
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -238,8 +238,6 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 
     pt1FilterInit(&pidRuntime.antiGravityThrottleLpf, pt1FilterGain(ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF, pidRuntime.dT));
     pt1FilterInit(&pidRuntime.antiGravitySmoothLpf, pt1FilterGain(ANTI_GRAVITY_SMOOTH_FILTER_CUTOFF, pidRuntime.dT));
-
-    pidRuntime.feedforwardBoostFactor = (float)pidProfile->feedforward_boost / 10.0f;
 }
 
 void pidInit(const pidProfile_t *pidProfile)
@@ -417,17 +415,18 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
 #ifdef USE_FEEDFORWARD
+    if (pidProfile->feedforward_transition == 0) {
+        pidRuntime.feedforwardTransitionFactor = 0;
+    } else {
+        pidRuntime.feedforwardTransitionFactor = 100.0f / pidProfile->feedforward_transition;
+    }
     pidRuntime.feedforwardAveraging = pidProfile->feedforward_averaging;
     pidRuntime.feedforwardSmoothFactor = 1.0f;
     if (pidProfile->feedforward_smooth_factor) {
         pidRuntime.feedforwardSmoothFactor = 1.0f - ((float)pidProfile->feedforward_smooth_factor) / 100.0f;
     }
     pidRuntime.feedforwardJitterFactor = pidProfile->feedforward_jitter_factor;
-    if (pidProfile->feedforwardTransition == 0) {
-        pidRuntime.feedforwardTransitionFactor = 0;
-    } else {
-        pidRuntime.feedforwardTransitionFactor = 100.0f / pidProfile->feedforwardTransition;
-    }
+    pidRuntime.feedforwardBoostFactor = (float)pidProfile->feedforward_boost / 10.0f;
     feedforwardInit(pidProfile);
 #endif
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1822,7 +1822,11 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, 0); // was pidProfile.yaw_p_limit
         sbufWriteU8(dst, 0); // reserved
         sbufWriteU8(dst, 0); // was vbatPidCompensation
-        sbufWriteU8(dst, currentPidProfile->feedforwardTransition);
+#if defined(USE_FEEDFORWARD)
+        sbufWriteU8(dst, currentPidProfile->feedforward_transition);
+#else
+        sbufWriteU8(dst, 0);
+#endif
         sbufWriteU8(dst, 0); // was low byte of currentPidProfile->dtermSetpointWeight
         sbufWriteU8(dst, 0); // reserved
         sbufWriteU8(dst, 0); // reserved
@@ -1901,11 +1905,12 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 #if defined(USE_FEEDFORWARD)
         sbufWriteU8(dst, currentPidProfile->feedforward_averaging);
         sbufWriteU8(dst, currentPidProfile->feedforward_smooth_factor);
+        sbufWriteU8(dst, currentPidProfile->feedforward_boost);
 #else
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
 #endif
-        sbufWriteU8(dst, currentPidProfile->feedforward_boost);
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
         sbufWriteU8(dst, currentPidProfile->vbat_sag_compensation);
 #else
@@ -2707,7 +2712,11 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         sbufReadU16(src); // was pidProfile.yaw_p_limit
         sbufReadU8(src); // reserved
         sbufReadU8(src); // was vbatPidCompensation
-        currentPidProfile->feedforwardTransition = sbufReadU8(src);
+#if defined(USE_FEEDFORWARD)
+        currentPidProfile->feedforward_transition = sbufReadU8(src);
+#else
+        sbufReadU8(src);
+#endif
         sbufReadU8(src); // was low byte of currentPidProfile->dtermSetpointWeight
         sbufReadU8(src); // reserved
         sbufReadU8(src); // reserved
@@ -2804,11 +2813,13 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #if defined(USE_FEEDFORWARD)
             currentPidProfile->feedforward_averaging = sbufReadU8(src);
             currentPidProfile->feedforward_smooth_factor = sbufReadU8(src);
+            currentPidProfile->feedforward_boost = sbufReadU8(src);
 #else
             sbufReadU8(src);
             sbufReadU8(src);
+            sbufReadU8(src);
 #endif
-            currentPidProfile->feedforward_boost = sbufReadU8(src);
+
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
             currentPidProfile->vbat_sag_compensation = sbufReadU8(src);
 #else

--- a/src/main/target/ALIENWHOOP/config.c
+++ b/src/main/target/ALIENWHOOP/config.c
@@ -131,7 +131,7 @@ void targetConfiguration(void)
         pidProfile->dterm_notch_hz = 0;
         pidProfile->pid[PID_PITCH].F = 100;
         pidProfile->pid[PID_ROLL].F = 100;
-        pidProfile->feedforwardTransition = 0;
+        pidProfile->feedforward_transition = 0;
 
 	/* Anti-Gravity */
 	pidProfile->itermThrottleThreshold = 500;

--- a/src/main/target/NAZE/config.c
+++ b/src/main/target/NAZE/config.c
@@ -88,7 +88,7 @@ void targetConfiguration(void)
 
         pidProfile->pid[PID_PITCH].F = 200;
         pidProfile->pid[PID_ROLL].F = 200;
-        pidProfile->feedforwardTransition = 50;
+        pidProfile->feedforward_transition = 50;
     }
 
     for (uint8_t rateProfileIndex = 0; rateProfileIndex < CONTROL_RATE_PROFILE_COUNT; rateProfileIndex++) {

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -101,7 +101,10 @@ extern "C" {
     {
         UNUSED(newRcFrame);
         UNUSED(feedforwardAveraging);
-        return simulatedSetpointRate[axis] - simulatedPrevSetpointRate[axis];
+        const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
+        float setpointDelta = simulatedSetpointRate[axis] - simulatedPrevSetpointRate[axis];
+        setpointDelta *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1;
+        return setpointDelta;
     }
     bool shouldApplyFeedforwardLimits(int axis)
     {

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -142,7 +142,7 @@ void setDefaultTestSettings(void) {
     pidProfile->itermWindupPointPercent = 50;
     pidProfile->pidAtMinThrottle = PID_STABILISATION_ON;
     pidProfile->levelAngleLimit = 55;
-    pidProfile->feedforwardTransition = 100;
+    pidProfile->feedforward_transition = 100;
     pidProfile->yawRateAccelLimit = 100;
     pidProfile->rateAccelLimit = 0;
     pidProfile->antiGravityMode = ANTI_GRAVITY_SMOOTH;


### PR DESCRIPTION
@etracer65 raised a concern that Rx noise from un-smoothed rcCommand might cause problems with feedforward transition.

Feedforward transition is a direct attenuator, by simple multiplication, of feedforward, derived from the absolute stick position.  The user sets a limit in percent from centre over which the attenuation should occur.

When sticks are centred, the multiplier is 0, rising linearly to 1 at the end of the transitional zone.

Since it is a simple multiplier, a step change in un-smoothed rcCommand of say 10% should cause a 10% change in feed forward.  And that should result in a step change of 10% in the pilot's feed forward value.  
However it is tough get such a big change from RC step to RC step with a modern radio, other than at 50hz or if there are dropouts.  For most normal radios, in normal operation, and certainly for any link above 100hz, very large changes from packet to packet require very rapid movement of the stick.

When the change is large, like that, so is the change in feed forward.  

Feedforward is calculated as steps directly from the un-smoothed setpoint values; hence it will immedialely change when every new RC value comes in.  Feedforward smoothing smooths these steps out, just as setpoint smoothing smooths out the steps in the setpoint signal.

So the worry was that the Transition effect may put sharp square steps into the otherwise smooth feedforward signal whenever the sticks move a lot.  The 'print-through' of transition noise would only happen if rcCommand consisted of steep, sharp steps.  And since #10723, these steps have not been smoothed.

The problem should be greatest when the transition zone is narrow, since the percentage change per RC step can be greater when the transition line is steeper .  However in most setups, a narrow transition range means that the effect would only apply in the centre, low expo region, where setpoint changes are small.  So those effects cancel out.

If the transition zone is wide, then there is relatively little change per step, so the potential for this problem is attenuated.

If we look hard at the log, and this is a problem, we should see the sharp step corners appearing superimposed on an otherwise smooth feedforward trace.  

I looked hard, and couldn't find any trace of this actually happening, not with any transition value or any feedforward value.

I looked really hard, and just couldn't see it, not with a standard FrSky link, and no matter how heavily I smoothed the feedforward trace.

However the possibility does exist that some rcCommand data may have extreme jitter.

And the transition maths is repeated every PID loop, even though actually the radio input signals only change infrequently.

We could calculate the transition amount within the feedforward code, when new RC data arrives, instead of every PID loop.  This way any step change in transition just multiplies the feedforward value before it is smoothed.  Once smoothed, there is no chance that the transition effect will result in any sharp corners in the feedforward trace.

This PR does just that, effectively eliminating the possibility of un-smoothed transfer of sharp rcCommand steps into feedforward.

However, it is a solution in search of a problem.  It solves nothing, to be honest.  There is just nothing to solve.

This graphic shows current master with un-smoothed rcCommand compared to the new code on the right.  Transition is 100, setpoint is un-smoothed to show us where the steps are.  There is no sign of any sharp stepping on the master code.  Both logs appear identical.  There are significant irregularities in feed forward due to my tremor, timer inaccuracy and other things, like in all feedforward traces.  These errors vastly outweigh the small percentage variation due to transition effects. 

![not much](https://user-images.githubusercontent.com/11737748/120161942-38fe9700-c23b-11eb-9c03-5300842bc31f.jpg)

Here I used extreme feedforward smoothing to make any added sharp steps visible, and moved the sticks as quickly as I could.

There was no sign of any spikes in this code or in master.  

![not much 2](https://user-images.githubusercontent.com/11737748/120163906-559bce80-c23d-11eb-881a-69b0941081d9.jpg)

Even though this code is perhaps a better way to do transition, its tough to see any problem from not doing it.
