### PR TITLE
Warning in CLI for Actual Rates Default and Warning Against Pasting Diffs/Dumps

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6798,6 +6798,9 @@ void cliEnter(serialPort_t *serialPort)
 
 #ifndef MINIMAL_CLI
     cliPrintLine("\r\nEntering CLI Mode, type 'exit' to return, or 'help'");
+    cliPrintLine("\r\n**Default RATE type now 'ACTUAL': DO NOT paste RATES without");
+    cliPrintLine("confirming values in configurator!**");
+    cliPrintLine("\r\n**DO NOT paste DIFFs or DUMPs between versions!**");
 #else
     cliPrintLine("\r\nCLI");
 #endif


### PR DESCRIPTION
Re: https://github.com/betaflight/betaflight/pull/10724

I did review the discussion there. I do appreciate the need to move to ACTUAL rates as default.  I do think that there's going to be friction regardless and you'll have to peel this band aid eventually. I do recognize that pasting diffs and dumps is bad practice and **explicitly** discouraged. That being said, I do think that a decent portion of the user base does paste highly repetitive snippets common across their builds to save time configuring betaflight installs like rates and some osd elements for example. And as etracer demonstrated, that can result in dramatic rate changes.

I _fully_ appreciate that people shouldn't should be pasting diffs/dumps between versions. I don't, however, side with the mentality that this is a teachable moment specifically with regards to rates, which have been ok to copy/paste for years.

It looks like these concerns have largely been put to bed in the linked PR above, but I was hoping squeeze in at least a small change to add a warning in CLI as a last ditch effort to catch those that can't help themselves from pasting configuration snippets.  I would assume the "rates" section of this could be deleted in a future release, but a regular reminder to not paste diff/dumps doesn't seem like a terrible idea.

At the very least this change should be configurator independent (right?) and is a _very, very_ clear warning that A: reminds users not to do something and B: is a very clear warning that anyone can point to and say, "I know you can't be bothered to read the release notes and manual, but if you ALSO can't read the final warning we put right in front of your face ... what more can we do?"

I know this isn't going to catch everyone ... but I am hopeful it will stop a few mishaps and angry folks.

Illustration of the change shown below that, if understand correctly, should load by default upon entering CLI:
![cli_warn](https://user-images.githubusercontent.com/13352373/120367742-3f464f00-c2df-11eb-8fc7-af88078e1a1c.png)

Happy to change the verbiage as people see fit.