### PR TITLE
small error in horizon code

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -382,7 +382,7 @@ STATIC_UNIT_TESTED float calcHorizonLevelStrength(void)
         }
     } else { // horizon_tilt_expert_mode = 0 (leveling always active when sticks centered)
         float sensitFact;
-        if (pidRuntime.horizonFactorRatio < 1.01f) { // if horizonTiltEffect > 0
+        if (pidRuntime.horizonFactorRatio < 1.0f) { // if horizonTiltEffect > 0
             // horizonFactorRatio: 1.0 to 0.0 (larger means more leveling)
             // inclinationLevelRatio (0.0 to 1.0) is smaller (less leveling)
             //  for larger inclinations, goes to 1.0 at inclination==level:


### PR DESCRIPTION
It seems there is an accidental error in some old Horizon code since #2570, originally from around 2017...

In pid.init.c line 301, where `pidProfile->horizon_tilt_effect` can be entered in the range 0-250, `pidRuntime.horizonFactorRatio` is calculated as follows...

```
    pidRuntime.horizonFactorRatio = (100 - pidProfile->horizon_tilt_effect) * 0.01f;
```

The possible range of values for `pidRuntime.horizonFactorRatio` is therefore 1 (at an input of 0) through 0 (at 100) to -1.5 (at 250).

In calcHorizonLevelStrength, a check using `horizonFactorRatio` is performed like this...

```
    if (pidRuntime.horizonFactorRatio < 1.01f) { // if horizonTiltEffect > 0
```

Since `pidRuntime.horizonFactorRatio` cannot exceed 1.0f, this check can never fail.

If the check was changed to `<1.0f`, then user supplied value of 0 for `horizon_tilt_effect` would result in `pidRuntime.horizonFactorRatio` = 1.0, and then the check would fail, falling through to 392, which has a comment that suggests this is what ought to happen.

```
    } else { // horizonTiltEffect = 0 for "old" functionality
```
It seems that this was a typo.  
