### PR TITLE
Add `stats_total_packs`

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1422,7 +1422,8 @@ const clivalue_t valueTable[] = {
     { "osd_rcchannels_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_RC_CHANNELS]) },
     { "osd_camera_frame_pos",   VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CAMERA_FRAME]) },
     { "osd_efficiency_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_EFFICIENCY]) },
-    { "osd_total_flights_pos",     VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_TOTAL_FLIGHTS]) },
+    { "osd_total_flights_pos",  VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_TOTAL_FLIGHTS]) },
+    { "osd_total_packs_pos",    VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_TOTAL_PACKS]) },
 
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
@@ -1664,11 +1665,11 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_PERSISTENT_STATS
-    { "stats_min_armed_time_s",   VAR_INT8   | MASTER_VALUE, .config.minmax = { STATS_OFF, INT8_MAX }, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_min_armed_time_s) },
+    { "stats_min_armed_time_s", VAR_INT8   | MASTER_VALUE, .config.minmax = { STATS_OFF, INT8_MAX }, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_min_armed_time_s) },
     { "stats_total_flights",    VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_total_flights) },
-
     { "stats_total_time_s",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_total_time_s) },
     { "stats_total_dist_m",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_total_dist_m) },
+    { "stats_total_packs",      VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_total_packs) },
 
 #ifdef USE_BATTERY_CONTINUE
     { "stats_mah_used",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_mah_used) },

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -165,6 +165,7 @@ const OSD_Entry menuOsdActiveElemsEntries[] =
     {"RC CHANNELS",        OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_RC_CHANNELS]},
     {"CAMERA FRAME",       OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_CAMERA_FRAME]},
     {"TOTAL FLIGHTS",      OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_TOTAL_FLIGHTS]},
+    {"TOTAL PACKS",        OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_TOTAL_PACKS]},
     {"BACK",               OME_Back,    NULL, NULL},
     {NULL,                 OME_END,     NULL, NULL}
 };

--- a/src/main/cms/cms_menu_persistent_stats.c
+++ b/src/main/cms/cms_menu_persistent_stats.c
@@ -36,6 +36,7 @@
 #include "pg/stats.h"
 
 uint32_t stats_total_flights;
+uint32_t stats_total_packs;
 uint32_t stats_total_time_s;
 uint32_t stats_total_dist_m;
 int8_t stats_min_armed_time_s;
@@ -45,6 +46,7 @@ static const void *cmsx_PersistentStats_onEnter(displayPort_t *pDisp)
     UNUSED(pDisp);
 
     stats_total_flights = statsConfig()->stats_total_flights;
+    stats_total_packs = statsConfig()->stats_total_packs;
     stats_total_time_s = statsConfig()->stats_total_time_s;
     stats_total_dist_m = statsConfig()->stats_total_dist_m;
     stats_min_armed_time_s = statsConfig()->stats_min_armed_time_s;
@@ -58,6 +60,7 @@ static const void *cmsx_PersistentStats_onExit(displayPort_t *pDisp, const OSD_E
     UNUSED(self);
 
     statsConfigMutable()->stats_total_flights = stats_total_flights;
+    statsConfigMutable()->stats_total_packs = stats_total_packs;
     statsConfigMutable()->stats_total_time_s = stats_total_time_s;
     statsConfigMutable()->stats_total_dist_m = stats_total_dist_m;
     statsConfigMutable()->stats_min_armed_time_s = stats_min_armed_time_s;
@@ -70,6 +73,7 @@ static const void *cmsx_ResetStats(displayPort_t *pDisplay, const void *ptr)
     UNUSED(ptr);
 
     stats_total_flights = 0;
+    stats_total_packs = 0;
     stats_total_time_s = 0;
     stats_total_dist_m = 0;
 
@@ -83,6 +87,7 @@ static const OSD_Entry cmsx_menuPersistentStatsEntries[] =
 {
     {"-- PERSISTENT STATS --", OME_Label, NULL, NULL},
     {"FLIGHTS", OME_UINT32, NULL, &(OSD_UINT32_t){ &stats_total_flights, 0, UINT32_MAX, 1}},
+    {"PACKS", OME_UINT32, NULL, &(OSD_UINT32_t){ &stats_total_packs, 0, UINT32_MAX, 1}},
     {"TIME(sec)", OME_UINT32, NULL, &(OSD_UINT32_t){ &stats_total_time_s, 0, UINT32_MAX, 1}},
     {"DIST(m)", OME_UINT32, NULL, &(OSD_UINT32_t){ &stats_total_dist_m, 0, UINT32_MAX, 1}},
     {"RESET STATS", OME_Funcall, cmsx_ResetStats, NULL},

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -43,6 +43,8 @@
 static timeMs_t arm_millis;
 static uint32_t arm_distance_cm;
 
+static bool statsNotSavedYet = true;
+
 static bool saveRequired = false;
 
 #ifdef USE_GPS
@@ -94,6 +96,12 @@ void statsOnDisarm(void)
             statsConfigMutable()->stats_total_flights += 1;    // arm / flight counter
             statsConfigMutable()->stats_total_time_s += dtS;
             statsConfigMutable()->stats_total_dist_m += (DISTANCE_FLOWN_CM - arm_distance_cm) / 100;
+            
+            if (statsNotSavedYet) {
+              statsConfigMutable()->stats_total_packs += 1;    // packs counter
+              statsNotSavedYet = false;
+            }
+            
 #ifdef USE_BATTERY_CONTINUE
             statsConfigMutable()->stats_mah_used = getMAhDrawn();
 #endif

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -148,7 +148,7 @@ escSensorData_t *osdEscDataCombined;
 
 STATIC_ASSERT(OSD_POS_MAX == OSD_POS(31,31), OSD_POS_MAX_incorrect);
 
-PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 9);
+PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 10);
 
 PG_REGISTER_WITH_RESET_FN(osdElementConfig_t, osdElementConfig, PG_OSD_ELEMENT_CONFIG, 0);
 
@@ -185,6 +185,7 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
     OSD_STAT_MAX_FFT,
     OSD_STAT_MIN_RSSI_DBM,
     OSD_STAT_TOTAL_FLIGHTS,
+    OSD_STAT_TOTAL_PACKS,
     OSD_STAT_TOTAL_TIME,
     OSD_STAT_TOTAL_DIST,
     OSD_STAT_WATT_HOURS_DRAWN,
@@ -751,7 +752,7 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
         osdDisplayStatisticLabel(displayRow, osdConfig()->stat_show_cell_value ? "END AVG CELL" : "END BATTERY", buff);
         return true;
 
-    case OSD_STAT_BATTERY: 
+    case OSD_STAT_BATTERY:
         {
             const uint16_t statsVoltage = getStatsVoltage();
             osdPrintFloat(buff, SYM_NONE, statsVoltage / 100.0f, "", 2, true, SYM_VOLT);
@@ -875,6 +876,11 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
     case OSD_STAT_TOTAL_FLIGHTS:
         itoa(statsConfig()->stats_total_flights, buff, 10);
         osdDisplayStatisticLabel(displayRow, "TOTAL FLIGHTS", buff);
+        return true;
+
+    case OSD_STAT_TOTAL_PACKS:
+        itoa(statsConfig()->stats_total_packs, buff, 10);
+        osdDisplayStatisticLabel(displayRow, "TOTAL PACKS", buff);
         return true;
 
     case OSD_STAT_TOTAL_TIME: {

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -162,6 +162,7 @@ typedef enum {
     OSD_UP_DOWN_REFERENCE,
     OSD_TX_UPLINK_POWER,
     OSD_WATT_HOURS_DRAWN,
+    OSD_TOTAL_PACKS,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -202,6 +203,7 @@ typedef enum {
     OSD_STAT_TOTAL_DIST,
     OSD_STAT_MIN_RSSI_DBM,
     OSD_STAT_WATT_HOURS_DRAWN,
+    OSD_STAT_TOTAL_PACKS,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -719,7 +719,7 @@ static void osdElementUpDownReference(osdElementParms_t *element)
 // Up/Down reference feature displays reference points on the OSD at Zenith and Nadir
     const float earthUpinBodyFrame[3] = {-rMat[2][0], -rMat[2][1], -rMat[2][2]}; //transforum the up vector to the body frame
 
-    if (ABS(earthUpinBodyFrame[2]) < SINE_25_DEG && ABS(earthUpinBodyFrame[1]) < SINE_25_DEG) { 
+    if (ABS(earthUpinBodyFrame[2]) < SINE_25_DEG && ABS(earthUpinBodyFrame[1]) < SINE_25_DEG) {
         float thetaB; // pitch from body frame to zenith/nadir
         float psiB; // psi from body frame to zenith/nadir
         char *symbol[2] = {"U", "D"}; // character buffer
@@ -888,6 +888,12 @@ static void osdElementTotalFlights(osdElementParms_t *element)
 {
     const int32_t total_flights = statsConfig()->stats_total_flights;
     tfp_sprintf(element->buff, "#%d", total_flights);
+}
+
+static void osdElementTotalPacks(osdElementParms_t *element)
+{
+    const int32_t total_packs = statsConfig()->stats_total_packs + 1;
+    tfp_sprintf(element->buff, "#%d", total_packs);
 }
 #endif
 
@@ -1600,6 +1606,7 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_CAMERA_FRAME,
 #ifdef USE_PERSISTENT_STATS
     OSD_TOTAL_FLIGHTS,
+    OSD_TOTAL_PACKS,
 #endif
 };
 
@@ -1716,6 +1723,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #endif
 #ifdef USE_PERSISTENT_STATS
     [OSD_TOTAL_FLIGHTS]           = osdElementTotalFlights,
+    [OSD_TOTAL_PACKS]             = osdElementTotalPacks,
 #endif
 };
 
@@ -1782,6 +1790,7 @@ void osdAddActiveElements(void)
 
 #ifdef USE_PERSISTENT_STATS
     osdAddActiveElement(OSD_TOTAL_FLIGHTS);
+    osdAddActiveElement(OSD_TOTAL_PACKS);
 #endif
 }
 

--- a/src/main/pg/stats.c
+++ b/src/main/pg/stats.c
@@ -35,5 +35,6 @@ PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
     .stats_total_time_s = 0,
     .stats_total_dist_m = 0,
     .stats_mah_used = 0,
+    .stats_total_packs = 0,
 );
 #endif

--- a/src/main/pg/stats.h
+++ b/src/main/pg/stats.h
@@ -31,6 +31,7 @@ typedef struct statsConfig_s {
     uint32_t stats_total_dist_m;
     int8_t stats_min_armed_time_s;
     uint32_t stats_mah_used;
+    uint32_t stats_total_packs;
 } statsConfig_t;
 
 PG_DECLARE(statsConfig_t, statsConfig);


### PR DESCRIPTION
# stats_total_packs 

## What is there today : 
stats_total_flights is supposed to count our flights. And it does ! But what do we count as "flights" ? (Turtle mode, breaks, fast checkin, ...). Reviewing DVR (and the ones we forgot to press play), we have to go to the end to see which flight we are talking about. Sometimes we didn't really miss a DVR : flight count for two.

## What's that feature provides :
That new feature works just as `stats_total_flights`, except  :

- it does not count the times you've satisfied _minArmedTimeS_, that can be more than one time in a pack if you disarm and arm again in the middle of your pack
- it does count the times you've satisfied _minArmedTimesS_, and only once per pack. Once it has be incremented one time, it won't count that "second flight".

I both add this feature and the ability to add it in OSD both stat and during the flight. It is usefull for "enthousiastic racers" (see #10215).

## Issues ?
However, I am concerned about adding yet another persistant_stat element. There is today 26 elements on 32 availables on the 32bit chip. See #10503 arguments.

It would be possible to set stats_total_flights to either work like right now, or counting in packs. It would also be trickier, "and why change something that does work / field test", and was suggested in #10803 to make it a different parameter.


Fixes #10803

The commit has passed the `make pre-push` and I attach unified_zip targets for user to test the feature.

**2021-06-22_17-52 :** updated unified_zip [from last commit](https://github.com/betaflight/betaflight/pull/10808/commits/68549ae7fd8c06b3ca56093a8ffee0d155c27340).
[betaflight_4.3.0_STM32G47X_68549ae7f.zip](https://github.com/betaflight/betaflight/files/6695747/betaflight_4.3.0_STM32G47X_68549ae7f.zip)
[betaflight_4.3.0_STM32F745_68549ae7f.zip](https://github.com/betaflight/betaflight/files/6695748/betaflight_4.3.0_STM32F745_68549ae7f.zip)
[betaflight_4.3.0_STM32F7X2_68549ae7f.zip](https://github.com/betaflight/betaflight/files/6695749/betaflight_4.3.0_STM32F7X2_68549ae7f.zip)
[betaflight_4.3.0_STM32F411_68549ae7f.zip](https://github.com/betaflight/betaflight/files/6695750/betaflight_4.3.0_STM32F411_68549ae7f.zip)
[betaflight_4.3.0_STM32F405_68549ae7f.zip](https://github.com/betaflight/betaflight/files/6695751/betaflight_4.3.0_STM32F405_68549ae7f.zip)

