### PR TITLE
add `runaway_takeoff_prevention_first_arm_only`

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1025,6 +1025,7 @@ const clivalue_t valueTable[] = {
     { "pid_process_denom",          VAR_UINT8  | MASTER_VALUE,  .config.minmaxUnsigned = { 1, MAX_PID_PROCESS_DENOM }, PG_PID_CONFIG, offsetof(pidConfig_t, pid_process_denom) },
 #ifdef USE_RUNAWAY_TAKEOFF
     { "runaway_takeoff_prevention", VAR_UINT8  | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_prevention) },    // enables/disables runaway takeoff prevention
+    { "runaway_takeoff_prevention_first_arm_only", VAR_UINT8  | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_prevention_first_arm_only) },    // enables/disables runaway takeoff prevention after first arm for the remaining battery
     { "runaway_takeoff_deactivate_delay",  VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 100, 1000 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_delay) },           // deactivate time in ms
     { "runaway_takeoff_deactivate_throttle_percent",  VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_throttle) }, // minimum throttle percentage during deactivation phase
 #endif

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -103,6 +103,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);
 PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
     .pid_process_denom = PID_PROCESS_DENOM_DEFAULT,
     .runaway_takeoff_prevention = true,
+    .runaway_takeoff_prevention_first_arm_only = false,
     .runaway_takeoff_deactivate_throttle = 20,  // throttle level % needed to accumulate deactivation time
     .runaway_takeoff_deactivate_delay = 500     // Accumulated time (in milliseconds) before deactivation in successful takeoff
 );

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -230,10 +230,11 @@ typedef struct pidProfile_s {
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
 
 typedef struct pidConfig_s {
-    uint8_t pid_process_denom;              // Processing denominator for PID controller vs gyro sampling rate
-    uint8_t runaway_takeoff_prevention;          // off, on - enables pidsum runaway disarm logic
-    uint16_t runaway_takeoff_deactivate_delay;   // delay in ms for "in-flight" conditions before deactivation (successful flight)
-    uint8_t runaway_takeoff_deactivate_throttle; // minimum throttle percent required during deactivation phase
+    uint8_t pid_process_denom;                          // Processing denominator for PID controller vs gyro sampling rate
+    uint8_t runaway_takeoff_prevention;                 // off, on - enables pidsum runaway disarm logic
+    uint8_t runaway_takeoff_prevention_first_arm_only;  // off, on - prevents runaway_takeoff_prevention after armed once
+    uint16_t runaway_takeoff_deactivate_delay;          // delay in ms for "in-flight" conditions before deactivation (successful flight)
+    uint8_t runaway_takeoff_deactivate_throttle;        // minimum throttle percent required during deactivation phase
 } pidConfig_t;
 
 PG_DECLARE(pidConfig_t, pidConfig);


### PR DESCRIPTION
# Add `runaway_takeoff_prevention_first_arm_only`

I didn't went with the suggested `runaway_takeoff_prevention_crashflip_reset` in #10746 since that would imply we would have to enable crash flip over to get rid of that `runaway_takeoff_prevention`, however sometimes we don't need to flip over for that, and still get that runaway prevention.

I change comments accordingly
```core.c
- // for the remaining battery
+ // until next arm
```

Set to OFF by default, which mean the if condition will not be accounted for unless the pilot decides to set it ON with CLI.

I'm not sure I have inserted the _static bool_ at the right/cleaner place, but I believe I have. I'd love your insight about it.
```core.c
static bool runawayTakeoffPrevention_FirstArmDone = false;
```

`make pre-push` and `make unified_targets` went well.

`make unified_zip` are attached to the PR.

#Fixes #10746

--- 
[betaflight_4.3.0_STM32F7X2_9ae2fe6d6.zip](https://github.com/betaflight/betaflight/files/6689816/betaflight_4.3.0_STM32F7X2_9ae2fe6d6.zip)
[betaflight_4.3.0_STM32F405_9ae2fe6d6.zip](https://github.com/betaflight/betaflight/files/6689817/betaflight_4.3.0_STM32F405_9ae2fe6d6.zip)
[betaflight_4.3.0_STM32F411_9ae2fe6d6.zip](https://github.com/betaflight/betaflight/files/6689818/betaflight_4.3.0_STM32F411_9ae2fe6d6.zip)
[betaflight_4.3.0_STM32F745_9ae2fe6d6.zip](https://github.com/betaflight/betaflight/files/6689819/betaflight_4.3.0_STM32F745_9ae2fe6d6.zip)
[betaflight_4.3.0_STM32G47X_9ae2fe6d6.zip](https://github.com/betaflight/betaflight/files/6689820/betaflight_4.3.0_STM32G47X_9ae2fe6d6.zip)
