### PR TITLE
Add `runaway_takeoff_prevention_crashflip_reset`

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1025,6 +1025,7 @@ const clivalue_t valueTable[] = {
     { "pid_process_denom",          VAR_UINT8  | MASTER_VALUE,  .config.minmaxUnsigned = { 1, MAX_PID_PROCESS_DENOM }, PG_PID_CONFIG, offsetof(pidConfig_t, pid_process_denom) },
 #ifdef USE_RUNAWAY_TAKEOFF
     { "runaway_takeoff_prevention", VAR_UINT8  | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_prevention) },    // enables/disables runaway takeoff prevention
+    { "runaway_takeoff_prevention_crashflip_reset", VAR_UINT8  | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_prevention_crashflip_reset) },    // enables/disables runaway takeoff prevention after crashflip
     { "runaway_takeoff_deactivate_delay",  VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 100, 1000 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_delay) },           // deactivate time in ms
     { "runaway_takeoff_deactivate_throttle_percent",  VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_CONFIG, offsetof(pidConfig_t, runaway_takeoff_deactivate_throttle) }, // minimum throttle percentage during deactivation phase
 #endif

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -517,7 +517,12 @@ void tryArm(void)
             } else {
                 flipOverAfterCrashActive = true;
 #ifdef USE_RUNAWAY_TAKEOFF
-                runawayTakeoffCheckDisabled = false;
+                if (pidConfig()->runaway_takeoff_prevention_crashflip_reset) {
+                    runawayTakeoffCheckDisabled = false;
+                } else {
+                  runawayTakeoffCheckDisabled = true;
+                }
+
 #endif
                 if (!featureIsEnabled(FEATURE_3D)) {
                     dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED, DSHOT_CMD_TYPE_INLINE);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -103,6 +103,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);
 PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
     .pid_process_denom = PID_PROCESS_DENOM_DEFAULT,
     .runaway_takeoff_prevention = true,
+    .runaway_takeoff_prevention_crashflip_reset = true,
     .runaway_takeoff_deactivate_throttle = 20,  // throttle level % needed to accumulate deactivation time
     .runaway_takeoff_deactivate_delay = 500     // Accumulated time (in milliseconds) before deactivation in successful takeoff
 );

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -230,10 +230,11 @@ typedef struct pidProfile_s {
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
 
 typedef struct pidConfig_s {
-    uint8_t pid_process_denom;              // Processing denominator for PID controller vs gyro sampling rate
-    uint8_t runaway_takeoff_prevention;          // off, on - enables pidsum runaway disarm logic
-    uint16_t runaway_takeoff_deactivate_delay;   // delay in ms for "in-flight" conditions before deactivation (successful flight)
-    uint8_t runaway_takeoff_deactivate_throttle; // minimum throttle percent required during deactivation phase
+    uint8_t pid_process_denom;                            // Processing denominator for PID controller vs gyro sampling rate
+    uint8_t runaway_takeoff_prevention;                   // off, on - enables pidsum runaway disarm logic
+    uint8_t runaway_takeoff_prevention_crashflip_reset;   // off, on - prevents runaway_takeoff_prevention after armed once
+    uint16_t runaway_takeoff_deactivate_delay;            // delay in ms for "in-flight" conditions before deactivation (successful flight)
+    uint8_t runaway_takeoff_deactivate_throttle;          // minimum throttle percent required during deactivation phase
 } pidConfig_t;
 
 PG_DECLARE(pidConfig_t, pidConfig);


### PR DESCRIPTION
### Add `runaway_takeoff_prevention_crashflip_reset`
`minor feature`
#Fixes #10746
Follow PR #10810 

---

Add the suggested `runaway_takeoff_prevention_crashflip_reset` in #10746. It allows users, using CLI, to disable the runaway_takeoff_prevention that resets to its initial value after you go in flip over after crash mode.

It allows racers to go back faster in the air if their quad is somewhat stuck in grass, trusting raw power to get out of there, instead of being disarmed and loose precious time. Today users would have to disable completely `runaway_takeoff_prevention` and cross fingers for luck, to avoid this. However, the use of this would be to the user's own risks of runaways.

Default value of `runaway_takeoff_prevention_crashflip_reset` is set to `true`, so it won't change anything if you don't change it in the CLI. If you do, it will change the `runawayTakeoffCheckDisabled` to `true` instead of `false`, and won't init the runaway_takeoff_prevention function (l.810 of core.c).

```c
                if (pidConfig()->runaway_takeoff_prevention_crashflip_reset) {
                    runawayTakeoffCheckDisabled = false;
                } else {
                  runawayTakeoffCheckDisabled = true;
                }
```

According changes have been made in `settings.c` , `pid.c` and `pid.h`.

As always :

 - `make pre-push` and `make unified_zip` went well.

- `make unified_zip` are attached to the PR with firmware targets for users to test.

- awaiting for your reviews and explaination, because I'm not 100% sure I commit in the right function in `core.c`, although it looks like to me I did.

- Shoud this change be made ? (in _/betaflight/src/main/flight/pid.c_). In doubt, I didn't commit it.
  - from `PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 2);`
  - to `PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);`


[betaflight_4.3.0_STM32F405_5b8621c9e.zip](https://github.com/betaflight/betaflight/files/6694178/betaflight_4.3.0_STM32F405_5b8621c9e.zip)
[betaflight_4.3.0_STM32F411_5b8621c9e.zip](https://github.com/betaflight/betaflight/files/6694179/betaflight_4.3.0_STM32F411_5b8621c9e.zip)
[betaflight_4.3.0_STM32F7X2_5b8621c9e.zip](https://github.com/betaflight/betaflight/files/6694180/betaflight_4.3.0_STM32F7X2_5b8621c9e.zip)
[betaflight_4.3.0_STM32F745_5b8621c9e.zip](https://github.com/betaflight/betaflight/files/6694181/betaflight_4.3.0_STM32F745_5b8621c9e.zip)
[betaflight_4.3.0_STM32G47X_5b8621c9e.zip](https://github.com/betaflight/betaflight/files/6694182/betaflight_4.3.0_STM32G47X_5b8621c9e.zip)