### PR TITLE
Fix UART/USART mismatch for USART10.

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -97,7 +97,7 @@ const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
     SERIAL_PORT_UART9,
 #endif
 #ifdef USE_UART10
-    SERIAL_PORT_UART10,
+    SERIAL_PORT_USART10,
 #endif
 #ifdef USE_SOFTSERIAL1
     SERIAL_PORT_SOFTSERIAL1,


### PR DESCRIPTION
Found an issue in #10704 after compiling a target yesterday that uses USART10.

USART10 *is* a USART, not a UART.  I verfied this in the RM0468 reference manual.