### PR TITLE
Fix rcSmoothing such that rcCommand is always filtered

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4347,7 +4347,7 @@ static void cliDefaults(const char *cmdName, char *cmdline)
 
             if (!parameterGroupId) {
                 cliShowParseError(cmdName);
-                
+
                 return;
             }
         } else if (strcasestr(tok, "group_id")) {
@@ -5019,7 +5019,7 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
             cliPrintLine("(auto)");
         }
         cliPrintf("# Active throttle cutoff: %dhz ", rcSmoothingData->throttleCutoffFrequency);
-        if (rcSmoothingData->ffCutoffSetting) {
+        if (rcSmoothingData->throttleCutoffSetting) {
             cliPrintLine("(manual)");
         } else {
             cliPrintLine("(auto)");

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1027,6 +1027,8 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         float pidSetpointDelta = 0;
 #ifdef USE_FEEDFORWARD
         pidSetpointDelta = feedforwardApply(axis, newRcFrame, pidRuntime.feedforwardAveraging);
+#else
+        pidSetpointDelta = currentPidSetpoint - previousPidSetpoint[axis];
 #endif
         pidRuntime.previousPidSetpoint[axis] = currentPidSetpoint;
 


### PR DESCRIPTION
There are no viable arguments for why we would want to use an unfiltered rcCommand. The old way rcSmoothing worked filtered rcCommand. Now that is no longer the case and is filtering the setpoint instead and is causing many issues. Other methods are in the works like PR #10774, but these cause a long list of future fixes that will need to be accounted for creating a maintenance mess. This aims to restore previous functionality while still providing rawSetpoint for the feedforward. Not sure if it makes sense to feed feedforward raw setpoint instead of giving it filtered data. 

@etracer65 I think that this is more in line with your previous suggestions and desires mentioned in PR #10774, if not I'd love to fix this PR until it is.