### PR TITLE
Suport for long range RC links with refresh rate lower than 33Hz down to 16Hz 

### DIFF
--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -47,3 +47,4 @@ float applyCurve(int axis, float deflection);
 bool getShouldUpdateFeedforward();
 void updateRcRefreshRate(timeUs_t currentTimeUs);
 uint16_t getCurrentRxRefreshRate(void);
+bool getRxRateValid(void);

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -94,7 +94,7 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
         // interpolate setpoint if necessary
         if (rcCommandDelta == 0.0f) {
             // duplicate packet data on this axis
-            if (goodPacketCount[axis] >= 2 && setpointPercent < 0.95f) {
+            if (getRxRateValid() && goodPacketCount[axis] >= 2 && setpointPercent < 0.95f) {
                 // interpolate if two or more preceding valid packets, or if sticks near max
                 setpoint = prevSetpoint[axis] + (prevSetpointSpeed[axis] + prevAcceleration[axis] * jitterAttenuator) * rxInterval * jitterAttenuator;
                 // setpoint interpolation includes previous acceleration and attenuation

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -120,6 +120,7 @@ uint32_t rcInvalidPulsPeriod[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 
 #define DELAY_50_HZ (1000000 / 50)
 #define DELAY_33_HZ (1000000 / 33)
+#define DELAY_15_HZ (1000000 / 15)
 #define DELAY_10_HZ (1000000 / 10)
 #define DELAY_5_HZ (1000000 / 5)
 #define SKIP_RC_ON_SUSPEND_PERIOD 1500000           // 1.5 second period in usec (call frequency independent)
@@ -695,7 +696,7 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
     }
 
     rxDataProcessingRequired = false;
-    rxNextUpdateAtUs = currentTimeUs + DELAY_33_HZ;
+    rxNextUpdateAtUs = currentTimeUs + DELAY_15_HZ;
 
     // only proceed when no more samples to skip and suspend period is over
     if (skipRxSamples || currentTimeUs <= suspendRxSignalUntil) {


### PR DESCRIPTION
Some RC links support long range mode and needs lower refresh rates.

Eg.
* IRC GHOST 19Hz
* ELRS 25Hz

This PR
* Enables refresh rate down to 15Hz
* Enables smoothing down to 15.26Hz
* Set minimum cutoff frequency for RC smoothing to 15Hz. Lower frequencies result in a lot of delay (tens of milliseconds).
* Minimum refresh rate in fact seems to be 16Hz and I would not recommend going below 20Hz.

We need to test that
* PR doesn't break anything
* Behavior after some frame loss with low refresh rate, especially FF

Thanks @ctzsnooze for strong support.