### PR TITLE
Prioritize pid-mix over throttle-mix

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -350,6 +350,14 @@ static void applyMixToMotors(float motorMix[MAX_SUPPORTED_MOTORS], motorMixer_t 
 {
     // Now add in the desired throttle, but keep in a range that doesn't clip adjusted
     // roll/pitch/yaw. This could move throttle down, but also up for those low throttle flips.
+    for (int i=0; i < mixerRuntime.motorCount; i++) {
+        if(motorOutputMixSign * motorMix[i] + throttle * activeMixer[i].throttle > 1) {
+            throttle = (1 - motorOutputMixSign * motorMix[i]) / activeMixer[i].throttle;
+        } else if(motorOutputMixSign * motorMix[i] + throttle * activeMixer[i].throttle < 0) {
+            throttle = - motorOutputMixSign * motorMix[i] / activeMixer[i].throttle;
+        }
+    }
+
     for (int i = 0; i < mixerRuntime.motorCount; i++) {
         float motorOutput = motorOutputMixSign * motorMix[i] + throttle * activeMixer[i].throttle;
 #ifdef USE_THRUST_LINEARIZATION


### PR DESCRIPTION
## General

I investigated a couple of crashes which I initially considered as propwash problems. In that crashes, the drone is typically flying with quite some speed in one direction and then wants to break and accelerate in the opposite direction. The drone then looses attitude control and tumbles to the ground.
It turns out that for me the problem is not a propwash problem but a bug in the motor output mixer.

## Problem

Currently, betaflight is calculating the motor output from the pid-mix (coming from the pid-controller/attitude control) and the throttle mix without prioritizing the pid-mix. For aggressive maneuvers this leads to instabilities in the drone attitude, when for at least one motor the motor output violates the motor limits. In that case the motor output (pid-mix and throttle-mix) is just clamped to motor limits which leads to an arbitrary cut in the pid-mix.

## What is changed

Before the actual motor mix is calculated, the throttle is checked whether it is violating a motor output limit. If this is the case, a new throttle is found which just holds the motor output limit.

