### PR TITLE
Default yaw lowpass to 100hz

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -135,7 +135,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         },
         .pidSumLimit = PIDSUM_LIMIT,
         .pidSumLimitYaw = PIDSUM_LIMIT_YAW,
-        .yaw_lowpass_hz = 0,
+        .yaw_lowpass_hz = 100,
         .dterm_notch_hz = 0,
         .dterm_notch_cutoff = 0,
         .itermWindupPointPercent = 100,


### PR DESCRIPTION
Yaw provides a path for noise from the gyros to the motors.

It is also the fastest responding axis in most quad rotor builds, typically quicker than pitch or roll to respond, and isn't prone to oscillation on P.

An additional 100hz first order filter on yaw attenuates noise without adding meaningful delay, and helps reduce the amount of noise going to the motors. 