### PR TITLE
Fix TIM15_CH2 IO assignment

### DIFF
--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -982,7 +982,7 @@
 
 #define DEF_TIM_AF__PA1__TCH_TIM15_CH1N   D(4, 15)
 #define DEF_TIM_AF__PA2__TCH_TIM15_CH1    D(4, 15)
-#define DEF_TIM_AF__PA2__TCH_TIM15_CH2    D(4, 15)
+#define DEF_TIM_AF__PA3__TCH_TIM15_CH2    D(4, 15)
 
 //PORTB
 #define DEF_TIM_AF__PB0__TCH_TIM1_CH2N    D(1, 1)

--- a/src/main/drivers/timer_stm32h7xx.c
+++ b/src/main/drivers/timer_stm32h7xx.c
@@ -80,7 +80,7 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
 
     DEF_TIM(TIM15, CH1N, PA1, TIM_USE_ANY, 0, 0, 0),
     DEF_TIM(TIM15, CH1, PA2, TIM_USE_ANY, 0, 0, 0),
-    DEF_TIM(TIM15, CH2, PA2, TIM_USE_ANY, 0, 0, 0),
+    DEF_TIM(TIM15, CH2, PA3, TIM_USE_ANY, 0, 0, 0),
 
 // Port B
     DEF_TIM(TIM1, CH2N, PB0, TIM_USE_ANY, 0, 0, 0),


### PR DESCRIPTION
Fixes IO assignment for TIM15 CH2. Was PA2 instead of PA3