### PR TITLE
Change RPM Filter minHz limit / rename CLI commands and parameters

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1430,10 +1430,11 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE("motor_poles", "%d",                     motorConfig()->motorPoleCount);
 #endif
 #ifdef USE_RPM_FILTER
-        BLACKBOX_PRINT_HEADER_LINE("gyro_rpm_notch_harmonics", "%d",        rpmFilterConfig()->gyro_rpm_notch_harmonics);
-        BLACKBOX_PRINT_HEADER_LINE("gyro_rpm_notch_q", "%d",                rpmFilterConfig()->gyro_rpm_notch_q);
-        BLACKBOX_PRINT_HEADER_LINE("gyro_rpm_notch_min", "%d",              rpmFilterConfig()->gyro_rpm_notch_min);
-        BLACKBOX_PRINT_HEADER_LINE("rpm_notch_lpf", "%d",                   rpmFilterConfig()->rpm_lpf);
+        BLACKBOX_PRINT_HEADER_LINE("rpm_filter_harmonics", "%d",            rpmFilterConfig()->rpm_filter_harmonics);
+        BLACKBOX_PRINT_HEADER_LINE("rpm_filter_q", "%d",                    rpmFilterConfig()->rpm_filter_q);
+        BLACKBOX_PRINT_HEADER_LINE("rpm_filter_min_hz", "%d",               rpmFilterConfig()->rpm_filter_min_hz);
+        BLACKBOX_PRINT_HEADER_LINE("rpm_filter_fade_range_hz", "%d",        rpmFilterConfig()->rpm_filter_fade_range_hz);
+        BLACKBOX_PRINT_HEADER_LINE("rpm_filter_lpf_hz", "%d",               rpmFilterConfig()->rpm_filter_lpf_hz);
 #endif
 #if defined(USE_ACC)
         BLACKBOX_PRINT_HEADER_LINE("acc_lpf_hz", "%d",                 (int)(accelerometerConfig()->acc_lpf_hz * 100.0f));

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1656,11 +1656,11 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_RPM_FILTER
-    { "gyro_rpm_notch_harmonics",  VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, gyro_rpm_notch_harmonics) },
-    { "gyro_rpm_notch_q",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 250, 3000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, gyro_rpm_notch_q) },
-    { "gyro_rpm_notch_min",  VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 50, 200 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, gyro_rpm_notch_min) },
-    { "gyro_rpm_notch_fade_range_hz",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, gyro_rpm_notch_fade_range_hz) },
-    { "rpm_notch_lpf",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 500 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_lpf) },
+    { "rpm_filter_harmonics",  VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_harmonics) },
+    { "rpm_filter_q",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 250, 3000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_q) },
+    { "rpm_filter_min_hz",  VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 30, 200 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_min_hz) },
+    { "rpm_filter_fade_range_hz",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_fade_range_hz) },
+    { "rpm_filter_lpf_hz",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 500 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_lpf_hz) },
 #endif
 
 #ifdef USE_RX_FLYSKY

--- a/src/main/flight/rpm_filter.h
+++ b/src/main/flight/rpm_filter.h
@@ -25,18 +25,19 @@
 
 typedef struct rpmFilterConfig_s
 {
-    uint8_t  gyro_rpm_notch_harmonics;     // how many harmonics should be covered with notches? 0 means filter off
-    uint8_t  gyro_rpm_notch_min;           // minimum frequency of the notches
-    uint16_t gyro_rpm_notch_fade_range_hz; // range in which to gradually turn off notches down to minHz
-    uint16_t gyro_rpm_notch_q;             // q of the notches
+    uint8_t  rpm_filter_harmonics;     // how many harmonics should be covered with notches? 0 means filter off
+    uint8_t  rpm_filter_min_hz;        // minimum frequency of the notches
+    uint16_t rpm_filter_fade_range_hz; // range in which to gradually turn off notches down to minHz
+    uint16_t rpm_filter_q;             // q of the notches
 
-    uint16_t rpm_lpf;                      // the cutoff of the lpf on reported motor rpm
+    uint16_t rpm_filter_lpf_hz;        // the cutoff of the lpf on reported motor rpm
+
 } rpmFilterConfig_t;
 
 PG_DECLARE(rpmFilterConfig_t, rpmFilterConfig);
 
 void  rpmFilterInit(const rpmFilterConfig_t *config);
 float rpmFilterGyro(const int axis, float value);
-void  rpmFilterUpdate();
+void  rpmFilterUpdate(void);
 bool isRpmFilterEnabled(void);
-float rpmMinMotorFrequency();
+float rpmMinMotorFrequency(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1792,8 +1792,8 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, 0);
 #endif
 #if defined(USE_RPM_FILTER)
-        sbufWriteU8(dst, rpmFilterConfig()->gyro_rpm_notch_harmonics);
-        sbufWriteU8(dst, rpmFilterConfig()->gyro_rpm_notch_min);
+        sbufWriteU8(dst, rpmFilterConfig()->rpm_filter_harmonics);
+        sbufWriteU8(dst, rpmFilterConfig()->rpm_filter_min_hz);
 #else
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
@@ -2675,8 +2675,8 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU16(src);
 #endif
 #if defined(USE_RPM_FILTER)
-            rpmFilterConfigMutable()->gyro_rpm_notch_harmonics = sbufReadU8(src);
-            rpmFilterConfigMutable()->gyro_rpm_notch_min = sbufReadU8(src);
+            rpmFilterConfigMutable()->rpm_filter_harmonics = sbufReadU8(src);
+            rpmFilterConfigMutable()->rpm_filter_min_hz = sbufReadU8(src);
 #else
             sbufReadU8(src);
             sbufReadU8(src);


### PR DESCRIPTION
# RPM Filter limit

@ctzsnooze mentioned that XClass drones can have very low RPMs. Their motor noise can go as low as **2000RPM**, which corresponds to about **33Hz**. Since we now have [biquad crossfading](https://github.com/betaflight/betaflight/pull/10757) merged to master, latency and resonances at minHz is not as much of an issue anymore. Therefore we can now allow minHz to go a bit lower if it is needed.

**So this PR primarily is to extend the lower range the RPM Filter can operate in.** 

# Renaming

@ctzsnooze also brought up that there are some inconsistencies with the naming of the RPM Filter's CLI commands. This can lead to confusion about the actual purpose of the commands.

For example: `gyro_rpm_notch_min` can be **wrongly** interpreted as the RPM Filter's limit in the unit of RPM (instead of the correct unit Hz).

In addition, now that we don't have the option of the RPM Filter on the Dterm anymore, we can also get rid of the `gyro_` prefix. This leaves us with the prefix `rpm_notch_`. To make this prefix more descriptive for the end user it is now called by its actual name: `rpm_filter_`.

### The following is a table with the old and new CLI commands:

| Old CLI command                     | New CLI command |
| -------------------------------- | ---------------------- |
| gyro_rpm_notch_harmonics       | rpm_filter_harmonics  |
| gyro_rpm_notch_q                     | rpm_filter_q               |
| gyro_rpm_notch_min                 | rpm_filter_min_hz       |
| gyro_rpm_notch_fade_range_hz | rpm_filter_fade_range_hz |
| rpm_notch_lpf                            | rpm_filter_lpf_hz         |

**The same applies to the variable names in the source code.**

# Blackbox header

In the original PR for [biquad crossfading](https://github.com/betaflight/betaflight/pull/10757) I forgot to include the setting `rpm_filter_fade_range_hz` to the blackbox header, so this PR also fixes that.

# Credits

All credits go to @ctzsnooze who pointed it out to me.
