### PR TITLE
fix fpv camera angle code error

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -236,7 +236,7 @@ float applyCurve(int axis, float deflection)
     return applyRates(axis, deflection, fabsf(deflection));
 }
 
-static void scaleSetpointToFpvCamAngle(void)
+static void scaleRawSetpointToFpvCamAngle(void)
 {
     //recalculate sin/cos only when rxConfig()->fpvCamAngleDegrees changed
     static uint8_t lastFpvCamAngleDegrees = 0;
@@ -249,10 +249,10 @@ static void scaleSetpointToFpvCamAngle(void)
         sinFactor = sin_approx(rxConfig()->fpvCamAngleDegrees * RAD);
     }
 
-    float roll = setpointRate[ROLL];
-    float yaw = setpointRate[YAW];
-    setpointRate[ROLL] = constrainf(roll * cosFactor -  yaw * sinFactor, -SETPOINT_RATE_LIMIT * 1.0f, SETPOINT_RATE_LIMIT * 1.0f);
-    setpointRate[YAW]  = constrainf(yaw  * cosFactor + roll * sinFactor, -SETPOINT_RATE_LIMIT * 1.0f, SETPOINT_RATE_LIMIT * 1.0f);
+    float roll = rawSetpoint[ROLL];
+    float yaw = rawSetpoint[YAW];
+    rawSetpoint[ROLL] = constrainf(roll * cosFactor -  yaw * sinFactor, -SETPOINT_RATE_LIMIT * 1.0f, SETPOINT_RATE_LIMIT * 1.0f);
+    rawSetpoint[YAW]  = constrainf(yaw  * cosFactor + roll * sinFactor, -SETPOINT_RATE_LIMIT * 1.0f, SETPOINT_RATE_LIMIT * 1.0f);
 }
 
 #define THROTTLE_BUFFER_MAX 20
@@ -587,11 +587,10 @@ FAST_CODE void processRcCommand(void)
             }
             rawSetpoint[axis] = constrainf(angleRate, -1.0f * currentControlRateProfile->rate_limit[axis], 1.0f * currentControlRateProfile->rate_limit[axis]);
             DEBUG_SET(DEBUG_ANGLERATE, axis, angleRate);
-        } 
-
-        // adjust un-filtered setpoint steps to camera angle (mixing Roll and Yaw)
+        }
+        // adjust raw setpoint steps to camera angle (mixing Roll and Yaw)
         if (rxConfig()->fpvCamAngleDegrees && IS_RC_MODE_ACTIVE(BOXFPVANGLEMIX) && !FLIGHT_MODE(HEADFREE_MODE)) {
-            scaleSetpointToFpvCamAngle();
+            scaleRawSetpointToFpvCamAngle();
         }
     }
 


### PR DESCRIPTION
Fixes #10849.

As noted in issue #10849, the changes recently made in rc.c have had the unintended result that feedforward isn't being calculated on the new camera-angle modified set points.  

This would happen when `fpv_mix_degrees` is set to a non-zero value, activating the FPV camera angle correction code, which crosses roll and yaw set points over to compensate for FPV camera angle.

This PR is a bug-fix that performs the camera angle corrections on the 'rawSetpoint' steps, which are the values used for feedforward calculations.  The result should be feedforward from the adapted setpoints.

I think this is how it should have been done in the first place.

Thanks to @haplm for identifying the problem.

