### PR TITLE
Added indication for N-channel timers to 'resource show all'.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5864,7 +5864,8 @@ static void showTimers(void)
         cliPrintf("TIM%d:", timerNumber);
         bool timerUsed = false;
         for (unsigned timerIndex = 0; timerIndex < CC_CHANNELS_PER_TIMER; timerIndex++) {
-            const resourceOwner_t *timerOwner = timerGetOwner(timerNumber, CC_CHANNEL_FROM_INDEX(timerIndex));
+            const timerHardware_t *timer = timerGetAllocatedByNumberAndChannel(timerNumber, CC_CHANNEL_FROM_INDEX(timerIndex));
+            const resourceOwner_t *timerOwner = timerGetOwner(timer);
             if (timerOwner->owner) {
                 if (!timerUsed) {
                     timerUsed = true;
@@ -5873,9 +5874,9 @@ static void showTimers(void)
                 }
 
                 if (timerOwner->resourceIndex > 0) {
-                    cliPrintLinef("    CH%d: %s %d", timerIndex + 1, ownerNames[timerOwner->owner], timerOwner->resourceIndex);
+                    cliPrintLinef("    CH%d%s: %s %d", timerIndex + 1, timer->output & TIMER_OUTPUT_N_CHANNEL ? "N" : " ", ownerNames[timerOwner->owner], timerOwner->resourceIndex);
                 } else {
-                    cliPrintLinef("    CH%d: %s", timerIndex + 1, ownerNames[timerOwner->owner]);
+                    cliPrintLinef("    CH%d%s: %s", timerIndex + 1, timer->output & TIMER_OUTPUT_N_CHANNEL ? "N" : " ", ownerNames[timerOwner->owner]);
                 }
             }
         }

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1589,7 +1589,7 @@ static void cliSerialPassthrough(const char *cmdName, char *cmdline)
         for (unsigned i = 0; i < motorsCount; i++) {
             const ioTag_t tag = motorConfig()->dev.ioTags[i];
             if (tag) {
-                const timerHardware_t *timerHardware = timerGetByTag(tag);
+                const timerHardware_t *timerHardware = timerGetConfiguredByTag(tag);
                 if (timerHardware) {
                     IO_t io = IOGetByTag(tag);
                     IOInit(io, OWNER_MOTOR, 0);
@@ -5646,7 +5646,7 @@ static void cliDmaopt(const char *cmdName, char *cmdline)
 #if defined(USE_TIMER_MGMT)
         timerIoConfig = timerIoConfigByTag(ioTag);
 #endif
-        timer = timerGetByTag(ioTag);
+        timer = timerGetConfiguredByTag(ioTag);
     }
 
     // opt or list

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -476,7 +476,7 @@ static void validateAndFixConfig(void)
 
 #if defined(USE_BEEPER)
 #ifdef USE_TIMER
-    if (beeperDevConfig()->frequency && !timerGetByTag(beeperDevConfig()->ioTag)) {
+    if (beeperDevConfig()->frequency && !timerGetConfiguredByTag(beeperDevConfig()->ioTag)) {
         beeperDevConfigMutable()->frequency = 0;
     }
 #endif

--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -245,11 +245,11 @@ static bbPort_t *bbAllocMotorPort(int portIndex)
     return bbPort;
 }
 
-const resourceOwner_t *dshotBitbangTimerGetOwner(int8_t timerNumber, uint16_t timerChannel)
+const resourceOwner_t *dshotBitbangTimerGetOwner(const timerHardware_t *timer)
 {
     for (int index = 0; index < usedMotorPorts; index++) {
-        const timerHardware_t *timer = bbPorts[index].timhw;
-        if (timerGetTIMNumber(timer->tim) == timerNumber && timer->channel == timerChannel) {
+        const timerHardware_t *bitbangTimer = bbPorts[index].timhw;
+        if (bitbangTimer && bitbangTimer == timer) {
             return &bbPorts[index].owner;
         }
     }
@@ -351,7 +351,8 @@ static void bbFindPacerTimer(void)
             }
             bool timerConflict = false;
             for (int channel = 0; channel < CC_CHANNELS_PER_TIMER; channel++) {
-                const resourceOwner_e timerOwner = timerGetOwner(timNumber, CC_CHANNEL_FROM_INDEX(channel))->owner;
+                const timerHardware_t *timer = timerGetAllocatedByNumberAndChannel(timNumber, CC_CHANNEL_FROM_INDEX(channel));
+                const resourceOwner_e timerOwner = timerGetOwner(timer)->owner;
                 if (timerOwner != OWNER_FREE && timerOwner != OWNER_DSHOT_BITBANG) {
                     timerConflict = true;
                     break;

--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -711,7 +711,7 @@ motorDevice_t *dshotBitbangDevInit(const motorDevConfig_t *motorConfig, uint8_t 
 
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
         const unsigned reorderedMotorIndex = motorConfig->motorOutputReordering[motorIndex];
-        const timerHardware_t *timerHardware = timerGetByTag(motorConfig->ioTags[reorderedMotorIndex]);
+        const timerHardware_t *timerHardware = timerGetConfiguredByTag(motorConfig->ioTags[reorderedMotorIndex]);
         const IO_t io = IOGetByTag(motorConfig->ioTags[reorderedMotorIndex]);
 
         uint8_t output = motorConfig->motorPwmInversion ?  timerHardware->output ^ TIMER_OUTPUT_INVERTED : timerHardware->output;

--- a/src/main/drivers/dshot_bitbang.h
+++ b/src/main/drivers/dshot_bitbang.h
@@ -39,4 +39,4 @@ struct motorDevConfig_s;
 struct motorDevice_s;
 struct motorDevice_s *dshotBitbangDevInit(const struct motorDevConfig_s *motorConfig, uint8_t motorCount);
 dshotBitbangStatus_e dshotBitbangGetStatus();
-const resourceOwner_t *dshotBitbangTimerGetOwner(int8_t timerNumber, uint16_t timerChannel);
+const resourceOwner_t *dshotBitbangTimerGetOwner(const timerHardware_t *timer);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -278,7 +278,8 @@ extern const resourceOwner_t freeOwner;
 struct timerIOConfig_s;
 
 struct timerIOConfig_s *timerIoConfigByTag(ioTag_t ioTag);
-const resourceOwner_t *timerGetOwner(int8_t timerNumber, uint16_t timerChannel);
+const timerHardware_t *timerGetAllocatedByNumberAndChannel(int8_t timerNumber, uint16_t timerChannel);
+const resourceOwner_t *timerGetOwner(const timerHardware_t *timer);
 #endif
 const timerHardware_t *timerGetByTag(ioTag_t ioTag);
 const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -281,7 +281,7 @@ struct timerIOConfig_s *timerIoConfigByTag(ioTag_t ioTag);
 const timerHardware_t *timerGetAllocatedByNumberAndChannel(int8_t timerNumber, uint16_t timerChannel);
 const resourceOwner_t *timerGetOwner(const timerHardware_t *timer);
 #endif
-const timerHardware_t *timerGetByTag(ioTag_t ioTag);
+const timerHardware_t *timerGetConfiguredByTag(ioTag_t ioTag);
 const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex);
 const timerHardware_t *timerGetByTagAndIndex(ioTag_t ioTag, unsigned timerIndex);
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index);

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -44,16 +44,6 @@ timerIOConfig_t *timerIoConfigByTag(ioTag_t ioTag)
     return NULL;
 }
 
-static uint8_t timerIndexByTag(ioTag_t ioTag)
-{
-    for (unsigned i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
-        if (timerIOConfig(i)->ioTag == ioTag) {
-            return timerIOConfig(i)->index;
-        }
-    }
-    return 0;
-}
-
 const timerHardware_t *timerGetByTagAndIndex(ioTag_t ioTag, unsigned timerIndex)
 {
 
@@ -74,9 +64,16 @@ const timerHardware_t *timerGetByTagAndIndex(ioTag_t ioTag, unsigned timerIndex)
     return NULL;
 }
 
-const timerHardware_t *timerGetByTag(ioTag_t ioTag)
+const timerHardware_t *timerGetConfiguredByTag(ioTag_t ioTag)
 {
-    uint8_t timerIndex = timerIndexByTag(ioTag);
+    uint8_t timerIndex = 0;
+    for (unsigned i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
+        if (timerIOConfig(i)->ioTag == ioTag) {
+            timerIndex = timerIOConfig(i)->index;
+
+            break;
+        }
+    }
 
     return timerGetByTagAndIndex(ioTag, timerIndex);
 }
@@ -139,7 +136,7 @@ const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8
 }
 #else
 
-const timerHardware_t *timerGetByTag(ioTag_t ioTag)
+const timerHardware_t *timerGetConfiguredByTag(ioTag_t ioTag)
 {
 #if TIMER_CHANNEL_COUNT > 0
     for (unsigned i = 0; i < TIMER_CHANNEL_COUNT; i++) {
@@ -158,7 +155,7 @@ const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8
     UNUSED(owner);
     UNUSED(resourceIndex);
 
-    return timerGetByTag(ioTag);
+    return timerGetConfiguredByTag(ioTag);
 }
 #endif
 


### PR DESCRIPTION
This will show timers using an N-channel in the output of `timer show`, making it easier to diagnose situations where bidirectional Dshot will not work (because N-channel timers are output only):

```
# timer show

Currently active Timers:
-----------------------
TIM1:
    CH1 : MOTOR 3
    CH2 : MOTOR 4
TIM2: FREE
TIM3: FREE
TIM4:
    CH3 : CAMERA_CONTROL
TIM5: FREE
TIM6: FREE
TIM7: FREE
TIM8:
    CH2N: MOTOR 1
    CH4 : MOTOR 2
TIM9: FREE
TIM10: FREE
TIM11: FREE
TIM12: FREE
TIM13: FREE
TIM14: FREE
```

I also renamed some of the helper functions for timers to make it more obvious what set of timers they are working on.
