### PR TITLE
Changed naming of SPI DMA resources to reflect the SPI bus number.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -250,7 +250,7 @@ static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
 
 static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const gyroDeviceConfig_t *config)
 {
-    if (!config->csnTag || !spiSetBusInstance(&gyro->dev, config->spiBus, OWNER_GYRO_CS)) {
+    if (!config->csnTag || !spiSetBusInstance(&gyro->dev, config->spiBus)) {
         return false;
     }
 

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -62,7 +62,6 @@ typedef struct busDevice_s {
     bool useDMA;
     bool useAtomicWait;
     uint8_t deviceCount;
-    resourceOwner_e owner; // owner of first device to use this bus
     dmaChannelDescriptor_t *dmaTx;
     dmaChannelDescriptor_t *dmaRx;
     uint32_t dmaTxChannel;

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -471,8 +471,8 @@ static void spiRxIrqHandler(dmaChannelDescriptor_t* descriptor)
     }
 }
 
-// Mark this bus as being SPI and record the first owner to use it
-bool spiSetBusInstance(extDevice_t *dev, uint32_t device, resourceOwner_e owner)
+// Mark this bus as being SPI
+bool spiSetBusInstance(extDevice_t *dev, uint32_t device)
 {
     if (device > SPIDEV_COUNT) {
         return false;
@@ -499,7 +499,6 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device, resourceOwner_e owner)
     bus->useDMA = false;
     bus->useAtomicWait = false;
     bus->deviceCount = 1;
-    bus->owner = owner;
     bus->initTx = &dev->initTx;
     bus->initRx = &dev->initRx;
 
@@ -545,7 +544,7 @@ void spiInitBusDMA()
                 }
 #endif
                 bus->dmaTxChannel = dmaTxChannelSpec->channel;
-                dmaInit(dmaTxIdentifier, bus->owner, 0);
+                dmaInit(dmaTxIdentifier, OWNER_SPI_MOSI, device + 1);
                 break;
             }
         }
@@ -566,7 +565,7 @@ void spiInitBusDMA()
                 }
 #endif
                 bus->dmaRxChannel = dmaRxChannelSpec->channel;
-                dmaInit(dmaRxIdentifier, bus->owner, 0);
+                dmaInit(dmaRxIdentifier, OWNER_SPI_MISO, device + 1);
                 break;
             }
         }

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -112,8 +112,8 @@ SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
 // BusDevice API
 
-// Mark a device's associated bus as being SPI and record the first owner to use it
-bool spiSetBusInstance(extDevice_t *dev, uint32_t device, resourceOwner_e owner);
+// Mark a device's associated bus as being SPI
+bool spiSetBusInstance(extDevice_t *dev, uint32_t device);
 // Determine the divisor to use for a given bus frequency
 uint16_t spiCalculateDivider(uint32_t freq);
 // Set the clock divisor to be used for accesses by the given device

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -147,7 +147,7 @@ static bool flashSpiInit(const flashConfig_t *flashConfig)
         return false;
     }
 
-    if (!spiSetBusInstance(dev, flashConfig->spiDevice, OWNER_FLASH_CS)) {
+    if (!spiSetBusInstance(dev, flashConfig->spiDevice)) {
         return false;
     }
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -351,7 +351,7 @@ max7456InitStatus_e max7456Init(const max7456Config_t *max7456Config, const vcdP
 
     max7456HardwareReset();
 
-    if (!max7456Config->csTag || !spiSetBusInstance(dev, max7456Config->spiDevice, OWNER_OSD_CS)) {
+    if (!max7456Config->csTag || !spiSetBusInstance(dev, max7456Config->spiDevice)) {
         return MAX7456_INIT_NOT_CONFIGURED;
     }
 

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -87,7 +87,7 @@ void rxSpiStartupSpeed()
 
 bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig)
 {
-    if (!spiSetBusInstance(dev, rxSpiConfig->spibus, OWNER_RX_SPI_CS)) {
+    if (!spiSetBusInstance(dev, rxSpiConfig->spibus)) {
         return false;
     }
 

--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -549,7 +549,7 @@ static void sdcardSpi_init(const sdcardConfig_t *config, const spiPinConfig_t *s
         return;
     }
 
-    spiSetBusInstance(&sdcard.dev, config->device, OWNER_SDCARD_CS);
+    spiSetBusInstance(&sdcard.dev, config->device);
 
     IO_t chipSelectIO;
     if (config->chipSelectTag) {

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -110,7 +110,7 @@ bool rtc6705IOInit(const vtxIOConfig_t *vtxIOConfig)
         IOConfigGPIO(vtxPowerPin, IOCFG_OUT_PP);
     }
 
-    if (vtxIOConfig->csTag && spiSetBusInstance(dev, vtxIOConfig->spiDevice, OWNER_VTX_CS)) {
+    if (vtxIOConfig->csTag && spiSetBusInstance(dev, vtxIOConfig->spiDevice)) {
         devInstance.busType_u.spi.csnPin = csnPin;
         IOInit(devInstance.busType_u.spi.csnPin, OWNER_VTX_CS, 0);
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -184,7 +184,7 @@ bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
         {
-            if (!spiSetBusInstance(dev, barometerConfig()->baro_spi_device, OWNER_BARO_CS)) {
+            if (!spiSetBusInstance(dev, barometerConfig()->baro_spi_device)) {
                 return false;
             }
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -147,7 +147,7 @@ bool compassDetect(magDev_t *magDev, uint8_t *alignment)
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
         {
-            if (!spiSetBusInstance(dev, compassConfig()->mag_spi_device, OWNER_COMPASS_CS)) {
+            if (!spiSetBusInstance(dev, compassConfig()->mag_spi_device)) {
                 return false;
             }
 


### PR DESCRIPTION
Now we are reflecting the directionality and bus number:

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: SPI_MISO 3
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC
DMA2 Stream 1: MOTOR 3
DMA2 Stream 2: SPI_MISO 1
DMA2 Stream 3: MOTOR 1
DMA2 Stream 4: FREE
DMA2 Stream 5: SPI_MOSI 1
DMA2 Stream 6: MOTOR 4
DMA2 Stream 7: MOTOR 2
```