### PR TITLE
Determine valid SPI clock if USE_OVERCLOCK is not defined

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -420,6 +420,7 @@ max7456InitStatus_e max7456Init(const max7456Config_t *max7456Config, const vcdP
 #else
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
+    max7456SpiClock = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
 #endif
 
     spiSetClkDivisor(dev, max7456SpiClock);


### PR DESCRIPTION
Fix for https://github.com/betaflight/betaflight/pull/10705#issuecomment-886965895

max7456SpiClock was not being calculated if USE_OVERCLOCK was not defined. Only affected H7.