### PR TITLE
RTC6705SOFTSPI - Fix null pointer de-reference caused by 87c8847c13d7f759548c2384e400d2bc387b159a

### DIFF
--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -110,7 +110,9 @@ bool rtc6705IOInit(const vtxIOConfig_t *vtxIOConfig)
         IOConfigGPIO(vtxPowerPin, IOCFG_OUT_PP);
     }
 
-    if (vtxIOConfig->csTag && spiSetBusInstance(dev, vtxIOConfig->spiDevice)) {
+    // RTC6705 when using SOFT SPI driver doesn't use an SPI device, so don't attempt to initialise an spiInstance.
+    SPI_TypeDef *spiInstance = spiInstanceByDevice(SPI_CFG_TO_DEV(vtxIOConfig->spiDevice));
+    if (spiInstance && spiSetBusInstance(dev, vtxIOConfig->spiDevice)) {
         devInstance.busType_u.spi.csnPin = csnPin;
         IOInit(devInstance.busType_u.spi.csnPin, OWNER_VTX_CS, 0);
 


### PR DESCRIPTION
Details:

https://github.com/betaflight/betaflight/pull/10705/files#r679890520
https://github.com/betaflight/betaflight/pull/10705#issuecomment-889856778
