### PR TITLE
FLASH/M25P16 - Fix m25p16_pageProgramContinue not incrementing the address.

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -369,6 +369,8 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
     if (fdevice->callback == NULL) {
         // No callback was provided so block
         spiWait(fdevice->io.handle.dev);
+
+        fdevice->currentWriteAddress += segments[3].len + segments[4].len;
     }
 
     return fdevice->callbackArg;


### PR DESCRIPTION
When testing `master` on a target that uses the M25P16 driver and `CONFIG_IN_EXTERNAL_FLASH` the write to the flash silently fails.

Here you can see the contents of eepromData, after the flash has been read back in, is full of 0xFF and only the first 8 bytes are written.

![image](https://user-images.githubusercontent.com/57075/127656071-7b9a08f4-fed9-4566-878e-dc9f85bd7af5.png)

Log from steve's logic analyzer:

![image](https://user-images.githubusercontent.com/57075/127655775-e1ebf11c-6a00-4662-b22c-71213ee94e78.png)

Fix can be seen here on my scope, second write is now ok, `0x1f,0x00,0x08`:

![image](https://user-images.githubusercontent.com/57075/127655873-877ed73b-cc5b-406f-9b4f-b4bbc9ee7e96.png)

More details: https://github.com/betaflight/betaflight/pull/10705#issuecomment-889511829

Apparently when pageProgramContinue was used by blackbox it was OK as the callback increments the address.  However to me it feels like that flash driver should be responsible for managing it's state so perhaps @SteveEvans could do another PR to address that?