### PR TITLE
Fix bitbang dshot

### DIFF
--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -605,21 +605,20 @@ static void bbUpdateComplete(void)
     }
 #endif
 
-#ifdef USE_DSHOT_TELEMETRY
     for (int i = 0; i < usedMotorPorts; i++) {
         bbPort_t *bbPort = &bbPorts[i];
 
+#ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {
             if (bbPort->direction == DSHOT_BITBANG_DIRECTION_INPUT) {
                 bbPort->inputActive = false;
                 bbSwitchToOutput(bbPort);
             }
-
-
-            bbDMA_Cmd(bbPort, ENABLE);
         }
-    }
 #endif
+
+        bbDMA_Cmd(bbPort, ENABLE);
+    }
 
     lastSendUs = micros();
     for (int i = 0; i < usedMotorPacers; i++) {

--- a/src/main/drivers/memprot_stm32h7xx.c
+++ b/src/main/drivers/memprot_stm32h7xx.c
@@ -45,6 +45,7 @@ mpuRegion_t mpuRegions[] = {
         .bufferable = MPU_ACCESS_BUFFERABLE,
     },
 #endif
+#ifdef USE_DMA_RAM
     {
         // DMA transmit buffer in D2 SRAM1
         // Reading needs cache coherence operation
@@ -57,7 +58,6 @@ mpuRegion_t mpuRegions[] = {
         .cacheable  = MPU_ACCESS_CACHEABLE,
         .bufferable = MPU_ACCESS_NOT_BUFFERABLE,
     },
-#ifdef USE_SDCARD_SDIO
     {
         // A region in AXI RAM accessible from SDIO internal DMA
         .start      = (uint32_t)&dmarwaxi_start,


### PR DESCRIPTION
Two issues:

1) memory protection not configured correctly on targets without an SD card.
2) DMA never started when bi-directional dshot is disabled (the default).

Details:

https://github.com/betaflight/betaflight/pull/10705#issuecomment-890067042
https://github.com/betaflight/betaflight/pull/10705#issuecomment-890085888
https://github.com/betaflight/betaflight/pull/10705#issuecomment-890097415
https://github.com/betaflight/betaflight/pull/10705#issuecomment-890133423
