### PR TITLE
Fix crsf unit test

### DIFF
--- a/src/test/unit/rx_crsf_unittest.cc
+++ b/src/test/unit/rx_crsf_unittest.cc
@@ -129,7 +129,7 @@ TEST(CrossFireTest, TestCrsfFrameStatus)
     memset(crsfFrame.frame.payload, 0, CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE);
     const uint8_t crc = crsfFrameCRC();
     crsfFrame.frame.payload[CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE] = crc;
-
+    memcpy(&crsfChannelDataFrame, &crsfFrame, sizeof(crsfFrame));
     const uint8_t status = crsfFrameStatus();
     EXPECT_EQ(RX_FRAME_COMPLETE, status);
     EXPECT_FALSE(crsfFrameDone);


### PR DESCRIPTION
I'm getting a segmentation fault in ```TestCrsfFrameStatus``` when running the tests locally.
Fixed by copying ```crsfFrame``` to ```crsfChannelDataFrame``` because that's what ```crsfFrameStatus()``` want's to access.
This is in line with how it's done in the other tests in this file.