### PR TITLE
Fixed the 'make pre-push' build on MacOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,12 @@ FEATURE_CUT_LEVEL_SUPPLIED := $(FEATURE_CUT_LEVEL)
 FEATURE_CUT_LEVEL =
 
 # The list of targets to build for 'pre-push'
-PRE_PUSH_TARGET_LIST ?= $(UNIFIED_TARGETS) NUCLEOH743 SITL STM32F4DISCOVERY_DEBUG test-representative
+ifeq ($(OSFAMILY), macosx)
+# SITL is not buildable on MacOS
+PRE_PUSH_TARGET_LIST ?= $(UNIFIED_TARGETS) STM32F4DISCOVERY_DEBUG test-representative
+else
+PRE_PUSH_TARGET_LIST ?= $(UNIFIED_TARGETS) SITL STM32F4DISCOVERY_DEBUG test-representative
+endif
 
 include $(ROOT)/make/targets.mk
 
@@ -603,8 +608,7 @@ targets:
 	@echo "Unified targets:     $(UNIFIED_TARGETS)"
 	@echo "Legacy targets:      $(LEGACY_TARGETS)"
 	@echo "Unsupported targets: $(UNSUPPORTED_TARGETS)"
-	@echo "Target:              $(TARGET)"
-	@echo "Base target:         $(BASE_TARGET)"
+	@echo "Default target:      $(TARGET)"
 	@echo "targets-group-1:     $(GROUP_1_TARGETS)"
 	@echo "targets-group-2:     $(GROUP_2_TARGETS)"
 	@echo "targets-group-rest:  $(GROUP_OTHER_TARGETS)"


### PR DESCRIPTION
Removed the SITL target build from `make pre-push` SITL requires librt, which is not available on MacOS, so there is no easy way to make this work.