### PR TITLE
Workaround Cygwin test build issues

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -526,7 +526,14 @@ ifeq ($(shell $(CC) -v 2>&1 | grep -q "clang version" && echo "clang"),clang)
 # Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 14 }
 # Travis reports CC_VERSION of 4.2.1
 CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
+
+# On Cygwin, the latest version of clang 8.0.1 reports itself as version 4.2.1 when using the `-dumpversion` option, when using `--version` the result is 8.0.1
+ifeq ($(CYGWIN), 1)
+CC_VERSION_CHECK_MIN := 4
+else
 CC_VERSION_CHECK_MIN := 7
+endif
+
 CC_VERSION_CHECK_MAX := 14
 
 # Added flags for clang 11 - 13 are not backwards compatible

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -17,7 +17,14 @@ ROOT = ../..
 OBJECT_DIR = ../../obj/test
 TARGET_DIR = $(USER_DIR)/target
 
+# Allow certain tests to be temporarily excluded, e.g. `make TEST_EXCLUDES="alignsensor_unittest arming_prevention_unittest atomic_unittest"`
+TEST_EXCLUDES ?= 
+
 include $(ROOT)/make/system-id.mk
+
+ifneq ($(TEST_EXCLUDES),)
+$(warning Exclusions: $(TEST_EXCLUDES))
+endif
 
 VPATH := $(VPATH):$(USER_DIR):$(TEST_DIR)
 
@@ -579,12 +586,13 @@ endif
 
 # Gather up all of the tests.
 TEST_SRCS = $(sort $(wildcard $(TEST_DIR)/*.cc))
-TEST_BASENAMES = $(TEST_SRCS:$(TEST_DIR)/%.cc=%)
+TEST_BASENAMES = $(filter-out $(TEST_EXCLUDES), $(TEST_SRCS:$(TEST_DIR)/%.cc=%))
 TESTS_TARGET_SPECIFIC = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),$(test)))
 
 TESTS = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),,$(test)))
 TESTS_ALL = $(TESTS)
-
+$(info $(TEST_EXCLUDES))
+$(info $(TESTS))
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
 GTEST_HEADERS = $(GTEST_DIR)/inc/gtest/*.h
@@ -697,7 +705,6 @@ target = $(1:$(basename $1).%=%)
 #
 # param $1 = plain test name for global tests, test.target for per-target tests
 define test-specific-stuff
-
 ifeq ($1,$(basename $1))
 # standard global test
 $1_OBJS = $(patsubst \

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -22,6 +22,12 @@ TEST_EXCLUDES ?=
 
 include $(ROOT)/make/system-id.mk
 
+ifeq ($(CYGWIN),1)
+CYGWIN_TEST_EXCLUDES = atomic_unittest
+TEST_EXCLUDES += $(CYGWIN_TEST_EXCLUDES)
+$(warning Cygwin detected: Automatically excluding $(CYGWIN_TEST_EXCLUDES) until the tests are made to run on Cygwin) 
+endif
+
 ifneq ($(TEST_EXCLUDES),)
 $(warning Exclusions: $(TEST_EXCLUDES))
 endif
@@ -591,8 +597,7 @@ TESTS_TARGET_SPECIFIC = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),
 
 TESTS = $(foreach test,$(TEST_BASENAMES),$(if $($(test)_EXPAND),,$(test)))
 TESTS_ALL = $(TESTS)
-$(info $(TEST_EXCLUDES))
-$(info $(TESTS))
+
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
 GTEST_HEADERS = $(GTEST_DIR)/inc/gtest/*.h


### PR DESCRIPTION
There are two issues:

1) the build system requires clang 7.x but on cygwin clang 8.0.1 reports itself as 4.2.1 when using `-dumpversion` instead of `--version` - See https://github.com/betaflight/betaflight/issues/10814
2) the atomic_unittest fails with this:
```
compiling ../main/build/atomic.c
linking ../../obj/test/atomic_unittest/atomic_unittest
/usr/bin/ld: ../../obj/test/atomic_unittest/atomic_unittest_c.c.o: in function `testAtomicBarrier_C':
/cygdrive/d/My Documents/dev/embedded/betaflight/src/test/unit/atomic_unittest_c.c:22: undefined reference to `__imp__NSConcreteStackBlock'
/usr/bin/ld: /cygdrive/d/My Documents/dev/embedded/betaflight/src/test/unit/atomic_unittest_c.c:23: undefined reference to `__imp__NSConcreteStackBlock'
/usr/bin/ld: /cygdrive/d/My Documents/dev/embedded/betaflight/src/test/unit/atomic_unittest_c.c:26: undefined reference to `__imp__NSConcreteStackBlock'
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:758: ../../obj/test/atomic_unittest/atomic_unittest] Error 1
make[1]: Leaving directory '/cygdrive/d/My Documents/dev/embedded/betaflight/src/test'
make: *** [Makefile:672: test] Error 2
```

This PR serves as a workaround for both issues, via 3 commits, to allow a developer to run all the tests on cygwin, apart from the problematic `atomic_unittest` until someone has time to update the build system/test to allow it to run.  The idea is that being able to run as many tests as possible, locally, is still better than not running any at all and/or clogging up the CI build queue.

Example of how to exclude multiple unit tests, this is also useful when refactoring and you're not ready to run some unit tests yet:

```
make TEST_EXCLUDES="notreadytotestyet_unittest someother_unittest"
```