### PR TITLE
Dmin high-pass changed from biquad to PT2 with cutoff optimisation

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -329,8 +329,8 @@ typedef struct pidRuntime_s {
 #endif
 
 #ifdef USE_D_MIN
-    biquadFilter_t dMinRange[XYZ_AXIS_COUNT];
-    pt1Filter_t dMinLowpass[XYZ_AXIS_COUNT];
+    pt2Filter_t dMinRange[XYZ_AXIS_COUNT];
+    pt2Filter_t dMinLowpass[XYZ_AXIS_COUNT];
     float dMinPercent[XYZ_AXIS_COUNT];
     float dMinGyroGain;
     float dMinSetpointGain;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -46,10 +46,10 @@
 #include "pid_init.h"
 
 #if defined(USE_D_MIN)
-#define D_MIN_RANGE_HZ 80    // Biquad lowpass input cutoff to peak D around propwash frequencies
-#define D_MIN_LOWPASS_HZ 10  // PT1 lowpass cutoff to smooth the boost effect
-#define D_MIN_GAIN_FACTOR 0.00005f
-#define D_MIN_SETPOINT_GAIN_FACTOR 0.00005f
+#define D_MIN_RANGE_HZ 85    // PT2 lowpass input cutoff to peak D around propwash frequencies
+#define D_MIN_LOWPASS_HZ 35  // PT2 lowpass cutoff to smooth the boost effect
+#define D_MIN_GAIN_FACTOR 0.00008f
+#define D_MIN_SETPOINT_GAIN_FACTOR 0.00008f
 #endif
 
 #define ANTI_GRAVITY_THROTTLE_FILTER_CUTOFF 15  // The anti gravity throttle highpass filter cutoff
@@ -224,8 +224,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     // in-flight adjustments and transition from 0 to > 0 in flight the feature
     // won't work because the filter wasn't initialized.
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
-        biquadFilterInitLPF(&pidRuntime.dMinRange[axis], D_MIN_RANGE_HZ, targetPidLooptime);
-        pt1FilterInit(&pidRuntime.dMinLowpass[axis], pt1FilterGain(D_MIN_LOWPASS_HZ, pidRuntime.dT));
+        pt2FilterInit(&pidRuntime.dMinRange[axis], pt2FilterGain(D_MIN_RANGE_HZ, pidRuntime.dT));
+        pt2FilterInit(&pidRuntime.dMinLowpass[axis], pt2FilterGain(D_MIN_LOWPASS_HZ, pidRuntime.dT));
      }
 #endif
 


### PR DESCRIPTION
This PR replaces the biquad with a PT2 to provide the smoothed high-pass function used by Dmin to boost towards Dmax.

The rationale is that we need to smooth the Dmin boost with a filter that has no adverse characteristics.  The Advance element is driven by setpoint which can have steps that a biquad will not handle well.  Both elements of Dmin can be noisy or spiky or stepped.  The PT2 is very similar but probably better in this situation than the biquad.

I also revisited the timing and gain of the Dmin boost to suit the different filter characteristics.

There is no particular intention of greatly changing Dmin functionally.

The intent is to get the Dmin boost to coincide best with the point in fast moves where we really do want the peak 'slowing down' to occur.  If Dmin is boosted too early, and the boost goes away too soon, then it isn't going to control overshoot too well.  If it comes on too late, we have the reverse effect.