### PR TITLE
Fix memory corruption caused by MSP_BOXNAMES buffer overflow.

### DIFF
--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -77,7 +77,7 @@ typedef enum {
 #define MSP_PORT_DATAFLASH_INFO_SIZE 16
 #define MSP_PORT_OUTBUF_SIZE (MSP_PORT_DATAFLASH_BUFFER_SIZE + MSP_PORT_DATAFLASH_INFO_SIZE)
 #else
-#define MSP_PORT_OUTBUF_SIZE 256
+#define MSP_PORT_OUTBUF_SIZE 320 // As of 2021/08/10 MSP_BOXNAMES generates a 307 byte response for page 1.
 #endif
 
 typedef struct __attribute__((packed)) {


### PR DESCRIPTION
Fixes #10896.

See #10896 for more details.

Buffer is too small to hold MSP_BOXNAMES page 1 response which is 0x133 / 307 bytes long. (0x4701 - 0x45CE = 0x133)

![image](https://user-images.githubusercontent.com/57075/128848526-88cc2362-603c-4039-be7c-4530815982f4.png)

Buffer overflows and corrupts memory which leads to an eventual crash or other weird errors occurring in unrelated parts of the system.  I was lucky to find a repeatable problem via way of a debugger watch point (on memory write) when making a patch for #10573 which started failing unexpectedly after connecting using the configurator.

This bug affects all targets which do not have a flash chip.
