### PR TITLE
fix typos in code comments in main/common and main/drivers folders

### DIFF
--- a/src/main/common/printf.h
+++ b/src/main/common/printf.h
@@ -84,7 +84,7 @@ This is not often needed but it was implemented like that because it made
 implementing the sprintf function so neat (look at the source code).
 
 The code is re-entrant, except for the 'init_printf' function, so it
-is safe to call it from interupts too, although this may result in mixed output.
+is safe to call it from interrupts too, although this may result in mixed output.
 If you rely on re-entrancy, take care that your 'putc' function is re-entrant!
 
 The printf and sprintf functions are actually macros that translate to
@@ -94,7 +94,7 @@ You just need to undef the names before you include the 'stdio.h'.
 Note that these are not function like macros, so if you have variables
 or struct members with these names, things will explode in your face.
 Without variadic macros this is the best we can do to wrap these
-fucnction. If it is a problem just give up the macros and use the
+functions. If it is a problem just give up the macros and use the
 functions directly or rename them.
 
 For further details see source code.

--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -87,7 +87,7 @@ bool dateTimeFormatLocalShort(char *buf, dateTime_t *dt);
 void dateTimeUTCToLocal(dateTime_t *utcDateTime, dateTime_t *localDateTime);
 // dateTimeSplitFormatted splits a formatted date into its date
 // and time parts. Note that the string pointed by formatted will
-// be modifed and will become invalid after calling this function.
+// be modified and will become invalid after calling this function.
 bool dateTimeSplitFormatted(char *formatted, char **date, char **time);
 
 bool rtcHasTime(void);

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -48,7 +48,7 @@
 #define PP_IIF_0(t, f) f
 #define PP_IIF_1(t, f) t
 
-// Expand all argumens and call macro with them. When expansion of some argument contains ',', it will be passed as multiple arguments
+// Expand all arguments and call macro with them. When expansion of some argument contains ',', it will be passed as multiple arguments
 // #define TAKE3(_1,_2,_3) CONCAT3(_1,_2,_3)
 // #define MULTI2 A,B
 // PP_CALL(TAKE3, MULTI2, C) expands to ABC

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -88,7 +88,7 @@ typedef struct {
 #define E_SENSOR_NOT_DETECTED   (char) 0
 #define BMP085_PROM_START__ADDR 0xaa
 #define BMP085_PROM_DATA__LEN   22
-#define BMP085_T_MEASURE        0x2E                // temperature measurment
+#define BMP085_T_MEASURE        0x2E                // temperature measurement
 #define BMP085_P_MEASURE        0x34                // pressure measurement
 #define BMP085_CTRL_MEAS_REG    0xF4
 #define BMP085_ADC_OUT_MSB_REG  0xF6

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -88,7 +88,7 @@ typedef struct {
 #define E_SENSOR_NOT_DETECTED   (char) 0
 #define BMP085_PROM_START__ADDR 0xaa
 #define BMP085_PROM_DATA__LEN   22
-#define BMP085_T_MEASURE        0x2E                // temperature measurent
+#define BMP085_T_MEASURE        0x2E                // temperature measurment
 #define BMP085_P_MEASURE        0x34                // pressure measurement
 #define BMP085_CTRL_MEAS_REG    0xF4
 #define BMP085_ADC_OUT_MSB_REG  0xF6

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -392,7 +392,7 @@ void ak8963BusInit(const extDevice_t *dev)
     case BUS_TYPE_MPU_SLAVE:
         rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
 
-        // initialze I2C master via SPI bus
+        // initialize I2C master via SPI bus
         ak8963SpiWriteRegisterDelay(dev->bus->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
         ak8963SpiWriteRegisterDelay(dev->bus->busType_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz
         ak8963SpiWriteRegisterDelay(dev->bus->busType_u.mpuSlave.master, MPU_RA_USER_CTRL, 0x30);   // I2C master mode, SPI mode only

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -165,7 +165,7 @@ void updateDshotTelemetryQuality(dshotTelemetryQuality_t *qualityStats, bool pac
 
 #endif // USE_DSHOT
 
-// temporarly here, needs to be moved during refactoring
+// temporarily here, needs to be moved during refactoring
 void validateAndfixMotorOutputReordering(uint8_t *array, const unsigned size)
 {
     bool invalid = false;

--- a/src/main/drivers/dshot_bitbang_impl.h
+++ b/src/main/drivers/dshot_bitbang_impl.h
@@ -209,7 +209,7 @@ extern uint8_t bbPuPdMode;
 extern uint32_t bbOutputBuffer[MOTOR_DSHOT_BUF_CACHE_ALIGN_LENGTH * MAX_SUPPORTED_MOTOR_PORTS];
 
 // DMA input buffer
-// (30us + <frame time> + <slack>) / <input sampling clock perid>
+// (30us + <frame time> + <slack>) / <input sampling clock period>
 // <frame time> = <DShot symbol time> * 16
 // Temporary size for DS600
 // <frame time> = 26us

--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -279,7 +279,7 @@ FAST_CODE_NOINLINE bool dshotCommandOutputIsEnabled(uint8_t motorCount)
     case DSHOT_COMMAND_STATE_STARTDELAY:
         if (command->nextCommandCycleDelay) {
             --command->nextCommandCycleDelay;
-            return false;  // Delay motor output until the start of the command seequence
+            return false;  // Delay motor output until the start of the command sequence
         }
         command->state = DSHOT_COMMAND_STATE_ACTIVE;
         command->nextCommandCycleDelay = 0;  // first iteration of the repeat happens now

--- a/src/main/drivers/dshot_command.h
+++ b/src/main/drivers/dshot_command.h
@@ -23,7 +23,7 @@
 #define DSHOT_MAX_COMMAND 47
 
 /*
-  DshotSettingRequest (KISS24). Spin direction, 3d and save Settings reqire 10 requests.. and the TLM Byte must always be high if 1-47 are used to send settings
+  DshotSettingRequest (KISS24). Spin direction, 3d and save Settings require 10 requests.. and the TLM Byte must always be high if 1-47 are used to send settings
 
   3D Mode:
   0 = stop

--- a/src/main/drivers/exti.c
+++ b/src/main/drivers/exti.c
@@ -36,7 +36,7 @@ typedef struct {
 
 extiChannelRec_t extiChannelRecs[16];
 
-// IRQ gouping, same on F103, F303, F40x, F7xx, H7xx and G4xx.
+// IRQ grouping, same on F103, F303, F40x, F7xx, H7xx and G4xx.
 #define EXTI_IRQ_GROUPS 7
 //                                      0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
 static const uint8_t extiGroups[16] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6 };

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -464,7 +464,7 @@ void max7456Invert(bool invert)
 }
 
 /**
- * Sets the brighness of black and white pixels.
+ * Sets the brightness of black and white pixels.
  *
  * @param black Black brightness (0-3, 0 is darkest)
  * @param white White brightness (0-3, 0 is darkest)

--- a/src/main/drivers/mco.c
+++ b/src/main/drivers/mco.c
@@ -39,7 +39,7 @@
 // it is required to use DIV4 for SYSCLK = 254MHz (derives 62.5MHz)
 // it is required to use DIV2 for SYSCLK = 170MHz (derives 85MHz)
 //
-// - MCO frequenchy can be more flexible if PLLR is made configurable.
+// - MCO frequency can be more flexible if PLLR is made configurable.
 
 const uint32_t mcoSources[MCO_SOURCE_COUNT] = {
     RCC_MCO1SOURCE_NOCLOCK,

--- a/src/main/drivers/sdcard_standard.h
+++ b/src/main/drivers/sdcard_standard.h
@@ -203,7 +203,7 @@ typedef struct sdcardCSD_t {
 
 #define SDCARD_BLOCK_SIZE 512
 
-// Idle bit is set to 1 only when idle during intialization phase:
+// Idle bit is set to 1 only when idle during initialization phase:
 #define SDCARD_R1_STATUS_BIT_IDLE                 1
 #define SDCARD_R1_STATUS_BIT_ERASE_RESET          2
 #define SDCARD_R1_STATUS_BIT_ILLEGAL_COMMAND      4

--- a/src/main/drivers/sdio_f4xx.c
+++ b/src/main/drivers/sdio_f4xx.c
@@ -282,7 +282,7 @@ static void SD_DataTransferInit(uint32_t Size, uint32_t DataBlockSize, bool IsIt
 /** -----------------------------------------------------------------------------------------------------------------*/
 /**		SD_TransmitCommand
   *
-  * @brief  Send the commande to SDIO
+  * @brief  Send the command to SDIO
   * @param  uint32_t Command
   * @param  uint32_t Argument              Must provide the response size
   * @param  uint8_t ResponseType

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -265,7 +265,7 @@ void initialiseMemorySections(void)
 #endif
 
 #ifdef USE_FAST_DATA
-    /* Load FAST_DATA variable intializers into DTCM RAM */
+    /* Load FAST_DATA variable initializers into DTCM RAM */
     extern uint8_t _sfastram_data;
     extern uint8_t _efastram_data;
     extern uint8_t _sfastram_idata;

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -525,7 +525,7 @@ static unsigned getFilter(unsigned ticks)
     return 0x0f;
 }
 
-// Configure input captupre
+// Configure input capture
 void timerChConfigIC(const timerHardware_t *timHw, bool polarityRising, unsigned inputFilterTicks)
 {
     TIM_ICInitTypeDef TIM_ICInitStructure;
@@ -629,7 +629,7 @@ static void timCCxHandler(TIM_TypeDef *tim, timerConfig_t *timerConfig)
 #if 1
     while (tim_status) {
         // flags will be cleared by reading CCR in dual capture, make sure we call handler correctly
-        // currrent order is highest bit first. Code should not rely on specific order (it will introduce race conditions anyway)
+        // current order is highest bit first. Code should not rely on specific order (it will introduce race conditions anyway)
         unsigned bit = __builtin_clz(tim_status);
         unsigned mask = ~(0x80000000 >> bit);
         tim->SR = mask;
@@ -816,7 +816,7 @@ void timerStart(void)
                 // TODO - move IRQ to timer info
                 irq = TIMER_HARDWARE[hwc].irq;
             }
-        // TODO - aggregate required timer paramaters
+        // TODO - aggregate required timer parameters
         configTimeBase(usedTimers[timer], 0, 1);
         TIM_Cmd(usedTimers[timer],  ENABLE);
         if (priority >= 0) {  // maybe none of the channels was configured

--- a/src/main/drivers/timer_stm32h7xx.c
+++ b/src/main/drivers/timer_stm32h7xx.c
@@ -195,7 +195,7 @@ uint32_t timerClock(TIM_TypeDef *tim)
 
     int index = (timpre << 3) | ppre;
 
-    static uint8_t periphToKernel[16] = { // The mutiplier table
+    static uint8_t periphToKernel[16] = { // The multiplier table
         1, 1, 1, 1, 2, 2, 2, 2, // TIMPRE = 0
         1, 1, 1, 1, 2, 4, 4, 4  // TIMPRE = 1
     };


### PR DESCRIPTION
Just typo fixes, no change to the actual code.