### PR TITLE
Debug pin fixes and improvements.

### DIFF
--- a/src/main/build/debug_pin.c
+++ b/src/main/build/debug_pin.c
@@ -80,7 +80,7 @@ void dbgPinHi(int index)
 
 void dbgPinLo(int index)
 {
-    if ((unsigned)index > ARRAYLEN(dbgPins)) {
+    if ((unsigned)index >= ARRAYLEN(dbgPins)) {
         return;
     }
 

--- a/src/main/build/debug_pin.c
+++ b/src/main/build/debug_pin.c
@@ -32,7 +32,7 @@ typedef struct dbgPin_s {
     uint32_t resetBSRR;
 } dbgPin_t;
 
-dbgPin_t dbgPins[] = {
+__weak dbgPin_t dbgPins[] = {
     { .tag = IO_TAG(NONE) },
 };
 

--- a/src/main/build/debug_pin.c
+++ b/src/main/build/debug_pin.c
@@ -53,6 +53,7 @@ void dbgPinInit(void)
         if (!io) {
             continue;
         }
+        IOInit(io, OWNER_SYSTEM, 0);
         IOConfigGPIO(io, IOCFG_OUT_PP);
         dbgPinState->gpio = IO_GPIO(io);
         int pinSrc = IO_GPIO_PinSource(io);

--- a/src/main/build/debug_pin.c
+++ b/src/main/build/debug_pin.c
@@ -60,7 +60,7 @@ void dbgPinHi(int index)
 
     dbgPin_t *dbgPin = &dbgPins[index];
     if (dbgPin->gpio) {
-#if defined(STM32F7)
+#if defined(STM32F7) || defined(STM32H7)
         dbgPin->gpio->BSRR = dbgPin->setBSRR;
 #else
         dbgPin->gpio->BSRRL = dbgPin->setBSRR;
@@ -77,7 +77,7 @@ void dbgPinLo(int index)
     dbgPin_t *dbgPin = &dbgPins[index];
 
     if (dbgPin->gpio) {
-#if defined(STM32F7)
+#if defined(STM32F7) || defined(STM32H7)
         dbgPin->gpio->BSRR = dbgPin->resetBSRR;
 #else
         dbgPin->gpio->BSRRL = dbgPin->resetBSRR;

--- a/src/main/build/debug_pin.c
+++ b/src/main/build/debug_pin.c
@@ -76,7 +76,7 @@ void dbgPinLo(int index)
 
     dbgPin_t *dbgPin = &dbgPins[index];
 
-    if (dbgPins->gpio) {
+    if (dbgPin->gpio) {
 #if defined(STM32F7)
         dbgPin->gpio->BSRR = dbgPin->resetBSRR;
 #else

--- a/src/main/build/debug_pin.h
+++ b/src/main/build/debug_pin.h
@@ -27,3 +27,13 @@ typedef struct dbgPin_s {
 void dbgPinInit(void);
 void dbgPinHi(int index);
 void dbgPinLo(int index);
+
+#ifdef USE_DEBUG_PIN
+#define DEBUG_LO(index) \
+   dbgPinLo(index);
+#define DEBUG_HI(index) \
+   dbgPinHi(index);
+#else
+#define DEBUG_LO(index)
+#define DEBUG_HI(index)
+#endif

--- a/src/main/build/debug_pin.h
+++ b/src/main/build/debug_pin.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <drivers/io.h>
+#include <drivers/io_types.h>
 
 typedef struct dbgPin_s {
     ioTag_t tag;

--- a/src/main/build/debug_pin.h
+++ b/src/main/build/debug_pin.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+typedef struct dbgPin_s {
+    ioTag_t tag;
+} dbgPin_t;
+
 void dbgPinInit(void);
 void dbgPinHi(int index);
 void dbgPinLo(int index);

--- a/src/main/build/debug_pin.h
+++ b/src/main/build/debug_pin.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <drivers/io.h>
+
 typedef struct dbgPin_s {
     ioTag_t tag;
 } dbgPin_t;

--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -27,6 +27,7 @@
 #ifdef USE_DSHOT_BITBANG
 
 #include "build/debug.h"
+#include "build/debug_pin.h"
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
@@ -45,14 +46,6 @@
 #include "drivers/timer.h"
 
 #include "pg/motor.h"
-
-#if defined(USE_DEBUG_PIN)
-#include "build/debug_pin.h"
-#else
-#define dbgPinInit()
-#define dbgPinHi(x)
-#define dbgPinLo(x)
-#endif
 
 FAST_DATA_ZERO_INIT bbPacer_t bbPacers[MAX_MOTOR_PACERS];  // TIM1 or TIM8
 FAST_DATA_ZERO_INIT int usedMotorPacers = 0;
@@ -300,7 +293,7 @@ static void bbAllocDma(bbPort_t *bbPort)
 
 void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 {
-    dbgPinHi(0);
+    DEBUG_HI(0);
 
     bbPort_t *bbPort = (bbPort_t *)descriptor->userParam;
 
@@ -333,7 +326,7 @@ void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
         }
     }
 #endif
-    dbgPinLo(0);
+    DEBUG_LO(0);
 }
 
 // Setup bbPorts array elements so that they each have a TIM1 or TIM8 channel
@@ -693,9 +686,8 @@ dshotBitbangStatus_e dshotBitbangGetStatus()
 
 motorDevice_t *dshotBitbangDevInit(const motorDevConfig_t *motorConfig, uint8_t count)
 {
-    dbgPinInit();
-    dbgPinLo(0);
-    dbgPinLo(1);
+    DEBUG_LO(0);
+    DEBUG_LO(1);
 
     motorPwmProtocol = motorConfig->motorPwmProtocol;
     bbDevice.vTable = bbVTable;

--- a/src/main/drivers/dshot_bitbang_stdperiph.c
+++ b/src/main/drivers/dshot_bitbang_stdperiph.c
@@ -28,6 +28,7 @@
 
 #include "build/atomic.h"
 #include "build/debug.h"
+#include "build/debug_pin.h"
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
@@ -43,14 +44,6 @@
 #include "drivers/timer.h"
 
 #include "pg/motor.h"
-
-#if defined(USE_DEBUG_PIN)
-#include "build/debug_pin.h"
-#else
-#define dbgPinInit()
-#define dbgPinHi(x)
-#define dbgPinLo(x)
-#endif
 
 void bbGpioSetup(bbMotor_t *bbMotor)
 {
@@ -142,7 +135,7 @@ static void bbSaveDMARegs(dmaResource_t *dmaResource, dmaRegCache_t *dmaRegCache
 
 void bbSwitchToOutput(bbPort_t * bbPort)
 {
-    dbgPinHi(1);
+    DEBUG_HI(1);
     // Output idle level before switching to output
     // Use BSRR register for this
     // Normal: Use BR (higher half)
@@ -173,13 +166,13 @@ void bbSwitchToOutput(bbPort_t * bbPort)
 
     bbPort->direction = DSHOT_BITBANG_DIRECTION_OUTPUT;
 
-    dbgPinLo(1);
+    DEBUG_LO(1);
 }
 
 #ifdef USE_DSHOT_TELEMETRY
 void bbSwitchToInput(bbPort_t *bbPort)
 {
-    dbgPinHi(1);
+    DEBUG_HI(1);
 
     // Set GPIO to input
 
@@ -208,7 +201,7 @@ void bbSwitchToInput(bbPort_t *bbPort)
 
     bbPort->direction = DSHOT_BITBANG_DIRECTION_INPUT;
 
-    dbgPinLo(1);
+    DEBUG_LO(1);
 }
 #endif
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -29,6 +29,7 @@
 
 #include "build/build_config.h"
 #include "build/debug.h"
+#include "build/debug_pin.h"
 
 #include "cms/cms.h"
 #include "cms/cms_types.h"
@@ -412,6 +413,10 @@ void init(void)
     }
 
     systemState |= SYSTEM_STATE_CONFIG_LOADED;
+
+#ifdef USE_DEBUG_PIN
+    dbgPinInit();
+#endif
 
 #ifdef USE_SDCARD
     // Ensure the SD card is initialised before the USB MSC starts to avoid a race condition

--- a/src/main/target/NUCLEOH743/target.c
+++ b/src/main/target/NUCLEOH743/target.c
@@ -27,6 +27,8 @@
 #include "drivers/timer.h"
 #include "drivers/timer_def.h"
 
+#include "build/debug_pin.h"
+
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     // DEF_TIM(TIM2,  CH2, PB3,  TIM_USE_LED,                 0,  7,  0 ), // SPI1_SCK
     DEF_TIM(TIM12, CH2, PB15, TIM_USE_LED,                 0,  0,  0 ),
@@ -51,4 +53,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     // DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_MOTOR,               0,  8,  0 ), // I2C1
     // DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_MOTOR,               0,  0,  0 ), // I2C1
     // DEF_TIM(TIM9,  CH2, PE6,  TIM_USE_MOTOR,               0,  0,  0 ),
+};
+
+dbgPin_t dbgPins[DEBUG_PIN_COUNT] = {
+    { .tag = IO_TAG(PG1) },
 };

--- a/src/main/target/NUCLEOH743/target.c
+++ b/src/main/target/NUCLEOH743/target.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "platform.h"
+#include "drivers/io_def.h"
 #include "drivers/io.h"
 
 #include "drivers/dma.h"

--- a/src/main/target/NUCLEOH743/target.h
+++ b/src/main/target/NUCLEOH743/target.h
@@ -25,6 +25,9 @@
 
 #define USE_TARGET_CONFIG
 
+#define USE_DEBUG_PIN
+#define DEBUG_PIN_COUNT         1
+
 #define LED0_PIN                PB0
 #define LED1_PIN                PB7 // PE1 on NUCLEO-H743ZI2 (may collide with UART8_TX)
 //#define LED2_PIN                PB14 // SDMMC2_D0

--- a/src/test/unit/timer_definition_unittest.include/drivers/io.h
+++ b/src/test/unit/timer_definition_unittest.include/drivers/io.h
@@ -1,0 +1,1 @@
+#define IO_TAG(pinid) DEFIO_TAG(pinid)


### PR DESCRIPTION
This PR:

* Fixes a bug in `dbgPinLo` always using the first pin in the list.
* Fixes an illegal pointer de-reference bug in `dbgPinLo`
* Adds H7 support (defining `USE_DEBUG_PIN` caused compilation errors)
* Allows per-target configuration
* Separates runtime state/implementation details from config.
* Defines a debug pin configuration for the NucleoH743 target for CI visibility and to show how to use per-target configuration.
* Fixes the initialization code so that debug pins can be used on all targets, not just those with dshot bitbang compiled-in and enabled.