### PR TITLE
Use static definition for ClassData to support USB MSC DMA on G4

### DIFF
--- a/lib/main/STM32F4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32F4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -283,6 +283,7 @@ __ALIGN_BEGIN  uint8_t USBD_MSC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] 
   * @}
   */ 
 
+static DMA_DATA_ZERO_INIT USBD_MSC_BOT_HandleTypeDef ClassData;
 
 /** @defgroup MSC_CORE_Private_Functions
   * @{
@@ -328,18 +329,12 @@ uint8_t  USBD_MSC_Init (USBD_HandleTypeDef *pdev,
                    USBD_EP_TYPE_BULK,
                    MSC_MAX_FS_PACKET);  
   }
-  pdev->pClassData = USBD_malloc(sizeof (USBD_MSC_BOT_HandleTypeDef));
-  
-  if(pdev->pClassData == NULL)
-  {
-    ret = 1; 
-  }
-  else
-  {
-    /* Init the BOT  layer */
-    MSC_BOT_Init(pdev); 
-    ret = 0;
-  }
+
+  pdev->pMSC_ClassData = (void *)&ClassData;
+
+  /* Init the BOT  layer */
+  MSC_BOT_Init(pdev);
+  ret = 0;
   
   return ret;
 }

--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -281,8 +281,9 @@ __ALIGN_BEGIN  uint8_t USBD_MSC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] 
   * @}
   */
 
+static DMA_DATA_ZERO_INIT USBD_MSC_BOT_HandleTypeDef ClassData;
 
-/** @defgroup MSC_CORE_Private_Functions
+ /** @defgroup MSC_CORE_Private_Functions
   * @{
   */
 
@@ -317,12 +318,8 @@ uint8_t  USBD_MSC_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
     USBD_LL_OpenEP(pdev, MSC_EPIN_ADDR, USBD_EP_TYPE_BULK, MSC_MAX_FS_PACKET);
     pdev->ep_in[MSC_EPIN_ADDR & 0xFU].is_used = 1U;
   }
-  pdev->pMSC_ClassData = USBD_malloc(sizeof (USBD_MSC_BOT_HandleTypeDef));
 
-  if(pdev->pMSC_ClassData == NULL)
-  {
-    return USBD_FAIL;
-  }
+  pdev->pMSC_ClassData = (void *)&ClassData;
 
   /* Init the BOT  layer */
   MSC_BOT_Init(pdev);

--- a/lib/main/STM32G4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32G4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -281,6 +281,7 @@ __ALIGN_BEGIN  uint8_t USBD_MSC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] 
   * @}
   */
 
+static DMA_DATA_ZERO_INIT USBD_MSC_BOT_HandleTypeDef ClassData;
 
 /** @defgroup MSC_CORE_Private_Functions
   * @{
@@ -296,6 +297,8 @@ __ALIGN_BEGIN  uint8_t USBD_MSC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] 
 uint8_t  USBD_MSC_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
   UNUSED(cfgidx);
+
+  pdev->pMSC_ClassData = (void *)&ClassData;
 
   if(pdev->dev_speed == USBD_SPEED_HIGH)
   {
@@ -316,12 +319,6 @@ uint8_t  USBD_MSC_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
     /* Open EP IN */
     USBD_LL_OpenEP(pdev, MSC_EPIN_ADDR, USBD_EP_TYPE_BULK, MSC_MAX_FS_PACKET);
     pdev->ep_in[MSC_EPIN_ADDR & 0xFU].is_used = 1U;
-  }
-  pdev->pMSC_ClassData = USBD_malloc(sizeof (USBD_MSC_BOT_HandleTypeDef));
-
-  if(pdev->pMSC_ClassData == NULL)
-  {
-    return USBD_FAIL;
   }
 
   /* Init the BOT  layer */

--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -281,17 +281,8 @@ static DMA_DATA_ZERO_INIT USBD_MSC_BOT_HandleTypeDef ClassData;
 uint8_t USBD_MSC_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
   UNUSED(cfgidx);
-  USBD_MSC_BOT_HandleTypeDef *hmsc;
 
-  hmsc = &ClassData;
-
-  if (hmsc == NULL)
-  {
-    pdev->pMSC_ClassData = NULL;
-    return (uint8_t)USBD_EMEM;
-  }
-
-  pdev->pMSC_ClassData = (void *)hmsc;
+  pdev->pMSC_ClassData = (void *)&ClassData;
 
   if (pdev->dev_speed == USBD_SPEED_HIGH)
   {


### PR DESCRIPTION
This should be merged before https://github.com/betaflight/betaflight/pull/10909#issuecomment-907803332 to add necessary library support.