### PR TITLE
Fix pg_resetdata location in FLASH

### DIFF
--- a/src/link/stm32_flash_f7_split.ld
+++ b/src/link/stm32_flash_f7_split.ld
@@ -90,7 +90,7 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_start = .);
     KEEP (*(.pg_resetdata))
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
-  } >FLASH1 AT >WRITABLE_FLASH1
+  } >WRITABLE_FLASH1
 
   /* Storage for the address for the configuration section so we can grab it out of the hex file */
   .custom_defaults :


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/10920.

`.pg_resetdata` section was being stored in FLASH at the `WRITABLE_FLASH1` alias, but mapped to appear at `FLASH1` so the default config was mis-mapped and effectively corrupt. This broke the application of `defaults`.