### PR TITLE
Add 50 mW TX power level to CRSF protocol

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -74,9 +74,9 @@ static float channelScale = CRSF_RC_CHANNEL_SCALE_LEGACY;
 static timeUs_t lastRcFrameTimeUs = 0;
 
 #ifdef USE_RX_LINK_UPLINK_POWER
-#define CRSF_UPLINK_POWER_LEVEL_MW_ITEMS_COUNT 8
-// Uplink power levels by uplinkTXPower expressed in mW (250 mW is from ver >=4.00)
-const uint16_t uplinkTXPowerStatesMw[CRSF_UPLINK_POWER_LEVEL_MW_ITEMS_COUNT] = {0, 10, 25, 100, 500, 1000, 2000, 250};
+#define CRSF_UPLINK_POWER_LEVEL_MW_ITEMS_COUNT 9
+// Uplink power levels by uplinkTXPower expressed in mW (250 mW is from ver >=4.00, 50 mW in a future version and for ExpressLRS)
+const uint16_t uplinkTXPowerStatesMw[CRSF_UPLINK_POWER_LEVEL_MW_ITEMS_COUNT] = {0, 10, 25, 100, 500, 1000, 2000, 250, 50};
 #endif
 
 /*

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -256,7 +256,9 @@ typedef enum {
     CRSF_RF_POWER_100_mW = 3,
     CRSF_RF_POWER_500_mW = 4,
     CRSF_RF_POWER_1000_mW = 5,
-    CRSF_RF_POWER_2000_mW = 6
+    CRSF_RF_POWER_2000_mW = 6,
+    CRSF_RF_POWER_250_mW = 7,
+    CRSF_RF_POWER_50_mW = 8
 } crsrRfPower_e;
 
 /*


### PR DESCRIPTION
This PR adds the 50 mW TX power level to the CRSF protocol. TBS is adding this power level in a future firmware version and they already added support for it in OpenTX. ExpressLRS uses 50 mW but cannot include it in the link statistics until the various projects that use CRSF support it, hence this PR.