### PR TITLE
UART - Add generic pin swap functionality.

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -222,6 +222,9 @@ typedef struct uartDevice_s {
     uartPinDef_t tx;
     volatile uint8_t *rxBuffer;
     volatile uint8_t *txBuffer;
+#if !(defined(STM32F1) || defined(STM32F4)) // Older CPUs don't support pin swap.
+    bool pinSwap;
+#endif
 } uartDevice_t;
 
 extern uartDevice_t *uartDevmap[];

--- a/src/main/drivers/serial_uart_pinconfig.c
+++ b/src/main/drivers/serial_uart_pinconfig.c
@@ -53,14 +53,31 @@ void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig)
         const uartHardware_t *hardware = &uartHardware[hindex];
         const UARTDevice_e device = hardware->device;
 
+#if !(defined(STM32F1) || defined(STM32F4)) // Older CPUs don't support pin swap.
+        uartdev->pinSwap = false;
+#endif
         for (int pindex = 0 ; pindex < UARTHARDWARE_MAX_PINS ; pindex++) {
-            if (hardware->rxPins[pindex].pin == pSerialPinConfig->ioTagRx[device]) {
+            if (pSerialPinConfig->ioTagRx[device] == hardware->rxPins[pindex].pin) {
                 uartdev->rx = hardware->rxPins[pindex];
             }
 
-            if (hardware->txPins[pindex].pin == pSerialPinConfig->ioTagTx[device]) {
+            if (pSerialPinConfig->ioTagTx[device] == hardware->txPins[pindex].pin) {
                 uartdev->tx = hardware->txPins[pindex];
             }
+
+
+#if !(defined(STM32F1) || defined(STM32F4))
+            // Check for swapped pins
+            if (pSerialPinConfig->ioTagTx[device] == hardware->rxPins[pindex].pin) {
+                uartdev->tx = hardware->rxPins[pindex];
+                uartdev->pinSwap = true;
+            }
+
+            if (pSerialPinConfig->ioTagRx[device] == hardware->txPins[pindex].pin) {
+                uartdev->rx = hardware->txPins[pindex];
+                uartdev->pinSwap = true;
+            }
+#endif
         }
 
         if (uartdev->rx.pin || uartdev->tx.pin) {


### PR DESCRIPTION
If RX pin resource is assigned to a TX hardware pin, or vice versa, then pin-swap is enabled.

This allows hardware designers to allocate pins more effectively, for instance using a UART5 TX pin for ESC Telemetry which usually uses an RX pin when UART5 RX is unavailable.

Target definitions simply just swap the RX and TX resources.

This also helps users transitioning from FlightOne to Betaflight, since on FlightOne FC's the RC receiver's TX pin is often connected to the FC's TX pin, so now users don't have to re-wire/re-solder.
