### PR TITLE
Cleanup of the bus switch functionality.

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -198,7 +198,7 @@ void processLoopback(void)
 #ifdef BUS_SWITCH_PIN
 void busSwitchInit(void)
 {
-static IO_t busSwitchResetPin        = IO_NONE;
+    IO_t busSwitchResetPin = IO_NONE;
 
     busSwitchResetPin = IOGetByTag(IO_TAG(BUS_SWITCH_PIN));
     IOInit(busSwitchResetPin, OWNER_SYSTEM, 0);


### PR DESCRIPTION
Not sure if this still has got a valid use case, it has probably been superseded by the debug pin functionality.