### PR TITLE
Fixed instances of 'FAST_CODE FAST_CODE_NOINLINE'.

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -38,7 +38,7 @@ int main(void)
     return 0;
 }
 
-void FAST_CODE FAST_CODE_NOINLINE run(void)
+void FAST_CODE run(void)
 {
     while (true) {
         scheduler();

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -371,7 +371,7 @@ static FAST_CODE void checkForYawSpin(timeUs_t currentTimeUs)
 }
 #endif // USE_YAW_SPIN_RECOVERY
 
-static FAST_CODE FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t *gyroSensor)
+static FAST_CODE void gyroUpdateSensor(gyroSensor_t *gyroSensor)
 {
     if (!gyroSensor->gyroDev.readFn(&gyroSensor->gyroDev)) {
         return;


### PR DESCRIPTION
`FAST_CODE` forces functions to be put into fast code storage (on platforms that support it) - in itself this will prevent inlining if the caller of the function is not in fast code RAM as well.
`FAST_CODE_NOINLINE` prevents inlining, and is used to force functions to be put into 'normal' code storage when they are called from functions in fast code storage.
As a consequence, combining the two does not result in desirable behaviour.