### PR TITLE
Fixed optimisation for board alignment.

### DIFF
--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -78,7 +78,7 @@ FAST_CODE_NOINLINE void alignSensorViaMatrix(float *dest, fp_rotationMatrix_t* s
     }
 }
 
-FAST_CODE void alignSensorViaRotation(float *dest, uint8_t rotation)
+void alignSensorViaRotation(float *dest, uint8_t rotation)
 {
     const float x = dest[X];
     const float y = dest[Y];


### PR DESCRIPTION
In the existing situation, **all** uses of `alignSensorViaRotation()` were done into fast storage (including ones that are on non-optimised code paths like compass). This changes this so that only uses in optimised code paths do this in fast storage, in an inlined fashion.