### PR TITLE
Fixed 'timer show' for bitbanged Dshot timers.

### DIFF
--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -238,6 +238,18 @@ static bbPort_t *bbAllocMotorPort(int portIndex)
     return bbPort;
 }
 
+const timerHardware_t *dshotBitbangTimerGetAllocatedByNumberAndChannel(int8_t timerNumber, uint16_t timerChannel)
+{
+    for (int index = 0; index < usedMotorPorts; index++) {
+        const timerHardware_t *bitbangTimer = bbPorts[index].timhw;
+        if (bitbangTimer && timerGetTIMNumber(bitbangTimer->tim) == timerNumber && bitbangTimer->channel == timerChannel && bbPorts[index].owner.owner) {
+            return bitbangTimer;
+        }
+    }
+
+    return NULL;
+}
+
 const resourceOwner_t *dshotBitbangTimerGetOwner(const timerHardware_t *timer)
 {
     for (int index = 0; index < usedMotorPorts; index++) {
@@ -280,7 +292,7 @@ static void bbAllocDma(bbPort_t *bbPort)
 #endif
 
     dmaIdentifier_e dmaIdentifier = dmaGetIdentifier(bbPort->dmaResource);
-    dmaInit(dmaIdentifier, OWNER_DSHOT_BITBANG, bbPort->owner.resourceIndex);
+    dmaInit(dmaIdentifier, bbPort->owner.owner, bbPort->owner.resourceIndex);
     bbPort->dmaSource = timerDmaSource(timhw->channel);
 
     bbPacer_t *bbPacer = bbFindMotorPacer(timhw->tim);

--- a/src/main/drivers/dshot_bitbang.h
+++ b/src/main/drivers/dshot_bitbang.h
@@ -39,4 +39,5 @@ struct motorDevConfig_s;
 struct motorDevice_s;
 struct motorDevice_s *dshotBitbangDevInit(const struct motorDevConfig_s *motorConfig, uint8_t motorCount);
 dshotBitbangStatus_e dshotBitbangGetStatus();
+const timerHardware_t *dshotBitbangTimerGetAllocatedByNumberAndChannel(int8_t timerNumber, uint16_t timerChannel);
 const resourceOwner_t *dshotBitbangTimerGetOwner(const timerHardware_t *timer);

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -87,28 +87,27 @@ const timerHardware_t *timerGetAllocatedByNumberAndChannel(int8_t timerNumber, u
         }
     }
 
+#if defined(USE_DSHOT_BITBANG)
+    return dshotBitbangTimerGetAllocatedByNumberAndChannel(timerNumber, timerChannel);
+#else
     return NULL;
+#endif
 }
 
 const resourceOwner_t *timerGetOwner(const timerHardware_t *timer)
 {
-    const resourceOwner_t *timerOwner = &freeOwner;
     for (unsigned i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
         const timerHardware_t *assignedTimer = timerGetByTagAndIndex(timerIOConfig(i)->ioTag, timerIOConfig(i)->index);
         if (assignedTimer && assignedTimer == timer) {
-            timerOwner = &timerOwners[i];
-
-            break;
+            return &timerOwners[i];
         }
     }
 
 #if defined(USE_DSHOT_BITBANG)
-    if (!timerOwner->owner) {
-        timerOwner = dshotBitbangTimerGetOwner(timer);
-    }
-#endif
-
+    return dshotBitbangTimerGetOwner(timer);
+#else
     return timerOwner;
+#endif
 }
 
 const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex)


### PR DESCRIPTION
Fixes the problem of the timer allocation not showing when bitbanged Dshot is used.

Before:

```
# resource show all
Currently active IO resource assignments:
(reboot to update)
--------------------
A00: FREE
A01: FREE
A02: FREE
A03: SERIAL_RX 2
A04: FREE
A05: SPI_SCK 1
A06: SPI_MISO 1
A07: SPI_MOSI 1
A08: FREE
A09: FREE
A10: FREE
A11: USB
A12: USB
A13: SWD
A14: LED 2
A15: FREE
B00: FREE
B01: FREE
B02: FREE
B03: SPI_SCK 3
B04: SPI_MISO 3
B05: SPI_MOSI 3
B06: I2C_SCL 1
B07: I2C_SDA 1
B08: FREE
B09: LED 1
B10: OSD_CS
B11: FREE
B12: FREE
B13: SPI_SCK 2
B14: SPI_MISO 2
B15: SPI_MOSI 2
C00: ADC_BATT
C01: SDCARD_CS
C02: GYRO_CS 1
C03: GYRO_EXTI
C04: ADC_CURR
C05: FREE
C06: MOTOR 1
C07: MOTOR 2
C08: MOTOR 3
C09: MOTOR 4
C10: FREE
C11: FREE
C12: FREE
C13: BEEPER
C14: FREE
C15: FREE
D00: FREE
D01: FREE
D02: FREE
D03: FREE
D04: FREE
D05: FREE
D06: FREE
D07: FREE
D08: FREE
D09: FREE
D10: FREE
D11: FREE
D12: FREE
D13: FREE
D14: FREE
D15: FREE
E00: FREE
E01: FREE
E02: FREE
E03: FREE
E04: FREE
E05: FREE
E06: FREE
E07: FREE
E08: FREE
E09: FREE
E10: FREE
E11: FREE
E12: FREE
E13: FREE
E14: FREE
E15: FREE
F00: FREE
F01: FREE
F02: FREE
F03: FREE
F04: FREE
F05: FREE
F06: FREE
F07: FREE
F08: FREE
F09: FREE
F10: FREE
F11: FREE
F12: FREE
F13: FREE
F14: FREE
F15: FREE

Currently active Timers:
-----------------------
TIM1: FREE
TIM2: FREE
TIM3: FREE
TIM4: FREE
TIM5: FREE
TIM6: FREE
TIM7: FREE
TIM8: FREE
TIM9: FREE
TIM10: FREE
TIM11: FREE
TIM12: FREE
TIM13: FREE
TIM14: FREE

Currently active DMA:
--------------------
DMA1 Stream 0: SPI_MISO 3
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC
DMA2 Stream 1: FREE
DMA2 Stream 2: DSHOT_BITBANG 3
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

After:

```
# resource show all
Currently active IO resource assignments:
(reboot to update)
--------------------
A00: FREE
A01: FREE
A02: FREE
A03: SERIAL_RX 2
A04: FREE
A05: SPI_SCK 1
A06: SPI_MISO 1
A07: SPI_MOSI 1
A08: FREE
A09: FREE
A10: FREE
A11: USB
A12: USB
A13: SWD
A14: LED 2
A15: FREE
B00: FREE
B01: FREE
B02: FREE
B03: SPI_SCK 3
B04: SPI_MISO 3
B05: SPI_MOSI 3
B06: I2C_SCL 1
B07: I2C_SDA 1
B08: FREE
B09: LED 1
B10: OSD_CS
B11: FREE
B12: FREE
B13: SPI_SCK 2
B14: SPI_MISO 2
B15: SPI_MOSI 2
C00: ADC_BATT
C01: SDCARD_CS
C02: GYRO_CS 1
C03: GYRO_EXTI
C04: ADC_CURR
C05: FREE
C06: MOTOR 1
C07: MOTOR 2
C08: MOTOR 3
C09: MOTOR 4
C10: FREE
C11: FREE
C12: FREE
C13: BEEPER
C14: FREE
C15: FREE
D00: FREE
D01: FREE
D02: FREE
D03: FREE
D04: FREE
D05: FREE
D06: FREE
D07: FREE
D08: FREE
D09: FREE
D10: FREE
D11: FREE
D12: FREE
D13: FREE
D14: FREE
D15: FREE
E00: FREE
E01: FREE
E02: FREE
E03: FREE
E04: FREE
E05: FREE
E06: FREE
E07: FREE
E08: FREE
E09: FREE
E10: FREE
E11: FREE
E12: FREE
E13: FREE
E14: FREE
E15: FREE
F00: FREE
F01: FREE
F02: FREE
F03: FREE
F04: FREE
F05: FREE
F06: FREE
F07: FREE
F08: FREE
F09: FREE
F10: FREE
F11: FREE
F12: FREE
F13: FREE
F14: FREE
F15: FREE

Currently active Timers:
-----------------------
TIM1: FREE
TIM2: FREE
TIM3: FREE
TIM4: FREE
TIM5: FREE
TIM6: FREE
TIM7: FREE
TIM8:
    CH1 : DSHOT_BITBANG 3
TIM9: FREE
TIM10: FREE
TIM11: FREE
TIM12: FREE
TIM13: FREE
TIM14: FREE

Currently active DMA:
--------------------
DMA1 Stream 0: SPI_MISO 3
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC
DMA2 Stream 1: FREE
DMA2 Stream 2: DSHOT_BITBANG 3
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```