### PR TITLE
Uprev PG config since 4.2.9

### DIFF
--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -34,7 +34,7 @@
 #include "drivers/dma.h"
 #include "drivers/dma_reqmap.h"
 
-PG_REGISTER_WITH_RESET_FN(sdcardConfig_t, sdcardConfig, PG_SDCARD_CONFIG, 1);
+PG_REGISTER_WITH_RESET_FN(sdcardConfig_t, sdcardConfig, PG_SDCARD_CONFIG, 2);
 
 void pgResetFn_sdcardConfig(sdcardConfig_t *config)
 {


### PR DESCRIPTION
Following a comment in https://github.com/betaflight/betaflight/pull/10972 about incrementing the PG version when a `xyzConfig_t` structure is updated I reviewed all such changes introduced into master since 4.2.9 and found that `sdcardConfig_t` had been updated with no such revision update. This change was introduced by me in https://github.com/betaflight/betaflight/pull/10705.