### PR TITLE
CLI option to not interpolate duplicates in feedforward

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1156,6 +1156,7 @@ const clivalue_t valueTable[] = {
     { "feedforward_jitter_reduction", VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { "feedforward_boost",            VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { "feedforward_max_rate_limit",   VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 150}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
+    { "feedforward_interpolate_dups", VAR_UINT8 | PROFILE_VALUE| MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_interpolate_dups) },
 #endif
 
 #ifdef USE_DYN_IDLE

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -207,6 +207,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .feedforward_smooth_factor = 25,
         .feedforward_jitter_factor = 7,
         .feedforward_boost = 15,
+        .feedforward_interpolate_dups = false,
         .dyn_lpf_curve_expo = 5,
         .level_race_mode = false,
         .vbat_sag_compensation = 0,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -204,12 +204,13 @@ typedef struct pidProfile_s {
     uint8_t dyn_idle_d_gain;                // D gain for corrections around rapid changes in rpm
     uint8_t dyn_idle_max_increase;          // limit on maximum possible increase in motor idle drive during active control
 
-    uint8_t feedforward_transition;          // Feedforward attenuation around centre sticks
+    uint8_t feedforward_transition;         // Feedforward attenuation around centre sticks
     uint8_t feedforward_averaging;          // Number of packets to average when averaging is on
     uint8_t feedforward_smooth_factor;      // Amount of lowpass type smoothing for feedforward steps
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward
     uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
     uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
+    uint8_t feedforward_interpolate_dups;   // Whether or not to interpolate duplicate packets - on for SBUS
 
     uint8_t dyn_lpf_curve_expo;             // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calculation is gyro based in level mode


### PR DESCRIPTION
This is a PR for discussion purposes.

Backround:

Duplicate packets - identical data on a given axis in successive packets - occur in certain radio links, eg FrSky SBus and probably others, either during telemetry transmission or when a packet is not or garbled.  

They also occur when the sticks move so slowly, relative to the available number of amplitude steps, so that there are periods of no change in transmitted value, followed by a step up to a new value, another flat spot, and so on. This can lead to patterns of alternating flat spots and steps up, eg `up, flat, up, flat` data, `1-up, 2-flat, 1-up, 3-flat`, etc.  This is more of a problem with faster links, where the amplitude change is smaller because there is less time between packets for a meaningful change to occur.  It also happens If the FrSky hardware ADC filter is active, where the RC data becomes a series of large steps with big flat spots in-between.

If we are moving the sticks steadily and there is a duplicate, the delta value on which feedforward is based will abruptly drop to zero.  The next step up will be twice as big, leading to a spike to twice the regular feedforward value.  Thus a single duplicate causes an extreme spike in feedforward. This is magnified 2-3x by the 'boost' parameter. The spike will be biggest when the sticks are moving fairly quickly, and the amount of feedforward is large.  Since feedforward is set point based, the spike will be worse when the sticks are relatively far out.  

Hence the current feedforward code includes an interpolation method to minimise these spikes.  It2 uses the preceding setpoint movement to determine the likely next setpoint value, and uses this interpolated value in place of the duplicate, holding feedforward on the same general trajectory as it had been.  This is very effective when the sticks are moving reasonably predictably and smoothly.

However interpolation is counter-productive when the sticks have abruptly, but truly, stopped, and when there is up/down flat spot behaviour.

So the code includes a number of methods to avoid or attenuate interpolation when it is likely to be un-helpful.  They include:
- not interpolating the first step after a preceding flat spot, eg ADC was active.
- not interpolating after a prolonged dropout 
- not interpolating when sticks are near max, since jitter there makes big FF spikes due to expo
- jitter reduction code that attenuates all feedforward for slow stick movements relative to packet rate where the absolute RC packet delta is small
- not applying boost under some conditions where it would exaggerate the problem

Good as these 'protections' are, they are not perfect.

Many of the newer high-speed links, eg ELRS, Ghost, Tracer and so on, have specific issues with interpolation code.  They do not send duplicates intentionally, eg for telemetry, so they don't really need interpolation at all.  However many are prone to sync problems with the host radio, especially with firmware mismatches, and don't tolerate gimbal 'junk' well at all.  These sync issues manifest as erratic stepping behaviour at slower stick movements.  This can be quite extreme, eg `up4, same, down2, up3, same, same, up5' and so on.  The interpolation code just goes nuts with this type of input, resulting in exaggerated feedforward noise that is only partly attenuated by the jitter reduction code.

This PR is a draft proposal whereby an option is provided, and enabled by default, to bypass the interpolation altogether.

The idea is that for most of these newer links, it is better, overall, not to interpolate.  But users of FrSky SBUS and so on can enable the interpolation and get less spiking in their feedforward traces.

I've tested the code and I do get cleaner results with slower stick movement in my ELRS setups.  Not a lot, but its definitely better. In contrast, my FrSky setups are definitely better with the interpolation on.

I'm putting this up for discussion.  Its a rather technical change and I'm reluctant to add 'yet another' profile based feedforward parameter, so I welcome any input.
