### PR TITLE
Added application of simplified tuning on reset.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3095,14 +3095,29 @@ static void cliVtxInfo(const char *cmdName, char *cmdline)
 }
 #endif // USE_VTX_TABLE
 
-#ifdef USE_SIMPLIFIED_TUNING
-static void cliApplySimplifiedTuning(const char *cmdName, char *cmdline)
+#if defined(USE_SIMPLIFIED_TUNING)
+static void applySimplifiedTuningAllProfiles(void)
 {
-    UNUSED(cmdName);
-    UNUSED(cmdline);
+    for (unsigned pidProfileIndex = 0; pidProfileIndex < PID_PROFILE_COUNT; pidProfileIndex++) {
+        applySimplifiedTuning(pidProfilesMutable(pidProfileIndex));
+    }
+}
 
-    applySimplifiedTuning(currentPidProfile);
-    cliPrintLine("Applied tuning based on simplified tuning settings.");
+static void cliSimplifiedTuning(const char *cmdName, char *cmdline)
+{
+    if (strcasecmp(cmdline, "apply") == 0) {
+        applySimplifiedTuningAllProfiles();
+
+        cliPrintLine("Applied simplified tuning.");
+    } else if (strcasecmp(cmdline, "disable") == 0) {
+        for (unsigned pidProfileIndex = 0; pidProfileIndex < PID_PROFILE_COUNT; pidProfileIndex++) {
+            disableSimplifiedTuning(pidProfilesMutable(pidProfileIndex));
+        }
+
+        cliPrintLine("Disabled simplified tuning.");
+    } else {
+        cliShowParseError(cmdName);
+    }
 }
 #endif
 
@@ -4260,6 +4275,10 @@ bool resetConfigToCustomDefaults(void)
 
     cliProcessCustomDefaults(true);
 
+#if defined(USE_SIMPLIFIED_TUNING)
+    applySimplifiedTuningAllProfiles();
+#endif
+
     return prepareSave();
 }
 
@@ -4412,6 +4431,10 @@ static void cliDefaults(const char *cmdName, char *cmdline)
     if (useCustomDefaults) {
         cliProcessCustomDefaults(false);
     }
+#endif
+
+#if defined(USE_SIMPLIFIED_TUNING)
+    applySimplifiedTuningAllProfiles();
 #endif
 
     if (parameterGroupId) {
@@ -6444,9 +6467,6 @@ static void cliHelp(const char *cmdName, char *cmdline);
 // should be sorted a..z for bsearch()
 const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("adjrange", "configure adjustment ranges", "<index> <unused> <range channel> <start> <end> <function> <select channel> [<center> <scale>]", cliAdjustmentRange),
-#ifdef USE_SIMPLIFIED_TUNING
-    CLI_COMMAND_DEF("apply_simplified_tuning", "applies tuning based on simplified tuning settings", NULL, cliApplySimplifiedTuning),
-#endif
     CLI_COMMAND_DEF("aux", "configure modes", "<index> <mode> <aux> <start> <end> <logic>", cliAux),
 #ifdef USE_CLI_BATCH
     CLI_COMMAND_DEF("batch", "start or end a batch of commands", "start | end", cliBatch),
@@ -6576,6 +6596,9 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("set", "change setting", "[<name>=<value>]", cliSet),
 #if defined(USE_SIGNATURE)
     CLI_COMMAND_DEF("signature", "get / set the board type signature", "[signature]", cliSignature),
+#endif
+#if defined(USE_SIMPLIFIED_TUNING)
+    CLI_COMMAND_DEF("simplified_tuning", "applies or disables simplified tuning", "apply | disable", cliSimplifiedTuning),
 #endif
 #ifdef USE_SERVOS
     CLI_COMMAND_DEF("smix", "servo mixer", "<rule> <servo> <source> <rate> <speed> <min> <max> <box>\r\n"

--- a/src/main/config/simplified_tuning.c
+++ b/src/main/config/simplified_tuning.c
@@ -95,4 +95,13 @@ void applySimplifiedTuning(pidProfile_t *pidProfile)
         calculateNewGyroFilterValues();
     }
 }
+
+void disableSimplifiedTuning(pidProfile_t *pidProfile)
+{
+    pidProfile->simplified_pids_mode = PID_SIMPLIFIED_TUNING_OFF;
+
+    pidProfile->simplified_dterm_filter = false;
+
+    gyroConfigMutable()->simplified_gyro_filter = false;
+}
 #endif // USE_SIMPLIFIED_TUNING

--- a/src/main/config/simplified_tuning.h
+++ b/src/main/config/simplified_tuning.h
@@ -39,3 +39,4 @@ typedef enum {
 } pidSimplifiedTuningMode_e;
 
 void applySimplifiedTuning(pidProfile_t *pidProfile);
+void disableSimplifiedTuning(pidProfile_t *pidProfile);


### PR DESCRIPTION
This pull request adds the following:
- [x] whenever the configuration is reset, after custom defaults have been applied, the simplified settings are applied. This ensures that the configuration is consistent;
- [x] the `apply_simplified_settings` command is renamed to `simplified_settings apply`;
- [x] there is a new `simplified_settings disable` command that disables the simplified settings by setting the respective parameters to their 'off' value.