### PR TITLE
Changed the optimisation level for ITCM RAM code to free up some ITCM RAM space on F745.

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -74,6 +74,7 @@
 
 #ifdef STM32F7
 #define USE_ITCM_RAM
+#define ITCM_RAM_OPTIMISATION "-O2"
 #define USE_FAST_DATA
 #define USE_DSHOT
 #define USE_DSHOT_BITBANG
@@ -159,7 +160,11 @@
 
 
 #ifdef USE_ITCM_RAM
+#if defined(ITCM_RAM_OPTIMISATION) && !defined(DEBUG)
+#define FAST_CODE                   __attribute__((section(".tcm_code"))) __attribute__((optimize(ITCM_RAM_OPTIMISATION)))
+#else
 #define FAST_CODE                   __attribute__((section(".tcm_code")))
+#endif
 #define FAST_CODE_NOINLINE          NOINLINE
 #else
 #define FAST_CODE


### PR DESCRIPTION
Before:

```
Linking STM32F745 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       15764 B        16 KB     96.22%
[...]
```

After:

```
Linking STM32F745 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       13476 B        16 KB     82.25%
[...]
```

Note: This does not result in a change on F722, as all of the speed optimised compilation units are built with `-O2` optimisation already.