### PR TITLE
Make unit test working on MacOS and clang 12/13

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -462,28 +462,19 @@ CXX_VERSION = $(shell $(CXX) -dumpversion)
 
 ifeq ($(shell $(CC) -v 2>&1 | grep -q "clang version" && echo "clang"),clang)
 
-# Please revisit versions when new clang version arrive. Supported versions: { Linux: 7 - 11; OSX: 7- 12 }
+# Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 13 }
 # Travis reports CC_VERSION of 4.2.1
 CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
 CC_VERSION_CHECK_MIN := 7
-CC_VERSION_CHECK_MAX := 11
+CC_VERSION_CHECK_MAX := 13
 
-# Added flags for clang 11 (linux) are not backwards compatible:
-# -fcommon
-# -Wno-void-pointer-to-int-cast
-
-ifneq ($(OSFAMILY), macosx)
-ifeq ($(CC_VERSION_MAJOR), 11)
+# Added flags for clang 11 - 13 are not backwards compatible
+ifeq ($(shell expr $(CC_VERSION_MAJOR) \> 10 \& $(CC_VERSION_MAJOR) \< 14), 1)
 COMMON_FLAGS += \
 	-fcommon \
 	-Wno-void-pointer-to-int-cast
 endif
-endif
 
-ifeq ($(OSFAMILY), macosx)
-# MacOS comes with Apple's own flavour of clang that does not adhere to the official versioning
-CC_VERSION_CHECK_MAX := 12
-endif
 ifeq ($(shell expr $(CC_VERSION_MAJOR) \< $(CC_VERSION_CHECK_MIN) \| $(CC_VERSION_MAJOR) \> $(CC_VERSION_CHECK_MAX)),1)
 $(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-10'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)
 endif


### PR DESCRIPTION
Unit test cannot be run on MacOS with clang 12.

This should fix the problem.