### PR TITLE
Support dual gyros sharing a common SPI bus

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -112,6 +112,7 @@ typedef struct gyroDev_s {
     uint32_t gyroSyncEXTI;
     int32_t gyroShortPeriod;
     int32_t gyroDmaMaxDuration;
+    busSegment_t segments[2];
 #endif
     volatile bool dataReady;
     bool gyro_high_fsr;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -82,7 +82,13 @@ typedef struct busDevice_s {
  * is defined by a segment, with optional callback after each is completed
  */
 typedef struct busSegment_s {
+    /* Note that txData may point to the transmit buffer, or in the case of the final segment to
+     * a const extDevice_t * structure to link to the next transfer.
+     */
     uint8_t *txData;
+    /* Note that rxData may point to the receive buffer, or in the case of the final segment to
+     * a busSegment_t * structure to link to the next transfer.
+     */
     uint8_t *rxData;
     int len;
     bool negateCS; // Should CS be negated at the end of this segment

--- a/src/main/drivers/bus_spi_impl.h
+++ b/src/main/drivers/bus_spi_impl.h
@@ -32,6 +32,9 @@
 #error Unknown MCU family
 #endif
 
+#define BUS_SPI_FREE   0x0
+#define BUS_SPI_LOCKED 0x4
+
 typedef struct spiPinDef_s {
     ioTag_t pin;
 #if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
@@ -87,4 +90,5 @@ void spiInternalStartDMA(const extDevice_t *dev);
 void spiInternalStopDMA (const extDevice_t *dev);
 void spiInternalResetStream(dmaChannelDescriptor_t *descriptor);
 void spiInternalResetDescriptors(busDevice_t *bus);
+void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments);
 

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -270,7 +270,7 @@ void spiInternalStopDMA (const extDevice_t *dev)
 }
 
 // DMA transfer setup and start
-void spiSequence(const extDevice_t *dev, busSegment_t *segments)
+void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
 {
     busDevice_t *bus = dev->bus;
     SPI_TypeDef *instance = bus->busType_u.spi.instance;
@@ -360,7 +360,16 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments)
             bus->curSegment++;
         }
 
-        bus->curSegment = (busSegment_t *)NULL;
+        // If a following transaction has been linked, start it
+        if (bus->curSegment->txData) {
+            const extDevice_t *nextDev = (const extDevice_t *)bus->curSegment->txData;
+            busSegment_t *nextSegments = (busSegment_t *)bus->curSegment->rxData;
+            bus->curSegment->txData = NULL;
+            spiSequenceStart(nextDev, nextSegments);
+        } else {
+            // The end of the segment list has been reached, so mark transactions as complete
+            bus->curSegment = (busSegment_t *)NULL;
+        }
     }
 }
 #endif

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -392,6 +392,9 @@ void ak8963BusInit(const extDevice_t *dev)
     case BUS_TYPE_MPU_SLAVE:
         rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
 
+        // Disable DMA on gyro as this upsets slave access timing
+        spiDmaEnable(dev->bus->busType_u.mpuSlave.master, false);
+
         // initialize I2C master via SPI bus
         ak8963SpiWriteRegisterDelay(dev->bus->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
         ak8963SpiWriteRegisterDelay(dev->bus->busType_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz

--- a/src/main/drivers/exti.c
+++ b/src/main/drivers/exti.c
@@ -234,39 +234,40 @@ void EXTIEnable(IO_t io, bool enable)
 
 #define EXTI_EVENT_MASK 0xFFFF // first 16 bits only, see also definition of extiChannelRecs.
 
-void EXTI_IRQHandler(void)
+void EXTI_IRQHandler(uint32_t mask)
 {
-    uint32_t exti_active = (EXTI_REG_IMR & EXTI_REG_PR) & EXTI_EVENT_MASK;
+    uint32_t exti_active = (EXTI_REG_IMR & EXTI_REG_PR) & mask;
+
+    EXTI_REG_PR = exti_active;  // clear pending mask (by writing 1)
 
     while (exti_active) {
         unsigned idx = 31 - __builtin_clz(exti_active);
         uint32_t mask = 1 << idx;
         extiChannelRecs[idx].handler->fn(extiChannelRecs[idx].handler);
-        EXTI_REG_PR = mask;  // clear pending mask (by writing 1)
         exti_active &= ~mask;
     }
 }
 
-#define _EXTI_IRQ_HANDLER(name)                 \
-    void name(void) {                           \
-        EXTI_IRQHandler();                      \
-    }                                           \
-    struct dummy                                \
+#define _EXTI_IRQ_HANDLER(name, mask)            \
+    void name(void) {                            \
+        EXTI_IRQHandler(mask & EXTI_EVENT_MASK); \
+    }                                            \
+    struct dummy                                 \
     /**/
 
 
-_EXTI_IRQ_HANDLER(EXTI0_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI1_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI0_IRQHandler, 0x0001);
+_EXTI_IRQ_HANDLER(EXTI1_IRQHandler, 0x0002);
 #if defined(STM32F1) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
-_EXTI_IRQ_HANDLER(EXTI2_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI2_IRQHandler, 0x0004);
 #elif defined(STM32F3)
-_EXTI_IRQ_HANDLER(EXTI2_TS_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI2_TS_IRQHandler, 0x0004);
 #else
 # warning "Unknown CPU"
 #endif
-_EXTI_IRQ_HANDLER(EXTI3_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI4_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI9_5_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI15_10_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI3_IRQHandler, 0x0008);
+_EXTI_IRQ_HANDLER(EXTI4_IRQHandler, 0x0010);
+_EXTI_IRQ_HANDLER(EXTI9_5_IRQHandler, 0x03e0);
+_EXTI_IRQ_HANDLER(EXTI15_10_IRQHandler, 0xfc00);
 
 #endif

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -361,6 +361,7 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
         segments[DATA1].negateCS = true;
         segments[DATA1].callback = m25p16_callbackWriteComplete;
         // Mark segment following data as being of zero length
+        segments[DATA2].txData = (uint8_t *)NULL;
         segments[DATA2].len = 0;
     } else if (bufferCount == 2) {
         segments[DATA1].negateCS = false;


### PR DESCRIPTION
Dual gyros will typically not be synchronised and thus their interrupts can trigger EXTI interrupts, and consequently SPI DMA reads which may see one gyro's DMA aborting because the bus is already busy reading the other gyro. This PR addresses that by allowing SPI accesses to be queued using what is effectively a linked list tagging a new SPI access onto the end of a currently executing one.

Note that this will not create an arbitrary length queue, but only link one transfer after the current one. Should more transfers clash then they'll be silently dropped, but that's not believed to be a issue with any flight controllers.

This PR also fixes an issue that any EXTI interrupt would service all pending interrupts, not just those associated with the pin that have triggered the interrupt.