### PR TITLE
Apply CMS simplified tuning settings on exit if there are changes.

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -280,52 +280,44 @@ static const void *cmsx_simplifiedTuningOnExit(displayPort_t *pDisp, const OSD_E
 
     pidProfile_t *pidProfile = currentPidProfile;
 
-    pidProfile->simplified_pids_mode = cmsx_simplified_pids_mode;
-    pidProfile->simplified_master_multiplier = cmsx_simplified_master_multiplier;
-    pidProfile->simplified_roll_pitch_ratio = cmsx_simplified_roll_pitch_ratio;
-    pidProfile->simplified_i_gain = cmsx_simplified_i_gain;
-    pidProfile->simplified_d_gain = cmsx_simplified_d_gain;
-    pidProfile->simplified_pi_gain = cmsx_simplified_pi_gain;
+    const bool anySettingChanged = pidProfile->simplified_pids_mode != cmsx_simplified_pids_mode
+        || pidProfile->simplified_master_multiplier != cmsx_simplified_master_multiplier
+        || pidProfile->simplified_roll_pitch_ratio != cmsx_simplified_roll_pitch_ratio
+        || pidProfile->simplified_i_gain != cmsx_simplified_i_gain
+        || pidProfile->simplified_d_gain != cmsx_simplified_d_gain
+        || pidProfile->simplified_pi_gain != cmsx_simplified_pi_gain
 #ifdef USE_D_MIN
-    pidProfile->simplified_dmin_ratio = cmsx_simplified_dmin_ratio;
+        || pidProfile->simplified_dmin_ratio != cmsx_simplified_dmin_ratio
 #endif
-    pidProfile->simplified_feedforward_gain = cmsx_simplified_feedforward_gain;
-    pidProfile->simplified_pitch_pi_gain = cmsx_simplified_pitch_pi_gain;
+        || pidProfile->simplified_feedforward_gain != cmsx_simplified_feedforward_gain
+        || pidProfile->simplified_pitch_pi_gain != cmsx_simplified_pitch_pi_gain
+        || pidProfile->simplified_dterm_filter != cmsx_simplified_dterm_filter
+        || pidProfile->simplified_dterm_filter_multiplier != cmsx_simplified_dterm_filter_multiplier
+        || gyroConfigMutable()->simplified_gyro_filter != cmsx_simplified_gyro_filter
+        || gyroConfigMutable()->simplified_gyro_filter_multiplier != cmsx_simplified_gyro_filter_multiplier;
 
-    pidProfile->simplified_dterm_filter = cmsx_simplified_dterm_filter;
-    pidProfile->simplified_dterm_filter_multiplier = cmsx_simplified_dterm_filter_multiplier;
-    gyroConfigMutable()->simplified_gyro_filter = cmsx_simplified_gyro_filter;
-    gyroConfigMutable()->simplified_gyro_filter_multiplier = cmsx_simplified_gyro_filter_multiplier;
+    if (anySettingChanged) {
+        pidProfile->simplified_pids_mode = cmsx_simplified_pids_mode;
+        pidProfile->simplified_master_multiplier = cmsx_simplified_master_multiplier;
+        pidProfile->simplified_roll_pitch_ratio = cmsx_simplified_roll_pitch_ratio;
+        pidProfile->simplified_i_gain = cmsx_simplified_i_gain;
+        pidProfile->simplified_d_gain = cmsx_simplified_d_gain;
+        pidProfile->simplified_pi_gain = cmsx_simplified_pi_gain;
+#ifdef USE_D_MIN
+        pidProfile->simplified_dmin_ratio = cmsx_simplified_dmin_ratio;
+#endif
+        pidProfile->simplified_feedforward_gain = cmsx_simplified_feedforward_gain;
+        pidProfile->simplified_pitch_pi_gain = cmsx_simplified_pitch_pi_gain;
+
+        pidProfile->simplified_dterm_filter = cmsx_simplified_dterm_filter;
+        pidProfile->simplified_dterm_filter_multiplier = cmsx_simplified_dterm_filter_multiplier;
+        gyroConfigMutable()->simplified_gyro_filter = cmsx_simplified_gyro_filter;
+        gyroConfigMutable()->simplified_gyro_filter_multiplier = cmsx_simplified_gyro_filter_multiplier;
+
+        applySimplifiedTuning(currentPidProfile);
+    }
 
     return 0;
-}
-
-static const void *cmsx_applySimplifiedTuning(displayPort_t *pDisp, const void *self)
-{
-    UNUSED(pDisp);
-    UNUSED(self);
-
-    pidProfile_t *pidProfile = currentPidProfile;
-    pidProfile->simplified_master_multiplier = cmsx_simplified_master_multiplier;
-    pidProfile->simplified_pids_mode = cmsx_simplified_pids_mode;
-    pidProfile->simplified_roll_pitch_ratio = cmsx_simplified_roll_pitch_ratio;
-    pidProfile->simplified_i_gain = cmsx_simplified_i_gain;
-    pidProfile->simplified_d_gain = cmsx_simplified_d_gain;
-    pidProfile->simplified_pi_gain = cmsx_simplified_pi_gain;
-#ifdef USE_D_MIN
-    pidProfile->simplified_dmin_ratio = cmsx_simplified_dmin_ratio;
-#endif
-    pidProfile->simplified_feedforward_gain = cmsx_simplified_feedforward_gain;
-    pidProfile->simplified_pitch_pi_gain = cmsx_simplified_pitch_pi_gain;
-
-    pidProfile->simplified_dterm_filter = cmsx_simplified_dterm_filter;
-    pidProfile->simplified_dterm_filter_multiplier = cmsx_simplified_dterm_filter_multiplier;
-    gyroConfigMutable()->simplified_gyro_filter = cmsx_simplified_gyro_filter;
-    gyroConfigMutable()->simplified_gyro_filter_multiplier = cmsx_simplified_gyro_filter_multiplier;
-
-    applySimplifiedTuning(currentPidProfile);
-
-    return MENU_CHAIN_BACK;
 }
 
 static const OSD_Entry cmsx_menuSimplifiedTuningEntries[] =
@@ -352,9 +344,6 @@ static const OSD_Entry cmsx_menuSimplifiedTuningEntries[] =
     { "GYRO MULT",      OME_FLOAT, NULL, &(OSD_FLOAT_t) { &cmsx_simplified_gyro_filter_multiplier,  SIMPLIFIED_TUNING_MIN, SIMPLIFIED_TUNING_MAX, 5, 10 }, 0 },
     { "DTERM TUNING",   OME_TAB,   NULL, &(OSD_TAB_t)   { &cmsx_simplified_dterm_filter, 1, lookupTableOffOn }, 0 },
     { "DTERM MULT",     OME_FLOAT, NULL, &(OSD_FLOAT_t) { &cmsx_simplified_dterm_filter_multiplier, SIMPLIFIED_TUNING_MIN, SIMPLIFIED_TUNING_MAX, 5, 10 }, 0 },
-
-    { "-- GENERAL --", OME_Label, NULL, NULL, 0},
-    { "APPLY TUNING",  OME_Funcall, cmsx_applySimplifiedTuning, NULL, 0 },
 
     { "BACK", OME_Back, NULL, NULL, 0 },
     { NULL, OME_END, NULL, NULL, 0 }


### PR DESCRIPTION
It's great to have the simplified ("sliders") way of tuning in the CMS thanks to #9119. But having to apply any changes with the APPLY TUNING option (which is not even visible from the initial screen, you need to scroll down) is confusing, no other CMS menu settings require this extra confirmation.

This PR simply applies the tune if any values have been changed. This still allows you to manually change PIDs, it won't overwrite those if you accidentally enter the simplified tuning screen and exit it without changing any values.

The diff looks weird but it's simply the removal of cmsx_applySimplifiedTuning() and its menu entries, addition of boolean _anySettingChanged_ with a lot of ORed comparisons, and saving the values and calling applySimplifiedTuning() **only** if _anySettingChanged_ is true.

(this PR was previously #10966 but I messed that one up because of some recent other commits and my lack of experience with Git merge/rebase)