### PR TITLE
Fix ITM unlock

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -67,8 +67,10 @@ void cycleCounterInit(void)
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 
 #if defined(DWT_LAR_UNLOCK_VALUE)
-#if defined(STM32F7) || defined(STM32H7)
+#if defined(STM32H7)
     ITM->LAR = DWT_LAR_UNLOCK_VALUE;
+#elif defined(STM32F7)
+    DWT->LAR = DWT_LAR_UNLOCK_VALUE;
 #elif defined(STM32F3) || defined(STM32F4)
     // Note: DWT_Type does not contain LAR member.
 #define DWT_LAR


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11003

The  [STM32F74xxx reference manual](https://www.st.com/resource/en/reference_manual/rm0385-stm32f75xxx-and-stm32f74xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) shows the following:

![image](https://user-images.githubusercontent.com/11480839/136302923-c3df9e4b-cc69-442b-a021-5f643421e01a.png)

However https://github.com/betaflight/betaflight/blob/master/lib/main/CMSIS/Core/Include/core_cm7.h defines both `ITM_Type` containing an `LAR` register at `0xe0000fb0` and a `DWT_Type` also containing an `LAR` register at `0xe0001fb0`. Whilst an STM32F7X2 will unlock the ITM registers with a write of `0xc5acce55` to either LAR register, the STM32F745 requires a write to the DWT copy. This is thus now adopted for all F7 processor types.

Note that the consequence of this not working was that the `DWT->CYCCNT` was stuck at zero and thus the new scheduler code which relies on it couldn't work. The immediate symptom was the gyro not being read after being detected and then being stuck in calibration.