### PR TITLE
Allow selection of SPI MOSI/MISO DMA streams

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5393,14 +5393,17 @@ typedef struct dmaoptEntry_s {
     { device, peripheral, pgn, sizeof(type), offsetof(type, member), max, mask }
 
 dmaoptEntry_t dmaoptEntryTable[] = {
-    DEFW("SPI_TX",  DMA_PERIPH_SPI_TX,  PG_SPI_PIN_CONFIG,     spiPinConfig_t,     txDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
-    DEFW("SPI_RX",  DMA_PERIPH_SPI_RX,  PG_SPI_PIN_CONFIG,     spiPinConfig_t,     rxDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
-    DEFA("ADC",     DMA_PERIPH_ADC,     PG_ADC_CONFIG,         adcConfig_t,        dmaopt,   ADCDEV_COUNT,                    MASK_IGNORED),
-    DEFS("SDIO",    DMA_PERIPH_SDIO,    PG_SDIO_CONFIG,        sdioConfig_t,       dmaopt),
-    DEFW("UART_TX", DMA_PERIPH_UART_TX, PG_SERIAL_UART_CONFIG, serialUartConfig_t, txDmaopt, UARTDEV_CONFIG_MAX,              MASK_IGNORED),
-    DEFW("UART_RX", DMA_PERIPH_UART_RX, PG_SERIAL_UART_CONFIG, serialUartConfig_t, rxDmaopt, UARTDEV_CONFIG_MAX,              MASK_IGNORED),
+    DEFW("SPI_MOSI", DMA_PERIPH_SPI_MOSI, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     txDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    DEFW("SPI_MISO", DMA_PERIPH_SPI_MISO, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     rxDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    // SPI_TX/SPI_RX for backwards compatibility with unified configs defined for 4.2.x
+    DEFW("SPI_TX",   DMA_PERIPH_SPI_MOSI, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     txDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    DEFW("SPI_RX",   DMA_PERIPH_SPI_MISO, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     rxDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    DEFA("ADC",      DMA_PERIPH_ADC,      PG_ADC_CONFIG,         adcConfig_t,        dmaopt,   ADCDEV_COUNT,                    MASK_IGNORED),
+    DEFS("SDIO",     DMA_PERIPH_SDIO,     PG_SDIO_CONFIG,        sdioConfig_t,       dmaopt),
+    DEFW("UART_TX",  DMA_PERIPH_UART_TX,  PG_SERIAL_UART_CONFIG, serialUartConfig_t, txDmaopt, UARTDEV_CONFIG_MAX,              MASK_IGNORED),
+    DEFW("UART_RX",  DMA_PERIPH_UART_RX,  PG_SERIAL_UART_CONFIG, serialUartConfig_t, rxDmaopt, UARTDEV_CONFIG_MAX,              MASK_IGNORED),
 #if defined(STM32H7) || defined(STM32G4)
-    DEFW("TIMUP",   DMA_PERIPH_TIMUP,   PG_TIMER_UP_CONFIG,    timerUpConfig_t,    dmaopt,   HARDWARE_TIMER_DEFINITION_COUNT, TIMUP_TIMERS),
+    DEFW("TIMUP",    DMA_PERIPH_TIMUP,    PG_TIMER_UP_CONFIG,    timerUpConfig_t,    dmaopt,   HARDWARE_TIMER_DEFINITION_COUNT, TIMUP_TIMERS),
 #endif
 };
 

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -37,6 +37,7 @@
 #include "drivers/motor.h"
 #include "drivers/rcc.h"
 #include "nvic.h"
+#include "pg/bus_spi.h"
 
 static uint8_t spiRegisteredDeviceCount = 0;
 
@@ -540,8 +541,17 @@ void spiInitBusDMA()
         dmaIdentifier_e dmaTxIdentifier = DMA_NONE;
         dmaIdentifier_e dmaRxIdentifier = DMA_NONE;
 
-        for (uint8_t opt = 0; opt < MAX_PERIPHERAL_DMA_OPTIONS; opt++) {
-            const dmaChannelSpec_t *dmaTxChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_TX, device, opt);
+        int8_t txDmaopt = spiPinConfig(device)->txDmaopt;
+        uint8_t txDmaoptMin = 0;
+        uint8_t txDmaoptMax = MAX_PERIPHERAL_DMA_OPTIONS - 1;
+
+        if (txDmaopt != -1) {
+            txDmaoptMin = txDmaopt;
+            txDmaoptMax = txDmaopt;
+        }
+
+        for (uint8_t opt = txDmaoptMin; opt <= txDmaoptMax; opt++) {
+            const dmaChannelSpec_t *dmaTxChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_MOSI, device, opt);
 
             if (dmaTxChannelSpec) {
                 dmaTxIdentifier = dmaGetIdentifier(dmaTxChannelSpec->ref);
@@ -565,8 +575,17 @@ void spiInitBusDMA()
             }
         }
 
-        for (uint8_t opt = 0; opt < MAX_PERIPHERAL_DMA_OPTIONS; opt++) {
-            const dmaChannelSpec_t *dmaRxChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_RX, device, opt);
+        int8_t rxDmaopt = spiPinConfig(device)->rxDmaopt;
+        uint8_t rxDmaoptMin = 0;
+        uint8_t rxDmaoptMax = MAX_PERIPHERAL_DMA_OPTIONS - 1;
+
+        if (rxDmaopt != -1) {
+            rxDmaoptMin = rxDmaopt;
+            rxDmaoptMax = rxDmaopt;
+        }
+
+        for (uint8_t opt = rxDmaoptMin; opt <= rxDmaoptMax; opt++) {
+            const dmaChannelSpec_t *dmaRxChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_MISO, device, opt);
 
             if (dmaRxChannelSpec) {
                 dmaRxIdentifier = dmaGetIdentifier(dmaRxChannelSpec->ref);

--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -71,16 +71,26 @@ typedef struct dmaTimerMapping_s {
 #define DMA_REQUEST_UART9_RX DMA_REQUEST_LPUART1_RX
 #define DMA_REQUEST_UART9_TX DMA_REQUEST_LPUART1_TX
 
+// Resolve our preference for MOSI/MISO rather than TX/RX
+#define DMA_REQUEST_SPI1_MOSI DMA_REQUEST_SPI1_TX
+#define DMA_REQUEST_SPI1_MISO DMA_REQUEST_SPI1_RX
+#define DMA_REQUEST_SPI2_MOSI DMA_REQUEST_SPI2_TX
+#define DMA_REQUEST_SPI2_MISO DMA_REQUEST_SPI2_RX
+#define DMA_REQUEST_SPI3_MOSI DMA_REQUEST_SPI3_TX
+#define DMA_REQUEST_SPI3_MISO DMA_REQUEST_SPI3_RX
+#define DMA_REQUEST_SPI4_MOSI DMA_REQUEST_SPI4_TX
+#define DMA_REQUEST_SPI4_MISO DMA_REQUEST_SPI4_RX
+
 static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
 #ifdef USE_SPI
-    REQMAP_DIR(SPI, 1, TX),
-    REQMAP_DIR(SPI, 1, RX),
-    REQMAP_DIR(SPI, 2, TX),
-    REQMAP_DIR(SPI, 2, RX),
-    REQMAP_DIR(SPI, 3, TX),
-    REQMAP_DIR(SPI, 3, RX),
-    REQMAP_DIR(SPI, 4, TX),
-    REQMAP_DIR(SPI, 4, RX),
+    REQMAP_DIR(SPI, 1, MOSI),
+    REQMAP_DIR(SPI, 1, MISO),
+    REQMAP_DIR(SPI, 2, MOSI),
+    REQMAP_DIR(SPI, 2, MISO),
+    REQMAP_DIR(SPI, 3, MOSI),
+    REQMAP_DIR(SPI, 3, MISO),
+    REQMAP_DIR(SPI, 4, MOSI),
+    REQMAP_DIR(SPI, 4, MISO),
 #endif // USE_SPI
 
 #ifdef USE_ADC
@@ -209,20 +219,32 @@ static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
 #define DMA_REQUEST_UART6_RX DMA_REQUEST_USART6_RX
 #define DMA_REQUEST_UART6_TX DMA_REQUEST_USART6_TX
 
+// Resolve our preference for MOSI/MISO rather than TX/RX
+#define DMA_REQUEST_SPI1_MOSI DMA_REQUEST_SPI1_TX
+#define DMA_REQUEST_SPI1_MISO DMA_REQUEST_SPI1_RX
+#define DMA_REQUEST_SPI2_MOSI DMA_REQUEST_SPI2_TX
+#define DMA_REQUEST_SPI2_MISO DMA_REQUEST_SPI2_RX
+#define DMA_REQUEST_SPI3_MOSI DMA_REQUEST_SPI3_TX
+#define DMA_REQUEST_SPI3_MISO DMA_REQUEST_SPI3_RX
+#define DMA_REQUEST_SPI4_MOSI DMA_REQUEST_SPI4_TX
+#define DMA_REQUEST_SPI4_MISO DMA_REQUEST_SPI4_RX
+#define DMA_REQUEST_SPI5_MOSI DMA_REQUEST_SPI5_TX
+#define DMA_REQUEST_SPI5_MISO DMA_REQUEST_SPI5_RX
+
 static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
 #ifdef USE_SPI
-    REQMAP_DIR(SPI, 1, TX),
-    REQMAP_DIR(SPI, 1, RX),
-    REQMAP_DIR(SPI, 2, TX),
-    REQMAP_DIR(SPI, 2, RX),
-    REQMAP_DIR(SPI, 3, TX),
-    REQMAP_DIR(SPI, 3, RX),
-    REQMAP_DIR(SPI, 4, TX),
-    REQMAP_DIR(SPI, 4, RX),
-    REQMAP_DIR(SPI, 5, TX), // Not available in smaller packages
-    REQMAP_DIR(SPI, 5, RX), // ditto
-    // REQMAP_DIR(SPI, 6, TX), // SPI6 is on BDMA (todo)
-    // REQMAP_DIR(SPI, 6, TX), // ditto
+    REQMAP_DIR(SPI, 1, MOSI),
+    REQMAP_DIR(SPI, 1, MISO),
+    REQMAP_DIR(SPI, 2, MOSI),
+    REQMAP_DIR(SPI, 2, MISO),
+    REQMAP_DIR(SPI, 3, MOSI),
+    REQMAP_DIR(SPI, 3, MISO),
+    REQMAP_DIR(SPI, 4, MOSI),
+    REQMAP_DIR(SPI, 4, MISO),
+    REQMAP_DIR(SPI, 5, MOSI), // Not available in smaller packages
+    REQMAP_DIR(SPI, 5, MISO), // ditto
+    // REQMAP_DIR(SPI, 6, MOSI), // SPI6 is on BDMA (todo)
+    // REQMAP_DIR(SPI, 6, MOSI), // ditto
 #endif // USE_SPI
 
 #ifdef USE_ADC
@@ -343,24 +365,24 @@ static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
 static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
 #ifdef USE_SPI
     // Everything including F405 and F446
-    { DMA_PERIPH_SPI_TX,  SPIDEV_1,  { DMA(2, 3, 3), DMA(2, 5, 3) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_1,  { DMA(2, 0, 3), DMA(2, 2, 3) } },
-    { DMA_PERIPH_SPI_TX,  SPIDEV_2,  { DMA(1, 4, 0) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_2,  { DMA(1, 3, 0) } },
-    { DMA_PERIPH_SPI_TX,  SPIDEV_3,  { DMA(1, 5, 0), DMA(1, 7, 0) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_3,  { DMA(1, 0, 0), DMA(1, 2, 0) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_1,  { DMA(2, 3, 3), DMA(2, 5, 3) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_1,  { DMA(2, 0, 3), DMA(2, 2, 3) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_2,  { DMA(1, 4, 0) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_2,  { DMA(1, 3, 0) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_3,  { DMA(1, 5, 0), DMA(1, 7, 0) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_3,  { DMA(1, 0, 0), DMA(1, 2, 0) } },
 
 #if defined(STM32F411xE) || defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx) || defined(STM32F722xx)
-    { DMA_PERIPH_SPI_TX,  SPIDEV_4,  { DMA(2, 1, 4) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_4,  { DMA(2, 0, 4) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_4,  { DMA(2, 1, 4) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_4,  { DMA(2, 0, 4) } },
 
 #ifdef USE_EXTENDED_SPI_DEVICE
-    { DMA_PERIPH_SPI_TX,  SPIDEV_5,  { DMA(2, 6, 7) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_5,  { DMA(2, 5, 7) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_5,  { DMA(2, 6, 7) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_5,  { DMA(2, 5, 7) } },
 
 #if !defined(STM32F722xx)
-    { DMA_PERIPH_SPI_TX,  SPIDEV_6,  { DMA(2, 5, 1) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_6,  { DMA(2, 6, 1) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_6,  { DMA(2, 5, 1) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_6,  { DMA(2, 6, 1) } },
 #endif
 #endif // USE_EXTENDED_SPI_DEVICE
 #endif
@@ -434,12 +456,12 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
 #define DMA(d, c) { DMA_CODE(d, 0, c), (dmaResource_t *)DMA ## d ## _Channel ## c }
 static const dmaPeripheralMapping_t dmaPeripheralMapping[18] = {
 #ifdef USE_SPI
-    { DMA_PERIPH_SPI_TX,  SPIDEV_1, { DMA(1, 3) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_1, { DMA(1, 2) } },
-    { DMA_PERIPH_SPI_TX,  SPIDEV_2, { DMA(1, 5) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_2, { DMA(1, 4) } },
-    { DMA_PERIPH_SPI_TX,  SPIDEV_3, { DMA(2, 2) } },
-    { DMA_PERIPH_SPI_RX,  SPIDEV_3, { DMA(2, 1) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_1, { DMA(1, 3) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_1, { DMA(1, 2) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_2, { DMA(1, 5) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_2, { DMA(1, 4) } },
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_3, { DMA(2, 2) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_3, { DMA(2, 1) } },
 #endif
 
 #ifdef USE_ADC

--- a/src/main/drivers/dma_reqmap.h
+++ b/src/main/drivers/dma_reqmap.h
@@ -42,8 +42,8 @@ typedef struct dmaChannelSpec_s {
 #define DMA_CODE_REQUEST(code) DMA_CODE_CHANNEL(code)
 
 typedef enum {
-    DMA_PERIPH_SPI_TX,
-    DMA_PERIPH_SPI_RX,
+    DMA_PERIPH_SPI_MOSI,
+    DMA_PERIPH_SPI_MISO,
     DMA_PERIPH_ADC,
     DMA_PERIPH_SDIO,
     DMA_PERIPH_UART_TX,

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -964,14 +964,25 @@ void init(void)
 
     setArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
 
+    // On F4/F7 allocate SPI DMA streams before motor timers
+#if defined(STM32F4) || defined(STM32F7)
+#ifdef USE_SPI
+    // Attempt to enable DMA on all SPI busses
+    spiInitBusDMA();
+#endif
+#endif
+
 #ifdef USE_MOTOR
     motorPostInit();
     motorEnable();
 #endif
 
+    // On H7/G4 allocate SPI DMA streams after motor timers as SPI DMA allocate will always be possible
+#if defined(STM32H7) || defined(STM32G4)
 #ifdef USE_SPI
     // Attempt to enable DMA on all SPI busses
     spiInitBusDMA();
+#endif
 #endif
 
     swdPinsInit();

--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -25,6 +25,7 @@
 #include "drivers/dma_reqmap.h"
 #include "drivers/io.h"
 
+#include "pg/bus_spi.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11003

Merge after: https://github.com/betaflight/betaflight/pull/11006

Most FCs are able to automatically allocate DMA streams for each SPI_MOSI/SPI_MISO instance, avoiding other allocations, without issue, however the IFLIGHT_F745_AIO and KAKUTEF7MINI for example are unusual in that it uses both SPI bus 1 and 4, both of which use DMA controller 2. This is actually a common feature on F745 based FCs.

Default DMA allocations for the KAKUTEF7MINI are as shown below and it can be seen that `SPI_MISO 4` has not been assigned to a stream.

```
Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: FREE
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: SPI_MISO 1
DMA2 Stream 1: SPI_MOSI 4
DMA2 Stream 2: FREE
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: ADC
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

With reference to the table below, SPI bus 1 got allocated first, grabbing the first available SPI1_RX on Stream 0 as `SPI_MISO 1` and then the first available SPI1_TX on Stream 3 as `SPI_MOSI 1`. SPI bus 4 was able to allocate SPI4_TX on Stream 1 as `SPI_MOSI 4`, but then couldn't find a SPI4_RX to map as `SPI_MISO 4` as they're only available on Streams 0 and 3 which are already taken by bus 1.

![image](https://user-images.githubusercontent.com/11480839/136435486-faf67be5-e5bc-435d-af0d-8803109d3a27.png)

This PR adds support for the `dma` command to assign static SPI DMA streams.

On an IFLIGHT_F745_AIO for example, the default DMA stream allocation is as shown below.

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: LED_STRIP
DMA1 Stream 1: FREE
DMA1 Stream 2: SPI_MISO 3
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: SPI_MISO 1
DMA2 Stream 1: SPI_MOSI 4
DMA2 Stream 2: FREE
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: ADC
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

Entering the following:

```
dma SPI_MOSI 1 1
# dma SPI_MOSI 1: changed from NONE to 1
dma SPI_MISO 1 1
# dma SPI_MISO 1: changed from NONE to 1
save
```

Results in:

```
dma show

Currently active DMA:
--------------------
DMA1 Stream 0: LED_STRIP
DMA1 Stream 1: FREE
DMA1 Stream 2: SPI_MISO 3
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: SPI_MISO 4
DMA2 Stream 1: SPI_MOSI 4
DMA2 Stream 2: SPI_MISO 1
DMA2 Stream 3: FREE
DMA2 Stream 4: ADC
DMA2 Stream 5: SPI_MOSI 1
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

Unfortunately this breaks again if bit banged DSHOT is enabled, so that requires another PR to add similar control over `dma DSHOT_BITBANG`

```
dma show

Currently active DMA:
--------------------
DMA1 Stream 0: LED_STRIP
DMA1 Stream 1: FREE
DMA1 Stream 2: SPI_MISO 3
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: SPI_MISO 4
DMA2 Stream 1: DSHOT_BITBANG 2
DMA2 Stream 2: DSHOT_BITBANG 5
DMA2 Stream 3: FREE
DMA2 Stream 4: ADC
DMA2 Stream 5: SPI_MOSI 1
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```