### PR TITLE
set feedforward max rate limit to 90

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -203,7 +203,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dyn_idle_d_gain = 50,
         .dyn_idle_max_increase = 150,
         .feedforward_averaging = FEEDFORWARD_AVERAGING_OFF,
-        .feedforward_max_rate_limit = 100,
+        .feedforward_max_rate_limit = 90,
         .feedforward_smooth_factor = 25,
         .feedforward_jitter_factor = 7,
         .feedforward_boost = 15,


### PR DESCRIPTION
Very simple change to default feedforward max rate limit.

Apologies for overlooking this.

Since reworking the feedforward code, we found that this parameter now works properly.

A value of 90 works better than 100.