### PR TITLE
Dshot dshot_bitbang=AUTO behaviour change for non-F4

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -328,8 +328,13 @@ timeMs_t motorGetMotorEnableTimeMs(void)
 #ifdef USE_DSHOT_BITBANG
 bool isDshotBitbangActive(const motorDevConfig_t *motorDevConfig)
 {
+#ifdef STM32F4
     return motorDevConfig->useDshotBitbang == DSHOT_BITBANG_ON ||
         (motorDevConfig->useDshotBitbang == DSHOT_BITBANG_AUTO && motorDevConfig->useDshotTelemetry && motorDevConfig->motorPwmProtocol != PWM_TYPE_PROSHOT1000);
+#else
+    return motorDevConfig->useDshotBitbang == DSHOT_BITBANG_ON ||
+        (motorDevConfig->useDshotBitbang == DSHOT_BITBANG_AUTO && motorDevConfig->motorPwmProtocol != PWM_TYPE_PROSHOT1000);
+#endif
 }
 #endif
 


### PR DESCRIPTION
On F4's we’re better off not using bit-banged DSHOT if possible as that allows gyro DMA to be used, but on other processors it chews up extra DMA streams which we should ideally avoid.

> See https://www.st.com/resource/en/errata_sheet/dm00037591-stm32f405407xx-and-stm32f415417xx-device-limitations-stmicroelectronics.pdf section 2.1.10 which reports an errata that corruption may occurs on DMA2 if AHB peripherals (eg GPIO ports) are access concurrently with APB peripherals (eg SPI busses). Bitbang DSHOT uses DMA2 to write to GPIO ports. If this is enabled, then don't enable DMA on an SPI bus using DMA2.


On non-F4 FCs though, such as an IFLIGHT_F745_AIO with DSHOT bit-banged enabled either with `dshot_bitbang=ON` or by setting `dshot_burst = ON` we have once https://github.com/betaflight/betaflight/pull/11007 is merged, the following:

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: LED_STRIP
DMA1 Stream 1: FREE
DMA1 Stream 2: SPI_MISO 3
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: SPI_MISO 4
DMA2 Stream 1: SPI_MOSI 4
DMA2 Stream 2: SPI_MISO 1
DMA2 Stream 3: DSHOT_BITBANG 2
DMA2 Stream 4: ADC
DMA2 Stream 5: SPI_MOSI 1
DMA2 Stream 6: DSHOT_BITBANG 5
DMA2 Stream 7: FREE
```

Whereas with `dshot_bitbang=OFF` or `AUTO` with `dshot_burst = OFF` we have the following which prevents SPI_MISO 1 from being assigned.

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: LED_STRIP
DMA1 Stream 1: FREE
DMA1 Stream 2: MOTOR 2
DMA1 Stream 3: FREE
DMA1 Stream 4: FREE
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: FREE
DMA1 Stream 7: MOTOR 1
DMA2 Stream 0: SPI_MISO 4
DMA2 Stream 1: SPI_MOSI 4
DMA2 Stream 2: MOTOR 4
DMA2 Stream 3: MOTOR 3
DMA2 Stream 4: ADC
DMA2 Stream 5: SPI_MOSI 1
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

This PR changes the behaviour of `dshot_bitbang=AUTO` to always enable bit-banged DSHOT unless ProShot 1000 is being used on processors other than the F4.