### PR TITLE
Fixed ADC on STM32H7 Unified Targets.

### DIFF
--- a/src/main/drivers/adc_stm32h7xx.c
+++ b/src/main/drivers/adc_stm32h7xx.c
@@ -42,17 +42,6 @@
 
 #include "pg/adc.h"
 
-// XXX Instance and DMA stream defs will be gone in unified target
-
-#ifndef ADC1_INSTANCE
-#define ADC1_INSTANCE NULL
-#endif
-#ifndef ADC2_INSTANCE
-#define ADC2_INSTANCE NULL
-#endif
-#ifndef ADC3_INSTANCE
-#define ADC3_INSTANCE NULL
-#endif
 #ifndef ADC1_DMA_STREAM
 #define ADC1_DMA_STREAM NULL
 #endif
@@ -65,25 +54,25 @@
 
 const adcDevice_t adcHardware[ADCDEV_COUNT] = {
     {
-        .ADCx = ADC1_INSTANCE,
+        .ADCx = ADC1,
         .rccADC = RCC_AHB1(ADC12),
 #if !defined(USE_DMA_SPEC)
         .dmaResource = (dmaResource_t *)ADC1_DMA_STREAM,
         .channel = DMA_REQUEST_ADC1,
 #endif
     },
-    { .ADCx = ADC2_INSTANCE,
+    { .ADCx = ADC2,
         .rccADC = RCC_AHB1(ADC12),
 #if !defined(USE_DMA_SPEC)
         .dmaResource = (dmaResource_t *)ADC2_DMA_STREAM,
         .channel = DMA_REQUEST_ADC2,
 #endif
     },
-#if defined(ADC3)
+#if !(defined(STM32H7A3xx) || defined(STM32H7A3xxQ))
     // ADC3 is not available on all H7 MCUs, e.g. H7A3
     // On H743 and H750, ADC3 can be serviced by BDMA also, but we settle for DMA1 or 2 (for now).
     {
-        .ADCx = ADC3_INSTANCE,
+        .ADCx = ADC3,
         .rccADC = RCC_AHB4(ADC3),
 #if !defined(USE_DMA_SPEC)
         .dmaResource = (dmaResource_t *)ADC3_DMA_STREAM,
@@ -384,7 +373,7 @@ void adcInit(const adcConfig_t *config)
     for (int dev = 0; dev < ADCDEV_COUNT; dev++) {
         adcDevice_t *adc = &adcDevice[dev];
 
-        if (!(adc->ADCx && adc->channelBits)) {
+        if (!adc->channelBits) {
             continue;
         }
 
@@ -499,7 +488,7 @@ void adcInit(const adcConfig_t *config)
 
         adcDevice_t *adc = &adcDevice[dev];
 
-        if (!(adc->ADCx && adc->channelBits)) {
+        if (!adc->channelBits) {
             continue;
         }
 

--- a/src/main/target/IFLIGHT_H743_AIO/target.h
+++ b/src/main/target/IFLIGHT_H743_AIO/target.h
@@ -171,10 +171,6 @@
 #define USE_ADC
 #define USE_ADC_INTERNAL
 
-#define ADC1_INSTANCE               ADC1
-#define ADC2_INSTANCE               ADC2
-#define ADC3_INSTANCE               ADC3
-
 #define RSSI_ADC_PIN                PC5
 #define VBAT_ADC_PIN                PC3
 #define CURRENT_METER_ADC_PIN       PC2

--- a/src/main/target/IFLIGHT_H743_AIO_V2/target.h
+++ b/src/main/target/IFLIGHT_H743_AIO_V2/target.h
@@ -171,10 +171,6 @@
 #define USE_ADC
 #define USE_ADC_INTERNAL
 
-#define ADC1_INSTANCE               ADC1
-#define ADC2_INSTANCE               ADC2
-#define ADC3_INSTANCE               ADC3
-
 #define RSSI_ADC_PIN                PC5
 #define VBAT_ADC_PIN                PC3
 #define CURRENT_METER_ADC_PIN       PC2

--- a/src/main/target/MATEKH743/target.h
+++ b/src/main/target/MATEKH743/target.h
@@ -182,8 +182,6 @@
 
 #define USE_ADC
 #define USE_ADC_INTERNAL   // ADC3
-#define ADC1_INSTANCE ADC1
-#define ADC3_INSTANCE ADC3
 
 #define VBAT_ADC_PIN            PC0  //ADC123 VBAT1 
 #define CURRENT_METER_ADC_PIN   PC1  //ADC123 CURR1

--- a/src/main/target/NUCLEOH723ZG/target.h
+++ b/src/main/target/NUCLEOH723ZG/target.h
@@ -242,10 +242,6 @@
 
 #define USE_ADC
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2
-#define ADC3_INSTANCE ADC3
-
 // DMA stream assignmnets
 #define VBAT_ADC_PIN            PB1  // ADC1
 #define CURRENT_METER_ADC_PIN   PC0  // ADC1

--- a/src/main/target/NUCLEOH725ZG/target.h
+++ b/src/main/target/NUCLEOH725ZG/target.h
@@ -251,10 +251,6 @@
 
 #define USE_ADC
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2
-#define ADC3_INSTANCE ADC3
-
 // DMA stream assignmnets
 #define VBAT_ADC_PIN            PB1  // ADC1
 #define CURRENT_METER_ADC_PIN   PC0  // ADC1

--- a/src/main/target/NUCLEOH743/target.h
+++ b/src/main/target/NUCLEOH743/target.h
@@ -256,10 +256,6 @@
 
 #define USE_ADC
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2
-#define ADC3_INSTANCE ADC3
-
 // DMA stream assignmnets
 #define VBAT_ADC_PIN            PB1  // ADC1
 #define CURRENT_METER_ADC_PIN   PC0  // ADC1

--- a/src/main/target/NUCLEOH7A3ZI/target.h
+++ b/src/main/target/NUCLEOH7A3ZI/target.h
@@ -242,10 +242,6 @@
 
 #define USE_ADC
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2
-#define ADC3_INSTANCE ADC3
-
 // DMA stream assignmnets
 #define VBAT_ADC_PIN            PB1  // ADC1
 #define CURRENT_METER_ADC_PIN   PC0  // ADC1

--- a/src/main/target/SPRACINGH7EXTREME/target.h
+++ b/src/main/target/SPRACINGH7EXTREME/target.h
@@ -220,10 +220,6 @@
 #define USE_ADC
 #define USE_ADC_INTERNAL // ADC3
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2 // ADC2 not used
-#define ADC3_INSTANCE ADC3 // ADC3 only for core temp and vrefint
-
 #define RSSI_ADC_PIN            PC4  // ADC123
 #define VBAT_ADC_PIN            PC1  // ADC12
 #define CURRENT_METER_ADC_PIN   PC0  // ADC123

--- a/src/main/target/SPRACINGH7NANO/target.h
+++ b/src/main/target/SPRACINGH7NANO/target.h
@@ -213,10 +213,6 @@
 #define USE_ADC
 #define USE_ADC_INTERNAL // ADC3
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2 // ADC2 not used
-#define ADC3_INSTANCE ADC3 // ADC3 only for core temp and vrefint
-
 #define RSSI_ADC_PIN            PC4  // ADC123
 #define VBAT_ADC_PIN            PC1  // ADC12
 #define CURRENT_METER_ADC_PIN   PC0  // ADC123

--- a/src/main/target/SPRACINGH7ZERO/target.h
+++ b/src/main/target/SPRACINGH7ZERO/target.h
@@ -215,10 +215,6 @@
 #define USE_ADC
 #define USE_ADC_INTERNAL // ADC3
 
-#define ADC1_INSTANCE ADC1
-#define ADC2_INSTANCE ADC2 // ADC2 not used
-#define ADC3_INSTANCE ADC3 // ADC3 only for core temp and vrefint
-
 #define RSSI_ADC_PIN            PC0  // ADC123
 #define VBAT_ADC_PIN            PC4  // ADC123
 #define CURRENT_METER_ADC_PIN   PC1  // ADC12

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -53,7 +53,6 @@
 #define USE_RPM_FILTER
 #define USE_DYN_IDLE
 #define USE_DYN_NOTCH_FILTER
-#define USE_ADC
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC


### PR DESCRIPTION
Fixes the non-working ADC on the STM32H743 Unified Target and removes deprecated non-runtime-configurable configuration.