### PR TITLE
add feedforward max_rate_limit and jitter_factor to msp for 4.3

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1907,7 +1907,11 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, currentPidProfile->feedforward_averaging);
         sbufWriteU8(dst, currentPidProfile->feedforward_smooth_factor);
         sbufWriteU8(dst, currentPidProfile->feedforward_boost);
+        sbufWriteU8(dst, currentPidProfile->feedforward_max_rate_limit);
+        sbufWriteU8(dst, currentPidProfile->feedforward_jitter_factor);
 #else
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
@@ -2814,13 +2818,17 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU8(src);
 #endif
         }
-        if (sbufBytesRemaining(src) >= 5) {
+        if (sbufBytesRemaining(src) >= 7) {
             // Added in MSP API 1.44
 #if defined(USE_FEEDFORWARD)
             currentPidProfile->feedforward_averaging = sbufReadU8(src);
             currentPidProfile->feedforward_smooth_factor = sbufReadU8(src);
             currentPidProfile->feedforward_boost = sbufReadU8(src);
+            currentPidProfile->feedforward_max_rate_limit = sbufReadU8(src);
+            currentPidProfile->feedforward_jitter_factor = sbufReadU8(src);
 #else
+            sbufReadU8(src);
+            sbufReadU8(src);
             sbufReadU8(src);
             sbufReadU8(src);
             sbufReadU8(src);


### PR DESCRIPTION
Although `feedforward_max_rate_limit` and `feedforward_ jitter_factor` are new variables for 4.3, it would be great if they could be included in the MSP so we can set and review them in Configurator 1.44.

In particular, the `feedforward_ jitter_factor` parameter can, and should, be user editable without need to go to the CLI.  Higher values give a strong 'transition-like' effect for freestyle at lower or Rx link rates, and with fast links, a value around 5 works better than defaults.

`feedforward_max_rate_limit` affects the onset time of the pull-back in feedforward when the sticks are rapidly heading towards max, eg at the start of a flip or roll.  A value of 90 is default.  On heavier setups with a stronger tendency to overshoot, a lower value, eg 85, may work better, and on a highly tuned racer, 95 may be better.