### PR TITLE
Force F7 reset after flashing

### DIFF
--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -76,7 +76,7 @@ static void checkForBootLoaderRequest(void)
     if (bootloaderRequest != RESET_BOOTLOADER_REQUEST_ROM) {
         return;
     }
-    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_BOOTLOADER_POST);
 
     __SYSCFG_CLK_ENABLE();
     SYSCFG->MEMRMP |= SYSCFG_MEM_BOOT_ADD0 ;

--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -313,6 +313,13 @@ void OverclockRebootIfNecessary(uint32_t overclockLevel)
   */
 void SystemInit(void)
 {
+    uint32_t bootloaderRequest = persistentObjectRead(PERSISTENT_OBJECT_RESET_REASON);
+
+    if (bootloaderRequest == RESET_BOOTLOADER_POST) {
+        persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
+        NVIC_SystemReset();
+    }
+
     initialiseMemorySections();
 
     SystemInitOC();


### PR DESCRIPTION
After reflashing STM32F7 FCs sometimes hang. A symptom is an apparently uninitialised data segment. This PR ensures everything is reset to a known state by detecting the first boot after a bootloader operation and then forcing a reboot.