### PR TITLE
Support for GCC 11.2.1

### DIFF
--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -148,10 +148,10 @@ VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
 
 ifeq ($(TARGET),$(filter $(TARGET),$(F411_TARGETS)))
-DEVICE_FLAGS    = -DSTM32F411xE
+DEVICE_FLAGS    = -DSTM32F411xE -finline-limit=20
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_f411.ld
 STARTUP_SRC     = startup_stm32f411xe.s
 else ifeq ($(TARGET),$(filter $(TARGET),$(F405_TARGETS)))

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -123,7 +123,7 @@ VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant
 
 # Flags that are used in the STM32 libraries
 DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER

--- a/make/mcu/STM32G4.mk
+++ b/make/mcu/STM32G4.mk
@@ -126,7 +126,7 @@ VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
 
 DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER -DUSE_DMA_RAM -DMAX_MPU_REGIONS=16
 

--- a/make/mcu/STM32H7.mk
+++ b/make/mcu/STM32H7.mk
@@ -147,7 +147,7 @@ VPATH           := $(VPATH):$(FATFS_DIR)
 endif
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant -Wdouble-promotion
+ARCH_FLAGS      = -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 -fsingle-precision-constant
 
 # Flags that are used in the STM32 libraries
 DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5244,7 +5244,7 @@ static void printResource(dumpFlags_t dumpMask, const char *headingStr)
 
         for (int index = 0; index < RESOURCE_VALUE_MAX_INDEX(resourceTable[i].maxIndex); index++) {
             const ioTag_t ioTag = *(ioTag_t *)((const uint8_t *)currentConfig + resourceTable[i].stride * index + resourceTable[i].offset);
-            ioTag_t ioTagDefault = NULL;
+            ioTag_t ioTagDefault = 0;
             if (defaultConfig) {
                 ioTagDefault = *(ioTag_t *)((const uint8_t *)defaultConfig + resourceTable[i].stride * index + resourceTable[i].offset);
             }

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -114,7 +114,7 @@ void * memcpy_fn ( void * destination, const void * source, size_t num ) asm("me
 #endif
 
 #if __GNUC__ > 6
-#define FALLTHROUGH __attribute__ ((fallthrough))
+#define FALLTHROUGH ;__attribute__ ((fallthrough))
 #else
 #define FALLTHROUGH do {} while(0)
 #endif

--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -687,7 +687,7 @@ static void bbPostInit()
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
 
         if (!bbMotorConfig(bbMotors[motorIndex].io, motorIndex, motorPwmProtocol, bbMotors[motorIndex].output)) {
-            return NULL;
+            return;
         }
 
 

--- a/src/main/drivers/sdio_f4xx.c
+++ b/src/main/drivers/sdio_f4xx.c
@@ -1231,7 +1231,7 @@ SD_Error_t SD_GetStatus(void)
     }
     else
     {
-        ErrorState = SD_CARD_ERROR;
+        ErrorState = SD_ERROR;
     }
 
     return ErrorState;

--- a/src/main/drivers/sdio_f7xx.c
+++ b/src/main/drivers/sdio_f7xx.c
@@ -1216,7 +1216,7 @@ SD_Error_t SD_GetStatus(void)
     }
     else
     {
-        ErrorState = SD_CARD_ERROR;
+        ErrorState = SD_ERROR;
     }
 
     return ErrorState;

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -81,7 +81,7 @@ static void uartConfigurePinSwap(uartPort_t *uartPort)
 {
     uartDevice_t *uartDevice = uartFindDevice(uartPort);
     if (!uartDevice) {
-        return NULL;
+        return;
     }
 
     if (uartDevice->pinSwap) {

--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -2141,7 +2141,7 @@ afatfsOperationStatus_e afatfs_fseek(afatfsFilePtr_t file, int32_t offset, afatf
         break;
 
         case AFATFS_SEEK_SET:
-            FALLTHROUGH;
+        break;
     }
 
     // Now we have a SEEK_SET with a positive offset. Begin by seeking to the start of the file

--- a/src/main/io/displayport_crsf.c
+++ b/src/main/io/displayport_crsf.c
@@ -85,7 +85,7 @@ static int crsfWriteString(displayPort_t *displayPort, uint8_t col, uint8_t row,
     if (row >= crsfScreen.rows || col >= crsfScreen.cols) {
         return 0;
     }
-    const size_t truncLen = MIN((int)strlen(s), crsfScreen.cols-col);  // truncate at colCount
+    const size_t truncLen = MIN(strlen(s), (size_t)(crsfScreen.cols - col));  // truncate at colCount
     char *rowStart = &crsfScreen.buffer[row * crsfScreen.cols + col];
     crsfScreen.updated |= memcmp(rowStart, s, truncLen);
     if (crsfScreen.updated) {

--- a/src/main/msc/usbd_storage_sd_spi.c
+++ b/src/main/msc/usbd_storage_sd_spi.c
@@ -216,7 +216,7 @@ static int8_t STORAGE_Read (uint8_t lun,
 {
 	UNUSED(lun);
 	for (int i = 0; i < blk_len; i++) {
-	    while (sdcard_readBlock(blk_addr + i, buf + (512 * i), NULL, NULL) == 0);
+		while (sdcard_readBlock(blk_addr + i, buf + (512 * i), NULL, 0) == 0);
 		while (sdcard_poll() == 0);
 	}
     mscSetActive();
@@ -236,7 +236,7 @@ static int8_t STORAGE_Write (uint8_t lun,
 {
 	UNUSED(lun);
 	for (int i = 0; i < blk_len; i++) {
-		while (sdcard_writeBlock(blk_addr + i, buf + (i * 512), NULL, NULL) != SDCARD_OPERATION_IN_PROGRESS) {
+		while (sdcard_writeBlock(blk_addr + i, buf + (i * 512), NULL, 0) != SDCARD_OPERATION_IN_PROGRESS) {
 			sdcard_poll();
 		}
 		while (sdcard_poll() == 0);

--- a/src/main/startup/system_stm32f4xx.c
+++ b/src/main/startup/system_stm32f4xx.c
@@ -812,8 +812,6 @@ void SetSysClock(void)
 
     /* Wait till the main PLL is used as system clock source */
     while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
-    {
-    }
 
 #if defined(STM32F446xx)
 // Always use PLLSAI to derive USB 48MHz clock.

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -57,7 +57,7 @@
 
 #ifdef STM32F7
 #define USE_ITCM_RAM
-#define ITCM_RAM_OPTIMISATION "-O2"
+#define ITCM_RAM_OPTIMISATION "-O2", "-freorder-blocks-algorithm=simple"
 #define USE_FAST_DATA
 #define USE_DSHOT
 #define USE_DSHOT_BITBANG

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -499,7 +499,8 @@ COMMON_FLAGS = \
 	-isystem $(GTEST_DIR)/inc \
 	-MMD -MP \
 	-Wno-c99-extensions \
-	-Wno-reorder
+	-Wno-reorder \
+	-pipe
 
 CC_VERSION = $(shell $(CC) -dumpversion)
 CXX_VERSION = $(shell $(CXX) -dumpversion)


### PR DESCRIPTION
**Merge**
- Before https://github.com/betaflight/betaflight/pull/11680

Removes warnings during GCC11 compilation. Solve overflowing.

Fixes: #10415

Tested on MacOS Monterey 12.0.1
`gcc version 11.2.1 20220111 (GNU Toolchain for the Arm Architecture 11.2-2022.02 (arm-11.14))`

Changes made:

1.  `-finline-functions` is enabled by default (https://gcc.gnu.org/gcc-10/changes.html) in GCC 10+ with `-O2` so I have added for F411 (others fit without any issues)
```
DEVICE_FLAGS    = -DSTM32F411xE -finline-limit=20
```
And we can use it to balance between speed and size.

2. `-std=gnu17` Just update. I don't  expect any visible changes. C17 is just bugfix of C11 without new features.
3. `-Werror` fail compilation on any warning
4. `-pipe` instead of `-save-temps=obj` less IO during compilation, can reduce compilation time a little bit and can save SSD drive a bit
5. `-Wdouble-promotion` removed from `make/mcu/STM32xxx.mk` files. It is already included in root `Makefile`
6. `/src/` changes. Just to suppress warning. Please review this carefully.
7. `#define ITCM_RAM_OPTIMISATION "-O2", "-freorder-blocks-algorithm=simple"` Disable one of `-02` optimization which adds a lot of bytes to code size.

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

~~Will help with: #10415~~

Cons:
GCC 11.2.1 causes freezing of F405 and F411 with different inlining levels (`-finline-limit=X`).

~~Still  #overflowing:~~
~~ITCM_RAM on F7XX~~
~~FLASH1 on F411~~