### PR TITLE
Fix peaky task duration estimation

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1477,7 +1477,6 @@ const clivalue_t valueTable[] = {
     { "cpu_overclock",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OVERCLOCK }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, cpu_overclock) },
 #endif
     { "pwr_on_arm_grace",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, powerOnArmingGraceTime) },
-    { "scheduler_optimize_rate",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, schedulerOptimizeRate) },
     { "enable_stick_arming",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, enableStickArming) },
 
 // PG_VTX_CONFIG

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -109,7 +109,7 @@ PG_RESET_TEMPLATE(pilotConfig_t, pilotConfig,
     .displayName = { 0 },
 );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 3);
 
 PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .pidProfileIndex = 0,
@@ -122,7 +122,6 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .boardIdentifier = TARGET_BOARD_IDENTIFIER,
     .hseMhz = SYSTEM_HSE_VALUE,  // Only used for F4 and G4 targets
     .configurationState = CONFIGURATION_STATE_DEFAULTS_BARE,
-    .schedulerOptimizeRate = SCHEDULER_OPTIMIZE_RATE_AUTO,
     .enableStickArming = false,
 );
 
@@ -157,7 +156,6 @@ void resetConfig(void)
 
 static void activateConfig(void)
 {
-    schedulerOptimizeRate(systemConfig()->schedulerOptimizeRate == SCHEDULER_OPTIMIZE_RATE_ON || (systemConfig()->schedulerOptimizeRate == SCHEDULER_OPTIMIZE_RATE_AUTO && motorConfig()->dev.useDshotTelemetry));
     loadPidProfile();
     loadControlRateProfile();
 
@@ -513,7 +511,7 @@ static void validateAndFixConfig(void)
         }
     }
 
-    if ((!configuredMotorProtocolDshot || (motorConfig()->dev.useDshotBitbang == DSHOT_BITBANG_OFF && (motorConfig()->dev.useBurstDshot == DSHOT_DMAR_ON || nChannelTimerUsed)) || systemConfig()->schedulerOptimizeRate == SCHEDULER_OPTIMIZE_RATE_OFF) && motorConfig()->dev.useDshotTelemetry) {
+    if ((!configuredMotorProtocolDshot || (motorConfig()->dev.useDshotBitbang == DSHOT_BITBANG_OFF && (motorConfig()->dev.useBurstDshot == DSHOT_DMAR_ON || nChannelTimerUsed))) && motorConfig()->dev.useDshotTelemetry) {
         motorConfigMutable()->dev.useDshotTelemetry = false;
     }
 #endif // USE_DSHOT_TELEMETRY

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -33,12 +33,6 @@ typedef enum {
     CONFIGURATION_STATE_CONFIGURED,
 } configurationState_e;
 
-typedef enum {
-    SCHEDULER_OPTIMIZE_RATE_OFF = 0,
-    SCHEDULER_OPTIMIZE_RATE_ON,
-    SCHEDULER_OPTIMIZE_RATE_AUTO,
-} schedulerOptimizeRate_e;
-
 typedef struct pilotConfig_s {
     char name[MAX_NAME_LENGTH + 1];
     char displayName[MAX_NAME_LENGTH + 1];
@@ -57,7 +51,6 @@ typedef struct systemConfig_s {
     char boardIdentifier[sizeof(TARGET_BOARD_IDENTIFIER) + 1];
     uint8_t hseMhz;                 // Only used for F4 and G4 targets
     uint8_t configurationState;     // The state of the configuration (defaults / configured)
-    uint8_t schedulerOptimizeRate;
     uint8_t enableStickArming; // boolean that determines whether stick arming can be used
 } systemConfig_t;
 

--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -181,7 +181,7 @@ void ws2811UpdateStrip(ledStripFormatRGB_e ledFormat)
 {
     // don't wait - risk of infinite block, just get an update next time round
     if (!ws2811Initialised || ws2811LedDataTransferInProgress) {
-        ignoreTaskStateTime();
+        schedulerIgnoreTaskStateTime();
         return;
     }
 

--- a/src/main/fc/dispatch.c
+++ b/src/main/fc/dispatch.c
@@ -30,6 +30,8 @@
 
 #include "fc/dispatch.h"
 
+#include "scheduler/scheduler.h"
+
 static dispatchEntry_t *head = NULL;
 static bool dispatchEnabled = false;
 
@@ -43,10 +45,10 @@ void dispatchEnable(void)
     dispatchEnabled = true;
 }
 
-void dispatchProcess(uint32_t currentTime)
+void dispatchProcess(uint32_t currentTimeUs)
 {
     for (dispatchEntry_t **p = &head; *p; ) {
-        if (cmp32(currentTime, (*p)->delayedUntil) < 0)
+        if (cmp32(currentTimeUs, (*p)->delayedUntil) < 0)
             break;
         // unlink entry first, so handler can replan self
         dispatchEntry_t *current = *p;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -593,7 +593,7 @@ void imuUpdateAttitude(timeUs_t currentTimeUs)
         acc.accADC[X] = 0;
         acc.accADC[Y] = 0;
         acc.accADC[Z] = 0;
-        ignoreTaskStateTime();
+        schedulerIgnoreTaskStateTime();
     }
 }
 #endif // USE_ACC

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -96,7 +96,7 @@ void calculateEstimatedAltitude(timeUs_t currentTimeUs)
 
     const uint32_t dTime = currentTimeUs - previousTimeUs;
     if (dTime < BARO_UPDATE_FREQUENCY_40HZ) {
-        ignoreTaskExecTime();
+        schedulerIgnoreTaskExecTime();
         return;
     }
     previousTimeUs = currentTimeUs;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -49,6 +49,8 @@
 
 #include "pg/beeper.h"
 
+#include "scheduler/scheduler.h"
+
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
 
@@ -390,6 +392,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
     }
 
     if (beeperNextToggleTime > currentTimeUs) {
+        schedulerIgnoreTaskExecTime();
         return;
     }
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1066,8 +1066,8 @@ static void applyStatusProfile(timeUs_t now) {
     }
 
     if (!timActive) {
-        // Call ignoreTaskExecTime() unless data is being processed
-        ignoreTaskExecTime();
+        // Call schedulerIgnoreTaskExecTime() unless data is being processed
+        schedulerIgnoreTaskExecTime();
         return;          // no change this update, keep old state
     }
 
@@ -1248,13 +1248,11 @@ static void applySimpleProfile(timeUs_t currentTimeUs)
 
 void ledStripUpdate(timeUs_t currentTimeUs)
 {
-#ifndef USE_LED_STRIP_STATUS_MODE
     UNUSED(currentTimeUs);
-#endif
 
     if (!isWS2811LedStripReady()) {
-        // Call ignoreTaskExecTime() unless data is being processed
-        ignoreTaskExecTime();
+        // Call schedulerIgnoreTaskExecTime() unless data is being processed
+        schedulerIgnoreTaskExecTime();
         return;
     }
 
@@ -1282,8 +1280,8 @@ void ledStripUpdate(timeUs_t currentTimeUs)
                 break;
         }
     } else {
-        // Call ignoreTaskExecTime() unless data is being processed
-        ignoreTaskExecTime();
+        // Call schedulerIgnoreTaskExecTime() unless data is being processed
+        schedulerIgnoreTaskExecTime();
     }
 }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2889,7 +2889,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 
         // This is going to take some time and won't be done where real-time performance is needed so
         // ignore how long it takes to avoid confusing the scheduler
-        ignoreTaskStateTime();
+        schedulerIgnoreTaskStateTime();
 
         writeEEPROM();
         readEEPROM();

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -195,6 +195,10 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
 // Allow a margin by which a group render can exceed that of the sum of the elements before declaring insane
 // This will most likely be violated by a USB interrupt whilst using the CLI
 #define OSD_ELEMENT_RENDER_GROUP_MARGIN 5
+// Safe margin when rendering elements
+#define OSD_ELEMENT_RENDER_MARGIN 5
+// Safe margin in other states
+#define OSD_MARGIN 2
 
 // Format a float to the specified number of decimal places with optional rounding.
 // OSD symbols can optionally be placed before and after the formatted number (use SYM_NONE for no symbol).
@@ -1073,7 +1077,7 @@ void osdUpdate(timeUs_t currentTimeUs)
     osdState_e osdCurState = osdState;
 
     if (osdState != OSD_STATE_UPDATE_CANVAS) {
-        ignoreTaskExecRate();
+        schedulerIgnoreTaskExecRate();
     }
 
     switch (osdState) {
@@ -1083,7 +1087,7 @@ void osdUpdate(timeUs_t currentTimeUs)
             if (osdDisplayPortDeviceType == OSD_DISPLAYPORT_DEVICE_FRSKYOSD) {
                 displayRedraw(osdDisplayPort);
             } else {
-                ignoreTaskExecTime();
+                schedulerIgnoreTaskExecTime();
             }
             return;
         }
@@ -1309,14 +1313,14 @@ void osdUpdate(timeUs_t currentTimeUs)
     }
 
     if (osdState == OSD_STATE_UPDATE_ELEMENTS) {
-        schedulerSetNextStateTime(osdElementGroupDurationUs[osdElementGroup]);
+        schedulerSetNextStateTime(osdElementGroupDurationUs[osdElementGroup] + OSD_ELEMENT_RENDER_MARGIN);
     } else {
         if (osdState == OSD_STATE_IDLE) {
-            schedulerSetNextStateTime(osdStateDurationUs[OSD_STATE_CHECK]);
+            schedulerSetNextStateTime(osdStateDurationUs[OSD_STATE_CHECK] + OSD_MARGIN);
         } else {
-            schedulerSetNextStateTime(osdStateDurationUs[osdState]);
+            schedulerSetNextStateTime(osdStateDurationUs[osdState] + OSD_MARGIN);
         }
-        ignoreTaskExecTime();
+        schedulerIgnoreTaskExecTime();
     }
 }
 

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -31,12 +31,12 @@
 
 #define LOAD_PERCENTAGE_ONE 100
 
-#define SCHED_START_LOOP_MIN_US         4   // Wait at start of scheduler loop if gyroTask is nearly due
+#define SCHED_START_LOOP_MIN_US         1   // Wait at start of scheduler loop if gyroTask is nearly due
 #define SCHED_START_LOOP_MAX_US         12
 #define SCHED_START_LOOP_DOWN_STEP      50  // Fraction of a us to reduce start loop wait
 #define SCHED_START_LOOP_UP_STEP        1   // Fraction of a us to increase start loop wait
 
-#define TASK_GUARD_MARGIN_MIN_US        4   // Add an amount to the estimate of a task duration
+#define TASK_GUARD_MARGIN_MIN_US        1   // Add an amount to the estimate of a task duration
 #define TASK_GUARD_MARGIN_MAX_US        6
 #define TASK_GUARD_MARGIN_DOWN_STEP     50  // Fraction of a us to reduce task guard margin
 #define TASK_GUARD_MARGIN_UP_STEP       1   // Fraction of a us to increase task guard margin

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -388,14 +388,14 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
 
     DEBUG_SET(DEBUG_BARO, 0, state);
 
-    // Where we are using a state machine call ignoreTaskExecRate() for all states bar one
+    // Where we are using a state machine call schedulerIgnoreTaskExecRate() for all states bar one
     if (state != BARO_STATE_TEMPERATURE_START) {
-        ignoreTaskExecRate();
+        schedulerIgnoreTaskExecRate();
     }
 
     if (busBusy(&baro.dev.dev, NULL)) {
         // If the bus is busy, simply return to have another go later
-        ignoreTaskStateTime();
+        schedulerIgnoreTaskStateTime();
         return sleepTime;
     }
 
@@ -429,7 +429,7 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             if (baro.dev.read_up(&baro.dev)) {
                 state = BARO_STATE_PRESSURE_SAMPLE;
             } else {
-                ignoreTaskStateTime();
+                schedulerIgnoreTaskStateTime();
             }
             break;
 

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -45,6 +45,8 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
+#include "scheduler/scheduler.h"
+
 #include "sensors/battery.h"
 
 /**
@@ -409,12 +411,10 @@ void batteryInit(void)
         default:
             break;
     }
-
 }
 
 void batteryUpdateCurrentMeter(timeUs_t currentTimeUs)
 {
-    UNUSED(currentTimeUs);
     if (batteryCellCount == 0) {
         currentMeterReset(&currentMeter);
         return;

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1108,4 +1108,5 @@ extern "C" {
     uint16_t getAverageSystemLoadPercent(void) { return 0; }
     bool isMotorProtocolEnabled(void) { return true; }
     void pinioBoxTaskControl(void) {}
+    void schedulerSetNextStateTime(timeDelta_t) {}
 }

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -250,6 +250,8 @@ void mixerSetThrottleAngleCorrection(int) {};
 bool gpsRescueIsRunning(void) { return false; }
 bool isFixedWing(void) { return false; }
 void pinioBoxTaskControl(void) {}
-void ignoreTaskExecTime(void) {}
-void ignoreTaskStateTime(void) {}
+void schedulerIgnoreTaskExecTime(void) {}
+void schedulerIgnoreTaskStateTime(void) {}
+void schedulerSetNextStateTime(timeDelta_t) {}
+bool schedulerGetIgnoreTaskExecTime() { return false; }
 }

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -397,5 +397,7 @@ void ws2811LedStripEnable(void) { }
 
 void setUsedLedCount(unsigned) { }
 void pinioBoxTaskControl(void) {}
-void ignoreTaskExecTime(void) {}
+void schedulerIgnoreTaskExecTime(void) {}
+bool schedulerGetIgnoreTaskExecTime() { return false; }
+void schedulerSetNextStateTime(timeDelta_t) {}
 }

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -510,9 +510,9 @@ extern "C" {
     void failsafeOnValidDataFailed(void) { }
     void pinioBoxTaskControl(void) { }
     bool taskUpdateRxMainInProgress() { return true; }
-    void ignoreTaskStateTime(void) { }
-    void ignoreTaskExecRate(void) { }
-    void ignoreTaskExecTime(void) { }
+    void schedulerIgnoreTaskStateTime(void) { }
+    void schedulerIgnoreTaskExecRate(void) { }
+    void schedulerIgnoreTaskExecTime(void) { }
     void schedulerSetNextStateTime(timeDelta_t) {}
 
     void rxPwmInit(rxRuntimeState_t *rxRuntimeState, rcReadRawDataFnPtr *callback)

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1376,8 +1376,8 @@ extern "C" {
     bool isUpright(void) { return true; }
     float getMotorOutputLow(void) { return 1000.0; }
     float getMotorOutputHigh(void) { return 2047.0; }
-    void ignoreTaskStateTime(void) { }
-    void ignoreTaskExecRate(void) { }
-    void ignoreTaskExecTime(void) { }
+    void schedulerIgnoreTaskStateTime(void) { }
+    void schedulerIgnoreTaskExecRate(void) { }
+    void schedulerIgnoreTaskExecTime(void) { }
     void schedulerSetNextStateTime(timeDelta_t) {}
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -197,5 +197,5 @@ extern "C" {
     void sbufWriteU8(sbuf_t *, uint8_t) {}
     void sbufWriteU16(sbuf_t *, uint16_t) {}
     void sbufWriteU32(sbuf_t *, uint32_t) {}
-
+    void schedulerSetNextStateTime(timeDelta_t) {}
 }

--- a/src/test/unit/ws2811_unittest.cc
+++ b/src/test/unit/ws2811_unittest.cc
@@ -32,8 +32,8 @@ extern "C" {
 
 extern "C" {
     void updateLEDDMABuffer(ledStripFormatRGB_e ledFormat, rgbColor24bpp_t *color, unsigned ledIndex);
-    void ignoreTaskExecTime(void) {}
-    void ignoreTaskStateTime(void) {}
+    void schedulerIgnoreTaskExecTime(void) {}
+    void schedulerIgnoreTaskStateTime(void) {}
 }
 
 TEST(WS2812, updateDMABuffer) {


### PR DESCRIPTION
Address the peaky duration of ledStripUpdate() to prevent lateness in execution.

Merge after https://github.com/betaflight/betaflight/pull/10813