### PR TITLE
include gyro and dterm static lpf1 in simplified tuning

### DIFF
--- a/src/main/config/simplified_tuning.c
+++ b/src/main/config/simplified_tuning.c
@@ -67,6 +67,7 @@ static void calculateNewDTermFilterValues(pidProfile_t *pidProfile)
 {
     pidProfile->dterm_lpf1_dyn_min_hz = constrain(DTERM_LPF1_DYN_MIN_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
     pidProfile->dterm_lpf1_dyn_max_hz = constrain(DTERM_LPF1_DYN_MAX_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+    pidProfile->dterm_lpf1_static_hz = constrain(DTERM_LPF1_DYN_MIN_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
     pidProfile->dterm_lpf2_static_hz = constrain(DTERM_LPF2_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, LPF_MAX_HZ);
     pidProfile->dterm_lpf1_type = FILTER_PT1;
     pidProfile->dterm_lpf2_type = FILTER_PT1;
@@ -76,6 +77,7 @@ static void calculateNewGyroFilterValues()
 {
     gyroConfigMutable()->gyro_lpf1_dyn_min_hz = constrain(GYRO_LPF1_DYN_MIN_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
     gyroConfigMutable()->gyro_lpf1_dyn_max_hz = constrain(GYRO_LPF1_DYN_MAX_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+    gyroConfigMutable()->gyro_lpf1_static_hz = constrain(GYRO_LPF1_DYN_MIN_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
     gyroConfigMutable()->gyro_lpf2_static_hz = constrain(GYRO_LPF2_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, LPF_MAX_HZ);
     gyroConfigMutable()->gyro_lpf1_type = FILTER_PT1;
     gyroConfigMutable()->gyro_lpf2_type = FILTER_PT1;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -173,10 +173,11 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .abs_control_error_limit = 20,
         .abs_control_cutoff = 11,
         .antiGravityMode = ANTI_GRAVITY_SMOOTH,
-        .dterm_lpf1_static_hz = 150,    // NOTE: dynamic lpf is enabled by default so this setting is actually
-                                    // overridden and the static lowpass 1 is disabled. We can't set this
-                                    // value to 0 otherwise Configurator versions 10.4 and earlier will also
-                                    // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
+        .dterm_lpf1_static_hz = DTERM_LPF1_DYN_MIN_HZ_DEFAULT,
+            // NOTE: dynamic lpf is enabled by default so this setting is actually
+            // overridden and the static lowpass 1 is disabled. We can't set this
+            // value to 0 otherwise Configurator versions 10.4 and earlier will also
+            // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
         .dterm_lpf2_static_hz = DTERM_LPF2_HZ_DEFAULT,   // second Dterm LPF ON by default
         .dterm_lpf1_type = FILTER_PT1,
         .dterm_lpf2_type = FILTER_PT1,
@@ -222,10 +223,12 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .simplified_dterm_filter = true,
         .simplified_dterm_filter_multiplier = SIMPLIFIED_TUNING_DEFAULT,
     );
+
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;
     pidProfile->pid[PID_PITCH].D = 32;
 #endif
+
 #ifdef USE_SIMPLIFIED_TUNING
         applySimplifiedTuning(pidProfile);
 #endif

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -110,10 +110,11 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyroMovementCalibrationThreshold = 48;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
     gyroConfig->gyro_lpf1_type = FILTER_PT1;
-    gyroConfig->gyro_lpf1_static_hz = 250;  // NOTE: dynamic lpf is enabled by default so this setting is actually
-                                        // overridden and the static lowpass 1 is disabled. We can't set this
-                                        // value to 0 otherwise Configurator versions 10.4 and earlier will also
-                                        // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
+    gyroConfig->gyro_lpf1_static_hz = GYRO_LPF1_DYN_MIN_HZ_DEFAULT;  
+        // NOTE: dynamic lpf is enabled by default so this setting is actually
+        // overridden and the static lowpass 1 is disabled. We can't set this
+        // value to 0 otherwise Configurator versions 10.4 and earlier will also
+        // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
     gyroConfig->gyro_lpf2_type = FILTER_PT1;
     gyroConfig->gyro_lpf2_static_hz = GYRO_LPF2_HZ_DEFAULT;
     gyroConfig->gyro_high_fsr = false;


### PR DESCRIPTION
Works with Configurator [filter sliders PR 2638](https://github.com/betaflight/betaflight-configurator/pull/2638)

Corrects an issue where, when adjusting filters with sliders, the value of the static lowpass 1 was not updated.

Also sets static lowpass 1 default values to the same value as dynamic lowpass min, so that if the user switches out of dynamic mode, they will get a safe static value that matches their dynamic minimum.  This is better than getting a static value which ignores the user's filter slider completely.

The behaviour is consistent for both D and Gyro static low passes.