### PR TITLE
Dynamic idle - values retained, can be activated without RPM filtering, ignores DShot Idle percentage

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -522,14 +522,6 @@ static void validateAndFixConfig(void)
     if ((!configuredMotorProtocolDshot || (motorConfig()->dev.useDshotBitbang == DSHOT_BITBANG_OFF && (motorConfig()->dev.useBurstDshot == DSHOT_DMAR_ON || nChannelTimerUsed)) || systemConfig()->schedulerOptimizeRate == SCHEDULER_OPTIMIZE_RATE_OFF) && motorConfig()->dev.useDshotTelemetry) {
         motorConfigMutable()->dev.useDshotTelemetry = false;
     }
-
-#if defined(USE_DYN_IDLE)
-    if (!isRpmFilterEnabled()) {
-        for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {
-            pidProfilesMutable(i)->dyn_idle_min_rpm = 0;
-        }
-    }
-#endif // USE_DYN_IDLE
 #endif // USE_DSHOT_TELEMETRY
 #endif // USE_DSHOT
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -105,7 +105,6 @@ static FAST_DATA_ZERO_INIT float motorRangeMax;
 static FAST_DATA_ZERO_INIT float motorOutputRange;
 static FAST_DATA_ZERO_INIT int8_t motorOutputMixSign;
 
-
 static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
 {
     static uint16_t rcThrottlePrevious = 0;   // Store the last throttle direction for deadband transitions
@@ -220,7 +219,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
 
 #ifdef USE_DYN_IDLE
         if (mixerRuntime.dynIdleMinRps > 0.0f) {
-            const float maxIncrease = isAirmodeActivated() ? mixerRuntime.dynIdleMaxIncrease : 0.04f;
+            const float maxIncrease = isAirmodeActivated() ? mixerRuntime.dynIdleMaxIncrease : 0.05f;
             float minRps = rpmMinMotorFrequency();
             DEBUG_SET(DEBUG_DYN_IDLE, 3, (minRps * 10));
             float rpsError = mixerRuntime.dynIdleMinRps - minRps;
@@ -233,11 +232,10 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             mixerRuntime.dynIdleI += rpsError * mixerRuntime.dynIdleIGain;
             mixerRuntime.dynIdleI = constrainf(mixerRuntime.dynIdleI, 0.0f, maxIncrease);
             motorRangeMinIncrease = constrainf((dynIdleP + mixerRuntime.dynIdleI + dynIdleD), 0.0f, maxIncrease);
-
             DEBUG_SET(DEBUG_DYN_IDLE, 0, (MAX(-1000.0f, dynIdleP * 10000)));
             DEBUG_SET(DEBUG_DYN_IDLE, 1, (mixerRuntime.dynIdleI * 10000));
             DEBUG_SET(DEBUG_DYN_IDLE, 2, (dynIdleD * 10000));
-       } else {
+        } else {
             motorRangeMinIncrease = 0;
         }
 #endif
@@ -537,9 +535,9 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
     mixerThrottle = throttle;
 
 #ifdef USE_DYN_IDLE
-    // Apply digital idle throttle offset when stick is at zero after all other adjustments are complete
+    // Set min throttle offset of 1% when stick is at zero and dynamic idle is active
     if (mixerRuntime.dynIdleMinRps > 0.0f) {
-        throttle = MAX(throttle, mixerRuntime.idleThrottleOffset);
+        throttle = MAX(throttle, 0.01f);
     }
 #endif
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -166,16 +166,17 @@ float rpmFilterGyro(const int axis, float value)
 
 FAST_CODE_NOINLINE void rpmFilterUpdate(void)
 {
-    if (gyroFilter == NULL) {
-        return;
-    }
-
     for (int motor = 0; motor < getMotorCount(); motor++) {
         filteredMotorErpm[motor] = pt1FilterApply(&rpmFilters[motor], getDshotTelemetry(motor));
         if (motor < 4) {
             DEBUG_SET(DEBUG_RPM_FILTER, motor, motorFrequency[motor]);
         }
         motorFrequency[motor] = erpmToHz * filteredMotorErpm[motor];
+    }
+
+    if (gyroFilter == NULL) {
+        minMotorFrequency = 0.0f;
+        return;
     }
 
     for (int i = 0; i < filterUpdatesPerIteration; i++) {
@@ -230,7 +231,7 @@ bool isRpmFilterEnabled(void)
 float rpmMinMotorFrequency(void)
 {
     if (minMotorFrequency == 0.0f) {
-        minMotorFrequency = 10000.0f;
+        minMotorFrequency = 10000.0f; // max RPM reported in Hz = 600,000RPM
         for (int i = getMotorCount(); i--;) {
             if (motorFrequency[i] < minMotorFrequency) {
                 minMotorFrequency = motorFrequency[i];
@@ -239,6 +240,5 @@ float rpmMinMotorFrequency(void)
     }
     return minMotorFrequency;
 }
-
 
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2846,6 +2846,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         }
         pidInitConfig(currentPidProfile);
+        mixerInitProfile();
 
         break;
     case MSP_SET_SENSOR_CONFIG:


### PR DESCRIPTION
This PR makes three main changes:

1. Stops the Dynamic Idle min_rpm value from being 'permanently' force-saved to zero if the user turns RPM telemetry off or sets their RPM harmonic count to 0.  
2. Allows the use of Dynamic Idle when RPM Telemetry is active, even if RPM filtering is not enabled.  It now only depends on DShot Telemetry (dshot_bidir) being active.  Previously, setting an RPM harmonic count of zero would force save the dyn_idle_min_rpm value to zero.
3. Ignores the DShot Idle (Digital Idle) percentage while Dynamic Idle is active.  This value now is set to 1% temporarily and cannot be user modified.
4. Allows the user to enable/disable Dynamic Idle, without needing to power cycle the FC, so long as RPM Telemetry is continuously active.  
5. Allows testing Dynamic Idle off by cycling profiles without power cycling.  Previously although the Dynamic Idle value was in a Profile, DShot Idle percent was not, and since it was necessary to manually change DShot Idle to get the most of out of Dynamic Idle, we were not practically able to properly and easily compare the two by switching profiles.  This is fixed.

With this PR, the user does not need to change their DShot Idle value to get optimal Dynamic Idle performance.  

They can, and should, leave their DShot Idle value at whatever works best without Dynamic Idle.  Previously, to get the best Dynamic Idle results during inverted drops, the user needed to manually set the DShot Idle % to a very low value, eg 1%.  Many users were nervous about doing this, and consequently did not get the most out of it.  If they did set it to 1%, and wanted to switch Dynamic Idle off and quickly compare to the old way, they needed to to also re-enter their old value for DShot Idle (eg 5.5%) or they would get stuck with 1% and get desyncs.  This could not be done, in the past, by simply switching profiles, since DShot Idle is not profile based.  

This is achieved by the following code changes:

- in rpm_filter.c, each motor's RPM is calculated before the check for whether or not RPM filtering is enabled applies.  This allows the user of RPM data by dynamic idle when RPM filtering is not active.
- we test for non-zero value for `mixerRuntime.dynIdleMinRps`and check that DShot Telemetry is enabled
- When DShot Telemetry isn't active, dynamic idle will not run.  The user's normal DShot idle behaviour becomes active automatically.
- instead of using the DShot Idle % as the 'idle up' value at zero throttle, this PR sets that value at a hard coded 1%.  