### PR TITLE
Change filter slider

### DIFF
--- a/src/main/config/simplified_tuning.c
+++ b/src/main/config/simplified_tuning.c
@@ -65,22 +65,50 @@ static void calculateNewPidValues(pidProfile_t *pidProfile)
 
 static void calculateNewDTermFilterValues(pidProfile_t *pidProfile)
 {
-    pidProfile->dterm_lpf1_dyn_min_hz = constrain(DTERM_LPF1_DYN_MIN_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
-    pidProfile->dterm_lpf1_dyn_max_hz = constrain(DTERM_LPF1_DYN_MAX_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
-    pidProfile->dterm_lpf1_static_hz = constrain(DTERM_LPF1_DYN_MIN_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
-    pidProfile->dterm_lpf2_static_hz = constrain(DTERM_LPF2_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, LPF_MAX_HZ);
-    pidProfile->dterm_lpf1_type = FILTER_PT1;
-    pidProfile->dterm_lpf2_type = FILTER_PT1;
+    if (pidProfile->dterm_lpf1_dyn_min_hz) {
+        pidProfile->dterm_lpf1_dyn_min_hz = constrain(DTERM_LPF1_DYN_MIN_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+        pidProfile->dterm_lpf1_dyn_max_hz = constrain(DTERM_LPF1_DYN_MAX_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+    }
+
+    if (pidProfile->dterm_lpf1_static_hz) {
+        pidProfile->dterm_lpf1_static_hz = constrain(DTERM_LPF1_DYN_MIN_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+    }
+
+    if (pidProfile->dterm_lpf2_static_hz) {
+        pidProfile->dterm_lpf2_static_hz = constrain(DTERM_LPF2_HZ_DEFAULT * pidProfile->simplified_dterm_filter_multiplier / 100, 0, LPF_MAX_HZ);
+    }
+
+    if (!pidProfile->dterm_lpf1_type) {
+        pidProfile->dterm_lpf1_type = FILTER_PT1;
+    }
+
+    if (!pidProfile->dterm_lpf2_type) {
+        pidProfile->dterm_lpf2_type = FILTER_PT1;
+    }
 }
 
 static void calculateNewGyroFilterValues()
 {
-    gyroConfigMutable()->gyro_lpf1_dyn_min_hz = constrain(GYRO_LPF1_DYN_MIN_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
-    gyroConfigMutable()->gyro_lpf1_dyn_max_hz = constrain(GYRO_LPF1_DYN_MAX_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
-    gyroConfigMutable()->gyro_lpf1_static_hz = constrain(GYRO_LPF1_DYN_MIN_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
-    gyroConfigMutable()->gyro_lpf2_static_hz = constrain(GYRO_LPF2_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, LPF_MAX_HZ);
-    gyroConfigMutable()->gyro_lpf1_type = FILTER_PT1;
-    gyroConfigMutable()->gyro_lpf2_type = FILTER_PT1;
+    if (gyroConfigMutable()->gyro_lpf1_dyn_min_hz) {
+        gyroConfigMutable()->gyro_lpf1_dyn_min_hz = constrain(GYRO_LPF1_DYN_MIN_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+        gyroConfigMutable()->gyro_lpf1_dyn_max_hz = constrain(GYRO_LPF1_DYN_MAX_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+    }
+
+    if (gyroConfigMutable()->gyro_lpf1_static_hz) {
+        gyroConfigMutable()->gyro_lpf1_static_hz = constrain(GYRO_LPF1_DYN_MIN_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, DYN_LPF_MAX_HZ);
+    }
+
+    if (gyroConfigMutable()->gyro_lpf2_static_hz) {
+        gyroConfigMutable()->gyro_lpf2_static_hz = constrain(GYRO_LPF2_HZ_DEFAULT * gyroConfig()->simplified_gyro_filter_multiplier / 100, 0, LPF_MAX_HZ);
+    }
+
+    if (!gyroConfigMutable()->gyro_lpf1_type) {
+        gyroConfigMutable()->gyro_lpf1_type = FILTER_PT1;
+    }
+
+    if (!gyroConfigMutable()->gyro_lpf2_type) {
+        gyroConfigMutable()->gyro_lpf2_type = FILTER_PT1;
+    }
 }
 
 void applySimplifiedTuning(pidProfile_t *pidProfile)


### PR DESCRIPTION
This PR makes `simplified_tuning` filter slider keeping slider enabled if using any (valid) filter combination not just defaults.

Needs testing with https://github.com/betaflight/betaflight-configurator/pull/2638

Firmware for testing:

[betaflight_4.3.0_STM32F7X2_1fdaaa3bf.zip](https://github.com/betaflight/betaflight/files/7518174/betaflight_4.3.0_STM32F7X2_1fdaaa3bf.zip)
[betaflight_4.3.0_STM32F405_1fdaaa3bf.zip](https://github.com/betaflight/betaflight/files/7518177/betaflight_4.3.0_STM32F405_1fdaaa3bf.zip)
[betaflight_4.3.0_STM32F411_1fdaaa3bf.zip](https://github.com/betaflight/betaflight/files/7518178/betaflight_4.3.0_STM32F411_1fdaaa3bf.zip)
[betaflight_4.3.0_STM32F745_1fdaaa3bf.zip](https://github.com/betaflight/betaflight/files/7518180/betaflight_4.3.0_STM32F745_1fdaaa3bf.zip)
[betaflight_4.3.0_STM32G47X_1fdaaa3bf.zip](https://github.com/betaflight/betaflight/files/7518181/betaflight_4.3.0_STM32G47X_1fdaaa3bf.zip)
[betaflight_4.3.0_STM32H743_1fdaaa3bf.zip](https://github.com/betaflight/betaflight/files/7518182/betaflight_4.3.0_STM32H743_1fdaaa3bf.zip)

(how to install the test firmware: https://youtu.be/I1uN9CN30gw)