### PR TITLE
Fixed burst Dshot.

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -363,10 +363,10 @@ bool pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }
 
-    if (!dmaIsConfigured) {
-        xDMA_Cmd(dmaRef, DISABLE);
-        xDMA_DeInit(dmaRef);
+    xDMA_Cmd(dmaRef, DISABLE);
+    xDMA_DeInit(dmaRef);
 
+    if (!dmaIsConfigured) {
         dmaEnable(dmaIdentifier);
     }
 
@@ -438,7 +438,7 @@ bool pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
         if (!dmaIsConfigured) {
-            dmaSetHandler(dmaIdentifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, timerIndex);
+            dmaSetHandler(dmaIdentifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, motor->index);
         }
     } else
 #endif

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -419,7 +419,7 @@ bool pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
         if (!dmaIsConfigured) {
-            dmaSetHandler(dmaIdentifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, timerIndex);
+            dmaSetHandler(dmaIdentifier, motor_DMA_IRQHandler, NVIC_PRIO_DSHOT_DMA, motor->index);
         }
     } else
 #endif


### PR DESCRIPTION
Fixes #10995.
Fixes #11002.
Fixes #11036.

**Update 2 Nov 2021:** There was another fix, I've updated the targets below, please re-test.

Test targets:

[betaflight_4.3.0_STM32H743_60e035be0.zip](https://github.com/betaflight/betaflight/files/7455762/betaflight_4.3.0_STM32H743_60e035be0.zip)
[betaflight_4.3.0_STM32G47X_60e035be0.zip](https://github.com/betaflight/betaflight/files/7455763/betaflight_4.3.0_STM32G47X_60e035be0.zip)
[betaflight_4.3.0_STM32F745_60e035be0.zip](https://github.com/betaflight/betaflight/files/7455764/betaflight_4.3.0_STM32F745_60e035be0.zip)
[betaflight_4.3.0_STM32F7X2_60e035be0.zip](https://github.com/betaflight/betaflight/files/7455765/betaflight_4.3.0_STM32F7X2_60e035be0.zip)
[betaflight_4.3.0_STM32F411_60e035be0.zip](https://github.com/betaflight/betaflight/files/7455767/betaflight_4.3.0_STM32F411_60e035be0.zip)
[betaflight_4.3.0_STM32F405_60e035be0.zip](https://github.com/betaflight/betaflight/files/7455769/betaflight_4.3.0_STM32F405_60e035be0.zip)

And the same fix, cherry-picked onto 4.2-maintenance:

[betaflight_4.2.11_STM32H743_6cb4612f0.zip](https://github.com/betaflight/betaflight/files/7455798/betaflight_4.2.11_STM32H743_6cb4612f0.zip)
[betaflight_4.2.11_STM32F745_6cb4612f0.zip](https://github.com/betaflight/betaflight/files/7455799/betaflight_4.2.11_STM32F745_6cb4612f0.zip)
[betaflight_4.2.11_STM32F7X2_6cb4612f0.zip](https://github.com/betaflight/betaflight/files/7455801/betaflight_4.2.11_STM32F7X2_6cb4612f0.zip)
[betaflight_4.2.11_STM32F411_6cb4612f0.zip](https://github.com/betaflight/betaflight/files/7455802/betaflight_4.2.11_STM32F411_6cb4612f0.zip)
[betaflight_4.2.11_STM32F405_6cb4612f0.zip](https://github.com/betaflight/betaflight/files/7455803/betaflight_4.2.11_STM32F405_6cb4612f0.zip)

(how to install the test firmware: https://youtu.be/I1uN9CN30gw)
