### PR TITLE
Fix BMI270 gyro sync on H743

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -115,7 +115,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
 // Gyro read has just completed
 busStatus_e mpuIntcallback(uint32_t arg)
 {
-    volatile gyroDev_t *gyro = (gyroDev_t *)arg;
+    gyroDev_t *gyro = (gyroDev_t *)arg;
     int32_t gyroDmaDuration = cmpTimeCycles(getCycleCounter(), gyro->gyroLastEXTI);
 
     if (gyroDmaDuration > gyro->gyroDmaMaxDuration) {

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -47,7 +47,7 @@
 #define TASK_AGE_EXPEDITE_SCALE         0.9 // By scaling their expected execution time
 
 // Gyro interrupt counts over which to measure loop time and skew
-#define GYRO_RATE_COUNT 32000
+#define GYRO_RATE_COUNT 25000
 #define GYRO_LOCK_COUNT 400
 
 typedef enum {


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11035

On a processor running at 480MHz the counter for the number of cycles in `GYRO_RATE_COUNT` gyro periods was wrapping due to the longer gyro period as the BMI270 runs at 3.2kHz compared to the more normal 8kHz. `GYRO_RATE_COUNT` was therefore reduced from 32K to 25K.

This PR also fixes the BMI270 gyro's DMA read to match that of the MPU6000, potentially supporting dual BMI270 gyros used simultaneously.