### PR TITLE
Add constant (i.e. string) deduplication, including at link time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ else
 ifeq ($(DEBUG),INFO)
 DEBUG_FLAGS            = -ggdb3
 endif
-OPTIMISATION_BASE     := -flto -fuse-linker-plugin -ffast-math
+OPTIMISATION_BASE     := -flto -fuse-linker-plugin -ffast-math -fmerge-all-constants
 OPTIMISE_DEFAULT      := -O2
 OPTIMISE_SPEED        := -Ofast
 OPTIMISE_SIZE         := -Os


### PR DESCRIPTION
Before:

```
Linking STM32F411 
Memory region         Used Size  Region Size  %age Used
[...]
          FLASH1:      486743 B       480 KB     99.03%
```

After:

```
Linking STM32F411 
Memory region         Used Size  Region Size  %age Used
[...]
          FLASH1:      486583 B       480 KB     99.00%
```
