### PR TITLE
Dynamic Notches: Track peaks even below mean squared 

### DIFF
--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -316,7 +316,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             for (int p = 0; p < dynNotch.count; p++) {
 
                 // Only update dynNotch.centerFreq if there is a peak (ignore void peaks) and if peak is above noise floor
-                if (peaks[p].bin != 0 && peaks[p].value > sdftMeanSq) {
+                if (peaks[p].bin != 0) {
 
                     float meanBin = peaks[p].bin;
 

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -315,7 +315,6 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
         {
             for (int p = 0; p < dynNotch.count; p++) {
 
-                // Only update dynNotch.centerFreq if there is a peak (ignore void peaks) and if peak is above noise floor
                 if (peaks[p].bin != 0) {
 
                     float meanBin = peaks[p].bin;


### PR DESCRIPTION
Current implementation on Dynamic Notches tries to track peaks only when they are above the noise floor.

![01](https://user-images.githubusercontent.com/966811/141818972-191b1d72-7139-4e13-b19b-e7e707207fbf.png)

This is done by comparing the peak value with a mean of all bins above min bin/frequency. However, this is not true, as the bin value mean is not a noise floor level. 

![02](https://user-images.githubusercontent.com/966811/141819511-7e9b4f4c-9077-48db-bf1a-870bb09e27d9.png)

In the case of some builds, the first peak (or 2 first peak combined) can have enough energy to move the mean high enough, so that the following peak fall below it, while still being well above the noise floor. As a result, Dynamic Notch stops tracking those lower energy peaks even if they are visible above the noise floor.

![03](https://user-images.githubusercontent.com/966811/141819957-42cc9b2d-48fd-4a33-8262-81718849f60c.png)

High energy peaks can saturate the peak detection algorithm.

This PR modifies this behavior by removing the `peaks[p].value > sdftMeanSq` condition. As a result, the frequency domain peak will be tracked even if its energy is below the mean value.

Bear in mind that previous steps detect on N strongest peaks. Tests revealed that 2nd and 3rd harmonics are still visible in the tracked frequency range. High-frequency notch attenuating low energy peak is still better than notch loosing track of a peak completely.