### PR TITLE
Implement battery continuation

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -925,6 +925,9 @@ const clivalue_t valueTable[] = {
     { "ibatv_scale",                VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, scale) },
     { "ibatv_offset",               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, offset) },
 #endif
+#ifdef USE_BATTERY_CONTINUE
+    { "battery_continue",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, isBatteryContinueEnabled) },
+#endif
 
 #ifdef USE_BEEPER
 // PG_BEEPER_DEV_CONFIG
@@ -1662,6 +1665,10 @@ const clivalue_t valueTable[] = {
 
     { "stats_total_time_s",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_total_time_s) },
     { "stats_total_dist_m",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_total_dist_m) },
+
+#ifdef USE_BATTERY_CONTINUE
+    { "stats_mah_used",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_STATS_CONFIG, offsetof(statsConfig_t, stats_mah_used) },
+#endif
 #endif
     { "name",             VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, MAX_NAME_LENGTH, STRING_FLAGS_NONE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, name) },
 #ifdef USE_OSD

--- a/src/main/cms/cms_menu_main.c
+++ b/src/main/cms/cms_menu_main.c
@@ -62,6 +62,11 @@
 
 #include "cms_menu_main.h"
 
+#ifdef USE_BATTERY_CONTINUE
+#include "sensors/battery.h"
+#include "pg/stats.h"
+#endif
+
 #define CALIBRATION_STATUS_MAX_LENGTH 9
 
 #define CALIBRATION_STATUS_REQUIRED "REQUIRED"
@@ -70,6 +75,10 @@
 
 #if defined(USE_ACC)
 static char accCalibrationStatus[CALIBRATION_STATUS_MAX_LENGTH];
+#endif
+
+#ifdef USE_BATTERY_CONTINUE
+static char batteryContinueAmount[18];
 #endif
 
 // Features
@@ -121,9 +130,27 @@ static const void *cmsx_SaveExitMenu(displayPort_t *pDisplay, const void *ptr)
 }
 
 
+#ifdef USE_BATTERY_CONTINUE
+#define SETUP_POPUP_MAX_ENTRIES 2   // Increase as new entries are added
+#else
 #define SETUP_POPUP_MAX_ENTRIES 1   // Increase as new entries are added
+#endif
 
 static OSD_Entry setupPopupMenuEntries[SETUP_POPUP_MAX_ENTRIES + 3];
+
+#ifdef USE_BATTERY_CONTINUE
+static const void *cmsRestoreMah(displayPort_t *pDisp, const void *self)
+{
+    UNUSED(self);
+
+    setMAhDrawn(statsConfig()->stats_mah_used);
+    statsConfigMutable()->stats_mah_used = 0;
+
+    cmsMenuExit(pDisp, (void *)CMS_EXIT);
+
+    return NULL;
+}
+#endif
 
 static bool setupPopupMenuBuild(void)
 {
@@ -136,6 +163,12 @@ static bool setupPopupMenuBuild(void)
 #if defined(USE_ACC)
     if (sensors(SENSOR_ACC) && (getArmingDisableFlags() & ARMING_DISABLED_ACC_CALIBRATION)) {
         cmsAddMenuEntry(&setupPopupMenuEntries[++menuIndex], "CALIBRATE ACC", OME_Funcall | DYNAMIC, cmsCalibrateAccMenu, accCalibrationStatus);
+    }
+#endif
+
+#ifdef USE_BATTERY_CONTINUE
+    if (hasUsedMAh()) {
+        cmsAddMenuEntry(&setupPopupMenuEntries[++menuIndex], batteryContinueAmount, OME_Funcall | DYNAMIC, cmsRestoreMah, NULL);
     }
 #endif
 
@@ -153,6 +186,11 @@ static const void *setupPopupMenuOnDisplayUpdate(displayPort_t *pDisp, const OSD
 #if defined(USE_ACC)
     // Update the ACC calibration status message.
     tfp_sprintf(accCalibrationStatus, accIsCalibrationComplete() ? accHasBeenCalibrated() ? CALIBRATION_STATUS_COMPLETE : CALIBRATION_STATUS_REQUIRED : CALIBRATION_STATUS_ACTIVE);
+#endif
+#ifdef USE_BATTERY_CONTINUE
+    if (hasUsedMAh()) {
+        tfp_sprintf(batteryContinueAmount, "RESTORE %5d MAH", statsConfig()->stats_mah_used);
+    }
 #endif
 
     return NULL;

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -34,6 +34,9 @@
 
 #include "pg/stats.h"
 
+#ifdef USE_BATTERY_CONTINUE
+#include "sensors/battery.h"
+#endif
 
 #define STATS_SAVE_DELAY_US 500000 // Let disarming complete and save stats after this time
 
@@ -91,6 +94,9 @@ void statsOnDisarm(void)
             statsConfigMutable()->stats_total_flights += 1;    // arm / flight counter
             statsConfigMutable()->stats_total_time_s += dtS;
             statsConfigMutable()->stats_total_dist_m += (DISTANCE_FLOWN_CM - arm_distance_cm) / 100;
+#ifdef USE_BATTERY_CONTINUE
+            statsConfigMutable()->stats_mah_used = getMAhDrawn();
+#endif
 
             saveRequired = true;
         }

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -327,6 +327,15 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         return;
     }
 
+#ifdef USE_BATTERY_CONTINUE
+    // Show warning if battery is not fresh and battery continue is active
+    if (hasUsedMAh()) {
+        tfp_sprintf(warningText, "BATTERY CONTINUE");
+        *displayAttr = DISPLAYPORT_ATTR_INFO;
+        return;
+    }
+#endif // USE_BATTERY_CONTINUE
+
     // Show warning if battery is not fresh
     if (osdWarnGetState(OSD_WARNING_BATTERY_NOT_FULL) && !(ARMING_FLAG(ARMED) || ARMING_FLAG(WAS_EVER_ARMED)) && (getBatteryState() == BATTERY_OK)
           && getBatteryAverageCellVoltage() < batteryConfig()->vbatfullcellvoltage) {

--- a/src/main/pg/stats.c
+++ b/src/main/pg/stats.c
@@ -27,12 +27,13 @@
 
 #include "stats.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 3);
 
 PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
     .stats_min_armed_time_s = STATS_OFF,
     .stats_total_flights = 0,
     .stats_total_time_s = 0,
     .stats_total_dist_m = 0,
+    .stats_mah_used = 0,
 );
 #endif

--- a/src/main/pg/stats.h
+++ b/src/main/pg/stats.h
@@ -30,6 +30,7 @@ typedef struct statsConfig_s {
     uint32_t stats_total_time_s;
     uint32_t stats_total_dist_m;
     int8_t stats_min_armed_time_s;
+    uint32_t stats_mah_used;
 } statsConfig_t;
 
 PG_DECLARE(statsConfig_t, statsConfig);

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -46,6 +46,9 @@
 #include "pg/pg_ids.h"
 
 #include "scheduler/scheduler.h"
+#ifdef USE_BATTERY_CONTINUE
+#include "pg/stats.h"
+#endif
 
 #include "sensors/battery.h"
 
@@ -541,5 +544,24 @@ int32_t getAmperageLatest(void)
 
 int32_t getMAhDrawn(void)
 {
+#ifdef USE_BATTERY_CONTINUE
+    return currentMeter.mAhDrawn + currentMeter.mAhDrawnOffset;
+#else
     return currentMeter.mAhDrawn;
+#endif
 }
+
+#ifdef USE_BATTERY_CONTINUE
+bool hasUsedMAh()
+{
+    return batteryConfig()->isBatteryContinueEnabled
+          && !(ARMING_FLAG(ARMED) || ARMING_FLAG(WAS_EVER_ARMED)) && (getBatteryState() == BATTERY_OK)
+          && getBatteryAverageCellVoltage() < batteryConfig()->vbatfullcellvoltage
+          && statsConfig()->stats_mah_used > 0;
+}
+
+void setMAhDrawn(uint32_t mAhDrawn)
+{
+    currentMeter.mAhDrawnOffset = mAhDrawn;
+}
+#endif

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -71,6 +71,10 @@ typedef struct batteryConfig_s {
     uint8_t vbatDurationForWarning;         // Period voltage has to sustain before the battery state is set to BATTERY_WARNING (in 0.1 s)
     uint8_t vbatDurationForCritical;        // Period voltage has to sustain before the battery state is set to BATTERY_CRIT (in 0.1 s)
     uint8_t vbatSagLpfPeriod;               // Period of the cutoff frequency for the Vbat sag and PID compensation filter (in 0.1 s)
+
+#ifdef USE_BATTERY_CONTINUE
+    bool isBatteryContinueEnabled;
+#endif
 } batteryConfig_t;
 
 PG_DECLARE(batteryConfig_t, batteryConfig);
@@ -116,6 +120,10 @@ bool isAmperageConfigured(void);
 int32_t getAmperage(void);
 int32_t getAmperageLatest(void);
 int32_t getMAhDrawn(void);
+#ifdef USE_BATTERY_CONTINUE
+bool hasUsedMAh();
+void setMAhDrawn(uint32_t mAhDrawn);
+#endif
 
 void batteryUpdateCurrentMeter(timeUs_t currentTimeUs);
 

--- a/src/main/sensors/current.h
+++ b/src/main/sensors/current.h
@@ -38,6 +38,9 @@ typedef struct currentMeter_s {
     int32_t amperage;           // current read by current sensor in centiampere (1/100th A)
     int32_t amperageLatest;     // current read by current sensor in centiampere (1/100th A) (unfiltered)
     int32_t mAhDrawn;           // milliampere hours drawn from the battery since start
+#ifdef USE_BATTERY_CONTINUE
+    int32_t mAhDrawnOffset;     // mAh offset
+#endif
 } currentMeter_t;
 
 // WARNING - do not mix usage of CURRENT_SENSOR_* and CURRENT_METER_*, they are separate concerns.

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -416,4 +416,5 @@ extern uint8_t _dmaram_end__;
 #define USE_EMFAT_AUTORUN
 #define USE_EMFAT_ICON
 #define USE_GPS_PLUS_CODES
+#define USE_BATTERY_CONTINUE
 #endif


### PR DESCRIPTION
Since my previous attempt at this in #8989 persistent stats and popup menus have been added, greatly simplifying battery continue functionality.

## Why

I fly mainly on mAh consumed to decide when to land and find it annoying to remember and mentally subtract the already consumed amount in case I need to unplug the battery to switch props after a crash or something.

## How

When persistent stats are enabled (`stats_min_armed_time_s` > 0) and `battery_continue = ON` the mah drawn is saved with the rest of the persistent stats. If the battery is detected as not full "BATTERY CONTINUE" is shown in the warning field.

![image1](https://user-images.githubusercontent.com/509294/143684556-f2d40bed-5f0b-4bac-b9d0-12500539089d.png)

If the user enters the OSD menu the existing popup menu (currently used only for forced accelerometer calibration) is shown giving the user the option to restore the previous mAh drawn as offset.

![image2](https://user-images.githubusercontent.com/509294/143684566-941197ab-ccdf-46a3-9a1e-962462049f3d.png)

After restoring the drawn mah the offset is updated and the normal `BATT < FULL` warning is visible.

![image3](https://user-images.githubusercontent.com/509294/143684573-efdf7ec3-f073-4e47-a9ac-5d886e623cf3.png)

If the accelerometer also needs calibration both options are shown.

![image4](https://user-images.githubusercontent.com/509294/143684582-0de26a9c-8022-4295-a71f-7d34e191efa9.png)


[betaflight_4.3.0_STM32H743_9f475f5ca.zip](https://github.com/betaflight/betaflight/files/7611869/betaflight_4.3.0_STM32H743_9f475f5ca.zip)
[betaflight_4.3.0_STM32G47X_9f475f5ca.zip](https://github.com/betaflight/betaflight/files/7611870/betaflight_4.3.0_STM32G47X_9f475f5ca.zip)
[betaflight_4.3.0_STM32F745_9f475f5ca.zip](https://github.com/betaflight/betaflight/files/7611871/betaflight_4.3.0_STM32F745_9f475f5ca.zip)
[betaflight_4.3.0_STM32F7X2_9f475f5ca.zip](https://github.com/betaflight/betaflight/files/7611872/betaflight_4.3.0_STM32F7X2_9f475f5ca.zip)
[betaflight_4.3.0_STM32F411_9f475f5ca.zip](https://github.com/betaflight/betaflight/files/7611873/betaflight_4.3.0_STM32F411_9f475f5ca.zip)
[betaflight_4.3.0_STM32F405_9f475f5ca.zip](https://github.com/betaflight/betaflight/files/7611874/betaflight_4.3.0_STM32F405_9f475f5ca.zip)