### PR TITLE
Fix CPU over flow on G4 when pid rate set to higher than 4k

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -93,7 +93,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
 #define PID_PROCESS_DENOM_DEFAULT       8
 #elif defined(STM32F3)
 #define PID_PROCESS_DENOM_DEFAULT       4
-#elif defined(STM32F411xE)
+#elif defined(STM32F411xE) || defined(STM32G4) //G4 sometimes cpu overflow when PID rate set to higher than 4k
 #define PID_PROCESS_DENOM_DEFAULT       2
 #else
 #define PID_PROCESS_DENOM_DEFAULT       1


### PR DESCRIPTION
Counter PR to https://github.com/betaflight/unified-targets/pull/532.

After some SPI DMA PRs (I guess) was introduced in, on G4 when PID rate was set to higher than 4k, the CPU load is quite high that might cause overflow and lockup problems.

On MPU6000 8k PID rate:
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)      8       3       1    0.5%    0.5%         0      0    252       1
01 - (         SYSTEM)    546       9       0    0.9%    0.0%        13     57  13025       0
02 - (           GYRO)   8000      23       5   18.9%    4.5%      1827      0 375268       0
03 - (         FILTER)   8000      49      21   39.7%   17.3%      7618      0 375268       0
04 - (            PID)   8000     126      77  101.3%   62.1%     29512      0 375268       0
05 - (            ACC)    456      19       1    1.3%    0.5%        54   7736  10357       0
06 - (       ATTITUDE)     51      30       2    0.6%    0.5%        22   1347   1353       1
07 - (             RX)     13      51       3    0.5%    0.5%        32   1247   1668       3
08 - (         SERIAL)     29  383165       0 1111.6%    0.0%       722    318    650       0
09 - (       DISPATCH)    592      11       0    1.1%    0.0%        10     64  14551       0
10 - (BATTERY_VOLTAGE)     35      12       1    0.5%    0.5%         3     32    899       1
11 - (BATTERY_CURRENT)     35      10       1    0.5%    0.5%         0      2    875       1
12 - ( BATTERY_ALERTS)      3      10       2    0.5%    0.5%         0      4    129       2
13 - (         BEEPER)     26      17       0    0.5%    0.0%         1     17    626       0
16 - (           BARO)      6      37       0    0.5%    0.0%         8    351   1063       0
17 - (       ALTITUDE)     12      17       1    0.5%    0.5%         3    280    314       1
20 - (            OSD)     12     152       2    0.6%    0.5%         9    434    443       2
22 - (            CMS)      6      11       0    0.5%    0.0%         0     11    175       0
23 - (        VTXCTRL)      1       9       0    0.5%    0.0%         0      2     25       0
24 - (        CAMCTRL)      1       9       0    0.5%    0.0%         0      0     23       0
26 - (    ADCINTERNAL)      1       3       0    0.5%    0.0%         0      0     10       0
RX Check Function                   9       1                         2
Total (excluding SERIAL)                       170.4%   88.4%
```
On LSM6DSO 6.6k PID rate:
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       0    0.5%    0.0%         0      0    216       1
01 - (         SYSTEM)    952       8       1    1.2%    0.5%        20      0  20411       1
02 - (           GYRO)   6667      33      17   22.5%   11.8%      2314      0 142843       0
03 - (         FILTER)   6667      39      21   26.5%   14.5%      2975      0 142843       0
04 - (            PID)   6667      89      51   59.8%   34.5%      7456      0 142843       0
05 - (            ACC)    818      30      17    2.9%    1.8%       298     66  17450      18
06 - (       ATTITUDE)     99      28      16    0.7%    0.6%        33      2   2133      16
07 - (             RX)     15      48      15    0.5%    0.5%        23     95   1296      15
08 - (         SERIAL)     99  381146       2 3773.8%    0.5%       731    255   2115       2
09 - (       DISPATCH)    952       5       0    0.9%    0.0%        14      0  20413       0
11 - (BATTERY_CURRENT)     50       4       1    0.5%    0.5%         0      0   1070       1
12 - ( BATTERY_ALERTS)      5       5       2    0.5%    0.5%         0      0    109       2
13 - (         BEEPER)     99       7       1    0.5%    0.5%         3      2   2114       2
16 - (           BARO)     40      41      28    0.6%    0.6%        57     13   2545      28
17 - (       ALTITUDE)     40      19      16    0.5%    0.5%        12      3    855      15
22 - (            CMS)     20       5       2    0.5%    0.5%         1      0    430       2
23 - (        VTXCTRL)      5      33       5    0.5%    0.5%         1     10    109       5
24 - (        CAMCTRL)      5       1       0    0.5%    0.0%         0      0    109       1
26 - (    ADCINTERNAL)      2      10       1    0.5%    0.5%         0      0     23       1
RX Check Function                   5       1                         1
Total (excluding SERIAL)                       120.1%   68.3%
```
Then change pid_process_denom to 2:
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       9       1    0.5%    0.5%         0      0    460       1
01 - (         SYSTEM)    989      16       1    2.0%    0.5%        49     13  45286       1
02 - (           GYRO)   8000      26       5   21.3%    4.5%      1873      0 366944       0
03 - (         FILTER)   4000      49      27   20.1%   11.3%      4828      0 183472       0
04 - (            PID)   4000     109      74   44.1%   30.1%     13482      0 183472       0
05 - (            ACC)    981      26       5    3.0%    0.9%       263     55  45239       5
06 - (       ATTITUDE)    100      34      18    0.8%    0.6%        82     48   4570      18
07 - (             RX)     15      57      15    0.5%    0.5%        57    450   2756      15
08 - (         SERIAL)    100  383213       3 3832.6%    0.5%       791    275   4555       3
09 - (       DISPATCH)    987      15       0    1.9%    0.0%        36     13  45296       0
10 - (BATTERY_VOLTAGE)     50      20       4    0.6%    0.5%         9      0   2291       4
11 - (BATTERY_CURRENT)     50       9       1    0.5%    0.5%         2      1   2291       1
12 - ( BATTERY_ALERTS)      5      11       3    0.5%    0.5%         0      0    231       3
13 - (         BEEPER)    100      11       2    0.6%    0.5%         7      0   4554       1
16 - (           BARO)     20      46      30    0.5%    0.5%        48     23   5479      30
17 - (       ALTITUDE)     40      32      17    0.6%    0.5%        29      8   1832      17
20 - (            OSD)     60     161      49    1.4%    0.7%        74     40   2741      49
22 - (            CMS)     20      11       2    0.5%    0.5%         2      1    918       2
23 - (        VTXCTRL)      5       9       1    0.5%    0.5%         0      0    231       1
24 - (        CAMCTRL)      5       9       1    0.5%    0.5%         0      0    231       1
26 - (    ADCINTERNAL)      1      11       4    0.5%    0.5%         0      0     47       4
RX Check Function                  15       1                         4
Total (excluding SERIAL)                       100.9%   54.6%
```
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       1    0.5%    0.5%         0      0     64       0
01 - (         SYSTEM)    951       9       1    1.3%    0.5%         5      0   5851       1
02 - (           GYRO)   6667      30      17   20.5%   11.8%       556      0  40983       0
03 - (         FILTER)   3333      49      23   16.8%    8.1%       478      0  20491       0
04 - (            PID)   3333      79      52   26.8%   17.8%      1082      0  20492       0
05 - (            ACC)    829      25      17    2.5%    1.9%        87     19   5089      17
06 - (       ATTITUDE)     99      20      16    0.6%    0.6%         9      0    615      16
07 - (             RX)     13      49      16    0.5%    0.5%         6     51    376      16
08 - (         SERIAL)     99  374215       3 3705.2%    0.5%       692     22    614       3
09 - (       DISPATCH)    951       3       1    0.7%    0.5%         3      0   5851       1
11 - (BATTERY_CURRENT)     47       4       1    0.5%    0.5%         0      0    310       1
12 - ( BATTERY_ALERTS)      6       3       1    0.5%    0.5%         0      0     33       1
13 - (         BEEPER)     99       7       2    0.5%    0.5%         0      0    613       1
16 - (           BARO)     36      30      28    0.6%    0.6%        16     14    733      28
17 - (       ALTITUDE)     36      19      15    0.5%    0.5%         2      0    247      15
22 - (            CMS)     18       4       2    0.5%    0.5%         0      0    125       2
23 - (        VTXCTRL)      6      33       9    0.5%    0.5%         0     10     33       9
24 - (        CAMCTRL)      6       1       0    0.5%    0.0%         0      0     33       0
26 - (    ADCINTERNAL)      4       3       0    0.5%    0.0%         0      0      7       0
RX Check Function                   3       2                         0
Total (excluding SERIAL)                        74.8%   45.8%
```