### PR TITLE
Make float truncation explicit

### DIFF
--- a/lib/main/MAVLink/mavlink_conversions.h
+++ b/lib/main/MAVLink/mavlink_conversions.h
@@ -45,15 +45,15 @@ MAVLINK_HELPER void mavlink_quaternion_to_dcm(const float quaternion[4], float d
     double bSq = b * b;
     double cSq = c * c;
     double dSq = d * d;
-    dcm[0][0] = aSq + bSq - cSq - dSq;
-    dcm[0][1] = 2 * (b * c - a * d);
-    dcm[0][2] = 2 * (a * c + b * d);
-    dcm[1][0] = 2 * (b * c + a * d);
-    dcm[1][1] = aSq - bSq + cSq - dSq;
-    dcm[1][2] = 2 * (c * d - a * b);
-    dcm[2][0] = 2 * (b * d - a * c);
-    dcm[2][1] = 2 * (a * b + c * d);
-    dcm[2][2] = aSq - bSq - cSq + dSq;
+    dcm[0][0] = (float)(aSq + bSq - cSq - dSq);
+    dcm[0][1] = (float)(2 * (b * c - a * d));
+    dcm[0][2] = (float)(2 * (a * c + b * d));
+    dcm[1][0] = (float)(2 * (b * c + a * d));
+    dcm[1][1] = (float)(aSq - bSq + cSq - dSq);
+    dcm[1][2] = (float)(2 * (c * d - a * b));
+    dcm[2][0] = (float)(2 * (b * d - a * c));
+    dcm[2][1] = (float)(2 * (a * b + c * d));
+    dcm[2][2] = (float)(aSq - bSq - cSq + dSq);
 }
 
 

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1088,7 +1088,7 @@ static void loadMainState(timeUs_t currentTimeUs)
     blackboxCurrent->setpoint[3] = lrintf(mixerGetThrottle() * 1000);
 
     for (int i = 0; i < DEBUG16_VALUE_COUNT; i++) {
-        blackboxCurrent->debug[i] = debug[i];
+        blackboxCurrent->debug[i] = (int16_t)debug[i];
     }
 
     const int motorCount = getMotorCount();

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4042,7 +4042,7 @@ static void cliMotor(const char *cmdName, char *cmdline)
         if (motorValue < PWM_RANGE_MIN || motorValue > PWM_RANGE_MAX) {
             cliShowArgumentRangeError(cmdName, "VALUE", 1000, 2000);
         } else {
-            uint32_t motorOutputValue = motorConvertFromExternal(motorValue);
+            uint32_t motorOutputValue = (uint32_t)motorConvertFromExternal(motorValue);
 
             if (motorIndex != ALL_MOTORS) {
                 motor_disarmed[motorIndex] = motorOutputValue;

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -49,7 +49,7 @@
 #endif
 float sin_approx(float x)
 {
-    int32_t xint = x;
+    int32_t xint = (int32_t)x;
     if (xint < -32 || xint > 32) return 0.0f;                               // Stop here on error input (5 * 360 Deg)
     while (x >  M_PIf) x -= (2.0f * M_PIf);                                 // always wrap input angle to -PI..PI
     while (x < -M_PIf) x += (2.0f * M_PIf);

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -173,3 +173,8 @@ static inline float constrainf(float amt, float low, float high)
     else
         return amt;
 }
+
+static inline int lconstrainf(float amt, int low, int high)
+{
+    return constrain((int)amt, low, high);
+}

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -683,7 +683,7 @@ void validateAndFixGyroConfig(void)
                 motorUpdateRestriction *= 2;
             }
             if (pidLooptime < motorUpdateRestriction) {
-                uint8_t minPidProcessDenom = motorUpdateRestriction / samplingTime;
+                uint8_t minPidProcessDenom = (uint8_t)(motorUpdateRestriction / samplingTime);
                 if (motorUpdateRestriction / samplingTime > minPidProcessDenom) {
                     // if any fractional part then round up
                     minPidProcessDenom++;

--- a/src/main/config/simplified_tuning.c
+++ b/src/main/config/simplified_tuning.c
@@ -48,16 +48,16 @@ static void calculateNewPidValues(pidProfile_t *pidProfile)
     for (int axis = FD_ROLL; axis <= pidProfile->simplified_pids_mode; ++axis) {
         const float pitchDGain = (axis == FD_PITCH) ? pidProfile->simplified_roll_pitch_ratio / 100.0f : 1.0f;
         const float pitchPiGain = (axis == FD_PITCH) ? pidProfile->simplified_pitch_pi_gain / 100.0f : 1.0f;
-        pidProfile->pid[axis].P = constrain(pidDefaults[axis].P * masterMultiplier * piGain * pitchPiGain, 0, PID_GAIN_MAX);
-        pidProfile->pid[axis].I = constrain(pidDefaults[axis].I * masterMultiplier * piGain * iGain * pitchPiGain, 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].P = constrain((int)(pidDefaults[axis].P * masterMultiplier * piGain * pitchPiGain), 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].I = constrain((int)(pidDefaults[axis].I * masterMultiplier * piGain * iGain * pitchPiGain), 0, PID_GAIN_MAX);
 #ifdef USE_D_MIN
         const float dminRatio = (dMinDefaults[axis] > 0) ? 1.0f + (((float)pidDefaults[axis].D - dMinDefaults[axis]) / dMinDefaults[axis]) * (pidProfile->simplified_dmin_ratio / 100.0f) : 1.0f;
-        pidProfile->pid[axis].D = constrain(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain * dminRatio, 0, PID_GAIN_MAX);
-        pidProfile->d_min[axis] = constrain(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain, 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].D = constrain((int)(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain * dminRatio), 0, PID_GAIN_MAX);
+        pidProfile->d_min[axis] = constrain((int)(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain), 0, PID_GAIN_MAX);
 #else
-        pidProfile->pid[axis].D = constrain(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain, 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].D = constrain((int)(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain), 0, PID_GAIN_MAX);
 #endif
-        pidProfile->pid[axis].F = constrain(pidDefaults[axis].F * masterMultiplier * pitchPiGain * feedforwardGain, 0, F_GAIN_MAX);
+        pidProfile->pid[axis].F = constrain((int)(pidDefaults[axis].F * masterMultiplier * pitchPiGain * feedforwardGain), 0, F_GAIN_MAX);
     }
 }
 

--- a/src/main/config/simplified_tuning.c
+++ b/src/main/config/simplified_tuning.c
@@ -48,16 +48,16 @@ static void calculateNewPidValues(pidProfile_t *pidProfile)
     for (int axis = FD_ROLL; axis <= pidProfile->simplified_pids_mode; ++axis) {
         const float pitchDGain = (axis == FD_PITCH) ? pidProfile->simplified_roll_pitch_ratio / 100.0f : 1.0f;
         const float pitchPiGain = (axis == FD_PITCH) ? pidProfile->simplified_pitch_pi_gain / 100.0f : 1.0f;
-        pidProfile->pid[axis].P = constrain((int)(pidDefaults[axis].P * masterMultiplier * piGain * pitchPiGain), 0, PID_GAIN_MAX);
-        pidProfile->pid[axis].I = constrain((int)(pidDefaults[axis].I * masterMultiplier * piGain * iGain * pitchPiGain), 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].P = lconstrainf(pidDefaults[axis].P * masterMultiplier * piGain * pitchPiGain, 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].I = lconstrainf(pidDefaults[axis].I * masterMultiplier * piGain * iGain * pitchPiGain, 0, PID_GAIN_MAX);
 #ifdef USE_D_MIN
         const float dminRatio = (dMinDefaults[axis] > 0) ? 1.0f + (((float)pidDefaults[axis].D - dMinDefaults[axis]) / dMinDefaults[axis]) * (pidProfile->simplified_dmin_ratio / 100.0f) : 1.0f;
-        pidProfile->pid[axis].D = constrain((int)(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain * dminRatio), 0, PID_GAIN_MAX);
-        pidProfile->d_min[axis] = constrain((int)(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain), 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].D = lconstrainf(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain * dminRatio, 0, PID_GAIN_MAX);
+        pidProfile->d_min[axis] = lconstrainf(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain, 0, PID_GAIN_MAX);
 #else
-        pidProfile->pid[axis].D = constrain((int)(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain), 0, PID_GAIN_MAX);
+        pidProfile->pid[axis].D = lconstrainf(dMinDefaults[axis] * masterMultiplier * dGain * pitchDGain, 0, PID_GAIN_MAX);
 #endif
-        pidProfile->pid[axis].F = constrain((int)(pidDefaults[axis].F * masterMultiplier * pitchPiGain * feedforwardGain), 0, F_GAIN_MAX);
+        pidProfile->pid[axis].F = lconstrainf(pidDefaults[axis].F * masterMultiplier * pitchPiGain * feedforwardGain, 0, F_GAIN_MAX);
     }
 }
 

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -275,11 +275,11 @@ static bool dps310GetUP(baroDev_t *baro)
 static void deviceCalculate(int32_t *pressure, int32_t *temperature)
 {
     if (pressure) {
-        *pressure = baroState.pressure; 
+        *pressure = (int32_t)baroState.pressure; 
     }
 
     if (temperature) {
-        *temperature = (baroState.temperature * 100);   // to centidegrees
+        *temperature = (int32_t)(baroState.temperature * 100);   // to centidegrees
     }
 }
 

--- a/src/main/drivers/bus_i2c_timing.c
+++ b/src/main/drivers/bus_i2c_timing.c
@@ -67,8 +67,8 @@ static void i2cClockComputeRaw(uint32_t pclkFreq, int i2cFreqKhz, int presc, int
     // Convert target i2cFreq into cycle time (nsec)
     float tSCL = 1000000.0f / i2cFreqKhz;
 
-    uint32_t SCLDELmin = (trmax + tsuDATmin) / ((presc + 1) * tI2cclk) - 1;
-    uint32_t SDADELmin = (tfmax + thdDATmin - tAFmin - ((dfcoeff + 3) * tI2cclk)) / ((presc + 1) * tI2cclk);
+    uint32_t SCLDELmin = (uint32_t)((trmax + tsuDATmin) / ((presc + 1) * tI2cclk) - 1);
+    uint32_t SDADELmin = (uint32_t)((tfmax + thdDATmin - tAFmin - ((dfcoeff + 3) * tI2cclk)) / ((presc + 1) * tI2cclk));
 
     float tsync1 = tf + tAFmin + dfcoeff * tI2cclk + 2 * tI2cclk;
     float tsync2 = tr + tAFmin + dfcoeff * tI2cclk + 2 * tI2cclk;
@@ -76,8 +76,8 @@ static void i2cClockComputeRaw(uint32_t pclkFreq, int i2cFreqKhz, int presc, int
     float tSCLH = tHIGHmin * tSCL / (tHIGHmin + tLOWmin) - tsync2;
     float tSCLL = tSCL - tSCLH - tsync1 - tsync2;
 
-    uint32_t SCLH = tSCLH / ((presc + 1) * tI2cclk) - 1;
-    uint32_t SCLL = tSCLL / ((presc + 1) * tI2cclk) - 1;
+    uint32_t SCLH = (uint32_t)(tSCLH / ((presc + 1) * tI2cclk) - 1);
+    uint32_t SCLL = (uint32_t)(tSCLL / ((presc + 1) * tI2cclk) - 1);
 
     while (tsync1 + tsync2 + ((SCLH + 1) + (SCLL + 1)) * ((presc + 1) * tI2cclk) < tSCL) {
         SCLH++;

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -90,12 +90,12 @@ uint16_t dshotConvertToExternal(float motorValue)
         if (motorValue == DSHOT_CMD_MOTOR_STOP || motorValue < DSHOT_MIN_THROTTLE) {
             externalValue = PWM_RANGE_MIDDLE;
         } else if (motorValue <= DSHOT_3D_FORWARD_MIN_THROTTLE - 1) {
-            externalValue = scaleRangef(motorValue, DSHOT_MIN_THROTTLE, DSHOT_3D_FORWARD_MIN_THROTTLE - 1, PWM_RANGE_MIDDLE - 1, PWM_RANGE_MIN);
+            externalValue = (uint16_t)scaleRangef(motorValue, DSHOT_MIN_THROTTLE, DSHOT_3D_FORWARD_MIN_THROTTLE - 1, PWM_RANGE_MIDDLE - 1, PWM_RANGE_MIN);
         } else {
-            externalValue = scaleRangef(motorValue, DSHOT_3D_FORWARD_MIN_THROTTLE, DSHOT_MAX_THROTTLE, PWM_RANGE_MIDDLE + 1, PWM_RANGE_MAX);
+            externalValue = (uint16_t)scaleRangef(motorValue, DSHOT_3D_FORWARD_MIN_THROTTLE, DSHOT_MAX_THROTTLE, PWM_RANGE_MIDDLE + 1, PWM_RANGE_MAX);
         }
     } else {
-        externalValue = (motorValue < DSHOT_MIN_THROTTLE) ? PWM_RANGE_MIN : scaleRangef(motorValue, DSHOT_MIN_THROTTLE, DSHOT_MAX_THROTTLE, PWM_RANGE_MIN + 1, PWM_RANGE_MAX);
+        externalValue = (motorValue < DSHOT_MIN_THROTTLE) ? PWM_RANGE_MIN : (uint16_t)scaleRangef(motorValue, DSHOT_MIN_THROTTLE, DSHOT_MAX_THROTTLE, PWM_RANGE_MIN + 1, PWM_RANGE_MAX);
     }
 
     return lrintf(externalValue);

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -716,7 +716,7 @@ void runawayTakeoffTemporaryDisable(uint8_t disableFlag)
 int8_t calculateThrottlePercent(void)
 {
     uint8_t ret = 0;
-    int channelData = constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
+    int channelData = constrain((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
 
     if (featureIsEnabled(FEATURE_3D)
         && !IS_RC_MODE_ACTIVE(BOX3D)

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -716,7 +716,7 @@ void runawayTakeoffTemporaryDisable(uint8_t disableFlag)
 int8_t calculateThrottlePercent(void)
 {
     uint8_t ret = 0;
-    int channelData = constrain((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
+    int channelData = lconstrainf(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
 
     if (featureIsEnabled(FEATURE_3D)
         && !IS_RC_MODE_ACTIVE(BOX3D)

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -624,10 +624,10 @@ FAST_CODE_NOINLINE void updateRcCommands(void)
 
     int32_t tmp;
     if (featureIsEnabled(FEATURE_3D)) {
-        tmp = constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
+        tmp = constrain((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - PWM_RANGE_MIN);
     } else {
-        tmp = constrain(rcData[THROTTLE], rxConfig()->mincheck, PWM_RANGE_MAX);
+        tmp = constrain((int)rcData[THROTTLE], rxConfig()->mincheck, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - rxConfig()->mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - rxConfig()->mincheck);
     }
 

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -624,10 +624,10 @@ FAST_CODE_NOINLINE void updateRcCommands(void)
 
     int32_t tmp;
     if (featureIsEnabled(FEATURE_3D)) {
-        tmp = constrain((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
+        tmp = lconstrainf(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - PWM_RANGE_MIN);
     } else {
-        tmp = constrain((int)rcData[THROTTLE], rxConfig()->mincheck, PWM_RANGE_MAX);
+        tmp = lconstrainf(rcData[THROTTLE], rxConfig()->mincheck, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - rxConfig()->mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - rxConfig()->mincheck);
     }
 

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -803,7 +803,7 @@ static void processContinuosAdjustments(controlRateConfig_t *controlRateConfig)
                         switchPositions =  6;
                     }
                     const uint16_t rangeWidth = (2100 - 900) / switchPositions;
-                    const uint8_t position = (constrain((int)rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
+                    const uint8_t position = (lconstrainf(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
                     newValue = applySelectAdjustment(adjustmentFunction, position);
 
                     setConfigDirtyIfNotPermanent(&adjustmentRange->range);

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -803,7 +803,7 @@ static void processContinuosAdjustments(controlRateConfig_t *controlRateConfig)
                         switchPositions =  6;
                     }
                     const uint16_t rangeWidth = (2100 - 900) / switchPositions;
-                    const uint8_t position = (constrain(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
+                    const uint8_t position = (constrain((int)rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
                     newValue = applySelectAdjustment(adjustmentFunction, position);
 
                     setConfigDirtyIfNotPermanent(&adjustmentRange->range);

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -88,7 +88,7 @@ bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range) {
         return false;
     }
 
-    const uint16_t channelValue = constrain((int)rcData[auxChannelIndex + NON_AUX_CHANNEL_COUNT], CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX - 1);
+    const uint16_t channelValue = lconstrainf(rcData[auxChannelIndex + NON_AUX_CHANNEL_COUNT], CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX - 1);
     return (channelValue >= 900 + (range->startStep * 25) &&
             channelValue < 900 + (range->endStep * 25));
 }

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -88,7 +88,7 @@ bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range) {
         return false;
     }
 
-    const uint16_t channelValue = constrain(rcData[auxChannelIndex + NON_AUX_CHANNEL_COUNT], CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX - 1);
+    const uint16_t channelValue = constrain((int)rcData[auxChannelIndex + NON_AUX_CHANNEL_COUNT], CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX - 1);
     return (channelValue >= 900 + (range->startStep * 25) &&
             channelValue < 900 + (range->endStep * 25));
 }

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -94,7 +94,7 @@ static void writeAllMotors(int16_t mc)
 
 void stopMotors(void)
 {
-    writeAllMotors(mixerRuntime.disarmMotorOutput);
+    writeAllMotors((int16_t)mixerRuntime.disarmMotorOutput);
     delay(50); // give the timers and ESCs a chance to react.
 }
 
@@ -156,7 +156,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             }
             motorOutputMixSign = -1;
 
-            rcThrottlePrevious = rcCommand[THROTTLE];
+            rcThrottlePrevious = (uint16_t)rcCommand[THROTTLE];
             throttle = rcCommand3dDeadBandLow - rcCommand[THROTTLE];
             currentThrottleInputRange = rcCommandThrottleRange3dLow;
         } else if (rcCommand[THROTTLE] >= rcCommand3dDeadBandHigh) {
@@ -169,7 +169,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
                 reversalTimeUs = currentTimeUs;
             }
             motorOutputMixSign = 1;
-            rcThrottlePrevious = rcCommand[THROTTLE];
+            rcThrottlePrevious = (uint16_t)rcCommand[THROTTLE];
             throttle = rcCommand[THROTTLE] - rcCommand3dDeadBandHigh;
             currentThrottleInputRange = rcCommandThrottleRange3dHigh;
         } else if ((rcThrottlePrevious <= rcCommand3dDeadBandLow &&

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -169,7 +169,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
     for (int motor = 0; motor < getMotorCount(); motor++) {
         filteredMotorErpm[motor] = pt1FilterApply(&rpmFilters[motor], getDshotTelemetry(motor));
         if (motor < 4) {
-            DEBUG_SET(DEBUG_RPM_FILTER, motor, motorFrequency[motor]);
+            DEBUG_SET(DEBUG_RPM_FILTER, motor, (int16_t)motorFrequency[motor]);
         }
         motorFrequency[motor] = erpmToHz * filteredMotorErpm[motor];
     }

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -202,7 +202,7 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        return rcData[channelToForwardFrom];
+        return (int16_t)rcData[channelToForwardFrom];
     }
 
     return servoParams(servoIndex)->middle;
@@ -406,14 +406,14 @@ void servoMixer(void)
 
     if (FLIGHT_MODE(PASSTHRU_MODE)) {
         // Direct passthru from RX
-        input[INPUT_STABILIZED_ROLL] = rcCommand[ROLL];
-        input[INPUT_STABILIZED_PITCH] = rcCommand[PITCH];
-        input[INPUT_STABILIZED_YAW] = rcCommand[YAW];
+        input[INPUT_STABILIZED_ROLL] = (int16_t)rcCommand[ROLL];
+        input[INPUT_STABILIZED_PITCH] = (int16_t)rcCommand[PITCH];
+        input[INPUT_STABILIZED_YAW] = (int16_t)rcCommand[YAW];
     } else {
         // Assisted modes (gyro only or gyro+acc according to AUX configuration in Gui
-        input[INPUT_STABILIZED_ROLL] = pidData[FD_ROLL].Sum * PID_SERVO_MIXER_SCALING;
-        input[INPUT_STABILIZED_PITCH] = pidData[FD_PITCH].Sum * PID_SERVO_MIXER_SCALING;
-        input[INPUT_STABILIZED_YAW] = pidData[FD_YAW].Sum * PID_SERVO_MIXER_SCALING;
+        input[INPUT_STABILIZED_ROLL] = (int16_t)(pidData[FD_ROLL].Sum * PID_SERVO_MIXER_SCALING);
+        input[INPUT_STABILIZED_PITCH] = (int16_t)(pidData[FD_PITCH].Sum * PID_SERVO_MIXER_SCALING);
+        input[INPUT_STABILIZED_YAW] = (int16_t)(pidData[FD_YAW].Sum * PID_SERVO_MIXER_SCALING);
 
         // Reverse yaw servo when inverted in 3D mode
         if (featureIsEnabled(FEATURE_3D) && (rcData[THROTTLE] < rxConfig()->midrc)) {

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -257,7 +257,8 @@ static void drawRxChannel(uint8_t channelIndex, uint8_t width)
 {
     LCDprint(rcChannelLetters[channelIndex]);
 
-    const uint32_t percentage = (constrain(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN);
+    const int value = lconstrainf(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX);
+    const uint32_t percentage = (value - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN);
     drawHorizonalPercentageBar(width - 1, percentage);
 }
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1824,9 +1824,9 @@ void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, int32_t
 {
     float dLat = *destinationLat2 - *currentLat1; // difference of latitude in 1/10 000 000 degrees
     float dLon = (float)(*destinationLon2 - *currentLon1) * GPS_scaleLonDown;
-    *dist = sqrtf(sq(dLat) + sq(dLon)) * DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR_IN_HUNDREDS_OF_KILOMETERS;
+    *dist = (uint32_t)(sqrtf(sq(dLat) + sq(dLon)) * DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR_IN_HUNDREDS_OF_KILOMETERS);
 
-    *bearing = 9000.0f + atan2_approx(-dLat, dLon) * TAN_89_99_DEGREES;      // Convert the output radians to 100xdeg
+    *bearing = (int32_t)(9000.0f + atan2_approx(-dLat, dLon) * TAN_89_99_DEGREES);      // Convert the output radians to 100xdeg
     if (*bearing < 0)
         *bearing += 36000;
 }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -484,7 +484,7 @@ static void applyLedFixedLayers(void)
             hsvColor_t previousColor = ledStripStatusModeConfig()->colors[(ledGetColor(ledConfig) - 1 + LED_CONFIGURABLE_COLOR_COUNT) % LED_CONFIGURABLE_COLOR_COUNT];
 
             if (ledGetOverlayBit(ledConfig, LED_OVERLAY_THROTTLE)) {   //smooth fade with selected Aux channel of all HSV values from previousColor through color to nextColor
-                const int auxInput = rcData[ledStripStatusModeConfig()->ledstrip_aux_channel];
+                const int auxInput = (int)rcData[ledStripStatusModeConfig()->ledstrip_aux_channel];
                 int centerPWM = (PWM_RANGE_MIN + PWM_RANGE_MAX) / 2;
                 if (auxInput < centerPWM) {
                     color.h = scaleRange(auxInput, PWM_RANGE_MIN, centerPWM, previousColor.h, color.h);
@@ -530,7 +530,7 @@ static void applyLedFixedLayers(void)
         }
 
         if ((fn != LED_FUNCTION_COLOR) && ledGetOverlayBit(ledConfig, LED_OVERLAY_THROTTLE)) {
-            const int auxInput = rcData[ledStripStatusModeConfig()->ledstrip_aux_channel];
+            const int auxInput = (int)rcData[ledStripStatusModeConfig()->ledstrip_aux_channel];
             hOffset += scaleRange(auxInput, PWM_RANGE_MIN, PWM_RANGE_MAX, 0, HSV_HUE_MAX + 1);
         }
 
@@ -821,7 +821,7 @@ static void applyLedIndicatorLayer(bool updateNow, timeUs_t *timer)
     if (updateNow) {
         if (rxIsReceivingSignal()) {
             // calculate update frequency
-            int scale = MAX(fabsf(rcCommand[ROLL]), fabsf(rcCommand[PITCH]));  // 0 - 500
+            int scale = (int)MAX(fabsf(rcCommand[ROLL]), fabsf(rcCommand[PITCH]));  // 0 - 500
             scale = scale - INDICATOR_DEADBAND;  // start increasing frequency right after deadband
             *timer += HZ_TO_US(5 + (45 * scale) / (500 - INDICATOR_DEADBAND));   // 5 - 50Hz update, 2.5 - 25Hz blink
 
@@ -865,7 +865,7 @@ static void applyLedThrustRingLayer(bool updateNow, timeUs_t *timer)
     if (updateNow) {
         rotationPhase = rotationPhase > 0 ? rotationPhase - 1 : ledCounts.ringSeqLen - 1;
 
-        const int scaledThrottle = ARMING_FLAG(ARMED) ? scaleRange(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100) : 0;
+        const int scaledThrottle = ARMING_FLAG(ARMED) ? scaleRange((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100) : 0;
         *timer += HZ_TO_US(5 + (45 * scaledThrottle) / 100);  // 5 - 50Hz update rate
     }
 

--- a/src/main/io/usb_cdc_hid.c
+++ b/src/main/io/usb_cdc_hid.c
@@ -78,7 +78,7 @@ void sendRcDataToHid(void)
      // Axes
     for (unsigned i = 0; i < USB_CDC_HID_NUM_AXES; i++) {
         const uint8_t channel = hidChannelMapping[i];
-        report[i] = scaleRange(constrain((int)rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX);
+        report[i] = scaleRange(lconstrainf(rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX);
         if (channel == PITCH) {
             // PITCH is inverted in Windows
             report[i] = -report[i];
@@ -90,7 +90,7 @@ void sendRcDataToHid(void)
     report[8] = 0;
     for (unsigned i = 0; i < USB_CDC_HID_NUM_BUTTONS; i++) {
         const uint8_t channel = hidChannelMapping[i + USB_CDC_HID_NUM_AXES];
-        if (scaleRange(constrain((int)rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX) > 0) {
+        if (scaleRange(lconstrainf(rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX) > 0) {
             report[8] |= (1 << i);
         }
     }

--- a/src/main/io/usb_cdc_hid.c
+++ b/src/main/io/usb_cdc_hid.c
@@ -78,7 +78,7 @@ void sendRcDataToHid(void)
      // Axes
     for (unsigned i = 0; i < USB_CDC_HID_NUM_AXES; i++) {
         const uint8_t channel = hidChannelMapping[i];
-        report[i] = scaleRange(constrain(rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX);
+        report[i] = scaleRange(constrain((int)rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX);
         if (channel == PITCH) {
             // PITCH is inverted in Windows
             report[i] = -report[i];
@@ -90,7 +90,7 @@ void sendRcDataToHid(void)
     report[8] = 0;
     for (unsigned i = 0; i < USB_CDC_HID_NUM_BUTTONS; i++) {
         const uint8_t channel = hidChannelMapping[i + USB_CDC_HID_NUM_AXES];
-        if (scaleRange(constrain(rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX) > 0) {
+        if (scaleRange(constrain((int)rcData[channel], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, USB_CDC_HID_RANGE_MIN, USB_CDC_HID_RANGE_MAX) > 0) {
             report[8] |= (1 << i);
         }
     }

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1308,7 +1308,7 @@ static bool mspProcessOutCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, sbuf_t
 
     case MSP_RC:
         for (int i = 0; i < rxRuntimeState.channelCount; i++) {
-            sbufWriteU16(dst, rcData[i]);
+            sbufWriteU16(dst, (uint16_t)rcData[i]);
         }
         break;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1416,8 +1416,8 @@ static void osdElementStickOverlay(osdElementParms_t *element)
         horizontal_channel = radioModes[osdConfig()->overlay_radio_mode-1].right_horizontal;
     }
 
-    const uint8_t cursorX = scaleRange(constrain((int)rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
-    const uint8_t cursorY = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - scaleRange(constrain((int)rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS);
+    const uint8_t cursorX = scaleRange(lconstrainf(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
+    const uint8_t cursorY = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - scaleRange(lconstrainf(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS);
     const char cursor = SYM_STICK_OVERLAY_SPRITE_HIGH + (cursorY % OSD_STICK_OVERLAY_SPRITE_HEIGHT);
 
     osdDisplayWriteChar(element, xpos + cursorX, ypos + cursorY / OSD_STICK_OVERLAY_SPRITE_HEIGHT, DISPLAYPORT_ATTR_NONE, cursor);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1251,7 +1251,7 @@ static void osdElementMotorDiagnostics(osdElementParms_t *element)
     const bool motorsRunning = areMotorsRunning();
     for (; i < getMotorCount(); i++) {
         if (motorsRunning) {
-            element->buff[i] =  0x88 - scaleRange(motor[i], getMotorOutputLow(), getMotorOutputHigh(), 0, 8);
+            element->buff[i] =  0x88 - scaleRange((int)motor[i], (int)getMotorOutputLow(), (int)getMotorOutputHigh(), 0, 8);
 #if defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
             if (getEscRpm(i) < MOTOR_STOPPED_THRESHOLD_RPM) {
                 // Motor is not spinning properly. Mark as Stopped
@@ -1327,7 +1327,7 @@ static void osdElementRcChannels(osdElementParms_t *element)
     for (int i = 0; i < OSD_RCCHANNELS_COUNT; i++) {
         if (osdConfig()->rcChannels[i] >= 0) {
             // Translate (1000, 2000) to (-1000, 1000)
-            int data = scaleRange(rcData[osdConfig()->rcChannels[i]], PWM_RANGE_MIN, PWM_RANGE_MAX, -1000, 1000);
+            int data = scaleRange((int)rcData[osdConfig()->rcChannels[i]], PWM_RANGE_MIN, PWM_RANGE_MAX, -1000, 1000);
             // Opt for the simplest formatting for now.
             // Decimal notation can be added when tfp_sprintf supports float among fancy options.
             char fmtbuf[6];
@@ -1416,8 +1416,8 @@ static void osdElementStickOverlay(osdElementParms_t *element)
         horizontal_channel = radioModes[osdConfig()->overlay_radio_mode-1].right_horizontal;
     }
 
-    const uint8_t cursorX = scaleRange(constrain(rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
-    const uint8_t cursorY = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - scaleRange(constrain(rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS);
+    const uint8_t cursorX = scaleRange(constrain((int)rcData[horizontal_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_WIDTH);
+    const uint8_t cursorY = OSD_STICK_OVERLAY_VERTICAL_POSITIONS - 1 - scaleRange(constrain((int)rcData[vertical_channel], PWM_RANGE_MIN, PWM_RANGE_MAX - 1), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, OSD_STICK_OVERLAY_VERTICAL_POSITIONS);
     const char cursor = SYM_STICK_OVERLAY_SPRITE_HIGH + (cursorY % OSD_STICK_OVERLAY_SPRITE_HEIGHT);
 
     osdDisplayWriteChar(element, xpos + cursorX, ypos + cursorY / OSD_STICK_OVERLAY_SPRITE_HEIGHT, DISPLAYPORT_ATTR_NONE, cursor);
@@ -1920,7 +1920,7 @@ void osdUpdateAlarms(void)
 {
     // This is overdone?
 
-    int32_t alt = osdGetMetersToSelectedUnit(getEstimatedAltitudeCm()) / 100;
+    int32_t alt = (int32_t)(osdGetMetersToSelectedUnit(getEstimatedAltitudeCm()) / 100);
 
     if (getRssiPercent() < osdConfig()->rssi_alarm) {
         SET_BLINK(OSD_RSSI_VALUE);

--- a/src/main/rx/msp_override.c
+++ b/src/main/rx/msp_override.c
@@ -30,9 +30,9 @@
 
 uint16_t rxMspOverrideReadRawRc(const rxRuntimeState_t *rxRuntimeState, const rxConfig_t *rxConfig, uint8_t chan)
 {
-    uint16_t rxSample = (rxRuntimeState->rcReadRawFn)(rxRuntimeState, chan);
+    uint16_t rxSample = (uint16_t)((rxRuntimeState->rcReadRawFn)(rxRuntimeState, chan));
 
-    uint16_t overrideSample = rxMspReadRawRC(rxRuntimeState, chan);
+    uint16_t overrideSample = (uint16_t)rxMspReadRawRC(rxRuntimeState, chan);
     bool override = (1 << chan) & rxConfig->msp_override_channels_mask;
 
     if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && override) {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -640,6 +640,9 @@ static void readRxChannelsApplyRanges(void)
 void detectAndApplySignalLossBehaviour(void)
 {
     const uint32_t currentTimeMs = millis();
+    const bool failsafeAuxSwitch = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
+    rxFlightChannelsValid = rxSignalReceived && !failsafeAuxSwitch;
+    //  set rxFlightChannelsValid false when a packet is bad or we use a failsafe switch
 
     for (int channel = 0; channel < rxChannelCount; channel++) {
         float sample = rcRaw[channel]; // sample has latest RC value, rcData has last 'accepted valid' value

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -640,9 +640,6 @@ static void readRxChannelsApplyRanges(void)
 void detectAndApplySignalLossBehaviour(void)
 {
     const uint32_t currentTimeMs = millis();
-    const bool failsafeAuxSwitch = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
-    rxFlightChannelsValid = rxSignalReceived && !failsafeAuxSwitch;
-    //  set rxFlightChannelsValid false when a packet is bad or we use a failsafe switch
 
     for (int channel = 0; channel < rxChannelCount; channel++) {
         float sample = rcRaw[channel]; // sample has latest RC value, rcData has last 'accepted valid' value
@@ -787,7 +784,7 @@ void setRssi(uint16_t rssiValue, rssiSource_e source)
 
     // Filter RSSI value
     if (source == RSSI_SOURCE_FRAME_ERRORS) {
-        rssi = pt1FilterApply(&frameErrFilter, rssiValue);
+        rssi = (uint16_t)pt1FilterApply(&frameErrFilter, rssiValue);
     } else {
         // calculate new sample mean
         rssi = updateRssiSamples(rssiValue);
@@ -809,7 +806,7 @@ void setRssiMsp(uint8_t newMspRssi)
 static void updateRSSIPWM(void)
 {
     // Read value of AUX channel as rssi
-    int16_t pwmRssi = rcData[rxConfig()->rssi_channel - 1];
+    int16_t pwmRssi = (int16_t)rcData[rxConfig()->rssi_channel - 1];
 
     // Range of rawPwmRssi is [1000;2000]. rssi should be in [0;1023];
     setRssiDirect(scaleRange(constrain(pwmRssi, PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_CHANNEL);

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -339,8 +339,8 @@ void compassStartCalibration(void)
     flightDynamicsTrims_t *magZero = &compassConfigMutable()->magZero;
     for (int axis = 0; axis < 3; axis++) {
         magZero->raw[axis] = 0;
-        magZeroTempMin.raw[axis] = mag.magADC[axis];
-        magZeroTempMax.raw[axis] = mag.magADC[axis];
+        magZeroTempMin.raw[axis] = (int16_t)mag.magADC[axis];
+        magZeroTempMax.raw[axis] = (int16_t)mag.magADC[axis];
     }
 }
 
@@ -378,9 +378,9 @@ uint32_t compassUpdate(timeUs_t currentTimeUs)
             LED0_TOGGLE;
             for (int axis = 0; axis < 3; axis++) {
                 if (mag.magADC[axis] < magZeroTempMin.raw[axis])
-                    magZeroTempMin.raw[axis] = mag.magADC[axis];
+                    magZeroTempMin.raw[axis] = (int16_t)mag.magADC[axis];
                 if (mag.magADC[axis] > magZeroTempMax.raw[axis])
-                    magZeroTempMax.raw[axis] = mag.magADC[axis];
+                    magZeroTempMax.raw[axis] = (int16_t)mag.magADC[axis];
             }
         } else {
             tCal = 0;

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -128,7 +128,7 @@ static int32_t currentMeterADCToCentiamps(const uint16_t src)
 static void updateCurrentmAhDrawnState(currentMeterMAhDrawnState_t *state, int32_t amperageLatest, int32_t lastUpdateAt)
 {
     state->mAhDrawnF = state->mAhDrawnF + (amperageLatest * lastUpdateAt / (100.0f * 1000 * 3600));
-    state->mAhDrawn = state->mAhDrawnF;
+    state->mAhDrawn = (int32_t)state->mAhDrawnF;
 }
 #endif
 
@@ -149,7 +149,7 @@ void currentMeterADCRefresh(int32_t lastUpdateAt)
 #ifdef USE_ADC
     const uint16_t iBatSample = adcGetChannel(ADC_CURRENT);
     currentMeterADCState.amperageLatest = currentMeterADCToCentiamps(iBatSample);
-    currentMeterADCState.amperage = currentMeterADCToCentiamps(pt1FilterApply(&adciBatFilter, iBatSample));
+    currentMeterADCState.amperage = currentMeterADCToCentiamps((uint16_t)pt1FilterApply(&adciBatFilter, iBatSample));
 
     updateCurrentmAhDrawnState(&currentMeterADCState.mahDrawnState, currentMeterADCState.amperageLatest, lastUpdateAt);
 #else

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -588,7 +588,7 @@ bool gyroYawSpinDetected(void)
 
 uint16_t gyroAbsRateDps(int axis)
 {
-    return fabsf(gyro.gyroADCf[axis]);
+    return (uint16_t)fabsf(gyro.gyroADCf[axis]);
 }
 
 #ifdef USE_DYN_LPF
@@ -602,7 +602,7 @@ void dynLpfGyroUpdate(float throttle)
     if (gyro.dynLpfFilter != DYN_LPF_NONE) {
         float cutoffFreq;
         if (gyro.dynLpfCurveExpo > 0) {
-            cutoffFreq = dynLpfCutoffFreq(throttle, gyro.dynLpfMin, gyro.dynLpfMax, gyro.dynLpfCurveExpo);
+            cutoffFreq = (unsigned int)dynLpfCutoffFreq(throttle, gyro.dynLpfMin, gyro.dynLpfMax, gyro.dynLpfCurveExpo);
         } else {
             cutoffFreq = fmaxf(dynThrottle(throttle) * gyro.dynLpfMax, gyro.dynLpfMin);
         }

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -165,7 +165,7 @@ bool rangefinderInit(void)
     // XXX Interface to CF/BF legacy(?) altitude estimation code.
     // XXX Will be gone once iNav's estimator is ported.
     rangefinderMaxRangeCm = rangefinder.dev.maxRangeCm;
-    rangefinderMaxAltWithTiltCm = rangefinderMaxRangeCm * rangefinder.maxTiltCos;
+    rangefinderMaxAltWithTiltCm = (int16_t)(rangefinderMaxRangeCm * rangefinder.maxTiltCos);
     rangefinderCfAltCm = rangefinder.dev.maxRangeCm / 2 ; // Complimentary Filter altitude
 
     return true;
@@ -318,7 +318,7 @@ bool rangefinderProcess(float cosTiltAngle)
     if (cosTiltAngle < rangefinder.maxTiltCos || rangefinder.rawAltitude < 0) {
         rangefinder.calculatedAltitude = RANGEFINDER_OUT_OF_RANGE;
     } else {
-        rangefinder.calculatedAltitude = rangefinder.rawAltitude * cosTiltAngle;
+        rangefinder.calculatedAltitude = (int32_t)(rangefinder.rawAltitude * cosTiltAngle);
     }
 
     DEBUG_SET(DEBUG_RANGEFINDER, 1, rangefinder.rawAltitude);

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -173,7 +173,7 @@ void voltageMeterADCRefresh(void)
 
         uint8_t channel = voltageMeterAdcChannelMap[i];
         uint16_t rawSample = adcGetChannel(channel);
-        uint16_t filteredDisplaySample = pt1FilterApply(&state->displayFilter, rawSample);
+        uint16_t filteredDisplaySample = (uint16_t)pt1FilterApply(&state->displayFilter, rawSample);
 
         // always calculate the latest voltage, see getLatestVoltage() which does the calculation on demand.
         state->voltageDisplayFiltered = voltageAdcToVoltage(filteredDisplaySample, config);
@@ -181,7 +181,7 @@ void voltageMeterADCRefresh(void)
 
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
         if (isSagCompensationConfigured()) {
-            uint16_t filteredSagSample = pt1FilterApply(&state->sagFilter, rawSample);
+            uint16_t filteredSagSample = (uint16_t)pt1FilterApply(&state->sagFilter, rawSample);
             state->voltageSagFiltered = voltageAdcToVoltage(filteredSagSample, config);
         }
 #endif
@@ -272,7 +272,7 @@ void voltageMeterESCRefresh(void)
     escSensorData_t *escData = getEscSensorData(ESC_SENSOR_COMBINED);
     if (escData) {
         voltageMeterESCState.voltageUnfiltered = escData->dataAge <= ESC_BATTERY_AGE_MAX ? escData->voltage : 0;
-        voltageMeterESCState.voltageDisplayFiltered = pt1FilterApply(&voltageMeterESCState.displayFilter, voltageMeterESCState.voltageUnfiltered);
+        voltageMeterESCState.voltageDisplayFiltered = (uint16_t)pt1FilterApply(&voltageMeterESCState.displayFilter, voltageMeterESCState.voltageUnfiltered);
     }
 #endif
 }

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -241,7 +241,7 @@ static uint16_t getRPM()
     uint16_t rpm = 0;
     if (ARMING_FLAG(ARMED)) {
         const throttleStatus_e throttleStatus = calculateThrottleStatus();
-        rpm = rcCommand[THROTTLE];  // / BLADE_NUMBER_DIVIDER;
+        rpm = (uint16_t)rcCommand[THROTTLE];  // / BLADE_NUMBER_DIVIDER;
         if (throttleStatus == THROTTLE_LOW && featureIsEnabled(FEATURE_MOTOR_STOP)) rpm = 0;
     } else {
         rpm = (uint16_t)(batteryConfig()->batteryCapacity); //  / BLADE_NUMBER_DIVIDER

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -275,21 +275,21 @@ void mavlinkSendRCChannelsAndRSSI(void)
         // port Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.
         0,
         // chan1_raw RC channel 1 value, in microseconds
-        (rxRuntimeState.channelCount >= 1) ? rcData[0] : 0,
+        (rxRuntimeState.channelCount >= 1) ? (uint16_t)rcData[0] : 0,
         // chan2_raw RC channel 2 value, in microseconds
-        (rxRuntimeState.channelCount >= 2) ? rcData[1] : 0,
+        (rxRuntimeState.channelCount >= 2) ? (uint16_t)rcData[1] : 0,
         // chan3_raw RC channel 3 value, in microseconds
-        (rxRuntimeState.channelCount >= 3) ? rcData[2] : 0,
+        (rxRuntimeState.channelCount >= 3) ? (uint16_t)rcData[2] : 0,
         // chan4_raw RC channel 4 value, in microseconds
-        (rxRuntimeState.channelCount >= 4) ? rcData[3] : 0,
+        (rxRuntimeState.channelCount >= 4) ? (uint16_t)rcData[3] : 0,
         // chan5_raw RC channel 5 value, in microseconds
-        (rxRuntimeState.channelCount >= 5) ? rcData[4] : 0,
+        (rxRuntimeState.channelCount >= 5) ? (uint16_t)rcData[4] : 0,
         // chan6_raw RC channel 6 value, in microseconds
-        (rxRuntimeState.channelCount >= 6) ? rcData[5] : 0,
+        (rxRuntimeState.channelCount >= 6) ? (uint16_t)rcData[5] : 0,
         // chan7_raw RC channel 7 value, in microseconds
-        (rxRuntimeState.channelCount >= 7) ? rcData[6] : 0,
+        (rxRuntimeState.channelCount >= 7) ? (uint16_t)rcData[6] : 0,
         // chan8_raw RC channel 8 value, in microseconds
-        (rxRuntimeState.channelCount >= 8) ? rcData[7] : 0,
+        (rxRuntimeState.channelCount >= 8) ? (uint16_t)rcData[7] : 0,
         // rssi Receive signal strength indicator, 0: 0%, 254: 100%
         scaleRange(getRssi(), 0, RSSI_MAX_VALUE, 0, 254));
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
@@ -424,7 +424,7 @@ void mavlinkSendHUDAndHeartbeat(void)
         // heading Current heading in degrees, in compass units (0..360, 0=north)
         headingOrScaledMilliAmpereHoursDrawn(),
         // throttle Current throttle setting in integer percent, 0 to 100
-        scaleRange(constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
+        scaleRange(constrain((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
         // alt Current altitude (MSL), in meters, if we have sonar or baro use them, otherwise use GPS (less accurate)
         mavAltitude,
         // climb Current climb rate in meters/second

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -424,7 +424,7 @@ void mavlinkSendHUDAndHeartbeat(void)
         // heading Current heading in degrees, in compass units (0..360, 0=north)
         headingOrScaledMilliAmpereHoursDrawn(),
         // throttle Current throttle setting in integer percent, 0 to 100
-        scaleRange(constrain((int)rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
+        scaleRange(lconstrainf(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
         // alt Current altitude (MSL), in meters, if we have sonar or baro use them, otherwise use GPS (less accurate)
         mavAltitude,
         // climb Current climb rate in meters/second


### PR DESCRIPTION
This adds an explicit cast when floating point values are being truncated to lower precision.
This fixes some warnings produced by adding the GCC flag `Wfloat-conversion`.

These fixes specifically are "safe" because they do not change the output of the compiled hex files.

I also added a shorthand for the constrain function `lconstrainf`, following the naming pattern of e.g. `lrintf`.