### PR TITLE
Bugfix for a clean flash diff-all reporting lowpass static cutoffs of zero

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -173,11 +173,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .abs_control_error_limit = 20,
         .abs_control_cutoff = 11,
         .antiGravityMode = ANTI_GRAVITY_SMOOTH,
-        .dterm_lpf1_static_hz = DTERM_LPF1_DYN_MIN_HZ_DEFAULT,
-            // NOTE: dynamic lpf is enabled by default so this setting is actually
-            // overridden and the static lowpass 1 is disabled. We can't set this
-            // value to 0 otherwise Configurator versions 10.4 and earlier will also
-            // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
+        .dterm_lpf1_static_hz = 0,
         .dterm_lpf2_static_hz = DTERM_LPF2_HZ_DEFAULT,   // second Dterm LPF ON by default
         .dterm_lpf1_type = FILTER_PT1,
         .dterm_lpf2_type = FILTER_PT1,

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -110,11 +110,7 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyroMovementCalibrationThreshold = 48;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
     gyroConfig->gyro_lpf1_type = FILTER_PT1;
-    gyroConfig->gyro_lpf1_static_hz = GYRO_LPF1_DYN_MIN_HZ_DEFAULT;  
-        // NOTE: dynamic lpf is enabled by default so this setting is actually
-        // overridden and the static lowpass 1 is disabled. We can't set this
-        // value to 0 otherwise Configurator versions 10.4 and earlier will also
-        // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
+    gyroConfig->gyro_lpf1_static_hz = 0;  
     gyroConfig->gyro_lpf2_type = FILTER_PT1;
     gyroConfig->gyro_lpf2_static_hz = GYRO_LPF2_HZ_DEFAULT;
     gyroConfig->gyro_high_fsr = false;


### PR DESCRIPTION
The lowpass 1 static cutoffs default  in firmware to `DTERM_LPF1_DYN_MIN_HZ_DEFAULT` and `GYRO_LPF1_DYN_MIN_HZ_DEFAULT`.

Configurator 10.8 sliders operate on the basis that if `gyro_lpf1_static_hz` or `dterm_lpf1_static_hz` are zero, they are off. Since the default mode for lowpass 1 is dynamic, simply opening a pid_tuning tab in Configurator will set the static values to zero, and this zero value is used for switching between static and dynamic mode.

The mismatch is caused by the non-zero initialisation. There is a note about this in the firmware:

```
    gyroConfig->gyro_lpf1_static_hz = GYRO_LPF1_DYN_MIN_HZ_DEFAULT;  
        // NOTE: dynamic lpf is enabled by default so this setting is actually
        // overridden and the static lowpass 1 is disabled. We can't set this
        // value to 0 otherwise Configurator versions 10.4 and earlier will also
        // reset the lowpass filter type to PT1 overriding the desired BIQUAD setting.
```

I am not sure how relevant this note is to 4.3.   

The Configurator version required for 4.3 is 10.8; 4.3 should not open in earlier Configurator versions. Hence the note seems confusing.

This PR solves the diff issue by initialising `gyro_lpf1_static_hz` and `dterm_lpf1_static_hz` at zero.  This appears to work without problems, but the NOTE bothers me.  From a filter initialisation point of view, the default filter config is that dynamic mode is enabled, so the filter would be initialised with the dynamic minimum anyway.  Since the user can configure lowpass1 to be off by setting both the static and dynamic_min cutoffs to zero, and since the filter initialisation must be able to handle this, it seems certain that changing the initialisation of the static to zero should not be problematic.

It is possible that there are Configurator-side solutions, but it would be better if we could fix it in firmware, since it is much simpler if a cutoff of 0 consistently means off in both firmware and Configurator.

I'm putting this up for discussion in case I'm missing something, but I feel it is a bug fix for 4.3.