### PR TITLE
Fix telemetry displayport initialisation

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -765,12 +765,6 @@ void init(void)
     }
 #endif
 
-#ifdef USE_TELEMETRY
-    if (featureIsEnabled(FEATURE_TELEMETRY)) {
-        telemetryInit();
-    }
-#endif
-
 #ifdef USE_ESC_SENSOR
     if (featureIsEnabled(FEATURE_ESC_SENSOR)) {
         escSensorInit();
@@ -875,6 +869,12 @@ void init(void)
  */
 #ifdef USE_CMS
     cmsInit();
+#endif
+
+#ifdef USE_TELEMETRY
+    if (featureIsEnabled(FEATURE_TELEMETRY)) {
+        telemetryInit();
+    }
 #endif
 
 #if (defined(USE_OSD) || (defined(USE_MSP_DISPLAYPORT) && defined(USE_CMS)))


### PR DESCRIPTION
The initialisation is done as part of ```telemetryInit()``` and will fail because cms hasn't been initialised yet. This causes the Betaflight CMS lua script to not work.

This PR moves ```telemetryInit()``` to after ```cmsInit()```. Now both telemetry and cms over telemetry works as it should.