### PR TITLE
stop applying sliders when changing profiles

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -223,14 +223,9 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .simplified_dterm_filter = true,
         .simplified_dterm_filter_multiplier = SIMPLIFIED_TUNING_DEFAULT,
     );
-
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;
     pidProfile->pid[PID_PITCH].D = 32;
-#endif
-
-#ifdef USE_SIMPLIFIED_TUNING
-        applySimplifiedTuning(pidProfile);
 #endif
 }
 


### PR DESCRIPTION
PR #10919 called `applySimplifiedTuning` when Profiles were changed.  

This PR removes that functionality.

I think it was intended to ensure that if sliders were enabled, the values would be consistent with the current slider positions.  It does this perfectly well.  However, it is probably unnecessary, and causes some problems with the current 'hybrid' model, where users can change PID values or cutoffs with impunity in CLI, OSD and LUA, while their sliders are still set to be 'active'.

The problem is subtle.  If a user is field-tuning their quad using direct value entry over OSD, or if they are making manual changes in CLI, to values that an active slider is set to control, they can do this, and fly and tune their quad.  They may have simply forgotten about sliders being active.  Then, on the next power cycle, the profile re-loads, and this code replaces their manual value tuning changes with slider-computed values.  

We could say, "bad luck, the sliders were enabled; you should have used the sliders".

But we currently permit direct value changes in OSD, LUA and CLI, even if sliders are active we allow these changes.  So we should not just discard them at next power-up.

If we accept this PR, direct PID or filter value changes made while field tuning will be retained across power cycles, even if sliders are set to be active.  The sliders will only override the PID numbers when they are 'applied'.

We are revising Configurator so that when the user gets home and plugs in, they will see the same PIDs they adjusted in the field, and then have the option of turning sliders off and keeping those values, or turning sliders on and moving the sliders to get them to give a similar result.

Note that if the user changes *and then applies* sliders in OSD, and saves, then, as expected, the slider values will over-write any changes made by direct value manipulation.   

There currently is a problem that applying sliders will apply PID and filter slider positions, whether triggered from the PID screen or the Filter screen.  The user may expect applying PID sliders will only change PIDs, but actually it will change any non-slider Filter customisations as well.  This is something to consider in a separate PR.

My main concern is that this may break LUA slider updates.  This we have to test.

This is quite an important change.  It supports the 'hybrid' model supported by @mikeller in which sliders can be on but manual tuning changes overlaid over the top, with slider changes only actioned by 'applying' them, by not losing those changes across power cycles or on connecting to Configurator.

When testing, make a change in CLI to say gyro_lpf1_max_hz, save that, and check what happens in Configurator.  There are still a few bugs in Configurator in situations of this kind, but if you use Configurator PR 2686 https://github.com/betaflight/betaflight-configurator/pull/2686 you should find that your manual changes are not lost across power cycles.