### PR TITLE
Remove icon file and autorun on low flash space targets

### DIFF
--- a/src/main/msc/emfat_file.c
+++ b/src/main/msc/emfat_file.c
@@ -45,10 +45,6 @@
 #define FILESYSTEM_SIZE_MB 256
 #define HDR_BUF_SIZE 32
 
-#define USE_EMFAT_AUTORUN
-#define USE_EMFAT_ICON
-//#define USE_EMFAT_README
-
 #ifdef USE_EMFAT_AUTORUN
 static const char autorun_file[] =
     "[autorun]\r\n"
@@ -231,6 +227,7 @@ static const char icon_file[] =
 #define CMA_TIME EMFAT_ENCODE_CMA_TIME(1,1,2018, 13,0,0)
 #define CMA { CMA_TIME, CMA_TIME, CMA_TIME }
 
+#if defined (USE_EMFAT_AUTORUN) || defined (USE_EMFAT_ICON) || defined (USE_EMFAT_README)
 static void memory_read_proc(uint8_t *dest, int size, uint32_t offset, emfat_entry_t *entry)
 {
     int len;
@@ -247,6 +244,7 @@ static void memory_read_proc(uint8_t *dest, int size, uint32_t offset, emfat_ent
 
     memcpy(dest, &((char *)entry->user_data)[offset], len);
 }
+#endif
 
 static void bblog_read_proc(uint8_t *dest, int size, uint32_t offset, emfat_entry_t *entry)
 {

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -414,4 +414,6 @@ extern uint8_t _dmaram_end__;
 #define USE_ESCSERIAL_SIMONK
 #define USE_SERIAL_4WAY_SK_BOOTLOADER
 #define USE_DASHBOARD
+#define USE_EMFAT_AUTORUN
+#define USE_EMFAT_ICON
 #endif


### PR DESCRIPTION
PR removes `USE_EMFAT_AUTORUN` and `USE_EMFAT_ICON` on targets that has less than 512kB flash memory.

It help us to include important PRs on F411 and F722. We save around 2.8kB.


Unfortunately no more BF icon on Windows when connected through USB as a Mass Storage.