### PR TITLE
Fix SDFT batch size

### DIFF
--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -52,7 +52,7 @@ void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numB
     sdft->startBin = startBin;
     sdft->endBin = endBin;
     sdft->numBatches = numBatches;
-    sdft->batchSize = (sdft->endBin - sdft->startBin + 1) / sdft->numBatches + 1;
+    sdft->batchSize = (sdft->endBin - sdft->startBin) / sdft->numBatches + 1;  // batchSize = ceil(numBins / numBatches)
 
     for (int i = 0; i < SDFT_SAMPLE_SIZE; i++) {
         sdft->samples[i] = 0.0f;


### PR DESCRIPTION
# Fix SDFT batch size

Apparently I can't count correctly... As an example let's assume the following SDFT edge case:
```c
startBin = 5
endBin = 34
numBatches = 3
```

With this configuration we have **30 active bins**. If we want to compute one whole SDFT spectrum in **3 batches**, we could set the batchSize to 10 to optimally spread out the workload:
- **10 bins | 10 bins | 10 bins**

But on master the SDFT currently allocates it like this:
- **11 bins | 11 bins | 8 bins**

This PR corrects the mistake of making batchSize too big by +1 in edge cases and now correctly/optimally splits up the workload across the number of batches in every case.

## Example calculation

#### Master
```c
batchSize = (endBin - startBin + 1) / numBatches + 1
          = 30 / 3 + 1
          = 10 + 1
          = 11
```

#### PR
```c
batchSize = (endBin - startBin) / numBatches + 1
          = 29 / 3 + 1
          = 9 + 1
          = 10
```