### PR TITLE
Add github actions workflow to compare build size

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -1,0 +1,94 @@
+name: Build size report
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build targets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch toolchain from cache
+        uses: actions/cache@v2
+        id: cache-toolchain
+        with:
+          path: tools/
+          key: ${{ runner.os }}-${{ hashFiles('make/tools.mk') }}
+
+      - name: Fetch toolchain online
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
+        run: make arm_sdk_install
+
+      - name: Run sanity checks
+        run: make EXTRA_FLAGS=-Werror checks
+
+      - name: Build unified targets
+        run: make EXTRA_FLAGS=-Werror unified
+
+      - name: Create build size report
+        run: make size-report > size-report.json
+
+      - name: Archive size report
+        uses: actions/upload-artifact@v2
+        with:
+          name: size-report
+          path: size-report.json
+
+  size-report:
+    name: Create build size comparison report
+    if: github.event_name == 'pull_request'
+    needs: build
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch new size report
+        uses: actions/download-artifact@v2
+        with:
+          name: size-report
+
+      - name: Fetch base size report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: size-report.yml
+          commit: ${{ github.event.pull_request.base.sha }}
+          name: size-report
+          path: base
+
+      - name: Create build size change report
+        run: src/utils/compare-sizes.py base/size-report.json size-report.json > size-report.md
+
+      - name: Escape PR comment body
+        id: get-comment-body
+        run: |
+          body="$(cat size-report.md)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+
+      - name: Find PR Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Build size comparison:'
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Build size comparison: https://github.com/betaflight/betaflight/compare/${{ github.event.pull_request.base.sha }}...${{ github.sha }}
+            ${{ steps.get-comment-body.outputs.body }}
+          edit-mode: replace

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ CROSS_GDB   := $(ARM_SDK_PREFIX)gdb
 OBJCOPY     := $(ARM_SDK_PREFIX)objcopy
 OBJDUMP     := $(ARM_SDK_PREFIX)objdump
 READELF     := $(ARM_SDK_PREFIX)readelf
-SIZE        := $(ARM_SDK_PREFIX)size
+SIZE        := $(ARM_SDK_PREFIX)size -G
 DFUSE-PACK  := src/utils/dfuse-pack.py
 
 #
@@ -556,6 +556,9 @@ binary:
 
 hex:
 	$(V0) $(MAKE) -j $(TARGET_HEX)
+
+size-report:
+	$(V1) $(SIZE) $(OBJECT_DIR)/*.elf
 
 TARGETS_REVISION = $(addsuffix _rev,$(VALID_TARGETS))
 ## <TARGET>_rev    : build target and add revision to filename

--- a/src/utils/compare-sizes.py
+++ b/src/utils/compare-sizes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+import csv
+
+if len(sys.argv) != 3:
+    sys.exit('Must provide two size report file arguments')
+
+def read_size_report(file):
+    targets = {}
+    with open(file, newline='') as file:
+        reader = csv.DictReader(file, delimiter=' ', skipinitialspace=True)
+        for row in reader:
+            targetName = re.findall('_([^/]+).elf', row['filename'])[0]
+            targets[targetName] = target = {}
+            for key in ['text', 'data', 'bss']:
+                target[key] = int(row[key])
+
+    return targets
+
+reports = [read_size_report(sys.argv[1]), read_size_report(sys.argv[2])]
+
+def print_size_comparison(target):
+    print('| Region | Before | After | Difference |')
+    print('| ------ | ------ | ----- | ---------- |')
+    regionsA = reports[0][target]
+    regionsB = reports[1][target]
+    for region in regionsA:
+        if region not in regionsB:
+            continue
+
+        sizeA = regionsA[region]
+        sizeB = regionsB[region]
+        diff = sizeB - sizeA
+
+        items = [region, sizeA, sizeB, signed(diff)]
+        items = [str(item) for item in items]
+
+        print('|', ' | '.join(items), '|')
+
+def total_size_difference(target):
+    return sum(reports[1][target].values()) - sum(reports[0][target].values())
+
+def signed(int):
+    return f'{int:+d}' if int != 0 else 0
+
+def b(text):
+    return '**' + str(text) + '**'
+
+short_target = 'STM32F411'
+
+if short_target in reports[0] and short_target in reports[1]:
+    diff = total_size_difference(short_target)
+    print('Size for target', b(short_target), 'changed by:', b(signed(diff)), 'bytes')
+    print()
+
+print('<details>')
+print('<summary>Show all targets</summary>')
+print()
+
+for target in reports[0]:
+    if target not in reports[1]:
+        continue
+
+    diff = total_size_difference(target)
+    print(b(target), 'changed by', b(signed(diff)), 'bytes')
+    print()
+
+    if diff != 0:
+        print_size_comparison(target)
+        print()
+
+print('</details>')


### PR DESCRIPTION
This adds a CI workflow that comments on pull requests about how the build size changes.

See https://github.com/mathiasvr/betaflight/pull/1#issuecomment-991837778 for an example.

I failed to figure out how to invoke this from Azure pipelines so I included a build stage here as well.
If there is any interest in moving builds/releases to github actions I can help with that.
Otherwise I probably need help integrating this with Azure pipelines, or we can just run both.

Currently only unified targets are built and compared.

I also changed the current make size reports to use GNU format since I liked that better.

Before:
```
   text	   data	    bss	    dec	    hex	filename
 507471	   7632	 110916	 626019	  98d63	obj/main/betaflight_STM32F405.elf
 490943	   7320	 102112	 600375	  92937	obj/main/betaflight_STM32F411.elf
```
After:
```
      text       data        bss      total filename
    504336      10767     110916     626019 obj/main/betaflight_STM32F405.elf
    487920      10343     102112     600375 obj/main/betaflight_STM32F411.elf
```

This format does not show the total in additional hex format and read only data is included under data instead of text. I can change it back if preferred.
