### PR TITLE
Cache toolchain in Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,8 +44,15 @@ stages:
     pool:
       vmImage: '$(vmImage)'
     steps:
+    - task: Cache@2
+      inputs:
+        key: '"toolchain" | "$(Agent.OS)" | make/tools.mk'
+        path: tools/
+        cacheHitVar: CACHE_RESTORED
+      displayName: Restore toolchain from cache
     - script: make arm_sdk_install
       displayName: 'Install the build toolchain'
+      condition: ne(variables.CACHE_RESTORED, 'true')
     - script: sudo apt-get install -y libblocksruntime-dev
       displayName: 'Install extra packages'
     - script: make  EXTRA_FLAGS=-Werror checks


### PR DESCRIPTION
This caches the build toolchain in Azure pipelines so it doesn't have to download and install it for every build.