### PR TITLE
Only call sdCardAndFSInit() when SD card is in use

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -600,7 +600,14 @@ void init(void)
         ledInit(statusLedConfig());
 
 #ifdef USE_SDCARD
-        sdCardAndFSInit();
+        if (blackboxConfig()->device == BLACKBOX_DEVICE_SDCARD) {
+            if (sdcardConfig()->mode) {
+                if (!(initFlags & SD_INIT_ATTEMPTED)) {
+                    sdCardAndFSInit();
+                    initFlags |= SD_INIT_ATTEMPTED;
+                }
+            }
+        }
 #endif
 
 #if defined(USE_FLASHFS)


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11119

Tested on CLRACINGF7v2 and MATEKF722SE to prove operation with local FLASH or SD. Also tested on MATEKH743 to demonstrate that H7 SD operation is not impacted.