### PR TITLE
Fix FrSky D8 protocol bind issues

### DIFF
--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -229,7 +229,8 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
                     timeoutUs = 1;
                     if (packet[0] == 0x11) {
                         if ((packet[1] == rxCc2500SpiConfig()->bindTxId[0]) &&
-                            (packet[2] == rxCc2500SpiConfig()->bindTxId[1])) {
+                            (packet[2] == rxCc2500SpiConfig()->bindTxId[1]) &&
+                            (packet[5] == rxCc2500SpiConfig()->bindTxId[2])) {
                             rxSpiLedOn();
                             nextChannel(1);
                             cc2500setRssiDbm(packet[18]);

--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -339,8 +339,13 @@ static bool getBind(uint8_t *packet)
                     if (packet[5] == 0x00) {
                         rxCc2500SpiConfigMutable()->bindTxId[0] = packet[3];
                         rxCc2500SpiConfigMutable()->bindTxId[1] = packet[4];
-                        rxCc2500SpiConfigMutable()->bindTxId[2] = packet[11];
-                        rxCc2500SpiConfigMutable()->rxNum = packet[12];
+                        if (spiProtocol == RX_SPI_FRSKY_D) {
+                            rxCc2500SpiConfigMutable()->bindTxId[2] = packet[17];
+                            rxCc2500SpiConfigMutable()->rxNum = 0;
+                        } else {
+                            rxCc2500SpiConfigMutable()->bindTxId[2] = packet[11];
+                            rxCc2500SpiConfigMutable()->rxNum = packet[12];
+                        }
                     }
                     for (uint8_t n = 0; n < 5; n++) {
                          rxCc2500SpiConfigMutable()->bindHopData[packet[5] + n] = (packet[5] + n) >= 47 ? 0 : packet[6 + n];
@@ -491,6 +496,7 @@ bool frSkySpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeS
 
         handlePacket = frSkyDHandlePacket;
         setRcData = frSkyDSetRcData;
+        packetLength = FRSKY_RX_D8_LENGTH;
         frSkyDInit();
 
         break;

--- a/src/main/rx/cc2500_frsky_shared.h
+++ b/src/main/rx/cc2500_frsky_shared.h
@@ -33,9 +33,10 @@
 
 #define MAX_MISSING_PKT 100
 
-#define FRSKY_RX_D16FCC_LENGTH 0x1d + 3
-#define FRSKY_RX_D16LBT_LENGTH 0x20 + 3
-#define FRSKY_RX_D16v2_LENGTH  0x1d + 3
+#define FRSKY_RX_D8_LENGTH     (0x11 + 3)
+#define FRSKY_RX_D16FCC_LENGTH (0x1d + 3)
+#define FRSKY_RX_D16LBT_LENGTH (0x20 + 3)
+#define FRSKY_RX_D16v2_LENGTH  (0x1d + 3)
 
 enum {
     STATE_INIT = 0,


### PR DESCRIPTION
This should fix bind issues with FrSky D8 protocol. Bug was introduced in: https://github.com/betaflight/betaflight/pull/9697
See also: https://github.com/betaflight/betaflight/issues/11125
Tested with Devo10, MPM, AlienflightNG_RX prototype and D8 protocol. More D8 tests are recommended. There are no changes for the other FrSky protocols.
