### PR TITLE
Remove shared MSP buffer

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -391,10 +391,10 @@ static int mspSerialEncode(mspPort_t *msp, mspPacket_t *packet, mspVersion_e msp
     return mspSerialSendFrame(msp, hdrBuf, hdrLen, sbufPtr(&packet->buf), dataLen, crcBuf, crcLen);
 }
 
-uint8_t mspSerialOutBuf[MSP_PORT_OUTBUF_SIZE];   // this buffer also used in msp_shared.c
-
 static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspProcessCommandFnPtr mspProcessCommandFn)
 {
+    static uint8_t mspSerialOutBuf[MSP_PORT_OUTBUF_SIZE];
+
     mspPacket_t reply = {
         .buf = { .ptr = mspSerialOutBuf, .end = ARRAYEND(mspSerialOutBuf), },
         .cmd = -1,

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -124,5 +124,3 @@ void mspSerialReleasePortIfAllocated(struct serialPort_s *serialPort);
 void mspSerialReleaseSharedTelemetryPorts(void);
 int mspSerialPush(serialPortIdentifier_e port, uint8_t cmd, uint8_t *data, int datalen, mspDirection_e direction);
 uint32_t mspSerialTxBytesFree(void);
-
-extern uint8_t mspSerialOutBuf[MSP_PORT_OUTBUF_SIZE];   // this buffer also used in msp_shared.c

--- a/src/main/telemetry/msp_shared.h
+++ b/src/main/telemetry/msp_shared.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#define MSP_TLM_INBUF_SIZE 128
+#define MSP_TLM_OUTBUF_SIZE 128
+
 // type of function to send MSP response chunk over telemetry.
 typedef void (*mspResponseFnPtr)(uint8_t *payload, const uint8_t payloadSize);
 

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -51,7 +51,6 @@ extern "C" {
     #include "io/gps.h"
 
     #include "msp/msp.h"
-    #include "msp/msp_serial.h"
 
     #include "rx/rx.h"
     #include "rx/crsf.h"
@@ -88,7 +87,7 @@ extern "C" {
 
     extern bool crsfFrameDone;
     extern crsfFrame_t crsfFrame;
-    extern uint8_t requestBuffer[MSP_PORT_INBUF_SIZE];
+    extern uint8_t requestBuffer[MSP_TLM_INBUF_SIZE];
     extern struct mspPacket_s requestPacket;
     extern struct mspPacket_s responsePacket;
 
@@ -254,7 +253,7 @@ extern "C" {
 
     gpsSolutionData_t gpsSol;
     attitudeEulerAngles_t attitude = { { 0, 0, 0 } };
-    uint8_t mspSerialOutBuf[MSP_PORT_OUTBUF_SIZE];
+    uint8_t responseBuffer[MSP_TLM_OUTBUF_SIZE];
 
     uint32_t micros(void) {return dummyTimeUs;}
     uint32_t microsISR(void) {return micros();}


### PR DESCRIPTION
It didn't work quite as intended. What happens is that when this is used both by serial msp and msp over telemetry we'll have a conflict. A MSP over telemetry response could be written to the buffer only to be overwritten by the response to a request from the configurator before it's sent. This wasn't obvious with crossfire because responses are sent very quickly, but it's very clear that it's not working as it should when using smartport/fport. 

Made separate buffers for serial msp and telemetry msp like it used to be. Reduced the size of the input buffer from 196 to 128 bytes and made the output buffer for telemetry msp 128 bytes. The result is a 8 byte increase in flash use on a F722. 
