### PR TITLE
If GPS serial data remains, reschedule task to run again after 1ms

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -489,7 +489,7 @@ task_t tasks[TASK_COUNT] = {
 #endif
 
 #ifdef USE_GPS
-    [TASK_GPS] = DEFINE_TASK("GPS", NULL, NULL, gpsUpdate, TASK_PERIOD_HZ(100), TASK_PRIORITY_MEDIUM), // Required to prevent buffer overruns if running at 115200 baud (115 bytes / period < 256 bytes buffer)
+    [TASK_GPS] = DEFINE_TASK("GPS", NULL, NULL, gpsUpdate, TASK_PERIOD_HZ(TASK_GPS_RATE), TASK_PRIORITY_MEDIUM), // Required to prevent buffer overruns if running at 115200 baud (115 bytes / period < 256 bytes buffer)
 #endif
 
 #ifdef USE_MAG

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -180,6 +180,9 @@ extern uint8_t GPS_svinfo_cno[16];         // Carrier to Noise Ratio (Signal Str
 #define GPS_DBHZ_MIN 0
 #define GPS_DBHZ_MAX 55
 
+#define TASK_GPS_RATE       100
+#define TASK_GPS_RATE_FAST  1000
+
 void gpsInit(void);
 void gpsUpdate(timeUs_t currentTimeUs);
 bool gpsNewFrame(uint8_t c);


### PR DESCRIPTION
Potential fix for https://github.com/betaflight/betaflight/pull/10921.

This PR breaks draining the GPS serial buffer into a burst, each of a max 30us at 1ms intervals as shown below.

![image](https://user-images.githubusercontent.com/11480839/146690201-1b6aea83-0f37-4e76-ab61-f6e5070ea2ae.png)

Each call lasts ~30us so doesn't break determinism.

![image](https://user-images.githubusercontent.com/11480839/146690237-7c78921d-fb5e-4cba-b568-8c68c4e944ff.png)
