### PR TITLE
Increase task guard margin to 3us

### DIFF
--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -36,7 +36,7 @@
 #define SCHED_START_LOOP_DOWN_STEP      50  // Fraction of a us to reduce start loop wait
 #define SCHED_START_LOOP_UP_STEP        1   // Fraction of a us to increase start loop wait
 
-#define TASK_GUARD_MARGIN_MIN_US        1   // Add an amount to the estimate of a task duration
+#define TASK_GUARD_MARGIN_MIN_US        3   // Add an amount to the estimate of a task duration
 #define TASK_GUARD_MARGIN_MAX_US        6
 #define TASK_GUARD_MARGIN_DOWN_STEP     50  // Fraction of a us to reduce task guard margin
 #define TASK_GUARD_MARGIN_UP_STEP       1   // Fraction of a us to increase task guard margin


### PR DESCRIPTION
Minor tweak to scheduler task margin. This is added to the scheduler's estimation of how long a task will take in considering if it should be run or not. This only has any impact at the end of a 125us cycle. Increasing it to 3us accommodates any interrupts that may occur during the last task executed in the gyro loop before the next invocation of the gyro task.