### PR TITLE
Disable GYRO_EXTI on boards with Gyro and OSD on same SPI channel

### DIFF
--- a/src/main/target/KROOZX/target.h
+++ b/src/main/target/KROOZX/target.h
@@ -43,7 +43,8 @@
 // MPU6000 interrupts
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
-#define USE_GYRO_EXTI
+// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
+// #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PA4
 
 #define USE_GYRO

--- a/src/main/target/NOX/target.h
+++ b/src/main/target/NOX/target.h
@@ -44,9 +44,12 @@
 #define GYRO_1_CS_PIN           PB12
 #define GYRO_1_SPI_INSTANCE     SPI2
 
+
 #define USE_EXTI
-#define USE_GYRO_EXTI
+// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
+// #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PA8
+
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_BARO

--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -85,7 +85,10 @@
 
 // MPU6000 interrupts
 #define USE_EXTI
+// disable EXTI when MAX7456 is on same SPI bus as gyro
+#if defined(OMNIBUSF4V6)
 #define USE_GYRO_EXTI
+#endif
 #define GYRO_1_EXTI_PIN         PC4
 #define GYRO_2_EXTI_PIN         NONE
 #define USE_MPU_DATA_READY_SIGNAL

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -37,7 +37,8 @@
 // Gyro interrupt
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
-#define USE_GYRO_EXTI
+// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
+// #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4
 
 #define USE_ACC

--- a/src/main/target/YUPIF7/target.h
+++ b/src/main/target/YUPIF7/target.h
@@ -40,7 +40,8 @@
 #define SPI1_MOSI_PIN           PA7
 
 #define USE_EXTI
-#define USE_GYRO_EXTI
+// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
+// #define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4
 
 #define USE_MPU_DATA_READY_SIGNAL


### PR DESCRIPTION
With current master, `NOX` boards (not all, but some) have an issue where the gyro abruptly, and randomly, goes nuts.

It is definitely related to gyro EXTI sync to the CPU, since if we disable EXTI sync, the problem disappears.  

It appears to have started with #10997 but we haven't isolated a fix yet.  The only known affected board is the NOX, but it may potentially affect any board where GYRO and OSD share the same bus.  Only This PR disables EXTI support for the five legacy targets that could possibly be affected.

It is a temporary fix until @SteveCEvans can figure out exactly why the NOX board is particularly affected. 

I've made an equivalent [PR 544](https://github.com/betaflight/unified-targets/pull/544) for the Unified Targets that may have the same problem.