### PR TITLE
Rename identifiers for F40x unified target

### DIFF
--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -21,9 +21,9 @@
 #pragma once
 
 #if defined(STM32F405)
-#define TARGET_BOARD_IDENTIFIER "S405"
+#define TARGET_BOARD_IDENTIFIER "S40X"
 
-#define USBD_PRODUCT_STRING     "Betaflight STM32F405"
+#define USBD_PRODUCT_STRING     "Betaflight STM32F40x"
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2


### PR DESCRIPTION
~~As we now support H743 and G47x chips as unified targets and they were named as ``S<line><part number>`` like ``SG47`` and ``SH74``, clean up old F line chips' unified target identifier to follow the rules above.~~

If this is gonna be moved to 4.4, I'll reuse this PR to fix the name for F40x target.

As in tests for https://github.com/betaflight/unified-targets/pull/527, I've found that the current "F405" unified target can be smoothly used on STM32F407 without any bug, so rename this.