### PR TITLE
Enhance SDFT noise floor

### DIFF
--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -150,7 +150,7 @@ static FAST_DATA_ZERO_INIT float   sdftSampleRateHz;
 static FAST_DATA_ZERO_INIT float   sdftResolutionHz;
 static FAST_DATA_ZERO_INIT int     sdftStartBin;
 static FAST_DATA_ZERO_INIT int     sdftEndBin;
-static FAST_DATA_ZERO_INIT float   sdftMeanSq;
+static FAST_DATA_ZERO_INIT float   sdftNoiseThreshold;
 static FAST_DATA_ZERO_INIT float   pt1LooptimeS;
 
 
@@ -259,22 +259,21 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
 
     switch (state.step) {
     
-        case STEP_WINDOW: // 6us @ F722
+        case STEP_WINDOW: // 4.1us (3-6us) @ F722
         {
             sdftWinSq(&sdft[state.axis], sdftData);
             
-            // Calculate mean square over frequency range (= average power of vibrations)
-            sdftMeanSq = 0.0f;
+            // Get total vibrational power in dyn notch range for noise floor estimate in STEP_CALC_FREQUENCIES
+            sdftNoiseThreshold = 0.0f;
             for (int bin = (sdftStartBin + 1); bin < sdftEndBin; bin++) {   // don't use startBin or endBin because they are not windowed properly
-                sdftMeanSq += sdftData[bin];                                // sdftData is already squared (see sdftWinSq)
+                sdftNoiseThreshold += sdftData[bin];                        // sdftData contains power spectral density
             }
-            sdftMeanSq /= sdftEndBin - sdftStartBin - 1;
 
             DEBUG_SET(DEBUG_FFT_TIME, 1, micros() - startTime);
 
             break;
         }
-        case STEP_DETECT_PEAKS: // 6us @ F722
+        case STEP_DETECT_PEAKS: // 5.5us (4-7us) @ F722
         {
             // Get memory ready for new peak data on current axis
             for (int p = 0; p < dynNotch.count; p++) {
@@ -319,12 +318,27 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
 
             break;
         }
-        case STEP_CALC_FREQUENCIES: // 4us @ F722
+        case STEP_CALC_FREQUENCIES: // 4.0us (2-7us) @ F722
         {
+            // Approximate noise floor (= average power spectral density in dyn notch range, excluding peaks)
+            int peakCount = 0;
+            for (int p = 0; p < dynNotch.count; p++) {
+                if (peaks[p].bin != 0) {
+                    sdftNoiseThreshold -= 0.75f * sdftData[peaks[p].bin - 1];
+                    sdftNoiseThreshold -= sdftData[peaks[p].bin];
+                    sdftNoiseThreshold -= 0.75f * sdftData[peaks[p].bin + 1];
+                    peakCount++;
+                }
+            }
+            sdftNoiseThreshold /= sdftEndBin - sdftStartBin - peakCount - 1;
+
+            // A noise threshold 2 times the noise floor prevents peak tracking being too sensitive to noise
+            sdftNoiseThreshold *= 2.0f;
+
             for (int p = 0; p < dynNotch.count; p++) {
 
                 // Only update dynNotch.centerFreq if there is a peak (ignore void peaks) and if peak is above noise floor
-                if (peaks[p].bin != 0 && peaks[p].value > sdftMeanSq) {
+                if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
 
                     float meanBin = peaks[p].bin;
 
@@ -343,7 +357,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
                     const float centerFreq = constrainf(meanBin * sdftResolutionHz, dynNotch.minHz, dynNotch.maxHz);
 
                     // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 10x faster 
-                    const float cutoffMult = constrainf(peaks[p].value / sdftMeanSq, 1.0f, 10.0f);
+                    const float cutoffMult = constrainf(peaks[p].value / sdftNoiseThreshold, 1.0f, 10.0f);
                     const float gain = pt1FilterGain(DYN_NOTCH_SMOOTH_HZ * cutoffMult, pt1LooptimeS); // dynamic PT1 k value
 
                     // Finally update notch center frequency p on current axis
@@ -368,11 +382,11 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
 
             break;
         }
-        case STEP_UPDATE_FILTERS: // 7us @ F722
+        case STEP_UPDATE_FILTERS: // 5.4us (2-9us) @ F722
         {
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
-                if (peaks[p].bin != 0 && peaks[p].value > sdftMeanSq) {
+                if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
                     biquadFilterUpdate(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.looptimeUs, dynNotch.q, FILTER_NOTCH, 1.0f);
                 }
             }


### PR DESCRIPTION
# General

While developing the new dynamic notch I mainly optimized it while having the RPM filter enabled. But when the RPM filter is disabled there are very high noise peaks in the dyn notch range (caused by the rotating motors and props).

My initial "lazy" approximation of the noise floor is not ideal to accommodate this. The motor noise peaks carry so much power that they will significantly raise the noise floor up over its "true" value and some small peaks may be invisible to the tracking algorithm.

This PR makes the noise floor approximation a lot more robust and ignores already detected peaks.


# RMS vs. noiseFloor

Below you can see the old "lazy" approximation (**RMS**) and the new approximation (**noiseFloor**). Big peaks no longer influence the noise floor significantly. Note that the PR uses a threshold 2x the noise floor to make sure a new found peak is very likely distinguishable from noise.

![sim_transparent](https://user-images.githubusercontent.com/19867640/146886561-51f05449-e619-45c4-8131-da50732b6a0a.gif)


# Comparison to master

Compared to current master, with this PR the notches (red lines) stick to the small 2nd and 3rd motor harmonics a bit better, as you can see.

### PR
![01_PR](https://user-images.githubusercontent.com/19867640/146886888-4f8bbbd0-eae0-431d-971a-3181a5229afa.png)

### Master
![00_master](https://user-images.githubusercontent.com/19867640/146886876-fc7c5b07-773d-4df0-823a-cb869b488e3e.png)



