### PR TITLE
Get rid of double math on <512kB targets

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -727,8 +727,8 @@ static void osdElementUpDownReference(osdElementParms_t *element)
             psiB = earthUpinBodyFrame[1]; // calculate the yaw w/re to zenith (use small angle approx for sine)
             direction = UP;
         }
-        int posX = element->elemPosX + round(scaleRangef(psiB, -M_PIf / 4, M_PIf / 4, -14, 14));
-        int posY = element->elemPosY + round(scaleRangef(thetaB, -M_PIf / 4, M_PIf / 4, -8, 8));
+        int posX = element->elemPosX + lrintf(scaleRangef(psiB, -M_PIf / 4, M_PIf / 4, -14, 14));
+        int posY = element->elemPosY + lrintf(scaleRangef(thetaB, -M_PIf / 4, M_PIf / 4, -8, 8));
 
         osdDisplayWrite(element, posX, posY, DISPLAYPORT_ATTR_NONE, symbol[direction]);
     }


### PR DESCRIPTION
We have postponed #11102 so I have created new PR just with two lines to get rid of double math.
Need to merge with #11134 to additionally save around 1.2kB on <512kB.

Credits: @mathiasvr 

This PR with #11134
```
Linking STM32F411 
          FLASH1:      484171 B       480 KB     98.50%
```

```
arm-none-eabi-gcc-nm --size-sort --radix=d obj/main/betaflight_STM32F411.elf| grep __ | tail -n 15
00000012 T __math_uflowf
00000016 d __compound_literal.0.lto_priv.9
00000016 d __compound_literal.1.lto_priv.8
00000016 d __compound_literal.2.lto_priv.8
00000036 T __NVIC_SystemReset.lto_priv.0.lto_priv.0
00000036 T __NVIC_SystemReset.lto_priv.1.lto_priv.0
00000036 T __NVIC_SystemReset.lto_priv.2.lto_priv.0
00000040 T __popcountsi2
00000080 T __strtok_r
00000144 T __kernel_sinf
00000260 T __kernel_cosf
00000612 T __ieee754_rem_pio2f
00000720 T __udivmoddi4
00001576 T __ieee754_powf
00001652 T __kernel_rem_pio2f
```


Master with #11134
```
Linking STM32F411 
          FLASH1:      485367 B       480 KB     98.75%
```

```
arm-none-eabi-gcc-nm --size-sort --radix=d obj/main/betaflight_STM32F411.elf| grep __ | tail -n 15
00000080 T __strtok_r
00000090 T __aeabi_l2d
00000090 T __floatdidf
00000106 T __aeabi_ul2d
00000106 T __floatundidf
00000144 T __kernel_sinf
00000260 T __kernel_cosf
00000612 T __ieee754_rem_pio2f
00000630 T __adddf3
00000630 T __aeabi_dadd
00000634 T __aeabi_dsub
00000634 T __subdf3
00000720 T __udivmoddi4
00001576 T __ieee754_powf
00001652 T __kernel_rem_pio2f
```