### PR TITLE
ExpressLRS - bumped task priority to realtime

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -481,7 +481,11 @@ task_t tasks[TASK_COUNT] = {
     [TASK_ACCEL] = DEFINE_TASK("ACC", NULL, NULL, taskUpdateAccelerometer, TASK_PERIOD_HZ(1000), TASK_PRIORITY_MEDIUM),
     [TASK_ATTITUDE] = DEFINE_TASK("ATTITUDE", NULL, NULL, imuUpdateAttitude, TASK_PERIOD_HZ(100), TASK_PRIORITY_MEDIUM),
 #endif
+#ifdef USE_RX_EXPRESSLRS
+    [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(33), TASK_PRIORITY_REALTIME),
+#else
     [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(33), TASK_PRIORITY_HIGH), // If event-based scheduling doesn't work, fallback to periodic scheduling
+#endif
     [TASK_DISPATCH] = DEFINE_TASK("DISPATCH", NULL, NULL, dispatchProcess, TASK_PERIOD_HZ(1000), TASK_PRIORITY_HIGH),
 
 #ifdef USE_BEEPER

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -442,10 +442,23 @@ FAST_CODE void scheduler(void)
     uint32_t nextTargetCycles = 0;
     int32_t schedLoopRemainingCycles;
 
+    nowCycles = getCycleCounter();
+    currentTimeUs = clockCyclesToMicros(nowCycles);
+
+#ifdef USE_RX_EXPRESSLRS
+    bool rxTaskRan = false;
+    task_t *rxTask = getTask(TASK_RX);
+    if (rxTask->checkFunc(currentTimeUs, cmpTimeUs(currentTimeUs, rxTask->lastExecutedAtUs))) {
+        taskExecutionTimeUs = schedulerExecuteTask(rxTask, currentTimeUs);
+        rxTaskRan = true;
+    }
+
+    if (gyroEnabled && !rxTaskRan) {
+#else
     if (gyroEnabled) {
+#endif
         // Realtime gyro/filtering/PID tasks get complete priority
         task_t *gyroTask = getTask(TASK_GYRO);
-        nowCycles = getCycleCounter();
 #if defined(UNIT_TEST)
         lastTargetCycles = clockMicrosToCycles(gyroTask->lastExecutedAtUs);
 #endif
@@ -480,7 +493,6 @@ FAST_CODE void scheduler(void)
             }
             DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 0, clockCyclesTo10thMicros(cmpTimeCycles(nowCycles, lastTargetCycles)));
 #endif
-            currentTimeUs = clockCyclesToMicros(nowCycles);
             taskExecutionTimeUs += schedulerExecuteTask(gyroTask, currentTimeUs);
 
             if (gyroFilterReady()) {


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/11153

Bumped task priority for expresslrs code to realtime to avoid race conditions with other tasks. This is based on user feedback in PR #10788.

@AndreaCCIE @turboed13b @CarloGaz @wang322588 @betafpv-engineer and others -  I'd appreciate if you confirmed this solves your issues.

[betaflight_4.3.0_BETAFPVF4SX1280_7c9e5ac8e.zip](https://github.com/betaflight/betaflight/files/7773944/betaflight_4.3.0_BETAFPVF4SX1280_7c9e5ac8e.zip)
[betaflight_4.3.0_CRAZYBEEF4SX1280_7c9e5ac8e.zip](https://github.com/betaflight/betaflight/files/7773945/betaflight_4.3.0_CRAZYBEEF4SX1280_7c9e5ac8e.zip)
