### PR TITLE
Add DMA support for ICM-42688-P

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -125,6 +125,8 @@ typedef struct gyroDev_s {
     fp_rotationMatrix_t rotationMatrix;
     uint16_t gyroSampleRateHz;
     uint16_t accSampleRateHz;
+    uint8_t accDataReg;
+    uint8_t gyroDataReg;
 } gyroDev_t;
 
 typedef struct accDev_s {

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -325,13 +325,13 @@ bool mpuGyroReadSPI(gyroDev_t *gyro)
     case GYRO_EXTI_INT_DMA:
     {
         // Acc and gyro data may not be continuous (MPU6xxx has temperature in between)
-        uint8_t gyroDataIndex = ((gyro->gyroDataReg - gyro->accDataReg) >> 1) + 1;
+        const uint8_t gyroDataIndex = ((gyro->gyroDataReg - gyro->accDataReg) >> 1) + 1;
 
         // If read was triggered in interrupt don't bother waiting. The worst that could happen is that we pick
         // up an old value.
-        gyro->gyroADCRaw[X] = __builtin_bswap16(gyroData[gyroDataIndex++]);
-        gyro->gyroADCRaw[Y] = __builtin_bswap16(gyroData[gyroDataIndex++]);
-        gyro->gyroADCRaw[Z] = __builtin_bswap16(gyroData[gyroDataIndex]);
+        gyro->gyroADCRaw[X] = __builtin_bswap16(gyroData[gyroDataIndex]);
+        gyro->gyroADCRaw[Y] = __builtin_bswap16(gyroData[gyroDataIndex + 1]);
+        gyro->gyroADCRaw[Z] = __builtin_bswap16(gyroData[gyroDataIndex + 2]);
         break;
     }
 


### PR DESCRIPTION
Add DMA support for the [ICM-42688-P](https://invensense.tdk.com/download-pdf/icm-42688-p-datasheet/) as used and tested on the [SPRACINGH7RF](http://seriouslypro.com/files/SPRacingH7RF-Manual-latest.pdf).