### PR TITLE
Reduce number of OSD bytes transferred in polled mode

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -205,7 +205,7 @@ static uint8_t shadowBuffer[VIDEO_BUFFER_CHARS_PAL];
 //Max bytes to update in one call to max7456DrawScreen()
 
 #define MAX_BYTES2SEND          250
-#define MAX_BYTES2SEND_POLLED   25
+#define MAX_BYTES2SEND_POLLED   20
 
 static DMA_DATA uint8_t spiBuf[MAX_BYTES2SEND];
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1151,7 +1151,7 @@ void osdUpdate(timeUs_t currentTimeUs)
         osdUpdateAlarms();
 
         if (resumeRefreshAt) {
-            osdState = OSD_STATE_IDLE;
+            osdState = OSD_STATE_TRANSFER;
         } else {
             osdState = OSD_STATE_UPDATE_CANVAS;
         }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -709,7 +709,7 @@ TEST_F(OsdTest, TestAlarms)
     // elements showing values in alarm range should flash
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    timeUs_t startTime = simulationTime;
+    timeUs_t startTime = simulationTime + 0.25e6;
     for (int i = 0; i < 15; i++) {
         // Blinking should happen at 2Hz
         simulationTime = startTime + i*0.25e6;
@@ -1083,7 +1083,6 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    simulationTime += 0.25e6;
     osdRefresh();
 
     // then
@@ -1099,7 +1098,6 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    simulationTime += 0.25e6;
     osdRefresh();
 
     // then
@@ -1206,7 +1204,7 @@ TEST_F(OsdTest, TestGpsElements)
     // Sat indicator should blink and show "NC"
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    timeUs_t startTime = simulationTime;
+    timeUs_t startTime = simulationTime + 0.25e6;
     for (int i = 0; i < 15; i++) {
         // Blinking should happen at 2Hz
         simulationTime = startTime + i*0.25e6;
@@ -1230,7 +1228,7 @@ TEST_F(OsdTest, TestGpsElements)
     // Sat indicator should blink and show "0"
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    startTime = simulationTime;
+    startTime = simulationTime + 0.25e6;
     for (int i = 0; i < 15; i++) {
         // Blinking should happen at 2Hz
         simulationTime = startTime + i*0.25e6;


### PR DESCRIPTION
When using polled mode for the MAX7456 OSD the driver tries to transfer as many bytes as possible up to a limit. If this limit is set too high then the transfer takes too long and the scheduler won't run the OSD task often enough as there won't be as many opportunities to do so and meet timings.

This PR reduces the maximum number of bytes to transfer which fixes the problem reported in https://github.com/betaflight/betaflight/issues/11167. This will result in more attempts being needed to update the OSD, increasing CPU usage.

Note that `set cpu_overclock=120MHz` must be used to ensure that there is enough time within a gyro cycle to schedule the OSD task often enough.