### PR TITLE
Add support for Omron 2SMBP-02B barometer

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -295,6 +295,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             drivers/barometer/barometer_ms5611.c \
             drivers/barometer/barometer_lps.c \
             drivers/barometer/barometer_qmp6988.c \
+            drivers/barometer/barometer_2smpb_02b.c \
             drivers/bus_i2c_config.c \
             drivers/bus_i2c_timing.c \
             drivers/bus_spi_config.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -150,7 +150,7 @@ const char * const lookupTableGyroHardware[] = {
 #if defined(USE_SENSOR_NAMES) || defined(USE_BARO)
 // sync with baroSensor_e
 const char * const lookupTableBaroHardware[] = {
-    "AUTO", "NONE", "BMP085", "MS5611", "BMP280", "LPS", "QMP6988", "BMP388", "DPS310"
+    "AUTO", "NONE", "BMP085", "MS5611", "BMP280", "LPS", "QMP6988", "BMP388", "DPS310", "2SMPB_02B"
 };
 #endif
 #if defined(USE_SENSOR_NAMES) || defined(USE_MAG)

--- a/src/main/drivers/barometer/barometer_2smpb_02b.c
+++ b/src/main/drivers/barometer/barometer_2smpb_02b.c
@@ -1,0 +1,321 @@
+/*
+ * This file is part of Cleanflight, Betaflight and INAV.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright: INAVFLIGHT OU
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+#include "build/debug.h"
+#include "common/utils.h"
+
+#include "drivers/io.h"
+#include "drivers/bus.h"
+#include "drivers/bus_spi.h"
+#include "drivers/time.h"
+#include "drivers/barometer/barometer.h"
+#include "drivers/resource.h"
+
+#include "barometer_2smpb_02b.h"
+
+// 10 MHz max SPI frequency
+#define BARO_2SMBP_MAX_SPI_CLK_HZ 10000000
+
+#if defined(USE_BARO) && defined(USE_BARO_2SMBP_02B)
+
+#define BARO_2SMBP_I2C_ADDRESS 0x70
+
+#define BARO_2SMBP_CHIP_ID 0x5C
+
+#define REG_CHIP_ID 0xD1
+#define REG_RESET 0xE0
+
+#define REG_COE_PR11 0xA0
+#define REG_COE_PR21 0xA3
+#define REG_COE_PR31 0xA5
+#define REG_COE_TEMP11 0xA7
+#define REG_COE_TEMP21 0xA9
+#define REG_COE_TEMP31 0xAB
+#define REG_COE_PTAT11 0xAD
+#define REG_COE_PTAT21 0xB1
+#define REG_COE_PTAT31 0xB3
+
+#define REG_IIR_CNT 0xF1
+#define REG_DEVICE_STAT 0xF3
+#define REG_CTRL_MEAS 0xF4
+#define REG_IO_SETUP 0xF5
+#define REG_PRESS_TXD2 0xF7
+
+// Value for CTRL_MEAS with 4x temperature averaging, 32x perssure, forced mode
+#define REG_CLT_MEAS_VAL_TAVG4X_PAVG32X_FORCED ((0x03 << 5) | (0x05 << 2) | 0x01)
+
+// IIR coefficient setting 8x
+#define REG_IIR_CNT_VAL_8X 0x03
+
+typedef struct {
+    float aa;
+    float ba;
+    int32_t ca;
+    float ap;
+    float bp;
+    int32_t cp;
+    float at;
+    float bt;
+    float ct;
+} calibrationCoefficients_t;
+
+typedef struct {
+    calibrationCoefficients_t   calib;
+    float                       pressure;       // Pa
+    float                       temperature;    // DegC
+} baroState_t;
+
+static baroState_t  baroState;
+static uint8_t baroDataBuf[6];
+
+
+static int32_t readSignedRegister(const extDevice_t *dev, uint8_t reg, uint8_t nBytes)
+{
+    uint8_t buf[3];
+    uint32_t rawValue = 0;
+
+    busReadRegisterBuffer(dev, reg, &buf[0], nBytes);
+
+    for (int i=0; i<nBytes; i++) {
+        rawValue += (uint32_t)buf[i] << (8 * (nBytes - i - 1));
+    }
+
+    // 2's complement
+    if (rawValue & ((int32_t)1 << (8 * nBytes - 1))) {
+        // Negative
+        return ((int32_t)rawValue) - ((int32_t)1 << (8 * nBytes));
+    }
+    else {
+        return rawValue;
+    }
+}
+
+static int32_t getSigned24bitValue(uint8_t * pData)
+{
+    uint32_t raw;
+
+    raw = (((uint32_t)pData[0] << 16) | ((uint32_t)pData[1] << 8) | (uint32_t)pData[2]) - ((uint32_t)1 << 23);
+
+    return raw;
+}
+
+static bool deviceConfigure(const extDevice_t *dev)
+{
+    /** Note: Chip reset causes I2C error due missing ACK. This causes interrupt based read (busReadRegisterBufferStart)
+        to not work (read stops due to error flags). It works fine without chip reset. **/
+
+    //busWriteRegister(busDev, REG_RESET, 0xE6);
+
+    // No need to write IO_SETUP register: default values are fine
+
+    // Read calibration coefficients and scale them
+    baroState.calib.aa = (4.2e-4f  * readSignedRegister(dev, REG_COE_PTAT31, 2)) / 32767;
+    baroState.calib.ba = (8.0e0f  * readSignedRegister(dev, REG_COE_PTAT21, 2)) / 32767 - 1.6e2f;
+    baroState.calib.ca = readSignedRegister(dev, REG_COE_PTAT11, 3);
+    baroState.calib.ap = (3.0e-5f  * readSignedRegister(dev, REG_COE_PR31, 2)) / 32767;
+    baroState.calib.bp = (10 * readSignedRegister(dev, REG_COE_PR21, 2)) / 32767 + 3.0e1f;
+    baroState.calib.cp = readSignedRegister(dev, REG_COE_PR11, 3);
+    baroState.calib.at = (8.0e-11f  * readSignedRegister(dev, REG_COE_TEMP31, 2)) / 32767;
+    baroState.calib.bt = (1.6e-6f  * readSignedRegister(dev, REG_COE_TEMP21, 2)) / 32767 - 6.6e-6f;
+    baroState.calib.ct = (8.5e-3f  * readSignedRegister(dev, REG_COE_TEMP11, 2)) / 32767 + 4.0e-2f;
+
+    // Configure IIR filter
+    busWriteRegister(dev, REG_IIR_CNT, REG_IIR_CNT_VAL_8X);
+
+    return true;
+}
+
+#define DETECTION_MAX_RETRY_COUNT   5
+static bool deviceDetect(const extDevice_t *dev)
+{
+    for (int retry = 0; retry < DETECTION_MAX_RETRY_COUNT; retry++) {
+        uint8_t chipId;
+
+        chipId = busReadRegister(dev, REG_CHIP_ID);
+
+        if (chipId == BARO_2SMBP_CHIP_ID) {
+            return true;
+        }
+
+        delay(50);
+    };
+
+    return false;
+}
+
+static void deviceInit(const extDevice_t *dev, resourceOwner_e owner)
+{
+#ifdef USE_BARO_SPI_2SMBP_02B
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        IOHi(dev->busType_u.spi.csnPin); // Disable
+        IOInit(dev->busType_u.spi.csnPin, owner, 0);
+        IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetClkDivisor(dev, spiCalculateDivider(BARO_2SMBP_MAX_SPI_CLK_HZ));
+    }
+#else
+    UNUSED(dev);
+    UNUSED(owner);
+#endif
+}
+
+static void busDeviceDeInit(const extDevice_t *dev)
+{
+#ifdef USE_BARO_SPI_2SMBP_02B
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        spiPreinitByIO(dev->busType_u.spi.csnPin);
+    }
+#else
+    UNUSED(dev);
+#endif
+}
+
+static void b2smpbStartUP(baroDev_t *baro)
+{
+    // start a forced measurement
+    busWriteRegister(&baro->dev, REG_CTRL_MEAS, REG_CLT_MEAS_VAL_TAVG4X_PAVG32X_FORCED);
+}
+
+static bool b2smpbReadUP(baroDev_t *baro)
+{
+    if (busBusy(&baro->dev, NULL)) {
+        return false;
+    }
+
+    // Start reading temperature and pressure data
+    busReadRegisterBufferStart(&baro->dev, REG_PRESS_TXD2, &baroDataBuf[0], 6);
+
+    return true;
+}
+
+static bool b2smpbGetUP(baroDev_t *baro)
+{
+    int32_t dtp;
+    float tr, pl, tmp;
+
+    if (busBusy(&baro->dev, NULL)) {
+        return false;
+    }
+
+    // Calculate compensated temperature
+    dtp = getSigned24bitValue(&baroDataBuf[3]);
+
+    tmp = baroState.calib.ba * baroState.calib.ba;
+    tr = (-1 * baroState.calib.ba - sqrtf(tmp - 4 * baroState.calib.aa * (baroState.calib.ca - dtp))) / (2 * baroState.calib.aa);
+    baroState.temperature = tr / 256;
+
+    // Calculate raw pressure
+    dtp = getSigned24bitValue(&baroDataBuf[0]);
+
+    tmp = baroState.calib.bp * baroState.calib.bp;
+    pl = (sqrtf(tmp - 4 * baroState.calib.ap * (baroState.calib.cp - dtp)) - baroState.calib.bp) / (2 * baroState.calib.ap);
+
+    // Calculate temperature compensated pressure
+    tmp = tr * tr;
+    baroState.pressure = pl / (baroState.calib.at * tmp + baroState.calib.bt * tr + baroState.calib.ct + 1);
+
+    return true;
+}
+
+static void b2smpbStartUT(baroDev_t *baro)
+{
+    UNUSED(baro);
+}
+
+static bool b2smpbReadUT(baroDev_t *baro)
+{
+    UNUSED(baro);
+
+    return true;
+}
+
+static bool b2smpbGetUT(baroDev_t *baro)
+{
+    UNUSED(baro);
+
+    return true;
+}
+
+static void deviceCalculate(int32_t *pressure, int32_t *temperature)
+{
+    if (pressure) {
+        *pressure = baroState.pressure;
+    }
+
+    if (temperature) {
+        *temperature = (baroState.temperature * 100);   // to centidegrees
+    }
+}
+
+bool baro2SMPB02BDetect(baroDev_t *baro)
+{
+    extDevice_t *dev = &baro->dev;
+    bool defaultAddressApplied = false;
+
+    deviceInit(&baro->dev, OWNER_BARO_CS);
+
+    if ((dev->bus->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
+        dev->busType_u.i2c.address = BARO_2SMBP_I2C_ADDRESS;
+        defaultAddressApplied = true;
+    }
+
+    if (!deviceDetect(dev)) {
+        busDeviceDeInit(dev);
+        if (defaultAddressApplied) {
+            dev->busType_u.i2c.address = 0;
+        }
+        return false;
+    }
+
+    if (!deviceConfigure(dev)) {
+        busDeviceDeInit(dev);
+        return false;
+    }
+
+    baro->up_delay = 35000; // measurement takes 33.7 ms with 4x / 32x averaging
+    baro->start_up = b2smpbStartUP;
+    baro->read_up = b2smpbReadUP;
+    baro->get_up = b2smpbGetUP;
+
+    // these are dummies, temperature is read with pressure
+    baro->ut_delay = 0;
+    baro->start_ut = b2smpbStartUT;
+    baro->read_ut = b2smpbReadUT;
+    baro->get_ut = b2smpbGetUT;
+
+    baro->calculate = deviceCalculate;
+
+    return true;
+}
+
+#endif

--- a/src/main/drivers/barometer/barometer_2smpb_02b.h
+++ b/src/main/drivers/barometer/barometer_2smpb_02b.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Cleanflight, Betaflight and INAV.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ * Copyright: INAVFLIGHT OU
+ */
+
+#pragma once
+
+bool baro2SMPB02BDetect(baroDev_t *baro);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -43,6 +43,7 @@
 #include "drivers/barometer/barometer_fake.h"
 #include "drivers/barometer/barometer_ms5611.h"
 #include "drivers/barometer/barometer_lps.h"
+#include "drivers/barometer/barometer_2smpb_02b.h"
 #include "drivers/bus.h"
 #include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
@@ -109,15 +110,21 @@ void pgResetFn_barometerConfig(barometerConfig_t *barometerConfig)
 #elif defined(DEFAULT_BARO_BMP085)
 #define DEFAULT_BARO_BMP085
 #endif
+#elif defined(USE_BARO_2SMBP_02B) || defined(USE_BARO_SPI_2SMBP_02B)
+#if defined(USE_BARO_SPI_2SMBP_02B)
+#define DEFAULT_BARO_SPI_2SMBP_02B
+#else
+#define DEFAULT_BARO_2SMBP_02B
+#endif
 #endif
 
-#if defined(DEFAULT_BARO_SPI_BMP388) || defined(DEFAULT_BARO_SPI_BMP280) || defined(DEFAULT_BARO_SPI_MS5611) || defined(DEFAULT_BARO_SPI_QMP6988) || defined(DEFAULT_BARO_SPI_LPS) || defined(DEFAULT_BARO_SPI_DPS310)
+#if defined(DEFAULT_BARO_SPI_BMP388) || defined(DEFAULT_BARO_SPI_BMP280) || defined(DEFAULT_BARO_SPI_MS5611) || defined(DEFAULT_BARO_SPI_QMP6988) || defined(DEFAULT_BARO_SPI_LPS) || defined(DEFAULT_BARO_SPI_DPS310) || defined(DEFAULT_BARO_SPI_2SMBP_02B)
     barometerConfig->baro_busType = BUS_TYPE_SPI;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(BARO_SPI_INSTANCE));
     barometerConfig->baro_spi_csn = IO_TAG(BARO_CS_PIN);
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
-#elif defined(DEFAULT_BARO_MS5611) || defined(DEFAULT_BARO_BMP388) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_BMP085) ||defined(DEFAULT_BARO_QMP6988) || defined(DEFAULT_BARO_DPS310)
+#elif defined(DEFAULT_BARO_MS5611) || defined(DEFAULT_BARO_BMP388) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_BMP085) ||defined(DEFAULT_BARO_QMP6988) || defined(DEFAULT_BARO_DPS310) || defined(DEFAULT_BARO_2SMBP_02B)
     // All I2C devices shares a default config with address = 0 (per device default)
     barometerConfig->baro_busType = BUS_TYPE_I2C;
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(BARO_I2C_INSTANCE);
@@ -162,7 +169,7 @@ static bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
 
     baroSensor_e baroHardware = baroHardwareToUse;
 
-#if !defined(USE_BARO_BMP085) && !defined(USE_BARO_MS5611) && !defined(USE_BARO_SPI_MS5611) && !defined(USE_BARO_BMP388) && !defined(USE_BARO_BMP280) && !defined(USE_BARO_SPI_BMP280)&& !defined(USE_BARO_QMP6988) && !defined(USE_BARO_SPI_QMP6988) && !defined(USE_BARO_DPS310) && !defined(USE_BARO_SPI_DPS310)
+#if !defined(USE_BARO_BMP085) && !defined(USE_BARO_MS5611) && !defined(USE_BARO_SPI_MS5611) && !defined(USE_BARO_BMP388) && !defined(USE_BARO_BMP280) && !defined(USE_BARO_SPI_BMP280)&& !defined(USE_BARO_QMP6988) && !defined(USE_BARO_SPI_QMP6988) && !defined(USE_BARO_DPS310) && !defined(USE_BARO_SPI_DPS310) && !defined(DEFAULT_BARO_SPI_2SMBP_02B) && !defined(DEFAULT_BARO_2SMBP_02B)
     UNUSED(dev);
 #endif
 
@@ -274,6 +281,16 @@ static bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
         }
 #endif
         FALLTHROUGH;
+
+     case BARO_2SMPB_02B:
+#if defined(USE_BARO_2SMBP_02B) || defined(USE_BARO_SPI_2SMBP_02B)
+        if (baro2SMPB02BDetect(baroDev)) {
+            baroHardware = BARO_2SMPB_02B;
+            break;
+        }
+#endif
+        FALLTHROUGH;
+
     case BARO_NONE:
         baroHardware = BARO_NONE;
         break;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -33,6 +33,7 @@ typedef enum {
     BARO_QMP6988 = 6,
     BARO_BMP388 = 7,
     BARO_DPS310 = 8,
+    BARO_2SMPB_02B = 9,
 } baroSensor_e;
 
 typedef struct barometerConfig_s {

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -58,6 +58,8 @@
 #define USE_BARO_DPS310
 #define USE_BARO_SPI_DPS310
 #define USE_BARO_BMP085
+#define USE_BARO_2SMBP_02B
+#define USE_BARO_SPI_2SMBP_02B
 #endif
 
 #if defined(USE_RX_CC2500)


### PR DESCRIPTION
Add driver for the Omron 2SMPB-02B barometer. Performance wise, this barometer is very similar to the DPS310 barometer that has become widely used. 

I have tested it and everything is working as expected. Note that I have only tested the I2C mode, but the code should also support SPI.