### PR TITLE
Fix cli unit test on Clang 13

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -708,12 +708,11 @@ FAST_CODE void scheduler(void)
         }
     }
 
-#if !defined(UNIT_TEST)
-    DEBUG_SET(DEBUG_SCHEDULER, 2, micros() - schedulerStartTimeUs - taskExecutionTimeUs); // time spent in scheduler
-#endif
-
 #if defined(UNIT_TEST)
     readSchedulerLocals(selectedTask, selectedTaskDynamicPriority);
+    UNUSED(taskExecutionTimeUs);
+#else
+    DEBUG_SET(DEBUG_SCHEDULER, 2, micros() - schedulerStartTimeUs - taskExecutionTimeUs); // time spent in scheduler
 #endif
 
     scheduleCount++;

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -241,9 +241,7 @@ const box_t *findBoxByBoxId(boxId_e) { return &boxes[0]; }
 
 int8_t unitTestDataArray[3];
 
-void pgResetFn_unitTestData(int8_t *ptr) {
-    ptr = &unitTestDataArray[0];
-}
+void pgResetFn_unitTestData(int8_t *) {}
 
 uint32_t getBeeperOffMask(void) { return 0; }
 uint32_t getPreferredBeeperOffMask(void) { return 0; }


### PR DESCRIPTION
**Merge**
- Before https://github.com/betaflight/betaflight/pull/11581

On Clang 13 unit-test is failing.
```
unit/cli_unittest.cc 244:37 error: parameter 'ptr' set but not used [-Werror, -Wunused-but-set-parameter]
void pgResetFn_unitTestData(int8_t *ptr) {
```