### PR TITLE
Reorder bug report template headings

### DIFF
--- a/.github/ISSUE_TEMPLATE/firmware-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/firmware-bug-report.md
@@ -3,8 +3,8 @@ name: Firmware Bug Report
 about: Create a report to help us fix bugs in the Betaflight firmware
 labels: "Template: Bug"
 ---
-<!-- This is a template that you must fill. If not, the message will be closed. So don't erase any subtitle in this template (they start with ###)
-and complete all of them -->
+<!-- This is a template that you must fill. If not, the message will be closed.
+So don't erase any subtitle in this template (they start with ###) and complete all of them -->
 
 ### Describe the bug
 <!-- A clear and concise description of what the bug is. -->
@@ -15,8 +15,17 @@ and complete all of them -->
 ### Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
+### Setup / Versions
+<!-- Specify your flight controller model (what type is it, where was it bought from, ...) -->
+- Flight controller: 
+<!-- Specify other components attached to the flight controller (RX, VTX, brand / model for all of them, firmware version where applicable...) -->
+- Other components:
+<!-- Details about how all is wired -->
+- How are the different components wired up:
+
 ### Flight controller configuration
-<!-- Create a diff and post it here in a code block. Put (three backticks) at the start and end of the diff block (instructions  on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/)
+<!-- Create a diff and post it here in a code block.
+Put (three backticks) at the start and end of the diff block (instructions on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/)
 Use resource show all to create a resource allocation list and post it here in a code block. Put (three backticks) at the start and end of the output block. -->
 ```
 PASTE THE OUTPUT OF 'diff' HERE
@@ -24,14 +33,5 @@ PASTE THE OUTPUT OF 'diff' HERE
 ```
 PASTE THE OUTPUT OF 'resource show all' HERE
 ```
-
-### Setup / Versions
- <!-- Specify your flight controller model (what type is it, where was it bought from, ...) -->
- - Flight controller: 
- <!-- Specify other components attached to the flight controller (RX, VTX, brand / model for all of them, firmware version where applicable...) -->
- - Other components:
- <!-- Details about how all is wired -->
- - How are the different components wired up:
-
 
 <!-- Add any other context about the problem that you think might be relevant here. -->


### PR DESCRIPTION
Moves `Flight controller configuration` where diffs are posted to the bottom.

- It can be more difficult to navigate to `Setup / Versions` when it's at the bottom of a long diff.
- It seems some users who fill the template misses `Setup / Versions`, maybe because pasting the diff "hides" it?
