### PR TITLE
Adjust GYRO_LOCK_COUNT

### DIFF
--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -52,7 +52,7 @@
 
 // Gyro interrupt counts over which to measure loop time and skew
 #define GYRO_RATE_COUNT 25000
-#define GYRO_LOCK_COUNT 400
+#define GYRO_LOCK_COUNT 50
 
 typedef enum {
     TASK_PRIORITY_REALTIME = -1, // Task will be run outside the scheduler logic


### PR DESCRIPTION
The skew between gyro interrupt and gyro loop is accumulated over `GYRO_LOCK_COUNT` cycles and with the previous value, on an F411 with bit-banged DSHOT enabled, the effective gain created by this resulted in a failure to lock. Tested on F411, F405, F722 and H743