### PR TITLE
Move telemetry displayport init and cms device registering

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -878,12 +878,6 @@ void init(void)
     cmsInit();
 #endif
 
-#ifdef USE_TELEMETRY
-    if (featureIsEnabled(FEATURE_TELEMETRY)) {
-        telemetryInit();
-    }
-#endif
-
 #if (defined(USE_OSD) || (defined(USE_MSP_DISPLAYPORT) && defined(USE_CMS)))
     displayPort_t *osdDisplayPort = NULL;
     osdDisplayPortDevice_e osdDisplayPortDevice = OSD_DISPLAYPORT_DEVICE_NONE;
@@ -966,6 +960,13 @@ void init(void)
         dashboardResetPageCycling();
         dashboardEnablePageCycling();
 #endif
+    }
+#endif
+
+#ifdef USE_TELEMETRY
+    // Telemetry will initialise displayport and register with CMS by itself.
+    if (featureIsEnabled(FEATURE_TELEMETRY)) {
+        telemetryInit();
     }
 #endif
 


### PR DESCRIPTION
to ensure that the osd is registered as a cms device first and ends up first in the list of cms displayports.

Should partially fix https://github.com/betaflight/betaflight/issues/11178

EDIT: Added a comment that should make it clear why telemetryInit has to be done exactly here. Please dont' move it 😁 
