### PR TITLE
Allow for HALF/NOMINAL/DOUBLE frequency of MAX7456 SPI clock

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -331,7 +331,7 @@ static const char * const lookupTableBusType[] = {
 
 #ifdef USE_MAX7456
 static const char * const lookupTableMax7456Clock[] = {
-    "HALF", "DEFAULT", "FULL"
+    "HALF", "NOMINAL", "DOUBLE"
 };
 #endif
 

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -414,6 +414,19 @@ uint16_t spiCalculateDivider(uint32_t freq)
     return divisor;
 }
 
+uint32_t spiCalculateClock(uint16_t spiClkDivisor)
+{
+#if defined(STM32F4) || defined(STM32G4) || defined(STM32F7)
+    uint32_t spiClk = SystemCoreClock / 2;
+#elif defined(STM32H7)
+    uint32_t spiClk = 100000000;
+#else
+#error "Base SPI clock not defined for this architecture"
+#endif
+
+    return spiClk / spiClkDivisor;
+}
+
 // Interrupt handler for SPI receive DMA completion
 static void spiIrqHandler(const extDevice_t *dev)
 {

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -116,6 +116,8 @@ SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 bool spiSetBusInstance(extDevice_t *dev, uint32_t device);
 // Determine the divisor to use for a given bus frequency
 uint16_t spiCalculateDivider(uint32_t freq);
+// Return the SPI clock based on the given divisor
+uint32_t spiCalculateClock(uint16_t spiClkDivisor);
 // Set the clock divisor to be used for accesses by the given device
 void spiSetClkDivisor(const extDevice_t *dev, uint16_t divider);
 // Set the clock phase/polarity to be used for accesses by the given device

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -395,21 +395,20 @@ max7456InitStatus_e max7456Init(const max7456Config_t *max7456Config, const vcdP
     }
 
 #if defined(USE_OVERCLOCK)
-    max7456SpiClockDiv = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
-
     // Determine SPI clock divisor based on config and the device type.
 
     switch (max7456Config->clockConfig) {
     case MAX7456_CLOCK_CONFIG_HALF:
-        max7456SpiClockDiv <<= 1;
+        max7456SpiClockDiv = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ / 2);
         break;
 
     case MAX7456_CLOCK_CONFIG_NOMINAL:
     default:
+        max7456SpiClockDiv = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
         break;
 
     case MAX7456_CLOCK_CONFIG_DOUBLE:
-        max7456SpiClockDiv >>= 1;
+        max7456SpiClockDiv = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ * 2);
         break;
     }
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -56,6 +56,7 @@
 #define DEBUG_MAX7456_SPICLOCK_OVERCLOCK   0
 #define DEBUG_MAX7456_SPICLOCK_DEVTYPE     1
 #define DEBUG_MAX7456_SPICLOCK_DIVISOR     2
+#define DEBUG_MAX7456_SPICLOCK_X100        3
 
 // VM0 bits
 #define VIDEO_BUFFER_DISABLE        0x01
@@ -192,7 +193,7 @@ extDevice_t max7456Device;
 extDevice_t *dev = &max7456Device;
 
 static bool max7456DeviceDetected = false;
-static uint16_t max7456SpiClock;
+static uint16_t max7456SpiClockDiv;
 
 uint16_t maxScreenSize = VIDEO_BUFFER_CHARS_PAL;
 
@@ -394,32 +395,35 @@ max7456InitStatus_e max7456Init(const max7456Config_t *max7456Config, const vcdP
     }
 
 #if defined(USE_OVERCLOCK)
+    max7456SpiClockDiv = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
+
     // Determine SPI clock divisor based on config and the device type.
 
     switch (max7456Config->clockConfig) {
     case MAX7456_CLOCK_CONFIG_HALF:
-        max7456SpiClock = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ / 2);
+        max7456SpiClockDiv <<= 1;
         break;
 
-    case MAX7456_CLOCK_CONFIG_OC:
-        max7456SpiClock = (cpuOverclock && (max7456DeviceType == MAX7456_DEVICE_TYPE_MAX)) ? spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ / 2) : spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
+    case MAX7456_CLOCK_CONFIG_NOMINAL:
+    default:
         break;
 
-    case MAX7456_CLOCK_CONFIG_FULL:
-        max7456SpiClock = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
+    case MAX7456_CLOCK_CONFIG_DOUBLE:
+        max7456SpiClockDiv >>= 1;
         break;
     }
 
     DEBUG_SET(DEBUG_MAX7456_SPICLOCK, DEBUG_MAX7456_SPICLOCK_OVERCLOCK, cpuOverclock);
     DEBUG_SET(DEBUG_MAX7456_SPICLOCK, DEBUG_MAX7456_SPICLOCK_DEVTYPE, max7456DeviceType);
-    DEBUG_SET(DEBUG_MAX7456_SPICLOCK, DEBUG_MAX7456_SPICLOCK_DIVISOR, max7456SpiClock);
+    DEBUG_SET(DEBUG_MAX7456_SPICLOCK, DEBUG_MAX7456_SPICLOCK_DIVISOR, max7456SpiClockDiv);
+    DEBUG_SET(DEBUG_MAX7456_SPICLOCK, DEBUG_MAX7456_SPICLOCK_X100, spiCalculateClock(max7456SpiClockDiv) / 10000);
 #else
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
-    max7456SpiClock = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
+    max7456SpiClockDiv = spiCalculateDivider(MAX7456_MAX_SPI_CLK_HZ);
 #endif
 
-    spiSetClkDivisor(dev, max7456SpiClock);
+    spiSetClkDivisor(dev, max7456SpiClockDiv);
 
     // force soft reset on Max7456
     spiWriteReg(dev, MAX7456ADD_VM0, MAX7456_RESET);

--- a/src/main/pg/max7456.c
+++ b/src/main/pg/max7456.c
@@ -34,7 +34,7 @@ PG_REGISTER_WITH_RESET_FN(max7456Config_t, max7456Config, PG_MAX7456_CONFIG, 0);
 
 void pgResetFn_max7456Config(max7456Config_t *config)
 {
-    config->clockConfig = MAX7456_CLOCK_CONFIG_DEFAULT;
+    config->clockConfig = MAX7456_CLOCK_CONFIG_NOMINAL;
     config->csTag = IO_TAG(MAX7456_SPI_CS_PIN);
     config->spiDevice = SPI_DEV_TO_CFG(spiDeviceByInstance(MAX7456_SPI_INSTANCE));
     config->preInitOPU = false;

--- a/src/main/pg/max7456.h
+++ b/src/main/pg/max7456.h
@@ -24,15 +24,15 @@
 #include "pg/pg.h"
 
 typedef struct max7456Config_s {
-    uint8_t clockConfig; // SPI clock based on device type and overclock state (MAX7456_CLOCK_CONFIG_xxxx)
+    uint8_t clockConfig; // SPI clock modifier
     ioTag_t csTag;
     uint8_t spiDevice;
     bool preInitOPU;
 } max7456Config_t;
 
 // clockConfig values
-#define MAX7456_CLOCK_CONFIG_HALF 0  // Force half clock
-#define MAX7456_CLOCK_CONFIG_OC   1  // Half clock if OC
-#define MAX7456_CLOCK_CONFIG_FULL 2  // Force full clock
+#define MAX7456_CLOCK_CONFIG_HALF       0  // Force half clock
+#define MAX7456_CLOCK_CONFIG_NOMINAL    1  // Nominal clock (default)
+#define MAX7456_CLOCK_CONFIG_DOUBLE     2  // Double clock
 
 PG_DECLARE(max7456Config_t, max7456Config);

--- a/src/main/rx/expresslrs.c
+++ b/src/main/rx/expresslrs.c
@@ -840,15 +840,15 @@ bool expressLrsSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeSta
     }
 
     rxSpiCommonIOInit(rxConfig);
-	
+    
     rxRuntimeState->channelCount = ELRS_MAX_CHANNELS;
-	
+    
     extiConfig->ioConfig = IOCFG_IPD;
     extiConfig->trigger = BETAFLIGHT_EXTI_TRIGGER_RISING;
 
     if (rxExpressLrsSpiConfig()->resetIoTag) {
         receiver.resetPin = IOGetByTag(rxExpressLrsSpiConfig()->resetIoTag);
-	} else {
+    } else {
         receiver.resetPin = IO_NONE;
     }
 


### PR DESCRIPTION
With `max7456_clock` set to the default value the SPI clock as being set to half what it should have been, slowing down the transfers from the OSD shadow buffer to the MAX7456. This PR supports setting `max7456_clock` to `HALF`, `NOMINAL` or `DOUBLE` and removes the need to raise the CPU overclocking on an F411 to `120MHz` as per https://github.com/betaflight/betaflight/issues/11167#issuecomment-1002314922. Using `NOMINAL` works with the CPU overclock at its default of `108MHz`.

This PR compliments https://github.com/betaflight/betaflight/pull/11169.