### PR TITLE
SPI: Make sure RX FIFO is empty at start of transfer

### DIFF
--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -355,6 +355,12 @@ void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
 
     SPI_Cmd(instance, ENABLE);
 
+    // Make sure the RX FIFO is empty
+    while (SPI_I2S_GetFlagStatus(instance, SPI_I2S_FLAG_RXNE)) {
+        volatile uint16_t w = SPI_I2S_ReceiveData(instance);
+        (void)w;
+    }
+
     // Check that any there are no attempts to DMA to/from CCD SRAM
     for (busSegment_t *checkSegment = bus->curSegment; checkSegment->len; checkSegment++) {
         // Check there is no receive data as only transmit DMA is available


### PR DESCRIPTION
I encountered an odd bug when working on adding DMA support to the BMI160 driver (see #11200). It would work fine 95% of the times, but sometimes the gyro and barometer data would get completely screwed up. This is on a BrainFPV RADIX flight controller, that uses an STM32F446 with a BMI160 gyro and and a BMP280 barometer connected to the same SPI.

After some investigation, I found that the SPI CS signal would go H one byte too early, which then shifted all the SPI and gyro data by one byte resulting in the screwed up data. See screenshot below.

My best guess is that this happens because the SPI RX FIFO is not empty at the start of the transfer, which causes the DMA RX transfer to terminate one byte too early. I haven't found what exactly is causing one byte to be left in the RX FIFO. It could be a bug in the SPI code elsewhere. 

As a workaround,  I added code to flush the SPI RX FIFO at the start of the transfer, which fixes the problem. 

I have only seen this problem on an F4 based flight controller and added the fix to the driver that uses the standard peripheral library, but it may be a good idea to add it to the `spi_ll` driver as well.

![image](https://user-images.githubusercontent.com/647005/147759621-d5bf66fa-1183-4a25-960d-89e487a5397a.png)
