### PR TITLE
fix for gps time

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1498,10 +1498,15 @@ static bool UBLOX_parse_gps(void)
 #ifdef USE_RTC_TIME
         //set clock, when gps time is available
         if (!rtcHasTime() && (_buffer.pvt.valid & NAV_VALID_DATE) && (_buffer.pvt.valid & NAV_VALID_TIME)) {
-            rtcTime_t temp_time = (_buffer.pvt.sec + _buffer.pvt.min * 60 + _buffer.pvt.hour * 3600 + _buffer.pvt.day * 86400 +
-                                    (_buffer.pvt.year - 70) * 31536000 + ((_buffer.pvt.year - 69) / 4) * 86400 -
-                                    ((_buffer.pvt.year - 1) / 100) * 86400 + ((_buffer.pvt.year + 299) / 400) * 86400) * 1000L;
-            rtcSet(&temp_time);
+            dateTime_t dt;
+            dt.year = _buffer.pvt.year;
+            dt.month = _buffer.pvt.month;
+            dt.day = _buffer.pvt.day;
+            dt.hours = _buffer.pvt.hour;
+            dt.minutes = _buffer.pvt.min;
+            dt.seconds = _buffer.pvt.sec;
+            dt.millis = (_buffer.pvt.nano > 0) ? _buffer.pvt.nano / 1000 : 0; //up to 5ms of error
+            rtcSetDateTime(&dt);
         }
 #endif
         break;


### PR DESCRIPTION
Something was wrong with the time conversion, but luckily I've found this conversion was already implemented on time.c, so the builds are now 76 bytes smaller, fwiw.