### PR TITLE
Fix devices sharing a common SPI bus

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -217,9 +217,6 @@ bool mpuAccReadSPI(accDev_t *acc)
     case GYRO_EXTI_INT:
     case GYRO_EXTI_NO_INT:
     {
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(&acc->gyro->dev);
-
         acc->gyro->dev.txBuf[0] = MPU_RA_ACCEL_XOUT_H | 0x80;
 
         busSegment_t segments[] = {
@@ -274,8 +271,6 @@ bool mpuGyroReadSPI(gyroDev_t *gyro)
         gyro->gyroDmaMaxDuration = 5;
         if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
             if (spiUseDMA(&gyro->dev)) {
-                // Indicate that the bus on which this device resides may initiate DMA transfers from interrupt context
-                spiSetAtomicWait(&gyro->dev);
                 gyro->dev.callbackArg = (uint32_t)gyro;
                 gyro->dev.txBuf[0] = MPU_RA_ACCEL_XOUT_H | 0x80;
                 gyro->segments[0].len = 15;
@@ -299,9 +294,6 @@ bool mpuGyroReadSPI(gyroDev_t *gyro)
     case GYRO_EXTI_INT:
     case GYRO_EXTI_NO_INT:
     {
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(&gyro->dev);
-
         gyro->dev.txBuf[0] = MPU_RA_GYRO_XOUT_H | 0x80;
 
         busSegment_t segments[] = {

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -220,11 +220,11 @@ bool mpuAccReadSPI(accDev_t *acc)
         acc->gyro->dev.txBuf[0] = MPU_RA_ACCEL_XOUT_H | 0x80;
 
         busSegment_t segments[] = {
-                {NULL, NULL, 7, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {NULL, NULL}, 7, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
-        segments[0].txData = acc->gyro->dev.txBuf;
-        segments[0].rxData = &acc->gyro->dev.rxBuf[1];
+        segments[0].u.buffers.txData = acc->gyro->dev.txBuf;
+        segments[0].u.buffers.rxData = &acc->gyro->dev.rxBuf[1];
 
         spiSequence(&acc->gyro->dev, &segments[0]);
 
@@ -275,8 +275,8 @@ bool mpuGyroReadSPI(gyroDev_t *gyro)
                 gyro->dev.txBuf[0] = MPU_RA_ACCEL_XOUT_H | 0x80;
                 gyro->segments[0].len = 15;
                 gyro->segments[0].callback = mpuIntcallback;
-                gyro->segments[0].txData = gyro->dev.txBuf;
-                gyro->segments[0].rxData = &gyro->dev.rxBuf[1];
+                gyro->segments[0].u.buffers.txData = gyro->dev.txBuf;
+                gyro->segments[0].u.buffers.rxData = &gyro->dev.rxBuf[1];
                 gyro->segments[0].negateCS = true;
                 gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
             } else {
@@ -297,11 +297,11 @@ bool mpuGyroReadSPI(gyroDev_t *gyro)
         gyro->dev.txBuf[0] = MPU_RA_GYRO_XOUT_H | 0x80;
 
         busSegment_t segments[] = {
-                {NULL, NULL, 7, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {NULL, NULL}, 7, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
-        segments[0].txData = gyro->dev.txBuf;
-        segments[0].rxData = &gyro->dev.rxBuf[1];
+        segments[0].u.buffers.txData = gyro->dev.txBuf;
+        segments[0].u.buffers.rxData = &gyro->dev.rxBuf[1];
 
         spiSequence(&gyro->dev, &segments[0]);
 

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -319,11 +319,11 @@ static bool bmi270AccRead(accDev_t *acc)
         acc->gyro->dev.txBuf[0] = BMI270_REG_ACC_DATA_X_LSB | 0x80;
 
         busSegment_t segments[] = {
-                {NULL, NULL, 8, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {NULL, NULL}, 8, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
-        segments[0].txData = acc->gyro->dev.txBuf;
-        segments[0].rxData = acc->gyro->dev.rxBuf;
+        segments[0].u.buffers.txData = acc->gyro->dev.txBuf;
+        segments[0].u.buffers.rxData = acc->gyro->dev.rxBuf;
 
         spiSequence(&acc->gyro->dev, &segments[0]);
 
@@ -375,8 +375,8 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
                 gyro->dev.txBuf[0] = BMI270_REG_ACC_DATA_X_LSB | 0x80;
                 gyro->segments[0].len = 14;
                 gyro->segments[0].callback = bmi270Intcallback;
-                gyro->segments[0].txData = gyro->dev.txBuf;
-                gyro->segments[0].rxData = gyro->dev.rxBuf;
+                gyro->segments[0].u.buffers.txData = gyro->dev.txBuf;
+                gyro->segments[0].u.buffers.rxData = gyro->dev.rxBuf;
                 gyro->segments[0].negateCS = true;
                 gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
             } else {
@@ -397,11 +397,11 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
         gyro->dev.txBuf[0] = BMI270_REG_GYR_DATA_X_LSB | 0x80;
 
         busSegment_t segments[] = {
-                {NULL, NULL, 8, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {NULL, NULL}, 8, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
-        segments[0].txData = gyro->dev.txBuf;
-        segments[0].rxData = gyro->dev.rxBuf;
+        segments[0].u.buffers.txData = gyro->dev.txBuf;
+        segments[0].u.buffers.rxData = gyro->dev.rxBuf;
 
         spiSequence(&gyro->dev, &segments[0]);
 

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -316,9 +316,6 @@ static bool bmi270AccRead(accDev_t *acc)
     case GYRO_EXTI_INT:
     case GYRO_EXTI_NO_INT:
     {
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(&acc->gyro->dev);
-
         acc->gyro->dev.txBuf[0] = BMI270_REG_ACC_DATA_X_LSB | 0x80;
 
         busSegment_t segments[] = {
@@ -374,8 +371,6 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
         // Using DMA for gyro access upsets the scheduler on the F4
         if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
             if (spiUseDMA(&gyro->dev)) {
-                // Indicate that the bus on which this device resides may initiate DMA transfers from interrupt context
-                spiSetAtomicWait(&gyro->dev);
                 gyro->dev.callbackArg = (uint32_t)gyro;
                 gyro->dev.txBuf[0] = BMI270_REG_ACC_DATA_X_LSB | 0x80;
                 gyro->segments[0].len = 14;
@@ -399,9 +394,6 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
     case GYRO_EXTI_INT:
     case GYRO_EXTI_NO_INT:
     {
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(&gyro->dev);
-
         gyro->dev.txBuf[0] = BMI270_REG_GYR_DATA_X_LSB | 0x80;
 
         busSegment_t segments[] = {

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -60,7 +60,6 @@ typedef struct busDevice_s {
         } mpuSlave;
     } busType_u;
     bool useDMA;
-    bool useAtomicWait;
     uint8_t deviceCount;
     dmaChannelDescriptor_t *dmaTx;
     dmaChannelDescriptor_t *dmaRx;

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -169,8 +169,8 @@ void spiReadWriteBuf(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, i
 {
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {txData, rxData, len, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {txData, rxData}, len, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -198,8 +198,8 @@ uint8_t spiReadWrite(const extDevice_t *dev, uint8_t data)
 
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&data, &retval, sizeof(data), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&data, &retval}, sizeof(data), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -216,9 +216,9 @@ uint8_t spiReadWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data)
 
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&reg, NULL, sizeof(reg), false, NULL},
-            {&data, &retval, sizeof(data), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+            {.u.buffers = {&data, &retval}, sizeof(data), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -233,8 +233,8 @@ void spiWrite(const extDevice_t *dev, uint8_t data)
 {
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&data, NULL, sizeof(data), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&data, NULL}, sizeof(data), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -247,9 +247,9 @@ void spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data)
 {
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&reg, NULL, sizeof(reg), false, NULL},
-            {&data, NULL, sizeof(data), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+            {.u.buffers = {&data, NULL}, sizeof(data), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -275,9 +275,9 @@ void spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t l
 {
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&reg, NULL, sizeof(reg), false, NULL},
-            {NULL, data, length, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+            {.u.buffers = {NULL, data}, length, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -309,9 +309,9 @@ void spiWriteRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint32_t
 {
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&reg, NULL, sizeof(reg), false, NULL},
-            {data, NULL, length, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+            {.u.buffers = {data, NULL}, length, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -325,9 +325,9 @@ uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg)
     uint8_t data;
     // This routine blocks so no need to use static data
     busSegment_t segments[] = {
-            {&reg, NULL, sizeof(reg), false, NULL},
-            {NULL, &data, sizeof(data), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+            {.u.buffers = {NULL, &data}, sizeof(data), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(dev, &segments[0]);
@@ -393,12 +393,12 @@ static void spiIrqHandler(const extDevice_t *dev)
 
     if (nextSegment->len == 0) {
         // If a following transaction has been linked, start it
-        if (nextSegment->txData) {
-            const extDevice_t *nextDev = (const extDevice_t *)nextSegment->txData;
-            busSegment_t *nextSegments = (busSegment_t *)nextSegment->rxData;
+        if (nextSegment->u.link.dev) {
+            const extDevice_t *nextDev = nextSegment->u.link.dev;
+            busSegment_t *nextSegments = nextSegment->u.link.segments;
             // The end of the segment list has been reached
             bus->curSegment = nextSegments;
-            nextSegment->txData = NULL;
+            nextSegment->u.link.dev = NULL;
             spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete
@@ -441,15 +441,15 @@ static void spiRxIrqHandler(dmaChannelDescriptor_t* descriptor)
 
 #ifdef __DCACHE_PRESENT
 #ifdef STM32H7
-    if (bus->curSegment->rxData &&
-        ((bus->curSegment->rxData < &_dmaram_start__) || (bus->curSegment->rxData >= &_dmaram_end__))) {
+    if (bus->curSegment->u.buffers.rxData &&
+        ((bus->curSegment->u.buffers.rxData < &_dmaram_start__) || (bus->curSegment->u.buffers.rxData >= &_dmaram_end__))) {
 #else
-    if (bus->curSegment->rxData) {
+    if (bus->curSegment->u.buffers.rxData) {
 #endif
          // Invalidate the D cache covering the area into which data has been read
         SCB_InvalidateDCache_by_Addr(
-            (uint32_t *)((uint32_t)bus->curSegment->rxData & ~CACHE_LINE_MASK),
-            (((uint32_t)bus->curSegment->rxData & CACHE_LINE_MASK) +
+            (uint32_t *)((uint32_t)bus->curSegment->u.buffers.rxData & ~CACHE_LINE_MASK),
+            (((uint32_t)bus->curSegment->u.buffers.rxData & CACHE_LINE_MASK) +
               bus->curSegment->len - 1 + CACHE_LINE_SIZE) & ~CACHE_LINE_MASK);
     }
 #endif // __DCACHE_PRESENT
@@ -716,18 +716,18 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments)
                         return;
                     }
 
-                    if (endCmpSegment->txData == NULL) {
+                    if (endCmpSegment->u.link.dev == NULL) {
                         // End of the segment list queue reached
                         break;
                     } else {
                         // Follow the link to the next queued segment list
-                        endCmpSegment = (busSegment_t *)endCmpSegment->rxData;
+                        endCmpSegment = endCmpSegment->u.link.segments;
                     }
                 }
 
                 // Record the dev and segments parameters in the terminating segment entry
-                endCmpSegment->txData = (uint8_t *)dev;
-                endCmpSegment->rxData = (uint8_t *)segments;
+                endCmpSegment->u.link.dev = dev;
+                endCmpSegment->u.link.segments = segments;
 
                 return;
             }

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -157,34 +157,6 @@ bool spiIsBusy(const extDevice_t *dev)
     return (dev->bus->curSegment != (busSegment_t *)BUS_SPI_FREE);
 }
 
-// Indicate that the bus on which this device resides may initiate DMA transfers from interrupt context
-void spiSetAtomicWait(const extDevice_t *dev)
-{
-    dev->bus->useAtomicWait = true;
-}
-
-// Wait for DMA completion and claim the bus driver
-void spiWaitClaim(const extDevice_t *dev)
-{
-    // If there is a device on the bus whose driver might call spiSequence from an ISR then an
-    // atomic access is required to claim the bus, however if not, then interrupts need not be
-    // disabled as this can result in edge triggered interrupts being missed
-
-    if (dev->bus->useAtomicWait) {
-        // Prevent race condition where the bus appears free, but a gyro interrupt starts a transfer
-        do {
-            ATOMIC_BLOCK(NVIC_PRIO_MAX) {
-                if (dev->bus->curSegment == (busSegment_t *)BUS_SPI_FREE) {
-                    dev->bus->curSegment = (busSegment_t *)BUS_SPI_LOCKED;
-                }
-            }
-        } while (dev->bus->curSegment != (busSegment_t *)BUS_SPI_LOCKED);
-    } else {
-        // Wait for completion
-        while (dev->bus->curSegment != (busSegment_t *)BUS_SPI_FREE);
-    }
-}
-
 // Wait for DMA completion
 void spiWait(const extDevice_t *dev)
 {
@@ -200,9 +172,6 @@ void spiReadWriteBuf(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, i
             {txData, rxData, len, true, NULL},
             {NULL, NULL, 0, true, NULL},
     };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
 
     spiSequence(dev, &segments[0]);
 
@@ -233,9 +202,6 @@ uint8_t spiReadWrite(const extDevice_t *dev, uint8_t data)
             {NULL, NULL, 0, true, NULL},
     };
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
-
     spiSequence(dev, &segments[0]);
 
     spiWait(dev);
@@ -255,9 +221,6 @@ uint8_t spiReadWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data)
             {NULL, NULL, 0, true, NULL},
     };
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
-
     spiSequence(dev, &segments[0]);
 
     spiWait(dev);
@@ -274,9 +237,6 @@ void spiWrite(const extDevice_t *dev, uint8_t data)
             {NULL, NULL, 0, true, NULL},
     };
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
-
     spiSequence(dev, &segments[0]);
 
     spiWait(dev);
@@ -291,9 +251,6 @@ void spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data)
             {&data, NULL, sizeof(data), true, NULL},
             {NULL, NULL, 0, true, NULL},
     };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
 
     spiSequence(dev, &segments[0]);
 
@@ -322,9 +279,6 @@ void spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t l
             {NULL, data, length, true, NULL},
             {NULL, NULL, 0, true, NULL},
     };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
 
     spiSequence(dev, &segments[0]);
 
@@ -360,9 +314,6 @@ void spiWriteRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint32_t
             {NULL, NULL, 0, true, NULL},
     };
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
-
     spiSequence(dev, &segments[0]);
 
     spiWait(dev);
@@ -378,9 +329,6 @@ uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg)
             {NULL, &data, sizeof(data), true, NULL},
             {NULL, NULL, 0, true, NULL},
     };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(dev);
 
     spiSequence(dev, &segments[0]);
 
@@ -448,9 +396,10 @@ static void spiIrqHandler(const extDevice_t *dev)
         if (nextSegment->txData) {
             const extDevice_t *nextDev = (const extDevice_t *)nextSegment->txData;
             busSegment_t *nextSegments = (busSegment_t *)nextSegment->rxData;
-            nextSegment->txData = NULL;
             // The end of the segment list has been reached
-            spiSequenceStart(nextDev, nextSegments);
+            bus->curSegment = nextSegments;
+            nextSegment->txData = NULL;
+            spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete
             bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
@@ -559,7 +508,6 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device)
 
     bus->busType = BUS_TYPE_SPI;
     bus->useDMA = false;
-    bus->useAtomicWait = false;
     bus->deviceCount = 1;
     bus->initTx = &dev->initTx;
     bus->initRx = &dev->initRx;
@@ -745,26 +693,50 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments)
     busDevice_t *bus = dev->bus;
 
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
-        if ((bus->curSegment != (busSegment_t *)BUS_SPI_LOCKED) && spiIsBusy(dev)) {
-            /* Defer this transfer to be triggered upon completion of the current transfer. Blocking calls
-             * and those from non-interrupt context will have already called spiWaitClaim() so this will
-             * only happen for non-blocking calls called from an ISR.
-             */
-            busSegment_t *endSegment = bus->curSegment;
+        if (spiIsBusy(dev)) {
+            busSegment_t *endSegment;
 
-            if (endSegment) {
-                // Find the last segment of the current transfer
-                for (; endSegment->len; endSegment++);
+            // Defer this transfer to be triggered upon completion of the current transfer
+
+            // Find the last segment of the current transfer
+            for (endSegment = segments; endSegment->len; endSegment++);
+
+            busSegment_t *endCmpSegment = bus->curSegment;
+
+            if (endCmpSegment) {
+                while (true) {
+                    // Find the last segment of the current transfer
+                    for (; endCmpSegment->len; endCmpSegment++);
+
+                    if (endCmpSegment == endSegment) {
+                        /* Attempt to use the new segment list twice in the same queue. Abort.
+                         * Note that this can only happen with non-blocking transfers so drivers must take
+                         * care to avoid this.
+                         * */
+                        return;
+                    }
+
+                    if (endCmpSegment->txData == NULL) {
+                        // End of the segment list queue reached
+                        break;
+                    } else {
+                        // Follow the link to the next queued segment list
+                        endCmpSegment = (busSegment_t *)endCmpSegment->rxData;
+                    }
+                }
 
                 // Record the dev and segments parameters in the terminating segment entry
-                endSegment->txData = (uint8_t *)dev;
-                endSegment->rxData = (uint8_t *)segments;
+                endCmpSegment->txData = (uint8_t *)dev;
+                endCmpSegment->rxData = (uint8_t *)segments;
 
                 return;
             }
+        } else {
+            // Claim the bus with this list of segments
+            bus->curSegment = segments;
         }
     }
 
-    spiSequenceStart(dev, segments);
+    spiSequenceStart(dev);
 }
 #endif

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -127,10 +127,6 @@ void spiDmaEnable(const extDevice_t *dev, bool enable);
 void spiSequence(const extDevice_t *dev, busSegment_t *segments);
 // Wait for DMA completion
 void spiWait(const extDevice_t *dev);
-// Indicate that the bus on which this device resides may initiate DMA transfers from interrupt context
-void spiSetAtomicWait(const extDevice_t *dev);
-// Wait for DMA completion and claim the bus driver - use this when waiting for a prior access to complete before starting a new one
-void spiWaitClaim(const extDevice_t *dev);
 // Return true if DMA engine is busy
 bool spiIsBusy(const extDevice_t *dev);
 

--- a/src/main/drivers/bus_spi_impl.h
+++ b/src/main/drivers/bus_spi_impl.h
@@ -33,7 +33,6 @@
 #endif
 
 #define BUS_SPI_FREE   0x0
-#define BUS_SPI_LOCKED 0x4
 
 typedef struct spiPinDef_s {
     ioTag_t pin;
@@ -90,5 +89,5 @@ void spiInternalStartDMA(const extDevice_t *dev);
 void spiInternalStopDMA (const extDevice_t *dev);
 void spiInternalResetStream(dmaChannelDescriptor_t *descriptor);
 void spiInternalResetDescriptors(busDevice_t *bus);
-void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments);
+void spiSequenceStart(const extDevice_t *dev);
 

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -539,7 +539,7 @@ void spiInternalStopDMA (const extDevice_t *dev)
 }
 
 // DMA transfer setup and start
-void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
+void spiSequenceStart(const extDevice_t *dev)
 {
     busDevice_t *bus = dev->bus;
     SPI_TypeDef *instance = bus->busType_u.spi.instance;
@@ -549,7 +549,6 @@ void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
     uint32_t segmentCount = 0;
 
     bus->initSegment = true;
-    bus->curSegment = segments;
 
     // Switch bus speed
 #if !defined(STM32H7)
@@ -689,8 +688,10 @@ void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
         if (bus->curSegment->txData) {
             const extDevice_t *nextDev = (const extDevice_t *)bus->curSegment->txData;
             busSegment_t *nextSegments = (busSegment_t *)bus->curSegment->rxData;
-            bus->curSegment->txData = NULL;
-            spiSequenceStart(nextDev, nextSegments);
+            busSegment_t *endSegment = bus->curSegment;
+            bus->curSegment = nextSegments;
+            endSegment->txData = NULL;
+            spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete
             bus->curSegment = (busSegment_t *)BUS_SPI_FREE;

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -320,7 +320,7 @@ void spiInternalStopDMA (const extDevice_t *dev)
 }
 
 // DMA transfer setup and start
-void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
+void spiSequenceStart(const extDevice_t *dev)
 {
     busDevice_t *bus = dev->bus;
     SPI_TypeDef *instance = bus->busType_u.spi.instance;
@@ -329,7 +329,6 @@ void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
     uint32_t segmentCount = 0;
 
     dev->bus->initSegment = true;
-    dev->bus->curSegment = segments;
 
     SPI_Cmd(instance, DISABLE);
 
@@ -415,8 +414,10 @@ void spiSequenceStart(const extDevice_t *dev, busSegment_t *segments)
         if (bus->curSegment->txData) {
             const extDevice_t *nextDev = (const extDevice_t *)bus->curSegment->txData;
             busSegment_t *nextSegments = (busSegment_t *)bus->curSegment->rxData;
-            bus->curSegment->txData = NULL;
-            spiSequenceStart(nextDev, nextSegments);
+            busSegment_t *endSegment = bus->curSegment;
+            bus->curSegment = nextSegments;
+            endSegment->txData = NULL;
+            spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete
             bus->curSegment = (busSegment_t *)BUS_SPI_FREE;

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -179,7 +179,7 @@ void spiInternalInitStream(const extDevice_t *dev, bool preInit)
 
     int len = segment->len;
 
-    uint8_t *txData = segment->txData;
+    uint8_t *txData = segment->u.buffers.txData;
     DMA_InitTypeDef *initTx = bus->initTx;
 
     if (txData) {
@@ -193,7 +193,7 @@ void spiInternalInitStream(const extDevice_t *dev, bool preInit)
     initTx->DMA_BufferSize = len;
 
     if (dev->bus->dmaRx) {
-        uint8_t *rxData = segment->rxData;
+        uint8_t *rxData = segment->u.buffers.rxData;
         DMA_InitTypeDef *initRx = bus->initRx;
 
         if (rxData) {
@@ -357,8 +357,8 @@ void spiSequenceStart(const extDevice_t *dev)
     // Check that any there are no attempts to DMA to/from CCD SRAM
     for (busSegment_t *checkSegment = bus->curSegment; checkSegment->len; checkSegment++) {
         // Check there is no receive data as only transmit DMA is available
-        if (((checkSegment->rxData) && (IS_CCM(checkSegment->rxData) || (bus->dmaRx == (dmaChannelDescriptor_t *)NULL))) ||
-            ((checkSegment->txData) && IS_CCM(checkSegment->txData))) {
+        if (((checkSegment->u.buffers.rxData) && (IS_CCM(checkSegment->u.buffers.rxData) || (bus->dmaRx == (dmaChannelDescriptor_t *)NULL))) ||
+            ((checkSegment->u.buffers.txData) && IS_CCM(checkSegment->u.buffers.txData))) {
             dmaSafe = false;
             break;
         }
@@ -381,8 +381,8 @@ void spiSequenceStart(const extDevice_t *dev)
 
             spiInternalReadWriteBufPolled(
                     bus->busType_u.spi.instance,
-                    bus->curSegment->txData,
-                    bus->curSegment->rxData,
+                    bus->curSegment->u.buffers.txData,
+                    bus->curSegment->u.buffers.rxData,
                     bus->curSegment->len);
 
             if (bus->curSegment->negateCS) {
@@ -411,12 +411,12 @@ void spiSequenceStart(const extDevice_t *dev)
         }
 
         // If a following transaction has been linked, start it
-        if (bus->curSegment->txData) {
-            const extDevice_t *nextDev = (const extDevice_t *)bus->curSegment->txData;
-            busSegment_t *nextSegments = (busSegment_t *)bus->curSegment->rxData;
+        if (bus->curSegment->u.link.dev) {
+            const extDevice_t *nextDev = bus->curSegment->u.link.dev;
+            busSegment_t *nextSegments = bus->curSegment->u.link.segments;
             busSegment_t *endSegment = bus->curSegment;
             bus->curSegment = nextSegments;
-            endSegment->txData = NULL;
+            endSegment->u.link.dev = NULL;
             spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -257,7 +257,7 @@ busStatus_e m25p16_callbackReady(uint32_t arg)
     flashDevice_t *fdevice = (flashDevice_t *)arg;
     extDevice_t *dev = fdevice->io.handle.dev;
 
-    uint8_t readyPoll = dev->bus->curSegment->rxData[1];
+    uint8_t readyPoll = dev->bus->curSegment->u.buffers.rxData[1];
 
     if (readyPoll & M25P16_STATUS_FLAG_WRITE_IN_PROGRESS) {
         return BUS_BUSY;
@@ -281,10 +281,10 @@ static void m25p16_eraseSector(flashDevice_t *fdevice, uint32_t address)
     STATIC_DMA_DATA_AUTO uint8_t writeEnable[] = { M25P16_INSTRUCTION_WRITE_ENABLE };
 
     busSegment_t segments[] = {
-            {readStatus, readyStatus, sizeof(readStatus), true, m25p16_callbackReady},
-            {writeEnable, NULL, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
-            {sectorErase, NULL, fdevice->isLargeFlash ? 5 : 4, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, m25p16_callbackReady},
+            {.u.buffers = {writeEnable, NULL}, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
+            {.u.buffers = {sectorErase, NULL}, fdevice->isLargeFlash ? 5 : 4, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     // Ensure any prior DMA has completed before continuing
@@ -306,10 +306,10 @@ static void m25p16_eraseCompletely(flashDevice_t *fdevice)
     STATIC_DMA_DATA_AUTO uint8_t bulkErase[] = { M25P16_INSTRUCTION_BULK_ERASE };
 
     busSegment_t segments[] = {
-            {readStatus, readyStatus, sizeof(readStatus), true, m25p16_callbackReady},
-            {writeEnable, NULL, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
-            {bulkErase, NULL, sizeof(bulkErase), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, m25p16_callbackReady},
+            {.u.buffers = {writeEnable, NULL}, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
+            {.u.buffers = {bulkErase, NULL}, sizeof(bulkErase), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     spiSequence(fdevice->io.handle.dev, segments);
@@ -334,12 +334,12 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
     STATIC_DMA_DATA_AUTO uint8_t pageProgram[5] = { M25P16_INSTRUCTION_PAGE_PROGRAM };
 
     static busSegment_t segments[] = {
-            {readStatus, readyStatus, sizeof(readStatus), true, m25p16_callbackReady},
-            {writeEnable, NULL, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
-            {pageProgram, NULL, 0, false, NULL},
-            {NULL, NULL, 0, true, NULL},
-            {NULL, NULL, 0, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, m25p16_callbackReady},
+            {.u.buffers = {writeEnable, NULL}, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
+            {.u.buffers = {pageProgram, NULL}, 0, false, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     // Ensure any prior DMA has completed before continuing
@@ -350,7 +350,7 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
     m25p16_setCommandAddress(&pageProgram[1], fdevice->currentWriteAddress, fdevice->isLargeFlash);
 
     // Patch the data segments
-    segments[DATA1].txData = (uint8_t *)buffers[0];
+    segments[DATA1].u.buffers.txData = (uint8_t *)buffers[0];
     segments[DATA1].len = bufferSizes[0];
     fdevice->callbackArg = bufferSizes[0];
 
@@ -358,12 +358,12 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
         segments[DATA1].negateCS = true;
         segments[DATA1].callback = m25p16_callbackWriteComplete;
         // Mark segment following data as being of zero length
-        segments[DATA2].txData = (uint8_t *)NULL;
+        segments[DATA2].u.buffers.txData = (uint8_t *)NULL;
         segments[DATA2].len = 0;
     } else if (bufferCount == 2) {
         segments[DATA1].negateCS = false;
         segments[DATA1].callback = NULL;
-        segments[DATA2].txData = (uint8_t *)buffers[1];
+        segments[DATA2].u.buffers.txData = (uint8_t *)buffers[1];
         segments[DATA2].len = bufferSizes[1];
         fdevice->callbackArg += bufferSizes[1];
         segments[DATA2].negateCS = true;
@@ -427,10 +427,10 @@ static int m25p16_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *b
     spiWait(fdevice->io.handle.dev);
 
     busSegment_t segments[] = {
-            {readStatus, readyStatus, sizeof(readStatus), true, m25p16_callbackReady},
-            {readBytes, NULL, fdevice->isLargeFlash ? 5 : 4, false, NULL},
-            {NULL, buffer, length, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, m25p16_callbackReady},
+            {.u.buffers = {readBytes, NULL}, fdevice->isLargeFlash ? 5 : 4, false, NULL},
+            {.u.buffers = {NULL, buffer}, length, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     // Patch the readBytes command

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -288,7 +288,7 @@ static void m25p16_eraseSector(flashDevice_t *fdevice, uint32_t address)
     };
 
     // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(fdevice->io.handle.dev);
+    spiWait(fdevice->io.handle.dev);
 
     m25p16_setCommandAddress(&sectorErase[1], address, fdevice->isLargeFlash);
 
@@ -311,9 +311,6 @@ static void m25p16_eraseCompletely(flashDevice_t *fdevice)
             {bulkErase, NULL, sizeof(bulkErase), true, NULL},
             {NULL, NULL, 0, true, NULL},
     };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(fdevice->io.handle.dev);
 
     spiSequence(fdevice->io.handle.dev, segments);
 
@@ -346,7 +343,7 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
     };
 
     // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(fdevice->io.handle.dev);
+    spiWait(fdevice->io.handle.dev);
 
     // Patch the pageProgram segment
     segments[PAGE_PROGRAM].len = fdevice->isLargeFlash ? 5 : 4;
@@ -427,7 +424,7 @@ static int m25p16_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *b
     STATIC_DMA_DATA_AUTO uint8_t readBytes[5] = { M25P16_INSTRUCTION_READ_BYTES };
 
     // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(fdevice->io.handle.dev);
+    spiWait(fdevice->io.handle.dev);
 
     busSegment_t segments[] = {
             {readStatus, readyStatus, sizeof(readStatus), true, m25p16_callbackReady},

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -73,8 +73,8 @@ static void w25m_dieSelect(const extDevice_t *dev, int die)
     uint8_t command[2] = { W25M_INSTRUCTION_SOFTWARE_DIE_SELECT, die };
 
     busSegment_t segments[] = {
-            {command, NULL, sizeof(command), true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {command, NULL}, sizeof(command), true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     // Ensure any prior DMA has completed before continuing

--- a/src/main/drivers/flash_w25n01g.c
+++ b/src/main/drivers/flash_w25n01g.c
@@ -154,9 +154,6 @@ static void w25n01g_performOneByteCommand(flashDeviceIO_t *io, uint8_t command)
                 {NULL, NULL, 0, true, NULL},
         };
 
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(dev);
-
         spiSequence(dev, &segments[0]);
 
         // Block pending completion of SPI access
@@ -181,9 +178,6 @@ static void w25n01g_performCommandWithPageAddress(flashDeviceIO_t *io, uint8_t c
                 {cmd, NULL, sizeof(cmd), true, NULL},
                 {NULL, NULL, 0, true, NULL},
         };
-
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(dev);
 
         spiSequence(dev, &segments[0]);
 
@@ -419,9 +413,6 @@ static void w25n01g_programDataLoad(flashDevice_t *fdevice, uint16_t columnAddre
                  {NULL, NULL, 0, true, NULL},
          };
 
-         // Ensure any prior DMA has completed before continuing
-         spiWaitClaim(dev);
-
          spiSequence(dev, &segments[0]);
 
          // Block pending completion of SPI access
@@ -452,9 +443,6 @@ static void w25n01g_randomProgramDataLoad(flashDevice_t *fdevice, uint16_t colum
                 {(uint8_t *)data, NULL, length, true, NULL},
                 {NULL, NULL, 0, true, NULL},
         };
-
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(dev);
 
         spiSequence(dev, &segments[0]);
 
@@ -699,9 +687,6 @@ int w25n01g_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer,
                 {NULL, NULL, 0, true, NULL},
         };
 
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(dev);
-
         spiSequence(dev, &segments[0]);
 
         // Block pending completion of SPI access
@@ -866,9 +851,6 @@ void w25n01g_readBBLUT(flashDevice_t *fdevice, bblut_t *bblut, int lutsize)
                 {NULL, in, sizeof(in), true, w25n01g_readBBLUTCallback},
                 {NULL, NULL, 0, true, NULL},
         };
-
-        // Ensure any prior DMA has completed before continuing
-        spiWaitClaim(dev);
 
         spiSequence(dev, &segments[0]);
 

--- a/src/main/drivers/flash_w25n01g.c
+++ b/src/main/drivers/flash_w25n01g.c
@@ -150,8 +150,8 @@ static void w25n01g_performOneByteCommand(flashDeviceIO_t *io, uint8_t command)
         extDevice_t *dev = io->handle.dev;
 
         busSegment_t segments[] = {
-                {&command, NULL, sizeof(command), true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {&command, NULL}, sizeof(command), true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         spiSequence(dev, &segments[0]);
@@ -175,8 +175,8 @@ static void w25n01g_performCommandWithPageAddress(flashDeviceIO_t *io, uint8_t c
         uint8_t cmd[] = { command, 0, (pageAddress >> 8) & 0xff, (pageAddress >> 0) & 0xff};
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         spiSequence(dev, &segments[0]);
@@ -202,8 +202,8 @@ static uint8_t w25n01g_readRegister(flashDeviceIO_t *io, uint8_t reg)
         uint8_t in[3];
 
         busSegment_t segments[] = {
-                {cmd, in, sizeof(cmd), true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, in}, sizeof(cmd), true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         // Ensure any prior DMA has completed before continuing
@@ -237,8 +237,8 @@ static void w25n01g_writeRegister(flashDeviceIO_t *io, uint8_t reg, uint8_t data
         uint8_t cmd[3] = { W25N01G_INSTRUCTION_WRITE_STATUS_REG, reg, data };
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         // Ensure any prior DMA has completed before continuing
@@ -408,9 +408,9 @@ static void w25n01g_programDataLoad(flashDevice_t *fdevice, uint16_t columnAddre
         uint8_t cmd[] = { W25N01G_INSTRUCTION_PROGRAM_DATA_LOAD, columnAddress >> 8, columnAddress & 0xff };
 
          busSegment_t segments[] = {
-                 {cmd, NULL, sizeof(cmd), false, NULL},
-                 {(uint8_t *)data, NULL, length, true, NULL},
-                 {NULL, NULL, 0, true, NULL},
+                 {.u.buffers = {cmd, NULL}, sizeof(cmd), false, NULL},
+                 {.u.buffers = {(uint8_t *)data, NULL}, length, true, NULL},
+                 {.u.buffers = {NULL, NULL}, 0, true, NULL},
          };
 
          spiSequence(dev, &segments[0]);
@@ -439,9 +439,9 @@ static void w25n01g_randomProgramDataLoad(flashDevice_t *fdevice, uint16_t colum
         extDevice_t *dev = fdevice->io.handle.dev;
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), false, NULL},
-                {(uint8_t *)data, NULL, length, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), false, NULL},
+                {.u.buffers = {(uint8_t *)data, NULL}, length, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         spiSequence(dev, &segments[0]);
@@ -682,9 +682,9 @@ int w25n01g_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer,
         cmd[3] = 0;
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), false, NULL},
-                {NULL, buffer, length, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), false, NULL},
+                {.u.buffers = {NULL, buffer}, length, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         spiSequence(dev, &segments[0]);
@@ -747,9 +747,9 @@ int w25n01g_readExtensionBytes(flashDevice_t *fdevice, uint32_t address, uint8_t
         cmd[3] = 0;
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), false, NULL},
-                {NULL, buffer, length, true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), false, NULL},
+                {.u.buffers = {NULL, buffer}, length, true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         // Ensure any prior DMA has completed before continuing
@@ -811,7 +811,7 @@ busStatus_e w25n01g_readBBLUTCallback(uint32_t arg)
 {
     cb_context_t *cb_context = (cb_context_t *)arg;
     flashDevice_t *fdevice = cb_context->fdevice;
-    uint8_t *rxData = fdevice->io.handle.dev->bus->curSegment->rxData;
+    uint8_t *rxData = fdevice->io.handle.dev->bus->curSegment->u.buffers.rxData;
 
 
     cb_context->bblut->pba = (rxData[0] << 16)|rxData[1];
@@ -847,9 +847,9 @@ void w25n01g_readBBLUT(flashDevice_t *fdevice, bblut_t *bblut, int lutsize)
         cb_context.lutindex = 0;
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), false, NULL},
-                {NULL, in, sizeof(in), true, w25n01g_readBBLUTCallback},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), false, NULL},
+                {.u.buffers = {NULL, in}, sizeof(in), true, w25n01g_readBBLUTCallback},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         spiSequence(dev, &segments[0]);
@@ -887,8 +887,8 @@ void w25n01g_writeBBLUT(flashDevice_t *fdevice, uint16_t lba, uint16_t pba)
         uint8_t cmd[5] = { W25N01G_INSTRUCTION_BB_MANAGEMENT, lba >> 8, lba, pba >> 8, pba };
 
         busSegment_t segments[] = {
-                {cmd, NULL, sizeof(cmd), true, NULL},
-                {NULL, NULL, 0, true, NULL},
+                {.u.buffers = {cmd, NULL}, sizeof(cmd), true, NULL},
+                {.u.buffers = {NULL, NULL}, 0, true, NULL},
         };
 
         // Ensure any prior DMA has completed before continuing

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -631,9 +631,6 @@ bool max7456DrawScreen(void)
             return true;
         }
 
-        // Ensure any prior DMA has completed before overwriting the buffer
-        spiWaitClaim(dev);
-
         // Allow for 8 bytes followed by an ESCAPE and reset of DMM at end of buffer
         maxSpiBufStartIndex -= 12;
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -611,8 +611,8 @@ bool max7456DrawScreen(void)
     static uint16_t pos = 0;
     // This routine doesn't block so need to use static data
     static busSegment_t segments[] = {
-            {NULL, NULL, 0, true, NULL},
-            {NULL, NULL, 0, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
+            {.u.buffers = {NULL, NULL}, 0, true, NULL},
     };
 
     if (!fontIsLoading) {
@@ -693,7 +693,7 @@ bool max7456DrawScreen(void)
         }
 
         if (spiBufIndex) {
-            segments[0].txData = spiBuf;
+            segments[0].u.buffers.txData = spiBuf;
             segments[0].len = spiBufIndex;
 
             spiSequence(dev, &segments[0]);

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -98,8 +98,6 @@ bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig)
         return false;
     }
 
-    spiSetAtomicWait(dev);
-
     const IO_t rxCsPin = IOGetByTag(rxSpiConfig->csnTag);
     IOInit(rxCsPin, OWNER_RX_SPI_CS, 0);
     IOConfigGPIO(rxCsPin, SPI_IO_CS_CFG);

--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -174,9 +174,6 @@ static bool sdcard_waitForIdle(int maxBytesToWait)
 
     sdcard.idleCount = maxBytesToWait;
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
-
     spiSequence(&sdcard.dev, &segments[0]);
 
     // Block pending completion of SPI access
@@ -201,9 +198,6 @@ static uint8_t sdcard_waitForNonIdleByte(int maxDelay)
     };
 
     sdcard.idleCount = maxDelay;
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
 
     spiSequence(&sdcard.dev, &segments[0]);
 
@@ -247,9 +241,6 @@ static uint8_t sdcard_sendCommand(uint8_t commandCode, uint32_t commandArgument)
         return 0xFF;
 
     sdcard.idleCount = SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY;
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
 
     spiSequence(&sdcard.dev, &segments[0]);
 
@@ -374,9 +365,6 @@ static sdcardReceiveBlockStatus_e sdcard_receiveDataBlock(uint8_t *buffer, int c
             {NULL, NULL, 0, false, NULL},
         };
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
-
     spiSequence(&sdcard.dev, &segments[0]);
 
     // Block pending completion of SPI access
@@ -395,9 +383,6 @@ static bool sdcard_sendDataBlockFinish(void)
             {NULL, &dataResponseToken, sizeof(dataResponseToken), false, NULL},
             {NULL, NULL, 0, false, NULL},
         };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
 
     spiSequence(&sdcard.dev, &segments[0]);
 
@@ -439,9 +424,6 @@ static void sdcard_sendDataBlockBegin(uint8_t *buffer, bool multiBlockWrite)
 
     segments[2].txData = buffer;
     segments[2].len = spiUseDMA(&sdcard.dev) ? SDCARD_BLOCK_SIZE : SDCARD_NON_DMA_CHUNK_SIZE;
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
 
     spiSequence(&sdcard.dev, &segments[0]);
 
@@ -584,9 +566,6 @@ static void sdcardSpi_init(const sdcardConfig_t *config, const spiPinConfig_t *s
             {NULL, NULL, 0, false, NULL},
         };
 
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
-
     spiSequence(&sdcard.dev, &segments[0]);
 
     // Block pending completion of SPI access
@@ -638,9 +617,6 @@ static sdcardOperationStatus_e sdcard_endWriteBlocks(void)
             {&token, NULL, sizeof(token), false, NULL},
             {NULL, NULL, 0, false, NULL},
         };
-
-    // Ensure any prior DMA has completed before continuing
-    spiWaitClaim(&sdcard.dev);
 
     spiSequence(&sdcard.dev, &segments[0]);
 


### PR DESCRIPTION
There was a potential race condition which this PR addresses, and in the process simplifies the SPI API by removing the `spiSetAtomicAccess()` and `spiWaitClaim()` routine. Claiming the bus, and queuing accesses if required is now handled entirely within the call to `spiSequence()`.

I'd be grateful for any testing of FCs with devices sharing an SPI bus.