### PR TITLE
Fix MSP over CRSF for larger read and writes

### DIFF
--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -68,6 +68,8 @@ typedef enum {
 } mspPendingSystemRequest_e;
 
 #define MSP_PORT_INBUF_SIZE 192
+#define MSP_PORT_OUTBUF_SIZE_MIN 320
+
 #ifdef USE_FLASHFS
 #ifdef STM32F1
 #define MSP_PORT_DATAFLASH_BUFFER_SIZE 1024
@@ -77,7 +79,7 @@ typedef enum {
 #define MSP_PORT_DATAFLASH_INFO_SIZE 16
 #define MSP_PORT_OUTBUF_SIZE (MSP_PORT_DATAFLASH_BUFFER_SIZE + MSP_PORT_DATAFLASH_INFO_SIZE)
 #else
-#define MSP_PORT_OUTBUF_SIZE 320 // As of 2021/08/10 MSP_BOXNAMES generates a 307 byte response for page 1.
+#define MSP_PORT_OUTBUF_SIZE MSP_PORT_OUTBUF_SIZE_MIN // As of 2021/08/10 MSP_BOXNAMES generates a 307 byte response for page 1.
 #endif
 
 typedef struct __attribute__((packed)) {

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -48,7 +48,7 @@
 
 #include "telemetry/crsf.h"
 
-#define CRSF_TIME_NEEDED_PER_FRAME_US   1100 // 700 ms + 400 ms for potential ad-hoc request
+#define CRSF_TIME_NEEDED_PER_FRAME_US   1750 // a maximally sized 64byte payload will take ~1550us, round up to 1750.
 #define CRSF_TIME_BETWEEN_FRAMES_US     6667 // At fastest, frames are sent by the transmitter every 6.667 milliseconds, 150 Hz
 
 #define CRSF_DIGITAL_CHANNEL_MIN 172

--- a/src/main/telemetry/msp_shared.h
+++ b/src/main/telemetry/msp_shared.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#define MSP_TLM_INBUF_SIZE 128
-#define MSP_TLM_OUTBUF_SIZE 128
+#define MSP_TLM_INBUF_SIZE MSP_PORT_INBUF_SIZE
+#define MSP_TLM_OUTBUF_SIZE MSP_PORT_OUTBUF_SIZE_MIN
 
 // type of function to send MSP response chunk over telemetry.
 typedef void (*mspResponseFnPtr)(uint8_t *payload, const uint8_t payloadSize);

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -51,6 +51,7 @@ extern "C" {
     #include "io/gps.h"
 
     #include "msp/msp.h"
+    #include "msp/msp_serial.h"
 
     #include "rx/rx.h"
     #include "rx/crsf.h"

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -57,6 +57,8 @@ extern "C" {
     #include "sensors/sensors.h"
     #include "sensors/acceleration.h"
 
+    #include "msp/msp_serial.h"
+
     #include "telemetry/crsf.h"
     #include "telemetry/telemetry.h"
     #include "telemetry/msp_shared.h"


### PR DESCRIPTION
MSP over CRSF was not working for larger read/write requests for two reasons:

1. Insufficient buffer allocation in MSP_TLM_OUTBUF_SIZE/MSP_TLM_INBUF_SIZE
2. Too short of a CRSF_TIME_NEEDED_PER_FRAME_US timeout to ingest a full-sized CRSF frame. 

This PR adjusts the MSP telemetry buffers to be the same as MSP_PORT_OUTBUF_SIZE and increases the CRSF packet read timeout to able to accept the maximum sized 64byte CRSF frame. 

Please consider this for RC2 as this is a bugfix in my opinion. 