### PR TITLE
Don't allow bidirectional DSHOT600 on an F411

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -618,6 +618,16 @@ void validateAndFixGyroConfig(void)
 
         // check for looptime restrictions based on motor protocol. Motor times have safety margin
         float motorUpdateRestriction;
+
+#if defined(STM32F40_41xxx) || defined(STM32F411xE)
+        /* If bidirectional DSHOT is being used on an F411 then force DSHOT300. The motor update restrictions then applied
+         * will automatically consider the loop time and adjust pid_process_denom appropriately
+         */
+        if (motorConfig()->dev.useDshotTelemetry && (motorConfig()->dev.motorPwmProtocol == PWM_TYPE_DSHOT600)) {
+            motorConfigMutable()->dev.motorPwmProtocol = PWM_TYPE_DSHOT300;
+        }
+#endif
+
         switch (motorConfig()->dev.motorPwmProtocol) {
         case PWM_TYPE_STANDARD:
                 motorUpdateRestriction = 1.0f / BRUSHLESS_MOTORS_PWM_RATE;


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11221

This PR adds an additional check to `validateAndFixGyroConfig()` which detects an attempt to use bidirectional DSHOT600 on an F411 and if found will force DSHOT300. In turn this will result in the pid loop denominator being set appropriately for DSHOT300, which with an MPU6000 gyro, for example, will mean a 4K PID loop. With a BMI160 gyro the loop time would not be affected.

Usability is important and whilst automatic application of settings contrary to what the user has selected is bad, this avoids "this firmware has bricked my FC" type claims.