### PR TITLE
ExpressLRS - Fix compilation of unit test.

### DIFF
--- a/src/main/rx/expresslrs.c
+++ b/src/main/rx/expresslrs.c
@@ -98,7 +98,10 @@ typedef struct eprState_s {
     bool eventRecorded[EPR_EVENT_COUNT];
 } eprState_t;
 
-eprState_t eprState = {0};
+eprState_t eprState = {
+    .eventAtUs = {0},
+    .eventRecorded = {0},
+};
 
 static void expressLrsEPRRecordEvent(eprEvent_e event, uint32_t currentTimeUs)
 {


### PR DESCRIPTION
Error was:

```
compiling ../main/rx/expresslrs.c
../main/rx/expresslrs.c:101:24: error: suggest braces around
initialization of subobject [-Werror,-Wmissing-braces]
eprState_t eprState = {0};
```
