### PR TITLE
Ignore time taken to update EEPROM as otherwise stick commands can ups…

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -761,6 +761,9 @@ void ensureEEPROMStructureIsValid(void)
 
 void saveConfigAndNotify(void)
 {
+    // The write to EEPROM will cause a big delay in the current task, so ignore
+    schedulerIgnoreTaskExecTime();
+
     writeEEPROM();
     readEEPROM();
     beeperConfirmationBeeps(1);

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -806,6 +806,9 @@ void changePidProfileFromCellCount(uint8_t cellCount)
 
 void changePidProfile(uint8_t pidProfileIndex)
 {
+    // The config switch will cause a big enough delay in the current task to upset the scheduler
+    schedulerIgnoreTaskExecTime();
+
     if (pidProfileIndex < PID_PROFILE_COUNT) {
         systemConfigMutable()->pidProfileIndex = pidProfileIndex;
         loadPidProfile();

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -115,7 +115,7 @@
 
 // taskUpdateRxMain() has occasional peaks in execution time so normal moving average duration estimation doesn't work
 // Decay the estimated max task duration by 1/(1 << RX_TASK_DECAY_SHIFT) on every invocation
-#define RX_TASK_DECAY_SHIFT 5
+#define RX_TASK_DECAY_SHIFT 7
 // Add a margin to the task duration estimation
 #define RX_TASK_MARGIN 1
 

--- a/src/main/rx/expresslrs.c
+++ b/src/main/rx/expresslrs.c
@@ -840,15 +840,15 @@ bool expressLrsSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeSta
     }
 
     rxSpiCommonIOInit(rxConfig);
-	
+    
     rxRuntimeState->channelCount = ELRS_MAX_CHANNELS;
-	
+    
     extiConfig->ioConfig = IOCFG_IPD;
     extiConfig->trigger = BETAFLIGHT_EXTI_TRIGGER_RISING;
 
     if (rxExpressLrsSpiConfig()->resetIoTag) {
         receiver.resetPin = IOGetByTag(rxExpressLrsSpiConfig()->resetIoTag);
-	} else {
+    } else {
         receiver.resetPin = IO_NONE;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11226

Issue was caused by write of config to FLASH (THR_LO + YAW_LO + PIT_LO + ROL_HI) which took ~20ms and upset the RX task scheduling. `tasks` command run after this showed the issue.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)      8       5       4    0.0%    0.0%         0      1     49       4
01 - (         SYSTEM)    497      11       6    0.5%    0.2%        90      2   4888       6
02 - (           GYRO)   7491      14       5   10.4%    3.7%       571      0  48385       0
03 - (         FILTER)   7491      25      22   18.7%   16.4%      2838      0  48385       0
04 - (            PID)   7491      51      43   38.2%   32.2%      8082      0  48385       0
05 - (            ACC)    497      13       9    0.6%    0.4%       105      4   4887       9
06 - (       ATTITUDE)     53      18      16    0.0%    0.0%        42      0    490      16
07 - (             RX)     41   19642   19640   80.5%   80.5%       296      9   2502   19640
...
```