### PR TITLE
Fix H7 USART1 AF for PB6 and PB7

### DIFF
--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -113,12 +113,12 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
 #endif
         .rxPins = {
             { DEFIO_TAG_E(PA10), GPIO_AF7_USART1 },
-            { DEFIO_TAG_E(PB7),  GPIO_AF4_USART1 },
+            { DEFIO_TAG_E(PB7),  GPIO_AF7_USART1 },
             { DEFIO_TAG_E(PB15), GPIO_AF4_USART1 },
         },
         .txPins = {
             { DEFIO_TAG_E(PA9),  GPIO_AF7_USART1 },
-            { DEFIO_TAG_E(PB6),  GPIO_AF4_USART1 },
+            { DEFIO_TAG_E(PB6),  GPIO_AF7_USART1 },
             { DEFIO_TAG_E(PB14), GPIO_AF4_USART1 },
         },
         .rcc = RCC_APB2(USART1),


### PR DESCRIPTION
AF mapping was incorrect. Checked that AF7 is correct for H743 and H750
