### PR TITLE
Fix max7456ConfigMutable()->clockConfig for OMNIBUSF4

### DIFF
--- a/src/main/target/OMNIBUSF4/config.c
+++ b/src/main/target/OMNIBUSF4/config.c
@@ -63,7 +63,7 @@ void targetConfiguration(void)
 {
 #ifdef OMNIBUSF4BASE
     // OMNIBUS F4 AIO (1st gen) has a AB7456 chip that is detected as MAX7456
-    max7456ConfigMutable()->clockConfig = MAX7456_CLOCK_CONFIG_FULL;
+    max7456ConfigMutable()->clockConfig = MAX7456_CLOCK_CONFIG_NOMINAL;
 #endif
 
 #ifdef EXUAVF4PRO


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/commit/5ef34f79d509303756cd39328409dafad43b9b13#commitcomment-63094050