### PR TITLE
Only allocate DMA streams for SPI_MOSI 1/SPI_MISO 1 if enabled on F4

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -567,16 +567,16 @@ void spiInitBusDMA()
 
             if (dmaTxChannelSpec) {
                 dmaTxIdentifier = dmaGetIdentifier(dmaTxChannelSpec->ref);
-                if (!dmaAllocate(dmaTxIdentifier, OWNER_SPI_MOSI, device + 1)) {
-                    dmaTxIdentifier = DMA_NONE;
-                    continue;
-                }
 #if defined(STM32F4) && defined(USE_DSHOT_BITBANG)
                 if (dshotBitbangActive && (DMA_DEVICE_NO(dmaTxIdentifier) == 2)) {
                     dmaTxIdentifier = DMA_NONE;
                     break;
                 }
 #endif
+                if (!dmaAllocate(dmaTxIdentifier, OWNER_SPI_MOSI, device + 1)) {
+                    dmaTxIdentifier = DMA_NONE;
+                    continue;
+                }
                 bus->dmaTx = dmaGetDescriptorByIdentifier(dmaTxIdentifier);
                 bus->dmaTx->stream = DMA_DEVICE_INDEX(dmaTxIdentifier);
                 bus->dmaTx->channel = dmaTxChannelSpec->channel;
@@ -601,16 +601,16 @@ void spiInitBusDMA()
 
             if (dmaRxChannelSpec) {
                 dmaRxIdentifier = dmaGetIdentifier(dmaRxChannelSpec->ref);
-                if (!dmaAllocate(dmaRxIdentifier, OWNER_SPI_MISO, device + 1)) {
-                    dmaRxIdentifier = DMA_NONE;
-                    continue;
-                }
 #if defined(STM32F4) && defined(USE_DSHOT_BITBANG)
                 if (dshotBitbangActive && (DMA_DEVICE_NO(dmaRxIdentifier) == 2)) {
                     dmaRxIdentifier = DMA_NONE;
                     break;
                 }
 #endif
+                if (!dmaAllocate(dmaRxIdentifier, OWNER_SPI_MISO, device + 1)) {
+                    dmaRxIdentifier = DMA_NONE;
+                    continue;
+                }
                 bus->dmaRx = dmaGetDescriptorByIdentifier(dmaRxIdentifier);
                 bus->dmaRx->stream = DMA_DEVICE_INDEX(dmaRxIdentifier);
                 bus->dmaRx->channel = dmaRxChannelSpec->channel;


### PR DESCRIPTION
Currently DMA streams are allocated for SPI bus 1 on an F4 even if they are disabled due to bit banged DSHOT being used thus:

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: FREE
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC 1
DMA2 Stream 1: DSHOT_BITBANG 2
DMA2 Stream 2: SPI_MISO 1
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

This PR prevents this allocation if they're not being used, to free up these resources to allow more freedom in allocating `DSHOT_BITBANG` streams where multiple ports are used for motor pins. It is also confusing to have unused streams allocated and this change makes is cleared that DMA on SPI 1 has not been enabled when bit banged DSHOT is enabled.

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: FREE
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: ADC 1
DMA2 Stream 1: DSHOT_BITBANG 2
DMA2 Stream 2: FREE
DMA2 Stream 3: FREE
DMA2 Stream 4: FREE
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```