### PR TITLE
Ignore duration of calcActiveAdjustmentRanges() and optimize RX_TASK_DECAY_SHIFT

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -61,6 +61,8 @@
 
 #include "rc_adjustments.h"
 
+#include "scheduler/scheduler.h"
+
 #define ADJUSTMENT_RANGE_COUNT_INVALID -1
 
 PG_REGISTER_ARRAY(adjustmentRange_t, MAX_ADJUSTMENT_RANGE_COUNT, adjustmentRanges, PG_ADJUSTMENT_RANGE_CONFIG, 2);
@@ -834,6 +836,8 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig)
 
     // Recalculate the new active adjustments if required
     if (stepwiseAdjustmentCount == ADJUSTMENT_RANGE_COUNT_INVALID) {
+        // This can take up to 30us and is only call when not armed so ignore this timing as it doesn't impact flight
+        schedulerIgnoreTaskExecTime();
         calcActiveAdjustmentRanges();
     }
 

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -115,7 +115,7 @@
 
 // taskUpdateRxMain() has occasional peaks in execution time so normal moving average duration estimation doesn't work
 // Decay the estimated max task duration by 1/(1 << RX_TASK_DECAY_SHIFT) on every invocation
-#define RX_TASK_DECAY_SHIFT 7
+#define RX_TASK_DECAY_SHIFT 6
 // Add a margin to the task duration estimation
 #define RX_TASK_MARGIN 1
 

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -656,4 +656,5 @@ void setLedProfile(uint8_t profile) { UNUSED(profile); }
 uint8_t getLedProfile(void) { return 0; }
 void compassStartCalibration(void) {}
 void pinioBoxTaskControl(void) {}
+void schedulerIgnoreTaskExecTime(void) {}
 }


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11258
Fixes: https://github.com/betaflight/betaflight/issues/11246

On startup, and whilst not armed, a call to `calcActiveAdjustmentRanges()` from the `RX` task's `RX_TASK_DECAY_SHIFT` state took approx 30us and the scheduler's estimate of how long that state would subsequently take to execute was increased accordingly. The `RX` task could not then be scheduled at the desired rate and thus the link could not be established. The scheduler's estimates of task duration are based on a peak hold with decay and this peak of 30us additional time was taking some time to reduce hence the fact it was taking some time to establish the RC connection.

This PR tells the scheduler to ignore the extra time taken to call `calcActiveAdjustmentRanges()` preventing the scheduler's estimate of the time needed to execute the `RX_TASK_DECAY_SHIFT` state being increased. Whilst doing this means the RX task could then overrun it's time slot and break determinism, this situation only occurs whilst disarmed (and thus isn't so important), and also only happens once.

In addition this PR tunes the value of `RX_TASK_DECAY_SHIFT` which controls the rate at which the scheduler's estimate of RX task state execution decays after a peak. Too fast as the estimate won't be enough and tasks will be late, too slow and there's a risk of the task not being scheduled.