### PR TITLE
Bring back F405 bidirectional DSHOT600

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -619,7 +619,7 @@ void validateAndFixGyroConfig(void)
         // check for looptime restrictions based on motor protocol. Motor times have safety margin
         float motorUpdateRestriction;
 
-#if defined(STM32F40_41xxx) || defined(STM32F411xE)
+#if defined(STM32F411xE)
         /* If bidirectional DSHOT is being used on an F411 then force DSHOT300. The motor update restrictions then applied
          * will automatically consider the loop time and adjust pid_process_denom appropriately
          */


### PR DESCRIPTION
Looks like it was accidentally disabled in #11198 