### PR TITLE
Make bitbang DSHOT the default for F4

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -328,13 +328,8 @@ timeMs_t motorGetMotorEnableTimeMs(void)
 #ifdef USE_DSHOT_BITBANG
 bool isDshotBitbangActive(const motorDevConfig_t *motorDevConfig)
 {
-#ifdef STM32F4
-    return motorDevConfig->useDshotBitbang == DSHOT_BITBANG_ON ||
-        (motorDevConfig->useDshotBitbang == DSHOT_BITBANG_AUTO && motorDevConfig->useDshotTelemetry && motorDevConfig->motorPwmProtocol != PWM_TYPE_PROSHOT1000);
-#else
     return motorDevConfig->useDshotBitbang == DSHOT_BITBANG_ON ||
         (motorDevConfig->useDshotBitbang == DSHOT_BITBANG_AUTO && motorDevConfig->motorPwmProtocol != PWM_TYPE_PROSHOT1000);
-#endif
 }
 #endif
 


### PR DESCRIPTION
A number of people have reported laggy/crawling updates of the OSD on the F411. The default for F4 processors had been for DSHOT bitbang to be disabled if `dshot_bitbang=AUTO` which resulted in the motors being assigned to DMA streams in such a way that the SPI 2 DMA resources could not be assigned. Consequently the OSD was forced to run in polled mode which struggled to maintain the required transfers from the OSD frame buffer to the MAX7456 device.

With bitbang DSHOT disabled, as had been the default, it can be seen that `SPI_MOSI 2` is not assigned. The blow is from a MATEKF411SE.
```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: MOTOR 1
DMA1 Stream 5: MOTOR 2
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: SPI_MISO 1
DMA2 Stream 1: MOTOR 3
DMA2 Stream 2: MOTOR 4
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: ADC 1
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

Taken over 5 seconds, with an admittedly busy OSD display, it can be seen that with DMA disabled the OSD task used 1078 ms of processor time.

![image](https://user-images.githubusercontent.com/11480839/149144972-7eb74936-9506-442f-a393-5e5147b55afb.png)


```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       6       5    0.0%    0.0%         1      1     50       5
01 - (         SYSTEM)    988       6       4    0.5%    0.3%       125      0   4917       4
02 - (           GYRO)   8006      24      16   19.2%   12.8%      9020      0  39760       0
03 - (         FILTER)   4002      43      32   17.2%   12.8%     11399      0  19880       0
04 - (            PID)   4002      77      68   30.8%   27.2%     32983      0  19880       0
05 - (            ACC)    989       9       6    0.8%    0.5%       433      5   4915       6
06 - (       ATTITUDE)    100      15      14    0.1%    0.1%       135      0    496      14
07 - (             RX)     15      28       6    0.0%    0.0%       126      0    300      20
08 - (         SERIAL)     99   12999      44  128.6%    0.4%      1206      0    493      44
09 - (       DISPATCH)    988       6       4    0.5%    0.3%       103      6   4921       4
10 - (BATTERY_VOLTAGE)     50       7       5    0.0%    0.0%        12      0    249       5
11 - (BATTERY_CURRENT)     50       6       5    0.0%    0.0%         6      0    249       5
12 - ( BATTERY_ALERTS)      5       6       5    0.0%    0.0%         0      0     25       5
13 - (         BEEPER)     99       3       2    0.0%    0.0%        16      0    493       2
18 - (      TELEMETRY)    249       5       4    0.1%    0.0%        23      1   1235       4
20 - (            OSD)     11      45      79    0.0%    0.0%      1078      6   1920      79
22 - (            CMS)     10       6       5    0.0%    0.0%         2      1     50       5
23 - (        VTXCTRL)      2       1       1    0.0%    0.0%         0      0      9       1
24 - (        CAMCTRL)      3       1       3    0.0%    0.0%         0      0     12       3
26 - (    ADCINTERNAL)      1       3       6    0.0%    0.0%         0      0      2       6
RX Check Function                  12       5                       300
Total (excluding SERIAL)                                54.0%
```

With bitbang DSHOT enabled the SPI_MOSI and SPI_MISO streams for SPI bus 2 are allocated, enabling DMA.
```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: FREE
DMA1 Stream 1: FREE
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: FREE
DMA1 Stream 6: FREE
DMA1 Stream 7: FREE
DMA2 Stream 0: FREE
DMA2 Stream 1: DSHOT_BITBANG 2
DMA2 Stream 2: DSHOT_BITBANG 1
DMA2 Stream 3: FREE
DMA2 Stream 4: ADC 1
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

Taken over 5 seconds it can be seen that with DMA enabled the OSD task used only 92 ms of processor time. 
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       2    0.0%    0.0%         0      0     50       2
01 - (         SYSTEM)    983       3       2    0.2%    0.1%        17      0   4831       2
02 - (           GYRO)   7874      18      11   14.1%    8.6%      1524      0  38679       0
03 - (         FILTER)   3935      29      26   11.4%   10.2%      1701      0  19340       0
04 - (            PID)   3935      71      68   27.9%   26.7%      4976      0  19339       0
05 - (            ACC)    983      16      10    1.5%    0.9%       185      1   4830      10
06 - (       ATTITUDE)    100      11      10    0.1%    0.1%        18      0    490      10
07 - (             RX)     15      26       3    0.0%    0.0%        17      0    292      16
08 - (         SERIAL)     99    9284      27   91.9%    0.2%      1130      0    488      27
09 - (       DISPATCH)    983       2       0    0.1%    0.0%        13      0   4831       0
10 - (BATTERY_VOLTAGE)     50       2       1    0.0%    0.0%         1      0    245       1
11 - (BATTERY_CURRENT)     50       2       1    0.0%    0.0%         0      0    245       0
12 - ( BATTERY_ALERTS)      6       2       1    0.0%    0.0%         0      0     25       1
13 - (         BEEPER)     99       3       2    0.0%    0.0%         2      0    488       2
18 - (      TELEMETRY)    246       2       0    0.0%    0.0%         5      0   1208       0
20 - (            OSD)     12      41       4    0.0%    0.0%        92      2   1180      59
22 - (            CMS)     20       2       1    0.0%    0.0%         0      0     98       1
23 - (        VTXCTRL)      6       1       0    0.0%    0.0%         0      0     25       1
24 - (        CAMCTRL)      6       1       1    0.0%    0.0%         0      0     25       1
26 - (    ADCINTERNAL)      3       3       2    0.0%    0.0%         0      0      5       3
RX Check Function                   8       4                        26
Total (excluding SERIAL)                                46.6%
```