### PR TITLE
[WIP ]Add rounding to proper display dshot values

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1089,7 +1089,7 @@ static void loadMainState(timeUs_t currentTimeUs)
 
     const int motorCount = getMotorCount();
     for (int i = 0; i < motorCount; i++) {
-        blackboxCurrent->motor[i] = motor[i];
+        blackboxCurrent->motor[i] = lrintf(motor[i]);
     }
 
     blackboxCurrent->vbatLatest = getBatteryVoltageLatest();

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -86,7 +86,7 @@ float dshotConvertFromExternal(uint16_t externalValue)
 
 uint16_t dshotConvertToExternal(float motorValue)
 {
-    uint16_t externalValue;
+    float externalValue;
 
     if (featureIsEnabled(FEATURE_3D)) {
         if (motorValue == DSHOT_CMD_MOTOR_STOP || motorValue < DSHOT_MIN_THROTTLE) {
@@ -100,7 +100,7 @@ uint16_t dshotConvertToExternal(float motorValue)
         externalValue = (motorValue < DSHOT_MIN_THROTTLE) ? PWM_RANGE_MIN : scaleRangef(motorValue, DSHOT_MIN_THROTTLE, DSHOT_MAX_THROTTLE, PWM_RANGE_MIN + 1, PWM_RANGE_MAX);
     }
 
-    return externalValue;
+    return lrintf(externalValue);
 }
 
 FAST_CODE uint16_t prepareDshotPacket(dshotProtocolControl_t *pcb)

--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -585,7 +585,7 @@ static void bbWriteInt(uint8_t motorIndex, uint16_t value)
 
 static void bbWrite(uint8_t motorIndex, float value)
 {
-    bbWriteInt(motorIndex, value);
+    bbWriteInt(motorIndex, lrintf(value));
 }
 
 static void bbUpdateComplete(void)


### PR DESCRIPTION
Fixed issue in DSHOT reporting only 1999 instead of 2000 on full throttle.

Use rounding also on BB DSHOT - it is already on dpwm.
Blackbox rounding.