### PR TITLE
revert 11141 re-enable gyro exti sync

### DIFF
--- a/src/main/target/KROOZX/target.h
+++ b/src/main/target/KROOZX/target.h
@@ -43,8 +43,7 @@
 // MPU6000 interrupts
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
-// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
-// #define USE_GYRO_EXTI
+#define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PA4
 
 #define USE_GYRO

--- a/src/main/target/NOX/target.h
+++ b/src/main/target/NOX/target.h
@@ -46,8 +46,7 @@
 
 
 #define USE_EXTI
-// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
-// #define USE_GYRO_EXTI
+#define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PA8
 
 #define USE_MPU_DATA_READY_SIGNAL

--- a/src/main/target/OMNIBUSF4FW/target.h
+++ b/src/main/target/OMNIBUSF4FW/target.h
@@ -85,10 +85,7 @@
 
 // MPU6000 interrupts
 #define USE_EXTI
-// disable EXTI when MAX7456 is on same SPI bus as gyro
-#if defined(OMNIBUSF4V6)
 #define USE_GYRO_EXTI
-#endif
 #define GYRO_1_EXTI_PIN         PC4
 #define GYRO_2_EXTI_PIN         NONE
 #define USE_MPU_DATA_READY_SIGNAL

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -37,8 +37,7 @@
 // Gyro interrupt
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
-// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
-// #define USE_GYRO_EXTI
+#define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4
 
 #define USE_ACC

--- a/src/main/target/YUPIF7/target.h
+++ b/src/main/target/YUPIF7/target.h
@@ -40,8 +40,7 @@
 #define SPI1_MOSI_PIN           PA7
 
 #define USE_EXTI
-// disable GYRO_EXTI when MAX7456 is on same SPI bus as gyro
-// #define USE_GYRO_EXTI
+#define USE_GYRO_EXTI
 #define GYRO_1_EXTI_PIN         PC4
 
 #define USE_MPU_DATA_READY_SIGNAL


### PR DESCRIPTION
Recent commits from Steve have fixed the original issue where boards with gyro and OSD on the same SPI line had intermittent gyro corruption when gyro_exti sync was enabled.  As an interim fix, we disabled gyro_exti for those boards in #11141.  

Now that the problem is fixed, this PR reverts #11141.
