### PR TITLE
If barometer read is still in progress ignore state execution time as it is short

### DIFF
--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -410,17 +410,19 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
         case BARO_STATE_TEMPERATURE_READ:
             if (baro.dev.read_ut(&baro.dev)) {
                 state = BARO_STATE_TEMPERATURE_SAMPLE;
+            } else {
+                // No action was taken as the read has not completed
+                schedulerIgnoreTaskStateTime();
             }
-            // No action was taken as the read has not completed
-            schedulerIgnoreTaskStateTime();
             break;
 
         case BARO_STATE_TEMPERATURE_SAMPLE:
             if (baro.dev.get_ut(&baro.dev)) {
                 state = BARO_STATE_PRESSURE_START;
+            } else {
+                // No action was taken as the read has not completed
+                schedulerIgnoreTaskStateTime();
             }
-            // No action was taken as the read has not completed
-            schedulerIgnoreTaskStateTime();
             break;
 
         case BARO_STATE_PRESSURE_START:

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -411,12 +411,16 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             if (baro.dev.read_ut(&baro.dev)) {
                 state = BARO_STATE_TEMPERATURE_SAMPLE;
             }
+            // No action was taken as the read has not completed
+            schedulerIgnoreTaskStateTime();
             break;
 
         case BARO_STATE_TEMPERATURE_SAMPLE:
             if (baro.dev.get_ut(&baro.dev)) {
                 state = BARO_STATE_PRESSURE_START;
             }
+            // No action was taken as the read has not completed
+            schedulerIgnoreTaskStateTime();
             break;
 
         case BARO_STATE_PRESSURE_START:
@@ -429,12 +433,15 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             if (baro.dev.read_up(&baro.dev)) {
                 state = BARO_STATE_PRESSURE_SAMPLE;
             } else {
+                // No action was taken as the read has not completed
                 schedulerIgnoreTaskStateTime();
             }
             break;
 
         case BARO_STATE_PRESSURE_SAMPLE:
             if (!baro.dev.get_up(&baro.dev)) {
+                // No action was taken as the read has not completed
+                schedulerIgnoreTaskStateTime();
                 break;
             }
 


### PR DESCRIPTION
In the barometer state machine reads are triggered on I2C/SPI. The next state will then check if the data read has completed and if so proceed with processing to the next state. If the bus is still busy however it will immediately return to try again in 1ms. That return is quick and not representative of the time being allowed by the scheduler for the real work to be done once the read has completed. Therefore tell the scheduler to ignore the time taken in these cases.

Tested on a JHEF7DUAL with a BMP280 baro where previously the BARO was was late approx. twice per second as a consequence of this issue. Now seen late only once in five minutes.
```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
...
16 - (           BARO)      0      37      36    0.0%    0.0%      1820      1  80511      35
```