### PR TITLE
 Fixing segmentation fault of SITL.

### DIFF
--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -243,8 +243,6 @@ void systemInit(void) {
         exit(1);
     }
 
-    // serial can't been slow down
-    rescheduleTask(TASK_SERIAL, 1);
 }
 
 void systemReset(void){


### PR DESCRIPTION
Currently, systemInit in SITL will call rescheduleTask, which will use uninitialized pointers and cause a segmentation fault.
I fixed this bug.
This is part of https://github.com/betaflight/betaflight/pull/11296