### PR TITLE
Remove LPUART1 from STM32G4 and SMT32H7 if no resource configured

### DIFF
--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -61,15 +61,13 @@ typedef struct dmaTimerMapping_s {
 #define REQMAP_DIR(periph, device, dir) { DMA_PERIPH_ ## periph ## _ ## dir, periph ## DEV_ ## device, DMA_REQUEST_ ## periph ## device ## _ ## dir }
 #define REQMAP_TIMUP(periph, timno) { DMA_PERIPH_TIMUP, timno - 1, DMA_REQUEST_ ## TIM ## timno ## _UP }
 
-// Resolve UART/USART mess, also map UART6 requests to LPUART1 requests
+// Resolve UART/USART mess
 #define DMA_REQUEST_UART1_RX DMA_REQUEST_USART1_RX
 #define DMA_REQUEST_UART1_TX DMA_REQUEST_USART1_TX
 #define DMA_REQUEST_UART2_RX DMA_REQUEST_USART2_RX
 #define DMA_REQUEST_UART2_TX DMA_REQUEST_USART2_TX
 #define DMA_REQUEST_UART3_RX DMA_REQUEST_USART3_RX
 #define DMA_REQUEST_UART3_TX DMA_REQUEST_USART3_TX
-#define DMA_REQUEST_UART9_RX DMA_REQUEST_LPUART1_RX
-#define DMA_REQUEST_UART9_TX DMA_REQUEST_LPUART1_TX
 
 // Resolve our preference for MOSI/MISO rather than TX/RX
 #define DMA_REQUEST_SPI1_MOSI DMA_REQUEST_SPI1_TX
@@ -112,8 +110,10 @@ static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
     REQMAP_DIR(UART, 4, RX),
     REQMAP_DIR(UART, 5, TX),
     REQMAP_DIR(UART, 5, RX),
-    REQMAP_DIR(UART, 9, TX),
-    REQMAP_DIR(UART, 9, RX),
+#ifdef USE_LPUART1
+    { DMA_PERIPH_UART_TX, LPUARTDEV_1, DMA_REQUEST_LPUART1_TX },
+    { DMA_PERIPH_UART_RX, LPUARTDEV_1, DMA_REQUEST_LPUART1_RX },
+#endif
 #endif
 
 #ifdef USE_TIMER
@@ -218,6 +218,8 @@ static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
 #define DMA_REQUEST_UART3_TX DMA_REQUEST_USART3_TX
 #define DMA_REQUEST_UART6_RX DMA_REQUEST_USART6_RX
 #define DMA_REQUEST_UART6_TX DMA_REQUEST_USART6_TX
+#define DMA_REQUEST_UART10_RX DMA_REQUEST_USART10_RX
+#define DMA_REQUEST_UART10_TX DMA_REQUEST_USART10_TX
 
 // Resolve our preference for MOSI/MISO rather than TX/RX
 #define DMA_REQUEST_SPI1_MOSI DMA_REQUEST_SPI1_TX
@@ -272,6 +274,16 @@ static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
     REQMAP_DIR(UART, 7, RX),
     REQMAP_DIR(UART, 8, TX),
     REQMAP_DIR(UART, 8, RX),
+#if defined(STM32H7A3xxQ)
+    REQMAP_DIR(UART, 9, TX),
+    REQMAP_DIR(UART, 9, RX),
+    REQMAP_DIR(UART, 10, TX),
+    REQMAP_DIR(UART, 10, RX),
+#endif
+#ifdef USE_LPUART1
+    { DMA_PERIPH_UART_TX, LPUARTDEV_1, BDMA_REQUEST_LPUART1_TX },
+    { DMA_PERIPH_UART_RX, LPUARTDEV_1, BDMA_REQUEST_LPUART1_RX },
+#endif
 #endif
 
 #ifdef USE_TIMER

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -67,7 +67,7 @@
 #endif
 #endif
 #elif defined(STM32H7)
-#define UARTDEV_COUNT_MAX 8
+#define UARTDEV_COUNT_MAX 11 // UARTs 1 to 10 + LPUART1
 #define UARTHARDWARE_MAX_PINS 5
 #ifndef UART_RX_BUFFER_SIZE
 #define UART_RX_BUFFER_SIZE     128
@@ -80,7 +80,7 @@
 #endif
 #endif
 #elif defined(STM32G4)
-#define UARTDEV_COUNT_MAX 9  // UART1~5 + UART9 (Implemented with LPUART1)
+#define UARTDEV_COUNT_MAX 11  // UARTs 1 to 5 + LPUART1 (index 10)
 #define UARTHARDWARE_MAX_PINS 3
 #ifndef UART_RX_BUFFER_SIZE
 #define UART_RX_BUFFER_SIZE     128

--- a/src/main/drivers/serial_uart_pinconfig.c
+++ b/src/main/drivers/serial_uart_pinconfig.c
@@ -41,7 +41,7 @@
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
 
-FAST_DATA_ZERO_INIT uartDevice_t uartDevice[UARTDEV_COUNT];      // Only those configured in target.h
+static FAST_DATA_ZERO_INIT uartDevice_t uartDevice[UARTDEV_COUNT];      // Only those configured in target.h
 FAST_DATA_ZERO_INIT uartDevice_t *uartDevmap[UARTDEV_COUNT_MAX]; // Full array
 
 void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig)

--- a/src/main/drivers/serial_uart_stm32g4xx.c
+++ b/src/main/drivers/serial_uart_stm32g4xx.c
@@ -222,10 +222,9 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     },
 #endif
 
-#ifdef USE_UART9
-    // On G474, UART9 is implemented as LPUART1
+#ifdef USE_LPUART1
     {
-        .device = UARTDEV_9,
+        .device = LPUARTDEV_1,
         .reg = LPUART1,
 #ifdef USE_DMA
         .rxDMAChannel = DMA_REQUEST_LPUART1_RX,
@@ -247,10 +246,10 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rxIrq = LPUART1_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6,
-        .txBuffer = uart9TxBuffer,
-        .rxBuffer = uart9RxBuffer,
-        .txBufferSize = sizeof(uart9TxBuffer),
-        .rxBufferSize = sizeof(uart9RxBuffer),
+        .txBuffer = lpuart1TxBuffer,
+        .rxBuffer = lpuart1RxBuffer,
+        .txBufferSize = sizeof(lpuart1TxBuffer),
+        .rxBufferSize = sizeof(lpuart1RxBuffer),
     },
 #endif
 };

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -106,7 +106,7 @@ const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
     SERIAL_PORT_SOFTSERIAL2,
 #endif
 #ifdef USE_LPUART1
-    SERIAL_PORT_LPUART1
+    SERIAL_PORT_LPUART1,
 #endif
 };
 
@@ -406,6 +406,9 @@ serialPort_t *openSerialPort(
 #ifdef USE_UART10
         case SERIAL_PORT_USART10:
 #endif
+#ifdef USE_LPUART1
+        case SERIAL_PORT_LPUART1:
+#endif
 #if defined(SIMULATOR_BUILD)
             // emulate serial ports over TCP
             serialPort = serTcpOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, rxCallbackData, baudRate, mode, options);
@@ -474,9 +477,12 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
                 serialPortCount--;
             }
         }
-
 #if !defined(SIMULATOR_BUILD)
-        else if (serialPortUsageList[index].identifier <= SERIAL_PORT_USART8) {
+        else if (serialPortUsageList[index].identifier <= SERIAL_PORT_USART10
+#ifdef USE_LPUART1
+            || serialPortUsageList[index].identifier == SERIAL_PORT_LPUART1
+#endif
+        ) {
             int resourceIndex = SERIAL_PORT_IDENTIFIER_TO_INDEX(serialPortUsageList[index].identifier);
             if (!(serialPinConfig()->ioTagTx[resourceIndex] || serialPinConfig()->ioTagRx[resourceIndex])) {
                 serialPortUsageList[index].identifier = SERIAL_PORT_NONE;
@@ -484,7 +490,6 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
             }
         }
 #endif
-
         else if ((serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1
 #ifdef USE_SOFTSERIAL1
             && !(softserialEnabled && (serialPinConfig()->ioTagTx[RESOURCE_SOFT_OFFSET + SOFTSERIAL1] ||

--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -189,7 +189,7 @@
 #define USE_UART6
 #define USE_UART7
 #define USE_UART8
-// #define USE_LPUART1
+#define USE_LPUART1
 
 #define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 9)
 

--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -189,7 +189,7 @@
 #define USE_UART6
 #define USE_UART7
 #define USE_UART8
-#define USE_LPUART1
+// #define USE_LPUART1
 
 #define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 9)
 


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight-configurator/issues/2762

Fixes: #11045