### PR TITLE
Fix RX loss caused by OSD stats display.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -1440,7 +1440,7 @@ static uint16_t cmsScanKeys(timeMs_t currentTimeMs, timeMs_t lastCalledMs, int16
                     repeatCount = repeatCount + (holdCount - repeatBase) / 5;
 
                     if (repeatCount > 5) {
-                        repeatCount= 5;
+                        repeatCount = 5;
                     }
                 }
             }

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -268,7 +268,7 @@ static void cmsPageSelect(displayPort_t *instance, int8_t newpage)
     for (p = pageTop, i = 0; (p <= pageTop + pageMaxRow); p++, i++) {
         runtimeEntryFlags[i] = p->flags;
     }
-    displayClearScreen(instance);
+    displayClearScreen(instance, DISPLAY_CLEAR_WAIT);
 }
 
 static void cmsPageNext(displayPort_t *instance)
@@ -998,7 +998,7 @@ const void *cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
     currentCtx.menu = NULL;
 
     if ((exitType == CMS_EXIT_SAVEREBOOT) || (exitType == CMS_POPUP_SAVEREBOOT) || (exitType == CMS_POPUP_EXITREBOOT)) {
-        displayClearScreen(pDisplay);
+        displayClearScreen(pDisplay, DISPLAY_CLEAR_WAIT);
         cmsDisplayWrite(pDisplay, 5, 3, DISPLAYPORT_ATTR_NONE, "REBOOTING...");
 
         // Flush display
@@ -1364,6 +1364,92 @@ uint16_t cmsHandleKeyWithRepeat(displayPort_t *pDisplay, cms_key_e key, int repe
     return ret;
 }
 
+static uint16_t cmsScanKeys(timeMs_t currentTimeMs, timeMs_t lastCalledMs, int16_t rcDelayMs)
+{
+    static int holdCount = 1;
+    static int repeatCount = 1;
+    static int repeatBase = 0;
+
+    //
+    // Scan 'key' first
+    //
+
+    cms_key_e key = CMS_KEY_NONE;
+
+    if (externKey != CMS_KEY_NONE) {
+        rcDelayMs = cmsHandleKey(pCurrentDisplay, externKey);
+        externKey = CMS_KEY_NONE;
+    } else {
+        if (IS_MID(THROTTLE) && IS_LO(YAW) && IS_HI(PITCH) && !ARMING_FLAG(ARMED)) {
+            key = CMS_KEY_MENU;
+        } else if (IS_HI(PITCH)) {
+            key = CMS_KEY_UP;
+        } else if (IS_LO(PITCH)) {
+            key = CMS_KEY_DOWN;
+        } else if (IS_LO(ROLL)) {
+            key = CMS_KEY_LEFT;
+        } else if (IS_HI(ROLL)) {
+            key = CMS_KEY_RIGHT;
+        } else if (IS_LO(YAW)) {
+            key = CMS_KEY_ESC;
+        } else if (IS_HI(YAW)) {
+            key = CMS_KEY_SAVEMENU;
+        }
+
+        if (key == CMS_KEY_NONE) {
+            // No 'key' pressed, reset repeat control
+            holdCount = 1;
+            repeatCount = 1;
+            repeatBase = 0;
+        } else {
+            // The 'key' is being pressed; keep counting
+            ++holdCount;
+        }
+
+        if (rcDelayMs > 0) {
+            rcDelayMs -= (currentTimeMs - lastCalledMs);
+        } else if (key) {
+            rcDelayMs = cmsHandleKeyWithRepeat(pCurrentDisplay, key, repeatCount);
+
+            // Key repeat effect is implemented in two phases.
+            // First phldase is to decrease rcDelayMs reciprocal to hold time.
+            // When rcDelayMs reached a certain limit (scheduling interval),
+            // repeat rate will not raise anymore, so we call key handler
+            // multiple times (repeatCount).
+            //
+            // XXX Caveat: Most constants are adjusted pragmatically.
+            // XXX Rewrite this someday, so it uses actual hold time instead
+            // of holdCount, which depends on the scheduling interval.
+
+            if (((key == CMS_KEY_LEFT) || (key == CMS_KEY_RIGHT)) && (holdCount > 20)) {
+
+                // Decrease rcDelayMs reciprocally
+
+                rcDelayMs /= (holdCount - 20);
+
+                // When we reach the scheduling limit,
+
+                if (rcDelayMs <= 50) {
+
+                    // start calling handler multiple times.
+
+                    if (repeatBase == 0) {
+                        repeatBase = holdCount;
+                    }
+
+                    repeatCount = repeatCount + (holdCount - repeatBase) / 5;
+
+                    if (repeatCount > 5) {
+                        repeatCount= 5;
+                    }
+                }
+            }
+        }
+    }
+
+    return rcDelayMs;
+}
+
 static void cmsUpdate(uint32_t currentTimeUs)
 {
     if (IS_RC_MODE_ACTIVE(BOXPARALYZE)
@@ -1378,9 +1464,6 @@ static void cmsUpdate(uint32_t currentTimeUs)
     }
 
     static int16_t rcDelayMs = BUTTON_TIME;
-    static int holdCount = 1;
-    static int repeatCount = 1;
-    static int repeatBase = 0;
 
     static uint32_t lastCalledMs = 0;
     static uint32_t lastCmsHeartBeatMs = 0;
@@ -1394,82 +1477,9 @@ static void cmsUpdate(uint32_t currentTimeUs)
             rcDelayMs = BUTTON_PAUSE;    // Tends to overshoot if BUTTON_TIME
         }
     } else {
-        //
-        // Scan 'key' first
-        //
+        displayBeginTransaction(pCurrentDisplay, DISPLAY_TRANSACTION_OPT_RESET_DRAWING);
 
-        cms_key_e key = CMS_KEY_NONE;
-
-        if (externKey != CMS_KEY_NONE) {
-            rcDelayMs = cmsHandleKey(pCurrentDisplay, externKey);
-            externKey = CMS_KEY_NONE;
-        } else {
-            if (IS_MID(THROTTLE) && IS_LO(YAW) && IS_HI(PITCH) && !ARMING_FLAG(ARMED)) {
-                key = CMS_KEY_MENU;
-            } else if (IS_HI(PITCH)) {
-                key = CMS_KEY_UP;
-            } else if (IS_LO(PITCH)) {
-                key = CMS_KEY_DOWN;
-            } else if (IS_LO(ROLL)) {
-                key = CMS_KEY_LEFT;
-            } else if (IS_HI(ROLL)) {
-                key = CMS_KEY_RIGHT;
-            } else if (IS_LO(YAW)) {
-                key = CMS_KEY_ESC;
-            } else if (IS_HI(YAW)) {
-                key = CMS_KEY_SAVEMENU;
-            }
-
-            if (key == CMS_KEY_NONE) {
-                // No 'key' pressed, reset repeat control
-                holdCount = 1;
-                repeatCount = 1;
-                repeatBase = 0;
-            } else {
-                // The 'key' is being pressed; keep counting
-                ++holdCount;
-            }
-
-            if (rcDelayMs > 0) {
-                rcDelayMs -= (currentTimeMs - lastCalledMs);
-            } else if (key) {
-                rcDelayMs = cmsHandleKeyWithRepeat(pCurrentDisplay, key, repeatCount);
-
-                // Key repeat effect is implemented in two phases.
-                // First phldase is to decrease rcDelayMs reciprocal to hold time.
-                // When rcDelayMs reached a certain limit (scheduling interval),
-                // repeat rate will not raise anymore, so we call key handler
-                // multiple times (repeatCount).
-                //
-                // XXX Caveat: Most constants are adjusted pragmatically.
-                // XXX Rewrite this someday, so it uses actual hold time instead
-                // of holdCount, which depends on the scheduling interval.
-
-                if (((key == CMS_KEY_LEFT) || (key == CMS_KEY_RIGHT)) && (holdCount > 20)) {
-
-                    // Decrease rcDelayMs reciprocally
-
-                    rcDelayMs /= (holdCount - 20);
-
-                    // When we reach the scheduling limit,
-
-                    if (rcDelayMs <= 50) {
-
-                        // start calling handler multiple times.
-
-                        if (repeatBase == 0) {
-                            repeatBase = holdCount;
-                        }
-
-                        repeatCount = repeatCount + (holdCount - repeatBase) / 5;
-
-                        if (repeatCount > 5) {
-                            repeatCount= 5;
-                        }
-                    }
-                }
-            }
-        }
+        rcDelayMs = cmsScanKeys(currentTimeMs, lastCalledMs, rcDelayMs);
 
         cmsDrawMenu(pCurrentDisplay, currentTimeUs);
 
@@ -1479,6 +1489,8 @@ static void cmsUpdate(uint32_t currentTimeUs)
             displayHeartbeat(pCurrentDisplay);
             lastCmsHeartBeatMs = currentTimeMs;
         }
+
+        displayCommitTransaction(pCurrentDisplay);
     }
 
     // Some key (command), notably flash erase, takes too long to use the

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -1412,7 +1412,7 @@ static uint16_t cmsScanKeys(timeMs_t currentTimeMs, timeMs_t lastCalledMs, int16
             rcDelayMs = cmsHandleKeyWithRepeat(pCurrentDisplay, key, repeatCount);
 
             // Key repeat effect is implemented in two phases.
-            // First phldase is to decrease rcDelayMs reciprocal to hold time.
+            // First phase is to decrease rcDelayMs reciprocal to hold time.
             // When rcDelayMs reached a certain limit (scheduling interval),
             // repeat rate will not raise anymore, so we call key handler
             // multiple times (repeatCount).

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -169,7 +169,7 @@ static const void *cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
         return NULL;
     }
 
-    displayClearScreen(pDisplay);
+    displayClearScreen(pDisplay, DISPLAY_CLEAR_WAIT);
     displayWrite(pDisplay, 5, 3, DISPLAYPORT_ATTR_INFO, "ERASING FLASH...");
     displayRedraw(pDisplay);
 
@@ -180,7 +180,7 @@ static const void *cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
     }
 
     beeper(BEEPER_BLACKBOX_ERASE);
-    displayClearScreen(pDisplay);
+    displayClearScreen(pDisplay, DISPLAY_CLEAR_WAIT);
     displayRedraw(pDisplay);
 
     // Update storage device status to show new used space amount

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -356,7 +356,7 @@ static const void *cmsx_max7456Update(displayPort_t *pDisp, const void *self)
     displayPortProfileMax7456Mutable()->blackBrightness = displayPortProfileMax7456_blackBrightness;
     displayPortProfileMax7456Mutable()->whiteBrightness = displayPortProfileMax7456_whiteBrightness;
 
-    displayClearScreen(pDisp);
+    displayClearScreen(pDisp, DISPLAY_CLEAR_WAIT);
 
     return NULL;
 }

--- a/src/main/cms/cms_menu_persistent_stats.c
+++ b/src/main/cms/cms_menu_persistent_stats.c
@@ -73,7 +73,7 @@ static const void *cmsx_ResetStats(displayPort_t *pDisplay, const void *ptr)
     stats_total_time_s = 0;
     stats_total_dist_m = 0;
 
-    displayClearScreen(pDisplay);
+    displayClearScreen(pDisplay, DISPLAY_CLEAR_WAIT);
     displayRedraw(pDisplay);
 
     return NULL;

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -31,9 +31,9 @@
 
 #include "display.h"
 
-void displayClearScreen(displayPort_t *instance)
+void displayClearScreen(displayPort_t *instance, displayClearOption_e options)
 {
-    instance->vTable->clearScreen(instance);
+    instance->vTable->clearScreen(instance, options);
     instance->cleared = true;
     instance->cursorRow = -1;
 }
@@ -52,7 +52,7 @@ int displayScreenSize(const displayPort_t *instance)
 void displayGrab(displayPort_t *instance)
 {
     instance->vTable->grab(instance);
-    instance->vTable->clearScreen(instance);
+    instance->vTable->clearScreen(instance, DISPLAY_CLEAR_WAIT);
     ++instance->grabCount;
 }
 
@@ -216,10 +216,11 @@ bool displaySupportsOsdSymbols(displayPort_t *instance)
 void displayInit(displayPort_t *instance, const displayPortVTable_t *vTable, displayPortDeviceType_e deviceType)
 {
     instance->vTable = vTable;
-    instance->vTable->clearScreen(instance);
     instance->useFullscreen = false;
-    instance->cleared = true;
     instance->grabCount = 0;
-    instance->cursorRow = -1;
     instance->deviceType = deviceType;
+
+    displayBeginTransaction(instance, DISPLAY_TRANSACTION_OPT_NONE);
+    displayClearScreen(instance, DISPLAY_CLEAR_WAIT);
+    displayCommitTransaction(instance);
 }

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -60,7 +60,15 @@ typedef enum {
 } displayPortBackground_e;
 
 typedef enum {
+    // Display drivers that can perform screen clearing in the background, e.g. via DMA, should do so.
+    // use `displayCheckReady` function to check if the screen clear has been completed.
     DISPLAY_CLEAR_NONE = 0,
+
+    // * when set, the display driver should block until the screen clear has completed, use in synchronous cases
+    //   only, e.g. where the screen is cleared and the display is immediately drawn to.
+    // * when NOT set, return immediately and do not block unless screen is a simple operation or cannot
+    //   be performed in the background.  As with any long delay, waiting can cause task starvation which
+    //   can result in RX loss.
     DISPLAY_CLEAR_WAIT = 1 << 0,
 } displayClearOption_e;
 

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -59,6 +59,11 @@ typedef enum {
     DISPLAY_BACKGROUND_COUNT    // must be the last entry
 } displayPortBackground_e;
 
+typedef enum {
+    DISPLAY_CLEAR_NONE = 0,
+    DISPLAY_CLEAR_WAIT = 1 << 0,
+} displayClearOption_e;
+
 struct displayCanvas_s;
 struct osdCharacter_s;
 struct displayPortVTable_s;
@@ -87,7 +92,7 @@ typedef struct displayPort_s {
 typedef struct displayPortVTable_s {
     int (*grab)(displayPort_t *displayPort);
     int (*release)(displayPort_t *displayPort);
-    int (*clearScreen)(displayPort_t *displayPort);
+    int (*clearScreen)(displayPort_t *displayPort, displayClearOption_e options);
     bool (*drawScreen)(displayPort_t *displayPort);
     int (*screenSize)(const displayPort_t *displayPort);
     int (*writeString)(displayPort_t *displayPort, uint8_t x, uint8_t y, uint8_t attr, const char *text);
@@ -112,7 +117,7 @@ void displayGrab(displayPort_t *instance);
 void displayRelease(displayPort_t *instance);
 void displayReleaseAll(displayPort_t *instance);
 bool displayIsGrabbed(const displayPort_t *instance);
-void displayClearScreen(displayPort_t *instance);
+void displayClearScreen(displayPort_t *instance, displayClearOption_e options);
 bool displayDrawScreen(displayPort_t *instance);
 int displayScreenSize(const displayPort_t *instance);
 void displaySetXY(displayPort_t *instance, uint8_t x, uint8_t y);

--- a/src/main/io/displayport_crsf.c
+++ b/src/main/io/displayport_crsf.c
@@ -49,9 +49,10 @@ static int crsfGrab(displayPort_t *displayPort)
     return displayPort->grabCount = 1;
 }
 
-static int crsfClearScreen(displayPort_t *displayPort)
+static int crsfClearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
     UNUSED(displayPort);
+    UNUSED(options);
     memset(crsfScreen.buffer, ' ', sizeof(crsfScreen.buffer));
     crsfScreen.updated = false;
     crsfScreen.reset = true;
@@ -62,7 +63,7 @@ static int crsfClearScreen(displayPort_t *displayPort)
 static int crsfRelease(displayPort_t *displayPort)
 {
     displayPort->grabCount = 0;
-    return crsfClearScreen(displayPort);
+    return crsfClearScreen(displayPort, DISPLAY_CLEAR_WAIT);
 }
 
 static bool crsfDrawScreen(displayPort_t *displayPort)

--- a/src/main/io/displayport_frsky_osd.c
+++ b/src/main/io/displayport_frsky_osd.c
@@ -47,9 +47,10 @@ static int release(displayPort_t *displayPort)
     return 0;
 }
 
-static int clearScreen(displayPort_t *displayPort)
+static int clearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
     UNUSED(displayPort);
+    UNUSED(options);
     frskyOsdClearScreen();
     return 0;
 }

--- a/src/main/io/displayport_hott.c
+++ b/src/main/io/displayport_hott.c
@@ -61,8 +61,10 @@ static int hottWriteString(displayPort_t *displayPort, uint8_t col, uint8_t row,
     return 0;
 }
 
-static int hottClearScreen(displayPort_t *displayPort)
+static int hottClearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
+    UNUSED(options);
+
     for (int row = 0; row < displayPort->rows; row++) {
         for (int col= 0; col < displayPort->cols; col++) {
             hottWriteChar(displayPort, col, row, DISPLAYPORT_ATTR_NONE, ' ');
@@ -106,7 +108,7 @@ static int hottGrab(displayPort_t *displayPort)
 static int hottRelease(displayPort_t *displayPort)
 {
     int cnt = displayPort->grabCount = 0;
-    hottClearScreen(displayPort);
+    hottClearScreen(displayPort, DISPLAY_CLEAR_WAIT);
     hottTextmodeExit();
     return cnt;
 }

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -60,9 +60,10 @@ static int release(displayPort_t *displayPort)
     return 0;
 }
 
-static int clearScreen(displayPort_t *displayPort)
+static int clearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
     UNUSED(displayPort);
+    UNUSED(options);
 
     max7456Invert(displayPortProfileMax7456()->invert);
     max7456Brightness(displayPortProfileMax7456()->blackBrightness, displayPortProfileMax7456()->whiteBrightness);

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -81,8 +81,10 @@ static int release(displayPort_t *displayPort)
     return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
 }
 
-static int clearScreen(displayPort_t *displayPort)
+static int clearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
+    UNUSED(options);
+
     uint8_t subcmd[] = { 2 };
 
     return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));

--- a/src/main/io/displayport_oled.c
+++ b/src/main/io/displayport_oled.c
@@ -42,8 +42,10 @@ static int oledRelease(displayPort_t *displayPort)
     return 0;
 }
 
-static int oledClearScreen(displayPort_t *displayPort)
+static int oledClearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
+    UNUSED(options);
+
     i2c_OLED_clear_display_quick(displayPort->device);
     return 0;
 }

--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -66,8 +66,9 @@ static int srxlWriteString(displayPort_t *displayPort, uint8_t col, uint8_t row,
     return 0;
 }
 
-static int srxlClearScreen(displayPort_t *displayPort)
+static int srxlClearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
+    UNUSED(options);
     for (int row = 0; row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS; row++) {
         for (int col= 0; col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS; col++) {
             srxlWriteChar(displayPort, col, row, DISPLAYPORT_ATTR_NONE, ' ');
@@ -120,7 +121,7 @@ static int srxlGrab(displayPort_t *displayPort)
 static int srxlRelease(displayPort_t *displayPort)
 {
     int cnt = displayPort->grabCount = 0;
-    srxlClearScreen(displayPort);
+    srxlClearScreen(displayPort, DISPLAY_CLEAR_WAIT);
     return cnt;
 }
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -965,7 +965,7 @@ static bool osdRefreshStats(void)
         if (osdStatsRenderingState.rowCount > 0) {
             phase = RENDER_STATS;
         } else {
-            phase++;
+            phase = COUNT_STATS;
         }
         displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_NONE);
         break;
@@ -975,7 +975,7 @@ static bool osdRefreshStats(void)
             // Go through the logic one time to determine how many stats are actually displayed.
             bool count_phase_complete = osdRenderStatsContinue();
             if (count_phase_complete) {
-                phase++;
+                phase = CLEAR_SCREEN;
             }
             break;
         }
@@ -984,7 +984,7 @@ static bool osdRefreshStats(void)
         // Then clear the screen and commence with normal stats display which will
         // determine if the heading should be displayed and also center the content vertically.
         displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_NONE);
-        phase++;
+        phase = RENDER_STATS;
         break;
     case RENDER_STATS:
         completed = osdRenderStatsContinue();

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -428,7 +428,7 @@ static void osdCompleteInitialization(void)
     displayLayerSelect(osdDisplayPort, DISPLAYPORT_LAYER_FOREGROUND);
 
     displayBeginTransaction(osdDisplayPort, DISPLAY_TRANSACTION_OPT_RESET_DRAWING);
-    displayClearScreen(osdDisplayPort);
+    displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
 
     osdDrawLogo(3, 1);
 
@@ -903,14 +903,14 @@ static void osdRefreshStats(void)
     // Non-flight operation which takes a little longer than normal
     schedulerIgnoreTaskExecTime();
 
-    displayClearScreen(osdDisplayPort);
+    displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
     if (osdStatsRowCount == 0) {
         // No stats row count has been set yet.
         // Go through the logic one time to determine how many stats are actually displayed.
         osdStatsRowCount = osdShowStats(0);
         // Then clear the screen and commence with normal stats display which will
         // determine if the heading should be displayed and also center the content vertically.
-        displayClearScreen(osdDisplayPort);
+        displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
     }
     osdShowStats(osdStatsRowCount);
 }
@@ -919,7 +919,7 @@ static timeDelta_t osdShowArmed(void)
 {
     timeDelta_t ret;
 
-    displayClearScreen(osdDisplayPort);
+    displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
 
     if ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_ON) || ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_FIRST) && !ARMING_FLAG(WAS_EVER_ARMED))) {
         osdDrawLogo(3, 1);
@@ -973,7 +973,7 @@ STATIC_UNIT_TESTED void osdDrawStats1(timeUs_t currentTimeUs)
         } else {
             if (IS_RC_MODE_ACTIVE(BOXOSD) && osdStatsVisible) {
                 osdStatsVisible = false;
-                displayClearScreen(osdDisplayPort);
+                displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
             } else if (!IS_RC_MODE_ACTIVE(BOXOSD)) {
                 if (!osdStatsVisible) {
                     osdStatsVisible = true;
@@ -1001,7 +1001,7 @@ void osdDrawStats2(timeUs_t currentTimeUs)
             }
             return;
         } else {
-            displayClearScreen(osdDisplayPort);
+            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
             resumeRefreshAt = 0;
             osdStatsEnabled = false;
             stats.armed_time = 0;
@@ -1172,7 +1172,7 @@ void osdUpdate(timeUs_t currentTimeUs)
     case OSD_STATE_UPDATE_CANVAS:
         // Hide OSD when OSDSW mode is active
         if (IS_RC_MODE_ACTIVE(BOXOSD)) {
-            displayClearScreen(osdDisplayPort);
+            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
             osdState = OSD_STATE_COMMIT;
             break;
         }
@@ -1184,7 +1184,7 @@ void osdUpdate(timeUs_t currentTimeUs)
         } else {
             // Background layer not supported, just clear the foreground in preparation
             // for drawing the elements including their backgrounds.
-            displayClearScreen(osdDisplayPort);
+            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
         }
 
 #ifdef USE_GPS

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -954,9 +954,9 @@ static bool osdRefreshStats(void)
         COUNT_STATS,
         CLEAR_SCREEN,
         RENDER_STATS,
-    } osd_refresh_stats_phase_e;
+    } osdRefreshStatsPhase_e;
 
-    static osd_refresh_stats_phase_e phase = INITIAL_CLEAR_SCREEN;
+    static osdRefreshStatsPhase_e phase = INITIAL_CLEAR_SCREEN;
 
     switch (phase) {
     default:

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -958,9 +958,6 @@ static bool osdRefreshStats(void)
 
     static osd_refresh_stats_phase_e phase = INITIAL_CLEAR_SCREEN;
 
-    // Non-flight operation which takes a little longer than normal
-    schedulerIgnoreTaskExecTime();
-
     switch (phase) {
     default:
     case INITIAL_CLEAR_SCREEN:

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1846,7 +1846,7 @@ void osdDrawActiveElementsBackground(displayPort_t *osdDisplayPort)
 {
     if (backgroundLayerSupported) {
         displayLayerSelect(osdDisplayPort, DISPLAYPORT_LAYER_BACKGROUND);
-        displayClearScreen(osdDisplayPort);
+        displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
         for (unsigned i = 0; i < activeOsdElementCount; i++) {
             osdDrawSingleElementBackground(osdDisplayPort, activeOsdElementArray[i]);
         }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -744,7 +744,7 @@ TEST_F(OsdTest, TestElementRssi)
 
     // when
     rssi = 1024;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -752,7 +752,7 @@ TEST_F(OsdTest, TestElementRssi)
 
     // when
     rssi = 0;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -760,7 +760,7 @@ TEST_F(OsdTest, TestElementRssi)
 
     // when
     rssi = 512;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -779,7 +779,7 @@ TEST_F(OsdTest, TestElementAmperage)
 
     // when
     simulationBatteryAmperage = 0;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -787,7 +787,7 @@ TEST_F(OsdTest, TestElementAmperage)
 
     // when
     simulationBatteryAmperage = 2156;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -795,7 +795,7 @@ TEST_F(OsdTest, TestElementAmperage)
 
     // when
     simulationBatteryAmperage = 12345;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -814,7 +814,7 @@ TEST_F(OsdTest, TestElementMahDrawn)
 
     // when
     simulationMahDrawn = 0;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -822,7 +822,7 @@ TEST_F(OsdTest, TestElementMahDrawn)
 
     // when
     simulationMahDrawn = 4;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -830,7 +830,7 @@ TEST_F(OsdTest, TestElementMahDrawn)
 
     // when
     simulationMahDrawn = 15;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -838,7 +838,7 @@ TEST_F(OsdTest, TestElementMahDrawn)
 
     // when
     simulationMahDrawn = 246;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -846,7 +846,7 @@ TEST_F(OsdTest, TestElementMahDrawn)
 
     // when
     simulationMahDrawn = 1042;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -870,7 +870,7 @@ TEST_F(OsdTest, TestElementPower)
     simulationBatteryAmperage = 0; // 0A
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -880,7 +880,7 @@ TEST_F(OsdTest, TestElementPower)
     simulationBatteryAmperage = 10; // 0.1A
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -890,7 +890,7 @@ TEST_F(OsdTest, TestElementPower)
     simulationBatteryAmperage = 120; // 1.2A
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -900,7 +900,7 @@ TEST_F(OsdTest, TestElementPower)
     simulationBatteryAmperage = 1230; // 12.3A
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -910,7 +910,7 @@ TEST_F(OsdTest, TestElementPower)
     simulationBatteryAmperage = 12340; // 123.4A
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -933,7 +933,7 @@ TEST_F(OsdTest, TestElementAltitude)
 
     // when
     simulationAltitude = 0;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -941,7 +941,7 @@ TEST_F(OsdTest, TestElementAltitude)
 
     // when
     sensorsSet(SENSOR_GPS);
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -949,7 +949,7 @@ TEST_F(OsdTest, TestElementAltitude)
 
     // when
     simulationAltitude = 247;  // rounds to 2.5m
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -957,7 +957,7 @@ TEST_F(OsdTest, TestElementAltitude)
 
     // when
     simulationAltitude = 4247;  // rounds to 42.5m
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -965,7 +965,7 @@ TEST_F(OsdTest, TestElementAltitude)
 
     // when
     simulationAltitude = -247;  // rounds to -2.5m
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -973,7 +973,7 @@ TEST_F(OsdTest, TestElementAltitude)
 
     // when
     simulationAltitude = -70;
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -998,7 +998,7 @@ TEST_F(OsdTest, TestElementCoreTemperature)
     simulationCoreTemperature = 0;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1008,7 +1008,7 @@ TEST_F(OsdTest, TestElementCoreTemperature)
     simulationCoreTemperature = 33;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1018,7 +1018,7 @@ TEST_F(OsdTest, TestElementCoreTemperature)
     osdConfigMutable()->units = UNIT_IMPERIAL;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1052,7 +1052,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     simulationBatteryState = BATTERY_OK;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
@@ -1067,7 +1067,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     simulationBatteryState = BATTERY_OK;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1079,7 +1079,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     simulationBatteryState = BATTERY_WARNING;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
@@ -1094,7 +1094,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     simulationBatteryState = BATTERY_CRITICAL;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
@@ -1109,7 +1109,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     simulationBatteryState = BATTERY_OK;
 
     // when
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1197,7 +1197,7 @@ TEST_F(OsdTest, TestGpsElements)
     simulationGpsHealthy = false;
     gpsSol.numSat = 0;
 
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1221,7 +1221,7 @@ TEST_F(OsdTest, TestGpsElements)
     simulationGpsHealthy = true;
     gpsSol.numSat = 0;
 
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then
@@ -1245,7 +1245,7 @@ TEST_F(OsdTest, TestGpsElements)
     simulationGpsHealthy = true;
     gpsSol.numSat = 10;
 
-    displayClearScreen(&testDisplayPort);
+    displayClearScreen(&testDisplayPort, DISPLAY_CLEAR_WAIT);
     osdRefresh();
 
     // then

--- a/src/test/unit/unittest_displayport.h
+++ b/src/test/unit/unittest_displayport.h
@@ -48,9 +48,10 @@ static int displayPortTestRelease(displayPort_t *displayPort)
     return 0;
 }
 
-static int displayPortTestClearScreen(displayPort_t *displayPort)
+static int displayPortTestClearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
     UNUSED(displayPort);
+    UNUSED(options);
     memset(testDisplayPortBuffer, ' ', UNITTEST_DISPLAYPORT_BUFFER_LEN);
     return 0;
 }


### PR DESCRIPTION
The display of the OSD stats causes RX task starvation which in the case of an ELRS SPI 500hz link can cause it to drop.

There are three main issues:
* rendering a page of stats itself is expensive.
* initial display of stats renders every stat twice, once to count them, once to render them centered on the screen.
* screen clear may be expensive, depending on the OSD system used.

This PR solves these issues as follows:
* each stat item is now rendered, then the OSD task returns, on the next iteration it renders the next stat item.
* stats refresh itself is also broken into multi phases, screen clear -> count items -> screen clear -> render.
* displayClear() now has an extra argument, which allows OSD systems to implement the screen clear asynchronously.

Reviewers:
Please review each commit separately, they build upon each other.
The initial call to clear the screen OSD should have been using displayClearScreen, and not using the vtable directly and should have also been in a transaction.
The new `cmsScanKeys` function is just a relocation of the existing code, to allow wrapping the code in a transaction.  inav did the same thing.
