### PR TITLE
Increase number of element groups and use peak hold task estimation for OSD

### DIFF
--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -635,7 +635,7 @@ void spiSequenceStart(const extDevice_t *dev)
     }
 
     // Use DMA if possible
-    if (bus->useDMA && dmaSafe && ((segmentCount > 1) || (xferLen > 8))) {
+    if (bus->useDMA && dmaSafe && ((segmentCount > 1) || (xferLen >= 8))) {
         // Intialise the init structures for the first transfer
         spiInternalInitStream(dev, false);
 

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -367,7 +367,7 @@ void spiSequenceStart(const extDevice_t *dev)
         xferLen += checkSegment->len;
     }
     // Use DMA if possible
-    if (bus->useDMA && dmaSafe && ((segmentCount > 1) || (xferLen > 8))) {
+    if (bus->useDMA && dmaSafe && ((segmentCount > 1) || (xferLen >= 8))) {
         // Intialise the init structures for the first transfer
         spiInternalInitStream(dev, false);
 

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -182,7 +182,7 @@ bool taskUpdateRxMainInProgress()
 
 static void taskUpdateRxMain(timeUs_t currentTimeUs)
 {
-    static timeDelta_t rxStateDurationFracUs[RX_STATE_COUNT];
+    static timeDelta_t rxStateDurationFractionUs[RX_STATE_COUNT];
     timeDelta_t executeTimeUs;
     rxState_e oldRxState = rxState;
     timeDelta_t anticipatedExecutionTime;
@@ -230,23 +230,23 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs)
 
         // If the scheduler has reduced the anticipatedExecutionTime due to task aging, pick that up
         anticipatedExecutionTime = schedulerGetNextStateTime();
-        if (anticipatedExecutionTime != (rxStateDurationFracUs[oldRxState] >> RX_TASK_DECAY_SHIFT)) {
-            rxStateDurationFracUs[oldRxState] = anticipatedExecutionTime << RX_TASK_DECAY_SHIFT;
+        if (anticipatedExecutionTime != (rxStateDurationFractionUs[oldRxState] >> RX_TASK_DECAY_SHIFT)) {
+            rxStateDurationFractionUs[oldRxState] = anticipatedExecutionTime << RX_TASK_DECAY_SHIFT;
         }
 
-        if (executeTimeUs > (rxStateDurationFracUs[oldRxState] >> RX_TASK_DECAY_SHIFT)) {
-            rxStateDurationFracUs[oldRxState] = executeTimeUs << RX_TASK_DECAY_SHIFT;
+        if (executeTimeUs > (rxStateDurationFractionUs[oldRxState] >> RX_TASK_DECAY_SHIFT)) {
+            rxStateDurationFractionUs[oldRxState] = executeTimeUs << RX_TASK_DECAY_SHIFT;
         } else {
             // Slowly decay the max time
-            rxStateDurationFracUs[oldRxState]--;
+            rxStateDurationFractionUs[oldRxState]--;
         }
     }
 
     if (debugMode == DEBUG_RX_STATE_TIME) {
-        debug[oldRxState] = rxStateDurationFracUs[oldRxState] >> RX_TASK_DECAY_SHIFT;
+        debug[oldRxState] = rxStateDurationFractionUs[oldRxState] >> RX_TASK_DECAY_SHIFT;
     }
 
-    schedulerSetNextStateTime(rxStateDurationFracUs[rxState] >> RX_TASK_DECAY_SHIFT);
+    schedulerSetNextStateTime(rxStateDurationFractionUs[rxState] >> RX_TASK_DECAY_SHIFT);
 }
 
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -766,7 +766,7 @@ void gpsUpdate(timeUs_t currentTimeUs)
 {
     static gpsState_e gpsStateDurationUs[GPS_STATE_COUNT];
     timeUs_t executeTimeUs;
-    gpsState_e gpsCurState = gpsData.state;
+    gpsState_e gpsCurrentState = gpsData.state;
 
     // read out available GPS bytes
     if (gpsPort) {
@@ -861,8 +861,8 @@ void gpsUpdate(timeUs_t currentTimeUs)
 
     executeTimeUs = micros() - currentTimeUs;
 
-    if (executeTimeUs > gpsStateDurationUs[gpsCurState]) {
-        gpsStateDurationUs[gpsCurState] = executeTimeUs;
+    if (executeTimeUs > gpsStateDurationUs[gpsCurrentState]) {
+        gpsStateDurationUs[gpsCurrentState] = executeTimeUs;
     }
     schedulerSetNextStateTime(gpsStateDurationUs[gpsData.state]);
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -198,6 +198,7 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
 #else
 #define OSD_ELEMENT_RENDER_GROUP_MARGIN 2
 #endif
+#define OSD_TASK_MARGIN                 1
 // Decay the estimated max task duration by 1/(1 << OSD_EXEC_TIME_SHIFT) on every invocation
 #define OSD_EXEC_TIME_SHIFT             8
 
@@ -1130,6 +1131,7 @@ typedef enum {
     OSD_STATE_PROCESS_STATS3,
     OSD_STATE_UPDATE_ALARMS,
     OSD_STATE_UPDATE_CANVAS,
+    OSD_STATE_GROUP_ELEMENTS,
     OSD_STATE_UPDATE_ELEMENTS,
     OSD_STATE_UPDATE_HEARTBEAT,
     OSD_STATE_COMMIT,
@@ -1164,14 +1166,13 @@ bool osdUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
     return (osdState != OSD_STATE_IDLE);
 }
 
-
 // Called when there is OSD update work to be done
 void osdUpdate(timeUs_t currentTimeUs)
 {
     // Times are known to be short so use uint16_t rather than timeUs_t
     static uint16_t osdStateDurationFracUs[OSD_STATE_COUNT] = { 0 };
-    static uint16_t osdElementDurationUs[OSD_ITEM_COUNT] = { 0 };
-    static uint16_t osdElementGroupMembership[OSD_ITEM_COUNT];
+    static uint32_t osdElementDurationUs[OSD_ITEM_COUNT] = { 0 };
+    static uint8_t osdElementGroupMembership[OSD_ITEM_COUNT];
     static uint16_t osdElementGroupTargetFracUs[OSD_GROUP_COUNT] = { 0 };
     static uint16_t osdElementGroupDurationFracUs[OSD_GROUP_COUNT] = { 0 };
     static uint8_t osdElementGroup;
@@ -1304,44 +1305,51 @@ void osdUpdate(timeUs_t currentTimeUs)
 
         osdSyncBlink();
 
-        uint8_t elementGroup;
-        uint8_t activeElements = osdGetActiveElementCount();
+        osdState = OSD_STATE_GROUP_ELEMENTS;
 
-        // Reset groupings
-        for (elementGroup = 0; elementGroup < OSD_GROUP_COUNT; elementGroup++) {
-            if (osdElementGroupDurationFracUs[elementGroup] > (OSD_ELEMENT_RENDER_TARGET << OSD_EXEC_TIME_SHIFT)) {
-                osdElementGroupDurationFracUs[elementGroup] = 0;
-            }
-            osdElementGroupTargetFracUs[elementGroup] = 0;
-        }
+        break;
 
-        elementGroup = 0;
+    case OSD_STATE_GROUP_ELEMENTS:
+        {
+            uint8_t elementGroup;
+            uint8_t activeElements = osdGetActiveElementCount();
 
-        // Based on the current element rendering, group to execute in approx 40us
-        for (uint8_t curElement = 0; curElement < activeElements; curElement++) {
-            if ((osdElementGroupTargetFracUs[elementGroup] == 0) ||
-                (osdElementGroupTargetFracUs[elementGroup] + (osdElementDurationUs[curElement]) <= (OSD_ELEMENT_RENDER_TARGET << OSD_EXEC_TIME_SHIFT)) ||
-                (elementGroup == (OSD_GROUP_COUNT - 1))) {
-                osdElementGroupTargetFracUs[elementGroup] += osdElementDurationUs[curElement];
-                // If group membership changes, reset the stats for the group
-                if (osdElementGroupMembership[curElement] != elementGroup) {
-                    osdElementGroupDurationFracUs[elementGroup] = osdElementGroupTargetFracUs[elementGroup];
+            // Reset groupings
+            for (elementGroup = 0; elementGroup < OSD_GROUP_COUNT; elementGroup++) {
+                if (osdElementGroupDurationFracUs[elementGroup] > (OSD_ELEMENT_RENDER_TARGET << OSD_EXEC_TIME_SHIFT)) {
+                    osdElementGroupDurationFracUs[elementGroup] = 0;
                 }
-                osdElementGroupMembership[curElement] = elementGroup;
-            } else {
-                elementGroup++;
-                // Try again for this element
-                curElement--;
+                osdElementGroupTargetFracUs[elementGroup] = 0;
             }
-        }
 
-        // Start with group 0
-        osdElementGroup = 0;
+            elementGroup = 0;
 
-        if (activeElements > 0) {
-            osdState = OSD_STATE_UPDATE_ELEMENTS;
-        } else {
-            osdState = OSD_STATE_COMMIT;
+            // Based on the current element rendering, group to execute in approx 40us
+            for (uint8_t curElement = 0; curElement < activeElements; curElement++) {
+                if ((osdElementGroupTargetFracUs[elementGroup] == 0) ||
+                    (osdElementGroupTargetFracUs[elementGroup] + (osdElementDurationUs[curElement]) <= (OSD_ELEMENT_RENDER_TARGET << OSD_EXEC_TIME_SHIFT)) ||
+                    (elementGroup == (OSD_GROUP_COUNT - 1))) {
+                    osdElementGroupTargetFracUs[elementGroup] += osdElementDurationUs[curElement];
+                    // If group membership changes, reset the stats for the group
+                    if (osdElementGroupMembership[curElement] != elementGroup) {
+                        osdElementGroupDurationFracUs[elementGroup] = osdElementGroupTargetFracUs[elementGroup] + (OSD_ELEMENT_RENDER_GROUP_MARGIN << OSD_EXEC_TIME_SHIFT);
+                    }
+                    osdElementGroupMembership[curElement] = elementGroup;
+                } else {
+                    elementGroup++;
+                    // Try again for this element
+                    curElement--;
+                }
+            }
+
+            // Start with group 0
+            osdElementGroup = 0;
+
+            if (activeElements > 0) {
+                osdState = OSD_STATE_UPDATE_ELEMENTS;
+            } else {
+                osdState = OSD_STATE_COMMIT;
+            }
         }
         break;
 
@@ -1406,6 +1414,7 @@ void osdUpdate(timeUs_t currentTimeUs)
 
         firstPass = false;
         osdState = OSD_STATE_IDLE;
+
         break;
 
     case OSD_STATE_IDLE:
@@ -1424,11 +1433,17 @@ void osdUpdate(timeUs_t currentTimeUs)
             if (osdCurState == OSD_STATE_UPDATE_ELEMENTS) {
                 if (executeTimeUs > (osdElementGroupDurationFracUs[osdCurElementGroup] >> OSD_EXEC_TIME_SHIFT)) {
                     osdElementGroupDurationFracUs[osdCurElementGroup] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
+                } else if (osdElementGroupDurationFracUs[osdCurElementGroup] > 0) {
+                    // Slowly decay the max time
+                    osdElementGroupDurationFracUs[osdCurElementGroup]--;
                 }
             }
 
             if (executeTimeUs > (osdStateDurationFracUs[osdCurState] >> OSD_EXEC_TIME_SHIFT)) {
                 osdStateDurationFracUs[osdCurState] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
+            } else if (osdStateDurationFracUs[osdCurState] > 0) {
+                // Slowly decay the max time
+                osdStateDurationFracUs[osdCurState]--;
             }
         }
     }
@@ -1437,9 +1452,9 @@ void osdUpdate(timeUs_t currentTimeUs)
         schedulerSetNextStateTime((osdElementGroupDurationFracUs[osdElementGroup] >> OSD_EXEC_TIME_SHIFT) + OSD_ELEMENT_RENDER_GROUP_MARGIN);
     } else {
         if (osdState == OSD_STATE_IDLE) {
-            schedulerSetNextStateTime(osdStateDurationFracUs[OSD_STATE_CHECK] >> OSD_EXEC_TIME_SHIFT);
+            schedulerSetNextStateTime((osdStateDurationFracUs[OSD_STATE_CHECK] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
         } else {
-            schedulerSetNextStateTime(osdStateDurationFracUs[osdState] >> OSD_EXEC_TIME_SHIFT);
+            schedulerSetNextStateTime((osdStateDurationFracUs[osdState] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
         }
     }
 }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -709,7 +709,7 @@ TEST_F(OsdTest, TestAlarms)
     // elements showing values in alarm range should flash
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    timeUs_t startTime = simulationTime + 0.25e6;
+    timeUs_t startTime = simulationTime;
     for (int i = 0; i < 15; i++) {
         // Blinking should happen at 2Hz
         simulationTime = startTime + i*0.25e6;
@@ -1083,6 +1083,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
+    simulationTime += 0.25e6;
     osdRefresh();
 
     // then
@@ -1098,6 +1099,7 @@ TEST_F(OsdTest, TestElementWarningsBattery)
     // Delay as the warnings are flashing
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
+    simulationTime += 0.25e6;
     osdRefresh();
 
     // then
@@ -1204,7 +1206,7 @@ TEST_F(OsdTest, TestGpsElements)
     // Sat indicator should blink and show "NC"
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    timeUs_t startTime = simulationTime + 0.25e6;
+    timeUs_t startTime = simulationTime;
     for (int i = 0; i < 15; i++) {
         // Blinking should happen at 2Hz
         simulationTime = startTime + i*0.25e6;
@@ -1228,7 +1230,7 @@ TEST_F(OsdTest, TestGpsElements)
     // Sat indicator should blink and show "0"
     simulationTime += 1000000;
     simulationTime -= simulationTime % 1000000;
-    startTime = simulationTime + 0.25e6;
+    startTime = simulationTime;
     for (int i = 0; i < 15; i++) {
         // Blinking should happen at 2Hz
         simulationTime = startTime + i*0.25e6;


### PR DESCRIPTION
This PR addresses the following two issues:
1. In light of the observation at https://github.com/betaflight/betaflight/issues/11333#issuecomment-1020353023 that there were insufficient element groups in the OSD driver this has been increased
2.  Long element render times do not decay like other task prediction which may cause issues with some lower level display device drivers with inconsistent render times.

Tested on a AIRB-NOX (F411), MATEKF405TE, MATEKF722SE and MATEKH743 with MAX7456.
Tested on JHEF7DUAL with DJI.