### PR TITLE
OSD - Use async screen clear in OSD_STATE_UPDATE_CANVAS.

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -300,8 +300,8 @@ void osdAnalyzeActiveElements(void)
 {
     /* This code results in a total RX task RX_STATE_MODES state time of ~68us on an F411 overclocked to 108MHz
      * This upsets the scheduler task duration estimation and will break SPI RX communication. This can
-     * occur in flight, but only when the OSD profile is changed by switch so can be ignored, only causing
-     * one late task instance.
+     * occur in flight, e.g. when the OSD profile is changed by switch so can be ignored, or GPS sensor comms
+     * is lost - only causing one late task instance.
      */
     schedulerIgnoreTaskExecTime();
 
@@ -1272,7 +1272,7 @@ void osdUpdate(timeUs_t currentTimeUs)
     case OSD_STATE_UPDATE_CANVAS:
         // Hide OSD when OSDSW mode is active
         if (IS_RC_MODE_ACTIVE(BOXOSD)) {
-            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
+            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_NONE);
             osdState = OSD_STATE_COMMIT;
             break;
         }
@@ -1284,7 +1284,7 @@ void osdUpdate(timeUs_t currentTimeUs)
         } else {
             // Background layer not supported, just clear the foreground in preparation
             // for drawing the elements including their backgrounds.
-            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
+            displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_NONE);
         }
 
 #ifdef USE_GPS


### PR DESCRIPTION
As noted in the comment linked below, and with reference to #11330, `DISPLAY_CLEAR_NONE` needed to be used in `OSD_STATE_UPDATE_CANVAS` too.

https://github.com/betaflight/betaflight/pull/10813#issuecomment-1019529951

Now when the display driver supports async screen clear (as in #10702) the OSD task doesn't sit waiting for the screen clear to occur.
