### PR TITLE
Only prioritise a task if there's time to run it

### DIFF
--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -32,7 +32,7 @@
 
 #define LOAD_PERCENTAGE_ONE             100
 
-#define SCHED_TASK_DEFER_MASK           7   // Scheduler loop count is masked with this and when 0 long running tasks are processed
+#define SCHED_TASK_DEFER_MASK           0x07 // Scheduler loop count is masked with this and when 0 long running tasks are processed
 
 #define SCHED_START_LOOP_MIN_US         1   // Wait at start of scheduler loop if gyroTask is nearly due
 #define SCHED_START_LOOP_MAX_US         12

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -28,9 +28,11 @@
 #define TASK_PERIOD_MS(ms) ((ms) * 1000)
 #define TASK_PERIOD_US(us) (us)
 
-#define TASK_STATS_MOVING_SUM_COUNT 64
+#define TASK_STATS_MOVING_SUM_COUNT     64
 
-#define LOAD_PERCENTAGE_ONE 100
+#define LOAD_PERCENTAGE_ONE             100
+
+#define SCHED_TASK_DEFER_MASK           7   // Scheduler loop count is masked with this and when 0 long running tasks are processed
 
 #define SCHED_START_LOOP_MIN_US         1   // Wait at start of scheduler loop if gyroTask is nearly due
 #define SCHED_START_LOOP_MAX_US         12


### PR DESCRIPTION
The scheduler in 4.3 inherited the following feature from 4.2

- Once the prioritisation has been performed the scheduler won't schedule any other task until it has run

As Betaflight is a cooperative multi-tasking system there is a contract between the scheduler and tasks that if the tasks are well behaved and return within their portion of the time available after the gyro/filter/pid tasks (approx 45us on an F411 at 8kHz) then the scheduler will call all tasks at the desired rate. Should any task hog the processor and not return when it should then the scheduler, knowing how long the task takes to run, will allow it to run only when there is time to do so, but if the time taken was too long the scheduler may need to apply special consideration and reduce its estimate of how long the task will take to run, in order that it will eventually run. Due to the above behaviour no other tasks can run whilst the scheduler tries to schedule the errant task, resulting in other tasks not being called as often as they should.

The PR modifies the 4.3 scheduler with the following behaviour.

- A task will only be prioritised above others if there's enough time to run it (apart from the `SERIAL` task which takes ms to run due to its use of USB).
- The highest priority task for which time is available will be selected
- One pass in 8 the scheduler will allow any task to be prioritised allowing the scheduler to reduce the anticipated execution time so the task will ultimately be executed

The above allows other tasks to run whilst the scheduler attempts to schedule errant tasks. Thus a task which makes itself unschedulable by taking too long to execute will not block other tasks from running.

The trace below demonstrates this code working. Taken from an F411 with 4kHz PID loop, two consecutive gyro cycles are shown, measured by the `0` and `1` markers as being both 125us. The green `Priority bumped` trace shows the above algorithm being invoked to effectively bump up the priority of a task (indicated by the `2` markers) above that of one which doesn't quite have time to execute and which then executes in the next cycle when there is more time (indicated by the `3` markers).

![image](https://user-images.githubusercontent.com/11480839/151456195-48b7ac2e-d25c-4745-81a2-9b759c33567e.png)

To prove a fix for the contrived filtering in https://github.com/betaflight/betaflight/issues/11344#issuecomment-1022877341 I've added a 100us delay into the FILTER task and I see the following showing a max  task time of 133us. It can be seen that the gyro rate is halved in order to next execute on time. Whilst conducting this experiment the SPI RX did not drop telemetry nor failsafe at any time. All tasks can be seen to be still running at their normal rate and OSD is unaffected.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       6       4    0.0%    0.0%         0      1    296       4
01 - (         SYSTEM)    783       6       1    0.4%    0.0%        69     48  22928       1
02 - (           GYRO)   4693       7       4    3.2%    1.8%      1512      0 138774       0
03 - (         FILTER)   4693     133     129   62.4%   60.5%     51204      0 138774       0
04 - (            PID)   4693      71      64   33.3%   30.0%     21562      0 138774       0
05 - (            ACC)    759       9       8    0.6%    0.6%       243     75  22231       8
06 - (       ATTITUDE)     96      20      16    0.1%    0.1%       100      1   2849      16
07 - (             RX)     82      32       2    0.2%    0.0%       382     36   8428      22
08 - (         SERIAL)     96    1729      13   16.5%    0.1%      1221      0   2809      13
09 - (       DISPATCH)    792       6       1    0.4%    0.0%        56     27  23254       0
13 - (         BEEPER)     96       7       4    0.0%    0.0%        10      5   2809       4
19 - (       LEDSTRIP)     95      15      14    0.1%    0.1%        30      0   2807      14
20 - (            OSD)     12      40       6    0.0%    0.0%      1016    139  17839      25
22 - (            CMS)     20       6       4    0.0%    0.0%         3      0    583       4
23 - (        VTXCTRL)      5       4       4    0.0%    0.0%         0      0    147       4
24 - (        CAMCTRL)      5       4       3    0.0%    0.0%         0      0    147       3
26 - (    ADCINTERNAL)      1       6      10    0.0%    0.0%         0      0     30      10
RX Check Function                  85      14                      1522
Total (excluding SERIAL)                                93.1%
```

Below is a trace showing execution of the realtime tasks and two occasions where the scheduler still runs its prioritisation and scheduling of tasks despite the unrealistic FILTER task duration.
![image](https://user-images.githubusercontent.com/11480839/151461623-bd74f4f3-2d82-47b6-b464-f0622d19e566.png)
