### PR TITLE
Update for Battery Efficiency Fix Issue #11277

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -121,6 +121,7 @@
 #include "common/typeconversion.h"
 #include "common/utils.h"
 #include "common/unit.h"
+#include "common/filter.h"
 
 #include "config/config.h"
 #include "config/feature.h"
@@ -178,6 +179,9 @@
 
 #define FULL_CIRCLE 360
 #define EFFICIENCY_MINIMUM_SPEED_CM_S 100
+#define EFFICIENCY_CUTOFF_HZ 0.5f
+
+static pt1Filter_t batteryEfficiencyFilt;
 
 #define MOTOR_STOPPED_THRESHOLD_RPM 1000
 
@@ -1082,12 +1086,9 @@ static void osdElementEfficiency(osdElementParms_t *element)
 {
     int efficiency = 0;
     if (sensors(SENSOR_GPS) && ARMING_FLAG(ARMED) && STATE(GPS_FIX) && gpsSol.groundSpeed >= EFFICIENCY_MINIMUM_SPEED_CM_S) {
-        const int speedX100 = osdGetSpeedToSelectedUnit(gpsSol.groundSpeed * 100); // speed * 100 for improved resolution at slow speeds
-        
-        if (speedX100 > 0) {
-            const int mAmperage = getAmperage() * 10; // Current in mA
-            efficiency = mAmperage * 100 / speedX100; // mAmperage * 100 to cancel out speed * 100 from above
-        }
+        const float speed = (float)osdGetSpeedToSelectedUnit(gpsSol.groundSpeed);
+        const float mAmperage = (float)getAmperage() * 10.f; // Current in mA
+        efficiency = lrintf(pt1FilterApply(&batteryEfficiencyFilt, (mAmperage / speed)));
     }
 
     const char unitSymbol = osdConfig()->units == UNIT_IMPERIAL ? SYM_MILES : SYM_KM;
@@ -1858,6 +1859,7 @@ void osdElementsInit(bool backgroundLayerFlag)
 {
     backgroundLayerSupported = backgroundLayerFlag;
     activeOsdElementCount = 0;
+    pt1FilterInit(&batteryEfficiencyFilt, pt1FilterGain(EFFICIENCY_CUTOFF_HZ, 1.0f / osdConfig()->framerate_hz));
 }
 
 void osdSyncBlink() {

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -192,6 +192,7 @@ osd_unittest_SRC := \
 		$(USER_DIR)/common/maths.c \
 		$(USER_DIR)/common/printf.c \
 		$(USER_DIR)/common/time.c \
+		$(USER_DIR)/common/filter.c \
 		$(USER_DIR)/fc/runtime_config.c
 
 osd_unittest_DEFINES := \


### PR DESCRIPTION
This update has two objectives: 
1. Fix the battery efficiency OSD element.  With British units, the display reads "-----" whenever the speed exceeds 47 miles/hour.  The original logic scaled the gps speed in cm/sec by 100 then converted it to miles/hr.  In the process, whenever the GPS speed exceeds 47 miles/hr the return value goes invalid. The fix for this is to remove the scaling, whereby keeping the number from going invalid.  
2. During testing I noticed the battery efficiency readout seemed to have a lot of noise and was "jumpy".  To address this, I added a filter to the battery efficiency calculation.  This also improves readout at slow speed.  