### PR TITLE
PINIO BOX: Support configurable "ON duration" for box activation

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1608,6 +1608,7 @@ const clivalue_t valueTable[] = {
     { "pinio_config", VAR_UINT8 | HARDWARE_VALUE | MODE_ARRAY, .config.array.length = PINIO_COUNT, PG_PINIO_CONFIG, offsetof(pinioConfig_t, config) },
 #ifdef USE_PINIOBOX
     { "pinio_box", VAR_UINT8 | HARDWARE_VALUE | MODE_ARRAY, .config.array.length = PINIO_COUNT, PG_PINIOBOX_CONFIG, offsetof(pinioBoxConfig_t, permanentId) },
+    { "pinio_box_on_duration", VAR_UINT8 | HARDWARE_VALUE | MODE_ARRAY, .config.array.length = PINIO_COUNT, PG_PINIOBOX_CONFIG, offsetof(pinioBoxConfig_t, onDuration) },
 #endif
 #endif
 

--- a/src/main/pg/piniobox.c
+++ b/src/main/pg/piniobox.c
@@ -31,7 +31,7 @@
 #include "piniobox.h"
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(pinioBoxConfig_t, pinioBoxConfig, PG_PINIOBOX_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(pinioBoxConfig_t, pinioBoxConfig, PG_PINIOBOX_CONFIG, 2);
 
 PG_RESET_TEMPLATE(pinioBoxConfig_t, pinioBoxConfig,
     .permanentId = {
@@ -39,6 +39,12 @@ PG_RESET_TEMPLATE(pinioBoxConfig_t, pinioBoxConfig,
         PERMANENT_ID_NONE,
         PERMANENT_ID_NONE,
         PERMANENT_ID_NONE
+    },
+    .onDuration = {
+      0,
+      0,
+      0,
+      0
     },
 );
 #endif

--- a/src/main/pg/piniobox.h
+++ b/src/main/pg/piniobox.h
@@ -26,6 +26,7 @@
 
 typedef struct pinioBoxConfig_s {
     uint8_t permanentId[PINIO_COUNT];
+    uint8_t onDuration[PINIO_COUNT]; // on duration length x 100ms or zero
 } pinioBoxConfig_t;
 
 PG_DECLARE(pinioBoxConfig_t, pinioBoxConfig);


### PR DESCRIPTION
By default, PINIO BOX facility is capable of turning on the configured PINIO when the associated box/mode is active and turning it off when it is no longer active. This PR adds an ability to optionally turn the pin on for a specified duration when the associated box/mode gets activated. The intended use-case for this feature is to control devices that use push-buttons which must be pressed for a certain duration to activate their functions.
An example that is presented at the end shows how this new feature can be used to control SMO 4K camera's power and recording in a more robust way than is possible via a regular PINIO BOX alone.

This PR introduces a new configuration option: "pinio_box_on_duration". It is an array of four numbers, similarly to "pinio_config" and "pinio_box" options. The default value of "pinio_box_on_duration" is "0,0,0,0". Zero value means that the corresponding PINIO works as usual -- it tracks the status of the corresponding box/mode as specified in "pinio_box". A non-zero value of "pinio_box_on_duration" specifies a duration in units of 100ms (e.g. 10 means 1 second). When the duration is configured, then the PINIO is turned on for the specified duration every time when the associated mode/box is activated.

### Example

For example, lets take an iFlight Beast F745 AIO FC (IFLIGHT_F745_AIO) and SMO 4K camera. Let's solder camera's power control wire to T7 pad on FC and camera's record control wire to R7 pad on FC, and reconfigure the corresponding pads for PINIO:

```
resource SERIAL_TX 7 NONE # was set to E08
resource SERIAL_RX 7 NONE # was set to E07
resource PINIO 1 E07      # R7 pad on FC
resource PINIO 2 E08      # T7 pad on FC
```

Now we configure PINIO_BOX to associate USER1 and USER2 boxes with PINIO 1 and PINIO 2.

```
set pinio_box = 40,41,255,255
```

Our goal is to turn on the power on SMO 4K and turn the recording on/off, which can be robustly done with 0.5 second press (pressing these buttons for too long activates their alternate functions and pressing them for too short does not get reliably recognized by the camera). So, we configure "pinio_box_on_duration" for both of those pins:

```
set pinio_box_on_duration = 5,5,0,0
```

Now we can go to "Modes" tab in configurator and configure USER1 (Camera recording) and USER2 (Camera power) modes. For example, we can take any AUX channel and assign a full range of this channel to USER2 box. This way, USER2 becomes active as soon as FC boots and, because of "pinio_box_on_duration" configuration, the corresponding pad is turned on for 0.5 seconds, powering on the attached camera. So, now the camera is powered on every time we attach a battery to FC (and will naturally be powered off when we detach the battery).

For recording control, for example, assume that we are using a high range of a three-position switch on AUX2 for PREARM. Let's set the same range of this AUX2 switch to USER1. This way, every time we move that switch to prearm, it will activate USER1 box, pushing a recording button for 0.5 seconds. You can flick the switch to prearm again to turn the recording off.

Note, that in order to work reliably, the switch must stay in the configured range for at least 20 ms to be reliably detected by PINIO BOX and trigger the USERx modes.

### Testing

The test binaries based on Betaflight 4.3.0-RC5 can be found here: https://github.com/elizarov/betaflight/releases/tag/pinio_box_on_duration-4.3.0-RC5