### PR TITLE
fix the range of the dynamic notch and sdft

### DIFF
--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -94,7 +94,7 @@ FAST_CODE void sdftPushBatch(sdft_t* sdft, const float sample, const int batchId
         batchEnd += sdft->batchSize;
     }
 
-    for (int i = batchStart; i <= batchEnd; i++) {
+    for (int i = batchStart; i < batchEnd; i++) {
         sdft->data[i] = twiddle[i] * (sdft->data[i] + delta);
     }
 }
@@ -106,7 +106,7 @@ FAST_CODE void sdftMagSq(const sdft_t *sdft, float *output)
     float re;
     float im;
 
-    for (int i = sdft->startBin; i <= sdft->endBin; i++) {
+    for (int i = sdft->startBin; i < sdft->endBin; i++) {
         re = crealf(sdft->data[i]);
         im = cimagf(sdft->data[i]);
         output[i] = re * re + im * im;

--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -94,7 +94,7 @@ FAST_CODE void sdftPushBatch(sdft_t* sdft, const float sample, const int batchId
         batchEnd += sdft->batchSize;
     }
 
-    for (int i = batchStart; i < batchEnd; i++) {
+    for (int i = batchStart; i <= batchEnd; i++) {
         sdft->data[i] = twiddle[i] * (sdft->data[i] + delta);
     }
 }
@@ -130,7 +130,7 @@ FAST_CODE void sdftWinSq(const sdft_t *sdft, float *output)
     float re;
     float im;
 
-    for (int i = (sdft->startBin + 1); i < sdft->endBin; i++) {
+    for (int i = sdft->startBin ; i <= sdft->endBin; i++) {
         val = sdft->data[i] - 0.5f * (sdft->data[i - 1] + sdft->data[i + 1]); // multiply by 2 to save one multiplication
         re = crealf(val);
         im = cimagf(val);

--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -106,7 +106,7 @@ FAST_CODE void sdftMagSq(const sdft_t *sdft, float *output)
     float re;
     float im;
 
-    for (int i = sdft->startBin; i < sdft->endBin; i++) {
+    for (int i = sdft->startBin; i <= sdft->endBin; i++) {
         re = crealf(sdft->data[i]);
         im = cimagf(sdft->data[i]);
         output[i] = re * re + im * im;
@@ -130,7 +130,7 @@ FAST_CODE void sdftWinSq(const sdft_t *sdft, float *output)
     float re;
     float im;
 
-    for (int i = sdft->startBin ; i <= sdft->endBin; i++) {
+    for (int i = sdft->startBin ; i < sdft->endBin; i++) {
         val = sdft->data[i] - 0.5f * (sdft->data[i - 1] + sdft->data[i + 1]); // multiply by 2 to save one multiplication
         re = crealf(val);
         im = cimagf(val);

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -282,7 +282,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             }
 
             // Search for N biggest peaks in frequency spectrum
-            for (int bin = (sdftStartBin + 1); bin < sdftEndBin; bin++) {
+            for (int bin = sdftStartBin; bin <= sdftEndBin; bin++) {
                 // Check if bin is peak
                 if ((sdftData[bin] > sdftData[bin - 1]) && (sdftData[bin] > sdftData[bin + 1])) {
                     // Check if peak is big enough to be one of N biggest peaks.


### PR DESCRIPTION
Current dynamic notch code calculates the frequency range incorrectly. Currently the min hz and max hz are off by at least 1 sdft resolution, in some cases closer to 2. This fixes the range so that the worst the sdft will be away from the min or max hz set by a user to be only 1 sdft resolution away, or best case completely accurate.

[sdft.txt](https://github.com/betaflight/betaflight/files/8034921/sdft.txt)
[sdft fixed.txt](https://github.com/betaflight/betaflight/files/8034924/sdft.fixed.txt)

Included are test files that have C code which shows this phenomenon.