### PR TITLE
Fix SDFT windowing

### DIFF
--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -49,9 +49,12 @@ void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numB
     }
 
     sdft->idx = 0;
-    sdft->startBin = startBin;
-    sdft->endBin = endBin;
-    sdft->numBatches = numBatches;
+
+    // Add 1 bin on either side outside of range (if possible) to get proper windowing up to range limits
+    sdft->startBin = constrain(startBin - 1, 0, SDFT_BIN_COUNT - 1);
+    sdft->endBin = constrain(endBin + 1, sdft->startBin, SDFT_BIN_COUNT - 1);
+
+    sdft->numBatches = MAX(numBatches, 1);
     sdft->batchSize = (sdft->endBin - sdft->startBin) / sdft->numBatches + 1;  // batchSize = ceil(numBins / numBatches)
 
     for (int i = 0; i < SDFT_SAMPLE_SIZE; i++) {


### PR DESCRIPTION
Thanks to @Quick-Flash it got apparent in PR https://github.com/betaflight/betaflight/pull/11397 that we are not reaching as many frequencies towards the edges of the dyn notch range as expected. Unfortunately, the approach of the PR introduced new problems.

### Problem & Solution

There is no incorrect range calculation but merely an issue of not updating the SDFT edge bins. This PR slightly expands the range in which the dyn notches can operate because now the windowing is properly applied up to the edge bins (only if possible). 

### Dynamic Notch Range
1. `minHz` and `maxHz` are still true limits: a notch never goes below `minHz` or above `maxHz`, 100% guaranteed

2. The dynamic notch range is:
`[ (startBin + 0.5) * sdftResolution; (endBin - 0.5) * sdftResolution ]`

3. Now we are off `minHz` and `maxHz` by `0.5 * sdftResolution` (half a bin) **at max**, just like intended in the first place.

4. The only situation where we are off by up to `1.5 * sdftResolution` from `endBin` is when `maxHz` is equal to the Nyquist limit