### PR TITLE
Fix USE_DSHOT_TELEMETRY & USE_DSHOT_BITBANG  define compilation issues

### DIFF
--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -172,8 +172,8 @@ FAST_CODE static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
 {
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         motorDmaOutput_t * const motor = &dmaMotors[descriptor->userParam];
-        if (!motor->isInput) {
 #ifdef USE_DSHOT_TELEMETRY
+        if (!motor->isInput) {
             dshotDMAHandlerCycleCounters.irqAt = getCycleCounter();
 #endif
 #ifdef USE_DSHOT_DMAR
@@ -195,8 +195,8 @@ FAST_CODE static void motor_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
                 LL_EX_TIM_EnableIT(motor->timerHardware->tim, motor->timerDmaSource);
                 dshotDMAHandlerCycleCounters.changeDirectionCompletedAt = getCycleCounter();
             }
-#endif
         }
+#endif
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
     }
 }

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -106,7 +106,7 @@ const resourceOwner_t *timerGetOwner(const timerHardware_t *timer)
 #if defined(USE_DSHOT_BITBANG)
     return dshotBitbangTimerGetOwner(timer);
 #else
-    return timerOwner;
+    return &freeOwner;
 #endif
 }
 


### PR DESCRIPTION
Found in testing that removing either of these defines for the H7 target resulted in uncompilable builds. These two commits fix that.