### PR TITLE
Fix non DSHOT protocols

### DIFF
--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -306,12 +306,8 @@ void mixerInitProfile(void)
     mixerRuntime.dynIdleDGain = currentPidProfile->dyn_idle_d_gain * 0.0000003f * pidGetPidFrequency();
     mixerRuntime.dynIdleMaxIncrease = currentPidProfile->dyn_idle_max_increase * 0.001f;
     mixerRuntime.minRpsDelayK = 800 * pidGetDT() / 20.0f; //approx 20ms D delay, arbitrarily suits many motors
-    if (!mixerRuntime.feature3dEnabled ) {
-        if (mixerRuntime.dynIdleMinRps) {
-            mixerRuntime.motorOutputLow = DSHOT_MIN_THROTTLE;
-        } else {
-            mixerRuntime.motorOutputLow = DSHOT_MIN_THROTTLE + mixerRuntime.idleThrottleOffset * DSHOT_RANGE;
-        }
+    if (!mixerRuntime.feature3dEnabled && mixerRuntime.dynIdleMinRps) {
+        mixerRuntime.motorOutputLow = DSHOT_MIN_THROTTLE; // Override value set by initEscEndpoints to allow zero motor drive
     }
 #endif
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3030,6 +3030,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         }
         pidInitConfig(currentPidProfile);
+        initEscEndpoints();
         mixerInitProfile();
 
         break;


### PR DESCRIPTION
Non DSHOT protocols are currently broken. At least multishot and oneshot.
Tested and confirmed working with all protocols except brushed and pwm, but that probably works too.

Fixes #11413, fixes #11363
