### PR TITLE
Included ICM20689 to CRAZYBEEF4SX1280 target

### DIFF
--- a/src/main/target/CRAZYBEEF4SX1280/target.h
+++ b/src/main/target/CRAZYBEEF4SX1280/target.h
@@ -51,10 +51,11 @@
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM20689
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
-
+#define USE_ACC_SPI_ICM20689
 
 // *************** OSD/FLASH *****************************
 #define USE_SPI_DEVICE_2

--- a/src/main/target/CRAZYBEEF4SX1280/target.mk
+++ b/src/main/target/CRAZYBEEF4SX1280/target.mk
@@ -3,6 +3,7 @@ FEATURES       += VCP ONBOARDFLASH
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_icm20689.c \
             drivers/max7456.c \
             drivers/vtx_rtc6705.c \
             drivers/vtx_rtc6705_soft_spi.c \


### PR DESCRIPTION
This is a small update to CRAZYBEEF4SX1280 target.
MPU6000 is getting too expensive and it will be replaced by ICM20689, so I added the driver to support both gyro chips.

Target hex to test:
[betaflight_4.3.0_CRAZYBEEF4SX1280_70ace55b2.zip](https://github.com/betaflight/betaflight/files/8114349/betaflight_4.3.0_CRAZYBEEF4SX1280_70ace55b2.zip)
