### PR TITLE
Perform compass reads in the background

### DIFF
--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -200,19 +200,23 @@ static void hmc5883SpiInit(const extDevice_t *dev)
 
 static bool hmc5883lRead(magDev_t *mag, int16_t *magData)
 {
-    uint8_t buf[6];
+    static uint8_t buf[6];
+    static bool pendingRead = true;
 
     extDevice_t *dev = &mag->dev;
 
-    bool ack = busReadRegisterBuffer(dev, HMC58X3_REG_DATA, buf, 6);
+    if (pendingRead) {
+        busReadRegisterBufferStart(dev, HMC58X3_REG_DATA, buf, sizeof(buf));
 
-    if (!ack) {
+        pendingRead = false;
         return false;
     }
 
     magData[X] = (int16_t)(buf[0] << 8 | buf[1]);
     magData[Z] = (int16_t)(buf[2] << 8 | buf[3]);
     magData[Y] = (int16_t)(buf[4] << 8 | buf[5]);
+
+    pendingRead = true;
 
     return true;
 }

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -103,19 +103,23 @@
 
 static bool lis3mdlRead(magDev_t * mag, int16_t *magData)
 {
-    uint8_t buf[6];
+    static uint8_t buf[6];
+    static bool pendingRead = true;
 
     extDevice_t *dev = &mag->dev;
 
-    bool ack = busReadRegisterBuffer(dev, LIS3MDL_REG_OUT_X_L, buf, 6);
+    if (pendingRead) {
+        busReadRegisterBufferStart(dev, LIS3MDL_REG_OUT_X_L, buf, sizeof(buf));
 
-    if (!ack) {
+        pendingRead = false;
         return false;
     }
 
     magData[X] = (int16_t)(buf[1] << 8 | buf[0]) / 4;
     magData[Y] = (int16_t)(buf[3] << 8 | buf[2]) / 4;
     magData[Z] = (int16_t)(buf[5] << 8 | buf[4]) / 4;
+
+    pendingRead = true;
 
     return true;
 }

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -264,6 +264,20 @@ static void taskUpdateBaro(timeUs_t currentTimeUs)
 }
 #endif
 
+#ifdef USE_MAG
+static void taskUpdateMag(timeUs_t currentTimeUs)
+{
+    UNUSED(currentTimeUs);
+
+    if (sensors(SENSOR_MAG)) {
+        const uint32_t newDeadline = compassUpdate(currentTimeUs);
+        if (newDeadline != 0) {
+            rescheduleTask(TASK_SELF, newDeadline);
+        }
+    }
+}
+#endif
+
 #if defined(USE_RANGEFINDER)
 void taskUpdateRangefinder(timeUs_t currentTimeUs)
 {
@@ -356,7 +370,7 @@ task_attribute_t task_attributes[TASK_COUNT] = {
 #endif
 
 #ifdef USE_MAG
-    [TASK_COMPASS] = DEFINE_TASK("COMPASS", NULL, NULL, compassUpdate,TASK_PERIOD_HZ(10), TASK_PRIORITY_LOW),
+    [TASK_COMPASS] = DEFINE_TASK("COMPASS", NULL, NULL, taskUpdateMag, TASK_PERIOD_HZ(10), TASK_PRIORITY_LOW),
 #endif
 
 #ifdef USE_BARO

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -62,7 +62,7 @@ typedef struct compassConfig_s {
 PG_DECLARE(compassConfig_t, compassConfig);
 
 bool compassIsHealthy(void);
-void compassUpdate(timeUs_t currentTime);
+uint32_t compassUpdate(timeUs_t currentTime);
 bool compassInit(void);
 void compassPreInit(void);
 void compassStartCalibration(void);


### PR DESCRIPTION
Compass reads are slow, so this PR initiates the access, and then returns 1ms later to get the result so as not to block the processor.

Fixes: https://github.com/betaflight/betaflight/issues/11437