### PR TITLE
Save not set for VTX osd settings

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -610,7 +610,7 @@ static const OSD_Entry saCmsMenuPORFreqEntries[] = {
 
     { "CUR FREQ",     OME_UINT16 | DYNAMIC,  NULL,             &(OSD_UINT16_t){ &saCmsORFreq, 5000, 5999, 0 } },
     { "NEW FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5999, 1 } },
-    { "SET",          OME_Funcall, saCmsSetPORFreq,  NULL },
+    { "SAVE",         OME_Funcall, saCmsSetPORFreq,  NULL },
 
     { "BACK",         OME_Back,    NULL,             NULL },
     { NULL,           OME_END,     NULL,             NULL }
@@ -633,7 +633,7 @@ static const OSD_Entry saCmsMenuUserFreqEntries[] = {
 
     { "CUR FREQ",      OME_UINT16 | DYNAMIC,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5999, 0 } },
     { "NEW FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5999, 1 } },
-    { "SET",           OME_Funcall, saCmsConfigUserFreq, NULL },
+    { "SAVE",          OME_Funcall, saCmsConfigUserFreq, NULL },
 
     { "BACK",          OME_Back,    NULL,             NULL },
     { NULL,            OME_END,     NULL,             NULL }
@@ -706,7 +706,7 @@ static const OSD_Entry saCmsMenuFreqModeEntries[] = {
     { "FREQ",   OME_Submenu | OPTSTRING, (CMSEntryFuncPtr)saCmsUserFreqGetString,  &saCmsMenuUserFreq },
     { "POWER",  OME_TAB | DYNAMIC,     saCmsConfigPowerByGvar,                   &saCmsEntPower },
     { "PIT",    OME_TAB | DYNAMIC,     saCmsConfigPitByGvar,                     &saCmsEntPit },
-    { "SET",    OME_Submenu, cmsMenuChange,                            &saCmsMenuCommence },
+    { "SAVE",   OME_Submenu, cmsMenuChange,                            &saCmsMenuCommence },
     { "CONFIG", OME_Submenu, cmsMenuChange,                            &saCmsMenuConfig },
 
     { "BACK", OME_Back, NULL, NULL },
@@ -723,7 +723,7 @@ static const OSD_Entry saCmsMenuChanModeEntries[] =
     { "(FREQ)", OME_UINT16 | DYNAMIC,  NULL,                   &saCmsEntFreqRef },
     { "POWER",  OME_TAB | DYNAMIC,     saCmsConfigPowerByGvar, &saCmsEntPower },
     { "PIT",    OME_TAB | DYNAMIC,     saCmsConfigPitByGvar,   &saCmsEntPit },
-    { "SET",    OME_Submenu, cmsMenuChange,          &saCmsMenuCommence },
+    { "SAVE",   OME_Submenu, cmsMenuChange,          &saCmsMenuCommence },
     { "CONFIG", OME_Submenu, cmsMenuChange,          &saCmsMenuConfig },
 
     { "BACK",   OME_Back, NULL, NULL },

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -269,14 +269,14 @@ static const OSD_Entry trampMenuEntries[] =
 {
     { "- TRAMP -", OME_Label, NULL, NULL },
 
-    { "",       OME_Label | DYNAMIC,   NULL,                   trampCmsStatusString },
+    { "",       OME_Label | DYNAMIC,   NULL,         trampCmsStatusString },
     { "PIT",    OME_TAB,     trampCmsSetPitMode,     &trampCmsEntPitMode },
     { "BAND",   OME_TAB,     trampCmsConfigBand,     &trampCmsEntBand },
     { "CHAN",   OME_TAB,     trampCmsConfigChan,     &trampCmsEntChan },
-    { "(FREQ)", OME_UINT16 | DYNAMIC,  NULL,                   &trampCmsEntFreqRef },
+    { "(FREQ)", OME_UINT16 | DYNAMIC,  NULL,         &trampCmsEntFreqRef },
     { "POWER",  OME_TAB,     trampCmsConfigPower,    &trampCmsEntPower },
-    { "T(C)",   OME_INT16 | DYNAMIC,   NULL,                   &trampCmsEntTemp },
-    { "SET",    OME_Submenu, cmsMenuChange,          &trampCmsMenuCommence },
+    { "T(C)",   OME_INT16 | DYNAMIC,   NULL,         &trampCmsEntTemp },
+    { "SAVE",   OME_Submenu, cmsMenuChange,          &trampCmsMenuCommence },
 
     { "BACK",   OME_Back, NULL, NULL },
     { NULL,     OME_END, NULL, NULL }


### PR DESCRIPTION
When using the TRAMP Vtx protocol, pressing `SET` in the OSD after making a channel or other VTx change results in the new values being saved permanttly to the EEPROM.

There is no need to menu back to save or save and reboot if all you change is the VTx.

Hence it seems better make the OSD label in the VTx settings page say `SAVE`, not `SET`.