### PR TITLE
Report true average task execution time in tasks report

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4929,20 +4929,20 @@ static void cliTasks(const char *cmdName, char *cmdline)
             int taskFrequency = taskInfo.averageDeltaTime10thUs == 0 ? 0 : lrintf(1e7f / taskInfo.averageDeltaTime10thUs);
             cliPrintf("%02d - (%15s) ", taskId, taskInfo.taskName);
             const int maxLoad = taskInfo.maxExecutionTimeUs == 0 ? 0 : (taskInfo.maxExecutionTimeUs * taskFrequency) / 1000;
-            const int averageLoad = taskInfo.averageExecutionTimeUs == 0 ? 0 : (taskInfo.averageExecutionTimeUs * taskFrequency) / 1000;
+            const int averageLoad = taskInfo.averageExecutionTime10thUs == 0 ? 0 : (taskInfo.averageExecutionTime10thUs * taskFrequency) / 10000;
             if (taskId != TASK_SERIAL) {
                 averageLoadSum += averageLoad;
             }
             if (systemConfig()->task_statistics) {
 #if defined(USE_LATE_TASK_STATISTICS)
                 cliPrintLinef("%6d %7d %7d %4d.%1d%% %4d.%1d%% %9d %6d %6d %7d",
-                        taskFrequency, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTimeUs,
+                        taskFrequency, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTime10thUs / 10,
                         maxLoad/10, maxLoad%10, averageLoad/10, averageLoad%10,
                         taskInfo.totalExecutionTimeUs / 1000,
                         taskInfo.lateCount, taskInfo.runCount, taskInfo.execTime);
 #else
                 cliPrintLinef("%6d %7d %7d %4d.%1d%% %4d.%1d%% %9d",
-                        taskFrequency, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTimeUs,
+                        taskFrequency, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTime10thUs / 10,
                         maxLoad/10, maxLoad%10, averageLoad/10, averageLoad%10,
                         taskInfo.totalExecutionTimeUs / 1000);
 #endif

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -555,9 +555,9 @@ static void showTasksPage(void)
         getTaskInfo(taskId, &taskInfo);
         if (taskInfo.isEnabled && taskId != TASK_SERIAL) {// don't waste a line of the display showing serial taskInfo
             const int taskFrequency = (int)(1000000.0f / ((float)taskInfo.latestDeltaTimeUs));
-            const int maxLoad = (taskInfo.maxExecutionTimeUs * taskFrequency + 5000) / 10000;
-            const int averageLoad = (taskInfo.averageExecutionTimeUs * taskFrequency + 5000) / 10000;
-            tfp_sprintf(lineBuffer, format, taskId, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTimeUs, maxLoad, averageLoad);
+            const int maxLoad = taskInfo.maxExecutionTimeUs == 0 ? 0 : (taskInfo.maxExecutionTimeUs * taskFrequency) / 1000;
+            const int averageLoad = taskInfo.averageExecutionTime10thUs == 0 ? 0 : (taskInfo.averageExecutionTime10thUs * taskFrequency) / 10000;
+            tfp_sprintf(lineBuffer, format, taskId, taskInfo.maxExecutionTimeUs, taskInfo.averageExecutionTime10thUs / 10, maxLoad, averageLoad);
             padLineBuffer();
             i2c_OLED_set_line(dev, rowIndex++);
             i2c_OLED_send_string(dev, lineBuffer);

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -217,7 +217,7 @@ void getTaskInfo(taskId_e taskId, taskInfo_t * taskInfo)
     taskInfo->subTaskName = getTask(taskId)->attribute->subTaskName;
     taskInfo->maxExecutionTimeUs = getTask(taskId)->maxExecutionTimeUs;
     taskInfo->totalExecutionTimeUs = getTask(taskId)->totalExecutionTimeUs;
-    taskInfo->averageExecutionTimeUs = getTask(taskId)->anticipatedExecutionTime >> TASK_EXEC_TIME_SHIFT;
+    taskInfo->averageExecutionTime10thUs = getTask(taskId)->movingSumExecutionTime10thUs / TASK_STATS_MOVING_SUM_COUNT;
     taskInfo->averageDeltaTime10thUs = getTask(taskId)->movingSumDeltaTime10thUs / TASK_STATS_MOVING_SUM_COUNT;
     taskInfo->latestDeltaTimeUs = getTask(taskId)->taskLatestDeltaTimeUs;
     taskInfo->movingAverageCycleTimeUs = getTask(taskId)->movingAverageCycleTimeUs;
@@ -389,6 +389,7 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
         selectedTask->attribute->taskFunc(currentTimeBeforeTaskCallUs);
         taskExecutionTimeUs = micros() - currentTimeBeforeTaskCallUs;
         taskTotalExecutionTime += taskExecutionTimeUs;
+        selectedTask->movingSumExecutionTime10thUs += (taskExecutionTimeUs * 10) - selectedTask->movingSumExecutionTime10thUs / TASK_STATS_MOVING_SUM_COUNT;
         if (!ignoreCurrentTaskExecRate) {
             // Record task execution rate and max execution time
             selectedTask->taskLatestDeltaTimeUs = cmpTimeUs(currentTimeUs, selectedTask->lastStatsAtUs);

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -85,7 +85,7 @@ typedef struct {
     timeDelta_t  latestDeltaTimeUs;
     timeUs_t     maxExecutionTimeUs;
     timeUs_t     totalExecutionTimeUs;
-    timeUs_t     averageExecutionTimeUs;
+    timeUs_t     averageExecutionTime10thUs;
     timeUs_t     averageDeltaTime10thUs;
     float        movingAverageCycleTimeUs;
 #if defined(USE_LATE_TASK_STATISTICS)
@@ -212,6 +212,7 @@ typedef struct {
     float    movingAverageCycleTimeUs;
     timeUs_t anticipatedExecutionTime;  // Fixed point expectation of next execution time
     timeUs_t movingSumDeltaTime10thUs;  // moving sum over 64 samples
+    timeUs_t movingSumExecutionTime10thUs;
     timeUs_t maxExecutionTimeUs;
     timeUs_t totalExecutionTimeUs;      // total time consumed by task since boot
     timeUs_t lastStatsAtUs;             // time of last stats gathering for rate calculation


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/11445

With ELRS connected on a BETAFPVF4SX1280 the tasks command now reports the correct average task loads, but it is noticeable that the max loads are much higher. This is due to tasks being delayed by the peaks of interrupt activity caused by ELRS and is perfectly OK.

The CPU load is a true average whereas the figure being presented as a task average relates (in master) not to the average time the tasks are taking, but the scheduler's estimate of how much time allow for the tasks to run which is more conservative and higher.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       1    0.0%    0.0%         0      0     45      22
01 - (         SYSTEM)    774      64       0    4.9%    0.0%        61     15   3828      29
02 - (           GYRO)   7994      98       4   78.3%    3.5%      3212      0  35630       0
03 - (         FILTER)   3997     162      47   64.7%   18.7%     19853      0  17815       0
04 - (            PID)   3997     201      96   80.3%   38.4%     39281      0  17815       0
05 - (            ACC)    777      31       3    2.4%    0.3%       339     14   3634      19
06 - (       ATTITUDE)     97      48      10    0.4%    0.1%       111      1    436      47
07 - (             RX)    250      50      22    1.2%    0.5%      1824     76   3345      17
08 - (         SERIAL)     98    3746       2   36.7%    0.0%      1031      0    436      29
09 - (       DISPATCH)    820      65       0    5.3%    0.0%        80     19   3843      22
10 - (BATTERY_VOLTAGE)     50       4       2    0.0%    0.0%        11      0    222      32
11 - (BATTERY_CURRENT)     50       1       0    0.0%    0.0%         5      0    222      24
12 - ( BATTERY_ALERTS)      5       2       1    0.0%    0.0%         0      0     22      46
13 - (         BEEPER)     98       7       1    0.0%    0.0%        15      1    436      11
16 - (      TELEMETRY)    242      21       0    0.5%    0.0%        27      2   1076      19
17 - (       LEDSTRIP)     97      14       3    0.1%    0.0%        38      0    434      35
18 - (            OSD)     11      52      19    0.0%    0.0%       620      8   1306      33
20 - (            CMS)     20       7       1    0.0%    0.0%         3      0     89      26
21 - (        VTXCTRL)      5       1       1    0.0%    0.0%         0      0     22      19
22 - (        CAMCTRL)      5       1       0    0.0%    0.0%         0      0     22       2
24 - (    ADCINTERNAL)      1       3       2    0.0%    0.0%         0      0      4      22
RX Check Function                  80       3                       366
Total (excluding SERIAL)                                61.5%
```