### PR TITLE
Fix ELRS issues

### DIFF
--- a/src/main/drivers/nvic.h
+++ b/src/main/drivers/nvic.h
@@ -28,11 +28,14 @@
 #define NVIC_PRIO_SONAR_EXTI               NVIC_BUILD_PRIORITY(2, 0)  // maybe increase slightly
 #define NVIC_PRIO_DSHOT_DMA                NVIC_BUILD_PRIORITY(2, 1)
 #define NVIC_PRIO_TRANSPONDER_DMA          NVIC_BUILD_PRIORITY(3, 0)
-#define NVIC_PRIO_RX_INT_EXTI              NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_RX_BUSY_EXTI             NVIC_BUILD_PRIORITY(3, 0)
+
+// RX_SPI must be lower priority than SPI DMA so EXTI ISRs don't interfere with SPI transfers and transfer complete callbacks
+#define NVIC_PRIO_RX_SPI_INT_EXTI          NVIC_BUILD_PRIORITY(3, 0x0f)
+#define NVIC_PRIO_RX_INT_EXTI              NVIC_BUILD_PRIORITY(3, 0x0f)
+#define NVIC_PRIO_RX_BUSY_EXTI             NVIC_BUILD_PRIORITY(3, 0x0f)
+
 #define NVIC_PRIO_MPU_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
 #define NVIC_PRIO_MAG_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_RX_SPI_INT_EXTI          NVIC_BUILD_PRIORITY(0x0f, 0x0f)
 #define NVIC_PRIO_WS2811_DMA               NVIC_BUILD_PRIORITY(1, 2)  // TODO - is there some reason to use high priority? (or to use DMA IRQ at all?)
 #define NVIC_PRIO_SERIALUART_TXDMA         NVIC_BUILD_PRIORITY(1, 1)  // Highest of all SERIALUARTx_TXDMA
 #define NVIC_PRIO_SERIALUART1_TXDMA        NVIC_BUILD_PRIORITY(1, 1)

--- a/src/main/drivers/rx/rx_sx1280.c
+++ b/src/main/drivers/rx/rx_sx1280.c
@@ -208,6 +208,7 @@ bool sx1280Init(IO_t resetPin, IO_t busyPin)
 
     if (busyPin) {
         IOInit(busyPin, OWNER_RX_SPI_EXPRESSLRS_BUSY, 0);
+        IOConfigGPIO(busyPin, IOCFG_IN_FLOATING);
     } else {
         busyPin = IO_NONE;
     }


### PR DESCRIPTION
Depending on MCU and EXTI line/pin selection the current code in `master` will be broken.

These fixes came about after testing #11380 on an H7 but the fixes are not H7 specific.

See #11451 for further details.  Can be merged before or after #11456 which is also related.
