### PR TITLE
Make negotiated baud configurable for CRSF

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -780,6 +780,9 @@ const clivalue_t valueTable[] = {
 #endif
 #if defined(USE_SERIALRX_CRSF)
     { "crsf_use_rx_snr",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, crsf_use_rx_snr) },
+#if defined(USE_CRSF_V3)
+    { "crsf_use_negotiated_baud",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, crsf_use_negotiated_baud) },
+#endif
 #endif
     { "airmode_start_throttle_percent", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RX_CONFIG, offsetof(rxConfig_t, airModeActivateThreshold) },
     { "rx_min_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_min_usec) },

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -71,6 +71,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .sbus_baud_fast = false,
         .crsf_use_rx_snr = false,
         .msp_override_channels_mask = 0,
+        .crsf_use_negotiated_baud = false,
     );
 
 #ifdef RX_CHANNELS_TAER

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -62,6 +62,7 @@ typedef struct rxConfig_s {
     uint8_t sbus_baud_fast;                    // Select SBus fast baud rate
     uint8_t crsf_use_rx_snr;                   // Use RX SNR (in dB) instead of RSSI dBm for CRSF
     uint32_t msp_override_channels_mask;       // Channels to override when the MSP override mode is enabled
+    uint8_t crsf_use_negotiated_baud;          // Use negotiated baud rate for CRSF V3
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -656,6 +656,11 @@ void crsfRxUpdateBaudrate(uint32_t baudrate)
 {
     serialSetBaudRate(serialPort, baudrate);
 }
+
+bool crsfRxUseNegotiatedBaud(void)
+{
+    return rxConfig()->crsf_use_negotiated_baud;
+}
 #endif
 
 bool crsfRxIsActive(void)

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -86,4 +86,5 @@ struct rxConfig_s;
 struct rxRuntimeState_s;
 bool crsfRxInit(const struct rxConfig_s *initialRxConfig, struct rxRuntimeState_s *rxRuntimeState);
 void crsfRxUpdateBaudrate(uint32_t baudrate);
+bool crsfRxUseNegotiatedBaud(void);
 bool crsfRxIsActive(void);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -431,7 +431,7 @@ void speedNegotiationProcess(uint32_t currentTime)
         crsfRxSendTelemetryData();
     } else {
         if (crsfSpeed.hasPendingReply) {
-            bool found = crsfSpeed.index < BAUD_COUNT ? true : false;
+            bool found = ((crsfSpeed.index < BAUD_COUNT) && crsfRxUseNegotiatedBaud()) ? true : false;
             sbuf_t crsfSpeedNegotiationBuf;
             sbuf_t *dst = &crsfSpeedNegotiationBuf;
             crsfInitializeFrame(dst);
@@ -440,7 +440,7 @@ void speedNegotiationProcess(uint32_t currentTime)
             crsfFinalize(dst);
             crsfRxSendTelemetryData();
             crsfSpeed.hasPendingReply = false;
-            crsfSpeed.isNewSpeedValid = true;
+            crsfSpeed.isNewSpeedValid = found;
             crsfSpeed.confirmationTime = currentTime;
             return;
         } else if (crsfSpeed.isNewSpeedValid) {


### PR DESCRIPTION
Allows enabling/disabling the CRSF v3 baud rate negotiation by setting ```crsf_use_negotiated_baud``` in cli. Defaults to OFF.

There have been reports of strange behaviour and seemingly random failsafes at any range on some setups using Crossfire.
Ours and TBS's investigations show that this likely has something to do with the crsf baud rate negotiation and we have decided that for now it is best that this is disabled by default.

Disabling the baud rate negotiation will cause the FC to reject any baud rate proposed by the RX and ensure that it stays at the default 420000/416666. This will also cause the RX to fall back to using CRSF V2 and this will provide safety for those that haven't updated their equipment to crossfire/tracer firmware version 6.17 that disables CRSF V3 completely.

[betaflight_4.3.0_STM32F7X2_norevision.zip](https://github.com/betaflight/betaflight/files/8254231/betaflight_4.3.0_STM32F7X2_norevision.zip)
[betaflight_4.3.0_STM32F405_norevision.zip](https://github.com/betaflight/betaflight/files/8254233/betaflight_4.3.0_STM32F405_norevision.zip)
[betaflight_4.3.0_STM32F411_norevision.zip](https://github.com/betaflight/betaflight/files/8254235/betaflight_4.3.0_STM32F411_norevision.zip)
[betaflight_4.3.0_STM32F745_norevision.zip](https://github.com/betaflight/betaflight/files/8254237/betaflight_4.3.0_STM32F745_norevision.zip)
[betaflight_4.3.0_STM32G47X_norevision.zip](https://github.com/betaflight/betaflight/files/8254238/betaflight_4.3.0_STM32G47X_norevision.zip)
[betaflight_4.3.0_STM32H743_norevision.zip](https://github.com/betaflight/betaflight/files/8254239/betaflight_4.3.0_STM32H743_norevision.zip)

