### PR TITLE
recover from failsafe more predictably and more quickly

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -245,10 +245,13 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                             && failsafeConfig()->failsafe_procedure != FAILSAFE_PROCEDURE_GPS_RESCUE
 #endif
                             ) {
-                            // JustDisarm: throttle was LOW for at least 'failsafe_throttle_low_delay' seconds
+                            // JustDisarm: throttle was LOW for at least 'failsafe_throttle_low_delay' seconds before failsafe
+                            // protects against false arming when the Tx is powered up after the quad
                             failsafeActivate();
-                            failsafeState.phase = FAILSAFE_LANDED;      // skip auto-landing procedure
-                            failsafeState.receivingRxDataPeriodPreset = PERIOD_OF_3_SECONDS; // require 3 seconds of valid rxData
+                            // skip auto-landing procedure
+                            failsafeState.phase = FAILSAFE_LANDED;
+                            // re-arm at rxDataRecoveryPeriod - default is 1.0 seconds
+                            failsafeState.receivingRxDataPeriodPreset = failsafeState.rxDataRecoveryPeriod;
                         } else {
                             failsafeState.phase = FAILSAFE_RX_LOSS_DETECTED;
                         }
@@ -279,7 +282,10 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                         case FAILSAFE_PROCEDURE_DROP_IT:
                             // Drop the craft
                             failsafeActivate();
-                            failsafeState.phase = FAILSAFE_LANDED;      // skip auto-landing procedure
+                            // re-arm at rxDataRecoveryPeriod - default is 1.0 seconds
+                            failsafeState.receivingRxDataPeriodPreset = failsafeState.rxDataRecoveryPeriod;
+                            // skip auto-landing procedure
+                            failsafeState.phase = FAILSAFE_LANDED;
                             break;
 #ifdef USE_GPS_RESCUE
                         case FAILSAFE_PROCEDURE_GPS_RESCUE:


### PR DESCRIPTION
In reviewing the failsafe code, I noted the cause of some significant delays affecting re-arming.

Some are addressed in #11459, but these two require specific consideration.

**1. More reliable and user-configurable time to re-arm after `Drop` failsafe mode has terminated.**

Current master code does not explicitly set `failsafeState.receivingRxDataPeriodPreset` in `Drop` mode.  When `Drop` activates, the most recent value for `receivingRxDataPeriodPreset` will apply.  This could be zero seconds, 3 seconds, or 30 seconds depending on what happened previously.  This unpredictability is quite annoying on a race track.  

This PR sets the delay after a Drop failsafe, whether induced with the sticks or by loss of signal, to the `failsafeState.rxDataRecoveryPeriod`.  This is a value that can be user-configurable via the CLI `failsafe_recovery_delay` parameter.  The previous value was hard coded at 3.0 seconds and was not user-modifiable.

`failsafe_recovery_delay` currently defaults to 2.0 seconds, with a configurable range from zero to 20 seconds.  200ms is added to this time, so that the default time for `failsafeState.rxDataRecoveryPeriod` becomes 2.2 seconds.  Note that #11459 intends to change the default for `failsafe_recovery_delay` to 1.0s.

As background, recovery from a signal loss failsafe requires first that the signal is stable for the `rxDataRecoveryPeriod`, and then secondly that there is a further wait to unset the arming block and exit `FAILSAFE_RX_LOSS_MONITORING` mode.  Both delays are sequential.  This means an inevitable minimum total delay of 4.4s by default, and un-predictably 5.2 or 32.2s, depending on prior failsafe actions.

With this change, the total delay can be customised to be as short as 0.4s, e.g. when `failsafe_recovery_delay` is set to zero) or a very long time if desired.  A short recovery time is very useful when racing after transient power out or switch based failsafe is used in team racing.  Additionally, the time taken to re-arm after a DROP failsafe will be predictable.

Being able to customise the time to a shorter period may assist with recovery from failsafe, including switch induced failsafe, while falling.  However, excessively short times may not allow a new Rx link to stabilise, resulting in a risk of flyaway or abnormal control on arming.

Note this change makes no difference to landing or GPS Rescue failsafe re-arming inhibition.

**2. Make the same change to the "Just Disarm" feature**

 The "Just Disarm" feature is a little known but important failsafe feature, which disarms the quad immediately on failsafe if the throttle has been at zero for 5s or more before the failsafe.  This provides additional safety for people who, having landed and had throttle down for at least 5s, turn the radio off and forget to disarm before powering down the quad.  

The 5s period is customisable in the CLI with the `failsafe_throttle_low_delay` value, to a value from zero to 300s.

This PR concerns only the re-arm delay time after signal restoration following this kind of failsafe, which is currently fixed at 3.0 seconds, if throttle was down for more than 5s before the failsafe.  However, if the throttle was not down for more than 5.0 seconds before failsafe, the re-arm time becomes unpredictable, as above, if the failsafe is configured to Drop mode.

This PR shortens that time to 2.2 seconds, but more importantly makes it user-configurable.

Additionally, with the above change, the pilot will get the same re-arm time whether or not the throttle was held less than or more than the `failsafe_throttle_low_delay` period.

Together, these changes provide a much more predictable re-arming process.  It will be little faster than before on defaults, and can be made a lot faster if desired. 

I consider this is a bug-fix PR because the unpredictability of the delay time is, I think, can reasonably be considered a bug.

