### PR TITLE
Create release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+   categories:
+    - title: Features
+       labels:
+         - RN: MAJOR FEATURE
+         - RN: MINOR FEATURE
+    - title: Fixes
+       labels:
+         - RN: BUGFIX
+         - RN: SAFETY IMPROVEMENT
+         - RN: IMPROVEMENT
+    - title: Targets
+       labels:
+         - RN: NEW TARGET
+         - RN: TARGET UPDATE
+    - title: Known Issues
+       labels: 
+         - BUG


### PR DESCRIPTION
This is a first attempt at the auto-release notes generation - which happens when this 'release.yml' file is added to the repo. 

With that file in place, when the official Release is created by those with clearance to do so - the release notes will be generated with the press of a button as part of the process. 

It is outlined here:

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

I have included the categories and labels, and on consideration, I don't see a reason to use the exclude functions.

Let me know any issues...