### PR TITLE
Adding CLI min for failsafe_delay (value of '2' - 0.2s)

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -869,7 +869,7 @@ const clivalue_t valueTable[] = {
     { "thr_corr_angle",             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1,  900 }, PG_THROTTLE_CORRECTION_CONFIG, offsetof(throttleCorrectionConfig_t, throttle_correction_angle) },
 
 // PG_FAILSAFE_CONFIG
-    { "failsafe_delay",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_delay) },
+    { "failsafe_delay",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, 200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_delay) },
     { "failsafe_off_delay",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_off_delay) },
     { "failsafe_throttle",          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_throttle) },
     { "failsafe_switch_mode",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FAILSAFE_SWITCH_MODE }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_switch_mode) },

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -78,7 +78,7 @@ static const OSD_Entry cmsx_menuFailsafeEntries[] =
     { "-- FAILSAFE --", OME_Label, NULL, NULL},
 
     { "PROCEDURE",        OME_TAB | REBOOT_REQUIRED,    NULL, &(OSD_TAB_t)    { &failsafeConfig_failsafe_procedure, FAILSAFE_PROCEDURE_COUNT - 1, failsafeProcedureNames } },
-    { "GUARD TIME",       OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_delay, 0, 200, 1, 100 } },
+    { "GUARD TIME",       OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_delay, PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, 200, 1, 100 } },
     { "STAGE 2 DELAY",    OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_off_delay, 0, 200, 1, 100 } },
     { "STAGE 2 THROTTLE", OME_UINT16 | REBOOT_REQUIRED, NULL, &(OSD_UINT16_t) { &failsafeConfig_failsafe_throttle, PWM_PULSE_MIN, PWM_PULSE_MAX, 1 } },
 #ifdef USE_CMS_GPS_RESCUE_MENU

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -87,8 +87,12 @@ const char * const failsafeProcedureNames[FAILSAFE_PROCEDURE_COUNT] = {
 void failsafeReset(void)
 {
     failsafeState.rxDataFailurePeriod = failsafeConfig()->failsafe_delay * MILLIS_PER_TENTH_SECOND; // time to start stage2
+    if (failsafeState.rxDataFailurePeriod < PERIOD_RXDATA_RECOVERY) {
+        // PERIOD_RXDATA_RECOVERY (200ms) - avoid transients and ensure reliable arming
+        failsafeState.rxDataFailurePeriod = PERIOD_RXDATA_RECOVERY;
+    }
     failsafeState.rxDataRecoveryPeriod = failsafeConfig()->failsafe_recovery_delay * MILLIS_PER_TENTH_SECOND;
-    if (failsafeState.rxDataRecoveryPeriod < PERIOD_RXDATA_RECOVERY){
+    if (failsafeState.rxDataRecoveryPeriod < PERIOD_RXDATA_RECOVERY) {
         // PERIOD_RXDATA_RECOVERY (200ms) is the minimum allowed RxData recovery time
         failsafeState.rxDataRecoveryPeriod = PERIOD_RXDATA_RECOVERY;
     }


### PR DESCRIPTION
A value of 0 seconds does not make sense for `failsafe_delay`, so adding a hard min limit of 0.2 seconds for this value.
This is a guard time - time in stage 1 before switching to stage 2.