### PR TITLE
widening range of BLHeli/_S device id

### DIFF
--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -76,7 +76,7 @@
 // *** change to adapt Revision
 #define SERIAL_4WAY_VER_MAIN 20
 #define SERIAL_4WAY_VER_SUB_1 (uint8_t) 0
-#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 05
+#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 06
 
 #define SERIAL_4WAY_PROTOCOL_VER 108
 // *** end
@@ -332,10 +332,8 @@ uint16_t _crc_xmodem_update (uint16_t crc, uint8_t data) {
 #define ATMEL_DEVICE_MATCH ((pDeviceInfo->words[0] == 0x9307) || (pDeviceInfo->words[0] == 0x930A) || \
         (pDeviceInfo->words[0] == 0x930F) || (pDeviceInfo->words[0] == 0x940B))
 
-#define SILABS_DEVICE_MATCH ((pDeviceInfo->words[0] == 0xF310) || (pDeviceInfo->words[0] == 0xF330) || \
-        (pDeviceInfo->words[0] == 0xF410) || (pDeviceInfo->words[0] == 0xF390) || \
-        (pDeviceInfo->words[0] == 0xF850) || (pDeviceInfo->words[0] == 0xE8B1) || \
-        (pDeviceInfo->words[0] == 0xE8B2))
+#define SILABS_DEVICE_MATCH (pDeviceInfo->words[0] > 0xE800) // && (pDeviceInfo->words[0] < 0xF900))
+
 
 // BLHeli_32 MCU ID hi > 0x00 and < 0x90 / lo always = 0x06
 #define ARM_DEVICE_MATCH ((pDeviceInfo->bytes[1] > 0x00) && (pDeviceInfo->bytes[1] < 0x90) && (pDeviceInfo->bytes[0] == 0x06))

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -332,7 +332,7 @@ uint16_t _crc_xmodem_update (uint16_t crc, uint8_t data) {
 #define ATMEL_DEVICE_MATCH ((pDeviceInfo->words[0] == 0x9307) || (pDeviceInfo->words[0] == 0x930A) || \
         (pDeviceInfo->words[0] == 0x930F) || (pDeviceInfo->words[0] == 0x940B))
 
-#define SILABS_DEVICE_MATCH (pDeviceInfo->words[0] > 0xE800) // && (pDeviceInfo->words[0] < 0xF900))
+#define SILABS_DEVICE_MATCH ((pDeviceInfo->words[0] > 0xE800) && (pDeviceInfo->words[0] < 0xF900))
 
 
 // BLHeli_32 MCU ID hi > 0x00 and < 0x90 / lo always = 0x06


### PR DESCRIPTION
widening range of BLHeli/_S device id filtering to ease integration of upcoming MCU types to ease integration of upcoming MCU types.
Should be integrated into BF 4.3 release, otherwise ESCs with new Sil BLHeli_S MCUs will not be detected.