### PR TITLE
Prevent false failsafe / rx loss on eeprom write for all RX protocols

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -717,7 +717,7 @@ void validateAndFixGyroConfig(void)
 
 bool readEEPROM(void)
 {
-    suspendRxPwmPpmSignal();
+    suspendRxSignal();
 
     // Sanity check, read flash
     bool success = loadEEPROM();
@@ -728,7 +728,7 @@ bool readEEPROM(void)
 
     activateConfig();
 
-    resumeRxPwmPpmSignal();
+    resumeRxSignal();
 
     return success;
 }
@@ -737,11 +737,11 @@ void writeUnmodifiedConfigToEEPROM(void)
 {
     validateAndFixConfig();
 
-    suspendRxPwmPpmSignal();
+    suspendRxSignal();
 
     writeConfigToEEPROM();
 
-    resumeRxPwmPpmSignal();
+    resumeRxSignal();
     configIsDirty = false;
 }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -374,26 +374,26 @@ bool rxAreFlightChannelsValid(void)
     return rxFlightChannelsValid;
 }
 
-void suspendRxPwmPpmSignal(void)
+void suspendRxSignal(void)
 {
 #if defined(USE_PWM) || defined(USE_PPM)
     if (rxRuntimeState.rxProvider == RX_PROVIDER_PARALLEL_PWM || rxRuntimeState.rxProvider == RX_PROVIDER_PPM) {
         suspendRxSignalUntil = micros() + DELAY_1500_MS;  // 1.5s
         skipRxSamples = SKIP_RC_SAMPLES_ON_RESUME;
-        failsafeOnRxSuspend(DELAY_1500_MS);  // 1.5s
     }
 #endif
+    failsafeOnRxSuspend(DELAY_1500_MS);  // 1.5s
 }
 
-void resumeRxPwmPpmSignal(void)
+void resumeRxSignal(void)
 {
 #if defined(USE_PWM) || defined(USE_PPM)
     if (rxRuntimeState.rxProvider == RX_PROVIDER_PARALLEL_PWM || rxRuntimeState.rxProvider == RX_PROVIDER_PPM) {
         suspendRxSignalUntil = micros();
         skipRxSamples = SKIP_RC_SAMPLES_ON_RESUME;
-        failsafeOnRxResume();
     }
 #endif
+    failsafeOnRxResume();
 }
 
 #ifdef USE_RX_LINK_QUALITY_INFO

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -214,8 +214,8 @@ uint16_t rxGetUplinkTxPwrMw(void);
 
 void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRangeConfig);
 
-void suspendRxPwmPpmSignal(void);
-void resumeRxPwmPpmSignal(void);
+void suspendRxSignal(void);
+void resumeRxSignal(void);
 
 uint16_t rxGetRefreshRate(void);
 


### PR DESCRIPTION
Currently a write to flash can trigger the failsafe code for non pwm/ppm protocols. 
This PR sets the failsafe valid data received timestamp and link state in order to prevent triggering failsafe during and right after a eeprom write. This change only has an effect in the special case of a write to flash

Binaries for testing:
[betaflight_4.3.0_STM32F7X2_norevision.zip](https://github.com/betaflight/betaflight/files/8489681/betaflight_4.3.0_STM32F7X2_norevision.zip)
[betaflight_4.3.0_STM32F405_norevision.zip](https://github.com/betaflight/betaflight/files/8489682/betaflight_4.3.0_STM32F405_norevision.zip)
[betaflight_4.3.0_STM32F411_norevision.zip](https://github.com/betaflight/betaflight/files/8489683/betaflight_4.3.0_STM32F411_norevision.zip)
[betaflight_4.3.0_STM32F745_norevision.zip](https://github.com/betaflight/betaflight/files/8489684/betaflight_4.3.0_STM32F745_norevision.zip)
[betaflight_4.3.0_STM32G47X_norevision.zip](https://github.com/betaflight/betaflight/files/8489685/betaflight_4.3.0_STM32G47X_norevision.zip)
[betaflight_4.3.0_STM32H743_norevision.zip](https://github.com/betaflight/betaflight/files/8489686/betaflight_4.3.0_STM32H743_norevision.zip)

Fixes #11511 