### PR TITLE
Introduced failsafe_rxloss_delay - adjustable CLI parameter that cont…

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -877,6 +877,7 @@ const clivalue_t valueTable[] = {
     { "failsafe_procedure",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FAILSAFE }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_procedure) },
     { "failsafe_recovery_delay",    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_recovery_delay) },
     { "failsafe_stick_threshold",   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_stick_threshold) },
+    { "failsafe_rxloss_delay",      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 10 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_rxloss_delay) },
 
 // PG_BOARDALIGNMENT_CONFIG
     { "align_board_roll",           VAR_INT16  | MASTER_VALUE, .config.minmax = { -180, 360 }, PG_BOARD_ALIGNMENT, offsetof(boardAlignment_t, rollDegrees) },

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -70,7 +70,8 @@ PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_switch_mode = FAILSAFE_SWITCH_MODE_STAGE1, // default failsafe switch action is identical to rc link loss
     .failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT,    // default full failsafe procedure is 0: auto-landing
     .failsafe_recovery_delay = 10,                       // 1 sec of valid rx data needed to allow recovering from failsafe procedure
-    .failsafe_stick_threshold = 30                       // 30 percent of stick deflection to exit GPS Rescue procedure
+    .failsafe_stick_threshold = 30,                      // 30 percent of stick deflection to exit GPS Rescue procedure
+    .failsafe_rxloss_delay = 1                           // 0.1sec of no RX signal before stage 1 is activated
 );
 
 const char * const failsafeProcedureNames[FAILSAFE_PROCEDURE_COUNT] = {

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -40,6 +40,7 @@ typedef struct failsafeConfig_s {
     uint8_t failsafe_procedure;             // selected full failsafe procedure is 0: auto-landing, 1: Drop it
     uint16_t failsafe_recovery_delay;       // Time (in 0.1sec) of valid rx data (min 200ms PERIOD_RXDATA_RECOVERY) to allow recovering from failsafe procedure
     uint8_t failsafe_stick_threshold;       // Stick deflection percentage to exit GPS Rescue procedure
+    uint8_t failsafe_rxloss_delay;          // The delay of no RX signal before stage 1 is activated
 } failsafeConfig_t;
 
 PG_DECLARE(failsafeConfig_t, failsafeConfig);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -150,6 +150,7 @@ typedef struct rxRuntimeState_s {
     uint16_t            *channelData;
     void                *frameData;
     timeUs_t            lastRcFrameTimeUs;
+    timeDelta_t         needRxSignalMaxDelayUs; // number of Us of lost RX signal before stage 1 failsafe is activated
 } rxRuntimeState_t;
 
 typedef enum {


### PR DESCRIPTION
Introduced failsafe_rxloss_delay - adjustable CLI parameter that controls when stage 1 failsafe (RXLOSS) should be activated after the last RX signal is received.

failsafe_rxloss_delay is in units of 0.1s. So
1 = 0.1s
10 = 1s
Min value: 1
Max value: 10