### PR TITLE
fix for GPS Return failure in RC4 and RC5

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -985,7 +985,7 @@ void processRxModes(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_GPS_RESCUE
-    if (ARMING_FLAG(ARMED) && IS_RC_MODE_ACTIVE(BOXGPSRESCUE)) {
+    if (ARMING_FLAG(ARMED) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
         if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -653,15 +653,17 @@ void detectAndApplySignalLossBehaviour(void)
         }
 
        if (ARMING_FLAG(ARMED) && failsafeIsActive()) {
-            //  apply failsafe values, until failsafe ends, or disarmed, unless in GPS Return
-            if ((channel < NON_AUX_CHANNEL_COUNT) && !FLIGHT_MODE(GPS_RESCUE_MODE)) {
-                if (channel == THROTTLE ) {
-                    sample = failsafeConfig()->failsafe_throttle;
-                } else {
-                    sample = rxConfig()->midrc;
+            //  apply failsafe values, until failsafe ends, or disarmed, unless in GPS Return (where stick values should remain)
+            if (channel < NON_AUX_CHANNEL_COUNT) {
+                if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
+                    if (channel == THROTTLE ) {
+                        sample = failsafeConfig()->failsafe_throttle;
+                    } else {
+                        sample = rxConfig()->midrc;
+                    }
                 }
             } else if (!failsafeAuxSwitch) {
-                //  aux channels as Set in Configurator, unless failsafe initiated by switch
+                // aux channels as Set in Configurator, unless failsafe initiated by switch
                 sample = getRxfailValue(channel);
             }
         } else {


### PR DESCRIPTION
RC5 had an unexpected failure of GPS Rescue because:
- the flightMode flag was being disabled by a change in core.c
- there was a logic error in rx.c

The logic error in rx.c also existed in RC4.

This PR should address both those problems in the simplest way possible.  #11530 is an alternate PR with more changes, but ultimately simpler coding.

It has been tested with a code emulation where the GPS return code was enabled despite there being no GPS.