### PR TITLE
alternative fix for GPS Return issue

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -984,16 +984,6 @@ void processRxModes(timeUs_t currentTimeUs)
         DISABLE_FLIGHT_MODE(HORIZON_MODE);
     }
 
-#ifdef USE_GPS_RESCUE
-    if (ARMING_FLAG(ARMED) && IS_RC_MODE_ACTIVE(BOXGPSRESCUE)) {
-        if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
-            ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
-        }
-    } else {
-        DISABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
-    }
-#endif
-
     if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) {
         LED1_ON;
         // increase frequency of attitude task to reduce drift when in angle or horizon mode

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -352,6 +352,7 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                         reprocessState = true;
                     }
                 } else {
+                    ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE); // if the link is bad, reaffirm GPS Rescue flight mode is active 
                     if (armed) {
                         beeperMode = BEEPER_RX_LOST_LANDING;
                     } else {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -653,12 +653,14 @@ void detectAndApplySignalLossBehaviour(void)
         }
 
        if (ARMING_FLAG(ARMED) && failsafeIsActive()) {
-            //  apply failsafe values, until failsafe ends, or disarmed, unless in GPS Return
-            if ((channel < NON_AUX_CHANNEL_COUNT) && !FLIGHT_MODE(GPS_RESCUE_MODE)) {
-                if (channel == THROTTLE ) {
-                    sample = failsafeConfig()->failsafe_throttle;
-                } else {
-                    sample = rxConfig()->midrc;
+            //  apply failsafe values, until failsafe ends, or disarmed, unless in GPS Return (where stick values should remain)
+            if (channel < NON_AUX_CHANNEL_COUNT) {
+                if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
+                    if (channel == THROTTLE ) {
+                        sample = failsafeConfig()->failsafe_throttle;
+                    } else {
+                        sample = rxConfig()->midrc;
+                    }
                 }
             } else if (!failsafeAuxSwitch) {
                 //  aux channels as Set in Configurator, unless failsafe initiated by switch


### PR DESCRIPTION
This PR has the same fix in rx.c as per #11350.

But it deals with the core.c issue by moving the responsibility for maintaining the status of the GPS Rescue Flight Mode into failsafe.c.

This simplifies the core.c code.

It also requires the pilot to move the sticks out > 30% to terminate a stick induced GPS Return, just like a real one.  I think this is useful to reinforce the necessity for moving the sticks to exit failsafe.

This PR is for discussion and could be left for RC6, with the other less complex change being perhaps more amenable as a fast track fix.