### PR TITLE
Not show RXLOSS until 300ms has elapsed

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -158,9 +158,6 @@ void failsafeOnRxResume(void)
 void failsafeOnValidDataReceived(void)
 // runs when packets are received for more than the signal validation period (100ms)
 {
-    unsetArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
-    // clear RXLOSS in OSD immediately we get a good packet, and un-set its arming block
-
     failsafeState.validRxDataReceivedAt = millis();
 
     if (failsafeState.validRxDataFailedAt == 0) {
@@ -184,9 +181,6 @@ void failsafeOnValidDataReceived(void)
 void failsafeOnValidDataFailed(void)
 // runs when packets are lost for more than the signal validation period (100ms)
 {
-    setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
-    //  set RXLOSS in OSD and block arming after 100ms of signal loss (is restored in rx.c immediately signal returns)
-
     failsafeState.validRxDataFailedAt = millis();
     if ((cmp32(failsafeState.validRxDataFailedAt, failsafeState.validRxDataReceivedAt) > (int32_t)failsafeState.rxDataFailurePeriod)) {
         // sets rxLinkState = DOWN to initiate stage 2 failsafe, if no validated signal for the stage 1 period
@@ -201,8 +195,6 @@ void failsafeCheckDataFailurePeriod(void)
     if (cmp32(millis(), failsafeState.validRxDataReceivedAt) > (int32_t)failsafeState.rxDataFailurePeriod) {
         // sets link DOWN after the stage 1 failsafe period, initiating stage 2
         failsafeState.rxLinkState = FAILSAFE_RXLINK_DOWN;
-        // Prevent arming with no RX link
-        setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
     }
 }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -682,6 +682,8 @@ void detectAndApplySignalLossBehaviour(void)
                     if (channel < NON_AUX_CHANNEL_COUNT) {
                         allAuxChannelsAreGood = false;
                         //  declare signal lost after 300ms of at least one bad flight channel
+                        setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
+                        //  set RXLOSS in OSD (cleared immediately signal returns, see below)
                     }
                     sample = getRxfailValue(channel);
                     //  set all channels to Stage 1 values
@@ -708,6 +710,9 @@ void detectAndApplySignalLossBehaviour(void)
     if (rxFlightChannelsValid && allAuxChannelsAreGood) {
         failsafeOnValidDataReceived();
         //  --> start the timer to exit stage 2 failsafe
+        unsetArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
+        // clear RXLOSS in OSD immediately, and un-set its arming block
+
     } else {
         failsafeOnValidDataFailed();
         //  -> start timer to enter stage2 failsafe

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -215,7 +215,7 @@ TEST(FlightFailsafeTest, TestFailsafeDetectsRxLossAndStartsLanding)
     EXPECT_FALSE(failsafeIsActive());
     EXPECT_EQ(FAILSAFE_IDLE, failsafePhase());
     EXPECT_EQ(0, CALL_COUNTER(COUNTER_MW_DISARM));
-    EXPECT_TRUE(isArmingDisabled());
+    EXPECT_FALSE(isArmingDisabled());
 
     sysTickUptime ++;                               // exceed the stage 1 period by one tick
     failsafeOnValidDataFailed();                    // confirm that we still have no valid data
@@ -350,7 +350,6 @@ TEST(FlightFailsafeTest, TestFailsafeDetectsRxLossAndJustDisarms)
     EXPECT_FALSE(failsafeIsActive());
     EXPECT_EQ(FAILSAFE_IDLE, failsafePhase());
     EXPECT_EQ(0, CALL_COUNTER(COUNTER_MW_DISARM));
-    EXPECT_TRUE(isArmingDisabled());
 
     sysTickUptime ++;                               // now we exceed stage 1
     failsafeOnValidDataFailed();                    // we still have no valid data
@@ -745,9 +744,6 @@ TEST(FlightFailsafeTest, TestFailsafeNotActivatedWhenDisarmedAndRXLossIsDetected
     EXPECT_FALSE(failsafeIsActive());
     EXPECT_EQ(FAILSAFE_IDLE, failsafePhase());
     EXPECT_EQ(0, CALL_COUNTER(COUNTER_MW_DISARM));
-
-    // the lock on the aux channels persists at fixed stage 1 values until recovery time
-    EXPECT_TRUE(isArmingDisabled());
 
     // allow signal received for the recovery time
     sysTickUptime += PERIOD_RXDATA_RECOVERY;


### PR DESCRIPTION
There has been a lot of discussion about the optimal period before we inform the pilot that the Rx link is in poor shape.  There would be a warning in some reasonable time before we actually have a hard failsafe, to give time for possible corrective strategies.  But we don't want that warning to flash all the time, after trivial signal loss periods.

In RC5 the RXLOSS time was set to 100ms after the last packet.  Long-range pilots felt this was too short.

This PR increases the RXLOSS display time to 300ms.  It will greatly reduce the 'false positives' and only appear when there truly is a long delay.

It is built over #11350, which has been merged.

300ms coincides with the time when the 'held' or 'last good' values will be replaced with your fixed Stage 1 values.  It marks the beginning of Stage 1.

I am hopeful that 300ms represents a suitable compromise.  If not, we will need to make the value adjustable in the CLI as proposed in #11529.  Being adjustable is good, but perhaps 300ms will be acceptable even to die-hard long-rangers :-)

With this, RXLOSS will not appear in the OSD when failsafe is tested by a switch until we enter Stage 2.

The unit tests can't validate an arming lock since they only get `failsafeOnValidDataFailed()` as an input.  They should, at some point, be revised to accept `rxSignalReceived()` as the relevant input to the failsafe code