### PR TITLE
Initialize tasks data earlier

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -261,6 +261,10 @@ void init(void)
 
     systemInit();
 
+    // Initialize task data as soon as possible. Has to be done before tasksInit(),
+    // and any init code that may try to modify task behaviour before tasksInit().
+    tasksInitData();
+
     // initialize IO (needed for all IO operations)
     IOInitGlobal();
 

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -438,12 +438,16 @@ task_t *getTask(unsigned taskId)
     return &tasks[taskId];
 }
 
-void tasksInit(void)
+// Has to be done before tasksInit() in order to initialize any task data which may be uninitialized at boot
+void tasksInitData(void)
 {
     for (int i = 0; i < TASK_COUNT; i++) {
         tasks[i].attribute = &task_attributes[i];
     }
+}
 
+void tasksInit(void)
+{
     schedulerInit();
 
     setTaskEnabled(TASK_MAIN, true);

--- a/src/main/fc/tasks.h
+++ b/src/main/fc/tasks.h
@@ -22,6 +22,7 @@
 
 #include "scheduler/scheduler.h"
 
+void tasksInitData(void);
 void tasksInit(void);
 task_t *getTask(unsigned taskId);
 


### PR DESCRIPTION
After https://github.com/betaflight/betaflight/pull/11198/commits/9bdf9c11e9cfc3c14c1efe3409c829f6a538b700 `tasks` is in .bss which is uninitialized and has to be manually initialized. The current behaviour is to initialize the `tasks` array in `tasksInit()` which runs at the end of `init()`. This fails when other init code tries to modify task behaviour before tasks are initialized and the scheduler starts running. For compass, rangefinder and IBUS there's the possibility for their tasks to be rescheduled at init.

This PR breaks out the initialization of uninitialized task data into it's own function that should be executed as soon as possible in init  to ensure that the data is initialized before any attempt to modify it is made. There are comments to explain this.
This is IMO the simplest, most robust solution at the moment.

The alternative would be to refactor the existing code or handle each case of task modifying behaviour before tasksInit separately. The issue is that this can lead to hard to find bugs in the future. The compiler doesn't throw any warnings about this.

Binaries for testing:
[betaflight_4.3.0_STM32F7X2_norevision.zip](https://github.com/betaflight/betaflight/files/8500061/betaflight_4.3.0_STM32F7X2_norevision.zip)
[betaflight_4.3.0_STM32F405_norevision.zip](https://github.com/betaflight/betaflight/files/8500062/betaflight_4.3.0_STM32F405_norevision.zip)
[betaflight_4.3.0_STM32F411_norevision.zip](https://github.com/betaflight/betaflight/files/8500063/betaflight_4.3.0_STM32F411_norevision.zip)
[betaflight_4.3.0_STM32F745_norevision.zip](https://github.com/betaflight/betaflight/files/8500064/betaflight_4.3.0_STM32F745_norevision.zip)
[betaflight_4.3.0_STM32G47X_norevision.zip](https://github.com/betaflight/betaflight/files/8500065/betaflight_4.3.0_STM32G47X_norevision.zip)
[betaflight_4.3.0_STM32H743_norevision.zip](https://github.com/betaflight/betaflight/files/8500066/betaflight_4.3.0_STM32H743_norevision.zip)


Fixes #11473
Probably also fixes rangefinder and compass issues that haven't been discovered or reported yet.
