### PR TITLE
Fix OSD visual beeper

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -47,6 +47,10 @@
 #include "io/gps.h"
 #endif
 
+#ifdef USE_OSD
+#include "osd/osd.h"
+#endif
+
 #include "pg/beeper.h"
 
 #include "scheduler/scheduler.h"
@@ -435,6 +439,14 @@ void beeperUpdate(timeUs_t currentTimeUs)
         }
     }
 
+#if defined(USE_OSD)
+    static bool beeperWasOn = false;
+    if (beeperIsOn && !beeperWasOn) {
+        osdSetVisualBeeperState(true);
+    }
+    beeperWasOn = beeperIsOn;
+#endif
+    
     beeperProcessCommand(currentTimeUs);
 }
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1205,8 +1205,6 @@ void osdUpdate(timeUs_t currentTimeUs)
         break;
 
     case OSD_STATE_CHECK:
-        showVisualBeeper = isBeeperOn();
-
         // don't touch buffers if DMA transaction is in progress
         if (displayIsTransferInProgress(osdDisplayPort)) {
             break;
@@ -1472,6 +1470,11 @@ bool osdElementVisible(uint16_t value)
 bool osdGetVisualBeeperState(void)
 {
     return showVisualBeeper;
+}
+
+void osdSetVisualBeeperState(bool state)
+{
+    showVisualBeeper = state;
 }
 
 statistic_t *osdGetStats(void)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -354,6 +354,7 @@ void osdWarnSetState(uint8_t warningIndex, bool enabled);
 bool osdWarnGetState(uint8_t warningIndex);
 bool osdElementVisible(uint16_t value);
 bool osdGetVisualBeeperState(void);
+void osdSetVisualBeeperState(bool state);
 statistic_t *osdGetStats(void);
 bool osdNeedsAccelerometer(void);
 int osdPrintFloat(char *buffer, char leadingSymbol, float value, char *formatString, unsigned decimalPlaces, bool round, char trailingSymbol);

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -331,6 +331,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     if (osdWarnGetState(OSD_WARNING_VISUAL_BEEPER) && osdGetVisualBeeperState()) {
         tfp_sprintf(warningText, "  * * * *");
         *displayAttr = DISPLAYPORT_ATTR_INFO;
+        osdSetVisualBeeperState(false);
         return;
     }
 


### PR DESCRIPTION
Fixes the visual beeper in OSD.

Because of the osd task running at a low rate, there's no guarantee that we'll be able to catch the case where the beeper is on. 
This PR fixes it by having the beeper task turn on the visual beeper for every new beep. 

Binaries for testing: 
[betaflight_4.3.0_STM32F7X2_norevision.zip](https://github.com/betaflight/betaflight/files/8505728/betaflight_4.3.0_STM32F7X2_norevision.zip)
[betaflight_4.3.0_STM32F405_norevision.zip](https://github.com/betaflight/betaflight/files/8505729/betaflight_4.3.0_STM32F405_norevision.zip)
[betaflight_4.3.0_STM32F411_norevision.zip](https://github.com/betaflight/betaflight/files/8505731/betaflight_4.3.0_STM32F411_norevision.zip)
[betaflight_4.3.0_STM32F745_norevision.zip](https://github.com/betaflight/betaflight/files/8505732/betaflight_4.3.0_STM32F745_norevision.zip)
[betaflight_4.3.0_STM32G47X_norevision.zip](https://github.com/betaflight/betaflight/files/8505733/betaflight_4.3.0_STM32G47X_norevision.zip)
[betaflight_4.3.0_STM32H743_norevision.zip](https://github.com/betaflight/betaflight/files/8505734/betaflight_4.3.0_STM32H743_norevision.zip)

Fixes #11438 

Thanks to @Martivip for reporting and helping with testing
