### PR TITLE
Automatically enter Level Mode in Stage1 for GPS Rescue and Landing

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -961,8 +961,12 @@ void processRxModes(timeUs_t currentTimeUs)
     }
 
     bool canUseHorizonMode = true;
-
-    if ((IS_RC_MODE_ACTIVE(BOXANGLE) || failsafeIsActive()) && (sensors(SENSOR_ACC))) {
+    const bool useLevelInStage1 = !rxAreFlightChannelsValid() && !failsafeIsActive() && (
+#ifdef USE_GPS_RESCUE
+    (failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE) || 
+#endif
+    (failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_AUTO_LANDING));
+    if ((IS_RC_MODE_ACTIVE(BOXANGLE) || failsafeIsActive() || useLevelInStage1) && (sensors(SENSOR_ACC))) {
         // bumpless transfer to Level mode
         canUseHorizonMode = false;
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -637,7 +637,6 @@ void detectAndApplySignalLossBehaviour(void)
 {
     const uint32_t currentTimeMs = millis();
     const bool failsafeAuxSwitch = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
-    bool allAuxChannelsAreGood = true; 
     // used to record if any non-aux channel is out of range for the timeout period, assume they are good
     rxFlightChannelsValid = rxSignalReceived && !failsafeAuxSwitch;
     //  set rxFlightChannelsValid false when a packet is bad or we use a failsafe switch
@@ -680,7 +679,7 @@ void detectAndApplySignalLossBehaviour(void)
                 } else {
                     //  then use STAGE 1 failsafe values
                     if (channel < NON_AUX_CHANNEL_COUNT) {
-                        allAuxChannelsAreGood = false;
+                        rxFlightChannelsValid = false;
                         //  declare signal lost after 300ms of at least one bad flight channel
                     }
                     sample = getRxfailValue(channel);
@@ -705,7 +704,7 @@ void detectAndApplySignalLossBehaviour(void)
         }
     }
 
-    if (rxFlightChannelsValid && allAuxChannelsAreGood) {
+    if (rxFlightChannelsValid) {
         failsafeOnValidDataReceived();
         //  --> start the timer to exit stage 2 failsafe
     } else {

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1109,4 +1109,5 @@ extern "C" {
     bool isMotorProtocolEnabled(void) { return true; }
     void pinioBoxTaskControl(void) {}
     void schedulerSetNextStateTime(timeDelta_t) {}
+    bool rxAreFlightChannelsValid(void) { return true; }
 }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -198,4 +198,5 @@ extern "C" {
     void sbufWriteU16(sbuf_t *, uint16_t) {}
     void sbufWriteU32(sbuf_t *, uint32_t) {}
     void schedulerSetNextStateTime(timeDelta_t) {}
+    bool rxAreFlightChannelsValid(void) { return true; }
 }


### PR DESCRIPTION
This PR automatically activates Angle/Level Mode when
- the user has selected Landing or GPS Rescue as the stage 2 failsafe mode, and
- the craft has lost signal for more than the 100-300ms initial hold period, and
- has entered Stage 1 failsafe, and
- the accelerometer is active

It does not change anything when Stage 2 is Drop mode.

I'm putting it up for discussion, because I think it is a useful improvement for users of Landing and GPS Rescue modes.

Background:

The Stage 1 failsafe period is the time where we are hoping the signal will return, prior to doing something definitive about it.  By default this is 1.5s.  

In current code, with defaults, Stage 1 will hold the most recent values for 300ms, then cut throttle to zero and centre the sticks before entering the definitive Stage 2 failsafe mode - Drop, Landing, or GPS Rescue - 1.2s later.

In testing, the quad will fall quite a long distance vertically downwards during that 1.2s.

This is perfectly OK with the default Drop mode. On signal loss, the quad will continue on its flightpath at the same throttle for 300ms, then motors go to zero and sticks are centred; if signal is restored before 1.5s elapses, there is a 'clunk', and you keep flying; if not, it disarms.  

This PR does not alter Drop behaviour in any way.

In Landing mode, the Stage 2 intent is to get the quad level (ie to enter Angle/Level mode), and descend gently under a suitably slow descent throttle value.  

In GPS Rescue mode, the Stage 2 intent is to get the quad level (in Angle/Level mode), climb, and fly home.

In both cases, a suitable Stage 1 throttle value MUST be configured by the user.  For Landing mode, Stage 1 throttle should be set to a value that causes a gentle descent rate; for GPS Rescue, it needs to be enough to make the quad gently climb.  If the user fails to set the Stage 1 throttle value to a good value, the quad will drop up to 10m during the Stage 1 period, potentially into water or some other object.  

However just configuring throttle isn't enough.  The quad needs to be in Level/Angle mode during Stage 1 for the configured throttle to work as intended.  If the quad is not level, the set throttle value will not achieve the desired outcome.  

Active levelling with an appropriate Stage 1 throttle value will result in a predictable outcome regardless of the initial attitude of the craft at signal loss time.  

For example, if a GPS Rescue setup lost signal while diving behind a tree, the craft would very quickly right itself, and apply the user's previously configured 'gentle lift' throttle.  This would start to abort the dive very early after signal loss.  If signal restored, the pilot would see a significant glitch in flight behaviour.  But if it did not restore, the GPS Rescue Stage 2 code would be far more likely to successfully pull out of the dive and climb before hitting the ground.

Likewise a long-range flight at low level over water cannot tolerate much of an altitude drop on signal loss.  If the quad was turning at the time of the signal loss, the configured Stage 1 throttle may be inadequate to hold altitude, and the craft may spear sideways into the water.  By levelling the quad and applying a Stage 1 throttle value that we know will not lose altitude when level, we won't end up in the water.  

For high altitude long-range, losing signal while flying fairly straight would show RXLOSS and the quad would level out, but otherwise nothing much would happen until it went into full failsafe and started to fly home.

I think that for users of GPS Rescue or Landing Mode, this will be a significant improvement.

The PR includes a minor logical simplification in rx.c also.