### PR TITLE
Reorder SPI_MOSI 1 and SPI_MISO 1 stream options

### DIFF
--- a/src/main/drivers/dma_reqmap.c
+++ b/src/main/drivers/dma_reqmap.c
@@ -377,8 +377,13 @@ static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
 static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
 #ifdef USE_SPI
     // Everything including F405 and F446
+#if defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx)
+    { DMA_PERIPH_SPI_MOSI,  SPIDEV_1,  { DMA(2, 5, 3), DMA(2, 3, 3) } },
+    { DMA_PERIPH_SPI_MISO,  SPIDEV_1,  { DMA(2, 2, 3), DMA(2, 0, 3) } },
+#else
     { DMA_PERIPH_SPI_MOSI,  SPIDEV_1,  { DMA(2, 3, 3), DMA(2, 5, 3) } },
     { DMA_PERIPH_SPI_MISO,  SPIDEV_1,  { DMA(2, 0, 3), DMA(2, 2, 3) } },
+#endif
     { DMA_PERIPH_SPI_MOSI,  SPIDEV_2,  { DMA(1, 4, 0) } },
     { DMA_PERIPH_SPI_MISO,  SPIDEV_2,  { DMA(1, 3, 0) } },
     { DMA_PERIPH_SPI_MOSI,  SPIDEV_3,  { DMA(1, 5, 0), DMA(1, 7, 0) } },


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11199

Just reviving the PR mentioned in https://github.com/betaflight/betaflight/pull/11012#issuecomment-1110179104

All credits go to @SteveCEvans 

Needs merging before https://github.com/betaflight/unified-targets/pull/586