### PR TITLE
CRSF use persistent object to retain baudrate

### DIFF
--- a/src/main/drivers/persistent.h
+++ b/src/main/drivers/persistent.h
@@ -37,6 +37,7 @@ typedef enum {
 #endif
     PERSISTENT_OBJECT_RTC_HIGH,           // high 32 bits of rtcTime_t
     PERSISTENT_OBJECT_RTC_LOW,            // low 32 bits of rtcTime_t
+    PERSISTENT_OBJECT_SERIALRX_BAUD,      // serial rx baudrate
     PERSISTENT_OBJECT_COUNT,
 #ifdef USE_SPRACING_PERSISTENT_RTC_WORKAROUND
     // On SPRACING H7 firmware use this alternate location for all reset reasons interpreted by this firmware

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -38,6 +38,7 @@
 
 #include "pg/rx.h"
 
+#include "drivers/persistent.h"
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"
 #include "drivers/system.h"
@@ -639,7 +640,7 @@ bool crsfRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     uint32_t crsfBaudrate = CRSF_BAUDRATE;
 
 #if defined(USE_CRSF_V3)
-    crsfBaudrate = (isMPUSoftReset() && rxConfig->crsf_use_negotiated_baud) ? getCrsfCachedBaudrate() : CRSF_BAUDRATE;
+    crsfBaudrate = rxConfig->crsf_use_negotiated_baud ? getCrsfCachedBaudrate() : CRSF_BAUDRATE;
 #endif
 
     serialPort = openSerialPort(portConfig->identifier,
@@ -667,6 +668,7 @@ bool crsfRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 void crsfRxUpdateBaudrate(uint32_t baudrate)
 {
     serialSetBaudRate(serialPort, baudrate);
+    persistentObjectWrite(PERSISTENT_OBJECT_SERIALRX_BAUD, baudrate);
 }
 
 bool crsfRxUseNegotiatedBaud(void)


### PR DESCRIPTION
Use persistent object to store negotiated CRSF baudrate in RTC backup register instead of .noinit that was used in https://github.com/betaflight/betaflight/pull/11500
As there is a limited number of rtc backup registers, I made a generic serial rx baud object.

Thanks @jflyper and @hydra for the suggestion