### PR TITLE
Fix ICM-20689 initialisation

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -67,6 +67,9 @@
 
 #define MPU_INQUIRY_MASK   0x7E
 
+// Allow 100ms before attempting to access SPI bus
+#define GYRO_SPI_STARTUP_MS 100
+
 // Need to see at least this many interrupts during initialisation to confirm EXTI connectivity
 #define GYRO_EXTI_DETECT_THRESHOLD 1000
 
@@ -383,6 +386,10 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const gyro
     IOHi(gyro->dev.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
 
     uint8_t sensor = MPU_NONE;
+
+    // Allow 100ms before attempting to access gyro's SPI bus
+    // Do this once here rather than in each detection routine to speed boot
+    while (millis() < GYRO_SPI_STARTUP_MS);
 
     // It is hard to use hardware to optimize the detection loop here,
     // as hardware type and detection function name doesn't match.

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -36,13 +36,51 @@
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
-
-
 // 10 MHz max SPI frequency
-#define ICM20689_MAX_SPI_CLK_HZ 10000000
+#define ICM20689_MAX_SPI_CLK_HZ 8000000
 
 // 10 MHz max SPI frequency for intialisation
 #define ICM20689_MAX_SPI_INIT_CLK_HZ 1000000
+
+// Register 0x37 - INT_PIN_CFG / Pin Bypass Enable Configuration
+#define ICM20689_INT_ANYRD_2CLEAR   0x10
+
+// Register 0x68 - SIGNAL_PATH_RESET / Pin Bypass Enable Configuration
+#define ICM20689_ACCEL_RST          0x02
+#define ICM20689_TEMP_RST           0x01
+
+// Register 0x6a - USER_CTRL / User Control
+#define ICM20689_I2C_IF_DIS         0x10
+
+// Register 0x6b - PWR_MGMT_1 / Power Management 1
+#define ICM20689_BIT_RESET          0x80
+
+/* Allow CLKSEL setting time to settle when PLL is selected
+ *
+ * Not specified in the ICM-20689 datasheet, but in the ICM-20690 datasheet,
+ *
+ * https://invensense.tdk.com/wp-content/uploads/2016/10/DS-000178-ICM-20690-v1.0.pdf
+ *
+ * says (section 10.11) that the clock selection takes ~20us to settle. Testing
+ * has shown that 60us is required, so double to allow a margin
+ */
+#define ICM20689_CLKSEL_SETTLE_US   120
+
+/* Not specified in the ICM-20689 datasheet, but in the MPU-6000 datasheet,
+ *
+ * https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf
+ *
+ * says (section 4.28) suggest a delay of 100ms after a reset
+ */
+#define ICM20689_RESET_DELAY_MS     100
+
+/* Not specified in the ICM-20689 datasheet, but in the MPU-6000 datasheet,
+ *
+ * https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf
+ *
+ * says (section 4.28) suggest a delay of 100ms after a path reset
+ */
+#define ICM20689_PATH_RESET_DELAY_MS 100
 
 static void icm20689SpiInit(const extDevice_t *dev)
 {
@@ -51,7 +89,6 @@ static void icm20689SpiInit(const extDevice_t *dev)
     if (hardwareInitialised) {
         return;
     }
-
 
     spiSetClkDivisor(dev, spiCalculateDivider(ICM20689_MAX_SPI_CLK_HZ));
 
@@ -64,13 +101,12 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev)
 
     spiSetClkDivisor(dev, spiCalculateDivider(ICM20689_MAX_SPI_INIT_CLK_HZ));
 
+    // Note that the following reset is being done repeatedly by each MPU6000
+    // compatible device being probed
+
     // reset the device configuration
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
-    delay(100);
-
-    // reset the device signal paths
-    spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
-    delay(100);
+    delay(ICM20689_RESET_DELAY_MS);
 
     uint8_t icmDetected;
 
@@ -91,10 +127,20 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev)
         break;
     default:
         icmDetected = MPU_NONE;
-        break;
+        return icmDetected;
     }
 
+    // We now know the device is recognised so it's safe to perform device
+    // specific register accesses
     spiSetClkDivisor(dev, spiCalculateDivider(ICM20689_MAX_SPI_CLK_HZ));
+
+    // Disable Primary I2C Interface
+    spiWriteReg(dev, MPU_RA_USER_CTRL, ICM20689_I2C_IF_DIS);
+
+    // Reset the device signal paths
+    spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, ICM20689_ACCEL_RST | ICM20689_TEMP_RST);
+
+    delay(ICM20689_PATH_RESET_DELAY_MS);
 
     return icmDetected;
 }
@@ -129,24 +175,17 @@ void icm20689GyroInit(gyroDev_t *gyro)
     // Device was already reset during detection so proceed with configuration
 
     spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
-    delay(15);
+    delayMicroseconds(ICM20689_CLKSEL_SETTLE_US);
     spiWriteReg(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
-    delay(15);
     spiWriteReg(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
-    delay(15);
     spiWriteReg(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
-    delay(15);
-    spiWriteReg(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
-    delay(100);
+    spiWriteReg(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
 
     // Data ready interrupt configuration
-//    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
-
-    delay(15);
+    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, ICM20689_INT_ANYRD_2CLEAR);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 
     spiSetClkDivisor(&gyro->dev, spiCalculateDivider(ICM20689_MAX_SPI_CLK_HZ));

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.h
@@ -22,8 +22,6 @@
 
 #include "drivers/bus.h"
 
-#define ICM20689_BIT_RESET                  (0x80)
-
 bool icm20689AccDetect(accDev_t *acc);
 bool icm20689GyroDetect(gyroDev_t *gyro);
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -138,10 +138,6 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev)
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(100);  // datasheet specifies a 100ms delay after reset
 
-    // reset the device signal paths
-    spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
-    delay(100);  // datasheet specifies a 100ms delay after signal path reset
-
 
     const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
     delayMicroseconds(1); // Ensure CS high time is met which is violated on H7 without this delay
@@ -168,9 +164,14 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev)
         case MPU6000_REV_D10:
             detectedSensor = MPU_60x0_SPI;
         }
+
+        spiSetClkDivisor(dev, spiCalculateDivider(MPU6000_MAX_SPI_CLK_HZ));
+
+        // reset the device signal paths
+        spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+        delay(100);  // datasheet specifies a 100ms delay after signal path reset
     }
 
-    spiSetClkDivisor(dev, spiCalculateDivider(MPU6000_MAX_SPI_CLK_HZ));
     return detectedSensor;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -47,7 +47,7 @@
 static void mpu6500SpiInit(const extDevice_t *dev)
 {
 
-    spiSetClkDivisor(dev, spiCalculateDivider(MPU6500_MAX_SPI_CLK_HZ));
+    spiSetClkDivisor(dev, spiCalculateDivider(MPU6500_MAX_SPI_INIT_CLK_HZ));
 }
 
 uint8_t mpu6500SpiDetect(const extDevice_t *dev)
@@ -82,7 +82,11 @@ uint8_t mpu6500SpiDetect(const extDevice_t *dev)
         break;
     default:
         mpuDetected = MPU_NONE;
+        return mpuDetected;
     }
+
+    spiSetClkDivisor(dev, spiCalculateDivider(MPU6500_MAX_SPI_CLK_HZ));
+
     return mpuDetected;
 }
 


### PR DESCRIPTION
There have been reports of the yaw axis becoming unresponsive on the [ICM-20689](https://3cfeqx1hf82y3xcoull08ihx-wpengine.netdna-ssl.com/wp-content/uploads/2021/03/DS-000143-ICM-20689-TYP-v1.1.pdf) gyro. Once this occurs the change is persistent across power cycles and reverting to old firmware versions has no effect. I have been able to restore the functionality of one such affected gyro by writing values to undocumented registers (as read from a good gyro), but this was very hit and miss and has failed to recover another gyro.

It is believed that this issue is being caused by an inadvertent write to a reserved register.

A support case is ongoing with TDK.

Meanwhile I have reviewed the startup code and this PR fixes the following issues:

1. SPI clock was set to a max of 10MHz. When I had a gyro go bad it was being clocked at 6.75MHz (derived from 108MHz overclocked F411) so this wasn't the cause of this issue, but nevertheless this PR drops the max clock speed to 8MHz as per the data sheet.
2. The detect routines for the supported gyros are called in turn and the MPU6500 driver was performing accesses with an SPI clock of 20MHz (`MPU6500_MAX_SPI_CLK_HZ`) which could have caused erroneous register accesses. This has been reduced to 1MHz (`MPU6500_MAX_SPI_INIT_CLK_HZ`).
3. Section 6.1 of the data sheet states that `I2C_IF_DIS` should be set immediately after reset to avoid the device switching to I2C mode which we were not doing. This is now done once the `WHO_AM_I` register has been read and validated.
4. The `mpu6000SpiDetect()` routine was writing to the `SIGNAL_PATH_RESET` register, setting bit 2 which is a reserved bit in the ICM-20689. This write is now only performed once the MPU6000's identity has been confirmed.
5. There were unnecessary delays between register writes which have now been reviewed, eliminated where possible, and adjusted where needed, with comments justifying the delay values.