### PR TITLE
Add CRCs to EEPROM PG records to enable check for dirty config

### DIFF
--- a/src/main/common/crc.c
+++ b/src/main/common/crc.c
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "common/crc.h"
+
 #include "platform.h"
 
 #include "streambuf.h"
@@ -112,5 +114,19 @@ void crc8_xor_sbuf_append(sbuf_t *dst, uint8_t *start)
         crc ^= *ptr;
     }
     sbufWriteU8(dst, crc);
+}
+
+// Fowler–Noll–Vo hash function; see https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function
+uint32_t fnv_update(uint32_t hash, const void *data, uint32_t length)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    const uint8_t *pend = p + length;
+
+    for (; p != pend; p++) {
+        hash *= FNV_PRIME;
+        hash ^= *p;
+    }
+
+    return hash;
 }
 

--- a/src/main/common/crc.h
+++ b/src/main/common/crc.h
@@ -38,3 +38,8 @@ void crc8_sbuf_append(struct sbuf_s *dst, uint8_t *start, uint8_t poly);
 
 uint8_t crc8_xor_update(uint8_t crc, const void *data, uint32_t length);
 void crc8_xor_sbuf_append(struct sbuf_s *dst, uint8_t *start);
+
+#define FNV_PRIME           16777619
+#define FNV_OFFSET_BASIS    2166136261
+
+uint32_t fnv_update(uint32_t hash, const void *data, uint32_t length);

--- a/src/main/pg/pg.c
+++ b/src/main/pg/pg.c
@@ -24,6 +24,7 @@
 
 #include "platform.h"
 
+#include "common/crc.h"
 #include "common/maths.h"
 
 #include "pg.h"
@@ -79,6 +80,8 @@ bool pgLoad(const pgRegistry_t* reg, const void *from, int size, int version)
     if (version == pgVersion(reg)) {
         const int take = MIN(size, pgSize(reg));
         memcpy(pgOffset(reg), from, take);
+
+        *reg->fnv_hash = fnv_update(FNV_OFFSET_BASIS, from, take);
 
         return true;
     }

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -106,7 +106,9 @@ blackbox_encoding_unittest_SRC :=  \
 
 cli_unittest_SRC := \
 		$(USER_DIR)/cli/cli.c \
+		$(USER_DIR)/common/crc.c \
 		$(USER_DIR)/common/printf.c \
+		$(USER_DIR)/common/streambuf.c \
 		$(USER_DIR)/config/feature.c \
 		$(USER_DIR)/pg/pg.c \
 		$(USER_DIR)/common/typeconversion.c
@@ -227,6 +229,8 @@ link_quality_unittest_DEFINES := \
 		USE_RX_LINK_QUALITY_INFO=
 
 pg_unittest_SRC := \
+		$(USER_DIR)/common/crc.c \
+		$(USER_DIR)/common/streambuf.c \
 		$(USER_DIR)/pg/pg.c
 
 
@@ -234,7 +238,9 @@ rc_controls_unittest_SRC := \
 		$(USER_DIR)/fc/rc_controls.c \
 		$(USER_DIR)/pg/pg.c \
 		$(USER_DIR)/common/bitarray.c \
+		$(USER_DIR)/common/crc.c \
 		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/streambuf.c \
 		$(USER_DIR)/fc/rc_adjustments.c \
 		$(USER_DIR)/fc/rc_modes.c
 
@@ -254,7 +260,9 @@ rx_ibus_unittest_SRC := \
 
 rx_ranges_unittest_SRC := \
 		$(USER_DIR)/common/bitarray.c \
+		$(USER_DIR)/common/crc.c \
 		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/streambuf.c \
 		$(USER_DIR)/fc/rc_modes.c \
 		$(USER_DIR)/rx/rx.c \
 		$(USER_DIR)/pg/pg.c \
@@ -287,7 +295,9 @@ sensor_gyro_unittest_SRC := \
 		$(USER_DIR)/sensors/gyro_init.c \
 		$(USER_DIR)/sensors/boardalignment.c \
 		$(USER_DIR)/common/filter.c \
+		$(USER_DIR)/common/crc.c \
 		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/streambuf.c \
 		$(USER_DIR)/common/sensor_alignment.c \
 		$(USER_DIR)/drivers/accgyro/accgyro_fake.c \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
@@ -378,8 +388,10 @@ rcdevice_unittest_SRC := \
 		$(USER_DIR)/pg/pg.c \
 
 pid_unittest_SRC :=  \
+		$(USER_DIR)/common/crc.c \
 		$(USER_DIR)/common/filter.c \
 		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/streambuf.c \
 		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
 		$(USER_DIR)/fc/controlrate_profile.c \
 		$(USER_DIR)/fc/runtime_config.c \


### PR DESCRIPTION
Following the feedback in https://github.com/betaflight/betaflight/pull/11573 this PR checksums each PG section when it's read from EEPROM (FLASH) and a check is made in `writeSettingsToEEPROM()` to only perform a write if the checksum of any PG section has changed.