### PR TITLE
Simplify SPI CLK speed setting during gyro detection

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -65,6 +65,9 @@
 #define MPU_ADDRESS             0x68
 #endif
 
+// 1 MHz max SPI frequency during device detection
+#define MPU_MAX_SPI_DETECT_CLK_HZ 1000000
+
 #define MPU_INQUIRY_MASK   0x7E
 
 // Allow 100ms before attempting to access SPI bus
@@ -390,6 +393,9 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const gyro
     // Allow 100ms before attempting to access gyro's SPI bus
     // Do this once here rather than in each detection routine to speed boot
     while (millis() < GYRO_SPI_STARTUP_MS);
+
+    // Set a slow SPI clock that all potential devices can handle during gyro detection
+    spiSetClkDivisor(&gyro->dev, spiCalculateDivider(MPU_MAX_SPI_DETECT_CLK_HZ));
 
     // It is hard to use hardware to optimize the detection loop here,
     // as hardware type and detection function name doesn't match.

--- a/src/main/drivers/accgyro/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6050.c
@@ -77,25 +77,27 @@ bool mpu6050AccDetect(accDev_t *acc)
 
 static void mpu6050GyroInit(gyroDev_t *gyro)
 {
+    extDevice_t *dev = &gyro->dev;
+
     mpuGyroInit(gyro);
 
-    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    busWriteRegister(dev, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    busWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    busWriteRegister(dev, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    busWriteRegister(dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    busWriteRegister(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro)); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    busWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    busWriteRegister(dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro)); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    busWriteRegister(dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    busWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    busWriteRegister(dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
 
-    busWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG,
+    busWriteRegister(dev, MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    busWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    busWriteRegister(dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6500.c
@@ -54,6 +54,8 @@ bool mpu6500AccDetect(accDev_t *acc)
 
 void mpu6500GyroInit(gyroDev_t *gyro)
 {
+    extDevice_t *dev = &gyro->dev;
+
     mpuGyroInit(gyro);
 
     int gyro_range = INV_FSR_2000DPS;
@@ -64,33 +66,33 @@ void mpu6500GyroInit(gyroDev_t *gyro)
         accel_range = ICM_HIGH_RANGE_FSR_16G;
     }
 
-    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    busWriteRegister(dev, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    busWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    busWriteRegister(dev, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
+    busWriteRegister(dev, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    busWriteRegister(dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    busWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, gyro_range << 3);
+    busWriteRegister(dev, MPU_RA_GYRO_CONFIG, gyro_range << 3);
     delay(15);
-    busWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, accel_range << 3);
+    busWriteRegister(dev, MPU_RA_ACCEL_CONFIG, accel_range << 3);
     delay(15);
-    busWriteRegister(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
+    busWriteRegister(dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
     delay(15);
-    busWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
+    busWriteRegister(dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    busWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    busWriteRegister(dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    busWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    busWriteRegister(dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    busWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    busWriteRegister(dev, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -108,11 +108,12 @@ uint8_t bmi160Detect(const extDevice_t *dev)
         return BMI_160_SPI;
     }
 
-    /* Toggle CS to activate SPI (see https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi160-ds000.pdf section 3.2.1) */
+    // Toggle CS to activate SPI (see https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi160-ds000.pdf section 3.2.1)
     spiWrite(dev, 0xFF);
+
     delay(100); // Give SPI some time to start up
 
-    /* Check the chip ID */
+    // Check the chip ID
     if (spiReadRegMsk(dev, BMI160_REG_CHIPID) != 0xd1) {
         return MPU_NONE;
     }
@@ -169,7 +170,6 @@ static uint8_t getBmiOsrMode()
  */
 static int32_t BMI160_Config(const extDevice_t *dev)
 {
-
     // Set normal power mode for gyro and accelerometer
     spiWriteReg(dev, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_GYR_NORMAL);
     delay(100); // can take up to 80ms
@@ -445,6 +445,8 @@ void bmi160SpiGyroInit(gyroDev_t *gyro)
 #if defined(USE_GYRO_EXTI)
     bmi160IntExtiInit(gyro);
 #endif
+
+    spiSetClkDivisor(dev, spiCalculateDivider(BMI160_MAX_SPI_CLK_HZ));
 }
 
 void bmi160SpiAccInit(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -166,7 +166,6 @@ static void bmi270EnableSPI(const extDevice_t *dev)
 
 uint8_t bmi270Detect(const extDevice_t *dev)
 {
-    spiSetClkDivisor(dev, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
     bmi270EnableSPI(dev);
 
     if (bmi270RegisterRead(dev, BMI270_REG_CHIP_ID) == BMI270_CHIP_ID) {
@@ -530,11 +529,15 @@ static bool bmi270GyroRead(gyroDev_t *gyro)
 
 static void bmi270SpiGyroInit(gyroDev_t *gyro)
 {
+    extDevice_t *dev = &gyro->dev;
+
     bmi270Config(gyro);
 
 #if defined(USE_GYRO_EXTI)
     bmi270IntExtiInit(gyro);
 #endif
+
+    spiSetClkDivisor(dev, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
 }
 
 static void bmi270SpiAccInit(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -42,28 +42,8 @@
 // 8 MHz max SPI frequency
 #define ICM20649_MAX_SPI_CLK_HZ 8000000
 
-static void icm20649SpiInit(const extDevice_t *dev)
-{
-    static bool hardwareInitialised = false;
-
-    if (hardwareInitialised) {
-        return;
-    }
-
-    // all registers can be read/written at full speed (7MHz +-10%)
-    // TODO verify that this works at 9MHz and 10MHz on non F7
-    spiSetClkDivisor(dev, spiCalculateDivider(ICM20649_MAX_SPI_CLK_HZ));
-
-    hardwareInitialised = true;
-}
-
 uint8_t icm20649SpiDetect(const extDevice_t *dev)
 {
-
-    icm20649SpiInit(dev);
-
-    spiSetClkDivisor(dev, spiCalculateDivider(ICM20649_MAX_SPI_CLK_HZ));
-
     spiWriteReg(dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
 

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -81,7 +81,6 @@ typedef enum {
 uint8_t lsm6dsoDetect(const extDevice_t *dev)
 {
     uint8_t chipID = 0;
-    spiSetClkDivisor(dev, spiCalculateDivider(LSM6DSO_MAX_SPI_CLK_HZ));
 
     if (busReadRegisterBuffer(dev, LSM6DSO_REG_WHO_AM_I, &chipID, 1)) {
         if (chipID == LSM6DSO_CHIP_ID) {
@@ -166,11 +165,15 @@ static void lsm6dsoIntExtiInit(gyroDev_t *gyro)
 
 static void lsm6dsoSpiGyroInit(gyroDev_t *gyro)
 {
+    extDevice_t *dev = &gyro->dev;
+
     lsm6dsoConfig(gyro);
 
 #if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
     lsm6dsoIntExtiInit(gyro);
 #endif
+
+    spiSetClkDivisor(dev, spiCalculateDivider(LSM6DSO_MAX_SPI_CLK_HZ));
 }
 
 static void lsm6dsoSpiAccInit(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -47,8 +47,6 @@
 
 static void mpu6000AccAndGyroInit(gyroDev_t *gyro);
 
-// 1 MHz max SPI frequency for initialisation
-#define MPU6000_MAX_SPI_INIT_CLK_HZ 1000000
 // 20 MHz max SPI frequency
 #define MPU6000_MAX_SPI_CLK_HZ 20000000
 
@@ -109,8 +107,6 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
 
     mpu6000AccAndGyroInit(gyro);
 
-    spiSetClkDivisor(&gyro->dev, spiCalculateDivider(MPU6000_MAX_SPI_INIT_CLK_HZ));
-
     // Accel and Gyro DLPF Setting
     spiWriteReg(&gyro->dev, MPU6000_CONFIG, mpuGyroDLPF(gyro));
     delayMicroseconds(1);
@@ -131,13 +127,9 @@ void mpu6000SpiAccInit(accDev_t *acc)
 
 uint8_t mpu6000SpiDetect(const extDevice_t *dev)
 {
-
-    spiSetClkDivisor(dev, spiCalculateDivider(MPU6000_MAX_SPI_INIT_CLK_HZ));
-
     // reset the device configuration
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(100);  // datasheet specifies a 100ms delay after reset
-
 
     const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
     delayMicroseconds(1); // Ensure CS high time is met which is violated on H7 without this delay
@@ -165,8 +157,6 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev)
             detectedSensor = MPU_60x0_SPI;
         }
 
-        spiSetClkDivisor(dev, spiCalculateDivider(MPU6000_MAX_SPI_CLK_HZ));
-
         // reset the device signal paths
         spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
         delay(100);  // datasheet specifies a 100ms delay after signal path reset
@@ -177,8 +167,6 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev)
 
 static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
 {
-    spiSetClkDivisor(&gyro->dev, spiCalculateDivider(MPU6000_MAX_SPI_INIT_CLK_HZ));
-
     // Device was already reset during detection so proceed with configuration
 
     // Clock Source PPL with Z axis gyro reference
@@ -212,9 +200,6 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
-
-    spiSetClkDivisor(&gyro->dev, spiCalculateDivider(MPU6000_MAX_SPI_CLK_HZ));
-    delayMicroseconds(1);
 }
 
 bool mpu6000SpiAccDetect(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -37,8 +37,6 @@
 #include "accgyro_mpu6500.h"
 #include "accgyro_spi_mpu6500.h"
 
-// 1 MHz max SPI frequency for initialisation
-#define MPU6500_MAX_SPI_INIT_CLK_HZ 1000000
 // 20 MHz max SPI frequency
 #define MPU6500_MAX_SPI_CLK_HZ 20000000
 
@@ -46,8 +44,7 @@
 
 static void mpu6500SpiInit(const extDevice_t *dev)
 {
-
-    spiSetClkDivisor(dev, spiCalculateDivider(MPU6500_MAX_SPI_INIT_CLK_HZ));
+    UNUSED(dev);
 }
 
 uint8_t mpu6500SpiDetect(const extDevice_t *dev)
@@ -97,9 +94,6 @@ void mpu6500SpiAccInit(accDev_t *acc)
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro)
 {
-    spiSetClkDivisor(&gyro->dev, spiCalculateDivider(MPU6500_MAX_SPI_INIT_CLK_HZ));
-    delayMicroseconds(1);
-
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -44,9 +44,6 @@
 #include "drivers/time.h"
 #include "drivers/system.h"
 
-
-// 1 MHz max SPI frequency for initialisation
-#define MPU9250_MAX_SPI_INIT_CLK_HZ 1000000
 // 20 MHz max SPI frequency
 #define MPU9250_MAX_SPI_CLK_HZ 20000000
 
@@ -110,10 +107,8 @@ bool mpu9250SpiWriteRegisterVerify(const extDevice_t *dev, uint8_t reg, uint8_t 
     return false;
 }
 
-static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
-
-    spiSetClkDivisor(&gyro->dev, spiCalculateDivider(MPU9250_MAX_SPI_INIT_CLK_HZ)); //low speed for writing to slow registers
-
+static void mpu9250AccAndGyroInit(gyroDev_t *gyro)
+{
     mpu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
 
@@ -137,8 +132,6 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 
 uint8_t mpu9250SpiDetect(const extDevice_t *dev)
 {
-
-    spiSetClkDivisor(dev, spiCalculateDivider(MPU9250_MAX_SPI_INIT_CLK_HZ)); //low speed
     mpu9250SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
 
     uint8_t attemptsRemaining = 20;
@@ -152,8 +145,6 @@ uint8_t mpu9250SpiDetect(const extDevice_t *dev)
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-
-    spiSetClkDivisor(dev, spiCalculateDivider(MPU9250_MAX_SPI_CLK_HZ));
 
     return MPU_9250_SPI;
 }


### PR DESCRIPTION
Following https://github.com/betaflight/betaflight/pull/11584 which ensured that the SPI clock didn't exceed the max permissible for the ICM20689 whilst it was being detected, review of the gyro detection / initialisation code reveals an excessive number of calls to `spiSetClkDivisor()` where all that's needed is one call to set the SPI clock to a slow value prior to detection, and then another in each gyro's `xxxSpiGyroInit()` routine to set the clock to a suitable device specific value.

This PR applies the above, simplifying the code and saving ~180 bytes of FLASH.

This has been testing using the following FCs/targets

| Target | FC | Gyro |
| - | - | - |
| STM32G47X | AIRFLEETG4V11 | BMI270 |
| STM32H743 | MATEKH743 | ICM20602 |
| STM32H743 | MATEKH743 | MPU6000 |
| BETAFPVF4SX1280 | BETAFPVF4SX1280 | ICM20689 |
| STM32F7X2 | MATEKF722SE | ICM20602 |
| STM32F7X2 | MATEKF722SE | MPU6000 |
| STM32F405 | MATEKF405TE | ICM42605 |