### PR TITLE
Changes in "crash flip" OSD warning

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -440,7 +440,7 @@ void disarm(flightLogDisarmReason_e reason)
         lastDisarmTimeUs = micros();
 
 #ifdef USE_OSD
-        if (flipOverAfterCrashActive || isLaunchControlActive()) {
+        if (IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || isLaunchControlActive()) {
             osdSuppressStats(true);
         }
 #endif

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -63,6 +63,8 @@
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
 
+const char CRASH_FLIP_WARNING[] = "> CRASH FLIP <";
+
 void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 {
     const batteryState_e batteryState = getBatteryState();
@@ -132,10 +134,16 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     }
 
     // Warn when in flip over after crash mode
-    if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && isFlipOverAfterCrashActive()) {
-        tfp_sprintf(warningText, "CRASH FLIP");
-        *displayAttr = DISPLAYPORT_ATTR_INFO;
-        return;
+    if (osdWarnGetState(OSD_WARNING_CRASH_FLIP) && IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+        if (isFlipOverAfterCrashActive()) { // if was armed in crash flip mode
+            tfp_sprintf(warningText, CRASH_FLIP_WARNING);
+            *displayAttr = DISPLAYPORT_ATTR_INFO;
+            return;
+        } else if (!ARMING_FLAG(ARMED)) { // if disarmed, but crash flip mode is activated
+            tfp_sprintf(warningText, "CRASH FLIP SWITCH");
+            *displayAttr = DISPLAYPORT_ATTR_INFO;
+            return;
+        }
     }
 
 #ifdef USE_LAUNCH_CONTROL

--- a/src/main/osd/osd_warnings.h
+++ b/src/main/osd/osd_warnings.h
@@ -23,6 +23,8 @@
 #define OSD_WARNINGS_MAX_SIZE 12
 #define OSD_FORMAT_MESSAGE_BUFFER_SIZE (OSD_WARNINGS_MAX_SIZE + 1)
 
+extern const char CRASH_FLIP_WARNING[];
+
 STATIC_ASSERT(OSD_FORMAT_MESSAGE_BUFFER_SIZE <= OSD_ELEMENT_BUFFER_LENGTH, osd_warnings_size_exceeds_buffer_size);
 
 void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr);


### PR DESCRIPTION
Simple changes:
1. show `ARMED [new line] > CRASH FLIP <` when arming in crash flip
2. show "CRASH FLIP SWITCH" when disarmed, but in crash flip.
3. Hide the disarmed stats screen if "CRASH FLIP SWITCH" is activated.
4. When in armed crash flip mode, show `> CRASH FLIP <` instead of  `CRASH FLIP` to show it's armed.

When the race director announces "Arm your quads be ready in less than 5...", your heartbeat goes crazy..... You arm your quad and suddenly see "CRASH FLIP" because you accidentally left the "TURTLE MODE" switch in the wrong position. By this time it's almost late and really distracts from the race that is about to go live. The situation is even worse if a pilot turned off all the warnings (like many racers do)

The current "master" branch implementation shows "CRASH FLIP" warning only if the pilot arms in flip crash mode.
Especially for racing, it is essential for the pilot to see if he is in "flip over mode" before he arms as well.

This simple PR fixes this little sad issue:

It will show "CRASH FLIP SWITCH" when the drone is disarmed and the crash flip mode is activated. And it will show a regular "CRASH FLIP" when the drone is armed in crash flip mode.
When the drone is in the air and the pilot accidentally turns on "CRASH FLIP" it won't show a "CRASH FLIP" warning at all.

In addition, this PR shows "CRASH FLIP" on the arming screen: "ARMED"... "CRASH FLIP".
Some racers like to turn off the warnings, so this will be the only option they can use to see that they are arming in "turtle mode".
It also helps to understand what's happening during an intense race hits when you trying to get back in the air as fast as possible after a sad crash.

![image](https://user-images.githubusercontent.com/2925027/170631443-54165415-f8ec-4e1d-a534-370caf7d20a5.png)

