### PR TITLE
Added BMI270 drivers to CRAZYBEEF4SX1280 target

### DIFF
--- a/src/main/target/CRAZYBEEF4SX1280/target.h
+++ b/src/main/target/CRAZYBEEF4SX1280/target.h
@@ -56,6 +56,7 @@
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_ICM20689
+#define USE_ACCGYRO_BMI270
 
 // *************** OSD/FLASH *****************************
 #define USE_SPI_DEVICE_2

--- a/src/main/target/CRAZYBEEF4SX1280/target.mk
+++ b/src/main/target/CRAZYBEEF4SX1280/target.mk
@@ -4,6 +4,8 @@ FEATURES       += VCP ONBOARDFLASH
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
             drivers/accgyro/accgyro_spi_icm20689.c \
+            $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
+            drivers/accgyro/accgyro_spi_bmi270.c \
             drivers/max7456.c \
             drivers/vtx_rtc6705.c \
             drivers/vtx_rtc6705_soft_spi.c \


### PR DESCRIPTION
Small addition to CRAZYBEEF4SX1280 to include BMI270 gyro.

[betaflight_4.3.0_CRAZYBEEF4SX1280_95bbc8933.zip](https://github.com/betaflight/betaflight/files/8821520/betaflight_4.3.0_CRAZYBEEF4SX1280_95bbc8933.zip)
