### PR TITLE
failsafe by switch aux channel hold change

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -124,7 +124,7 @@ bool failsafeIsMonitoring(void)
     return failsafeState.monitoring;
 }
 
-bool failsafeIsActive(void)
+bool failsafeIsActive(void) // real or switch-induced stage 2 failsafe
 {
     return failsafeState.active;
 }


### PR DESCRIPTION
Change to Aux channel behaviour in Failsafe Stage 1.

@limonspb noted that, since RC3, any time Stage 2 failsafe is induced with a switch, all aux channels remain active.  This was done to ensure that switch induced failsafe could be terminated with the same Aux switch that started it.

However, a consequence of this is that all Aux switches operate normally during stick induced failsafe.  This prevented the user from using the SET option to control the state of the quad.

This PR ensures that all Aux channels that are SET to a certain value during failsafe will have that value applied during switch induced failsafe.   For example, if the user configures an Aux channel for Level Mode, and also SETS that Aux channel to be active during Failsafe (in the Configurator Failsafe Tab), the quad will always go into Level Mode, during either a true signal loss failsafe, or a stick induced failsafe.

Note that Aux channels that are configured to HOLD a value in failsafe, will pass received values to the FC. 

This improves US style Team Racing behaviour.