### PR TITLE
Remove double initialization

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -622,10 +622,6 @@ void init(void)
             emfat_init_files();
         }
 #endif
-        // There's no more initialisation to be done, so enable DMA where possible for SPI
-#ifdef USE_SPI
-        spiInitBusDMA();
-#endif
         if (mscStart() == 0) {
              mscWaitForButton();
         } else {


### PR DESCRIPTION
Sorry can't test right now but found `spiInitBusDMA()` being called twice.

Needs testing on all targets