### PR TITLE
Use gdwarf-5 debugging information.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ ifeq ($(DEBUG),GDB)
 OPTIMISE_DEFAULT      := -Og
 
 LTO_FLAGS             := $(OPTIMISE_DEFAULT)
-DEBUG_FLAGS            = -ggdb3 -DDEBUG
+DEBUG_FLAGS            = -ggdb3 -gdwarf-5 -DDEBUG
 else
 ifeq ($(DEBUG),INFO)
 DEBUG_FLAGS            = -ggdb3


### PR DESCRIPTION
Modern debuggers and IDE support this, I've been using this commit for a couple of years now in Eclipse, CLion and VSCode and with BlackMagicProbe, OpenOCD, J-Link and STLink debuggers.

