### PR TITLE
Use the new render attribute for diff/resource yaml form

### DIFF
--- a/.github/ISSUE_TEMPLATE/firmware-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/firmware-bug-report.yml
@@ -29,19 +29,32 @@ body:
     validations:
       required: true
 
+  - type: markdown
+    attributes:
+      value: |
+        # Flight controller configuration
+
   - type: textarea
     attributes:
-      label: Flight controller configuration
+      label: Diff configuration
       description: |
-        Create a `diff` and post it here in a code block. Put (three backticks) at the start and end of the diff block (instructions  on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/).
-        Use `resource show all` to create a resource allocation list and post it here in a code block. Put (three backticks) at the start and end of the output block.
-      value: |
-        ```
-          # REPLACE THIS LINE BY THE OUTPUT OF YOUR `diff`
-        ```
-        ```
-          # REPLACE THIS LINE BY THE OUTPUT OF YOUR `resource show all`
-        ```
+        Create a `diff` and post it here. Instructions on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/
+        Don't add three backticks or any other format symbol at the start or end of the block, they will be added automatically.
+      placeholder: |
+          # PASTE HERE THE OUTPUT OF `diff` COMMAND IN THE CLI TAB
+      render: txt
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Resources configuration
+      description: |
+        Use `resource show all` to create a resource allocation list and post it here.
+        Don't add three backticks or any other format symbol at the start or end of the block, they will be added automatically.
+      placeholder: |
+          # PASTE HERE THE OUTPUT OF `resource show all` COMMAND IN THE CLI TAB
+      render: txt
     validations:
       required: true
 


### PR DESCRIPTION
Users seem to have a problem adding the three backticks symbol in he form to format the diff or resource text block.

GitHub has added a new attribute, `render`, to add it automatically.

This change adds this new attribute and modifies the form, adding placeholder, etc. to simplify the use.

This is the final result:
![image](https://user-images.githubusercontent.com/2673520/173843506-cf195e06-6c23-4285-82cc-87523b2c74bc.png)

