### PR TITLE
Make sure to write dshot stop cmd to all other motors when targeting …

### DIFF
--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -223,6 +223,8 @@ void dshotCommandWrite(uint8_t index, uint8_t motorCount, uint8_t command, dshot
                     motorDmaOutput_t *const motor = getMotorDmaOutput(i);
                     motor->protocolControl.requestTelemetry = true;
                     motorGetVTable().writeInt(i, command);
+                } else {
+                    motorGetVTable().writeInt(i, DSHOT_CMD_MOTOR_STOP);
                 }
             }
 


### PR DESCRIPTION
Fixes #11420 

When running `dshotprog 0 7` with dshot bitbang from the cli, the target motor will receive the correct command but all other motors will receive a dshot command of `0xFF`

```c
#ifdef USE_DSHOT_TELEMETRY
      timeUs_t timeoutUs = micros() + 1000;
      while (!motorGetVTable().updateStart() &&
             cmpTimeUs(timeoutUs, micros()) > 0);
#endif
      for (uint8_t i = 0; i < motorDeviceCount(); i++) {
          if ((i == index) || (index == ALL_MOTORS)) {
              motorDmaOutput_t *const motor = getMotorDmaOutput(i);
              motor->protocolControl.requestTelemetry = true;
              motorGetVTable().writeInt(i, command);
          }
      }

      motorGetVTable().updateComplete();
```

`updateStart()` calls `bbOutputDataClear` which sets middle phase to 0 - "no change" where Reset=0 and Set=0 this leaves the gpio pin unchanged unless a dshot packet is written to the output buffer. STOP command seems the safest and is actually what is used in similar code below for inline dshot commands.


Test firmware:
[betaflight_4.4.0_STM32H743.zip](https://github.com/betaflight/betaflight/files/8932984/betaflight_4.4.0_STM32H743.zip)
[betaflight_4.4.0_STM32G47X.zip](https://github.com/betaflight/betaflight/files/8932985/betaflight_4.4.0_STM32G47X.zip)
[betaflight_4.4.0_STM32F745.zip](https://github.com/betaflight/betaflight/files/8932986/betaflight_4.4.0_STM32F745.zip)
[betaflight_4.4.0_STM32F411SX1280.zip](https://github.com/betaflight/betaflight/files/8932987/betaflight_4.4.0_STM32F411SX1280.zip)
[betaflight_4.4.0_STM32F411.zip](https://github.com/betaflight/betaflight/files/8932988/betaflight_4.4.0_STM32F411.zip)
[betaflight_4.4.0_STM32F405.zip](https://github.com/betaflight/betaflight/files/8932989/betaflight_4.4.0_STM32F405.zip)
[betaflight_4.4.0_STM32F7X2.zip](https://github.com/betaflight/betaflight/files/8932990/betaflight_4.4.0_STM32F7X2.zip)

(Instructions on how to install the test firmware: https://youtu.be/I1uN9CN30gw)