### PR TITLE
Update ARM SDK to 11.2-2022

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -14,9 +14,9 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-9-2020-q2-update
+ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
-GCC_REQUIRED_VERSION ?= 9.3.1
+GCC_REQUIRED_VERSION ?= 11.2
 
 .PHONY: arm_sdk_version
 
@@ -26,19 +26,18 @@ arm_sdk_version:
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
-ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update
+# source: https://developer.arm.com/downloads/-/gnu-rm
 
-# source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifeq ($(OSFAMILY), linux)
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-x86_64-linux.tar.bz2
+  ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz
 endif
 
 ifeq ($(OSFAMILY), macosx)
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-mac.tar.bz2
+  ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-darwin-x86_64-arm-none-eabi.tar.xz
 endif
 
 ifeq ($(OSFAMILY), windows)
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip
+  ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-mingw-w64-i686-arm-none-eabi.zip
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
@@ -53,7 +52,7 @@ arm_sdk_install: arm_sdk_download $(SDK_INSTALL_MARKER)
 $(SDK_INSTALL_MARKER):
 ifneq ($(OSFAMILY), windows)
         # binary only release so just extract it
-	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) tar -C $(TOOLS_DIR) -xf "$(DL_DIR)/$(ARM_SDK_FILE)"
 else
 	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
 endif


### PR DESCRIPTION
**Merge**
- After https://github.com/betaflight/betaflight/pull/11032
- After https://github.com/betaflight/betaflight/pull/11713

For GCC 11.2 support we need to update ARM SDK. See also: https://github.com/betaflight/betaflight/pull/11032

Needs work on fixing the warnings as they are treated as errors. Rather fix then suppress. 

Unfortunate F411 build fails on flash size (size seems enough if we move some memory to FLASH from FLASH1)
```
/home/mark/dev/pr/update-arm-sdk/betaflight/tools/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.2.1/../../../../arm-none-eabi/bin/ld: region `FLASH1' overflowed by 18371 bytes
Memory region         Used Size  Region Size  %age Used
           FLASH:        9176 B        10 KB     89.61%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      509891 B       480 KB    103.74%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB
   SYSTEM_MEMORY:          0 GB        29 KB      0.00%
             RAM:      112864 B       128 KB     86.11%
       MEMORY_B1:          0 GB         0 GB

```