### PR TITLE
update antigravity I boost debug to match #11679

### DIFF
--- a/src/main/target/ALIENWHOOP/config.c
+++ b/src/main/target/ALIENWHOOP/config.c
@@ -134,8 +134,7 @@ void targetConfiguration(void)
         pidProfile->feedforward_transition = 0;
 
     /* Anti-Gravity */
-    pidProfile->itermThrottleThreshold = 500;
-    pidProfile->itermAcceleratorGain = 5000;
+    pidProfile->itermAcceleratorGain = 80;
 
     pidProfile->levelAngleLimit = 65;
     }


### PR DESCRIPTION
Sets the AntiGravity Debug 2 trace to show the effect of antiGravity as a multiple of the user's pitch iTerm gain factor.  

Use this PR ONLY to compare logs with PR #11679.  It will not be required if #11679 is merged.

Using a build from this PR allows direct value comparison of our current antiGravity behaviour with the update to antiGravity in https://github.com/betaflight/betaflight/pull/11679, which uses this method in its antiGravity debugs.

iTerm is an accumulator,  If the amount of iTerm accumulated from antiGravity in a given loop was to equal the normal accumulator amount, we effectively double the rate of change of iTerm.  This will now show in Debug 2 as two times multiplier (2000 in the log).

Note that if the user changes their pitch iTerm value, the absolute value shown in the log for the magnitude of the antiGravity effect on iTerm will change, even if the antiGravity value itself, and its effect, will not have changed.  However the logged value will accurately reflect the 'multiplier' effect of antiGravity over their current iTerm gain, much as Debug 3 shows the multiplier effect on P in the same way.

This PR logs the P Boost multiplier into Debug 3, so we see both iTerm and pTerm effects.