### PR TITLE
Ghost rssi fix

### DIFF
--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -248,7 +248,8 @@ static bool ghstProcessFrame(const rxRuntimeState_t *rxRuntimeState)
 
                     if (rssiSource == RSSI_SOURCE_RX_PROTOCOL) {
                         // rssi sent sign-inverted
-                        const uint16_t rssiPercentScaled = scaleRange(-rssiFrame->rssi, GHST_RSSI_DBM_MIN, 0, GHST_RSSI_DBM_MAX, RSSI_MAX_VALUE);
+                        uint16_t rssiPercentScaled = scaleRange(-rssiFrame->rssi, GHST_RSSI_DBM_MIN, GHST_RSSI_DBM_MAX, 0, RSSI_MAX_VALUE);
+                        rssiPercentScaled = MIN(rssiPercentScaled, RSSI_MAX_VALUE);
                         setRssi(rssiPercentScaled, RSSI_SOURCE_RX_PROTOCOL);
                     }
 


### PR DESCRIPTION
Change parameters order in `scaleRange` and add clipping.

Thanks @tonycake for letting me know. Please test it.


Should be in:
- BF4.4 - included in https://github.com/betaflight/betaflight/pull/10801
- Also in BF 4.3.1 as a bugfix.