### PR TITLE
Fixed wrong pointer assignment that could lead to unexpected behabiour

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1766,7 +1766,7 @@ static void osdDrawSingleElement(displayPort_t *osdDisplayPort, uint8_t item)
     element.elemPosX = elemPosX;
     element.elemPosY = elemPosY;
     element.type = OSD_TYPE(osdElementConfig()->item_pos[item]);
-    element.buff = (char *)&buff;
+    element.buff = buff;
     element.osdDisplayPort = osdDisplayPort;
     element.drawElement = true;
     element.attr = DISPLAYPORT_ATTR_NONE;
@@ -1794,7 +1794,7 @@ static void osdDrawSingleElementBackground(displayPort_t *osdDisplayPort, uint8_
     element.elemPosX = elemPosX;
     element.elemPosY = elemPosY;
     element.type = OSD_TYPE(osdElementConfig()->item_pos[item]);
-    element.buff = (char *)&buff;
+    element.buff = buff;
     element.osdDisplayPort = osdDisplayPort;
     element.drawElement = true;
 


### PR DESCRIPTION
I have found a couple of wrong pointer assignments that can cause unexpected behabiour in osd_elements module.