### PR TITLE
Only write to FLASH once 64 bytes are buffered

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -214,7 +214,7 @@ void blackboxDeviceFlush(void)
          * devices will progressively write in the background without Blackbox calling anything.
          */
     case BLACKBOX_DEVICE_FLASH:
-        flashfsFlushAsync();
+        flashfsFlushAsync(false);
         break;
 #endif // USE_FLASHFS
 
@@ -237,7 +237,7 @@ bool blackboxDeviceFlushForce(void)
 
 #ifdef USE_FLASHFS
     case BLACKBOX_DEVICE_FLASH:
-        return flashfsFlushAsync();
+        return flashfsFlushAsync(true);
 #endif // USE_FLASHFS
 
 #ifdef USE_SDCARD
@@ -735,7 +735,7 @@ blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes)
              * that the Blackbox header writing code doesn't have to guess about the best time to ask flashfs to
              * flush, and doesn't stall waiting for a flush that would otherwise not automatically be called.
              */
-            flashfsFlushAsync();
+            flashfsFlushAsync(true);
         }
         return BLACKBOX_RESERVE_TEMPORARY_FAILURE;
 #endif // USE_FLASHFS

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -44,7 +44,7 @@ void flashfsWrite(const uint8_t *data, unsigned int len, bool sync);
 
 int flashfsReadAbs(uint32_t offset, uint8_t *data, unsigned int len);
 
-bool flashfsFlushAsync(void);
+bool flashfsFlushAsync(bool force);
 void flashfsFlushSync(void);
 
 void flashfsClose(void);


### PR DESCRIPTION
Black box data to be written to FLASH is buffered in a 128 byte buffer, but is being written more often than necessary, typically 28 bytes at a time. This PR changes that to write no less than 64 bytes.

This reduces CPU load as fewer write operations are required.