### PR TITLE
Extend Board Name length

### DIFF
--- a/src/main/pg/board.h
+++ b/src/main/pg/board.h
@@ -23,7 +23,7 @@
 #include "pg/pg.h"
 
 #define MAX_MANUFACTURER_ID_LENGTH 4
-#define MAX_BOARD_NAME_LENGTH 20
+#define MAX_BOARD_NAME_LENGTH 24
 #define SIGNATURE_LENGTH 32
 
 // Warning: This configuration is meant to be applied when loading the initial


### PR DESCRIPTION
Fixes:
```
# version
# Betaflight / STM32F7X2 (S7X2) 4.3.0 Jun 14 2022 / 00:50:37 (229ac66) MSP API: 1.44
# config: manufacturer_id: HOWI, board_name: HOBBYWING_XROTORF7CO, version: c2b8c0d3, date: 2021-06-18T03:42:42Z
# board: manufacturer_id: HOWI, board_name: HOBBYWING_XROTORF7CON
```

`MAX_BOARD_NAME_LENGTH` was defined with `20`, this targets uses 22 characters. Extended to 24 for now.

So either we shorten the target name (HOBBYWING_XRTRF7CNV), or we extend the length. In the end `HOBBYWING` does not have to be part of the `board_name` as we have `manufacturer_id` but would require more work also on configurator.