### PR TITLE
Fix data overwriting in VCP_DataTx on F4

### DIFF
--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -44,7 +44,7 @@ __IO uint32_t bDeviceState = UNCONNECTED; /* USB device status */
 
 /* This is the buffer for data received from the MCU to APP (i.e. MCU TX, APP RX) */
 extern uint8_t APP_Rx_Buffer[];
-extern uint32_t APP_Rx_ptr_out;
+extern volatile uint32_t APP_Rx_ptr_out;
 /* Increment this buffer position or roll it back to
  start address when writing received data
  in the buffer APP_Rx_Buffer. */
@@ -190,12 +190,8 @@ uint32_t CDC_Send_FreeBytes(void)
 {
     /*
         return the bytes free in the circular buffer
-
-        functionally equivalent to:
-        (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE - APP_Rx_ptr_in + APP_Rx_ptr_in)
-        but without the impact of the condition check.
     */
-    return ((APP_Rx_ptr_out - APP_Rx_ptr_in) + (-((int)(APP_Rx_ptr_out <= APP_Rx_ptr_in)) & APP_RX_DATA_SIZE)) - 1;
+    return (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE + APP_Rx_ptr_out - APP_Rx_ptr_in);
 }
 
 /**
@@ -212,15 +208,13 @@ static uint16_t VCP_DataTx(const uint8_t* Buf, uint32_t Len)
         could just check for: USB_CDC_ZLP, but better to be safe
         and wait for any existing transmission to complete.
     */
-    while (USB_Tx_State != 0);
-
     for (uint32_t i = 0; i < Len; i++) {
-        APP_Rx_Buffer[APP_Rx_ptr_in] = Buf[i];
-        APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
-
-        while (CDC_Send_FreeBytes() == 0) {
+        while ((APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE == APP_Rx_ptr_out || APP_Rx_ptr_out == APP_RX_DATA_SIZE || USB_Tx_State != 0) {
             delay(1);
         }
+
+        APP_Rx_Buffer[APP_Rx_ptr_in] = Buf[i];
+        APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
     }
 
     return USBD_OK;


### PR DESCRIPTION
**Merge**
- Before https://github.com/betaflight/betaflight/pull/11680
- Backport to BF 4.3

CLI on F4 boards is broken - even more pronounced with GCC 11.2.1. Latest master works by a chance but commit ea5b108 is not working (just compile it with GCC 11.2.1, no code changes). It is probably caused by some optimizations (not 100% sure yet). I have tried to debug and found that it is stuck here:

<img width="833" alt="Snímek obrazovky 2022-07-02 v 0 17 25" src="https://user-images.githubusercontent.com/36531759/176995954-3eba07ce-e5e1-499d-9179-42bee3222761.png">

**Changes**
- `VCP_DataTx()` needs to properly implement waiting if circular buffer is full otherwise overwriting of `APP_Rx_Buffer` takes place. We need to wait before any write to  `APP_Rx_Buffer`.
- `CDC_Send_FreeBytes()` is not working as intended. It does not return number of free bytes - current implementation seems to be wrong and also commented one is wrong. `CDC_Send_FreeBytes()` makes no sense at all because `APP_Rx_ptr_in == APP_Rx_ptr_out` in both cases - if circular buffer is free or empty. No way to differentiate. Don't use this function. Should we remove it?
- `APP_Rx_ptr_out` must have `volatile` because it is changed out of the scope of `VCP_DataTx()` in interrupt.

**Testing CLI commands**
- `dump all`
- `tasks`
- `diff`
- Check for missing lines, inconsistent data etc