### PR TITLE
Added invite to the Betaflight Discord server to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ There's a dedicated Slack chat channel here:
 
 https://slack.betaflight.com/
 
+And a Discord server here:
+
+https://discord.gg/n4E6ak4u3c
+
 We also have a Facebook Group. Join us to get a place to talk about Betaflight, ask configuration questions, or just hang out with fellow pilots.
 
 https://www.facebook.com/groups/betaflightgroup/


### PR DESCRIPTION
Made the invite not expire and have an unlimited amount of uses, it shouldn't go unusable for a long time