### PR TITLE
Fix mcu types

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -289,8 +289,6 @@ static const char * const *sensorHardwareNames[] = {
 // Needs to be aligned with mcuTypeId_e
 static const char *mcuTypeNames[] = {
     "SIMULATOR",
-    "F103",
-    "F303",
     "F40X",
     "F411",
     "F446",


### PR DESCRIPTION
MCU types are shifted by 2 in status `command` because of removing F1 and F3.