### PR TITLE
Flashfs: Add support for asynchronous complete erase

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -61,6 +61,7 @@
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/beeper.h"
 #include "io/dashboard.h"
+#include "io/flashfs.h"
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/piniobox.h"
@@ -125,6 +126,10 @@ static void taskMain(timeUs_t currentTimeUs)
 
 #ifdef USE_SDCARD
     afatfs_poll();
+#endif
+
+#ifdef USE_FLASHFS
+    flashfsEraseAsync();
 #endif
 }
 

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -46,6 +46,7 @@ int flashfsReadAbs(uint32_t offset, uint8_t *data, unsigned int len);
 
 bool flashfsFlushAsync(bool force);
 void flashfsFlushSync(void);
+void flashfsEraseAsync(void);
 
 void flashfsClose(void);
 void flashfsInit(void);


### PR DESCRIPTION
Adds support for asynchronously erasing the flashfs when not the complete flash chip is used for the flashfs. This fixes the problem that the flight controller is hanging when the "Erase Flash" button in the configurator is clicked. With this change, LED1 will blink during the erase and the erase dialog closes as expected when the erasing is complete. 

Fixes #8345
