### PR TITLE
Fix debug mode D_LPF

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -910,11 +910,11 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         // This is done to avoid DTerm spikes that occur with dynamically
         // calculated deltaT whenever another task causes the PID
         // loop execution to be delayed.
-        previousRawGyroRateDterm[axis] = gyroRateDterm[axis];
 
         // Log the unfiltered D for ROLL and PITCH
         if (axis != FD_YAW) {
             const float delta = (previousRawGyroRateDterm[axis] - gyroRateDterm[axis]) * pidRuntime.pidFrequency / D_LPF_RAW_SCALE;
+            previousRawGyroRateDterm[axis] = gyroRateDterm[axis];
             DEBUG_SET(DEBUG_D_LPF, axis, lrintf(delta));
         }
 


### PR DESCRIPTION
On master `delta` was always zero, because `gyroRateDterm` and `previousRawGyroRateDterm` both were equal to `gyroADCf`. 

```
delta = (gyroADCf - gyroADCf) * ... = 0
```

In debug mode `D_LPF` **debug[0]** and **debug[1]** were always showing zero and were therefore unusable.