### PR TITLE
Make sure to write dshot stop cmd to all other motors when targeting …

### DIFF
--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -223,6 +223,8 @@ void dshotCommandWrite(uint8_t index, uint8_t motorCount, uint8_t command, dshot
                     motorDmaOutput_t *const motor = getMotorDmaOutput(i);
                     motor->protocolControl.requestTelemetry = true;
                     motorGetVTable().writeInt(i, command);
+                } else {
+                    motorGetVTable().writeInt(i, DSHOT_CMD_MOTOR_STOP);
                 }
             }
 


### PR DESCRIPTION
…less than max motor count

(cherry picked from commit 6a7d2c37889aa5663b1906d6466263d19e321744)
