### PR TITLE
Fix compilation error when USE_RX_MSP_OVERRIDE is defined without

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -154,6 +154,10 @@
 #undef USE_MSP_OVER_TELEMETRY
 #endif
 
+#if !defined(USE_RX_MSP) && defined(USE_RX_MSP_OVERRIDE)
+#undef USE_RX_MSP_OVERRIDE
+#endif
+
 /* If either VTX_CONTROL or VTX_COMMON is undefined then remove common code and device drivers */
 #if !defined(USE_VTX_COMMON) || !defined(USE_VTX_CONTROL)
 #undef USE_VTX_COMMON


### PR DESCRIPTION
USE_RX_MSP.

(cherry picked from commit 73ada57702207e3b608c77b1952a3011409c7aa8)
