### PR TITLE
Don't set sleepTime to ut_delay in BARO_STATE_PRESSURE_SAMPLE state

### DIFF
--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -456,12 +456,11 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             DEBUG_SET(DEBUG_BARO, 2, baroPressure);
             DEBUG_SET(DEBUG_BARO, 3, baroPressureSum);
 
-            sleepTime = baro.dev.ut_delay;
             break;
     }
 
     // Where we are using a state machine call schedulerIgnoreTaskExecRate() for all states bar one
-    if (sleepTime != baro.dev.ut_delay) {
+    if (state != BARO_STATE_PRESSURE_START) {
         schedulerIgnoreTaskExecRate();
     }
 


### PR DESCRIPTION
Barometer sensor driver was adding an unnecessary delay between the BARO_STATE_PRESSURE_SAMPLE and BARO_STATE_PRESSURE_START/BARO_STATE_TEMPERATURE_START states.