### PR TITLE
Revert b6e2790f as this broke FrSky SPI

### DIFF
--- a/lib/main/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
+++ b/lib/main/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
@@ -186,7 +186,7 @@ __ALIGN_BEGIN uint8_t CmdBuff[CDC_CMD_PACKET_SZE] __ALIGN_END ;
 
 volatile uint32_t APP_Rx_ptr_in  = 0;
 volatile uint32_t APP_Rx_ptr_out = 0;
-volatile uint32_t APP_Rx_length  = 0;
+uint32_t APP_Rx_length  = 0;
 
 uint8_t  USB_Tx_State = USB_CDC_IDLE;
 
@@ -641,7 +641,7 @@ uint8_t  usbd_cdc_DataIn (void *pdev, uint8_t epnum)
             DCD_EP_Tx(pdev, CDC_IN_EP, (uint8_t*)&APP_Rx_Buffer[APP_Rx_ptr_out], USB_Tx_length);
 
             // Advance the out pointer
-            APP_Rx_ptr_out = (APP_Rx_ptr_out + USB_Tx_length) % APP_RX_DATA_SIZE;;
+            APP_Rx_ptr_out = (APP_Rx_ptr_out + USB_Tx_length) % APP_RX_DATA_SIZE;
             APP_Rx_length -= USB_Tx_length;
 
             return USBD_OK;

--- a/lib/main/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
+++ b/lib/main/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
@@ -184,9 +184,9 @@ __ALIGN_BEGIN uint8_t APP_Rx_Buffer   [APP_RX_DATA_SIZE] __ALIGN_END ;
 #endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
 __ALIGN_BEGIN uint8_t CmdBuff[CDC_CMD_PACKET_SZE] __ALIGN_END ;
 
-uint32_t APP_Rx_ptr_in  = 0;
-uint32_t APP_Rx_ptr_out = 0;
-uint32_t APP_Rx_length  = 0;
+volatile uint32_t APP_Rx_ptr_in  = 0;
+volatile uint32_t APP_Rx_ptr_out = 0;
+volatile uint32_t APP_Rx_length  = 0;
 
 uint8_t  USB_Tx_State = USB_CDC_IDLE;
 
@@ -482,8 +482,8 @@ uint8_t  usbd_cdc_Init (void  *pdev,
 uint8_t  usbd_cdc_DeInit (void  *pdev, 
                                  uint8_t cfgidx)
 {
-	  (void)pdev;
-	  (void)cfgidx;
+      (void)pdev;
+      (void)cfgidx;
   /* Open EP IN */
   DCD_EP_Close(pdev,
               CDC_IN_EP);
@@ -594,7 +594,7 @@ uint8_t  usbd_cdc_Setup (void  *pdev,
   */
 uint8_t  usbd_cdc_EP0_RxReady (void  *pdev)
 { 
-	(void)pdev;
+    (void)pdev;
   if (cdcCmd != NO_CMD)
   {
     /* Process the data */
@@ -617,60 +617,45 @@ uint8_t  usbd_cdc_EP0_RxReady (void  *pdev)
   */
 uint8_t  usbd_cdc_DataIn (void *pdev, uint8_t epnum)
 {
-	(void)pdev;
-	(void)epnum;
-  uint16_t USB_Tx_ptr;
-  uint16_t USB_Tx_length;
-  
-  if (USB_Tx_State == USB_CDC_BUSY)
-  {
-    if (APP_Rx_length == 0) 
+    (void)pdev;
+    (void)epnum;
+    uint16_t USB_Tx_length;
+
+    if (USB_Tx_State == USB_CDC_BUSY)
     {
-      USB_Tx_State = USB_CDC_IDLE;
-    }
-    else 
-    {
-      if (APP_Rx_length > CDC_DATA_IN_PACKET_SIZE){
-        USB_Tx_ptr = APP_Rx_ptr_out;
-        USB_Tx_length = CDC_DATA_IN_PACKET_SIZE;
-        
-        APP_Rx_ptr_out += CDC_DATA_IN_PACKET_SIZE;
-        APP_Rx_length -= CDC_DATA_IN_PACKET_SIZE;    
-      }
-      else 
-      {
-        USB_Tx_ptr = APP_Rx_ptr_out;
-        USB_Tx_length = APP_Rx_length;
-        
-        APP_Rx_ptr_out += APP_Rx_length;
-        APP_Rx_length = 0;
-        if(USB_Tx_length == CDC_DATA_IN_PACKET_SIZE)
+        if (APP_Rx_length == 0)
         {
-          USB_Tx_State = USB_CDC_ZLP;
+            USB_Tx_State = USB_CDC_IDLE;
+        } else {
+            if (APP_Rx_length > CDC_DATA_IN_PACKET_SIZE) {
+                USB_Tx_length = CDC_DATA_IN_PACKET_SIZE;
+            } else {
+                USB_Tx_length = APP_Rx_length;
+
+                if (USB_Tx_length == CDC_DATA_IN_PACKET_SIZE) {
+                    USB_Tx_State = USB_CDC_ZLP;
+                }
+            }
+
+            /* Prepare the available data buffer to be sent on IN endpoint */
+            DCD_EP_Tx(pdev, CDC_IN_EP, (uint8_t*)&APP_Rx_Buffer[APP_Rx_ptr_out], USB_Tx_length);
+
+            // Advance the out pointer
+            APP_Rx_ptr_out = (APP_Rx_ptr_out + USB_Tx_length) % APP_RX_DATA_SIZE;;
+            APP_Rx_length -= USB_Tx_length;
+
+            return USBD_OK;
         }
-      }
-      
-      /* Prepare the available data buffer to be sent on IN endpoint */
-      DCD_EP_Tx (pdev,
-                 CDC_IN_EP,
-                 (uint8_t*)&APP_Rx_Buffer[USB_Tx_ptr],
-                 USB_Tx_length);
-      return USBD_OK;
     }
-  }  
-  
-  /* Avoid any asynchronous transfer during ZLP */
-  if (USB_Tx_State == USB_CDC_ZLP)
-  {
-    /*Send ZLP to indicate the end of the current transfer */
-    DCD_EP_Tx (pdev,
-               CDC_IN_EP,
-               NULL,
-               0);
-    
-    USB_Tx_State = USB_CDC_IDLE;
-  }
-  return USBD_OK;
+
+    /* Avoid any asynchronous transfer during ZLP */
+    if (USB_Tx_State == USB_CDC_ZLP) {
+        /*Send ZLP to indicate the end of the current transfer */
+        DCD_EP_Tx(pdev, CDC_IN_EP, NULL, 0);
+
+        USB_Tx_State = USB_CDC_IDLE;
+    }
+    return USBD_OK;
 }
 
 /**
@@ -731,67 +716,49 @@ uint8_t  usbd_cdc_SOF (void *pdev)
   */
 static void Handle_USBAsynchXfer (void *pdev)
 {
-  uint16_t USB_Tx_ptr;
-  uint16_t USB_Tx_length;
-  
-  if(USB_Tx_State == USB_CDC_IDLE)
-  {
-    if (APP_Rx_ptr_out == APP_RX_DATA_SIZE)
-    {
-      APP_Rx_ptr_out = 0;
-    }
-    
-    if(APP_Rx_ptr_out == APP_Rx_ptr_in) 
-    {
-      USB_Tx_State = USB_CDC_IDLE; 
-      return;
-    }
-    
-    if(APP_Rx_ptr_out > APP_Rx_ptr_in) /* rollback */
-    { 
-      APP_Rx_length = APP_RX_DATA_SIZE - APP_Rx_ptr_out;
-      
-    }
-    else 
-    {
-      APP_Rx_length = APP_Rx_ptr_in - APP_Rx_ptr_out;
-      
-    }
+    uint16_t USB_Tx_length;
+
+    if (USB_Tx_State == USB_CDC_IDLE) {
+        if (APP_Rx_ptr_out == APP_Rx_ptr_in) {
+            // Ring buffer is empty
+            return;
+        }
+
+        if (APP_Rx_ptr_out > APP_Rx_ptr_in) {
+            // Transfer bytes up to the end of the ring buffer
+            APP_Rx_length = APP_RX_DATA_SIZE - APP_Rx_ptr_out;
+        } else {
+            // Transfer all bytes in ring buffer
+            APP_Rx_length = APP_Rx_ptr_in - APP_Rx_ptr_out;
+        }
+
 #ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
-    APP_Rx_length &= ~0x03;
+        // Only transfer whole 32 bit words of data
+        APP_Rx_length &= ~0x03;
 #endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+
+        if (APP_Rx_length > CDC_DATA_IN_PACKET_SIZE) {
+            USB_Tx_length = CDC_DATA_IN_PACKET_SIZE;
+
+            USB_Tx_State = USB_CDC_BUSY;
+        } else {
+            USB_Tx_length = APP_Rx_length;
+
+            if (USB_Tx_length == CDC_DATA_IN_PACKET_SIZE) {
+                USB_Tx_State = USB_CDC_ZLP;
+            } else {
+                USB_Tx_State = USB_CDC_BUSY;
+            }
+        }
     
-    if (APP_Rx_length > CDC_DATA_IN_PACKET_SIZE)
-    {
-      USB_Tx_ptr = APP_Rx_ptr_out;
-      USB_Tx_length = CDC_DATA_IN_PACKET_SIZE;
-      
-      APP_Rx_ptr_out += CDC_DATA_IN_PACKET_SIZE;	
-      APP_Rx_length -= CDC_DATA_IN_PACKET_SIZE;
-      USB_Tx_State = USB_CDC_BUSY;
+        DCD_EP_Tx (pdev,
+                   CDC_IN_EP,
+                   (uint8_t*)&APP_Rx_Buffer[APP_Rx_ptr_out],
+                   USB_Tx_length);
+
+        APP_Rx_ptr_out = (APP_Rx_ptr_out + USB_Tx_length) % APP_RX_DATA_SIZE;
+        APP_Rx_length -= USB_Tx_length;
     }
-    else
-    {
-      USB_Tx_ptr = APP_Rx_ptr_out;
-      USB_Tx_length = APP_Rx_length;
-      
-      APP_Rx_ptr_out += APP_Rx_length;
-      APP_Rx_length = 0;
-      if(USB_Tx_length == CDC_DATA_IN_PACKET_SIZE)
-      {
-        USB_Tx_State = USB_CDC_ZLP;
-      }
-      else
-      {
-        USB_Tx_State = USB_CDC_BUSY;
-      }
-    }
-    
-    DCD_EP_Tx (pdev,
-               CDC_IN_EP,
-               (uint8_t*)&APP_Rx_Buffer[USB_Tx_ptr],
-               USB_Tx_length);
-  }  
 }
 
 /**
@@ -803,7 +770,7 @@ static void Handle_USBAsynchXfer (void *pdev)
   */
 static uint8_t  *USBD_cdc_GetCfgDesc (uint8_t speed, uint16_t *length)
 {
-	(void)speed;
+    (void)speed;
   *length = sizeof (usbd_cdc_CfgDesc);
   return usbd_cdc_CfgDesc;
 }

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -181,9 +181,10 @@ static serialPort_t *cliPort = NULL;
 #define CLI_IN_BUFFER_SIZE 256
 #define CLI_OUT_BUFFER_SIZE 64
 
+static bufWriter_t cliWriterDesc;
 static bufWriter_t *cliWriter = NULL;
 static bufWriter_t *cliErrorWriter = NULL;
-static uint8_t cliWriteBuffer[sizeof(bufWriter_t) + CLI_OUT_BUFFER_SIZE];
+static uint8_t cliWriteBuffer[CLI_OUT_BUFFER_SIZE];
 
 static char cliBuffer[CLI_IN_BUFFER_SIZE];
 static uint32_t bufferIndex = 0;
@@ -6863,8 +6864,8 @@ void cliEnter(serialPort_t *serialPort)
     cliMode = true;
     cliPort = serialPort;
     setPrintfSerialPort(cliPort);
-    cliWriter = bufWriterInit(cliWriteBuffer, sizeof(cliWriteBuffer), (bufWrite_t)serialWriteBufShim, serialPort);
-    cliErrorWriter = cliWriter;
+    bufWriterInit(&cliWriterDesc, cliWriteBuffer, sizeof(cliWriteBuffer), (bufWrite_t)serialWriteBufShim, serialPort);
+    cliErrorWriter = cliWriter = &cliWriterDesc;
 
 #ifndef MINIMAL_CLI
     cliPrintLine("\r\nEntering CLI Mode, type 'exit' to return, or 'help'");

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -183,7 +183,7 @@ static serialPort_t *cliPort = NULL;
 
 static bufWriter_t *cliWriter = NULL;
 static bufWriter_t *cliErrorWriter = NULL;
-static uint8_t cliWriteBuffer[sizeof(*cliWriter) + CLI_OUT_BUFFER_SIZE];
+static uint8_t cliWriteBuffer[sizeof(bufWriter_t) + CLI_OUT_BUFFER_SIZE];
 
 static char cliBuffer[CLI_IN_BUFFER_SIZE];
 static uint32_t bufferIndex = 0;

--- a/src/main/drivers/buf_writer.c
+++ b/src/main/drivers/buf_writer.c
@@ -24,15 +24,14 @@
 
 #include "buf_writer.h"
 
-bufWriter_t *bufWriterInit(uint8_t *b, int total_size, bufWrite_t writer, void *arg)
+void bufWriterInit(bufWriter_t *b, uint8_t *data, int size, bufWrite_t writer, void *arg)
 {
     bufWriter_t *buf = (bufWriter_t *)b;
     buf->writer = writer;
     buf->arg = arg;
     buf->at = 0;
-    buf->capacity = total_size - sizeof(*buf);
-
-    return buf;
+    buf->capacity = size;
+    buf->data = data;
 }
 
 void bufWriterAppend(bufWriter_t *b, uint8_t ch)

--- a/src/main/drivers/buf_writer.h
+++ b/src/main/drivers/buf_writer.h
@@ -26,16 +26,12 @@ typedef void (*bufWrite_t)(void *arg, void *data, int count);
 typedef struct bufWriter_s {
     bufWrite_t writer;
     void *arg;
+    uint8_t *data;
     uint8_t capacity;
     uint8_t at;
-    uint8_t data[];
 } bufWriter_t;
 
 // Initialise a block of memory as a buffered writer.
-//
-// b should be sizeof(bufWriter_t) + the number of bytes to buffer.
-// total_size should be the total size of b.
-//
-bufWriter_t *bufWriterInit(uint8_t *b, int total_size, bufWrite_t writer, void *p);
+void bufWriterInit(bufWriter_t *b, uint8_t *data, int size, bufWrite_t writer, void *p);
 void bufWriterAppend(bufWriter_t *b, uint8_t ch);
 void bufWriterFlush(bufWriter_t *b);

--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -409,17 +409,11 @@ uint32_t CDC_Receive_BytesAvailable(void)
 
 uint32_t CDC_Send_FreeBytes(void)
 {
-    /*
-        return the bytes free in the circular buffer
-
-        functionally equivalent to:
-        (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE - APP_Rx_ptr_in + APP_Rx_ptr_in)
-        but without the impact of the condition check.
-    */
+    // return the bytes free in the circular buffer
     uint32_t freeBytes;
 
     ATOMIC_BLOCK(NVIC_BUILD_PRIORITY(6, 0)) {
-        freeBytes = ((UserTxBufPtrOut - UserTxBufPtrIn) + (-((int)(UserTxBufPtrOut <= UserTxBufPtrIn)) & APP_TX_DATA_SIZE)) - 1;
+        freeBytes = APP_RX_DATA_SIZE - rxAvailable;
     }
 
     return freeBytes;

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -191,7 +191,7 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength)
 
 uint32_t CDC_Send_FreeBytes(void)
 {
-    return APP_RX_DATA_SIZE - CDC_Receive_BytesAvailable();;
+    return APP_RX_DATA_SIZE - CDC_Receive_BytesAvailable();
 }
 
 /**

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -44,7 +44,7 @@ __IO uint32_t bDeviceState = UNCONNECTED; /* USB device status */
 
 /* This is the buffer for data received from the MCU to APP (i.e. MCU TX, APP RX) */
 extern uint8_t APP_Rx_Buffer[];
-extern volatile uint32_t APP_Rx_ptr_out;
+extern uint32_t APP_Rx_ptr_out;
 /* Increment this buffer position or roll it back to
  start address when writing received data
  in the buffer APP_Rx_Buffer. */
@@ -190,8 +190,12 @@ uint32_t CDC_Send_FreeBytes(void)
 {
     /*
         return the bytes free in the circular buffer
+
+        functionally equivalent to:
+        (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE - APP_Rx_ptr_in + APP_Rx_ptr_in)
+        but without the impact of the condition check.
     */
-    return (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE + APP_Rx_ptr_out - APP_Rx_ptr_in);
+    return ((APP_Rx_ptr_out - APP_Rx_ptr_in) + (-((int)(APP_Rx_ptr_out <= APP_Rx_ptr_in)) & APP_RX_DATA_SIZE)) - 1;
 }
 
 /**
@@ -208,13 +212,15 @@ static uint16_t VCP_DataTx(const uint8_t* Buf, uint32_t Len)
         could just check for: USB_CDC_ZLP, but better to be safe
         and wait for any existing transmission to complete.
     */
-    for (uint32_t i = 0; i < Len; i++) {
-        while ((APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE == APP_Rx_ptr_out || APP_Rx_ptr_out == APP_RX_DATA_SIZE || USB_Tx_State != 0) {
-            delay(1);
-        }
+    while (USB_Tx_State != 0);
 
+    for (uint32_t i = 0; i < Len; i++) {
         APP_Rx_Buffer[APP_Rx_ptr_in] = Buf[i];
         APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
+
+        while (CDC_Send_FreeBytes() == 0) {
+            delay(1);
+        }
     }
 
     return USBD_OK;

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -25,8 +25,11 @@
 
 #include "platform.h"
 
+#include "build/atomic.h"
+
 #include "usbd_cdc_vcp.h"
 #include "stm32f4xx_conf.h"
+#include "drivers/nvic.h"
 #include "drivers/time.h"
 
 #ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
@@ -44,11 +47,11 @@ __IO uint32_t bDeviceState = UNCONNECTED; /* USB device status */
 
 /* This is the buffer for data received from the MCU to APP (i.e. MCU TX, APP RX) */
 extern uint8_t APP_Rx_Buffer[];
-extern uint32_t APP_Rx_ptr_out;
+extern volatile uint32_t APP_Rx_ptr_out;
 /* Increment this buffer position or roll it back to
  start address when writing received data
  in the buffer APP_Rx_Buffer. */
-extern uint32_t APP_Rx_ptr_in;
+extern volatile uint32_t APP_Rx_ptr_in;
 
 /*
     APP TX is the circular buffer for data that is transmitted from the APP (host)
@@ -188,14 +191,7 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength)
 
 uint32_t CDC_Send_FreeBytes(void)
 {
-    /*
-        return the bytes free in the circular buffer
-
-        functionally equivalent to:
-        (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE - APP_Rx_ptr_in + APP_Rx_ptr_in)
-        but without the impact of the condition check.
-    */
-    return ((APP_Rx_ptr_out - APP_Rx_ptr_in) + (-((int)(APP_Rx_ptr_out <= APP_Rx_ptr_in)) & APP_RX_DATA_SIZE)) - 1;
+    return APP_RX_DATA_SIZE - CDC_Receive_BytesAvailable();;
 }
 
 /**
@@ -215,12 +211,13 @@ static uint16_t VCP_DataTx(const uint8_t* Buf, uint32_t Len)
     while (USB_Tx_State != 0);
 
     for (uint32_t i = 0; i < Len; i++) {
-        APP_Rx_Buffer[APP_Rx_ptr_in] = Buf[i];
-        APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
-
-        while (CDC_Send_FreeBytes() == 0) {
+        // Stall if the ring buffer is full
+        while (((APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE) == APP_Rx_ptr_out) {
             delay(1);
         }
+
+        APP_Rx_Buffer[APP_Rx_ptr_in] = Buf[i];
+        APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
     }
 
     return USBD_OK;
@@ -237,7 +234,7 @@ uint32_t CDC_Receive_DATA(uint8_t* recvBuf, uint32_t len)
 {
     uint32_t count = 0;
 
-    while (APP_Tx_ptr_out != APP_Tx_ptr_in && count < len) {
+    while (APP_Tx_ptr_out != APP_Tx_ptr_in && (count < len)) {
         recvBuf[count] = APP_Tx_Buffer[APP_Tx_ptr_out];
         APP_Tx_ptr_out = (APP_Tx_ptr_out + 1) % APP_TX_DATA_SIZE;
         count++;
@@ -248,7 +245,7 @@ uint32_t CDC_Receive_DATA(uint8_t* recvBuf, uint32_t len)
 uint32_t CDC_Receive_BytesAvailable(void)
 {
     /* return the bytes available in the receive circular buffer */
-    return APP_Tx_ptr_out > APP_Tx_ptr_in ? APP_TX_DATA_SIZE - APP_Tx_ptr_out + APP_Tx_ptr_in : APP_Tx_ptr_in - APP_Tx_ptr_out;
+    return (APP_Tx_ptr_in + APP_TX_DATA_SIZE - APP_Tx_ptr_out) % APP_TX_DATA_SIZE;
 }
 
 /**

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -325,7 +325,7 @@ uint8_t serialRead(serialPort_t *){return 0;}
 
 void bufWriterAppend(bufWriter_t *, uint8_t ch){ printf("%c", ch); }
 void serialWriteBufShim(void *, const uint8_t *, int) {}
-bufWriter_t *bufWriterInit(uint8_t *, int, bufWrite_t, void *) {return NULL;}
+void bufWriterInit(bufWriter_t *, uint8_t *, int, bufWrite_t, void *) { }
 void setArmingDisabled(armingDisableFlags_e) {}
 
 void waitForSerialPortToFinishTransmitting(serialPort_t *) {}


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11710

A `git bisect` to establish where this issue was introduced, testing on a `BETAFPVF411RX` gives:

```
b6e2790f15cdc27235175b42926c9389ee3c05fe is the first bad commit
commit b6e2790f15cdc27235175b42926c9389ee3c05fe
Author: Štěpán Dalecký <daleckystepan@gmail.com>
Date:   Sat Jul 2 12:03:45 2022 +0200

    Fix CDC_Send_FreeBytes
```

The preceding commit, which works is:

```
commit 4339e4ffd6c61c87e17dbd515fe77f8079eaf073
Merge: d46b337 6e04a6b
Author: J Blackman <blckmn@users.noreply.github.com>
Date:   Tue Jul 5 12:46:35 2022 +1000

    Merge pull request #11716 from daleckystepan/fix-mcu-types
    
    Fix mcu types
```

Connected a logic analyser, and adding some debug to a `CRAZYBEEF4R` shows that with 4339e4ffd6c61c87e17dbd515fe77f8079eaf073 we have:
![image](https://user-images.githubusercontent.com/11480839/179840334-fbe0b531-1571-4f45-bca2-b80abe4ae36e.png)

With b6e2790f15cdc27235175b42926c9389ee3c05fe it can be seen that `CDC_Send_FreeBytes()` is not being called and there are periodic pauses in the SPI activity to the `CC2500` device every 1.73s.
![image](https://user-images.githubusercontent.com/11480839/179840692-73619a46-6d12-49cf-bbae-d93b567a6e9f.png)

This PR reverts the change introduced in b6e2790f15cdc27235175b42926c9389ee3c05fe and we get a stable RC link again.
![image](https://user-images.githubusercontent.com/11480839/179840993-53aa27f1-3139-4909-8f7a-8bbe8b2bbd29.png)
