### PR TITLE
Change UBLox update rate to 10Hz (up from 5Hz)

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -681,7 +681,8 @@ void gpsInitUblox(void)
                         }
                         break;
                     case 12:
-                        ubloxSetNavRate(0xC8, 1, 1); // set rate to 5Hz (measurement period: 200ms, navigation rate: 1 cycle)
+                        ubloxSetNavRate(0x64, 1, 1); // set rate to 10Hz (measurement period: 100ms, navigation rate: 1 cycle)
+//                        ubloxSetNavRate(0xC8, 1, 1); // set rate to 5Hz (measurement period: 200ms, navigation rate: 1 cycle)
                         break;
                     case 13:
                         ubloxSetSbas();


### PR DESCRIPTION
Simple change to see if we can get UBlox GPS update rates at 10Hz instead of 5Hz.

Thanks to RabbitAmbulance for finding the [UBlox data sheet](https://content.u-blox.com/sites/default/files/products/documents/u-blox6_ReceiverDescrProtSpec_%28GPS.G6-SW-10018%29_Public.pdf) and suggesting this change, and Zzyzx for testing.

Initial test results appear very positive.  Higher data rate provides much cleaner control signals.

Note that higher rates may cause GPS data instability.  Not all GPS units will be capable of 10Hz, but most modern UBlox units that can do 5Hz should be able to do 10Hz.

Please test with switch initiated failsafe only.

GPS data is logged and can be graphed in blackbox explorer when GPS is active.