### PR TITLE
Consistent Minimum satellite count, GPS Trust focusing more on Baro

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -63,6 +63,7 @@
 #include "flight/rpm_filter.h"
 #include "flight/servos.h"
 #include "flight/gps_rescue.h"
+#include "flight/position.h"
 
 #include "io/beeper.h"
 #include "io/gps.h"
@@ -1450,6 +1451,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_NOISE_LPF, "%d",          barometerConfig()->baro_noise_lpf);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_VARIO_LPF, "%d",          barometerConfig()->baro_vario_lpf);
 #endif
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALT_SOURCE, "%d",      positionConfig()->altSource);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALT_PREFER_BARO, "%d", positionConfig()->altPreferBaro);
 #ifdef USE_MAG
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MAG_HARDWARE, "%d",           compassConfig()->mag_hardware);
 #endif
@@ -1520,6 +1523,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_PROVIDER, "%d",               gpsConfig()->provider)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_SET_HOME_POINT_ONCE, "%d",    gpsConfig()->gps_set_home_point_once)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_USE_3D_SPEED, "%d",           gpsConfig()->gps_use_3d_speed)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_REQUIRED_SATS, "%d",          gpsConfig()->gpsRequiredSats)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_MINIMUM_SATS, "%d",           gpsConfig()->gpsMinimumSats)
 
 #ifdef USE_GPS_RESCUE
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ANGLE, "%d",           gpsRescueConfig()->angle)
@@ -1543,7 +1548,6 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_DESCEND_RATE, "%d",    gpsRescueConfig()->descendRate)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER, "%d",  gpsRescueConfig()->throttleHover)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_SANITY_CHECKS, "%d",   gpsRescueConfig()->sanityChecks)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_MIN_SATS, "%d",        gpsRescueConfig()->minSats)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_MIN_DTH, "%d",         gpsRescueConfig()->minRescueDth)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX, "%d", gpsRescueConfig()->allowArmingWithoutFix)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALT_MODE, "%d",        gpsRescueConfig()->altitudeMode)

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1011,6 +1011,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_GPS_UBLOX_MODE,             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_UBLOX_MODE }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_ublox_mode) },
     { PARAM_NAME_GPS_SET_HOME_POINT_ONCE,    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_set_home_point_once) },
     { PARAM_NAME_GPS_USE_3D_SPEED,           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_use_3d_speed) },
+    { PARAM_NAME_GPS_REQUIRED_SATS,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = {5, 50}, PG_GPS_CONFIG, offsetof(gpsConfig_t, gpsRequiredSats) },
+    { PARAM_NAME_GPS_MINIMUM_SATS,           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = {4, 50}, PG_GPS_CONFIG, offsetof(gpsConfig_t, gpsMinimumSats) },
 
 #ifdef USE_GPS_RESCUE
     // PG_GPS_RESCUE
@@ -1035,7 +1037,6 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_GPS_RESCUE_DESCEND_RATE,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 25, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descendRate) },
     { PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER,  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleHover) },
     { PARAM_NAME_GPS_RESCUE_SANITY_CHECKS,   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE_SANITY_CHECK }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, sanityChecks) },
-    { PARAM_NAME_GPS_RESCUE_MIN_SATS,        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minSats) },
     { PARAM_NAME_GPS_RESCUE_MIN_DTH,         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDth) },
     { PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, allowArmingWithoutFix) },
     { PARAM_NAME_GPS_RESCUE_ALT_MODE,        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE_ALT_MODE }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, altitudeMode) },
@@ -1666,8 +1667,7 @@ const clivalue_t valueTable[] = {
 
 // PG_POSITION
     { "position_alt_source",                    VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_POSITION_ALT_SOURCE }, PG_POSITION, offsetof(positionConfig_t, altSource) },
-    { "position_alt_gps_min_sats",              VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { 4, 50 }, PG_POSITION, offsetof(positionConfig_t, altNumSatsGpsUse) },
-    { "position_alt_baro_fallback_sats",        VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { 3, 49 }, PG_POSITION, offsetof(positionConfig_t, altNumSatsBaroFallback) },
+    { "position_alt_prefer_baro",               VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_POSITION, offsetof(positionConfig_t, altPreferBaro) },
 // PG_MODE_ACTIVATION_CONFIG
 #if defined(USE_CUSTOM_BOX_NAMES)
     { "box_user_1_name", VAR_UINT8 | HARDWARE_VALUE | MODE_STRING, .config.string = { 1, MAX_BOX_USER_NAME_LENGTH, STRING_FLAGS_NONE }, PG_MODE_ACTIVATION_CONFIG, offsetof(modeActivationConfig_t, box_user_1_name) },

--- a/src/main/cms/cms_menu_gps_rescue.c
+++ b/src/main/cms/cms_menu_gps_rescue.c
@@ -38,7 +38,7 @@
 #include "config/config.h"
 
 #include "flight/gps_rescue.h"
-
+#include "io/gps.h"
 
 static uint16_t gpsRescueConfig_angle; //degrees
 static uint16_t gpsRescueConfig_initialAltitudeM; //meters
@@ -47,7 +47,7 @@ static uint16_t gpsRescueConfig_rescueGroundspeed; // centimeters per second
 static uint16_t gpsRescueConfig_throttleMin;
 static uint16_t gpsRescueConfig_throttleMax;
 static uint16_t gpsRescueConfig_throttleHover;
-static uint8_t gpsRescueConfig_minSats;
+static uint8_t gpsConfig_gpsMinimumSats;
 static uint16_t gpsRescueConfig_minRescueDth; //meters
 static uint8_t gpsRescueConfig_allowArmingWithoutFix;
 static uint16_t gpsRescueConfig_throttleP, gpsRescueConfig_throttleI, gpsRescueConfig_throttleD;
@@ -133,7 +133,7 @@ static const void *cmsx_menuGpsRescueOnEnter(displayPort_t *pDisp)
     gpsRescueConfig_throttleMin = gpsRescueConfig()->throttleMin  ;
     gpsRescueConfig_throttleMax = gpsRescueConfig()->throttleMax;
     gpsRescueConfig_throttleHover = gpsRescueConfig()->throttleHover;
-    gpsRescueConfig_minSats = gpsRescueConfig()->minSats;
+    gpsConfig_gpsMinimumSats = gpsConfig()->gpsMinimumSats;
     gpsRescueConfig_minRescueDth = gpsRescueConfig()->minRescueDth;
     gpsRescueConfig_allowArmingWithoutFix = gpsRescueConfig()->allowArmingWithoutFix;
     gpsRescueConfig_targetLandingAltitudeM = gpsRescueConfig()->targetLandingAltitudeM;
@@ -156,7 +156,7 @@ static const void *cmsx_menuGpsRescueOnExit(displayPort_t *pDisp, const OSD_Entr
     gpsRescueConfigMutable()->throttleMin = gpsRescueConfig_throttleMin;
     gpsRescueConfigMutable()->throttleMax = gpsRescueConfig_throttleMax;
     gpsRescueConfigMutable()->throttleHover = gpsRescueConfig_throttleHover;
-    gpsRescueConfigMutable()->minSats = gpsRescueConfig_minSats;
+    gpsConfigMutable()->gpsMinimumSats = gpsConfig_gpsMinimumSats;
     gpsRescueConfigMutable()->minRescueDth = gpsRescueConfig_minRescueDth;
     gpsRescueConfigMutable()->allowArmingWithoutFix = gpsRescueConfig_allowArmingWithoutFix;
     gpsRescueConfigMutable()->targetLandingAltitudeM = gpsRescueConfig_targetLandingAltitudeM;
@@ -184,7 +184,7 @@ const OSD_Entry cmsx_menuGpsRescueEntries[] =
     { "ASCEND RATE",       OME_UINT16 | REBOOT_REQUIRED, NULL, &(OSD_UINT16_t){ &gpsRescueConfig_ascendRate, 50, 2500, 1 } },
     { "DESCEND RATE",      OME_UINT16 | REBOOT_REQUIRED, NULL, &(OSD_UINT16_t){ &gpsRescueConfig_descendRate, 25, 500, 1 } },
     { "ARM WITHOUT FIX",   OME_Bool | REBOOT_REQUIRED,  NULL, &gpsRescueConfig_allowArmingWithoutFix },
-    { "MIN SATELITES",     OME_UINT8 | REBOOT_REQUIRED, NULL, &(OSD_UINT8_t){ &gpsRescueConfig_minSats, 5, 50, 1 } },
+    { "MIN SATELITES",     OME_UINT8 | REBOOT_REQUIRED, NULL, &(OSD_UINT8_t){ &gpsConfig_gpsMinimumSats, 4, 50, 1 } },
     { "GPS RESCUE PID",    OME_Submenu, cmsMenuChange, &cms_menuGpsRescuePid},
 
     {"BACK", OME_Back, NULL, NULL},

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -209,11 +209,11 @@ static void validateAndFixRatesSettings(void)
     }
 }
 
-static void validateAndFixPositionConfig(void)
+static void validateAndFixMinSatsGpsConfig(void)
 {
-    if (positionConfig()->altNumSatsBaroFallback >= positionConfig()->altNumSatsGpsUse) {
-        positionConfigMutable()->altNumSatsGpsUse = POSITION_DEFAULT_ALT_NUM_SATS_GPS_USE;
-        positionConfigMutable()->altNumSatsBaroFallback = POSITION_DEFAULT_ALT_NUM_SATS_BARO_FALLBACK;
+    if (gpsConfig()->gpsMinimumSats >= gpsConfig()->gpsRequiredSats) {
+        gpsConfigMutable()->gpsRequiredSats = GPS_REQUIRED_SAT_COUNT;
+        gpsConfigMutable()->gpsMinimumSats = GPS_MINIMUM_SAT_COUNT;
     }
 }
 
@@ -603,7 +603,7 @@ static void validateAndFixConfig(void)
     targetValidateConfiguration();
 #endif
 
-    validateAndFixPositionConfig();
+    validateAndFixMinSatsGpsConfig();
 }
 
 void validateAndFixGyroConfig(void)

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -344,7 +344,8 @@ void updateArmingStatus(void)
 
 #ifdef USE_GPS_RESCUE
         if (gpsRescueIsConfigured()) {
-            if (gpsRescueConfig()->allowArmingWithoutFix || STATE(GPS_FIX) || ARMING_FLAG(WAS_EVER_ARMED) || IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
+            if (gpsRescueConfig()->allowArmingWithoutFix || (STATE(GPS_FIX) && (gpsSol.numSat >= gpsConfig()->gpsRequiredSats)) ||
+            ARMING_FLAG(WAS_EVER_ARMED) || IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH)) {
                 unsetArmingDisabled(ARMING_DISABLED_GPS);
             } else {
                 setArmingDisabled(ARMING_DISABLED_GPS);
@@ -560,10 +561,9 @@ void tryArm(void)
 
 #ifdef USE_GPS
         GPS_reset_home_position();
-
         //beep to indicate arming
         if (featureIsEnabled(FEATURE_GPS)) {
-            if (STATE(GPS_FIX) && gpsSol.numSat >= 5) {
+            if (STATE(GPS_FIX) && gpsSol.numSat >= gpsConfig()->gpsRequiredSats) {
                 beeper(BEEPER_ARMING_GPS_FIX);
             } else {
                 beeper(BEEPER_ARMING_GPS_NO_FIX);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -119,6 +119,8 @@
 #define PARAM_NAME_RPM_FILTER_MIN_HZ "rpm_filter_min_hz"
 #define PARAM_NAME_RPM_FILTER_FADE_RANGE_HZ "rpm_filter_fade_range_hz"
 #define PARAM_NAME_RPM_FILTER_LPF_HZ "rpm_filter_lpf_hz"
+#define PARAM_NAME_POSITION_ALT_SOURCE "position_alt_source"
+#define PARAM_NAME_POSITION_ALT_PREFER_BARO "position_alt_prefer_baro"
 
 #ifdef USE_GPS
 #define PARAM_NAME_GPS_PROVIDER "gps_provider"
@@ -130,6 +132,8 @@
 #define PARAM_NAME_GPS_UBLOX_MODE "gps_ublox_mode"
 #define PARAM_NAME_GPS_SET_HOME_POINT_ONCE "gps_set_home_point_once"
 #define PARAM_NAME_GPS_USE_3D_SPEED "gps_use_3d_speed"
+#define PARAM_NAME_GPS_REQUIRED_SATS "gps_required_sats"
+#define PARAM_NAME_GPS_MINIMUM_SATS "gps_minimum_sats"
 
 #ifdef USE_GPS_RESCUE
 #define PARAM_NAME_GPS_RESCUE_ANGLE "gps_rescue_angle"
@@ -152,7 +156,6 @@
 #define PARAM_NAME_GPS_RESCUE_DESCEND_RATE "gps_rescue_descend_rate"
 #define PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER "gps_rescue_throttle_hover"
 #define PARAM_NAME_GPS_RESCUE_SANITY_CHECKS "gps_rescue_sanity_checks"
-#define PARAM_NAME_GPS_RESCUE_MIN_SATS "gps_rescue_min_sats"
 #define PARAM_NAME_GPS_RESCUE_MIN_DTH "gps_rescue_min_dth"
 #define PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX "gps_rescue_allow_arming_without_fix"
 #define PARAM_NAME_GPS_RESCUE_ALT_MODE "gps_rescue_alt_mode"

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -32,7 +32,6 @@ typedef struct gpsRescue_s {
     uint16_t throttleMax;
     uint16_t throttleHover;
     uint8_t velP, velI, velD;
-    uint8_t minSats;
     uint16_t minRescueDth; //meters
     uint8_t sanityChecks;
     uint8_t allowArmingWithoutFix;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -488,7 +488,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     }
 #endif
 #if defined(USE_GPS)
-    if (!useMag && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 5 && gpsSol.groundSpeed >= GPS_COG_MIN_GROUNDSPEED) {
+    if (!useMag && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat > gpsConfig()->gpsMinimumSats && gpsSol.groundSpeed >= GPS_COG_MIN_GROUNDSPEED) {
         // Use GPS course over ground to correct attitude.values.yaw
         courseOverGround = DECIDEGREES_TO_RADIANS(gpsSol.groundCourse);
         useCOG = true;

--- a/src/main/flight/position.h
+++ b/src/main/flight/position.h
@@ -23,13 +23,9 @@
 #include "common/time.h"
 
 #define TASK_ALTITUDE_RATE_HZ 120
-#define POSITION_DEFAULT_ALT_NUM_SATS_GPS_USE 10
-#define POSITION_DEFAULT_ALT_NUM_SATS_BARO_FALLBACK 7
-
 typedef struct positionConfig_s {
     uint8_t altSource;
-    uint8_t altNumSatsGpsUse;
-    uint8_t altNumSatsBaroFallback;
+    uint8_t altPreferBaro;
 } positionConfig_t;
 
 PG_DECLARE(positionConfig_t, positionConfig);

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -358,8 +358,8 @@ void beeperWarningBeeps(uint8_t beepCount)
 static void beeperGpsStatus(void)
 {
     if (!(beeperConfig()->beeper_off_flags & BEEPER_GET_FLAG(BEEPER_GPS_STATUS))) {
-        // if GPS fix then beep out number of satellites
-        if (STATE(GPS_FIX) && gpsSol.numSat >= 5) {
+        // if GPS 3D fix and at least the minimum number available, then beep out number of satellites
+        if (STATE(GPS_FIX) && gpsSol.numSat > gpsConfig()->gpsMinimumSats) {
             uint8_t i = 0;
             do {
                 beep_multiBeeps[i++] = 5;

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -82,6 +82,8 @@ typedef enum {
     UBLOX_ACK_GOT_NACK
 } ubloxAckState_e;
 
+#define GPS_REQUIRED_SAT_COUNT 8
+#define GPS_MINIMUM_SAT_COUNT 4
 #define GPS_BAUDRATE_MAX GPS_BAUDRATE_9600
 
 typedef struct gpsConfig_s {
@@ -94,6 +96,8 @@ typedef struct gpsConfig_s {
     uint8_t gps_set_home_point_once;
     uint8_t gps_use_3d_speed;
     uint8_t sbas_integrity;
+    uint8_t gpsRequiredSats;
+    uint8_t gpsMinimumSats;
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1452,6 +1452,9 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         // Added in API version 1.43
         sbufWriteU8(dst, gpsConfig()->gps_set_home_point_once);
         sbufWriteU8(dst, gpsConfig()->gps_ublox_use_galileo);
+        // Added in API version 1.45
+        sbufWriteU8(dst, gpsConfig()->gpsRequiredSats);
+        sbufWriteU8(dst, gpsConfig()->gpsMinimumSats);
         break;
 
     case MSP_RAW_GPS:
@@ -1492,7 +1495,8 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, gpsRescueConfig()->throttleMax);
         sbufWriteU16(dst, gpsRescueConfig()->throttleHover);
         sbufWriteU8(dst,  gpsRescueConfig()->sanityChecks);
-        sbufWriteU8(dst,  gpsRescueConfig()->minSats);
+        sbufWriteU8(dst, 0); // not required in API 1.44, gpsRescueConfig()->minSats
+
         // Added in API version 1.43
         sbufWriteU16(dst, gpsRescueConfig()->ascendRate);
         sbufWriteU16(dst, gpsRescueConfig()->descendRate);
@@ -2690,6 +2694,12 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             gpsConfigMutable()->gps_set_home_point_once = sbufReadU8(src);
             gpsConfigMutable()->gps_ublox_use_galileo = sbufReadU8(src);
         }
+        if (sbufBytesRemaining(src) >= 2) {
+            // Added in API version 1.45
+            gpsConfigMutable()->gpsRequiredSats = sbufReadU8(src);
+            gpsConfigMutable()->gpsMinimumSats = sbufReadU8(src);
+        }
+
         break;
 
 #ifdef USE_GPS_RESCUE
@@ -2702,7 +2712,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         gpsRescueConfigMutable()->throttleMax = sbufReadU16(src);
         gpsRescueConfigMutable()->throttleHover = sbufReadU16(src);
         gpsRescueConfigMutable()->sanityChecks = sbufReadU8(src);
-        gpsRescueConfigMutable()->minSats = sbufReadU8(src);
+        sbufReadU8(src);  // not used since 1.43, was gps rescue minSats
         if (sbufBytesRemaining(src) >= 6) {
             // Added in API version 1.43
             gpsRescueConfigMutable()->ascendRate = sbufReadU16(src);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -315,9 +315,9 @@
 #define MSP_SET_SENSOR_ALIGNMENT 220    //in message          set the orientation of the acc,gyro,mag
 #define MSP_SET_LED_STRIP_MODECOLOR 221 //in  message         Set LED strip mode_color settings
 #define MSP_SET_MOTOR_CONFIG     222    //out message         Motor configuration (min/max throttle, etc)
-#define MSP_SET_GPS_CONFIG       223    //out message         GPS configuration
+#define MSP_SET_GPS_CONFIG       223    //out message         GPS configuration including from 1.44 minSats
 //DEPRECATED - #define MSP_SET_COMPASS_CONFIG   224    //out message         Compass configuration
-#define MSP_SET_GPS_RESCUE       225    //in message          GPS Rescues's angle, initialAltitude, descentDistance, rescueGroundSpeed, sanityChecks and minSats
+#define MSP_SET_GPS_RESCUE       225    //in message          GPS Rescues's angle, initialAltitude, descentDistance, rescueGroundSpeed and sanityChecks
 #define MSP_SET_GPS_RESCUE_PIDS  226    //in message          GPS Rescues's throttleP and velocity PIDS + yaw P
 #define MSP_SET_VTXTABLE_BAND    227    //in message          set vtxTable band/channel data (one band at a time)
 #define MSP_SET_VTXTABLE_POWERLEVEL 228 //in message          set vtxTable powerLevel data (one powerLevel at a time)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1905,9 +1905,9 @@ void osdUpdateAlarms(void)
     }
 
 #ifdef USE_GPS
-    if ((STATE(GPS_FIX) == 0) || (gpsSol.numSat < 5)
+    if ((STATE(GPS_FIX) == 0) || (gpsSol.numSat < gpsConfig()->gpsMinimumSats)
 #ifdef USE_GPS_RESCUE
-            || ((gpsSol.numSat < gpsRescueConfig()->minSats) && gpsRescueIsConfigured())
+            || ((gpsSol.numSat < gpsConfig()->gpsRequiredSats) && gpsRescueIsConfigured())
 #endif
             ) {
         SET_BLINK(OSD_GPS_SATS);

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -218,7 +218,7 @@ void hottPrepareGPSResponse(HOTT_GPS_MSG_t *hottGPSMessage)
         return;
     }
 
-    if (gpsSol.numSat >= 5) {
+    if (gpsSol.numSat >= gpsConfig()->gpsMinimumSats) {
         hottGPSMessage->gps_fix_char = GPS_FIX_CHAR_3D;
     } else {
         hottGPSMessage->gps_fix_char = GPS_FIX_CHAR_2D;

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -306,8 +306,9 @@ static bool setGPS(uint8_t sensorType, ibusTelemetry_s* value)
 
     uint16_t gpsFixType = 0;
     uint16_t sats = 0;
+    uint8_t minSats = gpsConfig()->gpsMinimumSats;
     if (sensors(SENSOR_GPS)) {
-        gpsFixType = !STATE(GPS_FIX) ? 1 : (gpsSol.numSat < 5 ? 2 : 3);
+        gpsFixType = !STATE(GPS_FIX) ? 1 : (gpsSol.numSat < minSats ? 2 : 3);
         sats = gpsSol.numSat;
         if (STATE(GPS_FIX) || sensorType == IBUS_SENSOR_TYPE_GPS_STATUS) {
             result = true;

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -137,7 +137,7 @@ static void ltm_gframe(void)
 
     if (!STATE(GPS_FIX))
         gps_fix_type = 1;
-    else if (gpsSol.numSat < 5)
+    else if (gpsSol.numSat < gpsConfig()->gpsMinimumSats)
         gps_fix_type = 2;
     else
         gps_fix_type = 3;

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -309,7 +309,7 @@ void mavlinkSendPosition(void)
         gpsFixType = 1;
     }
     else {
-        if (gpsSol.numSat < 5) {
+        if (gpsSol.numSat < gpsConfig()->gpsMinimumSats) {
             gpsFixType = 2;
         }
         else {

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -302,7 +302,7 @@ bool srxlFrameGpsLoc(sbuf_t *dst, timeUs_t currentTimeUs)
     uint16_t altitudeLoBcd, groundCourseBcd, hdop;
     uint8_t hdopBcd, gpsFlags;
 
-    if (!featureIsEnabled(FEATURE_GPS) || !STATE(GPS_FIX) || gpsSol.numSat < 6) {
+    if (!featureIsEnabled(FEATURE_GPS) || !STATE(GPS_FIX) || gpsSol.numSat < gpsConfig()->gpsMinimumSats) {
         return false;
     }
 
@@ -370,7 +370,7 @@ bool srxlFrameGpsStat(sbuf_t *dst, timeUs_t currentTimeUs)
     uint8_t numSatBcd, altitudeHighBcd;
     bool timeProvided = false;
 
-    if (!featureIsEnabled(FEATURE_GPS) || !STATE(GPS_FIX) || gpsSol.numSat < 6) {
+    if (!featureIsEnabled(FEATURE_GPS) || !STATE(GPS_FIX) || gpsSol.numSat < gpsConfig()->gpsMinimumSats) {
         return false;
     }
 

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -58,6 +58,7 @@ extern "C" {
     PG_REGISTER(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 0);
     PG_REGISTER(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 0);
     PG_REGISTER(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
+    PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 
     float rcCommand[4];
     float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -64,6 +64,7 @@ extern "C" {
 
     PG_REGISTER(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
     PG_REGISTER(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
+    PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 
     PG_RESET_TEMPLATE(featureConfig_t, featureConfig,
         .enabledFeatures = 0

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1190,6 +1190,8 @@ TEST_F(OsdTest, TestGpsElements)
 {
     // given
     osdElementConfigMutable()->item_pos[OSD_GPS_SATS] = OSD_POS(2, 4) | OSD_PROFILE_1_FLAG;
+    gpsConfigMutable()->gpsMinimumSats = GPS_MINIMUM_SAT_COUNT;
+    gpsConfigMutable()->gpsRequiredSats = GPS_REQUIRED_SAT_COUNT;
 
     sensorsSet(SENSOR_GPS);
     osdAnalyzeActiveElements();

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -51,6 +51,7 @@ extern "C" {
     #include "telemetry/hott.h"
 
     PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
+    PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 
     uint16_t testBatteryVoltage = 0;
     int32_t testAmperage = 0;

--- a/src/test/unit/telemetry_ibus_unittest.cc
+++ b/src/test/unit/telemetry_ibus_unittest.cc
@@ -22,6 +22,7 @@ extern "C" {
 #include "platform.h"
 #include "common/utils.h"
 #include "pg/pg.h"
+#include "pg/pg_ids.h"
 #include "drivers/serial.h"
 #include "io/serial.h"
 #include "io/gps.h"
@@ -36,6 +37,8 @@ extern "C" {
 #include "sensors/acceleration.h"
 #include "scheduler/scheduler.h"
 #include "fc/tasks.h"
+
+PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 }
 
 #include "unittest_macros.h"

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -61,6 +61,7 @@ extern "C" {
     PG_REGISTER(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 0);
     PG_REGISTER(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 0);
     PG_REGISTER(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
+    PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 
     float rcCommand[4];
     float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];


### PR DESCRIPTION
Properly tested, works great!  Rebased to master since #11775 has been merged; good to go.

- Fixes a bug where the pilot could have GPS Rescue configured, but arm without a home fix, which would cause the rescue to fail.  This is fixed by preventing arming unless `GPS_REQUIRED_SATS` exist at arm time.

- Simplifies the minimum and required satellite count configuration, and makes it consistent throughout the code.  `GPS_REQUIRED_SATS` is the minimum number of satellites required for a home lock etc.  `GPS_MINIMUM_SATS` is the value used for 'failure' situations eg rescue sanity checks.

- Fixes some bugs and refactors GPS Trust and the setting of GPS and Baro offsets to ensure a correct zero value on takeoff and to favour Baro more strongly.

- Progressively favours barometer altitude values over GPS altitude values, when they differ significantly (increasingly favours Baro when difference exceeds 1 meter), to better handle substantial drifts and errors in GPS altitude.  GPS drifts typically exceed those of Baro in nearly all cases.  

- The user can choose the amount of 'trust' they have in their Baro with the CLI parameter `position_alt_prefer_baro`.  The new 'favour Baro' default of 100 will favour Baro over GPS as above.  If set to zero, the 'traditional', favour GPS mode is used.  Baro typically provides very little to altitude in this mode.  A value of 50 weights the two approximately equally.  

The PR was prompted by these observations:
- With GPS Rescue was configured, it was possible to arm with so few satellites a rescue would fail due to not having a home fix.
- The sanity checks would disarm the quad (crash it) when the sat count was less than the GPS rescue sat count when initiated.  This wasn't great if the user set a high rescue sat count to ensure a good home fix before takeoff!
- There were lots of different 'minimum satellite' values in the code... hard-coded number of 5 in a lot of places, 7 in others, and, confusingly, different user-configured values for `gps_rescue_min_sats`, `position_alt_gps_min_sats` and `position_alt_baro_fallback_sats`.
- GPS altitude would often drift a great deal during a flight, causing gps_rescue landing failures because, on landing, either the GPS thought that the quad was much higher than, or way below, true ground level.
- the blue flashing LED on the GPS module didn't seem to correlate with whether or not I could arm, or the satellite number set for GPS Rescue.  There's nothing that can be done about this; it flashes when the GPS module has a 3D fix, but doesn't care, or know about, sat count, or whether our home point has been set.

This table shows how `gps_required_sats` and `gps_minimum_sats` replace some older values.

| Current CLI name | Proposed CLI name | Notes |
|  ----- |  ----- | ----- |
| various  | `gps_required_sats`, default 9, range 5-50 |  to indicate a strong likelihood of a good fix eg for setting home points |
| `gps_min_sats` default 6, range 5-50  | `GPS_MINIMUM_SATS` default 4, range 4-50 |  a 3D fix must have a minimum of 4 sats; we should warn at 4, and cannot trust position estimates below 4 |
| `position_alt_gps_min_sats `, set to `POSITION_DEFAULT_ALT_NUM_SATS_GPS_USE`, ie 10  | use`GPS_REQUIRED_SATS`, ie 9 instead |  this decided whether or not to reset the GPS altitude to zero on arming |
| `position_alt_baro_fallback_sats `, set to `POSITION_DEFAULT_ALT_NUM_SATS_BARO_FALLBACK`, ie 7  | not used | code changed to not require this value, I think there was logical bug so it was never used |


This table lists the places in the code where GPS sat counts were used, and the changes made in this PR:

|  Function/code  |  Current requirements  | This PR | Notes |
|  ----- |  ----- | ----- | ----- |
|  allow arm, if GPS Rescue is configured, in core.c |  `GPS_FIX_HOME` | no change | Only requirement is a fix to home |
|  in `gps.c`, abort on initialisation of the rescue |  `!GPS_FIX_HOME` | no change | Rescue will abort at start if no home fix existed |
|  in `gps.c`, `GPS_reset_home_position()`, sets `GPS_FIX_HOME`, called from `tryArm` in core.c and on stick cal |  `GPS_FIX` + `>=GPS_MIN_SATS` | `GPS_FIX` + `>=GPS_REQUIRED_SATS` | called when attempting to reset  `GPS_FIX_HOME` to current GPS altitude and position |
|  Beep `BEEPER_ARMING_GPS_FIX` in `tryArm` in core.c, only if `FEATURE_GPS` is enabled | `GPS_FIX` + `>=GPS_MIN_SATS` | `GPS_FIX` + `>=GPS_REQUIRED_SATS` | modify arming beep to indicate whether a fix exists on arming; in 4.2 the requirement was a GPS Fix and >=5 sats |
|  in `gps_rescue.c`, `checkGPSRescueIsAvailable()`, flash the OSD GPS Rescue warning | `GPS_FIX_HOME` + `GPS_FIX` + `<GPS_MIN_SATS` |  `GPS_FIX_HOME` + `GPS_FIX` + `<GPS_MINIMUM_SATS`  | While armed with GPS Rescue enabled and the OSD configured to warn, flashes the warning when rescue is not available (or will fail). Triggered if the connection to the GPS module fails, if there is no 3D fix, or sats are the set number, on arming and while flying.  I use <= minimum since this is an in-flight warning that signal is bad and the rescue will fail |
|  in `gps_rescue.c`, sanity check `secondsLowSats` | half of `GPS_MIN_SATS` + 1 |  `<GPS_MINIMUM_SATS`  | Should really include a GPS 3D fix check, that's more important; will crash quad if fails; a 3D fix cannot exist with <4 sats |
|  `onGpsNewData ()`  |  `GPS_FIX` + `>= (GPS_MIN_SATS + 1) / 2` (4) | `GPS_FIX_HOME` + `>=GPS_MINIMUM_SATS` (4) | will not give new GPS Data to GPS Rescue, leading to sanity check failure |
|  Flash GPS LED indicator `updateGpsIndicator()` |  `GPS_MIN_SATS` | `GPS_FIX_HOME` + `>=GPS_REQUIRED_SATS` | Flashes the GPS LED when GPS Rescue arming requirements are met |
|  Beeper Ready in gps.c | `GPS_FIX_HOME` + `gpsIsHealthy()` + `>=GPS_MIN_SATS` | `GPS_FIX_HOME` + `gpsIsHealthy()` + `>=GPS_REQUIRED_SATS` | beeper to indicate GPS has a home fix, ie is ready to arm for GPS rescue |
|  Beep the Sat count, `beeperGpsStatus()`, beeper.c | `GPS_FIX` + `numSat >= 5` | `GPS_FIX` + `>GPS_MINIMUM_SATS` (5) | beep the sat count if a switch is enabled to do that; no change|
|  allow arming with GPS Rescue |  `GPS_FIX_HOME` + `GPS_MIN_SATS` | `GPS_FIX_HOME` + `GPS_REQUIRED_SATS` | |
|  abort start of GPS Rescue |  No `GPS_FIX_HOME` | no change | causes instant disarm on failsafe for people who allow no GPS fix check on arming |
| in `position.c`, update `gpsAlt`, `gpsNumSat`, `gpsTrust`  |  GPS_FIX | no change | if GPS_FIX is lost, none of these are updated | 
| in `position.c`, `calculateEstimatedAltitude()`, `altitudeOffsetSetGPS` |  `altNumSatsGpsUse` >= default of 10 | `>= GPS_REQUIRED_SATS` |  reset GPS zero altitude on arming | 
| IMU course over ground | `GPS_FIX` + `GPS_MIN_SATS` + min groundspeed|  `GPS_FIX` + `>GPS_MINIMUM_SATS`  + min groundspeed |  should probably use hDOP|
| various OSD distances | `GPS_FIX_HOME` + `GPS_FIX`  | no change | eg distance to home, note doesn't care about sat count|
| OSD home direction arrow | `GPS_FIX_HOME` + `GPS_FIX`  | no change | doesn't care about sat count |
| OSD flash `RESCUE N/A`if gpsRescue is enabled | `!GPS_FIX` or `!GPS_FIX_HOME` | `!GPS_FIX` or `<= GPS_MINIMUM_SATS`| via `!gpsRescueIsDisabled()` (tests `GPS_FIX_HOME`) and `!gpsRescueIsAvailable()` (tests `GPS_FIX_HOME` + `GPS_FIX` + `<GPS_MINIMUM_SATS`) *** some duplication here |
| OSD flash number of sats, with Rescue active | `!GPS_FIX` or `<GPS_MIN_SATS`  | `!GPS_FIX` or `< GPS_REQUIRED_SATS`| indicating reduced GPS accuracy due to lower sat count than required for arming. |
| OSD flash number of sats, Rescue not enabled | `!GPS_FIX` or < `GPS_MIN_SATS`  | `< GPS_MINIMUM_SATS`| no change, basically |

The use on satellite count alone appears to be a poor indicator of GPS performance, but we currently use it a lot.  

When evaluating the accuracy of the GPS signal, Betaflight currently uses different combinations of:
- satellite count, 
- GPS 3D fix, aka `GPS_FIX`, 
-  pDOP (from Ublox) or hDOP(from NMEA).

Note: `GPS_FIX` means that a 3D fix exists.  This requires a minimum of 4 satellites, and includes altitude.  If there is no 3D fix, the GPS will not report altitude.  A 2D fix is possible with a minimum of 3 satellites, but altitude will not be reported.  Hence for GPS Rescue and other functions requiring altitude from GPS, a 3D fix is a sufficient check.  If Baro is active and can provide the altitude value required, a 2D fix with a minimum of 3 satellites should suffice.  

Note: we do not currently request hDOP from UBlox, instead we get pDOP and call it hDOP.  Nor do we use vDOP or vAcc for vertical altitude accuracy, while UBlox suggest that they are superior for that functionality.

We need to carefully assess which of the available GPS quality parameters (sat count, 3D fix, pDOP, hDOP and vDOP on both NMEA and UBlox, and vAcc and hAcc on UBlox) provide the best indicators of horizontal accuracy and vertical accuracy.  A separate PR may then alter the requirements for the functions listed above.
