### PR TITLE
CLI: Raise upper limit of dyn_idle_min_rpm

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1188,7 +1188,7 @@ const clivalue_t valueTable[] = {
 #endif
 
 #ifdef USE_DYN_IDLE
-    { PARAM_NAME_DYN_IDLE_MIN_RPM,           VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_min_rpm) },
+    { PARAM_NAME_DYN_IDLE_MIN_RPM,           VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_min_rpm) },
     { PARAM_NAME_DYN_IDLE_P_GAIN,            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_p_gain) },
     { PARAM_NAME_DYN_IDLE_I_GAIN,            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_i_gain) },
     { PARAM_NAME_DYN_IDLE_D_GAIN,            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_d_gain) },

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -192,7 +192,7 @@ typedef struct pidProfile_s {
     uint8_t transient_throttle_limit;       // Maximum DC component of throttle change to mix into throttle to prevent airmode mirroring noise
     char profileName[MAX_PROFILE_NAME_LENGTH + 1]; // Descriptive name for profile
 
-    uint8_t dyn_idle_min_rpm;                   // minimum motor speed enforced by the dynamic idle controller
+    uint8_t dyn_idle_min_rpm;               // minimum motor speed enforced by the dynamic idle controller
     uint8_t dyn_idle_p_gain;                // P gain during active control of rpm
     uint8_t dyn_idle_i_gain;                // I gain during active control of rpm
     uint8_t dyn_idle_d_gain;                // D gain for corrections around rapid changes in rpm


### PR DESCRIPTION
# CLI: Raise upper limit of `dyn_idle_min_rpm`
Some tiny whoops might need to have dynamic idle values **higher than 100 (=10,000rpm or 167Hz)**, which is currently the highest possible value for `dyn_idle_min_rpm.` So I extended the range to **200 (= 20,000rpm or 333Hz)** to give plenty of room for ultra high KV motors.

I'm open to suggestions.

I'm going to follow up with the configurator PR.