### PR TITLE
Add OSD_CRAFTNAME_MSGS to insert additional data into CraftName

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1438,6 +1438,10 @@ const clivalue_t valueTable[] = {
     { "osd_menu_background",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CMS_BACKGROUND }, PG_OSD_CONFIG, offsetof(osdConfig_t, cms_background_type) },
 #endif // end of #ifdef USE_OSD
 
+#ifdef USE_CRAFTNAME_MSGS
+    { "osd_craftname_msgs",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_craftname_msgs) },
+#endif //USE_CRAFTNAME_MSGS
+
 // PG_SYSTEM_CONFIG
 #if defined(STM32F4) || defined(STM32G4)
     { "system_hse_mhz",             VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, hseMhz) },

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -387,6 +387,9 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->stat_show_cell_value = false;
     osdConfig->framerate_hz = OSD_FRAMERATE_DEFAULT_HZ;
     osdConfig->cms_background_type = DISPLAY_BACKGROUND_TRANSPARENT;
+    #ifdef USE_CRAFTNAME_MSGS
+    osdConfig->osd_craftname_msgs = false;   // Insert LQ/RSSI-dBm and warnings into CraftName
+    #endif //USE_CRAFTNAME_MSGS
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -303,6 +303,9 @@ typedef struct osdConfig_s {
     uint16_t framerate_hz;
     uint8_t cms_background_type;              // For supporting devices, determines whether the CMS background is transparent or opaque
     uint8_t stat_show_cell_value;
+    #ifdef USE_CRAFTNAME_MSGS
+    uint8_t osd_craftname_msgs;               // Insert LQ/RSSI-dBm and warnings into CraftName
+    #endif //USE_CRAFTNAME_MSGS
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1443,6 +1443,35 @@ static void osdElementWarnings(osdElementParms_t *element)
     } else {
         CLR_BLINK(OSD_WARNINGS);
     }
+
+    #ifdef USE_CRAFTNAME_MSGS
+    // Injects data into the CraftName variable for systems which limit
+    // the available MSP data field in their OSD.
+    if (osdConfig()->osd_craftname_msgs == true) {
+        // if warning is not set, or blink is off, then display LQ & RSSI
+        if (blinkState || (strlen(element->buff) == 0)) {
+            #ifdef USE_RX_LINK_QUALITY_INFO
+            // replicate the LQ functionality without the special font symbols
+            uint16_t osdLinkQuality = 0;
+            if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) { // 0-99
+                osdLinkQuality = rxGetLinkQuality();
+                const uint8_t osdRfMode = rxGetRfMode();
+                tfp_sprintf(element->buff, "LQ %2d:%03d %3d", osdRfMode, osdLinkQuality, getRssiDbm());
+            } else if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_GHST) { // 0-100
+                osdLinkQuality = rxGetLinkQuality();
+                tfp_sprintf(element->buff, "LQ %03d %3d", osdLinkQuality, getRssiDbm());
+            } else { // 0-9
+                osdLinkQuality = rxGetLinkQuality() * 10 / LINK_QUALITY_MAX_VALUE;
+                if (osdLinkQuality >= 10) {
+                    osdLinkQuality = 9;
+                }
+                tfp_sprintf(element->buff, "LQ %1d", osdLinkQuality);
+            }
+            #endif // USE_RX_LINK_QUALITY_INFO
+        }
+        strncpy(pilotConfigMutable()->name, element->buff, MAX_NAME_LENGTH);
+    }
+    #endif // USE_CRAFTNAME_MSGS
 }
 
 // Define the order in which the elements are drawn.

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -407,6 +407,7 @@ extern uint8_t _dmaram_end__;
 #define USE_SIMPLIFIED_TUNING
 #define USE_RX_LINK_UPLINK_POWER
 #define USE_CRSF_V3
+#define USE_CRAFTNAME_MSGS
 #endif
 
 #if (TARGET_FLASH_SIZE > 512)


### PR DESCRIPTION
Inserts alternative data into the MSP CraftName field to aid those whose OSD options are limited to a reduced set of MSP fields. In particular this assists users who are not able to view the Warnings or LQ/RSSI-dBm fields, which includes DJI Goggles users.

By default a string is created from the LQ and RSSI-dBm values (`LQ  7:100 -20`). This includes the flight-mode, and is therefore superior to a raw ADC read, as well as being able to show RSSI and LQ at once.

When a warning is present the warning text is shown in place of the LQ/RSSI text when the `blinkState` is true. This enables the pilot to view warnings and LQ/RSSI at the same time.

Whilst not a complete solution, as no CLI flag is included and option must be enabled at build-time, this partially addresses https://github.com/betaflight/betaflight/issues/11554

Those wishing to test this can do so using the attached zip which includes hex files.
[MSP_CRAFTNAME_HACK.zip](https://github.com/betaflight/betaflight/files/9261588/MSP_CRAFTNAME_HACK.zip)

Because this is a build-time option you must specify the options when creating the firmware files. For example:
`make unified OPTIONS=USE_MSP_CRAFTNAME_HACK`

Settings variable `msp_craftname_hack` has been added, set this to `ON` to enable the feature.
