### PR TITLE
Lower max CraftName length to avoid ugly truncation errors

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1469,7 +1469,7 @@ static void osdElementWarnings(osdElementParms_t *element)
             }
             #endif // USE_RX_LINK_QUALITY_INFO
         }
-        strncpy(pilotConfigMutable()->name, element->buff, MAX_NAME_LENGTH);
+        strncpy(pilotConfigMutable()->name, element->buff, MAX_NAME_LENGTH - 1);
     }
     #endif // USE_CRAFTNAME_MSGS
 }


### PR DESCRIPTION
Fixes the truncation of warnings and addition of "....". The craftname is being cut down due to sending 1 character too much to this field.

BEFORE `CRASH F...`
AFTER `CRASH FLIP SWIT`