### PR TITLE
Restore iTerm Windup to all axes, active by default

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1004,22 +1004,19 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
         // -----calculate I component
         float Ki = pidRuntime.pidCoefficient[axis].Ki;
-        float axisDynCi = pidRuntime.dT;
 #ifdef USE_LAUNCH_CONTROL
         // if launch control is active override the iterm gains and apply iterm windup protection to all axes
         if (launchControlActive) {
             Ki = pidRuntime.launchControlKi;
-            axisDynCi = dynCi;
         } else
 #endif
         {
             if (axis == FD_YAW) {
-                axisDynCi = dynCi; // only apply windup protection to yaw
                 pidRuntime.itermAccelerator = 0.0f; // no antigravity on yaw iTerm
             }
         }
 
-        pidData[axis].I = constrainf(previousIterm + (Ki * axisDynCi + pidRuntime.itermAccelerator) * itermErrorRate, -pidRuntime.itermLimit, pidRuntime.itermLimit);
+        pidData[axis].I = constrainf(previousIterm + (Ki * dynCi + pidRuntime.itermAccelerator) * itermErrorRate, -pidRuntime.itermLimit, pidRuntime.itermLimit);
 
         // -----calculate pidSetpointDelta
         float pidSetpointDelta = 0;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -322,8 +322,8 @@ TEST(pidControllerTest, testPidLoop) {
     // Simulate Iterm behaviour during mixer saturation
     simulatedMotorMixRange = 1.2f;
     pidController(pidProfile, currentTestTime());
-    EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
-    EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
+    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
+    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
     EXPECT_NEAR(-8.8, pidData[FD_YAW].I, calculateTolerance(-8.8));
     simulatedMotorMixRange = 0;
 
@@ -339,8 +339,8 @@ TEST(pidControllerTest, testPidLoop) {
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
-    EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
+    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
+    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
     EXPECT_NEAR(-10.6, pidData[FD_YAW].I, calculateTolerance(-10.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
@@ -457,12 +457,12 @@ TEST(pidControllerTest, testMixerSaturation) {
     simulatedMotorMixRange = 2.0f;
     pidController(pidProfile, currentTestTime());
 
-    // Expect no iterm accumulation for yaw
-    EXPECT_FLOAT_EQ(150, pidData[FD_ROLL].I);
-    EXPECT_FLOAT_EQ(-150, pidData[FD_PITCH].I);
+    // Expect no iterm accumulation for all axes
+    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
+    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 
-    // Test itermWindup limit (note: windup limit now only affects yaw)
+    // Test itermWindup limit
     // First store values without exceeding iterm windup limit
     resetTest();
     ENABLE_ARMING_FLAG(ARMED);
@@ -483,10 +483,10 @@ TEST(pidControllerTest, testMixerSaturation) {
     setStickPosition(FD_ROLL, 0.1f);
     setStickPosition(FD_PITCH, -0.1f);
     setStickPosition(FD_YAW, 0.1f);
-    simulatedMotorMixRange = (pidProfile->itermWindupPointPercent + 1) / 100.0f;
+    simulatedMotorMixRange = (pidProfile->itermWindupPointPercent + 2) / 100.0f;
     pidController(pidProfile, currentTestTime());
-    EXPECT_FLOAT_EQ(pidData[FD_ROLL].I, rollTestIterm);
-    EXPECT_FLOAT_EQ(pidData[FD_PITCH].I, pitchTestIterm);
+    EXPECT_LT(pidData[FD_ROLL].I, rollTestIterm);
+    EXPECT_GE(pidData[FD_PITCH].I, pitchTestIterm);
     EXPECT_LT(pidData[FD_YAW].I, yawTestIterm);
 }
 


### PR DESCRIPTION
This PR retires `iterm_windup` to Roll and Pitch, reverting to the original behaviour, and reversing PR's #9569 and #9597, which were part of 4.3.  

Large builds like X Class can readily reach 100% motor saturation, due to a combination of high PIDs and delay achieving thrust.  This leads to an ongoing error, which can exceed the iTerm Relax period as calculated from setpoint, causing iTerm windup.  

Even if the iTerm_Relax Cutoff is set lower than normal, to prolong its effect, its suppression of iTerm accumulation may not be sufficient to avoid iTerm windup.

Additionally, very low authority quads (of any kind) can saturate motors on fast inputs, due to lags and high PIDs, and then fast input can result in ongoing slow oscillation.  The mechanism includes high P and I during the prolonged error phase, a large overshoot, and then a response to the overshoot that also saturates the motors.  This can result in ongoing oscillation that can persist even though setpoint is held constant, and is exaggerated by iTerm accumulation.  Our current `iterm_relax` is useless for this kind of high motor differential, steady setpoint oscillation.  It also does nothing to prevent iTerm accumulation following an impact that causes motors to max out in response.

This PR will suppress iTerm accumulation above a default motor differential of 85%, on all axes.

The nature of this suppression is non-linear.  There is no suppression below the `iterm_windup` threshold.  Above the threshold, the amount of iTerm accumulation is linearly suppressed.  With the default value of 85, the rate of iTerm accumulation is normal until a differential of 85, halved by 92.5, and is zero only when the requested motor differential is 100 or greater.

For normally responsive quads, the existing iTerm Relax behaviour will not be affected, since they rarely require more than 85% motor differential during normal flight.  If they were to hit 100%, eg during a flip, it would then be desirable to prevent iTerm accumulation until the PIDs had some kind of control back.

On reflection, the change - proposed by me in #9569 for 4.3, to limit iterm_windup to yaw only - was a mistake.

This PR reverts back to the historical / original behaviour.  It should improve iTerm behaviour in conditions where the quad cannot achieve set point without motor saturation.  The existing `iterm_relax` code should continue to work as normal.

This shows the amount of iTerm accumulation suppression for different amounts of motor differential.

motor differential | suppression
-- | --
0 | 1
0.1 | 1
0.2 | 1
0.3 | 1
0.4 | 1
0.5 | 1
0.6 | 1
0.7 | 1
0.8 | 1
0.85 | 1
0.9 | 0.66666667
0.95 | 0.33333333
0.99 | 0.06666667
1 | 0

The default value of 85 should be OK for 6-8" quads, but for X Class or other heavy builds, a value of 60 or even lower may work better.