### PR TITLE
Remove unused MSP_SET_PID_CONTROLLER code

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2544,9 +2544,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         }
         break;
 
-    case MSP_SET_PID_CONTROLLER:
-        break;
-
     case MSP_SET_PID:
         for (int i = 0; i < PID_ITEM_COUNT; i++) {
             currentPidProfile->pid[i].P = sbufReadU8(src);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -150,7 +150,7 @@
 #define MSP_SONAR_ALTITUDE              58 //out message get sonar altitude [cm]
 
 #define MSP_PID_CONTROLLER              59
-#define MSP_SET_PID_CONTROLLER          60
+// DEPRECATED - #define MSP_SET_PID_CONTROLLER          60
 
 #define MSP_ARMING_CONFIG               61
 #define MSP_SET_ARMING_CONFIG           62


### PR DESCRIPTION
Just as we only have one type of PID controller now: `PID_CONTROLLER_BETAFLIGHT`