### PR TITLE
Maintain previous MSP GPS Heading resolution

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1468,7 +1468,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 
     case MSP_COMP_GPS:
         sbufWriteU16(dst, GPS_distanceToHome);
-        sbufWriteU16(dst, GPS_directionToHome);
+        sbufWriteU16(dst, GPS_directionToHome / 10); // resolution increased in Betaflight 4.4 by factor of 10, this maintains backwards compatibility for DJI OSD
         sbufWriteU8(dst, GPS_update & 1);
         break;
 


### PR DESCRIPTION
Fix for issue https://github.com/betaflight/betaflight/issues/11752

PR https://github.com/betaflight/betaflight/pull/11579 , amongst many changes, increased the resolution of the GPS Heading data by a factor of 10, so that where previously a heading value might have been reported as 179 for 179 degrees, it would now be reported as 1793, meaning 179.3.  

The analog OSD code within Betaflight was adjusted at the same time, so it’s arrow works fine.

DJI OSD users get an arrow that rotates much too fast and points in the wrong direction, because it gets heading over MSP and still uses degrees.

GPS rescue uses direction to home to calculate the yaw angle.  Having decimal point precision about that angle isn't essential, but may reduce yaw PID dithering either side of a degree whey flying home in a fairly straight line, especially at some distance.

I think I would favour option 2 since apart from showing the arrow in DJI goggles, we have no other use for the msp GPS heading information that I know of.  And I can’t imagine DJI doing anything about it.

So this PR gets MSP to report heading in degrees, as before.  