### PR TITLE
Change Dynamic Notch Min Hz default to 100Hz

### DIFF
--- a/src/main/pg/dyn_notch.c
+++ b/src/main/pg/dyn_notch.c
@@ -27,10 +27,10 @@
 
 #include "dyn_notch.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(dynNotchConfig_t, dynNotchConfig, PG_DYN_NOTCH_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(dynNotchConfig_t, dynNotchConfig, PG_DYN_NOTCH_CONFIG, 1);
 
 PG_RESET_TEMPLATE(dynNotchConfig_t, dynNotchConfig,
-    .dyn_notch_min_hz = 150,
+    .dyn_notch_min_hz = 100,
     .dyn_notch_max_hz = 600,
     .dyn_notch_q = 300,
     .dyn_notch_count = 3


### PR DESCRIPTION
Change Dynamic Notch Min Hz default from 150Hz to 100Hz

....this default value should better cover the range of issues that arise in the spooky world of frame resonance...