### PR TITLE
increase led limit to 220

### DIFF
--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -14,7 +14,7 @@ The STATUS profile is used to display all the information mentioned below, i.e. 
 
 Addressable LED strips can be used to show information from the flight controller system, the current implementation supports the following:
 
-* Up to 32 LEDs. (Support for more than 32 LEDs is possible, it just requires additional development.)
+* Up to 220 LEDs.
 * Indicators showing pitch/roll stick positions.
 * Heading/Orientation lights.
 * Flight mode specific color schemes.
@@ -81,7 +81,7 @@ The BEACON profile is used to find a lost quad, it flashes all LEDs white once p
 
 ## Supported hardware
 
-Only strips of 32 WS2811/WS2812 LEDs are supported currently.  If the strip is longer than 32 LEDs it does not matter, but only the first 32 are used.
+Only strips of 220 WS2811/WS2812 LEDs are supported currently.  If the strip is longer than 220 LEDs it does not matter, but only the first 220 are used.
 
 WS2812 LEDs require an 800khz signal and precise timings and thus requires the use of a dedicated hardware timer.
 

--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -24,7 +24,7 @@
 
 #include "drivers/io_types.h"
 
-#define WS2811_LED_STRIP_LENGTH    32
+#define WS2811_LED_STRIP_LENGTH    220
 
 #define WS2811_BITS_PER_LED_MAX    32
 

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -28,7 +28,7 @@
 
 #include "pg/pg.h"
 
-#define LED_MAX_STRIP_LENGTH           32
+#define LED_MAX_STRIP_LENGTH           220
 #define LED_CONFIGURABLE_COLOR_COUNT   16
 #define LED_MODE_COUNT                  6
 #define LED_DIRECTION_COUNT             6


### PR DESCRIPTION
I have looked absolutely everywhere for why the led limit is 32 and could not find any good reason. My closest guess was some kind of hardware speed limitation way way back in the cleanflight f1 naze32 days which obviously are not relevant. Led's consume negligible clock cycles in contrast to the rest of the realtime tasks. I have a quad with 56 led's so this change is one I personally utilize and others might. For some reason compilation fails for any limit above 221 but I don't like odd numbers and can't be bothered to figure out why it fails to compile above this limit since 220 seems generous enough regardless. A configurator change is not necessary since it seems the configurator queries the fc for its internal limit.