### PR TITLE
GPS Rescue smoothed with upsampled inputs, bug fixes

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1448,11 +1448,12 @@ static bool blackboxWriteSysinfo(void)
 #endif
 #ifdef USE_BARO
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_HARDWARE, "%d",           barometerConfig()->baro_hardware);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_NOISE_LPF, "%d",          barometerConfig()->baro_noise_lpf);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_VARIO_LPF, "%d",          barometerConfig()->baro_vario_lpf);
 #endif
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALT_SOURCE, "%d",      positionConfig()->altSource);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALT_PREFER_BARO, "%d", positionConfig()->altPreferBaro);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALTITUDE_SOURCE, "%d",      positionConfig()->altitude_source);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALTITUDE_PREFER_BARO, "%d", positionConfig()->altitude_prefer_baro);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALTITUDE_LPF, "%d",         positionConfig()->altitude_lpf);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_POSITION_ALTITUDE_D_LPF, "%d",       positionConfig()->altitude_d_lpf);
+
 #ifdef USE_MAG
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MAG_HARDWARE, "%d",           compassConfig()->mag_hardware);
 #endif

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1528,14 +1528,14 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_MINIMUM_SATS, "%d",           gpsConfig()->gpsMinimumSats)
 
 #ifdef USE_GPS_RESCUE
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_MIN_START_DIST, "%d",         gpsRescueConfig()->minRescueDth)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_MIN_START_DIST, "%d",  gpsRescueConfig()->minRescueDth)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALT_MODE, "%d",        gpsRescueConfig()->altitudeMode)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_INITIAL_CLIMB, "%d",      gpsRescueConfig()->rescueAltitudeBufferM)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_INITIAL_CLIMB, "%d",   gpsRescueConfig()->rescueAltitudeBufferM)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ASCEND_RATE, "%d",     gpsRescueConfig()->ascendRate)
 
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_RETURN_ALT, "%d",     gpsRescueConfig()->initialAltitudeM)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_RETURN_ALT, "%d",      gpsRescueConfig()->initialAltitudeM)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_RETURN_SPEED, "%d",    gpsRescueConfig()->rescueGroundspeed)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_PITCH_ANGLE_MAX, "%d",    gpsRescueConfig()->angle)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_PITCH_ANGLE_MAX, "%d", gpsRescueConfig()->angle)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ROLL_MIX, "%d",        gpsRescueConfig()->rollMix)
 
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_DESCENT_DIST, "%d",    gpsRescueConfig()->descentDistanceM)

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1528,12 +1528,27 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_MINIMUM_SATS, "%d",           gpsConfig()->gpsMinimumSats)
 
 #ifdef USE_GPS_RESCUE
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ANGLE, "%d",           gpsRescueConfig()->angle)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALT_BUFFER, "%d",      gpsRescueConfig()->rescueAltitudeBufferM)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_INITIAL_ALT, "%d",     gpsRescueConfig()->initialAltitudeM)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_MIN_START_DIST, "%d",         gpsRescueConfig()->minRescueDth)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALT_MODE, "%d",        gpsRescueConfig()->altitudeMode)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_INITIAL_CLIMB, "%d",      gpsRescueConfig()->rescueAltitudeBufferM)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ASCEND_RATE, "%d",     gpsRescueConfig()->ascendRate)
+
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_RETURN_ALT, "%d",     gpsRescueConfig()->initialAltitudeM)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_RETURN_SPEED, "%d",    gpsRescueConfig()->rescueGroundspeed)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_PITCH_ANGLE_MAX, "%d",    gpsRescueConfig()->angle)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ROLL_MIX, "%d",        gpsRescueConfig()->rollMix)
+
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_DESCENT_DIST, "%d",    gpsRescueConfig()->descentDistanceM)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_DESCEND_RATE, "%d",    gpsRescueConfig()->descendRate)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_LANDING_ALT, "%d",     gpsRescueConfig()->targetLandingAltitudeM)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_GROUND_SPEED, "%d",    gpsRescueConfig()->rescueGroundspeed)
+
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_MIN, "%d",    gpsRescueConfig()->throttleMin)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_MAX, "%d",    gpsRescueConfig()->throttleMax)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER, "%d",  gpsRescueConfig()->throttleHover)
+
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_SANITY_CHECKS, "%d",   gpsRescueConfig()->sanityChecks)
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX, "%d", gpsRescueConfig()->allowArmingWithoutFix)
+
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_P, "%d",      gpsRescueConfig()->throttleP)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_I, "%d",      gpsRescueConfig()->throttleI)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_D, "%d",      gpsRescueConfig()->throttleD)
@@ -1541,17 +1556,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_VELOCITY_I, "%d",      gpsRescueConfig()->velI)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_VELOCITY_D, "%d",      gpsRescueConfig()->velD)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_YAW_P, "%d",           gpsRescueConfig()->yawP)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ROLL_MIX, "%d",        gpsRescueConfig()->rollMix)
 
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_MIN, "%d",    gpsRescueConfig()->throttleMin)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_MAX, "%d",    gpsRescueConfig()->throttleMax)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ASCEND_RATE, "%d",     gpsRescueConfig()->ascendRate)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_DESCEND_RATE, "%d",    gpsRescueConfig()->descendRate)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER, "%d",  gpsRescueConfig()->throttleHover)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_SANITY_CHECKS, "%d",   gpsRescueConfig()->sanityChecks)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_MIN_DTH, "%d",         gpsRescueConfig()->minRescueDth)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX, "%d", gpsRescueConfig()->allowArmingWithoutFix)
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_ALT_MODE, "%d",        gpsRescueConfig()->altitudeMode)
+ 
 #ifdef USE_MAG
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_RESCUE_USE_MAG, "%d",         gpsRescueConfig()->useMag)
 #endif

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -467,7 +467,7 @@ static const char * const lookupTableGyroFilterDebug[] = {
     "ROLL", "PITCH", "YAW"
 };
 
-static const char * const lookupTablePositionAltSource[] = {
+static const char * const lookupTablePositionAltitudeSource[] = {
     "DEFAULT", "BARO_ONLY", "GPS_ONLY"
 };
 
@@ -630,7 +630,7 @@ const lookupTableEntry_t lookupTables[] = {
 
     LOOKUP_TABLE_ENTRY(lookupTableGyroFilterDebug),
 
-    LOOKUP_TABLE_ENTRY(lookupTablePositionAltSource),
+    LOOKUP_TABLE_ENTRY(lookupTablePositionAltitudeSource),
     LOOKUP_TABLE_ENTRY(lookupTableOffOnAuto),
     LOOKUP_TABLE_ENTRY(lookupTableFeedforwardAveraging),
     LOOKUP_TABLE_ENTRY(lookupTableDshotBitbangedTimer),
@@ -733,8 +733,6 @@ const clivalue_t valueTable[] = {
     { "baro_i2c_device",            VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 5 }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_i2c_device) },
     { "baro_i2c_address",           VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_i2c_address) },
     { PARAM_NAME_BARO_HARDWARE,     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BARO_HARDWARE }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_hardware) },
-    { "baro_noise_lpf",             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 1000 }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_noise_lpf) },
-    { "baro_vario_lpf",             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 1000 }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_vario_lpf) },
 #endif
 
 // PG_RX_CONFIG
@@ -1669,8 +1667,11 @@ const clivalue_t valueTable[] = {
 #endif
 
 // PG_POSITION
-    { "position_alt_source",                    VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_POSITION_ALT_SOURCE }, PG_POSITION, offsetof(positionConfig_t, altSource) },
-    { "position_alt_prefer_baro",               VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_POSITION, offsetof(positionConfig_t, altPreferBaro) },
+    { "altitude_source",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_POSITION_ALT_SOURCE }, PG_POSITION, offsetof(positionConfig_t, altitude_source) },
+    { "altitude_prefer_baro",  VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_POSITION, offsetof(positionConfig_t, altitude_prefer_baro) },
+    { "altitude_lpf",          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 1000 }, PG_POSITION, offsetof(positionConfig_t, altitude_lpf) },
+    { "altitude_d_lpf",        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 1000 }, PG_POSITION, offsetof(positionConfig_t, altitude_d_lpf) },
+
 // PG_MODE_ACTIVATION_CONFIG
 #if defined(USE_CUSTOM_BOX_NAMES)
     { "box_user_1_name", VAR_UINT8 | HARDWARE_VALUE | MODE_STRING, .config.string = { 1, MAX_BOX_USER_NAME_LENGTH, STRING_FLAGS_NONE }, PG_MODE_ACTIVATION_CONFIG, offsetof(modeActivationConfig_t, box_user_1_name) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1015,12 +1015,27 @@ const clivalue_t valueTable[] = {
 
 #ifdef USE_GPS_RESCUE
     // PG_GPS_RESCUE
-    { PARAM_NAME_GPS_RESCUE_ANGLE,           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, angle) },
-    { PARAM_NAME_GPS_RESCUE_ALT_BUFFER,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, rescueAltitudeBufferM) },
-    { PARAM_NAME_GPS_RESCUE_INITIAL_ALT,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 2, 100 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, initialAltitudeM) },
-    { PARAM_NAME_GPS_RESCUE_DESCENT_DIST,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descentDistanceM) },
+    { PARAM_NAME_GPS_RESCUE_MIN_START_DIST,  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDth) },
+    { PARAM_NAME_GPS_RESCUE_ALT_MODE,        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE_ALT_MODE }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, altitudeMode) },
+    { PARAM_NAME_GPS_RESCUE_INITIAL_CLIMB,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, rescueAltitudeBufferM) },
+    { PARAM_NAME_GPS_RESCUE_ASCEND_RATE,     VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 50, 2500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, ascendRate) },
+
+    { PARAM_NAME_GPS_RESCUE_RETURN_ALT,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 2, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, initialAltitudeM) },
+    { PARAM_NAME_GPS_RESCUE_RETURN_SPEED,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, rescueGroundspeed) },
+    { PARAM_NAME_GPS_RESCUE_PITCH_ANGLE_MAX, VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, angle) },
+    { PARAM_NAME_GPS_RESCUE_ROLL_MIX,        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, rollMix) },
+
+    { PARAM_NAME_GPS_RESCUE_DESCENT_DIST,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 5, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descentDistanceM) },
+    { PARAM_NAME_GPS_RESCUE_DESCEND_RATE,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 25, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descendRate) },
     { PARAM_NAME_GPS_RESCUE_LANDING_ALT,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 3, 15 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, targetLandingAltitudeM) },
-    { PARAM_NAME_GPS_RESCUE_GROUND_SPEED,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 250, 3000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, rescueGroundspeed) },
+
+    { PARAM_NAME_GPS_RESCUE_THROTTLE_MIN,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMin) },
+    { PARAM_NAME_GPS_RESCUE_THROTTLE_MAX,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMax) },
+    { PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER,  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleHover) },
+
+    { PARAM_NAME_GPS_RESCUE_SANITY_CHECKS,   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE_SANITY_CHECK }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, sanityChecks) },
+    { PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, allowArmingWithoutFix) },
+
     { PARAM_NAME_GPS_RESCUE_THROTTLE_P,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleP) },
     { PARAM_NAME_GPS_RESCUE_THROTTLE_I,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleI) },
     { PARAM_NAME_GPS_RESCUE_THROTTLE_D,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleD) },
@@ -1028,17 +1043,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_GPS_RESCUE_VELOCITY_I,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, velI) },
     { PARAM_NAME_GPS_RESCUE_VELOCITY_D,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, velD) },
     { PARAM_NAME_GPS_RESCUE_YAW_P,           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, yawP) },
-    { PARAM_NAME_GPS_RESCUE_ROLL_MIX,        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, rollMix) },
 
-    { PARAM_NAME_GPS_RESCUE_THROTTLE_MIN,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMin) },
-    { PARAM_NAME_GPS_RESCUE_THROTTLE_MAX,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMax) },
-    { PARAM_NAME_GPS_RESCUE_ASCEND_RATE,     VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 50, 2500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, ascendRate) },
-    { PARAM_NAME_GPS_RESCUE_DESCEND_RATE,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 25, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descendRate) },
-    { PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER,  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleHover) },
-    { PARAM_NAME_GPS_RESCUE_SANITY_CHECKS,   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE_SANITY_CHECK }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, sanityChecks) },
-    { PARAM_NAME_GPS_RESCUE_MIN_DTH,         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, minRescueDth) },
-    { PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, allowArmingWithoutFix) },
-    { PARAM_NAME_GPS_RESCUE_ALT_MODE,        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_RESCUE_ALT_MODE }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, altitudeMode) },
 #ifdef USE_MAG
     { PARAM_NAME_GPS_RESCUE_USE_MAG,         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, useMag) },
 #endif

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -95,6 +95,7 @@
 #include "flight/failsafe.h"
 #include "flight/imu.h"
 #include "flight/mixer.h"
+#include "flight/gps_rescue.h"
 #include "flight/pid.h"
 #include "flight/pid_init.h"
 #include "flight/servos.h"
@@ -766,6 +767,7 @@ void init(void)
 #ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)) {
         gpsInit();
+        gpsRescueInit();
     }
 #endif
 
@@ -828,6 +830,7 @@ void init(void)
 #ifdef USE_BARO
     baroStartCalibration();
 #endif
+    positionInit();
 
 #if defined(USE_VTX_COMMON) || defined(USE_VTX_CONTROL)
     vtxTableInit();

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -136,12 +136,27 @@
 #define PARAM_NAME_GPS_MINIMUM_SATS "gps_minimum_sats"
 
 #ifdef USE_GPS_RESCUE
-#define PARAM_NAME_GPS_RESCUE_ANGLE "gps_rescue_angle"
-#define PARAM_NAME_GPS_RESCUE_ALT_BUFFER "gps_rescue_alt_buffer"
-#define PARAM_NAME_GPS_RESCUE_INITIAL_ALT "gps_rescue_initial_alt"
+#define PARAM_NAME_GPS_RESCUE_MIN_START_DIST "gps_rescue_min_start_dist"
+#define PARAM_NAME_GPS_RESCUE_ALT_MODE "gps_rescue_alt_mode"
+#define PARAM_NAME_GPS_RESCUE_INITIAL_CLIMB "gps_rescue_initial_climb"
+#define PARAM_NAME_GPS_RESCUE_ASCEND_RATE "gps_rescue_ascend_rate"
+
+#define PARAM_NAME_GPS_RESCUE_RETURN_ALT "gps_rescue_return_alt"
+#define PARAM_NAME_GPS_RESCUE_RETURN_SPEED "gps_rescue_ground_speed"
+#define PARAM_NAME_GPS_RESCUE_PITCH_ANGLE_MAX "gps_rescue_pitch_angle_max"
+#define PARAM_NAME_GPS_RESCUE_ROLL_MIX "gps_rescue_roll_mix"
+
 #define PARAM_NAME_GPS_RESCUE_DESCENT_DIST "gps_rescue_descent_dist"
+#define PARAM_NAME_GPS_RESCUE_DESCEND_RATE "gps_rescue_descend_rate"
 #define PARAM_NAME_GPS_RESCUE_LANDING_ALT "gps_rescue_landing_alt"
-#define PARAM_NAME_GPS_RESCUE_GROUND_SPEED "gps_rescue_ground_speed"
+
+#define PARAM_NAME_GPS_RESCUE_THROTTLE_MIN "gps_rescue_throttle_min"
+#define PARAM_NAME_GPS_RESCUE_THROTTLE_MAX "gps_rescue_throttle_max"
+#define PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER "gps_rescue_throttle_hover"
+
+#define PARAM_NAME_GPS_RESCUE_SANITY_CHECKS "gps_rescue_sanity_checks"
+#define PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX "gps_rescue_allow_arming_without_fix"
+
 #define PARAM_NAME_GPS_RESCUE_THROTTLE_P "gps_rescue_throttle_p"
 #define PARAM_NAME_GPS_RESCUE_THROTTLE_I "gps_rescue_throttle_i"
 #define PARAM_NAME_GPS_RESCUE_THROTTLE_D "gps_rescue_throttle_d"
@@ -149,16 +164,7 @@
 #define PARAM_NAME_GPS_RESCUE_VELOCITY_I "gps_rescue_velocity_i"
 #define PARAM_NAME_GPS_RESCUE_VELOCITY_D "gps_rescue_velocity_d"
 #define PARAM_NAME_GPS_RESCUE_YAW_P "gps_rescue_yaw_p"
-#define PARAM_NAME_GPS_RESCUE_ROLL_MIX "gps_rescue_roll_mix"
-#define PARAM_NAME_GPS_RESCUE_THROTTLE_MIN "gps_rescue_throttle_min"
-#define PARAM_NAME_GPS_RESCUE_THROTTLE_MAX "gps_rescue_throttle_max"
-#define PARAM_NAME_GPS_RESCUE_ASCEND_RATE "gps_rescue_ascend_rate"
-#define PARAM_NAME_GPS_RESCUE_DESCEND_RATE "gps_rescue_descend_rate"
-#define PARAM_NAME_GPS_RESCUE_THROTTLE_HOVER "gps_rescue_throttle_hover"
-#define PARAM_NAME_GPS_RESCUE_SANITY_CHECKS "gps_rescue_sanity_checks"
-#define PARAM_NAME_GPS_RESCUE_MIN_DTH "gps_rescue_min_dth"
-#define PARAM_NAME_GPS_RESCUE_ALLOW_ARMING_WITHOUT_FIX "gps_rescue_allow_arming_without_fix"
-#define PARAM_NAME_GPS_RESCUE_ALT_MODE "gps_rescue_alt_mode"
+
 #ifdef USE_MAG
 #define PARAM_NAME_GPS_RESCUE_USE_MAG "gps_rescue_use_mag"
 #endif

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -34,8 +34,6 @@
 #define PARAM_NAME_ACC_LPF_HZ "acc_lpf_hz"
 #define PARAM_NAME_MAG_HARDWARE "mag_hardware"
 #define PARAM_NAME_BARO_HARDWARE "baro_hardware"
-#define PARAM_NAME_BARO_NOISE_LPF "baro_noise_lpf"
-#define PARAM_NAME_BARO_VARIO_LPF "baro_vario_lpf"
 #define PARAM_NAME_RC_SMOOTHING "rc_smoothing"
 #define PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR "rc_smoothing_auto_factor"
 #define PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR_THROTTLE "rc_smoothing_auto_factor_throttle"
@@ -119,8 +117,10 @@
 #define PARAM_NAME_RPM_FILTER_MIN_HZ "rpm_filter_min_hz"
 #define PARAM_NAME_RPM_FILTER_FADE_RANGE_HZ "rpm_filter_fade_range_hz"
 #define PARAM_NAME_RPM_FILTER_LPF_HZ "rpm_filter_lpf_hz"
-#define PARAM_NAME_POSITION_ALT_SOURCE "position_alt_source"
-#define PARAM_NAME_POSITION_ALT_PREFER_BARO "position_alt_prefer_baro"
+#define PARAM_NAME_POSITION_ALTITUDE_SOURCE "altitude_source"
+#define PARAM_NAME_POSITION_ALTITUDE_PREFER_BARO "altitude_prefer_baro"
+#define PARAM_NAME_POSITION_ALTITUDE_LPF "altitude_lpf"
+#define PARAM_NAME_POSITION_ALTITUDE_D_LPF "altitude_d_lpf"
 
 #ifdef USE_GPS
 #define PARAM_NAME_GPS_PROVIDER "gps_provider"

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -804,10 +804,10 @@ void updateGPSRescueState(void)
             rescueState.intent.yawAttenuator += 0.02f;
         }
         if (rescueState.intent.rollAngleLimitDeg < gpsRescueConfig()->angle) { // gradually acquire full roll authority
-            rescueState.intent.rollAngleLimitDeg += 0.05f;
+            rescueState.intent.rollAngleLimitDeg += 1;
         } 
         if (rescueState.intent.pitchAngleLimitDeg < gpsRescueConfig()->angle) { // gradually acquire full pitch authority
-            rescueState.intent.pitchAngleLimitDeg += 0.05f;
+            rescueState.intent.pitchAngleLimitDeg += 1;
         } 
         if (newGPSData) {
             if (rescueState.sensor.distanceToHomeM <= rescueState.intent.descentDistanceM) {

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -797,7 +797,6 @@ void updateGPSRescueState(void)
             // once , gradually increase target velocity and roll angle
             rescueState.intent.targetVelocityCmS = gpsRescueConfig()->rescueGroundspeed * angleToHome;
             rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->angle * angleToHome;
-            rescueState.intent.rollAngleLimitDeg = gpsRescueConfig()->angle * angleToHome; 
             if (rescueState.sensor.absErrorAngle < 10.0f) {
                 // enter fly home phase with full forward velocity target and full angle values
                 rescueState.phase = RESCUE_FLY_HOME;
@@ -805,13 +804,16 @@ void updateGPSRescueState(void)
                 rescueState.intent.yawAttenuator = 1.0f;
                 rescueState.intent.targetVelocityCmS = gpsRescueConfig()->rescueGroundspeed;
                 rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->angle;
-                rescueState.intent.rollAngleLimitDeg = gpsRescueConfig()->angle; 
             }
         }
         break;
 
     case RESCUE_FLY_HOME:
         // fly home with full control on all axes, pitching forward to gain speed
+        // gradually open up the roll limits up as we get underway
+        if (rescueState.intent.rollAngleLimitDeg < gpsRescueConfig()->angle) {
+            rescueState.intent.rollAngleLimitDeg += 0.05f;
+        } 
         if (newGPSData) {
             if (rescueState.sensor.distanceToHomeM <= rescueState.intent.descentDistanceM) {
                 rescueState.phase = RESCUE_DESCENT;

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -689,9 +689,9 @@ void descend(void)
         rescueState.intent.altitudeStep *= descentAttenuator;
     }
 
-    rescueState.intent.descentSpeedModifier = constrainf(rescueState.sensor.currentAltitudeCm / 4000.0f, 0.0f, 1.0f);
+    rescueState.intent.descentSpeedModifier = constrainf(rescueState.intent.targetAltitudeCm / 5000.0f, 0.0f, 1.0f);
     rescueState.intent.targetAltitudeCm += rescueState.intent.altitudeStep * (1.0f + (2.0f * rescueState.intent.descentSpeedModifier));
-    // increase descent rate to max of 3x default above 40m, 2x above 20m, 1.166 at 5m, default at ground level.
+    // increase descent rate to max of 3x default above 5m, 2x above 25m, 1.2 at 5m, default by ground level.
 }
 
 void altitudeAchieved(void)

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -48,6 +48,7 @@ PG_DECLARE(gpsRescueConfig_t, gpsRescueConfig);
 
 extern float gpsRescueAngle[ANGLE_INDEX_COUNT]; //NOTE: ANGLES ARE IN CENTIDEGREES
 
+void gpsRescueInit(void);
 void updateGPSRescueState(void);
 void rescueNewGpsData(void);
 

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -179,7 +179,9 @@ void calculateEstimatedAltitude()
     // favour GPS if Baro reads negative, this happens due to ground effects
     float gpsTrustModifier = gpsTrust;
     const float absDifferenceM = fabsf(altitudeToFilterCm - baroAltCm) * positionConfig()->altitude_prefer_baro / 10000.0f;
-    if (absDifferenceM > 1.0f && baroAltCm > -100.0f) { // significant difference, and baro altitude not negative
+    if (absDifferenceM > 1.0f) { // when there is a large difference, favour Baro
+        // warning: "ground effect" in last 10cm of descent causes abrupt increase in pressure
+        // this is interpreted as an abrupt fall in altitude and could cause motors to increase just as we hit ground, leading to bouncing
         gpsTrustModifier /=  absDifferenceM;
     }
     // eg if discrepancy is 3m and GPS trust was 0.9, it would now be 0.3

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -74,7 +74,7 @@ typedef enum {
     DEFAULT = 0,
     BARO_ONLY,
     GPS_ONLY
-} altitude_source_e;
+} altitudeSource_e;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(positionConfig_t, positionConfig, PG_POSITION, 4);
 

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -184,18 +184,14 @@ void calculateEstimatedAltitude()
     }
     // eg if discrepancy is 3m and GPS trust was 0.9, it would now be 0.3
 
-    // *** If we have  a GPS with 3D fix and a Baro signal, blend them
-    if (haveGpsAlt && haveBaroAlt && positionConfig()->altitude_source == DEFAULT) {
-        if (ARMING_FLAG(ARMED)) {
+    if (haveGpsAlt && !(positionConfig()->altitude_source == BARO_ONLY)) {
+        if (haveBaroAlt) { // have a baro signal, and are in GPS_ONLY or DEFAULT modes, so mix GPS and Baro
             altitudeToFilterCm = altitudeToFilterCm * gpsTrustModifier + baroAltCm * (1 - gpsTrustModifier);
+            // if we have no Baro signal, then altitudeToFilterCm and baroAltCm carry existing GPS altitude values through
         }
-
-    // *** if we only have a Baro, use it if in Default or Baro Only modes, but not if in GPS_only mode
     } else if (haveBaroAlt && (positionConfig()->altitude_source == BARO_ONLY || positionConfig()->altitude_source == DEFAULT)) {
-        altitudeToFilterCm = baroAltCm;
-        gpsAltCm = baroAltCm; // gpsAltCm will be shown in OSD or sensors while disarmed.  If no GPS it will show baro.
-
-    // we only have a Baro, but settings say don't use it, or, we have neither GPS nor Baro data; lock altitude solid at zero so the user knows
+        altitudeToFilterCm = baroAltCm; // ignore GPS altitude because we want Baro only
+        gpsAltCm = baroAltCm; // it's the gpsAltCm value that is shown in OSD before arming, so with no GPS we show Baro values
     } else {
         altitudeToFilterCm = 0.0f;
         gpsAltCm = 0.0f;

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -81,7 +81,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(positionConfig_t, positionConfig, PG_POSITION, 4
 PG_RESET_TEMPLATE(positionConfig_t, positionConfig,
     .altitude_source = DEFAULT,
     .altitude_prefer_baro = 100,
-    .altitude_lpf = 400,
+    .altitude_lpf = 300,
     .altitude_d_lpf = 100,
 );
 

--- a/src/main/flight/position.h
+++ b/src/main/flight/position.h
@@ -26,8 +26,8 @@
 typedef struct positionConfig_s {
     uint8_t altitude_source;
     uint8_t altitude_prefer_baro;
-    uint16_t altitude_lpf;                // lowpass cutoff (value / 100) Hz for baro smoothing
-    uint16_t altitude_d_lpf;                // lowpass for (value / 100) Hz baro derivative smoothing
+    uint16_t altitude_lpf;                // lowpass cutoff (value / 100) Hz for altitude smoothing
+    uint16_t altitude_d_lpf;              // lowpass for (value / 100) Hz for altitude derivative smoothing
 } positionConfig_t;
 
 PG_DECLARE(positionConfig_t, positionConfig);

--- a/src/main/flight/position.h
+++ b/src/main/flight/position.h
@@ -24,13 +24,17 @@
 
 #define TASK_ALTITUDE_RATE_HZ 120
 typedef struct positionConfig_s {
-    uint8_t altSource;
-    uint8_t altPreferBaro;
+    uint8_t altitude_source;
+    uint8_t altitude_prefer_baro;
+    uint16_t altitude_lpf;                // lowpass cutoff (value / 100) Hz for baro smoothing
+    uint16_t altitude_d_lpf;                // lowpass for (value / 100) Hz baro derivative smoothing
 } positionConfig_t;
 
 PG_DECLARE(positionConfig_t, positionConfig);
 
 bool isAltitudeOffset(void);
 void calculateEstimatedAltitude();
+void positionInit(void);
 int32_t getEstimatedAltitudeCm(void);
+float getAltitude(void);
 int16_t getEstimatedVario(void);

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -199,7 +199,7 @@ extern uint8_t GPS_svinfo_cno[GPS_SV_MAXSATS_M8N];      // Carrier to Noise Rati
 #define GPS_DBHZ_MIN 0
 #define GPS_DBHZ_MAX 55
 
-#define TASK_GPS_RATE       100
+#define TASK_GPS_RATE       120
 #define TASK_GPS_RATE_FAST  1000
 
 void gpsInit(void);

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -43,8 +43,6 @@ typedef struct barometerConfig_s {
     uint8_t baro_i2c_device;
     uint8_t baro_i2c_address;
     uint8_t baro_hardware;                  // Barometer hardware to use
-    uint16_t baro_noise_lpf;                // lowpass cutoff (value / 100) Hz for baro smoothing
-    uint16_t baro_vario_lpf;                // lowpass for (value / 100) Hz baro derivative smoothing
     ioTag_t baro_eoc_tag;
     ioTag_t baro_xclr_tag;
 } barometerConfig_t;
@@ -72,5 +70,5 @@ void baroSetGroundLevel(void);
 uint32_t baroUpdate(timeUs_t currentTimeUs);
 bool isBaroReady(void);
 bool isBaroSampleReady(void);
-float baroUpsampleAltitude(void);
+float getBaroAltitude(void);
 void performBaroCalibrationCycle(void);

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -32,8 +32,6 @@
 #include "fc/runtime_config.h"
 
 #include "flight/pid.h"
-#include "flight/position.h"
-#include "flight/gps_rescue.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -86,9 +84,6 @@ bool sensorsAutodetect(void)
 #ifdef USE_BARO
     baroInit();
 #endif
-
-positionInit();
-gpsRescueInit();
 
 #ifdef USE_RANGEFINDER
     rangefinderInit();

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -32,6 +32,8 @@
 #include "fc/runtime_config.h"
 
 #include "flight/pid.h"
+#include "flight/position.h"
+#include "flight/gps_rescue.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -45,6 +47,7 @@
 #include "sensors/initialisation.h"
 #include "sensors/rangefinder.h"
 #include "sensors/sensors.h"
+
 
 // requestedSensors is not actually used
 uint8_t requestedSensors[SENSOR_INDEX_COUNT] = { GYRO_NONE, ACC_NONE, BARO_NONE, MAG_NONE, RANGEFINDER_NONE };
@@ -83,6 +86,9 @@ bool sensorsAutodetect(void)
 #ifdef USE_BARO
     baroInit();
 #endif
+
+positionInit();
+gpsRescueInit();
 
 #ifdef USE_RANGEFINDER
     rangefinderInit();

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -36,6 +36,7 @@ extern "C" {
     #include "flight/imu.h"
     #include "flight/mixer.h"
     #include "flight/pid.h"
+    #include "flight/position.h"
     #include "flight/servos.h"
     #include "io/beeper.h"
     #include "io/gps.h"
@@ -59,6 +60,7 @@ extern "C" {
     PG_REGISTER(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 0);
     PG_REGISTER(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
     PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
+    PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 
     float rcCommand[4];
     float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
@@ -1113,5 +1115,23 @@ extern "C" {
     bool isMotorProtocolEnabled(void) { return true; }
     void pinioBoxTaskControl(void) {}
     void schedulerSetNextStateTime(timeDelta_t) {}
-    float pt1FilterGain(float, float) {return 0.5f;}
+    float getAltitude(void) { return 3000.0f; }
+    float pt1FilterGain(float, float) { return 0.5f; }
+    float pt2FilterGain(float, float)  { return 0.1f; }
+    float pt3FilterGain(float, float)  { return 0.1f; }
+    void pt2FilterInit(pt2Filter_t *throttleDLpf, float) {
+        UNUSED(throttleDLpf);
+    }
+    float pt2FilterApply(pt2Filter_t *throttleDLpf, float) {
+        UNUSED(throttleDLpf);
+        return 0.0f;
+    }
+    void pt3FilterInit(pt3Filter_t *pitchLpf, float) {
+        UNUSED(pitchLpf);
+    }
+    float pt3FilterApply(pt3Filter_t *pitchLpf, float) {
+        UNUSED(pitchLpf);
+        return 0.0f;
+    }
+
 }

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -256,6 +256,7 @@ extern "C" {
     float gyroGetFilteredDownsampled(int) { return 0.0f; }
     float baroUpsampleAltitude()  { return 0.0f; }
     float pt2FilterGain(float, float)  { return 0.0f; }
+    float getBaroAltitude(void) { return 3000.0f; }
 
     void pt2FilterInit(pt2Filter_t *baroDerivativeLpf, float) {
         UNUSED(baroDerivativeLpf);

--- a/src/test/unit/telemetry_ibus_unittest.cc
+++ b/src/test/unit/telemetry_ibus_unittest.cc
@@ -73,7 +73,7 @@ uint16_t getVbat(void)
 
 extern "C" {
 static int32_t amperage = 100;
-static int32_t estimatedVario = 0;
+static int16_t estimatedVario = 0;
 static uint8_t batteryRemaining = 0;
 static throttleStatus_e throttleStatus = THROTTLE_HIGH;
 static uint32_t definedFeatures = 0;


### PR DESCRIPTION
A long list of changes...

- fixes an issue where an under-powered quad could fail to achieve the altitude target, leading to sanity check failure and disarm.  Solved by continuing to increment the requested altitude to values above the return altitude, until either the quad reaches the altitude, or the ascent sanity check triggers (10 net seconds of less than half the target climb rate).

- fixes an issue where some slow long descents may require the target altitude decrease per unit time to be slower than the set descent rate in the late part of the descent, and this could potentially trigger the sanity check which requires at least the target descent rate to be met.  

- fixes a potential issue in the old code where if the quad was supposed to descend in the ascent phase (initiated higher than the fixed return altitude value), then the sanity check would not work.

- fixes an issue where using max_alt could sometimes result in a never-ending climb.

- improves the existing basic sensor integration of Baro and GPS data in position.c, to favour Barometer more than previously.  This is because we found that Baro was more stable, generally.  Includes logic to avoid the 'ground effect' problem where throttling up on the ground gives a transient increase in pressure below the quad, causing a false negative baro reading.  An `altitude_prefer_baro` parameter is provided in CLI, defaulting to 100, which sets the extent to which Baro data should be preferred over GPS.  When set to zero, and both Baro and GPS are used, the old GPS-dominant method is used, which typically resulted in Baro accounting for 30% of the altitude estimate.  When set to 100, Baro provides 90% of the altitude estimate.

- retains the old Vario signal with its deadband, using the same altitude D lowpass filter frequency as for GPS Rescue.  Should this Vario have it's own CLI entiy for it's smoothing requirements?

- cleans up the GPS and Baro zeroing code to ensure both zero properly on arming.

- upsamples the integrated values to return an altitude value at 120Hz.  Filters for altitude and altitude derivative can be adjusted in CLI for both the altitude value itself, and the altitude derivative.  As for gyro, these filters are sequential.  Both are PT2.  Default value is 3hz for altitude and 1hz for altitude derivative.  The result is a very much smoother and slightly more responsive altitude signal for use in GPS Rescue.

- GPS Rescue now calculates yaw, throttle and pitch at 120hz.  Yaw uses the IMU attitude.values.yaw estimate, which is updated around 100Hz.  Throttle uses the upsampled sensor integrated altitude value from position.c.  The altitude derivative is calculated from error to provide kick when target values change.  Pitch PIDs are calculated at GPS rates within GPS Rescue and the final pitch angle is smoothed and upsampled to 120Hz using a PT3 filter.

- To improve reliability of the rotation to home at the start of a rescue, the quad now flattens out and climbs vertically, and does not rotate until the target return altitude is attained.  The IMU bug which causes incorrect rotation if the quad is drifting sideways faster than 2m/s is less of a problem like this, because the quad often has slowed down to less than 2m/s, and also it will be higher up, and more likely to avoid trees if it does go off at an angle.  This IMU issue remains unresolved.

- The GPS Rescue parameter names have been re-arranged into logical sequence.  For example, settings related to the ascend phase are together, then the fly home settings, then the descend settings.  Some names could be improved, perhaps; happy to hear suggestions for improvement.  This re-naming has been applied to OSD and Blackbox.  All GPS Rescue fields and the Altitude smoothing settings are in the log header.

- Purely for experimentation, and probably not for final use, the CLI range for velocity home can be set to zero.  This results in a form of position hold, where the quad climbs and rotates to home, but does not fly home, instead it uses pitch to maintain its distance from home.  It will be blown downwind on windy days but should keep adjusting the nose to point to home, unless the drift speed exceeds 2m/s, where the IMU may get confused by sideways movement.  This does allow some testing of altitude control algorithms.  For the release PR, the minimum return speed will be 5m/s, to avoid the IMU error problem on the return leg.

- Again purely for testing, the rescue can be initiated at very low altitude, and with zero climb.  This makes for a very 'flat' rescue but is useful for testing the algorithm.  A very low rescue is best configured with a short descend distance and as low a landing altitude as can be reliably entered.

- the initial yaw rate is 180 deg/s, and instead of slamming suddenly into a yaw spin, the rate is acquired at 2 degrees per calculation, or over about half a second.  There is also a smoother transition for pitch and roll at the start.

- the descent rate is increased (up to 3x the set value), and throttle D is boosted, when the quad returns from higher altitudes.  This results in a quicker drop from significant height but gives a slow terminal descent.  The additional throttle D is needed to counter propwash problems.  There may be shaking during the faster descent period.

- the disarm on landing threshold is now an accelerometer increase of 2G, not 1G.  This reduces the chance of a false disarm during the landing phase, but appears to still disarm reliably.  A number of bugs that could cause unexpected failure during landing mode have been fixed.  Unwanted/early disarms should not occur now.

- updates the `gps_rescue_heading` debug to make it more useful in debugging the IMU problem.  Course over ground, GPS course (GPS heading), IMU heading, and the angle from quad to home are all recorded.

The end result is quite good.

I am sure that @KarateBrot and @pichimeter will improve on this; the framework here is simple enough.  At this point it provides reliable GPS Rescue with reasonable stability on most builds.