### PR TITLE
Fixes for maxAlt and gpsTrust bugs

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1030,7 +1030,7 @@ const clivalue_t valueTable[] = {
 
     { PARAM_NAME_GPS_RESCUE_DESCENT_DIST,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 5, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descentDistanceM) },
     { PARAM_NAME_GPS_RESCUE_DESCEND_RATE,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 25, 500 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, descendRate) },
-    { PARAM_NAME_GPS_RESCUE_LANDING_ALT,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 3, 15 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, targetLandingAltitudeM) },
+    { PARAM_NAME_GPS_RESCUE_LANDING_ALT,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 15 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, targetLandingAltitudeM) },
 
     { PARAM_NAME_GPS_RESCUE_THROTTLE_MIN,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMin) },
     { PARAM_NAME_GPS_RESCUE_THROTTLE_MAX,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 2000 }, PG_GPS_RESCUE, offsetof(gpsRescueConfig_t, throttleMax) },

--- a/src/main/flight/position.h
+++ b/src/main/flight/position.h
@@ -32,7 +32,6 @@ typedef struct positionConfig_s {
 
 PG_DECLARE(positionConfig_t, positionConfig);
 
-bool isAltitudeOffset(void);
 void calculateEstimatedAltitude();
 void positionInit(void);
 int32_t getEstimatedAltitudeCm(void);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -428,7 +428,7 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             }
 
             DEBUG_SET(DEBUG_BARO, 1, baro.baroTemperature);
-            DEBUG_SET(DEBUG_BARO, 2, baroAltitudeRaw - baroGroundAltitude);
+            DEBUG_SET(DEBUG_BARO, 2, baro.BaroAlt);
 
             baroSampleReady = true;
 
@@ -459,7 +459,6 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
 // baroAltitude samples baro.BaroAlt the ALTITUDE task rate
 float getBaroAltitude(void)
 {
-    DEBUG_SET(DEBUG_BARO, 3, baro.BaroAlt); // cm
     return baro.BaroAlt;
 }
 

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1099,7 +1099,6 @@ extern "C" {
     bool crashRecoveryModeActive(void) { return false; }
     int32_t getEstimatedAltitudeCm(void) { return 0; }
     bool gpsIsHealthy() { return false; }
-    bool isAltitudeOffset(void) { return false; }
     float getCosTiltAngle(void) { return 0.0f; }
     void pidSetItermReset(bool) {}
     void applyAccelerometerTrimsDelta(rollAndPitchTrims_t*) {}


### PR DESCRIPTION
This PR fixes bugs found during feedback and testing from users in Discord (thanks mouseFPV, Sek101, OlegSyr) and improves GPS Rescue smoothness and reliability

The main issue this fixes is where quads set to `baro_hardware = none` would climb indefinitely in maxAlt mode on rescue initiation

Other non-critical bugs were found in the GpsTrust algorithm, iTerm not being attenuated in the descent phase, and others.

The PIDs and filtering have been re-tuned to match faster Baro data.  Landing behaviour is more precise than before, and velocity control more accurate.  There seems to be less risk of circling around the landing point on windy days but this needs to be confirmed.

I strongly recommend people enabling Baro if it is available.  Overall altitude accuracy and control should be much better when it is enabled.  Slightly higher PIDs may be needed without Baro input.

Fixes:
- fixes indefinite climb in max_alt mode when baro hardware was
- fixes slow altitude control when baro_hardware was disabled
- the GPS trust algorithm to properly use Baro when it should, and recalculate faster
- sets rescue velocity_i correctly when descending
- prevents a transient loss of 3D fix from immediately triggering a sanity check
 
 Other changes:
-  logs the final GPS trust value, including Baro modification, not just the value from pDOP
- allows pitch and roll in landing phase, and keeps some velocity I, to minimise drift in the last few meters of the landing
- uses floats for smoothness in all places where it might help
- landing 'cylinder' radius now half the landing height
- some sanity checks will allow the quad to descend, flat, in level mode, with throttle at 75 points below the set hover throttle, for up to 75s.  It can (and will) disarm from crash protection or the usual disarm method on impact or if stuck.  This should result in a partially controlled descent with less damage than a total disarm.  It is also recoverable if switch-induced.
- PT3 filtering is used to smooth the final upsampled pitch angle, leading to smoother and more effective angle changes, and in place of the previous rate limiter on pitch angle.
- removes velocity attenuation when not pointing to home, to ensure forward velocity if the IMU has an issue at the start
- a sanity check on altitude gain applies during the climb phase as well as descent and landing.
- mproved the ascent/descent check method
- the 'min sats' sanity check monitors the presence of a 3D fix since the 3D fix can be lost with more than min sats
- roll is acquired slowly, later and more smoothly at the start
- yaw initiates more smoothly at the start
- pitch PIDs are attenuated by a factor of 0.7 during fly home phase only, to enhance smoothness in that phase.  "Normal" pitch PIDs are available in descent and landing.
- landing reliability is improved when Baro is used.  If Baro is active, ground effect when really close to the ground will increase air pressure and make the PIDs think the quad has descended abruptly.  This causes a throttle blip which can cause bouncing.  The problem is solved by lowering the threshold for disarming when throttle D rises due to the ground effect.  Result is a very soft and bounce-free landing.
- More roll than before, relative to yaw
- substantial refactoring of position.c to improve readability

This graphic shows the tracking debug, with target altitude and velocity vs the response of the quad.

The IMU issue remains, returns where the quad is drifting sideways relative to the pitch axis may get the wrong idea of where home is, and head off sideways at high speed.

![Screen Shot 2022-09-19 at 15 18 22](https://user-images.githubusercontent.com/11737748/190973648-121c6647-e3fd-4425-a52d-f3d6b0e2bb2c.jpg)

Short low quality video showing sequential landings.
https://www.youtube.com/watch?v=WMg8Mw5hasE