### PR TITLE
Watt Hours Drawn OSD Element and Post Flight Stat

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1360,6 +1360,7 @@ const clivalue_t valueTable[] = {
     { "osd_ah_pos",                 VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_ARTIFICIAL_HORIZON]) },
     { "osd_current_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CURRENT_DRAW]) },
     { "osd_mah_drawn_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_MAH_DRAWN]) },
+    { "osd_wh_drawn_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_WATT_HOURS_DRAWN]) },
     { "osd_motor_diag_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_MOTOR_DIAG]) },
     { "osd_craft_name_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CRAFT_NAME]) },
     { "osd_display_name_pos",       VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_DISPLAY_NAME]) },

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -187,6 +187,7 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
     OSD_STAT_TOTAL_FLIGHTS,
     OSD_STAT_TOTAL_TIME,
     OSD_STAT_TOTAL_DIST,
+    OSD_STAT_WATT_HOURS_DRAWN,
 };
 
 // Group elements in a number of groups to reduce task scheduling overhead
@@ -777,6 +778,14 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
         if (batteryConfig()->currentMeterSource != CURRENT_METER_NONE) {
             tfp_sprintf(buff, "%d%c", getMAhDrawn(), SYM_MAH);
             osdDisplayStatisticLabel(displayRow, "USED MAH", buff);
+            return true;
+        }
+        break;
+    
+    case OSD_STAT_WATT_HOURS_DRAWN:
+        if (batteryConfig()->currentMeterSource != CURRENT_METER_NONE) {
+            osdPrintFloat(buff, SYM_NONE, getWhDrawn(), "", 2, true, SYM_NONE);
+            osdDisplayStatisticLabel(displayRow, "USED WATT HOURS", buff);
             return true;
         }
         break;

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -161,6 +161,7 @@ typedef enum {
     OSD_TOTAL_FLIGHTS,
     OSD_UP_DOWN_REFERENCE,
     OSD_TX_UPLINK_POWER,
+    OSD_WATT_HOURS_DRAWN,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -200,6 +201,7 @@ typedef enum {
     OSD_STAT_TOTAL_TIME,
     OSD_STAT_TOTAL_DIST,
     OSD_STAT_MIN_RSSI_DBM,
+    OSD_STAT_WATT_HOURS_DRAWN,
     OSD_STAT_COUNT // MUST BE LAST
 } osd_stats_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1166,6 +1166,20 @@ static void osdElementMahDrawn(osdElementParms_t *element)
     tfp_sprintf(element->buff, "%4d%c", getMAhDrawn(), SYM_MAH);
 }
 
+static void osdElementWattHoursDrawn(osdElementParms_t *element)
+{
+    const float wattHoursDrawn = getWhDrawn();
+
+    if (wattHoursDrawn < 1.0f) {        
+        tfp_sprintf(element->buff, "%3dMWH", lrintf(wattHoursDrawn * 1000));
+    } else {
+        int wattHourWholeNumber = (int)wattHoursDrawn;
+        int wattHourDecimalValue = (int)((wattHoursDrawn - wattHourWholeNumber) * 100);
+
+        tfp_sprintf(element->buff, wattHourDecimalValue >= 10 ? "%3d.%2dWH" : "%3d.0%1dWH", wattHourWholeNumber, wattHourDecimalValue);
+    }
+}
+
 static void osdElementMainBatteryUsage(osdElementParms_t *element)
 {
     // Set length of indicator bar
@@ -1524,6 +1538,7 @@ static const uint8_t osdElementDisplayOrder[] = {
     OSD_VTX_CHANNEL,
     OSD_CURRENT_DRAW,
     OSD_MAH_DRAWN,
+    OSD_WATT_HOURS_DRAWN,
     OSD_CRAFT_NAME,
     OSD_ALTITUDE,
     OSD_ROLL_PIDS,
@@ -1610,6 +1625,7 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #endif
     [OSD_CURRENT_DRAW]            = osdElementCurrentDraw,
     [OSD_MAH_DRAWN]               = osdElementMahDrawn,
+    [OSD_WATT_HOURS_DRAWN]        = osdElementWattHoursDrawn,
 #ifdef USE_GPS
     [OSD_GPS_SPEED]               = osdElementGpsSpeed,
     [OSD_GPS_SATS]                = osdElementGpsSats,

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -120,6 +120,7 @@ bool isAmperageConfigured(void);
 int32_t getAmperage(void);
 int32_t getAmperageLatest(void);
 int32_t getMAhDrawn(void);
+float getWhDrawn(void);
 #ifdef USE_BATTERY_CONTINUE
 bool hasUsedMAh();
 void setMAhDrawn(uint32_t mAhDrawn);

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -479,6 +479,7 @@ extern "C" {
     uint16_t getBatteryAverageCellVoltage() { return  420; }
     int32_t getAmperage() { return 0; }
     int32_t getMAhDrawn() { return 0; }
+    float getWhDrawn() { return 0.0; }
     int32_t getEstimatedAltitudeCm() { return 0; }
     int32_t getEstimatedVario() { return 0; }
     int32_t blackboxGetLogNumber() { return 0; }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -100,6 +100,7 @@ extern "C" {
     uint16_t simulationBatteryVoltage;
     uint32_t simulationBatteryAmperage;
     uint32_t simulationMahDrawn;
+    float simulationWhDrawn;
     int32_t simulationAltitude;
     int32_t simulationVerticalSpeed;
     uint16_t simulationCoreTemperature;
@@ -128,6 +129,7 @@ void setDefaultSimulationState()
     simulationBatteryVoltage = 1680;
     simulationBatteryAmperage = 0;
     simulationMahDrawn = 0;
+    simulationWhDrawn = 0;
     simulationAltitude = 0;
     simulationVerticalSpeed = 0;
     simulationCoreTemperature = 0;
@@ -1322,6 +1324,10 @@ extern "C" {
 
     int32_t getMAhDrawn() {
         return simulationMahDrawn;
+    }
+
+    float getWhDrawn() {
+        return simulationWhDrawn;
     }
 
     int32_t getEstimatedAltitudeCm() {


### PR DESCRIPTION
The Watt hours used element was added per a feature request to give another way of interpreting the battery usage. It was also added as a post flight stat to show consumption similar to the mAh post flight stat. This once again is just giving pilots another option that some may find useful.

Here are the Test Files:
[betaflight_4.4.0_STM32H743.zip](https://github.com/betaflight/betaflight/files/9603890/betaflight_4.4.0_STM32H743.zip)
[betaflight_4.4.0_STM32G47X.zip](https://github.com/betaflight/betaflight/files/9603891/betaflight_4.4.0_STM32G47X.zip)
[betaflight_4.4.0_STM32F745.zip](https://github.com/betaflight/betaflight/files/9603892/betaflight_4.4.0_STM32F745.zip)
[betaflight_4.4.0_STM32F411SX1280.zip](https://github.com/betaflight/betaflight/files/9603893/betaflight_4.4.0_STM32F411SX1280.zip)
[betaflight_4.4.0_STM32F411.zip](https://github.com/betaflight/betaflight/files/9603894/betaflight_4.4.0_STM32F411.zip)
[betaflight_4.4.0_STM32F405.zip](https://github.com/betaflight/betaflight/files/9603895/betaflight_4.4.0_STM32F405.zip)
[betaflight_4.4.0_STM32F7X2.zip](https://github.com/betaflight/betaflight/files/9603896/betaflight_4.4.0_STM32F7X2.zip)


Here are instructions on installation of unified target:

[Unified Target Installation](https://www.youtube.com/watch?v=I1uN9CN30gw)