### PR TITLE
Defer DSHOT telemetry calculations to avoid overload on F411 MCUs

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -843,7 +843,8 @@ const clivalue_t valueTable[] = {
     { "dshot_burst",                VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useBurstDshot) },
 #endif
 #ifdef USE_DSHOT_TELEMETRY
-    { PARAM_NAME_DSHOT_BIDIR,        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotTelemetry) },
+    { PARAM_NAME_DSHOT_BIDIR,       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotTelemetry) },
+    { "dshot_edt",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotEdt) },
 #endif
 #ifdef USE_DSHOT_BITBANG
     { "dshot_bitbang",               VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotBitbang) },

--- a/src/main/drivers/dshot.h
+++ b/src/main/drivers/dshot.h
@@ -54,7 +54,8 @@ typedef struct dshotTelemetryQuality_s {
 extern dshotTelemetryQuality_t dshotTelemetryQuality[MAX_SUPPORTED_MOTORS];
 #endif // USE_DSHOT_TELEMETRY_STATS
 
-#define DSHOT_EXTENDED_TELEMETRY_MASK   (~(1<<DSHOT_TELEMETRY_TYPE_eRPM))
+#define DSHOT_NORMAL_TELEMETRY_MASK     (1 << DSHOT_TELEMETRY_TYPE_eRPM)
+#define DSHOT_EXTENDED_TELEMETRY_MASK   (~DSHOT_NORMAL_TELEMETRY_MASK)
 
 typedef enum dshotTelemetryType_e {
     DSHOT_TELEMETRY_TYPE_eRPM           = 0,
@@ -67,6 +68,12 @@ typedef enum dshotTelemetryType_e {
     DSHOT_TELEMETRY_TYPE_STATE_EVENTS   = 7,
     DSHOT_TELEMETRY_TYPE_COUNT          = 8
 } dshotTelemetryType_t;
+
+typedef enum dshotRawValueState_e {
+    DSHOT_RAW_VALUE_STATE_INVALID = 0,
+    DSHOT_RAW_VALUE_STATE_NOT_PROCESSED = 1,
+    DSHOT_RAW_VALUE_STATE_PROCESSED = 2
+} dshotRawValueState_t;
 
 typedef struct dshotProtocolControl_s {
     uint16_t value;
@@ -83,8 +90,9 @@ uint16_t prepareDshotPacket(dshotProtocolControl_t *pcb);
 extern bool useDshotTelemetry;
 
 typedef struct dshotTelemetryMotorState_s {
-    uint8_t telemetryTypes;
+    uint16_t rawValue;
     uint16_t telemetryData[DSHOT_TELEMETRY_TYPE_COUNT];
+    uint8_t telemetryTypes;
     uint8_t maxTemp;
 } dshotTelemetryMotorState_t;
 
@@ -96,6 +104,7 @@ typedef struct dshotTelemetryState_s {
     dshotTelemetryMotorState_t motorState[MAX_SUPPORTED_MOTORS];
     uint32_t inputBuffer[MAX_GCR_EDGES];
     uint32_t averageRpm;
+    dshotRawValueState_t rawValueState;
 } dshotTelemetryState_t;
 
 extern dshotTelemetryState_t dshotTelemetryState;
@@ -114,9 +123,4 @@ bool isDshotTelemetryActive(void);
 int16_t getDshotTelemetryMotorInvalidPercent(uint8_t motorIndex);
 
 void validateAndfixMotorOutputReordering(uint8_t *array, const unsigned size);
-
-dshotTelemetryType_t dshot_get_telemetry_type_to_decode(uint8_t motorIndex);
-uint32_t dshot_decode_telemetry_value(uint32_t value, dshotTelemetryType_t *type);
 void dshotCleanTelemetryData(void);
-void dshotUpdateTelemetryData(uint8_t motorIndex, dshotTelemetryType_t type, uint16_t value);
-

--- a/src/main/drivers/dshot_bitbang_decode.c
+++ b/src/main/drivers/dshot_bitbang_decode.c
@@ -43,7 +43,7 @@ int sequenceIndex = 0;
 #endif
 
 
-static uint32_t decode_bb_value(uint32_t value, uint16_t buffer[], uint32_t count, uint32_t bit, dshotTelemetryType_t *type)
+static uint32_t decode_bb_value(uint32_t value, uint16_t buffer[], uint32_t count, uint32_t bit)
 {
 #ifndef DEBUG_BBDECODE
     UNUSED(buffer);
@@ -75,14 +75,14 @@ static uint32_t decode_bb_value(uint32_t value, uint16_t buffer[], uint32_t coun
 #endif
         value = DSHOT_TELEMETRY_INVALID;
     } else {
-        value = dshot_decode_telemetry_value(decodedValue >> 4, type);
+        value = decodedValue >> 4;
     }
 
     return value;
 }
 
 
-uint32_t decode_bb_bitband( uint16_t buffer[], uint32_t count, uint32_t bit, dshotTelemetryType_t *type)
+uint32_t decode_bb_bitband( uint16_t buffer[], uint32_t count, uint32_t bit)
 {
 #ifdef DEBUG_BBDECODE
     memset(sequence, 0, sizeof(sequence));
@@ -193,10 +193,10 @@ uint32_t decode_bb_bitband( uint16_t buffer[], uint32_t count, uint32_t bit, dsh
         value |= 1 << (nlen - 1);
     }
 
-    return decode_bb_value(value, buffer, count, bit, type);
+    return decode_bb_value(value, buffer, count, bit);
 }
 
-FAST_CODE uint32_t decode_bb( uint16_t buffer[], uint32_t count, uint32_t bit, dshotTelemetryType_t *type)
+FAST_CODE uint32_t decode_bb( uint16_t buffer[], uint32_t count, uint32_t bit)
 {
 #ifdef DEBUG_BBDECODE
     memset(sequence, 0, sizeof(sequence));
@@ -286,7 +286,7 @@ FAST_CODE uint32_t decode_bb( uint16_t buffer[], uint32_t count, uint32_t bit, d
         value |= 1 << (nlen - 1);
     }
 
-    return decode_bb_value(value, buffer, count, bit, type);
+    return decode_bb_value(value, buffer, count, bit);
 }
 
 #endif

--- a/src/main/drivers/dshot_bitbang_decode.h
+++ b/src/main/drivers/dshot_bitbang_decode.h
@@ -24,8 +24,8 @@
 
 
 
-uint32_t decode_bb(uint16_t buffer[], uint32_t count, uint32_t mask, dshotTelemetryType_t *type);
-uint32_t decode_bb_bitband( uint16_t buffer[], uint32_t count, uint32_t bit, dshotTelemetryType_t *type);
+uint32_t decode_bb(uint16_t buffer[], uint32_t count, uint32_t mask);
+uint32_t decode_bb_bitband( uint16_t buffer[], uint32_t count, uint32_t bit);
 
 
 #endif

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -509,29 +509,32 @@ void tryArm(void)
             return;
         }
 
-
+        if (isMotorProtocolDshot()) {
 #if defined(USE_ESC_SENSOR) && defined(USE_DSHOT_TELEMETRY)
-        // Try to activate extended DSHOT telemetry only if no esc sensor exists and dshot telemetry is active
-        if (isMotorProtocolDshot() && !featureIsEnabled(FEATURE_ESC_SENSOR) && motorConfig()->dev.useDshotTelemetry) {
-            dshotCleanTelemetryData();
-            dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_EXTENDED_TELEMETRY_ENABLE, DSHOT_CMD_TYPE_INLINE);
-        }
+            // Try to activate extended DSHOT telemetry only if no esc sensor exists and dshot telemetry is active
+            if (!featureIsEnabled(FEATURE_ESC_SENSOR) && motorConfig()->dev.useDshotTelemetry) {
+                dshotCleanTelemetryData();
+                if (motorConfig()->dev.useDshotEdt) {
+                    dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_EXTENDED_TELEMETRY_ENABLE, DSHOT_CMD_TYPE_INLINE);
+                }
+            }
 #endif
 
-        if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
-            // Set motor spin direction
-            if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
-                flipOverAfterCrashActive = false;
-                if (!featureIsEnabled(FEATURE_3D)) {
-                    dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, DSHOT_CMD_TYPE_INLINE);
-                }
-            } else {
-                flipOverAfterCrashActive = true;
+            if (isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
+                // Set motor spin direction
+                if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
+                    flipOverAfterCrashActive = false;
+                    if (!featureIsEnabled(FEATURE_3D)) {
+                        dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, DSHOT_CMD_TYPE_INLINE);
+                    }
+                } else {
+                    flipOverAfterCrashActive = true;
 #ifdef USE_RUNAWAY_TAKEOFF
-                runawayTakeoffCheckDisabled = false;
+                    runawayTakeoffCheckDisabled = false;
 #endif
-                if (!featureIsEnabled(FEATURE_3D)) {
-                    dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED, DSHOT_CMD_TYPE_INLINE);
+                    if (!featureIsEnabled(FEATURE_3D)) {
+                        dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED, DSHOT_CMD_TYPE_INLINE);
+                    }
                 }
             }
         }

--- a/src/main/pg/motor.h
+++ b/src/main/pg/motor.h
@@ -44,6 +44,7 @@ typedef struct motorDevConfig_s {
     uint8_t  useUnsyncedPwm;
     uint8_t  useBurstDshot;
     uint8_t  useDshotTelemetry;
+    uint8_t  useDshotEdt;
     ioTag_t  ioTags[MAX_SUPPORTED_MOTORS];
     uint8_t  motorTransportProtocol;
     uint8_t  useDshotBitbang;


### PR DESCRIPTION
Some users have reported bidirectional dshot stopped working after installing master build 2767, produced after installing edt patch. 
https://github.com/betaflight/betaflight/issues/11848

This patch keeps edt functionality, but all telemetry calculations are deferred until DSHOT telemetry is actually requested, allowing edt on more modest MCUs, also reducing ISR overload generated by edt patch
