### PR TITLE
Dynamic airmode strength

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -655,7 +655,7 @@ const lookupTableEntry_t lookupTables[] = {
 const clivalue_t valueTable[] = {
 // PG_GYRO_CONFIG
     { PARAM_NAME_GYRO_HARDWARE_LPF, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_HARDWARE_LPF }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_hardware_lpf) },
-    
+
 #if defined(USE_GYRO_SPI_ICM20649)
     { "gyro_high_range",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_high_fsr) },
 #endif
@@ -1179,6 +1179,8 @@ const clivalue_t valueTable[] = {
 #ifdef USE_THRUST_LINEARIZATION
     { "thrust_linear",              VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearization) },
 #endif
+
+    { "airmode_transition_throttle",VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, airmode_transitioned_throttle) },
 
 #ifdef USE_AIRMODE_LPF
     { "transient_throttle_limit",   VAR_UINT8 | PROFILE_VALUE, .config.minmax = { 0, 30 }, PG_PID_PROFILE, offsetof(pidProfile_t, transient_throttle_limit) },

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -425,7 +425,7 @@ static void updateDynLpfCutoffs(timeUs_t currentTimeUs, float throttle)
 #endif
 
 static void applyMixerAdjustmentLinear(float *motorMix, const bool airmodeEnabled) {
-    const float motorMixNormalizationFactor = motorMixRange > 1.0f ? 1.0 * motorMixRange : 1.0f;
+    const float motorMixNormalizationFactor = motorMixRange > 1.0f ? 1.0 / motorMixRange : 1.0f;
     const float motorMixDelta = 0.5f * motorMixRange;
     const float preAirmodeThrottle = throttle;
     float preMotorAdjustments[MAX_SUPPORTED_MOTORS];

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -223,6 +223,8 @@ typedef struct pidProfile_s {
 
     uint8_t anti_gravity_cutoff_hz;
     uint8_t anti_gravity_p_gain;
+
+    uint8_t airmode_transitioned_throttle;  // Throttle level above which airmode is totally turned on
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -390,6 +392,8 @@ typedef struct pidRuntime_s {
 #ifdef USE_ACC
     pt3Filter_t attitudeFilter[2];  // Only for ROLL and PITCH
 #endif
+
+    float airmodeTransitionedThrottle;
 } pidRuntime_t;
 
 extern pidRuntime_t pidRuntime;
@@ -421,6 +425,9 @@ bool pidAntiGravityEnabled(void);
 float pidApplyThrustLinearization(float motorValue);
 float pidCompensateThrustLinearization(float throttle);
 #endif
+
+float calcAirmodePercent(float throttle);
+float airmodeTransition(float startThrottle, float airmodeThrottle);
 
 #ifdef USE_AIRMODE_LPF
 void pidUpdateAirmodeLpf(float currentOffset);

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -430,6 +430,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;
+
+    pidRuntime.airmodeTransitionedThrottle = pidProfile->airmode_transitioned_throttle / 100.0f;
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)
@@ -439,4 +441,3 @@ void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)
         memcpy(pidProfilesMutable(dstPidProfileIndex), pidProfilesMutable(srcPidProfileIndex), sizeof(pidProfile_t));
     }
 }
-


### PR DESCRIPTION
This is built on top of #11860. This code makes cases where airmode is off smoothly move towards full airmode strength. Currently airmode is just always on full strength when throttle is above 0.5, which could lead to some movements that are less smooth as the throttle reaches 0.5. This code should fix this and should be particularly helpful for the linear and dynamic mixer types. Currently with airmode off and throttle below 0.5 the linear and dynamic mixers act like the legacy mixer with airmode off. This creates an issue where the switch between airmode off and airmode on can be somewhat jerky.

For the legacy mixer there won't be much seen, expect for the cases previously where airmode on and legacy mixer picked caused an issue.

For discussion is whether or not there should be a way to get the old kind of airmode off behavior. I do think that this dynamic airmode strength could be an improvement for users who prefer to turn airmode off for various reasons. It may even make more users want to try airmode off with this new logic.