### PR TITLE
Remove scheduled nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,8 +15,6 @@ env:
 name: Nightly
 
 on:
-  schedule:
-    - cron: "0 1 * * *"
   push:
     branches:
       - master


### PR DESCRIPTION
For some reason we are launching nightly with each commit to master, but too once each night. The latest one is not necessary, it simply builds the same version again and again.


![image](https://user-images.githubusercontent.com/2673520/193442359-69464c9a-b678-4bb8-b475-95d942df4252.png)
