### PR TITLE
Add MSP displayport sub-command definitions

### DIFF
--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -76,7 +76,7 @@ static int grab(displayPort_t *displayPort)
 
 static int release(displayPort_t *displayPort)
 {
-    uint8_t subcmd[] = { 1 };
+    uint8_t subcmd[] = { MSP_DP_RELEASE };
 
     return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
 }
@@ -85,14 +85,14 @@ static int clearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
     UNUSED(options);
 
-    uint8_t subcmd[] = { 2 };
+    uint8_t subcmd[] = { MSP_DP_CLEAR_SCREEN };
 
     return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
 }
 
 static bool drawScreen(displayPort_t *displayPort)
 {
-    uint8_t subcmd[] = { 4 };
+    uint8_t subcmd[] = { MSP_DP_DRAW_SCREEN };
     output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
 
     return 0;
@@ -113,7 +113,7 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, uin
         len = MSP_OSD_MAX_STRING_LENGTH;
     }
 
-    buf[0] = 3;
+    buf[0] = MSP_DP_WRITE_STRING;
     buf[1] = row;
     buf[2] = col;
     buf[3] = displayPortProfileMsp()->attrValues[attr] & ~DISPLAYPORT_MSP_ATTR_BLINK & DISPLAYPORT_MSP_ATTR_MASK;

--- a/src/main/io/displayport_msp.h
+++ b/src/main/io/displayport_msp.h
@@ -24,6 +24,12 @@
 
 #include "pg/displayport_profiles.h"
 
+// MSP Display Port commands
+#define MSP_DP_RELEASE      1
+#define MSP_DP_CLEAR_SCREEN 2
+#define MSP_DP_WRITE_STRING 3
+#define MSP_DP_DRAW_SCREEN  4
+
 // MSP displayport V2 attribute byte bit functions
 #define DISPLAYPORT_MSP_ATTR_VERSION BIT(7) // Format indicator; must be zero for V2 (and V1)
 #define DISPLAYPORT_MSP_ATTR_BLINK   BIT(6) // Device local blink


### PR DESCRIPTION
Remove hardcoded sub-command numbers for MSP display port.