### PR TITLE
Ensure that airmode off to on always has a smooth transition

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -454,12 +454,8 @@ static void applyMixerAdjustmentLinear(float *motorMix, const bool airmodeEnable
         minMotor = MIN(motorMix[i], minMotor);
     }
 
-    // correct throttle so it won't clip any outputs
-    if (minMotor + throttle < 0.0f) {
-        throttle = -minMotor;
-    } else if (maxMotor + throttle > 1.0f) {
-        throttle = 1.0f - maxMotor;
-    }
+    // constrain throttle so it won't clip any outputs
+    throttle = constrainf(throttle, -minMotor, 1.0f - maxMotor);
 }
 
 static void applyMixerAdjustment(float *motorMix, const float motorMixMin, const float motorMixMax, const bool airmodeEnabled) {


### PR DESCRIPTION
Closed #11860 and #11861 in favor of this method. This code makes the airmode off on to transition smooth under all cases and mimic the desired effect of airmode off. The desired airmode behaviour (from reading what the previous code did) was to have the motor authority scaled and limited to 0.5 with throttle at 0 while linearly increasing the motor authority and limit up to 1.0 as the throttle increases to 0.5. This fix keeps that behavior while ensuring that all the edge cases where the old airmode logic was broken are accounted for.

This code also ensures that non legacy mixer types also function as expected and have a smooth airmode off to on transition similar to what was described above. This still accounts for the fact that these mixers handle the average throttle differently than the legacy mixer, so this will make airmode off for these mixer types feel even more consistent to the mixer type.

This PR lays the groundwork for an airmode strength setting. This can be done by treating the airmodeTransitionPercent value as a motor authority value, or airmode strength value. Airmode strength could for instance always be set to 0.5, or handled however future devs want to treat it. I likely won't attempt to do anything fun with the airmodeTransitionPercent and will allow others to play with that.

