### PR TITLE
Fix CMS anti gravity gain

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -503,7 +503,7 @@ static uint8_t  cmsx_horizonTransition;
 static uint8_t  cmsx_levelAngleLimit;
 static uint8_t  cmsx_throttleBoost;
 static uint8_t  cmsx_thrustLinearization;
-static uint16_t cmsx_antiGravityGain;
+static uint8_t  cmsx_antiGravityGain;
 static uint8_t  cmsx_motorOutputLimit;
 static int8_t   cmsx_autoProfileCellCount;
 #ifdef USE_D_MIN
@@ -644,7 +644,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "HORZN TRS",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonTransition,      0,    200,   1  }    },
     { "ANGLE LIMIT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_levelAngleLimit,        10,    90,   1  }    },
 
-    { "AG GAIN",     OME_UINT8,  NULL, &(OSD_UINT16_t) { &cmsx_antiGravityGain,   ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX, 10 }    },
+    { "AG GAIN",     OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &cmsx_antiGravityGain,   ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX, 1, 100 }    },
 #ifdef USE_THROTTLE_BOOST
     { "THR BOOST",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_throttleBoost,          0,    100,   1  }    },
 #endif


### PR DESCRIPTION
There's a type mismatch and wrong step size that causes anti gravity gain adjustment in cms to not work correctly.
Fixed the type and adjusted step size to from 10 to 1. This is necessary after https://github.com/betaflight/betaflight/pull/11679

EDIT: Changed it to display as float. 
with
https://github.com/betaflight/betaflight-configurator/pull/3032 and https://github.com/betaflight/betaflight-tx-lua-scripts/pull/454 it will be displayed in the same way on all clients. 
