### PR TITLE
Make anti-windup affect the gain from Anti Gravity

### DIFF
--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -498,6 +498,29 @@ TEST(pidControllerTest, testMixerSaturation)
     EXPECT_LT(pidData[FD_ROLL].I, rollTestIterm);
     EXPECT_GE(pidData[FD_PITCH].I, pitchTestIterm);
     EXPECT_LT(pidData[FD_YAW].I, yawTestIterm);
+
+    // Test that the added i term gain from Anti Gravity
+    // is also affected by itermWindup
+    resetTest();
+    ENABLE_ARMING_FLAG(ARMED);
+    pidStabilisationState(PID_STABILISATION_ON);
+
+    setStickPosition(FD_ROLL, 1.0f);
+    setStickPosition(FD_PITCH, -1.0f);
+    setStickPosition(FD_YAW, 1.0f);
+    simulatedMotorMixRange = 2.0f;
+    const bool prevAgState = pidRuntime.antiGravityEnabled;
+    const float prevAgTrhottleD = pidRuntime.antiGravityThrottleD;
+    pidRuntime.antiGravityEnabled = true;
+    pidRuntime.antiGravityThrottleD = 1.0;
+    pidController(pidProfile, currentTestTime());
+    pidRuntime.antiGravityEnabled = prevAgState;
+    pidRuntime.antiGravityThrottleD = prevAgTrhottleD;
+
+    // Expect no iterm accumulation for all axes
+    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
+    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
+    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 }
 
 // TODO - Add more scenarios


### PR DESCRIPTION
Fixes #11853 
See the issue for description and steps to replicate.
With this PR the extra I term gain from Anti Gravity is affected by anti-windup the same way as the normal I term gain.

