### PR TITLE
Fix cloud build

### DIFF
--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -22,7 +22,7 @@
 
 #include "platform.h"
 
-#ifdef USE_RX_FRSKY_SPI_X
+#if defined(USE_RX_FRSKY_SPI_X) && defined(USE_SERIALRX)
 
 #include "build/build_config.h"
 #include "build/debug.h"


### PR DESCRIPTION
Fix for cloud based support of firmware builds.

https://build.betaflight.com/api/builds/4.4.0/AG3XF4/31267d25-a831-8a42-eae8-e32162525c7b/log