### PR TITLE
Use SPI DMA for single segments if negateCS false on end marker

### DIFF
--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -36,6 +36,9 @@
 #include "drivers/io.h"
 #include "drivers/rcc.h"
 
+// Use DMA if possible if this many bytes are to be transferred
+#define SPI_DMA_THRESHOLD 8
+
 #ifndef SPI2_SCK_PIN
 #define SPI2_NSS_PIN    PB12
 #define SPI2_SCK_PIN    PB13
@@ -632,8 +635,10 @@ void spiSequenceStart(const extDevice_t *dev)
     }
 
     // Use DMA if possible
-    // If there are more than one segments, or a single segment with negateCS negated then force DMA irrespective of length
-    if (bus->useDMA && dmaSafe && ((segmentCount > 1) || (xferLen >= 8) || !bus->curSegment->negateCS)) {
+    // If there are more than one segments, or a single segment with negateCS negated in the list terminator then force DMA irrespective of length
+    if (bus->useDMA && dmaSafe && ((segmentCount > 1) ||
+                                   (xferLen >= SPI_DMA_THRESHOLD) ||
+                                   !bus->curSegment[segmentCount].negateCS)) {
         // Intialise the init structures for the first transfer
         spiInternalInitStream(dev, false);
 

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -37,6 +37,9 @@
 #include "drivers/io.h"
 #include "drivers/rcc.h"
 
+// Use DMA if possible if this many bytes are to be transferred
+#define SPI_DMA_THRESHOLD 8
+
 static SPI_InitTypeDef defaultInit = {
     .SPI_Mode = SPI_Mode_Master,
     .SPI_Direction = SPI_Direction_2Lines_FullDuplex,
@@ -364,8 +367,10 @@ void spiSequenceStart(const extDevice_t *dev)
         xferLen += checkSegment->len;
     }
     // Use DMA if possible
-    // If there are more than one segments, or a single segment with negateCS negated then force DMA irrespective of length
-    if (bus->useDMA && dmaSafe && ((segmentCount > 1) || (xferLen >= 8) || !bus->curSegment->negateCS)) {
+    // If there are more than one segments, or a single segment with negateCS negated in the list terminator then force DMA irrespective of length
+    if (bus->useDMA && dmaSafe && ((segmentCount > 1) ||
+                                   (xferLen >= SPI_DMA_THRESHOLD) ||
+                                   !bus->curSegment[segmentCount].negateCS)) {
         // Intialise the init structures for the first transfer
         spiInternalInitStream(dev, false);
 

--- a/src/main/drivers/rx/rx_sx1280.c
+++ b/src/main/drivers/rx/rx_sx1280.c
@@ -597,7 +597,7 @@ static void sx1280IrqGetStatus(extiCallbackRec_t *cb)
 
     static busSegment_t segments[] = {
             {.u.buffers = {irqStatusCmd, irqStatus}, sizeof(irqStatusCmd), true, sx1280IrqStatusRead},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     spiSequence(dev, segments);
@@ -640,7 +640,7 @@ static void sx1280IrqClearStatus(extiCallbackRec_t *cb)
 
     static busSegment_t segments[] = {
             {.u.buffers = {irqCmd, NULL}, sizeof(irqCmd), true, sx1280IrqCmdComplete},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     spiSequence(dev, segments);
@@ -673,7 +673,7 @@ static void sx1280ProcessIrq(extiCallbackRec_t *cb)
 
         static busSegment_t segments[] = {
             {.u.buffers = {cmdBufStatusCmd, bufStatus}, sizeof(cmdBufStatusCmd), true, sx1280GotFIFOAddr},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
         };
 
         spiSequence(dev, segments);
@@ -684,7 +684,7 @@ static void sx1280ProcessIrq(extiCallbackRec_t *cb)
 
         static busSegment_t segments[] = {
             {.u.buffers = {irqSetRxCmd, NULL}, sizeof(irqSetRxCmd), true, sx1280EnableIRQs},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
         };
 
         spiSequence(dev, segments);
@@ -720,7 +720,7 @@ static void sx1280DoReadBuffer(extiCallbackRec_t *cb)
     static busSegment_t segments[] = {
             {.u.buffers = {cmdReadBuf, NULL}, sizeof(cmdReadBuf), false, NULL},
             {.u.buffers = {NULL, NULL}, ELRS_RX_TX_BUFF_SIZE, true, sx1280ReadBufferComplete},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     segments[1].u.buffers.rxData = (uint8_t *)expressLrsGetRxBuffer();
@@ -752,7 +752,7 @@ static void sx1280GetPacketStats(extiCallbackRec_t *cb)
 
     static busSegment_t segments[] = {
             {.u.buffers = {getStatsCmd, stats}, sizeof(getStatsCmd), true, sx1280GetStatsCmdComplete},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     spiSequence(dev, segments);
@@ -817,7 +817,7 @@ static void sx1280SetFrequency(extiCallbackRec_t *cb)
 
     static busSegment_t segments[] = {
             {.u.buffers = {setFreqCmd, NULL}, sizeof(setFreqCmd), true, sx1280SetFreqComplete},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     spiSequence(dev, segments);
@@ -854,7 +854,7 @@ static void sx1280StartReceivingDMA(extiCallbackRec_t *cb)
 
     static busSegment_t segments[] = {
             {.u.buffers = {irqSetRxCmd, NULL}, sizeof(irqSetRxCmd), true, sx1280EnableIRQs},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     spiSequence(dev, segments);
@@ -893,7 +893,7 @@ static void sx1280SendTelemetryBuffer(extiCallbackRec_t *cb)
     static busSegment_t segments[] = {
             {.u.buffers = {writeBufferCmd, NULL}, sizeof(writeBufferCmd), false, NULL},
             {.u.buffers = {NULL, NULL}, ELRS_RX_TX_BUFF_SIZE, true, sx1280TelemetryComplete},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     segments[1].u.buffers.txData = (uint8_t *)expressLrsGetTelemetryBuffer();
@@ -925,7 +925,7 @@ static void sx1280StartTransmittingDMA(extiCallbackRec_t *cb)
 
     static busSegment_t segments[] = {
             {.u.buffers = {irqSetRxCmd, NULL}, sizeof(irqSetRxCmd), true, sx1280EnableIRQs},
-            {.u.link = {NULL, NULL}, 0, true, NULL},
+            {.u.link = {NULL, NULL}, 0, false, NULL},
     };
 
     spiSequence(dev, segments);


### PR DESCRIPTION
Fixes regression introduced in https://github.com/betaflight/betaflight/pull/11845

To force single segment SPI transfers to use DMA (for example in the ELRS RX code) set `negateCS` to `false` in the list terminator thus.

```
    static busSegment_t segments[] = {
            {.u.buffers = {irqSetRxCmd, NULL}, sizeof(irqSetRxCmd), true, sx1280EnableIRQs},
            {.u.link = {NULL, NULL}, 0, **false**, NULL},
    };
```