### PR TITLE
Add def for AKK/RDQ SmartAudio bug

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -512,6 +512,9 @@ static void saSendFrame(uint8_t *buf, int len)
         for (int i = 0 ; i < len ; i++) {
             serialWrite(smartAudioSerialPort, buf[i]);
         }
+        #ifdef USE_AKK_SMARTAUDIO
+        serialWrite(smartAudioSerialPort, 0x00); // AKK/RDQ SmartAudio devices can expect an extra byte due to manufacturing errors.
+        #endif // USE_AKK_SMARTAUDIO
 
         saStat.pktsent++;
     } else {


### PR DESCRIPTION
Add simple def to support incorrectly manufactured SmartAudio VTXs produced by AKK and RDQ.

It is anticipated that the fix will be useful to users once Cloud-Builds enable users to select optional defs like this more easily.