### PR TITLE
BMI160/270: Stronger acc anti-aliasing

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -90,6 +90,10 @@
 #define BMI160_VAL_GYRO_CONF_BWP_OSR4 0x00
 #define BMI160_VAL_GYRO_CONF_BWP_OSR2 0x10
 #define BMI160_VAL_GYRO_CONF_BWP_NORM 0x20
+#define BMI160_VAL_ACC_CONF_BWP_OSR4 0x00
+#define BMI160_VAL_ACC_CONF_BWP_OSR2 0x10
+#define BMI160_VAL_ACC_CONF_BWP_NORM 0x20
+#define BMI160_VAL_ACC_CONF_US_HP 0x00
 
 // Need to see at least this many interrupts during initialisation to confirm EXTI connectivity
 #define GYRO_EXTI_DETECT_THRESHOLD 1000
@@ -157,10 +161,13 @@ static uint8_t getBmiOsrMode(void)
             return BMI160_VAL_GYRO_CONF_BWP_OSR2;
         case GYRO_HARDWARE_LPF_OPTION_2:
             return BMI160_VAL_GYRO_CONF_BWP_NORM;
+#ifdef USE_GYRO_DLPF_EXPERIMENTAL
         case GYRO_HARDWARE_LPF_EXPERIMENTAL:
             return BMI160_VAL_GYRO_CONF_BWP_NORM;
+#endif
+        default:
+            return BMI160_VAL_GYRO_CONF_BWP_OSR4;
     }
-    return 0;
 }
 
 /**
@@ -182,8 +189,8 @@ static int32_t BMI160_Config(const extDevice_t *dev)
     }
 
     // Set odr and ranges
-    // Set acc_us = 0 acc_bwp = 0b010 so only the first filter stage is used
-    spiWriteReg(dev, BMI160_REG_ACC_CONF, 0x20 | BMI160_ODR_800_Hz);
+    // Set acc_us = 0 & acc_bwp = 0b001 for high performance and OSR2 mode
+    spiWriteReg(dev, BMI160_REG_ACC_CONF, BMI160_VAL_ACC_CONF_US_HP | BMI160_VAL_ACC_CONF_BWP_OSR2 | BMI160_ODR_800_Hz);
     delay(1);
 
     spiWriteReg(dev, BMI160_REG_GYR_CONF, getBmiOsrMode() | BMI160_ODR_3200_Hz);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -105,7 +105,7 @@ typedef enum {
     BMI270_VAL_PWR_CONF = 0x02,              // disable advanced power save, enable FIFO self-wake
     BMI270_VAL_ACC_CONF_ODR800 = 0x0B,       // set acc sample rate to 800hz
     BMI270_VAL_ACC_CONF_ODR1600 = 0x0C,      // set acc sample rate to 1600hz
-    BMI270_VAL_ACC_CONF_BWP = 0x02,          // set acc filter in normal mode
+    BMI270_VAL_ACC_CONF_BWP = 0x01,          // set acc filter in osr2 mode (only in high performance mode)
     BMI270_VAL_ACC_CONF_HP = 0x01,           // set acc in high performance mode
     BMI270_VAL_ACC_RANGE_8G = 0x02,          // set acc to 8G full scale
     BMI270_VAL_ACC_RANGE_16G = 0x03,         // set acc to 16G full scale
@@ -196,10 +196,13 @@ static uint8_t getBmiOsrMode(void)
             return BMI270_VAL_GYRO_CONF_BWP_OSR2;
         case GYRO_HARDWARE_LPF_OPTION_2:
             return BMI270_VAL_GYRO_CONF_BWP_NORM;
+#ifdef USE_GYRO_DLPF_EXPERIMENTAL
         case GYRO_HARDWARE_LPF_EXPERIMENTAL:
             return BMI270_VAL_GYRO_CONF_BWP_NORM;
+#endif
+        default:
+            return BMI270_VAL_GYRO_CONF_BWP_OSR4;
     }
-    return 0;
 }
 
 static void bmi270Config(gyroDev_t *gyro)


### PR DESCRIPTION
There might be a problem with the BMI160 and BMI270 accelerometer data. The gyro is sampling at 800Hz, while the filter cutoff is at ~400Hz. This might be too high so aliasing might be occurring.

This is a quick fix which sets the acc filter cutoff to OSR2 mode, which halves the current acc filter cutoff to ~200Hz. Unfortunately Bosch doesn't want to disclose the filter type, so it's not perfectly clear if this will suffice. But as a matter of fact this setup will definitely be better at anti-aliasing the acc signal than before.

-----

If this PR does not change the behavior of https://github.com/betaflight/betaflight/issues/11894 at all I have another idea for the culprit...