### PR TITLE
Fix chaining of FLASH SPI transactions

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -415,6 +415,7 @@ static void spiIrqHandler(const extDevice_t *dev)
             // The end of the segment list has been reached
             bus->curSegment = nextSegments;
             nextSegment->u.link.dev = NULL;
+            nextSegment->u.link.segments = NULL;
             spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -691,11 +691,12 @@ void spiSequenceStart(const extDevice_t *dev)
 
         // If a following transaction has been linked, start it
         if (bus->curSegment->u.link.dev) {
-            const extDevice_t *nextDev = bus->curSegment->u.link.dev;
-            busSegment_t *nextSegments = (busSegment_t *)bus->curSegment->u.link.segments;
             busSegment_t *endSegment = (busSegment_t *)bus->curSegment;
+            const extDevice_t *nextDev = endSegment->u.link.dev;
+            busSegment_t *nextSegments = (busSegment_t *)endSegment->u.link.segments;
             bus->curSegment = nextSegments;
             endSegment->u.link.dev = NULL;
+            endSegment->u.link.segments = NULL;
             spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -418,11 +418,12 @@ void spiSequenceStart(const extDevice_t *dev)
 
         // If a following transaction has been linked, start it
         if (bus->curSegment->u.link.dev) {
-            const extDevice_t *nextDev = bus->curSegment->u.link.dev;
-            busSegment_t *nextSegments = (busSegment_t *)bus->curSegment->u.link.segments;
             busSegment_t *endSegment = (busSegment_t *)bus->curSegment;
+            const extDevice_t *nextDev = endSegment->u.link.dev;
+            busSegment_t *nextSegments = (busSegment_t *)endSegment->u.link.segments;
             bus->curSegment = nextSegments;
             endSegment->u.link.dev = NULL;
+            endSegment->u.link.segments = NULL;
             spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -356,6 +356,13 @@ static uint32_t m25p16_pageProgramContinue(flashDevice_t *fdevice, uint8_t const
     segments[DATA1].len = bufferSizes[0];
     fdevice->callbackArg = bufferSizes[0];
 
+    /* As the DATA2 segment may be used as the terminating segment, the rxData and txData may be overwritten
+     * with a link to the following transaction (u.link.dev and u.link.segments respectively) so ensure that
+     * rxData is reinitialised otherwise it will remain pointing at a chained u.link.segments structure which
+     * would result in it being corrupted.
+     */
+    segments[DATA2].u.buffers.rxData = (uint8_t *)NULL;
+
     if (bufferCount == 1) {
         segments[DATA1].negateCS = true;
         segments[DATA1].callback = m25p16_callbackWriteComplete;


### PR DESCRIPTION
In order to queue SPI requests the terminating segment uses the `link` member of the union shown below to use the terminating (`len` = 0) segment to point to the next list of segments to transfer.

```
typedef struct busSegment_s {
    union {
        struct {
            // Transmit buffer
            uint8_t *txData;
            // Receive buffer, or in the case of the final segment to
            uint8_t *rxData;
        } buffers;
        struct {
            // Link to the device associated with the next transfer
            const extDevice_t *dev;
            // Segments to process in the next transfer.
            volatile struct busSegment_s *segments;
        } link;
    } u;
    int len;
    bool negateCS; // Should CS be negated at the end of this segment
    busStatus_e (*callback)(uint32_t arg);
} busSegment_t;
```

When writing to FLASH memory the data may be written in one or two bursts, the segment list being shown below. It can be seen that if only a single data burst is written the terminator will immediately follow it. If this terminator gets written with a link to a chained segment list this will overwrite the default values of both `dev` and `segments`, AKA `txData` and `rxData` respectively. If a subsequent transfer writes in two bursts then whilst `txData` was being set, `rxData` was not and consequently during the flash write, data (`0xFF`) was being read into the location pointed to by the old `segments` pointer, corrupting the segment list at this location.

This PR ensures that the `rxData` field of the second data block is always initialised to `NULL`.

```
    static busSegment_t segments[] = {
            {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, m25p16_callbackReady},
            {.u.buffers = {writeEnable, NULL}, sizeof(writeEnable), true, m25p16_callbackWriteEnable},
            {.u.buffers = {pageProgram, NULL}, 0, false, NULL},
            {.u.link = {NULL, NULL}, 0, true, NULL}, <-- First data block
            {.u.link = {NULL, NULL}, 0, true, NULL}, <-- Second data block or terminator
            {.u.link = {NULL, NULL}, 0, true, NULL}, <-- Terminator
    };
```