### PR TITLE
Removing 'UNIFIED_TARGET' 

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -30,6 +30,14 @@
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 
+#ifndef BOARD_NAME
+#define BOARD_NAME       FC_FIRMWARE_NAME 
+#endif
+
+#ifndef MANUFACTURER_ID
+#define MANUFACTURER_ID  FC_FIRMWARE_IDENTIFIER 
+#endif
+
 extern const char* const targetName;
 
 #define GIT_SHORT_REVISION_LENGTH   7 // lower case hexadecimal digits.

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4962,7 +4962,7 @@ static void cliTasks(const char *cmdName, char *cmdline)
 
 static void printVersion(const char *cmdName, bool printBoardInfo)
 {
-#if !(defined(USE_CUSTOM_DEFAULTS) && defined(USE_UNIFIED_TARGET))
+#if !(defined(USE_CUSTOM_DEFAULTS))
     UNUSED(cmdName);
     UNUSED(printBoardInfo);
 #endif
@@ -4997,15 +4997,11 @@ static void printVersion(const char *cmdName, bool printBoardInfo)
             cliPrintHashLine("config: YES");
         }
     } else {
-#if defined(USE_UNIFIED_TARGET)
         cliPrintError(cmdName, "NO CONFIG FOUND");
-#else
-        cliPrintHashLine("NO CUSTOM DEFAULTS FOUND");
-#endif // USE_UNIFIED_TARGET
     }
 #endif // USE_CUSTOM_DEFAULTS
 
-#if defined(USE_UNIFIED_TARGET) && defined(USE_BOARD_INFO)
+#if defined(USE_BOARD_INFO)
     if (printBoardInfo && strlen(getManufacturerId()) && strlen(getBoardName())) {
         cliPrintLinef("# board: manufacturer_id: %s, board_name: %s", getManufacturerId(), getBoardName());
     }

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -133,7 +133,7 @@ typedef enum {
 
 #define MHZ_TO_HZ(x) ((x) * 1000000)
 
-#if !defined(USE_UNIFIED_TARGET)
+#if USABLE_TIMER_CHANNEL_COUNT > 0
 extern const timerHardware_t timerHardware[];
 #endif
 

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -160,7 +160,7 @@ const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8
 
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index)
 {
-#if !defined(USE_UNIFIED_TARGET) && USABLE_TIMER_CHANNEL_COUNT > 0
+#if USABLE_TIMER_CHANNEL_COUNT > 0
     uint8_t currentIndex = 0;
     for (unsigned i = 0; i < USABLE_TIMER_CHANNEL_COUNT; i++) {
         if ((timerHardware[i].usageFlags & usageFlag) == usageFlag) {

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -684,11 +684,7 @@ void init(void)
 
     if (!sensorsAutodetect()) {
         // if gyro was not detected due to whatever reason, notify and don't arm.
-        if (true
-#if defined(USE_UNIFIED_TARGET)
-            && isSystemConfigured()
-#endif
-            ) {
+        if (isSystemConfigured()) {
             indicateFailure(FAILURE_MISSING_ACC, 2);
         }
         setArmingDisabled(ARMING_DISABLED_NO_GYRO);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -663,9 +663,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
 #if defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2)
         targetCapabilities |= BIT(TARGET_HAS_SOFTSERIAL);
 #endif
-#if defined(USE_UNIFIED_TARGET)
         targetCapabilities |= BIT(TARGET_IS_UNIFIED);
-#endif
 #if defined(USE_FLASH_BOOT_LOADER)
         targetCapabilities |= BIT(TARGET_HAS_FLASH_BOOTLOADER);
 #endif

--- a/src/main/pg/board.c
+++ b/src/main/pg/board.c
@@ -42,16 +42,7 @@ void pgResetFn_boardConfig(boardConfig_t *boardConfig)
         strncpy(boardConfig->boardName, getBoardName(), MAX_BOARD_NAME_LENGTH + 1);
         boardConfig->boardInformationSet = true;
     } else {
-#if !defined(USE_UNIFIED_TARGET)
-        strncpy(boardConfig->boardName, targetName, MAX_BOARD_NAME_LENGTH + 1);
-
-#if defined(TARGET_MANUFACTURER_IDENTIFIER)
-        strncpy(boardConfig->manufacturerId, TARGET_MANUFACTURER_IDENTIFIER, MAX_MANUFACTURER_ID_LENGTH + 1);
-#endif
-        boardConfig->boardInformationSet = true;
-#else
         boardConfig->boardInformationSet = false;
-#endif // USE_UNIFIED_TARGET
     }
 
 #if defined(USE_SIGNATURE)

--- a/src/main/pg/timerio.c
+++ b/src/main/pg/timerio.c
@@ -33,7 +33,7 @@ PG_REGISTER_ARRAY_WITH_RESET_FN(timerIOConfig_t, MAX_TIMER_PINMAP_COUNT, timerIO
 
 void pgResetFn_timerIOConfig(timerIOConfig_t *config)
 {
-#if defined(USE_TIMER_MGMT) && !defined(USE_UNIFIED_TARGET)
+#if defined(USE_TIMER_MGMT) && USABLE_TIMER_CHANNEL_COUNT > 0
     unsigned configIndex = 0;
     for (unsigned timerIndex = 0; timerIndex < USABLE_TIMER_CHANNEL_COUNT; timerIndex++) {
         const timerHardware_t *configuredTimer = &timerHardware[timerIndex];

--- a/src/main/pg/timerup.c
+++ b/src/main/pg/timerup.c
@@ -37,7 +37,7 @@ void pgResetFn_timerUpConfig(timerUpConfig_t *config)
         config[timno].dmaopt = DMA_OPT_UNUSED;
     }
 
-#if !defined(USE_UNIFIED_TARGET)
+#if USABLE_TIMER_CHANNEL_COUNT > 0
     // Scan target timerHardware and extract dma option for TIMUP
     for (unsigned i = 0; i < USABLE_TIMER_CHANNEL_COUNT; i++) {
         const timerHardware_t *timhw = &timerHardware[i];

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -51,10 +51,6 @@
 #define TARGET_IO_PORTF 0xffff
 
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -46,11 +46,6 @@
 #define TARGET_IO_PORTD 0xffff
 #define TARGET_IO_PORTE 0xffff
 
-
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X

--- a/src/main/target/STM32F411SX1280/target.h
+++ b/src/main/target/STM32F411SX1280/target.h
@@ -41,10 +41,6 @@
 #define TARGET_IO_PORTD 0xffff
 #define TARGET_IO_PORTE 0xffff
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
 #define RX_SPI_DEFAULT_PROTOCOL RX_SPI_EXPRESSLRS
 

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -52,10 +52,6 @@
 #define TARGET_IO_PORTE 0xffff
 #define TARGET_IO_PORTF 0xffff
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
 
 #define USE_RX_FRSKY_SPI_D

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -48,10 +48,6 @@
 #define TARGET_IO_PORTE 0xffff
 #define TARGET_IO_PORTF 0xffff
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
 
 #define USE_RX_FRSKY_SPI_D

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -49,10 +49,6 @@
 #define TARGET_IO_PORTE 0xffff
 #define TARGET_IO_PORTF 0xffff
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -56,10 +56,6 @@
 #define TARGET_IO_PORTF 0xffff
 #define TARGET_IO_PORTG 0xffff
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -495,12 +495,6 @@
 #endif
 
 #ifdef USE_ADC
-#if !defined(USE_UNIFIED_TARGET) && !defined(ADC_INSTANCE)
-#define ADC_INSTANCE ADC1
-#ifndef ADC1_DMA_OPT
-#define ADC1_DMA_OPT 1
-#endif
-#endif
 
 #if !defined(ADC1_DMA_OPT)
 #define ADC1_DMA_OPT (DMA_OPT_UNUSED)

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -265,15 +265,7 @@
 // Should be set to zero for generic targets to ensure USB is working
 // when unconfigured for targets with non-standard crystal.
 // Can be set at runtime with with CLI parameter 'system_hse_value'.
-#if !defined(STM32F4) || defined(USE_UNIFIED_TARGET)
 #define SYSTEM_HSE_VALUE 0
-#else
-#ifdef TARGET_XTAL_MHZ
-#define SYSTEM_HSE_VALUE TARGET_XTAL_MHZ
-#else
-#define SYSTEM_HSE_VALUE (HSE_VALUE/1000000U)
-#endif
-#endif // !STM32F4 || USE_UNIFIED_TARGET
 
 // Number of pins that needs pre-init
 #ifdef USE_SPI
@@ -357,8 +349,6 @@
 
 #if defined(USE_TIMER_MGMT)
 #undef USED_TIMERS
-#else
-#undef USE_UNIFIED_TARGET
 #endif
 
 #if !defined(USE_RANGEFINDER)

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -396,8 +396,6 @@ bool sensors(uint32_t mask)
     return false;
 };
 
-const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {};
-
 bool isArmingDisabled(void) { return false; }
 
 uint8_t getRssiPercent(void) { return 0; }

--- a/src/test/unit/timer_definition_unittest.cc
+++ b/src/test/unit/timer_definition_unittest.cc
@@ -27,7 +27,7 @@ extern "C" {
 #include <string>
 #include "gtest/gtest.h"
 
-#if !defined(USE_UNIFIED_TARGET)
+#if USABLE_TIMER_CHANNEL_COUNT > 0
 extern "C" {
     extern const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT];
 }
@@ -110,4 +110,4 @@ extern "C" {
 
     void bstInit(int) {}
 }
-#endif // USE_UNIFIED_TARGET
+#endif // USABLE_TIMER_CHANNEL_COUNT > 0


### PR DESCRIPTION
All targets are in essence unified now with cloud build.
- will remove board info (next) - this will be baked into the build.
- custom defaults is now applicable to all targets (except SITL).
