### PR TITLE
Lock altitude task at 100Hz & fix baro calibration

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -217,7 +217,7 @@ static const blackboxDeltaFieldDefinition_t blackboxMainFields[] = {
     {"magADC",      2, SIGNED,   .Ipredict = PREDICT(0),       .Iencode = ENCODING(SIGNED_VB),   .Ppredict = PREDICT(PREVIOUS),      .Pencode = ENCODING(TAG8_8SVB), CONDITION(MAG)},
 #endif
 #ifdef USE_BARO
-    {"BaroAlt",    -1, SIGNED,   .Ipredict = PREDICT(0),       .Iencode = ENCODING(SIGNED_VB),   .Ppredict = PREDICT(PREVIOUS),      .Pencode = ENCODING(TAG8_8SVB), CONDITION(BARO)},
+    {"baroAlt",    -1, SIGNED,   .Ipredict = PREDICT(0),       .Iencode = ENCODING(SIGNED_VB),   .Ppredict = PREDICT(PREVIOUS),      .Pencode = ENCODING(TAG8_8SVB), CONDITION(BARO)},
 #endif
 #ifdef USE_RANGEFINDER
     {"surfaceRaw",   -1, SIGNED,   .Ipredict = PREDICT(0),       .Iencode = ENCODING(SIGNED_VB),   .Ppredict = PREDICT(PREVIOUS),      .Pencode = ENCODING(TAG8_8SVB), CONDITION(RANGEFINDER)},
@@ -319,7 +319,7 @@ typedef struct blackboxMainState_s {
     int32_t amperageLatest;
 
 #ifdef USE_BARO
-    int32_t BaroAlt;
+    int32_t baroAlt;
 #endif
 #ifdef USE_MAG
     int16_t magADC[XYZ_AXIS_COUNT];
@@ -614,7 +614,7 @@ static void writeIntraframe(void)
 
 #ifdef USE_BARO
     if (testBlackboxCondition(CONDITION(BARO))) {
-        blackboxWriteSignedVB(blackboxCurrent->BaroAlt);
+        blackboxWriteSignedVB(blackboxCurrent->baroAlt);
     }
 #endif
 
@@ -762,7 +762,7 @@ static void writeInterframe(void)
 
 #ifdef USE_BARO
     if (testBlackboxCondition(CONDITION(BARO))) {
-        deltas[optionalFieldCount++] = blackboxCurrent->BaroAlt - blackboxLast->BaroAlt;
+        deltas[optionalFieldCount++] = blackboxCurrent->baroAlt - blackboxLast->baroAlt;
     }
 #endif
 
@@ -1101,7 +1101,7 @@ static void loadMainState(timeUs_t currentTimeUs)
     blackboxCurrent->amperageLatest = getAmperageLatest();
 
 #ifdef USE_BARO
-    blackboxCurrent->BaroAlt = baro.BaroAlt;
+    blackboxCurrent->baroAlt = baro.altitude;
 #endif
 
 #ifdef USE_RANGEFINDER

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -98,6 +98,7 @@
 #include "flight/gps_rescue.h"
 #include "flight/pid.h"
 #include "flight/pid_init.h"
+#include "flight/position.h"
 #include "flight/servos.h"
 
 #include "io/asyncfatfs/asyncfatfs.h"

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -294,23 +294,7 @@ void taskUpdateRangefinder(timeUs_t currentTimeUs)
 #endif
 
 #if defined(USE_BARO) || defined(USE_GPS)
-static bool taskAltitudeCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
-{
-    UNUSED(currentTimeUs);
-
-#if defined(USE_BARO)
-    if (isBaroSampleReady()) {
-        return true;
-    }
-#endif
-
-    if (currentDeltaTimeUs > getTask(TASK_ALTITUDE)->attribute->desiredPeriodUs) {
-        return true;
-    }
-
-    return false;
- }
- static void taskCalculateAltitude(timeUs_t currentTimeUs)
+static void taskCalculateAltitude(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
     calculateEstimatedAltitude();
@@ -395,7 +379,7 @@ task_attribute_t task_attributes[TASK_COUNT] = {
 #endif
 
 #if defined(USE_BARO) || defined(USE_GPS)
-    [TASK_ALTITUDE] = DEFINE_TASK("ALTITUDE", NULL, taskAltitudeCheck, taskCalculateAltitude, TASK_PERIOD_HZ(TASK_ALTITUDE_RATE_HZ), TASK_PRIORITY_LOW),
+    [TASK_ALTITUDE] = DEFINE_TASK("ALTITUDE", NULL, NULL, taskCalculateAltitude, TASK_PERIOD_HZ(TASK_ALTITUDE_RATE_HZ), TASK_PRIORITY_LOW),
 #endif
 
 #ifdef USE_DASHBOARD

--- a/src/main/flight/position.h
+++ b/src/main/flight/position.h
@@ -22,7 +22,8 @@
 
 #include "common/time.h"
 
-#define TASK_ALTITUDE_RATE_HZ 120
+#define TASK_ALTITUDE_RATE_HZ 100
+
 typedef struct positionConfig_s {
     uint8_t altitude_source;
     uint8_t altitude_prefer_baro;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -22,7 +22,6 @@
 
 #include "pg/pg.h"
 #include "drivers/barometer/barometer.h"
-#include "flight/position.h"
 
 typedef enum {
     BARO_DEFAULT = 0,
@@ -49,15 +48,13 @@ typedef struct barometerConfig_s {
 
 PG_DECLARE(barometerConfig_t, barometerConfig);
 
-// #define TASK_BARO_DENOM       3
-// #define TASK_BARO_RATE_HZ     (TASK_ALTITUDE_RATE_HZ / TASK_BARO_DENOM)
-#define TASK_BARO_RATE_HZ        40
+#define TASK_BARO_RATE_HZ 40                // Will be overwritten by the baro device driver
 
 typedef struct baro_s {
     baroDev_t dev;
-    float BaroAlt;
-    int32_t baroTemperature;             // Use temperature for telemetry
-    int32_t baroPressure;                // Use pressure for telemetry
+    float altitude;
+    int32_t temperature;                    // Use temperature for telemetry
+    int32_t pressure;                       // Use pressure for telemetry
 } baro_t;
 
 extern baro_t baro;
@@ -69,6 +66,4 @@ void baroStartCalibration(void);
 void baroSetGroundLevel(void);
 uint32_t baroUpdate(timeUs_t currentTimeUs);
 bool isBaroReady(void);
-bool isBaroSampleReady(void);
 float getBaroAltitude(void);
-void performBaroCalibrationCycle(void);

--- a/src/main/telemetry/frsky_hub.c
+++ b/src/main/telemetry/frsky_hub.c
@@ -219,9 +219,9 @@ static void sendTemperature1(void)
         data = escData->dataAge < ESC_DATA_INVALID ? escData->temperature : 0;
     }
 #elif defined(USE_BARO)
-    data = (baro.baroTemperature + 50)/ 100; // Airmamaf
+    data = lrintf(baro.temperature / 100.0f); // Airmamaf
 #else
-    data = gyroGetTemperature() / 10;
+    data = lrintf(gyroGetTemperature() / 10.0f);
 #endif
     frSkyHubWriteFrame(ID_TEMPRATURE1, data);
 }

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <math.h>
 
 #include "platform.h"
 #include "telemetry/telemetry.h"
@@ -219,7 +220,7 @@ static uint16_t getTemperature(void)
     uint16_t temperature = gyroGetTemperature() * 10;
 #if defined(USE_BARO)
     if (sensors(SENSOR_BARO)) {
-        temperature = (uint16_t) ((baro.baroTemperature + 50) / 10);
+        temperature = lrintf(baro.temperature / 10.0f);
     }
 #endif
     return temperature + IBUS_TEMPERATURE_OFFSET;
@@ -425,10 +426,10 @@ static void setValue(uint8_t* bufferPtr, uint8_t sensorType, uint8_t length)
 #ifdef USE_BARO
         case IBUS_SENSOR_TYPE_ALT:
         case IBUS_SENSOR_TYPE_ALT_MAX:
-            value.int32 = baro.BaroAlt;
+            value.int32 = baro.altitude;
             break;
         case IBUS_SENSOR_TYPE_PRES:
-            value.uint32 = baro.baroPressure | (((uint32_t)getTemperature()) << 19);
+            value.uint32 = baro.pressure | (((uint32_t)getTemperature()) << 19);
             break;
 #endif
 #endif //defined(TELEMETRY_IBUS_EXTENDED)

--- a/src/test/unit/rx_ibus_unittest.cc
+++ b/src/test/unit/rx_ibus_unittest.cc
@@ -42,7 +42,7 @@ extern "C" {
     uint8_t batteryCellCount = 3;
     float rcCommand[4] = {0, 0, 0, 0};
     int16_t telemTemperature1 = 0;
-    baro_t baro = { .baroTemperature = 50 };
+    baro_t baro = { .temperature = 50 };
     telemetryConfig_t telemetryConfig_System;
     timeUs_t rxFrameTimeUs(void) { return 0; }
 }

--- a/src/test/unit/rx_sumd_unittest.cc
+++ b/src/test/unit/rx_sumd_unittest.cc
@@ -41,7 +41,7 @@ extern "C" {
     uint8_t batteryCellCount = 3;
     float rcCommand[4] = {0, 0, 0, 0};
     int16_t telemTemperature1 = 0;
-    baro_t baro = { .baroTemperature = 50 };
+    baro_t baro = { .temperature = 50 };
     telemetryConfig_t telemetryConfig_System;
     timeUs_t rxFrameTimeUs(void) { return 0; }
 }


### PR DESCRIPTION
This is part 1 of a series to prepare for altitude estimations (and later on full 3-dimensional estimations) with a new sensor fusion model. Choosing a reliable task rate of 100Hz gives us about 50Hz of bandwidth (max.) to work with for translational movements of the drone. Additionally, it is a convenient divisor for most of our gyro rates to keep resampling to 100Hz for gyro fusion relatively simple.

I made several commits to make reviewing easier. Squash before merge.

## Changes
- **Lock altitude task at 100Hz** _(most important change)_
- Fix small baro calibration bug _(calibration values slightly off after first calibration)_
- Add pressure data to `DEBUG_BARO`
- Refactoring