### PR TITLE
Remove duplicate DSHOT port configuration

### DIFF
--- a/src/main/drivers/dshot_bitbang_ll.c
+++ b/src/main/drivers/dshot_bitbang_ll.c
@@ -76,12 +76,6 @@ void bbGpioSetup(bbMotor_t *bbMotor)
     {
         IOWrite(bbMotor->io, 0);
     }
-
-#if defined(STM32F7) || defined(STM32G4) || defined(STM32H7)
-    IOConfigGPIO(bbMotor->io, IO_CONFIG(GPIO_MODE_OUTPUT_PP, GPIO_SPEED_FREQ_HIGH, bbPuPdMode));
-#else
-#error MCU dependent code required
-#endif
 }
 
 void bbTimerChannelInit(bbPort_t *bbPort)

--- a/src/main/drivers/dshot_bitbang_stdperiph.c
+++ b/src/main/drivers/dshot_bitbang_stdperiph.c
@@ -71,12 +71,6 @@ void bbGpioSetup(bbMotor_t *bbMotor)
     {
         IOWrite(bbMotor->io, 0);
     }
-
-#if defined(STM32F4)
-    IOConfigGPIO(bbMotor->io, IO_CONFIG(GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, bbPuPdMode));
-#else
-#error MCU dependent code required
-#endif
 }
 
 void bbTimerChannelInit(bbPort_t *bbPort)


### PR DESCRIPTION
Following from https://github.com/betaflight/betaflight/pull/11494 which fixed the GPIO speed initialisation for bitbang DSHOT in _src/main/drivers/dshot_bitbang.c_ there was still initialisation being done in _src/main/drivers/dshot_bitbang_ll.c_ and _src/main/drivers/dshot_bitbang_stdperiph.c_ which this PR removes.

Tested on `MATEKF405TE`, `TMOTORF7` and `MAMBAH743`.