### PR TITLE
Set GPIOs to GPIO_SPEED_FREQ_LOW for timer based DSHOT

### DIFF
--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -284,7 +284,7 @@ bool pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
 #endif
     motor->timerHardware = timerHardware;
 
-    motor->iocfg = IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, pupMode);
+    motor->iocfg = IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_LOW, pupMode);
 #ifdef STM32H7
     motor->io = motorIO;
 #endif

--- a/src/main/drivers/pwm_output_dshot_hal_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal_hal.c
@@ -294,7 +294,7 @@ bool pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     }
 #endif
 
-    motor->iocfg = IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, pupMode);
+    motor->iocfg = IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_LOW, pupMode);
     const uint8_t timerIndex = getTimerIndex(timer);
     const bool configureTimer = (timerIndex == dmaMotorTimerCount - 1);
 


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/11494 showed that DSHOT GPIO ports can be run using `GPIO_SPEED_FREQ_LOW` rather than `GPIO_SPEED_FREQ_VERY_HIGH`. This PR applies that to timer based DSHOT.

Keeping edge rates as low as possible is good for EMC and we know that DSHOT switching contributes to noise on the current sense line which is an analog signal, so this is a good change from that perspective.