### PR TITLE
Fix for OSD Aux Value channel selection

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1116,8 +1116,10 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
     }
 
     if (VISIBLE(osdElementConfig()->item_pos[OSD_AUX_VALUE])) {
+        const uint8_t auxChannel = osdConfig()->aux_channel + NON_AUX_CHANNEL_COUNT - 1;
         if (currentTimeUs > osdAuxRefreshTimeUs) {
-            osdAuxValue = (constrain(rcData[osdConfig()->aux_channel - 1], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * osdConfig()->aux_scale / (PWM_RANGE_MAX - PWM_RANGE_MIN);
+            // aux channel start after main channels
+            osdAuxValue = (constrain(rcData[auxChannel], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * osdConfig()->aux_scale / PWM_RANGE;
             osdAuxRefreshTimeUs = currentTimeUs + REFRESH_1S;
         }
     }


### PR DESCRIPTION
Aux channel starts from channel 5 (if counting from 1).

PR #10789 was supposed to display in the OSD, data from the `osd_aux_channel` that was selected in the CLI.

It actually displayed values from the rcChannel, not the auxChannel, that was being requested.

This PR fixes the problem by getting values from the configured aux channel.