### PR TITLE
Adding board scratch space.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,8 @@ stm32.mak
 .vagrant
 ubuntu*.log
 
-
 # EEPROM image file (created by SITL)
 eeprom.bin
 
-# Target scratch space used for automated build API
-/src/main/target/AUTOMATED_BUILD/
+# board scratch space used for automated build API, and developers
+/src/main/board

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 
 # The target to build, see VALID_TARGETS below
 TARGET    ?= STM32F405
+BOARD     ?= 
 
 # Compile-time options
 OPTIONS   ?=
@@ -99,6 +100,11 @@ FEATURES        =
 # used to disable features based on flash space shortage (larger number => more features disabled)
 FEATURE_CUT_LEVEL_SUPPLIED := $(FEATURE_CUT_LEVEL)
 FEATURE_CUT_LEVEL =
+
+ifneq ($(BOARD),)
+# silently ignore if the file is not present. Allows for target defaults.
+-include $(ROOT)/src/main/board/$(BOARD)/board.mk
+endif
 
 include $(ROOT)/make/targets.mk
 

--- a/make/source.mk
+++ b/make/source.mk
@@ -449,6 +449,12 @@ SRC += $(MSC_SRC)
 endif
 # end target specific make file checks
 
+ifneq ($(BOARD),)
+SRC += board/$(BOARD)/board.c
+INCLUDE_DIRS += $(ROOT)/src/main/board/$(BOARD)
+TARGET_FLAGS := -D'__BOARD__="$(BOARD)"' $(TARGET_FLAGS)
+endif
+
 # Search path and source files for the ST stdperiph library
 VPATH        := $(VPATH):$(STDPERIPH_DIR)/src
 

--- a/src/link/stm32_flash_f4_split.ld
+++ b/src/link/stm32_flash_f4_split.ld
@@ -125,7 +125,8 @@ SECTIONS
     KEEP (*(.custom_defaults_end_address))
     . = ALIGN(4);
     __custom_defaults_internal_start = .;
-    *(.custom_defaults);
+    KEEP (*(.custom_defaults))
+    . = ALIGN(4);
   } >FLASH_CUSTOM_DEFAULTS
 
     PROVIDE_HIDDEN (__custom_defaults_start = DEFINED(USE_CUSTOM_DEFAULTS_EXTENDED) ? ORIGIN(FLASH_CUSTOM_DEFAULTS_EXTENDED) : __custom_defaults_internal_start);

--- a/src/link/stm32_flash_f7_split.ld
+++ b/src/link/stm32_flash_f7_split.ld
@@ -101,7 +101,8 @@ SECTIONS
     KEEP (*(.custom_defaults_end_address))
     . = ALIGN(4);
     __custom_defaults_internal_start = .;
-    *(.custom_defaults);
+    KEEP (*(.custom_defaults))
+    . = ALIGN(4);
   } >FLASH_CUSTOM_DEFAULTS
 
   PROVIDE_HIDDEN (__custom_defaults_start = DEFINED(USE_CUSTOM_DEFAULTS_EXTENDED) ? ORIGIN(FLASH_CUSTOM_DEFAULTS_EXTENDED) : __custom_defaults_internal_start);

--- a/src/link/stm32_flash_g4_split.ld
+++ b/src/link/stm32_flash_g4_split.ld
@@ -128,7 +128,8 @@ SECTIONS
     KEEP (*(.custom_defaults_end_address))
     . = ALIGN(4);
     __custom_defaults_internal_start = .;
-    *(.custom_defaults);
+    KEEP (*(.custom_defaults))
+    . = ALIGN(4);
   } >FLASH_CUSTOM_DEFAULTS
 
   PROVIDE_HIDDEN (__custom_defaults_start = DEFINED(USE_CUSTOM_DEFAULTS_EXTENDED) ? ORIGIN(FLASH_CUSTOM_DEFAULTS_EXTENDED) : __custom_defaults_internal_start);

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -30,8 +30,10 @@
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 
-#ifndef BOARD_NAME
-#define BOARD_NAME       FC_FIRMWARE_NAME 
+#ifndef __BOARD__
+#define BOARD_NAME       FC_FIRMWARE_NAME
+#else
+#define BOARD_NAME       __BOARD__
 #endif
 
 #ifndef MANUFACTURER_ID

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -222,20 +222,13 @@ static bool processingCustomDefaults = false;
 static char cliBufferTemp[CLI_IN_BUFFER_SIZE];
 
 #define CUSTOM_DEFAULTS_START_PREFIX ("# " FC_FIRMWARE_NAME)
-#define CUSTOM_DEFAULTS_MANUFACTURER_ID_PREFIX "# config: manufacturer_id: "
-#define CUSTOM_DEFAULTS_BOARD_NAME_PREFIX ", board_name: "
-#define CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX ", version: "
-#define CUSTOM_DEFAULTS_DATE_PREFIX ", date: "
 
 #define MAX_CHANGESET_ID_LENGTH 8
 #define MAX_DATE_LENGTH 20
 
 static bool customDefaultsHeaderParsed = false;
 static bool customDefaultsFound = false;
-static char customDefaultsManufacturerId[MAX_MANUFACTURER_ID_LENGTH + 1] = { 0 };
-static char customDefaultsBoardName[MAX_BOARD_NAME_LENGTH + 1] = { 0 };
-static char customDefaultsChangesetId[MAX_CHANGESET_ID_LENGTH + 1] = { 0 };
-static char customDefaultsDate[MAX_DATE_LENGTH + 1] = { 0 };
+
 #endif
 
 #if defined(USE_CUSTOM_DEFAULTS_ADDRESS)
@@ -4284,27 +4277,6 @@ static bool customDefaultsHasNext(const char *customDefaultsPtr)
     return *customDefaultsPtr && *customDefaultsPtr != 0xFF && customDefaultsPtr < customDefaultsEnd;
 }
 
-static const char *parseCustomDefaultsHeaderElement(char *dest, const char *customDefaultsPtr, const char *prefix, const char terminator, const unsigned maxLength)
-{
-    char *endPtr = NULL;
-    unsigned len = strlen(prefix);
-    if (customDefaultsPtr && customDefaultsHasNext(customDefaultsPtr) && strncmp(customDefaultsPtr, prefix, len) == 0) {
-        customDefaultsPtr += len;
-        endPtr = strchr(customDefaultsPtr, terminator);
-    }
-
-    if (endPtr && customDefaultsHasNext(endPtr)) {
-        len = endPtr - customDefaultsPtr;
-        memcpy(dest, customDefaultsPtr, MIN(len, maxLength));
-
-        customDefaultsPtr += len;
-
-        return customDefaultsPtr;
-    }
-
-    return NULL;
-}
-
 static void parseCustomDefaultsHeader(void)
 {
     const char *customDefaultsPtr = customDefaultsStart;
@@ -4315,14 +4287,6 @@ static void parseCustomDefaultsHeader(void)
         if (customDefaultsPtr && customDefaultsHasNext(customDefaultsPtr)) {
             customDefaultsPtr++;
         }
-
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsManufacturerId, customDefaultsPtr, CUSTOM_DEFAULTS_MANUFACTURER_ID_PREFIX, CUSTOM_DEFAULTS_BOARD_NAME_PREFIX[0], MAX_MANUFACTURER_ID_LENGTH);
-
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsBoardName, customDefaultsPtr, CUSTOM_DEFAULTS_BOARD_NAME_PREFIX, CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX[0], MAX_BOARD_NAME_LENGTH);
-
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsChangesetId, customDefaultsPtr, CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX, CUSTOM_DEFAULTS_DATE_PREFIX[0], MAX_CHANGESET_ID_LENGTH);
-
-        customDefaultsPtr = parseCustomDefaultsHeaderElement(customDefaultsDate, customDefaultsPtr, CUSTOM_DEFAULTS_DATE_PREFIX, '\n', MAX_DATE_LENGTH);
     }
 
     customDefaultsHeaderParsed = true;
@@ -4986,16 +4950,7 @@ static void printVersion(const char *cmdName, bool printBoardInfo)
 
 #if defined(USE_CUSTOM_DEFAULTS)
     if (hasCustomDefaults()) {
-        if (strlen(customDefaultsManufacturerId) || strlen(customDefaultsBoardName) || strlen(customDefaultsChangesetId) || strlen(customDefaultsDate)) {
-            cliPrintLinef("%s%s%s%s%s%s%s%s",
-                CUSTOM_DEFAULTS_MANUFACTURER_ID_PREFIX, customDefaultsManufacturerId,
-                CUSTOM_DEFAULTS_BOARD_NAME_PREFIX, customDefaultsBoardName,
-                CUSTOM_DEFAULTS_CHANGESET_ID_PREFIX, customDefaultsChangesetId,
-                CUSTOM_DEFAULTS_DATE_PREFIX, customDefaultsDate
-            );
-        } else {
-            cliPrintHashLine("config: YES");
-        }
+        cliPrintHashLine("config: YES");
     } else {
         cliPrintError(cmdName, "NO CONFIG FOUND");
     }

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -117,6 +117,11 @@
 #endif
 
 #include "target/common_pre.h"
+
+#ifdef __BOARD__
+#include "board.h"
+#endif
+
 #include "target.h"
 #include "target/common_deprecated_post.h"
 #include "target/common_post.h"


### PR DESCRIPTION
- Including ability to define custom defaults as char[] that is baked into the build
- removed unnecessary size of custom defaults header parsing (defines provided by build process or in board.h for devs).

Example board.c
```
#include "board.h"

const char __attribute__ ((section(".custom_defaults"), used, aligned(4))) customDefaults[] = 
    "# Betaflight\n"
    "board_name NERO\n"
    "\0";

```
board.h allows for any defines that you are working on as developers (rather than specify via command line).

board.mk allows for any additional source files, and to specify the target.

e.g. 
```
TARGET := STM32F7X2

```

NOTE: One could argue this is re-inventing the "target" directory. However it is primarily to aid in development rather than be a replacement for target.