### PR TITLE
use PWM_RANGE consistently

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -699,7 +699,7 @@ void initRcProcessing(void)
         if (tmp < 0)
             y = currentControlRateProfile->thrMid8;
         lookupThrottleRC[i] = 10 * currentControlRateProfile->thrMid8 + tmp * (100 - currentControlRateProfile->thrExpo8 + (int32_t) currentControlRateProfile->thrExpo8 * (tmp * tmp) / (y * y)) / 10;
-        lookupThrottleRC[i] = PWM_RANGE_MIN + (PWM_RANGE_MAX - PWM_RANGE_MIN) * lookupThrottleRC[i] / 1000; // [MINTHROTTLE;MAXTHROTTLE]
+        lookupThrottleRC[i] = PWM_RANGE_MIN + PWM_RANGE * lookupThrottleRC[i] / 1000; // [MINTHROTTLE;MAXTHROTTLE]
     }
 
     switch (currentControlRateProfile->rates_type) {

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -257,7 +257,7 @@ static void drawRxChannel(uint8_t channelIndex, uint8_t width)
 {
     LCDprint(rcChannelLetters[channelIndex]);
 
-    const uint32_t percentage = (constrain(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN);
+    const uint32_t percentage = (constrain(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / PWM_RANGE;
     drawHorizonalPercentageBar(width - 1, percentage);
 }
 

--- a/src/main/rx/nrf24_h8_3d.c
+++ b/src/main/rx/nrf24_h8_3d.c
@@ -131,8 +131,6 @@ STATIC_UNIT_TESTED bool h8_3dCheckBindPacket(const uint8_t *payload)
 
 STATIC_UNIT_TESTED uint16_t h8_3dConvertToPwm(uint8_t val, int16_t _min, int16_t _max)
 {
-#define PWM_RANGE (PWM_RANGE_MAX - PWM_RANGE_MIN)
-
     int32_t ret = val;
     const int32_t range = _max - _min;
     ret = PWM_RANGE_MIN + ((ret - _min) * PWM_RANGE)/range;

--- a/src/main/rx/nrf24_syma.c
+++ b/src/main/rx/nrf24_syma.c
@@ -150,14 +150,14 @@ STATIC_UNIT_TESTED bool symaCheckBindPacket(const uint8_t *packet)
 STATIC_UNIT_TESTED uint16_t symaConvertToPwmUnsigned(uint8_t val)
 {
     uint32_t ret = val;
-    ret = ret * (PWM_RANGE_MAX - PWM_RANGE_MIN) / UINT8_MAX + PWM_RANGE_MIN;
+    ret = ret * PWM_RANGE / UINT8_MAX + PWM_RANGE_MIN;
     return (uint16_t)ret;
 }
 
 STATIC_UNIT_TESTED uint16_t symaConvertToPwmSigned(uint8_t val)
 {
     int32_t ret = val & 0x7f;
-    ret = (ret * (PWM_RANGE_MAX - PWM_RANGE_MIN)) / (2 * INT8_MAX);
+    ret = ret * PWM_RANGE / (2 * INT8_MAX);
     if (val & 0x80) {// sign bit set
         ret = -ret;
     }


### PR DESCRIPTION
Quick little PR unimportant refactor, to use `PWM_RANGE` instead of `PWM_RANGE_MAX - PWM_RANGE_MIN`.