### PR TITLE
ztpa attenuate P I and D, but not F, below a set throttle threshold

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1379,10 +1379,12 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_RELAX_CUTOFF, "%d",     currentPidProfile->iterm_relax_cutoff);
 #endif
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_PID_AT_MIN_THROTTLE, "%d",    currentPidProfile->pidAtMinThrottle);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ZTPA_PID_PERCENT, "%d",       currentPidProfile->ztpa_pid_percent);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ZTPA_THROTTLE_THRESHOLD, "%d", currentPidProfile->ztpa_throttle_threshold);
 
         // Betaflight PID controller parameters
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANTI_GRAVITY_GAIN, "%d",      currentPidProfile->anti_gravity_gain);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANTI_GRAVITY_CUTOFF_HZ, "%d",    currentPidProfile->anti_gravity_cutoff_hz);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANTI_GRAVITY_CUTOFF_HZ, "%d", currentPidProfile->anti_gravity_cutoff_hz);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANTI_GRAVITY_P_GAIN, "%d",    currentPidProfile->anti_gravity_p_gain);
 
 #ifdef USE_ABSOLUTE_CONTROL

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1081,10 +1081,12 @@ const clivalue_t valueTable[] = {
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     { PARAM_NAME_VBAT_SAG_COMPENSATION, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, vbat_sag_compensation) },
 #endif
-    { PARAM_NAME_PID_AT_MIN_THROTTLE, VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, pidAtMinThrottle) },
-    { PARAM_NAME_ANTI_GRAVITY_GAIN,   VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, anti_gravity_gain) },
-    { PARAM_NAME_ANTI_GRAVITY_CUTOFF_HZ, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 2, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, anti_gravity_cutoff_hz) },
-    { PARAM_NAME_ANTI_GRAVITY_P_GAIN, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, anti_gravity_p_gain) },
+    { PARAM_NAME_PID_AT_MIN_THROTTLE,     VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, pidAtMinThrottle) },
+    { PARAM_NAME_ZTPA_PID_PERCENT,        VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, ztpa_pid_percent) },
+    { PARAM_NAME_ZTPA_THROTTLE_THRESHOLD, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 2, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, ztpa_throttle_threshold) },
+    { PARAM_NAME_ANTI_GRAVITY_GAIN,       VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, anti_gravity_gain) },
+    { PARAM_NAME_ANTI_GRAVITY_CUTOFF_HZ,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 2, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, anti_gravity_cutoff_hz) },
+    { PARAM_NAME_ANTI_GRAVITY_P_GAIN,     VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, anti_gravity_p_gain) },
     { PARAM_NAME_ACC_LIMIT_YAW,     VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yawRateAccelLimit) },
     { PARAM_NAME_ACC_LIMIT,         VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, rateAccelLimit) },
     { "crash_dthreshold",           VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 2000 }, PG_PID_PROFILE, offsetof(pidProfile_t, crash_dthreshold) },

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -201,7 +201,7 @@ bool canUseLaunchControl(void)
     if (!isFixedWing()
         && !isUsingSticksForArming()     // require switch arming for safety
         && IS_RC_MODE_ACTIVE(BOXLAUNCHCONTROL)
-        && (!featureIsEnabled(FEATURE_MOTOR_STOP) || airmodeIsEnabled())  // can't use when motors are stopped
+        && airmodeIsEnabled()  // if motor_stop is active, pilot will need to provide a bit of throttle
         && !featureIsEnabled(FEATURE_3D) // pitch control is not 3D aware
         && (flightModeFlags == 0)) {     // don't want to use unless in acro mode
         return true;

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -69,6 +69,8 @@
 #define PARAM_NAME_DTERM_NOTCH_CUTOFF "dterm_notch_cutoff"
 #define PARAM_NAME_VBAT_SAG_COMPENSATION "vbat_sag_compensation"
 #define PARAM_NAME_PID_AT_MIN_THROTTLE "pid_at_min_throttle"
+#define PARAM_NAME_ZTPA_PID_PERCENT "ztpa_pid_percent"
+#define PARAM_NAME_ZTPA_THROTTLE_THRESHOLD "ztpa_throttle_threshold"
 #define PARAM_NAME_ANTI_GRAVITY_GAIN "anti_gravity_gain"
 #define PARAM_NAME_ANTI_GRAVITY_CUTOFF_HZ "anti_gravity_cutoff_hz"
 #define PARAM_NAME_ANTI_GRAVITY_P_GAIN "anti_gravity_p_gain"

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -549,6 +549,9 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
     updateDynLpfCutoffs(currentTimeUs, throttle);
 #endif
 
+    // send throttle value to attenuate PIDs with when low
+    ztpaUpdate(throttle);
+
     // apply throttle boost when throttle moves quickly
 #if defined(USE_THROTTLE_BOOST)
     if (throttleBoost > 0.0f) {
@@ -628,7 +631,6 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
     if (featureIsEnabled(FEATURE_MOTOR_STOP)
         && ARMING_FLAG(ARMED)
         && !mixerRuntime.feature3dEnabled
-        && !airmodeEnabled
         && !FLIGHT_MODE(GPS_RESCUE_MODE)   // disable motor_stop while GPS Rescue is active
         && (rcData[THROTTLE] < rxConfig()->mincheck)) {
         // motor_stop handling

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -232,6 +232,8 @@ typedef struct pidProfile_s {
     uint8_t anti_gravity_p_gain;
     uint8_t tpa_rate;                       // Percent reduction in P or D at full throttle
     uint16_t tpa_breakpoint;                // Breakpoint where TPA is activated
+    uint8_t ztpa_pid_percent;               // Amount to attenuate P, I and D by at zero throttle, linearly increasing attenuation below airmode throttle point
+    uint8_t ztpa_throttle_threshold;        // Throttle threshold below which to attenuate P, I and D linearly towards the attenuation amount at zero throttle
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -316,6 +318,10 @@ typedef struct pidRuntime_s {
     bool zeroThrottleItermReset;
     bool levelRaceMode;
     float tpaFactor;
+    bool ztpaShouldApply;
+    float ztpaPidPercent;
+    float ztpaThrottleThreshold;
+    float ztpaAttenuation;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
@@ -424,6 +430,7 @@ bool crashRecoveryModeActive(void);
 void pidAcroTrainerInit(void);
 void pidSetAcroTrainerState(bool newState);
 void pidUpdateTpaFactor(float throttle);
+void ztpaUpdate(float throttle);
 void pidUpdateAntiGravityThrottleFilter(float throttle);
 bool pidOsdAntiGravityActive(void);
 void pidSetAntiGravityState(bool newState);

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -430,6 +430,9 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;
+    pidRuntime.ztpaShouldApply = pidProfile->ztpa_pid_percent < 100;
+    pidRuntime.ztpaPidPercent = (float)pidProfile->ztpa_pid_percent / 100.0f;
+    pidRuntime.ztpaThrottleThreshold = (float)pidProfile->ztpa_throttle_threshold / 100.0f;
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)


### PR DESCRIPTION
DO NOT MERGE!  FOR TESTING PURPOSES ONLY!  

This PR is **only** here so that people can experiment with the concepts of `ztpa` and `motor_stop`.  It would require a lot more work to be ready to merge. 

I'm happy 
This PR does two main things:
- allows motor_stop when air mode is active.  By default it is off.
- allows a kind of zero throttle TPA, or `ZTPA`, where PIDs are attenuated at the low throttle end.  By default it is off.

**Purpose:** to facilitate perching, or landing on small objects, and to permit bounce-free landings

**WARNING:**  if you `motor_stop` is enabled, the motors *will not spin while armed!*  This is **DANGEROUS** since you may not realise that you are armed, bump the throttle, and have the quad leap into the air and hit you or someone else.  **PLEASE TAKE CARE!**

### 1.  motor_stop

This will stop the motors whenever throttle is below min_throttle (default of 1070), regardless of airmode state.  The quad will go wonky and not respond to any stick inputs as soon as the motors stop.  

If the radio is good, you can set min_throttle to a very low value, eg 1020, and motors will stop only when throttle is below 2%.  Then, only a tiny amount of throttle while flying will keep everything 'normal'.  

Some throttle must be manually held on (the famous 'idle up' trick of experienced FPV masters) during flips, rolls, inverted, etc, to keep the motors running.  On the other hand. when you 'perch', or land, bringing throttle to zero will instantly stop the motors, and there will be absolutely no bouncing or PID reaction.  The quad can be stabilised after landing by bringing throttle just above min_throttle, where the motors will re-start with full PID stability.

This can also be used by whoop pilots to 'un-stick' from a wall; put throttle to zero and it will immediately un-stick.  Of course, the pilot will need to keep some 'idle up' the whole time, in-flight.  

### 2.  ztpa

This works like TPA but at the 'bottom end' of the throttle.  P and D will be attenuated by the specified percentage, and iTerm accumulation will be reduced, at zero throttle, and rise linearly back to normal when throttle hits threshold.  Just like reducing the P, I and D 'tuning' values.  Feedforward is not affected.

`ztpa_pid_percent` : the PID value you will get at zero throttle (default 100%, range 0-100%)
`ztpa_throttle_threshold` : the throttle value at which PIDs are normal (default 10%, range 2-100%)

To be honest I find this to not be very helpful.  

Most quads will still bounce on landing even with heavy reductions in PID at zero throttle, not many quads are stable with meaningful reductions in PIDs at zero throttle.  