### PR TITLE
Only declare attitudeIsEstablished if USE_ACC is defined

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -99,7 +99,9 @@ static imuRuntimeConfig_t imuRuntimeConfig;
 
 float rMat[3][3];
 
+#if defined(USE_ACC)
 STATIC_UNIT_TESTED bool attitudeIsEstablished = false;
+#endif
 
 // quaternion of sensor frame relative to earth frame
 STATIC_UNIT_TESTED quaternion q = QUATERNION_INITIALIZE;

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -86,6 +86,14 @@
 
 #include "acceleration_init.h"
 
+#if !defined(USE_ACC_MPU6500) && !defined(USE_ACC_SPI_MPU6000) && !defined(USE_ACC_SPI_MPU6500) &&  \
+    !defined(USE_ACC_SPI_ICM20689) && !defined(USE_ACCGYRO_LSM6DSO) && !defined(USE_ACCGYRO_BMI160) && \
+    !defined(USE_ACCGYRO_BMI270) && !defined(USE_ACC_SPI_ICM42605) && !defined(USE_ACC_SPI_ICM42688P) && \
+    !defined(USE_ACC_ADXL345) && !defined(USE_ACC_BMA280) && !defined(USE_ACC_LSM303DLHC) && \
+    !defined(USE_ACC_MMA8452) && !defined(USE_FAKE_ACC)
+#error At least one USE_ACC device definition required
+#endif
+
 #define CALIBRATING_ACC_CYCLES              400
 
 FAST_DATA_ZERO_INIT accelerationRuntime_t accelerationRuntime;


### PR DESCRIPTION
Needed if USE_ACC isn't defined in build configuration.

Also check that if USE_ACC is defined, then at least one USE_ACC* definition is given.