### PR TITLE
Fix USE_MAX7456

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -232,10 +232,6 @@
 #define USE_USB_ADVANCED_PROFILES
 #endif
 
-#if defined(USE_MAX7456)
-#define USE_OSD
-#endif
-
 #if !defined(USE_OSD)
 #undef USE_RX_LINK_QUALITY_INFO
 #undef USE_OSD_PROFILES


### PR DESCRIPTION
Fix #define USE_MAX7456 in unified targets for cloud build system