### PR TITLE
Fix debug GPS_DOP

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -105,5 +105,6 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "GPS_RESCUE_HEADING",
     "GPS_RESCUE_TRACKING",
     "ATTITUDE",
-    "VTX_MSP"
+    "VTX_MSP",
+    "GPS_DOP",
 };


### PR DESCRIPTION
Forgot to add `GPS_DOP` to the end of `debugModeNames` to make the debug mode usable.

More information in the corresponding main PR https://github.com/betaflight/betaflight/pull/11912