### PR TITLE
Add G4 SX1280 unified target

### DIFF
--- a/src/main/target/STM32G47XSX1280/target.c
+++ b/src/main/target/STM32G47XSX1280/target.c
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Needed to suppress the pedantic warning about an empty file
+#include <stddef.h>

--- a/src/main/target/STM32G47XSX1280/target.h
+++ b/src/main/target/STM32G47XSX1280/target.h
@@ -65,9 +65,6 @@
 #define USE_I2C
 #define I2C_FULL_RECONFIGURABILITY
 
-#define USE_MAG
-#define USE_BARO
-
 #define USE_BEEPER
 
 #if !defined(CLOUD_BUILD)
@@ -76,6 +73,8 @@
 
 #define USE_ACC
 #define USE_GYRO
+#define USE_MAG
+#define USE_BARO
 
 #define USE_ACC_MPU6500
 #define USE_GYRO_MPU6500

--- a/src/main/target/STM32G47XSX1280/target.h
+++ b/src/main/target/STM32G47XSX1280/target.h
@@ -1,0 +1,163 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#define TARGET_BOARD_IDENTIFIER "SGSX"
+
+#define USBD_PRODUCT_STRING     "Betaflight STM32G47xSX1280"
+
+#define USE_I2C_DEVICE_1
+#define USE_I2C_DEVICE_2
+#define USE_I2C_DEVICE_3
+#define USE_I2C_DEVICE_4
+
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_LPUART1
+
+#define SERIAL_PORT_COUNT       (UNIFIED_SERIAL_PORT_COUNT + 6)
+
+#define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_2
+#define USE_SPI_DEVICE_3
+#define USE_SPI_DEVICE_4
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+#define TARGET_IO_PORTF 0xffff
+
+// Treat the target as unified, and expect manufacturer id / board name
+// to be supplied when the board is configured for the first time
+#define USE_UNIFIED_TARGET
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
+#define RX_SPI_DEFAULT_PROTOCOL RX_SPI_EXPRESSLRS
+
+#define USE_RX_EXPRESSLRS
+#define USE_RX_EXPRESSLRS_TELEMETRY
+#define USE_RX_SX1280
+#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
+#define RX_CHANNELS_AETR
+
+#define USE_I2C
+#define I2C_FULL_RECONFIGURABILITY
+
+#define USE_MAG
+#define USE_BARO
+
+#define USE_BEEPER
+
+#if !defined(CLOUD_BUILD)
+
+// MPU interrupt
+
+#define USE_ACC
+#define USE_GYRO
+
+#define USE_ACC_MPU6500
+#define USE_GYRO_MPU6500
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define USE_ACC_SPI_ICM20689
+#define USE_GYRO_SPI_ICM20689
+#define USE_ACCGYRO_LSM6DSO
+#define USE_ACCGYRO_BMI270
+#define USE_GYRO_SPI_ICM42605
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42605
+#define USE_ACC_SPI_ICM42688P
+
+#ifdef USE_MAG
+#define USE_MAG_DATA_READY_SIGNAL
+#define USE_MAG_HMC5883
+#define USE_MAG_SPI_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_LIS3MDL
+#define USE_MAG_AK8963
+#define USE_MAG_MPU925X_AK8963
+#define USE_MAG_SPI_AK8963
+#define USE_MAG_AK8975
+#endif
+
+#ifdef USE_BARO
+#define USE_BARO_MS5611
+#define USE_BARO_SPI_MS5611
+#define USE_BARO_BMP280
+#define USE_BARO_SPI_BMP280
+#define USE_BARO_BMP388
+#define USE_BARO_SPI_BMP388
+#define USE_BARO_LPS
+#define USE_BARO_SPI_LPS
+#define USE_BARO_QMP6988
+#define USE_BARO_SPI_QMP6988
+#define USE_BARO_DPS310
+#define USE_BARO_SPI_DPS310
+#endif
+
+#define USE_FLASHFS
+#define USE_FLASH_TOOLS
+#define USE_FLASH_M25P16
+#define USE_FLASH_W25N01G          // 1Gb NAND flash support
+#define USE_FLASH_W25M             // Stacked die support
+#define USE_FLASH_W25M512          // 512Kb (256Kb x 2 stacked) NOR flash support
+#define USE_FLASH_W25M02G          // 2Gb (1Gb x 2 stacked) NAND flash support
+#define USE_FLASH_W25Q128FV        // 16MB Winbond 25Q128
+
+#define USE_MAX7456
+
+#define USE_RX_SPI
+#define USE_ACC_MPU6050
+#define USE_GYRO_MPU6050
+#define USE_ACCGYRO_BMI160
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_HCSR04
+#define USE_RANGEFINDER_TF
+
+#endif // cloud_build
+
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+
+#define USE_SPI
+#define SPI_FULL_RECONFIGURABILITY
+
+#define USE_VCP
+
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+#define UNIFIED_SERIAL_PORT_COUNT       3
+
+#define USE_USB_DETECT
+
+#define USE_ESCSERIAL
+
+#define USE_ADC
+
+#define USE_CUSTOM_DEFAULTS

--- a/src/main/target/STM32G47XSX1280/target.h
+++ b/src/main/target/STM32G47XSX1280/target.h
@@ -49,10 +49,6 @@
 #define TARGET_IO_PORTE 0xffff
 #define TARGET_IO_PORTF 0xffff
 
-// Treat the target as unified, and expect manufacturer id / board name
-// to be supplied when the board is configured for the first time
-#define USE_UNIFIED_TARGET
-
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SPI
 #define RX_SPI_DEFAULT_PROTOCOL RX_SPI_EXPRESSLRS
 

--- a/src/main/target/STM32G47XSX1280/target.mk
+++ b/src/main/target/STM32G47XSX1280/target.mk
@@ -1,0 +1,21 @@
+RX_SRC = \
+    drivers/rx/expresslrs_driver.c \
+    drivers/rx/rx_sx127x.c \
+    drivers/rx/rx_sx1280.c \
+    rx/expresslrs.c \
+    rx/expresslrs_common.c \
+    rx/expresslrs_telemetry.c \
+
+G47X_TARGETS += $(TARGET)
+
+FEATURES       += VCP SDCARD_SPI ONBOARDFLASH
+
+TARGET_SRC = \
+    $(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+    $(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
+    $(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
+    $(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \
+    drivers/max7456.c \
+    drivers/vtx_rtc6705.c \
+    drivers/vtx_rtc6705_soft_spi.c \
+    $(RX_SRC)


### PR DESCRIPTION
This PR adds a unified target for G4 with SX1280 (integrated SPI radio control receiver; ExpressLRS etc). This is currently required in order to support flight controllers that use a STM32G473, G474, G483, and G484 MCU, in conjunction with an SX1280/SX1281 radio controller. It is based on the `STM32G47X` and `STM32F411SX1280` targets. Tested on a G473 FC.