### PR TITLE
Fix F411 target

### DIFF
--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -46,7 +46,7 @@
 #define TARGET_IO_PORTD 0xffff
 #define TARGET_IO_PORTE 0xffff
 
-#if defined(USE_RX_SPI) || !defined(CLOUD_BUILD)
+#if defined(USE_RX_SPI) && !defined(CLOUD_BUILD)
 #define USE_RX_FRSKY_SPI_D
 #define USE_RX_FRSKY_SPI_X
 #define USE_RX_SFHSS_SPI


### PR DESCRIPTION
Fixes cloud build for RX_SPI

https://build.betaflight.com/api/builds/4.4.0/BETAFPVF4SX1280/f2badbeb-7c4d-c40c-ba99-b21b9f766c7a/log

Tested on Betafpv STM32F411 with SX1280 ELRS (SPI)