### PR TITLE
Fix ATTITUDE task rate

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1013,7 +1013,7 @@ void processRxModes(timeUs_t currentTimeUs)
         rescheduleTask(TASK_ATTITUDE, TASK_PERIOD_HZ(acc.sampleRateHz / (float)imuConfig()->imu_process_denom));
     } else {
         LED1_OFF;
-        rescheduleTask(TASK_ATTITUDE, TASK_PERIOD_HZ(acc.sampleRateHz / 10.0f));
+        rescheduleTask(TASK_ATTITUDE, TASK_PERIOD_HZ(100));
     }
 
     if (!IS_RC_MODE_ACTIVE(BOXPREARM) && ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {


### PR DESCRIPTION
I noticed that the `ATTITUDE` task was running at 80Hz on a BMI270 when I was in acro mode (= not angle or horizon mode). This is because on this gyro the maximum accelerometer sample rate is 800Hz, not the usual 1000Hz default acc rate of Betaflight. So the `ATTITUDE` task was running at 80Hz (instead of the desired 100Hz).

This PR fixes this to make the `ATTITUDE` task always run at 100Hz in acro mode, independent from acc hardware used.