### PR TITLE
Compatability with older MSP implementations for "name" field

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1532,7 +1532,8 @@ static void osdElementWarnings(osdElementParms_t *element)
             }
             #endif // USE_RX_LINK_QUALITY_INFO
         }
-        strncpy(pilotConfigMutable()->craftName, element->buff, MAX_NAME_LENGTH - 1);
+	// Use the old "name" instead of "craftName" because older MSP implementations rely on this field.
+        strncpy(pilotConfigMutable()->name, element->buff, MAX_NAME_LENGTH - 1);
     }
     #endif // USE_CRAFTNAME_MSGS
 }


### PR DESCRIPTION
Fix compatibility with older MSP implementations which was the use case for the OSD_CRAFTNAME_MSGS feature.

To fix https://github.com/betaflight/betaflight/issues/11977