### PR TITLE
Fix getRssiDbm compiler error

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1507,22 +1507,24 @@ static void osdElementWarnings(osdElementParms_t *element)
         CLR_BLINK(OSD_WARNINGS);
     }
 
-    #ifdef USE_CRAFTNAME_MSGS
+#ifdef USE_CRAFTNAME_MSGS
     // Injects data into the CraftName variable for systems which limit
     // the available MSP data field in their OSD.
     if (osdConfig()->osd_craftname_msgs == true) {
         // if warning is not set, or blink is off, then display LQ & RSSI
         if (blinkState || (strlen(element->buff) == 0)) {
-            #ifdef USE_RX_LINK_QUALITY_INFO
+#ifdef USE_RX_LINK_QUALITY_INFO
             // replicate the LQ functionality without the special font symbols
             uint16_t osdLinkQuality = 0;
             if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_CRSF) { // 0-99
                 osdLinkQuality = rxGetLinkQuality();
+#ifdef USE_RX_RSSI_DBM
                 const uint8_t osdRfMode = rxGetRfMode();
                 tfp_sprintf(element->buff, "LQ %2d:%03d %3d", osdRfMode, osdLinkQuality, getRssiDbm());
             } else if (linkQualitySource == LQ_SOURCE_RX_PROTOCOL_GHST) { // 0-100
                 osdLinkQuality = rxGetLinkQuality();
                 tfp_sprintf(element->buff, "LQ %03d %3d", osdLinkQuality, getRssiDbm());
+#endif
             } else { // 0-9
                 osdLinkQuality = rxGetLinkQuality() * 10 / LINK_QUALITY_MAX_VALUE;
                 if (osdLinkQuality >= 10) {
@@ -1530,11 +1532,11 @@ static void osdElementWarnings(osdElementParms_t *element)
                 }
                 tfp_sprintf(element->buff, "LQ %1d", osdLinkQuality);
             }
-            #endif // USE_RX_LINK_QUALITY_INFO
+#endif // USE_RX_LINK_QUALITY_INFO
         }
         strncpy(pilotConfigMutable()->craftName, element->buff, MAX_NAME_LENGTH - 1);
     }
-    #endif // USE_CRAFTNAME_MSGS
+#endif // USE_CRAFTNAME_MSGS
 }
 
 // Define the order in which the elements are drawn.


### PR DESCRIPTION
Fixes compiler error on command:

`make TARGET=STM32F7X2 EXTRA_FLAGS="-DCLOUD_BUILD -DUSE_SERIAL_RX -DUSE_SERIALRX_GHST -DUSE_TELEMETRY -DUSE_TELEMETRY_GHST -DUSE_GPS -DUSE_LED -DUSE_OSD -DUSE_FLASH -DUSE_BARO_BMP280 -DUSE_ACC_SPI_ICM20689 -DUSE_ACC_SPI_MPU600 -DUSE_GYRO_SPI_ICM20689 -DUSE_GYRO_SPI_MPU6000 -DUSE_MAX7456 -DUSE_GYRO -DUSE_ACC"`