### PR TITLE
Fix RPM Filter copy instructions

### DIFF
--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -161,10 +161,11 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
         // update notch
         biquadFilterUpdate(template, frequencyHz, rpmFilter.looptimeUs, rpmFilter.q, FILTER_NOTCH, weight);
 
-        // copy notch properties to corresponding notches (clones) on PITCH and YAW
+        // copy notch properties to corresponding notches on PITCH and YAW
         for (int axis = 1; axis < XYZ_AXIS_COUNT; axis++) {
-            biquadFilter_t *clone = &rpmFilter.notch[axis][motorIndex][harmonicIndex];
-            memcpy(clone, template, sizeof(biquadFilter_t));
+            biquadFilter_t *src = template;
+            biquadFilter_t *dst = &rpmFilter.notch[axis][motorIndex][harmonicIndex];
+            memcpy(dst, src, sizeof(biquadFilter_t));
         }
 
         // cycle through all notches on ROLL (takes RPM_FILTER_DURATION_S at max.)


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/11985

## How to test

Before you do anything please enable blackbox logging and then go to the CLI to type:
```
set debug_mode = GYRO_SAMPLE
set gyro_filter_debug_axis = YAW
save
```
This will enable a debug mode where I can see what the RPM filter does before and after filtering on the pitch axis. The code change from above only gets applied to pitch and yaw axes, so it's  important the debug axis is NOT roll.

Now you can test carefully if the quad flips out again.
- If it flips out, please provide me with the log
- If it doesn't flip out, we are good :)