### PR TITLE
Naming adjustment for USE_SERIAL_RX to USE_SERIALRX

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -230,7 +230,7 @@ static const char * const lookupTableBlackboxSampleRate[] = {
 };
 #endif
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
 static const char * const lookupTableSerialRX[] = {
     "SPEK1024",
     "SPEK2048",
@@ -549,7 +549,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef USE_SERVOS
     LOOKUP_TABLE_ENTRY(lookupTableGimbalMode),
 #endif
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
     LOOKUP_TABLE_ENTRY(lookupTableSerialRX),
 #endif
 #ifdef USE_RX_SPI
@@ -759,7 +759,7 @@ const clivalue_t valueTable[] = {
 
     { "fpv_mix_degrees",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 90 }, PG_RX_CONFIG, offsetof(rxConfig_t, fpvCamAngleDegrees) },
     { "max_aux_channels",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, MAX_AUX_CHANNEL_COUNT }, PG_RX_CONFIG, offsetof(rxConfig_t, max_aux_channel) },
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
     { PARAM_NAME_SERIAL_RX_PROVIDER, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SERIAL_RX }, PG_RX_CONFIG, offsetof(rxConfig_t, serialrx_provider) },
     { "serialrx_inverted",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, serialrx_inverted) },
 #endif

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -48,7 +48,7 @@ typedef enum {
 #ifdef USE_SERVOS
     TABLE_GIMBAL_MODE,
 #endif
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
     TABLE_SERIAL_RX,
 #endif
 #ifdef USE_RX_SPI

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -419,7 +419,7 @@ static void validateAndFixConfig(void)
     featureDisableImmediate(FEATURE_RX_PPM);
 #endif
 
-#ifndef USE_SERIAL_RX
+#ifndef USE_SERIALRX
     featureDisableImmediate(FEATURE_RX_SERIAL);
 #endif
 

--- a/src/main/io/spektrum_rssi.c
+++ b/src/main/io/spektrum_rssi.c
@@ -19,7 +19,7 @@
  */
 
 #include "platform.h"
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
 #if defined(USE_SPEKTRUM_REAL_RSSI) || defined(USE_SPEKTRUM_FAKE_RSSI)
 
 #include "config/feature.h"
@@ -213,4 +213,4 @@ void spektrumHandleRSSI(volatile uint8_t spekFrame[])
 #endif // USE_SPEKTRUM_FAKE_RSSI
 }
 #endif // USE_SPEKTRUM_REAL_RSSI || USE_SPEKTRUM_FAKE_RSSI
-#endif // USE_SERIAL_RX
+#endif // USE_SERIALRX

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -20,7 +20,7 @@
 
 #include "platform.h"
 
-#if defined(USE_PWM) || defined(USE_PPM) || defined(USE_SERIAL_RX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
+#if defined(USE_PWM) || defined(USE_PPM) || defined(USE_SERIALRX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -198,7 +198,7 @@ STATIC_UNIT_TESTED bool isPulseValid(uint16_t pulseDuration)
             pulseDuration <= rxConfig()->rx_max_usec;
 }
 
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
 static bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 {
     bool enabled = false;
@@ -324,7 +324,7 @@ void rxInit(void)
     default:
 
         break;
-#ifdef USE_SERIAL_RX
+#ifdef USE_SERIALRX
     case RX_PROVIDER_SERIAL:
         {
             const bool enabled = serialRxInit(rxConfig(), &rxRuntimeState);

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -98,7 +98,7 @@
 #undef USE_OSD
 #undef USE_PPM
 #undef USE_PWM
-#undef USE_SERIAL_RX
+#undef USE_SERIALRX
 #undef USE_SERIALRX_CRSF
 #undef USE_SERIALRX_GHST
 #undef USE_SERIALRX_IBUS

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -122,7 +122,7 @@
 #define BARO_EOC_PIN NONE
 #endif
 
-#if !defined(USE_SERIAL_RX)
+#if !defined(USE_SERIALRX)
 #undef USE_SERIALRX_CRSF
 #undef USE_SERIALRX_IBUS
 #undef USE_SERIALRX_JETIEXBUS

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -239,7 +239,7 @@ extern uint8_t _dmaram_end__;
 
 #if (!defined(CLOUD_BUILD))
 #define USE_PPM
-#define USE_SERIAL_RX
+#define USE_SERIALRX
 #define USE_SERIALRX_CRSF       // Team Black Sheep Crossfire protocol
 #define USE_SERIALRX_GHST       // ImmersionRC Ghost Protocol
 #define USE_SERIALRX_IBUS       // FlySky and Turnigy receivers

--- a/src/test/unit/target.h
+++ b/src/test/unit/target.h
@@ -33,7 +33,7 @@
 #define USE_BARO
 #define USE_GPS
 #define USE_DASHBOARD
-#define USE_SERIAL_RX
+#define USE_SERIALRX
 #define USE_RX_MSP
 #define USE_SERIALRX_CRSF       // Team Black Sheep Crossfire protocol
 #define USE_SERIALRX_SPEKTRUM   // DSM2 and DSMX protocol


### PR DESCRIPTION
Purely for naming convention cleanup, to keep it inline with the protocol defines naming convention. 

Will be adding a number of PRs cleaning up the defines to make managing the cloud build easier.