### PR TITLE
ezLanding

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1259,9 +1259,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_LOW_BREAKPOINT,      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PWM_RANGE_MIN, PWM_RANGE_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_breakpoint) },
     { PARAM_NAME_TPA_LOW_ALWAYS, VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_always) },
 
-    { PARAM_NAME_EZ_LANDING_THRESHOLD,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
-    { PARAM_NAME_EZ_LANDING_LIMIT,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 75 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
-    { PARAM_NAME_EZ_LANDING_SPEED,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_speed) },
+    { PARAM_NAME_EZ_LANDING_THRESHOLD, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
+    { PARAM_NAME_EZ_LANDING_LIMIT,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -63,7 +63,6 @@ static float rawSetpoint[XYZ_AXIS_COUNT];
 
 static float setpointRate[3], rcDeflection[3], rcDeflectionAbs[3]; // deflection range -1 to 1
 static float maxRcDeflectionAbs;
-
 static bool reverseMotors = false;
 static applyRatesFn *applyRates;
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -261,6 +261,21 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
         motorOutputMin = motorRangeMin;
         motorOutputRange = motorRangeMax - motorRangeMin;
         motorOutputMixSign = 1;
+
+        // easy landing code, limits motor output when sticks and throttle are below threshold
+        const float throttlePercent = throttle / 1000.0f;
+        if (mixerRuntime.ezLandingThreshold && throttlePercent < mixerRuntime.ezLandingThreshold) { // throttle low
+            float ezLandAttenuator = 0.0f;
+            float maxDeflection = getMaxRcDeflectionAbs();
+            if (maxDeflection < mixerRuntime.ezLandingThreshold) { // all sticks, including throttle, under threshold
+                ezLandAttenuator = fmaxf(maxDeflection, throttlePercent); // value range 0 -> threshold
+                ezLandAttenuator /= mixerRuntime.ezLandingThreshold; // normalised 0 - 1
+                ezLandAttenuator = 1.0f - ezLandAttenuator; // 1 -> 0
+                ezLandAttenuator *= mixerRuntime.ezLandingLimit; // eg 0.9 -> 0.0 if limit is 10
+            }
+            const float motorRange = motorRangeMax - mixerRuntime.motorOutputLow;
+            motorRangeMax -= ezLandAttenuator * motorRange; // available motor range limited to 15% if threshold is 15
+        }
     }
 
     throttle = constrainf(throttle / currentThrottleInputRange, 0.0f, 1.0f);

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -366,10 +366,8 @@ void mixerInitProfile(void)
     pt1FilterInit(&mixerRuntime.rpmLimiterThrottleScaleOffsetFilter, pt1FilterGain(2.0f, pidGetDT()));
     mixerResetRpmLimiter();
 #endif
-
-    mixerRuntime.ezLandingThreshold = 2.0f * currentPidProfile->ez_landing_threshold / 100.0f;
-    mixerRuntime.ezLandingLimit = currentPidProfile->ez_landing_limit / 100.0f;
-    mixerRuntime.ezLandingSpeed = 2.0f * currentPidProfile->ez_landing_speed / 10.0f;
+    mixerRuntime.ezLandingThreshold = currentPidProfile->ez_landing_threshold / 100.0f;
+    mixerRuntime.ezLandingLimit = 1.0f - currentPidProfile->ez_landing_limit / 100.0f;
 }
 
 #ifdef USE_RPM_LIMIT

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -228,8 +228,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_breakpoint = 1050,
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
-        .ez_landing_limit = 15,
-        .ez_landing_speed = 50,
+        .ez_landing_limit = 10,
     );
 
 #ifndef USE_D_MIN

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -89,7 +89,6 @@ extern "C" {
     bool gyroOverflowDetected(void) { return false; }
     float getRcDeflection(int axis) { return simulatedRcDeflection[axis]; }
     float getRcDeflectionRaw(int axis) { return simulatedRcDeflection[axis]; }
-    float getRawSetpoint(int axis) { return simulatedRawSetpoint[axis]; }
     float getFeedforward(int axis) {
         return simulatedSetpointRate[axis] - simulatedPrevSetpointRate[axis];
     }


### PR DESCRIPTION
A possible method to reduce 'bounce aggression' on landing, facilitate `perching`, retain throttle control on unexpected 'fly to the moon on arming' events, etc, with little negative impact on normal flight.

Limits motor output to not exceed the set `ez_landing_limit` when all sticks are centred and zeroed.  Smoothly restores motor output limit when any stick, including throttle, is more than `ez_landing_threshold` percent away from centre/zero.

**Applications:**
- smoother, bounce-free landings
- tricks like 'perching' on objects
- cut motor output during flyaways without having to disarm
- (possibly) un-stick a ducted quad (whoop) from a wall just by centring sticks and cutting throttle

A 'fly to the moon on arming' problem is usually due to extreme resonance while airmode is on, effectively sending 50% throttle to the motors via the PIDs and airmode.  With this PR, cutting throttle to zero and entering sticks would stop the climb to the moon, which may be better than having to disarm.  However I'm not sure that this is a big thing; there will be very little control like this, and it will fall anyway.  However it won't get so high and may help resolve the issue before it gets out of hand.

Whoops get stuck on a wall by PIDs and airmode attempting to push some motors quite hard to restore normal attitude.  With this PR, just by centering sticks and cutting throttle, the whoop should fall off the wall and be immediately recoverable.

**Testing and Tuning**
To test it, flash the hex and try to take off and land, comparing how much it bounces to normal.  Then see if it wrecks anything, eg in situations other than landing, where you'd normally have zero throttle and all sticks centred.

Default is strongly ON, with a limit of 10%, and a threshold of 20%.  Higher values, eg limit of 20% or close to hover throttle, and threshold of 25-30% could be tested.

If threshold is set to 0, the code is 'bypassed' or 'turned off'.  

For battery-below designs, which are unstable without some reasonable motor authority, a motor output limit of 10% on arming may not be sufficient to hold attitude after arming, and the ideal value would be just sufficient to barely keep the machine stable.

**Possible drawback and problems:**

- Hard throttle chops, with all sticks centred, eg in straight-line flying, WILL BECOME UNSTABLE with this PR.  The quad will have much less authority than normal unless some residual 'idle up' on the throttle is retained.
- iTerm will accumulate during the low motor output period, so in the above setting, there may be a wobble as the accumulated iTerm is removed.
- yaw position is included in the stick check on landing, so if you cut throttle but accidentally have some residual yaw, the motors may not get limited to the minimum you've set.  
- All sticks must be dead centre, and throttle must be fully at zero, to get full motor output limiting on landing.  If throttle is 'on the way down' but not actually zero, then you may bounce a bit until you get it to zero.

**Idle Up**
Keeping throttle above the threshold of 20% during active moves - the old "idle up" method - will bypass this code and ensure 100% normal authority at all times.

If you encounter some 'negative' effect, eg instability after a throttle chop to zero in fast flight, or perhaps a wobble at the end of a flip or roll, repeat the move with some 'idle up' on your throttle.

Questions:
- Anyone have a better name for this function?
- May cause bad problems for 3D quads?
- More efficient ways to code it?
- Not a big flash consumer, should all this be inside #IFDEF 

Replaces #11927 which has been closed. 