### PR TITLE
FIX: for if CRSF Telemetry not selected, yet CRSF serial is

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -331,6 +331,7 @@ STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)
     return crc;
 }
 
+#ifdef USE_CRSF_V3
 STATIC_UNIT_TESTED uint8_t crsfFrameCmdCRC(void)
 {
     // CRC includes type and payload
@@ -340,6 +341,7 @@ STATIC_UNIT_TESTED uint8_t crsfFrameCmdCRC(void)
     }
     return crc;
 }
+#endif
 
 // Receive ISR callback, called back from serial port
 STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -331,7 +331,7 @@ STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)
     return crc;
 }
 
-#ifdef USE_CRSF_V3
+#if defined(USE_CRSF_V3) || defined(UNIT_TEST)
 STATIC_UNIT_TESTED uint8_t crsfFrameCmdCRC(void)
 {
     // CRC includes type and payload

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -167,6 +167,10 @@
 #undef USE_CRSF_CMS_TELEMETRY
 #endif
 
+#if !defined(USE_TELEMETRY_CRSF)
+#undef USE_CRSF_V3
+#endif
+
 #if !defined(USE_SERIALRX_JETIEXBUS)
 #undef USE_TELEMETRY_JETIEXBUS
 #endif


### PR DESCRIPTION
This is to fix the linker issues with this build:

```
make TARGET=STM32H743 EXTRA_FLAGS="-DCLOUD_BUILD -DUSE_DSHOT -DUSE_SERIALRX -DUSE_SERIALRX_CRSF -DUSE_GPS -DUSE_OSD -DUSE_FLASH -DUSE_SDCARD -DUSE_GYRO_SPI_MPU6000 -DUSE_ACC_SPI_MPU6000 -DUSE_ACCGYRO_BMI270 -DUSE_FLASH_W25N01G -DUSE_MAX7456 -DUSE_GYRO -DUSE_ACC"
```
