### PR TITLE
Make Gyro FF respect angle/horizon mode setpoint in angle/horizon mode.

### DIFF
--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -59,7 +59,7 @@ void feedforwardInit(const pidProfile_t *pidProfile)
     }
 }
 
-FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging)
+FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint)
 {
 
     if (newRcFrame) {
@@ -74,7 +74,6 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
         const float rxInterval = getCurrentRxRefreshRate() * 1e-6f; // 0.0066 for 150hz RC Link.
         const float rxRate = 1.0f / rxInterval; // eg 150 for a 150Hz RC link
 
-        const float setpoint = getRawSetpoint(axis);
         const float absSetpointPercent = fabsf(setpoint) / feedforwardMaxRate[axis];
 
         float rcCommandDelta = getRcCommandDelta(axis);

--- a/src/main/flight/feedforward.h
+++ b/src/main/flight/feedforward.h
@@ -26,6 +26,6 @@
 #include "flight/pid.h"
 
 void feedforwardInit(const pidProfile_t *pidProfile);
-float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging);
+float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint);
 float applyFeedforwardLimit(int axis, float value, float Kp, float currentPidSetpoint);
 bool shouldApplyFeedforwardLimits(int axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -947,7 +947,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 #if defined(USE_ACC)
         if ((levelMode == LEVEL_MODE_R && axis == FD_ROLL)
             || (levelMode == LEVEL_MODE_RP && (axis == FD_ROLL || axis ==  FD_PITCH)) ) {
-            currentPidSetpoint = pidLevel(axis, pidProfile, angleTrim, currentPidSetpoint, horizonLevelStrength);
+            currentPidSetpoint = pidLevel(axis, pidProfile, angleTrim, getRawSetpoint(axis), horizonLevelStrength);
             DEBUG_SET(DEBUG_ATTITUDE, axis - FD_ROLL + 2, currentPidSetpoint);
         }
 #endif

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -95,10 +95,11 @@ extern "C" {
         return value;
     }
     void feedforwardInit(const pidProfile_t) { }
-    float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging)
+    float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint)
     {
         UNUSED(newRcFrame);
         UNUSED(feedforwardAveraging);
+        UNUSED(setpoint);
         const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
         float setpointDelta = simulatedSetpointRate[axis] - simulatedPrevSetpointRate[axis];
         setpointDelta *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1;


### PR DESCRIPTION
This is a prototype update to FF to make it respect setpoint calculation in all flight modes. Needs code review and testing. Fixes issue #12034.
