### PR TITLE
Link to flash types supported by M25P16 driver

### DIFF
--- a/docs/Manufacturer Design Guidelines.md
+++ b/docs/Manufacturer Design Guidelines.md
@@ -379,7 +379,7 @@ Define at least one gyro and one accelerometer.
 
 Define correct flash driver(s) only if physical present on the board.
 
-    #define USE_FLASH_M25P16           // 16MB Micron M25P16
+    #define USE_FLASH_M25P16           // 16MB Micron M25P16 and others (https://github.com/betaflight/betaflight/blob/master/src/main/drivers/flash_m25p16.c#L68)
     #define USE_FLASH_W25N01G          // 1Gb NAND flash support
     #define USE_FLASH_W25M             // 16, 32, 64 or 128MB Winbond stacked die support
     #define USE_FLASH_W25M512          // 512Kb (256Kb x 2 stacked) NOR flash support


### PR DESCRIPTION
Update Manufacturer Guidelines to link to the full list of flash types supported by M25P16 driver instead of just calling out the default Micron 16MB.