### PR TITLE
Add ff to angle controller, make feedforward respect gyro setpoint in all modes

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1351,9 +1351,10 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE("yawPID", "%d,%d,%d",                    currentPidProfile->pid[PID_YAW].P,
                                                                             currentPidProfile->pid[PID_YAW].I,
                                                                             currentPidProfile->pid[PID_YAW].D);
-        BLACKBOX_PRINT_HEADER_LINE("levelPID", "%d,%d,%d",                  currentPidProfile->pid[PID_LEVEL].P,
+        BLACKBOX_PRINT_HEADER_LINE("levelPID", "%d,%d,%d,%d",               currentPidProfile->pid[PID_LEVEL].P,
                                                                             currentPidProfile->pid[PID_LEVEL].I,
-                                                                            currentPidProfile->pid[PID_LEVEL].D);
+                                                                            currentPidProfile->pid[PID_LEVEL].D,
+                                                                            currentPidProfile->pid[PID_LEVEL].F);
         BLACKBOX_PRINT_HEADER_LINE("magPID", "%d",                          currentPidProfile->pid[PID_MAG].P);
 #ifdef USE_D_MIN
         BLACKBOX_PRINT_HEADER_LINE("d_min", "%d,%d,%d",                     currentPidProfile->d_min[ROLL],
@@ -1402,8 +1403,11 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_JITTER_FACTOR, "%d",  currentPidProfile->feedforward_jitter_factor);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_BOOST, "%d",          currentPidProfile->feedforward_boost);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_GYRO_FF_SCALE, "%d",        currentPidProfile->angle_gyro_feedforward_scale);
 #endif
-
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_ROLL_EXPO, "%d",        currentControlRateProfile->levelExpo[FD_ROLL]);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_PITCH_EXPO, "%d",       currentControlRateProfile->levelExpo[FD_PITCH]);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ACC_LIMIT_YAW, "%d",          currentPidProfile->yawRateAccelLimit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ACC_LIMIT, "%d",              currentPidProfile->rateAccelLimit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_PIDSUM_LIMIT, "%d",           currentPidProfile->pidSumLimit);

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -107,4 +107,7 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "ATTITUDE",
     "VTX_MSP",
     "GPS_DOP",
+    "ANGLE_MODE",
+    "ANGLE_FEEDFORWARD",
+    "ANGLE_DERIVATIVE",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -105,7 +105,10 @@ typedef enum {
     DEBUG_ATTITUDE,
     DEBUG_VTX_MSP,
     DEBUG_GPS_DOP,
-    DEBUG_COUNT
+    DEBUG_ANGLE_MODE,
+    DEBUG_ANGLE_FEEDFORWARD,
+    DEBUG_ANGLE_DERIVATIVE,
+    DEBUG_COUNT,
 } debugType_e;
 
 extern const char * const debugModeNames[DEBUG_COUNT];

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1129,9 +1129,12 @@ const clivalue_t valueTable[] = {
     { "d_yaw",                      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, PID_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].D) },
     { "f_yaw",                      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, F_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].F) },
 
-    { "angle_level_strength",       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].P) },
-    { "horizon_level_strength",     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].I) },
-    { "horizon_transition",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].D) },
+    { "angle_level_strength",           VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].P) },
+    { "horizon_level_strength",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].I) },
+    { PARAM_NAME_ANGLE_DERIVATIVE_GAIN, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].D) },
+    { "horizon_transition",             VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizonTransition) },
+    { PARAM_NAME_ANGLE_FEEDFORWARD,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].F) },
+    { PARAM_NAME_ANGLE_GYRO_FF_SCALE,   VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_gyro_feedforward_scale) },
 
     { "level_limit",                VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelAngleLimit) },
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -978,8 +978,8 @@ const clivalue_t valueTable[] = {
     { "roll_rate_limit",            VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_ROLL]) },
     { "pitch_rate_limit",           VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_PITCH]) },
     { "yaw_rate_limit",             VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_YAW]) },
-    { "roll_level_expo",            VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_ROLL]) },
-    { "pitch_level_expo",           VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_PITCH]) },
+    { PARAM_NAME_ANGLE_ROLL_EXPO,   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_ROLL]) },
+    { PARAM_NAME_ANGLE_PITCH_EXPO,  VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_PITCH]) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },
@@ -1129,14 +1129,14 @@ const clivalue_t valueTable[] = {
     { "d_yaw",                      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, PID_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].D) },
     { "f_yaw",                      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, F_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].F) },
 
-    { "angle_level_strength",           VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].P) },
+    { PARAM_NAME_ANGLE_ERROR_GAIN,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].P) },
     { "horizon_level_strength",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].I) },
     { PARAM_NAME_ANGLE_DERIVATIVE_GAIN, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].D) },
     { "horizon_transition",             VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizonTransition) },
     { PARAM_NAME_ANGLE_FEEDFORWARD,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].F) },
     { PARAM_NAME_ANGLE_GYRO_FF_SCALE,   VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_gyro_feedforward_scale) },
 
-    { "level_limit",                VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelAngleLimit) },
+    { PARAM_NAME_ANGLE_LIMIT,           VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, angleLimit) },
 
     { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0,  250 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_effect) },
     { "horizon_tilt_expert_mode",   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_expert_mode) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -521,7 +521,7 @@ static uint8_t  cmsx_angleFeedforward;
 static uint8_t  cmsx_angleDerivative;
 static uint8_t  cmsx_horizonStrength;
 static uint8_t  cmsx_horizonTransition;
-static uint8_t  cmsx_levelAngleLimit;
+static uint8_t  cmsx_angleLimit;
 static uint8_t  cmsx_throttleBoost;
 static uint8_t  cmsx_thrustLinearization;
 static uint8_t  cmsx_antiGravityGain;
@@ -567,7 +567,7 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     cmsx_horizonStrength =   pidProfile->pid[PID_LEVEL].I;
     cmsx_angleDerivative =   pidProfile->pid[PID_LEVEL].D;
     cmsx_horizonTransition = pidProfile->horizonTransition;
-    cmsx_levelAngleLimit =   pidProfile->levelAngleLimit;
+    cmsx_angleLimit =   pidProfile->angleLimit;
 
     cmsx_antiGravityGain   = pidProfile->anti_gravity_gain;
 
@@ -620,7 +620,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->horizonTransition = cmsx_horizonTransition;
     pidProfile->pid[PID_LEVEL].D = cmsx_angleDerivative;
     pidProfile->pid[PID_LEVEL].F = cmsx_angleFeedforward;
-    pidProfile->levelAngleLimit  = cmsx_levelAngleLimit;
+    pidProfile->angleLimit  = cmsx_angleLimit;
 
     pidProfile->anti_gravity_gain   = cmsx_antiGravityGain;
 
@@ -676,7 +676,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "ANGLE D",     OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleDerivative,        0,    200,   1  }    },
     { "HORZN STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonStrength,        0,    200,   1  }    },
     { "HORZN TRS",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonTransition,      0,    200,   1  }    },
-    { "ANGLE LIMIT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_levelAngleLimit,        10,    90,   1  }    },
+    { "ANGLE LIMIT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleLimit,            10,    90,   1  }    },
 
     { "AG GAIN",     OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &cmsx_antiGravityGain,   ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX, 1, 100 }    },
 #ifdef USE_THROTTLE_BOOST

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -517,6 +517,8 @@ static CMS_Menu cmsx_menuLaunchControl = {
 #endif
 
 static uint8_t  cmsx_angleStrength;
+static uint8_t  cmsx_angleFeedforward;
+static uint8_t  cmsx_angleDerivative;
 static uint8_t  cmsx_horizonStrength;
 static uint8_t  cmsx_horizonTransition;
 static uint8_t  cmsx_levelAngleLimit;
@@ -561,8 +563,10 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
 
     cmsx_angleStrength =     pidProfile->pid[PID_LEVEL].P;
+    cmsx_angleFeedforward =  pidProfile->pid[PID_LEVEL].F;
     cmsx_horizonStrength =   pidProfile->pid[PID_LEVEL].I;
-    cmsx_horizonTransition = pidProfile->pid[PID_LEVEL].D;
+    cmsx_angleDerivative =   pidProfile->pid[PID_LEVEL].D;
+    cmsx_horizonTransition = pidProfile->horizonTransition;
     cmsx_levelAngleLimit =   pidProfile->levelAngleLimit;
 
     cmsx_antiGravityGain   = pidProfile->anti_gravity_gain;
@@ -613,7 +617,9 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
 
     pidProfile->pid[PID_LEVEL].P = cmsx_angleStrength;
     pidProfile->pid[PID_LEVEL].I = cmsx_horizonStrength;
-    pidProfile->pid[PID_LEVEL].D = cmsx_horizonTransition;
+    pidProfile->horizonTransition = cmsx_horizonTransition;
+    pidProfile->pid[PID_LEVEL].D = cmsx_angleDerivative;
+    pidProfile->pid[PID_LEVEL].F = cmsx_angleFeedforward;
     pidProfile->levelAngleLimit  = cmsx_levelAngleLimit;
 
     pidProfile->anti_gravity_gain   = cmsx_antiGravityGain;
@@ -666,6 +672,8 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "FF BOOST",      OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_boost,             0,     50,   1  }    },
 #endif
     { "ANGLE STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleStrength,          0,    200,   1  }    },
+    { "ANGLE FF",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleFeedforward,       0,    200,   1  }    },
+    { "ANGLE D",     OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleDerivative,        0,    200,   1  }    },
     { "HORZN STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonStrength,        0,    200,   1  }    },
     { "HORZN TRS",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonTransition,      0,    200,   1  }    },
     { "ANGLE LIMIT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_levelAngleLimit,        10,    90,   1  }    },

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -62,8 +62,8 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .profileName = { 0 },
             .quickRatesRcExpo = 0,
-            .levelExpo[FD_ROLL] = 0,
-            .levelExpo[FD_PITCH] = 0,
+            .levelExpo[FD_ROLL] = 60,
+            .levelExpo[FD_PITCH] = 60,
         );
     }
 }

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -127,6 +127,8 @@
 #define PARAM_NAME_ANGLE_ROLL_EXPO "angle_roll_expo"
 #define PARAM_NAME_ANGLE_PITCH_EXPO "angle_pitch_expo"
 #define PARAM_NAME_ANGLE_DERIVATIVE_GAIN "angle_derivative_gain"
+#define PARAM_NAME_ANGLE_ERROR_GAIN "angle_error_gain"
+#define PARAM_NAME_ANGLE_LIMIT "angle_limit"
 
 #ifdef USE_GPS
 #define PARAM_NAME_GPS_PROVIDER "gps_provider"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -122,6 +122,11 @@
 #define PARAM_NAME_POSITION_ALTITUDE_PREFER_BARO "altitude_prefer_baro"
 #define PARAM_NAME_POSITION_ALTITUDE_LPF "altitude_lpf"
 #define PARAM_NAME_POSITION_ALTITUDE_D_LPF "altitude_d_lpf"
+#define PARAM_NAME_ANGLE_FEEDFORWARD "angle_feedforward_gain"
+#define PARAM_NAME_ANGLE_GYRO_FF_SCALE "angle_gyro_feedforward_scale"
+#define PARAM_NAME_ANGLE_ROLL_EXPO "angle_roll_expo"
+#define PARAM_NAME_ANGLE_PITCH_EXPO "angle_pitch_expo"
+#define PARAM_NAME_ANGLE_DERIVATIVE_GAIN "angle_derivative_gain"
 
 #ifdef USE_GPS
 #define PARAM_NAME_GPS_PROVIDER "gps_provider"

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -132,6 +132,11 @@ float getRcDeflectionAbs(int axis)
     return rcDeflectionAbs[axis];
 }
 
+float getRcDeflectionRaw(int axis)
+{
+    return rcDeflection[axis];
+}
+
 #ifdef USE_FEEDFORWARD
 float getRawSetpoint(int axis)
 {

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -33,6 +33,7 @@ void processRcCommand(void);
 float getSetpointRate(int axis);
 float getRcDeflection(int axis);
 float getRcDeflectionAbs(int axis);
+float getRcDeflectionRaw(int axis);
 void updateRcCommands(void);
 void resetYawAxis(void);
 void initRcProcessing(void);

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -612,9 +612,9 @@ static uint8_t applySelectAdjustment(adjustmentFunction_e adjustmentFunction, ui
     case ADJUSTMENT_HORIZON_STRENGTH:
         {
             uint8_t newValue = constrain(position, 0, 200); // FIXME magic numbers repeated in serial_cli.c
-            if (currentPidProfile->pid[PID_LEVEL].D != newValue) {
-                beeps = ((newValue - currentPidProfile->pid[PID_LEVEL].D) / 8) + 1;
-                currentPidProfile->pid[PID_LEVEL].D = newValue;
+            if (currentPidProfile->horizonTransition != newValue) {
+                beeps = ((newValue - currentPidProfile->horizonTransition) / 8) + 1;
+                currentPidProfile->horizonTransition = newValue;
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_HORIZON_STRENGTH, position);
             }
         }

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -71,17 +71,6 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
         prevSetpointSpeed[axis] = setpointSpeed;
         setpointAcceleration *= feedforwardBoostFactor;
         setpointDelta[axis] = (setpointSpeed + setpointAcceleration);
-        if (newRcFrame) {
-            const float rcCommandDelta = getRcCommandDelta(axis);
-            if (rcCommandDelta) {
-                duplicateCount[axis] = 0;
-            } else {
-                if (duplicateCount[axis] > 1) {
-                    duplicateCount[axis] = 1;
-                }
-            duplicateCount[axis] += 1;
-            }
-        }
     } else {
         if (newRcFrame) {
             const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -28,6 +28,7 @@
 #include "common/maths.h"
 
 #include "fc/rc.h"
+#include "fc/runtime_config.h"
 
 #include "flight/pid.h"
 
@@ -41,12 +42,11 @@ static uint8_t duplicateCount[XYZ_AXIS_COUNT];
 static uint8_t averagingCount;
 static float feedforwardMaxRateLimit[XYZ_AXIS_COUNT];
 static float feedforwardMaxRate[XYZ_AXIS_COUNT];
-
-typedef struct laggedMovingAverageCombined_s {
-     laggedMovingAverage_t filter;
-     float buf[4];
-} laggedMovingAverageCombined_t;
 laggedMovingAverageCombined_t  setpointDeltaAvg[XYZ_AXIS_COUNT];
+
+uint8_t getFeedforwardDuplicateCount(int axis){
+    return duplicateCount[axis];
+}
 
 void feedforwardInit(const pidProfile_t *pidProfile)
 {
@@ -59,136 +59,154 @@ void feedforwardInit(const pidProfile_t *pidProfile)
     }
 }
 
-FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging)
+FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint)
 {
+    const float feedforwardBoostFactor = pidGetFeedforwardBoostFactor();
 
-    if (newRcFrame) {
-
-        const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
-        const float feedforwardSmoothFactor = pidGetFeedforwardSmoothFactor();
-                    // good values : 25 for 111hz FrSky, 30 for 150hz, 50 for 250hz, 65 for 500hz links
-        const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
-                    // 7 is default, 5 for faster links with smaller steps and for racing, 10-12 for 150hz freestyle
-        const float feedforwardBoostFactor = pidGetFeedforwardBoostFactor();
-
-        const float rxInterval = getCurrentRxRefreshRate() * 1e-6f; // 0.0066 for 150hz RC Link.
-        const float rxRate = 1.0f / rxInterval; // eg 150 for a 150Hz RC link
-
-        const float setpoint = getRawSetpoint(axis);
-        const float absSetpointPercent = fabsf(setpoint) / feedforwardMaxRate[axis];
-
-        float rcCommandDelta = getRcCommandDelta(axis);
-
-        if (axis == FD_ROLL) {
-            DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 100.0f));
-            // rcCommand packet difference = value of 100 if 1000 RC steps
-            DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));
-            // un-smoothed in blackbox
+    if (FLIGHT_MODE(ANGLE_MODE)) {
+        // bare bones feedforward with boost on pre-smoothed data
+        const float setpointSpeed = (setpoint - prevSetpoint[axis]);
+        prevSetpoint[axis] = setpoint;
+        float setpointAcceleration = (setpointSpeed - prevSetpointSpeed[axis]);
+        prevSetpointSpeed[axis] = setpointSpeed;
+        setpointAcceleration *= feedforwardBoostFactor;
+        setpointDelta[axis] = (setpointSpeed + setpointAcceleration);
+        if (newRcFrame) {
+            const float rcCommandDelta = getRcCommandDelta(axis);
+            if (rcCommandDelta) {
+                duplicateCount[axis] = 0;
+            } else {
+                if (duplicateCount[axis] > 1) {
+                    duplicateCount[axis] = 1;
+                }
+            duplicateCount[axis] += 1;
+            }
         }
+    } else {
+        if (newRcFrame) {
+            const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
+            const float feedforwardSmoothFactor = pidGetFeedforwardSmoothFactor();
+                        // good values : 25 for 111hz FrSky, 30 for 150hz, 50 for 250hz, 65 for 500hz links
+            const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
+                        // 7 is default, 5 for faster links with smaller steps and for racing, 10-12 for 150hz freestyle
+            const float rxInterval = getCurrentRxRefreshRate() * 1e-6f; // 0.0066 for 150hz RC Link.
+            const float rxRate = 1.0f / rxInterval; // eg 150 for a 150Hz RC link
 
-        // calculate setpoint speed
-        float setpointSpeed = (setpoint - prevSetpoint[axis]) * rxRate;
-        float absSetpointSpeed = fabsf(setpointSpeed); // unsmoothed for kick prevention
-        float absPrevSetpointSpeed = fabsf(prevSetpointSpeed[axis]);
+            const float absSetpointPercent = fabsf(setpoint) / feedforwardMaxRate[axis];
 
-        float setpointAcceleration = 0.0f;
+            float rcCommandDelta = getRcCommandDelta(axis);
 
-        rcCommandDelta = fabsf(rcCommandDelta);
+            if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 100.0f));
+                // rcCommand packet difference = value of 100 if 1000 RC steps
+                DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));
+                // un-smoothed in blackbox
+            }
 
-        if (rcCommandDelta) {
-            // we have movement and should calculate feedforward
+            // calculate setpoint speed
+            float setpointSpeed = (setpoint - prevSetpoint[axis]) * rxRate;
+            float absSetpointSpeed = fabsf(setpointSpeed); // unsmoothed for kick prevention
+            float absPrevSetpointSpeed = fabsf(prevSetpointSpeed[axis]);
 
-            // jitter attenuator falls below 1 when rcCommandDelta falls below jitter threshold
-            float jitterAttenuator = 1.0f;
-            if (feedforwardJitterFactor) {
-                if (rcCommandDelta < feedforwardJitterFactor) {
-                    jitterAttenuator = MAX(1.0f - (rcCommandDelta / feedforwardJitterFactor), 0.0f);
-                    jitterAttenuator = 1.0f - jitterAttenuator * jitterAttenuator;
+            float setpointAcceleration = 0.0f;
+
+            rcCommandDelta = fabsf(rcCommandDelta);
+
+            if (rcCommandDelta) {
+                // we have movement and should calculate feedforward
+
+                // jitter attenuator falls below 1 when rcCommandDelta falls below jitter threshold
+                float jitterAttenuator = 1.0f;
+                if (feedforwardJitterFactor) {
+                    if (rcCommandDelta < feedforwardJitterFactor) {
+                        jitterAttenuator = MAX(1.0f - (rcCommandDelta / feedforwardJitterFactor), 0.0f);
+                        jitterAttenuator = 1.0f - jitterAttenuator * jitterAttenuator;
+                    }
+                }
+
+                // duplicateCount indicates number of prior duplicate/s, 1 means one only duplicate prior to this packet
+                // reduce setpoint speed by half after a single duplicate or a third after two. Any more are forced to zero.
+                // needed because while sticks are moving, the next valid step up will be proportionally bigger
+                // and stops excessive feedforward where steps are at intervals, eg when the OpenTx ADC filter is active
+                // downside is that for truly held sticks, the first feedforward step won't be as big as it should be
+                if (duplicateCount[axis]) {
+                    setpointSpeed /= duplicateCount[axis] + 1;
+                }
+
+                // first order type smoothing for setpoint speed noise reduction
+                setpointSpeed = prevSetpointSpeed[axis] + feedforwardSmoothFactor * (setpointSpeed - prevSetpointSpeed[axis]);
+
+                // calculate acceleration from smoothed setpoint speed
+                setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];
+
+                // use rxRate to normalise acceleration to nominal RC packet interval of 100hz
+                // without this, we would get less boost than we should at higher Rx rates
+                // note rxRate updates with every new packet (though not every time data changes), hence
+                // if no Rx packets are received for a period, boost amount is correctly attenuated in proportion to the delay
+                setpointAcceleration *= rxRate * 0.01f;
+
+                // first order acceleration smoothing (with smoothed input this is effectively second order all up)
+                setpointAcceleration = prevAcceleration[axis] + feedforwardSmoothFactor * (setpointAcceleration - prevAcceleration[axis]);
+
+                // jitter reduction to reduce acceleration spikes at low rcCommandDelta values
+                // no effect for rcCommandDelta values above jitter threshold (zero delay)
+                // does not attenuate the basic feedforward amount, but this is small anyway at centre due to expo
+                setpointAcceleration *= jitterAttenuator;
+
+                if (absSetpointPercent > 0.95f && absSetpointSpeed < 3.0f * absPrevSetpointSpeed) {
+                    // approaching max stick position so zero out feedforward to minimise overshoot
+                    setpointSpeed = 0.0f;
+                    setpointAcceleration = 0.0f;
+                }
+
+
+                prevSetpointSpeed[axis] = setpointSpeed;
+                prevAcceleration[axis] = setpointAcceleration;
+
+                setpointAcceleration *= feedforwardBoostFactor;
+
+                // add attenuated boost to base feedforward and apply jitter attenuation
+                setpointDelta[axis] = (setpointSpeed + setpointAcceleration) * pidGetDT() * jitterAttenuator;
+
+                //reset counter
+                duplicateCount[axis] = 0;
+
+            } else {
+                // no movement
+                if (duplicateCount[axis]) {
+                    // increment duplicate count to max of 2
+                    duplicateCount[axis] += (duplicateCount[axis] < 2) ? 1 : 0;
+                    // second or subsequent duplicate, or duplicate when held at max stick or centre position.
+                    // force feedforward to zero
+                    setpointDelta[axis] = 0.0f;
+                    // zero speed and acceleration for correct smoothing of next good packet
+                    setpointSpeed = 0.0f;
+                    prevSetpointSpeed[axis] = 0.0f;
+                    prevAcceleration[axis] = 0.0f;
+                } else {
+                    // first duplicate; hold feedforward and previous static values, as if we just never got anything
+                    duplicateCount[axis] = 1;
                 }
             }
 
-            // duplicateCount indicates number of prior duplicate/s, 1 means one only duplicate prior to this packet
-            // reduce setpoint speed by half after a single duplicate or a third after two. Any more are forced to zero.
-            // needed because while sticks are moving, the next valid step up will be proportionally bigger
-            // and stops excessive feedforward where steps are at intervals, eg when the OpenTx ADC filter is active
-            // downside is that for truly held sticks, the first feedforward step won't be as big as it should be
-            if (duplicateCount[axis]) {
-                setpointSpeed /= duplicateCount[axis] + 1;
+
+            if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * pidGetDT() * 100.0f)); // setpoint speed after smoothing
+                DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * pidGetDT() * 100.0f)); // boost amount after smoothing
+                // debug 0 is interpolated setpoint, above
+                // debug 3 is rcCommand delta, above
             }
 
-            // first order type smoothing for setpoint speed noise reduction
-            setpointSpeed = prevSetpointSpeed[axis] + feedforwardSmoothFactor * (setpointSpeed - prevSetpointSpeed[axis]);
+            prevSetpoint[axis] = setpoint;
 
-            // calculate acceleration from smoothed setpoint speed
-            setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];
-
-            // use rxRate to normalise acceleration to nominal RC packet interval of 100hz
-            // without this, we would get less boost than we should at higher Rx rates
-            // note rxRate updates with every new packet (though not every time data changes), hence
-            // if no Rx packets are received for a period, boost amount is correctly attenuated in proportion to the delay
-            setpointAcceleration *= rxRate * 0.01f;
-
-            // first order acceleration smoothing (with smoothed input this is effectively second order all up)
-            setpointAcceleration = prevAcceleration[axis] + feedforwardSmoothFactor * (setpointAcceleration - prevAcceleration[axis]);
-
-            // jitter reduction to reduce acceleration spikes at low rcCommandDelta values
-            // no effect for rcCommandDelta values above jitter threshold (zero delay)
-            // does not attenuate the basic feedforward amount, but this is small anyway at centre due to expo
-            setpointAcceleration *= jitterAttenuator;
-
-            if (absSetpointPercent > 0.95f && absSetpointSpeed < 3.0f * absPrevSetpointSpeed) {
-                // approaching max stick position so zero out feedforward to minimise overshoot
-                setpointSpeed = 0.0f;
-                setpointAcceleration = 0.0f;
+            // apply averaging, if enabled - include zero values in averaging
+            if (feedforwardAveraging) {
+                setpointDelta[axis] = laggedMovingAverageUpdate(&setpointDeltaAvg[axis].filter, setpointDelta[axis]);
             }
 
-            prevSetpointSpeed[axis] = setpointSpeed;
-            prevAcceleration[axis] = setpointAcceleration;
-
-            setpointAcceleration *= feedforwardBoostFactor;
-
-            // add attenuated boost to base feedforward and apply jitter attenuation
-            setpointDelta[axis] = (setpointSpeed + setpointAcceleration) * pidGetDT() * jitterAttenuator;
-
-            //reset counter
-            duplicateCount[axis] = 0;
-
-        } else {
-            // no movement
-            if (duplicateCount[axis]) {
-                // increment duplicate count to max of 2
-                duplicateCount[axis] += (duplicateCount[axis] < 2) ? 1 : 0;
-                // second or subsequent duplicate, or duplicate when held at max stick or centre position.
-                // force feedforward to zero
-                setpointDelta[axis] = 0.0f;
-                // zero speed and acceleration for correct smoothing of next good packet
-                setpointSpeed = 0.0f;
-                prevSetpointSpeed[axis] = 0.0f;
-                prevAcceleration[axis] = 0.0f;
-            } else {
-                // first duplicate; hold feedforward and previous static values, as if we just never got anything
-                duplicateCount[axis] = 1;
-            }
+            // apply feedforward transition
+            setpointDelta[axis] *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1.0f;
         }
-
-
-        if (axis == FD_ROLL) {
-            DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * pidGetDT() * 100.0f)); // setpoint speed after smoothing
-            DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * pidGetDT() * 100.0f)); // boost amount after smoothing
-            // debug 0 is interpolated setpoint, above
-            // debug 3 is rcCommand delta, above
-        }
-
-        prevSetpoint[axis] = setpoint;
-
-        // apply averaging, if enabled - include zero values in averaging
-        if (feedforwardAveraging) {
-            setpointDelta[axis] = laggedMovingAverageUpdate(&setpointDeltaAvg[axis].filter, setpointDelta[axis]);
-        }
-
-        // apply feedforward transition
-        setpointDelta[axis] *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1.0f;
-
     }
     return setpointDelta[axis]; // the value used by the PID code
 }

--- a/src/main/flight/feedforward.h
+++ b/src/main/flight/feedforward.h
@@ -25,7 +25,8 @@
 #include "common/axis.h"
 #include "flight/pid.h"
 
+uint8_t getFeedforwardDuplicateCount(int axis);
 void feedforwardInit(const pidProfile_t *pidProfile);
-float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging);
+float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint);
 float applyFeedforwardLimit(int axis, float value, float Kp, float currentPidSetpoint);
 bool shouldApplyFeedforwardLimits(int axis);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -146,7 +146,7 @@ typedef struct pidProfile_s {
     uint16_t pidSumLimit;
     uint16_t pidSumLimitYaw;
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.
-    uint8_t levelAngleLimit;                // Max angle in degrees in level mode
+    uint8_t angleLimit;                // Max angle in degrees in level mode
 
     uint8_t horizon_tilt_effect;            // inclination factor for Horizon mode
     float   horizonTransition;
@@ -326,6 +326,7 @@ typedef struct pidRuntime_s {
     bool zeroThrottleItermReset;
     bool levelRaceMode;
     float tpaFactor;
+    float angleTargetDelta[XYZ_AXIS_COUNT];
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
@@ -410,6 +411,7 @@ typedef struct pidRuntime_s {
     float previousAngle[XYZ_AXIS_COUNT];
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
     laggedMovingAverageCombined_t  angleFeedforwardAvg[XYZ_AXIS_COUNT];
+    uint8_t angleDuplicateCount[XYZ_AXIS_COUNT];
 #endif
 
 #ifdef USE_ACC

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1946,7 +1946,7 @@ case MSP_NAME:
         sbufWriteU8(dst, 0); // reserved
         sbufWriteU16(dst, currentPidProfile->rateAccelLimit);
         sbufWriteU16(dst, currentPidProfile->yawRateAccelLimit);
-        sbufWriteU8(dst, currentPidProfile->levelAngleLimit);
+        sbufWriteU8(dst, currentPidProfile->angleLimit);
         sbufWriteU8(dst, 0); // was pidProfile.levelSensitivity
         sbufWriteU16(dst, 0); // was currentPidProfile->itermThrottleThreshold
         sbufWriteU16(dst, currentPidProfile->anti_gravity_gain);
@@ -3084,7 +3084,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         currentPidProfile->rateAccelLimit = sbufReadU16(src);
         currentPidProfile->yawRateAccelLimit = sbufReadU16(src);
         if (sbufBytesRemaining(src) >= 2) {
-            currentPidProfile->levelAngleLimit = sbufReadU8(src);
+            currentPidProfile->angleLimit = sbufReadU8(src);
             sbufReadU8(src); // was pidProfile.levelSensitivity
         }
         if (sbufBytesRemaining(src) >= 4) {

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -28,6 +28,10 @@ bool simulatedAirmodeEnabled = true;
 float simulatedSetpointRate[3] = { 0,0,0 };
 float simulatedPrevSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
+float simulatedRcCommandDelta[3] = { 1,1,1 };
+float simulatedRawSetpoint[3] = { 0,0,0 };
+uint16_t simulatedCurrentRxRefreshRate = 10000;
+uint8_t simulatedDuplicateCount = 0;
 float simulatedMotorMixRange = 0.0f;
 
 int16_t debug[DEBUG16_VALUE_COUNT];
@@ -75,6 +79,7 @@ extern "C" {
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);
 
     bool unitLaunchControlActive = false;
+    bool newAttitudeData = true;
     launchControlMode_e unitLaunchControlMode = LAUNCH_CONTROL_MODE_NORMAL;
 
     float getMotorMixRange(void) { return simulatedMotorMixRange; }
@@ -84,6 +89,10 @@ extern "C" {
     void systemBeep(bool) { }
     bool gyroOverflowDetected(void) { return false; }
     float getRcDeflection(int axis) { return simulatedRcDeflection[axis]; }
+    float getRcCommandDelta(int axis) { return simulatedRcCommandDelta[axis]; }
+    float getRawSetpoint(int axis) { return simulatedRawSetpoint[axis]; }
+    uint16_t getCurrentRxRefreshRate(void) { return simulatedCurrentRxRefreshRate; }
+    uint8_t getFeedforwardDuplicateCount(void) { return simulatedDuplicateCount; }
     void beeperConfirmationBeeps(uint8_t) { }
     bool isLaunchControlActive(void) {return unitLaunchControlActive; }
     void disarm(flightLogDisarmReason_e) { }
@@ -95,10 +104,11 @@ extern "C" {
         return value;
     }
     void feedforwardInit(const pidProfile_t) { }
-    float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging)
+    float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint)
     {
         UNUSED(newRcFrame);
         UNUSED(feedforwardAveraging);
+        UNUSED(setpoint);
         const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
         float setpointDelta = simulatedSetpointRate[axis] - simulatedPrevSetpointRate[axis];
         setpointDelta *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1;
@@ -125,7 +135,7 @@ void setDefaultTestSettings(void)
     pidProfile->pid[PID_ROLL]  =  { 40, 40, 30, 65 };
     pidProfile->pid[PID_PITCH] =  { 58, 50, 35, 60 };
     pidProfile->pid[PID_YAW]   =  { 70, 45, 20, 60 };
-    pidProfile->pid[PID_LEVEL] =  { 50, 50, 75, 0 };
+    pidProfile->pid[PID_LEVEL] =  { 50, 50, 0, 200 };
 
     // Compensate for the upscaling done without 'use_integrated_yaw'
     pidProfile->pid[PID_YAW].I = pidProfile->pid[PID_YAW].I / 2.5f;
@@ -194,6 +204,7 @@ void resetTest(void)
         pidData[axis].Sum = 0;
         simulatedSetpointRate[axis] = 0;
         simulatedRcDeflection[axis] = 0;
+        simulatedRawSetpoint[axis] = 0;
         gyro.gyroADCf[axis] = 0;
     }
     attitude.values.roll = 0;
@@ -381,39 +392,38 @@ TEST(pidControllerTest, testPidLevel)
     float currentPidSetpoint = 30;
     rollAndPitchTrims_t angleTrim = { { 0, 0 } };
 
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
     EXPECT_FLOAT_EQ(0, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
     EXPECT_FLOAT_EQ(0, currentPidSetpoint);
 
     // Test attitude response
     setStickPosition(FD_ROLL, 1.0f);
     setStickPosition(FD_PITCH, -1.0f);
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(244.07211, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-244.07211, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(275, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-275, currentPidSetpoint);
 
     setStickPosition(FD_ROLL, -0.5f);
     setStickPosition(FD_PITCH, 0.5f);
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-93.487915, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(93.487915, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-137.5, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(137.5, currentPidSetpoint);
 
     attitude.values.roll = -275;
     attitude.values.pitch = 275;
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-12.047981, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(12.047981, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(0, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(0, currentPidSetpoint);
 
     // Disable ANGLE_MODE
     disableFlightMode(ANGLE_MODE);
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(11.07958, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(12.047981, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(0, currentPidSetpoint);
 
     // Test level mode expo
     enableFlightMode(ANGLE_MODE);
@@ -423,10 +433,10 @@ TEST(pidControllerTest, testPidLevel)
     setStickPosition(FD_PITCH, -0.5f);
     currentControlRateProfile->levelExpo[FD_ROLL] = 50;
     currentControlRateProfile->levelExpo[FD_PITCH] = 26;
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(76.208672, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-98.175163, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(85.9375, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-110.6875, currentPidSetpoint);
 }
 
 

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -150,7 +150,7 @@ void setDefaultTestSettings(void)
     pidProfile->dterm_lpf1_type = FILTER_BIQUAD;
     pidProfile->itermWindupPointPercent = 50;
     pidProfile->pidAtMinThrottle = PID_STABILISATION_ON;
-    pidProfile->levelAngleLimit = 55;
+    pidProfile->angleLimit = 55;
     pidProfile->feedforward_transition = 100;
     pidProfile->yawRateAccelLimit = 100;
     pidProfile->rateAccelLimit = 0;


### PR DESCRIPTION
This is a simple addition of an FF term into the angle controller. This PR also changes FF in level modes to respect the unfiltered level mode setpoint rather than acro stick inputs.

Before, stick inputs in angle mode would be passed with acro rate scaling (!) into feedforward instead of the correct setpoint from the angle controller. This causes bad behaviour #12034 

This PR correctly adds stick input FF into the angle mode controller. Giving back the sharp response to stick inputs we like in angle mode but without all the bad behaviour associated with the previous implementation.

The benefits of this split approach to FF in angle mode are numerous.

More accurate stick tracking in the angle controller due to proper FF
More accurate gyro setpoint tracking in angle mode
Better response to sudden perturbations (crashes) in angle mode as FF will push the gyro pid loop to better follow the angle controller setpoint.
World peace.