### PR TITLE
Gps Rescue: Fix "velocityD" filtering

### DIFF
--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -17,37 +17,33 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #include "common/axis.h"
 
-#include "pg/pg.h"
+#include "pg/gps_rescue.h"
 
-#define TASK_GPS_RESCUE_RATE_HZ 100 // synced to altitude task rate
+#define TASK_GPS_RESCUE_RATE_HZ 100  // in sync with altitude task rate
 
-typedef struct gpsRescue_s {
-    uint16_t angle; // degrees
-    uint16_t initialAltitudeM; // meters
-    uint16_t descentDistanceM; // meters
-    uint16_t rescueGroundspeed; // centimeters per second
-    uint8_t throttleP, throttleI, throttleD;
-    uint8_t yawP;
-    uint16_t throttleMin;
-    uint16_t throttleMax;
-    uint16_t throttleHover;
-    uint8_t minSats;
-    uint8_t velP, velI, velD;
-    uint16_t minRescueDth; // meters
-    uint8_t sanityChecks;
-    uint8_t allowArmingWithoutFix;
-    uint8_t useMag;
-    uint8_t targetLandingAltitudeM; // meters
-    uint8_t altitudeMode;
-    uint16_t ascendRate;
-    uint16_t descendRate;
-    uint16_t rescueAltitudeBufferM; // meters
-    uint8_t rollMix;
-} gpsRescueConfig_t;
+#ifdef USE_MAG
+#define GPS_RESCUE_USE_MAG  true
+#else
+#define GPS_RESCUE_USE_MAG  false
+#endif
 
-PG_DECLARE(gpsRescueConfig_t, gpsRescueConfig);
+typedef enum {
+    RESCUE_SANITY_OFF = 0,
+    RESCUE_SANITY_ON,
+    RESCUE_SANITY_FS_ONLY,
+    RESCUE_SANITY_COUNT
+} gpsRescueSanity_e;
+
+typedef enum {
+    GPS_RESCUE_ALT_MODE_MAX = 0,
+    GPS_RESCUE_ALT_MODE_FIXED,
+    GPS_RESCUE_ALT_MODE_CURRENT,
+    GPS_RESCUE_ALT_MODE_COUNT
+} gpsRescueAltitudeMode_e;
 
 extern float gpsRescueAngle[ANGLE_INDEX_COUNT]; // NOTE: ANGLES ARE IN CENTIDEGREES
 

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -217,3 +217,4 @@ void GPS_reset_home_position(void);
 void GPS_calc_longitude_scaling(int32_t lat);
 void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, int32_t *destinationLat2, int32_t *destinationLon2, uint32_t *dist, int32_t *bearing);
 void gpsSetFixState(bool state);
+float gpsGetSampleRateHz(void);

--- a/src/main/pg/gps_rescue.c
+++ b/src/main/pg/gps_rescue.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#ifdef USE_GPS_RESCUE
+
+#include "flight/gps_rescue.h"
+
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+
+#include "gps_rescue.h"
+
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 3);
+
+PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
+
+    .minRescueDth = 30,
+    .altitudeMode = GPS_RESCUE_ALT_MODE_MAX,
+    .rescueAltitudeBufferM = 10,
+    .ascendRate = 500,          // cm/s, for altitude corrections on ascent
+
+    .initialAltitudeM = 30,
+    .rescueGroundspeed = 500,
+    .angle = 40,
+    .rollMix = 150,
+
+    .descentDistanceM = 20,
+    .descendRate = 100,         // cm/s, minimum for descent and landing phase, or for descending if starting high ascent
+    .targetLandingAltitudeM = 4,
+
+    .throttleMin = 1100,
+    .throttleMax = 1600,
+    .throttleHover = 1275,
+
+    .allowArmingWithoutFix = false,
+    .sanityChecks = RESCUE_SANITY_FS_ONLY,
+    .minSats = 8,
+
+    .throttleP = 15,
+    .throttleI = 15,
+    .throttleD = 15,
+    .velP = 8,
+    .velI = 30,
+    .velD = 20,
+    .yawP = 20,
+
+    .useMag = GPS_RESCUE_USE_MAG
+);
+
+#endif // USE_GPS_RESCUE

--- a/src/main/pg/gps_rescue.h
+++ b/src/main/pg/gps_rescue.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "pg/pg.h"
+
+typedef struct gpsRescue_s {
+
+    uint16_t angle; // degrees
+    uint16_t initialAltitudeM; // meters
+    uint16_t descentDistanceM; // meters
+    uint16_t rescueGroundspeed; // centimeters per second
+    uint8_t  throttleP, throttleI, throttleD;
+    uint8_t  yawP;
+    uint16_t throttleMin;
+    uint16_t throttleMax;
+    uint16_t throttleHover;
+    uint8_t  minSats;
+    uint8_t  velP, velI, velD;
+    uint16_t minRescueDth; // meters
+    uint8_t  sanityChecks;
+    uint8_t  allowArmingWithoutFix;
+    uint8_t  useMag;
+    uint8_t  targetLandingAltitudeM; // meters
+    uint8_t  altitudeMode;
+    uint16_t ascendRate;
+    uint16_t descendRate;
+    uint16_t rescueAltitudeBufferM; // meters
+    uint8_t  rollMix;
+
+} gpsRescueConfig_t;
+
+PG_DECLARE(gpsRescueConfig_t, gpsRescueConfig);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -35,13 +35,13 @@ alignsensor_unittest_SRC := \
 		$(USER_DIR)/common/maths.c
 
 arming_prevention_unittest_SRC := \
+		$(USER_DIR)/common/bitarray.c \
 		$(USER_DIR)/fc/core.c \
 		$(USER_DIR)/fc/dispatch.c \
 		$(USER_DIR)/fc/rc_controls.c \
 		$(USER_DIR)/fc/rc_modes.c \
 		$(USER_DIR)/fc/runtime_config.c \
-		$(USER_DIR)/flight/gps_rescue.c \
-		$(USER_DIR)/common/bitarray.c
+		$(USER_DIR)/flight/gps_rescue.c
 
 arming_prevention_unittest_DEFINES := \
             USE_GPS_RESCUE=

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -18,34 +18,48 @@
 #include <stdint.h>
 
 extern "C" {
+
     #include "blackbox/blackbox.h"
+
     #include "build/debug.h"
+
+    #include "common/filter.h"
     #include "common/maths.h"
-    #include "config/feature.h"
-    #include "pg/motor.h"
-    #include "pg/pg.h"
-    #include "pg/pg_ids.h"
-    #include "pg/rx.h"
+
     #include "config/config.h"
+    #include "config/feature.h"
+
     #include "fc/controlrate_profile.h"
     #include "fc/core.h"
     #include "fc/rc_controls.h"
     #include "fc/rc_modes.h"
     #include "fc/runtime_config.h"
+
     #include "flight/failsafe.h"
+    #include "flight/gps_rescue.h"
     #include "flight/imu.h"
     #include "flight/mixer.h"
     #include "flight/pid.h"
     #include "flight/position.h"
     #include "flight/servos.h"
+
     #include "io/beeper.h"
     #include "io/gps.h"
+
+    #include "pg/gps_rescue.h"
+    #include "pg/motor.h"
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+    #include "pg/rx.h"
+
     #include "rx/rx.h"
+
     #include "scheduler/scheduler.h"
+
     #include "sensors/acceleration.h"
     #include "sensors/gyro.h"
+
     #include "telemetry/telemetry.h"
-    #include "flight/gps_rescue.h"
 
     PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
     PG_REGISTER(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 0);
@@ -60,6 +74,7 @@ extern "C" {
     PG_REGISTER(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 0);
     PG_REGISTER(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
     PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
+    PG_REGISTER(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 0);
     PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 
     float rcCommand[4];
@@ -81,6 +96,9 @@ extern "C" {
     acc_t acc = {};
     bool mockIsUpright = false;
     uint8_t activePidLoopDenom = 1;
+
+    float gpsGetSampleRateHz(void) { return 10.0f; }
+    void pt2FilterUpdateCutoff(pt2Filter_t *filter, float k) { filter->k = k; }
 }
 
 uint32_t simulationFeatureFlags = 0;

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -54,6 +54,7 @@ extern "C" {
     #include "osd/osd_elements.h"
     #include "osd/osd_warnings.h"
 
+    #include "pg/gps_rescue.h"
     #include "pg/pg.h"
     #include "pg/pg_ids.h"
     #include "pg/rx.h"

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -43,6 +43,7 @@ extern "C" {
     #include "io/gps.h"
     #include "io/vtx.h"
 
+    #include "pg/gps_rescue.h"
     #include "pg/motor.h"
     #include "pg/pg.h"
     #include "pg/pg_ids.h"


### PR DESCRIPTION
- Refactoring of parameter group for GPS Rescue
- Fix for dependency of velocity D-gain filter cutoff from the GPS Rescue task rate

Now `velocityD` shouldn't be getting more noisy after lowering the GPS Rescue task rate from 120Hz to 100Hz or when changing the GPS sample rate. I also increased the filter order from 1 to 2 (from PT1 to PT2) to guarantee that high frequency noise cannot get amplified and cannot end up in the velocity PID-controller.