### PR TITLE
Use USE_DMA_SPEC without preconditions

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -390,13 +390,9 @@
 #undef BEEPER_PWM_HZ
 #endif
 
-#if defined(USE_DSHOT) || defined(USE_LED_STRIP) || defined(USE_TRANSPONDER)
+#if defined(USE_DMA_SPEC)
 #define USE_TIMER_DMA
 #else
-#undef USE_DMA_SPEC
-#endif
-
-#if !defined(USE_DMA_SPEC)
 #undef USE_TIMER_MGMT
 #endif
 


### PR DESCRIPTION
Fixes cloud build when using non Dshot protocol.

`USE_DMA_SPEC` makes use of DMA Timer management.