### PR TITLE
Display FLASH JEDEC ID in status and flash_info

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2456,8 +2456,8 @@ static void cliFlashInfo(const char *cmdName, char *cmdline)
 
     const flashGeometry_t *layout = flashGetGeometry();
 
-    cliPrintLinef("Flash sectors=%u, sectorSize=%u, pagesPerSector=%u, pageSize=%u, totalSize=%u",
-            layout->sectors, layout->sectorSize, layout->pagesPerSector, layout->pageSize, layout->totalSize);
+    cliPrintLinef("Flash sectors=%u, sectorSize=%u, pagesPerSector=%u, pageSize=%u, totalSize=%u JEDEC ID=0x%08x",
+            layout->sectors, layout->sectorSize, layout->pagesPerSector, layout->pageSize, layout->totalSize, layout->jedecId);
 
     for (uint8_t index = 0; index < FLASH_MAX_PARTITIONS; index++) {
         const flashPartition_t *partition;
@@ -4852,6 +4852,13 @@ static void cliStatus(const char *cmdName, char *cmdline)
 
 #ifdef USE_SDCARD
     cliSdInfo(cmdName, "");
+#endif
+
+#ifdef USE_FLASH_CHIP
+    const flashGeometry_t *layout = flashGetGeometry();
+    if (layout->jedecId != 0) {
+        cliPrintLinef("FLASH: JEDEC ID=0x%08x %uM", layout->jedecId, layout->totalSize >> 20);
+    }
 #endif
 
     cliPrint("Arming disable flags:");

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -45,6 +45,7 @@ typedef struct flashGeometry_s {
     uint32_t totalSize;  // This is just sectorSize * sectors
     uint16_t pagesPerSector;
     flashType_e flashType;
+    uint32_t jedecId;
 } flashGeometry_t;
 
 void flashPreInit(const flashConfig_t *flashConfig);


### PR DESCRIPTION
To aid debug of FLASH memory detection, display the FLASH JEDEC ID with both the `status` command:

```
# status
MCU F40X Clock=168MHz (PLLP-HSE), Vref=3.29V, Core temp=41degC
Stack size: 2048, Stack address: 0x1000fff0
Configuration: CONFIGURED, size: 4190, max available: 16384
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1 locked dma
GYRO=ICM42605, ACC=ICM42605, BARO=DPS310
OSD: MSP
System Uptime: 9 seconds, Current Time: 2022-12-15T00:32:51.399+00:00
CPU:34%, cycle time: 125, GYRO rate: 8000, RX rate: 15, System rate: 9
Voltage: 34 * 0.01V (0S battery - NOT PRESENT)
I2C Errors: 0
SD card: Not configured
FLASH: JEDEC ID=0x00ef4018 16M
Arming disable flags: RXLOSS CLI MSP NO_ACC_CAL MOTOR_PROTO
```

And the `flash_info` command:

```
# flash_info
Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216 JEDEC ID=0x00ef4018
Partitions:
  0: FLASHFS   0 255
FlashFS size=16777216, usedSize=4646912
```