### PR TITLE
Fix ELRS gating issues.

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -451,6 +451,9 @@ extern uint8_t __config_end;
 
 #if defined(USE_RX_EXPRESSLRS) && defined(STM32F411)
 #define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
+#endif
+
+#if defined(USE_RX_EXPRESSLRS) && !defined(RX_EXPRESSLRS_TIMER_INSTANCE) && (defined(STM32F411) || defined(STM32F405) || defined(STM32F745) || defined(STM32H7))
 #define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #endif
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -457,6 +457,22 @@ extern uint8_t __config_end;
 #define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #endif
 
+#if defined(USE_RX_EXPRESSLRS)
+// ELRS depends on CRSF telemetry
+#if !defined(USE_TELEMETRY)
+#define USE_TELEMETRY
+#endif
+#if !defined(USE_TELEMETRY_CRSF)
+#define USE_TELEMETRY_CRSF
+#endif
+#if !defined(USE_CRSF_LINK_STATISTICS)
+#define USE_CRSF_LINK_STATISTICS
+#endif
+#if !defined(USE_SERIALRX_CRSF)
+#define USE_SERIALRX_CRSF
+#endif
+#endif
+
 #if defined(USE_RX_SPI) || defined (USE_SERIALRX_SRXL2)
 #define USE_RX_BIND
 #endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -289,7 +289,6 @@ extern uint8_t _dmaram_end__;
 #define USE_RANGEFINDER_TF
 
 #define USE_RX_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define USE_RX_SX127X
 #endif


### PR DESCRIPTION
1) default ELRS hardware timer should be done in common_defaults_post.h.
2) ELRS depends on CRSF code.

Reviewers: See individual commits.