### PR TITLE
Cloud build option for 64 leds

### DIFF
--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -24,7 +24,7 @@
 
 #include "drivers/io_types.h"
 
-#define WS2811_LED_STRIP_LENGTH    32
+#define WS2811_LED_STRIP_LENGTH    LED_MAX_STRIP_LENGTH
 
 #define WS2811_BITS_PER_LED_MAX    32
 

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -28,7 +28,6 @@
 
 #include "pg/pg.h"
 
-#define LED_MAX_STRIP_LENGTH           32
 #define LED_CONFIGURABLE_COLOR_COUNT   16
 #define LED_MODE_COUNT                  6
 #define LED_DIRECTION_COUNT             6

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -339,6 +339,14 @@ extern uint8_t _dmaram_end__;
 
 #endif // !defined(CLOUD_BUILD)
 
+#ifndef LED_MAX_STRIP_LENGTH
+    #ifdef USE_LEDSTRIP_64
+        #define LED_MAX_STRIP_LENGTH           64
+    #else
+        #define LED_MAX_STRIP_LENGTH           32
+    #endif
+#endif // #ifndef LED_MAX_STRIP_LENGTH
+
 #if defined(USE_SDCARD)
 #define USE_SDCARD_SPI
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -43,6 +43,14 @@
 #define USE_SERVOS
 #define USE_TRANSPONDER
 
+#ifndef LED_MAX_STRIP_LENGTH
+    #ifdef USE_LEDSTRIP_64
+        #define LED_MAX_STRIP_LENGTH           64
+    #else
+        #define LED_MAX_STRIP_LENGTH           32
+    #endif
+#endif // #ifndef LED_MAX_STRIP_LENGTH
+
 typedef enum
 {
     Mode_TEST = 0x0,


### PR DESCRIPTION
This small change leaves 32 LEDs by default.
But if used with cloud build + -DUSE_64_LED allows the use of 64 separate LEDs.

Justification:
First time in history MultiGP requires leds for night racing events (2023 season rules)
Giant LED rigs become more and more popular for racing.
64 separate LEDs can help dedicated pilots to build drones that stand out and would allow LED manufacturers to go above and beyond.
So it be nice to have it for 2023, BF 4.4

F7X2 test:
![image](https://user-images.githubusercontent.com/2925027/208614389-190f2fcd-e4c8-490c-9d23-32b0647b685d.png)
