### PR TITLE
Angle mode feedforward and earth referencing of yaw inputs

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1402,7 +1402,13 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_JITTER_FACTOR, "%d",  currentPidProfile->feedforward_jitter_factor);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_BOOST, "%d",          currentPidProfile->feedforward_boost);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FF_SMOOTHING, "%d",         currentPidProfile->angle_feedforward_smoothing);
 #endif
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_ROLL_EXPO, "%d",            currentControlRateProfile->levelExpo[ROLL]);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_PITCH_EXPO, "%d",           currentControlRateProfile->levelExpo[PITCH]);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_LIMIT, "%d",                currentPidProfile->angle_limit);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_EARTH_REF, "%d",            currentPidProfile->angle_earth_ref);
 
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ACC_LIMIT_YAW, "%d",          currentPidProfile->yawRateAccelLimit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ACC_LIMIT, "%d",              currentPidProfile->rateAccelLimit);

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -108,4 +108,7 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "VTX_MSP",
     "GPS_DOP",
     "FAILSAFE",
+    "ANGLE_MODE",
+    "ANGLE_TARGET",
+    "CURRENT_ANGLE",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -106,6 +106,9 @@ typedef enum {
     DEBUG_VTX_MSP,
     DEBUG_GPS_DOP,
     DEBUG_FAILSAFE,
+    DEBUG_ANGLE_MODE,
+    DEBUG_ANGLE_TARGET,
+    DEBUG_CURRENT_ANGLE,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -978,8 +978,8 @@ const clivalue_t valueTable[] = {
     { "roll_rate_limit",            VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_ROLL]) },
     { "pitch_rate_limit",           VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_PITCH]) },
     { "yaw_rate_limit",             VAR_UINT16 | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { CONTROL_RATE_CONFIG_RATE_LIMIT_MIN, CONTROL_RATE_CONFIG_RATE_LIMIT_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rate_limit[FD_YAW]) },
-    { "roll_level_expo",            VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_ROLL]) },
-    { "pitch_level_expo",           VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_PITCH]) },
+    { PARAM_NAME_ANGLE_ROLL_EXPO,   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_ROLL]) },
+    { PARAM_NAME_ANGLE_PITCH_EXPO,  VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, CONTROL_RATE_CONFIG_RC_EXPO_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, levelExpo[FD_PITCH]) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },
@@ -1129,11 +1129,13 @@ const clivalue_t valueTable[] = {
     { "d_yaw",                      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, PID_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].D) },
     { "f_yaw",                      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, F_GAIN_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_YAW].F) },
 
-    { "angle_level_strength",       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].P) },
-    { "horizon_level_strength",     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].I) },
-    { "horizon_transition",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].D) },
-
-    { "level_limit",                VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelAngleLimit) },
+    { PARAM_NAME_ANGLE_P_GAIN,       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].P) },
+    { "horizon_level_strength",      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].I) },
+    { "horizon_transition",          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].D) },
+    { PARAM_NAME_ANGLE_FEEDFORWARD,  VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].F) },
+    { PARAM_NAME_ANGLE_FF_SMOOTHING, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_feedforward_smoothing) },
+    { PARAM_NAME_ANGLE_LIMIT,        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 85 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_limit) },
+    { PARAM_NAME_ANGLE_EARTH_REF,    VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_earth_ref) },
 
     { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0,  250 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_effect) },
     { "horizon_tilt_expert_mode",   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_expert_mode) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -516,10 +516,11 @@ static CMS_Menu cmsx_menuLaunchControl = {
 };
 #endif
 
-static uint8_t  cmsx_angleStrength;
+static uint8_t  cmsx_angleP;
+static uint8_t  cmsx_angleFF;
 static uint8_t  cmsx_horizonStrength;
 static uint8_t  cmsx_horizonTransition;
-static uint8_t  cmsx_levelAngleLimit;
+static uint8_t  cmsx_angleLimit;
 static uint8_t  cmsx_throttleBoost;
 static uint8_t  cmsx_thrustLinearization;
 static uint8_t  cmsx_antiGravityGain;
@@ -560,10 +561,11 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
 
-    cmsx_angleStrength =     pidProfile->pid[PID_LEVEL].P;
+    cmsx_angleP =            pidProfile->pid[PID_LEVEL].P;
+    cmsx_angleFF =           pidProfile->pid[PID_LEVEL].F;
     cmsx_horizonStrength =   pidProfile->pid[PID_LEVEL].I;
     cmsx_horizonTransition = pidProfile->pid[PID_LEVEL].D;
-    cmsx_levelAngleLimit =   pidProfile->levelAngleLimit;
+    cmsx_angleLimit =   pidProfile->angle_limit;
 
     cmsx_antiGravityGain   = pidProfile->anti_gravity_gain;
 
@@ -611,10 +613,11 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);
     pidInitConfig(currentPidProfile);
 
-    pidProfile->pid[PID_LEVEL].P = cmsx_angleStrength;
+    pidProfile->pid[PID_LEVEL].P = cmsx_angleP;
     pidProfile->pid[PID_LEVEL].I = cmsx_horizonStrength;
     pidProfile->pid[PID_LEVEL].D = cmsx_horizonTransition;
-    pidProfile->levelAngleLimit  = cmsx_levelAngleLimit;
+    pidProfile->pid[PID_LEVEL].F = cmsx_angleFF;
+    pidProfile->angle_limit  = cmsx_angleLimit;
 
     pidProfile->anti_gravity_gain   = cmsx_antiGravityGain;
 
@@ -665,10 +668,11 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "FF JITTER",     OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_jitter_factor,     0,     20,   1  }    },
     { "FF BOOST",      OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_feedforward_boost,             0,     50,   1  }    },
 #endif
-    { "ANGLE STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleStrength,          0,    200,   1  }    },
+    { "ANGLE P",     OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleP,                  0,    200,   1  }    },
+    { "ANGLE FF",    OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleFF,                0,    200,   1  }    },
     { "HORZN STR",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonStrength,        0,    200,   1  }    },
     { "HORZN TRS",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_horizonTransition,      0,    200,   1  }    },
-    { "ANGLE LIMIT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_levelAngleLimit,        10,    90,   1  }    },
+    { "ANGLE LIMIT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_angleLimit,        10,    90,   1  }    },
 
     { "AG GAIN",     OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &cmsx_antiGravityGain,   ITERM_ACCELERATOR_GAIN_OFF, ITERM_ACCELERATOR_GAIN_MAX, 1, 100 }    },
 #ifdef USE_THROTTLE_BOOST

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -62,8 +62,8 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .profileName = { 0 },
             .quickRatesRcExpo = 0,
-            .levelExpo[FD_ROLL] = 0,
-            .levelExpo[FD_PITCH] = 0,
+            .levelExpo[FD_ROLL] = 33,
+            .levelExpo[FD_PITCH] = 33,
         );
     }
 }

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -122,6 +122,13 @@
 #define PARAM_NAME_POSITION_ALTITUDE_PREFER_BARO "altitude_prefer_baro"
 #define PARAM_NAME_POSITION_ALTITUDE_LPF "altitude_lpf"
 #define PARAM_NAME_POSITION_ALTITUDE_D_LPF "altitude_d_lpf"
+#define PARAM_NAME_ANGLE_FEEDFORWARD "angle_feedforward"
+#define PARAM_NAME_ANGLE_FF_SMOOTHING "angle_feedforward_smoothing"
+#define PARAM_NAME_ANGLE_ROLL_EXPO "angle_roll_expo"
+#define PARAM_NAME_ANGLE_PITCH_EXPO "angle_pitch_expo"
+#define PARAM_NAME_ANGLE_LIMIT "angle_limit"
+#define PARAM_NAME_ANGLE_P_GAIN "angle_p_gain"
+#define PARAM_NAME_ANGLE_EARTH_REF "angle_earth_ref"
 
 #ifdef USE_GPS
 #define PARAM_NAME_GPS_PROVIDER "gps_provider"

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -127,6 +127,11 @@ float getRcDeflection(int axis)
 #endif
 }
 
+float getRcDeflectionRaw(int axis)
+{
+    return rcDeflection[axis];
+}
+
 float getRcDeflectionAbs(int axis)
 {
     return rcDeflectionAbs[axis];

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -32,6 +32,7 @@
 void processRcCommand(void);
 float getSetpointRate(int axis);
 float getRcDeflection(int axis);
+float getRcDeflectionRaw(int axis);
 float getRcDeflectionAbs(int axis);
 void updateRcCommands(void);
 void resetYawAxis(void);

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -28,6 +28,7 @@
 #include "common/maths.h"
 
 #include "fc/rc.h"
+#include "fc/runtime_config.h"
 
 #include "flight/pid.h"
 
@@ -48,6 +49,10 @@ typedef struct laggedMovingAverageCombined_s {
 } laggedMovingAverageCombined_t;
 laggedMovingAverageCombined_t  setpointDeltaAvg[XYZ_AXIS_COUNT];
 
+uint8_t getFeedforwardDuplicateCount(int axis){
+    return duplicateCount[axis];
+}
+
 void feedforwardInit(const pidProfile_t *pidProfile)
 {
     const float feedforwardMaxRateScale = pidProfile->feedforward_max_rate_limit * 0.01f;
@@ -59,136 +64,144 @@ void feedforwardInit(const pidProfile_t *pidProfile)
     }
 }
 
-FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging)
+FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint)
 {
+    const float feedforwardBoostFactor = pidGetFeedforwardBoostFactor();
 
-    if (newRcFrame) {
+    if (FLIGHT_MODE(ANGLE_MODE)) {
+        // bare bones feedforward with boost on pre-smoothed data
+        const float setpointSpeed = (setpoint - prevSetpoint[axis]);
+        prevSetpoint[axis] = setpoint;
+        float setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];
+        prevSetpointSpeed[axis] = setpointSpeed;
+        setpointAcceleration *= feedforwardBoostFactor;
+        setpointDelta[axis] = (setpointSpeed + setpointAcceleration);
+    } else {
+        if (newRcFrame) {
+            const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
+            const float feedforwardSmoothFactor = pidGetFeedforwardSmoothFactor();
+                        // good values : 25 for 111hz FrSky, 30 for 150hz, 50 for 250hz, 65 for 500hz links
+            const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
+                        // 7 is default, 5 for faster links with smaller steps and for racing, 10-12 for 150hz freestyle
+            const float rxInterval = getCurrentRxRefreshRate() * 1e-6f; // 0.0066 for 150hz RC Link.
+            const float rxRate = 1.0f / rxInterval; // eg 150 for a 150Hz RC link
 
-        const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
-        const float feedforwardSmoothFactor = pidGetFeedforwardSmoothFactor();
-                    // good values : 25 for 111hz FrSky, 30 for 150hz, 50 for 250hz, 65 for 500hz links
-        const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
-                    // 7 is default, 5 for faster links with smaller steps and for racing, 10-12 for 150hz freestyle
-        const float feedforwardBoostFactor = pidGetFeedforwardBoostFactor();
+            const float absSetpointPercent = fabsf(setpoint) / feedforwardMaxRate[axis];
 
-        const float rxInterval = getCurrentRxRefreshRate() * 1e-6f; // 0.0066 for 150hz RC Link.
-        const float rxRate = 1.0f / rxInterval; // eg 150 for a 150Hz RC link
+            float rcCommandDelta = getRcCommandDelta(axis);
 
-        const float setpoint = getRawSetpoint(axis);
-        const float absSetpointPercent = fabsf(setpoint) / feedforwardMaxRate[axis];
+            if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 100.0f));
+                // rcCommand packet difference = value of 100 if 1000 RC steps
+                DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));
+                // un-smoothed in blackbox
+            }
 
-        float rcCommandDelta = getRcCommandDelta(axis);
+            // calculate setpoint speed
+            float setpointSpeed = (setpoint - prevSetpoint[axis]) * rxRate;
+            float absSetpointSpeed = fabsf(setpointSpeed); // unsmoothed for kick prevention
+            float absPrevSetpointSpeed = fabsf(prevSetpointSpeed[axis]);
 
-        if (axis == FD_ROLL) {
-            DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 100.0f));
-            // rcCommand packet difference = value of 100 if 1000 RC steps
-            DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));
-            // un-smoothed in blackbox
-        }
+            float setpointAcceleration = 0.0f;
 
-        // calculate setpoint speed
-        float setpointSpeed = (setpoint - prevSetpoint[axis]) * rxRate;
-        float absSetpointSpeed = fabsf(setpointSpeed); // unsmoothed for kick prevention
-        float absPrevSetpointSpeed = fabsf(prevSetpointSpeed[axis]);
+            rcCommandDelta = fabsf(rcCommandDelta);
 
-        float setpointAcceleration = 0.0f;
+            if (rcCommandDelta) {
+                // we have movement and should calculate feedforward
 
-        rcCommandDelta = fabsf(rcCommandDelta);
+                // jitter attenuator falls below 1 when rcCommandDelta falls below jitter threshold
+                float jitterAttenuator = 1.0f;
+                if (feedforwardJitterFactor) {
+                    if (rcCommandDelta < feedforwardJitterFactor) {
+                        jitterAttenuator = MAX(1.0f - (rcCommandDelta / feedforwardJitterFactor), 0.0f);
+                        jitterAttenuator = 1.0f - jitterAttenuator * jitterAttenuator;
+                    }
+                }
 
-        if (rcCommandDelta) {
-            // we have movement and should calculate feedforward
+                // duplicateCount indicates number of prior duplicate/s, 1 means one only duplicate prior to this packet
+                // reduce setpoint speed by half after a single duplicate or a third after two. Any more are forced to zero.
+                // needed because while sticks are moving, the next valid step up will be proportionally bigger
+                // and stops excessive feedforward where steps are at intervals, eg when the OpenTx ADC filter is active
+                // downside is that for truly held sticks, the first feedforward step won't be as big as it should be
+                if (duplicateCount[axis]) {
+                    setpointSpeed /= duplicateCount[axis] + 1;
+                }
 
-            // jitter attenuator falls below 1 when rcCommandDelta falls below jitter threshold
-            float jitterAttenuator = 1.0f;
-            if (feedforwardJitterFactor) {
-                if (rcCommandDelta < feedforwardJitterFactor) {
-                    jitterAttenuator = MAX(1.0f - (rcCommandDelta / feedforwardJitterFactor), 0.0f);
-                    jitterAttenuator = 1.0f - jitterAttenuator * jitterAttenuator;
+                // first order type smoothing for setpoint speed noise reduction
+                setpointSpeed = prevSetpointSpeed[axis] + feedforwardSmoothFactor * (setpointSpeed - prevSetpointSpeed[axis]);
+
+                // calculate acceleration from smoothed setpoint speed
+                setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];
+
+                // use rxRate to normalise acceleration to nominal RC packet interval of 100hz
+                // without this, we would get less boost than we should at higher Rx rates
+                // note rxRate updates with every new packet (though not every time data changes), hence
+                // if no Rx packets are received for a period, boost amount is correctly attenuated in proportion to the delay
+                setpointAcceleration *= rxRate * 0.01f;
+
+                // first order acceleration smoothing (with smoothed input this is effectively second order all up)
+                setpointAcceleration = prevAcceleration[axis] + feedforwardSmoothFactor * (setpointAcceleration - prevAcceleration[axis]);
+
+                // jitter reduction to reduce acceleration spikes at low rcCommandDelta values
+                // no effect for rcCommandDelta values above jitter threshold (zero delay)
+                // does not attenuate the basic feedforward amount, but this is small anyway at centre due to expo
+                setpointAcceleration *= jitterAttenuator;
+
+                if (!FLIGHT_MODE(ANGLE_MODE)) {
+                    if (absSetpointPercent > 0.95f && absSetpointSpeed < 3.0f * absPrevSetpointSpeed) {
+                        // approaching max stick position so zero out feedforward to minimise overshoot
+                        setpointSpeed = 0.0f;
+                        setpointAcceleration = 0.0f;
+                    }
+                }
+
+                prevSetpointSpeed[axis] = setpointSpeed;
+                prevAcceleration[axis] = setpointAcceleration;
+
+                setpointAcceleration *= feedforwardBoostFactor;
+
+                // add attenuated boost to base feedforward and apply jitter attenuation
+                setpointDelta[axis] = (setpointSpeed + setpointAcceleration) * pidGetDT() * jitterAttenuator;
+
+                //reset counter
+                duplicateCount[axis] = 0;
+
+            } else {
+                // no movement
+                if (duplicateCount[axis]) {
+                    // increment duplicate count to max of 2
+                    duplicateCount[axis] += (duplicateCount[axis] < 2) ? 1 : 0;
+                    // second or subsequent duplicate, or duplicate when held at max stick or centre position.
+                    // force feedforward to zero
+                    setpointDelta[axis] = 0.0f;
+                    // zero speed and acceleration for correct smoothing of next good packet
+                    setpointSpeed = 0.0f;
+                    prevSetpointSpeed[axis] = 0.0f;
+                    prevAcceleration[axis] = 0.0f;
+                } else {
+                    // first duplicate; hold feedforward and previous static values, as if we just never got anything
+                    duplicateCount[axis] = 1;
                 }
             }
 
-            // duplicateCount indicates number of prior duplicate/s, 1 means one only duplicate prior to this packet
-            // reduce setpoint speed by half after a single duplicate or a third after two. Any more are forced to zero.
-            // needed because while sticks are moving, the next valid step up will be proportionally bigger
-            // and stops excessive feedforward where steps are at intervals, eg when the OpenTx ADC filter is active
-            // downside is that for truly held sticks, the first feedforward step won't be as big as it should be
-            if (duplicateCount[axis]) {
-                setpointSpeed /= duplicateCount[axis] + 1;
+
+            if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * pidGetDT() * 100.0f)); // setpoint speed after smoothing
+                DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * pidGetDT() * 100.0f)); // boost amount after smoothing
+                // debug 0 is interpolated setpoint, above
+                // debug 3 is rcCommand delta, above
             }
 
-            // first order type smoothing for setpoint speed noise reduction
-            setpointSpeed = prevSetpointSpeed[axis] + feedforwardSmoothFactor * (setpointSpeed - prevSetpointSpeed[axis]);
+            prevSetpoint[axis] = setpoint;
 
-            // calculate acceleration from smoothed setpoint speed
-            setpointAcceleration = setpointSpeed - prevSetpointSpeed[axis];
-
-            // use rxRate to normalise acceleration to nominal RC packet interval of 100hz
-            // without this, we would get less boost than we should at higher Rx rates
-            // note rxRate updates with every new packet (though not every time data changes), hence
-            // if no Rx packets are received for a period, boost amount is correctly attenuated in proportion to the delay
-            setpointAcceleration *= rxRate * 0.01f;
-
-            // first order acceleration smoothing (with smoothed input this is effectively second order all up)
-            setpointAcceleration = prevAcceleration[axis] + feedforwardSmoothFactor * (setpointAcceleration - prevAcceleration[axis]);
-
-            // jitter reduction to reduce acceleration spikes at low rcCommandDelta values
-            // no effect for rcCommandDelta values above jitter threshold (zero delay)
-            // does not attenuate the basic feedforward amount, but this is small anyway at centre due to expo
-            setpointAcceleration *= jitterAttenuator;
-
-            if (absSetpointPercent > 0.95f && absSetpointSpeed < 3.0f * absPrevSetpointSpeed) {
-                // approaching max stick position so zero out feedforward to minimise overshoot
-                setpointSpeed = 0.0f;
-                setpointAcceleration = 0.0f;
+            // apply averaging, if enabled - include zero values in averaging
+            if (feedforwardAveraging) {
+                setpointDelta[axis] = laggedMovingAverageUpdate(&setpointDeltaAvg[axis].filter, setpointDelta[axis]);
             }
 
-            prevSetpointSpeed[axis] = setpointSpeed;
-            prevAcceleration[axis] = setpointAcceleration;
-
-            setpointAcceleration *= feedforwardBoostFactor;
-
-            // add attenuated boost to base feedforward and apply jitter attenuation
-            setpointDelta[axis] = (setpointSpeed + setpointAcceleration) * pidGetDT() * jitterAttenuator;
-
-            //reset counter
-            duplicateCount[axis] = 0;
-
-        } else {
-            // no movement
-            if (duplicateCount[axis]) {
-                // increment duplicate count to max of 2
-                duplicateCount[axis] += (duplicateCount[axis] < 2) ? 1 : 0;
-                // second or subsequent duplicate, or duplicate when held at max stick or centre position.
-                // force feedforward to zero
-                setpointDelta[axis] = 0.0f;
-                // zero speed and acceleration for correct smoothing of next good packet
-                setpointSpeed = 0.0f;
-                prevSetpointSpeed[axis] = 0.0f;
-                prevAcceleration[axis] = 0.0f;
-            } else {
-                // first duplicate; hold feedforward and previous static values, as if we just never got anything
-                duplicateCount[axis] = 1;
-            }
+            // apply feedforward transition
+            setpointDelta[axis] *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1.0f;
         }
-
-
-        if (axis == FD_ROLL) {
-            DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * pidGetDT() * 100.0f)); // setpoint speed after smoothing
-            DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * pidGetDT() * 100.0f)); // boost amount after smoothing
-            // debug 0 is interpolated setpoint, above
-            // debug 3 is rcCommand delta, above
-        }
-
-        prevSetpoint[axis] = setpoint;
-
-        // apply averaging, if enabled - include zero values in averaging
-        if (feedforwardAveraging) {
-            setpointDelta[axis] = laggedMovingAverageUpdate(&setpointDeltaAvg[axis].filter, setpointDelta[axis]);
-        }
-
-        // apply feedforward transition
-        setpointDelta[axis] *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1.0f;
-
     }
     return setpointDelta[axis]; // the value used by the PID code
 }
@@ -221,6 +234,6 @@ FAST_CODE_NOINLINE float applyFeedforwardLimit(int axis, float value, float Kp, 
 
 bool shouldApplyFeedforwardLimits(int axis)
 {
-    return axis < FD_YAW && feedforwardMaxRateLimit[axis] != 0.0f;
+    return axis < FD_YAW && !FLIGHT_MODE(ANGLE_MODE) && feedforwardMaxRateLimit[axis] != 0.0f;
 }
 #endif

--- a/src/main/flight/feedforward.h
+++ b/src/main/flight/feedforward.h
@@ -25,7 +25,8 @@
 #include "common/axis.h"
 #include "flight/pid.h"
 
+uint8_t getFeedforwardDuplicateCount(int axis);
 void feedforwardInit(const pidProfile_t *pidProfile);
-float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging);
+float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint);
 float applyFeedforwardLimit(int axis, float value, float Kp, float currentPidSetpoint);
 bool shouldApplyFeedforwardLimits(int axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -128,7 +128,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
             [PID_ROLL] =  PID_ROLL_DEFAULT,
             [PID_PITCH] = PID_PITCH_DEFAULT,
             [PID_YAW] =   PID_YAW_DEFAULT,
-            [PID_LEVEL] = { 50, 50, 75, 0 },
+            [PID_LEVEL] = { 50, 50, 75, 50 },
             [PID_MAG] =   { 40, 0, 0, 0 },
         },
         .pidSumLimit = PIDSUM_LIMIT,
@@ -138,7 +138,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dterm_notch_cutoff = 0,
         .itermWindupPointPercent = 85,
         .pidAtMinThrottle = PID_STABILISATION_ON,
-        .levelAngleLimit = 55,
+        .angle_limit = 60,
         .feedforward_transition = 0,
         .yawRateAccelLimit = 0,
         .rateAccelLimit = 0,
@@ -223,6 +223,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_mode = TPA_MODE_D,
         .tpa_rate = 65,
         .tpa_breakpoint = 1350,
+        .angle_feedforward_smoothing = 50,
+        .angle_earth_ref = 100,
     );
 
 #ifndef USE_D_MIN
@@ -364,9 +366,20 @@ float pidApplyThrustLinearization(float motorOutput)
 
 #if defined(USE_ACC)
 // calculate the stick deflection while applying level mode expo
-static float getLevelModeRcDeflection(uint8_t axis)
+static float getAngleModeStickInput(uint8_t axis)
 {
     const float stickDeflection = getRcDeflection(axis);
+    if (axis < FD_YAW) {
+        const float expof = currentControlRateProfile->levelExpo[axis] / 100.0f;
+        return power3(stickDeflection) * expof + stickDeflection * (1 - expof);
+    } else {
+        return stickDeflection;
+    }
+}
+
+static float getAngleModeStickInputRaw(uint8_t axis)
+{
+    const float stickDeflection = getRcDeflectionRaw(axis);
     if (axis < FD_YAW) {
         const float expof = currentControlRateProfile->levelExpo[axis] / 100.0f;
         return power3(stickDeflection) * expof + stickDeflection * (1 - expof);
@@ -379,7 +392,7 @@ static float getLevelModeRcDeflection(uint8_t axis)
 STATIC_UNIT_TESTED FAST_CODE_NOINLINE float calcHorizonLevelStrength(void)
 {
     // start with 1.0 at center stick, 0.0 at max stick deflection:
-    float horizonLevelStrength = 1.0f - MAX(fabsf(getLevelModeRcDeflection(FD_ROLL)), fabsf(getLevelModeRcDeflection(FD_PITCH)));
+    float horizonLevelStrength = 1.0f - MAX(fabsf(getAngleModeStickInput(FD_ROLL)), fabsf(getAngleModeStickInput(FD_PITCH)));
 
     // 0 at level, 90 at vertical, 180 at inverted (degrees):
     const float currentInclination = MAX(abs(attitude.values.roll), abs(attitude.values.pitch)) / 10.0f;
@@ -436,28 +449,117 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float calcHorizonLevelStrength(void)
 // The impact is possibly slightly slower performance on F7/H7 but they have more than enough
 // processing power that it should be a non-issue.
 STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim,
-                                                        float currentPidSetpoint, float horizonLevelStrength)
+                                                        float rawSetpoint, float horizonLevelStrength, bool newRcFrame)
 {
-    const float levelAngleLimit = pidProfile->levelAngleLimit;
-    // calculate error angle and limit the angle to the max inclination
-    // rcDeflection is in range [-1.0, 1.0]
-    float angle = levelAngleLimit * getLevelModeRcDeflection(axis);
-#ifdef USE_GPS_RESCUE
-    angle += gpsRescueAngle[axis] / 100; // ANGLE IS IN CENTIDEGREES
+    const float angleLimit = pidProfile->angle_limit;
+
+    // ** angle loop feedforward
+    float angleFeedforward = 0.0f;
+#ifdef USE_FEEDFORWARD
+    const float rxRateHz = 1e6f / getCurrentRxRefreshRate();
+    const float rcCommandDelta = fabsf(getRcCommandDelta(axis));
+    if (newRcFrame){
+        float angleTargetRaw = angleLimit * getAngleModeStickInputRaw(axis);
+        #ifdef USE_GPS_RESCUE
+            angleTargetRaw += gpsRescueAngle[axis] / 100.0f; // ANGLE IS IN CENTIDEGREES
+        #endif
+        // set angleFeedforward to previous feedforward value, to be used if we get a duplicate packet
+        float angleFeedforwardInput = 0.0f;
+        if (rcCommandDelta) {
+            // this runs at Rx link rate
+            pidRuntime.angleTargetDelta[axis] = (angleTargetRaw - pidRuntime.angleTargetPrevious[axis]);
+            angleFeedforwardInput = pidRuntime.angleTargetDelta[axis];
+            pidRuntime.angleDuplicateCount[axis] = 0;
+            pidRuntime.angleTargetPrevious[axis] = angleTargetRaw;
+            // no need for averaging or PT1 smoothing because of the strong PT3 smoothing of the final value
+        } else { // it's a duplicate
+            // TO DO - interpolate duplicates in rc.c for frsky so that incoming steps don't have them
+            pidRuntime.angleDuplicateCount[axis] += 1;
+            float rcDeflectionAbs = getRcDeflectionAbs(axis);
+            if (pidRuntime.angleDuplicateCount[axis] == 1 && rcDeflectionAbs < 0.97f) {
+                // on first duplicate, unless we just hit max deflection, reduce glitch by interpolation
+                angleFeedforwardInput = pidRuntime.angleTargetDelta[axis];
+            } else {
+                // force feedforward to zero
+                pidRuntime.angleDuplicateCount[axis] = 2;
+                pidRuntime.angleTargetDelta[axis] = 0.0f;
+                angleFeedforwardInput = 0.0f;
+            }
+        }
+        // jitter attenuation copied from feedforward.c
+        // TO DO move jitter algorithm to rc.c and use same code here and in feedforward.c
+        const float feedforwardJitterFactor = pidRuntime.feedforwardJitterFactor;
+        float jitterAttenuator = 1.0f;
+        if (feedforwardJitterFactor) {
+            if (rcCommandDelta < feedforwardJitterFactor) {
+                jitterAttenuator = MAX(1.0f - (rcCommandDelta / feedforwardJitterFactor), 0.0f);
+                jitterAttenuator = 1.0f - jitterAttenuator * jitterAttenuator;
+            }
+        }
+        angleFeedforwardInput *= jitterAttenuator * rxRateHz;
+        pidRuntime.angleFeedforward[axis] = angleFeedforwardInput; // feedforward element in degrees
+    }
+    angleFeedforward = pidRuntime.angleFeedforward[axis] * pidRuntime.angleFeedforwardGain;
+    // filter angle feedforward, heavily, at the PID loop rate, providing user control over time constant
+    // const float angleFeedforwardRaw = angleFeedforward; // for debugging
+    angleFeedforward = pt3FilterApply(&pidRuntime.angleFeedforwardPt3[axis], angleFeedforward);
 #endif
-    angle = constrainf(angle, -levelAngleLimit, levelAngleLimit);
-    const float errorAngle = angle - ((attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f);
+
+    // ** angle error correction
+    // calculate error angle and limit the angle to the max inclination
+    // stick input is from rcCommand, is smoothed, includes level expo, and is in range [-1.0, 1.0]
+    float angleTarget = angleLimit * getAngleModeStickInput(axis);
+#ifdef USE_GPS_RESCUE
+    angleTarget += gpsRescueAngle[axis] / 100.0f; // ANGLE IS IN CENTIDEGREES
+#endif
+    pidRuntime.angleTarget[axis] = angleTarget;
+    const float currentAngle = (attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f; // stepped at 500hz with some 4ms flat spots
+    const float errorAngle = angleTarget - currentAngle;
+    // smooth the errorAngle to clean up both attitude signal steps (500hz) and RC dropout steps at ATTITUDE_CUTOFF_HZ
+    const float errorAngleSmoothed = pt3FilterApply(&pidRuntime.attitudeFilter[axis], errorAngle);
+
+    float axisCoordination = 0.0f;
     if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
-        // ANGLE mode - control is angle based
-        const float setpointCorrection = errorAngle * pidRuntime.levelGain;
-        currentPidSetpoint = pt3FilterApply(&pidRuntime.attitudeFilter[axis], setpointCorrection);
+        // ANGLE mode - control is angle based with P term based on angle error and feedforward based on angle setpoint velocity
+        rawSetpoint = errorAngleSmoothed * pidRuntime.angleGain + angleFeedforward;
+        // optionally, minimise cross-axis wobble due to faster yaw responses than roll or pitch, and make co-ordinated yaw turns
+        // by compensating for the effect of yaw on roll while pitched, and on pitch while rolled
+        if (pidRuntime.angleEarthRef) {
+            axisCoordination = pidRuntime.angleYawSetpoint;
+            if (axis == FD_ROLL){
+                axisCoordination *= sin_approx(DEGREES_TO_RADIANS(pidRuntime.angleTarget[FD_PITCH]));
+                axisCoordination = -axisCoordination;
+            } else if (axis == FD_PITCH) {
+                axisCoordination *= sin_approx(DEGREES_TO_RADIANS(pidRuntime.angleTarget[FD_ROLL]));
+            }
+            // adjust the amount of yaw/roll/pitch integration here for testing
+            rawSetpoint += axisCoordination * pidRuntime.angleEarthRef;
+        }
+
     } else {
         // HORIZON mode - mix of ANGLE and ACRO modes
         // mix in errorAngle to currentPidSetpoint to add a little auto-level feel
-        const float setpointCorrection = errorAngle * pidRuntime.horizonGain * horizonLevelStrength;
-        currentPidSetpoint += pt3FilterApply(&pidRuntime.attitudeFilter[axis], setpointCorrection);
+        rawSetpoint += errorAngleSmoothed * horizonLevelStrength * pidRuntime.horizonGain;
     }
-    return currentPidSetpoint;
+
+
+    //logging
+    if (axis == FD_ROLL) {
+        DEBUG_SET(DEBUG_ANGLE_MODE, 0, lrintf(angleTarget * 10.0f)); // target angle
+//        DEBUG_SET(DEBUG_ANGLE_MODE, 1, lrintf(angleFeedforwardRaw * 10.0f));
+        DEBUG_SET(DEBUG_ANGLE_MODE, 1, lrintf(errorAngleSmoothed * pidRuntime.angleGain * 10.0f)); // un-smoothed error correction in degrees
+        DEBUG_SET(DEBUG_ANGLE_MODE, 2, lrintf(angleFeedforward * 10.0f)); // feedforward amount in degrees
+        DEBUG_SET(DEBUG_ANGLE_MODE, 3, lrintf(currentAngle * 10.0f)); // angle returned
+
+        DEBUG_SET(DEBUG_ANGLE_TARGET, 0, lrintf(angleTarget * 10.0f));
+        DEBUG_SET(DEBUG_ANGLE_TARGET, 1, lrintf(axisCoordination * 10.0f));
+        // debug 2 is yaw attenuation
+        DEBUG_SET(DEBUG_ANGLE_TARGET, 3, lrintf(currentAngle * 10.0f)); // angle returned
+    }
+
+//    DEBUG_SET(DEBUG_ANGLE_TARGET, axis, lrintf(angleTarget * 10.0f)); // target angle
+    DEBUG_SET(DEBUG_CURRENT_ANGLE, axis, lrintf(currentAngle * 10.0f)); // current angle
+    return rawSetpoint;
 }
 
 static FAST_CODE_NOINLINE void handleCrashRecovery(
@@ -475,7 +577,7 @@ static FAST_CODE_NOINLINE void handleCrashRecovery(
             if (sensors(SENSOR_ACC)) {
                 // errorAngle is deviation from horizontal
                 const float errorAngle =  -(attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f;
-                *currentPidSetpoint = errorAngle * pidRuntime.levelGain;
+                *currentPidSetpoint = errorAngle * pidRuntime.angleGain;
                 *errorRate = *currentPidSetpoint - gyroRate;
             }
         }
@@ -731,7 +833,11 @@ STATIC_UNIT_TESTED void applyItermRelax(const int axis, const float iterm,
 
     if (pidRuntime.itermRelax) {
         if (axis < FD_YAW || pidRuntime.itermRelax == ITERM_RELAX_RPY || pidRuntime.itermRelax == ITERM_RELAX_RPY_INC) {
-            const float itermRelaxFactor = MAX(0, 1 - setpointHpf / ITERM_RELAX_SETPOINT_THRESHOLD);
+            float itermRelaxThreshold = ITERM_RELAX_SETPOINT_THRESHOLD;
+            if (FLIGHT_MODE(ANGLE_MODE)) {
+                itermRelaxThreshold *= 0.2f;
+            }
+            const float itermRelaxFactor = MAX(0, 1 - setpointHpf / itermRelaxThreshold);
             const bool isDecreasingI =
                 ((iterm > 0) && (*itermErrorRate < 0)) || ((iterm < 0) && (*itermErrorRate > 0));
             if ((pidRuntime.itermRelax >= ITERM_RELAX_RP_INC) && isDecreasingI) {
@@ -931,23 +1037,34 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     rpmFilterUpdate();
 #endif
 
-#ifdef USE_FEEDFORWARD
-    const bool newRcFrame = getShouldUpdateFeedforward();
-#endif
+const bool newRcFrame = getShouldUpdateFeedforward();
 
     // ----------PID controller----------
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
 
         float currentPidSetpoint = getSetpointRate(axis);
+        float rawSetpoint = getRawSetpoint(axis);
         if (pidRuntime.maxVelocity[axis]) {
             currentPidSetpoint = accelerationLimit(axis, currentPidSetpoint);
         }
         // Yaw control is GYRO based, direct sticks control is applied to rate PID
         // When Race Mode is active PITCH control is also GYRO based in level or horizon mode
 #if defined(USE_ACC)
+        if (axis == FD_YAW && pidRuntime.angleEarthRef) {
+            pidRuntime.angleYawSetpoint = currentPidSetpoint;
+            if (levelMode == LEVEL_MODE_RP && !FLIGHT_MODE(HORIZON_MODE)) {
+                float maxAngleTargetAbs = fmaxf( fabsf(pidRuntime.angleTarget[FD_ROLL]), fabsf(pidRuntime.angleTarget[FD_PITCH]) );
+                maxAngleTargetAbs *= pidRuntime.angleEarthRef;
+                const float attenuateYawSetpoint = cos_approx(DEGREES_TO_RADIANS(maxAngleTargetAbs));
+                currentPidSetpoint *= attenuateYawSetpoint;
+                rawSetpoint *= attenuateYawSetpoint;
+        DEBUG_SET(DEBUG_ANGLE_TARGET, 2, lrintf(attenuateYawSetpoint * 100.0f)); // yaw attenuation
+            }
+        }
         if ((levelMode == LEVEL_MODE_R && axis == FD_ROLL)
             || (levelMode == LEVEL_MODE_RP && (axis == FD_ROLL || axis ==  FD_PITCH)) ) {
-            currentPidSetpoint = pidLevel(axis, pidProfile, angleTrim, currentPidSetpoint, horizonLevelStrength);
+            rawSetpoint = pidLevel(axis, pidProfile, angleTrim, rawSetpoint, horizonLevelStrength, newRcFrame);
+            currentPidSetpoint = rawSetpoint;
             DEBUG_SET(DEBUG_ATTITUDE, axis - FD_ROLL + 2, currentPidSetpoint);
         }
 #endif
@@ -1030,7 +1147,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         // -----calculate pidSetpointDelta
         float pidSetpointDelta = 0;
 #ifdef USE_FEEDFORWARD
-        pidSetpointDelta = feedforwardApply(axis, newRcFrame, pidRuntime.feedforwardAveraging);
+        pidSetpointDelta = feedforwardApply(axis, newRcFrame, pidRuntime.feedforwardAveraging, rawSetpoint);
 #endif
         pidRuntime.previousPidSetpoint[axis] = currentPidSetpoint;
 
@@ -1102,8 +1219,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         // no feedforward in launch control
         float feedforwardGain = launchControlActive ? 0.0f : pidRuntime.pidCoefficient[axis].Kf;
         if (feedforwardGain > 0) {
-            // halve feedforward in Level mode since stick sensitivity is weaker by about half
-            feedforwardGain *= FLIGHT_MODE(ANGLE_MODE) ? 0.5f : 1.0f;
             // transition now calculated in feedforward.c when new RC data arrives
             float feedForward = feedforwardGain * pidSetpointDelta * pidRuntime.pidFrequency;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -146,7 +146,7 @@ typedef struct pidProfile_s {
     uint16_t pidSumLimit;
     uint16_t pidSumLimitYaw;
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.
-    uint8_t levelAngleLimit;                // Max angle in degrees in level mode
+    uint8_t angle_limit;                     // Max angle in degrees in Angle mode
 
     uint8_t horizon_tilt_effect;            // inclination factor for Horizon mode
     uint8_t horizon_tilt_expert_mode;       // OFF or ON
@@ -233,6 +233,8 @@ typedef struct pidProfile_s {
     uint8_t tpa_mode;                       // Controls which PID terms TPA effects
     uint8_t tpa_rate;                       // Percent reduction in P or D at full throttle
     uint16_t tpa_breakpoint;                // Breakpoint where TPA is activated
+    uint8_t angle_feedforward_smoothing;    // Smoothing factor for angle feedforward
+    uint8_t angle_earth_ref;         // Control amount of "co-ordination" from yaw into roll while pitched forward in angle mode
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -293,7 +295,8 @@ typedef struct pidRuntime_s {
     uint8_t antiGravityGain;
     float antiGravityPGain;
     pidCoefficient_t pidCoefficient[XYZ_AXIS_COUNT];
-    float levelGain;
+    float angleGain;
+    float angleFeedforwardGain;
     float horizonGain;
     float horizonTransition;
     float horizonCutoffDegrees;
@@ -395,10 +398,18 @@ typedef struct pidRuntime_s {
     float feedforwardSmoothFactor;
     float feedforwardJitterFactor;
     float feedforwardBoostFactor;
+    float angleFeedforward[XYZ_AXIS_COUNT];
+    float angleTargetPrevious[XYZ_AXIS_COUNT];
+    float angleTargetDelta[XYZ_AXIS_COUNT];
+    uint8_t angleDuplicateCount[XYZ_AXIS_COUNT];
 #endif
 
 #ifdef USE_ACC
     pt3Filter_t attitudeFilter[2];  // Only for ROLL and PITCH
+    pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
+    float angleYawSetpoint;
+    float angleEarthRef;
+    float angleTarget[2];
 #endif
 } pidRuntime_t;
 
@@ -445,7 +456,7 @@ void applyItermRelax(const int axis, const float iterm,
 void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate);
 void rotateItermAndAxisError();
 float pidLevel(int axis, const pidProfile_t *pidProfile,
-    const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint, float horizonLevelStrength);
+    const rollAndPitchTrims_t *angleTrim, float rawSetpoint, float horizonLevelStrength, bool newRcFrame);
 float calcHorizonLevelStrength(void);
 #endif
 void dynLpfDTermUpdate(float throttle);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1946,7 +1946,7 @@ case MSP_NAME:
         sbufWriteU8(dst, 0); // reserved
         sbufWriteU16(dst, currentPidProfile->rateAccelLimit);
         sbufWriteU16(dst, currentPidProfile->yawRateAccelLimit);
-        sbufWriteU8(dst, currentPidProfile->levelAngleLimit);
+        sbufWriteU8(dst, currentPidProfile->angle_limit);
         sbufWriteU8(dst, 0); // was pidProfile.levelSensitivity
         sbufWriteU16(dst, 0); // was currentPidProfile->itermThrottleThreshold
         sbufWriteU16(dst, currentPidProfile->anti_gravity_gain);
@@ -3084,7 +3084,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         currentPidProfile->rateAccelLimit = sbufReadU16(src);
         currentPidProfile->yawRateAccelLimit = sbufReadU16(src);
         if (sbufBytesRemaining(src) >= 2) {
-            currentPidProfile->levelAngleLimit = sbufReadU8(src);
+            currentPidProfile->angle_limit = sbufReadU8(src);
             sbufReadU8(src); // was pidProfile.levelSensitivity
         }
         if (sbufBytesRemaining(src) >= 4) {

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -28,6 +28,10 @@ bool simulatedAirmodeEnabled = true;
 float simulatedSetpointRate[3] = { 0,0,0 };
 float simulatedPrevSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
+float simulatedRcCommandDelta[3] = { 1,1,1 };
+float simulatedRawSetpoint[3] = { 0,0,0 };
+uint16_t simulatedCurrentRxRefreshRate = 10000;
+uint8_t simulatedDuplicateCount = 0;
 float simulatedMotorMixRange = 0.0f;
 
 int16_t debug[DEBUG16_VALUE_COUNT];
@@ -84,6 +88,11 @@ extern "C" {
     void systemBeep(bool) { }
     bool gyroOverflowDetected(void) { return false; }
     float getRcDeflection(int axis) { return simulatedRcDeflection[axis]; }
+    float getRcCommandDelta(int axis) { return simulatedRcCommandDelta[axis]; }
+    float getRcDeflectionRaw(int axis) { return simulatedRcDeflection[axis]; }
+    float getRawSetpoint(int axis) { return simulatedRawSetpoint[axis]; }
+    uint16_t getCurrentRxRefreshRate(void) { return simulatedCurrentRxRefreshRate; }
+    uint8_t getFeedforwardDuplicateCount(void) { return simulatedDuplicateCount; }
     void beeperConfirmationBeeps(uint8_t) { }
     bool isLaunchControlActive(void) {return unitLaunchControlActive; }
     void disarm(flightLogDisarmReason_e) { }
@@ -95,10 +104,11 @@ extern "C" {
         return value;
     }
     void feedforwardInit(const pidProfile_t) { }
-    float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging)
+    float feedforwardApply(int axis, bool newRcFrame, feedforwardAveraging_t feedforwardAveraging, const float setpoint)
     {
         UNUSED(newRcFrame);
         UNUSED(feedforwardAveraging);
+        UNUSED(setpoint);
         const float feedforwardTransitionFactor = pidGetFeedforwardTransitionFactor();
         float setpointDelta = simulatedSetpointRate[axis] - simulatedPrevSetpointRate[axis];
         setpointDelta *= feedforwardTransitionFactor > 0 ? MIN(1.0f, getRcDeflectionAbs(axis) * feedforwardTransitionFactor) : 1;
@@ -125,7 +135,7 @@ void setDefaultTestSettings(void)
     pidProfile->pid[PID_ROLL]  =  { 40, 40, 30, 65 };
     pidProfile->pid[PID_PITCH] =  { 58, 50, 35, 60 };
     pidProfile->pid[PID_YAW]   =  { 70, 45, 20, 60 };
-    pidProfile->pid[PID_LEVEL] =  { 50, 50, 75, 0 };
+    pidProfile->pid[PID_LEVEL] =  { 50, 50, 75, 50 };
 
     // Compensate for the upscaling done without 'use_integrated_yaw'
     pidProfile->pid[PID_YAW].I = pidProfile->pid[PID_YAW].I / 2.5f;
@@ -140,7 +150,7 @@ void setDefaultTestSettings(void)
     pidProfile->dterm_lpf1_type = FILTER_BIQUAD;
     pidProfile->itermWindupPointPercent = 50;
     pidProfile->pidAtMinThrottle = PID_STABILISATION_ON;
-    pidProfile->levelAngleLimit = 55;
+    pidProfile->angle_limit = 60;
     pidProfile->feedforward_transition = 100;
     pidProfile->yawRateAccelLimit = 100;
     pidProfile->rateAccelLimit = 0;
@@ -194,6 +204,7 @@ void resetTest(void)
         pidData[axis].Sum = 0;
         simulatedSetpointRate[axis] = 0;
         simulatedRcDeflection[axis] = 0;
+        simulatedRawSetpoint[axis] = 0;
         gyro.gyroADCf[axis] = 0;
     }
     attitude.values.roll = 0;
@@ -381,39 +392,38 @@ TEST(pidControllerTest, testPidLevel)
     float currentPidSetpoint = 30;
     rollAndPitchTrims_t angleTrim = { { 0, 0 } };
 
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
     EXPECT_FLOAT_EQ(0, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
     EXPECT_FLOAT_EQ(0, currentPidSetpoint);
 
     // Test attitude response
     setStickPosition(FD_ROLL, 1.0f);
     setStickPosition(FD_PITCH, -1.0f);
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(244.07211, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-244.07211, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(175.93526, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-175.93526, currentPidSetpoint);
 
     setStickPosition(FD_ROLL, -0.5f);
     setStickPosition(FD_PITCH, 0.5f);
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-93.487915, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(93.487915, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(4.5994134, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-4.5994134, currentPidSetpoint);
 
     attitude.values.roll = -275;
     attitude.values.pitch = 275;
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-12.047981, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(12.047981, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-19.85273, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(19.85273, currentPidSetpoint);
 
     // Disable ANGLE_MODE
     disableFlightMode(ANGLE_MODE);
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(11.07958, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(12.047981, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(19.85273, currentPidSetpoint);
 
     // Test level mode expo
     enableFlightMode(ANGLE_MODE);
@@ -423,10 +433,10 @@ TEST(pidControllerTest, testPidLevel)
     setStickPosition(FD_PITCH, -0.5f);
     currentControlRateProfile->levelExpo[FD_ROLL] = 50;
     currentControlRateProfile->levelExpo[FD_PITCH] = 26;
-    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(76.208672, currentPidSetpoint);
-    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-98.175163, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(44.735287, currentPidSetpoint);
+    currentPidSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpoint, calcHorizonLevelStrength(), true);
+    EXPECT_FLOAT_EQ(-60.569462, currentPidSetpoint);
 }
 
 


### PR DESCRIPTION
This PR continues the development of @ChrisRosser's initial PR #12041, which added feedforward to Angle Mode.

## Main changes

- **angle mode feedforward** - adjustable with `angle_feedforward` and `angle_feedforward_smoothing`
- **angle mode earth referencing for yaw inputs** - adjustable with `angle_earth_ref`

Angle mode feedforward speeds up responsiveness to stick inputs by adding a feedforward element the simple angle error controller.  It respects the angle expo settings and the general feedforward jitter correction settings.  

Earth referencing of yaw inputs is provided because:
- it minimises the cross-axis wobble that otherwise would occur with a fast yaw input at steep quad angles.  This happened previously because yaw inputs in the axis of the quad were too fast for the pitch and roll levelling functionality.
- it automatically 'co-ordinates' turns, keeping the PFV camera image, and the pitch of the quad, unchanged during a fast yaw input while pitched forward.  This is achieved by mixing in the right amount of roll to a yaw input, and attenuating yaw at high quad angles.

The earth referencing code in this PR was inspired by Chris Rosser's PR #12071.  There are two main differences between the two variants are that here:
- only yaw inputs are earth referenced; pitch and roll inputs act in the quad's plane of reference, whereas 12071 earth references inputs on all axes.  By only earth referencing yaw, stick 'feel' is very similar to our 'traditional' Angle mode feel
- the 'strength' of the earth referencing can be varied from zero to 100%
- that the input to the earth referencing code is from target angles, not from measured attitude.  This ensures no weird outcomes on impacts where measured attitude values could enter extreme ranges, but can lead to a bit more wobble with very fast inputs in less responsive builds.

Overall this PR brings a significant improvement in Angle Mode responsiveness, reducing the need to push angle P gains higher than normal, and much improved yaw behaviour.  

Horizon mode is not changed (hopefully).

**CLI snippet to remove all angle feedforward and earth referencing - to see what it used to be like:**
```
set angle_feedforward = 0
set angle_earth_ref = 0
```

**CLI snippet to restore new angle feedforward and full earth referencing of yaw**
```
set angle_feedforward = 50
set angle_earth_ref = 100
```

## Background

Previously, Angle Mode replaced the acro mode setpoint with a new setpoint that was calculated only from the error between the target angle and the measured angle of the quad.  It was a simple P controller.  The angle_error correction gain factor was called `level_strength`.  In this PR it is renamed to `angle_p_gain`.  

In the older versions, a stick input in Angle Mode (a change from one target Angle value to something different) would dynamically adjust the PID loop setpoint values in proportion to the angle error (it was a simple P controller). The setpoint value / resulting gyro rate was proportional to the angle error.  Because the gyro rate was proportional to error, it would decrease as the error decreased, and the quad followed an exponential decay from the initial towards the new target value - literally taking 'forever'.  Additionally, the initial response was slow, since error would be small at the start of any change in stick position.  The result was a floaty, drifting, slow stick response, in angle mode, typically taking hundreds of milliseconds to acquire the intended target angle.  If the user wanted a quicker stick response, the only option was to increase the level gain factor, which often caused oscillation.

@ChrisRosser recognised that we could add a direct stick-movement-related feedforward element to the angle controller, which would generate an immediate change in angle setpoint, especially with quick stick inputs, in turn leading to an immediate gyro response.  The concept was, in principle, similar to the feedforward used in the acro PID loop.

There were significant technical challenges in providing feedforward in two places at the same time, most notably exaggerated feedforward noise unless the angle mode feedforward was very heavily smoothed.  Additionally, feedforward in angle mode will exaggerate any wobbles in the stick inputs much more than feedforward in the gyro loop.  The end result was very good.

Note that Angle Mode feedforward respects both the angle_expo settings and the general jitter reduction and duplicate interpolation settings.  Also note that the PID loop feedforward works on setpoint as usual.

## Summary of changes

- all CLI parameters used by Angle Mode re-named to start with `angle_`
- `angle_feedforward` CLI value: Adjusts the angle feedforward amount or strength; default is 50, zero means none, returning the previous behaviour.
- `angle_feedforward_smoothing` CLI value: Adjusts the response time of the angle feedforward effect; this is implemented using a PT3 filter over the raw feedforward data, with its cutoff set to `100 / angle_feedforward_smoothing` in Hz.  The default of 50 returns the time constant of a 2hz PT3 lowpass filter.  This filter removes noise and jitter from the angle feedforward element.
- Angle Mode expo factor: Defaults to 33 on both `angle_roll_expo` and `angle_pitch_expo`, to soften centre stick responsiveness
- `angle_limit` changes - the default value is increased to 60 degrees (from 55 degrees), and the max reduced to 85 degrees (from 90).  You may experience control issues when angle_limit is set to more than 63 degrees and both pitch and roll sticks are at full deflection, since the FC will point to the ground (be up-side down)with those inputs.  Don't go above 63 unless you avoid full stick deflections on pitch and roll at the same time.
- `angle_earth_ref` sets the amount of earth referencing.  When at default of 100, we get automatic 'co-ordinated' turns, i.e. the pitch angle of the quad remains stable even during quick yaws at high stick angle.  A value of 0 disables earth referencing, and the behaviour is same as the old Angle Mode code, where the pilot needs to manually provide significant roll input, and use less yaw, when turning at high pitch angles. A value of 50 applies roughly half the effect.
- iTerm_Relax is made more sensitive to avoid iTerm wobble with slow wobbly stick inputs

- an `ANGLE_MODE` debug is provided to visualise target angle, acquired angle, and the contributions from error and feedforward control elements.  All values are in degrees.

## Understanding Feedforward in Angle Mode

Absolute stick position in Angle Mode sets the requested angle of the quad. A change in angle is acquired by dynamically adjusting the gyro rate setpoint until the required angle is achieved.

Feedforward in Angle Mode translates stick velocity into the rate of change of angle target.  This is the same as a direct change in gyro rate setpoint (the target turn rate for the acro PID controller).  Angle Feedforward is therefore entirely independent of the contribution from the error-based method, which sets the target turn rate in proportion to angle error only.

After a given amount of stick movement is complete, the gyro rate that has integrated over the stick movement period from angle feedforward will have achieved, from the feedforward alone, a certain change in the angle, or attitude, of the quad.  The amount of angle change from angle_feedforward depends only on the speed of stick movement, the duration of the movement, and the `angle_feedforward` gain setting.

Therefore we can think of the angle feedforward element as being a way to directly add angle from stick input alone.  In fact, with enough feedforward, the requested angle can be acquired, with zero `angle_P_ gain`, from feedforward alone.

If the `angle_feedforward` value is set too high, it will cause the quad to overshoot the target angle change, leading to a delayed 'rubber-banding' or pull-back of that overshoot. This is a sure way to know that the `angle_feedforward` setting is too high, assuming the quad is otherwise properly tuned in acro mode.  An LOS pilot, or a quad with a gimballed camera, may intentionally seek some pull-back to pull up more quickly in Angle Mode.  For general FPV flying the default value is close to the maximum that should be used.

Lowering the `angle_feedforward` value leaves the simple error controller more work to do, and the quad's responsiveness to stick inputs will be slower, smoother, and less complete, leading to greater lag and drift.  

The `angle_feedforward_smoothing` parameter changes the response time, but not the overall amount, of the angle feedforward factor. 

If there was no smoothing, an abrupt increase in stick velocity would lead to a step increase in the angle feedforward value, which would result in a step, or instant, increase in requested gyro rate.  This would result in an incredibly jerky response from the motors, and lead to a lot of oscillation.  Hence the angle feedforward value must be smoothed quite heavily.

Increasing `angle_feedforward_smoothing` smooths out the angle mode feedforward effect, using a PT3 filter.  Higher values result in slower rates of change of gyro response, with more gentle feedforward effects.   Too much smoothing can lead to overshoot or rubber-banding after fast stick inputs, because of slow decay of the feedforward element.  When seeking a smoother or less aggressive feedforward effect, the the amount of `angle_feedforward` gain should be reduced at the same time.

Decreasing `angle_feedforward_smoothing` makes angle mode stick responses faster.  This can be great for LOS level flying, since the quad will start and stop much more quickly and precisely.  For FPV racing in level mode, eg `level_race` mode, the pilot will get a much more prompt and complete angle response.  When set really fast, every little adjustment the pilot makes results in a quick gyro change, so that when set too fast, the quad appears to wobble or jump with even a tiny input.

## Tuning

The defaults are really very nice, for general use.

Tuning is only needed if optimal performance is sought for level mode racing, or if less aggressive responses are needed for smooth HD video.

*For racing / fastest possible angle mode responsiveness:*
- disable angle mode feedforward completely in the CLI with `set angle_feedforward = 0`.
- Adjust `angle_p_gain` upwards.  Aim for about 10% less than the value that introduces wobble.  Angle wobble is easily seen in FPV goggles.  Optimising this value helps the quad quickly fix both commanded and un-commanded angle errors.
- restore `angle_feedforward` to the default value
- test fly with fast stick inputs, spirals etc
- if faster stick responsiveness is required, increase `angle_feedforward` until you get rubber-banding, then back off until it isn't there any more.
- if even faster stick responsiveness is required, reduce `angle_feedforward_smoothing` until it's just too crazy.  You may be able to slightly increase `angle_feedforward` at this point above the previous value.
- for easy 'yaw only' inputs on turns, leave `angle_earth_ref` at default of 100.  For a more acro-style / traditional 'roll into fast turn' behaviour, reduce the `angle_earth_ref` setting.  At lower values you must provide a lot of roll input, and use less yaw input, to make clean turns at high pitch angles.

*For smoothness:*
- disable angle mode feedforward completely in the CLI with `set angle_feedforward = 0`.
- make sure there is no `angle_p_gain` wobble in the video footage.  This would be seen as additional wobble that is not present in acro mode, perhaps more obvious around stick inputs.  If there is, reduce `angle_p_gain` until the wobble is no worse than acro.
- do a test flight and see if the responsiveness is 'about right'
- if a faster stick response is needed, add `angle_feedforward` in steps, until the stick response feels about right
- if the overall stick response is about right, but the quad still is a bit 'reactive', try increasing the `angle_feedforward_smoothing` parameter until the video is smooth enough.

*For learning*
- use the defaults
- consider reducing angle_limit, but usually not less than 40 degrees

## To Do's

For this PR:
- check that the unit tests are sensible.  Currently they do not consider the effect of yaw inputs.

For other PR's:
- move the jitterFactor calculation to rc.c so we only do that maths once
- likewise move the duplicate detection and correction code so that it only applies to rc protocols that create duplicates.
- integrate yaw inputs into angle set points.  Currently a pure yaw input while pitched forward rotates the quad on the local yaw axis, losing pitch angle and gaining roll angle, and the error-based Angle Mode controller corrects these errors.  But this correction is slow and has no feedforward.  This could, perhaps, generate a setpoint change on roll, proportional to the pitch angle and the yaw rate, to provide a 'co-ordinated turn', and otherwise handle yaw inputs better, in level mode.
- investigate a more earth-referenced attitude control method