### PR TITLE
FIX: Include the legacy drivers (gated)

### DIFF
--- a/src/main/target/STM32F411/target.mk
+++ b/src/main/target/STM32F411/target.mk
@@ -23,6 +23,7 @@ FEATURES       += VCP SDCARD_SPI SDCARD_SDIO ONBOARDFLASH
 
 TARGET_SRC = \
 	$(addprefix drivers/accgyro/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro/*.c))) \
+	$(addprefix drivers/accgyro_legacy/,$(notdir $(wildcard $(SRC_DIR)/drivers/accgyro_legacy/*.c))) \
 	$(ROOT)/lib/main/BoschSensortec/BMI270-Sensor-API/bmi270_maximum_fifo.c \
 	$(addprefix drivers/barometer/,$(notdir $(wildcard $(SRC_DIR)/drivers/barometer/*.c))) \
 	$(addprefix drivers/compass/,$(notdir $(wildcard $(SRC_DIR)/drivers/compass/*.c))) \


### PR DESCRIPTION
Unable to use the gyro for STM32F411DISCOVERY target