### PR TITLE
Add coordination to level mode setpoints: DO NOT MERGE PROTOTYPE ONLY

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -112,6 +112,7 @@ quaternion offset = QUATERNION_INITIALIZE;
 
 // absolute angle inclination in multiple of 0.1 degree    180 deg = 1800
 attitudeEulerAngles_t attitude = EULER_INITIALIZE;
+attitudeEulerCosines_t attitudeCosines = ATTITUDE_COSINES_INITIALIZE;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 2);
 
@@ -343,6 +344,10 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
     if (attitude.values.yaw < 0) {
         attitude.values.yaw += 3600;
     }
+    attitudeCosines.sineRoll = sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
+    attitudeCosines.cosineRoll = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
+    attitudeCosines.sinePitch = sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
+    attitudeCosines.cosinePitch = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
 }
 
 static bool imuIsAccelerometerHealthy(float *accAverage)

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -49,7 +49,17 @@ typedef union {
 } attitudeEulerAngles_t;
 #define EULER_INITIALIZE  { { 0, 0, 0 } }
 
+typedef struct {
+    // cosines of absolute angles
+    float cosineRoll;
+    float cosinePitch;
+    float sineRoll;
+    float sinePitch;
+} attitudeEulerCosines_t;
+#define ATTITUDE_COSINES_INITIALIZE  { 0, 0, 0, 0 }
+
 extern attitudeEulerAngles_t attitude;
+extern attitudeEulerCosines_t attitudeCosines;
 extern float rMat[3][3];
 
 typedef struct imuConfig_s {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -440,7 +440,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
 {  
     if(axis == FD_YAW){
         if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)){
-            currentPidSetpoint = pidRuntime.angleSetpoint[FD_YAW] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch)) * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) - pidRuntime.angleSetpoint[FD_PITCH] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) + pidRuntime.angleSetpoint[FD_ROLL] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
+            currentPidSetpoint = pidRuntime.angleSetpoint[FD_YAW] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch)) * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) + pidRuntime.angleSetpoint[FD_PITCH] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) - pidRuntime.angleSetpoint[FD_ROLL] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
         }
     } else {
         const float levelAngleLimit = pidProfile->levelAngleLimit;
@@ -458,10 +458,10 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
             pidRuntime.angleSetpoint[axis] = pt3FilterApply(&pidRuntime.attitudeFilter[axis], setpointCorrection);
             //cross co-ordination of gyro setpoints
             if(axis == FD_ROLL){
-                currentPidSetpoint = pidRuntime.angleSetpoint[FD_ROLL] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch)) - pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
+                currentPidSetpoint = pidRuntime.angleSetpoint[FD_ROLL] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch)) + pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
             }
             if(axis == FD_PITCH){
-                currentPidSetpoint = pidRuntime.angleSetpoint[FD_PITCH] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) + pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
+                currentPidSetpoint = pidRuntime.angleSetpoint[FD_PITCH] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) - pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
             }
         } else {
             // HORIZON mode - mix of ANGLE and ACRO modes

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -439,10 +439,10 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
                                                         float currentPidSetpoint, float horizonLevelStrength, levelMode_e levelMode)
 {  
     if(axis == FD_YAW && !FLIGHT_MODE(HORIZON_MODE)){
-        currentPidSetpoint = pidRuntime.angleSetpoint[FD_YAW] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch)) * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) - pidRuntime.angleSetpoint[FD_PITCH] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) + pidRuntime.angleSetpoint[FD_ROLL] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
+        currentPidSetpoint = pidRuntime.angleSetpoint[FD_YAW] * attitudeCosines.cosinePitch * attitudeCosines.cosineRoll - pidRuntime.angleSetpoint[FD_PITCH] * attitudeCosines.sineRoll + pidRuntime.angleSetpoint[FD_ROLL] * attitudeCosines.sinePitch;
     } else if((levelMode == LEVEL_MODE_R) && (axis == FD_PITCH)) {
         pidRuntime.angleSetpoint[FD_PITCH] = currentPidSetpoint;
-        currentPidSetpoint = pidRuntime.angleSetpoint[FD_PITCH] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) + pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
+        currentPidSetpoint = pidRuntime.angleSetpoint[FD_PITCH] * attitudeCosines.cosineRoll + pidRuntime.angleSetpoint[FD_YAW] * attitudeCosines.sineRoll;
     } else {
         const float levelAngleLimit = pidProfile->levelAngleLimit;
         // calculate error angle and limit the angle to the max inclination
@@ -459,10 +459,9 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
             pidRuntime.angleSetpoint[axis] = pt3FilterApply(&pidRuntime.attitudeFilter[axis], setpointCorrection);
             //cross co-ordination of gyro setpoints
             if(axis == FD_ROLL){
-                currentPidSetpoint = pidRuntime.angleSetpoint[FD_ROLL] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch)) - pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
-            }
-            if(axis == FD_PITCH){
-                currentPidSetpoint = pidRuntime.angleSetpoint[FD_PITCH] * cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll)) + pidRuntime.angleSetpoint[FD_YAW] * sin_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
+                currentPidSetpoint = pidRuntime.angleSetpoint[FD_ROLL] * attitudeCosines.cosinePitch - pidRuntime.angleSetpoint[FD_YAW] * attitudeCosines.sinePitch;
+            } else {
+                currentPidSetpoint = pidRuntime.angleSetpoint[FD_PITCH] * attitudeCosines.cosineRoll + pidRuntime.angleSetpoint[FD_YAW] * attitudeCosines.sineRoll;
             }
         } else {
             // HORIZON mode - mix of ANGLE and ACRO modes

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -446,7 +446,7 @@ void applyItermRelax(const int axis, const float iterm,
 void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate);
 void rotateItermAndAxisError();
 float pidLevel(int axis, const pidProfile_t *pidProfile,
-    const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint, float horizonLevelStrength);
+    const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint, float horizonLevelStrength, levelMode_e levelMode);
 float calcHorizonLevelStrength(void);
 #endif
 void dynLpfDTermUpdate(float throttle);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -399,6 +399,7 @@ typedef struct pidRuntime_s {
 
 #ifdef USE_ACC
     pt3Filter_t attitudeFilter[2];  // Only for ROLL and PITCH
+    float angleSetpoint[XYZ_AXIS_COUNT];
 #endif
 } pidRuntime_t;
 


### PR DESCRIPTION
Video by @ctzsnooze showing the problem and the fix in this PR: https://www.youtube.com/watch?v=euXXkhVT-9A

@ctzsnooze I hope that similar to my last PR you can work on this, test it, and open a mergeable PR at an approprate time.

Angle mode gets a bit confused when you give sharp yaw inputs to the quad when the quad is already pitched quite far over. This code aims to fix that.

Why do we have an issue today?

**The angle mode controller is fundamentally horizon referenced.** We request pitch and angle relative to the horizon with stick inputs. We also **implicitly** request yaw relative to the horizon as well (otherwise our control axes are not orthogonal!)

The angle controller takes those requests and turns them into a gyro setpoint to move the quad to the requested angle. **These gyro setpoints are quad referenced.**

**All is well when quad reference and horizon reference are similar:**
A change in roll angle creates a change in roll gyro setpoint. A change in roll angle requires the quad to rotate about it's roll axis only.
A change in pitch angle creates a change in pitch gyro setpoint. A change in pitch angle requires the quad to rotate about it's pitch axis only.

However, when the quad is pitched forward at an angle **the quad reference is at an angle to the horizon reference.** This means that a **change in roll angle (which is horizon referenced) requires the quad to rotate about both it's roll and yaw axes.**

When the quad is rolled over at an angle **the quad reference is again at an angle to the horizon reference.** This means that a **change in pitch angle (which is horizon referenced) requires the quad to rotate about both it's pitch and yaw axes.**

Yaw is even more complicated. A change in yaw angle (horizon referenced) may require roatation about all 3 quad axes to achieve it.

This causes issues for the current angle controller as when the quad is at an angle **an input on one axis creates error on the others** this error then needs to be corrected by the controller causing wobbles.

This PR updates the roll, pitch and yaw gyro setpoints based on the current attitude of the quad so that **the gyro setpoints always move the quad straight towards the target angles**. Inputs on one axis will no longer create angle error on the other axes.