### PR TITLE
Fixed edt telemetry initial value assignation

### DIFF
--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -541,7 +541,7 @@ static bool bbUpdateStart(void)
             if (rawValue != DSHOT_TELEMETRY_INVALID) {
                 // Check EDT enable or store raw value
                 if ((rawValue == 0x0E00) && (dshotCommandGetCurrent(motorIndex) == DSHOT_CMD_EXTENDED_TELEMETRY_ENABLE)) {
-                    dshotTelemetryState.motorState[motorIndex].telemetryTypes = DSHOT_TELEMETRY_TYPE_STATE_EVENTS;
+                    dshotTelemetryState.motorState[motorIndex].telemetryTypes = 1 << DSHOT_TELEMETRY_TYPE_STATE_EVENTS;
                 } else {
                     dshotTelemetryState.motorState[motorIndex].rawValue = rawValue;
                 }

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -218,7 +218,7 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
                 if (rawValue != DSHOT_TELEMETRY_INVALID) {
                     // Check EDT enable or store raw value
                     if ((rawValue == 0x0E00) && (dshotCommandGetCurrent(i) == DSHOT_CMD_EXTENDED_TELEMETRY_ENABLE)) {
-                        dshotTelemetryState.motorState[i].telemetryTypes = DSHOT_TELEMETRY_TYPE_STATE_EVENTS;
+                        dshotTelemetryState.motorState[i].telemetryTypes = 1 << DSHOT_TELEMETRY_TYPE_STATE_EVENTS;
                     } else {
                         dshotTelemetryState.motorState[i].rawValue = rawValue;
                     }


### PR DESCRIPTION
DSHOT telemetry types were initialized wrong. When using Bluejay the following dshot_telemetry info was reported:
![imagen](https://user-images.githubusercontent.com/2889851/209102637-948a8488-b627-40c2-a466-2933ca147313.png)

Type is reported as RTV-- (RPM, Temperature, Voltage) when it should be reported as RT--S (RPM, Temperature, STATUS).
This PR solves this issue

