### PR TITLE
Bake in the board information at build time

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -30,16 +30,6 @@
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 
-#ifndef __BOARD__
-#define BOARD_NAME       FC_FIRMWARE_NAME
-#else
-#define BOARD_NAME       __BOARD__
-#endif
-
-#ifndef MANUFACTURER_ID
-#define MANUFACTURER_ID  FC_FIRMWARE_IDENTIFIER 
-#endif
-
 extern const char* const targetName;
 
 #define GIT_SHORT_REVISION_LENGTH   7 // lower case hexadecimal digits.

--- a/src/main/fc/board_info.c
+++ b/src/main/fc/board_info.c
@@ -26,21 +26,25 @@
 #if defined(USE_BOARD_INFO)
 #include "pg/board.h"
 
+#if !defined(BOARD_NAME)
 static bool boardInformationSet = false;
 static char manufacturerId[MAX_MANUFACTURER_ID_LENGTH + 1];
 static char boardName[MAX_BOARD_NAME_LENGTH + 1];
 static bool boardInformationWasUpdated = false;
+#endif
 
 static bool signatureSet = false;
 static uint8_t signature[SIGNATURE_LENGTH];
 
 void initBoardInformation(void)
 {
+#if !defined(BOARD_NAME)
     boardInformationSet = boardConfig()->boardInformationSet;
     if (boardInformationSet) {
         strncpy(manufacturerId, boardConfig()->manufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
         strncpy(boardName, boardConfig()->boardName, MAX_BOARD_NAME_LENGTH + 1);
     }
+#endif
 
     signatureSet = boardConfig()->signatureSet;
     if (signatureSet) {
@@ -50,21 +54,36 @@ void initBoardInformation(void)
 
 const char *getManufacturerId(void)
 {
+#if defined(MANUFACTURER_ID) && defined(BOARD_NAME)
+    return STR(MANUFACTURER_ID);
+#elif defined(BOARD_NAME)
+    return "----";
+#else
     return manufacturerId;
+#endif
 }
 
 const char *getBoardName(void)
 {
+#if defined(BOARD_NAME)
+    return STR(BOARD_NAME);
+#else
     return boardName;
+#endif
 }
 
 bool boardInformationIsSet(void)
 {
+#if defined(BOARD_NAME)
+    return true;
+#else
     return boardInformationSet;
+#endif
 }
 
 bool setManufacturerId(const char *newManufacturerId)
 {
+#if !defined(BOARD_NAME)
     if (!boardInformationSet || strlen(manufacturerId) == 0) {
         strncpy(manufacturerId, newManufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
 
@@ -74,10 +93,15 @@ bool setManufacturerId(const char *newManufacturerId)
     } else {
         return false;
     }
+#else
+    UNUSED(newManufacturerId);
+    return false;
+#endif
 }
 
 bool setBoardName(const char *newBoardName)
 {
+#if !defined(BOARD_NAME)
     if (!boardInformationSet || strlen(boardName) == 0) {
         strncpy(boardName, newBoardName, MAX_BOARD_NAME_LENGTH + 1);
 
@@ -87,10 +111,15 @@ bool setBoardName(const char *newBoardName)
     } else {
         return false;
     }
+#else
+    UNUSED(newBoardName);
+    return false;
+#endif
 }
 
 bool persistBoardInformation(void)
 {
+#if !defined(BOARD_NAME)
     if (boardInformationWasUpdated) {
         strncpy(boardConfigMutable()->manufacturerId, manufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
         strncpy(boardConfigMutable()->boardName, boardName, MAX_BOARD_NAME_LENGTH + 1);
@@ -102,6 +131,9 @@ bool persistBoardInformation(void)
     } else {
         return false;
     }
+#else
+    return false;
+#endif
 }
 
 #if defined(USE_SIGNATURE)


### PR DESCRIPTION
- if provided.

Ultimately I think we can do away with board_info entirely, and bake it into the build - even for classic builds - however this will render the assets produced by github actions to be "Betaflight" as the board name and "BTFL" as the manufacturer id.