### PR TITLE
Flash M25P16: Add QSPI support

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -103,6 +103,12 @@ static bool flashQuadSpiInit(const flashConfig_t *flashConfig)
                     detected = true;
                 }
 #endif
+
+#ifdef USE_FLASH_M25P16
+                if (!detected && m25p16_detect(&flashDevice, chipID)) {
+                    detected = true;
+                }
+#endif
             }
 
             if (offset == 1) {


### PR DESCRIPTION
Some of the SPI flash chips supported by the M25P16 driver can support Quad-SPI. This add support for Quad-SPI to the driver. 

The read command is 0x6B (1-1-4 read), which should be supported by most manufactures (see [here](https://docs.xilinx.com/r/en-US/pg153-axi-quad-spi/Commonly-Supported-Commands-for-Quad-SPI-and-Mixed-Memory-Mode)).

The write command is 0x32 (1-1-4 write), which should be supported by most manufacturers except Macronix.

The number of dummy cycles is currently set to 8 for all chips, which should be the default for most chips. Alternatively, the dummy cycles could be added to the `m25p16FlashConfig` struct. 