### PR TITLE
FIX: Barometers tend to be on boards

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -44,7 +44,7 @@
 #define USE_MAG_AK8975
 #endif
 
-#if defined(USE_BARO) && !defined(USE_FAKE_BARO)
+#if defined(USE_BARO) && !defined(USE_FAKE_BARO) && !defined(CLOUD_BUILD)
 #define USE_BARO_MS5611
 #define USE_BARO_SPI_MS5611
 #define USE_BARO_BMP280


### PR DESCRIPTION
- this removes the inclusion of all the barometers, expectation is the specific baro will be in the config file.
- users can still add any baro using the custom defines (to work out what needs updating for the config file)

Supported barometers are:
```
#define USE_BARO_MS5611
#define USE_BARO_SPI_MS5611
#define USE_BARO_BMP280
#define USE_BARO_SPI_BMP280
#define USE_BARO_BMP388
#define USE_BARO_SPI_BMP388
#define USE_BARO_LPS
#define USE_BARO_SPI_LPS
#define USE_BARO_QMP6988
#define USE_BARO_SPI_QMP6988
#define USE_BARO_DPS310
#define USE_BARO_SPI_DPS310
#define USE_BARO_BMP085
#define USE_BARO_2SMBP_02B
#define USE_BARO_SPI_2SMBP_02B
```

Quick CUSTOM defines list: 
```
BARO BARO_MS5611 BARO_SPI_MS5611 BARO_BMP280 BARO_SPI_BMP280 BARO_BMP388 BARO_SPI_BMP388 BARO_LPS BARO_SPI_LPS BARO_QMP6988 BARO_SPI_QMP6988 BARO_DPS310 BARO_SPI_DPS310 BARO_BMP085 BARO_2SMBP_02B BARO_SPI_2SMBP_02B
```