### PR TITLE
FIX: MSP Displayport now has dependency on OSD config

### DIFF
--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -165,6 +165,7 @@ static bool isSynced(const displayPort_t *displayPort)
 
 static void redraw(displayPort_t *displayPort)
 {
+#ifdef USE_OSD
     if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
         displayPort->rows = osdConfig()->canvas_rows;
         displayPort->cols = osdConfig()->canvas_cols;
@@ -173,6 +174,11 @@ static void redraw(displayPort_t *displayPort)
         displayPort->rows = displayRows + displayPortProfileMsp()->rowAdjust;
         displayPort->cols = 30 + displayPortProfileMsp()->colAdjust;
     }
+#else
+    const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? 16 : 13;
+    displayPort->rows = displayRows + displayPortProfileMsp()->rowAdjust;
+    displayPort->cols = 30 + displayPortProfileMsp()->colAdjust;
+#endif
     drawScreen(displayPort);
 }
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -350,11 +350,11 @@ extern uint8_t _dmaram_end__;
 #endif // !defined(CLOUD_BUILD)
 
 #ifndef LED_MAX_STRIP_LENGTH
-    #ifdef USE_LEDSTRIP_64
-        #define LED_MAX_STRIP_LENGTH           64
-    #else
-        #define LED_MAX_STRIP_LENGTH           32
-    #endif
+#ifdef USE_LEDSTRIP_64
+#define LED_MAX_STRIP_LENGTH           64
+#else
+#define LED_MAX_STRIP_LENGTH           32
+#endif
 #endif // #ifndef LED_MAX_STRIP_LENGTH
 
 #if defined(USE_SDCARD)
@@ -376,7 +376,7 @@ extern uint8_t _dmaram_end__;
 #define USE_VTX_TRAMP
 #define USE_VTX_MSP
 #define USE_VTX_TABLE
-#endif
+#endif // USE_VTX
 
 #define USE_HUFFMAN
 
@@ -426,7 +426,7 @@ extern uint8_t _dmaram_end__;
 #define USE_SPEKTRUM_VTX_CONTROL
 #define USE_SPEKTRUM_VTX_TELEMETRY
 #define USE_SPEKTRUM_CMS_TELEMETRY
-#endif
+#endif // USE_SERIALRX_SPEKTRUM
 
 #define USE_BOARD_INFO
 #define USE_EXTENDED_CMS_MENUS
@@ -469,7 +469,7 @@ extern uint8_t _dmaram_end__;
 #define USE_GPS_NMEA
 #define USE_GPS_UBLOX
 #define USE_GPS_RESCUE
-#endif
+#endif // USE_GPS
 
 #if defined(USE_OSD) || defined(USE_OSD_HD) || defined(USE_OSD_SD)
 
@@ -483,10 +483,9 @@ extern uint8_t _dmaram_end__;
 #define USE_OSD_ADJUSTMENTS
 #define USE_OSD_PROFILES
 #define USE_OSD_STICK_OVERLAY
-#endif
+#endif // defined(USE_OSD) || defined(USE_OSD_HD) || defined(USE_OSD_SD)
 
 #if defined(CLOUD_BUILD)
-
 // Handle the CRSF co-dependency requirements
 #if defined(USE_TELEMETRY_CRSF) 
 
@@ -494,8 +493,8 @@ extern uint8_t _dmaram_end__;
 #if defined(USE_CMS)
 #define USE_CRSF_CMS_TELEMETRY
 #define USE_CRSF_LINK_STATISTICS
-#endif 
+#endif  // USE_CMS
 
-#endif // CRSF co-dependency requirements.
+#endif // USE_TELEMETRY_CRSF (CRSF co-dependency requirements).
 
-#endif
+#endif // CLOUD_BUILD

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -397,9 +397,7 @@ extern uint8_t _dmaram_end__;
 #endif
 
 #define USE_CMS
-#define USE_MSP_DISPLAYPORT
 #define USE_MSP_OVER_TELEMETRY
-#define USE_OSD_OVER_MSP_DISPLAYPORT
 
 #define USE_VIRTUAL_CURRENT_METER
 #define USE_CAMERA_CONTROL
@@ -474,7 +472,13 @@ extern uint8_t _dmaram_end__;
 #define USE_GPS_RESCUE
 #endif
 
-#ifdef USE_OSD
+#if defined(USE_OSD) || defined(USE_OSD_HD) || defined(USE_OSD_SD)
+
+#ifndef USE_OSD
+#define USE_OSD
+#endif
+
+#define USE_MSP_DISPLAYPORT
 #define USE_OSD_OVER_MSP_DISPLAYPORT
 #define USE_OSD_ADJUSTMENTS
 #define USE_OSD_PROFILES

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -396,7 +396,6 @@ extern uint8_t _dmaram_end__;
 #define USE_DSHOT_DMAR
 #endif
 
-#define USE_CMS
 #define USE_MSP_OVER_TELEMETRY
 
 #define USE_VIRTUAL_CURRENT_METER
@@ -478,6 +477,7 @@ extern uint8_t _dmaram_end__;
 #define USE_OSD
 #endif
 
+#define USE_CMS
 #define USE_MSP_DISPLAYPORT
 #define USE_OSD_OVER_MSP_DISPLAYPORT
 #define USE_OSD_ADJUSTMENTS


### PR DESCRIPTION
See: Center logo and CMS display for HD OSD (#12056)

FAILED:
```
git checkout 4.4.0-RC2 && make TARGET=STM32F405 EXTRA_FLAGS="-D'BUILD_KEY=4.4.0-RC2/REVO/2926a06aaa6a45d2f69d9e26a7f08f05' -D'BOARD_NAME=REVO' -D'MANUFACTURER_ID=OPEN' -DCLOUD_BUILD -DTARGET_FLAGS -DUSE_ACC -DUSE_ACC_SPI_MPU6000 -DUSE_ACC_SPI_MPU6500 -DUSE_DSHOT -DUSE_FLASH -DUSE_FLASH_M25P16 -DUSE_GPS -DUSE_GYRO -DUSE_GYRO_SPI_MPU6000 -DUSE_GYRO_SPI_MPU6500 -DUSE_LED_STRIP -DUSE_MAG -DUSE_PINIO -DUSE_SERIALRX -DUSE_SERIALRX_CRSF -DUSE_SERIALRX_DEFAULT -DUSE_SERIALRX_GHST -DUSE_SERIALRX_SBUS -DUSE_TELEMETRY -DUSE_TELEMETRY_CRSF -DUSE_TELEMETRY_GHST -DUSE_TELEMETRY_IBUS_EXTENDED -DUSE_VTX"
```

SUCCEEDED:
```
git checkout 4.4.0-RC2 && make TARGET=STM32F405 EXTRA_FLAGS="-D'BUILD_KEY=4.4.0-RC2/REVO/2926a06aaa6a45d2f69d9e26a7f08f05' -D'BOARD_NAME=REVO' -D'MANUFACTURER_ID=OPEN' -DCLOUD_BUILD -DTARGET_FLAGS -DUSE_ACC -DUSE_ACC_SPI_MPU6000 -DUSE_ACC_SPI_MPU6500 -DUSE_DSHOT -DUSE_FLASH -DUSE_FLASH_M25P16 -DUSE_GPS -DUSE_GYRO -DUSE_GYRO_SPI_MPU6000 -DUSE_GYRO_SPI_MPU6500 -DUSE_LED_STRIP -DUSE_MAG -DUSE_PINIO -DUSE_SERIALRX -DUSE_SERIALRX_CRSF -DUSE_SERIALRX_DEFAULT -DUSE_SERIALRX_GHST -DUSE_SERIALRX_SBUS -DUSE_TELEMETRY -DUSE_TELEMETRY_CRSF -DUSE_TELEMETRY_GHST -DUSE_TELEMETRY_IBUS_EXTENDED -DUSE_VTX -DUSE_OSD"
```

Issue is displayport (included with `USE_MSP_DISPLAYPORT`) now has hard dependency on OSD Configuration (not included unless `USE_OSD` is included).