### PR TITLE
Display OSD canvas size in status command

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4808,9 +4808,9 @@ static void cliStatus(const char *cmdName, char *cmdline)
 
 #if defined(USE_OSD)
     osdDisplayPortDevice_e displayPortDeviceType;
-    osdGetDisplayPort(&displayPortDeviceType);
+    displayPort_t *osdDisplayPort = osdGetDisplayPort(&displayPortDeviceType);
 
-    cliPrintLinef("OSD: %s", lookupTableOsdDisplayPortDevice[displayPortDeviceType]);
+    cliPrintLinef("OSD: %s (%u x %u)", lookupTableOsdDisplayPortDevice[displayPortDeviceType], osdDisplayPort->cols, osdDisplayPort->rows);
 #endif
 
 #ifdef BUILD_KEY


### PR DESCRIPTION
Now that we have potentially different HD resolutions, it's useful to display the available canvas size in the status command as per the example below when using WTFOS on DJI.

```
# status
MCU F722 Clock=216MHz, Vref=3.28V, Core temp=50degC
Stack size: 2048, Stack address: 0x20010000
Configuration: CONFIGURED, size: 4122, max available: 16384
Devices detected: SPI:2, I2C:1
Gyros detected: gyro 1, gyro 2 locked dma shared
GYRO=MPU6000, ACC=MPU6000, BARO=BMP280
OSD: MSP (60 x 22)
System Uptime: 13 seconds, Current Time: 2022-12-29T12:22:59.217+00:00
CPU:57%, cycle time: 125, GYRO rate: 8000, RX rate: 15, System rate: 9
Voltage: 0 * 0.01V (1S battery - CRITICAL)
I2C Errors: 2
SD card: Not configured
FLASH: JEDEC ID=0x00ef4018 16M
Arming disable flags: RXLOSS CLI MSP RPMFILTER
```

This also works with the MAX7456, so with PAL we see the following.

```
# status
MCU F722 Clock=216MHz, Vref=3.27V, Core temp=53degC
Stack size: 2048, Stack address: 0x20010000
Configuration: CONFIGURED, size: 4122, max available: 16384
Devices detected: SPI:2, I2C:1
Gyros detected: gyro 1, gyro 2 locked dma shared
GYRO=MPU6000, ACC=MPU6000, BARO=BMP280
OSD: MAX7456 (30 x 16)
System Uptime: 25 seconds, Current Time: 2022-12-29T12:26:18.525+00:00
CPU:57%, cycle time: 126, GYRO rate: 7936, RX rate: 15, System rate: 9
Voltage: 0 * 0.01V (1S battery - CRITICAL)
I2C Errors: 2
SD card: Not configured
FLASH: JEDEC ID=0x00ef4018 16M
Arming disable flags: RXLOSS CLI MSP RPMFILTER
```