### PR TITLE
Disarm on fail-safe when `allow arming without fix` is enabled and failsafe procedure is set to GPS-RESCUE

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -394,19 +394,22 @@ static void performSanityChecks(void)
         previousDistanceToHomeCm = rescueState.sensor.distanceToHomeCm;
         secondsLowSats = 0;
         secondsDoingNothing = 0;
-        return;
     }
 
     // Handle events that set a failure mode to other than healthy.
     // Disarm via Abort when sanity on, or for hard Rx loss in FS_ONLY mode
     // Otherwise allow 20s of semi-controlled descent with impact disarm detection
-    const bool hardFailsafe = !rxIsReceivingSignal();
     if (rescueState.failure != RESCUE_HEALTHY) {
-        if (gpsRescueConfig()->sanityChecks == RESCUE_SANITY_ON) {
+        switch(gpsRescueConfig()->sanityChecks) {
+        case RESCUE_SANITY_ON:
             rescueState.phase = RESCUE_ABORT;
-        } else if ((gpsRescueConfig()->sanityChecks == RESCUE_SANITY_FS_ONLY) && hardFailsafe) {
-            rescueState.phase = RESCUE_ABORT;
-        } else {
+            break;
+        case RESCUE_SANITY_FS_ONLY:
+            if (!rxIsReceivingSignal()) {
+                rescueState.phase = RESCUE_ABORT;
+            }
+            break;
+        default:
             // even with sanity checks off, 
             rescueState.phase = RESCUE_DO_NOTHING; // 20s semi-controlled descent with impact detection, then abort
         }
@@ -450,7 +453,7 @@ static void performSanityChecks(void)
             } else
 #endif
             {
-            rescueState.failure = RESCUE_FLYAWAY;
+                rescueState.failure = RESCUE_FLYAWAY;
             }
         }
     }
@@ -471,14 +474,17 @@ static void performSanityChecks(void)
     prevAltitudeCm = rescueState.sensor.currentAltitudeCm;
     prevTargetAltitudeCm = rescueState.intent.targetAltitudeCm;
 
-    if (rescueState.phase == RESCUE_LANDING) {
+    switch (rescueState.phase) {
+    case RESCUE_LANDING:
         rescueState.intent.secondsFailing += ratio > 0.5f ? -1 : 1;
         rescueState.intent.secondsFailing = constrain(rescueState.intent.secondsFailing, 0, 10);
         if (rescueState.intent.secondsFailing == 10) {
             rescueState.phase = RESCUE_ABORT;
             // Landing mode shouldn't take more than 10s
         }
-    } else if (rescueState.phase == RESCUE_ATTAIN_ALT || rescueState.phase == RESCUE_DESCENT) {
+        break;
+    case RESCUE_ATTAIN_ALT:
+    case RESCUE_DESCENT:
         rescueState.intent.secondsFailing += ratio > 0.5f ? -1 : 1;
         rescueState.intent.secondsFailing = constrain(rescueState.intent.secondsFailing, 0, 10);
         if (rescueState.intent.secondsFailing == 10) {
@@ -486,12 +492,17 @@ static void performSanityChecks(void)
             rescueState.intent.secondsFailing = 0;
             // if can't climb, or slow descending, enable impact detection and time out in 10s
         }
-    } else if (rescueState.phase == RESCUE_DO_NOTHING) {
+        break;
+    case RESCUE_DO_NOTHING:
         secondsDoingNothing = MIN(secondsDoingNothing + 1, 20);
         if (secondsDoingNothing == 20) {
             rescueState.phase = RESCUE_ABORT;
             // time-limited semi-controlled fall with impact detection
         }
+        break;
+    default:
+        // do nothing
+        break;
     }
 
     DEBUG_SET(DEBUG_RTH, 2, (rescueState.failure * 10 + rescueState.phase));

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -684,7 +684,7 @@ void detectAndApplySignalLossBehaviour(void)
             validRxSignalTimeout[channel] = currentTimeMs + MAX_INVALID_PULSE_TIME_MS;
         }
 
-       if (ARMING_FLAG(ARMED) && failsafeIsActive()) {
+        if (ARMING_FLAG(ARMED) && failsafeIsActive()) {
             // while in failsafe Stage 2, whether Rx loss or switch induced, pass valid incoming flight channel values
             // this allows GPS Rescue to detect the 30% requirement for termination
             if (channel < NON_AUX_CHANNEL_COUNT) {


### PR DESCRIPTION
Fixes: #12119

When `Allow arming without fix` is enabled and fail-safe is set to `GPS Rescue`, the craft will not disarm on fail-safe.

Turns out as staying at `RESCUE_INITIALIZE` the return blocked the execution of the sanity checks.

Test parameters:

    set failsafe_procedure = GPS-RESCUE
    set gps_rescue_min_start_dist = 25
    set gps_rescue_sanity_checks = RESCUE_SANITY_ON
    set gps_rescue_allow_arming_without_fix = ON

![image](https://user-images.githubusercontent.com/8344830/210185249-cf4700f0-b8e2-4277-8012-da499ba3e154.png)

