### PR TITLE
Add RX_SPI to RX_CC2500

### DIFF
--- a/docs/Manufacturer Design Guidelines.md
+++ b/docs/Manufacturer Design Guidelines.md
@@ -15,6 +15,7 @@ Version Change Register
 | Draft 0.5 | 24 October 2022 | Add additional information |
 | Draft 0.6 | 06 November 2022 | Add cloud build information |
 | Draft 0.7 | 17 November 2022 | Remove off-board hardware defines |
+| Draft 0.8 | 01 January 2023 | Update BARO and CC2500 |
 
 
 Thank you for considering or continuing your development of Betaflight capable flight control hardware.  
@@ -77,7 +78,7 @@ Achieving state of the art performance requires minimizing latency in craft resp
 - Initial Submission
     - This will require key information to be available, such as specific MCU arrangement (e.g. SPI Bus allocations) may be required in order to support complete feature sets.
 
-    - Desired Target name, MCU type, and which unified target architecture to be used required.
+    - Desired Target name, MCU type, and which target architecture to be used required.
 
         - Optionally, if any Official Betaflight Presets are to be requested with this hardware, what specific configurations will be used, and a rough plan of what complete system hardware will be provided to support these efforts.
 
@@ -354,7 +355,7 @@ Additionally, there are no RC ecosystems that are actively developing a supporte
 Note that the use of gyros such as the BMI270 lowers the gyro loop rate from 8kHz to 3.2kHz and is therefore advantageous for F411 designs.
 
 
-## 4.2 Definitions for unified targets
+## 4.2 Definitions for targets
 
 As reference please choose the defines for your target from this list as applicable for the target to select appropiate hardware for the cloud build.
 
@@ -375,6 +376,7 @@ Define at least one gyro and one accelerometer.
     #define USE_GYRO_SPI_ICM42688P
     #define USE_ACC_SPI_ICM42688P
 
+
 ### 4.2.2 Defines for FLASH
 
 Define correct flash driver(s) only if physical present on the board.
@@ -385,6 +387,7 @@ Define correct flash driver(s) only if physical present on the board.
     #define USE_FLASH_W25M512          // 512Kb (256Kb x 2 stacked) NOR flash support
     #define USE_FLASH_W25M02G          // 2Gb (1Gb x 2 stacked) NAND flash support
     #define USE_FLASH_W25Q128FV        // 16MB Winbond 25Q128 and the 8MB Winbond W25Q8 types
+
 
 ### 4.2.3 Defines for BARO
 
@@ -402,6 +405,9 @@ Define a barometer only if physical present on the board.
     #define USE_BARO_SPI_QMP6988
     #define USE_BARO_DPS310
     #define USE_BARO_SPI_DPS310
+    #define USE_BARO_2SMBP_02B
+    #define USE_BARO_SPI_2SMBP_02B
+
 
 ### 4.2.4 Defines for MAG
 
@@ -417,30 +423,33 @@ Define a magnetometer only if physical present of the board.
     #define USE_MAG_SPI_AK8963
     #define USE_MAG_AK8975
 
+
 ### 4.2.5 Defines for SX1280
 
 For SPI based SX1280 target designs add the following defines:
 
-    #define USE_RX_SPI
     #define USE_RX_EXPRESSLRS
     #define USE_RX_EXPRESSLRS_TELEMETRY
     #define USE_RX_SX1280
     #define RX_CHANNELS_AETR
 
+
 ### 4.2.6 Defines for OSD
 
     #define USE_MAX7456
+
 
 ### 4.2.7 Defines for SDCARD
 
     #define USE_SDCARD
 
+
 ### 4.2.8 Defines for CC2500
 
-For SPI based CC2500 target designs add the following defines:
+For SPI based CC2500 target designs add the following define:
 
-    #define USE_RX_SPI
-    #define USR_RX_CC2500
+    #define USE_RX_CC2500
+
 
 ## 4.3 Usage of the cloud build API
 
@@ -456,3 +465,4 @@ See reference to [cloud build API](https://github.com/betaflight/betaflight/blob
 * This project is operated and maintained by volunteers, with community support from pilots with a diverse range of flight goals.  
 
 * Pilots flying Betaflight have won every major FAI, MultiGP, and other major FPV multirotor racing event since 2019.
+

--- a/docs/TargetMaintenance/CreatingAUnifiedTarget.md
+++ b/docs/TargetMaintenance/CreatingAUnifiedTarget.md
@@ -1,6 +1,6 @@
-# How to Create a Unified Target Configuration
+# How to Create a Target Configuration
 
-## 1. Considerations for Unified Target Configurations
+## 1. Considerations for Target Configurations
 
 ### 1.1. General
 
@@ -47,7 +47,7 @@ Betaflight Configurator distributes customised targets featuring settings specif
 
 These firmware types can be created by building locally and specifying the MCU type such as `make STM32F405`. Firmware files are created in the `obj` directory and can be flashed by choosing `Load local file` in Betaflight Configurator.
 
-### 2.2 Flashing the unified target firmware
+### 2.2 Flashing the target firmware
 
 (Theoretically there is no need for the board to match the firmware that is flashed in this step, but there is a chance that the board configuration is setting an input pin on the board to be an output pin, thus leading to a short and potential hardware damage.)
 
@@ -94,7 +94,7 @@ For example on [this target](https://github.com/betaflight/unified-targets/blob/
     board_name NOX
     manufacturer_id AIRB
 
-For more information see reference at the [Hardware specification](https://github.com/betaflight/betaflight/blob/master/docs/Manufacturer%20Design%20Guidelines.md#42-definitions-for-unified-targets)
+For more information see reference at the [Hardware specification](https://github.com/betaflight/betaflight/blob/master/docs/Manufacturer%20Design%20Guidelines.md#42-definitions-for-targets)
 
 ### 2.7 Add the board and manufacturer information
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -46,6 +46,10 @@
 
 #if defined(USE_RX_CC2500)
 
+#if !defined(USE_RX_SPI)
+#define USE_RX_SPI
+#endif
+
 #define USE_RX_CC2500_SPI_PA_LNA
 #define USE_RX_CC2500_SPI_DIVERSITY
 


### PR DESCRIPTION
Fixes: #12123

Targets have been updated: https://github.com/betaflight/unified-targets/pull/767

Build

```
make TARGET=STM32F411 \
EXTRA_FLAGS="-D'BUILD_KEY=4.4.0-RC3/CRAZYBEEF4FR0e5d954c9cb122d3503ba09352b14693' \
-D'BOARD_NAME=CRAZYBEEF4FR' -D'MANUFACTURER_ID=HAMO' -DCLOUD_BUILD -DTARGET_FLAGS \
-DUSE_ACC -DUSE_ACC_SPI_MPU6000 -DUSE_DSHOT -DUSE_FLASH -DUSE_GYRO -DUSE_GYRO_SPI_MPU6000 \
-DUSE_LED_STRIP -DUSE_MAX7456 -DUSE_OSD -DUSE_PINIO -DUSE_SERIALRX  -DUSE_SERIALRX_DEFAULT \
-DUSE_SERIALRX_SBUS -DUSE_TELEMETRY -DUSE_VTX -DUSE_RX_CC2500"
```