### PR TITLE
Feature cutback making headroom for local development

### DIFF
--- a/docs/Cloud build API.md
+++ b/docs/Cloud build API.md
@@ -29,12 +29,9 @@ For optimal use please select ONLY the appropiate hardware for the flight contro
     SUMH
     XBUS
 
-    EXPRESSLRS (SPI)
-    CC2500 (SPI)
-    SX1280 (SPI)
+
 ### Telemetry Protocols
 
-    CRSF
     FRSKY_HUB
     GHOST
     HOTT
@@ -45,17 +42,22 @@ For optimal use please select ONLY the appropiate hardware for the flight contro
     SMARTPORT
     SRXL
 
+
+Note: telemetry for CRSF, ELRS, FPORT and GHST are included during the build.
+
 ### Other Options
 
     AKK (SA FIX)
-    BARO
     FLASH
     GPS
     LED
+    LED64
     MAG
     OSD
+    OSD (HD)
     PINIO
     VTX
+
 
 ### Motor Protocols
 
@@ -66,6 +68,7 @@ For optimal use please select ONLY the appropiate hardware for the flight contro
     PROSHOT
     PWM
 
+
 ### Custom Defines
 
     BATTERY_CONTINUE
@@ -73,6 +76,8 @@ For optimal use please select ONLY the appropiate hardware for the flight contro
     EMFAT_AUTORUN
     EMFAT_ICON
     ESCSERIAL_SIMONK
+    GPS
     GPS_PLUS_CODES
+    LED_STRIP
     SERIAL_4WAY_SK_BOOTLOADER
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -361,8 +361,6 @@ extern uint8_t _dmaram_end__;
 #define USE_SERVOS
 
 #define USE_VTX
-
-#define USE_GPS
 #define USE_OSD
 #define USE_OSD_SD
 #define USE_OSD_HD
@@ -394,7 +392,9 @@ extern uint8_t _dmaram_end__;
 #define USE_EMFAT_AUTORUN
 #define USE_EMFAT_ICON
 #define USE_ESCSERIAL_SIMONK
+#define USE_GPS
 #define USE_GPS_PLUS_CODES
+#define USE_LED_STRIP
 #define USE_SERIAL_4WAY_SK_BOOTLOADER
 #endif
 


### PR DESCRIPTION
For ongoing local development we need only hardware drivers in our base targets.

This PR moves some features (GPS, LED_STRIP) out of 512K targets by default. Actual idea came from @blckmn as some PR's already surpass 100% flash size,

We can add features on command line like: `make STM32F411 EXTRA_FLAGS="-DUSE_GPS"`

Before:
```
Linking STM32F7X2 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       15896 B        16 KB     97.02%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        2952 B        10 KB     28.83%
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      485937 B       480 KB     98.86%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB
        DTCM_RAM:       38620 B        64 KB     58.93%
           SRAM1:       77376 B       176 KB     42.93%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
   text	   data	    bss	    dec	    hex	filename
 481017	   7880	 108120	 597017	  91c19	./obj/main/betaflight_STM32F7X2.elf
 ```

After:
``` 
 Linking STM32F7X2 
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       15840 B        16 KB     96.68%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
      AXIM_FLASH:        2840 B        10 KB     27.73%
AXIM_FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
AXIM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     AXIM_FLASH1:      447473 B       480 KB     91.04%
AXIM_FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB
        DTCM_RAM:       34344 B        64 KB     52.40%
           SRAM1:       74560 B       176 KB     41.37%
           SRAM2:          0 GB        16 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
   text	   data	    bss	    dec	    hex	filename
 442853	   7468	 101444	 551765	  86b55	./obj/main/betaflight_STM32F7X2.elf
Creating HEX ./obj/betaflight_4.4.0_STM32F7X2.hex 
```

Before:
```
Linking STM32F411 
Memory region         Used Size  Region Size  %age Used
           FLASH:       10052 B        10 KB     98.16%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      477131 B       480 KB     97.07%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB
   SYSTEM_MEMORY:          0 GB        29 KB      0.00%
             RAM:      111236 B       128 KB     84.87%
       MEMORY_B1:          0 GB         0 GB
   text	   data	    bss	    dec	    hex	filename
 480039	   7152	 103684	 590875	  9041b	./obj/main/betaflight_STM32F411.elf
Creating HEX ./obj/betaflight_4.4.0_STM32F411.hex
```

After:
```
inking STM32F411 
Memory region         Used Size  Region Size  %age Used
           FLASH:        9540 B        10 KB     93.16%
FLASH_CUSTOM_DEFAULTS:           8 B         6 KB      0.13%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      441455 B       480 KB     89.81%
FLASH_CUSTOM_DEFAULTS_EXTENDED:          0 GB         0 GB
   SYSTEM_MEMORY:          0 GB        29 KB      0.00%
             RAM:      104364 B       128 KB     79.62%
       MEMORY_B1:          0 GB         0 GB
   text	   data	    bss	    dec	    hex	filename
 444251	   6752	  97212	 548215	  85d77	./obj/main/betaflight_STM32F411.elf
Creating HEX ./obj/betaflight_4.4.0_STM32F411.hex
```