### PR TITLE
Fix reset PG behaviour and configurator interactions based on USE_OSD_SD and USE_OSD_HD definitions

### DIFF
--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#define VIDEO_COLUMNS_SD          30
+#define VIDEO_LINES_NTSC          13
+#define VIDEO_LINES_PAL           16
+
 typedef enum {
     DISPLAYPORT_DEVICE_TYPE_MAX7456 = 0,
     DISPLAYPORT_DEVICE_TYPE_OLED,

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -27,8 +27,6 @@
 /** PAL or NTSC, value is number of chars total */
 #define VIDEO_BUFFER_CHARS_NTSC   390
 #define VIDEO_BUFFER_CHARS_PAL    480
-#define VIDEO_LINES_NTSC          13
-#define VIDEO_LINES_PAL           16
 
 typedef enum {
     // IO defined and MAX7456 was detected

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -165,20 +165,14 @@ static bool isSynced(const displayPort_t *displayPort)
 
 static void redraw(displayPort_t *displayPort)
 {
-#ifdef USE_OSD
     if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
         displayPort->rows = osdConfig()->canvas_rows;
         displayPort->cols = osdConfig()->canvas_cols;
     } else {
-        const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? 16 : 13;
+        const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? VIDEO_LINES_PAL : VIDEO_LINES_NTSC;
         displayPort->rows = displayRows + displayPortProfileMsp()->rowAdjust;
-        displayPort->cols = 30 + displayPortProfileMsp()->colAdjust;
+        displayPort->cols = OSD_SD_COLS + displayPortProfileMsp()->colAdjust;
     }
-#else
-    const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? 16 : 13;
-    displayPort->rows = displayRows + displayPortProfileMsp()->rowAdjust;
-    displayPort->cols = 30 + displayPortProfileMsp()->colAdjust;
-#endif // USE_OSD
     drawScreen(displayPort);
 }
 
@@ -214,6 +208,17 @@ displayPort_t *displayPortMspInit(void)
     if (displayPortProfileMsp()->useDeviceBlink) {
         mspDisplayPort.useDeviceBlink = true;
     }
+
+#ifndef USE_OSD_SD
+    if (vcdProfile()->video_system != VIDEO_SYSTEM_HD) {
+        vcdProfileMutable()->video_system = VIDEO_SYSTEM_HD;
+    }
+#endif
+#ifndef USE_OSD_HD
+    if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
+        vcdProfileMutable()->video_system = VIDEO_SYSTEM_AUTO;
+    }
+#endif
 
     redraw(&mspDisplayPort);
     return &mspDisplayPort;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -982,7 +982,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
 #endif
         sbufWriteU8(dst, osdFlags);
 
-#ifdef USE_MAX7456
+#ifdef USE_OSD_SD
         // send video system (AUTO/PAL/NTSC/HD)
         sbufWriteU8(dst, vcdProfile()->video_system);
 #else
@@ -4081,7 +4081,6 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
 
             if ((int8_t)addr == -1) {
                 /* Set general OSD settings */
-#ifdef USE_MAX7456
                 videoSystem_e video_system = sbufReadU8(src);
 #ifndef USE_OSD_HD
                 if (video_system == VIDEO_SYSTEM_HD) {
@@ -4089,10 +4088,7 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                 }
 #endif
                 vcdProfileMutable()->video_system = video_system;
-#else
-                sbufReadU8(src); // Skip video system
-#endif
-#if defined(USE_OSD)
+
                 osdConfigMutable()->units = sbufReadU8(src);
 
                 // Alarms
@@ -4140,19 +4136,16 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                     osdConfigMutable()->camera_frame_width = sbufReadU8(src);
                     osdConfigMutable()->camera_frame_height = sbufReadU8(src);
                 }
-#endif
             } else if ((int8_t)addr == -2) {
-#if defined(USE_OSD)
                 // Timers
                 uint8_t index = sbufReadU8(src);
                 if (index > OSD_TIMER_COUNT) {
                   return MSP_RESULT_ERROR;
                 }
                 osdConfigMutable()->timers[index] = sbufReadU16(src);
-#endif
+
                 return MSP_RESULT_ERROR;
             } else {
-#if defined(USE_OSD)
                 const uint16_t value = sbufReadU16(src);
 
                 /* Get screen index, 0 is post flight statistics, 1 and above are in flight OSD screens */
@@ -4168,9 +4161,6 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                 } else {
                   return MSP_RESULT_ERROR;
                 }
-#else
-                return MSP_RESULT_ERROR;
-#endif
             }
         }
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4082,7 +4082,13 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
             if ((int8_t)addr == -1) {
                 /* Set general OSD settings */
 #ifdef USE_MAX7456
-                vcdProfileMutable()->video_system = sbufReadU8(src);
+                videoSystem_e video_system = sbufReadU8(src);
+#ifndef USE_OSD_HD
+                if (video_system == VIDEO_SYSTEM_HD) {
+                    video_system = VIDEO_SYSTEM_AUTO;
+                }
+#endif
+                vcdProfileMutable()->video_system = video_system;
 #else
                 sbufReadU8(src); // Skip video system
 #endif
@@ -4207,6 +4213,7 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
         }
         break;
 
+#ifdef USE_OSD_HD
     case MSP_SET_OSD_CANVAS:
         {
             osdConfigMutable()->canvas_cols = sbufReadU8(src);
@@ -4216,6 +4223,7 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
             vcdProfileMutable()->video_system = VIDEO_SYSTEM_HD;
         }
         break;
+#endif //USE_OSD_HD
 #endif // OSD
 
     default:

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -82,6 +82,9 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_Y(x)      ((x >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
 #define OSD_TYPE(x)   ((x & OSD_TYPE_MASK) >> 14)
 
+#define OSD_SD_COLS VIDEO_COLUMNS_SD
+#define OSD_SD_ROWS VIDEO_LINES_PAL
+
 // Default HD OSD canvas size to be applied unless the goggles announce otherwise
 #define OSD_HD_COLS 53
 #define OSD_HD_ROWS 20

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -364,6 +364,8 @@ extern uint8_t _dmaram_end__;
 
 #define USE_GPS
 #define USE_OSD
+#define USE_OSD_SD
+#define USE_OSD_HD
 #define USE_LED_STRIP
 #define USE_BLACKBOX
 
@@ -526,10 +528,24 @@ extern uint8_t _dmaram_end__;
 #define USE_GPS_RESCUE
 #endif // USE_GPS
 
-#if defined(USE_OSD) || defined(USE_OSD_HD) || defined(USE_OSD_SD)
-
+#if defined(USE_OSD_HD) || defined(USE_OSD_SD)
+// If either USE_OSD_SD for USE_OSD_HD are defined, ensure that USE_OSD is also defined
 #ifndef USE_OSD
 #define USE_OSD
+#endif
+#endif
+
+#ifdef USE_OSD
+
+#if !defined(USE_OSD_HD) && !defined(USE_OSD_SD)
+// If USE_OSD is defined without specifying SD or HD, then support both
+#define USE_OSD_SD
+#define USE_OSD_HD
+#endif
+
+#if !defined(USE_OSD_SD) && defined(USE_MAX7456)
+// If USE_OSD_SD isn't defined then explicitly exclude MAX7456 support
+#undef USE_MAX7456
 #endif
 
 #define USE_CMS


### PR DESCRIPTION
`USE_OSD`, `USE_OSD_SD` and `USE_OSD_HD` behaviours defined thus:

If either `USE_OSD_SD` or `USE_OSD_HD` are defined then `USE_OSD` is automatically defined.

If neither `USE_OSD_SD` nor `USE_OSD_HD` are defined, but `USE_OSD` is, then both `USE_OSD_SD` and `USE_OSD_HD` are automatically defined.

If only `USE_OSD_SD` is defined then the CLI and configurator will not allow `vcd_video_system` to be set to `HD` nor be selected on the OSD tab. Any attempt to do so will result in `AUTO` being selected.

If only `USE_OSD_HD` is defined then the CLI and configurator will not allow `vcd_video_system` to be set to anything other than `HD` nor be selected as any other option on the OSD tab.

If `USE_OSD_SD` is defined then setting defaults will result in the default position of OSD element being centred for a standard definition PAL display.

If only `USE_OSD_HD` is defined then setting defaults will result in the default position of OSD element being centred for an HD display assuming the default 53x20 canvas as at the time of setting defaults the FC knows no different.

A sample local build for just HD can be generated thus, for example:

```
$ make TARGET=STM32F405 EXTRA_FLAGS="-D'BOARD_NAME=MATEKF405TE' -D'MANUFACTURER_ID=MTKS' -DCLOUD_BUILD -DTARGET_FLAGS -DUSE_ACC -DUSE_ACC_SPI_ICM42688P -DUSE_BARO -DUSE_BARO_DPS310 -DUSE_DSHOT -DUSE_FLASH -DUSE_GPS -DUSE_GYRO -DUSE_GYRO_SPI_ICM42688P -DUSE_LED_STRIP -DUSE_MAX7456 -DUSE_OSD_HD -DUSE_PINIO -DUSE_PWM -DUSE_SDCARD -DUSE_SERIALRX -DUSE_SERIALRX_CRSF -DUSE_SERIALRX_DEFAULT -DUSE_SERIALRX_GHST -DUSE_SERIALRX_SBUS -DUSE_TELEMETRY -DUSE_TELEMETRY_CRSF -DUSE_TELEMETRY_GHST -DUSE_VTX -DUSE_FLASH_M25P16"
```

