### PR TITLE
Move JETIEXBUS serial RX to targets > 512kb flash.

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -342,7 +342,6 @@ extern uint8_t _dmaram_end__;
 #define USE_SERIALRX_FPORT      // FrSky FPort
 #define USE_SERIALRX_XBUS       // JR
 #define USE_SERIALRX_SRXL2      // Spektrum SRXL2 protocol
-#define USE_SERIALRX_JETIEXBUS
 #endif // !defined(USE_SERIAL_RX)
 
 #if !defined(USE_TELEMETRY)
@@ -373,6 +372,7 @@ extern uint8_t _dmaram_end__;
 
 #if defined(USE_SERIALRX)
 
+#define USE_SERIALRX_JETIEXBUS
 #define USE_SERIALRX_SUMD       // Graupner Hott protocol
 #define USE_SERIALRX_SUMH       // Graupner legacy protocol
 


### PR DESCRIPTION
This is inline with the telemetry settings. Those who want JETIEXBUS on smaller targets will need to perform a cloud build and select it as an option.
