### PR TITLE
Add osd_canvas_width/height variables

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1465,6 +1465,8 @@ const clivalue_t valueTable[] = {
     { "osd_aux_channel",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, MAX_SUPPORTED_RC_CHANNEL_COUNT }, PG_OSD_CONFIG, offsetof(osdConfig_t, aux_channel) },
     { "osd_aux_scale",              VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 1000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, aux_scale) },
     { "osd_aux_symbol",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 },  PG_OSD_CONFIG, offsetof(osdConfig_t, aux_symbol) },
+    { "osd_canvas_width",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 63 }, PG_OSD_CONFIG, offsetof(osdConfig_t, canvas_cols) },
+    { "osd_canvas_height",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 31 }, PG_OSD_CONFIG, offsetof(osdConfig_t, canvas_rows) },
 #endif // end of #ifdef USE_OSD
 
 #ifdef USE_CRAFTNAME_MSGS

--- a/src/main/io/displayport_crsf.c
+++ b/src/main/io/displayport_crsf.c
@@ -205,6 +205,8 @@ static displayPort_t *displayPortCrsfInit(void)
     crsfDisplayPortSetDimensions(CRSF_DISPLAY_PORT_ROWS_MAX, CRSF_DISPLAY_PORT_COLS_MAX);
     displayInit(&crsfDisplayPort, &crsfDisplayPortVTable, DISPLAYPORT_DEVICE_TYPE_CRSF);
 
+    crsfRedraw(&crsfDisplayPort);
+
     return &crsfDisplayPort;
 }
 

--- a/src/main/io/displayport_frsky_osd.c
+++ b/src/main/io/displayport_frsky_osd.c
@@ -33,6 +33,8 @@
 #include "io/displayport_frsky_osd.h"
 #include "io/frsky_osd.h"
 
+#include "osd/osd.h"
+
 static displayPort_t frskyOsdDisplayPort;
 
 static int grab(displayPort_t *displayPort)
@@ -496,6 +498,8 @@ displayPort_t *frskyOsdDisplayPortInit(const videoSystem_e videoSystem)
 {
     if (frskyOsdInit(videoSystem)) {
         displayInit(&frskyOsdDisplayPort, &frskyOsdVTable, DISPLAYPORT_DEVICE_TYPE_FRSKYOSD);
+        frskyOsdDisplayPort.cols = OSD_SD_COLS;
+        frskyOsdDisplayPort.rows = OSD_SD_ROWS;
         redraw(&frskyOsdDisplayPort);
         return &frskyOsdDisplayPort;
     }

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -182,9 +182,6 @@ static bool checkReady(displayPort_t *displayPort, bool rescan)
         }
     }
 
-    displayPort->rows = max7456GetRowsCount() + displayPortProfileMax7456()->rowAdjust;
-    displayPort->cols = 30 + displayPortProfileMax7456()->colAdjust;
-
     return true;
 }
 
@@ -246,6 +243,26 @@ bool max7456DisplayPortInit(const vcdProfile_t *vcdProfile, displayPort_t **disp
 
         break;
     }
+
+    uint8_t displayRows;
+
+    switch(vcdProfile->video_system) {
+    default:
+    case VIDEO_SYSTEM_PAL:
+        displayRows = VIDEO_LINES_PAL;
+        break;
+
+    case VIDEO_SYSTEM_NTSC:
+        displayRows = VIDEO_LINES_NTSC;
+        break;
+
+    case VIDEO_SYSTEM_AUTO:
+        displayRows = max7456GetRowsCount();
+        break;
+    }
+
+    max7456DisplayPort.rows = displayRows + displayPortProfileMax7456()->rowAdjust;
+    max7456DisplayPort.cols = 30 + displayPortProfileMax7456()->colAdjust;
 
     return true;
 }

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -165,14 +165,6 @@ static bool isSynced(const displayPort_t *displayPort)
 
 static void redraw(displayPort_t *displayPort)
 {
-    if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
-        displayPort->rows = osdConfig()->canvas_rows;
-        displayPort->cols = osdConfig()->canvas_cols;
-    } else {
-        const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? VIDEO_LINES_PAL : VIDEO_LINES_NTSC;
-        displayPort->rows = displayRows + displayPortProfileMsp()->rowAdjust;
-        displayPort->cols = OSD_SD_COLS + displayPortProfileMsp()->colAdjust;
-    }
     drawScreen(displayPort);
 }
 
@@ -220,7 +212,17 @@ displayPort_t *displayPortMspInit(void)
     }
 #endif
 
+    if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
+        mspDisplayPort.rows = osdConfig()->canvas_rows;
+        mspDisplayPort.cols = osdConfig()->canvas_cols;
+    } else {
+        const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? VIDEO_LINES_PAL : VIDEO_LINES_NTSC;
+        mspDisplayPort.rows = displayRows + displayPortProfileMsp()->rowAdjust;
+        mspDisplayPort.cols = OSD_SD_COLS + displayPortProfileMsp()->colAdjust;
+    }
+
     redraw(&mspDisplayPort);
+
     return &mspDisplayPort;
 }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4087,6 +4087,14 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                     video_system = VIDEO_SYSTEM_AUTO;
                 }
 #endif
+
+                if ((video_system == VIDEO_SYSTEM_HD) && (vcdProfile()->video_system != VIDEO_SYSTEM_HD)) {
+                    // If switching to HD, don't wait for the VTX to communicate the correct resolution, just
+                    // increase the canvas size to the HD default as that is what the user will expect
+                    osdConfigMutable()->canvas_cols = OSD_HD_COLS;
+                    osdConfigMutable()->canvas_rows = OSD_HD_ROWS;
+                }
+
                 vcdProfileMutable()->video_system = video_system;
 
                 osdConfigMutable()->units = sbufReadU8(src);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -512,6 +512,14 @@ void osdInit(displayPort_t *osdDisplayPortToUse, osdDisplayPortDevice_e displayP
 #endif
 
     if (osdDisplayPort->cols && osdDisplayPort->rows) {
+        // Ensure that osd_canvas_width/height are correct
+        if (osdConfig()->canvas_cols != osdDisplayPort->cols) {
+            osdConfigMutable()->canvas_cols = osdDisplayPort->cols;
+        }
+        if (osdConfig()->canvas_rows != osdDisplayPort->rows) {
+            osdConfigMutable()->canvas_rows = osdDisplayPort->rows;
+        }
+
         // Ensure that all OSD elements are on the canvas once number of row/columns is known
         for (int i = 0; i < OSD_ITEM_COUNT; i++) {
             uint16_t itemPos = osdElementConfig()->item_pos[i];


### PR DESCRIPTION
This makes the canvas size part of the saved configuration so, when in HD mode it's not necessary to connect power to the VTX/goggles in order to establish the correct canvas size after restoring a configuration.

To avoid confusion this also reflects the canvas size for SD as well as HD, so that required a few more changes.