### PR TITLE
Avoid debugging other data than RPM telemetry when decoding DSHOT RPM

### DIFF
--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -29,6 +29,7 @@
 
 #ifdef USE_DSHOT
 
+#include "build/debug.h"
 #include "build/atomic.h"
 
 #include "common/maths.h"
@@ -159,6 +160,11 @@ static void dshot_decode_telemetry_value(uint8_t motorIndex, uint32_t *pDecoded,
         // Decode eRPM telemetry
         *pDecoded = dshot_decode_eRPM_telemetry_value(value);
 
+        // Update debug buffer
+        if (motorIndex < 4) {
+            DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, motorIndex, *pDecoded);
+        }
+
         // Set telemetry type
         *pType = DSHOT_TELEMETRY_TYPE_eRPM;
     } else {
@@ -224,6 +230,11 @@ static void dshot_decode_telemetry_value(uint8_t motorIndex, uint32_t *pDecoded,
         default:
             // Decode as eRPM
             *pDecoded = dshot_decode_eRPM_telemetry_value(value);
+
+            // Update debug buffer
+            if (motorIndex < 4) {
+                DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, motorIndex, *pDecoded);
+            }
 
             // Set telemetry type
             *pType = DSHOT_TELEMETRY_TYPE_eRPM;

--- a/src/main/drivers/dshot_bitbang.c
+++ b/src/main/drivers/dshot_bitbang.c
@@ -545,10 +545,6 @@ static bool bbUpdateStart(void)
                 } else {
                     dshotTelemetryState.motorState[motorIndex].rawValue = rawValue;
                 }
-
-                if (motorIndex < 4) {
-                    DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, motorIndex, rawValue);
-                }
             } else {
                 dshotTelemetryState.invalidPacketCount++;
             }

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -212,9 +212,6 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
 
                 rawValue = decodeTelemetryPacket(dmaMotors[i].dmaBuffer, edges);
 
-#ifdef USE_DSHOT_TELEMETRY_STATS
-                bool validTelemetryPacket = false;
-#endif
                 if (rawValue != DSHOT_TELEMETRY_INVALID) {
                     // Check EDT enable or store raw value
                     if ((rawValue == 0x0E00) && (dshotCommandGetCurrent(i) == DSHOT_CMD_EXTENDED_TELEMETRY_ENABLE)) {
@@ -222,13 +219,6 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
                     } else {
                         dshotTelemetryState.motorState[i].rawValue = rawValue;
                     }
-
-                    if (i < 4) {
-                        DEBUG_SET(DEBUG_DSHOT_RPM_TELEMETRY, i, rawValue);
-                    }
-#ifdef USE_DSHOT_TELEMETRY_STATS
-                    validTelemetryPacket = true;
-#endif
                 } else {
                     dshotTelemetryState.invalidPacketCount++;
                     if (i == 0) {
@@ -236,7 +226,7 @@ FAST_CODE_NOINLINE bool pwmStartDshotMotorUpdate(void)
                     }
                 }
 #ifdef USE_DSHOT_TELEMETRY_STATS
-                updateDshotTelemetryQuality(&dshotTelemetryQuality[i], validTelemetryPacket, currentTimeMs);
+                updateDshotTelemetryQuality(&dshotTelemetryQuality[i], rawValue != DSHOT_TELEMETRY_INVALID, currentTimeMs);
 #endif
             }
         }


### PR DESCRIPTION
In the previous DSHOT version RPM data was decoded just when DSHOT frame was received, and the RPM data was written into debug buffer just in that moment.

When EDT was implemented decoding took much time so in slow MCUs like STM32F411, caused issues so I decided to implement decoding DSHOT data under demand, but I didn't take into account that RPM data also had to be written into debug buffer in that moment.

This hotfix moves the writting of RPM data in debug buffer into the decoding routines, so now it is sinchronized with the moment it is going to be used and avoids to be filled with undecoded DSHOT data.  
