### PR TITLE
Fixed getDshotAverageRpm function

### DIFF
--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -250,7 +250,7 @@ uint16_t getDshotTelemetry(uint8_t index)
     // Process telemetry in case it haven´t been processed yet
     if (dshotTelemetryState.rawValueState == DSHOT_RAW_VALUE_STATE_NOT_PROCESSED) {
         const unsigned motorCount = motorDeviceCount();
-        uint32_t rpmTotal = 0;
+        uint32_t erpmTotal = 0;
         uint32_t rpmSamples = 0;
 
         // Decode all telemetry data now to discharge interrupt from this task
@@ -264,7 +264,7 @@ uint16_t getDshotTelemetry(uint8_t index)
                 dshotUpdateTelemetryData(k, type, value);
 
                 if (type == DSHOT_TELEMETRY_TYPE_eRPM) {
-                    rpmTotal += value;
+                    erpmTotal += value;
                     rpmSamples++;
                 }
             }
@@ -272,7 +272,7 @@ uint16_t getDshotTelemetry(uint8_t index)
 
         // Update average
         if (rpmSamples > 0) {
-            dshotTelemetryState.averageRpm = rpmTotal / rpmSamples;
+            dshotTelemetryState.averageErpm = (uint16_t)(erpmTotal / rpmSamples);
         }
 
         // Set state to processed
@@ -314,7 +314,7 @@ uint32_t erpmToRpm(uint16_t erpm)
 
 uint32_t getDshotAverageRpm(void)
 {
-    return dshotTelemetryState.averageRpm;
+    return erpmToRpm(dshotTelemetryState.averageErpm);
 }
 
 #endif // USE_DSHOT_TELEMETRY

--- a/src/main/drivers/dshot.h
+++ b/src/main/drivers/dshot.h
@@ -103,7 +103,7 @@ typedef struct dshotTelemetryState_s {
     uint32_t readCount;
     dshotTelemetryMotorState_t motorState[MAX_SUPPORTED_MOTORS];
     uint32_t inputBuffer[MAX_GCR_EDGES];
-    uint32_t averageRpm;
+    uint16_t averageErpm;
     dshotRawValueState_t rawValueState;
 } dshotTelemetryState_t;
 


### PR DESCRIPTION
It was returning erpm value instead of rpm one

getDshotAverageRpm was returning erpm value instead rpm one. This pr fixes issue https://github.com/betaflight/betaflight/issues/12163 related to Spektrum Telemetry.

getDshotAverageRpm function is called from the osd and slrx modules at low rate, so for that reason the conversion between erpm to rpm is done inside this function instead when average erpm is calculated during dshot decoding, that is executed at a higher rate. This way impact on performance is reduced