### PR TITLE
Automatically apply HD settings if HD VTX is detected

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4217,8 +4217,17 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
             osdConfigMutable()->canvas_cols = sbufReadU8(src);
             osdConfigMutable()->canvas_rows = sbufReadU8(src);
 
-            // An HD VTX has communicated it's canvas size, so we must be in HD mode
-            vcdProfileMutable()->video_system = VIDEO_SYSTEM_HD;
+            if ((vcdProfile()->video_system != VIDEO_SYSTEM_HD) ||
+                (osdConfig()->displayPortDevice != OSD_DISPLAYPORT_DEVICE_MSP)) {
+                // An HD VTX has communicated it's canvas size, so we must be in HD mode
+                vcdProfileMutable()->video_system = VIDEO_SYSTEM_HD;
+                // And using MSP displayport
+                osdConfigMutable()->displayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
+
+                // Save settings and reboot or the user won't see the effect and will have to manually save
+                writeEEPROM();
+                systemReset();
+            }
         }
         break;
 #endif //USE_OSD_HD


### PR DESCRIPTION
This PR makes use of HD much more straightforward for the user.

If we start with an SD configuration, having for example selected PAL and positioned some OSD elements on the screen.

```
# get vcd_video_system
vcd_video_system = PAL
Allowed values: AUTO, PAL, NTSC, HD
Default value: AUTO

# get osd_displayport_device
osd_displayport_device = MAX7456
Allowed values: NONE, AUTO, MAX7456, MSP, FRSKYOSD
Default value: AUTO
```

Which on the **OSD** tab appears thus.
![Screenshot 2023-01-13 at 16 35 35](https://user-images.githubusercontent.com/11480839/212375411-0799bd7b-f629-485a-a238-37092f43363a.png)

The user then attaches a VTX and on the **Ports** tab they declare that the appropriate UART is connected to an MSP attached VTX.

![image](https://user-images.githubusercontent.com/11480839/212375683-0ac11ca1-9694-451d-a399-db910a72a062.png)

Upon powering the VTX and Goggles (in this case a WTFOS DJI system), the FC receives a `MSP_SET_OSD_CANVAS` command setting the OSD canvas to 60x22. This tells the FC that HD is being used.

This PR then automatically applies the following settings, saves and reboots.

```
set osd_displayport_device = MSP
set vcd_video_system = HD
```

After the reboot we have.

```
# get vcd_video_system
vcd_video_system = HD
Allowed values: AUTO, PAL, NTSC, HD
Default value: AUTO

# get osd_displayport_device
osd_displayport_device = MSP
Allowed values: NONE, AUTO, MAX7456, MSP, FRSKYOSD
Default value: AUTO
```

Which on the OSD tab appears thus.
![image](https://user-images.githubusercontent.com/11480839/212376865-d68c06fd-e258-496b-91a2-737e8a956c72.png)

This automatic reboot only happens once, the first time the HD VTX is detected. Note that if the user were to then select `PAL` again on the **OSD** tab then `osd_displayport_device` would not change back to its prior setting. This would need to be done manually, but it is not a likely use-case.