### PR TITLE
GPS Rescue Bugfix, add a failsafe debug, refactor stick deflection

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -107,4 +107,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "ATTITUDE",
     "VTX_MSP",
     "GPS_DOP",
+    "FAILSAFE",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -105,6 +105,7 @@ typedef enum {
     DEBUG_ATTITUDE,
     DEBUG_VTX_MSP,
     DEBUG_GPS_DOP,
+    DEBUG_FAILSAFE,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -683,18 +683,7 @@ static bool canUpdateVTX(void)
 bool areSticksActive(uint8_t stickPercentLimit)
 {
     for (int axis = FD_ROLL; axis <= FD_YAW; axis ++) {
-        const uint8_t deadband = axis == FD_YAW ? rcControlsConfig()->yaw_deadband : rcControlsConfig()->deadband;
-        uint8_t stickPercent = 0;
-        if ((rcData[axis] >= PWM_RANGE_MAX) || (rcData[axis] <= PWM_RANGE_MIN)) {
-            stickPercent = 100;
-        } else {
-            if (rcData[axis] > (rxConfig()->midrc + deadband)) {
-                stickPercent = ((rcData[axis] - rxConfig()->midrc - deadband) * 100) / (PWM_RANGE_MAX - rxConfig()->midrc - deadband);
-            } else if (rcData[axis] < (rxConfig()->midrc - deadband)) {
-                stickPercent = ((rxConfig()->midrc - deadband - rcData[axis]) * 100) / (rxConfig()->midrc - deadband - PWM_RANGE_MIN);
-            }
-        }
-        if (stickPercent >= stickPercentLimit) {
+        if (getRcDeflectionAbs(axis) * 100.f >= stickPercentLimit) {
             return true;
         }
     }

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -217,16 +217,18 @@ uint32_t failsafeFailurePeriodMs(void)
 }
 
 FAST_CODE_NOINLINE void failsafeUpdateState(void)
-// triggered directly, and ONLY, by the cheduler, at 10ms = PERIOD_RXDATA_FAILURE - intervals
+// triggered directly, and ONLY, by the scheduler, at 10ms = PERIOD_RXDATA_FAILURE - intervals
 {
     if (!failsafeIsMonitoring()) {
         return;
     }
 
     bool receivingRxData = failsafeIsReceivingRxData();
-    // true when FAILSAFE_RXLINK_UP
-    // FAILSAFE_RXLINK_UP is set in failsafeOnValidDataReceived
+    // returns state of FAILSAFE_RXLINK_UP
+    // FAILSAFE_RXLINK_UP is set in failsafeOnValidDataReceived, after the various Stage 1 and recovery delays
     // failsafeOnValidDataReceived runs from detectAndApplySignalLossBehaviour
+
+    DEBUG_SET(DEBUG_FAILSAFE, 2, receivingRxData); // from Rx alone, not considering switch
 
     bool armed = ARMING_FLAG(ARMED);
     bool failsafeSwitchIsOn = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
@@ -414,6 +416,10 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
             default:
                 break;
         }
+
+    DEBUG_SET(DEBUG_FAILSAFE, 0, failsafeSwitchIsOn);
+    DEBUG_SET(DEBUG_FAILSAFE, 3, failsafeState.phase);
+
     } while (reprocessState);
 
     if (beeperMode != BEEPER_SILENCE) {

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -312,8 +312,6 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                             //  Enter Stage 2 with settings for landing mode
                             ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
                             failsafeState.phase = FAILSAFE_LANDING;
-                            failsafeState.receivingRxDataPeriodPreset = failsafeState.rxDataRecoveryPeriod;
-                            //  allow re-arming 1 second after Rx recovery
                             failsafeState.landingShouldBeFinishedAt = millis() + failsafeConfig()->failsafe_off_delay * MILLIS_PER_TENTH_SECOND;
                             break;
 
@@ -321,21 +319,20 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                             ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
                             failsafeState.phase = FAILSAFE_LANDED;
                             //  go directly to FAILSAFE_LANDED
-                            failsafeState.receivingRxDataPeriodPreset = failsafeState.rxDataRecoveryPeriod;
-                            //  allow re-arming 1 second after Rx recovery
                             break;
 #ifdef USE_GPS_RESCUE
                         case FAILSAFE_PROCEDURE_GPS_RESCUE:
                             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
                             failsafeState.phase = FAILSAFE_GPS_RESCUE;
-                            failsafeState.receivingRxDataPeriodPreset = failsafeState.rxDataRecoveryPeriod;
-                            //  allow re-arming 1 second after Rx recovery
                             break;
 #endif
                     }
                     if (failsafeState.failsafeSwitchWasOn) {
                         failsafeState.receivingRxDataPeriodPreset = 0;
-                        // allow immediate recovery if failsafe was triggered by a switch
+                        // recover immediately if failsafe was triggered by a switch
+                    } else {
+                        failsafeState.receivingRxDataPeriodPreset = failsafeState.rxDataRecoveryPeriod;
+                        // recover from true link loss failsafe 1 second after RC Link recovers
                     }
                 }
                 reprocessState = true;

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -90,6 +90,7 @@ typedef struct failsafeState_s {
     uint32_t receivingRxDataPeriodPreset;   // preset for the required period of valid rxData
     failsafePhase_e phase;
     failsafeRxLinkState_e rxLinkState;
+    bool failsafeSwitchWasOn;
 } failsafeState_t;
 
 void failsafeInit(void);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -564,6 +564,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
         }
     }
 
+    DEBUG_SET(DEBUG_FAILSAFE, 1, rxSignalReceived);
     DEBUG_SET(DEBUG_RX_SIGNAL_LOSS, 0, rxSignalReceived);
 }
 

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1150,5 +1150,5 @@ extern "C" {
         UNUSED(pitchLpf);
         return 0.0f;
     }
-
+    void getRcDeflectionAbs(void) {}
 }


### PR DESCRIPTION
When testing GPS Rescue, @limonspb found that the requirement to wiggle sticks after the link recovers, to regain control after a true RC Link failure, was broken.

This PR should fix that problem by monitoring the status of the failsafe switch while IDLE, and storing that position in a static variable, so that we know what the switch position was at the start of the Rescue.

If initiated by a switch, the link will appear to return immediately the switch is reversed, the GPS Rescue failsafe phase exit test will note that the switch was `ON` at the start, and exit immediately.

If initiated by a true RC Link Loss, the link will appear when the signal is strong again, and the the GPS Rescue failsafe phase exit test will wait for stick inputs. 

This PR also provides a `FAILSAFE` debug for testing failsafe behaviour, which was useful in resolving this problem.

It also simplifies the coding of the stick deflection test to exit GPS Rescue on restoration of signal and includes some other minor refactoring, all of which reduce flash space requirements.

| Debug | Data | Notes |
| -- | -- | -- |
| 0 | `failsafeSwitchIsOn` | bool, true if failsafe was initiated by failsafe switch (not set by GPS Rescue Mode Switch) |
| 1 | `rxSignalReceived` | bool, from rx.c, true when receiving RC packets |
| 2 | `receivingRxData ` | bool, true when we have valid flight channel data for longer than the recovery delay period, false after stage 1 delay |
| 3 | `failsafeState.phase` | failsafe phase from failsafe.c, see table below |

Table 1: debug values and notes

| Value  | failsafeState.phase  | Notes |
| -- | -- | -- |
| 0 | `FAILSAFE_IDLE` | monitors !receivingRxData, and when that fails, changes phase to `FAILSAFE_RX_LOSS_DETECTED` |
| 1 | `FAILSAFE_RX_LOSS_DETECTED` | only transiently here; immediately changes phase to trigger the stage 2 response, depending on the selected failsafe procedure (see table 3, below) |
| 2 | `FAILSAFE_LANDING` | Beeps the Rx Loss pattern until timed out or disarmed, then enters `FAILSAFE_LANDED` |
| 3 | `FAILSAFE_LANDED` | Disarms, blocks re-arming, then immediately enters `FAILSAFE_RX_LOSS_MONITORING` phase |
| 4 | `FAILSAFE_RX_LOSS_MONITORING` | monitors for presence of `receivingRxData` for longer than `receivingRxDataPeriod`, then goes to `FAILSAFE_RX_LOSS_RECOVERED` |
| 5 | `FAILSAFE_RX_LOSS_RECOVERED` | means we should go back to normal; returns phase to `FAILSAFE_IDLE`, terminates the flight modes `GPS_RESCUE_MODE` or `FAILSAFE_MODE`, restores arming |
| 6 | `FAILSAFE_GPS_RESCUE` | returns to `FAILSAFE_RX_LOSS_RECOVERED` when `receivingRxData` becomes true and sticks move (but if initiated by a failsafe switch, there is no stick movement requirement) |

Table 2: Failsafe phases

| Failsafe procedure | resulting `failsafeState.phase`  | resulting `Flight_Mode` |
| -- | -- | -- |
| `FAILSAFE_PROCEDURE_AUTO_LANDING` | `FAILSAFE_LANDING ` | `FAILSAFE_MODE` |
| `FAILSAFE_PROCEDURE_DROP_IT` | `FAILSAFE_LANDED ` | `FAILSAFE_MODE` |
| `FAILSAFE_PROCEDURE_GPS_RESCUE` | `FAILSAFE_GPS_RESCUE` | `GPS_RESCUE_MODE` |

Table 3: Possible stage 2 values and the outcome when failsafe becomes active


