### PR TITLE
Remove getRcStickDeflection and areSticksInApModePosition

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -405,10 +405,6 @@ void processRcStickPositions(void)
 #endif
 }
 
-int32_t getRcStickDeflection(int32_t axis, uint16_t midrc) {
-    return MIN(abs((int32_t)rcData[axis] - midrc), 500);
-}
-
 void rcControlsInit(void)
 {
     analyzeModeActivationConditions();

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -105,11 +105,6 @@ bool isUsingSticksForArming(void)
     return isUsingSticksToArm;
 }
 
-bool areSticksInApModePosition(uint16_t ap_mode)
-{
-    return fabsf(rcCommand[ROLL]) < ap_mode && fabsf(rcCommand[PITCH]) < ap_mode;
-}
-
 throttleStatus_e calculateThrottleStatus(void)
 {
     if (featureIsEnabled(FEATURE_3D)) {

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -139,7 +139,6 @@ PG_DECLARE(armingConfig_t, armingConfig);
 
 bool areUsingSticksToArm(void);
 
-bool areSticksInApModePosition(uint16_t ap_mode);
 throttleStatus_e calculateThrottleStatus(void);
 void processRcStickPositions();
 

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -144,5 +144,4 @@ void processRcStickPositions();
 
 bool isUsingSticksForArming(void);
 
-int32_t getRcStickDeflection(int32_t axis, uint16_t midrc);
 void rcControlsInit(void);


### PR DESCRIPTION
This PR removes two functions that are not used in Betaflight at present:
- getRcStickDeflection 
- areSticksInApModePosition