### PR TITLE
Include MSP over telemetry for ghost

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -191,7 +191,7 @@
 #define USE_SBUS_CHANNELS
 #endif
 
-#if !defined(USE_TELEMETRY_SMARTPORT) && !defined(USE_TELEMETRY_CRSF)
+#if !defined(USE_TELEMETRY_SMARTPORT) && !defined(USE_TELEMETRY_CRSF) && !defined(USE_TELEMETRY_GHST)
 #undef USE_MSP_OVER_TELEMETRY
 #endif
 


### PR DESCRIPTION
Cloud build with only ghost selected as rx protocol will cause MSP_OVER_TELEMETRY to be undefined. It went unnoticed until now because USE_TELEMETRY_SMARTPORT and/or USE_TELEMETRY_CRSF have always been defined for all targets.

Keep it defined also if USE_TELEMETRY_GHST is defined. 

