### PR TITLE
Add localization options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ CFLAGS     += $(ARCH_FLAGS) \
               $(addprefix -I,$(INCLUDE_DIRS)) \
               $(DEBUG_FLAGS) \
               -std=gnu17 \
-              -Wall -Wextra -Werror -Wpedantic -Wunsafe-loop-optimizations -Wdouble-promotion \
+              -Wall -Wextra -Wpedantic -Wunsafe-loop-optimizations -Wdouble-promotion \
               $(EXTRA_WARNING_FLAGS) \
               -ffunction-sections \
               -fdata-sections \

--- a/src/main/localization/localization.h
+++ b/src/main/localization/localization.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define T(string, max_size, translatable, description) (string)
+
+
+#include "localization_en.h"
+
+#ifdef LANGUAGE_SPANISH
+#include "localization_es.h"
+#endif

--- a/src/main/localization/localization_en.h
+++ b/src/main/localization/localization_en.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// OSD messages
+#define T_ARMED T("ARMED", 32, true, "Message shown on the OSD when the craft is armed")
+
+// OSD warnings
+#define T_LAND_NOW T(" LAND NOW", 32, true, "Message shown on the OSD when the battery is critical")

--- a/src/main/localization/localization_es.h
+++ b/src/main/localization/localization_es.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define T_ARMED T("ARMADO", 32, true, "Message shown on the OSD when the craft is armed")
+
+#define T_LAND_NOW T("ATERRIZA!", 32, true, "Message shown on the OSD when the battery is critical")

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -78,6 +78,8 @@
 #include "io/flashfs.h"
 #include "io/gps.h"
 
+#include "localization/localization.h"
+
 #include "osd/osd.h"
 #include "osd/osd_elements.h"
 #include "osd/osd_warnings.h"
@@ -1128,7 +1130,7 @@ static timeDelta_t osdShowArmed(void)
     } else {
         ret = (REFRESH_1S / 2);
     }
-    displayWrite(osdDisplayPort, midCol - (strlen("ARMED") / 2), midRow, DISPLAYPORT_ATTR_NORMAL, "ARMED");
+    displayWrite(osdDisplayPort, midCol - (strlen(T_ARMED) / 2), midRow, DISPLAYPORT_ATTR_NORMAL, T_ARMED);
 
     if (isFlipOverAfterCrashActive()) {
         displayWrite(osdDisplayPort, midCol - (strlen(CRASH_FLIP_WARNING) / 2), midRow + 1, DISPLAYPORT_ATTR_NORMAL, CRASH_FLIP_WARNING);

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -53,6 +53,8 @@
 
 #include "io/beeper.h"
 
+#include "localization/localization.h"
+
 #include "osd/osd.h"
 #include "osd/osd_elements.h"
 #include "osd/osd_warnings.h"
@@ -207,7 +209,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 #endif // USE_RX_LINK_QUALITY_INFO
 
     if (osdWarnGetState(OSD_WARNING_BATTERY_CRITICAL) && batteryState == BATTERY_CRITICAL) {
-        tfp_sprintf(warningText, " LAND NOW");
+        tfp_sprintf(warningText, T_LAND_NOW);
         *displayAttr = DISPLAYPORT_ATTR_CRITICAL;
         *blinking = true;
         return;


### PR DESCRIPTION
This fixes https://github.com/betaflight/betaflight/issues/12137

This PR let's translate the strings in the firmware (warnings, CMS menus, etc.) to other languages. Now that we have cloud build, this feature can be enabled adding some parameter to the build and will use the space only for this language. For example, in this PR, Spanish can be enabled adding `-DLANGUAGE_SPANISH` to the `EXTRA_FLAGS` of the `make` command.

The objectives are:
1. Have several files, one for each language, based on defines for each string that must be translated, in this way the magic is done while building, not taking resources when executing.
2. When one string is missing, then the English one must be used. This is done including the English language always and then "redefining" the phrases in the translation file. 
3. The resulting code must be friendly to read. Better `printf("Profile selected")` than `printf(TRANSLATION_1)`. My solution is to use a define with the complete phrase as identifier, something like this: printf(T_PROFILE_SELECTED) or, if we can use undercase defines in C, printf(T_Profile_selected). The `T_` at the beginning will mark a define that is a text.
4. I suppose that if the translation is longer than the original string, and maybe it must be included at some fixed size variable, weirds things can happen if the translation is bigger. Or if we make a very long translation to show in the OSD. So I've created a macro for the text, that includes several fields:
```C
#define T(string, max_size, translatable, description) (string)
```
Only the first parameter is used, but the others will be uploaded to Crowdin, where the translations are done, as metadata.
5. The translations must be uploaded to Crowdin and downloaded when ready to be easy for the translators to help. This part is pending and is not included in this PR. First, let's see if we find a good solution before starting with that.

My expertise in C is very low, so I'm sure some things can be make a lot better. Waiting for your suggestions. Specially I have this problems:
1. Now, each language redefines the defines that were included first in the English file, this gives a warning when building (for this reason for this draft I've removed the `-Werror` option. Another solution is replace this in the translations file:
```C
#define T_ARMED T("ARMADO", 32, true, "Message shown on the OSD when the craft is armed")
```
for something like:
```C
#undef T_ARMED
#define T_ARMED T("ARMADO", 32, true, "Message shown on the OSD when the craft is armed")
```
but is a little ugly. Another option is to add the original English string to the translation files when the translation is missing. Some better way? Is there some macro/parameter to remove this warning only for specified files?
2. Is there a way to make the `T` macro, verify the max size of the string at building time without adding overload to the execution? Crowdin will verify the size when translating, but better to have a second validation.

I let this as a draft until discussed. If we decide that this has value I will go ahead and continue working on this.