### PR TITLE
Fix gating for USE_ACC_SPI_MPU9250

### DIFF
--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -86,7 +86,8 @@
 
 #include "acceleration_init.h"
 
-#if !defined(USE_ACC_MPU6500) && !defined(USE_ACC_SPI_MPU6000) && !defined(USE_ACC_SPI_MPU6500) &&  \
+#if !defined(USE_ACC_MPU6000) && !defined(USE_ACC_SPI_MPU6000) && !defined(USE_ACC_MPU6500) && \
+    !defined(USE_ACC_SPI_MPU6500) && !defined(USE_ACC_SPI_MPU9250) && !defined(USE_ACC_SPI_ICM20602) && \
     !defined(USE_ACC_SPI_ICM20689) && !defined(USE_ACCGYRO_LSM6DSO) && !defined(USE_ACCGYRO_BMI160) && \
     !defined(USE_ACCGYRO_BMI270) && !defined(USE_ACC_SPI_ICM42605) && !defined(USE_ACC_SPI_ICM42688P) && \
     !defined(USE_ACC_ADXL345) && !defined(USE_ACC_BMA280) && !defined(USE_ACC_LSM303DLHC) && \

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -287,7 +287,7 @@
 #if !defined(USE_ACC_MPU6500) && (defined(USE_ACC_ICM20601) || defined(USE_ACC_ICM20602) || defined(USE_ACC_ICM20608G))
 #define USE_ACC_MPU6500
 #endif
-#if !defined(USE_ACC_SPI_MPU6500) && (defined(USE_ACC_SPI_ICM20601) || defined(USE_ACC_SPI_ICM20602) || defined(USE_ACC_SPI_ICM20608G))
+#if !defined(USE_ACC_SPI_MPU6500) && (defined(USE_ACC_SPI_MPU9250) || defined(USE_ACC_SPI_ICM20601) || defined(USE_ACC_SPI_ICM20602) || defined(USE_ACC_SPI_ICM20608G))
 #define USE_ACC_SPI_MPU6500
 #endif
 #if !defined(USE_GYRO_MPU6500) && (defined(USE_GYRO_ICM20601) || defined(USE_GYRO_ICM20602) || defined(USE_GYRO_ICM20608G))


### PR DESCRIPTION
A requested build has failed (REVONANO / 4.4.0-RC5).

Log: https://build.betaflight.com/api/builds/8405f2abf2124b47966e0f4a6c014d30/log
Request: https://build.betaflight.com/api/builds/8405f2abf2124b47966e0f4a6c014d30/json