### PR TITLE
Add GYRO_CALIBRATION debug mode

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -108,4 +108,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "VTX_MSP",
     "GPS_DOP",
     "FAILSAFE",
+    "GYRO_CALIBRATION",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -106,6 +106,7 @@ typedef enum {
     DEBUG_VTX_MSP,
     DEBUG_GPS_DOP,
     DEBUG_FAILSAFE,
+    DEBUG_GYRO_CALIBRATION,
     DEBUG_COUNT
 } debugType_e;
 


### PR DESCRIPTION
When evaluating FCs a key characteristic is gyro noise. During gyro calibration the standard deviation of the gyro rates on each axis is calculated and calibration only terminates once this falls below `gyro_calib_noise_limit` on every axis.

This PR adds a debug mode which displays these standard deviations at the end of each calibration cycle for  each axis. By setting `gyro_calib_noise_limit` to a low, non-zero value, eg `1` the amount of noise can be observed on the sensors tab. Such a low value prevents calibration completing and allows the noise level to be observed.

```
set debug_mode = GYRO_CALIBRATION
set gyro_calib_noise_limit = 1
```

On a good FC we get.

| Debug | Value |
| - | - |
| 0 | X Axis |
| 1 | Y Axis |
| 2 | Z Axis |
| 3 | Remaining calibration steps |

![image](https://user-images.githubusercontent.com/11480839/214974445-33909d0f-260e-4367-af5c-08aaf612041c.png)

With a bad gyro (either faulty or due to power supply noise) a higher value will be observed for the affected axis.
