### PR TITLE
Don't bundle flash drivers and flash fs/tools together.

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -234,6 +234,9 @@
 #endif
 
 #ifdef USE_FLASH
+#define USE_FLASH_TOOLS
+#define USE_FLASHFS
+#endif
 
 #if (defined(USE_FLASH_W25M512) || defined(USE_FLASH_W25Q128FV)) && !defined(USE_FLASH_M25P16)
 #define USE_FLASH_M25P16
@@ -249,11 +252,7 @@
 
 #if defined(USE_FLASH_M25P16) || defined(USE_FLASH_W25M) || defined(USE_FLASH_W25N01G) || defined(USE_FLASH_W25Q128FV)
 #define USE_FLASH_CHIP
-#define USE_FLASH_TOOLS
-#define USE_FLASHFS
 #endif
-
-#endif // USE_FLASH
 
 #ifndef USE_FLASH_CHIP
 #undef USE_FLASH_TOOLS


### PR DESCRIPTION
Flash drivers need to be able to be compiled in without flashfs/flash tools.

See https://github.com/betaflight/betaflight/pull/12221#issuecomment-1407711629

This reverts the change that incorrectly #12221 introduced, and as far as I can tell the change should not have been in #12221 anyway.