### PR TITLE
Fix missing CUSTOM_DEFAULTS for H730/H750 targets.

### DIFF
--- a/src/link/stm32_h730_common.ld
+++ b/src/link/stm32_h730_common.ld
@@ -98,6 +98,21 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
+  /* Storage for the address for the configuration section so we can grab it out of the hex file */
+  .custom_defaults :
+  {
+    . = ALIGN(4);
+    KEEP (*(.custom_defaults_start_address))
+    . = ALIGN(4);
+    KEEP (*(.custom_defaults_end_address))
+    . = ALIGN(4);
+    __custom_defaults_internal_start = .;
+    *(.custom_defaults);
+  } >CUSTOM_DEFAULTS
+
+  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
+  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
+
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_h750_common.ld
+++ b/src/link/stm32_h750_common.ld
@@ -82,6 +82,21 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
+  /* Storage for the address for the configuration section so we can grab it out of the hex file */
+  .custom_defaults :
+  {
+    . = ALIGN(4);
+    KEEP (*(.custom_defaults_start_address))
+    . = ALIGN(4);
+    KEEP (*(.custom_defaults_end_address))
+    . = ALIGN(4);
+    __custom_defaults_internal_start = .;
+    *(.custom_defaults);
+  } >CUSTOM_DEFAULTS
+
+  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
+  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
+
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_ram_h730_exst.ld
+++ b/src/link/stm32_ram_h730_exst.ld
@@ -46,6 +46,24 @@ The initial CODE_RAM is sized at 1MB.
 /* see .exst section below */
 _exst_hash_size = 64;
 
+/*
+
+A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
+Using RAM will suffice until an alternative location for it can be made workable.
+
+It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
+code to read them from external flash instead of a copy of them stored in precious RAM.
+There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
+not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
+in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
+then the custom defaults would also be erased...
+Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
+flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
+
+*/
+
+_custom_defaults_size = 8K;
+
 /* Specify the memory areas */
 MEMORY
 {
@@ -62,8 +80,9 @@ MEMORY
 
     OCTOSPI2 (rx)     : ORIGIN = 0x70000000, LENGTH = 256M
     OCTOSPI1 (rx)     : ORIGIN = 0x90000000, LENGTH = 256M 
-    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
+    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _custom_defaults_size
+    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(CUSTOM_DEFAULTS) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
 }
 
 REGION_ALIAS("STACKRAM", DTCM_RAM)

--- a/src/link/stm32_ram_h750_exst.ld
+++ b/src/link/stm32_ram_h750_exst.ld
@@ -54,14 +54,34 @@ possible.
 /* see .exst section below */
 _exst_hash_size = 64;
 
+/*
+
+A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
+Using RAM will suffice until an alternative location for it can be made workable.
+
+It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
+code to read them from external flash instead of a copy of them stored in precious RAM.
+There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
+not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
+in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
+then the custom defaults would also be erased...
+Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
+flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
+
+*/
+
+_custom_defaults_size = 8K;
+
 /* Specify the memory areas */
 MEMORY
 {
     ITCM_RAM (rwx)    : ORIGIN = 0x00000000, LENGTH = 64K
     DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
     RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 64K
-    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
+    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(CODE_RAM) + LENGTH(CODE_RAM), LENGTH = _custom_defaults_size
+    
+    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM) + LENGTH(CUSTOM_DEFAULTS), LENGTH = _exst_hash_size
 
     D2_RAM (rwx)      : ORIGIN = 0x30000000, LENGTH = 256K /* SRAM1 + SRAM2 */
 

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -107,3 +107,7 @@
 #if !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD) && !defined(CONFIG_IN_EXTERNAL_FLASH)
 #define CONFIG_IN_RAM
 #endif
+
+#ifdef USE_EXST
+#define USE_CUSTOM_DEFAULTS
+#endif

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -114,3 +114,8 @@
 #if !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD) && !defined(CONFIG_IN_EXTERNAL_FLASH)
 #define CONFIG_IN_RAM
 #endif
+
+#ifdef USE_EXST
+#define USE_CUSTOM_DEFAULTS
+#endif
+


### PR DESCRIPTION
As we were unable to test the could build system for the SPRacingH7EXTREME target until *after* a release was published (the 4.4 final) we were not aware that the unified target configuration was not being applied by the configurator.

@haslinghuis reported "Trying to get the SPRACINGH7EXTREME working - now the cloud build finally succeeds. Only baro is detected as the resources and settings are not executed and there is no apply custom defaults modal after flashing and first connect. Configuring manual brings alive the gyro + acc."

FYI: My testing of the SPRacingH7EXTREME target involved using the `./support/scripts/build_spracingh7extreme.sh` script and manually applying the `SPRO-SPRACINGH7EXTREME.config` as it wasn't possible to use the configurator.

@blckmn @McGiverGim This also highlights an issue were we are unable to test configurator/target/build/repo systems until *after* a release when it's already too late.  We should avoid this situation.

This PR should be merged into `4.4-maintenance` and scheduled for `4.4.1` as well as being merged into `master`.

For good measure I also updated the H730 code in addition to the H750.

Not quite sure how to test this PR fully, the linker script output looks correct to me, i.e. there's a 'CUSTOM_DEFAULTS' section present when EXST is enabled.

```
make TARGET=STM32H750 OPTIONS="EXST=YES"
Linking STM32H750
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:        9936 B        64 KB     15.16%
        DTCM_RAM:       71632 B       128 KB     54.65%
             RAM:       24448 B        64 KB     37.30%
        CODE_RAM:      364629 B     450496 B     80.94%
 CUSTOM_DEFAULTS:           8 B         8 KB      0.10%
       EXST_HASH:          64 B         64 B    100.00%
          D2_RAM:          0 GB       256 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
         QUADSPI:          0 GB         0 GB
   text    data     bss     dec     hex filename
 357029    7672   88468  453169   6ea31 ./obj/main/betaflight_STM32H750.elf```


```
make TARGET=STM32H730 OPTIONS="EXST=YES"
...
Linking STM32H730
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:       17928 B        64 KB     27.36%
        DTCM_RAM:       31656 B       128 KB     24.15%
             RAM:       77056 B       320 KB     23.52%
          D2_RAM:          0 GB        32 KB      0.00%
          D3_RAM:          0 GB        16 KB      0.00%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
        OCTOSPI2:          0 GB       256 MB      0.00%
        OCTOSPI1:          0 GB       256 MB      0.00%
   OCTOSPI1_CODE:      539471 B    1040320 B     51.86%
 CUSTOM_DEFAULTS:           8 B         8 KB      0.10%
       EXST_HASH:          64 B         64 B    100.00%
   text    data     bss     dec     hex filename
 531451    8088  100672  640211   9c4d3 ./obj/main/betaflight_STM32H730.elf
```

Do we need to wait for a nightly build or release candidate in order to test that the configurator can build, flash and the unified target configuration (custom defaults)?
