### PR TITLE
Enable retrieval of the BUILD_KEY using MSP2

### DIFF
--- a/src/main/build/version.c
+++ b/src/main/build/version.c
@@ -26,3 +26,9 @@ const char * const targetName = __TARGET__;
 const char * const shortGitRevision = __REVISION__;
 const char * const buildDate = __DATE__;
 const char * const buildTime = __TIME__;
+
+#ifdef BUILD_KEY
+const char * const buildKey = STR(BUILD_KEY);
+#else
+const char * const buildKey = " ";
+#endif

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -42,3 +42,5 @@ extern const char* const buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
 extern const char* const buildTime;  // "HH:MM:SS"
 
 #define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR)
+
+extern const char* const buildKey;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4814,7 +4814,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
 #endif
 
 #ifdef BUILD_KEY
-    cliPrintf("BUILD KEY: %s", STR(BUILD_KEY));
+    cliPrintf("BUILD KEY: %s", buildKey);
 #ifdef RELEASE_NAME
     cliPrintf(" (%s)", STR(RELEASE_NAME));
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2522,7 +2522,7 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
             // type byte, then length byte followed by the actual characters
             const uint8_t textType = sbufBytesRemaining(src) ? sbufReadU8(src) : 0;
 
-            char* textVar;
+            const char* textVar;
 
             switch (textType) {
                 case MSP2TEXT_PILOT_NAME:
@@ -2539,6 +2539,10 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
 
                 case MSP2TEXT_RATE_PROFILE_NAME:
                     textVar = currentControlRateProfile->profileName;
+                    break;
+
+                case MSP2TEXT_BUILDKEY:
+                    textVar = buildKey;
                     break;
 
                 default:

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2522,7 +2522,7 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
             // type byte, then length byte followed by the actual characters
             const uint8_t textType = sbufBytesRemaining(src) ? sbufReadU8(src) : 0;
 
-            const char* textVar;
+            const char *textVar;
 
             switch (textType) {
                 case MSP2TEXT_PILOT_NAME:

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -32,3 +32,4 @@
 #define MSP2TEXT_CRAFT_NAME                      2
 #define MSP2TEXT_PID_PROFILE_NAME                3
 #define MSP2TEXT_RATE_PROFILE_NAME               4
+#define MSP2TEXT_BUILDKEY                        5


### PR DESCRIPTION
This will enable the configurator to look up the configuration for the build, and set the defaults.

Will be a corresponding PR in configurator, though this can be merged as is, and is not dependent on configurator.