### PR TITLE
Fix Bug causing Dynamic Idle to fail if  RPM filtering is turned off

### DIFF
--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -94,6 +94,8 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
         pt1FilterInit(&motorFreqLpf[i], pt1FilterGain(config->rpm_filter_lpf_hz, looptimeUs * 1e-6f));
     }
 
+    erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE  / (motorConfig()->motorPoleCount / 2.0f);
+
     // if RPM Filtering is configured to be off
     if (!config->rpm_filter_harmonics) {
         return;
@@ -114,8 +116,6 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
             }
         }
     }
-
-    erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE  / (motorConfig()->motorPoleCount / 2.0f);
 
     const float loopIterationsPerUpdate = RPM_FILTER_DURATION_S / (looptimeUs * 1e-6f);
     const float numNotchesPerAxis = getMotorCount() * rpmFilter.numHarmonics;


### PR DESCRIPTION
This is a Bug Fix for an issue where Dynamic Idle went to maximum Idle boost, when activated, if RPM Filtering was switched off, even though DShot Telemetry was enabled.

Many thanks to Eddie Trejo for finding the bug and reporting it!

I think the bug originated [here](https://github.com/betaflight/betaflight/pull/11765/files#diff-09007314a5a5c7d0ab61c6cd900b476ef0a173f0bd7f794b1d294bd2e198e1b0R99-R101
) in PR #11765, where the initialisation of the various RPM Filter init values exited **before** calculating the `erpmToHz` value.  `erpmToHz` is required to calculate and return `minMotorFrequencyHz` to Dynamic Idle via `getMinMotorFrequency`.

This PR just moves the calculation `erpmToHz` up, in `rpmFilterInit`, so that it is calculated before the return when RPM Filtering is not enabled.

This appears to solve the bug.