### PR TITLE
Fix motors incorrect spin direction after fast arm from turtle mode

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -525,7 +525,7 @@ void tryArm(void)
             if (isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
                 // Set motor spin direction
                 if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
-                    if (cmpTimeUs(currentTimeUs, lastDisarmTimeUs) < 200000 && flipOverAfterCrashWasActiveLast) {
+                    if (cmpTimeUs(currentTimeUs, lastDisarmTimeUs) < 450000 && flipOverAfterCrashWasActiveLast) {
                         tryingToArm = ARMING_DELAYED_NORMAL;
                         return;
                     }
@@ -534,7 +534,7 @@ void tryArm(void)
                         dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, DSHOT_CMD_TYPE_INLINE);
                     }
                 } else {
-                    if (cmpTimeUs(currentTimeUs, lastDisarmTimeUs) < 200000 && !flipOverAfterCrashWasActiveLast) {
+                    if (cmpTimeUs(currentTimeUs, lastDisarmTimeUs) < 450000 && !flipOverAfterCrashWasActiveLast) {
                         tryingToArm = ARMING_DELAYED_CRASHFLIP;
                         return;
                     }

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -525,7 +525,7 @@ void tryArm(void)
             if (isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
                 // Set motor spin direction
                 if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
-                    if (currentTimeUs - lastDisarmTimeUs < 200000 && flipOverAfterCrashWasActiveLast) {
+                    if (cmpTimeUs(currentTimeUs, lastDisarmTimeUs) < 200000 && flipOverAfterCrashWasActiveLast) {
                         tryingToArm = ARMING_DELAYED_NORMAL;
                         return;
                     }
@@ -534,7 +534,7 @@ void tryArm(void)
                         dshotCommandWrite(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, DSHOT_CMD_TYPE_INLINE);
                     }
                 } else {
-                    if (currentTimeUs - lastDisarmTimeUs < 200000 && !flipOverAfterCrashWasActiveLast) {
+                    if (cmpTimeUs(currentTimeUs, lastDisarmTimeUs) < 200000 && !flipOverAfterCrashWasActiveLast) {
                         tryingToArm = ARMING_DELAYED_CRASHFLIP;
                         return;
                     }


### PR DESCRIPTION
This fixes a bug that I noticed while programming auto crashflip mode. It is easily reproducible using the setup some racers use with crashflip on a momentary switch.
The bug occurs when:
1. Copter is armed in crashflip mode
2. Sticks are moved such that one or more motors spin
3. Copter is rapidly disarmed and rearmed into normal mode

Symptom:
1. One or more motors will not be spinning in the correct direction after arming in normal mode

Solution:
1. Add a minimum delay of 0.2s before quad is armed after leaving turtle mode

Video of the bug happening along with my fix
[https://youtu.be/OPd9PqgVMhE](https://youtu.be/OPd9PqgVMhE)
