### PR TITLE
Require explicit usage of firmware partition for EXST targets.

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -519,7 +519,7 @@ static void flashConfigurePartitions(void)
     }
 #endif
 
-#if defined(FIRMWARE_SIZE)
+#if defined(FIRMWARE_SIZE) && defined(USE_FIRMWARE_PARTITION)
     const uint32_t firmwareSize = (FIRMWARE_SIZE * 1024);
     flashSector_t firmwareSectors = (firmwareSize / flashGeometry->sectorSize);
 


### PR DESCRIPTION
This is in preparation for memory mapped EXST targets with a second flash chip for data storage and config.

For example: The H7EF target uses memory mapped flash for code execution, and SPI for black-box logging and config storage.