### PR TITLE
Don't enable all flash chips by default on EXST targets.

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -166,6 +166,7 @@
 
 #if defined(USE_FLASH)
 
+#if !defined(USE_EXST)
 #define USE_FLASHFS
 #define USE_FLASH_TOOLS
 #define USE_FLASH_M25P16
@@ -174,9 +175,10 @@
 #define USE_FLASH_W25M512    // 512Kb (256Kb x 2 stacked) NOR flash support
 #define USE_FLASH_W25M02G    // 2Gb (1Gb x 2 stacked) NAND flash support
 #define USE_FLASH_W25Q128FV  // 16MB Winbond 25Q128
+#endif // USE_EXST
 
-#endif
-#endif
+#endif // USE_FLASH
+#endif // USE_FLASH_CHIP
 
 #ifndef USE_MAX7456
 #define USE_MAX7456


### PR DESCRIPTION
EXST targets generally ship with a specific flash chip, so there is no point including flash chip drivers that are never intended to be on the PCB.

e.g.  there's no point including other flash chip drivers for the SPRacingH7NANO/ZERO which always have the W25N01G.