### PR TITLE
Include smartport telemetry for Fport

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -156,7 +156,12 @@
 #undef USE_TELEMETRY_SRXL
 
 #ifdef USE_SERIALRX_FPORT
+#ifndef USE_TELEMETRY
 #define USE_TELEMETRY
+#endif
+#ifndef USE_TELEMETRY_SMARTPORT
+#define USE_TELEMETRY_SMARTPORT
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Fport should include working telemetry when selected as serial rx protocol. It's not obvious for the user that smartport telemetry has to be selected to get telemetry working for fport.

The documentation also suggests that telemetry should be included during the build for Fport http://betaflight.com/docs/development/API/Cloud-Build-API#telemetry-protocols