### PR TITLE
Enable DMA on AT32F435 SPI

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -1021,7 +1021,7 @@ void init(void)
 #endif
 
     // On H7/G4 allocate SPI DMA streams after motor timers as SPI DMA allocate will always be possible
-#if defined(STM32H7) || defined(STM32G4)
+#if defined(STM32H7) || defined(STM32G4) || defined(AT32F435)
 #ifdef USE_SPI
     // Attempt to enable DMA on all SPI busses
     spiInitBusDMA();

--- a/src/main/target/AT32F435/target.h
+++ b/src/main/target/AT32F435/target.h
@@ -54,9 +54,23 @@
 //#define I2C_FULL_RECONFIGURABILITY
 
 #define USE_SPI
-#define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2
-#define SPI_FULL_RECONFIGURABILITY
+
+// AT-START-F435 J7 connector SPI 1
+#define SPI2_SCK_PIN            PD1
+#define SPI2_MISO_PIN           PC2
+#define SPI2_MOSI_PIN           PD4
+
+#define J7_NSS                  PD0
+
+#define GYRO_1_CS_PIN           J7_NSS
+#define GYRO_1_SPI_INSTANCE     SPI2
+
+#define USE_EXTI
+#define USE_GYRO_EXTI
+#define GYRO_1_EXTI_PIN         PB11
+
+#define USE_ACCGYRO_BMI160
 
 //#define USE_USB_DETECT
 #define USE_VCP


### PR DESCRIPTION
This PR enables SPI DMA for AT32F435 processors and adds definitions to the AT32F435 target to support use of a gyro connected to the J7 connector of the AT-START-F435 eval card. Note that the AT-START-F435 specifics should be removed from the AT32F435 target definition, but this is just a convenience for now.

The gyro used to test this was a widely available [BMI160 evaluation card](https://www.amazon.co.uk/HALJIA-BMI160-Module-6DOF-Acceleration/dp/B08BC15D9S). This source is just given as an example.

![IMG_2723](https://user-images.githubusercontent.com/11480839/217384443-9cfc361d-cb72-43ea-aa43-c7e78bcd2025.jpeg)

Unfortunately the silk screen on the eval board (and all it's clones that I could find) was wrong.

To save anybody else struggling with this, with reference to the [data sheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi160-ds000.pdf) the wiring for SPI is shown as:

![image](https://user-images.githubusercontent.com/11480839/169617363-4921be00-4db9-4152-934f-2fdb55f95ae1.png)

The eval card is silkscreened as shown below:

![image](https://user-images.githubusercontent.com/11480839/169617645-3b2e52d8-5ff3-4d1f-b101-27564f56321f.png)

The required connections are:

| AT-START-F435 J7 | Eval card | Expected |
| - | - | - |
| 5V | VIN |
| GND | GND |
| SCLK | SCL | SCX |
| MOSI | SDA | SDX |
| MISO | SA0 |
| NSS | CS |
| PB11 | INT 1|

The detection of both the interrupt and DMA is confirmed by

```
# status
MCU AT32F435 Clock=288MHz
Stack size: 2048, Stack address: 0x2002fff0
Configuration: CONFIGURED, size: 3114, max available: 16384
Devices detected: SPI:1
Gyros detected: gyro 1 locked dma
GYRO=BMI160, ACC=BMI160
System Uptime: 84 seconds, Current Time: 2023-02-07T22:41:05.662+00:00
CPU:4%, cycle time: 317, GYRO rate: 3154, RX rate: 15, System rate: 9
Voltage: 0 * 0.01V (0S battery - NOT PRESENT)
I2C Errors: 0
Arming disable flags: RXLOSS ANGLE CLI MSP MOTOR_PROTO

# dma show

Currently active DMA:
--------------------
DMA1 Channel 1: SPI_MOSI 2
DMA1 Channel 2: SPI_MISO 2
DMA1 Channel 3: FREE
DMA1 Channel 4: FREE
DMA1 Channel 5: FREE
DMA1 Channel 6: FREE
DMA1 Channel 7: FREE
DMA2 Channel 1: FREE
DMA2 Channel 2: FREE
DMA2 Channel 3: FREE
DMA2 Channel 4: FREE
DMA2 Channel 5: FREE
DMA2 Channel 6: FREE
DMA2 Channel 7: FREE
```

The traces below show the SPI transfer reading the gyro/accel date.

![image](https://user-images.githubusercontent.com/11480839/217385677-6d502a83-d768-4c02-9e14-664c473c20d0.png)

![image](https://user-images.githubusercontent.com/11480839/217385895-83350c82-84f2-4f3f-985b-71a2e1a150b1.png)
