### PR TITLE
Fix SDFT batchSize rounding

### DIFF
--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -55,7 +55,7 @@ void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numB
     sdft->endBin = constrain(endBin, sdft->startBin, SDFT_BIN_COUNT - 1);
 
     sdft->numBatches = MAX(numBatches, 1);
-    sdft->batchSize = (sdft->endBin - sdft->startBin) / sdft->numBatches + 1;  // batchSize = ceil(numBins / numBatches)
+    sdft->batchSize = (sdft->endBin - sdft->startBin + 1) / sdft->numBatches;
 
     for (int i = 0; i < SDFT_SAMPLE_SIZE; i++) {
         sdft->samples[i] = 0.0f;
@@ -183,7 +183,7 @@ static FAST_CODE void applySqrt(const sdft_t *sdft, float *data)
 }
 
 
-// Needed for proper windowing at the edges of startBin and endBin
+// Needed for proper windowing at the edges of active range
 static FAST_CODE void updateEdges(sdft_t *sdft, const float value, const int batchIdx)
 {
     // First bin outside of lower range


### PR DESCRIPTION
Fixes a bug where the FC freezes on very specific `dyn_notch_min_hz` and `dyn_notch_max_hz` configurations due to an "array index out of bounds error" in `void sdftPushBatch(...)`.

Cherry-picked from https://github.com/betaflight/betaflight/pull/12329