### PR TITLE
Revert "Fix missing CUSTOM_DEFAULTS for H730/H750 targets. (#12281)"

### DIFF
--- a/src/link/stm32_h730_common.ld
+++ b/src/link/stm32_h730_common.ld
@@ -98,21 +98,6 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_start_address))
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_end_address))
-    . = ALIGN(4);
-    __custom_defaults_internal_start = .;
-    *(.custom_defaults);
-  } >CUSTOM_DEFAULTS
-
-  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
-
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_h750_common.ld
+++ b/src/link/stm32_h750_common.ld
@@ -82,21 +82,6 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_start_address))
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_end_address))
-    . = ALIGN(4);
-    __custom_defaults_internal_start = .;
-    *(.custom_defaults);
-  } >CUSTOM_DEFAULTS
-
-  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
-
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_ram_h730_exst.ld
+++ b/src/link/stm32_ram_h730_exst.ld
@@ -46,24 +46,6 @@ The initial CODE_RAM is sized at 1MB.
 /* see .exst section below */
 _exst_hash_size = 64;
 
-/*
-
-A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
-Using RAM will suffice until an alternative location for it can be made workable.
-
-It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
-code to read them from external flash instead of a copy of them stored in precious RAM.
-There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
-not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
-in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
-then the custom defaults would also be erased...
-Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
-flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
-
-*/
-
-_custom_defaults_size = 8K;
-
 /* Specify the memory areas */
 MEMORY
 {
@@ -80,9 +62,8 @@ MEMORY
 
     OCTOSPI2 (rx)     : ORIGIN = 0x70000000, LENGTH = 256M
     OCTOSPI1 (rx)     : ORIGIN = 0x90000000, LENGTH = 256M 
-    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _custom_defaults_size
-    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(CUSTOM_DEFAULTS) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
+    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
 }
 
 REGION_ALIAS("STACKRAM", DTCM_RAM)

--- a/src/link/stm32_ram_h750_exst.ld
+++ b/src/link/stm32_ram_h750_exst.ld
@@ -54,34 +54,14 @@ possible.
 /* see .exst section below */
 _exst_hash_size = 64;
 
-/*
-
-A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
-Using RAM will suffice until an alternative location for it can be made workable.
-
-It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
-code to read them from external flash instead of a copy of them stored in precious RAM.
-There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
-not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
-in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
-then the custom defaults would also be erased...
-Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
-flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
-
-*/
-
-_custom_defaults_size = 8K;
-
 /* Specify the memory areas */
 MEMORY
 {
     ITCM_RAM (rwx)    : ORIGIN = 0x00000000, LENGTH = 64K
     DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
     RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 64K
-    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(CODE_RAM) + LENGTH(CODE_RAM), LENGTH = _custom_defaults_size
-    
-    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM) + LENGTH(CUSTOM_DEFAULTS), LENGTH = _exst_hash_size
+    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
 
     D2_RAM (rwx)      : ORIGIN = 0x30000000, LENGTH = 256K /* SRAM1 + SRAM2 */
 

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -107,7 +107,3 @@
 #if !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD) && !defined(CONFIG_IN_EXTERNAL_FLASH)
 #define CONFIG_IN_RAM
 #endif
-
-#ifdef USE_EXST
-#define USE_CUSTOM_DEFAULTS
-#endif

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -114,8 +114,3 @@
 #if !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD) && !defined(CONFIG_IN_EXTERNAL_FLASH)
 #define CONFIG_IN_RAM
 #endif
-
-#ifdef USE_EXST
-#define USE_CUSTOM_DEFAULTS
-#endif
-


### PR DESCRIPTION
This reverts commit ec20d399c5e7a97b01c80f80ee8987f6179109d9.

The plan is to remove custom defaults support for EXST targets for 4.4.1 and remove custom defaults support for all targets for 4.5.0.

See https://github.com/betaflight/betaflight-configurator/issues/3316#issuecomment-1419909205

Maintainers: Please tag this for 4.4.1