### PR TITLE
Add support for easy compilation of define-only custom targets.

### DIFF
--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -61,6 +61,10 @@
 #include "board.h"
 #endif
 
+#ifdef USE_CUSTOM_TARGET
+#include <custom_target.h>
+#endif
+
 #include "target.h"
 #include "target/common_post.h"
 #include "target/common_defaults_post.h"


### PR DESCRIPTION
e.g.

```
make TARGET=STM32H730 CUSTOM_TARGET=SPRO-SPRACINGH7EXTREME
```

Thus, no need to create temporary build scripts anymore.

To test this, ensure you have BF and BF unified targets repo as siblings in your filesystem.

```
$ git clone <betaflight-repo-url> betaflight
$ git clone <betaflight-unified-targets-repo-url> betaflight-unified-targets
$ tree -L 1
.
├── betaflight
└── betaflight-unified-targets
```

then setup BF for development as usual, usually just:

```
cd betaflight
make arm_sdk_install
```

then finally just run:

```
make TARGET=STM32H730 CUSTOM_TARGET=SPRO-SPRACINGH7EXTREME
```

this will result in a log similar to this:

```
$ make TARGET=STM32H750 CUSTOM_TARGET=SPRO-SPRACINGH7EXTREME
make -j ./obj/betaflight_4.5.0_STM32H750.hex
make[1]: Entering directory '/cygdrive/d/Users/Hydra/Documents/dev/projects/betaflight/betaflight'
Extracting #defines from custom target file ./../betaflight-unified-targets/configs/default/SPRO-SPRACINGH7EXTREME.config to ./obj/main/STM32H750/custom_target.h
rm -f ./obj/main/STM32H750/.efhash_*
EF HASH -> ./obj/main/STM32H750/.efhash_d41d8cd98f00b204e9800998ecf8427e
%% startup_stm32h743xx.s
%% (size optimised) ./src/main/drivers/bus_i2c_timing.c
...
%% (size optimised) lib/main/google/olc/olc.c
Linking STM32H750
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:        9848 B        64 KB     15.03%
        DTCM_RAM:       82156 B       128 KB     62.68%
             RAM:       27924 B        64 KB     42.61%
        CODE_RAM:      384653 B     450496 B     85.38%
 CUSTOM_DEFAULTS:           8 B         8 KB      0.10%
       EXST_HASH:          64 B         64 B    100.00%
          D2_RAM:          0 GB       256 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
         QUADSPI:          0 GB         0 GB
   text    data     bss     dec     hex filename
 376769    7956  102196  486921   76e09 ./obj/main/betaflight_STM32H750.elf
Creating BIN (without checksum) ./obj/main/betaflight_STM32H750_UNPATCHED.bin
Creating EXST ./obj/betaflight_4.5.0_STM32H750.bin
448+0 records in
896+0 records out
458752 bytes (459 kB, 448 KiB) copied, 0.0041625 s, 110 MB/s
896+0 records in
896+0 records out
458752 bytes (459 kB, 448 KiB) copied, 0.0048189 s, 95.2 MB/s
Generating MD5 hash of binary
Patching MD5 hash into binary
0006fff0: 39fc fc26 b8b6 2e49 1e48 c229 1860 9963  9..&...I.H.).`.c
Extracting HASH section from unpatched EXST elf ./obj/main/betaflight_STM32H750.elf
./tools/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-objcopy ./obj/main/betaflight_STM32H750.elf ./obj/main/betaflight_STM32H750_EXST.elf.tmp --dump-section .exst_hash=./obj/main/STM32H750/exst_hash_section.bin -j .exst_hash
D:\Users\Hydra\Documents\dev\projects\betaflight\betaflight\tools\gcc-arm-none-eabi-10.3-2021.10\bin\arm-none-eabi-objcopy.exe: ./obj/main/betaflight_STM32H750.elf: warning: empty loadable segment detected at vaddr=0x4beeb320010000, is this intentional?
D:\Users\Hydra\Documents\dev\projects\betaflight\betaflight\tools\gcc-arm-none-eabi-10.3-2021.10\bin\arm-none-eabi-objcopy.exe: ./obj/mainrm ./obj/main/betaflight_STM32H750_EXST.elf.tmp
Patching MD5 hash into HASH section
Patching updated HASH section into ./obj/main/betaflight_STM32H750_EXST.elf
./tools/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-objcopy ./obj/main/betaflight_STM32H750.elf ./obj/main/betaflight_STM32H750_EXST.elf --update-section .exst_hash=./obj/main/STM32H750/exst_hash_section.bin
There are 27 section headers, starting at offset 0xd7bc4:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .isr_vector       PROGBITS        24010000 010000 000298 00   A  0   0  1
  [ 2] .text             PROGBITS        24010298 010298 058ae8 00  AX  0   0  8
  [ 3] .tcm_code         PROGBITS        00000000 070000 002678 00  AX  0   0  8
  [ 4] .ARM              ARM_EXIDX       2406b3f8 07b3f8 000008 00  AL  2   0  4
  [ 5] .pg_registry      PROGBITS        2406b400 07b400 0009bc 00   A  0   0  4
  [ 6] .pg_resetdata     PROGBITS        2406bdbc 07bdbc 000205 00   A  0   0  4
  [ 7] .custom_defaults  PROGBITS        2407dfc0 09dfc0 000008 00  WA  0   0  4
  [ 8] .data             PROGBITS        20000000 080000 001b08 00  WA  0   0  4
  [ 9] .bss              NOBITS          20001b08 081b08 00ca9c 00  WA  0   0  8
  [10] .sram2            PROGBITS        24000000 0a0000 000000 00   W  0   0  1
  [11] .fastram_data     PROGBITS        2000e5a4 08e5a4 000004 00  WA  0   0  4
  [12] .fastram_bss      NOBITS          2000e5a8 08e5a8 005344 00  WA  0   0  4
  [13] .dmaram_data      PROGBITS        24000000 090000 0003c0 00  WA  0   0 32
  [14] .dmaram_bss       NOBITS          240003c0 0903c0 001680 00  WA  0   0 32
  [15] .DMA_RAM          NOBITS          24001a40 091a40 005060 00  WA  0   0 32
  [16] .DMA_RW_D2        PROGBITS        30000000 0a0000 000000 00   W  0   0  1
  [17] .DMA_RW_AXI       NOBITS          24006aa0 006aa0 000274 00  WA  0   0 32
  [18] .persistent_data  PROGBITS        24006d14 0a0000 000000 00   W  0   0  1
  [19] ._user_heap_stack NOBITS          200138ec 0038ec 000800 00  WA  0   0  1
  [20] .ARM.attributes   ARM_ATTRIBUTES  00000000 0a0000 000035 00      0   0  1
  [21] .exst_hash        PROGBITS        2407ffc0 09ffc0 000040 00  WA  0   0  1
  [22] .comment          PROGBITS        00000000 0a0035 000049 01  MS  0   0  1
  [23] .debug_frame      PROGBITS        00000000 0a0080 00075c 00      0   0  4
  [24] .symtab           SYMTAB          00000000 0a07dc 01f410 10     25 5542  4
  [25] .strtab           STRTAB          00000000 0bfbec 017eb4 00      0   0  1
  [26] .shstrtab         STRTAB          00000000 0d7aa0 000122 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  y (purecode), p (processor specific)

Elf file type is EXEC (Executable file)
Entry point 0x24057081
There are 11 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000000 0x20010000 0x20010000 0x00194 0x040ec RW  0x10000
  LOAD           0x006aa0 0x24006aa0 0x24006aa0 0x00000 0x00274 RW  0x10000
  LOAD           0x010000 0x24010000 0x24010000 0x58d80 0x58d80 R E 0x10000
  LOAD           0x070000 0x00000000 0x24068d80 0x02678 0x02678 R E 0x10000
  LOAD           0x07b3f8 0x2406b3f8 0x2406b3f8 0x00bc9 0x00bc9 R   0x10000
  LOAD           0x080000 0x20000000 0x2406bfc1 0x01b08 0x0e5a4 RW  0x10000
  LOAD           0x08e5a4 0x2000e5a4 0x2406dac9 0x00004 0x05348 RW  0x10000
  LOAD           0x090000 0x24000000 0x2406dacd 0x003c0 0x01a40 RW  0x10000
  LOAD           0x001a40 0x24001a40 0x2406de8d 0x00000 0x05060 RW  0x10000
  LOAD           0x09dfc0 0x2407dfc0 0x2407dfc0 0x00008 0x00008 RW  0x10000
  LOAD           0x09ffc0 0x2407ffc0 0x2407ffc0 0x00040 0x00040 RW  0x10000

 Section to Segment mapping:
  Segment Sections...
   00     ._user_heap_stack
   01     .DMA_RW_AXI
   02     .isr_vector .text
   03     .tcm_code
   04     .ARM .pg_registry .pg_resetdata
   05     .data .bss
   06     .fastram_data .fastram_bss
   07     .dmaram_data .dmaram_bss
   08     .DMA_RAM
   09     .custom_defaults
   10     .exst_hash
Creating EXST HEX from patched EXST BIN ./obj/betaflight_4.5.0_STM32H750.bin, VMA Adjust 0x97CE0000
make[1]: Leaving directory '/cygdrive/d/Users/Hydra/Documents/dev/projects/betaflight/betaflight'
```
