### PR TITLE
Resource management via `#define` - Version 1: re-use of resourceTable from CLI.

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -199,6 +199,7 @@ COMMON_SRC = \
             io/vtx_control.c \
             io/vtx_msp.c \
             cms/cms_menu_vtx_msp.c \
+            resource/resource.c \
             resource/resource_table.c \
 
 ifneq ($(SIMULATOR_BUILD),yes)

--- a/make/source.mk
+++ b/make/source.mk
@@ -198,7 +198,8 @@ COMMON_SRC = \
             io/vtx_tramp.c \
             io/vtx_control.c \
             io/vtx_msp.c \
-            cms/cms_menu_vtx_msp.c
+            cms/cms_menu_vtx_msp.c \
+            resource/resource_table.c \
 
 ifneq ($(SIMULATOR_BUILD),yes)
 

--- a/src/link/stm32_h730_common.ld
+++ b/src/link/stm32_h730_common.ld
@@ -98,21 +98,6 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_start_address))
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_end_address))
-    . = ALIGN(4);
-    __custom_defaults_internal_start = .;
-    *(.custom_defaults);
-  } >CUSTOM_DEFAULTS
-
-  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
-
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_h750_common.ld
+++ b/src/link/stm32_h750_common.ld
@@ -82,21 +82,6 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_start_address))
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_end_address))
-    . = ALIGN(4);
-    __custom_defaults_internal_start = .;
-    *(.custom_defaults);
-  } >CUSTOM_DEFAULTS
-
-  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
-
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_ram_h730_exst.ld
+++ b/src/link/stm32_ram_h730_exst.ld
@@ -46,24 +46,6 @@ The initial CODE_RAM is sized at 1MB.
 /* see .exst section below */
 _exst_hash_size = 64;
 
-/*
-
-A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
-Using RAM will suffice until an alternative location for it can be made workable.
-
-It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
-code to read them from external flash instead of a copy of them stored in precious RAM.
-There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
-not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
-in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
-then the custom defaults would also be erased...
-Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
-flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
-
-*/
-
-_custom_defaults_size = 8K;
-
 /* Specify the memory areas */
 MEMORY
 {
@@ -80,9 +62,8 @@ MEMORY
 
     OCTOSPI2 (rx)     : ORIGIN = 0x70000000, LENGTH = 256M
     OCTOSPI1 (rx)     : ORIGIN = 0x90000000, LENGTH = 256M 
-    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _custom_defaults_size
-    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(CUSTOM_DEFAULTS) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
+    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
 }
 
 REGION_ALIAS("STACKRAM", DTCM_RAM)

--- a/src/link/stm32_ram_h750_exst.ld
+++ b/src/link/stm32_ram_h750_exst.ld
@@ -54,34 +54,14 @@ possible.
 /* see .exst section below */
 _exst_hash_size = 64;
 
-/*
-
-A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
-Using RAM will suffice until an alternative location for it can be made workable.
-
-It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
-code to read them from external flash instead of a copy of them stored in precious RAM.
-There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
-not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
-in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
-then the custom defaults would also be erased...
-Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
-flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
-
-*/
-
-_custom_defaults_size = 8K;
-
 /* Specify the memory areas */
 MEMORY
 {
     ITCM_RAM (rwx)    : ORIGIN = 0x00000000, LENGTH = 64K
     DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
     RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 64K
-    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(CODE_RAM) + LENGTH(CODE_RAM), LENGTH = _custom_defaults_size
-    
-    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM) + LENGTH(CUSTOM_DEFAULTS), LENGTH = _exst_hash_size
+    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
 
     D2_RAM (rwx)      : ORIGIN = 0x30000000, LENGTH = 256K /* SRAM1 + SRAM2 */
 

--- a/src/main/pg/pg.c
+++ b/src/main/pg/pg.c
@@ -27,6 +27,7 @@
 #include "common/crc.h"
 #include "common/maths.h"
 
+#include "resource/resource.h"
 #include "pg.h"
 
 const pgRegistry_t* pgFind(pgn_t pgn)
@@ -101,4 +102,6 @@ void pgResetAll(void)
     PG_FOREACH(reg) {
         pgReset(reg);
     }
+
+    resource_applyDefaults();
 }

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -61,6 +61,10 @@
 #include "board.h"
 #endif
 
+#ifdef USE_CUSTOM_TARGET
+#include <custom_target.h>
+#endif
+
 #include "target.h"
 #include "target/common_post.h"
 #include "target/common_defaults_post.h"

--- a/src/main/resource/resource.c
+++ b/src/main/resource/resource.c
@@ -1,0 +1,275 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+
+#include "platform.h"
+
+#include "resource/resource_table.h"
+
+
+#if defined(USE_RESOURCE_MGMT)
+
+bool resource_strToPin(char *ptr, ioTag_t *tag)
+{
+    if (strcasecmp(ptr, "NONE") == 0) {
+        *tag = IO_TAG_NONE;
+
+        return true;
+    } else {
+        const unsigned port = (*ptr >= 'a') ? *ptr - 'a' : *ptr - 'A';
+        if (port < 8) {
+            ptr++;
+
+            char *end;
+            const long pin = strtol(ptr, &end, 10);
+            if (end != ptr && pin >= 0 && pin < 16) {
+                *tag = DEFIO_TAG_MAKE(port, pin);
+
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+ioTag_t *resource_getIoTag(const resourceValue_t value, uint8_t index)
+{
+    const pgRegistry_t* rec = pgFind(value.pgn);
+    return CONST_CAST(ioTag_t *, rec->address + value.stride * index + value.offset);
+}
+
+void resource_assign(uint8_t resourceIndex, uint8_t index, ioTag_t newTag)
+{
+    if (!newTag) {
+        return;
+    }
+
+    for (int r = 0; r < (int)resource_resourceTableLength(); r++) {
+        for (int i = 0; i < RESOURCE_VALUE_MAX_INDEX(resourceTable[r].maxIndex); i++) {
+            ioTag_t *tag = resource_getIoTag(resourceTable[r], i);
+            if (*tag == newTag) {
+                // resource already assigned
+
+                if (r == resourceIndex) {
+                    if (i == index) {
+                        continue;
+                    }
+                    // cleared
+                    *tag = IO_TAG_NONE;
+                }
+            }
+        }
+    }
+}
+
+
+#define MAX_RESOURCE_COMMAND_LENGTH 50
+
+// Successful if result is CLEARED, or ASSIGNED
+// Failure otherwise
+resourceApplyResult_t resource_apply(const char *args)
+{
+    char cmdline[MAX_RESOURCE_COMMAND_LENGTH + 1] = {0};
+    strncpy(cmdline, args, MAX_RESOURCE_COMMAND_LENGTH);
+
+    char *pch = NULL;
+    char *saveptr;
+
+    pch = strtok_r(cmdline, " ", &saveptr);
+
+    unsigned resourceIndex = 0;
+    for (; ; resourceIndex++) {
+        if (resourceIndex >= resource_resourceTableLength()) {
+            return INVALID_RESOURSE_NAME;
+        }
+
+        const char *resourceName = ownerNames[resourceTable[resourceIndex].owner];
+        if (strncasecmp(pch, resourceName, strlen(resourceName)) == 0) {
+            break;
+        }
+    }
+
+    pch = strtok_r(NULL, " ", &saveptr);
+    int index = atoi(pch);
+
+    if (resourceTable[resourceIndex].maxIndex > 0 || index > 0) {
+        if (index <= 0 || index > RESOURCE_VALUE_MAX_INDEX(resourceTable[resourceIndex].maxIndex)) {
+            return RESOURCE_INDEX_OUT_OF_RANGE;
+        }
+        index -= 1;
+
+        pch = strtok_r(NULL, " ", &saveptr);
+    }
+
+    ioTag_t *tag = resource_getIoTag(resourceTable[resourceIndex], index);
+
+    if (strlen(pch) > 0) {
+        if (resource_strToPin(pch, tag)) {
+            if (*tag == IO_TAG_NONE) {
+                return CLEARED;
+            } else {
+                ioRec_t *rec = IO_Rec(IOGetByTag(*tag));
+                if (rec) {
+                    resource_assign(resourceIndex, index, *tag);
+                } else {
+                    return PARSE_ERROR;
+                }
+                return ASSIGNED;
+            }
+        }
+    }
+
+    return PARSE_ERROR;
+}
+
+// Call once, immediately after pgReset
+void resource_applyDefaults(void)
+{
+#ifdef RESOURCE_0
+    resource_apply(RESOURCE_0);
+#endif
+#ifdef RESOURCE_1
+    resource_apply(RESOURCE_1);
+#endif
+#ifdef RESOURCE_2
+    resource_apply(RESOURCE_2);
+#endif
+#ifdef RESOURCE_3
+    resource_apply(RESOURCE_3);
+#endif
+#ifdef RESOURCE_4
+    resource_apply(RESOURCE_4);
+#endif
+#ifdef RESOURCE_5
+    resource_apply(RESOURCE_5);
+#endif
+#ifdef RESOURCE_6
+    resource_apply(RESOURCE_6);
+#endif
+#ifdef RESOURCE_7
+    resource_apply(RESOURCE_7);
+#endif
+#ifdef RESOURCE_8
+    resource_apply(RESOURCE_8);
+#endif
+#ifdef RESOURCE_9
+    resource_apply(RESOURCE_9);
+#endif
+#ifdef RESOURCE_10
+    resource_apply(RESOURCE_10);
+#endif
+#ifdef RESOURCE_11
+    resource_apply(RESOURCE_11);
+#endif
+#ifdef RESOURCE_12
+    resource_apply(RESOURCE_12);
+#endif
+#ifdef RESOURCE_13
+    resource_apply(RESOURCE_13);
+#endif
+#ifdef RESOURCE_14
+    resource_apply(RESOURCE_14);
+#endif
+#ifdef RESOURCE_15
+    resource_apply(RESOURCE_15);
+#endif
+#ifdef RESOURCE_16
+    resource_apply(RESOURCE_16);
+#endif
+#ifdef RESOURCE_17
+    resource_apply(RESOURCE_17);
+#endif
+#ifdef RESOURCE_18
+    resource_apply(RESOURCE_18);
+#endif
+#ifdef RESOURCE_19
+    resource_apply(RESOURCE_19);
+#endif
+#ifdef RESOURCE_20
+    resource_apply(RESOURCE_20);
+#endif
+#ifdef RESOURCE_21
+    resource_apply(RESOURCE_21);
+#endif
+#ifdef RESOURCE_22
+    resource_apply(RESOURCE_22);
+#endif
+#ifdef RESOURCE_23
+    resource_apply(RESOURCE_23);
+#endif
+#ifdef RESOURCE_24
+    resource_apply(RESOURCE_24);
+#endif
+#ifdef RESOURCE_25
+    resource_apply(RESOURCE_25);
+#endif
+#ifdef RESOURCE_26
+    resource_apply(RESOURCE_26);
+#endif
+#ifdef RESOURCE_27
+    resource_apply(RESOURCE_27);
+#endif
+#ifdef RESOURCE_28
+    resource_apply(RESOURCE_28);
+#endif
+#ifdef RESOURCE_29
+    resource_apply(RESOURCE_29);
+#endif
+#ifdef RESOURCE_30
+    resource_apply(RESOURCE_30);
+#endif
+#ifdef RESOURCE_31
+    resource_apply(RESOURCE_31);
+#endif
+#ifdef RESOURCE_32
+    resource_apply(RESOURCE_32);
+#endif
+#ifdef RESOURCE_33
+    resource_apply(RESOURCE_33);
+#endif
+#ifdef RESOURCE_34
+    resource_apply(RESOURCE_34);
+#endif
+#ifdef RESOURCE_35
+    resource_apply(RESOURCE_35);
+#endif
+#ifdef RESOURCE_36
+    resource_apply(RESOURCE_36);
+#endif
+#ifdef RESOURCE_37
+    resource_apply(RESOURCE_37);
+#endif
+#ifdef RESOURCE_38
+    resource_apply(RESOURCE_38);
+#endif
+#ifdef RESOURCE_39
+    resource_apply(RESOURCE_39);
+#endif
+}
+
+#endif // USE_RESOURCE_MGMT

--- a/src/main/resource/resource.h
+++ b/src/main/resource/resource.h
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "drivers/io_types.h"
+
+#include "pg/pg.h"
+
+#if defined(USE_RESOURCE_MGMT)
+
+typedef struct {
+    const uint8_t owner;
+    pgn_t pgn;
+    uint8_t stride;
+    uint8_t offset;
+    const uint8_t maxIndex;
+} resourceValue_t;
+
+typedef enum {
+    CLEARED = 0,
+    ASSIGNED = 1,
+
+    PARSE_ERROR = 10,
+
+    INVALID_RESOURSE_NAME = 11,
+    RESOURCE_INDEX_OUT_OF_RANGE = 12,
+} resourceApplyResult_t;
+
+
+bool resource_strToPin(char *ptr, ioTag_t *tag);
+ioTag_t *resource_getIoTag(const resourceValue_t value, uint8_t index);
+void resource_assign(uint8_t resourceIndex, uint8_t index, ioTag_t newTag);
+resourceApplyResult_t resource_apply(const char *args);
+
+void resource_applyDefaults(void);
+#endif // USE_RESOURCE_MGMT

--- a/src/main/resource/resource_table.c
+++ b/src/main/resource/resource_table.c
@@ -1,0 +1,233 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+
+#include "platform.h"
+
+#include "resource/resource_table.h"
+
+
+#if defined(USE_RESOURCE_MGMT)
+
+// Handy macros for keeping the table tidy.
+// DEFS : Single entry
+// DEFA : Array of uint8_t (stride = 1)
+// DEFW : Wider stride case; array of structs.
+
+#define DEFS(owner, pgn, type, member) \
+    { owner, pgn, 0, offsetof(type, member), 0 }
+
+#define DEFA(owner, pgn, type, member, max) \
+    { owner, pgn, sizeof(ioTag_t), offsetof(type, member), max }
+
+#define DEFW(owner, pgn, type, member, max) \
+    { owner, pgn, sizeof(type), offsetof(type, member), max }
+
+const resourceValue_t resourceTable_impl[] = {
+#if defined(USE_BEEPER)
+    DEFS( OWNER_BEEPER,        PG_BEEPER_DEV_CONFIG, beeperDevConfig_t, ioTag) ,
+#endif
+    DEFA( OWNER_MOTOR,         PG_MOTOR_CONFIG, motorConfig_t, dev.ioTags[0], MAX_SUPPORTED_MOTORS ),
+#if defined(USE_SERVOS)
+    DEFA( OWNER_SERVO,         PG_SERVO_CONFIG, servoConfig_t, dev.ioTags[0], MAX_SUPPORTED_SERVOS ),
+#endif
+#if defined(USE_RX_PPM)
+    DEFS( OWNER_PPMINPUT,      PG_PPM_CONFIG, ppmConfig_t, ioTag ),
+#endif
+#if defined(USE_RX_PWM)
+    DEFA( OWNER_PWMINPUT,      PG_PWM_CONFIG, pwmConfig_t, ioTags[0], PWM_INPUT_PORT_COUNT ),
+#endif
+#if defined(USE_RANGEFINDER_HCSR04)
+    DEFS( OWNER_SONAR_TRIGGER, PG_SONAR_CONFIG, sonarConfig_t, triggerTag ),
+    DEFS( OWNER_SONAR_ECHO,    PG_SONAR_CONFIG, sonarConfig_t, echoTag ),
+#endif
+#if defined(USE_LED_STRIP)
+    DEFS( OWNER_LED_STRIP,     PG_LED_STRIP_CONFIG, ledStripConfig_t, ioTag ),
+#endif
+#ifdef USE_UART
+    DEFA( OWNER_SERIAL_TX,     PG_SERIAL_PIN_CONFIG, serialPinConfig_t, ioTagTx[0], SERIAL_PORT_MAX_INDEX ),
+    DEFA( OWNER_SERIAL_RX,     PG_SERIAL_PIN_CONFIG, serialPinConfig_t, ioTagRx[0], SERIAL_PORT_MAX_INDEX ),
+#endif
+#ifdef USE_INVERTER
+    DEFA( OWNER_INVERTER,      PG_SERIAL_PIN_CONFIG, serialPinConfig_t, ioTagInverter[0], SERIAL_PORT_MAX_INDEX ),
+#endif
+#ifdef USE_I2C
+    DEFW( OWNER_I2C_SCL,       PG_I2C_CONFIG, i2cConfig_t, ioTagScl, I2CDEV_COUNT ),
+    DEFW( OWNER_I2C_SDA,       PG_I2C_CONFIG, i2cConfig_t, ioTagSda, I2CDEV_COUNT ),
+#endif
+    DEFA( OWNER_LED,           PG_STATUS_LED_CONFIG, statusLedConfig_t, ioTags[0], STATUS_LED_NUMBER ),
+#ifdef USE_SPEKTRUM_BIND
+    DEFS( OWNER_RX_BIND,       PG_RX_CONFIG, rxConfig_t, spektrum_bind_pin_override_ioTag ),
+    DEFS( OWNER_RX_BIND_PLUG,  PG_RX_CONFIG, rxConfig_t, spektrum_bind_plug_ioTag ),
+#endif
+#ifdef USE_TRANSPONDER
+    DEFS( OWNER_TRANSPONDER,   PG_TRANSPONDER_CONFIG, transponderConfig_t, ioTag ),
+#endif
+#ifdef USE_SPI
+    DEFW( OWNER_SPI_SCK,       PG_SPI_PIN_CONFIG, spiPinConfig_t, ioTagSck, SPIDEV_COUNT ),
+    DEFW( OWNER_SPI_MISO,      PG_SPI_PIN_CONFIG, spiPinConfig_t, ioTagMiso, SPIDEV_COUNT ),
+    DEFW( OWNER_SPI_MOSI,      PG_SPI_PIN_CONFIG, spiPinConfig_t, ioTagMosi, SPIDEV_COUNT ),
+#endif
+#ifdef USE_ESCSERIAL
+    DEFS( OWNER_ESCSERIAL,     PG_ESCSERIAL_CONFIG, escSerialConfig_t, ioTag ),
+#endif
+#ifdef USE_CAMERA_CONTROL
+    DEFS( OWNER_CAMERA_CONTROL, PG_CAMERA_CONTROL_CONFIG, cameraControlConfig_t, ioTag ),
+#endif
+#ifdef USE_ADC
+    DEFS( OWNER_ADC_BATT,      PG_ADC_CONFIG, adcConfig_t, vbat.ioTag ),
+    DEFS( OWNER_ADC_RSSI,      PG_ADC_CONFIG, adcConfig_t, rssi.ioTag ),
+    DEFS( OWNER_ADC_CURR,      PG_ADC_CONFIG, adcConfig_t, current.ioTag ),
+    DEFS( OWNER_ADC_EXT,       PG_ADC_CONFIG, adcConfig_t, external1.ioTag ),
+#endif
+#ifdef USE_BARO
+    DEFS( OWNER_BARO_CS,       PG_BAROMETER_CONFIG, barometerConfig_t, baro_spi_csn ),
+    DEFS( OWNER_BARO_EOC,      PG_BAROMETER_CONFIG, barometerConfig_t, baro_eoc_tag ),
+    DEFS( OWNER_BARO_XCLR,     PG_BAROMETER_CONFIG, barometerConfig_t, baro_xclr_tag ),
+#endif
+#ifdef USE_MAG
+    DEFS( OWNER_COMPASS_CS,    PG_COMPASS_CONFIG, compassConfig_t, mag_spi_csn ),
+#ifdef USE_MAG_DATA_READY_SIGNAL
+    DEFS( OWNER_COMPASS_EXTI,  PG_COMPASS_CONFIG, compassConfig_t, interruptTag ),
+#endif
+#endif
+#ifdef USE_SDCARD_SPI
+    DEFS( OWNER_SDCARD_CS,     PG_SDCARD_CONFIG, sdcardConfig_t, chipSelectTag ),
+#endif
+#ifdef USE_SDCARD
+    DEFS( OWNER_SDCARD_DETECT, PG_SDCARD_CONFIG, sdcardConfig_t, cardDetectTag ),
+#endif
+#if defined(STM32H7) && defined(USE_SDCARD_SDIO)
+    DEFS( OWNER_SDIO_CK,       PG_SDIO_PIN_CONFIG, sdioPinConfig_t, CKPin ),
+    DEFS( OWNER_SDIO_CMD,      PG_SDIO_PIN_CONFIG, sdioPinConfig_t, CMDPin ),
+    DEFS( OWNER_SDIO_D0,       PG_SDIO_PIN_CONFIG, sdioPinConfig_t, D0Pin ),
+    DEFS( OWNER_SDIO_D1,       PG_SDIO_PIN_CONFIG, sdioPinConfig_t, D1Pin ),
+    DEFS( OWNER_SDIO_D2,       PG_SDIO_PIN_CONFIG, sdioPinConfig_t, D2Pin ),
+    DEFS( OWNER_SDIO_D3,       PG_SDIO_PIN_CONFIG, sdioPinConfig_t, D3Pin ),
+#endif
+#ifdef USE_PINIO
+    DEFA( OWNER_PINIO,         PG_PINIO_CONFIG, pinioConfig_t, ioTag, PINIO_COUNT ),
+#endif
+#if defined(USE_USB_MSC)
+    DEFS( OWNER_USB_MSC_PIN,   PG_USB_CONFIG, usbDev_t, mscButtonPin ),
+#endif
+#ifdef USE_FLASH_CHIP
+    DEFS( OWNER_FLASH_CS,      PG_FLASH_CONFIG, flashConfig_t, csTag ),
+#endif
+#ifdef USE_MAX7456
+    DEFS( OWNER_OSD_CS,        PG_MAX7456_CONFIG, max7456Config_t, csTag ),
+#endif
+#ifdef USE_RX_SPI
+    DEFS( OWNER_RX_SPI_CS,     PG_RX_SPI_CONFIG, rxSpiConfig_t, csnTag ),
+    DEFS( OWNER_RX_SPI_EXTI,   PG_RX_SPI_CONFIG, rxSpiConfig_t, extiIoTag ),
+    DEFS( OWNER_RX_SPI_BIND,   PG_RX_SPI_CONFIG, rxSpiConfig_t, bindIoTag ),
+    DEFS( OWNER_RX_SPI_LED,    PG_RX_SPI_CONFIG, rxSpiConfig_t, ledIoTag ),
+#if defined(USE_RX_CC2500) && defined(USE_RX_CC2500_SPI_PA_LNA)
+    DEFS( OWNER_RX_SPI_CC2500_TX_EN,   PG_RX_CC2500_SPI_CONFIG, rxCc2500SpiConfig_t, txEnIoTag ),
+    DEFS( OWNER_RX_SPI_CC2500_LNA_EN,  PG_RX_CC2500_SPI_CONFIG, rxCc2500SpiConfig_t, lnaEnIoTag ),
+#if defined(USE_RX_CC2500_SPI_DIVERSITY)
+    DEFS( OWNER_RX_SPI_CC2500_ANT_SEL, PG_RX_CC2500_SPI_CONFIG, rxCc2500SpiConfig_t, antSelIoTag ),
+#endif
+#endif
+#if defined(USE_RX_EXPRESSLRS)
+    DEFS( OWNER_RX_SPI_EXPRESSLRS_RESET, PG_RX_EXPRESSLRS_SPI_CONFIG, rxExpressLrsSpiConfig_t, resetIoTag ),
+    DEFS( OWNER_RX_SPI_EXPRESSLRS_BUSY, PG_RX_EXPRESSLRS_SPI_CONFIG, rxExpressLrsSpiConfig_t, busyIoTag ),
+#endif
+#endif
+    DEFW( OWNER_GYRO_EXTI,     PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, extiTag, MAX_GYRODEV_COUNT ),
+    DEFW( OWNER_GYRO_CS,       PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, csnTag, MAX_GYRODEV_COUNT ),
+#ifdef USE_USB_DETECT
+    DEFS( OWNER_USB_DETECT,    PG_USB_CONFIG, usbDev_t, detectPin ),
+#endif
+#ifdef USE_VTX_RTC6705
+    DEFS( OWNER_VTX_POWER,     PG_VTX_IO_CONFIG, vtxIOConfig_t, powerTag ),
+    DEFS( OWNER_VTX_CS,        PG_VTX_IO_CONFIG, vtxIOConfig_t, csTag ),
+    DEFS( OWNER_VTX_DATA,      PG_VTX_IO_CONFIG, vtxIOConfig_t, dataTag ),
+    DEFS( OWNER_VTX_CLK,       PG_VTX_IO_CONFIG, vtxIOConfig_t, clockTag ),
+#endif
+#ifdef USE_PIN_PULL_UP_DOWN
+    DEFA( OWNER_PULLUP,        PG_PULLUP_CONFIG,   pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),
+    DEFA( OWNER_PULLDOWN,      PG_PULLDOWN_CONFIG, pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),
+#endif
+};
+
+const resourceValue_t *resourceTable = &resourceTable_impl[0];
+
+#undef DEFS
+#undef DEFA
+#undef DEFW
+
+uint8_t resource_resourceTableLength(void)
+{
+    return ARRAYLEN(resourceTable_impl);
+}
+
+#endif // USE_RESOURCE_MGMT
+
+#ifdef USE_DMA_SPEC
+
+// Handy macros for keeping the table tidy.
+// DEFS : Single entry
+// DEFA : Array of uint8_t (stride = 1)
+// DEFW : Wider stride case; array of structs.
+
+#define DEFS(device, peripheral, pgn, type, member) \
+    { device, peripheral, pgn, 0,               offsetof(type, member), 0, MASK_IGNORED }
+
+#define DEFA(device, peripheral, pgn, type, member, max, mask) \
+    { device, peripheral, pgn, sizeof(uint8_t), offsetof(type, member), max, mask }
+
+#define DEFW(device, peripheral, pgn, type, member, max, mask) \
+    { device, peripheral, pgn, sizeof(type), offsetof(type, member), max, mask }
+
+const dmaoptEntry_t dmaoptEntryTable_impl[] = {
+    DEFW("SPI_MOSI", DMA_PERIPH_SPI_MOSI, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     txDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    DEFW("SPI_MISO", DMA_PERIPH_SPI_MISO, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     rxDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    // SPI_TX/SPI_RX for backwards compatibility with unified configs defined for 4.2.x
+    DEFW("SPI_TX",   DMA_PERIPH_SPI_MOSI, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     txDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    DEFW("SPI_RX",   DMA_PERIPH_SPI_MISO, PG_SPI_PIN_CONFIG,     spiPinConfig_t,     rxDmaopt, SPIDEV_COUNT,                    MASK_IGNORED),
+    DEFA("ADC",      DMA_PERIPH_ADC,      PG_ADC_CONFIG,         adcConfig_t,        dmaopt,   ADCDEV_COUNT,                    MASK_IGNORED),
+    DEFS("SDIO",     DMA_PERIPH_SDIO,     PG_SDIO_CONFIG,        sdioConfig_t,       dmaopt),
+    DEFW("UART_TX",  DMA_PERIPH_UART_TX,  PG_SERIAL_UART_CONFIG, serialUartConfig_t, txDmaopt, UARTDEV_CONFIG_MAX,              MASK_IGNORED),
+    DEFW("UART_RX",  DMA_PERIPH_UART_RX,  PG_SERIAL_UART_CONFIG, serialUartConfig_t, rxDmaopt, UARTDEV_CONFIG_MAX,              MASK_IGNORED),
+#if defined(STM32H7) || defined(STM32G4)
+    DEFW("TIMUP",    DMA_PERIPH_TIMUP,    PG_TIMER_UP_CONFIG,    timerUpConfig_t,    dmaopt,   HARDWARE_TIMER_DEFINITION_COUNT, TIMUP_TIMERS),
+#endif
+};
+
+#undef DEFS
+#undef DEFA
+#undef DEFW
+
+const dmaoptEntry_t *dmaoptEntryTable = &dmaoptEntryTable_impl[0];
+
+uint8_t resource_dmaoptEntryTableLength(void)
+{
+    return ARRAYLEN(dmaoptEntryTable_impl);
+}
+
+#endif // USE_DMA_SPEC

--- a/src/main/resource/resource_table.h
+++ b/src/main/resource/resource_table.h
@@ -116,15 +116,9 @@
 #include "sensors/gyro_init.h"
 #include "sensors/sensors.h"
 
-#if defined(USE_RESOURCE_MGMT)
+#include "resource/resource.h"
 
-typedef struct {
-    const uint8_t owner;
-    pgn_t pgn;
-    uint8_t stride;
-    uint8_t offset;
-    const uint8_t maxIndex;
-} resourceValue_t;
+#if defined(USE_RESOURCE_MGMT)
 
 #define RESOURCE_VALUE_MAX_INDEX(x) ((x) == 0 ? 1 : (x))
 

--- a/src/main/resource/resource_table.h
+++ b/src/main/resource/resource_table.h
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pg/pg.h"
+
+#include "cms/cms.h"
+
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/adc.h"
+#include "drivers/buf_writer.h"
+#include "drivers/bus_i2c.h"
+#include "drivers/bus_spi.h"
+#include "drivers/dma.h"
+#include "drivers/dma_reqmap.h"
+#include "drivers/dshot.h"
+#include "drivers/dshot_command.h"
+#include "drivers/dshot_dpwm.h"
+#include "drivers/pwm_output_dshot_shared.h"
+#include "drivers/camera_control.h"
+#include "drivers/compass/compass.h"
+#include "drivers/display.h"
+#include "drivers/dma.h"
+#include "drivers/flash.h"
+#include "drivers/inverter.h"
+#include "drivers/io.h"
+#include "drivers/io_impl.h"
+#include "drivers/light_led.h"
+#include "drivers/motor.h"
+#include "drivers/rangefinder/rangefinder_hcsr04.h"
+#include "drivers/resource.h"
+#include "drivers/sdcard.h"
+#include "drivers/sensor.h"
+#include "drivers/serial.h"
+#include "drivers/serial_escserial.h"
+#include "drivers/sound_beeper.h"
+#include "drivers/stack_check.h"
+#include "drivers/system.h"
+#include "drivers/time.h"
+#include "drivers/timer.h"
+#include "drivers/transponder_ir.h"
+#include "drivers/usb_msc.h"
+#include "drivers/vtx_common.h"
+#include "drivers/vtx_table.h"
+
+#include "flight/failsafe.h"
+#include "flight/imu.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/position.h"
+#include "flight/servos.h"
+
+#include "io/asyncfatfs/asyncfatfs.h"
+#include "io/beeper.h"
+#include "io/flashfs.h"
+#include "io/gimbal.h"
+#include "io/gps.h"
+#include "io/ledstrip.h"
+#include "io/serial.h"
+#include "io/transponder_ir.h"
+#include "io/usb_msc.h"
+#include "io/vtx_control.h"
+#include "io/vtx.h"
+
+#include "pg/adc.h"
+#include "pg/beeper.h"
+#include "pg/beeper_dev.h"
+#include "pg/board.h"
+#include "pg/bus_i2c.h"
+#include "pg/bus_spi.h"
+#include "pg/gyrodev.h"
+#include "pg/max7456.h"
+#include "pg/mco.h"
+#include "pg/motor.h"
+#include "pg/pinio.h"
+#include "pg/pin_pull_up_down.h"
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+#include "pg/rx.h"
+#include "pg/rx_pwm.h"
+#include "pg/rx_spi_cc2500.h"
+#include "pg/rx_spi_expresslrs.h"
+#include "pg/serial_uart.h"
+#include "pg/sdio.h"
+#include "pg/timerio.h"
+#include "pg/timerup.h"
+#include "pg/usb.h"
+#include "pg/vtx_table.h"
+
+#include "rx/rx_bind.h"
+#include "rx/rx_spi.h"
+
+#include "sensors/acceleration.h"
+#include "sensors/adcinternal.h"
+#include "sensors/barometer.h"
+#include "sensors/battery.h"
+#include "sensors/boardalignment.h"
+#include "sensors/compass.h"
+#include "sensors/gyro.h"
+#include "sensors/gyro_init.h"
+#include "sensors/sensors.h"
+
+#if defined(USE_RESOURCE_MGMT)
+
+typedef struct {
+    const uint8_t owner;
+    pgn_t pgn;
+    uint8_t stride;
+    uint8_t offset;
+    const uint8_t maxIndex;
+} resourceValue_t;
+
+#define RESOURCE_VALUE_MAX_INDEX(x) ((x) == 0 ? 1 : (x))
+
+extern const resourceValue_t *resourceTable;
+
+uint8_t resource_resourceTableLength(void);
+
+#endif // USE_RESOURCE_MGMT
+
+
+#ifdef USE_DMA_SPEC
+
+#define MASK_IGNORED (0)
+
+typedef struct dmaoptEntry_s {
+    char *device;
+    dmaPeripheral_e peripheral;
+    pgn_t pgn;
+    uint8_t stride;
+    uint8_t offset;
+    uint8_t maxIndex;
+    uint32_t presenceMask;
+} dmaoptEntry_t;
+
+extern const dmaoptEntry_t *dmaoptEntryTable;
+
+uint8_t resource_dmaoptEntryTableLength(void);
+
+#endif // USE_DMA_SPEC

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -108,8 +108,4 @@
 #define CONFIG_IN_RAM
 #endif
 
-#ifdef USE_EXST
-#define USE_CUSTOM_DEFAULTS
-#endif
-
 #define USE_EXTI

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -115,8 +115,4 @@
 #define CONFIG_IN_RAM
 #endif
 
-#ifdef USE_EXST
-#define USE_CUSTOM_DEFAULTS
-#endif
-
 #define USE_EXTI


### PR DESCRIPTION
## Motivation

Due to plan to migrate to 'define-only' targets in the unified targets repository there needs to be a compile-time way of specifying all target resources in the form of `#define`s.

It does this by re-locating and re-using the cli's resource command table and provides an API to allow assignment of resources during parameter group (PG) initialization.

That cannot currently be configured by #defines that this PR addresses:

## Motor pins

Motor pins used to be in a target's config.c file, but currently require use of the `resource MOTOR <x> <pin>`  command.

This PR allows specification of resources in text form, the same form used by the CLI command, for example:

```
#define RESOURCE_0 "MOTOR 1 B00"
...
#define RESOURCE_7 "MOTOR 8 A03"
```

## Other resources

The approach in this PR works for ALL OTHER RESOURCES that can currently be configured by the CLI resource command, such as LED_STRIP, PPM, PWM, BEEPER, ADC, I2C, SPI, LED, SDIO, PINIO, PX_SPI, GYRO_CS, GYRO_EXTI, SERIAL_RX/TX.

## What's missing

* [ ] Support for `timer` <- same approach as for `resource` re-use.
* [ ] Support for `dmaopt` <- same approach as for `resource` re-use.


## Commits from other PRs

Maintainers: This PR contains commits from other PRs as follows which should be ingnored, they are included here so you can get the big-picture.

* [ ] #12333 - Revert "Fix missing CUSTOM_DEFAULTS for H730/H750 targets. (#12261)"
* [ ] #12335 - Add support for easy compilation of define-only custom targets.

## Status

Work-in-progress.