### PR TITLE
Resource management via #define - Version 2: PG specific initialisation code.

### DIFF
--- a/src/link/stm32_h730_common.ld
+++ b/src/link/stm32_h730_common.ld
@@ -98,21 +98,6 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_start_address))
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_end_address))
-    . = ALIGN(4);
-    __custom_defaults_internal_start = .;
-    *(.custom_defaults);
-  } >CUSTOM_DEFAULTS
-
-  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
-
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_h750_common.ld
+++ b/src/link/stm32_h750_common.ld
@@ -82,21 +82,6 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >MAIN
 
-  /* Storage for the address for the configuration section so we can grab it out of the hex file */
-  .custom_defaults :
-  {
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_start_address))
-    . = ALIGN(4);
-    KEEP (*(.custom_defaults_end_address))
-    . = ALIGN(4);
-    __custom_defaults_internal_start = .;
-    *(.custom_defaults);
-  } >CUSTOM_DEFAULTS
-
-  PROVIDE_HIDDEN (__custom_defaults_start = __custom_defaults_internal_start);
-  PROVIDE_HIDDEN (__custom_defaults_end = ORIGIN(CUSTOM_DEFAULTS) + LENGTH(CUSTOM_DEFAULTS));
-
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 

--- a/src/link/stm32_ram_h730_exst.ld
+++ b/src/link/stm32_ram_h730_exst.ld
@@ -46,24 +46,6 @@ The initial CODE_RAM is sized at 1MB.
 /* see .exst section below */
 _exst_hash_size = 64;
 
-/*
-
-A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
-Using RAM will suffice until an alternative location for it can be made workable.
-
-It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
-code to read them from external flash instead of a copy of them stored in precious RAM.
-There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
-not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
-in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
-then the custom defaults would also be erased...
-Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
-flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
-
-*/
-
-_custom_defaults_size = 8K;
-
 /* Specify the memory areas */
 MEMORY
 {
@@ -80,9 +62,8 @@ MEMORY
 
     OCTOSPI2 (rx)     : ORIGIN = 0x70000000, LENGTH = 256M
     OCTOSPI1 (rx)     : ORIGIN = 0x90000000, LENGTH = 256M 
-    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _custom_defaults_size
-    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(CUSTOM_DEFAULTS) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
+    OCTOSPI1_CODE (rx): ORIGIN = ORIGIN(OCTOSPI1) + 1M, LENGTH = 1M - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    EXST_HASH (rx)    : ORIGIN = ORIGIN(OCTOSPI1_CODE) + LENGTH(OCTOSPI1_CODE), LENGTH = _exst_hash_size
 }
 
 REGION_ALIAS("STACKRAM", DTCM_RAM)

--- a/src/link/stm32_ram_h750_exst.ld
+++ b/src/link/stm32_ram_h750_exst.ld
@@ -54,34 +54,14 @@ possible.
 /* see .exst section below */
 _exst_hash_size = 64;
 
-/*
-
-A section for custom defaults needs to exist for unified targets, however it is a hideous waste of precious RAM.
-Using RAM will suffice until an alternative location for it can be made workable.
-
-It would be much better to store the custom defaults on some spare flash pages on the external flash and have some
-code to read them from external flash instead of a copy of them stored in precious RAM.
-There are usually spare flash pages after the config page on the external flash, however current EXST bootloaders are
-not 'custom defaults' aware. they only know about firmware partitions and config partitions.  Using the spare sectors
-in the config partition for custom defaults would work, but if users use the bootloader menus to erase their config
-then the custom defaults would also be erased...
-Also, it would need a change the packaging a distribution method of BF as there would be 2 non-contiguous files to
-flash if they were separated, i.e. load firmware at flash address 'x' and load custom defaults at flash address 'y'.
-
-*/
-
-_custom_defaults_size = 8K;
-
 /* Specify the memory areas */
 MEMORY
 {
     ITCM_RAM (rwx)    : ORIGIN = 0x00000000, LENGTH = 64K
     DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
     RAM (rwx)         : ORIGIN = 0x24000000, LENGTH = 64K
-    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _custom_defaults_size - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
-    CUSTOM_DEFAULTS (r) : ORIGIN = ORIGIN(CODE_RAM) + LENGTH(CODE_RAM), LENGTH = _custom_defaults_size
-    
-    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM) + LENGTH(CUSTOM_DEFAULTS), LENGTH = _exst_hash_size
+    CODE_RAM (rx)     : ORIGIN = 0x24010000, LENGTH = 448K - _exst_hash_size /* hard coded start address, as required by SPRACINGH7 boot loader, don't change! */
+    EXST_HASH (rx)    : ORIGIN = 0x24010000 + LENGTH(CODE_RAM), LENGTH = _exst_hash_size
 
     D2_RAM (rwx)      : ORIGIN = 0x30000000, LENGTH = 256K /* SRAM1 + SRAM2 */
 

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -69,6 +69,55 @@ void pgResetFn_servoConfig(servoConfig_t *servoConfig)
     for (unsigned servoIndex = 0; servoIndex < MAX_SUPPORTED_SERVOS; servoIndex++) {
         servoConfig->dev.ioTags[servoIndex] = timerioTagGetByUsage(TIM_USE_SERVO, servoIndex);
     }
+#ifdef RESOURCE_SERVO1_PIN
+    servoConfig->dev.ioTags[0] = IO_TAG(RESOURCE_SERVO1_PIN);
+#endif
+#ifdef RESOURCE_SERVO2_PIN
+    servoConfig->dev.ioTags[1] = IO_TAG(RESOURCE_SERVO2_PIN);
+#endif
+#ifdef RESOURCE_SERVO3_PIN
+    servoConfig->dev.ioTags[2] = IO_TAG(RESOURCE_SERVO3_PIN);
+#endif
+#ifdef RESOURCE_SERVO4_PIN
+    servoConfig->dev.ioTags[3] = IO_TAG(RESOURCE_SERVO4_PIN);
+#endif
+#ifdef RESOURCE_SERVO5_PIN
+    servoConfig->dev.ioTags[4] = IO_TAG(RESOURCE_SERVO5_PIN);
+#endif
+#ifdef RESOURCE_SERVO6_PIN
+    servoConfig->dev.ioTags[5] = IO_TAG(RESOURCE_SERVO6_PIN);
+#endif
+#ifdef RESOURCE_SERVO7_PIN
+    servoConfig->dev.ioTags[6] = IO_TAG(RESOURCE_SERVO7_PIN);
+#endif
+#ifdef RESOURCE_SERVO8_PIN
+    servoConfig->dev.ioTags[7] = IO_TAG(RESOURCE_SERVO8_PIN);
+#endif
+#ifdef RESOURCE_SERVO9_PIN
+    servoConfig->dev.ioTags[8] = IO_TAG(RESOURCE_SERVO9_PIN);
+#endif
+#ifdef RESOURCE_SERVO10_PIN
+    servoConfig->dev.ioTags[9] = IO_TAG(RESOURCE_SERVO10_PIN);
+#endif
+#ifdef RESOURCE_SERVO11_PIN
+    servoConfig->dev.ioTags[10] = IO_TAG(RESOURCE_SERVO11_PIN);
+#endif
+#ifdef RESOURCE_SERVO12_PIN
+    servoConfig->dev.ioTags[11] = IO_TAG(RESOURCE_SERVO12_PIN);
+#endif
+#ifdef RESOURCE_SERVO13_PIN
+    servoConfig->dev.ioTags[12] = IO_TAG(RESOURCE_SERVO13_PIN);
+#endif
+#ifdef RESOURCE_SERVO14_PIN
+    servoConfig->dev.ioTags[13] = IO_TAG(RESOURCE_SERVO14_PIN);
+#endif
+#ifdef RESOURCE_SERVO15_PIN
+    servoConfig->dev.ioTags[14] = IO_TAG(RESOURCE_SERVO15_PIN);
+#endif
+#ifdef RESOURCE_SERVO16_PIN
+    servoConfig->dev.ioTags[15] = IO_TAG(RESOURCE_SERVO16_PIN);
+#endif
+
 }
 
 PG_REGISTER_ARRAY(servoMixer_t, MAX_SERVO_RULES, customServoMixers, PG_SERVO_MIXER, 0);

--- a/src/main/pg/motor.c
+++ b/src/main/pg/motor.c
@@ -70,7 +70,55 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS; motorIndex++) {
         motorConfig->dev.ioTags[motorIndex] = timerioTagGetByUsage(TIM_USE_MOTOR, motorIndex);
     }
+#ifdef RESOURCE_MOTOR1_PIN
+    motorConfig->dev.ioTags[0] = IO_TAG(RESOURCE_MOTOR1_PIN);
 #endif
+#ifdef RESOURCE_MOTOR2_PIN
+    motorConfig->dev.ioTags[1] = IO_TAG(RESOURCE_MOTOR2_PIN);
+#endif
+#ifdef RESOURCE_MOTOR3_PIN
+    motorConfig->dev.ioTags[2] = IO_TAG(RESOURCE_MOTOR3_PIN);
+#endif
+#ifdef RESOURCE_MOTOR4_PIN
+    motorConfig->dev.ioTags[3] = IO_TAG(RESOURCE_MOTOR4_PIN);
+#endif
+#ifdef RESOURCE_MOTOR5_PIN
+    motorConfig->dev.ioTags[4] = IO_TAG(RESOURCE_MOTOR5_PIN);
+#endif
+#ifdef RESOURCE_MOTOR6_PIN
+    motorConfig->dev.ioTags[5] = IO_TAG(RESOURCE_MOTOR6_PIN);
+#endif
+#ifdef RESOURCE_MOTOR7_PIN
+    motorConfig->dev.ioTags[6] = IO_TAG(RESOURCE_MOTOR7_PIN);
+#endif
+#ifdef RESOURCE_MOTOR8_PIN
+    motorConfig->dev.ioTags[7] = IO_TAG(RESOURCE_MOTOR8_PIN);
+#endif
+#ifdef RESOURCE_MOTOR9_PIN
+    motorConfig->dev.ioTags[8] = IO_TAG(RESOURCE_MOTOR9_PIN);
+#endif
+#ifdef RESOURCE_MOTOR10_PIN
+    motorConfig->dev.ioTags[9] = IO_TAG(RESOURCE_MOTOR10_PIN);
+#endif
+#ifdef RESOURCE_MOTOR11_PIN
+    motorConfig->dev.ioTags[10] = IO_TAG(RESOURCE_MOTOR11_PIN);
+#endif
+#ifdef RESOURCE_MOTOR12_PIN
+    motorConfig->dev.ioTags[11] = IO_TAG(RESOURCE_MOTOR12_PIN);
+#endif
+#ifdef RESOURCE_MOTOR13_PIN
+    motorConfig->dev.ioTags[12] = IO_TAG(RESOURCE_MOTOR13_PIN);
+#endif
+#ifdef RESOURCE_MOTOR14_PIN
+    motorConfig->dev.ioTags[13] = IO_TAG(RESOURCE_MOTOR14_PIN);
+#endif
+#ifdef RESOURCE_MOTOR15_PIN
+    motorConfig->dev.ioTags[14] = IO_TAG(RESOURCE_MOTOR15_PIN);
+#endif
+#ifdef RESOURCE_MOTOR16_PIN
+    motorConfig->dev.ioTags[15] = IO_TAG(RESOURCE_MOTOR16_PIN);
+#endif
+#endif // USE_TIMER
 
     motorConfig->motorPoleCount = 14;   // Most brushes motors that we use are 14 poles
 

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -61,6 +61,10 @@
 #include "board.h"
 #endif
 
+#ifdef USE_CUSTOM_TARGET
+#include <custom_target.h>
+#endif
+
 #include "target.h"
 #include "target/common_post.h"
 #include "target/common_defaults_post.h"

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -108,8 +108,4 @@
 #define CONFIG_IN_RAM
 #endif
 
-#ifdef USE_EXST
-#define USE_CUSTOM_DEFAULTS
-#endif
-
 #define USE_EXTI

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -115,8 +115,4 @@
 #define CONFIG_IN_RAM
 #endif
 
-#ifdef USE_EXST
-#define USE_CUSTOM_DEFAULTS
-#endif
-
 #define USE_EXTI


### PR DESCRIPTION
This is an alternative PR to #12336

## Motivation

Due to plan to migrate to 'define-only' targets in the unified targets repository there needs to be a compile-time way of specifying all target resources in the form of `#define`s.

That cannot currently be configured by #defines that this PR addresses:

## Motor pins

Motor pins used to be in a target's config.c file, but currently require use of the `resource MOTOR <x> <pin>`  command.

This PR allows specification of resources, using pin-definitions in the data-sheet form, i.e. `P<gpio-port-letter><one-or-two-digit-pin-index>` form, which is the same as other potential `#defines` (e.g. `SPI1_MOSI_PIN` , but different from form used by the CLI command which are `<gpio-port-letter><two-digital-pin-index>, for example:

```
#define RESOURCE_MOTOR1_PIN PA0
#define RESOURCE_MOTOR2_PIN PA16
```

It does this by re-locating and re-using the cli's resource command table and provides an API to allow assignment of resources during parameter group (PG) initialization.

## Servo pins

As per motor pins, example:

```
#define RESOURCE_SERVO1_PIN PA0
#define RESOURCE_SERVO2_PIN PA16
```

## What's missing?

Support for:

* [ ] dmaopt
* [ ] timer
* [ ] support anything other resource that can already be configured by the code in #12336, e.g. led strip, pwm, ppm, etc.

## Commits from other PRs

Maintainers: This PR contains commits from other PRs as follows which should be ingnored, they are included here so you can get the big-picture.

* [ ] #12333 - Revert "Fix missing CUSTOM_DEFAULTS for H730/H750 targets. (#12261)"
* [ ] #12335 - Add support for easy compilation of define-only custom targets.

## Status

Work-in-progress.