### PR TITLE
Simplified platform.h

### DIFF
--- a/src/main/drivers/at32/platform_at32.h
+++ b/src/main/drivers/at32/platform_at32.h
@@ -44,6 +44,7 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 #endif
 
 #define USE_TIMER_MGMT
+#define USE_TIMER_AF
 #define USE_DMA_SPEC
 #define USE_PERSISTENT_OBJECTS
 #define USE_CUSTOM_DEFAULTS_ADDRESS

--- a/src/main/drivers/stm32/platform_stm32.h
+++ b/src/main/drivers/stm32/platform_stm32.h
@@ -124,7 +124,6 @@
 #define USE_PERSISTENT_MSC_RTC
 #define USE_MCO
 #define USE_DMA_SPEC
-#define USE_TIMER_MGMT
 #define USE_PERSISTENT_OBJECTS
 #define USE_CUSTOM_DEFAULTS_ADDRESS
 #define USE_LATE_TASK_STATISTICS
@@ -148,7 +147,6 @@
 #define USE_PERSISTENT_MSC_RTC
 #define USE_MCO
 #define USE_DMA_SPEC
-#define USE_TIMER_MGMT
 #define USE_PERSISTENT_OBJECTS
 #define USE_CUSTOM_DEFAULTS_ADDRESS
 #define USE_LATE_TASK_STATISTICS
@@ -168,7 +166,6 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_DMA_SPEC
-#define USE_TIMER_MGMT
 #define USE_PERSISTENT_OBJECTS
 #define USE_DMA_RAM
 #define USE_USB_MSC
@@ -187,7 +184,6 @@
 #define USE_USB_CDC_HID
 #define USE_MCO
 #define USE_DMA_SPEC
-#define USE_TIMER_MGMT
 #define USE_LATE_TASK_STATISTICS
 #endif
 
@@ -255,3 +251,6 @@ extern uint8_t _dmaram_end__;
 #define DMA_RAM_W
 #define DMA_RAM_RW
 #endif
+
+#define USE_TIMER_MGMT
+#define USE_TIMER_AF

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -26,35 +26,6 @@
 #pragma GCC poison sprintf snprintf
 #endif
 
-// common to all
-#define USE_TIMER_AF
-
-#if defined(STM32)
-
-#include "drivers/stm32/platform_stm32.h"
-
-#elif defined(AT32)
-
-#include "drivers/at32/platform_at32.h"
-
-#elif defined(SIMULATOR_BUILD)
-
-// Nop
-#undef USE_TIMER_AF
-#define DEFAULT_CPU_OVERCLOCK 1
-#define DMA_RAM
-#define DMA_RW_AXI
-#define DMA_RAM_R
-#define DMA_RAM_W
-#define DMA_RAM_RW
-
-#define DMA_DATA_ZERO_INIT
-#define DMA_DATA
-#define STATIC_DMA_DATA_AUTO
-#else
-#error "Invalid chipset specified. Update platform.h"
-#endif
-
 #include "target/common_pre.h"
 
 #ifdef USE_CONFIG

--- a/src/main/target/AT32F435/target.h
+++ b/src/main/target/AT32F435/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/at32/platform_at32.h"
+
 #define TARGET_BOARD_IDENTIFIER "A435"
 
 #define USBD_PRODUCT_STRING     "Betaflight AT32F435"
@@ -84,7 +86,6 @@
 //#define USE_ADC
 
 #define USE_CUSTOM_DEFAULTS
-#define USE_TIMER_MGMT
 #define USE_PWM_OUTPUT
 
 #undef USE_BEEPER

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -31,6 +31,17 @@
 
 #define SIMULATOR_MULTITHREAD
 
+#define DEFAULT_CPU_OVERCLOCK 1
+#define DMA_RAM
+#define DMA_RW_AXI
+#define DMA_RAM_R
+#define DMA_RAM_W
+#define DMA_RAM_RW
+
+#define DMA_DATA_ZERO_INIT
+#define DMA_DATA
+#define STATIC_DMA_DATA_AUTO
+
 // use simulatior's attitude directly
 // disable this if wants to test AHRS algorithm
 #undef USE_IMU_CALC

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #define TARGET_BOARD_IDENTIFIER "S405"
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F405"

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #define TARGET_BOARD_IDENTIFIER "S411"
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F411"

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #define TARGET_BOARD_IDENTIFIER "S745"
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F745"

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #define TARGET_BOARD_IDENTIFIER "S7X2"
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32F7x2"

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -19,6 +19,9 @@
  */
 
 #pragma once
+
+#include "drivers/stm32/platform_stm32.h"
+
 #define TARGET_BOARD_IDENTIFIER "SG47"
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32G47x"

--- a/src/main/target/STM32H723/target.h
+++ b/src/main/target/STM32H723/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "SH72"
 #endif

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "S730"
 #endif

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #define TARGET_BOARD_IDENTIFIER "SH74"
 
 #define USBD_PRODUCT_STRING     "Betaflight STM32H743"

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include "drivers/stm32/platform_stm32.h"
+
 #ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "S750"
 #endif


### PR DESCRIPTION
As targets are limited to MCU now, we can use this fact to remove the #ifdef statements related to MCU from platform.h. 

The MCU family is implied by the target.h and can be used for including MCU platform specific includes.
