### PR TITLE
FIX: Flash status compilation error

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -104,7 +104,7 @@ struct {
     { 0xEF4016, 133, 50, 64, 256 },
     // Winbond W25Q64
     // Datasheet: https://www.winbond.com/resource-files/w25q64jv%20spi%20%20%20revc%2006032016%20kms.pdf
-    { 0xEF4017, 133, 50, 128, 256 }, // W25Q64JV-IQ/JQ 
+    { 0xEF4017, 133, 50, 128, 256 }, // W25Q64JV-IQ/JQ
     { 0xEF7017, 133, 50, 128, 256 }, // W25Q64JV-IM/JM*
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
@@ -145,7 +145,7 @@ static uint8_t m25p16_page_buffer[M25P16_PAGESIZE];
 
 static uint8_t m25p16_readStatus(flashDevice_t *fdevice)
 {
-    uint8_t status;
+    uint8_t status = 0;
     if (fdevice->io.mode == FLASHIO_SPI) {
         STATIC_DMA_DATA_AUTO uint8_t readStatus[2] = { M25P16_INSTRUCTION_READ_STATUS_REG, 0 };
         STATIC_DMA_DATA_AUTO uint8_t readyStatus[2];
@@ -153,12 +153,13 @@ static uint8_t m25p16_readStatus(flashDevice_t *fdevice)
         spiReadWriteBuf(fdevice->io.handle.dev, readStatus, readyStatus, sizeof(readStatus));
 
         status = readyStatus[1];
-    }
+    } else {
 #ifdef USE_QUADSPI
-        else if (fdevice->io.mode == FLASHIO_QUADSPI) {
+        if (fdevice->io.mode == FLASHIO_QUADSPI) {
             quadSpiReceive1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_READ_STATUS_REG, 0, &status, 1);
         }
 #endif
+    }
 
     return status;
 }


### PR DESCRIPTION
Fixes:

```
%% (debug) ./src/main/io/asyncfatfs/asyncfatfs.c
./src/main/drivers/flash_m25p16.c: In function 'm25p16_readStatus':
./src/main/drivers/flash_m25p16.c:163:12: error: 'status' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  163 |     return status;
      |            ^~~~~~
cc1: all warnings being treated as errors
```