### PR TITLE
Remove USE_SWDIO, simply refer to DEBUG

### DIFF
--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -154,6 +154,7 @@ MCU_COMMON_SRC = \
             drivers/stm32/adc_stm32f4xx.c \
             drivers/stm32/bus_i2c_stm32f4xx.c \
             drivers/stm32/bus_spi_stdperiph.c \
+            drivers/stm32/debug.c \
             drivers/stm32/dma_stm32f4xx.c \
             drivers/stm32/dshot_bitbang.c \
             drivers/stm32/dshot_bitbang_stdperiph.c \

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -164,6 +164,7 @@ MCU_COMMON_SRC = \
             drivers/stm32/bus_i2c_hal_init.c \
             drivers/stm32/bus_i2c_hal.c \
             drivers/stm32/bus_spi_ll.c \
+            drivers/stm32/debug.c \
             drivers/stm32/dma_stm32f7xx.c \
             drivers/stm32/dshot_bitbang_ll.c \
             drivers/stm32/dshot_bitbang.c \

--- a/make/mcu/STM32G4.mk
+++ b/make/mcu/STM32G4.mk
@@ -150,6 +150,7 @@ MCU_COMMON_SRC = \
             drivers/stm32/bus_i2c_hal_init.c \
             drivers/stm32/bus_i2c_hal.c \
             drivers/stm32/bus_spi_ll.c \
+            drivers/stm32/debug.c \
             drivers/stm32/dma_stm32g4xx.c \
             drivers/stm32/dshot_bitbang_ll.c \
             drivers/stm32/dshot_bitbang.c \

--- a/make/mcu/STM32H7.mk
+++ b/make/mcu/STM32H7.mk
@@ -306,6 +306,7 @@ MCU_COMMON_SRC = \
             drivers/stm32/bus_spi_ll.c \
             drivers/stm32/bus_quadspi_hal.c \
             drivers/stm32/bus_octospi_stm32h7xx.c \
+            drivers/stm32/debug.c \
             drivers/stm32/dma_stm32h7xx.c \
             drivers/stm32/dshot_bitbang_ll.c \
             drivers/stm32/dshot_bitbang.c \

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -111,3 +111,5 @@ typedef enum {
 } debugType_e;
 
 extern const char * const debugModeNames[DEBUG_COUNT];
+
+void debugInit(void);

--- a/src/main/drivers/at32/debug.c
+++ b/src/main/drivers/at32/debug.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+#include "build/debug.h"
+#include "drivers/io.h"
+
+#ifdef DEBUG // DEBUG=GDB on command line
+void debugInit(void)
+{
+    IO_t io = IOGetByTag(DEFIO_TAG_E(PA13)); // SWDIO
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
+    io = IOGetByTag(DEFIO_TAG_E(PA14));      // SWCLK
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
+}
+#endif

--- a/src/main/drivers/stm32/debug.c
+++ b/src/main/drivers/stm32/debug.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+#include "build/debug.h"
+#include "drivers/io.h"
+
+#ifdef DEBUG // DEBUG=GDB on command line
+void debugInit(void)
+{
+    IO_t io = IOGetByTag(DEFIO_TAG_E(PA13)); // SWDIO
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
+    io = IOGetByTag(DEFIO_TAG_E(PA14));      // SWCLK
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
+}
+#endif

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -256,20 +256,6 @@ static void sdCardAndFSInit(void)
 }
 #endif
 
-#ifdef USE_SWDIO
-static void swdPinsInit(void)
-{
-    IO_t io = IOGetByTag(DEFIO_TAG_E(PA13)); // SWDIO
-    if (IOGetOwner(io) == OWNER_FREE) {
-        IOInit(io, OWNER_SWD, 0);
-    }
-    io = IOGetByTag(DEFIO_TAG_E(PA14)); // SWCLK
-    if (IOGetOwner(io) == OWNER_FREE) {
-        IOInit(io, OWNER_SWD, 0);
-    }
-}
-#endif
-
 void init(void)
 {
 #ifdef SERIAL_PORT_COUNT
@@ -1030,8 +1016,8 @@ void init(void)
     spiInitBusDMA();
 #endif
 
-#ifdef USE_SWDIO
-    swdPinsInit();
+#ifdef DEBUG
+    debugInit();
 #endif
 
     unusedPinsInit();


### PR DESCRIPTION
Command line of `make TARGET=STM32F405 DEBUG=GDB` will trigger this.

Alternative is simply `make TARGET=STM32F405 EXTRA_FLAGS="-DDEBUG"`

This is if you want to use the SWDIO pins for debugging, rather than alternate functions. This is sets up for alternatives depending on MCU type, as we add more MCU options. i.e. moves some MCU specific code out of init.c