### PR TITLE
To enable display of pin mapping for config.h

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5857,6 +5857,7 @@ static void showTimerMap(void)
     cliPrintLine("Timer Mapping:");
     for (unsigned int i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
         const ioTag_t ioTag = timerIOConfig(i)->ioTag;
+
         if (!ioTag) {
             continue;
         }
@@ -5864,7 +5865,7 @@ static void showTimerMap(void)
         cliPrintLinef(" TIMER_PIN_MAP(%d, P%c%d, %d, %d)",
             i,
             IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag),
-            timerIOConfig(i)->index ,
+            timerIOConfig(i)->index,
             timerIOConfig(i)->dmaopt
         );
     }

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5850,6 +5850,27 @@ static void alternateFunctionToString(const ioTag_t ioTag, const int index, char
     }
 }
 
+#ifdef USE_TIMER_MAP_PRINT
+static void showTimerMap(void)
+{
+    cliPrintLinefeed();
+    cliPrintLine("Timer Mapping:");
+    for (unsigned int i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
+        const ioTag_t ioTag = timerIOConfig(i)->ioTag;
+        if (!ioTag) {
+            continue;
+        }
+
+        cliPrintLinef(" TIMER_PIN_MAP(%d, P%c%d, %d, %d)",
+            i,
+            IO_GPIOPortIdxByTag(ioTag) + 'A', IO_GPIOPinIdxByTag(ioTag),
+            timerIOConfig(i)->index ,
+            timerIOConfig(i)->dmaopt
+        );
+    }
+}
+#endif
+
 static void showTimers(void)
 {
     cliPrintLinefeed();
@@ -5901,6 +5922,12 @@ static void cliTimer(const char *cmdName, char *cmdline)
         cliPrintErrorLinef(cmdName, "NOT IMPLEMENTED YET");
 
         return;
+#ifdef USE_TIMER_MAP_PRINT
+    } else if (strncasecmp(cmdline, "map", len) == 0) {
+        showTimerMap();
+
+        return;
+#endif
     } else if (strncasecmp(cmdline, "show", len) == 0) {
         showTimers();
 

--- a/src/main/pg/timerio.c
+++ b/src/main/pg/timerio.c
@@ -29,6 +29,13 @@
 
 #include "timerio.h"
 
+/*
+    idx      => is the index in the config array,
+    pin      => is the pin to be mapped,
+    pos      => is the pin position (index) within timerHardware (full) that should be used
+                e.g. 1 = first occurence of the pin, 2 = second occurence, etc.
+    dmaopt   => the configured dma opt for the pin
+*/
 #define TIMER_PIN_MAP(idx, pin, pos, dmaOpt)  \
         { config[idx].ioTag = IO_TAG(pin); config[idx].index = pos; config[idx].dmaopt = dmaOpt; }
 

--- a/src/main/pg/timerio.c
+++ b/src/main/pg/timerio.c
@@ -30,14 +30,15 @@
 #include "timerio.h"
 
 /*
-    idx      => is the index in the config array,
-    pin      => is the pin to be mapped,
-    pos      => is the pin position (index) within timerHardware (full) that should be used
+Details of the TIMER_PIN_MAP macro:
+    i => is the index in the PG timer IO config array,
+    p => is the hardware pin to be mapped,
+    o => is the hardware pin occurrence (1 based index) within timerHardware (full) that should be used
                 e.g. 1 = first occurence of the pin, 2 = second occurence, etc.
-    dmaopt   => the configured dma opt for the pin
+    d => the configured dma opt for the pin
 */
-#define TIMER_PIN_MAP(idx, pin, pos, dmaOpt)  \
-        { config[idx].ioTag = IO_TAG(pin); config[idx].index = pos; config[idx].dmaopt = dmaOpt; }
+#define TIMER_PIN_MAP(i, p, o, d)  \
+        { config[i].ioTag = IO_TAG(p); config[i].index = o; config[i].dmaopt = d; }
 
 PG_REGISTER_ARRAY_WITH_RESET_FN(timerIOConfig_t, MAX_TIMER_PINMAP_COUNT, timerIOConfig, PG_TIMER_IO_CONFIG, 0);
 


### PR DESCRIPTION
Specially for @hydra to help him understand how the timer pin mapping works.

First you would configure the timer as you would in the existing custom defaults in cli, i.e.:

using a **STM32F722**:
```
# timer
timer A00 AF2
# pin A00: TIM5 CH1 (AF2)
timer A01 AF2
# pin A01: TIM5 CH2 (AF2)
timer A02 AF2
# pin A02: TIM5 CH3 (AF2)
timer A03 AF2
# pin A03: TIM5 CH4 (AF2)
timer B00 AF2
# pin B00: TIM3 CH3 (AF2)
timer B01 AF2
# pin B01: TIM3 CH4 (AF2)
timer C07 AF3
# pin C07: TIM8 CH2 (AF3)
timer C08 AF3
# pin C08: TIM8 CH3 (AF3)
timer C09 AF3
# pin C09: TIM8 CH4 (AF3)
```

Also set the DMA options, so the command `timer map` outputs the right values, else they will be `-1` for dmaopt (which is unused).

e.g.

```
dma pin A01 0
# pin A01: DMA1 Stream 4 Channel 6
dma pin A00 0
# pin A00: DMA1 Stream 2 Channel 6
```

The below is an example of the output after running `timer map` in cli:

```
# timer map

Timer Mapping:
 TIMER_PIN_MAP(0, PA0, 2, 0)
 TIMER_PIN_MAP(1, PA1, 2, 0)
 TIMER_PIN_MAP(2, PA2, 2, -1)
 TIMER_PIN_MAP(3, PA3, 2, -1)
 TIMER_PIN_MAP(4, PB0, 2, 0)
 TIMER_PIN_MAP(5, PB1, 2, 0)
 TIMER_PIN_MAP(6, PC7, 2, -1)
 TIMER_PIN_MAP(7, PC8, 2, -1)
 TIMER_PIN_MAP(8, PC9, 2, -1)
```

To enable this command (`timer map`) you need to add the define `USE_TIMER_MAP_PRINT` so use either:

```
make TARGET=XX EXTRA_FLAGS="-DUSE_TIMER_MAP_PRINT"

or 

make CONFIG=XX EXTRA_FLAGS="-DUSE_TIMER_MAP_PRINT"
```

