### PR TITLE
Fix: Renamed USE_LEDSTRIP_64 to USE_LED_STRIP_64

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -283,7 +283,7 @@
 #endif // !defined(CLOUD_BUILD)
 
 #if !defined(LED_MAX_STRIP_LENGTH)
-#ifdef USE_LEDSTRIP_64
+#ifdef USE_LED_STRIP_64
 #define LED_MAX_STRIP_LENGTH           64
 #else
 #define LED_MAX_STRIP_LENGTH           32

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -44,7 +44,7 @@
 #define USE_TRANSPONDER
 
 #ifndef LED_MAX_STRIP_LENGTH
-    #ifdef USE_LEDSTRIP_64
+    #ifdef USE_LED_STRIP_64
         #define LED_MAX_STRIP_LENGTH           64
     #else
         #define LED_MAX_STRIP_LENGTH           32


### PR DESCRIPTION
Fixes for this:
![image](https://user-images.githubusercontent.com/2925027/218597664-814961bc-285c-4715-b620-c5149e63b095.png)

Cloud build provides USE_LED_STRIP and USE_LED_STRIP_64, not USE_LEDSTRIP_64

if this PR goes through, i guess i should raise a cherry-pick PR against 4.4-maintenance