### PR TITLE
Fix MPU6000 reset

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -339,6 +339,9 @@ bool mpuGyroReadSPI(gyroDev_t *gyro)
 typedef uint8_t (*gyroSpiDetectFn_t)(const extDevice_t *dev);
 
 static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
+#ifdef USE_GYRO_SPI_ICM20689
+    icm20689SpiDetect,  // icm20689SpiDetect detects ICM20602 and ICM20689
+#endif
 #ifdef USE_GYRO_SPI_MPU6000
     mpu6000SpiDetect,
 #endif
@@ -347,9 +350,6 @@ static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
 #endif
 #ifdef  USE_GYRO_SPI_MPU9250
     mpu9250SpiDetect,
-#endif
-#ifdef USE_GYRO_SPI_ICM20689
-    icm20689SpiDetect,  // icm20689SpiDetect detects ICM20602 and ICM20689
 #endif
 #ifdef USE_ACCGYRO_LSM6DSO
     lsm6dsoDetect,

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -132,6 +132,9 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev)
     // reset the device configuration
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(100);  // datasheet specifies a 100ms delay after reset
+    // reset the device signal paths
+    spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    delay(100);  // datasheet specifies a 100ms delay after signal path reset
 
     const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
     delayMicroseconds(1); // Ensure CS high time is met which is violated on H7 without this delay
@@ -158,10 +161,6 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev)
         case MPU6000_REV_D10:
             detectedSensor = MPU_60x0_SPI;
         }
-
-        // reset the device signal paths
-        spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
-        delay(100);  // datasheet specifies a 100ms delay after signal path reset
     }
 
     return detectedSensor;


### PR DESCRIPTION
Gyro detection fails on some boards after a soft reboot. This PR fixes it by restoring the reset during detection to how it used to be. 
This is what the manufacturers documentation says about reset. It's also how it used to be.
![bilde](https://user-images.githubusercontent.com/41271048/219159508-6fe84af1-1f5f-4fbb-9c87-a2423da1bbf2.png)

Based on this I would assume that reading registers between these two operations is illegal.
It was changed last year to avoid unintentionally writing to reserved bits  in the signal path reset register of the ICM20689 during gyro detection. This behaviour is preserved by moving the ICM20689 detect function to be first in the list.
