### PR TITLE
NEW TARGET: ATSTARTF435

### DIFF
--- a/src/config/ATSTARTF435/config.h
+++ b/src/config/ATSTARTF435/config.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+   This file has been auto generated from unified-targets repo.
+
+   The auto generation is transitional only.
+*/
+
+#define FC_TARGET_MCU     AT32F435
+
+#define BOARD_NAME        ATSTARTF435
+#define MANUFACTURER_ID   ATRY
+
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6000
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
+// AT-START-F435 V1.0 UART 1 assignments to use as a default
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+#define USE_MSP_UART            SERIAL_PORT_USART1
+
+// AT-START-F435 V1.0 LED assignments to use as a default
+#define LED0_PIN                PD13 // Labelled LED2 Red
+#define LED1_PIN                PD14 // Labelled LED3 Amber
+#define LED2_PIN                PD15 // Labelled LED4 Green
+
+// AT-START-F435 J7 connector SPI 1
+#define SPI2_SCK_PIN            PD1
+#define SPI2_MISO_PIN           PC2
+#define SPI2_MOSI_PIN           PD4
+
+#define J7_NSS                  PD0
+
+#define GYRO_1_CS_PIN           J7_NSS
+#define GYRO_1_SPI_INSTANCE     SPI2
+#define GYRO_1_EXTI_PIN         PB11

--- a/src/config/ATSTARTF435/config.h
+++ b/src/config/ATSTARTF435/config.h
@@ -19,12 +19,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*
-   This file has been auto generated from unified-targets repo.
-
-   The auto generation is transitional only.
-*/
-
 #define FC_TARGET_MCU     AT32F435
 
 #define BOARD_NAME        ATSTARTF435

--- a/src/main/drivers/at32/bus_spi_at32bsp.c
+++ b/src/main/drivers/at32/bus_spi_at32bsp.c
@@ -44,7 +44,7 @@ static spi_init_type defaultInit = {
     .first_bit_transmission = SPI_FIRST_BIT_MSB,
     .mclk_freq_division = SPI_MCLK_DIV_8,
     .clock_polarity = SPI_CLOCK_POLARITY_HIGH,
-    .clock_phase = SPI_CLOCK_PHASE_2EDGE 
+    .clock_phase = SPI_CLOCK_PHASE_2EDGE
 };
 
 static uint16_t spiDivisorToBRbits(spi_type  *instance, uint16_t divisor)

--- a/src/main/drivers/at32/platform_at32.h
+++ b/src/main/drivers/at32/platform_at32.h
@@ -70,7 +70,6 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 
 #define USE_LATE_TASK_STATISTICS
 
-/*
 #ifndef SPI1_SCK_PIN
 #define SPI1_SCK_PIN    PA5
 #define SPI1_MISO_PIN   PA6
@@ -106,4 +105,3 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 #define SPI6_MISO_PIN   NONE
 #define SPI6_MOSI_PIN   NONE
 #endif
-*/

--- a/src/main/target/AT32F435/target.h
+++ b/src/main/target/AT32F435/target.h
@@ -30,18 +30,9 @@
 #define AT32F435
 #endif
 
-// AT-START-F435 V1.0 LED assignments to use as a default
-#define LED0_PIN                PD13 // Labelled LED2 Red
-#define LED1_PIN                PD14 // Labelled LED3 Amber
-#define LED2_PIN                PD15 // Labelled LED4 Green
-
 //#define USE_I2C_DEVICE_1
 
 #define USE_UART1
-// AT-START-F435 V1.0 UART 1 assignments to use as a default
-#define UART1_RX_PIN PA10
-#define UART1_TX_PIN PA9
-#define USE_MSP_UART SERIAL_PORT_USART1
 
 #define USE_UART2
 #define USE_UART3
@@ -59,19 +50,8 @@
 #define USE_SPI_DEVICE_2
 #define USE_SPI_DMA_ENABLE_LATE
 
-// AT-START-F435 J7 connector SPI 1
-#define SPI2_SCK_PIN            PD1
-#define SPI2_MISO_PIN           PC2
-#define SPI2_MOSI_PIN           PD4
-
-#define J7_NSS                  PD0
-
-#define GYRO_1_CS_PIN           J7_NSS
-#define GYRO_1_SPI_INSTANCE     SPI2
-
 #define USE_EXTI
 #define USE_GYRO_EXTI
-#define GYRO_1_EXTI_PIN         PB11
 
 #define USE_ACCGYRO_BMI160
 
@@ -79,7 +59,6 @@
 #define USE_VCP
 //#define USE_SOFTSERIAL1
 //#define USE_SOFTSERIAL2
-
 
 #define UNIFIED_SERIAL_PORT_COUNT       1
 
@@ -119,5 +98,3 @@
 // 2K page sectors
 #define FLASH_PAGE_SIZE   ((uint32_t)0x0800)
 #endif
-
-#define USE_EXTI


### PR DESCRIPTION
Removing the pin definitions from AT32F435 target.h and setting up an actual configured target.