### PR TITLE
FIX: Multi-gyro enabled but not configured at compile time.

### DIFF
--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -34,6 +34,13 @@
 #include "drivers/sensor.h"
 #include "sensors/gyro.h"
 
+#ifndef GYRO_2_CS_PIN
+#define GYRO_2_CS_PIN NONE
+#endif
+
+#ifndef GYRO_2_EXTI_PIN
+#define GYRO_2_EXTI_PIN NONE
+#endif
 
 ioTag_t selectMPUIntExtiConfigByHardwareRevision(void); // XXX Should be gone
 


### PR DESCRIPTION
As per the label on the tin. Fixes an issue with a lack of compile time settings for second gyro. Will allow building, and then run time configuration.