### PR TITLE
Fix: Renamed USE_LEDSTRIP_64 to USE_LED_STRIP_64

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -421,7 +421,7 @@ extern uint8_t _dmaram_end__;
 #endif // !defined(CLOUD_BUILD)
 
 #if !defined(LED_MAX_STRIP_LENGTH)
-#ifdef USE_LEDSTRIP_64
+#ifdef USE_LED_STRIP_64
 #define LED_MAX_STRIP_LENGTH           64
 #else
 #define LED_MAX_STRIP_LENGTH           32

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -44,7 +44,7 @@
 #define USE_TRANSPONDER
 
 #ifndef LED_MAX_STRIP_LENGTH
-    #ifdef USE_LEDSTRIP_64
+    #ifdef USE_LED_STRIP_64
         #define LED_MAX_STRIP_LENGTH           64
     #else
         #define LED_MAX_STRIP_LENGTH           32


### PR DESCRIPTION
Cherry-pick of this PR for 4.4-maintenance:
https://github.com/betaflight/betaflight/pull/12365