### PR TITLE
Update NMEA initialization

### DIFF
--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -27,10 +27,7 @@
 
 void serialPrint(serialPort_t *instance, const char *str)
 {
-    uint8_t ch;
-    while ((ch = *(str++)) != 0) {
-        serialWrite(instance, ch);
-    }
+    serialWriteBuf(instance, (const uint8_t *)str, sizeof(str) - 1);
 }
 
 uint32_t serialGetBaudRate(serialPort_t *instance)

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -379,6 +379,36 @@ extern uint32_t dashboardGpsNavSvInfoRcvCount;                  // Count of time
 #define GPS_DBHZ_MAX 55
 #endif  // USE_DASHBOARD
 
+// UBX NMEA message types
+#define GPS_PUBX_115200         "$PUBX,41,1,0003,0001,115200,0*1E\r\n"
+#define GPS_PUBX_57600          "$PUBX,41,1,0003,0001,57600,0*2D\r\n"
+#define GPS_PUBX_38400          "$PUBX,41,1,0003,0001,38400,0*26\r\n"
+#define GPS_PUBX_19200          "$PUBX,41,1,0003,0001,19200,0*23\r\n"
+#define GPS_PUBX_9600           "$PUBX,41,1,0003,0001,9600,0*16\r\n"
+
+// MTK NMEA message types
+#define GPS_PMTK_115200         "$PMTK251,115200*1F\r\n"
+#define GPS_PMTK_57600          "$PMTK251,57600*2C\r\n"
+#define GPS_PMTK_38400          "$PMTK251,38400*27\r\n"
+#define GPS_PMTK_19200          "$PMTK251,19200*22\r\n"
+#define GPS_PMTK_9600           "$PMTK251,9600*17\r\n"
+
+#define GPS_PMTK_GGA_RATE_5HZ   "$PMTK220,200*2C\r\n"
+
+// SIRF NMEA message types
+#define GPS_PSRF_NMEA_115200    "$PSRF100,1,115200,8,1,0*05\r\n"
+#define GPS_PSRF_NMEA_57600     "$PSRF100,1,57600,8,1,0*36\r\n"
+#define GPS_PSRF_NMEA_38400     "$PSRF100,1,38400,8,1,0*3D\r\n"
+#define GPS_PSRF_NMEA_19200     "$PSRF100,1,19200,8,1,0*38\r\n"
+#define GPS_PSRF_NMEA_9600      "$PSRF100,1,9600,8,1,0*0D\r\n"
+
+#define GPS_PSRF_GGA_RATE_1HZ   "$PSRF103,00,00,01,01*25\r\n"
+#define GPS_PSRF_GGA_RATE_5HZ   "$PSRF103,00,00,05,01*21\r\n"
+#define GPS_PSRF_DISABLE_GSV    "$PSRF103,03,00,00,01*27\r\n"
+
+// ATGM336 message types
+#define GPS_ATGM336_RATE_10HZ   "$PCAS02,100*1E\r\n"
+#define GPS_ATGM336_HOT_RESTART "$PCAS10,0*1C\r\n"
 
 #ifdef USE_GPS_UBLOX
 ubloxVersion_e ubloxParseVersion(const uint32_t version);

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -394,6 +394,7 @@ extern uint32_t dashboardGpsNavSvInfoRcvCount;                  // Count of time
 #define GPS_PMTK_9600           "$PMTK251,9600*17\r\n"
 
 #define GPS_PMTK_GGA_RATE_5HZ   "$PMTK220,200*2C\r\n"
+#define GPS_PMTK_GSV_DISABLE    "$PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29\r\n"
 
 // SIRF NMEA message types
 #define GPS_PSRF_NMEA_115200    "$PSRF100,1,115200,8,1,0*05\r\n"
@@ -404,7 +405,7 @@ extern uint32_t dashboardGpsNavSvInfoRcvCount;                  // Count of time
 
 #define GPS_PSRF_GGA_RATE_1HZ   "$PSRF103,00,00,01,01*25\r\n"
 #define GPS_PSRF_GGA_RATE_5HZ   "$PSRF103,00,00,05,01*21\r\n"
-#define GPS_PSRF_DISABLE_GSV    "$PSRF103,03,00,00,01*27\r\n"
+#define GPS_PSRF_GSV_DISABLE    "$PSRF103,03,00,00,01*27\r\n"
 
 // ATGM336 message types
 #define GPS_ATGM336_RATE_10HZ   "$PCAS02,100*1E\r\n"


### PR DESCRIPTION
See: https://github.com/betaflight/betaflight/issues/12239

![image](https://github.com/betaflight/betaflight/assets/8344830/71555e2c-41e1-4b5a-88b7-0ec79f1ea702)

[IEC 61162-1-2010-728ad3778103426ab0a9a64b6cc5e474.pdf](https://github.com/betaflight/betaflight/files/12403059/IEC.61162-1-2010-728ad3778103426ab0a9a64b6cc5e474.pdf)

https://www.plaisance-pratique.com/IMG/pdf/NMEA0183-2.pdf
https://cdn-shop.adafruit.com/datasheets/PMTK_A11.pdf
https://www.sparkfun.com/datasheets/GPS/NMEA%20Reference%20Manual-Rev2.1-Dec07.pdf

https://www.youtube.com/watch?v=SVYkDurlj7w

![IMG_20230818_000936_HDR](https://github.com/betaflight/betaflight/assets/8344830/69b6f8a0-7fc5-4ac9-b5fa-1f496a3428ff)

According to the standard we have:
- NMEA 0183 (IEC 61162-1) NMEA 3.01 - 9600 baud
- NMEA 0183-HS (IEC 61162-2) Rev 1.0 - 38400 baud
- NMEA 2000 (IEC 61162-3) CAN bus
- NMEA OneNet

As we already have presets for setting MediaTeK and GoTop modules the Ublox M8N only connects to 9600 baud if NMEA is selected, when selecting UBLOX it does 115K2 without issues. UBX or MTK messages won't work.

https://github.com/betaflight/betaflight/pull/12591
https://github.com/betaflight/firmware-presets/pull/393

![image](https://github.com/betaflight/betaflight/assets/8344830/c1abdf47-d4b5-48e1-b9cc-1cb8a42f82e6)
