### PR TITLE
added fake barometer sensor name to cli lookup table, fixes cli status crash for SITL

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -150,7 +150,7 @@ const char * const lookupTableGyroHardware[] = {
 #if defined(USE_SENSOR_NAMES) || defined(USE_BARO)
 // sync with baroSensor_e
 const char * const lookupTableBaroHardware[] = {
-    "AUTO", "NONE", "BMP085", "MS5611", "BMP280", "LPS", "QMP6988", "BMP388", "DPS310", "2SMPB_02B"
+    "AUTO", "NONE", "BMP085", "MS5611", "BMP280", "LPS", "QMP6988", "BMP388", "DPS310", "2SMPB_02B", "FAKE"
 };
 #endif
 #if defined(USE_SENSOR_NAMES) || defined(USE_MAG)


### PR DESCRIPTION
Fixes crash if you call status in CLI for SITL builds.