### PR TITLE
Prevent SPRACINGH7RF accidentally using external storage for logging when required for EXST

### DIFF
--- a/src/config/SPRACINGH7RF/config.h
+++ b/src/config/SPRACINGH7RF/config.h
@@ -262,3 +262,8 @@
 #define USE_SPI_GYRO
 #define GYRO_1_SPI_INSTANCE SPI6
 #define GYRO_1_ALIGN CW270_DEG_FLIP
+
+// Prevent flash being used for logs as target requires EXST
+#ifdef USE_FLASH
+#undef USE_FLASH
+#endif


### PR DESCRIPTION
SPRACINGH7RF will fail to boot if `USE_FLASH` is set so we will undef that option.