### PR TITLE
FIX: CRSF no active serial port and telem causing hardfault

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -607,7 +607,7 @@ void crsfRxWriteTelemetryData(const void *data, int len)
 void crsfRxSendTelemetryData(void)
 {
     // if there is telemetry data to write
-    if (telemetryBufLen > 0) {
+    if (telemetryBufLen > 0 && serialPort != NULL) {
         serialWriteBuf(serialPort, telemetryBuf, telemetryBufLen);
         telemetryBufLen = 0; // reset telemetry buffer
     }

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -607,8 +607,10 @@ void crsfRxWriteTelemetryData(const void *data, int len)
 void crsfRxSendTelemetryData(void)
 {
     // if there is telemetry data to write
-    if (telemetryBufLen > 0 && serialPort != NULL) {
-        serialWriteBuf(serialPort, telemetryBuf, telemetryBufLen);
+    if (telemetryBufLen > 0) {
+        if (serialPort != NULL) {
+            serialWriteBuf(serialPort, telemetryBuf, telemetryBufLen);
+        }
         telemetryBufLen = 0; // reset telemetry buffer
     }
 }


### PR DESCRIPTION
If no serial ports are allocted to SERIAL RX, and you enable CRSF as a provider, then a hard fault occurs when telemetry is sent.