### PR TITLE
Fix RX protocol config

### DIFF
--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -34,16 +34,6 @@
 #include "rx/rx.h"
 #include "rx/rx_spi.h"
 
-#ifndef SERIALRX_PROVIDER
-#if defined(USE_SERIALRX_SBUS)
-#define SERIALRX_PROVIDER SERIALRX_SBUS
-#elif defined(USE_SERIALRX_GHST)
-#define SERIALRX_PROVIDER SERIALRX_GHST
-#else
-#define SERIALRX_PROVIDER SERIALRX_CRSF
-#endif
-#endif
-
 PG_REGISTER_WITH_RESET_FN(rxConfig_t, rxConfig, PG_RX_CONFIG, 4);
 void pgResetFn_rxConfig(rxConfig_t *rxConfig)
 {

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -34,6 +34,20 @@
 #include "rx/rx.h"
 #include "rx/rx_spi.h"
 
+#ifndef SERIALRX_PROVIDER
+
+#if defined(USE_SERIALRX_SBUS)
+#define SERIALRX_PROVIDER SERIALRX_SBUS
+#elif defined(USE_SERIALRX_GHST)
+#define SERIALRX_PROVIDER SERIALRX_GHST
+#elif defined(USE_SERIALRX_CRSF)
+#define SERIALRX_PROVIDER SERIALRX_CRSF
+#else
+#define SERIALRX_PROVIDER 0
+#endif
+
+#endif
+
 PG_REGISTER_WITH_RESET_FN(rxConfig_t, rxConfig, PG_RX_CONFIG, 4);
 void pgResetFn_rxConfig(rxConfig_t *rxConfig)
 {

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -59,10 +59,6 @@
 #define RX_SPI_DEFAULT_PROTOCOL 0
 #endif
 
-#ifndef SERIALRX_PROVIDER
-#define SERIALRX_PROVIDER 0
-#endif
-
 #define RX_MIN_USEC 885
 #define RX_MAX_USEC 2115
 #define RX_MID_USEC 1500

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -58,6 +58,7 @@
 #ifndef RX_SPI_DEFAULT_PROTOCOL
 #define RX_SPI_DEFAULT_PROTOCOL 0
 #endif
+
 #ifndef SERIALRX_PROVIDER
 #define SERIALRX_PROVIDER 0
 #endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -423,3 +423,15 @@
 #endif
 
 #endif // defined(USE_SERIALRX_CRSF)
+
+#if defined(USE_SERIALRX) && !defined(SERIALRX_PROVIDER)
+
+#if defined(USE_SERIALRX_SBUS)
+#define SERIALRX_PROVIDER SERIALRX_SBUS
+#elif defined(USE_SERIALRX_GHST)
+#define SERIALRX_PROVIDER SERIALRX_GHST
+#else
+#define SERIALRX_PROVIDER SERIALRX_CRSF
+#endif
+
+#endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -423,15 +423,3 @@
 #endif
 
 #endif // defined(USE_SERIALRX_CRSF)
-
-#if defined(USE_SERIALRX) && !defined(SERIALRX_PROVIDER)
-
-#if defined(USE_SERIALRX_SBUS)
-#define SERIALRX_PROVIDER SERIALRX_SBUS
-#elif defined(USE_SERIALRX_GHST)
-#define SERIALRX_PROVIDER SERIALRX_GHST
-#else
-#define SERIALRX_PROVIDER SERIALRX_CRSF
-#endif
-
-#endif


### PR DESCRIPTION
Moved protocol configuration to common_pre.h as common_post.h was preventing the macro in pg/rx.c