### PR TITLE
Remove SPEK1024 as the default RX (set to NONE)

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -232,7 +232,7 @@ static const char * const lookupTableBlackboxSampleRate[] = {
 
 #ifdef USE_SERIALRX
 static const char * const lookupTableSerialRX[] = {
-    "SPEK1024",
+    "NONE",
     "SPEK2048",
     "SBUS",
     "SUMD",
@@ -247,6 +247,7 @@ static const char * const lookupTableSerialRX[] = {
     "FPORT",
     "SRXL2",
     "GHST",
+    "SPEK1024",
 };
 #endif
 

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -124,7 +124,9 @@ void ghstRxSendTelemetryData(void)
 {
     // if there is telemetry data to write
     if (telemetryBufLen > 0) {
-        serialWriteBuf(serialPort, telemetryBuf, telemetryBufLen);
+        if (serialPort != NULL) {
+            serialWriteBuf(serialPort, telemetryBuf, telemetryBufLen);
+        }
         telemetryBufLen = 0; // reset telemetry buffer
     }
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -54,7 +54,7 @@ typedef enum {
 } rxFrameState_e;
 
 typedef enum {
-    SERIALRX_SPEKTRUM1024 = 0,
+    SERIALRX_NONE = 0,
     SERIALRX_SPEKTRUM2048 = 1,
     SERIALRX_SBUS = 2,
     SERIALRX_SUMD = 3,
@@ -68,7 +68,8 @@ typedef enum {
     SERIALRX_TARGET_CUSTOM = 11,
     SERIALRX_FPORT = 12,
     SERIALRX_SRXL2 = 13,
-    SERIALRX_GHST = 14
+    SERIALRX_GHST = 14,
+    SERIALRX_SPEKTRUM1024 = 15
 } SerialRXType;
 
 #define MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT          12


### PR DESCRIPTION
At the moment, after a bare flash SPEK1024 is the default RX provider. This should be NONE.

Also included is a little protection for GHST telemetry like what was recently done for CRSF.