### PR TITLE
Revert 12302 NVIC SPI Priority

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -748,7 +748,7 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments)
 {
     busDevice_t *bus = dev->bus;
 
-    ATOMIC_BLOCK(NVIC_PRIO_SPI_DMA) {
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
         if (spiIsBusy(dev)) {
             busSegment_t *endSegment;
 


### PR DESCRIPTION
This PR reverts a part of PR#12302 from Feb 6, by @hydra  - the bit that changed SPI priority.

Unfortunately it seemed to badly affect some F411 boards.

For example, the NOX F411, with GPS and Softserial would randomly lock up, and fall out of the sky with 4.5.  Additionally it didn't have the loop time stability I saw in the past.  The only way to stop it locking up was to disable the OSD entirely.

This PR brings the old NOX board back to life, it now is rock solid stable again, even with OSD, GPS, new Angle and Horizon code. soft serial, all active.  

This PR has been checked with several SX1280 ELRS SPI boards and does not appear to adversely affect link reliability.
