### PR TITLE
Fix default PID DENOM

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -682,6 +682,12 @@ void validateAndFixGyroConfig(void)
         }
 #endif
 
+#if defined(USE_GYRO_DENOM_CHECK) && (defined(USE_ACCGYRO_BMI160) || defined(USE_ACCGYRO_BMI270))
+        if (gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI270) {
+            pidConfigMutable()->pid_process_denom = 1;
+        }
+#endif
+
         switch (motorConfig()->dev.motorPwmProtocol) {
         case PWM_TYPE_STANDARD:
                 motorUpdateRestriction = 1.0f / BRUSHLESS_MOTORS_PWM_RATE;

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -682,9 +682,16 @@ void validateAndFixGyroConfig(void)
         }
 #endif
 
-#if defined(USE_GYRO_DENOM_CHECK) && (defined(USE_ACCGYRO_BMI160) || defined(USE_ACCGYRO_BMI270))
-        if (gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI270) {
+#ifdef USE_GYRO_DENOM_CHECK
+        bool bmiDetected = gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI270
+            || gyro.gyroSensor2.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor2.gyroDev.gyroHardware == GYRO_BMI270;
+
+        if (bmiDetected) {
             pidConfigMutable()->pid_process_denom = 1;
+        }
+
+        if (motorConfig()->dev.useDshotTelemetry && rxRuntimeState.rxProvider == RX_PROVIDER_SPI) {
+            pidConfigMutable()->pid_process_denom = bmiDetected ? 2 : 4;
         }
 #endif
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -683,8 +683,9 @@ void validateAndFixGyroConfig(void)
 #endif
 
 #ifdef USE_GYRO_DENOM_CHECK
-        bool bmiDetected = gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI270
-            || gyro.gyroSensor2.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor2.gyroDev.gyroHardware == GYRO_BMI270;
+        bool bmiDetected = gyro.gyroToUse == 0
+            ? gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor1.gyroDev.gyroHardware == GYRO_BMI270
+            : gyro.gyroSensor2.gyroDev.gyroHardware == GYRO_BMI160 || gyro.gyroSensor2.gyroDev.gyroHardware == GYRO_BMI270;
 
         if (bmiDetected) {
             pidConfigMutable()->pid_process_denom = 1;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -90,12 +90,10 @@ pt1Filter_t throttleLpf;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
 
-#if !defined(DEFAULT_PID_PROCESS_DENOM)
-#if defined(STM32F411xE)
+#if !defined(DEFAULT_PID_PROCESS_DENOM) && defined(USE_GYRO_DENOM_CHECK)
 #define DEFAULT_PID_PROCESS_DENOM       2
 #else
 #define DEFAULT_PID_PROCESS_DENOM       1
-#endif
 #endif
 
 #ifdef USE_RUNAWAY_TAKEOFF

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -90,9 +90,7 @@ pt1Filter_t throttleLpf;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
 
-#if !defined(DEFAULT_PID_PROCESS_DENOM) && defined(USE_GYRO_DENOM_CHECK)
-#define DEFAULT_PID_PROCESS_DENOM       2
-#else
+#ifndef DEFAULT_PID_PROCESS_DENOM
 #define DEFAULT_PID_PROCESS_DENOM       1
 #endif
 

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -79,4 +79,6 @@
 
 #define USE_EXTI
 
+#define USE_GYRO_DENOM_CHECK
+
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -79,6 +79,6 @@
 
 #define USE_EXTI
 
-#define USE_GYRO_DENOM_CHECK
+#define USE_PID_DENOM_CHECK
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -78,4 +78,6 @@
 
 #define USE_EXTI
 
+#define USE_GYRO_DENOM_CHECK
+
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -78,6 +78,6 @@
 
 #define USE_EXTI
 
-#define USE_GYRO_DENOM_CHECK
+#define USE_PID_DENOM_CHECK
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -72,5 +72,9 @@
 #define USE_ESCSERIAL
 
 #define USE_ADC
+
 #define USE_EXTI
+
+#define USE_PID_DENOM_CHECK
+
 #define USE_TIMER_UP_CONFIG


### PR DESCRIPTION
Found that BMI gyro was set to 1.6Khz instead of 3.2Khz as DENOM was set to 2 as default for F411 MCU.

http://betaflight.com/docs/manufacturer/manufacturer-design-guidelines#41-rated-looptime-and-performance