### PR TITLE
Fix NEUTRONRCG4AIO config file

### DIFF
--- a/src/config/NEUTRONRCG4AIO/config.h
+++ b/src/config/NEUTRONRCG4AIO/config.h
@@ -26,6 +26,16 @@
 #define BOARD_NAME        NEUTRONRCG4AIO
 #define MANUFACTURER_ID   NERC
 
+#define USE_GYRO
+#define USE_ACC
+#define ACCGYRO_SPI_LSM6DSO
+#define USE_ACCGYRO_LSM6DSO
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_M25P16
+#define USE_MAX7456
+
 #define BEEPER_PIN           PC14
 #define MOTOR1_PIN           PB1
 #define MOTOR2_PIN           PB0
@@ -76,7 +86,6 @@
 #define TIMUP4_DMA_OPT      0
 #define TIMUP5_DMA_OPT      0
 
-#define USE_BARO
 #define BARO_I2C_INSTANCE (I2CDEV_1)
 #define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
 #define DEFAULT_DSHOT_BURST DSHOT_DMAR_OFF

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -144,7 +144,7 @@ const char * const lookupTableAccHardware[] = {
 const char * const lookupTableGyroHardware[] = {
     "AUTO", "NONE", "MPU6050", "L3G4200D", "MPU3050", "L3GD20",
     "MPU6000", "MPU6500", "MPU9250", "ICM20601", "ICM20602", "ICM20608G", "ICM20649", "ICM20689", "ICM42605", "ICM42688P",
-    "BMI160", "BMI270", "LSM6SDO", "VIRTUAL"
+    "BMI160", "BMI270", "LSM6DSO", "VIRTUAL"
 };
 
 #if defined(USE_SENSOR_NAMES) || defined(USE_BARO)

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -75,7 +75,8 @@
 #if !defined(USE_GYRO_L3G4200D) && !defined(USE_GYRO_MPU3050) && !defined(USE_GYRO_MPU6050) && \
     !defined(USE_GYRO_MPU6500) && !defined(USE_GYRO_SPI_ICM20689) && !defined(USE_GYRO_SPI_MPU6000) && \
     !defined(USE_GYRO_SPI_MPU6500) && !defined(USE_GYRO_SPI_MPU9250) && !defined(USE_GYRO_L3GD20) && \
-    !defined(USE_GYRO_SPI_ICM42605) && !defined(USE_GYRO_SPI_ICM42688P) && !defined(USE_ACCGYRO_BMI270) && !defined(USE_VIRTUAL_GYRO)
+    !defined(USE_GYRO_SPI_ICM42605) && !defined(USE_GYRO_SPI_ICM42688P) && !defined(USE_ACCGYRO_BMI270) && \
+    !defined(USE_ACCGYRO_LSM6DSO) && !defined(USE_VIRTUAL_GYRO)
 #error At least one USE_GYRO device definition required
 #endif
 


### PR DESCRIPTION
Supports the LSM6DSO acc/gyro and DPS310 Baro on the NEUTRONRCG4AIO board.

Reviewers please check that the changes 'make sense'.  There was a spelling mistake in settings.c, and LSM6DSO wasn't included in gyro_init.c.

I have only one board of this type, and it is now working well with 4.5 Zulu.