### PR TITLE
CONFIG: define W25Q128FV for OMNIBUSF4

### DIFF
--- a/src/config/OMNIBUSF4/config.h
+++ b/src/config/OMNIBUSF4/config.h
@@ -33,6 +33,8 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_ACC_SPI_MPU6000
 #define USE_BARO_BMP280
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 
 #define BEEPER_PIN           PB4


### PR DESCRIPTION
* as per https://discord.com/channels/868013470023548938/1047982336974790766/1087087723963232296

Co-authored-by: Mark Haslinghuis <mark@numloq.nl>

