### PR TITLE
Enable AT32 ADC for internal measurements

### DIFF
--- a/src/config/ATSTARTF435/config.h
+++ b/src/config/ATSTARTF435/config.h
@@ -53,5 +53,5 @@
 #define UART1_TX_PIN PA9
 #define USE_MSP_UART SERIAL_PORT_USART1
 
-
+#define ADC1_DMA_OPT                    1
 

--- a/src/config/NEUTRONRCF435/config.h
+++ b/src/config/NEUTRONRCF435/config.h
@@ -65,3 +65,5 @@
 #define MAX7456_SPI_INSTANCE SPI2
 #define MAX7456_SPI_CS_PIN   PB12
 
+#define ADC1_DMA_OPT                    1
+

--- a/src/config/REVO_AT/config.h
+++ b/src/config/REVO_AT/config.h
@@ -67,3 +67,5 @@
 #define BARO_I2C_INSTANCE       I2CDEV_1
 #define USE_BARO
 #define USE_BARO_MS5611
+
+#define ADC1_DMA_OPT                    1


### PR DESCRIPTION
Enable AT32 ADC for internal measurements, Vref and Core Temperature.