### PR TITLE
Fix F411 PA10 Motor DMA Assignment

### DIFF
--- a/src/config/EMAX_BABYHAWK_II_HD/config.h
+++ b/src/config/EMAX_BABYHAWK_II_HD/config.h
@@ -76,7 +76,7 @@
     TIMER_PIN_MAP( 0, PA2 , 3, -1) \
     TIMER_PIN_MAP( 1, PA8 , 1,  1) \
     TIMER_PIN_MAP( 2, PA9 , 1,  1) \
-    TIMER_PIN_MAP( 3, PA10, 1,  0) \
+    TIMER_PIN_MAP( 3, PA10, 1,  1) \
     TIMER_PIN_MAP( 4, PB0 , 2,  0) \
     TIMER_PIN_MAP( 5, PB4 , 1,  0) \
     TIMER_PIN_MAP( 6, PB1 , 2,  0) \

--- a/src/config/FLYWOOF411/config.h
+++ b/src/config/FLYWOOF411/config.h
@@ -74,7 +74,7 @@
     TIMER_PIN_MAP( 0, PA2 , 3, -1) \
     TIMER_PIN_MAP( 1, PA8 , 1,  1) \
     TIMER_PIN_MAP( 2, PA9 , 1,  1) \
-    TIMER_PIN_MAP( 3, PA10, 1,  0) \
+    TIMER_PIN_MAP( 3, PA10, 1,  1) \
     TIMER_PIN_MAP( 4, PB0 , 2,  0) \
     TIMER_PIN_MAP( 5, PB4 , 1,  0) \
     TIMER_PIN_MAP( 6, PB1 , 2,  0) \

--- a/src/config/FLYWOOF411EVO_HD/config.h
+++ b/src/config/FLYWOOF411EVO_HD/config.h
@@ -69,7 +69,7 @@
     TIMER_PIN_MAP( 0, PA2 , 3, -1) \
     TIMER_PIN_MAP( 1, PA8 , 1,  1) \
     TIMER_PIN_MAP( 2, PA9 , 1,  1) \
-    TIMER_PIN_MAP( 3, PA10, 1,  0) \
+    TIMER_PIN_MAP( 3, PA10, 1,  1) \
     TIMER_PIN_MAP( 4, PB0 , 2,  0) \
     TIMER_PIN_MAP( 5, PB4 , 1,  0) \
     TIMER_PIN_MAP( 6, PB1 , 2,  0) \

--- a/src/config/JHEF411/config.h
+++ b/src/config/JHEF411/config.h
@@ -77,7 +77,7 @@
     TIMER_PIN_MAP( 0, PA2 , 3, -1) \
     TIMER_PIN_MAP( 1, PA8 , 1,  1) \
     TIMER_PIN_MAP( 2, PA9 , 1,  1) \
-    TIMER_PIN_MAP( 3, PA10, 1,  0) \
+    TIMER_PIN_MAP( 3, PA10, 1,  1) \
     TIMER_PIN_MAP( 4, PB0 , 2,  0) \
     TIMER_PIN_MAP( 5, PB4 , 1,  0) \
     TIMER_PIN_MAP( 6, PB1 , 2,  0) \


### PR DESCRIPTION
Timer-based DShot does not work on F411 FCs that use pin A10 as a motor output when DMA2 Stream 6 Channel 0 is used for TIM1_CH3. Moving the DMA assignment to DMA2 Stream 6 Channel 6 fixes the issue.

See: https://github.com/betaflight/unified-targets/pull/961
