### PR TITLE
Remove USE_VIRTUAL_GYRO defintion for AT32F435

### DIFF
--- a/src/main/target/AT32F435G/target.h
+++ b/src/main/target/AT32F435G/target.h
@@ -34,8 +34,6 @@
 #define HANG_ON_ERRORS
 #endif
 
-#define USE_VIRTUAL_GYRO
-
 #define USE_UART1
 #define USE_UART2
 #define USE_UART3

--- a/src/main/target/AT32F435M/target.h
+++ b/src/main/target/AT32F435M/target.h
@@ -34,8 +34,6 @@
 #define HANG_ON_ERRORS
 #endif
 
-#define USE_VIRTUAL_GYRO
-
 #define USE_UART1
 #define USE_UART2
 #define USE_UART3


### PR DESCRIPTION
This was resulting in a bogus second gyro as per the below.

```
# status
MCU AT32F435 Clock=288MHz, Vref=3.29V, Core temp=57degC
Stack size: 2048, Stack address: 0x2002fff0
Configuration: CONFIGURED, size: 3526, max available: 16384
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1, gyro 2 locked
GYRO=VIRTUAL, BARO=DPS310
```