### PR TITLE
CONFIG: Add W25Q128FV to RUSHCORE7

### DIFF
--- a/src/config/RUSHCORE7/config.h
+++ b/src/config/RUSHCORE7/config.h
@@ -34,6 +34,8 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_MPU6000
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 
 #define BEEPER_PIN           PB1


### PR DESCRIPTION
Fixes: https://github.com/betaflight/unified-targets/issues/964