### PR TITLE
Fix NEUTRONRCF7AIO Target Defines

### DIFF
--- a/src/config/NEUTRONRCF7AIO/config.h
+++ b/src/config/NEUTRONRCF7AIO/config.h
@@ -26,6 +26,16 @@
 #define BOARD_NAME        NEUTRONRCF7AIO
 #define MANUFACTURER_ID   NERC
 
+#define USE_ACC
+#define USE_ACC_SPI_ICM20689
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM20689
+#define USE_ACCGYRO_BMI270
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_W25N01G
+#define USE_MAX7456
+
 #define BEEPER_PIN           PD2
 #define MOTOR1_PIN           PB0
 #define MOTOR2_PIN           PB1
@@ -94,8 +104,6 @@
 
 #define ADC1_DMA_OPT        0
 
-#define MAG_ALIGN CW180_DEG
-#define MAG_ALIGN_YAW 1800
 //TODO #define MAG_BUSTYPE I2C
 #define MAG_I2C_INSTANCE (I2CDEV_1)
 #define USE_BARO
@@ -116,4 +124,3 @@
 #define GYRO_2_SPI_INSTANCE SPI2
 #define GYRO_2_ALIGN CW180_DEG
 #define GYRO_2_ALIGN_YAW 1800
-#define DEFAULT_ALIGN_BOARD_YAW -45


### PR DESCRIPTION
 - Add gyro defines (Gyro 1: BMI270, Gyro 2: ICM-20689)
 - Add flash defines (W25N01G)
 - Add OSD defines (MAX7456)
 - Remove MAG orientation defines (Build specific)
 - Remove default yaw offset (Gyro is not at 45 deg)

Tested both gyros.

---------------------------------------------------

`Status` from working 4.4.0 core
```
MCU F745 Clock=216MHz, Vref=3.30V, Core temp=42degC
Stack size: 2048, Stack address: 0x20010000
Configuration: CONFIGURED, size: 4192, max available: 32768
Devices detected: SPI:2, I2C:0
Gyros detected: gyro 1, gyro 2 locked dma
GYRO=BMI270, ACC=BMI270
OSD: MAX7456 (30 x 13)
BUILD KEY: 2450ef5c51a6e1c4e397015611fa704c (4.4.0)
System Uptime: 10 seconds, Current Time: 2023-03-28T15:34:12.140+00:00
CPU:20%, cycle time: 312, GYRO rate: 3205, RX rate: 15, System rate: 9
Voltage: 439 * 0.01V (0S battery - NOT PRESENT)
I2C Errors: 22
SD card: Not configured
FLASH: JEDEC ID=0x00efaa21 128M
Arming disable flags: RXLOSS CLI MSP
```
`Status` after my changes:
```
MCU F745 Clock=216MHz, Vref=3.30V, Core temp=42degC
Stack size: 2048, Stack address: 0x20010000
Configuration: CONFIGURED, size: 4192, max available: 32768
Devices detected: SPI:2, I2C:0
Gyros detected: gyro 1, gyro 2 locked dma
GYRO=BMI270, ACC=BMI270
OSD: MAX7456 (30 x 13)
BUILD KEY: 2450ef5c51a6e1c4e397015611fa704c (4.4.0)
System Uptime: 10 seconds, Current Time: 2023-03-28T15:34:12.140+00:00
CPU:20%, cycle time: 312, GYRO rate: 3205, RX rate: 15, System rate: 9
Voltage: 439 * 0.01V (0S battery - NOT PRESENT)
I2C Errors: 22
SD card: Not configured
FLASH: JEDEC ID=0x00efaa21 128M
Arming disable flags: RXLOSS CLI MSP
```

NOTE: i2c errors are because my board does not have the baro populated. I'll test the baro once it gets here from AliExpress.
