### PR TITLE
Add NMEA Custom commands

### DIFF
--- a/src/main/cli/cli_debug_print.h
+++ b/src/main/cli/cli_debug_print.h
@@ -32,7 +32,7 @@
 //           elements before submitting final code.
 
 #include "platform.h"
-
+#define USE_CLI_DEBUG_PRINT
 #ifdef USE_CLI_DEBUG_PRINT
 
 #include "cli/cli.h"

--- a/src/main/cli/cli_debug_print.h
+++ b/src/main/cli/cli_debug_print.h
@@ -32,7 +32,7 @@
 //           elements before submitting final code.
 
 #include "platform.h"
-#define USE_CLI_DEBUG_PRINT
+
 #ifdef USE_CLI_DEBUG_PRINT
 
 #include "cli/cli.h"

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1008,7 +1008,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_GPS_SET_HOME_POINT_ONCE,    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_set_home_point_once) },
     { PARAM_NAME_GPS_USE_3D_SPEED,           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_use_3d_speed) },
     { PARAM_NAME_GPS_SBAS_INTEGRITY,         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, sbas_integrity) },
-    { PARAM_NAME_GPS_NMEA_CUSTOM_COMMANDS,   VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, MAX_NMEA_CUSTOM_COMMANDS_LENGTH, STRING_FLAGS_NONE }, PG_GPS_CONFIG, offsetof(gpsConfig_t, nmeaCustomCommands) },
+    { PARAM_NAME_GPS_NMEA_CUSTOM_COMMANDS,   VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, NMEA_CUSTOM_COMMANDS_MAX_LENGTH, STRING_FLAGS_NONE }, PG_GPS_CONFIG, offsetof(gpsConfig_t, nmeaCustomCommands) },
 
 #ifdef USE_GPS_RESCUE
     // PG_GPS_RESCUE

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1008,6 +1008,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_GPS_SET_HOME_POINT_ONCE,    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_set_home_point_once) },
     { PARAM_NAME_GPS_USE_3D_SPEED,           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_use_3d_speed) },
     { PARAM_NAME_GPS_SBAS_INTEGRITY,         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, sbas_integrity) },
+    { PARAM_NAME_GPS_NMEA_CUSTOM_COMMANDS,   VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, MAX_NMEA_CUSTOM_COMMANDS_LENGTH, STRING_FLAGS_NONE }, PG_GPS_CONFIG, offsetof(gpsConfig_t, nmeaCustomCommands) },
 
 #ifdef USE_GPS_RESCUE
     // PG_GPS_RESCUE

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -148,6 +148,7 @@
 #define PARAM_NAME_GPS_UBLOX_FLIGHT_MODEL "gps_ublox_flight_model"
 #define PARAM_NAME_GPS_SET_HOME_POINT_ONCE "gps_set_home_point_once"
 #define PARAM_NAME_GPS_USE_3D_SPEED "gps_use_3d_speed"
+#define PARAM_NAME_GPS_NMEA_CUSTOM_COMMANDS "gps_nmea_custom_commands"
 
 #ifdef USE_GPS_RESCUE
 #define PARAM_NAME_GPS_RESCUE_MIN_START_DIST "gps_rescue_min_start_dist"

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -440,8 +440,8 @@ void gpsInitNmea(void)
 
                     if (*cmd) {
                         // Send the current command to the GPS
-                        serialWriteBuf(gpsPort, (uint8_t *) cmd, commandLen);
-                        serialWriteBuf(gpsPort, (uint8_t *) "\r\n", 2);
+                        serialWriteBuf(gpsPort, (uint8_t *)cmd, commandLen);
+                        serialWriteBuf(gpsPort, (uint8_t *)"\r\n", 2);
 
                         // Move to the next command
                         cmd += commandLen;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -440,8 +440,8 @@ void gpsInitNmea(void)
 
                     if (*cmd) {
                         // Send the current command to the GPS
-                        serialWriteBuf(gpsPort, (uint8_t*)cmd, commandLen);
-                        serialWriteBuf(gpsPort, (uint8_t*)"\r\n", 2);
+                        serialWriteBuf(gpsPort, (uint8_t *) cmd, commandLen);
+                        serialWriteBuf(gpsPort, (uint8_t *) "\r\n", 2);
 
                         // Move to the next command
                         cmd += commandLen;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -415,6 +415,7 @@ void gpsInitNmea(void)
                return;
            }
            gpsData.state_ts = now;
+
            if (gpsData.state_position < GPS_STATE_INITIALIZING) {
                serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.baudrateIndex].baudrateIndex]);
                gpsData.state_position++;
@@ -424,8 +425,22 @@ void gpsInitNmea(void)
                if (!atgmRestartDone) {
                    atgmRestartDone = true;
                    serialPrint(gpsPort, "$PCAS02,100*1E\r\n");  // 10Hz refresh rate
-                   serialPrint(gpsPort, "$PCAS10,0*1C\r\n");    // hot restart 
+                   serialPrint(gpsPort, "$PCAS10,0*1C\r\n");    // hot restart
                }
+
+               //NMEA custom commands
+               char *commands = strdup(gpsConfig()->nmeaCustomCommands);
+
+               //divide commands with spaces and send them to the gps one by one
+               char *saveptr;
+               char* tok = strtok_r(commands, " ", &saveptr);
+               while (tok != NULL) {
+                   char *printable = strdup(tok);
+                   strcat(printable, "\r\n");
+                   serialPrint(gpsPort, printable);
+                   tok = strtok_r(NULL, " ", &saveptr);
+               }
+
                gpsData.state_position++;
            } else
 #else

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -17,7 +17,7 @@
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */
-#include "cli/cli_debug_print.h"
+
 #include <ctype.h>
 #include <string.h>
 #include <math.h>
@@ -101,8 +101,7 @@ uint8_t GPS_svinfo_cno[GPS_SV_MAXSATS_M8N];
 #define GPS_TIMEOUT (2500)
 // How many entries in gpsInitData array below
 #define GPS_INIT_ENTRIES (GPS_BAUDRATE_MAX + 1)
-//Delay between gps commands. E.g for BAUD rate.
-#define GPS_CHANGE_DELAY (200)
+#define GPS_BAUDRATE_CHANGE_DELAY (200)
 // Timeout for waiting ACK/NAK in GPS task cycles (0.25s at 100Hz)
 #define UBLOX_ACK_TIMEOUT_MAX_COUNT (25)
 
@@ -385,7 +384,6 @@ void gpsInit(void)
 void gpsInitNmea(void)
 {
     static bool atgmRestartDone = false;
-    static uint8_t customCommandIndex=0;
 #if !defined(GPS_NMEA_TX_ONLY)
     uint32_t now;
 #endif
@@ -393,7 +391,7 @@ void gpsInitNmea(void)
         case GPS_STATE_INITIALIZING:
 #if !defined(GPS_NMEA_TX_ONLY)
            now = millis();
-           if (now - gpsData.state_ts < GPS_CHANGE_DELAY) {
+           if (now - gpsData.state_ts < 1000) {
                return;
            }
            gpsData.state_ts = now;
@@ -413,7 +411,7 @@ void gpsInitNmea(void)
         case GPS_STATE_CHANGE_BAUD:
 #if !defined(GPS_NMEA_TX_ONLY)
            now = millis();
-           if (now - gpsData.state_ts < GPS_CHANGE_DELAY) {
+           if (now - gpsData.state_ts < 1000) {
                return;
            }
            gpsData.state_ts = now;
@@ -428,33 +426,38 @@ void gpsInitNmea(void)
                    atgmRestartDone = true;
                    serialPrint(gpsPort, "$PCAS02,100*1E\r\n");  // 10Hz refresh rate
                    serialPrint(gpsPort, "$PCAS10,0*1C\r\n");    // hot restart
+               } else {
+                    // NMEA custom commands after ATGM336 initialization
+                    static int commandOffset = 0;
+                    const char *commands = gpsConfig()->nmeaCustomCommands;
+                    const char *cmd = commands + commandOffset;
+
+                    // skip leading whitespaces and get first command length
+                    int commandLen;
+                    while (*cmd && (commandLen = strcspn(cmd, " \0")) == 0) {
+                        cmd++;  // skip separators
+                    }
+
+                    if (*cmd) {
+                        // Send the current command to the GPS
+                        serialWriteBuf(gpsPort, (uint8_t*)cmd, commandLen);
+                        serialWriteBuf(gpsPort, (uint8_t*)"\r\n", 2);
+
+                        // Move to the next command
+                        cmd += commandLen;
+                    }
+
+                    // skip trailing whitespaces
+                    while (*cmd && strcspn(cmd, " \0") == 0) cmd++;
+
+                    if (*cmd) {
+                        // more commands to send
+                        commandOffset = cmd - commands;
+                    } else {
+                        gpsData.state_position++;
+                        commandOffset = 0;
+                    }
                }
-
-                //NMEA custom commands
-                char commands[strlen(gpsConfig()->nmeaCustomCommands) + 1];
-                strcpy(commands, gpsConfig()->nmeaCustomCommands);
-
-                //divide commands with spaces and send them to the gps one by one
-                char *saveptr;
-                char* tok = strtok_r(commands, " ", &saveptr);
-
-                for (uint8_t i=0; i < customCommandIndex; i++) {
-                    tok = strtok_r(NULL, " ", &saveptr);
-                }
-
-                if (tok == NULL) {
-                    customCommandIndex=0;
-                    gpsData.state_position++;
-                }
-                else {
-                    customCommandIndex++;
-
-                    char printable[strlen(tok) + 3];
-                    strcpy(printable, tok);
-                    strcat(printable, "\r\n");
-                    serialPrint(gpsPort, printable);
-                    cliPrintLine(printable);
-                }
            } else
 #else
            {
@@ -633,7 +636,7 @@ void gpsInitUblox(void)
     switch (gpsData.state) {
         case GPS_STATE_INITIALIZING:
             now = millis();
-            if (now - gpsData.state_ts < GPS_CHANGE_DELAY)
+            if (now - gpsData.state_ts < GPS_BAUDRATE_CHANGE_DELAY)
                 return;
 
             if (gpsData.state_position < GPS_INIT_ENTRIES) {

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -108,7 +108,6 @@ uint8_t GPS_svinfo_cno[GPS_SV_MAXSATS_M8N];
 
 static serialPort_t *gpsPort;
 static float gpsDataIntervalSeconds;
-static uint8_t customCommandIndex=0;
 
 typedef struct gpsInitData_s {
     uint8_t index;
@@ -386,6 +385,7 @@ void gpsInit(void)
 void gpsInitNmea(void)
 {
     static bool atgmRestartDone = false;
+    static uint8_t customCommandIndex=0;
 #if !defined(GPS_NMEA_TX_ONLY)
     uint32_t now;
 #endif
@@ -431,7 +431,8 @@ void gpsInitNmea(void)
                }
 
                 //NMEA custom commands
-                char *commands = strdup(gpsConfig()->nmeaCustomCommands);
+                char commands[strlen(gpsConfig()->nmeaCustomCommands) + 1];
+                strcpy(commands, gpsConfig()->nmeaCustomCommands);
 
                 //divide commands with spaces and send them to the gps one by one
                 char *saveptr;
@@ -448,7 +449,8 @@ void gpsInitNmea(void)
                 else {
                     customCommandIndex++;
 
-                    char *printable = strdup(tok);
+                    char printable[strlen(tok) + 3];
+                    strcpy(printable, tok);
                     strcat(printable, "\r\n");
                     serialPrint(gpsPort, printable);
                     cliPrintLine(printable);

--- a/src/main/pg/gps.h
+++ b/src/main/pg/gps.h
@@ -25,6 +25,8 @@
 
 #include "pg/pg.h"
 
+#define MAX_NMEA_CUSTOM_COMMANDS_LENGTH 64
+
 typedef struct gpsConfig_s {
     uint8_t provider;
     uint8_t sbasMode;
@@ -37,6 +39,7 @@ typedef struct gpsConfig_s {
     bool gps_set_home_point_once;
     bool gps_use_3d_speed;
     bool sbas_integrity;
+    char nmeaCustomCommands[MAX_NMEA_CUSTOM_COMMANDS_LENGTH+1];
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);

--- a/src/main/pg/gps.h
+++ b/src/main/pg/gps.h
@@ -25,7 +25,7 @@
 
 #include "pg/pg.h"
 
-#define MAX_NMEA_CUSTOM_COMMANDS_LENGTH 64
+#define NMEA_CUSTOM_COMMANDS_MAX_LENGTH 64
 
 typedef struct gpsConfig_s {
     uint8_t provider;
@@ -39,7 +39,7 @@ typedef struct gpsConfig_s {
     bool gps_set_home_point_once;
     bool gps_use_3d_speed;
     bool sbas_integrity;
-    char nmeaCustomCommands[MAX_NMEA_CUSTOM_COMMANDS_LENGTH+1];
+    char nmeaCustomCommands[NMEA_CUSTOM_COMMANDS_MAX_LENGTH + 1];
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);


### PR DESCRIPTION
Resolves: #12239 
You can add a custom NMEA commands with `set gps_nmea_custom_commands =` and the commands you want.
You can add multiple commands with a space ' ' between them.
Commands will be sent to the gps after the initialization.

I can't test because I only have UBLOX gps.