### PR TITLE
Remove code comments using word retarded

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -85,7 +85,7 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
 PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 1);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
-    .gyro_cal_on_first_arm = 0,  // TODO - Cleanup retarded arm support
+    .gyro_cal_on_first_arm = 0,
     .auto_disarm_delay = 5
 );
 

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -131,7 +131,7 @@ typedef struct flight3DConfig_s {
 PG_DECLARE(flight3DConfig_t, flight3DConfig);
 
 typedef struct armingConfig_s {
-    uint8_t gyro_cal_on_first_arm;          // allow disarm/arm on throttle down + roll left/right
+    uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
 } armingConfig_t;
 


### PR DESCRIPTION
Correct the comment about gyro_cal_on_first_arm and remove comment about retarded arm. When the old feature "retarded_arm" was removed from BF, gyro_cal_on_first_arm was put in its place for some reason??? https://github.com/betaflight/betaflight/commit/4ec5166c0fdf25a97de453e8702353db0818d9b1 In doing so incorrect comments about what gyro_cal_on_first_arm does were in the code, along with a comment that "retarded_arm" needed to be removed.