### PR TITLE
Fix feedforward auto rc smoothing calculation

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1488,7 +1488,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_ACTIVE_CUTOFFS, "%d,%d,%d", rcSmoothingData->feedforwardCutoffFrequency,
                                                                             rcSmoothingData->setpointCutoffFrequency,
                                                                             rcSmoothingData->throttleCutoffFrequency);
-        BLACKBOX_PRINT_HEADER_LINE("rc_smoothing_rx_average", "%d",         rcSmoothingData->averageFrameTimeUs);
+        BLACKBOX_PRINT_HEADER_LINE("rc_smoothing_rx_average", "%d",         rcSmoothingData->averageRxIntervalUs);
 #endif // USE_RC_SMOOTHING_FILTER
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RATES_TYPE, "%d",             currentControlRateProfile->rates_type);
 

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1481,7 +1481,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR, "%d",          rxConfig()->rc_smoothing_auto_factor_rpy);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR_THROTTLE, "%d", rxConfig()->rc_smoothing_auto_factor_throttle);
 
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_FEEDFORWARD_CUTOFF, "%d", rcSmoothingData->ffCutoffSetting);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_FEEDFORWARD_CUTOFF, "%d", rcSmoothingData->feedforwardCutoffSetting);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_SETPOINT_CUTOFF, "%d",    rcSmoothingData->setpointCutoffSetting);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_THROTTLE_CUTOFF, "%d",    rcSmoothingData->throttleCutoffSetting);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_DEBUG_AXIS, "%d",         rcSmoothingData->debugAxis);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4845,7 +4845,7 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
     if (rxConfig()->rc_smoothing_mode) {
         cliPrintLine("FILTER");
         if (rcSmoothingAutoCalculate()) {
-            const uint16_t avgRxFrameUs = rcSmoothingData->averageFrameTimeUs;
+            const uint16_t avgRxFrameUs = rcSmoothingData->averageRxIntervalUs;
             cliPrint("# Detected RX frame rate: ");
             if (avgRxFrameUs == 0) {
                 cliPrintLine("NO SIGNAL");

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4699,7 +4699,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
     // Run status
 
     const int gyroRate = getTaskDeltaTimeUs(TASK_GYRO) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTimeUs(TASK_GYRO)));
-    int rxRate = getCurrentRxRefreshRate();
+    int rxRate = getCurrentRxIntervalUs();
     if (rxRate != 0) {
         rxRate = (int)(1000000.0f / ((float)rxRate));
     }
@@ -4860,7 +4860,7 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
             cliPrintLine("(auto)");
         }
         cliPrintf("# Active FF cutoff: %dhz ", rcSmoothingData->feedforwardCutoffFrequency);
-        if (rcSmoothingData->ffCutoffSetting) {
+        if (rcSmoothingData->feedforwardCutoffSetting) {
             cliPrintLine("(manual)");
         } else {
             cliPrintLine("(auto)");

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -46,5 +46,5 @@ float getRcCommandDelta(int axis);
 float applyCurve(int axis, float deflection);
 bool getShouldUpdateFeedforward();
 void updateRcRefreshRate(timeUs_t currentTimeUs);
-uint16_t getCurrentRxRefreshRate(void);
+uint16_t getCurrentRxIntervalUs(void);
 bool getRxRateValid(void);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -84,18 +84,18 @@ typedef enum {
 
 extern float rcCommand[4];
 
-typedef struct rcSmoothingFilterTraining_s {
-    float sum;
-    int count;
-    uint16_t min;
-    uint16_t max;
-} rcSmoothingFilterTraining_t;
+// typedef struct rcSmoothingFilterTraining_s {
+//     float sum;
+//     int count;
+//     uint16_t min;
+//     uint16_t max;
+// } rcSmoothingFilterTraining_t;
 
 typedef struct rcSmoothingFilter_s {
     bool filterInitialized;
     pt3Filter_t filterSetpoint[4];
-    pt3Filter_t filterRcDeflection[2]
-    ;
+    pt3Filter_t filterRcDeflection[2];
+
     uint8_t setpointCutoffSetting;
     uint8_t throttleCutoffSetting;
     uint8_t feedforwardCutoffSetting;
@@ -104,8 +104,11 @@ typedef struct rcSmoothingFilter_s {
     uint16_t throttleCutoffFrequency;
     uint16_t feedforwardCutoffFrequency;
 
-    int averageFrameTimeUs;
-    rcSmoothingFilterTraining_t training;
+    int averageRxIntervalUs;
+    float smoothedCurrentRxIntervalUs;
+    bool rxIntervalAcceptable;
+    uint8_t sampleCount;
+    bool filterCutoffComplete;
     uint8_t debugAxis;
 
     uint8_t autoSmoothnessFactorSetpoint;

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -93,19 +93,24 @@ typedef struct rcSmoothingFilterTraining_s {
 
 typedef struct rcSmoothingFilter_s {
     bool filterInitialized;
-    pt3Filter_t filter[4];
-    pt3Filter_t filterDeflection[2];
+    pt3Filter_t filterSetpoint[4];
+    pt3Filter_t filterRcDeflection[2]
+    ;
     uint8_t setpointCutoffSetting;
     uint8_t throttleCutoffSetting;
+    uint8_t feedforwardCutoffSetting;
+
     uint16_t setpointCutoffFrequency;
     uint16_t throttleCutoffFrequency;
-    uint8_t ffCutoffSetting;
     uint16_t feedforwardCutoffFrequency;
+
     int averageFrameTimeUs;
     rcSmoothingFilterTraining_t training;
     uint8_t debugAxis;
+
     uint8_t autoSmoothnessFactorSetpoint;
     uint8_t autoSmoothnessFactorThrottle;
+    uint8_t autoSmoothnessFactorFeedforward;
 } rcSmoothingFilter_t;
 
 typedef struct rcControlsConfig_s {

--- a/src/main/flight/feedforward.c
+++ b/src/main/flight/feedforward.c
@@ -84,7 +84,7 @@ FAST_CODE_NOINLINE float feedforwardApply(int axis, bool newRcFrame, feedforward
                         // good values : 25 for 111hz FrSky, 30 for 150hz, 50 for 250hz, 65 for 500hz links
             const float feedforwardJitterFactor = pidGetFeedforwardJitterFactor();
                         // 7 is default, 5 for faster links with smaller steps and for racing, 10-12 for 150hz freestyle
-            const float rxInterval = getCurrentRxRefreshRate() * 1e-6f; // 0.0066 for 150hz RC Link.
+            const float rxInterval = getCurrentRxIntervalUs() * 1e-6f; // 0.0066 for 150hz RC Link.
             const float rxRate = 1.0f / rxInterval; // eg 150 for a 150Hz RC link
 
             const float absSetpointPercent = fabsf(setpoint) / feedforwardMaxRate[axis];

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -408,7 +408,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
     // ** angle loop feedforward
     float angleFeedforward = 0.0f;
 #ifdef USE_FEEDFORWARD
-    const float rxRateHz = 1e6f / getCurrentRxRefreshRate();
+    const float rxRateHz = 1e6f / getCurrentRxIntervalUs();
     const float rcCommandDeltaAbs = fabsf(getRcCommandDelta(axis));
 
     if (newRcFrame){

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -310,7 +310,7 @@ uint8_t __config_end = 0x10;
 uint16_t averageSystemLoadPercent = 0;
 
 timeDelta_t getTaskDeltaTimeUs(taskId_e){ return 0; }
-uint16_t currentRxRefreshRate = 9000;
+uint16_t currentRxIntervalUs = 9000;
 armingDisableFlags_e getArmingDisableFlags(void) { return ARMING_DISABLED_NO_GYRO; }
 
 const char *armingDisableFlagNames[]= {
@@ -368,6 +368,6 @@ bool isModeActivationConditionConfigured(const modeActivationCondition_t *, cons
 void delay(uint32_t) {}
 displayPort_t *osdGetDisplayPort(osdDisplayPortDevice_e *) { return NULL; }
 mcuTypeId_e getMcuTypeId(void) { return MCU_TYPE_UNKNOWN; }
-uint16_t getCurrentRxRefreshRate(void) { return 0; }
+uint16_t getCurrentRxIntervalUs(void) { return 0; }
 uint16_t getAverageSystemLoadPercent(void) { return 0; }
 }

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -30,7 +30,7 @@ float simulatedPrevSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
 float simulatedRcCommandDelta[3] = { 1,1,1 };
 float simulatedRawSetpoint[3] = { 0,0,0 };
-uint16_t simulatedCurrentRxRefreshRate = 10000;
+uint16_t simulatedCurrentRxIntervalUs = 10000;
 uint8_t simulatedDuplicateCount = 0;
 float simulatedMotorMixRange = 0.0f;
 
@@ -91,7 +91,7 @@ extern "C" {
     float getRcCommandDelta(int axis) { return simulatedRcCommandDelta[axis]; }
     float getRcDeflectionRaw(int axis) { return simulatedRcDeflection[axis]; }
     float getRawSetpoint(int axis) { return simulatedRawSetpoint[axis]; }
-    uint16_t getCurrentRxRefreshRate(void) { return simulatedCurrentRxRefreshRate; }
+    uint16_t getCurrentRxIntervalUs(void) { return simulatedCurrentRxIntervalUs; }
     uint8_t getFeedforwardDuplicateCount(void) { return simulatedDuplicateCount; }
     void beeperConfirmationBeeps(uint8_t) { }
     bool isLaunchControlActive(void) {return unitLaunchControlActive; }


### PR DESCRIPTION
I've tested this very carefully, and it is ready for serious review.

Note that there are many merge conflicts with #12578 since they change similar files.  I'll make a mashup PR with both in the one file, it may be easier to review there.

Bugfix PR to correct the following issues with feedforward:

- with low RC rates, eg 50Hz, the automatically calculated feedforward RC smoothing cutoff could be too high, higher than for setpoint, leading to stepping on the feedforward trace.  Fixed by removing unnecessary default code and ensuring the initialisation and updating was correct.

- fixed an overflow in the logged value for `currentRxIntervalUs` in `DEBUG_RC_SMOOTHING_RATE`, where if the value was more than about 30ms, the logged value overflowed and falsely became a negative value.  The fix was to divide all microsecond Rx time interval values by 10 so we can show up to 65ms, the max we support.

- fixes errors in RC interval measurement leading to incorrect Rx link frequency estimations, especially with telemetry rates of 1:16 or lower in ELRS setups.  The same bug would affect Rx link calculations in any setup that was subject to frequent dropouts.  This was done by extensively revising the RC smoothing code, using a first order lowpass filter after removing outliers, and then a stepped series of intermittent filter cutoff recalculations from the smoothed values (every 20 samples to 250Hz then every 40 samples).  Added many comments to hopefully make the code easier to follow than before.  Result is a very accurate determination of the Rx Link interval, even at 1:4 telemetry ratios, and a rapid transition to the new value.

Summary of the Rx link interval calculation changes.

- Removed the old code, which accumulated samples if they varied by more than a certain percentage, clearing the average if any one 'good' sample appeared within a certain number, and if enough continuous samples existed at a different value, removing the min and max outliers and getting the average, then changing the filters to that new value.  

- In its place, incoming Rx interval values that are outside the allowed limits, and those outside 80% of the previous value are ignored.  This excluded startup steps, steps at the start and finish of a dropout, and telemetry steps.  Most of the measurements that get through reflect the true link interval.  These are smoothed through a first order lowpass filter with k = 0.15.  A lower filter coefficient results in less likelihood of a false recalculation, especially if the Rx transmitted very long interval data during link restoration.

- At least 80 samples pass through an averaging process, with the 'working' average and the filters being updated every 20 samples, and after 60 samples, the first final value for RC Smoothing is established.

- Once the initial value is established, the code monitors the difference between the smoothed incoming Rx interval and the current Rx interval value.  If the difference exceeds 15%, typically implying a change in link rate,  a new measurement process is initiated, with updates to the cutoff every 20 samples.   

- The measurement process uses 80 samples, with five updates every 20hz, for links below 300hz.  At higher link rates, switching takes longer, so 160 samples are checked with updates every 40 samples.

- Testing with ELRS shows very precise measurement of the true link speed.  

- While a median filter could be used, a lowpass seems to work very effectively. 

> NOTE:  The code does not continuously update the filter cutoffs at regular intervals, eg every 20 samples.  It could be easily modified to do this.  This would be essential for dynamic link interval Rx systems that smoothly and gradually changed their link intervals.  However most Rx links hold frequency constant, with abrupt steps.  The current method detects abrupt changes very well, and we are not updating all 6 RC smoothing filter cutoffs every 20 packets unless we need to.  It may be almost as CPU effective, overall, to smooth the interval and  just update the cutoffs to the newest average at regular intervals, eg after some defined number of packets.  The outlier extraction and first order smoothing would still need to be done when each packet arrives, but we wouldn't need to compare the smoothed value to the current value.  With auto smoothing, throttle and setpoint share the same cutoff, so we only need to recalculate two PT3 cutoffs. The code would be simpler using this approach, and would support continuously changing Rx link intervals better.  I'd appreciate your thoughts on what we should do.

Also made these minor cosmetic changes:

- re-named `getCurrentRxRefreshRate` to `getCurrentRxIntervalUs` to avoid confusion when naming a value that is an interval in microseconds as if it was a rate.  Likewise `currentRxRefreshRate` to `getCurrentRxIntervalUs`,  `averageFrameTimeUs` to `averageRxIntervalUs`, etc, for clarity.

- re-named some remaining `ff_` variables to `feedforward_`

- added two extra debug lines to `DEBUG_RC_SMOOTHING_RATE` to show the value that is actually used to set the filters (averageFrameTimeUs / 10) and the state of the rc_smoothing guard time.  

- re-named some RC smoothing filters to make it easier to follow which does what.  eg the PT3 named `filter` is now `filterSetpoint`, making it easier to locate the setpoint filter. 

- grouped the RC filters in threes, and included the feedforward RC smoothing filter as a separate entity for clarity, and to ensure it initialised correctly.

Tested on ELRS over all current frequencies, with rapid and slow changes, poor link quality, hard failsafe and power cycling the flight controller.