### PR TITLE
If CS is asserted between transfers then consider bus to be busy for all but owning device

### DIFF
--- a/src/main/drivers/at32/bus_spi_at32bsp.c
+++ b/src/main/drivers/at32/bus_spi_at32bsp.c
@@ -402,8 +402,10 @@ void spiSequenceStart(const extDevice_t *dev)
             busSegment_t *endSegment = (busSegment_t *)bus->curSegment;
             bus->curSegment = nextSegments;
             endSegment->u.link.dev = NULL;
+            endSegment->u.link.segments = NULL;
             spiSequenceStart(nextDev);
         } else {
+            // The end of the segment list has been reached, so mark transactions as complete
             bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
         }
     }

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -42,6 +42,7 @@ typedef enum {
     BUS_ABORT
 } busStatus_e;
 
+struct extDevice_s;
 
 // Bus interface, independent of connected device
 typedef struct busDevice_s {
@@ -74,6 +75,7 @@ typedef struct busDevice_s {
 #endif
 #endif // UNIT_TEST
     volatile struct busSegment_s* volatile curSegment;
+    volatile struct extDevice_s *csLockDevice;
     bool initSegment;
 } busDevice_t;
 

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -160,6 +160,10 @@ bool spiInit(SPIDevice device)
 // Return true if DMA engine is busy
 bool spiIsBusy(const extDevice_t *dev)
 {
+    if (dev->bus->csLockDevice && (dev->bus->csLockDevice != dev)) {
+        // If CS is still asserted, but not by the current device, the bus is busy
+        return true;
+    }
     return (dev->bus->curSegment != (busSegment_t *)BUS_SPI_FREE);
 }
 
@@ -167,7 +171,7 @@ bool spiIsBusy(const extDevice_t *dev)
 void spiWait(const extDevice_t *dev)
 {
     // Wait for completion
-    while (dev->bus->curSegment != (busSegment_t *)BUS_SPI_FREE);
+    while (spiIsBusy(dev));
 }
 
 // Wait for bus to become free, then read/write block of data
@@ -425,12 +429,6 @@ FAST_IRQ_HANDLER static void spiIrqHandler(const extDevice_t *dev)
     nextSegment = (busSegment_t *)bus->curSegment + 1;
 
     if (nextSegment->len == 0) {
-#if defined(USE_ATBSP_DRIVER)
-        if (!bus->curSegment->negateCS) {
-            // Negate Chip Select if not done so already
-            IOHi(dev->busType_u.spi.csnPin);
-        }
-#endif
         // If a following transaction has been linked, start it
         if (nextSegment->u.link.dev) {
             const extDevice_t *nextDev = nextSegment->u.link.dev;
@@ -442,6 +440,11 @@ FAST_IRQ_HANDLER static void spiIrqHandler(const extDevice_t *dev)
             spiSequenceStart(nextDev);
         } else {
             // The end of the segment list has been reached, so mark transactions as complete
+            if (bus->curSegment->negateCS) {
+                bus->csLockDevice = (extDevice_t *)NULL;
+             } else {
+                bus->csLockDevice = (extDevice_t *)dev;
+            }
             bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
         }
     } else {
@@ -760,6 +763,11 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments)
             // Safe to discard the volatile qualifier as we're in an atomic block
             busSegment_t *endCmpSegment = (busSegment_t *)bus->curSegment;
 
+            /* It is possible that the endCmpSegment may be NULL as the bus is held busy by csLockDevice.
+             * If this is the case this transfer will be silently dropped. Therefore holding CS low after a transfer,
+             * as is done with the SD card, MUST not be done on a bus where interrupts may trigger a transfer
+             * on an idle bus, such as would be the case with a gyro. This would be result in skipped gyro transfers.
+             */
             if (endCmpSegment) {
                 while (true) {
                     // Find the last segment of the current transfer
@@ -781,11 +789,11 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments)
                         endCmpSegment = (busSegment_t *)endCmpSegment->u.link.segments;
                     }
                 }
-            }
 
-            // Record the dev and segments parameters in the terminating segment entry
-            endCmpSegment->u.link.dev = dev;
-            endCmpSegment->u.link.segments = segments;
+                // Record the dev and segments parameters in the terminating segment entry
+                endCmpSegment->u.link.dev = dev;
+                endCmpSegment->u.link.segments = segments;
+            }
 
             return;
         } else {

--- a/src/main/drivers/stm32/bus_spi_ll.c
+++ b/src/main/drivers/stm32/bus_spi_ll.c
@@ -377,13 +377,11 @@ void spiInternalStartDMA(const extDevice_t *dev)
         LL_DMA_Init(dmaTx->dma, dmaTx->stream, bus->initTx);
         LL_DMA_Init(dmaRx->dma, dmaRx->stream, bus->initRx);
 
-        LL_SPI_EnableDMAReq_RX(dev->bus->busType_u.spi.instance);
-
         // Enable channels
         LL_DMA_EnableChannel(dmaTx->dma, dmaTx->stream);
         LL_DMA_EnableChannel(dmaRx->dma, dmaRx->stream);
 
-        LL_SPI_EnableDMAReq_TX(dev->bus->busType_u.spi.instance);
+        SET_BIT(dev->bus->busType_u.spi.instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
 #else
         DMA_Stream_TypeDef *streamRegsTx = (DMA_Stream_TypeDef *)dmaTx->ref;
         DMA_Stream_TypeDef *streamRegsRx = (DMA_Stream_TypeDef *)dmaRx->ref;


### PR DESCRIPTION
May fix https://github.com/betaflight/betaflight/issues/12583.

This PR checks if CS is asserted between transfers and then consider the SPI bus to be busy for all but the device which asserted CS.