### PR TITLE
Add missing LUXF4OSD flash define

### DIFF
--- a/src/config/LUXF4OSD/config.h
+++ b/src/config/LUXF4OSD/config.h
@@ -33,6 +33,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_ACC_SPI_MPU6000
 #define USE_MAX7456
+#define USE_FLASH
 #define USE_FLASH_W25Q128FV
 
 #define BEEPER_PIN           PB4

--- a/src/config/LUXF4OSD/config.h
+++ b/src/config/LUXF4OSD/config.h
@@ -33,6 +33,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_ACC_SPI_MPU6000
 #define USE_MAX7456
+#define USE_FLASH_W25Q128FV
 
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB0


### PR DESCRIPTION
Adds missing flash define for blackbox on this target. Confirmed working in support channel on BF Discord: https://discord.com/channels/868013470023548938/924169080045445120/1092145727473459220

See also: https://github.com/betaflight/unified-targets/pull/972

