### PR TITLE
update pid.c PG to 7

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -119,7 +119,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 6);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 7);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {


### PR DESCRIPTION
In the last Angle and Horizon update, the pid profile PG was left at 6 even though new fields were added.
It should have been updated to 7.
This causes issues on saving changes in OSD.