### PR TITLE
Fix PG initialization of DMA defaults for TIMUP configuration

### DIFF
--- a/src/main/pg/timerup.c
+++ b/src/main/pg/timerup.c
@@ -55,5 +55,35 @@ void pgResetFn_timerUpConfig(timerUpConfig_t *config)
 #if defined(TIMUP8_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 7)
     config[7].dmaopt = TIMUP8_DMA_OPT;
 #endif
+#if defined(TIMUP9_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 8)
+    config[8].dmaopt = TIMUP9_DMA_OPT;
+#endif
+#if defined(TIMUP10_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 9)
+    config[9].dmaopt = TIMUP10_DMA_OPT;
+#endif
+#if defined(TIMUP11_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 10)
+    config[10].dmaopt = TIMUP11_DMA_OPT;
+#endif
+#if defined(TIMUP12_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 11)
+    config[11].dmaopt = TIMUP12_DMA_OPT;
+#endif
+#if defined(TIMUP13_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 12)
+    config[12].dmaopt = TIMUP13_DMA_OPT;
+#endif
+#if defined(TIMUP14_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 13)
+    config[13].dmaopt = TIMUP14_DMA_OPT;
+#endif
+#if defined(TIMUP15_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 14)
+    config[14].dmaopt = TIMUP15_DMA_OPT;
+#endif
+#if defined(TIMUP16_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 15)
+    config[15].dmaopt = TIMUP16_DMA_OPT;
+#endif
+#if defined(TIMUP17_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 16)
+    config[16].dmaopt = TIMUP17_DMA_OPT;
+#endif
+#if defined(TIMUP20_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 19)
+    config[19].dmaopt = TIMUP20_DMA_OPT;
+#endif
 }
 #endif

--- a/src/main/pg/timerup.c
+++ b/src/main/pg/timerup.c
@@ -37,22 +37,22 @@ void pgResetFn_timerUpConfig(timerUpConfig_t *config)
         config[timno].dmaopt = DMA_OPT_UNUSED;
     }
 
-#if defined(TIMUP1_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 1)
+#if defined(TIMUP1_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 0)
     config[0].dmaopt = TIMUP1_DMA_OPT;
 #endif
-#if defined(TIMUP2_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 2)
+#if defined(TIMUP2_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 1)
     config[1].dmaopt = TIMUP2_DMA_OPT;
 #endif
-#if defined(TIMUP3_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 3)
+#if defined(TIMUP3_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 2)
     config[2].dmaopt = TIMUP3_DMA_OPT;
 #endif
-#if defined(TIMUP4_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 4)
+#if defined(TIMUP4_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 3)
     config[3].dmaopt = TIMUP4_DMA_OPT;
 #endif
-#if defined(TIMUP5_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 5)
+#if defined(TIMUP5_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 4)
     config[4].dmaopt = TIMUP5_DMA_OPT;
 #endif
-#if defined(TIMUP8_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 8)
+#if defined(TIMUP8_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 7)
     config[7].dmaopt = TIMUP8_DMA_OPT;
 #endif
 }

--- a/src/main/pg/timerup.c
+++ b/src/main/pg/timerup.c
@@ -36,5 +36,24 @@ void pgResetFn_timerUpConfig(timerUpConfig_t *config)
     for (unsigned timno = 0; timno < HARDWARE_TIMER_DEFINITION_COUNT; timno++) {
         config[timno].dmaopt = DMA_OPT_UNUSED;
     }
+
+#if defined(TIMUP1_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 1)
+    config[0].dmaopt = TIMUP1_DMA_OPT;
+#endif
+#if defined(TIMUP2_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 2)
+    config[1].dmaopt = TIMUP2_DMA_OPT;
+#endif
+#if defined(TIMUP3_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 3)
+    config[2].dmaopt = TIMUP3_DMA_OPT;
+#endif
+#if defined(TIMUP4_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 4)
+    config[3].dmaopt = TIMUP4_DMA_OPT;
+#endif
+#if defined(TIMUP5_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 5)
+    config[4].dmaopt = TIMUP5_DMA_OPT;
+#endif
+#if defined(TIMUP8_DMA_OPT) && (HARDWARE_TIMER_DEFINITION_COUNT > 8)
+    config[7].dmaopt = TIMUP8_DMA_OPT;
+#endif
 }
 #endif


### PR DESCRIPTION
With the removal of timerHardware configuration, the TIMUP dma was not being defaulted in the PG initialisation.