### PR TITLE
CONFIG: Fix TMotor F7 BMP280 baro

### DIFF
--- a/src/config/TMOTORF7/config.h
+++ b/src/config/TMOTORF7/config.h
@@ -36,7 +36,7 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_ACC_SPI_MPU6500
 #define USE_BARO
-#define USE_BARO_SPI_BM280
+#define USE_BARO_SPI_BMP280
 #define USE_FLASH
 #define USE_FLASH_M25P16
 


### PR DESCRIPTION
Fixes define that caused BMP280 barometer not working over SPI on T-Motor F7 flight controller.

Tested on hardware. 