### PR TITLE
Position: Remove 15 m/s limit on estimated vario

### DIFF
--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -198,7 +198,6 @@ void calculateEstimatedAltitude(void)
 #ifdef USE_VARIO
     estimatedVario = lrintf(zeroedAltitudeDerivative);
     estimatedVario = applyDeadband(estimatedVario, 10); // ignore climb rates less than 0.1 m/s
-    estimatedVario = constrain(estimatedVario, -1500, 1500);
 #endif
  
     // *** set debugs


### PR DESCRIPTION
The estimated vario is currently limited to +/- 15 m/s. I have a report from a pilot who likes to dive mountains who has the vario shown in the OSD not going over 15 m/s.

It is not clear to me why the 15 m/s limit is needed and this removes the limit. Alternatively, the limit could also be increased to allow for higher vertical velocities.