### PR TITLE
[CONFIG] ESCSERIAL for mambaf405us_i2c.

### DIFF
--- a/src/config/MAMBAF405US_I2C/config.h
+++ b/src/config/MAMBAF405US_I2C/config.h
@@ -111,6 +111,7 @@
 #define ADC3_DMA_OPT        0
 
 #define INVERTER_PIN_UART1   PC0
+#define ESCSERIAL_PIN        PB9
 #define PINIO1_PIN           PB0
 
 #define USE_BARO


### PR DESCRIPTION
Enable "escprog" CLI command for MAMBAF405US_I2C. Works as expected. Tested with ESCape32 esc firmware (https://github.com/neoxic/ESCape32).

Originally started here: https://github.com/betaflight/unified-targets/pull/988