### PR TITLE
Add a feedforward unit test in rc.c

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -488,7 +488,7 @@ NOINLINE void initAveraging(uint16_t feedforwardAveraging)
     }
 }
 
-FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
+STATIC_UNIT_TESTED FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
 {
     const float rxInterval = currentRxIntervalUs * 1e-6f; // seconds
     float rxRate = currentRxRateHz;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -533,7 +533,7 @@ ifeq ($(shell $(CC) -v 2>&1 | grep -q "clang version" && echo "clang"),clang)
 # Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 14 }
 # Travis reports CC_VERSION of 4.2.1
 CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
-CC_VERSION_CHECK_MIN := 7
+CC_VERSION_CHECK_MIN := 4
 CC_VERSION_CHECK_MAX := 14
 
 # Added flags for clang 11 - 13 are not backwards compatible

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -391,6 +391,26 @@ pid_unittest_DEFINES := \
 		USE_LAUNCH_CONTROL= \
 		USE_FEEDFORWARD=
 
+rc_unittest_SRC :=  \
+		$(USER_DIR)/common/crc.c \
+		$(USER_DIR)/common/filter.c \
+		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/streambuf.c \
+		$(USER_DIR)/drivers/accgyro/gyro_sync.c \
+		$(USER_DIR)/fc/controlrate_profile.c \
+		$(USER_DIR)/fc/rc.c \
+		$(USER_DIR)/fc/runtime_config.c \
+		$(USER_DIR)/flight/pid.c \
+		$(USER_DIR)/flight/pid_init.c \
+		$(USER_DIR)/pg/pg.c
+
+rc_unittest_DEFINES := \
+		USE_ITERM_RELAX= \
+		USE_RC_SMOOTHING_FILTER= \
+		USE_ABSOLUTE_CONTROL= \
+		USE_LAUNCH_CONTROL= \
+		USE_FEEDFORWARD=
+
 rcdevice_unittest_DEFINES := \
 		USE_RCDEVICE=
 

--- a/src/test/unit/rc_unittest.cc
+++ b/src/test/unit/rc_unittest.cc
@@ -1,0 +1,166 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <cmath>
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+#include "build/debug.h"
+
+// fake pid returns
+float simulatedRawSetpoint[3] = { 0,0,0 };
+float simulatedSetpointRate[3] = { 0,0,0 };
+float simulatedRcDeflection[3] = { 0,0,0 };
+float simulatedMaxRate[3] = { 670,670,670 };
+float simulatedGetFeedforward[3] = { 0,0,0};
+float feedforward = 0.0f;
+
+int16_t debug[DEBUG16_VALUE_COUNT];
+uint8_t debugMode;
+
+// pid requirements
+float simulatedMotorMixRange = 0.0f;
+
+bool simulatedAirmodeEnabled = true;
+
+extern "C" {
+    #include "platform.h"
+
+    #include "build/debug.h"
+
+    #include "common/axis.h"
+    #include "common/maths.h"
+    #include "common/filter.h"
+
+    #include "config/config.h"
+    #include "config/config_reset.h"
+
+    #include "drivers/sound_beeper.h"
+    #include "drivers/time.h"
+
+    #include "fc/controlrate_profile.h"
+    #include "fc/core.h"
+    #include "fc/rc.h"
+
+    #include "fc/rc_controls.h"
+    #include "fc/runtime_config.h"
+
+    #include "flight/imu.h"
+    #include "flight/mixer.h"
+    #include "flight/pid.h"
+    #include "flight/pid_init.h"
+
+    #include "io/gps.h"
+
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+
+    #include "sensors/gyro.h"
+    #include "sensors/acceleration.h"
+
+    gyro_t gyro;
+    attitudeEulerAngles_t attitude;
+
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+    PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);
+
+    // pid requirements
+    bool unitLaunchControlActive = false;
+    bool isAirmodeActivated(void) { return simulatedAirmodeEnabled; }
+    bool isLaunchControlActive(void) {return unitLaunchControlActive; }
+    launchControlMode_e unitLaunchControlMode = LAUNCH_CONTROL_MODE_NORMAL;
+    bool gyroOverflowDetected(void) { return false; }
+    float getSetpointRate(int axis) { return simulatedSetpointRate[axis]; }
+    float getRcDeflection(int axis) { return simulatedRcDeflection[axis]; }
+    float getMotorMixRange(void) { return simulatedMotorMixRange; }
+    float getFeedforward(int axis)
+    {
+        UNUSED(axis);
+        return simulatedGetFeedforward[axis];
+    }
+    float getMaxRcRate(int axis)
+    {
+        UNUSED(axis);
+        return simulatedMaxRate[axis];
+    }
+
+    void systemBeep(bool) { }
+    void beeperConfirmationBeeps(uint8_t) { }
+    void disarm(flightLogDisarmReason_e) { }
+
+    void initRcProcessing(void) { }
+}
+
+pidProfile_t *pidProfile;
+pidRuntime_t pidRuntime;
+
+int loopIter = 0;
+
+timeUs_t currentTestTime(void)
+{
+    return targetPidLooptime * loopIter++;
+}
+
+void resetTest(void)
+{
+    loopIter = 0;
+
+    for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
+        pidData[axis].P = 0;
+        pidData[axis].I = 0;
+        pidData[axis].D = 0;
+        pidData[axis].F = 120;
+        pidData[axis].Sum = 0;
+        gyro.gyroADCf[axis] = 0;
+    }
+
+    attitude.values.roll = 0;
+    attitude.values.pitch = 0;
+    attitude.values.yaw = 0;
+
+    flightModeFlags = 0;
+    loadControlRateProfile();
+}
+
+// All calculations will have 10% tolerance
+float calculateTolerance(float input)
+{
+    return fabsf(input * 0.1f);
+}
+
+
+// *******  do the feedforward tests here ***********
+TEST(rcUnitTest, testFeedForward)
+
+{
+    resetTest();
+    ENABLE_ARMING_FLAG(ARMED);
+    pidStabilisationState(PID_STABILISATION_ON);
+
+    calculateFeedforward(&pidRuntime, FD_ROLL); // **** FAILS !! *******
+
+
+    EXPECT_NEAR(0.1, feedforward, calculateTolerance(0.1));
+
+    // typical tests
+    // EXPECT_NEAR(-3.6, itermErrorRate, calculateTolerance(-3.6));
+    // EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].F);
+    // EXPECT_EQ(0, ALIGNMENT_YAW_ROTATIONS(bits));
+}

--- a/src/test/unit/rc_unittest.cc
+++ b/src/test/unit/rc_unittest.cc
@@ -1,18 +1,22 @@
 /*
- * This file is part of Cleanflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight is distributed in the hope that it will be useful,
+ * Betaflight is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * You should have received a copy of the GNU General Public License
- * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdint.h>
@@ -29,7 +33,7 @@ float simulatedRawSetpoint[3] = { 0,0,0 };
 float simulatedSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
 float simulatedMaxRate[3] = { 670,670,670 };
-float simulatedGetFeedforward[3] = { 0,0,0};
+float simulatedGetFeedforward[3] = { 0,0,0 };
 float feedforward = 0.0f;
 
 int16_t debug[DEBUG16_VALUE_COUNT];
@@ -145,7 +149,6 @@ float calculateTolerance(float input)
     return fabsf(input * 0.1f);
 }
 
-
 // *******  do the feedforward tests here ***********
 TEST(rcUnitTest, testFeedForward)
 
@@ -155,7 +158,6 @@ TEST(rcUnitTest, testFeedForward)
     pidStabilisationState(PID_STABILISATION_ON);
 
     calculateFeedforward(&pidRuntime, FD_ROLL); // **** FAILS !! *******
-
 
     EXPECT_NEAR(0.1, feedforward, calculateTolerance(0.1));
 


### PR DESCRIPTION
The previous feedforward unit test, which was part of the `pid_unittest`, only tested the pid 'F' value from a given setpointDelta value.  Basically it just multiplied that value by the feedforward gain.  It included a copy of the transition code, but didn't test the transition code in the firmware.  Most importantly, it didn't test how the feedforward code returned the new setpointDelta value - the boost, jitter reduction, feedforward smoothing and other aspects of feedforward.c were not tested at all.

Since #12605 the main feedforward code is now located within rc.c.  That PR includes limited pid feedforward unit testing, but doesn't properly test feedforward itself.

This PR is a 'work in progress' to build a unit test for the feedforward calculations in rc.c.

I would greatly appreciate any advice to would help get it done, since I don't have any experience with unit tests.

At present this proposed unit test fails with this error:

```
unit/rc_unittest.cc:157:5: error: use of undeclared identifier 'calculateFeedforward'
```
What is required to fix it?
