### PR TITLE
Thrust linear code optimisations

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -335,12 +335,7 @@ float pidCompensateThrustLinearization(float throttle)
 
 float pidApplyThrustLinearization(float motorOutput)
 {
-    if (pidRuntime.thrustLinearization != 0.0f) {
-        if (motorOutput > 0.0f) {
-            const float motorOutputReversed = (1.0f - motorOutput);
-            motorOutput *= 1.0f + sq(motorOutputReversed) * pidRuntime.thrustLinearization;
-        }
-    }
+    motorOutput *= 1.0f + pidRuntime.thrustLinearization * sq(1.0f - motorOutput);
     return motorOutput;
 }
 #endif


### PR DESCRIPTION
Simple PR to remove two unnecessary conditions on the thrust linear calculation, saving about 25 cycles per iteration, when the thrust linear setting is non-zero.  

When thrust linear is zero, the code uses just one cycle in both cases.

Since this calculation is per-motor, the overall saving is 100 cycles per PID loop.