### PR TITLE
TPA optimisations

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1223,7 +1223,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_MODE,          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_TPA_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_mode) },
 #endif
     { PARAM_NAME_TPA_RATE,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_MAX}, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_rate) },
-    { PARAM_NAME_TPA_BREAKPOINT,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 1000, 1990 }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_breakpoint) },
+    { PARAM_NAME_TPA_BREAKPOINT,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PWM_RANGE_MIN, PWM_RANGE_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_breakpoint) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1223,7 +1223,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_MODE,          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_TPA_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_mode) },
 #endif
     { PARAM_NAME_TPA_RATE,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_MAX}, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_rate) },
-    { PARAM_NAME_TPA_BREAKPOINT,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_breakpoint) },
+    { PARAM_NAME_TPA_BREAKPOINT,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 1000, 1990 }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_breakpoint) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -277,10 +277,9 @@ void pidResetIterm(void)
 
 void pidUpdateTpaFactor(float throttle)
 {
-    pidRuntime.tpaFactor = 1.0f;
     const float throttleTemp = fminf(throttle, 1.0f); // don't permit throttle > 1 ? is this needed ? can throttle be > 1 at this point ?
     const float throttleDifference = fmaxf(throttleTemp - pidRuntime.tpaBreakpoint, 0.0f);
-    pidRuntime.tpaFactor -= throttleDifference * pidRuntime.tpaMultiplier;
+    pidRuntime.tpaFactor = 1.0f - throttleDifference * pidRuntime.tpaMultiplier;
 }
 
 void pidUpdateAntiGravityThrottleFilter(float throttle)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -907,7 +907,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
                     maxAngleTargetAbs *= (FLIGHT_MODE(HORIZON_MODE)) ? horizonLevelStrength : 1.0f;
                     // reduce compensation whenever Horizon uses less levelling
                     currentPidSetpoint *= cos_approx(DEGREES_TO_RADIANS(maxAngleTargetAbs));
-                    // DEBUG_SET(DEBUG_ANGLE_TARGET, 2, currentPidSetpoint); // yaw setpoint after attenuation
+                    DEBUG_SET(DEBUG_ANGLE_TARGET, 2, currentPidSetpoint); // yaw setpoint after attenuation
                 }
             }
         }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -322,6 +322,8 @@ typedef struct pidRuntime_s {
     bool zeroThrottleItermReset;
     bool levelRaceMode;
     float tpaFactor;
+    float tpaBreakpoint;
+    float tpaMultiplier;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -423,8 +423,9 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;
-    pidRuntime.tpaBreakpoint = (pidProfile->tpa_breakpoint - 1000) * 0.001f; // .35 from 1350, range can be 0 to 0.99, limited by CLI range
-    pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint); // tpaBreakpoint must not be 1.0 to avoid div by zero
+    pidRuntime.tpaBreakpoint = (pidProfile->tpa_breakpoint - PWM_RANGE_MIN) * 0.001f; // .35 from 1350, range can be 0 to 0.99, limited by CLI range
+    pidRuntime.tpaBreakpoint = constrainf(pidRuntime.tpaBreakpoint, 0.0f, 0.99f); // limit range to 0 to 0.99
+    pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -40,6 +40,8 @@
 #include "flight/pid.h"
 #include "flight/rpm_filter.h"
 
+#include "rx/rx.h"
+
 #include "sensors/gyro.h"
 #include "sensors/sensors.h"
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -425,8 +425,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;
-    pidRuntime.tpaBreakpoint = (pidProfile->tpa_breakpoint - PWM_RANGE_MIN) * 0.001f; // .35 from 1350, range can be 0 to 0.99, limited by CLI range
-    pidRuntime.tpaBreakpoint = constrainf(pidRuntime.tpaBreakpoint, 0.0f, 0.99f); // limit range to 0 to 0.99
+    pidRuntime.tpaBreakpoint = constrainf((pidProfile->tpa_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, 0.99f);
+    // default of 1350 returns 0.35. range limited to 0 to 0.99
     pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
 }
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -423,6 +423,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;
+    pidRuntime.tpaBreakpoint = (pidProfile->tpa_breakpoint - 1000) * 0.001f; // .35 from 1350, range can be 0 to 0.99, limited by CLI range
+    pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint); // tpaBreakpoint must not be 1.0 to avoid div by zero
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)


### PR DESCRIPTION
Code optimisation for the TPA calculation.

Master code requires 26 cycles while throttle < TPA breakpoint, and 63 cycles while sticks are above breakpoint.

This PR reduces that to only 8 cycles, regardless of the throttle position, and returns the same result.  This is achieved by doing most of the computation in pid_init.c and avoiding conditional statements.

I'm not sure that throttle can be > 1.0 at this point in the code, but kept that check in place, just in case, since if it was > 1.0 then P and D could be pushed higher than intended.