### PR TITLE
Fix GYRO_1_EXTI_PIN definition

### DIFF
--- a/src/config/NEUTRONRCF435/config.h
+++ b/src/config/NEUTRONRCF435/config.h
@@ -19,7 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define FC_TARGET_MCU     AT32F435G
+#define FC_TARGET_MCU     AT32F435M
 
 #define BOARD_NAME        NEUTRONRCF435
 #define MANUFACTURER_ID   NERC
@@ -33,10 +33,10 @@
 #define GYRO_1_SPI_INSTANCE  SPI1
 #define GYRO_1_ALIGN         CW270_DEG
 
-// MPU6000 interrupts
+// Gyro interrupts
 #define USE_EXTI
 #define USE_GYRO_EXTI
-#define GYRO_1_EXTI_PIN      PB8
+#define GYRO_1_EXTI_PIN      PA8
 
 #define SPI1_SCK_PIN         PA5
 #define SPI2_SCK_PIN         PB13


### PR DESCRIPTION
Fix EXTI definition for gyro to match schematics. Gyro now shows as locked.

```
# status
MCU AT32F435 Clock=288MHz, Vref=3.27V, Core temp=48degC
Stack size: 2048, Stack address: 0x2002fff0
Configuration: CONFIGURED, size: 3528, max available: 16384
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1 locked dma
GYRO=BMI270, ACC=BMI270, BARO=DPS310
```