### PR TITLE
Lead-Lag Compensator

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1142,7 +1142,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_HORIZON_LIMIT_STICKS,   VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, pid[PID_LEVEL].D) },
     { PARAM_NAME_HORIZON_LIMIT_DEGREES,  VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10,  250 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_limit_degrees) },
     { PARAM_NAME_HORIZON_IGNORE_STICKS,  VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_ignore_sticks) },
-    { PARAM_NAME_HORIZON_DELAY_MS,       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 10,  5000 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_delay_ms) }, 
+    { PARAM_NAME_HORIZON_DELAY_MS,       VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 10,  5000 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_delay_ms) },
 
 #if defined(USE_ABSOLUTE_CONTROL)
     { PARAM_NAME_ABS_CONTROL_GAIN,  VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 20 }, PG_PID_PROFILE, offsetof(pidProfile_t, abs_control_gain) },

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -25,6 +25,20 @@
 
 struct filter_s;
 typedef struct filter_s filter_t;
+typedef float (*filterApplyFnPtr)(filter_t *filter, float input);
+
+typedef enum {
+    FILTER_PT1 = 0,
+    FILTER_BIQUAD,
+    FILTER_PT2,
+    FILTER_PT3,
+} lowpassFilterType_e;
+
+typedef enum {
+    FILTER_LPF,    // 2nd order Butterworth section
+    FILTER_NOTCH,
+    FILTER_BPF,
+} biquadFilterType_e;
 
 typedef struct pt1Filter_s {
     float state;
@@ -44,12 +58,6 @@ typedef struct pt3Filter_s {
     float k;
 } pt3Filter_t;
 
-typedef struct slewFilter_s {
-    float state;
-    float slewLimit;
-    float threshold;
-} slewFilter_t;
-
 /* this holds the data required to update samples thru a filter */
 typedef struct biquadFilter_s {
     float b0, b1, b2, a1, a2;
@@ -62,6 +70,12 @@ typedef struct phaseComp_s {
     float x1, y1;
 } phaseComp_t;
 
+typedef struct slewFilter_s {
+    float state;
+    float slewLimit;
+    float threshold;
+} slewFilter_t;
+
 typedef struct laggedMovingAverage_s {
     uint16_t movingWindowIndex;
     uint16_t windowSize;
@@ -70,39 +84,18 @@ typedef struct laggedMovingAverage_s {
     bool primed;
 } laggedMovingAverage_t;
 
-typedef enum {
-    FILTER_PT1 = 0,
-    FILTER_BIQUAD,
-    FILTER_PT2,
-    FILTER_PT3,
-} lowpassFilterType_e;
+typedef struct simpleLowpassFilter_s {
+    int32_t fp;
+    int32_t beta;
+    int32_t fpShift;
+} simpleLowpassFilter_t;
 
-typedef enum {
-    FILTER_LPF,    // 2nd order Butterworth section
-    FILTER_NOTCH,
-    FILTER_BPF,
-} biquadFilterType_e;
-
-typedef float (*filterApplyFnPtr)(filter_t *filter, float input);
+typedef struct meanAccumulator_s {
+    int32_t accumulator;
+    int32_t count;
+} meanAccumulator_t;
 
 float nullFilterApply(filter_t *filter, float input);
-
-void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
-void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight);
-void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight);
-void biquadFilterUpdateLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
-
-float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
-float biquadFilterApplyDF1Weighted(biquadFilter_t *filter, float input);
-float biquadFilterApply(biquadFilter_t *filter, float input);
-float filterGetNotchQ(float centerFreq, float cutoffFreq);
-
-void phaseCompInit(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
-void phaseCompUpdate(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
-float phaseCompApply(phaseComp_t *filter, const float input);
-
-void laggedMovingAverageInit(laggedMovingAverage_t *filter, uint16_t windowSize, float *buf);
-float laggedMovingAverageUpdate(laggedMovingAverage_t *filter, float input);
 
 float pt1FilterGain(float f_cut, float dT);
 void pt1FilterInit(pt1Filter_t *filter, float k);
@@ -119,23 +112,29 @@ void pt3FilterInit(pt3Filter_t *filter, float k);
 void pt3FilterUpdateCutoff(pt3Filter_t *filter, float k);
 float pt3FilterApply(pt3Filter_t *filter, float input);
 
+float filterGetNotchQ(float centerFreq, float cutoffFreq);
+
+void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
+void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight);
+void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight);
+void biquadFilterUpdateLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
+float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
+float biquadFilterApplyDF1Weighted(biquadFilter_t *filter, float input);
+float biquadFilterApply(biquadFilter_t *filter, float input);
+
+void phaseCompInit(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
+void phaseCompUpdate(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
+float phaseCompApply(phaseComp_t *filter, const float input);
+
 void slewFilterInit(slewFilter_t *filter, float slewLimit, float threshold);
 float slewFilterApply(slewFilter_t *filter, float input);
 
-typedef struct simpleLowpassFilter_s {
-    int32_t fp;
-    int32_t beta;
-    int32_t fpShift;
-} simpleLowpassFilter_t;
+void laggedMovingAverageInit(laggedMovingAverage_t *filter, uint16_t windowSize, float *buf);
+float laggedMovingAverageUpdate(laggedMovingAverage_t *filter, float input);
 
-int32_t simpleLPFilterUpdate(simpleLowpassFilter_t *filter, int32_t newVal);
 void simpleLPFilterInit(simpleLowpassFilter_t *filter, int32_t beta, int32_t fpShift);
+int32_t simpleLPFilterUpdate(simpleLowpassFilter_t *filter, int32_t newVal);
 
-typedef struct meanAccumulator_s {
-    int32_t accumulator;
-    int32_t count;
-} meanAccumulator_t;
-
+void meanAccumulatorInit(meanAccumulator_t *filter);
 void meanAccumulatorAdd(meanAccumulator_t *filter, const int8_t newVal);
 int8_t meanAccumulatorCalc(meanAccumulator_t *filter, const int8_t defaultValue);
-void meanAccumulatorInit(meanAccumulator_t *filter);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -19,7 +19,9 @@
  */
 
 #pragma once
+
 #include <stdbool.h>
+#include <stdint.h>
 
 struct filter_s;
 typedef struct filter_s filter_t;
@@ -55,6 +57,11 @@ typedef struct biquadFilter_s {
     float weight;
 } biquadFilter_t;
 
+typedef struct phaseComp_s {
+    float b0, b1, a1;
+    float x1, y1;
+} phaseComp_t;
+
 typedef struct laggedMovingAverage_s {
     uint16_t movingWindowIndex;
     uint16_t windowSize;
@@ -89,6 +96,10 @@ float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
 float biquadFilterApplyDF1Weighted(biquadFilter_t *filter, float input);
 float biquadFilterApply(biquadFilter_t *filter, float input);
 float filterGetNotchQ(float centerFreq, float cutoffFreq);
+
+void phaseCompInit(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
+void phaseCompUpdate(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
+float phaseCompApply(phaseComp_t *filter, const float input);
 
 void laggedMovingAverageInit(laggedMovingAverage_t *filter, uint16_t windowSize, float *buf);
 float laggedMovingAverageUpdate(laggedMovingAverage_t *filter, float input);

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -123,7 +123,7 @@ typedef struct dynNotch_s {
 
     int maxCenterFreq;
     float centerFreq[XYZ_AXIS_COUNT][DYN_NOTCH_COUNT_MAX];
-    
+
     timeUs_t looptimeUs;
     biquadFilter_t notch[XYZ_AXIS_COUNT][DYN_NOTCH_COUNT_MAX];
 
@@ -261,11 +261,11 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
     DEBUG_SET(DEBUG_FFT_TIME, 0, state.step);
 
     switch (state.step) {
-    
+
         case STEP_WINDOW: // 4.1us (3-6us) @ F722
         {
             sdftWinSq(&sdft[state.axis], sdftData);
-            
+
             // Get total vibrational power in dyn notch range for noise floor estimate in STEP_CALC_FREQUENCIES
             sdftNoiseThreshold = 0.0f;
             for (int bin = sdftStartBin; bin <= sdftEndBin; bin++) {
@@ -359,7 +359,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
                     // Convert bin to frequency: freq = bin * binResoultion (bin 0 is 0Hz)
                     const float centerFreq = constrainf(meanBin * sdftResolutionHz, dynNotch.minHz, dynNotch.maxHz);
 
-                    // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 10x faster 
+                    // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 10x faster
                     const float cutoffMult = constrainf(peaks[p].value / sdftNoiseThreshold, 1.0f, 10.0f);
                     const float gain = pt1FilterGain(DYN_NOTCH_SMOOTH_HZ * cutoffMult, pt1LooptimeS); // dynamic PT1 k value
 
@@ -403,7 +403,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
     state.step = (state.step + 1) % STEP_COUNT;
 }
 
-FAST_CODE float dynNotchFilter(const int axis, float value) 
+FAST_CODE float dynNotchFilter(const int axis, float value)
 {
     for (int p = 0; p < dynNotch.count; p++) {
         value = biquadFilterApplyDF1(&dynNotch.notch[axis][p], value);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -91,7 +91,7 @@ pt1Filter_t throttleLpf;
 PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
 
 #if !defined(DEFAULT_PID_PROCESS_DENOM)
-#if defined(STM32F411xE) 
+#if defined(STM32F411xE)
 #define DEFAULT_PID_PROCESS_DENOM       2
 #else
 #define DEFAULT_PID_PROCESS_DENOM       1
@@ -298,7 +298,7 @@ void pidUpdateAntiGravityThrottleFilter(float throttle)
     static float previousThrottle = 0.0f;
     const float throttleInv = 1.0f - throttle;
     float throttleDerivative = fabsf(throttle - previousThrottle) * pidRuntime.pidFrequency;
-    DEBUG_SET(DEBUG_ANTI_GRAVITY, 0, lrintf(throttleDerivative * 100)); 
+    DEBUG_SET(DEBUG_ANTI_GRAVITY, 0, lrintf(throttleDerivative * 100));
     throttleDerivative *= throttleInv * throttleInv;
     // generally focus on the low throttle period
     if (throttle > previousThrottle) {
@@ -310,7 +310,7 @@ void pidUpdateAntiGravityThrottleFilter(float throttle)
     // lower cutoff suppresses peaks relative to troughs and prolongs the effects
     // PT2 smoothing of throttle derivative.
     // 6 is a typical value for the peak boost factor with default cutoff of 6Hz
-    DEBUG_SET(DEBUG_ANTI_GRAVITY, 1, lrintf(throttleDerivative * 100)); 
+    DEBUG_SET(DEBUG_ANTI_GRAVITY, 1, lrintf(throttleDerivative * 100));
     pidRuntime.antiGravityThrottleD = throttleDerivative;
 }
 
@@ -911,7 +911,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             if (levelMode == LEVEL_MODE_RP) {
                 // if earth referencing is requested, attenuate yaw axis setpoint when pitched or rolled
                 // and send yawSetpoint to Angle code to modulate pitch and roll
-                // code cost is 107 cycles when earthRef enabled, 20 otherwise, nearly all in cos_approx 
+                // code cost is 107 cycles when earthRef enabled, 20 otherwise, nearly all in cos_approx
                 if (pidRuntime.angleEarthRef) {
                     pidRuntime.angleYawSetpoint = currentPidSetpoint;
                     float maxAngleTargetAbs = pidRuntime.angleEarthRef * fmaxf( fabsf(pidRuntime.angleTarget[FD_ROLL]), fabsf(pidRuntime.angleTarget[FD_PITCH]) );

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -432,4 +432,3 @@ void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)
         memcpy(pidProfilesMutable(dstPidProfileIndex), pidProfilesMutable(srcPidProfileIndex), sizeof(pidProfile_t));
     }
 }
-

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -108,7 +108,7 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyroMovementCalibrationThreshold = 48;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
     gyroConfig->gyro_lpf1_type = FILTER_PT1;
-    gyroConfig->gyro_lpf1_static_hz = GYRO_LPF1_DYN_MIN_HZ_DEFAULT;  
+    gyroConfig->gyro_lpf1_static_hz = GYRO_LPF1_DYN_MIN_HZ_DEFAULT;
         // NOTE: dynamic lpf is enabled by default so this setting is actually
         // overridden and the static lowpass 1 is disabled. We can't set this
         // value to 0 otherwise Configurator versions 10.4 and earlier will also


### PR DESCRIPTION
This PR implements a lead-lag compensator (LLC). LLC's are used to improve the frequency response of a system by pushing in or pulling out phase in a selected frequency range around the center frequency. This enables us to basically get rid of delay (or to introduce delay) at particular frequencies, selectively.

# Implementation Details

The LLC's transfer function can be expressed as
```
H(s) = (a*τ*s + 1) / (τ*s + 1)
```
with `a = (1 + sin(Φ)) / (1 - sin(Φ))` and `τ = 1 / (2 * π * centerFreq * sqrt(a))`

## Discretization

Applying the bilinear transform with frequency prewarping to discretize the LLC for digital signal applications yields the following coefficients:

- `b0 = 1 + a*τ*V`
- `b1 = 1 - a*τ*V`
- `a0 = 1 + τ*V`
- `a1 = 1 - τ*V`

with frequency prewarping `V = w / tan(w * Ts / 2)`. Because of the tangent, frequency prewarping is computationally intensive. We can approximate this by applying a series expansion at `w = 0` and stop after the second term. This is significantly more efficient to calculate but yields practically the same results up to half the nyquist frequency (= 0.25).

Therefore `V` gets simplified to
```
V = w / tan(w * Ts / 2) ≈ 2/Ts - Ts/6*w²
```
This ultimately leaves us with the implemented coefficients in this PR.

## Gain

Pulling out phase (negative phase values - lag compensator) attenuates high frequencies but pushing in phase (positive phase values - lead compensator) amplifies them. Positive phase values therefore always need to be handled with additional care. If the gain is too high due to a high positive phase shift, noise gets amplified significantly.

- `a < 1` - LLC attenuates noise - negative phase
- `a > 1` - LLC amplifies noise - positive phase

The maximum gain `a` can be calculated using
```
Φ = centerPhaseDeg * π / 180;
a = (1 + sin(Φ)) / (1 - sin(Φ))
```
In the example below (see bode plot), if we want to add +20° of phase shift, we get a gain of `a = 2.04`, which means if you apply this LLC to a signal, high frequencies (higher than the center frequency) get amplified by approx. 2 at max.

# Bode Plot

_Frequencies are normalized to the sample rate (sample rate = 1, nyquist limit = 0.5)_

#### Example:
- center frequency = 0.01 * sample rate
- center phase = 20°
![llc_bode](https://user-images.githubusercontent.com/19867640/234464072-05eac231-3ff5-4001-bcb2-63a66b8dd5c0.svg)
