### PR TITLE
Converge IMU faster at higher groundspeed during GPS Rescue

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -537,7 +537,7 @@ static void sensorUpdate(void)
 
     DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 2, lrintf(rescueState.sensor.currentAltitudeCm));
     DEBUG_SET(DEBUG_GPS_RESCUE_THROTTLE_PID, 2, lrintf(rescueState.sensor.currentAltitudeCm));
-//    DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 0, rescueState.sensor.groundSpeedCmS); // groundspeed cm/s
+    DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 0, rescueState.sensor.groundSpeedCmS); // groundspeed cm/s
     DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 1, gpsSol.groundCourse); // degrees * 10
     DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 2, attitude.values.yaw); // degrees * 10
     DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 3, rescueState.sensor.directionToHome); // degrees * 10
@@ -573,7 +573,7 @@ static void sensorUpdate(void)
     if (gpsRescueConfig()->rescueGroundspeed) {
         const float setGroundspeedInv = 1.0f / gpsRescueConfig()->rescueGroundspeed;
         float groundspeedErrorRatio = fabsf(rescueState.sensor.groundSpeedCmS - rescueState.sensor.velocityToHomeCmS) * setGroundspeedInv;
-        // zero if groundspeed = velocity to home,
+        // 0 if groundspeed = velocity to home,
         // 1 if flying sideways at target groundspeed but zero home velocity,
         // 2 if flying backwards at target groundspeed
         groundspeedErrorRatio = constrainf(1.0f + groundspeedErrorRatio, 1.0f, 5.0f);

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -571,9 +571,9 @@ static void sensorUpdate(void)
 
     // when there is significant velocity error, increase IMU COG Gain for yaw to a higher value, and reduce max pitch angle
     if (gpsRescueConfig()->rescueGroundspeed) {
-        const float rescueGroundspeedGain = 10.0f;
+        const float rescueGroundspeed = 1000.0f; // equivalent of fixed 10 m/s groundspeed
         // sets the slope of the increase in IMU COG Gain as velocity error increases; at 10, we get max CoG gain around 25m/s drift, approx the limit of what we can fix
-        const float groundspeedErrorRatio = fmaxf(0.0f, rescueState.sensor.groundSpeedCmS - rescueState.sensor.velocityToHomeCmS) / rescueGroundspeedGain;
+        const float groundspeedErrorRatio = fabsf(rescueState.sensor.groundSpeedCmS - rescueState.sensor.velocityToHomeCmS) / rescueGroundspeed;
         // 0 if groundspeed = velocity to home,
         // 1 if moving sideways at 10m/s but zero home velocity,
         // 2 if moving backwards (away from home) at 10 m/s
@@ -585,7 +585,7 @@ static void sensorUpdate(void)
             // up to 6x increase in CoG IMU Yaw gain
             rescueState.sensor.imuYawCogGain =  constrainf(1.0f + groundspeedErrorRatio, 1.0f, 6.0f);
         }
-        rescueState.sensor.groundspeedPitchAttenuator = 1.0f / constrainf(1.0f + groundspeedErrorRatio , 1.0f, 3.0f); // cut pitch angle by up to one third
+        rescueState.sensor.groundspeedPitchAttenuator = 1.0f / constrainf(1.0f + groundspeedErrorRatio, 1.0f, 3.0f); // cut pitch angle by up to one third
     }
 
     rescueState.sensor.gpsDataIntervalSeconds = getGpsDataIntervalSeconds();

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -571,7 +571,7 @@ static void sensorUpdate(void)
 
     // when there is significant velocity error, increase IMU COG Gain for yaw to a higher value, and reduce max pitch angle
     if (gpsRescueConfig()->rescueGroundspeed) {
-        const float rescueGroundspeed = 1000.0f; // equivalent of fixed 10 m/s groundspeed
+        const float rescueGroundspeed = 1000.0f; // in cm/s, fixed 10 m/s groundspeed
         // sets the slope of the increase in IMU COG Gain as velocity error increases; at 10, we get max CoG gain around 25m/s drift, approx the limit of what we can fix
         const float groundspeedErrorRatio = fabsf(rescueState.sensor.groundSpeedCmS - rescueState.sensor.velocityToHomeCmS) / rescueGroundspeed;
         // 0 if groundspeed = velocity to home,

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -576,10 +576,10 @@ static void sensorUpdate(void)
         // 0 if groundspeed = velocity to home,
         // 1 if moving sideways at target groundspeed but zero home velocity,
         // 2 if moving backwards (away from home) at target groundspeed
-        rescueState.sensor.groundspeedErrorRatio = constrainf(1.0f + groundspeedErrorRatio, 1.0f, 5.0f);
-        // start at 1, not 0, and limit to max 5
+        rescueState.sensor.dcm_kpModifier = constrainf(1.0f + groundspeedErrorRatio, 1.0f, 6.0f); // up to 6x dcm_kp increase
+        rescueState.sensor.groundspeedErrorRatio = fminf(rescueState.sensor.dcm_kpModifier, 3.0f); // cut pitch angle by up to one third
         const bool climbOrRotate = (rescueState.phase == RESCUE_ATTAIN_ALT) || (rescueState.phase == RESCUE_ROTATE);
-        rescueState.sensor.dcm_kpModifier = (climbOrRotate) ? 0.0f : rescueState.sensor.groundspeedErrorRatio;
+        rescueState.sensor.dcm_kpModifier = (climbOrRotate) ? 0.0f : rescueState.sensor.dcm_kpModifier;
         // zero dcm_kp during climb or rotate, to stop IMU error accumulation arising from drift during long climbs
     }
 

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -816,7 +816,7 @@ void gpsRescueUpdate(void)
 
         rescueState.intent.rollAngleLimitDeg = 0.5f * rescueState.intent.velocityItermRelax * gpsRescueConfig()->maxRescueAngle;
         // gradually gain roll capability to max of half of max pitch angle
- 
+
         if (newGPSData) {
             // cut back on allowed angle if there is a high groundspeed error
             rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle * rescueState.sensor.groundspeedPitchAttenuator;

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -669,7 +669,7 @@ void descend(void)
         rescueState.intent.targetVelocityCmS = gpsRescueConfig()->rescueGroundspeed * rescueState.intent.proximityToLandingArea;
         // reduce target velocity as we get closer to home. Zero within 2m of home, reducing risk of overshooting.
         // if quad drifts further than 2m away from home, should by then have rotated towards home, so pitch is allowed
-        rescueState.intent.rollAngleLimitDeg = gpsRescueConfig()->maxRescueAngle * rescueState.intent.proximityToLandingArea;
+        rescueState.intent.rollAngleLimitDeg = 0.5f * gpsRescueConfig()->maxRescueAngle * rescueState.intent.proximityToLandingArea;
         // reduce roll capability when closer to home, none within final 2m
         rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle * rescueState.sensor.groundspeedPitchAttenuator;
     }

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -456,7 +456,7 @@ static void performSanityChecks(void)
     if (rescueState.phase == RESCUE_FLY_HOME) {
         const float velocityToHomeCmS = previousDistanceToHomeCm - rescueState.sensor.distanceToHomeCm; // cm/s
         previousDistanceToHomeCm = rescueState.sensor.distanceToHomeCm;
-        rescueState.intent.secondsFailing += (velocityToHomeCmS < 0.5f * rescueState.intent.targetVelocityCmS) ? 1 : -1;
+        rescueState.intent.secondsFailing += (velocityToHomeCmS < 0.1f * rescueState.intent.targetVelocityCmS) ? 1 : -1;
         rescueState.intent.secondsFailing = constrain(rescueState.intent.secondsFailing, 0, 15);
         if (rescueState.intent.secondsFailing == 15) {
 #ifdef USE_MAG
@@ -479,7 +479,6 @@ static void performSanityChecks(void)
     if (secondsLowSats == 10) {
         rescueState.failure = RESCUE_LOWSATS;
     }
-
 
     // These conditions ignore sanity mode settings, and apply in all rescues, to handle getting stuck in a climb or descend
 

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -112,8 +112,8 @@ typedef struct {
     float alitutudeStepCm;
     float maxPitchStep;
     float absErrorAngle;
-    float groundspeedErrorRatio;
-    float dcm_kpModifier;
+    float groundspeedPitchAttenuator;
+    float imuYawGain;
 } rescueSensorData_s;
 
 typedef struct {
@@ -236,7 +236,7 @@ static void rescueAttainPosition(void)
         previousAltitudeError = 0.0f;
         throttleAdjustment = 0;
         rescueState.intent.disarmThreshold = gpsRescueConfig()->disarmThreshold * 0.1f;
-        rescueState.sensor.dcm_kpModifier = 1.0f;
+        rescueState.sensor.imuYawGain = 1.0f;
         return;
     case RESCUE_DO_NOTHING:
         // 20s of slow descent for switch induced sanity failures to allow time to recover
@@ -572,14 +572,15 @@ static void sensorUpdate(void)
     // values to modify dcm_kp to a low value when climbing, and a higher value when there is a velocity error
     if (gpsRescueConfig()->rescueGroundspeed) {
         const float setGroundspeedInv = 1.0f / gpsRescueConfig()->rescueGroundspeed;
-        const float groundspeedErrorRatio = fabsf(rescueState.sensor.groundSpeedCmS - rescueState.sensor.velocityToHomeCmS) * setGroundspeedInv;
+        const float groundspeedPitchAttenuator = fabsf(rescueState.sensor.groundSpeedCmS - rescueState.sensor.velocityToHomeCmS) * setGroundspeedInv;
         // 0 if groundspeed = velocity to home,
         // 1 if moving sideways at target groundspeed but zero home velocity,
         // 2 if moving backwards (away from home) at target groundspeed
-        rescueState.sensor.dcm_kpModifier = constrainf(1.0f + groundspeedErrorRatio, 1.0f, 6.0f); // up to 6x dcm_kp increase
-        rescueState.sensor.groundspeedErrorRatio = fminf(rescueState.sensor.dcm_kpModifier, 3.0f); // cut pitch angle by up to one third
+        // 4 if moving backwards (away from home) at twice target groundspeed
+        rescueState.sensor.imuYawGain = constrainf(1.0f + groundspeedPitchAttenuator, 1.0f, 6.0f); // up to 6x increase in IMU Yaw gain
+        rescueState.sensor.groundspeedPitchAttenuator = fminf(rescueState.sensor.imuYawGain, 3.0f); // cut pitch angle by up to one third
         const bool climbOrRotate = (rescueState.phase == RESCUE_ATTAIN_ALT) || (rescueState.phase == RESCUE_ROTATE);
-        rescueState.sensor.dcm_kpModifier = (climbOrRotate) ? 0.0f : rescueState.sensor.dcm_kpModifier;
+        rescueState.sensor.imuYawGain = (climbOrRotate) ? 0.0f : rescueState.sensor.imuYawGain;
         // zero dcm_kp during climb or rotate, to stop IMU error accumulation arising from drift during long climbs
     }
 
@@ -666,10 +667,10 @@ void descend(void)
         // if quad drifts further than 2m away from home, should by then have rotated towards home, so pitch is allowed
         rescueState.intent.rollAngleLimitDeg = gpsRescueConfig()->maxRescueAngle * rescueState.intent.proximityToLandingArea;
         // reduce roll capability when closer to home, none within final 2m
+        rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle / rescueState.sensor.groundspeedPitchAttenuator;
     }
 
     rescueState.intent.yawAttenuator = 1.0f; // just in case entered descend phase before yaw authority was complete
-    rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle; // just in case we entered descend directly
 
     // configure altitude step for descent, considering interval between altitude readings
     rescueState.intent.altitudeStep = -1.0f * rescueState.sensor.altitudeDataIntervalSeconds * gpsRescueConfig()->descendRate;
@@ -777,8 +778,8 @@ void gpsRescueUpdate(void)
             rescueState.intent.yawAttenuator += rescueState.sensor.gpsRescueTaskIntervalSeconds;
         }
         if (rescueState.sensor.absErrorAngle < 30.0f) {
-            // allow pitch, limiting allowed angle if there is a significant groundspeedErrorRatio
-            rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle / rescueState.sensor.groundspeedErrorRatio;
+            // allow pitch, limiting allowed angle if there is a significant groundspeedPitchAttenuator
+            rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle / rescueState.sensor.groundspeedPitchAttenuator;
             rescueState.phase = RESCUE_FLY_HOME; // enter fly home phase
             rescueState.intent.secondsFailing = 0; // reset sanity timer for flight home
             rescueState.intent.proximityToLandingArea = 1.0f; // velocity iTerm activated, initialise proximity for descent phase at 1.0
@@ -814,7 +815,7 @@ void gpsRescueUpdate(void)
  
         if (newGPSData) {
             // cut back on allowed angle if there is a high groundspeed error
-            rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle / rescueState.sensor.groundspeedErrorRatio;
+            rescueState.intent.pitchAngleLimitDeg = gpsRescueConfig()->maxRescueAngle / rescueState.sensor.groundspeedPitchAttenuator;
             if (rescueState.sensor.distanceToHomeM <= rescueState.intent.descentDistanceM) {
                 rescueState.phase = RESCUE_DESCENT;
                 rescueState.intent.secondsFailing = 0; // reset sanity timer for descent
@@ -874,9 +875,9 @@ float gpsRescueGetYawRate(void)
     return rescueYaw;
 }
 
-float gpsRescueGetDcmKpModifier(void)
+float gpsRescueGetImuYawGain(void)
 {
-    return rescueState.sensor.dcm_kpModifier;
+    return rescueState.sensor.imuYawGain;
 }
 
 float gpsRescueGetThrottle(void)

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -583,7 +583,7 @@ static void sensorUpdate(void)
             rescueState.sensor.imuYawCogGain = 0;
         } else {
             // up to 6x increase in CoG IMU Yaw gain
-            rescueState.sensor.imuYawCogGain =  constrainf(1.0f + groundspeedErrorRatio, 1.0f, 6.0f);
+            rescueState.sensor.imuYawCogGain =  constrainf(1.0f + (2.0f * groundspeedErrorRatio), 1.0f, 6.0f);
         }
         rescueState.sensor.groundspeedPitchAttenuator = 1.0f / constrainf(1.0f + groundspeedErrorRatio, 1.0f, 3.0f); // cut pitch angle by up to one third
     }

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -57,3 +57,4 @@ bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsDisabled(void);
 bool gpsRescueDisableMag(void);
+float gpsRescueGetDcmKpModifier(void);

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -57,4 +57,4 @@ bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsDisabled(void);
 bool gpsRescueDisableMag(void);
-float gpsRescueGetImuYawGain(void);
+float gpsRescueGetImuYawCogGain(void);

--- a/src/main/flight/gps_rescue.h
+++ b/src/main/flight/gps_rescue.h
@@ -57,4 +57,4 @@ bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsDisabled(void);
 bool gpsRescueDisableMag(void);
-float gpsRescueGetDcmKpModifier(void);
+float gpsRescueGetImuYawGain(void);

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -223,7 +223,7 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
 
 #ifdef USE_GPS_RESCUE
         if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-            ez_ef *= gpsRescueGetImuYawGain();
+            ez_ef *= gpsRescueGetImuYawCogGain();
             // converge yaw faster if groundspeed differs significantly from velocity to home during fly home phase
             // don't converge while climbing or rotating, keeping the original IMU information, which in most cases should be correct
         }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -425,7 +425,7 @@ static float imuCalcKpGain(timeUs_t currentTimeUs, bool useAcc, float *gyroAvera
     } else {
         ret = imuRuntimeConfig.dcm_kp;
         if (!armState) {
-            ret = ret * 10.0f; // Scale the kP to generally converge faster when disarmed.
+            ret *= 10.0f; // Scale the kP to generally converge faster when disarmed.
         }
     }
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -415,7 +415,14 @@ static float imuCalcKpGain(timeUs_t currentTimeUs, bool useAcc, float *gyroAvera
     if (attitudeResetActive) {
         ret = ATTITUDE_RESET_KP_GAIN;
     } else {
-       ret = imuRuntimeConfig.dcm_kp;
+        ret = imuRuntimeConfig.dcm_kp;
+#ifdef USE_GPS_RESCUE
+        if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+            ret *= gpsRescueGetDcmKpModifier();
+            // converge faster if groundspeed differs significantly from velocity to home during fly home phase
+            // don't converge while climbing or rotating, keeping the original IMU information, which in most cases should be correct
+        }
+#endif
        if (!armState) {
           ret = ret * 10.0f; // Scale the kP to generally converge faster when disarmed.
        }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -223,7 +223,7 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
 
 #ifdef USE_GPS_RESCUE
         if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-            ez_ef *= gpsRescueGetDcmKpModifier();
+            ez_ef *= gpsRescueGetImuYawGain();
             // converge yaw faster if groundspeed differs significantly from velocity to home during fly home phase
             // don't converge while climbing or rotating, keeping the original IMU information, which in most cases should be correct
         }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -211,7 +211,7 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
     // Use raw heading error (from GPS or whatever else)
     float ex = 0, ey = 0, ez = 0;
     if (cogYawGain != 0.0f) {
-        // if in a GPS Rescue, boost IMU yaw gain when course over ground and velocity to home differ significantly
+        // Used in a GPS Rescue to boost IMU yaw gain when course over ground and velocity to home differ significantly
         while (courseOverGround >  M_PIf) {
             courseOverGround -= (2.0f * M_PIf);
         }
@@ -474,7 +474,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     static timeUs_t previousIMUUpdateTime;
     bool useAcc = false;
     bool useMag = false;
-    float cogYawGain = 0.0f; // IMU yaw gain to be applied in imuMahonyAHRSupdate from ground course, default to no modification
+    float cogYawGain = 0.0f; // IMU yaw gain to be applied in imuMahonyAHRSupdate from ground course, default to no correction from CoG
     float courseOverGround = 0; // To be used when cogYawGain is non-zero, in radians
 
     const timeDelta_t deltaT = currentTimeUs - previousIMUUpdateTime;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -261,7 +261,7 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
     // Use measured acceleration vector
     float recipAccNorm = sq(ax) + sq(ay) + sq(az);
     if (useAcc && recipAccNorm > 0.01f) {
-        // Normalise accelerometer measurement when smoothed acc is within 20% of 1G
+        // Normalise accelerometer measurement; useAcc is true when all smoothed acc axes are within 20% of 1G
         recipAccNorm = invSqrt(recipAccNorm);
         ax *= recipAccNorm;
         ay *= recipAccNorm;

--- a/src/main/pg/gps_rescue.c
+++ b/src/main/pg/gps_rescue.c
@@ -40,7 +40,7 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
 
     .initialAltitudeM = 30,
     .rescueGroundspeed = 750,
-    .maxRescueAngle = 70,
+    .maxRescueAngle = 40,
     .rollMix = 150,
     .pitchCutoffHz = 75,
 

--- a/src/main/pg/gps_rescue.c
+++ b/src/main/pg/gps_rescue.c
@@ -40,7 +40,7 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
 
     .initialAltitudeM = 30,
     .rescueGroundspeed = 750,
-    .maxRescueAngle = 40,
+    .maxRescueAngle = 45,
     .rollMix = 150,
     .pitchCutoffHz = 75,
 

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -57,7 +57,6 @@ extern "C" {
 
     void imuComputeRotationMatrix(void);
     void imuUpdateEulerAngles(void);
-    void gpsRescueGetImuYawCogGain(void);
 
     extern quaternion q;
     extern float rMat[3][3];
@@ -257,6 +256,7 @@ extern "C" {
     float baroUpsampleAltitude()  { return 0.0f; }
     float pt2FilterGain(float, float)  { return 0.0f; }
     float getBaroAltitude(void) { return 3000.0f; }
+    float gpsRescueGetImuYawCogGain(void) { return 1.0f; }
 
     void pt2FilterInit(pt2Filter_t *baroDerivativeLpf, float) {
         UNUSED(baroDerivativeLpf);

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -57,7 +57,7 @@ extern "C" {
 
     void imuComputeRotationMatrix(void);
     void imuUpdateEulerAngles(void);
-    void gpsRescueGetDcmKpModifier(void);
+    void gpsRescueGetImuYawGain(void);
 
     extern quaternion q;
     extern float rMat[3][3];

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -57,7 +57,7 @@ extern "C" {
 
     void imuComputeRotationMatrix(void);
     void imuUpdateEulerAngles(void);
-    void gpsRescueGetImuYawGain(void);
+    void gpsRescueGetImuYawCogGain(void);
 
     extern quaternion q;
     extern float rMat[3][3];

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -57,6 +57,7 @@ extern "C" {
 
     void imuComputeRotationMatrix(void);
     void imuUpdateEulerAngles(void);
+    void gpsRescueGetDcmKpModifier(void);
 
     extern quaternion q;
     extern float rMat[3][3];


### PR DESCRIPTION
Tested, works well, but would appreciate further testing please!  

Makes the following changes:

- Yaw IMU gain increases up to 6x when there is a large drift over ground error, so that the IMU can re-orient itself more quickly the worse the error
- locks yaw IMU gain to zero during climb and rotate phases, preventing acquisition of IMU orientation errors due to drift during long climbs
- attenuates the maximum angle allowed when there is a large drift over ground error, to reduce the speed of the flyaway that can happen when the IMU orientation is very incorrect
- max rescue angle defaults to 45 degrees.  Even with a maximum IMU error, 45 degrees max angle doesn't cause the quad to speed off madly into the distance.
- fixes an issue where direct entry to a descent mode may not gain full yaw authority
- changes the sensitivity of the `FLY HOME` sanity check.  Now the sanity check will only count up towards to the 15s disarm value if the quad fails to reach 10%, not 50%, of the set return speed, when checked each second.  As before this is an up-down counter, so any time the quad attains >10% of the set return velocity to home, the counter decrements by 1, towards a minimum of zero, and when less than 10%, the counter increments by one.  If there is a net cumulative period of more than 15s with less than 10% forward speed to home, the sanity check will disarm the quad, since it is most unlikely that it will return home.  Users should expect some counting up in the early part of a rescue, especially with bad IMU disorientation, but with the above changes the quad should not disarm from this sanity check unless something really has gone badly wrong, eg stuck in a tree, or crashed, or extremely high wind.

WARNING 1: 
A GPS-only rescue system cannot handle high wind drift - do NOT rely on GPS Rescue in winds above 50-60kph unless you have a properly calibrated and fully functional, tested, Magnetometer (compass).  Higher maximum angle will help handle strong winds better, but the max throttle must be increased also, and in the face of a temporary IMU error, the quad may fly off in the wrong direction at high speed.  In practice, a 35-45 degree angle is more than enough for normal conditions, a 50-55 degree angle may be better in stronger winds.  Always test the return in the conditions of the day to ensure your quad will turn and head for home effectively.  If the wind is too high, the quad will kind of spiral around, at speed, making little or no headway.  Don't let it do this for more than 15s or it will sanity check and drop.

WARNING 2:
IMU disorientation is always possible with GPS-only systems. If a rescue is initiated and the IMU is disoriented from prior drift or high wind, the quad may initially head off in completely the wrong direction, even though the arrow points straight up.  Functionally the quad thinks it is flying home, but has temporarily got the orientation of the quad wrong.  The IMU will, or should, correct itself over the next 2-3seconds, but will fly in a large arc while doing so.  If the maxim allows angle in the rescue is set high, this arc may be flown at high speed, and cover some considerable distance, but the quad will likely handle higher wind rescues a bit more reliably.

To test: enter a GPS Rescue after a 6-8s period of tail drift (fly backwards at > 2m/s for say 6-10s).  Hold that drift long enough for the arrow to rotate 180 degrees wrong.  Initiate the rescue. The rescue will then rotate entirely the wrong direction, ie fly directly away from home.  With this PR it should gain speed away from home for less than a second, and then smoothly and steadily, over 2-3 seconds rotate towards home.  The arrow will keep pointing straight up all the time (the turning is the IMU correcting itself).  After maybe 2-4s, it should be heading home.  The quad will attain a decent speed while correcting itself.  The max speed is determined mostly by the maximum angle. 

If the debug mode `RTH` is displayed on the OSD screen, the sanity check timer is the value of the last two digits of the last debug element.

Testing in high wind and/or with prior extreme back drift would be appreciated.
Testing to figure out how much wind can be tolerated would be helpful, too.

Thanks to @Sek101 for investigating and clarifying the problem.  To summarise, the problem is that:

- if the quad drifts in a direction other than in the direction of the nose of the quad, and
- the drift is at a significant speed (anything > 2m/s), and
- the drift is sustained for at least one or two dcm_kp time constants (6-8 seconds)
- the IMU will, over time, consider that the nose of the quad is pointing in the direction of the course over ground, not the true heading of the quad, and point the arrow to the bottom of the goggles, thinking that is where home is.
- Then, when a rescue is initiated, the quad will rotate so that the arrow points upwards, and will fly in a direction that can be entirely incorrect, including a full 180 degrees wrong.  It will also fly faster than usual at first, and may make a large arc in the sky before finally settling on the true path to home.

This excellent video from Sek101 shows a takeoff, then a quick rotation to fly away from home backwards.  The home arrow slowly orients itself to become 180 degrees wrong.  When the rescue is initiated, the quad rotates according to the incorrect IMU orientation, and flies off 180 degrees in the wrong direction.  
https://www.youtube.com/watch?v=DyEYdI-Qgtw

Code attempt 1 = FAILURE!
This idea was simple: make the dcm_kp value proportional to groundspeed during a GPS Rescue, using about a 4x increase in dcm_kp at normal rescue speed, and very low dcm_kp at low/zero groundspeed.  
RESULT: spirals during initiation when IMU error existed at the start, quad flies off very fast, then enters a kind of "chasing the tail" behaviour.
Video shows, around 44s, quad in reverse, arrow going wrong, then persisting rotation.
https://www.youtube.com/watch?v=BSOgY-f1XtM

Code attempt 2 = NOT QUITE THERE YET!
Here we detect an absolute error between groundspeed and velocity to home, normalised to the intended return speed, plus one.  If the quad is flying directly home, there is no velocity error, so this `groundspeedErrorRatio` value would be 0+1 , ie  1.0.  If the quad is flying off at 90 degrees to home at a groundspeed equal to the intended return speed, the `groundspeedErrorRatio` would be 2.0.  If flying off with a full 180 degree error, at the intended return speed, this factor would be 3.0.  
Then we use this factor to boost `dcm_kp` during the rescue.
RESULT: Some improvement, but still tended to spiral and pick up a lot of speed.

Code attempt 3 = very good!
- calculate `groundspeedErrorRatio` as above, and use it to boost `dcm_kp` up to 5 times.
- use the inverse of this value to attenuate the maximum allowed pitch angle, thereby limiting absolute velocity when the IMU error would send the quad in the wrong direction.
- set `dcm_kp` forcibly to zero while in the climb or rotate phases of the rescue.  This locks in the pre-existing IMU state, which is normally pitch forward flight with a high likelihood of pointing to home.  By locking in that IMU state, we prevent drift (from wind, etc) from building up an IMU error of the kind that could cause a flyaway.
- finally, restore the max angle to the previous default of 40, for pilots who may have GPS modules that aren't working well, to avoid excessive pitch error issues in those cases.

Here is some low-res video of the IMU problem and how this PR achieves a pretty good result in the face of the worst possible IMU errors.

https://www.youtube.com/watch?v=IKbeWCsQj24

This PR should significantly reduce the chance that a working GPS Rescue setup would fail, especially if there is, or has been, signficant sideways or rear-wards drift either for a period of time before the rescue was initiated, or during the climb period.  Previous versions of GPS Rescue were very susceptible to IMU disorientation and could enter persistent non-recovering flyaways.

