### PR TITLE
Detect if no motor GPIO is specified during DSHOT intialisation

### DIFF
--- a/src/main/drivers/stm32/dshot_bitbang.c
+++ b/src/main/drivers/stm32/dshot_bitbang.c
@@ -429,6 +429,11 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorPwmProtocolTypes_e dshotProto
 
 static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorPwmProtocolTypes_e pwmProtocolType, uint8_t output)
 {
+    // Return if no GPIO is specified
+    if (!io) {
+        return false;
+    }
+
     int pinIndex = IO_GPIOPinIdx(io);
     int portIndex = IO_GPIOPortIdx(io);
 


### PR DESCRIPTION
Issue spotted trying to use STM32G47X target, but would affect others.