### PR TITLE
Tri-state USART TX output if load due to powered down peripheral is detected

### DIFF
--- a/src/main/drivers/at32/serial_uart_at32bsp.c
+++ b/src/main/drivers/at32/serial_uart_at32bsp.c
@@ -177,9 +177,42 @@ void uartReconfigure(uartPort_t *uartPort)
         } else {
             usart_interrupt_enable(uartPort->USARTx, USART_TDBE_INT, TRUE);
         }
+        usart_interrupt_enable(uartPort->USARTx, USART_TDC_INT, TRUE);
     }
 
     usart_enable(uartPort->USARTx,TRUE);
+}
+
+bool checkUsartTxOutput(uartPort_t *s)
+{
+    uartDevice_t *uart = container_of(s, uartDevice_t, port);
+    IO_t txIO = IOGetByTag(uart->tx.pin);
+
+    if ((uart->txPinState == TX_PIN_MONITOR) && txIO) {
+        if (IORead(txIO)) {
+            // TX is high so we're good to transmit
+
+            // Enable USART TX output
+            uart->txPinState = TX_PIN_ACTIVE;
+            IOConfigGPIOAF(txIO, IOCFG_AF_PP, uart->hardware->af);
+            return true;
+        } else {
+            // TX line is pulled low so don't enable USART TX
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void uartTxMonitor(uartPort_t *s)
+{
+    uartDevice_t *uart = container_of(s, uartDevice_t, port);
+    IO_t txIO = IOGetByTag(uart->tx.pin);
+
+    // Switch TX to an input with pullup so it's state can be monitored
+    uart->txPinState = TX_PIN_MONITOR;
+    IOConfigGPIO(txIO, IOCFG_IPU);
 }
 
 #ifdef USE_DMA
@@ -228,7 +261,14 @@ void uartTryStartTxDMA(uartPort_t *s)
 
 static void handleUsartTxDma(uartPort_t *s)
 {
+    uartDevice_t *uart = container_of(s, uartDevice_t, port);
+
     uartTryStartTxDMA(s);
+
+    if (s->txDMAEmpty && (uart->txPinState != TX_PIN_IGNORE)) {
+        // Switch TX to an input with pullup so it's state can be monitored
+        uartTxMonitor(s);
+    }
 }
 
 void uartDmaIrqHandler(dmaChannelDescriptor_t* descriptor)
@@ -256,6 +296,14 @@ void uartIrqHandler(uartPort_t *s)
             s->port.rxBuffer[s->port.rxBufferHead] = s->USARTx->dt;
             s->port.rxBufferHead = (s->port.rxBufferHead + 1) % s->port.rxBufferSize;
         }
+    }
+
+    // UART transmission completed
+    if ((usart_flag_get(s->USARTx, USART_TDC_FLAG) != RESET)) {
+        usart_flag_clear(s->USARTx, USART_TDC_FLAG);
+
+        // Switch TX to an input with pull-up so it's state can be monitored
+        uartTxMonitor(s);
     }
 
     if (!s->txDMAResource && (usart_flag_get(s->USARTx, USART_TDBE_FLAG) == SET)) {

--- a/src/main/drivers/at32/serial_uart_at32f43x.c
+++ b/src/main/drivers/at32/serial_uart_at32f43x.c
@@ -286,6 +286,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     s->port.rxBufferSize = hardware->rxBufferSize;
     s->port.txBufferSize = hardware->txBufferSize;
 
+    s->checkUsartTxOutput = checkUsartTxOutput;
+
 #ifdef USE_DMA
     uartConfigureDma(uartdev);
 #endif
@@ -296,6 +298,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);
+
+    uartdev->txPinState = TX_PIN_IGNORE;
 
     if ((options & SERIAL_BIDIR) && txIO) {
         //mode,speed,otype,pupd
@@ -310,7 +314,14 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-            IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+
+            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+                uartdev->txPinState = TX_PIN_ACTIVE;
+                // Switch TX to an input with pullup so it's state can be monitored
+                uartTxMonitor(s);
+            } else {
+                IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+            }
         }
 
         if ((mode & MODE_RX) && rxIO) {

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -267,6 +267,12 @@ static void uartWrite(serialPort_t *instance, uint8_t ch)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
 
+    // Check if the TX line is being pulled low by an unpowered peripheral
+    if (uartPort->checkUsartTxOutput && !uartPort->checkUsartTxOutput(uartPort)) {
+        // TX line is being pulled low, so don't transmit
+        return;
+    }
+
     uartPort->port.txBuffer[uartPort->port.txBufferHead] = ch;
 
     if (uartPort->port.txBufferHead + 1 >= uartPort->port.txBufferSize) {

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -76,6 +76,8 @@ typedef struct uartPort_s {
 #endif
     USART_TypeDef *USARTx;
     bool txDMAEmpty;
+
+    bool (* checkUsartTxOutput)(struct uartPort_s *s);
 } uartPort_t;
 
 void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig);

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -217,6 +217,12 @@ extern const uartHardware_t uartHardware[];
 // uartDevice_t is an actual device instance.
 // XXX Instances are allocated for uarts defined by USE_UARTx atm.
 
+typedef enum {
+    TX_PIN_ACTIVE,
+    TX_PIN_MONITOR,
+    TX_PIN_IGNORE
+} txPinState_t;
+
 typedef struct uartDevice_s {
     uartPort_t port;
     const uartHardware_t *hardware;
@@ -227,6 +233,7 @@ typedef struct uartDevice_s {
 #if !defined(STM32F4) // Don't support pin swap.
     bool pinSwap;
 #endif
+    txPinState_t txPinState;
 } uartDevice_t;
 
 extern uartDevice_t *uartDevmap[];
@@ -244,6 +251,9 @@ void uartReconfigure(uartPort_t *uartPort);
 void uartConfigureDma(uartDevice_t *uartdev);
 
 void uartDmaIrqHandler(dmaChannelDescriptor_t* descriptor);
+
+bool checkUsartTxOutput(uartPort_t *s);
+void uartTxMonitor(uartPort_t *s);
 
 #if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
 #define UART_REG_RXD(base) ((base)->RDR)

--- a/src/main/drivers/stm32/serial_uart_stdperiph.c
+++ b/src/main/drivers/stm32/serial_uart_stdperiph.c
@@ -180,6 +180,8 @@ void uartReconfigure(uartPort_t *uartPort)
         } else {
             USART_ITConfig(uartPort->USARTx, USART_IT_TXE, ENABLE);
         }
+        // Enable the interrupt so completion of the transmission will be signalled
+        USART_ITConfig(uartPort->USARTx, USART_IT_TC, ENABLE);
     }
 
     USART_Cmd(uartPort->USARTx, ENABLE);

--- a/src/main/drivers/stm32/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f7xx.c
@@ -345,6 +345,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     s->port.rxBufferSize = hardware->rxBufferSize;
     s->port.txBufferSize = hardware->txBufferSize;
 
+    s->checkUsartTxOutput = checkUsartTxOutput;
+
 #ifdef USE_DMA
     uartConfigureDma(uartdev);
 #endif
@@ -357,6 +359,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);
+
+    uartdev->txPinState = TX_PIN_IGNORE;
 
     if ((options & SERIAL_BIDIR) && txIO) {
         ioConfig_t ioCfg = IO_CONFIG(
@@ -371,7 +375,14 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-            IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+
+            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+                uartdev->txPinState = TX_PIN_ACTIVE;
+                // Switch TX to an input with pullup so it's state can be monitored
+                uartTxMonitor(s);
+            } else {
+                IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+            }
         }
 
         if ((mode & MODE_RX) && rxIO) {

--- a/src/main/drivers/stm32/serial_uart_stm32g4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32g4xx.c
@@ -279,6 +279,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     s->port.rxBufferSize = hardware->rxBufferSize;
     s->port.txBufferSize = hardware->txBufferSize;
 
+    s->checkUsartTxOutput = checkUsartTxOutput;
+
 #ifdef USE_DMA
     uartConfigureDma(uartdev);
 #endif
@@ -292,6 +294,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);
 
+    uartdev->txPinState = TX_PIN_IGNORE;
+
     if ((options & SERIAL_BIDIR) && txIO) {
         ioConfig_t ioCfg = IO_CONFIG(
             ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP) || (options & SERIAL_BIDIR_PP_PD)) ? GPIO_MODE_AF_PP : GPIO_MODE_AF_OD,
@@ -304,7 +308,14 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-            IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+
+            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+                uartdev->txPinState = TX_PIN_ACTIVE;
+                // Switch TX to an input with pullup so it's state can be monitored
+                uartTxMonitor(s);
+            } else {
+                IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+            }
         }
 
         if ((mode & MODE_RX) && rxIO) {

--- a/src/main/drivers/stm32/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32h7xx.c
@@ -456,6 +456,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     s->port.rxBufferSize = hardware->rxBufferSize;
     s->port.txBufferSize = hardware->txBufferSize;
 
+    s->checkUsartTxOutput = checkUsartTxOutput;
+
 #ifdef USE_DMA
     uartConfigureDma(uartdev);
 #endif
@@ -469,6 +471,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     IO_t txIO = IOGetByTag(uartdev->tx.pin);
     IO_t rxIO = IOGetByTag(uartdev->rx.pin);
 
+    uartdev->txPinState = TX_PIN_IGNORE;
+
     if ((options & SERIAL_BIDIR) && txIO) {
         ioConfig_t ioCfg = IO_CONFIG(
             ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP) || (options & SERIAL_BIDIR_PP_PD)) ? GPIO_MODE_AF_PP : GPIO_MODE_AF_OD,
@@ -481,7 +485,14 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-            IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+
+            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+                uartdev->txPinState = TX_PIN_ACTIVE;
+                // Switch TX to an input with pullup so it's state can be monitored
+                uartTxMonitor(s);
+            } else {
+                IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
+            }
         }
 
         if ((mode & MODE_RX) && rxIO) {


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/12723

This PR monitors the state of the TX line when full duplex connections are used. When no data is being transmitted the TX line is set to be an input with pullup and when new data is to be transmitted the line is checked. It should always be high unless it is being excessively loaded. If the line is found to be pulled low, it is left tri-stated and the data discarded.

Note:
This build sets `debug[0]` to `debug[3]` to indicate the status of UARTs 1 - 4 respectively.

| Value | Meaning |
| - | -|
| 1 | Normal Operation |
| 2 | Powered down peripheral detected |

This debug will be removed once fix is tested/proven.