### PR TITLE
SPRacingH7RF - Update target configuration.

### DIFF
--- a/src/config/SPRACINGH7RF/config.h
+++ b/src/config/SPRACINGH7RF/config.h
@@ -66,6 +66,7 @@
 #define CONFIG_IN_MEMORY_MAPPED_FLASH
 #define USE_FIRMWARE_PARTITION
 
+#define USE_SDCARD_SDIO
 #define SDCARD_DETECT_PIN PC13
 #define SDCARD_DETECT_INVERTED
 #define SDIO_DEVICE             SDIODEV_1
@@ -245,6 +246,44 @@
 #define GYRO_2_EXTI_PIN      NONE
 #define GYRO_1_CS_PIN        PA15
 #define GYRO_2_CS_PIN        NONE
+
+// Pre-BF-4.4 config:
+// On 4in1ESC_1 (Top, CPU side)
+// DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               0,  0,  0 ), // M1
+// DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               0,  1,  0 ), // ..
+// DEF_TIM(TIM3,  CH1, PA6,  TIM_USE_MOTOR,               0,  2,  0 ), // ..
+// DEF_TIM(TIM3,  CH2, PA7,  TIM_USE_MOTOR,               0,  3,  0 ), // M4
+// On 4in1ESC_2 (Bottom)
+// DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_MOTOR,               0,  4,  0 ), // M5
+// DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MOTOR,               0,  5,  0 ), // ..
+// DEF_TIM(TIM5,  CH3, PA2,  TIM_USE_MOTOR,               0,  6,  0 ), // ..
+// DEF_TIM(TIM5,  CH4, PA3,  TIM_USE_MOTOR,               0,  7,  0 ), // M8
+// On SX1280
+// DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_NONE,                0,  8,  1 ),  // SX1280 DIO1
+// DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_NONE,                0,  9,  1 ),  // SX1280 BUSY
+// On GYRO
+// DEF_TIM(TIM4,  CH3, PD14, TIM_USE_NONE,                0,  0,  0 ), // Gyro SYNC
+// DEF_TIM(TIM4,  CH4, PD15, TIM_USE_NONE,                0,  0,  0 ), // Gyro INT
+// On LED strip connector
+// DEF_TIM(TIM17, CH1N, PB7, TIM_USE_LED,                 0,  12, 1 ), // LED Strip
+// On PixelOSD
+// DEF_TIM(TIM15, CH1, PE5,  TIM_USE_VIDEO_PIXEL,         0,  15, 15 ), // Pixel DMA
+// DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_VIDEO_SYNC,          0,  14, 14 ), // Sync
+
+// Index, Pin, 1-based occurrence of pin in fullTimerHardware, dma opt (use -1 for no DMA)
+// See timerio.c and timer_stm32h7xx.c
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB0 , 2,  0 ) \
+    TIMER_PIN_MAP( 1, PB1 , 2,  1 ) \
+    TIMER_PIN_MAP( 2, PA6 , 1,  2 ) \
+    TIMER_PIN_MAP( 3, PA7 , 2,  3 ) \
+    TIMER_PIN_MAP( 4, PA0 , 2,  4 ) \
+    TIMER_PIN_MAP( 5, PA1 , 2,  5 ) \
+    TIMER_PIN_MAP( 6, PA2 , 2,  6 ) \
+    TIMER_PIN_MAP( 7, PA3 , 2,  7 ) \
+    TIMER_PIN_MAP( 8, PB7 , 1,  8 ) \
+
 
 #define ADC3_DMA_OPT       10
 


### PR DESCRIPTION
* SD card set to SDIO by default.
* Timer mapping added.

```
# timer
timer B00 AF2
# pin B00: TIM3 CH3 (AF2)
timer B01 AF2
# pin B01: TIM3 CH4 (AF2)
timer A06 AF2
# pin A06: TIM3 CH1 (AF2)
timer A07 AF2
# pin A07: TIM3 CH2 (AF2)
timer A00 AF2
# pin A00: TIM5 CH1 (AF2)
timer A01 AF2
# pin A01: TIM5 CH2 (AF2)
timer A02 AF2
# pin A02: TIM5 CH3 (AF2)
timer A03 AF2
# pin A03: TIM5 CH4 (AF2)
timer B07 AF1
# pin B07: TIM17 CH1N (AF1)

# timer map

Timer Mapping:
 TIMER_PIN_MAP(0, PB0, 2, 0)
 TIMER_PIN_MAP(1, PB1, 2, 1)
 TIMER_PIN_MAP(2, PA6, 1, 2)
 TIMER_PIN_MAP(3, PA7, 2, 3)
 TIMER_PIN_MAP(4, PA0, 2, 4)
 TIMER_PIN_MAP(5, PA1, 2, 5)
 TIMER_PIN_MAP(6, PA2, 2, 6)
 TIMER_PIN_MAP(7, PA3, 2, 7)
 TIMER_PIN_MAP(8, PB7, 1, 8)

# diff

# version
# Betaflight / STM32H730 (SP7R) 4.5.0 May  4 2023 / 11:26:23 (norevision) MSP API: 1.46

# start the command batch
batch start

board_name SPRACINGH7RF
manufacturer_id SPRO

profile 0

rateprofile 0

# end the command batch
batch end

# status
MCU H730 Clock=520MHz, Vref=3.31V, Core temp=55degC
Stack size: 2048, Stack address: 0x2000f000
Configuration: CONFIGURED, size: 4159, max available: 65536
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1 locked
GYRO=ICM42605, ACC=ICM42605, BARO=BMP388
OSD: NONE (104 x 10)
System Uptime: 54 seconds, Current Time: 2023-05-04T09:30:23.099+00:00
CPU:25%, cycle time: 124, GYRO rate: 8064, RX rate: 15, System rate: 10
Voltage: 1199 * 0.01V (3S battery - OK)
I2C Errors: 7
SD card: Manufacturer 0x27, 30289920kB, 01/2005, v6.0, 'SD32G'
Filesystem: Ready
Arming disable flags: RXLOSS CLI MSP
```