### PR TITLE
Add GPS Status Line to CLI Status Output

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4759,11 +4759,10 @@ static void cliStatus(const char *cmdName, char *cmdline)
             cliPrint("NOT CONFIGURED");
         } else {
             if (gpsConfig()->autoConfig == GPS_AUTOCONFIG_OFF) {
-               cliPrint("auto config OFF, ");
+               cliPrint("auto config OFF");
             } else {
-                cliPrint("configured, ");
+                cliPrint("configured");
             }
-            cliPrint(" ");
         }
     } else {
         cliPrint("NOT ENABLED");

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4731,6 +4731,46 @@ static void cliStatus(const char *cmdName, char *cmdline)
     }
 #endif
 
+#ifdef USE_GPS
+    cliPrint("GPS: ");
+    if (featureIsEnabled(FEATURE_GPS)) {
+        if (gpsIsHealthy()) {
+            cliPrint("connected, ");
+        } else {
+            cliPrint("NOT CONNECTED, ");
+        }
+        if (gpsConfig()->provider == GPS_MSP) {
+            cliPrint("MSP, ");
+        } else {
+            const serialPortConfig_t *gpsPortConfig = findSerialPortConfig(FUNCTION_GPS);
+            if (!gpsPortConfig) {
+                cliPrint("NO PORT, ");
+            } else {
+                cliPrintf("UART%d %ld(", (gpsPortConfig->identifier + 1), baudRates[getGPSPortActualBaudRateIndex()]);
+                if (gpsConfig()->autoBaud == GPS_AUTOBAUD_ON) {
+                    cliPrint("AUTO");
+                } else {
+                    cliPrintf("%ld", baudRates[gpsPortConfig->gps_baudrateIndex]);
+                }
+                cliPrint("), ");  // Place holder for queried config items to be added (firmware & protocol version, actual solution rate, etc.)
+            }
+        }
+        if (!gpsIsHealthy()) {
+            cliPrint("NOT CONFIGURED");
+        } else {
+            if (gpsConfig()->autoConfig == GPS_AUTOCONFIG_OFF) {
+               cliPrint("auto config OFF, ");
+            } else {
+                cliPrint("configured, ");
+            }
+            cliPrint(" ");
+        }
+    } else {
+        cliPrint("NOT ENABLED");
+    }
+    cliPrintLinefeed();
+#endif
+
     cliPrint("Arming disable flags:");
     armingDisableFlags_e flags = getArmingDisableFlags();
     while (flags) {

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4746,20 +4746,20 @@ static void cliStatus(const char *cmdName, char *cmdline)
             if (!gpsPortConfig) {
                 cliPrint("NO PORT, ");
             } else {
-                cliPrintf("UART%d %ld(", (gpsPortConfig->identifier + 1), baudRates[getGPSPortActualBaudRateIndex()]);
+                cliPrintf("UART%d %ld (set to ", (gpsPortConfig->identifier + 1), baudRates[getGpsPortActualBaudRateIndex()]);
                 if (gpsConfig()->autoBaud == GPS_AUTOBAUD_ON) {
                     cliPrint("AUTO");
                 } else {
                     cliPrintf("%ld", baudRates[gpsPortConfig->gps_baudrateIndex]);
                 }
-                cliPrint("), ");  // Place holder for queried config items to be added (firmware & protocol version, actual solution rate, etc.)
+                cliPrint("), ");
             }
         }
         if (!gpsIsHealthy()) {
             cliPrint("NOT CONFIGURED");
         } else {
             if (gpsConfig()->autoConfig == GPS_AUTOCONFIG_OFF) {
-               cliPrint("auto config OFF");
+                cliPrint("auto config OFF");
             } else {
                 cliPrint("configured");
             }
@@ -4768,7 +4768,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
         cliPrint("NOT ENABLED");
     }
     cliPrintLinefeed();
-#endif
+#endif // USE_GPS
 
     cliPrint("Arming disable flags:");
     armingDisableFlags_e flags = getArmingDisableFlags();

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1985,4 +1985,9 @@ float getGpsDataIntervalSeconds(void)
     return gpsDataIntervalSeconds;
 }
 
+baudRate_e getGPSPortActualBaudRateIndex(void)
+{
+    return lookupBaudRateIndex(serialGetBaudRate(gpsPort));
+}
+
 #endif // USE_GPS

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1985,7 +1985,7 @@ float getGpsDataIntervalSeconds(void)
     return gpsDataIntervalSeconds;
 }
 
-baudRate_e getGPSPortActualBaudRateIndex(void)
+baudRate_e getGpsPortActualBaudRateIndex(void)
 {
     return lookupBaudRateIndex(serialGetBaudRate(gpsPort));
 }

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -221,4 +221,4 @@ void GPS_calc_longitude_scaling(int32_t lat);
 void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, int32_t *destinationLat2, int32_t *destinationLon2, uint32_t *dist, int32_t *bearing);
 void gpsSetFixState(bool state);
 float getGpsDataIntervalSeconds(void);
-baudRate_e getGPSPortActualBaudRateIndex(void);
+baudRate_e getGpsPortActualBaudRateIndex(void);

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -26,6 +26,8 @@
 #include "common/axis.h"
 #include "common/time.h"
 
+#include "io/serial.h"
+
 #include "pg/gps.h"
 
 #define GPS_DEGREES_DIVIDER 10000000L
@@ -219,3 +221,4 @@ void GPS_calc_longitude_scaling(int32_t lat);
 void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, int32_t *destinationLat2, int32_t *destinationLon2, uint32_t *dist, int32_t *bearing);
 void gpsSetFixState(bool state);
 float getGpsDataIntervalSeconds(void);
+baudRate_e getGPSPortActualBaudRateIndex(void);

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -279,8 +279,8 @@ bool resetEEPROM(void) { return true; }
 void bufWriterFlush(bufWriter_t *) {}
 void mixerResetDisarmedMotors(void) {}
 void gpsEnablePassthrough(struct serialPort_s *) {}
-bool gpsIsHealthy(void) {return true;}
-baudRate_e getGPSPortActualBaudRateIndex(void) {return BAUD_AUTO;}
+bool gpsIsHealthy(void) { return true; }
+baudRate_e getGPSPortActualBaudRateIndex(void) { return BAUD_AUTO; }
 
 bool parseLedStripConfig(int, const char *){return false; }
 const char rcChannelLetters[] = "AERT12345678abcdefgh";
@@ -299,7 +299,7 @@ serialPortConfig_t *serialFindPortConfigurationMutable(serialPortIdentifier_e) {
 baudRate_e lookupBaudRateIndex(uint32_t){return BAUD_9600; }
 serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e){ return NULL; }
 serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e, serialReceiveCallbackPtr, void *, uint32_t, portMode_e, portOptions_e) { return NULL; }
-const serialPortConfig_t *findSerialPortConfig(serialPortFunction_e) {return NULL;}
+const serialPortConfig_t *findSerialPortConfig(serialPortFunction_e) { return NULL; }
 void serialSetBaudRate(serialPort_t *, uint32_t) {}
 void serialSetMode(serialPort_t *, portMode_e) {}
 void serialPassthrough(serialPort_t *, serialPort_t *, serialConsumer *, serialConsumer *) {}

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -49,6 +49,7 @@ extern "C" {
     #include "pg/pg.h"
     #include "pg/pg_ids.h"
     #include "pg/beeper.h"
+    #include "pg/gps.h"
     #include "pg/rx.h"
     #include "rx/rx.h"
     #include "scheduler/scheduler.h"
@@ -88,6 +89,7 @@ extern "C" {
     PG_REGISTER_ARRAY(rxFailsafeChannelConfig_t, MAX_SUPPORTED_RC_CHANNEL_COUNT, rxFailsafeChannelConfigs, PG_RX_FAILSAFE_CHANNEL_CONFIG, 0);
     PG_REGISTER(pidConfig_t, pidConfig, PG_PID_CONFIG, 0);
     PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+    PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
 
     PG_REGISTER_WITH_RESET_FN(int8_t, unitTestData, PG_RESERVED_FOR_TESTING_1, 0);
 }
@@ -277,6 +279,9 @@ bool resetEEPROM(void) { return true; }
 void bufWriterFlush(bufWriter_t *) {}
 void mixerResetDisarmedMotors(void) {}
 void gpsEnablePassthrough(struct serialPort_s *) {}
+bool gpsIsHealthy(void) {return true;}
+baudRate_e getGPSPortActualBaudRateIndex(void) {return 0;}
+
 bool parseLedStripConfig(int, const char *){return false; }
 const char rcChannelLetters[] = "AERT12345678abcdefgh";
 
@@ -294,6 +299,7 @@ serialPortConfig_t *serialFindPortConfigurationMutable(serialPortIdentifier_e) {
 baudRate_e lookupBaudRateIndex(uint32_t){return BAUD_9600; }
 serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e){ return NULL; }
 serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e, serialReceiveCallbackPtr, void *, uint32_t, portMode_e, portOptions_e) { return NULL; }
+const serialPortConfig_t *findSerialPortConfig(serialPortFunction_e function) {return NULL;}
 void serialSetBaudRate(serialPort_t *, uint32_t) {}
 void serialSetMode(serialPort_t *, portMode_e) {}
 void serialPassthrough(serialPort_t *, serialPort_t *, serialConsumer *, serialConsumer *) {}

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -280,7 +280,7 @@ void bufWriterFlush(bufWriter_t *) {}
 void mixerResetDisarmedMotors(void) {}
 void gpsEnablePassthrough(struct serialPort_s *) {}
 bool gpsIsHealthy(void) {return true;}
-baudRate_e getGPSPortActualBaudRateIndex(void) {return 0;}
+baudRate_e getGPSPortActualBaudRateIndex(void) {return BAUD_AUTO;}
 
 bool parseLedStripConfig(int, const char *){return false; }
 const char rcChannelLetters[] = "AERT12345678abcdefgh";
@@ -299,7 +299,7 @@ serialPortConfig_t *serialFindPortConfigurationMutable(serialPortIdentifier_e) {
 baudRate_e lookupBaudRateIndex(uint32_t){return BAUD_9600; }
 serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e){ return NULL; }
 serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e, serialReceiveCallbackPtr, void *, uint32_t, portMode_e, portOptions_e) { return NULL; }
-const serialPortConfig_t *findSerialPortConfig(serialPortFunction_e function) {return NULL;}
+const serialPortConfig_t *findSerialPortConfig(serialPortFunction_e) {return NULL;}
 void serialSetBaudRate(serialPort_t *, uint32_t) {}
 void serialSetMode(serialPort_t *, portMode_e) {}
 void serialPassthrough(serialPort_t *, serialPort_t *, serialConsumer *, serialConsumer *) {}

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -280,7 +280,7 @@ void bufWriterFlush(bufWriter_t *) {}
 void mixerResetDisarmedMotors(void) {}
 void gpsEnablePassthrough(struct serialPort_s *) {}
 bool gpsIsHealthy(void) { return true; }
-baudRate_e getGPSPortActualBaudRateIndex(void) { return BAUD_AUTO; }
+baudRate_e getGpsPortActualBaudRateIndex(void) { return BAUD_AUTO; }
 
 bool parseLedStripConfig(int, const char *){return false; }
 const char rcChannelLetters[] = "AERT12345678abcdefgh";

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -39,6 +39,7 @@ extern "C" {
     #include "flight/pid.h"
     #include "flight/servos.h"
     #include "io/beeper.h"
+    #include "io/gps.h"
     #include "io/ledstrip.h"
     #include "io/serial.h"
     #include "io/vtx.h"


### PR DESCRIPTION
Note: This is "Part 1" of a series of additions for the GPS Status Line functionality. See [future] comments below for planned additions.

Adds a new `GPS: ....` status line to the output of the CLI `status` command.

The `GPS: ...` status line will appear only when the firmware has been built with the `USE_GPS` feature define.

If the GPS feature is not enabled, the GPS status line will show `GPS: NOT ENABLED`.

The GPS status line shows a list of status items following `GPS: `:

- Whether Betaflight has established a serial port connection to the GPS module -- either `NOT CONNECTED` or `connected`.
- Serial port information in the format `UARTn actualBaudRate(configuredBaudRate)`, for example:
   - `UART4 115200(AUTO)` when using UART4 connected at 115200 configured with GPS Auto Baud on.
   - `UART4 57600(57600)` when using UART4 connected at 57600 configured with GPS Auto Baud off and the serial port configured for 57600.
- Whether Betaflight has completed its configuration steps -- either `auto config OFF`, `NOT CONFIGURED` or `configured`.
- [future] Additional actual module configuration items (polled from the module), such as solution rate, platform model, power level, etc. (TBD)

See attached status output screen captures for illustrations of the above output (GPS status is next to last line).

Additional Notes:
- The basic GPS status items implemented for Part 1 of the PR are common for both NMEA and U-BLOX protocols. Testing has shown them to work for both.
- In testing, it was observed that sometimes when Auto Baud is off the serial port connected at a lower baud rate than configured for the port. Power cycling the GPS module usually fixed this. This not believed to be a bug with this status line code.
- This PR adds 356 bytes to the firmware size.
- Betaflight does not currently verify the actual module configuration after completing the configuring steps. The `configured` status only means the state machine has moved through the configuration steps.
- Adding additional actual module configuration items requires adding module config polling functionality to the GPS state machine, and will require both NMEA and U_BLOX support.

![image](https://user-images.githubusercontent.com/26205931/236643056-3160633f-5460-4e7f-85d1-3b2a17a1630a.png)
![image](https://user-images.githubusercontent.com/26205931/236643085-fb4ad04e-78e8-40b9-95f3-055078271509.png)
![image](https://user-images.githubusercontent.com/26205931/236643119-61d74a2a-c38d-4c05-b6de-fd5d9510bca6.png)
![image](https://user-images.githubusercontent.com/26205931/236643134-dee038d0-f909-424c-8556-426e7a3abeaa.png)
