### PR TITLE
refactor with half Pi and twice Pi as runtime constants

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -44,7 +44,7 @@ float nullFilterApply(filter_t *filter, float input)
 
 FAST_CODE_NOINLINE float pt1FilterGain(float f_cut, float dT)
 {
-    float omega = 2.0f * M_PIf * f_cut * dT;
+    float omega = M_TWO_PIf * f_cut * dT;
     return omega / (omega + 1.0f);
 }
 
@@ -157,7 +157,7 @@ void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refresh
 FAST_CODE void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight)
 {
     // setup variables
-    const float omega = 2.0f * M_PIf * filterFreq * refreshRate * 0.000001f;
+    const float omega = M_TWO_PIf * filterFreq * refreshRate * 0.000001f;
     const float sn = sin_approx(omega);
     const float cs = cos_approx(omega);
     const float alpha = sn / (2.0f * Q);
@@ -257,7 +257,7 @@ void phaseCompInit(phaseComp_t *filter, const float centerFreqHz, const float ce
 
 FAST_CODE void phaseCompUpdate(phaseComp_t *filter, const float centerFreqHz, const float centerPhaseDeg, const uint32_t looptimeUs)
 {
-    const float omega = 2.0f * M_PIf * centerFreqHz * looptimeUs * 1e-6f;
+    const float omega = M_TWO_PIf * centerFreqHz * looptimeUs * 1e-6f;
     const float sn = sin_approx(centerPhaseDeg * RAD);
     const float gain = (1 + sn) / (1 - sn);
     const float alpha = (12 - sq(omega)) / (6 * omega * sqrtf(gain));  // approximate prewarping (series expansion)

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -52,17 +52,17 @@ float sin_approx(float x)
 {
     int32_t xint = x;
     if (xint < -32 || xint > 32) return 0.0f;                               // Stop here on error input (5 * 360 Deg)
-    while (x >  M_PIf) x -= (2.0f * M_PIf);                                 // always wrap input angle to -PI..PI
-    while (x < -M_PIf) x += (2.0f * M_PIf);
-    if (x >  (0.5f * M_PIf)) x =  (0.5f * M_PIf) - (x - (0.5f * M_PIf));   // We just pick -90..+90 Degree
-    else if (x < -(0.5f * M_PIf)) x = -(0.5f * M_PIf) - ((0.5f * M_PIf) + x);
+    while (x >  M_PIf) x -= M_TWO_PIf;                                      // always wrap input angle to -PI..PI
+    while (x < -M_PIf) x += M_TWO_PIf;
+    if (x >  M_HALF_PIf) x =  M_PIf - x;                                    // We just pick -90..+90 Degree
+    else if (x < -M_HALF_PIf) x = - M_PIf - x;
     float x2 = x * x;
     return x + x * x2 * (sinPolyCoef3 + x2 * (sinPolyCoef5 + x2 * (sinPolyCoef7 + x2 * sinPolyCoef9)));
 }
 
 float cos_approx(float x)
 {
-    return sin_approx(x + (0.5f * M_PIf));
+    return sin_approx(x + M_HALF_PIf);
 }
 
 // Initial implementation by Crashpilot1000 (https://github.com/Crashpilot1000/HarakiriWebstore1/blob/396715f73c6fcf859e0db0f34e12fe44bace6483/src/mw.c#L1292)

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -34,6 +34,8 @@
 
 // Use floating point M_PI instead explicitly.
 #define M_PIf       3.14159265358979323846f
+#define M_TWO_PIf   2.0f * M_PIf
+#define M_HALF_PIf  0.5f * M_PIf
 #define M_EULERf    2.71828182845904523536f
 
 #define RAD    (M_PIf / 180.0f)

--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -40,7 +40,7 @@ void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numB
 {
     if (!isInitialized) {
         rPowerN = powf(SDFT_R, SDFT_SAMPLE_SIZE);
-        const float c = 2.0f * M_PIf / (float)SDFT_SAMPLE_SIZE;
+        const float c = M_TWO_PIf / (float)SDFT_SAMPLE_SIZE;
         float phi = 0.0f;
         for (int i = 0; i < SDFT_BIN_COUNT; i++) {
             phi = c * i;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -212,11 +212,11 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
     float ex = 0, ey = 0, ez = 0;
     if (useCOG) {
         while (courseOverGround >  M_PIf) {
-            courseOverGround -= (2.0f * M_PIf);
+            courseOverGround -= M_TWO_PIf;
         }
 
         while (courseOverGround < -M_PIf) {
-            courseOverGround += (2.0f * M_PIf);
+            courseOverGround += M_TWO_PIf;
         }
 
         const float ez_ef = (- sin_approx(courseOverGround) * rMat[0][0] - cos_approx(courseOverGround) * rMat[1][0]);
@@ -332,11 +332,11 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
        imuQuaternionComputeProducts(&headfree, &buffer);
 
        attitude.values.roll = lrintf(atan2_approx((+2.0f * (buffer.wx + buffer.yz)), (+1.0f - 2.0f * (buffer.xx + buffer.yy))) * (1800.0f / M_PIf));
-       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(+2.0f * (buffer.wy - buffer.xz))) * (1800.0f / M_PIf));
+       attitude.values.pitch = lrintf((M_HALF_PIf - acos_approx(+2.0f * (buffer.wy - buffer.xz))) * (1800.0f / M_PIf));
        attitude.values.yaw = lrintf((-atan2_approx((+2.0f * (buffer.wz + buffer.xy)), (+1.0f - 2.0f * (buffer.yy + buffer.zz))) * (1800.0f / M_PIf)));
     } else {
        attitude.values.roll = lrintf(atan2_approx(rMat[2][1], rMat[2][2]) * (1800.0f / M_PIf));
-       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(-rMat[2][0])) * (1800.0f / M_PIf));
+       attitude.values.pitch = lrintf((M_HALF_PIf - acos_approx(-rMat[2][0])) * (1800.0f / M_PIf));
        attitude.values.yaw = lrintf((-atan2_approx(rMat[1][0], rMat[0][0]) * (1800.0f / M_PIf)));
     }
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -237,11 +237,11 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 
 #ifdef USE_ACC
     const float k = pt3FilterGain(ATTITUDE_CUTOFF_HZ, pidRuntime.dT);
-    const float angleCutoffHz = 1000.0f / (2.0f * M_PIf * pidProfile->angle_feedforward_smoothing_ms); // default of 80ms -> 2.0Hz, 160ms -> 1.0Hz, approximately
+    const float angleCutoffHz = 1000.0f / (M_TWO_PIf * pidProfile->angle_feedforward_smoothing_ms); // default of 80ms -> 2.0Hz, 160ms -> 1.0Hz, approximately
     const float k2 = pt3FilterGain(angleCutoffHz, pidRuntime.dT);
     pidRuntime.horizonDelayMs = pidProfile->horizon_delay_ms;
     if (pidRuntime.horizonDelayMs) {
-        const float horizonSmoothingHz = 1e3f / (2.0f * M_PIf * pidProfile->horizon_delay_ms); // default of 500ms means 0.318Hz
+        const float horizonSmoothingHz = 1e3f / (M_TWO_PIf * pidProfile->horizon_delay_ms); // default of 500ms means 0.318Hz
         const float kHorizon = pt1FilterGain(horizonSmoothingHz, pidRuntime.dT);
         pt1FilterInit(&pidRuntime.horizonSmoothingPt1, kHorizon);
     }

--- a/src/test/unit/maths_unittest.cc
+++ b/src/test/unit/maths_unittest.cc
@@ -176,7 +176,7 @@ TEST(MathsUnittest, TestConstrainf)
 TEST(MathsUnittest, TestDegreesToRadians)
 {
     EXPECT_FLOAT_EQ(degreesToRadians(0), 0.0f);
-    EXPECT_FLOAT_EQ(degreesToRadians(90), 0.5f * M_PIf);
+    EXPECT_FLOAT_EQ(degreesToRadians(90), M_HALF_PIf);
     EXPECT_FLOAT_EQ(degreesToRadians(180), M_PIf);
     EXPECT_FLOAT_EQ(degreesToRadians(-180), - M_PIf);
 }


### PR DESCRIPTION
Two simple refactoring suggestions... 

- instead of calculating `2 * Pi` and `0.5 * pi` locally, and doing so many times in the code, perhaps we can make these into constants, and
- simplify `sin_approx ` to remove some subtractions and duplications

Open to discussion as to whether this is worthwhile or not.  I note that sinApprox is used widely in IMU, Angle and GPS code, on multiple axes; efficiency here would reap some reward.
