### PR TITLE
Increase IMU yaw CoG gain at higher positive pitch angles

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -584,12 +584,13 @@ static void sensorUpdate(void)
         // gpsRescueAngle angle is in degrees * 100
         // pitchAngleFactor is 1 if pitch angle is 10 degrees
         // pitchAngleFactor is 2 if pitch angle is 20 degrees
-        if ((rescueState.phase == RESCUE_ATTAIN_ALT) || (rescueState.phase == RESCUE_ROTATE)) {
-            // zero IMU CoG yaw during climb or rotate, to stop IMU error accumulation arising from drift during long climbs
-            rescueState.sensor.imuYawCogGain = 0;
-        } else {
-            // up to 6x increase in CoG IMU Yaw gain
+        if (rescueState.phase == RESCUE_FLY_HOME) {
+            // only enhance imuYawCogGain during fly home
             rescueState.sensor.imuYawCogGain =  constrainf(1.0f + pitchAngleFactor + (2.0f * groundspeedErrorRatio), 1.0f, 6.0f);
+            // up to 6x increase in CoG IMU Yaw gain, with inputs from groundspeed error and pitch angle
+        } else {
+            rescueState.sensor.imuYawCogGain = 0;
+            // prevent IMU disorientation arising from drift during climb, rotate or descend phases
         }
         rescueState.sensor.groundspeedPitchAttenuator = 1.0f / constrainf(1.0f + groundspeedErrorRatio, 1.0f, 3.0f); // cut pitch angle by up to one third
     }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -493,14 +493,12 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     if (!useMag && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat > GPS_MIN_SAT_COUNT && gpsSol.groundSpeed >= GPS_COG_MIN_GROUNDSPEED) {
         // Use GPS course over ground to correct attitude.values.yaw
         courseOverGround = DECIDEGREES_TO_RADIANS(gpsSol.groundCourse);
-        if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-            cogYawGain = gpsRescueGetImuYawCogGain(); // do not modify IMU yaw gain unless in a rescue
-        }
+        cogYawGain = (FLIGHT_MODE(GPS_RESCUE_MODE)) ? gpsRescueGetImuYawCogGain() : 1.0f;
+        // normally update yaw heading with GPS data, but when in a Rescue, modify the IMU yaw gain dynamically
         if (shouldInitializeGPSHeading()) {
             // Reset our reference and reinitialize quaternion.
             // shouldInitializeGPSHeading() returns true only once.
             imuComputeQuaternionFromRPY(&qP, attitude.values.roll, attitude.values.pitch, gpsSol.groundCourse);
-
             cogYawGain = 0.0f; // Don't use the COG when we first initialize
         }
     }


### PR DESCRIPTION
@ledvinap encouraged consideration of a pitch angle based factor to dynamically modulate the IMU gain for yaw.

This PR implements this in a simple way during a GPS rescue.  It adds to the recent PR where we modulated the IMU gain based on groundspeed error.  In this PR we add another modulation factor based on pitch angle.

In this PR, when the pitch angle is positive, which normally would be associated with forward flight, the pitch angle in degrees divided by 10 is added to the IMU gain multiplier.  For example, if the quad pitched forward the full 45 degrees, we add 4.5 to the IMU gain value, bringing it close to the maximum allowed 6x gain.  Any IMU error should then correct more quickly when pitched forward.

This will be very useful when a rescue is initiated with minimal drift and a 180 degree IMU error. In this case, there is little or no groundspeed error at the start, but a significant velocity to home error.  The lack of a groundspeed error means that we almost immediately get a strong pitch forward in the completely wrong direction.  However it still takes 1-2 seconds before we get enough speed to boost the IMU gain enough to correct the error.  The quad can cover some 50-60m away from home in this time.  With this pitch based factor we should much more quickly get the desired IMU gain boost, because the pitch angle change precedes the groundspeed error factor.  The flyaway should be attenuated considerably.

In other common rescue situations, the drift factor will already be pushing the IMU gain factor high, so it won't help as much.  It is not likely to do any harm because while pitched forward, especially over time, we typically get a velocity over ground that is 'nose-forward' and appropriate for IMU correction.   

It should prevent IMU error accumulation when the quad is pitched backwards, as can sometimes happen in a rescue.

This approach could be applied more generally.  In non-GPS rescue flight, it is mostly true that the IMU is more likely to be correct when we are flying forwards, and that we are more likely to be flying forwards when we are requesting a positive pitch angle.  This is not always the case, however.  For example, the presence of strong side-winds, or being only slightly pitched forward while carrying significant prior sideways or rear-wards drift, or when there is a significant roll element, we may have a vector over ground that is not entirely nose-forward, and could even be be nose-backward.  Additionally, it takes time for a pitch forward attitude to generate forward speed, and also it takes time for that forward speed to 'bleed off'.  Hence a 'general' solution for IMU error would need to be implemented cautiously, perhaps using smoothing so that we respond primarily to a sustained pitch forward effect and not to transients, and probably considering the roll angle as well.  It would be great to have a more general solution, since then may be able to prevent many common IMU errors from developing.

However, in the GPS Rescue context, this PR is likely to help minimise the impact of common pre-existing IMU errors at the time a rescue starts.  Despite being a simple heuristic solution, we do need a short-term fix, especially for low-drift Rescue initiations with 180 degree pre-existing IMU errors.