### PR TITLE
[4.4.2] fixes not working Ghost on F4xx (#12809)

### DIFF
--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -245,9 +245,11 @@ void uartTxMonitor(uartPort_t *s)
     uartDevice_t *uart = container_of(s, uartDevice_t, port);
     IO_t txIO = IOGetByTag(uart->tx.pin);
 
-    // Switch TX to an input with pullup so it's state can be monitored
-    uart->txPinState = TX_PIN_MONITOR;
-    IOConfigGPIO(txIO, IOCFG_IPU);
+    if (uart->txPinState == TX_PIN_ACTIVE) {
+        // Switch TX to an input with pullup so it's state can be monitored
+        uart->txPinState = TX_PIN_MONITOR;
+        IOConfigGPIO(txIO, IOCFG_IPU);
+    }
 }
 
 static void handleUsartTxDma(uartPort_t *s)
@@ -335,7 +337,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);
             } else {
-                IOConfigGPIOAF(txIO, IOCFG_AF_PP, hardware->af);
+                IOConfigGPIOAF(txIO, IOCFG_AF_PP_UP, hardware->af);
             }
         }
 


### PR DESCRIPTION
* fixes not working Ghost on F4xx

In the original line that was replaced, this was IOCFG_AF_PP_UP.

Backport of #12809