### PR TITLE
rename GEPRCG4AIO

### DIFF
--- a/src/config/TAKERG4AIO/config.h
+++ b/src/config/TAKERG4AIO/config.h
@@ -20,7 +20,7 @@
  */
 
 #define FC_TARGET_MCU       STM32G47X
-#define BOARD_NAME          GEPRCG4AIO 
+#define BOARD_NAME          TAKERG4AIO 
 #define MANUFACTURER_ID     GEPR
 
 #define USE_ACC


### PR DESCRIPTION
Hi,


GEPRC wants to rename the GEPR-GEPRCG4AIO to GEPR-TAKERG4AIO

KR
David