### PR TITLE
Add cloud build instructions to Pull Request

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -9,12 +9,22 @@ jobs:
     name: Add artifact links to PR and issues
     runs-on: ubuntu-22.04
     steps:
+      - name: Get information about the original PR
+        uses: potiuk/get-workflow-origin@v1_5
+        id: get-info
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
       - name: Add artifact links to PR and issues
         uses: tonyhallett/artifacts-url-comments@v1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prefix: "**Do you want to test this code? Here you have an automated build:**"
-          suffix: "_**WARNING:** It may be unstable. Use only for testing! See: https://www.youtube.com/watch?v=I1uN9CN30gw for instructions for unified targets!_"
+          suffix: |
+            - See: https://www.youtube.com/watch?v=I1uN9CN30gw for instructions about installing this unified targets!
+            - An easier way to test this, using the Configurator cloud build, is simply put `#${{ steps.get-info.outputs.pullRequestNumber }}` (this pull request number) in the `Select commit` field of the Configurator firmware flasher tab (you need to `Enable expert mode`, `Show release candidates` and `Development`).
+
+            _**WARNING:** It may be unstable. Use only for testing!_
           format: name
           addTo: pull

--- a/.github/workflows/hide-artifact-links.yml
+++ b/.github/workflows/hide-artifact-links.yml
@@ -14,4 +14,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           starts-with: "**Do you want to test this code? Here you have an automated build:**"
-          ends-with: "_**WARNING:** It may be unstable. Use only for testing! See: https://www.youtube.com/watch?v=I1uN9CN30gw for instructions for unified targets!_"


### PR DESCRIPTION
This PR adds info to any PR with instructions about installing this code for tesing, using the cloud build. 
Until now we have the unified targets attached to the PR, but this gives an alternative and easier way to do it:

![image](https://github.com/betaflight/betaflight/assets/2673520/9fb0d81d-ef22-43e1-91e0-54d553c487d8)

Some things about this PR:
- Is good to let the unified targets option for testing? It does not serve for some of the tests since the cloud build because it is missing some features. I think it simply complicates the testing instructions. If some "developer" wants to test it without using the cloud build system, then he can build the code himself from the PR branch code. So, we remove this option or is better to let it like is now?
- If someone with a youtube channel wants to create a *short* video, only some seconds if possible, with the instructions to use the cloud build, I can add it to the message.
