### PR TITLE
Add PR cloud comment to maintenance branch too

### DIFF
--- a/.github/workflows/pr-cloud-comment.yml
+++ b/.github/workflows/pr-cloud-comment.yml
@@ -6,6 +6,9 @@ on:
       - master
       - '*-maintenance'
 
+permissions:
+  pull-requests: write
+
 jobs:
   comment-pr:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-cloud-comment.yml
+++ b/.github/workflows/pr-cloud-comment.yml
@@ -2,6 +2,9 @@ name: PR cloud build comment
 on:
   pull_request:
     types: [opened]
+    branches:
+      - master
+      - '*-maintenance'
 
 jobs:
   comment-pr:


### PR DESCRIPTION
Add filters to execute the action for master and maintenance branch only.

I don't know if we will need to merge this and the earlier https://github.com/betaflight/betaflight/pull/12834 into the maintenance branch too to be enabled on this branch. 
