### PR TITLE
Dimmable RPM harmonics

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1518,6 +1518,9 @@ static bool blackboxWriteSysinfo(void)
 #endif
 #ifdef USE_RPM_FILTER
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RPM_FILTER_HARMONICS, "%d",     rpmFilterConfig()->rpm_filter_harmonics);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RPM_FILTER_WEIGHTS, "%d,%d,%d", rpmFilterConfig()->rpm_filter_weights[0],
+                                                                              rpmFilterConfig()->rpm_filter_weights[1],
+                                                                              rpmFilterConfig()->rpm_filter_weights[2]);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RPM_FILTER_Q, "%d",             rpmFilterConfig()->rpm_filter_q);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RPM_FILTER_MIN_HZ, "%d",        rpmFilterConfig()->rpm_filter_min_hz);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RPM_FILTER_FADE_RANGE_HZ, "%d", rpmFilterConfig()->rpm_filter_fade_range_hz);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1720,6 +1720,7 @@ const clivalue_t valueTable[] = {
 
 #ifdef USE_RPM_FILTER
     { PARAM_NAME_RPM_FILTER_HARMONICS,     VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_harmonics) },
+    { PARAM_NAME_RPM_FILTER_WEIGHTS,       VAR_UINT8 | MASTER_VALUE | MODE_ARRAY, .config.array.length = RPM_FILTER_HARMONICS_MAX, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_weights) },
     { PARAM_NAME_RPM_FILTER_Q,             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 250, 3000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_q) },
     { PARAM_NAME_RPM_FILTER_MIN_HZ,        VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 30, 200 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_min_hz) },
     { PARAM_NAME_RPM_FILTER_FADE_RANGE_HZ, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_fade_range_hz) },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -116,6 +116,7 @@
 #define PARAM_NAME_SIMPLIFIED_GYRO_FILTER_MULTIPLIER "simplified_gyro_filter_multiplier"
 #define PARAM_NAME_DEBUG_MODE "debug_mode"
 #define PARAM_NAME_RPM_FILTER_HARMONICS "rpm_filter_harmonics"
+#define PARAM_NAME_RPM_FILTER_WEIGHTS "rpm_filter_weights"
 #define PARAM_NAME_RPM_FILTER_Q "rpm_filter_q"
 #define PARAM_NAME_RPM_FILTER_MIN_HZ "rpm_filter_min_hz"
 #define PARAM_NAME_RPM_FILTER_FADE_RANGE_HZ "rpm_filter_fade_range_hz"

--- a/src/main/pg/rpm_filter.c
+++ b/src/main/pg/rpm_filter.c
@@ -34,7 +34,8 @@ PG_RESET_TEMPLATE(rpmFilterConfig_t, rpmFilterConfig,
     .rpm_filter_min_hz = 100,
     .rpm_filter_fade_range_hz = 50,
     .rpm_filter_q = 500,
-    .rpm_filter_lpf_hz = 150
+    .rpm_filter_lpf_hz = 150,
+    .rpm_filter_weights = { 100, 100, 100 },
 );
 
 #endif // USE_RPM_FILTER

--- a/src/main/pg/rpm_filter.h
+++ b/src/main/pg/rpm_filter.h
@@ -24,9 +24,12 @@
 
 #include "pg/pg.h"
 
+#define RPM_FILTER_HARMONICS_MAX 3
+
 typedef struct rpmFilterConfig_s
 {
     uint8_t  rpm_filter_harmonics;     // how many harmonics should be covered with notches? 0 means filter off
+    uint8_t  rpm_filter_weights[RPM_FILTER_HARMONICS_MAX];  // effect or "weight" (0% - 100%) of each RPM filter harmonic
     uint8_t  rpm_filter_min_hz;        // minimum frequency of the notches
     uint16_t rpm_filter_fade_range_hz; // range in which to gradually turn off notches down to minHz
     uint16_t rpm_filter_q;             // q of the notches


### PR DESCRIPTION
This PR lets you adjust the amount of attenuation of each RPM harmonic between 0% and 100%, kind of like the layer opacity in Photoshop.

### CLI
This example sets the 1st harmonic to 100%, the 2nd to 0% and the 3rd to 80% filter effect. Filtering the 2nd harmonic is effectively disabled.
```
set rpm_filter_weights = 100, 0, 80
```