### PR TITLE
Fix cloud build comment action

### DIFF
--- a/.github/workflows/pr-cloud-comment.yml
+++ b/.github/workflows/pr-cloud-comment.yml
@@ -1,6 +1,6 @@
 name: PR cloud build comment
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches:
       - master


### PR DESCRIPTION
`pull_request` events, can't have write permissions when the PR comes from a fork.

It seems `pull_request_target` is the solution, it executes it in the "target" of the PR, in place of in the own PR.