### PR TITLE
Fix wrong test for BOXMSPOVERRIDE channel

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -601,7 +601,7 @@ if (systemConfig()->configurationState == CONFIGURATION_STATE_DEFAULTS_BARE) {
 
     for (int i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
         const modeActivationCondition_t *mac = modeActivationConditions(i);
-        if (mac->modeId == BOXMSPOVERRIDE && ((1 << (mac->auxChannelIndex) & (rxConfig()->msp_override_channels_mask)))) {
+        if (mac->modeId == BOXMSPOVERRIDE && ((1 << (mac->auxChannelIndex + NON_AUX_CHANNEL_COUNT) & (rxConfig()->msp_override_channels_mask)))) {
             rxConfigMutable()->msp_override_channels_mask &= ~(1 << (mac->auxChannelIndex + NON_AUX_CHANNEL_COUNT));
         }
     }


### PR DESCRIPTION
`msp_override_channels_mask` bits are indexed by raw channels, but `auxChannelIndex` (starting from `NON_AUX_CHANNEL_COUNT`) was used for test
