### PR TITLE
Upgrade stale action to v8

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@v8
       with:
         exempt-all-milestones: true
         days-before-stale: 30


### PR DESCRIPTION
The stale action is outdate, in the logs we can see a:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/stale@v4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates it to the latest version to get rid of this warning.