### PR TITLE
Enable retrieval of the BUILD_KEY using MSP2 (#12264)

### DIFF
--- a/src/main/build/version.c
+++ b/src/main/build/version.c
@@ -26,3 +26,9 @@ const char * const targetName = __TARGET__;
 const char * const shortGitRevision = __REVISION__;
 const char * const buildDate = __DATE__;
 const char * const buildTime = __TIME__;
+
+#ifdef BUILD_KEY
+const char * const buildKey = STR(BUILD_KEY);
+#else
+const char * const buildKey = " ";
+#endif

--- a/src/main/build/version.c
+++ b/src/main/build/version.c
@@ -28,7 +28,13 @@ const char * const buildDate = __DATE__;
 const char * const buildTime = __TIME__;
 
 #ifdef BUILD_KEY
-const char * const buildKey = STR(BUILD_KEY);
+    const char * const buildKey = STR(BUILD_KEY);
 #else
-const char * const buildKey = " ";
+    const char * const buildKey = NULL;
+#endif
+
+#if defined(BUILD_KEY) && defined(RELEASE_NAME)
+    const char * const releaseName = STR(RELEASE_NAME);
+#else
+    const char * const releaseName = NULL;
 #endif

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -42,3 +42,5 @@ extern const char* const buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
 extern const char* const buildTime;  // "HH:MM:SS"
 
 #define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR)
+
+extern const char* const buildKey;

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -44,3 +44,4 @@ extern const char* const buildTime;  // "HH:MM:SS"
 #define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR)
 
 extern const char* const buildKey;
+extern const char* const releaseName;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4814,7 +4814,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
 #endif
 
 #ifdef BUILD_KEY
-    cliPrintf("BUILD KEY: %s", STR(BUILD_KEY));
+    cliPrintf("BUILD KEY: %s", buildKey);
 #ifdef RELEASE_NAME
     cliPrintf(" (%s)", STR(RELEASE_NAME));
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4813,13 +4813,13 @@ static void cliStatus(const char *cmdName, char *cmdline)
     cliPrintLinef("OSD: %s (%u x %u)", lookupTableOsdDisplayPortDevice[displayPortDeviceType], osdDisplayPort->cols, osdDisplayPort->rows);
 #endif
 
-#ifdef BUILD_KEY
+if (buildKey) {
     cliPrintf("BUILD KEY: %s", buildKey);
-#ifdef RELEASE_NAME
-    cliPrintf(" (%s)", STR(RELEASE_NAME));
-#endif
+    if (releaseName) {
+        cliPrintf(" (%s)", releaseName);
+    }
     cliPrintLinefeed();
-#endif
+}
 
     // Uptime and wall clock
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2522,7 +2522,7 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
             // type byte, then length byte followed by the actual characters
             const uint8_t textType = sbufBytesRemaining(src) ? sbufReadU8(src) : 0;
 
-            char* textVar;
+            const char *textVar;
 
             switch (textType) {
                 case MSP2TEXT_PILOT_NAME:
@@ -2539,6 +2539,10 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
 
                 case MSP2TEXT_RATE_PROFILE_NAME:
                     textVar = currentControlRateProfile->profileName;
+                    break;
+
+                case MSP2TEXT_BUILDKEY:
+                    textVar = buildKey;
                     break;
 
                 default:

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2545,9 +2545,15 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
                     textVar = buildKey;
                     break;
 
+                case MSP2TEXT_RELEASENAME:
+                    textVar = releaseName;
+                    break;
+
                 default:
                     return MSP_RESULT_ERROR;
             }
+
+            if (!textVar) return MSP_RESULT_ERROR;
 
             const uint8_t textLength = strlen(textVar);
 

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -33,3 +33,4 @@
 #define MSP2TEXT_PID_PROFILE_NAME                3
 #define MSP2TEXT_RATE_PROFILE_NAME               4
 #define MSP2TEXT_BUILDKEY                        5
+#define MSP2TEXT_RELEASENAME                     6

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -32,3 +32,4 @@
 #define MSP2TEXT_CRAFT_NAME                      2
 #define MSP2TEXT_PID_PROFILE_NAME                3
 #define MSP2TEXT_RATE_PROFILE_NAME               4
+#define MSP2TEXT_BUILDKEY                        5

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -66,7 +66,8 @@ extern "C" {
     const uint16_t valueTableEntryCount = ARRAYLEN(valueTable);
     const lookupTableEntry_t lookupTables[] = {};
     const char * const lookupTableOsdDisplayPortDevice[] = {};
-
+    const char * const buildKey = NULL;
+    const char * const releaseName = NULL;
 
     PG_REGISTER(osdConfig_t, osdConfig, PG_OSD_CONFIG, 0);
     PG_REGISTER(batteryConfig_t, batteryConfig, PG_BATTERY_CONFIG, 0);


### PR DESCRIPTION
* Commit 1 (added by cherry-pick) enables retrieval of the BUILD_KEY using MSP2 to aid configurator firmware flasher options
* Commit 2 enables retrieval of the RELEASE_NAME.

Backport of https://github.com/betaflight/betaflight/pull/12264