### PR TITLE
Enables retrieval of the RELEASE_NAME using MSP2

### DIFF
--- a/src/main/build/version.c
+++ b/src/main/build/version.c
@@ -30,8 +30,14 @@ const char * const shortConfigGitRevision = __CONFIG_REVISION__;
 const char * const buildDate = __DATE__;
 const char * const buildTime = __TIME__;
 
-#if defined(BUILD_KEY)
-const char * const buildKey = STR(BUILD_KEY);
+#ifdef BUILD_KEY
+    const char * const buildKey = STR(BUILD_KEY);
 #else
-const char * const buildKey = " ";
+    const char * const buildKey = NULL;
+#endif
+
+#if defined(BUILD_KEY) && defined(RELEASE_NAME)
+    const char * const releaseName = STR(RELEASE_NAME);
+#else
+    const char * const releaseName = NULL;
 #endif

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -47,3 +47,4 @@ extern const char* const buildTime;  // "HH:MM:SS"
 #define MSP_API_VERSION_STRING STR(API_VERSION_MAJOR) "." STR(API_VERSION_MINOR)
 
 extern const char* const buildKey;
+extern const char* const releaseName;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4728,14 +4728,13 @@ static void cliStatus(const char *cmdName, char *cmdline)
     cliPrintLinef("OSD: %s (%u x %u)", lookupTableOsdDisplayPortDevice[displayPortDeviceType], osdDisplayPort->cols, osdDisplayPort->rows);
 #endif
 
-#ifdef BUILD_KEY
+if (buildKey) {
     cliPrintf("BUILD KEY: %s", buildKey);
-#ifdef RELEASE_NAME
-    cliPrintf(" (%s)", STR(RELEASE_NAME));
-#endif
+    if (releaseName) {
+        cliPrintf(" (%s)", releaseName);
+    }
     cliPrintLinefeed();
-#endif
-
+}
     // Uptime and wall clock
 
     cliPrintf("System Uptime: %d seconds", millis() / 1000);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2551,9 +2551,15 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
                     textVar = buildKey;
                     break;
 
+                case MSP2TEXT_RELEASENAME:
+                    textVar = releaseName;
+                    break;
+
                 default:
                     return MSP_RESULT_ERROR;
             }
+
+            if (!textVar) return MSP_RESULT_ERROR;
 
             const uint8_t textLength = strlen(textVar);
 

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -33,3 +33,4 @@
 #define MSP2TEXT_PID_PROFILE_NAME                3
 #define MSP2TEXT_RATE_PROFILE_NAME               4
 #define MSP2TEXT_BUILDKEY                        5
+#define MSP2TEXT_RELEASENAME                     6

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -68,6 +68,8 @@ extern "C" {
     const uint16_t valueTableEntryCount = ARRAYLEN(valueTable);
     const lookupTableEntry_t lookupTables[] = {};
     const char * const lookupTableOsdDisplayPortDevice[] = {};
+    const char * const buildKey = NULL;
+    const char * const releaseName = NULL;
 
 
     PG_REGISTER(osdConfig_t, osdConfig, PG_OSD_CONFIG, 0);


### PR DESCRIPTION
In addition to #12264 this enables retrieval of build options from a previous version.

See also: #12876
