### PR TITLE
GPIO alternate function initialisation removal for HAL.

### DIFF
--- a/src/main/drivers/at32/timer_at32bsp.c
+++ b/src/main/drivers/at32/timer_at32bsp.c
@@ -670,11 +670,6 @@ _TIM_IRQ_HANDLER(TMR8_TRG_HALL_TMR14_IRQnHandler, 14);
 _TIM_IRQ_HANDLER(TMR20_CH_IRQnHandler, 20);
 #endif
 
-
-void timerIOInit(void)
-{
-}
-
 void timerInit(void)
 {
     memset(timerConfig, 0, sizeof(timerConfig));

--- a/src/main/drivers/stm32/timer_hal.c
+++ b/src/main/drivers/stm32/timer_hal.c
@@ -1043,17 +1043,6 @@ void timerInit(void)
     }
 }
 
-void timerIOInit(void)
-{
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-    for (unsigned timerIndex = 0; timerIndex < TIMER_CHANNEL_COUNT; timerIndex++) {
-        const timerHardware_t *timerHardwarePtr = &TIMER_HARDWARE[timerIndex];
-        // XXX IOConfigGPIOAF in timerInit should eventually go away.
-        IOConfigGPIOAF(IOGetByTag(timerHardwarePtr->tag), IOCFG_AF_PP, timerHardwarePtr->alternateFunction);
-    }
-#endif
-}
-
 // finish configuring timers after allocation phase
 // start timers
 // TODO - Work in progress - initialization routine must be modified/verified to start correctly without timers

--- a/src/main/drivers/stm32/timer_stdperiph.c
+++ b/src/main/drivers/stm32/timer_stdperiph.c
@@ -851,10 +851,6 @@ void timerInit(void)
     }
 }
 
-void timerIOInit(void)
-{
-    // No-op
-}
 // finish configuring timers after allocation phase
 // start timers
 // TODO - Work in progress - initialization routine must be modified/verified to start correctly without timers

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -127,7 +127,6 @@ void timerConfigure(const timerHardware_t *timHw, uint16_t period, uint32_t hz);
 // Initialisation
 //
 void timerInit(void);
-void timerIOInit(void);
 void timerStart(void);
 
 //

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -271,15 +271,6 @@ void init(void)
     // initialize IO (needed for all IO operations)
     IOInitGlobal();
 
-#ifdef USE_TIMER
-    // timerIOInit blindly reconfigures GPIO AF for all pins in the fullTimerHardware array regardless
-    // of if the timer pin is used already by something else.
-    // If it is called AFTER the SPI initilisation, any AF settings for the SPI are overridden by timer
-    // AF, making the SPI hang when it's used.
-    // To work-around this issue init timer AF before other AF, such as SPI/QSPI/OSPI/etc.
-    timerIOInit();
-#endif
-
 #ifdef USE_HARDWARE_REVISION_DETECTION
     detectHardwareRevision();
 #endif

--- a/src/main/target/SITL/sitl.c
+++ b/src/main/target/SITL/sitl.c
@@ -358,10 +358,6 @@ void timerInit(void)
     printf("[timer]Init...\n");
 }
 
-void timerIOInit(void)
-{
-}
-
 void timerStart(void)
 {
 }


### PR DESCRIPTION
The all timer initialisation was actually not required as the initialisation is located where needed, which is a requirement for STD PERIPH / AT32 in any case. 

The previous for loop excluded the actual setup as all the full timer hardware entries where TIM_USE_ANY.
