### PR TITLE
Fix g force calculation

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1271,6 +1271,7 @@ void osdProcessStats2(timeUs_t currentTimeUs)
 void osdProcessStats3(void)
 {
 #if defined(USE_ACC)
+    osdGForce = 0.0f;
     if (sensors(SENSOR_ACC)
        && (VISIBLE(osdElementConfig()->item_pos[OSD_G_FORCE]) || osdStatGetState(OSD_STAT_MAX_G_FORCE))) {
             // only calculate the G force if the element is visible or the stat is enabled


### PR DESCRIPTION
This line of code seems to have been lost in [this refactor](https://github.com/betaflight/betaflight/commit/30672a37c52c5be69c615e5b5bfca664ed6b5ce0#diff-a680ca1e23901579e9214c055509004e8b5c05e3f7281ed74ac1edfc38caabae). Without it the G force indicator in the OSD only works until about 1.5-2G. When it gets any higher the value seems to accumulate and the OSD shows fluctuating garbage values of "0.xG" (x = random digit).

I tested the same code change on v4.4.2 and it worked, showing plausible values. I did not yet test it on master branch.

I did not manage to run either `make pre-push` or `make unified_zip`. Both failed with "No rule to make target [...]". Am I doing something wrong or is the PR preset just outdated?
