### PR TITLE
Report GPS home latitude and longitude

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1530,6 +1530,10 @@ case MSP_NAME:
         sbufWriteU16(dst, GPS_distanceToHome);
         sbufWriteU16(dst, GPS_directionToHome / 10); // resolution increased in Betaflight 4.4 by factor of 10, this maintains backwards compatibility for DJI OSD
         sbufWriteU8(dst, GPS_update & 1);
+        // Added in API version 1.46
+        // report GPS home position
+        sbufWriteU32(dst, GPS_home[GPS_LATITUDE]);
+        sbufWriteU32(dst, GPS_home[GPS_LONGITUDE]);
         break;
 
     case MSP_GPSSVINFO:


### PR DESCRIPTION
This PR prepare to report GPS home latitude and longitude in call to MSP_COMP_GPS

To be used by ex configurator to show the GPS home position like last line in GPS status:
![image](https://github.com/betaflight/betaflight/assets/99370924/07665186-acad-4f59-8095-fb7fed3965dd)

Provides support for [https://github.com/betaflight/betaflight-configurator/pull/3486](https://github.com/betaflight/betaflight-configurator/pull/3486)
