### PR TITLE
Fix Serial USB COM port

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -499,7 +499,7 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
 #else
         else if (
             (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1) ||
-            (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1)
+            (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL2)
         )
 #endif
         {

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -492,12 +492,17 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
             }
         }
 #endif
+        else if ((serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1
 #ifdef USE_SOFTSERIAL
-        else if (!softserialEnabled &&
-            ((softSerialPinConfig()->ioTagTx[SOFTSERIAL1] || serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1) ||
-            (softSerialPinConfig()->ioTagTx[SOFTSERIAL2] || serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL2)))
+            && !(softserialEnabled && (softSerialPinConfig()->ioTagTx[SOFTSERIAL1] ||
+                softSerialPinConfig()->ioTagRx[SOFTSERIAL1]))
 #endif
-        {
+           ) || (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL2
+#ifdef USE_SOFTSERIAL
+            && !(softserialEnabled && (softSerialPinConfig()->ioTagTx[SOFTSERIAL2] ||
+                softSerialPinConfig()->ioTagRx[SOFTSERIAL2]))
+#endif
+        )) {
             serialPortUsageList[index].identifier = SERIAL_PORT_NONE;
             serialPortCount--;
         }

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -492,17 +492,17 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
             }
         }
 #endif
-        else if ((serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1
 #ifdef USE_SOFTSERIAL
-            && !(softserialEnabled && (softSerialPinConfig()->ioTagTx[SOFTSERIAL1] ||
-                softSerialPinConfig()->ioTagRx[SOFTSERIAL1]))
+        else if (!softserialEnabled &&
+            ((softSerialPinConfig()->ioTagTx[SOFTSERIAL1] || serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1) ||
+            (softSerialPinConfig()->ioTagTx[SOFTSERIAL2] || serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL2)))
+#else
+        else if (
+            (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1) ||
+            (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL1)
+        )
 #endif
-           ) || (serialPortUsageList[index].identifier == SERIAL_PORT_SOFTSERIAL2
-#ifdef USE_SOFTSERIAL
-            && !(softserialEnabled && (softSerialPinConfig()->ioTagTx[SOFTSERIAL2] ||
-                softSerialPinConfig()->ioTagRx[SOFTSERIAL2]))
-#endif
-        )) {
+        {
             serialPortUsageList[index].identifier = SERIAL_PORT_NONE;
             serialPortCount--;
         }


### PR DESCRIPTION
After the softserial rework, when a target does not have "USE_SOFTSERIAL" the identifier for softserial will not be set to "none", thus somehow breaks the virtual com port.