### PR TITLE
Add dshot_telemetry_start_margin setting

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -853,6 +853,7 @@ const clivalue_t valueTable[] = {
 #ifdef USE_DSHOT_BITBANG
     { "dshot_bitbang",               VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotBitbang) },
     { "dshot_bitbang_timer",         VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_DSHOT_BITBANGED_TIMER }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useDshotBitbangedTimer) },
+    { "dshot_telemetry_start_margin", VAR_UINT8  | HARDWARE_VALUE , .config.minmaxUnsigned = { 0, 100 }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.telemetryStartMargin) },
 #endif
 #endif
     { PARAM_NAME_USE_UNSYNCED_PWM,  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, dev.useUnsyncedPwm) },

--- a/src/main/drivers/dshot_bitbang_decode.c
+++ b/src/main/drivers/dshot_bitbang_decode.c
@@ -49,8 +49,6 @@ uint16_t bbBuffer[134];
 #define BITBAND_SRAM_BASE  0x22000000
 #define BITBAND_SRAM(a,b) ((BITBAND_SRAM_BASE + (((a)-BITBAND_SRAM_REF)<<5) + ((b)<<2)))  // Convert SRAM address
 
-#define DSHOT_TELEMETRY_START_MARGIN 10
-
 static uint8_t preambleSkip = 0;
 
 typedef struct bitBandWord_s {
@@ -217,7 +215,13 @@ uint32_t decode_bb_bitband( uint16_t buffer[], uint32_t count, uint32_t bit)
 #endif
 
     // The anticipated edges were observed
-    preambleSkip = startMargin - DSHOT_TELEMETRY_START_MARGIN;
+
+    // Attempt to skip the preamble ahead of the telemetry to save CPU
+    if (startMargin > motorConfig()->dev.telemetryStartMargin) {
+        preambleSkip = startMargin - motorConfig()->dev.telemetryStartMargin;
+    } else {
+        preambleSkip = 0;
+    }
 
     if (nlen > 0) {
         value <<= nlen;
@@ -325,7 +329,13 @@ FAST_CODE uint32_t decode_bb( uint16_t buffer[], uint32_t count, uint32_t bit)
     }
 
     // The anticipated edges were observed
-    preambleSkip = startMargin - DSHOT_TELEMETRY_START_MARGIN;
+
+    // Attempt to skip the preamble ahead of the telemetry to save CPU
+    if (startMargin > motorConfig()->dev.telemetryStartMargin) {
+        preambleSkip = startMargin - motorConfig()->dev.telemetryStartMargin;
+    } else {
+        preambleSkip = 0;
+    }
 
     if (nlen > 0) {
         value <<= nlen;

--- a/src/main/pg/motor.c
+++ b/src/main/pg/motor.c
@@ -44,6 +44,10 @@
 #define DEFAULT_DSHOT_BURST DSHOT_DMAR_OFF
 #endif
 
+#if !defined(DSHOT_TELEMETRY_START_MARGIN)
+#define DSHOT_TELEMETRY_START_MARGIN 10
+#endif
+
 PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 2);
 
 void pgResetFn_motorConfig(motorConfig_t *motorConfig)
@@ -110,6 +114,7 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
 #ifdef USE_DSHOT_BITBANG
     motorConfig->dev.useDshotBitbang = DEFAULT_DSHOT_BITBANG;
     motorConfig->dev.useDshotBitbangedTimer = DSHOT_BITBANGED_TIMER_DEFAULT;
+    motorConfig->dev.telemetryStartMargin = DSHOT_TELEMETRY_START_MARGIN;
 #endif
 }
 

--- a/src/main/pg/motor.h
+++ b/src/main/pg/motor.h
@@ -50,6 +50,7 @@ typedef struct motorDevConfig_s {
     uint8_t  useDshotBitbang;
     uint8_t  useDshotBitbangedTimer;
     uint8_t  motorOutputReordering[MAX_SUPPORTED_MOTORS]; // Reindexing motors for "remap motors" feature in Configurator
+    uint8_t  telemetryStartMargin;
 } motorDevConfig_t;
 
 typedef struct motorConfig_s {


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/12612 introduced an optimisation where the number of cycles of preamble preceding the DSHOT telemetry was counted and recorded, and then on subsequent cycles the code could skip forwards that count, less a margin, in the input buffer to reduct CPU load. This virtually eliminated dropped DSHOT frames.

Whilst this works with BLHeli32 with a margin of 10 cycles it has been noted by @limon and in a conversation at https://discord.com/channels/868013470023548938/1120926144682791064 that AM32 suffers from high error rates at high RPM. It has been observed that the time from the DSHOT command being sent to the start of telemetry reception varies randomly from approx 30us down to 23us at higher RPM. 

The margin therefore needs to be increased on AM32.

The `dshot_telemetry_start_margin` has a default value of `10` to match current behaviour and a valid range of `0` to `100`. A value less than `4` causes errors to rise with BLHeli32.

@limon please test with AM32 and increase this value to see if it will fix the errors.

If you debug with `DSHOT_TELEMETRY_COUNTS` and look at debug 3 on the sensors tab you'll see the max valid value beyond which no preamble skipping is done. For BLHeli32 and `DSHOT300` this is `29`, and for `DSHOT150` it's `16`.