### PR TITLE
Fix: disable sag compensation if RPM limit is active

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -65,12 +65,6 @@
 #define DYN_LPF_THROTTLE_STEPS           100
 #define DYN_LPF_THROTTLE_UPDATE_DELAY_US 5000 // minimum of 5ms between updates
 
-#ifdef USE_RPM_LIMIT
-#define RPM_LIMIT_ACTIVE mixerConfig()->rpm_limit
-#else
-#define RPM_LIMIT_ACTIVE false
-#endif
-
 static FAST_DATA_ZERO_INIT float motorMixRange;
 
 float FAST_DATA_ZERO_INIT motor[MAX_SUPPORTED_MOTORS];

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -109,6 +109,12 @@ PG_DECLARE(mixerConfig_t, mixerConfig);
 
 #define CHANNEL_FORWARDING_DISABLED (uint8_t)0xFF
 
+#ifdef USE_RPM_LIMIT
+#define RPM_LIMIT_ACTIVE mixerConfig()->rpm_limit
+#else
+#define RPM_LIMIT_ACTIVE false
+#endif
+
 extern const mixer_t mixers[];
 extern float motor[MAX_SUPPORTED_MOTORS];
 extern float motor_disarmed[MAX_SUPPORTED_MOTORS];

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -37,6 +37,7 @@
 #include "fc/controlrate_profile.h"
 #include "fc/runtime_config.h"
 
+#include "mixer.h"
 #include "flight/mixer_tricopter.h"
 #include "flight/pid.h"
 
@@ -345,7 +346,7 @@ void mixerInitProfile(void)
 
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     mixerRuntime.vbatSagCompensationFactor = 0.0f;
-    if (currentPidProfile->vbat_sag_compensation > 0) {
+    if (currentPidProfile->vbat_sag_compensation > 0 && !RPM_LIMIT_ACTIVE) {
         //TODO: Make this voltage user configurable
         mixerRuntime.vbatFull = CELL_VOLTAGE_FULL_CV;
         mixerRuntime.vbatRangeToCompensate = mixerRuntime.vbatFull - batteryConfig()->vbatwarningcellvoltage;

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -35,6 +35,7 @@
 
 #include "drivers/adc.h"
 
+#include "flight/mixer.h"
 #include "flight/pid.h"
 
 #include "pg/pg.h"
@@ -235,7 +236,7 @@ void voltageMeterGenericInit(void)
     sagCompensationConfigured = false;
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {
-        if (pidProfiles(i)->vbat_sag_compensation > 0) {
+        if (pidProfiles(i)->vbat_sag_compensation > 0 && !RPM_LIMIT_ACTIVE) {
             sagCompensationConfigured = true;
         }
     }


### PR DESCRIPTION
Sag compensation is useless when RPM limiter is active.
And it messes up the RPM limiter.

So need to internally deactivate sag compensation, if RPM limiter is active.