### PR TITLE
Handle USART TX pulldown

### DIFF
--- a/src/main/drivers/at32/serial_uart_at32f43x.c
+++ b/src/main/drivers/at32/serial_uart_at32f43x.c
@@ -315,7 +315,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
                 uartdev->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/drivers/stm32/serial_uart_hal.c
+++ b/src/main/drivers/stm32/serial_uart_hal.c
@@ -264,9 +264,10 @@ bool checkUsartTxOutput(uartPort_t *s)
 void uartTxMonitor(uartPort_t *s)
 {
     uartDevice_t *uart = container_of(s, uartDevice_t, port);
-    IO_t txIO = IOGetByTag(uart->tx.pin);
 
     if (uart->txPinState == TX_PIN_ACTIVE) {
+        IO_t txIO = IOGetByTag(uart->tx.pin);
+
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;
         IOConfigGPIO(txIO, IOCFG_IPU);

--- a/src/main/drivers/stm32/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f4xx.c
@@ -245,9 +245,10 @@ bool checkUsartTxOutput(uartPort_t *s)
 void uartTxMonitor(uartPort_t *s)
 {
     uartDevice_t *uart = container_of(s, uartDevice_t, port);
-    IO_t txIO = IOGetByTag(uart->tx.pin);
 
     if (uart->txPinState == TX_PIN_ACTIVE) {
+        IO_t txIO = IOGetByTag(uart->tx.pin);
+
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;
         IOConfigGPIO(txIO, IOCFG_IPU);
@@ -334,7 +335,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
                 uart->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/drivers/stm32/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f7xx.c
@@ -376,7 +376,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
                 uartdev->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/drivers/stm32/serial_uart_stm32g4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32g4xx.c
@@ -309,7 +309,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
                 uartdev->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/drivers/stm32/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32h7xx.c
@@ -486,7 +486,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if ((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) {
+            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
                 uartdev->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -707,12 +707,7 @@ bool vtxSmartAudioInit(void)
     // the SA protocol instead requires pulldowns, and therefore uses SERIAL_BIDIR_PP_PD instead of SERIAL_BIDIR_PP
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_SMARTAUDIO);
     if (portConfig) {
-        portOptions_e portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR_NOPULL;
-#if defined(USE_VTX_COMMON)
-        portOptions = portOptions | (vtxConfig()->halfDuplex ? SERIAL_BIDIR | SERIAL_BIDIR_PP_PD : SERIAL_UNIDIR);
-#else
-        portOptions = SERIAL_BIDIR;
-#endif
+        portOptions_e portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR | SERIAL_BIDIR_PP_PD;
 
         smartAudioSerialPort = openSerialPort(portConfig->identifier, FUNCTION_VTX_SMARTAUDIO, NULL, NULL, 4800, MODE_RXTX, portOptions);
     }


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/12760 would stall transmission if the TX line was pulled down, but SmartAudio uses a pulldown, do don't use this behaviour under such circumstances.

Also, always configure SmartAudio to be bi-directional.