### PR TITLE
Revert 12512

### DIFF
--- a/src/main/config/feature.h
+++ b/src/main/config/feature.h
@@ -59,7 +59,6 @@ typedef enum {
     FEATURE_CHANNEL_FORWARDING = 1 << 20,
     FEATURE_TRANSPONDER = 1 << 21,
     FEATURE_AIRMODE = 1 << 22,
-    FEATURE_VTX = 1 << 24,
     FEATURE_RX_SPI = 1 << 25,
     //FEATURE_SOFTSPI = 1 << 26, (removed)
     FEATURE_ESC_SENSOR = 1 << 27,

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -364,10 +364,6 @@
 #define USE_USB_ADVANCED_PROFILES
 #endif
 
-#if defined(USE_VTX) && !defined(DEFAULT_FEATURES)
-#define DEFAULT_FEATURES FEATURE_VTX
-#endif
-
 #if !defined(USE_OSD)
 #undef USE_RX_LINK_QUALITY_INFO
 #undef USE_OSD_PROFILES


### PR DESCRIPTION
Revert #12512
Adding support only would require additional code (i.e. cli for feature command) and did not work as intended.