### PR TITLE
Makefile - use -gddb2, not -gddb3 due to issues with GDB crashing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,10 +145,10 @@ ifeq ($(DEBUG),GDB)
 OPTIMISE_DEFAULT      := -Og
 
 LTO_FLAGS             := $(OPTIMISE_DEFAULT)
-DEBUG_FLAGS            = -ggdb3 -gdwarf-5 -DDEBUG
+DEBUG_FLAGS            = -ggdb2 -gdwarf-5 -DDEBUG
 else
 ifeq ($(DEBUG),INFO)
-DEBUG_FLAGS            = -ggdb3
+DEBUG_FLAGS            = -ggdb2
 endif
 OPTIMISATION_BASE     := -flto -fuse-linker-plugin -ffast-math -fmerge-all-constants
 OPTIMISE_DEFAULT      := -O2


### PR DESCRIPTION
The cause seems to be the macro debugging information which when generated by the compiler, apparently incorrectly, causes GDB to use excessive amounts of CPU and crash.

Error:
"gdb/utils.c:717\
: internal-error: virtual memory exhausted: can't allocate 4064 bytes.\nA problem internal to GDB ha\
s been detected,\nfurther debugging may prove unreliable."

Reference:
* https://sourceware.org/bugzilla/show_bug.cgi?id=28219#c15
* https://github.com/microsoft/vscode-cpptools/issues/9219#issuecomment-1118034083

Note this crashing behavior is observed with `GCC > 9.3.1`, `9.3.1` itself is OK.

