### PR TITLE
Only switch TX line to input if transmission is complete

### DIFF
--- a/src/main/drivers/stm32/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f4xx.c
@@ -390,9 +390,6 @@ void uartIrqHandler(uartPort_t *s)
             s->port.txBufferTail = (s->port.txBufferTail + 1) % s->port.txBufferSize;
         } else {
             USART_ITConfig(s->USARTx, USART_IT_TXE, DISABLE);
-
-            // Switch TX to an input with pullup so it's state can be monitored
-            uartTxMonitor(s);
         }
     }
 


### PR DESCRIPTION
Only switch TX to input once transmission is actually complete, not when last character is transferring into the shift register.