### PR TITLE
Adding OSD quick menu

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -150,6 +150,7 @@ COMMON_SRC = \
             cms/cms_menu_vtx_smartaudio.c \
             cms/cms_menu_vtx_tramp.c \
             cms/cms_menu_persistent_stats.c \
+            cms/cms_menu_quick.c \
             drivers/display_ug2864hsweg01.c \
             drivers/light_ws2811strip.c \
             drivers/rangefinder/rangefinder_hcsr04.c \
@@ -410,6 +411,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             cms/cms_menu_vtx_smartaudio.c \
             cms/cms_menu_vtx_tramp.c \
             cms/cms_menu_persistent_stats.c \
+            cms/cms_menu_quick.c \
             io/vtx.c \
             io/vtx_rtc6705.c \
             io/vtx_smartaudio.c \

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -150,6 +150,7 @@ COMMON_SRC = \
             cms/cms_menu_vtx_smartaudio.c \
             cms/cms_menu_vtx_tramp.c \
             cms/cms_menu_persistent_stats.c \
+            cms/cms_menu_rpm_limit.c \
             cms/cms_menu_quick.c \
             drivers/display_ug2864hsweg01.c \
             drivers/light_ws2811strip.c \
@@ -411,6 +412,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             cms/cms_menu_vtx_smartaudio.c \
             cms/cms_menu_vtx_tramp.c \
             cms/cms_menu_persistent_stats.c \
+            cms/cms_menu_rpm_limit.c \
             cms/cms_menu_quick.c \
             io/vtx.c \
             io/vtx_rtc6705.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1367,8 +1367,9 @@ const clivalue_t valueTable[] = {
     { "osd_ah_invert",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahInvert) },
     { "osd_logo_on_arming",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OSD_LOGO_ON_ARMING }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming) },
     { "osd_logo_on_arming_duration",VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming_duration) },
-    { "extra_osd_use_quick_menu",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, extra_osd_use_quick_menu) },
-
+#ifdef USE_QUICK_OSD_MENU
+    { "osd_use_quick_menu",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_use_quick_menu) },
+#endif // USE_QUICK_OSD_MENU
     { "osd_tim1",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, timers[OSD_TIMER_1]) },
     { "osd_tim2",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, timers[OSD_TIMER_2]) },
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1367,6 +1367,7 @@ const clivalue_t valueTable[] = {
     { "osd_ah_invert",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahInvert) },
     { "osd_logo_on_arming",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OSD_LOGO_ON_ARMING }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming) },
     { "osd_logo_on_arming_duration",VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming_duration) },
+    { "extra_osd_use_quick_menu",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, extra_osd_use_quick_menu) },
 
     { "osd_tim1",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, timers[OSD_TIMER_1]) },
     { "osd_tim2",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, timers[OSD_TIMER_2]) },

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -41,6 +41,7 @@
 #include "build/version.h"
 
 #include "cms/cms.h"
+#include "cms/cms_menu_quick.h"
 #include "cms/cms_menu_main.h"
 #include "cms/cms_menu_saveexit.h"
 #include "cms/cms_types.h"
@@ -845,7 +846,7 @@ const void *cmsMenuChange(displayPort_t *pDisplay, const void *ptr)
     if (pMenu != currentCtx.menu) {
         saveMenuInhibited = false;
 
-        if (currentCtx.menu) {
+        if (currentCtx.menu && pMenu != &cmsx_menuMain) {
             // If we are opening the initial top-level menu, then currentCtx.menu will be NULL and nothing to do.
             // Otherwise stack the current menu before moving to the selected menu.
             if (menuStackIdx >= CMS_MENU_STACK_LIMIT - 1) {
@@ -896,6 +897,12 @@ void cmsMenuOpen(void)
         cmsInMenu = true;
         currentCtx = (cmsCtx_t){ NULL, 0, 0 };
         startMenu = &cmsx_menuMain;
+
+        if (osdConfig()->extra_osd_use_quick_menu)
+        {
+            startMenu = &cmsx_menuQuick;
+        }
+
         menuStackIdx = 0;
         setArmingDisabled(ARMING_DISABLED_CMS_MENU);
         displayLayerSelect(pCurrentDisplay, DISPLAYPORT_LAYER_FOREGROUND); // make sure the foreground layer is active

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -41,9 +41,9 @@
 #include "build/version.h"
 
 #include "cms/cms.h"
-#include "cms/cms_menu_quick.h"
 #include "cms/cms_menu_main.h"
 #include "cms/cms_menu_saveexit.h"
+#include "cms/cms_menu_quick.h"
 #include "cms/cms_types.h"
 
 #include "common/maths.h"
@@ -899,8 +899,7 @@ void cmsMenuOpen(void)
         startMenu = &cmsx_menuMain;
 
 #ifdef USE_QUICK_OSD_MENU
-        if (osdConfig()->osd_use_quick_menu)
-        {
+        if (osdConfig()->osd_use_quick_menu) {
             startMenu = &cmsx_menuQuick;
         }
 #endif // USE_QUICK_OSD_MENU

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -898,10 +898,12 @@ void cmsMenuOpen(void)
         currentCtx = (cmsCtx_t){ NULL, 0, 0 };
         startMenu = &cmsx_menuMain;
 
-        if (osdConfig()->extra_osd_use_quick_menu)
+#ifdef USE_QUICK_OSD_MENU
+        if (osdConfig()->osd_use_quick_menu)
         {
             startMenu = &cmsx_menuQuick;
         }
+#endif // USE_QUICK_OSD_MENU
 
         menuStackIdx = 0;
         setArmingDisabled(ARMING_DISABLED_CMS_MENU);

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//
+// Main menu structure and support functions
+//
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "platform.h"
+
+#ifdef USE_CMS
+
+#include "cms/cms.h"
+#include "cms/cms_types.h"
+
+// Sub menus
+
+#include "cms/cms_menu_imu.h"
+#include "cms/cms_menu_blackbox.h"
+#include "cms/cms_menu_failsafe.h"
+#include "cms/cms_menu_firmware.h"
+#include "cms/cms_menu_ledstrip.h"
+#include "cms/cms_menu_misc.h"
+#include "cms/cms_menu_osd.h"
+#include "cms/cms_menu_power.h"
+#include "cms/cms_menu_saveexit.h"
+#include "cms/cms_menu_main.h"
+
+#ifdef USE_PERSISTENT_STATS
+#include "cms/cms_menu_persistent_stats.h"
+#endif
+
+// VTX supplied menus
+
+#include "cms/cms_menu_vtx_common.h"
+
+#include "common/printf.h"
+#include "fc/controlrate_profile.h"
+#include "config/config.h"
+
+#include "fc/core.h"
+#include "fc/runtime_config.h"
+
+#include "sensors/acceleration.h"
+
+#include "cms_menu_quick.h"
+
+#include "sensors/battery.h"
+
+#include "flight/pid.h"
+#include "flight/pid_init.h"
+
+#include "drivers/pwm_output.h"
+
+// Features
+
+static controlRateConfig_t rateProfile;
+static uint8_t rateProfileIndex;
+static batteryConfig_t batteryProfile;
+static uint8_t  cmsx_motorOutputLimit;
+static uint8_t pidProfileIndex;
+static pidProfile_t *pidProfile;
+
+static const void *quickMenuOnEnter(displayPort_t *pDisp)
+{
+    UNUSED(pDisp);
+    pidProfileIndex = getCurrentPidProfileIndex();
+    pidProfile = pidProfilesMutable(pidProfileIndex);
+
+    rateProfileIndex = getCurrentControlRateProfileIndex();
+    memcpy(&rateProfile, controlRateProfiles(rateProfileIndex), sizeof(controlRateConfig_t));
+    memcpy(&batteryProfile, batteryConfigMutable(), sizeof(batteryConfig_t));
+
+    cmsx_motorOutputLimit = pidProfile->motor_output_limit;
+
+    // fill variables
+    return NULL;
+}
+
+static const void *cmsx_RateProfileWriteback(displayPort_t *pDisp, const OSD_Entry *self)
+{
+    UNUSED(pDisp);
+    UNUSED(self);
+
+    memcpy(controlRateProfilesMutable(rateProfileIndex), &rateProfile, sizeof(controlRateConfig_t));
+        memcpy(batteryConfigMutable(), &batteryProfile, sizeof(batteryConfig_t));
+
+    pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);
+    pidProfile->motor_output_limit = cmsx_motorOutputLimit;
+
+    pidInitConfig(currentPidProfile);
+
+    return NULL;
+}
+
+
+static const char * const osdTableThrottleLimitType[] = {
+    "OFF", "SCALE", "CLIP"
+};
+
+static const OSD_Entry menuMainEntries[] =
+{
+    {"-- QUICK --",  OME_Label, NULL, NULL},
+
+    { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, osdTableThrottleLimitType} },
+    { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 25,  100,  1} },
+    { "MTR OUT LIM %",OME_UINT8, NULL, &(OSD_UINT8_t) { &cmsx_motorOutputLimit, MOTOR_OUTPUT_LIMIT_PERCENT_MIN,  MOTOR_OUTPUT_LIMIT_PERCENT_MAX,  1} },
+    { "FORCE CELLS",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &batteryProfile.forceBatteryCellCount, 0, 24, 1} },
+#if defined(USE_VTX_CONTROL)
+#if defined(USE_VTX_RTC6705) || defined(USE_VTX_SMARTAUDIO) || defined(USE_VTX_TRAMP)
+    {"VTX", OME_Funcall, cmsSelectVtx, NULL},
+#endif
+#endif // VTX_CONTROL
+    {"MAIN",     OME_Submenu,  NULL, &cmsx_menuMain},
+    { "EXIT",            OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT},
+    { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT},
+    {NULL, OME_END, NULL, NULL},
+};
+
+CMS_Menu cmsx_menuQuick = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "MENUQUICK",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = quickMenuOnEnter,
+    .onExit = cmsx_RateProfileWriteback,
+    .onDisplayUpdate = NULL,
+    .entries = menuMainEntries,
+};
+
+#endif

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -52,6 +52,7 @@
 // VTX supplied menus
 
 #include "cms/cms_menu_vtx_common.h"
+#include "cms/cms_menu_rpm_limit.h"
 
 #include "common/printf.h"
 #include "fc/controlrate_profile.h"
@@ -121,6 +122,9 @@ static const OSD_Entry menuMainEntries[] =
 {
     {"-- QUICK --",  OME_Label, NULL, NULL},
 
+#if defined(USE_RPM_LIMITER)
+    {"RPM LIM", OME_Submenu, cmsMenuChange, &cmsx_menuRpmLimit},
+#endif
     { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, osdTableThrottleLimitType} },
     { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 25,  100,  1} },
     { "MTR OUT LIM %",OME_UINT8, NULL, &(OSD_UINT8_t) { &cmsx_motorOutputLimit, MOTOR_OUTPUT_LIMIT_PERCENT_MIN,  MOTOR_OUTPUT_LIMIT_PERCENT_MAX,  1} },

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -100,7 +100,7 @@ static const OSD_Entry menuMainEntries[] =
 {
     {"-- QUICK --",  OME_Label, NULL, NULL},
 
-#if defined(USE_RPM_LIMITER)
+#if defined(USE_RPM_LIMIT)
     {"RPM LIM", OME_Submenu, cmsMenuChange, &cmsx_menuRpmLimit},
 #endif
     { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, osdTableThrottleLimitType} },

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -28,49 +28,27 @@
 #include "platform.h"
 
 #ifdef USE_CMS
+#ifdef USE_QUICK_OSD_MENU
 
 #include "cms/cms.h"
 #include "cms/cms_types.h"
-
-// Sub menus
-
-#include "cms/cms_menu_imu.h"
-#include "cms/cms_menu_blackbox.h"
-#include "cms/cms_menu_failsafe.h"
-#include "cms/cms_menu_firmware.h"
-#include "cms/cms_menu_ledstrip.h"
-#include "cms/cms_menu_misc.h"
-#include "cms/cms_menu_osd.h"
-#include "cms/cms_menu_power.h"
-#include "cms/cms_menu_saveexit.h"
 #include "cms/cms_menu_main.h"
-
-#ifdef USE_PERSISTENT_STATS
-#include "cms/cms_menu_persistent_stats.h"
-#endif
-
-// VTX supplied menus
-
 #include "cms/cms_menu_vtx_common.h"
 #include "cms/cms_menu_rpm_limit.h"
-
 #include "common/printf.h"
-#include "fc/controlrate_profile.h"
 #include "config/config.h"
 
+#include "drivers/pwm_output.h"
+
+#include "fc/controlrate_profile.h"
 #include "fc/core.h"
 #include "fc/runtime_config.h"
-
-#include "sensors/acceleration.h"
-
-#include "cms_menu_quick.h"
-
-#include "sensors/battery.h"
-
 #include "flight/pid.h"
 #include "flight/pid_init.h"
 
-#include "drivers/pwm_output.h"
+#include "sensors/battery.h"
+
+#include "cms_menu_quick.h"
 
 // Features
 
@@ -151,4 +129,5 @@ CMS_Menu cmsx_menuQuick = {
     .entries = menuMainEntries,
 };
 
-#endif
+#endif // USE_QUICK_OSD_MENU
+#endif // USE_CMS

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -1,26 +1,23 @@
 /*
- * This file is part of Cleanflight and Betaflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight and Betaflight are free software. You can redistribute
- * this software and/or modify this software under the terms of the
- * GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight and Betaflight are distributed in the hope that they
- * will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this software.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */
-
-//
-// Main menu structure and support functions
-//
 
 #include <stdbool.h>
 #include <string.h>
@@ -50,8 +47,6 @@
 
 #include "cms_menu_quick.h"
 
-// Features
-
 static controlRateConfig_t rateProfile;
 static uint8_t rateProfileIndex;
 static batteryConfig_t batteryProfile;
@@ -71,7 +66,6 @@ static const void *quickMenuOnEnter(displayPort_t *pDisp)
 
     cmsx_motorOutputLimit = pidProfile->motor_output_limit;
 
-    // fill variables
     return NULL;
 }
 

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -98,10 +98,10 @@ static const char * const osdTableThrottleLimitType[] = {
 
 static const OSD_Entry menuMainEntries[] =
 {
-    {"-- QUICK --",  OME_Label, NULL, NULL},
+    { "-- QUICK --",  OME_Label, NULL, NULL },
 
 #if defined(USE_RPM_LIMIT)
-    {"RPM LIM", OME_Submenu, cmsMenuChange, &cmsx_menuRpmLimit},
+    { "RPM LIM", OME_Submenu, cmsMenuChange, &cmsx_menuRpmLimit },
 #endif
     { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, osdTableThrottleLimitType} },
     { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 25,  100,  1} },
@@ -112,7 +112,7 @@ static const OSD_Entry menuMainEntries[] =
     {"VTX", OME_Funcall, cmsSelectVtx, NULL},
 #endif
 #endif // VTX_CONTROL
-    {"MAIN",     OME_Submenu,  NULL, &cmsx_menuMain},
+    { "MAIN",            OME_Submenu,  NULL, &cmsx_menuMain },
     { "EXIT",            OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT},
     { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT},
     {NULL, OME_END, NULL, NULL},

--- a/src/main/cms/cms_menu_quick.h
+++ b/src/main/cms/cms_menu_quick.h
@@ -1,19 +1,20 @@
 /*
- * This file is part of Cleanflight and Betaflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight and Betaflight are free software. You can redistribute
- * this software and/or modify this software under the terms of the
- * GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight and Betaflight are distributed in the hope that they
- * will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this software.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/main/cms/cms_menu_quick.h
+++ b/src/main/cms/cms_menu_quick.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cms/cms_types.h"
+
+extern CMS_Menu cmsx_menuQuick;

--- a/src/main/cms/cms_menu_rpm_limit.c
+++ b/src/main/cms/cms_menu_rpm_limit.c
@@ -1,19 +1,20 @@
 /*
- * This file is part of Cleanflight and Betaflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight and Betaflight are free software. You can redistribute
- * this software and/or modify this software under the terms of the
- * GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight and Betaflight are distributed in the hope that they
- * will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this software.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/main/cms/cms_menu_rpm_limit.c
+++ b/src/main/cms/cms_menu_rpm_limit.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "platform.h"
+
+#ifdef USE_CMS
+#ifdef USE_RPM_LIMITER
+
+#include "cms/cms.h"
+#include "cms/cms_types.h"
+#include "cms/cms_menu_rpm_limit.h"
+
+#include "config/config.h"
+#include "pg/stats.h"
+
+#include "flight/mixer.h"
+
+uint16_t rpm_limiter_rpm_limit;
+uint16_t motor_kv;
+bool rpm_limiter;
+
+static const void *cmsx_RpmLimit_onEnter(displayPort_t *pDisp)
+{
+    UNUSED(pDisp);
+
+    rpm_limiter_rpm_limit = mixerConfig()->rpm_limiter_rpm_limit;
+    motor_kv = mixerConfig()->motor_kv;
+    rpm_limiter = mixerConfig()->rpm_limiter;
+
+    return NULL;
+}
+
+static const void *cmsx_RpmLimit_onExit(displayPort_t *pDisp, const OSD_Entry *self)
+{
+    UNUSED(pDisp);
+    UNUSED(self);
+
+    mixerConfigMutable()->rpm_limiter_rpm_limit = rpm_limiter_rpm_limit;
+    mixerConfigMutable()->motor_kv = motor_kv;
+    mixerConfigMutable()->rpm_limiter = rpm_limiter;
+
+    return NULL;
+}
+
+static const OSD_Entry cmsx_menuRpmLimitEntries[] =
+{
+    {"-- RPM LIMIT --", OME_Label, NULL, NULL},
+    { "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limiter },
+    {"MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limiter_rpm_limit, 0, UINT16_MAX, 1}},
+    {"KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &motor_kv, 0, UINT16_MAX, 1}},
+
+    { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT},
+    {"BACK", OME_Back, NULL, NULL},
+    { NULL, OME_END, NULL, NULL}
+};
+
+CMS_Menu cmsx_menuRpmLimit = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "RPMLIMIT",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = cmsx_RpmLimit_onEnter,
+    .onExit = cmsx_RpmLimit_onExit,
+    .onDisplayUpdate = NULL,
+    .entries = cmsx_menuRpmLimitEntries
+};
+
+#endif
+#endif // USE_RPM_LIMITER

--- a/src/main/cms/cms_menu_rpm_limit.c
+++ b/src/main/cms/cms_menu_rpm_limit.c
@@ -68,7 +68,7 @@ static const OSD_Entry cmsx_menuRpmLimitEntries[] =
 {
     {"-- RPM LIMIT --", OME_Label, NULL, NULL},
     { "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limiter },
-    {"MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limiter_rpm_limit, 0, UINT16_MAX, 1}},
+    {"MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limiter_rpm_limit, 0, UINT16_MAX, 100}},
     {"KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &motor_kv, 0, UINT16_MAX, 1}},
 
     { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT},

--- a/src/main/cms/cms_menu_rpm_limit.c
+++ b/src/main/cms/cms_menu_rpm_limit.c
@@ -65,13 +65,13 @@ static const void *cmsx_RpmLimit_onExit(displayPort_t *pDisp, const OSD_Entry *s
 
 static const OSD_Entry cmsx_menuRpmLimitEntries[] =
 {
-    {"-- RPM LIMIT --", OME_Label, NULL, NULL},
-    { "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limit },
-    {"MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limit_value, 0, UINT16_MAX, 100}},
-    {"KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &kv, 0, UINT16_MAX, 1}},
+    { "-- RPM LIMIT --", OME_Label, NULL, NULL },
+    {  "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limit },
+    { "MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limit_value, 0, UINT16_MAX, 100} },
+    { "KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &kv, 0, UINT16_MAX, 1} },
 
-    { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT},
-    {"BACK", OME_Back, NULL, NULL},
+    { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT },
+    { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}
 };
 

--- a/src/main/cms/cms_menu_rpm_limit.c
+++ b/src/main/cms/cms_menu_rpm_limit.c
@@ -26,28 +26,27 @@
 #include "platform.h"
 
 #ifdef USE_CMS
-#ifdef USE_RPM_LIMITER
+#ifdef USE_RPM_LIMIT
 
 #include "cms/cms.h"
 #include "cms/cms_types.h"
-#include "cms/cms_menu_rpm_limit.h"
-
 #include "config/config.h"
 #include "pg/stats.h"
-
 #include "flight/mixer.h"
 
-uint16_t rpm_limiter_rpm_limit;
-uint16_t motor_kv;
-bool rpm_limiter;
+#include "cms/cms_menu_rpm_limit.h"
+
+uint16_t rpm_limit_value;
+uint16_t kv;
+bool rpm_limit;
 
 static const void *cmsx_RpmLimit_onEnter(displayPort_t *pDisp)
 {
     UNUSED(pDisp);
 
-    rpm_limiter_rpm_limit = mixerConfig()->rpm_limiter_rpm_limit;
-    motor_kv = mixerConfig()->motor_kv;
-    rpm_limiter = mixerConfig()->rpm_limiter;
+    rpm_limit_value = mixerConfig()->rpm_limit_value;
+    kv = motorConfig()->kv;
+    rpm_limit = mixerConfig()->rpm_limit;
 
     return NULL;
 }
@@ -57,9 +56,9 @@ static const void *cmsx_RpmLimit_onExit(displayPort_t *pDisp, const OSD_Entry *s
     UNUSED(pDisp);
     UNUSED(self);
 
-    mixerConfigMutable()->rpm_limiter_rpm_limit = rpm_limiter_rpm_limit;
-    mixerConfigMutable()->motor_kv = motor_kv;
-    mixerConfigMutable()->rpm_limiter = rpm_limiter;
+    mixerConfigMutable()->rpm_limit_value = rpm_limit_value;
+    motorConfigMutable()->kv = kv;
+    mixerConfigMutable()->rpm_limit = rpm_limit;
 
     return NULL;
 }
@@ -67,9 +66,9 @@ static const void *cmsx_RpmLimit_onExit(displayPort_t *pDisp, const OSD_Entry *s
 static const OSD_Entry cmsx_menuRpmLimitEntries[] =
 {
     {"-- RPM LIMIT --", OME_Label, NULL, NULL},
-    { "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limiter },
-    {"MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limiter_rpm_limit, 0, UINT16_MAX, 100}},
-    {"KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &motor_kv, 0, UINT16_MAX, 1}},
+    { "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limit },
+    {"MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limit_value, 0, UINT16_MAX, 100}},
+    {"KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &kv, 0, UINT16_MAX, 1}},
 
     { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT},
     {"BACK", OME_Back, NULL, NULL},
@@ -88,4 +87,4 @@ CMS_Menu cmsx_menuRpmLimit = {
 };
 
 #endif
-#endif // USE_RPM_LIMITER
+#endif // USE_RPM_LIMIT

--- a/src/main/cms/cms_menu_rpm_limit.h
+++ b/src/main/cms/cms_menu_rpm_limit.h
@@ -1,19 +1,20 @@
 /*
- * This file is part of Cleanflight and Betaflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight and Betaflight are free software. You can redistribute
- * this software and/or modify this software under the terms of the
- * GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight and Betaflight are distributed in the hope that they
- * will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this software.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/main/cms/cms_menu_rpm_limit.h
+++ b/src/main/cms/cms_menu_rpm_limit.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+extern CMS_Menu cmsx_menuRpmLimit;

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -491,9 +491,6 @@ static const void *saCmsConfigFreqModeByGvar(displayPort_t *pDisp, const void *s
 
 static const void *saCmsCommence(displayPort_t *pDisp, const void *self)
 {
-    UNUSED(pDisp);
-    UNUSED(self);
-
     const vtxSettingsConfig_t prevSettings = {
         .band = vtxSettingsConfig()->band,
         .channel = vtxSettingsConfig()->channel,
@@ -536,6 +533,8 @@ static const void *saCmsCommence(displayPort_t *pDisp, const void *self)
         vtxSettingsConfigMutable()->freq = newSettings.freq;
         saveConfigAndNotify();
     }
+
+    cmsMenuExit(pDisp, self);
 
     return MENU_CHAIN_BACK;
 }
@@ -682,7 +681,7 @@ static CMS_Menu saCmsMenuConfig = {
 static const OSD_Entry saCmsMenuCommenceEntries[] = {
     { "CONFIRM", OME_Label,   NULL,          NULL },
 
-    { "YES",     OME_Funcall, saCmsCommence, NULL },
+    { "YES",   OME_OSD_Exit, saCmsCommence, (void *)CMS_EXIT },
 
     { "NO",    OME_Back, NULL, NULL },
     { NULL,      OME_END, NULL, NULL }
@@ -706,7 +705,7 @@ static const OSD_Entry saCmsMenuFreqModeEntries[] = {
     { "FREQ",   OME_Submenu | OPTSTRING, (CMSEntryFuncPtr)saCmsUserFreqGetString,  &saCmsMenuUserFreq },
     { "POWER",  OME_TAB | DYNAMIC,     saCmsConfigPowerByGvar,                   &saCmsEntPower },
     { "PIT",    OME_TAB | DYNAMIC,     saCmsConfigPitByGvar,                     &saCmsEntPit },
-    { "SAVE",   OME_Submenu, cmsMenuChange,                            &saCmsMenuCommence },
+    { "SAVE&EXIT", OME_Submenu, cmsMenuChange,                            &saCmsMenuCommence },
     { "CONFIG", OME_Submenu, cmsMenuChange,                            &saCmsMenuConfig },
 
     { "BACK", OME_Back, NULL, NULL },
@@ -723,7 +722,7 @@ static const OSD_Entry saCmsMenuChanModeEntries[] =
     { "(FREQ)", OME_UINT16 | DYNAMIC,  NULL,                   &saCmsEntFreqRef },
     { "POWER",  OME_TAB | DYNAMIC,     saCmsConfigPowerByGvar, &saCmsEntPower },
     { "PIT",    OME_TAB | DYNAMIC,     saCmsConfigPitByGvar,   &saCmsEntPit },
-    { "SAVE",   OME_Submenu, cmsMenuChange,          &saCmsMenuCommence },
+    { "SAVE&EXIT", OME_Submenu, cmsMenuChange,          &saCmsMenuCommence },
     { "CONFIG", OME_Submenu, cmsMenuChange,          &saCmsMenuConfig },
 
     { "BACK",   OME_Back, NULL, NULL },

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -195,6 +195,7 @@ static const void *trampCmsCommence(displayPort_t *pDisp, const void *self)
     vtxSettingsConfigMutable()->freq = vtxCommonLookupFrequency(vtxCommonDevice(), trampCmsBand, trampCmsChan);
 
     saveConfigAndNotify();
+    cmsMenuExit(pDisp, self);
 
     return MENU_CHAIN_BACK;
 }
@@ -249,7 +250,7 @@ static const void *trampCmsOnEnter(displayPort_t *pDisp)
 
 static const OSD_Entry trampCmsMenuCommenceEntries[] = {
     { "CONFIRM", OME_Label,   NULL,          NULL },
-    { "YES",     OME_Funcall, trampCmsCommence, NULL },
+    { "YES",   OME_OSD_Exit, trampCmsCommence, (void *)CMS_EXIT },
     { "NO",    OME_Back, NULL, NULL },
     { NULL,      OME_END, NULL, NULL }
 };
@@ -276,7 +277,7 @@ static const OSD_Entry trampMenuEntries[] =
     { "(FREQ)", OME_UINT16 | DYNAMIC,  NULL,         &trampCmsEntFreqRef },
     { "POWER",  OME_TAB,     trampCmsConfigPower,    &trampCmsEntPower },
     { "T(C)",   OME_INT16 | DYNAMIC,   NULL,         &trampCmsEntTemp },
-    { "SAVE",   OME_Submenu, cmsMenuChange,          &trampCmsMenuCommence },
+    { "SAVE&EXIT", OME_Submenu, cmsMenuChange,          &trampCmsMenuCommence },
 
     { "BACK",   OME_Back, NULL, NULL },
     { NULL,     OME_END, NULL, NULL }

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -415,7 +415,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 #endif
 
 #ifdef USE_QUICK_OSD_MENU
-    osdConfig->osd_use_quick_menu = false;
+    osdConfig->osd_use_quick_menu = true;
 #endif // USE_QUICK_OSD_MENU
 }
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -413,6 +413,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->canvas_cols = OSD_SD_COLS;
     osdConfig->canvas_rows = OSD_SD_ROWS;
 #endif
+
+    osdConfig->extra_osd_use_quick_menu = true;
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -414,7 +414,9 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->canvas_rows = OSD_SD_ROWS;
 #endif
 
-    osdConfig->extra_osd_use_quick_menu = true;
+#ifdef USE_QUICK_OSD_MENU
+    osdConfig->osd_use_quick_menu = false;
+#endif // USE_QUICK_OSD_MENU
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -345,6 +345,7 @@ typedef struct osdConfig_s {
     uint8_t aux_symbol;
     uint8_t canvas_cols;                      // Canvas dimensions for HD display
     uint8_t canvas_rows;
+    uint8_t extra_osd_use_quick_menu;         // use QUICK menu YES/NO
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -345,7 +345,9 @@ typedef struct osdConfig_s {
     uint8_t aux_symbol;
     uint8_t canvas_cols;                      // Canvas dimensions for HD display
     uint8_t canvas_rows;
-    uint8_t extra_osd_use_quick_menu;         // use QUICK menu YES/NO
+    #ifdef USE_QUICK_OSD_MENU
+    uint8_t osd_use_quick_menu;               // use QUICK menu YES/NO
+    #endif // USE_QUICK_OSD_MENU
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -122,7 +122,7 @@ cms_unittest_SRC := \
 		$(USER_DIR)/cms/cms.c \
 		$(USER_DIR)/cms/cms_menu_saveexit.c \
 		$(USER_DIR)/common/typeconversion.c \
-		$(USER_DIR)/drivers/display.c
+		$(USER_DIR)/drivers/display.c \
 
 
 common_filter_unittest_SRC := \

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -122,7 +122,7 @@ cms_unittest_SRC := \
 		$(USER_DIR)/cms/cms.c \
 		$(USER_DIR)/cms/cms_menu_saveexit.c \
 		$(USER_DIR)/common/typeconversion.c \
-		$(USER_DIR)/drivers/display.c \
+		$(USER_DIR)/drivers/display.c
 
 
 common_filter_unittest_SRC := \

--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -29,6 +29,7 @@ extern "C" {
     #include "platform.h"
     #include "target.h"
     #include "cms/cms.h"
+    #include "cms/cms_menu_quick.h"
     #include "cms/cms_types.h"
     #include "fc/rc_modes.h"
     #include "fc/runtime_config.h"
@@ -46,6 +47,14 @@ extern "C" {
 #include "unittest_macros.h"
 #include "unittest_displayport.h"
 #include "gtest/gtest.h"
+
+CMS_Menu cmsx_menuQuick = {
+    .onEnter = NULL,
+    .onExit = NULL,
+    .onDisplayUpdate = NULL,
+    .entries = NULL,
+};
+
 
 TEST(CMSUnittest, TestCmsDisplayPortRegister)
 {


### PR DESCRIPTION
Feature well-adopted in special release KAACK and beloved by racers.
If defined `USE_OSD_QUICK_MENU` can use in CLI:
`set osd_use_quick_menu = ON`
This activates quick menu that replaces the main menu as a first CSM page.
PR also adds PRM limit OSD menu (if defined)
PR also replaces EXIT with SAVE&EXIT in VTX menu. Because it's annoying you have to quit from all menus after you have changed the channel - takes more time.
![image](https://github.com/betaflight/betaflight/assets/2925027/2084cda4-826c-46bd-b14e-385c8b12593c)
