### PR TITLE
Removing STM specific defines from common_pre, and other cleanups

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1910,7 +1910,7 @@ static void printLed(dumpFlags_t dumpMask, const ledConfig_t *ledConfigs, const 
     char ledConfigBuffer[20];
     char ledConfigDefaultBuffer[20];
     headingStr = cliPrintSectionHeading(dumpMask, false, headingStr);
-    for (uint32_t i = 0; i < LED_MAX_STRIP_LENGTH; i++) {
+    for (uint32_t i = 0; i < LED_STRIP_MAX_LENGTH; i++) {
         ledConfig_t ledConfig = ledConfigs[i];
         generateLedConfig(&ledConfig, ledConfigBuffer, sizeof(ledConfigBuffer));
         bool equalsDefault = false;
@@ -1937,7 +1937,7 @@ static void cliLed(const char *cmdName, char *cmdline)
     } else {
         ptr = cmdline;
         i = atoi(ptr);
-        if (i >= 0 && i < LED_MAX_STRIP_LENGTH) {
+        if (i >= 0 && i < LED_STRIP_MAX_LENGTH) {
             ptr = nextArg(cmdline);
             if (parseLedStripConfig(i, ptr)) {
                 generateLedConfig((ledConfig_t *)&ledStripStatusModeConfig()->ledConfigs[i], ledConfigBuffer, sizeof(ledConfigBuffer));
@@ -1946,7 +1946,7 @@ static void cliLed(const char *cmdName, char *cmdline)
                 cliShowParseError(cmdName);
             }
         } else {
-            cliShowArgumentRangeError(cmdName, "INDEX", 0, LED_MAX_STRIP_LENGTH - 1);
+            cliShowArgumentRangeError(cmdName, "INDEX", 0, LED_STRIP_MAX_LENGTH - 1);
         }
     }
 }

--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -47,7 +47,7 @@
 
 #include "scheduler/scheduler.h"
 
-#ifdef USE_LEDSTRIP_CACHE_MGMT
+#ifdef USE_LED_STRIP_CACHE_MGMT
 // WS2811_DMA_BUFFER_SIZE is multiples of uint32_t
 // Number of bytes required for buffer
 #define WS2811_DMA_BUF_BYTES              (WS2811_DMA_BUFFER_SIZE * sizeof(uint32_t))
@@ -210,7 +210,7 @@ void ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness)
     }
     needsFullRefresh = false;
 
-#ifdef USE_LEDSTRIP_CACHE_MGMT
+#ifdef USE_LED_STRIP_CACHE_MGMT
     SCB_CleanDCache_by_Addr(ledStripDMABuffer, WS2811_DMA_BUF_CACHE_ALIGN_BYTES);
 #endif
 

--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -24,7 +24,7 @@
 
 #include "drivers/io_types.h"
 
-#define WS2811_LED_STRIP_LENGTH    LED_MAX_STRIP_LENGTH
+#define WS2811_LED_STRIP_LENGTH    LED_STRIP_MAX_LENGTH
 
 #define WS2811_BITS_PER_LED_MAX    32
 
@@ -41,7 +41,7 @@
 #define WS2811_DMA_BUFFER_SIZE     (WS2811_DATA_BUFFER_SIZE * WS2811_BITS_PER_LED_MAX + WS2811_DELAY_BUFFER_LENGTH)
 #endif
 
-#ifdef USE_LEDSTRIP_CACHE_MGMT
+#ifdef USE_LED_STRIP_CACHE_MGMT
 // WS2811_DMA_BUFFER_SIZE is multiples of uint32_t
 // Number of bytes required for buffer
 #define WS2811_DMA_BUF_BYTES              (WS2811_DMA_BUFFER_SIZE * sizeof(uint32_t))

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -145,7 +145,7 @@ void pgResetFn_ledStripConfig(ledStripConfig_t *ledStripConfig)
 
 #ifdef USE_LED_STRIP_STATUS_MODE
 
-#if LED_MAX_STRIP_LENGTH > WS2811_LED_STRIP_LENGTH
+#if LED_STRIP_MAX_LENGTH > WS2811_LED_STRIP_LENGTH
 # error "Led strip length must match driver"
 #endif
 
@@ -187,7 +187,7 @@ PG_REGISTER_WITH_RESET_FN(ledStripStatusModeConfig_t, ledStripStatusModeConfig, 
 
 void pgResetFn_ledStripStatusModeConfig(ledStripStatusModeConfig_t *ledStripStatusModeConfig)
 {
-    memset(ledStripStatusModeConfig->ledConfigs, 0, LED_MAX_STRIP_LENGTH * sizeof(ledConfig_t));
+    memset(ledStripStatusModeConfig->ledConfigs, 0, LED_STRIP_MAX_LENGTH * sizeof(ledConfig_t));
     // copy hsv colors as default
     memset(ledStripStatusModeConfig->colors, 0, ARRAYLEN(hsv) * sizeof(hsvColor_t));
     STATIC_ASSERT(LED_CONFIGURABLE_COLOR_COUNT >= ARRAYLEN(hsv), LED_CONFIGURABLE_COLOR_COUNT_invalid);
@@ -260,7 +260,7 @@ STATIC_UNIT_TESTED void updateLedCount(void)
 {
     int count = 0, countRing = 0, countScanner= 0;
 
-    for (int ledIndex = 0; ledIndex < LED_MAX_STRIP_LENGTH; ledIndex++) {
+    for (int ledIndex = 0; ledIndex < LED_STRIP_MAX_LENGTH; ledIndex++) {
         const ledConfig_t *ledConfig = &ledStripStatusModeConfig()->ledConfigs[ledIndex];
 
         if (!(*ledConfig))
@@ -302,7 +302,7 @@ static const char overlayCodes[LED_OVERLAY_COUNT]   = { 'T', 'Y', 'O', 'B', 'V',
 #define CHUNK_BUFFER_SIZE 11
 bool parseLedStripConfig(int ledIndex, const char *config)
 {
-    if (ledIndex >= LED_MAX_STRIP_LENGTH)
+    if (ledIndex >= LED_STRIP_MAX_LENGTH)
         return false;
 
     enum parseState_e {

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -184,7 +184,7 @@ PG_DECLARE(ledStripConfig_t, ledStripConfig);
 
 #if defined(USE_LED_STRIP_STATUS_MODE)
 typedef struct ledStripStatusModeConfig_s {
-    ledConfig_t ledConfigs[LED_MAX_STRIP_LENGTH];
+    ledConfig_t ledConfigs[LED_STRIP_MAX_LENGTH];
     hsvColor_t colors[LED_CONFIGURABLE_COLOR_COUNT];
     modeColorIndexes_t modeColors[LED_MODE_COUNT];
     specialColorIndexes_t specialColors;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1721,7 +1721,7 @@ case MSP_NAME:
 
 #ifdef USE_LED_STRIP
     case MSP_LED_STRIP_CONFIG:
-        for (int i = 0; i < LED_MAX_STRIP_LENGTH; i++) {
+        for (int i = 0; i < LED_STRIP_MAX_LENGTH; i++) {
 #ifdef USE_LED_STRIP_STATUS_MODE
             const ledConfig_t *ledConfig = &ledStripStatusModeConfig()->ledConfigs[i];
             sbufWriteU32(dst, *ledConfig);
@@ -3824,7 +3824,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
     case MSP_SET_LED_STRIP_CONFIG:
         {
             i = sbufReadU8(src);
-            if (i >= LED_MAX_STRIP_LENGTH || dataSize != (1 + 4)) {
+            if (i >= LED_STRIP_MAX_LENGTH || dataSize != (1 + 4)) {
                 return MSP_RESULT_ERROR;
             }
 #ifdef USE_LED_STRIP_STATUS_MODE

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -70,7 +70,9 @@
 
 #define USE_USB_DETECT
 
-#define USE_ESCSERIAL
+#ifdef USE_ESCSERIAL
+#undef USE_ESCSERIAL
+#endif
 
 #define USE_ADC
 #define USE_EXTI

--- a/src/main/target/STM32H723/target.h
+++ b/src/main/target/STM32H723/target.h
@@ -96,3 +96,7 @@
 #define USE_TIMER_UP_CONFIG
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x20000) // 128K sectors
+
+#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
+#define USE_LED_STRIP_CACHE_MGMT
+#endif

--- a/src/main/target/STM32H725/target.h
+++ b/src/main/target/STM32H725/target.h
@@ -98,3 +98,7 @@
 #define USE_TIMER_UP_CONFIG
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x20000) // 128K sectors
+
+#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
+#define USE_LED_STRIP_CACHE_MGMT
+#endif

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -118,3 +118,7 @@
 #endif
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x20000) // 128K sectors
+
+#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
+#define USE_LED_STRIP_CACHE_MGMT
+#endif

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -85,3 +85,7 @@
 #define USE_TIMER_UP_CONFIG
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x20000) // 128K sectors
+
+#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
+#define USE_LED_STRIP_CACHE_MGMT
+#endif

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -112,3 +112,7 @@
 #endif
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x20000) // 128K sectors
+
+#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
+#define USE_LED_STRIP_CACHE_MGMT
+#endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -529,10 +529,6 @@
 #undef USE_CMS_GPS_RESCUE_MENU
 #endif
 
-// TODO: Remove this once HAL support is fixed for ESCSERIAL
-#ifdef STM32F7
-#undef USE_ESCSERIAL
-#endif
 
 #if defined(CONFIG_IN_RAM) || defined(CONFIG_IN_FILE) || defined(CONFIG_IN_EXTERNAL_FLASH) || defined(CONFIG_IN_SDCARD) || defined(CONFIG_IN_MEMORY_MAPPED_FLASH)
 #ifndef EEPROM_SIZE

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -28,14 +28,14 @@
     CLOUD_BUILD is used to signify that the build is a user requested build and that the 
     features to be enabled will be defined ALREADY.
 
-    CORE_BUILD is used to signify that the build is a user requested build and that the 
+    CORE_BUILD is used to signify that the build is a user requested build and that the
     features to be enabled will be the minimal set, and all the drivers should be present.
 
-    If neither of the above are present then the build should simply be a baseline build 
+    If neither of the above are present then the build should simply be a baseline build
     for continuous integration, i.e. the compilation of the majority of features and drivers
     dependent on the size of the flash available.
 
-    NOTE: for 4.5 we will be removing any conditions related to specific MCU types, instead 
+    NOTE: for 4.5 we will be removing any conditions related to specific MCU types, instead
     these should be defined in the target.h or in a file that is imported by target.h (in the
     case of common settings for a given MCU group)
 
@@ -115,7 +115,7 @@
 #define USE_ACC_SPI_ICM42605
 #define USE_ACC_SPI_ICM42688P
 
-#if defined(STM32F405) || defined(STM32F745) || defined(STM32G4) || defined(STM32H7)
+#if TARGET_FLASH_SIZE > 512
 #define USE_ACC_MPU6050
 #define USE_GYRO_MPU6050
 #define USE_ACCGYRO_BMI160
@@ -162,17 +162,6 @@
 #endif
 
 #endif // !defined(USE_CONFIG)
-
-#if defined(STM32F405) || defined(STM32F745) || defined(STM32H7)
-#define USE_VTX_RTC6705
-#define USE_VTX_RTC6705_SOFTSPI
-
-#define USE_TRANSPONDER
-
-#define USE_RANGEFINDER
-#define USE_RANGEFINDER_HCSR04
-#define USE_RANGEFINDER_TF
-#endif
 
 #define USE_RX_PPM
 #define USE_RX_PWM
@@ -238,34 +227,44 @@
 #define USE_EMFAT_AUTORUN
 #define USE_EMFAT_ICON
 #define USE_ESCSERIAL_SIMONK
+
+#if !defined(USE_GPS)
 #define USE_GPS
+#endif
+
+#if !defined(USE_GPS_PLUS_CODES)
 #define USE_GPS_PLUS_CODES
+#endif
+
+#if !defined(USE_LED_STRIP)
 #define USE_LED_STRIP
+#endif
+
 #define USE_SERIAL_4WAY_SK_BOOTLOADER
+
+#define USE_VTX_RTC6705
+#define USE_VTX_RTC6705_SOFTSPI
+
+#define USE_TRANSPONDER
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_HCSR04
+#define USE_RANGEFINDER_TF
+
 #endif
 
 #endif // !defined(CLOUD_BUILD)
 
-#if !defined(LED_MAX_STRIP_LENGTH)
+#if !defined(LED_STRIP_MAX_LENGTH)
 #ifdef USE_LED_STRIP_64
-#define LED_MAX_STRIP_LENGTH           64
+#define LED_STRIP_MAX_LENGTH           64
 #else
-#define LED_MAX_STRIP_LENGTH           32
+#define LED_STRIP_MAX_LENGTH           32
 #endif
-#endif // # !defined(LED_MAX_STRIP_LENGTH)
+#endif // # !defined(LED_STRIP_MAX_LENGTH)
 
 #if defined(USE_LED_STRIP)
-#if defined(STM32H7) && !defined(USE_LEDSTRIP_CACHE_MGMT)
-#define USE_LEDSTRIP_CACHE_MGMT
-#endif
 #define USE_LED_STRIP_STATUS_MODE
-#endif
-
-#if defined(USE_SDCARD)
-#define USE_SDCARD_SPI
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
-#define USE_SDCARD_SDIO
-#endif
 #endif
 
 #if defined(USE_PINIO)

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -74,7 +74,7 @@ extern "C" {
 TEST(LedStripTest, parseLedStripConfig)
 {
     // given
-    memset(&ledStripStatusModeConfigMutable()->ledConfigs, 0, LED_MAX_STRIP_LENGTH);
+    memset(&ledStripStatusModeConfigMutable()->ledConfigs, 0, LED_STRIP_MAX_LENGTH);
 
     // and
     static const ledConfig_t expectedLedStripConfig[WS2811_LED_STRIP_LENGTH] = {
@@ -195,7 +195,7 @@ TEST(LedStripTest, parseLedStripConfig)
 TEST(LedStripTest, smallestGridWithCenter)
 {
     // given
-    memset(&ledStripStatusModeConfigMutable()->ledConfigs, 0, LED_MAX_STRIP_LENGTH);
+    memset(&ledStripStatusModeConfigMutable()->ledConfigs, 0, LED_STRIP_MAX_LENGTH);
 
     // and
     static const ledConfig_t testLedConfigs[] = {
@@ -223,7 +223,7 @@ TEST(LedStripTest, smallestGridWithCenter)
 TEST(LedStripTest, smallestGrid)
 {
     // given
-    memset(&ledStripStatusModeConfigMutable()->ledConfigs, 0, LED_MAX_STRIP_LENGTH);
+    memset(&ledStripStatusModeConfigMutable()->ledConfigs, 0, LED_STRIP_MAX_LENGTH);
 
     // and
     static const ledConfig_t testLedConfigs[] = {

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -43,13 +43,13 @@
 #define USE_SERVOS
 #define USE_TRANSPONDER
 
-#ifndef LED_MAX_STRIP_LENGTH
+#ifndef LED_STRIP_MAX_LENGTH
     #ifdef USE_LED_STRIP_64
-        #define LED_MAX_STRIP_LENGTH           64
+        #define LED_STRIP_MAX_LENGTH           64
     #else
-        #define LED_MAX_STRIP_LENGTH           32
+        #define LED_STRIP_MAX_LENGTH           32
     #endif
-#endif // #ifndef LED_MAX_STRIP_LENGTH
+#endif // #ifndef LED_STRIP_MAX_LENGTH
 
 typedef enum
 {


### PR DESCRIPTION
Simply renamed LEDSTRIP to LED_STRIP (inline) and a few others for consistency.
Removed any STM32 specific define conditions from common_pre (to target.h where applicable).