### PR TITLE
Rename flight mode

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -378,11 +378,6 @@ void crsfFrameFlightMode(sbuf_t *dst)
     // Acro is the default mode
     const char *flightMode = "ACRO";
 
-    // Modes that are only relevant when disarmed
-    if (!ARMING_FLAG(ARMED) && isArmingDisabled()) {
-        flightMode = "GND";
-    } else
-
 #if defined(USE_GPS)
     if (!ARMING_FLAG(ARMED) && featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
         flightMode = "WAIT"; // Waiting for GPS lock

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -380,7 +380,7 @@ void crsfFrameFlightMode(sbuf_t *dst)
 
     // Modes that are only relevant when disarmed
     if (!ARMING_FLAG(ARMED) && isArmingDisabled()) {
-        flightMode = "!ERR";
+        flightMode = "GND";
     } else
 
 #if defined(USE_GPS)


### PR DESCRIPTION
Fixes: #12980 

When unarmed FM telemetry element shows `!ERR`.

This PR renames the element to show the selected flight mode.