### PR TITLE
Rename default configuration macro's for vbat divider and multiplier

### DIFF
--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -101,12 +101,12 @@ void voltageMeterReset(voltageMeter_t *meter)
 #define DEFAULT_VOLTAGE_METER_SCALE 110
 #endif
 
-#ifndef VBAT_RESDIVVAL_DEFAULT
-#define VBAT_RESDIVVAL_DEFAULT 10
+#ifndef DEFAULT_VOLTAGE_METER_DIVIDER
+#define DEFAULT_VOLTAGE_METER_DIVIDER 10
 #endif
 
-#ifndef VBAT_RESDIVMULTIPLIER_DEFAULT
-#define VBAT_RESDIVMULTIPLIER_DEFAULT 1
+#ifndef DEFAULT_VOLTAGE_METER_MULTIPLIER
+#define DEFAULT_VOLTAGE_METER_MULTIPLIER 1
 #endif
 
 typedef struct voltageMeterADCState_s {
@@ -135,8 +135,8 @@ void pgResetFn_voltageSensorADCConfig(voltageSensorADCConfig_t *instance)
     for (int i = 0; i < MAX_VOLTAGE_SENSOR_ADC; i++) {
         RESET_CONFIG(voltageSensorADCConfig_t, &instance[i],
             .vbatscale = DEFAULT_VOLTAGE_METER_SCALE,
-            .vbatresdivval = VBAT_RESDIVVAL_DEFAULT,
-            .vbatresdivmultiplier = VBAT_RESDIVMULTIPLIER_DEFAULT,
+            .vbatresdivval = DEFAULT_VOLTAGE_METER_DIVIDER,
+            .vbatresdivmultiplier = DEFAULT_VOLTAGE_METER_MULTIPLIER,
         );
     }
 }


### PR DESCRIPTION
Little refactor for configuration management.

New | Current
--- | ---
DEFAULT_VOLTAGE_METER_DIVIDER | VBAT_RESDIVVAL_DEFAULT
DEFAULT_VOLTAGE_METER_MULTIPLIER | VBAT_RESDIVMULTIPLIER_DEFAULT