### PR TITLE
Fix escserial for HAL targets.

### DIFF
--- a/src/main/drivers/at32/timer_at32bsp.c
+++ b/src/main/drivers/at32/timer_at32bsp.c
@@ -696,11 +696,9 @@ void timerInit(void)
     }
 }
 
-// finish configuring timers after allocation phase
-// start timers
-void timerStart(void)
+void timerStart(tmr_type *tim)
 {
-
+    tmr_counter_enable(tim, TRUE);
 }
 
 /**

--- a/src/main/drivers/stm32/timer_hal.c
+++ b/src/main/drivers/stm32/timer_hal.c
@@ -773,16 +773,24 @@ static void timCCxHandler(TIM_TypeDef *tim, timerConfig_t *timerConfig)
             break;
         }
         case __builtin_clz(TIM_IT_CC1):
-            timerConfig->edgeCallback[0]->fn(timerConfig->edgeCallback[0], tim->CCR1);
+            if (timerConfig->edgeCallback[0]) {
+                timerConfig->edgeCallback[0]->fn(timerConfig->edgeCallback[0], tim->CCR1);
+            }
             break;
         case __builtin_clz(TIM_IT_CC2):
-            timerConfig->edgeCallback[1]->fn(timerConfig->edgeCallback[1], tim->CCR2);
+            if (timerConfig->edgeCallback[1]) {
+                timerConfig->edgeCallback[1]->fn(timerConfig->edgeCallback[1], tim->CCR2);
+            }
             break;
         case __builtin_clz(TIM_IT_CC3):
-            timerConfig->edgeCallback[2]->fn(timerConfig->edgeCallback[2], tim->CCR3);
+            if (timerConfig->edgeCallback[2]) {
+                timerConfig->edgeCallback[2]->fn(timerConfig->edgeCallback[2], tim->CCR3);
+            }
             break;
         case __builtin_clz(TIM_IT_CC4):
-            timerConfig->edgeCallback[3]->fn(timerConfig->edgeCallback[3], tim->CCR4);
+            if (timerConfig->edgeCallback[3]) {
+                timerConfig->edgeCallback[3]->fn(timerConfig->edgeCallback[3], tim->CCR4);
+            }
             break;
         }
     }
@@ -1043,35 +1051,12 @@ void timerInit(void)
     }
 }
 
-// finish configuring timers after allocation phase
-// start timers
-// TODO - Work in progress - initialization routine must be modified/verified to start correctly without timers
-void timerStart(void)
+void timerStart(TIM_TypeDef *tim)
 {
-#if 0
-    for (unsigned timer = 0; timer < USED_TIMER_COUNT; timer++) {
-        int priority = -1;
-        int irq = -1;
-        for (unsigned hwc = 0; hwc < TIMER_CHANNEL_COUNT; hwc++) {
-            if ((timerChannelInfo[hwc].type != TYPE_FREE) && (TIMER_HARDWARE[hwc].tim == usedTimers[timer])) {
-                // TODO - move IRQ to timer info
-                irq = TIMER_HARDWARE[hwc].irq;
-            }
-        }
-        // TODO - aggregate required timer paramaters
-        configTimeBase(usedTimers[timer], 0, 1);
-        TIM_Cmd(usedTimers[timer], ENABLE);
-        if (priority >= 0) {  // maybe none of the channels was configured
-            NVIC_InitTypeDef NVIC_InitStructure;
+    TIM_HandleTypeDef* handle = timerFindTimerHandle(tim);
+    if (handle == NULL) return;
 
-            NVIC_InitStructure.NVIC_IRQChannel = irq;
-            NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_SPLIT_PRIORITY_BASE(priority);
-            NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_SPLIT_PRIORITY_SUB(priority);
-            NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-            NVIC_Init(&NVIC_InitStructure);
-        }
-    }
-#endif
+    __HAL_TIM_ENABLE(handle);
 }
 
 /**

--- a/src/main/drivers/stm32/timer_stdperiph.c
+++ b/src/main/drivers/stm32/timer_stdperiph.c
@@ -321,6 +321,11 @@ void timerNVICConfigure(uint8_t irq)
     NVIC_Init(&NVIC_InitStructure);
 }
 
+void timerReconfigureTimeBase(TIM_TypeDef *tim, uint16_t period, uint32_t hz)
+{
+    configTimeBase(tim, period, hz);
+}
+
 void configTimeBase(TIM_TypeDef *tim, uint16_t period, uint32_t hz)
 {
     TIM_TimeBaseInitTypeDef  TIM_TimeBaseStructure;

--- a/src/main/drivers/stm32/timer_stdperiph.c
+++ b/src/main/drivers/stm32/timer_stdperiph.c
@@ -851,34 +851,9 @@ void timerInit(void)
     }
 }
 
-// finish configuring timers after allocation phase
-// start timers
-// TODO - Work in progress - initialization routine must be modified/verified to start correctly without timers
-void timerStart(void)
+void timerStart(TIM_TypeDef *tim)
 {
-#if 0
-    for (unsigned timer = 0; timer < USED_TIMER_COUNT; timer++) {
-        int priority = -1;
-        int irq = -1;
-        for (unsigned hwc = 0; hwc < TIMER_CHANNEL_COUNT; hwc++)
-            if ((timerChannelInfo[hwc].type != TYPE_FREE) && (TIMER_HARDWARE[hwc].tim == usedTimers[timer])) {
-                // TODO - move IRQ to timer info
-                irq = TIMER_HARDWARE[hwc].irq;
-            }
-        // TODO - aggregate required timer parameters
-        configTimeBase(usedTimers[timer], 0, 1);
-        TIM_Cmd(usedTimers[timer],  ENABLE);
-        if (priority >= 0) {  // maybe none of the channels was configured
-            NVIC_InitTypeDef NVIC_InitStructure;
-
-            NVIC_InitStructure.NVIC_IRQChannel = irq;
-            NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_SPLIT_PRIORITY_BASE(priority);
-            NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_SPLIT_PRIORITY_SUB(priority);
-            NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-            NVIC_Init(&NVIC_InitStructure);
-        }
-    }
-#endif
+    TIM_Cmd(tim,  ENABLE);
 }
 
 /**

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -134,7 +134,13 @@ void timerConfigure(const timerHardware_t *timHw, uint16_t period, uint32_t hz);
 // Initialisation
 //
 void timerInit(void);
-void timerStart(void);
+
+//
+// per-timer
+//
+
+// once-upon-a-time all the timers were started on boot, now they are started when needed.
+void timerStart(TIM_TypeDef *tim);
 
 //
 // per-channel

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -855,12 +855,6 @@ void init(void)
 
 #endif // VTX_CONTROL
 
-#ifdef USE_TIMER
-    // start all timers
-    // TODO - not implemented yet
-    timerStart();
-#endif
-
     batteryInit(); // always needs doing, regardless of features.
 
 #ifdef USE_RCDEVICE

--- a/src/main/target/SITL/sitl.c
+++ b/src/main/target/SITL/sitl.c
@@ -358,10 +358,6 @@ void timerInit(void)
     printf("[timer]Init...\n");
 }
 
-void timerStart(void)
-{
-}
-
 void failureMode(failureMode_e mode)
 {
     printf("[failureMode]!!! %d\n", mode);

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -70,10 +70,6 @@
 
 #define USE_USB_DETECT
 
-#ifdef USE_ESCSERIAL
-#undef USE_ESCSERIAL
-#endif
-
 #define USE_ADC
 #define USE_EXTI
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors


### PR DESCRIPTION
* ESCSerial in `master` causes a hardfault on the H7.
* On the F7 it specifically disabled due to unfinished code in `serial_escserial.c` which was never completed in the move to unified targets (see https://github.com/betaflight/betaflight/commit/4caa20bab203e55fc54d8dfd9f4382b53a51e7ef#diff-e1c4e53026425b2c994be372a3352d03d9cb76a08107e63f555a5c8e86fdb44aR308-R310)

* There is MUCH legacy timer code, this PR does not seek to fix or address any of it's shortcomings, only to make it work for today's use-case, which is to support ESCape32 ESCs using an H7 FC.  Refer to the ESCape32 ESC documentation here: https://github.com/neoxic/ESCape32/wiki/Installation

This PR just serves as a point-in-time where it's known to work on the H7.  Other people can do additional PR's to cleanup the timer code further, check F7/G4/AT* but it won't be me, I do not have time nor inclination. (sorry).

![DS1Z_QuickPrint30_BIT_TIMING_38400_OK](https://github.com/betaflight/betaflight/assets/57075/1dc73f31-4bb1-4f94-a4b2-5dbcb1f6eb21)
(1,000,000 (us/s) / 38400 baud = 26.04166us per bit * 9 (visible) bits = 234.375us


Here's a scope trace of from motor 1 pin, driven by TIM8, on an H730 MCU as a result of pressing 'A' from putty while BF is in escserial kiss mode.

No other scenarios (eg, character reception, use of other escserial protocols, etc) have been tested, but hey, this works at least...