### PR TITLE
Document where dshot documentation is found

### DIFF
--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: jflyper
+ *
+ * Follows the extended dshot telemetry documentation found at https://github.com/bird-sanctuary/extended-dshot-telemetry
  */
 
 #include <stdbool.h>


### PR DESCRIPTION
This will make it easier for any developer looking to better understand dshot by looking at dshot.c to be directed to the dshot standard found at https://github.com/bird-sanctuary/extended-dshot-telemetry.
