### PR TITLE
Use coloured fonts if supported

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1498,13 +1498,18 @@ static void osdElementRtcTime(osdElementParms_t *element)
 static void osdElementRssiDbm(osdElementParms_t *element)
 {
     const int8_t antenna = getActiveAntenna();
+    const int16_t osdRssiDbm = getRssiDbm();
     static bool diversity = false;
+
+    if (osdRssiDbm < osdConfig()->rssi_dbm_alarm) {
+        element->attr = DISPLAYPORT_SEVERITY_CRITICAL;
+    }
 
     if (antenna || diversity) {
         diversity = true;
-        tfp_sprintf(element->buff, "%c%3d:%d", SYM_RSSI, getRssiDbm(), antenna + 1);
+        tfp_sprintf(element->buff, "%c%3d:%d", SYM_RSSI, osdRssiDbm, antenna + 1);
     } else {
-        tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, getRssiDbm());
+        tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, osdRssiDbm);
     }
 }
 #endif // USE_RX_RSSI_DBM
@@ -2143,6 +2148,14 @@ void osdUpdateAlarms(void)
     } else {
         CLR_BLINK(OSD_RSSI_VALUE);
     }
+
+#ifdef USE_RX_RSSI_DBM
+    if (getRssiDbm() < osdConfig()->rssi_dbm_alarm) {
+        SET_BLINK(OSD_RSSI_DBM_VALUE);
+    } else {
+        CLR_BLINK(OSD_RSSI_DBM_VALUE);
+    }
+#endif
 
 #ifdef USE_RX_LINK_QUALITY_INFO
     if (rxGetLinkQualityPercent() < osdConfig()->link_quality_alarm) {

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -173,7 +173,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     // RSSI
     if (osdWarnGetState(OSD_WARNING_RSSI) && (getRssiPercent() < osdConfig()->rssi_alarm)) {
         tfp_sprintf(warningText, "RSSI LOW");
-        *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
+        *displayAttr = DISPLAYPORT_SEVERITY_CRITICAL;
         *blinking = true;
         return;
     }
@@ -181,7 +181,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     // rssi dbm
     if (osdWarnGetState(OSD_WARNING_RSSI_DBM) && (getRssiDbm() < osdConfig()->rssi_dbm_alarm)) {
         tfp_sprintf(warningText, "RSSI DBM");
-        *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
+        *displayAttr = DISPLAYPORT_SEVERITY_CRITICAL;
         *blinking = true;
         return;
     }
@@ -190,7 +190,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     // rsnr
     if (osdWarnGetState(OSD_WARNING_RSNR) && (getRsnr() < osdConfig()->rsnr_alarm)) {
         tfp_sprintf(warningText, "RSNR LOW");
-        *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
+        *displayAttr = DISPLAYPORT_SEVERITY_CRITICAL;
         *blinking = true;
         return;
     }
@@ -200,7 +200,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     // Link Quality
     if (osdWarnGetState(OSD_WARNING_LINK_QUALITY) && (rxGetLinkQualityPercent() < osdConfig()->link_quality_alarm)) {
         tfp_sprintf(warningText, "LINK QUALITY");
-        *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
+        *displayAttr = DISPLAYPORT_SEVERITY_CRITICAL;
         *blinking = true;
         return;
     }

--- a/src/main/pg/displayport_profiles.c
+++ b/src/main/pg/displayport_profiles.c
@@ -30,7 +30,14 @@
 
 #if defined(USE_MSP_DISPLAYPORT)
 
-PG_REGISTER(displayPortProfile_t, displayPortProfileMsp, PG_DISPLAY_PORT_MSP_CONFIG, 1);
+PG_REGISTER_WITH_RESET_FN(displayPortProfile_t, displayPortProfileMsp, PG_DISPLAY_PORT_MSP_CONFIG, 1);
+
+void pgResetFn_displayPortProfileMsp(displayPortProfile_t *displayPortProfile)
+{
+    for (uint8_t font = 0; font < DISPLAYPORT_SEVERITY_COUNT; font++) {
+        displayPortProfile->fontSelection[font] = font;
+    }
+}
 
 #endif
 


### PR DESCRIPTION
Use coloured fonts if possible.

Display RSSI dBm as critical if below threshold.

Display all RX related warnings as critical.

Tested on WS firmware 34.40.12.

https://youtu.be/HkRrbCb4Vl8