### PR TITLE
Fix #12908 Add ICM-42688-P IMU to list of IMUs with overflow protection

### DIFF
--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -329,6 +329,7 @@ void gyroInitSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t *config)
     case GYRO_MPU9250:
     case GYRO_LSM6DSO:
     case GYRO_LSM6DSV16X:
+    case GYRO_ICM42688P:
         gyroSensor->gyroDev.gyroHasOverflowProtection = true;
         break;
 
@@ -336,6 +337,7 @@ void gyroInitSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t *config)
     case GYRO_ICM20602:
     case GYRO_ICM20608G:
     case GYRO_ICM20649:  // we don't actually know if this is affected, but as there are currently no flight controllers using it we err on the side of caution
+    case GYRO_ICM42605:  // we don't actually know if this is affected
     case GYRO_ICM20689:
         gyroSensor->gyroDev.gyroHasOverflowProtection = false;
         break;


### PR DESCRIPTION
What it says in the description.
The ICM-42688-P have been verified to have overflow protection in https://github.com/betaflight/betaflight/issues/12908.
Still have to find a working 42605 to test with.
The ICM-42605 is preliminary added to the list of gyros with overflow protection, since it's hard to test if a gyros has overflow protection if Betaflight's overflow protection is active.

**testing instructions**

* Have a FC capable of running betaflight 4.5, has a ICM-42605 IMU, and can log
* Flash this PR 
* Go to cli and set `blackbox_mode = ALWAYS`, `debug_mode = GYRO_RAW` and save
* Wait for FC to reboot and the gyro to calibrate, then flick the FC quickly a couple of times.
* Go to cli and set `blackbox_mode = NORMAL` and save
* Extract the log and look where the gyro traces reach 2000 dps. If the gyro has overflow protection the rate should remain at around 
2000 dps for a short while. If the gyros is subject to overflow, the rate should suddenly change sign.
