### PR TITLE
Fix # 12991 Change LSM6DSO gyro scaling to 70 mdps/LSB

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -40,6 +40,9 @@
 
 #define LSM6DSO_CHIP_ID 0x6C
 
+// equivalent to 70 mdps/LSB, as specified in LSM6DSO datasheet section 4.1, symbol G_So
+#define LSM6DSO_GYRO_SCALE_2000DPS 0.070f
+
 // LSM6DSO register configuration values
 typedef enum {
     LSM6DSO_VAL_INT1_CTRL = 0x02,             // enable gyro data ready interrupt pin 1
@@ -198,7 +201,7 @@ bool lsm6dsoSpiGyroDetect(gyroDev_t *gyro)
 
     gyro->initFn = lsm6dsoSpiGyroInit;
     gyro->readFn = lsm6dsoGyroRead;
-    gyro->scale = GYRO_SCALE_2000DPS;
+    gyro->scale = LSM6DSO_GYRO_SCALE_2000DPS;
 
     return true;
 }


### PR DESCRIPTION
Should fix https://github.com/betaflight/betaflight/issues/12991
Not yet tested on a board with a LSM6DSO.