### PR TITLE
Enable/disable the UART TX before changing the TX pin mode

### DIFF
--- a/src/main/drivers/stm32/serial_uart_hal.c
+++ b/src/main/drivers/stm32/serial_uart_hal.c
@@ -251,6 +251,10 @@ bool checkUsartTxOutput(uartPort_t *s)
             // Enable USART TX output
             uart->txPinState = TX_PIN_ACTIVE;
             IOConfigGPIOAF(txIO, IOCFG_AF_PP, uart->tx.af);
+
+            // Enable the UART transmitter
+            SET_BIT(s->Handle.Instance->CR1, USART_CR1_TE);
+
             return true;
         } else {
             // TX line is pulled low so don't enable USART TX
@@ -267,6 +271,9 @@ void uartTxMonitor(uartPort_t *s)
 
     if (uart->txPinState == TX_PIN_ACTIVE) {
         IO_t txIO = IOGetByTag(uart->tx.pin);
+
+        // Disable the UART transmitter
+        CLEAR_BIT(s->Handle.Instance->CR1, USART_CR1_TE);
 
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/12926

Before setting the TX pin to an input the UART TX must be disabled, and then reenabled once the TX pin has been set to a UART output again.