### PR TITLE
UART enable disable f4

### DIFF
--- a/src/main/drivers/at32/serial_uart_at32bsp.c
+++ b/src/main/drivers/at32/serial_uart_at32bsp.c
@@ -197,6 +197,10 @@ bool checkUsartTxOutput(uartPort_t *s)
             // Enable USART TX output
             uart->txPinState = TX_PIN_ACTIVE;
             IOConfigGPIOAF(txIO, IOCFG_AF_PP, uart->tx.af);
+
+            // Enable the UART transmitter
+            usart_transmitter_enable(s->USARTx, true);
+
             return true;
         } else {
             // TX line is pulled low so don't enable USART TX
@@ -213,6 +217,9 @@ void uartTxMonitor(uartPort_t *s)
 
     if (uart->txPinState == TX_PIN_ACTIVE) {
         IO_t txIO = IOGetByTag(uart->tx.pin);
+
+        // Disable the UART transmitter
+        usart_transmitter_enable(s->USARTx, false);
 
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;

--- a/src/main/drivers/stm32/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f4xx.c
@@ -232,6 +232,10 @@ bool checkUsartTxOutput(uartPort_t *s)
             // Enable USART TX output
             uart->txPinState = TX_PIN_ACTIVE;
             IOConfigGPIOAF(txIO, IOCFG_AF_PP, uart->hardware->af);
+
+            // Enable the UART transmitter
+            SET_BIT(s->USARTx->CR1, USART_CR1_TE);
+
             return true;
         } else {
             // TX line is pulled low so don't enable USART TX
@@ -248,6 +252,9 @@ void uartTxMonitor(uartPort_t *s)
 
     if (uart->txPinState == TX_PIN_ACTIVE) {
         IO_t txIO = IOGetByTag(uart->tx.pin);
+
+        // Disable the UART transmitter
+        CLEAR_BIT(s->USARTx->CR1, USART_CR1_TE);
 
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;


### PR DESCRIPTION
Following on from https://github.com/betaflight/betaflight/pull/13017 which addressed HAL based FCs (F7/H7/G4) this PR ensures that the UART is enabled/disabled appropriately for STM32F4 and AT32F4 processors.