### PR TITLE
Allow for F7 UART idle preamble to be sent on startup

### DIFF
--- a/src/main/drivers/stm32/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f7xx.c
@@ -377,9 +377,9 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
             if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
-                uartdev->txPinState = TX_PIN_ACTIVE;
-                // Switch TX to an input with pullup so it's state can be monitored
-                uartTxMonitor(s);
+                uartdev->txPinState = TX_PIN_MONITOR;
+                // Switch TX to UART output whilst UART sends idle preamble
+                checkUsartTxOutput(s);
             } else {
                 IOConfigGPIOAF(txIO, IOCFG_AF_PP, uartdev->tx.af);
             }


### PR DESCRIPTION
F7 UART sends a preamble byte on first opening and is thereafter OK. This PR prevents that corrupting the first bytes sent to a device such as an openlager. G4 and H7 which also use HAL based UART drivers don't have this issue, nor does F4 or AT32.

Before this PR
![image](https://github.com/betaflight/betaflight/assets/11480839/6de533b1-52d5-4d04-b278-f5e7ffa9fe86)
With this PR
![image](https://github.com/betaflight/betaflight/assets/11480839/2efa4fcc-1207-4807-b0b2-5ec62a9f641c)
