### PR TITLE
Fix MAX7456 clock configuration

### DIFF
--- a/src/main/pg/max7456.c
+++ b/src/main/pg/max7456.c
@@ -31,7 +31,7 @@
 #include "max7456.h"
 
 #ifndef MAX7456_CLOCK_CONFIG_DEFAULT
-#define MAX7456_CLOCK_CONFIG_DEFAULT    MAX7456_CLOCK_CONFIG_OC
+#define MAX7456_CLOCK_CONFIG_DEFAULT    MAX7456_CLOCK_CONFIG_NOMINAL
 #endif
 
 #ifndef MAX7456_SPI_CS_PIN
@@ -46,7 +46,7 @@ PG_REGISTER_WITH_RESET_FN(max7456Config_t, max7456Config, PG_MAX7456_CONFIG, 0);
 
 void pgResetFn_max7456Config(max7456Config_t *config)
 {
-    config->clockConfig = MAX7456_CLOCK_CONFIG_NOMINAL;
+    config->clockConfig = MAX7456_CLOCK_CONFIG_DEFAULT;
     config->csTag = IO_TAG(MAX7456_SPI_CS_PIN);
     config->spiDevice = SPI_DEV_TO_CFG(spiDeviceByInstance(MAX7456_SPI_INSTANCE));
     config->preInitOPU = false;


### PR DESCRIPTION
Allow MAX7456 clock configuration using MAX7456_CLOCK_CONFIG_DEFAULT define

    // clockConfig values
    #define MAX7456_CLOCK_CONFIG_HALF       0  // Force half clock
    #define MAX7456_CLOCK_CONFIG_NOMINAL    1  // Nominal clock (default)
    #define MAX7456_CLOCK_CONFIG_DOUBLE     2  // Double clock
