### PR TITLE
Feature: nmeaPrintf

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -172,6 +172,7 @@ COMMON_SRC = \
             io/rcdevice_cam.c \
             io/rcdevice.c \
             io/gps.c \
+	    io/gps_utils.c \
             io/ledstrip.c \
             io/pidaudio.c \
             osd/osd.c \

--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -27,10 +27,7 @@
 
 void serialPrint(serialPort_t *instance, const char *str)
 {
-    uint8_t ch;
-    while ((ch = *(str++)) != 0) {
-        serialWrite(instance, ch);
-    }
+    serialWriteBuf(instance, str, strlen(str);
 }
 
 uint32_t serialGetBaudRate(serialPort_t *instance)

--- a/src/main/io/gps_utils.c
+++ b/src/main/io/gps_utils.c
@@ -1,0 +1,56 @@
+#include <stdarg.h>
+
+#include "common/printf.h"
+#include "io/serial.h"
+
+struct nmea_putp {
+    serialPort_t* port;
+    uint8_t csum;
+};
+
+static void nmea_putcf_csum(void* putp, char c)
+{
+    struct nmea_putp* p = putp;
+    serialWrite(p->port, c);
+    p->csum ^= c;
+}
+
+static void nmea_putcf(void* putp, char c)
+{
+    struct nmea_putp* p = putp;
+    serialWrite(p->port, c);
+}
+
+static void nmeaPrintfva_raw(struct nmea_putp* putp, const char *format, va_list va)
+{
+    tfp_format(putp, nmea_putcf, format, va);
+}
+
+static void nmeaPrintf_raw(struct nmea_putp* putp, const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    nmeaPrintfva_raw(putp, format, va);
+    va_end(va);
+}
+
+static void nmeaPrintfva(serialPort_t *port, const char *format, va_list va)
+{
+    struct nmea_putp putp = {
+        .port = port,
+        .csum = '$'             // don't checkfum '$' in header
+    };
+    tfp_format(&putp, nmea_putcf_csum, format, va);
+    nmeaPrintf_raw(&putp, "*%02X\r\n", putp.csum);
+}
+
+// printf format (+ arguments), append "*<csum>\r\n"
+// nmeaPrintf(port, "$PUBX,41,1,0003,0001,%d,0", 115200);
+void nmeaPrintf(serialPort_t *port, const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    nmeaPrintfva(port, format, va);
+    va_end(va);
+}
+

--- a/src/main/io/gps_utils.h
+++ b/src/main/io/gps_utils.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int nmeaPrintf(const char *format, ...);


### PR DESCRIPTION
nmeaPrintf(gpsPort, "$PUBX,41,1,0003,0001,%d,0", 115200);

Also improves `serialPrint()` performance and size

Not tested