### PR TITLE
minimal NMEA support for 4.5

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1010,9 +1010,9 @@ void gpsConfigureNmea(void)
                 gpsData.state_position++;
                 gpsSetState(GPS_STATE_RECEIVING_DATA);
             }
-#else // !GP_NMEA_TX_ONLY
+#else // !GPS_NMEA_TX_ONLY
             gpsSetState(GPS_STATE_RECEIVING_DATA);
-#endif // !GP_NMEA_TX_ONLY
+#endif // !GPS_NMEA_TX_ONLY
             break;
     }
 }

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -101,17 +101,15 @@ typedef struct gpsInitData_s {
     uint8_t index;
     uint8_t baudrateIndex; // see baudRate_e
     const char *ubx;
-    const char *mtk;
 } gpsInitData_t;
 
-// NMEA will cycle through these until valid data is received
+// UBX will cycle through these until valid data is received
 static const gpsInitData_t gpsInitData[] = {
-    { GPS_BAUDRATE_115200,   BAUD_115200, "$PUBX,41,1,0003,0001,115200,0*1E\r\n", "$PMTK251,115200*1F\r\n" },
-    { GPS_BAUDRATE_57600,    BAUD_57600,  "$PUBX,41,1,0003,0001,57600,0*2D\r\n",  "$PMTK251,57600*2C\r\n" },
-    { GPS_BAUDRATE_38400,    BAUD_38400,  "$PUBX,41,1,0003,0001,38400,0*26\r\n",  "$PMTK251,38400*27\r\n" },
-    { GPS_BAUDRATE_19200,    BAUD_19200,  "$PUBX,41,1,0003,0001,19200,0*23\r\n",  "$PMTK251,19200*22\r\n" },
-    // 9600 is not enough for 5Hz updates - leave for compatibility to dumb NMEA that only runs at this speed
-    { GPS_BAUDRATE_9600,     BAUD_9600,   "$PUBX,41,1,0003,0001,9600,0*16\r\n",   "" }
+    { GPS_BAUDRATE_115200,   BAUD_115200, "$PUBX,41,1,0003,0001,115200,0*1E\r\n" },
+    { GPS_BAUDRATE_57600,    BAUD_57600,  "$PUBX,41,1,0003,0001,57600,0*2D\r\n" },
+    { GPS_BAUDRATE_38400,    BAUD_38400,  "$PUBX,41,1,0003,0001,38400,0*26\r\n" },
+    { GPS_BAUDRATE_19200,    BAUD_19200,  "$PUBX,41,1,0003,0001,19200,0*23\r\n" },
+    { GPS_BAUDRATE_9600,     BAUD_9600,   "$PUBX,41,1,0003,0001,9600,0*16\r\n" }
 };
 
 #define GPS_INIT_DATA_ENTRY_COUNT ARRAYLEN(gpsInitData)
@@ -339,8 +337,6 @@ typedef enum {
 
 baudRate_e initBaudRateIndex;
 size_t initBaudRateCycleCount;
-static void ubloxSendClassMessage(ubxProtocolBytes_e class_id, ubxProtocolBytes_e msg_id, uint16_t length);
-
 #endif // USE_GPS_UBLOX
 
 gpsData_t gpsData;
@@ -953,111 +949,57 @@ void setSatInfoMessageRate(uint8_t divisor)
 #ifdef USE_GPS_NMEA
 void gpsConfigureNmea(void)
 {
-    static bool atgmRestartDone = false;
-#if !defined(GPS_NMEA_TX_ONLY)
-#endif
+    // minimal support for NMEA, we only:
+    // - set the FC's GPS port to the user's configured rate, and 
+    // - send any NMEA custom commands to the GPS Module
+    // the user must configure the power-up baud rate of the module to be fast enough for their data rate
+    // Note: we always parse all incoming NMEA messages
     DEBUG_SET(DEBUG_GPS_CONNECTION, 4, (gpsData.state * 100 + gpsData.state_position));
+
+    // wait 500ms between changes
+    if (cmp32(gpsData.now, gpsData.state_ts) < 500) {
+        return;
+    }
+    gpsData.state_ts = gpsData.now;
+
+    // Check that the GPS transmit buffer is empty
+    if (!isSerialTransmitBufferEmpty(gpsPort)) {
+        return;
+    }
+
     switch (gpsData.state) {
+
         case GPS_STATE_DETECT_BAUD:
-#if !defined(GPS_NMEA_TX_ONLY)
-            if (cmp32(gpsData.now, gpsData.state_ts) < 1000) {
-                return;
-            }
-            gpsData.state_ts = gpsData.now;
-            switch (gpsData.state_position) {
-                case 0: // first run after bootup
-                    serialSetBaudRate(gpsPort, 4800);
-                    gpsData.state_position++;
-                    break;
-                case 1: // second run
-                    // print the init string for the baudrate we want to be at
-                    serialPrint(gpsPort, "$PSRF100,1,115200,8,1,0*05\r\n");
-                    gpsData.state_position++;
-                    break;
-                default: 
-                    // we're now (hopefully) at the correct rate, next state should switch to it
-                    // TO DO: Check that this actually works, it seems broken at present
-                    gpsData.state_position = 0;
-                    gpsSetState(GPS_STATE_CHANGE_BAUD);
-                    break;
-            }
+            // no attempt to read the baud rate of the GPS module, or change it
+            gpsSetState(GPS_STATE_CHANGE_BAUD);
             break;
-#endif
+
         case GPS_STATE_CHANGE_BAUD:
 #if !defined(GPS_NMEA_TX_ONLY)
-            // wait a short time between sending commands
-            // note that no commands are sent to request the packets we need
-            if (cmp32(gpsData.now, gpsData.state_ts) < 500) {
-                return;
-            }
-            gpsData.state_ts = gpsData.now;
-
-            if (gpsData.state_position < 1) { // first run after boot up 
+            if (gpsData.state_position < 1) {
+                // set the FC's baud rate to the user's configured baud rate
                 serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex]);
                 gpsData.state_position++;
             } else if (gpsData.state_position < 2) {
-                // *** this message also appears to fail ***//
-                // NMEA reports back at whatever speed the module is configured to send at, not 5Hz
-                serialPrint(gpsPort, "$PSRF103,00,6,00,0*23\r\n"); // set GGA rate to 5Hz
-                gpsData.state_position++;
-            } else if (gpsData.state_position < 3) {
-                // special initialization for NMEA ATGM336 and similar GPS recivers - should be done only once
-                if (!atgmRestartDone) {
-                    atgmRestartDone = true;
-                    serialPrint(gpsPort, "$PCAS02,100*1E\r\n");  // 10Hz refresh rate
-                    serialPrint(gpsPort, "$PCAS10,0*1C\r\n");    // hot restart
-                }
-                gpsData.state_position++;
-            } else if (gpsData.state_position < 4) {
-#ifdef USE_GPS_UBLOX
-                // try to disable UBlox NAV-PVT and NAV-SAT, using ValSet, to which M9 or above should respond
-                ubloxSetMessageRateValSet(CFG_MSGOUT_UBX_NAV_PVT_UART1, 0);
-                ubloxSetMessageRateValSet(CFG_MSGOUT_UBX_NAV_SAT_UART1, 0);
-#endif
-                gpsData.state_position++;
-            } else if (gpsData.state_position < 5) {
-#ifdef USE_GPS_UBLOX
-                // try to disable UBX NAV-PVT, NAV-SAT and NAV_SVINFO, to which M7 and M8 should respond
-                ubloxSetMessageRate(CLASS_NAV, MSG_NAV_PVT, 0);
-                ubloxSetMessageRate(CLASS_NAV, MSG_NAV_SAT, 0);
-                ubloxSetMessageRate(CLASS_NAV, MSG_NAV_SVINFO, 0);
-#endif
-                gpsData.state_position++;
-            } else if (gpsData.state_position < 6) {
-                if (!(isConfiguratorConnected())) {
-                    // disable GSV MESSAGES
-                    // *** THIS COMMAND FAILS TO DISABLE GSV MESSAGES WHEN SENT ****
-                    // bug?? why??
-                    serialPrint(gpsPort, "$PSRF103,03,00,00,01*27\r\n");  // disable GSV (Sat info) messages
-                    // *** BUT THE UBLOX EQUIVALENT WORKS ****
-                    // so I'll send both for now...
-                    ubloxSetMessageRate(CLASS_NMEA_STD, MSG_NMEA_GSV, 0);
-                    }
-                gpsData.state_position++;
-            } else if (gpsData.state_position < 7) {
-                // NMEA custom commands after ATGM336 initialization
+                // send NMEA custom commands to select which messages being sent, data rate etc
+                // use PUBX, MTK, SiRF or GTK format commands, depending on module type
                 static int commandOffset = 0;
                 const char *commands = gpsConfig()->nmeaCustomCommands;
                 const char *cmd = commands + commandOffset;
-
                 // skip leading whitespaces and get first command length
                 int commandLen;
                 while (*cmd && (commandLen = strcspn(cmd, " \0")) == 0) {
                     cmd++;  // skip separators
                 }
-
                 if (*cmd) {
                     // Send the current command to the GPS
                     serialWriteBuf(gpsPort, (uint8_t *)cmd, commandLen);
                     serialWriteBuf(gpsPort, (uint8_t *)"\r\n", 2);
-
                     // Move to the next command
                     cmd += commandLen;
                 }
-
                 // skip trailing whitespaces
                 while (*cmd && strcspn(cmd, " \0") == 0) cmd++;
-
                 if (*cmd) {
                     // more commands to send
                     commandOffset = cmd - commands;
@@ -1065,14 +1007,13 @@ void gpsConfigureNmea(void)
                     gpsData.state_position++;
                     commandOffset = 0;
                 }
-            } else
-#else
-            {
-                serialSetBaudRate (gpsPort, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex]);
+                gpsData.state_position++;
+                gpsSetState(GPS_STATE_RECEIVING_DATA);
             }
-#endif
+#else // !GP_NMEA_TX_ONLY
             gpsSetState(GPS_STATE_RECEIVING_DATA);
-        break;
+#endif // !GP_NMEA_TX_ONLY
+            break;
     }
 }
 #endif // USE_GPS_NMEA


### PR DESCRIPTION
This PR reduces NMEA support for 4.5 to the bare minimum.  NMEA is now intended only for experimental use with custom non-UBlox modules.

This code has been tested and works properly with a UBlox M8 board that connects at 9600 baud and outputs only NMEA messages.  Custom command strings are effective in modifying the data sent by the module.

This is an alternative to [PR#12424](https://github.com/betaflight/betaflight/pull/12424), and essentially indicates that we do not intend to provide advanced support for NMEA-only modules.

**NOTE: UBlox modules should ONLY be used with the `UBlox Protocol` option in the GPS tab!  NMEA is intended ONLY for modules which cannot connect via the UBlox protocol.**

With this PR, if the user selects NMEA, the FC will only:
- configure the GPS UART to the set baud rate
- send any custom NMEA strings to the GPS module at that baud rate

That's all it will do.

It will no longer:
- attempt to connect at 4800baud and reconfigure the GPS Module to 115200 baud using an SiRF command.  4800baud modules cannot be used in 4.5.
- send any configuration strings strings to the module

As before, the CLI settings for GPS data update rate, flight mode, UTC, etc, are ignored in NMEA mode.

The user will need to try different GPS Port settings on the FC until one of them connects.  A connection will only be possible when the baud rate on the FC matches that of the module.

Custom NMEA command strings can be sent to the module using the CLI `gps_nmea_custom_commands` command.  Each string should be separated by a space, up to a maximum of 64 characters.  There's no need to include "\r\n" at the end of the string.  Usually only two command will fit into 64 characters.  To clear all commands, replace the string with a hyphen.  For more information see #12591.

Custom NMEA commands will only be received if the baud rates match.  Do not use a custom string to change the baud rate, or the connection will fail due to baud rate mismatch.  An NMEA module's baud rate can only be changed by permanently reconfiguring its power-up baud rate.

NMEA modules that by default run 9600 baud at 1Hz can be used to provide basic GPS position information, but such a low data rate can't effectively be used for GPS Rescue.  To use an NMEA module for GPS purposes, the baud rate must be set, and the required essential messages should be sent, with all others disabled.

Currently Betaflight gathers data from the following NMEA messages, and displays it in the GPS tab:
- GGA: time, latitude, longitude altitude, fix, number of sats in the solution; not used: hdop
- RMC: UTC time, speed over ground, ground course deg, date; not used: latitude and longitude.
- GSV: satellite info (not required during a rescue); not used: number of sats in view
- GSA: pdop, hdopm and vdop; not used: sat info

Note:
- Only GGA is required to log/view latitude and longitude (locate a lost quad)
- For GPS Rescue, both GGA and RMC *must* be enabled, the gps data update rate should be 5Hz or 10Hz, and the baud rate should be 19200 or higher for 5Hz and 38400 or higher for 10Hz.
- GSA is only used to display pDop in the OSD.
- GSV is only required to show satellite details, which are only needed while connected to Configurator. GSV data is neither required not used in-flight, and should be disabled once the basic setup is complete, to keep the data requirements and CPU time requirements to the minimum while flying.

 No other NMEA messages are parsed, such as:
- VTG: not parsed; not used: cog (true and magnetic), speed over ground, fix
- GLL: not parsed; not used: latitude and longitude, UTC time, positioning mode
- ZDA: not parsed; not used: UTC time and date

**Rationale**

The intent of the NMEA option is to permit the use of GPS modules which do not support UBlox protocols.  Due to the large variety of 'NMEA' control messages, the user must either:
- configure their NMEA module so that when it powers up, it will use a suitable baud rate, and only output the messages required for the intended purpose, or
- accept its default baud rate, and send custom NMEA commands using the `gps_nmea_custom_commands` command, to set the data rate, enable only the messages that are needed, and disable the rest.

The NMEA 'standard' defines a widely used string format for data sent by a GPS Module to a client application, eg Betaflight.  It does not provide any commands by which the client application can change the module's baud rate or any other configuration settings.

Some module manufacturers have provided custom commands to configure their modules.  At present there are at least four mutually incompatible command architectures: UBlox, SiRF, MTK and GTK.  

It may not be possible to permanently re-configure the power-up behaviour of an NMEA-only module.  In this case, the module can only be used at its original manufacturer-configured baud rate.

Once connected, the user can send custom commands to the module using the CLI `gps_nmea_custom_commands` command, as described above.

It is best that the module be permanently configured to power up at a suitable baud rate and output only the data we need.  

**Note about UBlox**

UBlox GPS modules are very widely used, and we provide strong support for them in 4.5.  Because they may power up with different default baud rates, we cycle through all the common baud rates until we connect, then we identify the hardware version, and using the appropriate commands for that hardware, disable any unnecessary messages, enable the messages we need, and set the data update rate, UTC time method, data mode, etc, according to the user's preference.  All this is done automatically.  

Hence we strongly recommend using the UBlox option for all UBlox modules.

Many UBlox GPS modules send NMEA messages by default.  If such a module is connected using the NMEA option, and it connects at a matching baud rate, position and sat data may appear in the GPS tab. Even if you see usable data like this, avoid using the 'NMEA protocol' option; the default 'UBlox protocol' should always be used with UBlox modules.

-------
