### PR TITLE
Moving Home Point on OSD

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1513,6 +1513,9 @@ const clivalue_t valueTable[] = {
     { "osd_aux_symbol",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 },  PG_OSD_CONFIG, offsetof(osdConfig_t, aux_symbol) },
     { "osd_canvas_width",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 63 }, PG_OSD_CONFIG, offsetof(osdConfig_t, canvas_cols) },
     { "osd_canvas_height",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 31 }, PG_OSD_CONFIG, offsetof(osdConfig_t, canvas_rows) },
+    { "osd_camera_fov_h",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 255 }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_fov_h) },
+    { "osd_camera_fov_v",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 255 }, PG_OSD_CONFIG, offsetof(osdConfig_t, camera_fov_v) },
+    { "osd_home_point_show",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, home_point_show) },
 #ifdef USE_CRAFTNAME_MSGS
     { "osd_craftname_msgs",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_craftname_msgs) },
 #endif //USE_CRAFTNAME_MSGS

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -34,6 +34,7 @@
 #define GPS_X 1
 #define GPS_Y 0
 #define GPS_MIN_SAT_COUNT 4      // number of sats to trigger low sat count sanity check
+#define GPS_EARTH_RADIUS 6371000 
 
 #ifdef USE_GPS_UBLOX
 typedef enum {
@@ -299,6 +300,11 @@ typedef struct gpsData_s {
 #endif
 } gpsData_t;
 
+typedef struct gpsRelativePos_s {
+    uint16_t lat;
+    uint16_t lon;
+} gpsRelativePos_t;
+
 extern int32_t GPS_home[2];
 extern uint16_t GPS_distanceToHome;             // distance to home point in meters
 extern uint32_t GPS_distanceToHomeCm;           // distance to home point in cm
@@ -314,6 +320,7 @@ typedef enum {
 
 extern gpsData_t gpsData;
 extern gpsSolutionData_t gpsSol;
+extern gpsRelativePos_t gpsrelativePos;
 
 #define GPS_SV_MAXSATS_LEGACY   16U
 #define GPS_SV_MAXSATS_M8N      32U

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1050,6 +1050,9 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, osdConfig()->camera_frame_width);
         sbufWriteU8(dst, osdConfig()->camera_frame_height);
 
+        sbufWriteU8(dst, osdConfig()->camera_fov_h);
+        sbufWriteU8(dst, osdConfig()->camera_fov_v);
+
         break;
     }
 #endif // USE_OSD
@@ -4162,6 +4165,14 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                     osdConfigMutable()->camera_frame_width = sbufReadU8(src);
                     osdConfigMutable()->camera_frame_height = sbufReadU8(src);
                 }
+
+                if (sbufBytesRemaining(src) >= 2) {
+                    // API >= 1.46
+                    // OSD camera fov values
+                    osdConfigMutable()->camera_fov_h = sbufReadU8(src);
+                    osdConfigMutable()->camera_fov_v = sbufReadU8(src);
+                }
+
             } else if ((int8_t)addr == -2) {
                 // Timers
                 uint8_t index = sbufReadU8(src);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -404,6 +404,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->camera_frame_width = 24;
     osdConfig->camera_frame_height = 11;
 
+    osdConfig->camera_fov_h = 138;
+    osdConfig->camera_fov_v = 75;
+    osdConfig->home_point_show = false;
+    
     osdConfig->stat_show_cell_value = false;
     osdConfig->framerate_hz = OSD_FRAMERATE_DEFAULT_HZ;
     osdConfig->cms_background_type = DISPLAY_BACKGROUND_TRANSPARENT;

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -348,6 +348,9 @@ typedef struct osdConfig_s {
     uint8_t aux_symbol;
     uint8_t canvas_cols;                      // Canvas dimensions for HD display
     uint8_t canvas_rows;
+    uint8_t camera_fov_h;                     // Config fov for moving home point
+    uint8_t camera_fov_v;
+    uint8_t home_point_show;
     #ifdef USE_QUICK_OSD_MENU
     uint8_t osd_use_quick_menu;               // use QUICK menu YES/NO
     #endif // USE_QUICK_OSD_MENU

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -203,6 +203,7 @@ osd_unittest_SRC := \
 		$(USER_DIR)/common/printf.c \
 		$(USER_DIR)/common/time.c \
 		$(USER_DIR)/common/filter.c \
+		$(USER_DIR)/pg/rx.c \
 		$(USER_DIR)/fc/runtime_config.c
 
 osd_unittest_DEFINES := \


### PR DESCRIPTION
This is a PR for a Moving Home Point on the OSD. It´s always on the position on the screen where your homepoint is set, expect it gets out of fov then it´s on the corner.
It´s aktive if you set osd_home_point_show = ON and if you have aktivated osd_home_dir_pos German: "Richtung Start Position".

You have to Set fov to your camera for Vista with CADDXFPV for example:

the fov you can set with 3 values:
set osd_camera_fov_h = 122
set osd_camera_fov_v = 93
set osd_home_point_show = ON