### PR TITLE
Display one of four logos on arming

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1379,6 +1379,7 @@ const clivalue_t valueTable[] = {
     { "osd_ah_invert",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahInvert) },
     { "osd_logo_on_arming",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OSD_LOGO_ON_ARMING }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming) },
     { "osd_logo_on_arming_duration",VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming_duration) },
+    { "osd_arming_logo",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, DISPLAYPORT_SEVERITY_COUNT - 1 }, PG_OSD_CONFIG, offsetof(osdConfig_t, arming_logo) },
 #ifdef USE_OSD_QUICK_MENU
     { "osd_use_quick_menu",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_use_quick_menu) },
 #endif // USE_OSD_QUICK_MENU

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -463,14 +463,14 @@ void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)
     osdElementConfig->item_pos[OSD_UP_DOWN_REFERENCE]  = OSD_POS((midCol - 2), (midRow - 1));
 }
 
-static void osdDrawLogo(int x, int y)
+static void osdDrawLogo(int x, int y, displayPortSeverity_e fontSel)
 {
     // display logo and help
     int fontOffset = 160;
     for (int row = 0; row < OSD_LOGO_ROWS; row++) {
         for (int column = 0; column < OSD_LOGO_COLS; column++) {
             if (fontOffset <= SYM_END_OF_FONT)
-                displayWriteChar(osdDisplayPort, x + column, y + row, DISPLAYPORT_SEVERITY_NORMAL, fontOffset++);
+                displayWriteChar(osdDisplayPort, x + column, y + row, fontSel, fontOffset++);
         }
     }
 }
@@ -490,7 +490,8 @@ static void osdCompleteInitialization(void)
     displayBeginTransaction(osdDisplayPort, DISPLAY_TRANSACTION_OPT_RESET_DRAWING);
     displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_WAIT);
 
-    osdDrawLogo(midCol - (OSD_LOGO_COLS) / 2, midRow - 5);
+    // Display betaflight logo
+    osdDrawLogo(midCol - (OSD_LOGO_COLS) / 2, midRow - 5, DISPLAYPORT_SEVERITY_NORMAL);
 
     char string_buffer[30];
     tfp_sprintf(string_buffer, "V%s", FC_VERSION_STRING);
@@ -1193,7 +1194,7 @@ static timeDelta_t osdShowArmed(void)
     if ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_ON) || ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_FIRST) && !ARMING_FLAG(WAS_EVER_ARMED))) {
         uint8_t midRow = osdDisplayPort->rows / 2;
         uint8_t midCol = osdDisplayPort->cols / 2;
-        osdDrawLogo(midCol - (OSD_LOGO_COLS) / 2, midRow - 5);
+        osdDrawLogo(midCol - (OSD_LOGO_COLS) / 2, midRow - 5, osdConfig()->arming_logo);
         ret = osdConfig()->logo_on_arming_duration * 1e5;
     } else {
         ret = (REFRESH_1S / 2);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -355,6 +355,7 @@ typedef struct osdConfig_s {
 #ifdef USE_SPEC_PREARM_SCREEN
     uint8_t osd_show_spec_prearm;
 #endif // USE_SPEC_PREARM_SCREEN
+    displayPortSeverity_e arming_logo;        // font from which to display logo on arming
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
Building on https://github.com/betaflight/betaflight/pull/13005 this PR adds the ability to select one of four logos to display on arming. This currently only works on the Walksnail Avatar HD system, but other systems supporting the full HD OSD spec at https://betaflight.com/docs/development/API/DisplayPort will be able to use this in due course.

A new setting, `osd_arming_logo` is added which can take any value between 0 and 3. The default of 0 will use the standard logo displayed on startup. Values of 1 - 3 may then be used to select an alternate logo.

The desired logo has to be inserted into the font file on the goggles. For Walksnail Avatar this is in the `userfonts` directory on the SD card.

Using the script below a new logo can be inserted as logo 1 thus (with a nod to Caddx/Walksnail who have supported the colour OSD initiative first). Note that this is a MacOS command line, but a similar invocation will work on any OS supporting python. Note that the logo file must be 864 x 216 and in PNG format.

```
python logo2x4.py caddxfpv.png /Volumes/SD/userfont/WS_BFx4_SNEAKY_FPV_36.png 1 /Volumes/SD/userfont/WS_BFx4_SNEAKY_FPV_24.png /Volumes/SD/userfont/WS_BFx4_SNEAKY_FPV_36.png
```

[logo2x4.py.zip](https://github.com/betaflight/betaflight/files/12470536/logo2x4.py.zip)

With the above font and `set osd_arming_logo = 1` the following will be displayed on arming.

![IMG_4352](https://github.com/betaflight/betaflight/assets/11480839/eeace9a6-7d01-48e7-b1b2-bcb25f344857)

Below are the two font files which should be suitably renamed and placed in the `userfont` directory on the SD card.

[FontsWithLogos.zip](https://github.com/betaflight/betaflight/files/12470541/FontsWithLogos.zip)

