### PR TITLE
Add mag heading to the GPS Rescue heading debug

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -266,6 +266,9 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
         matrixVectorMul(&mag_ef, (const fpMat33_t*)&rMat, &mag_bf);  // BF->EF
         mag_ef.z = 0.0f;                // project to XY plane (optimized away)
 
+//        float magHeadingDeg = RADIANS_TO_DEGREES(-atan2f(mag_ef.y, mag_ef.x)); // heading in degrees
+        DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 4, (RADIANS_TO_DEGREES(-atan2f(mag_ef.y, mag_ef.x))) * 10);  // mag heading in degrees * 10
+
         fpVector2_t north_ef = {{ 1.0f, 0.0f }};
         // magnetometer error is cross product between estimated magnetic north and measured magnetic north (calculated in EF)
         // increase gain on large misalignment


### PR DESCRIPTION
This is a small PR to help finalise the GPS Rescue heading debug, with thanks to @pichim for advice on how to do it.

For Mag users, this would be very useful.  They could see the 'raw' Mag heading, and directly compare it, if flown in a straight line, to the raw 'GPS' 'heading' (groundCourse).  It would be easy to identify noise present on the Mag signal and other issues.

The same debug also now logs the IMU-calculated 'attitude' of the quad, i.e. the IMU estimate of the direction in which the nose of the quad is pointing.

If the quad is flown in a straight line, all these values should coincide.

Testing by flying a 'square' course over ground, with four 90 degree turns and straight flight between the turns, should be enough to validate that these data make sense.

This is untested code at this point.

The heading debug contains:

| Debug | Code | notes |
| --- | --- | --- |
| 0 |  rescueState.sensor.groundSpeedCmS | groundspeed cm/s |
| 1 | gpsSol.groundCourse | **GPS ground course** in degrees * 10 |
| 2 | attitude.values.yaw) | **IMU estimated heading** of the quad degrees * 10 |
| 3 | rescueState.sensor.directionToHome) |  **Absolute angle to home, in degrees**, from current GPS position vs home |
| 4 | (RADIANS_TO_DEGREES(-atan2f(mag_ef.y, mag_ef.x)))* 10) | **Mag heading** in degrees * 10 (this PR) |
| 5 |  rollMixAttenuator | 0-1 to suppress roll adjustments at higher yaw rates |
| 6 | gpsRescueAngle[AI_ROLL] |  roll added in degrees*100 |
| 7 | rescueYaw | the yaw rate in deg/s to correct a yaw error |
