### PR TITLE
Add mag heading to gps heading debug

### DIFF
--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -121,24 +121,6 @@ static inline fpVector3_t * matrixVectorMul(fpVector3_t * result, const fpMat33_
     return result;
 }
 
-static inline fpMat33_t * matrixMatrixMul(fpMat33_t * result, const fpMat33_t * matA, const fpMat33_t * matB)
-{
-    fpMat33_t r;
-
-    r.m[0][0] = matA->m[0][0] * matB->m[0][0] + matA->m[0][1] * matB->m[1][0] + matA->m[0][2] * matB->m[2][0];
-    r.m[1][0] = matA->m[1][0] * matB->m[0][0] + matA->m[1][1] * matB->m[1][0] + matA->m[1][2] * matB->m[2][0];
-    r.m[2][0] = matA->m[2][0] * matB->m[0][0] + matA->m[2][1] * matB->m[1][0] + matA->m[2][2] * matB->m[2][0];
-    r.m[0][1] = matA->m[0][0] * matB->m[0][1] + matA->m[0][1] * matB->m[1][1] + matA->m[0][2] * matB->m[2][1];
-    r.m[1][1] = matA->m[1][0] * matB->m[0][1] + matA->m[1][1] * matB->m[1][1] + matA->m[1][2] * matB->m[2][1];
-    r.m[2][1] = matA->m[2][0] * matB->m[0][1] + matA->m[2][1] * matB->m[1][1] + matA->m[2][2] * matB->m[2][1];
-    r.m[0][2] = matA->m[0][0] * matB->m[0][2] + matA->m[0][1] * matB->m[1][2] + matA->m[0][2] * matB->m[2][2];
-    r.m[1][2] = matA->m[1][0] * matB->m[0][2] + matA->m[1][1] * matB->m[1][2] + matA->m[1][2] * matB->m[2][2];
-    r.m[2][2] = matA->m[2][0] * matB->m[0][2] + matA->m[2][1] * matB->m[1][2] + matA->m[2][2] * matB->m[2][2];
-
-    *result = r;
-    return result;
-}
-
 static inline fpMat33_t * yawToRotationMatrixZ(fpMat33_t * result, const float yaw)
 {
     fpMat33_t r;

--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -121,6 +121,44 @@ static inline fpVector3_t * matrixVectorMul(fpVector3_t * result, const fpMat33_
     return result;
 }
 
+static inline fpMat33_t * matrixMatrixMul(fpMat33_t * result, const fpMat33_t * matA, const fpMat33_t * matB)
+{
+    fpMat33_t r;
+
+    r.m[0][0] = matA->m[0][0] * matB->m[0][0] + matA->m[0][1] * matB->m[1][0] + matA->m[0][2] * matB->m[2][0];
+    r.m[1][0] = matA->m[1][0] * matB->m[0][0] + matA->m[1][1] * matB->m[1][0] + matA->m[1][2] * matB->m[2][0];
+    r.m[2][0] = matA->m[2][0] * matB->m[0][0] + matA->m[2][1] * matB->m[1][0] + matA->m[2][2] * matB->m[2][0];
+    r.m[0][1] = matA->m[0][0] * matB->m[0][1] + matA->m[0][1] * matB->m[1][1] + matA->m[0][2] * matB->m[2][1];
+    r.m[1][1] = matA->m[1][0] * matB->m[0][1] + matA->m[1][1] * matB->m[1][1] + matA->m[1][2] * matB->m[2][1];
+    r.m[2][1] = matA->m[2][0] * matB->m[0][1] + matA->m[2][1] * matB->m[1][1] + matA->m[2][2] * matB->m[2][1];
+    r.m[0][2] = matA->m[0][0] * matB->m[0][2] + matA->m[0][1] * matB->m[1][2] + matA->m[0][2] * matB->m[2][2];
+    r.m[1][2] = matA->m[1][0] * matB->m[0][2] + matA->m[1][1] * matB->m[1][2] + matA->m[1][2] * matB->m[2][2];
+    r.m[2][2] = matA->m[2][0] * matB->m[0][2] + matA->m[2][1] * matB->m[1][2] + matA->m[2][2] * matB->m[2][2];
+
+    *result = r;
+    return result;
+}
+
+static inline fpMat33_t * yawToRotationMatrixZ(fpMat33_t * result, const float yaw)
+{
+    fpMat33_t r;
+    const float sinYaw = sin_approx(yaw);
+    const float cosYaw = cos_approx(yaw);
+
+    r.m[0][0] = cosYaw;
+    r.m[1][0] = sinYaw;
+    r.m[2][0] = 0.0f;
+    r.m[0][1] = -sinYaw;
+    r.m[1][1] = cosYaw;
+    r.m[2][1] = 0.0f;
+    r.m[0][2] = 0.0f;
+    r.m[1][2] = 0.0f;
+    r.m[2][2] = 1.0f;
+
+    *result = r;
+    return result;
+}
+
 static inline fpVector3_t * matrixTrnVectorMul(fpVector3_t * result, const fpMat33_t * mat, const fpVector3_t * a)
 {
     fpVector3_t r;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -266,6 +266,9 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
         matrixVectorMul(&mag_ef, (const fpMat33_t*)&rMat, &mag_bf);  // BF->EF
         mag_ef.z = 0.0f;                // project to XY plane (optimized away)
 
+//        float magHeadingDeg = RADIANS_TO_DEGREES(-atan2f(mag_ef.y, mag_ef.x)); // heading in degrees
+        DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 4, (RADIANS_TO_DEGREES(-atan2f(mag_ef.y, mag_ef.x))) * 10);  // mag heading in degrees * 10
+
         fpVector2_t north_ef = {{ 1.0f, 0.0f }};
         // magnetometer error is cross product between estimated magnetic north and measured magnetic north (calculated in EF)
         // increase gain on large misalignment

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -258,10 +258,10 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
 
     // Encapsulate additional operations in a block so that it is only executed when the according debug mode is used
     if (debugMode == DEBUG_GPS_RESCUE_HEADING) {
-        fpMat33_t rMatYTrans;
-        yawToRotationMatrixZ(&rMatYTrans, -atan2_approx(rMat[1][0], rMat[0][0]));
+        fpMat33_t rMatZTrans;
+        yawToRotationMatrixZ(&rMatZTrans, -atan2_approx(rMat[1][0], rMat[0][0]));
         fpVector3_t mag_ef_yawed;
-        matrixVectorMul(&mag_ef_yawed, &rMatYTrans, &mag_ef); // EF->EF yawed
+        matrixVectorMul(&mag_ef_yawed, &rMatZTrans, &mag_ef); // EF->EF yawed
         // Magnetic yaw is the angle between magnetic north and the X axis of the body frame
         int16_t magYaw = lrintf((atan2_approx(mag_ef_yawed.y, mag_ef_yawed.x) * (1800.0f / M_PIf)));
         if (magYaw < 0) {


### PR DESCRIPTION
@ctzsnooze corrected draft for PR  #13061. Goal is roll and pitch compensated mag readings to then calculate yaw based on mag readings. There is a more efficient way using quaternions rather than rotation matrices. I was hoping @ledvinap could jump in and revisit this :-). I will do the quaternion version at a later stage when we see this debug will stay. It worked on my desk but its already late here.
* Needs testing
* Needs proper review