### PR TITLE
GPS Lap Timer: Fix best 3 not being calculated

### DIFF
--- a/src/main/fc/gps_lap_timer.c
+++ b/src/main/fc/gps_lap_timer.c
@@ -120,6 +120,7 @@ void gpsLapTimerNewGpsData(void)
                 // Not the first time through the gate
                 if (gpsLapTimerData.timerRunning) {
                     uint32_t lapTime = minDistanceTime - gpsLapTimerData.timeOfLastLap;
+                    gpsLapTimerData.numberOfLapsRecorded++;
 
                     // Update best lap time
                     if (gpsLapTimerData.numberOfLapsRecorded >= 1 && (lapTime < gpsLapTimerData.bestLapTime || gpsLapTimerData.bestLapTime == 0)) {


### PR DESCRIPTION

To calculate the best 3 consecutive laps time, it needs to track the number of laps recorded. This must have been accidentally removed at some point.