### PR TITLE
Add OSD Feature 'Camera Angle Reference'

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1412,6 +1412,8 @@ const clivalue_t valueTable[] = {
     { "osd_gps_speed_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_GPS_SPEED]) },
     { "osd_gps_lon_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_GPS_LON]) },
     { "osd_gps_lat_pos",            VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_GPS_LAT]) },
+    { "osd_car_pos",                VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CAM_ANGLE_REFERENCE]) },
+    { "osd_car__sbar_pos",          VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_CAM_ANGLE_REFERENCE_SBAR]) },
 #ifdef USE_GPS_LAP_TIMER
     { "osd_gps_lap_curr_pos",       VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_GPS_LAP_TIME_CURRENT]) },
     { "osd_gps_lap_prev_pos",       VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_GPS_LAP_TIME_PREVIOUS]) },
@@ -1513,6 +1515,16 @@ const clivalue_t valueTable[] = {
     { "osd_aux_symbol",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 },  PG_OSD_CONFIG, offsetof(osdConfig_t, aux_symbol) },
     { "osd_canvas_width",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 63 }, PG_OSD_CONFIG, offsetof(osdConfig_t, canvas_cols) },
     { "osd_canvas_height",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 31 }, PG_OSD_CONFIG, offsetof(osdConfig_t, canvas_rows) },
+    { "osd_car_channel",            VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, MAX_SUPPORTED_RC_CHANNEL_COUNT }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_channel)},
+    { "osd_car_scale",              VAR_INT8   | MASTER_VALUE, .config.minmax         = { -22, 22 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_scale)},
+    { "osd_car_dots",               VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 20 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_dots)},
+    { "osd_car_width",              VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 46}, PG_OSD_CONFIG, offsetof(osdConfig_t, car_width)},
+    { "osd_car_sbar_scale",         VAR_UINT8  | MASTER_VALUE, .config.minmax         = { 1, 4 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_sbar_scale)},
+    { "osd_car_sbar_low",           VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -99, 99 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_sbar_low)},
+    { "osd_car_sbar_mid_low",       VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -99, 99 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_sbar_mid_low)},
+    { "osd_car_sbar_mid",           VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -99, 99 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_sbar_mid)},
+    { "osd_car_sbar_mid_high",      VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -99, 99 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_sbar_mid_high)},
+    { "osd_car_sbar_high",          VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -99, 99 }, PG_OSD_CONFIG, offsetof(osdConfig_t, car_sbar_high)},
 #ifdef USE_CRAFTNAME_MSGS
     { "osd_craftname_msgs",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_craftname_msgs) },
 #endif //USE_CRAFTNAME_MSGS

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -92,6 +92,9 @@ const OSD_Entry menuOsdActiveElemsEntries[] =
 #endif // GPS
     {"CROSSHAIRS",         OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_CROSSHAIRS]},
     {"HORIZON",            OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_ARTIFICIAL_HORIZON]},
+    {"CAM ANGLE REFERENCE",OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_CAM_ANGLE_REFERENCE]},
+    {"CAR SIDEBAR",        OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_CAM_ANGLE_REFERENCE_SBAR]},
+
     {"HORIZON SIDEBARS",   OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_HORIZON_SIDEBARS]},
     {"UP/DOWN REFERENCE",  OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_UP_DOWN_REFERENCE]},
     {"TIMER 1",            OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_ITEM_TIMER_1]},
@@ -195,6 +198,20 @@ static int16_t osdConfig_rssi_dbm_alarm;
 static int16_t osdConfig_rsnr_alarm;
 static uint16_t osdConfig_cap_alarm;
 static uint16_t osdConfig_alt_alarm;
+
+static int8_t osdConfig_car_scale;
+static uint8_t osdConfig_car_width;
+static uint8_t osdConfig_car_channel;
+static uint8_t osdConfig_car_dots;
+
+static uint8_t osdConfig_car_sbar_scale;
+static uint8_t osdConfig_car_sbar_low;
+static uint8_t osdConfig_car_sbar_mid_low;
+static uint8_t osdConfig_car_sbar_mid;
+static uint8_t osdConfig_car_sbar_mid_high;
+static uint8_t osdConfig_car_sbar_high;
+
+
 static uint16_t osdConfig_distance_alarm;
 static uint8_t batteryConfig_vbatDurationForWarning;
 static uint8_t batteryConfig_vbatDurationForCritical;
@@ -215,6 +232,7 @@ static const void *menuAlarmsOnEnter(displayPort_t *pDisp)
 
     return NULL;
 }
+
 
 static const void *menuAlarmsOnExit(displayPort_t *pDisp, const OSD_Entry *self)
 {
@@ -259,6 +277,72 @@ static CMS_Menu menuAlarms = {
     .onExit = menuAlarmsOnExit,
     .onDisplayUpdate = NULL,
     .entries = menuAlarmsEntries,
+};
+
+static const void *menuCarOnEnter(displayPort_t *pDisp)
+{
+    UNUSED(pDisp);
+
+    osdConfig_car_scale = osdConfig()->car_scale;
+    osdConfig_car_width = osdConfig()->car_width;
+    osdConfig_car_channel = osdConfig()->car_channel;
+    osdConfig_car_dots = osdConfig()->car_dots;
+
+    osdConfig_car_sbar_scale = osdConfig()->car_sbar_scale;
+    osdConfig_car_sbar_low = osdConfig()->car_sbar_low;
+    osdConfig_car_sbar_mid_low = osdConfig()->car_sbar_mid_low;
+    osdConfig_car_sbar_mid = osdConfig()->car_sbar_mid;
+    osdConfig_car_sbar_mid_high = osdConfig()->car_sbar_mid_high;
+    osdConfig_car_sbar_high = osdConfig()->car_sbar_high;
+   
+    return NULL;
+}
+static const void *menuCarOnExit(displayPort_t *pDisp, const OSD_Entry *self)
+{
+    UNUSED(pDisp);
+    UNUSED(self);
+
+    osdConfigMutable()->car_scale = osdConfig_car_scale;
+    osdConfigMutable()->car_width = osdConfig_car_width;
+    osdConfigMutable()->car_channel = osdConfig_car_channel;
+    osdConfigMutable()->car_dots = osdConfig_car_dots;
+
+    osdConfigMutable()->car_sbar_scale = osdConfig_car_sbar_scale;
+    osdConfigMutable()->car_sbar_low = osdConfig_car_sbar_low;
+    osdConfigMutable()->car_sbar_mid_low = osdConfig_car_sbar_mid_low;
+    osdConfigMutable()->car_sbar_mid = osdConfig_car_sbar_mid;
+    osdConfigMutable()->car_sbar_mid_high = osdConfig_car_sbar_mid_high;
+    osdConfigMutable()->car_sbar_high = osdConfig_car_sbar_high;
+
+    
+    return NULL;
+}
+
+const OSD_Entry menuCarEntries[] =
+{
+    {"--- CAR ---", OME_Label, NULL, NULL},
+    {"SCALE",     OME_INT8,  NULL, &(OSD_INT8_t){&osdConfig_car_scale, -22, 22, 13}},
+    {"WIDTH",     OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_width, 5, 46, 13}},
+    {"CHANNEL", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_channel, 1, 18, 7}},
+    {"DOTS", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_dots, 1, 20, 7}},
+    {"SBAR_SCALE", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_sbar_scale, 1, 4, 2}},
+    {"SBAR_LOW", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_sbar_low, -99, 99, 30}},
+    {"SBAR_MID_LOW", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_sbar_mid_low, -99, 99, 15}},
+    {"SBAR_MID", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_sbar_mid, -99, 99, 0}},
+    {"SBAR_MID_HIGH", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_sbar_mid_high, -99, 99, 15}},
+    {"SBAR_HIGH", OME_UINT8,  NULL, &(OSD_UINT8_t){&osdConfig_car_sbar_high, -99, 99, 30}},
+    {NULL, OME_END, NULL, NULL,}
+};
+
+static CMS_Menu menuCar = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "MENUCAR",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = menuCarOnEnter,
+    .onExit = menuCarOnExit,
+    .onDisplayUpdate = menuCarOnExit,
+    .entries = menuCarEntries,
 };
 
 osd_timer_source_e timerSource[OSD_TIMER_COUNT];
@@ -393,6 +477,8 @@ const OSD_Entry cmsx_menuOsdEntries[] =
     {"ACTIVE ELEM", OME_Submenu, cmsMenuChange, &menuOsdActiveElems},
     {"TIMERS",      OME_Submenu, cmsMenuChange, &menuTimers},
     {"ALARMS",      OME_Submenu, cmsMenuChange, &menuAlarms},
+    {"CAR",         OME_Submenu, cmsMenuChange, &menuCar},
+
 #endif
 #ifdef USE_MAX7456
     {"INVERT",    OME_Bool,  cmsx_max7456Update, &displayPortProfileMax7456_invert},

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1050,6 +1050,19 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, osdConfig()->camera_frame_width);
         sbufWriteU8(dst, osdConfig()->camera_frame_height);
 
+        // API >= 1.46
+        sbufWriteU8(dst, osdConfig()->car_scale);
+        sbufWriteU8(dst, osdConfig()->car_width);        
+        sbufWriteU8(dst, osdConfig()->car_channel);        
+        sbufWriteU8(dst, osdConfig()->car_dots);
+
+        sbufWriteU8(dst, osdConfig()->car_sbar_scale);
+        sbufWriteU8(dst, osdConfig()->car_sbar_low);        
+        sbufWriteU8(dst, osdConfig()->car_sbar_mid_low);        
+        sbufWriteU8(dst, osdConfig()->car_sbar_mid);
+        sbufWriteU8(dst, osdConfig()->car_sbar_mid_high);
+        sbufWriteU8(dst, osdConfig()->car_sbar_high);
+
         break;
     }
 #endif // USE_OSD
@@ -4123,6 +4136,7 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                 sbufReadU16(src); // Skip unused (previously fly timer)
                 osdConfigMutable()->alt_alarm = sbufReadU16(src);
 
+
                 if (sbufBytesRemaining(src) >= 2) {
                     /* Enabled warnings */
                     // API < 1.41 supports only the low 16 bits
@@ -4162,6 +4176,22 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                     osdConfigMutable()->camera_frame_width = sbufReadU8(src);
                     osdConfigMutable()->camera_frame_height = sbufReadU8(src);
                 }
+
+                if (sbufBytesRemaining(src) >= 10) {
+                    // API >= 1.46
+                    osdConfigMutable()->car_scale = sbufReadU8(src);
+                    osdConfigMutable()->car_width = sbufReadU8(src);
+                    osdConfigMutable()->car_channel = sbufReadU8(src);
+                    osdConfigMutable()->car_dots = sbufReadU8(src);
+                    
+                    osdConfigMutable()->car_sbar_scale = sbufReadU8(src);
+                    osdConfigMutable()->car_sbar_low = sbufReadU8(src);
+                    osdConfigMutable()->car_sbar_mid_low = sbufReadU8(src);
+                    osdConfigMutable()->car_sbar_mid = sbufReadU8(src);
+                    osdConfigMutable()->car_sbar_mid_high = sbufReadU8(src);
+                    osdConfigMutable()->car_sbar_high = sbufReadU8(src);
+                }
+                
             } else if ((int8_t)addr == -2) {
                 // Timers
                 uint8_t index = sbufReadU8(src);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -415,6 +415,18 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->aux_scale = 200;
     osdConfig->aux_symbol = 'A';
 
+    osdConfig->car_channel = 7;  //CAR 'Camera Angle Reference' Values.  CAR Channel controlling servo/gimbal
+    osdConfig->car_scale = 13;   //CAR Scale for adjusting vertical scale / sesitivity
+    osdConfig->car_dots = 7;     //CAR Dots for adjusting number of dots on each side
+    osdConfig->car_width = 18;   //CAR Width for adjusting witdh between dots
+
+    osdConfig->car_sbar_scale = 2;  //CAR Sidebar Values.  CAR Sidebar Scale for adjusting vertical scale
+    osdConfig->car_sbar_low = 30;   //CAR Sidebar angle 1/5
+    osdConfig->car_sbar_mid_low = 15;     //CAR Sidebar angle 2/5
+    osdConfig->car_sbar_mid = 0;   //CAR Sidebar angle 3/5
+    osdConfig->car_sbar_mid_high = 15;   //CAR Sidebar angle 4/5
+    osdConfig->car_sbar_high = 30;   //CAR Sidebar angle 5/5
+
     // Make it obvious on the configurator that the FC doesn't support HD
 #ifdef USE_OSD_HD
     osdConfig->canvas_cols = OSD_HD_COLS;

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -189,6 +189,8 @@ typedef enum {
     OSD_GPS_LAP_TIME_CURRENT,
     OSD_GPS_LAP_TIME_PREVIOUS,
     OSD_GPS_LAP_TIME_BEST3,
+    OSD_CAM_ANGLE_REFERENCE,
+    OSD_CAM_ANGLE_REFERENCE_SBAR,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -348,6 +350,18 @@ typedef struct osdConfig_s {
     uint8_t aux_symbol;
     uint8_t canvas_cols;                      // Canvas dimensions for HD display
     uint8_t canvas_rows;
+    uint8_t car_channel;                      //CAR 'Camera Angle Reference' Values.  CAR Channel controlling servo/gimbal
+    int8_t car_scale;                         //CAR Scale for adjusting vertical scale / sesitivity
+    uint8_t car_dots;                         //CAR Dots for adjusting number of dots on each side
+    uint8_t car_width;                        //CAR Width for adjusting witdh between dots 
+    uint8_t car_sbar_scale;                   //CAR Sidebar Values.  CAR Sidebar Scale for adjusting vertical scale
+    int8_t car_sbar_low;                      //CAR Sidebar angle 1/5
+    int8_t car_sbar_mid_low;                  //CAR Sidebar angle 2/5
+    int8_t car_sbar_mid;                      //CAR Sidebar angle 3/5
+    int8_t car_sbar_mid_high;                 //CAR Sidebar angle 4/5
+    int8_t car_sbar_high;                     //CAR Sidebar angle 5/5
+
+
     #ifdef USE_QUICK_OSD_MENU
     uint8_t osd_use_quick_menu;               // use QUICK menu YES/NO
     #endif // USE_QUICK_OSD_MENU


### PR DESCRIPTION
This depends on Configurator pull request #3570 https://github.com/betaflight/betaflight-configurator/pull/3570 

Changing name of OSD feature to 'Camera Angle Reference' from the original 'Artificial Prop Line'

Camera Angle Reference OSD Feature

This is my first pull request so be gentle. 

This is an OSD visual reference for current camera angle intended to be used with a single axis tilt gimbal, like those shown on medlindrone.com

This is currently configured via CLI, will add a GUI for it in the future.

There are five new cli parameters:
    -osd_car_pos (osd element position)
    -osd_car_channel (channel controlling the gimbal/apl)
    -osd_car_scale (scale for adjusting vertical scale / sensitivity) 
    -osd_car_width (width for adjusting witdh between dots)
    -osd_car_dots (number of dots on each side)  

https://github.com/betaflight/betaflight/discussions/12438