### PR TITLE
rearrange rescue phase enum and keep Mag during landing

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -59,9 +59,9 @@ typedef enum {
     RESCUE_FLY_HOME,
     RESCUE_DESCENT,
     RESCUE_LANDING,
+    RESCUE_DO_NOTHING,
     RESCUE_ABORT,
-    RESCUE_COMPLETE,
-    RESCUE_DO_NOTHING
+    RESCUE_COMPLETE
 } rescuePhase_e;
 
 typedef enum {
@@ -981,7 +981,9 @@ bool gpsRescueIsDisabled(void)
 #ifdef USE_MAG
 bool gpsRescueDisableMag(void)
 {
-    return ((!gpsRescueConfig()->useMag || magForceDisable) && (rescueState.phase >= RESCUE_INITIALIZE) && (rescueState.phase <= RESCUE_LANDING));
+    // Enable mag on user request, but don't use it during fly home or if force disabled 
+    // Note that while flying home the course over ground from GPS provides a heading that is less affected by wind
+    return !(gpsRescueConfig()->useMag && rescueState.phase != RESCUE_FLY_HOME && !magForceDisable);
 }
 #endif
 #endif


### PR DESCRIPTION
**Main changes:**

- Doesn't use Mag in the the 'fly home' phase of GPS Rescue, does use it in all other phases.

- rearranges the `rescue_phase` enum to ensure that `do_nothing` phase, in which the quad hovers and otherwise does nothing much, is considered a flight phase.

**Rationale for not using Mag in the Fly Home phase of a Rescue:**

In the old compass code, there was a bug where if the user chose to disable Mag during a rescue, it would be still be active if the quad was in the Landing phase.

Testing showed that Mag is helpful in climb and rotate, and also during descend and land. In those situations, the GPS can be way off, due to lack of groundspeed, and to wind drag.  But Mag isn't so useful in the fly home phase if there is a side-wind.  That's because although the Mag points the nose to home, the wind continually drags the quad down-wind.  Since the nose is always pointing to home, the yaw correction is only sufficient to point the nose to home, and ignores the fact that the course over ground is not actually in the direction of home.  The quad follows a kind of ellipsoid path to home, and finds itself down-wind of home, flying back directly into the wind.  It doesn't travel the most direct path, and could run into downwind objects.  

In contrast, with GPS control only during the fly home phase, the heading error is derived from the difference between course over ground and direction to home.  Even a small deviation from the intended ground course results in a fairly strong yaw correction.  Hence the quad flies directly to home despite the wind, or with minimal wind drift.

This image shows the difference between the two approaches.  The green and cyan tracks are Rescues with Mag enabled throughout the rescue, whereas the orange and red tracks do not use Mag data.  Wind was from right to left (ENE) at about 15-20kph.

![MagTestingMap](https://github.com/betaflight/betaflight/assets/11737748/1c83fdb7-d97b-48c7-9e87-2b8e1019c85b)

If GPS Rescue is set as the Failsafe method, and Mag is enabled, this PR: 
- uses Mag to set the Heading value while GPS Rescue is 'idle' (ie, at all times other than when a GPS Rescue is taking place)
- uses Mag to set the Heading during all phases of a rescue *except* the fly home phase, to minimise drift due to wind while flying home.

NOTE:  initially a number of Mag related changes and fixes were in this PR.  In the interest of simplicity, all directly mag related code changes are now in 13073.  This PR focuses only on the GPS rescue changes needed when a mag is used. 