### PR TITLE
Fix: ledstrip vtx freq based color selection in RACE mode

### DIFF
--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -28,6 +28,7 @@
 #include "common/time.h"
 #include "common/streambuf.h"
 
+#define VTX_SETTINGS_MIN_FREQUENCY_MHZ 5000          //min freq (in MHz) for 'vtx_freq' setting
 #define VTX_SETTINGS_MAX_FREQUENCY_MHZ 5999          //max freq (in MHz) for 'vtx_freq' setting
 
 #if defined(USE_VTX_RTC6705)


### PR DESCRIPTION
##  Problem

Predefined single color LEDs must be used in races and colors are matched to used VTX frequencies. Pilots have to change the VTX frequency and the LED according to race seat position. That puts some extra complexity to the pilots in the race event situation.
Simple and easy single color solution is to use `RACE` mode (as the name states). Unfortunately `RACE` mode does not support VTX freq based color selection.

## Solution

This PR adds support to use VTX freq based selection when `ledstrip_race_color` is set to `BLACK` ( = disabled). Functionality does not expect VTX to be ready and just reads currently set values (direct freq or band+channel are both supported).

## Cli params required to get auto mode working

`set ledstrip_profile = RACE`
`set ledstrip_race_color = BLACK`