### PR TITLE
Drive TX line high before switching to input

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -116,4 +116,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "DSHOT_TELEMETRY_COUNTS",
     "RPM_LIMIT",
     "RC_STATS",
+    "UART_TX",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -116,6 +116,7 @@ typedef enum {
     DEBUG_DSHOT_TELEMETRY_COUNTS,
     DEBUG_RPM_LIMIT,
     DEBUG_RC_STATS,
+    DEBUG_UART_TX,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/drivers/at32/serial_uart_at32bsp.c
+++ b/src/main/drivers/at32/serial_uart_at32bsp.c
@@ -223,6 +223,10 @@ void uartTxMonitor(uartPort_t *s)
 
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;
+        // Initially drive the line high
+        IOHi(txIO);
+        IOConfigGPIO(txIO, IOCFG_OUT_PP_UP);
+        // And then switch to an input
         IOConfigGPIO(txIO, IOCFG_IPU);
     }
 }

--- a/src/main/drivers/stm32/serial_uart_hal.c
+++ b/src/main/drivers/stm32/serial_uart_hal.c
@@ -277,6 +277,10 @@ void uartTxMonitor(uartPort_t *s)
 
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;
+        // Initially drive the line high
+        IOHi(txIO);
+        IOConfigGPIO(txIO, IOCFG_OUT_PP_UP);
+        // And then switch to an input
         IOConfigGPIO(txIO, IOCFG_IPU);
     }
 }

--- a/src/main/drivers/stm32/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f4xx.c
@@ -258,6 +258,10 @@ void uartTxMonitor(uartPort_t *s)
 
         // Switch TX to an input with pullup so it's state can be monitored
         uart->txPinState = TX_PIN_MONITOR;
+        // Initially drive the line high
+        IOHi(txIO);
+        IOConfigGPIO(txIO, IOCFG_OUT_PP_UP);
+        // And then switch to an input
         IOConfigGPIO(txIO, IOCFG_IPU);
     }
 }


### PR DESCRIPTION
This PR attempts to fix the issues tackled by https://github.com/betaflight/betaflight/pull/13095.

The proposed solution mentioned at https://github.com/betaflight/betaflight/pull/13095#issuecomment-1738699761 of only disabling the TX output once at 100ms have passed since a received character, resulted in the original issue resurfacing which was the FC dropping into DFU mode when a connected WS VTX was powered off.

The PR drives the TX line high with a pull-up before switching to an input with a pull-up. For https://github.com/betaflight/betaflight/pull/13095 to have any positive effect it must be either preventing the TX being sampled low, or the TX line is actually being pulled down by the attached device. This PR addresses the former.

@dxs94 could you please test this PR and report back.