### PR TITLE
Fix clang version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get install -y libblocksruntime-dev
+        run: sudo apt-get install -y libblocksruntime-dev clang-12
 
       - name: Run sanity checks
         run: make EXTRA_FLAGS=-Werror checks

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -483,12 +483,13 @@ GTEST_DIR = ../../lib/test/gtest
 
 CC  := clang-12
 CXX := clang++-12
+ifneq ($(OSFAMILY), linux)
 ifeq ($(shell which $(CC) 2>/dev/null),)
-$(info Falling back to 'clang'.)
+$(info Falling back to 'clang' on Windows and OSX.)
 CC  := clang
 CXX := clang++
 endif
-
+endif
 #CC  := gcc
 #CXX := g++
 


### PR DESCRIPTION
As unit test fails with `clang` (version 14) we fallback to `clang-12` instead.

> Clang version has been updated in the workflow image: [actions/runner-images#8329](https://github.com/actions/runner-images/pull/8329)
