### PR TITLE
Check tx on MSP and GPS only

### DIFF
--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -55,6 +55,9 @@ typedef enum {
     SERIAL_BIDIR_PP        = 1 << 4,
     SERIAL_BIDIR_NOPULL    = 1 << 5, // disable pulls in BIDIR RX mode
     SERIAL_BIDIR_PP_PD     = 1 << 6, // PP mode, normall inverted, but with PullDowns, to fix SA after bidir issue fixed (#10220)
+
+    // If this option is set then switch the TX line to input when not in use to detect it being pulled low
+    SERIAL_CHECK_TX        = 1 << 7,
 } portOptions_e;
 
 // Define known line control states which may be passed up by underlying serial driver callback

--- a/src/main/drivers/stm32/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f4xx.c
@@ -342,7 +342,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
+            if (options & SERIAL_CHECK_TX) {
                 uart->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/drivers/stm32/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32f7xx.c
@@ -376,7 +376,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
+            if (options & SERIAL_CHECK_TX) {
                 uartdev->txPinState = TX_PIN_MONITOR;
                 // Switch TX to UART output whilst UART sends idle preamble
                 checkUsartTxOutput(s);

--- a/src/main/drivers/stm32/serial_uart_stm32g4xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32g4xx.c
@@ -309,7 +309,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
+            if (options & SERIAL_CHECK_TX) {
                 uartdev->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/drivers/stm32/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/stm32/serial_uart_stm32h7xx.c
@@ -486,7 +486,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
 
-            if (((options & SERIAL_INVERTED) == SERIAL_NOT_INVERTED) && !(options & SERIAL_BIDIR_PP_PD)) {
+            if (options & SERIAL_CHECK_TX) {
                 uartdev->txPinState = TX_PIN_ACTIVE;
                 // Switch TX to an input with pullup so it's state can be monitored
                 uartTxMonitor(s);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -435,6 +435,7 @@ void gpsInit(void)
     gpsData.tempBaudRateIndex = gpsData.userBaudRateIndex;
 
     portMode_e mode = MODE_RXTX;
+    portOptions_e options = SERIAL_NOT_INVERTED;
 
 #if defined(GPS_NMEA_TX_ONLY)
     if (gpsConfig()->provider == GPS_NMEA) {
@@ -442,8 +443,12 @@ void gpsInit(void)
     }
 #endif
 
+    if ((gpsPortConfig->identifier >= SERIAL_PORT_USART1) && (gpsPortConfig->identifier <= SERIAL_PORT_USART_MAX)){
+        options |= SERIAL_CHECK_TX;
+    }
+
     // no callback - buffer will be consumed in gpsUpdate()
-    gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, NULL, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex], mode, SERIAL_NOT_INVERTED);
+    gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, NULL, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex], mode, options);
     if (!gpsPort) {
         return;
     }

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -69,6 +69,8 @@ void mspSerialAllocatePorts(void)
 
         if (mspConfig()->halfDuplex) {
             options |= SERIAL_BIDIR;
+        } else if ((portConfig->identifier >= SERIAL_PORT_USART1) && (portConfig->identifier <= SERIAL_PORT_USART_MAX)){
+            options |= SERIAL_CHECK_TX;
         }
 
         serialPort_t *serialPort = openSerialPort(portConfig->identifier, FUNCTION_MSP, NULL, NULL, baudRates[portConfig->msp_baudrateIndex], MODE_RXTX, options);


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/13098 and https://github.com/betaflight/betaflight/pull/13095 have demonstrated that there are issues with some receivers pulling their UART TX low randomly whilst powered up.

This PR only enables checking for TX being pulled low on MSP and GPS ports. Others are not reported as triggering DFU mode when the peripherals are not powered.

@dxs94 Again I would very much appreciate your testing of this.