### PR TITLE
fix GPS task at 500Hz

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1333,27 +1333,12 @@ void gpsUpdate(timeUs_t currentTimeUs)
 
     if (gpsPort) {
         DEBUG_SET(DEBUG_GPS_CONNECTION, 7, serialRxBytesWaiting(gpsPort));
-        static uint8_t wait = 0;
-        static bool isFast = false;
         while (serialRxBytesWaiting(gpsPort)) {
-            wait = 0;
-            if (!isFast) {
-                rescheduleTask(TASK_SELF, TASK_PERIOD_HZ(TASK_GPS_RATE_FAST));
-                isFast = true;
-            }
             if (cmpTimeUs(micros(), currentTimeUs) > GPS_RECV_TIME_MAX) {
                 break;
             }
             // Add every byte to _buffer, when enough bytes are received, convert data to values
             gpsNewData(serialRead(gpsPort));
-        }
-        if (wait < 1) {
-            wait++;
-        } else if (wait == 1) {
-            wait++;
-            // wait one iteration be sure the buffer is empty, then reset to the slower task interval
-            isFast = false;
-            rescheduleTask(TASK_SELF, TASK_PERIOD_HZ(TASK_GPS_RATE));
         }
     } else if (gpsConfig()->provider == GPS_MSP) {
         if (GPS_update & GPS_MSP_UPDATE) { // GPS data received via MSP

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -347,9 +347,7 @@ extern uint8_t GPS_svinfo_quality[GPS_SV_MAXSATS_M8N];  // When NumCh is 16 or l
                                                         //     1 = carrier smoothed pseudorange used
 extern uint8_t GPS_svinfo_cno[GPS_SV_MAXSATS_M8N];      // Carrier to Noise Ratio (Signal Strength)
 
-#define TASK_GPS_RATE       100     // default update rate of GPS task
-#define TASK_GPS_RATE_FAST  500    // update rate of GPS task while Rx buffer is not empty
-
+#define TASK_GPS_RATE       500    // default update rate of GPS task
 
 #ifdef USE_DASHBOARD
 // Data used *only* by the dashboard device (OLED display).


### PR DESCRIPTION
Very quick PR to test whether running the GPS task at 500hz prevents, or at least significantly reduces, the variability in the CPU time required by the GPS task at 57600 baud and below.  

Purely for testing.  Do not merge. 