### PR TITLE
fix ARTERY UART4 pin 'PH2&PH3'

### DIFF
--- a/src/main/drivers/at32/serial_uart_at32f43x.c
+++ b/src/main/drivers/at32/serial_uart_at32f43x.c
@@ -193,10 +193,12 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rxPins = {
             { DEFIO_TAG_E(PA1),  GPIO_MUX_8 },
             { DEFIO_TAG_E(PC11), GPIO_MUX_8 },
+            { DEFIO_TAG_E(PH2),  GPIO_MUX_8 },
         },
         .txPins = {
             { DEFIO_TAG_E(PA0),  GPIO_MUX_8 },
             { DEFIO_TAG_E(PC10), GPIO_MUX_8 },
+            { DEFIO_TAG_E(PH3),  GPIO_MUX_8 },
         },
         .rcc = RCC_APB1(UART4),
         .irqn = UART4_IRQn,


### PR DESCRIPTION
Repairing the pin configuration of ARTERY chip UART4 is very useful for "PH2&PH3" pins, and the chip itself is natively supported