### PR TITLE
Update esc_sensor.h to support higher esc telemetry voltage display 

### DIFF
--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -33,7 +33,7 @@ PG_DECLARE(escSensorConfig_t, escSensorConfig);
 typedef struct {
     uint8_t dataAge;
     int8_t temperature;  // C degrees
-    int16_t voltage;     // 0.01V
+    uint16_t voltage;     // 0.01V 
     int32_t current;     // 0.01A
     int32_t consumption; // mAh
     int16_t rpm;         // 0.01erpm


### PR DESCRIPTION
Use unsigned short to extend voltage range. 
Change esc telemetry total voltage limit from 327.67V to 655.35V. 

Currently used signed short integral can only store value up to 32767, which cause high voltage X8 aircrafts unable to display voltage higher than 40.76V . Since I m testing 12s X8 aircraft ,it needs to display voltage up to 52.2V, and ESC total voltages exceed the limit of  signed short integral. Therefore I make the least change to fix this issues and keep the voltage averaging step as it was. I doubt the necessary of storing negative voltage value.

