### PR TITLE
Removed SITL hardcoded state port number

### DIFF
--- a/src/main/target/SITL/sitl.c
+++ b/src/main/target/SITL/sitl.c
@@ -318,7 +318,7 @@ void systemInit(void)
     ret = udpInit(&rcLink, NULL, PORT_RC, true);
     printf("[SITL] start UDP server for RC input @%d...%d\n", PORT_RC, ret);
 
-    ret = udpInit(&stateLink, NULL, 9003, true);
+    ret = udpInit(&stateLink, NULL, PORT_STATE, true);
     printf("start UDP server...%d\n", ret);
 
     ret = pthread_create(&udpWorker, NULL, udpThread, NULL);

--- a/src/main/target/SITL/sitl.c
+++ b/src/main/target/SITL/sitl.c
@@ -318,9 +318,6 @@ void systemInit(void)
     ret = udpInit(&rcLink, NULL, PORT_RC, true);
     printf("[SITL] start UDP server for RC input @%d...%d\n", PORT_RC, ret);
 
-    ret = udpInit(&stateLink, NULL, PORT_STATE, true);
-    printf("start UDP server...%d\n", ret);
-
     ret = pthread_create(&udpWorker, NULL, udpThread, NULL);
     if (ret != 0) {
         printf("Create udpWorker error!\n");


### PR DESCRIPTION
I was trying to run multiple instances of Betaflight SITL (by changing the UDP ports used)
https://github.com/betaflight/betaflight/blob/e805c73eb1828bce5c08c81e646d1bf56d3d57c0/src/main/target/SITL/sitl.c#L79-L82
and noted that port 9003 was hardcoded on line
https://github.com/betaflight/betaflight/blob/e805c73eb1828bce5c08c81e646d1bf56d3d57c0/src/main/target/SITL/sitl.c#L321

Multiple SITL instances work fine once I changed that and I only re-define `PORT_PWM`, `PORT_RC`, `PORT_STATE`