### PR TITLE
Allow CRSF RX binding via cli

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -693,8 +693,8 @@ void crsfRxBind(void)
             CRSF_ADDRESS_FLIGHT_CONTROLLER,
             CRSF_COMMAND_SUBCMD_RX,
             CRSF_COMMAND_SUBCMD_RX_BIND,
-            0x9E,  // CMD CRC
-            0xE8
+            0x9E,  // Command CRC8
+            0xE8,  // Packet CRC8
         };
         serialWriteBuf(serialPort, bindFrame, 9);
     }

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -681,4 +681,22 @@ bool crsfRxIsActive(void)
 {
     return serialPort != NULL;
 }
+
+void crsfRxBind(void)
+{
+    if (serialPort != NULL) {
+        uint8_t bindFrame[] = {
+            CRSF_SYNC_BYTE,
+            0x07,  // frame length
+            CRSF_FRAMETYPE_COMMAND,
+            CRSF_ADDRESS_CRSF_RECEIVER,
+            CRSF_ADDRESS_FLIGHT_CONTROLLER,
+            CRSF_COMMAND_SUBCMD_RX,
+            CRSF_COMMAND_SUBCMD_RX_BIND,
+            0x9E,  // CMD CRC
+            0xE8
+        };
+        serialWriteBuf(serialPort, bindFrame, 9);
+    }
+}
 #endif

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -88,3 +88,4 @@ bool crsfRxInit(const struct rxConfig_s *initialRxConfig, struct rxRuntimeState_
 void crsfRxUpdateBaudrate(uint32_t baudrate);
 bool crsfRxUseNegotiatedBaud(void);
 bool crsfRxIsActive(void);
+void crsfRxBind(void);

--- a/src/main/rx/crsf_protocol.h
+++ b/src/main/rx/crsf_protocol.h
@@ -60,7 +60,12 @@ typedef enum {
 } crsfFrameType_e;
 
 enum {
+    CRSF_COMMAND_SUBCMD_RX = 0x10,    // receiver command
     CRSF_COMMAND_SUBCMD_GENERAL = 0x0A,    // general command
+};
+
+enum {
+    CRSF_COMMAND_SUBCMD_RX_BIND = 0x01,    // bind command
 };
 
 enum {

--- a/src/main/rx/rx_bind.c
+++ b/src/main/rx/rx_bind.c
@@ -24,12 +24,13 @@
 
 #include "rx/rx_spi_common.h"
 #include "rx/srxl2.h"
+#include "rx/crsf.h"
 
 #include "rx_bind.h"
 
 static bool doRxBind(bool doBind)
 {
-#if !defined(USE_SERIALRX_SRXL2) && !defined(USE_RX_FRSKY_SPI) && !defined(USE_RX_SFHSS_SPI) && !defined(USE_RX_FLYSKY) && !defined(USE_RX_SPEKTRUM) && !defined(USE_RX_EXPRESSLRS)
+#if !defined(USE_SERIALRX_SRXL2) && !defined(USE_RX_FRSKY_SPI) && !defined(USE_RX_SFHSS_SPI) && !defined(USE_RX_FLYSKY) && !defined(USE_RX_SPEKTRUM) && !defined(USE_RX_EXPRESSLRS) && !defined(USE_RX_CRSF)
     UNUSED(doBind);
 #endif
 
@@ -40,6 +41,14 @@ static bool doRxBind(bool doBind)
         switch (rxRuntimeState.serialrxProvider) {
         default:
             return false;
+#if defined(USE_RX_CRSF)
+        case SERIALRX_CRSF:
+            if (doBind) {
+                crsfRxBind();
+            }
+
+            break;
+#endif
 #if defined(USE_SERIALRX_SRXL2)
         case SERIALRX_SRXL2:
             if (doBind) {

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -152,6 +152,7 @@
 #define USE_RX_SPI
 
 #define USE_RX_CC2500
+#define USE_RX_CRSF
 #define USE_RX_EXPRESSLRS
 #define USE_RX_SX1280
 #define USE_RX_SX127X


### PR DESCRIPTION
This Pull Request enables CRSF RX binding via CLI. 

The change has been tested with `OMNIBUSF4SD` and TBS Tracer Nano RX.

**Rationale**
There are conditions under which access to the binding function is necessary but limited or not possible using a button.
Examples:
- Access to the receiver is limited
- The pairing button is physically damaged

**Steps to test a feature:**
1) Configure CRSF receiver
2) Go to `CLI`
3) Execute `bind_rx`

**Result:** 
- CLI outputs `Binding...`
- RX starts blinking a green LED indicating binding mode

Resolves #8458
