### PR TITLE
Add OSD Link Quality alarm value to the MSP

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1050,6 +1050,9 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, osdConfig()->camera_frame_width);
         sbufWriteU8(dst, osdConfig()->camera_frame_height);
 
+        // API >= 1.46
+        sbufWriteU16(dst, osdConfig()->link_quality_alarm);
+
         break;
     }
 #endif // USE_OSD
@@ -4211,6 +4214,12 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                     osdConfigMutable()->camera_frame_width = sbufReadU8(src);
                     osdConfigMutable()->camera_frame_height = sbufReadU8(src);
                 }
+
+                if (sbufBytesRemaining(src) >= 2) {
+                    // API >= 1.46
+                    osdConfigMutable()->link_quality_alarm = sbufReadU16(src);
+                }
+
             } else if ((int8_t)addr == -2) {
                 // Timers
                 uint8_t index = sbufReadU8(src);


### PR DESCRIPTION
Now that ELRS is the main radio control link, I think is important to let the user config the link quality (the recommended rssi value to be used with ELRS) directly in the Configurator OSD tab, like other alarms.

This PR adds the value to the MSP protocol, to be able to use it inside the Configurator:
![image](https://github.com/betaflight/betaflight/assets/2673520/f92f4767-f941-476a-b8ae-f8c6bb1e367a)

I will push a PR to the configurator too with the changes needed.
https://github.com/betaflight/betaflight-configurator/pull/3609
