### PR TITLE
enable HSI on all mcus via define

### DIFF
--- a/src/main/startup/at32/system_at32f435_437.c
+++ b/src/main/startup/at32/system_at32f435_437.c
@@ -77,10 +77,19 @@ void SystemInit (void)
   while(CRM->ctrl_bit.hickstbl != SET);
 
   /* hick used as system clock */
-  CRM->cfg_bit.sclksel = CRM_SCLK_HICK;
+  CRM->cfg_bit.sclksel =
+#ifdef USE_CLOCK_SOURCE_HSI
+                          CRM_SCLK_HICK;
+#else
+                          CRM_SCLK_HEXT;
+#endif
 
   /* wait sclk switch status */
+#ifdef USE_CLOCK_SOURCE_HSI
   while(CRM->cfg_bit.sclksts != CRM_SCLK_HICK);
+#else
+  while(CRM->cfg_bit.sclksts != CRM_SCLK_HEXT);
+#endif
 
   /* reset cfg register, include sclk switch, ahbdiv, apb1div, apb2div, adcdiv, clkout bits */
   CRM->cfg = 0;

--- a/src/main/startup/system_stm32f4xx.c
+++ b/src/main/startup/system_stm32f4xx.c
@@ -689,7 +689,14 @@ static int StartHSx(uint32_t onBit, uint32_t readyBit, int maxWaitCount)
   */
 void SetSysClock(void)
 {
-    uint32_t hse_value = persistentObjectRead(PERSISTENT_OBJECT_HSE_VALUE);
+    uint32_t hse_value =
+#ifdef USE_CLOCK_SOURCE_HSI
+                          0
+#else
+                          persistentObjectRead(PERSISTENT_OBJECT_HSE_VALUE)
+#endif
+                          ;
+
     uint32_t hse_mhz = hse_value / 1000000;
 
     // Switch to HSI during clock manipulation

--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -153,7 +153,7 @@
 
       __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
 
-#ifdef CLOCK_SOURCE_USE_HSI
+#ifdef USE_CLOCK_SOURCE_HSI
       /* Enable HSI Oscillator and activate PLL with HSI as source */
       RCC_OscInitStruct.OscillatorType       = RCC_OSCILLATORTYPE_HSI;
       RCC_OscInitStruct.HSIState             = RCC_HSI_ON;

--- a/src/main/startup/system_stm32g4xx.c
+++ b/src/main/startup/system_stm32g4xx.c
@@ -117,7 +117,12 @@ void SystemInit(void)
   */
 void SystemCoreClockUpdate(void)
 {
-  uint32_t hse_value = persistentObjectRead(PERSISTENT_OBJECT_HSE_VALUE);
+  uint32_t hse_value =
+#ifdef USE_CLOCK_SOURCE_HSI
+        0;
+#else
+      persistentObjectRead(PERSISTENT_OBJECT_HSE_VALUE);
+#endif
 
   uint32_t tmp, pllvco, pllr, pllsource, pllm;
 
@@ -276,7 +281,13 @@ static int sysclkMhz;
 
 static bool systemClock_PLLConfig(int overclockLevel)
 {
-    uint32_t hse_value = persistentObjectRead(PERSISTENT_OBJECT_HSE_VALUE);
+    uint32_t hse_value =
+#ifdef USE_CLOCK_SOURCE_HSI
+        0;
+#else
+      persistentObjectRead(PERSISTENT_OBJECT_HSE_VALUE);
+#endif
+
     int pllInput;
     int targetMhz;
 
@@ -372,9 +383,19 @@ void SystemClock_Config(void)
   // Initializes the CPU, AHB and APB busses clocks 
 
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI|RCC_OSCILLATORTYPE_HSI48
-                              |RCC_OSCILLATORTYPE_LSI|RCC_OSCILLATORTYPE_HSE;
+                              |RCC_OSCILLATORTYPE_LSI
+#ifndef USE_CLOCK_SOURCE_HSI
+                              |RCC_OSCILLATORTYPE_HSE
+#endif
+                              ;
+                          
 
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.HSEState =
+#ifdef USE_CLOCK_SOURCE_HSI
+              RCC_HSE_OFF;
+#else
+              RCC_HSE_ON;
+#endif
   RCC_OscInitStruct.HSIState = RCC_HSI_ON;
   RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
   RCC_OscInitStruct.LSIState = RCC_LSI_ON;


### PR DESCRIPTION
This PR enables board designs without a external crystal.

Just use the config and define `USE_CLOCK_SOURCE_HSI`