### PR TITLE
Fix compass loop time

### DIFF
--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -31,6 +31,7 @@
 #include "cms/cms.h"
 
 #include "common/color.h"
+#include "common/time.h"
 #include "common/utils.h"
 
 #include "config/feature.h"

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -27,7 +27,7 @@
 #include "pg/pg.h"
 #include "sensors/sensors.h"
 
-#define TASK_COMPASS_RATE_HZ 200
+#define TASK_COMPASS_RATE_HZ 300
 
 // Type of magnetometer used/detected
 typedef enum {


### PR DESCRIPTION
Compass reads were in two phases, one of 5ms, and one of 500us thus:

![image](https://github.com/betaflight/betaflight/assets/11480839/05c89330-91de-480e-a884-d3b6fa2b2016)

This resulted in a cycle time of 5.5ms rather than the desires 5ms.

This PR fixes that to give:

![image](https://github.com/betaflight/betaflight/assets/11480839/ed6eb716-b8e5-4eb8-bd25-843b7bc6a620)
