### PR TITLE
Keep I-terms at zero throttle for fixed wings

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -786,7 +786,8 @@ bool processRx(timeUs_t currentTimeUs)
     /* In airmode iterm should be prevented to grow when Low thottle and Roll + Pitch Centered.
      This is needed to prevent iterm winding on the ground, but keep full stabilisation on 0 throttle while in air */
     if (throttleStatus == THROTTLE_LOW && !airmodeIsActivated && !launchControlActive) {
-        pidSetItermReset(true);
+        const bool fixedWingArmed = isFixedWing() && ARMING_FLAG(ARMED);
+        pidSetItermReset(!fixedWingArmed); // don't reset iterm for fixed wing when armed at zero throttle
         if (currentPidProfile->pidAtMinThrottle)
             pidStabilisationState(PID_STABILISATION_ON);
         else

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -770,31 +770,17 @@ bool processRx(timeUs_t currentTimeUs)
         failsafeStartMonitoring();
     }
 
-    const throttleStatus_e throttleStatus = calculateThrottleStatus();
+    const bool throttleActive = calculateThrottleStatus() != THROTTLE_LOW;
     const uint8_t throttlePercent = calculateThrottlePercentAbs();
-
     const bool launchControlActive = isLaunchControlActive();
+    airmodeIsActivated = airmodeIsEnabled() && throttlePercent >= rxConfig()->airModeActivateThreshold && !launchControlActive;
 
-    if (airmodeIsEnabled() && ARMING_FLAG(ARMED) && !launchControlActive) {
-        if (throttlePercent >= rxConfig()->airModeActivateThreshold) {
-            airmodeIsActivated = true; // Prevent iterm from being reset
-        }
-    } else {
-        airmodeIsActivated = false;
-    }
-
-    /* In airmode iterm should be prevented to grow when Low thottle and Roll + Pitch Centered.
-     This is needed to prevent iterm winding on the ground, but keep full stabilisation on 0 throttle while in air */
-    if (throttleStatus == THROTTLE_LOW && !airmodeIsActivated && !launchControlActive) {
-        const bool fixedWingArmed = isFixedWing() && ARMING_FLAG(ARMED);
-        pidSetItermReset(!fixedWingArmed); // don't reset iterm for fixed wing when armed at zero throttle
-        if (currentPidProfile->pidAtMinThrottle)
-            pidStabilisationState(PID_STABILISATION_ON);
-        else
-            pidStabilisationState(PID_STABILISATION_OFF);
-    } else {
+    if (ARMING_FLAG(ARMED) && (airmodeIsActivated || throttleActive || launchControlActive || isFixedWing())) {
         pidSetItermReset(false);
         pidStabilisationState(PID_STABILISATION_ON);
+    } else {
+        pidSetItermReset(true);
+        pidStabilisationState(currentPidProfile->pidAtMinThrottle ? PID_STABILISATION_ON : PID_STABILISATION_OFF);
     }
 
 #ifdef USE_RUNAWAY_TAKEOFF
@@ -817,7 +803,7 @@ bool processRx(timeUs_t currentTimeUs)
         //   - sticks are active and have deflection greater than runaway_takeoff_deactivate_stick_percent
         //   - pidSum on all axis is less then runaway_takeoff_deactivate_pidlimit
         bool inStableFlight = false;
-        if (!featureIsEnabled(FEATURE_MOTOR_STOP) || airmodeIsEnabled() || (throttleStatus != THROTTLE_LOW)) { // are motors running?
+        if (!featureIsEnabled(FEATURE_MOTOR_STOP) || airmodeIsEnabled() || throttleActive) { // are motors running?
             const uint8_t lowThrottleLimit = pidConfig()->runaway_takeoff_deactivate_throttle;
             const uint8_t midThrottleLimit = constrain(lowThrottleLimit * 2, lowThrottleLimit * 2, RUNAWAY_TAKEOFF_HIGH_THROTTLE_PERCENT);
             if ((((throttlePercent >= lowThrottleLimit) && areSticksActive(RUNAWAY_TAKEOFF_DEACTIVATE_STICK_PERCENT)) || (throttlePercent >= midThrottleLimit))

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -773,7 +773,7 @@ bool processRx(timeUs_t currentTimeUs)
     const bool throttleActive = calculateThrottleStatus() != THROTTLE_LOW;
     const uint8_t throttlePercent = calculateThrottlePercentAbs();
     const bool launchControlActive = isLaunchControlActive();
-    airmodeIsActivated = airmodeIsEnabled() && throttlePercent >= rxConfig()->airModeActivateThreshold && !launchControlActive;
+    airmodeIsActivated = airmodeIsEnabled() && ARMING_FLAG(ARMED) && throttlePercent >= rxConfig()->airModeActivateThreshold && !launchControlActive;
 
     if (ARMING_FLAG(ARMED) && (airmodeIsActivated || throttleActive || launchControlActive || isFixedWing())) {
         pidSetItermReset(false);


### PR DESCRIPTION
This PR fixes wings behavior at zero throttle (I-term)

Fixed wings need to be able to fly like normal at zero throttle (gliding).
For this purpose, I-term needs to stay active together with the rest of PIDFF.

PR allows I-term to accumulate at zero throttle if mixer is fixed-wing and its armed.

Huge tHanks to @ctzsnooze for helping to figure out where to put this code.