### PR TITLE
Fix buffer overflow in JETIEXBUS character reception

### DIFF
--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -153,6 +153,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
 
     static timeUs_t jetiExBusTimeLast = 0;
     static uint8_t *jetiExBusFrame;
+    static uint8_t jetiExBusFrameMaxSize;
     const timeUs_t now = microsISR();
 
     // Check if we shall reset frame position due to time
@@ -169,16 +170,28 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
         case EXBUS_START_CHANNEL_FRAME:
             jetiExBusFrameState = EXBUS_STATE_IN_PROGRESS;
             jetiExBusFrame = jetiExBusChannelFrame;
+            jetiExBusFrameMaxSize = EXBUS_MAX_CHANNEL_FRAME_SIZE;
             break;
 
         case EXBUS_START_REQUEST_FRAME:
             jetiExBusRequestState = EXBUS_STATE_IN_PROGRESS;
             jetiExBusFrame = jetiExBusRequestFrame;
+            jetiExBusFrameMaxSize = EXBUS_MAX_REQUEST_FRAME_SIZE;
             break;
 
         default:
             return;
         }
+    }
+
+    if (jetiExBusFramePosition == jetiExBusFrameMaxSize)
+    {
+        // frame overrun
+        jetiExBusFrameReset();
+        jetiExBusFrameState = EXBUS_STATE_ZERO;
+        jetiExBusRequestState = EXBUS_STATE_ZERO;
+
+        return;
     }
 
     // Store in frame copy

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -184,8 +184,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
         }
     }
 
-    if (jetiExBusFramePosition == jetiExBusFrameMaxSize)
-    {
+    if (jetiExBusFramePosition == jetiExBusFrameMaxSize) {
         // frame overrun
         jetiExBusFrameReset();
         jetiExBusFrameState = EXBUS_STATE_ZERO;


### PR DESCRIPTION
This fixes a buffer overflow that resulted in an FC hang.

Fixes https://github.com/betaflight/betaflight/issues/12756

Credit to @klutvott123 for determining how to reliably reproduce this issue using the python script below to send a serial data stream to an FC using an FTDI serial adaptor, connecting the FTDI TX line to the FC TX line via a 1K resistor.

[jetiexbus_test.py.zip](https://github.com/betaflight/betaflight/files/13059335/jetiexbus_test.py.zip)
