### PR TITLE
Add parameter to remove PREARM toggleing

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1014,6 +1014,7 @@ const clivalue_t valueTable[] = {
 // PG_ARMING_CONFIG
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
+    { PARAM_NAME_PREARM_TOGGLE, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_toggle) },
 
 // PG_GPS_CONFIG
 #ifdef USE_GPS

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -337,7 +337,7 @@ void updateArmingStatus(void)
         }
 
         if (isModeActivationConditionPresent(BOXPREARM)) {
-            if (IS_RC_MODE_ACTIVE(BOXPREARM) && !ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {
+            if (IS_RC_MODE_ACTIVE(BOXPREARM) && !(armingConfig()->prearm_toggle && ARMING_FLAG(WAS_ARMED_WITH_PREARM))) {
                 unsetArmingDisabled(ARMING_DISABLED_NOPREARM);
             } else {
                 setArmingDisabled(ARMING_DISABLED_NOPREARM);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -58,6 +58,7 @@
 #define PARAM_NAME_THROTTLE_LIMIT_TYPE "throttle_limit_type"
 #define PARAM_NAME_THROTTLE_LIMIT_PERCENT "throttle_limit_percent"
 #define PARAM_NAME_GYRO_CAL_ON_FIRST_ARM "gyro_cal_on_first_arm"
+#define PARAM_NAME_PREARM_TOGGLE "prearm_toggle"
 #define PARAM_NAME_DEADBAND "deadband"
 #define PARAM_NAME_YAW_DEADBAND "yaw_deadband"
 #define PARAM_NAME_PID_PROCESS_DENOM "pid_process_denom"

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -86,7 +86,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,
-    .auto_disarm_delay = 5
+    .auto_disarm_delay = 5,
+    .prearm_toggle = true
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -132,6 +132,7 @@ PG_DECLARE(flight3DConfig_t, flight3DConfig);
 typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
+    bool prearm_toggle;                     // after disarm, prearm needs to be toggled to arm again.
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);


### PR DESCRIPTION
When using PREARM we have to toggle the PREARM mode whenever we want to rearm after a disarm. I like to have PREARM on a toggle switch on the RC and as long as I have the Quad PREARMed to be able to fast disarm/arm without having extra toggeling logic to deal with.

To not mess with existing users I introduced the parameter `prearm_toggle` - defaults to `ON` which is the existing behaviour of PREARM.

These are my first wanderings into BF code and a I hope the parameter addition is complete with what I did. I also left it out of Blackbox headers as I see no need for it...