### PR TITLE
Remove back-and-forth float to int to float conversion in acceleration calculation

### DIFF
--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -79,7 +79,7 @@ void accUpdate(timeUs_t currentTimeUs)
     applyAccelerationTrims(accelerationRuntime.accelerationTrims);
 
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        const int16_t val = acc.accADC[axis];
+        const float val = acc.accADC[axis];
         acc.accADC[axis] = accelerationRuntime.accLpfCutHz ? pt2FilterApply(&accelerationRuntime.accFilter[axis], val) : val;
     }
 }


### PR DESCRIPTION
The current code in acceleration converts `acc.accADC[axis]`, which is a float, to an uint16_t, and then back to float again. 
I'm not sure why. 
Aside from a small performance hit, the back and forth conversion might cause some quantization if a matrix is used for the sensor rotation.
