### PR TITLE
Mag scheduling improvements

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -117,4 +117,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RPM_LIMIT",
     "RC_STATS",
     "MAG_CALIB",
+    "MAG_TASK_RATE",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -117,6 +117,7 @@ typedef enum {
     DEBUG_RPM_LIMIT,
     DEBUG_RC_STATS,
     DEBUG_MAG_CALIB,
+    DEBUG_MAG_TASK_RATE,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/drivers/compass/compass.h
+++ b/src/main/drivers/compass/compass.h
@@ -36,4 +36,5 @@ typedef struct magDev_s {
     fp_rotationMatrix_t rotationMatrix;
     ioTag_t magIntExtiTag;
     int16_t magGain[3];
+    uint16_t magOdrHz;
 } magDev_t;

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -368,6 +368,7 @@ static bool ak8963Init(magDev_t *mag)
 
     // Trigger first measurement
     ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL1, CNTL1_BIT_16_BIT | CNTL1_MODE_ONCE);
+    mag->magOdrHz = 50; // arbitrary value, need to check what ODR is actually returned
     return true;
 }
 

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -391,7 +391,6 @@ void ak8963BusInit(const extDevice_t *dev)
 
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
-        rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
 
         // Disable DMA on gyro as this upsets slave access timing
         spiDmaEnable(dev->bus->busType_u.mpuSlave.master, false);

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -108,6 +108,7 @@ static bool ak8975Init(magDev_t *mag)
 
     // Trigger first measurement
     busWriteRegister(dev, AK8975_MAG_REG_CNTL, CNTL_BIT_16_BIT | CNTL_MODE_ONCE);
+    mag->magOdrHz = 50; // arbitrary value, need to check what ODR is actually returned
     return true;
 }
 

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -235,6 +235,7 @@ static bool hmc5883lInit(magDev_t *mag)
     delay(100);
 
     hmc5883lConfigureDataReadyInterruptHandling(mag);
+    mag->magOdrHz = 75; // HMC_CONFA_DOR_75HZ
     return true;
 }
 

--- a/src/main/drivers/compass/compass_ist8310.c
+++ b/src/main/drivers/compass/compass_ist8310.c
@@ -127,6 +127,8 @@ static bool ist8310Init(magDev_t *magDev)
     delay(6); 
     ack = ack && busWriteRegister(dev, IST8310_REG_CNTRL1, IST8310_ODR_SINGLE);
 
+    magDev->magOdrHz = 100;
+    // need to check what ODR is actually returned, may be a bit faster than 100Hz
     return ack;
 }
 

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -137,7 +137,7 @@ static bool lis3mdlInit(magDev_t *mag)
     busWriteRegister(dev, LIS3MDL_REG_CTRL_REG3, 0x00);
 
     delay(100);
-
+    mag->magOdrHz = 80; // LIS3MDL_DO_80
     return true;
 }
 

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -68,6 +68,7 @@
 
 #define QMC5883L_REG_DATA_OUTPUT_X 0x00
 #define QMC5883L_REG_STATUS 0x06
+#define QMC5883L_REG_STATUS_DRDY 0x01
 
 #define QMC5883L_REG_ID 0x0D
 #define QMC5883_ID_VAL 0xFF
@@ -93,39 +94,36 @@ static bool qmc5883lInit(magDev_t *magDev)
 static bool qmc5883lRead(magDev_t *magDev, int16_t *magData)
 {
     static uint8_t buf[6];
-    static uint8_t status;
+    static uint8_t status = 0;
     static enum {
-        STATE_READ_STATUS,
-        STATE_WAIT_STATUS,
-        STATE_WAIT_READ,
-    } state = STATE_READ_STATUS;
+        STATE_WAIT_DRDY,
+        STATE_READ,
+    } state = STATE_WAIT_DRDY;
 
     extDevice_t *dev = &magDev->dev;
 
     switch (state) {
         default:
-        case STATE_READ_STATUS:
-            busReadRegisterBufferStart(dev, QMC5883L_REG_STATUS, &status, sizeof(status));
-            state = STATE_WAIT_STATUS;
-            return false;
-
-        case STATE_WAIT_STATUS:
-            if ((status & 0x01) == 0) {
+        case STATE_WAIT_DRDY:
+            if (status & QMC5883L_REG_STATUS_DRDY) {
+                // New data is available
+                busReadRegisterBufferStart(dev, QMC5883L_REG_DATA_OUTPUT_X, buf, sizeof(buf));
+                state = STATE_READ;
+            } else {
+                // Read status register to check for data ready
                 busReadRegisterBufferStart(dev, QMC5883L_REG_STATUS, &status, sizeof(status));
-                return false;
             }
-
-            busReadRegisterBufferStart(dev, QMC5883L_REG_DATA_OUTPUT_X, buf, sizeof(buf));
-            state = STATE_WAIT_READ;
             return false;
 
-        case STATE_WAIT_READ:
-
+        case STATE_READ:
             magData[X] = (int16_t)(buf[1] << 8 | buf[0]);
             magData[Y] = (int16_t)(buf[3] << 8 | buf[2]);
             magData[Z] = (int16_t)(buf[5] << 8 | buf[4]);
 
-            state = STATE_READ_STATUS;
+            state = STATE_WAIT_DRDY;
+
+            // Indicate that new data is required
+            status = 0;
 
             return true;
     }

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -86,6 +86,7 @@ static bool qmc5883lInit(magDev_t *magDev)
         return false;
     }
 
+    magDev->magOdrHz = 200; // QMC5883L_ODR_200HZ
     return true;
 }
 

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -110,7 +110,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData)
 
         case STATE_WAIT_STATUS:
             if ((status & 0x01) == 0) {
-                state = STATE_READ_STATUS;
+                busReadRegisterBufferStart(dev, QMC5883L_REG_STATUS, &status, sizeof(status));
                 return false;
             }
 

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -31,7 +31,6 @@
 #include "cms/cms.h"
 
 #include "common/color.h"
-#include "common/time.h"
 #include "common/utils.h"
 
 #include "config/feature.h"

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -27,7 +27,7 @@
 #include "pg/pg.h"
 #include "sensors/sensors.h"
 
-#define TASK_COMPASS_RATE_HZ 300
+#define TASK_COMPASS_RATE_HZ 40 // the base mag update rate; faster intervals will apply for higher ODR mags
 
 // Type of magnetometer used/detected
 typedef enum {


### PR DESCRIPTION
**Tested carefully, and works well, with the QMC5883L and HMC5883L mags.  Take care with other magnetometers.**

*edit 21/11/2023: included a more efficient check code for the QMC mag - thank you @SteveCEvans; removed Testing Required flag*
*edit 18/11/2023: rebased to master and @pichim's cal code, testing notes included, improved bus busy behaviour*

## To test:

- connect a Magnetometer, validate that it is detected.  
- in cli go: `set debug_mode = MAG_TASK_RATE`, and `set blackbox_mode = always`; save
- power up for about 10s from lipo, or external USB power supply if the FC powers the mag
- return blackbox logging to normal with: `set blackbox_mode = always`

Save and share the log; we want to check the mag data update rate, CPU loading, etc, with other mags.

## Notes:

This PR improves the scheduling of Mag / Compass tasks.

Recently [PR13125](https://github.com/betaflight/betaflight/pull/13125) improved the scheduling of Mag reads.  Unfortunately one of the changes there led to significantly faster I2C requests than intended, such that on the QMC5883L, reads were happening at 2kHz.

This PR simplifies the code related to Mag scheduling.  It allows the ODR of the Mag unit to be specified in the compass driver file, and uses that value to determine when to commence checking for new data after receiving data.

It also includes a small but significant improvement from @SteveCEvans that reduces the time taken to read data from the QMC5338L by one task interval. 

The Mag task now defaults to 40hz.  This only applies to drivers where the ODR is *not* specified in the driver.  

There are now three possible return intervals for Mags with defined ODR:
- 500us if the i2c bus is busy
- 1000us if data was requested but not returned
- a per-mag `compassReadIntervalUs` period, during which time the Mag task will not poll the i2C bus; this would be close to 20ms for a Mag with a 50Hz ODR

When the `compassReadIntervalUs` period expires, the code polls the i2c bus at 1ms intervals, looking for new compass data.  When the data ready flag is true, data is requested, at 1ms intervals we return to get the requested data.  After receiving data, we again wait for the `compassReadIntervalUs` period.

If the ODR is known to `compass.c` from `magDev.magOdrHz`, a suitable value for `compassReadIntervalUs` is  determined, on init, as follows:
- the interval in us for the ODR, minus
- two re-check intervals, currently 1ms each
- a margin of error of 5% of the ODR interval, since the Mag clock may be faster or slower than the FC.

For example, a QMC at 200Hz has an output data rate (ODR) interval of 5000us.  If we subtract 2000us and then a further 250us for the 5% margin, and we get `compassReadIntervalUs` of 2.75us.  This is the 'quiet period' after a read before we go looking for the next data value.  Hence the task can return data from this Mag as quickly as every 3.75ms, followed by a check every millisecond until new data arrives.  Usually it runs approximately every 4.9ms.  After 5-15 task iterations, the asynchronous nature of the transmission may cause one inter-packet interval to be 3.9ms or 5.9ms depending on whether the Mag or the FC runs faster. 

This image shows the various intervals for the 200Hz QMC.

![Screen Shot 2023-11-13 at 10 11 09](https://github.com/betaflight/betaflight/assets/11737748/3aa10291-398d-4d88-8bc2-d3cd4b4259e8)

In contrast, an HMC at 75Hz would have a basic interval of 13,333uS.  Subtract 2000us and an extra 666us and we get a quiet period of 10.7ms before we check again.

The intent is to load the i2C bus  as lightly as reasonably practical, given the asynchronous nature of the reads and the slightly variable intervals in task initiation.

Validation using the `MAG_TASK_RATE` debug is needed for other Mag units.  I've emulated slower Mag behaviour by configuring the QMC to 50Hz, and the current code works well in this case, but we need to be sure that other Mags are OK, particularly those using 'direct read' methods.