### PR TITLE
64 bits for osd_stat_bitmask

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1492,7 +1492,7 @@ const clivalue_t valueTable[] = {
 #endif
 
     // OSD stats enabled flags are stored as bitmapped values inside a 32bit parameter
-    { "osd_stat_bitmask",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
+    { "osd_stat_bitmask",     VAR_UINT64 | MASTER_VALUE, .config.u64Max = UINT64_MAX, PG_OSD_CONFIG, offsetof(osdConfig_t, enabled_stats)},
 
 #ifdef USE_OSD_PROFILES
     { "osd_profile",                VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, OSD_PROFILE_COUNT }, PG_OSD_CONFIG, offsetof(osdConfig_t, osdProfileIndex) },

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -166,6 +166,8 @@ typedef enum {
     VAR_INT16 = (3 << VALUE_TYPE_OFFSET),
     VAR_UINT32 = (4 << VALUE_TYPE_OFFSET),
     VAR_INT32 = (5 << VALUE_TYPE_OFFSET),
+    VAR_UINT64 = (6 << VALUE_TYPE_OFFSET),
+    VAR_INT64 = (7 << VALUE_TYPE_OFFSET),
 
     // value section, bits 3-4
     MASTER_VALUE = (0 << VALUE_SECTION_OFFSET),
@@ -222,6 +224,8 @@ typedef union {
     uint8_t bitpos;                           // used for MODE_BITSET
     uint32_t u32Max;                          // used for MODE_DIRECT with VAR_UINT32
     int32_t d32Max;                           // used for MODE_DIRECT with VAR_INT32
+    uint64_t u64Max;                          // used for MODE_DIRECT with VAR_UINT64
+    int64_t d64Max;                           // used for MODE_DIRECT with VAR_INT64
 } cliValueConfig_t;
 
 typedef struct clivalue_s {

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -239,7 +239,7 @@ typedef enum {
 } osd_stats_e;
 
 // Make sure the number of stats do not exceed the available 32bit storage
-STATIC_ASSERT(OSD_STAT_COUNT <= 32, osdstats_overflow);
+STATIC_ASSERT(OSD_STAT_COUNT <= 64, osdstats_overflow);
 
 typedef enum {
     OSD_TIMER_1,
@@ -317,7 +317,7 @@ typedef struct osdConfig_s {
 
     uint8_t ahMaxPitch;
     uint8_t ahMaxRoll;
-    uint32_t enabled_stats;
+    uint64_t enabled_stats;
     uint8_t esc_temp_alarm;
     int16_t esc_rpm_alarm;
     int16_t esc_current_alarm;


### PR DESCRIPTION
osd_stat_bitmask is full (31 elements)
For future use let's make this bitmask 64 bits + add the necessary logic for INT64/UINT64 for CLI.
Hope i didn't miss anything...
