### PR TITLE
Add default config option for dshot telemetry

### DIFF
--- a/src/main/pg/motor.c
+++ b/src/main/pg/motor.c
@@ -44,6 +44,10 @@
 #define DEFAULT_DSHOT_BURST DSHOT_DMAR_OFF
 #endif
 
+#if !defined(DEFAULT_DSHOT_TELEMETRY)
+#define DEFAULT_DSHOT_TELEMETRY DSHOT_TELEMETRY_OFF
+#endif
+
 PG_REGISTER_WITH_RESET_FN(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 2);
 
 void pgResetFn_motorConfig(motorConfig_t *motorConfig)
@@ -105,6 +109,10 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
 
 #ifdef USE_DSHOT_DMAR
     motorConfig->dev.useBurstDshot = DEFAULT_DSHOT_BURST;
+#endif
+
+#ifdef USE_DSHOT_TELEMETRY
+    motorConfig->dev.useDshotTelemetry = DEFAULT_DSHOT_TELEMETRY;
 #endif
 
 #ifdef USE_DSHOT_BITBANG

--- a/src/main/pg/motor.h
+++ b/src/main/pg/motor.h
@@ -37,6 +37,11 @@ typedef enum {
     DSHOT_DMAR_AUTO
 } dshotDmar_e;
 
+typedef enum {
+    DSHOT_TELEMETRY_OFF,
+    DSHOT_TELEMETRY_ON,
+} dshotTelemetry_e;
+
 typedef struct motorDevConfig_s {
     uint16_t motorPwmRate;                  // The update rate of motor outputs (50-498Hz)
     uint8_t  motorPwmProtocol;              // Pwm Protocol


### PR DESCRIPTION
For use in config.h


Enable:

    #define DEFAULT_DSHOT_TELEMETRY DSHOT_TELEMETRY_ON

Disable:

    #define DEFAULT_DSHOT_TELEMETRY DSHOT_TELEMETRY_OFF
