### PR TITLE
Add RPM Limiter to baseline build

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -349,7 +349,7 @@ static void applyRpmLimiter(mixerRuntime_t *mixer)
 {
     static float prevError = 0.0f;
     static float i = 0.0f;
-    const float unsmoothedAverageRpm = getDshotAverageRpm();
+    const float unsmoothedAverageRpm = getDshotRpmAverage();
     const float averageRpm = pt1FilterApply(&mixer->averageRpmFilter, unsmoothedAverageRpm);
     const float error = averageRpm - mixer->rpmLimiterRpmLimit;
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -222,6 +222,10 @@
 
 #endif // USE_TELEMETRY
 
+#ifdef USE_DSHOT_TELEMETRY
+#define USE_RPM_LIMIT
+#endif
+
 #define USE_BATTERY_CONTINUE
 #define USE_DASHBOARD
 #define USE_EMFAT_AUTORUN
@@ -251,7 +255,7 @@
 #define USE_RANGEFINDER_HCSR04
 #define USE_RANGEFINDER_TF
 
-#endif
+#endif // TARGET_FLASH_SIZE > 512
 
 #endif // !defined(CLOUD_BUILD)
 


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/pull/13012#issuecomment-1837394747

This error flew under my radar because when trying to compile with all defines enabled, `USE_RPM_LIMIT` is still not enabled. (Is this wanted behavior or just a small pre-define error?)

Edit:
I added the RPM Limiter define to the baseline build, as suggested by @haslinghuis, so that its code does not get ignored during continuous integration on Github.