### PR TITLE
Change WHO_AM_I to match datasheet

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -45,7 +45,7 @@
 #define ICM20689_WHO_AM_I_CONST             (0x98)
 #define ICM42605_WHO_AM_I_CONST             (0x42)
 #define ICM42688P_WHO_AM_I_CONST            (0x47)
-#define LSM6DSV16X_WHO_AM_I_CONST           (0x71) // TODO Datasheet says this should be 0x70
+#define LSM6DSV16X_WHO_AM_I_CONST           (0x70)
 
 // RA = Register Address
 


### PR DESCRIPTION
It was noted in developing support for the STMicro [LSM6DSV16X](https://www.st.com/content/ccc/resource/technical/document/datasheet/group3/47/03/b2/44/47/32/4b/76/DM00741844/files/DM00741844.pdf/jcr:content/translations/en.DM00741844.pdf) IMU in https://github.com/betaflight/betaflight/pull/13046 that the WHO_AM_I value returned by the device on the evaluation board was 0x71, not the expected value of 0x70 from the datasheet.

Now, having received production samples the value is 0x70, matching the datasheet.