### PR TITLE
Make lookupTableThrottleLimitType an extern variable

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -375,10 +375,9 @@ static const char * const lookupOverclock[] = {
     };
 #endif
 
-static const char * const lookupTableThrottleLimitType[] = {
+const char * const lookupTableThrottleLimitType[] = {
     "OFF", "SCALE", "CLIP"
 };
-
 
 #ifdef USE_GPS_RESCUE
 static const char * const lookupTableRescueSanityType[] = {

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -270,3 +270,5 @@ extern const char * const lookupTableOffOn[];
 extern const char * const lookupTableSimplifiedTuningPidsMode[];
 
 extern const char * const lookupTableCMSMenuBackgroundType[];
+
+extern const char * const lookupTableThrottleLimitType[];

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -78,10 +78,6 @@ static uint8_t rateProfileIndex;
 static char rateProfileIndexString[MAX_RATE_PROFILE_NAME_LENGTH + PROFILE_INDEX_STRING_ADDITIONAL_SIZE];
 static controlRateConfig_t rateProfile;
 
-static const char * const osdTableThrottleLimitType[] = {
-    "OFF", "SCALE", "CLIP"
-};
-
 #ifdef USE_MULTI_GYRO
 static const char * const osdTableGyroToUse[] = {
     "FIRST", "SECOND", "BOTH"
@@ -435,7 +431,7 @@ static const OSD_Entry cmsx_menuRateProfileEntries[] =
     { "THR MID",     OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.thrMid8,           0,  100,  1} },
     { "THR EXPO",    OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.thrExpo8,          0,  100,  1} },
 
-    { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, osdTableThrottleLimitType} },
+    { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, lookupTableThrottleLimitType} },
     { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 25,  100,  1} },
 
     { "BACK", OME_Back, NULL, NULL },

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -45,6 +45,8 @@
 
 #include "sensors/battery.h"
 
+#include "cli/settings.h"
+
 #include "cms_menu_quick.h"
 
 static controlRateConfig_t rateProfile;
@@ -84,11 +86,6 @@ static const void *cmsx_RateProfileWriteback(displayPort_t *pDisp, const OSD_Ent
 
     return NULL;
 }
-
-
-static const char * const osdTableThrottleLimitType[] = {
-    "OFF", "SCALE", "CLIP"
-};
 
 static const OSD_Entry menuMainEntries[] =
 {


### PR DESCRIPTION
quick PR to prepare for the demanded OSD_SPEC prearm screen for 4.5.
It just makes it possible to use same variable lookupTableThrottleLimitType in different OSD menus and elements without defining it over and over. Saves a few bits :)