### PR TITLE
OSD spec prearm screen if defined USE_SPEC_PREARM_SCREEN

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1378,6 +1378,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_QUICK_OSD_MENU
     { "osd_use_quick_menu",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_use_quick_menu) },
 #endif // USE_QUICK_OSD_MENU
+#ifdef USE_SPEC_PREARM_SCREEN
+    { "osd_show_spec_prearm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_show_spec_prearm) },
+#endif // USE_SPEC_PREARM_SCREEN
     { "osd_tim1",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, timers[OSD_TIMER_1]) },
     { "osd_tim2",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, timers[OSD_TIMER_2]) },
 

--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -138,6 +138,14 @@ static void analogInitEndpoints(const motorConfig_t *motorConfig, float outputLi
     }
 }
 
+bool isProtocolBidirectionalDshot(const motorDevConfig_t *motorDevConfig)
+{
+    bool motorProtocolDshot = false;
+    const bool motorProtocolEnabled = checkMotorProtocolEnabled(motorDevConfig, &motorProtocolDshot);
+    const bool isBidir = motorDevConfig->useDshotTelemetry;
+    return motorProtocolEnabled && motorProtocolDshot && isBidir;
+}
+
 bool checkMotorProtocolEnabled(const motorDevConfig_t *motorDevConfig, bool *isProtocolDshot)
 {
     bool enabled = false;

--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -138,14 +138,6 @@ static void analogInitEndpoints(const motorConfig_t *motorConfig, float outputLi
     }
 }
 
-bool isProtocolBidirectionalDshot(const motorDevConfig_t *motorDevConfig)
-{
-    bool motorProtocolDshot = false;
-    const bool motorProtocolEnabled = checkMotorProtocolEnabled(motorDevConfig, &motorProtocolDshot);
-    const bool isBidir = motorDevConfig->useDshotTelemetry;
-    return motorProtocolEnabled && motorProtocolDshot && isBidir;
-}
-
 bool checkMotorProtocolEnabled(const motorDevConfig_t *motorDevConfig, bool *isProtocolDshot)
 {
     bool enabled = false;
@@ -301,6 +293,11 @@ bool isMotorProtocolEnabled(void)
 bool isMotorProtocolDshot(void)
 {
     return motorProtocolDshot;
+}
+
+bool isMotorProtocolBidirDshot(void)
+{
+    return isMotorProtocolDshot() && motorConfig()->dev.useDshotTelemetry;
 }
 
 void motorDevInit(const motorDevConfig_t *motorDevConfig, uint16_t idlePulse, uint8_t motorCount)

--- a/src/main/drivers/motor.h
+++ b/src/main/drivers/motor.h
@@ -87,6 +87,7 @@ struct motorDevConfig_s; // XXX Shouldn't be needed once pwm_output* is really c
 void motorDevInit(const struct motorDevConfig_s *motorConfig, uint16_t idlePulse, uint8_t motorCount);
 unsigned motorDeviceCount(void);
 motorVTable_t *motorGetVTable(void);
+bool isProtocolBidirectionalDshot(const motorDevConfig_t *motorDevConfig);
 bool checkMotorProtocolEnabled(const motorDevConfig_t *motorConfig, bool *protocolIsDshot);
 bool isMotorProtocolDshot(void);
 bool isMotorProtocolEnabled(void);

--- a/src/main/drivers/motor.h
+++ b/src/main/drivers/motor.h
@@ -87,9 +87,9 @@ struct motorDevConfig_s; // XXX Shouldn't be needed once pwm_output* is really c
 void motorDevInit(const struct motorDevConfig_s *motorConfig, uint16_t idlePulse, uint8_t motorCount);
 unsigned motorDeviceCount(void);
 motorVTable_t *motorGetVTable(void);
-bool isProtocolBidirectionalDshot(const motorDevConfig_t *motorDevConfig);
 bool checkMotorProtocolEnabled(const motorDevConfig_t *motorConfig, bool *protocolIsDshot);
 bool isMotorProtocolDshot(void);
+bool isMotorProtocolBidirDshot(void);
 bool isMotorProtocolEnabled(void);
 
 void motorDisable(void);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1581,7 +1581,7 @@ void osdUpdate(timeUs_t currentTimeUs)
                 break;
             }
 #ifdef USE_SPEC_PREARM_SCREEN
-                osdDrawSpec(osdDisplayPort);
+            osdDrawSpec(osdDisplayPort);
 #endif // USE_SPEC_PREARM_SCREEN
 
             osdElementGroup = 0;

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -427,6 +427,9 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 #ifdef USE_QUICK_OSD_MENU
     osdConfig->osd_use_quick_menu = true;
 #endif // USE_QUICK_OSD_MENU
+#ifdef USE_SPEC_PREARM_SCREEN
+    osdConfig->osd_show_spec_prearm = true;
+#endif // USE_SPEC_PREARM_SCREEN
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)
@@ -1577,6 +1580,11 @@ void osdUpdate(timeUs_t currentTimeUs)
                 // There are more elements to draw
                 break;
             }
+            #ifdef USE_SPEC_PREARM_SCREEN
+            else {
+                osdDrawSpec(osdDisplayPort);
+            }
+            #endif // USE_SPEC_PREARM_SCREEN
 
             osdElementGroup = 0;
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1580,11 +1580,9 @@ void osdUpdate(timeUs_t currentTimeUs)
                 // There are more elements to draw
                 break;
             }
-            #ifdef USE_SPEC_PREARM_SCREEN
-            else {
+#ifdef USE_SPEC_PREARM_SCREEN
                 osdDrawSpec(osdDisplayPort);
-            }
-            #endif // USE_SPEC_PREARM_SCREEN
+#endif // USE_SPEC_PREARM_SCREEN
 
             osdElementGroup = 0;
 

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -351,6 +351,9 @@ typedef struct osdConfig_s {
     #ifdef USE_QUICK_OSD_MENU
     uint8_t osd_use_quick_menu;               // use QUICK menu YES/NO
     #endif // USE_QUICK_OSD_MENU
+    #ifdef USE_SPEC_PREARM_SCREEN
+    uint8_t osd_show_spec_prearm;
+    #endif // USE_SPEC_PREARM_SCREEN
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -340,20 +340,20 @@ typedef struct osdConfig_s {
     uint16_t framerate_hz;
     uint8_t cms_background_type;              // For supporting devices, determines whether the CMS background is transparent or opaque
     uint8_t stat_show_cell_value;
-    #ifdef USE_CRAFTNAME_MSGS
+#ifdef USE_CRAFTNAME_MSGS
     uint8_t osd_craftname_msgs;               // Insert LQ/RSSI-dBm and warnings into CraftName
-    #endif //USE_CRAFTNAME_MSGS
+#endif //USE_CRAFTNAME_MSGS
     uint8_t aux_channel;
     uint16_t aux_scale;
     uint8_t aux_symbol;
     uint8_t canvas_cols;                      // Canvas dimensions for HD display
     uint8_t canvas_rows;
-    #ifdef USE_QUICK_OSD_MENU
+#ifdef USE_QUICK_OSD_MENU
     uint8_t osd_use_quick_menu;               // use QUICK menu YES/NO
-    #endif // USE_QUICK_OSD_MENU
-    #ifdef USE_SPEC_PREARM_SCREEN
+#endif // USE_QUICK_OSD_MENU
+#ifdef USE_SPEC_PREARM_SCREEN
     uint8_t osd_show_spec_prearm;
-    #endif // USE_SPEC_PREARM_SCREEN
+#endif // USE_SPEC_PREARM_SCREEN
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -2122,10 +2122,8 @@ void osdDrawSpec(displayPort_t *osdDisplayPort)
         int len = 0;
         int currentRow = midRow - 3;
 
-        bool rpmLimitActive = false;
-
 #ifdef USE_RPM_LIMIT
-        rpmLimitActive = mixerConfig()->rpm_limit > 0 && isMotorProtocolBidirDshot();
+        const bool rpmLimitActive = mixerConfig()->rpm_limit > 0 && isMotorProtocolBidirDshot();
         if (rpmLimitActive) {
             len = tfp_sprintf(buff, "RPM LIMIT ON  %d", mixerConfig()->rpm_limit_value);
         } else {
@@ -2141,10 +2139,9 @@ void osdDrawSpec(displayPort_t *osdDisplayPort)
             memset(buff,0,strlen(buff));
             len = tfp_sprintf(buff, "%d  %d  %d", mixerConfig()->rpm_limit_p, mixerConfig()->rpm_limit_i, mixerConfig()->rpm_limit_d);
             displayWrite(osdDisplayPort, midCol - len/2, currentRow++, DISPLAYPORT_SEVERITY_NORMAL, buff);
-        }
+        } else
 #endif // #USE_RPM_LIMIT
-
-        if (!rpmLimitActive) {
+        {
             memset(buff,0,strlen(buff));
             len = tfp_sprintf(buff, "THR LIMIT %s", lookupTableThrottleLimitType[currentControlRateProfile->throttle_limit_type]);
             if (currentControlRateProfile->throttle_limit_type != THROTTLE_LIMIT_TYPE_OFF) {

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -2112,8 +2112,7 @@ bool osdDrawNextActiveElement(displayPort_t *osdDisplayPort, timeUs_t currentTim
 #ifdef USE_SPEC_PREARM_SCREEN
 void osdDrawSpec(displayPort_t *osdDisplayPort)
 {
-    if (!ARMING_FLAG(ARMED) && osdConfig()->osd_show_spec_prearm)
-    {
+    if (!ARMING_FLAG(ARMED) && osdConfig()->osd_show_spec_prearm) {
         const uint8_t midRow = osdDisplayPort->rows / 2;
         const uint8_t midCol = osdDisplayPort->cols / 2;
 
@@ -2126,7 +2125,7 @@ void osdDrawSpec(displayPort_t *osdDisplayPort)
         bool rpmLimitActive = false;
 
 #ifdef USE_RPM_LIMIT
-        rpmLimitActive = mixerConfig()->rpm_limit > 0 && isProtocolBidirectionalDshot(&motorConfig()->dev);
+        rpmLimitActive = mixerConfig()->rpm_limit > 0 && isMotorProtocolBidirDshot();
         if (rpmLimitActive) {
             len = tfp_sprintf(buff, "RPM LIMIT ON  %d", mixerConfig()->rpm_limit_value);
         } else {

--- a/src/main/osd/osd_elements.h
+++ b/src/main/osd/osd_elements.h
@@ -64,3 +64,6 @@ void osdSyncBlink();
 void osdResetAlarms(void);
 void osdUpdateAlarms(void);
 bool osdElementsNeedAccelerometer(void);
+#ifdef USE_SPEC_PREARM_SCREEN
+void osdDrawSpec(displayPort_t *osdDisplayPort);
+#endif // USE_SPEC_PREARM_SCREEN


### PR DESCRIPTION
Briefly discussed in discord, that we can sneak it in 4.5.

This helps with testing
Useful for racers.
And for controlling the racing spec if any are required at the race.
Define USE_SPEC_PREARM_SCREEN
or use `SPEC_PREARM_SCREEN` in Configurator
then in CLI
`set osd_show_spec_prearm = ON/OFF` (ON by default)
![image](https://github.com/betaflight/betaflight/assets/2925027/2c998a86-6d13-4a2f-94e9-afc889b6cea4)
