### PR TITLE
Changed some defaults for RACE_PRO

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -527,7 +527,7 @@ if (systemConfig()->configurationState == CONFIGURATION_STATE_DEFAULTS_BARE) {
 
 #ifdef USE_DSHOT
     if (beeperConfig()->dshotBeaconOffFlags & ~DSHOT_BEACON_ALLOWED_MODES) {
-        beeperConfigMutable()->dshotBeaconOffFlags = 0;
+        beeperConfigMutable()->dshotBeaconOffFlags = DEFAULT_DSHOT_BEACON_OFF_FLAGS;
     }
 
     if (beeperConfig()->dshotBeaconTone < DSHOT_CMD_BEACON1

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -62,6 +62,12 @@ static failsafeState_t failsafeState;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 2);
 
+#ifdef USE_RACE_PRO
+    #define DEFAULT_FAILSAFE_RECOVERY_DELAY 1            // 100ms of valid rx data needed to allow recovery from failsafe and arming block
+#else
+    #define DEFAULT_FAILSAFE_RECOVERY_DELAY 5            // 500ms of valid rx data needed to allow recovery from failsafe and arming block
+#endif
+
 PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_throttle = 1000,                           // default throttle off.
     .failsafe_throttle_low_delay = 100,                  // default throttle low delay for "just disarm" on failsafe condition
@@ -69,7 +75,7 @@ PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_off_delay = 10,                            // 1 sec in landing phase, if enabled
     .failsafe_switch_mode = FAILSAFE_SWITCH_MODE_STAGE1, // default failsafe switch action is identical to rc link loss
     .failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT,    // default full failsafe procedure is 0: auto-landing
-    .failsafe_recovery_delay = 5,                        // 500ms of valid rx data needed to allow recovery from failsafe and arming block
+    .failsafe_recovery_delay = DEFAULT_FAILSAFE_RECOVERY_DELAY,
     .failsafe_stick_threshold = 30                       // 30 percent of stick deflection to exit GPS Rescue procedure
 );
 

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -63,9 +63,9 @@ static failsafeState_t failsafeState;
 PG_REGISTER_WITH_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 2);
 
 #ifdef USE_RACE_PRO
-    #define DEFAULT_FAILSAFE_RECOVERY_DELAY 1            // 100ms of valid rx data needed to allow recovery from failsafe and arming block
+#define DEFAULT_FAILSAFE_RECOVERY_DELAY 1            // 100ms of valid rx data needed to allow recovery from failsafe and arming block
 #else
-    #define DEFAULT_FAILSAFE_RECOVERY_DELAY 5            // 500ms of valid rx data needed to allow recovery from failsafe and arming block
+#define DEFAULT_FAILSAFE_RECOVERY_DELAY 5            // 500ms of valid rx data needed to allow recovery from failsafe and arming block
 #endif
 
 PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -118,10 +118,16 @@ attitudeEulerAngles_t attitude = EULER_INITIALIZE;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 3);
 
+#ifdef USE_RACE_PRO
+    #define DEFAULT_SMALL_ANGLE 180
+#else
+    #define DEFAULT_SMALL_ANGLE 25
+#endif
+
 PG_RESET_TEMPLATE(imuConfig_t, imuConfig,
     .imu_dcm_kp = 2500,      // 1.0 * 10000
     .imu_dcm_ki = 0,         // 0.003 * 10000
-    .small_angle = 25,
+    .small_angle = DEFAULT_SMALL_ANGLE,
     .imu_process_denom = 2,
     .mag_declination = 0
 );

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -119,9 +119,9 @@ attitudeEulerAngles_t attitude = EULER_INITIALIZE;
 PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 3);
 
 #ifdef USE_RACE_PRO
-    #define DEFAULT_SMALL_ANGLE 180
+#define DEFAULT_SMALL_ANGLE 180
 #else
-    #define DEFAULT_SMALL_ANGLE 25
+#define DEFAULT_SMALL_ANGLE 25
 #endif
 
 PG_RESET_TEMPLATE(imuConfig_t, imuConfig,

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -96,6 +96,12 @@ typedef enum {
     BEEPER_GET_FLAG(BEEPER_RX_LOST) \
     | BEEPER_GET_FLAG(BEEPER_RX_SET) )
 
+#ifdef USE_RACE_PRO
+#define DEFAULT_DSHOT_BEACON_OFF_FLAGS BEEPER_GET_FLAG(BEEPER_RX_LOST)
+#else
+#define DEFAULT_DSHOT_BEACON_OFF_FLAGS DSHOT_BEACON_ALLOWED_MODES
+#endif // USE_RACE_PRO
+
 void beeper(beeperMode_e mode);
 void beeperSilence(void);
 void beeperUpdate(timeUs_t currentTimeUs);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -332,17 +332,23 @@ const uint16_t osdTimerDefault[OSD_TIMER_COUNT] = {
         OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10)
 };
 
+#ifdef USE_RACE_PRO
+    #define RACE_PRO true
+#else
+    #define RACE_PRO false
+#endif
+
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 {
     // Enable the default stats
     osdConfig->enabled_stats = 0; // reset all to off and enable only a few initially
-    osdStatSetState(OSD_STAT_MAX_SPEED, true);
+    osdStatSetState(OSD_STAT_MAX_SPEED, !RACE_PRO);
     osdStatSetState(OSD_STAT_MIN_BATTERY, true);
-    osdStatSetState(OSD_STAT_MIN_RSSI, true);
-    osdStatSetState(OSD_STAT_MAX_CURRENT, true);
-    osdStatSetState(OSD_STAT_USED_MAH, true);
-    osdStatSetState(OSD_STAT_BLACKBOX, true);
-    osdStatSetState(OSD_STAT_BLACKBOX_NUMBER, true);
+    osdStatSetState(OSD_STAT_MIN_RSSI, !RACE_PRO);
+    osdStatSetState(OSD_STAT_MAX_CURRENT, !RACE_PRO);
+    osdStatSetState(OSD_STAT_USED_MAH, !RACE_PRO);
+    osdStatSetState(OSD_STAT_BLACKBOX, !RACE_PRO);
+    osdStatSetState(OSD_STAT_BLACKBOX_NUMBER, !RACE_PRO);
     osdStatSetState(OSD_STAT_TIMER_2, true);
 
     osdConfig->units = UNIT_METRIC;

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -333,9 +333,9 @@ const uint16_t osdTimerDefault[OSD_TIMER_COUNT] = {
 };
 
 #ifdef USE_RACE_PRO
-    #define RACE_PRO true
+#define RACE_PRO true
 #else
-    #define RACE_PRO false
+#define RACE_PRO false
 #endif
 
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)

--- a/src/main/pg/beeper.c
+++ b/src/main/pg/beeper.c
@@ -33,6 +33,6 @@ PG_REGISTER_WITH_RESET_TEMPLATE(beeperConfig_t, beeperConfig, PG_BEEPER_CONFIG, 
 
 PG_RESET_TEMPLATE(beeperConfig_t, beeperConfig,
     .dshotBeaconTone = 1,
-    .dshotBeaconOffFlags = DSHOT_BEACON_ALLOWED_MODES,
+    .dshotBeaconOffFlags = DEFAULT_DSHOT_BEACON_OFF_FLAGS,
 );
 #endif


### PR DESCRIPTION
For discussion
Following this PR:
https://github.com/betaflight/betaflight/pull/13212

Changed some defaults for when `RACE_PRO` build option is selected.
This can raise some safety concerns, but racers do this all the time anyway.

small_angle = 180 (arming at any angle by default instead of 25)
failsafe_recovery_delay = 1 (100ms instead of 500ms for faster arming for team racing scenarios)
Dshot beeper when aux set for beeper - ON (instead of OFF)
Hide OSD stats for:
OSD_STAT_MAX_SPEED,
OSD_STAT_MIN_RSSI,
OSD_STAT_MAX_CURRENT,
OSD_STAT_USED_MAH,
OSD_STAT_BLACKBOX,
OSD_STAT_BLACKBOX_NUMBER

