### PR TITLE
Break LED_STRIP update into 20us chunks

### DIFF
--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -42,6 +42,9 @@
 
 #include "drivers/dma.h"
 #include "drivers/io.h"
+#include "drivers/time.h"
+
+#include "io/ledstrip.h"
 
 #include "light_ws2811strip.h"
 
@@ -136,10 +139,12 @@ void ws2811LedStripEnable(void)
 
         const hsvColor_t hsv_black = { 0, 0, 0 };
         setStripColor(&hsv_black);
-        // RGB or GRB ordering doesn't matter for black, use 4-channel LED configuraton to make sure all channels are zero
-        ws2811UpdateStrip(LED_GRBW, 100);
 
         ws2811Initialised = true;
+
+        // RGB or GRB ordering doesn't matter for black, use 4-channel LED configuraton to make sure all channels are zero
+        // Multiple calls may be required as normally broken into multiple parts
+        while (!ws2811UpdateStrip(LED_GRBW, 100));
     }
 }
 
@@ -185,15 +190,16 @@ STATIC_UNIT_TESTED void updateLEDDMABuffer(ledStripFormatRGB_e ledFormat, rgbCol
  * This method is non-blocking unless an existing LED update is in progress.
  * it does not wait until all the LEDs have been updated, that happens in the background.
  */
-void ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness)
+bool ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness)
 {
+    static uint8_t ledIndex = 0;
+    timeUs_t startTime = micros();
     // don't wait - risk of infinite block, just get an update next time round
     if (!ws2811Initialised || ws2811LedDataTransferInProgress) {
         schedulerIgnoreTaskStateTime();
-        return;
+        return false;
     }
 
-    unsigned ledIndex = 0;              // reset led index
 
     // fill transmit buffer with correct compare values to achieve
     // correct pulse widths according to color values
@@ -207,7 +213,12 @@ void ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness)
         rgbColor24bpp_t *rgb24 = hsvToRgb24(&scaledLed);
 
         updateLEDDMABuffer(ledFormat, rgb24, ledIndex++);
+
+        if (cmpTimeUs(micros(), startTime) > LED_TARGET_UPDATE_US) {
+            return false;
+        }
     }
+    ledIndex = 0;
     needsFullRefresh = false;
 
 #ifdef USE_LED_STRIP_CACHE_MGMT
@@ -216,6 +227,8 @@ void ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness)
 
     ws2811LedDataTransferInProgress = true;
     ws2811LedStripDMAEnable();
+
+    return true;
 }
 
 #endif

--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -70,7 +70,7 @@ void ws2811LedStripEnable(void);
 bool ws2811LedStripHardwareInit(ioTag_t ioTag);
 void ws2811LedStripDMAEnable(void);
 
-void ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness);
+bool ws2811UpdateStrip(ledStripFormatRGB_e ledFormat, uint8_t brightness);
 
 void setLedHsv(uint16_t index, const hsvColor_t *color);
 void getLedHsv(uint16_t index, hsvColor_t *color);

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -71,6 +71,8 @@
 #define LED_XY_MASK      0x0F
 #define CALCULATE_LED_XY(x, y) ((((x) & LED_XY_MASK) << LED_X_BIT_OFFSET) | (((y) & LED_XY_MASK) << LED_Y_BIT_OFFSET))
 
+#define LED_TARGET_UPDATE_US 20
+
 typedef enum {
     COLOR_BLACK = 0,
     COLOR_WHITE,

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -50,6 +50,8 @@ extern "C" {
 
     #include "sensors/battery.h"
 
+    #include "scheduler/scheduler.h"
+
     #include "target.h"
 }
 
@@ -314,7 +316,7 @@ void ws2811LedStripInit(ioTag_t ioTag)
     UNUSED(ioTag);
 }
 
-void ws2811UpdateStrip(ledStripFormatRGB_e, uint8_t) {}
+bool ws2811UpdateStrip(ledStripFormatRGB_e, uint8_t) {return true;}
 
 void setLedValue(uint16_t index, const uint8_t value)
 {
@@ -406,7 +408,9 @@ void ws2811LedStripEnable(void) { }
 
 void setUsedLedCount(unsigned) { }
 void pinioBoxTaskControl(void) {}
+void rescheduleTask(taskId_e, timeDelta_t){}
 void schedulerIgnoreTaskExecTime(void) {}
+void schedulerIgnoreTaskExecRate(void) {}
 bool schedulerGetIgnoreTaskExecTime() { return false; }
 void schedulerSetNextStateTime(timeDelta_t) {}
 }

--- a/src/test/unit/ws2811_unittest.cc
+++ b/src/test/unit/ws2811_unittest.cc
@@ -31,6 +31,8 @@ extern "C" {
 #include "gtest/gtest.h"
 
 extern "C" {
+    uint32_t simulatedTime = 0;
+    uint32_t micros(void) { return simulatedTime; }
     void updateLEDDMABuffer(ledStripFormatRGB_e ledFormat, rgbColor24bpp_t *color, unsigned ledIndex);
     void schedulerIgnoreTaskExecTime(void) {}
     void schedulerIgnoreTaskStateTime(void) {}


### PR DESCRIPTION
The LED_STRIP task had become very ill behaved and often took over 150us to execute `ledStripUpdate()` as per the below. This is worse on slow processors; below a G4.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       1       0    0.0%    0.0%         0      0     16       5
01 - (         SYSTEM)    993      10       1    0.9%    0.0%        24      3   1610       1
02 - (           GYRO)   7937      21       8   16.6%    6.4%      1261      0  12930       0
03 - (         FILTER)   3939      42      28   16.5%   11.0%      4380      0   6465       0
04 - (            PID)   3932      99      78   38.9%   30.7%     12175      0   6465       0
05 - (            ACC)    992       9       3    0.8%    0.3%       133      1   1608       4
06 - (       ATTITUDE)    100      16       9    0.1%    0.0%        36      1    162      15
07 - (             RX)     10      21      14    0.0%    0.0%        17      0     48      21
08 - (         SERIAL)     99    7137       1   70.6%    0.0%       731      0    161      39
09 - (       DISPATCH)    998       6       0    0.5%    0.0%        27      2   1611       3
10 - (BATTERY_VOLTAGE)     50       3       2    0.0%    0.0%         3      0     81       3
11 - (BATTERY_CURRENT)     50       2       0    0.0%    0.0%         1      0     81       2
12 - ( BATTERY_ALERTS)      5       2       1    0.0%    0.0%         0      0      8       6
13 - (         BEEPER)     99       1       0    0.0%    0.0%         3      0    161       3
16 - (           BARO)     20      27       5    0.0%    0.0%        33      0    192       6
17 - (       ALTITUDE)     99       4       2    0.0%    0.0%         9      0    161       3
18 - (      TELEMETRY)    498       2       0    0.0%    0.0%        15      0    803       1
19 - (       LEDSTRIP)     51     152     144    0.7%    0.7%       102     74     77     143
20 - (            OSD)     12      15       5    0.0%    0.0%        26      0    209      10
22 - (            CMS)     20       3       1    0.0%    0.0%         1      0     33       4
23 - (        VTXCTRL)      5       1       0    0.0%    0.0%         0      0      8       1
24 - (        CAMCTRL)      5       1       0    0.0%    0.0%         0      0      8       5
26 - (    ADCINTERNAL)      1       2       1    0.0%    0.0%         0      0      2       1
```

This PR breaks down the task into a number of parts targeting 20us resulting in the following.

```
# tasks
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
00 - (         SYSTEM)     10       2       0    0.0%    0.0%         0      0     19       5
01 - (         SYSTEM)    994       7       0    0.6%    0.0%        46      5   1944       6
02 - (           GYRO)   7987      14       3   11.1%    2.7%      1934      0  15576       0
03 - (         FILTER)   3992      38      28   15.1%   11.2%      7821      0   7788       0
04 - (            PID)   3992     105      78   41.9%   31.1%     21568      0   7788       0
05 - (            ACC)    997      12       3    1.1%    0.3%       247      3   1943       9
06 - (       ATTITUDE)    100      15       8    0.1%    0.0%        61      0    195      13
07 - (             RX)     10      21      16    0.0%    0.0%        32      0     60      20
08 - (         SERIAL)    100    4115       1   41.1%    0.0%       700      0    194      38
09 - (       DISPATCH)    997       7       2    0.6%    0.2%        45      1   1945       5
10 - (BATTERY_VOLTAGE)     50       4       2    0.0%    0.0%         6      0     98       7
11 - (BATTERY_CURRENT)     50       1       0    0.0%    0.0%         2      0     98       0
12 - ( BATTERY_ALERTS)      5       2       1    0.0%    0.0%         0      0      9       8
13 - (         BEEPER)    100       1       0    0.0%    0.0%         4      0    194       1
14 - (           BARO)     20      27       5    0.0%    0.0%        60      0    234       6
15 - (       ALTITUDE)    100       3       2    0.0%    0.0%        14      1    194       2
16 - (      TELEMETRY)    250       2       0    0.0%    0.0%        10      0    486       0
17 - (       LEDSTRIP)    100      34      21    0.3%    0.2%       901      0   1165      32
18 - (            OSD)     12      20       5    0.0%    0.0%        47      0    264      10
20 - (            CMS)     20       5       1    0.0%    0.0%         2      0     39       7
21 - (        VTXCTRL)      5       1       0    0.0%    0.0%         0      0      9       5
22 - (        CAMCTRL)      5       1       0    0.0%    0.0%         0      0      9       6
24 - (    ADCINTERNAL)      1       1       1    0.0%    0.0%         0      0      2       8
```

@sugaarK Please test to see if this fixes your jitter issues.