### PR TITLE
Remove ESCSERIAL from F7X2 targets

### DIFF
--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -70,8 +70,6 @@
 
 #define USE_USB_DETECT
 
-#define USE_ESCSERIAL
-
 #define USE_ADC
 
 #define USE_EXTI


### PR DESCRIPTION
Fixes #13220
Reverts #13078

According to comment in #12992 escserial does not work on F7 targets.

Think we need to remove USE_ESCSERIAL define from the F7 target for now.