### PR TITLE
at32: add mux 3 for tmr9 on port c

### DIFF
--- a/src/main/drivers/at32/timer_at32f43x.c
+++ b/src/main/drivers/at32/timer_at32f43x.c
@@ -116,6 +116,8 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TMR5,  CH3,  PC11, 0, 0,  0),
 
 // PORTC MUX 3
+    DEF_TIM(TMR9,  CH1,  PC4,  0, 0,  0),
+    DEF_TIM(TMR9,  CH2,  PC5,  0, 0,  0),
     DEF_TIM(TMR8,  CH1,  PC6,  0, 0,  0),
     DEF_TIM(TMR8,  CH2,  PC7,  0, 0,  0),
     DEF_TIM(TMR8,  CH3,  PC8,  0, 0,  0),

--- a/src/main/drivers/at32/timer_def.h
+++ b/src/main/drivers/at32/timer_def.h
@@ -26,7 +26,7 @@
 
 #define USED_TIMERS  ( BIT(1) | BIT(2) | BIT(3) | BIT(4) | BIT(5) | BIT(8) | BIT(9) | BIT(10) | BIT(11) | BIT(12) | BIT(13) | BIT(14) | BIT(20) )
 #define TIMUP_TIMERS ( BIT(1) | BIT(2) | BIT(3) | BIT(4) | BIT(5) | BIT(8) | BIT(20) )
-#define FULL_TIMER_CHANNEL_COUNT        101
+#define FULL_TIMER_CHANNEL_COUNT        103
 #define HARDWARE_TIMER_DEFINITION_COUNT 15
 
 // allow conditional definition of DMA related members


### PR DESCRIPTION
adds muxes for timer 9 on port c, appears they have slipped the cracks in #12548
do note that these pins can only be used for [non-dma applications like servo output](https://github.com/betaflight/betaflight/pull/12548#issuecomment-1837296759)