### PR TITLE
bugfix compassBiasEstimatorInit initialisation

### DIFF
--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -385,6 +385,8 @@ bool compassInit(void)
 
     buildRotationMatrixFromAlignment(&compassConfig()->mag_customAlignment, &magDev.rotationMatrix);
 
+    compassBiasEstimatorInit(&compassBiasEstimator, LAMBDA_MIN, P0);
+
     if (magDev.magOdrHz) {
         // For Mags that send data at a fixed ODR, we wait some quiet period after a read before checking for new data
         // allow two re-check intervals, plus a margin for clock variations in mag vs FC


### PR DESCRIPTION
Bug fix PR to restore the ability to calibrate the Mag.

In https://github.com/betaflight/betaflight/pull/13166 the line initialising the calibration estimator values during compass initialisation was accidentally deleted.  By me.

This PR restores that line, and now we can calibrate Mag again.

Stupid mistake, my apologies.  Thanks to aowi7280 on Discord for finding the bug!

This is what got removed, unintentionally: 
![Screen Shot 2023-12-14 at 13 53 27](https://github.com/betaflight/betaflight/assets/11737748/abefa0de-4839-4a13-8b73-fbb7ef7b720c)
