### PR TITLE
Fix error in I2C write operation on AT32

### DIFF
--- a/lib/main/AT32F43x/middlewares/i2c_application_library/i2c_application.c
+++ b/lib/main/AT32F43x/middlewares/i2c_application_library/i2c_application.c
@@ -23,7 +23,6 @@
   */
 
 #include "i2c_application.h"
-#include "drivers/pinio.h"
 
 /** @addtogroup AT32F435_437_middlewares_i2c_application_library
   * @{
@@ -1071,7 +1070,7 @@ i2c_status_type i2c_memory_write(i2c_handle_type* hi2c, i2c_mem_address_width_ty
   hi2c->mode   = I2C_MA_TX;
 
   // Initialise the data buffer
-  i2c_set_buffer(hi2c, I2C_STEP_DATA, pdata, size);
+  i2c_set_buffer(hi2c, I2C_STEP_DATA, pdata, size + mem_address_width);
 
   hi2c->error_code = I2C_OK;
 


### PR DESCRIPTION
Fix for bug introduced in https://github.com/betaflight/betaflight/pull/13171 which shortened the number of bytes written in a blocking I2C write. Didn't show up with the devices on the REVO_AT used for development, but broke the DPS310 baro. 