### PR TITLE
Add gyro jitter analysis to DEBUG_SCHEDULER_DETERMINISM

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -175,6 +175,12 @@ int32_t clockCyclesTo10thMicros(int32_t clockCycles)
     return 10 * clockCycles / (int32_t)usTicks;
 }
 
+// Note that this conversion is signed as this is used for periods rather than absolute timestamps
+int32_t clockCyclesTo100thMicros(int32_t clockCycles)
+{
+    return 100 * clockCycles / (int32_t)usTicks;
+}
+
 uint32_t clockMicrosToCycles(uint32_t micros)
 {
     return micros * usTicks;

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -68,6 +68,7 @@ void cycleCounterInit(void);
 int32_t clockCyclesToMicros(int32_t clockCycles);
 float clockCyclesToMicrosf(int32_t clockCycles);
 int32_t clockCyclesTo10thMicros(int32_t clockCycles);
+int32_t clockCyclesTo100thMicros(int32_t clockCycles);
 uint32_t clockMicrosToCycles(uint32_t micros);
 uint32_t getCycleCounter(void);
 #if defined(STM32H7) || defined(STM32G4)

--- a/src/main/target/SITL/sitl.c
+++ b/src/main/target/SITL/sitl.c
@@ -437,6 +437,11 @@ int32_t clockCyclesTo10thMicros(int32_t clockCycles)
     return clockCycles;
 }
 
+int32_t clockCyclesTo100thMicros(int32_t clockCycles)
+{
+    return clockCycles;
+}
+
 uint32_t clockMicrosToCycles(uint32_t micros)
 {
     return micros;

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -76,6 +76,7 @@ extern "C" {
     uint32_t millis(void) { return simulatedTime/1000; } // Note simplistic mapping suitable only for short unit tests
     int32_t clockCyclesToMicros(int32_t x) { return x/10;}
     int32_t clockCyclesTo10thMicros(int32_t x) { return x;}
+    int32_t clockCyclesTo100thMicros(int32_t x) { return x;}
     uint32_t clockMicrosToCycles(uint32_t x) { return x*10;}
     uint32_t getCycleCounter(void) {return simulatedTime * 10;}
 


### PR DESCRIPTION
It has been observed that some FC's get a very solid lock of the scheduler loop to the gyro rate, whilst others do not. This PR adds debug to help assess this and deal with software issues, or possible underlying hardware issue; most likely poor power supply regulation.

On a good FC the scheduler remains locked to the gyro within a few tenths of a microsecond, in this case over a 0.2us range.

![image](https://github.com/betaflight/betaflight/assets/11480839/19fa0df7-1b7f-424e-846a-eb9dfd8002ee)

On a bad FC the lock is much poorer, in this case wandering over a 5us range.

![image](https://github.com/betaflight/betaflight/assets/11480839/f655974e-e6c1-4160-a455-d550be98139b)

This is important as it impacts the accuracy of the timing of the filtering by introducing jitter, and it also reduces the efficiency of the scheduler.

This PR adds items 4, 5 and 6 to the `DEBUG_SCHEDULER_DETERMINISM` debug mode. These values are recorded over the 500 gyro cycle period used to determine the correct scheduler rate in order to bring it into lock. They are measured in 100th of a us and are recorded .

DEBUG_SCHEDULER_DETERMINISM
0 - Gyro task start cycle time in 10th of a us
1 - ID of late task
2 - Amount task is late in 10th of a us
3 - Gyro lock skew in 10th of a us
4 - Minimum Gyro period in 100th of a us
5 - Maximum Gyro period in 100th of a us
6 - Span of Gyro period in 100th of a us

The cause of the poor lock can then be seen. From the good FC we get, showing a peak of 1.5us variation between min/max gyro period.

![image](https://github.com/betaflight/betaflight/assets/11480839/105f77c1-90bd-45da-b566-1cf452249001)

And on the bad FC we get up to 10us of variation between min and max gyro interrupt period.

![image](https://github.com/betaflight/betaflight/assets/11480839/4c239824-ba4c-4fe7-af44-b2a4c0dac7be)
