### PR TITLE
Update hardware specification link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This fork differs from Baseflight and Cleanflight in that it focuses on flight p
 
 The following new requirements for pull requests adding new targets or modifying existing targets are put in place from now on:
 
-1. Read the [hardware specification](https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines)
+1. Read the [hardware specification](https://betaflight.com/docs/development/manufacturer/manufacturer-design-guidelines)
 
 2. No new F3 based targets will be accepted;
 


### PR DESCRIPTION
In the README.md file's News section, the hardware specification link is not working. The link is corrected.