### PR TITLE
Fix dma pin <io> list

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5334,7 +5334,7 @@ dmaoptEntry_t dmaoptEntryTable[] = {
 #define DMA_OPT_UI_INDEX(i) ((i) + 1)
 #define DMA_OPT_STRING_BUFSIZE 5
 
-#if defined(STM32H7) || defined(STM32G4)
+#if defined(STM32H7) || defined(STM32G4) || defined(AT32F435)
 #define DMA_CHANREQ_STRING "Request"
 #else
 #define DMA_CHANREQ_STRING "Channel"

--- a/src/main/drivers/at32/dma_reqmap_mcu.c
+++ b/src/main/drivers/at32/dma_reqmap_mcu.c
@@ -169,7 +169,7 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
 #undef TC
 #undef REQMAP_TIM
 
-#define DMA(d, c) { DMA_CODE(d, 0, c), (dmaResource_t *) DMA ## d ## _CHANNEL ## c , 0 }
+#define DMA(d, c) { DMA_CODE(d, c, 0), (dmaResource_t *) DMA ## d ## _CHANNEL ## c , 0 }
 
 static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
     DMA(1, 1),
@@ -232,7 +232,7 @@ dmaoptValue_t dmaoptByTag(ioTag_t ioTag)
 
 const dmaChannelSpec_t *dmaGetChannelSpecByTimerValue(TIM_TypeDef *tim, uint8_t channel, dmaoptValue_t dmaopt)
 {
-    if (dmaopt < 0 || dmaopt >= MAX_TIMER_DMA_OPTIONS) {
+    if (dmaopt < 0 || dmaopt >= MAX_PERIPHERAL_DMA_OPTIONS) {
         return NULL;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/13138

This also fixes the DMA channel/request naming for AT32.