### PR TITLE
Add hardware LPF1 options for lsm6dsv16x gyro

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -411,6 +411,10 @@ static void validateAndFixConfig(void)
 #endif
 #endif // USE_ADC
 
+    // Bounds check gyro filter selection in case prior build had USE_GYRO_DLPF_EXPERIMENTAL defined
+    if (gyroConfig()->gyro_hardware_lpf >= GYRO_HARDWARE_LPF_COUNT) {
+        gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
+    }
 
 // clear features that are not supported.
 // I have kept them all here in one place, some could be moved to sections of code above.


### PR DESCRIPTION
The [LSM6DSV16X datasheet](https://www.st.com/resource/en/datasheet/lsm6dsv16x.pdf) isn't very clear on the hardware lowpass filter options when operating in High Accuracy ODR (HAODDR) mode.

We use `HAODR_SEL_[1:0]` set to `01` and `ODR_G_[3:0]` set to `1100` to select an 8kHz output rate. The following states that we can use the LPF1 filter.

![image](https://github.com/betaflight/betaflight/assets/11480839/acbf28fa-0fe0-4b31-a738-47f83558797c)

The available LPF1 filter setting options are described thus, but note that no details are given for the 8kHz operation.

![image](https://github.com/betaflight/betaflight/assets/11480839/3d0c4b60-aefa-4c1a-81e0-e06f40dcecaa)

This PR allows the four highest LPF1 bandwidths to be selected using the `gyro_hardware_lpf` setting. Were the bandwidths to be the same as for 7.68kHz operation, the values would be as shown below, but they are not actually known.

| gyro_hardware_lpf | Bandwidth (Hz) |
| - | - |
| NORMAL | 407|
| OPTION_1 | 281 |
| OPTION_2 | 213 |
| EXPERIMENTAL | 156 |

New default values may be selected as a result of flight testing.