### PR TITLE
Fix builds when PWM motor protocol is used

### DIFF
--- a/src/main/pg/motor.c
+++ b/src/main/pg/motor.c
@@ -61,6 +61,9 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
     motorConfig->minthrottle = 1070;
     motorConfig->dev.motorPwmRate = BRUSHLESS_MOTORS_PWM_RATE;
 #ifndef USE_DSHOT
+    // if (motorConfig->dev.motorPwmProtocol == PWM_TYPE_STANDARD) {
+    //     motorConfig->dev.useUnsyncedPwm = true;
+    // }
     motorConfig->dev.motorPwmProtocol = PWM_TYPE_DISABLED;
 #elif defined(DEFAULT_MOTOR_DSHOT_SPEED)
     motorConfig->dev.motorPwmProtocol = DEFAULT_MOTOR_DSHOT_SPEED;

--- a/src/main/target/AT32F435G/target.h
+++ b/src/main/target/AT32F435G/target.h
@@ -75,8 +75,6 @@
 
 #define USE_ADC
 
-#define USE_PWM_OUTPUT
-
 // Remove these undefines as support is added
 //#undef USE_BEEPER
 //#undef USE_LED_STRIP

--- a/src/main/target/AT32F435M/target.h
+++ b/src/main/target/AT32F435M/target.h
@@ -75,8 +75,6 @@
 
 #define USE_ADC
 
-#define USE_PWM_OUTPUT
-
 // Remove these undefines as support is added
 //#undef USE_BEEPER
 //#undef USE_LED_STRIP

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -99,7 +99,9 @@
 
 #define USE_PARAMETER_GROUPS
 
+#ifndef USE_PWM_OUTPUT
 #define USE_PWM_OUTPUT
+#endif
 
 #undef USE_STACK_CHECK // I think SITL don't need this
 #undef USE_DASHBOARD


### PR DESCRIPTION
- Remove `USE_PWM_OUTPUT` from targets (except SITL)
- Corrects usage in https://github.com/betaflight/betaflight/pull/12220
- Log: https://build.betaflight.com/api/builds/bf80c6e5414d05db3062e37f84452999/log