### PR TITLE
Fix BMI160 gate and optimize directives

### DIFF
--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -37,21 +37,63 @@
 #include "config/feature.h"
 
 #include "drivers/accgyro/accgyro.h"
-#include "drivers/accgyro/accgyro_virtual.h"
 #include "drivers/accgyro/accgyro_mpu.h"
+
+#ifdef USE_VIRTUAL_ACC
+#include "drivers/accgyro/accgyro_virtual.h"
+#endif
+
+#ifdef USE_ACC_MPU3050
 #include "drivers/accgyro/accgyro_mpu3050.h"
+#endif
+
+#ifdef USE_ACC_MPU6050
 #include "drivers/accgyro/accgyro_mpu6050.h"
+#endif
+
+#ifdef USE_ACC_MPU6500
 #include "drivers/accgyro/accgyro_mpu6500.h"
+#endif
+
+#ifdef USE_ACCGYRO_BMI160
 #include "drivers/accgyro/accgyro_spi_bmi160.h"
+#endif
+
+#ifdef USE_ACCGYRO_BMI270
 #include "drivers/accgyro/accgyro_spi_bmi270.h"
+#endif
+
+#ifdef USE_ACC_SPI_ICM20649
 #include "drivers/accgyro/accgyro_spi_icm20649.h"
+#endif
+
+#ifdef USE_ACC_SPI_ICM20689
 #include "drivers/accgyro/accgyro_spi_icm20689.h"
+#endif
+
+#if defined(USE_ACC_SPI_ICM42605) || defined(USE_ACC_SPI_ICM42688P)
 #include "drivers/accgyro/accgyro_spi_icm426xx.h"
+#endif
+
+#ifdef USE_ACCGYRO_LSM6DSO
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
+#endif
+
+#ifdef USE_ACC_SPI_MPU6000
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
+#endif
+
+#if defined(USE_ACC_SPI_MPU6500) || defined(USE_ACC_SPI_MPU9250) || defined(USE_ACC_SPI_ICM20601) || defined(USE_ACC_SPI_ICM20602) || defined(USE_ACC_SPI_ICM20608G)
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
+#endif
+
+#ifdef USE_ACC_SPI_MPU9250
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
+#endif
+
+#ifdef USE_ACCGYRO_LSM6DSV16X
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
+#endif
 
 #ifdef USE_ACC_ADXL345
 #include "drivers/accgyro_legacy/accgyro_adxl345.h"
@@ -240,7 +282,7 @@ retry:
     case ACC_ICM20608G:
 #if defined(USE_ACC_MPU6500) || defined(USE_ACC_SPI_MPU6500)
 #ifdef USE_ACC_SPI_MPU6500
-        if (mpu6500AccDetect(dev) || mpu6500SpiAccDetect(dev)) {
+        if (mpu6500SpiAccDetect(dev)) {
 #else
         if (mpu6500AccDetect(dev)) {
 #endif

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -37,63 +37,21 @@
 #include "config/feature.h"
 
 #include "drivers/accgyro/accgyro.h"
-#include "drivers/accgyro/accgyro_mpu.h"
-
-#ifdef USE_VIRTUAL_ACC
 #include "drivers/accgyro/accgyro_virtual.h"
-#endif
-
-#ifdef USE_ACC_MPU3050
+#include "drivers/accgyro/accgyro_mpu.h"
 #include "drivers/accgyro/accgyro_mpu3050.h"
-#endif
-
-#ifdef USE_ACC_MPU6050
 #include "drivers/accgyro/accgyro_mpu6050.h"
-#endif
-
-#ifdef USE_ACC_MPU6500
 #include "drivers/accgyro/accgyro_mpu6500.h"
-#endif
-
-#ifdef USE_ACCGYRO_BMI160
 #include "drivers/accgyro/accgyro_spi_bmi160.h"
-#endif
-
-#ifdef USE_ACCGYRO_BMI270
 #include "drivers/accgyro/accgyro_spi_bmi270.h"
-#endif
-
-#ifdef USE_ACC_SPI_ICM20649
 #include "drivers/accgyro/accgyro_spi_icm20649.h"
-#endif
-
-#ifdef USE_ACC_SPI_ICM20689
 #include "drivers/accgyro/accgyro_spi_icm20689.h"
-#endif
-
-#if defined(USE_ACC_SPI_ICM42605) || defined(USE_ACC_SPI_ICM42688P)
 #include "drivers/accgyro/accgyro_spi_icm426xx.h"
-#endif
-
-#ifdef USE_ACCGYRO_LSM6DSO
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
-#endif
-
-#ifdef USE_ACC_SPI_MPU6000
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
-#endif
-
-#if defined(USE_ACC_SPI_MPU6500) || defined(USE_ACC_SPI_MPU9250) || defined(USE_ACC_SPI_ICM20601) || defined(USE_ACC_SPI_ICM20602) || defined(USE_ACC_SPI_ICM20608G)
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
-#endif
-
-#ifdef USE_ACC_SPI_MPU9250
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
-#endif
-
-#ifdef USE_ACCGYRO_LSM6DSV16X
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
-#endif
 
 #ifdef USE_ACC_ADXL345
 #include "drivers/accgyro_legacy/accgyro_adxl345.h"

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -35,63 +35,21 @@
 #include "config/config.h"
 
 #include "drivers/accgyro/accgyro.h"
-#include "drivers/accgyro/accgyro_mpu.h"
-
-#ifdef USE_VIRTUAL_GYRO
 #include "drivers/accgyro/accgyro_virtual.h"
-#endif
-
-#ifdef USE_GYRO_MPU3050
+#include "drivers/accgyro/accgyro_mpu.h"
 #include "drivers/accgyro/accgyro_mpu3050.h"
-#endif
-
-#ifdef USE_GYRO_MPU6050
 #include "drivers/accgyro/accgyro_mpu6050.h"
-#endif
-
-#if defined(USE_GYRO_MPU6500)
 #include "drivers/accgyro/accgyro_mpu6500.h"
-#endif
-
-#ifdef USE_ACCGYRO_BMI160
 #include "drivers/accgyro/accgyro_spi_bmi160.h"
-#endif
-
-#ifdef USE_ACCGYRO_BMI270
 #include "drivers/accgyro/accgyro_spi_bmi270.h"
-#endif
-
-#ifdef USE_GYRO_SPI_ICM20649
 #include "drivers/accgyro/accgyro_spi_icm20649.h"
-#endif
-
-#ifdef USE_GYRO_SPI_ICM20689
 #include "drivers/accgyro/accgyro_spi_icm20689.h"
-#endif
-
-#if defined(USE_GYRO_SPI_ICM42605) || defined(USE_GYRO_SPI_ICM42688P)
 #include "drivers/accgyro/accgyro_spi_icm426xx.h"
-#endif
-
-#ifdef USE_ACCGYRO_LSM6DSO
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
-#endif
-
-#ifdef USE_GYRO_SPI_MPU6000
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
-#endif
-
-#if defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20601) || defined(USE_GYRO_SPI_ICM20602) || defined(USE_GYRO_SPI_ICM20608G)
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
-#endif
-
-#ifdef USE_GYRO_SPI_MPU9250
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
-#endif
-
-#ifdef USE_ACCGYRO_LSM6DSV16X
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
-#endif
 
 #ifdef USE_GYRO_L3GD20
 #include "drivers/accgyro/accgyro_spi_l3gd20.h"

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -600,10 +600,10 @@ static bool gyroDetectSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t 
 
 static void gyroPreInitSensor(const gyroDeviceConfig_t *config)
 {
-#ifndef USE_VIRTUAL_ACC
-    mpuPreInit(config);
-#else
+#ifdef USE_VIRTUAL_GYRO
     UNUSED(config);
+#else
+    mpuPreInit(config);
 #endif
 }
 


### PR DESCRIPTION
- Fixes https://build.betaflight.com/api/builds/3453efb87ef50b1eabb41961a62ef28a/log
- Optimized some preprocessor directives for easier maintenance as the list to maintain is in now in one place only.
- Optimizes initialization:  do not use I2C `mpu6500AccDetect` for MPU6500 if SPI is defined.
