### PR TITLE
Revised LPF1+LPF2 filter cutoff bandwidths from STMicro

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
@@ -321,10 +321,11 @@
 #define LSM6DSV_CTRL6_LPF1_G_BW_SHIFT                   4
 
 // Gyro LPF1 + LPF2 bandwidth selection when ODR=7.68kHz
-#define LSM6DSV_CTRL6_FS_G_BW_281HZ                     0
-#define LSM6DSV_CTRL6_FS_G_BW_213HZ                     1
-#define LSM6DSV_CTRL6_FS_G_BW_156HZ                     2
-#define LSM6DSV_CTRL6_FS_G_BW_407HZ                     3
+// Note that these figures were advised by STmicro tech support and differ from the datasheet
+#define LSM6DSV_CTRL6_FS_G_BW_288HZ                     0
+#define LSM6DSV_CTRL6_FS_G_BW_215HZ                     1
+#define LSM6DSV_CTRL6_FS_G_BW_157HZ                     2
+#define LSM6DSV_CTRL6_FS_G_BW_455HZ                     3
 #define LSM6DSV_CTRL6_FS_G_BW_102HZ                     4
 #define LSM6DSV_CTRL6_FS_G_BW_58HZ                      5
 #define LSM6DSV_CTRL6_FS_G_BW_28_8HZ                    6
@@ -947,11 +948,11 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
     const extDevice_t *dev = &gyro->dev;
     // Set default LPF1 filter bandwidth to be as close as possible to MPU6000's 250Hz cutoff
     uint8_t lsm6dsv16xLPF1BandwidthOptions[GYRO_HARDWARE_LPF_COUNT] = {
-            [GYRO_HARDWARE_LPF_NORMAL] = LSM6DSV_CTRL6_FS_G_BW_281HZ,
-            [GYRO_HARDWARE_LPF_OPTION_1] = LSM6DSV_CTRL6_FS_G_BW_156HZ,
-            [GYRO_HARDWARE_LPF_OPTION_2] = LSM6DSV_CTRL6_FS_G_BW_213HZ,
+            [GYRO_HARDWARE_LPF_NORMAL] = LSM6DSV_CTRL6_FS_G_BW_288HZ,
+            [GYRO_HARDWARE_LPF_OPTION_1] = LSM6DSV_CTRL6_FS_G_BW_157HZ,
+            [GYRO_HARDWARE_LPF_OPTION_2] = LSM6DSV_CTRL6_FS_G_BW_215HZ,
 #ifdef USE_GYRO_DLPF_EXPERIMENTAL
-            [GYRO_HARDWARE_LPF_EXPERIMENTAL] = LSM6DSV_CTRL6_FS_G_BW_407HZ
+            [GYRO_HARDWARE_LPF_EXPERIMENTAL] = LSM6DSV_CTRL6_FS_G_BW_455HZ
 #endif
     };
 


### PR DESCRIPTION
STMicro have advised that the LPF1+LPF2 cut-off frequency and phase shifts are as below, contrary to the datasheet.


|LPF1_G_BW_[2:0] | TOTAL (LPF1+LPF2) cut-off [Hz] (phase @ 20 Hz)|
|-- | -- |
Bypassed | 527 (-8.5°)
000 | 280 (-14.1°)
001 | 213 (-15.9°)
010 | 156 (-18.8°)
011 | 402 (-11.9°)
100 | 102 (-24.5°)
101 | 58 (-37.4°)
110 | 28.8 (-43.7°)
111 | 14.4 (-63.4°)

The LPF1 cut-off values, referenced in the source code have been revised as per the following.

LPF1_G_BW_[2:0] | LPF1 cut-off [Hz]
-- | --
000 | 288
001 | 215
010 | 157
011 | 455
100 | 102
101 | 58
110 | 28.8
111 | 14.4

