### PR TITLE
Add MSP request for UBLOX SatInfo and disable SatInfo on ARMING.

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -371,20 +371,13 @@ static void logErrorToPacketLog(void)
 #ifdef USE_GPS_UBLOX
 void gpsRequestSatInfo(void)
 {
-    gpsData.satMessagesDisabled = false;
     setSatInfoMessageRate(5);
 }
 #endif
 
 static bool isConfiguratorConnected(void)
 {
-    bool connected = getArmingDisableFlags() & ARMING_DISABLED_MSP;
-
-    if (!connected) {
-        gpsData.satMessagesDisabled = true;
-    }
-
-    return connected;
+    return getArmingDisableFlags() & ARMING_DISABLED_MSP;
 }
 
 static void gpsNewData(uint16_t c);
@@ -410,7 +403,6 @@ void gpsInit(void)
     gpsDataIntervalSeconds = 0.1f;
     gpsData.userBaudRateIndex = 0;
     gpsData.timeouts = 0;
-    gpsData.satMessagesDisabled = true;
     gpsData.state_ts = millis();
 #ifdef USE_GPS_UBLOX
     gpsData.ubloxUsingFlightModel = false;

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -382,7 +382,10 @@ extern uint32_t dashboardGpsNavSvInfoRcvCount;                  // Count of time
 
 #ifdef USE_GPS_UBLOX
 ubloxVersion_e ubloxParseVersion(const uint32_t version);
+void gpsRequestSatInfo(void);
+void setSatInfoMessageRate(uint8_t divisor);
 #endif
+
 void gpsInit(void);
 void gpsUpdate(timeUs_t currentTimeUs);
 bool gpsNewFrame(uint8_t c);

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -292,7 +292,6 @@ typedef struct gpsData_s {
     bool ubloxM8orAbove;
     bool ubloxM9orAbove;
     bool ubloxUsingFlightModel;     // false = Acquire model, true = Flight model
-    bool satMessagesDisabled;
 #ifdef USE_GPS_UBLOX
     uint32_t lastNavSolTs;          // time stamp of last UBCX message.  Used to calculate message delta
     ubloxVersion_e platformVersion; // module platform version, mapped from reported hardware version

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4052,6 +4052,12 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         break;
 #endif
 
+#ifdef USE_GPS
+    case MSP2_GPS_REQUEST_SV_INFO:
+        gpsRequestSatInfo();
+        break;
+#endif
+
     default:
         // we do not know how to handle the (valid) message, indicate error MSP $M!
         return MSP_RESULT_ERROR;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4052,7 +4052,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         break;
 #endif
 
-#if defined(USE_GPS) && defined(USE_GPS_UBLOX)
+#ifdef USE_GPS_UBLOX
     case MSP2_UBLOX_REQUEST_SV_INFO:
         gpsRequestSatInfo();
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4053,7 +4053,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
 
 #if defined(USE_GPS) && defined(USE_GPS_UBLOX)
-    case MSP2_GPS_REQUEST_SV_INFO:
+    case MSP2_UBLOX_REQUEST_SV_INFO:
         gpsRequestSatInfo();
         break;
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4052,7 +4052,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         break;
 #endif
 
-#ifdef USE_GPS
+#if defined(USE_GPS) && defined(USE_GPS_UBLOX)
     case MSP2_GPS_REQUEST_SV_INFO:
         gpsRequestSatInfo();
         break;

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -29,6 +29,7 @@
 #define MSP2_GET_LED_STRIP_CONFIG_VALUES    0x3008
 #define MSP2_SET_LED_STRIP_CONFIG_VALUES    0x3009
 #define MSP2_SENSOR_CONFIG_ACTIVE           0x300A
+#define MSP2_GPS_REQUEST_SV_INFO            0x300B
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -29,7 +29,7 @@
 #define MSP2_GET_LED_STRIP_CONFIG_VALUES    0x3008
 #define MSP2_SET_LED_STRIP_CONFIG_VALUES    0x3009
 #define MSP2_SENSOR_CONFIG_ACTIVE           0x300A
-#define MSP2_GPS_REQUEST_SV_INFO            0x300B
+#define MSP2_UBLOX_REQUEST_SV_INFO          0x300B
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -29,7 +29,7 @@
 
 #include "gps.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 4);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .provider = GPS_UBLOX,


### PR DESCRIPTION
As configurator some times fails to get satellite info as it missed the opportunity we rather like to add a MSP request from client.

- Send a MSP  request from configurator to firmware to enable SatInfo.
- Added support for configurator https://github.com/betaflight/betaflight-configurator/pull/3689
- Does not have to wait 3 seconds for GPS data to arrive in OSD.
- Disables sat info on arming.