### PR TITLE
Fix arming when GPS included in build but no active GNSS device attached + revert msp request for SatInfo

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -484,9 +484,6 @@ if (systemConfig()->configurationState == CONFIGURATION_STATE_UNCONFIGURED) {
 #ifdef USE_DASHBOARD
     featureEnableImmediate(FEATURE_DASHBOARD);
 #endif
-#ifdef USE_GPS
-    featureEnableImmediate(FEATURE_GPS);
-#endif
 #ifdef USE_LED_STRIP
     featureEnableImmediate(FEATURE_LED_STRIP);
 #endif

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -580,9 +580,10 @@ void tryArm(void)
         lastArmingDisabledReason = 0;
 
 #ifdef USE_GPS
-        GPS_reset_home_position();
         //beep to indicate arming
         if (featureIsEnabled(FEATURE_GPS)) {
+            GPS_reset_home_position();
+
             if (STATE(GPS_FIX) && gpsSol.numSat >= gpsRescueConfig()->minSats) {
                 beeper(BEEPER_ARMING_GPS_FIX);
             } else {

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2559,7 +2559,7 @@ void GPS_reset_home_position(void)
 
 #ifdef USE_GPS_UBLOX
     // disable Sat Info requests on arming
-    if (ARMING_FLAG(ARMED)) {
+    if (gpsConfig()->provider == GPS_UBLOX && ARMING_FLAG(ARMED)) {
         setSatInfoMessageRate(0);
     }
 #endif

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -381,7 +381,6 @@ extern uint32_t dashboardGpsNavSvInfoRcvCount;                  // Count of time
 
 #ifdef USE_GPS_UBLOX
 ubloxVersion_e ubloxParseVersion(const uint32_t version);
-void gpsRequestSatInfo(void);
 void setSatInfoMessageRate(uint8_t divisor);
 #endif
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4052,12 +4052,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         break;
 #endif
 
-#ifdef USE_GPS_UBLOX
-    case MSP2_UBLOX_REQUEST_SV_INFO:
-        gpsRequestSatInfo();
-        break;
-#endif
-
     default:
         // we do not know how to handle the (valid) message, indicate error MSP $M!
         return MSP_RESULT_ERROR;

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -29,7 +29,6 @@
 #define MSP2_GET_LED_STRIP_CONFIG_VALUES    0x3008
 #define MSP2_SET_LED_STRIP_CONFIG_VALUES    0x3009
 #define MSP2_SENSOR_CONFIG_ACTIVE           0x300A
-#define MSP2_UBLOX_REQUEST_SV_INFO          0x300B
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -29,7 +29,7 @@
 
 #include "gps.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 4);
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 3);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .provider = GPS_UBLOX,

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -29,7 +29,7 @@
 
 #include "gps.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 4);
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 5);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .provider = GPS_UBLOX,
@@ -44,6 +44,7 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .gps_use_3d_speed = false,
     .sbas_integrity = false,
     .gps_ublox_utc_standard = UBLOX_UTC_STANDARD_AUTO,
+    .nmeaCustomCommands = "",
 );
 
 #endif // USE_GPS

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -29,7 +29,7 @@
 
 #include "gps.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 5);
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 4);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .provider = GPS_UBLOX,
@@ -44,7 +44,6 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .gps_use_3d_speed = false,
     .sbas_integrity = false,
     .gps_ublox_utc_standard = UBLOX_UTC_STANDARD_AUTO,
-    .nmeaCustomCommands = "",
 );
 
 #endif // USE_GPS


### PR DESCRIPTION
Turns out when users have a build with `USE_GPS` build option included without an actual GNSS device attached the request to disable SatInfo freezes the quad during arming. Thanks to this issue found some other bugs.

Lesson learned:  do not active a feature based on define only

Request for SatInfo from configurator seems to have timing issues and added extra layer of complexity so this change has been reverted.

Main reason for the change in the first place was to ensure SatInfo messaging was disabled to improve flight performance upon arming the quad as some users have reported freezing of the flight controller in flight.