### PR TITLE
revert msp method for gps sat info messages

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -580,9 +580,9 @@ void tryArm(void)
         lastArmingDisabledReason = 0;
 
 #ifdef USE_GPS
-        GPS_reset_home_position();
         //beep to indicate arming
         if (featureIsEnabled(FEATURE_GPS)) {
+            GPS_reset_home_position();
             if (STATE(GPS_FIX) && gpsSol.numSat >= gpsRescueConfig()->minSats) {
                 beeper(BEEPER_ARMING_GPS_FIX);
             } else {

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2559,7 +2559,9 @@ void GPS_reset_home_position(void)
 
 #ifdef USE_GPS_UBLOX
     // disable Sat Info requests on arming
-    setSatInfoMessageRate(0);
+    if (gpsConfig()->provider == GPS_UBLOX) {
+         setSatInfoMessageRate(0);
+     }
 #endif
     GPS_calculateDistanceFlown(true); // Initialize
 }

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -329,9 +329,10 @@ typedef enum {
     UBLOX_MSG_STATUS,       // 15: set STATUS MSG rate
     UBLOX_MSG_VELNED,       // 16. set VELNED MSG rate
     UBLOX_MSG_DOP,          // 17. MSG_NAV_DOP
-    UBLOX_SET_NAV_RATE,     // 18. set to user requested GPS sample rate
-    UBLOX_MSG_CFG_GNSS,     // 19. For not SBAS or GALILEO
-    UBLOX_CONFIG_COMPLETE   // 20. Config finished, start receiving data
+    UBLOX_SAT_INFO,         // 18. MSG_NAV_SAT message
+    UBLOX_SET_NAV_RATE,     // 19. set to user requested GPS sample rate
+    UBLOX_MSG_CFG_GNSS,     // 20. For not SBAS or GALILEO
+    UBLOX_CONFIG_COMPLETE   // 21. Config finished, start receiving data
 } ubloxStatePosition_e;
 
 baudRate_e initBaudRateIndex;
@@ -365,16 +366,6 @@ static void logErrorToPacketLog(void)
     gpsData.errors++;
 }
 #endif  // USE_DASHBOARD
-
-// Enable sat info using MSP request
-#ifdef USE_GPS_UBLOX
-void gpsRequestSatInfo(void)
-{
-    if (!ARMING_FLAG(ARMED)) {
-        setSatInfoMessageRate(5);
-    }
-}
-#endif
 
 static void gpsNewData(uint16_t c);
 #ifdef USE_GPS_NMEA
@@ -941,7 +932,7 @@ static void ubloxSetSbas(void)
 
 void setSatInfoMessageRate(uint8_t divisor)
 {
-    // enable satInfoMessage at 1:5 of the nav rate if configurator is connected
+    // enable satInfoMessage by default, turn off on arming.
     if (gpsData.ubloxM9orAbove) {
          ubloxSetMessageRateValSet(CFG_MSGOUT_UBX_NAV_SAT_UART1, divisor);
     } else if (gpsData.ubloxM8orAbove) {
@@ -1108,6 +1099,11 @@ void gpsConfigureUblox(void)
                 break;
             }
 
+            // allow 1s for the GPS module's new baud rate to stabilise before sending commands
+            if (cmp32(gpsData.now, gpsData.state_ts) < (3 * GPS_CONFIG_BAUD_CHANGE_INTERVAL)) {
+                return;
+            }
+
             if (gpsData.ackState == UBLOX_ACK_IDLE) {
 
                 // short delay before between commands, including the first command
@@ -1231,6 +1227,10 @@ void gpsConfigureUblox(void)
                         } else {
                             ubloxSetMessageRate(CLASS_NAV, MSG_NAV_DOP, 1);
                         }
+                        break;
+                    case UBLOX_SAT_INFO:
+                        // enable by default, turned off when armed and receiving data to reduce in-flight traffic
+                        setSatInfoMessageRate(5);
                         break;
                     case UBLOX_SET_NAV_RATE:
                         // set the nav solution rate to the user's configured update rate
@@ -2559,9 +2559,7 @@ void GPS_reset_home_position(void)
 
 #ifdef USE_GPS_UBLOX
     // disable Sat Info requests on arming
-    if (ARMING_FLAG(ARMED)) {
-        setSatInfoMessageRate(0);
-    }
+    setSatInfoMessageRate(0);
 #endif
     GPS_calculateDistanceFlown(true); // Initialize
 }

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -381,8 +381,6 @@ extern uint32_t dashboardGpsNavSvInfoRcvCount;                  // Count of time
 
 #ifdef USE_GPS_UBLOX
 ubloxVersion_e ubloxParseVersion(const uint32_t version);
-void gpsRequestSatInfo(void);
-void setSatInfoMessageRate(uint8_t divisor);
 #endif
 
 void gpsInit(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4052,12 +4052,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         break;
 #endif
 
-#ifdef USE_GPS_UBLOX
-    case MSP2_UBLOX_REQUEST_SV_INFO:
-        gpsRequestSatInfo();
-        break;
-#endif
-
     default:
         // we do not know how to handle the (valid) message, indicate error MSP $M!
         return MSP_RESULT_ERROR;

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -29,7 +29,6 @@
 #define MSP2_GET_LED_STRIP_CONFIG_VALUES    0x3008
 #define MSP2_SET_LED_STRIP_CONFIG_VALUES    0x3009
 #define MSP2_SENSOR_CONFIG_ACTIVE           0x300A
-#define MSP2_UBLOX_REQUEST_SV_INFO          0x300B
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -29,7 +29,7 @@
 
 #include "gps.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 4);
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 3);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .provider = GPS_UBLOX,


### PR DESCRIPTION
This restores the reliable sending of SatInfo data from the GPS module on power up, which was lost with PR #13240.

Any version of Configurator should reliably see satellite info on connecting a firmware 4.5 quad to betaflight.  There is no requirement to have the latest nightly version of Configurator.  Sat info data will be sent by the GPS once it has established a serial connection and once the early configuration is complete, typically about 2s after powering up.  Then, on arming, a message is sent to the module to tell it to stop sending the Satellite Info data. 

This achieves the same effective outcome as the code before PR #13240, which it largely reverts, but does not require Configurator to be connected within a certain time at the start.  The module will just get told to send satellite info until it is armed.  After that, no more Satellite info until a power cycle.  

it is a simpler alternative to #13244, which introduces a CLI value to change the time for the check for whether Configurator is connected. 

I've tested it and it works.  Sat info is reliably displayed by all Configurator versions back to 10.8, and stops on arming.

There may be a possible user interest in re-enabling the Sat Info on disarming, but I don't see it being an issue at this point in time.  And previously it was not possible to re-enable the data.

Nor should there be a problem if we send SatInfo data from the time the module turns on.