### PR TITLE
Led task optimistion

### DIFF
--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -28,7 +28,7 @@
 
 #include "pg/pg.h"
 
-#define TASK_LEDSTRIP_RATE_HZ 100
+#define TASK_LEDSTRIP_RATE_HZ 50
 
 #define LED_CONFIGURABLE_COLOR_COUNT   16
 #define LED_MODE_COUNT                  6


### PR DESCRIPTION
On the F411 the time taken to process the LED updates, when broken into sub-states, was exceeding the target task period as the sub-states were not being called frequently enough to get all the work done.

The PR addresses this by employing three task rates:
1. 100Hz, the standard task rate
2. 500Hz, used when an update is expected, but a layer timer has yet to fire
3. As fast as possible, used when a timer has fired to update the layers or the DMA buffer

If the layer update code still takes a long time to process, the task rate with gracefully drop.

@ASDosjani @ctzsnooze Please test. 
