### PR TITLE
Increasing frequency of MSP protocol in SITL

### DIFF
--- a/src/main/target/SITL/sitl.c
+++ b/src/main/target/SITL/sitl.c
@@ -270,7 +270,7 @@ static void* tcpThread(void* data)
 
     dyad_init();
     dyad_setTickInterval(0.2f);
-    dyad_setUpdateTimeout(0.5f);
+    dyad_setUpdateTimeout(0.01f);
 
     while (workerRunning) {
         dyad_update();


### PR DESCRIPTION
This change stems from incurring in #10827, the high cycle time is fixed by setting correctly the PID frequency, however the low MSP update frequency is still present.

The MSP frequency over tcp in the SITL is about 1Hz, too slow to be useful for real-time control. 

I increased it so that it is about 100Hz, similar to real hardware flight controllers.