### PR TITLE
Fix CLI command "bind_rx" for CRSF

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6468,7 +6468,7 @@ const clicmd_t cmdTable[] = {
         "\t<->[name]", cliBeeper),
 #endif // USE_BEEPER
 #if defined(USE_RX_BIND)
-    CLI_COMMAND_DEF("bind_rx", "initiate binding for RX SPI or SRXL2", NULL, cliRxBind),
+    CLI_COMMAND_DEF("bind_rx", "initiate binding for RX SPI, SRXL2 or CRSF", NULL, cliRxBind),
 #endif
 #if defined(USE_FLASH_BOOT_LOADER)
     CLI_COMMAND_DEF("bl", "reboot into bootloader", "[flash|rom]", cliBootloader),

--- a/src/main/rx/rx_bind.c
+++ b/src/main/rx/rx_bind.c
@@ -30,7 +30,7 @@
 
 static bool doRxBind(bool doBind)
 {
-#if !defined(USE_SERIALRX_SRXL2) && !defined(USE_RX_FRSKY_SPI) && !defined(USE_RX_SFHSS_SPI) && !defined(USE_RX_FLYSKY) && !defined(USE_RX_SPEKTRUM) && !defined(USE_RX_EXPRESSLRS) && !defined(USE_RX_CRSF)
+#if !defined(USE_SERIALRX_SRXL2) && !defined(USE_RX_FRSKY_SPI) && !defined(USE_RX_SFHSS_SPI) && !defined(USE_RX_FLYSKY) && !defined(USE_RX_SPEKTRUM) && !defined(USE_RX_EXPRESSLRS) && !defined(USE_SERIALRX_CRSF)
     UNUSED(doBind);
 #endif
 
@@ -41,7 +41,7 @@ static bool doRxBind(bool doBind)
         switch (rxRuntimeState.serialrxProvider) {
         default:
             return false;
-#if defined(USE_RX_CRSF)
+#if defined(USE_SERIALRX_CRSF)
         case SERIALRX_CRSF:
             if (doBind) {
                 crsfRxBind();

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -612,7 +612,7 @@ extern uint8_t __config_end;
 #endif
 #endif
 
-#if defined(USE_RX_SPI) || defined(USE_SERIALRX_SRXL2)
+#if defined(USE_RX_SPI) || defined(USE_SERIALRX_SRXL2) || defined(USE_SERIALRX_CRSF)
 #define USE_RX_BIND
 #endif
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -155,7 +155,6 @@
 #define USE_RX_SPI
 
 #define USE_RX_CC2500
-#define USE_RX_CRSF
 #define USE_RX_EXPRESSLRS
 #define USE_RX_SX1280
 #define USE_RX_SX127X


### PR DESCRIPTION
PR #13119 introduced binding via CLI command `bind_rx` for the CRSF protocol but on cloud builds the CLI command was not available (even if CRSF was selected).

Bug in action: https://www.youtube.com/watch?v=FMbBfef_R-g&t=1361s

This PR fixes the gating issue and makes `bind_rx` available for the CRSF protocol on cloud builds.