### PR TITLE
Fix F7X2 AXIM flash region

### DIFF
--- a/src/link/stm32_flash_f722.ld
+++ b/src/link/stm32_flash_f722.ld
@@ -49,6 +49,6 @@ REGION_ALIAS("RAM", SRAM1)
 
 /* Put various bits and bobs of data into the free space after the vector table in sector 0 to save flash space. */
 
-REGION_ALIAS("MOVABLE_FLASH", AXIM_FLASH)
+REGION_ALIAS("MOVABLE_FLASH", AXIM_FLASH1)
 
 INCLUDE "stm32_flash_f7_split.ld"


### PR DESCRIPTION
For testing.

Found that on F7X2 `MOVABLE_FLASH` alias was pointing to `AXIM_FLASH` (16K) instead of `AXIM_FLASH1` (480K)
as on F745 and F765 `MOVABLE_FLASH` alias points to `AXIM_FLASH1`.
