### PR TITLE
Rename USE_QUICK_OSD_MENU

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1378,9 +1378,9 @@ const clivalue_t valueTable[] = {
     { "osd_ah_invert",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, ahInvert) },
     { "osd_logo_on_arming",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OSD_LOGO_ON_ARMING }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming) },
     { "osd_logo_on_arming_duration",VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_OSD_CONFIG, offsetof(osdConfig_t, logo_on_arming_duration) },
-#ifdef USE_QUICK_OSD_MENU
+#ifdef USE_OSD_QUICK_MENU
     { "osd_use_quick_menu",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_use_quick_menu) },
-#endif // USE_QUICK_OSD_MENU
+#endif // USE_OSD_QUICK_MENU
 #ifdef USE_SPEC_PREARM_SCREEN
     { "osd_show_spec_prearm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, osd_show_spec_prearm) },
 #endif // USE_SPEC_PREARM_SCREEN

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -898,11 +898,11 @@ void cmsMenuOpen(void)
         currentCtx = (cmsCtx_t){ NULL, 0, 0 };
         startMenu = &cmsx_menuMain;
 
-#ifdef USE_QUICK_OSD_MENU
+#ifdef USE_OSD_QUICK_MENU
         if (osdConfig()->osd_use_quick_menu) {
             startMenu = &cmsx_menuQuick;
         }
-#endif // USE_QUICK_OSD_MENU
+#endif // USE_OSD_QUICK_MENU
 
         menuStackIdx = 0;
         setArmingDisabled(ARMING_DISABLED_CMS_MENU);

--- a/src/main/cms/cms_menu_quick.c
+++ b/src/main/cms/cms_menu_quick.c
@@ -25,7 +25,7 @@
 #include "platform.h"
 
 #ifdef USE_CMS
-#ifdef USE_QUICK_OSD_MENU
+#ifdef USE_OSD_QUICK_MENU
 
 #include "cms/cms.h"
 #include "cms/cms_types.h"
@@ -120,5 +120,5 @@ CMS_Menu cmsx_menuQuick = {
     .entries = menuMainEntries,
 };
 
-#endif // USE_QUICK_OSD_MENU
+#endif // USE_OSD_QUICK_MENU
 #endif // USE_CMS

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -430,9 +430,9 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->canvas_rows = OSD_SD_ROWS;
 #endif
 
-#ifdef USE_QUICK_OSD_MENU
+#ifdef USE_OSD_QUICK_MENU
     osdConfig->osd_use_quick_menu = true;
-#endif // USE_QUICK_OSD_MENU
+#endif // USE_OSD_QUICK_MENU
 #ifdef USE_SPEC_PREARM_SCREEN
     osdConfig->osd_show_spec_prearm = true;
 #endif // USE_SPEC_PREARM_SCREEN

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -348,9 +348,9 @@ typedef struct osdConfig_s {
     uint8_t aux_symbol;
     uint8_t canvas_cols;                      // Canvas dimensions for HD display
     uint8_t canvas_rows;
-#ifdef USE_QUICK_OSD_MENU
+#ifdef USE_OSD_QUICK_MENU
     uint8_t osd_use_quick_menu;               // use QUICK menu YES/NO
-#endif // USE_QUICK_OSD_MENU
+#endif // USE_OSD_QUICK_MENU
 #ifdef USE_SPEC_PREARM_SCREEN
     uint8_t osd_show_spec_prearm;
 #endif // USE_SPEC_PREARM_SCREEN

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -231,7 +231,7 @@
 
 #ifdef USE_OSD
 // Dependency for CMS is defined outside this block.
-#define USE_QUICK_OSD_MENU
+#define USE_OSD_QUICK_MENU
 #define USE_RC_STATS
 #define USE_SPEC_PREARM_SCREEN
 #endif
@@ -445,8 +445,8 @@
 #endif
 
 #ifdef USE_OSD
-#ifndef USE_QUICK_OSD_MENU
-#define USE_QUICK_OSD_MENU
+#ifndef USE_OSD_QUICK_MENU
+#define USE_OSD_QUICK_MENU
 #endif
 #ifndef USE_RC_STATS
 #define USE_RC_STATS


### PR DESCRIPTION
Seems it was original intended to use `USE_OSD_QUICK_MENU`

Reference #12977