### PR TITLE
In GPS Rescue current altitude mode, ensure that return height is not less than climb height

### DIFF
--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -206,7 +206,7 @@ static void setReturnAltitude(void)
                 break;
             case GPS_RESCUE_ALT_MODE_MAX:
             default:
-                rescueState.intent.returnAltitudeCm = rescueState.intent.maxAltitudeCm + initiaClimbCm;
+                rescueState.intent.returnAltitudeCm = rescueState.intent.maxAltitudeCm + initialClimbCm;
                 break;
         }
     }

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -202,7 +202,7 @@ static void setReturnAltitude(void)
                 break;
             case GPS_RESCUE_ALT_MODE_CURRENT:
                 // climb above current altitude, but always return at least initial height above takeoff point, in case current altitude was negative
-                rescueState.intent.returnAltitudeCm = fmaxf(initiaClimbCm, rescueState.sensor.currentAltitudeCm + initiaClimbCm);
+                rescueState.intent.returnAltitudeCm = fmaxf(initialClimbCm, rescueState.sensor.currentAltitudeCm + initialClimbCm);
                 break;
             case GPS_RESCUE_ALT_MODE_MAX:
             default:

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -195,7 +195,7 @@ static void setReturnAltitude(void)
         // Set this to the user's intended descent distance, but not more than half the distance to home to ensure some fly home time
         rescueState.intent.descentDistanceM = fminf(0.5f * rescueState.sensor.distanceToHomeM, gpsRescueConfig()->descentDistanceM);
 
-        const float initiaClimbCm = gpsRescueConfig()->initialClimbM * 100.0f;
+        const float initialClimbCm = gpsRescueConfig()->initialClimbM * 100.0f;
         switch (gpsRescueConfig()->altitudeMode) {
             case GPS_RESCUE_ALT_MODE_FIXED:
                 rescueState.intent.returnAltitudeCm = gpsRescueConfig()->returnAltitudeM * 100.0f;

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -194,17 +194,19 @@ static void setReturnAltitude(void)
         // Intended descent distance for rescues that start outside the minStartDistM distance
         // Set this to the user's intended descent distance, but not more than half the distance to home to ensure some fly home time
         rescueState.intent.descentDistanceM = fminf(0.5f * rescueState.sensor.distanceToHomeM, gpsRescueConfig()->descentDistanceM);
- 
+
+        const float initiaClimbCm = gpsRescueConfig()->initialClimbM * 100.0f;
         switch (gpsRescueConfig()->altitudeMode) {
             case GPS_RESCUE_ALT_MODE_FIXED:
                 rescueState.intent.returnAltitudeCm = gpsRescueConfig()->returnAltitudeM * 100.0f;
                 break;
             case GPS_RESCUE_ALT_MODE_CURRENT:
-                rescueState.intent.returnAltitudeCm = rescueState.sensor.currentAltitudeCm + gpsRescueConfig()->initialClimbM * 100.0f;
+                // climb above current altitude, but always return at least initial height above takeoff point, in case current altitude was negative
+                rescueState.intent.returnAltitudeCm = fmaxf(initiaClimbCm, rescueState.sensor.currentAltitudeCm + initiaClimbCm);
                 break;
             case GPS_RESCUE_ALT_MODE_MAX:
             default:
-                rescueState.intent.returnAltitudeCm = rescueState.intent.maxAltitudeCm + gpsRescueConfig()->initialClimbM * 100.0f;
+                rescueState.intent.returnAltitudeCm = rescueState.intent.maxAltitudeCm + initiaClimbCm;
                 break;
         }
     }


### PR DESCRIPTION
Discord user jungleman_12 pointed out that if a pilot using GPS Rescue in `current_altitude` mode was to descend below takeoff point, and trigger a rescue, then the initial climb height of 10m might not be sufficient to return home safely.  

This is a simple change which ensures that the return altitude cannot be less than the set initial climb height.

For example, assuming the default `gps_rescue_initial_climb` value of 10m, if the user was to fly from a high point on a hill, descend 100m, and then initiate a rescue, this PR would result in a climb of 110m and a return height set to 10m above takeoff altitude.  Whereas, without this change, the craft would only climb 10m and, returning 90m below take-off point, would inevitably crash into the side of the hill.

For pilots flying over flat areas, or when initiating the rescue some height above the takeoff point, there will be no change in behaviour. 

No change in the other return altitude modes is intended.  Neither max_alt nor fixed_alt modes have this potential issue.

<edit> this has been tested - see link to video below - and works as expected.

There is little downside risk and I'm tempted to consider it a bug fix and suggest it be included in 4.5
