### PR TITLE
Add timeout to serial four way interface for ESC programming

### DIFF
--- a/src/main/drivers/at32/serial_usb_vcp_at32f4.c
+++ b/src/main/drivers/at32/serial_usb_vcp_at32f4.c
@@ -362,15 +362,14 @@ static uint32_t usbVcpAvailable(const serialPort_t *instance)
 {
     UNUSED(instance);
 
-    uint32_t available=0;
+    cdc_struct_type *pcdc = (cdc_struct_type *)otg_core_struct.dev.class_handler->pdata;
+    uint32_t available = APP_Rx_ptr_in-APP_Rx_ptr_out;
 
-    available=APP_Rx_ptr_in-APP_Rx_ptr_out;
-    if(available == 0){
-        cdc_struct_type *pcdc = (cdc_struct_type *)otg_core_struct.dev.class_handler->pdata;
-        if(pcdc->g_rx_completed == 1){
-            available=pcdc->g_rxlen;
-        }
+    // Return the sum of the bytes in the APP_Rx_Buffer buffer and those received by the VCP driver
+    if (pcdc->g_rx_completed == 1) {
+        available += pcdc->g_rxlen;
     }
+
     return available;
 }
 
@@ -382,6 +381,7 @@ static uint8_t usbVcpRead(serialPort_t *instance)
         APP_Rx_ptr_out = 0;
         APP_Rx_ptr_in = usb_vcp_get_rxdata(&otg_core_struct.dev, APP_Rx_Buffer);
         if(APP_Rx_ptr_in == 0) {
+            // We've drained the input buffer
             return 0;
         }
     }


### PR DESCRIPTION
This PR add timeouts to the 4way-if code for ESC programming.

When using https://esc-configurator.com/ on a Mac with Google Chrome Version 120.0.6099.129 on MacOS Version 10.15.7 ESC flashing via an AT32F435 frequently hangs. Whilst this PR doesn't fix this issue it did reveal that the hang occurs with a timeout at :

https://github.com/betaflight/betaflight/blob/70e70c5d7be06ff5656c9787c684a9a5ff2183df/src/main/io/serial_4way.c#L395

having been called from `esc4wayProcess()`, most frequently at:

https://github.com/betaflight/betaflight/blob/70e70c5d7be06ff5656c9787c684a9a5ff2183df/src/main/io/serial_4way.c#L464

This PR reduces the frequency of failure somewhat by occasionally triggering retries, but this doesn't fix the hang. The addition of timeouts is nevertheless a good thing.

Note that this issue doesn't affect Windows using Edge. It would be useful to know if this is an issue on more recent MacOS releases. I'll aim to get access to Mac running MacOS Sonoma.

Note that the same FC with an STM32F405 is unaffected by this issue. It appears to be peculiar to the combination of MacOS and the AT32F435.