### PR TITLE
Set IST8310 mag default address to 0x0E or 14

### DIFF
--- a/src/main/drivers/compass/compass_ist8310.c
+++ b/src/main/drivers/compass/compass_ist8310.c
@@ -44,16 +44,22 @@
 
 //#define DEBUG_MAG_DATA_READY_INTERRUPT
 
-#define IST8310_MAG_I2C_ADDRESS 0x0C
+#define IST8310_MAG_I2C_ADDRESS 0x0E
 
-/* ist8310 Slave Address Select : default address 0x0C
- *        CAD1  |  CAD0   |  Address
- *    ------------------------------
- *         VSS   |   VSS  |  0CH
- *         VSS   |   VDD  |  0DH
- *         VDD   |   VSS  |  0EH
- *         VDD   |   VDD  |  0FH
- * if CAD1 and CAD0 are floating, I2C address will be 0EH
+/* ist8310 Slave Address is set by the value of two pins CAD1 and CAD 0
+ * see https://isentek.com/userfiles/files/IST8310Datasheet_3DMagneticSensors.pdf
+ * from which the table below is copied
+ * Note 2 on page 6 says "If CAD1 and CAD0 are floating (default), I2C address will be 0EH"
+ * Users should be aware that any address from 12 to 15 may apply, depending on the board
+ * if manufacturers follow the note on the datasheet, the default address is 0x0E or 14
+ *
+ *        CAD1  |  CAD0   |  Address  |  Decimal  |
+ *    ---------------------------------------------
+ *         VSS   |   VSS  |    0CH    |    12     |
+ *         VSS   |   VDD  |    0DH    |    13     |
+ *         VDD   |   VSS  |    0EH    |    14     |
+ *         VDD   |   VDD  |    0FH    |    15     |
+ * 
  *
  *
  * CTRL_REGA: Control Register 1


### PR DESCRIPTION
A Betaflight Discord user squirrel2918 found that the only way to enable the IST8310 Mag on their GEP-M1025-MI GPS unit, which has an IST8310 Mag and an MS5611 Baro chip on an i2c bus, was to set the `mag_i2c_address` to 14.

Auto configuration of the Mag, or using `mag_i2c_address` of 12, which is the current address in our driver, failed.

This PR highlights potential issues with this Mag and our auto-identification method.

This Mag can have any one of four i2c addresses, from 0x0C (12) through to 0x0F (15), depending on how two pins on the chip are wired up.  See the following table from page 6 of the [datasheet](https://isentek.com/userfiles/files/IST8310Datasheet_3DMagneticSensors.pdf):

![Screen Shot 2024-01-09 at 07 14 14](https://github.com/betaflight/betaflight/assets/11737748/b7c33960-d1ca-4c45-a11f-e70e7d5cc8c4)

The note on the table says, "If CAD1 and CAD0 are floating (default), I2C address will be 0CH", or 12.

Users should be aware that any address from 12 to 15 may work, depending on what the manufacturer chooses.  If automatic address selection (`mag_i2c_address = 0`) fails, the user should try `mag_i2c_address` values from 12-15.  If that fails they should check whether the mag is connected to i2c 'device' (bus) 1 or 2.
