### PR TITLE
4.6: Calculations for ACC in the ground coordinate system

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -117,4 +117,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "MAG_CALIB",
     "MAG_TASK_RATE",
     "EZLANDING",
+    "EARTH_FRAME",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -119,6 +119,7 @@ typedef enum {
     DEBUG_MAG_CALIB,
     DEBUG_MAG_TASK_RATE,
     DEBUG_EZLANDING,
+    DEBUG_EARTH_FRAME,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -210,14 +210,28 @@ void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation)
     rotation->m[2][Z] = cosy * cosx;
 }
 
-void applyMatrixRotation(float *v, fp_rotationMatrix_t *rotationMatrix)
+void transposeMatrix3x3(float transposedMatrix[3][3], float matrix[3][3])
+{
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            transposedMatrix[i][j] = matrix[j][i];
+        }
+    }
+}
+
+void applyMatrixRotationArray(float *v, float rotationMatrix[3][3])
 {
     struct fp_vector *vDest = (struct fp_vector *)v;
     struct fp_vector vTmp = *vDest;
 
-    vDest->X = (rotationMatrix->m[0][X] * vTmp.X + rotationMatrix->m[1][X] * vTmp.Y + rotationMatrix->m[2][X] * vTmp.Z);
-    vDest->Y = (rotationMatrix->m[0][Y] * vTmp.X + rotationMatrix->m[1][Y] * vTmp.Y + rotationMatrix->m[2][Y] * vTmp.Z);
-    vDest->Z = (rotationMatrix->m[0][Z] * vTmp.X + rotationMatrix->m[1][Z] * vTmp.Y + rotationMatrix->m[2][Z] * vTmp.Z);
+    vDest->X = (rotationMatrix[0][X] * vTmp.X + rotationMatrix[1][X] * vTmp.Y + rotationMatrix[2][X] * vTmp.Z);
+    vDest->Y = (rotationMatrix[0][Y] * vTmp.X + rotationMatrix[1][Y] * vTmp.Y + rotationMatrix[2][Y] * vTmp.Z);
+    vDest->Z = (rotationMatrix[0][Z] * vTmp.X + rotationMatrix[1][Z] * vTmp.Y + rotationMatrix[2][Z] * vTmp.Z);
+}
+
+void applyMatrixRotation(float *v, fp_rotationMatrix_t *rotationMatrix)
+{
+    applyMatrixRotationArray(v, rotationMatrix->m);
 }
 
 // Quick median filter implementation

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -118,6 +118,8 @@ int scaleRange(int x, int srcFrom, int srcTo, int destFrom, int destTo);
 float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float destTo);
 
 void buildRotationMatrix(fp_angles_t *delta, fp_rotationMatrix_t *rotation);
+void transposeMatrix3x3(float transposedMatrix[3][3], float matrix[3][3]);
+void applyMatrixRotationArray(float *v, float rotationMatrix[3][3]);
 void applyMatrixRotation(float *v, fp_rotationMatrix_t *rotationMatrix);
 
 int32_t quickMedianFilter3(int32_t * v);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -87,3 +87,5 @@ bool imuQuaternionHeadfreeOffsetSet(void);
 void imuQuaternionHeadfreeTransformVectorEarthToBody(t_fp_vector_def * v);
 bool shouldInitializeGPSHeading(void);
 bool isUpright(void);
+void vectorEarthToBody(float * v);
+void vectorBodyToEarth(float * v);

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -55,6 +55,8 @@ typedef struct acc_s {
     accDev_t dev;
     uint16_t sampleRateHz;
     float accADC[XYZ_AXIS_COUNT];
+    float accEarth[XYZ_AXIS_COUNT]; // in units of Gs, gravity substracted
+    float accMagnitudeEarthFrame; // in units of Gs, gravity substracted
     bool isAccelUpdatedAtLeastOnce;
 } acc_t;
 


### PR DESCRIPTION
A small PR of calculations for accelerometer readings in the ground coordinate system.
`float accEarth[XYZ_AXIS_COUNT]` - accelerations of the aircraft relative to the ground with correctly subtracted gravity in the aircraft frame.
Future benefits:

- Base for future sensor fusion of baro/GPS + accelerometer (`float accEarth[XYZ_AXIS_COUNT];`) - alt hold, pos hold, more accurate GPS rescue altitude estimations.
- `accMagnitudeEarthFrame` could be used for GPS rescue landing detection as it substracts G-force regardless of attitude.
- `accMagnitudeEarthFrame` could be used to detect if stats saving is safe, or drone is in crashing process.
- ...

new debug mode: GROUND_FRAME
0 -` accEarth[X] * 100.0`
1 - `accEarth[Y]  * 100.0`
2 - `accEarth[Z]  * 100.0`
3 - `accMagnitudeEarthFrame * 100.0`