### PR TITLE
Fix ESC-Sensor RPM

### DIFF
--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -161,12 +161,12 @@ void initDshotTelemetry(const timeUs_t looptimeUs)
     // erpmToHz is used by bidir dshot and ESC telemetry
     erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE / (motorConfig()->motorPoleCount / 2.0f);
 
-    // init LPFs for RPM data
-    for (int i = 0; i < getMotorCount(); i++) {
-        pt1FilterInit(&motorFreqLpf[i], pt1FilterGain(rpmFilterConfig()->rpm_filter_lpf_hz, looptimeUs * 1e-6f));
+    if (motorConfig()->dev.useDshotTelemetry) {
+        // init LPFs for RPM data
+        for (int i = 0; i < getMotorCount(); i++) {
+            pt1FilterInit(&motorFreqLpf[i], pt1FilterGain(rpmFilterConfig()->rpm_filter_lpf_hz, looptimeUs * 1e-6f));
+        }
     }
-
-    erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE / (motorConfig()->motorPoleCount / 2.0f);
 }
 
 static uint32_t dshot_decode_eRPM_telemetry_value(uint16_t value)

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -145,9 +145,7 @@ FAST_DATA_ZERO_INIT dshotTelemetryState_t dshotTelemetryState;
 FAST_DATA_ZERO_INIT static pt1Filter_t motorFreqLpf[MAX_SUPPORTED_MOTORS];
 FAST_DATA_ZERO_INIT static float motorFrequencyHz[MAX_SUPPORTED_MOTORS];
 FAST_DATA_ZERO_INIT static float minMotorFrequencyHz;
-#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
 FAST_DATA_ZERO_INIT static float erpmToHz;
-#endif
 FAST_DATA_ZERO_INIT static float dshotRpmAverage;
 FAST_DATA_ZERO_INIT static float dshotRpm[MAX_SUPPORTED_MOTORS];
 

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -145,7 +145,9 @@ FAST_DATA_ZERO_INIT dshotTelemetryState_t dshotTelemetryState;
 FAST_DATA_ZERO_INIT static pt1Filter_t motorFreqLpf[MAX_SUPPORTED_MOTORS];
 FAST_DATA_ZERO_INIT static float motorFrequencyHz[MAX_SUPPORTED_MOTORS];
 FAST_DATA_ZERO_INIT static float minMotorFrequencyHz;
+#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
 FAST_DATA_ZERO_INIT static float erpmToHz;
+#endif
 FAST_DATA_ZERO_INIT static float dshotRpmAverage;
 FAST_DATA_ZERO_INIT static float dshotRpm[MAX_SUPPORTED_MOTORS];
 
@@ -387,6 +389,12 @@ void dshotCleanTelemetryData(void)
 #endif // USE_DSHOT_TELEMETRY
 
 #if defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
+
+void initEscSensor(void) {
+    if (!motorConfig()->dev.useDshotTelemetry && featureIsEnabled(FEATURE_ESC_SENSOR)) {
+        erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE / (motorConfig()->motorPoleCount / 2.0f);
+    }
+}
 
 // Used with serial esc telem as well as dshot telem
 float erpmToRpm(uint32_t erpm)

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -154,9 +154,12 @@ FAST_DATA_ZERO_INIT static float dshotRpm[MAX_SUPPORTED_MOTORS];
 void initDshotTelemetry(const timeUs_t looptimeUs)
 {
     // if bidirectional DShot is not available
-    if (!motorConfig()->dev.useDshotTelemetry) {
+    if (!motorConfig()->dev.useDshotTelemetry && !featureIsEnabled(FEATURE_ESC_SENSOR)) {
         return;
     }
+
+    // erpmToHz is used by bidir dshot and ESC telemetry
+    erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE / (motorConfig()->motorPoleCount / 2.0f);
 
     // init LPFs for RPM data
     for (int i = 0; i < getMotorCount(); i++) {
@@ -389,12 +392,6 @@ void dshotCleanTelemetryData(void)
 #endif // USE_DSHOT_TELEMETRY
 
 #if defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
-
-void initEscSensor(void) {
-    if (!motorConfig()->dev.useDshotTelemetry && featureIsEnabled(FEATURE_ESC_SENSOR)) {
-        erpmToHz = ERPM_PER_LSB / SECONDS_PER_MINUTE / (motorConfig()->motorPoleCount / 2.0f);
-    }
-}
 
 // Used with serial esc telem as well as dshot telem
 float erpmToRpm(uint32_t erpm)

--- a/src/main/drivers/dshot.h
+++ b/src/main/drivers/dshot.h
@@ -120,8 +120,6 @@ void updateDshotTelemetryQuality(dshotTelemetryQuality_t *qualityStats, bool pac
 void initDshotTelemetry(const timeUs_t looptimeUs);
 void updateDshotTelemetry(void);
 
-void initEscSensor(void);
-
 uint16_t getDshotErpm(uint8_t motorIndex);
 float getDshotRpm(uint8_t motorIndex);
 float getDshotRpmAverage(void);

--- a/src/main/drivers/dshot.h
+++ b/src/main/drivers/dshot.h
@@ -120,6 +120,8 @@ void updateDshotTelemetryQuality(dshotTelemetryQuality_t *qualityStats, bool pac
 void initDshotTelemetry(const timeUs_t looptimeUs);
 void updateDshotTelemetry(void);
 
+void initEscSensor(void);
+
 uint16_t getDshotErpm(uint8_t motorIndex);
 float getDshotRpm(uint8_t motorIndex);
 float getDshotRpmAverage(void);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -694,7 +694,7 @@ void init(void)
     // Now reset the targetLooptime as it's possible for the validation to change the pid_process_denom
     gyroSetTargetLooptime(pidConfig()->pid_process_denom);
 
-#ifdef USE_DSHOT_TELEMETRY
+#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
     // Initialize the motor frequency filter now that we have a target looptime
     initDshotTelemetry(gyro.targetLooptime);
 #endif

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -694,10 +694,6 @@ void init(void)
     // Now reset the targetLooptime as it's possible for the validation to change the pid_process_denom
     gyroSetTargetLooptime(pidConfig()->pid_process_denom);
 
-#ifdef USE_ESC_SENSOR
-    initEscSensor();
-#endif
-
 #ifdef USE_DSHOT_TELEMETRY
     // Initialize the motor frequency filter now that we have a target looptime
     initDshotTelemetry(gyro.targetLooptime);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -694,6 +694,10 @@ void init(void)
     // Now reset the targetLooptime as it's possible for the validation to change the pid_process_denom
     gyroSetTargetLooptime(pidConfig()->pid_process_denom);
 
+#ifdef USE_ESC_SENSOR
+    initEscSensor();
+#endif
+
 #ifdef USE_DSHOT_TELEMETRY
     // Initialize the motor frequency filter now that we have a target looptime
     initDshotTelemetry(gyro.targetLooptime);


### PR DESCRIPTION
`erpmToHz` was not intialized for `ESC_SENSOR`.

Just a simple fix as we need to refactor this later on as `ESC_SENSOR` should not be dependent on `DSHOT` but seems it has been that for 5 years already

IDK if `ONESHOT` or `MULTISHOT` provides `ESC_SENSOR` telemetry in the first place.