### PR TITLE
Enable PINIO by default when available

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -281,6 +281,13 @@
 #define USE_LED_STRIP_STATUS_MODE
 #endif
 
+// Enable PINIO by default if defined
+#if defined(PINIO1_PIN) || defined(PINIO2_PIN) || defined(PINIO3_PIN) || defined(PINIO4_PIN)
+#ifndef USE_PINIO
+#define USE_PINIO
+#endif
+#endif
+
 #if defined(USE_PINIO)
 #define USE_PINIOBOX
 #define USE_PIN_PULL_UP_DOWN


### PR DESCRIPTION
Fixes #13288

Needs further investigation into the root cause.

Alternative is to add this to config.h