### PR TITLE
Do not arm above configurable threshold

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -172,6 +172,10 @@
 
 #include "telemetry/telemetry.h"
 
+#ifndef CPU_OVERLOAD_THRESHOLD
+#define CPU_OVERLOAD_THRESHOLD 50
+#endif
+
 #ifdef USE_HARDWARE_REVISION_DETECTION
 #include "hardware_revision.h"
 #endif
@@ -973,6 +977,10 @@ void init(void)
         telemetryInit();
     }
 #endif
+
+    if (getAverageSystemLoadPercent() > CPU_OVERLOAD_THRESHOLD) {
+        setArmingDisabled(ARMING_DISABLED_CPU_OVERLOAD);
+    }
 
     setArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
 

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -59,6 +59,7 @@ const char *armingDisableFlagNames[]= {
     "DSHOT_BBANG",
     "NO_ACC_CAL",
     "MOTOR_PROTO",
+    "CPU_OVERLOAD",
     "ARMSWITCH",
 };
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -65,7 +65,8 @@ typedef enum {
     ARMING_DISABLED_DSHOT_BITBANG   = (1 << 22),
     ARMING_DISABLED_ACC_CALIBRATION = (1 << 23),
     ARMING_DISABLED_MOTOR_PROTOCOL  = (1 << 24),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 25), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_CPU_OVERLOAD    = (1 << 25),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 26), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
 #define ARMING_DISABLE_FLAGS_COUNT (LOG2(ARMING_DISABLED_ARM_SWITCH) + 1)


### PR DESCRIPTION
Fixes #13290 where the quad did not disarm on user command.

In general it is our responsibility that users can fly safely.

Not sure how we should approach this issue but we need to provide safety first. We should set a safe value where advanced users can override this setting. Limiting 4K loop on F7X2 might be an alternative solution.

We must ensure that disarmament works promptly at every opportunity. That is the mean reason for this proposal.

Further investigation will be required to find the root cause.

See also
- #13292
- #13249
- #11222
