### PR TITLE
Do not permit MSP on softserial ports as the load on the CPU is too great

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -229,7 +229,7 @@ static void validateAndFixConfig(void)
     }
 #endif
 
-    if (!isSerialConfigValid(serialConfig())) {
+    if (!isSerialConfigValid(serialConfigMutable())) {
         pgResetFn_serialConfig(serialConfigMutable());
     }
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -28,6 +28,7 @@
 
 #include "cli/cli.h"
 
+#include "common/maths.h"
 #include "common/utils.h"
 
 #include "drivers/time.h"
@@ -324,9 +325,8 @@ serialPort_t *findSharedSerialPort(uint16_t functionMask, serialPortFunction_e s
 #define ALL_FUNCTIONS_SHARABLE_WITH_MSP (FUNCTION_BLACKBOX | FUNCTION_VTX_MSP)
 #endif
 
-bool isSerialConfigValid(const serialConfig_t *serialConfigToCheck)
+bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
 {
-    UNUSED(serialConfigToCheck);
     /*
      * rules:
      * - 1 MSP port minimum, max MSP ports is defined and must be adhered to.
@@ -340,6 +340,19 @@ bool isSerialConfigValid(const serialConfig_t *serialConfigToCheck)
 
     for (int index = 0; index < SERIAL_PORT_COUNT; index++) {
         const serialPortConfig_t *portConfig = &serialConfigToCheck->portConfigs[index];
+
+#ifdef USE_SOFTSERIAL
+        if ((portConfig->identifier == SERIAL_PORT_SOFTSERIAL1) ||
+            (portConfig->identifier == SERIAL_PORT_SOFTSERIAL2)) {
+            // Ensure MSP or serial RX is not enabled on soft serial ports
+            serialConfigToCheck->portConfigs[index].functionMask &= ~(FUNCTION_MSP | FUNCTION_RX_SERIAL);
+
+            // Ensure that the baud rate on soft serial ports is limited to 19200
+            serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
+            serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
+            serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_19200);
+        }
+#endif
 
         if (portConfig->functionMask & FUNCTION_MSP) {
             mspPortCount++;
@@ -422,6 +435,13 @@ serialPort_t *openSerialPort(
     }
 
     serialPort_t *serialPort = NULL;
+
+#ifdef USE_SOFTSERIAL
+    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 19200)) {
+        // Limit baud rate on soft serial ports
+        baudRate = 19200;
+    }
+#endif
 
     switch (identifier) {
 #ifdef USE_VCP

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -157,7 +157,7 @@ void serialInit(bool softserialEnabled, serialPortIdentifier_e serialPortToDisab
 void serialRemovePort(serialPortIdentifier_e identifier);
 uint8_t serialGetAvailablePortCount(void);
 bool serialIsPortAvailable(serialPortIdentifier_e identifier);
-bool isSerialConfigValid(const serialConfig_t *serialConfig);
+bool isSerialConfigValid(serialConfig_t *serialConfig);
 const serialPortConfig_t *serialFindPortConfiguration(serialPortIdentifier_e identifier);
 serialPortConfig_t *serialFindPortConfigurationMutable(serialPortIdentifier_e identifier);
 bool doesConfigurationUsePort(serialPortIdentifier_e portIdentifier);


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/13290

This prevents a soft serial port being used for MSP or serial RX, and also limits the baud rate to 19200.

@GSfpv please test. I appreciate that this disables part of the config you were using, but please confirm this prevents the disarm delay.
