### PR TITLE
Make high rate IMU DcmKp change relative to user value

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -174,8 +174,8 @@ static float calculateThrottleAngleScale(uint16_t throttle_correction_angle)
 
 void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correction_value)
 {
+    // current default for imu_dcm_kp is 2500; our 'normal' or baseline value for imuDcmKp is 0.25
     imuRuntimeConfig.imuDcmKp = imuConfig()->imu_dcm_kp / 10000.0f;
-    // current default for imu_dcm_kp is 2500, so this returns a base value for imuDcmKp of 0.25
     imuRuntimeConfig.imuDcmKi = imuConfig()->imu_dcm_ki / 10000.0f;
     // magnetic declination has negative sign (positive clockwise when seen from top)
     const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination / 10.0f);


### PR DESCRIPTION
It was noted in [issue 11894](https://github.com/betaflight/betaflight/issues/11894), using 4.4, that if `imu_dcm_kp` was set to a low value, the BMI270 gyro could be seen to be inadequately calibrated.

The issue arises when the FC is rotated at speeds above 15deg/s, during which time the IMU estimate of angular change comes from the integral of the gyro data.  Once the rotation falls below 15 deg/s, the flight controller will favour the Acc values.  The rate of the transition to Acc from gyro estimates is set by the `imu_dcm_kp` value, which defaults to 2500.

If the calibration constant of the gyro is good, then there will be no offset when the FC is returned to its original position after a fast move (so long as the fast move does not exceed 2000 deg/s).

The user showed that when the `imu_dcm_kp` value was set very low, eg 50, an FC with a BMI270 would develop and hold an offset in attitude for some time after being returned to the original position after a quick rotation.

I have confirmed this myself, but noted that in 4.5 we made it so that there was a fast re-orientation phase immediately after the rotation rate falls below 15deg/s.  This used a dcmKp value 100 times greater than default, but expressed as a constant.

The only problem is that now even if the user was to lower `imu_dcm_kp` to 50, they would still get this very rapid initial return to using the accelerometer value, hiding the issue with the BMI270 gyro.  What happens is that after a quick rotation and return to 'normal' position, there is a kind of offset, but only briefly, which quickly corrects.

This PR makes the rapid correction phase to 100x their `imu_dcm_kp` value.  This will be the same as normal with default values.

However if the user sets the `imu_dcm_kp` value to 1, or zero, they will now see sustained offsets due to BMI270 calibration errors.

As an aside, it seems that iNav have a method for writing custom cal factors to a BMI270 in an attempt to make it work better in level modes.  For us the biggest problem would be for fast whoop racing in level, or level race modes, or in Horizon mode, where flips and rolls are possible.