### PR TITLE
Move USE_SOFTSERIAL to build options

### DIFF
--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -38,9 +38,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -34,9 +34,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32F446/target.h
+++ b/src/main/target/STM32F446/target.h
@@ -35,9 +35,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2
@@ -74,8 +76,6 @@
 #define USE_SPI_DMA_ENABLE_EARLY
 
 #define USE_USB_DETECT
-
-#define USE_ESCSERIAL
 
 #define USE_ADC
 

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -39,9 +39,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -34,9 +34,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -35,9 +35,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32H723/target.h
+++ b/src/main/target/STM32H723/target.h
@@ -54,9 +54,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32H725/target.h
+++ b/src/main/target/STM32H725/target.h
@@ -83,9 +83,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_USB_DETECT
 

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -35,9 +35,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -68,9 +68,11 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL
-
+#ifdef USE_SOFTSERIAL
 #define UNIFIED_SERIAL_PORT_COUNT       3
+#else
+#define UNIFIED_SERIAL_PORT_COUNT       1
+#endif
 
 #define USE_UART1
 #define USE_UART2


### PR DESCRIPTION
- SoftSerial uses lots of computation as #13303 will limit it's use
- Any MCU F7 or above would deploy enough pads in the first place. Reducing non optimal code in the progress as we phase out support for F4 gradually.
- Users will still be able to add `SOFTSERIAL` using cloud build API.
- Needs `#define BUILD_OPTION_SOFTSERIAL 16422` available in cloud build options.
