### PR TITLE
Possible solution OSD Canvas issue

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -422,12 +422,12 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->aux_symbol = 'A';
 
     // Make it obvious on the configurator that the FC doesn't support HD
-#ifdef USE_OSD_HD
-    osdConfig->canvas_cols = OSD_HD_COLS;
-    osdConfig->canvas_rows = OSD_HD_ROWS;
-#else
+#ifdef USE_OSD_SD
     osdConfig->canvas_cols = OSD_SD_COLS;
     osdConfig->canvas_rows = OSD_SD_ROWS;
+#else
+    osdConfig->canvas_cols = OSD_HD_COLS;
+    osdConfig->canvas_rows = OSD_HD_ROWS;
 #endif
 
 #ifdef USE_OSD_QUICK_MENU


### PR DESCRIPTION
Fixes #13301 possible solution to issue where osdConfig values would always be assigned default OSD_HD values, regardless on the OSD_SD values. Have not tested this.
