### PR TITLE
Enable MSP DP for HD

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -896,8 +896,12 @@ void init(void)
         switch(device) {
 
         case OSD_DISPLAYPORT_DEVICE_AUTO:
+#if defined(USE_OSD_HD) && !defined(USE_OSD_SD)
+            device = OSD_DISPLAYPORT_DEVICE_MSP;
+            // User has to configure port for MSP DisplayPort
+            osdConfigMutable()->displayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
+#endif
             FALLTHROUGH;
-
 #if defined(USE_FRSKYOSD)
         // Test OSD_DISPLAYPORT_DEVICE_FRSKYOSD first, since an FC could
         // have a builtin MAX7456 but also an FRSKYOSD connected to an

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -213,8 +213,8 @@ displayPort_t *displayPortMspInit(void)
 #endif
 
     if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
-        mspDisplayPort.rows = osdConfig()->canvas_rows;
-        mspDisplayPort.cols = osdConfig()->canvas_cols;
+        mspDisplayPort.rows = OSD_HD_ROWS;
+        mspDisplayPort.cols = OSD_HD_COLS;
     } else {
         const uint8_t displayRows = (vcdProfile()->video_system == VIDEO_SYSTEM_PAL) ? VIDEO_LINES_PAL : VIDEO_LINES_NTSC;
         mspDisplayPort.rows = displayRows + displayPortProfileMsp()->rowAdjust;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4178,15 +4178,25 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                 if (video_system == VIDEO_SYSTEM_HD) {
                     video_system = VIDEO_SYSTEM_AUTO;
                 }
-#endif
-
+#else
                 if ((video_system == VIDEO_SYSTEM_HD) && (vcdProfile()->video_system != VIDEO_SYSTEM_HD)) {
                     // If switching to HD, don't wait for the VTX to communicate the correct resolution, just
                     // increase the canvas size to the HD default as that is what the user will expect
                     osdConfigMutable()->canvas_cols = OSD_HD_COLS;
                     osdConfigMutable()->canvas_rows = OSD_HD_ROWS;
-                }
 
+                    if (osdConfig()->displayPortDevice != OSD_DISPLAYPORT_DEVICE_MSP) {
+                        osdConfigMutable()->displayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
+                    }
+                }
+#endif
+#ifdef USE_OSD_SD
+                if ((video_system != VIDEO_SYSTEM_HD) && (vcdProfile()->video_system == VIDEO_SYSTEM_HD)) {
+                    // Switching back to SD
+                    osdConfigMutable()->canvas_cols = OSD_SD_COLS;
+                    osdConfigMutable()->canvas_rows = OSD_SD_ROWS;
+                }
+#endif
                 vcdProfileMutable()->video_system = video_system;
 
                 osdConfigMutable()->units = sbufReadU8(src);


### PR DESCRIPTION
- [msp] Somehow DP did not get enabled upon switching. This PR seems to solve that.
- [init] Sets DP to MSP when only OSD_HD is defined.
- Switching seems a real pain with centering items
- Recommended to use only OSD_SD or OSD_HD.
