### PR TITLE
Enable clang-14 on Linux for tests

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4250,7 +4250,6 @@ static void cliDefaults(const char *cmdName, char *cmdline)
 
     char *saveptr;
     char* tok = strtok_r(cmdline, " ", &saveptr);
-    int index = 0;
     bool expectParameterGroupId = false;
     while (tok != NULL) {
         if (expectParameterGroupId) {
@@ -4271,7 +4270,6 @@ static void cliDefaults(const char *cmdName, char *cmdline)
             return;
         }
 
-        index++;
         tok = strtok_r(NULL, " ", &saveptr);
     }
 

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -329,8 +329,6 @@ void hottPrepareEAMResponse(HOTT_EAM_MSG_t *hottEAMMessage)
 
 static void hottSerialWrite(uint8_t c)
 {
-    static uint8_t serialWrites = 0;
-    serialWrites++;
     serialWrite(hottPort, c);
 }
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -483,15 +483,11 @@ GTEST_DIR = ../../lib/test/gtest
 
 CC  := clang-12
 CXX := clang++-12
-ifneq ($(OSFAMILY), linux)
 ifeq ($(shell which $(CC) 2>/dev/null),)
-$(info Falling back to 'clang' on Windows and OSX.)
+$(info Falling back to 'clang'.)
 CC  := clang
 CXX := clang++
 endif
-endif
-#CC  := gcc
-#CXX := g++
 
 # These flags are needed for clang > 10 (linux / MacOS) to make test work:
 # -Wno-c99-extensions
@@ -523,8 +519,8 @@ CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
 CC_VERSION_CHECK_MIN := 7
 CC_VERSION_CHECK_MAX := 14
 
-# Added flags for clang 11 - 13 are not backwards compatible
-ifeq ($(shell expr $(CC_VERSION_MAJOR) \> 10 \& $(CC_VERSION_MAJOR) \< 14), 1)
+# Added flags for clang 11 - 14 are not backwards compatible
+ifeq ($(shell expr $(CC_VERSION_MAJOR) \> 10 \& $(CC_VERSION_MAJOR) \< 15), 1)
 COMMON_FLAGS += \
 	-fcommon \
 	-Wno-void-pointer-to-int-cast

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -517,10 +517,10 @@ ifeq ($(shell $(CC) -v 2>&1 | grep -q "clang version" && echo "clang"),clang)
 # Travis reports CC_VERSION of 4.2.1
 CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
 CC_VERSION_CHECK_MIN := 7
-CC_VERSION_CHECK_MAX := 14
+CC_VERSION_CHECK_MAX := 15
 
 # Added flags for clang 11 - 14 are not backwards compatible
-ifeq ($(shell expr $(CC_VERSION_MAJOR) \> 10 \& $(CC_VERSION_MAJOR) \< 15), 1)
+ifeq ($(shell expr $(CC_VERSION_MAJOR) \> 10 \& $(CC_VERSION_MAJOR) \< 16), 1)
 COMMON_FLAGS += \
 	-fcommon \
 	-Wno-void-pointer-to-int-cast


### PR DESCRIPTION
Current Linux distributions such as Debian 12
ship clang-14. This commit enables ```make test``` to run with clang-14 (alias to clang).

