### PR TITLE
Added dedicated xtal support for ICM-42688

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -59,6 +59,8 @@
 #define ICM426XX_INTF_CONFIG1                       0x4D
 #define ICM426XX_INTF_CONFIG1_AFSR_MASK             0xC0
 #define ICM426XX_INTF_CONFIG1_AFSR_DISABLE          0x40
+#define ICM426XX_INTF_CONFIG5                       0x7B
+#define ICM426XX_INTF_CONFIG5_CLKIN                 0x04
 
 #define ICM426XX_RA_PWR_MGMT0                       0x4E  // User Bank 0
 #define ICM426XX_PWR_MGMT0_ACCEL_MODE_LN            (3 << 0)
@@ -285,6 +287,10 @@ void icm426xxGyroInit(gyroDev_t *gyro)
     intfConfig1Value |= ICM426XX_INTF_CONFIG1_AFSR_DISABLE;
     spiWriteReg(dev, ICM426XX_INTF_CONFIG1, intfConfig1Value);
 
+    // If an external 32.768kHz crystal oscillator is connector, enable it as the timing
+    // source: PIN9_FUNCTION = CLKIN
+    uint8_t intfConfig5Value = spiReadRegMsk(dev, ICM426XX_INTF_CONFIG5);
+    intfConfig1Value |= ICM426XX_INTF_CONFIG5_CLKIN;
 
     // Turn on gyro and acc on again so ODR and FSR can be configured
     turnGyroAccOn(dev);


### PR DESCRIPTION
The ICM42688 can be configured with a dedicated 32.768kHz timing crystal, connected to pin 9:

![image](https://github.com/betaflight/betaflight/assets/4590796/67d1fd85-3115-40f7-ad50-a441ec4ce83b)

Datasheet, section 4.10:

> 4.10 CLOCKING
"The ICM-42688-P has a flexible clocking scheme, allowing external or internal clock sources to be used for the internal synchronous
circuitry. This synchronous circuitry includes the signal conditioning and ADCs, and various control circuits and registers.
The CLKIN pin on ICM-42688-P provides the ability to input an external clock. A highly accurate external clock may be used rather
than the internal clocks sources, if greater clock accuracy is desired. External clock input supports highly accurate clock input from
31kHz to 50kHz, resulting in improvement of the following:
a) ODR uncertainty due to process, temperature, operating mode (PLL vs. RCOSC), and design limitations. This uncertainty can
be as high as ±8% in RCOSC mode and ±1% in PLL mode. The CLKIN, assuming a 50ppm or better 32.768kHz source, will
improve the ODR accuracy from ±80,000ppm to ±50ppm in RCOSC mode, or from ±10,000ppm to ±50ppm in PLL mode.
b) System level sensitivity error. Any clock uncertainty directly impacts gyroscope sensitivity at the system level.
Sophisticated systems can estimate ODR inaccuracy to some extent, but not to the extent improved by using CLKIN.
c) System-level clock/sensor synchronization. When using CLKIN, the accelerometer and gyroscope are on the same clock as
the host. There is no need to continually re-synchronize the sensor data as the sensor sample points and period are known
to be in exact alignment with the common system clock.
d) CLKIN helps EIS (Electronic Image Stabilization) performance by providing:
o
Very accurate gyroscope sample points for use during integration to find true angular displacement.
o
Automatic time alignment between the motion sensor and the host and potentially the camera system.
e) Other applications that benefit from CLKIN include navigation, gaming, robotics.
Allowable internal sources for generating the internal clock are:
a) An internal relaxation oscillator
b) Auto-select between internal relaxation oscillator and gyroscope MEMS oscillator to use the best available source
For internal sources, the only setting supporting specified performance in all modes is option b). It is recommended that option b)
be used when using internal clock source."

Draft; standby testing, and it's likely I made one or more errors, as I'm a bit rusty on C and the BF codebase.