### PR TITLE
Fix OSD defaults based on SD/HD

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -891,7 +891,13 @@ void init(void)
     //The OSD need to be initialised after GYRO to avoid GYRO initialisation failure on some targets
 
     if (featureIsEnabled(FEATURE_OSD)) {
-        osdDisplayPortDevice_e device = osdConfig()->displayPortDevice;
+        osdDisplayPortDevice_e device;
+
+        if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
+            device = OSD_DISPLAYPORT_DEVICE_MSP;
+        } else {
+            device = osdConfig()->displayPortDevice;
+        }
 
         switch(device) {
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -401,8 +401,6 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
         osdConfig->rcChannels[i] = -1;
     }
 
-    osdConfig->displayPortDevice = OSD_DISPLAYPORT_DEVICE_AUTO;
-
     osdConfig->distance_alarm = 0;
     osdConfig->logo_on_arming = OSD_LOGO_ARMING_OFF;
     osdConfig->logo_on_arming_duration = 5;  // 0.5 seconds
@@ -423,9 +421,11 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 
     // Make it obvious on the configurator that the FC doesn't support HD
 #ifdef USE_OSD_HD
+    osdConfig->displayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
     osdConfig->canvas_cols = OSD_HD_COLS;
     osdConfig->canvas_rows = OSD_HD_ROWS;
 #else
+    osdConfig->displayPortDevice = OSD_DISPLAYPORT_DEVICE_AUTO;
     osdConfig->canvas_cols = OSD_SD_COLS;
     osdConfig->canvas_rows = OSD_SD_ROWS;
 #endif

--- a/src/main/pg/vcd.c
+++ b/src/main/pg/vcd.c
@@ -23,7 +23,20 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
+#include "drivers/osd.h"
+
 #include "vcd.h"
 
 // no template required since defaults are zero
-PG_REGISTER(vcdProfile_t, vcdProfile, PG_VCD_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(vcdProfile_t, vcdProfile, PG_VCD_CONFIG, 0);
+
+void pgResetFn_vcdProfile(vcdProfile_t *vcdProfile)
+{
+    // Make it obvious on the configurator that the FC doesn't support HD
+#ifdef USE_OSD_HD
+    vcdProfile->video_system = VIDEO_SYSTEM_HD;
+#else
+    vcdProfile->video_system = VIDEO_SYSTEM_AUTO;
+#endif
+
+}


### PR DESCRIPTION
If USE_OSD_HD only is defined:

```
vcd_video_system = HD
osd_displayport_device = MSP
osd_canvas_width = 53
osd_canvas_height = 20
```

If USE_OSD_SD only is defined based on automatic NTSC/PAL detection:

```
vcd_video_system = AUTO
osd_displayport_device = AUTO
osd_canvas_width = 30
osd_canvas_height = 13 or 16
```
