### PR TITLE
Do not return MSP_RESULT_ERROR when succesful

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4259,11 +4259,9 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                 // Timers
                 uint8_t index = sbufReadU8(src);
                 if (index > OSD_TIMER_COUNT) {
-                  return MSP_RESULT_ERROR;
+                    return MSP_RESULT_ERROR;
                 }
                 osdConfigMutable()->timers[index] = sbufReadU16(src);
-
-                return MSP_RESULT_ERROR;
             } else {
                 const uint16_t value = sbufReadU16(src);
 
@@ -4278,7 +4276,7 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
                     osdElementConfigMutable()->item_pos[addr] = value;
                     osdAnalyzeActiveElements();
                 } else {
-                  return MSP_RESULT_ERROR;
+                    return MSP_RESULT_ERROR;
                 }
             }
         }


### PR DESCRIPTION
`EXIT_SUCCESS` would be better.

Saw this issue while troubleshooting reboot into DFU issue on a H7.

To reproduce unsupported message error - change timer settings in OSD tab and save.