### PR TITLE
Use cpu_late_10ths_percent_limit to set limit on % of late tasks in 10th of a %

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1721,7 +1721,7 @@ const clivalue_t valueTable[] = {
     { "scheduler_relax_osd", VAR_UINT16  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_SCHEDULER_CONFIG, PG_ARRAY_ELEMENT_OFFSET(schedulerConfig_t, 0, osdRelaxDeterminism) },
 
 #ifdef USE_LATE_TASK_STATISTICS
-    { "cpu_late_10ths_percent_limit", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_SCHEDULER_CONFIG, offsetof(schedulerConfig_t, cpuLatePercentageLimit) },
+    { "cpu_late_limit_permille", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_SCHEDULER_CONFIG, offsetof(schedulerConfig_t, cpuLatePercentageLimit) },
 #endif
 
     { "serialmsp_halfduplex", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MSP_CONFIG, offsetof(mspConfig_t, halfDuplex) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1720,6 +1720,10 @@ const clivalue_t valueTable[] = {
     { "scheduler_relax_rx",  VAR_UINT16  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_SCHEDULER_CONFIG, PG_ARRAY_ELEMENT_OFFSET(schedulerConfig_t, 0, rxRelaxDeterminism) },
     { "scheduler_relax_osd", VAR_UINT16  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_SCHEDULER_CONFIG, PG_ARRAY_ELEMENT_OFFSET(schedulerConfig_t, 0, osdRelaxDeterminism) },
 
+#ifdef USE_LATE_TASK_STATISTICS
+    { "cpu_late_10ths_percent_limit", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_SCHEDULER_CONFIG, offsetof(schedulerConfig_t, cpuLatePercentageLimit) },
+#endif
+
     { "serialmsp_halfduplex", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MSP_CONFIG, offsetof(mspConfig_t, halfDuplex) },
 
 // PG_TIMECONFIG

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -323,11 +323,13 @@ void updateArmingStatus(void)
             unsetArmingDisabled(ARMING_DISABLED_ANGLE);
         }
 
-        if (getAverageSystemLoadPercent() > LOAD_PERCENTAGE_ONE) {
+#if defined(USE_LATE_TASK_STATISTICS)
+        if ((getCPUPercentageLate() > schedulerConfig()->cpuLatePercentageLimit)) {
             setArmingDisabled(ARMING_DISABLED_LOAD);
         } else {
             unsetArmingDisabled(ARMING_DISABLED_LOAD);
         }
+#endif // USE_LATE_TASK_STATISTICS
 
         if (isCalibrating()) {
             setArmingDisabled(ARMING_DISABLED_CALIBRATING);

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -324,7 +324,7 @@ void updateArmingStatus(void)
         }
 
 #if defined(USE_LATE_TASK_STATISTICS)
-        if ((getCPUPercentageLate() > schedulerConfig()->cpuLatePercentageLimit)) {
+        if ((getCpuPercentageLate() > schedulerConfig()->cpuLatePercentageLimit)) {
             setArmingDisabled(ARMING_DISABLED_LOAD);
         } else {
             unsetArmingDisabled(ARMING_DISABLED_LOAD);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -281,6 +281,7 @@ typedef enum {
     OSD_WARNING_RSSI_DBM,
     OSD_WARNING_OVER_CAP,
     OSD_WARNING_RSNR,
+    OSD_WARNING_LOAD,
     OSD_WARNING_COUNT // MUST BE LAST
 } osdWarningsFlags_e;
 

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -213,6 +213,13 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         return;
     }
 
+    if (osdWarnGetState(OSD_WARNING_LOAD) && (getArmingDisableFlags() & ARMING_DISABLED_LOAD)) {
+        tfp_sprintf(warningText, "CPU OVERLOAD");
+        *displayAttr = DISPLAYPORT_SEVERITY_CRITICAL;
+        *blinking = true;
+        return;
+    }
+
 #ifdef USE_GPS_RESCUE
     if (osdWarnGetState(OSD_WARNING_GPS_RESCUE_UNAVAILABLE) &&
        ARMING_FLAG(ARMED) &&

--- a/src/main/pg/scheduler.c
+++ b/src/main/pg/scheduler.c
@@ -23,9 +23,10 @@
 #include "pg/pg_ids.h"
 #include "pg/scheduler.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig, PG_SCHEDULER_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig, PG_SCHEDULER_CONFIG, 1);
 
 PG_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig,
     .rxRelaxDeterminism = SCHEDULER_RELAX_RX,
     .osdRelaxDeterminism = SCHEDULER_RELAX_OSD,
+    .cpuLatePercentageLimit = CPU_LOAD_LATE_LIMIT
 );

--- a/src/main/pg/scheduler.h
+++ b/src/main/pg/scheduler.h
@@ -31,9 +31,13 @@
 #define SCHEDULER_RELAX_OSD 25
 #endif
 
+// Tenths of a % of tasks late
+#define CPU_LOAD_LATE_LIMIT 10
+
 typedef struct schedulerConfig_s {
     uint16_t rxRelaxDeterminism;
     uint16_t osdRelaxDeterminism;
+    uint16_t cpuLatePercentageLimit;
 } schedulerConfig_t;
 
 PG_DECLARE(schedulerConfig_t, schedulerConfig);

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -69,6 +69,7 @@
 // 1 - Tasks late in last second
 // 2 - Total lateness in last second in 10ths us
 // 3 - Total tasks run in last second
+// 4 - 10ths % of tasks late in last second
 
 extern task_t tasks[];
 
@@ -107,6 +108,7 @@ static uint8_t skippedOSDAttempts = 0;
 static int16_t lateTaskCount = 0;
 static uint32_t lateTaskTotal = 0;
 static int16_t taskCount = 0;
+static uint32_t lateTaskPercentage = 0;
 static uint32_t nextTimingCycles;
 #endif
 
@@ -196,6 +198,15 @@ void taskSystemLoad(timeUs_t currentTimeUs)
 
 #if defined(SIMULATOR_BUILD)
     averageSystemLoadPercent = 0;
+#endif
+}
+
+uint32_t getCPUPercentageLate(void)
+{
+#if defined(USE_LATE_TASK_STATISTICS)
+    return lateTaskPercentage;
+#else
+    return 0;
 #endif
 }
 
@@ -534,6 +545,10 @@ FAST_CODE void scheduler(void)
                 DEBUG_SET(DEBUG_TIMING_ACCURACY, 2, clockCyclesTo10thMicros(lateTaskTotal));
                 // Total tasks run in last second
                 DEBUG_SET(DEBUG_TIMING_ACCURACY, 3, taskCount);
+
+                lateTaskPercentage = 1000 * (uint32_t)lateTaskCount / taskCount;
+                // 10ths % of tasks late in last second
+                DEBUG_SET(DEBUG_TIMING_ACCURACY, 4, lateTaskPercentage);
 
                 lateTaskCount = 0;
                 lateTaskTotal = 0;

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -201,7 +201,7 @@ void taskSystemLoad(timeUs_t currentTimeUs)
 #endif
 }
 
-uint32_t getCPUPercentageLate(void)
+uint32_t getCpuPercentageLate(void)
 {
 #if defined(USE_LATE_TASK_STATISTICS)
     return lateTaskPercentage;

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -243,7 +243,7 @@ void schedulerInit(void);
 void scheduler(void);
 timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTimeUs);
 void taskSystemLoad(timeUs_t currentTimeUs);
-uint32_t getCPUPercentageLate(void);
+uint32_t getCpuPercentageLate(void);
 void schedulerEnableGyro(void);
 uint16_t getAverageSystemLoadPercent(void);
 float schedulerGetCycleTimeMultiplier(void);

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -243,6 +243,7 @@ void schedulerInit(void);
 void scheduler(void);
 timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTimeUs);
 void taskSystemLoad(timeUs_t currentTimeUs);
+uint32_t getCPUPercentageLate(void);
 void schedulerEnableGyro(void);
 uint16_t getAverageSystemLoadPercent(void);
 float schedulerGetCycleTimeMultiplier(void);

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1161,4 +1161,5 @@ extern "C" {
         return 0.0f;
     }
     void getRcDeflectionAbs(void) {}
+    uint32_t getCPUPercentageLate(void) { return 0; };
 }

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1161,5 +1161,5 @@ extern "C" {
         return 0.0f;
     }
     void getRcDeflectionAbs(void) {}
-    uint32_t getCPUPercentageLate(void) { return 0; };
+    uint32_t getCpuPercentageLate(void) { return 0; };
 }


### PR DESCRIPTION
This PR introduces a `cpu_late_percent_limit` setting which gives the % of tasks which may be late (in 10ths of a percent) before setting the `ARMING_DISABLED_LOAD` flag.

@limonspb @ctzsnooze Please test using `TIMING_ACCURACY` debug to determine what you consider to be an unacceptable % of late tasks. We'll then adjust the value of `SCHEDULER_LATE_LIMIT`.

To test set `cpu_late_percent_limit = 1`. This says that any more than 0.1% of tasks being late should signal an overload. The default is 5%. You should then see regular LOAD flags on the setup tab and `CPU OVERLOAD` as an OSD warning.