### PR TITLE
Install linux tools for appropriate architecture

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -31,7 +31,7 @@ arm_sdk_version:
 ARM_SDK_URL_BASE  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10
 # source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifeq ($(OSFAMILY), linux)
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-x86_64-linux.tar.bz2
+  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-$(shell uname -m)-linux.tar.bz2
 endif
 
 ifeq ($(OSFAMILY), macosx)


### PR DESCRIPTION
Prior to this PR linux was assumed to run on the Intel `x86_64` architecture. This PR uses a `uname -m` shell command to determine the correct architecture and then will, for example, use the `aarch64` architecture on Linux running in a VM on Apple silicon, such as Ubuntu Linux installed using Parallels.

To build Betaflight using such a VM the following commands will now need to be issued.

```
$ make arm_sdk_install
$ sudo apt-get install clang-12 libblocksruntime-dev
$ make all
```