### PR TITLE
Fix unit test build under aarch64 Linux

### DIFF
--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -150,7 +150,7 @@ CMS_Menu cmsx_menuMain = {
 };
 uint8_t armingFlags;
 int16_t debug[4];
-int16_t rcData[18];
+float rcData[18];
 void delay(uint32_t) {}
 uint32_t micros(void) { return 0; }
 uint32_t millis(void) { return 0; }


### PR DESCRIPTION
This PR fixes the following error when build using `aarch64` Linux caused by the definition of `rcData` to be a `int16_t` rather than a `float`.

```
compiling unit/cms_unittest.cc
linking ../../obj/test/cms_unittest/cms_unittest
../../obj/test/cms_unittest/cms/cms.c.o: in function `cmsScanKeys':
/home/parallels/Documents/betaflight/src/test/../main/cms/cms.c:1412:(.text+0x2ab0): relocation truncated to fit: R_AARCH64_LDST32_ABS_LO12_NC against symbol `rcData' defined in .bss section in ../../obj/test/cms_unittest/cms_unittest.o
/usr/bin/ld: /home/parallels/Documents/betaflight/src/test/../main/cms/cms.c:1412: warning: one possible cause of this error is that the symbol is being referenced in the indicated code as if it had a larger alignment than was declared where it was defined
/home/parallels/Documents/betaflight/src/test/../main/cms/cms.c:1414:(.text+0x2ae8): relocation truncated to fit: R_AARCH64_LDST32_ABS_LO12_NC against symbol `rcData' defined in .bss section in ../../obj/test/cms_unittest/cms_unittest.o
/usr/bin/ld: /home/parallels/Documents/betaflight/src/test/../main/cms/cms.c:1414: warning: one possible cause of this error is that the symbol is being referenced in the indicated code as if it had a larger alignment than was declared where it was defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:786: ../../obj/test/cms_unittest/cms_unittest] Error 1
make[1]: Leaving directory '/home/parallels/Documents/betaflight/src/test'
make: *** [Makefile:643: test] Error 2
```