### PR TITLE
 TPA_Low refactor, saves 30bytes and is simpler

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -281,10 +281,10 @@ void pidUpdateTpaFactor(float throttle)
     // don't permit throttle > 1 & throttle < 0 ? is this needed ? can throttle be > 1 or < 0 at this point
     throttle = constrainf(throttle, 0.0f, 1.0f);
 
-    const bool tpaLowInactive = (pidRuntime.tpaLowDisabled || (throttle >= pidRuntime.tpaLowBreakpoint));
+    const bool tpaLowInactive = pidRuntime.tpaLowDisabled || (throttle >= pidRuntime.tpaLowBreakpoint);
     float tpaRate = 0.0f;
     if (tpaLowInactive) {
-        // to get here, throttle exceeded the tpaLow threshold
+        // to get here, throttle exceeded the tpaLow threshold, or tpaLowBreakpoint set < PWM_RANGE_MIN + 10
         // disable when not configured to be always on 
         pidRuntime.tpaLowDisabled = pidRuntime.tpaLowDisabled || !pidRuntime.tpaLowAlways;
         // apply normal TPA

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -278,17 +278,15 @@ void pidResetIterm(void)
 
 void pidUpdateTpaFactor(float throttle)
 {
-    // always allow TPA low on arming
-    static bool isTpaLowFaded = false;
     // don't permit throttle > 1 & throttle < 0 ? is this needed ? can throttle be > 1 or < 0 at this point
     throttle = constrainf(throttle, 0.0f, 1.0f);
 
-    const bool tpaLowInactive = (pidRuntime.tpaLowDisabled || isTpaLowFaded || (throttle >= pidRuntime.tpaLowBreakpoint));
+    const bool tpaLowInactive = (pidRuntime.tpaLowDisabled || (throttle >= pidRuntime.tpaLowBreakpoint));
     float tpaRate = 0.0f;
     if (tpaLowInactive) {
         // to get here, throttle exceeded the tpaLow threshold
-        // set the 'faded' latch when not configured to be always on
-        isTpaLowFaded = !pidRuntime.tpaLowAlways;
+        // disable when not configured to be always on 
+        pidRuntime.tpaLowDisabled = pidRuntime.tpaLowDisabled || !pidRuntime.tpaLowAlways;
         // apply normal TPA
         tpaRate = pidRuntime.tpaMultiplier * fmaxf(throttle - pidRuntime.tpaBreakpoint, 0.0f);
     } else {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -334,6 +334,7 @@ typedef struct pidRuntime_s {
     float tpaLowBreakpoint;
     float tpaLowMultiplier;
     bool tpaLowAlways;
+    bool tpaLowDisabled;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -428,9 +428,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaBreakpoint = constrainf((pidProfile->tpa_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, 0.99f);
     // default of 1350 returns 0.35. range limited to 0 to 0.99
     pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
-    // it is assumed that tpaLowBreakpoint is always less than or equal to tpaBreakpoint
-    pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.01f, 1.0f);
+    pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, 1.0f);
+    // tpaLowBreakpoint must be less than or equal to tpaBreakpoint
     pidRuntime.tpaLowBreakpoint = MIN(pidRuntime.tpaLowBreakpoint, pidRuntime.tpaBreakpoint);
+    // disable TPA Low if its breakpoint is 1000 (or lower), or if TPA itself is disabled by setting the tpa_breakpoint to 1000
+    pidRuntime.tpaLowDisabled = pidRuntime.tpaLowBreakpoint <= 0.01f;
     pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 }

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -425,15 +425,20 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;
+
     pidRuntime.tpaBreakpoint = constrainf((pidProfile->tpa_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, 0.99f);
     // default of 1350 returns 0.35. range limited to 0 to 0.99
     pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
-    pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, 1.0f);
-    // tpaLowBreakpoint must be less than or equal to tpaBreakpoint
-    pidRuntime.tpaLowBreakpoint = MIN(pidRuntime.tpaLowBreakpoint, pidRuntime.tpaBreakpoint);
-    // disable TPA Low if its breakpoint is 1000 (or lower), or if TPA itself is disabled by setting the tpa_breakpoint to 1000
-    pidRuntime.tpaLowDisabled = pidRuntime.tpaLowBreakpoint <= 0.01f;
-    pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
+
+    if (pidProfile->tpa_low_breakpoint > PWM_RANGE_MIN + 10) {
+        // tpaLowBreakpoint must be less than or equal to tpaBreakpoint
+        pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.01f, pidRuntime.tpaBreakpoint);
+        pidRuntime.tpaLowDisabled = false;
+        pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
+    } else {
+       pidRuntime.tpaLowDisabled = true;
+       pidRuntime.tpaLowBreakpoint = 0.01f;
+    }
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 }
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -432,12 +432,13 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
     if (pidProfile->tpa_low_breakpoint > PWM_RANGE_MIN + 10) {
         // tpaLowBreakpoint must be less than or equal to tpaBreakpoint
-        pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.01f, pidRuntime.tpaBreakpoint);
         pidRuntime.tpaLowDisabled = false;
+        pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, pidRuntime.tpaBreakpoint);
         pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
     } else {
        pidRuntime.tpaLowDisabled = true;
-       pidRuntime.tpaLowBreakpoint = 0.01f;
+       pidRuntime.tpaLowBreakpoint = 0.0f;
+       pidRuntime.tpaLowMultiplier = 0;
     }
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 }

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -52,7 +52,6 @@
 #define D_MIN_LOWPASS_HZ 35  // PT2 lowpass cutoff to smooth the boost effect
 #define D_MIN_GAIN_FACTOR 0.00008f
 #define D_MIN_SETPOINT_GAIN_FACTOR 0.00008f
-#define TPA_LOW_MIN_BREAKPOINT 1010  // minimum TPA 
 #endif
 
 #define ATTITUDE_CUTOFF_HZ 50
@@ -431,7 +430,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     // default of 1350 returns 0.35. range limited to 0 to 0.99
     pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
 
-    if (pidProfile->tpa_low_breakpoint > TPA_LOW_MIN_BREAKPOINT) {
+    if (pidProfile->tpa_low_breakpoint > PWM_RANGE_MIN + 10) {
         // tpaLowBreakpoint must be less than or equal to tpaBreakpoint
         pidRuntime.tpaLowDisabled = false;
         pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, pidRuntime.tpaBreakpoint);

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -52,6 +52,7 @@
 #define D_MIN_LOWPASS_HZ 35  // PT2 lowpass cutoff to smooth the boost effect
 #define D_MIN_GAIN_FACTOR 0.00008f
 #define D_MIN_SETPOINT_GAIN_FACTOR 0.00008f
+#define TPA_LOW_MIN_BREAKPOINT 1010  // minimum TPA 
 #endif
 
 #define ATTITUDE_CUTOFF_HZ 50
@@ -430,7 +431,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     // default of 1350 returns 0.35. range limited to 0 to 0.99
     pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
 
-    if (pidProfile->tpa_low_breakpoint > PWM_RANGE_MIN + 10) {
+    if (pidProfile->tpa_low_breakpoint > TPA_LOW_MIN_BREAKPOINT) {
         // tpaLowBreakpoint must be less than or equal to tpaBreakpoint
         pidRuntime.tpaLowDisabled = false;
         pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, pidRuntime.tpaBreakpoint);


### PR DESCRIPTION
PR for discussion.
Intent is to simplify the TPA low code, and reduce the number of calculations needed while in the air, but make no functional changes.
Saves about 30 bytes of code.