### PR TITLE
Introduce MSP_RADIO_SETUP

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -751,6 +751,30 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteData(dst, shortGitRevision, GIT_SHORT_REVISION_LENGTH);
         break;
 
+    case MSP_RADIO_SETUP:
+    {
+#define BUILD_HAS_VTX      0
+#define BUILD_HAS_GPS      1
+#define BUILD_HAS_OSD      2
+#define BUILD_HAS_BLACKBOX 3
+
+        uint8_t options = 0;
+#ifdef USE_VTX
+        options |= BIT(BUILD_HAS_VTX); // byte 1 bit 1
+#endif
+#ifdef USE_GPS
+        options |= BIT(BUILD_HAS_GPS); // byte 1 bit 2
+#endif
+#ifdef USE_OSD
+        options |= BIT(BUILD_HAS_OSD); // byte 1 bit 3
+#endif
+#ifdef USE_BLACKBOX
+        options |= BIT(BUILD_HAS_BLACKBOX); // byte 1 bit 4
+#endif
+        sbufWriteU8(dst, options);
+        break;
+    }
+
     case MSP_ANALOG:
         sbufWriteU8(dst, (uint8_t)constrain(getLegacyBatteryVoltage(), 0, 255));
         sbufWriteU16(dst, (uint16_t)constrain(getMAhDrawn(), 0, 0xFFFF)); // milliamp hours drawn from battery

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -167,8 +167,7 @@
 
 #define MSP_REBOOT                      68 //in message reboot settings
 
-// Use MSP_BUILD_INFO instead
-// DEPRECATED - #define MSP_BF_BUILD_INFO               69 //out message build date as well as some space for future expansion
+#define MSP_RADIO_SETUP                 69 //out message list of options available in radio menu
 
 #define MSP_DATAFLASH_SUMMARY           70 //out message - get description of dataflash chip
 #define MSP_DATAFLASH_READ              71 //out message - get content of dataflash chip


### PR DESCRIPTION
This is a byproduct of #13333. These changes repurpose a previously unused MSP command `MSP_BF_BUILD_INFO` to efficiently communicate available build options over-the-air for the Betaflight setup menu on the transmitter.