### PR TITLE
Allow overriding the spi clock speed for icm42688

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -45,8 +45,16 @@
 
 #include "sensors/gyro.h"
 
-// 24 MHz max SPI frequency
+// Allows frequency to be set from the compile line EXTRA_FLAGS by adding e.g.
+// -D'ICM426XX_CLOCK=12000000'. If using the configurator this simply becomes
+// ICM426XX_CLOCK=12000000 in the custom settings text box.
+#ifndef ICM426XX_CLOCK
+// Default: 24 MHz max SPI frequency
 #define ICM426XX_MAX_SPI_CLK_HZ 24000000
+#else
+// Use the supplied value
+#define ICM426XX_MAX_SPI_CLK_HZ ICM426XX_CLOCK
+#endif
 
 #define ICM426XX_RA_REG_BANK_SEL                    0x76
 #define ICM426XX_BANK_SELECT0                       0x00


### PR DESCRIPTION
There was a report of glitches on the raw gyro output of an icm42688 which were resolved by reducing the the SPI clock speed. I don't think a single report justifies changing the default speed or even adding a CLI command to make it configurable, but it's relatively low impact to allow the speed to be set at compile time by passing the value via EXTRA_FLAGS and this will make it easier to see if changing the speed solves any future cases that might turn up.
(The first attempt at this PR used the existing macro name ICM426XX_MAX_SPI_CLK_HZ to set the override value, however this can't be passed to the cloud build via the configurator, so the PR was changed to introduce a new, simpler name to provide the override value, ICM426XX_CLOCK)

When passing a value for a macro through EXTRA_FLAGS we need to use single quotes, e.g. to set 12MHz we could use

-D'ICM426XX_CLOCK=12000000'

When using the configurator to start a cloud build the value can be placed in the "Custom Defines" text box as

ICM426XX_CLOCK=12000000

(or whatever value is desired)

Thread discussing (in part) the problem:
https://discord.com/channels/868013470023548938/1202941174177079336

Image showing a glitch:
https://cdn.discordapp.com/attachments/1202941174177079336/1203147744370495558/image.png?ex=65d009a7&is=65bd94a7&hm=12c936b068c6d6852e1239107d7b827a487461c25f2fdd35ccd159cd437d6e6e&