### PR TITLE
ICM42688: configurabe AA & UI Filter

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1502,6 +1502,11 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_YAW_DEADBAND, "%d",           rcControlsConfig()->yaw_deadband);
 
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_HARDWARE_LPF, "%d",      gyroConfig()->gyro_hardware_lpf);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_DELT, "%d",              gyroConfig()->gyro_delt);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_DELTSQR, "%d",           gyroConfig()->gyro_deltSqr);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_BITSHIFT, "%d",          gyroConfig()->gyro_bitshift);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_UI, "%d",                gyroConfig()->gyro_ui);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_UI_ORD, "%d",            gyroConfig()->gyro_ui_ord);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_LPF1_TYPE, "%d",         gyroConfig()->gyro_lpf1_type);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_LPF1_STATIC_HZ, "%d",    gyroConfig()->gyro_lpf1_static_hz);
 #ifdef USE_DYN_LPF

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -660,7 +660,12 @@ const lookupTableEntry_t lookupTables[] = {
 
 const clivalue_t valueTable[] = {
 // PG_GYRO_CONFIG
-    { PARAM_NAME_GYRO_HARDWARE_LPF, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_HARDWARE_LPF }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_hardware_lpf) },
+    { PARAM_NAME_GYRO_HARDWARE_LPF, VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_HARDWARE_LPF }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_hardware_lpf) },
+    { PARAM_NAME_GYRO_DELT,         VAR_UINT8  | HARDWARE_VALUE,  .config.minmaxUnsigned = { 1,   63 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_delt) },
+    { PARAM_NAME_GYRO_DELTSQR,      VAR_UINT16 | HARDWARE_VALUE,  .config.minmaxUnsigned = { 1, 3968 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_deltSqr) },
+    { PARAM_NAME_GYRO_BITSHIFT,     VAR_UINT8  | HARDWARE_VALUE,  .config.minmaxUnsigned = { 3,   15 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_bitshift) },
+    { PARAM_NAME_GYRO_UI,           VAR_UINT8  | HARDWARE_VALUE,  .config.minmaxUnsigned = { 0,   15 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_ui) },
+    { PARAM_NAME_GYRO_UI_ORD,       VAR_UINT8  | HARDWARE_VALUE,  .config.minmaxUnsigned = { 0,    2 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_ui_ord) },
 
 #if defined(USE_GYRO_SPI_ICM20649)
     { "gyro_high_range",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_high_fsr) },

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -69,6 +69,10 @@
 
 #define ICM426XX_RA_GYRO_CONFIG0                    0x4F
 #define ICM426XX_RA_ACCEL_CONFIG0                   0x50
+#define ICM426XX_RA_GYRO_CONFIG1                    0x51
+#define ICM426XX_RA_TEMP_FILT_BW                    (0  << 5)
+#define ICM426XX_RA_GYRO_UI_FILT_ORD(x)             ((x)<< 2)
+#define ICM426XX_RA_GYRO_DEC2_M2_ORD                (1  << 1)
 
 // --- Registers for gyro and acc Anti-Alias Filter ---------
 #define ICM426XX_RA_GYRO_CONFIG_STATIC3             0x0C  // User Bank 1
@@ -79,8 +83,8 @@
 #define ICM426XX_RA_ACCEL_CONFIG_STATIC4            0x05  // User Bank 2
 // --- Register & setting for gyro and acc UI Filter --------
 #define ICM426XX_RA_GYRO_ACCEL_CONFIG0              0x52  // User Bank 0
-#define ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY       (15 << 4) 
-#define ICM426XX_GYRO_UI_FILT_BW_LOW_LATENCY        (15 << 0)
+#define ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY       (15 << 4)
+#define ICM426XX_GYRO_UI_FILT_BW(x)                 ((x)<< 0)
 // ----------------------------------------------------------
 
 #define ICM426XX_RA_GYRO_DATA_X1                    0x25  // User Bank 0
@@ -249,7 +253,11 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 
     // Configure gyro Anti-Alias Filter (see section 5.3 "ANTI-ALIAS FILTER")
     const mpuSensor_e gyroModel = gyro->mpuDetectionResult.sensor;
-    aafConfig_t aafConfig = getGyroAafConfig(gyroModel, gyroConfig()->gyro_hardware_lpf);
+    aafConfig_t aafConfig = { gyroConfig()->gyro_delt, gyroConfig()->gyro_deltSqr, gyroConfig()->gyro_bitshift };
+    if (gyroModel == ICM_42688P_SPI) {
+        aafConfig = getGyroAafConfig(gyroModel, gyroConfig()->gyro_hardware_lpf);
+    };
+
     setUserBank(dev, ICM426XX_BANK_SELECT1);
     spiWriteReg(dev, ICM426XX_RA_GYRO_CONFIG_STATIC3, aafConfig.delt);
     spiWriteReg(dev, ICM426XX_RA_GYRO_CONFIG_STATIC4, aafConfig.deltSqr & 0xFF);
@@ -264,7 +272,13 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 
     // Configure gyro and acc UI Filters
     setUserBank(dev, ICM426XX_BANK_SELECT0);
-    spiWriteReg(dev, ICM426XX_RA_GYRO_ACCEL_CONFIG0, ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM426XX_GYRO_UI_FILT_BW_LOW_LATENCY);
+    uint8_t ui = gyroConfig()->gyro_ui;
+    if (ui > 7 && ui < 14) {
+        ui = 7;
+    }
+    spiWriteReg(dev, ICM426XX_RA_GYRO_ACCEL_CONFIG0, ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM426XX_GYRO_UI_FILT_BW(ui));
+    uint8_t ui_ord = gyroConfig()->gyro_ui_ord;
+    spiWriteReg(dev, ICM426XX_RA_GYRO_CONFIG1, ICM426XX_RA_TEMP_FILT_BW | ICM426XX_RA_GYRO_UI_FILT_ORD(ui_ord) | ICM426XX_RA_GYRO_DEC2_M2_ORD);
 
     // Configure interrupt pin
     spiWriteReg(dev, ICM426XX_RA_INT_CONFIG, ICM426XX_INT1_MODE_PULSED | ICM426XX_INT1_DRIVE_CIRCUIT_PP | ICM426XX_INT1_POLARITY_ACTIVE_HIGH);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -21,6 +21,11 @@
 #pragma once
 
 #define PARAM_NAME_GYRO_HARDWARE_LPF "gyro_hardware_lpf"
+#define PARAM_NAME_GYRO_DELT "gyro_delt"
+#define PARAM_NAME_GYRO_DELTSQR "gyro_deltsqr"
+#define PARAM_NAME_GYRO_BITSHIFT "gyro_bitshift"
+#define PARAM_NAME_GYRO_UI "gyro_ui"
+#define PARAM_NAME_GYRO_UI_ORD "gyro_ui_ord"
 #define PARAM_NAME_GYRO_LPF1_TYPE "gyro_lpf1_type"
 #define PARAM_NAME_GYRO_LPF1_STATIC_HZ "gyro_lpf1_static_hz"
 #define PARAM_NAME_GYRO_LPF2_TYPE "gyro_lpf2_type"

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -96,7 +96,7 @@ STATIC_UNIT_TESTED gyroDev_t * const gyroDevPtr = &gyro.gyroSensor1.gyroDev;
 #define GYRO_OVERFLOW_TRIGGER_THRESHOLD 31980  // 97.5% full scale (1950dps for 2000dps gyro)
 #define GYRO_OVERFLOW_RESET_THRESHOLD 30340    // 92.5% full scale (1850dps for 2000dps gyro)
 
-PG_REGISTER_WITH_RESET_FN(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 9);
+PG_REGISTER_WITH_RESET_FN(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 10);
 
 #ifndef DEFAULT_GYRO_TO_USE
 #define DEFAULT_GYRO_TO_USE GYRO_CONFIG_USE_GYRO_1
@@ -107,6 +107,11 @@ void pgResetFn_gyroConfig(gyroConfig_t *gyroConfig)
     gyroConfig->gyroCalibrationDuration = 125;        // 1.25 seconds
     gyroConfig->gyroMovementCalibrationThreshold = 48;
     gyroConfig->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
+    gyroConfig->gyro_delt = 6;
+    gyroConfig->gyro_deltSqr = 36;
+    gyroConfig->gyro_bitshift = 10;
+    gyroConfig->gyro_ui = 14;
+    gyroConfig->gyro_ui_ord = 1;
     gyroConfig->gyro_lpf1_type = FILTER_PT1;
     gyroConfig->gyro_lpf1_static_hz = GYRO_LPF1_DYN_MIN_HZ_DEFAULT;
         // NOTE: dynamic lpf is enabled by default so this setting is actually

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -167,6 +167,11 @@ enum {
 typedef struct gyroConfig_s {
     uint8_t gyroMovementCalibrationThreshold; // people keep forgetting that moving model while init results in wrong gyro offsets. and then they never reset gyro. so this is now on by default.
     uint8_t gyro_hardware_lpf;                // gyro DLPF setting
+    uint8_t gyro_delt;
+    uint16_t gyro_deltSqr;
+    uint8_t gyro_bitshift;
+    uint8_t gyro_ui;
+    uint8_t gyro_ui_ord;
     uint8_t gyro_high_fsr;
     uint8_t gyro_to_use;
 


### PR DESCRIPTION
I exposed the ICM42688 registers to quickly change the internal gyro filter settings for testing. Only flash this PR if you know what you are doing!

## Signal Path
![grafik](https://github.com/betaflight/betaflight/assets/19867640/bc816093-4060-42de-9a2b-d50341b494a7)

# Anti-Alias-Filter
The AAF can be adjusted using the corresponding values for `gyro_delt`, `gyro_deltsqr` and `gyro_bitshift` from the list below. 
![grafik](https://github.com/betaflight/betaflight/assets/19867640/d1a465db-ed09-4d19-ac29-b222902b8f96)

### Defaults
The default values are set up for a bandwidth of **258Hz**.
| CLI command | Value (default) |
| ----- | ----- |
| `gyro_delt` | 6 |
| `gyro_deltsqr` | 36 |
| `gyro_bitshift` | 10 |

# UI-Filter
The UI-Filter can be adjusted using `gyro_ui_ord` and `gyro_ui`. `gyro_ui_ord` is the filter order and can be adjusted from order 1 to order 3
| `gyro_ui_ord` | Filter Order |
| ----- | ----- |
| 0 | 1 |
| 1 | 2 (default) |
| 2 | 3 |

`gyro_ui` adjusts the UI-Filter bandwidth according to the list below (ODR is set to 8kHz in BF)
![grafik](https://github.com/betaflight/betaflight/assets/19867640/b0081549-b5d1-4e47-a4f6-83d366c6f416)

### Defaults
| CLI command | Value (default) |
| ----- | ----- |
| `gyro_ui` | 14 |
| `gyro_ui_ord` | 1 |