### PR TITLE
Ensure MSP channel data is valid

### DIFF
--- a/src/main/rx/msp_override.c
+++ b/src/main/rx/msp_override.c
@@ -32,7 +32,8 @@ uint16_t rxMspOverrideReadRawRc(const rxRuntimeState_t *rxRuntimeState, const rx
 {
     uint16_t rxSample = (rxRuntimeState->rcReadRawFn)(rxRuntimeState, chan);
 
-    uint16_t overrideSample = rxMspReadRawRC(rxRuntimeState, chan);
+    uint16_t overrideSample = constrainf(rxMspReadRawRC(rxRuntimeState, chan), rxConfig->rx_min_usec, rxConfig->rx_max_usec);
+
     bool override = (1 << chan) & rxConfig->msp_override_channels_mask;
 
     if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && override) {


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/12790

When `msp_override_channels_mask` is defined and `BOXMSPOVERRIDE` is activated MSP channel data is used to substitute RC channel data. However, if any of that data fails the `isPulseValid()` check the whole RX packet is disguarded as invalid, consequently the AUX channel used to control the `BOXMSPOVERRIDE` is subsequently ignored.

This PR constrains the MSP RC data to the valid range.