### PR TITLE
Bump workflow action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: List assets
         run: ls -al Assets

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
 
       - name: List assets
         run: ls -al Assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     outputs:
       targets: ${{ steps.get-targets.outputs.targets }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache build toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-toolchain
         with:
           path: tools
@@ -49,10 +49,10 @@ jobs:
         target: ${{ fromJson(needs.setup.outputs.targets) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch toolchain from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-toolchain
         with:
           path: tools
@@ -71,7 +71,7 @@ jobs:
         run: make EXTRA_FLAGS=-Werror ${{ matrix.target }}_rev
 
       - name: Publish build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Assets
           path: obj/*.hex
@@ -81,7 +81,7 @@ jobs:
     name: Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: sudo apt-get install -y libblocksruntime-dev clang-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: make EXTRA_FLAGS=-Werror ${{ matrix.target }}_rev
 
       - name: Publish build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Assets
           path: obj/*.hex

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Select release notes
         id: notes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
 
       - name: Select release notes
         id: notes


### PR DESCRIPTION
Did not address issue with artifacts workflow using v4 - so keep it on v3 for now.

https://github.com/actions/upload-artifact/issues/478

Solution provided did not work:

```
- name: Upload artifacts
  uses: actions/upload-artifact@v4
  with:
    name: dist-${{ matrix.os }}
    path: dist

- name: Download artifacts
  uses: actions/download-artifact@v4
  with:
    pattern: dist-*
    merge-multiple: true
    path: dist
```