### PR TITLE
Improve IMU responsiveness, refactor

### DIFF
--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -111,10 +111,11 @@ static inline fpVector3_t * vectorNormalize(fpVector3_t *result, const fpVector3
 
 static inline fpVector2_t * vector2Normalize(fpVector2_t *result, const fpVector2_t *v)
 {
-    float norm = sqrtf(v->x * v->x + v->y * v->y);
-    if (norm > 0) {
-        result->x = v->x / norm;
-        result->y = v->y / norm;
+    float normSq = sq(v->x) + sq(v->y);
+    if (normSq > 0.0f) {
+        normSq = 1.0f / sqrtf(normSq);
+        result->x = v->x * normSq;
+        result->y = v->y * normSq;
     } else {
         result->x = 0.0f;
         result->y = 0.0f;

--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -109,6 +109,19 @@ static inline fpVector3_t * vectorNormalize(fpVector3_t *result, const fpVector3
     }
 }
 
+static inline fpVector2_t * vector2Normalize(fpVector2_t *result, const fpVector2_t *v)
+{
+    float norm = sqrtf(v->x * v->x + v->y * v->y);
+    if (norm > 0) {
+        result->x = v->x / norm;
+        result->y = v->y / norm;
+    } else {
+        result->x = 0.0f;
+        result->y = 0.0f;
+    }
+    return result;
+}
+
 static inline fpVector3_t * matrixVectorMul(fpVector3_t * result, const fpMat33_t * mat, const fpVector3_t * a)
 {
     fpVector3_t r;

--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -109,18 +109,38 @@ static inline fpVector3_t * vectorNormalize(fpVector3_t *result, const fpVector3
     }
 }
 
+
+static inline float vector2NormSquared(const fpVector2_t *a)
+{
+    return sq(a->x) + sq(a->y);
+}
+
+static inline float vector2Norm(const fpVector2_t *a)
+{
+    return sqrtf(vector2NormSquared(a));
+}
+
+
+static inline fpVector2_t * vector2Scale(fpVector2_t *result, const fpVector2_t *a, const float b)
+{
+    fpVector2_t ab;
+
+    ab.x = a->x * b;
+    ab.y = a->y * b;
+
+    *result = ab;
+    return result;
+}
+
 static inline fpVector2_t * vector2Normalize(fpVector2_t *result, const fpVector2_t *v)
 {
-    float normSq = sq(v->x) + sq(v->y);
+    float normSq = vector2NormSquared(v);
     if (normSq > 0.0f) {
-        normSq = 1.0f / sqrtf(normSq);
-        result->x = v->x * normSq;
-        result->y = v->y * normSq;
+        return vector2Scale(result, v, 1.0f / sqrtf(normSq));
     } else {
-        result->x = 0.0f;
-        result->y = 0.0f;
+        *result = (fpVector2_t){.x = 0.0f, .y = 0.0f};
+        return result;
     }
-    return result;
 }
 
 static inline fpVector3_t * matrixVectorMul(fpVector3_t * result, const fpMat33_t * mat, const fpVector3_t * a)
@@ -177,7 +197,3 @@ static inline float vector2Dot(const fpVector2_t *a, const fpVector2_t *b)
     return a->x * b->x + a->y * b->y;
 }
 
-static inline float vector2Mag(const fpVector2_t *a)
-{
-    return sqrtf(sq(a->x) + sq(a->y));
-}

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -599,7 +599,7 @@ static void sensorUpdate(void)
     // positive = towards home.  First value is useless since prevDistanceToHomeCm was zero.
     prevDistanceToHomeCm = rescueState.sensor.distanceToHomeCm;
 
-    DEBUG_SET(DEBUG_ATTITUDE, 4, rescueState.sensor.velocityToHomeCmS); // velocity to home
+// TEMPORARY    DEBUG_SET(DEBUG_ATTITUDE, 4, rescueState.sensor.velocityToHomeCmS); // velocity to home
 
     // when there is a flyaway due to IMU disorientation, increase IMU yaw CoG gain, and reduce max pitch angle
     if (gpsRescueConfig()->groundSpeedCmS) {
@@ -613,7 +613,8 @@ static void sensorUpdate(void)
         // 1 if forward velocity is zero but sideways speed is imuYawGain in m/s
         // 2 if moving backwards at imuYawGain m/s, 4 if moving backwards at 2* imuYawGain m/s, etc
 
-        DEBUG_SET(DEBUG_ATTITUDE, 5, groundspeedErrorRatio * 100);
+// TEMPORARY
+//        DEBUG_SET(DEBUG_ATTITUDE, 5, groundspeedErrorRatio * 100);
 
         rescueState.intent.velocityItermAttenuator = 4.0f / (groundspeedErrorRatio + 4.0f);
         // 1 if groundspeedErrorRatio = 0, falling to 2/3 if groundspeedErrorRatio = 2, 0.5 if groundspeedErrorRatio = 4, etc

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -599,7 +599,7 @@ static void sensorUpdate(void)
     // positive = towards home.  First value is useless since prevDistanceToHomeCm was zero.
     prevDistanceToHomeCm = rescueState.sensor.distanceToHomeCm;
 
-// TEMPORARY    DEBUG_SET(DEBUG_ATTITUDE, 4, rescueState.sensor.velocityToHomeCmS); // velocity to home
+    DEBUG_SET(DEBUG_ATTITUDE, 4, rescueState.sensor.velocityToHomeCmS); // velocity to home
 
     // when there is a flyaway due to IMU disorientation, increase IMU yaw CoG gain, and reduce max pitch angle
     if (gpsRescueConfig()->groundSpeedCmS) {
@@ -613,8 +613,7 @@ static void sensorUpdate(void)
         // 1 if forward velocity is zero but sideways speed is imuYawGain in m/s
         // 2 if moving backwards at imuYawGain m/s, 4 if moving backwards at 2* imuYawGain m/s, etc
 
-// TEMPORARY
-//        DEBUG_SET(DEBUG_ATTITUDE, 5, groundspeedErrorRatio * 100);
+        DEBUG_SET(DEBUG_ATTITUDE, 5, groundspeedErrorRatio * 100);
 
         rescueState.intent.velocityItermAttenuator = 4.0f / (groundspeedErrorRatio + 4.0f);
         // 1 if groundspeedErrorRatio = 0, falling to 2/3 if groundspeedErrorRatio = 2, 0.5 if groundspeedErrorRatio = 4, etc
@@ -634,7 +633,7 @@ static void sensorUpdate(void)
         // pitchForwardAngle is 1.0 if pitch angle is 30 degrees (ie with rescue angle of 60 and 180deg IMU error)
         // pitchForwardAngle is 2.0 if pitch angle is 60 degrees and flying towards home (unlikely to be sustained at that angle)
 
-//        DEBUG_SET(DEBUG_ATTITUDE, 6, pitchForwardAngle * 100.0f);
+        DEBUG_SET(DEBUG_ATTITUDE, 6, pitchForwardAngle * 100.0f);
 
         if (rescueState.phase != RESCUE_FLY_HOME) {
             // prevent IMU disorientation arising from drift during climb, rotate or do nothing phases, which have zero pitch angle

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -633,7 +633,7 @@ static void sensorUpdate(void)
         // pitchForwardAngle is 1.0 if pitch angle is 30 degrees (ie with rescue angle of 60 and 180deg IMU error)
         // pitchForwardAngle is 2.0 if pitch angle is 60 degrees and flying towards home (unlikely to be sustained at that angle)
 
-        DEBUG_SET(DEBUG_ATTITUDE, 6, pitchForwardAngle * 100.0f);
+//        DEBUG_SET(DEBUG_ATTITUDE, 6, pitchForwardAngle * 100.0f);
 
         if (rescueState.phase != RESCUE_FLY_HOME) {
             // prevent IMU disorientation arising from drift during climb, rotate or do nothing phases, which have zero pitch angle

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -230,7 +230,7 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
         const fpVector2_t cog_ef = {.x = cos_approx(-courseOverGround), .y = sin_approx(-courseOverGround)};
 
         // Compute and normalise craft earth frame heading vector from body X axis
-        fpVector2_t heading_ef = {.x = rMat[0][0], .y = rMat[1][0]};
+        fpVector2_t heading_ef = {.x = rMat[X][X], .y = rMat[Y][X]};
         vector2Normalize(&heading_ef, &heading_ef); // XY only, normalised to magnitude 1.0
 
         // cross (vector product) = heading * cog * sin angle

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -679,6 +679,8 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
             gpsHeadingInitialized = true;
         }
     }
+#else
+    UNUSED(useMag);
 #endif
 
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -582,7 +582,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
                 // - heavily average GPS heading values at low speed, since they are random, almost
                 // - respond more quickly at higher speeds.
                 // GPS typically returns quite good heading estimates at or above 0.5- 1.0 m/s, quite solid by 2m/s
-                // gpsGroundspeedGain will be 0 at 0.0m/s, rising slowly towards 1.0 at 2m/s, and reaching max of 10.0 at 20m/s
+                // gpsGroundspeedGain will be 0 at 0.0m/s, rising slowly towards 1.0 at 1.0 m/s, and reaching max of 10.0 at 10m/s
                 const float speedRatio = (float)gpsSol.groundSpeed / GPS_COG_MIN_GROUNDSPEED;
                 gpsGroundspeedGain = speedRatio > 1.0f ? fminf(speedRatio, 10.0f) : speedRatio * speedRatio;
             }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -674,8 +674,6 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
         } else if (gpsSol.groundSpeed > GPS_COG_MIN_GROUNDSPEED) {
             // Reset the reference and reinitialize quaternion factors when GPS groundspeed > GPS_COG_MIN_GROUNDSPEED
             imuComputeQuaternionFromRPY(&qP, attitude.values.roll, attitude.values.pitch, gpsSol.groundCourse);
-            // groundspeedGain will be zero before and during the initialisation run
-            // Only runs once; not really sure this needs to run at all?
             gpsHeadingInitialized = true;
         }
     }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -538,7 +538,7 @@ STATIC_UNIT_TESTED float imuCalcMagErr(void)
 
         // For magnetometer correction we make an assumption that magnetic field is perpendicular to gravity (ignore Z-component in EF).
         // This way magnetic field will only affect heading and wont mess roll/pitch angles
-        fpVector2_t mag2d_ef = {.x = mag_ef.x, .y=mag_ef.y};
+        fpVector2_t mag2d_ef = {.x = mag_ef.x, .y = mag_ef.y};
         // mag2d_ef - measured mag field vector in EF (2D ground plane projection)
         // north_ef - reference mag field vector heading due North in EF (2D ground plane projection).
         //              Adjusted for magnetic declination (in imuConfigure)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -308,8 +308,8 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
         DEBUG_SET(DEBUG_ATTITUDE, 3, (ez_ef * 100));
     }
 
-    DEBUG_SET(DEBUG_ATTITUDE, 2, groundspeedGain * 100);
-    DEBUG_SET(DEBUG_ATTITUDE, 7, dcmKpGain * 100);
+    DEBUG_SET(DEBUG_ATTITUDE, 2, lrintf(groundspeedGain * 100.0f));
+    DEBUG_SET(DEBUG_ATTITUDE, 7, lrintf(dcmKpGain * 100.0f));
 
 #ifdef USE_MAG
     // Use measured magnetic field vector

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -550,7 +550,7 @@ STATIC_UNIT_TESTED float imuCalcMagErr(void)
         return (dot > 0) ? cross : (cross < 0 ? -1.0f : 1.0f) * vector2Norm(&mag2d_ef);
     } else {
         // invalid magnetometer data
-        return 0;
+        return 0.0f;
     }
 }
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -544,7 +544,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
 #if defined(USE_GPS)
     if (!useMag && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat > GPS_MIN_SAT_COUNT && gpsSol.groundSpeed >= GPS_COG_MIN_GROUNDSPEED) {
         // Use GPS course over ground to correct attitude.values.yaw
-        const float imuYawGroundspeed = fminf (gpsSol.groundSpeed / GPS_COG_MAX_GROUNDSPEED, 2.0f);
+        const float imuYawGroundspeed = fminf ((float)gpsSol.groundSpeed / GPS_COG_MAX_GROUNDSPEED, 2.0f);
         courseOverGround = DECIDEGREES_TO_RADIANS(gpsSol.groundCourse);
         cogYawGain = (FLIGHT_MODE(GPS_RESCUE_MODE)) ? gpsRescueGetImuYawCogGain() : imuYawGroundspeed;
         // normally update yaw heading with GPS data, but when in a Rescue, modify the IMU yaw gain dynamically

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -647,7 +647,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
 #endif
 
 #if defined(USE_MAG) && defined(USE_GPS_RESCUE)
-    // fill in GPS rescue debug value (from code refactoring)
+    // fill in GPS rescue debug value (leftover from code refactoring)
     imuDebug_GPS_RESCUE_HEADING();
 #endif
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -290,7 +290,7 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
             float pitchSuppression = 1.0f;
             if (!isWing) {
                 const float pitchAngle = (float)attitude.values.pitch; // decidegrees, negative is backwards
-                float pitchSuppression = pitchAngle / 450.0f; // 1.0 at 45 degrees, 2.0 at 90 degrees
+                pitchSuppression = pitchAngle / 450.0f; // 1.0 at 45 degrees, 2.0 at 90 degrees
                 pitchSuppression = (pitchSuppression >= 0) ? pitchSuppression : 0.0f; // zero if flat or pitched backwards
             }
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -687,7 +687,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
         gyroAverage[axis] = gyroGetFilteredDownsampled(axis);
     }
 
-    bool useAcc = imuIsAccelerometerHealthy(acc.accADC); // all smoothed accADC values are within 20% of 1G
+    const bool useAcc = imuIsAccelerometerHealthy(acc.accADC); // all smoothed accADC values are within 20% of 1G
 
     imuMahonyAHRSupdate(dt,
                         DEGREES_TO_RADIANS(gyroAverage[X]), DEGREES_TO_RADIANS(gyroAverage[Y]), DEGREES_TO_RADIANS(gyroAverage[Z]),

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -281,7 +281,7 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
             float rollMax = isWing ? 250.0f : 120.0f; // 25 degrees for wing, 12 degrees for quad
             // note: these value are 'educated guesses' - for quads it must be very tight
             // for wings, which can't fly sideways, it can be wider
-            const float rollSuppression = (absRollAngle < rollMax) ? fmaxf((rollMax - absRollAngle) / rollMax, 0.0f) : 0.0f;
+            const float rollSuppression = (absRollAngle < rollMax) ? (rollMax - absRollAngle) / rollMax : 0.0f;
 
             // 4. attenuate ez_ef by pitch angle, will be zero if flat or negative (ie flying tail first)
             // allow faster adaptation for quads at higher pitch angles; returns 1.0 at 45 degrees

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -427,7 +427,7 @@ extern "C" {
     float pt2FilterGain(float, float)  { return 0.0f; }
     float getBaroAltitude(void) { return 3000.0f; }
     float gpsRescueGetImuYawCogGain(void) { return 1.0f; }
-    float getMaxRcDeflectionAbs(void) {return 0.0f; }
+    float getRcDeflectionAbs(int) { return 0.0f; }
 
     void pt2FilterInit(pt2Filter_t *baroDerivativeLpf, float) {
         UNUSED(baroDerivativeLpf);

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -63,7 +63,7 @@ extern "C" {
     void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
                              bool useAcc, float ax, float ay, float az,
                              bool useMag,
-                             float gpsGroundspeedGain, float courseOverGround, const float dcmKpGain);
+                             float groundspeedGain, float courseOverGround, const float dcmKpGain);
     extern quaternion q;
     extern float rMat[3][3];
     extern bool attitudeIsEstablished;
@@ -427,7 +427,7 @@ extern "C" {
     float pt2FilterGain(float, float)  { return 0.0f; }
     float getBaroAltitude(void) { return 3000.0f; }
     float gpsRescueGetImuYawCogGain(void) { return 1.0f; }
-    float getRcDeflectionAbs(int) {return 0.0f; }
+    float getMaxRcDeflectionAbs(void) {return 0.0f; }
 
     void pt2FilterInit(pt2Filter_t *baroDerivativeLpf, float) {
         UNUSED(baroDerivativeLpf);

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -61,7 +61,7 @@ extern "C" {
     void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
                              bool useAcc, float ax, float ay, float az,
                              bool useMag,
-                             float cogYawGain, float courseOverGround, const float dcmKpGain);
+                             float gpsGroundspeedGain, float courseOverGround, const float dcmKpGain);
     extern quaternion q;
     extern float rMat[3][3];
     extern bool attitudeIsEstablished;

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -40,12 +40,14 @@ extern "C" {
     #include "fc/rc_controls.h"
     #include "fc/rc_modes.h"
     #include "fc/runtime_config.h"
-
+    #include "fc/rc.h"
+    
     #include "flight/mixer.h"
     #include "flight/pid.h"
     #include "flight/imu.h"
     #include "flight/position.h"
 
+    
     #include "io/gps.h"
 
     #include "rx/rx.h"
@@ -425,6 +427,7 @@ extern "C" {
     float pt2FilterGain(float, float)  { return 0.0f; }
     float getBaroAltitude(void) { return 3000.0f; }
     float gpsRescueGetImuYawCogGain(void) { return 1.0f; }
+    float getRcDeflectionAbs(int) {return 0.0f; }
 
     void pt2FilterInit(pt2Filter_t *baroDerivativeLpf, float) {
         UNUSED(baroDerivativeLpf);


### PR DESCRIPTION
Has been tested, and works well.  Rebased to master on 24th March 2024.

The goal is for the arrow to be quicker in responding and to respond properly to roll-dominant turns.  This applies to both wings and quads.

@limonspb noted that on his Wing, the 'Heading' arrow in the OSD was very slow to respond.  After some investigation, and after simple changes to increase the rate of adaptation for IMU to GPS values, a small improvement was made.

However further testing with quads revealed that while the IMU code responded very quickly, and correctly, to 'pure' yaw inputs, it responded very slowly, and incorrectly, when the inputs were primarily roll type inputs, and also seemed to go wrong when a pitch input was applied after a roll input.  I then confirmed the same issues in quads.

Note that this PR:
- **Includes [PR13379](https://github.com/betaflight/betaflight/pull/13379)**, to use heading error calculated from the quad's X axis orientation, not the Z axis orientation.
- Should make the arrow / heading estimate change more quickly and more accurately
- Should not change GPS Rescue behaviour.

Test by flashing and flying with a known good GPS setup.  Log to `ATTITUDE` debug.  While watching the arrow, test the following:
- sudden yaw only inputs
- sudden coordinated roll/pitch turns
- snap 180 degree heading reversal, while travelling fast forward, then go flat and drift backwards
- intentionally flying 'sideways', with persistent roll input
- intentionally flying 'backwards' (pitched back).  
Ideally the arrow should be OK.  
Also try inverted slow pitch or roll loops and check the arrow behaviour when inverted.  Wing pilots can evaluate arrow behaviour in sustained inverted flight.  
Compare to 4.5 Master and to 4.4 if you have it.

Changes to date:

- modifies the `ATTITUDE` debug so that we can investigate the Roll/Pitch problem more effectively;  use it when testing this issue.
- increases the primary Gyro/IMU <--> GPS ez_eg gain modifier, `groundspeedGain `, to a max of 10x (up from 2x) at a max of 10m/s, see graph below.  It uses an exponential curve to reject GPS data at very low groundspeed more strongly.  
- introduces three more `ez_ef` gain factors, suppressing ez_ef in situations where we know the GPS course over ground heading will not likely reflect the heading of the craft:
- (1) Suppress `ez_ef` during, and soon after, fast yaw stick inputs. A very fast yaw input will rotate the quad, changing heading immediately, but the craft will still drift on its original path for some time.  This factor stops the heading being incorrectly modified by GPS heading for about 2-3s after a fast yaw input
- (2) Suppress `ez_ef`when the quad is not flat on the roll axis.  If the user adds roll angle to a quad, it will start to fly 'sideways', and the GPS heading will track a course over ground that will not be consistent with the heading of the quad.  So we suppress the GPS adaptation completely when Roll exceeds 12 degrees, so that you only get a GPS heading correction when Roll angle is essentially flat to the horizon.  The allowed angle for wings is 25 degrees because they can't drift like a quad.
- (3) Suppress `ez_ef` when the quad's pitch attitude is flat, or pitched backwards, so that the quad will only adapt it's heading to GPS heading when pitched forward, which typically suggests that the quad is flying nose forward.  This stops errors arising from drift from wind or prior non-forward flight when the quad is flat, and stops errors developing when a quad is flown with negative pitch angle (backwards).  Note this pitch factor is not used for wings, since they fly forwards very nicely at a zero pitch angle.
- All three of these gain factors are multiplied together, so that we get a kind of overall assessment of the likelihood that the GPS heading is likely to be useful.  At times, `ez_ef` will be zero, and the gps data will not be considered, until such time as we assess that the quad is likely to be flying 'nose forward' at some decent speed.
- fixes an issue where an integer division resulted in abrupt steps in `cogYawGain`.
- changes and simplifies the logic relating to the one-off inflight re-calibration of the quaternion, so that in-flight re-calibration won't happen until there is at least 1m/s forward speed, previously even a transient speed of 1m/s would trigger this, and that could happen while carrying the quad around before takeoff. Not sure what that code achieves, but we can now more readily find out.
- Holds `ez_ef` at zero - GPS heading ignored - until there is at least 1m/s forward speed.  Once that threshold is reached, the code considers any GPS heading value.  At very low speeds, the `gpsGroundspeedGain ` factor is very close to zero and acts like a lowpass filter on `ez_ef`.  This works well. 

With this PR, this image shows a quick coordinated turn while pitched forward.  Note that IMU heading changes immediately we start the yaw+roll on gyro, and stay nearly constant once the roll and yaw gyros settle.  The IMU heading changes way ahead of GPS.  Once we complete the turn, the IMU heading is stable, and after a few seconds, the two heading readings become similar....

![Screen Shot 2024-02-24 at 10 44 29](https://github.com/betaflight/betaflight/assets/11737748/d0039cc6-4562-4279-b0f5-201866cdeb49)


*Notes about the IMU heading error with roll inputs*

This image is without the PR.  It again is a coordinated turn.  However, notice that the IMU estimate *lags* both the GPS data and lags the gyro changes a lot.
![Screen Shot 2024-02-17 at 12 04 03](https://github.com/betaflight/betaflight/assets/11737748/08ab8c84-042f-42ce-bec0-d39cfe87546e)

This image shows two pure yaw inputs, with rapid, accurate, and immediate IMU heading changes, but then with a coordinated, primarily roll turn, we see a lot of IMU heading lag, IMU heading overshoot, and a biphasic `ez_ef` trace, none of which should be happening:
![Screen Shot 2024-02-17 at 11 35 07](https://github.com/betaflight/betaflight/assets/11737748/6a6f891f-3522-41e1-baf4-cd038d8be962)

This image shows a pure yaw input followed by pitch forward to fly back along the same path.  Note that the IMU heading changes perfectly with the Yaw input, but as soon as we pitch forward, we get a big `ez_ef` error and the 'correct' heading change is kind of taken away transiently, only being restored later on by an opposite `ex_ef` value:
![Screen Shot 2024-02-17 at 11 39 43](https://github.com/betaflight/betaflight/assets/11737748/c31c11e6-aa41-4bf7-90e9-2cf0d5110c63)

These issues are fixed by changing the heading error value from the craft's X axis heading, and by modifying ez_ef gain parameters.

In [PR#12792]( https://github.com/betaflight/betaflight/pull/12792) the change was made to get heading error from Z axis (thrust vector) and I think that caused the roll/pitch heading issues. I regret not picking it up during GPS Rescue testing; with GPS Rescue, the majority of the heading changes are yaw dominant, and pitch/roll inputs are either minimal, constant, or transient.

Congratulations @limonspb for identifying the issue, testing extensively, and providing the logs that helped us identify the cause.

The PR has been tested quite a bit now, but still needs further review for coding and user edge cases.