### PR TITLE
Increase ez_landing_limit default to 15 (was 5)

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -228,7 +228,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_breakpoint = 1050,
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
-        .ez_landing_limit = 5,
+        .ez_landing_limit = 15,
     );
 
 #ifndef USE_D_MIN


### PR DESCRIPTION
There has been reports of instability when using EzLanding with the default ez_landing_limit of 5.
Especially freestyle quads with action cameras appear to have problems.
For example
https://youtube.com/clip/Ugkx-I6x2nW888n3OSC91ISli89JiUwHw-w-?si=s5hrpcZgTIUDIOyH

https://github.com/betaflight/betaflight/assets/6018638/0fd02995-2bc3-4d89-9576-a44ad282274f
[ez_landing_instability_logs.zip](https://github.com/betaflight/betaflight/files/14319357/ez_landing_instability_logs.zip)

Increasing ez_landing_limit have fixed the instability without noticeably increasing bounciness in at least one case.
The current ez_landing_limit is also known to be pretty conservative.
In theory 15 should still be less bouncy (with sticks centered and throttle at zero) than airmode off with the LEGACY mixer_type, and provide a bit more stability during dives.
More testing on different types of quad is still required though.

Thanks to DrainMan FPV for the first video and reptethetetlen for the second video and logs.