### PR TITLE
Log the standard deviation of gyro cycle time in SCHEDULER_DETERMINISM and TIMING_ACCURACY

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <limits.h>
+#include <math.h>
 
 #include "platform.h"
 
@@ -63,6 +64,7 @@
 // 4 - Minimum Gyro period in 100th of a us
 // 5 - Maximum Gyro period in 100th of a us
 // 6 - Span of Gyro period in 100th of a us
+// 7 - Standard deviation of gyro cycle time in 100th of a us
 
 // DEBUG_TIMING_ACCURACY, requires USE_LATE_TASK_STATISTICS to be defined
 // 0 - % CPU busy
@@ -70,6 +72,7 @@
 // 2 - Total lateness in last second in 10ths us
 // 3 - Total tasks run in last second
 // 4 - 10ths % of tasks late in last second
+// 7 - Standard deviation of gyro cycle time in 100th of a us
 
 extern task_t tasks[];
 
@@ -110,6 +113,7 @@ static uint32_t lateTaskTotal = 0;
 static int16_t taskCount = 0;
 static uint32_t lateTaskPercentage = 0;
 static uint32_t nextTimingCycles;
+static int32_t gyroCyclesNow;
 #endif
 
 static timeMs_t lastFailsafeCheckMs = 0;
@@ -453,6 +457,12 @@ FAST_CODE void scheduler(void)
 {
     static uint32_t checkCycles = 0;
     static uint32_t scheduleCount = 0;
+#if defined(USE_LATE_TASK_STATISTICS)
+    static uint32_t gyroCyclesMean = 0;
+    static uint32_t gyroCyclesCount = 0;
+    static uint64_t gyroCyclesTotal = 0;
+    static float devSquared = 0.0;
+#endif
 #if !defined(UNIT_TEST)
     const timeUs_t schedulerStartTimeUs = micros();
 #endif
@@ -507,7 +517,6 @@ FAST_CODE void scheduler(void)
                 nowCycles = getCycleCounter();
                 schedLoopRemainingCycles = cmpTimeCycles(nextTargetCycles, nowCycles);
             }
-            DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 0, clockCyclesTo10thMicros(cmpTimeCycles(nowCycles, lastTargetCycles)));
 #endif
             currentTimeUs = micros();
             taskExecutionTimeUs += schedulerExecuteTask(gyroTask, currentTimeUs);
@@ -533,6 +542,13 @@ FAST_CODE void scheduler(void)
             }
 
 #if defined(USE_LATE_TASK_STATISTICS)
+            gyroCyclesNow = cmpTimeCycles(nowCycles, lastTargetCycles);
+            gyroCyclesTotal += gyroCyclesNow;
+            gyroCyclesCount++;
+            DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 0, clockCyclesTo10thMicros(gyroCyclesNow));
+            int32_t deviationCycles = gyroCyclesNow - gyroCyclesMean;
+            devSquared += deviationCycles * deviationCycles;
+
             // % CPU busy
             DEBUG_SET(DEBUG_TIMING_ACCURACY, 0, getAverageSystemLoadPercent());
 
@@ -550,6 +566,16 @@ FAST_CODE void scheduler(void)
                 // 10ths % of tasks late in last second
                 DEBUG_SET(DEBUG_TIMING_ACCURACY, 4, lateTaskPercentage);
 
+                float gyroCyclesStdDev = sqrt(devSquared/gyroCyclesCount);
+                int32_t gyroCyclesStdDev100thus = clockCyclesTo100thMicros((int32_t)gyroCyclesStdDev);
+                DEBUG_SET(DEBUG_TIMING_ACCURACY, 7, gyroCyclesStdDev100thus);
+                DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 7, gyroCyclesStdDev100thus);
+
+                gyroCyclesMean = gyroCyclesTotal/gyroCyclesCount;
+
+                devSquared = 0.0;
+                gyroCyclesTotal = 0;
+                gyroCyclesCount = 0;
                 lateTaskCount = 0;
                 lateTaskTotal = 0;
                 taskCount = 0;
@@ -581,10 +607,6 @@ FAST_CODE void scheduler(void)
                 // Track the actual gyro rate over given number of cycle times and remove skew
                 static uint32_t terminalGyroLockCount = 0;
                 static int32_t accGyroSkew = 0;
-                static int32_t minGyroPeriod = (int32_t)INT_MAX;
-                static int32_t maxGyroPeriod = (int32_t)INT_MIN;
-                static uint32_t lastGyroSyncEXTI;
-                int32_t gyroCycles;
 
                 int32_t gyroSkew = cmpTimeCycles(nextTargetCycles, gyro->gyroSyncEXTI) % desiredPeriodCycles;
                 if (gyroSkew > (desiredPeriodCycles / 2)) {
@@ -593,22 +615,28 @@ FAST_CODE void scheduler(void)
 
                 accGyroSkew += gyroSkew;
 
-                gyroCycles = cmpTimeCycles(gyro->gyroSyncEXTI, lastGyroSyncEXTI);
+#if defined(USE_LATE_TASK_STATISTICS)
+                static int32_t minGyroPeriod = (int32_t)INT_MAX;
+                static int32_t maxGyroPeriod = (int32_t)INT_MIN;
+                static uint32_t lastGyroSyncEXTI;
 
-                if (gyroCycles) {
+                gyroCyclesNow = cmpTimeCycles(gyro->gyroSyncEXTI, lastGyroSyncEXTI);
+
+                if (gyroCyclesNow) {
                     lastGyroSyncEXTI = gyro->gyroSyncEXTI;
                     // If we're syncing to a short cycle, divide by eight
                     if (gyro->gyroShortPeriod != 0) {
-                        gyroCycles /= 8;
+                        gyroCyclesNow /= 8;
                     }
-                    if (gyroCycles < minGyroPeriod) {
-                        minGyroPeriod = gyroCycles;
+                    if (gyroCyclesNow < minGyroPeriod) {
+                        minGyroPeriod = gyroCyclesNow;
                     }
                     // Crude detection of missed cycles caused by configurator traffic
-                    if ((gyroCycles > maxGyroPeriod) && (gyroCycles < (1.5 * minGyroPeriod))) {
-                        maxGyroPeriod = gyroCycles;
+                    if ((gyroCyclesNow > maxGyroPeriod) && (gyroCyclesNow < (1.5 * minGyroPeriod))) {
+                        maxGyroPeriod = gyroCyclesNow;
                     }
                 }
+#endif
 
                 if (terminalGyroLockCount == 0) {
                     terminalGyroLockCount = gyro->detectedEXTI + GYRO_LOCK_COUNT;
@@ -620,13 +648,15 @@ FAST_CODE void scheduler(void)
                     // Move the desired start time of the gyroTask
                     lastTargetCycles -= (accGyroSkew/GYRO_LOCK_COUNT);
 
+#if defined(USE_LATE_TASK_STATISTICS)
                     DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 3, clockCyclesTo10thMicros(accGyroSkew/GYRO_LOCK_COUNT));
                     DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 4, clockCyclesTo100thMicros(minGyroPeriod));
                     DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 5, clockCyclesTo100thMicros(maxGyroPeriod));
                     DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 6, clockCyclesTo100thMicros(maxGyroPeriod - minGyroPeriod));
-                    accGyroSkew = 0;
                     minGyroPeriod = INT_MAX;
                     maxGyroPeriod = INT_MIN;
+#endif
+                    accGyroSkew = 0;
                 }
             }
        }

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -573,7 +573,7 @@ FAST_CODE void scheduler(void)
 
                 gyroCyclesMean = gyroCyclesTotal/gyroCyclesCount;
 
-                devSquared = 0.0;
+                devSquared = 0.0f;
                 gyroCyclesTotal = 0;
                 gyroCyclesCount = 0;
                 lateTaskCount = 0;

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -461,7 +461,7 @@ FAST_CODE void scheduler(void)
     static uint32_t gyroCyclesMean = 0;
     static uint32_t gyroCyclesCount = 0;
     static uint64_t gyroCyclesTotal = 0;
-    static float devSquared = 0.0;
+    static float devSquared = 0.0f;
 #endif
 #if !defined(UNIT_TEST)
     const timeUs_t schedulerStartTimeUs = micros();

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -625,15 +625,15 @@ static void convertVtxTmData(spektrumVtx_t * vtx)
 /*
 typedef struct
 {
-    UINT8		identifier;
-    UINT8		sID;	  // Secondary ID
-    UINT8		band;	  // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A, 5-7 = Reserved)
-    UINT8		channel;  // VTX Channel (0-7)
-    UINT8		pit;	  // Pit/Race mode (0 = Race, 1 = Pit). Race = (normal operating) mode. Pit = (reduced power) mode. When PIT is set, it overrides all other power settings
-    UINT8		power;	  // VTX Power (0 = Off, 1 = 1mw to 14mW, 2 = 15mW to 25mW, 3 = 26mW to 99mW, 4 = 100mW to 299mW, 5 = 300mW to 600mW, 6 = 601mW+, 7 = manual control)
-    UINT16		powerDec; // VTX Power as a decimal 1mw/unit
-    UINT8		region;	  // Region (0 = USA, 1 = EU, 0xFF = N/A)
-    UINT8		rfu[7];	  // reserved
+    UINT8       identifier;
+    UINT8       sID;      // Secondary ID
+    UINT8       band;     // VTX Band (0 = Fatshark, 1 = Raceband, 2 = E, 3 = B, 4 = A, 5-7 = Reserved)
+    UINT8       channel;  // VTX Channel (0-7)
+    UINT8       pit;      // Pit/Race mode (0 = Race, 1 = Pit). Race = (normal operating) mode. Pit = (reduced power) mode. When PIT is set, it overrides all other power settings
+    UINT8       power;    // VTX Power (0 = Off, 1 = 1mw to 14mW, 2 = 15mW to 25mW, 3 = 26mW to 99mW, 4 = 100mW to 299mW, 5 = 300mW to 600mW, 6 = 601mW+, 7 = manual control)
+    UINT16      powerDec; // VTX Power as a decimal 1mw/unit
+    UINT8       region;   // Region (0 = USA, 1 = EU, 0xFF = N/A)
+    UINT8       rfu[7];   // reserved
 } STRU_TELE_VTX;
 */
 


### PR DESCRIPTION
The SCHEDULER_DETERMINISM and TIMING_ACCURACY debug modes focus  on task lateness. This PR adds a measure of the impact on the gyro loop timing by reporting the standard deviation in 100ths of a us in debug[7].

This log was taken from a ZEEZF7V3 and shows how, with USB connected at the start and end of the log, this figure was about 2us, however with USB disconnected (between 5 and 10 seconds in the log), the figure was about 30ns!

[ZEEZF7V3_STDDEV.bbl.zip](https://github.com/betaflight/betaflight/files/14322701/ZEEZF7V3_STDDEV.bbl.zip)

@KarateBrot Please check the maths