### PR TITLE
IMU heading fix

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -230,12 +230,7 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt, float gx, float gy, float 
         // Compute heading vector in EF from scalar CoG. CoG is clockwise from North
         // Note that Earth frame X is pointing north and sin/cos argument is anticlockwise
         const fpVector2_t cog_ef = {.x = cos_approx(-courseOverGround), .y = sin_approx(-courseOverGround)};
-#define THRUST_COG 1
-#if THRUST_COG
-        const fpVector2_t heading_ef = {.x = rMat[X][Z], .y = rMat[Y][Z]};  // body Z axis (up) - direction of thrust vector
-#else
         const fpVector2_t heading_ef = {.x = rMat[0][0], .y = rMat[1][0]};  // body X axis. Projected vector magnitude is reduced as pitch increases
-#endif
         // cross product = 1 * |heading| * sin(angle) (magnitude of Z vector in 3D)
         // order operands so that rotation is in direction of zero error
         const float cross = vector2Cross(&heading_ef, &cog_ef);


### PR DESCRIPTION
@ctzsnooze  and me were trying to figure out why 4.5 home direction arrow is not as accurate as it was in 4.4.
Its the most visible on a wing where there is no yaw. But its also visible on the quad when you fly almost without YAW, but just with roll and pitch.

This is a partial revert to 4.4 behavior that fixes the problem
@ledvinap  could you plz have a look.
I want to emphasize that this also improves quad home arrow, more noticeable when doing coordinated roll-pitch turns.
