### PR TITLE
Do not go into failsafe when the correct roll/pitch/yaw/throttle are sent via MSP_OVERRIDE

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -789,6 +789,7 @@ const clivalue_t valueTable[] = {
     { "serialrx_halfduplex",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, halfDuplex) },
 #if defined(USE_RX_MSP_OVERRIDE)
     { "msp_override_channels_mask",      VAR_UINT32 | MASTER_VALUE, .config.u32Max = (1 << MAX_SUPPORTED_RC_CHANNEL_COUNT) - 1, PG_RX_CONFIG, offsetof(rxConfig_t, msp_override_channels_mask)},
+    { "msp_override_failsafe",      VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, msp_override_failsafe)},
 #endif
 #ifdef USE_RX_SPI
     { "rx_spi_protocol",            VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RX_SPI }, PG_RX_SPI_CONFIG, offsetof(rxSpiConfig_t, rx_spi_protocol) },

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -62,6 +62,7 @@ typedef struct rxConfig_s {
     uint8_t srxl2_baud_fast;                   // Select Spektrum SRXL2 fast baud rate
     uint8_t sbus_baud_fast;                    // Select SBus fast baud rate
     uint32_t msp_override_channels_mask;       // Channels to override when the MSP override mode is enabled
+    uint8_t msp_override_failsafe;             // if true then extra RC link is always required in msp_override mode, false - allows control via msp_override without extra RC link (autonomy use case)
     uint8_t crsf_use_negotiated_baud;          // Use negotiated baud rate for CRSF V3
 } rxConfig_t;
 

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -62,7 +62,7 @@ typedef struct rxConfig_s {
     uint8_t srxl2_baud_fast;                   // Select Spektrum SRXL2 fast baud rate
     uint8_t sbus_baud_fast;                    // Select SBus fast baud rate
     uint32_t msp_override_channels_mask;       // Channels to override when the MSP override mode is enabled
-    uint8_t msp_override_failsafe;             // if true then extra RC link is always required in msp_override mode, false - allows control via msp_override without extra RC link (autonomy use case)
+    uint8_t msp_override_failsafe;             // if false then extra RC link is always required in msp_override mode, true - allows control via msp_override without extra RC link (autonomous use case)
     uint8_t crsf_use_negotiated_baud;          // Use negotiated baud rate for CRSF V3
 } rxConfig_t;
 

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -73,6 +73,7 @@ static uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)
     return RX_FRAME_COMPLETE;
 }
 
+#if defined(USE_RX_MSP_OVERRIDE)
 uint8_t rxMspOverrideFrameStatus(void)
 {
     if (!rxMspOverrideFrameDone) {
@@ -82,6 +83,7 @@ uint8_t rxMspOverrideFrameStatus(void)
     rxMspOverrideFrameDone = false;
     return RX_FRAME_COMPLETE;
 }
+#endif
 
 void rxMspInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 {

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -59,7 +59,7 @@ void rxMspFrameReceive(uint16_t *frame, int channelCount)
     rxMspFrameDone = true;
 }
 
-static uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)
+uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
 

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -35,6 +35,7 @@
 
 static uint16_t mspFrame[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 static bool rxMspFrameDone = false;
+static bool rxMspOverrideFrameDone = false;
 
 float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan)
 {
@@ -57,9 +58,10 @@ void rxMspFrameReceive(uint16_t *frame, int channelCount)
     }
 
     rxMspFrameDone = true;
+    rxMspOverrideFrameDone = true;
 }
 
-uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)
+static uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
 
@@ -68,6 +70,16 @@ uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)
     }
 
     rxMspFrameDone = false;
+    return RX_FRAME_COMPLETE;
+}
+
+uint8_t rxMspOverrideFrameStatus(void)
+{
+    if (!rxMspOverrideFrameDone) {
+        return RX_FRAME_PENDING;
+    }
+
+    rxMspOverrideFrameDone = false;
     return RX_FRAME_COMPLETE;
 }
 

--- a/src/main/rx/msp.h
+++ b/src/main/rx/msp.h
@@ -25,4 +25,4 @@ struct rxRuntimeState_s;
 float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan);
 void rxMspInit(const struct rxConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState);
 void rxMspFrameReceive(uint16_t *frame, int channelCount);
-uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState);
+uint8_t rxMspOverrideFrameStatus();

--- a/src/main/rx/msp.h
+++ b/src/main/rx/msp.h
@@ -25,3 +25,4 @@ struct rxRuntimeState_s;
 float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan);
 void rxMspInit(const struct rxConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState);
 void rxMspFrameReceive(uint16_t *frame, int channelCount);
+uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -567,7 +567,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     }
 
 #if defined(USE_RX_MSP_OVERRIDE)
-    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask) {
+    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask && !rxConfig()->msp_override_failsafe) {
         if (rxMspOverrideFrameStatus() & RX_FRAME_COMPLETE) {
             rxSignalReceived = true;
             rxDataProcessingRequired = true;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -568,9 +568,11 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
 
 #if defined(USE_RX_MSP_OVERRIDE)
     if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask) {
-        rxSignalReceived = true;
-        rxDataProcessingRequired = true;
-        needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;
+        if (rxMspFrameStatus(&rxRuntimeState) & RX_FRAME_COMPLETE) {
+            rxSignalReceived = true;
+            rxDataProcessingRequired = true;
+            needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;
+        }
     }
 #endif
     

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -567,7 +567,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     }
 
 #if defined(USE_RX_MSP_OVERRIDE)
-    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask && !rxConfig()->msp_override_failsafe) {
+    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask && rxConfig()->msp_override_failsafe) {
         if (rxMspOverrideFrameStatus() & RX_FRAME_COMPLETE) {
             rxSignalReceived = true;
             rxDataProcessingRequired = true;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -567,7 +567,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     }
 
 #if defined(USE_RX_MSP_OVERRIDE)
-    if (rxConfig()->msp_override_channels_mask) {
+    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask) {
         rxSignalReceived = true;
         rxDataProcessingRequired = true;
         needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -566,6 +566,14 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
         }
     }
 
+#if defined(USE_RX_MSP_OVERRIDE)
+    if (rxConfig()->msp_override_channels_mask) {
+        rxSignalReceived = true;
+        rxDataProcessingRequired = true;
+        needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;
+    }
+#endif
+    
     DEBUG_SET(DEBUG_FAILSAFE, 1, rxSignalReceived);
     DEBUG_SET(DEBUG_RX_SIGNAL_LOSS, 0, rxSignalReceived);
 }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -568,7 +568,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
 
 #if defined(USE_RX_MSP_OVERRIDE)
     if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && rxConfig()->msp_override_channels_mask) {
-        if (rxMspFrameStatus(&rxRuntimeState) & RX_FRAME_COMPLETE) {
+        if (rxMspOverrideFrameStatus() & RX_FRAME_COMPLETE) {
             rxSignalReceived = true;
             rxDataProcessingRequired = true;
             needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;


### PR DESCRIPTION
Fixes #13374

Do not go into failsafe when the correct roll/pitch/yaw/throttle is sent via MSP_OVERRIDE.
Make sure to go into failsafe when there are no controls via RC link and via MSP_OVERRIDE.