### PR TITLE
Ensure consistent openssl behaviour with version 3.2.x and 3.3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ TARGET_MAP      = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).map
 
 TARGET_EXST_HASH_SECTION_FILE = $(TARGET_OBJ_DIR)/exst_hash_section.bin
 
-TARGET_EF_HASH      := $(shell echo -n "$(EXTRA_FLAGS)" | openssl dgst -md5 | awk '{print $$2;}')
+TARGET_EF_HASH      := $(shell echo -n "$(EXTRA_FLAGS)" | openssl dgst -md5 -r | awk '{print $$1;}')
 TARGET_EF_HASH_FILE := $(TARGET_OBJ_DIR)/.efhash_$(TARGET_EF_HASH)
 
 CLEAN_ARTIFACTS := $(TARGET_BIN)


### PR DESCRIPTION
When building from the command line or from within eclipse under MacOS is was noticed that the make dependencies were not being handled correctly.

This was due to the `EXTRA_FLAGS` being checksummed, see https://github.com/betaflight/betaflight/blob/c6250fee6e5e9833cfcc4f6e8f8541ff67ca203a/Makefile#L338

but the path used by the terminal was `/opt/local/bin/openssl` whereas the path within eclipse was `/usr/bin/openssl`. The former is version 3.2.0, whereas the latter is 3.3.6.

The output of `$(shell echo -n "$(EXTRA_FLAGS)" | openssl dgst -md5)` is `MD5(stdin)= 818b631372f10ad09e29463180b1c7d7` from the command line, and `818b631372f10ad09e29463180b1c7d7` from eclipse.

The addition of a `-r` argument leads to a consistent output without the `MD5(stdin)=` prefix.