### PR TITLE
Disable USE_SPEC_PREARM_SCREEN until timing is fixed

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -233,7 +233,7 @@
 // Dependency for CMS is defined outside this block.
 #define USE_OSD_QUICK_MENU
 #define USE_RC_STATS
-#define USE_SPEC_PREARM_SCREEN
+//#define USE_SPEC_PREARM_SCREEN
 #endif
 
 #define USE_BATTERY_CONTINUE
@@ -447,7 +447,7 @@
 #define USE_RC_STATS
 #endif
 #ifndef USE_SPEC_PREARM_SCREEN
-#define USE_SPEC_PREARM_SCREEN
+//#define USE_SPEC_PREARM_SCREEN
 #endif
 #endif
 


### PR DESCRIPTION
Disables functionality introduced in https://github.com/betaflight/betaflight/pull/13210 as it rides roughshod over the requires timing constraints for well behaved tasks.

Should fix the issues being discussed in https://github.com/betaflight/betaflight/pull/13330.