### PR TITLE
Fix OSD task timing when using MSP

### DIFF
--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -44,16 +44,16 @@ void serialWrite(serialPort_t *instance, uint8_t ch)
 }
 
 
-void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count)
+void serialWriteBufNoFlush(serialPort_t *instance, const uint8_t *data, int count)
 {
     if (instance->vTable->writeBuf) {
         instance->vTable->writeBuf(instance, data, count);
     } else {
+        // The transmit buffer is large enough to hold any single message, so only wait once
+        while (serialTxBytesFree(instance) < (uint32_t)count) {
+        };
+
         for (const uint8_t *p = data; count > 0; count--, p++) {
-
-            while (!serialTxBytesFree(instance)) {
-            };
-
             serialWrite(instance, *p);
         }
     }
@@ -107,11 +107,6 @@ void serialSetBaudRateCb(serialPort_t *serialPort, void (*cb)(serialPort_t *cont
     }
 }
 
-void serialWriteBufShim(void *instance, const uint8_t *data, int count)
-{
-    serialWriteBuf((serialPort_t *)instance, data, count);
-}
-
 void serialBeginWrite(serialPort_t *instance)
 {
     if (instance->vTable->beginWrite)
@@ -122,4 +117,15 @@ void serialEndWrite(serialPort_t *instance)
 {
     if (instance->vTable->endWrite)
         instance->vTable->endWrite(instance);
+}
+
+void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count)
+{
+    serialBeginWrite(instance);
+    serialWriteBufNoFlush(instance, data, count);
+    serialEndWrite(instance);
+}
+void serialWriteBufShim(void *instance, const uint8_t *data, int count)
+{
+    serialWriteBuf((serialPort_t *)instance, data, count);
 }

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -141,6 +141,7 @@ void serialWrite(serialPort_t *instance, uint8_t ch);
 uint32_t serialRxBytesWaiting(const serialPort_t *instance);
 uint32_t serialTxBytesFree(const serialPort_t *instance);
 void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count);
+void serialWriteBufNoFlush(serialPort_t *instance, const uint8_t *data, int count);
 uint8_t serialRead(serialPort_t *instance);
 void serialSetBaudRate(serialPort_t *instance, uint32_t baudRate);
 void serialSetMode(serialPort_t *instance, portMode_e mode);

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -317,9 +317,9 @@ static int mspSerialSendFrame(mspPort_t *msp, const uint8_t * hdr, int hdrLen, c
 
     // Transmit frame
     serialBeginWrite(msp->port);
-    serialWriteBuf(msp->port, hdr, hdrLen);
-    serialWriteBuf(msp->port, data, dataLen);
-    serialWriteBuf(msp->port, crc, crcLen);
+    serialWriteBufNoFlush(msp->port, hdr, hdrLen);
+    serialWriteBufNoFlush(msp->port, data, dataLen);
+    serialWriteBufNoFlush(msp->port, crc, crcLen);
     serialEndWrite(msp->port);
 
     return totalFrameLength;

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -206,13 +206,7 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
 #define OSD_GROUP_COUNT                 OSD_ITEM_COUNT
 // Aim to render a group of elements within a target time
 #define OSD_ELEMENT_RENDER_TARGET       30
-// Allow a margin by which a group render can exceed that of the sum of the elements before declaring insane
-// This will most likely be violated by a USB interrupt whilst using the CLI
-#if defined(STM32F411xE)
-#define OSD_ELEMENT_RENDER_GROUP_MARGIN 7
-#else
-#define OSD_ELEMENT_RENDER_GROUP_MARGIN 2
-#endif
+
 #define OSD_TASK_MARGIN                 1
 // Decay the estimated max task duration by 1/(1 << OSD_EXEC_TIME_SHIFT) on every invocation
 #define OSD_EXEC_TIME_SHIFT             8
@@ -1339,8 +1333,8 @@ typedef enum {
     OSD_STATE_PROCESS_STATS2,
     OSD_STATE_PROCESS_STATS3,
     OSD_STATE_UPDATE_ALARMS,
+    OSD_STATE_REFRESH_PREARM,
     OSD_STATE_UPDATE_CANVAS,
-    OSD_STATE_GROUP_ELEMENTS,
     OSD_STATE_UPDATE_ELEMENTS,
     OSD_STATE_UPDATE_HEARTBEAT,
     OSD_STATE_COMMIT,
@@ -1379,13 +1373,8 @@ bool osdUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 void osdUpdate(timeUs_t currentTimeUs)
 {
     static uint16_t osdStateDurationFractionUs[OSD_STATE_COUNT] = { 0 };
-    static uint32_t osdElementDurationUs[OSD_ITEM_COUNT] = { 0 };
-    static uint8_t osdElementGroupMemberships[OSD_ITEM_COUNT];
-    static uint16_t osdElementGroupTargetFractionUs[OSD_GROUP_COUNT] = { 0 };
-    static uint16_t osdElementGroupDurationFractionUs[OSD_GROUP_COUNT] = { 0 };
-    static uint8_t osdElementGroup;
+    static uint32_t osdElementDurationFractionUs[OSD_ITEM_COUNT] = { 0 };
     static bool firstPass = true;
-    uint8_t osdCurrentElementGroup = 0;
     timeUs_t executeTimeUs;
     osdState_e osdCurrentState = osdState;
 
@@ -1473,8 +1462,29 @@ void osdUpdate(timeUs_t currentTimeUs)
         if (resumeRefreshAt) {
             osdState = OSD_STATE_TRANSFER;
         } else {
+#ifdef USE_SPEC_PREARM_SCREEN
+            osdState = OSD_STATE_REFRESH_PREARM;
+#else
             osdState = OSD_STATE_UPDATE_CANVAS;
+#endif
         }
+        break;
+
+    case OSD_STATE_REFRESH_PREARM:
+        {
+#ifdef USE_SPEC_PREARM_SCREEN
+            if (!ARMING_FLAG(ARMED) && osdConfig()->osd_show_spec_prearm) {
+                if (osdDrawSpec(osdDisplayPort)) {
+                        // Rendering is complete
+                        osdState = OSD_STATE_COMMIT;
+                }
+            } else
+#endif // USE_SPEC_PREARM_SCREEN
+            {
+                osdState = OSD_STATE_UPDATE_CANVAS;
+            }
+        }
+
         break;
 
     case OSD_STATE_UPDATE_CANVAS:
@@ -1508,66 +1518,23 @@ void osdUpdate(timeUs_t currentTimeUs)
 
         osdSyncBlink();
 
-        osdState = OSD_STATE_GROUP_ELEMENTS;
+        osdState = OSD_STATE_UPDATE_ELEMENTS;
 
-        break;
-
-    case OSD_STATE_GROUP_ELEMENTS:
-        {
-            uint8_t elementGroup;
-            uint8_t activeElements = osdGetActiveElementCount();
-
-            // Reset groupings
-            for (elementGroup = 0; elementGroup < OSD_GROUP_COUNT; elementGroup++) {
-                if (osdElementGroupDurationFractionUs[elementGroup] > (OSD_ELEMENT_RENDER_TARGET << OSD_EXEC_TIME_SHIFT)) {
-                    osdElementGroupDurationFractionUs[elementGroup] = 0;
-                }
-                osdElementGroupTargetFractionUs[elementGroup] = 0;
-            }
-
-            elementGroup = 0;
-
-            // Based on the current element rendering, group to execute in approx 40us
-            for (uint8_t curElement = 0; curElement < activeElements; curElement++) {
-                if ((osdElementGroupTargetFractionUs[elementGroup] == 0) ||
-                    (osdElementGroupTargetFractionUs[elementGroup] + (osdElementDurationUs[curElement]) <= (OSD_ELEMENT_RENDER_TARGET << OSD_EXEC_TIME_SHIFT)) ||
-                    (elementGroup == (OSD_GROUP_COUNT - 1))) {
-                    osdElementGroupTargetFractionUs[elementGroup] += osdElementDurationUs[curElement];
-                    // If group membership changes, reset the stats for the group
-                    if (osdElementGroupMemberships[curElement] != elementGroup) {
-                        osdElementGroupDurationFractionUs[elementGroup] = osdElementGroupTargetFractionUs[elementGroup] + (OSD_ELEMENT_RENDER_GROUP_MARGIN << OSD_EXEC_TIME_SHIFT);
-                    }
-                    osdElementGroupMemberships[curElement] = elementGroup;
-                } else {
-                    elementGroup++;
-                    // Try again for this element
-                    curElement--;
-                }
-            }
-
-            // Start with group 0
-            osdElementGroup = 0;
-
-            if (activeElements > 0) {
-                osdState = OSD_STATE_UPDATE_ELEMENTS;
-            } else {
-                osdState = OSD_STATE_COMMIT;
-            }
-        }
         break;
 
     case OSD_STATE_UPDATE_ELEMENTS:
         {
-            osdCurrentElementGroup = osdElementGroup;
             bool moreElements = true;
 
-            do {
-                timeUs_t startElementTime = micros();
+            for (int rendered = 0; moreElements; rendered++) {
                 uint8_t osdCurrentElement = osdGetActiveElement();
 
-                // This element should be rendered in the next group
-                if (osdElementGroupMemberships[osdCurrentElement] != osdElementGroup) {
-                    osdElementGroup++;
+                timeUs_t startElementTime = micros();
+
+                timeUs_t anticipatedEndUs = startElementTime + (osdElementDurationFractionUs[osdCurrentElement] >> OSD_EXEC_TIME_SHIFT);
+
+                if ((rendered > 0) && cmpTimeUs(anticipatedEndUs, currentTimeUs) > OSD_ELEMENT_RENDER_TARGET) {
+                    // There isn't time to render the next element
                     break;
                 }
 
@@ -1575,23 +1542,18 @@ void osdUpdate(timeUs_t currentTimeUs)
 
                 executeTimeUs = micros() - startElementTime;
 
-                if (executeTimeUs > (osdElementDurationUs[osdCurrentElement] >> OSD_EXEC_TIME_SHIFT)) {
-                    osdElementDurationUs[osdCurrentElement] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
-                } else if (osdElementDurationUs[osdCurrentElement] > 0) {
+                if (executeTimeUs > (osdElementDurationFractionUs[osdCurrentElement] >> OSD_EXEC_TIME_SHIFT)) {
+                    osdElementDurationFractionUs[osdCurrentElement] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
+                } else if (osdElementDurationFractionUs[osdCurrentElement] > 0) {
                     // Slowly decay the max time
-                    osdElementDurationUs[osdCurrentElement]--;
+                    osdElementDurationFractionUs[osdCurrentElement]--;
                 }
-            } while (moreElements);
+            };
 
             if (moreElements) {
                 // There are more elements to draw
                 break;
             }
-#ifdef USE_SPEC_PREARM_SCREEN
-            osdDrawSpec(osdDisplayPort);
-#endif // USE_SPEC_PREARM_SCREEN
-
-            osdElementGroup = 0;
 
             osdState = OSD_STATE_COMMIT;
         }
@@ -1636,15 +1598,6 @@ void osdUpdate(timeUs_t currentTimeUs)
         // On the first pass no element groups will have been formed, so all elements will have been
         // rendered which is unrepresentative, so ignore
         if (!firstPass) {
-            if (osdCurrentState == OSD_STATE_UPDATE_ELEMENTS) {
-                if (executeTimeUs > (osdElementGroupDurationFractionUs[osdCurrentElementGroup] >> OSD_EXEC_TIME_SHIFT)) {
-                    osdElementGroupDurationFractionUs[osdCurrentElementGroup] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
-                } else if (osdElementGroupDurationFractionUs[osdCurrentElementGroup] > 0) {
-                    // Slowly decay the max time
-                    osdElementGroupDurationFractionUs[osdCurrentElementGroup]--;
-                }
-            }
-
             if (executeTimeUs > (osdStateDurationFractionUs[osdCurrentState] >> OSD_EXEC_TIME_SHIFT)) {
                 osdStateDurationFractionUs[osdCurrentState] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
             } else if (osdStateDurationFractionUs[osdCurrentState] > 0) {
@@ -1654,14 +1607,10 @@ void osdUpdate(timeUs_t currentTimeUs)
         }
     }
 
-    if (osdState == OSD_STATE_UPDATE_ELEMENTS) {
-        schedulerSetNextStateTime((osdElementGroupDurationFractionUs[osdElementGroup] >> OSD_EXEC_TIME_SHIFT) + OSD_ELEMENT_RENDER_GROUP_MARGIN);
+    if (osdState == OSD_STATE_IDLE) {
+        schedulerSetNextStateTime((osdStateDurationFractionUs[OSD_STATE_CHECK] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
     } else {
-        if (osdState == OSD_STATE_IDLE) {
-            schedulerSetNextStateTime((osdStateDurationFractionUs[OSD_STATE_CHECK] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
-        } else {
-            schedulerSetNextStateTime((osdStateDurationFractionUs[osdState] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
-        }
+        schedulerSetNextStateTime((osdStateDurationFractionUs[osdState] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
     }
 }
 

--- a/src/main/osd/osd_elements.h
+++ b/src/main/osd/osd_elements.h
@@ -39,6 +39,7 @@ typedef struct osdElementParms_s {
     char *buff;
     displayPort_t *osdDisplayPort;
     bool drawElement;
+    bool rendered;
     uint8_t attr;
 } osdElementParms_t;
 
@@ -65,5 +66,5 @@ void osdResetAlarms(void);
 void osdUpdateAlarms(void);
 bool osdElementsNeedAccelerometer(void);
 #ifdef USE_SPEC_PREARM_SCREEN
-void osdDrawSpec(displayPort_t *osdDisplayPort);
+bool osdDrawSpec(displayPort_t *osdDisplayPort);
 #endif // USE_SPEC_PREARM_SCREEN


### PR DESCRIPTION
Merge after:

- https://github.com/betaflight/betaflight/pull/13377
- https://github.com/betaflight/betaflight/pull/13385
- https://github.com/betaflight/betaflight/pull/13390

Prior to this PR the sending of OSD data over MSP was rather sub-optimal and resulted in a lot of late tasks.

Using the rather busy OSD display below as an example...

```
set osd_tim1 = 2592
set osd_vbat_pos = 2488
set osd_link_quality_pos = 2433
set osd_tim_1_pos = 6710
set osd_crosshairs_pos = 2253
set osd_ah_sbar_pos = 206
set osd_ah_pos = 78
set osd_current_pos = 2519
set osd_mah_drawn_pos = 2553
set osd_motor_diag_pos = 2465
set osd_gps_lon_pos = 0
set osd_gps_lat_pos = 17
set osd_gps_sats_pos = 417
set osd_compass_bar_pos = 2090
set osd_debug_pos = 2402
set osd_power_pos = 2497
set osd_pidrate_profile_pos = 2054
set osd_avg_cell_voltage_pos = 2456
set osd_pit_ang_pos = 2199
set osd_rol_ang_pos = 2231
set osd_battery_usage_pos = 2528
set osd_nheading_pos = 2101
set osd_rtc_date_time_pos = 357
set osd_rate_profile_name_pos = 2064
set osd_pid_profile_name_pos = 2058
set osd_profile_name_pos = 2048
set osd_rcchannels_pos = 2112
set osd_camera_frame_pos = 4270
set osd_efficiency_pos = 449
```

Logging with `TIMING_ACCURACY` on a MATEKF405TE connected to a WS VTX resulted in ~220 late tasks per second out of ~4850, approximately 4.5%.

![image](https://github.com/betaflight/betaflight/assets/11480839/19bec7c2-0361-4761-a861-0a54e9398fec)

With this PR this is greatly improved with <8 late tasks per second.

![image](https://github.com/betaflight/betaflight/assets/11480839/45420d9d-3877-47c8-bce1-6efd35d4a8dd)

Note that multi line elements such as the artificial horizon and sidebars, and the camera frame still causes issues and remain to be fixed.