### PR TITLE
Remove dshot 48 as lowest motor output on dyn idle

### DIFF
--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -339,9 +339,6 @@ void mixerInitProfile(void)
     mixerRuntime.dynIdleMaxIncrease = currentPidProfile->dyn_idle_max_increase * 0.001f;
     mixerRuntime.dynIdleStartIncrease = currentPidProfile->dyn_idle_start_increase * 0.001f;
     mixerRuntime.minRpsDelayK = 800 * pidGetDT() / 20.0f; //approx 20ms D delay, arbitrarily suits many motors
-    if (!mixerRuntime.feature3dEnabled && mixerRuntime.dynIdleMinRps) {
-        mixerRuntime.motorOutputLow = DSHOT_MIN_THROTTLE; // Override value set by initEscEndpoints to allow zero motor drive
-    }
 #endif
 
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)


### PR DESCRIPTION
The current state of dynamic idle will send dshot 48 (throttle 0%) as the lowest motor output command.
If the ESC is fast enough, and does not have a guard it self (like AM32), it will actually issue 0% throttle, which is not enough to drive a motor reliable with rpm reports, thus the motor and esc will loose sync. 
Small desyncs and motor restart are the symptoms.

With this PR you can adjust the lowest motor output command with the configured idle percentage. Previous behavior can be achieved with 0% idle.

More information and examples will follow.