### PR TITLE
Add ez_landing_speed parameter

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1410,6 +1410,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MIXER_TYPE, "%s",             lookupTableMixerType[mixerConfig()->mixer_type]);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_THRESHOLD, "%d",   currentPidProfile->ez_landing_threshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_LIMIT, "%d",       currentPidProfile->ez_landing_limit);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_SPEED, "%d",       currentPidProfile->ez_landing_speed);
 
         BLACKBOX_PRINT_HEADER_LINE("rc_rates", "%d,%d,%d",                  currentControlRateProfile->rcRates[ROLL],
                                                                             currentControlRateProfile->rcRates[PITCH],

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1261,6 +1261,7 @@ const clivalue_t valueTable[] = {
 
     { PARAM_NAME_EZ_LANDING_THRESHOLD,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
     { PARAM_NAME_EZ_LANDING_LIMIT,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 75 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
+    { PARAM_NAME_EZ_LANDING_SPEED,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_speed) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -61,6 +61,7 @@
 #define PARAM_NAME_MIXER_TYPE "mixer_type"
 #define PARAM_NAME_EZ_LANDING_THRESHOLD "ez_landing_threshold"
 #define PARAM_NAME_EZ_LANDING_LIMIT "ez_landing_limit"
+#define PARAM_NAME_EZ_LANDING_SPEED "ez_landing_speed"
 #define PARAM_NAME_THROTTLE_LIMIT_TYPE "throttle_limit_type"
 #define PARAM_NAME_THROTTLE_LIMIT_PERCENT "throttle_limit_percent"
 #define PARAM_NAME_GYRO_CAL_ON_FIRST_ARM "gyro_cal_on_first_arm"

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -508,7 +508,7 @@ static float calcEzLandLimit(float maxDeflection, float speed)
 {
     // calculate limit to where the mixer can raise the throttle based on RPY stick deflection
     // 0.0 = no increas allowed, 1.0 = 100% increase allowed
-    const float deflectionLimit = fminf(1.0f, maxDeflection / mixerRuntime.ezLandingThreshold);
+    const float deflectionLimit = mixerRuntime.ezLandingThreshold > 0.0f ? fminf(1.0f, maxDeflection / mixerRuntime.ezLandingThreshold) : 0.0f;
     DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
 
     // calculate limit to where the mixer can raise the throttle based on speed

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -528,10 +528,8 @@ static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin,
     const float normalizedMotorMixMin = motorMixMin * baseNormalizationFactor;
     const float normalizedMotorMixMax = motorMixMax * baseNormalizationFactor;
 
-    // Upper throttle limit
-    // range default 0.05 - 1.0 with ezLandingLimit = 5, no stick deflection -> 0.05
 #ifdef USE_GPS
-    const float speed = gpsSol.speed3d;
+    const float speed = STATE(GPS_FIX) ? gpsSol.speed3d : 0.0f;
 #else
     const float speed = 0.0f;
 #endif

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -529,7 +529,7 @@ static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin,
     const float normalizedMotorMixMax = motorMixMax * baseNormalizationFactor;
 
 #ifdef USE_GPS
-    const float speed = STATE(GPS_FIX) ? gpsSol.speed3d : 0.0f;
+    const float speed = STATE(GPS_FIX) ? gpsSol.speed3d / 100.0f : 0.0f;
 #else
     const float speed = 0.0f;
 #endif

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -509,6 +509,7 @@ static float calcEzLandLimit(float maxDeflection, float speed)
     // calculate limit to where the mixer can raise the throttle based on RPY stick deflection
     // 0.0 = no increas allowed, 1.0 = 100% increase allowed
     const float deflectionLimit = fminf(1.0f, maxDeflection / mixerRuntime.ezLandingThreshold);
+    DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
 
     // calculate limit to where the mixer can raise the throttle based on speed
     // TODO sanity checks like number of sats, dop, accuracy?
@@ -566,6 +567,7 @@ static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin,
     // DEBUG_EZLANDING 1 is the adjusted throttle
     DEBUG_SET(DEBUG_EZLANDING, 2, upperLimit * 10000U);
     DEBUG_SET(DEBUG_EZLANDING, 3, fminf(1.0f, ezLandLimit / absMotorMixMin) * 10000U);
+    // DEBUG_EZLANDING 4 and 5 is the upper limits based on stick input and speed respectively
 }
 
 static void applyMixerAdjustment(float *motorMix, const float motorMixMin, const float motorMixMax, const bool airmodeEnabled)

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -529,7 +529,7 @@ static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin,
     const float normalizedMotorMixMax = motorMixMax * baseNormalizationFactor;
 
 #ifdef USE_GPS
-    const float speed = STATE(GPS_FIX) ? gpsSol.speed3d / 100.0f : 0.0f;
+    const float speed = STATE(GPS_FIX) ? gpsSol.speed3d / 100.0f : 0.0f;  // m/s
 #else
     const float speed = 0.0f;
 #endif

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -369,7 +369,7 @@ void mixerInitProfile(void)
 
     mixerRuntime.ezLandingThreshold = 2.0f * currentPidProfile->ez_landing_threshold / 100.0f;
     mixerRuntime.ezLandingLimit = currentPidProfile->ez_landing_limit / 100.0f;
-    mixerRuntime.ezLandingSpeed = currentPidProfile->ez_landing_speed > 0 ? 2.0f * currentPidProfile->ez_landing_speed / 10.0f : 0.0f;
+    mixerRuntime.ezLandingSpeed = 2.0f * currentPidProfile->ez_landing_speed / 10.0f;
 }
 
 #ifdef USE_RPM_LIMIT

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -369,7 +369,7 @@ void mixerInitProfile(void)
 
     mixerRuntime.ezLandingThreshold = 2.0f * currentPidProfile->ez_landing_threshold / 100.0f;
     mixerRuntime.ezLandingLimit = currentPidProfile->ez_landing_limit / 100.0f;
-    mixerRuntime.ezLandingSpeed = currentPidProfile->ez_landing_speed > 0 ? currentPidProfile->ez_landing_speed / 10.0f : 0.0f;
+    mixerRuntime.ezLandingSpeed = currentPidProfile->ez_landing_speed > 0 ? 2.0f * currentPidProfile->ez_landing_speed / 10.0f : 0.0f;
 }
 
 #ifdef USE_RPM_LIMIT

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -369,6 +369,7 @@ void mixerInitProfile(void)
 
     mixerRuntime.ezLandingThreshold = 2.0f * currentPidProfile->ez_landing_threshold / 100.0f;
     mixerRuntime.ezLandingLimit = currentPidProfile->ez_landing_limit / 100.0f;
+    mixerRuntime.ezLandingSpeed = currentPidProfile->ez_landing_speed > 0 ? currentPidProfile->ez_landing_speed / 10.0f : 0.0f;
 }
 
 #ifdef USE_RPM_LIMIT

--- a/src/main/flight/mixer_init.h
+++ b/src/main/flight/mixer_init.h
@@ -66,6 +66,7 @@ typedef struct mixerRuntime_s {
 #endif
     float ezLandingThreshold;
     float ezLandingLimit;
+    float ezLandingSpeed;
 } mixerRuntime_t;
 
 extern mixerRuntime_t mixerRuntime;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -229,6 +229,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
         .ez_landing_limit = 15,
+        .ez_landing_speed = 50,
     );
 
 #ifndef USE_D_MIN

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -244,6 +244,7 @@ typedef struct pidProfile_s {
 
     uint8_t ez_landing_threshold;           // Threshold stick position below which motor output is limited
     uint8_t ez_landing_limit;               // Maximum motor output when all sticks centred and throttle zero
+    uint8_t ez_landing_speed;               // Speed below which motor output is limited
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);


### PR DESCRIPTION
Draft for adding a factor based on speed to the EzLanding calculation.

The parameter is the speed at which ez_landing will be effectively disabled in tenths of meters per second. Default value 50 (5 m/s).

### Added debug fields
* EZLANDING debug 4  is the contribution from stick position to the ezlanding throttle cap.
* EZLANDING debug 5 is the contribution from this parameter to the ezlanding throttle cap.

Note that the highest value from stick position and speed is used. The values are not added. 
