### PR TITLE
Add VTX Offline warning in OSD

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -365,6 +365,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     // turn off the over mah capacity warning
     osdWarnSetState(OSD_WARNING_OVER_CAP, false);
 
+#ifdef USE_VTX
+    osdWarnSetState(OSD_WARNING_VTX_OFFLINE, true);
+#endif
+
 #ifdef USE_RC_STATS
     osdStatSetState(OSD_STAT_FULL_THROTTLE_TIME, true);
     osdStatSetState(OSD_STAT_FULL_THROTTLE_COUNTER, true);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -282,6 +282,7 @@ typedef enum {
     OSD_WARNING_OVER_CAP,
     OSD_WARNING_RSNR,
     OSD_WARNING_LOAD,
+    OSD_WARNING_VTX_OFFLINE,
     OSD_WARNING_COUNT // MUST BE LAST
 } osdWarningsFlags_e;
 

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -39,6 +39,7 @@
 #include "drivers/osd_symbols.h"
 #include "drivers/time.h"
 #include "drivers/dshot.h"
+#include "drivers/vtx_common.h"
 
 #include "fc/core.h"
 #include "fc/rc.h"
@@ -426,6 +427,16 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         osdSetVisualBeeperState(false);
         return;
     }
+
+#ifdef USE_VTX
+    if (osdWarnGetState(OSD_WARNING_VTX_OFFLINE) && !ARMING_FLAG(ARMED)) {
+        if (!vtxCommonDeviceIsReady(vtxCommonDevice())) {
+            tfp_sprintf(warningText, "VTX OFFLINE");
+            *displayAttr = DISPLAYPORT_SEVERITY_INFO;
+            return;
+        }
+    }
+#endif // USE_VTX
 
 }
 


### PR DESCRIPTION
Closes #13415. Small change to show "VTX OFFLINE" warning in OSD when built with VTX support and VTX is not detected.

it's a lower priority than all other elements as it is not an "emergent" warning (if you have video, you can at least somewhat fly). Respective VTX menus already show a warning when a VTX is not detected, so this only adds the warning element from the issue.