### PR TITLE
Add support for SPL07_003 barometer - based on DPS310

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -224,12 +224,12 @@ static bool deviceConfigure(const extDevice_t *dev)
     baroState.calib.c40 = 0;
 
     if (chipId[0] == SPL07_003_CHIP_ID) {
-		// 0x23 c31 [3:0] + 0x22 c31 [11:4]
-		baroState.calib.c31 = getTwosComplement(((uint32_t)coef[18] << 4) | (((uint32_t)coef[19] >> 4) & 0x0F), 12);
-	
-		// 0x23 c40 [11:8] + 0x24 c40 [7:0]
-		baroState.calib.c40 = getTwosComplement((((uint32_t)coef[19] & 0x0F) << 8) | (uint32_t)coef[20], 12);
-	}
+        // 0x23 c31 [3:0] + 0x22 c31 [11:4]
+        baroState.calib.c31 = getTwosComplement(((uint32_t)coef[18] << 4) | (((uint32_t)coef[19] >> 4) & 0x0F), 12);
+
+        // 0x23 c40 [11:8] + 0x24 c40 [7:0]
+        baroState.calib.c40 = getTwosComplement((((uint32_t)coef[19] & 0x0F) << 8) | (uint32_t)coef[20], 12);
+    }
 
     // PRS_CFG: pressure measurement rate (32 Hz) and oversampling (16 time standard)
     registerSetBits(dev, DPS310_REG_PRS_CFG, DPS310_PRS_CFG_BIT_PM_RATE_32HZ | DPS310_PRS_CFG_BIT_PM_PRC_16);

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -35,6 +35,7 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 #include "common/utils.h"
+#include "common/maths.h"
 
 #include "drivers/io.h"
 #include "drivers/bus.h"
@@ -173,24 +174,16 @@ static bool deviceConfigure(const extDevice_t *dev)
     // 1. Read the pressure calibration coefficients (c00, c10, c20, c30, c01, c11, and c21) from the Calibration Coefficient register.
     //   Note: The coefficients read from the coefficient register are 2's complement numbers.
     // Do the read of the coefficients in multiple parts, as the chip will return a read failure when trying to read all at once over I2C.
-    uint8_t COEFFICIENT_LENGTH, READ_LENGTH;
+    unsigned coefficientLength = chipId[0] == SPL07_003_CHIP_ID ? 22 : 18;
+    uint8_t coef[coefficientLength];
 
-    if (chipId[0] == SPL07_003_CHIP_ID) {
-        COEFFICIENT_LENGTH = 22;
-    } else {
-        COEFFICIENT_LENGTH = 18;
+    for (unsigned i = 0; i < sizeof(coef); ) {
+        int chunk = MIN(coefficientLength / 2, (sizeof(coef) - i));
+        if (!busReadBuf(dev, DPS310_REG_COEF + i,  coef + i, chunk)) {
+            return false;
+        }
+        i += chunk;
     }
-
-    READ_LENGTH = COEFFICIENT_LENGTH / 2;
-
-    uint8_t coef[COEFFICIENT_LENGTH];
-    if (!busReadBuf(dev, DPS310_REG_COEF, coef, READ_LENGTH)) {
-        return false;
-    }
-    if (!busReadBuf(dev, DPS310_REG_COEF + READ_LENGTH, coef + READ_LENGTH, COEFFICIENT_LENGTH - READ_LENGTH)) {
-        return false;
-    }
-
     // See section 8.11, Calibration Coefficients (COEF), of datasheet
 
     // 0x11 c0 [3:0] + 0x10 c0 [11:4]
@@ -238,8 +231,8 @@ static bool deviceConfigure(const extDevice_t *dev)
     if (chipId[0] == SPL07_003_CHIP_ID) {
         registerSetBits(dev, DPS310_REG_TMP_CFG, DPS310_TMP_CFG_BIT_TMP_RATE_32HZ | DPS310_TMP_CFG_BIT_TMP_PRC_16);
     } else {
-        const uint8_t TMP_COEF_SRCE = registerRead(dev, DPS310_REG_COEF_SRCE) & DPS310_COEF_SRCE_BIT_TMP_COEF_SRCE;
-        registerSetBits(dev, DPS310_REG_TMP_CFG, DPS310_TMP_CFG_BIT_TMP_RATE_32HZ | DPS310_TMP_CFG_BIT_TMP_PRC_16 | TMP_COEF_SRCE);
+        const uint8_t tempCoefSource = registerRead(dev, DPS310_REG_COEF_SRCE) & DPS310_COEF_SRCE_BIT_TMP_COEF_SRCE;
+        registerSetBits(dev, DPS310_REG_TMP_CFG, DPS310_TMP_CFG_BIT_TMP_RATE_32HZ | DPS310_TMP_CFG_BIT_TMP_PRC_16 | tempCoefSource);
     }
 
     // CFG_REG: set pressure and temperature result bit-shift (required when the oversampling rate is >8 times)

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -171,7 +171,7 @@ static bool deviceConfigure(const extDevice_t *dev)
         return false;
     }
 
-    // 1. Read the pressure calibration coefficients (c00, c10, c20, c30, c01, c11, and c21) from the Calibration Coefficient register.
+    // 1. Read the pressure calibration coefficients (c00, c10, c20, c30, c01, c11, and c21, c31, c40) from the Calibration Coefficient register.
     //   Note: The coefficients read from the coefficient register are 2's complement numbers.
     // Do the read of the coefficients in multiple parts, as the chip will return a read failure when trying to read all at once over I2C.
     unsigned coefficientLength = chipId[0] == SPL07_003_CHIP_ID ? 22 : 18;
@@ -284,9 +284,11 @@ static bool dps310GetUP(baroDev_t *baro)
     const float c20 = baroState.calib.c20;
     const float c21 = baroState.calib.c21;
     const float c30 = baroState.calib.c30;
+    const float c31 = baroState.calib.c31;
+    const float c40 = baroState.calib.c40;
 
     // See section 4.9.1, How to Calculate Compensated Pressure Values, of datasheet
-    baroState.pressure = c00 + Praw_sc * (c10 + Praw_sc * (c20 + Praw_sc * c30)) + Traw_sc * c01 + Traw_sc * Praw_sc * (c11 + Praw_sc * c21);
+    baroState.pressure = c00 + Praw_sc * (c10 + Praw_sc * (c20 + Praw_sc * (c30 + Praw_sc * c40))) + Traw_sc * c01 + Traw_sc * Praw_sc * (c11 + Praw_sc * (c21 + Praw_sc * c31));
 
     const float c0 = baroState.calib.c0;
     const float c1 = baroState.calib.c1;

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -178,7 +178,7 @@ static bool deviceConfigure(const extDevice_t *dev)
     uint8_t coef[coefficientLength];
 
     for (unsigned i = 0; i < sizeof(coef); ) {
-        int chunk = MIN(9, (sizeof(coef) - i));
+        int chunk = MIN((unsigned)9, (sizeof(coef) - i));
         if (!busReadBuf(dev, DPS310_REG_COEF + i,  coef + i, chunk)) {
             return false;
         }

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -178,7 +178,7 @@ static bool deviceConfigure(const extDevice_t *dev)
     uint8_t coef[coefficientLength];
 
     for (unsigned i = 0; i < sizeof(coef); ) {
-        int chunk = MIN(coefficientLength / 2, (sizeof(coef) - i));
+        int chunk = MIN(9, (sizeof(coef) - i));
         if (!busReadBuf(dev, DPS310_REG_COEF + i,  coef + i, chunk)) {
             return false;
         }

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -221,6 +221,9 @@ static bool deviceConfigure(const extDevice_t *dev)
 
         // 0x23 c40 [11:8] + 0x24 c40 [7:0]
         baroState.calib.c40 = getTwosComplement((((uint32_t)coef[19] & 0x0F) << 8) | (uint32_t)coef[20], 12);
+    } else {
+        baroState.calib.c31 = 0;
+        baroState.calib.c40 = 0; 
     }
 
     // PRS_CFG: pressure measurement rate (32 Hz) and oversampling (16 time standard)

--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -70,7 +70,7 @@
 #define DPS310_REG_COEF_SRCE        0x28
 
 #define DPS310_ID_REV_AND_PROD_ID       (0x10)  // Infineon DPS310
-#define SPL07_003_CHIP_ID               (0x11)  // GoerTek SPA006_003 or SPL07_003
+#define SPL07_003_CHIP_ID               (0x11)  // SPL07_003
 
 #define DPS310_RESET_BIT_SOFT_RST       (0x09)    // 0b1001
 


### PR DESCRIPTION
- https://github.com/betaflight/betaflight/files/14509296/SPA06-003.datasheet.Ver02.pdf
- Tested DPS310 as performance is not affected.
- We need SPL07_003 samples to verify and test the changes [✓ tested with SPEEDYBEEF405MINI]
- PR is such designed that new changes are totally depend on chip ID and does not affect original DPS310 driver.
