### PR TITLE
Fix code style

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -359,8 +359,7 @@ static void validateAndFixConfig(void)
         rxConfigMutable()->rssi_src_frame_errors = false;
     }
 
-    if (
-        featureIsConfigured(FEATURE_3D) || !featureIsConfigured(FEATURE_GPS) || mixerModeIsFixedWing(mixerConfig()->mixerMode)
+    if (featureIsConfigured(FEATURE_3D) || !featureIsConfigured(FEATURE_GPS) || mixerModeIsFixedWing(mixerConfig()->mixerMode)
 #if !defined(USE_GPS) || !defined(USE_GPS_RESCUE)
         || true
 #endif

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -177,7 +177,7 @@ void processRcStickPositions(void)
                 // in a true signal loss situation, allow disarm only once we regain validated RxData (failsafeIsReceivingRxData = true),
                 // to avoid potentially false disarm signals soon after link recover
                 // Note that BOXFAILSAFE will also drive failsafeIsReceivingRxData false (immediately at start or end)
-                // That's why we explicitly allow disarm here BOXFAILSAFE switch is active
+                // That's why we explicitly allow disarm here if BOXFAILSAFE switch is active
                 // Note that BOXGPSRESCUE mode does not trigger failsafe - we can always disarm in that mode
                 rcDisarmTicks++;
                 if (rcDisarmTicks > 3) {


### PR DESCRIPTION
~~- Fix GPS arming disable flag showing up while `BOXGPSRESCUE` is enabled but `failsafe_procedure` is not set to `GPS_RESCUE`~~
- Fix code style