### PR TITLE
Refactor Rx code and better support 25Hz links

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -905,7 +905,7 @@ static void loadSlowState(blackboxSlowState_t *slow)
     memcpy(&slow->flightModeFlags, &rcModeActivationMask, sizeof(slow->flightModeFlags)); //was flightModeFlags;
     slow->stateFlags = stateFlags;
     slow->failsafePhase = failsafePhase();
-    slow->rxSignalReceived = rxIsReceivingSignal();
+    slow->rxSignalReceived = isRxReceivingSignal();
     slow->rxFlightChannelsValid = rxAreFlightChannelsValid();
 }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4961,8 +4961,7 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
         if (rcSmoothingAutoCalculate()) {
             cliPrint("# Detected Rx frequency: ");
             if (getRxRateValid()) {
-	            const uint16_t smoothedRxRateHz = lrintf(rcSmoothingData->smoothedRxRateHz);
-                cliPrintLinef("%dHz", smoothedRxRateHz);
+	            cliPrintLinef("%dHz", lrintf(rcSmoothingData->smoothedRxRateHz));
             } else {
             	cliPrintLine("NO SIGNAL");          
             }

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4770,10 +4770,9 @@ if (buildKey) {
     // Run status
 
     const int gyroRate = getTaskDeltaTimeUs(TASK_GYRO) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTimeUs(TASK_GYRO)));
-    int rxRate = getCurrentRxIntervalUs();
-    if (rxRate != 0) {
-        rxRate = (int)(1000000.0f / ((float)rxRate));
-    }
+
+    int rxRate = getRxRateValid() ? getCurrentRxRateHz() : 0;
+
     const int systemRate = getTaskDeltaTimeUs(TASK_SYSTEM) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTimeUs(TASK_SYSTEM)));
     cliPrintLinef("CPU:%d%%, cycle time: %d, GYRO rate: %d, RX rate: %d, System rate: %d",
             constrain(getAverageSystemLoadPercent(), 0, LOAD_PERCENTAGE_ONE), getTaskDeltaTimeUs(TASK_GYRO), gyroRate, rxRate, systemRate);
@@ -4960,12 +4959,12 @@ static void cliRcSmoothing(const char *cmdName, char *cmdline)
     if (rxConfig()->rc_smoothing_mode) {
         cliPrintLine("FILTER");
         if (rcSmoothingAutoCalculate()) {
-            const uint16_t smoothedRxRateHz = lrintf(rcSmoothingData->smoothedRxRateHz);
             cliPrint("# Detected Rx frequency: ");
-            if (getCurrentRxIntervalUs() == 0) {
-                cliPrintLine("NO SIGNAL");
-            } else {
+            if (getRxRateValid()) {
+	            const uint16_t smoothedRxRateHz = lrintf(rcSmoothingData->smoothedRxRateHz);
                 cliPrintLinef("%dHz", smoothedRxRateHz);
+            } else {
+            	cliPrintLine("NO SIGNAL");          
             }
         }
         cliPrintf("# Active setpoint cutoff: %dhz ", rcSmoothingData->setpointCutoffFrequency);

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -762,7 +762,7 @@ bool processRx(timeUs_t currentTimeUs)
         return false;
     }
 
-    updateRcRefreshRate(currentTimeUs);
+    updateRcRefreshRate(currentTimeUs, rxIsReceivingSignal());
 
     // in 3D mode, we need to be able to disarm by switch at any time
     if (featureIsEnabled(FEATURE_3D)) {

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -292,7 +292,7 @@ void updateArmingStatus(void)
         // If switch is used for arming then check it is not defaulting to on when the RX link recovers from a fault
         if (!isUsingSticksForArming()) {
             static bool hadRx = false;
-            const bool haveRx = rxIsReceivingSignal();
+            const bool haveRx = isRxReceivingSignal();
 
             const bool justGotRxBack = !hadRx && haveRx;
 
@@ -762,7 +762,7 @@ bool processRx(timeUs_t currentTimeUs)
         return false;
     }
 
-    updateRcRefreshRate(currentTimeUs, rxIsReceivingSignal());
+    updateRcRefreshRate(currentTimeUs, isRxReceivingSignal());
 
     // in 3D mode, we need to be able to disarm by switch at any time
     if (featureIsEnabled(FEATURE_3D)) {

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -271,8 +271,6 @@ void updateRcRefreshRate(timeUs_t currentTimeUs, bool rxReceivingSignal)
     // every time a new frame is detected,
     // and after RXLOSS_TRIGGER_INTERVAL since the last good frame, and
     // then every RX_FRAME_RECHECK_INTERVAL, until a new frame is detected
-    //   (rxReceivingSignal == false)
-
     // it provides values for use in RCSmoothing, Feedforward, etc.
     static timeUs_t lastRxTimeUs = 0;
     timeDelta_t delta = 0;

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -279,10 +279,13 @@ void updateRcRefreshRate(timeUs_t currentTimeUs)
 
     DEBUG_SET(DEBUG_RX_TIMING, 4, MIN(frameDeltaUs / 10, INT16_MAX));   // time between frames based on rxFrameCheck
     DEBUG_SET(DEBUG_RX_TIMING, 5, MIN(frameDeltaUsRx / 10, INT16_MAX)); // time between frames as reported by Rx
+#ifdef USE_RX_LINK_QUALITY_INFO
+    DEBUG_SET(DEBUG_RX_TIMING, 6, rxGetLinkQualityPercent());                  // raw link quality value
+#endif
 
     // if we have non-zero Rx-reported values, and
-    // the Rx Reported frameAgeUs is less than our rxFrameCheck delta time
-    // meaning we got a packet with an interval less than that reported by the Rx, perhaps Rx packet didn't have a time stamp?
+    // the Rx Reported frameAgeUs is less than our rxFrameCheck delta time (normally less than 30us)
+    // if the link is lost, the incoming frameDeltaUsRx does not change, but frameAge climbs rapidly to integer maximum
     if (frameDeltaUsRx && frameAgeUs < frameDeltaUs) {
         frameDeltaUs = frameDeltaUsRx;
     }

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -272,9 +272,6 @@ void updateRcRefreshRate(timeUs_t currentTimeUs)
     // then every RX_FRAME_CHECK_INTERVAL, until a new frame is detected
     // it provides values for use in RCSmoothing, Feedforward, etc.
 
-    // get the frame interval reported by the Rx driver code
-    // this will be zero for NULL values and for forced checks in the absence of incoming data
-    timeDelta_t frameDeltaUsRx = rxGetFrameDelta();
 
     // calculate frame interval here as well both on new packets and on forced checks without new packets
     // provides an alternative delta value if zero returned by rxGetFrameDelta()

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -267,7 +267,9 @@ static void scaleRawSetpointToFpvCamAngle(void)
 
 void updateRcRefreshRate(timeUs_t currentTimeUs)
 {
-    // this function runs when a new frame is detected, after 150ms of no frames, and then every 50ms until the link is restored.
+    // this function runs whenever a new frame is detected, and
+    // after RXLOSS_TRIGGER_INTERVAL since the last good frame, and 
+    // then every RX_FRAME_CHECK_INTERVAL, until a new frame is detected
     // it provides values for use in RCSmoothing, Feedforward, etc.
 
     // get the frame interval reported by the Rx driver code

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -268,7 +268,7 @@ void updateRcRefreshRate(timeUs_t currentTimeUs, bool newDataReceived)
 {
     // this function runs whenever a new frame is detected (newDataReceived == true),
     // and after RXLOSS_TRIGGER_INTERVAL since the last good frame, and
-    // then every RX_FRAME_CHECK_INTERVAL, until a new frame is detected
+    // then every RX_FRAME_RECHECK_INTERVAL, until a new frame is detected
     //   (newDataReceived == false)
 
     // it provides values for use in RCSmoothing, Feedforward, etc.
@@ -283,6 +283,7 @@ void updateRcRefreshRate(timeUs_t currentTimeUs, bool newDataReceived)
             delta = cmpTimeUs(rxTime, lastRxTimeUs);
         }
         lastRxTimeUs = rxTime;
+        DEBUG_SET(DEBUG_RX_TIMING, 1, rxTime / 100);   // output value in hundredths of ms
     } else {
         if (lastRxTimeUs) {
             // no packet received, use current time for delta

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -56,6 +56,8 @@
 
 #include "rc.h"
 
+#define RX_INTERVAL_MIN_US     950 // 0.950ms to fit 1kHz without an issue
+#define RX_INTERVAL_MAX_US   65500 // 65.5ms or 15.26hz
 
 typedef float (applyRatesFn)(const int axis, float rcCommandf, const float rcCommandfAbs);
 // note that rcCommand[] is an external float
@@ -68,8 +70,6 @@ static float maxRcDeflectionAbs;
 static bool reverseMotors = false;
 static applyRatesFn *applyRates;
 
-#define RX_INTERVAL_MIN_US     950 // 0.950ms to fit 1kHz without an issue
-#define RX_INTERVAL_MAX_US   65500 // 65.5ms or 15.26hz
 static uint16_t currentRxIntervalUs;  // packet interval in microseconds, constrained to above range
 static uint16_t previousRxIntervalUs; // previous packet interval in microseconds
 static float currentRxRateHz;         // packet interval in Hz, constrained as above

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -47,5 +47,5 @@ float getMaxRcRate(int axis);
 float getFeedforward(int axis);
 
 void updateRcRefreshRate(timeUs_t currentTimeUs, bool newDataReceived);
-uint16_t getCurrentRxIntervalUs(void);
+uint16_t getCurrentRxRateHz(void);
 bool getRxRateValid(void);

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -46,6 +46,6 @@ bool rcSmoothingInitializationComplete(void);
 float getMaxRcRate(int axis);
 float getFeedforward(int axis);
 
-void updateRcRefreshRate(timeUs_t currentTimeUs);
+void updateRcRefreshRate(timeUs_t currentTimeUs, bool newDataReceived);
 uint16_t getCurrentRxIntervalUs(void);
 bool getRxRateValid(void);

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -46,6 +46,6 @@ bool rcSmoothingInitializationComplete(void);
 float getMaxRcRate(int axis);
 float getFeedforward(int axis);
 
-void updateRcRefreshRate(timeUs_t currentTimeUs, bool newDataReceived);
+void updateRcRefreshRate(timeUs_t currentTimeUs, bool rxReceivingSignal);
 uint16_t getCurrentRxRateHz(void);
 bool getRxRateValid(void);

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -835,7 +835,7 @@ static void processContinuosAdjustments(controlRateConfig_t *controlRateConfig)
 
 void processRcAdjustments(controlRateConfig_t *controlRateConfig)
 {
-    const bool canUseRxData = rxIsReceivingSignal();
+    const bool canUseRxData = isRxReceivingSignal();
 
     // Recalculate the new active adjustments if required
     if (stepwiseAdjustmentCount == ADJUSTMENT_RANGE_COUNT_INVALID) {

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -368,7 +368,7 @@ task_attribute_t task_attributes[TASK_COUNT] = {
     [TASK_ATTITUDE] = DEFINE_TASK("ATTITUDE", NULL, NULL, imuUpdateAttitude, TASK_PERIOD_HZ(100), TASK_PRIORITY_MEDIUM),
 #endif
 
-    [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(33), TASK_PRIORITY_HIGH), // If event-based scheduling doesn't work, fallback to periodic scheduling
+    [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(22), TASK_PRIORITY_HIGH), // If event-based scheduling doesn't work, fallback to periodic scheduling
     [TASK_DISPATCH] = DEFINE_TASK("DISPATCH", NULL, NULL, dispatchProcess, TASK_PERIOD_HZ(1000), TASK_PRIORITY_HIGH),
 
 #ifdef USE_BEEPER

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -368,7 +368,7 @@ task_attribute_t task_attributes[TASK_COUNT] = {
     [TASK_ATTITUDE] = DEFINE_TASK("ATTITUDE", NULL, NULL, imuUpdateAttitude, TASK_PERIOD_HZ(100), TASK_PRIORITY_MEDIUM),
 #endif
 
-    [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(22), TASK_PRIORITY_HIGH), // If event-based scheduling doesn't work, fallback to periodic scheduling
+    [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(33), TASK_PRIORITY_HIGH), // If event-based scheduling doesn't work, fallback to periodic scheduling
     [TASK_DISPATCH] = DEFINE_TASK("DISPATCH", NULL, NULL, dispatchProcess, TASK_PERIOD_HZ(1000), TASK_PRIORITY_HIGH),
 
 #ifdef USE_BEEPER

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -149,7 +149,7 @@ static bool failsafeShouldHaveCausedLandingByNow(void)
 bool failsafeIsReceivingRxData(void)
 {
     return (failsafeState.rxLinkState == FAILSAFE_RXLINK_UP);
-    // False with BOXFAILSAFE switch or when no valid packets for 200ms or any flight channel invalid for 300ms,
+    // False with BOXFAILSAFE switch or when no valid packets for 150ms or any flight channel invalid for 300ms,
     // becomes true immediately BOXFAILSAFE switch reverts, or after recovery period expires when valid packets are received
     // rxLinkState RXLINK_DOWN (not up) is the trigger for the various failsafe stage 2 outcomes.
 }
@@ -184,7 +184,7 @@ void failsafeOnValidDataReceived(void)
 
     if (cmp32(failsafeState.validRxDataReceivedAt, failsafeState.validRxDataFailedAt) > (int32_t)failsafeState.receivingRxDataPeriodPreset) {
         // receivingRxDataPeriodPreset is rxDataRecoveryPeriod unless set to zero to allow immediate control recovery after switch induced failsafe
-        // rxDataRecoveryPeriod defaults to 1.0s with minimum of PERIOD_RXDATA_RECOVERY (200ms)
+        // rxDataRecoveryPeriod defaults to 1.0s with minimum of PERIOD_RXDATA_RECOVERY (100ms)
         // link is not considered 'up', after it has been 'down', until that recovery period has expired
         failsafeState.rxLinkState = FAILSAFE_RXLINK_UP;
         // after the rxDataRecoveryPeriod, typically 1s after receiving valid data, clear RXLOSS in OSD and permit arming
@@ -193,11 +193,11 @@ void failsafeOnValidDataReceived(void)
 }
 
 void failsafeOnValidDataFailed(void)
-// run from rc.c when packets are lost for more than the signal validation period (200ms), or immediately BOXFAILSAFE switch is active
+// run from rc.c when packets are lost for more than the signal validation period (150ms), or immediately BOXFAILSAFE switch is active
 // after the stage 1 delay has expired, sets the rxLinkState to RXLINK_DOWN, ie not up, causing failsafeIsReceivingRxData to become false
 // if failsafe is configured to go direct to stage 2, this is emulated immediately in failsafeUpdateState()
 {
-    //  set RXLOSS in OSD and block arming after 200ms of signal loss
+    //  set RXLOSS in OSD and block arming after 150ms of signal loss
     setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
 
     failsafeState.validRxDataFailedAt = millis();

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -149,7 +149,7 @@ static bool failsafeShouldHaveCausedLandingByNow(void)
 bool failsafeIsReceivingRxData(void)
 {
     return (failsafeState.rxLinkState == FAILSAFE_RXLINK_UP);
-    // False with BOXFAILSAFE switch or when no valid packets for 100ms or any flight channel invalid for 300ms,
+    // False with BOXFAILSAFE switch or when no valid packets for 200ms or any flight channel invalid for 300ms,
     // becomes true immediately BOXFAILSAFE switch reverts, or after recovery period expires when valid packets are received
     // rxLinkState RXLINK_DOWN (not up) is the trigger for the various failsafe stage 2 outcomes.
 }
@@ -193,11 +193,11 @@ void failsafeOnValidDataReceived(void)
 }
 
 void failsafeOnValidDataFailed(void)
-// run from rc.c when packets are lost for more than the signal validation period (100ms), or immediately BOXFAILSAFE switch is active
+// run from rc.c when packets are lost for more than the signal validation period (200ms), or immediately BOXFAILSAFE switch is active
 // after the stage 1 delay has expired, sets the rxLinkState to RXLINK_DOWN, ie not up, causing failsafeIsReceivingRxData to become false
 // if failsafe is configured to go direct to stage 2, this is emulated immediately in failsafeUpdateState()
 {
-    //  set RXLOSS in OSD and block arming after 100ms of signal loss
+    //  set RXLOSS in OSD and block arming after 200ms of signal loss
     setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
 
     failsafeState.validRxDataFailedAt = millis();

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -149,7 +149,7 @@ static bool failsafeShouldHaveCausedLandingByNow(void)
 bool failsafeIsReceivingRxData(void)
 {
     return (failsafeState.rxLinkState == FAILSAFE_RXLINK_UP);
-    // False with BOXFAILSAFE switch or when no valid packets for 150ms or any flight channel invalid for 300ms,
+    // False with BOXFAILSAFE switch or when no valid packets for RXLOSS_TRIGGER_INTERVAL or any flight channel invalid for 300ms,
     // becomes true immediately BOXFAILSAFE switch reverts, or after recovery period expires when valid packets are received
     // rxLinkState RXLINK_DOWN (not up) is the trigger for the various failsafe stage 2 outcomes.
 }
@@ -193,11 +193,11 @@ void failsafeOnValidDataReceived(void)
 }
 
 void failsafeOnValidDataFailed(void)
-// run from rc.c when packets are lost for more than the signal validation period (150ms), or immediately BOXFAILSAFE switch is active
+// run from rc.c when packets are lost for more than RXLOSS_TRIGGER_INTERVAL, or immediately BOXFAILSAFE switch is active
 // after the stage 1 delay has expired, sets the rxLinkState to RXLINK_DOWN, ie not up, causing failsafeIsReceivingRxData to become false
 // if failsafe is configured to go direct to stage 2, this is emulated immediately in failsafeUpdateState()
 {
-    //  set RXLOSS in OSD and block arming after 150ms of signal loss
+    //  set RXLOSS in OSD and block arming after RXLOSS_TRIGGER_INTERVAL of frame loss
     setArmingDisabled(ARMING_DISABLED_RX_FAILSAFE);
 
     failsafeState.validRxDataFailedAt = millis();

--- a/src/main/flight/gps_rescue.c
+++ b/src/main/flight/gps_rescue.c
@@ -425,7 +425,7 @@ static void performSanityChecks(void)
     // Handle events that set a failure mode to other than healthy.
     // Disarm via Abort when sanity on, or for hard Rx loss in FS_ONLY mode
     // Otherwise allow 20s of semi-controlled descent with impact disarm detection
-    const bool hardFailsafe = !rxIsReceivingSignal();
+    const bool hardFailsafe = !isRxReceivingSignal();
 
     if (rescueState.failure != RESCUE_HEALTHY) {
         // Default to 20s semi-controlled descent with impact detection, then abort

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -203,7 +203,7 @@ static void updateRxStatus(void)
 {
     i2c_OLED_set_xy(dev, SCREEN_CHARACTER_COLUMN_COUNT - 2, 0);
     char rxStatus = '!';
-    if (rxIsReceivingSignal()) {
+    if (isRxReceivingSignal()) {
         rxStatus = 'r';
     } if (rxAreFlightChannelsValid()) {
         rxStatus = 'R';

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -962,7 +962,7 @@ static void applyLedIndicatorLayer(bool updateNow, timeUs_t *timer)
     static bool flash = 0;
 
     if (updateNow) {
-        if (rxIsReceivingSignal()) {
+        if (isRxReceivingSignal()) {
             // calculate update frequency
             int scale = MAX(fabsf(rcCommand[ROLL]), fabsf(rcCommand[PITCH]));  // 0 - 500
             scale = scale - INDICATOR_DEADBAND;  // start increasing frequency right after deadband

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -630,7 +630,6 @@ bool crsfRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = CRSF_MAX_CHANNEL;
     rxRuntimeState->rcReadRawFn = crsfReadRawRC;
     rxRuntimeState->rcFrameStatusFn = crsfFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -394,7 +394,6 @@ bool fportRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = SBUS_MAX_CHANNEL;
     rxRuntimeState->rcFrameStatusFn = fportFrameStatus;
     rxRuntimeState->rcProcessFrameFn = fportProcessFrame;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -417,7 +417,6 @@ bool ghstRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = GHST_MAX_NUM_CHANNELS;
     rxRuntimeState->rcReadRawFn = ghstReadRawRC;
     rxRuntimeState->rcFrameStatusFn = ghstFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
     rxRuntimeState->rcProcessFrameFn = ghstProcessFrame;
 
     for (int iChan = 0; iChan < rxRuntimeState->channelCount; ++iChan) {

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -211,7 +211,6 @@ bool ibusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = IBUS_MAX_CHANNEL;
     rxRuntimeState->rcReadRawFn = ibusReadRawRC;
     rxRuntimeState->rcFrameStatusFn = ibusFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -262,7 +262,6 @@ bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = JETIEXBUS_CHANNEL_COUNT;
     rxRuntimeState->rcReadRawFn = jetiExBusReadRawRC;
     rxRuntimeState->rcFrameStatusFn = jetiExBusFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 
     jetiExBusFrameReset();
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -397,7 +397,7 @@ void rxInit(void)
     rxChannelCount = MIN(rxConfig()->max_aux_channel + NON_AUX_CHANNEL_COUNT, rxRuntimeState.channelCount);
 }
 
-bool rxIsReceivingSignal(void)
+bool isRxReceivingSignal(void)
 {
     return rxSignalReceived;
 }
@@ -561,10 +561,10 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     } else {
         //  watch for next packet
         if (cmpTimeUs(currentTimeUs, needRxSignalBefore) > 0) {
-            //  initial time to rxDataReceived failure is RXLOSS_TRIGGER_INTERVAL, then we check every RX_FRAME_RECHECK_INTERVAL
-            rxSignalReceived = false;
-            needRxSignalBefore = currentTimeUs + reCheckRxSignalInterval;
-            //  review and process rcData values every 50ms in case failsafe changed them
+            // initial time to rxDataReceived failure is RXLOSS_TRIGGER_INTERVAL (150ms),
+            // after that, we check every RX_FRAME_RECHECK_INTERVAL (50ms)
+            rxSignalReceived = false; // results in `RXLOSS` message etc
+            needRxSignalBefore += reCheckRxSignalInterval;
             rxDataProcessingRequired = true;
         }
     }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -133,7 +133,7 @@ uint32_t validRxSignalTimeout[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 #define PPM_AND_PWM_SAMPLE_COUNT 3
 
 #define RSSI_UPDATE_INTERVAL (20 * 1000)                // 20ms in us
-#define RX_FRAME_CHECK_INTERVAL (50 * 1000)             // 50ms in us
+#define RX_FRAME_RECHECK_INTERVAL (50 * 1000)             // 50ms in us
 #define RXLOSS_TRIGGER_INTERVAL (150 * 1000)            // 150ms in us
 #define DELAY_1500_MS (1500 * 1000)                     // 1.5 seconds in us
 #define SKIP_RC_SAMPLES_ON_RESUME  2                    // flush 2 samples to drop wrong measurements (timing independent)
@@ -506,7 +506,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     bool signalReceived = false;
     bool useDataDrivenProcessing = true;
     timeDelta_t needRxSignalMaxDelayUs = RXLOSS_TRIGGER_INTERVAL;
-    timeDelta_t reCheckRxSignalInterval = RX_FRAME_CHECK_INTERVAL;
+    timeDelta_t reCheckRxSignalInterval = RX_FRAME_RECHECK_INTERVAL;
 
     DEBUG_SET(DEBUG_RX_SIGNAL_LOSS, 2, MIN(2000, currentDeltaTimeUs / 100));
 
@@ -561,7 +561,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     } else {
         //  watch for next packet
         if (cmpTimeUs(currentTimeUs, needRxSignalBefore) > 0) {
-            //  initial time to signalReceived failure is RXLOSS_TRIGGER_INTERVAL, then we check every RX_FRAME_CHECK_INTERVAL
+            //  initial time to signalReceived failure is RXLOSS_TRIGGER_INTERVAL, then we check every RX_FRAME_RECHECK_INTERVAL
             rxSignalReceived = false;
             needRxSignalBefore = currentTimeUs + reCheckRxSignalInterval;
             //  review and process rcData values every 50ms in case failsafe changed them

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -1025,15 +1025,17 @@ bool isRssiConfigured(void)
 
 timeDelta_t rxGetFrameDelta(timeDelta_t *frameAgeUs)
 {
+    // returns the delta time based on the Rx Driver time stamps
     static timeUs_t previousFrameTimeUs = 0;
     static timeDelta_t frameTimeDeltaUs = 0; // last valid Rx-reported frame time stamp delta
 
+    // when a new packet arrives, return the delta time 
     if (rxRuntimeState.rcFrameTimeUsFn) {
         const timeUs_t frameTimeUs = rxRuntimeState.rcFrameTimeUsFn(); // Frame time stamp from Rx driver
 
         *frameAgeUs = cmpTimeUs(micros(), frameTimeUs);
         // Time interval between now and most recent Rx-reported frame time
-        // will grow large if Rx does not update the last reported frame time stamp
+        // steps up every 100ms if Rx does not update the last reported frame time stamp
 
         const timeDelta_t deltaUs = cmpTimeUs(frameTimeUs, previousFrameTimeUs);
         if (deltaUs) {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -133,7 +133,7 @@ uint32_t validRxSignalTimeout[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 #define PPM_AND_PWM_SAMPLE_COUNT 3
 
 #define RSSI_UPDATE_INTERVAL (20 * 1000)                // 20ms in us
-#define RX_FRAME_RECHECK_INTERVAL (50 * 1000)             // 50ms in us
+#define RX_FRAME_RECHECK_INTERVAL (50 * 1000)           // 50ms in us
 #define RXLOSS_TRIGGER_INTERVAL (150 * 1000)            // 150ms in us
 #define DELAY_1500_MS (1500 * 1000)                     // 1.5 seconds in us
 #define SKIP_RC_SAMPLES_ON_RESUME  2                    // flush 2 samples to drop wrong measurements (timing independent)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -295,7 +295,7 @@ void rxInit(void)
     rxRuntimeState.rcReadRawFn = nullReadRawRC;
     rxRuntimeState.rcFrameStatusFn = nullFrameStatus;
     rxRuntimeState.rcProcessFrameFn = nullProcessFrame;
-    rxRuntimeState.lastRcFrameTimeUs = 0;
+    rxRuntimeState.lastRcFrameTimeUs = 0;              // zero when driver does not provide timing info
     rcSampleIndex = 0;
 
     uint32_t now = millis();
@@ -1024,26 +1024,3 @@ bool isRssiConfigured(void)
     return rssiSource != RSSI_SOURCE_NONE;
 }
 
-timeDelta_t rxGetFrameDelta(void)
-{
-    // return the delta time based on time stamps provided by the Rx driver
-    // frameTimeDeltaUs holds its 'last good value' until, after RXLOSS_TRIGGER_INTERVAL, it goes to zero
-    static timeDelta_t frameTimeDeltaUs = 0;
-    static timeUs_t previousFrameTimeUs = 0;
-    timeUs_t frameTimeUs = 0;
-
-    if (rxRuntimeState.rcFrameTimeUsFn) {               // only update delta when time is provided, handle possibility of NULL
-        frameTimeUs = rxRuntimeState.rcFrameTimeUsFn(); // Frame time stamp from Rx driver
-        frameTimeDeltaUs = cmpTimeUs(frameTimeUs, previousFrameTimeUs);
-        previousFrameTimeUs = frameTimeUs;
-    }
-
-    DEBUG_SET(DEBUG_RX_TIMING, 1, frameTimeUs/100);     // 32 bit time will roll over 16 bit limit
-
-    return frameTimeDeltaUs;
-}
-
-timeUs_t rxFrameTimeUs(void)
-{
-    return rxRuntimeState.lastRcFrameTimeUs;
-}

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -1028,16 +1028,17 @@ timeDelta_t rxGetFrameDelta(void)
 {
     // return the delta time based on time stamps provided by the Rx driver
     // frameTimeDeltaUs holds its last good value until after 150ms of no frames, it goes to zero)
-    static timeUs_t previousFrameTimeUs = 0;
     static timeDelta_t frameTimeDeltaUs = 0;
+    static timeUs_t previousFrameTimeUs = 0;
+    timeUs_t frameTimeUs = 0;
 
-    const timeUs_t frameTimeUs = rxRuntimeState.rcFrameTimeUsFn(); // Frame time stamp from Rx driver
-    DEBUG_SET(DEBUG_RX_TIMING, 1, frameTimeUs);     // time from reception of frame to now in hundredths of ms
-
-    if (frameTimeUs) {
+    if (rxRuntimeState.rcFrameTimeUsFn) {               // only update delta when time is provided, handle possibility of NULL
+        frameTimeUs = rxRuntimeState.rcFrameTimeUsFn(); // Frame time stamp from Rx driver
         frameTimeDeltaUs = cmpTimeUs(frameTimeUs, previousFrameTimeUs);
         previousFrameTimeUs = frameTimeUs;
     }
+
+    DEBUG_SET(DEBUG_RX_TIMING, 1, frameTimeUs/100);     // 32 bit time will roll over 16 bit limit
 
     return frameTimeDeltaUs;
 }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -688,7 +688,7 @@ void detectAndApplySignalLossBehaviour(void)
     const uint32_t currentTimeMs = millis();
     const bool boxFailsafeSwitchIsOn = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
     rxFlightChannelsValid = rxSignalReceived && !boxFailsafeSwitchIsOn;
-    // rxFlightChannelsValid is false after 200ms of no packets, or as soon as use the BOXFAILSAFE switch is actioned
+    // rxFlightChannelsValid is false after 150ms of no packets, or as soon as use the BOXFAILSAFE switch is actioned
     // rxFlightChannelsValid is true the instant we get a good packet or the BOXFAILSAFE switch is reverted
     // can also go false with good packets but where one flight channel is bad > 300ms (PPM type receiver error)
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -1025,15 +1025,18 @@ bool isRssiConfigured(void)
 timeDelta_t rxGetFrameDelta(timeDelta_t *frameAgeUs)
 {
     static timeUs_t previousFrameTimeUs = 0;
-    static timeDelta_t frameTimeDeltaUs = 0;
+    static timeDelta_t frameTimeDeltaUs = 0; // last valid Rx-reported frame time stamp delta
 
     if (rxRuntimeState.rcFrameTimeUsFn) {
-        const timeUs_t frameTimeUs = rxRuntimeState.rcFrameTimeUsFn();
+        const timeUs_t frameTimeUs = rxRuntimeState.rcFrameTimeUsFn(); // Frame time stamp from Rx driver
 
         *frameAgeUs = cmpTimeUs(micros(), frameTimeUs);
+        // Time interval between now and most recent Rx-reported frame time
+        // will grow large if Rx does not update the last reported frame time stamp
 
         const timeDelta_t deltaUs = cmpTimeUs(frameTimeUs, previousFrameTimeUs);
         if (deltaUs) {
+            // Rx-reported frame time has changed, compared to previous Rx-reported frame time stamp
             frameTimeDeltaUs = deltaUs;
             previousFrameTimeUs = frameTimeUs;
         }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -579,6 +579,7 @@ FAST_CODE_NOINLINE void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t current
     
     DEBUG_SET(DEBUG_FAILSAFE, 1, rxSignalReceived);
     DEBUG_SET(DEBUG_RX_SIGNAL_LOSS, 0, rxSignalReceived);
+    DEBUG_SET(DEBUG_RX_TIMING, 7, rxSignalReceived);
 }
 
 #if defined(USE_RX_PWM) || defined(USE_RX_PPM)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -225,6 +225,6 @@ void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRange
 void suspendRxSignal(void);
 void resumeRxSignal(void);
 
-timeDelta_t rxGetFrameDelta(timeDelta_t *frameAgeUs);
+timeDelta_t rxGetFrameDelta();
 
 timeUs_t rxFrameTimeUs(void);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -144,7 +144,6 @@ typedef struct rxRuntimeState_s {
     rcReadRawDataFnPtr  rcReadRawFn;
     rcFrameStatusFnPtr  rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
-    rcGetFrameTimeUsFn *rcFrameTimeUsFn;
     uint16_t            *channelData;
     void                *frameData;
     timeUs_t            lastRcFrameTimeUs;

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -175,7 +175,7 @@ void rxInit(void);
 void rxProcessPending(bool state);
 bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
-bool rxIsReceivingSignal(void);
+bool isRxReceivingSignal(void);
 bool rxAreFlightChannelsValid(void);
 bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs);
 
@@ -224,6 +224,6 @@ void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRange
 void suspendRxSignal(void);
 void resumeRxSignal(void);
 
-timeDelta_t rxGetFrameDelta();
+timeDelta_t rxGetFrameDelta(void);
 
 timeUs_t rxFrameTimeUs(void);

--- a/src/main/rx/rx_spi.c
+++ b/src/main/rx/rx_spi.c
@@ -205,14 +205,15 @@ STATIC_UNIT_TESTED bool rxSpiSetProtocol(rx_spi_protocol_e protocol)
  */
 static uint8_t rxSpiFrameStatus(rxRuntimeState_t *rxRuntimeState)
 {
-    UNUSED(rxRuntimeState);
-
     uint8_t status = RX_FRAME_PENDING;
 
     rx_spi_received_e result = protocolDataReceived(rxSpiPayload);
 
     if (result & RX_SPI_RECEIVED_DATA) {
         rxSpiNewPacketAvailable = true;
+        // use SPI EXTI time as frame time
+        // note that there is not rx time without EXTI
+        rxRuntimeState->lastRcFrameTimeUs = rxSpiGetLastExtiTimeUs();
         status = RX_FRAME_COMPLETE;
     }
 
@@ -260,8 +261,6 @@ bool rxSpiInit(const rxSpiConfig_t *rxSpiConfig, rxRuntimeState_t *rxRuntimeStat
 
     if (rxSpiExtiConfigured()) {
         rxSpiExtiInit(extiConfig.ioConfig, extiConfig.trigger);
-
-        rxRuntimeState->rcFrameTimeUsFn = rxSpiGetLastExtiTimeUs;
     }
 
     rxSpiNewPacketAvailable = false;

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -177,7 +177,6 @@ bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     }
 
     rxRuntimeState->rcFrameStatusFn = sbusFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -387,7 +387,6 @@ bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 
     rxRuntimeState->rcReadRawFn = spektrumReadRawRC;
     rxRuntimeState->rcFrameStatusFn = spektrumFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 #if defined(USE_TELEMETRY_SRXL)
     rxRuntimeState->rcProcessFrameFn = spektrumProcessFrame;
 #endif

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -491,7 +491,6 @@ bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = SRXL2_MAX_CHANNELS;
     rxRuntimeState->rcReadRawFn = srxl2ReadRawRC;
     rxRuntimeState->rcFrameStatusFn = srxl2FrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
     rxRuntimeState->rcProcessFrameFn = srxl2ProcessFrame;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -174,7 +174,6 @@ bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = MIN(SUMD_MAX_CHANNEL, MAX_SUPPORTED_RC_CHANNEL_COUNT);
     rxRuntimeState->rcReadRawFn = sumdReadRawRC;
     rxRuntimeState->rcFrameStatusFn = sumdFrameStatus;
-    rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1128,7 +1128,7 @@ extern "C" {
     bool isUpright(void) { return mockIsUpright; }
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
     void gyroFiltering(timeUs_t) {};
-    timeDelta_t rxGetFrameDelta(timeDelta_t *) { return 0; }
+    timeDelta_t rxGetFrameDelta() { return 0; }
     void updateRcRefreshRate(timeUs_t) {};
     uint16_t getAverageSystemLoadPercent(void) { return 0; }
     bool isMotorProtocolEnabled(void) { return true; }

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1051,7 +1051,7 @@ TEST(ArmingPreventionTest, Paralyze)
 extern "C" {
     uint32_t micros(void) { return simulationTime; }
     uint32_t millis(void) { return micros() / 1000; }
-    bool rxIsReceivingSignal(void) { return simulationHaveRx; }
+    bool isRxReceivingSignal(void) { return simulationHaveRx; }
 
     bool featureIsEnabled(uint32_t f) { return simulationFeatureFlags & f; }
     void warningLedFlash(void) {}

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -380,7 +380,7 @@ void closeSerialPort(serialPort_t *) {}
 portSharing_e determinePortSharing(const serialPortConfig_t *, serialPortFunction_e ) {return PORTSHARING_UNUSED;}
 failsafePhase_e failsafePhase(void) {return FAILSAFE_IDLE;}
 bool rxAreFlightChannelsValid(void) {return false;}
-bool rxIsReceivingSignal(void) {return false;}
+bool isRxReceivingSignal(void) {return false;}
 bool isRssiConfigured(void) {return false;}
 float getMotorOutputLow(void) {return 0.0;}
 float getMotorOutputHigh(void) {return 0.0;}

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -387,6 +387,7 @@ bool isModeActivationConditionConfigured(const modeActivationCondition_t *, cons
 void delay(uint32_t) {}
 displayPort_t *osdGetDisplayPort(osdDisplayPortDevice_e *) { return NULL; }
 mcuTypeId_e getMcuTypeId(void) { return MCU_TYPE_UNKNOWN; }
-uint16_t getCurrentRxIntervalUs(void) { return 0; }
+uint16_t getCurrentRxRateHz(void) { return 0; }
 uint16_t getAverageSystemLoadPercent(void) { return 0; }
+bool getRxRateValid(void) { return false; }
 }

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -588,7 +588,7 @@ TEST(FlightFailsafeTest, TestFailsafeSwitchModeStage2Land)
     // when
     failsafeUpdateState();
 
-    // now should be in monitoring mode, with switch holding signalReceived false
+    // now should be in monitoring mode, with switch holding rxDataReceived false
     EXPECT_TRUE(failsafeIsActive());
     EXPECT_EQ(FAILSAFE_RX_LOSS_MONITORING, failsafePhase());
     EXPECT_TRUE(isArmingDisabled());

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -386,7 +386,7 @@ int scaleRange(int x, int srcMin, int srcMax, int destMin, int destMax)
 }
 
 bool failsafeIsActive() { return false; }
-bool rxIsReceivingSignal() { return true; }
+bool isRxReceivingSignal() { return true; }
 
 bool isBeeperOn() { return false; };
 

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -622,7 +622,7 @@ void dashboardDisablePageCycling() {}
 void dashboardEnablePageCycling() {}
 
 bool failsafeIsActive() { return false; }
-bool rxIsReceivingSignal() { return true; }
+bool isRxReceivingSignal() { return true; }
 bool failsafeIsReceivingRxData() { return true; }
 
 uint8_t getCurrentControlRateProfileIndex(void)

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -130,7 +130,7 @@ extern "C" {
     uint8_t activePidLoopDenom = 1;
     uint32_t micros(void) { return simulationTime; }
     uint32_t millis(void) { return micros() / 1000; }
-    bool rxIsReceivingSignal(void) { return simulationHaveRx; }
+    bool isRxReceivingSignal(void) { return simulationHaveRx; }
 
     bool featureIsEnabled(uint32_t f) { return simulationFeatureFlags & f; }
     void warningLedFlash(void) {}

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -202,7 +202,7 @@ extern "C" {
     bool isUpright(void) { return true; }
     void blackboxLogEvent(FlightLogEvent, union flightLogEventData_u *) {};
     void gyroFiltering(timeUs_t) {};
-    timeDelta_t rxGetFrameDelta(timeDelta_t *) { return 0; }
+    timeDelta_t rxGetFrameDelta() { return 0; }
     void updateRcRefreshRate(timeUs_t) {};
     uint16_t getAverageSystemLoadPercent(void) { return 0; }
     bool isMotorProtocolEnabled(void) { return false; }


### PR DESCRIPTION
Users had noted a high incidence of `RXLOSS` warnings when using ELRS 25Hz, despite 100% LQ being reported by the ELRS code.

ELRS code uses a 100 sample moving average, effectively, to return LQ (with telemetry packets counted as 'good' despite no data being received); the internal Betaflight LQ method is not used.  It seems that single packet loss, and telemetry loss, isn't counted.  

Previously we would announce RXLOSS if there were no good frames over a continuous 100ms period.  For 25Hz users this meant that dropping just two frames in a row or one frame either side of a telemetry packet would result in an RXLOSS warning.  Logging showed single and double-frame random drops were not all that uncommon at range, but rarely interfere significantly with flight.  By increasing the 'no data' window to 150ms we can reduce 'false alarms' quite a lot, not only at 25Hz but also at 50Hz.

This PR makes quite a few small changes to improve the tendency for false RXLOSS warnings at low Rx rates:
- requiring a gap > 150ms of no valid Rx frames, up from 100ms, before announcing`RXLOSS`
- after this, re-checking for new data every 50ms (20Hz)
- removing the `FrameAge` parameter, which was used in a manner that seemed quite confusing
- simplifying the calculation of frame delta when based on values provided by the Rx driver
- using frame delta values from the Rx driver, if available.
- some variables were re-named for consistency and to make the code more readable.
- removes three separate places where `rxRate` is calculated independently, with one single calculation to derive `rxRateHz` in rc.c, and a get function to return it where needed in cli.c via `getCurrentRxRateHz`. 
- re-name some variables for clarity

Overall these changes should reduce inappropriate RXLOSS indications for 25Hz links, and help a bit with 50Hz links also.  Most pilots won't notice any significant difference.  RXLOSS should appear whenever a sustained loss of data for more than 150ms occurs.

The refactoring should reduce CPU load a fraction.

Please test with the `RX_TIMING` debug, to which LQ and signalReceived values are logged; please compare Master to this PR.  The CLI Tasks command will also show how frequently the Rx task runs.  With no valid incoming data, it now shows 20Hz.

This is the debug content of RX_TIMING debug in this PR:
<img width="782" alt="Screen Shot 2024-03-26 at 12 01 15 pm" src="https://github.com/betaflight/betaflight/assets/11737748/02772452-6817-4277-8083-8eaca9ee1c89">

vs master:
<img width="580" alt="Screen Shot 2024-03-26 at 12 02 20 pm" src="https://github.com/betaflight/betaflight/assets/11737748/280a7d3c-7f2f-4709-b4d8-fb9a1d87ab8a">


Testing appears OK, has been rebased to master.

Here is a graphic showing simulated link loss (put the quad into the microwave oven and shut the door).  Axes are not labeled properly.  The spikes coming up from the bottom indicate the duration of the dropout; the log is done at 50Hz so each discrete step up is 20ms of lag from one lost packet.

The very top trace is the SignalReceived indicator that triggers RXLOSS warning when it goes false, which happens on the left on four occasions when the LQ falls to around 50%.  On the less severe link problem to the right, where LQ drops to around  70, there is no RXLOSS warning.

![Screen Shot 2024-03-12 at 20 43 01](https://github.com/betaflight/betaflight/assets/11737748/5db60db9-58a2-4eb5-9794-f5079dc62f2b)

I do appreciate that quite a few long-range pilots felt that the RXLOSS warning was too intrusive.  This perhaps shifts the balance back a bit away from it being a false alarm.  When it appears, you have had no packets at all for 150ms, and that's cause for concern regardless of link speed.