### PR TITLE
Include a target's `config.h` before `common_pre.h`.

### DIFF
--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -26,11 +26,11 @@
 #pragma GCC poison sprintf snprintf
 #endif
 
-#include "target/common_pre.h"
-
 #ifdef USE_CONFIG
 #include "config.h"
 #endif
+
+#include "target/common_pre.h"
 
 // MCU specific platform from drivers/XX
 #include "platform_mcu.h"


### PR DESCRIPTION
Some gating in `common_pre.h` requires the target's `#define`s to be present, such as `#if defined(USE_LED_STRIP)`...

Fixes #13438.
