### PR TITLE
Support 180° servos, finnaly

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2178,11 +2178,11 @@ static void cliServo(const char *cmdName, char *cmdline)
         servo = servoParamsMutable(i);
 
         if (
-            arguments[MIN] < PWM_PULSE_MIN || arguments[MIN] > PWM_PULSE_MAX ||
-            arguments[MAX] < PWM_PULSE_MIN || arguments[MAX] > PWM_PULSE_MAX ||
+            arguments[MIN] < PWM_SERVO_MIN || arguments[MIN] > PWM_SERVO_MAX ||
+            arguments[MAX] < PWM_SERVO_MIN || arguments[MAX] > PWM_SERVO_MAX ||
             arguments[MIDDLE] < arguments[MIN] || arguments[MIDDLE] > arguments[MAX] ||
             arguments[MIN] > arguments[MAX] ||
-            arguments[RATE] < -125 || arguments[RATE] > 125 ||
+            arguments[RATE] < -100 || arguments[RATE] > 100 ||
             arguments[FORWARD] >= MAX_SUPPORTED_RC_CHANNEL_COUNT
         ) {
             cliShowArgumentRangeError(cmdName, NULL, 0, 0);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2182,7 +2182,7 @@ static void cliServo(const char *cmdName, char *cmdline)
             arguments[MAX] < PWM_PULSE_MIN || arguments[MAX] > PWM_PULSE_MAX ||
             arguments[MIDDLE] < arguments[MIN] || arguments[MIDDLE] > arguments[MAX] ||
             arguments[MIN] > arguments[MAX] ||
-            arguments[RATE] < -100 || arguments[RATE] > 100 ||
+            arguments[RATE] < -125 || arguments[RATE] > 125 ||
             arguments[FORWARD] >= MAX_SUPPORTED_RC_CHANNEL_COUNT
         ) {
             cliShowArgumentRangeError(cmdName, NULL, 0, 0);

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -211,7 +211,7 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        return rcData[channelToForwardFrom];
+        return scaleRange(constrain(rcData[channelToForwardFrom], 1000, 2000), 1000, 2000, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
     }
 
     return servoParams(servoIndex)->middle;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -211,7 +211,7 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        return scaleRange(constrain(rcData[channelToForwardFrom], 1000, 2000), 1000, 2000, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
+        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
     }
 
     return servoParams(servoIndex)->middle;

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -24,6 +24,13 @@
 #include "drivers/io_types.h"
 #include "drivers/pwm_output.h"
 
+#define PWM_SERVO_MIN   500       // minimum servo PWM pulse width which we can set from cli
+#define PWM_SERVO_MAX   2500      // maximum servo PWM pulse width which we can set from cli
+
+#define DEFAULT_SERVO_MIN 1000
+#define DEFAULT_SERVO_MIDDLE 1500
+#define DEFAULT_SERVO_MAX 2000
+
 // These must be consecutive, see 'reversedSources'
 enum {
     INPUT_STABILIZED_ROLL = 0,

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -41,6 +41,9 @@
 #define CHANNEL_VALUE_TO_RXFAIL_STEP(channelValue) ((constrain(channelValue, PWM_PULSE_MIN, PWM_PULSE_MAX) - PWM_PULSE_MIN) / 25)
 #define MAX_RXFAIL_RANGE_STEP ((PWM_PULSE_MAX - PWM_PULSE_MIN) / 25)
 
+#define PWM_SERVO_MIN   500       // minimum servo PWM pulse width which we can set from cli
+#define PWM_SERVO_MAX   2500      // maximum servo PWM pulse width which we can set from cli
+
 #define DEFAULT_SERVO_MIN 1000
 #define DEFAULT_SERVO_MIDDLE 1500
 #define DEFAULT_SERVO_MAX 2000

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -41,12 +41,6 @@
 #define CHANNEL_VALUE_TO_RXFAIL_STEP(channelValue) ((constrain(channelValue, PWM_PULSE_MIN, PWM_PULSE_MAX) - PWM_PULSE_MIN) / 25)
 #define MAX_RXFAIL_RANGE_STEP ((PWM_PULSE_MAX - PWM_PULSE_MIN) / 25)
 
-#define PWM_SERVO_MIN   500       // minimum servo PWM pulse width which we can set from cli
-#define PWM_SERVO_MAX   2500      // maximum servo PWM pulse width which we can set from cli
-
-#define DEFAULT_SERVO_MIN 1000
-#define DEFAULT_SERVO_MIDDLE 1500
-#define DEFAULT_SERVO_MAX 2000
 
 typedef enum {
     RX_FRAME_PENDING = 0,


### PR DESCRIPTION
**History flashback:**
Previously betaflight supported only 90° servos.
Somebody called 1000-2000us pwm output as "default" range, while nowadays 90% servos on market support at least 800-2200.
So if you plug 180° - nothing happens, betaflights outputs signal only for "standard" (while standard is different already) range: 1000-2000.

**How this changes solves the problem:**
Main fix:
1. Previously, range (which we define at Betaflight configurator) was not used at all in case of SERVO_TILT, without CMA_STAB.
So old code just took RC data (which is limited to be inside ~1000-2000) and use that as servo output.
Finnaly time has come to change that.

Bonus change:
2. Relaxed CLI argument validation restrictions to accept more wide range for servo min/max
Before this we could only set 750-2250 there, while in Betaflight Configurator UI we bypassed this restrifction at all.
So now CLI will still be restricted. But values will make more sens for 180° servos.
+ Detaches them to separate #define.

Now example how to use it:
Just configure
![image](https://github.com/betaflight/betaflight/assets/12896163/e99456c9-6514-471d-b7d4-e3311e1507a7)
and it will just work
![image](https://github.com/betaflight/betaflight/assets/12896163/d2b54bbb-82db-462c-8c89-b3a0d11cbc2c)
