### PR TITLE
Fix bmp388 spi (and add BMP390)

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -191,7 +191,7 @@ static bool bmp388ReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_
         uint8_t buf[length + 1];
         bool ret = busReadRegisterBuffer(dev, reg, buf, length + 1);
         if (ret) {
-            memcpy(data, buf + 1, length - 1);
+            memcpy(data, buf + 1, length);
         }
         return ret;
     } else {

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -48,7 +48,8 @@
 #define BMP388_MAX_SPI_CLK_HZ 10000000
 
 #define BMP388_I2C_ADDR                                 (0x76) // same as BMP280/BMP180
-#define BMP388_DEFAULT_CHIP_ID                          (0x50) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L130
+#define BMP388_CHIP_ID_BMP3                             (0x50) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L130
+#define BMP388_CHIP_ID_BMP390                           (0x60) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L133
 
 #define BMP388_CMD_REG                                  (0x7E)
 #define BMP388_RESERVED_UPPER_REG                       (0x7D)
@@ -273,7 +274,7 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
 
     bmp388ReadRegisterBuffer(dev, BMP388_CHIP_ID_REG, &bmp388_chip_id, 1);
 
-    if (bmp388_chip_id != BMP388_DEFAULT_CHIP_ID) {
+    if (bmp388_chip_id != BMP388_CHIP_ID_BMP3 && bmp388_chip_id != BMP388_CHIP_ID_BMP390) {
         bmp388BusDeinit(dev);
         if (defaultAddressApplied) {
             dev->busType_u.i2c.address = 0;


### PR DESCRIPTION
SPI read returns dummy byte first when reading BMP3 barometer. This dummy byte is not ignored as it shoud.

BMP390 is added to test this PR (nobody seems to have SPI BMP388)