### PR TITLE
Render spec screen over normal OSD

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1462,29 +1462,8 @@ void osdUpdate(timeUs_t currentTimeUs)
         if (resumeRefreshAt) {
             osdState = OSD_STATE_TRANSFER;
         } else {
-#ifdef USE_SPEC_PREARM_SCREEN
-            osdState = OSD_STATE_REFRESH_PREARM;
-#else
             osdState = OSD_STATE_UPDATE_CANVAS;
-#endif
         }
-        break;
-
-    case OSD_STATE_REFRESH_PREARM:
-        {
-#ifdef USE_SPEC_PREARM_SCREEN
-            if (!ARMING_FLAG(ARMED) && osdConfig()->osd_show_spec_prearm) {
-                if (osdDrawSpec(osdDisplayPort)) {
-                        // Rendering is complete
-                        osdState = OSD_STATE_COMMIT;
-                }
-            } else
-#endif // USE_SPEC_PREARM_SCREEN
-            {
-                osdState = OSD_STATE_UPDATE_CANVAS;
-            }
-        }
-
         break;
 
     case OSD_STATE_UPDATE_CANVAS:
@@ -1555,9 +1534,26 @@ void osdUpdate(timeUs_t currentTimeUs)
                 break;
             }
 
-            osdState = OSD_STATE_COMMIT;
+#ifdef USE_SPEC_PREARM_SCREEN
+            if (!ARMING_FLAG(ARMED) && osdConfig()->osd_show_spec_prearm) {
+                osdState = OSD_STATE_REFRESH_PREARM;
+            } else
+#endif // USE_SPEC_PREARM_SCREEN
+            {
+                osdState = OSD_STATE_COMMIT;
+            }
         }
         break;
+
+#ifdef USE_SPEC_PREARM_SCREEN
+    case OSD_STATE_REFRESH_PREARM:
+        if (osdDrawSpec(osdDisplayPort)) {
+            // Rendering is complete
+            osdState = OSD_STATE_COMMIT;
+        }
+
+        break;
+#endif // USE_SPEC_PREARM_SCREEN
 
     case OSD_STATE_COMMIT:
         displayCommitTransaction(osdDisplayPort);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -2199,7 +2199,7 @@ bool osdDrawNextActiveElement(displayPort_t *osdDisplayPort, timeUs_t currentTim
 #ifdef USE_SPEC_PREARM_SCREEN
 bool osdDrawSpec(displayPort_t *osdDisplayPort)
 {
-    static enum {CLR, RPM, POLES, MIXER, THR, MOTOR, BAT, VER} specState = CLR;
+    static enum {RPM, POLES, MIXER, THR, MOTOR, BAT, VER} specState = RPM;
     static int currentRow;
 
     const uint8_t midRow = osdDisplayPort->rows / 2;
@@ -2211,14 +2211,8 @@ bool osdDrawSpec(displayPort_t *osdDisplayPort)
 
     switch (specState) {
     default:
-    case CLR:
-        displayClearScreen(osdDisplayPort, DISPLAY_CLEAR_NONE);
-        currentRow = midRow - 3;
-
-        specState = RPM;
-        break;
-
     case RPM:
+        currentRow = midRow - 3;
 #ifdef USE_RPM_LIMIT
         {
             const bool rpmLimitActive = mixerConfig()->rpm_limit > 0 && isMotorProtocolBidirDshot();
@@ -2283,7 +2277,7 @@ bool osdDrawSpec(displayPort_t *osdDisplayPort)
         len = strlen(FC_VERSION_STRING);
         displayWrite(osdDisplayPort, midCol - (len / 2), currentRow++, DISPLAYPORT_SEVERITY_NORMAL, FC_VERSION_STRING);
 
-        specState = CLR;
+        specState = RPM;
 
         return true;
     }


### PR DESCRIPTION
Render the spec screen over the standard OSD rather than instead of it.