### PR TITLE
[github actions] release assets upload fix

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,10 +30,10 @@ jobs:
           set -x
           ASSETS=()
           for asset in Assets/*.hex; do
-            ASSETS+=("-a" "$asset")
+            ASSETS+=("$asset")
             echo "$asset"
           done
           TAG_NAME="${GITHUB_REF##*/}"
-          gh release edit "${ASSETS[@]}" "${TAG_NAME}"
+          gh release upload "${TAG_NAME}" "${ASSETS[@]}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- fix github actions release upload assets
- https://cli.github.com/manual/gh_release_upload

![image](https://github.com/betaflight/betaflight/assets/56646290/6ffe9fab-fedf-48f9-99c6-d7884c51f21e)
![image](https://github.com/betaflight/betaflight/assets/56646290/8e2eda03-9b31-47f6-9b96-9a9921cfce9e)



