### PR TITLE
Use intptr_t for casting void * to an integer

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -984,7 +984,7 @@ static void cmsTraverseGlobalExit(const CMS_Menu *pMenu)
 
 const void *cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
 {
-    intptr_t exitType = (intptr_t)ptr;
+    int exitType = (intptr_t)ptr;
     switch (exitType) {
     case CMS_EXIT_SAVE:
     case CMS_EXIT_SAVEREBOOT:

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -984,7 +984,7 @@ static void cmsTraverseGlobalExit(const CMS_Menu *pMenu)
 
 const void *cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
 {
-    int exitType = (int)ptr;
+    intptr_t exitType = (intptr_t)ptr;
     switch (exitType) {
     case CMS_EXIT_SAVE:
     case CMS_EXIT_SAVEREBOOT:


### PR DESCRIPTION
Rather than attempting to cast `void *` to `int` which can result in the following error.

```
cast to smaller integer type 'int' from 'const void *' [-Werror,-Wvoid-pointer-to-int-cast]
```

Instead use the `intptr_t` type which is designed for this purpose.

This PR doesn't excuse such heinous coding, but somewhat mitigates its nastiness!