### PR TITLE
Fix qmc5883l lockup

### DIFF
--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -67,8 +67,11 @@
 #define QMC5883L_RST 0x80
 
 #define QMC5883L_REG_DATA_OUTPUT_X 0x00
+#define QMC5883L_REG_DATA_UNLOCK 0x05
 #define QMC5883L_REG_STATUS 0x06
 #define QMC5883L_REG_STATUS_DRDY 0x01
+#define QMC5883L_REG_STATUS_OVL  0x02
+#define QMC5883L_REG_STATUS_DOR  0x04
 
 #define QMC5883L_REG_ID 0x0D
 #define QMC5883_ID_VAL 0xFF
@@ -94,7 +97,7 @@ static bool qmc5883lInit(magDev_t *magDev)
 static bool qmc5883lRead(magDev_t *magDev, int16_t *magData)
 {
     static uint8_t buf[6];
-    static uint8_t status = 0;
+    static uint8_t status = 0; // request status on first read
     static enum {
         STATE_WAIT_DRDY,
         STATE_READ,
@@ -109,6 +112,10 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData)
                 // New data is available
                 busReadRegisterBufferStart(dev, QMC5883L_REG_DATA_OUTPUT_X, buf, sizeof(buf));
                 state = STATE_READ;
+            } else if (status & QMC5883L_REG_STATUS_DOR) {
+                // Data overrun (and data not ready). Data registers may be locked, read unlock regiter (ZH)
+                busReadRegisterBufferStart(dev, QMC5883L_REG_DATA_UNLOCK, buf + sizeof(buf) - 1, 1);
+                status = 0;   // force status read next
             } else {
                 // Read status register to check for data ready
                 busReadRegisterBufferStart(dev, QMC5883L_REG_STATUS, &status, sizeof(status));


### PR DESCRIPTION
Data registers are locked until last/unlock register is read. New data are not stored when locked and DRDY is not set.
On bus error, read may finish early (not reading unlock register) and thus cause driver lockup.
