### PR TITLE
Speed up serial GPS message decoding

### DIFF
--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -316,6 +316,8 @@ uint32_t millis(void) { return 0; }
 uint8_t getBatteryCellCount(void) { return 1; }
 void servoMixerLoadMix(int) {}
 const char * getBatteryStateString(void){ return "_getBatteryStateString_"; }
+uint32_t getCycleCounter(void) { return 0; }
+uint32_t clockMicrosToCycles(uint32_t micros) { return micros; }
 
 uint32_t stackTotalSize(void) { return 0x4000; }
 uint32_t stackHighMem(void) { return 0x80000000; }


### PR DESCRIPTION
This PR improves the performance of the serial GPS message decoding. The execute time of the GPS task now usually stays bellow 20 us on an F722. Usually only one more fast cycle is required process a nav-pvt message compared to current master. Previously the processing time was just bellow 30.

[Limit gps processing time with clock cycles instead of micros](https://github.com/betaflight/betaflight/commit/7cf01e505903e7a57f078f7e61f0220cb4968775)
Replacing the repeated calls to micros with checking the number of CPU cycles speeds up the message processing by about 25-30%. The max processing time is lowered to 15 us (from 25) to take advantage of the faster processing.

[Defer ublox message processing if low on time](https://github.com/betaflight/betaflight/commit/16a557249c156f9d58e7dc96f66be664f1b1313f)
Processing an ublox message after the last byte is received takes about 4-5 us. The task will now use a lower time limit if the ublox parser is on the last byte to prevent the task time from spiking at the end of a message.

#### Logs 
[gps_processing_logs.zip](https://github.com/betaflight/betaflight/files/14696790/gps_processing_logs.zip)
The logs were recorder at 115200 kbit to create a worst case scenario.
