### PR TITLE
SPI ELRS: Add bind the receiver with power-cycle 3 times

### DIFF
--- a/src/main/pg/rx_spi_expresslrs.c
+++ b/src/main/pg/rx_spi_expresslrs.c
@@ -37,7 +37,7 @@
 #define RX_EXPRESSLRS_SPI_BUSY_PIN NONE
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(rxExpressLrsSpiConfig_t, rxExpressLrsSpiConfig, PG_RX_EXPRESSLRS_SPI_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(rxExpressLrsSpiConfig_t, rxExpressLrsSpiConfig, PG_RX_EXPRESSLRS_SPI_CONFIG, 1);
 
 PG_RESET_TEMPLATE(rxExpressLrsSpiConfig_t, rxExpressLrsSpiConfig,
     .resetIoTag = IO_TAG(RX_EXPRESSLRS_SPI_RESET_PIN),

--- a/src/main/pg/rx_spi_expresslrs.c
+++ b/src/main/pg/rx_spi_expresslrs.c
@@ -47,5 +47,6 @@ PG_RESET_TEMPLATE(rxExpressLrsSpiConfig_t, rxExpressLrsSpiConfig,
     .domain = 0,
     .rateIndex = 0,
     .modelId = 0xFF,
+    .powerOnCounter = 0,
 );
 #endif

--- a/src/main/pg/rx_spi_expresslrs.h
+++ b/src/main/pg/rx_spi_expresslrs.h
@@ -32,6 +32,7 @@ typedef struct rxExpressLrsSpiConfig_s {
     uint8_t domain;
     uint8_t rateIndex;
     uint8_t modelId;
+    uint32_t powerOnCounter;
 } rxExpressLrsSpiConfig_t;
 
 PG_DECLARE(rxExpressLrsSpiConfig_t, rxExpressLrsSpiConfig);

--- a/src/main/rx/expresslrs.c
+++ b/src/main/rx/expresslrs.c
@@ -952,6 +952,11 @@ bool expressLrsSpiInit(const struct rxSpiConfig_s *rxConfig, struct rxRuntimeSta
     // Timer IRQs must only be enabled after the receiver is configured otherwise race conditions occur.
     expressLrsTimerEnableIRQs();
 
+#ifdef USE_PERSISTENT_STATS
+    rxExpressLrsSpiConfigMutable()->powerOnCounter = rxExpressLrsSpiConfig()->powerOnCounter + 1;
+    receiver.configChanged = true;
+#endif
+
     return true;
 }
 
@@ -1120,6 +1125,24 @@ rx_spi_received_e expressLrsDataReceived(uint8_t *payloadBuffer)
         initializeReceiver();
         receiver.initializeReceiverPending = false;
     }
+
+#ifdef USE_PERSISTENT_STATS
+    // We haven't reached our binding mode power cycles and we've been powered on for 2s, reset the power on counter.
+    static bool enter_once = false;
+    if (rxExpressLrsSpiConfig()->powerOnCounter >= 3 && !enter_once)
+    {
+        rxExpressLrsSpiConfigMutable()->powerOnCounter = 0;
+        receiver.configChanged = true;
+
+        enterBindingMode();
+        enter_once = true;
+    }
+    else if ((millis() > 4000) && (rxExpressLrsSpiConfig()->powerOnCounter != 0))
+    {
+        rxExpressLrsSpiConfigMutable()->powerOnCounter = 0;
+        receiver.configChanged = true;
+    }
+#endif
 
     if (rxSpiCheckBindRequested(true)) {
         enterBindingMode();

--- a/src/main/rx/expresslrs.c
+++ b/src/main/rx/expresslrs.c
@@ -1129,16 +1129,13 @@ rx_spi_received_e expressLrsDataReceived(uint8_t *payloadBuffer)
 #ifdef USE_PERSISTENT_STATS
     // We haven't reached our binding mode power cycles and we've been powered on for 2s, reset the power on counter.
     static bool enter_once = false;
-    if (rxExpressLrsSpiConfig()->powerOnCounter >= 3 && !enter_once)
-    {
+    if (rxExpressLrsSpiConfig()->powerOnCounter >= 3 && !enter_once) {
         rxExpressLrsSpiConfigMutable()->powerOnCounter = 0;
         receiver.configChanged = true;
 
         enterBindingMode();
         enter_once = true;
-    }
-    else if ((millis() > 4000) && (rxExpressLrsSpiConfig()->powerOnCounter != 0))
-    {
+    } else if ((millis() > 4000) && (rxExpressLrsSpiConfig()->powerOnCounter != 0)) {
         rxExpressLrsSpiConfigMutable()->powerOnCounter = 0;
         receiver.configChanged = true;
     }


### PR DESCRIPTION
Because some flight controllers do not have a reserved binding button, convenient binding cannot be performed outdoors. This idea comes from the ELRS external receiver.