### PR TITLE
Use PDOP consistently, since it replaces HDOP

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1509,7 +1509,7 @@ const clivalue_t valueTable[] = {
     { "osd_profile_2_name",         VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, OSD_PROFILE_NAME_LENGTH, STRING_FLAGS_NONE }, PG_OSD_CONFIG, offsetof(osdConfig_t, profile[1]) },
     { "osd_profile_3_name",         VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, OSD_PROFILE_NAME_LENGTH, STRING_FLAGS_NONE }, PG_OSD_CONFIG, offsetof(osdConfig_t, profile[2]) },
 #endif
-    { "osd_gps_sats_show_hdop",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, gps_sats_show_hdop) },
+    { "osd_gps_sats_show_pdop",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_OSD_CONFIG, offsetof(osdConfig_t, gps_sats_show_pdop) },
     { "osd_displayport_device",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OSD_DISPLAYPORT_DEVICE }, PG_OSD_CONFIG, offsetof(osdConfig_t, displayPortDevice) },
 
     { "osd_rcchannels",             VAR_INT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = OSD_RCCHANNELS_COUNT, PG_OSD_CONFIG, offsetof(osdConfig_t, rcChannels) },

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -99,7 +99,7 @@ void calculateEstimatedAltitude(void)
     static float newBaroAltOffsetCm = 0.0f;
 
     float baroAltCm = 0.0f;
-    float gpsTrust = 0.3f; // if no hDOP value, use 0.3
+    float gpsTrust = 0.3f; // if no pDOP value, use 0.3
     bool haveBaroAlt = false; // true if baro exists and has been calibrated on power up
     bool haveGpsAlt = false; // true if GPS is connected and while it has a 3D fix, set each run to false
 
@@ -116,8 +116,8 @@ void calculateEstimatedAltitude(void)
         // On loss of 3D fix, gpsAltCm remains at the last value, haveGpsAlt becomes false, and gpsTrust goes to zero.
         gpsAltCm = gpsSol.llh.altCm; // static, so hold last altitude value if 3D fix is lost to prevent fly to moon
         haveGpsAlt = true; // stays false if no 3D fix
-        if (gpsSol.dop.hdop != 0) {
-            gpsTrust = 100.0f / gpsSol.dop.hdop;
+        if (gpsSol.dop.pdop != 0) {
+            gpsTrust = 100.0f / gpsSol.dop.pdop;
             // *** TO DO - investigate if we should use vDOP or vACC with UBlox units;
         }
         // always use at least 10% of other sources besides gps if available

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -99,7 +99,7 @@ void calculateEstimatedAltitude(void)
     static float newBaroAltOffsetCm = 0.0f;
 
     float baroAltCm = 0.0f;
-    float gpsTrust = 0.3f; // if no pDOP value, use 0.3
+    float gpsTrust = 0.3f; // if no pDOP value, use 0.3, intended range 0-1;
     bool haveBaroAlt = false; // true if baro exists and has been calibrated on power up
     bool haveGpsAlt = false; // true if GPS is connected and while it has a 3D fix, set each run to false
 
@@ -117,6 +117,8 @@ void calculateEstimatedAltitude(void)
         gpsAltCm = gpsSol.llh.altCm; // static, so hold last altitude value if 3D fix is lost to prevent fly to moon
         haveGpsAlt = true; // stays false if no 3D fix
         if (gpsSol.dop.pdop != 0) {
+            // pDOP of 1.0 is good.  100 is very bad.  Our gpsSol.dop.pdop values are *100
+            // When pDOP is a value less than 3.3, GPS trust will be stronger than default.
             gpsTrust = 100.0f / gpsSol.dop.pdop;
             // *** TO DO - investigate if we should use vDOP or vACC with UBlox units;
         }

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1514,7 +1514,7 @@ case MSP_NAME:
         sbufWriteU16(dst, gpsSol.groundSpeed);
         sbufWriteU16(dst, gpsSol.groundCourse);
         // Added in API version 1.44
-        sbufWriteU16(dst, gpsSol.dop.hdop);
+        sbufWriteU16(dst, gpsSol.dop.pdop);
         break;
 
     case MSP_COMP_GPS:
@@ -3641,7 +3641,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         gpsSol.acc.hAcc = sbufReadU16(src) * 10; // horizontal_pos_accuracy - convert cm to mm
         gpsSol.acc.vAcc = sbufReadU16(src) * 10; // vertical_pos_accuracy - convert cm to mm
         gpsSol.acc.sAcc = sbufReadU16(src) * 10; // horizontal_vel_accuracy - convert cm to mm
-        gpsSol.dop.hdop = sbufReadU16(src); // hdop
+        gpsSol.dop.pdop = sbufReadU16(src); // hdop in 4.4 and earlier, pdop in 4.5 and above
         gpsSol.llh.lon = sbufReadU32(src);
         gpsSol.llh.lat = sbufReadU32(src);
         gpsSol.llh.altCm = sbufReadU32(src); // alt

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -389,7 +389,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     }
     osdConfig->rssi_dbm_alarm = -60;
     osdConfig->rsnr_alarm = 4;
-    osdConfig->gps_sats_show_hdop = false;
+    osdConfig->gps_sats_show_pdop = false;
 
     for (int i = 0; i < OSD_RCCHANNELS_COUNT; i++) {
         osdConfig->rcChannels[i] = -1;

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -330,7 +330,7 @@ typedef struct osdConfig_s {
     uint16_t link_quality_alarm;
     int16_t rssi_dbm_alarm;
     int16_t rsnr_alarm;
-    uint8_t gps_sats_show_hdop;
+    uint8_t gps_sats_show_pdop;
     int8_t rcChannels[OSD_RCCHANNELS_COUNT];  // RC channel values to display, -1 if none
     uint8_t displayPortDevice;                // osdDisplayPortDevice_e
     uint16_t distance_alarm;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1151,7 +1151,7 @@ static void osdElementGpsSats(osdElementParms_t *element)
         tfp_sprintf(element->buff, "%c%cNC", SYM_SAT_L, SYM_SAT_R);
     } else {
         int pos = tfp_sprintf(element->buff, "%c%c%2d", SYM_SAT_L, SYM_SAT_R, gpsSol.numSat);
-        if (osdConfig()->gps_sats_show_hdop) { // add on the GPS module HDOP estimate
+        if (osdConfig()->gps_sats_show_pdop) { // add on the GPS module PDOP estimate
             element->buff[pos++] = ' ';
             osdPrintFloat(element->buff + pos, SYM_NONE, gpsSol.dop.pdop / 100.0f, "", 1, true, SYM_NONE);
         }

--- a/src/main/telemetry/frsky_hub.c
+++ b/src/main/telemetry/frsky_hub.c
@@ -131,7 +131,7 @@ static frSkyHubWriteByteFn *frSkyHubWriteByte = NULL;
 #define ID_VERT_SPEED         0x30 // opentx vario
 
 #define GPS_BAD_QUALITY       300
-#define GPS_MAX_HDOP_VAL      9999
+#define GPS_MAX_DOP_VAL      9999
 #define DELAY_FOR_BARO_INITIALISATION_US 5000000
 #define BLADE_NUMBER_DIVIDER  5 // should set 12 blades in Taranis
 
@@ -288,8 +288,8 @@ static void sendSatalliteSignalQualityAsTemperature2(uint8_t cycleNum)
 {
     uint16_t satellite = gpsSol.numSat;
 
-    if (gpsSol.dop.hdop > GPS_BAD_QUALITY && ( (cycleNum % 16 ) < 8)) { // Every 1s
-        satellite = constrain(gpsSol.dop.hdop, 0, GPS_MAX_HDOP_VAL);
+    if (gpsSol.dop.pdop > GPS_BAD_QUALITY && ( (cycleNum % 16 ) < 8)) { // Every 1s
+        satellite = constrain(gpsSol.dop.pdop, 0, GPS_MAX_DOP_VAL);
     }
     int16_t data;
     if (telemetryConfig()->frsky_unit == UNIT_IMPERIAL) {

--- a/src/main/telemetry/ghst.c
+++ b/src/main/telemetry/ghst.c
@@ -209,7 +209,7 @@ typedef enum {
     GHST_FRAME_START_INDEX = 0,
     GHST_FRAME_PACK_INDEX = GHST_FRAME_START_INDEX, // Battery (Pack) data
     GHST_FRAME_GPS_PRIMARY_INDEX,                   // GPS, primary values (Lat, Long, Alt)
-    GHST_FRAME_GPS_SECONDARY_INDEX,                 // GPS, secondary values (Sat Count, HDOP, etc.)
+    GHST_FRAME_GPS_SECONDARY_INDEX,                 // GPS, secondary values (Sat Count, DOP, etc.)
     GHST_FRAME_MAGBARO_INDEX,                       // Magnetometer/Baro values
     GHST_SCHEDULE_COUNT_MAX
 } ghstFrameTypeIndex_e;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -795,9 +795,11 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
             case FSSP_DATAID_T2         :
 #ifdef USE_GPS
                 if (sensors(SENSOR_GPS)) {
-                    // satellite accuracy HDOP: 0 = worst [HDOP > 5.5m], 9 = best [HDOP <= 1.0m]
-                    uint16_t hdop = constrain(scaleRange(gpsSol.dop.hdop, 100, 550, 9, 0), 0, 9) * 100;
-                    smartPortSendPackage(id, (STATE(GPS_FIX) ? 1000 : 0) + (STATE(GPS_FIX_HOME) ? 2000 : 0) + hdop + gpsSol.numSat);
+                    // satellite accuracy PDOP: 0 = worst [PDOP > 5.5m], 9 = best [PDOP <= 1.0m]
+                    // the above comment isn't entirely right. DOP is accuracy relative to specified accuracy of the module, not a value in meters
+                    // eg a value of 1.0 means 1.0 times specified accuracy (typically 2m)
+                    uint16_t pdop = constrain(scaleRange(gpsSol.dop.pdop, 100, 550, 9, 0), 0, 9) * 100;
+                    smartPortSendPackage(id, (STATE(GPS_FIX) ? 1000 : 0) + (STATE(GPS_FIX_HOME) ? 2000 : 0) + pdop + gpsSol.numSat);
                     *clearToSend = false;
                 } else if (featureIsEnabled(FEATURE_GPS)) {
                     smartPortSendPackage(id, 0);

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -296,7 +296,7 @@ bool srxlFrameGpsLoc(sbuf_t *dst, timeUs_t currentTimeUs)
     UNUSED(currentTimeUs);
     gpsCoordinateDDDMMmmmm_t coordinate;
     uint32_t latitudeBcd, longitudeBcd, altitudeLo;
-    uint16_t altitudeLoBcd, groundCourseBcd, hpop;
+    uint16_t altitudeLoBcd, groundCourseBcd, pdop;
     uint8_t pdopBcd, gpsFlags;
 
     if (!featureIsEnabled(FEATURE_GPS) || !STATE(GPS_FIX) || gpsSol.numSat < GPS_MIN_SAT_COUNT) {

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -277,7 +277,7 @@ typedef struct
     UINT32   latitude;      // BCD, format 4.4, Degrees * 100 + minutes, less than 100 degrees
     UINT32   longitude;     // BCD, format 4.4 , Degrees * 100 + minutes, flag indicates > 99 degrees
     UINT16   course;        // BCD, 3.1
-    UINT8    HDOP;          // BCD, format 1.1
+    UINT8    PDOP;          // BCD, format 1.1
     UINT8    GPSflags;      // see definitions below
 } STRU_TELE_GPS_LOC;
 */
@@ -296,8 +296,8 @@ bool srxlFrameGpsLoc(sbuf_t *dst, timeUs_t currentTimeUs)
     UNUSED(currentTimeUs);
     gpsCoordinateDDDMMmmmm_t coordinate;
     uint32_t latitudeBcd, longitudeBcd, altitudeLo;
-    uint16_t altitudeLoBcd, groundCourseBcd, hdop;
-    uint8_t hdopBcd, gpsFlags;
+    uint16_t altitudeLoBcd, groundCourseBcd, hpop;
+    uint8_t pdopBcd, gpsFlags;
 
     if (!featureIsEnabled(FEATURE_GPS) || !STATE(GPS_FIX) || gpsSol.numSat < GPS_MIN_SAT_COUNT) {
         return false;
@@ -318,10 +318,10 @@ bool srxlFrameGpsLoc(sbuf_t *dst, timeUs_t currentTimeUs)
     // Ground course
     groundCourseBcd = dec2bcd(gpsSol.groundCourse);
 
-    // HDOP
-    hdop = gpsSol.dop.hdop / 10;
-    hdop = (hdop > 99) ? 99 : hdop;
-    hdopBcd = dec2bcd(hdop);
+    // PDOP
+    pdop = gpsSol.dop.pdop / 10;
+    pdop = (pdop > 99) ? 99 : pdop;
+    pdopBcd = dec2bcd(pdop);
 
     // flags
     gpsFlags = GPS_FLAGS_GPS_DATA_RECEIVED_BIT | GPS_FLAGS_GPS_FIX_VALID_BIT | GPS_FLAGS_3D_FIX_BIT;
@@ -337,7 +337,7 @@ bool srxlFrameGpsLoc(sbuf_t *dst, timeUs_t currentTimeUs)
     sbufWriteU32(dst, latitudeBcd);
     sbufWriteU32(dst, longitudeBcd);
     sbufWriteU16(dst, groundCourseBcd);
-    sbufWriteU8(dst, hdopBcd);
+    sbufWriteU8(dst, pdopBcd);
     sbufWriteU8(dst, gpsFlags);
 
     return true;


### PR DESCRIPTION
Initiated by issue [13461](https://github.com/betaflight/betaflight/issues/13461) 

In 4.5, with auto-configuration, we now only request `NAV_PVT` packets from the GPS modules, all others are blocked.  As a result, we only receive `PDOP` values in 4.5.  We do not receive `HDOP` data at all.

This is different from 4.4, where we did request `HDOP` values, and `HDOP` was used in a number of places.

This PR ensures that `PDOP` is used consistently in 4.5.  It fixes a bug where `gpsTrust` would not have been modulated by DOP as it should have been.

The user will notice that in 4.5 the DOP estimate shown in OSD will not be as 'good' (not as low) in 4.5 compared to 4.4 because the `PDOP` precision estimate includes a vertical error, component, which is usually worse than `HDOP`, which only considers horizontal accuracy.

Also the CLI command to include DOP in the OSD is now `osd_gps_sats_show_pdop`.

The decision to use `PDOP` in 4.5 was made because:
- in 4.4 not all modules would report `HDOP`, and the serial load could be very high
- reducing serial port load by not requesting separate DOP packets from the module is a definite advantage
- auto-configuration to always get `NAV_PVT` ensures that we always have `PDOP` values whenever we have a 3D fix.
- GPS rescue and position hold require vertical accuracy to be good, and `PDOP` includes consideration of vertical accuracy.

My apologies for not noticing these issues earlier.

May need coordination with Congifurator.

The `GPS_DOP` debug may be used to check which DOP values are being received in both 4.4 and 4.5, as follows:

```
    DEBUG_SET(DEBUG_GPS_DOP, 0, gpsSol.numSat);
    DEBUG_SET(DEBUG_GPS_DOP, 1, gpsSol.dop.pdop);
    DEBUG_SET(DEBUG_GPS_DOP, 2, gpsSol.dop.hdop);
    DEBUG_SET(DEBUG_GPS_DOP, 3, gpsSol.dop.vdop);
```