### PR TITLE
mag cal improvements

### DIFF
--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -485,7 +485,7 @@ uint32_t compassUpdate(timeUs_t currentTimeUs)
             // start acquiring mag data and computing new cal factors
             if (didMovementStart) {
                 // LED will flash at task rate while calibrating, looks like 'ON' all the time.
-                LED0_TOGGLE;
+                LED0_ON;
                 compassBiasEstimatorApply(&compassBiasEstimator, mag.magADC);
             }
         } else {

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -81,7 +81,7 @@
                                                              // a relatively high value so that the calibration routine is not triggered too early
 #define CALIBRATION_TIME_US (30 * 1000 * 1000)               // duration of the calibration phase in us
 
-static timeUs_t magCalProcessEndTimeUs = 0;
+static timeUs_t magCalEndTime = 0;
 static bool didMovementStart = false;
 static bool magCalProcessActive = false;
 
@@ -413,7 +413,7 @@ void compassStartCalibration(void)
     // starting now, the user has CALIBRATION_WAIT_US to start moving the quad and trigger the actual calibration routine
     beeper(BEEPER_ACC_CALIBRATION); // Beep to alert user that calibration request was received
     magCalProcessActive = true;
-    magCalProcessEndTimeUs = micros() + CALIBRATION_WAIT_US;
+    magCalEndTime = micros() + CALIBRATION_WAIT_US;
     didMovementStart = false;
     // reset / update the compass bias estimator for faster convergence
     compassBiasEstimatorUpdate(&compassBiasEstimator, LAMBDA_MIN, P0);
@@ -465,7 +465,7 @@ uint32_t compassUpdate(timeUs_t currentTimeUs)
 
     // ** perform calibration, if initiated by switch or Configurator button **
     if (magCalProcessActive) {
-        if (cmpTimeUs(magCalProcessEndTimeUs, currentTimeUs) > 0) {
+        if (cmpTimeUs(magCalEndTime, currentTimeUs) > 0) {
                 // compare squared norm of rotation rate to GYRO_NORM_SQUARED_MIN
             float gyroNormSquared = 0.0f;
             for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
@@ -480,7 +480,7 @@ uint32_t compassUpdate(timeUs_t currentTimeUs)
                 }
                 didMovementStart = true;
                 // the user has CALIBRATION_TIME_US from now to move the quad in all directions
-                magCalProcessEndTimeUs = micros() + CALIBRATION_TIME_US;
+                magCalEndTime = micros() + CALIBRATION_TIME_US;
             }
             // start acquiring mag data and computing new cal factors
             if (didMovementStart) {


### PR DESCRIPTION
Four small improvements following user feedback, intended to improve the user experience when calibrating a Magnetometer.

- Some users found it difficult to reliably initiate a Mag calibration.  This PR reduces the 'movement' threshold required to start measuring the Mag field strengths.  Any movement exceeding 350 deg/s - previously it was 450 deg/s - should be sufficient.  No need to 'hit' the frame, just wobble it quickly on any axis.

- Previously, LED0, the main status LED, would go 'solid' immediately the user clicked the Calibrate button, regardless of whether the threshold was reached.  There was no way to know if the threshold was reached.  This PR makes LED0 'solid' only when the threshold is reached.  It stays solid while the new Cal values are computed, and starts blinking normally after 30s, after the calibration is complete.  If the initation threshold is not reached, LED0 never changes its normal regular blinking, and the attempt to calibrate terminates after 15s, as before.

- The Beeper is supported, and highly recommended with a Mag.  It beeps twice, quickly, when the process starts, then a fast 7 beeps when you've moved the craft quickly to initiate the cal, then three steady beeps when the 30s period expires.  If you don't move it quick enough, or otherwise do nothing, after 15s it will give two slow beeps, indicating failure.  See [this table](https://github.com/betaflight/betaflight/pull/13487#issuecomment-2029106094).

- Previously, the old Cal values were set to zero the instant a Mag calibration was requested.  If the calibration process was aborted (eg by disconnecting the power, or quitting Configurator) before the movement threshold was reached, or if the threshold was never attained, the previous cal values would be lost (set to 0,0,0).  There would be no warning and no way of knowing that this happened.  This PR only zeroes the previous cal values after the movement threshold has been reached (when LED0 goes solid).  

- The Mag_Calib debug 7 field, which shows the lambda value while calibrating, is now zeroed on completion of the calibration, so that if you are looking at the sensors tab, you know when it is finished.

I've tested these changes and they work well.  Having a beeper to confirm the stick command, and to provide feedback during the cal process, is extremely helpful at the field.