### PR TITLE
Ez landing by PID input Error Limit method, with auto-disarm

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1409,9 +1409,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_BREAKPOINT, "%d",     currentPidProfile->tpa_low_breakpoint);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_ALWAYS, "%d",         currentPidProfile->tpa_low_always);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MIXER_TYPE, "%s",             lookupTableMixerType[mixerConfig()->mixer_type]);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_THRESHOLD, "%d",   currentPidProfile->ez_landing_threshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_LIMIT, "%d",       currentPidProfile->ez_landing_limit);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_SPEED, "%d",       currentPidProfile->ez_landing_speed);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_DISARM_THRESHOLD, "%d",    currentPidProfile->ez_landing_disarm_threshold);
 
 #ifdef USE_WING
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_SPA_ROLL_CENTER, "%d",        currentPidProfile->spa_center[FD_ROLL]);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1409,6 +1409,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_BREAKPOINT, "%d",     currentPidProfile->tpa_low_breakpoint);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_ALWAYS, "%d",         currentPidProfile->tpa_low_always);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MIXER_TYPE, "%s",             lookupTableMixerType[mixerConfig()->mixer_type]);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_THRESHOLD, "%d",   currentPidProfile->ez_landing_threshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_LIMIT, "%d",       currentPidProfile->ez_landing_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_DISARM_THRESHOLD, "%d",    currentPidProfile->ez_landing_disarm_threshold);
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1272,7 +1272,8 @@ const clivalue_t valueTable[] = {
 #endif
 
     { PARAM_NAME_EZ_LANDING_THRESHOLD, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
-    { PARAM_NAME_EZ_LANDING_LIMIT,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
+    { PARAM_NAME_EZ_LANDING_LIMIT,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
+    { PARAM_NAME_EZ_DISARM_THRESHOLD,  VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_disarm_threshold) },
 
 #ifdef USE_WING
     { PARAM_NAME_SPA_ROLL_CENTER,    VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_center[FD_ROLL]) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -506,7 +506,7 @@ const char * const lookupTableSimplifiedTuningPidsMode[] = {
 };
 
 const char* const lookupTableMixerType[] = {
-    "LEGACY", "LINEAR", "DYNAMIC", "EZLANDING",
+    "LEGACY", "LINEAR", "DYNAMIC",
 };
 
 #ifdef USE_OSD
@@ -1271,9 +1271,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_GRAVITY_THR100, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_GRAVITY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_gravity_thr100) },
 #endif
 
-    { PARAM_NAME_EZ_LANDING_THRESHOLD,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
-    { PARAM_NAME_EZ_LANDING_LIMIT,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 75 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
-    { PARAM_NAME_EZ_LANDING_SPEED,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_speed) },
+    { PARAM_NAME_EZ_LANDING_THRESHOLD, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
+    { PARAM_NAME_EZ_LANDING_LIMIT,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
 
 #ifdef USE_WING
     { PARAM_NAME_SPA_ROLL_CENTER,    VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_center[FD_ROLL]) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -559,10 +559,6 @@ static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
 
-static uint8_t cmsx_ez_landing_threshold;
-static uint8_t cmsx_ez_landing_limit;
-static uint8_t cmsx_ez_landing_disarm_threshold;
-
 static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 {
     UNUSED(pDisp);

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -266,6 +266,9 @@ static uint16_t cmsx_tpa_breakpoint;
 static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
+static uint8_t cmsx_ez_landing_threshold;
+static uint8_t cmsx_ez_landing_limit;
+static uint8_t cmsx_ez_landing_disarm_threshold;
 
 static const void *cmsx_simplifiedTuningOnEnter(displayPort_t *pDisp)
 {
@@ -556,6 +559,10 @@ static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
 
+static uint8_t cmsx_ez_landing_threshold;
+static uint8_t cmsx_ez_landing_limit;
+static uint8_t cmsx_ez_landing_disarm_threshold;
+
 static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 {
     UNUSED(pDisp);
@@ -610,6 +617,10 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     cmsx_tpa_low_rate = pidProfile->tpa_low_rate;
     cmsx_tpa_low_breakpoint = pidProfile->tpa_low_breakpoint;
     cmsx_tpa_low_always = pidProfile->tpa_low_always;
+
+    cmsx_ez_landing_threshold = pidProfile->ez_landing_threshold;
+    cmsx_ez_landing_limit = pidProfile->ez_landing_limit;
+    cmsx_ez_landing_disarm_threshold = pidProfile->ez_landing_disarm_threshold;
 
     return NULL;
 }
@@ -668,6 +679,10 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->tpa_low_rate = cmsx_tpa_low_rate;
     pidProfile->tpa_low_breakpoint = cmsx_tpa_low_breakpoint;
     pidProfile->tpa_low_always = cmsx_tpa_low_always;
+
+    pidProfile->ez_landing_threshold = cmsx_ez_landing_threshold;
+    pidProfile->ez_landing_limit = cmsx_ez_landing_limit;
+    pidProfile->ez_landing_disarm_threshold = cmsx_ez_landing_disarm_threshold;
 
     initEscEndpoints();
     return NULL;
@@ -728,6 +743,10 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "TPA LOW RATE",  OME_INT8,   NULL, &(OSD_INT8_t) { &cmsx_tpa_low_rate, TPA_LOW_RATE_MIN, TPA_MAX , 1} },
     { "TPA LOW BRKPT", OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_tpa_low_breakpoint, 1000, 2000, 10} },
     { "TPA LOW ALWYS", OME_Bool,   NULL, &cmsx_tpa_low_always },
+
+    { "EZLAND THRSH",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_threshold,        0,  50, 1} },
+    { "EZLAND LIMIT",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_limit,            1, 100, 1} },
+    { "EZDISARM THR",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_disarm_threshold, 0, 150, 1} },
 
     { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -55,6 +55,7 @@ typedef enum {
     DISARM_REASON_RUNAWAY_TAKEOFF   = 6,
     DISARM_REASON_GPS_RESCUE        = 7,
     DISARM_REASON_SERIAL_COMMAND    = 8,
+    DISARM_REASON_LANDING           = 9,
 #ifdef UNIT_TEST
     DISARM_REASON_SYSTEM            = 255,
 #endif

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -64,7 +64,7 @@
 #define PARAM_NAME_MIXER_TYPE "mixer_type"
 #define PARAM_NAME_EZ_LANDING_THRESHOLD "ez_landing_threshold"
 #define PARAM_NAME_EZ_LANDING_LIMIT "ez_landing_limit"
-#define PARAM_NAME_EZ_LANDING_SPEED "ez_landing_speed"
+#define PARAM_NAME_EZ_DISARM_THRESHOLD "ez_landing_disarm_threshold"
 #define PARAM_NAME_SPA_ROLL_CENTER "spa_roll_center"
 #define PARAM_NAME_SPA_ROLL_WIDTH "spa_roll_width"
 #define PARAM_NAME_SPA_ROLL_MODE "spa_roll_mode"

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -662,7 +662,7 @@ FAST_CODE void processRcCommand(void)
         calculateFeedforward(&pidRuntime, axis);
 #endif // USE_FEEDFORWARD
 
-        sendMaxDeflectionAbs(maxRcDeflectionAbs);
+        calcEzLandingFactor(maxRcDeflectionAbs);
 
         }
         // adjust unfiltered setpoint steps to camera angle (mixing Roll and Yaw)

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -662,7 +662,7 @@ FAST_CODE void processRcCommand(void)
         calculateFeedforward(&pidRuntime, axis);
 #endif // USE_FEEDFORWARD
 
-        calcEzLandingFactor(maxRcDeflectionAbs);
+        calcEzLandingLimit(maxRcDeflectionAbs);
 
         }
         // adjust unfiltered setpoint steps to camera angle (mixing Roll and Yaw)

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -63,7 +63,6 @@ static float rawSetpoint[XYZ_AXIS_COUNT];
 
 static float setpointRate[3], rcDeflection[3], rcDeflectionAbs[3]; // deflection range -1 to 1
 static float maxRcDeflectionAbs;
-
 static bool reverseMotors = false;
 static applyRatesFn *applyRates;
 
@@ -141,11 +140,6 @@ float getRcDeflectionRaw(int axis)
 float getRcDeflectionAbs(int axis)
 {
     return rcDeflectionAbs[axis];
-}
-
-float getMaxRcDeflectionAbs(void)
-{
-    return maxRcDeflectionAbs;
 }
 
 #define THROTTLE_LOOKUP_LENGTH 12
@@ -660,12 +654,15 @@ FAST_CODE void processRcCommand(void)
                 angleRate = applyRates(axis, rcCommandf, rcCommandfAbs);
             }
 
+
             rawSetpoint[axis] = constrainf(angleRate, -1.0f * currentControlRateProfile->rate_limit[axis], 1.0f * currentControlRateProfile->rate_limit[axis]);
             DEBUG_SET(DEBUG_ANGLERATE, axis, angleRate);
 
 #ifdef USE_FEEDFORWARD
         calculateFeedforward(&pidRuntime, axis);
 #endif // USE_FEEDFORWARD
+
+        sendMaxDeflectionAbs(maxRcDeflectionAbs);
 
         }
         // adjust unfiltered setpoint steps to camera angle (mixing Roll and Yaw)

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -34,7 +34,7 @@ float getSetpointRate(int axis);
 float getRcDeflection(int axis);
 float getRcDeflectionRaw(int axis);
 float getRcDeflectionAbs(int axis);
-float calcEzLandingFactor(float maxRcDeflectionAbs);
+void calcEzLandingLimit(float maxRcDeflectionAbs);
 void updateRcCommands(void);
 void resetYawAxis(void);
 void initRcProcessing(void);

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -34,7 +34,7 @@ float getSetpointRate(int axis);
 float getRcDeflection(int axis);
 float getRcDeflectionRaw(int axis);
 float getRcDeflectionAbs(int axis);
-float sendMaxDeflectionAbs(float maxRcDeflectionAbs);
+float calcEzLandingFactor(float maxRcDeflectionAbs);
 void updateRcCommands(void);
 void resetYawAxis(void);
 void initRcProcessing(void);

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -34,7 +34,7 @@ float getSetpointRate(int axis);
 float getRcDeflection(int axis);
 float getRcDeflectionRaw(int axis);
 float getRcDeflectionAbs(int axis);
-float getMaxRcDeflectionAbs(void);
+float sendMaxDeflectionAbs(float maxRcDeflectionAbs);
 void updateRcCommands(void);
 void resetYawAxis(void);
 void initRcProcessing(void);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,7 +100,7 @@ void stopMotors(void)
 }
 
 static FAST_DATA_ZERO_INIT float throttle = 0;
-static FAST_DATA_ZERO_INIT float basicThrottle = 0;
+static float basicThrottle = 0;
 static FAST_DATA_ZERO_INIT float mixerThrottle = 0;
 static FAST_DATA_ZERO_INIT float motorOutputMin;
 static FAST_DATA_ZERO_INIT float motorRangeMin;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,6 +100,7 @@ void stopMotors(void)
 }
 
 static FAST_DATA_ZERO_INIT float throttle = 0;
+static FAST_DATA_ZERO_INIT float basicThrottle = 0;
 static FAST_DATA_ZERO_INIT float mixerThrottle = 0;
 static FAST_DATA_ZERO_INIT float motorOutputMin;
 static FAST_DATA_ZERO_INIT float motorRangeMin;
@@ -264,6 +265,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
     }
 
     throttle = constrainf(throttle / currentThrottleInputRange, 0.0f, 1.0f);
+    basicThrottle = throttle;
 }
 
 #define CRASH_FLIP_DEADBAND 20
@@ -423,8 +425,6 @@ static void applyMixToMotors(const float motorMix[MAX_SUPPORTED_MOTORS], motorMi
             motor[i] = motor_disarmed[i];
         }
     }
-    DEBUG_SET(DEBUG_EZLANDING, 1, throttle * 10000U);
-    // DEBUG_EZLANDING 0 is the ezLanding factor 2 is the throttle limit
 }
 
 static float applyThrottleLimit(float throttle)
@@ -502,70 +502,6 @@ static void applyMixerAdjustmentLinear(float *motorMix, const bool airmodeEnable
 
     // constrain throttle so it won't clip any outputs
     throttle = constrainf(throttle, -minMotor, 1.0f - maxMotor);
-}
-
-static float calcEzLandLimit(float maxDeflection, float speed)
-{
-    // calculate limit to where the mixer can raise the throttle based on RPY stick deflection
-    // 0.0 = no increas allowed, 1.0 = 100% increase allowed
-    const float deflectionLimit = mixerRuntime.ezLandingThreshold > 0.0f ? fminf(1.0f, maxDeflection / mixerRuntime.ezLandingThreshold) : 0.0f;
-    DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
-
-    // calculate limit to where the mixer can raise the throttle based on speed
-    // TODO sanity checks like number of sats, dop, accuracy?
-    const float speedLimit = mixerRuntime.ezLandingSpeed > 0.0f ? fminf(1.0f, speed / mixerRuntime.ezLandingSpeed) : 0.0f;
-    DEBUG_SET(DEBUG_EZLANDING, 5, lrintf(speedLimit * 10000.0f));
-
-    // get the highest of the limits from deflection, speed, and the base ez_landing_limit
-    const float deflectionAndSpeedLimit = fmaxf(deflectionLimit, speedLimit);
-    return fmaxf(mixerRuntime.ezLandingLimit, deflectionAndSpeedLimit);
-}
-
-static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin, const float motorMixMax)
-{
-    // Calculate factor for normalizing motor mix range to <= 1.0
-    const float baseNormalizationFactor = motorMixRange > 1.0f ? 1.0f / motorMixRange : 1.0f;
-    const float normalizedMotorMixMin = motorMixMin * baseNormalizationFactor;
-    const float normalizedMotorMixMax = motorMixMax * baseNormalizationFactor;
-
-#ifdef USE_GPS
-    const float speed = STATE(GPS_FIX) ? gpsSol.speed3d / 100.0f : 0.0f;  // m/s
-#else
-    const float speed = 0.0f;
-#endif
-
-    const float ezLandLimit = calcEzLandLimit(getMaxRcDeflectionAbs(), speed);
-    // use the largest of throttle and limit calculated from RPY stick positions
-    float upperLimit = fmaxf(ezLandLimit, throttle);
-    // limit throttle to avoid clipping the highest motor output
-    upperLimit = fminf(upperLimit, 1.0f - normalizedMotorMixMax);
-
-    // Lower throttle Limit
-    const float epsilon = 1.0e-6f;  // add small value to avoid divisions by zero
-    const float absMotorMixMin = fabsf(normalizedMotorMixMin) + epsilon;
-    const float lowerLimit = fminf(upperLimit, absMotorMixMin);
-
-    // represents how much motor values have to be scaled to avoid clipping
-    const float ezLandFactor = upperLimit / absMotorMixMin;
-
-    // scale motor values
-    const float normalizationFactor = baseNormalizationFactor * fminf(1.0f, ezLandFactor);
-    for (int i = 0; i < mixerRuntime.motorCount; i++) {
-        motorMix[i] *= normalizationFactor;
-    }
-    motorMixRange *= baseNormalizationFactor;
-    // Make anti windup recognize reduced authority range
-    motorMixRange = fmaxf(motorMixRange, 1.0f / ezLandFactor);
-
-    // Constrain throttle
-    throttle = constrainf(throttle, lowerLimit, upperLimit);
-
-    // Log ezLandFactor, upper throttle limit, and ezLandFactor if throttle was zero
-    DEBUG_SET(DEBUG_EZLANDING, 0, fminf(1.0f, ezLandFactor) * 10000U);
-    // DEBUG_EZLANDING 1 is the adjusted throttle
-    DEBUG_SET(DEBUG_EZLANDING, 2, upperLimit * 10000U);
-    DEBUG_SET(DEBUG_EZLANDING, 3, fminf(1.0f, ezLandLimit / absMotorMixMin) * 10000U);
-    // DEBUG_EZLANDING 4 and 5 is the upper limits based on stick input and speed respectively
 }
 
 static void applyMixerAdjustment(float *motorMix, const float motorMixMin, const float motorMixMax, const bool airmodeEnabled)
@@ -740,9 +676,6 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
     case MIXER_DYNAMIC:
         applyMixerAdjustmentLinear(motorMix, airmodeEnabled);
         break;
-    case MIXER_EZLANDING:
-        applyMixerAdjustmentEzLand(motorMix, motorMixMin, motorMixMax);
-        break;
     default:
         applyMixerAdjustment(motorMix, motorMixMin, motorMixMax, airmodeEnabled);
         break;
@@ -770,4 +703,9 @@ void mixerSetThrottleAngleCorrection(int correctionValue)
 float mixerGetThrottle(void)
 {
     return mixerThrottle;
+}
+
+float mixerGetRcThrottle(void)
+{
+    return basicThrottle;
 }

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -71,7 +71,6 @@ typedef enum mixerType
     MIXER_LEGACY = 0,
     MIXER_LINEAR = 1,
     MIXER_DYNAMIC = 2,
-    MIXER_EZLANDING = 3,
 } mixerType_e;
 
 // Custom mixer data per motor
@@ -140,6 +139,7 @@ bool mixerIsTricopter(void);
 
 void mixerSetThrottleAngleCorrection(int correctionValue);
 float mixerGetThrottle(void);
+float mixerGetRcThrottle(void);
 mixerMode_e getMixerMode(void);
 bool mixerModeIsFixedWing(mixerMode_e mixerMode);
 bool isFixedWing(void);

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -366,10 +366,6 @@ void mixerInitProfile(void)
     pt1FilterInit(&mixerRuntime.rpmLimiterThrottleScaleOffsetFilter, pt1FilterGain(2.0f, pidGetDT()));
     mixerResetRpmLimiter();
 #endif
-
-    mixerRuntime.ezLandingThreshold = 2.0f * currentPidProfile->ez_landing_threshold / 100.0f;
-    mixerRuntime.ezLandingLimit = currentPidProfile->ez_landing_limit / 100.0f;
-    mixerRuntime.ezLandingSpeed = 2.0f * currentPidProfile->ez_landing_speed / 10.0f;
 }
 
 #ifdef USE_RPM_LIMIT

--- a/src/main/flight/mixer_init.h
+++ b/src/main/flight/mixer_init.h
@@ -64,9 +64,6 @@ typedef struct mixerRuntime_s {
     pt1Filter_t rpmLimiterAverageRpmFilter;
     pt1Filter_t rpmLimiterThrottleScaleOffsetFilter;
 #endif
-    float ezLandingThreshold;
-    float ezLandingLimit;
-    float ezLandingSpeed;
 } mixerRuntime_t;
 
 extern mixerRuntime_t mixerRuntime;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -774,22 +774,25 @@ float pidGetAirmodeThrottleOffset(void)
 }
 #endif
 
-// when new Rx data is received, update the maxDeflectionAbs value, so we don't do this every PID loop
+
+
+
+// runs when new Rx data is received in rc.c, updatesmaxDeflectionAbs, so we don't do this every PID loop
 static float maxDeflectionAbs = 0.0f;
 float sendMaxDeflectionAbs(float maxRcDeflectionAbs)
 {
     maxDeflectionAbs = fmaxf(maxRcDeflectionAbs, mixerGetRcThrottle());
     return maxDeflectionAbs;
+    DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
+
 }
 
-static void disarmOnImpact(const int axis)
+static void disarmOnImpact(void)
 {
-    // if both sticks are inside 20% of the stick threshold, enable auto-disarm on impact
+    // if both sticks are inside 50% of the stick threshold, enable auto-disarm on impact
     // will not disarm on gentle landings
-    // value should be highe enough to avoid unwanted disarms in the air on throttle chops
-    // note that unlike GPS code, this just compares one axis at a time, to reduce CPU load
-    // for the Z axis, 1G gets added while 'flat', but that won't matter much given we are looking around 8G mostly
-    float accMagnitude = fabsf(acc.accADC[axis]) * acc.dev.acc_1G_rec;
+    // threshold should be highe enough to avoid unwanted disarms in the air on throttle chops
+    float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
     // *** annoying to need to normalise accADC here, should normalise acc.accADC once, in accelerometer.c, not everywhere we use it
     if (isAirmodeActivated() && maxDeflectionAbs < pidRuntime.ezLandingThreshold * 0.5f) {
         if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
@@ -800,20 +803,23 @@ static void disarmOnImpact(const int axis)
     DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(accMagnitude * 10));
 }
 
-static float applyEzLanding(float rateToLimit, float multiplier)
+static float ezLandingFactor = 1.0f;
+static float calcEzLandingFactor(void)
 {
-    float ezLandFactor = 1.0f;
+    ezLandingFactor = 1.0f;
     if (!isFlipOverAfterCrashActive() && maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
-        ezLandFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
-        const float rateLimit = fabsf(ezLandFactor * rateToLimit);
-        rateToLimit = multiplier * constrainf(rateToLimit, -rateLimit, rateLimit);
+        ezLandingFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
     }
-    DEBUG_SET(DEBUG_EZLANDING, 0, ezLandFactor * 100);
-    DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
-    return rateToLimit;
+    DEBUG_SET(DEBUG_EZLANDING, 0, ezLandingFactor * 100);
+    return ezLandingFactor;
 }
 
-
+static float applyEzLanding(float rateToLimit, float multiplier)
+{
+    const float rateLimit = fabsf(ezLandingFactor * rateToLimit);
+    rateToLimit = multiplier * constrainf(rateToLimit, -rateLimit, rateLimit);
+    return rateToLimit;
+}
 
 
 #ifdef USE_LAUNCH_CONTROL
@@ -1016,6 +1022,14 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     rpmFilterUpdate();
 #endif
 
+    // do the non-axis dependent calculations once
+    if (pidRuntime.useEzLanding) {
+        calcEzLandingFactor();
+        if (pidRuntime.useEzDisarm) {
+            disarmOnImpact();
+        }
+    }
+
     // ----------PID controller----------
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
 
@@ -1105,9 +1119,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             DEBUG_SET(DEBUG_EZLANDING, 2, errorRate); // before attenuation
         }
         if (pidRuntime.useEzLanding) {
-            if (pidRuntime.useEzDisarm) {
-                disarmOnImpact(axis);
-            }
             errorRate = applyEzLanding(errorRate, 1.0f);
         }
         if (axis == FD_ROLL) {
@@ -1147,9 +1158,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         // *** EzLanding error limiter on error for the input to the ITerm accumulator ***
         //  - unfortunately iTermErrorRate is different from errorRate used by P, otherwise this is wasteful
         if (pidRuntime.useEzLanding) {
-            if (pidRuntime.useEzDisarm) {
-                disarmOnImpact(axis);
-            }
             itermErrorRate = applyEzLanding(itermErrorRate, 0.2f);
         }
 
@@ -1221,9 +1229,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
             // *** EzLanding limiter on DTerm ***
             if (pidRuntime.useEzLanding) {
-                if (pidRuntime.useEzDisarm) {
-                    disarmOnImpact(axis);
-                }
                 preTpaD = applyEzLanding(preTpaD, 1.0f);
             }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -229,7 +229,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
         .ez_landing_limit = 15,
-        .ez_landing_disarm_threshold = 100,
+        .ez_landing_disarm_threshold = 0,
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,
@@ -776,15 +776,32 @@ float pidGetAirmodeThrottleOffset(void)
 
 
 
+// ezLanding stuff
+static float ezLandingFactor = 1.0f;
+static float maxDeflectionAbs = 1.0f;
 
-// runs when new Rx data is received in rc.c, updatesmaxDeflectionAbs, so we don't do this every PID loop
-static float maxDeflectionAbs = 0.0f;
-float sendMaxDeflectionAbs(float maxRcDeflectionAbs)
+// EzLanding factors are updated only when new Rx data is received in rc.c
+// this will cause steps in PID as the limiting value changes
+
+float calcEzLandingFactor(float maxRcDeflectionAbs)
 {
     maxDeflectionAbs = fmaxf(maxRcDeflectionAbs, mixerGetRcThrottle());
-    return maxDeflectionAbs;
+    ezLandingFactor = 1.0f;
+    if (pidRuntime.useEzLanding && !isFlipOverAfterCrashActive() && maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
+        ezLandingFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
+    }
+    DEBUG_SET(DEBUG_EZLANDING, 0, ezLandingFactor * 100);
     DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
+    return ezLandingFactor;
+}
 
+static float applyEzLanding(float rateToLimit, float multiplier)
+{
+    if (ezLandingFactor < 1.0f) {
+        const float rateLimit = fabsf(ezLandingFactor * rateToLimit);
+        rateToLimit = multiplier * constrainf(rateToLimit, -rateLimit, rateLimit);
+    }
+    return rateToLimit;
 }
 
 static void disarmOnImpact(void)
@@ -801,24 +818,6 @@ static void disarmOnImpact(void)
             }
     }
     DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(accMagnitude * 10));
-}
-
-static float ezLandingFactor = 1.0f;
-static float calcEzLandingFactor(void)
-{
-    ezLandingFactor = 1.0f;
-    if (!isFlipOverAfterCrashActive() && maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
-        ezLandingFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
-    }
-    DEBUG_SET(DEBUG_EZLANDING, 0, ezLandingFactor * 100);
-    return ezLandingFactor;
-}
-
-static float applyEzLanding(float rateToLimit, float multiplier)
-{
-    const float rateLimit = fabsf(ezLandingFactor * rateToLimit);
-    rateToLimit = multiplier * constrainf(rateToLimit, -rateLimit, rateLimit);
-    return rateToLimit;
 }
 
 
@@ -1023,11 +1022,8 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 #endif
 
     // do the non-axis dependent calculations once
-    if (pidRuntime.useEzLanding) {
-        calcEzLandingFactor();
-        if (pidRuntime.useEzDisarm) {
-            disarmOnImpact();
-        }
+    if (pidRuntime.useEzLanding && pidRuntime.useEzDisarm) {
+        disarmOnImpact();
     }
 
     // ----------PID controller----------

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -792,7 +792,8 @@ static float applyEzLanding(float rateToLimit)
         // will not disarm on gentle landings
         // value should be highe enough to avoid unwanted disarms in the air on throttle chops
         if (pidRuntime.useEzDisarm && isAirmodeActivated() && ezLandFactor < 0.2f) {
-            float accMagnitude = (float) sqrtf(sq(acc.accADC[Z] - acc.dev.acc_1G) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec;
+//            float accMagnitude = (float) sqrtf(sq(acc.accADC[Z] - acc.dev.acc_1G) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec;
+            float accMagnitude = (acc.accADC[Z] + acc.accADC[X] + acc.accADC[Y] - acc.dev.acc_1G) * acc.dev.acc_1G_rec;
             if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
                 setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
                 disarm(DISARM_REASON_LANDING);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -776,7 +776,6 @@ float pidGetAirmodeThrottleOffset(void)
 #endif
 
 
-
 // ezLanding stuff
 static bool applyEzLandingLimiting = false;
 static float ezLandingLimit = PIDSUM_LIMIT;
@@ -784,7 +783,7 @@ static float maxDeflectionAbs = 1.0f;
 
 // EzLanding factors are updated only when new Rx data is received in rc.c
 // this will cause steps in PID as the limiting value changes
-void calcEzLandingLimit(float maxRcDeflectionAbs)
+FAST_CODE_NOINLINE void calcEzLandingLimit(float maxRcDeflectionAbs)
 {
     if (pidRuntime.useEzLanding && !isFlipOverAfterCrashActive()) {
         maxDeflectionAbs = fmaxf(maxRcDeflectionAbs, mixerGetRcThrottle());
@@ -800,8 +799,7 @@ void calcEzLandingLimit(float maxRcDeflectionAbs)
     DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
 }
 
-
-static void disarmOnImpact(void)
+static FAST_CODE_NOINLINE void disarmOnImpact(void)
 {
     // if both sticks are within 5% of center, check acc magnitude for impacts
     // at half the impact threshold, force iTerm to zero, to attenuate iTerm-mediated bouncing
@@ -820,7 +818,6 @@ static void disarmOnImpact(void)
         }
     }
 }
-
 
 #ifdef USE_LAUNCH_CONTROL
 #define LAUNCH_CONTROL_MAX_RATE 100.0f

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -640,7 +640,7 @@ static void rotateVector(float v[XYZ_AXIS_COUNT], const float rotation[XYZ_AXIS_
     }
 }
 
-STATIC_UNIT_TESTED void rotateItermAndAxisError(void)
+STATIC_UNIT_TESTED FAST_CODE_NOINLINE void rotateItermAndAxisError(void)
 {
     if (pidRuntime.itermRotation
 #if defined(USE_ABSOLUTE_CONTROL)
@@ -672,7 +672,7 @@ STATIC_UNIT_TESTED void rotateItermAndAxisError(void)
 
 #if defined(USE_ITERM_RELAX)
 #if defined(USE_ABSOLUTE_CONTROL)
-STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
+STATIC_UNIT_TESTED FAST_CODE_NOINLINE void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
 {
     if (pidRuntime.acGain > 0 || debugMode == DEBUG_AC_ERROR) {
         const float setpointLpf = pt1FilterApply(&pidRuntime.acLpf[axis], *currentPidSetpoint);
@@ -865,7 +865,7 @@ static FAST_CODE_NOINLINE float applyLaunchControl(int axis, const rollAndPitchT
 }
 #endif
 
-static float getSterm(int axis, const pidProfile_t *pidProfile)
+static FAST_CODE_NOINLINE float getSterm(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     const float sTerm = getSetpointRate(axis) / getMaxRcRate(axis) * 1000.0f *
@@ -881,7 +881,7 @@ static float getSterm(int axis, const pidProfile_t *pidProfile)
 #endif
 }
 
-NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
+static FAST_CODE_NOINLINE void calculateSpaValues(const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
@@ -895,7 +895,7 @@ NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
 #endif // #ifdef USE_WING ... #else
 }
 
-NOINLINE static void applySpa(int axis, const pidProfile_t *pidProfile)
+static FAST_CODE_NOINLINE void applySpa(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     switch(pidProfile->spa_mode[axis]){

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -511,7 +511,7 @@ static FAST_CODE_NOINLINE void detectAndSetCrashRecovery(
     const timeUs_t currentTimeUs, const float delta, const float errorRate)
 {
     // if crash recovery is on and accelerometer enabled and there is no gyro overflow, then check for a crash
-    // no point in trying to recover if the crash is so severe that the gyro overflows
+    // no point in trying to recover if the crash is so severe that the gyro in case we hit a tree
     if ((crash_recovery || FLIGHT_MODE(GPS_RESCUE_MODE)) && !gyroOverflowDetected()) {
         if (ARMING_FLAG(ARMED)) {
             if (getMotorMixRange() >= 1.0f && !pidRuntime.inCrashRecoveryMode
@@ -812,10 +812,10 @@ static void disarmOnImpact(void)
     float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
     // *** annoying to need to normalise accADC here, should normalise acc.accADC once, in accelerometer.c, not everywhere we use it
     if (isAirmodeActivated() && maxDeflectionAbs < pidRuntime.ezLandingThreshold * 0.5f) {
-        if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
+        if (accMagnitude > pidRuntime.ezLandingDisarmThreshold || getMotorMixRange() >= 1.0f) {
             setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
             disarm(DISARM_REASON_LANDING);
-            }
+        }
     }
     DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(accMagnitude * 10));
 }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -229,7 +229,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
         .ez_landing_limit = 15,
-        .ez_landing_disarm_threshold = 80,
+        .ez_landing_disarm_threshold = 100,
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,
@@ -789,17 +789,14 @@ static float applyEzLanding(float rateToLimit, float multiplier)
         // if both sticks are inside 20% of the stick threshold, enable auto-disarm on impact
         // will not disarm on gentle landings
         // value should be highe enough to avoid unwanted disarms in the air on throttle chops
-        bool maybeDisarm = false;
-        float accMagnitude = acc.dev.acc_1G_rec * (sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) - acc.dev.acc_1G);
+        float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
         if (pidRuntime.useEzDisarm && isAirmodeActivated() && maxDeflectionAbs < pidRuntime.ezLandingThreshold * 0.5f) {
-            maybeDisarm = true;
             if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
                 setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
                 disarm(DISARM_REASON_LANDING);
             }
         }
         DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(accMagnitude * 10));
-        DEBUG_SET(DEBUG_EZLANDING, 5, maybeDisarm);
 
         ezLandFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
         const float rateLimit = fabsf(ezLandFactor * rateToLimit);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -791,7 +791,7 @@ static float applyEzLanding(float rateToLimit)
         // if both sticks are inside 20% of the stick threshold, enable auto-disarm on impact
         // will not disarm on gentle landings
         // value should be highe enough to avoid unwanted disarms in the air on throttle chops
-        if (pidRuntime.useEzDisarm && isAirmodeActivated() && ezLandFactor < 0.2) {
+        if (pidRuntime.useEzDisarm && isAirmodeActivated() && ezLandFactor < 0.2f) {
             float accMagnitude = (float) sqrtf(sq(acc.accADC[Z] - acc.dev.acc_1G) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec;
             if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
                 setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -786,7 +786,7 @@ static float applyEzLanding(float rateToLimit)
 {
     float ezLandFactor = 1.0f;
 //    const float maxDeflectionAbs = fmaxf(getMaxRcDeflectionAbs(), mixerGetRcThrottle());
-    if (maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
+    if (!isFlipOverAfterCrashActive() && maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
         ezLandFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
         // if both sticks are inside 20% of the stick threshold, enable auto-disarm on impact
         // will not disarm on gentle landings

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -791,7 +791,7 @@ static float applyEzLanding(float rateToLimit)
         // if both sticks are inside 20% of the stick threshold, enable auto-disarm on impact
         // will not disarm on gentle landings
         // value should be highe enough to avoid unwanted disarms in the air on throttle chops
-        if (pidRuntime.useEzDisarm && ezLandFactor < 0.2) {
+        if (pidRuntime.useEzDisarm && isAirmodeActivated() && ezLandFactor < 0.2) {
             float accMagnitude = (float) sqrtf(sq(acc.accADC[Z] - acc.dev.acc_1G) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec;
             if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
                 setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -228,7 +228,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_breakpoint = 1050,
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
-        .ez_landing_limit = 10,
+        .ez_landing_limit = 25,
+        .ez_landing_disarm_threshold = 50,
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,
@@ -787,6 +788,16 @@ static float applyEzLanding(float rateToLimit)
 //    const float maxDeflectionAbs = fmaxf(getMaxRcDeflectionAbs(), mixerGetRcThrottle());
     if (maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
         ezLandFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
+        // if both sticks are inside 20% of the stick threshold, enable auto-disarm on impact
+        // will not disarm on gentle landings
+        // value should be highe enough to avoid unwanted disarms in the air on throttle chops
+        if (pidRuntime.useEzDisarm && ezLandFactor < 0.2) {
+            float accMagnitude = (float) sqrtf(sq(acc.accADC[Z] - acc.dev.acc_1G) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec;
+            if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
+                setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+                disarm(DISARM_REASON_LANDING);
+            }
+        }
         const float rateLimit = fabsf(ezLandFactor * rateToLimit);
         rateToLimit = constrainf(rateToLimit, -rateLimit, rateLimit);
     }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -228,8 +228,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_breakpoint = 1050,
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
-        .ez_landing_limit = 15,
-        .ez_landing_speed = 50,
+        .ez_landing_limit = 10,
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,
@@ -774,6 +773,31 @@ float pidGetAirmodeThrottleOffset(void)
 }
 #endif
 
+// when new Rx data is received, update the maxDeflectionAbs value, so we don't do this every PID loop
+static float maxDeflectionAbs = 0.0f;
+float sendMaxDeflectionAbs(float maxRcDeflectionAbs)
+{
+    maxDeflectionAbs = fmaxf(maxRcDeflectionAbs, mixerGetRcThrottle());
+    return maxDeflectionAbs;
+}
+
+static float applyEzLanding(float rateToLimit)
+{
+    float ezLandFactor = 1.0f;
+//    const float maxDeflectionAbs = fmaxf(getMaxRcDeflectionAbs(), mixerGetRcThrottle());
+    if (maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
+        ezLandFactor = fmaxf(pidRuntime.ezLandingLimit, maxDeflectionAbs / pidRuntime.ezLandingThreshold);
+        const float rateLimit = fabsf(ezLandFactor * rateToLimit);
+        rateToLimit = constrainf(rateToLimit, -rateLimit, rateLimit);
+    }
+    DEBUG_SET(DEBUG_EZLANDING, 0, ezLandFactor * 100);
+    DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
+    return rateToLimit;
+}
+
+
+
+
 #ifdef USE_LAUNCH_CONTROL
 #define LAUNCH_CONTROL_MAX_RATE 100.0f
 #define LAUNCH_CONTROL_MIN_RATE 5.0f
@@ -1043,6 +1067,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
         const float previousIterm = pidData[axis].I;
         float itermErrorRate = errorRate;
+
 #ifdef USE_ABSOLUTE_CONTROL
         const float uncorrectedSetpoint = currentPidSetpoint;
 #endif
@@ -1056,6 +1081,17 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 #ifdef USE_ABSOLUTE_CONTROL
         const float setpointCorrection = currentPidSetpoint - uncorrectedSetpoint;
 #endif
+
+        // *** EzLanding error limiter on error for P ***
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_EZLANDING, 2, errorRate); // before attenuation
+        }
+        if (pidRuntime.useEzLanding) {
+            errorRate = applyEzLanding(errorRate);
+        }
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_EZLANDING, 3, errorRate); // after attenuation
+        }
 
         // --------low-level gyro-based PID based on 2DOF PID controller. ----------
 
@@ -1080,13 +1116,20 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             }
         }
 
-        float iTermChange = (Ki + pidRuntime.itermAccelerator) * dynCi * pidRuntime.dT * itermErrorRate;
 #ifdef USE_WING
         if (pidProfile->spa_mode[axis] != SPA_MODE_OFF) {
             // slowing down I-term change, or even making it zero if setpoint is high enough
             iTermChange *= pidRuntime.spa[axis];
         }
 #endif // #ifdef USE_WING
+
+        // *** EzLanding error limiter on error for the input to the ITerm accumulator ***
+        //  - unfortunately iTermErrorRate is different from errorRate used by P, otherwise this is wasteful
+        if (pidRuntime.useEzLanding) {
+            itermErrorRate = applyEzLanding(itermErrorRate);
+        }
+
+        const float iTermChange = (Ki + pidRuntime.itermAccelerator) * dynCi * pidRuntime.dT * itermErrorRate;
         pidData[axis].I = constrainf(previousIterm + iTermChange, -pidRuntime.itermLimit, pidRuntime.itermLimit);
 
         // -----calculate D component
@@ -1151,6 +1194,12 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             // Apply the dMinFactor
             preTpaD *= dMinFactor;
 #endif
+
+            // *** EzLanding limiter on DTerm ***
+            if (pidRuntime.useEzLanding) {
+                preTpaD = applyEzLanding(preTpaD);
+            }
+
             pidData[axis].D = preTpaD * pidRuntime.tpaFactor;
 
             // Log the value of D pre application of TPA

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -486,6 +486,7 @@ bool pidOsdAntiGravityActive(void);
 void pidSetAntiGravityState(bool newState);
 bool pidAntiGravityEnabled(void);
 
+
 #ifdef USE_THRUST_LINEARIZATION
 float pidApplyThrustLinearization(float motorValue);
 float pidCompensateThrustLinearization(float throttle);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -358,6 +358,9 @@ typedef struct pidRuntime_s {
     float tpaLowBreakpoint;
     float tpaLowMultiplier;
     bool tpaLowAlways;
+    bool useEzLanding;
+    float ezLandingThreshold;
+    float ezLandingLimit;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -260,7 +260,8 @@ typedef struct pidProfile_s {
 
     uint8_t ez_landing_threshold;           // Threshold stick position below which motor output is limited
     uint8_t ez_landing_limit;               // Maximum motor output when all sticks centred and throttle zero
-    uint8_t ez_landing_speed;               // Speed below which motor output is limited
+    uint8_t ez_landing_disarm_threshold;    // Accelerometer vector threshold which disarms if exceeded
+
     uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter (time constant)
     uint16_t spa_center[XYZ_AXIS_COUNT];    // RPY setpoint at which PIDs are reduced to 50% (setpoint PID attenuation)
     uint16_t spa_width[XYZ_AXIS_COUNT];     // Width of smooth transition around spa_center
@@ -361,6 +362,8 @@ typedef struct pidRuntime_s {
     bool useEzLanding;
     float ezLandingThreshold;
     float ezLandingLimit;
+    bool useEzDisarm;
+    float ezLandingDisarmThreshold;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -445,8 +445,9 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.useEzLanding = pidProfile->ez_landing_threshold && pidProfile->ez_landing_limit;
     pidRuntime.useEzDisarm = pidRuntime.useEzLanding && pidProfile->ez_landing_disarm_threshold > 0;
     pidRuntime.ezLandingThreshold = pidProfile->ez_landing_threshold / 100.0f;
-    pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit / 100.0f;
+    pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit;
     pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;
+
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -443,7 +443,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 
     pidRuntime.useEzLanding = pidProfile->ez_landing_threshold && pidProfile->ez_landing_limit;
-    pidRuntime.useEzDisarm = pidProfile->ez_landing_disarm_threshold > 0;
+    pidRuntime.useEzDisarm = pidRuntime.useEzLanding && pidProfile->ez_landing_disarm_threshold > 0;
     pidRuntime.ezLandingThreshold = pidProfile->ez_landing_threshold / 100.0f;
     pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit / 100.0f;
     pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -443,8 +443,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 
     pidRuntime.useEzLanding = pidProfile->ez_landing_threshold && pidProfile->ez_landing_limit;
+    pidRuntime.useEzDisarm = pidProfile->ez_landing_disarm_threshold > 0;
     pidRuntime.ezLandingThreshold = pidProfile->ez_landing_threshold / 100.0f;
     pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit / 100.0f;
+    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -441,6 +441,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowBreakpoint = MIN(pidRuntime.tpaLowBreakpoint, pidRuntime.tpaBreakpoint);
     pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
+
+    pidRuntime.useEzLanding = pidProfile->ez_landing_threshold && pidProfile->ez_landing_limit;
+    pidRuntime.ezLandingThreshold = pidProfile->ez_landing_threshold / 100.0f;
+    pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit / 100.0f;
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -268,7 +268,7 @@ TEST(pidControllerTest, testPidLoop)
     
         // Disable ezLanding
     simulatedmaxRcDeflectionAbs = 1.0f;
-    calcEzLandingFactor (simulatedmaxRcDeflectionAbs);
+    calcEzLandingLimit (simulatedmaxRcDeflectionAbs);
 
     pidController(pidProfile, currentTestTime());
 
@@ -380,7 +380,7 @@ TEST(pidControllerTest, testEzLanding)
 
     // Enable ezLanding
     simulatedmaxRcDeflectionAbs = 0.01f;   
-    calcEzLandingFactor (simulatedmaxRcDeflectionAbs);
+    calcEzLandingLimit (simulatedmaxRcDeflectionAbs);
     
     pidController(pidProfile, currentTestTime());
 
@@ -439,7 +439,7 @@ TEST(pidControllerTest, testEzLanding)
 
    // Disable ezLanding
     simulatedmaxRcDeflectionAbs = 1.0f;
-    calcEzLandingFactor (simulatedmaxRcDeflectionAbs);
+    calcEzLandingLimit (simulatedmaxRcDeflectionAbs);
 }
 
 TEST(pidControllerTest, testPidLevel)

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -292,7 +292,7 @@ TEST(pidControllerTest, testPidLoop)
     EXPECT_NEAR(-12.81, pidData[FD_ROLL].P, calculateTolerance(-12.81));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.78, pidData[FD_ROLL].I, calculateTolerance(-0.78));
+    EXPECT_NEAR(-0.16, pidData[FD_ROLL].I, calculateTolerance(-0.16)); // iTerm accumulates at 20% of the others
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-19.8, pidData[FD_ROLL].D, calculateTolerance(-19.8));

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -402,7 +402,7 @@ TEST(pidControllerTest, testEzLanding)
     EXPECT_NEAR(-25.6, pidData[FD_ROLL].P, calculateTolerance(-25.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.312, pidData[FD_ROLL].I, calculateTolerance(-0.312));
+    EXPECT_NEAR(-1.6, pidData[FD_ROLL].I, calculateTolerance(-1.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-20, pidData[FD_ROLL].D, calculateTolerance(-20));
@@ -416,7 +416,7 @@ TEST(pidControllerTest, testEzLanding)
     EXPECT_NEAR(-25.6, pidData[FD_ROLL].P, calculateTolerance(-25.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.625, pidData[FD_ROLL].I, calculateTolerance(-0.625));
+    EXPECT_NEAR(-3.1, pidData[FD_ROLL].I, calculateTolerance(-3.1));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-20, pidData[FD_ROLL].D, calculateTolerance(-20));
@@ -430,7 +430,7 @@ TEST(pidControllerTest, testEzLanding)
     EXPECT_NEAR(-25.6, pidData[FD_ROLL].P, calculateTolerance(-25.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.94, pidData[FD_ROLL].I, calculateTolerance(-0.94));
+    EXPECT_NEAR(-4.7, pidData[FD_ROLL].I, calculateTolerance(-4.7));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-20, pidData[FD_ROLL].D, calculateTolerance(-20));

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -73,6 +73,7 @@ extern "C" {
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
 
+    acc_t acc;
     gyro_t gyro;
     attitudeEulerAngles_t attitude;
 
@@ -89,6 +90,7 @@ extern "C" {
     float getRcDeflectionAbs(int axis) { return fabsf(simulatedRcDeflection[axis]); }
     void systemBeep(bool) { }
     bool gyroOverflowDetected(void) { return false; }
+    bool isFlipOverAfterCrashActive(void) {return false; }
     float getRcDeflection(int axis) { return simulatedRcDeflection[axis]; }
     float getRcDeflectionRaw(int axis) { return simulatedRcDeflection[axis]; }
     float getRawSetpoint(int axis) { return simulatedRawSetpoint[axis]; }
@@ -161,6 +163,9 @@ void setDefaultTestSettings(void)
     pidProfile->launchControlMode = LAUNCH_CONTROL_MODE_NORMAL,
     pidProfile->launchControlGain = 40,
     pidProfile->level_race_mode = false,
+    pidProfile->ez_landing_threshold = 25,
+    pidProfile->ez_landing_limit = 10,
+
 
     gyro.targetLooptime = 8000;
 }


### PR DESCRIPTION
This PR is for evaluation of an alternative approach to 'ExLanding'.

** WARNING:  The auto-disarm function is enabled in the PR by default, and only works if AirMode is active.  Disable it with `set ez_landing_disarm_threshold = 0` if you aren't game to test that feature.  **

TESTING:

a) Testing the ezLanding stuff

First, do some gentle LOS landings over grass.  Watch the landing behaviour.  Gentle landings will not disarm. The quad may bounce but should retain its attitude.  Harder landings, or landings while drifting, will probably bounce, and may topple over.  If auto-disarm is enabled, it should disarm on bad landings.  If auto-disarm is not enabled, and if the quad topped over and gets stuck inverted, or just gets stuck in grass, etc, the motors will spool up like usual, and you'll have to manually disarm.  EzDisarm is actually pretty cool; I'd suggest testing with it on, to get a feel for what it does, and when it will vs won't auto-disarm for you.

Note that the disarm threshold is adjustable.  It is defaulted to 2.5 times higher than the normal GPS Rescue disarm threshold, and uses the same maths.  Note that ezDisarm is NOT intended to auto-disarm every time!  In a gentle landing, it won't trigger, and the quad should sit nicely on the ground in a stable manner.  EzDisarm is intended to disarm only if the landing goes bad.  If you think it is too sensitive, increase the threshold until it only kicks in with bad enough landings where you really want it to disarm the quad immediately for you.

b) Testing the ezDisarm stuff

Assuming you've enabled ez_disarm, and use AirMode, test for unwanted disarms in-flight.  Do this over soft grass at low altitude.  Do some flips and rolls LOS at low altitude and check it doesn't self-disarm unexpectedly.  Do a throttle pump and chop to zero, let it drop, lift throttle before it hits the ground.  All these should feel normal and there should be no disarming.

If it does disarm mid-air from a hard throttle chop, leave throttle at zero, quickly toggle to Disarm and back to Arm, then throttle up and you'll be OK.  I apologise in advance if something bad happens.  Note that the disarm code needs AirMode to be active, and AirMode requires 25% throttle after arming, so you shouldn't immediately disarm again on re-arming, even if the quad is falling in a bad way.  I think.  This remains to be tested. 

I think the most likely, and unpleasant, time for an unwanted disarm would be a hard throttle chop suddenly to zero at high speed.  We have AntiGravity to keep the quad stable in these situations, but most quads will wobble quite a bit when we do this.  This code weakens AntiGravity significantly, or at least I think it probably does, so you could get a significant wobble on chopping throttle hard to zero, and that could cause an unwanted disarm at speed, which might not be very pretty.  Again, don't panic, leave throttle at zero and disarm/re-arm quickly.

It may be possible to code it so that most of AntiGravity corrections still happen, but I haven't explicitly examined that, and in any case, AntiGravity isn't perfect, or may not be enabled, so please take care when testing high speed throttle chops.

I didn't have anything bad happen to me but I'm definitely concerned that it might happen to you.

** How does it work **

Our current approach to ezLanding involves constraining throttle and/or motor output when sticks are centred and throttle is low.  This work quite well, but has drawbacks.

This approach involves PID limitation, while retaining full motor authority.  

The code can be disabled by setting the `ez_landing_threshold` is set to zero in the CLI.

The optional simple auto-disarm for rougher landings can be disabled by setting it's threshold to zero. It uses the same detection technique as GPS Rescue, but with a default threshold set 2.5 times higher than for GPS Rescue.

When enabled:
- P is constraining error within `ez_landing_limit` deg/s
- I has its rate of change is reduced by limiting the incoming error `ez_landing_limit` deg/s; accumulated iTerm does not change.
- D cannot exceed `ez_landing_limit`, in practice resulting in a constraint on the amount of D that is similar to the constraint on P via incoming error.

Nothing else is changed.  PIDsum and Motor output is not limited. 

Even under full exLanding conditions, P and D will be normal for small movements and small errors, and will not react strongly to large errors or movements, eg impacts.  As soon as the sticks rise above zero or await from centre, you quickly get full authority back. As little as 10% away from centre, or 10% throttle, provides almost totally normal 'feel' and strong opposition to un-commanded movements.  Accumulated ITerm will stay approximately the same, and will only change relatively slowly.  A large spike from an impact will not immediately change the accumulated iTerm, or result in a strong reaction from P or D.

Because accumulated iTerm is retained, and because errors in flat drops are often quite small, a flat drop, or inverted hang, or a dive at zero throttle stay relatively stable.  

On the ground, the quad feels entirely 'normal'.

D-resonant flyaways on arming won't happen until the pilot lifts throttle; on cutting throttle, they should stop (didn't test this, but I think so).

If the pilot needs more stability in drops or dive type situations, increasing the `ez_landing_limit` value will help a great deal, however the amount of bounce or reaction to impacts on landing will be greater.  If EzDisarm is enabled, however, bad landings should be a lot less damaging, and less hazardous for bystanders.

Most race quads with batteries underneath are very unstable and difficult to land on grass without them leaning over and getting their props stuck, or without bouncing off the grass and flipping the quad over.  Even with effectively zero P and D, they still bounce and fall over; high-performance quads are very 'light' and 'bouncy' due to high power to weight ratio and relatively high minimum rpm.  So it's very hard to get a perfect landing, especially while drifting sideways.  The EzDisarm function will be quite helpful for racers I think, and while racing throttle is never zero so you won't notice any drawback at all.

Flat bottom freestyle quads tend to land better, so a higher `ez_landing_limit` may still result in better landings, even with a higher than default EzDisarm threshold.

Generally, iTerm turns out to be the main cause of landing problems.  However I kind of like how this code retains the iTerm, since in a clean landing the quad just kind of sits still and perches, balancing on an underslung battery quite easily.

Anyway have a fly and see what you think.  

I found that with the defaults, only antiGravity situations like hard throttle chops tended to wobble badly.  But my quad wobbled quite a bit anyway in those situations.  Definitely first do some hard throttle chops with normal code, or with ezLanding disabled, before testing it, otherwise you'll blame it for what the quad does anyway.

Please test with a beater quad, and let me know how you go.  Haven't tested on whoops but should be fine on whoops.