### PR TITLE
RX - minor optimizations/minor cleanup

### DIFF
--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -24,7 +24,7 @@
 
 #include "pg/pg.h"
 
-#define GET_FRAME_ERR_LPF_FREQUENCY(period) (1 / (period / 10.0f))
+#define GET_FRAME_ERR_LPF_FREQUENCY(period) (1.0f / ((period) * 0.1f/*[s]*/))
 #define FRAME_ERR_RESAMPLE_US 100000
 
 typedef struct rxConfig_s {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -297,9 +297,10 @@ void rxInit(void)
     rxRuntimeState.lastRcFrameTimeUs = 0;
     rcSampleIndex = 0;
 
+    uint32_t now = millis();
     for (int i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++) {
         rcData[i] = rxConfig()->midrc;
-        validRxSignalTimeout[i] = millis() + MAX_INVALID_PULSE_TIME_MS;
+        validRxSignalTimeout[i] = now + MAX_INVALID_PULSE_TIME_MS;
     }
 
     rcData[THROTTLE] = (featureIsEnabled(FEATURE_3D)) ? rxConfig()->midrc : rxConfig()->rx_min_usec;
@@ -310,7 +311,7 @@ void rxInit(void)
         const modeActivationCondition_t *modeActivationCondition = modeActivationConditions(i);
         if (modeActivationCondition->modeId == BOXARM && IS_RANGE_USABLE(&modeActivationCondition->range)) {
             // ARM switch is defined, determine an OFF value
-            uint16_t value;
+            float value;
             if (modeActivationCondition->range.startStep > 0) {
                 value = MODE_STEP_TO_CHANNEL_VALUE((modeActivationCondition->range.startStep - 1));
             } else {
@@ -377,7 +378,7 @@ void rxInit(void)
     }
 
     // Setup source frame RSSI filtering to take averaged values every FRAME_ERR_RESAMPLE_US
-    pt1FilterInit(&frameErrFilter, pt1FilterGain(GET_FRAME_ERR_LPF_FREQUENCY(rxConfig()->rssi_src_frame_lpf_period), FRAME_ERR_RESAMPLE_US/1000000.0));
+    pt1FilterInit(&frameErrFilter, pt1FilterGain(GET_FRAME_ERR_LPF_FREQUENCY(rxConfig()->rssi_src_frame_lpf_period), FRAME_ERR_RESAMPLE_US * 1e-6f));
 
     // Configurable amount of filtering to remove excessive jumpiness of the values on the osd
     float k = (256.0f - rxConfig()->rssi_smoothing) / 256.0f;


### PR DESCRIPTION
- reuse millis() in rxInit
- rcData[] is float
- cleanup some float math
- fix GET_FRAME_ERR_LPF_FREQUENCY macro argument
