### PR TITLE
Blackbox - use llog2 instead of LOG2

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -2065,7 +2065,7 @@ uint16_t blackboxGetPRatio(void)
 
 uint8_t blackboxCalculateSampleRate(uint16_t pRatio)
 {
-    return LOG2(32000 / (targetPidLooptime * pRatio));
+    return llog2(32000 / (targetPidLooptime * pRatio));
 }
 
 /**


### PR DESCRIPTION
LOG2 is for compile-time evaluated expressions only.

Difference is about 20 instructions (actually, I was surprised it is so fast)

https://godbolt.org/z/1GvcWvYad