### PR TITLE
Update blackbox.c

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1846,7 +1846,7 @@ void blackboxUpdate(timeUs_t currentTimeUs)
 
     switch (blackboxState) {
     case BLACKBOX_STATE_STOPPED:
-        if (ARMING_FLAG(ARMED)) {
+        if (true) {
             blackboxOpen();
             blackboxStart();
         }


### PR DESCRIPTION
Making blackbox always on and recording even when disarmed, for special use cases where a flight controller is being utilized for its sensor data in a non-drone related purpose.