### PR TITLE
Fix config write

### DIFF
--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -32,3 +32,6 @@ void writeConfigToEEPROM(void);
 
 uint16_t getEEPROMConfigSize(void);
 size_t getEEPROMStorageSize(void);
+
+bool saveEEPROMToSDCard(void);
+void saveEEPROMToMemoryMappedFlash(void);

--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -375,6 +375,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
     uint64_t *dest_addr = (uint64_t *)c->address;
     uint64_t *src_addr = (uint64_t*)buffer;
     uint8_t row_index = 4;
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE % sizeof(uint64_t) == 0, "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     /* copy the 256 bits flash word */
     do
     {
@@ -389,6 +390,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
             return -1;
         }
     }
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE == sizeof(uint32_t), "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     const FLASH_Status status = FLASH_ProgramWord(c->address, *buffer);
     if (status != FLASH_COMPLETE) {
         return -2;
@@ -415,6 +417,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
 
     // For H7
     // HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t DataAddress);
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE == sizeof(uint32_t) * FLASH_NB_32BITWORD_IN_FLASHWORD,  "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     const HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, c->address, (uint64_t)(uint32_t)buffer);
     if (status != HAL_OK) {
         return -2;
@@ -434,6 +437,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
         }
     }
 
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE == sizeof(uint32_t) * 1,  "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     // For F7
     // HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
     const HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, c->address, (uint64_t)*buffer);
@@ -455,6 +459,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
         }
     }
 
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE == sizeof(uint32_t) * 2,  "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     const HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, c->address, (uint64_t)*buffer);
     if (status != HAL_OK) {
         return -2;
@@ -467,6 +472,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
         }
     }
 
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE == sizeof(uint32_t) * 1,  "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     const flash_status_type status = flash_word_program(c->address, (uint32_t)*buffer);
     if (status != FLASH_OPERATE_DONE) {
         return -2;
@@ -478,6 +484,8 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
             return -1;
         }
     }
+
+    STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE == sizeof(uint32_t) * 1,  "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     const FLASH_Status status = FLASH_ProgramWord(c->address, *buffer);
     if (status != FLASH_COMPLETE) {
         return -2;

--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -374,7 +374,7 @@ static int write_word(config_streamer_t *c, config_streamer_buffer_align_type_t 
 
     uint64_t *dest_addr = (uint64_t *)c->address;
     uint64_t *src_addr = (uint64_t*)buffer;
-    uint8_t row_index = 4;
+    uint8_t row_index = CONFIG_STREAMER_BUFFER_SIZE / sizeof(uint64_t);
     STATIC_ASSERT(CONFIG_STREAMER_BUFFER_SIZE % sizeof(uint64_t) == 0, "CONFIG_STREAMER_BUFFER_SIZE does not match written size");
     /* copy the 256 bits flash word */
     do

--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -25,6 +25,7 @@
 #include "drivers/system.h"
 #include "drivers/flash.h"
 
+#include "config/config_eeprom.h"
 #include "config/config_streamer.h"
 
 #if !defined(CONFIG_IN_FLASH)
@@ -528,12 +529,10 @@ int config_streamer_finish(config_streamer_t *c)
 {
     if (c->unlocked) {
 #if defined(CONFIG_IN_SDCARD)
-        bool saveEEPROMToSDCard(void); // forward declaration to avoid circular dependency between config_streamer / config_eeprom
         saveEEPROMToSDCard();
 #elif defined(CONFIG_IN_EXTERNAL_FLASH)
         flashFlush();
 #elif defined(CONFIG_IN_MEMORY_MAPPED_FLASH)
-        void saveEEPROMToMemoryMappedFlash(void); // forward declaration to avoid circular dependency between config_streamer / config_eeprom
         saveEEPROMToMemoryMappedFlash();
 #elif defined(CONFIG_IN_RAM)
         // NOP

--- a/src/main/config/config_streamer.h
+++ b/src/main/config/config_streamer.h
@@ -29,6 +29,9 @@
 #if defined(CONFIG_IN_EXTERNAL_FLASH) || defined(CONFIG_IN_MEMORY_MAPPED_FLASH)
 #define CONFIG_STREAMER_BUFFER_SIZE 8 // Must not be greater than the smallest flash page size of all compiled-in flash devices.
 typedef uint32_t config_streamer_buffer_align_type_t;
+#elif defined(CONFIG_IN_RAM) || defined(CONFIG_IN_SDCARD)
+#define CONFIG_STREAMER_BUFFER_SIZE 32
+typedef uint64_t config_streamer_buffer_align_type_t;
 #elif defined(STM32H743xx) || defined(STM32H750xx) || defined(STM32H723xx) || defined(STM32H725xx)
 #define CONFIG_STREAMER_BUFFER_SIZE 32  // Flash word = 256-bits
 typedef uint64_t config_streamer_buffer_align_type_t;


### PR DESCRIPTION
Extra bytes are copied under some configurations.

gcc was generating warning for one case. The copy alone is pretty harmless, but it is a bug.
Edit: 

Actually, buffer overflow was possible. space for CONFIG_STREAMER_BUFFER_SIZE  was checked, but more was written:
- defined(CONFIG_IN_RAM) || defined(CONFIG_IN_SDCARD) CONFIG_STREAMER_BUFFER_SIZE   == 4, but 32 bytes was copied every write. Now 32 bytes chunk is used.
- CONFIG_IN_MEMORY_MAPPED_FLASH CONFIG_STREAMER_BUFFER_SIZE   == 8, 32 bytes was copied. Now 8 bytes chunk used.

Asserts added to prevent this in future.

Moved functions into header. 
@hydra : I don't understand '// forward declaration to avoid circular dependency between config_streamer / config_eeprom'


@hydra: Is there any reason for not using simple memcpy for memory-maped case? (gcc converts it into memcpy anyway). 