### PR TITLE
Fix for ITCM overflow for F722

### DIFF
--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -71,7 +71,7 @@ void sdftInit(sdft_t *sdft, const int startBin, const int endBin, const int numB
 FAST_CODE void sdftPush(sdft_t *sdft, const float sample)
 {
     const float delta = sample - rPowerN * sdft->samples[sdft->idx];
-    
+
     sdft->samples[sdft->idx] = sample;
     sdft->idx = (sdft->idx + 1) % SDFT_SAMPLE_SIZE;
 

--- a/src/main/drivers/rx/rx_sx1280.c
+++ b/src/main/drivers/rx/rx_sx1280.c
@@ -76,7 +76,7 @@ bool sx1280IsBusy(void)
     return IORead(busy);
 }
 
-FAST_CODE static bool sx1280PollBusy(void)
+FAST_CODE_PREF static bool sx1280PollBusy(void)
 {
     uint32_t startTime = micros();
     while (IORead(busy)) {
@@ -89,7 +89,7 @@ FAST_CODE static bool sx1280PollBusy(void)
     return true;
 }
 
-FAST_CODE static bool sx1280MarkBusy(void)
+FAST_CODE_PREF static bool sx1280MarkBusy(void)
 {
     // Check that there isn't already a sequence of accesses to the SX1280 in progress
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
@@ -109,7 +109,7 @@ static void sx1280ClearBusyFn(void)
 }
 
 // Switch to waiting for busy interrupt
-FAST_CODE static bool sx1280EnableBusy(void)
+FAST_CODE_PREF static bool sx1280EnableBusy(void)
 {
     if (!sx1280MarkBusy()) {
         return false;

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -86,5 +86,5 @@
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x8000) // 32K sectors
 
-// knowing the ITCM will overflow so need to drop items.
+// ITCM is in short supply so excluding fast code where preferred, not required.
 #define FAST_CODE_PREF

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -85,3 +85,6 @@
 #define USE_EXTI
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x8000) // 32K sectors
+
+// knowing the ITCM will overflow so need to drop items.
+#define FAST_CODE_PREF

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -77,3 +77,6 @@
 #define USE_EXTI
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors
+
+// knowing the ITCM will overflow so need to drop items.
+#define FAST_CODE_PREF

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -78,5 +78,5 @@
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x4000) // 16K sectors
 
-// knowing the ITCM will overflow so need to drop items.
+// ITCM is in short supply so excluding fast code where preferred, not required.
 #define FAST_CODE_PREF

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -51,13 +51,13 @@
 #else
 #define FAST_CODE                   __attribute__((section(".tcm_code")))
 #endif
-// Handle case where we'd prefer code to be in ITCM, but it won't fit on the F745
-#ifdef STM32F745xx
-#define FAST_CODE_PREF
-#else
-#define FAST_CODE_PREF                  __attribute__((section(".tcm_code")))
+// Handle case where we'd prefer code to be in ITCM, but it won't fit on the device
+#ifndef FAST_CODE_PREF
+#define FAST_CODE_PREF              FAST_CODE
 #endif
+
 #define FAST_CODE_NOINLINE          NOINLINE
+
 #else
 #define FAST_CODE
 #define FAST_CODE_PREF


### PR DESCRIPTION
Related to https://github.com/betaflight/betaflight/pull/13506

This allows for the use of FAST_CODE_PREF so it is easy to fall back for those targets with insufficient ITCM (F745 and F722)