### PR TITLE
Try to init MSP OVERRIDE frame with correct default values

### DIFF
--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -92,5 +92,10 @@ void rxMspInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
     rxRuntimeState->rcReadRawFn = rxMspReadRawRC;
     rxRuntimeState->rcFrameStatusFn = rxMspFrameStatus;
+
+    // Initialize ROLL, PITCH, and YAW channels to 1500
+    mspFrame[0] = 1500; // ROLL
+    mspFrame[1] = 1500; // PITCH
+    mspFrame[2] = 1500; // YAW    
 }
 #endif

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -37,6 +37,11 @@ static uint16_t mspFrame[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 static bool rxMspFrameDone = false;
 static bool rxMspOverrideFrameDone = false;
 
+// Initialize ROLL, PITCH, and YAW channels to 1500
+mspFrame[0] = 1500; // ROLL
+mspFrame[1] = 1500; // PITCH
+mspFrame[2] = 1500; // YAW    
+
 float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan)
 {
     UNUSED(rxRuntimeState);
@@ -92,10 +97,5 @@ void rxMspInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
     rxRuntimeState->rcReadRawFn = rxMspReadRawRC;
     rxRuntimeState->rcFrameStatusFn = rxMspFrameStatus;
-
-    // Initialize ROLL, PITCH, and YAW channels to 1500
-    mspFrame[0] = 1500; // ROLL
-    mspFrame[1] = 1500; // PITCH
-    mspFrame[2] = 1500; // YAW    
 }
 #endif

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -37,11 +37,6 @@ static uint16_t mspFrame[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 static bool rxMspFrameDone = false;
 static bool rxMspOverrideFrameDone = false;
 
-// Initialize ROLL, PITCH, and YAW channels to 1500
-mspFrame[0] = 1500; // ROLL
-mspFrame[1] = 1500; // PITCH
-mspFrame[2] = 1500; // YAW    
-
 float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan)
 {
     UNUSED(rxRuntimeState);
@@ -97,5 +92,10 @@ void rxMspInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
     rxRuntimeState->rcReadRawFn = rxMspReadRawRC;
     rxRuntimeState->rcFrameStatusFn = rxMspFrameStatus;
+
+    // Initialize ROLL, PITCH, and YAW channels to 1500
+    mspFrame[0] = 1500; // ROLL
+    mspFrame[1] = 1500; // PITCH
+    mspFrame[2] = 1500; // YAW    
 }
 #endif


### PR DESCRIPTION
There is a problem with default values in MSP override init frame, it makes the drone spin like crazy. In this PR the idea is to provide typical default values for ROLL, PITCH, and YAW like in betaflight configurator interface. I'm not sure if it's the best way to handle it and how to take into account that user can configure channel mapping (e.g. AETR, et).

In the previous version of the code (v4.4) it seems that default behavior was to return proper default values. The drones are crashing only with 4.5 and not with 4.4.

Looks like the issue was introduced in https://github.com/betaflight/betaflight/pull/13352
Before that change, in a moment between MSP_OVERRIDE is ON and the first MSP packet is received, the drone was not receiving new commands. But with this change, the drone receives commands that consist of 885, 885, 885... It makes the drone unstable within a fraction of a second, and eventually, it falls down.

The correct behavior would be to keep previous values or at least to have correct default values.