### PR TITLE
Limit i term accumulation by pid sum only

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -707,14 +707,14 @@ STATIC_UNIT_TESTED void applyItermRelax(const int axis, const float iterm,
                 DEBUG_SET(DEBUG_ITERM_RELAX, 1, lrintf(itermRelaxFactor * 100.0f));
                 DEBUG_SET(DEBUG_ITERM_RELAX, 2, lrintf(*itermErrorRate));
             }
-        } else {
+        } else if (axis == FD_YAW){
             // testing putting iTermRelax for yaw here
             // method uses a modification of tbolin's pidSum limiting
             // reduce iTerm rate of change (input gain) as pidSum approaches pidSum limit for yaw
-            float axisCi = 1.0f - (fabsf(pidData[axis].Sum) / pidRuntime.pidSumLimitYaw);
-            axisCi = constrainf(axisCi * pidRuntime.itermWindupPointInv, 0.0f, 1.0f);
-            *itermErrorRate *= axisCi;
+            const float axisCi = 1.0f - (fabsf(pidData[axis].Sum) * pidRuntime.pidSumLimitYawInv);
+            *itermErrorRate *= constrainf(axisCi * pidRuntime.itermWindupPointInv, 0.0f, 1.0f);
 
+            // these debugs cost 48 bytes of ITCM RAM; should be removed later
             DEBUG_SET(DEBUG_ITERM_RELAX, 4, lrintf(axisCi * 100.0f));
             DEBUG_SET(DEBUG_ITERM_RELAX, 5, lrintf(pidData[axis].Sum));
             DEBUG_SET(DEBUG_ITERM_RELAX, 6, lrintf(*itermErrorRate));

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -326,6 +326,7 @@ typedef struct pidRuntime_s {
     float crashSetpointThreshold;
     float crashLimitYaw;
     float itermLimit;
+    float pidSumLimitYaw;
     bool itermRotation;
     bool zeroThrottleItermReset;
     bool levelRaceMode;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -326,7 +326,7 @@ typedef struct pidRuntime_s {
     float crashSetpointThreshold;
     float crashLimitYaw;
     float itermLimit;
-    float pidSumLimitYaw;
+    float pidSumLimitYawInv;
     bool itermRotation;
     bool zeroThrottleItermReset;
     bool levelRaceMode;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -312,7 +312,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold;
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
-    pidRuntime.itermLimit = MIN(pidProfile->itermLimit, pidProfile->pidSumLimit);
+    // to avoid motor saturation by iTerm alone, itermLimit cannot be set higher than 80% of pidSumLimit
+    // **todo** yaw has it's own pidSumLimitYaw, this may cause issues?
+    pidRuntime.itermLimit = fminf((float)pidProfile->itermLimit, 0.8f * pidProfile->pidSumLimit);
+    pidRuntime.pidSumLimitYaw = pidProfile->pidSumLimitYaw;
 #if defined(USE_THROTTLE_BOOST)
     throttleBoost = pidProfile->throttle_boost * 0.1f;
 #endif

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -298,7 +298,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
     pidRuntime.maxVelocity[FD_ROLL] = pidRuntime.maxVelocity[FD_PITCH] = pidProfile->rateAccelLimit * 100 * pidRuntime.dT;
     pidRuntime.maxVelocity[FD_YAW] = pidProfile->yawRateAccelLimit * 100 * pidRuntime.dT;
-    pidRuntime.itermWindupPointInv = 1.0f;
+    pidRuntime.itermWindupPointInv = 100.0f; // value with user setting of 100; 0 means off
     if (pidProfile->itermWindupPointPercent < 100) {
         const float itermWindupPoint = pidProfile->itermWindupPointPercent / 100.0f;
         pidRuntime.itermWindupPointInv = 1.0f / (1.0f - itermWindupPoint);
@@ -312,7 +312,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold;
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
-    pidRuntime.itermLimit = pidProfile->itermLimit;
+    pidRuntime.itermLimit = MIN(pidProfile->itermLimit, pidProfile->pidSumLimit);
 #if defined(USE_THROTTLE_BOOST)
     throttleBoost = pidProfile->throttle_boost * 0.1f;
 #endif

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -315,7 +315,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     // to avoid motor saturation by iTerm alone, itermLimit cannot be set higher than 80% of pidSumLimit
     // **todo** yaw has it's own pidSumLimitYaw, this may cause issues?
     pidRuntime.itermLimit = fminf((float)pidProfile->itermLimit, 0.8f * pidProfile->pidSumLimit);
-    pidRuntime.pidSumLimitYaw = pidProfile->pidSumLimitYaw;
+    pidRuntime.pidSumLimitYawInv = 1.0f / pidProfile->pidSumLimitYaw;
 #if defined(USE_THROTTLE_BOOST)
     throttleBoost = pidProfile->throttle_boost * 0.1f;
 #endif

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -298,7 +298,7 @@ TEST(pidControllerTest, testPidLoop)
     EXPECT_NEAR(-128.1, pidData[FD_ROLL].P, calculateTolerance(-128.1));
     EXPECT_NEAR(185.8, pidData[FD_PITCH].P, calculateTolerance(185.8));
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-15.6, pidData[FD_ROLL].I, calculateTolerance(-15.6));
+    EXPECT_NEAR(-7.8, pidData[FD_ROLL].I, calculateTolerance(-7.8));
     EXPECT_NEAR(9.8, pidData[FD_PITCH].I, calculateTolerance(9.8));
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
@@ -313,8 +313,8 @@ TEST(pidControllerTest, testPidLoop)
     EXPECT_NEAR(-128.1, pidData[FD_ROLL].P, calculateTolerance(-128.1));
     EXPECT_NEAR(185.8, pidData[FD_PITCH].P, calculateTolerance(185.8));
     EXPECT_NEAR(-224.2, pidData[FD_YAW].P, calculateTolerance(-224.2));
-    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
-    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
+    EXPECT_NEAR(-9.3, pidData[FD_ROLL].I, calculateTolerance(-9.3));
+    EXPECT_NEAR(9.8, pidData[FD_PITCH].I, calculateTolerance(9.8));
     EXPECT_NEAR(-8.7, pidData[FD_YAW].I, calculateTolerance(-8.7));
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
@@ -323,8 +323,8 @@ TEST(pidControllerTest, testPidLoop)
     // Simulate Iterm behaviour during mixer saturation
     simulatedMotorMixRange = 1.2f;
     pidController(pidProfile, currentTestTime());
-    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
-    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
+    EXPECT_NEAR(-10.6, pidData[FD_ROLL].I, calculateTolerance(-10.6));
+    EXPECT_NEAR(9.8, pidData[FD_PITCH].I, calculateTolerance(9.8));
     EXPECT_NEAR(-8.8, pidData[FD_YAW].I, calculateTolerance(-8.8));
     simulatedMotorMixRange = 0;
 
@@ -340,9 +340,9 @@ TEST(pidControllerTest, testPidLoop)
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
-    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
-    EXPECT_NEAR(-10.6, pidData[FD_YAW].I, calculateTolerance(-10.6));
+    EXPECT_NEAR(-10.6, pidData[FD_ROLL].I, calculateTolerance(-10.6));
+    EXPECT_NEAR(9.8, pidData[FD_PITCH].I, calculateTolerance(9.8));
+    EXPECT_NEAR(-8.8, pidData[FD_YAW].I, calculateTolerance(-8.8));
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].D);
@@ -519,60 +519,64 @@ TEST(pidControllerTest, testMixerSaturation)
     simulatedMotorMixRange = 2.0f;
     pidController(pidProfile, currentTestTime());
 
-    // Expect no iterm accumulation for all axes
-    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
+    // Expect iterm accumulation for all axes because at this point, pidSum is not at limit
+    EXPECT_NEAR(156.2f, pidData[FD_ROLL].I, calculateTolerance(156.2));
+    EXPECT_NEAR(-195.3f, pidData[FD_PITCH].I, calculateTolerance(-195.3));
+    EXPECT_NEAR(7.0f, pidData[FD_YAW].I, calculateTolerance(7.0));
+
+//    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
+//    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
+//    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 
     // Test itermWindup limit
     // First store values without exceeding iterm windup limit
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-    setStickPosition(FD_ROLL, 0.1f);
-    setStickPosition(FD_PITCH, -0.1f);
-    setStickPosition(FD_YAW, 0.1f);
-    simulatedMotorMixRange = 0.0f;
-    pidController(pidProfile, currentTestTime());
-    float rollTestIterm = pidData[FD_ROLL].I;
-    float pitchTestIterm = pidData[FD_PITCH].I;
-    float yawTestIterm = pidData[FD_YAW].I;
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     setStickPosition(FD_ROLL, 0.1f);
+//     setStickPosition(FD_PITCH, -0.1f);
+//     setStickPosition(FD_YAW, 0.1f);
+//    simulatedMotorMixRange = 0.0f;
+//     pidController(pidProfile, currentTestTime());
+//     float rollTestIterm = pidData[FD_ROLL].I;
+//     float pitchTestIterm = pidData[FD_PITCH].I;
+//     float yawTestIterm = pidData[FD_YAW].I;
 
     // Now compare values when exceeding the limit
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-    setStickPosition(FD_ROLL, 0.1f);
-    setStickPosition(FD_PITCH, -0.1f);
-    setStickPosition(FD_YAW, 0.1f);
-    simulatedMotorMixRange = (pidProfile->itermWindupPointPercent + 2) / 100.0f;
-    pidController(pidProfile, currentTestTime());
-    EXPECT_LT(pidData[FD_ROLL].I, rollTestIterm);
-    EXPECT_GE(pidData[FD_PITCH].I, pitchTestIterm);
-    EXPECT_LT(pidData[FD_YAW].I, yawTestIterm);
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     setStickPosition(FD_ROLL, 0.1f);
+//     setStickPosition(FD_PITCH, -0.1f);
+//     setStickPosition(FD_YAW, 0.1f);
+//     simulatedMotorMixRange = (pidProfile->itermWindupPointPercent + 2) / 100.0f;
+//     pidController(pidProfile, currentTestTime());
+//     EXPECT_LT(pidData[FD_ROLL].I, rollTestIterm);
+//     EXPECT_GE(pidData[FD_PITCH].I, pitchTestIterm);
+//     EXPECT_LT(pidData[FD_YAW].I, yawTestIterm);
 
     // Test that the added i term gain from Anti Gravity
     // is also affected by itermWindup
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-
-    setStickPosition(FD_ROLL, 1.0f);
-    setStickPosition(FD_PITCH, -1.0f);
-    setStickPosition(FD_YAW, 1.0f);
-    simulatedMotorMixRange = 2.0f;
-    const bool prevAgState = pidRuntime.antiGravityEnabled;
-    const float prevAgTrhottleD = pidRuntime.antiGravityThrottleD;
-    pidRuntime.antiGravityEnabled = true;
-    pidRuntime.antiGravityThrottleD = 1.0;
-    pidController(pidProfile, currentTestTime());
-    pidRuntime.antiGravityEnabled = prevAgState;
-    pidRuntime.antiGravityThrottleD = prevAgTrhottleD;
-
-    // Expect no iterm accumulation for all axes
-    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+// 
+//     setStickPosition(FD_ROLL, 1.0f);
+//     setStickPosition(FD_PITCH, -1.0f);
+//     setStickPosition(FD_YAW, 1.0f);
+//     simulatedMotorMixRange = 2.0f;
+//     const bool prevAgState = pidRuntime.antiGravityEnabled;
+//     const float prevAgTrhottleD = pidRuntime.antiGravityThrottleD;
+//     pidRuntime.antiGravityEnabled = true;
+//     pidRuntime.antiGravityThrottleD = 1.0;
+//     pidController(pidProfile, currentTestTime());
+//     pidRuntime.antiGravityEnabled = prevAgState;
+//     pidRuntime.antiGravityThrottleD = prevAgTrhottleD;
+// 
+//     // Expect no iterm accumulation for all axes
+//     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
+//     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
+//     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 
     // // Test that i term is limited on yaw even when only yaw is saturated
     // resetTest();


### PR DESCRIPTION
<edit>CLOSED: Replaced by #13543.  Detailed testing showed that input limiting of iTerm on yaw isn't helpful.  A leaky integrator may be a better solution.  

The following notes are of relevance generally, and the images of the outcome clarify why this doesn't appear as helpful as we hoped it would be.
</edit>

This PR is an alternative to #13506, for which I am very grateful to @tbolin.

Based on testing and code analysis, this a bit of a more radical, and much simpler solution.

WARNING:  with this PR, `iterm_windup` DOES NOT suppress iTerm when motorMix is high!
`iterm_windup` is now *only* a 'soft knee' slope setting for how smoothly, or sharply, the `pid_sum_limit_yaw` value is applied when limiting iTerm on yaw.

I have flight tested, bench tested, and emulation tested this code.

### Recommended usage / testing:
- Fly master, do some flips and rolls and yaw spins, looking for 'rubber-band' like overshoot and return behaviours.  Save your current settings via a Preset.  If possible, make a log, using the `iterm_relax` debug mode.
- Flash the PR and load your old settings.  In CLI check that the values for `pid_sum_limit`, `pid_sum_limit_yaw`, and `iterm_limit` are on defaults.
- Fly the PR and do the same kinds of inputs; make a log if possible.

### Expected outcomes:
- Do some quick flips, rolls and yaw spin inputs with hard stops, and look for 'rubber-band' bounce-back at the end of the mover.
- Nothing much should change on pitch or roll.  If, previously, there was bounce back from iTerm, and if it is now stronger, the only possible explanation is that the old `iterm_windup` code was helping suppress iTerm on the control axis.  That means the iTerm_Relax settings were not quite right, before, and need to be adjusted (usually by reducing the iTerm_relax_cutoff value).  
- There may be improved cross-axis stability / recovery on all axes if the motors are saturating in a roll or pitch flip, since iTerm will not be limited on the non-involved axes, and should return the quad to its previous attitude on those axes even if transiently disturbed by the motor saturation.  
- If there is bounce-back at the end of short, quick yaw spins, try reducing `pid_sum_limit_yaw` in steps of 50 to find out if a lower value than default helps minimise the bounce-back. 
- The highest value of `pid_sum_limit_yaw` that is consistent with acceptable bounce-back is what you should go with.
- If `pid_sum_limit_yaw` is set too low (perhaps under 100), you may get yaw instability.

Follow-up:
- Please post feedback here, logs can be shared as zip files.

### Background:

iTerm accumulation during fast inputs, where there is inevitably some error and delay, leads to 'rubber-band' type overshoot / bounce back at the end of fast moves.  Inappropriate iTerm accumulation is called 'iterm windup'.  

Betaflight has specific solutions for this problem.

`iTerm_Relax` is the main way to prevent iTerm windup on Pitch and Roll, but has no effect on yaw.  This PR makes no changes to `iterm_relax` code for Pitch and Roll.

`iterm_windup` was a simple method that limited iTerm windup if motor_mix was above a threshold, by reducing iTerm input gain.  The result was slower accumulation / de-accumulation of iTerm above the threshold, until iTerm would get 'locked' at its last value when motor_mix was 100%.  This applied to ALL axes, including pitch and roll.  However, since yaw had no `iterm_relax` code, `iterm_windup` was the *primary* method for attenuating yaw iTerm windup. This PR stops `iterm_windup` blocking iTerm on other axis, and stops using it for yaw as well.

`iterm_limit` is a CLI value that limits the maximum allowed amount of the iTerm contribution to pidSum.  A value of 500 (50%) leads to full motor saturation.  The default value of 400 is a simple hard limit on iTerm that stops any one axis gaining enough iTerm to fully saturate the motors.  Once iTerm reaches that limit, it's usefulness as a 'return to where we were' function is lost.  Reducing `iterm_limit` is not advisable because the quad will be less likely to restore its previous heading after a bump.

`pid_sum_limit` is a CLI value that limits the pidSum on Pitch or Roll to a default of 500 in the mixer code.  The value of pidSum is not constrained within the PID code itself.  This limit is really just part of the mixer.  If the `pid_sum_limit` is reduced below 500, no one axis can command full motor authority.  For example, a `pid_sum_limit` of 400 will 'chop off' the top 20% of your authority on that axis, leaving some room for other axes to have control.  Some LOS and freestyle pilots doing complex multi-axis moves on high-authority quads may find this helpful, but normally this value should not modified by the user.  

`pid_sum_limit_yaw` is a CLI value that does the same thing for Yaw. By default, this value is 400.  This value prevents a full yaw input from gaining 100% motor authority, always leaving 20% for control over the other axes.

### Functional changes:

This PR is intended to make `pid_sum_limit_yaw` more useful as a limiter of iTerm windup on yaw, and to remove the old global motor_mix method of iTerm inhibition, so it won't mess with pitch and roll.

It does that by not only limiting the output range in the mixer, but also constraining the amount by which iTerm can grow on yaw.  It can now only occupy the space remaining inside the limit *after consideration for P and FF*.  That means, when there is a big stick input and ongoing error, that iTerm can only grow to a limited amount, which should reduce bounce-back in fast yaw inputs.

### Summary of code changes:
- removes the motorMix based `iterm_windup` method that previously attenuated iTerm growth *on all axes* if motorMix exceeded a threshold.  
- uses a pidSum based approach (thanks @tbolin) to constraining iTerm inside the `pid_sum_limit_yaw` value; iTerm now should not grow to a value that would exceed pidSum_Limit, it will grow more slowly when P and FF are high, and will not grow at all if the contribution of P and FF together exceed pid_sum_limit_yaw`.
- uses `iterm_windup` purely as a control for the 'soft-knee' onset of the iTerm limitation on yaw, starting the iTerm limiting earlier and more smoothly with lower values.
- overall, iTerm constraints are now entirely on a per-axis basis; what happens to iTerm on one axis does not affect another.
- fixes an issue where iTerm on yaw would not have been constrained by iterm_windup if the user set low `pid_sum_limit` or `pid_sum_limit_yaw` values.
- retains `iterm_limit` as a final 'hard stop' limit on iTerm for all axes.

Note: The old iterm_windup value now acts as a kind of slope adjustment for the 'harshness' of the limiting.  When set to 99 or 100 we get a very steep cutoff when `pid_sum_limit_yaw` approaches its limit.  When set to 50, iTerm growth attenuation starts half way to the `pid_sum_limit_yaw` limit, and will effectively reduce the rate at which iTerm on yaw grows a bit more strongly.

This PR addresses the issue identified by @tbolin with the current code where the protection from `iterm_windup` relied on motorMix being high.  If the user configured a pidSum limit that was significantly less than 500, motorMix could not not climb to reach the threshold required to suppress iTerm, unless multiple axes had high enough pidSum values to saturate the mixer.  Hence if there was an error on only one one axis, in this situation, iTerm would not be constrained, and could grow all the way to iTerm_Limit, causing bounce-back.  In contrast, with this PR, motor_Mix is ignored.  We only care about whether the iTerm value for yaw is in danger of saturating pidSum for the yaw axis.

This newer, simpler method works well in flight.  With normal Betaflight defaults for iterm_limit, pidsum_limit, and iterm_weight, iTerm growth in high pidSum / motorMix situations is suppressed a little bit earlier.  This balances out the lack of overall motorMix suppression quite well.

There are not many situations where iTerm growth has to be constrained due to high pidSum, not in normal flight, anyway.  In some crashes, in some constrained situations (quad stuck in grass), and in some low authority quads, motorMix based methods would limit iTerm growth.  This code will achieve the same result, because motorMix is dependent on pidSum.

This PR code requires the same amount of ITCM RAM as master once the additional test debugs are removed.

I had to 'hack' the unit tests to avoid checks based on the old motorMix based methods.  This was done inelegantly since I am not at all capable when it comes to unit tests.  I'd appreciate help with unit tests if the PR goes ahead.