### PR TITLE
Update default target.h so every board can have their own custom board name

### DIFF
--- a/src/main/target/AT32F435G/target.h
+++ b/src/main/target/AT32F435G/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "A435"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight AT32F435"
+#endif
 
 #ifndef AT32F435
 #define AT32F435

--- a/src/main/target/AT32F435M/target.h
+++ b/src/main/target/AT32F435M/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "A435"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight AT32F435"
+#endif
 
 #ifndef AT32F435
 #define AT32F435

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "S405"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight STM32F405"
+#endif
 
 #ifndef STM32F405
 #define STM32F405

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "S411"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight STM32F411"
+#endif
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2

--- a/src/main/target/STM32F446/target.h
+++ b/src/main/target/STM32F446/target.h
@@ -21,9 +21,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER         "S446"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING             "Betaflight STM32F446"
+#endif
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIE
 #define TARGET_BOARD_IDENTIFIER "S745"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight STM32F745"
+#endif
 
 #ifndef STM32F745
 #define STM32F745

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#ifndef TARGET_BOARD_IDENTIFIE
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "S745"
 #endif
 

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIE
 #define TARGET_BOARD_IDENTIFIER "S7X2"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight STM32F7x2"
+#endif
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#ifndef TARGET_BOARD_IDENTIFIE
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "S7X2"
 #endif
 

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIE
 #define TARGET_BOARD_IDENTIFIER "SG47"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight STM32G47x"
+#endif
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#ifndef TARGET_BOARD_IDENTIFIE
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "SG47"
 #endif
 

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -20,9 +20,13 @@
 
 #pragma once
 
+#ifndef TARGET_BOARD_IDENTIFIE
 #define TARGET_BOARD_IDENTIFIER "SH74"
+#endif
 
+#ifndef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_STRING     "Betaflight STM32H743"
+#endif
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#ifndef TARGET_BOARD_IDENTIFIE
+#ifndef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "SH74"
 #endif
 


### PR DESCRIPTION
H750, H730, H725 already have a check for defining TARGET_BOARD_IDENTIFIER and USBD_PRODUCT_STRING,
So I updated every other board to be consistent with these three boards.
