### PR TITLE
Expand the frequency range of vtx

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -607,8 +607,8 @@ static const void *saCmsConfigUserFreq(displayPort_t *pDisp, const void *self)
 static const OSD_Entry saCmsMenuPORFreqEntries[] = {
     { "- POR FREQ -", OME_Label,   NULL,             NULL },
 
-    { "CUR FREQ",     OME_UINT16 | DYNAMIC,  NULL,             &(OSD_UINT16_t){ &saCmsORFreq, 5000, 5999, 0 } },
-    { "NEW FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5999, 1 } },
+    { "CUR FREQ",     OME_UINT16 | DYNAMIC,  NULL,             &(OSD_UINT16_t){ &saCmsORFreq, 1000, 6700, 0 } },
+    { "NEW FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreqNew, 1000, 6700, 1 } },
     { "SAVE",         OME_Funcall, saCmsSetPORFreq,  NULL },
 
     { "BACK",         OME_Back,    NULL,             NULL },
@@ -630,8 +630,8 @@ static CMS_Menu saCmsMenuPORFreq =
 static const OSD_Entry saCmsMenuUserFreqEntries[] = {
     { "- USER FREQ -", OME_Label,   NULL,             NULL },
 
-    { "CUR FREQ",      OME_UINT16 | DYNAMIC,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5999, 0 } },
-    { "NEW FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5999, 1 } },
+    { "CUR FREQ",      OME_UINT16 | DYNAMIC,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreq, 1000, 6700, 0 } },
+    { "NEW FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreqNew, 1000, 6700, 1 } },
     { "SAVE",          OME_Funcall, saCmsConfigUserFreq, NULL },
 
     { "BACK",          OME_Back,    NULL,             NULL },

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -28,8 +28,8 @@
 #include "common/time.h"
 #include "common/streambuf.h"
 
-#define VTX_SETTINGS_MIN_FREQUENCY_MHZ 5000          //min freq (in MHz) for 'vtx_freq' setting
-#define VTX_SETTINGS_MAX_FREQUENCY_MHZ 5999          //max freq (in MHz) for 'vtx_freq' setting
+#define VTX_SETTINGS_MIN_FREQUENCY_MHZ 1000          //min freq (in MHz) for 'vtx_freq' setting
+#define VTX_SETTINGS_MAX_FREQUENCY_MHZ 6700          //max freq (in MHz) for 'vtx_freq' setting
 
 #if defined(USE_VTX_RTC6705)
 

--- a/src/main/drivers/vtx_table.h
+++ b/src/main/drivers/vtx_table.h
@@ -43,8 +43,8 @@
 #endif
 
 
-#define VTX_TABLE_MIN_USER_FREQ         5000
-#define VTX_TABLE_MAX_USER_FREQ         5999
+#define VTX_TABLE_MIN_USER_FREQ         1000
+#define VTX_TABLE_MAX_USER_FREQ         6700
 #define VTX_TABLE_DEFAULT_BAND          4
 #define VTX_TABLE_DEFAULT_CHANNEL       1
 #define VTX_TABLE_DEFAULT_FREQ          5740

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -35,8 +35,8 @@
 #define VTX_SMARTAUDIO_MIN_CHANNEL 1
 
 
-#define VTX_SMARTAUDIO_MIN_FREQUENCY_MHZ 5000        //min freq in MHz
-#define VTX_SMARTAUDIO_MAX_FREQUENCY_MHZ 5999        //max freq in MHz
+#define VTX_SMARTAUDIO_MIN_FREQUENCY_MHZ 1000        //min freq in MHz
+#define VTX_SMARTAUDIO_MAX_FREQUENCY_MHZ 6700        //max freq in MHz
 
 // opmode flags, GET side
 #define SA_MODE_GET_FREQ_BY_FREQ            1

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -24,8 +24,8 @@
 
 #define VTX_TRAMP_POWER_COUNT 5
 
-#define VTX_TRAMP_MIN_FREQUENCY_MHZ 5000             //min freq in MHz
-#define VTX_TRAMP_MAX_FREQUENCY_MHZ 5999             //max freq in MHz
+#define VTX_TRAMP_MIN_FREQUENCY_MHZ 1000             //min freq in MHz
+#define VTX_TRAMP_MAX_FREQUENCY_MHZ 6700             //max freq in MHz
 
 bool vtxTrampInit(void);
 


### PR DESCRIPTION
There are 1.2, 2.4, 3.3, 4.9 GHz vtx on the market, i think it is necessary to expand the minimum frequency to 1000 MHz .

ImmersionRC Rapidfire vrx support up to 6100 MHz , Some TrueRC antennas support up to 6.7 GHz, so i recommend expand the maximum frequency to 6700 MHz .