### PR TITLE
Fix smartport over softserial using override

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -346,11 +346,6 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
             (portConfig->identifier == SERIAL_PORT_SOFTSERIAL2)) {
             // Ensure MSP or serial RX is not enabled on soft serial ports
             serialConfigToCheck->portConfigs[index].functionMask &= ~(FUNCTION_MSP | FUNCTION_RX_SERIAL);
-
-            // Ensure that the baud rate on soft serial ports is limited to 19200
-            serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
-            serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
-            // serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_57600);
         }
 #endif
 
@@ -437,9 +432,16 @@ serialPort_t *openSerialPort(
     serialPort_t *serialPort = NULL;
 
 #ifdef USE_SOFTSERIAL
-    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 57600)) {
+
+#ifdef USE_OVERRIDE_SOFTSERIAL_BAUDRATE_RESTRICTION
+#define SOFTSERIAL_MAX_BAUDRATE 57600
+#else
+#define SOFTSERIAL_MAX_BAUDRATE 19200
+#endif
+
+    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > SOFTSERIAL_MAX_BAUDRATE)) {
         // Limit baud rate on soft serial ports
-        baudRate = 57600;
+        baudRate = SOFTSERIAL_MAX_BAUDRATE;
     }
 #endif
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -347,10 +347,10 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
             // Ensure MSP or serial RX is not enabled on soft serial ports
             serialConfigToCheck->portConfigs[index].functionMask &= ~(FUNCTION_MSP | FUNCTION_RX_SERIAL);
 
-            // Ensure that the baud rate on soft serial ports is limited to 57600
-            serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_57600);
-            serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_57600);
-            serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_57600);
+            // Ensure that the baud rate on soft serial ports is limited to 19200
+            serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
+            serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
+            // serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_19200);
         }
 #endif
 
@@ -437,9 +437,9 @@ serialPort_t *openSerialPort(
     serialPort_t *serialPort = NULL;
 
 #ifdef USE_SOFTSERIAL
-    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 57600)) {
+    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 19200)) {
         // Limit baud rate on soft serial ports
-        baudRate = 57600;
+        baudRate = 19200;
     }
 #endif
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -350,7 +350,7 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
             // Ensure that the baud rate on soft serial ports is limited to 19200
             serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
             serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
-            // serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_19200);
+            // serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_57600);
         }
 #endif
 
@@ -437,9 +437,9 @@ serialPort_t *openSerialPort(
     serialPort_t *serialPort = NULL;
 
 #ifdef USE_SOFTSERIAL
-    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 19200)) {
+    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 57600)) {
         // Limit baud rate on soft serial ports
-        baudRate = 19200;
+        baudRate = 57600;
     }
 #endif
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -347,10 +347,10 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
             // Ensure MSP or serial RX is not enabled on soft serial ports
             serialConfigToCheck->portConfigs[index].functionMask &= ~(FUNCTION_MSP | FUNCTION_RX_SERIAL);
 
-            // Ensure that the baud rate on soft serial ports is limited to 19200
-            serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
-            serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
-            serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_19200);
+            // Ensure that the baud rate on soft serial ports is limited to 57600
+            serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_57600);
+            serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_57600);
+            serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_57600);
         }
 #endif
 
@@ -437,9 +437,9 @@ serialPort_t *openSerialPort(
     serialPort_t *serialPort = NULL;
 
 #ifdef USE_SOFTSERIAL
-    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 19200)) {
+    if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 57600)) {
         // Limit baud rate on soft serial ports
-        baudRate = 19200;
+        baudRate = 57600;
     }
 #endif
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -347,7 +347,7 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
             // Ensure MSP or serial RX is not enabled on soft serial ports
             serialConfigToCheck->portConfigs[index].functionMask &= ~(FUNCTION_MSP | FUNCTION_RX_SERIAL);
             // Ensure that the baud rate on soft serial ports is limited to 19200
-#ifndef OVERRIDE_SOFTSERIAL_BAUDRATE_RESTRICTION
+#ifndef USE_OVERRIDE_SOFTSERIAL_BAUDRATE_RESTRICTION
             serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
             serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
             serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_19200);

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -440,8 +440,8 @@ serialPort_t *openSerialPort(
 #endif
 
     if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > SOFTSERIAL_MAX_BAUDRATE)) {
-        // Limit baud rate on soft serial ports
-        baudRate = SOFTSERIAL_MAX_BAUDRATE;
+        // Don't continue if baud rate requested is higher then the limit set on soft serial ports
+        return NULL;
     }
 #endif
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -347,7 +347,7 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
             // Ensure MSP or serial RX is not enabled on soft serial ports
             serialConfigToCheck->portConfigs[index].functionMask &= ~(FUNCTION_MSP | FUNCTION_RX_SERIAL);
             // Ensure that the baud rate on soft serial ports is limited to 19200
-#ifndef USE_OVERRIDE_SOFTSERIAL_BAUDRATE_RESTRICTION
+#ifndef USE_OVERRIDE_SOFTSERIAL_BAUDRATE
             serialConfigToCheck->portConfigs[index].gps_baudrateIndex = constrain(portConfig->gps_baudrateIndex, BAUD_AUTO, BAUD_19200);
             serialConfigToCheck->portConfigs[index].blackbox_baudrateIndex = constrain(portConfig->blackbox_baudrateIndex, BAUD_AUTO, BAUD_19200);
             serialConfigToCheck->portConfigs[index].telemetry_baudrateIndex = constrain(portConfig->telemetry_baudrateIndex, BAUD_AUTO, BAUD_19200);
@@ -437,7 +437,7 @@ serialPort_t *openSerialPort(
 
     serialPort_t *serialPort = NULL;
 
-#if defined(USE_SOFTSERIAL) && !defined(USE_OVERRIDE_SOFTSERIAL_BAUDRATE_RESTRICTION)
+#if defined(USE_SOFTSERIAL) && !defined(USE_OVERRIDE_SOFTSERIAL_BAUDRATE)
     if (((identifier == SERIAL_PORT_SOFTSERIAL1) || (identifier == SERIAL_PORT_SOFTSERIAL2)) && (baudRate > 19200)) {
         // Don't continue if baud rate requested is higher then the limit set on soft serial ports
         return NULL;


### PR DESCRIPTION
- Fixes #13539
- Using constrain does not permit serialpassthrough
- SmartPort works only with 57600
- GPS and blackbox won't really work with 19K2 baud. See #13303
- See also #13305

How to test:
- Need to add `OVERRIDE_SOFTSERIAL_BAUDRATE` custom define to override the baudrate limit.

![image](https://github.com/betaflight/betaflight/assets/8344830/f1b826fd-90f4-4b14-866e-409e28932e58)

**DISCLAIMER:** _**THE USE OF THIS DEFINE IS UNSUPPORTED**_