### PR TITLE
STM32H725 - fix USE_SOFTSERIAL

### DIFF
--- a/src/main/target/STM32H725/target.h
+++ b/src/main/target/STM32H725/target.h
@@ -83,8 +83,7 @@
 
 #define USE_VCP
 
-#define USE_SOFTSERIAL1
-#define USE_SOFTSERIAL2
+#define USE_SOFTSERIAL
 
 #define UNIFIED_SERIAL_PORT_COUNT       3
 


### PR DESCRIPTION
USE_SOFTSERIAL[12] is no longer supported

