### PR TITLE
set default of spec prearm screen to false if race pro not defined

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -428,7 +428,13 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->osd_use_quick_menu = true;
 #endif // USE_OSD_QUICK_MENU
 #ifdef USE_SPEC_PREARM_SCREEN
-    osdConfig->osd_show_spec_prearm = true;
+    osdConfig->osd_show_spec_prearm =
+#ifdef USE_RACE_PRO
+        true
+#else
+        false
+#endif //USE_RACE_PRO
+        ;
 #endif // USE_SPEC_PREARM_SCREEN
 }
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -427,15 +427,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 #ifdef USE_OSD_QUICK_MENU
     osdConfig->osd_use_quick_menu = true;
 #endif // USE_OSD_QUICK_MENU
-#ifdef USE_SPEC_PREARM_SCREEN
-    osdConfig->osd_show_spec_prearm =
+
 #ifdef USE_RACE_PRO
-        true
-#else
-        false
-#endif //USE_RACE_PRO
-        ;
-#endif // USE_SPEC_PREARM_SCREEN
+    osdConfig->osd_show_spec_prearm = true;
+#endif // USE_RACE_PRO
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)


### PR DESCRIPTION
If you build a local build, it will include the prearm spec screen on default (without rpm limiter enabled).
This PR makes sure, that it does not get shown in OSD without RACE_PRO define by default.