### PR TITLE
make mpuIntExtiHandler() static (#13520)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -133,7 +133,7 @@ busStatus_e mpuIntCallback(uint32_t arg)
     return BUS_READY;
 }
 
-void mpuIntExtiHandler(extiCallbackRec_t *cb)
+static void mpuIntExtiHandler(extiCallbackRec_t *cb)
 {
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
 

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -233,4 +233,3 @@ bool mpuAccRead(struct accDev_s *acc);
 bool mpuAccReadSPI(struct accDev_s *acc);
 
 busStatus_e mpuIntCallback(uint32_t arg);
-void mpuIntExtiHandler(extiCallbackRec_t *cb);


### PR DESCRIPTION
Function was made public in e126f1 for SPI case but seems unused outside the module. Make it static for all preprocessor cases and remove declaration.

Tested using CONFIG=STM32F411DISCOVERY.
