### PR TITLE
Fix clang unitests

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4250,7 +4250,6 @@ static void cliDefaults(const char *cmdName, char *cmdline)
 
     char *saveptr;
     char* tok = strtok_r(cmdline, " ", &saveptr);
-    int index = 0;
     bool expectParameterGroupId = false;
     while (tok != NULL) {
         if (expectParameterGroupId) {
@@ -4271,7 +4270,6 @@ static void cliDefaults(const char *cmdName, char *cmdline)
             return;
         }
 
-        index++;
         tok = strtok_r(NULL, " ", &saveptr);
     }
 

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -119,8 +119,12 @@ static int32_t gyroCyclesNow;
 static timeMs_t lastFailsafeCheckMs = 0;
 
 // No need for a linked list for the queue, since items are only inserted at startup
-
-STATIC_UNIT_TESTED FAST_DATA_ZERO_INIT task_t* taskQueueArray[TASK_COUNT + 1]; // extra item for NULL pointer at end of queue
+#ifdef UNIT_TEST
+#define TASK_QUEUE_RESERVE 1
+#else
+#define TASK_QUEUE_RESERVE 0
+#endif
+STATIC_UNIT_TESTED FAST_DATA_ZERO_INIT task_t* taskQueueArray[TASK_COUNT + 1 + TASK_QUEUE_RESERVE]; // extra item for NULL pointer at end of queue (+ overflow check in UNTT_TEST)
 
 void queueClear(void)
 {
@@ -443,8 +447,8 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
 }
 
 #if defined(UNIT_TEST)
-task_t *unittest_scheduler_selectedTask;
-uint8_t unittest_scheduler_selectedTaskDynamicPriority;
+STATIC_UNIT_TESTED task_t *unittest_scheduler_selectedTask;
+STATIC_UNIT_TESTED uint8_t unittest_scheduler_selectedTaskDynamicPriority;
 
 static void readSchedulerLocals(task_t *selectedTask, uint8_t selectedTaskDynamicPriority)
 {

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -329,8 +329,6 @@ void hottPrepareEAMResponse(HOTT_EAM_MSG_t *hottEAMMessage)
 
 static void hottSerialWrite(uint8_t c)
 {
-    static uint8_t serialWrites = 0;
-    serialWrites++;
     serialWrite(hottPort, c);
 }
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -517,11 +517,11 @@ CXX_VERSION = $(shell $(CXX) -dumpversion)
 
 ifeq ($(shell $(CC) -v 2>&1 | grep -q "clang version" && echo "clang"),clang)
 
-# Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 14 }
+# Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 16 }
 # Travis reports CC_VERSION of 4.2.1
 CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
 CC_VERSION_CHECK_MIN := 7
-CC_VERSION_CHECK_MAX := 14
+CC_VERSION_CHECK_MAX := 16
 
 # Added flags for clang 11 - 13 are not backwards compatible
 ifeq ($(shell expr $(CC_VERSION_MAJOR) \> 10 \& $(CC_VERSION_MAJOR) \< 14), 1)

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -78,7 +78,6 @@ extern "C" {
     PG_REGISTER(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_RESCUE, 0);
     PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 
-    float rcCommand[4];
     float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
     uint16_t averageSystemLoadPercent = 0;
     uint8_t cliMode = 0;

--- a/src/test/unit/baro_bmp085_unittest.cc
+++ b/src/test/unit/baro_bmp085_unittest.cc
@@ -50,7 +50,7 @@ typedef struct {
     int16_t oversampling_setting;
 } bmp085_t;
 
-bmp085_t bmp085;
+extern bmp085_t bmp085;
 
 }
 

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -44,7 +44,7 @@ typedef struct bmp280_calib_param_s {
     int16_t dig_P9; /* calibration P9 data */
 } __attribute__((packed)) bmp280_calib_param_t; // packed as we read directly from the device into this structure.
 
-bmp280_calib_param_t bmp280_cal;
+extern bmp280_calib_param_t bmp280_cal;
 }
 
 

--- a/src/test/unit/baro_bmp388_unittest.cc
+++ b/src/test/unit/baro_bmp388_unittest.cc
@@ -46,7 +46,7 @@ typedef struct bmp388_calib_param_s {
     int8_t P11;
 } __attribute__((packed)) bmp388_calib_param_t; // packed as we read directly from the device into this structure.
 
-bmp388_calib_param_t bmp388_cal;
+extern bmp388_calib_param_t bmp388_cal;
 
 } // extern "C"
 

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -346,7 +346,7 @@ const uint32_t baudRates[] = {0, 9600, 19200, 38400, 57600, 115200, 230400, 2500
         400000, 460800, 500000, 921600, 1000000, 1500000, 2000000, 2470000}; // see baudRate_e
 uint8_t debugMode = 0;
 int16_t debug[DEBUG16_VALUE_COUNT];
-int32_t blackboxHeaderBudget;
+extern int32_t blackboxHeaderBudget;
 gpsSolutionData_t gpsSol;
 int32_t GPS_home[2];
 

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -385,7 +385,7 @@ INSTANTIATE_TEST_SUITE_P(
 // STUBS
 
 extern "C" {
-    boxBitmask_t rcModeActivationMask;
+    extern boxBitmask_t rcModeActivationMask;
     float rcCommand[4];
     float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -303,7 +303,7 @@ uint8_t stateFlags = 0;
 uint16_t flightModeFlags = 0;
 float rcCommand[4];
 float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
-boxBitmask_t rcModeActivationMask;
+extern boxBitmask_t rcModeActivationMask;
 gpsSolutionData_t gpsSol;
 
 batteryState_e getBatteryState(void)

--- a/src/test/unit/link_quality_unittest.cc
+++ b/src/test/unit/link_quality_unittest.cc
@@ -70,7 +70,7 @@ extern "C" {
     float rMat[3][3];
 
     pidProfile_t *currentPidProfile;
-    float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+    extern float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
     uint8_t GPS_numSat;
     uint16_t GPS_distanceToHome;
     int16_t GPS_directionToHome;
@@ -104,7 +104,7 @@ extern "C" {
 extern "C" {
     PG_REGISTER(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
 
-    boxBitmask_t rcModeActivationMask;
+    extern boxBitmask_t rcModeActivationMask;
     int16_t debug[DEBUG16_VALUE_COUNT];
     uint8_t debugMode = 0;
 

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -43,7 +43,7 @@ extern "C" {
 PG_REGISTER(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
 PG_REGISTER(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 0);
 
-boxBitmask_t rcModeActivationMask;
+extern boxBitmask_t rcModeActivationMask;
 int16_t debug[DEBUG16_VALUE_COUNT];
 uint8_t debugMode = 0;
 uint8_t armingFlags = 0;

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -38,7 +38,7 @@ extern "C" {
     #include "pg/pg_ids.h"
     #include "io/beeper.h"
 
-    boxBitmask_t rcModeActivationMask;
+    extern boxBitmask_t rcModeActivationMask;
     int16_t debug[DEBUG16_VALUE_COUNT];
     uint8_t debugMode = 0;
     uint8_t armingFlags = 0;

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -55,8 +55,8 @@ const int TEST_UPDATE_OSD_TIME = 30;
 #define TASK_PERIOD_HZ(hz) (1000000 / (hz))
 
 extern "C" {
-    task_t * unittest_scheduler_selectedTask;
-    uint8_t unittest_scheduler_selectedTaskDynPrio;
+    extern task_t * unittest_scheduler_selectedTask;
+    extern uint8_t unittest_scheduler_selectedTaskDynPrio;
     timeDelta_t unittest_scheduler_taskRequiredTimeUs;
     bool taskGyroRan = false;
     bool taskFilterRan = false;

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -256,7 +256,7 @@ extern "C" {
 
     gpsSolutionData_t gpsSol;
     attitudeEulerAngles_t attitude = { { 0, 0, 0 } };
-    uint8_t responseBuffer[MSP_TLM_OUTBUF_SIZE];
+    extern uint8_t responseBuffer[MSP_TLM_OUTBUF_SIZE];
 
     uint32_t micros(void) {return dummyTimeUs;}
     uint32_t microsISR(void) {return micros();}

--- a/src/test/unit/unittest_displayport.h
+++ b/src/test/unit/unittest_displayport.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string.h>
+#include <stdarg.h>
 
 extern "C" {
     #include "drivers/display.h"

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -71,7 +71,7 @@ extern "C" {
     PG_REGISTER(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
     PG_REGISTER(gpsRescueConfig_t, gpsRescueConfig, PG_GPS_CONFIG, 0);
 
-    float rcCommand[4];
+    extern float rcCommand[4];
     float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
     uint16_t averageSystemLoadPercent = 0;
     uint8_t cliMode = 0;


### PR DESCRIPTION
clang-related part of https://github.com/betaflight/betaflight/pull/13507

Also bumped max to clang-16, tested on linux (with minor fix)

On Debian Bookworm, clang-12 is not supported for some reason, making development more tedious
