### PR TITLE
Use clang 15 as default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get install -y libblocksruntime-dev clang-12
+        run: sudo apt-get install -y libblocksruntime-dev clang-15
 
       - name: Run sanity checks
         run: make EXTRA_FLAGS=-Werror checks

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -482,8 +482,8 @@ GTEST_DIR = ../../lib/test/gtest
 
 # Use clang/clang++ by default
 
-CC  := clang-12
-CXX := clang++-12
+CC  := clang-15
+CXX := clang++-15
 ifeq ($(shell which $(CC) 2>/dev/null),)
 $(info Falling back to 'clang')
 CC  := clang
@@ -519,7 +519,7 @@ COMMON_FLAGS += -Wno-c99-designator
 COMMON_FLAGS += -Werror
 
 ifeq ($(shell expr $(CC_VERSION_MAJOR) \< $(CC_VERSION_CHECK_MIN) \| $(CC_VERSION_MAJOR) \> $(CC_VERSION_CHECK_MAX)),1)
-$(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-12'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)
+$(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-15'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)
 endif
 
 COMMON_FLAGS += -fblocks


### PR DESCRIPTION
- Merge after #13564 
- Update clang version for CI
- Update clang for running `make test` locally
