### PR TITLE
Fix pointer alignment to 8 bytes for MacOS unit tests

### DIFF
--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -224,6 +224,12 @@ typedef union {
     int32_t d32Max;                           // used for MODE_DIRECT with VAR_INT32
 } cliValueConfig_t;
 
+#ifdef __APPLE__
+#define PTR_PACKING
+#else
+#define PTR_PACKING __attribute__((packed))
+#endif
+
 typedef struct clivalue_s {
     const char *name;
     const uint8_t type;                       // see cliValueFlag_e
@@ -231,7 +237,7 @@ typedef struct clivalue_s {
 
     pgn_t pgn;
     uint16_t offset;
-} __attribute__((packed)) clivalue_t;
+} PTR_PACKING clivalue_t;
 
 
 extern const lookupTableEntry_t lookupTables[];

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -58,6 +58,12 @@ typedef enum
 
 typedef const void *(*CMSEntryFuncPtr)(displayPort_t *displayPort, const void *ptr);
 
+#ifdef __APPLE__
+#define PTR_PACKING
+#else
+#define PTR_PACKING __attribute__((packed))
+#endif
+
 typedef struct
 {
     const char * text;
@@ -65,7 +71,7 @@ typedef struct
     uint16_t flags;
     CMSEntryFuncPtr func;
     void *data;
-} __attribute__((packed)) OSD_Entry;
+} PTR_PACKING OSD_Entry;
 
 // Bits in flags
 #define OSD_MENU_ELEMENT_MASK 0x001f

--- a/src/main/pg/pg.h
+++ b/src/main/pg/pg.h
@@ -67,7 +67,7 @@ static inline uint16_t pgElementSize(const pgRegistry_t* reg) {return (reg->size
 #ifdef __APPLE__
 extern const pgRegistry_t __pg_registry_start[] __asm("section$start$__DATA$__pg_registry");
 extern const pgRegistry_t __pg_registry_end[] __asm("section$end$__DATA$__pg_registry");
-#define PG_REGISTER_ATTRIBUTES __attribute__ ((section("__DATA,__pg_registry"), used, aligned(4)))
+#define PG_REGISTER_ATTRIBUTES __attribute__ ((section("__DATA,__pg_registry"), used, aligned(8)))
 
 extern const uint8_t __pg_resetdata_start[] __asm("section$start$__DATA$__pg_resetdata");
 extern const uint8_t __pg_resetdata_end[] __asm("section$end$__DATA$__pg_resetdata");


### PR DESCRIPTION
Supersedes https://github.com/betaflight/betaflight/pull/13507 since https://github.com/betaflight/betaflight/pull/13551 was merged.