### PR TITLE
Fix inability to use the CLI resource command to configure LPUART_RX.

### DIFF
--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -113,6 +113,6 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "RX_SPI_EXPRESSLRS_BUSY",
     "SOFTSERIAL_TX",
     "SOFTSERIAL_RX",
-    [OWNER_LPUART_TX] = "LPUART_TX",
-    [OWNER_LPUART_RX] = "LPUART_RX",
+    "LPUART_TX",
+    "LPUART_RX",
 };


### PR DESCRIPTION
See https://github.com/betaflight/betaflight/issues/13567#issuecomment-2068693404

There may yet still be other issues, but this definitely fixes the second issue mentioned in the OP of #13567.

~This PR includes a commit from #13565 which was needed for testing, merge #13565 first.~ EDIT: Removed commit from #13565 and just keeping the change to keep the items in `ownerNames` consistent.