### PR TITLE
Fix debug mode DEBUG_ATTITUDE

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -744,8 +744,8 @@ void imuUpdateAttitude(timeUs_t currentTimeUs)
         schedulerIgnoreTaskStateTime();
     }
 
-    DEBUG_SET(DEBUG_ATTITUDE, 0, attitude.values.yaw); // roll
-    DEBUG_SET(DEBUG_ATTITUDE, 1, attitude.values.pitch); // pitch
+    DEBUG_SET(DEBUG_ATTITUDE, 0, attitude.values.roll);
+    DEBUG_SET(DEBUG_ATTITUDE, 1, attitude.values.pitch);
 }
 #endif // USE_ACC
 


### PR DESCRIPTION
Channel 0 was using the wrong input (yaw/heading instead of roll)

ref: #13373