### PR TITLE
bug - flash - SPRASINGH7NANO can't handle 100MHz

### DIFF
--- a/src/main/drivers/flash_w25n01g.c
+++ b/src/main/drivers/flash_w25n01g.c
@@ -353,7 +353,7 @@ bool w25n01g_identify(flashDevice_t *fdevice, uint32_t jedecID)
     fdevice->couldBeBusy = true; // Just for luck we'll assume the chip could be busy even though it isn't specced to be
     fdevice->vTable = &w25n01g_vTable;
 
-    spiSetClkDivisor(fdevice->io.handle.dev, spiCalculateDivider(100000000));
+    //spiSetClkDivisor(fdevice->io.handle.dev, spiCalculateDivider(100000000));
 
     return true;
 }


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/13555 changed SPI speed to 100MHz.  SPRASINGH7NANO (using QUADSPI, so not directly related to #13555) won't boot with this setting.
