### PR TITLE
Remove functionality to enter flash bootloader by sending 'F' on a UART configued for MSP.

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -453,10 +453,6 @@ static void mspEvaluateNonMspData(mspPort_t * mspPort, uint8_t receivedChar)
    } else if (receivedChar == '#') {
         mspPort->pendingRequest = MSP_PENDING_CLI;
 #endif
-#if defined(USE_FLASH_BOOT_LOADER)
-   } else if (receivedChar == 'F') {
-        mspPort->pendingRequest = MSP_PENDING_BOOTLOADER_FLASH;
-#endif
     }
 }
 


### PR DESCRIPTION
The proper way to reboot to the boot loader is by sending an MSP_REBOOT command.

It was added here:
https://github.com/betaflight/betaflight/commit/5cf42f40b6dddd64d59738b3420ad045bf926711#diff-00049baa371593fe10572252c0aff1498ed119bc38c4bedf404143d9a00ac0b2R435-R437

I came across this when developing an ELRS VTX addon board for the H7NEO/H7EVO and had 'MSP' enabled on UART1, when the device is powered on from cold boot there are startup messages emitted by the ROM of the ELRS MCU over it's serial port and one of the characters is an 'F' which causes the FC to reboot into bootloader mode.

Since this only happened on a cold boot, it was very tricky to find the cause as normally debugging methods could not be employed.

[![Watch the video](https://img.youtube.com/vi/ZbAFWn5YX-c/maxresdefault.jpg)](https://youtu.be/ZbAFWn5YX-c)


Additionally, entering the CLI using a single '#' character is probably also bad and could similarly be triggered accidentally.

This PR deletes this unwanted functionality and also serves to determine if the functionality is really needed or not, by way of responses to it.

As far as I know, being the only person and manufacturer of boards using a flash bootloader, we don't need this functionality.
