### PR TITLE
ctznooze's mashup of EZlanding, iterm_leak, and improved yaw feedforward

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1470,7 +1470,6 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DTERM_NOTCH_HZ, "%d",         currentPidProfile->dterm_notch_hz);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DTERM_NOTCH_CUTOFF, "%d",     currentPidProfile->dterm_notch_cutoff);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_WINDUP, "%d",           currentPidProfile->itermWindup);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_LEAK, "%d",             currentPidProfile->itermLeak);
 #if defined(USE_ITERM_RELAX)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_RELAX, "%d",            currentPidProfile->iterm_relax);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_RELAX_TYPE, "%d",       currentPidProfile->iterm_relax_type);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1468,7 +1468,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_YAW_LOWPASS_HZ, "%d",         currentPidProfile->yaw_lowpass_hz);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DTERM_NOTCH_HZ, "%d",         currentPidProfile->dterm_notch_hz);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DTERM_NOTCH_CUTOFF, "%d",     currentPidProfile->dterm_notch_cutoff);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_WINDUP, "%d",           currentPidProfile->itermWindupPointPercent);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_WINDUP, "%d",           currentPidProfile->itermWindup);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_LEAK, "%d",             currentPidProfile->itermLeak);
 #if defined(USE_ITERM_RELAX)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_RELAX, "%d",            currentPidProfile->iterm_relax);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ITERM_RELAX_TYPE, "%d",       currentPidProfile->iterm_relax_type);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1500,6 +1500,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FF_SMOOTHING_MS, "%d",      currentPidProfile->angle_feedforward_smoothing_ms);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN, "%d",  currentPidProfile->feedforward_yaw_hold_gain);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME, "%d",  currentPidProfile->feedforward_yaw_hold_time);
 #endif
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_LIMIT, "%d",                currentPidProfile->angle_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_EARTH_REF, "%d",            currentPidProfile->angle_earth_ref);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1499,7 +1499,6 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_JITTER_FACTOR, "%d",  currentPidProfile->feedforward_jitter_factor);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_BOOST, "%d",          currentPidProfile->feedforward_boost);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_INTERPOLATE, "%d",    currentPidProfile->feedforward_interpolate);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FF_SMOOTHING_MS, "%d",      currentPidProfile->angle_feedforward_smoothing_ms);
 #endif

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1499,6 +1499,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_JITTER_FACTOR, "%d",  currentPidProfile->feedforward_jitter_factor);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_BOOST, "%d",          currentPidProfile->feedforward_boost);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_INTERPOLATE, "%d",    currentPidProfile->feedforward_interpolate);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FF_SMOOTHING_MS, "%d",      currentPidProfile->angle_feedforward_smoothing_ms);
 #endif

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1409,9 +1409,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_BREAKPOINT, "%d",     currentPidProfile->tpa_low_breakpoint);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_ALWAYS, "%d",         currentPidProfile->tpa_low_always);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MIXER_TYPE, "%s",             lookupTableMixerType[mixerConfig()->mixer_type]);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_THRESHOLD, "%d",   currentPidProfile->ez_landing_threshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_LIMIT, "%d",       currentPidProfile->ez_landing_limit);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_SPEED, "%d",       currentPidProfile->ez_landing_speed);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_DISARM_THRESHOLD, "%d",    currentPidProfile->ez_landing_disarm_threshold);
 
 #ifdef USE_WING
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_SPA_ROLL_CENTER, "%d",        currentPidProfile->spa_center[FD_ROLL]);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1409,6 +1409,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_BREAKPOINT, "%d",     currentPidProfile->tpa_low_breakpoint);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_ALWAYS, "%d",         currentPidProfile->tpa_low_always);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_MIXER_TYPE, "%s",             lookupTableMixerType[mixerConfig()->mixer_type]);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_THRESHOLD, "%d",   currentPidProfile->ez_landing_threshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_LIMIT, "%d",       currentPidProfile->ez_landing_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_DISARM_THRESHOLD, "%d",    currentPidProfile->ez_landing_disarm_threshold);
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1134,7 +1134,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_ITERM_RELAX_TYPE,   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ITERM_RELAX_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_type) },
     { PARAM_NAME_ITERM_RELAX_CUTOFF, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff) },
 #endif
-    { PARAM_NAME_ITERM_WINDUP,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 30, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
+    { PARAM_NAME_ITERM_WINDUP,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
     { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
     { PARAM_NAME_PIDSUM_LIMIT,      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },
     { PARAM_NAME_PIDSUM_LIMIT_YAW,  VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimitYaw) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1228,6 +1228,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_FEEDFORWARD_JITTER_FACTOR,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { PARAM_NAME_FEEDFORWARD_BOOST,          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 200}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
+    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN,      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 100}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_gain) },
+    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {10, 250}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_time) },
 #endif
 
 #ifdef USE_DYN_IDLE

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1134,8 +1134,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_ITERM_RELAX_TYPE,   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ITERM_RELAX_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_type) },
     { PARAM_NAME_ITERM_RELAX_CUTOFF, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff) },
 #endif
-    { PARAM_NAME_ITERM_WINDUP,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindupPointPercent) },
-    { "iterm_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLimit) },
+    { PARAM_NAME_ITERM_WINDUP,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 20, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindup) },
+    { PARAM_NAME_ITERM_LEAK,        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLeak) },
     { PARAM_NAME_PIDSUM_LIMIT,      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },
     { PARAM_NAME_PIDSUM_LIMIT_YAW,  VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimitYaw) },
     { PARAM_NAME_YAW_LOWPASS_HZ,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lowpass_hz) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1228,7 +1228,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_FEEDFORWARD_JITTER_FACTOR,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { PARAM_NAME_FEEDFORWARD_BOOST,          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 200}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
-    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN,      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 100}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_gain) },
+    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 100}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_gain) },
     { PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {10, 250}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_time) },
 #endif
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1229,6 +1229,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_FEEDFORWARD_JITTER_FACTOR,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { PARAM_NAME_FEEDFORWARD_BOOST,          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 200}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
+    { PARAM_NAME_FEEDFORWARD_INTERPOLATE,    VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_interpolate) },
 #endif
 
 #ifdef USE_DYN_IDLE

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1135,7 +1135,6 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_ITERM_RELAX_CUTOFF, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, iterm_relax_cutoff) },
 #endif
     { PARAM_NAME_ITERM_WINDUP,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 20, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermWindup) },
-    { PARAM_NAME_ITERM_LEAK,        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermLeak) },
     { PARAM_NAME_PIDSUM_LIMIT,      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },
     { PARAM_NAME_PIDSUM_LIMIT_YAW,  VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PIDSUM_LIMIT_MIN, PIDSUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimitYaw) },
     { PARAM_NAME_YAW_LOWPASS_HZ,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lowpass_hz) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -508,7 +508,7 @@ const char * const lookupTableSimplifiedTuningPidsMode[] = {
 };
 
 const char* const lookupTableMixerType[] = {
-    "LEGACY", "LINEAR", "DYNAMIC", "EZLANDING",
+    "LEGACY", "LINEAR", "DYNAMIC",
 };
 
 #ifdef USE_OSD
@@ -1273,9 +1273,9 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_GRAVITY_THR100, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_GRAVITY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_gravity_thr100) },
 #endif
 
-    { PARAM_NAME_EZ_LANDING_THRESHOLD,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
-    { PARAM_NAME_EZ_LANDING_LIMIT,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 75 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
-    { PARAM_NAME_EZ_LANDING_SPEED,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_speed) },
+    { PARAM_NAME_EZ_LANDING_THRESHOLD, VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
+    { PARAM_NAME_EZ_LANDING_LIMIT,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
+    { PARAM_NAME_EZ_DISARM_THRESHOLD,  VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_disarm_threshold) },
 
 #ifdef USE_WING
     { PARAM_NAME_SPA_ROLL_CENTER,    VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_center[FD_ROLL]) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1229,7 +1229,6 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_FEEDFORWARD_JITTER_FACTOR,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { PARAM_NAME_FEEDFORWARD_BOOST,          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 200}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
-    { PARAM_NAME_FEEDFORWARD_INTERPOLATE,    VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_interpolate) },
 #endif
 
 #ifdef USE_DYN_IDLE

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -559,10 +559,6 @@ static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
 
-static uint8_t cmsx_ez_landing_threshold;
-static uint8_t cmsx_ez_landing_limit;
-static uint8_t cmsx_ez_landing_disarm_threshold;
-
 static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 {
     UNUSED(pDisp);

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -266,6 +266,9 @@ static uint16_t cmsx_tpa_breakpoint;
 static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
+static uint8_t cmsx_ez_landing_threshold;
+static uint8_t cmsx_ez_landing_limit;
+static uint8_t cmsx_ez_landing_disarm_threshold;
 
 static const void *cmsx_simplifiedTuningOnEnter(displayPort_t *pDisp)
 {
@@ -556,6 +559,10 @@ static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
 
+static uint8_t cmsx_ez_landing_threshold;
+static uint8_t cmsx_ez_landing_limit;
+static uint8_t cmsx_ez_landing_disarm_threshold;
+
 static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 {
     UNUSED(pDisp);
@@ -610,6 +617,10 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     cmsx_tpa_low_rate = pidProfile->tpa_low_rate;
     cmsx_tpa_low_breakpoint = pidProfile->tpa_low_breakpoint;
     cmsx_tpa_low_always = pidProfile->tpa_low_always;
+
+    cmsx_ez_landing_threshold = pidProfile->ez_landing_threshold;
+    cmsx_ez_landing_limit = pidProfile->ez_landing_limit;
+    cmsx_ez_landing_disarm_threshold = pidProfile->ez_landing_disarm_threshold;
 
     return NULL;
 }
@@ -668,6 +679,10 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->tpa_low_rate = cmsx_tpa_low_rate;
     pidProfile->tpa_low_breakpoint = cmsx_tpa_low_breakpoint;
     pidProfile->tpa_low_always = cmsx_tpa_low_always;
+
+    pidProfile->ez_landing_threshold = cmsx_ez_landing_threshold;
+    pidProfile->ez_landing_limit = cmsx_ez_landing_limit;
+    pidProfile->ez_landing_disarm_threshold = cmsx_ez_landing_disarm_threshold;
 
     initEscEndpoints();
     return NULL;
@@ -728,6 +743,10 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "TPA LOW RATE",  OME_INT8,   NULL, &(OSD_INT8_t) { &cmsx_tpa_low_rate, TPA_LOW_RATE_MIN, TPA_MAX , 1} },
     { "TPA LOW BRKPT", OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_tpa_low_breakpoint, 1000, 2000, 10} },
     { "TPA LOW ALWYS", OME_Bool,   NULL, &cmsx_tpa_low_always },
+
+    { "EZLAND THRSH",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_threshold,        0,  50, 1} },
+    { "EZLAND LIMIT",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_limit,            1, 100, 1} },
+    { "EZDISARM THR",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_disarm_threshold, 0, 150, 1} },
 
     { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -55,6 +55,7 @@ typedef enum {
     DISARM_REASON_RUNAWAY_TAKEOFF   = 6,
     DISARM_REASON_GPS_RESCUE        = 7,
     DISARM_REASON_SERIAL_COMMAND    = 8,
+    DISARM_REASON_LANDING           = 9,
 #ifdef UNIT_TEST
     DISARM_REASON_SYSTEM            = 255,
 #endif

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -114,6 +114,8 @@
 #define PARAM_NAME_FEEDFORWARD_JITTER_FACTOR "feedforward_jitter_factor"
 #define PARAM_NAME_FEEDFORWARD_BOOST "feedforward_boost"
 #define PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT "feedforward_max_rate_limit"
+#define PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN "feedforward_yaw_hold_gain"
+#define PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME "feedforward_yaw_hold_time"
 #define PARAM_NAME_DYN_IDLE_MIN_RPM "dyn_idle_min_rpm"
 #define PARAM_NAME_DYN_IDLE_P_GAIN "dyn_idle_p_gain"
 #define PARAM_NAME_DYN_IDLE_I_GAIN "dyn_idle_i_gain"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -97,6 +97,7 @@
 #define PARAM_NAME_ITERM_RELAX_TYPE "iterm_relax_type"
 #define PARAM_NAME_ITERM_RELAX_CUTOFF "iterm_relax_cutoff"
 #define PARAM_NAME_ITERM_WINDUP "iterm_windup"
+#define PARAM_NAME_ITERM_LEAK "iterm_leak"
 #define PARAM_NAME_PIDSUM_LIMIT "pidsum_limit"
 #define PARAM_NAME_PIDSUM_LIMIT_YAW "pidsum_limit_yaw"
 #define PARAM_NAME_YAW_LOWPASS_HZ "yaw_lowpass_hz"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -115,6 +115,7 @@
 #define PARAM_NAME_FEEDFORWARD_JITTER_FACTOR "feedforward_jitter_factor"
 #define PARAM_NAME_FEEDFORWARD_BOOST "feedforward_boost"
 #define PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT "feedforward_max_rate_limit"
+#define PARAM_NAME_FEEDFORWARD_INTERPOLATE "feedforward_interpolate"
 #define PARAM_NAME_DYN_IDLE_MIN_RPM "dyn_idle_min_rpm"
 #define PARAM_NAME_DYN_IDLE_P_GAIN "dyn_idle_p_gain"
 #define PARAM_NAME_DYN_IDLE_I_GAIN "dyn_idle_i_gain"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -97,7 +97,6 @@
 #define PARAM_NAME_ITERM_RELAX_TYPE "iterm_relax_type"
 #define PARAM_NAME_ITERM_RELAX_CUTOFF "iterm_relax_cutoff"
 #define PARAM_NAME_ITERM_WINDUP "iterm_windup"
-#define PARAM_NAME_ITERM_LEAK "iterm_leak"
 #define PARAM_NAME_PIDSUM_LIMIT "pidsum_limit"
 #define PARAM_NAME_PIDSUM_LIMIT_YAW "pidsum_limit_yaw"
 #define PARAM_NAME_YAW_LOWPASS_HZ "yaw_lowpass_hz"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -115,7 +115,6 @@
 #define PARAM_NAME_FEEDFORWARD_JITTER_FACTOR "feedforward_jitter_factor"
 #define PARAM_NAME_FEEDFORWARD_BOOST "feedforward_boost"
 #define PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT "feedforward_max_rate_limit"
-#define PARAM_NAME_FEEDFORWARD_INTERPOLATE "feedforward_interpolate"
 #define PARAM_NAME_DYN_IDLE_MIN_RPM "dyn_idle_min_rpm"
 #define PARAM_NAME_DYN_IDLE_P_GAIN "dyn_idle_p_gain"
 #define PARAM_NAME_DYN_IDLE_I_GAIN "dyn_idle_i_gain"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -64,7 +64,7 @@
 #define PARAM_NAME_MIXER_TYPE "mixer_type"
 #define PARAM_NAME_EZ_LANDING_THRESHOLD "ez_landing_threshold"
 #define PARAM_NAME_EZ_LANDING_LIMIT "ez_landing_limit"
-#define PARAM_NAME_EZ_LANDING_SPEED "ez_landing_speed"
+#define PARAM_NAME_EZ_DISARM_THRESHOLD "ez_landing_disarm_threshold"
 #define PARAM_NAME_SPA_ROLL_CENTER "spa_roll_center"
 #define PARAM_NAME_SPA_ROLL_WIDTH "spa_roll_width"
 #define PARAM_NAME_SPA_ROLL_MODE "spa_roll_mode"

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -63,7 +63,6 @@ static float rawSetpoint[XYZ_AXIS_COUNT];
 
 static float setpointRate[3], rcDeflection[3], rcDeflectionAbs[3]; // deflection range -1 to 1
 static float maxRcDeflectionAbs;
-
 static bool reverseMotors = false;
 static applyRatesFn *applyRates;
 
@@ -141,11 +140,6 @@ float getRcDeflectionRaw(int axis)
 float getRcDeflectionAbs(int axis)
 {
     return rcDeflectionAbs[axis];
-}
-
-float getMaxRcDeflectionAbs(void)
-{
-    return maxRcDeflectionAbs;
 }
 
 #define THROTTLE_LOOKUP_LENGTH 12
@@ -660,12 +654,15 @@ FAST_CODE void processRcCommand(void)
                 angleRate = applyRates(axis, rcCommandf, rcCommandfAbs);
             }
 
+
             rawSetpoint[axis] = constrainf(angleRate, -1.0f * currentControlRateProfile->rate_limit[axis], 1.0f * currentControlRateProfile->rate_limit[axis]);
             DEBUG_SET(DEBUG_ANGLERATE, axis, angleRate);
 
 #ifdef USE_FEEDFORWARD
         calculateFeedforward(&pidRuntime, axis);
 #endif // USE_FEEDFORWARD
+
+        calcEzLandingLimit(maxRcDeflectionAbs);
 
         }
         // adjust unfiltered setpoint steps to camera angle (mixing Roll and Yaw)

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -635,12 +635,12 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
         const float setpointLpfYaw = prevSetpointYaw + kFY * (setpoint - prevSetpointYaw);
         prevSetpointYaw = setpointLpfYaw;
         // provide separate boost gain for yaw; value of 20 works well for 5in, zero disables
-        const float feedforwardYawHoldGain = pid->feedforwardYawHoldGain * (setpoint - setpointLpfYaw);
+        const float feedforwardYawHold = pid->feedforwardYawHoldGain * (setpoint - setpointLpfYaw);
 
-        DEBUG_SET(DEBUG_FEEDFORWARD, 6, lrintf(feedforward * 0.01f));  // yaw feedforward without boost
-        DEBUG_SET(DEBUG_FEEDFORWARD, 7, lrintf(feedforwardYawHoldGain * 0.01f));  // boost element for yaw
+        DEBUG_SET(DEBUG_FEEDFORWARD, 6, lrintf(feedforward * 0.01f));  // basic yaw feedforward without hold element
+        DEBUG_SET(DEBUG_FEEDFORWARD, 7, lrintf(feedforwardYawHold * 0.01f));  // yaw feedforward hold element
 
-        feedforward += feedforwardYawHoldGain;
+        feedforward += feedforwardYawHold;
         // NB: yaw doesn't need max rate limiting since it rarely overshoots
     }
 
@@ -651,12 +651,12 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
     }
 
     if (axis == FD_ROLL) {
-        DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint)); // un-smoothed setpoint value used for FF
-        DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * 0.01f));         // setpoint speed smoothed
-        DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * 0.01f));  // acceleration smoothed
+        DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint)); // un-smoothed (raw) setpoint value used for FF
+        DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * 0.01f));         // smoothed and interpolated basic feedfoward element
+        DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * 0.01f));  // acceleration (boost) smoothed
         DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 10.0f));
         DEBUG_SET(DEBUG_FEEDFORWARD, 4, lrintf(jitterAttenuator * 100.0f));     // jitter attenuation percent
-        DEBUG_SET(DEBUG_FEEDFORWARD, 5, (int16_t)(prevDuplicatePacket[axis]));  // it a duplicate
+        DEBUG_SET(DEBUG_FEEDFORWARD, 5, (int16_t)(prevDuplicatePacket[axis]));  // previous packet was a duplicate
 
         DEBUG_SET(DEBUG_FEEDFORWARD_LIMIT, 0, lrintf(jitterAttenuator * 100.0f)); // jitter attenuation factor in percent
         DEBUG_SET(DEBUG_FEEDFORWARD_LIMIT, 1, lrintf(maxRcRate[axis])); // max RC rate

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -523,12 +523,11 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
     float setpointAcceleration = 0.0f;
     float feedforward = 0.0f;
 
-    // for FrSky and other systems that send duplicate packets to the FC when sending telemetry
     if (!pid->feedforwardInterpolate) {
-        // don't interpolate CRSF, ELRS, and other systems without this problem
+        // don't interpolate CRSF, ELRS, and other systems that don't send duplicate packets during telemetry sends
         setpointSpeed *= rxRate;
     } else {
-        // for FrSky, interpolate setpointSpeed remove steps in setpointSpeed when telemetry packets are sent
+        // for those which do send duplicates, interpolate setpointSpeed to remove steps in feedforward
         if (rcCommandDeltaAbs) {
             // movement!
             // next valid step will be larger if a duplicate was sent because the time interval will be longer

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -581,6 +581,12 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
     if (axis == FD_ROLL) {
         DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * 0.01f));         // setpoint speed smoothed
         DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(setpointAcceleration * 0.01f));  // acceleration smoothed
+        if (prevDuplicatePacket[axis]) {
+            DEBUG_SET(DEBUG_FEEDFORWARD, 6, 0);  // it a duplicate
+        } else {
+            DEBUG_SET(DEBUG_FEEDFORWARD, 6, 1);  // not a duplicate
+        }
+
     }
 
     // apply jitter attenuation to classic feedforward elements only (twice on acceleaertion)

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -570,7 +570,8 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
     // note that the jitter reduction attenuates a smoothed value of feedforward which has useful data even when rcCommandDelta is zero
     float jitterAttenuator = 1.0f;
     if (rcCommandDeltaAbs <= pid->feedforwardJitterFactor) {
-        jitterAttenuator = (rcCommandDeltaAbs + 1.0f) * pid->feedforwardJitterFactorInv;
+        jitterAttenuator = ((rcCommandDeltaAbs + prevRcCommandDeltaAbs[axis]) * 0.5f + 1.0f) * pid->feedforwardJitterFactorInv;
+        jitterAttenuator = MIN(jitterAttenuator, 1.0f);
     }
     prevRcCommandDeltaAbs[axis] = rcCommandDeltaAbs;
 
@@ -598,6 +599,7 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
         } else {
             DEBUG_SET(DEBUG_FEEDFORWARD, 6, 1);  // not a duplicate
         }
+        DEBUG_SET(DEBUG_FEEDFORWARD, 7, lrintf(jitterAttenuator * 100.0f));  // jitter factor
     }
 
     // apply jitter attenuation to final feedforward value

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -34,7 +34,7 @@ float getSetpointRate(int axis);
 float getRcDeflection(int axis);
 float getRcDeflectionRaw(int axis);
 float getRcDeflectionAbs(int axis);
-float getMaxRcDeflectionAbs(void);
+void calcEzLandingLimit(float maxRcDeflectionAbs);
 void updateRcCommands(void);
 void resetYawAxis(void);
 void initRcProcessing(void);

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -323,18 +323,10 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
     }
 }
 
-static bool imuIsAccelerometerHealthy(const float *accAverage)
+static bool imuIsAccelerometerHealthy(void)
 {
-    float accMagnitudeSq = 0;
-    for (int axis = 0; axis < 3; axis++) {
-        const float a = accAverage[axis];
-        accMagnitudeSq += a * a;
-    }
-
-    accMagnitudeSq = accMagnitudeSq * sq(acc.dev.acc_1G_rec);
-
     // Accept accel readings only in range 0.9g - 1.1g
-    return (0.81f < accMagnitudeSq) && (accMagnitudeSq < 1.21f);
+    return (0.9f < acc.accMagnitude) && (acc.accMagnitude < 1.1f);
 }
 
 // Calculate the dcmKpGain to use. When armed, the gain is imuRuntimeConfig.imuDcmKp, i.e., the default value
@@ -687,8 +679,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
         gyroAverage[axis] = gyroGetFilteredDownsampled(axis);
     }
 
-    const bool useAcc = imuIsAccelerometerHealthy(acc.accADC); // all smoothed accADC values are within 20% of 1G
-
+    const bool useAcc = imuIsAccelerometerHealthy(); // all smoothed accADC values are within 10% of 1G
     imuMahonyAHRSupdate(dt,
                         DEGREES_TO_RADIANS(gyroAverage[X]), DEGREES_TO_RADIANS(gyroAverage[Y]), DEGREES_TO_RADIANS(gyroAverage[Z]),
                         useAcc, acc.accADC[X], acc.accADC[Y], acc.accADC[Z],

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,7 +100,7 @@ void stopMotors(void)
 }
 
 static FAST_DATA_ZERO_INIT float throttle = 0;
-static float basicThrottle = 0;
+static FAST_DATA_ZERO_INIT float rcThrottle = 0;
 static FAST_DATA_ZERO_INIT float mixerThrottle = 0;
 static FAST_DATA_ZERO_INIT float motorOutputMin;
 static FAST_DATA_ZERO_INIT float motorRangeMin;
@@ -265,7 +265,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
     }
 
     throttle = constrainf(throttle / currentThrottleInputRange, 0.0f, 1.0f);
-    basicThrottle = throttle;
+    rcThrottle = throttle;
 }
 
 #define CRASH_FLIP_DEADBAND 20
@@ -707,5 +707,5 @@ float mixerGetThrottle(void)
 
 float mixerGetRcThrottle(void)
 {
-    return basicThrottle;
+    return rcThrottle;
 }

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -71,7 +71,6 @@ typedef enum mixerType
     MIXER_LEGACY = 0,
     MIXER_LINEAR = 1,
     MIXER_DYNAMIC = 2,
-    MIXER_EZLANDING = 3,
 } mixerType_e;
 
 // Custom mixer data per motor
@@ -140,6 +139,7 @@ bool mixerIsTricopter(void);
 
 void mixerSetThrottleAngleCorrection(int correctionValue);
 float mixerGetThrottle(void);
+float mixerGetRcThrottle(void);
 mixerMode_e getMixerMode(void);
 bool mixerModeIsFixedWing(mixerMode_e mixerMode);
 bool isFixedWing(void);

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -366,10 +366,6 @@ void mixerInitProfile(void)
     pt1FilterInit(&mixerRuntime.rpmLimiterThrottleScaleOffsetFilter, pt1FilterGain(2.0f, pidGetDT()));
     mixerResetRpmLimiter();
 #endif
-
-    mixerRuntime.ezLandingThreshold = 2.0f * currentPidProfile->ez_landing_threshold / 100.0f;
-    mixerRuntime.ezLandingLimit = currentPidProfile->ez_landing_limit / 100.0f;
-    mixerRuntime.ezLandingSpeed = 2.0f * currentPidProfile->ez_landing_speed / 10.0f;
 }
 
 #ifdef USE_RPM_LIMIT

--- a/src/main/flight/mixer_init.h
+++ b/src/main/flight/mixer_init.h
@@ -64,9 +64,6 @@ typedef struct mixerRuntime_s {
     pt1Filter_t rpmLimiterAverageRpmFilter;
     pt1Filter_t rpmLimiterThrottleScaleOffsetFilter;
 #endif
-    float ezLandingThreshold;
-    float ezLandingLimit;
-    float ezLandingSpeed;
 } mixerRuntime_t;
 
 extern mixerRuntime_t mixerRuntime;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -777,7 +777,6 @@ float pidGetAirmodeThrottleOffset(void)
 #endif
 
 
-
 // ezLanding stuff
 static bool applyEzLandingLimiting = false;
 static float ezLandingLimit = PIDSUM_LIMIT;
@@ -785,7 +784,7 @@ static float maxDeflectionAbs = 1.0f;
 
 // EzLanding factors are updated only when new Rx data is received in rc.c
 // this will cause steps in PID as the limiting value changes
-void calcEzLandingLimit(float maxRcDeflectionAbs)
+FAST_CODE_NOINLINE void calcEzLandingLimit(float maxRcDeflectionAbs)
 {
     if (pidRuntime.useEzLanding && !isFlipOverAfterCrashActive()) {
         maxDeflectionAbs = fmaxf(maxRcDeflectionAbs, mixerGetRcThrottle());
@@ -801,8 +800,7 @@ void calcEzLandingLimit(float maxRcDeflectionAbs)
     DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
 }
 
-
-static void disarmOnImpact(void)
+static FAST_CODE_NOINLINE void disarmOnImpact(void)
 {
     // if both sticks are within 5% of center, check acc magnitude for impacts
     // at half the impact threshold, force iTerm to zero, to attenuate iTerm-mediated bouncing
@@ -821,7 +819,6 @@ static void disarmOnImpact(void)
         }
     }
 }
-
 
 #ifdef USE_LAUNCH_CONTROL
 #define LAUNCH_CONTROL_MAX_RATE 100.0f

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -228,8 +228,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_breakpoint = 1050,
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
-        .ez_landing_limit = 15,
-        .ez_landing_disarm_threshold = 110,
+        .ez_landing_limit = 0, // off for this PR
+        .ez_landing_disarm_threshold = 110, // unlikely to trigger, ie off; 60 - 80 is more useful
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -804,23 +804,16 @@ FAST_CODE_NOINLINE void calcEzLandingLimit(float maxRcDeflectionAbs)
 static FAST_CODE_NOINLINE void disarmOnImpact(void)
 {
     // if both sticks are within 5% of center, check acc magnitude for impacts
-    // at half the impact threshold, force iTerm to zero, to attenuate iTerm-mediated bouncing
     // threshold should be highe enough to avoid unwanted disarms in the air on throttle chops
 
-    // normally these lines would be inside the dedflection test, I just want to know the values all the time for now
+    // normally the acc calculation would be done only when required, but having them here lets us log the acc magnitude in normal flight
     float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
     DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(accMagnitude * 10));
 
-    if (isAirmodeActivated() && maxDeflectionAbs < 0.05f) {
-        if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
-            // disarm after big bumps
-            setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
-            disarm(DISARM_REASON_LANDING);
-        } else if (accMagnitude > (0.3f * pidRuntime.ezLandingDisarmThreshold)) {
-            // force iTerm to zero on all axes on smaller bumps
-            pidResetIterm();
-            // after reset, iTerm will slowly re-accumulate
-        }
+    if (isAirmodeActivated() && maxDeflectionAbs < 0.05f && accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
+        // disarm after big bumps
+        setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+        disarm(DISARM_REASON_LANDING);
     }
 }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -236,7 +236,6 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .spa_center = { 0, 0, 0 },
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
-        .itermLeak = 15,
     );
 
 #ifndef USE_D_MIN
@@ -1129,7 +1128,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         // -----calculate I component
         float Ki = pidRuntime.pidCoefficient[axis].Ki;
         float itermLimit = pidRuntime.itermLimit; // windup fraction of pidSumLimit
-        float iTermLeak = 0.0f;
 
 #ifdef USE_LAUNCH_CONTROL
         // if launch control is active override the iterm gains and apply iterm windup protection to all axes
@@ -1141,7 +1139,6 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
             // handle yaw iTerm limit differently from other axes, and make yaw iTerm leaky
             if (axis == FD_YAW) {
-                iTermLeak = pidData[axis].I * pidRuntime.itermLeakRateYaw;
                 itermLimit = pidRuntime.itermLimitYaw; // windup fraction of pidSumLimitYaw
                 // note that this is a stronger limit than previously
                 pidRuntime.itermAccelerator = 0.0f; // no antigravity on yaw iTerm
@@ -1162,12 +1159,12 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 //        // Existing iterm_Relax may need a lower cutoff for cases of motor saturation during yaws.
 //        // This may be too aggressive, limiting iTerm growth too much.
 //        // Also will apply for un-commanded errors, weakening ability to return to previous heading
-//        float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate - iTermLeak;
+//        float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate;
 //        if (fabsf(pidData[axis].Sum) >= pidSumLimit && iTermChange * pidData[axis].I > 0) {
 //            iTermChange = 0.0f;
 //        }
 
-        const float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate - iTermLeak;
+        const float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate;
 
 #ifdef USE_WING
         if (pidProfile->spa_mode[axis] != SPA_MODE_OFF) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -230,14 +230,13 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .ez_landing_threshold = 25,
         .ez_landing_limit = 15,
         .ez_landing_disarm_threshold = 110,
-        .ez_landing_speed = 50,
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,
         .spa_center = { 0, 0, 0 },
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
-        .itermLeak = 30,
+        .itermLeak = 15,
     );
 
 #ifndef USE_D_MIN

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -236,6 +236,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .spa_center = { 0, 0, 0 },
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
+        .feedforward_yaw_hold_gain = 15,  // zero disables; 15-20 is OK for 5in
+        .feedforward_yaw_hold_time = 100,  // a value of 100 is a time constant of about 100ms, and is OK for a 5in; smaller values decay faster, eg for smaller props
     );
 
 #ifndef USE_D_MIN

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -237,6 +237,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
         .itermLeak = 15,
+        .feedforward_interpolate = false,
     );
 
 #ifndef USE_D_MIN

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -641,7 +641,7 @@ static void rotateVector(float v[XYZ_AXIS_COUNT], const float rotation[XYZ_AXIS_
     }
 }
 
-STATIC_UNIT_TESTED void rotateItermAndAxisError(void)
+STATIC_UNIT_TESTED FAST_CODE_NOINLINE void rotateItermAndAxisError(void)
 {
     if (pidRuntime.itermRotation
 #if defined(USE_ABSOLUTE_CONTROL)
@@ -673,7 +673,7 @@ STATIC_UNIT_TESTED void rotateItermAndAxisError(void)
 
 #if defined(USE_ITERM_RELAX)
 #if defined(USE_ABSOLUTE_CONTROL)
-STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
+STATIC_UNIT_TESTED FAST_CODE_NOINLINE void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
 {
     if (pidRuntime.acGain > 0 || debugMode == DEBUG_AC_ERROR) {
         const float setpointLpf = pt1FilterApply(&pidRuntime.acLpf[axis], *currentPidSetpoint);
@@ -863,7 +863,7 @@ static FAST_CODE_NOINLINE float applyLaunchControl(int axis, const rollAndPitchT
 }
 #endif
 
-static float getSterm(int axis, const pidProfile_t *pidProfile)
+static FAST_CODE_NOINLINE float getSterm(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     const float sTerm = getSetpointRate(axis) / getMaxRcRate(axis) * 1000.0f *
@@ -879,7 +879,7 @@ static float getSterm(int axis, const pidProfile_t *pidProfile)
 #endif
 }
 
-NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
+static FAST_CODE_NOINLINE void calculateSpaValues(const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
@@ -893,7 +893,7 @@ NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
 #endif // #ifdef USE_WING ... #else
 }
 
-NOINLINE static void applySpa(int axis, const pidProfile_t *pidProfile)
+static FAST_CODE_NOINLINE void applySpa(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     switch(pidProfile->spa_mode[axis]){

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -116,7 +116,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 8);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 9);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -229,6 +229,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_low_always = 0,
         .ez_landing_threshold = 25,
         .ez_landing_limit = 15,
+        .ez_landing_disarm_threshold = 110,
         .ez_landing_speed = 50,
         .tpa_delay_ms = 0,
         .tpa_gravity_thr0 = 0,
@@ -512,6 +513,7 @@ static FAST_CODE_NOINLINE void detectAndSetCrashRecovery(
 {
     // if crash recovery is on and accelerometer enabled and there is no gyro overflow, then check for a crash
     // no point in trying to recover if the crash is so severe that the gyro overflows
+    // automatically enable in a GPS Rescue, in case we hit a tree or a person
     if ((crash_recovery || FLIGHT_MODE(GPS_RESCUE_MODE)) && !gyroOverflowDetected()) {
         if (ARMING_FLAG(ARMED)) {
             if (getMotorMixRange() >= 1.0f && !pidRuntime.inCrashRecoveryMode
@@ -774,6 +776,53 @@ float pidGetAirmodeThrottleOffset(void)
 }
 #endif
 
+
+
+// ezLanding stuff
+static bool applyEzLandingLimiting = false;
+static float ezLandingLimit = PIDSUM_LIMIT;
+static float maxDeflectionAbs = 1.0f;
+
+// EzLanding factors are updated only when new Rx data is received in rc.c
+// this will cause steps in PID as the limiting value changes
+void calcEzLandingLimit(float maxRcDeflectionAbs)
+{
+    if (pidRuntime.useEzLanding && !isFlipOverAfterCrashActive()) {
+        maxDeflectionAbs = fmaxf(maxRcDeflectionAbs, mixerGetRcThrottle());
+        if (maxDeflectionAbs < pidRuntime.ezLandingThreshold) {
+            ezLandingLimit = fmaxf(pidRuntime.ezLandingLimit, PIDSUM_LIMIT * maxDeflectionAbs / pidRuntime.ezLandingThreshold);
+            // 15-500 with defaults
+            applyEzLandingLimiting = true;
+        } else {
+            applyEzLandingLimiting = false;
+        }
+    }
+    DEBUG_SET(DEBUG_EZLANDING, 0, ezLandingLimit * 100);
+    DEBUG_SET(DEBUG_EZLANDING, 1, maxDeflectionAbs * 100);
+}
+
+
+static void disarmOnImpact(void)
+{
+    // if both sticks are within 5% of center, check acc magnitude for impacts
+    // at half the impact threshold, force iTerm to zero, to attenuate iTerm-mediated bouncing
+    // threshold should be highe enough to avoid unwanted disarms in the air on throttle chops
+    if (isAirmodeActivated() && maxDeflectionAbs < 0.05f) {
+        float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
+        DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(accMagnitude * 10));
+        if (accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
+            // disarm after big bumps
+            setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+            disarm(DISARM_REASON_LANDING);
+        } else if (accMagnitude > (0.3f * pidRuntime.ezLandingDisarmThreshold)) {
+            // force iTerm to zero on all axes on smaller bumps
+            pidResetIterm();
+            // after reset, iTerm will slowly re-accumulate
+        }
+    }
+}
+
+
 #ifdef USE_LAUNCH_CONTROL
 #define LAUNCH_CONTROL_MAX_RATE 100.0f
 #define LAUNCH_CONTROL_MIN_RATE 5.0f
@@ -974,6 +1023,10 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     rpmFilterUpdate();
 #endif
 
+    if (pidRuntime.useEzDisarm) {
+        disarmOnImpact();
+    }
+
     // ----------PID controller----------
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
 
@@ -1043,6 +1096,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
         const float previousIterm = pidData[axis].I;
         float itermErrorRate = errorRate;
+
 #ifdef USE_ABSOLUTE_CONTROL
         const float uncorrectedSetpoint = currentPidSetpoint;
 #endif
@@ -1056,6 +1110,18 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 #ifdef USE_ABSOLUTE_CONTROL
         const float setpointCorrection = currentPidSetpoint - uncorrectedSetpoint;
 #endif
+
+        // *** EzLanding error limiter on error for P ***
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_EZLANDING, 2, errorRate); // before attenuation
+        }
+        if (applyEzLandingLimiting) {
+            errorRate = constrainf(errorRate, -ezLandingLimit, ezLandingLimit);
+
+        }
+        if (axis == FD_ROLL) {
+            DEBUG_SET(DEBUG_EZLANDING, 3, errorRate); // after attenuation
+        }
 
         // --------low-level gyro-based PID based on 2DOF PID controller. ----------
 
@@ -1080,13 +1146,21 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             }
         }
 
-        float iTermChange = (Ki + pidRuntime.itermAccelerator) * dynCi * pidRuntime.dT * itermErrorRate;
+        // *** EzLanding error limiter on error for the input to the ITerm accumulator ***
+        //  - unfortunately iTermErrorRate is different from errorRate used by P, otherwise this is wasteful
+        if (applyEzLandingLimiting) {
+            itermErrorRate = constrainf(itermErrorRate, -ezLandingLimit, ezLandingLimit);
+        }
+
+        const float iTermChange = (Ki + pidRuntime.itermAccelerator) * dynCi * pidRuntime.dT * itermErrorRate;
+
 #ifdef USE_WING
         if (pidProfile->spa_mode[axis] != SPA_MODE_OFF) {
             // slowing down I-term change, or even making it zero if setpoint is high enough
             iTermChange *= pidRuntime.spa[axis];
         }
 #endif // #ifdef USE_WING
+
         pidData[axis].I = constrainf(previousIterm + iTermChange, -pidRuntime.itermLimit, pidRuntime.itermLimit);
 
         // -----calculate D component
@@ -1151,6 +1225,12 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             // Apply the dMinFactor
             preTpaD *= dMinFactor;
 #endif
+
+            // *** EzLanding limiter on DTerm ***
+            if (applyEzLandingLimiting) {
+                preTpaD = constrainf(preTpaD, -ezLandingLimit, ezLandingLimit);
+            }
+
             pidData[axis].D = preTpaD * pidRuntime.tpaFactor;
 
             // Log the value of D pre application of TPA

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -237,7 +237,6 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
         .itermLeak = 15,
-        .feedforward_interpolate = false,
     );
 
 #ifndef USE_D_MIN

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -133,7 +133,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .yaw_lowpass_hz = 100,
         .dterm_notch_hz = 0,
         .dterm_notch_cutoff = 0,
-        .itermWindupPointPercent = 30, // now used for 'leaky iTerm' on yaw, temporarily, for testing
+        .itermWindupPointPercent = 60, // now used for 'leaky iTerm' on yaw, temporarily, for testing
         .pidAtMinThrottle = PID_STABILISATION_ON,
         .angle_limit = 60,
         .feedforward_transition = 0,
@@ -1159,7 +1159,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             itermErrorRate = constrainf(itermErrorRate, -ezLandingLimit, ezLandingLimit);
         }
 
-        const float iTermChange = (Ki + pidRuntime.itermAccelerator) * dynCi * pidRuntime.dT * itermErrorRate;
+        const float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate - iTermLeak;
 
 #ifdef USE_WING
         if (pidProfile->spa_mode[axis] != SPA_MODE_OFF) {
@@ -1168,7 +1168,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
 #endif // #ifdef USE_WING
 
-        pidData[axis].I = constrainf(previousIterm + iTermChange - iTermLeak, -itermLimit, itermLimit);
+        pidData[axis].I = constrainf(previousIterm + iTermChange, -itermLimit, itermLimit);
 
         // -----calculate D component
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1150,6 +1150,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             if (axis == FD_YAW) {
                 iTermLeak = pidData[axis].I * pidRuntime.itermLeakRateYaw;
                 itermLimit = pidRuntime.itermLimitYaw; // windup fraction of pidSumLimitYaw
+                // note that this is a stronger limit than previously
                 pidRuntime.itermAccelerator = 0.0f; // no antigravity on yaw iTerm
             }
         }
@@ -1159,6 +1160,16 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         if (applyEzLandingLimiting) {
             itermErrorRate = constrainf(itermErrorRate, -ezLandingLimit, ezLandingLimit);
         }
+
+//        // Alternate method for limiting iTerm growth when pidSum reaches pidSumLimit and change is in same direction as I
+//        // Without this, iTerm can grow to its limit when motors saturate or yaw pidSum reaches the limit
+//        // Existing iterm_Relax may need a lower cutoff for cases of motor saturation during yaws.
+//        // This may be too aggressive, limiting iTerm growth too much.
+//        // Also will apply for un-commanded errors, weakening ability to return to previous heading
+//        float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate - iTermLeak;
+//        if (fabsf(pidData[axis].Sum) >= pidSumLimit && iTermChange * pidData[axis].I > 0) {
+//            iTermChange = 0.0f;
+//        }
 
         const float iTermChange = (Ki + pidRuntime.itermAccelerator) * pidRuntime.dT * itermErrorRate - iTermLeak;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -337,7 +337,6 @@ typedef struct pidRuntime_s {
     float horizonLimitDegreesInv;
     float horizonIgnoreSticks;
     float maxVelocity[XYZ_AXIS_COUNT];
-    float itermWindupPointInv;
     bool inCrashRecoveryMode;
     timeUs_t crashDetectedAtUs;
     timeDelta_t crashTimeLimitUs;
@@ -348,7 +347,9 @@ typedef struct pidRuntime_s {
     float crashDtermThreshold;
     float crashSetpointThreshold;
     float crashLimitYaw;
+    float itermLeakRateYaw;
     float itermLimit;
+    float pidSumLimitYaw;
     bool itermRotation;
     bool zeroThrottleItermReset;
     bool levelRaceMode;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -228,7 +228,9 @@ typedef struct pidProfile_s {
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward
     uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
     uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
-
+    uint8_t feedforward_yaw_hold_gain;          // Amount of sustained high-pass yaw setpoint to add to feedforward, zero disables
+    uint8_t feedforward_yaw_hold_time ;     // Time constant of the sustained yaw hold element in ms to add to feed forward, higher values decay slower
+    
     uint8_t dterm_lpf1_dyn_expo;            // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calculation is gyro based in level mode
     uint8_t vbat_sag_compensation;          // Reduce motor output by this percentage of the maximum compensation amount
@@ -438,6 +440,8 @@ typedef struct pidRuntime_s {
     float feedforwardTransition;
     float feedforwardTransitionInv;
     uint8_t feedforwardMaxRateLimit;
+    uint8_t feedforwardYawHoldGain;
+    uint8_t feedforwardYawHoldTime;
     bool feedforwardInterpolate; // Whether to interpolate an FF value for duplicate/identical data values 
 
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -158,9 +158,9 @@ typedef struct pidProfile_s {
     pidf_t  pid[PID_ITEM_COUNT];
 
     uint8_t dterm_lpf1_type;                // Filter type for dterm lowpass 1
-    uint8_t itermWindupPointPercent;        // iterm windup threshold, percent motor saturation
-    uint16_t pidSumLimit;
-    uint16_t pidSumLimitYaw;
+    uint8_t itermWindup;                    // iterm windup threshold, percentage of pidSumLimit within which to limit iTerm
+    uint16_t pidSumLimit;                   // pidSum limit value for yaw
+    uint16_t pidSumLimitYaw;                // pidSum limit value for yaw
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.
     uint8_t angle_limit;                    // Max angle in degrees in Angle mode
 
@@ -267,6 +267,7 @@ typedef struct pidProfile_s {
     uint8_t spa_mode[XYZ_AXIS_COUNT];       // SPA mode for each axis
     uint16_t tpa_gravity_thr0;               // For wings: addition to tpa argument in % when zero throttle
     uint16_t tpa_gravity_thr100;             // For wings: addition to tpa argument in % when full throttle
+    uint8_t itermLeak;                      // Fractional rate at which iTerm on yaw leaks towards zero, arbitrary units
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -349,7 +350,7 @@ typedef struct pidRuntime_s {
     float crashLimitYaw;
     float itermLeakRateYaw;
     float itermLimit;
-    float pidSumLimitYaw;
+    float itermLimitYaw;
     bool itermRotation;
     bool zeroThrottleItermReset;
     bool levelRaceMode;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -260,7 +260,7 @@ typedef struct pidProfile_s {
 
     uint8_t ez_landing_threshold;           // Threshold stick position below which motor output is limited
     uint8_t ez_landing_limit;               // Maximum motor output when all sticks centred and throttle zero
-    uint8_t ez_landing_speed;               // Speed below which motor output is limited
+    uint8_t ez_landing_disarm_threshold;    // Accelerometer vector threshold which disarms if exceeded
     uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter (time constant)
     uint16_t spa_center[XYZ_AXIS_COUNT];    // RPY setpoint at which PIDs are reduced to 50% (setpoint PID attenuation)
     uint16_t spa_width[XYZ_AXIS_COUNT];     // Width of smooth transition around spa_center
@@ -358,6 +358,11 @@ typedef struct pidRuntime_s {
     float tpaLowBreakpoint;
     float tpaLowMultiplier;
     bool tpaLowAlways;
+    bool useEzLanding;
+    float ezLandingThreshold;
+    float ezLandingLimit;
+    bool useEzDisarm;
+    float ezLandingDisarmThreshold;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
@@ -479,6 +484,7 @@ void pidUpdateAntiGravityThrottleFilter(float throttle);
 bool pidOsdAntiGravityActive(void);
 void pidSetAntiGravityState(bool newState);
 bool pidAntiGravityEnabled(void);
+
 
 #ifdef USE_THRUST_LINEARIZATION
 float pidApplyThrustLinearization(float motorValue);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -228,6 +228,7 @@ typedef struct pidProfile_s {
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward
     uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
     uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
+    uint8_t feedforward_interpolate;        // Whether to interpolate a value for duplicate/identical data values 
 
     uint8_t dterm_lpf1_dyn_expo;            // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calculation is gyro based in level mode
@@ -440,6 +441,7 @@ typedef struct pidRuntime_s {
     float feedforwardTransition;
     float feedforwardTransitionInv;
     uint8_t feedforwardMaxRateLimit;
+    bool feedforwardInterpolate;
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
 #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -267,7 +267,6 @@ typedef struct pidProfile_s {
     uint8_t spa_mode[XYZ_AXIS_COUNT];       // SPA mode for each axis
     uint16_t tpa_gravity_thr0;               // For wings: addition to tpa argument in % when zero throttle
     uint16_t tpa_gravity_thr100;             // For wings: addition to tpa argument in % when full throttle
-    uint8_t itermLeak;                      // Fractional rate at which iTerm on yaw leaks towards zero, arbitrary units
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -348,7 +347,6 @@ typedef struct pidRuntime_s {
     float crashDtermThreshold;
     float crashSetpointThreshold;
     float crashLimitYaw;
-    float itermLeakRateYaw;
     float itermLimit;
     float itermLimitYaw;
     bool itermRotation;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -228,7 +228,6 @@ typedef struct pidProfile_s {
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward
     uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
     uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
-    uint8_t feedforward_interpolate;        // Whether to interpolate a value for duplicate/identical data values 
 
     uint8_t dterm_lpf1_dyn_expo;            // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calculation is gyro based in level mode
@@ -441,7 +440,8 @@ typedef struct pidRuntime_s {
     float feedforwardTransition;
     float feedforwardTransitionInv;
     uint8_t feedforwardMaxRateLimit;
-    bool feedforwardInterpolate;
+    bool feedforwardInterpolate; // Whether to interpolate an FF value for duplicate/identical data values 
+
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
 #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -440,8 +440,8 @@ typedef struct pidRuntime_s {
     float feedforwardTransition;
     float feedforwardTransitionInv;
     uint8_t feedforwardMaxRateLimit;
-    uint8_t feedforwardYawHoldGain;
-    uint8_t feedforwardYawHoldTime;
+    float feedforwardYawHoldGain;
+    float feedforwardYawHoldTime;
     bool feedforwardInterpolate; // Whether to interpolate an FF value for duplicate/identical data values 
 
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -311,8 +311,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashTimeDelayUs = pidProfile->crash_delay * 1000;
     pidRuntime.crashRecoveryAngleDeciDegrees = pidProfile->crash_recovery_angle * 10;
     pidRuntime.crashRecoveryRate = pidProfile->crash_recovery_rate;
-    pidRuntime.crashGyroThreshold = pidProfile->crash_gthreshold;
-    pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold;
+    pidRuntime.crashGyroThreshold = pidProfile->crash_gthreshold; // error in deg/s
+    pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold * 1000.0f; // gyro delta in deg/s/s divided by 1000 to match origingal 2017 intent
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
 
@@ -448,11 +448,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 
     pidRuntime.useEzLanding = pidProfile->ez_landing_threshold && pidProfile->ez_landing_limit;
-    pidRuntime.useEzDisarm = pidRuntime.useEzLanding && pidProfile->ez_landing_disarm_threshold > 0;
+    pidRuntime.useEzDisarm = pidProfile->ez_landing_disarm_threshold > 0;
     pidRuntime.ezLandingThreshold = pidProfile->ez_landing_threshold / 100.0f;
     pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit;
-    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;
-
+    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold * 10.0f;
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -316,7 +316,6 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
 
-    pidRuntime.itermLeakRateYaw = pidRuntime.dT * pidProfile->itermLeak / 10.0f;
     pidRuntime.itermLimit = 0.01f * pidProfile->itermWindup * pidProfile->pidSumLimit;
     pidRuntime.itermLimitYaw = 0.01f * pidProfile->itermWindup * pidProfile->pidSumLimitYaw;
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -441,6 +441,13 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowBreakpoint = MIN(pidRuntime.tpaLowBreakpoint, pidRuntime.tpaBreakpoint);
     pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
+
+    pidRuntime.useEzLanding = pidProfile->ez_landing_threshold && pidProfile->ez_landing_limit;
+    pidRuntime.useEzDisarm = pidRuntime.useEzLanding && pidProfile->ez_landing_disarm_threshold > 0;
+    pidRuntime.ezLandingThreshold = pidProfile->ez_landing_threshold / 100.0f;
+    pidRuntime.ezLandingLimit = pidProfile->ez_landing_limit;
+    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;
+
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -428,7 +428,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardJitterFactor = pidProfile->feedforward_jitter_factor;
     pidRuntime.feedforwardJitterFactorInv = 1.0f / (2.0f * pidProfile->feedforward_jitter_factor);
     // the extra division by 2 is to average the sum of the two previous rcCommandAbs values
-    pidRuntime.feedforwardBoostFactor = 0.1f * pidProfile->feedforward_boost;
+    pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
 #endif
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -429,6 +429,12 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
     pidRuntime.feedforwardInterpolate = !(rxRuntimeState.serialrxProvider == SERIALRX_CRSF);
+    pidRuntime.feedforwardYawHoldTime = (pidProfile->feedforward_yaw_hold_time == 0) ? 1.0f : 1000.0f / pidProfile->feedforward_yaw_hold_time;
+    pidRuntime.feedforwardYawHoldGain = pidProfile->feedforward_yaw_hold_gain;
+    // normalise/maintain boost when cutoffs are faster
+    if (pidProfile->feedforward_yaw_hold_time < 100) {
+        pidRuntime.feedforwardYawHoldGain *= pidRuntime.feedforwardYawHoldTime * 0.1f;
+    }
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -316,12 +316,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
 
-    // itermLimit cannot be set higher than 80% of pidSumLimit
-    pidRuntime.itermLimit = fminf((float)pidProfile->itermLimit, 0.8f * pidProfile->pidSumLimit);
-    // used to limit iTerm for yaw to not exceed pidSumLimitYaw
-    pidRuntime.pidSumLimitYaw = pidProfile->pidSumLimitYaw;
-    // precalculate iTerm leak rate factor for yaw
-    pidRuntime.itermLeakRateYaw = pidRuntime.dT * pidProfile->itermWindupPointPercent / 10.0f; // used for iTerm leak on yaw
+    pidRuntime.itermLeakRateYaw = pidRuntime.dT * pidProfile->itermLeak / 10.0f;
+    pidRuntime.itermLimit = 0.01f * pidProfile->itermWindup * pidProfile->pidSumLimit;
+    pidRuntime.itermLimitYaw = 0.01f * pidProfile->itermWindup * pidProfile->pidSumLimitYaw;
+
 
 #if defined(USE_THROTTLE_BOOST)
     throttleBoost = pidProfile->throttle_boost * 0.1f;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -429,11 +429,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
     pidRuntime.feedforwardInterpolate = !(rxRuntimeState.serialrxProvider == SERIALRX_CRSF);
-    pidRuntime.feedforwardYawHoldTime = (pidProfile->feedforward_yaw_hold_time == 0) ? 1.0f : 1000.0f / pidProfile->feedforward_yaw_hold_time;
+    pidRuntime.feedforwardYawHoldTime = 0.001f * pidProfile->feedforward_yaw_hold_time; // input time constant in milliseconds, converted to seconds
     pidRuntime.feedforwardYawHoldGain = pidProfile->feedforward_yaw_hold_gain;
-    // normalise/maintain boost when cutoffs are faster
+    // normalise/maintain boost when time constant is small, 1.5x at 50ms, 2x at 25ms, almost 3x at 10ms
     if (pidProfile->feedforward_yaw_hold_time < 100) {
-        pidRuntime.feedforwardYawHoldGain *= pidRuntime.feedforwardYawHoldTime * 0.1f;
+        pidRuntime.feedforwardYawHoldGain *= 150.0f / (float)(pidProfile->feedforward_yaw_hold_time + 50);
     }
 #endif
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -427,10 +427,9 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardSmoothFactor = 1.0f - (0.01f * pidProfile->feedforward_smooth_factor);
     pidRuntime.feedforwardJitterFactor = pidProfile->feedforward_jitter_factor;
     pidRuntime.feedforwardJitterFactorInv = 1.0f / (1.0f + pidProfile->feedforward_jitter_factor);
-    // the extra division by 2 is to average the sum of the two most recent rcCommandAbs values
     pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
-    pidRuntime.feedforwardInterpolate = pidProfile->feedforward_interpolate;
+    pidRuntime.feedforwardInterpolate = !(rxRuntimeState.serialrxProvider == SERIALRX_CRSF);
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -426,10 +426,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardAveraging = pidProfile->feedforward_averaging;
     pidRuntime.feedforwardSmoothFactor = 1.0f - (0.01f * pidProfile->feedforward_smooth_factor);
     pidRuntime.feedforwardJitterFactor = pidProfile->feedforward_jitter_factor;
-    pidRuntime.feedforwardJitterFactorInv = 1.0f / (2.0f * pidProfile->feedforward_jitter_factor);
-    // the extra division by 2 is to average the sum of the two previous rcCommandAbs values
+    pidRuntime.feedforwardJitterFactorInv = 1.0f / (1.0f + pidProfile->feedforward_jitter_factor);
+    // the extra division by 2 is to average the sum of the two most recent rcCommandAbs values
     pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
+    pidRuntime.feedforwardInterpolate = pidProfile->feedforward_interpolate;
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;

--- a/src/main/pg/gps_rescue.c
+++ b/src/main/pg/gps_rescue.c
@@ -47,7 +47,7 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .descentDistanceM = 20,
     .descendRate = 150,         // cm/s, minimum for descent and landing phase, or for descending if starting high ascent
     .targetLandingAltitudeM = 4,
-    .disarmThreshold = 20,
+    .disarmThreshold = 30,
 
     .throttleMin = 1100,
     .throttleMax = 1700,

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -51,6 +51,7 @@ static void applyAccelerationTrims(const flightDynamicsTrims_t *accelerationTrim
 void accUpdate(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
+    static float previousAccMagnitude;
 
     if (!acc.dev.readFn(&acc.dev)) {
         return;
@@ -78,10 +79,15 @@ void accUpdate(timeUs_t currentTimeUs)
 
     applyAccelerationTrims(accelerationRuntime.accelerationTrims);
 
+    float accAdcSquaredSum = 0.0f;
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         const float val = acc.accADC[axis];
         acc.accADC[axis] = accelerationRuntime.accLpfCutHz ? pt2FilterApply(&accelerationRuntime.accFilter[axis], val) : val;
+        accAdcSquaredSum += sq(acc.accADC[axis]);
     }
+    acc.accMagnitude = sqrtf(accAdcSquaredSum) * acc.dev.acc_1G_rec; // normally 1.0; used for disarm on impact detection
+    acc.accDelta = (acc.accMagnitude - previousAccMagnitude) * acc.sampleRateHz;
+    previousAccMagnitude = acc.accMagnitude;
 }
 
 #endif

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -56,6 +56,8 @@ typedef struct acc_s {
     uint16_t sampleRateHz;
     float accADC[XYZ_AXIS_COUNT];
     bool isAccelUpdatedAtLeastOnce;
+    float accMagnitude;
+    float accDelta;
 } acc_t;
 
 extern acc_t acc;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -79,7 +79,6 @@ extern "C" {
     acc_t acc;
     gyro_t gyro;
     attitudeEulerAngles_t attitude;
-    
     rxRuntimeState_t rxRuntimeState = {};
 
     PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -270,6 +270,18 @@ TEST(pidControllerTest, testPidLoop)
     simulatedmaxRcDeflectionAbs = 1.0f;
     calcEzLandingLimit (simulatedmaxRcDeflectionAbs);
 
+    // increase pid sum limits to avoid interactions with the i term anti windup mechanism
+    pidProfile->pidSumLimit = USHRT_MAX;
+    pidProfile->pidSumLimitYaw = USHRT_MAX;
+
+    // increase pid sum limits to avoid interactions with the i term anti windup mechanism
+    pidProfile->pidSumLimit = USHRT_MAX;
+    pidProfile->pidSumLimitYaw = USHRT_MAX;
+
+    // increase pid sum limits to avoid interactions with the i term anti windup mechanism
+    pidProfile->pidSumLimit = USHRT_MAX;
+    pidProfile->pidSumLimitYaw = USHRT_MAX;
+
     pidController(pidProfile, currentTestTime());
 
     // Loop 1 - Expecting zero since there is no error
@@ -330,9 +342,9 @@ TEST(pidControllerTest, testPidLoop)
     // Simulate Iterm behaviour during mixer saturation
     simulatedMotorMixRange = 1.2f;
     pidController(pidProfile, currentTestTime());
-    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
-    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
-    EXPECT_NEAR(-8.8, pidData[FD_YAW].I, calculateTolerance(-8.8));
+    EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
+    EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
+    EXPECT_NEAR(-17.6, pidData[FD_YAW].I, calculateTolerance(-17.6));
     simulatedMotorMixRange = 0;
 
     // Match the stick to gyro to stop error
@@ -343,13 +355,13 @@ TEST(pidControllerTest, testPidLoop)
     for(int loop = 0; loop < 5; loop++) {
         pidController(pidProfile, currentTestTime());
     }
-    // Iterm is stalled as it is not accumulating anymore
+    // Iterm is stalled as it is not accumulating anymore; yaw droops a little due to the leak
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
-    EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
-    EXPECT_NEAR(-10.6, pidData[FD_YAW].I, calculateTolerance(-10.6));
+    EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
+    EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
+    EXPECT_NEAR(-15.5, pidData[FD_YAW].I, calculateTolerance(-15.5));
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].D);
@@ -585,74 +597,142 @@ TEST(pidControllerTest, testPidHorizon)
 
 }
 
-TEST(pidControllerTest, testMixerSaturation)
-{
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
+// TEST(pidControllerTest, testMixerSaturation)
+// {
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+// 
+//     // Test full stick response
+//     setStickPosition(FD_ROLL, 1.0f);
+//     setStickPosition(FD_PITCH, -1.0f);
+//     setStickPosition(FD_YAW, 1.0f);
+//     simulatedMotorMixRange = 2.0f;
+//     pidController(pidProfile, currentTestTime());
+// 
+//     // Expect iterm accumulation for all axes because at this point, pidSum is not at limit
+//     EXPECT_NEAR(156.2f, pidData[FD_ROLL].I, calculateTolerance(156.2f));
+//     EXPECT_NEAR(-150.0f, pidData[FD_PITCH].I, calculateTolerance(-150.0f));
+//     EXPECT_NEAR(7.0f, pidData[FD_YAW].I, calculateTolerance(7.0f));
 
-    // Test full stick response
-    setStickPosition(FD_ROLL, 1.0f);
-    setStickPosition(FD_PITCH, -1.0f);
-    setStickPosition(FD_YAW, 1.0f);
-    simulatedMotorMixRange = 2.0f;
-    pidController(pidProfile, currentTestTime());
-
-    // Expect no iterm accumulation for all axes
-    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
+//    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
+//    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
+//    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 
     // Test itermWindup limit
     // First store values without exceeding iterm windup limit
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-    setStickPosition(FD_ROLL, 0.1f);
-    setStickPosition(FD_PITCH, -0.1f);
-    setStickPosition(FD_YAW, 0.1f);
-    simulatedMotorMixRange = 0.0f;
-    pidController(pidProfile, currentTestTime());
-    float rollTestIterm = pidData[FD_ROLL].I;
-    float pitchTestIterm = pidData[FD_PITCH].I;
-    float yawTestIterm = pidData[FD_YAW].I;
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     setStickPosition(FD_ROLL, 0.1f);
+//     setStickPosition(FD_PITCH, -0.1f);
+//     setStickPosition(FD_YAW, 0.1f);
+//    simulatedMotorMixRange = 0.0f;
+//     pidController(pidProfile, currentTestTime());
+//     float rollTestIterm = pidData[FD_ROLL].I;
+//     float pitchTestIterm = pidData[FD_PITCH].I;
+//     float yawTestIterm = pidData[FD_YAW].I;
 
     // Now compare values when exceeding the limit
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-    setStickPosition(FD_ROLL, 0.1f);
-    setStickPosition(FD_PITCH, -0.1f);
-    setStickPosition(FD_YAW, 0.1f);
-    simulatedMotorMixRange = (pidProfile->itermWindupPointPercent + 2) / 100.0f;
-    pidController(pidProfile, currentTestTime());
-    EXPECT_LT(pidData[FD_ROLL].I, rollTestIterm);
-    EXPECT_GE(pidData[FD_PITCH].I, pitchTestIterm);
-    EXPECT_LT(pidData[FD_YAW].I, yawTestIterm);
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     setStickPosition(FD_ROLL, 0.1f);
+//     setStickPosition(FD_PITCH, -0.1f);
+//     setStickPosition(FD_YAW, 0.1f);
+//     simulatedMotorMixRange = (pidProfile->itermWindupPointPercent + 2) / 100.0f;
+//     pidController(pidProfile, currentTestTime());
+//     EXPECT_LT(pidData[FD_ROLL].I, rollTestIterm);
+//     EXPECT_GE(pidData[FD_PITCH].I, pitchTestIterm);
+//     EXPECT_LT(pidData[FD_YAW].I, yawTestIterm);
 
     // Test that the added i term gain from Anti Gravity
     // is also affected by itermWindup
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+// 
+//     setStickPosition(FD_ROLL, 1.0f);
+//     setStickPosition(FD_PITCH, -1.0f);
+//     setStickPosition(FD_YAW, 1.0f);
+//     simulatedMotorMixRange = 2.0f;
+//     const bool prevAgState = pidRuntime.antiGravityEnabled;
+//     const float prevAgTrhottleD = pidRuntime.antiGravityThrottleD;
+//     pidRuntime.antiGravityEnabled = true;
+//     pidRuntime.antiGravityThrottleD = 1.0;
+//     pidController(pidProfile, currentTestTime());
+//     pidRuntime.antiGravityEnabled = prevAgState;
+//     pidRuntime.antiGravityThrottleD = prevAgTrhottleD;
+// 
+//     // Expect no iterm accumulation for all axes
+//     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
+//     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
+//     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 
-    setStickPosition(FD_ROLL, 1.0f);
-    setStickPosition(FD_PITCH, -1.0f);
-    setStickPosition(FD_YAW, 1.0f);
-    simulatedMotorMixRange = 2.0f;
-    const bool prevAgState = pidRuntime.antiGravityEnabled;
-    const float prevAgTrhottleD = pidRuntime.antiGravityThrottleD;
-    pidRuntime.antiGravityEnabled = true;
-    pidRuntime.antiGravityThrottleD = 1.0;
-    pidController(pidProfile, currentTestTime());
-    pidRuntime.antiGravityEnabled = prevAgState;
-    pidRuntime.antiGravityThrottleD = prevAgTrhottleD;
-
-    // Expect no iterm accumulation for all axes
-    EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
-    EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
-}
+    // // Test that i term is limited on yaw even when only yaw is saturated
+    // resetTest();
+    // ENABLE_ARMING_FLAG(ARMED);
+    // pidStabilisationState(PID_STABILISATION_ON);
+    // gyro.gyroADCf[FD_ROLL] = PIDSUM_LIMIT_YAW;
+    // gyro.gyroADCf[FD_PITCH] = PIDSUM_LIMIT_YAW;
+    // gyro.gyroADCf[FD_YAW] = PIDSUM_LIMIT_YAW;
+    // pidController(pidProfile, currentTestTime());
+    // // value from the previous itteration is used for efficiency reasons so expect
+    // // i term accumulation to stop at the second itteration
+    // const float i_term_after_first = pidData[FD_YAW].I;
+    // pidController(pidProfile, currentTestTime());
+    // EXPECT_FLOAT_EQ(i_term_after_first, pidData[FD_YAW].I);
+// }
+// 
+// TEST(pidControllerTest, testPidsumAntiWindup)
+// {
+//     // Test that i term is limited when the pidsum limit is hit
+//     // important for yaw since yaw cant saturate the mixer alone with the default pidsum_limit_yaw
+//     // Go axis by axis to avoid breaking the test if mixer saturation gets automatically calculated in the future
+//     // takes about 5 iterations for values to stabilise
+//     {
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     gyro.gyroADCf[FD_ROLL] = PIDSUM_LIMIT;
+//     for(int loop = 0; loop < 5; loop++) {
+//         pidController(pidProfile, currentTestTime());
+//     }
+//     // value from the previous iteration is used for efficiency reasons so expect
+//     // i term accumulation to stop after 5 iterations
+//     const float i_term_after_first = pidData[FD_ROLL].I;
+//     pidController(pidProfile, currentTestTime());
+//     EXPECT_FLOAT_EQ(i_term_after_first, pidData[FD_ROLL].I);
+//     }
+//     {
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     gyro.gyroADCf[FD_PITCH] = PIDSUM_LIMIT;
+//     for(int loop = 0; loop < 5; loop++) {
+//         pidController(pidProfile, currentTestTime());
+//     }
+//     // value from the previous iteration is used for efficiency reasons so expect
+//     // i term accumulation to stop after 5 iterations
+//     const float i_term_after_first = pidData[FD_PITCH].I;
+//     pidController(pidProfile, currentTestTime());
+//     EXPECT_FLOAT_EQ(i_term_after_first, pidData[FD_PITCH].I);
+//     }
+//     {
+//     resetTest();
+//     ENABLE_ARMING_FLAG(ARMED);
+//     pidStabilisationState(PID_STABILISATION_ON);
+//     gyro.gyroADCf[FD_YAW] = PIDSUM_LIMIT_YAW;
+//     for(int loop = 0; loop < 20; loop++) {
+//         pidController(pidProfile, currentTestTime());
+//     }
+//     // value from the previous iteration is used for efficiency reasons so expect
+//     // i term accumulation to stop after 5 iterations
+//     const float i_term_after_first = pidData[FD_YAW].I;
+//     pidController(pidProfile, currentTestTime());
+//     EXPECT_FLOAT_EQ(i_term_after_first, pidData[FD_YAW].I);
+//     }
+// }
 
 // TODO - Add more scenarios
 TEST(pidControllerTest, testCrashRecoveryMode)

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -415,7 +415,7 @@ TEST(pidControllerTest, testEzLanding)
     EXPECT_NEAR(-25.6, pidData[FD_ROLL].P, calculateTolerance(-25.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.312, pidData[FD_ROLL].I, calculateTolerance(-0.312));
+    EXPECT_NEAR(-1.6, pidData[FD_ROLL].I, calculateTolerance(-1.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-20, pidData[FD_ROLL].D, calculateTolerance(-20));
@@ -429,7 +429,7 @@ TEST(pidControllerTest, testEzLanding)
     EXPECT_NEAR(-25.6, pidData[FD_ROLL].P, calculateTolerance(-25.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.625, pidData[FD_ROLL].I, calculateTolerance(-0.625));
+    EXPECT_NEAR(-3.1, pidData[FD_ROLL].I, calculateTolerance(-3.1));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-20, pidData[FD_ROLL].D, calculateTolerance(-20));
@@ -443,7 +443,7 @@ TEST(pidControllerTest, testEzLanding)
     EXPECT_NEAR(-25.6, pidData[FD_ROLL].P, calculateTolerance(-25.6));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
-    EXPECT_NEAR(-0.94, pidData[FD_ROLL].I, calculateTolerance(-0.94));
+    EXPECT_NEAR(-4.7, pidData[FD_ROLL].I, calculateTolerance(-4.7));
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].I);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
     EXPECT_NEAR(-20, pidData[FD_ROLL].D, calculateTolerance(-20));

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -134,7 +134,8 @@ void setDefaultTestSettings(void)
     pidProfile->dterm_notch_hz = 260;
     pidProfile->dterm_notch_cutoff = 160;
     pidProfile->dterm_lpf1_type = FILTER_BIQUAD;
-    pidProfile->itermWindupPointPercent = 50;
+    pidProfile->itermWindup = 80;
+    pidProfile->itermLeak = 30;
     pidProfile->pidAtMinThrottle = PID_STABILISATION_ON;
     pidProfile->angle_limit = 60;
     pidProfile->feedforward_transition = 100;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -69,6 +69,9 @@ extern "C" {
 
     #include "pg/pg.h"
     #include "pg/pg_ids.h"
+    
+    #include "pg/rx.h"
+    #include "rx/rx.h"
 
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
@@ -76,6 +79,8 @@ extern "C" {
     acc_t acc;
     gyro_t gyro;
     attitudeEulerAngles_t attitude;
+    
+    rxRuntimeState_t rxRuntimeState = {};
 
     PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -355,13 +355,13 @@ TEST(pidControllerTest, testPidLoop)
     for(int loop = 0; loop < 5; loop++) {
         pidController(pidProfile, currentTestTime());
     }
-    // Iterm is stalled as it is not accumulating anymore; yaw climbs from setpoint factor
+    // Iterm is stalled as it is not accumulating anymore; yaw falls from leak
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].P);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
     EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
     EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
-    EXPECT_NEAR(-19.3, pidData[FD_YAW].I, calculateTolerance(-19.3));
+    EXPECT_NEAR(-17, pidData[FD_YAW].I, calculateTolerance(-17)); 
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].D);
@@ -733,7 +733,7 @@ TEST(pidControllerTest, testiTermWindup)
     pidController(pidProfile, currentTestTime());
     EXPECT_NEAR(150, pidData[FD_ROLL].I, calculateTolerance(150));
     EXPECT_NEAR(200, pidData[FD_PITCH].I, calculateTolerance(200));
-    EXPECT_NEAR(160, pidData[FD_YAW].I, calculateTolerance(160));
+    EXPECT_NEAR(137, pidData[FD_YAW].I, calculateTolerance(137));
 
     pidController(pidProfile, currentTestTime());
     EXPECT_NEAR(169, pidData[FD_ROLL].I, calculateTolerance(200));

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -330,31 +330,31 @@ TEST(pidControllerTest, testPidLoop)
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].D);
 
     // Add some rotation on YAW to generate error
-    gyro.gyroADCf[FD_YAW] = 100;
+    gyro.gyroADCf[FD_YAW] = 10;
     pidController(pidProfile, currentTestTime());
 
     // Loop 4 - Expect PID loop reaction to PITCH error, ROLL and PITCH are still in error
     EXPECT_NEAR(-128.1, pidData[FD_ROLL].P, calculateTolerance(-128.1));
     EXPECT_NEAR(185.8, pidData[FD_PITCH].P, calculateTolerance(185.8));
-    EXPECT_NEAR(-224.2, pidData[FD_YAW].P, calculateTolerance(-224.2));
+    EXPECT_NEAR(-22.4, pidData[FD_YAW].P, calculateTolerance(-22.4));
     EXPECT_NEAR(-23.5, pidData[FD_ROLL].I, calculateTolerance(-23.5));
     EXPECT_NEAR(19.6, pidData[FD_PITCH].I, calculateTolerance(19.6));
-    EXPECT_NEAR(-8.7, pidData[FD_YAW].I, calculateTolerance(-8.7));
+    EXPECT_NEAR(-0.9, pidData[FD_YAW].I, calculateTolerance(-0.9));
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
-    EXPECT_NEAR(-132.25, pidData[FD_YAW].D, calculateTolerance(-132.25));
+    EXPECT_NEAR(-13.2, pidData[FD_YAW].D, calculateTolerance(-13.2));
 
     // Simulate Iterm growth if not saturated
     pidController(pidProfile, currentTestTime());
     EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
     EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
-    EXPECT_NEAR(-17.6, pidData[FD_YAW].I, calculateTolerance(-17.6));
+    EXPECT_NEAR(-1.7, pidData[FD_YAW].I, calculateTolerance(-1.7));
     simulatedMotorMixRange = 0;
 
     // Match the stick to gyro to stop error
     simulatedSetpointRate[FD_ROLL] = 100;
     simulatedSetpointRate[FD_PITCH] = -100;
-    simulatedSetpointRate[FD_YAW] = 100;
+    simulatedSetpointRate[FD_YAW] = 10;
 
     for(int loop = 0; loop < 5; loop++) {
         pidController(pidProfile, currentTestTime());
@@ -365,7 +365,7 @@ TEST(pidControllerTest, testPidLoop)
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].P);
     EXPECT_NEAR(-31.3, pidData[FD_ROLL].I, calculateTolerance(-31.3));
     EXPECT_NEAR(29.3, pidData[FD_PITCH].I, calculateTolerance(29.3));
-    EXPECT_NEAR(-17, pidData[FD_YAW].I, calculateTolerance(-17)); 
+    EXPECT_NEAR(-1.7, pidData[FD_YAW].I, calculateTolerance(-1.7)); 
     EXPECT_FLOAT_EQ(0, pidData[FD_ROLL].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_PITCH].D);
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].D);

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -135,7 +135,6 @@ void setDefaultTestSettings(void)
     pidProfile->dterm_notch_cutoff = 160;
     pidProfile->dterm_lpf1_type = FILTER_BIQUAD;
     pidProfile->itermWindup = 80;
-    pidProfile->itermLeak = 30;
     pidProfile->pidAtMinThrottle = PID_STABILISATION_ON;
     pidProfile->angle_limit = 60;
     pidProfile->feedforward_transition = 100;


### PR DESCRIPTION
This is a 'mashup' build for testing only; its the code I fly day to day at present.

It includes:
- PR #13803, which provides auto-disarm on impact if throttle is close to zero and all sticks are centred.  This is enabled by default but the G force threshold is so high it won't activate (110 in CLI, or 11G's).  To formally disable, set the ez_disarm_threshold to zero.  Otherwise values around 6G will disarm on hard landings.  
- PR #13576, feedforward improvements (for 4.6), including automatic prevention of interpolation for CRSF links for smoother control during slow stick inputs, smoother and more accurate slow stick control at very low jitter reduction values, and the addition of a user-adjustable sustained 'hold' element on yaw, which makes yaw accurate and avoids bounce-back from excessive iTerm accumulation.
- PR #13506, which modifies itermWindup so that iTerm growth will only be blocked axis by axis, when iTerm exceeds the iTermWindup percentage of the iTerm_limit value, rather than all at once whenever motorMix reaches 100%.  This should improve attitude stability when partially hitting a branch or a gate or otherwise maxing the motors.

My alternative EZLanding PR 13488, is also included, but is disabled by default.  That PR is now closed.  It worked by limiting allowed PID input error values once sticks were centred, and throttle was zero, and could be used with the standard mixer. If you're interested, set the threshold to a non-zero value, eg 15.  I was hoping to find a method that would tame landings but not interfere with normal aggressive flying.  I flew it a lot, and didn't notice anything bad, but it wasn't totally helpful on landing, and I now tend to think that any code that really works well would need to suppress PIDs so much that it would inevitably mess with in-flight behaviour in that stick position, and so my original 'goal' seems unachievable.  Our existing ez_landing code requires a special mixer type, and can be used for special quads where easy landing is important.

I've removed the iTerm Leak PR because it isn't needed with the sustained yaw feedforward in #13576.

For more info, read the details of each PR.  The EzLanding and EzDisarm options can be changed via the OSD.  

Thanks to everyone who has helped test these ideas!

There are three new CLI parameters at this point:
- `ez_landing_disarm_threshold`, which is in the OSD as well.  100 will disarm on a good bounce or impact, but not normally.  A lower value will disarm more readily on landing.  The disarm threshold is much higher than GPS rescue, and is only active when throttle is zero and sticks centred.  If set to zero, it is disabled.
- `feedforward_yaw_hold_gain`: default 15, range 0-100. This is slower to rise than the old 'boost' factor. The intent is not to be quicker, but to provide a kind of adjustable 'boost and hold' on the yaw feedforward. The gain factor modifies the magnitude of the sustained element, and adds generally to the feedforward effect, a bit slower than the simple feedforward component in the PIDs.
- `feedforward_yaw_hold_time`: default 100. This is the time constant for the slow decay in this 'feedforward hold', in ms. Smaller values, eg 50, cause the feedforward value to drop more rapidly towards zero (time constant of 50ms). Larger values hold the yaw feedforward sustain for a longer period of time, better for quads with low yaw authority.  100ms is good for a normal kind of 5in build.

There are special debugs for the feedforward changes, see that PR.

I'll keep this mashup up to date.
