### PR TITLE
Feedforward improvements for 4.6

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1508,7 +1508,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FF_SMOOTHING_MS, "%d",      currentPidProfile->angle_feedforward_smoothing_ms);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN, "%d",      currentPidProfile->feedforward_yaw_hold_gain);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN, "%d",  currentPidProfile->feedforward_yaw_hold_gain);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME, "%d",  currentPidProfile->feedforward_yaw_hold_time);
 #endif
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_LIMIT, "%d",                currentPidProfile->angle_limit);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1508,6 +1508,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, "%d", currentPidProfile->feedforward_max_rate_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FEEDFORWARD, "%d",          currentPidProfile->pid[PID_LEVEL].F);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_FF_SMOOTHING_MS, "%d",      currentPidProfile->angle_feedforward_smoothing_ms);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN, "%d",      currentPidProfile->feedforward_yaw_hold_gain);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME, "%d",  currentPidProfile->feedforward_yaw_hold_time);
 #endif
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_LIMIT, "%d",                currentPidProfile->angle_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ANGLE_EARTH_REF, "%d",            currentPidProfile->angle_earth_ref);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1231,6 +1231,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_FEEDFORWARD_JITTER_FACTOR,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { PARAM_NAME_FEEDFORWARD_BOOST,          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 200}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
+    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN,      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 100}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_gain) },
+    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {10, 250}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_time) },
 #endif
 
 #ifdef USE_DYN_IDLE

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1231,7 +1231,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_FEEDFORWARD_JITTER_FACTOR,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 20}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_jitter_factor) },
     { PARAM_NAME_FEEDFORWARD_BOOST,          VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_boost) },
     { PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 200}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_max_rate_limit) },
-    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN,      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 100}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_gain) },
+    { PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {0, 100}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_gain) },
     { PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME,  VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = {10, 250}, PG_PID_PROFILE, offsetof(pidProfile_t, feedforward_yaw_hold_time) },
 #endif
 

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -115,6 +115,8 @@
 #define PARAM_NAME_FEEDFORWARD_JITTER_FACTOR "feedforward_jitter_factor"
 #define PARAM_NAME_FEEDFORWARD_BOOST "feedforward_boost"
 #define PARAM_NAME_FEEDFORWARD_MAX_RATE_LIMIT "feedforward_max_rate_limit"
+#define PARAM_NAME_FEEDFORWARD_YAW_HOLD_GAIN "feedforward_yaw_hold_gain"
+#define PARAM_NAME_FEEDFORWARD_YAW_HOLD_TIME "feedforward_yaw_hold_time"
 #define PARAM_NAME_DYN_IDLE_MIN_RPM "dyn_idle_min_rpm"
 #define PARAM_NAME_DYN_IDLE_P_GAIN "dyn_idle_p_gain"
 #define PARAM_NAME_DYN_IDLE_I_GAIN "dyn_idle_i_gain"

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -584,7 +584,7 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, flight_dyn
     setpointSpeed = prevSetpointSpeed[axis] + pid->feedforwardSmoothFactor * (setpointSpeed - prevSetpointSpeed[axis]);
 
     // calculate setpointDelta from smoothed setpoint speed
-    setpointSpeedDelta  = setpointSpeed - prevSetpointSpeed[axis];
+    setpointSpeedDelta = setpointSpeed - prevSetpointSpeed[axis];
     prevSetpointSpeed[axis] = setpointSpeed;
 
     // smooth the setpointDelta element (effectively a second order filter since incoming setpoint was already smoothed)
@@ -725,7 +725,6 @@ FAST_CODE_NOINLINE void updateRcCommands(void)
     isRxDataNew = true;
 
     for (int axis = 0; axis < 3; axis++) {
-        // non coupled PID reduction scaler used in PID controller 1 and PID controller 2.
 
         float tmp = MIN(fabsf(rcData[axis] - rxConfig()->midrc), 500.0f);
         if (axis == ROLL || axis == PITCH) {

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -640,7 +640,7 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
         feedforward *= rcDeflectionAbs[axis] * pid->feedforwardTransitionInv;
     }
 
-    if (axis == gyro.gyroDebugAxis) {
+    if (axis == (int)gyro.gyroDebugAxis) {
         DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));                       // un-smoothed (raw) setpoint value used for FF
         DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * 0.01f));          // smoothed and extrapolated basic feedfoward element
         DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(feedforwardBoost * 0.01f));       // acceleration (boost) smoothed

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -493,7 +493,7 @@ static FAST_CODE void processRcSmoothingFilter(void)
 #endif // USE_RC_SMOOTHING_FILTER
 
 #ifdef USE_FEEDFORWARD
-FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
+FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, flight_dynamics_index_t axis)
 {
     const float rxInterval = currentRxIntervalUs * 1e-6f; // seconds
     float rxRate = currentRxRateHz;                 // 1e6f / currentRxIntervalUs;
@@ -640,7 +640,7 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
         feedforward *= rcDeflectionAbs[axis] * pid->feedforwardTransitionInv;
     }
 
-    if (axis == (int)gyro.gyroDebugAxis) {
+    if (axis == gyro.gyroDebugAxis) {
         DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));                       // un-smoothed (raw) setpoint value used for FF
         DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * 0.01f));          // smoothed and extrapolated basic feedfoward element
         DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(feedforwardBoost * 0.01f));       // acceleration (boost) smoothed

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -489,6 +489,7 @@ static FAST_CODE void processRcSmoothingFilter(void)
 }
 #endif // USE_RC_SMOOTHING_FILTER
 
+// should this be inside ifdef USE_FEEDFORWARD ??
 NOINLINE void initFeedforwardFilters(uint16_t feedforwardAveraging)
 {
     if (feedforwardAveraging) {
@@ -511,8 +512,10 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, int axis)
     static float prevAcceleration[3];               // for duplicate interpolation
     static bool prevDuplicatePacket[3];             // to identify multiple identical packets
     static uint16_t feedforwardAveraging = 0; 
+
+    // needs a 'proper' init function that respects profile change - this is a hack that wastes cycles
     static bool initFilters = false;
-    if (!initFilters) {
+    if (!initFilters || feedforwardAveraging != pid->feedforwardAveraging) {
         feedforwardAveraging = pid->feedforwardAveraging;
         initFeedforwardFilters(feedforwardAveraging);
         initFilters = true;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -116,7 +116,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 9);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 10);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -237,6 +237,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
         .landing_disarm_threshold = 0, // relatively safe values are around 100
+        .feedforward_yaw_hold_gain = 15,  // zero disables; 15-20 is OK for 5in
+        .feedforward_yaw_hold_time = 100,  // a value of 100 is a time constant of about 100ms, and is OK for a 5in; smaller values decay faster, eg for smaller props
     );
 
 #ifndef USE_D_MIN

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -228,7 +228,9 @@ typedef struct pidProfile_s {
     uint8_t feedforward_jitter_factor;      // Number of RC steps below which to attenuate feedforward
     uint8_t feedforward_boost;              // amount of setpoint acceleration to add to feedforward, 10 means 100% added
     uint8_t feedforward_max_rate_limit;     // Maximum setpoint rate percentage for feedforward
-
+    uint8_t feedforward_yaw_hold_gain;          // Amount of sustained high-pass yaw setpoint to add to feedforward, zero disables
+    uint8_t feedforward_yaw_hold_time ;     // Time constant of the sustained yaw hold element in ms to add to feed forward, higher values decay slower
+    
     uint8_t dterm_lpf1_dyn_expo;            // set the curve for dynamic dterm lowpass filter
     uint8_t level_race_mode;                // NFE race mode - when true pitch setpoint calculation is gyro based in level mode
     uint8_t vbat_sag_compensation;          // Reduce motor output by this percentage of the maximum compensation amount
@@ -437,6 +439,9 @@ typedef struct pidRuntime_s {
     float feedforwardTransition;
     float feedforwardTransitionInv;
     uint8_t feedforwardMaxRateLimit;
+    uint8_t feedforwardYawHoldGain;
+    uint8_t feedforwardYawHoldTime;
+    bool feedforwardInterpolate; // Whether to interpolate an FF value for duplicate/identical data values 
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
 #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -439,8 +439,8 @@ typedef struct pidRuntime_s {
     float feedforwardTransition;
     float feedforwardTransitionInv;
     uint8_t feedforwardMaxRateLimit;
-    uint8_t feedforwardYawHoldGain;
-    uint8_t feedforwardYawHoldTime;
+    float feedforwardYawHoldGain;
+    float feedforwardYawHoldTime;
     bool feedforwardInterpolate; // Whether to interpolate an FF value for duplicate/identical data values 
     pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
 #endif

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -426,10 +426,17 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardAveraging = pidProfile->feedforward_averaging;
     pidRuntime.feedforwardSmoothFactor = 1.0f - (0.01f * pidProfile->feedforward_smooth_factor);
     pidRuntime.feedforwardJitterFactor = pidProfile->feedforward_jitter_factor;
-    pidRuntime.feedforwardJitterFactorInv = 1.0f / (2.0f * pidProfile->feedforward_jitter_factor);
-    // the extra division by 2 is to average the sum of the two previous rcCommandAbs values
-    pidRuntime.feedforwardBoostFactor = 0.1f * pidProfile->feedforward_boost;
+    pidRuntime.feedforwardJitterFactorInv = 1.0f / (1.0f + pidProfile->feedforward_jitter_factor);
+    pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
+    pidRuntime.feedforwardInterpolate = !(rxRuntimeState.serialrxProvider == SERIALRX_CRSF);
+    pidRuntime.feedforwardYawHoldTime = (pidProfile->feedforward_yaw_hold_time == 0) ? 1.0f : 1000.0f / pidProfile->feedforward_yaw_hold_time;
+    pidRuntime.feedforwardYawHoldGain = pidProfile->feedforward_yaw_hold_gain;
+    // normalise/maintain boost when cutoffs are faster
+    if (pidProfile->feedforward_yaw_hold_time < 100) {
+        pidRuntime.feedforwardYawHoldGain *= pidRuntime.feedforwardYawHoldTime * 0.1f;
+    }
+
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -430,13 +430,12 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.feedforwardBoostFactor = 0.001f * pidProfile->feedforward_boost;
     pidRuntime.feedforwardMaxRateLimit = pidProfile->feedforward_max_rate_limit;
     pidRuntime.feedforwardInterpolate = !(rxRuntimeState.serialrxProvider == SERIALRX_CRSF);
-    pidRuntime.feedforwardYawHoldTime = (pidProfile->feedforward_yaw_hold_time == 0) ? 1.0f : 1000.0f / pidProfile->feedforward_yaw_hold_time;
+    pidRuntime.feedforwardYawHoldTime = 0.001f * pidProfile->feedforward_yaw_hold_time; // input time constant in milliseconds, converted to seconds
     pidRuntime.feedforwardYawHoldGain = pidProfile->feedforward_yaw_hold_gain;
-    // normalise/maintain boost when cutoffs are faster
+    // normalise/maintain boost when time constant is small, 1.5x at 50ms, 2x at 25ms, almost 3x at 10ms
     if (pidProfile->feedforward_yaw_hold_time < 100) {
-        pidRuntime.feedforwardYawHoldGain *= pidRuntime.feedforwardYawHoldTime * 0.1f;
+        pidRuntime.feedforwardYawHoldGain *= 150.0f / (float)(pidProfile->feedforward_yaw_hold_time + 50);
     }
-
 #endif
 
     pidRuntime.levelRaceMode = pidProfile->level_race_mode;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -71,12 +71,17 @@ extern "C" {
     #include "pg/pg.h"
     #include "pg/pg_ids.h"
 
+    #include "pg/rx.h"
+    #include "rx/rx.h"
+
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
 
     acc_t acc;
     gyro_t gyro;
     attitudeEulerAngles_t attitude;
+
+    rxRuntimeState_t rxRuntimeState = {};
 
     PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
     PG_REGISTER(systemConfig_t, systemConfig, PG_SYSTEM_CONFIG, 2);


### PR DESCRIPTION
Many thanks to der_V / RubberQuads for his original idea to add a sustained element to yaw feedforward, by adding a fast-rising, slow-decaying 'setpoint' based value.

This PR 'grew' and now makes the following significant improvements:

- for yaw, replaces the 'boost' element with a high-pass setpoint component, providing 'sustain' to yaw which better matches the time course of the drive required for accurate yaw control.  Default is zero gain (off).  A gain factor around 20 works well.  The duration of the sustain can be adjusted in CLI.
- improves the jitter reduction code by not abruptly forcing FF to zero when sticks stop moving.  This is particularly important when jitter reduction is set low, for racing.  
- automatically does not apply extrapolation for duplicates in feedforward for CRSF type Rx links, reducing feedforward noise during slow stick movement.  FrSky and the other link types will continue to get extrapolated FF values when they send duplicate Rx data packets, as before.
- added debugs, comments, and some minor refactoring

Details:

**1.  Sustained feedforward for Yaw.**

This PR implements RubberQuads idea of sustaining yaw feedforward, since then we will be less reliant on growing iTerm, and can then have less bounce-back.

Yaw itself is driven by two elements:
- a 'propeller/motor angular momentum change' element, in which changing motor speed induces a reverse torque that causes yaw.  This element is zero when the motor rpm is constant.  This is a very fast element, but is limited in strength, and is limited by the fact that we can't keep increasing motor RPM forever.  For small inputs, and with smaller propellers and short arms (mini quads below 5in), this effect alone is usually sufficient to accurately track yaw inputs.  This element is weaker in larger quads.
- a 'propeller drag' element, which is proportional to static motor rpm inequalities.  This element is stronger in larger quads, but is delayed by the lag until the motors spool up.

Together, they induce a torque in the yaw axis, which accelerates yaw into a yaw spin.  Once the spin is acquired, less torque is needed.  

A simple feedforward element, based on stick travel / setpoint change, is only brief, and limited to the period of time that the sticks are moving.  This provides a useful 'push' or 'feedforward effect' of the fast 'angular momentum change' type.  However it rapidly drops to zero when the sticks stop moving, and for pitch and roll, the acceleration or boost element will actively pull back hard, to stop overshooting.  This is unhelpful for yaw, which rarely overshoots and more typically needs a sustained drive after the sticks stop moving, which is typically primarily handled by growing quite a lot of iTerm.  That iTerm causes bounce-back when the sticks are returned quickly to centre after a sustained yaw.

For yaw, this PR makes the following changes:
- the previous feedforward 'boost' is not added in yaw, reducing the amount of noise in the yaw feedforward signal.  
- in its place is a high-pass filtered setpoint value, which rises quickly and falls slowly.  It is not a second derivative, and isn't as 'quick' as the old 'boost' command, but also isn't as noisy.  It provides both derivative-like addition to feedforward, but more importantly, a sustained drive to the motor, mimicking what iTerm accumulation normally achieves.  By reducing the need for iTerm accumulation, less iTerm can be used, and there is less iTerm mediated bounce-back at the end of a fast yaw spin.

Two CLI adjustments are provided:
- `feedforward_yaw_hold_gain`: default 15, range 0-100.  This is slower to rise than the old 'boost' factor. The intent is not to be quicker, but to provide a kind of adjustable 'boost and hold' on the yaw feedforward.  The gain factor modifies the magnitude of the sustained element, and adds generally to the feedforward effect, a bit slower than the simple feedforward component in the PIDs.
- `feedforward_yaw_hold_time`: default 100. This is the time constant for the slow decay in this 'feedforward hold', in ms.  Smaller values, eg 50, cause the feedforward value to drop more rapidly towards zero (time constant of 50ms). Larger values hold the yaw feedforward sustain for a longer period of time.

**Tuning**

The intent is to get feedforward to so 'most of the work' on yaw, and when feedforward is optimised, we should see relatively little activity on P and I.  Typically PID iTerm on yaw can be attenuated by about half.

The defaults work well for normal 5in quads.

The best way to tune is to do make some logs of fast flat full-stick yaw spins while hovering.  Full yaw stick quickly out, hold until a full 360 rotation is complete, then full stick quickly back.  Watch for bounce-back and/or overshoot at the end.  Check the log and look at the yaw gyro, setpoint and PIDs.

Smaller quads than 5in usually yaw extremely quickly and accurately, because P finds it quick easy to achieve the target.

Heavier quads with longer arms, and ducted quads, can have issues with lag at the start, especially if the motors max out.  This leads to iTerm accumulation.  A similar issue happens at the end, leading to bounce-back.  When tuning, we aim to minimise the iTerm accumulation.

This approach could be considered equivalent to a 'leaky integral' of feedforward for yaw.  The concept of using a high-pass to provide the exponential decay came from the 'leaky iterm' idea in PR #13574.  However with this PR, 'leaky iterm' is now not needed for yaw, and it wasn't needed for pitch and roll, so I'll remove it from #13574.  

**2. Changes to the jitter reduction code**

This is a small improvement, mostly for racers who used jitter values of 1, 2 or 3 with faster radio links.

Previously, the jitter reduction code would always force feedforward to zero when sticks did not move for two successive RC packets.  This resulted in an excessively quick 'stop' to feedforward with fast radio links when the sticks hit centre, preventing feedforward from 'pulling back' smoothly to minimised overshoot.  

The change is to never force feedforward to zero, but instead to attenuate it to a fraction set by the user's jitter suppression value, relative to the rcCommandDelta value.  If the user chooses a low jitter reduction value, eg 1, 2, or 3, then the feedforward jitter reduction multiplier can't go below 50%, 33% and 25% respectively, retaining some feedforward even when the sticks are not moving.  This helps racers with high rate radios because feedforward will continue to actively manage the quad even when the sticks are moving very slowly, or are still.  The downside is that random stick noise will be more apparent and the quad will be 'twitchier' whenever the sticks are moved, even gently.  But that's what racer's want.  

In contrast, for freestyle, a value around 7 (default) will attenuate feedforward noise to only 1/8th of normal when the sticks are moving slowly, and will tend to drive feedforward very close to zero when the sticks are stopped.  This reduces the transmission of stick noise or thumb tremor to the quad when the sticks are moving slowly, but it will still respond quickly when the sticks move rapidly. For values much above 10, which only make sense for RC link rates of 150Hz or less,  the behaviour is much the same as it was.

**3.  Automatically disable setpoint delta extrapolation**

Currently this primarily benefits ELRS and CRSF pilots.  When a CRSF link is detected, feedforward will no longer extrapolate a 'predicted' setpointDelta value for the duplicate when new data is received after a single packet 'duplicate'.  Not extrapolating keeps Feedforward smoother for high data rate CRSF RC links, especially when the sticks are moving slowly.

There is no change in the behaviour of radio links like FrSky, which not infrequently send duplicate data values, randomly, on individual axes.  These 'duplicates' need extrapolation of setpointDelta to 'fill in the gap', because otherwise feedforward will abruptly drop from the previous value, to zero., and then leap up to double what it should be, every time a duplicate value is received.

**_PLEASE send logs as ZIP archives to this PR from other radio systems to check how they go!_**

**4. Refactoring and new debugs.**
The code has been refactored so that some of the older functions are a bit more transparent.
`setpointAcceleration' has been re-named `setpointSpeedDelta`, and after the user gain and rxRate compensation is added, the final value is named `feedforwardBoost` to match the user interface name - thanks @ledvinap
Debugs are more detailed (I'll need a PR to blackbox).

Unfortunately the additional yaw-related code adds about 350 bytes of ITCM flash compared to master.

** Debugs**
Values 0-5 are recorded from Roll and 6-7 from Yaw only, to the `FEEDFORWARD` debug
```
DEBUG 0, setpoint // un-smoothed (raw) setpoint value used for FF
DEBUG 1, setpointSpeed * 0.01f) // setpoint change, including extrapolation and smoothing
DEBUG 2, feedforwardBoost * 0.01f;  // boost element, smoothed
DEBUG 3, rcCommandDelta * 10.0f // change in rcCommand each packet, times 10
DEBUG 4, jitterAttenuator * 100.0f) // jitter attenuation percent
DEBUG 5, prevDuplicatePacket[axis] // true if current packet is a duplicate
DEBUG 6, feedforward * 0.01  // basic yaw feedforward without hold element
DEBUG 7, feedforwardYawHoldGain * 0.01f // hold/boost element for yaw

I'm keen to see some logs of this PR with low-authority builds.