### PR TITLE
battery - fix BATTERY_NOT_PRESENT detection, detection logic change

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -67,7 +67,6 @@
  *
  */
 
-#define VBAT_STABLE_MAX_DELTA 10 // 100mV
 #define LVC_AFFECT_TIME 10000000 //10 secs for the LVC to slowly kick in
 
 // Battery monitoring stuff
@@ -159,20 +158,13 @@ void batteryUpdateVoltage(timeUs_t currentTimeUs)
             break;
     }
 
-    if (!voltageMeter.isVoltageStable && cmp32(millis(), voltageMeter.prevDisplayFilteredTime) >= PREV_DISPLAY_FILTERED_TIME_DIFF) {
-        if ((voltageState == BATTERY_NOT_PRESENT || voltageState == BATTERY_INIT) && isVoltageFromBattery()) {
-            voltageMeter.isVoltageStable = abs(voltageMeter.prevDisplayFiltered - voltageMeter.displayFiltered) <= VBAT_STABLE_MAX_DELTA;
-        }
-
-        voltageMeter.prevDisplayFiltered = voltageMeter.displayFiltered;
-        voltageMeter.prevDisplayFilteredTime = millis();
-    }
+    voltageStableUpdate(&voltageMeter);
 
     DEBUG_SET(DEBUG_BATTERY, 0, voltageMeter.unfiltered);
     DEBUG_SET(DEBUG_BATTERY, 1, voltageMeter.displayFiltered);
-    DEBUG_SET(DEBUG_BATTERY, 4, voltageMeter.isVoltageStable ? 1 : 0);
+    DEBUG_SET(DEBUG_BATTERY, 4, voltageIsStable(&voltageMeter) ? 1 : 0);
     DEBUG_SET(DEBUG_BATTERY, 5, isVoltageFromBattery() ? 1 : 0);
-    DEBUG_SET(DEBUG_BATTERY, 6, voltageMeter.prevDisplayFiltered);
+    DEBUG_SET(DEBUG_BATTERY, 6, voltageMeter.voltageStableLastUpdate);
     DEBUG_SET(DEBUG_BATTERY, 7, voltageState);
 }
 
@@ -205,7 +197,9 @@ bool isVoltageFromBattery(void)
 
 void batteryUpdatePresence(void)
 {
-    if ((voltageState == BATTERY_NOT_PRESENT || voltageState == BATTERY_INIT) && isVoltageFromBattery() && voltageMeter.isVoltageStable) {
+    if ((voltageState == BATTERY_NOT_PRESENT || voltageState == BATTERY_INIT)
+        && isVoltageFromBattery()
+        && voltageIsStable(&voltageMeter)) {
         // Battery has just been connected - calculate cells, warning voltages and reset state
 
         consumptionState = voltageState = BATTERY_OK;
@@ -232,11 +226,12 @@ void batteryUpdatePresence(void)
         batteryCriticalHysteresisVoltage = (batteryCriticalVoltage > batteryConfig()->vbathysteresis) ? batteryCriticalVoltage - batteryConfig()->vbathysteresis : 0;
         lowVoltageCutoff.percentage = 100;
         lowVoltageCutoff.startTime = 0;
-    } else if (voltageState != BATTERY_NOT_PRESENT && voltageMeter.isVoltageStable && !isVoltageFromBattery()) {
+    } else if (voltageState != BATTERY_NOT_PRESENT
+               && voltageIsStable(&voltageMeter)
+               && !isVoltageFromBattery()) {
         /* battery has been disconnected - can take a while for filter cap to disharge so we use a threshold of batteryConfig()->vbatnotpresentcellvoltage */
         consumptionState = voltageState = BATTERY_NOT_PRESENT;
-        
-        voltageMeter.isVoltageStable = false;
+
         batteryCellCount = 0;
         batteryWarningVoltage = 0;
         batteryCriticalVoltage = 0;

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -162,9 +162,10 @@ void batteryUpdateVoltage(timeUs_t currentTimeUs)
 
     DEBUG_SET(DEBUG_BATTERY, 0, voltageMeter.unfiltered);
     DEBUG_SET(DEBUG_BATTERY, 1, voltageMeter.displayFiltered);
+    DEBUG_SET(DEBUG_BATTERY, 3, voltageMeter.voltageStableBits);
     DEBUG_SET(DEBUG_BATTERY, 4, voltageIsStable(&voltageMeter) ? 1 : 0);
     DEBUG_SET(DEBUG_BATTERY, 5, isVoltageFromBattery() ? 1 : 0);
-    DEBUG_SET(DEBUG_BATTERY, 6, voltageMeter.voltageStableLastUpdate);
+    DEBUG_SET(DEBUG_BATTERY, 6, voltageMeter.voltageStablePrevFiltered);
     DEBUG_SET(DEBUG_BATTERY, 7, voltageState);
 }
 

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -25,8 +25,9 @@
 #define SLOW_VOLTAGE_TASK_FREQ_HZ 50
 #define FAST_VOLTAGE_TASK_FREQ_HZ 200
 
-#define PREV_DISPLAY_FILTERED_TIME_DIFF 500 // ms
-
+#define VOLTAGE_STABLE_UPDATE_MS 50
+#define VOLTAGE_STABLE_MASK      (BIT(10 + 1) - 1)  // voltage must be stable for 10 samples (10LSB set)
+#define VOLTAGE_STABLE_MAX_DELTA 10 // 100mV
 //
 // meters
 //
@@ -43,11 +44,11 @@ extern const char * const voltageMeterSourceNames[VOLTAGE_METER_COUNT];
 // WARNING - do not mix usage of VOLTAGE_METER_* and VOLTAGE_SENSOR_*, they are separate concerns.
 
 typedef struct voltageMeter_s {
-    uint16_t displayFiltered;               // voltage in 0.01V steps
-    uint16_t prevDisplayFiltered;               // voltage in 0.01V steps
-    timeMs_t prevDisplayFilteredTime;
-    bool isVoltageStable;
-    uint16_t unfiltered;                    // voltage in 0.01V steps
+    uint16_t displayFiltered;                // voltage in 0.01V steps
+    uint16_t voltageStablePrevFiltered;      // last filtered voltage sample
+    timeMs_t voltageStableLastUpdate;
+    uint16_t voltageStableBits;              // rolling bitmask, bit 1 if battery difference is within threshold, shifted left
+    uint16_t unfiltered;                     // voltage in 0.01V steps
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     uint16_t sagFiltered;                   // voltage in 0.01V steps
 #endif
@@ -116,6 +117,12 @@ void voltageMeterESCRefresh(void);
 void voltageMeterESCReadCombined(voltageMeter_t *voltageMeter);
 void voltageMeterESCReadMotor(uint8_t motor, voltageMeter_t *voltageMeter);
 
+//
+// api for battery stable voltage detection
+//
+
+void voltageStableUpdate(voltageMeter_t* vm);
+bool voltageIsStable(voltageMeter_t* vm);
 
 //
 // API for reading/configuring current meters by id.

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -25,9 +25,13 @@
 #define SLOW_VOLTAGE_TASK_FREQ_HZ 50
 #define FAST_VOLTAGE_TASK_FREQ_HZ 200
 
-#define VOLTAGE_STABLE_UPDATE_MS 50
-#define VOLTAGE_STABLE_MASK      (BIT(10 + 1) - 1)  // voltage must be stable for 10 samples (10LSB set)
-#define VOLTAGE_STABLE_MAX_DELTA 10 // 100mV
+#define VOLTAGE_STABLE_TICK_MS        100
+#define VOLTAGE_STABLE_BITS_TOTAL     11    // number of samples to test
+#define VOLTAGE_STABLE_BITS_THRESHOLD 10    // number of samples tham must be within delta (~1s)
+#define VOLTAGE_STABLE_MAX_DELTA      10    // 100mV
+
+STATIC_ASSERT(VOLTAGE_STABLE_BITS_TOTAL < sizeof(uint16_t) * 8, "not enough voltageStableBits");
+
 //
 // meters
 //


### PR DESCRIPTION
Detection logic is refactored: 

- voltageStablePrevFiltered is reset every time delta is exceeded
- voltage within range is ANDed over 100ms periods (sampling at battery update interval)
- voltage is stable if it was within range for 10 out of 11 periods

slowly changing voltage will update threshold, but voltage will be considered stable, 1 update/s (100mV/s) is tolerated