### PR TITLE
only apply osd defines if not set

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -201,8 +201,10 @@
 
 #define USE_VTX
 #define USE_OSD
+#if !defined(USE_OSD_SD) && !defined(USE_OSD_HD)
 #define USE_OSD_SD
 #define USE_OSD_HD
+#endif
 #define USE_BLACKBOX
 
 #if TARGET_FLASH_SIZE >= 1024


### PR DESCRIPTION
This enables the user to make a local build and select osd_displayport_device and vcd_system_type via OSD_SD and OSD_HD defines in cli. Prior to this, you can not select which are preselected via EXTRA_FLAGS as it would be a redefine.