### PR TITLE
Update CRSF spec

### DIFF
--- a/src/main/rx/crsf_protocol.h
+++ b/src/main/rx/crsf_protocol.h
@@ -27,7 +27,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define CRSF_BAUDRATE           420000
+// Rev7 CRSF docs: UART runs at 400000 baud, 8N1 at 3.0 to 3.3V level.
+// Rev10 CRSF docs: UART runs at 416666 baud, 8N1 at 3.0 to 3.3V level.
+#define CRSF_BAUDRATE           416666
 
 enum { CRSF_SYNC_BYTE = 0xC8 };
 

--- a/src/main/rx/crsf_protocol.h
+++ b/src/main/rx/crsf_protocol.h
@@ -29,7 +29,12 @@
 
 // Rev7 CRSF docs: UART runs at 400000 baud, 8N1 at 3.0 to 3.3V level.
 // Rev10 CRSF docs: UART runs at 416666 baud, 8N1 at 3.0 to 3.3V level.
+// Avoid using with ExpressLRS STM32 receivers.
+#ifdef USE_CRSF_OFFICIAL_SPEC
 #define CRSF_BAUDRATE           416666
+#else
+#define CRSF_BAUDRATE           420000
+#endif
 
 enum { CRSF_SYNC_BYTE = 0xC8 };
 


### PR DESCRIPTION
- Fixes #12398

- According to spec CRSF uses a baudrate of 416666
- Please test carefully