### PR TITLE
Add MSP support for gyro_cal_on_first_arm

### DIFF
--- a/src/main/common/huffman.h
+++ b/src/main/common/huffman.h
@@ -29,8 +29,8 @@ typedef struct huffmanTable_s {
 } huffmanTable_t;
 
 typedef struct huffmanState_s {
-    uint8_t     *outByte;
     uint16_t    bytesWritten;
+    uint8_t     *outByte;
     uint16_t    outBufLen;
     uint8_t     outBit;
 } huffmanState_t;

--- a/src/main/common/huffman.h
+++ b/src/main/common/huffman.h
@@ -29,8 +29,8 @@ typedef struct huffmanTable_s {
 } huffmanTable_t;
 
 typedef struct huffmanState_s {
-    uint16_t    bytesWritten;
     uint8_t     *outByte;
+    uint16_t    bytesWritten;
     uint16_t    outBufLen;
     uint8_t     outBit;
 } huffmanState_t;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2698,7 +2698,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
     case MSP_SET_ARMING_CONFIG:
         armingConfigMutable()->auto_disarm_delay = sbufReadU8(src);
-        armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src); // reserved
+        armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src); // disarm_kill_switch was removed in #5073
         if (sbufBytesRemaining(src)) {
           imuConfigMutable()->small_angle = sbufReadU8(src);
         }

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1352,7 +1352,7 @@ case MSP_NAME:
 
     case MSP_ARMING_CONFIG:
         sbufWriteU8(dst, armingConfig()->auto_disarm_delay);
-        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, armingConfig()->gyro_cal_on_first_arm);
         sbufWriteU8(dst, imuConfig()->small_angle);
         break;
 
@@ -2698,7 +2698,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
     case MSP_SET_ARMING_CONFIG:
         armingConfigMutable()->auto_disarm_delay = sbufReadU8(src);
-        sbufReadU8(src); // reserved
+        armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src); // reserved
         if (sbufBytesRemaining(src)) {
           imuConfigMutable()->small_angle = sbufReadU8(src);
         }

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2700,10 +2700,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
     case MSP_SET_ARMING_CONFIG:
         armingConfigMutable()->auto_disarm_delay = sbufReadU8(src);
         sbufReadU8(src); // reserved. disarm_kill_switch was removed in #5073
-        if (sbufBytesRemaining(src)) {
+        if (sbufBytesRemaining(src) >= 1) {
           imuConfigMutable()->small_angle = sbufReadU8(src);
         }
-        if (sbufBytesRemaining(src)) {
+        if (sbufBytesRemaining(src) >= 1) {
             armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src);
         }
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2700,10 +2700,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
     case MSP_SET_ARMING_CONFIG:
         armingConfigMutable()->auto_disarm_delay = sbufReadU8(src);
         sbufReadU8(src); // reserved. disarm_kill_switch was removed in #5073
-        if (sbufBytesRemaining(src) >= 1) {
+        if (sbufBytesRemaining(src)) {
           imuConfigMutable()->small_angle = sbufReadU8(src);
         }
-        if (sbufBytesRemaining(src) >= 1) {
+        if (sbufBytesRemaining(src)) {
             armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src);
         }
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1352,8 +1352,9 @@ case MSP_NAME:
 
     case MSP_ARMING_CONFIG:
         sbufWriteU8(dst, armingConfig()->auto_disarm_delay);
-        sbufWriteU8(dst, armingConfig()->gyro_cal_on_first_arm);
+        sbufWriteU8(dst, 0);
         sbufWriteU8(dst, imuConfig()->small_angle);
+        sbufWriteU8(dst, armingConfig()->gyro_cal_on_first_arm);
         break;
 
     case MSP_RC_TUNING:
@@ -2698,9 +2699,12 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
     case MSP_SET_ARMING_CONFIG:
         armingConfigMutable()->auto_disarm_delay = sbufReadU8(src);
-        armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src); // disarm_kill_switch was removed in #5073
+        sbufReadU8(src); // reserved. disarm_kill_switch was removed in #5073
         if (sbufBytesRemaining(src)) {
           imuConfigMutable()->small_angle = sbufReadU8(src);
+        }
+        if (sbufBytesRemaining(src)) {
+            armingConfigMutable()->gyro_cal_on_first_arm = sbufReadU8(src);
         }
         break;
 

--- a/src/test/unit/huffman_unittest.cc
+++ b/src/test/unit/huffman_unittest.cc
@@ -427,8 +427,8 @@ TEST(HuffmanUnittest, TestHuffmanEncodeStreaming)
     // 1110 1101
     // e    d
     huffmanState_t state1 = {
-        .bytesWritten = 0,
         .outByte = outBuf,
+        .bytesWritten = 0,
         .outBufLen = OUTBUF_LEN,
         .outBit = 0x80,
     };
@@ -453,8 +453,8 @@ TEST(HuffmanUnittest, TestHuffmanEncodeStreaming)
     // 1110 1100 1100 01
     // e    c    c    8
     huffmanState_t state2 = {
-        .bytesWritten = 0,
         .outByte = outBuf,
+        .bytesWritten = 0,
         .outBufLen = OUTBUF_LEN,
         .outBit = 0x80,
     };
@@ -481,8 +481,8 @@ TEST(HuffmanUnittest, TestHuffmanEncodeStreaming)
     // 1110 1100 1100 0110 0000 1110 1011 1000 1101 1
     // e    c    c    6    0    e    b    8    d    8
     huffmanState_t state3 = {
-        .bytesWritten = 0,
         .outByte = outBuf,
+        .bytesWritten = 0,
         .outBufLen = OUTBUF_LEN,
         .outBit = 0x80,
     };


### PR DESCRIPTION
- Fixes https://github.com/betaflight/betaflight-configurator/issues/102
- Configurator PR: https://github.com/betaflight/betaflight-configurator/pull/3938
- Support for `disarm_kill_switch` was removed in #5073

![image](https://github.com/betaflight/betaflight/assets/8344830/71fd9299-7aea-497e-9005-dd7d3217a27a)
