### PR TITLE
minor define fixes found during documentation work

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -438,7 +438,7 @@ static void validateAndFixConfig(void)
     featureDisableImmediate(FEATURE_TELEMETRY);
 #endif
 
-#ifndef USE_PWM
+#ifndef USE_RX_PWM
     featureDisableImmediate(FEATURE_RX_PARALLEL_PWM);
 #endif
 

--- a/src/main/drivers/accgyro_legacy/accgyro_lsm303dlhc.h
+++ b/src/main/drivers/accgyro_legacy/accgyro_lsm303dlhc.h
@@ -65,7 +65,7 @@ typedef struct {
    LSM303DLHC_TIMEOUT_UserCallback() function is called whenever a timeout condition
    occure during communication (waiting transmit data register empty flag(TXE)
    or waiting receive data register is not empty flag (RXNE)). */
-/* #define USE_DEFAULT_TIMEOUT_CALLBACK */
+// #define USE_DEFAULT_TIMEOUT_CALLBACK
 
 /* Maximum Timeout values for flags waiting loops. These timeouts are not based
    on accurate values, they just guarantee that the application will not remain

--- a/src/main/drivers/stm32/vcpf4/usb_conf.h
+++ b/src/main/drivers/stm32/vcpf4/usb_conf.h
@@ -171,9 +171,9 @@
 #endif
 
 /****************** USB OTG MODE CONFIGURATION ********************************/
-//#define USE_HOST_MODE
+// #define USE_HOST_MODE
 #define USE_DEVICE_MODE
-//#define USE_OTG_MODE
+// #define USE_OTG_MODE
 
 
 #ifndef USB_OTG_FS_CORE

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -236,7 +236,7 @@ static void configureQuadSPIBusses(void)
 #ifdef USE_QUADSPI_DEVICE_1
     quadSpiInit(QUADSPIDEV_1);
 #endif
-#endif // USE_QUAD_SPI
+#endif // USE_QUADSPI
 }
 
 static void configureOctoSPIBusses(void)


### PR DESCRIPTION
While working on an update to the [Firmware Flashing Tab documentation](https://github.com/betaflight/betaflight.com/pull/418), I added an end-user-friendly listing of defines, with help from @nerdCopter.

When trying to figure out which made sense and which didn't, two minor anomalies were found, only one of which is a bug, that should be fixed by this PR:
- `USE_PWM` isn't valid, and has been changed to `USE_RX_PWM`
- the comment `USE_QUAD_SPI`, used to mark the ifdef closure, is a typo error, it should be `USE_QUADSPI`

Two other changes are editorial; putting the commented define on its own line makes it easier for grep to exclude it from the search.