### PR TITLE
Added call_scheduler

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -117,4 +117,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "MAG_CALIB",
     "MAG_TASK_RATE",
     "EZLANDING",
+    "CALL_SCHEDULER",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -119,6 +119,7 @@ typedef enum {
     DEBUG_MAG_CALIB,
     DEBUG_MAG_TASK_RATE,
     DEBUG_EZLANDING,
+    DEBUG_CALL_SCHEDULER,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/common/call_scheduler.c
+++ b/src/main/common/call_scheduler.c
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "platform.h"
+
+#include "build/debug.h"
+#include "common/utils.h"
+#include "drivers/time.h"
+#include "fc/core.h"
+#include "fc/rc_modes.h"
+#include "fc/runtime_config.h"
+
+#include "common/call_scheduler.h"
+
+#define MAX_SCHEDULED_CALLS 128
+
+typedef void (*ScheduledFunction)(void);
+
+typedef struct ScheduledCall_s {
+    ScheduledFunction function; // Function pointer to be called
+    timeUs_t callTimeUs;        // Execution time
+    uint32_t id;
+} ScheduledCall_t;
+
+ScheduledCall_t scheduledCalls[MAX_SCHEDULED_CALLS];
+ScheduledCall_t bufferedCalls[MAX_SCHEDULED_CALLS];
+int scheduledCallsCount = 0;
+int bufferedCallsCount = 0;
+uint32_t totalCalls = 0;
+uint32_t refusedCalls = 0;
+
+void sortScheduledCallsLast(void)
+{ // sorts the last element, assumes scheduledCalls is already sorted except the element sceduledCallsCount
+    if (scheduledCallsCount == 0) {
+        // No sorting needed, just increase the count
+        scheduledCallsCount++;
+        return;
+    }
+
+    // Store the last element which needs to be sorted
+    ScheduledCall_t newCall = scheduledCalls[scheduledCallsCount];
+
+    int i;
+    // Start from the end of the sorted part of the array
+    for (i = scheduledCallsCount - 1; (i >= 0) && (scheduledCalls[i].callTimeUs > newCall.callTimeUs); i--) {
+        // Shift elements forward to make room for the new element
+        scheduledCalls[i + 1] = scheduledCalls[i];
+    }
+
+    // Place the new element into the correct position
+    scheduledCalls[i + 1] = newCall;
+    // Now we increment the count of scheduled calls
+    scheduledCallsCount++;
+}
+
+uint32_t scheduleCall(ScheduledFunction func, timeUs_t delayUs)
+{ // returns 0 if not enough memory for a call, otherwize returns the call ID
+    totalCalls ++;
+
+    if (totalCalls == 0) {
+        totalCalls = 1; // in case of value overflow
+    }
+
+    if (scheduledCallsCount + bufferedCallsCount >= MAX_SCHEDULED_CALLS) {
+        refusedCalls ++;
+        return 0;
+    }
+
+    bufferedCalls[bufferedCallsCount].callTimeUs = micros() + delayUs;
+    bufferedCalls[bufferedCallsCount].function = func;
+    bufferedCalls[bufferedCallsCount].id = totalCalls;
+    bufferedCallsCount ++;
+    return totalCalls;
+}
+
+void callSchedulerUpdate(timeUs_t currentTimeUs)
+{
+    int i = 0;
+    // Call all functions whose time is due (callTimeUs <= currentTimeUs)
+    while (i < scheduledCallsCount && scheduledCalls[i].callTimeUs <= currentTimeUs) {
+        scheduledCalls[i].function(); // Call the scheduled function
+        i++;  // Move to the next scheduled call
+    }
+
+    // If any functions were called, we need to shift the remaining elements
+    if (i > 0) {
+        // Move the remaining elements forward to fill the gap
+        for (int j = 0; j < scheduledCallsCount - i; j++) {
+            scheduledCalls[j] = scheduledCalls[j + i];
+        }
+
+        // Reduce the count of scheduled calls
+        scheduledCallsCount -= i;
+    }
+
+    // Merge buffered calls
+    for (int i = 0; i < bufferedCallsCount; i++) {
+        scheduledCalls[scheduledCallsCount] =  bufferedCalls[i];
+        sortScheduledCallsLast();        
+    }
+
+    bufferedCallsCount = 0;    
+
+    DEBUG_SET(DEBUG_CALL_SCHEDULER, 0, lrintf(scheduledCallsCount));
+    DEBUG_SET(DEBUG_CALL_SCHEDULER, 1, lrintf(refusedCalls));
+    DEBUG_SET(DEBUG_CALL_SCHEDULER, 2, lrintf(totalCalls));
+}

--- a/src/main/common/call_scheduler.h
+++ b/src/main/common/call_scheduler.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/time.h"
+
+void callSchedulerUpdate(timeUs_t currentTimeUs); // to be callsed from task scheduler
+uint32_t scheduleCall(void (*func)(void), timeUs_t delayUs); // scedule a call

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -30,6 +30,7 @@
 
 #include "cms/cms.h"
 
+#include "common/call_scheduler.h"
 #include "common/color.h"
 #include "common/utils.h"
 
@@ -453,7 +454,7 @@ task_attribute_t task_attributes[TASK_COUNT] = {
 #ifdef USE_RC_STATS
     [TASK_RC_STATS] = DEFINE_TASK("RC_STATS", NULL, NULL, rcStatsUpdate, TASK_PERIOD_HZ(100), TASK_PRIORITY_LOW),
 #endif
-
+    [TASK_CALL_SCHEDULER] = DEFINE_TASK("CALL_SCEDULER", NULL, NULL, callSchedulerUpdate, TASK_PERIOD_HZ(1000), TASK_PRIORITY_MEDIUM),
 };
 
 task_t *getTask(unsigned taskId)
@@ -629,4 +630,6 @@ void tasksInit(void)
 #ifdef USE_RC_STATS
     setTaskEnabled(TASK_RC_STATS, true);
 #endif
+
+    setTaskEnabled(TASK_CALL_SCHEDULER, true);
 }

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -179,6 +179,7 @@ typedef enum {
 #ifdef USE_RC_STATS
     TASK_RC_STATS,
 #endif
+    TASK_CALL_SCHEDULER,
 
     /* Count of real tasks */
     TASK_COUNT,


### PR DESCRIPTION
allows to shcedule any function for a call like that, for example:

```
#include "common/call_scheduler.h"
....
ScheduleCall(myFunction, 5000000); // 5 seconds
```
myFunction will be executed by scheduler after 5 seconds or more.
Keep in mind that the execution time is not accurate, task running at 1000hz with TASK_PRIORITY_MEDIUM.

Adds new debug:

```
    DEBUG_SET(DEBUG_CALL_SCHEDULER, 0, lrintf(scheduledCallsCount));
    DEBUG_SET(DEBUG_CALL_SCHEDULER, 1, lrintf(refusedCalls));
    DEBUG_SET(DEBUG_CALL_SCHEDULER, 2, lrintf(totalCalls));
```


new functionality could be helpful in many cases, for example:
While saving stats/settings, can check if quad is stable (on the ground) then save, otherwize reschedule saving.
In future OSD menus when need to perform gyro-readings for some period of time.
