### PR TITLE
#13544 Add an action to update the home point for GPS Rescue from the remote control

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -998,6 +998,10 @@ void processRxModes(timeUs_t currentTimeUs)
     } else {
         DISABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
     }
+
+    if (!FLIGHT_MODE(GPS_RESCUE_MODE) && IS_RC_MODE_ACTIVE(BOXGPSRESETHOME) && featureIsEnabled(FEATURE_GPS)) {
+        GPS_reset_home_position();
+    }
 #endif
 
     if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) {

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -79,6 +79,7 @@ typedef enum {
     BOXBEEPERMUTE,
     BOXREADY,
     BOXLAPTIMERRESET,
+    BOXGPSRESETHOME,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2613,6 +2613,10 @@ void onGpsNewData(void)
     GPS_calculateDistanceAndDirectionToHome();
     if (ARMING_FLAG(ARMED)) {
         GPS_calculateDistanceFlown(false);
+
+        if (!STATE(GPS_FIX_HOME) && !gpsConfig()->gps_set_home_point_once) {
+            GPS_reset_home_position();
+        }
     }
 
 #ifdef USE_GPS_RESCUE

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2614,7 +2614,7 @@ void onGpsNewData(void)
     if (ARMING_FLAG(ARMED)) {
         GPS_calculateDistanceFlown(false);
 
-        if (!STATE(GPS_FIX_HOME) && !gpsConfig()->gps_set_home_point_once) {
+        if (!STATE(GPS_FIX_HOME)) {
             GPS_reset_home_position();
         }
     }

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -102,6 +102,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
     { .boxId = BOXBEEPERMUTE, .boxName = "BEEPER MUTE", .permanentId = 52},
     { .boxId = BOXREADY, .boxName = "READY", .permanentId = 53},
     { .boxId = BOXLAPTIMERRESET, .boxName = "LAP TIMER RESET", .permanentId = 54},
+    { .boxId = BOXGPSRESETHOME, .boxName = "GPS RESET HOME", .permanentId = 55},
 };
 
 // mask of enabled IDs, calculated on startup based on enabled features. boxId_e is used as bit index
@@ -230,6 +231,7 @@ void initActiveBoxIds(void)
         }
 #endif
         BME(BOXBEEPGPSCOUNT);
+        BME(BOXGPSRESETHOME);
     }
 #endif
 

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -256,6 +256,14 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         return;
     }
 
+    // Show warning if in GPSRESETHOME mode
+    if (IS_RC_MODE_ACTIVE(BOXGPSRESETHOME)) {
+        tfp_sprintf(warningText, "GPSRESETHOME");
+        *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
+        *blinking = true;
+        return;
+    }
+
 #ifdef USE_ADC_INTERNAL
     const int16_t coreTemperature = getCoreTemperatureCelsius();
     if (osdWarnGetState(OSD_WARNING_CORE_TEMPERATURE) && coreTemperature >= osdConfig()->core_temp_alarm) {


### PR DESCRIPTION
Made two changes:
1) Added the ability to reset the home point on the remote control.
2) Added automatic reset of the home point in flight when GPS FIX occurs, if the home point was not fixed during takeoff, so that the drone returns at least to the place where it is flying now.

More details here:
https://github.com/betaflight/betaflight/issues/13544

All changes have been successfully tested in the field in various situations on the Flywoo Explorer lr4 o3 quadcopter with dji remote controller 2.