### PR TITLE
Headtracker output on SBus

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -250,6 +250,7 @@ COMMON_SRC = \
             io/rcdevice_cam.c \
             io/rcdevice.c \
             io/gps.c \
+            io/headtracker.c \
             io/ledstrip.c \
             io/pidaudio.c \
             osd/osd.c \

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -137,6 +137,7 @@ bool cliMode = false;
 #include "pg/bus_i2c.h"
 #include "pg/bus_spi.h"
 #include "pg/gyrodev.h"
+#include "pg/headtracker.h"
 #include "pg/max7456.h"
 #include "pg/mco.h"
 #include "pg/motor.h"
@@ -5209,6 +5210,9 @@ const cliResourceValue_t resourceTable[] = {
 #ifdef USE_PIN_PULL_UP_DOWN
     DEFA( OWNER_PULLUP,        PG_PULLUP_CONFIG,   pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),
     DEFA( OWNER_PULLDOWN,      PG_PULLDOWN_CONFIG, pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),
+#endif
+#ifdef USE_HEADTRACKER
+    DEFS( OWNER_HEADTRACKER,   PG_HEADTRACKER_CONFIG, headtrackerConfig_t, headtracker_ioTag),
 #endif
 };
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -88,6 +88,7 @@
 #include "pg/dyn_notch.h"
 #include "pg/flash.h"
 #include "pg/gyrodev.h"
+#include "pg/headtracker.h"
 #include "pg/max7456.h"
 #include "pg/mco.h"
 #include "pg/motor.h"
@@ -793,6 +794,15 @@ const clivalue_t valueTable[] = {
 #ifdef USE_SERIALRX
     { PARAM_NAME_SERIAL_RX_PROVIDER, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SERIAL_RX }, PG_RX_CONFIG, offsetof(rxConfig_t, serialrx_provider) },
     { "serialrx_inverted",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, serialrx_inverted) },
+#endif
+#ifdef USE_SERIALTX
+    { "serialtx_inverted",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, serialtx_inverted) },
+#endif
+#ifdef USE_HEADTRACKER
+    { "headtracker_max_angle",       VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 180}, PG_RX_CONFIG, offsetof(headtrackerConfig_t, headtracker_max_angle) },
+    { "headtracker_yaw_shimmy_enable", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(headtrackerConfig_t, headtracker_yaw_shimmy_enable) },
+    { "headtracker_yaw_shimmy_amplitude", VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 50, 500}, PG_RX_CONFIG, offsetof(headtrackerConfig_t, headtracker_yaw_shimmy_amplitude) },
+    { "headtracker_yaw_shimmy_count", VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 3, 10}, PG_RX_CONFIG, offsetof(headtrackerConfig_t, headtracker_yaw_shimmy_count) },
 #endif
 #ifdef USE_SPEKTRUM_BIND
     { "spektrum_sat_bind",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { SPEKTRUM_SAT_BIND_DISABLED, SPEKTRUM_SAT_BIND_MAX}, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind) },

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -116,4 +116,5 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     [OWNER_LPUART_TX] = "LPUART_TX",
     [OWNER_LPUART_RX] = "LPUART_RX",
     "GYRO_CLKIN",
+    "HEADTRACKER",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -114,6 +114,7 @@ typedef enum {
     OWNER_LPUART_TX,             // TX must be just before RX
     OWNER_LPUART_RX,
     OWNER_GYRO_CLKIN,
+    OWNER_HEADTRACKER,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -114,6 +114,7 @@
 #include "io/flashfs.h"
 #include "io/gimbal.h"
 #include "io/gps.h"
+#include "io/headtracker.h"
 #include "io/ledstrip.h"
 #include "io/pidaudio.h"
 #include "io/piniobox.h"
@@ -158,6 +159,7 @@
 #include "pg/vtx_io.h"
 
 #include "rx/rx.h"
+#include "rx/sbus.h"
 #include "rx/spektrum.h"
 
 #include "scheduler/scheduler.h"
@@ -763,6 +765,14 @@ void init(void)
     failsafeInit();
 
     rxInit();
+
+#ifdef USE_SERIALTX
+    txInit();
+#endif
+
+#ifdef USE_HEADTRACKER
+    headtrackerInit();
+#endif
 
 #ifdef USE_GPS
     if (featureIsEnabled(FEATURE_GPS)) {

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -65,6 +65,7 @@
 #include "io/dashboard.h"
 #include "io/flashfs.h"
 #include "io/gps.h"
+#include "io/headtracker.h"
 #include "io/ledstrip.h"
 #include "io/piniobox.h"
 #include "io/serial.h"
@@ -84,6 +85,7 @@
 
 #include "rx/rx.h"
 #include "rx/rc_stats.h"
+#include "rx/sbus.h"
 
 #include "scheduler/scheduler.h"
 
@@ -362,6 +364,11 @@ task_attribute_t task_attributes[TASK_COUNT] = {
 #endif
 
     [TASK_RX] = DEFINE_TASK("RX", NULL, rxUpdateCheck, taskUpdateRxMain, TASK_PERIOD_HZ(33), TASK_PRIORITY_HIGH), // If event-based scheduling doesn't work, fallback to periodic scheduling
+
+#if defined(USE_HEADTRACKER) && defined(USE_SERIALTX)
+    // Run the SBus output task at 14ms intervals for standard rate
+    [TASK_HEADTRACKER] = DEFINE_TASK("HEADTRACKER", NULL, NULL, taskHeadtracker, 14000, TASK_PRIORITY_MEDIUM),
+#endif
     [TASK_DISPATCH] = DEFINE_TASK("DISPATCH", NULL, NULL, dispatchProcess, TASK_PERIOD_HZ(1000), TASK_PRIORITY_HIGH),
 
 #ifdef USE_BEEPER
@@ -520,6 +527,10 @@ void tasksInit(void)
 #endif
 
     setTaskEnabled(TASK_RX, true);
+
+#if defined(USE_HEADTRACKER)
+    setTaskEnabled(TASK_HEADTRACKER, true);
+#endif
 
     setTaskEnabled(TASK_DISPATCH, dispatchIsEnabled());
 

--- a/src/main/io/headtracker.c
+++ b/src/main/io/headtracker.c
@@ -1,0 +1,134 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "common/axis.h"
+
+#include "drivers/io.h"
+
+#include "fc/rc_controls.h"
+
+#include "pg/headtracker.h"
+
+#include "rx/rx.h"
+#include "rx/sbus.h"
+
+#include "sensors/gyro.h"
+
+#include "flight/imu.h"
+
+#if defined(USE_HEADTRACKER)
+static int16_t yawOffset = 1800;
+static IO_t headtrackerIO;
+
+#define SHIMMY_PERIOD 500000 // 500ms
+
+void headtrackerYawReset(void)
+{
+    // Capture the offset to express current yaw as 0 degrees
+    yawOffset = (1800 - attitude.values.yaw + 3600) % 3600;
+}
+
+bool headtrackerInit(void)
+{
+    headtrackerIO = IOGetByTag(headtrackerConfig()->headtracker_ioTag);
+
+    // Initialise the resource pin used for yaw reset
+    if (headtrackerIO) {
+        IOInit(headtrackerIO, OWNER_HEADTRACKER, 0);
+        IOConfigGPIO(headtrackerIO, IOCFG_IPU);
+    }
+
+    return true;
+}
+
+void taskHeadtracker(uint32_t currentTime)
+{
+    UNUSED(currentTime);
+    int16_t angles[3];
+    uint16_t channels[3];
+    float yawGyro = gyroGetFilteredDownsampled(YAW);
+    static int8_t shimmyCount = 0;
+    static uint32_t shimmyStartTime = 0;
+
+    // Check for a head shimmy to reset yaw
+    if (headtrackerConfig()->headtracker_yaw_shimmy_enable) {
+        uint16_t shimmyAmplitude = headtrackerConfig()->headtracker_yaw_shimmy_amplitude;
+
+        // Check for a head shimmy to reset the yaw
+        if (cmpTimeUs(currentTime, shimmyStartTime) > SHIMMY_PERIOD) {
+            // Shimmy phase timed out so reset
+            shimmyCount = 0;
+        }
+
+        // Look for alternate yaw directions in rapid succession exceeding a given amplitude
+        bool odd = shimmyCount % 2;
+
+        if ((odd && (yawGyro > shimmyAmplitude)) || (!odd && (yawGyro < -shimmyAmplitude))) {
+            shimmyStartTime = currentTime;
+            shimmyCount++;
+        }
+
+        // Check if the required number of shakes have been seen
+        if (shimmyCount == headtrackerConfig()->headtracker_yaw_shimmy_count) {
+            shimmyCount = 0;
+            headtrackerYawReset();
+        }
+    }
+
+    // Check for headtracker reset switch activation
+    if (headtrackerIO && !IORead(headtrackerIO)) {
+        shimmyCount = 0;
+        headtrackerYawReset();
+    }
+
+    // Express a level attitude as 0 degrees RPY
+    angles[ROLL] = attitude.values.roll + 1800;
+    angles[PITCH] = attitude.values.pitch + 1800;
+    angles[YAW] = (attitude.values.yaw + yawOffset) % 3600;
+
+    // Limit the max angle of delection
+    if (headtrackerConfig()->headtracker_max_angle) {
+        const int newValueMin = 1800 - headtrackerConfig()->headtracker_max_angle * 10;
+        const int newValueMax = 1800 + headtrackerConfig()->headtracker_max_angle * 10;
+        for (int channel = 0; channel < 3; channel++) {
+            angles[channel] = scaleRange(angles[channel], newValueMin, newValueMax, 0, 3600);
+            angles[channel] = constrain(angles[channel], 0, 3600);
+        }
+    }
+
+    // Convert the decidegrees value to the 11 bit channel value
+    for (int channel = 0; channel < 3; channel++) {
+        channels[channel] = angles[channel] * 2048 / 3600;
+    }
+
+    // Use the SBus output to send attitude information for headtracking
+    sbusTx(channels, 3);
+}
+#endif
+
+
+

--- a/src/main/io/headtracker.h
+++ b/src/main/io/headtracker.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if defined(USE_HEADTRACKER)
+bool headtrackerInit(void);
+void headtrackerYawReset(void);
+void taskHeadtracker(uint32_t currentTime);
+#endif

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -218,6 +218,13 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
     }
 #endif
 
+#ifdef SERIALTX_UART
+    serialPortConfig_t *serialTxUartConfig = serialFindPortConfigurationMutable(SERIALTX_UART);
+    if (serialTxUartConfig) {
+        serialTxUartConfig->functionMask = FUNCTION_TX_SERIAL;
+    }
+#endif
+
 #ifdef SBUS_TELEMETRY_UART
     serialPortConfig_t *serialTelemetryUartConfig = serialFindPortConfigurationMutable(SBUS_TELEMETRY_UART);
     if (serialTelemetryUartConfig) {

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -51,6 +51,7 @@ typedef enum {
     FUNCTION_LIDAR_TF            = (1 << 15), // 32768
     FUNCTION_FRSKY_OSD           = (1 << 16), // 65536
     FUNCTION_VTX_MSP             = (1 << 17), // 131072
+    FUNCTION_TX_SERIAL           = (1 << 18), // 262144
 } serialPortFunction_e;
 
 #define TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY_HUB | FUNCTION_TELEMETRY_LTM | FUNCTION_TELEMETRY_MAVLINK)

--- a/src/main/pg/headtracker.c
+++ b/src/main/pg/headtracker.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headtracker support
+
+#include "platform.h"
+
+#ifdef USE_HEADTRACKER
+
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+#include "pg/headtracker.h"
+
+PG_REGISTER_WITH_RESET_TEMPLATE(headtrackerConfig_t, headtrackerConfig, PG_HEADTRACKER_CONFIG, 0);
+
+PG_RESET_TEMPLATE(headtrackerConfig_t, headtrackerConfig,
+    .headtracker_max_angle = 0,
+    .headtracker_yaw_shimmy_enable = true,
+    .headtracker_yaw_shimmy_amplitude = 100,
+    .headtracker_yaw_shimmy_count = 5
+);
+
+#endif

--- a/src/main/pg/headtracker.h
+++ b/src/main/pg/headtracker.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drivers/io_types.h"
+
+#include "pg/pg.h"
+
+typedef struct headtrackerConfig_s {
+    ioTag_t headtracker_ioTag;                 // Pin used to reset yaw on headtracker
+    uint8_t headtracker_max_angle;             // angle for headtracker to report 100% as output; Leave at 0 to have 0 - 360 range
+    uint8_t headtracker_yaw_shimmy_enable;     // when true: resets yaw headtracker with head shimmy (quick small shaking)
+    uint8_t headtracker_yaw_shimmy_amplitude;  // amplitutde of required head shimmy (quick small shaking)
+    uint8_t headtracker_yaw_shimmy_count;      // count of required head shimmy (quick small shaking)
+} headtrackerConfig_t;
+
+PG_DECLARE(headtrackerConfig_t, headtrackerConfig);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -158,7 +158,8 @@
 #define PG_SCHEDULER_CONFIG         556
 #define PG_MSP_CONFIG               557
 //#define PG_SOFTSERIAL_PIN_CONFIG    558  // removed, merged into SERIAL_PIN_CONFIG
-#define PG_BETAFLIGHT_END           557
+#define PG_HEADTRACKER_CONFIG       559
+#define PG_BETAFLIGHT_END           559
 
 
 // OSD configuration (subject to change)

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -114,6 +114,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .sbus_baud_fast = false,
         .msp_override_channels_mask = 0,
         .crsf_use_negotiated_baud = false,
+        .serialtx_inverted = 0,
     );
 
 #ifdef RX_CHANNELS_TAER

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -64,6 +64,7 @@ typedef struct rxConfig_s {
     uint32_t msp_override_channels_mask;       // Channels to override when the MSP override mode is enabled
     uint8_t msp_override_failsafe;             // if false then extra RC link is always required in msp_override mode, true - allows control via msp_override without extra RC link (autonomous use case)
     uint8_t crsf_use_negotiated_baud;          // Use negotiated baud rate for CRSF V3
+    uint8_t serialtx_inverted;                 // invert the serial TX protocol compared to it's default setting
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -72,7 +72,6 @@
 #include "rx/targetcustomserial.h"
 #include "rx/msp_override.h"
 
-
 const char rcChannelLetters[] = "AERT12345678abcdefgh";
 
 static uint16_t rssi = 0;                  // range: [0;1023]
@@ -273,6 +272,14 @@ static bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntime
         break;
     }
     return enabled;
+}
+#endif
+
+#ifdef USE_SERIALTX
+void txInit(void)
+{
+    // For now only support SBUS output
+    (void)sbusTxInit();
 }
 #endif
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -172,6 +172,7 @@ extern linkQualitySource_e linkQualitySource;
 extern rxRuntimeState_t rxRuntimeState; //!!TODO remove this extern, only needed once for channelCount
 
 void rxInit(void);
+void txInit(void);
 void rxProcessPending(bool state);
 bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);

--- a/src/main/rx/sbus.h
+++ b/src/main/rx/sbus.h
@@ -21,3 +21,8 @@
 #pragma once
 
 bool sbusInit(const rxConfig_t *initialRxConfig, rxRuntimeState_t *rxRuntimeState);
+
+#ifdef USE_SERIALTX
+bool sbusTxInit();
+bool sbusTx(uint16_t *angles, int angleCount);
+#endif

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -182,6 +182,9 @@ typedef enum {
 #ifdef USE_RC_STATS
     TASK_RC_STATS,
 #endif
+#ifdef USE_HEADTRACKER
+    TASK_HEADTRACKER,
+#endif // USE_HEADTRACKER
 
     /* Count of real tasks */
     TASK_COUNT,

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -173,7 +173,7 @@
 
 #define USE_PINIO
 
-#if !defined(USE_SERIAL_RX)
+#if !defined(USE_SERIALRX)
 
 #define USE_SERIALRX
 #define USE_SERIALRX_CRSF       // Team Black Sheep Crossfire protocol
@@ -185,7 +185,7 @@
 #define USE_SERIALRX_XBUS       // JR
 #define USE_SERIALRX_SRXL2      // Spektrum SRXL2 protocol
 
-#endif // !defined(USE_SERIAL_RX)
+#endif // !defined(USE_SERIALRX)
 
 #if !defined(USE_TELEMETRY)
 #define USE_TELEMETRY
@@ -442,6 +442,10 @@
 #endif
 
 #endif // defined(USE_SERIALRX_CRSF)
+
+#if !defined(USE_SERIALTX) && defined(USE_HEADTRACKER)
+#define USE_SERIALTX
+#endif
 
 // USE_RACE_PRO feature pack
 #ifdef USE_RACE_PRO


### PR DESCRIPTION
This PR allows an FC to be used as a headtracker outputting data on SBus which may then be fed into an EdgeTX transmitter to either use for direct control or passed to a quadcopter to control a gimbal for example. The headtracker FC can also be mounted on a transmitter such as a Radiomater TX12 to enable the orientation of the controller to be used in the same way.

To enable the functionality build with `EXTRA_FLAGS="-DUSE_HEADTRACKER"`.

To select the serial port on which to output the SBus signal use `serial n 262144 115200 57600 0 115200` where `n` is the UART number (zero based, so UART1 would be `0`).

By default the `serialtx_inverted` setting is `ON` so it can be fed into an EdgeTX transmitter. If you wish to feed this directly into SBus compatible equipment then this should be set to `OFF`.

Roll/Pitch/Yaw are output on channels 0/1/2 respectively.

The roll and pitch angles will be output as mid-stick (1500) if the head tracker is level and will go lower or higher to communicate negative or positive angles respectively. The angle can be limited using the `headtracker_max_angle`, but if left at the default of `0`, no limit is imposed.

Whilst roll and pitch naturally zero with a level FC, yaw has no such reference. On reset it will point ahead but were one to then turn you'd get a constant offset. Two mechanisms are provided to recenter the yaw output to mid-stick (1500). The first is through a new `HEADTRACKER` resource.

Thus, were one to have a VTX connector with UART2 RX/TX available the following settings would send SBus data out on the TX line and have the RX line used as a reset which simply needs to be connected to ground via a momentary switch to operate.

```
# resources
resource SERIAL_RX 2 NONE
resource HEADTRACKER 1 A03

# serial
serial 1 262144 115200 57600 0 115200
```

As an alternative to the switch to reset yaw, a more convenient option, when used as a head tracker on goggles, is to simply shake on the yaw axis to reset by performing a quick head shimmy. The settings used to control this are shown below with their default values and ranges, and can be adjusted to need more or less duration and vigour of said shimmy. Alternatively this function can be disabled.

```
headtracker_yaw_shimmy_enable = ON
Allowed values: OFF, ON

headtracker_yaw_shimmy_amplitude = 100
Allowed range: 50 - 500

headtracker_yaw_shimmy_count = 5
Allowed range: 3 - 10
```

Thanks to @limonspb for the idea to do this, implementing the `headtracker_max_angle` functionality, and for doing the testing.

@limonspb please upload pictures and videos of your setup with the TX12 transmitter, together with your settings for the FC and radio.