### PR TITLE
Add all_configs make target to build all FC configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,8 +505,8 @@ clean_all: $(TARGETS_CLEAN) test_clean
 ## configs           : Hydrate configuration
 configs: configs
 
-## configs_all       : Build all configs
-configs_all: $(BASE_CONFIGS)
+## all_configs       : Build all configs
+all_configs: $(BASE_CONFIGS)
 
 TARGETS_FLASH = $(addsuffix _flash,$(BASE_TARGETS))
 

--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,12 @@ $(CONFIGS_CLEAN):
 ## clean_all         : clean all targets
 clean_all: $(TARGETS_CLEAN) test_clean
 
+## configs           : Hydrate configuration
+configs: configs
+
+## configs_all       : Build all configs
+configs_all: $(BASE_CONFIGS)
+
 TARGETS_FLASH = $(addsuffix _flash,$(BASE_TARGETS))
 
 ## <TARGET>_flash    : build and flash a target


### PR DESCRIPTION
To improve pre-merge testing this adds support for `make configs_all` to build all targets in the `src/config/configs` directory.