### PR TITLE
TPA delay in ms (for wings)

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1663,7 +1663,10 @@ static bool blackboxWriteSysinfo(void)
 #endif
 #endif
 #endif
+
+#ifdef USE_WING
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_DELAY_MS, "%d", currentPidProfile->tpa_delay_ms);
+#endif
 
         default:
             return true;

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1663,6 +1663,7 @@ static bool blackboxWriteSysinfo(void)
 #endif
 #endif
 #endif
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_DELAY_MS, "%d", currentPidProfile->tpa_delay_ms);
 
         default:
             return true;

--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -117,4 +117,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "MAG_CALIB",
     "MAG_TASK_RATE",
     "EZLANDING",
+    "TPA",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -119,6 +119,7 @@ typedef enum {
     DEBUG_MAG_CALIB,
     DEBUG_MAG_TASK_RATE,
     DEBUG_EZLANDING,
+    DEBUG_TPA,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1259,6 +1259,10 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_LOW_BREAKPOINT,      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PWM_RANGE_MIN, PWM_RANGE_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_breakpoint) },
     { PARAM_NAME_TPA_LOW_ALWAYS, VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_always) },
 
+#ifdef USE_WING
+    { PARAM_NAME_TPA_DELAY_MS, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_delay_ms) },
+#endif
+
     { PARAM_NAME_EZ_LANDING_THRESHOLD,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
     { PARAM_NAME_EZ_LANDING_LIMIT,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 75 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
     { PARAM_NAME_EZ_LANDING_SPEED,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_speed) },

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -48,11 +48,13 @@ FAST_CODE_NOINLINE float pt1FilterGain(float f_cut, float dT)
     return omega / (omega + 1.0f);
 }
 
+// Calculates filter cutoff frequency based on delay (time constant) - time it takes for filter response to reach 63.2% of a step input.
 FAST_CODE float pt1FilterCutoffFromDelay(float delay)
 {
     return 1.0f / (2.0f * M_PIf * delay);
 }
 
+// Calculates filter gain based on delay (time constant) - time it takes for filter response to reach 63.2% of a step input.
 float pt1FilterGainFromDelay(float delay, float dT)
 {
     if (delay == 0) {
@@ -92,6 +94,7 @@ FAST_CODE float pt2FilterGain(float f_cut, float dT)
     return pt1FilterGain(f_cut * CUTOFF_CORRECTION_PT2, dT);
 }
 
+// Calculates filter gain based on delay (time constant) - time it takes for filter response to reach 63.2% of a step input.
 float pt2FilterGainFromDelay(float delay, float dT)
 {
     if (delay == 0) {

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -48,20 +48,14 @@ FAST_CODE_NOINLINE float pt1FilterGain(float f_cut, float dT)
     return omega / (omega + 1.0f);
 }
 
-// Calculates filter cutoff frequency based on delay (time constant of filter) - time it takes for filter response to reach 63.2% of a step input.
-FAST_CODE float pt1FilterCutoffFromDelay(float delay)
-{
-    return 1.0f / (2.0f * M_PIf * delay);
-}
-
 // Calculates filter gain based on delay (time constant of filter) - time it takes for filter response to reach 63.2% of a step input.
-FAST_CODE float pt1FilterGainFromDelay(float delay, float dT)
+float pt1FilterGainFromDelay(float delay, float dT)
 {
     if (delay == 0) {
         return 1.0f; // gain = 1 means no filtering
     }
 
-    const float cutoffHz = pt1FilterCutoffFromDelay(delay);
+    const float cutoffHz = 1.0f / (2.0f * M_PIf * delay);
     return pt1FilterGain(cutoffHz, dT);
 }
 
@@ -95,7 +89,7 @@ FAST_CODE float pt2FilterGain(float f_cut, float dT)
 }
 
 // Calculates filter gain based on delay (time constant of filter) - time it takes for filter response to reach 63.2% of a step input.
-FAST_CODE float pt2FilterGainFromDelay(float delay, float dT)
+float pt2FilterGainFromDelay(float delay, float dT)
 {
     if (delay == 0) {
         return 1.0f; // gain = 1 means no filtering

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -48,14 +48,14 @@ FAST_CODE_NOINLINE float pt1FilterGain(float f_cut, float dT)
     return omega / (omega + 1.0f);
 }
 
-// Calculates filter cutoff frequency based on delay (time constant) - time it takes for filter response to reach 63.2% of a step input.
+// Calculates filter cutoff frequency based on delay (time constant of filter) - time it takes for filter response to reach 63.2% of a step input.
 FAST_CODE float pt1FilterCutoffFromDelay(float delay)
 {
     return 1.0f / (2.0f * M_PIf * delay);
 }
 
-// Calculates filter gain based on delay (time constant) - time it takes for filter response to reach 63.2% of a step input.
-float pt1FilterGainFromDelay(float delay, float dT)
+// Calculates filter gain based on delay (time constant of filter) - time it takes for filter response to reach 63.2% of a step input.
+FAST_CODE float pt1FilterGainFromDelay(float delay, float dT)
 {
     if (delay == 0) {
         return 1.0f; // gain = 1 means no filtering
@@ -94,8 +94,8 @@ FAST_CODE float pt2FilterGain(float f_cut, float dT)
     return pt1FilterGain(f_cut * CUTOFF_CORRECTION_PT2, dT);
 }
 
-// Calculates filter gain based on delay (time constant) - time it takes for filter response to reach 63.2% of a step input.
-float pt2FilterGainFromDelay(float delay, float dT)
+// Calculates filter gain based on delay (time constant of filter) - time it takes for filter response to reach 63.2% of a step input.
+FAST_CODE float pt2FilterGainFromDelay(float delay, float dT)
 {
     if (delay == 0) {
         return 1.0f; // gain = 1 means no filtering

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -135,7 +135,7 @@ float pt3FilterGainFromDelay(float delay, float dT)
     }
 
     const float cutoffHz = 1.0f / (M_PIf * delay * CUTOFF_CORRECTION_PT3);
-    return pt2FilterGain(cutoffHz, dT);
+    return pt3FilterGain(cutoffHz, dT);
 }
 
 void pt3FilterInit(pt3Filter_t *filter, float k)

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -110,6 +110,7 @@ void pt2FilterUpdateCutoff(pt2Filter_t *filter, float k);
 float pt2FilterApply(pt2Filter_t *filter, float input);
 
 float pt3FilterGain(float f_cut, float dT);
+float pt3FilterGainFromDelay(float delay, float dT);
 void pt3FilterInit(pt3Filter_t *filter, float k);
 void pt3FilterUpdateCutoff(pt3Filter_t *filter, float k);
 float pt3FilterApply(pt3Filter_t *filter, float input);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -98,11 +98,13 @@ typedef struct meanAccumulator_s {
 float nullFilterApply(filter_t *filter, float input);
 
 float pt1FilterGain(float f_cut, float dT);
+float pt1FilterGainFromDelay(float delay, float dT);
 void pt1FilterInit(pt1Filter_t *filter, float k);
 void pt1FilterUpdateCutoff(pt1Filter_t *filter, float k);
 float pt1FilterApply(pt1Filter_t *filter, float input);
 
 float pt2FilterGain(float f_cut, float dT);
+float pt2FilterGainFromDelay(float delay, float dT);
 void pt2FilterInit(pt2Filter_t *filter, float k);
 void pt2FilterUpdateCutoff(pt2Filter_t *filter, float k);
 float pt2FilterApply(pt2Filter_t *filter, float input);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -58,6 +58,7 @@
 #define PARAM_NAME_TPA_LOW_BREAKPOINT "tpa_low_breakpoint"
 #define PARAM_NAME_TPA_LOW_ALWAYS "tpa_low_always"
 #define PARAM_NAME_TPA_MODE "tpa_mode"
+#define PARAM_NAME_TPA_DELAY_MS "tpa_delay_ms"
 #define PARAM_NAME_MIXER_TYPE "mixer_type"
 #define PARAM_NAME_EZ_LANDING_THRESHOLD "ez_landing_threshold"
 #define PARAM_NAME_EZ_LANDING_LIMIT "ez_landing_limit"

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -88,7 +88,7 @@ FAST_DATA_ZERO_INIT float throttleBoost;
 pt1Filter_t throttleLpf;
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(pidConfig_t, pidConfig, PG_PID_CONFIG, 4);
 
 #ifndef DEFAULT_PID_PROCESS_DENOM
 #define DEFAULT_PID_PROCESS_DENOM       1

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -230,6 +230,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .ez_landing_threshold = 25,
         .ez_landing_limit = 15,
         .ez_landing_speed = 50,
+        .tpa_delay_ms = 0,
     );
 
 #ifndef USE_D_MIN
@@ -292,7 +293,17 @@ void pidUpdateTpaFactor(float throttle)
     } else {
         tpaRate = pidRuntime.tpaLowMultiplier * (pidRuntime.tpaLowBreakpoint - throttle);
     }
+
+    DEBUG_SET(DEBUG_TPA, 0, lrintf(pidRuntime.tpaFactor * 1000));
     pidRuntime.tpaFactor = 1.0f - tpaRate;
+
+#ifdef WING
+    if (isFixedWing()) {
+        pidRuntime.tpaFactor = pt2FilterApply(&pidRuntime.tpaLpf, pidRuntime.tpaFactor);
+    }    
+#endif
+    
+    DEBUG_SET(DEBUG_TPA, 1, lrintf(pidRuntime.tpaFactor * 1000));
 }
 
 void pidUpdateAntiGravityThrottleFilter(float throttle)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -294,16 +294,17 @@ void pidUpdateTpaFactor(float throttle)
         tpaRate = pidRuntime.tpaLowMultiplier * (pidRuntime.tpaLowBreakpoint - throttle);
     }
 
-    DEBUG_SET(DEBUG_TPA, 0, lrintf(pidRuntime.tpaFactor * 1000));
-    pidRuntime.tpaFactor = 1.0f - tpaRate;
+    float tpaFactor = 1.0f - tpaRate;
+    DEBUG_SET(DEBUG_TPA, 0, lrintf(tpaFactor * 1000));
 
 #ifdef USE_WING
     if (isFixedWing()) {
-        pidRuntime.tpaFactor = pt2FilterApply(&pidRuntime.tpaLpf, pidRuntime.tpaFactor);
+        tpaFactor = pt2FilterApply(&pidRuntime.tpaLpf, tpaFactor);
     }    
 #endif
-    
-    DEBUG_SET(DEBUG_TPA, 1, lrintf(pidRuntime.tpaFactor * 1000));
+
+    DEBUG_SET(DEBUG_TPA, 1, lrintf(tpaFactor * 1000));
+    pidRuntime.tpaFactor = tpaFactor;
 }
 
 void pidUpdateAntiGravityThrottleFilter(float throttle)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -297,7 +297,7 @@ void pidUpdateTpaFactor(float throttle)
     DEBUG_SET(DEBUG_TPA, 0, lrintf(pidRuntime.tpaFactor * 1000));
     pidRuntime.tpaFactor = 1.0f - tpaRate;
 
-#ifdef WING
+#ifdef USE_WING
     if (isFixedWing()) {
         pidRuntime.tpaFactor = pt2FilterApply(&pidRuntime.tpaLpf, pidRuntime.tpaFactor);
     }    

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -245,6 +245,7 @@ typedef struct pidProfile_s {
     uint8_t ez_landing_threshold;           // Threshold stick position below which motor output is limited
     uint8_t ez_landing_limit;               // Maximum motor output when all sticks centred and throttle zero
     uint8_t ez_landing_speed;               // Speed below which motor output is limited
+    uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -299,6 +300,9 @@ typedef struct pidRuntime_s {
     pt1Filter_t ptermYawLowpass;
     bool antiGravityEnabled;
     pt2Filter_t antiGravityLpf;
+#ifdef USE_WING
+    pt2Filter_t tpaLpf;
+#endif
     float antiGravityOsdCutoff;
     float antiGravityThrottleD;
     float itermAccelerator;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -245,7 +245,7 @@ typedef struct pidProfile_s {
     uint8_t ez_landing_threshold;           // Threshold stick position below which motor output is limited
     uint8_t ez_landing_limit;               // Maximum motor output when all sticks centred and throttle zero
     uint8_t ez_landing_speed;               // Speed below which motor output is limited
-    uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter
+    uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter (time constant)
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -300,9 +300,6 @@ typedef struct pidRuntime_s {
     pt1Filter_t ptermYawLowpass;
     bool antiGravityEnabled;
     pt2Filter_t antiGravityLpf;
-#ifdef USE_WING
-    pt2Filter_t tpaLpf;
-#endif
     float antiGravityOsdCutoff;
     float antiGravityThrottleD;
     float itermAccelerator;
@@ -426,6 +423,10 @@ typedef struct pidRuntime_s {
     float angleTarget[2];
     bool axisInAngleMode[3];
     float maxRcRateInv[2];
+#endif
+
+#ifdef USE_WING
+    pt2Filter_t tpaLpf;
 #endif
 } pidRuntime_t;
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -257,6 +257,9 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 #endif
 
     pt2FilterInit(&pidRuntime.antiGravityLpf, pt2FilterGain(pidProfile->anti_gravity_cutoff_hz, pidRuntime.dT));
+#ifdef USE_WING
+    pt2FilterInit(&pidRuntime.tpaLpf, pt2FilterGainFromDelay(pidProfile->tpa_delay_ms / 1000.0f, pidRuntime.dT));
+#endif
 }
 
 void pidInit(const pidProfile_t *pidProfile)


### PR DESCRIPTION
Wing speed has a delay from throttle.
The faster the wing goes the less PIDs is needed.
This is a simple way to introduce this delay for TPA for wings.
Future possible improvements: use GPS 3D speed for TPA factor, when GPS is available.

Include `USE_WING` in the build (not included by default)
`set tpa_delay_ms = 500` will add PT2 filter with a step response delay of 500 milliseconds.
`set tpa_delay_ms = 0` makes zero delay/no pt2 filter (default)
Value of 1000ms is a good starting point for tuning:
`set tpa_delay_ms = 1000`


new debug mode `TPA`
`DEBUG_SET(DEBUG_TPA, 0, lrintf(pidRuntime.tpaFactor * 1000));` - TPA factor before PT2
`DEBUG_SET(DEBUG_TPA, 1, lrintf(pidRuntime.tpaFactor * 1000));` - TPA factor after PT2

Original code had `tpa_cutoff_hz` but i think operating with step response delay in ms is more clear and user-friendly.
`USE_WING` define will have more wing/plane-specific features that i have queued up for later.