### PR TITLE
Add Serial Delay Option

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1001,6 +1001,7 @@ const clivalue_t valueTable[] = {
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },
     { "serial_update_rate_hz",      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 2000 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, serial_update_rate_hz) },
+    { "serial_delay_ms",            VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, serial_delay_ms) },
 
 // PG_IMU_CONFIG
     { PARAM_NAME_IMU_DCM_KP,          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 32000 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_dcm_kp) },

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -217,6 +217,7 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
 
     serialConfig->reboot_character = 'R';
     serialConfig->serial_update_rate_hz = 100;
+    serialConfig->serial_delay_ms = 0;
 }
 
 baudRate_e lookupBaudRateIndex(uint32_t baudRate)

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -143,6 +143,7 @@ typedef struct serialPortConfig_s {
 typedef struct serialConfig_s {
     serialPortConfig_t portConfigs[SERIAL_PORT_COUNT];
     uint16_t serial_update_rate_hz;
+    uint16_t serial_delay_ms;
     uint8_t reboot_character;               // which byte is used to reboot. Default 'R', could be changed carefully to something else.
 } serialConfig_t;
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -508,10 +508,6 @@ static void mspSerialProcessReceivedReply(mspPort_t *msp, mspProcessReplyFnPtr m
  */
 void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessCommandFnPtr mspProcessCommandFn, mspProcessReplyFnPtr mspProcessReplyFn)
 {
-    if (millis() < serialConfig()->serial_delay_ms) {
-        return;
-    }
-
     for (uint8_t portIndex = 0; portIndex < MAX_MSP_PORT_COUNT; portIndex++) {
         mspPort_t * const mspPort = &mspPorts[portIndex];
         if (!mspPort->port) {
@@ -521,6 +517,14 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
         mspPostProcessFnPtr mspPostProcessFn = NULL;
 
         if (serialRxBytesWaiting(mspPort->port)) {
+            if (mspPort->port->identifier != SERIAL_PORT_USB_VCP && millis() < serialConfig()->serial_delay_ms) {
+                // clear rx buffer
+                while (serialRxBytesWaiting(mspPort->port)) {
+                    serialRead(mspPort->port);
+                }
+                return;
+            }
+
             // There are bytes incoming - abort pending request
             mspPort->lastActivityMs = millis();
             mspPort->pendingRequest = MSP_PENDING_NONE;

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -508,6 +508,10 @@ static void mspSerialProcessReceivedReply(mspPort_t *msp, mspProcessReplyFnPtr m
  */
 void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessCommandFnPtr mspProcessCommandFn, mspProcessReplyFnPtr mspProcessReplyFn)
 {
+    if (millis() < serialConfig()->serial_delay_ms) {
+        return;
+    }
+
     for (uint8_t portIndex = 0; portIndex < MAX_MSP_PORT_COUNT; portIndex++) {
         mspPort_t * const mspPort = &mspPorts[portIndex];
         if (!mspPort->port) {


### PR DESCRIPTION
This PR add a new `serial_delay_ms` setting. The idea is to delay the serial communication / uart ports by a specific delay on startup. For example, ArduCopter has a similar setting: [TELEM_DELAY](https://ardupilot.org/copter/docs/parameters.html#telem-delay-telemetry-startup-delay). I have a project, where I'm connecting the Betaflight flight computer via serial to a companion computer, but betaflight prevents it from booting because the communication on the uart port interrupts the startup sequence.

I think this could be also a useful setting for other project with similar setups. :)