### PR TITLE
Set next state expected time on per element basis

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -202,12 +202,9 @@ const osd_stats_e osdStatsDisplayOrder[OSD_STAT_COUNT] = {
     OSD_STAT_AVG_THROTTLE,
 };
 
-// Group elements in a number of groups to reduce task scheduling overhead
-#define OSD_GROUP_COUNT                 OSD_ITEM_COUNT
-// Aim to render a group of elements within a target time
-#define OSD_ELEMENT_RENDER_TARGET       30
-
 #define OSD_TASK_MARGIN                 1
+#define OSD_ELEMENT_MARGIN              1
+
 // Decay the estimated max task duration by 1/(1 << OSD_EXEC_TIME_SHIFT) on every invocation
 #define OSD_EXEC_TIME_SHIFT             8
 
@@ -1376,7 +1373,6 @@ void osdUpdate(timeUs_t currentTimeUs)
 {
     static uint16_t osdStateDurationFractionUs[OSD_STATE_COUNT] = { 0 };
     static uint32_t osdElementDurationFractionUs[OSD_ITEM_COUNT] = { 0 };
-    static bool firstPass = true;
     timeUs_t executeTimeUs;
     osdState_e osdCurrentState = osdState;
 
@@ -1507,29 +1503,20 @@ void osdUpdate(timeUs_t currentTimeUs)
         {
             bool moreElements = true;
 
-            for (int rendered = 0; moreElements; rendered++) {
-                uint8_t osdCurrentElement = osdGetActiveElement();
+            uint8_t osdNextElement = osdGetActiveElement();
 
-                timeUs_t startElementTime = micros();
+            timeUs_t startElementTime = micros();
 
-                timeUs_t anticipatedEndUs = startElementTime + (osdElementDurationFractionUs[osdCurrentElement] >> OSD_EXEC_TIME_SHIFT);
+            moreElements = osdDrawNextActiveElement(osdDisplayPort, startElementTime);
 
-                if ((rendered > 0) && cmpTimeUs(anticipatedEndUs, currentTimeUs) > OSD_ELEMENT_RENDER_TARGET) {
-                    // There isn't time to render the next element
-                    break;
-                }
+            executeTimeUs = micros() - startElementTime;
 
-                moreElements = osdDrawNextActiveElement(osdDisplayPort, currentTimeUs);
-
-                executeTimeUs = micros() - startElementTime;
-
-                if (executeTimeUs > (osdElementDurationFractionUs[osdCurrentElement] >> OSD_EXEC_TIME_SHIFT)) {
-                    osdElementDurationFractionUs[osdCurrentElement] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
-                } else if (osdElementDurationFractionUs[osdCurrentElement] > 0) {
-                    // Slowly decay the max time
-                    osdElementDurationFractionUs[osdCurrentElement]--;
-                }
-            };
+            if (executeTimeUs > (osdElementDurationFractionUs[osdNextElement] >> OSD_EXEC_TIME_SHIFT)) {
+                osdElementDurationFractionUs[osdNextElement] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
+            } else if (osdElementDurationFractionUs[osdNextElement] > 0) {
+                // Slowly decay the max time
+                osdElementDurationFractionUs[osdNextElement]--;
+            }
 
             if (moreElements) {
                 // There are more elements to draw
@@ -1578,7 +1565,6 @@ void osdUpdate(timeUs_t currentTimeUs)
             break;
         }
 
-        firstPass = false;
         osdState = OSD_STATE_IDLE;
 
         break;
@@ -1592,21 +1578,18 @@ void osdUpdate(timeUs_t currentTimeUs)
     if (!schedulerGetIgnoreTaskExecTime()) {
         executeTimeUs = micros() - currentTimeUs;
 
-
-        // On the first pass no element groups will have been formed, so all elements will have been
-        // rendered which is unrepresentative, so ignore
-        if (!firstPass) {
-            if (executeTimeUs > (osdStateDurationFractionUs[osdCurrentState] >> OSD_EXEC_TIME_SHIFT)) {
-                osdStateDurationFractionUs[osdCurrentState] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
-            } else if (osdStateDurationFractionUs[osdCurrentState] > 0) {
-                // Slowly decay the max time
-                osdStateDurationFractionUs[osdCurrentState]--;
-            }
+        if (executeTimeUs > (osdStateDurationFractionUs[osdCurrentState] >> OSD_EXEC_TIME_SHIFT)) {
+            osdStateDurationFractionUs[osdCurrentState] = executeTimeUs << OSD_EXEC_TIME_SHIFT;
+        } else if (osdStateDurationFractionUs[osdCurrentState] > 0) {
+            // Slowly decay the max time
+            osdStateDurationFractionUs[osdCurrentState]--;
         }
     }
 
     if (osdState == OSD_STATE_IDLE) {
-        schedulerSetNextStateTime((osdStateDurationFractionUs[OSD_STATE_CHECK] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
+        schedulerSetNextStateTime((osdStateDurationFractionUs[OSD_STATE_CHECK] >> OSD_EXEC_TIME_SHIFT));
+    } else if (osdState == OSD_STATE_UPDATE_ELEMENTS) {
+        schedulerSetNextStateTime((osdElementDurationFractionUs[osdGetActiveElement()] >> OSD_EXEC_TIME_SHIFT) + OSD_ELEMENT_MARGIN);
     } else {
         schedulerSetNextStateTime((osdStateDurationFractionUs[osdState] >> OSD_EXEC_TIME_SHIFT) + OSD_TASK_MARGIN);
     }


### PR DESCRIPTION
May fix: https://github.com/betaflight/betaflight/issues/13656

The ability to schedule the OSD task is based on knowledge of the likely time for each [state](https://github.com/betaflight/betaflight/blob/660018b1de0c32ee60d8321f301d36fb1fd097f9/src/main/osd/osd.c#L1329) to execute.

This is OK typically, but when in the `OSD_STATE_UPDATE_ELEMENTS` state there is some variation in the required time to render elements. This PR therefore sets the expected next state duration for this state based on the element to be rendered. It also removes any attempt to render elements in groups. As a result, rather than always having to find a time slot big enough for the most complex element, smaller time slots can be utilised.

Tested on `ZEEZF7V3` and `MATEKF405TE` with Walksnail.

I'd be grateful if somebody could test on analog as my video capture card is playing up.