### PR TITLE
Fix unused variable compile time error

### DIFF
--- a/src/main/drivers/mcu/stm32/sdio_f7xx.c
+++ b/src/main/drivers/mcu/stm32/sdio_f7xx.c
@@ -1368,7 +1368,7 @@ SD_Error_t SD_GetCardStatus(SD_CardStatus_t* pCardStatus)
 static SD_Error_t SD_PowerON(void)
 {
     SD_Error_t ErrorState;
-    uint32_t   Response;
+    uint32_t   Response = 0;
     uint32_t   Count;
     uint32_t   ValidVoltage;
     uint32_t   SD_Type;


### PR DESCRIPTION
A debug build was resulting in the following error which this PR fixes.

```
./src/main/drivers/stm32/sdio_f7xx.c: In function 'SD_PowerON':
./src/main/drivers/stm32/sdio_f7xx.c:1442:22: error: 'Response' may be used uninitialized [-Werror=maybe-uninitialized]
 1442 |         if((Response & SD_RESP_HIGH_CAPACITY) == SD_RESP_HIGH_CAPACITY)
      |            ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
./src/main/drivers/stm32/sdio_f7xx.c:1371:16: note: 'Response' was declared here
 1371 |     uint32_t   Response;
```