### PR TITLE
Fixes #13664 - Smartaudio don't work with Softserial 

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -501,11 +501,11 @@ static void saSendFrame(uint8_t *buf, int len)
         case SERIAL_PORT_SOFTSERIAL1:
         case SERIAL_PORT_SOFTSERIAL2:
             if (vtxSettingsConfig()->softserialAlt) {
-                serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start bit
+                serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start byte
             }
             break;
         default:
-            serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start bit
+            serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start byte
             break;
         }
 
@@ -707,7 +707,7 @@ bool vtxSmartAudioInit(void)
     // the SA protocol instead requires pulldowns, and therefore uses SERIAL_BIDIR_PP_PD instead of SERIAL_BIDIR_PP
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_SMARTAUDIO);
     if (portConfig) {
-        portOptions_e portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR | SERIAL_BIDIR_PP_PD;
+        portOptions_e portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR | SERIAL_BIDIR_PP_PD | SERIAL_BIDIR_NOPULL;
 
         smartAudioSerialPort = openSerialPort(portConfig->identifier, FUNCTION_VTX_SMARTAUDIO, NULL, NULL, 4800, MODE_RXTX, portOptions);
     }


### PR DESCRIPTION
Fixes #13664
In Smartaudio the softserial port option has changed from 4.4.x to 4.5.0. By this the Smartaudio line is in an unknown voltage state while no TX is running - this violates the Smartaudio standard. vtx_softserial_alt should be set to OFF when using Smartaudio. 

To test it I used the LED pin of the FURYF4OSD connected to TBS Unify Pro HV. Additional I tested it with serial port 6. Both tests where successful. More information can be found below. 

It is desirable to bring this fix into a patch release of 4.5.

If someone wants to test the changes please find the prebuilds:

[betaflight_4.6.0.zip](https://github.com/user-attachments/files/15933049/betaflight_4.6.0.zip)

I could identify the issue. In (https://github.com/betaflight/betaflight/pull/12929) the port options where adapted in vtx_smartaudio.c. Compared to previous version the option now does not include SERIAL_BIDIR_NOPULL. This option is disabling the pull down/up in RX mode.

In serial_softserial.c the pull option is not considered. It sets the pullup/down based on the SERIAL_INVERTED option. As Smartaudio is not inverted it will set a pullup. I assume the Smartaudio device has a pulldown included. So a voltage divider is build which explains the undefined voltage level on the Smartaudio line.

Additional I figured out that the Smartaudio standard is violated at least on my TBS Unify Pro HV. The standard says:

"The SmartAudio line need to be low before a frame is sent. If the host MCU can’t handle this it can be done by
sending a 0x00 dummy byte in front of the actual frame."

![image](https://github.com/betaflight/betaflight/assets/18699122/660ba753-6aec-4ea4-be1d-f84a9cfb6fb2)
![image](https://github.com/betaflight/betaflight/assets/18699122/5b8c9c56-02f4-4096-b872-06d41aea63c5)

This can be seen on the images above. As soon this is done the flight controller can't communicate to the Smartaudio device (even with this fix - images are captured on R4.5.0 image). But this can be fixed via the following cli command:

set vtx_softserial_alt = OFF


