### PR TITLE
FIX: Release build asset name change

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   release:
     types: [published]
-        
+
 jobs:
   ci:
     name: CI
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: List assets
         run: ls -al Assets
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -x
           ASSETS=()
-          for asset in Assets/*.hex; do
+          for asset in ./*/*.hex; do
             ASSETS+=("$asset")
             echo "$asset"
           done


### PR DESCRIPTION
Clean up of the github actions following the asset name change. Missed in last PR.