### PR TITLE
Update to LSM6DSV16X gyro driver

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
@@ -947,20 +947,26 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
     // Wait for the device to be ready
     while (spiReadRegMsk(dev, LSM6DSV_CTRL3 & LSM6DSV_CTRL3_SW_RESET)) {}
 
-    // Select high-accuracy ODR mode 1 before leaving power-off mode
+    // Autoincrement register address when doing block SPI reads and update continuously
+    spiWriteReg(dev, LSM6DSV_CTRL3, LSM6DSV_CTRL3_IF_INC | LSM6DSV_CTRL3_BDU);      /*BDU bit need to be set*/
+
+    // Select high-accuracy ODR mode 1
     spiWriteReg(dev, LSM6DSV_HAODR_CFG,
                 LSM6DSV_ENCODE_BITS(LSM6DSV_HAODR_MODE1,
                                     LSM6DSV_HAODR_CFG_HAODR_SEL_MASK,
                                     LSM6DSV_HAODR_CFG_HAODR_SEL_SHIFT));
 
-    // Enable the accelerometer in high accuracy mode at 1kHz
+    // Enable the accelerometer in high accuracy
     spiWriteReg(dev, LSM6DSV_CTRL1,
                 LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_OP_MODE_XL_HIGH_ACCURACY,
                                     LSM6DSV_CTRL1_OP_MODE_XL_MASK,
-                                    LSM6DSV_CTRL1_OP_MODE_XL_SHIFT) |
-                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_ODR_XL_1000HZ,
-                                    LSM6DSV_CTRL1_ODR_XL_MASK,
-                                    LSM6DSV_CTRL1_ODR_XL_SHIFT));
+                                    LSM6DSV_CTRL1_OP_MODE_XL_SHIFT));
+
+    // Enable the gyro in high accuracy
+    spiWriteReg(dev, LSM6DSV_CTRL2,
+                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL2_OP_MODE_G_HIGH_ACCURACY,
+                                    LSM6DSV_CTRL2_OP_MODE_G_MASK,
+                                    LSM6DSV_CTRL2_OP_MODE_G_SHIFT));
 
     // Enable 16G sensitivity
     spiWriteReg(dev, LSM6DSV_CTRL8,
@@ -968,11 +974,14 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
                                     LSM6DSV_CTRL8_FS_XL_MASK,
                                     LSM6DSV_CTRL8_FS_XL_SHIFT));
 
-    // Enable the gyro in high accuracy mode at 8kHz
+    // Enable the accelerometer odr at 1kHz
+    spiWriteReg(dev, LSM6DSV_CTRL1,
+                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_ODR_XL_1000HZ,
+                                    LSM6DSV_CTRL1_ODR_XL_MASK,
+                                    LSM6DSV_CTRL1_ODR_XL_SHIFT));
+
+    // Enable the gyro odr at 8kHz
     spiWriteReg(dev, LSM6DSV_CTRL2,
-                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL2_OP_MODE_G_HIGH_ACCURACY,
-                                    LSM6DSV_CTRL2_OP_MODE_G_MASK,
-                                    LSM6DSV_CTRL2_OP_MODE_G_SHIFT) |
                 LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL2_ODR_G_8000HZ,
                                     LSM6DSV_CTRL2_ODR_G_MASK,
                                     LSM6DSV_CTRL2_ODR_G_SHIFT));
@@ -986,9 +995,6 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
                 LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL6_FS_G_2000DPS,
                                     LSM6DSV_CTRL6_FS_G_MASK,
                                     LSM6DSV_CTRL6_FS_G_SHIFT));
-
-    // Autoincrement register address when doing block SPI reads and update continuously
-    spiWriteReg(dev, LSM6DSV_CTRL3, LSM6DSV_CTRL3_IF_INC);
 
     // Enable the gyro digital LPF1 filter
     spiWriteReg(dev, LSM6DSV_CTRL7, LSM6DSV_CTRL7_LPF1_G_EN);

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
@@ -945,7 +945,7 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
     spiWriteReg(dev, LSM6DSV_CTRL3, LSM6DSV_CTRL3_SW_RESET);
 
     // Wait for the device to be ready
-    while (spiReadRegMsk(dev, LSM6DSV_CTRL3 & LSM6DSV_CTRL3_SW_RESET)) {}
+    while (spiReadRegMsk(dev, LSM6DSV_CTRL3) & LSM6DSV_CTRL3_SW_RESET) {}
 
     // Autoincrement register address when doing block SPI reads and update continuously
     spiWriteReg(dev, LSM6DSV_CTRL3, LSM6DSV_CTRL3_IF_INC | LSM6DSV_CTRL3_BDU);      /*BDU bit need to be set*/

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
@@ -860,23 +860,6 @@ uint8_t lsm6dsv16xSpiDetect(const extDevice_t *dev)
 
 void lsm6dsv16xAccInit(accDev_t *acc)
 {
-    const extDevice_t *dev = &acc->gyro->dev;
-
-    // Enable the accelerometer in high accuracy mode at 1kHz
-    spiWriteReg(dev, LSM6DSV_CTRL1,
-                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_OP_MODE_XL_HIGH_ACCURACY,
-                                    LSM6DSV_CTRL1_OP_MODE_XL_MASK,
-                                    LSM6DSV_CTRL1_OP_MODE_XL_SHIFT) |
-                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_ODR_XL_1000HZ,
-                                    LSM6DSV_CTRL1_ODR_XL_MASK,
-                                    LSM6DSV_CTRL1_ODR_XL_SHIFT));
-
-    // Enable 16G sensitivity
-    spiWriteReg(dev, LSM6DSV_CTRL8,
-                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL8_FS_XL_16G,
-                                    LSM6DSV_CTRL8_FS_XL_MASK,
-                                    LSM6DSV_CTRL8_FS_XL_SHIFT));
-
     // ±16G mode
     acc->acc_1G = 512 * 4;
 }
@@ -961,11 +944,29 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
     // Perform a software reset
     spiWriteReg(dev, LSM6DSV_CTRL3, LSM6DSV_CTRL3_SW_RESET);
 
+    // Wait for the device to be ready
+    while (spiReadRegMsk(dev, LSM6DSV_CTRL3 & LSM6DSV_CTRL3_SW_RESET)) {}
+
     // Select high-accuracy ODR mode 1 before leaving power-off mode
     spiWriteReg(dev, LSM6DSV_HAODR_CFG,
                 LSM6DSV_ENCODE_BITS(LSM6DSV_HAODR_MODE1,
                                     LSM6DSV_HAODR_CFG_HAODR_SEL_MASK,
                                     LSM6DSV_HAODR_CFG_HAODR_SEL_SHIFT));
+
+    // Enable the accelerometer in high accuracy mode at 1kHz
+    spiWriteReg(dev, LSM6DSV_CTRL1,
+                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_OP_MODE_XL_HIGH_ACCURACY,
+                                    LSM6DSV_CTRL1_OP_MODE_XL_MASK,
+                                    LSM6DSV_CTRL1_OP_MODE_XL_SHIFT) |
+                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL1_ODR_XL_1000HZ,
+                                    LSM6DSV_CTRL1_ODR_XL_MASK,
+                                    LSM6DSV_CTRL1_ODR_XL_SHIFT));
+
+    // Enable 16G sensitivity
+    spiWriteReg(dev, LSM6DSV_CTRL8,
+                LSM6DSV_ENCODE_BITS(LSM6DSV_CTRL8_FS_XL_16G,
+                                    LSM6DSV_CTRL8_FS_XL_MASK,
+                                    LSM6DSV_CTRL8_FS_XL_SHIFT));
 
     // Enable the gyro in high accuracy mode at 8kHz
     spiWriteReg(dev, LSM6DSV_CTRL2,
@@ -977,6 +978,7 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
                                     LSM6DSV_CTRL2_ODR_G_SHIFT));
 
     // Enable 2000 deg/s sensitivity and selected LPF1 filter setting
+    // Set the LPF1 filter bandwidth
     spiWriteReg(dev, LSM6DSV_CTRL6,
                 LSM6DSV_ENCODE_BITS(lsm6dsv16xLPF1BandwidthOptions[gyroConfig()->gyro_hardware_lpf],
                                     LSM6DSV_CTRL6_LPF1_G_BW_MASK,
@@ -987,6 +989,9 @@ void lsm6dsv16xGyroInit(gyroDev_t *gyro)
 
     // Autoincrement register address when doing block SPI reads and update continuously
     spiWriteReg(dev, LSM6DSV_CTRL3, LSM6DSV_CTRL3_IF_INC);
+
+    // Enable the gyro digital LPF1 filter
+    spiWriteReg(dev, LSM6DSV_CTRL7, LSM6DSV_CTRL7_LPF1_G_EN);
 
     // Generate pulse on interrupt line, not requiring a read to clear
     spiWriteReg(dev, LSM6DSV_CTRL4, LSM6DSV_CTRL4_DRDY_PULSED);


### PR DESCRIPTION
STMicro advised some changes to the driver to get the gyro LPF1 filtering working.

Tested on an `AIRBOTSUPERF4` to the extent that the gyro and acceleromter respond. Correct operation of the filters will need flight testing.