### PR TITLE
[4.5.1] FIX: make: Circular configs <- configs dependency dropped. (#13695)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,9 +501,6 @@ $(CONFIGS_CLEAN):
 ## clean_all         : clean all targets
 clean_all: $(TARGETS_CLEAN) test_clean
 
-## configs           : Hydrate configuration
-configs: configs
-
 TARGETS_FLASH = $(addsuffix _flash,$(BASE_TARGETS))
 
 ## <TARGET>_flash    : build and flash a target


### PR DESCRIPTION
(cherry picked from commit 660018b1de0c32ee60d8321f301d36fb1fd097f9)
