### PR TITLE
Add Lint Target to Makefile

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,13 @@
+style=kr
+indent=spaces=4
+min-conditional-indent=0
+max-instatement-indent=80
+pad-header
+pad-oper
+align-pointer=name
+align-reference=name
+max-code-length=120
+convert-tabs
+preserve-date
+suffix=none
+mode=c

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.c]
+indent_size = 4
+
+[*.{markdown,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

### Changes
- Introduce a simple make target for linting files to keep the coding style consistent.
- Moves linter arguments specified in the docs closer to the code for easier modifications as a .astylerc file.
- Add .editorconfig with basic defaults.
- Pin astyle linter version to 3.1

### How to use

To lint all the source files:
```sh
make lint
```

To lint specific files, for example only the cli directory C files(you can also hardcode the relative path to a single file):
```sh
LINT_TARGETS=$(find ./src/main/cli -type f -name '*.c' | xargs) make lint
```

### Tested on Ubuntu 22.04
If you have docker installed and you don't want to install astyle linter directly on your machine - here is a quick one-liner to test it on ubuntu 22.04:
```sh
docker run --rm -v $(pwd):/code -e LINT_TARGETS=./src/main/cli/cli.c -w /code ubuntu:22.04 bash -c "apt-get update && apt-get install -y git make astyle && make lint"
```

P.S I didn't run the command on the entire source code because there are a lot of code styling modifications (to be exact 523 files), this way it's easier to review.
I couldn't find where CodeStyle.md file is, wanted to adjust the docs accordingly.
 