### PR TITLE
Increase Number of Available Dynamic Notches to 7

### DIFF
--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -19,11 +19,11 @@
  */
 
 /* original work by Rav
- * 
+ *
  * 2018_07 updated by ctzsnooze to post filter, wider Q, different peak detection
  * coding assistance and advice from DieHertz, Rav, eTracer
  * test pilots icr4sh, UAV Tech, Flint723
- * 
+ *
  * 2021_02 updated by KarateBrot: switched FFT with SDFT, multiple notches per axis
  * test pilots: Sugar K, bizmar
  */
@@ -375,7 +375,8 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             }
 
             if (state.axis == gyro.gyroDebugAxis) {
-                for (int p = 0; p < dynNotch.count && p < 3; p++) {
+                for (int p = 1; p <= dynNotch.count && p <= DYN_NOTCH_COUNT_MAX; p++) {
+                  // debug channel 0 is reserved for pre DN gyro
                     DEBUG_SET(DEBUG_FFT_FREQ, p, lrintf(dynNotch.centerFreq[state.axis][p]));
                 }
                 DEBUG_SET(DEBUG_DYN_LPF, 1, lrintf(dynNotch.centerFreq[state.axis][0]));

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -375,9 +375,9 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             }
 
             if (state.axis == gyro.gyroDebugAxis) {
-                for (int p = 1; p <= dynNotch.count && p <= DYN_NOTCH_COUNT_MAX; p++) {
-                  // debug channel 0 is reserved for pre DN gyro
-                    DEBUG_SET(DEBUG_FFT_FREQ, p, lrintf(dynNotch.centerFreq[state.axis][p]));
+                for (int p = 0; p < dynNotch.count && p < DYN_NOTCH_COUNT_MAX; p++) {
+                    // debug channel 0 is reserved for pre DN gyro
+                    DEBUG_SET(DEBUG_FFT_FREQ, p + 1, lrintf(dynNotch.centerFreq[state.axis][p]));
                 }
                 DEBUG_SET(DEBUG_DYN_LPF, 1, lrintf(dynNotch.centerFreq[state.axis][0]));
             }

--- a/src/main/flight/dyn_notch_filter.h
+++ b/src/main/flight/dyn_notch_filter.h
@@ -26,7 +26,7 @@
 
 #include "pg/dyn_notch.h"
 
-#define DYN_NOTCH_COUNT_MAX 5
+#define DYN_NOTCH_COUNT_MAX 7
 
 void dynNotchInit(const dynNotchConfig_t *config, const timeUs_t targetLooptimeUs);
 void dynNotchPush(const int axis, const float sample);

--- a/src/main/sensors/gyro_filter_impl.c
+++ b/src/main/sensors/gyro_filter_impl.c
@@ -68,7 +68,7 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(void)
         if (isDynNotchActive()) {
             if (axis == gyro.gyroDebugAxis) {
                 GYRO_FILTER_DEBUG_SET(DEBUG_FFT, 0, lrintf(gyroADCf));
-                GYRO_FILTER_DEBUG_SET(DEBUG_FFT_FREQ, 3, lrintf(gyroADCf));
+                GYRO_FILTER_DEBUG_SET(DEBUG_FFT_FREQ, 0, lrintf(gyroADCf));
                 GYRO_FILTER_DEBUG_SET(DEBUG_DYN_LPF, 0, lrintf(gyroADCf));
             }
 


### PR DESCRIPTION
This is a simple PR to utilize the 8 columns/channels available in the debug 'FFT_FREQ', which currently contains only the first 3 dynamic notch center frequencies and pre-dynamic notch gyro signal. The PR includes a proposal to increase the Dynamic notch count max from the current 5, to 7, leaving one debug channel for the pre-Dynamic notch gyro signal. These changes will allow us to log ALL the dynamic notch centers plus the pre dyn notch gyro for a selected axis. The debug 'FFT_FREQ' will contain the following columns:

0. Pre Dynamic Notch Gyro for the selected axis
1. DN 1 center freq
2. DN 2 center freq
3. DN 3 center freq
4. DN 4 center freq
5. DN 5 center freq
6. DN 6 center freq
7. DN 7 center freq

With this change, the maximum configurable Dyn Notch Count will remain as 5 in the Configurator GUI, and DN 6 and 7 would be configurable only from the CLI. 

Why do we need more DNs? Wouldn't this be CPU intensive? There are many instances where the ability to ultilize more than 5 notches would be useful, specifically on larger (cinelifter etc) rigs with ESCs that are not capable of bidirectional dshot (e.g., APD 200a ESCs). Also, in many such rigs it is common to use bi-blade props which result in more motor harmonics than the typical tri-blades we are used to. For these reasons, more flexibility in the Max Dyn notch count would be valuable, as would the ability to log and see the effectiveness of selecting x number of notches. CPU resources in such a case would be fine because bidirectional dshot would not be an option, and therefore no enabled, freeing up resources for the additional DNs if needed.

The fig below shows an example of the 7 notch centers in red, overlay on a freq x time spectrogram (RPM filters off; Just for illustration of the PR) 
![image](https://github.com/betaflight/betaflight/assets/17284912/70e90547-c915-46c5-9974-e30b4e5e201a)

