### PR TITLE
rename fix: smoothStepUpTransition

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -156,7 +156,7 @@ int16_t qPercent(fix12_t q);
 int16_t qMultiply(fix12_t q, int16_t input);
 fix12_t qConstruct(int16_t num, int16_t den);
 
-float smoothStepDownTransition(const float x, const float center, const float width);
+float smoothStepUpTransition(const float x, const float center, const float width);
 
 static inline int constrain(int amt, int low, int high)
 {


### PR DESCRIPTION
fixing the function name, since now it's smoothStepUpTransition, not "Down"

maths.c already has `smoothStepUpTransition`