### PR TITLE
Modify STM32F405 UID Address for MSC Enumeration

### DIFF
--- a/src/main/drivers/mcu/stm32/usbd_msc_desc.c
+++ b/src/main/drivers/mcu/stm32/usbd_msc_desc.c
@@ -33,9 +33,15 @@
 #include "usb_regs.h"
 #include "platform.h"
 
+#if defined (STM32F4)
+#define         DEVICE_ID1          (0x1FFF7A10)
+#define         DEVICE_ID2          (0x1FFF7A14)
+#define         DEVICE_ID3          (0x1FFF7A18)
+#else
 #define         DEVICE_ID1          (0x1FFFF7E8)
 #define         DEVICE_ID2          (0x1FFFF7EA)
 #define         DEVICE_ID3          (0x1FFFF7EC)
+#endif
 #define  USB_SIZ_STRING_SERIAL       0x1A
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY


### PR DESCRIPTION
**Purpose of Modification:**
This update aims to resolve the inconsistency between the UID address on the STM32F405 microcontroller and its description in the ST manual.
Specifically as follows:
![image](https://github.com/user-attachments/assets/dae675a0-6307-4377-9eb2-e1d97e9fd10c)
**Modification Details:**
It has been identified that the current UID address used does not align with the description provided in the ST manual, potentially causing configuration and device recognition issues. We plan to update the UID address to align with the description in the ST manual, ensuring consistency between documentation and implementation.

Specifically as follows:
![image](https://github.com/user-attachments/assets/07373b2b-d664-4f52-8fb0-23cc3e341f9f)

