### PR TITLE
Read gyro data from correct lsm6dsv16x registers

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
@@ -1048,7 +1048,7 @@ bool lsm6dsv16xGyroReadSPI(gyroDev_t *gyro)
     case GYRO_EXTI_INT:
     case GYRO_EXTI_NO_INT:
     {
-        gyro->dev.txBuf[0] = gyro->gyroDataReg | 0x80;
+        gyro->dev.txBuf[0] = LSM6DSV_OUTX_L_G | 0x80;
 
         busSegment_t segments[] = {
                 {.u.buffers = {NULL, NULL}, 7, true, NULL},


### PR DESCRIPTION
This PR fixes the issue where the wrong registers were being read from the gyro if DMA mode was not being used.