### PR TITLE
Assign RPM Limiter average rpm filter cutoff factor to adjustable parameter 'rpm_limit_rpm_filter_cutoff'

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -955,6 +955,7 @@ const clivalue_t valueTable[] = {
     { "rpm_limit_i",                VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 1000 },       PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit_i) },
     { "rpm_limit_d",                VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 },        PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit_d) },
     { "rpm_limit_value",            VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 1, UINT16_MAX }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit_value) },
+    { "rpm_limit_rpm_filter_cutoff",    VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 1, 1000 },        PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit_rpm_filter_cutoff) },
 #endif
 
 // PG_MOTOR_3D_CONFIG

--- a/src/main/cms/cms_menu_rpm_limit.c
+++ b/src/main/cms/cms_menu_rpm_limit.c
@@ -40,6 +40,7 @@
 uint16_t rpm_limit_value;
 uint16_t kv;
 bool rpm_limit;
+uint16_t rpm_limit_rpm_filter_cutoff;
 
 static const void *cmsx_RpmLimit_onEnter(displayPort_t *pDisp)
 {
@@ -48,6 +49,7 @@ static const void *cmsx_RpmLimit_onEnter(displayPort_t *pDisp)
     rpm_limit_value = mixerConfig()->rpm_limit_value;
     kv = motorConfig()->kv;
     rpm_limit = mixerConfig()->rpm_limit;
+    rpm_limit_rpm_filter_cutoff = mixerConfig()->rpm_limit_rpm_filter_cutoff;
 
     return NULL;
 }
@@ -60,6 +62,7 @@ static const void *cmsx_RpmLimit_onExit(displayPort_t *pDisp, const OSD_Entry *s
     mixerConfigMutable()->rpm_limit_value = rpm_limit_value;
     motorConfigMutable()->kv = kv;
     mixerConfigMutable()->rpm_limit = rpm_limit;
+    mixerConfigMutable()->rpm_limit_rpm_filter_cutoff = rpm_limit_rpm_filter_cutoff;
 
     return NULL;
 }
@@ -70,6 +73,7 @@ static const OSD_Entry cmsx_menuRpmLimitEntries[] =
     {  "ACTIVE",   OME_Bool | REBOOT_REQUIRED,  NULL, &rpm_limit },
     { "MAX RPM", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limit_value, 0, UINT16_MAX, 100} },
     { "KV", OME_UINT16, NULL, &(OSD_UINT16_t){ &kv, 0, UINT16_MAX, 1} },
+    { "RPM FILTER CUTOFF", OME_UINT16, NULL, &(OSD_UINT16_t){ &rpm_limit_rpm_filter_cutoff, 1, UINT16_MAX, 1000} }, 
 
     { "SAVE&REBOOT",     OME_OSD_Exit, cmsMenuExit,   (void *)CMS_POPUP_SAVEREBOOT },
     { "BACK", OME_Back, NULL, NULL },

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -103,6 +103,7 @@ typedef struct mixerConfig_s {
     uint16_t rpm_limit_i;
     uint16_t rpm_limit_d;
     uint16_t rpm_limit_value;
+    uint16_t rpm_limit_rpm_filter_cutoff;
 #endif
 } mixerConfig_t;
 

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -62,6 +62,7 @@ void pgResetFn_mixerConfig(mixerConfig_t *mixerConfig)
     mixerConfig->rpm_limit_i = 10;
     mixerConfig->rpm_limit_d = 8;
     mixerConfig->rpm_limit_value = 18000;
+    mixerConfig->rpm_limit_rpm_filter_cutoff = 6;
 #endif
 }
 
@@ -362,7 +363,7 @@ void mixerInitProfile(void)
     mixerRuntime.rpmLimiterIGain = mixerConfig()->rpm_limit_i * 1e-3f * pidGetDT();
     mixerRuntime.rpmLimiterDGain = mixerConfig()->rpm_limit_d * 3e-7f * pidGetPidFrequency();
     mixerRuntime.rpmLimiterI = 0.0;
-    pt1FilterInit(&mixerRuntime.rpmLimiterAverageRpmFilter, pt1FilterGain(6.0f, pidGetDT()));
+    pt1FilterInit(&mixerRuntime.rpmLimiterAverageRpmFilter, pt1FilterGain(mixerConfig()->rpm_limit_rpm_filter_cutoff, pidGetDT()));
     pt1FilterInit(&mixerRuntime.rpmLimiterThrottleScaleOffsetFilter, pt1FilterGain(2.0f, pidGetDT()));
     mixerResetRpmLimiter();
 #endif

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -2199,7 +2199,7 @@ bool osdDrawNextActiveElement(displayPort_t *osdDisplayPort, timeUs_t currentTim
 #ifdef USE_SPEC_PREARM_SCREEN
 bool osdDrawSpec(displayPort_t *osdDisplayPort)
 {
-    static enum {RPM, POLES, MIXER, THR, MOTOR, BAT, VER} specState = RPM;
+    static enum {RPM, POLES, MIXER, THR, MOTOR, RPM_FILT_HZ, BAT, VER} specState = RPM;
     static int currentRow;
 
     const uint8_t midRow = osdDisplayPort->rows / 2;
@@ -2212,7 +2212,7 @@ bool osdDrawSpec(displayPort_t *osdDisplayPort)
     switch (specState) {
     default:
     case RPM:
-        currentRow = midRow - 3;
+        currentRow = midRow - 1;
 #ifdef USE_RPM_LIMIT
         {
             const bool rpmLimitActive = mixerConfig()->rpm_limit > 0 && isMotorProtocolBidirDshot();
@@ -2258,6 +2258,13 @@ bool osdDrawSpec(displayPort_t *osdDisplayPort)
 
     case MOTOR:
         len = tfp_sprintf(buff, "MOTOR LIMIT %d", currentPidProfile->motor_output_limit);
+        displayWrite(osdDisplayPort, midCol - (len / 2), currentRow++, DISPLAYPORT_SEVERITY_NORMAL, buff);
+
+        specState = RPM_FILT_HZ;
+        break;
+
+    case RPM_FILT_HZ:
+        len = tfp_sprintf(buff, "AVG RPM FILT CUTOFF %d", mixerConfig()->rpm_limit_rpm_filter_cutoff);
         displayWrite(osdDisplayPort, midCol - (len / 2), currentRow++, DISPLAYPORT_SEVERITY_NORMAL, buff);
 
         specState = BAT;


### PR DESCRIPTION
This pull request fixes  https://github.com/betaflight/betaflight/issues/13781

BACKGROUND
The RPM limiter uses a PT1 smoothed average RPM as an input to the RPM limiter PID controller. 
The average RPM PT1 filter uses a fixed 6.0f assigned as the cutoff / preK factor. 

PROBLEM
For motors with high responsiveness (like those used in tiny whoops with very high kV) this level of filtering of the average RPM is too strong when using the RPM limiter. The strong filtering creates a significant filter delay of the average RPM signal compared to the actual instantaneous RPM. This leads to uncontrolled initial overshoot of RPM when approaching the limit RPM, as the filtered averageRpm signal lags significantly behind the uncontrolled instantaneous unfiltered RPM. This can be improved by filter tuning on a case-by-case basis. See referenced issue above for more details

SOLUTION
Change the fixed 6.0f value to parameter 'rpm_limit_rpm_filter_cutoff', which can be changed in the CLI.
Add parameter value to Spec Pre Arm screen as 'AVG RPM FILTER CUTOFF', to allow monitoring by spec race organizers.

NOTE: This is my first pull request, so I apologize in advance! ;-)

