### PR TITLE
Fix SmartAudio (STM32F4)

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -710,7 +710,13 @@ bool vtxSmartAudioInit(void)
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_SMARTAUDIO);
     if (portConfig) {
         portOptions_e portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR | SERIAL_BIDIR_PP_PD | SERIAL_BIDIR_NOPULL;
-
+#ifdef USE_SMARTAUDIO_NOPULLDOWN
+        // softserial hack (#13797)
+        if (smartAudioSerialPort->identifier == SERIAL_PORT_SOFTSERIAL1 || smartAudioSerialPort->identifier == SERIAL_PORT_SOFTSERIAL2) {
+            portOptions &= ~SERIAL_BIDIR_PP_PD;
+            portOptions |= SERIAL_BIDIR_PP;
+        }
+#endif
         smartAudioSerialPort = openSerialPort(portConfig->identifier, FUNCTION_VTX_SMARTAUDIO, NULL, NULL, 4800, MODE_RXTX, portOptions);
     }
 

--- a/src/platform/STM32/serial_uart_stm32f4xx.c
+++ b/src/platform/STM32/serial_uart_stm32f4xx.c
@@ -337,13 +337,9 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     if (options & SERIAL_BIDIR) {
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        IOConfigGPIOAF(txIO,
-#ifdef USE_SMARTAUDIO_NOPULLDOWN
-                        ((options & SERIAL_BIDIR_PP) || (options & SERIAL_BIDIR_PP_PD))
-#else
-                        (options & SERIAL_BIDIR_PP_PD) ? IOCFG_AF_PP_PD : (options & SERIAL_BIDIR_PP)
-#endif
-                        ? IOCFG_AF_PP : IOCFG_AF_OD, hardware->af);
+        IOConfigGPIOAF(txIO, (options & SERIAL_BIDIR_PP_PD) ? IOCFG_AF_PP_PD 
+                             : (options & SERIAL_BIDIR_PP) ? IOCFG_AF_PP
+                             : IOCFG_AF_OD, hardware->af);
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));

--- a/src/platform/STM32/serial_uart_stm32f4xx.c
+++ b/src/platform/STM32/serial_uart_stm32f4xx.c
@@ -337,7 +337,13 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     if (options & SERIAL_BIDIR) {
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        IOConfigGPIOAF(txIO, ((options & SERIAL_BIDIR_PP) || (options & SERIAL_BIDIR_PP_PD)) ? IOCFG_AF_PP : IOCFG_AF_OD, hardware->af);
+        IOConfigGPIOAF(txIO,
+#ifdef USE_SMARTAUDIO_NOPULLDOWN
+                        ((options & SERIAL_BIDIR_PP) || (options & SERIAL_BIDIR_PP_PD))
+#else
+                        (options & SERIAL_BIDIR_PP_PD) ? IOCFG_AF_PP_PD : (options & SERIAL_BIDIR_PP)
+#endif
+                        ? IOCFG_AF_PP : IOCFG_AF_OD, hardware->af);
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));

--- a/src/platform/STM32/serial_uart_stm32f4xx.c
+++ b/src/platform/STM32/serial_uart_stm32f4xx.c
@@ -337,9 +337,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
 
     if (options & SERIAL_BIDIR) {
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        IOConfigGPIOAF(txIO, (options & SERIAL_BIDIR_PP_PD) ? IOCFG_AF_PP_PD 
-                             : (options & SERIAL_BIDIR_PP) ? IOCFG_AF_PP
-                             : IOCFG_AF_OD, hardware->af);
+        IOConfigGPIOAF(txIO, ((options & SERIAL_BIDIR_PP) || (options & SERIAL_BIDIR_PP_PD)) ? IOCFG_AF_PP : IOCFG_AF_OD, hardware->af);
     } else {
         if ((mode & MODE_TX) && txIO) {
             IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));


### PR DESCRIPTION
- fixes #13792
- requires adding custom define `SMARTAUDIO_NOPULLDOWN`