### PR TITLE
Add DEBUG_TASK mode

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -120,4 +120,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "TPA",
     "S_TERM",
     "SPA",
+    "TASK",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -122,6 +122,7 @@ typedef enum {
     DEBUG_TPA,
     DEBUG_S_TERM,
     DEBUG_SPA,
+    DEBUG_TASK,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -126,6 +126,8 @@
 #include "sensors/gyro.h"
 #include "sensors/rangefinder.h"
 
+#include "scheduler/scheduler.h"
+
 #include "telemetry/frsky_hub.h"
 #include "telemetry/ibus_shared.h"
 #include "telemetry/telemetry.h"
@@ -1746,6 +1748,8 @@ const clivalue_t valueTable[] = {
 
     { "scheduler_relax_rx",  VAR_UINT16  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_SCHEDULER_CONFIG, PG_ARRAY_ELEMENT_OFFSET(schedulerConfig_t, 0, rxRelaxDeterminism) },
     { "scheduler_relax_osd", VAR_UINT16  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 500 }, PG_SCHEDULER_CONFIG, PG_ARRAY_ELEMENT_OFFSET(schedulerConfig_t, 0, osdRelaxDeterminism) },
+
+    { "scheduler_debug_task", VAR_UINT16  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, TASK_COUNT }, PG_SCHEDULER_CONFIG, PG_ARRAY_ELEMENT_OFFSET(schedulerConfig_t, 0, debugTask) },
 
 #ifdef USE_LATE_TASK_STATISTICS
     { "cpu_late_limit_permille", VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_SCHEDULER_CONFIG, offsetof(schedulerConfig_t, cpuLatePercentageLimit) },

--- a/src/main/pg/scheduler.c
+++ b/src/main/pg/scheduler.c
@@ -23,7 +23,7 @@
 #include "pg/pg_ids.h"
 #include "pg/scheduler.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig, PG_SCHEDULER_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig, PG_SCHEDULER_CONFIG, 2);
 
 PG_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig,
     .rxRelaxDeterminism = SCHEDULER_RELAX_RX,

--- a/src/main/pg/scheduler.h
+++ b/src/main/pg/scheduler.h
@@ -38,6 +38,7 @@ typedef struct schedulerConfig_s {
     uint16_t rxRelaxDeterminism;
     uint16_t osdRelaxDeterminism;
     uint16_t cpuLatePercentageLimit;
+    uint8_t debugTask;
 } schedulerConfig_t;
 
 PG_DECLARE(schedulerConfig_t, schedulerConfig);

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -419,7 +419,9 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
 
         // Execute task
         const timeUs_t currentTimeBeforeTaskCallUs = micros();
+#if defined(USE_LATE_TASK_STATISTICS)
         const timeUs_t estimatedExecutionUs = selectedTask->execTime;
+#endif
         selectedTask->attribute->taskFunc(currentTimeBeforeTaskCallUs);
         taskExecutionTimeUs = micros() - currentTimeBeforeTaskCallUs;
         taskTotalExecutionTime += taskExecutionTimeUs;

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -81,7 +81,8 @@
 // 3 - average (us)
 // 4 - estimated execution time (us)
 // 5 - actual execution time (us)
-// 6 - late count
+// 6 - difference between estimated and actual execution time
+// 7 - late count
 
 extern task_t tasks[];
 
@@ -460,7 +461,8 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
             DEBUG_SET(DEBUG_TASK, 3, selectedTask->movingSumExecutionTime10thUs / TASK_STATS_MOVING_SUM_COUNT / 10);
             DEBUG_SET(DEBUG_TASK, 4, estimatedExecutionUs);
             DEBUG_SET(DEBUG_TASK, 5, taskExecutionTimeUs);
-            DEBUG_SET(DEBUG_TASK, 6, selectedTask->lateCount);
+            DEBUG_SET(DEBUG_TASK, 6, estimatedExecutionUs - taskExecutionTimeUs);
+            DEBUG_SET(DEBUG_TASK, 7, selectedTask->lateCount);
         }
 #endif
     }

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -74,6 +74,15 @@
 // 4 - 10ths % of tasks late in last second
 // 7 - Standard deviation of gyro cycle time in 100th of a us
 
+// DEBUG_TASK, requires USE_LATE_TASK_STATISTICS to be defined
+// 0 - Value of scheduler_debug_task setting
+// 1 - rate (Hz)
+// 2 - max (us)
+// 3 - average (us)
+// 4 - estimated execution time (us)
+// 5 - actual execution time (us)
+// 6 - late count
+
 extern task_t tasks[];
 
 static FAST_DATA_ZERO_INIT task_t *currentTask = NULL;
@@ -409,6 +418,7 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
 
         // Execute task
         const timeUs_t currentTimeBeforeTaskCallUs = micros();
+        const timeUs_t estimatedExecutionUs = selectedTask->execTime;
         selectedTask->attribute->taskFunc(currentTimeBeforeTaskCallUs);
         taskExecutionTimeUs = micros() - currentTimeBeforeTaskCallUs;
         taskTotalExecutionTime += taskExecutionTimeUs;
@@ -440,6 +450,18 @@ FAST_CODE timeUs_t schedulerExecuteTask(task_t *selectedTask, timeUs_t currentTi
         selectedTask->movingAverageCycleTimeUs += 0.05f * (period - selectedTask->movingAverageCycleTimeUs);
 #if defined(USE_LATE_TASK_STATISTICS)
         selectedTask->runCount++;
+
+        if ((selectedTask - tasks) == schedulerConfig()->debugTask) {
+            timeUs_t averageDeltaTime10thUs = selectedTask->movingSumDeltaTime10thUs / TASK_STATS_MOVING_SUM_COUNT;
+            int16_t taskFrequency = averageDeltaTime10thUs == 0 ? 0 : lrintf(1e7f / averageDeltaTime10thUs);
+            DEBUG_SET(DEBUG_TASK, 0, schedulerConfig()->debugTask);
+            DEBUG_SET(DEBUG_TASK, 1, taskFrequency);
+            DEBUG_SET(DEBUG_TASK, 2, selectedTask->maxExecutionTimeUs);
+            DEBUG_SET(DEBUG_TASK, 3, selectedTask->movingSumExecutionTime10thUs / TASK_STATS_MOVING_SUM_COUNT / 10);
+            DEBUG_SET(DEBUG_TASK, 4, estimatedExecutionUs);
+            DEBUG_SET(DEBUG_TASK, 5, taskExecutionTimeUs);
+            DEBUG_SET(DEBUG_TASK, 6, selectedTask->lateCount);
+        }
 #endif
     }
 


### PR DESCRIPTION
Add debug mode with the following logged values:

```
// DEBUG_TASK, requires USE_LATE_TASK_STATISTICS to be defined
// 0 - Value of scheduler_debug_task setting
// 1 - rate (Hz)
// 2 - max (us)
// 3 - average (us)
// 4 - estimated execution time (us)
// 5 - actual execution time (us)
// 6 - difference between estimated and actual execution time
// 7 - late count
```

Set the `scheduler_debug_task` to the task ID of the required task as listed by the `tasks` CLI command.