### PR TITLE
Auto-disarm on landing impact

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1412,6 +1412,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_THRESHOLD, "%d",   currentPidProfile->ez_landing_threshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_LIMIT, "%d",       currentPidProfile->ez_landing_limit);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_LANDING_SPEED, "%d",       currentPidProfile->ez_landing_speed);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_EZ_DISARM_THRESHOLD, "%d",    currentPidProfile->ez_landing_disarm_threshold);
 
 #ifdef USE_WING
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_SPA_ROLL_CENTER, "%d",        currentPidProfile->spa_center[FD_ROLL]);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1276,6 +1276,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_EZ_LANDING_THRESHOLD,      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_threshold) },
     { PARAM_NAME_EZ_LANDING_LIMIT,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 75 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_limit) },
     { PARAM_NAME_EZ_LANDING_SPEED,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_speed) },
+    { PARAM_NAME_EZ_DISARM_THRESHOLD,       VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, ez_landing_disarm_threshold) },
 
 #ifdef USE_WING
     { PARAM_NAME_SPA_ROLL_CENTER,    VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_center[FD_ROLL]) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -266,6 +266,7 @@ static uint16_t cmsx_tpa_breakpoint;
 static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
+static uint8_t cmsx_ez_landing_disarm_threshold;
 
 static const void *cmsx_simplifiedTuningOnEnter(displayPort_t *pDisp)
 {
@@ -610,7 +611,7 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     cmsx_tpa_low_rate = pidProfile->tpa_low_rate;
     cmsx_tpa_low_breakpoint = pidProfile->tpa_low_breakpoint;
     cmsx_tpa_low_always = pidProfile->tpa_low_always;
-
+    cmsx_ez_landing_disarm_threshold = pidProfile->ez_landing_disarm_threshold;
     return NULL;
 }
 
@@ -668,6 +669,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->tpa_low_rate = cmsx_tpa_low_rate;
     pidProfile->tpa_low_breakpoint = cmsx_tpa_low_breakpoint;
     pidProfile->tpa_low_always = cmsx_tpa_low_always;
+    pidProfile->ez_landing_disarm_threshold = cmsx_ez_landing_disarm_threshold;
 
     initEscEndpoints();
     return NULL;
@@ -728,6 +730,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "TPA LOW RATE",  OME_INT8,   NULL, &(OSD_INT8_t) { &cmsx_tpa_low_rate, TPA_LOW_RATE_MIN, TPA_MAX , 1} },
     { "TPA LOW BRKPT", OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_tpa_low_breakpoint, 1000, 2000, 10} },
     { "TPA LOW ALWYS", OME_Bool,   NULL, &cmsx_tpa_low_always },
+    { "EZDISARM THR",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_ez_landing_disarm_threshold, 0, 150, 1} },
 
     { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -55,6 +55,7 @@ typedef enum {
     DISARM_REASON_RUNAWAY_TAKEOFF   = 6,
     DISARM_REASON_GPS_RESCUE        = 7,
     DISARM_REASON_SERIAL_COMMAND    = 8,
+    DISARM_REASON_LANDING           = 9,
 #ifdef UNIT_TEST
     DISARM_REASON_SYSTEM            = 255,
 #endif

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -65,6 +65,7 @@
 #define PARAM_NAME_EZ_LANDING_THRESHOLD "ez_landing_threshold"
 #define PARAM_NAME_EZ_LANDING_LIMIT "ez_landing_limit"
 #define PARAM_NAME_EZ_LANDING_SPEED "ez_landing_speed"
+#define PARAM_NAME_EZ_DISARM_THRESHOLD "ez_landing_disarm_threshold"
 #define PARAM_NAME_SPA_ROLL_CENTER "spa_roll_center"
 #define PARAM_NAME_SPA_ROLL_WIDTH "spa_roll_width"
 #define PARAM_NAME_SPA_ROLL_MODE "spa_roll_mode"

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -326,7 +326,7 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
 static bool imuIsAccelerometerHealthy(void)
 {
     // Accept accel readings only in range 0.9g - 1.1g
-    return (-0.9f < acc.accMagnitude) && (acc.accMagnitude < 1.1f);
+    return (0.9f < acc.accMagnitude) && (acc.accMagnitude < 1.1f);
 }
 
 // Calculate the dcmKpGain to use. When armed, the gain is imuRuntimeConfig.imuDcmKp, i.e., the default value
@@ -679,8 +679,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
         gyroAverage[axis] = gyroGetFilteredDownsampled(axis);
     }
 
-    const bool useAcc = imuIsAccelerometerHealthy(); // all smoothed accADC values are within 10% of 1G !! Used to say 20% but was actually 10%
-
+    const bool useAcc = imuIsAccelerometerHealthy(); // all smoothed accADC values are within 10% of 1G
     imuMahonyAHRSupdate(dt,
                         DEGREES_TO_RADIANS(gyroAverage[X]), DEGREES_TO_RADIANS(gyroAverage[Y]), DEGREES_TO_RADIANS(gyroAverage[Z]),
                         useAcc, acc.accADC[X], acc.accADC[Y], acc.accADC[Z],

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -323,18 +323,10 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
     }
 }
 
-static bool imuIsAccelerometerHealthy(const float *accAverage)
+static bool imuIsAccelerometerHealthy(void)
 {
-    float accMagnitudeSq = 0;
-    for (int axis = 0; axis < 3; axis++) {
-        const float a = accAverage[axis];
-        accMagnitudeSq += a * a;
-    }
-
-    accMagnitudeSq = accMagnitudeSq * sq(acc.dev.acc_1G_rec);
-
     // Accept accel readings only in range 0.9g - 1.1g
-    return (0.81f < accMagnitudeSq) && (accMagnitudeSq < 1.21f);
+    return (-0.1f < acc.accMagnitude) && (acc.accMagnitude < 0.1f);
 }
 
 // Calculate the dcmKpGain to use. When armed, the gain is imuRuntimeConfig.imuDcmKp, i.e., the default value
@@ -687,7 +679,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
         gyroAverage[axis] = gyroGetFilteredDownsampled(axis);
     }
 
-    const bool useAcc = imuIsAccelerometerHealthy(acc.accADC); // all smoothed accADC values are within 20% of 1G
+    const bool useAcc = imuIsAccelerometerHealthy(); // all smoothed accADC values are within 10% of 1G !! Used to say 20% but was actually 10%
 
     imuMahonyAHRSupdate(dt,
                         DEGREES_TO_RADIANS(gyroAverage[X]), DEGREES_TO_RADIANS(gyroAverage[Y]), DEGREES_TO_RADIANS(gyroAverage[Z]),

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -326,7 +326,7 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
 static bool imuIsAccelerometerHealthy(void)
 {
     // Accept accel readings only in range 0.9g - 1.1g
-    return (-0.1f < acc.accMagnitude) && (acc.accMagnitude < 0.1f);
+    return (-0.9f < acc.accMagnitude) && (acc.accMagnitude < 1.1f);
 }
 
 // Calculate the dcmKpGain to use. When armed, the gain is imuRuntimeConfig.imuDcmKp, i.e., the default value

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,7 +100,7 @@ void stopMotors(void)
 }
 
 static FAST_DATA_ZERO_INIT float throttle = 0;
-static float basicThrottle = 0;
+static float rcThrottle = 0;
 static FAST_DATA_ZERO_INIT float mixerThrottle = 0;
 static FAST_DATA_ZERO_INIT float motorOutputMin;
 static FAST_DATA_ZERO_INIT float motorRangeMin;
@@ -265,7 +265,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
     }
 
     throttle = constrainf(throttle / currentThrottleInputRange, 0.0f, 1.0f);
-    basicThrottle = throttle;
+    rcThrottle = throttle;
 }
 
 #define CRASH_FLIP_DEADBAND 20
@@ -776,5 +776,5 @@ float mixerGetThrottle(void)
 
 float mixerGetRcThrottle(void)
 {
-    return basicThrottle;
+    return rcThrottle;
 }

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,7 +100,7 @@ void stopMotors(void)
 }
 
 static FAST_DATA_ZERO_INIT float throttle = 0;
-static float rcThrottle = 0;
+static FAST_DATA_ZERO_INIT float rcThrottle = 0;
 static FAST_DATA_ZERO_INIT float mixerThrottle = 0;
 static FAST_DATA_ZERO_INIT float motorOutputMin;
 static FAST_DATA_ZERO_INIT float motorRangeMin;
@@ -511,14 +511,12 @@ static float calcEzLandLimit(float maxDeflection, float speed)
     // calculate limit to where the mixer can raise the throttle based on RPY stick deflection
     // 0.0 = no increas allowed, 1.0 = 100% increase allowed
     const float deflectionLimit = mixerRuntime.ezLandingThreshold > 0.0f ? fminf(1.0f, maxDeflection / mixerRuntime.ezLandingThreshold) : 0.0f;
-// *** temporarily stealing this debug
-//    DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
+    DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
 
     // calculate limit to where the mixer can raise the throttle based on speed
     // TODO sanity checks like number of sats, dop, accuracy?
     const float speedLimit = mixerRuntime.ezLandingSpeed > 0.0f ? fminf(1.0f, speed / mixerRuntime.ezLandingSpeed) : 0.0f;
-// *** temporarily stealing this debug
-//    DEBUG_SET(DEBUG_EZLANDING, 5, lrintf(speedLimit * 10000.0f));
+    DEBUG_SET(DEBUG_EZLANDING, 5, lrintf(speedLimit * 10000.0f));
 
     // get the highest of the limits from deflection, speed, and the base ez_landing_limit
     const float deflectionAndSpeedLimit = fmaxf(deflectionLimit, speedLimit);
@@ -568,8 +566,7 @@ static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin,
     DEBUG_SET(DEBUG_EZLANDING, 0, fminf(1.0f, ezLandFactor) * 10000U);
     // DEBUG_EZLANDING 1 is the adjusted throttle
     DEBUG_SET(DEBUG_EZLANDING, 2, upperLimit * 10000U);
-// ** temporarily stolen for accDelta
-//     DEBUG_SET(DEBUG_EZLANDING, 3, fminf(1.0f, ezLandLimit / absMotorMixMin) * 10000U);
+    DEBUG_SET(DEBUG_EZLANDING, 3, fminf(1.0f, ezLandLimit / absMotorMixMin) * 10000U);
     // DEBUG_EZLANDING 4 and 5 is the upper limits based on stick input and speed respectively
 }
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,6 +100,7 @@ void stopMotors(void)
 }
 
 static FAST_DATA_ZERO_INIT float throttle = 0;
+static float basicThrottle = 0;
 static FAST_DATA_ZERO_INIT float mixerThrottle = 0;
 static FAST_DATA_ZERO_INIT float motorOutputMin;
 static FAST_DATA_ZERO_INIT float motorRangeMin;
@@ -264,6 +265,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
     }
 
     throttle = constrainf(throttle / currentThrottleInputRange, 0.0f, 1.0f);
+    basicThrottle = throttle;
 }
 
 #define CRASH_FLIP_DEADBAND 20
@@ -770,4 +772,9 @@ void mixerSetThrottleAngleCorrection(int correctionValue)
 float mixerGetThrottle(void)
 {
     return mixerThrottle;
+}
+
+float mixerGetRcThrottle(void)
+{
+    return basicThrottle;
 }

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -568,7 +568,8 @@ static void applyMixerAdjustmentEzLand(float *motorMix, const float motorMixMin,
     DEBUG_SET(DEBUG_EZLANDING, 0, fminf(1.0f, ezLandFactor) * 10000U);
     // DEBUG_EZLANDING 1 is the adjusted throttle
     DEBUG_SET(DEBUG_EZLANDING, 2, upperLimit * 10000U);
-    DEBUG_SET(DEBUG_EZLANDING, 3, fminf(1.0f, ezLandLimit / absMotorMixMin) * 10000U);
+// ** temporarily stolen for accDelta
+//     DEBUG_SET(DEBUG_EZLANDING, 3, fminf(1.0f, ezLandLimit / absMotorMixMin) * 10000U);
     // DEBUG_EZLANDING 4 and 5 is the upper limits based on stick input and speed respectively
 }
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -511,12 +511,14 @@ static float calcEzLandLimit(float maxDeflection, float speed)
     // calculate limit to where the mixer can raise the throttle based on RPY stick deflection
     // 0.0 = no increas allowed, 1.0 = 100% increase allowed
     const float deflectionLimit = mixerRuntime.ezLandingThreshold > 0.0f ? fminf(1.0f, maxDeflection / mixerRuntime.ezLandingThreshold) : 0.0f;
-    DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
+// *** temporarily stealing this debug
+//    DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(deflectionLimit * 10000.0f));
 
     // calculate limit to where the mixer can raise the throttle based on speed
     // TODO sanity checks like number of sats, dop, accuracy?
     const float speedLimit = mixerRuntime.ezLandingSpeed > 0.0f ? fminf(1.0f, speed / mixerRuntime.ezLandingSpeed) : 0.0f;
-    DEBUG_SET(DEBUG_EZLANDING, 5, lrintf(speedLimit * 10000.0f));
+// *** temporarily stealing this debug
+//    DEBUG_SET(DEBUG_EZLANDING, 5, lrintf(speedLimit * 10000.0f));
 
     // get the highest of the limits from deflection, speed, and the base ez_landing_limit
     const float deflectionAndSpeedLimit = fmaxf(deflectionLimit, speedLimit);

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -140,6 +140,7 @@ bool mixerIsTricopter(void);
 
 void mixerSetThrottleAngleCorrection(int correctionValue);
 float mixerGetThrottle(void);
+float mixerGetRcThrottle(void);
 mixerMode_e getMixerMode(void);
 bool mixerModeIsFixedWing(mixerMode_e mixerMode);
 bool isFixedWing(void);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -780,7 +780,7 @@ static FAST_CODE_NOINLINE void disarmOnImpact(const float delta, const float err
     // if all sticks are within 5% of center, and throttle low, check acc and gyro for impacts
     // threshold should be high enough to avoid unwanted disarms in the air on throttle chops
     if (isAirmodeActivated() && getMaxRcDeflectionAbs() < 0.05f && mixerGetRcThrottle() < 0.05f) {
-        if (acc.accMagnitude > pidRuntime.ezLandingDisarmThreshold || 
+        if (acc.accDelta > pidRuntime.ezLandingDisarmThreshold || 
             (fabsf(delta) > (pidRuntime.crashDtermThreshold) && fabsf(errorRate) > pidRuntime.crashGyroThreshold)) {
             // disarm after acc transients or fast gyro transients
             setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
@@ -1147,10 +1147,11 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
             }
             // log the roll values only, since we can't log them all, for testing
             if (axis == FD_ROLL) {
+                DEBUG_SET(DEBUG_EZLANDING, 3, lrintf(acc.accDelta));
                 DEBUG_SET(DEBUG_EZLANDING, 4, lrintf(fabsf(delta * 0.001f)));
                 DEBUG_SET(DEBUG_EZLANDING, 5, lrintf(fabsf(errorRate)));
-                DEBUG_SET(DEBUG_EZLANDING, 6, lrintf(getMaxRcDeflectionAbs() * 100));
-                DEBUG_SET(DEBUG_EZLANDING, 7, lrintf(acc.accMagnitude * 10));
+                DEBUG_SET(DEBUG_EZLANDING, 6, lrintf(getMaxRcDeflectionAbs() * 100.0f));
+                DEBUG_SET(DEBUG_EZLANDING, 7, lrintf(acc.accMagnitude * 10.0f));
             }
             if (pidRuntime.useEzDisarm) {
                 // monitor and check each axis for high gyro error and high gyro delta

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -778,7 +778,7 @@ float pidGetAirmodeThrottleOffset(void)
 static FAST_CODE_NOINLINE void disarmOnImpact(void)
 {
     // if all sticks are within 5% of center, and throttle low, check acc magnitude for impacts
-    // threshold should be highe enough to avoid unwanted disarms in the air on throttle chops
+    // threshold should be high enough to avoid unwanted disarms in the air on throttle chops
 
     // normally the acc calculation would be done only when required, but having them here lets us log the acc magnitude in normal flight
     float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -780,13 +780,11 @@ static FAST_CODE_NOINLINE void disarmOnImpact(void)
     // if all sticks are within 5% of center, and throttle low, check acc magnitude for impacts
     // threshold should be high enough to avoid unwanted disarms in the air on throttle chops
 
-    // normally the acc calculation would be done only when required, but having them here lets us log the acc magnitude in normal flight
-    float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
-    DEBUG_SET(DEBUG_EZLANDING, 7, lrintf(accMagnitude * 10));
+    DEBUG_SET(DEBUG_EZLANDING, 7, lrintf(acc.accMagnitude * 10));
 
     DEBUG_SET(DEBUG_EZLANDING, 6, lrintf(getMaxRcDeflectionAbs() * 100));
     if (isAirmodeActivated() && getMaxRcDeflectionAbs() < 0.05f && mixerGetRcThrottle() < 0.05f
-    && accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
+    && acc.accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
         // disarm after big bumps
         setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
         disarm(DISARM_REASON_LANDING);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -236,7 +236,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .spa_center = { 0, 0, 0 },
         .spa_width = { 0, 0, 0 },
         .spa_mode = { 0, 0, 0 },
-        .ez_landing_disarm_threshold = 110,
+        .ez_landing_disarm_threshold = 0                            ,
     );
 
 #ifndef USE_D_MIN
@@ -640,7 +640,7 @@ static void rotateVector(float v[XYZ_AXIS_COUNT], const float rotation[XYZ_AXIS_
     }
 }
 
-STATIC_UNIT_TESTED FAST_CODE_NOINLINE void rotateItermAndAxisError(void)
+STATIC_UNIT_TESTED void rotateItermAndAxisError(void)
 {
     if (pidRuntime.itermRotation
 #if defined(USE_ABSOLUTE_CONTROL)
@@ -672,7 +672,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE void rotateItermAndAxisError(void)
 
 #if defined(USE_ITERM_RELAX)
 #if defined(USE_ABSOLUTE_CONTROL)
-STATIC_UNIT_TESTED FAST_CODE_NOINLINE void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
+STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
 {
     if (pidRuntime.acGain > 0 || debugMode == DEBUG_AC_ERROR) {
         const float setpointLpf = pt1FilterApply(&pidRuntime.acLpf[axis], *currentPidSetpoint);
@@ -784,9 +784,9 @@ static FAST_CODE_NOINLINE void disarmOnImpact(void)
     float accMagnitude = sqrtf(sq(acc.accADC[Z]) + sq(acc.accADC[X]) + sq(acc.accADC[Y])) * acc.dev.acc_1G_rec - 1.0f;
     DEBUG_SET(DEBUG_EZLANDING, 7, lrintf(accMagnitude * 10));
 
-    float maxDeflectionAbs = fmaxf(getMaxRcDeflectionAbs(), mixerGetRcThrottle());
-    DEBUG_SET(DEBUG_EZLANDING, 6, lrintf(maxDeflectionAbs * 100));
-    if (isAirmodeActivated() && maxDeflectionAbs < 0.05f && accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
+    DEBUG_SET(DEBUG_EZLANDING, 6, lrintf(getMaxRcDeflectionAbs() * 100));
+    if (isAirmodeActivated() && getMaxRcDeflectionAbs() < 0.05f && mixerGetRcThrottle() < 0.05f
+    && accMagnitude > pidRuntime.ezLandingDisarmThreshold) {
         // disarm after big bumps
         setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
         disarm(DISARM_REASON_LANDING);
@@ -836,7 +836,7 @@ static FAST_CODE_NOINLINE float applyLaunchControl(int axis, const rollAndPitchT
 }
 #endif
 
-static FAST_CODE_NOINLINE float getSterm(int axis, const pidProfile_t *pidProfile)
+static float getSterm(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     const float sTerm = getSetpointRate(axis) / getMaxRcRate(axis) * 1000.0f *
@@ -852,7 +852,7 @@ static FAST_CODE_NOINLINE float getSterm(int axis, const pidProfile_t *pidProfil
 #endif
 }
 
-static FAST_CODE_NOINLINE void calculateSpaValues(const pidProfile_t *pidProfile)
+NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
@@ -866,7 +866,7 @@ static FAST_CODE_NOINLINE void calculateSpaValues(const pidProfile_t *pidProfile
 #endif // #ifdef USE_WING ... #else
 }
 
-static FAST_CODE_NOINLINE void applySpa(int axis, const pidProfile_t *pidProfile)
+NOINLINE static void applySpa(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
     switch(pidProfile->spa_mode[axis]){

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -116,7 +116,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 8);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 9);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -261,6 +261,8 @@ typedef struct pidProfile_s {
     uint8_t ez_landing_threshold;           // Threshold stick position below which motor output is limited
     uint8_t ez_landing_limit;               // Maximum motor output when all sticks centred and throttle zero
     uint8_t ez_landing_speed;               // Speed below which motor output is limited
+    uint8_t ez_landing_disarm_threshold;    // Accelerometer vector threshold which disarms if exceeded
+
     uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter (time constant)
     uint16_t spa_center[XYZ_AXIS_COUNT];    // RPY setpoint at which PIDs are reduced to 50% (setpoint PID attenuation)
     uint16_t spa_width[XYZ_AXIS_COUNT];     // Width of smooth transition around spa_center
@@ -358,6 +360,8 @@ typedef struct pidRuntime_s {
     float tpaLowBreakpoint;
     float tpaLowMultiplier;
     bool tpaLowAlways;
+    bool useEzDisarm;
+    float ezLandingDisarmThreshold;
 
 #ifdef USE_ITERM_RELAX
     pt1Filter_t windupLpf[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -443,7 +443,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
 
     pidRuntime.useEzDisarm = pidProfile->ez_landing_disarm_threshold > 0;
-    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;
+    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold * 10.0f;
 
 }
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -316,8 +316,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashTimeDelayUs = pidProfile->crash_delay * 1000;
     pidRuntime.crashRecoveryAngleDeciDegrees = pidProfile->crash_recovery_angle * 10;
     pidRuntime.crashRecoveryRate = pidProfile->crash_recovery_rate;
-    pidRuntime.crashGyroThreshold = pidProfile->crash_gthreshold;
-    pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold;
+    pidRuntime.crashGyroThreshold = pidProfile->crash_gthreshold; // error in deg/s
+    pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold * 1000.0f; // gyro delta in deg/s/s divided by 1000 to match origingal 2017 intent
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
     pidRuntime.itermLimit = pidProfile->itermLimit;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -317,7 +317,7 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.crashRecoveryAngleDeciDegrees = pidProfile->crash_recovery_angle * 10;
     pidRuntime.crashRecoveryRate = pidProfile->crash_recovery_rate;
     pidRuntime.crashGyroThreshold = pidProfile->crash_gthreshold; // error in deg/s
-    pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold * 1000.0f; // gyro delta in deg/s/s divided by 1000 to match origingal 2017 intent
+    pidRuntime.crashDtermThreshold = pidProfile->crash_dthreshold * 1000.0f; // gyro delta in deg/s/s * 1000 to match original 2017 intent
     pidRuntime.crashSetpointThreshold = pidProfile->crash_setpoint_threshold;
     pidRuntime.crashLimitYaw = pidProfile->crash_limit_yaw;
     pidRuntime.itermLimit = pidProfile->itermLimit;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -441,6 +441,10 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaLowBreakpoint = MIN(pidRuntime.tpaLowBreakpoint, pidRuntime.tpaBreakpoint);
     pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
+
+    pidRuntime.useEzDisarm = pidProfile->ez_landing_disarm_threshold > 0;
+    pidRuntime.ezLandingDisarmThreshold = pidProfile->ez_landing_disarm_threshold / 10.0f;
+
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex)

--- a/src/main/pg/gps_rescue.c
+++ b/src/main/pg/gps_rescue.c
@@ -47,7 +47,7 @@ PG_RESET_TEMPLATE(gpsRescueConfig_t, gpsRescueConfig,
     .descentDistanceM = 20,
     .descendRate = 150,         // cm/s, minimum for descent and landing phase, or for descending if starting high ascent
     .targetLandingAltitudeM = 4,
-    .disarmThreshold = 20,
+    .disarmThreshold = 30,
 
     .throttleMin = 1100,
     .throttleMax = 1700,

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -84,7 +84,7 @@ void accUpdate(timeUs_t currentTimeUs)
         acc.accADC[axis] = accelerationRuntime.accLpfCutHz ? pt2FilterApply(&accelerationRuntime.accFilter[axis], val) : val;
         accAdcSquaredSum += sq(acc.accADC[axis]);
     }
-    acc.accMagnitude = sqrtf(accAdcSquaredSum) * acc.dev.acc_1G_rec - 1.0f; // used for disarm on impact detection
+    acc.accMagnitude = sqrtf(accAdcSquaredSum) * acc.dev.acc_1G_rec; // normally 1.0; used for disarm on impact detection
 }
 
 #endif

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -51,6 +51,7 @@ static void applyAccelerationTrims(const flightDynamicsTrims_t *accelerationTrim
 void accUpdate(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
+    static float previousAccMagnitude;
 
     if (!acc.dev.readFn(&acc.dev)) {
         return;
@@ -85,6 +86,8 @@ void accUpdate(timeUs_t currentTimeUs)
         accAdcSquaredSum += sq(acc.accADC[axis]);
     }
     acc.accMagnitude = sqrtf(accAdcSquaredSum) * acc.dev.acc_1G_rec; // normally 1.0; used for disarm on impact detection
+    acc.accDelta = (acc.accMagnitude - previousAccMagnitude) * acc.sampleRateHz;
+    previousAccMagnitude = acc.accMagnitude;
 }
 
 #endif

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -78,10 +78,13 @@ void accUpdate(timeUs_t currentTimeUs)
 
     applyAccelerationTrims(accelerationRuntime.accelerationTrims);
 
+    float accAdcSquaredSum = 0.0f;
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         const float val = acc.accADC[axis];
         acc.accADC[axis] = accelerationRuntime.accLpfCutHz ? pt2FilterApply(&accelerationRuntime.accFilter[axis], val) : val;
+        accAdcSquaredSum += sq(acc.accADC[axis]);
     }
+    acc.accMagnitude = sqrtf(accAdcSquaredSum) * acc.dev.acc_1G_rec - 1.0f; // used for disarm on impact detection
 }
 
 #endif

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -56,6 +56,7 @@ typedef struct acc_s {
     uint16_t sampleRateHz;
     float accADC[XYZ_AXIS_COUNT];
     bool isAccelUpdatedAtLeastOnce;
+    float accMagnitude;
 } acc_t;
 
 extern acc_t acc;

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -57,6 +57,7 @@ typedef struct acc_s {
     float accADC[XYZ_AXIS_COUNT];
     bool isAccelUpdatedAtLeastOnce;
     float accMagnitude;
+    float accDelta;
 } acc_t;
 
 extern acc_t acc;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -28,6 +28,8 @@ bool simulatedAirmodeEnabled = true;
 float simulatedSetpointRate[3] = { 0,0,0 };
 float simulatedPrevSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
+float simulatedMaxRcDeflectionAbs = 0;
+float simulatedMixerGetRcThrottle = 0;
 float simulatedRcCommandDelta[3] = { 1,1,1 };
 float simulatedRawSetpoint[3] = { 0,0,0 };
 float simulatedMaxRate[3] = { 670,670,670 };
@@ -72,6 +74,7 @@ extern "C" {
     #include "sensors/gyro.h"
     #include "sensors/acceleration.h"
 
+    acc_t acc;
     gyro_t gyro;
     attitudeEulerAngles_t attitude;
 
@@ -85,6 +88,12 @@ extern "C" {
     float getSetpointRate(int axis) { return simulatedSetpointRate[axis]; }
     bool isAirmodeActivated(void) { return simulatedAirmodeEnabled; }
     float getRcDeflectionAbs(int axis) { return fabsf(simulatedRcDeflection[axis]); }
+
+    // for ezLanding auto-disarm
+    // note that there is no test to check that this code works.
+    float getMaxRcDeflectionAbs() { return fabsf(simulatedMaxRcDeflectionAbs); }
+    float mixerGetRcThrottle() { return fabsf(simulatedMixerGetRcThrottle); }
+
     void systemBeep(bool) { }
     bool gyroOverflowDetected(void) { return false; }
     float getRcDeflection(int axis) { return simulatedRcDeflection[axis]; }


### PR DESCRIPTION
This is a 'feature', that, if enabled, disarms the quad if:
- an accelerometer delta spike exceeds the `ez_landing_disarm_threshold`, 
- air mode is activated, and
- all sticks are within 5% of centre, and 
- throttle is below 5%.

It is intended to stop 'messy landings' by instantly disarming - much more quickly than you can manually disarm - whenever the landing is hard, or difficult.  It will detect when a nice landing goes wrong because the props catch something and the quad starts thrashing around and stop it immediately.

The pilot should not get 'lazy'.  They should still always 'disarm manually', anyway, as a matter of habit.  It's important, for safety, to put the switches into the disarm position once you've landed.

The default `ez_landing_disarm_threshold` is 0, disabling the function.  The threshold must be set to a positive value to enable the function.  Here are some tips for setting a suitable threshold:

- `set ez_landing_disarm_threshold  = 70` or `set ez_landing_disarm_threshold  = 90` are very safe starting points.
- `set ez_landing_disarm_threshold  = 50` is what I use on my quads
- Use the highest value that gives a reliable disarm when you want it to.   Higher values are less likely to be triggered in flight in manoeuvres where you chop throttle with sticks centred.
- The threshold can be set as low as 20, which will disarm on gentle landings, but then you get very close to acc noise values (typically below 15 of these units), and you may get unintended disarms in the air when chopping throttle.

It's been tested and disarms reliably on sharp hits - but only when the sticks are centered and throttle at zero.  This is very uncommon in-flight.  I've tried to cause it to trigger 'in-flight' by doing hard throttle chops, inverted hangs, flat drops, etc,  but there hasn't been one instance of false disarming.  The logs show no accDelta values anywhere above thresholds of about 15-20, and the sticks are almost never in the position where the disarm detection would be active, anyway.

Note that a very gentle landing won't trigger the auto-disarm, and it isn't supposed to. 

This code was developed in #13488, which is now closed.

The PR also fixes a longstanding bug in CrashRecovery, increasing the scale of the `crash_dthreshold` (gyroDelta) factor by 1000 times, so that it now works properly.  In most cases users should be able to set the `crash_gthreshold` factor above their max gyro rate, and disarm correctly from the `crash_dthreshold` method.  Thanks to @nerdCopter for encouraging me to look at our CrashRecovery code; logging it found the error. This fix should make CrashRecovery more reliable.

Thanks to @KarateBrot who suggested using AccMagnitude Delta (Jerk) as the impact detector.  It is a bit noisy, but there is a clear differential between noise and signal, at least on my quads.  This works better than simple Acc, and at least as well as GyroDelta.

The PR also does the maths for accMagnitude (sqare root of sum of acc values for each axis, returning `acc. accMagnitude`) only once, in accelerometer.c.  This is done only when new accelerometer data arrives, rather than multiple times (eg in GPS Rescue, imu.c, now in pid.c) and at the task rate of those functions.

The value for accMagnitude does not subtract 1G, so the threshold in GPS Rescue has been increased by 1G.  I've tested this and it works normally.  GPS Rescue cannot, at this point, use the AccDelta value, because the delta signal is very transient, and is often missed by GPS Rescue code, which only checks at 100Hz. 

I've temporarily grabbed some debug elements from EZ_LANDING to log each of these parameters.

```
DEBUG_SET(DEBUG_EZLANDING, 6, lrintf(getMaxRcDeflectionAbs() * 100));
DEBUG_SET(DEBUG_EZLANDING, 7, lrintf(acc.accDelta));
```
Note: non-zero value for `ez_disarm_threshold` is needed for these debugs to be active.

Before enabling this auto-disarm on an expensive machine, consider logging the above values by enabling the `EZLANDING` debug but with a high acc threshold (200 say) and maximum crashRecovery thresholds.  Give it a rough flight including hard throttle chops to zero, and check that the G forces do not get close to the disarm threshold you intend to use.  Do some gentle and hard landings, too.   Keep in mind that bent or damaged props, or wear and tear, or impacts with objects, can all cause accelerometer transients.  Then check the logs and choose thresholds which are not achieved in normal flight.

The most likely false trigger would be when testing AntiGravity by abruptly chopping throttle at high speed with sticks centred.  This would cause an abrupt deceleration and some shaking.  

If the quad was to disarm mid-air, the pilot should quickly toggle from arm to disarm and then back to arm again.

Note that in this PR, air mode must be active, or it will not disarm.  This is for two reasons, first, we want to have taken off before enabling the detection method, and second, because landing without bad bounces is not difficult when air mode is disabled.  This check may not be needed but that's how it is at present.

There may be better ways to detect impacts.  For example, if we had lidar we could check for proximity to ground at any altitude, or if we had a working Baro or GPS, we could check for proximity to the take-off altitude or location (assuming we only wanted auto-disarm in those ranges).  For now, this is a simple PR doing the simplest possible method, and it works quite well.  

Please report test results as a comment at the bottom - thanks!