### PR TITLE
TPA modes some refactoring

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1133,7 +1133,7 @@ static void loadMainState(timeUs_t currentTimeUs)
 
     for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
         blackboxCurrent->axisPID_P[i] = lrintf(pidData[i].P);
-        blackboxCurrent->axisPID_I[i] = lrintf(pidData[i].I);
+        blackboxCurrent->axisPID_I[i] = lrintf(pidData[i].I_afterTpa);
         blackboxCurrent->axisPID_D[i] = lrintf(pidData[i].D);
         blackboxCurrent->axisPID_F[i] = lrintf(pidData[i].F);
         blackboxCurrent->gyroADC[i] = lrintf(gyro.gyroADCf[i] * blackboxHighResolutionScale);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -437,7 +437,7 @@ static const char * const lookupTableLaunchControlMode[] = {
 
 #ifdef USE_TPA_MODE
 static const char * const lookupTableTpaMode[] = {
-    "PD", "D", "PID"
+    "PD", "D"
 };
 #endif
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -437,7 +437,7 @@ static const char * const lookupTableLaunchControlMode[] = {
 
 #ifdef USE_TPA_MODE
 static const char * const lookupTableTpaMode[] = {
-    "PD", "D"
+    "PD", "D", "PID"
 };
 #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -277,10 +277,6 @@ void getTpaFactors(const pidProfile_t *pidProfile, float tpaFactor, tpaFactors_t
     case TPA_MODE_PD:
         tpaFactors->tpaFactorKp = tpaFactor;
         break;
-    case TPA_MODE_PID:
-        tpaFactors->tpaFactorKp = tpaFactor;
-        tpaFactors->tpaFactorKi = tpaFactor;
-        break;
     default:
         break;
     }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -284,7 +284,9 @@ void getTpaFactors(const pidProfile_t *pidProfile, float tpaFactor, tpaFactors_t
     default:
         break;
     }
-#endif // #ifdef USE_TPA_MODE
+#else // USE_TPA_MODE undefined
+    UNUSED(pidProfile);
+#endif
 }
 
 void pidSetItermAccelerator(float newItermAccelerator)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -884,9 +884,11 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     calculateSpaValues(pidProfile);
 
 #ifdef USE_TPA_MODE
-    const float tpaFactorKp = (pidProfile->tpa_mode == TPA_MODE_PD) ? pidRuntime.tpaFactor : 1.0f;
+    const float tpaFactorKp = (pidProfile->tpa_mode == TPA_MODE_PD || pidProfile->tpa_mode == TPA_MODE_PID) ? pidRuntime.tpaFactor : 1.0f;
+    const float tpaFactorKi = (pidProfile->tpa_mode == TPA_MODE_PID) ? pidRuntime.tpaFactor : 1.0f;
 #else
     const float tpaFactorKp = pidRuntime.tpaFactor;
+    const float tpaFactorKi = 1.0f;
 #endif
 
 #ifdef USE_YAW_SPIN_RECOVERY
@@ -1225,7 +1227,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         applySpa(axis, pidProfile);
 
         // calculating the PID sum
-        const float pidSum = pidData[axis].P + pidData[axis].I + pidData[axis].D + pidData[axis].F + pidData[axis].S;
+        const float pidSum = pidData[axis].P + pidData[axis].I * tpaFactorKi + pidData[axis].D + pidData[axis].F + pidData[axis].S;
 #ifdef USE_INTEGRATED_YAW_CONTROL
         if (axis == FD_YAW && pidRuntime.useIntegratedYaw) {
             pidData[axis].Sum += pidSum * pidRuntime.dT * 100.0f;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -79,7 +79,8 @@
 
 typedef enum {
     TPA_MODE_PD,
-    TPA_MODE_D
+    TPA_MODE_D,
+    TPA_MODE_PID,
 } tpaMode_e;
 
 typedef enum {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -80,7 +80,6 @@
 typedef enum {
     TPA_MODE_PD,
     TPA_MODE_D,
-    TPA_MODE_PID,
 } tpaMode_e;
 
 typedef enum {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -290,6 +290,7 @@ typedef struct pidAxisData_s {
     float D;
     float F;
     float S;
+    float I_afterTpa;
 
     float Sum;
 } pidAxisData_t;


### PR DESCRIPTION
This refactoring would allow to easier modify/improve/understand TPA code behavior.

## Old description (not relevant anymore)
([read this comment](https://github.com/betaflight/betaflight/pull/13804#issuecomment-2292617666))

Not sure how to make it nicer. Current implementation downside: the I-term will be logged before TPA factor.
Upside: it's simple to follow, and works :)

I-term for wings works like a "dynamic servo trim", always trying to keep craft on rails.
However as wing speed grows, wing needs less I-term (less "default" servo angles) to keep it straight.
And when speed drops, we have to go back to the old bigger value, **without waiting for I-term to accumulate naturally.**

Please, let me know if anyone has an idea how to make it nicer. Can't really do: `pidData[axis].I *= tpaFactorKi`, because the next PID loop it's gonna do it again, making I-term zero pretty quick. (because I-term has accumulative effect, so it depends on previous values).

@KarateBrot  @ledvinap  @ctzsnooze @nerdCopter 