### PR TITLE
FIX: make: Circular configs <- configs dependency dropped. #13695

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,9 +516,6 @@ $(CONFIGS_CLEAN):
 ## clean_all         : clean all targets
 clean_all: $(TARGETS_CLEAN) test_clean
 
-## configs           : Hydrate configuration
-configs: configs
-
 ## all_configs       : Build all configs
 all_configs: $(BASE_CONFIGS)
 


### PR DESCRIPTION
- reintroduced by #13660 (possible bad re-base?)
