### PR TITLE
build - remove -Wpedantic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ CFLAGS     += $(ARCH_FLAGS) \
               $(addprefix -I,$(INCLUDE_DIRS)) \
               $(DEBUG_FLAGS) \
               -std=gnu17 \
-              -Wall -Wextra -Werror -Wpedantic -Wunsafe-loop-optimizations -Wdouble-promotion \
+              -Wall -Wextra -Werror -Wunsafe-loop-optimizations -Wdouble-promotion \
               $(EXTRA_WARNING_FLAGS) \
               -ffunction-sections \
               -fdata-sections \


### PR DESCRIPTION
`-Wpedantic` is only causing problems.

- BF is using gcc/clang extensions anyway, just taking extra steps to suppress errors

- Only warnings that are required by strict ISO compliance are enabled by it. Potentially useful warnings are part of -Wall / -Wextra

- Simple _Static_assert(1.0 < 2.0, "") is failing (expression in static assertion is not an integer constant expression)
