### PR TITLE
Fix searching a resource

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6050,7 +6050,7 @@ static void cliResource(const char *cmdName, char *cmdline)
         }
 
         const char *resourceName = ownerNames[resourceTable[resourceIndex].owner];
-        if (strncasecmp(pch, resourceName, strlen(resourceName)) == 0) {
+        if (strcasecmp(pch, resourceName) == 0) {
             break;
         }
     }


### PR DESCRIPTION
If you add a new resource whose name starts with an existing resource name it won't be found. For example if you add `PWM_EX` resource after `PWM` you won't be able to store a pin into it. So when you execute `resource PWM_EX 1 A01` it will be stored into `PWM`.

At the moment it works like following:

```c
// If we add PWM_EX resource
const char * const ownerNames[OWNER_TOTAL_COUNT] = {
    "FREE",
    "PWM",
    "PWM_EX",
    ...
};

// This will match
strncasecmp("PWM_EX", "PWM", 3) == 0
```