### PR TITLE
[4.5.2] FIX: Modify STM32F405 UID Address for MSC Enumeration (#13769)

### DIFF
--- a/src/main/drivers/stm32/usbd_msc_desc.c
+++ b/src/main/drivers/stm32/usbd_msc_desc.c
@@ -33,9 +33,15 @@
 #include "usb_regs.h"
 #include "platform.h"
 
+#if defined (STM32F4)
+#define         DEVICE_ID1          (0x1FFF7A10)
+#define         DEVICE_ID2          (0x1FFF7A14)
+#define         DEVICE_ID3          (0x1FFF7A18)
+#else
 #define         DEVICE_ID1          (0x1FFFF7E8)
 #define         DEVICE_ID2          (0x1FFFF7EA)
 #define         DEVICE_ID3          (0x1FFFF7EC)
+#endif
 #define  USB_SIZ_STRING_SERIAL       0x1A
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY


### PR DESCRIPTION
- backport of #13769