### PR TITLE
Extended stage2 & stage1 time

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -875,8 +875,8 @@ const clivalue_t valueTable[] = {
     { "thr_corr_angle",             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1,  900 }, PG_THROTTLE_CORRECTION_CONFIG, offsetof(throttleCorrectionConfig_t, throttle_correction_angle) },
 
 // PG_FAILSAFE_CONFIG
-    { "failsafe_delay",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, 200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_delay) },
-    { "failsafe_off_delay",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_off_delay) },
+    { "failsafe_delay",             VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, UINT16_MAX}, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_delay) },
+    { "failsafe_off_delay",         VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_off_delay) },
     { "failsafe_throttle",          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { PWM_PULSE_MIN, PWM_PULSE_MAX }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_throttle) },
     { "failsafe_switch_mode",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FAILSAFE_SWITCH_MODE }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_switch_mode) },
     { "failsafe_throttle_low_delay",VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 300 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_throttle_low_delay) },

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -1225,6 +1225,28 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, cms_key_e key)
                 }
             }
             break;
+        case OME_FLOAT16:
+            if (p->data) {
+                OSD_UINT16_t *ptr = p->data;
+                const uint16_t previousValue = *ptr->val;
+                if (key == CMS_KEY_RIGHT) {
+                    if (*ptr->val < ptr->max) {
+                        *ptr->val += ptr->step;
+                    }
+                } else {
+                    if (*ptr->val > ptr->min) {
+                        *ptr->val -= ptr->step;
+                    }
+                }
+                SET_PRINTVALUE(runtimeEntryFlags[currentCtx.cursorRow]);
+                if ((p->flags & REBOOT_REQUIRED) && (*ptr->val != previousValue)) {
+                    setRebootRequired();
+                }
+                if (p->func) {
+                    p->func(pDisplay, p);
+                }
+            }
+            break;
 
         case OME_TAB:
             if ((p->flags & OSD_MENU_ELEMENT_MASK) == OME_TAB) {

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -589,6 +589,15 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
         }
         break;
 
+    case OME_FLOAT16:
+        if (IS_PRINTVALUE(*flags) && p->data) {
+            OSD_FLOAT16_t *ptr = p->data;
+            cmsFormatFloat(*ptr->val * ptr->multipler, buff);
+            cnt = cmsDrawMenuItemValue(pDisplay, buff, row, CMS_NUM_FIELD_LEN);
+            CLR_PRINTVALUE(*flags);
+        }
+        break;
+
     case OME_Label:
         if (IS_PRINTVALUE(*flags) && p->data) {
             // A label with optional string, immediately following text

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -44,8 +44,8 @@
 #include "rx/rx.h"
 
 uint8_t failsafeConfig_failsafe_procedure;
-uint8_t failsafeConfig_failsafe_delay;
-uint16_t failsafeConfig_failsafe_off_delay; // Changed to uint16_t
+uint16_t failsafeConfig_failsafe_delay;
+uint16_t failsafeConfig_failsafe_off_delay;
 uint16_t failsafeConfig_failsafe_throttle;
 
 static const void *cmsx_Failsafe_onEnter(displayPort_t *pDisp)
@@ -54,7 +54,7 @@ static const void *cmsx_Failsafe_onEnter(displayPort_t *pDisp)
 
     failsafeConfig_failsafe_procedure = failsafeConfig()->failsafe_procedure;
     failsafeConfig_failsafe_delay = failsafeConfig()->failsafe_delay;
-    failsafeConfig_failsafe_off_delay = failsafeConfig()->failsafe_off_delay; // Changed to uint16_t
+    failsafeConfig_failsafe_off_delay = failsafeConfig()->failsafe_off_delay;
     failsafeConfig_failsafe_throttle = failsafeConfig()->failsafe_throttle;
 
     return NULL;
@@ -67,7 +67,7 @@ static const void *cmsx_Failsafe_onExit(displayPort_t *pDisp, const OSD_Entry *s
 
     failsafeConfigMutable()->failsafe_procedure = failsafeConfig_failsafe_procedure;
     failsafeConfigMutable()->failsafe_delay = failsafeConfig_failsafe_delay;
-    failsafeConfigMutable()->failsafe_off_delay = failsafeConfig_failsafe_off_delay; // Changed to uint16_t
+    failsafeConfigMutable()->failsafe_off_delay = failsafeConfig_failsafe_off_delay;
     failsafeConfigMutable()->failsafe_throttle = failsafeConfig_failsafe_throttle;
 
     return NULL;
@@ -78,8 +78,8 @@ static const OSD_Entry cmsx_menuFailsafeEntries[] =
     { "-- FAILSAFE --", OME_Label, NULL, NULL},
 
     { "PROCEDURE",        OME_TAB | REBOOT_REQUIRED,    NULL, &(OSD_TAB_t)    { &failsafeConfig_failsafe_procedure, FAILSAFE_PROCEDURE_COUNT - 1, failsafeProcedureNames } },
-    { "GUARD TIME",       OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_delay, PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, 200, 1, 100 } },
-    { "STAGE 2 DELAY",    OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_off_delay, 0, 65535, 1, 100 } },
+    { "GUARD TIME",       OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_delay, PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, UINT16_MAX, 1, 100 } },
+    { "STAGE 2 DELAY",    OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_off_delay, 0, UINT16_MAX, 1, 100 } },
     { "STAGE 2 THROTTLE", OME_UINT16 | REBOOT_REQUIRED, NULL, &(OSD_UINT16_t) { &failsafeConfig_failsafe_throttle, PWM_PULSE_MIN, PWM_PULSE_MAX, 1 } },
 #ifdef USE_CMS_GPS_RESCUE_MENU
     { "GPS RESCUE",       OME_Submenu, cmsMenuChange, &cmsx_menuGpsRescue},

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -78,8 +78,8 @@ static const OSD_Entry cmsx_menuFailsafeEntries[] =
     { "-- FAILSAFE --", OME_Label, NULL, NULL},
 
     { "PROCEDURE",        OME_TAB | REBOOT_REQUIRED,    NULL, &(OSD_TAB_t)    { &failsafeConfig_failsafe_procedure, FAILSAFE_PROCEDURE_COUNT - 1, failsafeProcedureNames } },
-    { "GUARD TIME",       OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_delay, PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, UINT16_MAX, 1, 100 } },
-    { "STAGE 2 DELAY",    OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_off_delay, 0, UINT16_MAX, 1, 100 } },
+    { "GUARD TIME",       OME_FLOAT16 | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT16_t)  { &failsafeConfig_failsafe_delay, PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, UINT16_MAX, 1, 100 } },
+    { "STAGE 2 DELAY",    OME_FLOAT16 | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT16_t)  { &failsafeConfig_failsafe_off_delay, 0, UINT16_MAX, 1, 100 } },
     { "STAGE 2 THROTTLE", OME_UINT16 | REBOOT_REQUIRED, NULL, &(OSD_UINT16_t) { &failsafeConfig_failsafe_throttle, PWM_PULSE_MIN, PWM_PULSE_MAX, 1 } },
 #ifdef USE_CMS_GPS_RESCUE_MENU
     { "GPS RESCUE",       OME_Submenu, cmsMenuChange, &cmsx_menuGpsRescue},

--- a/src/main/cms/cms_menu_failsafe.c
+++ b/src/main/cms/cms_menu_failsafe.c
@@ -45,7 +45,7 @@
 
 uint8_t failsafeConfig_failsafe_procedure;
 uint8_t failsafeConfig_failsafe_delay;
-uint8_t failsafeConfig_failsafe_off_delay;
+uint16_t failsafeConfig_failsafe_off_delay; // Changed to uint16_t
 uint16_t failsafeConfig_failsafe_throttle;
 
 static const void *cmsx_Failsafe_onEnter(displayPort_t *pDisp)
@@ -54,7 +54,7 @@ static const void *cmsx_Failsafe_onEnter(displayPort_t *pDisp)
 
     failsafeConfig_failsafe_procedure = failsafeConfig()->failsafe_procedure;
     failsafeConfig_failsafe_delay = failsafeConfig()->failsafe_delay;
-    failsafeConfig_failsafe_off_delay = failsafeConfig()->failsafe_off_delay;
+    failsafeConfig_failsafe_off_delay = failsafeConfig()->failsafe_off_delay; // Changed to uint16_t
     failsafeConfig_failsafe_throttle = failsafeConfig()->failsafe_throttle;
 
     return NULL;
@@ -67,7 +67,7 @@ static const void *cmsx_Failsafe_onExit(displayPort_t *pDisp, const OSD_Entry *s
 
     failsafeConfigMutable()->failsafe_procedure = failsafeConfig_failsafe_procedure;
     failsafeConfigMutable()->failsafe_delay = failsafeConfig_failsafe_delay;
-    failsafeConfigMutable()->failsafe_off_delay = failsafeConfig_failsafe_off_delay;
+    failsafeConfigMutable()->failsafe_off_delay = failsafeConfig_failsafe_off_delay; // Changed to uint16_t
     failsafeConfigMutable()->failsafe_throttle = failsafeConfig_failsafe_throttle;
 
     return NULL;
@@ -79,7 +79,7 @@ static const OSD_Entry cmsx_menuFailsafeEntries[] =
 
     { "PROCEDURE",        OME_TAB | REBOOT_REQUIRED,    NULL, &(OSD_TAB_t)    { &failsafeConfig_failsafe_procedure, FAILSAFE_PROCEDURE_COUNT - 1, failsafeProcedureNames } },
     { "GUARD TIME",       OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_delay, PERIOD_RXDATA_RECOVERY / MILLIS_PER_TENTH_SECOND, 200, 1, 100 } },
-    { "STAGE 2 DELAY",    OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_off_delay, 0, 200, 1, 100 } },
+    { "STAGE 2 DELAY",    OME_FLOAT | REBOOT_REQUIRED,  NULL, &(OSD_FLOAT_t)  { &failsafeConfig_failsafe_off_delay, 0, 65535, 1, 100 } },
     { "STAGE 2 THROTTLE", OME_UINT16 | REBOOT_REQUIRED, NULL, &(OSD_UINT16_t) { &failsafeConfig_failsafe_throttle, PWM_PULSE_MIN, PWM_PULSE_MAX, 1 } },
 #ifdef USE_CMS_GPS_RESCUE_MENU
     { "GPS RESCUE",       OME_Submenu, cmsMenuChange, &cmsx_menuGpsRescue},

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -53,7 +53,8 @@ typedef enum
     // Debug aid
     OME_MENU,
 
-    OME_MAX = OME_MENU
+    OME_MAX = OME_MENU,
+    OME_FLOAT16, // up to 65k
 } OSD_MenuElement;
 
 typedef const void *(*CMSEntryFuncPtr)(displayPort_t *displayPort, const void *ptr);
@@ -182,10 +183,19 @@ typedef struct
 {
     uint8_t *val;
     uint8_t min;
-    uint16_t max;
+    uint8_t max;
     uint8_t step;
     uint16_t multipler;
 } OSD_FLOAT_t;
+
+typedef struct
+{
+    uint8_t *val;
+    uint8_t min;
+    uint16_t max;
+    uint8_t step;
+    uint16_t multipler;
+} OSD_FLOAT16_t;
 
 typedef struct
 {

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -190,10 +190,10 @@ typedef struct
 
 typedef struct
 {
-    uint8_t *val;
-    uint8_t min;
+    uint16_t *val;
+    uint16_t min;
     uint16_t max;
-    uint8_t step;
+    uint16_t step;
     uint16_t multipler;
 } OSD_FLOAT16_t;
 

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -182,7 +182,7 @@ typedef struct
 {
     uint8_t *val;
     uint8_t min;
-    uint8_t max;
+    uint16_t max;
     uint8_t step;
     uint16_t multipler;
 } OSD_FLOAT_t;

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -72,7 +72,7 @@ PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_throttle = 1000,                           // default throttle off.
     .failsafe_throttle_low_delay = 100,                  // default throttle low delay for "just disarm" on failsafe condition
     .failsafe_delay = 15,                                // 1.5 sec stage 1 period, can regain control on signal recovery, at idle in drop mode
-    .failsafe_off_delay = 10,                            // 1 sec in landing phase, if enabled
+    .failsafe_off_delay = 3000,                            // 5 min in stage2 phase, if landing or gps resque is enabled
     .failsafe_switch_mode = FAILSAFE_SWITCH_MODE_STAGE1, // default failsafe switch action is identical to rc link loss
     .failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT,    // default full failsafe procedure is 0: auto-landing
     .failsafe_recovery_delay = DEFAULT_FAILSAFE_RECOVERY_DELAY,

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -34,8 +34,8 @@
 typedef struct failsafeConfig_s {
     uint16_t failsafe_throttle;             // Throttle level used for landing - specify value between 1000..2000 (pwm pulse width for slightly below hover). center throttle = 1500.
     uint16_t failsafe_throttle_low_delay;   // Time throttle stick must have been below 'min_check' to "JustDisarm" instead of "full failsafe procedure".
-    uint8_t failsafe_delay;                 // Guard time for failsafe activation after signal lost. 1 step = 0.1sec - 1sec in example (10)
-    uint8_t failsafe_off_delay;             // Time for Landing before motors stop in 0.1sec. 1 step = 0.1sec - 20sec in example (200)
+    uint16_t failsafe_delay;                 // Guard time for failsafe activation after signal lost. 1 step = 0.1sec - 1sec in example (10)
+    uint16_t failsafe_off_delay;             // Time for Landing before motors stop in 0.1sec. 1 step = 0.1sec - 20sec in example (200)
     uint8_t failsafe_switch_mode;           // failsafe switch action is 0: Stage 1, 1: Disarms instantly, 2: Stage 2
     uint8_t failsafe_procedure;             // selected full failsafe procedure is 0: auto-landing, 1: Drop it
     uint16_t failsafe_recovery_delay;       // Time (in 0.1sec) of valid rx data (min 100ms PERIOD_RXDATA_RECOVERY) to allow recovering from failsafe procedure

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1653,8 +1653,8 @@ case MSP_NAME:
 #endif
         break;
     case MSP_FAILSAFE_CONFIG:
-        sbufWriteU8(dst, failsafeConfig()->failsafe_delay);
-        sbufWriteU8(dst, failsafeConfig()->failsafe_off_delay);
+        sbufWriteU16(dst, failsafeConfig()->failsafe_delay);
+        sbufWriteU16(dst, failsafeConfig()->failsafe_off_delay);
         sbufWriteU16(dst, failsafeConfig()->failsafe_throttle);
         sbufWriteU8(dst, failsafeConfig()->failsafe_switch_mode);
         sbufWriteU16(dst, failsafeConfig()->failsafe_throttle_low_delay);
@@ -3810,8 +3810,8 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         }
         break;
     case MSP_SET_FAILSAFE_CONFIG:
-        failsafeConfigMutable()->failsafe_delay = sbufReadU8(src);
-        failsafeConfigMutable()->failsafe_off_delay = sbufReadU8(src);
+        failsafeConfigMutable()->failsafe_delay = sbufReadU16(src);
+        failsafeConfigMutable()->failsafe_off_delay = sbufReadU16(src);
         failsafeConfigMutable()->failsafe_throttle = sbufReadU16(src);
         failsafeConfigMutable()->failsafe_switch_mode = sbufReadU8(src);
         failsafeConfigMutable()->failsafe_throttle_low_delay = sbufReadU16(src);


### PR DESCRIPTION

requires: https://github.com/betaflight/betaflight-configurator/pull/4136 (but it needs semver gating, not yet implemented)