### PR TITLE
tpa_delay_decrease_ratio (for wings)

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1517,7 +1517,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_S_ROLL,  "%d", currentPidProfile->pid[PID_ROLL].S);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_S_PITCH, "%d", currentPidProfile->pid[PID_PITCH].S);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_S_YAW,   "%d", currentPidProfile->pid[PID_YAW].S);
-#endif // #ifdef USE_WING
+#endif // USE_WING
 
         // End of Betaflight controller parameters
 
@@ -1689,6 +1689,7 @@ static bool blackboxWriteSysinfo(void)
 
 #ifdef USE_WING
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_DELAY_MS, "%d", currentPidProfile->tpa_delay_ms);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_DELAY_DECREASE_RATIO, "%d", currentPidProfile->tpa_delay_decrease_ratio);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_GRAVITY_THR0, "%d", currentPidProfile->tpa_gravity_thr0);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_GRAVITY_THR100, "%d", currentPidProfile->tpa_gravity_thr100);
 #endif

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1271,6 +1271,7 @@ const clivalue_t valueTable[] = {
 
 #ifdef USE_WING
     { PARAM_NAME_TPA_DELAY_MS, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_delay_ms) },
+    { PARAM_NAME_TPA_DELAY_DECREASE_RATIO, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_delay_decrease_ratio) },
     { PARAM_NAME_TPA_GRAVITY_THR0, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_GRAVITY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_gravity_thr0) },
     { PARAM_NAME_TPA_GRAVITY_THR100, VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_GRAVITY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_gravity_thr100) },
 #endif

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -59,6 +59,7 @@
 #define PARAM_NAME_TPA_LOW_ALWAYS "tpa_low_always"
 #define PARAM_NAME_TPA_MODE "tpa_mode"
 #define PARAM_NAME_TPA_DELAY_MS "tpa_delay_ms"
+#define PARAM_NAME_TPA_DELAY_DECREASE_RATIO "tpa_delay_decrease_ratio"
 #define PARAM_NAME_TPA_GRAVITY_THR0 "tpa_gravity_thr0"
 #define PARAM_NAME_TPA_GRAVITY_THR100 "tpa_gravity_thr100"
 #define PARAM_NAME_MIXER_TYPE "mixer_type"

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -231,6 +231,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .ez_landing_limit = 15,
         .ez_landing_speed = 50,
         .tpa_delay_ms = 0,
+        .tpa_delay_decrease_ratio = 200,
         .tpa_gravity_thr0 = 0,
         .tpa_gravity_thr100 = 0,
         .spa_center = { 0, 0, 0 },
@@ -287,6 +288,8 @@ void pidResetIterm(void)
 #ifdef USE_WING
 static float getWingTpaArgument(float throttle)
 {
+    static float up = 1.0;
+
     const float pitchFactorAdjustment = scaleRangef(throttle, 0.0f, 1.0f, pidRuntime.tpaGravityThr0, pidRuntime.tpaGravityThr100);
     const float pitchAngleFactor = getSinPitchAngle() * pitchFactorAdjustment;
     DEBUG_SET(DEBUG_TPA, 1, lrintf(pitchAngleFactor * 1000.0f));
@@ -294,7 +297,18 @@ static float getWingTpaArgument(float throttle)
     float tpaArgument = throttle + pitchAngleFactor;
     const float maxTpaArgument = MAX(1.0 + pidRuntime.tpaGravityThr100, pidRuntime.tpaGravityThr0);
     tpaArgument = tpaArgument / maxTpaArgument;
+
+    if (up * (tpaArgument - pidRuntime.tpaLpf.state) < 0.0f) { // tpa argument trend changed the sign
+        up = -up;
+        if (up > 0.0f) {
+            pt2FilterUpdateCutoff(&pidRuntime.tpaLpf, pidRuntime.tpaLpfGainUp);
+        } else {
+            pt2FilterUpdateCutoff(&pidRuntime.tpaLpf, pidRuntime.tpaLpfGainDown);
+        }
+    }
+
     tpaArgument = pt2FilterApply(&pidRuntime.tpaLpf, tpaArgument);
+    tpaArgument = MAX(tpaArgument, 0.0f);
     DEBUG_SET(DEBUG_TPA, 2, lrintf(tpaArgument * 1000.0f));
 
     return tpaArgument;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -264,11 +264,12 @@ typedef struct pidProfile_s {
     uint8_t ez_landing_disarm_threshold;    // Accelerometer vector threshold which disarms if exceeded
 
     uint16_t tpa_delay_ms;                  // TPA delay for fixed wings using pt2 filter (time constant)
+    uint16_t tpa_delay_decrease_ratio;      // Multiplier of TPA delay in % for when TPA argument decreases
     uint16_t spa_center[XYZ_AXIS_COUNT];    // RPY setpoint at which PIDs are reduced to 50% (setpoint PID attenuation)
     uint16_t spa_width[XYZ_AXIS_COUNT];     // Width of smooth transition around spa_center
     uint8_t spa_mode[XYZ_AXIS_COUNT];       // SPA mode for each axis
-    uint16_t tpa_gravity_thr0;               // For wings: addition to tpa argument in % when zero throttle
-    uint16_t tpa_gravity_thr100;             // For wings: addition to tpa argument in % when full throttle
+    uint16_t tpa_gravity_thr0;              // For wings: addition to tpa argument in % when zero throttle
+    uint16_t tpa_gravity_thr100;            // For wings: addition to tpa argument in % when full throttle
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -453,6 +454,8 @@ typedef struct pidRuntime_s {
 
 #ifdef USE_WING
     pt2Filter_t tpaLpf;
+    float tpaLpfGainUp;
+    float tpaLpfGainDown;
     float spa[XYZ_AXIS_COUNT]; // setpoint pid attenuation (0.0 to 1.0). 0 - full attenuation, 1 - no attenuation
     float tpaGravityThr0;
     float tpaGravityThr100;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -258,7 +258,9 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 
     pt2FilterInit(&pidRuntime.antiGravityLpf, pt2FilterGain(pidProfile->anti_gravity_cutoff_hz, pidRuntime.dT));
 #ifdef USE_WING
-    pt2FilterInit(&pidRuntime.tpaLpf, pt2FilterGainFromDelay(pidProfile->tpa_delay_ms / 1000.0f, pidRuntime.dT));
+    pidRuntime.tpaLpfGainUp = pt2FilterGainFromDelay(pidProfile->tpa_delay_ms / 1000.0f, pidRuntime.dT);
+    pidRuntime.tpaLpfGainDown = pt2FilterGainFromDelay(pidProfile->tpa_delay_ms * pidProfile->tpa_delay_decrease_ratio / 1000.0f / 100.0f, pidRuntime.dT);
+    pt2FilterInit(&pidRuntime.tpaLpf, pidRuntime.tpaLpfGainUp);
     pidRuntime.tpaGravityThr0 = pidProfile->tpa_gravity_thr0 / 100.0f;
     pidRuntime.tpaGravityThr100 = pidProfile->tpa_gravity_thr100 / 100.0f;
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {


### PR DESCRIPTION
Upgrade of this PR:
https://github.com/betaflight/betaflight/pull/13662

Fixed wing might loose speed slower than it gains speed. In fact, for my wing, it seems to be ~3 times slower, and that should be reflected in TPA behavior. 
`set tpa_delay_ms = 1000` adds 1000ms delay between throttle-gravity and TPA argument.
If we use the same delay for when speed drops, we end up with too much PIDs too early.

The new parameter `tpa_delay_decrease_ratio` controls the delay of how fast wing looses speed versus how fast it gains speed.
For example:
```
set tpa_delay_ms = 1000
set tpa_delay_decrease_ratio  = 300 # 300 percent of tpa_delay_ms
```
makes the TPA argument increasing delay 1000ms, but decreasing delay x3, so 3000ms.
With this PR i was able to estimate the speed more accurate, and avoid oscillations when I drop throttle abruptly.
This is the plot of GPS 3D speed versus airspeed estimation with `set tpa_delay_decrease_ratio  = 300`.
Almost no wind, so can assume GPS 3D speed is ~ air speed.
![image](https://github.com/user-attachments/assets/d5cab106-3a73-484a-9d3e-9c2422de1f79)

Can see the TPA argument (debug[2]) is pretty close to the actual speed.

It also can be useful for some wings where motors blowing air over control surfaces. In this case the air speed over control surfaces grows faster than the overall wing speed.

### Future improvements:
Take into account roll/pitch/yaw setpoints, because hard maneuvers decrease speed.
Use average motor output instead of throttle.