### PR TITLE
CLEANUP: Removing source wild cards from makefiles

### DIFF
--- a/mk/mcu/APM32F4.mk
+++ b/mk/mcu/APM32F4.mk
@@ -5,28 +5,101 @@
 #CMSIS
 CMSIS_DIR      := $(ROOT)/lib/main/APM32F4/Libraries/Device
 STDPERIPH_DIR   = $(ROOT)/lib/main/APM32F4/Libraries/APM32F4xx_DAL_Driver
-STDPERIPH_SRC   = $(notdir $(wildcard $(STDPERIPH_DIR)/Source/*.c))
-EXCLUDES        = apm32f4xx_dal_timebase_rtc_alarm_template.c \
-                  apm32f4xx_dal_timebase_rtc_wakeup_template.c \
-                  apm32f4xx_dal_timebase_tmr_template.c \
-                  apm32f4xx_device_cfg_template.c
-
-STDPERIPH_SRC   := $(filter-out ${EXCLUDES}, $(STDPERIPH_SRC))
+STDPERIPH_SRC   = \
+            apm32f4xx_dal_adc.c \
+            apm32f4xx_dal_adc_ex.c \
+            apm32f4xx_dal.c \
+            apm32f4xx_dal_can.c \
+            apm32f4xx_dal_comp.c \
+            apm32f4xx_dal_cortex.c \
+            apm32f4xx_dal_crc.c \
+            apm32f4xx_dal_cryp.c \
+            apm32f4xx_dal_cryp_ex.c \
+            apm32f4xx_dal_dac.c \
+            apm32f4xx_dal_dac_ex.c \
+            apm32f4xx_dal_dci.c \
+            apm32f4xx_dal_dci_ex.c \
+            apm32f4xx_dal_dma.c \
+            apm32f4xx_dal_dma_ex.c \
+            apm32f4xx_dal_eint.c \
+            apm32f4xx_dal_eth.c \
+            apm32f4xx_dal_flash.c \
+            apm32f4xx_dal_flash_ex.c \
+            apm32f4xx_dal_flash_ramfunc.c \
+            apm32f4xx_dal_gpio.c \
+            apm32f4xx_dal_hash.c \
+            apm32f4xx_dal_hash_ex.c \
+            apm32f4xx_dal_hcd.c \
+            apm32f4xx_dal_i2c.c \
+            apm32f4xx_dal_i2c_ex.c \
+            apm32f4xx_dal_i2s.c \
+            apm32f4xx_dal_i2s_ex.c \
+            apm32f4xx_dal_irda.c \
+            apm32f4xx_dal_iwdt.c \
+            apm32f4xx_dal_log.c \
+            apm32f4xx_dal_mmc.c \
+            apm32f4xx_dal_nand.c \
+            apm32f4xx_dal_nor.c \
+            apm32f4xx_dal_pccard.c \
+            apm32f4xx_dal_pcd.c \
+            apm32f4xx_dal_pcd_ex.c \
+            apm32f4xx_dal_pmu.c \
+            apm32f4xx_dal_pmu_ex.c \
+            apm32f4xx_dal_qspi.c \
+            apm32f4xx_dal_rcm.c \
+            apm32f4xx_dal_rcm_ex.c \
+            apm32f4xx_dal_rng.c \
+            apm32f4xx_dal_rtc.c \
+            apm32f4xx_dal_rtc_ex.c \
+            apm32f4xx_dal_sd.c \
+            apm32f4xx_dal_sdram.c \
+            apm32f4xx_dal_smartcard.c \
+            apm32f4xx_dal_smbus.c \
+            apm32f4xx_dal_spi.c \
+            apm32f4xx_dal_sram.c \
+            apm32f4xx_dal_tmr.c \
+            apm32f4xx_dal_tmr_ex.c \
+            apm32f4xx_dal_uart.c \
+            apm32f4xx_dal_usart.c \
+            apm32f4xx_dal_wwdt.c \
+            apm32f4xx_ddl_adc.c \
+            apm32f4xx_ddl_comp.c \
+            apm32f4xx_ddl_crc.c \
+            apm32f4xx_ddl_dac.c \
+            apm32f4xx_ddl_dma.c \
+            apm32f4xx_ddl_dmc.c \
+            apm32f4xx_ddl_eint.c \
+            apm32f4xx_ddl_gpio.c \
+            apm32f4xx_ddl_i2c.c \
+            apm32f4xx_ddl_pmu.c \
+            apm32f4xx_ddl_rcm.c \
+            apm32f4xx_ddl_rng.c \
+            apm32f4xx_ddl_rtc.c \
+            apm32f4xx_ddl_sdmmc.c \
+            apm32f4xx_ddl_smc.c \
+            apm32f4xx_ddl_spi.c \
+            apm32f4xx_ddl_tmr.c \
+            apm32f4xx_ddl_usart.c \
+            apm32f4xx_ddl_usb.c \
+            apm32f4xx_ddl_utils.c
 
 VPATH       := $(VPATH):$(STDPERIPH_DIR)/Source
 
 #USB
 USBCORE_DIR = $(ROOT)/lib/main/APM32F4/Middlewares/APM32_USB_Library/Device/Core
-USBCORE_SRC = $(notdir $(wildcard $(USBCORE_DIR)/Src/*.c))
-USBCORE_SRC := $(filter-out ${EXCLUDES}, $(USBCORE_SRC))
+USBCORE_SRC = \
+        usbd_core.c \
+        usbd_dataXfer.c \
+        usbd_stdReq.c
 
 USBCDC_DIR = $(ROOT)/lib/main/APM32F4/Middlewares/APM32_USB_Library/Device/Class/CDC
-USBCDC_SRC = $(notdir $(wildcard $(USBCDC_DIR)/Src/*.c))
-USBCDC_SRC := $(filter-out ${EXCLUDES}, $(USBCDC_SRC))
+USBCDC_SRC = usbd_cdc.c
 
 USBMSC_DIR = $(ROOT)/lib/main/APM32F4/Middlewares/APM32_USB_Library/Device/Class/MSC
-USBMSC_SRC = $(notdir $(wildcard $(USBMSC_DIR)/Src/*.c))
-USBMSC_SRC := $(filter-out ${EXCLUDES}, $(USBMSC_SRC))
+USBMSC_SRC = \
+        usbd_msc.c \
+        usbd_msc_bot.c \
+        usbd_msc_scsi.c
 
 VPATH := $(VPATH):$(USBCDC_DIR)/Src:$(USBCORE_DIR)/Src:$(USBMSC_DIR)/Src
 
@@ -57,14 +130,16 @@ INCLUDE_DIRS    := $(INCLUDE_DIRS) \
 #Flags
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
 
+DEVICE_FLAGS    = -DUSE_DAL_DRIVER -DHSE_VALUE=$(HSE_VALUE) -DAPM32
+
 ifeq ($(TARGET_MCU),APM32F405xx)
-DEVICE_FLAGS    = -DUSE_DAL_DRIVER -DAPM32F405xx -DHSE_VALUE=$(HSE_VALUE) -DAPM32
+DEVICE_FLAGS    += -DAPM32F405xx
 LD_SCRIPT       = $(LINKER_DIR)/apm32_flash_f405.ld
 STARTUP_SRC     = apm32/startup_apm32f405xx.S
 MCU_FLASH_SIZE  := 1024
 
 else ifeq ($(TARGET_MCU),APM32F407xx)
-DEVICE_FLAGS    = -DUSE_DAL_DRIVER -DAPM32F407xx -DHSE_VALUE=$(HSE_VALUE) -DAPM32
+DEVICE_FLAGS    += -DAPM32F407xx
 LD_SCRIPT       = $(LINKER_DIR)/apm32_flash_f407.ld
 STARTUP_SRC     = apm32/startup_apm32f407xx.S
 MCU_FLASH_SIZE  := 1024

--- a/mk/mcu/AT32F4.mk
+++ b/mk/mcu/AT32F4.mk
@@ -5,27 +5,58 @@
 CMSIS_DIR      := $(ROOT)/lib/main/AT32F43x/cmsis
 STDPERIPH_DIR   = $(ROOT)/lib/main/AT32F43x/drivers
 MIDDLEWARES_DIR = $(ROOT)/lib/main/AT32F43x/middlewares
-STDPERIPH_SRC   = $(wildcard $(STDPERIPH_DIR)/src/*.c) \
-                  $(wildcard $(MIDDLEWARES_DIR)/usb_drivers/src/*.c) \
-                  $(wildcard $(MIDDLEWARES_DIR)/usbd_class/msc/*.c)
-
-EXCLUDES        = at32f435_437_dvp.c \
-                  at32f435_437_can.c \
-                  at32f435_437_xmc.c \
-                  at32f435_437_emac
+STDPERIPH_SRC   = \
+        at32f435_437_acc.c \
+        at32f435_437_adc.c \
+        at32f435_437_can.c \
+        at32f435_437_crc.c \
+        at32f435_437_crm.c \
+        at32f435_437_dac.c \
+        at32f435_437_debug.c \
+        at32f435_437_dma.c \
+        at32f435_437_dvp.c \
+        at32f435_437_edma.c \
+        at32f435_437_emac.c \
+        at32f435_437_ertc.c \
+        at32f435_437_exint.c \
+        at32f435_437_flash.c \
+        at32f435_437_gpio.c \
+        at32f435_437_i2c.c \
+        at32f435_437_misc.c \
+        at32f435_437_pwc.c \
+        at32f435_437_qspi.c \
+        at32f435_437_scfg.c \
+        at32f435_437_sdio.c \
+        at32f435_437_spi.c \
+        at32f435_437_tmr.c \
+        at32f435_437_usart.c \
+        at32f435_437_usb.c \
+        at32f435_437_wdt.c \
+        at32f435_437_wwdt.c \
+        at32f435_437_xmc.c \
+        usb_drivers/src/usb_core.c \
+        usb_drivers/src/usbd_core.c \
+        usb_drivers/src/usbd_int.c \
+        usb_drivers/src/usbd_sdr.c \
+        usb_drivers/src/usbh_core.c \
+        usb_drivers/src/usbh_ctrl.c \
+        usb_drivers/src/usbh_int.c \
+        usbd_class/msc/msc_bot_scsi.c \
+        usbd_class/msc/msc_class.c \
+        usbd_class/msc/msc_desc.c
 
 STARTUP_SRC     = at32/startup_at32f435_437.s
-STDPERIPH_SRC   := $(filter-out ${EXCLUDES}, $(STDPERIPH_SRC))
 
-VPATH           := $(VPATH):$(ROOT)/lib/main/AT32F43x/cmsis/cm4/core_support:$(STDPERIPH_DIR)/src:$(STDPERIPH_DIR)/inc:$(SRC_DIR)/startup/at32
+VPATH           := $(VPATH):$(ROOT)/lib/main/AT32F43x/cmsis/cm4/core_support:$(STDPERIPH_DIR)/src:$(MIDDLEWARES_DIR):$(SRC_DIR)/startup/at32
 
 VCP_SRC =  \
-            $(ROOT)/lib/main/AT32F43x/middlewares/usbd_class/cdc/cdc_class.c \
-            $(ROOT)/lib/main/AT32F43x/middlewares/usbd_class/cdc/cdc_desc.c \
+            usbd_class/cdc/cdc_class.c \
+            usbd_class/cdc/cdc_desc.c \
             drivers/usb_io.c
 
-VCP_INCLUDES =     $(ROOT)/lib/main/AT32F43x/middlewares/usb_drivers/inc \
-                   $(ROOT)/lib/main/AT32F43x/middlewares/usbd_class/cdc
+VCP_INCLUDES = \
+        $(MIDDLEWARES_DIR)/usb_drivers/inc \
+        $(MIDDLEWARES_DIR)/usbd_class/cdc
 
 DEVICE_STDPERIPH_SRC = $(STDPERIPH_SRC)
 

--- a/mk/mcu/STM32F4.mk
+++ b/mk/mcu/STM32F4.mk
@@ -65,28 +65,33 @@ DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
                         $(USBCDC_SRC)
 else
 USBCORE_DIR = $(ROOT)/lib/main/STM32_USB_Device_Library/Core
-USBCORE_SRC = $(notdir $(wildcard $(USBCORE_DIR)/src/*.c))
-USBOTG_DIR  = $(ROOT)/lib/main/STM32_USB_OTG_Driver
-USBOTG_SRC  = $(notdir $(wildcard $(USBOTG_DIR)/src/*.c))
-EXCLUDES    = usb_bsp_template.c \
-              usb_conf_template.c \
-              usb_hcd_int.c \
-              usb_hcd.c \
-              usb_otg.c
+USBCORE_SRC = \
+            usbd_core.c \
+            usbd_ioreq.c \
+            usbd_req.c
 
-USBOTG_SRC  := $(filter-out ${EXCLUDES}, $(USBOTG_SRC))
+USBOTG_DIR  = $(ROOT)/lib/main/STM32_USB_OTG_Driver
+USBOTG_SRC  = \
+            usb_core.c \
+            usb_dcd.c \
+            usb_dcd_int.c
+
 USBCDC_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/cdc
-USBCDC_SRC  = $(notdir $(wildcard $(USBCDC_DIR)/src/*.c))
-EXCLUDES    = usbd_cdc_if_template.c
-USBCDC_SRC  := $(filter-out ${EXCLUDES}, $(USBCDC_SRC))
+USBCDC_SRC  = usbd_cdc_core.c
+
 USBMSC_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/msc
-USBMSC_SRC  = $(notdir $(wildcard $(USBMSC_DIR)/src/*.c))
-EXCLUDES    = usbd_storage_template.c
-USBMSC_SRC  := $(filter-out ${EXCLUDES}, $(USBMSC_SRC))
+USBMSC_SRC  = \
+            usbd_msc_bot.c \
+            usbd_msc_core.c \
+            usbd_msc_data.c \
+            usbd_msc_scsi.c
+
 USBHID_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/hid
-USBHID_SRC  = $(notdir $(wildcard $(USBHID_DIR)/src/*.c))
+USBHID_SRC  = usbd_hid_core.c
+
 USBWRAPPER_DIR  = $(ROOT)/lib/main/STM32_USB_Device_Library/Class/hid_cdc_wrapper
-USBWRAPPER_SRC  = $(notdir $(wildcard $(USBWRAPPER_DIR)/src/*.c))
+USBWRAPPER_SRC  = usbd_hid_cdc_wrapper.c
+
 VPATH       := $(VPATH):$(USBOTG_DIR)/src:$(USBCORE_DIR)/src:$(USBCDC_DIR)/src:$(USBMSC_DIR)/src:$(USBHID_DIR)/src:$(USBWRAPPER_DIR)/src
 
 DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
@@ -107,27 +112,31 @@ INCLUDE_DIRS    := $(INCLUDE_DIRS) \
 
 ifeq ($(PERIPH_DRIVER), HAL)
 CMSIS_SRC       :=
-INCLUDE_DIRS    := $(INCLUDE_DIRS) \
-                   $(STDPERIPH_DIR)/Inc \
-                   $(USBCORE_DIR)/Inc \
-                   $(USBCDC_DIR)/Inc \
-                   $(CMSIS_DIR)/Include \
-                   $(CMSIS_DIR)/Device/ST/STM32F4xx/Include \
-                   $(SRC_DIR)/drivers/mcu/stm32/vcp_hal
+INCLUDE_DIRS    := \
+                $(INCLUDE_DIRS) \
+                $(STDPERIPH_DIR)/Inc \
+                $(USBCORE_DIR)/Inc \
+                $(USBCDC_DIR)/Inc \
+                $(CMSIS_DIR)/Include \
+                $(CMSIS_DIR)/Device/ST/STM32F4xx/Include \
+                $(SRC_DIR)/drivers/mcu/stm32/vcp_hal
 else
-CMSIS_SRC       := $(notdir $(wildcard $(CMSIS_DIR)/CoreSupport/*.c \
-                   $(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx/*.c))
-INCLUDE_DIRS    := $(INCLUDE_DIRS) \
-                   $(STDPERIPH_DIR)/inc \
-                   $(USBOTG_DIR)/inc \
-                   $(USBCORE_DIR)/inc \
-                   $(USBCDC_DIR)/inc \
-                   $(USBHID_DIR)/inc \
-                   $(USBWRAPPER_DIR)/inc \
-                   $(USBMSC_DIR)/inc \
-                   $(CMSIS_DIR)/Core/Include \
-                   $(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx \
-                   $(SRC_DIR)/drivers/mcu/stm32/vcpf4
+CMSIS_SRC       := \
+                stm32f4xx_gpio.c \
+                stm32f4xx_rcc.c
+
+INCLUDE_DIRS    := \
+                $(INCLUDE_DIRS) \
+                $(STDPERIPH_DIR)/inc \
+                $(USBOTG_DIR)/inc \
+                $(USBCORE_DIR)/inc \
+                $(USBCDC_DIR)/inc \
+                $(USBHID_DIR)/inc \
+                $(USBWRAPPER_DIR)/inc \
+                $(USBMSC_DIR)/inc \
+                $(CMSIS_DIR)/Core/Include \
+                $(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx \
+                $(SRC_DIR)/drivers/mcu/stm32/vcpf4
 endif
 
 #Flags

--- a/mk/mcu/STM32F4.mk
+++ b/mk/mcu/STM32F4.mk
@@ -60,9 +60,10 @@ USBCDC_SRC := $(filter-out ${EXCLUDES}, $(USBCDC_SRC))
 
 VPATH := $(VPATH):$(USBCDC_DIR)/Src:$(USBCORE_DIR)/Src
 
-DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
-                        $(USBCORE_SRC) \
-                        $(USBCDC_SRC)
+DEVICE_STDPERIPH_SRC := \
+            $(STDPERIPH_SRC) \
+            $(USBCORE_SRC) \
+            $(USBCDC_SRC)
 else
 USBCORE_DIR = $(ROOT)/lib/main/STM32_USB_Device_Library/Core
 USBCORE_SRC = \
@@ -94,49 +95,51 @@ USBWRAPPER_SRC  = usbd_hid_cdc_wrapper.c
 
 VPATH       := $(VPATH):$(USBOTG_DIR)/src:$(USBCORE_DIR)/src:$(USBCDC_DIR)/src:$(USBMSC_DIR)/src:$(USBHID_DIR)/src:$(USBWRAPPER_DIR)/src
 
-DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
-                        $(USBOTG_SRC) \
-                        $(USBCORE_SRC) \
-                        $(USBCDC_SRC) \
-                        $(USBHID_SRC) \
-                        $(USBWRAPPER_SRC) \
-                        $(USBMSC_SRC)
+DEVICE_STDPERIPH_SRC := \
+            $(STDPERIPH_SRC) \
+            $(USBOTG_SRC) \
+            $(USBCORE_SRC) \
+            $(USBCDC_SRC) \
+            $(USBHID_SRC) \
+            $(USBWRAPPER_SRC) \
+            $(USBMSC_SRC)
 endif
 
 #CMSIS
-VPATH           := $(VPATH):$(CMSIS_DIR)/Core/Include:$(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx
+VPATH        := $(VPATH):$(CMSIS_DIR)/Core/Include:$(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx
 
-INCLUDE_DIRS    := $(INCLUDE_DIRS) \
-                   $(SRC_DIR)/startup/stm32 \
-                   $(SRC_DIR)/drivers/mcu/stm32
+INCLUDE_DIRS := \
+            $(INCLUDE_DIRS) \
+            $(SRC_DIR)/startup/stm32 \
+            $(SRC_DIR)/drivers/mcu/stm32
 
 ifeq ($(PERIPH_DRIVER), HAL)
 CMSIS_SRC       :=
 INCLUDE_DIRS    := \
-                $(INCLUDE_DIRS) \
-                $(STDPERIPH_DIR)/Inc \
-                $(USBCORE_DIR)/Inc \
-                $(USBCDC_DIR)/Inc \
-                $(CMSIS_DIR)/Include \
-                $(CMSIS_DIR)/Device/ST/STM32F4xx/Include \
-                $(SRC_DIR)/drivers/mcu/stm32/vcp_hal
+            $(INCLUDE_DIRS) \
+            $(STDPERIPH_DIR)/Inc \
+            $(USBCORE_DIR)/Inc \
+            $(USBCDC_DIR)/Inc \
+            $(CMSIS_DIR)/Include \
+            $(CMSIS_DIR)/Device/ST/STM32F4xx/Include \
+            $(SRC_DIR)/drivers/mcu/stm32/vcp_hal
 else
 CMSIS_SRC       := \
-                stm32f4xx_gpio.c \
-                stm32f4xx_rcc.c
+            stm32f4xx_gpio.c \
+            stm32f4xx_rcc.c
 
 INCLUDE_DIRS    := \
-                $(INCLUDE_DIRS) \
-                $(STDPERIPH_DIR)/inc \
-                $(USBOTG_DIR)/inc \
-                $(USBCORE_DIR)/inc \
-                $(USBCDC_DIR)/inc \
-                $(USBHID_DIR)/inc \
-                $(USBWRAPPER_DIR)/inc \
-                $(USBMSC_DIR)/inc \
-                $(CMSIS_DIR)/Core/Include \
-                $(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx \
-                $(SRC_DIR)/drivers/mcu/stm32/vcpf4
+            $(INCLUDE_DIRS) \
+            $(STDPERIPH_DIR)/inc \
+            $(USBOTG_DIR)/inc \
+            $(USBCORE_DIR)/inc \
+            $(USBCDC_DIR)/inc \
+            $(USBHID_DIR)/inc \
+            $(USBWRAPPER_DIR)/inc \
+            $(USBMSC_DIR)/inc \
+            $(CMSIS_DIR)/Core/Include \
+            $(ROOT)/lib/main/STM32F4/Drivers/CMSIS/Device/ST/STM32F4xx \
+            $(SRC_DIR)/drivers/mcu/stm32/vcpf4
 endif
 
 #Flags

--- a/mk/mcu/STM32G4.mk
+++ b/mk/mcu/STM32G4.mk
@@ -3,7 +3,7 @@
 #
 
 ifeq ($(DEBUG_HARDFAULTS),G4)
-CFLAGS               += -DDEBUG_HARDFAULTS
+CFLAGS          += -DDEBUG_HARDFAULTS
 endif
 
 #CMSIS
@@ -65,27 +65,29 @@ USBMSC_SRC = \
 
 VPATH := $(VPATH):$(USBCDC_DIR)/Src:$(USBCORE_DIR)/Src:$(USBHID_DIR)/Src:$(USBMSC_DIR)/Src:$(STDPERIPH_DIR)/src
 
-DEVICE_STDPERIPH_SRC := $(STDPERIPH_SRC) \
-                        $(USBCORE_SRC) \
-                        $(USBCDC_SRC) \
-                        $(USBHID_SRC) \
-                        $(USBMSC_SRC)
+DEVICE_STDPERIPH_SRC := \
+            $(STDPERIPH_SRC) \
+            $(USBCORE_SRC) \
+            $(USBCDC_SRC) \
+            $(USBHID_SRC) \
+            $(USBMSC_SRC)
 
 #CMSIS
 VPATH           := $(VPATH):$(CMSIS_DIR)/Include:$(CMSIS_DIR)/Device/ST/STM32G4xx
 VPATH           := $(VPATH):$(STDPERIPH_DIR)/Src
 CMSIS_SRC       :=
-INCLUDE_DIRS    := $(INCLUDE_DIRS) \
-                   $(SRC_DIR)/startup/stm32 \
-                   $(STDPERIPH_DIR)/Inc \
-                   $(USBCORE_DIR)/Inc \
-                   $(USBCDC_DIR)/Inc \
-                   $(USBHID_DIR)/Inc \
-                   $(USBMSC_DIR)/Inc \
-                   $(CMSIS_DIR)/Core/Include \
-                   $(ROOT)/lib/main/STM32G4/Drivers/CMSIS/Device/ST/STM32G4xx/Include \
-                   $(SRC_DIR)/drivers/mcu/stm32 \
-                   $(SRC_DIR)/drivers/mcu/stm32/vcp_hal
+INCLUDE_DIRS    := \
+            $(INCLUDE_DIRS) \
+            $(SRC_DIR)/startup/stm32 \
+            $(STDPERIPH_DIR)/Inc \
+            $(USBCORE_DIR)/Inc \
+            $(USBCDC_DIR)/Inc \
+            $(USBHID_DIR)/Inc \
+            $(USBMSC_DIR)/Inc \
+            $(CMSIS_DIR)/Core/Include \
+            $(ROOT)/lib/main/STM32G4/Drivers/CMSIS/Device/ST/STM32G4xx/Include \
+            $(SRC_DIR)/drivers/mcu/stm32 \
+            $(SRC_DIR)/drivers/mcu/stm32/vcp_hal
 
 #Flags
 ARCH_FLAGS      = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
@@ -95,13 +97,13 @@ DEVICE_FLAGS    = -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER -DUSE_DMA_RAM -DMAX_MPU_
 # G47X_TARGETS includes G47{3,4}{RE,CE,CEU}
 
 ifeq ($(TARGET_MCU),STM32G474xx)
-DEVICE_FLAGS   += -DSTM32G474xx
+DEVICE_FLAGS    += -DSTM32G474xx
 LD_SCRIPT       = $(LINKER_DIR)/stm32_flash_g474.ld
 STARTUP_SRC     = stm32/startup_stm32g474xx.s
 MCU_FLASH_SIZE  = 512
 # Override the OPTIMISE_SPEED compiler setting to save flash space on these 512KB targets.
 # Performance is only slightly affected but around 50 kB of flash are saved.
-OPTIMISE_SPEED = -O2
+OPTIMISE_SPEED  = -O2
 else
 $(error Unknown MCU for G4 target)
 endif

--- a/mk/mcu/STM32G4.mk
+++ b/mk/mcu/STM32G4.mk
@@ -45,22 +45,23 @@ STDPERIPH_SRC   = \
 
 #USB
 USBCORE_DIR = $(ROOT)/lib/main/STM32G4/Middlewares/ST/STM32_USB_Device_Library/Core
-USBCORE_SRC = $(notdir $(wildcard $(USBCORE_DIR)/Src/*.c))
-EXCLUDES    = usbd_conf_template.c
-USBCORE_SRC := $(filter-out ${EXCLUDES}, $(USBCORE_SRC))
+USBCORE_SRC = \
+            usbd_core.c \
+            usbd_ctlreq.c \
+            usbd_ioreq.c
 
 USBCDC_DIR = $(ROOT)/lib/main/STM32G4/Middlewares/ST/STM32_USB_Device_Library/Class/CDC
-USBCDC_SRC = $(notdir $(wildcard $(USBCDC_DIR)/Src/*.c))
-EXCLUDES   = usbd_cdc_if_template.c
-USBCDC_SRC := $(filter-out ${EXCLUDES}, $(USBCDC_SRC))
+USBCDC_SRC = usbd_cdc.c
 
 USBHID_DIR = $(ROOT)/lib/main/STM32G4/Middlewares/ST/STM32_USB_Device_Library/Class/HID
-USBHID_SRC = $(notdir $(wildcard $(USBHID_DIR)/Src/*.c))
+USBHID_SRC = usbd_hid.c
 
 USBMSC_DIR = $(ROOT)/lib/main/STM32G4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC
-USBMSC_SRC = $(notdir $(wildcard $(USBMSC_DIR)/Src/*.c))
-EXCLUDES   = usbd_msc_storage_template.c
-USBMSC_SRC := $(filter-out ${EXCLUDES}, $(USBMSC_SRC))
+USBMSC_SRC = \
+            usbd_msc_bot.c \
+            usbd_msc.c \
+            usbd_msc_data.c \
+            usbd_msc_scsi.c
 
 VPATH := $(VPATH):$(USBCDC_DIR)/Src:$(USBCORE_DIR)/Src:$(USBHID_DIR)/Src:$(USBMSC_DIR)/Src:$(STDPERIPH_DIR)/src
 

--- a/mk/mcu/STM32H7.mk
+++ b/mk/mcu/STM32H7.mk
@@ -60,22 +60,23 @@ STDPERIPH_SRC   = \
 
 #USB
 USBCORE_DIR = $(ROOT)/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Core
-USBCORE_SRC = $(notdir $(wildcard $(USBCORE_DIR)/Src/*.c))
-EXCLUDES    = usbd_conf_template.c
-USBCORE_SRC := $(filter-out ${EXCLUDES}, $(USBCORE_SRC))
+USBCORE_SRC = \
+            usbd_core.c \
+            usbd_ctlreq.c \
+            usbd_ioreq.c
 
 USBCDC_DIR = $(ROOT)/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/CDC
-USBCDC_SRC = $(notdir $(wildcard $(USBCDC_DIR)/Src/*.c))
-EXCLUDES   = usbd_cdc_if_template.c
-USBCDC_SRC := $(filter-out ${EXCLUDES}, $(USBCDC_SRC))
+USBCDC_SRC = usbd_cdc.c
 
 USBHID_DIR = $(ROOT)/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/HID
-USBHID_SRC = $(notdir $(wildcard $(USBHID_DIR)/Src/*.c))
+USBHID_SRC = usbd_hid.c
 
 USBMSC_DIR = $(ROOT)/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC
-USBMSC_SRC = $(notdir $(wildcard $(USBMSC_DIR)/Src/*.c))
-EXCLUDES   = usbd_msc_storage_template.c
-USBMSC_SRC := $(filter-out ${EXCLUDES}, $(USBMSC_SRC))
+USBMSC_SRC = \
+            usbd_msc_bot.c \
+            usbd_msc.c \
+            usbd_msc_data.c \
+            usbd_msc_scsi.c
 
 VPATH := $(VPATH):$(USBCDC_DIR)/Src:$(USBCORE_DIR)/Src:$(USBHID_DIR)/Src:$(USBMSC_DIR)/Src:$(STDPERIPH_DIR)/src
 


### PR DESCRIPTION
As per @ledvinap request - removing wild cards from source files (note the F4 HAL still to be completed - currently unused).