### PR TITLE
Makefile - remove -j0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ ifneq ($(wildcard $(MAKE_SCRIPT_DIR)/local.mk),)
 include $(MAKE_SCRIPT_DIR)/local.mk
 endif
 
+# some targets use parallel build by default
+# MAKEFLAGS is valid only inside target, do not use this at parse phase
+DEFAULT_PARALLEL_JOBS 	:=    # all jobs in parallel (for backward compatibility)
+MAKE_PARALLEL 		= $(if $(filter -j%, $(MAKEFLAGS)),$(EMPTY),-j$(DEFAULT_PARALLEL_JOBS))
+
 # pre-build sanity checks
 include $(MAKE_SCRIPT_DIR)/checks.mk
 
@@ -507,11 +512,11 @@ test_clean:
 
 ## <TARGET>_clean    : clean up one specific target (alias for above)
 $(TARGETS_CLEAN):
-	$(V0) $(MAKE) -j TARGET=$(subst _clean,,$@) clean
+	$(V0) $(MAKE) $(MAKE_PARALLEL) TARGET=$(subst _clean,,$@) clean
 
 ## <CONFIG>_clean    : clean up one specific target (alias for above)
 $(CONFIGS_CLEAN):
-	$(V0) $(MAKE) -j CONFIG=$(subst _clean,,$@) clean
+	$(V0) $(MAKE) $(MAKE_PARALLEL) CONFIG=$(subst _clean,,$@) clean
 
 ## clean_all         : clean all targets
 clean_all: $(TARGETS_CLEAN) test_clean
@@ -568,10 +573,10 @@ zip:
 	$(V0) zip $(TARGET_ZIP) $(TARGET_HEX)
 
 binary:
-	$(V0) $(MAKE) -j $(TARGET_BIN)
+	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
 
 hex:
-	$(V0) $(MAKE) -j $(TARGET_HEX)
+	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
 TARGETS_REVISION = $(addsuffix _rev,$(BASE_TARGETS))
 ## <TARGET>_rev    : build target and add revision to filename

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -59,9 +59,9 @@ endif
 
 $(BASE_CONFIGS):
 	@echo "Building target config $@"
-	$(V0) $(MAKE) -j hex CONFIG=$@
+	$(V0) $(MAKE) $(MAKE_PARALLEL) hex CONFIG=$@
 	@echo "Building target config $@ succeeded."
 
 ## <CONFIG>_rev    : build configured target and add revision to filename
 $(addsuffix _rev,$(BASE_CONFIGS)):
-	$(V0) $(MAKE) -j hex CONFIG=$(subst _rev,,$@) REV=yes
+	$(V0) $(MAKE) $(MAKE_PARALLEL) hex CONFIG=$(subst _rev,,$@) REV=yes


### PR DESCRIPTION
> ‘-j [jobs]’
> Specifies the number of recipes (jobs) to run simultaneously. With no argument, make runs as many recipes simultaneously as possible.

`-j` in sub-makefiles interferes with `-j` on command line: Normal make use - ``make all -j `nproc` `` will run lot of submakes without job control, spawning thousands of processes, overloading system (a bit).

This change will affect users using `make all`, resulting in considerably slower, serial build (exactly as they requested).

My opinion is that `make` should follow user settings - if parallel build is desired, it should be specified on command line. Also, explicit -j (jobserver) is a a bit faster.

`make all` (master): 
real    3m44.487s
user    42m52.385s
sys     5m0.385s

``make -j 4 all`` (master): 
real    2m37.838s
user    49m29.350s
sys     5m1.863s

``make -j `nproc` all`` (master): 
real    2m44.280s
user    53m43.210s
sys     5m42.319s

``make -j `nproc` all`` (PR):
real    2m31.149s
user    49m40.533s
sys     5m13.114s

`make all` (PR):
real    22m2.152s
user    28m11.233s   #  It seems that hyperthreading is affecting this number
sys     3m47.562s

