### PR TITLE
Fix incorrect timer channel comments TIM2_CH1

### DIFF
--- a/src/main/drivers/mcu/stm32/timer_stm32f7xx.c
+++ b/src/main/drivers/mcu/stm32/timer_stm32f7xx.c
@@ -181,7 +181,7 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     0
     1
     2       TIM4_CH1                            TIM4_CH2                                        TIM4_CH3
-    3                   TIM2_CH3                                        TIM2_CH1    TIM2_CH1    TIM2_CH4
+    3                   TIM2_CH3                                        TIM2_CH1    TIM2_CH2    TIM2_CH4
                                                                                     TIM2_CH4
     4
     5                               TIM3_CH4                TIM3_CH1    TIM3_CH2                TIM3_CH3


### PR DESCRIPTION
I have compare dma timers table comments with f7 reference manual. The TIM2_CH1 comment in DMA1 stream6 channel 3 is not right, it's should be TIM2_CH2.

F7 reference manual: https://www.st.com/resource/en/reference_manual/rm0431-stm32f72xxx-and-stm32f73xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

![image](https://github.com/user-attachments/assets/32f24ff6-5646-4c8b-9735-c15b184006ef)
