### PR TITLE
Disable SPA for angle mode - fix (for wings)

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1245,7 +1245,10 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
 
         pidData[axis].S = getSterm(axis, pidProfile);
-        applySpa(axis, pidProfile);
+
+        if (!pidRuntime.axisInAngleMode[axis]) {
+            applySpa(axis, pidProfile);
+        }
 
         // calculating the PID sum
         const float pidSum = pidData[axis].P + pidData[axis].I + pidData[axis].D + pidData[axis].F + pidData[axis].S;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -865,11 +865,13 @@ NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
 NOINLINE static void applySpa(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
+    spaMode_e mode = pidProfile->spa_mode[axis];
+
     if (pidRuntime.axisInAngleMode[axis]) {
-        return;
+        mode = SPA_MODE_OFF;
     }
 
-    switch(pidProfile->spa_mode[axis]) {
+    switch(mode) {
         case SPA_MODE_PID:
             pidData[axis].P *= pidRuntime.spa[axis];
             pidData[axis].D *= pidRuntime.spa[axis];

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -865,7 +865,11 @@ NOINLINE static void calculateSpaValues(const pidProfile_t *pidProfile)
 NOINLINE static void applySpa(int axis, const pidProfile_t *pidProfile)
 {
 #ifdef USE_WING
-    switch(pidProfile->spa_mode[axis]){
+    if (pidRuntime.axisInAngleMode[axis]) {
+        return;
+    }
+
+    switch(pidProfile->spa_mode[axis]) {
         case SPA_MODE_PID:
             pidData[axis].P *= pidRuntime.spa[axis];
             pidData[axis].D *= pidRuntime.spa[axis];
@@ -1245,10 +1249,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
 
         pidData[axis].S = getSterm(axis, pidProfile);
-
-        if (!pidRuntime.axisInAngleMode[axis]) {
-            applySpa(axis, pidProfile);
-        }
+        applySpa(axis, pidProfile);
 
         // calculating the PID sum
         const float pidSum = pidData[axis].P + pidData[axis].I + pidData[axis].D + pidData[axis].F + pidData[axis].S;


### PR DESCRIPTION
https://github.com/betaflight/betaflight/pull/13719 broke angle mode for wings, because it gradually turns off some or all PIDs after a certain setpoint. So now angle mode behaves like angle mode only at small stick deflections.

This is a simple fix, applying Setpoint PID Attenuation only in Acro.

SPA might still be needed for horizon mode. But that's for the future updates.