### PR TITLE
Fix angle mode rate profile change bug

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -436,15 +436,17 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
     // We now use Acro Rates, transformed into the range +/- 1, to provide setpoints
     const float angleLimit = pidProfile->angle_limit;
     float angleFeedforward = 0.0f;
+    // if user changes rates profile, update the max setpoint for angle mode
+    const float maxSetpointRateInv = 1.0f / getMaxRcRate(axis);
 
 #ifdef USE_FEEDFORWARD
-    angleFeedforward = angleLimit * getFeedforward(axis) * pidRuntime.angleFeedforwardGain * pidRuntime.maxRcRateInv[axis];
+    angleFeedforward = angleLimit * getFeedforward(axis) * pidRuntime.angleFeedforwardGain * maxSetpointRateInv;
     //  angle feedforward must be heavily filtered, at the PID loop rate, with limited user control over time constant
     // it MUST be very delayed to avoid early overshoot and being too aggressive
     angleFeedforward = pt3FilterApply(&pidRuntime.angleFeedforwardPt3[axis], angleFeedforward);
 #endif
 
-    float angleTarget = angleLimit * currentPidSetpoint * pidRuntime.maxRcRateInv[axis];
+    float angleTarget = angleLimit * currentPidSetpoint * maxSetpointRateInv;
     // use acro rates for the angle target in both horizon and angle modes, converted to -1 to +1 range using maxRate
 
 #ifdef USE_GPS_RESCUE

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -473,7 +473,6 @@ typedef struct pidRuntime_s {
     float angleEarthRef;
     float angleTarget[2];
     bool axisInAngleMode[3];
-    float maxRcRateInv[2];
 #endif
 
 #ifdef USE_WING

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -251,7 +251,6 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     for (int axis = 0; axis < 2; axis++) {  // ROLL and PITCH only
         pt3FilterInit(&pidRuntime.attitudeFilter[axis], k);
         pt3FilterInit(&pidRuntime.angleFeedforwardPt3[axis], k2);
-        pidRuntime.maxRcRateInv[axis] = 1.0f / getMaxRcRate(axis);
     }
     pidRuntime.angleYawSetpoint = 0.0f;
 #endif


### PR DESCRIPTION
Credit to discord user Misza for finding a bug in Angle Mode when changing Rate Profiles, affecting 4.5 and later.

The problem arose if Rate Profiles had a different max rate value, and the user changed Rate Profiles while in Angle Mode. 

If say the max setpoint rate value in Rate Profile 1 was 10, and the max setpoint rate in Rate Profile 2 was say 600, then in Angle mode, switching from Rate Profile 1 to Rate Profile 2 would result in stick responsiveness that was 60 times normal.  And vice versa.

Changing PID Profile at the same time would solve the problem.

The issue was that we used to retrieve the max setpoint rate from rc.c using  `getMaxRcRate(axis)` inside of pid_init.c, calculate it's inverse there, and use the inverse in the Angle mode code as a pidRuntime value.  And of course, that inverse was only calculated *when the pid Profile changed*, and didn't know about a rates change.  

This PR makes a small change where the inverse of the current `getMaxRcRate(axis)` value is calculated within pid.c into a static const.  This solves the problem.

I'm not sure if this is the most effective solution, but I have tested it, and it fixes the issue.