### PR TITLE
Fix sbufReadData

### DIFF
--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -114,6 +114,7 @@ uint32_t sbufReadU32(sbuf_t *src)
 void sbufReadData(sbuf_t *src, void *data, int len)
 {
     memcpy(data, src->ptr, len);
+    src->ptr += len;
 }
 
 // reader - return bytes remaining in buffer

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3794,9 +3794,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         if (sbufBytesRemaining(src) >= 6) {
             // Added in MSP API 1.45
 #ifdef USE_RX_EXPRESSLRS
-            for (int i = 0; i < 6; i++) {
-                rxExpressLrsSpiConfigMutable()->UID[i] = sbufReadU8(src);
-            }
+            sbufReadData(src, rxExpressLrsSpiConfigMutable()->UID, 6);
 #else
             uint8_t emptyUid[6];
             sbufReadData(src, emptyUid, 6);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3794,7 +3794,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         if (sbufBytesRemaining(src) >= 6) {
             // Added in MSP API 1.45
 #ifdef USE_RX_EXPRESSLRS
-            sbufReadData(src, rxExpressLrsSpiConfigMutable()->UID, 6);
+            for (int i = 0; i < 6; i++) {
+                rxExpressLrsSpiConfigMutable()->UID[i] = sbufReadU8(src);
+            }
 #else
             uint8_t emptyUid[6];
             sbufReadData(src, emptyUid, 6);


### PR DESCRIPTION
- Fixes Model Match ID getting overwritten with first character of ELRS UID.

Reported by @JimB40

![image](https://github.com/user-attachments/assets/71b14034-057e-44dd-8abe-5c898d6f03ac)
