### PR TITLE
Create USE_VECTOR_EXPO for combined pitch roll 2D vector expo for better feel

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -664,49 +664,88 @@ FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, flight_dyn
 }
 #endif // USE_FEEDFORWARD
 
+FAST_CODE void preProcessRcCommandAxis(int axis) {
+    // scale rcCommandf to range [-1.0, 1.0]
+    float rcCommandf;
+    if (axis == FD_YAW) {
+        rcCommandf = rcCommand[axis] / rcCommandYawDivider;
+    } else {
+        rcCommandf = rcCommand[axis] / rcCommandDivider;
+    }
+    rcDeflection[axis] = rcCommandf;
+    const float rcCommandfAbs = fabsf(rcCommandf);
+    rcDeflectionAbs[axis] = rcCommandfAbs;
+    maxRcDeflectionAbs = fmaxf(maxRcDeflectionAbs, rcCommandfAbs);
+}
+
+FAST_CODE void writeSetpointAxis(int axis, float angleRate) {
+    rawSetpoint[axis] = constrainf(angleRate, -1.0f * currentControlRateProfile->rate_limit[axis], 1.0f * currentControlRateProfile->rate_limit[axis]);
+    DEBUG_SET(DEBUG_ANGLERATE, axis, angleRate);
+}
+
 FAST_CODE void processRcCommand(void)
 {
     if (isRxDataNew) {
         maxRcDeflectionAbs = 0.0f;
-        for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
 
-            float angleRate;
-            
+        float angleRateRoll = 0;
+        float angleRatePitch = 0;
+        float angleRateYaw = 0;
+
+        // Apply rates and expo for yaw axis independently
 #ifdef USE_GPS_RESCUE
-            if ((axis == FD_YAW) && FLIGHT_MODE(GPS_RESCUE_MODE)) {
-                // If GPS Rescue is active then override the setpointRate used in the
-                // pid controller with the value calculated from the desired heading logic.
-                angleRate = gpsRescueGetYawRate();
-                // Treat the stick input as centered to avoid any stick deflection base modifications (like acceleration limit)
-                rcDeflection[axis] = 0;
-                rcDeflectionAbs[axis] = 0;
-            } else
+        if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+            // If GPS Rescue is active then override the setpointRate used in the
+            // pid controller with the value calculated from the desired heading logic.
+            angleRateYaw = gpsRescueGetYawRate();
+            // Treat the stick input as centered to avoid any stick deflection base modifications (like acceleration limit)
+            rcDeflection[FD_YAW] = 0;
+            rcDeflectionAbs[FD_YAW] = 0;
+        } else
 #endif
-            {
-                // scale rcCommandf to range [-1.0, 1.0]
-                float rcCommandf;
-                if (axis == FD_YAW) {
-                    rcCommandf = rcCommand[axis] / rcCommandYawDivider;
-                } else {
-                    rcCommandf = rcCommand[axis] / rcCommandDivider;
-                }
+        {
+            preProcessRcCommandAxis(FD_YAW); // Yaw normalize rcCommand [-1.0, 1.0], store in rcDeflection, rcDeflectionAbs, maxRcDeflectionAbs
+            angleRateYaw = applyRates(FD_YAW, rcDeflection[FD_YAW], rcDeflectionAbs[FD_YAW]);
+        }
 
-                rcDeflection[axis] = rcCommandf;
-                const float rcCommandfAbs = fabsf(rcCommandf);
-                rcDeflectionAbs[axis] = rcCommandfAbs;
-                maxRcDeflectionAbs = fmaxf(maxRcDeflectionAbs, rcCommandfAbs);
+        // Apply rates for pitch and roll
+        preProcessRcCommandAxis(FD_ROLL); // normalize rcCommand [-1.0, 1.0], store in rcDeflection, rcDeflectionAbs, maxRcDeflectionAbs
+        preProcessRcCommandAxis(FD_PITCH); // normalize rcCommand [-1.0, 1.0], store in rcDeflection, rcDeflectionAbs, maxRcDeflectionAbs
+#ifdef USE_VECTOR_EXPO
+        /* vector expo - apply rates and expo for pitch and roll together for consistent feel in all directions */
+        float r = rcDeflection[FD_ROLL];
+        float p = rcDeflection[FD_PITCH];
+        float length = sqrtf(r*r + p*p);
+        if (length > 1.0f) { // constrain to circular area of max length 1.0 in case of square RC control
+            r /= length;
+            p /= length;
+            length = 1.0f;
+        }
+        float lengthExpo = applyRates(FD_PITCH, length, length); // for now use FD_PITCH rates info for both roll & pitch when combined like this, could adjust to interpolate between pitch and roll rates depending on the vector angle
+        if (length < 0.00001f) { // ensure no divide by zero, rc stick resolution is limited to 1/1000 due to PWM etc, though it is then low passed, so 1/100,000 as a limit is plenty
+            angleRateRoll = 0;
+            angleRatePitch = 0;
+        } else {
+            angleRateRoll = (r / length) * lengthExpo;
+            angleRatePitch = (p / length) * lengthExpo;
+        }
+#else
+        /* traditional independent pitch and roll */
+        angleRateRoll = applyRates(FD_ROLL, rcDeflection[FD_ROLL], rcDeflectionAbs[FD_ROLL]);
+        angleRatePitch = applyRates(FD_PITCH, rcDeflection[FD_PITCH], rcDeflectionAbs[FD_PITCH]);
+#endif
 
-                angleRate = applyRates(axis, rcCommandf, rcCommandfAbs);
-            }
-
-            rawSetpoint[axis] = constrainf(angleRate, -1.0f * currentControlRateProfile->rate_limit[axis], 1.0f * currentControlRateProfile->rate_limit[axis]);
-            DEBUG_SET(DEBUG_ANGLERATE, axis, angleRate);
+        // Write all axes to rawSetpoint after constraining values
+        writeSetpointAxis(FD_ROLL, angleRateRoll);
+        writeSetpointAxis(FD_PITCH, angleRatePitch);
+        writeSetpointAxis(FD_YAW, angleRateYaw);
 
 #ifdef USE_FEEDFORWARD
-        calculateFeedforward(&pidRuntime, axis);
+        calculateFeedforward(&pidRuntime, FD_ROLL);
+        calculateFeedforward(&pidRuntime, FD_PITCH);
+        calculateFeedforward(&pidRuntime, FD_YAW);
 #endif // USE_FEEDFORWARD
 
-        }
         // adjust unfiltered setpoint steps to camera angle (mixing Roll and Yaw)
         if (rxConfig()->fpvCamAngleDegrees && IS_RC_MODE_ACTIVE(BOXFPVANGLEMIX) && !FLIGHT_MODE(HEADFREE_MODE)) {
             scaleRawSetpointToFpvCamAngle();


### PR DESCRIPTION
Change how expo is applied to pitch and roll input as a 2D vector to maintain correct direction and magnitude all the way around the circle for a more consistent feel.

Enable with USE_VECTOR_EXPO at compile time. So in Betaflight Configurator Firmware Flasher type "VECTOR_EXPO" into the "Custom Defines" box to enable this feature. Or if compiling for yourself: $make CONFIG=XXX EXTRA_FLAGS="-DUSE_VECTOR_EXPO"

Note the expo curves used are the same. Also note this uses pitch expo rate settings for both pitch and roll because here they are calculated together as a single 2d vector, so the roll expo rate settings are ignored.

Fixes: https://github.com/betaflight/betaflight/issues/13861

Aside from some required refactoring and edge cases, the heart of this is:

```
float r = rcDeflection[FD_ROLL];
float p = rcDeflection[FD_PITCH];
float length = sqrtf(r*r + p*p);
float lengthExpo = applyRates(FD_PITCH, length, length);
angleRateRoll = (r / length) * lengthExpo;
angleRatePitch = (p / length) * lengthExpo;
```