### PR TITLE
Fix: the wrong ability to turn on HORIZON_MODE without ACC sensors

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1007,7 +1007,7 @@ void processRxModes(timeUs_t currentTimeUs)
     }
 #endif
 
-    if (IS_RC_MODE_ACTIVE(BOXHORIZON) && canUseHorizonMode) {
+    if (IS_RC_MODE_ACTIVE(BOXHORIZON) && canUseHorizonMode && sensors(SENSOR_ACC)) {
         DISABLE_FLIGHT_MODE(ANGLE_MODE);
         if (!FLIGHT_MODE(HORIZON_MODE)) {
             ENABLE_FLIGHT_MODE(HORIZON_MODE);


### PR DESCRIPTION
This PR resolved issue: wrong ability to turn on HORIZON_MODE without ACC sensors.
Issue description:
The ACC was disabled.
I've tryed on Angle. It does not work - Ok.
![angle](https://github.com/user-attachments/assets/39c59c7f-1693-4cb3-9254-1deb55dc2507)
But when i was trying on Horizon it turn on:
![horizon](https://github.com/user-attachments/assets/fb1b9a7c-e9b5-413e-ab48-455e76b678d7)
The issue was found by using [BBExplorer](https://github.com/betaflight/blackbox-log-viewer/pull/771) and BF firmware PRs

Solution:
Added check of ACC by turn on HORIZON_MODE  

