### PR TITLE
Added actual flight mode flags logging to blackbox

### DIFF
--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -55,6 +55,7 @@ typedef enum FlightLogEvent {
     FLIGHT_LOG_EVENT_LOGGING_RESUME = 14,
     FLIGHT_LOG_EVENT_DISARM = 15,
     FLIGHT_LOG_EVENT_FLIGHTMODE = 30, // Add new event type for flight mode status.
+    FLIGHT_LOG_EVENT_ACTUAL_FLIGHTMODE = 31, // Actual flight mode changed
     FLIGHT_LOG_EVENT_LOG_END = 255
 } FlightLogEvent;
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -81,15 +81,11 @@ typedef enum {
     ANGLE_MODE      = (1 << 0),
     HORIZON_MODE    = (1 << 1),
     MAG_MODE        = (1 << 2),
-    ALT_HOLD_MODE    = (1 << 3),
-//    GPS_HOME_MODE   = (1 << 4),
-//    GPS_HOLD_MODE   = (1 << 5),
-    HEADFREE_MODE   = (1 << 6),
-//    UNUSED_MODE     = (1 << 7), // old autotune
-    PASSTHRU_MODE   = (1 << 8),
-//    RANGEFINDER_MODE= (1 << 9),
-    FAILSAFE_MODE   = (1 << 10),
-    GPS_RESCUE_MODE = (1 << 11)
+    ALT_HOLD_MODE   = (1 << 3),
+    HEADFREE_MODE   = (1 << 4),
+    PASSTHRU_MODE   = (1 << 5),
+    FAILSAFE_MODE   = (1 << 6),
+    GPS_RESCUE_MODE = (1 << 7)
 } flightModeFlags_e;
 
 extern uint16_t flightModeFlags;

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -81,11 +81,15 @@ typedef enum {
     ANGLE_MODE      = (1 << 0),
     HORIZON_MODE    = (1 << 1),
     MAG_MODE        = (1 << 2),
-    ALT_HOLD_MODE   = (1 << 3),
-    HEADFREE_MODE   = (1 << 4),
-    PASSTHRU_MODE   = (1 << 5),
-    FAILSAFE_MODE   = (1 << 6),
-    GPS_RESCUE_MODE = (1 << 7)
+    ALT_HOLD_MODE    = (1 << 3),
+//    GPS_HOME_MODE   = (1 << 4),
+//    GPS_HOLD_MODE   = (1 << 5),
+    HEADFREE_MODE   = (1 << 6),
+//    UNUSED_MODE     = (1 << 7), // old autotune
+    PASSTHRU_MODE   = (1 << 8),
+//    RANGEFINDER_MODE= (1 << 9),
+    FAILSAFE_MODE   = (1 << 10),
+    GPS_RESCUE_MODE = (1 << 11)
 } flightModeFlags_e;
 
 extern uint16_t flightModeFlags;

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -358,6 +358,7 @@ struct pidProfile_s *currentPidProfile;
 uint32_t targetPidLooptime;
 
 boxBitmask_t rcModeActivationMask;
+uint16_t flightModeFlags;
 
 void mspSerialAllocatePorts(void) {}
 uint32_t getArmingBeepTimeMicros(void) {return 0;}


### PR DESCRIPTION
The current Flight mode flags in log file shows RC box mode state. It does not show actual flight modes.
This PR start work by logging actual flight mode flags in blackbox.
This PR need this version of [Blackbox Explorer](https://github.com/betaflight/blackbox-log-viewer/pull/771)