### PR TITLE
OSD background rendering

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -512,7 +512,7 @@ void max7456Write(uint8_t x, uint8_t y, const char *text)
 
 bool max7456LayerSupported(displayPortLayer_e layer)
 {
-    if (layer == DISPLAYPORT_LAYER_FOREGROUND || layer == DISPLAYPORT_LAYER_BACKGROUND) {
+    if (layer == DISPLAYPORT_LAYER_FOREGROUND) {
         return true;
     } else {
         return false;

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -2149,8 +2149,9 @@ static bool osdDrawSingleElementBackground(displayPort_t *osdDisplayPort, uint8_
     activeElement.type = OSD_TYPE(osdElementConfig()->item_pos[item]);
     activeElement.buff = elementBuff;
     activeElement.osdDisplayPort = osdDisplayPort;
-    activeElement.rendered = true;
     activeElement.drawElement = true;
+    activeElement.rendered = true;
+    activeElement.attr = DISPLAYPORT_SEVERITY_NORMAL;
 
     // Call the element background drawing function
     osdElementBackgroundFunction[item](&activeElement);


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/betaflight/betaflight/pull/13813#issuecomment-2344031509

There were two issues with rendering the craft and pilot name. Note that these are considered background items.

1. On Walksnail the attribute of the previous foreground items were picked up which could result in the wrong colour or even flashing.
2. The MAX7456 doesn't support a background layer, but the MAX7456 driver claimed that it does.