### PR TITLE
Added 'Storage mode' action in Blackbox part of OSD menu

### DIFF
--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -210,10 +210,12 @@ static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
 #endif
       beeper(BEEPER_USB);
       systemResetToMsc(timezoneOffsetMinutes);
+      return NULL;
     } else {
       displayWrite(pDisplay, 5, 3, DISPLAYPORT_SEVERITY_INFO, "STORAGE NOT PRESENT OR FAILED TO INITIALIZE!");
       displayRedraw(pDisplay);
       beeper(BEEPER_USB);
+      return MENU_CHAIN_BACK;
     }
 
     return MENU_CHAIN_BACK;

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -191,7 +191,9 @@ static const void *cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
 
     return MENU_CHAIN_BACK;
 }
+#endif // USE_FLASHFS
 
+#ifdef USE_USB_MSC
 static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
 {
     UNUSED(ptr);
@@ -215,7 +217,8 @@ static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
 
     return MENU_CHAIN_BACK;
 }
-#endif // USE_FLASHFS
+#endif //USE_USB_MSC 
+
 
 static const void *cmsx_Blackbox_onEnter(displayPort_t *pDisp)
 {
@@ -270,7 +273,9 @@ static CMS_Menu cmsx_menuEraseFlashCheck = {
     .onDisplayUpdate = NULL,
     .entries = menuEraseFlashCheckEntries
 };
+#endif //USE_FLASHFS
 
+#ifdef USE_USB_MSC
 static const OSD_Entry menuStorageDeviceCheckEntries[] = {
     { "CONFIRM USB MASS STORAGE", OME_Label, NULL, NULL},
     { "NO",            OME_Back, NULL, NULL },
@@ -289,7 +294,7 @@ static CMS_Menu cmsx_menuStorageDeviceCheck = {
     .onDisplayUpdate = NULL,
     .entries = menuStorageDeviceCheckEntries
 };
-#endif
+#endif //USE_USB_MSC
 
 static const OSD_Entry cmsx_menuBlackboxEntries[] =
 {
@@ -302,8 +307,10 @@ static const OSD_Entry cmsx_menuBlackboxEntries[] =
     { "(FREE)",      OME_String,  NULL,            &cmsx_BlackboxDeviceStorageFree },
     { "DEBUG MODE",  OME_TAB | REBOOT_REQUIRED,     NULL,            &(OSD_TAB_t)   { &systemConfig_debug_mode, DEBUG_COUNT - 1, debugModeNames } },
 
-#ifdef USE_FLASHFS
+#ifdef USE_USB_MSC
     { "USB MASS STORAGE", OME_Submenu, cmsMenuChange,   &cmsx_menuStorageDeviceCheck },
+#endif // USE_USB_MSC
+#ifdef USE_FLASHFS
     { "ERASE FLASH", OME_Submenu, cmsMenuChange,   &cmsx_menuEraseFlashCheck },
 #endif // USE_FLASHFS
 

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -295,7 +295,7 @@ static const OSD_Entry cmsx_menuBlackboxEntries[] =
 
 #ifdef USE_FLASHFS
     { "ERASE FLASH", OME_Submenu, cmsMenuChange,   &cmsx_menuEraseFlashCheck },
-    { "STORAGE DEVICE", OME_Submenu, cmsMenuChange,   &cmsx_menuStorageDeviceCheck },
+    { "STORAGE DEVICE", OME_Submenu, cmsMenuChange,  &cmsx_menuStorageDeviceCheck },
 #endif // USE_FLASHFS
 
     { "BACK", OME_Back, NULL, NULL },

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -245,9 +245,9 @@ static const void *cmsx_Blackbox_onExit(displayPort_t *pDisp, const OSD_Entry *s
 #ifdef USE_FLASHFS
 static const OSD_Entry menuEraseFlashCheckEntries[] = {
     { "CONFIRM ERASE", OME_Label, NULL, NULL},
-    { "YES",           OME_Funcall, cmsx_EraseFlash, NULL },
-
     { "NO",            OME_Back, NULL, NULL },
+
+    { "YES",           OME_Funcall, cmsx_EraseFlash, NULL },
     { NULL,            OME_END, NULL, NULL }
 };
 
@@ -264,9 +264,9 @@ static CMS_Menu cmsx_menuEraseFlashCheck = {
 
 static const OSD_Entry menuStorageDeviceCheckEntries[] = {
     { "CONFIRM USB MASS STORAGE", OME_Label, NULL, NULL},
-    { "YES",           OME_Funcall, cmsx_StorageDevice, NULL },
-
     { "NO",            OME_Back, NULL, NULL },
+
+    { "YES",           OME_Funcall, cmsx_StorageDevice, NULL },
     { NULL,            OME_END, NULL, NULL }
 };
 

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -217,8 +217,6 @@ static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
       beeper(BEEPER_USB);
       return MENU_CHAIN_BACK;
     }
-
-    return MENU_CHAIN_BACK;
 }
 #endif //USE_USB_MSC
 

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -199,7 +199,7 @@ static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
     }
 
     displayClearScreen(pDisplay, DISPLAY_CLEAR_WAIT);
-    displayWrite(pDisplay, 5, 3, DISPLAYPORT_SEVERITY_INFO, "STORAGE DEVICE MODE");
+    displayWrite(pDisplay, 5, 3, DISPLAYPORT_SEVERITY_INFO, "USB MASS STORAGE MODE: CONNECT YOUR DEVICE");
     displayRedraw(pDisplay);
     beeper(BEEPER_USB);
     systemResetToMsc(0);
@@ -216,7 +216,7 @@ static const void *cmsx_Blackbox_onEnter(displayPort_t *pDisp)
     cmsx_BlackboxDevice = blackboxConfig()->device;
     cmsx_BlackboxRate = blackboxConfig()->sample_rate;
     systemConfig_debug_mode = systemConfig()->debug_mode;
-    
+
     const uint16_t pidFreq = (uint16_t)pidGetPidFrequency();
     if (pidFreq > 1000) {
         tfp_sprintf(cmsx_pidFreq, "%1d.%02dKHZ", (pidFreq / 10) / 100, (pidFreq / 10) % 100);
@@ -263,11 +263,11 @@ static CMS_Menu cmsx_menuEraseFlashCheck = {
 };
 
 static const OSD_Entry menuStorageDeviceCheckEntries[] = {
-    { "CONFIRM STORAGE", OME_Label, NULL, NULL},
-    { "YES",            OME_Funcall, cmsx_StorageDevice, NULL },
+    { "CONFIRM USB MASS STORAGE", OME_Label, NULL, NULL},
+    { "YES",           OME_Funcall, cmsx_StorageDevice, NULL },
 
-    { "NO",             OME_Back, NULL, NULL },
-    { NULL,             OME_END, NULL, NULL }
+    { "NO",            OME_Back, NULL, NULL },
+    { NULL,            OME_END, NULL, NULL }
 };
 
 static CMS_Menu cmsx_menuStorageDeviceCheck = {
@@ -295,7 +295,7 @@ static const OSD_Entry cmsx_menuBlackboxEntries[] =
 
 #ifdef USE_FLASHFS
     { "ERASE FLASH", OME_Submenu, cmsMenuChange,   &cmsx_menuEraseFlashCheck },
-    { "STORAGE DEVICE", OME_Submenu, cmsMenuChange,  &cmsx_menuStorageDeviceCheck },
+    { "USB MASS STORAGE", OME_Submenu, cmsMenuChange,   &cmsx_menuStorageDeviceCheck },
 #endif // USE_FLASHFS
 
     { "BACK", OME_Back, NULL, NULL },

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -264,10 +264,10 @@ static CMS_Menu cmsx_menuEraseFlashCheck = {
 
 static const OSD_Entry menuStorageDeviceCheckEntries[] = {
     { "CONFIRM STORAGE", OME_Label, NULL, NULL},
-    { "YES",           OME_Funcall, cmsx_StorageDevice, NULL },
+    { "YES",            OME_Funcall, cmsx_StorageDevice, NULL },
 
-    { "NO",            OME_Back, NULL, NULL },
-    { NULL,            OME_END, NULL, NULL }
+    { "NO",             OME_Back, NULL, NULL },
+    { NULL,             OME_END, NULL, NULL }
 };
 
 static CMS_Menu cmsx_menuStorageDeviceCheck = {

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -309,7 +309,7 @@ static const OSD_Entry cmsx_menuBlackboxEntries[] =
     { "DEBUG MODE",  OME_TAB | REBOOT_REQUIRED,     NULL,            &(OSD_TAB_t)   { &systemConfig_debug_mode, DEBUG_COUNT - 1, debugModeNames } },
 
 #ifdef USE_USB_MSC
-    { "USB MASS STORAGE", OME_Submenu, cmsMenuChange,   &cmsx_menuStorageDeviceCheck },
+    { "USB MASS STORAGE", OME_Submenu, cmsMenuChange, &cmsx_menuStorageDeviceCheck },
 #endif // USE_USB_MSC
 #ifdef USE_FLASHFS
     { "ERASE FLASH", OME_Submenu, cmsMenuChange,   &cmsx_menuEraseFlashCheck },

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -200,7 +200,8 @@ static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
 
     if (mscCheckFilesystemReady()) {
       displayClearScreen(pDisplay, DISPLAY_CLEAR_WAIT);
-      displayWrite(pDisplay, 5, 3, DISPLAYPORT_SEVERITY_INFO, "USB MASS STORAGE MODE: CONNECT YOUR DEVICE");
+      displayWrite(pDisplay, 2, 4, DISPLAYPORT_SEVERITY_INFO, "USB MASS STORAGE MODE IS ON");
+      displayWrite(pDisplay, 4, 5, DISPLAYPORT_SEVERITY_INFO, "CONNECT YOUR GADGET");
       displayRedraw(pDisplay);
 #ifdef USE_RTC_TIME
       int timezoneOffsetMinutes = timeConfig()->tz_offsetMinutes;
@@ -217,7 +218,7 @@ static const void *cmsx_StorageDevice(displayPort_t *pDisplay, const void *ptr)
 
     return MENU_CHAIN_BACK;
 }
-#endif //USE_USB_MSC 
+#endif //USE_USB_MSC
 
 
 static const void *cmsx_Blackbox_onEnter(displayPort_t *pDisp)


### PR DESCRIPTION
Betaflight Configurator ver.11 (PWA) can not work on Android browsers, therefore it is unpossible load data from blackbox to Android device in the field.
The Betaflight OSD menu has Erase blackbox action only. But very often we need save data before.
This PR add  'Storage mode' action in Blackbox part of OSD menu.
Now we can turn on Storage device mode by using OSD menu and connect FC to any gadget to load blackbox data. Then we can Erase data and continue to record new flights.