### PR TITLE
Minor CLI update to give a `noreboot` option so `save` and `exit` 

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6516,7 +6516,7 @@ const clicmd_t cmdTable[] = {
 #ifdef USE_ESCSERIAL
     CLI_COMMAND_DEF("escprog", "passthrough esc to serial", "<mode [sk/bl/ki/cc]> <index>", cliEscPassthrough),
 #endif
-    CLI_COMMAND_DEF("exit", NULL, NULL, cliExit),
+    CLI_COMMAND_DEF("exit", "exit command line interface and reboot (default)", "[noreboot]", cliExit),
     CLI_COMMAND_DEF("feature", "configure features",
         "list\r\n"
         "\t<->[name]", cliFeature),
@@ -6575,7 +6575,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("rxfail", "show/set rx failsafe settings", NULL, cliRxFailsafe),
     CLI_COMMAND_DEF("rxrange", "configure rx channel ranges", NULL, cliRxRange),
-    CLI_COMMAND_DEF("save", "save and reboot", NULL, cliSave),
+    CLI_COMMAND_DEF("save", "save and reboot (default)", "[noreboot]", cliSave),
 #ifdef USE_SDCARD
     CLI_COMMAND_DEF("sd_info", "sdcard info", NULL, cliSdInfo),
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3594,7 +3594,7 @@ static void cliExit(const char *cmdName, char *cmdline)
     cliMode = false;
     // incase a motor was left running during motortest, clear it here
     mixerResetDisarmedMotors();
-    if (strncasecmp(cmdline, "-n", 2) == 0) {
+    if (strcasecmp(cmdline, "noreboot") == 0) {
         return;
     }
     cliReboot();
@@ -4251,7 +4251,7 @@ static void cliSave(const char *cmdName, char *cmdline)
         writeEEPROM();
         cliPrintHashLine("saving");
 
-        if (strncasecmp(cmdline, "-n", 2) == 0) {
+        if (strcasecmp(cmdline, "noreboot") == 0) {
             return;
         }
         cliReboot();

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3594,6 +3594,9 @@ static void cliExit(const char *cmdName, char *cmdline)
     cliMode = false;
     // incase a motor was left running during motortest, clear it here
     mixerResetDisarmedMotors();
+    if (strncasecmp(cmdline, "-n", 2) == 0) {
+        return;
+    }
     cliReboot();
 }
 
@@ -4248,6 +4251,9 @@ static void cliSave(const char *cmdName, char *cmdline)
         writeEEPROM();
         cliPrintHashLine("saving");
 
+        if (strncasecmp(cmdline, "-n", 2) == 0) {
+            return;
+        }
         cliReboot();
     }
 }
@@ -6766,7 +6772,7 @@ static void processCharacterInteractive(const char c)
 
 void cliProcess(void)
 {
-    if (!cliWriter) {
+    if (!cliWriter || !cliMode) {
         return;
     }
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -476,6 +476,7 @@ static void mspProcessPendingRequest(mspPort_t * mspPort)
 #endif
 #ifdef USE_CLI
     case MSP_PENDING_CLI:
+        mspPort->pendingRequest = MSP_PENDING_NONE;
         cliEnter(mspPort->port);
         break;
 #endif


### PR DESCRIPTION
- means you can set any serial port to MSP, and when you activate CLI on it using #, you can now exit or save with a "noreboot" cmd line to return to MSP mode without a reboot required.
- https://webserial.io is a great utility for using CLI outside the configurator.

Future changes will include: 
-  possible multiple CLIs being active at the same time, and 
-  debug printf from anywhere in the code to an active debug cli.
