### PR TITLE
Use static idle value to set the initial dynamic idle limit before takeoff

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1632,7 +1632,6 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DYN_IDLE_I_GAIN, "%d",         currentPidProfile->dyn_idle_i_gain);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DYN_IDLE_D_GAIN, "%d",         currentPidProfile->dyn_idle_d_gain);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DYN_IDLE_MAX_INCREASE, "%d",   currentPidProfile->dyn_idle_max_increase);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_DYN_IDLE_START_INCREASE, "%d", currentPidProfile->dyn_idle_start_increase);
 #endif
 
 #ifdef USE_SIMPLIFIED_TUNING

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1258,7 +1258,6 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_DYN_IDLE_I_GAIN,            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_i_gain) },
     { PARAM_NAME_DYN_IDLE_D_GAIN,            VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_d_gain) },
     { PARAM_NAME_DYN_IDLE_MAX_INCREASE,      VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_max_increase) },
-    { PARAM_NAME_DYN_IDLE_START_INCREASE,    VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, dyn_idle_start_increase) },
 #endif
     { "level_race_mode",            VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, level_race_mode) },
 

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -127,7 +127,6 @@
 #define PARAM_NAME_DYN_IDLE_I_GAIN "dyn_idle_i_gain"
 #define PARAM_NAME_DYN_IDLE_D_GAIN "dyn_idle_d_gain"
 #define PARAM_NAME_DYN_IDLE_MAX_INCREASE "dyn_idle_max_increase"
-#define PARAM_NAME_DYN_IDLE_START_INCREASE "dyn_idle_start_increase"
 #define PARAM_NAME_SIMPLIFIED_PIDS_MODE "simplified_pids_mode"
 #define PARAM_NAME_SIMPLIFIED_MASTER_MULTIPLIER "simplified_master_multiplier"
 #define PARAM_NAME_SIMPLIFIED_I_GAIN "simplified_i_gain"

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -337,7 +337,9 @@ void mixerInitProfile(void)
     mixerRuntime.dynIdleIGain = currentPidProfile->dyn_idle_i_gain * 0.01f * pidGetDT();
     mixerRuntime.dynIdleDGain = currentPidProfile->dyn_idle_d_gain * 0.0000003f * pidGetPidFrequency();
     mixerRuntime.dynIdleMaxIncrease = currentPidProfile->dyn_idle_max_increase * 0.001f;
-    mixerRuntime.dynIdleStartIncrease = currentPidProfile->dyn_idle_start_increase * 0.001f;
+    // before takeoff, use the static idle value as the dynamic idle limit.
+    // whoop users should first adjust static idle to ensure reliable motor start before enabling dynamic idle
+    mixerRuntime.dynIdleStartIncrease = motorConfig()->digitalIdleOffsetValue * 0.0001f;
     mixerRuntime.minRpsDelayK = 800 * pidGetDT() / 20.0f; //approx 20ms D delay, arbitrarily suits many motors
     if (!mixerRuntime.feature3dEnabled && mixerRuntime.dynIdleMinRps) {
         mixerRuntime.motorOutputLow = DSHOT_MIN_THROTTLE; // Override value set by initEscEndpoints to allow zero motor drive

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -118,7 +118,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 10);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 11);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -198,7 +198,6 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dyn_idle_i_gain = 50,
         .dyn_idle_d_gain = 50,
         .dyn_idle_max_increase = 150,
-        .dyn_idle_start_increase = 50,
         .feedforward_averaging = FEEDFORWARD_AVERAGING_OFF,
         .feedforward_max_rate_limit = 90,
         .feedforward_smooth_factor = 25,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -234,7 +234,6 @@ typedef struct pidProfile_s {
     uint8_t dyn_idle_i_gain;                // I gain during active control of rpm
     uint8_t dyn_idle_d_gain;                // D gain for corrections around rapid changes in rpm
     uint8_t dyn_idle_max_increase;          // limit on maximum possible increase in motor idle drive during active control
-    uint8_t dyn_idle_start_increase;        // limit on maximum possible increase in motor idle drive with airmode not activated
 
     uint8_t feedforward_transition;         // Feedforward attenuation around centre sticks
     uint8_t feedforward_averaging;          // Number of packets to average when averaging is on


### PR DESCRIPTION
The `dyn_idle_start_increase` value was added to the CLI in 4.5 with PR #12432.  That value was intended to solve an issue where a quad, usually a whoop, had difficulty starting the motors when the user chose dynamic idle.  It was CLI-only, having not been added to MSP, LUA or OSD.

This PR removes that parameter and sets the dynamic idle start limit (the effective idle value while in dynamic idle) to the user's static idle, or `digitalIdleOffsetValue`, rather than using a custom CLI value.  This value is currently editable via CLI, Configurator (when dynamic idle is disabled), LUA and OSD.

The cause of the failure to start was because dynamic idle was limiting the maximum allowed motor increase to 5%, and this 5% value was locked in the firmware.  It was too low for some motors to start, typically whoops.

It seems simpler, and better for the end user, to just use the basic idle value, rather than a custom CLI value, to solve this problem.  I say that because the whoop user must decide upon a suitable value to use.  It is easiest to do that by disabling dynamic idle, and adjusting the static idle percentage value (default 5.5%) upwards, in Configurator, until the motors show reliability when starting.  This can be done via LUA or OSD as well.  With this PR, that value will then be used automatically in dynamic idle, and should result in equally reliable motor starts in both idle modes.

The one advantage of the old method was that each PID profile could have a separate dynamic idle start value. Having different start values in different profiles may be useful if the motor start was battery dependent and the user had battery-specific profiles.

If that's important, we should keep this PR and bring the *static* idle value into the PID Profile, since users with static idle values would want both the static and dynamic min idle values to change with the Profile.  Personally I don't think it's necessary but we can make a separate PR if that's required.

Unfortunately #12432 was merged into 4.5 so this change is a bit annoying, because it will undo something I approved not  so long ago.  Apologies to all.