### PR TITLE
Update timer_at32f43x.c

### DIFF
--- a/src/main/drivers/mcu/at32/timer_at32f43x.c
+++ b/src/main/drivers/mcu/at32/timer_at32f43x.c
@@ -71,6 +71,10 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TMR1,  CH2,  PA9,  0, 0,  0),
     DEF_TIM(TMR1,  CH3,  PA10, 0, 0,  0),
     DEF_TIM(TMR1,  CH4,  PA11, 0, 0,  0),
+    DEF_TIM(TMR9,  CH1,  PA2,  0, 0,  0),
+    DEF_TIM(TMR9,  CH2,  PA3,  0, 0,  0),
+    DEF_TIM(TMR13, CH1,  PA6,  0, 0,  0),
+    DEF_TIM(TMR14, CH1,  PA7,  0, 0,  0),
 
 // PORTB MUX1
     DEF_TIM(TMR1,  CH2N, PB0,  0, 0,  0),
@@ -102,6 +106,8 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TMR8,  CH3N, PB1,  0, 0,  0),
     DEF_TIM(TMR8,  CH2N, PB14, 0, 0,  0),
     DEF_TIM(TMR8,  CH3N, PB15, 0, 0,  0),
+    DEF_TIM(TMR10, CH1,  PB8,  0, 0,  0),
+    DEF_TIM(TMR11, CH1,  PB9,  0, 0,  0),
 // PORTB MUX9
     DEF_TIM(TMR12, CH1,  PB14, 0, 0,  0),
     DEF_TIM(TMR12, CH2,  PB15, 0, 0,  0),

--- a/src/main/drivers/mcu/at32/timer_def.h
+++ b/src/main/drivers/mcu/at32/timer_def.h
@@ -362,6 +362,10 @@
 #define DEF_TIM_AF__PA5__TCH_TMR8_CH1N     D(3, 8)
 #define DEF_TIM_AF__PA7__TCH_TMR8_CH1N     D(3, 8)
 
+// PORTA MUX 9
+#define DEF_TIM_AF__PA6__TCH_TMR13_CH1    D(9, 13)
+#define DEF_TIM_AF__PA7__TCH_TMR14_CH1    D(9, 14)
+
 // PORTB MUX 1
 #define DEF_TIM_AF__PB0__TCH_TMR1_CH2N     D(1, 1)
 #define DEF_TIM_AF__PB1__TCH_TMR1_CH3N     D(1, 1)

--- a/src/main/drivers/mcu/at32/timer_def.h
+++ b/src/main/drivers/mcu/at32/timer_def.h
@@ -363,8 +363,8 @@
 #define DEF_TIM_AF__PA7__TCH_TMR8_CH1N     D(3, 8)
 
 // PORTA MUX 9
-#define DEF_TIM_AF__PA6__TCH_TMR13_CH1    D(9, 13)
-#define DEF_TIM_AF__PA7__TCH_TMR14_CH1    D(9, 14)
+#define DEF_TIM_AF__PA6__TCH_TMR13_CH1     D(9, 13)
+#define DEF_TIM_AF__PA7__TCH_TMR14_CH1     D(9, 14)
 
 // PORTB MUX 1
 #define DEF_TIM_AF__PB0__TCH_TMR1_CH2N     D(1, 1)

--- a/src/main/drivers/mcu/at32/timer_def.h
+++ b/src/main/drivers/mcu/at32/timer_def.h
@@ -26,7 +26,7 @@
 
 #define USED_TIMERS  ( BIT(1) | BIT(2) | BIT(3) | BIT(4) | BIT(5) | BIT(8) | BIT(9) | BIT(10) | BIT(11) | BIT(12) | BIT(13) | BIT(14) | BIT(20) )
 #define TIMUP_TIMERS ( BIT(1) | BIT(2) | BIT(3) | BIT(4) | BIT(5) | BIT(8) | BIT(20) )
-#define FULL_TIMER_CHANNEL_COUNT        103
+#define FULL_TIMER_CHANNEL_COUNT        109
 #define HARDWARE_TIMER_DEFINITION_COUNT 15
 
 // allow conditional definition of DMA related members


### PR DESCRIPTION
Adds missing timer defines from https://www.arterychip.com/download/RM/RM_AT32F435_437_EN_V2.06.pdf

*Needs testing*