### PR TITLE
Add support external clock for gyro ICM42688P

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5133,8 +5133,8 @@ const cliResourceValue_t resourceTable[] = {
 #endif
     DEFW( OWNER_GYRO_EXTI,     PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, extiTag, MAX_GYRODEV_COUNT ),
     DEFW( OWNER_GYRO_CS,       PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, csnTag, MAX_GYRODEV_COUNT ),
-#if defined(USE_GYRO_EXT_CLK)
-    DEFS( OWNER_GYRO_CLKIN,  PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, clkIn),
+#if defined(USE_GYRO_CLKIN)
+    DEFW( OWNER_GYRO_CLKIN,  PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, clkIn, MAX_GYRODEV_COUNT),
 #endif
 #ifdef USE_USB_DETECT
     DEFS( OWNER_USB_DETECT,    PG_USB_CONFIG, usbDev_t, detectPin ),

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5133,6 +5133,9 @@ const cliResourceValue_t resourceTable[] = {
 #endif
     DEFW( OWNER_GYRO_EXTI,     PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, extiTag, MAX_GYRODEV_COUNT ),
     DEFW( OWNER_GYRO_CS,       PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, csnTag, MAX_GYRODEV_COUNT ),
+#if defined(USE_GYRO_EXT_CLK)
+    DEFS( OWNER_GYRO_CLKIN,  PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, clkIn),
+#endif
 #ifdef USE_USB_DETECT
     DEFS( OWNER_USB_DETECT,    PG_USB_CONFIG, usbDev_t, detectPin ),
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5134,7 +5134,7 @@ const cliResourceValue_t resourceTable[] = {
     DEFW( OWNER_GYRO_EXTI,     PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, extiTag, MAX_GYRODEV_COUNT ),
     DEFW( OWNER_GYRO_CS,       PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, csnTag, MAX_GYRODEV_COUNT ),
 #if defined(USE_GYRO_CLKIN)
-    DEFW( OWNER_GYRO_CLKIN,  PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, clkIn, MAX_GYRODEV_COUNT),
+    DEFW( OWNER_GYRO_CLKIN,    PG_GYRO_DEVICE_CONFIG, gyroDeviceConfig_t, clkIn, MAX_GYRODEV_COUNT),
 #endif
 #ifdef USE_USB_DETECT
     DEFS( OWNER_USB_DETECT,    PG_USB_CONFIG, usbDev_t, detectPin ),

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -30,12 +30,6 @@
 
 #if defined(USE_GYRO_SPI_ICM42605) || defined(USE_GYRO_SPI_ICM42688P)
 
-#if defined(USE_GYRO_CLKIN)
-#ifndef GYRO_CLKIN_PIN
-#define GYRO_CLKIN_PIN NONE
-#endif
-#endif
-
 #include "common/axis.h"
 #include "common/utils.h"
 #include "build/debug.h"

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -58,6 +58,8 @@
 #define ICM426XX_MAX_SPI_CLK_HZ ICM426XX_CLOCK
 #endif
 
+#define ICM426XX_CLKIN_FREQ                         32000
+
 #define ICM426XX_RA_REG_BANK_SEL                    0x76
 #define ICM426XX_BANK_SELECT0                       0x00
 #define ICM426XX_BANK_SELECT1                       0x01
@@ -122,7 +124,11 @@
 #define ICM426XX_RA_INT_SOURCE0                     0x65  // User Bank 0
 #define ICM426XX_UI_DRDY_INT1_EN_DISABLED           (0 << 3)
 #define ICM426XX_UI_DRDY_INT1_EN_ENABLED            (1 << 3)
-#define ICM426XX_INTF_CONFIG1_CLKIN                 (1 << 5)
+
+// specific to CLKIN configuration
+#define ICM426XX_INTF_CONFIG5                       0x7B  // User Bank 1
+#define ICM426XX_INTF_CONFIG1_CLKIN                 (1 << 2)
+#define ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_CLKIN   (2 << 1)   // Set bits 2:1 to 10 for CLKIN (PIN9 as CLKIN)
 
 typedef enum {
     ODR_CONFIG_8K = 0,
@@ -171,19 +177,33 @@ static aafConfig_t aafLUT42605[AAF_CONFIG_COUNT] = {  // see table in section 5.
     [AAF_CONFIG_1962HZ] = { 63, 3968,  3 }, // 995 Hz is the max cutoff on the 42605
 };
 
+static void setUserBank(const extDevice_t *dev, const uint8_t user_bank)
+{
+    spiWriteReg(dev, ICM426XX_RA_REG_BANK_SEL, user_bank & 7);
+}
+
 #if defined(USE_GYRO_CLKIN)
 static pwmOutputPort_t pwmGyroClk = {0};
 
 static bool initExternalClock(const extDevice_t *dev)
 {
-    if (&gyro.gyroSensor1.gyroDev.dev != dev) {
-        // only gyro1 clkin supported. TODO: support two gyros, must be implemented in the next PR
+    int cfg;
+    if (&gyro.gyroSensor1.gyroDev.dev == dev) {
+        cfg = 0;
+    } else if (&gyro.gyroSensor2.gyroDev.dev == dev) {
+        cfg = 1;
+    } else {
+        // only gyroSensor<n> device supported
         return false;
     }
-    const ioTag_t tag = gyroDeviceConfig(0)->clkIn;
+    const ioTag_t tag = gyroDeviceConfig(cfg)->clkIn;
     const IO_t io = IOGetByTag(tag);
+    if (pwmGyroClk.enabled) {
+       // pwm is already taken, but test for shared clkIn pin
+       return pwmGyroClk.io == io;
+    }
 
-    const timerHardware_t *timer = timerAllocate(tag, OWNER_GYRO_CLKIN, 0);
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_GYRO_CLKIN, RESOURCE_INDEX(cfg));
     if (!timer) {
         // Error handling: failed to allocate timer
         return false;
@@ -192,13 +212,11 @@ static bool initExternalClock(const extDevice_t *dev)
     pwmGyroClk.io = io;
     pwmGyroClk.enabled = true;
 
-    IOInit(io, OWNER_GYRO_CLKIN, 0);
+    IOInit(io, OWNER_GYRO_CLKIN, RESOURCE_INDEX(cfg));
     IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 
-    uint32_t pwmFrequency = 32000;  // PWM frequency set to 32 kHz TODO: move to config: available freq 31-50kHz
     const uint32_t clock = timerClock(timer->tim);  // Get the timer clock frequency
-
-    const uint16_t period = clock / pwmFrequency;
+    const uint16_t period = clock / ICM426XX_CLKIN_FREQ;
 
     // Calculate duty cycle value for 50%
     const uint16_t value = period / 2;
@@ -215,9 +233,17 @@ static bool initExternalClock(const extDevice_t *dev)
 static void icm426xxEnableExternalClock(const extDevice_t *dev)
 {
     if (initExternalClock(dev)) {
-        uint8_t cfg1 = spiReadRegMsk(dev, ICM426XX_INTF_CONFIG1);
-        cfg1 |= ICM426XX_INTF_CONFIG1_CLKIN; // enable CLKIN for external clock
-        spiWriteReg(dev, ICM426XX_INTF_CONFIG1, cfg1);
+        // Switch to Bank 1 and set bits 2:1 in INTF_CONFIG5 (0x7B) to enable CLKIN on PIN9
+        setUserBank(dev, ICM426XX_BANK_SELECT1);
+        uint8_t intf_config5 = spiReadRegMsk(dev, ICM426XX_INTF_CONFIG5);
+        intf_config5 |= ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_CLKIN;  // Set bits 2:1 to 0b10 for CLKIN
+        spiWriteReg(dev, ICM426XX_INTF_CONFIG5, intf_config5);
+
+        // Switch to Bank 0 and set bit 2 in RTC_MODE (0x4D) to enable external CLK signal
+        setUserBank(dev, ICM426XX_BANK_SELECT0);
+        uint8_t rtc_mode = spiReadRegMsk(dev, ICM426XX_INTF_CONFIG1);
+        rtc_mode |= ICM426XX_INTF_CONFIG1_CLKIN; // Enable external CLK signal
+        spiWriteReg(dev, ICM426XX_INTF_CONFIG1, rtc_mode);
     }
 }
 #endif
@@ -291,11 +317,6 @@ static void turnGyroAccOn(const extDevice_t *dev)
 {
     spiWriteReg(dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_TEMP_DISABLE_OFF | ICM426XX_PWR_MGMT0_ACCEL_MODE_LN | ICM426XX_PWR_MGMT0_GYRO_MODE_LN);
     delay(1);
-}
-
-static void setUserBank(const extDevice_t *dev, const uint8_t user_bank)
-{
-    spiWriteReg(dev, ICM426XX_RA_REG_BANK_SEL, user_bank & 7);
 }
 
 void icm426xxGyroInit(gyroDev_t *gyro)

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -128,7 +128,8 @@
 // specific to CLKIN configuration
 #define ICM426XX_INTF_CONFIG5                       0x7B  // User Bank 1
 #define ICM426XX_INTF_CONFIG1_CLKIN                 (1 << 2)
-#define ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_CLKIN   (2 << 1)   // Set bits 2:1 to 10 for CLKIN (PIN9 as CLKIN)
+#define ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_MASK    (3 << 1)   // PIN9 mode config
+#define ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_CLKIN   (2 << 1)   // PIN9 as CLKIN
 
 typedef enum {
     ODR_CONFIG_8K = 0,
@@ -236,7 +237,7 @@ static void icm426xxEnableExternalClock(const extDevice_t *dev)
         // Switch to Bank 1 and set bits 2:1 in INTF_CONFIG5 (0x7B) to enable CLKIN on PIN9
         setUserBank(dev, ICM426XX_BANK_SELECT1);
         uint8_t intf_config5 = spiReadRegMsk(dev, ICM426XX_INTF_CONFIG5);
-        intf_config5 |= ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_CLKIN;  // Set bits 2:1 to 0b10 for CLKIN
+        intf_config5 = (intf_config5 & ~ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_MASK) | ICM426XX_INTF_CONFIG5_PIN9_FUNCTION_CLKIN;  // Clear & set bits 2:1 to 0b10 for CLKIN
         spiWriteReg(dev, ICM426XX_INTF_CONFIG5, intf_config5);
 
         // Switch to Bank 0 and set bit 2 in RTC_MODE (0x4D) to enable external CLK signal

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -115,4 +115,5 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "SOFTSERIAL_RX",
     "LPUART_TX",
     "LPUART_RX",
+    "GYRO_CLKIN",
 };

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -113,6 +113,7 @@ typedef enum {
     OWNER_SOFTSERIAL_RX,
     OWNER_LPUART_TX,
     OWNER_LPUART_RX,
+    OWNER_GYRO_CLKIN,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -129,7 +129,7 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
 #endif // GYRO_2_CUSTOM_ALIGN
 
 #ifdef GYRO_2_SPI_INSTANCE
-    // TODO: CLKIN gyro 2 not suported yet. need to imlement it 
+    // TODO: CLKIN gyro 2 on separate pin is not supported yet. need to implement it
     gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), IO_TAG(GYRO_2_CLKIN_PIN), GYRO_2_ALIGN, customAlignment2);
 #else
     devconf[1].busType = BUS_TYPE_NONE;

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -72,7 +72,7 @@
 #endif
 
 #if defined(USE_SPI_GYRO) && (defined(GYRO_1_SPI_INSTANCE) || defined(GYRO_2_SPI_INSTANCE))
-static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *instance, ioTag_t csnTag, ioTag_t extiTag, uint8_t alignment, sensorAlignment_t customAlignment)
+static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *instance, ioTag_t csnTag, ioTag_t extiTag, ioTag_t clkInTag, uint8_t alignment, sensorAlignment_t customAlignment)
 {
     devconf->busType = BUS_TYPE_SPI;
     devconf->spiBus = SPI_DEV_TO_CFG(spiDeviceByInstance(instance));
@@ -80,7 +80,7 @@ static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *i
     devconf->extiTag = extiTag;
     devconf->alignment = alignment;
     devconf->customAlignment = customAlignment;
-    devconf->clkIn = IO_TAG(GYRO_CLKIN_PIN);
+    devconf->clkIn = clkInTag;
 }
 #endif
 
@@ -111,7 +111,7 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
     // All multi-gyro boards use SPI based gyros.
 #ifdef USE_SPI_GYRO
 #ifdef GYRO_1_SPI_INSTANCE
-    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, customAlignment1);
+    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), IO_TAG(GYRO_CLKIN_PIN), GYRO_1_ALIGN, customAlignment1);
 #else
     devconf[0].busType = BUS_TYPE_NONE;
 #endif
@@ -125,7 +125,7 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
 #endif // GYRO_2_CUSTOM_ALIGN
 
 #ifdef GYRO_2_SPI_INSTANCE
-    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), GYRO_2_ALIGN, customAlignment2);
+    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), IO_TAG(GYRO_CLKIN_PIN), GYRO_2_ALIGN, customAlignment2);
 #else
     devconf[1].busType = BUS_TYPE_NONE;
 #endif

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -100,7 +100,7 @@ static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cb
 }
 #endif
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDeviceConfig, PG_GYRO_DEVICE_CONFIG, 0);
+PG_REGISTER_ARRAY_WITH_RESET_FN(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDeviceConfig, PG_GYRO_DEVICE_CONFIG, 1);
 
 void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
 {

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -93,7 +93,6 @@ static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cb
     devconf->extiTag = extiTag;
     devconf->alignment = alignment;
     devconf->customAlignment = customAlignment;
-    devconf->clkIn = IO_TAG(GYRO_CLKIN_PIN);
 }
 #endif
 

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -80,9 +80,7 @@ static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *i
     devconf->extiTag = extiTag;
     devconf->alignment = alignment;
     devconf->customAlignment = customAlignment;
-#if defined(USE_GYRO_EXT_CLK)
     devconf->clkIn = IO_TAG(GYRO_CLKIN_PIN);
-#endif
 }
 #endif
 
@@ -95,6 +93,7 @@ static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cb
     devconf->extiTag = extiTag;
     devconf->alignment = alignment;
     devconf->customAlignment = customAlignment;
+    devconf->clkIn = IO_TAG(GYRO_CLKIN_PIN);
 }
 #endif
 

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -50,6 +50,10 @@
 #define GYRO_2_EXTI_PIN NONE
 #endif
 
+#ifndef GYRO_CLKIN_PIN
+#define GYRO_CLKIN_PIN NONE
+#endif
+
 #ifdef MPU_ADDRESS
 #define GYRO_I2C_ADDRESS MPU_ADDRESS
 #else
@@ -76,6 +80,9 @@ static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *i
     devconf->extiTag = extiTag;
     devconf->alignment = alignment;
     devconf->customAlignment = customAlignment;
+#if defined(USE_GYRO_EXT_CLK)
+    devconf->clkIn = IO_TAG(GYRO_CLKIN_PIN);
+#endif
 }
 #endif
 

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -50,8 +50,12 @@
 #define GYRO_2_EXTI_PIN NONE
 #endif
 
-#ifndef GYRO_CLKIN_PIN
-#define GYRO_CLKIN_PIN NONE
+#ifndef GYRO_1_CLKIN_PIN
+#define GYRO_1_CLKIN_PIN NONE
+#endif
+
+#ifndef GYRO_2_CLKIN_PIN
+#define GYRO_2_CLKIN_PIN NONE
 #endif
 
 #ifdef MPU_ADDRESS
@@ -111,7 +115,7 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
     // All multi-gyro boards use SPI based gyros.
 #ifdef USE_SPI_GYRO
 #ifdef GYRO_1_SPI_INSTANCE
-    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), IO_TAG(GYRO_CLKIN_PIN), GYRO_1_ALIGN, customAlignment1);
+    gyroResetSpiDeviceConfig(&devconf[0], GYRO_1_SPI_INSTANCE, IO_TAG(GYRO_1_CS_PIN), IO_TAG(GYRO_1_EXTI_PIN), IO_TAG(GYRO_1_CLKIN_PIN), GYRO_1_ALIGN, customAlignment1);
 #else
     devconf[0].busType = BUS_TYPE_NONE;
 #endif
@@ -125,7 +129,8 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
 #endif // GYRO_2_CUSTOM_ALIGN
 
 #ifdef GYRO_2_SPI_INSTANCE
-    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), IO_TAG(GYRO_CLKIN_PIN), GYRO_2_ALIGN, customAlignment2);
+    // TODO: CLKIN gyro 2 not suported yet. need to imlement it 
+    gyroResetSpiDeviceConfig(&devconf[1], GYRO_2_SPI_INSTANCE, IO_TAG(GYRO_2_CS_PIN), IO_TAG(GYRO_2_EXTI_PIN), IO_TAG(GYRO_2_CLKIN_PIN), GYRO_2_ALIGN, customAlignment2);
 #else
     devconf[1].busType = BUS_TYPE_NONE;
 #endif

--- a/src/main/pg/gyrodev.h
+++ b/src/main/pg/gyrodev.h
@@ -45,6 +45,9 @@ typedef struct gyroDeviceConfig_s {
     ioTag_t extiTag;
     uint8_t alignment;        // sensor_align_e
     sensorAlignment_t customAlignment;
+#if defined(USE_GYRO_EXT_CLK)
+    ioTag_t clkIn;
+#endif
 } gyroDeviceConfig_t;
 
 PG_DECLARE_ARRAY(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDeviceConfig);

--- a/src/main/pg/gyrodev.h
+++ b/src/main/pg/gyrodev.h
@@ -45,9 +45,7 @@ typedef struct gyroDeviceConfig_s {
     ioTag_t extiTag;
     uint8_t alignment;        // sensor_align_e
     sensorAlignment_t customAlignment;
-#if defined(USE_GYRO_EXT_CLK)
     ioTag_t clkIn;
-#endif
 } gyroDeviceConfig_t;
 
 PG_DECLARE_ARRAY(gyroDeviceConfig_t, MAX_GYRODEV_COUNT, gyroDeviceConfig);


### PR DESCRIPTION
Implementation external clock for gyro ICM42688P

TDK's datasheet for the ICM-42688-P says:

> External clock input supports highly accurate clock input from 31kHz to 50kHz, resulting in improvement of the following:
> a) ODR uncertainty due to process, temperature, operating mode (PLL vs. RCOSC), and design limitations. This uncertainty can be as high as ±8% in RCOSC mode and ±1% in PLL mode. The CLKIN, assuming a 50ppm or better 32.768kHz source, will improve the ODR accuracy from ±80,000ppm to ±50ppm in RCOSC mode, or from ±10,000ppm to ±50ppm in PLL mode.
> b) System level sensitivity error. Any clock uncertainty directly impacts gyroscope sensitivity at the system level. Sophisticated systems can estimate ODR inaccuracy to some extent, but not to the extent improved by using CLKIN.
> c) System-level clock/sensor synchronization. When using CLKIN, the accelerometer and gyroscope are on the same clock as the host. There is no need to continually re-synchronize the sensor data as the sensor sample points and period are known to be in exact alignment with the common system clock.
> d) CLKIN helps EIS (Electronic Image Stabilization) performance by providing:
> 
> Very accurate gyroscope sample points for use during integration to find true angular displacement.
> Automatic time alignment between the motion sensor and the host and potentially the camera system.
> e) Other applications that benefit from CLKIN include navigation, gaming, robotics.


Example target define for STM32F7X2 (TIM1 CH1) to generate freq 32KHz for CLKIN

```C
#define USE_GYRO_CLKIN
#define GYRO_1_CLKIN_PIN PA8

...
 TIMER_PIN_MAP( x, PA8, 1, -1 )
```

- fixes https://github.com/betaflight/betaflight/issues/13502