### PR TITLE
Don't consider a prior I2C NACK to indicate the bus to be busy

### DIFF
--- a/src/main/drivers/mcu/at32/bus_i2c_atbsp.c
+++ b/src/main/drivers/mcu/at32/bus_i2c_atbsp.c
@@ -245,7 +245,8 @@ bool i2cBusy(I2CDevice device, bool *error)
         *error = pHandle->error_code;
     }
 
-    if (pHandle->error_code == I2C_OK) {
+    // I2C_ERR_ACKFAIL indicates that the last access wasn't acknowledged, but doesn't mean the bus is busy
+    if ((pHandle->error_code == I2C_OK) || (pHandle->error_code == I2C_ERR_ACKFAIL)) {
         if (i2c_flag_get(pHandle->i2cx, I2C_BUSYF_FLAG) == SET) {
             return true;
         }


### PR DESCRIPTION
On AT32F435 targets if USE_MAG is defined to support an external compass but it's not present then the probe for the magnetometer would terminate with the I2C bus error code reporting `I2C_ERR_ACKFAIL`.

As this was not `I2C_OK` the bus was then considered busy and any subsequent access on that bus, to for example a barometer, would be blocked.

This should not be taken to indicate that the bus is busy as the last I2C transaction terminated correctly and the bus is available for the next access.