### PR TITLE
Yaw type rudder/diff_thrust for TPA calculations (for wings)

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1745,7 +1745,6 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_SPEED_ADV_THRUST, "%d", currentPidProfile->tpa_speed_adv_thrust);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_SPEED_MAX_VOLTAGE, "%d", currentPidProfile->tpa_speed_max_voltage);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_SPEED_PITCH_OFFSET, "%d", currentPidProfile->tpa_speed_pitch_offset);
-
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_YAW_TYPE, "%d", currentPidProfile->yaw_type);
 #endif // USE_WING
 

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1745,7 +1745,9 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_SPEED_ADV_THRUST, "%d", currentPidProfile->tpa_speed_adv_thrust);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_SPEED_MAX_VOLTAGE, "%d", currentPidProfile->tpa_speed_max_voltage);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_SPEED_PITCH_OFFSET, "%d", currentPidProfile->tpa_speed_pitch_offset);
-#endif
+
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_YAW_TYPE, "%d", currentPidProfile->yaw_type);
+#endif // USE_WING
 
         default:
             return true;

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1321,7 +1321,6 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_SPA_YAW_CENTER,     VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_center[FD_YAW]) },
     { PARAM_NAME_SPA_YAW_WIDTH,      VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_width[FD_YAW]) },
     { PARAM_NAME_SPA_YAW_MODE,       VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SPA_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_mode[FD_YAW]) },
-
     { PARAM_NAME_YAW_TYPE,           VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_YAW_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_type) },
 #endif
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -543,7 +543,11 @@ const char* const lookupTableTpaCurveType[] = {
 const char* const lookupTableTpaSpeedType[] = {
     "BASIC", "ADVANCED",
 };
-#endif
+
+const char* const lookupTableYawType[] = {
+    "RUDDER", "DIFF_THRUST",
+};
+#endif // USE_WING
 
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
@@ -673,7 +677,8 @@ const lookupTableEntry_t lookupTables[] = {
 #endif
 #ifdef USE_WING
     LOOKUP_TABLE_ENTRY(lookupTableTpaSpeedType),
-#endif
+    LOOKUP_TABLE_ENTRY(lookupTableYawType),
+#endif // USE_WING
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -1316,6 +1321,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_SPA_YAW_CENTER,     VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_center[FD_YAW]) },
     { PARAM_NAME_SPA_YAW_WIDTH,      VAR_UINT16  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_width[FD_YAW]) },
     { PARAM_NAME_SPA_YAW_MODE,       VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_SPA_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, spa_mode[FD_YAW]) },
+
+    { PARAM_NAME_YAW_TYPE,           VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_YAW_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_type) },
 #endif
 
 // PG_TELEMETRY_CONFIG

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -148,7 +148,8 @@ typedef enum {
 #endif
 #ifdef USE_WING
     TABLE_TPA_SPEED_TYPE,
-#endif
+    TABLE_YAW_TYPE,
+#endif // USE_WING
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -72,6 +72,7 @@
 #define PARAM_NAME_TPA_SPEED_ADV_THRUST "tpa_speed_adv_thrust"
 #define PARAM_NAME_TPA_SPEED_MAX_VOLTAGE "tpa_speed_max_voltage"
 #define PARAM_NAME_TPA_SPEED_PITCH_OFFSET "tpa_speed_pitch_offset"
+#define PARAM_NAME_YAW_TYPE "yaw_type"
 #define PARAM_NAME_MIXER_TYPE "mixer_type"
 #define PARAM_NAME_EZ_LANDING_THRESHOLD "ez_landing_threshold"
 #define PARAM_NAME_EZ_LANDING_LIMIT "ez_landing_limit"

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1001,10 +1001,8 @@ static float getTpaFactor(const pidProfile_t *pidProfile, int axis, term_e term)
     switch (term) {
     case TERM_P:
         return (pidProfile->tpa_mode == TPA_MODE_PD) ? tpaFactor : 1.0f;
-        break;
     case TERM_D:
         return tpaFactor;
-        break;
     default:
         return 1.0f;
     }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -397,6 +397,7 @@ void pidUpdateTpaFactor(float throttle)
     case YAW_TYPE_RUDDER:
     default:
         pidRuntime.tpaFactorYaw = pidRuntime.tpaFactor;
+        break;
     }
 #endif // USE_WING
 }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -94,6 +94,14 @@ typedef enum {
 } tpaMode_e;
 
 typedef enum {
+    TERM_P,
+    TERM_I,
+    TERM_D,
+    TERM_F,
+    TERM_S,
+} term_e;
+
+typedef enum {
     SPA_MODE_OFF,
     SPA_MODE_I_FREEZE,
     SPA_MODE_I,
@@ -167,6 +175,11 @@ typedef enum tpaSpeedType_e {
     TPA_SPEED_BASIC,
     TPA_SPEED_ADVANCED,
 } tpaSpeedType_t;
+
+typedef enum yawType_e {
+    YAW_TYPE_RUDDER,
+    YAW_TYPE_DIFF_THRUST,
+} yawType_t;
 
 #define MAX_PROFILE_NAME_LENGTH 8u
 
@@ -302,6 +315,7 @@ typedef struct pidProfile_s {
     uint16_t tpa_speed_adv_thrust;      // For wings when tpa_speed_type = ADVANCED: stationary thrust in grams
     uint16_t tpa_speed_max_voltage;     // For wings: theoretical max voltage; used for throttle scailing with voltage for air speed estimation
     int16_t tpa_speed_pitch_offset;     // For wings: pitch offset in degrees*10 for craft speed estimation
+    uint8_t yaw_type;                   // For wings: type of yaw (rudder or differential thrust)
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
@@ -500,6 +514,7 @@ typedef struct pidRuntime_s {
 #ifdef USE_WING
     float spa[XYZ_AXIS_COUNT]; // setpoint pid attenuation (0.0 to 1.0). 0 - full attenuation, 1 - no attenuation
     tpaSpeedParams_t tpaSpeed;
+    float tpaFactorYaw;
 #endif // USE_WING
 
 #ifdef USE_ADVANCED_TPA

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -176,10 +176,10 @@ typedef enum tpaSpeedType_e {
     TPA_SPEED_ADVANCED,
 } tpaSpeedType_t;
 
-typedef enum yawType_e {
+typedef enum {
     YAW_TYPE_RUDDER,
     YAW_TYPE_DIFF_THRUST,
-} yawType_t;
+} yawType_e;
 
 #define MAX_PROFILE_NAME_LENGTH 8u
 


### PR DESCRIPTION
[`HYPERBOLIC`](https://github.com/betaflight/betaflight/pull/13805) TPA curve works good for control surfaces, it allows to have very high PIDs for speeds close to stall.
However if a plane has differential thrust instead of rudder then doubling or tripling yaw PIDs leads to oscillations on yaw.

Essentially for differential thrust yaw it needs a different type of curve, but classic drone curve works pretty good too, at least it's a good start.

`set yaw_type = RUDDER` - yaw TPA will be the same as for roll and pitch.
or 
`set yaw_type = DIFF_THRUST` - yaw TPA will be calculated using standard formula from quads/drones.

Future updates:
Allow `set yaw_type = MIXED` for planes with both differential thrust and rudder. But that will need more code changes, and separate pidsums for servos and motor mixer. Its for the far future.

### Tuning suggestions:
For planes with differential thrust and static vertical stabilizers:
```
set yaw_type = DIFF_THRUST # set this if differential thrust
set tpa_mode = PD # set this regardless of differential thrust or rudder
```
set yaw rates small, like 50-100 degrees/sec max.
set yaw I-term S-term and FF to zero.
Tune yaw P and D terms like it's a quad.
Keep in mind vertical stabilizers won't allow to yaw fast anyways.
Yawing with differential thrust at slow speeds can make a plane do crazy stuff, so be careful :)
Differential thrust can be used to automatically stabilize yaw, especially at slow speeds. Without differential thrust my AtomRC Penguin yaws by itself at slow speeds a lot. Differential thrust makes it fly forward like it's on rails. Yawing with stick at high speeds won't do much, even when one motor is maxed, and the other is zero, but, i guess it depends on the plane. Yaw for 3D type of flying is essential, and differential thrust does the job.
Little example, sorry for the language :) https://www.youtube.com/shorts/Ncs6f266WHY
