### PR TITLE
Fix DMax calculations

### DIFF
--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -448,10 +448,11 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 #ifdef USE_D_MAX
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
         const uint8_t dMax = pidProfile->d_max[axis];
-        if ((dMax > 0) && (dMax > pidProfile->pid[axis].D)) {
-            pidRuntime.dMaxPercent[axis] = (float) pidProfile->pid[axis].D / dMax;
+        if ((pidProfile->pid[axis].D > 0) && dMax > pidProfile->pid[axis].D) {
+            pidRuntime.dMaxPercent[axis] = (float) dMax / pidProfile->pid[axis].D;
+            // fraction that Dmax is higher than D, eg if D is 8 and Dmax is 10, Dmax is 1.25 times bigger
         } else {
-            pidRuntime.dMaxPercent[axis] = 0;
+            pidRuntime.dMaxPercent[axis] = 1.0f;
         }
     }
     pidRuntime.dMaxGyroGain = D_MAX_GAIN_FACTOR * pidProfile->d_max_gain / D_MAX_LOWPASS_HZ;


### PR DESCRIPTION
PR #13908 simplified and updated the DMin - DMax code.

However it may have introduced a small issue where the gain multiplier was slightly under-achieving the amount of change in D for a given amount of 'boost' to drive D towards DMax.  

If, for example, D was 80 and DMax was 100, and the 'gain' or 'boost' factor was 100, master would multiply D by 1.2, and D would be 96, whereas I think it should be multiplied by 1.25 to get 100.

Because I found it a little bit difficult to follow the maths in master, I did a refactoring which I hope makes it a little bit easier to follow, and less likely to be incorrect.

This appears to resolve the slight under-estimation problem, on bench testing at least