### PR TITLE
Fix custom box names

### DIFF
--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -142,12 +142,13 @@ int serializeBoxNameFn(sbuf_t *dst, const box_t *box)
     const char* name = NULL;
     int len;
 #if defined(USE_CUSTOM_BOX_NAMES)
-    if (name == NULL
-        && box->boxId >= BOXUSER1 && box->boxId <= BOXUSER4) {
+    if (box->boxId >= BOXUSER1 && box->boxId <= BOXUSER4) {
         const int n = box->boxId - BOXUSER1;
         name = modeActivationConfig()->box_user_names[n];
         // possibly there is no '\0' in boxname
-        len = strnlen(name, sizeof(modeActivationConfig()->box_user_names[0]));
+        if (!(len = strnlen(name, sizeof(modeActivationConfig()->box_user_names[n])))) {
+            name = NULL;
+        }
     }
 #endif
     if (name == NULL) {

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -146,7 +146,9 @@ int serializeBoxNameFn(sbuf_t *dst, const box_t *box)
         const int n = box->boxId - BOXUSER1;
         name = modeActivationConfig()->box_user_names[n];
         // possibly there is no '\0' in boxname
-        if (!(len = strnlen(name, sizeof(modeActivationConfig()->box_user_names[n])))) {
+        if (*name) {
+            len = strnlen(name, sizeof(modeActivationConfig()->box_user_names[n]));
+        } else {
             name = NULL;
         }
     }


### PR DESCRIPTION
After https://github.com/betaflight/betaflight/commit/aa922032158910489e22c420a0b51eca67e243da it was not possible to define or use cli to assign user defined box name.

![image](https://github.com/user-attachments/assets/6ff7ae49-335c-4bad-b74b-758dcb07ff03)
