### PR TITLE
Fixes #13934: Fix motor(PWM protocol) spin while fc reset.

### DIFF
--- a/src/main/drivers/mcu/stm32/pwm_output.c
+++ b/src/main/drivers/mcu/stm32/pwm_output.c
@@ -35,6 +35,10 @@
 
 #include "pg/motor.h"
 
+#ifndef PWM_SHUTDOWN_DELAY
+#define PWM_SHUTDOWN_DELAY 600
+#endif
+
 FAST_DATA_ZERO_INIT pwmOutputPort_t motors[MAX_SUPPORTED_MOTORS];
 
 static void pwmOCConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t value, uint8_t output)
@@ -137,6 +141,16 @@ void pwmDisableMotors(void)
     pwmShutdownPulsesForAllMotors();
 }
 
+void pwmShutdown(void)
+{
+    pwmShutdownPulsesForAllMotors();
+    /*
+        This delay ensures the output remains low for a period of time.
+        After motor shutdown the fc will reset. If the output in high level may cause motor unexpected spin.
+    */
+    delay(PWM_SHUTDOWN_DELAY);
+}
+
 static motorVTable_t motorPwmVTable;
 bool pwmEnableMotors(void)
 {
@@ -176,7 +190,7 @@ static motorVTable_t motorPwmVTable = {
     .enable = pwmEnableMotors,
     .disable = pwmDisableMotors,
     .isMotorEnabled = pwmIsMotorEnabled,
-    .shutdown = pwmShutdownPulsesForAllMotors,
+    .shutdown = pwmShutdown,
     .convertExternalToMotor = pwmConvertFromExternal,
     .convertMotorToExternal = pwmConvertToExternal,
 };


### PR DESCRIPTION
Fixes #13934

Tested targets: SPEEDYBEEF405V4, SPEEDYBEEF405AIO and ARGUSF7AIO.

Before change, the PWM output may in high level while reset: 
![reboot_pwm](https://github.com/user-attachments/assets/e952b6ef-b0c1-46f3-982c-118c0671c137)

After add delay, PWM output keep zero duty before fc reset:
![reboot_pwm_low](https://github.com/user-attachments/assets/1fa8ffc0-2673-41fe-a7ca-fcc9469b3a2f)
