### PR TITLE
Adding CLI command pass through for MSP

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6787,11 +6787,6 @@ void cliProcess(void)
         return;
     }
 
-    if (!cliInteractive) {
-        // Flush the buffer to get rid of any MSP data polls sent by configurator after CLI was invoked
-        cliWriterFlush();
-    }
-
     while (serialRxBytesWaiting(cliPort)) {
         uint8_t c = serialRead(cliPort);
         if (cliInteractive) {
@@ -6806,6 +6801,7 @@ void cliProcess(void)
             processCharacter(c);
         }
     }
+    cliWriterFlush();
 }
 
 static void cliExit(const bool reboot)

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3594,7 +3594,6 @@ static void cliExitCmd(const char *cmdName, char *cmdline)
     } else {
         cliPrintHashLine("leaving CLI mode, no reboot");
     }
-    cliWriterFlush();
     cliExit(reboot);
 }
 
@@ -6826,6 +6825,8 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
     cliInteractive = interactive;
     cliPort = serialPort;
     cliEntryTime = millis();
+    *cliBuffer = '\0';
+    bufferIndex = 0;
 
     if (interactive) {
         setPrintfSerialPort(cliPort);
@@ -6836,7 +6837,7 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
 
     if (interactive) {
 #ifndef MINIMAL_CLI
-        cliPrintLine("\r\nEntering CLI Mode, type 'exit' to return, or 'help'");
+        cliPrintLine("\r\nEntering CLI Mode, type 'exit' to reboot, or 'help'");
 #else
         cliPrintLine("\r\nCLI");
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6691,6 +6691,10 @@ static void processCharacter(const char c)
             }
             if (cmd < cmdTable + ARRAYLEN(cmdTable)) {
                 cmd->cliCommand(cmd->name, options);
+                if (!cliMode) {
+                    // cli session ended
+                    return;
+                }
             } else {
                 if (cliInteractive) {
                     cliPrintError("input", "UNKNOWN COMMAND, TRY 'HELP'");
@@ -6808,7 +6812,7 @@ static void cliExit(const bool reboot)
 {
     cliWriterFlush();
     waitForSerialPortToFinishTransmitting(cliPort);
-    *cliBuffer = '\0';
+    memset(cliBuffer, 0, sizeof(cliBuffer));
     bufferIndex = 0;
     cliMode = false;
     cliInteractive = false;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3591,7 +3591,8 @@ static void cliExitCmd(const char *cmdName, char *cmdline)
     cliPrintHashLine("leaving CLI mode, unsaved changes lost");
     cliWriterFlush();
 
-    cliExit(strcasecmp(cmdline, "noreboot") == 0);
+    const bool reboot = strcasecmp(cmdline, "noreboot") != 0;
+    cliExit(reboot);
 }
 
 #ifdef USE_GPS
@@ -6794,6 +6795,7 @@ void cliProcess(void)
         } else {
             // handle terminating flow control character
             if (c == 0x3) { // CTRL-C
+                cliWrite(0x3); // send end of text, terminating flow control
                 cliExit(false);
                 return;
             }
@@ -6839,14 +6841,14 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
 #endif
         setArmingDisabled(ARMING_DISABLED_CLI);
         cliPrompt();
+
+#ifdef USE_CLI_BATCH
+        resetCommandBatch();
+#endif
     } else {
         cliWrite('$'); // send start of flow control frame
         cliWrite(0x2); // send start of text, initiating flow control
     }
-
-#ifdef USE_CLI_BATCH
-    resetCommandBatch();
-#endif
 }
 
 #endif // USE_CLI

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6833,9 +6833,9 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
 
     if (interactive) {
 #ifndef MINIMAL_CLI
-    cliPrintLine("\r\nEntering CLI Mode, type 'exit' to return, or 'help'");
+        cliPrintLine("\r\nEntering CLI Mode, type 'exit' to return, or 'help'");
 #else
-    cliPrintLine("\r\nCLI");
+        cliPrintLine("\r\nCLI");
 #endif
         setArmingDisabled(ARMING_DISABLED_CLI);
         cliPrompt();

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -333,6 +333,12 @@ typedef struct serialPassthroughPort_s {
     serialPort_t *port;
 } serialPassthroughPort_t;
 
+static void cliClearInputBuffer(void)
+{
+    memset(cliBuffer, 0, sizeof(cliBuffer));
+    bufferIndex = 0;
+}
+
 static void cliWriterFlushInternal(bufWriter_t *writer)
 {
     if (writer) {
@@ -6703,10 +6709,9 @@ static void processCharacter(const char c)
                     cliPrintLine(cliBuffer);
                 }
             }
-            bufferIndex = 0;
         }
 
-        memset(cliBuffer, 0, sizeof(cliBuffer));
+        cliClearInputBuffer();
 
         // prompt if in interactive mode
         if (cliInteractive) {
@@ -6812,8 +6817,7 @@ static void cliExit(const bool reboot)
 {
     cliWriterFlush();
     waitForSerialPortToFinishTransmitting(cliPort);
-    memset(cliBuffer, 0, sizeof(cliBuffer));
-    bufferIndex = 0;
+    cliClearInputBuffer();
     cliMode = false;
     cliInteractive = false;
     // incase a motor was left running during motortest, clear it here
@@ -6830,8 +6834,7 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
     cliInteractive = interactive;
     cliPort = serialPort;
     cliEntryTime = millis();
-    *cliBuffer = '\0';
-    bufferIndex = 0;
+    cliClearInputBuffer();
 
     if (interactive) {
         setPrintfSerialPort(cliPort);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6798,7 +6798,7 @@ void cliProcess(void)
             processCharacterInteractive(c);
         } else {
             // handle terminating flow control character
-            if (c == 0x3 || (millis() - cliEntryTime < 2000)) { // CTRL-C (ETX) or 2 seconds timeout
+            if (c == 0x3 || (millis() - cliEntryTime > 2000)) { // CTRL-C (ETX) or 2 seconds timeout
                 cliWrite(0x3); // send end of text, terminating flow control
                 cliExit(false);
                 return;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6804,6 +6804,7 @@ void cliProcess(void)
 
 static void cliExit(const bool reboot)
 {
+    cliWriterFlush();
     waitForSerialPortToFinishTransmitting(cliPort);
     *cliBuffer = '\0';
     bufferIndex = 0;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6780,10 +6780,10 @@ static void processCharacterInteractive(const char c)
     }
 }
 
-void cliProcess(void)
+bool cliProcess(void)
 {
     if (!cliWriter || !cliMode) {
-        return;
+        return false;
     }
 
     while (serialRxBytesWaiting(cliPort)) {
@@ -6795,12 +6795,13 @@ void cliProcess(void)
             if (c == 0x3 || (millis() - cliEntryTime > 2000)) { // CTRL-C (ETX) or 2 seconds timeout
                 cliWrite(0x3); // send end of text, terminating flow control
                 cliExit(false);
-                return;
+                return cliMode;
             }
             processCharacter(c);
         }
     }
     cliWriterFlush();
+    return cliMode;
 }
 
 static void cliExit(const bool reboot)

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6796,7 +6796,7 @@ bool cliProcess(void)
             processCharacterInteractive(c);
         } else {
             // handle terminating flow control character
-            if (c == 0x3 || (millis() - cliEntryTime > 2000)) { // CTRL-C (ETX) or 2 seconds timeout
+            if (c == 0x3 || (cmp32(millis(), cliEntryTime) > 2000)) { // CTRL-C (ETX) or 2 seconds timeout
                 cliWrite(0x3); // send end of text, terminating flow control
                 cliExit(false);
                 return cliMode;

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6713,7 +6713,7 @@ static void processCharacter(const char c)
         }
         cliBuffer[bufferIndex++] = c;
 
-        // return the character to the terminal if interative
+        // return the character to the terminal if interactive
         if (cliInteractive) {
             cliWrite(c);
         }

--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -24,7 +24,7 @@
 
 extern bool cliMode;
 
-void cliProcess(void);
+bool cliProcess(void);
 struct serialPort_s;
 void cliEnter(struct serialPort_s *serialPort, bool interactive);
 

--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -26,10 +26,7 @@ extern bool cliMode;
 
 void cliProcess(void);
 struct serialPort_s;
-void cliEnter(struct serialPort_s *serialPort);
-void cliEnterNonInteractive(struct serialPort_s *serialPort);
-void cliProcessCharacter(uint8_t c);
-void cliBufferClear(void);
+void cliEnter(struct serialPort_s *serialPort, bool interactive);
 
 #ifdef USE_CLI_DEBUG_PRINT
 void cliPrint(const char *str);

--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -27,7 +27,8 @@ extern bool cliMode;
 void cliProcess(void);
 struct serialPort_s;
 void cliEnter(struct serialPort_s *serialPort);
-void cliProcessCharacter(struct serialPort_s *serialPort, uint8_t c);
+void cliEnterNonInteractive(struct serialPort_s *serialPort);
+void cliProcessCharacter(uint8_t c);
 void cliBufferClear(void);
 
 #ifdef USE_CLI_DEBUG_PRINT

--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -27,6 +27,8 @@ extern bool cliMode;
 void cliProcess(void);
 struct serialPort_s;
 void cliEnter(struct serialPort_s *serialPort);
+void cliProcessCharacter(struct serialPort_s *serialPort, uint8_t c);
+void cliBufferClear(void);
 
 #ifdef USE_CLI_DEBUG_PRINT
 void cliPrint(const char *str);

--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -125,6 +125,7 @@ void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count)
     serialWriteBufNoFlush(instance, data, count);
     serialEndWrite(instance);
 }
+
 void serialWriteBufShim(void *instance, const uint8_t *data, int count)
 {
     serialWriteBuf((serialPort_t *)instance, data, count);

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -138,13 +138,6 @@ static void taskHandleSerial(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_USB, 1, usbVcpIsConnected());
 #endif
 
-#ifdef USE_CLI
-    // in cli mode, all serial stuff goes to here. enter cli mode by sending #
-    if (cliMode) {
-        cliProcess();
-        return;
-    }
-#endif
     bool evaluateMspData = ARMING_FLAG(ARMED) ? MSP_SKIP_NON_MSP_DATA : MSP_EVALUATE_NON_MSP_DATA;
     mspSerialProcess(evaluateMspData, mspFcProcessCommand, mspFcProcessReply);
 }

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -142,7 +142,7 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
                 case 0x2:
                     mspPort->c_state = MSP_CLI_CMD;
                     mspPort->mspVersion = MSP_V1;
-                    cliEnterNonInteractive(mspPort->port);
+                    cliEnter(mspPort->port, false);
                     break;
 #endif
                 case 'M':
@@ -158,18 +158,6 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
                     break;
             }
             break;
-
-#ifdef USE_CLI
-        case MSP_CLI_CMD:
-            if (c == 0x3) {
-                waitForSerialPortToFinishTransmitting(mspPort->port);
-                cliBufferClear();
-                mspPort->c_state = MSP_IDLE;
-            } else {
-                cliProcessCharacter(c);
-            }
-            break;
-#endif
 
         case MSP_HEADER_M:      // Waiting for '<' / '>'
             mspPort->c_state = MSP_HEADER_V1;
@@ -498,7 +486,7 @@ static void mspProcessPendingRequest(mspPort_t * mspPort)
     case MSP_PENDING_CLI:
         mspPort->pendingRequest = MSP_PENDING_NONE;
         mspPort->c_state = MSP_CLI_ACTIVE;
-        cliEnter(mspPort->port);
+        cliEnter(mspPort->port, true);
         break;
 #endif
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -525,14 +525,14 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
         }
 
 #ifdef USE_CLI
-        // this port is in cli mode, so all serial for this port should be handled by cli.
         // enter interactive cli mode by sending #
         if (mspPort->c_state == MSP_CLI_ACTIVE || mspPort->c_state == MSP_CLI_CMD) {
             if (cliMode) {
+                // this port is in cli mode, so all serial for this port should be handled by cli.
                 cliProcess();
                 return;
             } else {
-                // incorrect setting. Reset to idle state.
+                // incorrect state. Reset to idle state.
                 mspPort->c_state = MSP_IDLE;
             }
         }

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -530,7 +530,7 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             if (cliMode) {
                 // this port is in cli mode, so all serial for this port should be handled by cli.
                 cliProcess();
-                return;
+                continue;
             } else {
                 // incorrect state. Reset to idle state.
                 mspPort->c_state = MSP_IDLE;

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -439,7 +439,7 @@ static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspPr
 static void mspProcessPendingRequest(mspPort_t * mspPort)
 {
     // If no request is pending or 100ms guard time has not elapsed - do nothing
-    if ((mspPort->pendingRequest == MSP_PENDING_NONE) || (millis() - mspPort->lastActivityMs < 100)) {
+    if ((mspPort->pendingRequest == MSP_PENDING_NONE) || (cmp32(millis(), mspPort->lastActivityMs) < 100)) {
         return;
     }
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -142,6 +142,7 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
                 case 0x2:
                     mspPort->c_state = MSP_CLI_CMD;
                     mspPort->mspVersion = MSP_V1;
+                    cliEnterNonInteractive(mspPort->port);
                     break;
 #endif
                 case 'M':
@@ -165,7 +166,7 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
                 cliBufferClear();
                 mspPort->c_state = MSP_IDLE;
             } else {
-                cliProcessCharacter(mspPort->port, c);
+                cliProcessCharacter(c);
             }
             break;
 #endif

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -549,6 +549,11 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
                 const uint8_t c = serialRead(mspPort->port);
                 const bool consumed = mspSerialProcessReceivedData(mspPort, c);
 
+                if (mspPort->c_state == MSP_CLI_CMD) {
+                    cliProcess();
+                    break;
+                }
+
                 if (!consumed && evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) {
                     mspEvaluateNonMspData(mspPort, c);
                 }

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -524,6 +524,20 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             continue;
         }
 
+#ifdef USE_CLI
+        // this port is in cli mode, so all serial for this port should be handled by cli.
+        // enter interactive cli mode by sending #
+        if (mspPort->c_state == MSP_CLI_ACTIVE || mspPort->c_state == MSP_CLI_CMD) {
+            if (cliMode) {
+                cliProcess();
+                return;
+            } else {
+                // incorrect setting. Reset to idle state.
+                mspPort->c_state = MSP_IDLE;
+            }
+        }
+#endif
+
         mspPostProcessFnPtr mspPostProcessFn = NULL;
 
         if (serialRxBytesWaiting(mspPort->port)) {

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -30,6 +30,13 @@
 #define MAX_MSP_PORT_COUNT 3
 
 typedef enum {
+    PORT_IDLE,
+    PORT_MSP_PACKET,
+    PORT_CLI_ACTIVE,
+    PORT_CLI_CMD
+} mspPortState_e;
+
+typedef enum {
     MSP_IDLE,
     MSP_HEADER_START,
     MSP_HEADER_M,
@@ -47,11 +54,8 @@ typedef enum {
     MSP_PAYLOAD_V2_NATIVE,
     MSP_CHECKSUM_V2_NATIVE,
 
-    MSP_CLI_ACTIVE,
-    MSP_CLI_CMD,
-
     MSP_COMMAND_RECEIVED
-} mspState_e;
+} mspPacketState_e;
 
 typedef enum {
     MSP_PACKET_COMMAND,
@@ -103,7 +107,8 @@ typedef struct mspPort_s {
     struct serialPort_s *port; // null when port unused.
     timeMs_t lastActivityMs;
     mspPendingSystemRequest_e pendingRequest;
-    mspState_e c_state;
+    mspPortState_e portState;
+    mspPacketState_e packetState;
     mspPacketType_e packetType;
     uint8_t inBuf[MSP_PORT_INBUF_SIZE];
     uint16_t cmdMSP;

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -47,6 +47,9 @@ typedef enum {
     MSP_PAYLOAD_V2_NATIVE,
     MSP_CHECKSUM_V2_NATIVE,
 
+    MSP_CLI_ACTIVE,
+    MSP_CLI_CMD,
+
     MSP_COMMAND_RECEIVED
 } mspState_e;
 


### PR DESCRIPTION
Simple addition of the ability to commandeer the MSP, for processing a cli command, and capture the output without entering a full blown CLI session.

The cli command(s) sent over an MSP port: 
- 0x2 -> start of text transmission, break out of MSP
- command
- LF -> command termination
- 0x3 -> end of text transmission

Serial output from this will be, in essence, the opposite. i.e.
- 0x2 -> start of text transmission (to signify flow control), then
- normal command output (in non-interactive), 
- 0x3 -> end of text transmission - flow control to revert to normal MSP processing.

Will require co-ordination with the configurator to make use of this.

Can use it currently with https://webserial.io
