### PR TITLE
Some defines removed from USE_WING build that is not useful for planes

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -459,10 +459,19 @@
 #endif // USE_RACE_PRO
 
 #ifdef USE_WING
+
 #ifndef USE_SERVOS
 #define USE_SERVOS
 #endif
+
 #ifndef USE_ADVANCED_TPA
 #define USE_ADVANCED_TPA
 #endif
+
+#undef USE_YAW_SPIN_RECOVERY
+#undef USE_LAUNCH_CONTROL
+#undef USE_ABSOLUTE_CONTROL
+#undef USE_INTEGRATED_YAW_CONTROL
+#undef USE_RUNAWAY_TAKEOFF
+
 #endif // USE_WING


### PR DESCRIPTION
Running out of  ITCM_RAM for `USE_WING`.
Removing the following, if `USE_WING` is defined, since these are not useful for planes.
Saves ~8% on F722

```C
#undef USE_YAW_SPIN_RECOVERY
#undef USE_LAUNCH_CONTROL
#undef USE_ABSOLUTE_CONTROL
#undef USE_INTEGRATED_YAW_CONTROL
#undef USE_RUNAWAY_TAKEOFF
```