### PR TITLE
[4.5.2] Fixes #13934: Fix motor(PWM protocol) spin while fc reset. (#13937)

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -51,11 +51,25 @@ static bool motorProtocolDshot = false;
 
 void motorShutdown(void)
 {
+    uint32_t shutdownDelayUs = 1500;
     motorDevice->vTable.shutdown();
     motorDevice->enabled = false;
     motorDevice->motorEnableTimeMs = 0;
     motorDevice->initialized = false;
-    delayMicroseconds(1500);
+
+    switch (motorConfig()->dev.motorPwmProtocol) {
+    case PWM_TYPE_STANDARD:
+    case PWM_TYPE_ONESHOT125:
+    case PWM_TYPE_ONESHOT42:
+    case PWM_TYPE_MULTISHOT:
+        // Delay 500ms will disarm esc which can prevent motor spin while reboot
+        shutdownDelayUs += 500 * 1000;
+        break;
+    default:
+        break;
+    }
+
+    delayMicroseconds(shutdownDelayUs);
 }
 
 void motorWriteAll(float *values)


### PR DESCRIPTION
- Backport of #13937 by @kedeng 
- Fix motor(PWM protocol) spin while fc reset.
- Move delay out to motorShutdown
