### PR TITLE
Make the imuGyroFilter actually filter

### DIFF
--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -278,7 +278,7 @@ void gyroInitFilters(void)
     dynNotchInit(dynNotchConfig(), gyro.targetLooptime);
 #endif
 
-    const float k = pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.targetLooptime);
+    const float k = pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.targetLooptime * 1e-6f);
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         pt1FilterInit(&gyro.imuGyroFilter[axis], k);
     }


### PR DESCRIPTION
When imuGyroFilter is initialized the wrong dt is used resulting in the filtering being initialized incorrectly. The dt in this case is 1,000,000 or 1 million times larger than it should be. This results in the filter gain or k value being set to essentially 1.0 (quite possibly 1.0 due to floating point accuracy). This leads to the filter doing essentially nothing.

This code is untested besides showing that it actually does create the correct k value for the filter. This will change some of the behavior of the attitude estimator found in imu.c and as such some testing should be done with this change. We may actually find that it is better to simply remove this filter and keep the current behavior. However, with the current behavior there is a risk that high frequency aliasing can cause the attitude estimator to gain a bit of a bias.