### PR TITLE
Use wasThrottleRaised in place of isAirmodeActivated where appropriate

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -816,8 +816,6 @@ bool processRx(timeUs_t currentTimeUs)
         }
         if (airmodeIsEnabled() && !launchControlActive) {
             airmodeIsActivated = throttleRaised;
-        } else {
-            airmodeIsActivated = false;
         }
     } else {
         throttleRaised = false;

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -92,6 +92,7 @@ uint8_t calculateThrottlePercentAbs(void);
 bool areSticksActive(uint8_t stickPercentLimit);
 void runawayTakeoffTemporaryDisable(uint8_t disableFlag);
 bool isAirmodeActivated();
+bool wasThrottleRaised();
 timeUs_t getLastDisarmTimeUs(void);
 bool isTryingToArm();
 void resetTryingToArm();

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -91,7 +91,6 @@ int8_t calculateThrottlePercent(void);
 uint8_t calculateThrottlePercentAbs(void);
 bool areSticksActive(uint8_t stickPercentLimit);
 void runawayTakeoffTemporaryDisable(uint8_t disableFlag);
-bool isAirmodeActivated();
 bool wasThrottleRaised();
 timeUs_t getLastDisarmTimeUs(void);
 bool isTryingToArm();

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -72,7 +72,7 @@ void rcModeUpdate(const boxBitmask_t *newState)
     rcModeActivationMask = *newState;
 }
 
-bool airmodeIsEnabled(void)
+bool isAirmodeEnabled(void)
 {
     return airmodeEnabled;
 }

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -142,7 +142,7 @@ typedef struct modeActivationProfile_s {
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(const boxBitmask_t *newState);
 
-bool airmodeIsEnabled(void);
+bool isAirmodeEnabled(void);
 
 bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range);
 void updateActivatedModes(void);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -227,7 +227,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
         currentThrottleInputRange = PWM_RANGE;
 #ifdef USE_DYN_IDLE
         if (mixerRuntime.dynIdleMinRps > 0.0f) {
-            const float maxIncrease = isAirmodeActivated()
+            const float maxIncrease = wasThrottleRaised()
                 ? mixerRuntime.dynIdleMaxIncrease : mixerRuntime.dynIdleStartIncrease;
             float minRps = getMinMotorFrequencyHz();
             DEBUG_SET(DEBUG_DYN_IDLE, 3, lrintf(minRps * 10.0f));

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -808,7 +808,7 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
         && ARMING_FLAG(ARMED)
         && !mixerRuntime.feature3dEnabled
         && !airmodeEnabled                               // not with airmode or launch control
-        && !FLIGHT_MODE(GPS_RESCUE_MODE | ALT_HOLD_MODE) // mot in autopilot modes
+        && !FLIGHT_MODE(GPS_RESCUE_MODE | ALT_HOLD_MODE) // not in autopilot modes
         && (rcData[THROTTLE] < rxConfig()->mincheck)) {
         applyMotorStop();
     } else {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -800,7 +800,7 @@ float pidGetAirmodeThrottleOffset(void)
 
 static FAST_CODE_NOINLINE void disarmOnImpact(void)
 {
-    // if, being armed, and adter takeoff...
+    // if, being armed, and after takeoff...
     if (wasThrottleRaised()
         // and, either sticks are centred and throttle zeroed,
         && ((getMaxRcDeflectionAbs() < 0.05f && mixerGetRcThrottle() < 0.05f)

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -718,7 +718,7 @@ STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRat
             acErrorRate = (gyroRate > gmaxac ? gmaxac : gminac ) - gyroRate;
         }
 
-        if (isAirmodeActivated()) {
+        if (wasThrottleRaised()) {
             axisError[axis] = constrainf(axisError[axis] + acErrorRate * pidRuntime.dT,
                 -pidRuntime.acErrorLimit, pidRuntime.acErrorLimit);
             const float acCorrection = constrainf(axisError[axis] * pidRuntime.acGain, -pidRuntime.acLimit, pidRuntime.acLimit);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -800,8 +800,8 @@ float pidGetAirmodeThrottleOffset(void)
 
 static FAST_CODE_NOINLINE void disarmOnImpact(void)
 {
-    // if, after takeoff...
-    if (isAirmodeActivated()
+    // if, being armed, and adter takeoff...
+    if (wasThrottleRaised()
         // and, either sticks are centred and throttle zeroed,
         && ((getMaxRcDeflectionAbs() < 0.05f && mixerGetRcThrottle() < 0.05f)
             // we could test here for stage 2 failsafe (including both landing or GPS Rescue)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1066,7 +1066,7 @@ static void osdElementFlymode(osdElementParms_t *element)
         strcpy(element->buff, "HOR ");
     } else if (IS_RC_MODE_ACTIVE(BOXACROTRAINER)) {
         strcpy(element->buff, "ATRN");
-    } else if (airmodeIsEnabled()) {
+    } else if (isAirmodeEnabled()) {
         strcpy(element->buff, "AIR ");
     } else {
         strcpy(element->buff, "ACRO");

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -405,7 +405,7 @@ void crsfFrameFlightMode(sbuf_t *dst)
         flightMode = "ALTH";
     } else if (FLIGHT_MODE(HORIZON_MODE)) {
         flightMode = "HOR";
-    } else if (airmodeIsEnabled()) {
+    } else if (isAirmodeEnabled()) {
         flightMode = "AIR";
     }
 

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1314,7 +1314,7 @@ extern "C" {
         return false;
     }
 
-    bool airmodeIsEnabled() {
+    bool isAirmodeEnabled() {
         return false;
     }
 

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -24,7 +24,7 @@
 #include "gtest/gtest.h"
 #include "build/debug.h"
 
-bool simulatedAirmodeEnabled = true;
+bool simulatedThrottleRaised = true;
 float simulatedSetpointRate[3] = { 0,0,0 };
 float simulatedPrevSetpointRate[3] = { 0,0,0 };
 float simulatedRcDeflection[3] = { 0,0,0 };
@@ -93,8 +93,7 @@ extern "C" {
 
     float getMotorMixRange(void) { return simulatedMotorMixRange; }
     float getSetpointRate(int axis) { return simulatedSetpointRate[axis]; }
-    bool isAirmodeActivated(void) { return simulatedAirmodeEnabled; }
-    bool wasThrottleRaised(void) { return simulatedAirmodeEnabled; }
+    bool wasThrottleRaised(void) { return simulatedThrottleRaised; }
     float getRcDeflectionAbs(int axis) { return fabsf(simulatedRcDeflection[axis]); }
 
     // used by auto-disarm code

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -94,6 +94,7 @@ extern "C" {
     float getMotorMixRange(void) { return simulatedMotorMixRange; }
     float getSetpointRate(int axis) { return simulatedSetpointRate[axis]; }
     bool isAirmodeActivated(void) { return simulatedAirmodeEnabled; }
+    bool wasThrottleRaised(void) { return simulatedAirmodeEnabled; }
     float getRcDeflectionAbs(int axis) { return fabsf(simulatedRcDeflection[axis]); }
 
     // used by auto-disarm code

--- a/src/test/unit/rx_spi_expresslrs_telemetry_unittest.cc
+++ b/src/test/unit/rx_spi_expresslrs_telemetry_unittest.cc
@@ -420,7 +420,7 @@ extern "C" {
     bool telemetryIsSensorEnabled(sensor_e) {return true; }
     bool sensors(uint32_t ) { return true; }
 
-    bool airmodeIsEnabled(void) {return airMode; }
+    bool isAirmodeEnabled(void) {return airMode; }
 
     bool isBatteryVoltageConfigured(void) { return true; }
     bool isAmperageConfigured(void) { return true; }

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -292,7 +292,7 @@ extern "C" {
 
     bool featureIsEnabled(uint32_t) {return false;}
 
-    bool airmodeIsEnabled(void) {return true;}
+    bool isAirmodeEnabled(void) {return true;}
 
     mspDescriptor_t mspDescriptorAlloc(void) {return 0;}
 

--- a/src/test/unit/telemetry_crsf_unittest.cc
+++ b/src/test/unit/telemetry_crsf_unittest.cc
@@ -343,7 +343,7 @@ bool telemetryIsSensorEnabled(sensor_e) {return true;}
 
 portSharing_e determinePortSharing(const serialPortConfig_t *, serialPortFunction_e) {return PORTSHARING_NOT_SHARED;}
 
-bool airmodeIsEnabled(void) {return airMode;}
+bool isAirmodeEnabled(void) {return airMode;}
 
 int32_t getAmperage(void)
 {


### PR DESCRIPTION
This PR is a significant change to Airmode control logic, with minor refactoring and variable name changes.

Fixes a long-standing bug where if airmode was not enabled, dynamic idle was not able to increase the motors above the idle value after takeoff.

The main change is that Airmode is no longer required for:
- Altitude Hold (and Position Hold, when we get it)
- Dynamic Idle
- Disam on impact in pid.c
- Absolute Control

These functions will, as before, only become active, after arming, once the throttle has been raised above the `airmode_start_throttle_percent` value. They then remain active until disarm.

What's different is that:
- they won't require Airmode to be enabled in order to work, and, conversely
- they can't be disabled, once enabled, by switching the Airmode Switch off (don't care about airmode)

There should be no other changes.  Mixer behaviours, launch control, motor stop, iTerm enabling, and PIDs below mincheck, all of which depend on Airmode, have not been changed.

This change should benefit:
- pilots who want to enable 'disarm on impact' detection, while landing with Airmode disabled
- whoops that are flown without airmode, but want to use dynamic idle, 
- users who want altitude or position hold but don't have or want airmode on (mostly cinematic users)

The refactoring changes are minor:
- the `airmodeEnabled` getter `airmodeIsEnabled` is re-named to `isAirmodeEnabled`
- `airmodeIsActivated` is re-named to `isAirmodeActive`
- the `isAirmodeActivated` getter is removed, it isn't needed anymore.
- `throttleRaised` and it's getter `wasThrottleRaised` are added

The following is a summary of airmode related functionalities with this PR.  I include it because a lot of people are confused about exactly what 'airmode' does.  Something similar can go into the wiki for 4.6.

There will be three possible "airmode" related identifiers (not two):
- `airmodeEnabled` and it's getter `isAirmodeEnabled` - true when the Airmode Feature is enabled, or the user's Airmode Switch is ON.  Note 1: `airmodeEnabled ` does _not_ care about throttle!  Note 2: nothing related to `airmodeEnabled` should change with this PR.
- `isAirmodeActive`, true, and latches true, if airmode is enabled *and* the throttle has been raised since arming; false while disarmed.
- `wasThrottleRaised`- true, and latches true, if the throttle has been raised since arming; false while disarmed.

1. `airmodeEnabled`, which ignores throttle, affects:
- mixer behaviour (all mixers except ezLanding)
- motor stop (only possible if airmode is not enabled)
- launch control (if the user has enabled motor stop, launch control will be only be blocked if airmode is not enabled)
- auto disarm after delay is blocked
- runaway takeoff, which has a custom throttle check (throttle below `THROTTLE_LOW`), and to check if motors are stopped by motor_stop, it needs to know if airmode is enabled.
- display that airmode is active in OSD and in telemetry

2. `isAirmodeActive`, requiring both airmode and throttle up, only affects iTerm and PID stabilisation:
- iTerm stays active while `isAirmodeActive` is true.  If airmode is not active, iTerm will be forced to zero while throttle is low (below min_check).
- PID stabilisation is likewise active while `isAirmodeActive` is true. If airmode is not active, PID stabilisation while throttle is low depends on `PID_AT_MIN_THROTTLE`.

3. `wasThrottleRaised`, which only requires throttle to have been raised, has these effects:
- Altitude Hold / Position Hold can't be activated until after takeoff
- Dynamic Idle limits motor drive to no greater than idle speed
- Disarm on impact in pid.c becomes active after takeoff
- Absolute Control can't be enabled until after takeoff.
