### PR TITLE
Draft: feat/sitl websocket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Fetch toolchain from cache
         uses: actions/cache@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/main/libwebsockets"]
+	path = lib/main/libwebsockets
+	url = git@github.com:warmcat/libwebsockets.git

--- a/src/main/drivers/serial_ws.c
+++ b/src/main/drivers/serial_ws.c
@@ -1,0 +1,379 @@
+/*
+ * TODO...
+ */
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+
+#include "common/utils.h"
+
+#include "io/serial.h"
+#include "serial_ws.h"
+
+#if !defined (LWS_PLUGIN_STATIC)
+#define LWS_DLL
+#define LWS_INTERNAL
+#include <libwebsockets.h>
+#endif
+
+#define BASE_PORT 5760
+
+static const struct serialPortVTable wsVTable;  // Forward
+static wsPort_t wsSerialPorts[SERIAL_PORT_COUNT];
+static bool wsPortInitialized[SERIAL_PORT_COUNT];
+
+//protocol definition
+
+/* one of these is created for each vhost our protocol is used with */
+struct per_vhost_data__minimal {
+	struct lws_context *context;
+	struct lws_vhost *vhost;
+	const struct lws_protocols *protocol;
+};
+
+static int
+callback_minimal(struct lws *wsi, enum lws_callback_reasons reason,
+			void *user, void *in, size_t len)
+{
+  (void) user;
+
+  const struct lws_protocols * proto = lws_get_protocol(wsi);
+
+  if(!proto){
+    return 0;
+  }
+
+  if(strcmp(proto->name,"wsSerial") != 0){
+    return 0;
+  }
+
+  wsPort_t *wsPort = (wsPort_t *)proto->user;
+
+  //fprintf(stderr, "callback on UART%u, %d reason: %d\n", wsPort->id + 1, wsPort->clientCount, reason);
+
+	struct per_vhost_data__minimal *vhd =
+			(struct per_vhost_data__minimal *)
+			lws_protocol_vh_priv_get(lws_get_vhost(wsi),
+					lws_get_protocol(wsi));
+	int m;
+
+	switch (reason) {
+	case LWS_CALLBACK_PROTOCOL_INIT:
+    fprintf(stderr, "LWS_CALLBACK_PROTOCOL_INIT\n");
+		vhd = lws_protocol_vh_priv_zalloc(lws_get_vhost(wsi),
+				lws_get_protocol(wsi),
+				sizeof(struct per_vhost_data__minimal));
+		vhd->context = lws_get_context(wsi);
+		vhd->protocol = lws_get_protocol(wsi);
+		vhd->vhost = lws_get_vhost(wsi);
+		break;
+
+	case LWS_CALLBACK_ESTABLISHED:
+    fprintf(stderr, "LWS_CALLBACK_ESTABLISHED\n");
+    fprintf(stderr, "New connection on UART%u, %d\n", wsPort->id + 1, wsPort->clientCount);
+    wsPort->wsi = wsi;
+    wsPort->connected = true;
+    if (wsPort->clientCount > 0) {
+      break;
+    }
+    wsPort->clientCount++;
+    fprintf(stderr, "[NEW]UART%u: %d,%d\n", wsPort->id + 1, wsPort->connected, wsPort->clientCount);
+		break;
+
+	case LWS_CALLBACK_CLOSED:
+    fprintf(stderr, "LWS_CALLBACK_CLOSED\n");
+    wsPort->clientCount--;
+    wsPort->wsi = NULL;
+    fprintf(stderr, "[CLS]UART%u: %d,%d\n", wsPort->id + 1, wsPort->connected, wsPort->clientCount);
+    if (wsPort->clientCount == 0) {
+      wsPort->connected = false;
+    }
+		break;
+
+	case LWS_CALLBACK_SERVER_WRITEABLE:
+    //fprintf(stderr, "LWS_CALLBACK_SERVER_WRITEABLE\n");
+    if (wsPort->wsi == NULL) {
+      fprintf(stderr, "wsPort->wsi == NULL\n");
+      break;
+    }
+    if (wsPort->wsi != wsi){
+      fprintf(stderr, "wsPort->wsi != wsi\n");
+      break; // different client than last connected?
+    }
+
+    if (wsPort->port.txBufferHead < wsPort->port.txBufferTail) {
+        // send data till end of buffer
+        int chunk = wsPort->port.txBufferSize - wsPort->port.txBufferTail;
+        m = lws_write(wsi, (unsigned char *)&wsPort->port.txBuffer[wsPort->port.txBufferTail], chunk, LWS_WRITE_BINARY);
+        if (m < 0) {
+          lwsl_err("ERROR %d writing to ws\n", m);
+          break;
+        }
+        
+        //advance tail by written bytes
+        wsPort->port.txBufferTail += m;
+        if(chunk == m){
+          // if remainder of buffer got written reset tail to start of ring buffer
+          wsPort->port.txBufferTail = 0;
+        }
+        //fprintf(stderr, "Written %d bytes\n", m);
+    }
+    int chunk = wsPort->port.txBufferHead - wsPort->port.txBufferTail;
+    if (chunk){
+      m = lws_write(wsi, (unsigned char  *)&wsPort->port.txBuffer[wsPort->port.txBufferTail], chunk, LWS_WRITE_BINARY);
+      if (m < 0) {
+        lwsl_err("ERROR %d writing to ws\n", m);
+        break;
+      }
+      wsPort->port.txBufferTail += m;
+      //fprintf(stderr, "Written %d bytes\n", m);
+    }
+		break;
+
+	case LWS_CALLBACK_RECEIVE:
+    //(stderr, "LWS_CALLBACK_RECEIVE\n");
+    if (wsPort->wsi == NULL) {
+      fprintf(stderr, "wsPort->wsi == NULL\n");
+      break;
+    }
+    if (wsPort->wsi != wsi){
+      fprintf(stderr, "wsPort->wsi != wsi\n");
+      break; // different client than last connected?
+    }
+
+    uint8_t * data = (uint8_t*)in;
+    int size = len;
+    while (size--) {
+      //printf("%c", *ch);
+      //printf("%02X", *ch);
+      wsPort->port.rxBuffer[wsPort->port.rxBufferHead] = *(data++);
+      if (wsPort->port.rxBufferHead + 1 >= wsPort->port.rxBufferSize) {
+          wsPort->port.rxBufferHead = 0;
+      } else {
+          wsPort->port.rxBufferHead++;
+      }
+    }
+    //fprintf(stderr, "Read %d bytes\n", len);
+
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+#define LWS_PLUGIN_PROTOCOL_SERIAL \
+	{ \
+		"wsSerial", \
+		callback_minimal, \
+		0, \
+		512, \
+		0, NULL, 512 \
+	}
+
+static struct lws_protocols protocols[] = {
+	LWS_PLUGIN_PROTOCOL_SERIAL,
+	LWS_PROTOCOL_LIST_TERM
+};
+
+
+static wsPort_t *wsReconfigure(wsPort_t *s, int id) {
+  if (wsPortInitialized[id]) {
+    fprintf(stderr, "port is already initialized!\n");
+    return s;
+  }
+
+  wsPortInitialized[id] = true;
+
+  s->connected = false;
+  s->clientCount = 0;
+  s->id = id;
+
+  struct lws_context_creation_info info;
+  struct lws_context *context;
+
+  lws_set_log_level(LLL_USER | LLL_ERR | LLL_WARN | LLL_NOTICE, NULL);
+  memset(&info, 0, sizeof info); /* otherwise uninitialized garbage */
+	info.port = BASE_PORT + id + 1;
+	info.mounts = NULL;
+
+  protocols[0].user = (void*)s;
+
+	info.protocols = protocols;
+	info.vhost_name = "localhost";
+  info.options = LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE;
+  context = lws_create_context(&info);
+  if (!context) {
+		lwsl_err("lws init failed\n");
+    fprintf(stderr,
+            "init port %u for UART%u failed!!\n",
+            (unsigned)BASE_PORT + id + 1,
+            (unsigned)id + 1);
+	}
+  fprintf(stderr,
+          "init port %u for UART%u\n",
+          (unsigned)BASE_PORT + id + 1,
+          (unsigned)id + 1);
+
+  s->context = context;
+
+
+
+  return s;
+}
+
+serialPort_t *serialWsOpen(int id,
+                        serialReceiveCallbackPtr rxCallback,
+                        void *rxCallbackData,
+                        uint32_t baudRate,
+                        portMode_e mode,
+                        portOptions_e options) {
+    wsPort_t *s = NULL;
+
+#if defined(USE_UART1) || defined(USE_UART2) || defined(USE_UART3) || \
+  defined(USE_UART4) || defined(USE_UART5) || defined(USE_UART6) ||   \
+  defined(USE_UART7) || defined(USE_UART8)
+    if (id >= 0 && id < SERIAL_PORT_COUNT) {
+        s = wsReconfigure(&wsSerialPorts[id], id);
+    }
+#endif
+    if (!s) return NULL;
+
+    s->port.vTable = &wsVTable;
+
+    // common serial initialisation code should move to serialPort::init()
+    s->port.rxBufferHead = s->port.rxBufferTail = 0;
+    s->port.txBufferHead = s->port.txBufferTail = 0;
+    s->port.rxBufferSize = RX_BUFFER_SIZE;
+    s->port.txBufferSize = TX_BUFFER_SIZE;
+    s->port.rxBuffer = s->rxBuffer;
+    s->port.txBuffer = s->txBuffer;
+
+    // callback works for IRQ-based RX ONLY
+    s->port.rxCallback = rxCallback;
+    s->port.rxCallbackData = rxCallbackData;
+    s->port.mode = mode;
+    s->port.baudRate = baudRate;
+    s->port.options = options;
+
+    return (serialPort_t *)s;
+}
+
+uint32_t wsTotalRxBytesWaiting(const serialPort_t *instance) {
+    wsPort_t *s = (wsPort_t *)instance;
+    uint32_t count;
+
+    if (s->port.rxBufferHead >= s->port.rxBufferTail) {
+        count = s->port.rxBufferHead - s->port.rxBufferTail;
+    } else {
+        count =
+          s->port.rxBufferSize + s->port.rxBufferHead - s->port.rxBufferTail;
+    }
+
+    return count;
+}
+
+uint32_t wsTotalTxBytesFree(const serialPort_t *instance) {
+    wsPort_t *s = (wsPort_t *)instance;
+    uint32_t bytesUsed;
+
+    if (s->port.txBufferHead >= s->port.txBufferTail) {
+        bytesUsed = s->port.txBufferHead - s->port.txBufferTail;
+    } else {
+        bytesUsed =
+          s->port.txBufferSize + s->port.txBufferHead - s->port.txBufferTail;
+    }
+    uint32_t bytesFree = (s->port.txBufferSize - 1) - bytesUsed;
+
+    return bytesFree;
+}
+
+bool isWsTransmitBufferEmpty(const serialPort_t *instance) {
+    wsPort_t *s = (wsPort_t *)instance;
+
+    bool isEmpty = s->port.txBufferTail == s->port.txBufferHead;
+
+    return isEmpty;
+}
+
+uint8_t wsRead(serialPort_t *instance) {
+    uint8_t ch;
+    wsPort_t *s = (wsPort_t *)instance;
+
+    ch = s->port.rxBuffer[s->port.rxBufferTail];
+    if (s->port.rxBufferTail + 1 >= s->port.rxBufferSize) {
+        s->port.rxBufferTail = 0;
+    } else {
+        s->port.rxBufferTail++;
+    }
+
+    //fprintf(stderr, "%c", ch);
+
+    return ch;
+}
+
+void wsWrite(serialPort_t *instance, uint8_t ch) {
+    wsPort_t *s = (wsPort_t *)instance;
+
+    //fprintf(stderr, "%c", ch);
+
+    //TODO: lock/thread sync ?
+
+    s->port.txBuffer[s->port.txBufferHead] = ch;
+    if (s->port.txBufferHead + 1 >= s->port.txBufferSize) {
+        s->port.txBufferHead = 0;
+    } else {
+        s->port.txBufferHead++;
+    }
+
+}
+
+void wsUpdate(void){
+  for(int i = 0; i < SERIAL_PORT_COUNT; i++){
+    if(wsPortInitialized[i]){
+      wsPort_t* ws = &wsSerialPorts[i];
+      int n = lws_service(ws->context, 1000);
+      if(n<0){
+         fprintf(stderr,
+            "timeout port %u for UART%u failed!!\n",
+            (unsigned)BASE_PORT + ws->id + 1,
+            (unsigned)ws->id + 1);
+      }
+
+      /*
+      * let everybody know we want to write something on them
+      * as soon as they are ready
+      */
+      int maxLoops = 2;
+      while(ws->wsi && !isWsTransmitBufferEmpty((serialPort_t *)&wsSerialPorts[i]) && lws_callback_on_writable(ws->wsi)){
+        if(maxLoops <= 0){
+          break;
+        }
+        maxLoops--;
+      }
+    }
+  }
+}
+
+static const struct serialPortVTable wsVTable = {
+  .serialWrite = wsWrite,
+  .serialTotalRxWaiting = wsTotalRxBytesWaiting,
+  .serialTotalTxFree = wsTotalTxBytesFree,
+  .serialRead = wsRead,
+  .serialSetBaudRate = NULL,
+  .isSerialTransmitBufferEmpty = isWsTransmitBufferEmpty,
+  .setMode = NULL,
+  .setCtrlLineStateCb = NULL,
+  .setBaudRateCb = NULL,
+  .writeBuf = NULL,
+  .beginWrite = NULL,
+  .endWrite = NULL,
+};

--- a/src/main/drivers/serial_ws.h
+++ b/src/main/drivers/serial_ws.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define PRE_LWS_BUFFER 40
+#define RX_BUFFER_SIZE 1400
+#define TX_BUFFER_SIZE 1400
+
+typedef struct {
+    serialPort_t port;
+    // prepend with allocated bytes, so ws transmission can prepend protocols stuff without reallocs
+    uint8_t rxBufferPre[PRE_LWS_BUFFER];
+    uint8_t rxBuffer[RX_BUFFER_SIZE];
+    uint8_t txBufferPre[PRE_LWS_BUFFER];
+    uint8_t txBuffer[TX_BUFFER_SIZE];
+
+    //server context
+    struct lws_context *context;
+    //client ?
+    struct lws *wsi;
+
+    //dyad_Stream *serv;
+    //dyad_Stream *conn;
+
+    bool connected;
+    uint16_t clientCount;
+    uint8_t id;
+} wsPort_t;
+
+serialPort_t *serialWsOpen( int id,
+                            serialReceiveCallbackPtr rxCallback,
+                            void *rxCallbackData,
+                            uint32_t baudRate,
+                            portMode_e mode,
+                            portOptions_e options);
+
+// wsPort API
+void wsDataIn(wsPort_t *instance, uint8_t *ch, int size);
+void wsDataOut(wsPort_t *instance);
+
+void wsUpdate(void);
+

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -40,7 +40,8 @@
 #endif
 
 #if defined(SIMULATOR_BUILD)
-#include "drivers/serial_tcp.h"
+//#include "drivers/serial_tcp.h"
+#include "drivers/serial_ws.h"
 #endif
 
 #include "drivers/light_led.h"
@@ -487,7 +488,10 @@ serialPort_t *openSerialPort(
 #endif
 #if defined(SIMULATOR_BUILD)
             // emulate serial ports over TCP
-            serialPort = serTcpOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, rxCallbackData, baudRate, mode, options);
+            // serialPort = serTcpOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, rxCallbackData, baudRate, mode, options);
+
+            //emulate serial over websocket
+            serialPort = serialWsOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, rxCallbackData, baudRate, mode, options);
 #else
             serialPort = uartOpen(SERIAL_PORT_IDENTIFIER_TO_UARTDEV(identifier), rxCallback, rxCallbackData, baudRate, mode, options);
 #endif

--- a/src/platform/SITL/mk/SITL.mk
+++ b/src/platform/SITL/mk/SITL.mk
@@ -1,9 +1,12 @@
+# Include the CMake project Makefile
 
 INCLUDE_DIRS    := $(INCLUDE_DIRS) \
                    $(TARGET_PLATFORM_DIR) \
-                   $(ROOT)/lib/main/dyad
+                   $(ROOT)/lib/main/dyad \
+									 $(ROOT)/obj/main/libwebsockets/include
 
 MCU_COMMON_SRC  := $(ROOT)/lib/main/dyad/dyad.c \
+                   $(ROOT)/src/main/drivers/serial_ws.c \
                    sitl.c \
                    udplink.c
 
@@ -54,7 +57,7 @@ LD_FLAGS    := \
               -Wl,-gc-sections,-Map,$(TARGET_MAP) \
               -Wl,-L$(LINKER_DIR) \
               -Wl,--cref \
-              -T$(LD_SCRIPT)
+              -T$(LD_SCRIPT) \
 
 ifneq ($(filter SITL_STATIC,$(OPTIONS)),)
 LD_FLAGS     += \
@@ -69,3 +72,5 @@ OPTIMISE_SIZE       := -Os
 
 LTO_FLAGS           := $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
 endif
+
+include $(TARGET_PLATFORM_DIR)/mk/libwebsockets.mk

--- a/src/platform/SITL/mk/libwebsockets.mk
+++ b/src/platform/SITL/mk/libwebsockets.mk
@@ -1,0 +1,30 @@
+# Set the build directory
+BUILD_DIR = $(ROOT)/obj/main/libwebsockets
+
+# Set CMake flags (you can add more options here)
+CMAKE_FLAGS = -DCMAKE_BUILD_TYPE=Release
+
+# Set the source directory (usually the current directory)
+SRC_DIR = $(ROOT)/lib/main/libwebsockets
+
+$(BUILD_DIR):
+	@mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/Makefile: $(BUILD_DIR)
+	@cmake $(CMAKE_FLAGS) -S $(SRC_DIR) -B $(BUILD_DIR) -DLWS_WITH_SSL=OFF -DLWS_WITH_SHARED=OFF -DLWS_WITH_MINIMAL_EXAMPLES=OFF -DLWS_WITHOUT_TESTAPPS=OFF -DLWS_WITHOUT_TEST_SERVER=OFF -DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON -DLWS_WITHOUT_TEST_PING=OFF -DLWS_WITHOUT_TEST_CLIENT=OFF
+
+$(BUILD_DIR)/lib/libwebsockets.a: $(BUILD_DIR)/Makefile
+	@cd $(BUILD_DIR) && $(MAKE)
+
+src/main/drivers/serial_ws.c: $(BUILD_DIR)/lib/libwebsockets.a
+
+clean: websocketsclean
+
+websocketsclean: 
+	@cd $(BUILD_DIR) && $(MAKE) clean
+
+.PHONY: websocketsclean
+
+$(TARGET_ELF): $(BUILD_DIR)/lib/libwebsockets.a
+
+LD_FLAGS += -L$(ROOT)/obj/main/libwebsockets/lib -lwebsockets

--- a/src/platform/SITL/sitl.c
+++ b/src/platform/SITL/sitl.c
@@ -748,3 +748,13 @@ void unusedPinsInit(void)
 {
     printf("unusedPinsInit\n");
 }
+
+void IOHi(IO_t io)
+{
+  (void)io;
+};
+
+void IOLo(IO_t io)
+{
+  (void)io;
+};

--- a/src/platform/SITL/sitl.c
+++ b/src/platform/SITL/sitl.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include <pthread.h>
 
 #include <errno.h>
 #include <time.h>
@@ -34,7 +35,7 @@
 #include "drivers/dma.h"
 #include "drivers/motor.h"
 #include "drivers/serial.h"
-#include "drivers/serial_tcp.h"
+#include "drivers/serial_ws.h"
 #include "drivers/system.h"
 #include "drivers/pwm_output.h"
 #include "drivers/light_led.h"
@@ -55,7 +56,7 @@
 
 #include "rx/rx.h"
 
-#include "dyad.h"
+//#include "dyad.h"
 #include "udplink.h"
 
 uint32_t SystemCoreClock;
@@ -268,16 +269,19 @@ static void* tcpThread(void* data)
 {
     UNUSED(data);
 
-    dyad_init();
-    dyad_setTickInterval(0.2f);
-    dyad_setUpdateTimeout(0.01f);
+
+    //dyad_init();
+    //dyad_setTickInterval(0.2f);
+    //dyad_setUpdateTimeout(0.01f);
 
     while (workerRunning) {
-        dyad_update();
+        //dyad_update();
+        wsUpdate();
     }
 
-    dyad_shutdown();
-    printf("tcpThread end!!\n");
+    //dyad_shutdown();
+    printf("wsThread end!!\n");
+    
     return NULL;
 }
 


### PR DESCRIPTION
Ultra dirty draft. Needs some support with make files. no idea where to add additional targets that are only executed when SITL target is built.

Calling `make TARGET=SITL` will generate an additional make file for libwebsockets under `obj/main/libwebsockets`:

```
obj/main/
├── SITL
│   ├── blackbox
│   ├── build
│   ├── cli
│   ├── cms
│   ├── common
│   ├── config
│   ├── drivers
│   ├── fc
│   ├── flight
│   ├── io
│   ├── lib
│   ├── main.d
│   ├── main.o
│   ├── msp
│   ├── osd
│   ├── pg
│   ├── rx
│   ├── scheduler
│   ├── sensors
│   ├── sitl.d
│   ├── sitl.o
│   ├── src
│   ├── target
│   ├── telemetry
│   ├── udplink.d
│   └── udplink.o
├── betaflight_SITL.elf
├── betaflight_SITL.map
└── libwebsockets
    ├── CMakeCache.txt
    ├── CMakeFiles
    ├── CPackConfig.cmake
    ├── CPackSourceConfig.cmake
    ├── CTestTestfile.cmake
    ├── DartConfiguration.tcl
    ├── LibwebsocketsTargets.cmake
    ├── LwsCheckRequirements.cmake
    ├── Makefile
    ├── Testing
    ├── bin
    ├── cmake_install.cmake
    ├── include
    ├── lib
    ├── libwebsockets-config-version.cmake
    ├── libwebsockets-config.cmake
    ├── libwebsockets.pc
    ├── libwebsockets_static.pc
    ├── lws_config.h
    ├── lws_config_private.h
    ├── lwsws
    ├── plugins
    ├── share
    └── test-apps
```

but the SITL project depends on libwebsockets' generated header in `obj/main/libwebsockets/include` which needs to be build prior to SITL!

MR is a draft and untested, but builds if make is called manually in `obj/main/libwebsockets` before the final `make TARGET=SITL` call.