### PR TITLE
add spi nor flash support winbond W25Q64JW

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -106,6 +106,9 @@ struct {
     // Datasheet: https://www.winbond.com/resource-files/w25q64jv%20spi%20%20%20revc%2006032016%20kms.pdf
     { 0xEF4017, 133, 50, 128, 256 }, // W25Q64JV-IQ/JQ
     { 0xEF7017, 133, 50, 128, 256 }, // W25Q64JV-IM/JM*
+    // Datasheet: https://www.winbond.com/resource-files/W25Q64JW%20RevE%2003102021%20Plus.pdf
+    { 0xEF6017, 133, 50, 128, 256 }, // W25Q64JW-IQ
+    { 0xEF8017, 133, 50, 128, 256 }, // W25Q64JW-IM*
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     { 0xEF4018, 104, 50, 256, 256 },

--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -107,8 +107,8 @@ struct {
     { 0xEF4017, 133, 50, 128, 256 }, // W25Q64JV-IQ/JQ
     { 0xEF7017, 133, 50, 128, 256 }, // W25Q64JV-IM/JM*
     // Datasheet: https://www.winbond.com/resource-files/W25Q64JW%20RevE%2003102021%20Plus.pdf
-    { 0xEF6017, 133, 50, 128, 256 }, // W25Q64JW-IQ/JQ
-    { 0xEF8017, 133, 50, 128, 256 }, // W25Q64JW-IM/JM*
+    { 0xEF6017, 104, 50, 128, 256 }, // W25Q64JW-IQ/JQ
+    { 0xEF8017, 104, 50, 128, 256 }, // W25Q64JW-IM/JM*
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     { 0xEF4018, 104, 50, 256, 256 },

--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -107,8 +107,8 @@ struct {
     { 0xEF4017, 133, 50, 128, 256 }, // W25Q64JV-IQ/JQ
     { 0xEF7017, 133, 50, 128, 256 }, // W25Q64JV-IM/JM*
     // Datasheet: https://www.winbond.com/resource-files/W25Q64JW%20RevE%2003102021%20Plus.pdf
-    { 0xEF6017, 133, 50, 128, 256 }, // W25Q64JW-IQ
-    { 0xEF8017, 133, 50, 128, 256 }, // W25Q64JW-IM*
+    { 0xEF6017, 133, 50, 128, 256 }, // W25Q64JW-IQ/JQ
+    { 0xEF8017, 133, 50, 128, 256 }, // W25Q64JW-IM/JM*
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     { 0xEF4018, 104, 50, 256, 256 },


### PR DESCRIPTION
Hello Team,

I've implemented support for the Winbond W25Q64JW SPI NOR Flash for repository. This addition will enhancing hardware compatibility and providing users with more storage options.

### Key change
- Add `W25Q64JW` JEDEC device ID to [flash_m25p16.c](https://github.com/betaflight/betaflight/blob/master/src/main/drivers/flash/flash_m25p16.c).

### Testing
- We already tested in our borad using `W25Q64JW` as blackbox and passed.