### PR TITLE
MSP Range Finder added (configured and tested on the MTF-01P Lidar)

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -134,6 +134,7 @@ COMMON_SRC = \
             io/transponder_ir.c \
             io/usb_cdc_hid.c \
             io/usb_msc.c \
+            io/rangefinder_msp.c \
             msp/msp.c \
             msp/msp_box.c \
             msp/msp_build_info.c \
@@ -232,6 +233,7 @@ COMMON_SRC = \
             drivers/light_ws2811strip.c \
             drivers/rangefinder/rangefinder_hcsr04.c \
             drivers/rangefinder/rangefinder_lidartf.c \
+            drivers/rangefinder/rangefinder_virtual.c \
             drivers/serial_escserial.c \
             drivers/vtx_common.c \
             drivers/vtx_table.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -166,7 +166,7 @@ const char * const lookupTableMagHardware[] = {
 #endif
 #if defined(USE_SENSOR_NAMES) || defined(USE_RANGEFINDER)
 const char * const lookupTableRangefinderHardware[] = {
-    "NONE", "HCSR04", "TFMINI", "TF02"
+    "NONE", "HCSR04", "TFMINI", "TF02", "MSP"
 };
 #endif
 

--- a/src/main/drivers/rangefinder/rangefinder_virtual.c
+++ b/src/main/drivers/rangefinder/rangefinder_virtual.c
@@ -1,0 +1,79 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+/*
+ * This is a bridge driver between a sensor reader that operates at high level (i.e. on top of UART)
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <platform.h>
+
+#include "build/build_config.h"
+
+#include "common/utils.h"
+
+#include "drivers/rangefinder/rangefinder_virtual.h"
+
+static const virtualRangefinderVTable_t * highLevelDeviceVTable = NULL;
+
+static void virtualRangefinderInit(rangefinderDev_t * dev)
+{
+    UNUSED(dev);
+    return highLevelDeviceVTable->init();
+}
+
+static void virtualRangefinderUpdate(rangefinderDev_t * dev)
+{
+    UNUSED(dev);
+    return highLevelDeviceVTable->update();
+}
+
+static int32_t virtualRangefinderGetDistance(rangefinderDev_t * dev)
+{
+    UNUSED(dev);
+    return highLevelDeviceVTable->read();
+}
+
+bool virtualRangefinderDetect(rangefinderDev_t * dev, const virtualRangefinderVTable_t * vtable)
+{
+    if (vtable && vtable->detect()) {
+        highLevelDeviceVTable = vtable;
+
+        dev->delayMs = RANGEFINDER_VIRTUAL_TASK_PERIOD_MS;
+        dev->maxRangeCm = RANGEFINDER_VIRTUAL_MAX_RANGE_CM;
+        dev->detectionConeDeciDegrees = RANGEFINDER_VIRTUAL_DETECTION_CONE_DECIDEGREES;
+        dev->detectionConeExtendedDeciDegrees = RANGEFINDER_VIRTUAL_DETECTION_CONE_DECIDEGREES;
+
+        dev->init = &virtualRangefinderInit;
+        dev->update = &virtualRangefinderUpdate;
+        dev->read = &virtualRangefinderGetDistance;
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/main/drivers/rangefinder/rangefinder_virtual.h
+++ b/src/main/drivers/rangefinder/rangefinder_virtual.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+#include "drivers/rangefinder/rangefinder.h"
+// the following values are from the MTF-01P Lidar
+// TODO: the parameters should be configrable to support other MSP Lidars
+#define RANGEFINDER_VIRTUAL_MAX_RANGE_CM                1200
+#define RANGEFINDER_VIRTUAL_TASK_PERIOD_MS  100
+
+// this value is taken from INAV, I tried to use 15 (according the dataset of MTTF-01P) but no readings were received 
+#define RANGEFINDER_VIRTUAL_DETECTION_CONE_DECIDEGREES  900 
+
+typedef struct virtualRangefinderVTable_s {
+    bool (*detect)(void);
+    void (*init)(void);
+    void (*update)(void);
+    int32_t (*read)(void);
+} virtualRangefinderVTable_t;
+
+bool virtualRangefinderDetect(rangefinderDev_t * dev, const virtualRangefinderVTable_t * vtable);

--- a/src/main/io/rangefinder.h
+++ b/src/main/io/rangefinder.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "sensors/rangefinder.h"
+#include "drivers/rangefinder/rangefinder_virtual.h"
+
+extern virtualRangefinderVTable_t rangefinderMSPVtable;
+extern virtualRangefinderVTable_t rangefinderBenewakeVtable;
+extern virtualRangefinderVTable_t rangefinderUSD1Vtable;
+extern virtualRangefinderVTable_t rangefinderNanoradarVtable; //NRA15/NRA24
+extern virtualRangefinderVTable_t rangefinderFakeVtable;
+
+void mspRangefinderReceiveNewData(uint8_t * bufferPtr);
+void fakeRangefindersSetData(int32_t data);

--- a/src/main/io/rangefinder_msp.c
+++ b/src/main/io/rangefinder_msp.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <math.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+#include "build/debug.h"
+
+#include "common/maths.h"
+
+#include "io/serial.h"
+
+#if defined(USE_RANGEFINDER_MSP)
+
+#include "drivers/rangefinder/rangefinder_virtual.h"
+#include "drivers/time.h"
+#include "io/rangefinder.h"
+#include "msp/msp_protocol_v2_sensor_msg.h"
+
+
+static bool hasNewData = false;
+static int32_t sensorData = RANGEFINDER_NO_NEW_DATA;
+
+static bool mspRangefinderDetect(void)
+{
+    // Always detectable
+    return true;
+}
+
+static void mspRangefinderInit(void)
+{
+}
+
+static void mspRangefinderUpdate(void)
+{
+}
+
+static int32_t mspRangefinderGetDistance(void)
+{
+    if (hasNewData) {
+        hasNewData = false;
+        return (sensorData > 0) ? sensorData : RANGEFINDER_OUT_OF_RANGE;
+    }
+    else {
+        return RANGEFINDER_NO_NEW_DATA;
+    }
+}
+
+void mspRangefinderReceiveNewData(uint8_t * bufferPtr)
+{
+    const mspSensorRangefinderDataMessage_t * pkt = (const mspSensorRangefinderDataMessage_t *)bufferPtr;
+
+    sensorData = pkt->distanceMm / 10;
+    hasNewData = true;
+}
+
+virtualRangefinderVTable_t rangefinderMSPVtable = {
+    .detect = mspRangefinderDetect,
+    .init = mspRangefinderInit,
+    .update = mspRangefinderUpdate,
+    .read = mspRangefinderGetDistance
+};
+
+#endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -106,6 +106,7 @@
 #include "io/vtx_control.h"
 #include "io/vtx.h"
 #include "io/vtx_msp.h"
+#include "io/rangefinder.h"
 
 #include "msp/msp_box.h"
 #include "msp/msp_build_info.h"
@@ -3296,6 +3297,12 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         break;
 
+#ifdef USE_RANGEFINDER
+            rangefinderConfigMutable()->rangefinder_hardware = sbufReadU8(src);
+#else
+            sbufReadU8(src);        // rangefinder hardware
+#endif
+        break;
 #ifdef USE_ACC
     case MSP_ACC_CALIBRATION:
         if (!ARMING_FLAG(ARMED))
@@ -3646,6 +3653,11 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         break;
 #endif
 
+#if defined(USE_RANGEFINDER_MSP)
+    case MSP2_SENSOR_RANGEFINDER:
+        mspRangefinderReceiveNewData(sbufPtr(src));
+        break;
+#endif
 #ifdef USE_GPS
     case MSP2_SENSOR_GPS:
         (void)sbufReadU8(src);              // instance

--- a/src/main/msp/msp_protocol_v2_common.h
+++ b/src/main/msp/msp_protocol_v2_common.h
@@ -23,3 +23,4 @@
 
 // Sensors
 #define MSP2_SENSOR_GPS                 0x1F03
+#define MSP2_SENSOR_RANGEFINDER         0x1F01

--- a/src/main/msp/msp_protocol_v2_sensor_msg.h
+++ b/src/main/msp/msp_protocol_v2_sensor_msg.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+typedef struct __attribute__((packed)) {
+    uint8_t quality;    // [0;255]
+    int32_t motionX;
+    int32_t motionY;
+} mspSensorOpflowDataMessage_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t quality;    // [0;255]
+    int32_t distanceMm; // Negative value for out of range
+} mspSensorRangefinderDataMessage_t;

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -41,6 +41,7 @@
 #include "drivers/rangefinder/rangefinder.h"
 #include "drivers/rangefinder/rangefinder_hcsr04.h"
 #include "drivers/rangefinder/rangefinder_lidartf.h"
+#include "drivers/rangefinder/rangefinder_virtual.h"
 #include "drivers/time.h"
 
 #include "fc/runtime_config.h"
@@ -53,6 +54,7 @@
 #include "sensors/sensors.h"
 #include "sensors/rangefinder.h"
 #include "sensors/battery.h"
+#include "io/rangefinder.h"
 
 //#include "uav_interconnect/uav_interconnect.h"
 
@@ -125,7 +127,15 @@ static bool rangefinderDetect(rangefinderDev_t * dev, uint8_t rangefinderHardwar
             }
 #endif
             break;
-
+   
+         case RANGEFINDER_MSP:
+#if defined(USE_RANGEFINDER_MSP)
+            if (virtualRangefinderDetect(dev, &rangefinderMSPVtable)) {
+                rangefinderHardware = RANGEFINDER_MSP;
+                rescheduleTask(TASK_RANGEFINDER, TASK_PERIOD_MS(RANGEFINDER_VIRTUAL_TASK_PERIOD_MS));
+            }
+#endif
+            break;
         case RANGEFINDER_NONE:
             rangefinderHardware = RANGEFINDER_NONE;
             break;

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -31,6 +31,7 @@ typedef enum {
     RANGEFINDER_HCSR04      = 1,
     RANGEFINDER_TFMINI      = 2,
     RANGEFINDER_TF02        = 3,
+    RANGEFINDER_MSP         = 4,
 } rangefinderType_e;
 
 typedef struct rangefinderConfig_s {


### PR DESCRIPTION
Summary: 
The MSP Range finder module is added from INAV to Betaflight, it is tested on the Lidar sensor MTF-01P.

How to use it:
- The following defines should be defined in the configs before building the project: 
        #define USE_RANGEFINDER
        #define USE_RANGEFINDER_MSP
- The sensor should be connected to a UART port with the MSP enabled in the configurator for this port.
- from the CLI, the following commands should be called:
        feature RANGEFINDER
        set rangefinder_hardware = MSP
       
Then, you should be able to get readings from the sensor plotted on the sensors page in the configurator.

Hardware used for testing:
FC: SPEEDYBEEF7V3
LIDAR: MTF-01P

Note:
With my wiring setup, the sensor worked only when I connected the battery.