### PR TITLE
Reduce number of multiplications / divisions during filter cycle

### DIFF
--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -90,7 +90,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
     rpmFilter.minHz = config->rpm_filter_min_hz;
     rpmFilter.maxHz = 0.48f * 1e6f / looptimeUs; // don't go quite to nyquist to avoid oscillations
     rpmFilter.fadeRangeHz = config->rpm_filter_fade_range_hz;
-    rpmFilter.fadeRangeHzInv = 1.0f / config->rpm_filter_fade_range_hz;
+    rpmFilter.fadeRangeHzInv = config->rpm_filter_fade_range_hz == 0 ? 0.0f : (1.0f / config->rpm_filter_fade_range_hz);
     rpmFilter.q = config->rpm_filter_q / 100.0f;
     rpmFilter.looptimeUs = looptimeUs;
 


### PR DESCRIPTION
This PR replaces float division by multiplication in rpm filter code. It also removes an extra multiplication in rpmFilterUpdate().
I'm assuming that float division is slower than multiplication. My smoke tests on F405 controller doesn't show any noticeable improvements in overall CPU usage though. 