### PR TITLE
Change default I2C adddress for IST8310

### DIFF
--- a/src/main/drivers/compass/compass_ist8310.c
+++ b/src/main/drivers/compass/compass_ist8310.c
@@ -44,7 +44,7 @@
 
 //#define DEBUG_MAG_DATA_READY_INTERRUPT
 
-#define IST8310_MAG_I2C_ADDRESS 0x0C
+#define IST8310_MAG_I2C_ADDRESS 0x0E
 
 /* ist8310 Slave Address Select : default address 0x0C
  *        CAD1  |  CAD0   |  Address


### PR DESCRIPTION
Most I8310 compass units I have seen use I2C address 0xE (14) by default. This change eases configuration for those devices.