### PR TITLE
Make three attempts to not only write to FLASH, but also validate it

### DIFF
--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -509,7 +509,7 @@ void writeConfigToEEPROM(void)
     bool success = false;
     // write it
     for (int attempt = 0; attempt < 3 && !success; attempt++) {
-        if (writeSettingsToEEPROM()) {
+        if (writeSettingsToEEPROM() && isEEPROMVersionValid() && isEEPROMStructureValid()) {
             success = true;
 
 #if defined(CONFIG_IN_EXTERNAL_FLASH) || defined(CONFIG_IN_MEMORY_MAPPED_FLASH)
@@ -523,8 +523,7 @@ void writeConfigToEEPROM(void)
         }
     }
 
-
-    if (success && isEEPROMVersionValid() && isEEPROMStructureValid()) {
+    if (success) {
         return;
     }
 


### PR DESCRIPTION
H7 sometimes hangs after a FLASH write when is reads 0xff from FLASH when validating the config. A power cycle fixes this, so the FLASH isn't actually corrupt. This PR stops that happening.