### PR TITLE
linearize the output thrust offset of the PID in the althold mode

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1835,10 +1835,11 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_HOVER_THROTTLE,      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1100, 1700 }, PG_AUTOPILOT, offsetof(autopilotConfig_t, hover_throttle) },
     { PARAM_NAME_THROTTLE_MIN,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1050, 1400 }, PG_AUTOPILOT, offsetof(autopilotConfig_t, throttle_min) },
     { PARAM_NAME_THROTTLE_MAX,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1400, 2000 }, PG_AUTOPILOT, offsetof(autopilotConfig_t, throttle_max) },
-    { PARAM_NAME_ALTITUDE_P,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_P) },
-    { PARAM_NAME_ALTITUDE_I,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_I) },
-    { PARAM_NAME_ALTITUDE_D,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_D) },
-    { PARAM_NAME_ALTITUDE_F,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_F) },
+    { PARAM_NAME_ALTITUDE_P,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_P) },
+    { PARAM_NAME_ALTITUDE_I,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_I) },
+    { PARAM_NAME_ALTITUDE_D,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_D) },
+    { PARAM_NAME_ALTITUDE_F,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_F) },
+    { PARAM_NAME_LINEARIZE_THRUST,    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1    },    PG_AUTOPILOT, offsetof(autopilotConfig_t, linearize_thrust) },
 
 // PG_MODE_ACTIVATION_CONFIG
 #if defined(USE_CUSTOM_BOX_NAMES)

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1835,10 +1835,10 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_HOVER_THROTTLE,      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1100, 1700 }, PG_AUTOPILOT, offsetof(autopilotConfig_t, hover_throttle) },
     { PARAM_NAME_THROTTLE_MIN,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1050, 1400 }, PG_AUTOPILOT, offsetof(autopilotConfig_t, throttle_min) },
     { PARAM_NAME_THROTTLE_MAX,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1400, 2000 }, PG_AUTOPILOT, offsetof(autopilotConfig_t, throttle_max) },
-    { PARAM_NAME_ALTITUDE_P,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_P) },
-    { PARAM_NAME_ALTITUDE_I,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_I) },
-    { PARAM_NAME_ALTITUDE_D,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_D) },
-    { PARAM_NAME_ALTITUDE_F,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_F) },
+    { PARAM_NAME_ALTITUDE_P,          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_P) },
+    { PARAM_NAME_ALTITUDE_I,          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_I) },
+    { PARAM_NAME_ALTITUDE_D,          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_D) },
+    { PARAM_NAME_ALTITUDE_F,          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, altitude_F) },
     { PARAM_NAME_LINEARIZE_THRUST,    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1    },    PG_AUTOPILOT, offsetof(autopilotConfig_t, linearize_thrust) },
 
 // PG_MODE_ACTIVATION_CONFIG

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -167,6 +167,7 @@
 #define PARAM_NAME_ALTITUDE_I "autopilot_altitude_I"
 #define PARAM_NAME_ALTITUDE_D "autopilot_altitude_D"
 #define PARAM_NAME_ALTITUDE_F "autopilot_altitude_F"
+#define PARAM_NAME_LINEARIZE_THRUST "autopilot_linearize_thrust"
 
 #define PARAM_NAME_ANGLE_FEEDFORWARD "angle_feedforward"
 #define PARAM_NAME_ANGLE_FF_SMOOTHING_MS "angle_feedforward_smoothing_ms"

--- a/src/main/flight/autopilot.c
+++ b/src/main/flight/autopilot.c
@@ -69,9 +69,10 @@ void altitudeControl(float targetAltitudeCm, float taskIntervalS, float vertical
     
     float throttleOffset = altitudeP + altitudeI - altitudeD + altitudeF;
 
+    // square root the throttle offset to linearize the change in thrust
     if(autopilotConfig()->linearize_thrust) {
         const float sign = (throttleOffset < 0.0f) ? -1.0f : 1.0f;
-        throttleOffset = sign * sqrtf(fabsf(throttleOffset)); // square root throttle to linearize the thrust
+        throttleOffset = sign * sqrtf(fabsf(throttleOffset));
     }
     
     const float hoverOffset = autopilotConfig()->hover_throttle - PWM_RANGE_MIN;

--- a/src/main/flight/autopilot.c
+++ b/src/main/flight/autopilot.c
@@ -69,10 +69,11 @@ void altitudeControl(float targetAltitudeCm, float taskIntervalS, float vertical
     
     float throttleOffset = altitudeP + altitudeI - altitudeD + altitudeF;
 
-    const float sign = (throttleOffset < 0.0f) ? -1.0f : 1.0f;
-
-    throttleOffset = sign * sqrtf(fabsf(throttleOffset)); // square root throttle to linearize the thrust
-
+    if(autopilotConfig()->linearize_thrust) {
+        const float sign = (throttleOffset < 0.0f) ? -1.0f : 1.0f;
+        throttleOffset = sign * sqrtf(fabsf(throttleOffset)); // square root throttle to linearize the thrust
+    }
+    
     const float hoverOffset = autopilotConfig()->hover_throttle - PWM_RANGE_MIN;
 
     throttleOffset += hoverOffset;

--- a/src/main/flight/autopilot.c
+++ b/src/main/flight/autopilot.c
@@ -66,10 +66,17 @@ void altitudeControl(float targetAltitudeCm, float taskIntervalS, float vertical
     const float altitudeD = verticalVelocity * altitudePidCoeffs.Kd;
 
     const float altitudeF = targetAltitudeStep * altitudePidCoeffs.Kf;
+    
+    float throttleOffset = altitudeP + altitudeI - altitudeD + altitudeF;
+
+    const float sign = (throttleOffset < 0.0f) ? -1.0f : 1.0f;
+
+    throttleOffset = sign * sqrtf(fabsf(throttleOffset)); // square root throttle to linearize the thrust
 
     const float hoverOffset = autopilotConfig()->hover_throttle - PWM_RANGE_MIN;
 
-    float throttleOffset = altitudeP + altitudeI - altitudeD + altitudeF + hoverOffset;
+    throttleOffset += hoverOffset;
+
     const float tiltMultiplier = 2.0f - fmaxf(getCosTiltAngle(), 0.5f);
     // 1 = flat, 1.24 at 40 degrees, max 1.5 around 60 degrees, the default limit of Angle Mode
     // 2 - cos(x) is between 1/cos(x) and 1/sqrt(cos(x)) in this range

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -38,4 +38,5 @@ PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .altitude_I = 15,
     .altitude_D = 15,
     .altitude_F = 15,
+    .linearize_thrust = 0,
 );

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -33,6 +33,7 @@ typedef struct autopilotConfig_s {
     uint8_t altitude_I;
     uint8_t altitude_D;
     uint8_t altitude_F;
+    uint8_t linearize_thrust;
 } autopilotConfig_t;
 
 PG_DECLARE(autopilotConfig_t, autopilotConfig);

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -29,10 +29,10 @@ typedef struct autopilotConfig_s {
     uint16_t hover_throttle;      // value used at the start of a rescue or position hold
     uint16_t throttle_min;
     uint16_t throttle_max;
-    uint8_t altitude_P;
-    uint8_t altitude_I;
-    uint8_t altitude_D;
-    uint8_t altitude_F;
+    uint16_t altitude_P;
+    uint16_t altitude_I;
+    uint16_t altitude_D;
+    uint16_t altitude_F;
     uint8_t linearize_thrust;
 } autopilotConfig_t;
 


### PR DESCRIPTION
This PR follows the advice introduced in (this conversation)[https://github.com/betaflight/betaflight/pull/13982#issuecomment-2426973310] by @ledvinap for better altitude hold PID.

This feature simply square-roots the output of the PID in the altitude hold mode to linearize the propellers' thrust, which leads to a smooth correction of the error.

In my experiments, tuning the PID became much easier.