### PR TITLE
PreArm allow Re-Arm (without resetting PreArm AUX)

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1046,7 +1046,7 @@ const clivalue_t valueTable[] = {
 // PG_ARMING_CONFIG
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
-    { PARAM_NAME_PREARM_UNTIL_FIRST_ARM, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_until_first_arm) },
+    { PARAM_NAME_PREARM_ALLOW_REARM, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_allow_rearm) },
 // PG_GPS_CONFIG
 #ifdef USE_GPS
     { PARAM_NAME_GPS_PROVIDER,               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_PROVIDER },   PG_GPS_CONFIG, offsetof(gpsConfig_t, provider) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1046,7 +1046,7 @@ const clivalue_t valueTable[] = {
 // PG_ARMING_CONFIG
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
-    { PARAM_NAME_PREARM_UNTIL_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_until_first_arm) },
+    { PARAM_NAME_PREARM_UNTIL_FIRST_ARM, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_until_first_arm) },
 // PG_GPS_CONFIG
 #ifdef USE_GPS
     { PARAM_NAME_GPS_PROVIDER,               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_PROVIDER },   PG_GPS_CONFIG, offsetof(gpsConfig_t, provider) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1046,7 +1046,7 @@ const clivalue_t valueTable[] = {
 // PG_ARMING_CONFIG
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
-
+    { PARAM_NAME_PREARM_UNTIL_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_until_first_arm) },
 // PG_GPS_CONFIG
 #ifdef USE_GPS
     { PARAM_NAME_GPS_PROVIDER,               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_PROVIDER },   PG_GPS_CONFIG, offsetof(gpsConfig_t, provider) },

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -373,7 +373,7 @@ void updateArmingStatus(void)
         }
 
         if (isModeActivationConditionPresent(BOXPREARM)) {
-            if (IS_RC_MODE_ACTIVE(BOXPREARM) && !ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {
+            if ((IS_RC_MODE_ACTIVE(BOXPREARM) || (armingConfig()->prearm_until_first_arm && ARMING_FLAG(WAS_EVER_ARMED))) && !ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {
                 unsetArmingDisabled(ARMING_DISABLED_NOPREARM);
             } else {
                 setArmingDisabled(ARMING_DISABLED_NOPREARM);

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -373,7 +373,7 @@ void updateArmingStatus(void)
         }
 
         if (isModeActivationConditionPresent(BOXPREARM)) {
-            if ((IS_RC_MODE_ACTIVE(BOXPREARM) || (armingConfig()->prearm_until_first_arm && ARMING_FLAG(WAS_EVER_ARMED))) && !ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {
+            if (IS_RC_MODE_ACTIVE(BOXPREARM) && (!ARMING_FLAG(WAS_ARMED_WITH_PREARM) || armingConfig()->prearm_allow_rearm) ) {
                 unsetArmingDisabled(ARMING_DISABLED_NOPREARM);
             } else {
                 setArmingDisabled(ARMING_DISABLED_NOPREARM);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -90,6 +90,7 @@
 #define PARAM_NAME_THROTTLE_LIMIT_TYPE "throttle_limit_type"
 #define PARAM_NAME_THROTTLE_LIMIT_PERCENT "throttle_limit_percent"
 #define PARAM_NAME_GYRO_CAL_ON_FIRST_ARM "gyro_cal_on_first_arm"
+#define PARAM_NAME_PREARM_UNTIL_FIRST_ARM "prearm_until_first_arm"
 #define PARAM_NAME_DEADBAND "deadband"
 #define PARAM_NAME_YAW_DEADBAND "yaw_deadband"
 #define PARAM_NAME_PID_PROCESS_DENOM "pid_process_denom"

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -90,7 +90,7 @@
 #define PARAM_NAME_THROTTLE_LIMIT_TYPE "throttle_limit_type"
 #define PARAM_NAME_THROTTLE_LIMIT_PERCENT "throttle_limit_percent"
 #define PARAM_NAME_GYRO_CAL_ON_FIRST_ARM "gyro_cal_on_first_arm"
-#define PARAM_NAME_PREARM_UNTIL_FIRST_ARM "prearm_until_first_arm"
+#define PARAM_NAME_PREARM_ALLOW_REARM "prearm_allow_rearm"
 #define PARAM_NAME_DEADBAND "deadband"
 #define PARAM_NAME_YAW_DEADBAND "yaw_deadband"
 #define PARAM_NAME_PID_PROCESS_DENOM "pid_process_denom"

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -85,7 +85,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,
-    .auto_disarm_delay = 5
+    .auto_disarm_delay = 5,
+    .prearm_until_first_arm = 0
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -81,7 +81,7 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .yaw_control_reversed = false,
 );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 2);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -86,7 +86,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,
     .auto_disarm_delay = 5,
-    .prearm_until_first_arm = 0
+    .prearm_allow_rearm = 0
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -86,7 +86,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,
     .auto_disarm_delay = 5,
-    .prearm_allow_rearm = 0
+    .prearm_allow_rearm = 0,
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -131,7 +131,7 @@ PG_DECLARE(flight3DConfig_t, flight3DConfig);
 typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
-    uint8_t prearm_until_first_arm;
+    uint8_t prearm_allow_rearm;
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -131,6 +131,7 @@ PG_DECLARE(flight3DConfig_t, flight3DConfig);
 typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
+    uint8_t prearm_until_first_arm;
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);


### PR DESCRIPTION
- Alternative to #13920 by @niksprv
- Arming still requires PreArm switch.
- `set prearm_allow_rearm = ON`, default is `OFF`.
- This allows re-arming mid-air, still **_requiring_** preArm, but without need for PreArm AUX _resetting_.
- TESTED SUCCESSFUL
- Required for mid-air rearm: `set small_angle = 180` (when using ACC)
- **WARNING** - it is very hard to coordinate 0 throttle (**_required_** for arming) in mid-air.

closes #13920