### PR TITLE
AT32F435 SD card support

### DIFF
--- a/lib/main/AT32F43x/middlewares/usbd_class/msc/msc_bot_scsi.c
+++ b/lib/main/AT32F43x/middlewares/usbd_class/msc/msc_bot_scsi.c
@@ -23,6 +23,7 @@
   */
 #include "msc_bot_scsi.h"
 #include "msc_diskio.h"
+#include "usbd_msc_mem.h"
 
 /** @addtogroup AT32F435_437_middlewares_usbd_class
   * @{
@@ -111,6 +112,8 @@ void bot_scsi_init(void *udev)
   pmsc->csw_struct.dCSWDataResidue = 0;
   pmsc->csw_struct.dCSWSignature = 0;
   pmsc->csw_struct.dCSWTag = CSW_BCSWSTATUS_PASS;
+
+  USBD_STORAGE_fops->Init(0);
 
   usbd_flush_tx_fifo(pudev, USBD_MSC_BULK_IN_EPT&0x7F);
 

--- a/src/platform/AT32/mk/AT32F4.mk
+++ b/src/platform/AT32/mk/AT32F4.mk
@@ -124,7 +124,8 @@ MCU_COMMON_SRC = \
             msc/usbd_storage.c \
             msc/usbd_storage_emfat.c \
             msc/emfat.c \
-            msc/emfat_file.c
+            msc/emfat_file.c \
+            msc/usbd_storage_sd_spi.c
 
 SPEED_OPTIMISED_SRC += \
             common/stm32/system.c


### PR DESCRIPTION
Define either USE_FLASH or USE_SDCARD to support FLASH or SDCARD on AT32F435.