### PR TITLE
Add gyro and magnetic custom alignment to MSP

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1035,7 +1035,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_SMALL_ANGLE,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,   180 }, PG_IMU_CONFIG, offsetof(imuConfig_t, small_angle) },
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
-    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -1800, 1800 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3599 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1035,7 +1035,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_SMALL_ANGLE,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,   180 }, PG_IMU_CONFIG, offsetof(imuConfig_t, small_angle) },
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
-    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3599 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0,  3599 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1035,7 +1035,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_SMALL_ANGLE,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,   180 }, PG_IMU_CONFIG, offsetof(imuConfig_t, small_angle) },
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
-    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0,  3599 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -300, 300 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1035,7 +1035,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_SMALL_ANGLE,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,   180 }, PG_IMU_CONFIG, offsetof(imuConfig_t, small_angle) },
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
-    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -30, 30 },  PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -300, 300 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1035,7 +1035,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_SMALL_ANGLE,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,   180 }, PG_IMU_CONFIG, offsetof(imuConfig_t, small_angle) },
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
-    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -300, 300 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT8   | MASTER_VALUE, .config.minmaxUnsigned = { -30, 30 },  PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1036,7 +1036,6 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
     { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -1800, 1800 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
-    { PARAM_NAME_IMU_MAG_INCLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -1800, 1800 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_inclination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1035,7 +1035,8 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_IMU_SMALL_ANGLE,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0,   180 }, PG_IMU_CONFIG, offsetof(imuConfig_t, small_angle) },
     { PARAM_NAME_IMU_PROCESS_DENOM,   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1,     4 }, PG_IMU_CONFIG, offsetof(imuConfig_t, imu_process_denom) },
 #ifdef USE_MAG
-    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0,  3599 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_DECLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -1800, 1800 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_declination) },
+    { PARAM_NAME_IMU_MAG_INCLINATION, VAR_INT16 | MASTER_VALUE, .config.minmaxUnsigned = { -1800, 1800 }, PG_IMU_CONFIG, offsetof(imuConfig_t, mag_inclination) },
 #endif
 
 // PG_ARMING_CONFIG

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -251,4 +251,5 @@
 #define PARAM_NAME_IMU_PROCESS_DENOM "imu_process_denom"
 #ifdef USE_MAG
 #define PARAM_NAME_IMU_MAG_DECLINATION "mag_declination"
+#define PARAM_NAME_IMU_MAG_INCLINATION "mag_inclination"
 #endif

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -249,7 +249,7 @@
 #define PARAM_NAME_IMU_DCM_KI "imu_dcm_ki"
 #define PARAM_NAME_IMU_SMALL_ANGLE "small_angle"
 #define PARAM_NAME_IMU_PROCESS_DENOM "imu_process_denom"
+
 #ifdef USE_MAG
 #define PARAM_NAME_IMU_MAG_DECLINATION "mag_declination"
-#define PARAM_NAME_IMU_MAG_INCLINATION "mag_inclination"
 #endif

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -173,7 +173,7 @@ void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correctio
     imuRuntimeConfig.imuDcmKp = imuConfig()->imu_dcm_kp / 10000.0f;
     imuRuntimeConfig.imuDcmKi = imuConfig()->imu_dcm_ki / 10000.0f;
     // magnetic declination has negative sign (positive clockwise when seen from top)
-    const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination / 10.0f);
+    const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination);
     north_ef.x = cos_approx(imuMagneticDeclinationRad);
     north_ef.y = -sin_approx(imuMagneticDeclinationRad);
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -123,7 +123,8 @@ PG_RESET_TEMPLATE(imuConfig_t, imuConfig,
     .imu_dcm_ki = 0,         // 0.003 * 10000
     .small_angle = DEFAULT_SMALL_ANGLE,
     .imu_process_denom = 2,
-    .mag_declination = 0
+    .mag_declination = 0,
+    .mag_inclination = 0
 );
 
 static void imuQuaternionComputeProducts(quaternion *quat, quaternionProducts *quatProd)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -173,7 +173,7 @@ void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correctio
     imuRuntimeConfig.imuDcmKp = imuConfig()->imu_dcm_kp / 10000.0f;
     imuRuntimeConfig.imuDcmKi = imuConfig()->imu_dcm_ki / 10000.0f;
     // magnetic declination has negative sign (positive clockwise when seen from top)
-    const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination);
+    const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination / 10.0f);
     north_ef.x = cos_approx(imuMagneticDeclinationRad);
     north_ef.y = -sin_approx(imuMagneticDeclinationRad);
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -110,7 +110,7 @@ quaternion offset = QUATERNION_INITIALIZE;
 // absolute angle inclination in multiple of 0.1 degree    180 deg = 1800
 attitudeEulerAngles_t attitude = EULER_INITIALIZE;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 4);
+PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 3);
 
 #ifdef USE_RACE_PRO
 #define DEFAULT_SMALL_ANGLE 180
@@ -124,7 +124,6 @@ PG_RESET_TEMPLATE(imuConfig_t, imuConfig,
     .small_angle = DEFAULT_SMALL_ANGLE,
     .imu_process_denom = 2,
     .mag_declination = 0,
-    .mag_inclination = 0
 );
 
 static void imuQuaternionComputeProducts(quaternion *quat, quaternionProducts *quatProd)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -110,7 +110,7 @@ quaternion offset = QUATERNION_INITIALIZE;
 // absolute angle inclination in multiple of 0.1 degree    180 deg = 1800
 attitudeEulerAngles_t attitude = EULER_INITIALIZE;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 4);
 
 #ifdef USE_RACE_PRO
 #define DEFAULT_SMALL_ANGLE 180

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -60,7 +60,6 @@ typedef struct imuConfig_s {
     uint8_t small_angle;
     uint8_t imu_process_denom;
     int16_t mag_declination;      // Magnetic declination in degrees * 10
-    int16_t mag_inclination;      // Magnetic inclination in degrees * 10
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -59,7 +59,7 @@ typedef struct imuConfig_s {
     uint16_t imu_dcm_ki;          // DCM filter integral gain ( x 10000)
     uint8_t small_angle;
     uint8_t imu_process_denom;
-    int16_t mag_declination;     // Magnetic declination in degrees * 10
+    int8_t mag_declination;       // Magnetic declination in degrees
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -59,7 +59,8 @@ typedef struct imuConfig_s {
     uint16_t imu_dcm_ki;          // DCM filter integral gain ( x 10000)
     uint8_t small_angle;
     uint8_t imu_process_denom;
-    uint16_t mag_declination;     // Magnetic declination in degrees * 10
+    int16_t mag_declination;      // Magnetic declination in degrees * 10
+    int16_t mag_inclination;      // Magnetic inclination in degrees * 10
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);
@@ -88,5 +89,4 @@ void imuSetHasNewData(uint32_t dt);
 
 bool imuQuaternionHeadfreeOffsetSet(void);
 void imuQuaternionHeadfreeTransformVectorEarthToBody(vector3_t *v);
-bool shouldInitializeGPSHeading(void);
 bool isUpright(void);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -59,7 +59,7 @@ typedef struct imuConfig_s {
     uint16_t imu_dcm_ki;          // DCM filter integral gain ( x 10000)
     uint8_t small_angle;
     uint8_t imu_process_denom;
-    int8_t mag_declination;       // Magnetic declination in degrees
+    int16_t mag_declination;      // Magnetic declination in degrees * 10
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -59,7 +59,7 @@ typedef struct imuConfig_s {
     uint16_t imu_dcm_ki;          // DCM filter integral gain ( x 10000)
     uint8_t small_angle;
     uint8_t imu_process_denom;
-    int16_t mag_declination;      // Magnetic declination in degrees * 10
+    uint16_t mag_declination;     // Magnetic declination in degrees * 10
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -59,7 +59,7 @@ typedef struct imuConfig_s {
     uint16_t imu_dcm_ki;          // DCM filter integral gain ( x 10000)
     uint8_t small_angle;
     uint8_t imu_process_denom;
-    uint16_t mag_declination;     // Magnetic declination in degrees * 10
+    int16_t mag_declination;     // Magnetic declination in degrees * 10
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1469,7 +1469,6 @@ case MSP_NAME:
 #ifdef USE_MAG
     case MSP_COMPASS_CONFIG:
         sbufWriteU16(dst, imuConfig()->mag_declination);
-        sbufWriteU16(dst, imuConfig()->mag_inclination);
         sbufWriteU16(dst, compassConfig()->mag_customAlignment.roll);
         sbufWriteU16(dst, compassConfig()->mag_customAlignment.pitch);
         sbufWriteU16(dst, compassConfig()->mag_customAlignment.yaw);
@@ -2874,7 +2873,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #ifdef USE_MAG
     case MSP_SET_COMPASS_CONFIG:
         imuConfigMutable()->mag_declination = sbufReadU16(src);
-        imuConfigMutable()->mag_inclination = sbufReadU16(src);
         compassConfigMutable()->mag_customAlignment.roll = sbufReadU16(src);
         compassConfigMutable()->mag_customAlignment.pitch = sbufReadU16(src);
         compassConfigMutable()->mag_customAlignment.yaw = sbufReadU16(src);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3033,6 +3033,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU16(src);
             sbufReadU16(src);
 #endif
+        }
         break;
     }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1469,9 +1469,6 @@ case MSP_NAME:
 #ifdef USE_MAG
     case MSP_COMPASS_CONFIG:
         sbufWriteU16(dst, imuConfig()->mag_declination);
-        sbufWriteU16(dst, compassConfig()->mag_customAlignment.roll);
-        sbufWriteU16(dst, compassConfig()->mag_customAlignment.pitch);
-        sbufWriteU16(dst, compassConfig()->mag_customAlignment.yaw);
         break;
 #endif
     // Deprecated in favor of MSP_MOTOR_TELEMETY as of API version 1.42
@@ -1852,7 +1849,16 @@ case MSP_NAME:
         sbufWriteU8(dst, gyroDeviceConfig(0)->alignment);
         sbufWriteU8(dst, ALIGN_DEFAULT);
 #endif
-
+        // Added in MSP API 1.47
+#ifdef USE_MAG
+        sbufWriteU16(dst, compassConfig()->mag_customAlignment.roll);
+        sbufWriteU16(dst, compassConfig()->mag_customAlignment.pitch);
+        sbufWriteU16(dst, compassConfig()->mag_customAlignment.yaw);
+#else
+        sbufWriteU16(dst, 0);
+        sbufWriteU16(dst, 0);
+        sbufWriteU16(dst, 0);
+#endif
         break;
     }
     case MSP_ADVANCED_CONFIG:
@@ -2873,9 +2879,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #ifdef USE_MAG
     case MSP_SET_COMPASS_CONFIG:
         imuConfigMutable()->mag_declination = sbufReadU16(src);
-        compassConfigMutable()->mag_customAlignment.roll = sbufReadU16(src);
-        compassConfigMutable()->mag_customAlignment.pitch = sbufReadU16(src);
-        compassConfigMutable()->mag_customAlignment.yaw = sbufReadU16(src);
         break;
 #endif
 
@@ -3018,8 +3021,18 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #else
             gyroDeviceConfigMutable(0)->alignment = gyroAlignment;
 #endif
-
         }
+        // Added in API 1.47
+        if (sbufBytesRemaining(src) >= 6) {
+#ifdef USE_MAG
+            compassConfigMutable()->mag_customAlignment.roll = sbufReadU16(src);
+            compassConfigMutable()->mag_customAlignment.pitch = sbufReadU16(src);
+            compassConfigMutable()->mag_customAlignment.yaw = sbufReadU16(src);
+#else
+            sbufReadU16(src);
+            sbufReadU16(src);
+            sbufReadU16(src);
+#endif
         break;
     }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1469,6 +1469,10 @@ case MSP_NAME:
 #ifdef USE_MAG
     case MSP_COMPASS_CONFIG:
         sbufWriteU16(dst, imuConfig()->mag_declination);
+        sbufWriteU16(dst, imuConfig()->mag_inclination);
+        sbufWriteU16(dst, compassConfig()->mag_customAlignment.roll);
+        sbufWriteU16(dst, compassConfig()->mag_customAlignment.pitch);
+        sbufWriteU16(dst, compassConfig()->mag_customAlignment.yaw);
         break;
 #endif
     // Deprecated in favor of MSP_MOTOR_TELEMETY as of API version 1.42
@@ -2870,6 +2874,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #ifdef USE_MAG
     case MSP_SET_COMPASS_CONFIG:
         imuConfigMutable()->mag_declination = sbufReadU16(src);
+        imuConfigMutable()->mag_inclination = sbufReadU16(src);
+        compassConfigMutable()->mag_customAlignment.roll = sbufReadU16(src);
+        compassConfigMutable()->mag_customAlignment.pitch = sbufReadU16(src);
+        compassConfigMutable()->mag_customAlignment.yaw = sbufReadU16(src);
         break;
 #endif
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1850,6 +1850,23 @@ case MSP_NAME:
         sbufWriteU8(dst, ALIGN_DEFAULT);
 #endif
         // Added in MSP API 1.47
+        switch (gyroConfig()->gyro_to_use) {
+#ifdef USE_MULTI_GYRO
+        case GYRO_CONFIG_USE_GYRO_2:
+            sbufWriteU16(dst, gyroDeviceConfig(1)->customAlignment.roll);
+            sbufWriteU16(dst, gyroDeviceConfig(1)->customAlignment.pitch);
+            sbufWriteU16(dst, gyroDeviceConfig(1)->customAlignment.yaw);
+            break;
+#endif
+        case GYRO_CONFIG_USE_GYRO_BOTH:
+            // for dual-gyro in "BOTH" mode we only read/write gyro 0
+        default:
+            sbufWriteU16(dst, gyroDeviceConfig(0)->customAlignment.roll);
+            sbufWriteU16(dst, gyroDeviceConfig(0)->customAlignment.pitch);
+            sbufWriteU16(dst, gyroDeviceConfig(0)->customAlignment.yaw);
+            break;
+        }
+
 #ifdef USE_MAG
         sbufWriteU16(dst, compassConfig()->mag_customAlignment.roll);
         sbufWriteU16(dst, compassConfig()->mag_customAlignment.pitch);
@@ -3023,6 +3040,24 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         }
         // Added in API 1.47
+        if (sbufBytesRemaining(src) >= 6) {
+            switch (gyroConfig()->gyro_to_use) {
+#ifdef USE_MULTI_GYRO
+            case GYRO_CONFIG_USE_GYRO_2:
+                gyroDeviceConfigMutable(1)->customAlignment.roll = sbufReadU16(src);
+                gyroDeviceConfigMutable(1)->customAlignment.pitch = sbufReadU16(src);
+                gyroDeviceConfigMutable(1)->customAlignment.yaw = sbufReadU16(src);
+                break;
+#endif
+            case GYRO_CONFIG_USE_GYRO_BOTH:
+                // For dual-gyro in "BOTH" mode we'll only update gyro 0
+            default:
+                gyroDeviceConfigMutable(0)->customAlignment.roll = sbufReadU16(src);
+                gyroDeviceConfigMutable(0)->customAlignment.pitch = sbufReadU16(src);
+                gyroDeviceConfigMutable(0)->customAlignment.yaw = sbufReadU16(src);
+                break;
+            }
+        }
         if (sbufBytesRemaining(src) >= 6) {
 #ifdef USE_MAG
             compassConfigMutable()->mag_customAlignment.roll = sbufReadU16(src);


### PR DESCRIPTION
- adds gyro custom alignment to msp
- adds magnetometer custom alignment to msp
- adjust range for magnetic declination
- use existing range for other parameters

| parameter | range |precision |
| --- | ---: |---: |
| `align_board_[RPY]` | -180 - 360 | 0 |
| `gyro_[12]_align_[RPY]` |-3600 - 3600 | 1 |
| `mag_align_[RPY]` | -3600 - 3600 | 1 |
| `mag_declination` | -300 - 300 |1 |
