### PR TITLE
Selected Default Blackbox Fields

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -101,10 +101,18 @@ void checkFlashStop(void);
 #define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_NONE
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 4);
+#define FIELDS_ENABLED_DEFAULT (0 \
+    | (1 << FLIGHT_LOG_FIELD_SELECT_SETPOINT) \
+    | (1 << FLIGHT_LOG_FIELD_SELECT_GYRO) \
+    | (1 << FLIGHT_LOG_FIELD_SELECT_ACC) \
+    | (1 << FLIGHT_LOG_FIELD_SELECT_MOTOR) \
+    | (1 << FLIGHT_LOG_FIELD_SELECT_GYROUNFILT) \
+)
+
+PG_REGISTER_WITH_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 5);
 
 PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
-    .fields_disabled_mask = 0, // default log all fields
+    .fields_disabled_mask = ~FIELDS_ENABLED_DEFAULT,  // invert bits to convert enabled to disabled mask (historic reason)
     .sample_rate = BLACKBOX_RATE_QUARTER,
     .device = DEFAULT_BLACKBOX_DEVICE,
     .mode = BLACKBOX_MODE_NORMAL,


### PR DESCRIPTION
In the past, **all available blackbox fields were enabled by default**. With the amount of available fields, this can cause pretty big log files (considering the usual sample rates of 1.6kHz / 2kHz and considering that some blackbox fields have a lot of channels).

This PR is meant to enable only a handful of fields by default to keep log files more lightweight, for longer recording times and to save some processing power (especially for F4 & F7 boards). Instead of blasting the EEPROM, logging more fields is an active choice by the pilot.

## New Defaults

### Enabled Fields
- SETPOINT
- GYRO
- ACC
- MOTOR
- GYROUNFILT

### Disabled Fields
- PID
- RC_COMMANDS
- BATTERY
- MAG
- ALTITUDE
- RSSI
- DEBUG_LOG
- GPS
- RPM
- SERVO