### PR TITLE
Mag LIS3MDL SPI mode support

### DIFF
--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -96,7 +96,7 @@ PG_REGISTER_WITH_RESET_FN(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 4);
 #define COMPASS_BUS_BUSY_INTERVAL_US 500
 // If we check for new mag data, and there is none, try again in 1000us
 #define COMPASS_RECHECK_INTERVAL_US 1000
-// default compass read interval, for those with no specified ODR, will be TASK_COMPASS_RATE_HZ 
+// default compass read interval, for those with no specified ODR, will be TASK_COMPASS_RATE_HZ
 static uint32_t compassReadIntervalUs = TASK_PERIOD_HZ(TASK_COMPASS_RATE_HZ);
 
 void pgResetFn_compassConfig(compassConfig_t *compassConfig)
@@ -115,7 +115,7 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 // 2. I2C devices are will be handled by address = 0 (per device default).
 // 3. Slave I2C device on SPI gyro
 
-#if defined(USE_SPI_MAG) && (defined(USE_MAG_SPI_HMC5883) || defined(USE_MAG_SPI_AK8963))
+#if defined(USE_SPI_MAG) && (defined(USE_MAG_SPI_HMC5883) || defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_SPI_LIS3MDL))
     compassConfig->mag_busType = BUS_TYPE_SPI;
     compassConfig->mag_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(MAG_SPI_INSTANCE));
     compassConfig->mag_spi_csn = IO_TAG(MAG_CS_PIN);
@@ -247,7 +247,7 @@ bool compassDetect(magDev_t *magDev, uint8_t *alignment)
         FALLTHROUGH;
 
     case MAG_LIS3MDL:
-#if defined(USE_MAG_LIS3MDL)
+#if defined(USE_MAG_LIS3MDL)|| defined(USE_MAG_SPI_LIS3MDL)
         if (dev->bus->busType == BUS_TYPE_I2C) {
             dev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
@@ -502,7 +502,7 @@ uint32_t compassUpdate(timeUs_t currentTimeUs)
                     // there was no movement, and no new calibration values were saved
                     beeper(BEEPER_ACC_CALIBRATION_FAIL); // calibration fail beep
                 }
-                // didMovementStart remains true until next run 
+                // didMovementStart remains true until next run
                 // signal that the calibration process is finalised, whether successful or not, by setting end time to zero
                 magCalProcessActive = false;
             }
@@ -561,7 +561,7 @@ void compassBiasEstimatorInit(compassBiasEstimator_t *cBE, const float lambda_mi
         cBE->U[i][i] = 1.0f;
     }
 
-    compassBiasEstimatorUpdate(cBE, lambda_min, p0); 
+    compassBiasEstimatorUpdate(cBE, lambda_min, p0);
 
     cBE->lambda = lambda_min;
 }
@@ -574,7 +574,7 @@ void compassBiasEstimatorUpdate(compassBiasEstimator_t *cBE, const float lambda_
     // update diagonal entries for faster convergence
     for (unsigned i = 0; i < 4; i++) {
         cBE->D[i] = p0;
-    } 
+    }
 }
 
 // apply one estimation step of the compass bias estimator

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -109,6 +109,9 @@
 #ifndef USE_MAG_LIS3MDL
 #define USE_MAG_LIS3MDL
 #endif
+#ifndef USE_MAG_SPI_LIS3MDL
+#define USE_MAG_SPI_LIS3MDL
+#endif
 #ifndef USE_MAG_AK8963
 #define USE_MAG_AK8963
 #endif


### PR DESCRIPTION
Hey all, we have a flight controller which uses the LIS3MDL mag via SPI. Upon review of the code it seems this isn't supported. This is a draft where we try to implement this. Definitely WIP.

So far: we copied the syntax from other SPI mag drivers, and can now compile betaflight without errors, but we do not yet have a functional driver it seems. Comments and suggestions welcome as we continue.
