### PR TITLE
Change optimization to preserve ITCM RAM

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -198,6 +198,8 @@
 
 #endif // !defined(USE_TELEMETRY)
 
+#define USE_SERVOS
+
 #define USE_VTX
 #define USE_OSD
 #if !defined(USE_OSD_SD) && !defined(USE_OSD_HD)

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -198,8 +198,6 @@
 
 #endif // !defined(USE_TELEMETRY)
 
-#define USE_SERVOS
-
 #define USE_VTX
 #define USE_OSD
 #if !defined(USE_OSD_SD) && !defined(USE_OSD_HD)

--- a/src/platform/STM32/platform_mcu.h
+++ b/src/platform/STM32/platform_mcu.h
@@ -134,7 +134,7 @@
 
 #ifdef STM32F7
 #define USE_ITCM_RAM
-#define ITCM_RAM_OPTIMISATION "-O2", "-freorder-blocks-algorithm=simple"
+#define ITCM_RAM_OPTIMISATION "-Os", "-freorder-blocks-algorithm=simple"
 #define USE_FAST_DATA
 #define USE_RPM_FILTER
 #define USE_DYN_IDLE


### PR DESCRIPTION
PR for testing change of optimization for F7 to preserve ITCM RAM.

Thanks to @SteveCEvans for the suggestion. 