### PR TITLE
Workaround: SERIAL_CHECK_TX is broken on F7

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -436,8 +436,11 @@ void gpsInit(void)
     }
 #endif
     if (serialType(gpsPortConfig->identifier) == SERIALTYPE_UART
-        || serialType(gpsPortConfig->identifier) == SERIALTYPE_LPUART){
+        || serialType(gpsPortConfig->identifier) == SERIALTYPE_LPUART) {
+        // TODO: SERIAL_CHECK_TX is broken on F7, disable it until it is fixed
+#if !defined(STM32F7) || defined(USE_F7_CHECK_TX)
         options |= SERIAL_CHECK_TX;
+#endif
     }
 
     // no callback - buffer will be consumed in gpsUpdate()

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -71,7 +71,10 @@ void mspSerialAllocatePorts(void)
             options |= SERIAL_BIDIR;
         } else if (serialType(portConfig->identifier) == SERIALTYPE_UART
                    || serialType(portConfig->identifier) == SERIALTYPE_LPUART) {
+            // TODO: SERIAL_CHECK_TX is broken on F7, disable it until it is fixed
+#if !defined(STM32F7) || defined(USE_F7_CHECK_TX)
             options |= SERIAL_CHECK_TX;
+#endif
         }
 
         serialPort_t *serialPort = openSerialPort(portConfig->identifier, FUNCTION_MSP, NULL, NULL, baudRates[portConfig->msp_baudrateIndex], MODE_RXTX, options);


### PR DESCRIPTION
SERIAL_CHECK_TX STM32F7 does not configure TX pin as pullup before checking it. This prevents transmission when pin is not pulled up (#13647, #14050). If you need SERIAL_CHECK_TX, define USE_F7_CHECK_TX in build.

This can be reverted when F7 SERIAL_CHECK_TX is fixed.

Fixes #13647, #14050