### PR TITLE
Fixed - reset all PID controller terms when PASSTHRU_MODE is active

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1458,10 +1458,11 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
     }
 
+#ifdef USE_WING
     // When PASSTHRU_MODE is active - reset all PIDs to zero so the aircraft won't snap out of control 
     // because of accumulated PIDs once PASSTHRU_MODE gets disabled.
     bool isFixedWingAndPassthru = isFixedWing() && FLIGHT_MODE(PASSTHRU_MODE);
-
+#endif // USE_WING
     // Disable PID control if at zero throttle or if gyro overflow detected
     // This may look very innefficient, but it is done on purpose to always show real CPU usage as in flight
     if (!pidRuntime.pidStabilisationEnabled

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1464,7 +1464,12 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
     // Disable PID control if at zero throttle or if gyro overflow detected
     // This may look very innefficient, but it is done on purpose to always show real CPU usage as in flight
-    if (!pidRuntime.pidStabilisationEnabled || gyroOverflowDetected() || isFixedWingAndPassthru) {
+    if (!pidRuntime.pidStabilisationEnabled
+        || gyroOverflowDetected()
+#ifdef USE_WING
+        || isFixedWingAndPassthru
+#endif
+        ) {
         for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
             pidData[axis].P = 0;
             pidData[axis].I = 0;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1458,9 +1458,13 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
     }
 
+    // When PASSTHRU_MODE is active - reset all PIDs to zero so the aircraft won't snap out of control 
+    // because of accumulated PIDs once PASSTHRU_MODE gets disabled.
+    float isFixedWingAndPassthru = isFixedWing() && FLIGHT_MODE(PASSTHRU_MODE);
+
     // Disable PID control if at zero throttle or if gyro overflow detected
     // This may look very innefficient, but it is done on purpose to always show real CPU usage as in flight
-    if (!pidRuntime.pidStabilisationEnabled || gyroOverflowDetected()) {
+    if (!pidRuntime.pidStabilisationEnabled || gyroOverflowDetected() || isFixedWingAndPassthru) {
         for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
             pidData[axis].P = 0;
             pidData[axis].I = 0;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1460,7 +1460,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
     // When PASSTHRU_MODE is active - reset all PIDs to zero so the aircraft won't snap out of control 
     // because of accumulated PIDs once PASSTHRU_MODE gets disabled.
-    float isFixedWingAndPassthru = isFixedWing() && FLIGHT_MODE(PASSTHRU_MODE);
+    bool isFixedWingAndPassthru = isFixedWing() && FLIGHT_MODE(PASSTHRU_MODE);
 
     // Disable PID control if at zero throttle or if gyro overflow detected
     // This may look very innefficient, but it is done on purpose to always show real CPU usage as in flight


### PR DESCRIPTION
This fix is wing-focused since the PASSTHRU_MODE is useless for quads and it's actually unavailable for non fixed-wing mixers.

Without this PR main PID controller is active when PASSTHRU_MODE is enabled, it leads to virtually unrestricted I term accumulation. Once PASSTHRU_MODE is disabled the aircraft snaps into uncontrollable manoeuvre dictated by the I term, and it may continue to be uncontrollable for a few seconds while I term is being _un-accumulated_. (In such a case the only thing you can do to save it - is to get back into PASSTHRU_MODE.)

@limonspb fyi