### PR TITLE
Support for apple silicon (M-series) chip. (Right version of Arm GNU toolchain)

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -42,7 +42,6 @@ ifeq ($(OSFAMILY), macosx)
   endif
 endif
 
-
 ifeq ($(OSFAMILY), windows)
   ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip
   ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-mingw-w64-i686-arm-none-eabi

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -31,9 +31,17 @@ ifeq ($(OSFAMILY), linux)
 endif
 
 ifeq ($(OSFAMILY), macosx)
-  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
-  ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-darwin-x86_64-arm-none-eabi
+  # Check for Apple Silicon
+  UNAME_PROCESSOR := $(shell uname -p)
+  ifeq ($(UNAME_PROCESSOR), arm)
+    ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz
+    ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-darwin-arm64-arm-none-eabi
+  else
+    ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
+    ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-darwin-x86_64-arm-none-eabi
+  endif
 endif
+
 
 ifeq ($(OSFAMILY), windows)
   ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip


### PR DESCRIPTION
When running "make arm_sdk_install" it will now install the correct version of Arm GNU toolchain to get it working on never Macs with the apple silicon chipset so you can compile. 