### PR TITLE
Bypass RX FAILSAFE issue in SITL

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -195,8 +195,13 @@ static bool nullProcessFrame(const rxRuntimeState_t *rxRuntimeState)
 
 STATIC_UNIT_TESTED bool isPulseValid(uint16_t pulseDuration)
 {
+#ifndef SIMULATOR_BUILD
     return  pulseDuration >= rxConfig()->rx_min_usec &&
             pulseDuration <= rxConfig()->rx_max_usec;
+#else
+    UNUSED(pulseDuration);
+    return true;
+#endif
 }
 
 #ifdef USE_SERIALRX


### PR DESCRIPTION
I try to use SITL and have RX FAILSAFE issue during simulation. I've checked, the udp connection and data exchange was working.
![RXFailsafe](https://github.com/user-attachments/assets/56ca16fb-7ac9-4b91-b533-f550b66d03a4)

The reason of issue is isPulseValid() checking. The pulse duration is zero in my case and checking gives failsafe result for limit failsafe pulse settings:
![pulsesettings](https://github.com/user-attachments/assets/a872fc3a-5bc7-49c1-b63e-80eb9f340a6c)

The solution is disable pulse check for SIMULATOR build.
I can arm and control my airplane model now.
![Armed](https://github.com/user-attachments/assets/495b4f69-a28b-4507-8f9e-5e86cd85d0cf)


 
