### PR TITLE
OSD - fix macro arguments

### DIFF
--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -74,11 +74,13 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_POSITION_XHD_MASK   (1 << OSD_POSITION_BIT_XHD)
 #define OSD_POSITION_XY_MASK    ((1 << OSD_POSITION_BITS) - 1)
 #define OSD_TYPE_MASK           0xC000  // bits 14-15
-#define OSD_POS(x,y)  ((x & OSD_POSITION_XY_MASK) | ((x << (OSD_POSITION_BIT_XHD - OSD_POSITION_BITS)) & OSD_POSITION_XHD_MASK) | \
-                       ((y & OSD_POSITION_XY_MASK) << OSD_POSITION_BITS))
-#define OSD_X(x)      ((x & OSD_POSITION_XY_MASK) | ((x & OSD_POSITION_XHD_MASK) >> (OSD_POSITION_BIT_XHD - OSD_POSITION_BITS)))
-#define OSD_Y(x)      ((x >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
-#define OSD_TYPE(x)   ((x & OSD_TYPE_MASK) >> 14)
+#define OSD_POS(x, y)  (((x) & OSD_POSITION_XY_MASK)                    \
+                        | (((x) << (OSD_POSITION_BIT_XHD - OSD_POSITION_BITS)) & OSD_POSITION_XHD_MASK) \
+                        | (((y) & OSD_POSITION_XY_MASK) << OSD_POSITION_BITS)) \
+    /**/
+#define OSD_X(x)      (((x) & OSD_POSITION_XY_MASK) | (((x) & OSD_POSITION_XHD_MASK) >> (OSD_POSITION_BIT_XHD - OSD_POSITION_BITS)))
+#define OSD_Y(x)      (((x) >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
+#define OSD_TYPE(x)   (((x) & OSD_TYPE_MASK) >> 14)
 
 #define OSD_SD_COLS VIDEO_COLUMNS_SD
 #define OSD_SD_ROWS VIDEO_LINES_PAL


### PR DESCRIPTION
A lot of code uses parentheses around arguments to these macros, it can be fixed now.
 