### PR TITLE
Adjust BOX3D boxname

### DIFF
--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -75,7 +75,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
     { .boxId = BOXBLACKBOX, .boxName = "BLACKBOX", .permanentId = 26 },
     { .boxId = BOXFAILSAFE, .boxName = "FAILSAFE", .permanentId = 27 },
     { .boxId = BOXAIRMODE, .boxName = "AIR MODE", .permanentId = 28 },
-    { .boxId = BOX3D, .boxName = "3D DISABLE / SWITCH", .permanentId = 29},
+    { .boxId = BOX3D, .boxName = "3D DISABLE", .permanentId = 29},
     { .boxId = BOXFPVANGLEMIX, .boxName = "FPV ANGLE MIX", .permanentId = 30},
     { .boxId = BOXBLACKBOXERASE, .boxName = "BLACKBOX ERASE", .permanentId = 31 },
     { .boxId = BOXCAMERA1, .boxName = "CAMERA CONTROL 1", .permanentId = 32},


### PR DESCRIPTION
- BOX3D boxname was updated in https://github.com/betaflight/betaflight/commit/232fc4e8de3b072fdefa73c3393b9fa7c5029b08#diff-628c92f45024c472bfae24a0418554cea674cd676b407524bf9c9fcfc423444e
- Configurator cannot handle the slash as this field is used as key.