### PR TITLE
MAKE - improvement

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -43,8 +43,8 @@ endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
 # remove compression suffixes
-ARM_SDK_DIR := $(TOOLS_DIR)/$(patsubst %.zip, %, 	\
-			    $(patsubst %.tar.xz, %, 	\
+ARM_SDK_DIR := $(TOOLS_DIR)/$(patsubst %.zip,%, 	\
+			    $(patsubst %.tar.xz,%, 	\
 			    $(notdir $(ARM_SDK_URL))))
 
 SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/.installed

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -42,8 +42,10 @@ else
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
-# remove both suffixes for tar.xz
-ARM_SDK_DIR := $(TOOLS_DIR)/$(basename $(basename $(notdir $(ARM_SDK_URL))))
+# remove compression suffixes
+ARM_SDK_DIR := $(TOOLS_DIR)/$(patsubst %.zip, %, 	\
+			    $(patsubst %.tar.xz, %, 	\
+			    $(notdir $(ARM_SDK_URL))))
 
 SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/.installed
 

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -17,39 +17,35 @@
 ##############################
 
 # Set up ARM (STM32) SDK
-ARM_SDK_BASE_DIR ?= $(TOOLS_DIR)/arm-gnu-toolchain-13.3.rel1
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
+# must match arm-none-eabi-gcc-<version> file in arm sdk distribution
 GCC_REQUIRED_VERSION ?= 13.3.1
 
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
 # source: https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
-ifeq ($(OSFAMILY), linux)
+ifeq ($(OSFAMILY)-$(ARCHFAMILY), linux-x86_64)
   ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
-  ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-x86_64-arm-none-eabi
-endif
-
-ifeq ($(OSFAMILY), macosx)
-  # Check for Apple Silicon
-  UNAME_PROCESSOR := $(shell uname -p)
-  ifeq ($(UNAME_PROCESSOR), arm)
-    ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz
-    ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-darwin-arm64-arm-none-eabi
-  else
-    ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
-    ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-darwin-x86_64-arm-none-eabi
-  endif
-endif
-
-ifeq ($(OSFAMILY), windows)
+  DL_CHECKSUM = 0601a9588bc5b9c99ad2b56133b7f118
+else ifeq ($(OSFAMILY)-$(ARCHFAMILY), macosx-x86_64)
+  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
+  DL_CHECKSUM = 4bb141e44b831635fde4e8139d470f1f
+else ifeq ($(OSFAMILY)-$(ARCHFAMILY), macosx-arm64)
+  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz
+  DL_CHECKSUM = f1c18320bb3121fa89dca11399273f4e
+else ifeq ($(OSFAMILY), windows)
   ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip
-  ARM_SDK_DIR := $(ARM_SDK_BASE_DIR)-mingw-w64-i686-arm-none-eabi
+  DL_CHECKSUM = 39d9882ca0eb475e81170ae826c1435d
+else
+  $(error No toolchain URL defined for $(OSFAMILY)-$(ARCHFAMILY))
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
+# remove both suffixes for tar.xz
+ARM_SDK_DIR := $(TOOLS_DIR)/$(basename $(basename $(notdir $(ARM_SDK_URL))))
 
-SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/bin/arm-none-eabi-gcc-$(GCC_REQUIRED_VERSION)
+SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/.installed
 
 .PHONY: arm_sdk_version
 
@@ -60,19 +56,26 @@ arm_sdk_version: | $(ARM_SDK_DIR)
 arm_sdk_install: | $(TOOLS_DIR)
 arm_sdk_install: arm_sdk_download $(SDK_INSTALL_MARKER)
 
-$(SDK_INSTALL_MARKER):
-ifneq ($(OSFAMILY), windows)
-        # binary only release so just extract it
-	$(V1) tar -C $(TOOLS_DIR) -xf "$(DL_DIR)/$(ARM_SDK_FILE)"
+$(SDK_INSTALL_MARKER): $(DL_DIR)/$(ARM_SDK_FILE)
+        # verify ckecksum first
+	@checksum=$$(md5sum "$<" | awk '{print $$1}'); \
+	if [ "$$checksum" != "$(DL_CHECKSUM)" ]; then \
+		echo "$@ Checksum mismatch! Expected $(DL_CHECKSUM), got $$checksum."; \
+		exit 1; \
+	fi
+ifeq ($(OSFAMILY), windows)
+	$(V1) unzip -q -d $(TOOLS_DIR) "$<"
 else
-	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
+        # binary only release so just extract it
+	$(V1) tar -C $(TOOLS_DIR) -xf "$<"
 endif
+	$(V1) touch $(SDK_INSTALL_MARKER)
 
 .PHONY: arm_sdk_download
 arm_sdk_download: | $(DL_DIR)
 arm_sdk_download: $(DL_DIR)/$(ARM_SDK_FILE)
 $(DL_DIR)/$(ARM_SDK_FILE):
-    # download the source only if it's newer than what we already have
+        # download the source only if it's newer than what we already have
 	$(V1) curl -L -k -o "$@" $(if $(wildcard $@), -z "$@",) "$(ARM_SDK_URL)"
 
 ## arm_sdk_clean     : Uninstall Arm SDK


### PR DESCRIPTION
- specify SDK file for each target pair on linux and macosx
- verify checksum before unpacking downloaded file (curl ignores server certificate)
- infer ARM_SDK_DIR from SDK file name
- detect installed SDK, checking that it is newer than downloaded file (.installed file in SDK dir)
- bugfix - fix unzip on windows (doubly nested SDK directory was created)

