### PR TITLE
./src/utils/ trim trailing whitestpaces

### DIFF
--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -35,7 +35,7 @@
 
 #include "msp/msp_build_info.h"
 
-void sbufWriteBuildInfoFlags(sbuf_t *dst) 
+void sbufWriteBuildInfoFlags(sbuf_t *dst)
 {
     static const uint16_t options[] = {
 #ifdef USE_SERIALRX_CRSF

--- a/src/utils/dfuse-pack.py
+++ b/src/utils/dfuse-pack.py
@@ -3,7 +3,7 @@
 # Written by Antonio Galea - 2010/11/18
 # Distributed under Gnu LGPL 3.0
 # see http://www.gnu.org/licenses/lgpl-3.0.txt
-# 
+#
 # based on a modified version of this script from https://sourceforge.net/p/dfu-util/tickets/35/#357c
 # with the patch supplied in https://sourceforge.net/p/dfu-util/tickets/35/#a2b6
 

--- a/src/utils/make-build-info.py
+++ b/src/utils/make-build-info.py
@@ -33,7 +33,7 @@ SOURCE_FILE_TEMPLATE = """{license_header}
 
 #include "msp/msp_build_info.h"
 
-void sbufWriteBuildInfoFlags(sbuf_t *dst) 
+void sbufWriteBuildInfoFlags(sbuf_t *dst)
 {
     static const uint16_t options[] = {
 {build_options}


### PR DESCRIPTION
- not even important.
- see https://github.com/betaflight/betaflight/pull/14080#discussion_r1878205892
- maybe we should have trimmed all files in #14026 , rather than only `.c` and `.h`.
- i believe there are other files still with trailing whitespaces.
