### PR TITLE
Adjust info/warning status

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -887,6 +887,7 @@ static void osdElementCrashFlipArrow(osdElementParms_t *element)
     }
 
     if ((isCrashFlipModeActive() || (!ARMING_FLAG(ARMED) && !isUpright())) && !((imuConfig()->small_angle < 180 && isUpright()) || (rollAngle == 0 && pitchAngle == 0))) {
+        element->attr = DISPLAYPORT_SEVERITY_INFO;
         if (abs(pitchAngle) < 2 * abs(rollAngle) && abs(rollAngle) < 2 * abs(pitchAngle)) {
             if (pitchAngle > 0) {
                 if (rollAngle > 0) {
@@ -1167,7 +1168,7 @@ static void osdElementGpsSats(osdElementParms_t *element)
     }
 #endif
     else {
-        element->attr = DISPLAYPORT_SEVERITY_INFO;
+        element->attr = DISPLAYPORT_SEVERITY_NORMAL;
     }
 
     if (!gpsIsHealthy()) {

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -139,7 +139,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     if (osdWarnGetState(OSD_WARNING_CRASHFLIP) && IS_RC_MODE_ACTIVE(BOXCRASHFLIP)) {
         if (isCrashFlipModeActive()) { // if was armed in crashflip mode
             tfp_sprintf(warningText, CRASHFLIP_WARNING);
-            *displayAttr = DISPLAYPORT_SEVERITY_INFO;
+            *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
             return;
         } else if (!ARMING_FLAG(ARMED)) { // if disarmed, but crashflip mode is activated (not allowed / can't happen)
             tfp_sprintf(warningText, "CRASHFLIP SW");
@@ -420,7 +420,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     if (osdWarnGetState(OSD_WARNING_BATTERY_NOT_FULL) && !(ARMING_FLAG(ARMED) || ARMING_FLAG(WAS_EVER_ARMED)) && (getBatteryState() == BATTERY_OK)
           && getBatteryAverageCellVoltage() < batteryConfig()->vbatfullcellvoltage) {
         tfp_sprintf(warningText, "BATT < FULL");
-        *displayAttr = DISPLAYPORT_SEVERITY_INFO;
+        *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
         return;
     }
 


### PR DESCRIPTION
Adjusted a few OSD elements with respect to their severity.

1. GPS satellite count is shown in white (DISPLAYPORT_SEVERITY_NORMAL) rather than green (DISPLAYPORT_SEVERITY_INFO) if normal as it rather stands out at present.
2. Crashflip arrow is displayed in green (DISPLAYPORT_SEVERITY_INFO) as it's good to draw one's eye to it when active
3. Crashflip switch warning text, `CRASHFLIP SW`, is shown in green (DISPLAYPORT_SEVERITY_INFO) when active, but disarmed, and amber (DISPLAYPORT_SEVERITY_WARNING) when armed, `>CRASH FLIP<`.
4. 'BATT<FULL' warning is displayed in amber ( DISPLAYPORT_SEVERITY_WARNING)