### PR TITLE
Add a configurable delay before MSP status changes from ARMED to DISARMED

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1664,6 +1664,8 @@ const clivalue_t valueTable[] = {
     { "displayport_msp_row_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -3, 0 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, rowAdjust) },
     { "displayport_msp_fonts",      VAR_UINT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = 4, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, fontSelection) },
     { "displayport_msp_use_device_blink",   VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, useDeviceBlink) },
+    { "displayport_msp_disarm_delay",       VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 120 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, disarmDelay) },
+
 #endif
 
 // PG_DISPLAY_PORT_MSP_CONFIG

--- a/src/main/pg/displayport_profiles.c
+++ b/src/main/pg/displayport_profiles.c
@@ -37,6 +37,7 @@ void pgResetFn_displayPortProfileMsp(displayPortProfile_t *displayPortProfile)
     for (uint8_t font = 0; font < DISPLAYPORT_SEVERITY_COUNT; font++) {
         displayPortProfile->fontSelection[font] = font;
     }
+    displayPortProfile->disarmDelay = 5;
 }
 
 #endif

--- a/src/main/pg/displayport_profiles.h
+++ b/src/main/pg/displayport_profiles.h
@@ -29,6 +29,7 @@ typedef struct displayPortProfile_s {
     bool invert;
     uint8_t blackBrightness;
     uint8_t whiteBrightness;
+    uint8_t disarmDelay;
 
     // For attribute-rich OSDs
 


### PR DESCRIPTION
Delay reporting **DISARMED** status over MSP by **displayport_msp_disarm_delay** seconds.

This is useful when using digital DVR, because the delay allows you to include crashes and turtle mode recoveries in the DVR footage that would otherwise have been lost.

Fixes #13366

This is a draft version, because it at least needs some feature flags for activation, and project maintainers probably know which flags should be used.

### Side effects

Reporting incorrect status flags over MSP might have some side effects, need to see if they are critical. It's not obvious to me how to distinguish **getBoxIdState** being called from VTX MSP code path vs other possible paths (non-VTX MSP and pinio).