### PR TITLE
Don't handle non-MSP characters on VTX MSP port

### DIFF
--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -51,12 +51,6 @@ static int output(displayPort_t *displayPort, uint8_t cmd, uint8_t *buf, int len
 {
     UNUSED(displayPort);
 
-#ifdef USE_CLI
-    // FIXME There should be no dependency on the CLI but mspSerialPush doesn't check for cli mode, and can't because it also shouldn't have a dependency on the CLI.
-    if (cliMode) {
-        return 0;
-    }
-#endif
     return mspSerialPush(displayPortSerial, cmd, buf, len, MSP_DIRECTION_REPLY, MSP_V1);
 }
 

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -229,4 +229,8 @@ displayPort_t *displayPortMspInit(void)
 void displayPortMspSetSerial(serialPortIdentifier_e serialPort) {
     displayPortSerial = serialPort;
 }
+
+serialPortIdentifier_e displayPortMspGetSerial(void) {
+    return displayPortSerial;
+}
 #endif // USE_MSP_DISPLAYPORT

--- a/src/main/io/displayport_msp.h
+++ b/src/main/io/displayport_msp.h
@@ -46,4 +46,5 @@ typedef enum {
 
 struct displayPort_s *displayPortMspInit(void);
 void displayPortMspSetSerial(serialPortIdentifier_e serialPort);
+serialPortIdentifier_e displayPortMspGetSerial(void);
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -459,6 +459,7 @@ static void mspProcessPendingRequest(mspPort_t * mspPort)
     case MSP_PENDING_CLI:
         mspPort->pendingRequest = MSP_PENDING_NONE;
         mspPort->portState = PORT_CLI_ACTIVE;
+
         cliEnter(mspPort->port, true);
         break;
 #endif
@@ -537,7 +538,9 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             if (c == '$') {
                 mspPort->portState = PORT_MSP_PACKET;
                 mspPort->packetState = MSP_HEADER_START;
-            } else if (evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) {
+            } else if ((evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) &&
+                       // Don't evaluate non-MSP commands on VTX MSP port
+                       (mspPort->port->identifier != displayPortMspGetSerial())) {
                 // evaluate the non-MSP data
                 if (c == serialConfig()->reboot_character) {
                     mspPort->pendingRequest = MSP_PENDING_BOOTLOADER_ROM;

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -538,9 +538,12 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             if (c == '$') {
                 mspPort->portState = PORT_MSP_PACKET;
                 mspPort->packetState = MSP_HEADER_START;
-            } else if ((evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) &&
+            } else if ((evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA)
+#ifdef USE_MSP_DISPLAYPORT
                        // Don't evaluate non-MSP commands on VTX MSP port
-                       (mspPort->port->identifier != displayPortMspGetSerial())) {
+                       && (mspPort->port->identifier != displayPortMspGetSerial())
+#endif
+                       ) {
                 // evaluate the non-MSP data
                 if (c == serialConfig()->reboot_character) {
                     mspPort->pendingRequest = MSP_PENDING_BOOTLOADER_ROM;


### PR DESCRIPTION
It was observed that the HDZero AIO5 would occasionally suffer from OSD lock up, typically after a minute or so, when not armed. This was found to be due to non-MSP characters, specifically 0x02, resulting in the FC entering CLI mode on that port. Such characters are ignored when the quad is armed so this would not normally be observed, however it could occur where one were waiting for a GPS lock, for example.

The PR adds a check to prevent non-MSP characters being processed on the serial port being used for display port OSD.