### PR TITLE
Position hold depends on GPS

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -483,3 +483,7 @@
 #undef USE_RUNAWAY_TAKEOFF
 
 #endif // USE_WING
+
+#if defined(USE_POSITION_HOLD) && !defined(USE_GPS)
+#undef USE_POSITION_HOLD
+#endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -485,5 +485,5 @@
 #endif // USE_WING
 
 #if defined(USE_POSITION_HOLD) && !defined(USE_GPS)
-#undef USE_POSITION_HOLD
+#error "USE_POSITION_HOLD requires USE_GPS to be defined"
 #endif


### PR DESCRIPTION
Don't we think we can isolate `USE_GPS` code needed in `USE_POSITION_HOLD` code.

- Build `USE_POSITION_HOLD` without `USE_GPS` and we get https://build.betaflight.com/api/builds/7cb7189115187214f14462c8e433601e/log
- Alternative can 
    - either add `USE_GPS` instead 
    - give a more meaningful build error