### PR TITLE
update serTcpOpen declaration to fix compile errors

### DIFF
--- a/src/main/drivers/serial_tcp.h
+++ b/src/main/drivers/serial_tcp.h
@@ -23,6 +23,7 @@
 #include <netinet/in.h>
 #include <pthread.h>
 #include "dyad.h"
+#include "io/serial.h"
 
 #define RX_BUFFER_SIZE    1400
 #define TX_BUFFER_SIZE    1400
@@ -41,7 +42,7 @@ typedef struct {
     uint8_t id;
 } tcpPort_t;
 
-serialPort_t *serTcpOpen(int id, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options);
+serialPort_t *serTcpOpen(serialPortIdentifier_e id, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options);
 
 // tcpPort API
 void tcpDataIn(tcpPort_t *instance, uint8_t* ch, int size);


### PR DESCRIPTION
fix compile error

```console
./src/main/drivers/serial_tcp.c:127:15: error: conflicting types for ‘serTcpOpen’ due to enum/integer mismatch; have ‘serialPort_t *(serialPortIdentifier_e,  void (*)(uint16_t,  void *), void *, uint32_t,  portMode_e,  portOptions_e)’ {aka ‘struct serialPort_s *(serialPortIdentifier_e,  void (*)(short unsigned int,  void *), void *, unsigned int,  portMode_e,  portOptions_e)’} [-Werror=enum-int-mismatch]
  127 | serialPort_t *serTcpOpen(serialPortIdentifier_e identifier, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options)
      |               ^~~~~~~~~~
In file included from ./src/main/drivers/serial_tcp.c:39:
./src/main/drivers/serial_tcp.h:44:15: note: previous declaration of ‘serTcpOpen’ with type ‘serialPort_t *(int,  void (*)(uint16_t,  void *), void *, uint32_t,  portMode_e,  portOptions_e)’ {aka 
 struct serialPort_s *(int,  void (*)(short unsigned int,  void *), void *, unsigned int,  portMode_e,  portOptions_e)’}
   44 | serialPort_t *serTcpOpen(int id, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options);
      |               ^~~~~~~~~~

```
