### PR TITLE
Bump clang version to 18

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -517,7 +517,7 @@ GTEST_DIR = ../../lib/test/gtest
 
 CC  := clang-18
 CXX := clang++-18
-ifeq ($(shell which $(CC) 2>/dev/null && which $(CXX) 2>/dev/null),)
+ifeq ($(and $(shell which $(CC) 2>/dev/null), $(shell which $(CXX) 2>/dev/null)),)
 $(info Falling back to 'clang')
 CC  := clang
 CXX := clang++

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -520,6 +520,9 @@ CXX := clang++-18
 ifeq ($(shell which $(CC) 2>/dev/null),)
 $(info Falling back to 'clang')
 CC  := clang
+endif
+ifeq ($(shell which $(CXX) 2>/dev/null),)
+$(info Falling back to 'clang++')
 CXX := clang++
 endif
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -517,12 +517,9 @@ GTEST_DIR = ../../lib/test/gtest
 
 CC  := clang-18
 CXX := clang++-18
-ifeq ($(shell which $(CC) 2>/dev/null),)
+ifeq ($(shell which $(CC) 2>/dev/null && which $(CXX) 2>/dev/null),)
 $(info Falling back to 'clang')
 CC  := clang
-endif
-ifeq ($(shell which $(CXX) 2>/dev/null),)
-$(info Falling back to 'clang++')
 CXX := clang++
 endif
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -515,8 +515,8 @@ GTEST_DIR = ../../lib/test/gtest
 
 # Use clang/clang++ by default
 
-CC  := clang-15
-CXX := clang++-15
+CC  := clang-18
+CXX := clang++-18
 ifeq ($(shell which $(CC) 2>/dev/null),)
 $(info Falling back to 'clang')
 CC  := clang
@@ -539,11 +539,10 @@ CXX_VERSION = $(shell $(CXX) -dumpversion)
 
 ifeq ($(shell $(CC) -v 2>&1 | grep -q "clang version" && echo "clang"),clang)
 
-# Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 16 }
-# Travis reports CC_VERSION of 4.2.1
+# Please revisit versions when new clang version arrive. Supported versions: { Linux / OSX: 7 - 18 }
 CC_VERSION_MAJOR := $(firstword $(subst ., ,$(CC_VERSION)))
 CC_VERSION_CHECK_MIN := 7
-CC_VERSION_CHECK_MAX := 16
+CC_VERSION_CHECK_MAX := 18
 
 # c99-designator is fine, code is not expected to be clean C++
 COMMON_FLAGS += -Wno-c99-designator
@@ -552,7 +551,7 @@ COMMON_FLAGS += -Wno-c99-designator
 COMMON_FLAGS += -Werror
 
 ifeq ($(shell expr $(CC_VERSION_MAJOR) \< $(CC_VERSION_CHECK_MIN) \| $(CC_VERSION_MAJOR) \> $(CC_VERSION_CHECK_MAX)),1)
-$(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-15'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)
+$(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-18'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)
 endif
 
 COMMON_FLAGS += -fblocks

--- a/src/test/unit/cms_unittest.cc
+++ b/src/test/unit/cms_unittest.cc
@@ -146,6 +146,7 @@ CMS_Menu cmsx_menuMain = {
 #endif
     .onEnter = NULL,
     .onExit = NULL,
+    .onDisplayUpdate = NULL,
     .entries = menuMainEntries,
 };
 uint8_t armingFlags;

--- a/src/test/unit/pg_unittest.cc
+++ b/src/test/unit/pg_unittest.cc
@@ -35,9 +35,25 @@ extern "C" {
 PG_REGISTER_WITH_RESET_TEMPLATE(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 1);
 
 PG_RESET_TEMPLATE(motorConfig_t, motorConfig,
-    .dev = {.motorPwmRate = 400},
+    .dev = {
+        .motorPwmRate = 400,
+        .motorPwmProtocol = 0,
+        .motorPwmInversion = 0,
+        .useUnsyncedPwm = 0,
+        .useBurstDshot = 0,
+        .useDshotTelemetry = 0,
+        .useDshotEdt = 0,
+        .ioTags = {IO_TAG_NONE, IO_TAG_NONE, IO_TAG_NONE, IO_TAG_NONE},
+        .motorTransportProtocol = 0,
+        .useDshotBitbang = 0,
+        .useDshotBitbangedTimer = 0,
+        .motorOutputReordering = {0, 1, 2, 3},
+    },
+    .motorIdle = 0,
     .maxthrottle = 1850,
     .mincommand = 1000,
+    .kv = 1000,
+    .motorPoleCount = 14,
 );
 }
 

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -262,9 +262,15 @@ protected:
     controlRateConfig_t controlRateConfig = {
         .thrMid8 = 0,
         .thrExpo8 = 0,
+        .rates_type = RATES_TYPE_BETAFLIGHT,
         .rcRates = {[FD_ROLL] = 90, [FD_PITCH] = 90},
         .rcExpo = {[FD_ROLL] = 0, [FD_PITCH] = 0, [FD_YAW] = 0},
         .rates = {0, 0, 0},
+        .throttle_limit_type = THROTTLE_LIMIT_TYPE_OFF,
+        .throttle_limit_percent = 100,
+        .rate_limit = {0, 0, 0},
+        .profileName = "default",
+        .quickRatesRcExpo = 0,
     };
 
     channelRange_t fullRange = {
@@ -361,9 +367,15 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     controlRateConfig_t controlRateConfig = {
         .thrMid8 = 0,
         .thrExpo8 = 0,
+        .rates_type = RATES_TYPE_BETAFLIGHT,
         .rcRates = {[FD_ROLL] = 90, [FD_PITCH] = 90},
         .rcExpo = {[FD_ROLL] = 0, [FD_PITCH] = 0, [FD_YAW] = 0},
-        .rates = {0,0,0},
+        .rates = {0, 0, 0},
+        .throttle_limit_type = THROTTLE_LIMIT_TYPE_OFF,
+        .throttle_limit_percent = 100,
+        .rate_limit = {0, 0, 0},
+        .profileName = "default",
+        .quickRatesRcExpo = 0,
     };
 
     // and

--- a/src/test/unit/rx_ibus_unittest.cc
+++ b/src/test/unit/rx_ibus_unittest.cc
@@ -30,23 +30,11 @@ extern "C" {
 #include "telemetry/telemetry.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
-#include "sensors/barometer.h"
 #include "sensors/battery.h"
 }
 
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
-
-
-extern "C" {
-    uint8_t batteryCellCount = 3;
-    float rcCommand[4] = {0, 0, 0, 0};
-    int16_t telemTemperature1 = 0;
-    baro_t baro;
-    telemetryConfig_t telemetryConfig_System;
-    timeUs_t rxFrameTimeUs(void) { return 0; }
-}
-
 
 bool telemetryCheckRxPortShared(const serialPortConfig_t *portConfig)
 {

--- a/src/test/unit/rx_ibus_unittest.cc
+++ b/src/test/unit/rx_ibus_unittest.cc
@@ -42,7 +42,7 @@ extern "C" {
     uint8_t batteryCellCount = 3;
     float rcCommand[4] = {0, 0, 0, 0};
     int16_t telemTemperature1 = 0;
-    baro_t baro = { .temperature = 50 };
+    baro_t baro;
     telemetryConfig_t telemetryConfig_System;
     timeUs_t rxFrameTimeUs(void) { return 0; }
 }
@@ -86,6 +86,10 @@ static serialPort_t serialTestInstance;
 static serialPortConfig_t serialTestInstanceConfig = {
     .functionMask = 0,
     .identifier = SERIAL_PORT_DUMMY_IDENTIFIER,
+    .msp_baudrateIndex = 0,
+    .gps_baudrateIndex = 0,
+    .blackbox_baudrateIndex = 0,
+    .telemetry_baudrateIndex = 0,
 };
 
 static serialReceiveCallbackPtr stub_serialRxCallback;

--- a/src/test/unit/rx_spi_expresslrs_unittest.cc
+++ b/src/test/unit/rx_spi_expresslrs_unittest.cc
@@ -54,6 +54,14 @@ extern "C" {
     static rxRuntimeState_t config = rxRuntimeState_t();
     static rxSpiExtiConfig_t extiConfig;
     static const rxSpiConfig_t injectedConfig = {
+        .rx_spi_protocol = 0,
+        .rx_spi_id = 0,
+        .rx_spi_rf_channel_count = 0,
+        .csnTag = IO_TAG_NONE,
+        .spibus = 0,
+        .bindIoTag = IO_TAG_NONE,
+        .ledIoTag = IO_TAG_NONE,
+        .ledInversion = 0,
         .extiIoTag = IO_TAG_NONE,
     };
 }

--- a/src/test/unit/rx_spi_spektrum_unittest.cc
+++ b/src/test/unit/rx_spi_spektrum_unittest.cc
@@ -135,6 +135,14 @@ extern "C" {
     }
 
     static const rxSpiConfig_t injectedConfig = {
+        .rx_spi_protocol = 0,
+        .rx_spi_id = 0,
+        .rx_spi_rf_channel_count = 0,
+        .csnTag = IO_TAG_NONE,
+        .spibus = 0,
+        .bindIoTag = IO_TAG_NONE,
+        .ledIoTag = IO_TAG_NONE,
+        .ledInversion = 0,
         .extiIoTag = IO_TAG_NONE,
     };
 }

--- a/src/test/unit/rx_sumd_unittest.cc
+++ b/src/test/unit/rx_sumd_unittest.cc
@@ -41,7 +41,7 @@ extern "C" {
     uint8_t batteryCellCount = 3;
     float rcCommand[4] = {0, 0, 0, 0};
     int16_t telemTemperature1 = 0;
-    baro_t baro = { .temperature = 50 };
+    // baro_t baro = { .temperature = 50 };
     telemetryConfig_t telemetryConfig_System;
     timeUs_t rxFrameTimeUs(void) { return 0; }
 }
@@ -88,6 +88,10 @@ static serialPort_t serialTestInstance;
 static serialPortConfig_t serialTestInstanceConfig = {
     .functionMask = 0,
     .identifier = SERIAL_PORT_DUMMY_IDENTIFIER,
+    .msp_baudrateIndex = 0,
+    .gps_baudrateIndex = 0,
+    .blackbox_baudrateIndex = 0,
+    .telemetry_baudrateIndex = 0,
 };
 
 static serialReceiveCallbackPtr stub_serialRxCallback;

--- a/src/test/unit/rx_sumd_unittest.cc
+++ b/src/test/unit/rx_sumd_unittest.cc
@@ -29,23 +29,11 @@ extern "C" {
 #include "telemetry/telemetry.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
-#include "sensors/barometer.h"
 #include "sensors/battery.h"
 }
 
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
-
-
-extern "C" {
-    uint8_t batteryCellCount = 3;
-    float rcCommand[4] = {0, 0, 0, 0};
-    int16_t telemTemperature1 = 0;
-    // baro_t baro = { .temperature = 50 };
-    telemetryConfig_t telemetryConfig_System;
-    timeUs_t rxFrameTimeUs(void) { return 0; }
-}
-
 
 bool telemetryCheckRxPortShared(const serialPortConfig_t *portConfig, const SerialRXType serialrxProvider)
 {

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -73,9 +73,7 @@ extern "C" {
 
     // set up tasks to take a simulated representative time to execute
     bool gyroFilterReady(void) { return taskFilterReady; }
-    gyroDev_t gyro {
-        .gyroModeSPI = GYRO_EXTI_NO_INT
-    };
+    gyroDev_t gyro;
     gyroDev_t *gyroActiveDev(void) { return &gyro; }
     bool pidLoopReady(void) { return taskPidReady; }
     void failsafeCheckDataFailurePeriod(void) {}

--- a/src/test/unit/telemetry_ibus_unittest.cc
+++ b/src/test/unit/telemetry_ibus_unittest.cc
@@ -148,6 +148,10 @@ serialPort_t serialTestInstance;
 serialPortConfig_t serialTestInstanceConfig = {
     .functionMask = 0,
     .identifier = SERIAL_PORT_DUMMY_IDENTIFIER,
+    .msp_baudrateIndex = 5,
+    .gps_baudrateIndex = 5,
+    .blackbox_baudrateIndex = 5,
+    .telemetry_baudrateIndex = 5
 };
 
 static serialPortConfig_t *findSerialPortConfig_stub_retval;

--- a/src/test/unit/unittest_displayport.h
+++ b/src/test/unit/unittest_displayport.h
@@ -104,6 +104,15 @@ static void displayPortTestRedraw(displayPort_t *displayPort)
     UNUSED(displayPort);
 }
 
+static int displayportWriteSys(displayPort_t *displayPort, uint8_t x, uint8_t y, displayPortSystemElement_e systemElement)
+{
+    UNUSED(displayPort);
+    UNUSED(x);
+    UNUSED(y);
+    UNUSED(systemElement);
+    return 0;
+}
+
 static uint32_t displayPortTestTxBytesFree(const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
@@ -116,12 +125,23 @@ static const displayPortVTable_t testDisplayPortVTable = {
     .clearScreen = displayPortTestClearScreen,
     .drawScreen = displayPortTestDrawScreen,
     .screenSize = displayPortTestScreenSize,
+    .writeSys = displayportWriteSys,
     .writeString = displayPortTestWriteString,
     .writeChar = displayPortTestWriteChar,
     .isTransferInProgress = displayPortTestIsTransferInProgress,
     .heartbeat = displayPortTestHeartbeat,
     .redraw = displayPortTestRedraw,
-    .txBytesFree = displayPortTestTxBytesFree
+    .isSynced = displayPortTestIsTransferInProgress,
+    .txBytesFree = displayPortTestTxBytesFree,
+    .layerSupported = NULL,
+    .layerSelect = NULL,
+    .layerCopy = NULL,
+    .writeFontCharacter = NULL,
+    .checkReady = NULL,
+    .beginTransaction = NULL,
+    .commitTransaction = NULL,
+    .getCanvas = NULL,
+    .setBackgroundType = NULL,
 };
 
 displayPort_t *displayPortTestInit(void)


### PR DESCRIPTION
- Reference https://github.com/betaflight/betaflight/pull/14114
- Initial commit to bump clang to use version 18
- Added check for clang++-18
- Needs verification on OSX