### PR TITLE
Initialize all assigned servos even if some are missing (fix)

### DIFF
--- a/src/platform/STM32/pwm_output.c
+++ b/src/platform/STM32/pwm_output.c
@@ -291,7 +291,7 @@ void servoDevInit(const servoDevConfig_t *servoConfig)
         const ioTag_t tag = servoConfig->ioTags[servoIndex];
 
         if (!tag) {
-            break;
+            continue;
         }
 
         servos[servoIndex].io = IOGetByTag(tag);


### PR DESCRIPTION
I am not 100% sure i am doing things correct. Need @SteveCEvans  or @blckmn maybe to check.

Current problem:
When using `mixer CUSTOMAIRPLANE` with servo mixer the servos have dedicated "spots".
For example, if you want servo to act like a rudder and react on yaw you need:
```
smix 0 5 2 100 0 0 100 0
```
(following this wiki https://betaflight.com/docs/development/mixer)
this command tells:
- `0` - rule number 0 (we have only one rule now)
- `5` - servo with a function `RUDDER`
- `2` - input source: `Stabilized YAW`
and then rate, speed, min/max and box - this doesn't matter.

Then you will also need have SERVO 4 resource with `resource SERVO 4 XXX`.

And then you will also need to assign resources for servo 1 - 3, despite you don't need them. Because inside of `servoDevInit` the initialization loop stops when it meets first unassigned servo.

This "fix" allows to initialize ALL assigned servos even if previous servo resources are missing.