### PR TITLE
Move STM (and clone) specific IO initialisation to platform

### DIFF
--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -129,56 +129,12 @@ bool IOIsFreeOrPreinit(IO_t io)
     return false;
 }
 
-#if DEFIO_PORT_USED_COUNT > 0
-static const uint16_t ioDefUsedMask[DEFIO_PORT_USED_COUNT] = { DEFIO_PORT_USED_LIST };
-static const uint8_t ioDefUsedOffset[DEFIO_PORT_USED_COUNT] = { DEFIO_PORT_OFFSET_LIST };
-#else
-// Avoid -Wpedantic warning
-static const uint16_t ioDefUsedMask[1] = {0};
-static const uint8_t ioDefUsedOffset[1] = {0};
-#endif
 #if DEFIO_IO_USED_COUNT
 ioRec_t ioRecs[DEFIO_IO_USED_COUNT];
 #else
 // Avoid -Wpedantic warning
 ioRec_t ioRecs[1];
 #endif
-
-// initialize all ioRec_t structures from ROM
-// currently only bitmask is used, this may change in future
-void IOInitGlobal(void)
-{
-    ioRec_t *ioRec = ioRecs;
-
-    for (unsigned port = 0; port < ARRAYLEN(ioDefUsedMask); port++) {
-        for (unsigned pin = 0; pin < sizeof(ioDefUsedMask[0]) * 8; pin++) {
-            if (ioDefUsedMask[port] & (1 << pin)) {
-                ioRec->gpio = (GPIO_TypeDef *)(GPIOA_BASE + (port << 10));   // ports are 0x400 apart
-                ioRec->pin = 1 << pin;
-                ioRec++;
-            }
-        }
-    }
-}
-
-IO_t IOGetByTag(ioTag_t tag)
-{
-    const int portIdx = DEFIO_TAG_GPIOID(tag);
-    const int pinIdx = DEFIO_TAG_PIN(tag);
-
-    if (portIdx < 0 || portIdx >= DEFIO_PORT_USED_COUNT) {
-        return NULL;
-    }
-    // check if pin exists
-    if (!(ioDefUsedMask[portIdx] & (1 << pinIdx))) {
-        return NULL;
-    }
-    // count bits before this pin on single port
-    int offset = popcount(((1 << pinIdx) - 1) & ioDefUsedMask[portIdx]);
-    // and add port offset
-    offset += ioDefUsedOffset[portIdx];
-    return ioRecs + offset;
-}
 
 void IOTraversePins(IOTraverseFuncPtr_t fnPtr)
 {

--- a/src/platform/APM32/mk/APM32F4.mk
+++ b/src/platform/APM32/mk/APM32F4.mk
@@ -147,6 +147,7 @@ endif
 
 MCU_COMMON_SRC = \
         common/stm32/system.c \
+        common/stm32/io_impl.c \
         APM32/startup/system_apm32f4xx.c \
         drivers/inverter.c \
         drivers/dshot_bitbang_decode.c \

--- a/src/platform/AT32/mk/AT32F4.mk
+++ b/src/platform/AT32/mk/AT32F4.mk
@@ -82,6 +82,7 @@ DEVICE_FLAGS   += -DUSE_ATBSP_DRIVER -DAT32F43x -DHSE_VALUE=$(HSE_VALUE) -DAT32 
 
 MCU_COMMON_SRC = \
             common/stm32/system.c \
+            common/stm32/io_impl.c \
             AT32/startup/at32f435_437_clock.c \
             AT32/startup/system_at32f435_437.c \
             AT32/adc_at32f43x.c \

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -762,3 +762,9 @@ void IOInitGlobal(void)
 {
     // NOOP
 }
+
+IO_t IOGetByTag(ioTag_t tag)
+{
+    UNUSED(tag);
+    return IO_TAG_NONE;
+}

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -757,3 +757,8 @@ void IOLo(IO_t io)
 {
     UNUSED(io);
 }
+
+void IOInitGlobal(void)
+{
+    // NOOP
+}

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -766,5 +766,5 @@ void IOInitGlobal(void)
 IO_t IOGetByTag(ioTag_t tag)
 {
     UNUSED(tag);
-    return IO_TAG_NONE;
+    return NULL;
 }

--- a/src/platform/STM32/mk/STM32_COMMON.mk
+++ b/src/platform/STM32/mk/STM32_COMMON.mk
@@ -4,9 +4,12 @@ INCLUDE_DIRS += $(PLATFORM_DIR)/common/stm32
 MCU_COMMON_SRC += \
             common/stm32/bus_spi_pinconfig.c \
             common/stm32/bus_spi_hw.c \
+            common/stm32/io_impl.c
 
 SIZE_OPTIMISED_SRC += \
             common/stm32/bus_spi_pinconfig.c
 
 SPEED_OPTIMISED_SRC += \
-            common/stm32/bus_spi_hw.c
+            common/stm32/bus_spi_hw.c \
+            common/stm32/io_impl.c
+

--- a/src/platform/common/stm32/io_impl.c
+++ b/src/platform/common/stm32/io_impl.c
@@ -23,10 +23,6 @@
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 
-#include "drivers/rcc.h"
-
-#include "common/utils.h"
-
 #if DEFIO_PORT_USED_COUNT > 0
 static const uint16_t ioDefUsedMask[DEFIO_PORT_USED_COUNT] = { DEFIO_PORT_USED_LIST };
 static const uint8_t ioDefUsedOffset[DEFIO_PORT_USED_COUNT] = { DEFIO_PORT_OFFSET_LIST };

--- a/src/platform/common/stm32/io_impl.c
+++ b/src/platform/common/stm32/io_impl.c
@@ -1,19 +1,20 @@
 /*
- * This file is part of Cleanflight and Betaflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight and Betaflight are free software. You can redistribute
- * this software and/or modify this software under the terms of the
- * GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight and Betaflight are distributed in the hope that they
- * will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this software.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/platform/common/stm32/io_impl.c
+++ b/src/platform/common/stm32/io_impl.c
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#include "drivers/io.h"
+#include "drivers/io_impl.h"
+
+#include "drivers/rcc.h"
+
+#include "common/utils.h"
+
+#if DEFIO_PORT_USED_COUNT > 0
+static const uint16_t ioDefUsedMask[DEFIO_PORT_USED_COUNT] = { DEFIO_PORT_USED_LIST };
+static const uint8_t ioDefUsedOffset[DEFIO_PORT_USED_COUNT] = { DEFIO_PORT_OFFSET_LIST };
+#else
+// Avoid -Wpedantic warning
+static const uint16_t ioDefUsedMask[1] = {0};
+static const uint8_t ioDefUsedOffset[1] = {0};
+#endif
+
+// initialize all ioRec_t structures from ROM
+// currently only bitmask is used, this may change in future
+void IOInitGlobal(void)
+{
+    ioRec_t *ioRec = ioRecs;
+
+    for (unsigned port = 0; port < ARRAYLEN(ioDefUsedMask); port++) {
+        for (unsigned pin = 0; pin < sizeof(ioDefUsedMask[0]) * 8; pin++) {
+            if (ioDefUsedMask[port] & (1 << pin)) {
+                ioRec->gpio = (GPIO_TypeDef *)(GPIOA_BASE + (port << 10));   // ports are 0x400 apart
+                ioRec->pin = 1 << pin;
+                ioRec++;
+            }
+        }
+    }
+}
+
+IO_t IOGetByTag(ioTag_t tag)
+{
+    const int portIdx = DEFIO_TAG_GPIOID(tag);
+    const int pinIdx = DEFIO_TAG_PIN(tag);
+
+    if (portIdx < 0 || portIdx >= DEFIO_PORT_USED_COUNT) {
+        return NULL;
+    }
+    // check if pin exists
+    if (!(ioDefUsedMask[portIdx] & (1 << pinIdx))) {
+        return NULL;
+    }
+    // count bits before this pin on single port
+    int offset = popcount(((1 << pinIdx) - 1) & ioDefUsedMask[portIdx]);
+    // and add port offset
+    offset += ioDefUsedOffset[portIdx];
+    return ioRecs + offset;
+}


### PR DESCRIPTION
Considerable amount of code is specific to STM and not required for either SITL or other platforms.

This will allow continued progress on RP2350B