### PR TITLE
Moved IO_GPIOPortIdx to platform

### DIFF
--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -52,14 +52,6 @@ uint16_t IO_Pin(IO_t io)
     return ioRec->pin;
 }
 
-int IO_GPIOPortIdx(IO_t io)
-{
-    if (!io) {
-        return -1;
-    }
-    return (((size_t)IO_GPIO(io) - GPIOA_BASE) >> 10);
-}
-
 int IO_EXTI_PortSourceGPIO(IO_t io)
 {
     return IO_GPIOPortIdx(io);

--- a/src/platform/common/stm32/io_impl.c
+++ b/src/platform/common/stm32/io_impl.c
@@ -68,3 +68,11 @@ IO_t IOGetByTag(ioTag_t tag)
     offset += ioDefUsedOffset[portIdx];
     return ioRecs + offset;
 }
+
+int IO_GPIOPortIdx(IO_t io)
+{
+    if (!io) {
+        return -1;
+    }
+    return (((size_t)IO_GPIO(io) - GPIOA_BASE) >> 10);
+}


### PR DESCRIPTION
Missed a function depending on GPIOA_BASE which is platform specific.