### PR TITLE
FIX: Makefile such that `make CONFIG=config-target` works as expected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,10 +219,14 @@ endif # TARGET specified
 # openocd specific includes
 include $(MAKE_SCRIPT_DIR)/openocd.mk
 
-ifneq ($(CONFIG),)
-.DEFAULT_GOAL := $(CONFIG)
-else
+ifeq ($(CONFIG),)
+ifeq ($(TARGET),)
 .DEFAULT_GOAL := all
+else
+.DEFAULT_GOAL := hex
+endif
+else
+.DEFAULT_GOAL := hex
 endif
 
 INCLUDE_DIRS    := $(INCLUDE_DIRS) \

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,6 @@ FC_VER       := $(FC_VER_MAJOR).$(FC_VER_MINOR).$(FC_VER_PATCH)
 # import config handling
 include $(MAKE_SCRIPT_DIR)/config.mk
 
-
 # default xtal value
 HSE_VALUE       ?= 8000000
 
@@ -220,7 +219,11 @@ endif # TARGET specified
 # openocd specific includes
 include $(MAKE_SCRIPT_DIR)/openocd.mk
 
+ifneq ($(CONFIG),)
+.DEFAULT_GOAL := $(CONFIG)
+else
 .DEFAULT_GOAL := all
+endif
 
 INCLUDE_DIRS    := $(INCLUDE_DIRS) \
                    $(ROOT)/lib/main/MAVLink


### PR DESCRIPTION
`make CONFIG=MATEKH743` or any others threw an error due to TARGET also being defined (due to default goal of all), when no recipe (e.g. hex) specified.

Default goal now modified depending on CONFIG or TARGET params utilised or not.