### PR TITLE
FIX: Flash page size check is STM (or clone) specific

### DIFF
--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -37,10 +37,6 @@ uint8_t eepromData[EEPROM_SIZE];
 #endif
 #endif
 
-#if !defined(FLASH_PAGE_SIZE)
-#error "Flash page size not defined for target."
-#endif
-
 void config_streamer_init(config_streamer_t *c)
 {
     memset(c, 0, sizeof(*c));

--- a/src/platform/common/stm32/config_flash.c
+++ b/src/platform/common/stm32/config_flash.c
@@ -27,6 +27,10 @@
 
 #if defined(CONFIG_IN_FLASH)
 
+#if !defined(FLASH_PAGE_SIZE)
+#error "Flash page size not defined for STM (or clone) target."
+#endif
+
 #if defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx)
 /*
 Sector 0    0x08000000 - 0x08007FFF 32 Kbytes


### PR DESCRIPTION
Not all platforms need to worry about the flash page size. 