### PR TITLE
Servo invert

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -209,7 +209,11 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
+#ifdef USE_SERVO180
+        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
+#else
         return rcData[channelToForwardFrom];
+#endif
     }
 
     return servoParams(servoIndex)->middle;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -209,7 +209,13 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
+        return scaleRangef(
+            constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX),
+            PWM_RANGE_MIN,
+            PWM_RANGE_MAX,
+            MIN(servoParams(servoIndex)->min, servoParams(servoIndex)->max),
+            MAX(servoParams(servoIndex)->min, servoParams(servoIndex)->max)
+        );
     }
 
     return servoParams(servoIndex)->middle;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -209,13 +209,10 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        return scaleRangef(
-            constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX),
-            PWM_RANGE_MIN,
-            PWM_RANGE_MAX,
-            MIN(servoParams(servoIndex)->min, servoParams(servoIndex)->max),
-            MAX(servoParams(servoIndex)->min, servoParams(servoIndex)->max)
-        );
+        if (rcData[channelToForwardFrom] < PWM_RANGE_MIN || rcData[channelToForwardFrom] > PWM_RANGE_MAX) {
+            return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
+        }
+        return rcData[channelToForwardFrom];
     }
 
     return servoParams(servoIndex)->middle;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -209,10 +209,10 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-#ifdef USE_SERVO180
-        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
-#else
+#ifdef USE_SERVO_LEGACY
         return rcData[channelToForwardFrom];
+#else
+        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
 #endif
     }
 

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -209,10 +209,10 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        if (rcData[channelToForwardFrom] < PWM_RANGE_MIN || rcData[channelToForwardFrom] > PWM_RANGE_MAX) {
-            return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
+        if (rcData[channelToForwardFrom] >= PWM_RANGE_MIN && rcData[channelToForwardFrom] <= PWM_RANGE_MAX) {
+            return rcData[channelToForwardFrom];
         }
-        return rcData[channelToForwardFrom];
+        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
     }
 
     return servoParams(servoIndex)->middle;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -209,10 +209,7 @@ int16_t determineServoMiddleOrForwardFromChannel(servoIndex_e servoIndex)
     const uint8_t channelToForwardFrom = servoParams(servoIndex)->forwardFromChannel;
 
     if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED && channelToForwardFrom < rxRuntimeState.channelCount) {
-        if (rcData[channelToForwardFrom] >= PWM_RANGE_MIN && rcData[channelToForwardFrom] <= PWM_RANGE_MAX) {
-            return rcData[channelToForwardFrom];
-        }
-        return scaleRangef(constrainf(rcData[channelToForwardFrom], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, servoParams(servoIndex)->min, servoParams(servoIndex)->max);
+        return rcData[channelToForwardFrom];
     }
 
     return servoParams(servoIndex)->middle;


### PR DESCRIPTION
This pull request includes a change to the `determineServoMiddleOrForwardFromChannel` function in the `src/main/flight/servos.c` file. The main update is the addition of a conditional compilation block to handle legacy servo behavior.

Changes to servo handling:

* [`src/main/flight/servos.c`](diffhunk://#diff-c90491cca5be9a11d702c750699464d7fbc1cc617e32cd982070552522a70207R212-R216): Added a preprocessor directive to return `rcData[channelToForwardFrom]` directly when `USE_SERVO_LEGACY` is defined, otherwise, it scales and constrains the value as before.