### PR TITLE
Leave SPI CPOL/CPHA at default for SD card

### DIFF
--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -566,9 +566,6 @@ static void sdcardSpi_init(const sdcardConfig_t *config, const spiPinConfig_t *s
     }
     sdcard.dev.busType_u.spi.csnPin = chipSelectIO;
 
-    // Set the clock phase/polarity
-    spiSetClkPhasePolarity(&sdcard.dev, true);
-
     // Set the callback argument when calling back to this driver for DMA completion
     sdcard.dev.callbackArg = (uint32_t)&sdcard;
 


### PR DESCRIPTION
An issue came to light on the SPEEDYBEEF405WING where the SD card wasn't being recognised and thanks to @limonspb it was established that this had worked in version 4.2.11, but not subsequently.

Strangely connecting a microSD extender card fixed the problem which made debug rather challenging.

![IMG_0998](https://github.com/user-attachments/assets/1f5e179c-465c-4ad1-b9ea-2924cfcd2593)

It was noted however that there was a strange glitch on MOSI on the first SPI clock transition. This, and the impact of connecting the debug analyzer led to the conclusion that there was a signal integrity issue.

![image](https://github.com/user-attachments/assets/dfea0707-a5bc-4813-8dca-5eba1ac110d4)

This led to the experimental removal of pull-up resistors by @limon which worked.

Somewhat baffled and wondering what could cause such a signal integrity issue, AI was consulted, and amazingly it pinpointed the issue. CPOL was wrong.

![image](https://github.com/user-attachments/assets/062e5dc9-2a6a-4c4d-bc55-ab3aa5408358)

Now an altogether different positioning of the glitch away from the clock edges.

![image](https://github.com/user-attachments/assets/fe65e5cf-b066-4a43-9082-aeccf9cd8201)


We had `SPI_CPOL_Low | SPI_CPHA_1Edge` set to clock on the first edge with the default state being clock low. This would be a rising edge (first edge after a low would be a rising edge) which would be OK normally. But we should have had the clock default to high and clock on the second edge, `SPI_CPOL_High | SPI_CPHA_2Edge`, which would again be the rising edge. As the SPI interface didn't believe it had to drive low before driving high, the pullup was, I suspect, preventing the first rising edge being seen consistently. You'll note in the second analyzer trace that the clock starts high, and is driven low later more cleanly.

Tested on:

- SPEEDYBEEF405WING
- ORBIFF435
- SPEEDYBEEF405V3
- MATEKF722SE
- MAKEKH743

Thanks to @limon V-22 and kedeng for their help.