### PR TITLE
[4.5.2] Leave SPI CPOL/CPHA at default for SD card (#14142)

### DIFF
--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -568,9 +568,6 @@ static void sdcardSpi_init(const sdcardConfig_t *config, const spiPinConfig_t *s
     }
     sdcard.dev.busType_u.spi.csnPin = chipSelectIO;
 
-    // Set the clock phase/polarity
-    spiSetClkPhasePolarity(&sdcard.dev, true);
-
     // Set the callback argument when calling back to this driver for DMA completion
     sdcard.dev.callbackArg = (uint32_t)&sdcard;
 


### PR DESCRIPTION
Backport of #14142 