### PR TITLE
h7: spi: SPI1 MISO add PG9 as AF option

### DIFF
--- a/src/platform/common/stm32/bus_spi_pinconfig.c
+++ b/src/platform/common/stm32/bus_spi_pinconfig.c
@@ -184,6 +184,7 @@ const spiHardware_t spiHardware[] = {
         .misoPins = {
             { DEFIO_TAG_E(PA6), GPIO_AF5_SPI1 },
             { DEFIO_TAG_E(PB4), GPIO_AF5_SPI1 },
+            { DEFIO_TAG_E(PG9), GPIO_AF5_SPI1 },
         },
         .mosiPins = {
             { DEFIO_TAG_E(PA7), GPIO_AF5_SPI1 },


### PR DESCRIPTION
I am working on a board port and our IMU did not initialize. After adding PG9 to the list of H7 SPI1 MISO options it initializes properly.