### PR TITLE
Default GPIO mode and state

### DIFF
--- a/src/main/drivers/io.h
+++ b/src/main/drivers/io.h
@@ -36,6 +36,12 @@
 // expand pinid to to ioTag_t
 #define IO_TAG(pinid) DEFIO_TAG(pinid)
 
+#define GPIO_STATE_HIGH 1
+#define GPIO_STATE_LOW 0
+
+#define GPIO_CONFIG(pin, mode, state) \
+    { IO_TAG(pin), mode, state }
+
 // declare available IO pins. Available pins are specified per target
 #include "io_def.h"
 
@@ -57,6 +63,7 @@ void IOConfigGPIOAF(IO_t io, ioConfig_t cfg, uint8_t af);
 #endif
 
 void IOInitGlobal(void);
+void IOInitGPIODefault(void);
 
 typedef void (*IOTraverseFuncPtr_t)(IO_t io);
 

--- a/src/main/drivers/io.h
+++ b/src/main/drivers/io.h
@@ -39,8 +39,11 @@
 #define GPIO_STATE_HIGH 1
 #define GPIO_STATE_LOW 0
 
-#define GPIO_CONFIG(pin, mode, state) \
-    { IO_TAG(pin), mode, state }
+#define GPIO_CONFIG_OUTPUT(pin, mode, state) \
+    { IO_TAG(pin), mode, state, true }
+
+#define GPIO_CONFIG_INPUT(pin, mode) \
+    { IO_TAG(pin), mode, false, false }
 
 // declare available IO pins. Available pins are specified per target
 #include "io_def.h"

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -278,6 +278,9 @@ void init(void)
     // initialize IO (needed for all IO operations)
     IOInitGlobal();
 
+    // initialize default GPIO
+    IOInitGPIODefault();
+
 #ifdef USE_HARDWARE_REVISION_DETECTION
     detectHardwareRevision();
 #endif

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -768,6 +768,12 @@ void IOInitGlobal(void)
     // NOOP
 }
 
+void IOInitGPIODefault(void)
+{
+    // NOOP
+}
+
+
 IO_t IOGetByTag(ioTag_t tag)
 {
     UNUSED(tag);

--- a/src/platform/common/stm32/io_impl.c
+++ b/src/platform/common/stm32/io_impl.c
@@ -33,6 +33,21 @@ static const uint16_t ioDefUsedMask[1] = {0};
 static const uint8_t ioDefUsedOffset[1] = {0};
 #endif
 
+typedef struct defaultGpioConfig_s {
+    ioTag_t pin;
+    uint8_t mode;
+    bool state;
+} gpioConfig_t;
+
+#ifdef DEFAULT_GPIO_ARRAY
+static const gpioConfig_t defaultGpios[] = {
+    DEFAULT_GPIO_ARRAY
+};
+#else
+// Avoid -Wpedantic warning
+static const gpioConfig_t defaultGpios[1] = {};
+#endif
+
 // initialize all ioRec_t structures from ROM
 // currently only bitmask is used, this may change in future
 void IOInitGlobal(void)
@@ -46,6 +61,26 @@ void IOInitGlobal(void)
                 ioRec->pin = 1 << pin;
                 ioRec++;
             }
+        }
+    }
+}
+
+void IOInitGPIODefault(void)
+{
+    for (unsigned i = 0; i < ARRAYLEN(defaultGpios); i++) {
+        IO_t io = IOGetByTag(defaultGpios[i].pin);
+        if (io == IO_TAG_NONE) {
+            continue;
+        }
+
+        IOInit(io, OWNER_SYSTEM, 0);
+        IOConfigGPIO(io, defaultGpios[i].mode);
+
+        bool is_output = (defaultGpios[i].mode & GPIO_MODE_OUTPUT_PP) ||
+                         (defaultGpios[i].mode & GPIO_MODE_OUTPUT_OD);
+
+        if (is_output) {
+            IOWrite(io, defaultGpios[i].state);
         }
     }
 }

--- a/src/platform/common/stm32/io_impl.c
+++ b/src/platform/common/stm32/io_impl.c
@@ -37,6 +37,7 @@ typedef struct defaultGpioConfig_s {
     ioTag_t pin;
     uint8_t mode;
     bool state;
+    bool isOutput;
 } gpioConfig_t;
 
 #ifdef DEFAULT_GPIO_ARRAY
@@ -76,10 +77,7 @@ void IOInitGPIODefault(void)
         IOInit(io, OWNER_SYSTEM, 0);
         IOConfigGPIO(io, defaultGpios[i].mode);
 
-        bool is_output = (defaultGpios[i].mode & GPIO_MODE_OUTPUT_PP) ||
-                         (defaultGpios[i].mode & GPIO_MODE_OUTPUT_OD);
-
-        if (is_output) {
+        if (defaultGpios[i].isOutput) {
             IOWrite(io, defaultGpios[i].state);
         }
     }


### PR DESCRIPTION
This adds a mechanism to specify default GPIO modes and states in config.h

```config.h
#define VDD_3V3_SENSORS1_EN  PI11
#define VDD_3V3_SD_CARD_EN   PC13

#define DEFAULT_GPIO_ARRAY \
    GPIO_CONFIG(VDD_3V3_SENSORS1_EN, IOCFG_OUT_PP, GPIO_STATE_HIGH), \
    GPIO_CONFIG(VDD_3V3_SD_CARD_EN,  IOCFG_OUT_PP, GPIO_STATE_HIGH), 
```

I am working on a board port for a Pixhawk based flight controller. Pixhawks have GPIO for power enable to sensors and SD card to allow hard resetting devices to ensure they boot up in a clean state with default register values.

Right now our board does work without this due to the fact that betaflight configures all unused IO as input pull-up. The concern is that these internal pull-ups are weak and we have 20k pull-downs on these EN signals.