### PR TITLE
Remove MCU name table from CLI (rely on build info), add MCU info MSP2 command

### DIFF
--- a/src/main/build/build_config.c
+++ b/src/main/build/build_config.c
@@ -32,17 +32,11 @@
 mcuTypeId_e getMcuTypeId(void)
 {
     const mcuTypeInfo_t *mcuTypeInfo = getMcuTypeInfo();
-    if (mcuTypeInfo) {
-        return mcuTypeInfo->id;
-    }
-    return MCU_TYPE_UNKNOWN;
+    return mcuTypeInfo ? mcuTypeInfo->id : MCU_TYPE_UNKNOWN;
 }
 
 const char *getMcuTypeName(void)
 {
     const mcuTypeInfo_t *mcuTypeInfo = getMcuTypeInfo();
-    if (mcuTypeInfo) {
-        return mcuTypeInfo->name;
-    }
-    return "Unknown";
+     return mcuTypeInfo ? mcuTypeInfo->name : "Unknown";
 }

--- a/src/main/build/build_config.c
+++ b/src/main/build/build_config.c
@@ -31,54 +31,10 @@
 
 mcuTypeId_e getMcuTypeId(void)
 {
-#if defined(SIMULATOR_BUILD)
-    return MCU_TYPE_SIMULATOR;
-#elif defined(STM32F40_41xxx)
-    return MCU_TYPE_F40X;
-#elif defined(STM32F411xE)
-    return MCU_TYPE_F411;
-#elif defined(STM32F446xx)
-    return MCU_TYPE_F446;
-#elif defined(STM32F722xx)
-    return MCU_TYPE_F722;
-#elif defined(STM32F745xx)
-    return MCU_TYPE_F745;
-#elif defined(STM32F746xx)
-    return MCU_TYPE_F746;
-#elif defined(STM32F765xx)
-    return MCU_TYPE_F765;
-#elif defined(STM32H750xx)
-    return MCU_TYPE_H750;
-#elif defined(STM32H730xx)
-    return MCU_TYPE_H730;
-#elif defined(STM32H743xx)
-    switch (HAL_GetREVID()) {
-    case REV_ID_Y:
-        return MCU_TYPE_H743_REV_Y;
-    case REV_ID_X:
-        return MCU_TYPE_H743_REV_X;
-    case REV_ID_V:
-        return MCU_TYPE_H743_REV_V;
-    default:
-        return MCU_TYPE_H743_REV_UNKNOWN;
-    }
-#elif defined(STM32H7A3xx) || defined(STM32H7A3xxQ)
-    return MCU_TYPE_H7A3;
-#elif defined(STM32H723xx) || defined(STM32H725xx)
-    return MCU_TYPE_H723_725;
-#elif defined(STM32G474xx)
-    return MCU_TYPE_G474;
-#elif defined(AT32F435G)
-    return MCU_TYPE_AT32F435G;
-#elif defined(AT32F435M)
-    return MCU_TYPE_AT32F435M;
-#elif defined(APM32F405)
-    return MCU_TYPE_APM32F405;
-#elif defined(APM32F407)
-    return MCU_TYPE_APM32F407;
-#elif defined(RP2350B)
-    return MCU_TYPE_RP2350B;
-#else
-    return MCU_TYPE_UNKNOWN;
-#endif
+    return getMcuTypeInfo()->id;
+}
+
+const char *getMcuTypeName(void)
+{
+    return getMcuTypeInfo()->name;
 }

--- a/src/main/build/build_config.c
+++ b/src/main/build/build_config.c
@@ -31,10 +31,18 @@
 
 mcuTypeId_e getMcuTypeId(void)
 {
-    return getMcuTypeInfo()->id;
+    const mcuTypeInfo_t *mcuTypeInfo = getMcuTypeInfo();
+    if (mcuTypeInfo) {
+        return mcuTypeInfo->id;
+    }
+    return MCU_TYPE_UNKNOWN;
 }
 
 const char *getMcuTypeName(void)
 {
-    return getMcuTypeInfo()->name;
+    const mcuTypeInfo_t *mcuTypeInfo = getMcuTypeInfo();
+    if (mcuTypeInfo) {
+        return mcuTypeInfo->name;
+    }
+    return "Unknown";
 }

--- a/src/main/build/build_config.c
+++ b/src/main/build/build_config.c
@@ -38,5 +38,5 @@ mcuTypeId_e getMcuTypeId(void)
 const char *getMcuTypeName(void)
 {
     const mcuTypeInfo_t *mcuTypeInfo = getMcuTypeInfo();
-     return mcuTypeInfo ? mcuTypeInfo->name : "Unknown";
+    return mcuTypeInfo ? mcuTypeInfo->name : "Unknown";
 }

--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -70,7 +70,7 @@ typedef enum {
 
 typedef struct mcuTypeInfo_s {
    mcuTypeId_e id;
-   const char* name;
+   const char *name;
 } mcuTypeInfo_t;
 
 const mcuTypeInfo_t *getMcuTypeInfo(void);

--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -68,4 +68,11 @@ typedef enum {
     MCU_TYPE_UNKNOWN = 255,
 } mcuTypeId_e;
 
+typedef struct mcuTypeInfo_s {
+   const mcuTypeId_e id;
+   const char* name;
+} mcuTypeInfo_t;
+
 mcuTypeId_e getMcuTypeId(void);
+const mcuTypeInfo_t *getMcuTypeInfo(void);
+const char *getMcuTypeName(void);

--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -69,10 +69,10 @@ typedef enum {
 } mcuTypeId_e;
 
 typedef struct mcuTypeInfo_s {
-   const mcuTypeId_e id;
+   mcuTypeId_e id;
    const char* name;
 } mcuTypeInfo_t;
 
-mcuTypeId_e getMcuTypeId(void);
 const mcuTypeInfo_t *getMcuTypeInfo(void);
+mcuTypeId_e getMcuTypeId(void);
 const char *getMcuTypeName(void);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -279,32 +279,6 @@ static const char * const *sensorHardwareNames[] = {
 };
 #endif // USE_SENSOR_NAMES
 
-// Needs to be aligned with mcuTypeId_e
-static const char *mcuTypeNames[MCU_TYPE_COUNT] = {
-    "SIMULATOR",
-    "F40X",
-    "F411",
-    "F446",
-    "F722",
-    "F745",
-    "F746",
-    "F765",
-    "H750",
-    "H743 (Rev Unknown)",
-    "H743 (Rev.Y)",
-    "H743 (Rev.X)",
-    "H743 (Rev.V)",
-    "H7A3",
-    "H723/H725",
-    "G474",
-    "H730",
-    "AT32F435G",
-    "APM32F405",
-    "APM32F407",
-    "AT32F435M",
-    "RP2350B",
-};
-
 static const char *configurationStates[] = {
     [CONFIGURATION_STATE_UNCONFIGURED] = "UNCONFIGURED",
     [CONFIGURATION_STATE_CONFIGURED] = "CONFIGURED"
@@ -4692,15 +4666,6 @@ STATIC_UNIT_TESTED void cliSet(const char *cmdName, char *cmdline)
     }
 }
 
-static const char *getMcuTypeById(mcuTypeId_e id)
-{
-    if (id < ARRAYLEN(mcuTypeNames)) {
-        return mcuTypeNames[id];
-    } else {
-        return "UNKNOWN";
-    }
-}
-
 static void cliStatus(const char *cmdName, char *cmdline)
 {
     UNUSED(cmdName);
@@ -4708,7 +4673,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
 
     // MCU type, clock, vrefint, core temperature
 
-    cliPrintf("MCU %s Clock=%dMHz", getMcuTypeById(getMcuTypeId()), (SystemCoreClock / 1000000));
+    cliPrintf("MCU %s Clock=%dMHz", getMcuTypeName(), (SystemCoreClock / 1000000));
 
 #if defined(STM32F4) || defined(STM32G4) || defined(APM32F4)
     // Only F4 and G4 is capable of switching between HSE/HSI (for now)

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -82,6 +82,12 @@ void sbufWriteString(sbuf_t *dst, const char *string)
     sbufWriteData(dst, string, strlen(string));
 }
 
+void sbufWritePString(sbuf_t *dst, const char *string)
+{
+    sbufWriteU8(dst, strlen(string));
+    sbufWriteData(dst, string, strlen(string));
+}
+
 void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string)
 {
     sbufWriteData(dst, string, strlen(string) + 1);

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -24,6 +24,7 @@
 #include "platform.h"
 
 #include "streambuf.h"
+#include "common/maths.h"
 
 sbuf_t *sbufInit(sbuf_t *sbuf, uint8_t *ptr, uint8_t *end)
 {
@@ -84,8 +85,9 @@ void sbufWriteString(sbuf_t *dst, const char *string)
 
 void sbufWritePString(sbuf_t *dst, const char *string)
 {
-    sbufWriteU8(dst, strlen(string));
-    sbufWriteData(dst, string, strlen(string));
+    const int length = MIN((int)strlen(string), 255);
+    sbufWriteU8(dst, length);
+    sbufWriteData(dst, string, length);
 }
 
 void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string)

--- a/src/main/common/streambuf.h
+++ b/src/main/common/streambuf.h
@@ -39,6 +39,7 @@ void sbufWriteU32BigEndian(sbuf_t *dst, uint32_t val);
 void sbufFill(sbuf_t *dst, uint8_t data, int len);
 void sbufWriteData(sbuf_t *dst, const void *data, int len);
 void sbufWriteString(sbuf_t *dst, const char *string);
+void sbufWritePString(sbuf_t *dst, const char *string);
 void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string);
 
 uint8_t sbufReadU8(sbuf_t *src);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -641,11 +641,9 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, FC_VERSION_PATCH_LEVEL);
         break;
 
-    case MSP2_MCU_TYPE_INFO: {
+    case MSP2_MCU_INFO: {
         sbufWriteU8(dst, getMcuTypeId());
-        const char *name = getMcuTypeName();
-        sbufWriteU8(dst, strlen(name));
-        sbufWriteString(dst, name);
+        sbufWritePString(dst, getMcuTypeName());
         break;
     }
 
@@ -687,19 +685,14 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, targetCapabilities);
 
         // Target name with explicit length
-        sbufWriteU8(dst, strlen(targetName));
-        sbufWriteData(dst, targetName, strlen(targetName));
+        sbufWritePString(dst, targetName);
 
 #if defined(USE_BOARD_INFO)
         // Board name with explicit length
-        char *value = getBoardName();
-        sbufWriteU8(dst, strlen(value));
-        sbufWriteString(dst, value);
+        sbufWritePString(dst, getBoardName());
 
         // Manufacturer id with explicit length
-        value = getManufacturerId();
-        sbufWriteU8(dst, strlen(value));
-        sbufWriteString(dst, value);
+        sbufWritePString(dst, getManufacturerId());
 #else
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
@@ -1299,14 +1292,13 @@ case MSP_NAME:
         char warningsBuffer[OSD_WARNINGS_MAX_SIZE + 1];
 
         renderOsdWarning(warningsBuffer, &isBlinking, &displayAttr);
-        const uint8_t warningsLen = strlen(warningsBuffer);
 
         if (isBlinking) {
             displayAttr |= DISPLAYPORT_BLINK;
         }
         sbufWriteU8(dst, displayAttr);  // see displayPortSeverity_e
-        sbufWriteU8(dst, warningsLen);  // length byte followed by the actual characters
-        sbufWriteData(dst, warningsBuffer, warningsLen);
+        sbufWritePString(dst, warningsBuffer);
+
         break;
     }
 #endif
@@ -2627,12 +2619,9 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
 
             if (!textVar) return MSP_RESULT_ERROR;
 
-            const uint8_t textLength = strlen(textVar);
-
             //  type byte, then length byte followed by the actual characters
             sbufWriteU8(dst, textType);
-            sbufWriteU8(dst, textLength);
-            sbufWriteData(dst, textVar, textLength);
+            sbufWritePString(dst, textVar);
         }
         break;
 #ifdef USE_LED_STRIP

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -409,8 +409,7 @@ void mspReboot(dispatchEntry_t* self)
     mspRebootFn(NULL);
 }
 
-dispatchEntry_t mspRebootEntry =
-{
+dispatchEntry_t mspRebootEntry = {
     mspReboot, 0, NULL, false
 };
 
@@ -433,8 +432,7 @@ void writeReadEeprom(dispatchEntry_t* self)
 #endif
 }
 
-dispatchEntry_t writeReadEepromEntry =
-{
+dispatchEntry_t writeReadEepromEntry = {
     writeReadEeprom, 0, NULL, false
 };
 
@@ -643,8 +641,15 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         sbufWriteU8(dst, FC_VERSION_PATCH_LEVEL);
         break;
 
-    case MSP_BOARD_INFO:
-    {
+    case MSP2_MCU_TYPE_INFO: {
+        sbufWriteU8(dst, getMcuTypeId());
+        const char *name = getMcuTypeName();
+        sbufWriteU8(dst, strlen(name));
+        sbufWriteString(dst, name);
+        break;
+    }
+
+    case MSP_BOARD_INFO: {
         sbufWriteData(dst, systemConfig()->boardIdentifier, BOARD_IDENTIFIER_LENGTH);
 #ifdef USE_HARDWARE_REVISION_DETECTION
         sbufWriteU16(dst, hardwareRevision);
@@ -845,28 +850,27 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         break;
     }
 
-    case MSP_VOLTAGE_METER_CONFIG:
-        {
-            // by using a sensor type and a sub-frame length it's possible to configure any type of voltage meter,
-            // e.g. an i2c/spi/can sensor or any sensor not built directly into the FC such as ESC/RX/SPort/SBus that has
-            // different configuration requirements.
-            STATIC_ASSERT(VOLTAGE_SENSOR_ADC_VBAT == 0, VOLTAGE_SENSOR_ADC_VBAT_incorrect); // VOLTAGE_SENSOR_ADC_VBAT should be the first index
-            sbufWriteU8(dst, MAX_VOLTAGE_SENSOR_ADC); // voltage meters in payload
-            for (int i = VOLTAGE_SENSOR_ADC_VBAT; i < MAX_VOLTAGE_SENSOR_ADC; i++) {
-                const uint8_t adcSensorSubframeLength = 1 + 1 + 1 + 1 + 1; // length of id, type, vbatscale, vbatresdivval, vbatresdivmultipler, in bytes
-                sbufWriteU8(dst, adcSensorSubframeLength); // ADC sensor sub-frame length
+    case MSP_VOLTAGE_METER_CONFIG: {
+        // by using a sensor type and a sub-frame length it's possible to configure any type of voltage meter,
+        // e.g. an i2c/spi/can sensor or any sensor not built directly into the FC such as ESC/RX/SPort/SBus that has
+        // different configuration requirements.
+        STATIC_ASSERT(VOLTAGE_SENSOR_ADC_VBAT == 0, VOLTAGE_SENSOR_ADC_VBAT_incorrect); // VOLTAGE_SENSOR_ADC_VBAT should be the first index
+        sbufWriteU8(dst, MAX_VOLTAGE_SENSOR_ADC); // voltage meters in payload
+        for (int i = VOLTAGE_SENSOR_ADC_VBAT; i < MAX_VOLTAGE_SENSOR_ADC; i++) {
+            const uint8_t adcSensorSubframeLength = 1 + 1 + 1 + 1 + 1; // length of id, type, vbatscale, vbatresdivval, vbatresdivmultipler, in bytes
+            sbufWriteU8(dst, adcSensorSubframeLength); // ADC sensor sub-frame length
 
-                sbufWriteU8(dst, voltageMeterADCtoIDMap[i]); // id of the sensor
-                sbufWriteU8(dst, VOLTAGE_SENSOR_TYPE_ADC_RESISTOR_DIVIDER); // indicate the type of sensor that the next part of the payload is for
+            sbufWriteU8(dst, voltageMeterADCtoIDMap[i]); // id of the sensor
+            sbufWriteU8(dst, VOLTAGE_SENSOR_TYPE_ADC_RESISTOR_DIVIDER); // indicate the type of sensor that the next part of the payload is for
 
-                sbufWriteU8(dst, voltageSensorADCConfig(i)->vbatscale);
-                sbufWriteU8(dst, voltageSensorADCConfig(i)->vbatresdivval);
-                sbufWriteU8(dst, voltageSensorADCConfig(i)->vbatresdivmultiplier);
-            }
-            // if we had any other voltage sensors, this is where we would output any needed configuration
+            sbufWriteU8(dst, voltageSensorADCConfig(i)->vbatscale);
+            sbufWriteU8(dst, voltageSensorADCConfig(i)->vbatresdivval);
+            sbufWriteU8(dst, voltageSensorADCConfig(i)->vbatresdivmultiplier);
         }
-
+        // if we had any other voltage sensors, this is where we would output any needed configuration
         break;
+    }
+
     case MSP_CURRENT_METER_CONFIG: {
         // the ADC and VIRTUAL sensors have the same configuration requirements, however this API reflects
         // that this situation may change and allows us to support configuration of any current sensor with
@@ -1085,78 +1089,75 @@ static bool mspProcessOutCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, sbuf_t
 
     switch (cmdMSP) {
     case MSP_STATUS_EX:
-    case MSP_STATUS:
-        {
-            boxBitmask_t flightModeFlags;
-            const int flagBits = packFlightModeFlags(&flightModeFlags);
+    case MSP_STATUS: {
+        boxBitmask_t flightModeFlags;
+        const int flagBits = packFlightModeFlags(&flightModeFlags);
 
-            sbufWriteU16(dst, getTaskDeltaTimeUs(TASK_PID));
+        sbufWriteU16(dst, getTaskDeltaTimeUs(TASK_PID));
 #ifdef USE_I2C
-            sbufWriteU16(dst, i2cGetErrorCounter());
+        sbufWriteU16(dst, i2cGetErrorCounter());
 #else
-            sbufWriteU16(dst, 0);
+        sbufWriteU16(dst, 0);
 #endif
-            sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_RANGEFINDER) << 4 | sensors(SENSOR_GYRO) << 5);
-            sbufWriteData(dst, &flightModeFlags, 4);        // unconditional part of flags, first 32 bits
-            sbufWriteU8(dst, getCurrentPidProfileIndex());
-            sbufWriteU16(dst, constrain(getAverageSystemLoadPercent(), 0, LOAD_PERCENTAGE_ONE));
-            if (cmdMSP == MSP_STATUS_EX) {
-                sbufWriteU8(dst, PID_PROFILE_COUNT);
-                sbufWriteU8(dst, getCurrentControlRateProfileIndex());
-            } else {  // MSP_STATUS
-                sbufWriteU16(dst, 0); // gyro cycle time
-            }
+        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_RANGEFINDER) << 4 | sensors(SENSOR_GYRO) << 5);
+        sbufWriteData(dst, &flightModeFlags, 4);        // unconditional part of flags, first 32 bits
+        sbufWriteU8(dst, getCurrentPidProfileIndex());
+        sbufWriteU16(dst, constrain(getAverageSystemLoadPercent(), 0, LOAD_PERCENTAGE_ONE));
+        if (cmdMSP == MSP_STATUS_EX) {
+            sbufWriteU8(dst, PID_PROFILE_COUNT);
+            sbufWriteU8(dst, getCurrentControlRateProfileIndex());
+        } else {  // MSP_STATUS
+            sbufWriteU16(dst, 0); // gyro cycle time
+        }
 
-            // write flightModeFlags header. Lowest 4 bits contain number of bytes that follow
-            // header is emited even when all bits fit into 32 bits to allow future extension
-            int byteCount = (flagBits - 32 + 7) / 8;        // 32 already stored, round up
-            byteCount = constrain(byteCount, 0, 15);        // limit to 16 bytes (128 bits)
-            sbufWriteU8(dst, byteCount);
-            sbufWriteData(dst, ((uint8_t*)&flightModeFlags) + 4, byteCount);
+        // write flightModeFlags header. Lowest 4 bits contain number of bytes that follow
+        // header is emited even when all bits fit into 32 bits to allow future extension
+        int byteCount = (flagBits - 32 + 7) / 8;        // 32 already stored, round up
+        byteCount = constrain(byteCount, 0, 15);        // limit to 16 bytes (128 bits)
+        sbufWriteU8(dst, byteCount);
+        sbufWriteData(dst, ((uint8_t*)&flightModeFlags) + 4, byteCount);
 
-            // Write arming disable flags
-            // 1 byte, flag count
-            sbufWriteU8(dst, ARMING_DISABLE_FLAGS_COUNT);
-            // 4 bytes, flags
-            const uint32_t armingDisableFlags = getArmingDisableFlags();
-            sbufWriteU32(dst, armingDisableFlags);
+        // Write arming disable flags
+        // 1 byte, flag count
+        sbufWriteU8(dst, ARMING_DISABLE_FLAGS_COUNT);
+        // 4 bytes, flags
+        const uint32_t armingDisableFlags = getArmingDisableFlags();
+        sbufWriteU32(dst, armingDisableFlags);
 
-            // config state flags - bits to indicate the state of the configuration, reboot required, etc.
-            // other flags can be added as needed
-            sbufWriteU8(dst, (getRebootRequired() << 0));
+        // config state flags - bits to indicate the state of the configuration, reboot required, etc.
+        // other flags can be added as needed
+        sbufWriteU8(dst, (getRebootRequired() << 0));
 
-            // Added in API version 1.46
-            // Write CPU temp
+        // Added in API version 1.46
+        // Write CPU temp
 #ifdef USE_ADC_INTERNAL
-            sbufWriteU16(dst, getCoreTemperatureCelsius());
+        sbufWriteU16(dst, getCoreTemperatureCelsius());
+#else
+        sbufWriteU16(dst, 0);
+#endif
+        break;
+    }
+
+    case MSP_RAW_IMU: {
+        for (int i = 0; i < 3; i++) {
+#if defined(USE_ACC)
+            sbufWriteU16(dst, lrintf(acc.accADC.v[i]));
+#else
+            sbufWriteU16(dst, 0);
+#endif
+        }
+        for (int i = 0; i < 3; i++) {
+            sbufWriteU16(dst, gyroRateDps(i));
+        }
+        for (int i = 0; i < 3; i++) {
+#if defined(USE_MAG)
+            sbufWriteU16(dst, lrintf(mag.magADC.v[i]));
 #else
             sbufWriteU16(dst, 0);
 #endif
         }
         break;
-
-    case MSP_RAW_IMU:
-        {
-
-            for (int i = 0; i < 3; i++) {
-#if defined(USE_ACC)
-                sbufWriteU16(dst, lrintf(acc.accADC.v[i]));
-#else
-                sbufWriteU16(dst, 0);
-#endif
-            }
-            for (int i = 0; i < 3; i++) {
-                sbufWriteU16(dst, gyroRateDps(i));
-            }
-            for (int i = 0; i < 3; i++) {
-#if defined(USE_MAG)
-                sbufWriteU16(dst, lrintf(mag.magADC.v[i]));
-#else
-                sbufWriteU16(dst, 0);
-#endif
-            }
-        }
-        break;
+    }
 
 case MSP_NAME:
         sbufWriteString(dst, pilotConfig()->craftName);
@@ -1203,7 +1204,6 @@ case MSP_NAME:
             sbufWriteU16(dst, 0);
 #endif
         }
-
         break;
 
     // Added in API version 1.42
@@ -1285,32 +1285,30 @@ case MSP_NAME:
         break;
 
 #ifdef USE_VTX_COMMON
-    case MSP2_GET_VTX_DEVICE_STATUS:
-        {
-            const vtxDevice_t *vtxDevice = vtxCommonDevice();
-            vtxCommonSerializeDeviceStatus(vtxDevice, dst);
-        }
+    case MSP2_GET_VTX_DEVICE_STATUS: {
+        const vtxDevice_t *vtxDevice = vtxCommonDevice();
+        vtxCommonSerializeDeviceStatus(vtxDevice, dst);
         break;
+    }
 #endif
 
 #ifdef USE_OSD
-    case MSP2_GET_OSD_WARNINGS:
-        {
-            bool isBlinking;
-            uint8_t displayAttr;
-            char warningsBuffer[OSD_WARNINGS_MAX_SIZE + 1];
+    case MSP2_GET_OSD_WARNINGS: {
+        bool isBlinking;
+        uint8_t displayAttr;
+        char warningsBuffer[OSD_WARNINGS_MAX_SIZE + 1];
 
-            renderOsdWarning(warningsBuffer, &isBlinking, &displayAttr);
-            const uint8_t warningsLen = strlen(warningsBuffer);
+        renderOsdWarning(warningsBuffer, &isBlinking, &displayAttr);
+        const uint8_t warningsLen = strlen(warningsBuffer);
 
-            if (isBlinking) {
-                displayAttr |= DISPLAYPORT_BLINK;
-            }
-            sbufWriteU8(dst, displayAttr);  // see displayPortSeverity_e
-            sbufWriteU8(dst, warningsLen);  // length byte followed by the actual characters
-            sbufWriteData(dst, warningsBuffer, warningsLen);
-            break;
+        if (isBlinking) {
+            displayAttr |= DISPLAYPORT_BLINK;
         }
+        sbufWriteU8(dst, displayAttr);  // see displayPortSeverity_e
+        sbufWriteU8(dst, warningsLen);  // length byte followed by the actual characters
+        sbufWriteData(dst, warningsBuffer, warningsLen);
+        break;
+    }
 #endif
 
     case MSP_RC:
@@ -1687,6 +1685,7 @@ case MSP_NAME:
             sbufWriteU8(dst, serialConfig()->portConfigs[i].blackbox_baudrateIndex);
         }
         break;
+
     case MSP2_COMMON_SERIAL_CONFIG: {
         uint8_t count = 0;
         for (int i = 0; i < SERIAL_PORT_COUNT; i++) {
@@ -1876,6 +1875,7 @@ case MSP_NAME:
 #endif
         break;
     }
+
     case MSP_ADVANCED_CONFIG:
         sbufWriteU8(dst, 1);  // was gyroConfig()->gyro_sync_denom - removed in API 1.43
         sbufWriteU8(dst, pidConfig()->pid_process_denom);
@@ -1894,9 +1894,9 @@ case MSP_NAME:
         //Added in MSP API 1.42
         sbufWriteU8(dst, systemConfig()->debug_mode);
         sbufWriteU8(dst, DEBUG_COUNT);
-
         break;
-    case MSP_FILTER_CONFIG :
+
+    case MSP_FILTER_CONFIG:
         sbufWriteU8(dst, gyroConfig()->gyro_lpf1_static_hz);
         sbufWriteU16(dst, currentPidProfile->dterm_lpf1_static_hz);
         sbufWriteU16(dst, currentPidProfile->yaw_lowpass_hz);
@@ -1963,8 +1963,8 @@ case MSP_NAME:
 #else
         sbufWriteU8(dst, 0);
 #endif
-
         break;
+
     case MSP_PID_ADVANCED:
         sbufWriteU16(dst, 0);
         sbufWriteU16(dst, 0);
@@ -2147,44 +2147,43 @@ case MSP_NAME:
         break;
 
 #if defined(USE_VTX_COMMON)
-    case MSP_VTX_CONFIG:
-        {
-            const vtxDevice_t *vtxDevice = vtxCommonDevice();
-            unsigned vtxStatus = 0;
-            vtxDevType_e vtxType = VTXDEV_UNKNOWN;
-            uint8_t deviceIsReady = 0;
-            if (vtxDevice) {
-                vtxCommonGetStatus(vtxDevice, &vtxStatus);
-                vtxType = vtxCommonGetDeviceType(vtxDevice);
-                deviceIsReady = vtxCommonDeviceIsReady(vtxDevice) ? 1 : 0;
-            }
-            sbufWriteU8(dst, vtxType);
-            sbufWriteU8(dst, vtxSettingsConfig()->band);
-            sbufWriteU8(dst, vtxSettingsConfig()->channel);
-            sbufWriteU8(dst, vtxSettingsConfig()->power);
-            sbufWriteU8(dst, (vtxStatus & VTX_STATUS_PIT_MODE) ? 1 : 0);
-            sbufWriteU16(dst, vtxSettingsConfig()->freq);
-            sbufWriteU8(dst, deviceIsReady);
-            sbufWriteU8(dst, vtxSettingsConfig()->lowPowerDisarm);
+    case MSP_VTX_CONFIG: {
+        const vtxDevice_t *vtxDevice = vtxCommonDevice();
+        unsigned vtxStatus = 0;
+        vtxDevType_e vtxType = VTXDEV_UNKNOWN;
+        uint8_t deviceIsReady = 0;
+        if (vtxDevice) {
+            vtxCommonGetStatus(vtxDevice, &vtxStatus);
+            vtxType = vtxCommonGetDeviceType(vtxDevice);
+            deviceIsReady = vtxCommonDeviceIsReady(vtxDevice) ? 1 : 0;
+        }
+        sbufWriteU8(dst, vtxType);
+        sbufWriteU8(dst, vtxSettingsConfig()->band);
+        sbufWriteU8(dst, vtxSettingsConfig()->channel);
+        sbufWriteU8(dst, vtxSettingsConfig()->power);
+        sbufWriteU8(dst, (vtxStatus & VTX_STATUS_PIT_MODE) ? 1 : 0);
+        sbufWriteU16(dst, vtxSettingsConfig()->freq);
+        sbufWriteU8(dst, deviceIsReady);
+        sbufWriteU8(dst, vtxSettingsConfig()->lowPowerDisarm);
 
-            // API version 1.42
-            sbufWriteU16(dst, vtxSettingsConfig()->pitModeFreq);
+        // API version 1.42
+        sbufWriteU16(dst, vtxSettingsConfig()->pitModeFreq);
 #ifdef USE_VTX_TABLE
-            sbufWriteU8(dst, 1);   // vtxtable is available
-            sbufWriteU8(dst, vtxTableConfig()->bands);
-            sbufWriteU8(dst, vtxTableConfig()->channels);
-            sbufWriteU8(dst, vtxTableConfig()->powerLevels);
+        sbufWriteU8(dst, 1);   // vtxtable is available
+        sbufWriteU8(dst, vtxTableConfig()->bands);
+        sbufWriteU8(dst, vtxTableConfig()->channels);
+        sbufWriteU8(dst, vtxTableConfig()->powerLevels);
 #else
-            sbufWriteU8(dst, 0);
-            sbufWriteU8(dst, 0);
-            sbufWriteU8(dst, 0);
-            sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
 #endif
 #ifdef USE_VTX_MSP
-            setMspVtxDeviceStatusReady(srcDesc);
+        setMspVtxDeviceStatusReady(srcDesc);
 #endif
-        }
         break;
+    }
 #endif
 
     case MSP_TX_INFO:
@@ -2199,25 +2198,24 @@ case MSP_NAME:
         rtcDateTimeIsSet = RTC_NOT_SUPPORTED;
 #endif
         sbufWriteU8(dst, rtcDateTimeIsSet);
-
         break;
+
 #ifdef USE_RTC_TIME
-    case MSP_RTC:
-        {
-            dateTime_t dt;
-            if (rtcGetDateTime(&dt)) {
-                sbufWriteU16(dst, dt.year);
-                sbufWriteU8(dst, dt.month);
-                sbufWriteU8(dst, dt.day);
-                sbufWriteU8(dst, dt.hours);
-                sbufWriteU8(dst, dt.minutes);
-                sbufWriteU8(dst, dt.seconds);
-                sbufWriteU16(dst, dt.millis);
-            }
+    case MSP_RTC: {
+        dateTime_t dt;
+        if (rtcGetDateTime(&dt)) {
+            sbufWriteU16(dst, dt.year);
+            sbufWriteU8(dst, dt.month);
+            sbufWriteU8(dst, dt.day);
+            sbufWriteU8(dst, dt.hours);
+            sbufWriteU8(dst, dt.minutes);
+            sbufWriteU8(dst, dt.seconds);
+            sbufWriteU16(dst, dt.millis);
         }
-
         break;
+    }
 #endif
+
     default:
         unsupportedCommand = true;
     }

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -30,7 +30,7 @@
 #define MSP2_SET_LED_STRIP_CONFIG_VALUES    0x3009
 #define MSP2_SENSOR_CONFIG_ACTIVE           0x300A
 #define MSP2_SENSOR_OPTICALFLOW             0x300B
-#define MSP2_MCU_TYPE_INFO                  0x300C
+#define MSP2_MCU_INFO                       0x300C
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -30,6 +30,7 @@
 #define MSP2_SET_LED_STRIP_CONFIG_VALUES    0x3009
 #define MSP2_SENSOR_CONFIG_ACTIVE           0x300A
 #define MSP2_SENSOR_OPTICALFLOW             0x300B
+#define MSP2_MCU_TYPE_INFO                  0x300C
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -773,3 +773,9 @@ IO_t IOGetByTag(ioTag_t tag)
     UNUSED(tag);
     return NULL;
 }
+
+const mcuTypeInfo_t *getMcuTypeInfo(void)
+{
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_SIMULATOR, .name = "SIMULATOR" };
+    return &info;
+}

--- a/src/platform/common/stm32/system.c
+++ b/src/platform/common/stm32/system.c
@@ -325,60 +325,59 @@ void unusedPinsInit(void)
 
 const mcuTypeInfo_t *getMcuTypeInfo(void)
 {
-#if defined(STM32H743xx)
     static const mcuTypeInfo_t info[] = {
-        { .id = MCU_TYPE_H743_REV_Y, .name = "H743 (Rev.Y)" },
-        { .id = MCU_TYPE_H743_REV_X, .name = "H743 (Rev.X)" },
-        { .id = MCU_TYPE_H743_REV_V, .name = "H743 (Rev.V)" },
-        { .id = MCU_TYPE_H743_REV_UNKNOWN, .name = "H743 (Rev Unknown)" },
+#if defined(STM32H743xx)
+        { .id = MCU_TYPE_H743_REV_UNKNOWN, .name = "STM32H743 (Rev Unknown)" },
+        { .id = MCU_TYPE_H743_REV_Y, .name = "STM32H743 (Rev.Y)" },
+        { .id = MCU_TYPE_H743_REV_X, .name = "STM32H743 (Rev.X)" },
+        { .id = MCU_TYPE_H743_REV_V, .name = "STM32H743 (Rev.V)" },
+#elif defined(STM32F40_41xxx)
+        { .id = MCU_TYPE_F40X, .name = "STM32F40X" },
+#elif defined(STM32F411xE)
+        { .id = MCU_TYPE_F411, .name = "STM32F411" },
+#elif defined(STM32F446xx)
+        { .id = MCU_TYPE_F446, .name = "STM32F446" },
+#elif defined(STM32F722xx)
+        { .id = MCU_TYPE_F722, .name = "STM32F722" },
+#elif defined(STM32F745xx)
+        { .id = MCU_TYPE_F745, .name = "STM32F745" },
+#elif defined(STM32F746xx)
+        { .id = MCU_TYPE_F746, .name = "STM32F746" },
+#elif defined(STM32F765xx)
+        { .id = MCU_TYPE_F765, .name = "STM32F765" },
+#elif defined(STM32H750xx)
+        { .id = MCU_TYPE_H750, .name = "STM32H750" },
+#elif defined(STM32H730xx)
+        { .id = MCU_TYPE_H730, .name = "STM32H730" },
+#elif defined(STM32H7A3xx) || defined(STM32H7A3xxQ)
+        { .id = MCU_TYPE_H7A3, .name = "STM32H7A3" },
+#elif defined(STM32H723xx) || defined(STM32H725xx)
+        { .id = MCU_TYPE_H723_725, .name = "STM32H723/H725" },
+#elif defined(STM32G474xx)
+        { .id = MCU_TYPE_G474, .name = "STM32G474" },
+#elif defined(AT32F435G)
+        { .id = MCU_TYPE_AT32F435G, .name = "AT32F435G" },
+#elif defined(AT32F435M)
+        { .id = MCU_TYPE_AT32F435M, .name = "AT32F435M" },
+#elif defined(APM32F405)
+        { .id = MCU_TYPE_APM32F405, .name = "APM32F405" },
+#elif defined(APM32F407)
+        { .id = MCU_TYPE_APM32F407, .name = "APM32F407" },
+#else
+#error MCU Type info not defined for STM (or clone)
+#endif
     };
-
+#if defined(STM32H743xx)
     switch (HAL_GetREVID()) {
     case REV_ID_Y:
-        return &info[0];
+        return info + 1;
     case REV_ID_X:
-        return &info[1];
+        return info + 2;
     case REV_ID_V:
-        return &info[2];
+        return info + 3;
     default:
-        return &info[3];
+        return info;
     }
-#else
-#if defined(STM32F40_41xxx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F40X, .name = "F40X" };
-#elif defined(STM32F411xE)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F411, .name = "F411" };
-#elif defined(STM32F446xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F446, .name = "F446" };
-#elif defined(STM32F722xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F722, .name = "F722" };
-#elif defined(STM32F745xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F745, .name = "F745" };
-#elif defined(STM32F746xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F746, .name = "F746" };
-#elif defined(STM32F765xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F765, .name = "F765" };
-#elif defined(STM32H750xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H750, .name = "H750" };
-#elif defined(STM32H730xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H730, .name = "H730" };
-#elif defined(STM32H7A3xx) || defined(STM32H7A3xxQ)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H7A3, .name = "H7A3" };
-#elif defined(STM32H723xx) || defined(STM32H725xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H723_725, .name = "H723/H725" };
-#elif defined(STM32G474xx)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_G474, .name = "G474" };
-#elif defined(AT32F435G)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_AT32F435G, .name = "AT32F435G" };
-#elif defined(AT32F435M)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_AT32F435M, .name = "AT32F435M" };
-#elif defined(APM32F405)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_APM32F405, .name = "APM32F405" };
-#elif defined(APM32F407)
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_APM32F407, .name = "APM32F407" };
-#else
-    static const mcuTypeInfo_t info = { .id = MCU_TYPE_UNKNOWN, .name = "Unknown" };
 #endif
-    return &info;
-#endif
+    return info;
 }

--- a/src/platform/common/stm32/system.c
+++ b/src/platform/common/stm32/system.c
@@ -367,17 +367,21 @@ const mcuTypeInfo_t *getMcuTypeInfo(void)
 #error MCU Type info not defined for STM (or clone)
 #endif
     };
+    unsigned revision = 0;
 #if defined(STM32H743xx)
     switch (HAL_GetREVID()) {
     case REV_ID_Y:
-        return info + 1;
+        revision = 1;
+        break;
     case REV_ID_X:
-        return info + 2;
+        revision = 2;
+        break;
     case REV_ID_V:
-        return info + 3;
+        revision = 3;
+        break;
     default:
-        return info;
+        revision = 0;
     }
 #endif
-    return info;
+    return info + revision;
 }

--- a/src/platform/common/stm32/system.c
+++ b/src/platform/common/stm32/system.c
@@ -322,3 +322,63 @@ void unusedPinsInit(void)
 {
     IOTraversePins(unusedPinInit);
 }
+
+const mcuTypeInfo_t *getMcuTypeInfo(void)
+{
+#if defined(STM32H743xx)
+    static const mcuTypeInfo_t info[] = {
+        { .id = MCU_TYPE_H743_REV_Y, .name = "H743 (Rev.Y)" },
+        { .id = MCU_TYPE_H743_REV_X, .name = "H743 (Rev.X)" },
+        { .id = MCU_TYPE_H743_REV_V, .name = "H743 (Rev.V)" },
+        { .id = MCU_TYPE_H743_REV_UNKNOWN, .name = "H743 (Rev Unknown)" },
+    };
+
+    switch (HAL_GetREVID()) {
+    case REV_ID_Y:
+        return &info[0];
+    case REV_ID_X:
+        return &info[1];
+    case REV_ID_V:
+        return &info[2];
+    default:
+        return &info[3];
+    }
+#else
+#if defined(STM32F40_41xxx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F40X, .name = "F40X" };
+#elif defined(STM32F411xE)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F411, .name = "F411" };
+#elif defined(STM32F446xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F446, .name = "F446" };
+#elif defined(STM32F722xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F722, .name = "F722" };
+#elif defined(STM32F745xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F745, .name = "F745" };
+#elif defined(STM32F746xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F746, .name = "F746" };
+#elif defined(STM32F765xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_F765, .name = "F765" };
+#elif defined(STM32H750xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H750, .name = "H750" };
+#elif defined(STM32H730xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H730, .name = "H730" };
+#elif defined(STM32H7A3xx) || defined(STM32H7A3xxQ)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H7A3, .name = "H7A3" };
+#elif defined(STM32H723xx) || defined(STM32H725xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_H723_725, .name = "H723/H725" };
+#elif defined(STM32G474xx)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_G474, .name = "G474" };
+#elif defined(AT32F435G)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_AT32F435G, .name = "AT32F435G" };
+#elif defined(AT32F435M)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_AT32F435M, .name = "AT32F435M" };
+#elif defined(APM32F405)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_APM32F405, .name = "APM32F405" };
+#elif defined(APM32F407)
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_APM32F407, .name = "APM32F407" };
+#else
+    static const mcuTypeInfo_t info = { .id = MCU_TYPE_UNKNOWN, .name = "Unknown" };
+#endif
+    return &info;
+#endif
+}

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -342,7 +342,7 @@ void schedulerResetTaskMaxExecutionTime(taskId_e) {}
 void schedulerResetCheckFunctionMaxExecutionTime(void) {}
 
 const char * const targetName = "UNITTEST";
-const char* const buildDate = "Jan 01 2017";
+const char * const buildDate = "Jan 01 2017";
 const char * const buildTime = "00:00:00";
 const char * const shortGitRevision = "MASTER";
 
@@ -401,6 +401,7 @@ bool isModeActivationConditionConfigured(const modeActivationCondition_t *, cons
 void delay(uint32_t) {}
 displayPort_t *osdGetDisplayPort(osdDisplayPortDevice_e *) { return NULL; }
 mcuTypeId_e getMcuTypeId(void) { return MCU_TYPE_UNKNOWN; }
+const char *getMcuTypeName(void) { return targetName; }
 uint16_t getCurrentRxRateHz(void) { return 0; }
 uint16_t getAverageSystemLoadPercent(void) { return 0; }
 bool getRxRateValid(void) { return false; }


### PR DESCRIPTION
Added based on suggestion from @ledvinap - removes need to store string array for MCU names that do not exist in a build.

Adding MSP command to get the text name to remove the need to keep the configurator in sync.

Minor formatting inconsistencies corrected in msp.c