### PR TITLE
Improve accuracy of dT used to update RPM filter

### DIFF
--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -121,6 +121,9 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
         return;
     }
 
+    const float dtCompensation = schedulerGetCycleTimeMultiplier();
+    const float correctedLooptime = rpmFilter.looptimeUs * dtCompensation;
+
     // update RPM notches
     for (int i = 0; i < notchUpdatesPerIteration; i++) {
 
@@ -143,7 +146,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             weight *= rpmFilter.weights[harmonicIndex];
 
             // update notch
-            biquadFilterUpdate(template, frequencyHz, rpmFilter.looptimeUs, rpmFilter.q, FILTER_NOTCH, weight);
+            biquadFilterUpdate(template, frequencyHz, correctedLooptime, rpmFilter.q, FILTER_NOTCH, weight);
 
             // copy notch properties to corresponding notches on PITCH and YAW
             for (int axis = 1; axis < XYZ_AXIS_COUNT; axis++) {


### PR DESCRIPTION
After some discussions it was realized that BF initializes and updates filters based on the gyro rate that we expect the gyro to be run at. The gyro will tend to slightly faster or slower than this rate due to its internal clock not being totally accurate. This can lead to the gyro running +-1% or more. This PR uses the function `schedulerGetCycleTimeMultiplier()` to find how much faster or slower the gyro is running compared to the rate we expect it to run. This is then used as a corrective term to the dt value used for RPM notch filters. This should improve the accuracy of these filters by 1% or more.

Warning: Not flight tested yet, but bench tested.