### PR TITLE
FIX: REVISION length not more than 7 symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 REVISION := norevision
 ifeq ($(shell git diff --shortstat),)
-REVISION := $(shell git log -1 --format="%h")
+REVISION := $(shell git log -1 --format="%h" | head -c 7)
 endif
 
 LD_FLAGS        :=

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 REVISION := norevision
 ifeq ($(shell git diff --shortstat),)
-REVISION := $(shell git log -1 --format="%h" | head -c 7)
+REVISION := $(shell git rev-parse --short=9 HEAD | head -c 9)
 endif
 
 LD_FLAGS        :=

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 REVISION := norevision
 ifeq ($(shell git diff --shortstat),)
-REVISION := $(shell git rev-parse --short=9 HEAD | head -c 9)
+REVISION := $(shell git rev-parse --short=9 HEAD)
 endif
 
 LD_FLAGS        :=

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -32,7 +32,7 @@
 
 extern const char* const targetName;
 
-#define GIT_SHORT_REVISION_LENGTH   7 // lower case hexadecimal digits.
+#define GIT_SHORT_REVISION_LENGTH   9 // lower case hexadecimal digits.
 extern const char* const shortGitRevision;
 
 #define GIT_SHORT_CONFIG_REVISION_LENGTH   7 // lower case hexadecimal digits.

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -32,7 +32,7 @@
 
 extern const char* const targetName;
 
-#define GIT_SHORT_REVISION_LENGTH   9 // lower case hexadecimal digits.
+#define GIT_SHORT_REVISION_LENGTH   7 // lower case hexadecimal digits.
 extern const char* const shortGitRevision;
 
 #define GIT_SHORT_CONFIG_REVISION_LENGTH   7 // lower case hexadecimal digits.


### PR DESCRIPTION
"git log -1 --format="%h""
returns string which can be longer than 7 symbols. I guess it may lead to a problem with:
#define GIT_SHORT_REVISION_LENGTH   7
in file:
betaflight\src\main\build\version.h

For example, "git version 2.47.1.windows.1" for commit "889aa9f9dac8a2fa38e327145955db4ee11d9894" returns "889aa9f9d" as result of "git log -1 --format="%h"".