### PR TITLE
Don't waste time displaying an empty OSD string

### DIFF
--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -93,6 +93,12 @@ int displayWrite(displayPort_t *instance, uint8_t x, uint8_t y, uint8_t attr, co
 {
     instance->posX = x + strlen(text);
     instance->posY = y;
+
+    if (strlen(text) == 0) {
+        // No point sending a message to do nothing
+        return 0;
+    }
+
     return instance->vTable->writeString(instance, x, y, attr, text);
 }
 


### PR DESCRIPTION
Using the Saleae Logic MSP High-Level Analyzer (HLA) at https://github.com/SteveCEvans/betaflightMSP I noticed that blank strings were being send over MSP to the VTX thus at row 13, column 20, the coordinates of the warning string:

![image](https://github.com/user-attachments/assets/baaf88af-6c87-448c-9eaa-4691cb831f60)

With a valid warning displayed this appeared thus:

![image](https://github.com/user-attachments/assets/d0a9e7f3-9307-404f-899f-a0162bfeffc2)

With the PR, when no warning is to be displayed no blank string is sent. Whilst easily demonstrated using MSP, this fix applies to all OSD interfaces.

![image](https://github.com/user-attachments/assets/2b16de78-d767-4f61-ae80-554fe2ce7637)
