### PR TITLE
Serial - BUGFIX - USART10 instead of UART10

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -490,7 +490,7 @@ UART_IRQHandler(UART, 9, UARTDEV_9)  // UART9 Rx/Tx IRQ Handler
 #endif
 
 #ifdef USE_UART10
-UART_IRQHandler(UART, 10, UARTDEV_10) // UART10 Rx/Tx IRQ Handler
+UART_IRQHandler(USART, 10, UARTDEV_10) // UART10 Rx/Tx IRQ Handler
 #endif
 
 #ifdef USE_LPUART1


### PR DESCRIPTION
Uart10 was broken on STM32H730, it is only target using it

