### PR TITLE
Add ability to specify a config.c file for a config target

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -16,10 +16,17 @@ ifneq ($(TARGET),)
 $(error TARGET or CONFIG should be specified. Not both.)
 endif
 
-CONFIG_FILE      = $(CONFIG_DIR)/configs/$(CONFIG)/config.h
-INCLUDE_DIRS    += $(CONFIG_DIR)/configs/$(CONFIG)
+CONFIG_HEADER_FILE  = $(CONFIG_DIR)/configs/$(CONFIG)/config.h
+CONFIG_SOURCE_FILE  = $(CONFIG_DIR)/configs/$(CONFIG)/config.c
+INCLUDE_DIRS       += $(CONFIG_DIR)/configs/$(CONFIG)
 
-ifneq ($(wildcard $(CONFIG_FILE)),)
+ifneq ($(wildcard $(CONFIG_HEADER_FILE)),)
+
+CONFIG_SRC :=
+ifneq ($(wildcard $(CONFIG_SOURCE_FILE)),)
+CONFIG_SRC += $(CONFIG_SOURCE_FILE)
+TARGET_FLAGS += -DUSE_CONFIG_SOURCE
+endif
 
 CONFIG_REVISION := norevision
 ifeq ($(shell git -C $(CONFIG_DIR) diff --shortstat),)
@@ -27,26 +34,26 @@ CONFIG_REVISION := $(shell git -C $(CONFIG_DIR) log -1 --format="%h")
 CONFIG_REVISION_DEFINE := -D'__CONFIG_REVISION__="$(CONFIG_REVISION)"'
 endif
 
-TARGET        := $(shell grep " FC_TARGET_MCU" $(CONFIG_FILE) | awk '{print $$3}' )
-HSE_VALUE_MHZ := $(shell grep " SYSTEM_HSE_MHZ" $(CONFIG_FILE) | awk '{print $$3}' )
+TARGET        := $(shell grep " FC_TARGET_MCU" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
+HSE_VALUE_MHZ := $(shell grep " SYSTEM_HSE_MHZ" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
 ifneq ($(HSE_VALUE_MHZ),)
 HSE_VALUE     := $(shell echo $$(( $(HSE_VALUE_MHZ) * 1000000 )) )
 endif
 
-GYRO_DEFINE   := $(shell grep " USE_GYRO_" $(CONFIG_FILE) | awk '{print $$2}' )
+GYRO_DEFINE   := $(shell grep " USE_GYRO_" $(CONFIG_HEADER_FILE) | awk '{print $$2}' )
 
 ifeq ($(TARGET),)
-$(error No TARGET identified. Is the $(CONFIG_FILE) valid for $(CONFIG)?)
+$(error No TARGET identified. Is the $(CONFIG_HEADER_FILE) valid for $(CONFIG)?)
 endif
 
-EXST_ADJUST_VMA := $(shell grep " FC_VMA_ADDRESS" $(CONFIG_FILE) | awk '{print $$3}' )
+EXST_ADJUST_VMA := $(shell grep " FC_VMA_ADDRESS" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
 ifneq ($(EXST_ADJUST_VMA),)
 EXST = yes
 endif
 
 else #exists
-$(error `$(CONFIG_FILE)` not found. Have you hydrated configuration using: 'make configs'?)
-endif #config_file exists
+$(error `$(CONFIG_HEADER_FILE)` not found. Have you hydrated configuration using: 'make configs'?)
+endif #CONFIG_HEADER_FILE exists
 endif #config
 
 .PHONY: configs

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -56,7 +56,6 @@ COMMON_SRC = \
             build/debug_pin.c \
             build/version.c \
             main.c \
-            $(PG_SRC) \
             common/bitarray.c \
             common/colorconversion.c \
             common/crc.c \
@@ -369,9 +368,8 @@ SDCARD_SRC += \
             io/asyncfatfs/asyncfatfs.c \
             io/asyncfatfs/fat_standard.c
 
-INCLUDE_DIRS    := $(INCLUDE_DIRS) \
-                   $(FATFS_DIR)
-VPATH           := $(VPATH):$(FATFS_DIR)
+INCLUDE_DIRS += $(FATFS_DIR)
+VPATH        := $(VPATH):$(FATFS_DIR)
 
 # Gyro driver files that only contain initialization and configuration code - not runtime code
 SIZE_OPTIMISED_SRC += \
@@ -411,22 +409,20 @@ SPEED_OPTIMISED_SRC += \
 
 endif
 
-COMMON_DEVICE_SRC = \
-            $(CMSIS_SRC) \
-            $(DEVICE_STDPERIPH_SRC)
+COMMON_DEVICE_SRC = $(CMSIS_SRC) $(DEVICE_STDPERIPH_SRC)
 
-COMMON_SRC := $(COMMON_SRC) $(COMMON_DEVICE_SRC) $(RX_SRC)
+COMMON_SRC += $(CONFIG_SRC) $(PG_SRC) $(COMMON_DEVICE_SRC) $(RX_SRC)
 
 ifeq ($(EXST),yes)
-TARGET_FLAGS := -DUSE_EXST $(TARGET_FLAGS)
+TARGET_FLAGS += -DUSE_EXST
 endif
 
 ifeq ($(RAM_BASED),yes)
-TARGET_FLAGS := -DUSE_EXST -DCONFIG_IN_RAM -DRAMBASED $(TARGET_FLAGS)
+TARGET_FLAGS += -DUSE_EXST -DCONFIG_IN_RAM -DRAMBASED
 endif
 
 ifeq ($(SIMULATOR_BUILD),yes)
-TARGET_FLAGS := -DSIMULATOR_BUILD $(TARGET_FLAGS)
+TARGET_FLAGS += -DSIMULATOR_BUILD
 endif
 
 SPEED_OPTIMISED_SRC += \

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -77,6 +77,7 @@ bool canSoftwareSerialBeUsed(void);
 void resetConfig(void);
 void targetConfiguration(void);
 void targetValidateConfiguration(void);
+void configTargetPreInit(void);
 
 bool isSystemConfigured(void);
 void setRebootRequired(void);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -278,13 +278,13 @@ void init(void)
     // initialize IO (needed for all IO operations)
     IOInitGlobal();
 
-#ifdef USE_HARDWARE_REVISION_DETECTION
-    detectHardwareRevision();
-#endif
-
 #if defined(USE_TARGET_CONFIG)
     // Call once before the config is loaded for any target specific configuration required to support loading the config
     targetConfiguration();
+#endif
+
+#if defined(USE_CONFIG_TARGET_PREINIT)
+    configTargetPreInit();
 #endif
 
     enum {


### PR DESCRIPTION
- adding configTargetPreInit() method to execute code for the config target

This will allow us to run abritrary code. I originally created this method years ago with target.c - so this is simply the same but using config.c, and not tying it to a release of betaflight - meaning it can be updated subsequently to a release to fix a specific config target if any issues become apparent with that config target.

