### PR TITLE
By default mark OSD element as rendered in case it's in the off blink state

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -2081,6 +2081,9 @@ void osdAddActiveElements(void)
 
 static bool osdDrawSingleElement(displayPort_t *osdDisplayPort, uint8_t item)
 {
+    // By default mark the element as rendered in case it's in the off blink state
+    activeElement.rendered = true;
+
     if (!osdElementDrawFunction[item]) {
         // Element has no drawing function
         return true;
@@ -2101,7 +2104,6 @@ static bool osdDrawSingleElement(displayPort_t *osdDisplayPort, uint8_t item)
     activeElement.buff = elementBuff;
     activeElement.osdDisplayPort = osdDisplayPort;
     activeElement.drawElement = true;
-    activeElement.rendered = true;
     activeElement.attr = DISPLAYPORT_SEVERITY_NORMAL;
 
     // Call the element drawing function


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/14149

This issue was caused by a slow ramp on the voltage ADC reading, peculiar to the `TBS_LUCID_FC` which resulted in it attempting to flash the battery voltage whilst rendering the Betaflight logo. It should have just skipped past the rendering routine for the battery voltage, but because it was in the off blink state the OSD state machine stalled waiting for the rendering to complete, which never happened.

This PR sets the default state to an element to be rendered so if an element is flashing and is in the off state it will be skipped. This may have been causing OSD issues when any element was flashing as rendering would stall when any element was in the off blink state.