### PR TITLE
Add 230K4 baudrate support for GPS

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1530,7 +1530,7 @@ static void cliSerialPassthrough(const char *cmdName, char *cmdline)
             cliPrintLinef("Invalid port%d %d", i + 1, ports[i].id);
             return;
         } else {
-            cliPrintLinef("Port%d: %s", i + 1, serialName(ports[i].id, "<invalid>"));
+            cliPrintLinef("Port%d: %s", i + 1, serialName(ports[i].id, invalidName));
         }
     }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1350,7 +1350,7 @@ static void cliSerial(const char *cmdName, char *cmdline)
             portConfig.msp_baudrateIndex = baudRateIndex;
             break;
         case 1:
-            if (baudRateIndex < BAUD_9600 || baudRateIndex > BAUD_115200) {
+            if (baudRateIndex < BAUD_9600 || baudRateIndex > BAUD_230400) {
                 continue;
             }
             portConfig.gps_baudrateIndex = baudRateIndex;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -107,6 +107,7 @@ typedef struct gpsInitData_s {
 
 // UBX will cycle through these until valid data is received
 static const gpsInitData_t gpsInitData[] = {
+    { BAUD_230400, "$PUBX,41,1,0003,0001,230400,0*1C\r\n" },
     { BAUD_115200, "$PUBX,41,1,0003,0001,115200,0*1E\r\n" },
     { BAUD_57600,  "$PUBX,41,1,0003,0001,57600,0*2D\r\n" },
     { BAUD_38400,  "$PUBX,41,1,0003,0001,38400,0*26\r\n" },


### PR DESCRIPTION
- [ ] - configurator change - https://github.com/betaflight/betaflight-configurator/pull/4317

This pull request includes changes to extend baud rate support and improve error messaging in the CLI.

Enhancements to baud rate support:

* [`src/main/cli/cli.c`](diffhunk://#diff-92382fe98d1b21a00115a698607460fe13ad7bdf44208bfd55c66b265268c076L1353-R1353): Updated the baud rate check in `cliSerial` to include support for `BAUD_230400`.
* [`src/main/io/gps.c`](diffhunk://#diff-15b828e75456a052109384cb9af7da6fb6001ebdf63c417647471ca2201cdee8R110): Added an entry for `BAUD_230400` in the `gpsInitData` array.

Improvements to error messaging:

* [`src/main/cli/cli.c`](diffhunk://#diff-92382fe98d1b21a00115a698607460fe13ad7bdf44208bfd55c66b265268c076L1533-R1533): Modified `cliSerialPassthrough` to use the `invalidName` variable for invalid port names, enhancing clarity in error messages.