### PR TITLE
Fix GPS UART representation (status command)

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4851,7 +4851,7 @@ if (buildKey) {
             if (!gpsPortConfig) {
                 cliPrint("NO PORT, ");
             } else {
-                cliPrintf("UART%d %ld (set to ", (gpsPortConfig->identifier + 1), baudRates[getGpsPortActualBaudRateIndex()]);
+                cliPrintf("%s %ld (set to ", serialName(gpsPortConfig->identifier, invalidName), baudRates[getGpsPortActualBaudRateIndex()]);
                 if (gpsConfig()->autoBaud == GPS_AUTOBAUD_ON) {
                     cliPrint("AUTO");
                 } else {


### PR DESCRIPTION
This pull request includes a change to the `src/main/cli/cli.c` file to improve the clarity of the GPS port configuration output. The most important change is the modification of the `cliPrintf` function to use the `serialName` function for better readability of the port identifier.

Output improvement:

* [`src/main/cli/cli.c`](diffhunk://#diff-92382fe98d1b21a00115a698607460fe13ad7bdf44208bfd55c66b265268c076L4854-R4857): Modified the `cliPrintf` function to use `serialName(gpsPortConfig->identifier, invalidName)` instead of directly printing the port identifier. This change enhances the readability of the GPS port configuration output.