### PR TITLE
Filter comment line while try to get SYSTEM_HSE_MHZ value.

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -34,19 +34,17 @@ CONFIG_REVISION := $(shell git -C $(CONFIG_DIR) log -1 --format="%h")
 CONFIG_REVISION_DEFINE := -D'__CONFIG_REVISION__="$(CONFIG_REVISION)"'
 endif
 
-TARGET        := $(shell grep " FC_TARGET_MCU" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
 HSE_VALUE_MHZ := $(shell sed -E -n "/^\s*#\s*define\s+SYSTEM_HSE_MHZ\s+([0-9]+).*/s//\1/p" $(CONFIG_HEADER_FILE))
 ifneq ($(HSE_VALUE_MHZ),)
 HSE_VALUE     := $(shell echo $$(( $(HSE_VALUE_MHZ) * 1000000 )) )
 endif
 
-GYRO_DEFINE   := $(shell grep " USE_GYRO_" $(CONFIG_HEADER_FILE) | awk '{print $$2}' )
-
+TARGET        := $(shell sed -E -n "/^\s*#\s*define\s+FC_TARGET_MCU\s+(\w+).*/s//\1/p" $(CONFIG_HEADER_FILE))
 ifeq ($(TARGET),)
 $(error No TARGET identified. Is the $(CONFIG_HEADER_FILE) valid for $(CONFIG)?)
 endif
 
-EXST_ADJUST_VMA := $(shell grep " FC_VMA_ADDRESS" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
+EXST_ADJUST_VMA := $(shell sed -E -n "/^\s*#\s*define\s+FC_VMA_ADDRESS\s+(0[xX][0-9a-fA-F]+).*/s//\1/p" $(CONFIG_HEADER_FILE))
 ifneq ($(EXST_ADJUST_VMA),)
 EXST = yes
 endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -44,7 +44,7 @@ ifeq ($(TARGET),)
 $(error No TARGET identified. Is the $(CONFIG_HEADER_FILE) valid for $(CONFIG)?)
 endif
 
-EXST_ADJUST_VMA := $(shell sed -E -n "/^\s*#\s*define\s+FC_VMA_ADDRESS\s+(0[xX][0-9a-fA-F]+).*/s//\1/p" $(CONFIG_HEADER_FILE))
+EXST_ADJUST_VMA := $(shell sed -E -n "/^\s*#\s*define\s+FC_VMA_ADDRESS\s+((0[xX])?[[:xdigit:]]+).*/s//\1/p" $(CONFIG_HEADER_FILE))
 ifneq ($(EXST_ADJUST_VMA),)
 EXST = yes
 endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -35,7 +35,7 @@ CONFIG_REVISION_DEFINE := -D'__CONFIG_REVISION__="$(CONFIG_REVISION)"'
 endif
 
 TARGET        := $(shell grep " FC_TARGET_MCU" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
-HSE_VALUE_MHZ := $(shell grep " SYSTEM_HSE_MHZ" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
+HSE_VALUE_MHZ := $(shell grep " SYSTEM_HSE_MHZ" $(CONFIG_HEADER_FILE) | grep -v "^\s*//" | awk '{print $$3}' )
 ifneq ($(HSE_VALUE_MHZ),)
 HSE_VALUE     := $(shell echo $$(( $(HSE_VALUE_MHZ) * 1000000 )) )
 endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -35,7 +35,7 @@ CONFIG_REVISION_DEFINE := -D'__CONFIG_REVISION__="$(CONFIG_REVISION)"'
 endif
 
 TARGET        := $(shell grep " FC_TARGET_MCU" $(CONFIG_HEADER_FILE) | awk '{print $$3}' )
-HSE_VALUE_MHZ := $(shell grep " SYSTEM_HSE_MHZ" $(CONFIG_HEADER_FILE) | grep -v "^\s*//" | awk '{print $$3}' )
+HSE_VALUE_MHZ := $(shell sed -E -n "/^\s*#\s*define\s+SYSTEM_HSE_MHZ\s+([0-9]+).*/s//\1/p" $(CONFIG_HEADER_FILE))
 ifneq ($(HSE_VALUE_MHZ),)
 HSE_VALUE     := $(shell echo $$(( $(HSE_VALUE_MHZ) * 1000000 )) )
 endif


### PR DESCRIPTION
`//#define SYSTEM_HSE_MHZ 25`
This is a valid comment in the C language, but we can get value 25 in config.mk. This PR want to filter " SYSTEM_HSE_MHZ " in comment line.

Tested with below shell code:

`echo "#define SYSTEM_HSE_MHZ 25" | grep " SYSTEM_HSE_MHZ" | grep -v "^\s*//" | awk '{print $3}'`
`echo " #define SYSTEM_HSE_MHZ 25" | grep " SYSTEM_HSE_MHZ" | grep -v "^\s*//" | awk '{print $3}'`
`echo " #define SYSTEM_HSE_MHZ 25 // some comments" | grep " SYSTEM_HSE_MHZ" | grep -v "^\s*//" | awk '{print $3}'`

`echo "//#define SYSTEM_HSE_MHZ 25" | grep " SYSTEM_HSE_MHZ" | grep -v "^\s*//" | awk '{print $3}'`
`echo "// #define SYSTEM_HSE_MHZ 25" | grep " SYSTEM_HSE_MHZ" | grep -v "^\s*//" | awk '{print $3}'`
`echo " // #define SYSTEM_HSE_MHZ 25" | grep " SYSTEM_HSE_MHZ" | grep -v "^\s*//" | awk '{print $3}'`
