### PR TITLE
Remove unused timer related defines

### DIFF
--- a/src/platform/STM32/exti.c
+++ b/src/platform/STM32/exti.c
@@ -88,12 +88,6 @@ void EXTIInit(void)
 #if defined(STM32F4)
     /* Enable SYSCFG clock otherwise the EXTI irq handlers are not called */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
-#ifdef REMAP_TIM16_DMA
-    SYSCFG_DMAChannelRemapConfig(SYSCFG_DMARemap_TIM16, ENABLE);
-#endif
-#ifdef REMAP_TIM17_DMA
-    SYSCFG_DMAChannelRemapConfig(SYSCFG_DMARemap_TIM17, ENABLE);
-#endif
 #endif
     memset(extiChannelRecs, 0, sizeof(extiChannelRecs));
     memset(extiGroupPriority, 0xff, sizeof(extiGroupPriority));


### PR DESCRIPTION
Back in Nov 2016 BorisB added a commit `remap some timers` : https://github.com/betaflight/betaflight/commit/a88ef7e1606a74e00fc45e089d8d8fa658751a45

It added the following lines to `plaform/stm32/exti.c`:
```
#ifdef REMAP_TIM16_DMA
    SYSCFG_DMAChannelRemapConfig(SYSCFG_DMARemap_TIM16, ENABLE);
#endif
#ifdef REMAP_TIM17_DMA
    SYSCFG_DMAChannelRemapConfig(SYSCFG_DMARemap_TIM17, ENABLE);
#endif
```

At the time, `REMAP_TIM16_DMA` and `REMAP_TIM17_DMA` were defined only for the `BETAFLIGHT_F3` target, since deprecated.

Also, I searched the betaflight codebase and could not find any function titled `SYSCFG_DMAChannelRemapConfig`.

This PR deletes the above lines.  Please confirm that they aren't needed.
