### PR TITLE
Remove PARTIAL_REMAP_TIM3 defines for AT32 and STM32

### DIFF
--- a/src/platform/AT32/timer_at32bsp.c
+++ b/src/platform/AT32/timer_at32bsp.c
@@ -676,10 +676,6 @@ void timerInit(void)
 {
     memset(timerConfig, 0, sizeof(timerConfig));
 
-#if defined(PARTIAL_REMAP_TIM3)
-    GPIO_PinRemapConfig(GPIO_PartialRemap_TIM3, ENABLE);
-#endif
-
     #ifdef USE_TIMER_MGMT
     /* enable the timer peripherals */
     for (unsigned i = 0; i < TIMER_CHANNEL_COUNT; i++) {

--- a/src/platform/STM32/timer_stdperiph.c
+++ b/src/platform/STM32/timer_stdperiph.c
@@ -837,10 +837,6 @@ void timerInit(void)
 {
     memset(timerConfig, 0, sizeof(timerConfig));
 
-#if defined(PARTIAL_REMAP_TIM3)
-    GPIO_PinRemapConfig(GPIO_PartialRemap_TIM3, ENABLE);
-#endif
-
     /* enable the timer peripherals */
     for (unsigned i = 0; i < TIMER_CHANNEL_COUNT; i++) {
         RCC_ClockCmd(timerRCC(TIMER_HARDWARE[i].tim), ENABLE);


### PR DESCRIPTION
Purely accidentally I found that the following lines in `platform/AT32/timer_at32bsp.c` and `platform/STM32/timer_stdperiph.c` appear to be unused:
```
#if defined(PARTIAL_REMAP_TIM3)
    GPIO_PinRemapConfig(GPIO_PartialRemap_TIM3, ENABLE);
#endif
```

I was unable to find anywhere where `PARTIAL_REMAP_TIM3` was defined, not in any config file or any other Betaflight file.  And the function `GPIO_PinRemapConfig` appears to not exist in the Betaflight codebase as well.

Perhaps these were introduced during AT32 development, and not required later?  

Anyway this PR proposes their removal, for consideration by those who understand these things better than me.