### PR TITLE
Fix G4 SPI clock being double what it should be

### DIFF
--- a/src/platform/common/stm32/bus_spi_hw.c
+++ b/src/platform/common/stm32/bus_spi_hw.c
@@ -174,10 +174,12 @@ FAST_IRQ_HANDLER static void spiTxIrqHandler(dmaChannelDescriptor_t* descriptor)
 
 uint16_t spiCalculateDivider(uint32_t freq)
 {
-#if defined(STM32F4) || defined(STM32G4) || defined(STM32F7) || defined(APM32F4)
+#if defined(STM32F4) || defined(STM32F7) || defined(APM32F4)
     uint32_t spiClk = SystemCoreClock / 2;
 #elif defined(STM32H7)
     uint32_t spiClk = 100000000;
+#elif defined(STM32G4)
+    uint32_t spiClk = SystemCoreClock;
 #elif defined(AT32F4)
     if(freq > 36000000){
         freq = 36000000;


### PR DESCRIPTION
G4 SPI clock was observed to be double what it should be.

Using a check for a number of frequencies using this temporary patch to the BMI270 driver:

![image](https://github.com/user-attachments/assets/66ca1011-d562-4c06-a83b-59b8500bcd32)

We get the following expected frequencies, but we actually see double that.

![image](https://github.com/user-attachments/assets/6f03d966-f293-4d8f-b88d-07ad1205c6cd)

As can be seen below:

![image](https://github.com/user-attachments/assets/c8be00fe-a250-4f9e-8784-49a2ecfb5312)

After this fix, we see the following:

![image](https://github.com/user-attachments/assets/514846d1-8214-4d51-b0f4-569d940e9664)

Previously the divisor values were half of what they should be, and the frequency was consequently double.

For FC's using the BMI270 gyro the consequence had been that the gyro was being clocked at 10.5MHz (one 8th of 84MHz), only just above its max permissible value of 10MHz. A consequence of this PR is that the frequency is now correctly set below 10MHz, to 5.25MHz, thus, but it's still plenty fast enough:

![image](https://github.com/user-attachments/assets/d4749a75-0535-414e-9123-a4ee755e5a08)
