### PR TITLE
Bug in STM32H5 makefile

### DIFF
--- a/src/platform/STM32/mk/STM32H5.mk
+++ b/src/platform/STM32/mk/STM32H5.mk
@@ -112,20 +112,16 @@ DEFAULT_LD_SCRIPT   = $(LINKER_DIR)/stm32_flash_h563_2m.ld
 STARTUP_SRC         = STM32/startup/startup_stm32h563xx.s
 MCU_FLASH_SIZE     := 2048
 DEVICE_FLAGS       += -DMAX_MPU_REGIONS=16
-
 # end H563xx
-
+else
+$(error Unknown MCU for STM32H5 target)
+endif
 
 ifneq ($(DEBUG),GDB)
 OPTIMISE_DEFAULT    := -Os
 OPTIMISE_SPEED      := -Os
 OPTIMISE_SIZE       := -Os
-
 LTO_FLAGS           := $(OPTIMISATION_BASE) $(OPTIMISE_DEFAULT)
-endif
-
-else
-$(error Unknown MCU for STM32H5 target)
 endif
 
 ifeq ($(LD_SCRIPT),)


### PR DESCRIPTION
Clean STM32H5 makefile around the MCU target check and selection.

the debug part is currently nested inside the traget H563, that should not be, as if we need to add additional (like H562) the debug cannot be activated.

(part of project raise from ticket #13482)
