### PR TITLE
fix compilation without ACC

### DIFF
--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -167,7 +167,6 @@ retry:
         FALLTHROUGH;
 #endif
 
-
 #if defined(USE_ACC_MPU6500) || defined(USE_ACC_SPI_MPU6500)
     case ACC_MPU6500:
     case ACC_ICM20601:

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -167,11 +167,12 @@ retry:
         FALLTHROUGH;
 #endif
 
+
+#if defined(USE_ACC_MPU6500) || defined(USE_ACC_SPI_MPU6500)
     case ACC_MPU6500:
     case ACC_ICM20601:
     case ACC_ICM20602:
     case ACC_ICM20608G:
-#if defined(USE_ACC_MPU6500) || defined(USE_ACC_SPI_MPU6500)
 #ifdef USE_ACC_SPI_MPU6500
         if (mpu6500SpiAccDetect(dev)) {
 #else
@@ -195,8 +196,8 @@ retry:
             }
             break;
         }
-#endif
         FALLTHROUGH;
+#endif
 
 #ifdef USE_ACC_SPI_ICM20649
     case ACC_ICM20649:
@@ -287,6 +288,7 @@ retry:
 
     default:
     case ACC_NONE: // disable ACC
+        UNUSED(dev);
         accHardware = ACC_NONE;
         break;
     }

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -500,6 +500,7 @@ STATIC_UNIT_TESTED gyroHardware_e gyroDetect(gyroDev_t *dev)
 #endif
 
     default:
+        UNUSED(dev);
         gyroHardware = GYRO_NONE;
     }
 


### PR DESCRIPTION
- compilation may fail with cryptic message when no ACC is selected (unused variable `dev`). Mark dev as unused
- MPU6500 is handled differently than all other accs (it is only driver that adds case labels)
- also make dev UNUSED for gyro
