### PR TITLE
lis2mdl: fix read

### DIFF
--- a/src/main/drivers/compass/compass_lis2mdl.c
+++ b/src/main/drivers/compass/compass_lis2mdl.c
@@ -82,8 +82,10 @@ static bool lis2mdlRead(magDev_t *mag, int16_t *magData)
 
     extDevice_t *dev = &mag->dev;
 
-    if (pendingRead && busReadRegisterBufferStart(dev, LIS2MDL_ADDR_OUTX_L_REG, (uint8_t *)buf, sizeof(buf))) {
-        pendingRead = false;
+    if (pendingRead) {
+        if (busReadRegisterBufferStart(dev, LIS2MDL_ADDR_OUTX_L_REG, (uint8_t *)buf, sizeof(buf))) {
+            pendingRead = false;
+        }
         return false;
     }
 

--- a/src/main/drivers/compass/compass_lis2mdl.c
+++ b/src/main/drivers/compass/compass_lis2mdl.c
@@ -82,10 +82,9 @@ static bool lis2mdlRead(magDev_t *mag, int16_t *magData)
 
     extDevice_t *dev = &mag->dev;
 
-    if (pendingRead) {
-        if (busReadRegisterBufferStart(dev, LIS2MDL_ADDR_OUTX_L_REG, (uint8_t *)buf, sizeof(buf))) {
-            pendingRead = false;
-        }
+    if (pendingRead && busReadRegisterBufferStart(dev, LIS2MDL_ADDR_OUTX_L_REG, (uint8_t *)buf, sizeof(buf))) {
+        pendingRead = false;
+    }
         return false;
     }
 

--- a/src/main/drivers/compass/compass_lis2mdl.c
+++ b/src/main/drivers/compass/compass_lis2mdl.c
@@ -84,7 +84,6 @@ static bool lis2mdlRead(magDev_t *mag, int16_t *magData)
 
     if (pendingRead && busReadRegisterBufferStart(dev, LIS2MDL_ADDR_OUTX_L_REG, (uint8_t *)buf, sizeof(buf))) {
         pendingRead = false;
-    }
         return false;
     }
 


### PR DESCRIPTION
In https://github.com/betaflight/betaflight/pull/14176 I changed the implementation to read the status register before reading the sensor data, as a well as performing blocking reads for both. For some reason doing a blocking read like this does not work, betalfight reports a preflight LOAD warning. I've reverted it to triggering the read and returning immediately and collecting the data on the next pass. This fixes the LOAD warning and I am able to arm and see the mag data in the blackbox.

**questions**
- Why can't we do a blocking read? Triggering the read and the coming back later assumes the transfer is complete by the time the next lis2mdlRead occurs.
- In both cases when I checked `tasks` in the CLI I see an update rate of 0 Hz. In the case where it was not working the "late" counter is non zero

**Working** (with this PR)
```
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
18 - (        COMPASS)      0      28      12    0.0%    0.0%       155      0   9910      26
```

**Not working** (before this PR)
```
Task list             rate/hz  max/us  avg/us maxload avgload  total/ms   late    run reqd/us
18 - (        COMPASS)      0     161     158    0.0%    0.0%      3575    364    364      76
```

