### PR TITLE
hover point throttle curve adjustment

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1527,6 +1527,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_PID_PROCESS_DENOM, "%d",      activePidLoopDenom);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THR_MID, "%d",                currentControlRateProfile->thrMid8);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THR_EXPO, "%d",               currentControlRateProfile->thrExpo8);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THR_HOVER, "%d",              currentControlRateProfile->thrHover8);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_MODE, "%d",               currentPidProfile->tpa_mode);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_RATE, "%d",               currentPidProfile->tpa_rate);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_BREAKPOINT, "%d",         currentPidProfile->tpa_breakpoint);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1056,6 +1056,7 @@ const clivalue_t valueTable[] = {
 #endif
     { PARAM_NAME_THR_MID,           VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, thrMid8) },
     { PARAM_NAME_THR_EXPO,          VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, thrExpo8) },
+    { PARAM_NAME_THR_HOVER,         VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, thrHover8) },
     { PARAM_NAME_RATES_TYPE,        VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RATES_TYPE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rates_type) },
     { "quickrates_rc_expo",         VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, quickRatesRcExpo) },
     { "roll_rc_rate",               VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmaxUnsigned = { 1, CONTROL_RATE_CONFIG_RC_RATES_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, rcRates[FD_ROLL]) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -429,6 +429,7 @@ static const OSD_Entry cmsx_menuRateProfileEntries[] =
 
     { "THR MID",     OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.thrMid8,           0,  100,  1} },
     { "THR EXPO",    OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.thrExpo8,          0,  100,  1} },
+    { "THR HOVER",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.thrHover8,         0,  100,  1} },
 
     { "THR LIM TYPE",OME_TAB,    NULL, &(OSD_TAB_t)   { &rateProfile.throttle_limit_type, THROTTLE_LIMIT_TYPE_COUNT - 1, lookupTableThrottleLimitType} },
     { "THR LIM %",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.throttle_limit_percent, 25,  100,  1} },

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -45,6 +45,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
         RESET_CONFIG(controlRateConfig_t, &controlRateConfig[i],
             .thrMid8 = 50,
             .thrExpo8 = 0,
+            .thrHover8 = 50,
             .rates_type = RATES_TYPE_ACTUAL,
             .rcRates[FD_ROLL] = 7,
             .rcRates[FD_PITCH] = 7,

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -45,7 +45,6 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
         RESET_CONFIG(controlRateConfig_t, &controlRateConfig[i],
             .thrMid8 = 50,
             .thrExpo8 = 0,
-            .thrHover8 = 50,
             .rates_type = RATES_TYPE_ACTUAL,
             .rcRates[FD_ROLL] = 7,
             .rcRates[FD_PITCH] = 7,
@@ -63,6 +62,7 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .rate_limit[FD_YAW] = CONTROL_RATE_CONFIG_RATE_LIMIT_MAX,
             .profileName = { 0 },
             .quickRatesRcExpo = 0,
+            .thrHover8 = 50,
         );
     }
 }

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -37,7 +37,7 @@
 
 controlRateConfig_t *currentControlRateProfile;
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 6);
+PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 7);
 
 void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
 {

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -51,7 +51,6 @@ typedef enum {
 typedef struct controlRateConfig_s {
     uint8_t thrMid8;
     uint8_t thrExpo8;
-    uint8_t thrHover8;
     uint8_t rates_type;
     uint8_t rcRates[3];
     uint8_t rcExpo[3];
@@ -61,6 +60,7 @@ typedef struct controlRateConfig_s {
     uint16_t rate_limit[3];                 // Sets the maximum rate for the axes
     char profileName[MAX_RATE_PROFILE_NAME_LENGTH + 1]; // Descriptive name for rate profile
     uint8_t quickRatesRcExpo;               // Sets expo on rc command for quick rates
+    uint8_t thrHover8;
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -51,6 +51,7 @@ typedef enum {
 typedef struct controlRateConfig_s {
     uint8_t thrMid8;
     uint8_t thrExpo8;
+    uint8_t thrHover8;
     uint8_t rates_type;
     uint8_t rcRates[3];
     uint8_t rcExpo[3];
@@ -60,7 +61,6 @@ typedef struct controlRateConfig_s {
     uint16_t rate_limit[3];                 // Sets the maximum rate for the axes
     char profileName[MAX_RATE_PROFILE_NAME_LENGTH + 1]; // Descriptive name for rate profile
     uint8_t quickRatesRcExpo;               // Sets expo on rc command for quick rates
-    uint8_t thrHover8;
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -51,6 +51,7 @@ typedef enum {
 typedef struct controlRateConfig_s {
     uint8_t thrMid8;
     uint8_t thrExpo8;
+    uint8_t thrHover8;
     uint8_t rates_type;
     uint8_t rcRates[3];
     uint8_t rcExpo[3];

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -51,6 +51,7 @@
 #define PARAM_NAME_MOTOR_POLES "motor_poles"
 #define PARAM_NAME_THR_MID "thr_mid"
 #define PARAM_NAME_THR_EXPO "thr_expo"
+#define PARAM_NAME_THR_HOVER "thr_hover"
 #define PARAM_NAME_RATES_TYPE "rates_type"
 #define PARAM_NAME_TPA_RATE "tpa_rate"
 #define PARAM_NAME_TPA_BREAKPOINT "tpa_breakpoint"

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -866,9 +866,8 @@ void initRcProcessing(void)
         }
 
         // Convert normalized y (0.0 to 1.0) to an integer value (0–1000)
-        int16_t y_int = (int16_t)(y * 1000.0f + 0.5f);
-        // Map to the PWM range: output value = PWM_RANGE_MIN + PWM_RANGE * (y_int / 1000)
-        lookupThrottleRC[i] = PWM_RANGE_MIN + (PWM_RANGE * y_int) / 1000;
+        // Map to the PWM range
+        lookupThrottleRC[i] = lrintf(scaleRangef(y, 0.0f, 1.0f, PWM_RANGE_MIN, PWM_RANGE_MAX));
     }
 
     switch (currentControlRateProfile->rates_type) {

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -857,7 +857,7 @@ void initRcProcessing(void)
             // Parameter t runs from 0 to 1 as x goes from thrMid to 1.
             float t = ((1.0f - thrMid) > 0.0f) ? (x - thrMid) / (1.0f - thrMid) : 0.0f;
             // Determine control point's y coordinate (cp2y) by blending:
-            //   - For expo=0: cp2y should be (thrHover+1)/2 (linear)
+            //   - For expo=0: cp2y should be thrHover + (1 - thrHover) / 2 (linear)
             //   - For expo=1: cp2y should be thrHover (full expo)
             float cp2y = (((thrHover + 1.0f) / 2.0f) * (1.0f - expo)) + (thrHover * expo);
             // Quadratic Bézier formula for y:

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -831,8 +831,8 @@ void initRcProcessing(void)
     // Retrieve throttle parameters from the current control rate profile.
     // Note: currentControlRateProfile is assumed to be a pointer to a structure containing these fields.
     float thrMid   = currentControlRateProfile->thrMid8   / 100.0f;  // normalized x coordinate for hover point
-    float thrHover = currentControlRateProfile->thrHover8 / 100.0f;  // normalized y coordinate for hover point
     float expo     = currentControlRateProfile->thrExpo8   / 100.0f;  // normalized expo (0.0 .. 1.0)
+    float thrHover = currentControlRateProfile->thrHover8 / 100.0f;  // normalized y coordinate for hover point
 
     // Generate the throttle lookup table with THROTTLE_LOOKUP_LENGTH points.
     // We sample x uniformly from 0 to 1.

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1372,7 +1372,8 @@ case MSP_NAME:
 
         // added in 1.43
         sbufWriteU8(dst, currentControlRateProfile->rates_type);
-
+        
+        // added in 1.47
         sbufWriteU8(dst, currentControlRateProfile->thrHover8);
         
         break;
@@ -2817,7 +2818,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU8(src);    // tpa_rate is moved to PID profile
             currentControlRateProfile->thrMid8 = sbufReadU8(src);
             currentControlRateProfile->thrExpo8 = sbufReadU8(src);
-            currentControlRateProfile->thrHover8 = sbufReadU8(src);
             sbufReadU16(src);   // tpa_breakpoint is moved to PID profile
 
             if (sbufBytesRemaining(src) >= 1) {
@@ -2853,6 +2853,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             if (sbufBytesRemaining(src) >= 1) {
                 currentControlRateProfile->rates_type = sbufReadU8(src);
             }
+
+            // version 1.47
+            currentControlRateProfile->thrHover8 = sbufReadU8(src);
 
             initRcProcessing();
         } else {

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2855,7 +2855,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             }
 
             // version 1.47
-            currentControlRateProfile->thrHover8 = sbufReadU8(src);
+            if (sbufBytesRemaining(src) >= 1) {
+                currentControlRateProfile->thrHover8 = sbufReadU8(src);
+            }
 
             initRcProcessing();
         } else {

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1355,6 +1355,7 @@ case MSP_NAME:
         sbufWriteU8(dst, 0);   // was currentControlRateProfile->tpa_rate
         sbufWriteU8(dst, currentControlRateProfile->thrMid8);
         sbufWriteU8(dst, currentControlRateProfile->thrExpo8);
+        sbufWriteU8(dst, currentControlRateProfile->thrHover8);
         sbufWriteU16(dst, 0);   // was currentControlRateProfile->tpa_breakpoint
         sbufWriteU8(dst, currentControlRateProfile->rcExpo[FD_YAW]);
         sbufWriteU8(dst, currentControlRateProfile->rcRates[FD_YAW]);
@@ -2815,6 +2816,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             sbufReadU8(src);    // tpa_rate is moved to PID profile
             currentControlRateProfile->thrMid8 = sbufReadU8(src);
             currentControlRateProfile->thrExpo8 = sbufReadU8(src);
+            currentControlRateProfile->thrHover8 = sbufReadU8(src);
             sbufReadU16(src);   // tpa_breakpoint is moved to PID profile
 
             if (sbufBytesRemaining(src) >= 1) {

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1355,7 +1355,6 @@ case MSP_NAME:
         sbufWriteU8(dst, 0);   // was currentControlRateProfile->tpa_rate
         sbufWriteU8(dst, currentControlRateProfile->thrMid8);
         sbufWriteU8(dst, currentControlRateProfile->thrExpo8);
-        sbufWriteU8(dst, currentControlRateProfile->thrHover8);
         sbufWriteU16(dst, 0);   // was currentControlRateProfile->tpa_breakpoint
         sbufWriteU8(dst, currentControlRateProfile->rcExpo[FD_YAW]);
         sbufWriteU8(dst, currentControlRateProfile->rcRates[FD_YAW]);
@@ -1374,6 +1373,8 @@ case MSP_NAME:
         // added in 1.43
         sbufWriteU8(dst, currentControlRateProfile->rates_type);
 
+        sbufWriteU8(dst, currentControlRateProfile->thrHover8);
+        
         break;
 
     case MSP_PID:

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -262,7 +262,6 @@ protected:
     controlRateConfig_t controlRateConfig = {
         .thrMid8 = 0,
         .thrExpo8 = 0,
-        .thrHover8 = 0,
         .rates_type = RATES_TYPE_BETAFLIGHT,
         .rcRates = {[FD_ROLL] = 90, [FD_PITCH] = 90},
         .rcExpo = {[FD_ROLL] = 0, [FD_PITCH] = 0, [FD_YAW] = 0},
@@ -272,6 +271,7 @@ protected:
         .rate_limit = {0, 0, 0},
         .profileName = "default",
         .quickRatesRcExpo = 0,
+        .thrHover8 = 0,
     };
 
     channelRange_t fullRange = {
@@ -369,7 +369,6 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     controlRateConfig_t controlRateConfig = {
         .thrMid8 = 0,
         .thrExpo8 = 0,
-        .thrHover8 = 0,
         .rates_type = RATES_TYPE_BETAFLIGHT,
         .rcRates = {[FD_ROLL] = 90, [FD_PITCH] = 90},
         .rcExpo = {[FD_ROLL] = 0, [FD_PITCH] = 0, [FD_YAW] = 0},
@@ -379,6 +378,7 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
         .rate_limit = {0, 0, 0},
         .profileName = "default",
         .quickRatesRcExpo = 0,
+        .thrHover8 = 0,
     };
 
     // and

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -262,6 +262,7 @@ protected:
     controlRateConfig_t controlRateConfig = {
         .thrMid8 = 0,
         .thrExpo8 = 0,
+        .thrHover8 = 0,
         .rates_type = RATES_TYPE_BETAFLIGHT,
         .rcRates = {[FD_ROLL] = 90, [FD_PITCH] = 90},
         .rcExpo = {[FD_ROLL] = 0, [FD_PITCH] = 0, [FD_YAW] = 0},
@@ -292,6 +293,7 @@ protected:
         controlRateConfig.rcExpo[FD_PITCH] = 0;
         controlRateConfig.thrMid8 = 0;
         controlRateConfig.thrExpo8 = 0;
+        controlRateConfig.thrHover8 = 0;
         controlRateConfig.rcExpo[FD_YAW] = 0;
         controlRateConfig.rates[0] = 0;
         controlRateConfig.rates[1] = 0;
@@ -367,6 +369,7 @@ TEST_F(RcControlsAdjustmentsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp
     controlRateConfig_t controlRateConfig = {
         .thrMid8 = 0,
         .thrExpo8 = 0,
+        .thrHover8 = 0,
         .rates_type = RATES_TYPE_BETAFLIGHT,
         .rcRates = {[FD_ROLL] = 90, [FD_PITCH] = 90},
         .rcExpo = {[FD_ROLL] = 0, [FD_PITCH] = 0, [FD_YAW] = 0},


### PR DESCRIPTION
- updated throttle lookup generation
- added thrHover8 to relevant files
- added PARAM_NAME_THR_HOVER to relevant files
- requires Configurator PR: https://github.com/betaflight/betaflight-configurator/pull/4245

Here is standalone C code I used to test the lookup table curve generation in `rc.c`:
```c
#include <stdio.h>
#include <string.h>

// Helper function: format a float with three decimals into a string,
// then replace the decimal point ('.') with a comma (',').
void floatToCommaString(float value, char *str, int size) {
    snprintf(str, size, "%.3f", value);
    for (int i = 0; str[i] != '\0'; i++) {
        if (str[i] == '.') {
            str[i] = ',';
        }
    }
}

int main(void) {
    // --- Parameters (reversed naming) ---
    // thrMid8:    Stick input (%) at which the hover point occurs (this is the x coordinate).
    // thrHover8:  Throttle output (%) at hover (this is the y coordinate).
    float thrMid8   = 50.0f;   // e.g. 50% stick input
    float thrHover8 = 30.0f;   // e.g. 50% throttle output at that input
    float expo      = 1.0f;    // expo parameter: 0 yields a straight line; 1 gives full expo bending

    // Convert percentage values to normalized values (0.0 to 1.0)
    float thrMid   = thrMid8 / 100.0f;    // x coordinate for hover point
    float thrHover = thrHover8 / 100.0f;    // y coordinate for hover point

    // --- Pre-calculate control points for the two segments ---

    // First segment: from (0,0) to (thrMid, thrHover)
    // For expo = 0 (linear) control point should be (thrMid/2, thrHover/2).
    // For expo = 1 (full expo) control point is (thrMid/2, thrHover).
    float cp1x = thrMid / 2.0f;
    float cp1y = (thrHover / 2.0f) * (1.0f - expo) + thrHover * expo;

    // Second segment: from (thrMid, thrHover) to (1,1)
    // For expo = 0 (linear) control point should be ((thrMid+1)/2, (thrHover+1)/2).
    // For expo = 1 (full expo) control point is ((thrMid+1)/2, thrHover).
    float cp2x = (thrMid + 1.0f) / 2.0f;
    float cp2y = (((thrHover + 1.0f) / 2.0f) * (1.0f - expo)) + (thrHover * expo);

    // --- Compute and output the curve ---
    int numPoints = 12;  // sample 101 points (from 0 to 1)
    printf("x\ty_normalized\ty_scaled\n");
    char buf[32];

    for (int i = 0; i < numPoints; i++) {
        // Normalized input (stick) value x in [0,1]
        float x = (float)i / (numPoints - 1);
        float y;  // computed throttle output (normalized)

        if (x <= thrMid) {
            // First segment: x from 0 to thrMid
            // Parameter t goes from 0 to 1 as x goes from 0 to thrMid.
            float t = (thrMid > 0.0f) ? x / thrMid : 0.0f;
            // Quadratic Bézier formula:
            // Endpoints: (0,0) and (thrMid, thrHover); control point's y = cp1y.
            // (Note: the x coordinate is used only to decide which segment to use.)
            y = 2.0f * (1.0f - t) * t * cp1y + t * t * thrHover;
        } else {
            // Second segment: x from thrMid to 1.
            float t = (1.0f - thrMid > 0.0f) ? (x - thrMid) / (1.0f - thrMid) : 0.0f;
            // Quadratic Bézier formula:
            // Endpoints: (thrMid, thrHover) and (1,1); control point's y = cp2y.
            y = (1.0f - t) * (1.0f - t) * thrHover + 2.0f * (1.0f - t) * t * cp2y + t * t;
        }

        // Scale the normalized throttle output to an integer in the range 0–1000.
        int yScaled = (int)(y * 1000.0f + 0.5f);

        // Print the values with tabs as separators and commas for decimals.
        floatToCommaString(x, buf, sizeof(buf));
        printf("%s\t", buf);
        floatToCommaString(y, buf, sizeof(buf));
        printf("%s\t", buf);
        printf("%d\n", yScaled);
    }

    return 0;
}
```

That results in the following graphs:

![image](https://github.com/user-attachments/assets/b91e2f09-08fa-4e2f-8578-0dcc307de556)

![image](https://github.com/user-attachments/assets/436732b8-7ebe-43b6-aa42-0273f8a0ec51)
