### PR TITLE
Fix PG ID and corruption in MSP_SET_SENSOR_CONFIG

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3350,7 +3350,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         sbufReadU8(src);
 #endif
 
-        if (sbufBytesRemaining(src) >= 1) {
+        if (sbufBytesRemaining(src)) {
 #ifdef USE_RANGEFINDER
             rangefinderConfigMutable()->rangefinder_hardware = sbufReadU8(src);
 #else
@@ -3358,7 +3358,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         }
 
-        if (sbufBytesRemaining(src) >= 1) {
+        if (sbufBytesRemaining(src)) {
 #ifdef USE_OPTICALFLOW
             opticalflowConfigMutable()->opticalflow_hardware = sbufReadU8(src);
 #else

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3350,7 +3350,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         sbufReadU8(src);
 #endif
 
-        if (sbufBytesRemaining(src)) {
+        if (sbufBytesRemaining(src) >= 1) {
 #ifdef USE_RANGEFINDER
             rangefinderConfigMutable()->rangefinder_hardware = sbufReadU8(src);
 #else
@@ -3358,7 +3358,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         }
 
-        if (sbufBytesRemaining(src)) {
+        if (sbufBytesRemaining(src) >= 1) {
 #ifdef USE_OPTICALFLOW
             opticalflowConfigMutable()->opticalflow_hardware = sbufReadU8(src);
 #else

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3350,18 +3350,23 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         sbufReadU8(src);
 #endif
 
+        if (sbufBytesRemaining(src) >= 1) {
 #ifdef USE_RANGEFINDER
-        rangefinderConfigMutable()->rangefinder_hardware = sbufReadU8(src);
+            rangefinderConfigMutable()->rangefinder_hardware = sbufReadU8(src);
 #else
-        sbufReadU8(src);
+            sbufReadU8(src);
 #endif
+        }
 
+        if (sbufBytesRemaining(src) >= 1) {
 #ifdef USE_OPTICALFLOW
-        opticalflowConfigMutable()->opticalflow_hardware = sbufReadU8(src);
+            opticalflowConfigMutable()->opticalflow_hardware = sbufReadU8(src);
 #else
-        sbufReadU8(src);
+            sbufReadU8(src);
 #endif
+        }
         break;
+
 #ifdef USE_ACC
     case MSP_ACC_CALIBRATION:
         if (!ARMING_FLAG(ARMED))

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -159,7 +159,7 @@
 //#define PG_SOFTSERIAL_PIN_CONFIG    558  // removed, merged into SERIAL_PIN_CONFIG
 #define PG_GIMBAL_TRACK_CONFIG      559
 #define PG_OPTICALFLOW_CONFIG       560
-#define PG_BETAFLIGHT_END           560
+#define PG_BETAFLIGHT_END           561
 
 
 // OSD configuration (subject to change)

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -159,7 +159,7 @@
 //#define PG_SOFTSERIAL_PIN_CONFIG    558  // removed, merged into SERIAL_PIN_CONFIG
 #define PG_GIMBAL_TRACK_CONFIG      559
 #define PG_OPTICALFLOW_CONFIG       560
-#define PG_BETAFLIGHT_END           561
+#define PG_BETAFLIGHT_END           560
 
 
 // OSD configuration (subject to change)

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -159,7 +159,6 @@
 //#define PG_SOFTSERIAL_PIN_CONFIG    558  // removed, merged into SERIAL_PIN_CONFIG
 #define PG_GIMBAL_TRACK_CONFIG      559
 #define PG_OPTICALFLOW_CONFIG       560
-#define PG_BETAFLIGHT_END           560
 
 
 // OSD configuration (subject to change)

--- a/src/main/sensors/opticalflow.c
+++ b/src/main/sensors/opticalflow.c
@@ -68,8 +68,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(opticalflowConfig_t, opticalflowConfig, PG_OPTIC
 PG_RESET_TEMPLATE(opticalflowConfig_t, opticalflowConfig,
     .opticalflow_hardware = OPTICALFLOW_NONE,
     .rotation = 0,
-    .flow_lpf = 0,
-    .flip_x = 0
+    .flip_x = 0,
+    .flow_lpf = 0
 );
 
 static opticalflow_t opticalflow;


### PR DESCRIPTION
- hunting issue reported in #14226
- issue seems MSP related (need to check configuration tab)   ✓
- `MSP_SET_SENSOR_CONFIG` seems to be the culprit

To reproduce (master)

- flash with `OPTICALFLOW_MT` custom define
- set rangefinder_hardware = MTF01P
- set opticalflow_hardware = MT
- disable baro in configuration tab and issue is triggered.
- set baro_hardware = NONE does not trigger the issue.

This pull request includes several changes to improve the handling of sensor configurations and clean up the codebase. The most important changes involve adding checks for remaining bytes in the buffer before reading sensor configurations, updating the `pg_ids.h` file, and reordering initialization parameters in `opticalflow.c`.

Improvements to sensor configuration handling:

* [`src/main/msp/msp.c`](diffhunk://#diff-5dc4eb2b2548bfc728653a89570779dabe03e47e60f72ad64d36c5d6c31eb5f6R3353-R3369): Added checks to ensure there are remaining bytes in the buffer before reading `rangefinder_hardware` and `opticalflow_hardware` configurations.

Codebase cleanup:

* [`src/main/pg/pg_ids.h`](diffhunk://#diff-85723413ba09324130b919a835d16d2896f51030b4ff1eb3cc130a0e5deaada6L162): Removed the `PG_BETAFLIGHT_END` definition which was no longer needed.
* [`src/main/sensors/opticalflow.c`](diffhunk://#diff-4339712ea8db7b370331ce5a6e40fcf98f715cec30d6745cf5de77b212ef1a75L71-R72): Reordered the initialization parameters in the `PG_RESET_TEMPLATE` for `opticalflowConfig` to improve readability.