### PR TITLE
Disable MOTOR_STOP when AIRMODE is enabled

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -984,6 +984,11 @@ void init(void)
     motorEnable();
 #endif
 
+    // MOTOR_STOP is not used when AIRMODE is enabled, note AIRMODE can be on a switch
+    if (featureIsEnabled(FEATURE_AIRMODE)) {
+        featureDisableImmediate(FEATURE_MOTOR_STOP);
+    }
+
 // allocate SPI DMA streams after motor timers as SPI DMA allocate will always be possible
 #if defined(USE_SPI) && defined(USE_SPI_DMA_ENABLE_LATE) && !defined(USE_SPI_DMA_ENABLE_EARLY)
     // Attempt to enable DMA on all SPI busses


### PR DESCRIPTION
This pull request includes a change to the `void init(void)` function in the `src/main/fc/init.c` file. The change disables the `FEATURE_MOTOR_STOP` feature when `FEATURE_AIRMODE` is enabled.

* [`src/main/fc/init.c`](diffhunk://#diff-f1295987bea33eb28fa10499c47023925c50045c50ab2c6b23295e0de89dba09R987-R991): Added a conditional check to disable `FEATURE_MOTOR_STOP` if `FEATURE_AIRMODE` is enabled.