### PR TITLE
Fix opticalflow detection (msp)

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1092,7 +1092,7 @@ static bool mspProcessOutCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, sbuf_t
 #else
         sbufWriteU16(dst, 0);
 #endif
-        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_RANGEFINDER) << 4 | sensors(SENSOR_GYRO) << 5);
+        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_RANGEFINDER) << 4 | sensors(SENSOR_GYRO) << 5 | sensors(SENSOR_OPTICALFLOW) << 6);
         sbufWriteData(dst, &flightModeFlags, 4);        // unconditional part of flags, first 32 bits
         sbufWriteU8(dst, getCurrentPidProfileIndex());
         sbufWriteU16(dst, constrain(getAverageSystemLoadPercent(), 0, LOAD_PERCENTAGE_ONE));

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2131,7 +2131,7 @@ case MSP_NAME:
 #else
         sbufWriteU8(dst, SENSOR_NOT_AVAILABLE);
 #endif
-#ifdef USE_OPTICAL_FLOW
+#ifdef USE_OPTICALFLOW
         sbufWriteU8(dst, detectedSensors[SENSOR_INDEX_OPTICALFLOW]);
 #else
         sbufWriteU8(dst, SENSOR_NOT_AVAILABLE);


### PR DESCRIPTION
This pull request includes updates to the `src/main/msp/msp.c` file to add support for the `SENSOR_OPTICALFLOW` sensor. The most important changes include updating the sensor bitmask and correcting a preprocessor directive.

Updates to sensor support:

* [`src/main/msp/msp.c`](diffhunk://#diff-5dc4eb2b2548bfc728653a89570779dabe03e47e60f72ad64d36c5d6c31eb5f6L1095-R1095): Added `SENSOR_OPTICALFLOW` to the sensor bitmask in the `mspProcessOutCommand` function.
* [`src/main/msp/msp.c`](diffhunk://#diff-5dc4eb2b2548bfc728653a89570779dabe03e47e60f72ad64d36c5d6c31eb5f6L2134-R2134): Corrected the preprocessor directive from `USE_OPTICAL_FLOW` to `USE_OPTICALFLOW` in the `MSP_NAME` case.