### PR TITLE
[4.5.2] Update actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: List assets
         run: ls -al Assets

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: 'Assets/*.hex'
+          merge-multiple: true
 
       - name: List assets
         run: ls -al Assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: make EXTRA_FLAGS=-Werror ${{ matrix.target }}_rev
 
       - name: Publish build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Assets
           path: obj/*.hex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Publish build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Assets
+          name: Assets-${{ strategy.job-index }}
           path: obj/*.hex
           retention-days: 60
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,9 @@ jobs:
         
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: 'Assets/*.hex'
+          merge-multiple: true
 
       - name: Select release notes
         id: notes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Select release notes
         id: notes


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This pull request includes updates to the GitHub Actions workflows to use the latest versions of certain actions and add additional configuration options.

Updates to GitHub Actions workflows:

* [`.github/workflows/build-release.yml`](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L23-R26): Updated `actions/download-artifact` from v3 to v4 and added `pattern` and `merge-multiple` options to fetch build artifacts.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R76): Updated `actions/upload-artifact` from v3 to v4 and modified the `name` option to include the job index for publishing build artifacts.
* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L38-R41): Updated `actions/download-artifact` from v3 to v4 and added `pattern` and `merge-multiple` options to fetch build artifacts.