### PR TITLE
CLI - prevent serial overflow

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6896,7 +6896,7 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
         setPrintfSerialPort(cliPort);
     }
 
-    bufWriterInit(&cliWriterDesc, cliWriteBuffer, sizeof(cliWriteBuffer), (bufWrite_t)serialWriteBufShim, serialPort);
+    bufWriterInit(&cliWriterDesc, cliWriteBuffer, sizeof(cliWriteBuffer), (bufWrite_t)serialWriteBufBlockingShim, serialPort);
     cliErrorWriter = cliWriter = &cliWriterDesc;
 
     if (interactive) {

--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -129,8 +129,20 @@ void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count)
     serialEndWrite(instance);
 }
 
+void serialWriteBufBlocking(serialPort_t *instance, const uint8_t *data, int count)
+{
+    while (serialTxBytesFree(instance) < (uint32_t)count) /* NOP */;
+    serialWriteBuf(instance, data, count);
+}
+
 void serialWriteBufShim(void *instance, const uint8_t *data, int count)
 {
     serialWriteBuf((serialPort_t *)instance, data, count);
 }
+
+void serialWriteBufBlockingShim(void *instance, const uint8_t *data, int count)
+{
+    serialWriteBufBlocking(instance, data, count);
+}
+
 

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -150,5 +150,6 @@ uint32_t serialGetBaudRate(serialPort_t *instance);
 
 // A shim that adapts the bufWriter API to the serialWriteBuf() API.
 void serialWriteBufShim(void *instance, const uint8_t *data, int count);
+void serialWriteBufBlockingShim(void *instance, const uint8_t *data, int count);
 void serialBeginWrite(serialPort_t *instance);
 void serialEndWrite(serialPort_t *instance);


### PR DESCRIPTION
use serialWriteBufBlocking for cli, busy-waiting if TX buffer is full
