### PR TITLE
Update CUSTOM_AIRPLANE mixer to require one motor

### DIFF
--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -268,7 +268,7 @@ const mixer_t mixers[] = {
     { 1, true,  NULL },                // MIXER_SINGLECOPTER
     { 4, false, mixerAtail4 },         // MIXER_ATAIL4
     { 0, false, NULL },                // MIXER_CUSTOM
-    { 2, true,  NULL },                // MIXER_CUSTOM_AIRPLANE
+    { 1, true,  NULL },                // MIXER_CUSTOM_AIRPLANE
     { 3, true,  NULL },                // MIXER_CUSTOM_TRI
     { 4, false, mixerQuadX1234 },      // MIXER_QUADX_1234
     { 8, false, mixerOctoX8P },        // MIXER_OCTOX8P


### PR DESCRIPTION
- only require one motor for MIXER_CUSTOM_AIRPLANE.
- configurator change https://github.com/betaflight/betaflight-configurator/pull/4319