### PR TITLE
Missing break statement was causing SITL build to fail

### DIFF
--- a/src/main/drivers/io_preinit.c
+++ b/src/main/drivers/io_preinit.c
@@ -48,7 +48,7 @@ void ioPreinitByIO(const IO_t io, uint8_t iocfg, ioPreinitPinState_e init)
         IOHi(io);
         break;
     default:
-        // Do nothing
+        break; // Do nothing
     }
 }
 


### PR DESCRIPTION
Tried building SITL and other tragets. Only SITL fails. 
`./src/main/drivers/io_preinit.c: In function ‘ioPreinitByIO’:
./src/main/drivers/io_preinit.c:50:5: error: label at end of compound statement
   50 |     default:
      |     ^~~~~~~
make[1]: *** [Makefile:489: obj/main/SITL/drivers/io_preinit.o] Error 1
`
Adding the break statement resolves the build issue.  

