### PR TITLE
FIX: https://github.com/betaflight/betaflight/issues/14265

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -184,7 +184,7 @@ bool checkMotorProtocolEnabled(const motorDevConfig_t *motorDevConfig, bool *isP
 motorProtocolFamily_e motorGetProtocolFamily(void)
 {
     switch (motorConfig()->dev.motorProtocol) {
-#ifdef USE_PWMOUTPUT
+#ifdef USE_PWM_OUTPUT
     case MOTOR_PROTOCOL_PWM :
     case MOTOR_PROTOCOL_ONESHOT125:
     case MOTOR_PROTOCOL_ONESHOT42:


### PR DESCRIPTION
This pull request includes a minor change to the `src/main/drivers/motor.c` file. The change corrects a preprocessor directive to ensure proper functionality of the motor protocol configuration.

* [`src/main/drivers/motor.c`](diffhunk://#diff-8d9c996b89478efcb15ef94b3e9fdec0f622cd2dda23f6aa6281a834b529e198L187-R187): Corrected the preprocessor directive from `USE_PWMOUTPUT` to `USE_PWM_OUTPUT` in the `motorGetProtocolFamily` function.
