### PR TITLE
Add NULL check for vTable->decodeTelemetry

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -109,7 +109,9 @@ void motorWriteAll(float *values)
             // Perform the decode of the last data received
             // New data will be received once the send of motor data, triggered above, completes
 #if defined(USE_DSHOT) && defined(USE_DSHOT_TELEMETRY)
-            motorDevice.vTable->decodeTelemetry();
+            if (motorDevice.vTable->decodeTelemetry) {
+                motorDevice.vTable->decodeTelemetry();
+            }
 #endif
 
             // Update the motor data


### PR DESCRIPTION
`decodeTelemetry` in `pwm_output_hw.c` is set to NULL. There is a situation that could cause the flight controller to attempt calling a NULL function and make it bricked.

1. Choose the motor protocol DSHOT and compile the firmware.
2. Cli set `set dshot_bitbang = OFF` and save.
3. Choose `ESC/Motorprotocl` to PWM_OUTPUT, save and reboot.

This issue was introduced from [c2768d0
](https://github.com/betaflight/betaflight/commit/c2768d0409a6dd6487bc88a0952079e3048ba43a)