### PR TITLE
Fix start frame detection for fast refresh (1 mS between frames)

### DIFF
--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -70,6 +70,8 @@
 
 #define SBUS_FRAME_BEGIN_BYTE 0x0F
 
+#define SBUS_TIME_NEEDED_PER_BYTE SBUS_TIME_NEEDED_PER_FRAME / SBUS_FRAME_SIZE
+
 #if !defined(SBUS_PORT_OPTIONS)
 #define SBUS_PORT_OPTIONS (SERIAL_STOPBITS_2 | SERIAL_PARITY_EVEN)
 #endif
@@ -117,7 +119,7 @@ static void sbusDataReceive(uint16_t c, void *data)
 
     const timeDelta_t sbusFrameTime = cmpTimeUs(nowUs, sbusFrameData->startAtUs);
 
-    if (sbusFrameTime > (long)(SBUS_TIME_NEEDED_PER_FRAME + 500)) {
+    if (sbusFrameTime > (long)(SBUS_TIME_NEEDED_PER_FRAME + 500) || sbusFrameTime > (long)(sbusFrameData->position * SBUS_TIME_NEEDED_PER_BYTE + 240)) {
         sbusFrameData->position = 0;
     }
 


### PR DESCRIPTION
When pause between frames less than frame length (e.g. 3 mS frame, 1 mS pause), connection is established in the middle of the frame, and start byte 0x0F is present in other part of frame (not only in start), a problem occured: frame's start shifting to the next (not first) position of byte 0x0F and frame will become invalid after 3500 uS. Current byte position and time from start of the frame check was added.