### PR TITLE
Add PB0 to AT32 SPI3 mosi pins

### DIFF
--- a/src/platform/AT32/platform_mcu.h
+++ b/src/platform/AT32/platform_mcu.h
@@ -139,7 +139,7 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 #define CHECK_SPI_RX_DATA_AVAILABLE(instance) LL_SPI_IsActiveFlag_RXNE(instance)
 #define SPI_RX_DATA_REGISTER(base) ((base)->DR)
 
-#define MAX_SPI_PIN_SEL    4
+#define MAX_SPI_PIN_SEL    5
 
 #define UART_TX_BUFFER_ATTRIBUTE                    // NONE
 #define UART_RX_BUFFER_ATTRIBUTE                    // NONE

--- a/src/platform/common/stm32/bus_spi_pinconfig.c
+++ b/src/platform/common/stm32/bus_spi_pinconfig.c
@@ -403,6 +403,7 @@ const spiHardware_t spiHardware[] = {
             { DEFIO_TAG_E(PC11), GPIO_MUX_6},
         },
         .mosiPins = {
+            { DEFIO_TAG_E(PB0),  GPIO_MUX_7},
             { DEFIO_TAG_E(PB2),  GPIO_MUX_7},
             { DEFIO_TAG_E(PB5),  GPIO_MUX_6},
             { DEFIO_TAG_E(PC12),  GPIO_MUX_6},


### PR DESCRIPTION
This pull request includes changes to the SPI pin configuration in the `platform_mcu.h` and `bus_spi_pinconfig.c` files to support an additional SPI pin selection.

SPI Configuration Updates:

* [`src/platform/AT32/platform_mcu.h`](diffhunk://#diff-a2d435852e67e63c309008892ead75f5998a4482624944a7418f5544f42040f5L142-R142): Increased the `MAX_SPI_PIN_SEL` definition from 4 to 5 to accommodate an additional SPI pin selection.
* [`src/platform/common/stm32/bus_spi_pinconfig.c`](diffhunk://#diff-fd66fff86b8245545b4d44a57d0eaf13d443f81316a8b9046e86bc1cdb7bb050R406): Added a new MOSI pin configuration for `PB0` with `GPIO_MUX_7` to the `spiHardware` array.