### PR TITLE
Added virtual blackbox for SITL

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1051,6 +1051,9 @@ void blackboxValidateConfig(void)
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
 #endif
+#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+    case BLACKBOX_DEVICE_VIRTUAL:
+#endif
     case BLACKBOX_DEVICE_SERIAL:
         // Device supported, leave the setting alone
         break;

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1051,7 +1051,7 @@ void blackboxValidateConfig(void)
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
 #endif
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
 #endif
     case BLACKBOX_DEVICE_SERIAL:

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -30,7 +30,7 @@ typedef enum BlackboxDevice {
     BLACKBOX_DEVICE_FLASH = 1,
     BLACKBOX_DEVICE_SDCARD = 2,
     BLACKBOX_DEVICE_SERIAL = 3,
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     BLACKBOX_DEVICE_VIRTUAL = 4
 #endif
 } BlackboxDevice_e;

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -30,9 +30,7 @@ typedef enum BlackboxDevice {
     BLACKBOX_DEVICE_FLASH = 1,
     BLACKBOX_DEVICE_SDCARD = 2,
     BLACKBOX_DEVICE_SERIAL = 3,
-#ifdef USE_BLACKBOX_VIRTUAL
     BLACKBOX_DEVICE_VIRTUAL = 4
-#endif
 } BlackboxDevice_e;
 
 typedef enum BlackboxMode {

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -29,7 +29,10 @@ typedef enum BlackboxDevice {
     BLACKBOX_DEVICE_NONE = 0,
     BLACKBOX_DEVICE_FLASH = 1,
     BLACKBOX_DEVICE_SDCARD = 2,
-    BLACKBOX_DEVICE_SERIAL = 3
+    BLACKBOX_DEVICE_SERIAL = 3,
+#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+    BLACKBOX_DEVICE_VIRTUAL = 4
+#endif
 } BlackboxDevice_e;
 
 typedef enum BlackboxMode {

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -30,7 +30,7 @@ typedef enum BlackboxDevice {
     BLACKBOX_DEVICE_FLASH = 1,
     BLACKBOX_DEVICE_SDCARD = 2,
     BLACKBOX_DEVICE_SERIAL = 3,
-    BLACKBOX_DEVICE_VIRTUAL = 4
+    BLACKBOX_DEVICE_VIRTUAL = 4,
 } BlackboxDevice_e;
 
 typedef enum BlackboxMode {

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -59,9 +59,7 @@
 #include "drivers/sdcard.h"
 #endif
 
-#ifdef USE_BLACKBOX_VIRTUAL
 #include "blackbox_virtual.h"
-#endif
 
 #define BLACKBOX_SERIAL_PORT_MODE MODE_TX
 

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -59,7 +59,7 @@
 #include "drivers/sdcard.h"
 #endif
 
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
 #include "blackbox_virtual.h"
 #endif
 
@@ -129,7 +129,7 @@ void blackboxWrite(uint8_t value)
         afatfs_fputc(blackboxSDCard.logFile, value);
         break;
 #endif
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         blackboxVirtualPutChar(value);
         break;
@@ -194,7 +194,7 @@ int blackboxWriteString(const char *s)
         break;
 #endif // USE_SDCARD
 
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         length = strlen(s);
         blackboxVirtualWrite((const uint8_t*) s, length);
@@ -233,7 +233,7 @@ void blackboxDeviceFlush(void)
         flashfsFlushAsync(false);
         break;
 #endif // USE_FLASHFS
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         blackboxVirtualFlush();
         break;
@@ -270,7 +270,7 @@ bool blackboxDeviceFlushForce(void)
         // been physically written to the SD card yet.
         return afatfs_flush();
 #endif // USE_SDCARD
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         return blackboxVirtualFlush();
 #endif
@@ -294,7 +294,7 @@ bool blackboxDeviceFlushForceComplete(void)
             return false;
         }
 #endif // USE_SDCARD
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         blackboxVirtualFlush();
         return true;
@@ -390,7 +390,7 @@ bool blackboxDeviceOpen(void)
         return true;
         break;
 #endif // USE_SDCARD
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         return blackboxVirtualOpen();
 
@@ -464,7 +464,7 @@ void blackboxDeviceClose(void)
         flashfsClose();
         break;
 #endif
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         blackboxVirtualClose();
         break;
@@ -604,7 +604,7 @@ bool blackboxDeviceBeginLog(void)
     case BLACKBOX_DEVICE_SDCARD:
         return blackboxSDCardBeginLog();
 #endif // USE_SDCARD
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         return blackboxVirtualBeginLog();
 #endif
@@ -643,7 +643,7 @@ bool blackboxDeviceEndLog(bool retainLog)
         return false;
 #endif // USE_SDCARD
 
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         blackboxVirtualEndLog();
         return true;
@@ -691,7 +691,7 @@ bool isBlackboxDeviceWorking(void)
         return flashfsIsReady();
 #endif
 
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         return true;
 #endif
@@ -709,7 +709,7 @@ int32_t blackboxGetLogNumber(void)
         return blackboxSDCard.largestLogFileNumber;
 #endif
 
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         return blackboxVirtualLogFileNumber();
         break;
@@ -742,7 +742,7 @@ void blackboxReplenishHeaderBudget(void)
         freeSpace = afatfs_getFreeBufferSpace();
         break;
 #endif
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         blackboxHeaderBudget = 1024*8;
         return;
@@ -812,7 +812,7 @@ blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes)
         return BLACKBOX_RESERVE_TEMPORARY_FAILURE;
 #endif // USE_SDCARD
 
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     case BLACKBOX_DEVICE_VIRTUAL:
         return BLACKBOX_RESERVE_TEMPORARY_FAILURE;
 #endif

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -19,6 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platform.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -36,13 +36,13 @@ static int32_t largestLogFileNumber = 0;
 bool blackboxVirtualOpen(void)
 {
     DIR *dir = opendir(".");
-    struct dirent *file;
-    while ((file = readdir(dir)) != NULL) {
-        if (strncmp(file->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
-                    && strncmp(file->d_name + 8, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strncmp(entry->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
+                    && strncmp(entry->d_name + 8, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
 
             char logSequenceNumberString[6];
-            memcpy(logSequenceNumberString, file->d_name + 3, 5);
+            memcpy(logSequenceNumberString, entry->d_name + 3, 5);
             logSequenceNumberString[5] = '\0';
             largestLogFileNumber = MAX((int32_t)atoi(logSequenceNumberString), largestLogFileNumber);
         }
@@ -73,7 +73,6 @@ bool blackboxVirtualFlush(void)
     } else {
         return false;
     }
-
 }
 
 bool blackboxVirtualBeginLog(void)
@@ -82,14 +81,8 @@ bool blackboxVirtualBeginLog(void)
         return false;
     }
 
-    int32_t remainder = largestLogFileNumber + 1;
-    char filename[] = LOGFILE_PREFIX "00000." LOGFILE_SUFFIX;
-
-    for (int i = 7; i >= 3; i--) {
-        filename[i] = (remainder % 10) + '0';
-        remainder /= 10;
-    }
-
+    char filename[13];
+    sprintf(filename, "%3s%05i.%3s", LOGFILE_PREFIX, largestLogFileNumber, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");
     if (blackboxVirtualFile != NULL) {
         largestLogFileNumber++;

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -33,6 +33,7 @@
 
 static FILE *blackboxVirtualFile = NULL;
 static int32_t largestLogFileNumber = 0;
+
 bool blackboxVirtualOpen(void)
 {
     const size_t log_name_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 1; //file name template: LOG00001.BFL

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -37,6 +37,10 @@ bool blackboxVirtualOpen(void)
 {
     const int log_name_length = 12; //file name template: LOG00001.BFL
     DIR *dir = opendir(".");
+    if (!dir) {
+        return false; // Failed to open directory
+    }
+
     struct dirent *entry;
     while ((entry = readdir(dir)) != NULL) {
         if (strlen(entry->d_name) == log_name_length

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -35,7 +35,7 @@ static FILE *blackboxVirtualFile = NULL;
 static int32_t largestLogFileNumber = 0;
 bool blackboxVirtualOpen(void)
 {
-    const int log_name_length = 12; //file name template: LOG00001.BFL
+    const int log_name_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 1; //file name template: LOG00001.BFL
     DIR *dir = opendir(".");
     if (!dir) {
         return false; // Failed to open directory

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -35,7 +35,7 @@ static FILE *blackboxVirtualFile = NULL;
 static int32_t largestLogFileNumber = 0;
 bool blackboxVirtualOpen(void)
 {
-    const int log_name_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 1; //file name template: LOG00001.BFL
+    const size_t log_name_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 1; //file name template: LOG00001.BFL
     DIR *dir = opendir(".");
     if (!dir) {
         return false; // Failed to open directory
@@ -86,9 +86,9 @@ bool blackboxVirtualBeginLog(void)
     if (blackboxVirtualFile != NULL) {
         return false;
     }
-
-    char filename[13];
-    sprintf(filename, "%3s%05i.%3s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
+    const size_t name_buffer_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 2; //file name template: LOG00001.BFL
+    char filename[name_buffer_length];
+    sprintf(filename, "%s%05i.%s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");
     if (blackboxVirtualFile != NULL) {
         largestLogFileNumber++;

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -35,11 +35,13 @@ static FILE *blackboxVirtualFile = NULL;
 static int32_t largestLogFileNumber = 0;
 bool blackboxVirtualOpen(void)
 {
+    const int log_name_length = 12; //file name template: LOG00001.BFL
     DIR *dir = opendir(".");
     struct dirent *entry;
     while ((entry = readdir(dir)) != NULL) {
-        if (strncmp(entry->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
-                    && strncmp(entry->d_name + 9, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
+        if (strlen(entry->d_name) == log_name_length
+            && strncmp(entry->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
+            && strncmp(entry->d_name + 9, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
 
             char logSequenceNumberString[6];
             memcpy(logSequenceNumberString, entry->d_name + 3, 5);

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <dirent.h>
+#include <common/maths.h>
+
+#define LOGFILE_PREFIX "LOG"
+#define LOGFILE_SUFFIX "BFL"
+
+static FILE *blackboxVirtualFile = NULL;
+static int32_t largestLogFileNumber = 0;
+bool blackboxVirtualOpen(void)
+{
+    DIR *dir = opendir(".");
+    struct dirent *file;
+    while ((file = readdir(dir)) != NULL) {
+        if (strncmp(file->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
+                    && strncmp(file->d_name + 8, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
+
+            char logSequenceNumberString[6];
+            memcpy(logSequenceNumberString, file->d_name + 3, 5);
+            logSequenceNumberString[5] = '\0';
+            largestLogFileNumber = MAX((int32_t)atoi(logSequenceNumberString), largestLogFileNumber);
+        }
+    }
+    closedir(dir);
+    return true;
+}
+
+void blackboxVirtualPutChar(uint8_t value)
+{
+    if (blackboxVirtualFile != NULL) {
+        fputc(value, blackboxVirtualFile);
+    }
+}
+
+void blackboxVirtualWrite(const uint8_t *buffer, uint32_t len)
+{
+    if (blackboxVirtualFile != NULL) {
+        fwrite(buffer, len, 1, blackboxVirtualFile);
+    }
+}
+
+bool blackboxVirtualFlush(void)
+{
+    if (blackboxVirtualFile != NULL) {
+        fflush(blackboxVirtualFile);
+        return true;
+    } else {
+        return false;
+    }
+
+}
+
+bool blackboxVirtualBeginLog(void)
+{
+    if (blackboxVirtualFile != NULL) {
+        return false;
+    }
+
+    int32_t remainder = largestLogFileNumber + 1;
+    char filename[] = LOGFILE_PREFIX "00000." LOGFILE_SUFFIX;
+
+    for (int i = 7; i >= 3; i--) {
+        filename[i] = (remainder % 10) + '0';
+        remainder /= 10;
+    }
+
+    blackboxVirtualFile = fopen(filename, "w");
+    if (blackboxVirtualFile != NULL) {
+        largestLogFileNumber++;
+    }
+    return blackboxVirtualFile != NULL;
+}
+
+bool blackboxVirtualEndLog(void)
+{
+    if (blackboxVirtualFile != NULL) {
+        fclose(blackboxVirtualFile);
+        blackboxVirtualFile = NULL;
+    }
+    return true;
+}
+
+void blackboxVirtualClose(void)
+{
+    blackboxVirtualEndLog();
+}
+
+uint32_t blackboxVirtualLogFileNumber(void)
+{
+    return largestLogFileNumber;
+}

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -39,7 +39,7 @@ bool blackboxVirtualOpen(void)
     struct dirent *entry;
     while ((entry = readdir(dir)) != NULL) {
         if (strncmp(entry->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
-                    && strncmp(entry->d_name + 8, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
+                    && strncmp(entry->d_name + 9, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
 
             char logSequenceNumberString[6];
             memcpy(logSequenceNumberString, entry->d_name + 3, 5);
@@ -82,7 +82,7 @@ bool blackboxVirtualBeginLog(void)
     }
 
     char filename[13];
-    sprintf(filename, "%3s%05i.%3s", LOGFILE_PREFIX, largestLogFileNumber, LOGFILE_SUFFIX);
+    sprintf(filename, "%3s%05i.%3s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");
     if (blackboxVirtualFile != NULL) {
         largestLogFileNumber++;

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -20,7 +20,9 @@
  */
 
 #pragma once
-
+#ifndef SIMULATOR_BUILD
+#error "USE_BLACKBOX_VIRTUAL uses in SITL build only"
+#endif
 bool blackboxVirtualOpen(void);
 void blackboxVirtualPutChar(uint8_t value);
 void blackboxVirtualWrite(const uint8_t *buffer, uint32_t len);

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#ifndef SIMULATOR_BUILD
+#if defined(USE_BLACKBOX_VIRTUAL) && !defined(SIMULATOR_BUILD)
 #error "USE_BLACKBOX_VIRTUAL valid for SITL build only"
 #endif
 

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+bool blackboxVirtualOpen(void);
+void blackboxVirtualPutChar(uint8_t value);
+void blackboxVirtualWrite(const uint8_t *buffer, uint32_t len);
+bool blackboxVirtualFlush(void);
+bool blackboxVirtualBeginLog(void);
+bool blackboxVirtualEndLog(void);
+void blackboxVirtualClose(void);
+uint32_t blackboxVirtualLogFileNumber(void);

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -24,6 +24,7 @@
 #ifndef SIMULATOR_BUILD
 #error "USE_BLACKBOX_VIRTUAL valid for SITL build only"
 #endif
+
 bool blackboxVirtualOpen(void);
 void blackboxVirtualPutChar(uint8_t value);
 void blackboxVirtualWrite(const uint8_t *buffer, uint32_t len);

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -20,6 +20,7 @@
  */
 
 #pragma once
+
 #ifndef SIMULATOR_BUILD
 #error "USE_BLACKBOX_VIRTUAL valid for SITL build only"
 #endif

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -21,7 +21,7 @@
 
 #pragma once
 #ifndef SIMULATOR_BUILD
-#error "USE_BLACKBOX_VIRTUAL uses in SITL build only"
+#error "USE_BLACKBOX_VIRTUAL valid for SITL build only"
 #endif
 bool blackboxVirtualOpen(void);
 void blackboxVirtualPutChar(uint8_t value);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -272,7 +272,7 @@ static const char * const lookupTableBlackboxDevice[] = {
     "SPIFLASH",
     "SDCARD",
     "SERIAL",
-#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+#ifdef USE_BLACKBOX_VIRTUAL
     "VIRTUAL"
 #endif
 };

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -273,7 +273,7 @@ static const char * const lookupTableBlackboxDevice[] = {
     "SDCARD",
     "SERIAL",
 #ifdef USE_BLACKBOX_VIRTUAL
-    "VIRTUAL"
+    "VIRTUAL",
 #endif
 };
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -268,7 +268,13 @@ static const char * const lookupTableGimbalMode[] = {
 
 #ifdef USE_BLACKBOX
 static const char * const lookupTableBlackboxDevice[] = {
-    "NONE", "SPIFLASH", "SDCARD", "SERIAL"
+    "NONE",
+    "SPIFLASH",
+    "SDCARD",
+    "SERIAL",
+#if defined(SIMULATOR_BUILD) && defined(USE_BLACKBOX_VIRTUAL)
+    "VIRTUAL"
+#endif
 };
 
 static const char * const lookupTableBlackboxMode[] = {

--- a/src/platform/SIMULATOR/target/SITL/target.h
+++ b/src/platform/SIMULATOR/target/SITL/target.h
@@ -105,6 +105,10 @@
 #define USE_PWM_OUTPUT
 #endif
 
+#ifdef USE_BLACKBOX
+#define USE_BLACKBOX_VIRTUAL
+#endif
+
 #undef USE_STACK_CHECK // I think SITL don't need this
 #undef USE_DASHBOARD
 #undef USE_TELEMETRY_LTM

--- a/src/platform/SIMULATOR/target/SITL/target.h
+++ b/src/platform/SIMULATOR/target/SITL/target.h
@@ -105,9 +105,8 @@
 #define USE_PWM_OUTPUT
 #endif
 
-#ifdef USE_BLACKBOX
+#define USE_BLACKBOX
 #define USE_BLACKBOX_VIRTUAL
-#endif
 
 #undef USE_STACK_CHECK // I think SITL don't need this
 #undef USE_DASHBOARD

--- a/src/platform/SIMULATOR/target/SITL/target.mk
+++ b/src/platform/SIMULATOR/target/SITL/target.mk
@@ -7,7 +7,8 @@ TARGET_SRC = \
             drivers/barometer/barometer_virtual.c \
             drivers/compass/compass_virtual.c \
             drivers/serial_tcp.c \
-            io/gps_virtual.c
+            io/gps_virtual.c \
+            blackbox/blackbox_virtual.c
 
 SIZE_OPTIMISED_SRC += \
             drivers/serial_tcp.c

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -52,6 +52,7 @@
 #define USE_LED_STRIP
 #define USE_SERVOS
 #define USE_TRANSPONDER
+#define USE_BLACKBOX
 
 #ifndef LED_STRIP_MAX_LENGTH
     #ifdef USE_LED_STRIP_64

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -52,7 +52,6 @@
 #define USE_LED_STRIP
 #define USE_SERVOS
 #define USE_TRANSPONDER
-#define USE_BLACKBOX
 
 #ifndef LED_STRIP_MAX_LENGTH
     #ifdef USE_LED_STRIP_64


### PR DESCRIPTION
The virtual blackbox is added in SITL. The logs are written into file on disk. 
It needs to set -DUSE_BLACKBOX flag to build SITL with virtual blackbox.
The blackbox device type is VIRTUAL. It can set from cli til.
The improvement directs log output into file. The all logging logic did not change.
The log file example from my X-Plane simulator flight by using my [SITL-XPlane bridge:](https://github.com/demvlad/BF-SITL-X-Plane-Bridge)
[LOG00005.txt](https://github.com/user-attachments/files/19512931/LOG00005.txt)
The log rate is not big on my weakly notebook, but this is enough to test some improvements, i think. We do not need filter tuning and other what need high log rate by using SITL.

This is hard system, but it is working!
![sitl_blackbox](https://github.com/user-attachments/assets/7426a148-6984-44fc-bc6b-da520588990a)

