### PR TITLE
Add Launch Timer

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -128,7 +128,7 @@ const char * const osdTimerSourceNames[] = {
 #define IS_MID(X) (rcData[X] > 1250 && rcData[X] < 1750)
 
 timeUs_t osdFlyTime = 0;
-timeUs_t osdRaceTime = 0;
+timeUs_t osdLaunchTime = 0;
 #if defined(USE_ACC)
 float osdGForce = 0;
 #endif
@@ -1247,7 +1247,7 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
         stats.armed_time += deltaT;
 #ifdef USE_LAUNCH_CONTROL
         if(!isLaunchControlActive())
-            osdRaceTime += deltaT;
+            osdLaunchTime += deltaT;
 #endif
     } else if (osdStatsEnabled) {  // handle showing/hiding stats based on OSD disable switch position
         if (displayIsGrabbed(osdDisplayPort)) {

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -115,7 +115,7 @@ const char * const osdTimerSourceNames[] = {
     "TOTAL ARM",
     "LAST ARM ",
     "ON/ARM   ",
-    "LAUNCH TIME"
+    "LAUNCH TIME",
 };
 
 #define OSD_LOGO_ROWS 4

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1246,7 +1246,7 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
         osdFlyTime += deltaT;
         stats.armed_time += deltaT;
 #ifdef USE_LAUNCH_CONTROL
-        if(!isLaunchControlActive())
+        if (!isLaunchControlActive())
             osdLaunchTime += deltaT;
 #endif
     } else if (osdStatsEnabled) {  // handle showing/hiding stats based on OSD disable switch position

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -114,7 +114,8 @@ const char * const osdTimerSourceNames[] = {
     "ON TIME  ",
     "TOTAL ARM",
     "LAST ARM ",
-    "ON/ARM   "
+    "ON/ARM   ",
+    "LAUNCH TIME"
 };
 
 #define OSD_LOGO_ROWS 4
@@ -127,6 +128,7 @@ const char * const osdTimerSourceNames[] = {
 #define IS_MID(X) (rcData[X] > 1250 && rcData[X] < 1750)
 
 timeUs_t osdFlyTime = 0;
+timeUs_t osdRaceTime = 0;
 #if defined(USE_ACC)
 float osdGForce = 0;
 #endif
@@ -1243,6 +1245,10 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
         timeUs_t deltaT = currentTimeUs - lastTimeUs;
         osdFlyTime += deltaT;
         stats.armed_time += deltaT;
+#ifdef USE_LAUNCH_CONTROL
+        if(!isLaunchControlActive())
+            osdRaceTime += deltaT;
+#endif
     } else if (osdStatsEnabled) {  // handle showing/hiding stats based on OSD disable switch position
         if (displayIsGrabbed(osdDisplayPort)) {
             osdStatsEnabled = false;

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1247,8 +1247,11 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
         osdFlyTime += deltaT;
         stats.armed_time += deltaT;
 #ifdef USE_LAUNCH_CONTROL
-        if (!isLaunchControlActive())
+        if (!isLaunchControlActive()) {
             osdLaunchTime += deltaT;
+        } else {
+            osdLaunchTime = 0;
+        }
 #endif
     } else if (osdStatsEnabled) {  // handle showing/hiding stats based on OSD disable switch position
         if (displayIsGrabbed(osdDisplayPort)) {

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -129,6 +129,7 @@ const char * const osdTimerSourceNames[] = {
 
 timeUs_t osdFlyTime = 0;
 timeUs_t osdLaunchTime = 0;
+
 #if defined(USE_ACC)
 float osdGForce = 0;
 #endif

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -393,7 +393,7 @@ typedef struct statistic_s {
 
 extern timeUs_t resumeRefreshAt;
 extern timeUs_t osdFlyTime;
-extern timeUs_t osdRaceTime;
+extern timeUs_t osdLaunchTime;
 #if defined(USE_ACC)
 extern float osdGForce;
 #endif

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -394,6 +394,7 @@ typedef struct statistic_s {
 extern timeUs_t resumeRefreshAt;
 extern timeUs_t osdFlyTime;
 extern timeUs_t osdLaunchTime;
+
 #if defined(USE_ACC)
 extern float osdGForce;
 #endif

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -29,7 +29,7 @@
 
 #include "sensors/esc_sensor.h"
 
-#define OSD_NUM_TIMER_TYPES 4
+#define OSD_NUM_TIMER_TYPES 5
 extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 
 #define OSD_ELEMENT_BUFFER_LENGTH 32
@@ -257,6 +257,7 @@ typedef enum {
     OSD_TIMER_SRC_TOTAL_ARMED,
     OSD_TIMER_SRC_LAST_ARMED,
     OSD_TIMER_SRC_ON_OR_ARMED,
+    OSD_TIMER_SRC_LAUNCH_TIME,
     OSD_TIMER_SRC_COUNT
 } osd_timer_source_e;
 
@@ -392,6 +393,7 @@ typedef struct statistic_s {
 
 extern timeUs_t resumeRefreshAt;
 extern timeUs_t osdFlyTime;
+extern timeUs_t osdRaceTime;
 #if defined(USE_ACC)
 extern float osdGForce;
 #endif

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -515,6 +515,8 @@ static char osdGetTimerSymbol(osd_timer_source_e src)
         return SYM_FLY_M;
     case OSD_TIMER_SRC_ON_OR_ARMED:
         return ARMING_FLAG(ARMED) ? SYM_FLY_M : SYM_ON_M;
+    case OSD_TIMER_SRC_LAUNCH_TIME:
+        return 'L';
     default:
         return ' ';
     }
@@ -533,6 +535,8 @@ static timeUs_t osdGetTimerValue(osd_timer_source_e src)
     }
     case OSD_TIMER_SRC_ON_OR_ARMED:
         return ARMING_FLAG(ARMED) ? osdFlyTime : micros();
+    case OSD_TIMER_SRC_LAUNCH_TIME:
+        return osdRaceTime;
     default:
         return 0;
     }

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -536,7 +536,7 @@ static timeUs_t osdGetTimerValue(osd_timer_source_e src)
     case OSD_TIMER_SRC_ON_OR_ARMED:
         return ARMING_FLAG(ARMED) ? osdFlyTime : micros();
     case OSD_TIMER_SRC_LAUNCH_TIME:
-        return osdRaceTime;
+        return osdLaunchTime;
     default:
         return 0;
     }


### PR DESCRIPTION
Implementing an feature issue #9055
Added a timer that starts counting down at the time when the drone leaves LAUNCH_MODE.

