### PR TITLE
STM32H7 add UART4 pins

### DIFF
--- a/src/platform/STM32/platform_mcu.h
+++ b/src/platform/STM32/platform_mcu.h
@@ -399,7 +399,7 @@ extern uint8_t _dmaram_end__;
 #elif defined(STM32F7)
 #define UARTHARDWARE_MAX_PINS 4
 #elif defined(STM32H7)
-#define UARTHARDWARE_MAX_PINS 5
+#define UARTHARDWARE_MAX_PINS 6
 #elif defined(STM32G4)
 #define UARTHARDWARE_MAX_PINS 3
 #endif

--- a/src/platform/STM32/serial_uart_stm32h7xx.c
+++ b/src/platform/STM32/serial_uart_stm32h7xx.c
@@ -207,14 +207,17 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PA11), GPIO_AF6_UART4 },
             { DEFIO_TAG_E(PB8),  GPIO_AF8_UART4 },
             { DEFIO_TAG_E(PC11), GPIO_AF8_UART4 },
-            { DEFIO_TAG_E(PD0),  GPIO_AF8_UART4 }
+            { DEFIO_TAG_E(PD0),  GPIO_AF8_UART4 },
+            { DEFIO_TAG_E(PH14), GPIO_AF8_UART4 }
+
         },
         .txPins = {
             { DEFIO_TAG_E(PA0),  GPIO_AF8_UART4 },
             { DEFIO_TAG_E(PA12), GPIO_AF6_UART4 },
             { DEFIO_TAG_E(PB9),  GPIO_AF8_UART4 },
             { DEFIO_TAG_E(PC10), GPIO_AF8_UART4 },
-            { DEFIO_TAG_E(PD1),  GPIO_AF8_UART4 }
+            { DEFIO_TAG_E(PD1),  GPIO_AF8_UART4 },
+            { DEFIO_TAG_E(PH13), GPIO_AF8_UART4 }
         },
         .rcc = RCC_APB1L(UART4),
         .irqn = UART4_IRQn,


### PR DESCRIPTION
This PR adds two more pin definitions for UART4 on the STM32H7. 

https://github.com/betaflight/config/pull/742