### PR TITLE
Make SA prepend configurable using CLI

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1693,6 +1693,7 @@ const clivalue_t valueTable[] = {
     { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, VTX_TABLE_MAX_POWER_LEVELS - 1 }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
     { "vtx_low_power_disarm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_VTX_LOW_POWER_DISARM }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, lowPowerDisarm) },
     { "vtx_softserial_alt",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, softserialAlt) },
+    { "vtx_serial_alt",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, serialAlt) },
 #ifdef VTX_SETTINGS_FREQCMD
     { "vtx_freq",                   VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, freq) },
     { "vtx_pit_mode_freq",          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, pitModeFreq) },

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -64,6 +64,7 @@ void pgResetFn_vtxSettingsConfig(vtxSettingsConfig_t *vtxSettingsConfig)
     vtxSettingsConfig->pitModeFreq = VTX_TABLE_DEFAULT_PITMODE_FREQ;
     vtxSettingsConfig->lowPowerDisarm = VTX_LOW_POWER_DISARM_OFF;
     vtxSettingsConfig->softserialAlt = 0;
+    vtxSettingsConfig->serialAlt = 0;
 }
 
 typedef enum {

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -40,6 +40,7 @@ typedef struct vtxSettingsConfig_s {
     uint16_t pitModeFreq;   // sets out-of-range pitmode frequency
     uint8_t lowPowerDisarm; // min power while disarmed, from vtxLowerPowerDisarm_e
     uint8_t softserialAlt;  // prepend 0xff before sending frame even with SOFTSERIAL
+    uint8_t serialAlt;      // prepend 0xff before sending frame even with SERIAL
 } vtxSettingsConfig_t;
 
 PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -499,11 +499,10 @@ static void saSendFrame(uint8_t *buf, int len)
             break;
         case SERIALTYPE_UART:
         case SERIALTYPE_LPUART: // decide HW uarts by MCU type
-#ifdef AT32F4
-            prepend00 = false;
-#else
-            prepend00 = true;
-#endif
+            // AT32F4 has a bug in the UART peripheral that causes it to
+            // not send the first byte of a transmission if the first byte
+            // is 0x00. This is not a problem for other MCUs.
+            prepend00 = vtxSettingsConfig()->serialAlt;
             break;
         default:
             prepend00 = false;


### PR DESCRIPTION
- Needs testing different VTX devices on different MCU's
- Make prepend byte configurable

AI generated:

This pull request includes several changes to the VTX settings configuration in the `src/main/io` and `src/main/cli` directories. The changes introduce a new configuration option `serialAlt` and update related functions to accommodate this new setting.

### VTX settings configuration updates:

* Added a new configuration option `serialAlt` to the `vtxSettingsConfig_t` struct in `src/main/io/vtx.h`.
* Updated the `valueTable` in `src/main/cli/settings.c` to include the new `serialAlt` setting.
* Modified the `pgResetFn_vtxSettingsConfig` function in `src/main/io/vtx.c` to initialize the new `serialAlt` setting to 0.

### UART transmission behavior:

* Updated the `saSendFrame` function in `src/main/io/vtx_smartaudio.c` to use the new `serialAlt` setting for determining whether to prepend 0x00 to the transmission buffer. This addresses a specific bug in the AT32F4 UART peripheral.