### PR TITLE
throttle lookup table increase size, fix linear interpolation and improve bezier interpolation logic

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -887,9 +887,9 @@ void initRcProcessing(void)
     rcCommandDivider = 500.0f - rcControlsConfig()->deadband;
     rcCommandYawDivider = 500.0f - rcControlsConfig()->yaw_deadband;
 
-    float thrMid   = currentControlRateProfile->thrMid8   / 100.0f;
-    float expo     = currentControlRateProfile->thrExpo8   / 100.0f;
-    float thrHover = currentControlRateProfile->thrHover8 / 100.0f;
+    float thrMid   = currentControlRateProfile->thrMid8   / 100.0f;  // normalized x coordinate for hover point
+    float expo     = currentControlRateProfile->thrExpo8   / 100.0f;  // normalized expo (0.0 .. 1.0)
+    float thrHover = currentControlRateProfile->thrHover8 / 100.0f;  // normalized y coordinate for hover point
 
     /*
     Algorithm Overview:

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -853,7 +853,7 @@ static float quadraticBezier(float x, float p0x, float p1x, float p2x, float p0y
         if (fabsf(b) > 1e-6f) {
             t = -c / b;
         }
-        // If both a and b are zero, t remains 0 (degenerate case)
+        // If both a and b are zero, t = 0 (degenerate case)
     } else {
         float disc = b * b - 4.0f * a * c;
         if (disc >= 0.0f) { // Real roots exist
@@ -869,7 +869,7 @@ static float quadraticBezier(float x, float p0x, float p1x, float p2x, float p0y
                 t = t2; // Use t2 even if it's outside [0, 1] as per original logic
             }
         }
-        // If disc < 0, no real roots, t remains 0.
+        // If disc < 0, no real roots, t = 0.
     }
 
     // Clamp t to the valid range [0, 1] before calculating y

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -150,7 +150,9 @@ float getMaxRcDeflectionAbs(void)
     return maxRcDeflectionAbs;
 }
 
-#define THROTTLE_LOOKUP_LENGTH 50
+#ifndef THROTTLE_LOOKUP_LENGTH
+# define THROTTLE_LOOKUP_LENGTH 12
+#endif
 static int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];    // lookup table for expo & mid THROTTLE
 
 static int16_t rcLookupThrottle(int32_t tmp)

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -162,9 +162,11 @@ static int16_t rcLookupThrottle(int32_t tmp)
     const int32_t idx    = scaled / PWM_RANGE;         // 0…steps
     const int32_t rem    = scaled % PWM_RANGE;         // for interpolation
 
-    // If index goes to the final slot, just return it
+    // If index goes outside the valid range, clamp it
     if (idx >= steps) {
         return lookupThrottleRC[steps];
+    } else if (idx < 0) {
+        return lookupThrottleRC[0];
     }
 
     // Otherwise linearly interpolate between lookupThrottleRC[idx] and [idx+1]

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -168,7 +168,7 @@ static int16_t rcLookupThrottle(int32_t tmp)
     }
 
     // Otherwise linearly interpolate between lookupThrottleRC[idx] and [idx+1]
-return scaleRange(rem, 0, PWM_RANGE, lookupThrottleRC[idx], lookupThrottleRC[idx + 1]);
+    return scaleRange(rem, 0, PWM_RANGE, lookupThrottleRC[idx], lookupThrottleRC[idx + 1]);
 }
 
 #define SETPOINT_RATE_LIMIT_MIN -1998.0f

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -905,11 +905,11 @@ void initRcProcessing(void)
       - The output y is mapped from [0,1] to the PWM range.
     */
 
-    // control points: slide horizontally by expo, keep Y at thrHover
-    float cp1x = thrMid * (1.0f - expo);
-    float cp1y = thrHover;
-    float cp2x = thrMid + (1.0f - thrMid) * expo;
-    float cp2y = thrHover;
+    // control points: move between 'on the diagonal' and 'at the same height as the hover point'
+    float cp1x = thrMid * 0.5f;
+    float cp1y = thrHover * 0.5f * (1.0f + expo);
+    float cp2x = (1.0f + thrMid) * 0.5f;
+    float cp2y = (1.0f + ((thrHover - 1.0f) * 0.5f * (1.0f + expo)));
 
     // build throttle lookup table by solving for t so that Bézier_x(t)=x
     for (int i = 0; i < THROTTLE_LOOKUP_LENGTH; i++) {

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -841,7 +841,8 @@ bool isMotorsReversed(void)
 // Calculates the y-coordinate of a point on a quadratic Bezier curve for a given x-coordinate.
 // It first solves for the parameter t such that Bezier_x(t) = x, using the x control points (p0x, p1x, p2x).
 // Then, it calculates the y-coordinate using the found t and the y control points (p0y, p1y, p2y).
-static float quadraticBezier(float x, float p0x, float p1x, float p2x, float p0y, float p1y, float p2y) {
+static float quadraticBezier(float x, float p0x, float p1x, float p2x, float p0y, float p1y, float p2y)
+{
     // Solve for t such that Bezier_x(t) = x
     // Bezier_x(t) = (1-t)^2*p0x + 2*(1-t)*t*p1x + t^2*p2x
     // Rearranging into A*t^2 + B*t + C = 0, where C = p0x - x


### PR DESCRIPTION
fix to bugs found after #14229 was merged

 - allow override of the lookup table length
 - linear interpolation uses lookup table indices 0..max
 - bezier interpolation calculates the correct t value first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved throttle response curve for greater accuracy and flexibility, using quadratic Bezier curve interpolation.
- **Refactor**
  - Enhanced throttle curve generation for smoother and more precise control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->