### PR TITLE
Fix ATRN

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1099,8 +1099,8 @@ static void osdElementFlymode(osdElementParms_t *element)
 #ifdef USE_CHIRP
     // the additional check for pidChirpIsFinished() is to have visual feedback for user that don't have warnings enabled in their googles
     } else if (FLIGHT_MODE(CHIRP_MODE) && !pidChirpIsFinished()) {
-#endif
         strcpy(element->buff, "CHIR");
+#endif
     } else if (isAirmodeEnabled()) {
         strcpy(element->buff, "AIR ");
     } else {

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1097,7 +1097,7 @@ static void osdElementFlymode(osdElementParms_t *element)
     } else if (IS_RC_MODE_ACTIVE(BOXACROTRAINER)) {
         strcpy(element->buff, "ATRN");
 #ifdef USE_CHIRP
-    // the additional check for pidChirpIsFinished() is to have visual feedback for user that don't have warnings enabled in their googles
+    // the additional check for pidChirpIsFinished() is to have visual feedback for user that don't have warnings enabled in their goggles
     } else if (FLIGHT_MODE(CHIRP_MODE) && !pidChirpIsFinished()) {
         strcpy(element->buff, "CHIR");
 #endif


### PR DESCRIPTION
- Fixes: #14359

This pull request makes a minor adjustment to the `osdElementFlymode` function in the `src/main/osd/osd_elements.c` file. It relocates the `#endif` directive to ensure that the `strcpy` call for the "CHIR" mode is properly enclosed within the `#ifdef USE_CHIRP` block.

Code logic adjustment:

* [`src/main/osd/osd_elements.c`](diffhunk://#diff-540c23c68731912a6a838f3a40d5f83bd48d3e79f79613c2136866a7bc3c188fL1102-R1103): Moved the `#endif` directive to encapsulate the `strcpy(element->buff, "CHIR");` line, ensuring it is only executed when `USE_CHIRP` is defined.