### PR TITLE
fix format overflow in blackboxVirtualBeginLog

### DIFF
--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -89,7 +89,7 @@ bool blackboxVirtualBeginLog(void)
     }
     const size_t name_buffer_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 2; //file name template: LOG00001.BFL
     char filename[name_buffer_length];
-    snprintf(filename, sizeof(filename), "%s%05u.%s", LOGFILE_PREFIX, (uint16_t)(largestLogFileNumber + 1), LOGFILE_SUFFIX);
+    snprintf(filename, sizeof(filename), "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");
     if (blackboxVirtualFile != NULL) {
         largestLogFileNumber++;

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -87,7 +87,7 @@ bool blackboxVirtualBeginLog(void)
     if (blackboxVirtualFile != NULL) {
         return false;
     }
-    const size_t name_buffer_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 2; //file name template: LOG00001.BFL
+    const size_t name_buffer_length = snprintf(NULL, 0, "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
     char filename[name_buffer_length];
     snprintf(filename, sizeof(filename), "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -89,7 +89,7 @@ bool blackboxVirtualBeginLog(void)
     }
     const size_t name_buffer_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 2; //file name template: LOG00001.BFL
     char filename[name_buffer_length];
-    sprintf(filename, "%s%05i.%s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
+    snprintf(filename, sizeof(filename), "%s%05u.%s", LOGFILE_PREFIX, (uint16_t)(largestLogFileNumber + 1), LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");
     if (blackboxVirtualFile != NULL) {
         largestLogFileNumber++;
@@ -111,7 +111,7 @@ void blackboxVirtualClose(void)
     blackboxVirtualEndLog();
 }
 
-uint32_t blackboxVirtualLogFileNumber(void)
+int32_t blackboxVirtualLogFileNumber(void)
 {
     return largestLogFileNumber;
 }

--- a/src/main/blackbox/blackbox_virtual.h
+++ b/src/main/blackbox/blackbox_virtual.h
@@ -32,4 +32,4 @@ bool blackboxVirtualFlush(void);
 bool blackboxVirtualBeginLog(void);
 bool blackboxVirtualEndLog(void);
 void blackboxVirtualClose(void);
-uint32_t blackboxVirtualLogFileNumber(void);
+int32_t blackboxVirtualLogFileNumber(void);


### PR DESCRIPTION
int32 can have more than 5 digits. uint16 maxes out at 5 digits

also add snprintf to prevent writing more than the buffer

I ran `make DEBUG=GDB SITL` and got this error

```bash
Building executable target SITL
EF HASH -> ./obj/main/SITL/.efhash_97f5c813e9701d1c55ed39faf46ea08e
%% (debug) lib/main/dyad/dyad.c 
%% (debug) ./src/platform/SIMULATOR/sitl.c 
%% (debug) ./src/platform/SIMULATOR/udplink.c 
%% (debug) ./src/main/drivers/accgyro/accgyro_virtual.c 
%% (debug) ./src/main/drivers/barometer/barometer_virtual.c 
%% (debug) ./src/main/drivers/compass/compass_virtual.c 
%% (debug) ./src/main/drivers/serial_tcp.c 
%% (debug) ./src/main/io/gps_virtual.c 
%% (debug) ./src/main/blackbox/blackbox_virtual.c 
./src/main/blackbox/blackbox_virtual.c: In function ‘blackboxVirtualBeginLog’:
./src/main/blackbox/blackbox_virtual.c:92:26: error: ‘%05i’ directive writing between 5 and 11 bytes into a region of size 10 [-Werror=format-overflow=]
   92 |     sprintf(filename, "%s%05i.%s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
      |                          ^~~~
./src/main/blackbox/blackbox_virtual.c:92:23: note: directive argument in the range [-2147483647, 2147483647]
   92 |     sprintf(filename, "%s%05i.%s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
      |                       ^~~~~~~~~~~
./src/main/blackbox/blackbox_virtual.c:92:5: note: ‘sprintf’ output between 13 and 19 bytes into a destination of size 13
   92 |     sprintf(filename, "%s%05i.%s", LOGFILE_PREFIX, largestLogFileNumber + 1, LOGFILE_SUFFIX);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:502: obj/main/SITL/blackbox/blackbox_virtual.o] Error 1
```
this error is only caught when using DEBUG=GDB

```bash
$ gcc --version
gcc (GCC) 14.2.1 20250207
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved log file naming to prevent potential errors and ensure consistent handling of log file sequence numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->