### PR TITLE
Fix inevitable timer overflow

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -219,7 +219,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             throttle = 0;
             currentThrottleInputRange = rcCommandThrottleRange3dHigh;
         }
-        if (currentTimeUs - reversalTimeUs < 250000) {
+        if (cmpTimeUs(currentTimeUs, reversalTimeUs) < 250000) {
             // keep iterm zero for 250ms after motor reversal
             pidResetIterm();
         }

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1243,7 +1243,7 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
 
     if (ARMING_FLAG(ARMED)) {
         osdUpdateStats();
-        timeUs_t deltaT = cmpTimeUs(currentTimeUs, lastTimeUs); // overflow-safe
+        int deltaT = cmpTimeUs(currentTimeUs, lastTimeUs);
         osdFlyTime += deltaT;
         stats.armed_time += deltaT;
 #ifdef USE_LAUNCH_CONTROL

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -1243,7 +1243,7 @@ STATIC_UNIT_TESTED bool osdProcessStats1(timeUs_t currentTimeUs)
 
     if (ARMING_FLAG(ARMED)) {
         osdUpdateStats();
-        timeUs_t deltaT = currentTimeUs - lastTimeUs;
+        timeUs_t deltaT = cmpTimeUs(currentTimeUs, lastTimeUs); // overflow-safe
         osdFlyTime += deltaT;
         stats.armed_time += deltaT;
 #ifdef USE_LAUNCH_CONTROL

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -116,7 +116,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 #ifdef USE_DSHOT
     if (isTryingToArm() && !ARMING_FLAG(ARMED)) {
         const int beaconGuard = cmpTimeUs(currentTimeUs, getLastDshotBeaconCommandTimeUs());
-        const int armingDelayTime = MAX(DSHOT_BEACON_GUARD_DELAY_US - beaconGuard, 0) / 100000;  // time remaining until BEACON_GUARD_DELAY, it tenths of second
+        const int armingDelayTime = MAX(DSHOT_BEACON_GUARD_DELAY_US - beaconGuard, 0) / 100000;  // time remaining until BEACON_GUARD_DELAY, in tenths of second
         if (beaconGuard < 500 * 1000) {   // first 0.5s since beacon
             tfp_sprintf(warningText, " BEACON ON");
         } else {

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -115,12 +115,13 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 
 #ifdef USE_DSHOT
     if (isTryingToArm() && !ARMING_FLAG(ARMED)) {
-        int armingDelayTime = (getLastDshotBeaconCommandTimeUs() + DSHOT_BEACON_GUARD_DELAY_US - currentTimeUs) / 1e5;
-        if (armingDelayTime < 0) {
-            armingDelayTime = 0;
+        int armingDelayTime = 0;
+        int beaconGuard = cmpTimeUs(currentTimeUs, getLastDshotBeaconCommandTimeUs());
+        if (beaconGuard < DSHOT_BEACON_GUARD_DELAY_US) {
+            armingDelayTime = (DSHOT_BEACON_GUARD_DELAY_US - beaconGuard) / 1e5;
         }
         if (armingDelayTime >= (DSHOT_BEACON_GUARD_DELAY_US / 1e5 - 5)) {
-            tfp_sprintf(warningText, " BEACON ON"); // Display this message for the first 0.5 seconds
+            tfp_sprintf(warningText, " BEACON ON");
         } else {
             tfp_sprintf(warningText, "ARM IN %d.%d", armingDelayTime / 10, armingDelayTime % 10);
         }

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -115,11 +115,8 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 
 #ifdef USE_DSHOT
     if (isTryingToArm() && !ARMING_FLAG(ARMED)) {
-        int armingDelayTime = 0;
-        int beaconGuard = cmpTimeUs(currentTimeUs, getLastDshotBeaconCommandTimeUs());
-        if (beaconGuard < DSHOT_BEACON_GUARD_DELAY_US) {
-            armingDelayTime = (DSHOT_BEACON_GUARD_DELAY_US - beaconGuard) / 1e5;
-        }
+        const int beaconGuard = cmpTimeUs(currentTimeUs, getLastDshotBeaconCommandTimeUs());
+        const int armingDelayTime = MAX(DSHOT_BEACON_GUARD_DELAY_US - beaconGuard, 0) / 100000;  // time remaining until BEACON_GUARD_DELAY, it tenths of second
         if (armingDelayTime >= (DSHOT_BEACON_GUARD_DELAY_US / 1e5 - 5)) {
             tfp_sprintf(warningText, " BEACON ON");
         } else {

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -117,7 +117,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     if (isTryingToArm() && !ARMING_FLAG(ARMED)) {
         const int beaconGuard = cmpTimeUs(currentTimeUs, getLastDshotBeaconCommandTimeUs());
         const int armingDelayTime = MAX(DSHOT_BEACON_GUARD_DELAY_US - beaconGuard, 0) / 100000;  // time remaining until BEACON_GUARD_DELAY, it tenths of second
-        if (armingDelayTime >= (DSHOT_BEACON_GUARD_DELAY_US / 1e5 - 5)) {
+        if (beaconGuard < 500 * 1000) {   // first 0.5s since beacon
             tfp_sprintf(warningText, " BEACON ON");
         } else {
             tfp_sprintf(warningText, "ARM IN %d.%d", armingDelayTime / 10, armingDelayTime % 10);

--- a/src/main/rx/rc_stats.c
+++ b/src/main/rx/rc_stats.c
@@ -44,7 +44,7 @@ int8_t previousThrottlePercent = 0;
 
 void rcStatsUpdate(timeUs_t currentTimeUs)
 {
-    uint32_t deltaT = currentTimeUs - previousTimeUs;
+    uint32_t deltaT = cmpTimeUs(currentTimeUs, previousTimeUs); // overflow-safe
     previousTimeUs = currentTimeUs;
     const int8_t throttlePercent = calculateThrottlePercent();
 

--- a/src/main/rx/rc_stats.c
+++ b/src/main/rx/rc_stats.c
@@ -44,7 +44,7 @@ int8_t previousThrottlePercent = 0;
 
 void rcStatsUpdate(timeUs_t currentTimeUs)
 {
-    uint32_t deltaT = cmpTimeUs(currentTimeUs, previousTimeUs); // overflow-safe
+    uint32_t deltaT = cmpTimeUs(currentTimeUs, previousTimeUs);
     previousTimeUs = currentTimeUs;
     const int8_t throttlePercent = calculateThrottlePercent();
 


### PR DESCRIPTION
- micros() will overflow after ~71 minutes.
- cmpTimeUse() is designed to handle this overflow safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of the arming delay timer display when DSHOT is enabled, ensuring the delay is calculated and shown more reliably in the on-screen display (OSD) warnings.
  - Enhanced timing calculations to handle timer overflow correctly, improving reliability of RC statistics updates.
  - Fixed timing calculations related to motor reversal and flight time tracking to prevent errors caused by timer wrap-around.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->