### PR TITLE
Use opaque struct to define linker symbols for eeprom

### DIFF
--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -319,7 +319,7 @@ void initEEPROM(void)
 
 bool isEEPROMVersionValid(void)
 {
-    const uint8_t *p = &__config_start;
+    const uint8_t *p = (const uint8_t*)&__config_start;
     const configHeader_t *header = (const configHeader_t *)p;
 
     if (header->eepromConfigVersion != EEPROM_CONF_VERSION) {
@@ -332,7 +332,7 @@ bool isEEPROMVersionValid(void)
 // Scan the EEPROM config. Returns true if the config is valid.
 bool isEEPROMStructureValid(void)
 {
-    const uint8_t *p = &__config_start;
+    const uint8_t *p = (const uint8_t*)&__config_start;
     const configHeader_t *header = (const configHeader_t *)p;
 
     if (header->magic_be != 0xBE) {
@@ -350,7 +350,7 @@ bool isEEPROMStructureValid(void)
             // Found the end.  Stop scanning.
             break;
         }
-        if (p + record->size >= &__config_end
+        if (p + record->size >= (const uint8_t*)&__config_end
             || record->size < sizeof(*record)) {
             // Too big or too small.
             return false;
@@ -370,7 +370,7 @@ bool isEEPROMStructureValid(void)
     crc = crc16_ccitt_update(crc, storedCrc, sizeof(*storedCrc));
     p += sizeof(storedCrc);
 
-    eepromConfigSize = p - &__config_start;
+    eepromConfigSize = p - (const uint8_t*)&__config_start;
 
     // CRC has the property that if the CRC itself is included in the calculation the resulting CRC will have constant value
     return crc == CRC_CHECK_VALUE;
@@ -391,7 +391,7 @@ size_t getEEPROMStorageSize(void)
 #ifdef CONFIG_IN_RAM
     return EEPROM_SIZE;
 #else
-    return &__config_end - &__config_start;
+    return (const uint8_t*)&__config_end - (const uint8_t*)&__config_start;
 #endif
 }
 
@@ -400,12 +400,12 @@ size_t getEEPROMStorageSize(void)
 // this function assumes that EEPROM content is valid
 static const configRecord_t *findEEPROM(const pgRegistry_t *reg, configRecordFlags_e classification)
 {
-    const uint8_t *p = &__config_start;
+    const uint8_t *p = (const uint8_t*)&__config_start;
     p += sizeof(configHeader_t);             // skip header
     while (true) {
         const configRecord_t *record = (const configRecord_t *)p;
         if (record->size == 0
-            || p + record->size >= &__config_end
+            || p + record->size >= (const uint8_t*)&__config_end
             || record->size < sizeof(*record))
             break;
         if (pgN(reg) == record->pgn
@@ -462,7 +462,7 @@ static bool writeSettingsToEEPROM(void)
         config_streamer_t streamer;
         config_streamer_init(&streamer);
 
-        config_streamer_start(&streamer, (uintptr_t)&__config_start, &__config_end - &__config_start);
+        config_streamer_start(&streamer, (uintptr_t)&__config_start, (const uint8_t*)&__config_end - (const uint8_t*)&__config_start);
 
         config_streamer_write(&streamer, (uint8_t *)&header, sizeof(header));
         uint16_t crc = CRC_START_VALUE;

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -612,8 +612,9 @@ extern uint8_t eepromData[EEPROM_SIZE];
 #ifndef CONFIG_IN_FLASH
 #define CONFIG_IN_FLASH
 #endif
-extern uint8_t __config_start;   // configured via linker script when building binaries.
-extern uint8_t __config_end;
+struct linker_symbol;
+extern struct linker_symbol __config_start;   // configured via linker script when building binaries.
+extern struct linker_symbol __config_end;
 #endif
 
 #if defined(USE_EXST) && !defined(RAMBASED)


### PR DESCRIPTION
This way code must be explicit when using linker-defined memory.

This is fixing part of #14381. 
For discussion, there are other ways to do it, possibly better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of configuration storage for enhanced type safety and consistency. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->