### PR TITLE
Add support for SPI_DEVICE_0

### DIFF
--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -51,7 +51,6 @@ typedef enum SPIDevice {
     SPIDEV_0   = SPIDEV_FIRST,
     SPIDEV_1,
 #else
-    SPIDEV_0   = SPIINVALID,
     SPIDEV_1   = SPIDEV_FIRST,
 #endif
     SPIDEV_2,

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -51,6 +51,7 @@ typedef enum SPIDevice {
     SPIDEV_0   = SPIDEV_FIRST,
     SPIDEV_1,
 #else
+    SPIDEV_0   = SPIINVALID,
     SPIDEV_1   = SPIDEV_FIRST,
 #endif
     SPIDEV_2,

--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -31,10 +31,12 @@
 
 #include "bus_spi.h"
 
+#ifdef USE_SPI_DEVICE_0
 #ifndef SPI0_SCK_PIN
 #define SPI0_SCK_PIN    NONE
 #define SPI0_SDI_PIN    NONE
 #define SPI0_SDO_PIN    NONE
+#endif
 #endif
 
 #ifndef SPI1_SCK_PIN

--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -31,6 +31,12 @@
 
 #include "bus_spi.h"
 
+#ifndef SPI0_SCK_PIN
+#define SPI0_SCK_PIN    NONE
+#define SPI0_SDI_PIN    NONE
+#define SPI0_SDO_PIN    NONE
+#endif
+
 #ifndef SPI1_SCK_PIN
 #define SPI1_SCK_PIN    NONE
 #define SPI1_SDI_PIN    NONE
@@ -77,6 +83,9 @@ typedef struct spiDefaultConfig_s {
 } spiDefaultConfig_t;
 
 const spiDefaultConfig_t spiDefaultConfig[] = {
+#ifdef USE_SPI_DEVICE_0
+    { SPIDEV_0, IO_TAG(SPI0_SCK_PIN), IO_TAG(SPI0_SDI_PIN ), IO_TAG(SPI0_SDO_PIN ), SPI0_TX_DMA_OPT, SPI0_RX_DMA_OPT },
+#endif
 #ifdef USE_SPI_DEVICE_1
     { SPIDEV_1, IO_TAG(SPI1_SCK_PIN), IO_TAG(SPI1_SDI_PIN ), IO_TAG(SPI1_SDO_PIN ), SPI1_TX_DMA_OPT, SPI1_RX_DMA_OPT },
 #endif

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -161,6 +161,14 @@
 #endif // USE_ADC
 
 #ifdef USE_SPI
+#ifdef USE_SPI_DEVICE_0
+#ifndef SPI0_TX_DMA_OPT
+#define SPI0_TX_DMA_OPT (DMA_OPT_UNUSED)
+#endif
+#ifndef SPI0_RX_DMA_OPT
+#define SPI0_RX_DMA_OPT (DMA_OPT_UNUSED)
+#endif
+#endif
 #ifdef USE_SPI_DEVICE_1
 #ifndef SPI1_TX_DMA_OPT
 #define SPI1_TX_DMA_OPT (DMA_OPT_UNUSED)


### PR DESCRIPTION
Add support for SPI device 0, required for PICO platform.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration support for SPI device 0, including default pin and DMA settings, when enabled.

- **Chores**
  - Improved consistency in SPI device configuration by aligning SPI0 handling with other SPI devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->