### PR TITLE
Update pwm_output_hw.c

### DIFF
--- a/src/platform/STM32/pwm_output_hw.c
+++ b/src/platform/STM32/pwm_output_hw.c
@@ -116,7 +116,7 @@ static void pwmWriteStandard(uint8_t index, float value)
 
 static void pwmShutdownPulsesForAllMotors(void)
 {
-    for (int index = 0; pwmMotorCount; index++) {
+    for (int index = 0; index < pwmMotorCount; index++) {
         // Set the compare register to 0, which stops the output pulsing if the timer overflows
         if (pwmMotors[index].channel.ccr) {
             *pwmMotors[index].channel.ccr = 0;
@@ -135,7 +135,7 @@ static void pwmCompleteMotorUpdate(void)
         return;
     }
 
-    for (int index = 0; pwmMotorCount; index++) {
+    for (int index = 0; index < pwmMotorCount; index++) {
         if (pwmMotors[index].forceOverflow) {
             timerForceOverflow(pwmMotors[index].channel.tim);
         }


### PR DESCRIPTION
During the pwm_output engine test on my own hardware, the system froze. When I checked with debug, there was an infinite loop and a hardware error for the engine driver that was not in the (vtable) table. I solved it this way. This is a very critical level. Please take it into consideration. Please comment if there is a problem that I do not understand or that is caused by my compiler. Good luck!! Enjoy your flights.