### PR TITLE
Remove #ifdef USE_TIMER from motorConfig reset function.

### DIFF
--- a/src/main/pg/motor.c
+++ b/src/main/pg/motor.c
@@ -75,7 +75,6 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
     motorConfig->mincommand = 1000;
     motorConfig->kv = 1960;
 
-#ifdef USE_TIMER
 #ifdef MOTOR1_PIN
     motorConfig->dev.ioTags[0] = IO_TAG(MOTOR1_PIN);
 #endif
@@ -99,7 +98,6 @@ void pgResetFn_motorConfig(motorConfig_t *motorConfig)
 #endif
 #ifdef MOTOR8_PIN
     motorConfig->dev.ioTags[7] = IO_TAG(MOTOR8_PIN);
-#endif
 #endif
 
     motorConfig->motorPoleCount = 14;   // Most brushless motors that we use are 14 poles


### PR DESCRIPTION
The #ifdef is not required now we are using MOTORn_PIN macros to set the pins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal logic for motor pin assignments, ensuring consistent behavior regardless of timer configuration. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->