### PR TITLE
Added float specifier to literal to prevent compile error

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -625,7 +625,7 @@ static void updateGpsHeadingUsable(float groundspeedGain, float imuCourseError, 
         gpsHeadingConfidence += fmaxf(groundspeedGain - fabsf(imuCourseError), 0.0f) * dt;
         // recenter at 2.5s time constant
         // TODO: intent is to match IMU time constant, approximately, but I don't exactly know how to do that
-        gpsHeadingConfidence -= 0.4 * dt * gpsHeadingConfidence; 
+        gpsHeadingConfidence -= 0.4f * dt * gpsHeadingConfidence;
         // if we accumulate enough 'points' over time, the IMU probably is OK
         // will need to reaccumulate after a disarm (will be retained partly for very brief disarms)
         canUseGPSHeading = gpsHeadingConfidence > 2.0f;


### PR DESCRIPTION

Added the float specifier to a literal value to prevent the compiler error:

./src/main/flight/imu.c:628:39: error: implicit conversion increases floating-point precision: 'float' to 'double' [-Werror,-Wdouble-promotion]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in floating-point calculations for GPS heading confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->