### PR TITLE
Added missing GCC diagnostic push pragma

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -343,16 +343,13 @@ static void mspFcSetPassthroughCommand(sbuf_t *dst, sbuf_t *src, mspPostProcessF
     }
 }
 
-// TODO: Remove the pragma once this is called from unconditional code
-#pragma GCC diagnostic ignored "-Wunused-function"
-static void configRebootUpdateCheckU8(uint8_t *parm, uint8_t value)
+MAYBE_UNUSED static void configRebootUpdateCheckU8(uint8_t *parm, uint8_t value)
 {
     if (*parm != value) {
         setRebootRequired();
     }
     *parm = value;
 }
-#pragma GCC diagnostic pop
 
 static void mspRebootFn(serialPort_t *serialPort)
 {


### PR DESCRIPTION
Added missing GCC diagnostic push pragma for matching GCC diagnostic pop pragma.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved handling of compiler warnings to ensure more consistent diagnostic behavior. No impact on user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->