### PR TITLE
EXTI priority

### DIFF
--- a/src/main/drivers/nvic.h
+++ b/src/main/drivers/nvic.h
@@ -32,7 +32,7 @@
 #define NVIC_PRIO_RX_INT_EXTI              NVIC_BUILD_PRIORITY(3, 0x0f)
 #define NVIC_PRIO_RX_BUSY_EXTI             NVIC_BUILD_PRIORITY(3, 0x0f)
 
-#define NVIC_PRIO_MPU_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
+#define NVIC_PRIO_MPU_INT_EXTI             NVIC_BUILD_PRIORITY(0, 0)  // This must be high priority as it drives the scheduler timing
 #define NVIC_PRIO_MAG_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
 #define NVIC_PRIO_WS2811_DMA               NVIC_BUILD_PRIORITY(1, 2)  // TODO - is there some reason to use high priority?
 #define NVIC_PRIO_SERIALUART_TXDMA         NVIC_BUILD_PRIORITY(1, 1)  // Highest of all SERIALUARTx_TXDMA


### PR DESCRIPTION
I noticed with and STM32H725 processor that I was seeing a lot of variation in cycle time:

![image](https://github.com/user-attachments/assets/3b25d227-ed09-4768-9117-808fa5b467fc)

And looking at the `EXTI_IRQHandler()` timing I was getting:

```
fmin    7800.555399620383    Hz
fmax    8257.638315421542    Hz
fmean    8021.502803748325    Hz
Tstd    8.394218781720484e-8    s
```

Having applied this change to make the MPU EXTI interrupt top priority I see:

![image](https://github.com/user-attachments/assets/1a695eec-1966-4436-8d69-91c58b813839)

And `EXTI_IRQHandler()` timing of:

```
fmin    8013.591050430948    Hz
fmax    8028.259473333197    Hz
fmean    8021.505130282706    Hz
Tstd    2.6134359731960335e-8    s
```

This is a significant improvement.

I then checked the same change on a F405. With `master`:

![image](https://github.com/user-attachments/assets/8bbe86a0-0c10-401a-87aa-ed9426dc9aa3)

With this PR:

![image](https://github.com/user-attachments/assets/f6cbc8ff-ad46-448d-8b20-d26e40f01481)

Again, a very significant improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the priority level for a key system interrupt to ensure more responsive scheduler timing.
- **Documentation**
	- Added a comment clarifying the importance of this interrupt's priority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->