### PR TITLE
PICO: Makefile uf2 support using picotool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,11 @@ CFLAGS_DISABLED         :=
 FORKNAME      = betaflight
 
 # Working directories
+# ROOT_DIR is the full path to the directory containing this Makefile
 ROOT_DIR        := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# ROOT is the relative path to the directory containing this Makefile
 ROOT            := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+
 PLATFORM_DIR	:= $(ROOT)/src/platform
 SRC_DIR         := $(ROOT)/src/main
 LIB_MAIN_DIR    := $(ROOT)/lib/main
@@ -432,7 +435,7 @@ $(TARGET_HEX): $(TARGET_ELF)
 
 $(TARGET_UF2): $(TARGET_ELF)
 	@echo "Creating UF2 $(TARGET_UF2)" "$(STDOUT)"
-	$(V1) $(PICOTOOL) uf2 convert $< $@
+	$(V1) $(PICOTOOL) uf2 convert $< $@ || { echo "Failed to convert ELF to UF2 format"; exit 1; }
 
 $(TARGET_DFU): $(TARGET_HEX)
 	@echo "Creating DFU $(TARGET_DFU)" "$(STDOUT)"
@@ -693,7 +696,7 @@ version:
 
 submodules:
 	@echo "Updating submodules"
-	$(V1) git submodule update --init --recursive
+	$(V1) git submodule update --init --recursive || { echo "Failed to update submodules"; exit 1; }
 	@echo "Submodules updated"
 
 ## help              : print this help message and exit

--- a/Makefile
+++ b/Makefile
@@ -579,7 +579,7 @@ preview: $(PREVIEW_TARGETS) test
 ## all_configs       : Build all configs
 all_configs: $(BASE_CONFIGS)
 
-TARGETS_FLASH = $(addsuffix _flash,$(HEX_TARGETS))
+TARGETS_FLASH = $(addsuffix _flash,$(BASE_TARGETS))
 
 ## <TARGET>_flash    : build and flash a target
 $(TARGETS_FLASH):
@@ -617,7 +617,7 @@ openocd-gdb: $(TARGET_ELF)
 	$(V0) $(OPENOCD_COMMAND) & $(CROSS_GDB) $(TARGET_ELF) -ex "target remote localhost:3333" -ex "load"
 endif
 
-TARGETS_ZIP = $(addsuffix _zip,$(HEX_TARGETS))
+TARGETS_ZIP = $(addsuffix _zip,$(BASE_TARGETS))
 
 ## <TARGET>_zip    : build target and zip it (useful for posting to GitHub)
 .PHONY: $(TARGETS_ZIP)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Things that the user might override on the commandline
 #
 
-# The target to build
+# The target or config to build
 TARGET    ?=
 CONFIG    ?=
 
@@ -423,10 +423,6 @@ $(TARGET_HEX): $(TARGET_ELF)
 	@echo "Creating HEX $(TARGET_HEX)" "$(STDOUT)"
 	$(V1) $(OBJCOPY) -O ihex --set-start 0x8000000 $< $@
 
-$(TARGET_UF2): $(TARGET_ELF)
-	@echo "Creating UF2 $(TARGET_UF2)" "$(STDOUT)"
-	$(V1) $(PICOTOOL) uf2 convert $< $@ || { echo "Failed to convert ELF to UF2 format"; exit 1; }
-
 $(TARGET_DFU): $(TARGET_HEX)
 	@echo "Creating DFU $(TARGET_DFU)" "$(STDOUT)"
 	$(V1) $(PYTHON) $(DFUSE-PACK) -i $< $@
@@ -483,8 +479,12 @@ $(TARGET_ELF): $(TARGET_OBJS) $(LD_SCRIPT) $(LD_SCRIPTS)
 	$(V1) $(CROSS_CC) -o $@ $(filter-out %.ld,$^) $(LD_FLAGS)
 	$(V1) $(SIZE) $(TARGET_ELF)
 
+$(TARGET_UF2): $(TARGET_ELF)
+	@echo "Creating UF2 $(TARGET_UF2)" "$(STDOUT)"
+	$(V1) $(PICOTOOL) uf2 convert $< $@ || { echo "Failed to convert ELF to UF2 format"; exit 1; }
+
 $(TARGET_EXE): $(TARGET_ELF)
-	@echo Copy $< to $@ "$(STDOUT)"
+	@echo "Creating exe - Copy $< to $@" "$(STDOUT)"
 	$(V1) cp $< $@
 
 # Compile

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ FC_VER_PATCH := $(shell grep " FC_VERSION_PATCH" src/main/build/version.h | awk 
 
 FC_VER       := $(FC_VER_MAJOR).$(FC_VER_MINOR).$(FC_VER_PATCH)
 
-# import config handling
+# import config handling (must occur after the hydration of hex, exe and uf2 targets)
 include $(MAKE_SCRIPT_DIR)/config.mk
 
 # default xtal value

--- a/Makefile
+++ b/Makefile
@@ -384,22 +384,22 @@ TARGET_FULLNAME = $(FORKNAME)_$(FC_VER)_$(TARGET_NAME)
 #
 # Things we will build
 #
-TARGET_BIN      = $(BIN_DIR)/$(TARGET_FULLNAME).bin
-TARGET_HEX      = $(BIN_DIR)/$(TARGET_FULLNAME).hex
-TARGET_UF2      = $(BIN_DIR)/$(TARGET_FULLNAME).uf2
-TARGET_EXE      = $(BIN_DIR)/$(TARGET_FULLNAME)
-TARGET_DFU      = $(BIN_DIR)/$(TARGET_FULLNAME).dfu
-TARGET_ZIP      = $(BIN_DIR)/$(TARGET_FULLNAME).zip
-TARGET_OBJ_DIR  = $(OBJECT_DIR)/$(TARGET_NAME)
-TARGET_ELF      = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).elf
-TARGET_EXST_ELF = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME)_EXST.elf
-TARGET_UNPATCHED_BIN = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME)_UNPATCHED.bin
-TARGET_LST      = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).lst
-TARGET_OBJS     = $(addsuffix .o,$(addprefix $(TARGET_OBJ_DIR)/,$(basename $(SRC))))
-TARGET_DEPS     = $(addsuffix .d,$(addprefix $(TARGET_OBJ_DIR)/,$(basename $(SRC))))
-TARGET_MAP      = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).map
+TARGET_BIN      := $(BIN_DIR)/$(TARGET_FULLNAME).bin
+TARGET_HEX      := $(BIN_DIR)/$(TARGET_FULLNAME).hex
+TARGET_UF2      := $(BIN_DIR)/$(TARGET_FULLNAME).uf2
+TARGET_EXE      := $(BIN_DIR)/$(TARGET_FULLNAME)
+TARGET_DFU      := $(BIN_DIR)/$(TARGET_FULLNAME).dfu
+TARGET_ZIP      := $(BIN_DIR)/$(TARGET_FULLNAME).zip
+TARGET_OBJ_DIR  := $(OBJECT_DIR)/$(TARGET_NAME)
+TARGET_ELF      := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).elf
+TARGET_EXST_ELF := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME)_EXST.elf
+TARGET_UNPATCHED_BIN := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME)_UNPATCHED.bin
+TARGET_LST      := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).lst
+TARGET_OBJS     := $(addsuffix .o,$(addprefix $(TARGET_OBJ_DIR)/,$(basename $(SRC))))
+TARGET_DEPS     := $(addsuffix .d,$(addprefix $(TARGET_OBJ_DIR)/,$(basename $(SRC))))
+TARGET_MAP      := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).map
 
-TARGET_EXST_HASH_SECTION_FILE = $(TARGET_OBJ_DIR)/exst_hash_section.bin
+TARGET_EXST_HASH_SECTION_FILE := $(TARGET_OBJ_DIR)/exst_hash_section.bin
 
 ifeq ($(DEBUG_MIXED),yes)
 TARGET_EF_HASH      := $(shell echo -n -- "$(EXTRA_FLAGS)" "$(OPTIONS)" "$(DEVICE_FLAGS)" "$(TARGET_FLAGS)"  | openssl dgst -md5 -r | awk '{print $$1;}')
@@ -645,15 +645,19 @@ $(TARGETS_ZIP):
 	$(V0) $(MAKE) hex TARGET=$(subst _zip,,$@)
 	$(V0) $(MAKE) zip TARGET=$(subst _zip,,$@)
 
+.phony: zip
 zip:
 	$(V0) zip $(TARGET_ZIP) $(TARGET_HEX)
 
+.phony: binary
 binary:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
 
+.phony: hex
 hex:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
+.phony: uf2
 uf2:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
 
@@ -694,6 +698,7 @@ $(DIRECTORIES):
 version:
 	@echo $(FC_VER)
 
+.phony: submodules
 submodules:
 	@echo "Updating submodules"
 	$(V1) git submodule update --init --recursive || { echo "Failed to update submodules"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,12 @@ CPPCHECK        = cppcheck $(CSOURCES) --enable=all --platform=unix64 \
                   $(addprefix -isystem,$(SYS_INCLUDE_DIRS)) \
                   -I/usr/include -I/usr/include/linux
 
+ifneq ($(filter fwo hex uf2 bin elf zip, $(MAKECMDGOALS)),)
+    ifeq ($(TARGET),)
+        $(error "You must specify a target to build.")
+    endif
+endif
+
 TARGET_NAME := $(TARGET)
 
 ifneq ($(CONFIG),)
@@ -622,11 +628,10 @@ TARGETS_ZIP = $(addsuffix _zip,$(BASE_TARGETS))
 ## <TARGET>_zip    : build target and zip it (useful for posting to GitHub)
 .PHONY: $(TARGETS_ZIP)
 $(TARGETS_ZIP):
-	$(V0) $(MAKE) hex TARGET=$(subst _zip,,$@)
-	$(V0) $(MAKE) zip TARGET=$(subst _zip,,$@)
+	$(V0) $(MAKE) $(MAKE_PARALLEL) zip TARGET=$(subst _zip,,$@)
 
 .PHONY: zip
-zip:
+zip: $(TARGET_HEX)
 	$(V0) zip $(TARGET_ZIP) $(TARGET_HEX)
 
 .PHONY: binary

--- a/Makefile
+++ b/Makefile
@@ -645,23 +645,23 @@ $(TARGETS_ZIP):
 	$(V0) $(MAKE) hex TARGET=$(subst _zip,,$@)
 	$(V0) $(MAKE) zip TARGET=$(subst _zip,,$@)
 
-.phony: zip
+.PHONY: zip
 zip:
 	$(V0) zip $(TARGET_ZIP) $(TARGET_HEX)
 
-.phony: binary
+.PHONY: binary
 binary:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
 
-.phony: hex
+.PHONY: hex
 hex:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
-.phony: uf2
+.PHONY: uf2
 uf2:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
 
-.phony: exe
+.PHONY: exe
 exe: $(TARGET_EXE)
 
 TARGETS_REVISION = $(addsuffix _rev,$(HEX_TARGETS))
@@ -698,7 +698,7 @@ $(DIRECTORIES):
 version:
 	@echo $(FC_VER)
 
-.phony: submodules
+.PHONY: submodules
 submodules:
 	@echo "Updating submodules"
 	$(V1) git submodule update --init --recursive || { echo "Failed to update submodules"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -490,7 +490,7 @@ $(TARGET_UF2): $(TARGET_ELF)
 	$(V1) $(PICOTOOL) uf2 convert $< $@ || { echo "Failed to convert ELF to UF2 format"; exit 1; }
 
 $(TARGET_EXE): $(TARGET_ELF)
-	@echo "Creating exe - Copy $< to $@" "$(STDOUT)"
+	@echo "Creating exe - copying $< to $@" "$(STDOUT)"
 	$(V1) cp $< $@
 
 # Compile
@@ -628,42 +628,43 @@ TARGETS_ZIP = $(addsuffix _zip,$(BASE_TARGETS))
 ## <TARGET>_zip    : build target and zip it (useful for posting to GitHub)
 .PHONY: $(TARGETS_ZIP)
 $(TARGETS_ZIP):
-	$(V0) $(MAKE) $(MAKE_PARALLEL) zip TARGET=$(subst _zip,,$@)
+	$(V1) $(MAKE) $(MAKE_PARALLEL) zip TARGET=$(subst _zip,,$@)
 
 .PHONY: zip
 zip: $(TARGET_HEX)
-	$(V0) zip $(TARGET_ZIP) $(TARGET_HEX)
+	$(V1) zip $(TARGET_ZIP) $(TARGET_HEX)
 
 .PHONY: binary
 binary:
-	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
+	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
 
 .PHONY: hex
 hex:
-	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
+	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
 .PHONY: uf2
 uf2:
-	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
+	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
 
 .PHONY: exe
 exe: $(TARGET_EXE)
 
+# FWO (Firmware Output) is the default output for building the firmware
 .PHONY: fwo
 fwo:
-ifneq ($(wildcard $(TARGET_DIR)/.exe),)
-	$(V0) $(MAKE) exe
-else ifneq ($(wildcard $(TARGET_DIR)/.uf2),)
-	$(V0) $(MAKE) uf2
+ifeq ($(DEFAULT_OUTPUT),exe)
+	$(V1) $(MAKE) exe
+else ifeq ($(DEFAULT_OUTPUT),uf2)
+	$(V1) $(MAKE) uf2
 else
-	$(V0) $(MAKE) hex
+	$(V1) $(MAKE) hex
 endif
 
 TARGETS_REVISION = $(addsuffix _rev, $(BASE_TARGETS))
 ## <TARGET>_rev    : build target and add revision to filename
 .PHONY: $(TARGETS_REVISION)
 $(TARGETS_REVISION):
-	$(V0) $(MAKE) fwo REV=yes TARGET=$(subst _rev,,$@)
+	$(V1) $(MAKE) fwo REV=yes TARGET=$(subst _rev,,$@)
 
 .PHONY: all_rev
 all_rev: $(addsuffix _rev, $(CI_TARGETS))

--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,15 @@ MAKE_PARALLEL 		     = $(if $(filter -j%, $(MAKEFLAGS)),$(EMPTY),-j$(DEFAULT_PAR
 # pre-build sanity checks
 include $(MAKE_SCRIPT_DIR)/checks.mk
 
-# list of targets that  are executed on host (using exe as goal)
-EXE_TARGETS      := SITL
-UF2_TARGETS      := RP2350
-
 # basic target list
 PLATFORMS        := $(sort $(notdir $(patsubst /%,%, $(wildcard $(PLATFORM_DIR)/*))))
 BASE_TARGETS     := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(PLATFORM_DIR)/*/target/*/target.mk)))))
 
+# list of targets that are executed on host - using exe as goal recipe
+EXE_TARGETS      := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(PLATFORM_DIR)/*/target/*/.exe)))))
+# list of targets using uf2 as goal recipe
+UF2_TARGETS      := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(PLATFORM_DIR)/*/target/*/.uf2)))))
+# list of targets using hex as goal recipe (default)
 HEX_TARGETS      := $(filter-out $(EXE_TARGETS) $(UF2_TARGETS),$(BASE_TARGETS))
 
 # configure some directories that are relative to wherever ROOT_DIR is located

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ FORKNAME      = betaflight
 
 # Working directories
 # ROOT_DIR is the full path to the directory containing this Makefile
-ROOT_DIR        := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR        := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 # ROOT is the relative path to the directory containing this Makefile
 ROOT            := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
@@ -235,7 +235,7 @@ endif # TARGET specified
 # openocd specific includes
 include $(MAKE_SCRIPT_DIR)/openocd.mk
 
-ifeq ($(CONFIG)$(TARGET),)
+ifeq ($(and $(CONFIG),$(TARGET)),)
 .DEFAULT_GOAL := all
 else ifneq ($(filter $(TARGET),$(EXE_TARGETS)),)
 .DEFAULT_GOAL := exe

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ CFLAGS_DISABLED         :=
 FORKNAME      = betaflight
 
 # Working directories
+ROOT_DIR        := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ROOT            := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 PLATFORM_DIR	:= $(ROOT)/src/platform
 SRC_DIR         := $(ROOT)/src/main
@@ -92,10 +93,13 @@ include $(MAKE_SCRIPT_DIR)/checks.mk
 
 # list of targets that  are executed on host (using exe as goal)
 EXE_TARGETS      := SITL
+UF2_TARGETS      := RP2350
 
 # basic target list
 PLATFORMS        := $(sort $(notdir $(patsubst /%,%, $(wildcard $(PLATFORM_DIR)/*))))
-BASE_TARGETS     := $(filter-out $(EXE_TARGETS),$(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(PLATFORM_DIR)/*/target/*/target.mk))))))
+BASE_TARGETS     := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(PLATFORM_DIR)/*/target/*/target.mk)))))
+
+HEX_TARGETS      := $(filter-out $(EXE_TARGETS) $(UF2_TARGETS),$(BASE_TARGETS))
 
 # configure some directories that are relative to wherever ROOT_DIR is located
 TOOLS_DIR  ?= $(ROOT)/tools
@@ -134,7 +138,7 @@ HSE_VALUE       ?= 8000000
 
 CI_EXCLUDED_TARGETS := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(PLATFORM_DIR)/*/target/*/.exclude)))))
 CI_COMMON_TARGETS   := STM32F4DISCOVERY CRAZYBEEF4SX1280 CRAZYBEEF4FR MATEKF405TE AIRBOTG4AIO TBS_LUCID_FC IFLIGHT_BLITZ_F722 NUCLEOF446 SPRACINGH7EXTREME SPRACINGH7RF
-CI_TARGETS          := $(filter-out $(CI_EXCLUDED_TARGETS), $(BASE_TARGETS) $(EXE_TARGETS)) $(filter $(CI_COMMON_TARGETS), $(BASE_CONFIGS))
+CI_TARGETS          := $(filter-out $(CI_EXCLUDED_TARGETS), $(BASE_TARGETS) $(filter $(CI_COMMON_TARGETS), $(BASE_CONFIGS)))
 PREVIEW_TARGETS     := MATEKF411 AIKONF4V2 AIRBOTG4AIO ZEEZF7V3 FOXEERF745V4_AIO KAKUTEH7 TBS_LUCID_FC SITL SPRACINGH7EXTREME SPRACINGH7RF
 
 TARGET_PLATFORM     := $(notdir $(patsubst %/,%,$(subst target/$(TARGET)/,, $(dir $(wildcard $(PLATFORM_DIR)/*/target/$(TARGET)/target.mk)))))
@@ -227,15 +231,13 @@ endif # TARGET specified
 # openocd specific includes
 include $(MAKE_SCRIPT_DIR)/openocd.mk
 
-ifeq ($(CONFIG),)
-ifeq ($(TARGET),)
+ifeq ($(CONFIG)$(TARGET),)
 .DEFAULT_GOAL := all
 else ifneq ($(filter $(TARGET),$(EXE_TARGETS)),)
 .DEFAULT_GOAL := exe
+else ifneq ($(filter $(TARGET),$(UF2_TARGETS)),)
+.DEFAULT_GOAL := uf2
 else
-.DEFAULT_GOAL := hex
-endif
-else  # ifeq ($(CONFIG),)
 .DEFAULT_GOAL := hex
 endif
 
@@ -380,6 +382,7 @@ TARGET_FULLNAME = $(FORKNAME)_$(FC_VER)_$(TARGET_NAME)
 #
 TARGET_BIN      = $(BIN_DIR)/$(TARGET_FULLNAME).bin
 TARGET_HEX      = $(BIN_DIR)/$(TARGET_FULLNAME).hex
+TARGET_UF2      = $(BIN_DIR)/$(TARGET_FULLNAME).uf2
 TARGET_EXE      = $(BIN_DIR)/$(TARGET_FULLNAME)
 TARGET_DFU      = $(BIN_DIR)/$(TARGET_FULLNAME).dfu
 TARGET_ZIP      = $(BIN_DIR)/$(TARGET_FULLNAME).zip
@@ -425,6 +428,10 @@ $(TARGET_BIN): $(TARGET_ELF)
 $(TARGET_HEX): $(TARGET_ELF)
 	@echo "Creating HEX $(TARGET_HEX)" "$(STDOUT)"
 	$(V1) $(OBJCOPY) -O ihex --set-start 0x8000000 $< $@
+
+$(TARGET_UF2): $(TARGET_ELF)
+	@echo "Creating UF2 $(TARGET_UF2)" "$(STDOUT)"
+	$(V1) $(PICOTOOL) uf2 convert $< $@
 
 $(TARGET_DFU): $(TARGET_HEX)
 	@echo "Creating DFU $(TARGET_DFU)" "$(STDOUT)"
@@ -539,9 +546,14 @@ $(TARGET_OBJ_DIR)/%.o: %.S
 ## all               : Build all currently built targets
 all: $(CI_TARGETS)
 
-$(BASE_TARGETS):
-	$(V0) @echo "Building target $@" && \
+$(HEX_TARGETS):
+	$(V0) @echo "Building hex target $@" && \
 	$(MAKE) hex TARGET=$@ && \
+	echo "Building $@ succeeded."
+
+$(UF2_TARGETS):
+	$(V0) @echo "Building uf2 target $@" && \
+	$(MAKE) uf2 TARGET=$@ && \
 	echo "Building $@ succeeded."
 
 $(EXE_TARGETS):
@@ -549,7 +561,7 @@ $(EXE_TARGETS):
 	$(MAKE) exe TARGET=$@ && \
 	echo "Building $@ succeeded."
 
-TARGETS_CLEAN = $(addsuffix _clean,$(BASE_TARGETS) $(EXE_TARGETS))
+TARGETS_CLEAN = $(addsuffix _clean,$(HEX_TARGETS) $(UF2_TARGETS) $(EXE_TARGETS))
 
 CONFIGS_CLEAN = $(addsuffix _clean,$(BASE_CONFIGS))
 
@@ -584,7 +596,7 @@ preview: $(PREVIEW_TARGETS) test
 ## all_configs       : Build all configs
 all_configs: $(BASE_CONFIGS)
 
-TARGETS_FLASH = $(addsuffix _flash,$(BASE_TARGETS))
+TARGETS_FLASH = $(addsuffix _flash,$(HEX_TARGETS))
 
 ## <TARGET>_flash    : build and flash a target
 $(TARGETS_FLASH):
@@ -622,7 +634,7 @@ openocd-gdb: $(TARGET_ELF)
 	$(V0) $(OPENOCD_COMMAND) & $(CROSS_GDB) $(TARGET_ELF) -ex "target remote localhost:3333" -ex "load"
 endif
 
-TARGETS_ZIP = $(addsuffix _zip,$(BASE_TARGETS))
+TARGETS_ZIP = $(addsuffix _zip,$(HEX_TARGETS))
 
 ## <TARGET>_zip    : build target and zip it (useful for posting to GitHub)
 $(TARGETS_ZIP):
@@ -638,10 +650,13 @@ binary:
 hex:
 	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
+uf2:
+	$(V0) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
+
 .phony: exe
 exe: $(TARGET_EXE)
 
-TARGETS_REVISION = $(addsuffix _rev,$(BASE_TARGETS))
+TARGETS_REVISION = $(addsuffix _rev,$(HEX_TARGETS))
 ## <TARGET>_rev    : build target and add revision to filename
 $(TARGETS_REVISION):
 	$(V0) $(MAKE) hex REV=yes TARGET=$(subst _rev,,$@)
@@ -675,6 +690,11 @@ $(DIRECTORIES):
 version:
 	@echo $(FC_VER)
 
+submodules:
+	@echo "Updating submodules"
+	$(V1) git submodule update --init --recursive
+	@echo "Submodules updated"
+
 ## help              : print this help message and exit
 help: Makefile mk/tools.mk
 	@echo ""
@@ -690,7 +710,7 @@ help: Makefile mk/tools.mk
 	@echo "To populate configuration targets:"
 	@echo "        make configs"
 	@echo ""
-	@echo "Valid TARGET values are: $(EXE_TARGETS) $(BASE_TARGETS)"
+	@echo "Valid TARGET values are: $(BASE_TARGETS)"
 	@echo ""
 	@sed -n 's/^## //p' $?
 
@@ -699,6 +719,7 @@ targets:
 	@echo "Platforms:           $(PLATFORMS)"
 	@echo "Valid targets:       $(BASE_TARGETS)"
 	@echo "Executable targets:  $(EXE_TARGETS)"
+	@echo "UF2 targets:         $(UF2_TARGETS)"
 	@echo "Built targets:       $(CI_TARGETS)"
 	@echo "Default target:      $(TARGET)"
 	@echo "CI common targets:   $(CI_COMMON_TARGETS)"

--- a/mk/build_verbosity.mk
+++ b/mk/build_verbosity.mk
@@ -9,6 +9,7 @@ ifndef V
 export V0    :=
 export V1    := $(AT)
 export STDOUT   :=
+export MAKE  := $(MAKE) --no-print-directory
 else ifeq ($(V), 0)
 export V0    := $(AT)
 export V1    := $(AT)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -44,15 +44,6 @@ ifeq ($(TARGET),)
 $(error No TARGET identified. Is the $(CONFIG_HEADER_FILE) valid for $(CONFIG)?)
 endif
 
-ifneq ($(filter $(TARGET),$(EXE_TARGETS)),)
-	OUTPUT_TYPE := exe
-else ifneq ($(filter $(subst _rev,,$@),$(UF2_TARGETS)),)
-	OUTPUT_TYPE := uf2
-else
-	OUTPUT_TYPE := hex
-endif
-
-
 EXST_ADJUST_VMA := $(shell sed -E -n "/^[[:space:]]*\#[[:space:]]*define[[:space:]]+FC_VMA_ADDRESS[[:space:]]+((0[xX])?[[:xdigit:]]+).*/s//\1/p" $(CONFIG_HEADER_FILE))
 ifneq ($(EXST_ADJUST_VMA),)
 EXST = yes
@@ -80,9 +71,9 @@ endif
 
 $(BASE_CONFIGS):
 	@echo "Building target config $@"
-	$(V0) $(MAKE) $(MAKE_PARALLEL) $(OUTPUT_TYPE) CONFIG=$@
+	$(V0) $(MAKE) fwo CONFIG=$@
 	@echo "Building target config $@ succeeded."
 
 ## <CONFIG>_rev    : build configured target and add revision to filename
 $(addsuffix _rev,$(BASE_CONFIGS)):
-	$(V0) $(MAKE) $(MAKE_PARALLEL) $(OUTPUT_TYPE) CONFIG=$(subst _rev,,$@) REV=yes
+	$(V0) $(MAKE) fwo CONFIG=$(subst _rev,,$@) REV=yes

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -58,14 +58,14 @@ endif #config
 configs:
 ifeq ($(shell realpath $(CONFIG_DIR)),$(shell realpath $(CONFIGS_SUBMODULE_DIR)))
 	@echo "Updating config submodule: $(CONFIGS_SUBMODULE_DIR)"
-	$(V0) git submodule update --init -- $(CONFIGS_SUBMODULE_DIR) || { echo "Config submodule update failed. Please check your git configuration."; exit 1; }
+	$(V1) git submodule update --init -- $(CONFIGS_SUBMODULE_DIR) || { echo "Config submodule update failed. Please check your git configuration."; exit 1; }
 	@echo "Submodule update succeeded."
 else
 ifeq ($(wildcard $(CONFIG_DIR)),)
 	@echo "Hydrating clone for configs: $(CONFIG_DIR)"
-	$(V0) git clone $(CONFIGS_REPO_URL) $(CONFIG_DIR)
+	$(V1) git clone $(CONFIGS_REPO_URL) $(CONFIG_DIR)
 else
-	$(V0) git -C $(CONFIG_DIR) pull origin
+	$(V1) git -C $(CONFIG_DIR) pull origin
 endif
 endif
 

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -337,16 +337,21 @@ PICOTOOL_REPO   := https://github.com/raspberrypi/picotool.git
 PICOTOOL_DL_DIR := $(DL_DIR)/picotool
 PICOTOOL_BUILD_DIR := $(PICOTOOL_DL_DIR)/build
 PICOTOOL_DIR    := $(TOOLS_DIR)/picotool
-PICO_SDK_PATH   := $(ROOT_DIR)/lib/main/pico-sdk
-PICOTOOL        := $(PICOTOOL_DIR)/picotool
+PICO_SDK_PATH   ?= $(ROOT_DIR)/lib/main/pico-sdk
+PICOTOOL        ?= $(PICOTOOL_DIR)/picotool
+
+ifeq ($(filter picotool_install,$(MAKECMDGOALS)), picotool_install)
+    ifneq ($(wildcard $(PICO_SDK_PATH)/CMakeLists.txt),$(PICO_SDK_PATH)/CMakeLists.txt)
+        $(error "PICO_SDK_PATH ($(PICO_SDK_PATH)) does not point to a valid Pico SDK. Please 'make submodules' to hydrate the Pico SDK.")
+    endif
+endif
 
 ifeq ($(filter uf2,$(MAKECMDGOALS)), uf2)
     ifeq (,$(wildcard $(PICOTOOL)))
-        PICOTOOL_VERSION := $(shell picotool version)
-        ifneq ($(PICOTOOL_VERSION),)
-            PICOTOOL := picotool
+        ifeq (,$(shell which picotool 2>/dev/null))
+            $(error "picotool not in the PATH or setup in tools. Run 'make picotool_install' to install in the tools folder.")
         else
-            $(error **ERROR** picotool not in the PATH or setup in tools. Run 'make picotool_install' to install automatically in the tools folder)
+            PICOTOOL := picotool
         endif
     endif
 endif
@@ -355,13 +360,13 @@ endif
 picotool_install: | $(DL_DIR) $(TOOLS_DIR)
 picotool_install: picotool_clean
 	@echo "\n CLONE     $(PICOTOOL_REPO)"
-	$(V1) git clone --depth 1 $(PICOTOOL_REPO) "$(PICOTOOL_DL_DIR)"
+	$(V1) git clone --depth 1 $(PICOTOOL_REPO) "$(PICOTOOL_DL_DIR)" || { echo "Failed to clone picotool repository"; exit 1; }
 	@echo "\n BUILD      $(PICOTOOL_BUILD_DIR)"
 	$(V1) [ -d "$(PICOTOOL_DIR)" ] || mkdir -p $(PICOTOOL_DIR)
 	$(V1) [ -d "$(PICOTOOL_BUILD_DIR)" ] || mkdir -p $(PICOTOOL_BUILD_DIR)
-	$(V1) cmake -S $(PICOTOOL_DL_DIR) -B $(PICOTOOL_BUILD_DIR) -D PICO_SDK_PATH=$(PICO_SDK_PATH)
-	$(V1) $(MAKE) -C $(PICOTOOL_BUILD_DIR)
-	$(V1) cp $(PICOTOOL_BUILD_DIR)/picotool $(PICOTOOL_DIR)/picotool
+	$(V1) cmake -S $(PICOTOOL_DL_DIR) -B $(PICOTOOL_BUILD_DIR) -D PICO_SDK_PATH=$(PICO_SDK_PATH) || { echo "CMake configuration failed"; exit 1; }
+	$(V1) $(MAKE) -C $(PICOTOOL_BUILD_DIR) || { echo "picotool build failed"; exit 1; }
+	$(V1) cp $(PICOTOOL_BUILD_DIR)/picotool $(PICOTOOL_DIR)/picotool || { echo "Failed to install picotool binary"; exit 1; }
 	@echo "\n VERSION:"
 	$(V1) $(PICOTOOL_DIR)/picotool version
 

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -340,16 +340,16 @@ PICOTOOL_DIR    := $(TOOLS_DIR)/picotool
 PICO_SDK_PATH   ?= $(ROOT_DIR)/lib/main/pico-sdk
 PICOTOOL        ?= $(PICOTOOL_DIR)/picotool
 
-ifeq ($(filter picotool_install,$(MAKECMDGOALS)), picotool_install)
-    ifneq ($(wildcard $(PICO_SDK_PATH)/CMakeLists.txt),$(PICO_SDK_PATH)/CMakeLists.txt)
+ifneq ($(filter picotool_install uf2,$(MAKECMDGOALS)),)
+    ifeq ($(wildcard $(PICO_SDK_PATH)/CMakeLists.txt),)
         $(error "PICO_SDK_PATH ($(PICO_SDK_PATH)) does not point to a valid Pico SDK. Please 'make submodules' to hydrate the Pico SDK.")
     endif
 endif
 
-ifeq ($(filter uf2,$(MAKECMDGOALS)), uf2)
+ifneq ($(filter uf2,$(MAKECMDGOALS)),)
     ifeq (,$(wildcard $(PICOTOOL)))
         ifeq (,$(shell which picotool 2>/dev/null))
-            $(error "picotool not in the PATH or setup in tools. Run 'make picotool_install' to install in the tools folder.")
+            $(error "picotool not in the PATH or configured. Run 'make picotool_install' to install in the tools folder.")
         else
             PICOTOOL := picotool
         endif

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -342,7 +342,7 @@ PICOTOOL        ?= $(PICOTOOL_DIR)/picotool
 
 ifneq ($(filter picotool_install uf2,$(MAKECMDGOALS)),)
     ifeq ($(wildcard $(PICO_SDK_PATH)/CMakeLists.txt),)
-        $(error "PICO_SDK_PATH ($(PICO_SDK_PATH)) does not point to a valid Pico SDK. Please 'make submodules' to hydrate the Pico SDK.")
+        $(error "PICO_SDK_PATH ($(PICO_SDK_PATH)) does not point to a valid Pico SDK. Please 'make pico_sdk' to hydrate the Pico SDK.")
     endif
 endif
 
@@ -355,6 +355,12 @@ ifneq ($(filter uf2,$(MAKECMDGOALS)),)
         endif
     endif
 endif
+
+.PHONY: pico_sdk
+pico_sdk:
+	@echo "Updating pico-sdk"
+	$(V1) git submodule update --init --recursive -- lib/main/pico-sdk || { echo "Failed to update pico-sdk"; exit 1; }
+	@echo "pico-sdk updated"
 
 .PHONY: picotool_install
 picotool_install: | $(DL_DIR) $(TOOLS_DIR)

--- a/src/platform/SIMULATOR/mk/SITL.mk
+++ b/src/platform/SIMULATOR/mk/SITL.mk
@@ -1,3 +1,7 @@
+# SITL Makefile for the simulator platform
+
+# Default output is an exe file
+DEFAULT_OUTPUT := exe
 
 INCLUDE_DIRS := \
         $(INCLUDE_DIRS) \


### PR DESCRIPTION
Adding ability to make to uf2 format for PICO, using picotool build (if required)

Requires: https://github.com/betaflight/betaflight/pull/14400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added explicit support for building UF2 firmware files alongside existing hex outputs.
	- Introduced automated installation and cleanup commands for Raspberry Pi Pico's picotool utility.
	- Added a new command to update git submodules directly from the build system.
- **Improvements**
	- Simplified build target categorization by removing executable target distinctions.
	- Updated help and listing commands to reflect new UF2 target support and streamlined target listings.
	- Added dynamic output type selection for build targets to improve build flexibility.
	- Improved feedback and error handling during configuration submodule updates.
	- Enhanced build verbosity handling for consistent output behavior.
	- Set default output to executable for the simulator platform build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->