### PR TITLE
Move flash_read arguments around in CLI help

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6589,7 +6589,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("flash_info", "show flash chip info", NULL, cliFlashInfo),
 #if defined(USE_FLASH_TOOLS) && defined(USE_FLASHFS)
-    CLI_COMMAND_DEF("flash_read", NULL, "<length> <address>", cliFlashRead),
+    CLI_COMMAND_DEF("flash_read", NULL, "<address> <length>", cliFlashRead),
     CLI_COMMAND_DEF("flash_scan", "scan flash device for errors", NULL, cliFlashVerify),
     CLI_COMMAND_DEF("flash_write", NULL, "<address> <message>", cliFlashWrite),
 #endif


### PR DESCRIPTION
Fixes #14403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the argument order description for the "flash_read" command in the CLI help text to correctly display "<address> <length>" instead of "<length> <address>".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->