### PR TITLE
Only wait for ESC to recognise DSHOT signal once at startup

### DIFF
--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -46,6 +46,7 @@ typedef uint32_t timeUs_t;
 #define SECONDS_PER_MINUTE          60.0f
 
 static inline timeDelta_t cmpTimeUs(timeUs_t a, timeUs_t b) { return (timeDelta_t)(a - b); }
+static inline timeDelta_t cmpTimeMs(timeMs_t a, timeMs_t b) { return (timeDelta_t)(a - b); }
 static inline int32_t cmpTimeCycles(uint32_t a, uint32_t b) { return (int32_t)(a - b); }
 
 #define FORMATTED_DATE_TIME_BUFSIZE 30

--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -153,7 +153,7 @@ bool dshotStreamingCommandsAreEnabled(void)
     bool goodMotorDetectDelay;
 
     if (firstCommand) {
-        goodMotorDetectDelay = motorGetMotorEnableTimeMs() && millis() > motorGetMotorEnableTimeMs() + DSHOT_PROTOCOL_DETECTION_DELAY_MS;
+        goodMotorDetectDelay = motorGetMotorEnableTimeMs() && (cmpTimeMs(millis(), motorGetMotorEnableTimeMs()) > DSHOT_PROTOCOL_DETECTION_DELAY_MS);
 
         if (goodMotorDetectDelay) {
             firstCommand = false;

--- a/src/main/drivers/dshot_command.c
+++ b/src/main/drivers/dshot_command.c
@@ -149,7 +149,20 @@ static bool allMotorsAreIdle(void)
 
 bool dshotStreamingCommandsAreEnabled(void)
 {
-    return motorIsEnabled() && motorGetMotorEnableTimeMs() && millis() > motorGetMotorEnableTimeMs() + DSHOT_PROTOCOL_DETECTION_DELAY_MS;
+    static bool firstCommand = true;
+    bool goodMotorDetectDelay;
+
+    if (firstCommand) {
+        goodMotorDetectDelay = motorGetMotorEnableTimeMs() && millis() > motorGetMotorEnableTimeMs() + DSHOT_PROTOCOL_DETECTION_DELAY_MS;
+
+        if (goodMotorDetectDelay) {
+            firstCommand = false;
+        }
+    } else {
+        goodMotorDetectDelay = true;
+    }
+
+    return motorIsEnabled() && goodMotorDetectDelay;
 }
 
 static bool dshotCommandsAreEnabled(dshotCommandType_e commandType)


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/14406

Now, a re-arm within 3 seconds (`DSHOT_PROTOCOL_DETECTION_DELAY_MS`) of the previous dis-arm sends the `DSHOT_CMD_SPIN_DIRECTION_NORMAL` or `DSHOT_CMD_SPIN_DIRECTION_REVERSED ` command correctly.

![image](https://github.com/user-attachments/assets/e89dd25e-9eee-4b00-89f3-c2346e6ca4d3)

![image](https://github.com/user-attachments/assets/e773db17-3924-413f-b463-5b942a6955da)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved motor command timing by ensuring a one-time detection delay is enforced only on the first activation, enhancing reliability during initial motor enablement.
- **Refactor**
  - Added a new inline comparison function for millisecond timestamps to support consistent timing calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->