### PR TITLE
feat: Add dedicated channel mapping for Car/Boat transmitters

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3540,14 +3540,14 @@ static void cliMap(const char *cmdName, char *cmdline)
     char buf[RX_MAPPABLE_CHANNEL_COUNT + 1];
 
     uint32_t len = strlen(cmdline);
-    if (len <= RX_MAPPABLE_CHANNEL_COUNT && len > NON_AUX_CHANNEL_COUNT) {
+    if (len <= RX_MAPPABLE_CHANNEL_COUNT && len >= NON_AUX_CHANNEL_COUNT) {
 
         for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
-        	if (i < len) {
+            if (i < len) {
                 buf[i] = toupper((unsigned char)cmdline[i]);
-        	}
-        	else {
-                buf[i] = RCMAP_UNMAPPED_INDEX;
+            }
+            else {
+                buf[i] = (unsigned char)RCMAP_UNMAPPED_INDEX;
         	}
         }
         buf[i] = '\0';
@@ -3571,10 +3571,13 @@ static void cliMap(const char *cmdName, char *cmdline)
         buf[i] = '\0';
     }
     for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
-    	mapIdx = rxConfig()->rcmap[i];
-    	if (mapIdx == RCMAP_UNMAPPED_INDEX) {
-    		continue;
-    	}
+        mapIdx = rxConfig()->rcmap[i];
+        if (mapIdx == RCMAP_UNMAPPED_INDEX) {
+            continue;
+		}
+        if (mapIdx >= RX_MAPPABLE_CHANNEL_COUNT) {
+            continue;  // Skip invalid indices
+        }
         buf[mapIdx] = rcChannelLetters[i];
     }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3537,6 +3537,7 @@ static void cliMap(const char *cmdName, char *cmdline)
 {
     uint32_t i;
     uint8_t mapIdx;
+    // Working buffer (+1 for the null terminator). Re-used later when we render the map back to the user.                     */
     char buf[RX_MAPPABLE_CHANNEL_COUNT + 1];
 
     uint32_t len = strlen(cmdline);
@@ -3566,13 +3567,14 @@ static void cliMap(const char *cmdName, char *cmdline)
         return;
     }
 
-    for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
-        buf[i] = '\0';
-    }
+    // Reset buffer, so we can rebuild it from rcmap[]
+    memset(buf, 0, sizeof(buf));
+
+    // Translate the numerical rcmap[] back into channel letters. Skip unmapped or invalid indices for robustness
     for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
         mapIdx = rxConfig()->rcmap[i];
         if (mapIdx == RCMAP_UNMAPPED_INDEX) {
-            continue;
+            continue; // Skip unmapped indices
         }
         if (mapIdx >= RX_MAPPABLE_CHANNEL_COUNT) {
             continue;  // Skip invalid indices

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3512,7 +3512,7 @@ static void printMap(dumpFlags_t dumpMask, const rxConfig_t *rxConfig, const rxC
     for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
         rcMapIdx = rxConfig->rcmap[i];
         if (rcMapIdx != RCMAP_UNMAPPED_INDEX) {
-            buf[rxConfig->rcmap[i]] = rcChannelLetters[i];
+            buf[rcMapIdx] = rcChannelLetters[i];
         }
         if (defaultRxConfig) {
             defaultRcMapIdx = defaultRxConfig->rcmap[i];

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3510,15 +3510,15 @@ static void printMap(dumpFlags_t dumpMask, const rxConfig_t *rxConfig, const rxC
 
     headingStr = cliPrintSectionHeading(dumpMask, false, headingStr);
     for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
-    	rcMapIdx = rxConfig->rcmap[i];
-    	if (rcMapIdx != RCMAP_UNMAPPED_INDEX) {
+        rcMapIdx = rxConfig->rcmap[i];
+        if (rcMapIdx != RCMAP_UNMAPPED_INDEX) {
             buf[rxConfig->rcmap[i]] = rcChannelLetters[i];
-    	}
+        }
         if (defaultRxConfig) {
-        	defaultRcMapIdx = defaultRxConfig->rcmap[i];
-        	if (defaultRcMapIdx != RCMAP_UNMAPPED_INDEX) {
-        		bufDefault[defaultRcMapIdx] = rcChannelLetters[i];
-			}
+            defaultRcMapIdx = defaultRxConfig->rcmap[i];
+            if (defaultRcMapIdx != RCMAP_UNMAPPED_INDEX) {
+                bufDefault[defaultRcMapIdx] = rcChannelLetters[i];
+            }
             equalsDefault = equalsDefault && (defaultRcMapIdx == rcMapIdx);
         }
     }
@@ -3544,16 +3544,15 @@ static void cliMap(const char *cmdName, char *cmdline)
 
         for (i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
             if (i < len) {
-                buf[i] = toupper((unsigned char)cmdline[i]);
+                buf[i] = toupper((unsigned char) cmdline[i]);
+            } else {
+                buf[i] = (unsigned char) RCMAP_UNMAPPED_INDEX;
             }
-            else {
-                buf[i] = (unsigned char)RCMAP_UNMAPPED_INDEX;
-        	}
         }
         buf[i] = '\0';
 
         for (i = 0; i < len; i++) {
-            buf[i] = toupper((unsigned char)cmdline[i]);
+            buf[i] = toupper((unsigned char) cmdline[i]);
 
             if (strchr(rcChannelLetters, buf[i]) && !strchr(buf + i + 1, buf[i]))
                 continue;
@@ -3574,7 +3573,7 @@ static void cliMap(const char *cmdName, char *cmdline)
         mapIdx = rxConfig()->rcmap[i];
         if (mapIdx == RCMAP_UNMAPPED_INDEX) {
             continue;
-		}
+        }
         if (mapIdx >= RX_MAPPABLE_CHANNEL_COUNT) {
             continue;  // Skip invalid indices
         }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -658,7 +658,7 @@ STATIC_UNIT_TESTED float applyRxChannelRangeConfiguraton(float sample, const rxC
 
 static void readRxChannelsApplyRanges(void)
 {
-	uint8_t unmappedCount = 0;
+    uint8_t unmappedCount = 0;
     for (int channel = 0; channel < rxChannelCount; channel++) {
 
         const uint8_t rawChannel = channel < RX_MAPPABLE_CHANNEL_COUNT ? rxConfig()->rcmap[channel] : channel;
@@ -672,16 +672,16 @@ static void readRxChannelsApplyRanges(void)
 #endif
         {
             if (rawChannel == RCMAP_UNMAPPED_INDEX) {
-            	sample = rxConfig()->midrc;
-            	unmappedCount++;
+                sample = rxConfig()->midrc;
+                unmappedCount++;
             }
             else {
-            	if (channel < RX_MAPPABLE_CHANNEL_COUNT) {
+                if (channel < RX_MAPPABLE_CHANNEL_COUNT) {
                     sample = rxRuntimeState.rcReadRawFn(&rxRuntimeState, rawChannel);
-            	}
-            	else {
+                }
+                else {
                     sample = rxRuntimeState.rcReadRawFn(&rxRuntimeState, rawChannel - unmappedCount);
-            	}
+                }
             }
         }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -674,14 +674,10 @@ static void readRxChannelsApplyRanges(void)
             if (rawChannel == RCMAP_UNMAPPED_INDEX) {
                 sample = rxConfig()->midrc;
                 unmappedCount++;
-            }
-            else {
-                if (channel < RX_MAPPABLE_CHANNEL_COUNT) {
-                    sample = rxRuntimeState.rcReadRawFn(&rxRuntimeState, rawChannel);
-                }
-                else {
-                    sample = rxRuntimeState.rcReadRawFn(&rxRuntimeState, rawChannel - unmappedCount);
-                }
+            } else {
+                sample = rxRuntimeState.rcReadRawFn(&rxRuntimeState, channel < RX_MAPPABLE_CHANNEL_COUNT
+                    ? rawChannel
+                    : rawChannel - unmappedCount);
             }
         }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -809,7 +809,7 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
 void parseRcChannels(const char *input, rxConfig_t *rxConfig)
 {
     // Initialize all rc map values to 255 (indicating unmapped)
-    for (uint8_t i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
+    for (unsigned i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
         rxConfig->rcmap[i] = RCMAP_UNMAPPED_INDEX;
     }
     for (const char *c = input; *c; c++) {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -809,9 +809,9 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
 void parseRcChannels(const char *input, rxConfig_t *rxConfig)
 {
     // Initialize all rc map values to 255 (indicating unmapped)
-	for (uint8_t i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
-	rxConfig->rcmap[i] = RCMAP_UNMAPPED_INDEX;
-	}
+    for (uint8_t i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
+        rxConfig->rcmap[i] = RCMAP_UNMAPPED_INDEX;
+    }
     for (const char *c = input; *c; c++) {
         const char *s = strchr(rcChannelLetters, *c);
         if (s && (s < rcChannelLetters + RX_MAPPABLE_CHANNEL_COUNT)) {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -810,7 +810,7 @@ void parseRcChannels(const char *input, rxConfig_t *rxConfig)
 {
     // Initialize all rc map values to 255 (indicating unmapped)
 	for (uint8_t i = 0; i < RX_MAPPABLE_CHANNEL_COUNT; i++) {
-		rxConfig->rcmap[i] = RCMAP_UNMAPPED_INDEX;
+	rxConfig->rcmap[i] = RCMAP_UNMAPPED_INDEX;
 	}
     for (const char *c = input; *c; c++) {
         const char *s = strchr(rcChannelLetters, *c);

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -54,6 +54,7 @@
 // Extracted from rx/rx.c and rx/rx.h
 
 #define RX_MAPPABLE_CHANNEL_COUNT 8
+#define RCMAP_UNMAPPED_INDEX 255
 
 #ifndef RX_SPI_DEFAULT_PROTOCOL
 #define RX_SPI_DEFAULT_PROTOCOL 0


### PR DESCRIPTION
This Pull Request implements new RC channel mapping presets specifically tailored for Car/Boat radio transmitters. The aim is to resolve existing limitations where Betaflight's default channel interpretation conflicts with the typical 2-channel primary setup (Throttle and Steering/Rudder) found in these transmitters.

**Problem Addressed:**
Betaflight currently mandates the allocation of four primary channels (Aileron, Elevator, Throttle, Rudder). When a Car/Boat transmitter is connected (e.g., a 4-channel unit with Throttle, Rudder, AUX1, AUX2), the system implicitly assigns these four channels to Betaflight's AETR, leading to incorrect mapping of auxiliary channels.

**Solution:**
This PR introduces `TR1234` and `RT1234` channel mapping options. These new configurations enable Betaflight to correctly identify and utilize the primary Throttle and Rudder/Steering channels without forcing the allocation of unused Aileron and Elevator channels. This ensures:
* Accurate interpretation of RC inputs from Car/Boat transmitters.
* Improved compatibility and user experience for RC car/boat enthusiasts.
* Prevention of auxiliary channels being inadvertently consumed by mandatory primary flight controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of unmapped RC channels, ensuring channels not explicitly mapped are now clearly identified and managed.
- **Bug Fixes**
	- Corrected RC channel mapping logic to prevent unintended assignments and improve input validation.
- **Chores**
	- Added a new macro to define unmapped RC channel indices for clearer configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->