### PR TITLE
REFACTOR: missed trait defines

### DIFF
--- a/src/main/drivers/bus_i2c_config.c
+++ b/src/main/drivers/bus_i2c_config.c
@@ -56,13 +56,13 @@ void i2cHardwareConfigure(const i2cConfig_t *i2cConfig)
         for (int pindex = 0 ; pindex < I2C_PIN_SEL_MAX ; pindex++) {
             if (i2cConfig[device].ioTagScl == hardware->sclPins[pindex].ioTag) {
                 pDev->scl = IOGetByTag(i2cConfig[device].ioTagScl);
-#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4) || defined(AT32F4) || defined(APM32F4)
+#if I2C_TRAIT_AF_PIN
                 pDev->sclAF = hardware->sclPins[pindex].af;
 #endif
             }
             if (i2cConfig[device].ioTagSda == hardware->sdaPins[pindex].ioTag) {
                 pDev->sda = IOGetByTag(i2cConfig[device].ioTagSda);
-#if defined(STM32F4) || defined(STM32H7) || defined(STM32G4) || defined(AT32F4) || defined(APM32F4)
+#if I2C_TRAIT_AF_PIN
                 pDev->sdaAF = hardware->sdaPins[pindex].af;
 #endif
             }


### PR DESCRIPTION
Just missed a couple of PIN_AF items on the i2c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal configuration logic for I2C pin assignments to improve compatibility across supported devices. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->