### PR TITLE
Move bus_i2c_config.c to platform

### DIFF
--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -51,7 +51,7 @@ typedef enum I2CDevice {
 #define I2C_ADDR7_MAX       119
 
 struct i2cConfig_s;
-void i2cHardwareConfigure(const struct i2cConfig_s *i2cConfig);
+void i2cPinConfigure(const struct i2cConfig_s *i2cConfig);
 void i2cInit(I2CDevice device);
 bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -624,7 +624,7 @@ void init(void)
 #endif
 
 #ifdef USE_I2C
-    i2cHardwareConfigure(i2cConfig(0));
+    i2cPinConfigure(i2cConfig(0));
 
     // Note: Unlike UARTs which are configured when client is present,
     // I2C buses are initialized unconditionally if they are configured.

--- a/src/platform/APM32/mk/APM32F4.mk
+++ b/src/platform/APM32/mk/APM32F4.mk
@@ -180,7 +180,7 @@ MCU_COMMON_SRC = \
         APM32/serial_uart_apm32f4xx.c \
         drivers/adc.c \
         drivers/bus_spi_config.c \
-        common/stm32/bus_i2c_config.c \
+        common/stm32/bus_i2c_pinconfig.c \
         common/stm32/bus_spi_hw.c \
         common/stm32/bus_spi_pinconfig.c \
         common/stm32/serial_uart_hw.c \
@@ -218,7 +218,7 @@ SIZE_OPTIMISED_SRC += \
         APM32/usb/vcp/serial_usb_vcp.c \
         drivers/inverter.c \
         drivers/bus_spi_config.c \
-        common/stm32/bus_i2c_config.c \
+        common/stm32/bus_i2c_pinconfig.c \
         common/stm32/bus_spi_pinconfig.c \
         drivers/serial_escserial.c \
         drivers/serial_pinconfig.c \

--- a/src/platform/AT32/mk/AT32F4.mk
+++ b/src/platform/AT32/mk/AT32F4.mk
@@ -122,7 +122,7 @@ MCU_COMMON_SRC = \
             drivers/usb_msc_common.c \
             drivers/adc.c \
             drivers/bus_spi_config.c \
-            common/stm32/bus_i2c_config.c \
+            common/stm32/bus_i2c_pinconfig.c \
             common/stm32/bus_spi_pinconfig.c \
             common/stm32/bus_spi_hw.c \
             common/stm32/serial_uart_hw.c \
@@ -145,7 +145,7 @@ SIZE_OPTIMISED_SRC += \
             drivers/bus_i2c_timing.c \
             drivers/inverter.c \
             drivers/bus_spi_config.c \
-            common/stm32/bus_i2c_config.c \
+            common/stm32/bus_i2c_pinconfig.c \
             common/stm32/bus_spi_pinconfig.c \
             drivers/serial_escserial.c \
             drivers/serial_pinconfig.c \

--- a/src/platform/STM32/mk/STM32_COMMON.mk
+++ b/src/platform/STM32/mk/STM32_COMMON.mk
@@ -6,7 +6,7 @@ MCU_COMMON_SRC += \
             common/stm32/config_flash.c \
             common/stm32/bus_spi_pinconfig.c \
             drivers/bus_spi_config.c \
-            common/stm32/bus_i2c_config.c \
+            common/stm32/bus_i2c_pinconfig.c \
             common/stm32/bus_spi_hw.c \
             common/stm32/io_impl.c \
             common/stm32/serial_uart_hw.c \
@@ -17,7 +17,7 @@ MCU_COMMON_SRC += \
 
 SIZE_OPTIMISED_SRC += \
             drivers/bus_spi_config.c \
-            common/stm32/bus_i2c_config.c \
+            common/stm32/bus_i2c_pinconfig.c \
             common/stm32/config_flash.c \
             common/stm32/bus_spi_pinconfig.c
 

--- a/src/platform/common/stm32/bus_i2c_pinconfig.c
+++ b/src/platform/common/stm32/bus_i2c_pinconfig.c
@@ -39,7 +39,7 @@
 
 #include "pg/bus_i2c.h"
 
-void i2cHardwareConfigure(const i2cConfig_t *i2cConfig)
+void i2cPinConfigure(const i2cConfig_t *i2cConfig)
 {
     for (int index = 0 ; index < I2CDEV_COUNT ; index++) {
         const i2cHardware_t *hardware = &i2cHardware[index];

--- a/src/test/unit/timer_definition_unittest.include/pg/bus_i2c.h
+++ b/src/test/unit/timer_definition_unittest.include/pg/bus_i2c.h
@@ -1,5 +1,5 @@
 #define I2CDEV_2 (1)
 
 int i2cConfig(int);
-void i2cHardwareConfigure(int);
+void i2cPinConfigure(int);
 void i2cInit(int);


### PR DESCRIPTION
Move bus_i2c_config.c to platform to allow different PICO implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build configurations to use a shared I2C pin configuration source for improved consistency across platforms.
	- Renamed I2C configuration function to better reflect its role in pin setup during system initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->