### PR TITLE
Removed extraneous parentheses to resolve compiler warning

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1628,7 +1628,7 @@ static void cliSerialPassthrough(const char *cmdName, char *cmdline)
 
     cliPrintLinef("Forwarding, power cycle %sto exit.", resetMessage);
 
-    if ((ports[1].id == SERIAL_PORT_USB_VCP)) {
+    if (ports[1].id == SERIAL_PORT_USB_VCP) {
         do {
             if (port1ResetOnDtr) {
                 serialSetCtrlLineStateCb(ports[1].port, cbCtrlLine_reset, NULL);


### PR DESCRIPTION
Resolve the following compiler warning in cli.c:

./src/main/cli/cli.c 
./src/main/cli/cli.c:1630:22: error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
    if ((ports[1].id == SERIAL_PORT_USB_VCP)) {
         ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
./src/main/cli/cli.c:1630:22: note: remove extraneous parentheses around the comparison to silence this warning
    if ((ports[1].id == SERIAL_PORT_USB_VCP)) {
        ~            ^                     ~
./src/main/cli/cli.c:1630:22: note: use '=' to turn this equality comparison into an assignment
    if ((ports[1].id == SERIAL_PORT_USB_VCP)) {
                     ^~
                     =
1 error generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Simplified syntax in an if statement by removing unnecessary parentheses. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->