### PR TITLE
Fix misplaced #else/#endif in accgyro_spi_icm456xx.c

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm456xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm456xx.c
@@ -479,7 +479,7 @@ bool icm456xxAccReadSPI(accDev_t *acc)
             spiWait(&acc->gyro->dev);
 
         } else 
-#else
+#endif
         {
            // Interrupts are present, but no DMA. Non-DMA read
            uint8_t raw[ICM456XX_DATA_LENGTH];
@@ -493,7 +493,6 @@ bool icm456xxAccReadSPI(accDev_t *acc)
            acc->ADCRaw[Z] = (int16_t)((raw[5] << 8) | raw[4]);
            
         }
-#endif
         break;
     }
 


### PR DESCRIPTION
Fix misplaced #else/#endif in accgyro_spi_icm456xx.c

Looks like intention is to allow alternative path if USE_DMA is defined and spiUseDMA() is true. As written, it will bypass the break and fall through in that scenario.
