### PR TITLE
paradigm shift

### DIFF
--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -30,6 +30,7 @@ typedef enum {
     RATES_TYPE_KISS,
     RATES_TYPE_ACTUAL,
     RATES_TYPE_QUICK,
+    RATES_TYPE_PLAINENGLISH,
     RATES_TYPE_COUNT    // must be the final entry
 } ratesType_e;
 

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -74,14 +74,24 @@ void changeControlRateProfile(uint8_t controlRateProfileIndex);
 
 void copyControlRateProfile(const uint8_t dstControlRateProfileIndex, const uint8_t srcControlRateProfileIndex);
 
-typedef struct plainEnglishRates {
+struct StickFeel {
 	float CenterStickPrecision;
 	float OuterStickTransition;
-	float MaxRotationSpeed;
+    //float CenterDeadZone;
+    //float OuterDeadZone;
 
-	FEasyRates() {
-		CenterStickPrecision = 0.5f;
-		OuterStickTransition = 0.33f;
-		MaxRotationSpeed = 650.f;
-	};
-} plainEnglishRates;
+    stickFeel() {
+        CenterStickPrecision = 0.5f;
+        OuterStickTransition = 0.33f;
+        //CenterDeadZone = 0.05f;
+        //OuterDeadZone = 0.05f;
+    };
+};
+
+const StickFeel MyStickFeel;
+/*
+    example, if you set this value to 360, and you tilt the stick all the way, 
+    then the Quadcopter will rotate 360 degrees each second that the stick is fully tilted.
+    the quadcopter itself spins 360 degrees per second if you set this to 360.f
+*/
+const float MaxQuadcopterRotationSpeed = 650.f;

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -73,3 +73,15 @@ void loadControlRateProfile(void);
 void changeControlRateProfile(uint8_t controlRateProfileIndex);
 
 void copyControlRateProfile(const uint8_t dstControlRateProfileIndex, const uint8_t srcControlRateProfileIndex);
+
+typedef struct plainEnglishRates {
+	float CenterStickPrecision;
+	float OuterStickTransition;
+	float MaxRotationSpeed;
+
+	FEasyRates() {
+		CenterStickPrecision = 0.5f;
+		OuterStickTransition = 0.33f;
+		MaxRotationSpeed = 650.f;
+	};
+} plainEnglishRates;

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -80,7 +80,7 @@ struct StickFeel {
     //float CenterDeadZone;
     //float OuterDeadZone;
 
-    stickFeel() {
+    StickFeel() {
         CenterStickPrecision = 0.5f;
         OuterStickTransition = 0.33f;
         //CenterDeadZone = 0.05f;

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -262,12 +262,12 @@ static float applyQuickRates(const int axis, float rcCommandf, const float rcCom
 
 static float applyPlainEnglishRates(const int axis, float rcCommandf, const float rcCommandfAbs)
 {
-    rcCommandf *= plainEnglishRates.MaxRotationSpeed * 
+    rcCommandf *= MaxQuadcopterRotationSpeed *
         (
-            plainEnglishRates.CenterStickPrecision * 
+            MyStickFeel.CenterStickPrecision *
             powf(rcCommandfAbs, 20.f * 
-            powf(plainEnglishRates.OuterStickTransition, 2.f)) + 
-            (1.f - plainEnglishRates.CenterStickPrecision)
+            powf(MyStickFeel.OuterStickTransition, 2.f)) +
+            (1.f - MyStickFeel.CenterStickPrecision)
         );   
     return rcCommandf;
 }

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -958,6 +958,9 @@ void initRcProcessing(void)
     case RATES_TYPE_QUICK:
         applyRates = applyQuickRates;
         break;
+    case RATES_TYPE_PLAINENGLISH:
+        applyRates = applyPlainEnglishRates;
+        break;
     }
 
 #ifdef USE_FEEDFORWARD

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -259,6 +259,19 @@ static float applyQuickRates(const int axis, float rcCommandf, const float rcCom
     return angleRate;
 }
 
+
+static float applyPlainEnglishRates(const int axis, float rcCommandf, const float rcCommandfAbs)
+{
+    rcCommandf *= plainEnglishRates.MaxRotationSpeed * 
+        (
+            plainEnglishRates.CenterStickPrecision * 
+            powf(rcCommandfAbs, 20.f * 
+            powf(plainEnglishRates.OuterStickTransition, 2.f)) + 
+            (1.f - plainEnglishRates.CenterStickPrecision)
+        );   
+    return rcCommandf;
+}
+
 static void scaleRawSetpointToFpvCamAngle(void)
 {
     //recalculate sin/cos only when rxConfig()->fpvCamAngleDegrees changed


### PR DESCRIPTION
I want to introduce a new way of thinking about rates.  
With my "Plain English Rates", you control the quad by setting it's maximum rotation speed with MaxQuadcopterRotationSpeed  
And you control the "Stick Feel" with 2 simple variables : CenterStickPrecision and OuterStickTransition (both of these are clamped from 0 to 1)  
  
https://www.desmos.com/calculator/gurmg3gous


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Plain English" rate type with user-friendly parameters for adjusting control rates.
	- Added new settings: Center Stick Precision, Outer Stick Transition, and Max Rotation Speed for more intuitive tuning of control response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->