### PR TITLE
Added MAYBE_UNUSED to get rid of compiler warning

### DIFF
--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -190,6 +190,7 @@ void voltageMeterADCRefresh(void)
 #endif
 #else
         UNUSED(voltageAdcToVoltage);
+        UNUSED(voltageMeterAdcChannelMap);
 
         state->voltageDisplayFiltered = 0;
         state->voltageUnfiltered = 0;


### PR DESCRIPTION
Hopefully this one isn't too controversial. Basically adding the MAYBE_UNUSED tag to get rid of a warning from the version of clang compiler we use on our fork:

> ./src/main/sensors/voltage.c:148:22: error: variable 'voltageMeterAdcChannelMap' is not needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
> static const uint8_t voltageMeterAdcChannelMap[] = {
>                      ^
> 1 error generated.

In our case USE_ADC is not defined so voltageMeterAdcChannelMap is only used in sizeof to compute the length of the array. The compiler, due to some issue (bug), doesn't register that as a use of it. As an experiment, changing the code to explicitly use the array makes the warning go away:

	uint8_t array_element = voltageMeterAdcChannelMap[0];
    for (uint8_t i = 0; i < MAX_VOLTAGE_SENSOR_ADC && i < (sizeof(voltageMeterAdcChannelMap)/sizeof(array_element)); i++) {

In all cases the generated code does not change. And if we change the value of MAX_VOLTAGE_SENSOR_ADC or the size of the voltageMeterAdcChannelMap array the generated code is still valid. So no actual issues with generating valid code, just in the generation of that warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved internal handling to prevent unnecessary compiler warnings. No impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->