### PR TITLE
Separate use of ESC_SENSOR and DSHOT_TELEMETRY

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -685,7 +685,7 @@ void init(void)
     // Now reset the targetLooptime as it's possible for the validation to change the pid_process_denom
     gyroSetTargetLooptime(pidConfig()->pid_process_denom);
 
-#if defined(USE_DSHOT_TELEMETRY) || defined(USE_ESC_SENSOR)
+#if defined(USE_DSHOT_TELEMETRY) && defined(USE_ESC_SENSOR)
     // Initialize the motor frequency filter now that we have a target looptime
     initDshotTelemetry(gyro.targetLooptime);
 #endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -216,10 +216,6 @@
 #define USE_VTX_RTC6705
 #endif
 
-#ifndef USE_DSHOT
-#undef USE_ESC_SENSOR
-#endif
-
 #ifndef USE_ESC_SENSOR
 #undef USE_ESC_SENSOR_TELEMETRY
 #endif

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -118,6 +118,11 @@ int lockMainPID(void)
 #define ACC_SCALE (256 / 9.80665)
 #define GYRO_SCALE (16.4)
 
+float erpmToRpm(uint32_t erpm)
+{
+    return (float) erpm;
+}
+
 static void sendMotorUpdate(void)
 {
     udpSend(&pwmLink, &pwmPkt, sizeof(servo_packet));


### PR DESCRIPTION
In our fork we have added support for our non-DShot (UART based) ESC. Our ESC supports ESC_SENSOR functionality so this PR separates the two features so that you can have ESC_SENSOR support without requiring DShot support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a function to convert ERPM values to floating-point format in the simulator.

- **Bug Fixes**
  - Adjusted the initialization of DShot telemetry to only occur when both DShot telemetry and ESC sensor features are enabled.

- **Refactor**
  - Updated feature flag handling to no longer automatically disable ESC sensor functionality when DShot is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->