### PR TITLE
CLI allow for DEFIO_PORT_PINS pins per port.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5307,7 +5307,7 @@ static bool strToPin(char *ptr, ioTag_t *tag)
 
             char *end;
             const long pin = strtol(ptr, &end, 10);
-            if (end != ptr && pin >= 0 && pin < 16) {
+            if (end != ptr && pin >= 0 && pin < DEFIO_PORT_PINS) {
                 *tag = DEFIO_TAG_MAKE(port, pin);
 
                 return true;


### PR DESCRIPTION
In CLI, allow pin numbers up to DEFIO_PORT_PINS, which can be more than 16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for pin numbers by using a configurable maximum value, ensuring more accurate checks for valid pin ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->