### PR TITLE
Add displayport_msp_use_disarm_delay

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1743,7 +1743,7 @@ const clivalue_t valueTable[] = {
     { "displayport_msp_fonts",      VAR_UINT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = 4, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, fontSelection) },
     { "displayport_msp_use_device_blink",   VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, useDeviceBlink) },
 #ifdef USE_MSP_DISPLAYPORT_DISARM_DELAY
-    { "displayport_msp_use_disarm_delay",   VAR_UINT8   | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, useDisarmDelay) },
+    { "displayport_msp_use_disarm_delay",   VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, useDisarmDelay) },
 #endif
 #endif
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1742,6 +1742,9 @@ const clivalue_t valueTable[] = {
     { "displayport_msp_row_adjust", VAR_INT8    | MASTER_VALUE, .config.minmax = { -3, 0 }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, rowAdjust) },
     { "displayport_msp_fonts",      VAR_UINT8   | MASTER_VALUE | MODE_ARRAY, .config.array.length = 4, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, fontSelection) },
     { "displayport_msp_use_device_blink",   VAR_UINT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, useDeviceBlink) },
+#ifdef USE_MSP_DISPLAYPORT_DISARM_DELAY
+    { "displayport_msp_use_disarm_delay",   VAR_UINT8   | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_DISPLAY_PORT_MSP_CONFIG, offsetof(displayPortProfile_t, useDisarmDelay) },
+#endif
 #endif
 
 // PG_DISPLAY_PORT_MSP_CONFIG

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1096,17 +1096,18 @@ static void mspDisplayportDelayDisarm(mspDescriptor_t srcDesc, boxBitmask_t *fli
     }
 
     if (displayPortMspDescriptor == srcDesc) {
-        bool currentState = bitArrayGet(flightModeFlags, BOXARM);
+        bool currentArmState = bitArrayGet(flightModeFlags, BOXARM);
         if (displayPortMspArmState) {
-            if (!currentState) {
+            if (!currentArmState) {
                 if (cmpTimeUs(micros(), getLastDisarmTimeUs()) < DISARM_DELAY_MULTIPLIER_US * displayPortProfileMsp()->useDisarmDelay) {
+                    // Override the arm state reported on displayport MSP to indicate still armed
                     bitArraySet(flightModeFlags, BOXARM);
                 } else {
                     displayPortMspArmState = false;
                 }
             }
         } else {
-            displayPortMspArmState = currentState;
+            displayPortMspArmState = currentArmState;
         }
     }
 }

--- a/src/main/pg/displayport_profiles.c
+++ b/src/main/pg/displayport_profiles.c
@@ -37,6 +37,9 @@ void pgResetFn_displayPortProfileMsp(displayPortProfile_t *displayPortProfile)
     for (uint8_t font = 0; font < DISPLAYPORT_SEVERITY_COUNT; font++) {
         displayPortProfile->fontSelection[font] = font;
     }
+#ifdef USE_MSP_DISPLAYPORT_DISARM_DELAY
+    displayPortProfile->useDisarmDelay = 30;
+#endif
 }
 
 #endif

--- a/src/main/pg/displayport_profiles.h
+++ b/src/main/pg/displayport_profiles.h
@@ -34,6 +34,9 @@ typedef struct displayPortProfile_s {
 
     uint8_t fontSelection[DISPLAYPORT_SEVERITY_COUNT];
     uint8_t useDeviceBlink;    // Use device local blink capability
+#ifdef USE_MSP_DISPLAYPORT_DISARM_DELAY
+    uint8_t useDisarmDelay;
+#endif
 } displayPortProfile_t;
 
 PG_DECLARE(displayPortProfile_t, displayPortProfileMsp);


### PR DESCRIPTION
Video systems at least DJI stop recording as soon as they receive the disarm flag, which is some inconvenience when the disarm was short-term, or in a situation when forced disarm at altitude does not allow viewing the DVR of the falling process. There is no hope that this will be fixed on their part.
I tried to minimize the impact on those who do not need it:
- it is enabled only with the USE_MSP_DISPLAYPORT_DISARM_DELAY flag during compilation
- it affects only the MSP DisplayPort
- one parameter is added "displayport_msp_use_disarm_delay" - sets the delay time in 0.1 seconds (0-25.5 seconds), by default 30 = 3 seconds

resolves: https://github.com/betaflight/betaflight/issues/14387
resolves: https://github.com/betaflight/betaflight/pull/14090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional configurable disarm delay for MSP commands via the DisplayPort interface.
  - Added a new parameter to control the disarm delay duration, defaulting to 30 when enabled.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Refactor**
  - None.

- **Style**
  - None.

- **Tests**
  - None.

- **Chores**
  - None.

- **Revert**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->