### PR TITLE
add CHIRP mode in msp build options defines

### DIFF
--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -110,6 +110,9 @@ void sbufWriteBuildInfoFlags(sbuf_t *dst)
 #ifdef USE_CAMERA_CONTROL
         BUILD_OPTION_CAMERA_CONTROL,
 #endif
+#ifdef USE_CHIRP
+        BUILD_OPTION_CHIRP,
+#endif
 #ifdef USE_DASHBOARD
         BUILD_OPTION_DASHBOARD,
 #endif

--- a/src/main/msp/msp_build_info.h
+++ b/src/main/msp/msp_build_info.h
@@ -58,6 +58,7 @@
 #define BUILD_OPTION_ALTITUDE_HOLD              16422
 #define BUILD_OPTION_BATTERY_CONTINUE           16406
 #define BUILD_OPTION_CAMERA_CONTROL             16407
+#define BUILD_OPTION_CHIRP                      16426
 #define BUILD_OPTION_DASHBOARD                  16408
 #define BUILD_OPTION_EMFAT_TOOLS                16409
 #define BUILD_OPTION_ESCSERIAL_SIMONK           16410


### PR DESCRIPTION
Add CHIRP to msp build defines so configurator could show it in defines list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying the CHIRP feature flag in build information when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->