### PR TITLE
Disable entering CMS menu when armed

### DIFF
--- a/src/main/io/displayport_crsf.c
+++ b/src/main/io/displayport_crsf.c
@@ -35,6 +35,7 @@
 #include "drivers/time.h"
 
 #include "displayport_crsf.h"
+#include "fc/runtime_config.h"
 
 #define CRSF_DISPLAY_PORT_OPEN_DELAY_MS     400
 #define CRSF_DISPLAY_PORT_CLEAR_DELAY_MS    45
@@ -155,6 +156,11 @@ crsfDisplayPortScreen_t *crsfDisplayPortScreen(void)
 
 void crsfDisplayPortMenuOpen(void)
 {
+    if (ARMING_FLAG(ARMED)) {
+        // when armed, make it impossible to open the menu (it wouldn't be possible to disarm)
+        return;
+    }
+
     if (cmsInMenu) {
         return;
     }


### PR DESCRIPTION
My friend encountered this rather severe safety issue which makes it impossible to disarm the drone in specific scenario involving CMS mode. This can lead to quite hilarious situations, but only for those behind the safety net: https://www.youtube.com/shorts/Hru-XtCGLgs

Its possible to enter CMS mode even when drone is armed. When CMS mode is active, processRcStickPositions (which also handles arming/disarming logic) is not called, so disarm is not possible. Steps to reproduce:
- Arm drone
- Enter CMS mode by launching Betaflight CMS lua script in radio
- Now arm/disarm switch does nothing, only way to disarm is to exit the CMS menu and then disarm.

Video with the bug in action (though with Czech commentary): https://www.youtube.com/shorts/e4TR_xhyOD4
In this case the Betaflight CMS lua script never loads, so even exiting it it doesn't exit the CMS in the drone. That makes it impossible to disarm in a normal way.

My proposed solution is to disable entering CMS mode via CRSF command while armed. Disclaimer though: I have spent 10 minutes on the fix, and I didn't even test it. So consider this more of a bug report with solution suggestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the menu from opening while the system is armed, improving safety and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->