### PR TITLE
REFACTOR: Adding DMA_FIRST_HANDLER

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5329,7 +5329,7 @@ static void showDma(void)
     cliPrintLine("Currently active DMA:");
     cliRepeat('-', 20);
 #endif
-    for (int i = 1; i <= DMA_LAST_HANDLER; i++) {
+    for (int i = DMA_FIRST_HANDLER; i <= DMA_LAST_HANDLER; i++) {
         const resourceOwner_t *owner = dmaGetOwner(i);
 
         cliPrintf(DMA_OUTPUT_STRING, DMA_DEVICE_NO(i), DMA_DEVICE_INDEX(i));

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -58,6 +58,8 @@ typedef struct dmaChannelDescriptor_s {
 #endif
 } dmaChannelDescriptor_t;
 
+#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - DMA_FIRST_HANDLER)
+
 void dmaMuxEnable(dmaIdentifier_e identifier, uint32_t dmaMuxId);
 
 dmaIdentifier_e dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -58,8 +58,6 @@ typedef struct dmaChannelDescriptor_s {
 #endif
 } dmaChannelDescriptor_t;
 
-#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
-
 void dmaMuxEnable(dmaIdentifier_e identifier, uint32_t dmaMuxId);
 
 dmaIdentifier_e dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);

--- a/src/platform/APM32/include/platform/dma.h
+++ b/src/platform/APM32/include/platform/dma.h
@@ -32,7 +32,8 @@
 
 typedef enum {
     DMA_NONE = 0,
-    DMA1_ST0_HANDLER = 1,
+    DMA_FIRST_HANDLER = 1,
+    DMA1_ST0_HANDLER = DMA_FIRST_HANDLER,
     DMA1_ST1_HANDLER,
     DMA1_ST2_HANDLER,
     DMA1_ST3_HANDLER,
@@ -55,7 +56,8 @@ typedef enum {
 #define DMA_DEVICE_INDEX(x) ((((x)-1) % 8))
 #define DMA_OUTPUT_INDEX    0
 #define DMA_OUTPUT_STRING   "DMA%d Stream %d:"
-#define DMA_INPUT_STRING    "DMA%d_ST%d"
+
+#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
 
 #define DEFINE_DMA_CHANNEL(d, s, f) { \
     .dma = d, \

--- a/src/platform/APM32/include/platform/dma.h
+++ b/src/platform/APM32/include/platform/dma.h
@@ -57,8 +57,6 @@ typedef enum {
 #define DMA_OUTPUT_INDEX    0
 #define DMA_OUTPUT_STRING   "DMA%d Stream %d:"
 
-#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
-
 #define DEFINE_DMA_CHANNEL(d, s, f) { \
     .dma = d, \
     .ref = (dmaResource_t *)d ## _Stream ## s, \

--- a/src/platform/AT32/include/platform/dma.h
+++ b/src/platform/AT32/include/platform/dma.h
@@ -53,8 +53,6 @@ typedef enum {
 #define DMA_DEVICE_NO(x)    ((((x)-1) / 7) + 1)
 #define DMA_DEVICE_INDEX(x) ((((x)-1) % 7) + 1)
 
-#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
-
 uint32_t dmaGetChannel(const uint8_t channel);
 
 #define DMA_OUTPUT_INDEX    0

--- a/src/platform/AT32/include/platform/dma.h
+++ b/src/platform/AT32/include/platform/dma.h
@@ -32,7 +32,8 @@
 
 typedef enum {
     DMA_NONE = 0,
-    DMA1_CH1_HANDLER = 1,
+    DMA_FIRST_HANDLER = 1,
+    DMA1_CH1_HANDLER = DMA_FIRST_HANDLER,
     DMA1_CH2_HANDLER,
     DMA1_CH3_HANDLER,
     DMA1_CH4_HANDLER,
@@ -52,11 +53,12 @@ typedef enum {
 #define DMA_DEVICE_NO(x)    ((((x)-1) / 7) + 1)
 #define DMA_DEVICE_INDEX(x) ((((x)-1) % 7) + 1)
 
+#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
+
 uint32_t dmaGetChannel(const uint8_t channel);
 
 #define DMA_OUTPUT_INDEX    0
 #define DMA_OUTPUT_STRING   "DMA%d Channel %d:"
-#define DMA_INPUT_STRING    "DMA%d_CH%d"
 
 #define DEFINE_DMA_CHANNEL(d, c, f) { \
     .dma = d, \

--- a/src/platform/SIMULATOR/include/platform/dma.h
+++ b/src/platform/SIMULATOR/include/platform/dma.h
@@ -25,3 +25,5 @@
     DMA_NONE = 0,
     DMA_LAST_HANDLER = DMA_NONE
 } dmaIdentifier_e;
+
+#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)

--- a/src/platform/SIMULATOR/include/platform/dma.h
+++ b/src/platform/SIMULATOR/include/platform/dma.h
@@ -23,7 +23,6 @@
 
  typedef enum {
     DMA_NONE = 0,
+    DMA_FIRST_HANDLER = DMA_NONE,
     DMA_LAST_HANDLER = DMA_NONE
 } dmaIdentifier_e;
-
-#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)

--- a/src/platform/STM32/include/platform/dma.h
+++ b/src/platform/STM32/include/platform/dma.h
@@ -23,8 +23,6 @@
 
 #include "platform.h"
 
-#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
-
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32G4) || defined(STM32H7) || defined(APM32F4)
 #define PLATFORM_TRAIT_DMA_STREAM_REQUIRED 1
 #endif

--- a/src/platform/STM32/include/platform/dma.h
+++ b/src/platform/STM32/include/platform/dma.h
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#define DMA_IDENTIFIER_TO_INDEX(x) ((x) - 1)
+
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32G4) || defined(STM32H7) || defined(APM32F4)
 #define PLATFORM_TRAIT_DMA_STREAM_REQUIRED 1
 #endif
@@ -40,7 +42,8 @@
 
 typedef enum {
     DMA_NONE = 0,
-    DMA1_ST0_HANDLER = 1,
+    DMA_FIRST_HANDLER = 1,
+    DMA1_ST0_HANDLER = DMA_FIRST_HANDLER,
     DMA1_ST1_HANDLER,
     DMA1_ST2_HANDLER,
     DMA1_ST3_HANDLER,
@@ -63,7 +66,6 @@ typedef enum {
 #define DMA_DEVICE_INDEX(x) ((((x)-1) % 8))
 #define DMA_OUTPUT_INDEX    0
 #define DMA_OUTPUT_STRING   "DMA%d Stream %d:"
-#define DMA_INPUT_STRING    "DMA%d_ST%d"
 
 #define DEFINE_DMA_CHANNEL(d, s, f) { \
     .dma = d, \
@@ -101,7 +103,8 @@ void dmaMuxEnable(dmaIdentifier_e identifier, uint32_t dmaMuxId);
 
 typedef enum {
     DMA_NONE = 0,
-    DMA1_CH1_HANDLER = 1,
+    DMA_FIRST_HANDLER = 1,
+    DMA1_CH1_HANDLER = DMA_FIRST_HANDLER,
     DMA1_CH2_HANDLER,
     DMA1_CH3_HANDLER,
     DMA1_CH4_HANDLER,
@@ -129,7 +132,8 @@ uint32_t dmaGetChannel(const uint8_t channel);
 
 typedef enum {
     DMA_NONE = 0,
-    DMA1_CH1_HANDLER = 1,
+    DMA_FIRST_HANDLER = 1,
+    DMA1_CH1_HANDLER = DMA_FIRST_HANDLER,
     DMA1_CH2_HANDLER,
     DMA1_CH3_HANDLER,
     DMA1_CH4_HANDLER,
@@ -146,7 +150,6 @@ typedef enum {
 
 #define DMA_OUTPUT_INDEX    0
 #define DMA_OUTPUT_STRING   "DMA%d Channel %d:"
-#define DMA_INPUT_STRING    "DMA%d_CH%d"
 
 #define DEFINE_DMA_CHANNEL(d, c, f) { \
     .dma = d, \


### PR DESCRIPTION
 dmaIdentifier_e could be zero based in the future and align to descriptor array index directly

Also removed unused DMA_INPUT_STRING



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved consistency of DMA handler identifiers across platforms by introducing a named constant for the first handler and updating related macros.
  - Removed unused string macros for DMA input formatting.
  - Standardized the conversion of DMA identifiers to zero-based indices.
- **Chores**
  - Cleaned up and streamlined macro definitions related to DMA handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->