### PR TITLE
Move beeper pwm functions to platform.

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -64,8 +64,6 @@ typedef struct servoDevConfig_s {
 
 void servoDevInit(const servoDevConfig_t *servoDevConfig);
 
-void pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse);
-
 void pwmOutConfig(timerChannel_t *channel, const timerHardware_t *timerHardware, uint32_t hz, uint16_t period, uint16_t value, uint8_t inversion);
 
 void pwmWriteServo(uint8_t index, float value);

--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -34,48 +34,6 @@
 static IO_t beeperIO = DEFIO_IO(NONE);
 static bool beeperInverted = false;
 static uint16_t beeperFrequency = 0;
-
-#ifdef USE_PWM_OUTPUT
-static pwmOutputPort_t beeperPwm;
-static uint16_t freqBeep = 0;
-
-static void pwmWriteBeeper(bool on)
-{
-    if (!beeperPwm.io) {
-        return;
-    }
-
-    if (on) {
-        *beeperPwm.channel.ccr = (PWM_TIMER_1MHZ / freqBeep) / 2;
-        beeperPwm.enabled = true;
-    } else {
-        *beeperPwm.channel.ccr = 0;
-        beeperPwm.enabled = false;
-    }
-}
-
-static void pwmToggleBeeper(void)
-{
-    pwmWriteBeeper(!beeperPwm.enabled);
-}
-
-static void beeperPwmInit(const ioTag_t tag, uint16_t frequency)
-{
-    const timerHardware_t *timer = timerAllocate(tag, OWNER_BEEPER, 0);
-    IO_t beeperIO = IOGetByTag(tag);
-
-    if (beeperIO && timer) {
-        beeperPwm.io = beeperIO;
-        IOInit(beeperPwm.io, OWNER_BEEPER, 0);
-        IOConfigGPIOAF(beeperPwm.io, IOCFG_AF_PP, timer->alternateFunction);
-        freqBeep = frequency;
-        pwmOutConfig(&beeperPwm.channel, timer, PWM_TIMER_1MHZ, PWM_TIMER_1MHZ / freqBeep, (PWM_TIMER_1MHZ / freqBeep) / 2, 0);
-
-        *beeperPwm.channel.ccr = 0;
-        beeperPwm.enabled = false;
-    }
-}
-#endif
 #endif
 
 void systemBeep(bool onoff)

--- a/src/main/drivers/sound_beeper.h
+++ b/src/main/drivers/sound_beeper.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/io_types.h"
+
 #ifdef USE_BEEPER
 #define BEEP_TOGGLE              systemBeepToggle()
 #define BEEP_OFF                 systemBeep(false)

--- a/src/main/drivers/sound_beeper.h
+++ b/src/main/drivers/sound_beeper.h
@@ -34,3 +34,8 @@ void systemBeep(bool on);
 void systemBeepToggle(void);
 struct beeperDevConfig_s;
 void beeperInit(const struct beeperDevConfig_s *beeperDevConfig);
+
+// platform implementation
+void pwmWriteBeeper(bool on);
+void pwmToggleBeeper(void);
+void beeperPwmInit(const ioTag_t tag, uint16_t frequency);

--- a/src/platform/APM32/mk/APM32F4.mk
+++ b/src/platform/APM32/mk/APM32F4.mk
@@ -154,6 +154,7 @@ MCU_COMMON_SRC = \
         APM32/startup/system_apm32f4xx.c \
         drivers/inverter.c \
         drivers/dshot_bitbang_decode.c \
+        common/stm32/pwm_output_beeper.c \
         common/stm32/pwm_output_dshot_shared.c \
         common/stm32/dshot_dpwm.c \
         common/stm32/dshot_bitbang_shared.c \
@@ -221,6 +222,7 @@ SIZE_OPTIMISED_SRC += \
         drivers/bus_spi_config.c \
         common/stm32/bus_i2c_pinconfig.c \
         common/stm32/bus_spi_pinconfig.c \
+        common/stm32/pwm_output_beeper.c \
         common/stm32/serial_uart_pinconfig.c \
         drivers/serial_escserial.c \
         drivers/serial_pinconfig.c

--- a/src/platform/AT32/mk/AT32F4.mk
+++ b/src/platform/AT32/mk/AT32F4.mk
@@ -115,6 +115,7 @@ MCU_COMMON_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/dshot_bitbang_decode.c \
             drivers/inverter.c \
+            common/stm32/pwm_output_beeper.c \
             common/stm32/pwm_output_dshot_shared.c \
             common/stm32/dshot_dpwm.c \
             common/stm32/dshot_bitbang_shared.c \
@@ -148,6 +149,7 @@ SIZE_OPTIMISED_SRC += \
             drivers/bus_spi_config.c \
             common/stm32/bus_i2c_pinconfig.c \
             common/stm32/bus_spi_pinconfig.c \
+            common/stm32/pwm_output_beeper.c \
             common/stm32/serial_uart_pinconfig.c \
             drivers/serial_escserial.c \
             drivers/serial_pinconfig.c

--- a/src/platform/STM32/mk/STM32_COMMON.mk
+++ b/src/platform/STM32/mk/STM32_COMMON.mk
@@ -16,6 +16,7 @@ MCU_COMMON_SRC += \
             common/stm32/dshot_dpwm.c \
             STM32/pwm_output_hw.c \
             common/stm32/pwm_output_dshot_shared.c \
+            common/stm32/pwm_output_beeper.c \
             common/stm32/dshot_bitbang_shared.c
 
 SIZE_OPTIMISED_SRC += \
@@ -24,6 +25,7 @@ SIZE_OPTIMISED_SRC += \
             common/stm32/bus_i2c_pinconfig.c \
             common/stm32/config_flash.c \
             common/stm32/bus_spi_pinconfig.c \
+            common/stm32/pwm_output_beeper.c \
             common/stm32/serial_uart_pinconfig.c
 
 SPEED_OPTIMISED_SRC += \

--- a/src/platform/common/stm32/pwm_output_beeper.c
+++ b/src/platform/common/stm32/pwm_output_beeper.c
@@ -32,7 +32,7 @@ static uint16_t freqBeep = 0;
 
 void pwmWriteBeeper(bool on)
 {
-    if (!beeperPwm.io) {
+    if (!beeperPwm.io || freqBeep == 0) {
         return;
     }
 

--- a/src/platform/common/stm32/pwm_output_beeper.c
+++ b/src/platform/common/stm32/pwm_output_beeper.c
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+
+#if defined(USE_BEEPER) && defined(USE_PWM_OUTPUT)
+
+#include "drivers/pwm_output.h"
+
+static pwmOutputPort_t beeperPwm;
+static uint16_t freqBeep = 0;
+
+void pwmWriteBeeper(bool on)
+{
+    if (!beeperPwm.io) {
+        return;
+    }
+
+    if (on) {
+        *beeperPwm.channel.ccr = (PWM_TIMER_1MHZ / freqBeep) / 2;
+        beeperPwm.enabled = true;
+    } else {
+        *beeperPwm.channel.ccr = 0;
+        beeperPwm.enabled = false;
+    }
+}
+
+void pwmToggleBeeper(void)
+{
+    pwmWriteBeeper(!beeperPwm.enabled);
+}
+
+void beeperPwmInit(const ioTag_t tag, uint16_t frequency)
+{
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_BEEPER, 0);
+    IO_t beeperIO = IOGetByTag(tag);
+
+    if (beeperIO && timer) {
+        beeperPwm.io = beeperIO;
+        IOInit(beeperPwm.io, OWNER_BEEPER, 0);
+        IOConfigGPIOAF(beeperPwm.io, IOCFG_AF_PP, timer->alternateFunction);
+        freqBeep = frequency;
+        pwmOutConfig(&beeperPwm.channel, timer, PWM_TIMER_1MHZ, PWM_TIMER_1MHZ / freqBeep, (PWM_TIMER_1MHZ / freqBeep) / 2, 0);
+
+        *beeperPwm.channel.ccr = 0;
+        beeperPwm.enabled = false;
+    }
+}
+
+#endif


### PR DESCRIPTION
Move the pwm implementations of sound beeper functions from main/drivers/sound_beeper.c to 
the platform area, to allow for different implementations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced PWM-based beeper control for supported platforms, enabling more flexible and precise beeper operation.
- **Bug Fixes**
  - Improved beeper compatibility by updating platform support and integrating new beeper control methods.
- **Chores**
  - Updated build configurations to include the new PWM beeper implementation for relevant hardware platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->