### PR TITLE
Fix ICM426XX_RA_DEVICE_CONFIG

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -61,7 +61,7 @@
 #define ICM426XX_CLKIN_FREQ                         32000
 
 // Soft Reset
-#define ICM426XX_RA_DEVICE_CONFIG                   0x17
+#define ICM426XX_RA_DEVICE_CONFIG                   0x11
 #define DEVICE_CONFIG_SOFT_RESET_BIT                (1 << 0) // Soft reset bit
 
 #define ICM426XX_RA_REG_BANK_SEL                    0x76


### PR DESCRIPTION
Decimal value had been taken from the data sheet, not the hex value.

From https://invensense.tdk.com/wp-content/uploads/2020/04/ds-000347_icm-42688-p-datasheet.pdf section 13.1:

![image](https://github.com/user-attachments/assets/d4d3955e-676b-42b8-a25d-5a68343ed1f5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the register address used for soft reset in the ICM426xx SPI driver to ensure proper device operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->