### PR TITLE
Add PICO EXTI support

### DIFF
--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -64,7 +64,7 @@ void dmaMuxEnable(dmaIdentifier_e identifier, uint32_t dmaMuxId);
 
 dmaIdentifier_e dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);
 void dmaEnable(dmaIdentifier_e identifier);
-void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam);
+void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority);
 
 dmaIdentifier_e dmaGetIdentifier(const dmaResource_t* channel);
 const resourceOwner_t *dmaGetOwner(dmaIdentifier_e identifier);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1830,7 +1830,7 @@ case MSP_NAME:
         }
 
         for (int i = 0; i < 8; i++) {
-            for (unsigned j; j < ARRAYLEN(gyroDeviceConfig(i)->customAlignment.raw); j++) {
+            for (unsigned j = 0; j < ARRAYLEN(gyroDeviceConfig(i)->customAlignment.raw); j++) {
                 sbufWriteU16(dst, i < GYRO_COUNT ? gyroDeviceConfig(i)->customAlignment.raw[j] : 0);
             }
         }

--- a/src/platform/PICO/bus_spi_pico.c
+++ b/src/platform/PICO/bus_spi_pico.c
@@ -33,7 +33,7 @@
 #include "platform.h"
 
 #ifdef USE_SPI
-#define TESTING_NO_DMA 1
+//#define TESTING_NO_DMA 1
 
 #include "common/maths.h"
 #include "drivers/bus.h"
@@ -43,6 +43,7 @@
 #include "drivers/io.h"
 #include "drivers/io_def.h"
 #include "drivers/io_impl.h"
+#include "drivers/nvic.h"
 
 #include "hardware/spi.h"
 #include "hardware/gpio.h"
@@ -125,6 +126,8 @@ const spiHardware_t spiHardware[] = {
         },
     },
 };
+
+extern busDevice_t spiBusDevice[SPIDEV_COUNT];
 
 void spiPinConfigure(const struct spiPinConfig_s *pConfig)
 {
@@ -242,11 +245,122 @@ void spiInitDevice(SPIDevice device)
     gpio_set_function(IO_PINBYTAG(spi->sck), GPIO_FUNC_SPI);
 }
 
+void spiInternalStopDMA (const extDevice_t *dev)
+{
+    dmaChannelDescriptor_t *dmaRx = dev->bus->dmaRx;
+    dmaChannelDescriptor_t *dmaTx = dev->bus->dmaTx;
+
+    if (dmaRx && dma_channel_is_busy(dmaRx->channel)) {
+        // Abort active DMA -  this should never happen
+        dma_channel_abort(dmaRx->channel);
+    }
+
+    if (dmaTx && dma_channel_is_busy(dmaTx->channel)) {
+        // Abort active DMA -  this should never happen as Tx should complete before Rx
+        dma_channel_abort(dmaTx->channel);
+    }
+}
+
+
+// Interrupt handler for SPI receive DMA completion
+FAST_IRQ_HANDLER static void spiRxIrqHandler(dmaChannelDescriptor_t* descriptor)
+{
+    const extDevice_t *dev = (const extDevice_t *)descriptor->userParam;
+
+    if (!dev) {
+        return;
+    }
+
+    busDevice_t *bus = dev->bus;
+
+    if (bus->curSegment->negateCS) {
+        // Negate Chip Select
+        IOHi(dev->busType_u.spi.csnPin);
+    }
+
+    spiInternalStopDMA(dev);
+
+#ifdef __DCACHE_PRESENT
+#ifdef STM32H7
+    if (bus->curSegment->u.buffers.rxData &&
+        ((bus->curSegment->u.buffers.rxData < &_dmaram_start__) || (bus->curSegment->u.buffers.rxData >= &_dmaram_end__))) {
+#else
+    if (bus->curSegment->u.buffers.rxData) {
+#endif
+         // Invalidate the D cache covering the area into which data has been read
+        SCB_InvalidateDCache_by_Addr(
+            (uint32_t *)((uint32_t)bus->curSegment->u.buffers.rxData & ~CACHE_LINE_MASK),
+            (((uint32_t)bus->curSegment->u.buffers.rxData & CACHE_LINE_MASK) +
+              bus->curSegment->len - 1 + CACHE_LINE_SIZE) & ~CACHE_LINE_MASK);
+    }
+#endif // __DCACHE_PRESENT
+
+    spiIrqHandler(dev);
+}
+
+#if 0
+// Interrupt handler for SPI transmit DMA completion
+FAST_IRQ_HANDLER static void spiTxIrqHandler(dmaChannelDescriptor_t* descriptor)
+{
+    const extDevice_t *dev = (const extDevice_t *)descriptor->userParam;
+
+    if (!dev) {
+        return;
+    }
+
+    busDevice_t *bus = dev->bus;
+
+    spiInternalStopDMA(dev);
+
+    if (bus->curSegment->negateCS) {
+        // Negate Chip Select
+        IOHi(dev->busType_u.spi.csnPin);
+    }
+
+    spiIrqHandler(dev);
+}
+#endif
+
+extern dmaChannelDescriptor_t dmaDescriptors[];
+
 void spiInitBusDMA(void)
 {
-  //TODO: implement
-  // if required to set up mappings of peripherals to DMA instances?
-  // can just start off with dma_claim_unused_channel in spiInternalInitStream?
+    for (uint32_t device = 0; device < SPIDEV_COUNT; device++) {
+        busDevice_t *bus = &spiBusDevice[device];
+        int32_t channel_tx;
+        int32_t channel_rx;
+
+        if (bus->busType != BUS_TYPE_SPI) {
+            // This bus is not in use
+            continue;
+        }
+
+        channel_tx = dma_claim_unused_channel(true);
+        if (channel_tx == -1) {
+            // no more available channels so give up
+            return;
+        }
+
+        channel_rx = dma_claim_unused_channel(true);
+        if (channel_rx == -1) {
+            // no more available channels so give up, first releasing the one
+            // channel we did claim
+            dma_channel_unclaim(channel_tx);
+            return;
+        }
+
+        bus->dmaTx = &dmaDescriptors[DMA_CHANNEL_TO_INDEX(channel_tx)];
+        bus->dmaTx->channel = channel_tx;
+
+        bus->dmaRx = &dmaDescriptors[DMA_CHANNEL_TO_INDEX(channel_rx)];
+        bus->dmaRx->channel = channel_rx;
+
+        // The transaction concludes when the data has been received which will be after transmission is complete
+        dmaSetHandler(DMA_CHANNEL_TO_IDENTIFIER(bus->dmaRx->channel), spiRxIrqHandler, NVIC_PRIO_SPI_DMA);
+
+        // We got the required resources, so we can use DMA on this bus
+        bus->useDMA = true;
+    }
 }
 
 void spiInternalResetStream(dmaChannelDescriptor_t *descriptor)
@@ -271,26 +385,22 @@ void spiInternalInitStream(const extDevice_t *dev, bool preInit)
 #else
     UNUSED(preInit);
 
-    int dma_tx = dma_claim_unused_channel(true);
-    int dma_rx = dma_claim_unused_channel(true);
-
-    dev->bus->dmaTx->channel = dma_tx;
-    dev->bus->dmaRx->channel = dma_rx;
-    dev->bus->dmaTx->irqHandlerCallback = NULL;
-    dev->bus->dmaRx->irqHandlerCallback = spiInternalResetStream; // TODO: implement - correct callback
-
     const spiDevice_t *spi = &spiDevice[spiDeviceByInstance(dev->bus->busType_u.spi.instance)];
-    dma_channel_config config = dma_channel_get_default_config(dma_tx);
+    dma_channel_config config = dma_channel_get_default_config(dev->bus->dmaTx->channel);
     channel_config_set_transfer_data_size(&config, DMA_SIZE_8);
+    channel_config_set_read_increment(&config, true);
+    channel_config_set_write_increment(&config, false);
     channel_config_set_dreq(&config, spi_get_dreq(SPI_INST(spi->dev), true));
 
-    dma_channel_configure(dma_tx, &config, &spi_get_hw(SPI_INST(spi->dev))->dr, dev->txBuf, 0, false);
+    dma_channel_configure(dev->bus->dmaTx->channel, &config, &spi_get_hw(SPI_INST(spi->dev))->dr, dev->txBuf, 0, false);
 
-    config = dma_channel_get_default_config(dma_rx);
+    config = dma_channel_get_default_config(dev->bus->dmaRx->channel);
     channel_config_set_transfer_data_size(&config, DMA_SIZE_8);
+    channel_config_set_read_increment(&config, false);
+    channel_config_set_write_increment(&config, true);
     channel_config_set_dreq(&config, spi_get_dreq(SPI_INST(spi->dev), false));
 
-    dma_channel_configure(dma_rx, &config, dev->rxBuf, &spi_get_hw(SPI_INST(spi->dev))->dr, 0, false);
+    dma_channel_configure(dev->bus->dmaRx->channel, &config, dev->rxBuf, &spi_get_hw(SPI_INST(spi->dev))->dr, 0, false);
 #endif
 }
 
@@ -300,12 +410,13 @@ void spiInternalStartDMA(const extDevice_t *dev)
 #ifndef USE_DMA
     UNUSED(dev);
 #else
+    dev->bus->dmaRx->userParam = (uint32_t)dev;
+
     // TODO check correct, was len + 1 now len
     dma_channel_set_trans_count(dev->bus->dmaTx->channel, dev->bus->curSegment->len, false);
     dma_channel_set_trans_count(dev->bus->dmaRx->channel, dev->bus->curSegment->len, false);
 
-    dma_channel_start(dev->bus->dmaTx->channel);
-    dma_channel_start(dev->bus->dmaRx->channel);
+    dma_start_channel_mask((1 << dev->bus->dmaTx->channel) | (1 << dev->bus->dmaRx->channel));
 #endif
 }
     

--- a/src/platform/PICO/exti_pico.c
+++ b/src/platform/PICO/exti_pico.c
@@ -80,6 +80,9 @@ void EXTIInit(void)
 
     // Register the shared handler for GPIO interrupts
     gpio_set_irq_callback(EXTI_IRQHandler);
+
+    // Enable the interrupt
+    irq_set_enabled(IO_IRQ_BANK0, true);
 }
 
 void EXTIHandlerInit(extiCallbackRec_t *self, extiHandlerCallback *fn)
@@ -89,10 +92,10 @@ void EXTIHandlerInit(extiCallbackRec_t *self, extiHandlerCallback *fn)
 
 void EXTIEnable(IO_t io)
 {
-    gpio_set_irq_enabled(IO_Pin(io), 0, true);
+    gpio_set_irq_enabled(IO_Pin(io), extiEventMask[IO_Pin(io)], true);
 }
 
 void EXTIDisable(IO_t io)
 {
-    gpio_set_irq_enabled(IO_Pin(io), extiEventMask[IO_Pin(io)], false);
+    gpio_set_irq_enabled(IO_Pin(io), 0, false);
 }

--- a/src/platform/PICO/exti_pico.c
+++ b/src/platform/PICO/exti_pico.c
@@ -19,22 +19,67 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string.h>
 #include "drivers/exti.h"
 #include "common/utils.h"
+#include "drivers/io_impl.h"
+
+#include "hardware/gpio.h"
+
+typedef struct {
+    extiCallbackRec_t* handler;
+} extiChannelRec_t;
+
+static extiChannelRec_t extiChannelRecs[DEFIO_USED_COUNT];
+static uint32_t extiEventMask[DEFIO_USED_COUNT];
 
 void EXTIConfig(IO_t io, extiCallbackRec_t *cb, int irqPriority, ioConfig_t config, extiTrigger_t trigger)
 {
-    UNUSED(io);
-    UNUSED(cb);
-    UNUSED(irqPriority);
-    UNUSED(config);
-    UNUSED(trigger);
+    uint32_t gpio = IO_Pin(io);
+
+    UNUSED(irqPriority); // Just stick with default GPIO irq priority for now
+    UNUSED(config); // TODO consider pullup/pulldown etc. Needs fixing first in platform.h
+
+    // Ensure the GPIO is initialised and not being used for some other function
+    gpio_init(gpio);
+
+    extiChannelRec_t *rec = &extiChannelRecs[gpio];
+    rec->handler = cb;
+
+    switch(trigger) {
+    case BETAFLIGHT_EXTI_TRIGGER_RISING:
+    default:
+        extiEventMask[gpio] = GPIO_IRQ_EDGE_RISE;
+        break;
+
+    case BETAFLIGHT_EXTI_TRIGGER_FALLING:
+        extiEventMask[gpio] = GPIO_IRQ_EDGE_FALL;
+        break;
+
+    case BETAFLIGHT_EXTI_TRIGGER_BOTH:
+        extiEventMask[gpio] = GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL;
+        break;
+    }
+}
+
+static void EXTI_IRQHandler(uint gpio, uint32_t event_mask)
+{
+    // Call the registered handler for this GPIO
+    if (extiChannelRecs[gpio].handler) {
+        extiChannelRecs[gpio].handler->fn(extiChannelRecs[gpio].handler);
+    }
+
+    // Acknowledge the interrupt
+    gpio_acknowledge_irq(gpio, event_mask);
 }
 
 void EXTIInit(void)
 {
-    //TODO: implement
-    // NOOP
+    // Clear all the callbacks
+    memset(extiChannelRecs, 0, sizeof(extiChannelRecs));
+
+    // Register the shared handler for GPIO interrupts
+    gpio_set_irq_callback(EXTI_IRQHandler);
 }
 
 void EXTIHandlerInit(extiCallbackRec_t *self, extiHandlerCallback *fn)
@@ -44,6 +89,10 @@ void EXTIHandlerInit(extiCallbackRec_t *self, extiHandlerCallback *fn)
 
 void EXTIEnable(IO_t io)
 {
-    //TODO: implement
-    UNUSED(io);
+    gpio_set_irq_enabled(IO_Pin(io), 0, true);
+}
+
+void EXTIDisable(IO_t io)
+{
+    gpio_set_irq_enabled(IO_Pin(io), extiEventMask[IO_Pin(io)], false);
 }

--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -61,7 +61,6 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 //#define SystemCoreClock
 //#define EXTI_TypeDef
 //#define EXTI_InitTypeDef
-//#define IRQn_Type           void*
 
 // We have to use SPI0_Type (or void) because config will pass in SPI0, SPI1,
 // which are defined in pico-sdk as SPI0_Type*.

--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -45,7 +45,7 @@
 #define USBD_PRODUCT_STRING     "Betaflight RP2350B"
 #endif
 
-#define USE_MULTICORE
+//#define USE_MULTICORE
 #define USE_IO
 #define USE_UART0
 #define USE_UART1

--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -53,6 +53,7 @@
 #define USE_SPI
 #define USE_SPI_DEVICE_0
 #define USE_SPI_DEVICE_1
+#define USE_SPI_DMA_ENABLE_LATE
 
 #define USE_I2C
 #define USE_I2C_DEVICE_0


### PR DESCRIPTION
Merge after https://github.com/betaflight/betaflight/pull/14483

Adds EXTI support.

Gyro is now showing `locked` and `dma`.

```
# status
MCU RP2350B Clock=150MHz
Stack size: 4096, Stack address: 0x20082000
Configuration: CONFIGURED, size: 2763, max available: 65536
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1 locked dma
GYRO=ICM42688P, ACC=ICM42688P, BARO=DPS310
System Uptime: 10 seconds, Current Time: 2025-06-29T21:51:59.739+00:00
CPU:35%, cycle time: 123, GYRO rate: 8130, RX rate: 0, System rate: 9
Voltage: 0 * 0.01V (0S battery - INIT)
I2C Errors: 0
Arming disable flags: RXLOSS CALIB CLI MSP
```