### PR TITLE
Move DMA IRQ acknowledge to before the callback as it's edge triggered

### DIFF
--- a/src/platform/PICO/bus_spi_pico.c
+++ b/src/platform/PICO/bus_spi_pico.c
@@ -160,18 +160,6 @@ void spiPinConfigure(const struct spiPinConfig_s *pConfig)
     }
 }
 
-/*
-  static spi_inst_t *getSpiInstanceByDevice(SPI_TypeDef *spi)
-{
-    if (spi == SPI0) {
-        return spi0;
-    } else if (spi == SPI1) {
-        return spi1;
-    }
-    return NULL;
-}
-*/
-
 static void spiSetClockFromSpeed(spi_inst_t *spi, uint16_t speed)
 {
     uint32_t freq = spiCalculateClock(speed);
@@ -219,14 +207,6 @@ Must be SPI_MSB_FIRST, no other values supported on the PL022
 
 void spiInitDevice(SPIDevice device)
 {
-  // maybe here set getSpiInstanceByDevice(spi->dev) SPI device with
-  // settings like
-  // STM does
-  //SetRXFIFOThreshold ...QF (1/4 full presumably)
-  //         Init -> full duplex, master, 8biut, baudrate, MSBfirst, no CRC,
-  //                  Clock = PolarityHigh, Phase_2Edge
-
-  
     const spiDevice_t *spi = &spiDevice[device];
 
     if (!spi->dev) {

--- a/src/platform/PICO/dma_pico.c
+++ b/src/platform/PICO/dma_pico.c
@@ -63,21 +63,23 @@ void dma_irq_handler(bool isIrq1)
     // channel equates to index in the dmaDescriptors array
     for (uint8_t channel = 0; channel < DMA_LAST_HANDLER; channel++) {
         if (status & (1u << channel)) {
-            uint8_t index = DMA_CHANNEL_TO_INDEX(channel);
-            // Call the handler if it is set
-            if (dmaDescriptors[index].irqHandlerCallback) {
-                dmaDescriptors[index].irqHandlerCallback(&dmaDescriptors[index]);
-            }
-
-            // Acknowledge the interrupt for this channel
+            // Acknowledge the interrupt for this channel as it is edge, not
+            // level triggered and the callback may trigger another DMA
             if (isIrq1) {
                 dma_channel_acknowledge_irq1(channel);
             } else {
                 dma_channel_acknowledge_irq0(channel);
             }
+
+            uint8_t index = DMA_CHANNEL_TO_INDEX(channel);
+            // Call the handler if it is set
+            if (dmaDescriptors[index].irqHandlerCallback) {
+                dmaDescriptors[index].irqHandlerCallback(&dmaDescriptors[index]);
+            }
         }
     }
 }
+
 void dma_irq0_handler(void)
 {
     dma_irq_handler(false);


### PR DESCRIPTION
Prior to this PR `spiRxIrqHandler()` was only called once, there being no subsequent call corresponding to the fresh transfer initiated by the second `spiInternalStartDMA()` call.

![image](https://github.com/user-attachments/assets/190b998f-4c2e-4ae0-bb4d-fc931661ca94)

With this PR the second interrupt occurs.

![image](https://github.com/user-attachments/assets/fba114f7-b71f-40a2-8c66-8527ff784c4f)
