### PR TITLE
Fix missing #if for PINIO_COUNT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SERIAL_DEVICE   ?= $(firstword $(wildcard /dev/ttyACM*) $(firstword $(wildcard /
 FLASH_SIZE ?=
 
 # Disabled build flags
-CFLAGS_DISABLED         :=
+CFLAGS_DISABLED         ?=
 
 ###############################################################################
 # Things that need to be maintained as the source changes
@@ -348,6 +348,8 @@ LD_FLAGS     = -lm \
               -T$(LD_SCRIPT) \
                $(EXTRA_LD_FLAGS)
 endif
+
+LTO_FLAGS               := $(filter-out $(CFLAGS_DISABLED), $(LTO_FLAGS))
 
 ###############################################################################
 # No user-serviceable parts below

--- a/src/main/cms/cms_menu_firmware.c
+++ b/src/main/cms/cms_menu_firmware.c
@@ -196,7 +196,9 @@ static const void *cmsx_FirmwareInit(displayPort_t *pDisp)
     UNUSED(pDisp);
 
     strncpy(manufacturerId, getManufacturerId(), MAX_MANUFACTURER_ID_LENGTH + 1);
+    manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
     strncpy(boardName, getBoardName(), MAX_BOARD_NAME_LENGTH + 1);
+    boardName[MAX_BOARD_NAME_LENGTH] = 0;
 
     return NULL;
 }

--- a/src/main/fc/board_info.c
+++ b/src/main/fc/board_info.c
@@ -43,7 +43,9 @@ void initBoardInformation(void)
     boardInformationSet = boardConfig()->boardInformationSet;
     if (boardInformationSet) {
         strncpy(manufacturerId, boardConfig()->manufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
+        manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
         strncpy(boardName, boardConfig()->boardName, MAX_BOARD_NAME_LENGTH + 1);
+        boardName[MAX_BOARD_NAME_LENGTH] = 0;
     }
 #endif
 
@@ -87,6 +89,7 @@ bool setManufacturerId(const char *newManufacturerId)
 #if !defined(BOARD_NAME)
     if (!boardInformationSet || strlen(manufacturerId) == 0) {
         strncpy(manufacturerId, newManufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
+        manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
 
         boardInformationWasUpdated = true;
 
@@ -105,6 +108,7 @@ bool setBoardName(const char *newBoardName)
 #if !defined(BOARD_NAME)
     if (!boardInformationSet || strlen(boardName) == 0) {
         strncpy(boardName, newBoardName, MAX_BOARD_NAME_LENGTH + 1);
+        boardName[MAX_BOARD_NAME_LENGTH] = 0;
 
         boardInformationWasUpdated = true;
 

--- a/src/main/pg/pinio.c
+++ b/src/main/pg/pinio.c
@@ -104,9 +104,11 @@ void pgResetFn_pinioConfig(pinioConfig_t *config)
     config->config[1] = PINIO2_CONFIG;
     config->config[2] = PINIO3_CONFIG;
     config->config[3] = PINIO4_CONFIG;
+#if PINIO_COUNT > 4
     config->config[4] = PINIO5_CONFIG;
     config->config[5] = PINIO6_CONFIG;
     config->config[6] = PINIO7_CONFIG;
     config->config[7] = PINIO8_CONFIG;
+#endif
 }
 #endif


### PR DESCRIPTION
Allow user to supply CFLAGS_DISABLED to Makefile.
Fix missing #if..endif for PINIO_COUNT in pinio.c. 
Fix other strncpy build warning/errors for build with CFLAGS_DISABLED="-flto=auto".



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured proper null-termination of manufacturer and board name strings to improve reliability and prevent potential string handling issues.
  * Corrected configuration logic for pin assignments to prevent out-of-bounds or unnecessary settings when the pin count is four or fewer.

* **Chores**
  * Improved build configuration by allowing disabled compiler flags to propagate correctly to link-time optimization flags, enhancing build flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->