### PR TITLE
Fix length for manufacturer and board name

### DIFF
--- a/src/main/cms/cms_menu_firmware.c
+++ b/src/main/cms/cms_menu_firmware.c
@@ -195,9 +195,9 @@ static const void *cmsx_FirmwareInit(displayPort_t *pDisp)
 {
     UNUSED(pDisp);
 
-    strncpy(manufacturerId, getManufacturerId(), MAX_MANUFACTURER_ID_LENGTH + 1);
+    strncpy(manufacturerId, getManufacturerId(), MAX_MANUFACTURER_ID_LENGTH);
     manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
-    strncpy(boardName, getBoardName(), MAX_BOARD_NAME_LENGTH + 1);
+    strncpy(boardName, getBoardName(), MAX_BOARD_NAME_LENGTH);
     boardName[MAX_BOARD_NAME_LENGTH] = 0;
 
     return NULL;

--- a/src/main/fc/board_info.c
+++ b/src/main/fc/board_info.c
@@ -42,9 +42,9 @@ void initBoardInformation(void)
 #if !defined(BOARD_NAME)
     boardInformationSet = boardConfig()->boardInformationSet;
     if (boardInformationSet) {
-        strncpy(manufacturerId, boardConfig()->manufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
+        strncpy(manufacturerId, boardConfig()->manufacturerId, MAX_MANUFACTURER_ID_LENGTH);
         manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
-        strncpy(boardName, boardConfig()->boardName, MAX_BOARD_NAME_LENGTH + 1);
+        strncpy(boardName, boardConfig()->boardName, MAX_BOARD_NAME_LENGTH);
         boardName[MAX_BOARD_NAME_LENGTH] = 0;
     }
 #endif
@@ -88,7 +88,7 @@ bool setManufacturerId(const char *newManufacturerId)
 {
 #if !defined(BOARD_NAME)
     if (!boardInformationSet || strlen(manufacturerId) == 0) {
-        strncpy(manufacturerId, newManufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
+        strncpy(manufacturerId, newManufacturerId, MAX_MANUFACTURER_ID_LENGTH);
         manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
 
         boardInformationWasUpdated = true;
@@ -107,7 +107,7 @@ bool setBoardName(const char *newBoardName)
 {
 #if !defined(BOARD_NAME)
     if (!boardInformationSet || strlen(boardName) == 0) {
-        strncpy(boardName, newBoardName, MAX_BOARD_NAME_LENGTH + 1);
+        strncpy(boardName, newBoardName, MAX_BOARD_NAME_LENGTH);
         boardName[MAX_BOARD_NAME_LENGTH] = 0;
 
         boardInformationWasUpdated = true;
@@ -126,8 +126,10 @@ bool persistBoardInformation(void)
 {
 #if !defined(BOARD_NAME)
     if (boardInformationWasUpdated) {
-        strncpy(boardConfigMutable()->manufacturerId, manufacturerId, MAX_MANUFACTURER_ID_LENGTH + 1);
-        strncpy(boardConfigMutable()->boardName, boardName, MAX_BOARD_NAME_LENGTH + 1);
+        strncpy(boardConfigMutable()->manufacturerId, manufacturerId, MAX_MANUFACTURER_ID_LENGTH);
+        boardConfigMutable()->manufacturerId[MAX_MANUFACTURER_ID_LENGTH] = 0;
+        strncpy(boardConfigMutable()->boardName, boardName, MAX_BOARD_NAME_LENGTH);
+        boardConfigMutable()->boardName[MAX_BOARD_NAME_LENGTH] = 0;
         boardConfigMutable()->boardInformationSet = true;
 
         initBoardInformation();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of manufacturer ID and board name strings to prevent potential buffer overflows and ensure proper null-termination. This enhances reliability when displaying or storing these fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->