### PR TITLE
Fix a CLI status crash when no gyro present

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4738,7 +4738,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
     }
 #ifdef USE_SPI
     if (!gyroActiveDev()) {
-        cliPrintf(" none!");
+        cliPrintf(" not active");
     } else {
         if (gyroActiveDev()->gyroModeSPI != GYRO_EXTI_NO_INT) {
             cliPrintf(" locked");


### PR DESCRIPTION
Fix a CLI status crash when no gyro present.

Allow for looking at status in CLI when there's no active gyro device (most likely when debugging / new board etc.).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by handling cases where no active gyro device is present, preventing potential errors and displaying "not active" in the CLI when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->