### PR TITLE
accgyro_mpu initialise gyro->segments.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -491,6 +491,12 @@ bool mpuDetect(gyroDev_t *gyro, const gyroDeviceConfig_t *config)
 
 void mpuGyroInit(gyroDev_t *gyro)
 {
+    // Initialise both segments of gyro->segments.
+    // Gyro code only sets the first segment. The second segment stays as
+    // an end segment with negateCS false, which enforces DMA whenever possible.
+    busSegment_t nullSegment = {.u.link = {NULL, NULL}, 0, false, NULL};
+    gyro->segments[0] = nullSegment;
+    gyro->segments[1] = nullSegment;
     gyro->accDataReg = MPU_RA_ACCEL_XOUT_H;
     gyro->gyroDataReg = MPU_RA_GYRO_XOUT_H;
     mpuIntExtiInit(gyro);


### PR DESCRIPTION
accgyro_mpu initialise gyro->segments.

Explicitly initialising to null / false, should be no change in behaviour because was zero-initialised on
account of being member of member of global variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of gyro segments to ensure both segments are properly set, enhancing stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->