### PR TITLE
PICO: Removing the flash CS pin as it will be defined in config.h

### DIFF
--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -247,7 +247,7 @@
 #define SPI1_SDO_PIN         PA27
 
 #define SDCARD_CS_PIN        PA25
-#define FLASH_CS_PIN         PA25
+
 #define MAX7456_SPI_CS_PIN   PA17
 
 #define GYRO_1_CS_PIN        PA1


### PR DESCRIPTION
Removing this pin definition from target.h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated hardware pin configuration by removing the definition for the flash chip select pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->