### PR TITLE
FIX: Skip undetected gyros (blocking VCP connection)

### DIFF
--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -663,16 +663,8 @@ bool gyroInit(void)
 
     // If no gyros are enabled but some are detected, enable at least the first detected gyro
     // This prevents lockups when configuration is inconsistent
-    if (gyro.gyroEnabledBitmask == 0 && gyroDetectedFlags != 0) {
-        // Find the first detected gyro and enable it
-        for (int i = 0; i < GYRO_COUNT; i++) {
-            if (gyroDetectedFlags & GYRO_MASK(i)) {
-                gyro.gyroEnabledBitmask = GYRO_MASK(i);
-                break;
-            }
-        }
-    }
-
+    // use lowest set bit from detected flags
+    gyro.gyroEnabledBitmask = gyroDetectedFlags & -gyroDetectedFlags;
     if (gyroConfigMutable()->gyro_enabled_bitmask != gyro.gyroEnabledBitmask) {
         gyroConfigMutable()->gyro_enabled_bitmask = gyro.gyroEnabledBitmask;
         eepromWriteRequired = true;


### PR DESCRIPTION
- fixes #14536
- (fixes my broken STELLARH7DEV board now connecting and showing IMU 3 and 4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and enablement of multiple gyros, ensuring all configured gyros are scanned and reducing the risk of system lockups in multi-gyro setups.
  * Added safe default settings when no gyros are detected to enhance system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->