### PR TITLE
Add SD card support to PICO

### DIFF
--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -88,6 +88,11 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 
 #define SCHEDULER_DELAY_LIMIT           10
 
+// There is no library definition for pupd, so define one here
+#define GPIO_PULLUP     1
+#define GPIO_PULLDOWN   2
+
+// speed will either GPIO_SLEW_RATE_SLOW or GPIO_SLEW_RATE_FAST
 #define IO_CONFIG(mode, speed, pupd) ((mode) | ((speed) << 2) | ((pupd) << 5))
 
 // TODO update these and IOConfigGPIO
@@ -104,7 +109,8 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 #define SPI_IO_AF_SCK_CFG_HIGH  0
 #define SPI_IO_AF_SCK_CFG_LOW   0
 #define SPI_IO_AF_SDI_CFG       0
-#define SPI_IO_CS_CFG           IO_CONFIG(GPIO_OUT, 0, 0) // todo pullup/down etc.
+#define SPI_IO_CS_CFG           IO_CONFIG(GPIO_OUT, 0, 0)
+#define SPI_IO_CS_HIGH_CFG      IO_CONFIG(GPIO_IN, 0, GPIO_PULLUP)
 
 
 #define SERIAL_UART_FIRST_INDEX     0

--- a/src/platform/PICO/io_pico.c
+++ b/src/platform/PICO/io_pico.c
@@ -141,6 +141,7 @@ SPI_IO_CS_HIGH_CFG (as defined)
         gpio_init(ioPin);
     }
     gpio_set_dir(ioPin, (cfg & 0x01)); // 0 = in, 1 = out
+    gpio_set_pulls(ioPin, cfg & GPIO_PULLUP, cfg & GPIO_PULLDOWN);
 }
 
 IO_t IOGetByTag(ioTag_t tag)

--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -70,7 +70,6 @@
 #undef USE_TRANSPONDER
 #undef USE_FLASH
 #undef USE_FLASH_CHIP
-#undef USE_SDCARD
 
 #undef USE_TIMER
 #undef USE_RCC


### PR DESCRIPTION
This PR adds SD card support, but note that USB MSC is not yet supported, so the SD card must be removed to be read.

Also note that this is mutually exclusive with the MAX7456 OSD on the `HELLBENDER_0001` card as both SD and MAX7456 share bus 1.