### PR TITLE
Add VTX power control for HUMMINGBIRD RSV2

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5190,6 +5190,9 @@ const cliResourceValue_t resourceTable[] = {
     DEFS( OWNER_VTX_DATA,      PG_VTX_IO_CONFIG, vtxIOConfig_t, dataTag ),
     DEFS( OWNER_VTX_CLK,       PG_VTX_IO_CONFIG, vtxIOConfig_t, clockTag ),
 #endif
+#ifdef RTC6705_DYNAMIC_POWER_CTRL
+    DEFA( OWNER_VTX_POWER,     PG_VTX_IO_CONFIG, vtxIOConfig_t, exPowerTag, VTX_DYNAMIC_CTRL_PIN_COUNT),
+#endif
 #ifdef USE_PIN_PULL_UP_DOWN
     DEFA( OWNER_PULLUP,        PG_PULLUP_CONFIG,   pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),
     DEFA( OWNER_PULLDOWN,      PG_PULLDOWN_CONFIG, pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -45,6 +45,11 @@ static uint8_t cmsx_vtxChannel;
 static uint8_t cmsx_vtxPower;
 static uint8_t cmsx_vtxPit;
 
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+static uint8_t lastVtxBand;
+static uint8_t lastVtxChannel;
+#endif
+
 static OSD_TAB_t entryVtxBand;
 static OSD_TAB_t entryVtxChannel;
 static OSD_TAB_t entryVtxPower;
@@ -59,6 +64,12 @@ static void cmsx_Vtx_ConfigRead(void)
 {
     vtxCommonGetBandAndChannel(vtxCommonDevice(), &cmsx_vtxBand, &cmsx_vtxChannel);
     vtxCommonGetPowerIndex(vtxCommonDevice(), &cmsx_vtxPower);
+
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+    lastVtxBand = cmsx_vtxBand;
+    lastVtxChannel = cmsx_vtxChannel;
+#endif
+
     unsigned status;
     if (vtxCommonGetStatus(vtxCommonDevice(), &status)) {
         cmsx_vtxPit = status & VTX_STATUS_PIT_MODE ? 2 : 1;
@@ -117,6 +128,32 @@ static const void *cmsx_Vtx_onBandChange(displayPort_t *pDisp, const void *self)
     if (cmsx_vtxBand == 0) {
         cmsx_vtxBand = 1;
     }
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+    for (uint8_t band = 0; band < VTX_TABLE_MAX_BANDS; band++) {
+        if (cmsx_vtxBand < (VTX_TABLE_MAX_BANDS + 1)) {
+            if (vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand, cmsx_vtxChannel) == 0) {
+                for (uint8_t channel = 1; channel < (VTX_TABLE_MAX_CHANNELS + 1); channel++) {
+                    if (vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand, channel) != 0) {
+                        lastVtxChannel = cmsx_vtxChannel = channel;
+                        lastVtxBand = cmsx_vtxBand;
+                        return NULL;
+                    }
+                }
+                if ((lastVtxBand - cmsx_vtxBand) > 0) {
+                    cmsx_vtxBand--;
+                } else {
+                    cmsx_vtxBand++;
+                }
+            } else {
+                lastVtxBand = cmsx_vtxBand;
+                break;
+            }
+        } else {
+            cmsx_vtxBand = lastVtxBand;
+            break;
+        }
+    }
+#endif
     return NULL;
 }
 
@@ -127,6 +164,25 @@ static const void *cmsx_Vtx_onChanChange(displayPort_t *pDisp, const void *self)
     if (cmsx_vtxChannel == 0) {
         cmsx_vtxChannel = 1;
     }
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+    for (uint8_t channel = 0; channel < VTX_TABLE_MAX_CHANNELS; channel++) {
+        if (cmsx_vtxChannel < (VTX_TABLE_MAX_CHANNELS + 1)) {
+            if (vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand, cmsx_vtxChannel) == 0) {
+                if ((lastVtxChannel - cmsx_vtxChannel) > 0) {
+                    cmsx_vtxChannel--;
+                } else {
+                    cmsx_vtxChannel++;
+                }
+            } else {
+                lastVtxChannel = cmsx_vtxChannel;
+                break;
+            }
+        } else {
+            cmsx_vtxChannel = lastVtxChannel;
+            break;
+        }
+    }
+#endif
     return NULL;
 }
 

--- a/src/main/drivers/vtx_rtc6705.h
+++ b/src/main/drivers/vtx_rtc6705.h
@@ -31,7 +31,14 @@
 
 #include "pg/vtx_io.h"
 
-#define VTX_RTC6705_POWER_COUNT           2
+#if defined(RTC6705_DYNAMIC_POWER_CTRL)
+    #define VTX_RTC6705_POWER_COUNT       4
+    #define VTX_DYNAMIC_CTRL_PIN_COUNT    2
+#elif defined(RTC6705_EXPAND_POWER_CTRL)
+    #define VTX_RTC6705_POWER_COUNT       3
+#else
+    #define VTX_RTC6705_POWER_COUNT       2
+#endif
 
 #define VTX_RTC6705_FREQ_MIN    5600
 #define VTX_RTC6705_FREQ_MAX    5950

--- a/src/main/pg/vtx_io.c
+++ b/src/main/pg/vtx_io.c
@@ -45,6 +45,12 @@ void pgResetFn_vtxIOConfig(vtxIOConfig_t *vtxIOConfig)
     vtxIOConfig->clockTag = IO_TAG(RTC6705_SPICLK_PIN);
     vtxIOConfig->dataTag = IO_TAG(RTC6705_SPI_SDO_PIN);
 
+    // external power controller
+#ifdef RTC6705_DYNAMIC_POWER_CTRL
+    vtxIOConfig->exPowerTag[0] = IO_TAG(RTC6705_EX_POWER_1_PIN);
+    vtxIOConfig->exPowerTag[1] = IO_TAG(RTC6705_EX_POWER_2_PIN);
+#endif
+
     // hardware spi
     vtxIOConfig->spiDevice = SPI_DEV_TO_CFG(spiDeviceByInstance(RTC6705_SPI_INSTANCE));
 }

--- a/src/main/pg/vtx_io.h
+++ b/src/main/pg/vtx_io.h
@@ -35,6 +35,11 @@ typedef struct vtxIOConfig_s {
     ioTag_t dataTag;
     ioTag_t clockTag;
 
+    // setting for dynamic VTx power control
+#ifdef RTC6705_DYNAMIC_POWER_CTRL
+    ioTag_t exPowerTag[2];
+#endif
+
     // settings for hardware SPI only
     uint8_t spiDevice;
 } vtxIOConfig_t;


### PR DESCRIPTION
Hi betaflight team,
We are submitting this pull request to enable proper VTX power control for the HUMMINGBIRD RSV2.
The purpose of this PR is to control the VTX power level by sending specific level signals from two standard GPIOs to our custom OSD board.
To ensure this implementation is clean and does not interfere with any other targets, the entire logic is wrapped in preprocessor macros. The code will only be compiled when the specific macro  is defined for the target, making the changes completely isolated.
We believe this is a safe and non-intrusive way to add support for our hardware. Looking forward to your feedback!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic power control on RTC6705 VTX, enabling multiple GPIO pins to control power levels.
  * Enhanced VTX band and channel selection to automatically skip invalid or empty entries, improving user navigation.

* **Bug Fixes**
  * Prevented selection of invalid VTX frequencies by maintaining and restoring the last valid band and channel.

* **Configuration**
  * Introduced new configuration options for dynamic power control pins in VTX settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->