### PR TITLE
Add support for cms_skip_empty_vtx_table_entries to rtc_6705_ex_power_control 

### DIFF
--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -45,6 +45,11 @@ static uint8_t cmsx_vtxChannel;
 static uint8_t cmsx_vtxPower;
 static uint8_t cmsx_vtxPit;
 
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+static uint8_t lastVtxBand;
+static uint8_t lastVtxChannel;
+#endif
+
 static OSD_TAB_t entryVtxBand;
 static OSD_TAB_t entryVtxChannel;
 static OSD_TAB_t entryVtxPower;
@@ -59,6 +64,12 @@ static void cmsx_Vtx_ConfigRead(void)
 {
     vtxCommonGetBandAndChannel(vtxCommonDevice(), &cmsx_vtxBand, &cmsx_vtxChannel);
     vtxCommonGetPowerIndex(vtxCommonDevice(), &cmsx_vtxPower);
+
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+    lastVtxBand = cmsx_vtxBand;
+    lastVtxChannel = cmsx_vtxChannel;
+#endif
+
     unsigned status;
     if (vtxCommonGetStatus(vtxCommonDevice(), &status)) {
         cmsx_vtxPit = status & VTX_STATUS_PIT_MODE ? 2 : 1;
@@ -117,6 +128,25 @@ static const void *cmsx_Vtx_onBandChange(displayPort_t *pDisp, const void *self)
     if (cmsx_vtxBand == 0) {
         cmsx_vtxBand = 1;
     }
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+    // Find a valid frequency for current band/channel combination
+    if (vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand, cmsx_vtxChannel) == 0) {
+        // Try to find a valid channel in current band
+        for (uint8_t channel = 1; channel <= VTX_TABLE_MAX_CHANNELS; channel++) {
+            if (vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand, channel) != 0) {
+                cmsx_vtxChannel = channel;
+                lastVtxBand = cmsx_vtxBand;
+                lastVtxChannel = cmsx_vtxChannel;
+                return NULL;
+            }
+        }
+        // No valid channel found in current band, revert to last valid band
+        cmsx_vtxBand = lastVtxBand;
+    } else {
+        // Current combination is valid, update tracking
+        lastVtxBand = cmsx_vtxBand;
+    }
+#endif
     return NULL;
 }
 
@@ -127,6 +157,15 @@ static const void *cmsx_Vtx_onChanChange(displayPort_t *pDisp, const void *self)
     if (cmsx_vtxChannel == 0) {
         cmsx_vtxChannel = 1;
     }
+#ifdef CMS_SKIP_EMPTY_VTX_TABLE_ENTRIES
+    // If current channel is invalid, revert to last valid channel
+    if (vtxCommonLookupFrequency(vtxCommonDevice(), cmsx_vtxBand, cmsx_vtxChannel) == 0) {
+        cmsx_vtxChannel = lastVtxChannel;
+    } else {
+        // Current channel is valid, update tracking
+        lastVtxChannel = cmsx_vtxChannel;
+    }
+#endif
     return NULL;
 }
 


### PR DESCRIPTION
Hi Betaflight team,
The rtc_6705_ex_power_control feature provides RF power control for the HUMMINGBIRD RSV2.
It operates by connecting two general-purpose GPIOs from the FC to the pins of a custom OSD chip. The RF power is then adjusted by transmitting signals through toggling the GPIO levels.
cms_skip_empty_vtx_table_entries is part of this implementation. The code is included via a macro to ensure it is self-contained and does not interfere with any other part of the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for VTX band and channel selection to prevent choosing empty or invalid frequency entries.
  * Added automatic fallback to the last valid band or channel if an invalid selection is made, ensuring stable operation when navigating VTX settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->