### PR TITLE
Add support for rtc6705_dynamic_power_ctrl to rtc_6705_ex_power_control

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5190,6 +5190,9 @@ const cliResourceValue_t resourceTable[] = {
     DEFS( OWNER_VTX_DATA,      PG_VTX_IO_CONFIG, vtxIOConfig_t, dataTag ),
     DEFS( OWNER_VTX_CLK,       PG_VTX_IO_CONFIG, vtxIOConfig_t, clockTag ),
 #endif
+#ifdef RTC6705_DYNAMIC_POWER_CTRL
+    DEFA( OWNER_VTX_POWER,     PG_VTX_IO_CONFIG, vtxIOConfig_t, exPowerTag, VTX_DYNAMIC_CTRL_PIN_COUNT),
+#endif
 #ifdef USE_PIN_PULL_UP_DOWN
     DEFA( OWNER_PULLUP,        PG_PULLUP_CONFIG,   pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),
     DEFA( OWNER_PULLDOWN,      PG_PULLDOWN_CONFIG, pinPullUpDownConfig_t, ioTag, PIN_PULL_UP_DOWN_COUNT ),

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -115,12 +115,13 @@ bool rtc6705IOInit(const vtxIOConfig_t *vtxIOConfig)
 
 #ifdef RTC6705_DYNAMIC_POWER_CTRL
     for (unsigned i = 0; i < VTX_DYNAMIC_CTRL_PIN_COUNT; i++) {
-        exPowerPin[i] = IOGetByTag(vtxIOConfig->exPowerTag[i]);
-        if (exPowerPin[i]) {
-            IOInit(exPowerPin[i], OWNER_VTX_POWER, i + 1);
-            IOLo(exPowerPin[i]);
-            IOConfigGPIO(exPowerPin[i], IOCFG_OUT_PP);
+        IO_t io = IOGetByTag(vtxIOConfig->exPowerTag[i]);
+        if (io) {
+            IOInit(io, OWNER_VTX_POWER, i + 1);
+            IOLo(io);
+            IOConfigGPIO(io, IOCFG_OUT_PP);
         }
+        exPowerPin[i] = io;
     }
 #endif
 

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -114,7 +114,7 @@ bool rtc6705IOInit(const vtxIOConfig_t *vtxIOConfig)
     }
 
 #ifdef RTC6705_DYNAMIC_POWER_CTRL
-    for (uint8_t i = 0; i < VTX_DYNAMIC_CTRL_PIN_COUNT; i++) {
+    for (unsigned i = 0; i < VTX_DYNAMIC_CTRL_PIN_COUNT; i++) {
         exPowerPin[i] = IOGetByTag(vtxIOConfig->exPowerTag[i]);
         if (exPowerPin[i]) {
             IOInit(exPowerPin[i], OWNER_VTX_POWER, i + 1);

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -199,12 +199,8 @@ void rtc6705DynamicPowerControl(uint8_t power)
 {
     power &= 0x03; // mask lsb 2 bits, vtx power value should be 0~3
 
-    for (uint8_t i = 0; i < VTX_DYNAMIC_CTRL_PIN_COUNT; i++) {
-        if (power & (0x01 << i)) {
-            IOHi(exPowerPin[i]);
-        } else {
-            IOLo(exPowerPin[i]);
-        }
+    for (unsigned i = 0; i < VTX_DYNAMIC_CTRL_PIN_COUNT; i++) {
+        IOWrite(exPowerPin[i], power & (0x01 << i));
     }
 }
 #endif

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -207,11 +207,7 @@ void rtc6705DynamicPowerControl(uint8_t power)
 
 void rtc6705SetRFPower(uint8_t rf_power)
 {
-#if defined(RTC6705_EXPAND_POWER_CTRL) || defined(RTC6705_DYNAMIC_POWER_CTRL)
-    rf_power = constrain(rf_power, 0, VTX_RTC6705_POWER_COUNT);
-#else
-    rf_power = constrain(rf_power, 1, 2);
-#endif
+    rf_power = constrain(rf_power, 1, VTX_RTC6705_POWER_COUNT);
 
 #if defined(RTC6705_EXPAND_POWER_CTRL)
     if (rf_power > 0) {

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -197,7 +197,7 @@ void rtc6705SetFrequency(uint16_t frequency)
 #ifdef RTC6705_DYNAMIC_POWER_CTRL
 void rtc6705DynamicPowerControl(uint8_t power)
 {
-    power &= 0x03; // mask lsb 2 bits, vtx power value should be 0~3
+    power &= (1 << VTX_DYNAMIC_CTRL_PIN_COUNT) - 1; // mask lsb 2 bits, vtx power value should be 0~3
 
     for (unsigned i = 0; i < VTX_DYNAMIC_CTRL_PIN_COUNT; i++) {
         IOWrite(exPowerPin[i], power & (0x01 << i));

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -57,7 +57,7 @@ static IO_t vtxPowerPin     = IO_NONE;
 #endif
 
 #ifdef RTC6705_DYNAMIC_POWER_CTRL
-static IO_t exPowerPin[VTX_DYNAMIC_CTRL_PIN_COUNT]   = {IO_NONE, IO_NONE};
+static IO_t exPowerPin[VTX_DYNAMIC_CTRL_PIN_COUNT]   = {0};
 #endif
 
 static extDevice_t *dev = NULL;

--- a/src/main/drivers/vtx_rtc6705.c
+++ b/src/main/drivers/vtx_rtc6705.c
@@ -207,16 +207,13 @@ void rtc6705DynamicPowerControl(uint8_t power)
 
 void rtc6705SetRFPower(uint8_t rf_power)
 {
+#if defined(RTC6705_DYNAMIC_POWER_CTRL)
+    rf_power = constrain(rf_power, 0, VTX_RTC6705_POWER_COUNT);
+#else 
     rf_power = constrain(rf_power, 1, VTX_RTC6705_POWER_COUNT);
+#endif    
 
-#if defined(RTC6705_EXPAND_POWER_CTRL)
-    if (rf_power > 0) {
-        rtc6705Enable();
-        rf_power = (rf_power > 1) ? (1) : (2);
-    } else {
-        rtc6705Disable();
-    }
-#elif defined(RTC6705_DYNAMIC_POWER_CTRL)
+#if defined(RTC6705_DYNAMIC_POWER_CTRL)
     rtc6705DynamicPowerControl(rf_power);
 #endif
 

--- a/src/main/drivers/vtx_rtc6705.h
+++ b/src/main/drivers/vtx_rtc6705.h
@@ -31,7 +31,14 @@
 
 #include "pg/vtx_io.h"
 
-#define VTX_RTC6705_POWER_COUNT           2
+#if defined(RTC6705_DYNAMIC_POWER_CTRL)
+    #define VTX_RTC6705_POWER_COUNT       4
+    #define VTX_DYNAMIC_CTRL_PIN_COUNT    2
+#elif defined(RTC6705_EXPAND_POWER_CTRL)
+    #define VTX_RTC6705_POWER_COUNT       3
+#else
+    #define VTX_RTC6705_POWER_COUNT       2
+#endif
 
 #define VTX_RTC6705_FREQ_MIN    5600
 #define VTX_RTC6705_FREQ_MAX    5950

--- a/src/main/drivers/vtx_rtc6705.h
+++ b/src/main/drivers/vtx_rtc6705.h
@@ -34,8 +34,6 @@
 #if defined(RTC6705_DYNAMIC_POWER_CTRL)
     #define VTX_RTC6705_POWER_COUNT       4
     #define VTX_DYNAMIC_CTRL_PIN_COUNT    2
-#elif defined(RTC6705_EXPAND_POWER_CTRL)
-    #define VTX_RTC6705_POWER_COUNT       3
 #else
     #define VTX_RTC6705_POWER_COUNT       2
 #endif

--- a/src/main/pg/vtx_io.c
+++ b/src/main/pg/vtx_io.c
@@ -45,6 +45,12 @@ void pgResetFn_vtxIOConfig(vtxIOConfig_t *vtxIOConfig)
     vtxIOConfig->clockTag = IO_TAG(RTC6705_SPICLK_PIN);
     vtxIOConfig->dataTag = IO_TAG(RTC6705_SPI_SDO_PIN);
 
+    // external power controller
+#ifdef RTC6705_DYNAMIC_POWER_CTRL
+    vtxIOConfig->exPowerTag[0] = IO_TAG(RTC6705_EX_POWER_1_PIN);
+    vtxIOConfig->exPowerTag[1] = IO_TAG(RTC6705_EX_POWER_2_PIN);
+#endif
+
     // hardware spi
     vtxIOConfig->spiDevice = SPI_DEV_TO_CFG(spiDeviceByInstance(RTC6705_SPI_INSTANCE));
 }

--- a/src/main/pg/vtx_io.h
+++ b/src/main/pg/vtx_io.h
@@ -35,6 +35,11 @@ typedef struct vtxIOConfig_s {
     ioTag_t dataTag;
     ioTag_t clockTag;
 
+    // setting for dynamic VTx power control
+#ifdef RTC6705_DYNAMIC_POWER_CTRL
+    ioTag_t exPowerTag[2];
+#endif
+
     // settings for hardware SPI only
     uint8_t spiDevice;
 } vtxIOConfig_t;


### PR DESCRIPTION
Hi Betaflight team,
This PR introduces the implementation for rtc6705_dynamic_power_ctrl, which is another part of the rtc_6705_ex_power_control feature.This new component is responsible for the GPIO output operations, managing the signals to set the corresponding power levels.The implementation is encapsulated within macros to ensure it remains self-contained and does not interfere with any other code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for dynamic VTx power control on RTC6705, enabling more granular power levels (up to 4 states).
  * Configuration now allows assigning external power-control pins for dynamic control.

* **Improvements**
  * Initialization and handling of external power pins improved for dynamic-power configurations.
  * RF power input is clamped to valid range and mapped to the new power-level scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->