### PR TITLE
Fix camera control

### DIFF
--- a/src/platform/STM32/camera_control_stm32.c
+++ b/src/platform/STM32/camera_control_stm32.c
@@ -36,7 +36,7 @@
 #ifdef CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
 void cameraControlHardwarePwmInit(timerChannel_t *channel, const timerHardware_t *timerHardware, uint8_t inverted)
 {
-    pwmOutConfig(channel, timerHardware, timerClock(TIM6), CAMERA_CONTROL_PWM_RESOLUTION, 0, inverted);
+    pwmOutConfig(channel, timerHardware, timerClock(timerHardware->tim), CAMERA_CONTROL_PWM_RESOLUTION, 0, inverted);
 }
 #endif
 

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -263,6 +263,15 @@ extern uint8_t _dmaram_end__;
 #define USE_TIMER_MGMT
 #define USE_TIMER_AF
 
+// Camera control PWM availability per STM32 family
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
+#define CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
+#endif
+
+#if defined(STM32F4)
+#define CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE
+#endif
+
 #if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
 
 // speed is packed between modebits 4 and 1,


### PR DESCRIPTION
- fixes #14416
- tested on SPEEDYBEEF7V3

```
TIM5:
    CH1 : CAMERA_CONTROL
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hardware PWM support for additional STM32 families (F4, F7, H7, G4) and software PWM availability for F4 to broaden camera control compatibility.

* **Bug Fixes**
  * PWM setup now uses the actual timer instance allocated at runtime, improving reliability and consistency of camera control timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->