### PR TITLE
PICO Fix: don't use IO_Pin(0) in exti_pico.c. Implement EXTIRelease

### DIFF
--- a/src/platform/PICO/bus_i2c_pico.c
+++ b/src/platform/PICO/bus_i2c_pico.c
@@ -430,12 +430,13 @@ void i2cInit(I2CDevice device)
 
     const IO_t scl = pDev->scl;
     const IO_t sda = pDev->sda;
-    const uint8_t sclPin = IO_Pin(scl);
-    const uint8_t sdaPin = IO_Pin(sda);
 
     if (!hardware || !scl || !sda) {
         return;
     }
+
+    const uint8_t sclPin = IO_Pin(scl);
+    const uint8_t sdaPin = IO_Pin(sda);
 
     // Set owners
     IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(device));


### PR DESCRIPTION
PICO Fix: don't use IO_Pin(0) in exti_pico.c

Guard against use of IO_Pin(0) in exti_pico.c.
Implement EXTIRelease.

These allow for scanning of more Gyro devices (which might or might not be present), when GYRO_1_EXTI_PIN is set.

Avoid IO_Pin(0) in bus_i2c_pico.c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved I2C initialization reliability by validating hardware and pins before use, preventing crashes with invalid configurations.
  - Added safeguards in external interrupt setup and control to handle missing or invalid inputs, reducing rare runtime faults and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->