### PR TITLE
Remove Dynamic Idle PID DTerm smoothing filter

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -233,9 +233,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             float minRps = getMinMotorFrequencyHz();
             DEBUG_SET(DEBUG_DYN_IDLE, 3, lrintf(minRps * 10.0f));
             float rpsError = mixerRuntime.dynIdleMinRps - minRps;
-            // PT1 type lowpass delay and smoothing for D
-            minRps = mixerRuntime.prevMinRps + mixerRuntime.minRpsDelayK * (minRps - mixerRuntime.prevMinRps);
-            float dynIdleD = (mixerRuntime.prevMinRps - minRps) * mixerRuntime.dynIdleDGain;
+            float dynIdleD = -mixerRuntime.dynIdleDGain * (minRps - mixerRuntime.prevMinRps);
             mixerRuntime.prevMinRps = minRps;
             float dynIdleP = rpsError * mixerRuntime.dynIdlePGain;
             rpsError = MAX(-0.1f, rpsError); //I rises fast, falls slowly

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -343,12 +343,11 @@ void mixerInitProfile(void)
     }
     mixerRuntime.dynIdlePGain = currentPidProfile->dyn_idle_p_gain * 0.00015f;
     mixerRuntime.dynIdleIGain = currentPidProfile->dyn_idle_i_gain * 0.01f * pidGetDT();
-    mixerRuntime.dynIdleDGain = currentPidProfile->dyn_idle_d_gain * 0.0000003f * pidGetPidFrequency();
+    mixerRuntime.dynIdleDGain = currentPidProfile->dyn_idle_d_gain * 0.0000003f * pidGetPidFrequency() * 800 * pidGetDT() / 20.0f;
     mixerRuntime.dynIdleMaxIncrease = currentPidProfile->dyn_idle_max_increase * 0.001f;
     // before takeoff, use the static idle value as the dynamic idle limit.
     // whoop users should first adjust static idle to ensure reliable motor start before enabling dynamic idle
     mixerRuntime.dynIdleStartIncrease = motorConfig()->motorIdle * 0.0001f;
-    mixerRuntime.minRpsDelayK = 800 * pidGetDT() / 20.0f; //approx 20ms D delay, arbitrarily suits many motors
     if (!mixerRuntime.feature3dEnabled && mixerRuntime.dynIdleMinRps) {
         mixerRuntime.motorOutputLow = DSHOT_MIN_THROTTLE; // Override value set by initEscEndpoints to allow zero motor drive
     }

--- a/src/main/flight/mixer_init.h
+++ b/src/main/flight/mixer_init.h
@@ -45,7 +45,6 @@ typedef struct mixerRuntime_s {
     float dynIdleIGain;
     float dynIdleDGain;
     float dynIdleI;
-    float minRpsDelayK;
 #endif
 #if defined(USE_BATTERY_VOLTAGE_SAG_COMPENSATION)
     float vbatSagCompensationFactor;


### PR DESCRIPTION
- not implemented due to comment in #14592

> Problem is that you still need to calculate filtered minRps (to set prevMinRps). Without it you remove PT1 part (and apply wrong scaling to D term)

