### PR TITLE
Temporary fix to blackbox header file

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1757,13 +1757,15 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR, "%d",          rxConfig()->rc_smoothing_auto_factor_rpy);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR_THROTTLE, "%d", rxConfig()->rc_smoothing_auto_factor_throttle);
 
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_FEEDFORWARD_CUTOFF, "%d", rcSmoothingData->setpointCutoffSetting);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_SETPOINT_CUTOFF, "%d",    rcSmoothingData->setpointCutoffSetting);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_THROTTLE_CUTOFF, "%d",    rcSmoothingData->throttleCutoffSetting);
 
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_DEBUG_AXIS, "%d",         rcSmoothingData->debugAxis);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_DEBUG_AXIS, "%d",        rcSmoothingData->debugAxis);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_ACTIVE_CUTOFFS, "%d,%d", rcSmoothingData->setpointCutoffFrequency,
-                                                                            rcSmoothingData->throttleCutoffFrequency);
-        BLACKBOX_PRINT_HEADER_LINE("rc_smoothing_rx_smoothed", "%d",        lrintf(getCurrentRxRateHz()));
+                                                                                    rcSmoothingData->setpointCutoffFrequency, // feedforward cutoff == setpoint cutoff
+                                                                                    rcSmoothingData->throttleCutoffFrequency);
+        BLACKBOX_PRINT_HEADER_LINE("rc_smoothing_rx_smoothed", "%d",                lrintf(getCurrentRxRateHz()));
 #endif // USE_RC_SMOOTHING_FILTER
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RATES_TYPE, "%d",             currentControlRateProfile->rates_type);
 

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1761,11 +1761,12 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_SETPOINT_CUTOFF, "%d",    rcSmoothingData->setpointCutoffSetting);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_THROTTLE_CUTOFF, "%d",    rcSmoothingData->throttleCutoffSetting);
 
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_DEBUG_AXIS, "%d",        rcSmoothingData->debugAxis);
-        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_ACTIVE_CUTOFFS, "%d,%d", rcSmoothingData->setpointCutoffFrequency,
-                                                                                    rcSmoothingData->setpointCutoffFrequency, // feedforward cutoff == setpoint cutoff
-                                                                                    rcSmoothingData->throttleCutoffFrequency);
-        BLACKBOX_PRINT_HEADER_LINE("rc_smoothing_rx_smoothed", "%d",                lrintf(getCurrentRxRateHz()));
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_DEBUG_AXIS, "%d",           rcSmoothingData->debugAxis);
+
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RC_SMOOTHING_ACTIVE_CUTOFFS, "%d,%d,%d", rcSmoothingData->setpointCutoffFrequency,
+                                                                                       rcSmoothingData->setpointCutoffFrequency, // feedforward cutoff == setpoint cutoff
+                                                                                       rcSmoothingData->throttleCutoffFrequency);
+        BLACKBOX_PRINT_HEADER_LINE("rc_smoothing_rx_smoothed", "%d",                   lrintf(getCurrentRxRateHz()));
 #endif // USE_RC_SMOOTHING_FILTER
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_RATES_TYPE, "%d",             currentControlRateProfile->rates_type);
 


### PR DESCRIPTION
Since PR #14411, there is no longer an independent rcSmoothing  feedforward value; it is always the same as setpoint.

When the blackbox header fields are written, previously there were three: feedforward, setpoint, throttle.  Now there are only these two: setpoint and throttle.

This causes a problem that log viewer still has 'spaces' for three parameters, but unfortunately now we only send two, with the result that the 'throttle' cutoff is now displayed in the 'feedforward' cutoff box, and the throttle cutoff box is empty.

This PR makes a simple, temporary fix, where the header includes three values, the first two of which are setpoint values, and the third is throttle.

This displays the correct values in the log header.

If someone later updates the log viewer header display code, so that it correctly handles only two cutoffs starting from 4.6, that's fine; at that point this PR can easily be reverted.

image shows the display after 14411:
<img width="603" height="276" alt="Screenshot 2025-08-15 at 4 19 45 pm" src="https://github.com/user-attachments/assets/924ee490-b08c-425f-b28e-2e5a20fd3a3d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added an extra cutoff value and header to diagnostic logs to show feedforward cutoff alongside existing cutoff values, improving debug visibility.
  * Reformatted and realigned several diagnostic log lines for clearer readability.
  * Purely cosmetic logging changes — no behavioral, settings, or performance changes; no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->