### PR TITLE
BUG: CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE not available on F411 (only F405)

### DIFF
--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -268,7 +268,7 @@ extern uint8_t _dmaram_end__;
 #define CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
 #endif
 
-#if defined(STM32F4)
+#if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
 #define CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE
 #endif
 

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -268,7 +268,7 @@ extern uint8_t _dmaram_end__;
 #define CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
 #endif
 
-#if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
+#if defined(STM32F405)
 #define CAMERA_CONTROL_SOFTWARE_PWM_AVAILABLE
 #endif
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Software-based camera control is now enabled only on STM32F405 within the STM32F4 family; other STM32F4 variants no longer enable it.

* **Notes**
  * Hardware PWM availability for supported families (STM32F4/F7/H7/G4) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->