### PR TITLE
Default to 2 point FF averaging and alter debug

### DIFF
--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -551,7 +551,7 @@ static FAST_CODE_NOINLINE void calculateFeedforward(const pidRuntime_t *pid, fli
         DEBUG_SET(DEBUG_FEEDFORWARD, 0, lrintf(setpoint));
         DEBUG_SET(DEBUG_FEEDFORWARD, 1, lrintf(setpointSpeed * 0.01f));
         DEBUG_SET(DEBUG_FEEDFORWARD, 2, lrintf(feedforwardBoost * 0.01f));
-        DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDelta * 10.0f));
+        DEBUG_SET(DEBUG_FEEDFORWARD, 3, lrintf(rcCommandDeltaAbs * 10.0f));
         DEBUG_SET(DEBUG_FEEDFORWARD, 4, lrintf(jitterAttenuator * 100.0f));
         DEBUG_SET(DEBUG_FEEDFORWARD, 5, (int16_t)(feedforwardData.isPrevPacketDuplicate[axis]));
         // 6 and 7 used for feedforward yaw hold logging

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -204,7 +204,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .dyn_idle_i_gain = 50,
         .dyn_idle_d_gain = 50,
         .dyn_idle_max_increase = 150,
-        .feedforward_averaging = FEEDFORWARD_AVERAGING_OFF,
+        .feedforward_averaging = FEEDFORWARD_AVERAGING_2_POINT,
         .feedforward_max_rate_limit = 90,
         .feedforward_smooth_factor = 65,
         .feedforward_jitter_factor = 7,


### PR DESCRIPTION
Minor bug fix following PR#11441 where, accidentally, 2-point averaging wasn't set as the default for feedforward.

This PR fixes that issue.

It also makes a minor change to a debug to make it easier to interpret jitter reduction by logging the absolute rcCommandDelta, which is the direct input to jitter reduction.

Please merge promptly because otherwise without 2-point averaging, the default behaviour will be too jittery