### PR TITLE
Optimize filters

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -264,11 +264,11 @@ FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFre
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
+    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     if (omega > (M_PIf * 0.5f)) {
         omega = M_PIf - omega;
     }
     const float sn = sin_approx_unchecked(omega);
-    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     const float alpha = sn / (2.0f * BUTTERWORTH_Q);
     const float invA0 = 1.0f / (1.0f + alpha);
 
@@ -285,11 +285,11 @@ FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterF
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
+    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     if (omega > (M_PIf * 0.5f)) {
         omega = M_PIf - omega;
     }
     const float sn = sin_approx_unchecked(omega);
-    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     const float alpha = sn / (2.0f * q);
     const float invA0 = 1.0f / (1.0f + alpha);
 
@@ -304,11 +304,11 @@ FAST_CODE void biquadFilterGainsNotchWeighted(biquadFilterGains_t *filter, float
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
+    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     if (omega > (M_PIf * 0.5f)) {
         omega = M_PIf - omega;
     }
     const float sn = sin_approx_unchecked(omega);
-    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     const float alpha = sn / (2.0f * q);
     const float invA0 = 1.0f / (1.0f + alpha);
 

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -42,10 +42,10 @@ float nullFilterApply(filter_t *filter, float input)
     return input;
 }
 
-float nullFilterVec3Apply(filter_t *filter, float input, int axis)
+float nullFilterVec3Apply(filter_t *filter, float input, int element)
 {
     UNUSED(filter);
-    UNUSED(axis);
+    UNUSED(element);
     return input;
 }
 
@@ -239,7 +239,7 @@ float filterGetNotchQ(float centerFreq, float cutoffFreq)
     return centerFreq * cutoffFreq / (centerFreq * centerFreq - cutoffFreq * cutoffFreq);
 }
 
-FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFreq, float dt)
+FAST_CODE void biquadFilterCoeffsLPF(biquadFilterCoeffs_t *filter, float filterFreq, float dt)
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
@@ -257,7 +257,7 @@ FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFre
      filter->a2 = (1 - alpha) * invA0;
 }
 
-FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterFreq, float dt, float q)
+FAST_CODE void biquadFilterCoeffsNotch(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q)
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
@@ -273,7 +273,7 @@ FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterF
     filter->a2 = (1 - alpha) * invA0;
 }
 
-FAST_CODE void biquadFilterGainsNotchWeighted(biquadFilterGains_t *filter, float filterFreq, float dt, float q, float weight)
+FAST_CODE void biquadFilterCoeffsNotchWeighted(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q, float weight)
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
@@ -296,152 +296,128 @@ FAST_CODE void biquadFilterGainsNotchWeighted(biquadFilterGains_t *filter, float
     filter->b2 = weight * filter->b2 + weightRecip * filter->a2;
 }
 
-void biquadFilterInitArrayLPF(void *filter, float filterFreq, float dt, int count)
+/* Computes a biquadFilter_t filter on a sample (slightly less precise than df2 but works in dynamic mode) */
+FAST_CODE float biquadFilterApplyDF1Split(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input)
 {
-    biquadFilter_t *f = (biquadFilter_t*)filter;
+    const float result = coeffs.b0 * input + coeffs.b1 * state->x1 + coeffs.b2 * state->x2
+                        - coeffs.a1 * state->y1 - coeffs.a2 * state->y2;
 
-    biquadFilterGainsLPF(&f->gains, filterFreq, dt);
+    /* shift x1 to x2, input to x1 */
+    state->x2 = state->x1;
+    state->x1 = input;
 
-    // Split state arrays to suppress compiler warnings
-    float *x1_state = &f->x1[0];
-    float *x2_state = &f->x2[0];
-    float *y1_state = &f->y1[0];
-    float *y2_state = &f->y2[0];
+    /* shift y1 to y2, result to y1 */
+    state->y2 = state->y1;
+    state->y1 = result;
 
-    // Zero initial samples
-    for (int i = 0; i < count; i++) {
-        x1_state[i] = 0.0f;
-        x2_state[i] = 0.0f;
-        y1_state[i] = 0.0f;
-        y2_state[i] = 0.0f;
+    return result;
+}
+
+/* Computes a biquadFilter_t filter in direct form 2 on a sample (higher precision but can't handle changes in coefficients */
+FAST_CODE float biquadFilterApplySplit(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input)
+{
+    const float result = coeffs.b0 * input + state->x1;
+
+    state->x1 = coeffs.b1 * input - coeffs.a1 * result + state->x2;
+    state->x2 = coeffs.b2 * input - coeffs.a2 * result;
+
+    return result;
+}
+
+FAST_CODE float biquadFilterApplyDF1(biquadFilter_t *filter, float input) {
+    return biquadFilterApplyDF1Split(&filter->state, filter->coeffs, input);
+}
+
+FAST_CODE float biquadFilterApply(biquadFilter_t *filter, float input) {
+    return biquadFilterApplySplit(&filter->state, filter->coeffs, input);
+}
+
+FAST_CODE float biquadFilterApplyArraySplit(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input, int element) {
+    return biquadFilterApplySplit(&state[element], coeffs, input);
+}
+
+FAST_CODE float biquadFilterApplyDF1ArraySplit(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input, int element) {
+    return biquadFilterApplyDF1Split(&state[element], coeffs, input);
+}
+
+void biquadFilterInitState(biquadFilterState_t *state)
+{
+    state->x1 = 0.0f;
+    state->x2 = 0.0f;
+    state->y1 = 0.0f;
+    state->y2 = 0.0f;
+}
+
+void biquadFilterInitStateArray(biquadFilterState_t *state, int size)
+{
+    for (int i = 0; i < size; i++) {
+        biquadFilterInitState(&state[i]);
     }
 }
 
 void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, float dt)
 {
-    biquadFilterInitArrayLPF(filter, filterFreq, dt, 1);
+    biquadFilterInitState(&filter->state);
+    biquadFilterCoeffsLPF(&filter->coeffs, filterFreq, dt);
 }
 
-void biquadFilterUpdateLPF(void *filter, float filterFreq, float dt)
-{
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-    biquadFilterGainsLPF(&f->gains, filterFreq, dt);
+void biquadFilterInitLPFArraySplit(biquadFilterState_t *state, biquadFilterCoeffs_t *coeffs, float filterFreq, float dt, int size) {
+    biquadFilterInitStateArray(state, size);
+    biquadFilterCoeffsLPF(coeffs, filterFreq, dt);
 }
 
-void biquadFilterInitArrayNotch(void *filter, float filterFreq, float dt, float Q, int count)
+void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float dt, float q)
 {
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-
-    biquadFilterGainsNotch(&f->gains, filterFreq, dt, Q);
-
-    // Split state arrays to suppress compiler warnings
-    float *x1_state = &f->x1[0];
-    float *x2_state = &f->x2[0];
-    float *y1_state = &f->y1[0];
-    float *y2_state = &f->y2[0];
-
-    // Zero initial samples
-    for (int i = 0; i < count; i++) {
-        x1_state[i] = 0.0f;
-        x2_state[i] = 0.0f;
-        y1_state[i] = 0.0f;
-        y2_state[i] = 0.0f;
-    }
+    biquadFilterInitState(&filter->state);
+    biquadFilterCoeffsNotch(&filter->coeffs, filterFreq, dt, q);
 }
 
-void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float Q, float dt)
-{
-    biquadFilterInitArrayNotch(filter, filterFreq, dt, Q, 1);
+void biquadFilterInitNotchArraySplit(biquadFilterState_t *state, biquadFilterCoeffs_t *coeffs, float filterFreq, float dt, float q, int size) {
+    biquadFilterInitStateArray(state, size);
+    biquadFilterCoeffsNotch(coeffs, filterFreq, dt, q);
 }
 
-void biquadFilterUpdateNotch(void *filter, float filterFreq, float dt, float Q)
+void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float q, float weight)
 {
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-    biquadFilterGainsNotch(&f->gains, filterFreq, dt, Q);
+    biquadFilterInitState(&filter->state);
+    biquadFilterCoeffsNotchWeighted(&filter->coeffs, filterFreq, dt, q, weight);
 }
 
-void biquadFilterInitArrayNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight, int count)
-{
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-
-    biquadFilterGainsNotchWeighted(&f->gains, filterFreq, dt, Q, weight);
-
-    // Split state arrays to suppress compiler warnings
-    float *x1_state = &f->x1[0];
-    float *x2_state = &f->x2[0];
-    float *y1_state = &f->y1[0];
-    float *y2_state = &f->y2[0];
-
-    // Zero initial samples
-    for (int i = 0; i < count; i++) {
-        x1_state[i] = 0.0f;
-        x2_state[i] = 0.0f;
-        y1_state[i] = 0.0f;
-        y2_state[i] = 0.0f;
-    }
+void biquadFilterInitNotchWeightedArraySplit(biquadFilterState_t *state, biquadFilterCoeffs_t *coeffs, float filterFreq, float dt, float q, float weight, int size) {
+    biquadFilterInitStateArray(state, size);
+    biquadFilterCoeffsNotchWeighted(coeffs, filterFreq, dt, q, weight);
 }
 
-void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight)
-{
-    biquadFilterInitArrayNotchWeighted(filter, filterFreq, dt, Q, weight, 1);
+void biquadFilterInitLPFVec3(biquadFilterVec3_t *filter, float filterFreq, float dt, int size) {
+    biquadFilterInitLPFArraySplit(filter->state, &filter->coeffs, filterFreq, dt, size);
 }
 
-void biquadFilterUpdateNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight)
-{
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-    biquadFilterGainsNotchWeighted(&f->gains, filterFreq, dt, Q, weight);
+void biquadFilterInitLPFServo(biquadFilterServoCount_t *filter, float filterFreq, float dt, int size) {
+    biquadFilterInitLPFArraySplit(filter->state, &filter->coeffs, filterFreq, dt, size);
 }
 
-/* Computes a biquadFilter_t filter on a sample (slightly less precise than df2 but works in dynamic mode) */
-FAST_CODE float biquadFilterApplyArrayDF1(void *filter, float input, int element)
-{
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-
-    float b0 = f->gains.b0; float b1 = f->gains.b1; float b2 = f->gains.b2;
-    float a1 = f->gains.a1; float a2 = f->gains.a2;
-
-    const float result = b0 * input + b1 * f->x1[element] + b2 * f->x2[element]
-                        - a1 * f->y1[element] - a2 * f->y2[element];
-
-    /* shift x1 to x2, input to x1 */
-    f->x2[element] = f->x1[element];
-    f->x1[element] = input;
-
-    /* shift y1 to y2, result to y1 */
-    f->y2[element] = f->y1[element];
-    f->y1[element] = result;
-
-    return result;
+void biquadFilterInitNotchVec3(biquadFilterVec3_t *filter, float filterFreq, float dt, float q, int size) {
+    biquadFilterInitNotchArraySplit(filter->state, &filter->coeffs, filterFreq, dt, q, size);
 }
 
-FAST_CODE float biquadFilterApplyDF1(biquadFilter_t *filter, float input)
-{
-    return biquadFilterApplyArrayDF1(filter, input, 0);
+void biquadFilterInitNotchWeightedVec3(biquadFilterVec3_t *filter, float filterFreq, float dt, float q, float weight, int size) {
+    biquadFilterInitNotchWeightedArraySplit(filter->state, &filter->coeffs, filterFreq, dt, q, weight, size);
 }
 
-/* Computes a biquadFilter_t filter in direct form 2 on a sample (higher precision but can't handle changes in coefficients */
-FAST_CODE float biquadFilterApplyArray(void *filter, float input, int element)
-{
-    biquadFilter_t *f = (biquadFilter_t*)filter;
-
-    float b0 = f->gains.b0; float b1 = f->gains.b1; float b2 = f->gains.b2;
-    float a1 = f->gains.a1; float a2 = f->gains.a2;
-
-    // suppress compiler warnings
-    float *x1_state = &f->x1[0];
-    float *x2_state = &f->x2[0];
-
-    const float result = b0 * input + x1_state[element];
-
-    x1_state[element] = b1 * input - a1 * result + x2_state[element];
-    x2_state[element] = b2 * input - a2 * result;
-
-    return result;
+float biquadFilterApplyArrayVec3(biquadFilterVec3_t *filter, float input, int element) {
+    return biquadFilterApplyArraySplit(filter->state, filter->coeffs, input, element);
 }
 
-FAST_CODE float biquadFilterApply(biquadFilter_t *filter, float input)
-{
-    return biquadFilterApplyArray(filter, input, 0);
+float biquadFilterApplyArrayServo(biquadFilterServoCount_t *filter, float input, int element) {
+    return biquadFilterApplyArraySplit(filter->state, filter->coeffs, input, element);
+}
+
+float biquadFilterApplyDF1ArrayVec3(biquadFilterVec3_t *filter, float input, int element) {
+    return biquadFilterApplyDF1ArraySplit(filter->state, filter->coeffs, input, element);
+}
+
+float biquadFilterApplyDF1ArrayServo(biquadFilterServoCount_t *filter, float input, int element) {
+    return biquadFilterApplyDF1ArraySplit(filter->state, filter->coeffs, input, element);
 }
 
 // Phase Compensator (Lead-Lag-Compensator)

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -243,11 +243,8 @@ FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFre
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
-    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
-    if (omega > (M_PIf * 0.5f)) {
-        omega = M_PIf - omega;
-    }
-    const float sn = sin_approx_unchecked(omega);
+    float sn, cs;
+    sincosf_approx(omega, &sn, &cs);
     const float alpha = sn / (2.0f * BUTTERWORTH_Q);
     const float invA0 = 1.0f / (1.0f + alpha);
 
@@ -264,11 +261,8 @@ FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterF
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
-    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
-    if (omega > (M_PIf * 0.5f)) {
-        omega = M_PIf - omega;
-    }
-    const float sn = sin_approx_unchecked(omega);
+    float sn, cs;
+    sincosf_approx(omega, &sn, &cs);
     const float alpha = sn / (2.0f * q);
     const float invA0 = 1.0f / (1.0f + alpha);
 
@@ -283,11 +277,8 @@ FAST_CODE void biquadFilterGainsNotchWeighted(biquadFilterGains_t *filter, float
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
-    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
-    if (omega > (M_PIf * 0.5f)) {
-        omega = M_PIf - omega;
-    }
-    const float sn = sin_approx_unchecked(omega);
+    float sn, cs;
+    sincosf_approx(omega, &sn, &cs);
     const float alpha = sn / (2.0f * q);
     const float invA0 = 1.0f / (1.0f + alpha);
 

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -42,10 +42,10 @@ float nullFilterApply(filter_t *filter, float input)
     return input;
 }
 
-float nullFilterVec3Apply(filter_t *filter, coeffs_t *coeffs, float input, int element)
+float nullFilterVec3Apply(filter_t *filter, float input, int axis)
 {
     UNUSED(filter);
-    UNUSED(element);
+    UNUSED(axis);
     return input;
 }
 
@@ -239,7 +239,7 @@ float filterGetNotchQ(float centerFreq, float cutoffFreq)
     return centerFreq * cutoffFreq / (centerFreq * centerFreq - cutoffFreq * cutoffFreq);
 }
 
-FAST_CODE void biquadFilterCoeffsLPF(biquadFilterCoeffs_t *filter, float filterFreq, float dt)
+FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFreq, float dt)
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
@@ -257,7 +257,7 @@ FAST_CODE void biquadFilterCoeffsLPF(biquadFilterCoeffs_t *filter, float filterF
      filter->a2 = (1 - alpha) * invA0;
 }
 
-FAST_CODE void biquadFilterCoeffsNotch(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q)
+FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterFreq, float dt, float q)
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
@@ -273,7 +273,7 @@ FAST_CODE void biquadFilterCoeffsNotch(biquadFilterCoeffs_t *filter, float filte
     filter->a2 = (1 - alpha) * invA0;
 }
 
-FAST_CODE void biquadFilterCoeffsNotchWeighted(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q, float weight)
+FAST_CODE void biquadFilterGainsNotchWeighted(biquadFilterGains_t *filter, float filterFreq, float dt, float q, float weight)
 {
     // setup variables
     float omega = 2.0f * M_PIf * filterFreq * dt;
@@ -296,40 +296,152 @@ FAST_CODE void biquadFilterCoeffsNotchWeighted(biquadFilterCoeffs_t *filter, flo
     filter->b2 = weight * filter->b2 + weightRecip * filter->a2;
 }
 
-void biquadFilterInitState(biquadFilterState_t *state)
+void biquadFilterInitArrayLPF(void *filter, float filterFreq, float dt, int count)
 {
-    state->x1 = 0.0f;
-    state->x2 = 0.0f;
-    state->y1 = 0.0f;
-    state->y2 = 0.0f;
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+
+    biquadFilterGainsLPF(&f->gains, filterFreq, dt);
+
+    // Split state arrays to suppress compiler warnings
+    float *x1_state = &f->x1[0];
+    float *x2_state = &f->x2[0];
+    float *y1_state = &f->y1[0];
+    float *y2_state = &f->y2[0];
+
+    // Zero initial samples
+    for (int i = 0; i < count; i++) {
+        x1_state[i] = 0.0f;
+        x2_state[i] = 0.0f;
+        y1_state[i] = 0.0f;
+        y2_state[i] = 0.0f;
+    }
+}
+
+void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, float dt)
+{
+    biquadFilterInitArrayLPF(filter, filterFreq, dt, 1);
+}
+
+void biquadFilterUpdateLPF(void *filter, float filterFreq, float dt)
+{
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+    biquadFilterGainsLPF(&f->gains, filterFreq, dt);
+}
+
+void biquadFilterInitArrayNotch(void *filter, float filterFreq, float dt, float Q, int count)
+{
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+
+    biquadFilterGainsNotch(&f->gains, filterFreq, dt, Q);
+
+    // Split state arrays to suppress compiler warnings
+    float *x1_state = &f->x1[0];
+    float *x2_state = &f->x2[0];
+    float *y1_state = &f->y1[0];
+    float *y2_state = &f->y2[0];
+
+    // Zero initial samples
+    for (int i = 0; i < count; i++) {
+        x1_state[i] = 0.0f;
+        x2_state[i] = 0.0f;
+        y1_state[i] = 0.0f;
+        y2_state[i] = 0.0f;
+    }
+}
+
+void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float Q, float dt)
+{
+    biquadFilterInitArrayNotch(filter, filterFreq, dt, Q, 1);
+}
+
+void biquadFilterUpdateNotch(void *filter, float filterFreq, float dt, float Q)
+{
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+    biquadFilterGainsNotch(&f->gains, filterFreq, dt, Q);
+}
+
+void biquadFilterInitArrayNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight, int count)
+{
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+
+    biquadFilterGainsNotchWeighted(&f->gains, filterFreq, dt, Q, weight);
+
+    // Split state arrays to suppress compiler warnings
+    float *x1_state = &f->x1[0];
+    float *x2_state = &f->x2[0];
+    float *y1_state = &f->y1[0];
+    float *y2_state = &f->y2[0];
+
+    // Zero initial samples
+    for (int i = 0; i < count; i++) {
+        x1_state[i] = 0.0f;
+        x2_state[i] = 0.0f;
+        y1_state[i] = 0.0f;
+        y2_state[i] = 0.0f;
+    }
+}
+
+void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight)
+{
+    biquadFilterInitArrayNotchWeighted(filter, filterFreq, dt, Q, weight, 1);
+}
+
+void biquadFilterUpdateNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight)
+{
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+    biquadFilterGainsNotchWeighted(&f->gains, filterFreq, dt, Q, weight);
 }
 
 /* Computes a biquadFilter_t filter on a sample (slightly less precise than df2 but works in dynamic mode) */
-FAST_CODE float biquadFilterApplyDF1(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input)
+FAST_CODE float biquadFilterApplyArrayDF1(void *filter, float input, int element)
 {
-    const float result = coeffs.b0 * input + coeffs.b1 * state->x1 + coeffs.b2 * state->x2
-                        - coeffs.a1 * state->y1 - coeffs.a2 * state->y2;
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+
+    float b0 = f->gains.b0; float b1 = f->gains.b1; float b2 = f->gains.b2;
+    float a1 = f->gains.a1; float a2 = f->gains.a2;
+
+    const float result = b0 * input + b1 * f->x1[element] + b2 * f->x2[element]
+                        - a1 * f->y1[element] - a2 * f->y2[element];
 
     /* shift x1 to x2, input to x1 */
-    state->x2 = state->x1;
-    state->x1 = input;
+    f->x2[element] = f->x1[element];
+    f->x1[element] = input;
 
     /* shift y1 to y2, result to y1 */
-    state->y2 = state->y1;
-    state->y1 = result;
+    f->y2[element] = f->y1[element];
+    f->y1[element] = result;
 
     return result;
 }
 
-/* Computes a biquadFilter_t filter in direct form 2 on a sample (higher precision but can't handle changes in coefficients */
-FAST_CODE float biquadFilterApply(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input)
+FAST_CODE float biquadFilterApplyDF1(biquadFilter_t *filter, float input)
 {
-    const float result = coeffs.b0 * input + state->x1;
+    return biquadFilterApplyArrayDF1(filter, input, 0);
+}
 
-    state->x1 = coeffs.b1 * input - coeffs.a1 * result + state->x2;
-    state->x2 = coeffs.b2 * input - coeffs.a2 * result;
+/* Computes a biquadFilter_t filter in direct form 2 on a sample (higher precision but can't handle changes in coefficients */
+FAST_CODE float biquadFilterApplyArray(void *filter, float input, int element)
+{
+    biquadFilter_t *f = (biquadFilter_t*)filter;
+
+    float b0 = f->gains.b0; float b1 = f->gains.b1; float b2 = f->gains.b2;
+    float a1 = f->gains.a1; float a2 = f->gains.a2;
+
+    // suppress compiler warnings
+    float *x1_state = &f->x1[0];
+    float *x2_state = &f->x2[0];
+
+    const float result = b0 * input + x1_state[element];
+
+    x1_state[element] = b1 * input - a1 * result + x2_state[element];
+    x2_state[element] = b2 * input - a2 * result;
 
     return result;
+}
+
+FAST_CODE float biquadFilterApply(biquadFilter_t *filter, float input)
+{
+    return biquadFilterApplyArray(filter, input, 0);
 }
 
 // Phase Compensator (Lead-Lag-Compensator)

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -268,7 +268,7 @@ FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFre
         omega = M_PIf - omega;
     }
     const float sn = sin_approx_unchecked(omega);
-    const float cs = cos_approx_unchecked(omega);
+    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     const float alpha = sn / (2.0f * BUTTERWORTH_Q);
     const float invA0 = 1.0f / (1.0f + alpha);
 
@@ -289,7 +289,7 @@ FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterF
         omega = M_PIf - omega;
     }
     const float sn = sin_approx_unchecked(omega);
-    const float cs = cos_approx_unchecked(omega);
+    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     const float alpha = sn / (2.0f * q);
     const float invA0 = 1.0f / (1.0f + alpha);
 
@@ -303,9 +303,12 @@ FAST_CODE void biquadFilterGainsNotch(biquadFilterGains_t *filter, float filterF
 FAST_CODE void biquadFilterGainsNotchWeighted(biquadFilterGains_t *filter, float filterFreq, float dt, float q, float weight)
 {
     // setup variables
-    const float omega = 2.0f * M_PIf * filterFreq * dt;
+    float omega = 2.0f * M_PIf * filterFreq * dt;
+    if (omega > (M_PIf * 0.5f)) {
+        omega = M_PIf - omega;
+    }
     const float sn = sin_approx_unchecked(omega);
-    const float cs = cos_approx_unchecked(omega);
+    const float cs = cos_approx_unchecked(-omega); // this is a hack since the valid range of cos unchecked is -pi to 0
     const float alpha = sn / (2.0f * q);
     const float invA0 = 1.0f / (1.0f + alpha);
 

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -185,7 +185,7 @@ FAST_CODE float pt3FilterGainFromDelay(float delay, float dT)
 
 void pt3FilterInitArray(void *filter, float k_value, int count)
 {
-    pt2Filter_t *f = (pt2Filter_t*)filter;
+    pt3Filter_t *f = (pt3Filter_t*)filter;
     f->k = k_value;
 
     // splitting the state as below suppresses compiler warnings

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -269,8 +269,8 @@ FAST_CODE void biquadFilterGainsLPF(biquadFilterGains_t *filter, float filterFre
      // 2nd order Butterworth (with Q=1/sqrt(2)) / Butterworth biquad section with Q
      // described in http://www.ti.com/lit/an/slaa447/slaa447.pdf
      filter->b1 = (1 - cs) * invA0;
-     filter->b0 = (filter->b1 * 0.5f) * invA0;
-     filter->b2 = (filter->b0) * invA0;
+     filter->b0 = (filter->b1 * 0.5f);
+     filter->b2 = (filter->b0);
      filter->a1 = (-2 * cs) * invA0;
      filter->a2 = (1 - alpha) * invA0;
 }

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -42,6 +42,13 @@ float nullFilterApply(filter_t *filter, float input)
     return input;
 }
 
+float nullFilterVec3Apply(filter_t *filter, float input, int axis)
+{
+    UNUSED(filter);
+    UNUSED(axis);
+    return input;
+}
+
 // PT1 Low Pass filter
 
 FAST_CODE_NOINLINE float pt1FilterGain(float f_cut, float dT)
@@ -353,7 +360,7 @@ void biquadFilterVec3InitLPF(biquadFilterVec3_t *filter, float filterFreq, float
     memset(filter->y2, 0.0f, sizeof(filter->y2));
 }
 
-void biquadFilterInitVec3InitNotch(biquadFilterVec3_t *filter, float filterFreq, float dt, float Q, float weight)
+void biquadFilterVec3InitNotch(biquadFilterVec3_t *filter, float filterFreq, float dt, float Q, float weight)
 {
     biquadFilterVec3UpdateNotch(filter, filterFreq, dt, Q, weight);
 

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -30,33 +30,43 @@ typedef float (filterApplyFn)(filter_t *filter, float input);
 typedef float (filterVec3ApplyFn)(filter_t *filter, float input, int axis);
 
 typedef struct pt1Filter_s {
-    float state;
     float k;
+    float state[1];
 } pt1Filter_t;
 
 typedef struct pt1FilterVec3_s {
-    float state[XYZ_AXIS_COUNT];
     float k;
+    float state[XYZ_AXIS_COUNT];
 } pt1FilterVec3_t;
 
-typedef struct pt2Filter_s {
-    float state[2];
+typedef struct pt1FilterMotorCount_s {
     float k;
+    float state[MAX_SUPPORTED_MOTORS];
+} pt1FilterMotorCount_t;
+
+typedef struct pt2Filter_s {
+    float k;
+    float state[2][1];
 } pt2Filter_t;
 
 typedef struct pt2FilterVec3_s {
-    float state[2][XYZ_AXIS_COUNT];
     float k;
+    float state[2][XYZ_AXIS_COUNT];
 } pt2FilterVec3_t;
 
 typedef struct pt3Filter_s {
-    float state[3];
     float k;
+    float state[3][1];
 } pt3Filter_t;
 
-typedef struct pt3FilterVec3_s {
-    float state[3][XYZ_AXIS_COUNT];
+typedef struct pt3FilterVec2_s {
     float k;
+    float state[3][2];
+} pt3FilterVec2_t;
+
+typedef struct pt3FilterVec3_s {
+    float k;
+    float state[3][XYZ_AXIS_COUNT];
 } pt3FilterVec3_t;
 
 typedef struct biquadFilterGains_s {
@@ -65,7 +75,7 @@ typedef struct biquadFilterGains_s {
 
 typedef struct biquadFilter_s {
     biquadFilterGains_t gains;
-    float x1, x2, y1, y2;
+    float x1[1], x2[1], y1[1], y2[1];
 } biquadFilter_t;
 
 typedef struct biquadFilterVec3_s {
@@ -73,6 +83,12 @@ typedef struct biquadFilterVec3_s {
     float x1[XYZ_AXIS_COUNT], x2[XYZ_AXIS_COUNT];
     float y1[XYZ_AXIS_COUNT], y2[XYZ_AXIS_COUNT];
 } biquadFilterVec3_t;
+
+typedef struct biquadFilterServoCount_s {
+    biquadFilterGains_t gains;
+    float x1[MAX_SUPPORTED_SERVOS], x2[MAX_SUPPORTED_SERVOS];
+    float y1[MAX_SUPPORTED_SERVOS], y2[MAX_SUPPORTED_SERVOS];
+} biquadFilterServoCount_t;
 
 typedef struct phaseComp_s {
     float b0, b1, a1;
@@ -124,52 +140,43 @@ float nullFilterVec3Apply(filter_t *filter, float input, int axis);
 float pt1FilterGain(float f_cut, float dT);
 float pt1FilterGainFromDelay(float delay, float dT);
 void pt1FilterInit(pt1Filter_t *filter, float k);
-void pt1FilterUpdateCutoff(pt1Filter_t *filter, float k);
+void pt1FilterInitArray(void *filter, float k_value, int count);
+void pt1FilterUpdateCutoff(void *filter, float k);
 float pt1FilterApply(pt1Filter_t *filter, float input);
-
-void pt1FilterVec3Init(pt1FilterVec3_t *filter, float k);
-void pt1FilterVec3UpdateCutoff(pt1FilterVec3_t *filter, float k);
-float pt1FilterVec3Apply(pt1FilterVec3_t *filter, float input, int axis);
+float pt1FilterApplyArray(void *filter, float input, int element);
 
 float pt2FilterGain(float f_cut, float dT);
 float pt2FilterGainFromDelay(float delay, float dT);
 void pt2FilterInit(pt2Filter_t *filter, float k);
-void pt2FilterUpdateCutoff(pt2Filter_t *filter, float k);
+void pt2FilterInitArray(void *filter, float k_value, int count);
+void pt2FilterUpdateCutoff(void *filter, float k);
 float pt2FilterApply(pt2Filter_t *filter, float input);
-
-void pt2FilterVec3Init(pt2FilterVec3_t *filter, float k);
-void pt2FilterVec3UpdateCutoff(pt2FilterVec3_t *filter, float k);
-float pt2FilterVec3Apply(pt2FilterVec3_t *filter, float input, int axis);
+float pt2FilterApplyArray(void *filter, float input, int element);
 
 float pt3FilterGain(float f_cut, float dT);
 float pt3FilterGainFromDelay(float delay, float dT);
 void pt3FilterInit(pt3Filter_t *filter, float k);
-void pt3FilterUpdateCutoff(pt3Filter_t *filter, float k);
+void pt3FilterInitArray(void *filter, float k_value, int count);
+void pt3FilterUpdateCutoff(void *filter, float k);
 float pt3FilterApply(pt3Filter_t *filter, float input);
-
-void pt3FilterVec3Init(pt3FilterVec3_t *filter, float k);
-void pt3FilterVec3UpdateCutoff(pt3FilterVec3_t *filter, float k);
-float pt3FilterVec3Apply(pt3FilterVec3_t *filter, float input, int axis);
+float pt3FilterApplyArray(void *filter, float input, int element);
 
 float filterGetNotchQ(float centerFreq, float cutoffFreq);
 
-void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, float dt);
-void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float dt, float Q);
-void biquadFilterUpdateNotch(biquadFilter_t *filter, float filterFreq, float dt, float Q);
-void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight);
-void biquadFilterUpdateNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight);
-void biquadFilterUpdateLPF(biquadFilter_t *filter, float filterFreq, float dt);
-float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
-float biquadFilterApply(biquadFilter_t *filter, float input);
 
-void biquadFilterVec3InitLPF(biquadFilterVec3_t *filter, float filterFreq, float dt);
-void biquadFilterVec3InitNotch(biquadFilterVec3_t *filter, float filterFreq, float dt, float Q);
-void biquadFilterVec3UpdateNotch(biquadFilterVec3_t *filter, float filterFreq, float dt, float Q);
-void biquadFilterVec3InitNotchWeighted(biquadFilterVec3_t *filter, float filterFreq, float dt, float Q, float weight);
-void biquadFilterVec3UpdateNotchWeighted(biquadFilterVec3_t *filter, float filterFreq, float dt, float Q, float weight);
-void biquadFilterVec3UpdateLPF(biquadFilterVec3_t *filter, float filterFreq, float dt);
-float biquadFilterVec3ApplyDF1(biquadFilterVec3_t *filter, float input, int axis);
-float biquadFilterVec3Apply(biquadFilterVec3_t *filter, float input, int axis);
+void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, float dt);
+void biquadFilterInitArrayLPF(void *filter, float filterFreq, float dt, int count);
+void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float dt, float Q);
+void biquadFilterInitArrayNotch(void *filter, float filterFreq, float dt, float Q, int count);
+void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight);
+void biquadFilterInitArrayNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight, int count);
+void biquadFilterUpdateLPF(void *filter, float filterFreq, float dt);
+void biquadFilterUpdateNotch(void *filter, float filterFreq, float dt, float Q);
+void biquadFilterUpdateNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight);
+float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
+float biquadFilterApplyArrayDF1(void *filter, float input, int element);
+float biquadFilterApply(biquadFilter_t *filter, float input);
+float biquadFilterApplyArray(void *filter, float input, int element);
 
 void phaseCompInit(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
 void phaseCompUpdate(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -69,27 +69,25 @@ typedef struct pt3FilterVec3_s {
     float state[3][XYZ_AXIS_COUNT];
 } pt3FilterVec3_t;
 
-typedef struct biquadFilterCoeffs_s {
+typedef struct biquadFilterGains_s {
     float b0, b1, b2, a1, a2;
-} biquadFilterCoeffs_t;
-
-typedef struct biquadFilterState_s {
-    float x1, x2, y1, y2;
-} biquadFilterState_t;
+} biquadFilterGains_t;
 
 typedef struct biquadFilter_s {
-    biquadFilterCoeffs_t coeffs;
-    biquadFilterState_t state;
+    biquadFilterGains_t gains;
+    float x1[1], x2[1], y1[1], y2[1];
 } biquadFilter_t;
 
 typedef struct biquadFilterVec3_s {
-    biquadFilterCoeffs_t coeffs;
-    biquadFilterState_t state[XYZ_AXIS_COUNT];
+    biquadFilterGains_t gains;
+    float x1[XYZ_AXIS_COUNT], x2[XYZ_AXIS_COUNT];
+    float y1[XYZ_AXIS_COUNT], y2[XYZ_AXIS_COUNT];
 } biquadFilterVec3_t;
 
 typedef struct biquadFilterServoCount_s {
-    biquadFilterCoeffs_t coeffs;
-    biquadFilterState_t state[MAX_SUPPORTED_SERVOS];
+    biquadFilterGains_t gains;
+    float x1[MAX_SUPPORTED_SERVOS], x2[MAX_SUPPORTED_SERVOS];
+    float y1[MAX_SUPPORTED_SERVOS], y2[MAX_SUPPORTED_SERVOS];
 } biquadFilterServoCount_t;
 
 typedef struct phaseComp_s {
@@ -165,12 +163,20 @@ float pt3FilterApplyArray(void *filter, float input, int element);
 
 float filterGetNotchQ(float centerFreq, float cutoffFreq);
 
-void biquadFilterCoeffsLPF(biquadFilterCoeffs_t *filter, float filterFreq, float dt);
-void biquadFilterCoeffsNotch(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q);
-void biquadFilterCoeffsNotchWeighted(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q, float weight);
-void biquadFilterInitState(biquadFilterState_t *state);
-float biquadFilterApplyDF1(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input);
-float biquadFilterApply(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input);
+
+void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, float dt);
+void biquadFilterInitArrayLPF(void *filter, float filterFreq, float dt, int count);
+void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float dt, float Q);
+void biquadFilterInitArrayNotch(void *filter, float filterFreq, float dt, float Q, int count);
+void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight);
+void biquadFilterInitArrayNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight, int count);
+void biquadFilterUpdateLPF(void *filter, float filterFreq, float dt);
+void biquadFilterUpdateNotch(void *filter, float filterFreq, float dt, float Q);
+void biquadFilterUpdateNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight);
+float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
+float biquadFilterApplyArrayDF1(void *filter, float input, int element);
+float biquadFilterApply(biquadFilter_t *filter, float input);
+float biquadFilterApplyArray(void *filter, float input, int element);
 
 void phaseCompInit(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
 void phaseCompUpdate(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -69,25 +69,27 @@ typedef struct pt3FilterVec3_s {
     float state[3][XYZ_AXIS_COUNT];
 } pt3FilterVec3_t;
 
-typedef struct biquadFilterGains_s {
+typedef struct biquadFilterCoeffs_s {
     float b0, b1, b2, a1, a2;
-} biquadFilterGains_t;
+} biquadFilterCoeffs_t;
+
+typedef struct biquadFilterState_s {
+    float x1, x2, y1, y2;
+} biquadFilterState_t;
 
 typedef struct biquadFilter_s {
-    biquadFilterGains_t gains;
-    float x1[1], x2[1], y1[1], y2[1];
+    biquadFilterCoeffs_t coeffs;
+    biquadFilterState_t state;
 } biquadFilter_t;
 
 typedef struct biquadFilterVec3_s {
-    biquadFilterGains_t gains;
-    float x1[XYZ_AXIS_COUNT], x2[XYZ_AXIS_COUNT];
-    float y1[XYZ_AXIS_COUNT], y2[XYZ_AXIS_COUNT];
+    biquadFilterCoeffs_t coeffs;
+    biquadFilterState_t state[XYZ_AXIS_COUNT];
 } biquadFilterVec3_t;
 
 typedef struct biquadFilterServoCount_s {
-    biquadFilterGains_t gains;
-    float x1[MAX_SUPPORTED_SERVOS], x2[MAX_SUPPORTED_SERVOS];
-    float y1[MAX_SUPPORTED_SERVOS], y2[MAX_SUPPORTED_SERVOS];
+    biquadFilterCoeffs_t coeffs;
+    biquadFilterState_t state[MAX_SUPPORTED_SERVOS];
 } biquadFilterServoCount_t;
 
 typedef struct phaseComp_s {
@@ -163,20 +165,12 @@ float pt3FilterApplyArray(void *filter, float input, int element);
 
 float filterGetNotchQ(float centerFreq, float cutoffFreq);
 
-
-void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, float dt);
-void biquadFilterInitArrayLPF(void *filter, float filterFreq, float dt, int count);
-void biquadFilterInitNotch(biquadFilter_t *filter, float filterFreq, float dt, float Q);
-void biquadFilterInitArrayNotch(void *filter, float filterFreq, float dt, float Q, int count);
-void biquadFilterInitNotchWeighted(biquadFilter_t *filter, float filterFreq, float dt, float Q, float weight);
-void biquadFilterInitArrayNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight, int count);
-void biquadFilterUpdateLPF(void *filter, float filterFreq, float dt);
-void biquadFilterUpdateNotch(void *filter, float filterFreq, float dt, float Q);
-void biquadFilterUpdateNotchWeighted(void *filter, float filterFreq, float dt, float Q, float weight);
-float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
-float biquadFilterApplyArrayDF1(void *filter, float input, int element);
-float biquadFilterApply(biquadFilter_t *filter, float input);
-float biquadFilterApplyArray(void *filter, float input, int element);
+void biquadFilterCoeffsLPF(biquadFilterCoeffs_t *filter, float filterFreq, float dt);
+void biquadFilterCoeffsNotch(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q);
+void biquadFilterCoeffsNotchWeighted(biquadFilterCoeffs_t *filter, float filterFreq, float dt, float q, float weight);
+void biquadFilterInitState(biquadFilterState_t *state);
+float biquadFilterApplyDF1(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input);
+float biquadFilterApply(biquadFilterState_t *state, biquadFilterCoeffs_t coeffs, float input);
 
 void phaseCompInit(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);
 void phaseCompUpdate(phaseComp_t *filter, const float centerFreq, const float centerPhase, const uint32_t looptimeUs);

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -64,15 +64,8 @@ float sin_approx_unchecked(float x)
 
 float cos_approx_unchecked(float x)
 {
-    // Only valid if values are in the range -π/2 to π/2
-    const float C0 = 0.99999994f;
-    const float C2 = -0.49999905f;
-    const float C4 = 0.041663583f;
-    const float C6 = -0.0013853704f;
-    const float C8 = 0.000023153932f;
-
-    float x2 = x * x;
-    return C0 + x2 * (C2 + x2 * (C4 + x2 * (C6 + C8 * x2)));
+    // Only valid if values are in the range -π to 0
+    return sin_approx_unchecked(x + M_PIf * 0.5f);
 }
 
 float reduce_anglef(float x) {

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -79,6 +79,19 @@ float cos_approx(float x)
     return sin_approx(x + (0.5f * M_PIf));
 }
 
+float sin_approx_unchecked(float x)
+{
+    // Only valid if values are in the range -π to π
+    float x2 = x * x;
+    return x + x * x2 * (sinPolyCoef3 + x2 * (sinPolyCoef5 + x2 * (sinPolyCoef7 + x2 * sinPolyCoef9)));
+}
+
+float cos_approx_unchecked(float x)
+{
+    // Only valid if values are in the range -π to π
+    return sin_approx_unchecked(x + (0.5f * M_PIf));
+}
+
 // Initial implementation by Crashpilot1000 (https://github.com/Crashpilot1000/HarakiriWebstore1/blob/396715f73c6fcf859e0db0f34e12fe44bace6483/src/mw.c#L1292)
 // Polynomial coefficients by Andor (http://www.dsprelated.com/showthread/comp.dsp/21872-1.php) optimized by Ledvinap to save one multiplication
 // Max absolute error 0,000027 degree

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -51,16 +51,19 @@ float cos_approx_unchecked(float x)
 }
 
 float reduce_anglef(float x) {
-    const float invTwoPi = 1.0f / (2.0f * M_PIf);
-    x -= floorf((x * invTwoPi) + 0.5f) * (2.0f * M_PIf); // wrap from -π to π
+    const float inv2pi = 1.0f / (2.0f * M_PIf);
 
-    // Use axis symmetry around x = ±π/2 for polynomial outside of range [-π/2 π/2]
+    float scaled = x * inv2pi + (x >= 0 ? 0.5f : -0.5f);
+    int cycles = (int)scaled;
+
+    x -= cycles * (2.0f * M_PIf);
+
+    // Reflection logic
     if (x > M_PIf / 2) {
-        x = M_PIf - x; // Reflect
+        x = M_PIf - x;
     } else if (x < -M_PIf / 2) {
-        x = -M_PIf - x; // Reflect
+        x = -M_PIf - x;
     }
-
     return x;
 }
 

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -30,25 +30,7 @@
 
 #include "maths.h"
 
-#if defined(FAST_MATH) || defined(VERY_FAST_MATH)
-#if defined(VERY_FAST_MATH)
-
-// http://lolengine.net/blog/2011/12/21/better-function-approximations
-// Chebyshev http://stackoverflow.com/questions/345085/how-do-trigonometric-functions-work/345117#345117
-// Thanks for ledvinap for making such accuracy possible! See: https://github.com/cleanflight/cleanflight/issues/940#issuecomment-110323384
-// https://github.com/Crashpilot1000/HarakiriWebstore1/blob/master/src/mw.c#L1235
-// sin_approx maximum absolute error = 2.305023e-06
-// cos_approx maximum absolute error = 2.857298e-06
-#define sinPolyCoef3 -1.666568107e-1f
-#define sinPolyCoef5  8.312366210e-3f
-#define sinPolyCoef7 -1.849218155e-4f
-#define sinPolyCoef9  0
-#else
-#define sinPolyCoef3 -1.666665710e-1f                                          // Double: -1.666665709650470145824129400050267289858e-1
-#define sinPolyCoef5  8.333017292e-3f                                          // Double:  8.333017291562218127986291618761571373087e-3
-#define sinPolyCoef7 -1.980661520e-4f                                          // Double: -1.980661520135080504411629636078917643846e-4
-#define sinPolyCoef9  2.600054768e-6f                                          // Double:  2.600054767890361277123254766503271638682e-6
-#endif
+#if defined(FAST_MATH)
 
 float sin_approx_unchecked(float x)
 {

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -130,6 +130,8 @@ float pow_approx(float a, float b);
 #else
 #define sin_approx(x)       sinf(x)
 #define cos_approx(x)       cosf(x)
+#define sin_approx_unchecked(x) sinf(x)
+#define cos_approx_unchecked(x) cosf(x)
 #define atan2_approx(y,x)   atan2f(y,x)
 #define acos_approx(x)      acosf(x)
 #define tan_approx(x)       tanf(x)

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -29,8 +29,7 @@
 #define power5(x) ((x)*(x)*(x)*(x)*(x))
 
 // Undefine this for use libc sinf/cosf. Keep this defined to use fast sin/cos approximations
-#define FAST_MATH             // order 9 approximation
-#define VERY_FAST_MATH        // order 7 approximation
+#define FAST_MATH
 
 // Use floating point M_PI instead explicitly.
 #define M_PIf       3.14159265358979323846f
@@ -116,7 +115,7 @@ float quickMedianFilter5f(const float * v);
 float quickMedianFilter7f(const float * v);
 float quickMedianFilter9f(const float * v);
 
-#if defined(FAST_MATH) || defined(VERY_FAST_MATH)
+#if defined(FAST_MATH))
 float sin_approx(float x);
 float cos_approx(float x);
 float cos_approx_unchecked(float x);

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -115,7 +115,7 @@ float quickMedianFilter5f(const float * v);
 float quickMedianFilter7f(const float * v);
 float quickMedianFilter9f(const float * v);
 
-#if defined(FAST_MATH))
+#if defined(FAST_MATH)
 float sin_approx(float x);
 float cos_approx(float x);
 float cos_approx_unchecked(float x);

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -119,6 +119,8 @@ float quickMedianFilter9f(const float * v);
 #if defined(FAST_MATH) || defined(VERY_FAST_MATH)
 float sin_approx(float x);
 float cos_approx(float x);
+float cos_approx_unchecked(float x);
+float sin_approx_unchecked(float x);
 float atan2_approx(float y, float x);
 float acos_approx(float x);
 float asin_approx(float x);

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -34,6 +34,7 @@
 // Use floating point M_PI instead explicitly.
 #define M_PIf       3.14159265358979323846f
 #define M_EULERf    2.71828182845904523536f
+#define INV_PIO2    (2.0f / M_PIf)
 
 #define RAD    (M_PIf / 180.0f)
 #define DEGREES_TO_DECIDEGREES(angle) ((angle) * 10)
@@ -118,8 +119,7 @@ float quickMedianFilter9f(const float * v);
 #if defined(FAST_MATH)
 float sin_approx(float x);
 float cos_approx(float x);
-float cos_approx_unchecked(float x);
-float sin_approx_unchecked(float x);
+void sincosf_approx(float x, float *out_s, float *out_c);
 float atan2_approx(float y, float x);
 float acos_approx(float x);
 float asin_approx(float x);
@@ -130,8 +130,6 @@ float pow_approx(float a, float b);
 #else
 #define sin_approx(x)       sinf(x)
 #define cos_approx(x)       cosf(x)
-#define sin_approx_unchecked(x) sinf(x)
-#define cos_approx_unchecked(x) cosf(x)
 #define atan2_approx(y,x)   atan2f(y,x)
 #define acos_approx(x)      acosf(x)
 #define tan_approx(x)       tanf(x)

--- a/src/main/fc/rc.h
+++ b/src/main/fc/rc.h
@@ -37,8 +37,8 @@ typedef struct feedforwardData_s {
     float prevSetpointSpeedDelta[XYZ_AXIS_COUNT];
     bool isPrevPacketDuplicate[XYZ_AXIS_COUNT];
     float prevRxInterval[XYZ_AXIS_COUNT];
-    pt1Filter_t filterSetpointSpeed[XYZ_AXIS_COUNT];
-    pt1Filter_t filterSetpointDelta[XYZ_AXIS_COUNT];
+    pt1FilterVec3_t filterSetpointSpeed;
+    pt1FilterVec3_t filterSetpointDelta;
 } feedforwardData_t;
 
 void processRcCommand(void);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -88,7 +88,7 @@ extern float rcCommand[4];
 typedef struct rcSmoothingFilter_s {
     pt3Filter_t filterSetpoint[PRIMARY_CHANNEL_COUNT];
     pt3Filter_t filterRcDeflection[RP_AXIS_COUNT];
-    pt3Filter_t filterFeedforward[XYZ_AXIS_COUNT];
+    pt3FilterVec3_t filterFeedforward;
 
     uint8_t setpointCutoffSetting;
     uint8_t throttleCutoffSetting;

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -86,9 +86,10 @@ typedef enum {
 extern float rcCommand[4];
 
 typedef struct rcSmoothingFilter_s {
-    pt3Filter_t filterSetpoint[PRIMARY_CHANNEL_COUNT];
+    pt3FilterVec3_t filterSetpoint;
     pt3Filter_t filterRcDeflection[RP_AXIS_COUNT];
     pt3FilterVec3_t filterFeedforward;
+    pt3Filter_t filterThrottle;
 
     uint8_t setpointCutoffSetting;
     uint8_t throttleCutoffSetting;

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -87,7 +87,7 @@ extern float rcCommand[4];
 
 typedef struct rcSmoothingFilter_s {
     pt3FilterVec3_t filterSetpoint;
-    pt3Filter_t filterRcDeflection[RP_AXIS_COUNT];
+    pt3FilterVec2_t filterRcDeflection;
     pt3FilterVec3_t filterFeedforward;
     pt3Filter_t filterThrottle;
 

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -198,8 +198,7 @@ void dynNotchInit(const dynNotchConfig_t *config, const float dt)
         for (int p = 0; p < dynNotch.count; p++) {
             // any init value is fine, but evenly spreading centerFreqs across frequency range makes notches stick to peaks quicker
             dynNotch.centerFreq[axis][p] = (p + 0.5f) * (dynNotch.maxHz - dynNotch.minHz) / (float)dynNotch.count + dynNotch.minHz;
-            biquadFilterInitState(&dynNotch.notch[axis][p].state);
-            biquadFilterCoeffsNotch(&dynNotch.notch[axis][p].coeffs, dynNotch.centerFreq[axis][p], dynNotch.dt, dynNotch.q);
+            biquadFilterInitNotch(&dynNotch.notch[axis][p], dynNotch.centerFreq[axis][p], dynNotch.dt, dynNotch.q);
         }
     }
 }
@@ -391,7 +390,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
                 if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
-                    biquadFilterCoeffsNotch(&dynNotch.notch[state.axis][p].coeffs, dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q);
+                    biquadFilterUpdateNotch(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q);
                 }
             }
 
@@ -407,7 +406,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
 FAST_CODE float dynNotchFilter(const int axis, float value)
 {
     for (int p = 0; p < dynNotch.count; p++) {
-        value = biquadFilterApplyDF1(&dynNotch.notch[axis][p].state, dynNotch.notch[axis][p].coeffs, value);
+        value = biquadFilterApplyDF1(&dynNotch.notch[axis][p], value);
     }
 
     return value;

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -124,7 +124,7 @@ typedef struct dynNotch_s {
     int maxCenterFreq;
     float centerFreq[XYZ_AXIS_COUNT][DYN_NOTCH_COUNT_MAX];
 
-    timeUs_t looptimeUs;
+    float dt;
     biquadFilter_t notch[XYZ_AXIS_COUNT][DYN_NOTCH_COUNT_MAX];
 
 } dynNotch_t;
@@ -153,10 +153,10 @@ static FAST_DATA_ZERO_INIT int     sdftEndBin;
 static FAST_DATA_ZERO_INIT float   sdftNoiseThreshold;
 static FAST_DATA_ZERO_INIT float   pt1LooptimeS;
 
-void dynNotchInit(const dynNotchConfig_t *config, const timeUs_t targetLooptimeUs)
+void dynNotchInit(const dynNotchConfig_t *config, const float dt)
 {
-    // dynNotchUpdate() is running at looprateHz (which is the PID looprate aka. 1e6f / gyro.targetLooptime)
-    const float looprateHz = 1.0f / targetLooptimeUs * 1e6f;
+    // dynNotchUpdate() is running at looprateHz (which is the PID looprate)
+    const float looprateHz = 1.0f / dt;
     const float nyquistHz = looprateHz / 2.0f;
 
     // Disable dynamic notch if dynNotchUpdate() would run at less than 2kHz
@@ -171,7 +171,7 @@ void dynNotchInit(const dynNotchConfig_t *config, const timeUs_t targetLooptimeU
     dynNotch.maxHz = MAX(dynNotch.minHz, config->dyn_notch_max_hz);
     dynNotch.maxHz = MIN(dynNotch.maxHz, nyquistHz); // Ensure to not go above the nyquist limit
     dynNotch.count = config->dyn_notch_count;
-    dynNotch.looptimeUs = targetLooptimeUs;
+    dynNotch.dt = dt;
     dynNotch.maxCenterFreq = 0;
 
     sampleCount = MAX(1, nyquistHz / dynNotch.maxHz); // maxHz = 600 & looprateHz = 8000 -> sampleCount = 6
@@ -198,7 +198,7 @@ void dynNotchInit(const dynNotchConfig_t *config, const timeUs_t targetLooptimeU
         for (int p = 0; p < dynNotch.count; p++) {
             // any init value is fine, but evenly spreading centerFreqs across frequency range makes notches stick to peaks quicker
             dynNotch.centerFreq[axis][p] = (p + 0.5f) * (dynNotch.maxHz - dynNotch.minHz) / (float)dynNotch.count + dynNotch.minHz;
-            biquadFilterInit(&dynNotch.notch[axis][p], dynNotch.centerFreq[axis][p], dynNotch.looptimeUs, dynNotch.q, FILTER_NOTCH, 1.0f);
+            biquadFilterInitNotch(&dynNotch.notch[axis][p], dynNotch.centerFreq[axis][p], dynNotch.dt, dynNotch.q, 1.0f);
         }
     }
 }
@@ -390,7 +390,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
                 if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
-                    biquadFilterUpdate(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.looptimeUs, dynNotch.q, FILTER_NOTCH, 1.0f);
+                    biquadFilterUpdateNotch(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q, 1.0f);
                 }
             }
 

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -390,7 +390,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
                 if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
-                    biquadFilterUpdateNotch(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q);
+                    biquadFilterCoeffsNotch(&dynNotch.notch[state.axis][p].coeffs, dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q);
                 }
             }
 

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -198,7 +198,7 @@ void dynNotchInit(const dynNotchConfig_t *config, const float dt)
         for (int p = 0; p < dynNotch.count; p++) {
             // any init value is fine, but evenly spreading centerFreqs across frequency range makes notches stick to peaks quicker
             dynNotch.centerFreq[axis][p] = (p + 0.5f) * (dynNotch.maxHz - dynNotch.minHz) / (float)dynNotch.count + dynNotch.minHz;
-            biquadFilterInitNotch(&dynNotch.notch[axis][p], dynNotch.centerFreq[axis][p], dynNotch.dt, dynNotch.q, 1.0f);
+            biquadFilterInitNotch(&dynNotch.notch[axis][p], dynNotch.centerFreq[axis][p], dynNotch.dt, dynNotch.q);
         }
     }
 }
@@ -390,7 +390,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
                 if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
-                    biquadFilterUpdateNotch(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q, 1.0f);
+                    biquadFilterUpdateNotch(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.dt, dynNotch.q);
                 }
             }
 

--- a/src/main/flight/dyn_notch_filter.h
+++ b/src/main/flight/dyn_notch_filter.h
@@ -28,7 +28,7 @@
 
 #define DYN_NOTCH_COUNT_MAX 7
 
-void dynNotchInit(const dynNotchConfig_t *config, const timeUs_t targetLooptimeUs);
+void dynNotchInit(const dynNotchConfig_t *config, const float dt);
 void dynNotchPush(const int axis, const float sample);
 void dynNotchUpdate(void);
 float dynNotchFilter(const int axis, float value);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -562,7 +562,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
     angleFeedforward = angleLimit * getFeedforward(axis) * pidRuntime.angleFeedforwardGain * maxSetpointRateInv;
     //  angle feedforward must be heavily filtered, at the PID loop rate, with limited user control over time constant
     // it MUST be very delayed to avoid early overshoot and being too aggressive
-    angleFeedforward = pt3FilterApply(&pidRuntime.angleFeedforwardPt3[axis], angleFeedforward);
+    angleFeedforward = pt3FilterVec3Apply(&pidRuntime.angleFeedforwardPt3, angleFeedforward, axis);
 #endif
 
     float angleTarget = angleLimit * currentPidSetpoint * maxSetpointRateInv;
@@ -843,7 +843,7 @@ STATIC_UNIT_TESTED void rotateItermAndAxisError(void)
 STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRate, float *currentPidSetpoint, float *itermErrorRate)
 {
     if (pidRuntime.acGain > 0 || debugMode == DEBUG_AC_ERROR) {
-        const float setpointLpf = pt1FilterApply(&pidRuntime.acLpf[axis], *currentPidSetpoint);
+        const float setpointLpf = pt1FilterVec3Apply(&pidRuntime.acLpf, *currentPidSetpoint, axis);
         const float setpointHpf = fabsf(*currentPidSetpoint - setpointLpf);
         float acErrorRate = 0;
         const float gmaxac = setpointLpf + 2 * setpointHpf;
@@ -882,7 +882,7 @@ STATIC_UNIT_TESTED void applyAbsoluteControl(const int axis, const float gyroRat
 STATIC_UNIT_TESTED void applyItermRelax(const int axis, const float iterm,
     const float gyroRate, float *itermErrorRate, float *currentPidSetpoint)
 {
-    const float setpointLpf = pt1FilterApply(&pidRuntime.windupLpf[axis], *currentPidSetpoint);
+    const float setpointLpf = pt1FilterVec3Apply(&pidRuntime.windupLpf, *currentPidSetpoint, axis);
     const float setpointHpf = fabsf(*currentPidSetpoint - setpointLpf);
 
     if (pidRuntime.itermRelax) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -599,7 +599,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
     // minimise cross-axis wobble due to faster yaw responses than roll or pitch, and make co-ordinated yaw turns
     // by compensating for the effect of yaw on roll while pitched, and on pitch while rolled
     // earthRef code here takes about 76 cycles, if conditional on angleEarthRef it takes about 100.  sin_approx costs most of those cycles.
-    float sinAngle = sin_approx_unchecked(DEGREES_TO_RADIANS(pidRuntime.angleTarget[axis == FD_ROLL ? FD_PITCH : FD_ROLL]));
+    float sinAngle = sin_approx(DEGREES_TO_RADIANS(pidRuntime.angleTarget[axis == FD_ROLL ? FD_PITCH : FD_ROLL]));
     sinAngle *= (axis == FD_ROLL) ? -1.0f : 1.0f; // must be negative for Roll
     const float earthRefGain = FLIGHT_MODE(GPS_RESCUE_MODE | ALT_HOLD_MODE) ? 1.0f : pidRuntime.angleEarthRef;
     angleRate += pidRuntime.angleYawSetpoint * sinAngle * earthRefGain;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1599,7 +1599,7 @@ void dynLpfDTermUpdate(float throttle)
             pt1FilterUpdateCutoff(&pidRuntime.dtermLowpass.pt1Filter, pt1FilterGain(cutoffFreq, pidRuntime.dT));
             break;
         case DYN_LPF_BIQUAD:
-            biquadFilterUpdateLPF(&pidRuntime.dtermLowpass.biquadFilter, cutoffFreq, pidRuntime.dT);
+            biquadFilterCoeffsLPF(&pidRuntime.dtermLowpass.biquadFilter.coeffs, cutoffFreq, pidRuntime.dT);
             break;
         case DYN_LPF_PT2:
             pt2FilterUpdateCutoff(&pidRuntime.dtermLowpass.pt2Filter, pt2FilterGain(cutoffFreq, pidRuntime.dT));

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -437,7 +437,7 @@ typedef struct pidRuntime_s {
     float landingDisarmThreshold;
 
 #ifdef USE_ITERM_RELAX
-    pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
+    pt1FilterVec3_t windupLpf;
     uint8_t itermRelax;
     uint8_t itermRelaxType;
     uint8_t itermRelaxCutoff;
@@ -448,7 +448,7 @@ typedef struct pidRuntime_s {
     float acGain;
     float acLimit;
     float acErrorLimit;
-    pt1Filter_t acLpf[XYZ_AXIS_COUNT];
+    pt1FilterVec3_t acLpf;
     float oldSetpointCorrection[XYZ_AXIS_COUNT];
 #endif
 
@@ -514,7 +514,7 @@ typedef struct pidRuntime_s {
     float feedforwardYawHoldGain;
     float feedforwardYawHoldTime;
     bool feedforwardInterpolate; // Whether to interpolate an FF value for duplicate/identical data values
-    pt3Filter_t angleFeedforwardPt3[XYZ_AXIS_COUNT];
+    pt3FilterVec3_t angleFeedforwardPt3;
 #endif
 
 #ifdef USE_ACC

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -359,10 +359,10 @@ typedef struct pidAxisData_s {
 } pidAxisData_t;
 
 typedef union dtermLowpass_u {
-    pt1Filter_t pt1Filter;
-    biquadFilter_t biquadFilter;
-    pt2Filter_t pt2Filter;
-    pt3Filter_t pt3Filter;
+    pt1FilterVec3_t pt1Filter;
+    biquadFilterVec3_t biquadFilter;
+    pt2FilterVec3_t pt2Filter;
+    pt3FilterVec3_t pt3Filter;
 } dtermLowpass_t;
 
 typedef struct pidCoefficient_s {
@@ -387,12 +387,12 @@ typedef struct pidRuntime_s {
     float pidFrequency;
     bool pidStabilisationEnabled;
     float previousPidSetpoint[XYZ_AXIS_COUNT];
-    filterApplyFnPtr dtermNotchApplyFn;
-    biquadFilter_t dtermNotch[XYZ_AXIS_COUNT];
-    filterApplyFnPtr dtermLowpassApplyFn;
-    dtermLowpass_t dtermLowpass[XYZ_AXIS_COUNT];
-    filterApplyFnPtr dtermLowpass2ApplyFn;
-    dtermLowpass_t dtermLowpass2[XYZ_AXIS_COUNT];
+    filterVec3ApplyFnPtr dtermNotchApplyFn;
+    biquadFilterVec3_t dtermNotch;
+    filterVec3ApplyFnPtr dtermLowpassApplyFn;
+    dtermLowpass_t dtermLowpass;
+    filterVec3ApplyFnPtr dtermLowpass2ApplyFn;
+    dtermLowpass_t dtermLowpass2;
     filterApplyFnPtr ptermYawLowpassApplyFn;
     pt1Filter_t ptermYawLowpass;
     bool antiGravityEnabled;
@@ -453,8 +453,8 @@ typedef struct pidRuntime_s {
 #endif
 
 #ifdef USE_D_MAX
-    pt2Filter_t dMaxRange[XYZ_AXIS_COUNT];
-    pt2Filter_t dMaxLowpass[XYZ_AXIS_COUNT];
+    pt2FilterVec3_t dMaxRange;
+    pt2FilterVec3_t dMaxLowpass;
     float dMaxPercent[XYZ_AXIS_COUNT];
     uint8_t dMax[XYZ_AXIS_COUNT];
     float dMaxGyroGain;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -358,13 +358,6 @@ typedef struct pidAxisData_s {
     float Sum;
 } pidAxisData_t;
 
-typedef union dtermLowpass_u {
-    pt1FilterVec3_t pt1Filter;
-    biquadFilterVec3_t biquadFilter;
-    pt2FilterVec3_t pt2Filter;
-    pt3FilterVec3_t pt3Filter;
-} dtermLowpass_t;
-
 typedef struct pidCoefficient_s {
     float Kp;
     float Ki;
@@ -387,13 +380,13 @@ typedef struct pidRuntime_s {
     float pidFrequency;
     bool pidStabilisationEnabled;
     float previousPidSetpoint[XYZ_AXIS_COUNT];
-    filterVec3ApplyFnPtr dtermNotchApplyFn;
+    filterVec3ApplyFn *dtermNotchApplyFn;
     biquadFilterVec3_t dtermNotch;
-    filterVec3ApplyFnPtr dtermLowpassApplyFn;
-    dtermLowpass_t dtermLowpass;
-    filterVec3ApplyFnPtr dtermLowpass2ApplyFn;
-    dtermLowpass_t dtermLowpass2;
-    filterApplyFnPtr ptermYawLowpassApplyFn;
+    filterVec3ApplyFn *dtermLowpassApplyFn;
+    lowpassFilterVec3_t dtermLowpass;
+    filterVec3ApplyFn *dtermLowpass2ApplyFn;
+    lowpassFilterVec3_t dtermLowpass2;
+    filterApplyFn *ptermYawLowpassApplyFn;
     pt1Filter_t ptermYawLowpass;
     bool antiGravityEnabled;
     pt2Filter_t antiGravityLpf;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -511,7 +511,7 @@ typedef struct pidRuntime_s {
 #endif
 
 #ifdef USE_ACC
-    pt3Filter_t attitudeFilter[RP_AXIS_COUNT];  // Only for ROLL and PITCH
+    pt3FilterVec2_t attitudeFilter;  // Only for ROLL and PITCH
     pt1Filter_t horizonSmoothingPt1;
     uint16_t horizonDelayMs;
     float angleYawSetpoint;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -155,9 +155,9 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     }
 
     if (dTermNotchHz != 0 && pidProfile->dterm_notch_cutoff != 0) {
-        pidRuntime.dtermNotchApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
+        pidRuntime.dtermNotchApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
         const float notchQ = filterGetNotchQ(dTermNotchHz, pidProfile->dterm_notch_cutoff);
-        biquadFilterVec3InitNotch(&pidRuntime.dtermNotch, dTermNotchHz, pidRuntime.dT, notchQ);
+        biquadFilterInitArrayNotch(&pidRuntime.dtermNotch, dTermNotchHz, pidRuntime.dT, notchQ, XYZ_AXIS_COUNT);
     } else {
         pidRuntime.dtermNotchApplyFn = nullFilterVec3Apply;
     }
@@ -174,28 +174,28 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     if (dterm_lpf1_init_hz > 0) {
         switch (pidProfile->dterm_lpf1_type) {
         case FILTER_PT1:
-            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt1FilterVec3Apply;
-            pt1FilterVec3Init(&pidRuntime.dtermLowpass.pt1Filter, pt1FilterGain(dterm_lpf1_init_hz, pidRuntime.dT));
+            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt1FilterApplyArray;
+            pt1FilterInitArray(&pidRuntime.dtermLowpass.pt1Filter, pt1FilterGain(dterm_lpf1_init_hz, pidRuntime.dT), XYZ_AXIS_COUNT);
             break;
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf1_static_hz < pidFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterVec3ApplyDF1;
+                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayDF1;
 #else
-                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
+                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
 #endif
-                biquadFilterVec3InitLPF(&pidRuntime.dtermLowpass.biquadFilter, dterm_lpf1_init_hz, pidRuntime.dT);
+                biquadFilterInitArrayLPF(&pidRuntime.dtermLowpass.biquadFilter, dterm_lpf1_init_hz, pidRuntime.dT, XYZ_AXIS_COUNT);
             } else {
                 pidRuntime.dtermLowpassApplyFn = nullFilterVec3Apply;
             }
             break;
         case FILTER_PT2:
-            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt2FilterVec3Apply;
-             pt2FilterVec3Init(&pidRuntime.dtermLowpass.pt2Filter, pt2FilterGain(dterm_lpf1_init_hz, pidRuntime.dT));
+            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt2FilterApplyArray;
+             pt2FilterInitArray(&pidRuntime.dtermLowpass.pt2Filter, pt2FilterGain(dterm_lpf1_init_hz, pidRuntime.dT), XYZ_AXIS_COUNT);
             break;
         case FILTER_PT3:
-            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt3FilterVec3Apply;
-             pt3FilterVec3Init(&pidRuntime.dtermLowpass.pt3Filter, pt3FilterGain(dterm_lpf1_init_hz, pidRuntime.dT));
+            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt3FilterApplyArray;
+             pt3FilterInitArray(&pidRuntime.dtermLowpass.pt3Filter, pt3FilterGain(dterm_lpf1_init_hz, pidRuntime.dT), XYZ_AXIS_COUNT);
             break;
         default:
             pidRuntime.dtermLowpassApplyFn = nullFilterVec3Apply;
@@ -209,24 +209,24 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     if (pidProfile->dterm_lpf2_static_hz > 0) {
         switch (pidProfile->dterm_lpf2_type) {
         case FILTER_PT1:
-            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt1FilterVec3Apply;
-            pt1FilterVec3Init(&pidRuntime.dtermLowpass2.pt1Filter, pt1FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT));
+            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt1FilterApplyArray;
+            pt1FilterInitArray(&pidRuntime.dtermLowpass2.pt1Filter, pt1FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT), XYZ_AXIS_COUNT);
             break;
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf2_static_hz < pidFrequencyNyquist) {
-                pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
-                biquadFilterVec3InitLPF(&pidRuntime.dtermLowpass2.biquadFilter, pidProfile->dterm_lpf2_static_hz, pidRuntime.dT);
+                pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
+                biquadFilterInitArrayLPF(&pidRuntime.dtermLowpass2.biquadFilter, pidProfile->dterm_lpf2_static_hz, pidRuntime.dT, XYZ_AXIS_COUNT);
             } else {
                 pidRuntime.dtermLowpass2ApplyFn = nullFilterVec3Apply;
             }
             break;
         case FILTER_PT2:
-            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt2FilterVec3Apply;
-            pt2FilterVec3Init(&pidRuntime.dtermLowpass2.pt2Filter, pt2FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT));
+            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt2FilterApplyArray;
+            pt2FilterInitArray(&pidRuntime.dtermLowpass2.pt2Filter, pt2FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT), XYZ_AXIS_COUNT);
             break;
         case FILTER_PT3:
-            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt3FilterVec3Apply;
-             pt3FilterVec3Init(&pidRuntime.dtermLowpass2.pt3Filter, pt3FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT));
+            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt3FilterApplyArray;
+             pt3FilterInitArray(&pidRuntime.dtermLowpass2.pt3Filter, pt3FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT), XYZ_AXIS_COUNT);
             break;
         default:
             pidRuntime.dtermLowpass2ApplyFn = nullFilterVec3Apply;
@@ -249,13 +249,13 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 
 #if defined(USE_ITERM_RELAX)
     if (pidRuntime.itermRelax) {
-        pt1FilterVec3Init(&pidRuntime.windupLpf, pt1FilterGain(pidRuntime.itermRelaxCutoff, pidRuntime.dT));
+        pt1FilterInitArray(&pidRuntime.windupLpf, pt1FilterGain(pidRuntime.itermRelaxCutoff, pidRuntime.dT), XYZ_AXIS_COUNT);
     }
 #endif
 
 #if defined(USE_ABSOLUTE_CONTROL)
     if (pidRuntime.itermRelax) {
-        pt1FilterVec3Init(&pidRuntime.acLpf, pt1FilterGain(pidRuntime.acCutoff, pidRuntime.dT));
+        pt1FilterInitArray(&pidRuntime.acLpf, pt1FilterGain(pidRuntime.acCutoff, pidRuntime.dT), XYZ_AXIS_COUNT);
     }
 #endif
 
@@ -264,8 +264,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     // Otherwise if the pidProfile->d_max_xxx parameters are ever added to
     // in-flight adjustments and transition from 0 to > 0 in flight the feature
     // won't work because the filter wasn't initialized.
-    pt2FilterVec3Init(&pidRuntime.dMaxRange, pt2FilterGain(D_MAX_RANGE_HZ, pidRuntime.dT));
-    pt2FilterVec3Init(&pidRuntime.dMaxLowpass, pt2FilterGain(D_MAX_LOWPASS_HZ, pidRuntime.dT));
+    pt2FilterInitArray(&pidRuntime.dMaxRange, pt2FilterGain(D_MAX_RANGE_HZ, pidRuntime.dT), XYZ_AXIS_COUNT);
+    pt2FilterInitArray(&pidRuntime.dMaxLowpass, pt2FilterGain(D_MAX_LOWPASS_HZ, pidRuntime.dT), XYZ_AXIS_COUNT);
 #endif
 
 #if defined(USE_AIRMODE_LPF)
@@ -286,10 +286,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         pt1FilterInit(&pidRuntime.horizonSmoothingPt1, kHorizon);
     }
 
-    for (int axis = 0; axis < 2; axis++) {  // ROLL and PITCH only
-        pt3FilterInit(&pidRuntime.attitudeFilter[axis], k);
-    }
-    pt3FilterVec3Init(&pidRuntime.angleFeedforwardPt3, k2);
+    pt3FilterInitArray(&pidRuntime.attitudeFilter, k, 2);
+    pt3FilterInitArray(&pidRuntime.angleFeedforwardPt3, k2, XYZ_AXIS_COUNT);
     pidRuntime.angleYawSetpoint = 0.0f;
 #endif
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -155,9 +155,9 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     }
 
     if (dTermNotchHz != 0 && pidProfile->dterm_notch_cutoff != 0) {
-        pidRuntime.dtermNotchApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
+        pidRuntime.dtermNotchApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayVec3;
         const float notchQ = filterGetNotchQ(dTermNotchHz, pidProfile->dterm_notch_cutoff);
-        biquadFilterInitArrayNotch(&pidRuntime.dtermNotch, dTermNotchHz, pidRuntime.dT, notchQ, XYZ_AXIS_COUNT);
+        biquadFilterInitNotchArray(&pidRuntime.dtermNotch, dTermNotchHz, pidRuntime.dT, notchQ, XYZ_AXIS_COUNT);
     } else {
         pidRuntime.dtermNotchApplyFn = nullFilterVec3Apply;
     }
@@ -180,11 +180,11 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf1_static_hz < pidFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayDF1;
+                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterApplyDF1ArrayVec3;
 #else
-                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
+                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayVec3;
 #endif
-                biquadFilterInitArrayLPF(&pidRuntime.dtermLowpass.biquadFilter, dterm_lpf1_init_hz, pidRuntime.dT, XYZ_AXIS_COUNT);
+                biquadFilterInitLPFArray(&pidRuntime.dtermLowpass.biquadFilter, dterm_lpf1_init_hz, pidRuntime.dT, XYZ_AXIS_COUNT);
             } else {
                 pidRuntime.dtermLowpassApplyFn = nullFilterVec3Apply;
             }
@@ -214,8 +214,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
             break;
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf2_static_hz < pidFrequencyNyquist) {
-                pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
-                biquadFilterInitArrayLPF(&pidRuntime.dtermLowpass2.biquadFilter, pidProfile->dterm_lpf2_static_hz, pidRuntime.dT, XYZ_AXIS_COUNT);
+                pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayVec3;
+                biquadFilterInitLPFArray(&pidRuntime.dtermLowpass2.biquadFilter, pidProfile->dterm_lpf2_static_hz, pidRuntime.dT, XYZ_AXIS_COUNT);
             } else {
                 pidRuntime.dtermLowpass2ApplyFn = nullFilterVec3Apply;
             }

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -264,10 +264,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     // Otherwise if the pidProfile->d_max_xxx parameters are ever added to
     // in-flight adjustments and transition from 0 to > 0 in flight the feature
     // won't work because the filter wasn't initialized.
-    for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
-        pt2FilterVec3Init(&pidRuntime.dMaxRange, pt2FilterGain(D_MAX_RANGE_HZ, pidRuntime.dT));
-        pt2FilterVec3Init(&pidRuntime.dMaxLowpass, pt2FilterGain(D_MAX_LOWPASS_HZ, pidRuntime.dT));
-     }
+    pt2FilterVec3Init(&pidRuntime.dMaxRange, pt2FilterGain(D_MAX_RANGE_HZ, pidRuntime.dT));
+    pt2FilterVec3Init(&pidRuntime.dMaxLowpass, pt2FilterGain(D_MAX_LOWPASS_HZ, pidRuntime.dT));
 #endif
 
 #if defined(USE_AIRMODE_LPF)

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -155,9 +155,9 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     }
 
     if (dTermNotchHz != 0 && pidProfile->dterm_notch_cutoff != 0) {
-        pidRuntime.dtermNotchApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3Apply;
+        pidRuntime.dtermNotchApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
         const float notchQ = filterGetNotchQ(dTermNotchHz, pidProfile->dterm_notch_cutoff);
-        biquadFilterVec3InitNotch(&pidRuntime.dtermNotch, dTermNotchHz, pidRuntime.dT, notchQ, 1.0f);
+        biquadFilterVec3InitNotch(&pidRuntime.dtermNotch, dTermNotchHz, pidRuntime.dT, notchQ);
     } else {
         pidRuntime.dtermNotchApplyFn = nullFilterVec3Apply;
     }
@@ -174,15 +174,15 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     if (dterm_lpf1_init_hz > 0) {
         switch (pidProfile->dterm_lpf1_type) {
         case FILTER_PT1:
-            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFnPtr)pt1FilterVec3Apply;
+            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt1FilterVec3Apply;
             pt1FilterVec3Init(&pidRuntime.dtermLowpass.pt1Filter, pt1FilterGain(dterm_lpf1_init_hz, pidRuntime.dT));
             break;
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf1_static_hz < pidFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3ApplyDF1;
+                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterVec3ApplyDF1;
 #else
-                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3Apply;
+                pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
 #endif
                 biquadFilterVec3InitLPF(&pidRuntime.dtermLowpass.biquadFilter, dterm_lpf1_init_hz, pidRuntime.dT);
             } else {
@@ -190,11 +190,11 @@ void pidInitFilters(const pidProfile_t *pidProfile)
             }
             break;
         case FILTER_PT2:
-            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFnPtr)pt2FilterVec3Apply;
+            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt2FilterVec3Apply;
              pt2FilterVec3Init(&pidRuntime.dtermLowpass.pt2Filter, pt2FilterGain(dterm_lpf1_init_hz, pidRuntime.dT));
             break;
         case FILTER_PT3:
-            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFnPtr)pt3FilterVec3Apply;
+            pidRuntime.dtermLowpassApplyFn = (filterVec3ApplyFn *)pt3FilterVec3Apply;
              pt3FilterVec3Init(&pidRuntime.dtermLowpass.pt3Filter, pt3FilterGain(dterm_lpf1_init_hz, pidRuntime.dT));
             break;
         default:
@@ -209,23 +209,23 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     if (pidProfile->dterm_lpf2_static_hz > 0) {
         switch (pidProfile->dterm_lpf2_type) {
         case FILTER_PT1:
-            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFnPtr)pt1FilterVec3Apply;
+            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt1FilterVec3Apply;
             pt1FilterVec3Init(&pidRuntime.dtermLowpass2.pt1Filter, pt1FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT));
             break;
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf2_static_hz < pidFrequencyNyquist) {
-                pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3Apply;
+                pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
                 biquadFilterVec3InitLPF(&pidRuntime.dtermLowpass2.biquadFilter, pidProfile->dterm_lpf2_static_hz, pidRuntime.dT);
             } else {
                 pidRuntime.dtermLowpass2ApplyFn = nullFilterVec3Apply;
             }
             break;
         case FILTER_PT2:
-            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFnPtr)pt2FilterVec3Apply;
+            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt2FilterVec3Apply;
             pt2FilterVec3Init(&pidRuntime.dtermLowpass2.pt2Filter, pt2FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT));
             break;
         case FILTER_PT3:
-            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFnPtr)pt3FilterVec3Apply;
+            pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFn *)pt3FilterVec3Apply;
              pt3FilterVec3Init(&pidRuntime.dtermLowpass2.pt3Filter, pt3FilterGain(pidProfile->dterm_lpf2_static_hz, pidRuntime.dT));
             break;
         default:
@@ -239,7 +239,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
     if (pidProfile->yaw_lowpass_hz == 0) {
         pidRuntime.ptermYawLowpassApplyFn = nullFilterApply;
     } else {
-        pidRuntime.ptermYawLowpassApplyFn = (filterApplyFnPtr)pt1FilterApply;
+        pidRuntime.ptermYawLowpassApplyFn = (filterApplyFn *)pt1FilterApply;
         pt1FilterInit(&pidRuntime.ptermYawLowpass, pt1FilterGain(pidProfile->yaw_lowpass_hz, pidRuntime.dT));
     }
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -217,7 +217,7 @@ void pidInitFilters(const pidProfile_t *pidProfile)
                 pidRuntime.dtermLowpass2ApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3Apply;
                 biquadFilterVec3InitLPF(&pidRuntime.dtermLowpass2.biquadFilter, pidProfile->dterm_lpf2_static_hz, pidRuntime.dT);
             } else {
-                pidRuntime.dtermLowpassApplyFn = nullFilterVec3Apply;
+                pidRuntime.dtermLowpass2ApplyFn = nullFilterVec3Apply;
             }
             break;
         case FILTER_PT2:

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -364,7 +364,7 @@ void pidInit(const pidProfile_t *pidProfile)
     pidInitFilters(pidProfile);
     pidInitConfig(pidProfile);
 #ifdef USE_RPM_FILTER
-    rpmFilterInit(rpmFilterConfig(), gyro.targetLooptime);
+    rpmFilterInit(rpmFilterConfig(), pidRuntime.dT);
 #endif
 #ifdef USE_ADVANCED_TPA
     tpaCurveInit(pidProfile);

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -249,17 +249,13 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 
 #if defined(USE_ITERM_RELAX)
     if (pidRuntime.itermRelax) {
-        for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
-            pt1FilterInit(&pidRuntime.windupLpf[i], pt1FilterGain(pidRuntime.itermRelaxCutoff, pidRuntime.dT));
-        }
+        pt1FilterVec3Init(&pidRuntime.windupLpf, pt1FilterGain(pidRuntime.itermRelaxCutoff, pidRuntime.dT));
     }
 #endif
 
 #if defined(USE_ABSOLUTE_CONTROL)
     if (pidRuntime.itermRelax) {
-        for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
-            pt1FilterInit(&pidRuntime.acLpf[i], pt1FilterGain(pidRuntime.acCutoff, pidRuntime.dT));
-        }
+        pt1FilterVec3Init(&pidRuntime.acLpf, pt1FilterGain(pidRuntime.acCutoff, pidRuntime.dT));
     }
 #endif
 
@@ -294,8 +290,8 @@ void pidInitFilters(const pidProfile_t *pidProfile)
 
     for (int axis = 0; axis < 2; axis++) {  // ROLL and PITCH only
         pt3FilterInit(&pidRuntime.attitudeFilter[axis], k);
-        pt3FilterInit(&pidRuntime.angleFeedforwardPt3[axis], k2);
     }
+    pt3FilterVec3Init(&pidRuntime.angleFeedforwardPt3, k2);
     pidRuntime.angleYawSetpoint = 0.0f;
 #endif
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -42,22 +42,6 @@
 
 #include "rpm_filter.h"
 
-#define RPM_FILTER_DURATION_S    0.001f  // Maximum duration allowed to update all RPM notches once
-
-typedef struct rpmFilter_s {
-
-    int numHarmonics;
-    float weights[RPM_FILTER_HARMONICS_MAX];
-    float minHz;
-    float maxHz;
-    float fadeRangeHz;
-    float q;
-
-    timeUs_t looptimeUs;
-    biquadFilter_t notch[XYZ_AXIS_COUNT][MAX_SUPPORTED_MOTORS][RPM_FILTER_HARMONICS_MAX];
-
-} rpmFilter_t;
-
 // Singleton
 FAST_DATA_ZERO_INIT static rpmFilter_t rpmFilter;
 
@@ -66,7 +50,7 @@ FAST_DATA_ZERO_INIT static int notchUpdatesPerIteration;
 FAST_DATA_ZERO_INIT static int motorIndex;
 FAST_DATA_ZERO_INIT static int harmonicIndex;
 
-void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
+void rpmFilterInit(const rpmFilterConfig_t *config, const float dt)
 {
     motorIndex = 0;
     harmonicIndex = 0;
@@ -85,10 +69,10 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
     // if we get to this point, enable and init RPM filtering
     rpmFilter.numHarmonics = config->rpm_filter_harmonics;
     rpmFilter.minHz = config->rpm_filter_min_hz;
-    rpmFilter.maxHz = 0.48f * 1e6f / looptimeUs; // don't go quite to nyquist to avoid oscillations
+    rpmFilter.maxHz = 0.48f / dt; // don't go quite to nyquist to avoid oscillations
     rpmFilter.fadeRangeHz = config->rpm_filter_fade_range_hz;
     rpmFilter.q = config->rpm_filter_q / 100.0f;
-    rpmFilter.looptimeUs = looptimeUs;
+    rpmFilter.dt = dt;
 
     for (int n = 0; n < RPM_FILTER_HARMONICS_MAX; n++) {
         rpmFilter.weights[n] = constrainf(config->rpm_filter_weights[n] / 100.0f, 0.0f, 1.0f);
@@ -97,12 +81,12 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         for (int motor = 0; motor < getMotorCount(); motor++) {
             for (int i = 0; i < rpmFilter.numHarmonics; i++) {
-                biquadFilterInit(&rpmFilter.notch[axis][motor][i], rpmFilter.minHz * i, rpmFilter.looptimeUs, rpmFilter.q, FILTER_NOTCH, 0.0f);
+                biquadFilterVec3InitNotch(&rpmFilter.notch[motor][i], rpmFilter.minHz * i, rpmFilter.dt, rpmFilter.q, 0.0f);
             }
         }
     }
 
-    const float loopIterationsPerUpdate = RPM_FILTER_DURATION_S / (looptimeUs * 1e-6f);
+    const float loopIterationsPerUpdate = RPM_FILTER_DURATION_S / dt;
     const float numNotchesPerAxis = getMotorCount() * rpmFilter.numHarmonics;
     notchUpdatesPerIteration = ceilf(numNotchesPerAxis / loopIterationsPerUpdate); // round to ceiling
 }
@@ -122,17 +106,13 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
     }
 
     const float dtCompensation = schedulerGetCycleTimeMultiplier();
-    const float correctedLooptime = rpmFilter.looptimeUs * dtCompensation;
+    const float correctedLooptime = rpmFilter.dt * dtCompensation;
 
     // update RPM notches
     for (int i = 0; i < notchUpdatesPerIteration; i++) {
 
         // Only bother updating notches which have an effect on filtered output
         if (rpmFilter.weights[harmonicIndex] > 0.0f) {
-
-            // select current notch on ROLL
-            biquadFilter_t *template = &rpmFilter.notch[0][motorIndex][harmonicIndex];
-
             const float frequencyHz = constrainf((harmonicIndex + 1) * getMotorFrequencyHz(motorIndex), rpmFilter.minHz, rpmFilter.maxHz);
             const float marginHz = frequencyHz - rpmFilter.minHz;
             float weight = 1.0f;
@@ -146,18 +126,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             weight *= rpmFilter.weights[harmonicIndex];
 
             // update notch
-            biquadFilterUpdate(template, frequencyHz, correctedLooptime, rpmFilter.q, FILTER_NOTCH, weight);
-
-            // copy notch properties to corresponding notches on PITCH and YAW
-            for (int axis = 1; axis < XYZ_AXIS_COUNT; axis++) {
-                biquadFilter_t *dest = &rpmFilter.notch[axis][motorIndex][harmonicIndex];
-                dest->b0 = template->b0;
-                dest->b1 = template->b1;
-                dest->b2 = template->b2;
-                dest->a1 = template->a1;
-                dest->a2 = template->a2;
-                dest->weight = template->weight;
-            }
+            biquadFilterVec3UpdateNotch(&rpmFilter.notch[motorIndex][harmonicIndex], frequencyHz, correctedLooptime, rpmFilter.q, weight);
         }
 
         // cycle through all notches on ROLL (takes RPM_FILTER_DURATION_S at max.)
@@ -179,7 +148,7 @@ FAST_CODE float rpmFilterApply(const int axis, float value)
         }
 
         for (int motor = 0; motor < getMotorCount(); motor++) {
-            value = biquadFilterApplyDF1Weighted(&rpmFilter.notch[axis][motor][i], value);
+            value = biquadFilterVec3ApplyDF1Weighted(&rpmFilter.notch[motor][i], value, axis);
         }
     }
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -77,7 +77,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const float dt)
 
     for (int motor = 0; motor < getMotorCount(); motor++) {
         for (int i = 0; i < rpmFilter.numHarmonics; i++) {
-            biquadFilterVec3InitNotchWeighted(&rpmFilter.notch[motor][i], MIN(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f);
+            biquadFilterInitArrayNotchWeighted(&rpmFilter.notch[motor][i], MIN(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f, XYZ_AXIS_COUNT);
         }
     }
 
@@ -123,7 +123,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             weight *= rpmFilter.weights[harmonicIndex];
 
             // update notch
-            biquadFilterVec3UpdateNotchWeighted(&rpmFilter.notch[motorIndex][harmonicIndex], frequencyHz, correctedLooptime, rpmFilter.q, weight);
+            biquadFilterUpdateNotchWeighted(&rpmFilter.notch[motorIndex][harmonicIndex], frequencyHz, correctedLooptime, rpmFilter.q, weight);
         }
 
         // cycle through all notches on ROLL (takes RPM_FILTER_DURATION_S at max.)
@@ -145,7 +145,7 @@ FAST_CODE float rpmFilterApply(const int axis, float value)
         }
 
         for (int motor = 0; motor < getMotorCount(); motor++) {
-            value = biquadFilterVec3ApplyDF1(&rpmFilter.notch[motor][i], value, axis);
+            value = biquadFilterApplyArray(&rpmFilter.notch[motor][i], value, axis);
         }
     }
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -77,7 +77,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const float dt)
 
     for (int motor = 0; motor < getMotorCount(); motor++) {
         for (int i = 0; i < rpmFilter.numHarmonics; i++) {
-            biquadFilterVec3InitNotch(&rpmFilter.notch[motor][i], rpmFilter.minHz * i, rpmFilter.dt, rpmFilter.q, 0.0f);
+            biquadFilterVec3InitNotch(&rpmFilter.notch[motor][i], constrainf(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f);
         }
     }
 
@@ -102,10 +102,11 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
         }
     }
 
+    const float dtCompensation = schedulerGetCycleTimeMultiplier();
+    const float correctedLooptime = rpmFilter.dt * dtCompensation;
+
     // update RPM notches
     for (int i = 0; i < notchUpdatesPerIteration; i++) {
-        const float dtCompensation = schedulerGetCycleTimeMultiplier();
-        const float correctedLooptime = rpmFilter.dt * dtCompensation;
 
         // Only bother updating notches which have an effect on filtered output
         if (rpmFilter.weights[harmonicIndex] > 0.0f) {

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -77,7 +77,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const float dt)
 
     for (int motor = 0; motor < getMotorCount(); motor++) {
         for (int i = 0; i < rpmFilter.numHarmonics; i++) {
-            biquadFilterInitArrayNotchWeighted(&rpmFilter.notch[motor][i], MIN(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f, XYZ_AXIS_COUNT);
+            biquadFilterInitNotchWeightedArray(&rpmFilter.notch[motor][i], MIN(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f, XYZ_AXIS_COUNT);
         }
     }
 
@@ -121,7 +121,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             weight *= rpmFilter.weights[harmonicIndex];
 
             // update notch
-            biquadFilterUpdateNotchWeighted(&rpmFilter.notch[motorIndex][harmonicIndex], frequencyHz, correctedLooptime, rpmFilter.q, weight);
+            biquadFilterCoeffsNotchWeighted(&rpmFilter.notch[motorIndex][harmonicIndex].coeffs, frequencyHz, correctedLooptime, rpmFilter.q, weight);
         }
 
         // cycle through all notches on ROLL (takes RPM_FILTER_DURATION_S at max.)

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -77,7 +77,7 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const float dt)
 
     for (int motor = 0; motor < getMotorCount(); motor++) {
         for (int i = 0; i < rpmFilter.numHarmonics; i++) {
-            biquadFilterVec3InitNotch(&rpmFilter.notch[motor][i], constrainf(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f);
+            biquadFilterVec3InitNotchWeighted(&rpmFilter.notch[motor][i], MIN(rpmFilter.minHz * (i+1), rpmFilter.maxHz), rpmFilter.dt, rpmFilter.q, 0.0f);
         }
     }
 
@@ -123,7 +123,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             weight *= rpmFilter.weights[harmonicIndex];
 
             // update notch
-            biquadFilterVec3UpdateNotch(&rpmFilter.notch[motorIndex][harmonicIndex], frequencyHz, correctedLooptime, rpmFilter.q, weight);
+            biquadFilterVec3UpdateNotchWeighted(&rpmFilter.notch[motorIndex][harmonicIndex], frequencyHz, correctedLooptime, rpmFilter.q, weight);
         }
 
         // cycle through all notches on ROLL (takes RPM_FILTER_DURATION_S at max.)
@@ -145,7 +145,7 @@ FAST_CODE float rpmFilterApply(const int axis, float value)
         }
 
         for (int motor = 0; motor < getMotorCount(); motor++) {
-            value = biquadFilterVec3ApplyDF1Weighted(&rpmFilter.notch[motor][i], value, axis);
+            value = biquadFilterVec3ApplyDF1(&rpmFilter.notch[motor][i], value, axis);
         }
     }
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -96,10 +96,8 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
         return;
     }
 
-    if (debugMode == DEBUG_RPM_FILTER) {
-        for (int motor = 0; motor < getMotorCount() && motor < DEBUG16_VALUE_COUNT; motor++) {
-            DEBUG_SET(DEBUG_RPM_FILTER, motor, lrintf(getMotorFrequencyHz(motor)));
-        }
+    for (int motor = 0; motor < getMotorCount() && motor < DEBUG16_VALUE_COUNT; motor++) {
+        DEBUG_SET(DEBUG_RPM_FILTER, motor, lrintf(getMotorFrequencyHz(motor)));
     }
 
     const float dtCompensation = schedulerGetCycleTimeMultiplier();

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -97,19 +97,20 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
         return;
     }
 
-    for (int motor = 0; motor < getMotorCount() && motor < DEBUG16_VALUE_COUNT; motor++) {
-        DEBUG_SET(DEBUG_RPM_FILTER, motor, lrintf(getMotorFrequencyHz(motor)));
-    }
-
     if (!isRpmFilterEnabled()) {
         return;
     }
 
-    const float dtCompensation = schedulerGetCycleTimeMultiplier();
-    const float correctedLooptime = rpmFilter.dt * dtCompensation;
+    if (debugMode == DEBUG_RPM_FILTER) {
+        for (int motor = 0; motor < getMotorCount() && motor < DEBUG16_VALUE_COUNT; motor++) {
+            DEBUG_SET(DEBUG_RPM_FILTER, motor, lrintf(getMotorFrequencyHz(motor)));
+        }
+    }
 
     // update RPM notches
     for (int i = 0; i < notchUpdatesPerIteration; i++) {
+        const float dtCompensation = schedulerGetCycleTimeMultiplier();
+        const float correctedLooptime = rpmFilter.dt * dtCompensation;
 
         // Only bother updating notches which have an effect on filtered output
         if (rpmFilter.weights[harmonicIndex] > 0.0f) {

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -26,15 +26,12 @@
 
 #include "build/debug.h"
 
-#include "common/filter.h"
 #include "common/maths.h"
 
 #include "drivers/dshot.h"
 
 #include "flight/mixer.h"
 #include "flight/pid.h"
-
-#include "pg/motor.h"
 
 #include "scheduler/scheduler.h"
 
@@ -78,11 +75,9 @@ void rpmFilterInit(const rpmFilterConfig_t *config, const float dt)
         rpmFilter.weights[n] = constrainf(config->rpm_filter_weights[n] / 100.0f, 0.0f, 1.0f);
     }
 
-    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        for (int motor = 0; motor < getMotorCount(); motor++) {
-            for (int i = 0; i < rpmFilter.numHarmonics; i++) {
-                biquadFilterVec3InitNotch(&rpmFilter.notch[motor][i], rpmFilter.minHz * i, rpmFilter.dt, rpmFilter.q, 0.0f);
-            }
+    for (int motor = 0; motor < getMotorCount(); motor++) {
+        for (int i = 0; i < rpmFilter.numHarmonics; i++) {
+            biquadFilterVec3InitNotch(&rpmFilter.notch[motor][i], rpmFilter.minHz * i, rpmFilter.dt, rpmFilter.q, 0.0f);
         }
     }
 

--- a/src/main/flight/rpm_filter.h
+++ b/src/main/flight/rpm_filter.h
@@ -23,7 +23,9 @@
 #include <stdbool.h>
 
 #include "common/time.h"
+#include "common/filter.h"
 
+#include "pg/motor.h"
 #include "pg/rpm_filter.h"
 
 #define RPM_FILTER_DURATION_S    0.001f  // Maximum duration allowed to update all RPM notches once

--- a/src/main/flight/rpm_filter.h
+++ b/src/main/flight/rpm_filter.h
@@ -26,7 +26,23 @@
 
 #include "pg/rpm_filter.h"
 
-void rpmFilterInit(const rpmFilterConfig_t *config, const timeUs_t looptimeUs);
+#define RPM_FILTER_DURATION_S    0.001f  // Maximum duration allowed to update all RPM notches once
+
+typedef struct rpmFilter_s {
+
+    int numHarmonics;
+    float weights[RPM_FILTER_HARMONICS_MAX];
+    float minHz;
+    float maxHz;
+    float fadeRangeHz;
+    float q;
+
+    float dt;
+    biquadFilterVec3_t notch[MAX_SUPPORTED_MOTORS][RPM_FILTER_HARMONICS_MAX];
+
+} rpmFilter_t;
+
+void rpmFilterInit(const rpmFilterConfig_t *config, const float dt);
 void rpmFilterUpdate(void);
 float rpmFilterApply(const int axis, float value);
 bool isRpmFilterEnabled(void);

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -546,7 +546,7 @@ void servosFilterInit(void)
 {
     if (servoConfig()->servo_lowpass_freq) {
         for (int servoIdx = 0; servoIdx < MAX_SUPPORTED_SERVOS; servoIdx++) {
-            biquadFilterInitLPF(&servoFilter[servoIdx], servoConfig()->servo_lowpass_freq, targetPidLooptime);
+            biquadFilterInitLPF(&servoFilter[servoIdx], servoConfig()->servo_lowpass_freq, targetPidLooptime * 1e-6f);
         }
     }
 

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -540,14 +540,12 @@ bool isMixerUsingServos(void)
     return useServo;
 }
 
-static biquadFilter_t servoFilter[MAX_SUPPORTED_SERVOS];
+static biquadFilter_t servoFilter;
 
 void servosFilterInit(void)
 {
     if (servoConfig()->servo_lowpass_freq) {
-        for (int servoIdx = 0; servoIdx < MAX_SUPPORTED_SERVOS; servoIdx++) {
-            biquadFilterInitLPF(&servoFilter[servoIdx], servoConfig()->servo_lowpass_freq, targetPidLooptime * 1e-6f);
-        }
+        biquadFilterInitArrayLPF(&servoFilter, servoConfig()->servo_lowpass_freq, targetPidLooptime, MAX_SUPPORTED_SERVOS);
     }
 
 }
@@ -558,7 +556,7 @@ static void filterServos(void)
 #endif
     if (servoConfig()->servo_lowpass_freq) {
         for (int servoIdx = 0; servoIdx < MAX_SUPPORTED_SERVOS; servoIdx++) {
-            servo[servoIdx] = lrintf(biquadFilterApply(&servoFilter[servoIdx], (float)servo[servoIdx]));
+            servo[servoIdx] = lrintf(biquadFilterApplyArray(&servoFilter, (float)servo[servoIdx], servoIdx));
             // Sanity check
             servo[servoIdx] = constrain(servo[servoIdx], servoParams(servoIdx)->min, servoParams(servoIdx)->max);
         }

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -540,12 +540,12 @@ bool isMixerUsingServos(void)
     return useServo;
 }
 
-static biquadFilter_t servoFilter;
+static biquadFilterServoCount_t  servoFilter;
 
 void servosFilterInit(void)
 {
     if (servoConfig()->servo_lowpass_freq) {
-        biquadFilterInitArrayLPF(&servoFilter, servoConfig()->servo_lowpass_freq, targetPidLooptime, MAX_SUPPORTED_SERVOS);
+        biquadFilterInitArrayLPF(&servoFilter, servoConfig()->servo_lowpass_freq, targetPidLooptime * 1e-6f, MAX_SUPPORTED_SERVOS);
     }
 
 }

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -545,7 +545,7 @@ static biquadFilterServoCount_t  servoFilter;
 void servosFilterInit(void)
 {
     if (servoConfig()->servo_lowpass_freq) {
-        biquadFilterInitArrayLPF(&servoFilter, servoConfig()->servo_lowpass_freq, targetPidLooptime * 1e-6f, MAX_SUPPORTED_SERVOS);
+        biquadFilterInitLPFArray(&servoFilter, servoConfig()->servo_lowpass_freq, targetPidLooptime * 1e-6f, MAX_SUPPORTED_SERVOS);
     }
 
 }

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -84,7 +84,7 @@ static inline void postProcessAccelerometer(void)
         }
 
         if (accelerationRuntime.accLpfCutHz) {
-            acc.accADC.v[axis] = pt2FilterApply(&accelerationRuntime.accFilter[axis], acc.accADC.v[axis]);
+            acc.accADC.v[axis] = pt2FilterVec3Apply(&accelerationRuntime.accFilter, acc.accADC.v[axis], axis);
         }
 
         // Calculate derivative of acc (jerk)

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -84,7 +84,7 @@ static inline void postProcessAccelerometer(void)
         }
 
         if (accelerationRuntime.accLpfCutHz) {
-            acc.accADC.v[axis] = pt2FilterVec3Apply(&accelerationRuntime.accFilter, acc.accADC.v[axis], axis);
+            acc.accADC.v[axis] = pt2FilterApplyArray(&accelerationRuntime.accFilter, acc.accADC.v[axis], axis);
         }
 
         // Calculate derivative of acc (jerk)

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -349,7 +349,7 @@ void accInitFilters(void)
     // the filter initialization is not defined (sample rate = 0)
     accelerationRuntime.accLpfCutHz = (acc.sampleRateHz) ? accelerometerConfig()->acc_lpf_hz : 0;
     if (accelerationRuntime.accLpfCutHz) {
-        pt2FilterVec3Init(&accelerationRuntime.accFilter, pt2FilterGain(accelerationRuntime.accLpfCutHz, HZ_TO_INTERVAL(acc.sampleRateHz)));
+        pt2FilterInitArray(&accelerationRuntime.accFilter, pt2FilterGain(accelerationRuntime.accLpfCutHz, HZ_TO_INTERVAL(acc.sampleRateHz)), XYZ_AXIS_COUNT);
     }
 }
 

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -349,10 +349,7 @@ void accInitFilters(void)
     // the filter initialization is not defined (sample rate = 0)
     accelerationRuntime.accLpfCutHz = (acc.sampleRateHz) ? accelerometerConfig()->acc_lpf_hz : 0;
     if (accelerationRuntime.accLpfCutHz) {
-        const float k = pt2FilterGain(accelerationRuntime.accLpfCutHz, HZ_TO_INTERVAL(acc.sampleRateHz));
-        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            pt2FilterInit(&accelerationRuntime.accFilter[axis], k);
-        }
+        pt2FilterVec3Init(&accelerationRuntime.accFilter, pt2FilterGain(accelerationRuntime.accLpfCutHz, HZ_TO_INTERVAL(acc.sampleRateHz)));
     }
 }
 

--- a/src/main/sensors/acceleration_init.h
+++ b/src/main/sensors/acceleration_init.h
@@ -30,7 +30,7 @@
 
 typedef struct accelerationRuntime_s {
     uint16_t accLpfCutHz;
-    pt2Filter_t accFilter[XYZ_AXIS_COUNT];
+    pt2FilterVec3_t accFilter;
     flightDynamicsTrims_t *accelerationTrims;
     uint16_t calibratingA;      // the calibration is done is the main loop. Calibrating decreases at each cycle down to 0, then we enter in a normal mode.
 } accelerationRuntime_t;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -594,7 +594,7 @@ void dynLpfGyroUpdate(float throttle)
             pt1FilterUpdateCutoff(&gyro.lowpassFilter.pt1Filter, pt1FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_BIQUAD:
-            biquadFilterUpdateLPF(&gyro.lowpassFilter.biquadFilter, cutoffFreq, gyroDt);
+            biquadFilterCoeffsLPF(&gyro.lowpassFilter.biquadFilter.coeffs, cutoffFreq, gyroDt);
             break;
         case  DYN_LPF_PT2:
             pt2FilterUpdateCutoff(&gyro.lowpassFilter.pt2Filter, pt2FilterGain(cutoffFreq, gyroDt));

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -425,21 +425,21 @@ FAST_CODE void gyroUpdate(void)
     }
 
     if (active != 0) {
-        gyro.gyroADC[X] = adcSum[X] / active;
-        gyro.gyroADC[Y] = adcSum[Y] / active;
-        gyro.gyroADC[Z] = adcSum[Z] / active;
+        for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
+            gyro.gyroADC[axis] = adcSum[axis] / active;
+        }
     }
 
     if (gyro.downsampleFilterEnabled) {
         // using gyro lowpass 2 filter for downsampling
-        gyro.sampleSum[X] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[X], X);
-        gyro.sampleSum[Y] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[Y], Y);
-        gyro.sampleSum[Z] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[Z], Z);
+        for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
+            gyro.sampleSum[axis] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[axis], axis);
+        }
     } else {
         // using simple averaging for downsampling
-        gyro.sampleSum[X] += gyro.gyroADC[X];
-        gyro.sampleSum[Y] += gyro.gyroADC[Y];
-        gyro.sampleSum[Z] += gyro.gyroADC[Z];
+        for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
+            gyro.sampleSum[axis] += gyro.gyroADC[axis];
+        }
         gyro.sampleCount++;
     }
 }
@@ -591,16 +591,16 @@ void dynLpfGyroUpdate(float throttle)
         const float gyroDt = gyro.targetLooptime * 1e-6f;
         switch (gyro.dynLpfFilter) {
         case DYN_LPF_PT1:
-            pt1FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt1FilterState, pt1FilterGain(cutoffFreq, gyroDt));
+            pt1FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt1Filter, pt1FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_BIQUAD:
-            biquadFilterVec3UpdateLPF(&gyro.lowpassFilter.biquadFilterState, cutoffFreq, gyroDt);
+            biquadFilterVec3UpdateLPF(&gyro.lowpassFilter.biquadFilter, cutoffFreq, gyroDt);
             break;
         case  DYN_LPF_PT2:
-            pt2FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt2FilterState, pt2FilterGain(cutoffFreq, gyroDt));
+            pt2FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt2Filter, pt2FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_PT3:
-            pt3FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt3FilterState, pt3FilterGain(cutoffFreq, gyroDt));
+            pt3FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt3Filter, pt3FilterGain(cutoffFreq, gyroDt));
             break;
         }
     }

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -594,7 +594,7 @@ void dynLpfGyroUpdate(float throttle)
             pt1FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt1FilterState, pt1FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_BIQUAD:
-            biquadFilterVec3UpdateLPF(&gyro.lowpassFilter.biquadFilterState, cutoffFreq, gyro.targetLooptime);
+            biquadFilterVec3UpdateLPF(&gyro.lowpassFilter.biquadFilterState, cutoffFreq, gyroDt);
             break;
         case  DYN_LPF_PT2:
             pt2FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt2FilterState, pt2FilterGain(cutoffFreq, gyroDt));

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -510,7 +510,7 @@ FAST_CODE void gyroFiltering(timeUs_t currentTimeUs)
 
     if (!overflowDetected) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            gyroFilteredDownsampled[axis] = pt1FilterVec3Apply(&gyro.imuGyroFilter, gyro.gyroADCf[axis], axis);
+            gyroFilteredDownsampled[axis] = pt1FilterApplyArray(&gyro.imuGyroFilter, gyro.gyroADCf[axis], axis);
         }
     }
 
@@ -591,16 +591,16 @@ void dynLpfGyroUpdate(float throttle)
         const float gyroDt = gyro.targetLooptime * 1e-6f;
         switch (gyro.dynLpfFilter) {
         case DYN_LPF_PT1:
-            pt1FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt1Filter, pt1FilterGain(cutoffFreq, gyroDt));
+            pt1FilterUpdateCutoff(&gyro.lowpassFilter.pt1Filter, pt1FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_BIQUAD:
-            biquadFilterVec3UpdateLPF(&gyro.lowpassFilter.biquadFilter, cutoffFreq, gyroDt);
+            biquadFilterUpdateLPF(&gyro.lowpassFilter.biquadFilter, cutoffFreq, gyroDt);
             break;
         case  DYN_LPF_PT2:
-            pt2FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt2Filter, pt2FilterGain(cutoffFreq, gyroDt));
+            pt2FilterUpdateCutoff(&gyro.lowpassFilter.pt2Filter, pt2FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_PT3:
-            pt3FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt3Filter, pt3FilterGain(cutoffFreq, gyroDt));
+            pt3FilterUpdateCutoff(&gyro.lowpassFilter.pt3Filter, pt3FilterGain(cutoffFreq, gyroDt));
             break;
         }
     }

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -432,9 +432,9 @@ FAST_CODE void gyroUpdate(void)
 
     if (gyro.downsampleFilterEnabled) {
         // using gyro lowpass 2 filter for downsampling
-        gyro.sampleSum[X] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter[X], gyro.gyroADC[X]);
-        gyro.sampleSum[Y] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter[Y], gyro.gyroADC[Y]);
-        gyro.sampleSum[Z] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter[Z], gyro.gyroADC[Z]);
+        gyro.sampleSum[X] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[X], X);
+        gyro.sampleSum[Y] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[Y], Y);
+        gyro.sampleSum[Z] = gyro.lowpass2FilterApplyFn((filter_t *)&gyro.lowpass2Filter, gyro.gyroADC[Z], Z);
     } else {
         // using simple averaging for downsampling
         gyro.sampleSum[X] += gyro.gyroADC[X];
@@ -510,7 +510,7 @@ FAST_CODE void gyroFiltering(timeUs_t currentTimeUs)
 
     if (!overflowDetected) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            gyroFilteredDownsampled[axis] = pt1FilterApply(&gyro.imuGyroFilter[axis], gyro.gyroADCf[axis]);
+            gyroFilteredDownsampled[axis] = pt1FilterVec3Apply(&gyro.imuGyroFilter, gyro.gyroADCf[axis], axis);
         }
     }
 
@@ -591,24 +591,16 @@ void dynLpfGyroUpdate(float throttle)
         const float gyroDt = gyro.targetLooptime * 1e-6f;
         switch (gyro.dynLpfFilter) {
         case DYN_LPF_PT1:
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                pt1FilterUpdateCutoff(&gyro.lowpassFilter[axis].pt1FilterState, pt1FilterGain(cutoffFreq, gyroDt));
-            }
+            pt1FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt1FilterState, pt1FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_BIQUAD:
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                biquadFilterUpdateLPF(&gyro.lowpassFilter[axis].biquadFilterState, cutoffFreq, gyro.targetLooptime);
-            }
+            biquadFilterVec3UpdateLPF(&gyro.lowpassFilter.biquadFilterState, cutoffFreq, gyro.targetLooptime);
             break;
         case  DYN_LPF_PT2:
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                pt2FilterUpdateCutoff(&gyro.lowpassFilter[axis].pt2FilterState, pt2FilterGain(cutoffFreq, gyroDt));
-            }
+            pt2FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt2FilterState, pt2FilterGain(cutoffFreq, gyroDt));
             break;
         case DYN_LPF_PT3:
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                pt3FilterUpdateCutoff(&gyro.lowpassFilter[axis].pt3FilterState, pt3FilterGain(cutoffFreq, gyroDt));
-            }
+            pt3FilterVec3UpdateCutoff(&gyro.lowpassFilter.pt3FilterState, pt3FilterGain(cutoffFreq, gyroDt));
             break;
         }
     }

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -53,13 +53,6 @@
 
 #define GYRO_MASK(x) BIT(x)
 
-typedef union gyroLowpassFilter_u {
-    pt1FilterVec3_t pt1FilterState;
-    biquadFilterVec3_t biquadFilterState;
-    pt2FilterVec3_t pt2FilterState;
-    pt3FilterVec3_t pt3FilterState;
-} gyroLowpassFilter_t;
-
 typedef struct gyroCalibration_s {
     float sum[XYZ_AXIS_COUNT];
     stdev_t var[XYZ_AXIS_COUNT];
@@ -87,18 +80,18 @@ typedef struct gyro_s {
     gyroDev_t *rawSensorDev;           // pointer to the sensor providing the raw data for DEBUG_GYRO_RAW
 
     // lowpass gyro soft filter
-    filterVec3ApplyFnPtr lowpassFilterApplyFn;
-    gyroLowpassFilter_t lowpassFilter;
+    filterVec3ApplyFn *lowpassFilterApplyFn;
+    lowpassFilterVec3_t lowpassFilter;
 
     // lowpass2 gyro soft filter
-    filterVec3ApplyFnPtr lowpass2FilterApplyFn;
-    gyroLowpassFilter_t lowpass2Filter;
+    filterVec3ApplyFn *lowpass2FilterApplyFn;
+    lowpassFilterVec3_t lowpass2Filter;
 
     // notch filters
-    filterVec3ApplyFnPtr notchFilter1ApplyFn;
+    filterVec3ApplyFn *notchFilter1ApplyFn;
     biquadFilterVec3_t notchFilter1;
 
-    filterVec3ApplyFnPtr notchFilter2ApplyFn;
+    filterVec3ApplyFn *notchFilter2ApplyFn;
     biquadFilterVec3_t notchFilter2;
 
     uint16_t accSampleRateHz;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -54,10 +54,10 @@
 #define GYRO_MASK(x) BIT(x)
 
 typedef union gyroLowpassFilter_u {
-    pt1Filter_t pt1FilterState;
-    biquadFilter_t biquadFilterState;
-    pt2Filter_t pt2FilterState;
-    pt3Filter_t pt3FilterState;
+    pt1FilterVec3_t pt1FilterState;
+    biquadFilterVec3_t biquadFilterState;
+    pt2FilterVec3_t pt2FilterState;
+    pt3FilterVec3_t pt3FilterState;
 } gyroLowpassFilter_t;
 
 typedef struct gyroCalibration_s {
@@ -87,19 +87,19 @@ typedef struct gyro_s {
     gyroDev_t *rawSensorDev;           // pointer to the sensor providing the raw data for DEBUG_GYRO_RAW
 
     // lowpass gyro soft filter
-    filterApplyFnPtr lowpassFilterApplyFn;
-    gyroLowpassFilter_t lowpassFilter[XYZ_AXIS_COUNT];
+    filterVec3ApplyFnPtr lowpassFilterApplyFn;
+    gyroLowpassFilter_t lowpassFilter;
 
     // lowpass2 gyro soft filter
-    filterApplyFnPtr lowpass2FilterApplyFn;
-    gyroLowpassFilter_t lowpass2Filter[XYZ_AXIS_COUNT];
+    filterVec3ApplyFnPtr lowpass2FilterApplyFn;
+    gyroLowpassFilter_t lowpass2Filter;
 
     // notch filters
-    filterApplyFnPtr notchFilter1ApplyFn;
-    biquadFilter_t notchFilter1[XYZ_AXIS_COUNT];
+    filterVec3ApplyFnPtr notchFilter1ApplyFn;
+    biquadFilterVec3_t notchFilter1;
 
-    filterApplyFnPtr notchFilter2ApplyFn;
-    biquadFilter_t notchFilter2[XYZ_AXIS_COUNT];
+    filterVec3ApplyFnPtr notchFilter2ApplyFn;
+    biquadFilterVec3_t notchFilter2;
 
     uint16_t accSampleRateHz;
     uint8_t gyroEnabledBitmask;
@@ -118,7 +118,7 @@ typedef struct gyro_s {
 #ifdef USE_GYRO_OVERFLOW_CHECK
     uint8_t overflowAxisMask;
 #endif
-    pt1Filter_t imuGyroFilter[XYZ_AXIS_COUNT];
+    pt1FilterVec3_t imuGyroFilter;
 } gyro_t;
 
 extern gyro_t gyro;

--- a/src/main/sensors/gyro_filter_impl.c
+++ b/src/main/sensors/gyro_filter_impl.c
@@ -53,9 +53,9 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(void)
         GYRO_FILTER_AXIS_DEBUG_SET(axis, DEBUG_GYRO_SAMPLE, 2, lrintf(gyroADCf));
 
         // apply static notch filters and software lowpass filters
-        gyroADCf = gyro.notchFilter1ApplyFn((filter_t *)&gyro.notchFilter1[axis], gyroADCf);
-        gyroADCf = gyro.notchFilter2ApplyFn((filter_t *)&gyro.notchFilter2[axis], gyroADCf);
-        gyroADCf = gyro.lowpassFilterApplyFn((filter_t *)&gyro.lowpassFilter[axis], gyroADCf);
+        gyroADCf = gyro.notchFilter1ApplyFn((filter_t *)&gyro.notchFilter1, gyroADCf, axis);
+        gyroADCf = gyro.notchFilter2ApplyFn((filter_t *)&gyro.notchFilter2, gyroADCf, axis);
+        gyroADCf = gyro.lowpassFilterApplyFn((filter_t *)&gyro.lowpassFilter, gyroADCf, axis);
 
         // DEBUG_GYRO_SAMPLE(3) Record the post-static notch and lowpass filter value for the selected debug axis
         GYRO_FILTER_AXIS_DEBUG_SET(axis, DEBUG_GYRO_SAMPLE, 3, lrintf(gyroADCf));

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -101,12 +101,9 @@ static void gyroInitFilterNotch1(uint16_t notchHz, uint16_t notchCutoffHz, float
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter1ApplyFn = (filterVec3ApplyFn *)biquadFilterApply;
+        gyro.notchFilter1ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        biquadFilterInitState(&gyro.notchFilter1.coeffs);
-        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            biquadFilterCoeffsNotch(&gyro.notchFilter1.coeffs[axis], notchHz, dt, notchQ);
-        }
+        biquadFilterInitArrayNotch(&gyro.notchFilter1, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
     }
 }
 
@@ -117,12 +114,9 @@ static void gyroInitFilterNotch2(uint16_t notchHz, uint16_t notchCutoffHz, float
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter2ApplyFn = (filterVec3ApplyFn *)biquadFilterApply;
+        gyro.notchFilter2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        biquadFilterInitState(&gyro.notchFilter2.coeffs);
-        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            biquadFilterCoeffsNotch(&gyro.notchFilter2.coeffs[axis], notchHz, dt, notchQ);
-        }
+        biquadFilterInitArrayNotch(&gyro.notchFilter2, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
     }
 }
 
@@ -166,14 +160,11 @@ static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, float d
         case FILTER_BIQUAD:
             if (lpfHz <= gyroFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterArrayDF1;
+                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArrayDF1;
 #else
-                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterArray;
+                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArray;
 #endif
-                biquadFilterInit(&lowpassFilter->biquadFilter.state);
-                for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                    biquadFilterCoeffsLPF(&lowpassFilter->biquadFilter.coeffs[axis], lpfHz, dt);
-                }
+                biquadFilterInitArrayLPF(&lowpassFilter->biquadFilter, lpfHz, dt, XYZ_AXIS_COUNT);
                 ret = true;
             }
             break;

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -101,9 +101,9 @@ static void gyroInitFilterNotch1(uint16_t notchHz, uint16_t notchCutoffHz, float
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter1ApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
+        gyro.notchFilter1ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        biquadFilterVec3InitNotch(&gyro.notchFilter1, notchHz, dt, notchQ);
+        biquadFilterInitArrayNotch(&gyro.notchFilter1, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
     }
 }
 
@@ -114,9 +114,9 @@ static void gyroInitFilterNotch2(uint16_t notchHz, uint16_t notchCutoffHz, float
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter2ApplyFn = (filterVec3ApplyFn *)biquadFilterVec3Apply;
+        gyro.notchFilter2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        biquadFilterVec3InitNotch(&gyro.notchFilter2, notchHz, dt, notchQ);
+        biquadFilterInitArrayNotch(&gyro.notchFilter2, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
     }
 }
 
@@ -153,29 +153,29 @@ static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, float d
     if (lpfHz) {
         switch (type) {
         case FILTER_PT1:
-            *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)pt1FilterVec3Apply;
-            pt1FilterVec3Init(&lowpassFilter->pt1Filter, pt1FilterGain(lpfHz, dt));
+            *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)pt1FilterApplyArray;
+            pt1FilterInitArray(&lowpassFilter->pt1Filter, pt1FilterGain(lpfHz, dt), XYZ_AXIS_COUNT);
             ret = true;
             break;
         case FILTER_BIQUAD:
             if (lpfHz <= gyroFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterVec3ApplyDF1;
+                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArrayDF1;
 #else
-                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterVec3Apply;
+                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArray;
 #endif
-                biquadFilterVec3InitLPF(&lowpassFilter->biquadFilter, lpfHz, dt);
+                biquadFilterInitArrayLPF(&lowpassFilter->biquadFilter, lpfHz, dt, XYZ_AXIS_COUNT);
                 ret = true;
             }
             break;
         case FILTER_PT2:
-            *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)pt2FilterVec3Apply;
-            pt2FilterVec3Init(&lowpassFilter->pt2Filter, pt2FilterGain(lpfHz, dt));
+            *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)pt2FilterApplyArray;
+            pt2FilterInitArray(&lowpassFilter->pt2Filter, pt2FilterGain(lpfHz, dt), XYZ_AXIS_COUNT);
             ret = true;
             break;
         case FILTER_PT3:
-            *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)pt3FilterVec3Apply;
-            pt3FilterVec3Init(&lowpassFilter->pt3Filter, pt3FilterGain(lpfHz, dt));
+            *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)pt3FilterApplyArray;
+            pt3FilterInitArray(&lowpassFilter->pt3Filter, pt3FilterGain(lpfHz, dt), XYZ_AXIS_COUNT);
             ret = true;
             break;
         }
@@ -246,7 +246,7 @@ void gyroInitFilters(void)
 #ifdef USE_DYN_NOTCH_FILTER
     dynNotchInit(dynNotchConfig(), dt);
 #endif
-    pt1FilterVec3Init(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.sampleLooptime * 1e-6f));
+    pt1FilterInitArray(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.sampleLooptime * 1e-6f), XYZ_AXIS_COUNT);
 }
 
 #if defined(USE_GYRO_SLEW_LIMITER)

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -101,9 +101,9 @@ static void gyroInitFilterNotch1(uint16_t notchHz, uint16_t notchCutoffHz, float
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter1ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
+        gyro.notchFilter1ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayVec3;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        biquadFilterInitArrayNotch(&gyro.notchFilter1, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
+        biquadFilterInitNotchArray(&gyro.notchFilter1, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
     }
 }
 
@@ -114,9 +114,9 @@ static void gyroInitFilterNotch2(uint16_t notchHz, uint16_t notchCutoffHz, float
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArray;
+        gyro.notchFilter2ApplyFn = (filterVec3ApplyFn *)biquadFilterApplyArrayVec3;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        biquadFilterInitArrayNotch(&gyro.notchFilter2, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
+        biquadFilterInitNotchArray(&gyro.notchFilter2, notchHz, dt, notchQ, XYZ_AXIS_COUNT);
     }
 }
 
@@ -160,11 +160,11 @@ static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, float d
         case FILTER_BIQUAD:
             if (lpfHz <= gyroFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArrayDF1;
+                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyDF1ArrayVec3;
 #else
-                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArray;
+                *lowpassFilterApplyFnPtr = (filterVec3ApplyFn *)biquadFilterApplyArrayVec3;
 #endif
-                biquadFilterInitArrayLPF(&lowpassFilter->biquadFilter, lpfHz, dt, XYZ_AXIS_COUNT);
+                biquadFilterInitLPFArray(&lowpassFilter->biquadFilter, lpfHz, dt, XYZ_AXIS_COUNT);
                 ret = true;
             }
             break;

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -143,7 +143,7 @@ static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, float d
     bool ret = false;
 
     // Establish some common constants
-    const uint32_t gyroFrequencyNyquist = 2 / dt;
+    const uint32_t gyroFrequencyNyquist = 0.5 / dt;
 
     // Dereference the pointer to null before checking valid cutoff and filter
     // type. It will be overridden for positive cases.

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -246,7 +246,7 @@ void gyroInitFilters(void)
 #ifdef USE_DYN_NOTCH_FILTER
     dynNotchInit(dynNotchConfig(), dt);
 #endif
-    pt1FilterVec3Init(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, dt));
+    pt1FilterVec3Init(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.targetLooptime * 1e-6f));
 }
 
 #if defined(USE_GYRO_SLEW_LIMITER)

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -246,7 +246,7 @@ void gyroInitFilters(void)
 #ifdef USE_DYN_NOTCH_FILTER
     dynNotchInit(dynNotchConfig(), dt);
 #endif
-    pt1FilterVec3Init(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.targetLooptime * 1e-6f));
+    pt1FilterVec3Init(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.sampleLooptime * 1e-6f));
 }
 
 #if defined(USE_GYRO_SLEW_LIMITER)

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -94,50 +94,46 @@ static uint16_t calculateNyquistAdjustedNotchHz(uint16_t notchHz, uint16_t notch
     return notchHz;
 }
 
-static void gyroInitFilterNotch1(uint16_t notchHz, uint16_t notchCutoffHz)
+static void gyroInitFilterNotch1(uint16_t notchHz, uint16_t notchCutoffHz, float dt)
 {
-    gyro.notchFilter1ApplyFn = nullFilterApply;
+    gyro.notchFilter1ApplyFn = nullFilterVec3Apply;
 
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter1ApplyFn = (filterApplyFnPtr)biquadFilterApply;
+        gyro.notchFilter1ApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3Apply;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            biquadFilterInit(&gyro.notchFilter1[axis], notchHz, gyro.targetLooptime, notchQ, FILTER_NOTCH, 1.0f);
-        }
+        biquadFilterVec3InitNotch(&gyro.notchFilter1, notchHz, dt, notchQ, 1.0f);
     }
 }
 
-static void gyroInitFilterNotch2(uint16_t notchHz, uint16_t notchCutoffHz)
+static void gyroInitFilterNotch2(uint16_t notchHz, uint16_t notchCutoffHz, float dt)
 {
-    gyro.notchFilter2ApplyFn = nullFilterApply;
+    gyro.notchFilter2ApplyFn = nullFilterVec3Apply;
 
     notchHz = calculateNyquistAdjustedNotchHz(notchHz, notchCutoffHz);
 
     if (notchHz != 0 && notchCutoffHz != 0) {
-        gyro.notchFilter2ApplyFn = (filterApplyFnPtr)biquadFilterApply;
+        gyro.notchFilter2ApplyFn = (filterVec3ApplyFnPtr)biquadFilterVec3Apply;
         const float notchQ = filterGetNotchQ(notchHz, notchCutoffHz);
-        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            biquadFilterInit(&gyro.notchFilter2[axis], notchHz, gyro.targetLooptime, notchQ, FILTER_NOTCH, 1.0f);
-        }
+        biquadFilterVec3InitNotch(&gyro.notchFilter2, notchHz, dt, notchQ, 1.0f);
     }
 }
 
-static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, uint32_t looptime)
+static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, float dt)
 {
-    filterApplyFnPtr *lowpassFilterApplyFn;
+    filterVec3ApplyFnPtr *lowpassFilterApplyFn;
     gyroLowpassFilter_t *lowpassFilter = NULL;
 
     switch (slot) {
     case FILTER_LPF1:
         lowpassFilterApplyFn = &gyro.lowpassFilterApplyFn;
-        lowpassFilter = gyro.lowpassFilter;
+        lowpassFilter = &gyro.lowpassFilter;
         break;
 
     case FILTER_LPF2:
         lowpassFilterApplyFn = &gyro.lowpass2FilterApplyFn;
-        lowpassFilter = gyro.lowpass2Filter;
+        lowpassFilter = &gyro.lowpass2Filter;
         break;
 
     default:
@@ -147,48 +143,39 @@ static bool gyroInitLowpassFilterLpf(int slot, int type, uint16_t lpfHz, uint32_
     bool ret = false;
 
     // Establish some common constants
-    const uint32_t gyroFrequencyNyquist = 1000000 / 2 / looptime;
-    const float gyroDt = looptime * 1e-6f;
+    const uint32_t gyroFrequencyNyquist = 2 / dt;
 
     // Dereference the pointer to null before checking valid cutoff and filter
     // type. It will be overridden for positive cases.
-    *lowpassFilterApplyFn = nullFilterApply;
+    *lowpassFilterApplyFn = nullFilterVec3Apply;
 
     // If lowpass cutoff has been specified
     if (lpfHz) {
         switch (type) {
         case FILTER_PT1:
-            *lowpassFilterApplyFn = (filterApplyFnPtr) pt1FilterApply;
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                pt1FilterInit(&lowpassFilter[axis].pt1FilterState, pt1FilterGain(lpfHz, gyroDt));
-            }
+            *lowpassFilterApplyFn = (filterVec3ApplyFnPtr) pt1FilterVec3Apply;
+            pt1FilterVec3Init(&lowpassFilter->pt1FilterState, pt1FilterGain(lpfHz, dt));
             ret = true;
             break;
         case FILTER_BIQUAD:
             if (lpfHz <= gyroFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                *lowpassFilterApplyFn = (filterApplyFnPtr) biquadFilterApplyDF1;
+                *lowpassFilterApplyFn = (filterVec3ApplyFnPtr) biquadFilterVec3ApplyDF1;
 #else
-                *lowpassFilterApplyFn = (filterApplyFnPtr) biquadFilterApply;
+                *lowpassFilterApplyFn = (filterVec3ApplyFnPtr) biquadFilterVec3Apply;
 #endif
-                for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                    biquadFilterInitLPF(&lowpassFilter[axis].biquadFilterState, lpfHz, looptime);
-                }
+                biquadFilterVec3InitLPF(&lowpassFilter->biquadFilterState, lpfHz, dt);
                 ret = true;
             }
             break;
         case FILTER_PT2:
-            *lowpassFilterApplyFn = (filterApplyFnPtr) pt2FilterApply;
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                pt2FilterInit(&lowpassFilter[axis].pt2FilterState, pt2FilterGain(lpfHz, gyroDt));
-            }
+            *lowpassFilterApplyFn = (filterVec3ApplyFnPtr) pt2FilterVec3Apply;
+            pt2FilterVec3Init(&lowpassFilter->pt2FilterState, pt2FilterGain(lpfHz, dt));
             ret = true;
             break;
         case FILTER_PT3:
-            *lowpassFilterApplyFn = (filterApplyFnPtr) pt3FilterApply;
-            for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                pt3FilterInit(&lowpassFilter[axis].pt3FilterState, pt3FilterGain(lpfHz, gyroDt));
-            }
+            *lowpassFilterApplyFn = (filterVec3ApplyFnPtr) pt3FilterVec3Apply;
+            pt3FilterVec3Init(&lowpassFilter->pt3FilterState, pt3FilterGain(lpfHz, dt));
             ret = true;
             break;
         }
@@ -235,34 +222,31 @@ void gyroInitFilters(void)
         gyro_lpf1_init_hz = gyroConfig()->gyro_lpf1_dyn_min_hz;
     }
 #endif
+    const float dt = gyro.targetLooptime * 1e-6f;
 
     gyroInitLowpassFilterLpf(
       FILTER_LPF1,
       gyroConfig()->gyro_lpf1_type,
       gyro_lpf1_init_hz,
-      gyro.targetLooptime
+      dt
     );
 
     gyro.downsampleFilterEnabled = gyroInitLowpassFilterLpf(
       FILTER_LPF2,
       gyroConfig()->gyro_lpf2_type,
       gyroConfig()->gyro_lpf2_static_hz,
-      gyro.sampleLooptime
+      dt
     );
 
-    gyroInitFilterNotch1(gyroConfig()->gyro_soft_notch_hz_1, gyroConfig()->gyro_soft_notch_cutoff_1);
-    gyroInitFilterNotch2(gyroConfig()->gyro_soft_notch_hz_2, gyroConfig()->gyro_soft_notch_cutoff_2);
+    gyroInitFilterNotch1(gyroConfig()->gyro_soft_notch_hz_1, gyroConfig()->gyro_soft_notch_cutoff_1, dt);
+    gyroInitFilterNotch2(gyroConfig()->gyro_soft_notch_hz_2, gyroConfig()->gyro_soft_notch_cutoff_2, dt);
 #ifdef USE_DYN_LPF
     dynLpfFilterInit();
 #endif
 #ifdef USE_DYN_NOTCH_FILTER
-    dynNotchInit(dynNotchConfig(), gyro.targetLooptime);
+    dynNotchInit(dynNotchConfig(), dt);
 #endif
-
-    const float k = pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, gyro.targetLooptime * 1e-6f);
-    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        pt1FilterInit(&gyro.imuGyroFilter[axis], k);
-    }
+    pt1FilterVec3Init(&gyro.imuGyroFilter, pt1FilterGain(GYRO_IMU_DOWNSAMPLE_CUTOFF_HZ, dt));
 }
 
 #if defined(USE_GYRO_SLEW_LIMITER)

--- a/src/test/unit/maths_unittest.cc
+++ b/src/test/unit/maths_unittest.cc
@@ -203,7 +203,7 @@ void expectVectorsAreEqual(vector3_t *a, vector3_t *b, float absTol)
     EXPECT_NEAR(a->z, b->z, absTol);
 }
 
-#if defined(FAST_MATH) || defined(VERY_FAST_MATH)
+#if defined(FAST_MATH)
 TEST(MathsUnittest, TestFastTrigonometrySinCos)
 {
     double sinError = 0;


### PR DESCRIPTION
This code creates optimized vectorized versions of common filters. It also improves the update speed of the biquad filters (notch and lowpass).

On an f411 (rpm filters turned on, but ESC not powered, results would look better if it were powered) we find this:
This PR
<img width="649" height="316" alt="image" src="https://github.com/user-attachments/assets/458f3aee-ca35-4078-ac1d-e205c07e8bf8" />
Master
<img width="627" height="317" alt="image" src="https://github.com/user-attachments/assets/37e119a5-e73c-436a-b07a-81a93860750c" />

On f411 we also notice this:
This PR
```
Linking STM32F411_MAMBAF411
Memory region         Used Size  Region Size  %age Used
           FLASH:        7896 B        16 KB     48.19%
    FLASH_CONFIG:           0 B        16 KB      0.00%
          FLASH1:      328621 B       480 KB     66.86%
   SYSTEM_MEMORY:           0 B        29 KB      0.00%
             RAM:       63356 B       128 KB     48.34%
       MEMORY_B1:           0 B          0 B
```
Master
```
Linking STM32F411_MAMBAF411
Memory region         Used Size  Region Size  %age Used
           FLASH:        7900 B        16 KB     48.22%
    FLASH_CONFIG:           0 B        16 KB      0.00%
          FLASH1:      332621 B       480 KB     67.67%
   SYSTEM_MEMORY:           0 B        29 KB      0.00%
             RAM:       65188 B       128 KB     49.73%
       MEMORY_B1:           0 B          0 B
```

Testing the RPM filter update performance on an STM32H750 I logged 550cycles with this PR and about 1180cycles on master. So This seems that the performance of the RPM filter update is about twice what it used to be with these changes... Thats a lot more than I was expecting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bézier-based throttle curve for smoother, more predictable throttle response.
  * New combined sine/cosine fast-math API.

* **Performance**
  * Consolidated 3‑axis/vectorized filtering reduces per-axis loops and CPU overhead across sensors, PID, RC, RPM, servos, and telemetry.

* **Refactor**
  * Filters moved to coefficient/state and dt-based timing with unified per-axis/Vec3 APIs.

* **Breaking Changes**
  * Public filter types and init/apply signatures are now dt-based and axis-aware — integration updates required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->