### PR TITLE
Fix some typos

### DIFF
--- a/src/main/pg/timerio.c
+++ b/src/main/pg/timerio.c
@@ -34,7 +34,7 @@ Details of the TIMER_PIN_MAP macro:
     i => is the index in the PG timer IO config array,
     p => is the hardware pin to be mapped,
     o => is the hardware pin occurrence (1 based index) within timerHardware (full) that should be used
-                e.g. 1 = first occurence of the pin, 2 = second occurence, etc.
+                e.g. 1 = first occurrence of the pin, 2 = second occurrence, etc.
     d => the configured dma opt for the pin
 */
 #define TIMER_PIN_MAP(i, p, o, d)  \

--- a/src/main/telemetry/frsky_hub.c
+++ b/src/main/telemetry/frsky_hub.c
@@ -324,12 +324,12 @@ static void sendFakeLatLong(void)
 
 static void sendGPSLatLong(void)
 {
-    static uint8_t gpsFixOccured = 0;
+    static uint8_t gpsFixOccurred = 0;
     int32_t coord[2] = {0,0};
 
-    if (STATE(GPS_FIX) || gpsFixOccured == 1) {
+    if (STATE(GPS_FIX) || gpsFixOccurred == 1) {
         // If we have ever had a fix, send the last known lat/long
-        gpsFixOccured = 1;
+        gpsFixOccurred = 1;
         coord[GPS_LATITUDE] = gpsSol.llh.lat;
         coord[GPS_LONGITUDE] = gpsSol.llh.lon;
         sendLatLong(coord);

--- a/src/main/telemetry/ghst.c
+++ b/src/main/telemetry/ghst.c
@@ -234,7 +234,7 @@ static void ghstSendMspResponse(uint8_t *payload, const uint8_t payloadSize)
     DEBUG_SET(DEBUG_GHST_MSP, 1, ++mspFrameCounter);
 
     ghstInitializeFrame(dst);                                                               // addr
-    sbufWriteU8(dst, GHST_PAYLOAD_SIZE + GHST_FRAME_LENGTH_CRC + GHST_FRAME_LENGTH_TYPE);   // lenght
+    sbufWriteU8(dst, GHST_PAYLOAD_SIZE + GHST_FRAME_LENGTH_CRC + GHST_FRAME_LENGTH_TYPE);   // length
     sbufWriteU8(dst, GHST_DL_MSP_RESP);                                                 // type
     sbufWriteData(dst, payload, payloadSize);                                           // payload
     for(int i = 0; i < GHST_PAYLOAD_SIZE - payloadSize; ++i) {                          // payload fill zeroes

--- a/src/platform/AT32/pwm_output_dshot.c
+++ b/src/platform/AT32/pwm_output_dshot.c
@@ -190,7 +190,7 @@ FAST_CODE void pwmDshotSetDirectionOutput(
 
     timerOCInit(timer, channel, pOcInit);
 
-    // On ST mcu this would be part of the ocInit struct, but on AT we have to do it seperately
+    // On ST mcu this would be part of the ocInit struct, but on AT we have to do it separately
     { // local scope for variables
         const bool useNChannel = false; // tmr_channel_value_set only supports the normal channels
         const tmr_channel_select_type atChannel = toCHSelectType(timerHardware->channel, useNChannel);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected spelling and improved comment clarity across timing, telemetry, and PWM output components to enhance readability. No functional changes.
- Style
  - Standardized internal naming for a GPS fix flag to use consistent spelling, maintaining existing behavior.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->