### PR TITLE
REFACTOR: Renaming SPI enums to consistent pattern

### DIFF
--- a/src/main/drivers/bus_octospi.c
+++ b/src/main/drivers/bus_octospi.c
@@ -60,7 +60,7 @@
 
 octoSpiDevice_t octoSpiDevice[OCTOSPIDEV_COUNT] = { 0 };
 
-MMFLASH_CODE_NOINLINE OCTOSPIDevice octoSpiDeviceByInstance(OCTOSPI_TypeDef *instance)
+MMFLASH_CODE_NOINLINE octoSpiDevice_e octoSpiDeviceByInstance(OCTOSPI_TypeDef *instance)
 {
 #ifdef USE_OCTOSPI_DEVICE_1
     if (instance == OCTOSPI1) {
@@ -71,7 +71,7 @@ MMFLASH_CODE_NOINLINE OCTOSPIDevice octoSpiDeviceByInstance(OCTOSPI_TypeDef *ins
     return OCTOSPIINVALID;
 }
 
-OCTOSPI_TypeDef *octoSpiInstanceByDevice(OCTOSPIDevice device)
+OCTOSPI_TypeDef *octoSpiInstanceByDevice(octoSpiDevice_e device)
 {
     if (device == OCTOSPIINVALID || device >= OCTOSPIDEV_COUNT) {
         return NULL;
@@ -91,12 +91,12 @@ const octoSpiHardware_t octoSpiHardware[] = {
 #endif
 };
 
-bool octoSpiInit(OCTOSPIDevice device)
+bool octoSpiInit(octoSpiDevice_e device)
 {
     for (size_t hwindex = 0; hwindex < ARRAYLEN(octoSpiHardware); hwindex++) {
         const octoSpiHardware_t *hw = &octoSpiHardware[hwindex];
 
-        OCTOSPIDevice device = hw->device;
+        octoSpiDevice_e device = hw->device;
         octoSpiDevice_t *pDev = &octoSpiDevice[device];
 
         pDev->dev = hw->reg;

--- a/src/main/drivers/bus_octospi.h
+++ b/src/main/drivers/bus_octospi.h
@@ -24,10 +24,10 @@
 
 #ifdef USE_OCTOSPI
 
-typedef enum OCTOSPIDevice {
+typedef enum octoSpiDevice_e {
     OCTOSPIINVALID = -1,
     OCTOSPIDEV_1   = 0,
-} OCTOSPIDevice;
+} octoSpiDevice_e;
 
 #define OCTOSPIDEV_COUNT 1
 
@@ -39,10 +39,10 @@ typedef enum OCTOSPIDevice {
 #error OctoSPI unsupported on this MCU
 #endif
 
-OCTOSPIDevice octoSpiDeviceByInstance(OCTOSPI_TypeDef *instance);
-OCTOSPI_TypeDef *octoSpiInstanceByDevice(OCTOSPIDevice device);
+octoSpiDevice_e octoSpiDeviceByInstance(OCTOSPI_TypeDef *instance);
+OCTOSPI_TypeDef *octoSpiInstanceByDevice(octoSpiDevice_e device);
 
-bool octoSpiInit(OCTOSPIDevice device);
+bool octoSpiInit(octoSpiDevice_e device);
 bool octoSpiReceive1LINE(OCTOSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length);
 bool octoSpiReceive4LINES(OCTOSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length);
 bool octoSpiTransmit1LINE(OCTOSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length);

--- a/src/main/drivers/bus_octospi_impl.h
+++ b/src/main/drivers/bus_octospi_impl.h
@@ -25,7 +25,7 @@
 #ifdef USE_OCTOSPI
 
 typedef struct octoSpiHardware_s {
-    OCTOSPIDevice device;
+    octoSpiDevice_e device;
     OCTOSPI_TypeDef *reg;
 } octoSpiHardware_t;
 
@@ -35,6 +35,6 @@ typedef struct OCTOSPIDevice_s {
 
 extern octoSpiDevice_t octoSpiDevice[OCTOSPIDEV_COUNT];
 
-void octoSpiInitDevice(OCTOSPIDevice device);
+void octoSpiInitDevice(octoSpiDevice_e device);
 
 #endif

--- a/src/main/drivers/bus_quadspi.c
+++ b/src/main/drivers/bus_quadspi.c
@@ -41,7 +41,7 @@
 
 quadSpiDevice_t quadSpiDevice[QUADSPIDEV_COUNT] = { 0 };
 
-QUADSPIDevice quadSpiDeviceByInstance(QUADSPI_TypeDef *instance)
+quadSpiDevice_e quadSpiDeviceByInstance(QUADSPI_TypeDef *instance)
 {
 #ifdef USE_QUADSPI_DEVICE_1
     if (instance == QUADSPI) {
@@ -52,7 +52,7 @@ QUADSPIDevice quadSpiDeviceByInstance(QUADSPI_TypeDef *instance)
     return QUADSPIINVALID;
 }
 
-QUADSPI_TypeDef *quadSpiInstanceByDevice(QUADSPIDevice device)
+QUADSPI_TypeDef *quadSpiInstanceByDevice(quadSpiDevice_e device)
 {
     if (device == QUADSPIINVALID || device >= QUADSPIDEV_COUNT) {
         return NULL;
@@ -61,7 +61,7 @@ QUADSPI_TypeDef *quadSpiInstanceByDevice(QUADSPIDevice device)
     return quadSpiDevice[device].dev;
 }
 
-bool quadSpiInit(QUADSPIDevice device)
+bool quadSpiInit(quadSpiDevice_e device)
 {
     switch (device) {
     case QUADSPIINVALID:
@@ -79,7 +79,7 @@ bool quadSpiInit(QUADSPIDevice device)
 
 uint32_t quadSpiTimeoutUserCallback(QUADSPI_TypeDef *instance)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     if (device == QUADSPIINVALID) {
         return -1;
     }
@@ -89,7 +89,7 @@ uint32_t quadSpiTimeoutUserCallback(QUADSPI_TypeDef *instance)
 
 uint16_t quadSpiGetErrorCounter(QUADSPI_TypeDef *instance)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     if (device == QUADSPIINVALID) {
         return 0;
     }
@@ -98,7 +98,7 @@ uint16_t quadSpiGetErrorCounter(QUADSPI_TypeDef *instance)
 
 void quadSpiResetErrorCounter(QUADSPI_TypeDef *instance)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     if (device != QUADSPIINVALID) {
         quadSpiDevice[device].errorCount = 0;
     }
@@ -169,7 +169,7 @@ void quadSpiPinConfigure(const quadSpiConfig_t *pConfig)
             continue;
         }
 
-        QUADSPIDevice device = hw->device;
+        quadSpiDevice_e device = hw->device;
         quadSpiDevice_t *pDev = &quadSpiDevice[device];
 
         for (int pindex = 0; pindex < MAX_QUADSPI_PIN_SEL; pindex++) {

--- a/src/main/drivers/bus_quadspi.h
+++ b/src/main/drivers/bus_quadspi.h
@@ -56,12 +56,12 @@ typedef enum {
     QUADSPI_CLOCK_STANDARD       = 9,   // 20.00000 MHz
     QUADSPI_CLOCK_FAST           = 3,   // 50.00000 MHz
     QUADSPI_CLOCK_ULTRAFAST      = 1    //100.00000 MHz
-} QUADSPIClockDivider_e;
+} quadSpiClockDivider_e;
 
-typedef enum QUADSPIDevice {
+typedef enum {
     QUADSPIINVALID = -1,
     QUADSPIDEV_1   = 0,
-} QUADSPIDevice;
+} quadSpiDevice_e;
 
 #define QUADSPIDEV_COUNT 1
 
@@ -102,7 +102,7 @@ typedef enum {
 
 void quadSpiPreInit(void);
 
-bool quadSpiInit(QUADSPIDevice device);
+bool quadSpiInit(quadSpiDevice_e device);
 void quadSpiSetDivisor(QUADSPI_TypeDef *instance, uint16_t divisor);
 
 bool quadSpiTransmit1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length);
@@ -123,8 +123,8 @@ bool quadSpiInstructionWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instr
 uint16_t quadSpiGetErrorCounter(QUADSPI_TypeDef *instance);
 void quadSpiResetErrorCounter(QUADSPI_TypeDef *instance);
 
-QUADSPIDevice quadSpiDeviceByInstance(QUADSPI_TypeDef *instance);
-QUADSPI_TypeDef *quadSpiInstanceByDevice(QUADSPIDevice device);
+quadSpiDevice_e quadSpiDeviceByInstance(QUADSPI_TypeDef *instance);
+QUADSPI_TypeDef *quadSpiInstanceByDevice(quadSpiDevice_e device);
 
 //
 // Config

--- a/src/main/drivers/bus_quadspi_impl.h
+++ b/src/main/drivers/bus_quadspi_impl.h
@@ -22,7 +22,10 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "platform.h"
+#include "drivers/bus_quadspi.h"
 
 #if PLATFORM_TRAIT_RCC
 #include "platform/rcc_types.h"
@@ -36,7 +39,7 @@ typedef struct quadSpiPinDef_s {
 } quadSpiPinDef_t;
 
 typedef struct quadSpiHardware_s {
-    QUADSPIDevice device;
+    quadSpiDevice_e device;
     QUADSPI_TypeDef *reg;
     quadSpiPinDef_t clkPins[MAX_QUADSPI_PIN_SEL];
     quadSpiPinDef_t bk1IO0Pins[MAX_QUADSPI_PIN_SEL];
@@ -94,5 +97,5 @@ typedef struct QUADSPIDevice_s {
 
 extern quadSpiDevice_t quadSpiDevice[QUADSPIDEV_COUNT];
 
-void quadSpiInitDevice(QUADSPIDevice device);
+void quadSpiInitDevice(quadSpiDevice_e device);
 uint32_t quadSpiTimeoutUserCallback(QUADSPI_TypeDef *instance);

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -45,7 +45,7 @@ static uint8_t spiRegisteredDeviceCount = 0;
 spiDevice_t spiDevice[SPIDEV_COUNT];
 busDevice_t spiBusDevice[SPIDEV_COUNT];
 
-SPIDevice spiDeviceByInstance(const SPI_TypeDef *instance)
+spiDevice_e spiDeviceByInstance(const SPI_TypeDef *instance)
 {
 #ifdef USE_SPI_DEVICE_0
     if (instance == SPI0) {
@@ -92,7 +92,7 @@ SPIDevice spiDeviceByInstance(const SPI_TypeDef *instance)
     return SPIINVALID;
 }
 
-SPI_TypeDef *spiInstanceByDevice(SPIDevice device)
+SPI_TypeDef *spiInstanceByDevice(spiDevice_e device)
 {
     if (device == SPIINVALID || device >= SPIDEV_COUNT) {
         return NULL;
@@ -101,7 +101,7 @@ SPI_TypeDef *spiInstanceByDevice(SPIDevice device)
     return spiDevice[device].dev;
 }
 
-bool spiInit(SPIDevice device)
+bool spiInit(spiDevice_e device)
 {
     switch (device) {
     case SPIINVALID:

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -44,7 +44,7 @@ typedef enum {
     SPI_MODE3_POL_HIGH_EDGE_2ND
 } SPIMode_e;
 
-typedef enum SPIDevice {
+typedef enum {
     SPIINVALID = -1,
     SPIDEV_FIRST = 0,
 #if defined(USE_SPI_DEVICE_0)
@@ -58,20 +58,20 @@ typedef enum SPIDevice {
     SPIDEV_4,
     SPIDEV_5,
     SPIDEV_6
-} SPIDevice;
+} spiDevice_e;
 
 // Macros to convert between CLI bus number and SPIDevice.
 #define SPI_CFG_TO_DEV(x)   ((x) - 1)
 #define SPI_DEV_TO_CFG(x)   ((x) + 1)
 
 void spiPreinit(void);
-bool spiInit(SPIDevice device);
+bool spiInit(spiDevice_e device);
 
 // Called after all devices are initialised to enable SPI DMA where streams are available.
 void spiInitBusDMA(void);
 
-SPIDevice spiDeviceByInstance(const SPI_TypeDef *instance);
-SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
+spiDevice_e spiDeviceByInstance(const SPI_TypeDef *instance);
+SPI_TypeDef *spiInstanceByDevice(spiDevice_e device);
 
 // BusDevice API
 

--- a/src/main/drivers/bus_spi_impl.h
+++ b/src/main/drivers/bus_spi_impl.h
@@ -38,7 +38,7 @@ typedef struct spiPinDef_s {
 } spiPinDef_t;
 
 typedef struct spiHardware_s {
-    SPIDevice device;
+    spiDevice_e device;
     SPI_TypeDef *reg;
     spiPinDef_t sckPins[MAX_SPI_PIN_SEL];
     spiPinDef_t misoPins[MAX_SPI_PIN_SEL];
@@ -86,7 +86,7 @@ typedef struct SPIDevice_s {
 
 extern spiDevice_t spiDevice[SPIDEV_COUNT];
 
-void spiInitDevice(SPIDevice device);
+void spiInitDevice(spiDevice_e device);
 void spiInternalInitStream(const extDevice_t *dev, volatile busSegment_t *segment);
 void spiInternalStartDMA(const extDevice_t *dev);
 void spiInternalStopDMA (const extDevice_t *dev);

--- a/src/main/pg/bus_quadspi.c
+++ b/src/main/pg/bus_quadspi.c
@@ -30,7 +30,7 @@
 #include "bus_quadspi.h"
 
 typedef struct quadSpiDefaultConfig_s {
-    QUADSPIDevice device;
+    quadSpiDevice_e device;
     ioTag_t clk;
 
     // Note: Either or both CS pin may be used in DUAL_FLASH mode, any unused pins should be IO_NONE

--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -76,7 +76,7 @@
 #endif
 
 typedef struct spiDefaultConfig_s {
-    SPIDevice device;
+    spiDevice_e device;
     ioTag_t sck;
     ioTag_t miso;
     ioTag_t mosi;

--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -83,7 +83,7 @@ void pgResetFn_sdcardConfig(sdcardConfig_t *config)
 #ifdef USE_SDCARD_SPI
     // These settings do not work for Unified Targets
     // They are only left in place to support legacy targets
-    SPIDevice spidevice = spiDeviceByInstance(SDCARD_SPI_INSTANCE);
+    spiDevice_e spidevice = spiDeviceByInstance(SDCARD_SPI_INSTANCE);
     config->device = SPI_DEV_TO_CFG(spidevice);
     config->chipSelectTag = IO_TAG(SDCARD_SPI_CS_PIN);
 

--- a/src/platform/APM32/bus_spi_apm32.c
+++ b/src/platform/APM32/bus_spi_apm32.c
@@ -68,7 +68,7 @@ static uint32_t spiDivisorToBRbits(const SPI_TypeDef *instance, uint16_t divisor
     return (ffs(divisor) - 2) << 3;// SPI_CR1_BR_Pos
 }
 
-void spiInitDevice(SPIDevice device)
+void spiInitDevice(spiDevice_e device)
 {
     spiDevice_t *spi = &spiDevice[device];
 

--- a/src/platform/AT32/bus_spi_at32bsp.c
+++ b/src/platform/AT32/bus_spi_at32bsp.c
@@ -67,7 +67,7 @@ static void spiSetDivisorBRreg(spi_type *instance, uint16_t divisor)
 #undef BR_BITS
 }
 
-void spiInitDevice(SPIDevice device)
+void spiInitDevice(spiDevice_e device)
 {
     spiDevice_t *spi = &(spiDevice[device]);
 

--- a/src/platform/PICO/bus_spi_pico.c
+++ b/src/platform/PICO/bus_spi_pico.c
@@ -138,7 +138,7 @@ void spiPinConfigure(const struct spiPinConfig_s *pConfig)
             continue;
         }
 
-        SPIDevice device = hw->device;
+        spiDevice_e device = hw->device;
         spiDevice_t *pDev = &spiDevice[device];
 
         for (int pindex = 0 ; pindex < MAX_SPI_PIN_SEL ; pindex++) {
@@ -206,9 +206,7 @@ Must be SPI_MSB_FIRST, no other values supported on the PL022
 
 
 */
-
-
-void spiInitDevice(SPIDevice device)
+void spiInitDevice(spiDevice_e device)
 {
     bprintf("pico spiInitDevice %d",device);
     const spiDevice_t *spi = &spiDevice[device];

--- a/src/platform/STM32/bus_octospi_stm32h7xx.c
+++ b/src/platform/STM32/bus_octospi_stm32h7xx.c
@@ -417,7 +417,7 @@ octoSpiMemoryMappedModeConfigurationRegisterBackup_t ospiMMMCRBackups[OCTOSPI_IN
 
 static void octoSpiBackupMemoryMappedModeConfiguration(OCTOSPI_TypeDef *instance)
 {
-    OCTOSPIDevice device = octoSpiDeviceByInstance(instance);
+    octoSpiDevice_e device = octoSpiDeviceByInstance(instance);
     if (device == OCTOSPIINVALID) {
         return;
     }
@@ -437,7 +437,7 @@ static void octoSpiBackupMemoryMappedModeConfiguration(OCTOSPI_TypeDef *instance
 
 static MMFLASH_CODE_NOINLINE void octoSpiRestoreMemoryMappedModeConfiguration(OCTOSPI_TypeDef *instance)
 {
-    OCTOSPIDevice device = octoSpiDeviceByInstance(instance);
+    octoSpiDevice_e device = octoSpiDeviceByInstance(instance);
     if (device == OCTOSPIINVALID) {
         return;
     }
@@ -822,7 +822,7 @@ MMFLASH_CODE_NOINLINE bool octoSpiInstructionWithAddress1LINE(OCTOSPI_TypeDef *i
     return status == SUCCESS;
 }
 
-void octoSpiInitDevice(OCTOSPIDevice device)
+void octoSpiInitDevice(octoSpiDevice_e device)
 {
     octoSpiDevice_t *octoSpi = &(octoSpiDevice[device]);
 

--- a/src/platform/STM32/bus_quadspi_hal.c
+++ b/src/platform/STM32/bus_quadspi_hal.c
@@ -39,7 +39,7 @@
 
 static void Error_Handler(void) { while (1); }
 
-void quadSpiInitDevice(QUADSPIDevice device)
+void quadSpiInitDevice(quadSpiDevice_e device)
 {
     quadSpiDevice_t *quadSpi = &(quadSpiDevice[device]);
 
@@ -136,7 +136,7 @@ static uint32_t quadSpi_addressSizeFromValue(uint8_t addressSize)
  */
 LOCAL_UNUSED_FUNCTION static bool quadSpiIsBusBusy(QUADSPI_TypeDef *instance)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     if(quadSpiDevice[device].hquadSpi.State == HAL_QSPI_STATE_BUSY)
         return true;
     else
@@ -147,7 +147,7 @@ LOCAL_UNUSED_FUNCTION static bool quadSpiIsBusBusy(QUADSPI_TypeDef *instance)
 
 static void quadSpiSelectDevice(QUADSPI_TypeDef *instance)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
 
     IO_t bk1CS = IOGetByTag(quadSpiDevice[device].bk1CS);
     IO_t bk2CS = IOGetByTag(quadSpiDevice[device].bk2CS);
@@ -176,7 +176,7 @@ static void quadSpiSelectDevice(QUADSPI_TypeDef *instance)
 
 static void quadSpiDeselectDevice(QUADSPI_TypeDef *instance)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
 
     IO_t bk1CS = IOGetByTag(quadSpiDevice[device].bk1CS);
     IO_t bk2CS = IOGetByTag(quadSpiDevice[device].bk2CS);
@@ -205,7 +205,7 @@ static void quadSpiDeselectDevice(QUADSPI_TypeDef *instance)
 
 bool quadSpiTransmit1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -248,7 +248,7 @@ bool quadSpiTransmit1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_
 
 bool quadSpiReceive1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -286,7 +286,7 @@ bool quadSpiReceive1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t
 
 bool quadSpiReceive4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -324,7 +324,7 @@ bool quadSpiReceive4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_
 
 bool quadSpiReceiveWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -363,7 +363,7 @@ bool quadSpiReceiveWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instructi
 
 bool quadSpiReceiveWithAddress4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -401,7 +401,7 @@ bool quadSpiReceiveWithAddress4LINES(QUADSPI_TypeDef *instance, uint8_t instruct
 }
 bool quadSpiTransmitWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -441,7 +441,7 @@ bool quadSpiTransmitWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruct
 
 bool quadSpiTransmitWithAddress4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -481,7 +481,7 @@ bool quadSpiTransmitWithAddress4LINES(QUADSPI_TypeDef *instance, uint8_t instruc
 
 bool quadSpiInstructionWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -516,7 +516,7 @@ bool quadSpiInstructionWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instr
 
 bool quadSpiInstructionWithData1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     HAL_StatusTypeDef status;
 
     QSPI_CommandTypeDef cmd;
@@ -554,7 +554,7 @@ bool quadSpiInstructionWithData1LINE(QUADSPI_TypeDef *instance, uint8_t instruct
 
 void quadSpiSetDivisor(QUADSPI_TypeDef *instance, uint16_t divisor)
 {
-    QUADSPIDevice device = quadSpiDeviceByInstance(instance);
+    quadSpiDevice_e device = quadSpiDeviceByInstance(instance);
     if (HAL_QSPI_DeInit(&quadSpiDevice[device].hquadSpi) != HAL_OK)
     {
         Error_Handler();

--- a/src/platform/STM32/bus_spi_ll.c
+++ b/src/platform/STM32/bus_spi_ll.c
@@ -110,7 +110,7 @@ static uint32_t spiDivisorToBRbits(const SPI_TypeDef *instance, uint16_t divisor
 #endif
 }
 
-void spiInitDevice(SPIDevice device)
+void spiInitDevice(spiDevice_e device)
 {
     spiDevice_t *spi = &spiDevice[device];
 

--- a/src/platform/STM32/bus_spi_stdperiph.c
+++ b/src/platform/STM32/bus_spi_stdperiph.c
@@ -76,7 +76,7 @@ static void spiSetDivisorBRreg(SPI_TypeDef *instance, uint16_t divisor)
 #undef BR_BITS
 }
 
-void spiInitDevice(SPIDevice device)
+void spiInitDevice(spiDevice_e device)
 {
     spiDevice_t *spi = &(spiDevice[device]);
 

--- a/src/platform/common/stm32/bus_spi_pinconfig.c
+++ b/src/platform/common/stm32/bus_spi_pinconfig.c
@@ -495,7 +495,7 @@ void spiPinConfigure(const spiPinConfig_t *pConfig)
             continue;
         }
 
-        SPIDevice device = hw->device;
+        spiDevice_e device = hw->device;
         spiDevice_t *pDev = &spiDevice[device];
 
         for (int pindex = 0 ; pindex < MAX_SPI_PIN_SEL ; pindex++) {


### PR DESCRIPTION
Simply renaming for consistency.
