### PR TITLE
Add EDT voltage data to OSD warnings

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1539,6 +1539,7 @@ const clivalue_t valueTable[] = {
     { "osd_esc_temp_alarm",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_temp_alarm) },
     { "osd_esc_rpm_alarm",          VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_RPM_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_rpm_alarm) },
     { "osd_esc_current_alarm",      VAR_INT16  | MASTER_VALUE, .config.minmax = { ESC_CURRENT_ALARM_OFF, INT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_current_alarm) },
+    { "osd_esc_voltage_alarm",      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { ESC_VOLTAGE_ALARM_OFF, UINT16_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, esc_voltage_alarm) },
 #ifdef USE_ADC_INTERNAL
     { "osd_core_temp_alarm",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, core_temp_alarm) },
 #endif

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -371,7 +371,7 @@ bool getDshotSensorData(escSensorData_t *dest, int motorIndex) {
         motorState->telemetryData[DSHOT_TELEMETRY_TYPE_CURRENT] : 0;
 
     dest->voltage = edt && (motorState->telemetryTypes & (1 << DSHOT_TELEMETRY_TYPE_VOLTAGE)) ? 
-        motorState->telemetryData[DSHOT_TELEMETRY_TYPE_VOLTAGE] : 0;
+        motorState->telemetryData[DSHOT_TELEMETRY_TYPE_VOLTAGE] * 25 : 0;
 
     return true;
 }

--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -370,6 +370,9 @@ bool getDshotSensorData(escSensorData_t *dest, int motorIndex) {
     dest->current = edt && (motorState->telemetryTypes & (1 << DSHOT_TELEMETRY_TYPE_CURRENT)) ? 
         motorState->telemetryData[DSHOT_TELEMETRY_TYPE_CURRENT] : 0;
 
+    dest->voltage = edt && (motorState->telemetryTypes & (1 << DSHOT_TELEMETRY_TYPE_VOLTAGE)) ? 
+        motorState->telemetryData[DSHOT_TELEMETRY_TYPE_VOLTAGE] : 0;
+
     return true;
 }
 

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -159,7 +159,7 @@ escSensorData_t *osdEscDataCombined;
 
 STATIC_ASSERT(OSD_POS_MAX == OSD_POS(63,31), OSD_POS_MAX_incorrect);
 
-PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 12);
+PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 13);
 
 PG_REGISTER_WITH_RESET_FN(osdElementConfig_t, osdElementConfig, PG_OSD_ELEMENT_CONFIG, 1);
 
@@ -379,6 +379,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->esc_temp_alarm = ESC_TEMP_ALARM_OFF; // off by default
     osdConfig->esc_rpm_alarm = ESC_RPM_ALARM_OFF; // off by default
     osdConfig->esc_current_alarm = ESC_CURRENT_ALARM_OFF; // off by default
+    osdConfig->esc_voltage_alarm = ESC_VOLTAGE_ALARM_OFF; // off by default
     osdConfig->core_temp_alarm = 70; // a temperature above 70C should produce a warning, lockups have been reported above 80C
 
     osdConfig->ahMaxPitch = 20; // 20 degrees

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -306,6 +306,7 @@ STATIC_ASSERT(OSD_WARNING_COUNT <= 32, osdwarnings_overflow);
 #define ESC_RPM_ALARM_OFF         -1
 #define ESC_TEMP_ALARM_OFF         0
 #define ESC_CURRENT_ALARM_OFF     -1
+#define ESC_VOLTAGE_ALARM_OFF      0
 
 #define OSD_GPS_RESCUE_DISABLED_WARNING_DURATION_US 3000000 // 3 seconds
 
@@ -363,6 +364,7 @@ typedef struct osdConfig_s {
     uint8_t osd_show_spec_prearm;
 #endif // USE_SPEC_PREARM_SCREEN
     displayPortSeverity_e arming_logo;        // font from which to display logo on arming
+    uint16_t esc_voltage_alarm;               // ESC voltage alarm in 0.01V, 0 means disabled
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -73,8 +73,9 @@ const char CRASHFLIP_WARNING[] = ">CRASH FLIP<";
 #define ESC_ALARM_CURRENT   'C'
 #define ESC_ALARM_TEMP      'T'
 #define ESC_ALARM_RPM       'R'
+#define ESC_ALARM_VOLTAGE   'V'
 
-#define ESC_ALARM_CHARS_SIZE 4 // ESC_ALARM_<chars> + '\0'
+#define ESC_ALARM_CHARS_SIZE 5 // ESC_ALARM_<chars> + '\0'
 
 static inline bool isMotorActive(uint8_t motorIndex) {
     return (motor[motorIndex] > mixerRuntime.disarmMotorOutput);
@@ -99,6 +100,10 @@ static bool checkEscAlarmConditions(const escSensorData_t *data, uint8_t motorIn
     // Check temperature alarm (regardless of motor spinning state)
     if (data->temperature && osdConfig()->esc_temp_alarm != ESC_TEMP_ALARM_OFF && data->temperature >= osdConfig()->esc_temp_alarm) {
         buffer[alarmPos++] = ESC_ALARM_TEMP;
+    }
+
+    if (data->voltage && osdConfig()->esc_voltage_alarm != ESC_VOLTAGE_ALARM_OFF && data->voltage >= osdConfig()->esc_voltage_alarm) {
+        buffer[alarmPos++] = ESC_ALARM_VOLTAGE;
     }
 
     buffer[alarmPos] = '\0';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ESC voltage telemetry support so ESC voltage can be monitored.
  * Introduced an OSD ESC voltage alarm that displays a "V" warning when threshold is exceeded.
  * New CLI setting to configure the ESC voltage alarm threshold (disabled by default).
  * OSD configuration now persists the new alarm setting.
  * Existing ESC alarms (RPM, current, temperature) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->