### PR TITLE
Allow builds with USE_DSHOT_TELEMETRY but without USE_ESC_SENSOR.

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -312,7 +312,7 @@ static void renderOsdEscRpmOrFreq(getEscRpmOrFreqFnPtr escFnPtr, osdElementParms
 }
 #endif
 
-#if defined(USE_ADC_INTERNAL) || defined(USE_ESC_SENSOR)
+#if defined(USE_ADC_INTERNAL) || defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
 int osdConvertTemperatureToSelectedUnit(int tempInDegreesCelcius)
 {
     switch (osdConfig()->units) {
@@ -668,7 +668,7 @@ MAYBE_UNUSED static char osdGetVarioToSelectedUnitSymbol(void)
     }
 }
 
-#if defined(USE_ADC_INTERNAL) || defined(USE_ESC_SENSOR)
+#if defined(USE_ADC_INTERNAL) || defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
 char osdGetTemperatureSymbolForSelectedUnit(void)
 {
     switch (osdConfig()->units) {

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -312,7 +312,6 @@ static void renderOsdEscRpmOrFreq(getEscRpmOrFreqFnPtr escFnPtr, osdElementParms
 }
 #endif
 
-#if defined(USE_ADC_INTERNAL) || defined(USE_ESC_SENSOR) || defined(USE_DSHOT_TELEMETRY)
 int osdConvertTemperatureToSelectedUnit(int tempInDegreesCelcius)
 {
     switch (osdConfig()->units) {
@@ -322,7 +321,7 @@ int osdConvertTemperatureToSelectedUnit(int tempInDegreesCelcius)
         return tempInDegreesCelcius;
     }
 }
-#endif
+
 static void osdFormatAltitudeString(char * buff, int32_t altitudeCm, osdElementType_e variantType)
 {
     static const struct {

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -123,7 +123,9 @@ static bool buildEscWarningMessage(char *warningText, bool isDshot) {
                 escData = &escDataBuffer;
             }
         } else {
+#ifdef USE_ESC_SENSOR
             escData = getEscSensorData(i);
+#endif
         }
 
         if (escData) {


### PR DESCRIPTION
Allow builds with USE_DSHOT_TELEMETRY but without USE_ESC_SENSOR.
(Adjust conditions to include relevant functions.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OSD will show temperature readings on more setups (including those using DSHOT telemetry).
  - Temperature display now consistently respects the selected unit and shows the appropriate unit symbol.

- Bug Fixes
  - ESC-related warning messages are suppressed on systems without ESC sensor support, preventing spurious warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->