### PR TITLE
REFACTOR: Rename I2CDevice to i2cDevice_e for consistent naming pattern for enums

### DIFF
--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -54,7 +54,7 @@ typedef struct busDevice_s {
             bool leadingEdge;
         } spi;
         struct busI2C_s {
-            I2CDevice device;
+            i2cDevice_e device;
         } i2c;
         struct busMpuSlave_s {
             struct extDevice_s *master;

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -28,7 +28,7 @@
 #define I2C_DEVICE I2CINVALID
 #endif
 
-typedef enum I2CDevice {
+typedef enum {
     I2CINVALID = -1,
     I2CDEV_FIRST = 0,
 #if defined(USE_I2C_DEVICE_0)
@@ -40,9 +40,9 @@ typedef enum I2CDevice {
     I2CDEV_2,
     I2CDEV_3,
     I2CDEV_4,
-} I2CDevice;
+} i2cDevice_e;
 
-// Macros to convert between CLI bus number and I2CDevice.
+// Macros to convert between CLI bus number and i2cDevice_e.
 #define I2C_CFG_TO_DEV(x)   ((x) - 1)
 #define I2C_DEV_TO_CFG(x)   ((x) + 1)
 
@@ -52,12 +52,12 @@ typedef enum I2CDevice {
 
 struct i2cConfig_s;
 void i2cPinConfigure(const struct i2cConfig_s *i2cConfig);
-void i2cInit(I2CDevice device);
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data);
-bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
-bool i2cBusy(I2CDevice device, bool *error);
+void i2cInit(i2cDevice_e device);
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
+bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg, uint8_t data);
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
+bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
+bool i2cBusy(i2cDevice_e device, bool *error);
 
 uint16_t i2cGetErrorCounter(void);
 uint8_t i2cGetRegisteredDeviceCount(void);

--- a/src/main/drivers/bus_i2c_impl.h
+++ b/src/main/drivers/bus_i2c_impl.h
@@ -23,6 +23,7 @@
 #include "platform.h"
 
 #include "drivers/io_types.h"
+#include "drivers/bus_i2c.h"  // for i2cDevice_e
 
 #if PLATFORM_TRAIT_RCC
 #include "platform/rcc_types.h"

--- a/src/main/drivers/bus_i2c_impl.h
+++ b/src/main/drivers/bus_i2c_impl.h
@@ -47,7 +47,7 @@ typedef struct i2cPinDef_s {
 #endif
 
 typedef struct i2cHardware_s {
-    I2CDevice device;
+    i2cDevice_e device;
     I2C_TypeDef *reg;
     i2cPinDef_t sclPins[I2C_PIN_SEL_MAX];
     i2cPinDef_t sdaPins[I2C_PIN_SEL_MAX];

--- a/src/main/drivers/bus_i2c_soft.c
+++ b/src/main/drivers/bus_i2c_soft.c
@@ -168,7 +168,7 @@ static uint8_t I2C_ReceiveByte(void)
     return byte;
 }
 
-void i2cInit(I2CDevice device)
+void i2cInit(i2cDevice_e device)
 {
     UNUSED(device);
 
@@ -179,7 +179,7 @@ void i2cInit(I2CDevice device)
     IOConfigGPIO(sda, IOCFG_OUT_OD);
 }
 
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t * data)
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t * data)
 {
     UNUSED(device);
 
@@ -207,7 +207,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, ui
     return true;
 }
 
-bool i2cWrite(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t data)
+bool i2cWrite(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t data)
 {
     UNUSED(device);
 
@@ -228,7 +228,7 @@ bool i2cWrite(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *buf)
+bool i2cRead(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *buf)
 {
     UNUSED(device);
 

--- a/src/main/pg/bus_i2c.c
+++ b/src/main/pg/bus_i2c.c
@@ -99,7 +99,7 @@ static const i2cDefaultConfig_t i2cDefaultConfig[] = {
 
 void pgResetFn_i2cConfig(i2cConfig_t *i2cConfig)
 {
-    memset(i2cConfig, 0, sizeof(*i2cConfig));
+    memset(i2cConfig, 0, sizeof(*i2cConfig) * I2CDEV_COUNT);
 
     for (size_t index = 0 ; index < ARRAYLEN(i2cDefaultConfig) ; index++) {
         const i2cDefaultConfig_t *defconf = &i2cDefaultConfig[index];

--- a/src/main/pg/bus_i2c.c
+++ b/src/main/pg/bus_i2c.c
@@ -103,7 +103,7 @@ void pgResetFn_i2cConfig(i2cConfig_t *i2cConfig)
 
     for (size_t index = 0 ; index < ARRAYLEN(i2cDefaultConfig) ; index++) {
         const i2cDefaultConfig_t *defconf = &i2cDefaultConfig[index];
-        int device = defconf->device;
+        const i2cDevice_e device = defconf->device;
         i2cConfig[device].ioTagScl = defconf->ioTagScl;
         i2cConfig[device].ioTagSda = defconf->ioTagSda;
         i2cConfig[device].pullUp = defconf->pullUp;

--- a/src/main/pg/bus_i2c.c
+++ b/src/main/pg/bus_i2c.c
@@ -73,7 +73,7 @@ PG_REGISTER_ARRAY_WITH_RESET_FN(i2cConfig_t, I2CDEV_COUNT, i2cConfig, PG_I2C_CON
 #endif
 
 typedef struct i2cDefaultConfig_s {
-    I2CDevice device;
+    i2cDevice_e device;
     ioTag_t ioTagScl, ioTagSda;
     bool pullUp;
     uint16_t clockSpeed;

--- a/src/main/pg/dashboard.h
+++ b/src/main/pg/dashboard.h
@@ -18,6 +18,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
+#include <stdint.h>
+#include "pg/bus_i2c.h"
+
 typedef struct dashboardConfig_s {
     i2cDevice_e device;
     uint8_t   address;

--- a/src/main/pg/dashboard.h
+++ b/src/main/pg/dashboard.h
@@ -19,7 +19,7 @@
  */
 
 typedef struct dashboardConfig_s {
-    I2CDevice device;
+    i2cDevice_e device;
     uint8_t   address;
 } dashboardConfig_t;
 

--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -230,7 +230,7 @@ static void gyroResetSpiDeviceConfig(gyroDeviceConfig_t *devconf, SPI_TypeDef *i
 #endif
 
 #if defined(USE_I2C_GYRO) && !(GYRO_COUNT > 1)
-static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, I2CDevice i2cbus, ioTag_t extiTag, uint8_t alignment, sensorAlignment_t customAlignment)
+static void gyroResetI2cDeviceConfig(gyroDeviceConfig_t *devconf, i2cDevice_e i2cbus, ioTag_t extiTag, uint8_t alignment, sensorAlignment_t customAlignment)
 {
     devconf->busType = BUS_TYPE_I2C;
     devconf->i2cBus = I2C_DEV_TO_CFG(i2cbus);

--- a/src/platform/APM32/bus_i2c_apm32.c
+++ b/src/platform/APM32/bus_i2c_apm32.c
@@ -74,7 +74,7 @@ void I2C3_EV_IRQHandler(void)
 
 static volatile uint16_t i2cErrorCount = 0;
 
-static bool i2cHandleHardwareFailure(I2CDevice device)
+static bool i2cHandleHardwareFailure(i2cDevice_e device)
 {
     UNUSED(device);
     i2cErrorCount++;
@@ -89,7 +89,7 @@ uint16_t i2cGetErrorCounter(void)
 }
 
 // Blocking write
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
+bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -117,7 +117,7 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
 }
 
 // Non-blocking write
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -145,7 +145,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
 }
 
 // Blocking read
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -173,7 +173,7 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
 }
 
 // Non-blocking read
-bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -200,7 +200,7 @@ bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, u
     return true;
 }
 
-bool i2cBusy(I2CDevice device, bool *error)
+bool i2cBusy(i2cDevice_e device, bool *error)
 {
     I2C_HandleTypeDef *pHandle = &i2cDevice[device].handle;
 

--- a/src/platform/APM32/bus_i2c_apm32_init.c
+++ b/src/platform/APM32/bus_i2c_apm32_init.c
@@ -78,7 +78,7 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
 
 i2cDevice_t i2cDevice[I2CDEV_COUNT];
 
-void i2cInit(I2CDevice device)
+void i2cInit(i2cDevice_e device)
 {
     if (device == I2CINVALID) {
         return;

--- a/src/platform/AT32/bus_i2c_atbsp.c
+++ b/src/platform/AT32/bus_i2c_atbsp.c
@@ -88,7 +88,7 @@ void I2C4_EVT_IRQHandler(void)
 
 static volatile uint16_t i2cErrorCount = 0;
 
-static bool i2cHandleHardwareFailure(I2CDevice device)
+static bool i2cHandleHardwareFailure(i2cDevice_e device)
 {
     (void)device;
     i2cErrorCount++;
@@ -100,7 +100,7 @@ uint16_t i2cGetErrorCounter(void)
     return i2cErrorCount;
 }
 
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
+bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -137,7 +137,7 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
     return true;
 }
 
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -168,7 +168,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
     return true;
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -205,7 +205,7 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
     return true;
 }
 
-bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -237,7 +237,7 @@ bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, u
     return true;
 }
 
-bool i2cBusy(I2CDevice device, bool *error)
+bool i2cBusy(i2cDevice_e device, bool *error)
 {
     i2c_handle_type *pHandle = &i2cDevice[device].handle;
 

--- a/src/platform/AT32/bus_i2c_atbsp_init.c
+++ b/src/platform/AT32/bus_i2c_atbsp_init.c
@@ -103,7 +103,7 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
 
 i2cDevice_t i2cDevice[I2CDEV_COUNT];
 
-void i2cInit(I2CDevice device)
+void i2cInit(i2cDevice_e device)
 {
     if (device == I2CINVALID) {
         return;

--- a/src/platform/PICO/bus_i2c_pico.c
+++ b/src/platform/PICO/bus_i2c_pico.c
@@ -96,7 +96,7 @@ void i2cPinConfigure(const i2cConfig_t *i2cConfig)
             continue;
         }
 
-        I2CDevice device = hardware->device;
+        i2cDevice_e device = hardware->device;
         i2cDevice_t *pDev = &i2cDevice[device];
 
         memset(pDev, 0, sizeof(*pDev));
@@ -132,7 +132,7 @@ uint16_t i2cGetErrorCounter(void)
     return i2cErrorCount;
 }
 
-bool i2cWrite(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t data)
+bool i2cWrite(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t data)
 {
     // Start non-blocking write
     if (!i2cWriteBuffer(device, addr, reg, 1, &data)) {
@@ -147,7 +147,7 @@ bool i2cWrite(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *data)
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *data)
 {
     // We don't ever write more bytes than will fit in the FIFO, but, just in case, validate args
     if (device == I2CINVALID || device >= I2CDEV_COUNT || len == 0 || len >= I2C_FIFO_BUFFER_DEPTH) {
@@ -200,7 +200,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, ui
     return true;
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* buf)
+bool i2cRead(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* buf)
 {
     // Start non-blocking read
     if (!i2cReadBuffer(device, addr, reg, len, buf)) {
@@ -228,7 +228,7 @@ static void i2c_load_read_commands(i2c_hw_t *hw, uint8_t len, bool final_batch)
     }
 }
 
-bool i2cReadBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT || len == 0) {
         return false;
@@ -303,7 +303,7 @@ bool i2cReadBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uin
     return true;
 }
 
-bool i2cBusy(I2CDevice device, bool *error)
+bool i2cBusy(i2cDevice_e device, bool *error)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -418,7 +418,7 @@ static void i2c_irq1_handler(void)
     i2c_irq_handler(&i2c_contexts[I2CDEV_1]);
 }
 
-void i2cInit(I2CDevice device)
+void i2cInit(i2cDevice_e device)
 {
     if (device == I2CINVALID) {
         return;

--- a/src/platform/STM32/bus_i2c_hal.c
+++ b/src/platform/STM32/bus_i2c_hal.c
@@ -85,7 +85,7 @@ void I2C4_EV_IRQHandler(void)
 
 static volatile uint16_t i2cErrorCount = 0;
 
-static bool i2cHandleHardwareFailure(I2CDevice device)
+static bool i2cHandleHardwareFailure(i2cDevice_e device)
 {
     (void)device;
     i2cErrorCount++;
@@ -100,7 +100,7 @@ uint16_t i2cGetErrorCounter(void)
 }
 
 // Blocking write
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
+bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -126,7 +126,7 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
 }
 
 // Non-blocking write
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -155,7 +155,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
 }
 
 // Blocking read
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -182,7 +182,7 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
 }
 
 // Non-blocking read
-bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -209,7 +209,7 @@ bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, u
     return true;
 }
 
-bool i2cBusy(I2CDevice device, bool *error)
+bool i2cBusy(i2cDevice_e device, bool *error)
 {
     I2C_HandleTypeDef *pHandle = &i2cDevice[device].handle;
 

--- a/src/platform/STM32/bus_i2c_hal_init.c
+++ b/src/platform/STM32/bus_i2c_hal_init.c
@@ -190,7 +190,7 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
 
 i2cDevice_t i2cDevice[I2CDEV_COUNT];
 
-void i2cInit(I2CDevice device)
+void i2cInit(i2cDevice_e device)
 {
     if (device == I2CINVALID) {
         return;

--- a/src/platform/STM32/bus_i2c_stm32f4xx.c
+++ b/src/platform/STM32/bus_i2c_stm32f4xx.c
@@ -36,8 +36,8 @@
 #include "drivers/bus_i2c_impl.h"
 #include "drivers/bus_i2c_utils.h"
 
-static void i2c_er_handler(I2CDevice device);
-static void i2c_ev_handler(I2CDevice device);
+static void i2c_er_handler(i2cDevice_e device);
+static void i2c_ev_handler(i2cDevice_e device);
 
 #ifdef STM32F4
 #define IOCFG_I2C_PU IO_CONFIG(GPIO_Mode_AF, 0, GPIO_OType_OD, GPIO_PuPd_UP)
@@ -158,7 +158,7 @@ void I2C3_EV_IRQHandler(void)
 }
 #endif
 
-static bool i2cHandleHardwareFailure(I2CDevice device)
+static bool i2cHandleHardwareFailure(i2cDevice_e device)
 {
     i2cErrorCount++;
     // reinit peripheral + clock out garbage
@@ -166,7 +166,7 @@ static bool i2cHandleHardwareFailure(I2CDevice device)
     return false;
 }
 
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -210,7 +210,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
     return true;
 }
 
-bool i2cBusy(I2CDevice device, bool *error)
+bool i2cBusy(i2cDevice_e device, bool *error)
 {
     i2cState_t *state = &i2cDevice[device].state;
 
@@ -220,7 +220,7 @@ bool i2cBusy(I2CDevice device, bool *error)
     return state->busy;
 }
 
-static bool i2cWait(I2CDevice device)
+static bool i2cWait(i2cDevice_e device)
 {
     i2cState_t *state = &i2cDevice[device].state;
     timeUs_t timeoutStartUs = microsISR();
@@ -234,12 +234,12 @@ static bool i2cWait(I2CDevice device)
     return !(state->error);
 }
 
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
+bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 {
     return i2cWriteBuffer(device, addr_, reg_, 1, &data) && i2cWait(device);
 }
 
-bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     if (device == I2CINVALID || device >= I2CDEV_COUNT) {
         return false;
@@ -282,12 +282,12 @@ bool i2cReadBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, u
     return true;
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
 {
     return i2cReadBuffer(device, addr_, reg_, len, buf) && i2cWait(device);
 }
 
-static void i2c_er_handler(I2CDevice device)
+static void i2c_er_handler(i2cDevice_e device)
 {
     I2C_TypeDef *I2Cx = i2cDevice[device].hardware->reg;
 
@@ -320,7 +320,7 @@ static void i2c_er_handler(I2CDevice device)
     state->busy = 0;
 }
 
-void i2c_ev_handler(I2CDevice device)
+void i2c_ev_handler(i2cDevice_e device)
 {
     I2C_TypeDef *I2Cx = i2cDevice[device].hardware->reg;
 
@@ -434,7 +434,7 @@ void i2c_ev_handler(I2CDevice device)
     }
 }
 
-void i2cInit(I2CDevice device)
+void i2cInit(i2cDevice_e device)
 {
     if (device == I2CINVALID)
         return;

--- a/src/platform/common/stm32/bus_i2c_pinconfig.c
+++ b/src/platform/common/stm32/bus_i2c_pinconfig.c
@@ -48,7 +48,7 @@ void i2cPinConfigure(const i2cConfig_t *i2cConfig)
             continue;
         }
 
-        i2cDevice_e device = hardware->device;
+        const i2cDevice_e device = hardware->device;
         i2cDevice_t *pDev = &i2cDevice[device];
 
         memset(pDev, 0, sizeof(*pDev));

--- a/src/platform/common/stm32/bus_i2c_pinconfig.c
+++ b/src/platform/common/stm32/bus_i2c_pinconfig.c
@@ -48,7 +48,7 @@ void i2cPinConfigure(const i2cConfig_t *i2cConfig)
             continue;
         }
 
-        I2CDevice device = hardware->device;
+        i2cDevice_e device = hardware->device;
         i2cDevice_t *pDev = &i2cDevice[device];
 
         memset(pDev, 0, sizeof(*pDev));


### PR DESCRIPTION
As per title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized I2C device identifier to a new public enum across the codebase.
  * Updated I2C APIs and configuration types to use the new device type uniformly on supported platforms.
  * No functional or behavioral changes; I2C operations behave the same.
  * Developers may need to adjust type references when integrating with I2C APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->