### PR TITLE
Fix configurator status crash when no osdDisplayPort.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4781,7 +4781,7 @@ static void cliStatus(const char *cmdName, char *cmdline)
     osdDisplayPortDevice_e displayPortDeviceType;
     displayPort_t *osdDisplayPort = osdGetDisplayPort(&displayPortDeviceType);
 
-    cliPrintLinef("OSD: %s (%u x %u)", lookupTableOsdDisplayPortDevice[displayPortDeviceType], osdDisplayPort->cols, osdDisplayPort->rows);
+    cliPrintLinef("OSD: %s (%u x %u)", lookupTableOsdDisplayPortDevice[displayPortDeviceType], osdDisplayPort ? osdDisplayPort->cols : 0, osdDisplayPort ? osdDisplayPort->rows : 0);
 #endif
 
 if (buildKey) {


### PR DESCRIPTION
Fix configurator status crash when no osdDisplayPort.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a rare crash in the CLI status output when display information was unavailable.
  * CLI now safely reports on-screen display dimensions as 0x0 if data is missing, preventing errors.
  * Improves overall stability and reliability of status reporting in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->