### PR TITLE
REFACTOR: Corrected SOFT_I2C to USE_SOFT_I2C

### DIFF
--- a/src/main/drivers/bus_i2c_soft.c
+++ b/src/main/drivers/bus_i2c_soft.c
@@ -23,7 +23,7 @@
 
 #include "platform.h"
 
-#ifdef SOFT_I2C
+#ifdef USE_SOFT_I2C
 
 #include "build/build_config.h"
 

--- a/src/main/pg/bus_i2c.c
+++ b/src/main/pg/bus_i2c.c
@@ -28,7 +28,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "common/utils.h"
 

--- a/src/platform/APM32/bus_i2c_apm32.c
+++ b/src/platform/APM32/bus_i2c_apm32.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"

--- a/src/platform/APM32/bus_i2c_apm32_init.c
+++ b/src/platform/APM32/bus_i2c_apm32_init.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/nvic.h"

--- a/src/platform/AT32/bus_i2c_atbsp.c
+++ b/src/platform/AT32/bus_i2c_atbsp.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"

--- a/src/platform/AT32/bus_i2c_atbsp_init.c
+++ b/src/platform/AT32/bus_i2c_atbsp_init.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/nvic.h"

--- a/src/platform/PICO/bus_i2c_pico.c
+++ b/src/platform/PICO/bus_i2c_pico.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "pg/bus_i2c.h"
 
@@ -486,4 +486,4 @@ void i2cInit(I2CDevice device)
     }
 }
 
-#endif // #if defined(USE_I2C) && !defined(SOFT_I2C)
+#endif // #if defined(USE_I2C) && !defined(USE_SOFT_I2C)

--- a/src/platform/STM32/bus_i2c_hal.c
+++ b/src/platform/STM32/bus_i2c_hal.c
@@ -24,7 +24,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"

--- a/src/platform/STM32/bus_i2c_hal_init.c
+++ b/src/platform/STM32/bus_i2c_hal_init.c
@@ -24,7 +24,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/nvic.h"

--- a/src/platform/STM32/bus_i2c_stm32f4xx.c
+++ b/src/platform/STM32/bus_i2c_stm32f4xx.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "drivers/io.h"
 #include "drivers/time.h"

--- a/src/platform/common/stm32/bus_i2c_pinconfig.c
+++ b/src/platform/common/stm32/bus_i2c_pinconfig.c
@@ -28,7 +28,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
 
 #include "build/build_config.h"
 #include "build/debug.h"


### PR DESCRIPTION
Noticed inconsistent naming for this define, SOFT_I2C versus USE_SOFT_I2C. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized the build-time flag for Software I2C to USE_SOFT_I2C across all platforms.
  - No changes to runtime behavior or user-facing features; hardware compatibility remains the same.
  - Default firmware builds are unaffected.
  - If you compile custom firmware, update your configuration to use the new USE_SOFT_I2C flag instead of the previous name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->