### PR TITLE
BUGFIX: Inoperative ADC due to internal readings returning 0

### DIFF
--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -52,10 +52,10 @@ typedef enum {
     ADC_CURRENT,
     ADC_EXTERNAL1,
     ADC_RSSI,
+    ADC_LAST_EXTERNAL = ADC_RSSI,
 #ifdef USE_ADC_INTERNAL
     // For certain processors internal sensors are treated in the similar fashion as regular ADC inputs
-    ADC_SOURCE_INTERNAL_FIRST_ID,
-    ADC_TEMPSENSOR = ADC_SOURCE_INTERNAL_FIRST_ID,
+    ADC_TEMPSENSOR,
     ADC_VREFINT,
 #if ADC_INTERNAL_VBAT4_ENABLED
     ADC_VBAT4,

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -52,16 +52,18 @@ typedef enum {
     ADC_CURRENT,
     ADC_EXTERNAL1,
     ADC_RSSI,
-    ADC_LAST_EXTERNAL = ADC_RSSI,
+    ADC_EXTERNAL_COUNT,
 #ifdef USE_ADC_INTERNAL
     // For certain processors internal sensors are treated in the similar fashion as regular ADC inputs
-    ADC_TEMPSENSOR,
+    ADC_TEMPSENSOR = ADC_EXTERNAL_COUNT,
     ADC_VREFINT,
 #if ADC_INTERNAL_VBAT4_ENABLED
     ADC_VBAT4,
 #endif
-#endif
     ADC_SOURCE_COUNT
+#else
+    ADC_SOURCE_COUNT = ADC_EXTERNAL_COUNT
+#endif
 } adcSource_e;
 
 struct adcConfig_s;

--- a/src/platform/APM32/adc_apm32f4xx.c
+++ b/src/platform/APM32/adc_apm32f4xx.c
@@ -195,14 +195,16 @@ void adcInternalStartConversion(void)
     adcInternalConversionInProgress = true;
 }
 
-uint16_t adcInternalReadVrefint(void)
+uint16_t adcInternalRead(adcSource_e source)
 {
-    return DAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_1);
-}
-
-uint16_t adcInternalReadTempsensor(void)
-{
-    return DAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_2);
+    switch (source) {
+    case ADC_VREFINT:
+        return DAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_1);
+    case ADC_TEMPSENSOR:
+        return DAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_2);
+    default:
+        return 0;
+    }
 }
 #endif // USE_ADC_INTERNAL
 
@@ -275,13 +277,16 @@ void adcInit(const adcConfig_t *config)
         adcInitInternalInjected(&adc);
     }
 
+    adcOperatingConfig[ADC_VREFINT].enabled = true;
+    adcOperatingConfig[ADC_TEMPSENSOR].enabled = true;
+
     if (!adcActive) {
         return;
     }
 #endif // USE_ADC_INTERNAL
 
     uint8_t rank = 1;
-    for (i = 0; i < ADC_SOURCE_COUNT; i++) {
+    for (i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (!adcOperatingConfig[i].enabled) {
             continue;
         }

--- a/src/platform/APM32/adc_apm32f4xx.c
+++ b/src/platform/APM32/adc_apm32f4xx.c
@@ -286,7 +286,7 @@ void adcInit(const adcConfig_t *config)
 #endif // USE_ADC_INTERNAL
 
     uint8_t rank = 1;
-    for (i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (i = 0; i < ADC_EXTERNAL_COUNT; i++) {
         if (!adcOperatingConfig[i].enabled) {
             continue;
         }

--- a/src/platform/AT32/adc_at32f43x.c
+++ b/src/platform/AT32/adc_at32f43x.c
@@ -358,7 +358,7 @@ void adcInit(const adcConfig_t *config)
         }
 
         dmaIdentifier_e dmaIdentifier = dmaGetIdentifier(dmaSpec->ref);
-        if ( ! dmaAllocate(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev)) ) {
+        if (!dmaAllocate(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev))) {
             return;
         }
 
@@ -420,7 +420,7 @@ void adcInit(const adcConfig_t *config)
 */
 void adcGetChannelValues(void)
 {
-    for (int i = 0; i < ADC_SOURCE_INTERNAL_FIRST_ID; i++) {
+    for (int i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (adcOperatingConfig[i].enabled) {
             adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
         }
@@ -446,42 +446,17 @@ void adcInternalStartConversion(void)
 }
 
 /**
- * Reads a given channel from the DMA buffer
+ * Reads a given internal channel from the DMA buffer
 */
-static uint16_t adcInternalRead(int channel)
+uint16_t adcInternalRead(adcSource_e source)
 {
-    const int dmaIndex = adcOperatingConfig[channel].dmaIndex;
-    return adcConversionBuffer[dmaIndex];
-}
-
-/**
- * Read the internal Vref and return raw value
- *
- * The internal Vref is 1.2V and can be used to calculate the external Vref+
- * External Vref+ determines the scale for the raw ADC readings but since it
- * is often directly connected to Vdd (approx 3.3V) it isn't accurately controlled.
- * Calculating the actual value of Vref+ by using measurements of the known 1.2V
- * internal reference can improve overall accuracy.
- *
- * @return the raw ADC reading for the internal voltage reference
- * @see adcInternalCompensateVref in src/main/drivers/adc.c
-*/
-uint16_t adcInternalReadVrefint(void)
-{
-    const uint16_t value = adcInternalRead(ADC_VREFINT);
-
-    return value;
-}
-
-/**
- * Read the internal temperature sensor
- *
- * @return the raw ADC reading
-*/
-uint16_t adcInternalReadTempsensor(void)
-{
-    const uint16_t value = adcInternalRead(ADC_TEMPSENSOR);
-    return value;
+    switch (source) {
+    case ADC_VREFINT:
+    case ADC_TEMPSENSOR:
+        return adcConversionBuffer[adcOperatingConfig[source].dmaIndex];
+    default:
+        return 0;
+    }
 }
 
 #endif // USE_ADC_INTERNAL

--- a/src/platform/AT32/adc_at32f43x.c
+++ b/src/platform/AT32/adc_at32f43x.c
@@ -257,13 +257,18 @@ void adcInit(const adcConfig_t *config)
         int map;
         int dev;
 
-        if (i == ADC_TEMPSENSOR) {
+        switch(i) {
+#ifdef USE_ADC_INTERNAL
+        case ADC_TEMPSENSOR:
             map = ADC_TAG_MAP_TEMPSENSOR;
             dev = ADCDEV_1;
-        } else if (i == ADC_VREFINT) {
+            break;
+        case ADC_VREFINT:
             map = ADC_TAG_MAP_VREFINT;
             dev = ADCDEV_1;
-        } else {
+            break;
+#endif
+        default:
             if (!adcOperatingConfig[i].tag) {
                 continue;
             }
@@ -347,7 +352,7 @@ void adcInit(const adcConfig_t *config)
         // Set the oversampling ratio and matching shift
         adc_oversample_ratio_shift_set(adc->ADCx, ADC_OVERSAMPLE_RATIO_64, ADC_OVERSAMPLE_SHIFT_6);
 
-        #ifdef USE_DMA_SPEC
+#ifdef USE_DMA_SPEC
 
         // Setup the DMA channel so that data is automatically and continuously transferred from the ADC output register
         // to the results buffer
@@ -387,7 +392,7 @@ void adcInit(const adcConfig_t *config)
         adc_dma_mode_enable(adc->ADCx, TRUE);
         adc_dma_request_repeat_enable(adc->ADCx, TRUE);
 
-        #endif //end of USE_DMA_SPEC
+#endif //end of USE_DMA_SPEC
 
         // set each channel into the auto sequence for this ADC device
         for (int adcChan = 0; adcChan < ADC_SOURCE_COUNT; adcChan++)

--- a/src/platform/AT32/adc_at32f43x.c
+++ b/src/platform/AT32/adc_at32f43x.c
@@ -420,7 +420,7 @@ void adcInit(const adcConfig_t *config)
 */
 void adcGetChannelValues(void)
 {
-    for (int i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (unsigned i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (adcOperatingConfig[i].enabled) {
             adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
         }

--- a/src/platform/AT32/adc_at32f43x.c
+++ b/src/platform/AT32/adc_at32f43x.c
@@ -425,7 +425,7 @@ void adcInit(const adcConfig_t *config)
 */
 void adcGetChannelValues(void)
 {
-    for (unsigned i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (unsigned i = 0; i < ADC_EXTERNAL_COUNT; i++) {
         if (adcOperatingConfig[i].enabled) {
             adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
         }
@@ -458,7 +458,8 @@ uint16_t adcInternalRead(adcSource_e source)
     switch (source) {
     case ADC_VREFINT:
     case ADC_TEMPSENSOR:
-        return adcConversionBuffer[adcOperatingConfig[source].dmaIndex];
+        const unsigned dmaIndex = adcOperatingConfig[source].dmaIndex;
+        return dmaIndex < ARRAYLEN(adcConversionBuffer) ? adcConversionBuffer[dmaIndex] : 0;
     default:
         return 0;
     }

--- a/src/platform/PICO/adc_pico.c
+++ b/src/platform/PICO/adc_pico.c
@@ -265,10 +265,5 @@ void adcInternalStartConversion(void)
 {
     //NOOP
 }
-
-uint16_t adcInternalRead(adcSource_e source)
-{
-    return 0;
-}
 #endif // USE_ADC_INTERNAL
 #endif // USE_ADC

--- a/src/platform/PICO/adc_pico.c
+++ b/src/platform/PICO/adc_pico.c
@@ -252,7 +252,7 @@ uint16_t adcGetValue(adcSource_e source)
     }
 
     const uint8_t dmaIndex = adcOperatingConfig[source].dmaIndex;
-    return adcValues[dmaIndex];
+    return dmaIndex < ARRAYLEN(adcValues) ? adcValues[dmaIndex] : 0;
 }
 
 #ifdef USE_ADC_INTERNAL

--- a/src/platform/PICO/adc_pico.c
+++ b/src/platform/PICO/adc_pico.c
@@ -256,7 +256,6 @@ uint16_t adcGetValue(adcSource_e source)
 }
 
 #ifdef USE_ADC_INTERNAL
-
 bool adcInternalIsBusy(void)
 {
     return false;
@@ -267,5 +266,9 @@ void adcInternalStartConversion(void)
     //NOOP
 }
 
+uint16_t adcInternalRead(adcSource_e source)
+{
+    return 0;
+}
 #endif // USE_ADC_INTERNAL
 #endif // USE_ADC

--- a/src/platform/STM32/adc_stm32f4xx.c
+++ b/src/platform/STM32/adc_stm32f4xx.c
@@ -292,7 +292,7 @@ void adcInit(const adcConfig_t *config)
     adcInitDevice(adc.ADCx, configuredAdcChannels);
 
     uint8_t rank = 1;
-    for (i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (i = 0; i < ADC_EXTERNAL_COUNT; i++) {
         if (!adcOperatingConfig[i].enabled) {
             continue;
         }

--- a/src/platform/STM32/adc_stm32f4xx.c
+++ b/src/platform/STM32/adc_stm32f4xx.c
@@ -194,14 +194,16 @@ void adcInternalStartConversion(void)
     adcInternalConversionInProgress = true;
 }
 
-uint16_t adcInternalReadVrefint(void)
+uint16_t adcInternalRead(adcSource_e source)
 {
-    return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_1);
-}
-
-uint16_t adcInternalReadTempsensor(void)
-{
-    return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_2);
+    switch (source) {
+    case ADC_VREFINT:
+        return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_1);
+    case ADC_TEMPSENSOR:
+        return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_2);
+    default:
+        return 0;
+    }
 }
 #endif
 
@@ -279,6 +281,9 @@ void adcInit(const adcConfig_t *config)
     // Initialize for injected conversion
     adcInitInternalInjected(config);
 
+    adcOperatingConfig[ADC_VREFINT].enabled = true;
+    adcOperatingConfig[ADC_TEMPSENSOR].enabled = true;
+
     if (!adcActive) {
         return;
     }
@@ -287,7 +292,7 @@ void adcInit(const adcConfig_t *config)
     adcInitDevice(adc.ADCx, configuredAdcChannels);
 
     uint8_t rank = 1;
-    for (i = 0; i < ADC_SOURCE_COUNT; i++) {
+    for (i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (!adcOperatingConfig[i].enabled) {
             continue;
         }

--- a/src/platform/STM32/adc_stm32f7xx.c
+++ b/src/platform/STM32/adc_stm32f7xx.c
@@ -191,14 +191,16 @@ void adcInternalStartConversion(void)
     adcInternalConversionInProgress = true;
 }
 
-uint16_t adcInternalReadVrefint(void)
+uint16_t adcInternalRead(adcSource_e source)
 {
-    return HAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_1);
-}
-
-uint16_t adcInternalReadTempsensor(void)
-{
-    return HAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_2);
+    switch (source) {
+    case ADC_VREFINT:
+        return HAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_1);
+    case ADC_TEMPSENSOR:
+        return HAL_ADCEx_InjectedGetValue(adcInternalHandle, ADC_INJECTED_RANK_2);
+    default:
+        return 0;
+    }
 }
 #endif
 
@@ -266,22 +268,26 @@ void adcInit(const adcConfig_t *config)
     } else {
         adcInitInternalInjected(&adc);
     }
+
+    adcOperatingConfig[ADC_VREFINT].enabled = true;
+    adcOperatingConfig[ADC_TEMPSENSOR].enabled = true;
 #endif
 
     uint8_t rank = 1;
-    for (i = 0; i < ADC_SOURCE_COUNT; i++) {
-        if (adcOperatingConfig[i].enabled) {
-            ADC_ChannelConfTypeDef sConfig;
+    for (i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+        if (!adcOperatingConfig[i].enabled) {
+            continue;
+        }
+        ADC_ChannelConfTypeDef sConfig;
 
-            sConfig.Channel      = adcOperatingConfig[i].adcChannel;
-            sConfig.Rank         = rank++;
-            sConfig.SamplingTime = adcOperatingConfig[i].sampleTime;
-            sConfig.Offset       = 0;
+        sConfig.Channel      = adcOperatingConfig[i].adcChannel;
+        sConfig.Rank         = rank++;
+        sConfig.SamplingTime = adcOperatingConfig[i].sampleTime;
+        sConfig.Offset       = 0;
 
-            if (HAL_ADC_ConfigChannel(&adc.ADCHandle, &sConfig) != HAL_OK)
-            {
-                /* Channel Configuration Error */
-            }
+        if (HAL_ADC_ConfigChannel(&adc.ADCHandle, &sConfig) != HAL_OK)
+        {
+            /* Channel Configuration Error */
         }
     }
 

--- a/src/platform/STM32/adc_stm32f7xx.c
+++ b/src/platform/STM32/adc_stm32f7xx.c
@@ -274,7 +274,7 @@ void adcInit(const adcConfig_t *config)
 #endif
 
     uint8_t rank = 1;
-    for (i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (i = 0; i < ADC_EXTERNAL_COUNT; i++) {
         if (!adcOperatingConfig[i].enabled) {
             continue;
         }

--- a/src/platform/STM32/adc_stm32g4xx.c
+++ b/src/platform/STM32/adc_stm32g4xx.c
@@ -87,7 +87,7 @@ const adcDevice_t adcHardware[ADCDEV_COUNT] = {
         .ADCx = ADC4,
         .rccADC = RCC_AHB2(ADC345),
 #if !defined(USE_DMA_SPEC)
-        .dmaResource = (dmaResource_t *)ADC3_DMA_CHANNEL,
+        .dmaResource = (dmaResource_t *)ADC4_DMA_CHANNEL,
         .channel = DMA_REQUEST_ADC4,
 #endif
     },
@@ -408,10 +408,11 @@ void adcInit(const adcConfig_t *config)
 
         // Configure DMA for this ADC peripheral
 
+        dmaIdentifier_e dmaIdentifier;
 #ifdef USE_DMA_SPEC
         const dmaChannelSpec_t *dmaSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_ADC, dev, config->dmaopt[dev]);
 
-        dmaIdentifier_e dmaIdentifier = dmaGetIdentifier(dmaSpec->ref);
+        dmaIdentifier = dmaGetIdentifier(dmaSpec->ref);
         if (!dmaSpec || !dmaAllocate(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev))) {
             return;
         }

--- a/src/platform/STM32/adc_stm32g4xx.c
+++ b/src/platform/STM32/adc_stm32g4xx.c
@@ -420,8 +420,12 @@ void adcInit(const adcConfig_t *config)
 #ifdef USE_DMA_SPEC
         const dmaChannelSpec_t *dmaSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_ADC, dev, config->dmaopt[dev]);
 
+        if (!dmaSpec || !dmaSpec->ref) {
+            return;
+        }
+
         dmaIdentifier = dmaGetIdentifier(dmaSpec->ref);
-        if (!dmaSpec || !dmaAllocate(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev))) {
+        if (!dmaIdentifier || !dmaAllocate(dmaIdentifier, OWNER_ADC, RESOURCE_INDEX(dev))) {
             return;
         }
 

--- a/src/platform/STM32/adc_stm32g4xx.c
+++ b/src/platform/STM32/adc_stm32g4xx.c
@@ -285,13 +285,18 @@ void adcInit(const adcConfig_t *config)
         int map;
         int dev;
 
-        if (i == ADC_TEMPSENSOR) {
+        switch(i) {
+#ifdef USE_ADC_INTERNAL
+            case ADC_TEMPSENSOR:
             map = ADC_TAG_MAP_TEMPSENSOR;
             dev = ADCDEV_1;
-        } else if (i == ADC_VREFINT) {
+            break;
+        case ADC_VREFINT:
             map = ADC_TAG_MAP_VREFINT;
             dev = ADCDEV_1;
-        } else {
+            break;
+#endif
+        default:
             if (!adcOperatingConfig[i].tag) {
                 continue;
             }

--- a/src/platform/STM32/adc_stm32g4xx.c
+++ b/src/platform/STM32/adc_stm32g4xx.c
@@ -310,14 +310,17 @@ void adcInit(const adcConfig_t *config)
             // Find an ADC device that can handle this input pin
 
             for (dev = 0; dev < ADCDEV_COUNT; dev++) {
-                if (!adcDevice[dev].ADCx
-#ifndef USE_DMA_SPEC
-                     || !adcDevice[dev].dmaResource
-#endif
-                   ) {
+                if (!adcDevice[dev].ADCx) {
                     // Instance not activated
                     continue;
                 }
+
+#ifndef USE_DMA_SPEC
+                if (!adcDevice[dev].dmaResource) {
+                    continue;
+                }
+#endif
+
                 if (adcTagMap[map].devices & (1 << dev)) {
                     // Found an activated ADC instance for this input pin
                     break;

--- a/src/platform/STM32/adc_stm32g4xx.c
+++ b/src/platform/STM32/adc_stm32g4xx.c
@@ -484,7 +484,7 @@ void adcGetChannelValues(void)
 {
     // Transfer values in conversion buffer into adcValues[]
     // Cache coherency should be maintained by MPU facility
-    for (int i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (unsigned i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (adcOperatingConfig[i].enabled) {
             adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
         }

--- a/src/platform/STM32/adc_stm32h7xx.c
+++ b/src/platform/STM32/adc_stm32h7xx.c
@@ -541,7 +541,7 @@ void adcGetChannelValues(void)
 {
     // Transfer values in conversion buffer into adcValues[]
     SCB_InvalidateDCache_by_Addr((uint32_t*)adcConversionBuffer, ADC_BUF_CACHE_ALIGN_BYTES);
-    for (int i = 0; i < ADC_SOURCE_INTERNAL_FIRST_ID; i++) {
+    for (int i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (adcOperatingConfig[i].enabled) {
             adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
         }
@@ -560,23 +560,16 @@ void adcInternalStartConversion(void)
     return;
 }
 
-static uint16_t adcInternalRead(int channel)
+uint16_t adcInternalRead(adcSource_e source)
 {
-    int dmaIndex = adcOperatingConfig[channel].dmaIndex;
-
-    return adcConversionBuffer[dmaIndex];
-}
-
-uint16_t adcInternalReadVrefint(void)
-{
-    uint16_t value = adcInternalRead(ADC_VREFINT);
-    return value;
-}
-
-uint16_t adcInternalReadTempsensor(void)
-{
-    uint16_t value = adcInternalRead(ADC_TEMPSENSOR);
-    return value;
+    switch (source) {
+    case ADC_VREFINT:
+    case ADC_TEMPSENSOR:
+        const int dmaIndex = adcOperatingConfig[source].dmaIndex;
+        return adcConversionBuffer[dmaIndex];
+    default:
+        return 0;
+    }
 }
 #endif // USE_ADC_INTERNAL
 

--- a/src/platform/STM32/adc_stm32h7xx.c
+++ b/src/platform/STM32/adc_stm32h7xx.c
@@ -363,7 +363,13 @@ void adcInit(const adcConfig_t *config)
                         continue;
                     }
 
-#ifndef USE_DMA_SPEC
+#ifdef USE_DMA_SPEC
+                    // check that there is a valid spec for this dev
+                    const dmaChannelSpec_t *spec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_ADC, dev, config->dmaopt[dev]);
+                    if (!spec) {
+                        continue;
+                    }
+#else
                     if (!adcDevice[dev].dmaResource) {
                         continue;
                     }

--- a/src/platform/STM32/adc_stm32h7xx.c
+++ b/src/platform/STM32/adc_stm32h7xx.c
@@ -541,7 +541,7 @@ void adcGetChannelValues(void)
 {
     // Transfer values in conversion buffer into adcValues[]
     SCB_InvalidateDCache_by_Addr((uint32_t*)adcConversionBuffer, ADC_BUF_CACHE_ALIGN_BYTES);
-    for (int i = 0; i <= ADC_LAST_EXTERNAL; i++) {
+    for (unsigned i = 0; i <= ADC_LAST_EXTERNAL; i++) {
         if (adcOperatingConfig[i].enabled) {
             adcValues[adcOperatingConfig[i].dmaIndex] = adcConversionBuffer[adcOperatingConfig[i].dmaIndex];
         }
@@ -565,6 +565,9 @@ uint16_t adcInternalRead(adcSource_e source)
     switch (source) {
     case ADC_VREFINT:
     case ADC_TEMPSENSOR:
+#if ADC_INTERNAL_VBAT4_ENABLED
+    case ADC_VBAT4:
+#endif
         const int dmaIndex = adcOperatingConfig[source].dmaIndex;
         return adcConversionBuffer[dmaIndex];
     default:

--- a/src/platform/STM32/adc_stm32h7xx.c
+++ b/src/platform/STM32/adc_stm32h7xx.c
@@ -317,22 +317,25 @@ void adcInit(const adcConfig_t *config)
         case ADC_TEMPSENSOR:
             map = ADC_TAG_MAP_TEMPSENSOR;
             dev = ffs(adcTagMap[map].devices) - 1;
+            if (dev < 0) { continue; }
             break;
         case ADC_VREFINT:
             map = ADC_TAG_MAP_VREFINT;
             dev = ffs(adcTagMap[map].devices) - 1;
+            if (dev < 0) { continue; }
             break;
 #if ADC_INTERNAL_VBAT4_ENABLED
         case ADC_VBAT4:
             map = ADC_TAG_MAP_VBAT4;
             dev = ffs(adcTagMap[map].devices) - 1;
+            if (dev < 0) { continue; }
             break;
 #endif
 #endif
         default:
             dev = ADC_CFG_TO_DEV(adcOperatingConfig[i].adcDevice);
 
-            if (!adcOperatingConfig[i].tag) {
+            if (dev < 0 || !adcOperatingConfig[i].tag) {
                 continue;
             }
 

--- a/src/platform/common/stm32/adc_impl.c
+++ b/src/platform/common/stm32/adc_impl.c
@@ -123,6 +123,9 @@ uint16_t adcGetValue(adcSource_e source)
 #ifdef USE_ADC_INTERNAL
     case ADC_VREFINT:
     case ADC_TEMPSENSOR:
+#if ADC_INTERNAL_VBAT4_ENABLED
+    case ADC_VBAT4:
+#endif
         return adcInternalRead(source);
 #endif
     default:

--- a/src/platform/common/stm32/adc_impl.c
+++ b/src/platform/common/stm32/adc_impl.c
@@ -129,7 +129,8 @@ uint16_t adcGetValue(adcSource_e source)
         return adcInternalRead(source);
 #endif
     default:
-        return adcValues[adcOperatingConfig[source].dmaIndex];
+        const unsigned dmaIndex = adcOperatingConfig[source].dmaIndex;
+        return dmaIndex < ARRAYLEN(adcValues) ? adcValues[dmaIndex] : 0;
     }
 }
 

--- a/src/platform/common/stm32/adc_impl.c
+++ b/src/platform/common/stm32/adc_impl.c
@@ -114,10 +114,20 @@ uint16_t adcGetValue(adcSource_e source)
         }
     }
 #endif
+
     if ((unsigned)source >= ADC_SOURCE_COUNT || !adcOperatingConfig[source].enabled) {
         return 0;
     }
-    return adcValues[adcOperatingConfig[source].dmaIndex];
+
+    switch (source) {
+#ifdef USE_ADC_INTERNAL
+    case ADC_VREFINT:
+    case ADC_TEMPSENSOR:
+        return adcInternalRead(source);
+#endif
+    default:
+        return adcValues[adcOperatingConfig[source].dmaIndex];
+    }
 }
 
 #if PLATFORM_TRAIT_ADC_DEVICE

--- a/src/platform/common/stm32/platform/adc_impl.h
+++ b/src/platform/common/stm32/platform/adc_impl.h
@@ -126,6 +126,8 @@ extern int32_t adcVREFINTCAL; // ADC value (12-bit) of band gap with Vref = VREF
 extern int32_t adcTSCAL1;
 extern int32_t adcTSCAL2;
 extern int32_t adcTSSlopeK;
+
+uint16_t adcInternalRead(adcSource_e source);
 #endif
 
 uint32_t adcChannelByTag(ioTag_t ioTag);


### PR DESCRIPTION
A further refactor and bugfix for ADC (G4, F4, H7 etc) due to internal VREF and TEMP returning 0 following refactor in https://github.com/betaflight/betaflight/pull/14587


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified internal ADC read API exposed across platforms.

- Bug Fixes
  - Internal VREFINT/temperature (and optional VBAT4) explicitly enabled during init.
  - Channel configuration now covers all external sources; unknown/out-of-range reads return 0.
  - Bounds-checks added to ADC value retrieval.

- Refactor
  - Consolidated duplicated internal ADC read logic and standardized APIs and loop bounds.

- Style
  - Minor formatting and indexing cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->