### PR TITLE
PICO: Adding reboot to flashing rom (like DFU)

### DIFF
--- a/src/platform/PICO/system.c
+++ b/src/platform/PICO/system.c
@@ -35,6 +35,7 @@
 #include "hardware/clocks.h"
 #include "hardware/timer.h"
 #include "hardware/watchdog.h"
+#include "pico/bootrom.h"
 #include "pico/unique_id.h"
 
 ///////////////////////////////////////////////////
@@ -114,8 +115,11 @@ void systemInit(void)
 
 void systemResetToBootloader(bootloaderRequestType_e requestType)
 {
-    UNUSED(requestType);
-    //TODO: implement
+    if (requestType == BOOTLOADER_REQUEST_FLASH) {
+        systemReset();
+    } else if (requestType == BOOTLOADER_REQUEST_ROM) {
+        rom_reset_usb_boot_extra(-1, 0, false);
+    }
 }
 
 // Return system uptime in milliseconds (rollover in 49 days)

--- a/src/platform/PICO/system.c
+++ b/src/platform/PICO/system.c
@@ -115,10 +115,13 @@ void systemInit(void)
 
 void systemResetToBootloader(bootloaderRequestType_e requestType)
 {
-    if (requestType == BOOTLOADER_REQUEST_FLASH) {
-        systemReset();
-    } else if (requestType == BOOTLOADER_REQUEST_ROM) {
+    switch (requestType) {
+    case BOOTLOADER_REQUEST_ROM:
         rom_reset_usb_boot_extra(-1, 0, false);
+        break;
+    case BOOTLOADER_REQUEST_FLASH:
+    default:
+        systemReset();
     }
 }
 


### PR DESCRIPTION
Makes sure one can reboot to the bootloader rom for flashing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Devices based on Pico can now reboot directly into the bootloader/USB mode, simplifying firmware updates and recovery.
  - Supports choosing between a standard reboot or entry to the ROM bootloader depending on user action.

* **Bug Fixes**
  - Restored and fixed the previously non-functional “Reboot to bootloader” action on Pico targets for reliable transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->