### PR TITLE
Fix mag custom alignment configuration

### DIFF
--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -105,7 +105,6 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 #define MAG_ALIGN ALIGN_DEFAULT
 #endif
     compassConfig->mag_alignment = MAG_ALIGN;
-#if MAG_ALIGN == ALIGN_CUSTOM
 #ifndef MAG_ALIGN_ROLL
 #define MAG_ALIGN_ROLL 0
 #endif
@@ -118,9 +117,6 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
     compassConfig->mag_customAlignment.roll = MAG_ALIGN_ROLL;
     compassConfig->mag_customAlignment.pitch = MAG_ALIGN_PITCH;
     compassConfig->mag_customAlignment.yaw = MAG_ALIGN_YAW;
-#else
-    memset(&compassConfig->mag_customAlignment, 0x00, sizeof(compassConfig->mag_customAlignment));
-#endif // MAG_ALIGN == ALIGN_CUSTOM
     compassConfig->mag_hardware = MAG_DEFAULT;
 
 #ifndef MAG_I2C_ADDRESS

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -101,8 +101,26 @@ static uint32_t compassReadIntervalUs = TASK_PERIOD_HZ(TASK_COMPASS_RATE_HZ);
 
 void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 {
-    compassConfig->mag_alignment = ALIGN_DEFAULT;
+#ifndef MAG_ALIGN
+#define MAG_ALIGN ALIGN_DEFAULT
+#endif
+    compassConfig->mag_alignment = MAG_ALIGN;
+#if MAG_ALIGN == ALIGN_CUSTOM
+#ifndef MAG_ALIGN_ROLL
+#define MAG_ALIGN_ROLL 0
+#endif
+#ifndef MAG_ALIGN_PITCH
+#define MAG_ALIGN_PITCH 0
+#endif
+#ifndef MAG_ALIGN_YAW
+#define MAG_ALIGN_YAW 0
+#endif
+    compassConfig->mag_customAlignment.roll = MAG_ALIGN_ROLL;
+    compassConfig->mag_customAlignment.pitch = MAG_ALIGN_PITCH;
+    compassConfig->mag_customAlignment.yaw = MAG_ALIGN_YAW;
+#else
     memset(&compassConfig->mag_customAlignment, 0x00, sizeof(compassConfig->mag_customAlignment));
+#endif // MAG_ALIGN == ALIGN_CUSTOM
     compassConfig->mag_hardware = MAG_DEFAULT;
 
 #ifndef MAG_I2C_ADDRESS

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -155,7 +155,6 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 #endif
     compassConfig->interruptTag = IO_TAG(MAG_INT_EXTI);
 
-    memset(&compassConfig->magZero, 0x00, sizeof(compassConfig->magZero));
 
     compassConfig->mag_customAlignment.roll = MAG_ALIGN_ROLL;
     compassConfig->mag_customAlignment.pitch = MAG_ALIGN_PITCH;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -99,12 +99,9 @@ PG_REGISTER_WITH_RESET_FN(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 4);
 // default compass read interval, for those with no specified ODR, will be TASK_COMPASS_RATE_HZ
 static uint32_t compassReadIntervalUs = TASK_PERIOD_HZ(TASK_COMPASS_RATE_HZ);
 
-void pgResetFn_compassConfig(compassConfig_t *compassConfig)
-{
 #ifndef MAG_ALIGN
 #define MAG_ALIGN ALIGN_DEFAULT
 #endif
-    compassConfig->mag_alignment = MAG_ALIGN;
 #ifndef MAG_ALIGN_ROLL
 #define MAG_ALIGN_ROLL 0
 #endif
@@ -114,14 +111,15 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 #ifndef MAG_ALIGN_YAW
 #define MAG_ALIGN_YAW 0
 #endif
-    compassConfig->mag_customAlignment.roll = MAG_ALIGN_ROLL;
-    compassConfig->mag_customAlignment.pitch = MAG_ALIGN_PITCH;
-    compassConfig->mag_customAlignment.yaw = MAG_ALIGN_YAW;
-    compassConfig->mag_hardware = MAG_DEFAULT;
 
 #ifndef MAG_I2C_ADDRESS
 #define MAG_I2C_ADDRESS 0
 #endif
+
+void pgResetFn_compassConfig(compassConfig_t *compassConfig)
+{
+    compassConfig->mag_alignment = MAG_ALIGN;
+    compassConfig->mag_hardware = MAG_DEFAULT;
 
 // Generate a reasonable default for backward compatibility
 // Strategy is
@@ -156,6 +154,12 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
     compassConfig->mag_spi_csn = IO_TAG_NONE;
 #endif
     compassConfig->interruptTag = IO_TAG(MAG_INT_EXTI);
+
+    memset(&compassConfig->magZero, 0x00, sizeof(compassConfig->magZero));
+
+    compassConfig->mag_customAlignment.roll = MAG_ALIGN_ROLL;
+    compassConfig->mag_customAlignment.pitch = MAG_ALIGN_PITCH;
+    compassConfig->mag_customAlignment.yaw = MAG_ALIGN_YAW;
 }
 
 static int16_t magADCRaw[XYZ_AXIS_COUNT];
@@ -172,11 +176,7 @@ void compassPreInit(void)
 #if !defined(SIMULATOR_BUILD)
 static bool compassDetect(magDev_t *magDev, uint8_t *alignment)
 {
-#ifdef MAG_ALIGN
     *alignment = MAG_ALIGN;
-#else
-    *alignment = ALIGN_DEFAULT;
-#endif
 
     magSensor_e magHardware = MAG_NONE;
 


### PR DESCRIPTION
- adds missing configuration for MAG_ALIGN
- example usage:

```
#define MAG_ALIGN ALIGN_CUSTOM
#define MAG_ALIGN_ROLL 900
#define MAG_ALIGN_YAW 2700
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Magnetometer alignment is now fully configurable at build time, with per-axis roll/pitch/yaw offsets and a selectable default orientation.
  * Build-time defaults also select magnetometer bus and interrupt wiring where applicable.

* **Bug Fixes / Calibration**
  * Magnetometer bias continues to be stored and applied during sensor updates for consistent readings.

* **Compatibility**
  * Alignment is no longer chosen at runtime—behavior is determined by build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->