### PR TITLE
Fix possible  integer underflow in ExpressLRS frequency hopping

### DIFF
--- a/src/main/rx/expresslrs_common.c
+++ b/src/main/rx/expresslrs_common.c
@@ -181,7 +181,7 @@ static uint8_t rngN(const uint8_t max)
 Requirements:
 1. 0 every n hops
 2. No two repeated channels
-3. Equal occurance of each (or as even as possible) of each channel
+3. Equal occurrence of each (or as even as possible) of each channel
 4. Pseudorandom
 
 Approach:


### PR DESCRIPTION
Prevent potential underflow in `fhssGenSequence()` when `freqCount` is `0` by adding bounds checking with `MAX(fhssConfig->freqCount - 1, 0)`.

Without this fix, if `freqCount` is `0`, the expression `(freqCount - 1)` underflows to `255`, causing `rngN(255)` to generate out-of-bounds random values that could lead to array access violations and incorrect frequency hopping behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Improved robustness of frequency-hopping sequence generation to avoid rare errors with very small channel lists, reducing potential lockups or unexpected behavior during startup or reconfiguration.
- Documentation
  - Corrected a spelling mistake in comments related to FHSS requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->