### PR TITLE
fix-undefined-customAlignment1-variable

### DIFF
--- a/src/main/pg/gyrodev.c
+++ b/src/main/pg/gyrodev.c
@@ -301,6 +301,6 @@ void pgResetFn_gyroDeviceConfig(gyroDeviceConfig_t *devconf)
     // I2C gyros appear as a sole gyro in single gyro boards.
 #if defined(USE_I2C_GYRO) && !(GYRO_COUNT > 1)
     devconf[0].i2cBus = I2C_DEV_TO_CFG(I2CINVALID); // XXX Not required?
-    gyroResetI2cDeviceConfig(&devconf[0], I2C_DEVICE, IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, customAlignment1);
+    gyroResetI2cDeviceConfig(&devconf[0], I2C_DEVICE, IO_TAG(GYRO_1_EXTI_PIN), GYRO_1_ALIGN, GYRO_1_CUSTOM_ALIGN);
 #endif
 }


### PR DESCRIPTION
Replace undefined variable customAlignment1 with GYRO_1_CUSTOM_ALIGN in pgResetFn_gyroDeviceConfig function.

The variable customAlignment1 was referenced but never declared, causing compilation failure for targets using I2C gyroscopes. GYRO_1_CUSTOM_ALIGN is the correct macro defined earlier in the file.

Fixes compilation error:
'customAlignment1' undeclared (first use in this function)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal naming for gyro alignment in the single-gyro I2C configuration to match established conventions and reduce ambiguity.
  * No functional changes: behavior, performance, device compatibility, and user settings remain unaffected.
  * Improves code maintainability and clarity for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->