### PR TITLE
POSIX compatible awk rules in order to build under OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,10 @@ FATFS_DIR        = $(ROOT)/lib/main/FatFS
 FATFS_SRC        = $(notdir $(wildcard $(FATFS_DIR)/*.c))
 CSOURCES        := $(shell find $(SRC_DIR) -name '*.c')
 
-FC_VER_YEAR   := $(shell awk '/^[[:space:]]*#define[[:space:]]+FC_VERSION_YEAR[[:space:]]+/  {print $$3}' src/main/build/version.h)
-FC_VER_MONTH  := $(shell awk '/^[[:space:]]*#define[[:space:]]+FC_VERSION_MONTH[[:space:]]+/ {print $$3}' src/main/build/version.h)
-FC_VER_PATCH  := $(shell awk '/^[[:space:]]*#define[[:space:]]+FC_VERSION_PATCH_LEVEL[[:space:]]+/ {print $$3}' src/main/build/version.h)
-FC_VER_SUFFIX := $(shell awk '/^[[:space:]]*#define[[:space:]]+FC_VERSION_SUFFIX[[:space:]]+/ {gsub(/"/,""); print $$3}' src/main/build/version.h)
+FC_VER_YEAR   := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_YEAR[[:space:]]+/  {print $$3}' src/main/build/version.h)
+FC_VER_MONTH  := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_MONTH[[:space:]]+/ {print $$3}' src/main/build/version.h)
+FC_VER_PATCH  := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_PATCH_LEVEL[[:space:]]+/ {print $$3}' src/main/build/version.h)
+FC_VER_SUFFIX := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_SUFFIX[[:space:]]+/ {gsub(/"/,""); print $$3}' src/main/build/version.h)
 
 FC_VER       := $(FC_VER_YEAR).$(FC_VER_MONTH).$(FC_VER_PATCH)
 


### PR DESCRIPTION
This fixes awk under OSX build environment
@blckmn 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version string now supports an optional suffix (e.g., -beta), displayed as YEAR.MONTH.PATCH-<suffix> when defined.

* **Chores**
  * Improved build-time version detection to more reliably recognize version components and avoid accidental matches; minor formatting tweaks to build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->