### PR TITLE
GYRO: Remove ability for user to set the gyro alignment at run time.

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1856,13 +1856,7 @@ const clivalue_t valueTable[] = {
     /* i2cBus   */                                                                 \
     { "gyro_" STR(N) "_i2cBus",        VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cBus) },\
     /* i2c addr */                                                                 \
-    { "gyro_" STR(N) "_i2c_address",   VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cAddress) },\
-    /* align lookup */                                                             \
-    { "gyro_" STR(N) "_sensor_align", VAR_UINT8 | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, alignment) },\
-    /* custom roll/pitch/yaw */                                                    \
-    { "gyro_" STR(N) "_align_roll",   VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.roll) },\
-    { "gyro_" STR(N) "_align_pitch",  VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.pitch) },\
-    { "gyro_" STR(N) "_align_yaw",    VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.yaw) }\
+    { "gyro_" STR(N) "_i2c_address",   VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cAddress) }\
 
     GYRO_DEVICE_RECORDS(1, 0),
 #if GYRO_COUNT > 1

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1856,7 +1856,11 @@ const clivalue_t valueTable[] = {
     /* i2cBus   */                                                                 \
     { "gyro_" STR(N) "_i2cBus",        VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cBus) },\
     /* i2c addr */                                                                 \
-    { "gyro_" STR(N) "_i2c_address",   VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cAddress) }\
+    { "gyro_" STR(N) "_i2c_address",   VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cAddress) },\
+    /* custom roll/pitch/yaw */                                                    \
+    { "gyro_" STR(N) "_align_roll",   VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.roll) },\
+    { "gyro_" STR(N) "_align_pitch",  VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.pitch) },\
+    { "gyro_" STR(N) "_align_yaw",    VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.yaw) }\
 
     GYRO_DEVICE_RECORDS(1, 0),
 #if GYRO_COUNT > 1

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1825,16 +1825,6 @@ case MSP_NAME:
         // API 1.41 - Add multi-gyro indicator, selected gyro, and support for separate gyro 1 & 2 alignment
         sbufWriteU8(dst, getGyroDetectedFlags());
         sbufWriteU8(dst, gyroConfig()->gyro_enabled_bitmask); // deprecates gyro_to_use
-        // Added support for more then two IMUs in MSP API 1.47
-        for (int i = 0; i < 8; i++) {
-            sbufWriteU8(dst, i < GYRO_COUNT ? gyroDeviceConfig(i)->alignment : ALIGN_DEFAULT);
-        }
-
-        for (int i = 0; i < 8; i++) {
-            for (unsigned j = 0; j < ARRAYLEN(gyroDeviceConfig(i)->customAlignment.raw); j++) {
-                sbufWriteU16(dst, i < GYRO_COUNT ? gyroDeviceConfig(i)->customAlignment.raw[j] : 0);
-            }
-        }
 
 #ifdef USE_MAG
         sbufWriteU16(dst, compassConfig()->mag_customAlignment.roll);
@@ -2995,23 +2985,6 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
 
         gyroConfigMutable()->gyro_enabled_bitmask = sbufReadU8(src);
-        // Added in API 1.47
-        if (sbufBytesRemaining(src) >= 8 * 7) {
-            /*
-                Skip alignments as these are no longer serviceable by the user.
-
-                The alignment is set by the manufacturer in config.h
-            */
-            for (int i = 0; i < 8; i++) {
-                sbufReadU8(src); // alignment
-            }
-
-            for (int i = 0; i < 8; i++) {
-                sbufReadU16(src); // roll
-                sbufReadU16(src); // pitch
-                sbufReadU16(src); // yaw
-            }
-        }
 
         if (sbufBytesRemaining(src) >= 6) {
 #ifdef USE_MAG

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2998,26 +2998,13 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         // Added in API 1.47
         if (sbufBytesRemaining(src) >= 8 * 7) {
             for (int i = 0; i < 8; i++) {
-                const uint8_t alignment = sbufReadU8(src);
-                if (i < GYRO_COUNT) {
-                    gyroDeviceConfigMutable(i)->alignment = alignment;
-                }
+                sbufReadU8(src); // skip unused alignment (alignment set in config.h and not user serviceable)
             }
 
             for (int i = 0; i < 8; i++) {
-                if (i < GYRO_COUNT) {
-                     sensorAlignment_t customAlignment;
-                     for (unsigned j = 0; j < ARRAYLEN(customAlignment.raw); j++) {
-                        customAlignment.raw[j] = (int16_t)sbufReadU16(src);
-                     }
-                     if (i < GYRO_COUNT) {
-                        gyroDeviceConfigMutable(i)->customAlignment = customAlignment;
-                     }
-                } else {
-                    sbufReadU16(src); // skip unused custom alignment roll
-                    sbufReadU16(src); // skip unused custom alignment pitch
-                    sbufReadU16(src); // skip unused custom alignment yaw
-                }
+                sbufReadU16(src); // skip unused custom alignment roll
+                sbufReadU16(src); // skip unused custom alignment pitch
+                sbufReadU16(src); // skip unused custom alignment yaw
             }
         }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2997,14 +2997,19 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         gyroConfigMutable()->gyro_enabled_bitmask = sbufReadU8(src);
         // Added in API 1.47
         if (sbufBytesRemaining(src) >= 8 * 7) {
+            /*
+                Skip alignments as these are no longer serviceable by the user.
+
+                The alignment is set by the manufacturer in config.h
+            */
             for (int i = 0; i < 8; i++) {
-                sbufReadU8(src); // skip unused alignment (alignment set in config.h and not user serviceable)
+                sbufReadU8(src); // alignment
             }
 
             for (int i = 0; i < 8; i++) {
-                sbufReadU16(src); // skip unused custom alignment roll
-                sbufReadU16(src); // skip unused custom alignment pitch
-                sbufReadU16(src); // skip unused custom alignment yaw
+                sbufReadU16(src); // roll
+                sbufReadU16(src); // pitch
+                sbufReadU16(src); // yaw
             }
         }
 


### PR DESCRIPTION
The position of the gyro on the board is NOT user serviceable. The gyro alignment is related to the circuit design and is the default forward direction of the gyro device relative to the board manufacturers direction indicator (on the board). This cannot be changed by the user.

To prevent undesirable states, this removes the ability for the user to modify the manufacturer settings placed in the respective config.h outside of a custom define (to which we may need to add support for, either in config.h or a new define).

Users can still set the board alignment - which is the mounting orientation of the board manufacturers "direction indicator" (as per silkscreen) relative to the forward direction of the vehicle to which it is installed.

NOTE: The only real reason this was configurable by the user in the past was for "unified targets".

TODO: in future PR, possibly remove the alignment from PG config and put it in its own array. Not a lot of difference, except a small issue is SENSOR_ALIGNMENT_FROM_STD is not currently "const" - so requires programmatic initialisation of the array.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed per-gyro alignment controls from user-visible settings and CLI to simplify configuration.
  * Gyro alignment data provided via external interfaces is no longer stored or transmitted; such inputs are ignored.
  * Magnetic sensor alignment handling remains unchanged and continues to be supported.
  * Bus and address configuration options remain available; no other public interfaces or user-facing behaviors were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->