### PR TITLE
Prioritise SPI RX DMA over TX to prevent overrun

### DIFF
--- a/src/platform/APM32/bus_spi_apm32.c
+++ b/src/platform/APM32/bus_spi_apm32.c
@@ -122,7 +122,7 @@ void spiInternalResetDescriptors(busDevice_t *bus)
         dmaInitRx->Mode = DDL_DMA_MODE_NORMAL;
         dmaInitRx->Direction = DDL_DMA_DIRECTION_PERIPH_TO_MEMORY;
         dmaInitRx->PeriphOrM2MSrcAddress = (uint32_t)&bus->busType_u.spi.instance->DATA;
-        dmaInitRx->Priority = DDL_DMA_PRIORITY_LOW;
+        dmaInitRx->Priority = DDL_DMA_PRIORITY_MEDIUM;
         dmaInitRx->PeriphOrM2MSrcIncMode  = DDL_DMA_PERIPH_NOINCREMENT;
         dmaInitRx->PeriphOrM2MSrcDataSize = DDL_DMA_PDATAALIGN_BYTE;
     }

--- a/src/platform/AT32/bus_spi_at32bsp.c
+++ b/src/platform/AT32/bus_spi_at32bsp.c
@@ -121,7 +121,7 @@ void spiInternalResetDescriptors(busDevice_t *bus)
         dmaInitRx->direction = DMA_DIR_PERIPHERAL_TO_MEMORY;
         dmaInitRx->loop_mode_enable = FALSE;
         dmaInitRx->peripheral_base_addr = (uint32_t)&bus->busType_u.spi.instance->dt;
-        dmaInitRx->priority = DMA_PRIORITY_LOW;
+        dmaInitRx->priority = DMA_PRIORITY_MEDIUM;
         dmaInitRx->peripheral_inc_enable = FALSE;
         dmaInitRx->peripheral_data_width = DMA_PERIPHERAL_DATA_WIDTH_BYTE;
 

--- a/src/platform/STM32/bus_spi_ll.c
+++ b/src/platform/STM32/bus_spi_ll.c
@@ -185,7 +185,7 @@ void spiInternalResetDescriptors(busDevice_t *bus)
 #else
         dmaInitRx->PeriphOrM2MSrcAddress = (uint32_t)&bus->busType_u.spi.instance->DR;
 #endif
-        dmaInitRx->Priority = LL_DMA_PRIORITY_LOW;
+        dmaInitRx->Priority = LL_DMA_PRIORITY_MEDIUM;
         dmaInitRx->PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
         dmaInitRx->PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     }

--- a/src/platform/STM32/bus_spi_stdperiph.c
+++ b/src/platform/STM32/bus_spi_stdperiph.c
@@ -126,7 +126,7 @@ void spiInternalResetDescriptors(busDevice_t *bus)
         dmaInitRx->DMA_DIR = DMA_DIR_PeripheralToMemory;
         dmaInitRx->DMA_Mode = DMA_Mode_Normal;
         dmaInitRx->DMA_PeripheralBaseAddr = (uint32_t)&bus->busType_u.spi.instance->DR;
-        dmaInitRx->DMA_Priority = DMA_Priority_Low;
+        dmaInitRx->DMA_Priority = DMA_Priority_Medium;
         dmaInitRx->DMA_PeripheralInc = DMA_PeripheralInc_Disable;
         dmaInitRx->DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     }


### PR DESCRIPTION
Fixes the issue highlighted in https://github.com/betaflight/betaflight/pull/14574 where writes to blackbox FLASH would stall after only a small number of bytes had been written on STM32G47X based FCs.

Investigation found that the issue was caused by SPI DMA writes to blackbox FLASH memory ending up in a state where the receive channel had not decremented to 0, and thus no TC (transfer complete) interrupt was generated.

Prior to a write of 64 bytes (the normal length),  the DMA channels for tx and rx respectively are thus:

<img width="426" height="171" alt="image" src="https://github.com/user-attachments/assets/02d8dae9-5eed-422b-97e5-be7cafdfa693" />

After a successful transfer all the data has been transmitted and a corresponding number of bytes received.

<img width="419" height="173" alt="image" src="https://github.com/user-attachments/assets/b6aec1d1-fabe-49d5-9e4c-14c8ba239f13" />

However ocassionally is was noted that the rx CNDTR register was stuck at one indicating that there was an outstanding byte still to be received.

<img width="400" height="177" alt="image" src="https://github.com/user-attachments/assets/d20168cf-e50c-4891-8c8f-6efcc02d632e" />

It was also noted that the SPI's SR register had the OVR bit set indicating that a byte had been received from the device before the DMA controller had read the last byte from the DR register.

The DMA channels were set to low priority for both tx and rx. The fix for this issue is to raise the priority of the rx channel so reception is always prioritised over transmission. Whilst this issue has only been observed on the STM32G47X processors, there have been occasional reports of logs being incomplete on other processors, so I have made an equivalent change on all processors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved SPI communication reliability across APM32, AT32, and STM32 platforms by increasing the priority of receive operations, reducing the risk of missed data under heavy system load.
  - Enhances stability during concurrent transfers and lowers the likelihood of sporadic communication glitches, leading to smoother device interaction and more consistent data capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->