### PR TITLE
sensors: esc: fix temperature encoding, int8 to uint8

### DIFF
--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -32,7 +32,7 @@ PG_DECLARE(escSensorConfig_t, escSensorConfig);
 
 typedef struct {
     uint8_t dataAge;
-    int8_t temperature;  // C degrees
+    uint8_t temperature;  // C degrees
     uint16_t voltage;     // 0.01V
     int32_t current;     // 0.01A
     int32_t consumption; // mAh


### PR DESCRIPTION
This looks like a bug. I haven't tested to verify.