### PR TITLE
Add a NOP to give processor time to handle interrupts

### DIFF
--- a/src/main/drivers/rx/rx_sx1280.c
+++ b/src/main/drivers/rx/rx_sx1280.c
@@ -83,7 +83,8 @@ FAST_CODE_PREF static bool sx1280PollBusy(void)
         if ((micros() - startTime) > SX1280_BUSY_TIMEOUT_US) {
             return false;
         } else {
-            __asm__("nop");
+            // Ensure a service window exists for interrupts
+            __NOP();
         }
     }
     return true;

--- a/src/main/drivers/usb_msc_common.c
+++ b/src/main/drivers/usb_msc_common.c
@@ -96,10 +96,12 @@ void mscActivityLed(void)
     static timeMs_t nextToggleMs = 0;
     const timeMs_t nowMs = millis();
 
+    // Turn off LED if no activity in last ACTIVITY_LED_PERIOD_MS
     if (cmpTimeMs(nowMs, lastActiveTimeMs) > ACTIVITY_LED_PERIOD_MS) {
         LED0_OFF;
         nextToggleMs = 0;
     } else if (cmpTimeMs(nowMs, nextToggleMs) > 0) {
+        // Otherwise toggle the LED every ACTIVITY_LED_PERIOD_MS
         LED0_TOGGLE;
         nextToggleMs = nowMs + ACTIVITY_LED_PERIOD_MS;
     }
@@ -127,6 +129,8 @@ void mscWaitForButton(void)
     delay(DEBOUNCE_TIME_MS);
     while (true) {
         mscTask();
+        // Ensure a service window exists for interrupts
+        asm("NOP");
         if (mscCheckButton()) {
             systemResetFromMsc();
         }

--- a/src/main/drivers/usb_msc_common.c
+++ b/src/main/drivers/usb_msc_common.c
@@ -130,7 +130,7 @@ void mscWaitForButton(void)
     while (true) {
         mscTask();
         // Ensure a service window exists for interrupts
-        asm("NOP");
+        __NOP();
         if (mscCheckButton()) {
             systemResetFromMsc();
         }


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/14619

This issue was caused by the very tight loop in `mscWaitForButton()` making lot's of branch and link calls to subroutines, each of which resulted in a pipeline flush, and branch prediction reset which can result in execution stalls. This meant that the processor was too busy to service USB interrupts in a timely manner. Adding a NOP ensured that interrupts had a chance to be called at least once per loop.

Also added some comments to the `mscActivityLed()` routine for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device responsiveness during button-wait and radio busy-wait scenarios, helping the product remain more reactive under load.

* **Documentation**
  * Clarified activity LED timing behavior in USB mass storage mode with explanatory comments for easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->