### PR TITLE
PICO work around memcpy alignment issue with -fno-builtin-memcpy

### DIFF
--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -238,7 +238,7 @@ SYS_INCLUDE_DIRS += \
             $(SDK_DIR)/rp2350/boot_stage2/include
 
 #Flags
-ARCH_FLAGS      = -mthumb -mcpu=cortex-m33 -march=armv8-m.main+fp+dsp -mcmse -mfloat-abi=softfp
+ARCH_FLAGS      = -fno-builtin-memcpy -mthumb -mcpu=cortex-m33 -march=armv8-m.main+fp+dsp -mcmse -mfloat-abi=softfp
 ARCH_FLAGS      += -DPICO_COPY_TO_RAM=$(RUN_FROM_RAM)
 
 # Automatically treating constants as single-precision breaks pico-sdk (-Werror=double-promotion)


### PR DESCRIPTION
PICO work around memcpy alignment issue with -fno-builtin-memcpy

Work around an issue that turned up recently, where gcc / linker generates bogus code that doesn't work with uint8_t * data that is not 32-bit aligned.