### PR TITLE
Update Makefile to fix local build make error on MacOSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,10 @@ FATFS_DIR        = $(ROOT)/lib/main/FatFS
 FATFS_SRC        = $(notdir $(wildcard $(FATFS_DIR)/*.c))
 CSOURCES        := $(shell find $(SRC_DIR) -name '*.c')
 
-FC_VER_YEAR   := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_YEAR[[:space:]]+/  {print $$3}' src/main/build/version.h)
-FC_VER_MONTH  := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_MONTH[[:space:]]+/ {print $$3}' src/main/build/version.h)
-FC_VER_PATCH  := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_PATCH_LEVEL[[:space:]]+/ {print $$3}' src/main/build/version.h)
-FC_VER_SUFFIX := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_SUFFIX[[:space:]]+/ {gsub(/"/,""); print $$3}' src/main/build/version.h)
+FC_VER_YEAR   := $(shell awk '/^[[:space:]]*\#define[[:space:]]+FC_VERSION_YEAR[[:space:]]+/  {print $$3}' src/main/build/version.h)
+FC_VER_MONTH  := $(shell awk '/^[[:space:]]*\#define[[:space:]]+FC_VERSION_MONTH[[:space:]]+/ {print $$3}' src/main/build/version.h)
+FC_VER_PATCH  := $(shell awk '/^[[:space:]]*\#define[[:space:]]+FC_VERSION_PATCH_LEVEL[[:space:]]+/ {print $$3}' src/main/build/version.h)
+FC_VER_SUFFIX := $(shell awk '/^[[:space:]]*\#define[[:space:]]+FC_VERSION_SUFFIX[[:space:]]+/ {gsub(/"/,""); print $$3}' src/main/build/version.h)
 
 FC_VER       := $(FC_VER_YEAR).$(FC_VER_MONTH).$(FC_VER_PATCH)
 


### PR DESCRIPTION
Fixes an issue where trying a local build in recent MacOS X computers failed to compile with the following error:

`Makefile:124: *** unterminated call to function `shell': missing `)'.  Stop.
`


CHATGPT SUGGESTED THIS explanation for the proposed chsnges to`makefile`:
Escaped # in the four awk regexes that extract FC_VER_YEAR, FC_VER_MONTH, FC_VER_PATCH, and FC_VER_SUFFIX from src/main/build/version.h.

Hope this is useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version parsing to read explicit macros from the source header.
  * Version string now conditionally includes a suffix (e.g., -beta) when defined, producing year.month.patch[-suffix].
  * Ensures consistent versioning across built artifacts and displayed version info.
  * No changes to user-facing features or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->