### PR TITLE
PICO: maths performance - use pico_float and pico_double from SDK

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -601,7 +601,7 @@ FAST_CODE void scheduler(void)
                 // 10ths % of tasks late in last second
                 DEBUG_SET(DEBUG_TIMING_ACCURACY, 4, lateTaskPercentage);
 
-                float gyroCyclesStdDev = sqrt(devSquared/gyroCyclesCount);
+                float gyroCyclesStdDev = sqrtf(devSquared/gyroCyclesCount);
                 int32_t gyroCyclesStdDev100thus = clockCyclesTo100thMicros((int32_t)gyroCyclesStdDev);
                 DEBUG_SET(DEBUG_TIMING_ACCURACY, 7, gyroCyclesStdDev100thus);
                 DEBUG_SET(DEBUG_SCHEDULER_DETERMINISM, 7, gyroCyclesStdDev100thus);

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -83,7 +83,6 @@ PICO_LIB_SRC = \
             rp2_common/pico_divider/divider_compiler.c \
             rp2_common/pico_double/double_math.c \
             rp2_common/pico_flash/flash.c \
-            rp2_common/pico_float/float_math.c \
             rp2_common/hardware_divider/divider.c \
             rp2_common/hardware_vreg/vreg.c \
             rp2_common/hardware_xip_cache/xip_cache.c \
@@ -116,6 +115,126 @@ TINYUSB_SRC += \
             $(TINY_USB_SRC_DIR)/class/usbtmc/usbtmc_device.c \
             $(TINY_USB_SRC_DIR)/class/audio/audio_device.c
 
+# pico_float
+PICO_FLOAT_SRC  = \
+            rp2_common/pico_float/float_common_m33.S \
+            rp2_common/pico_float/float_conv32_vfp.S \
+            rp2_common/pico_float/float_math.c \
+            rp2_common/pico_float/float_sci_m33_vfp.S
+
+PICO_FLOAT_LD_FLAGS = \
+            -Wl,--wrap=__aeabi_f2lz \
+            -Wl,--wrap=__aeabi_f2ulz \
+            -Wl,--wrap=__aeabi_l2f \
+            -Wl,--wrap=__aeabi_ul2f \
+            -Wl,--wrap=acosf \
+            -Wl,--wrap=acoshf \
+            -Wl,--wrap=asinf \
+            -Wl,--wrap=asinhf \
+            -Wl,--wrap=atan2f \
+            -Wl,--wrap=atanf \
+            -Wl,--wrap=atanhf \
+            -Wl,--wrap=cbrtf \
+            -Wl,--wrap=ceilf \
+            -Wl,--wrap=copysignf \
+            -Wl,--wrap=cosf \
+            -Wl,--wrap=coshf \
+            -Wl,--wrap=dremf \
+            -Wl,--wrap=exp10f \
+            -Wl,--wrap=exp2f \
+            -Wl,--wrap=expf \
+            -Wl,--wrap=expm1f \
+            -Wl,--wrap=floorf \
+            -Wl,--wrap=fmaf \
+            -Wl,--wrap=fmodf \
+            -Wl,--wrap=hypotf \
+            -Wl,--wrap=ldexpf \
+            -Wl,--wrap=log10f \
+            -Wl,--wrap=log1pf \
+            -Wl,--wrap=log2f \
+            -Wl,--wrap=logf \
+            -Wl,--wrap=powf \
+            -Wl,--wrap=powintf \
+            -Wl,--wrap=remainderf \
+            -Wl,--wrap=remquof \
+            -Wl,--wrap=roundf \
+            -Wl,--wrap=sincosf \
+            -Wl,--wrap=sinf \
+            -Wl,--wrap=sinhf \
+            -Wl,--wrap=tanf \
+            -Wl,--wrap=tanhf \
+            -Wl,--wrap=truncf
+
+#pico_double
+PICO_DOUBLE_SRC = \
+            rp2_common/pico_double/double_aeabi_dcp.S \
+            rp2_common/pico_double/double_conv_m33.S \
+            rp2_common/pico_double/double_fma_dcp.S \
+            rp2_common/pico_double/double_math.c \
+            rp2_common/pico_double/double_sci_m33.S
+
+PICO_DOUBLE_LD_FLAGS = \
+            -Wl,--wrap=__aeabi_cdcmpeq \
+            -Wl,--wrap=__aeabi_cdcmple \
+            -Wl,--wrap=__aeabi_cdrcmple \
+            -Wl,--wrap=__aeabi_d2f \
+            -Wl,--wrap=__aeabi_d2iz \
+            -Wl,--wrap=__aeabi_d2lz \
+            -Wl,--wrap=__aeabi_d2uiz \
+            -Wl,--wrap=__aeabi_d2ulz \
+            -Wl,--wrap=__aeabi_dadd \
+            -Wl,--wrap=__aeabi_dcmpeq \
+            -Wl,--wrap=__aeabi_dcmpge \
+            -Wl,--wrap=__aeabi_dcmpgt \
+            -Wl,--wrap=__aeabi_dcmple \
+            -Wl,--wrap=__aeabi_dcmplt \
+            -Wl,--wrap=__aeabi_dcmpun \
+            -Wl,--wrap=__aeabi_ddiv \
+            -Wl,--wrap=__aeabi_dmul \
+            -Wl,--wrap=__aeabi_drsub \
+            -Wl,--wrap=__aeabi_dsub \
+            -Wl,--wrap=__aeabi_i2d \
+            -Wl,--wrap=__aeabi_l2d \
+            -Wl,--wrap=__aeabi_ui2d \
+            -Wl,--wrap=__aeabi_ul2d \
+            -Wl,--wrap=acos \
+            -Wl,--wrap=acosh \
+            -Wl,--wrap=asin \
+            -Wl,--wrap=asinh \
+            -Wl,--wrap=atan \
+            -Wl,--wrap=atan2 \
+            -Wl,--wrap=atanh \
+            -Wl,--wrap=cbrt \
+            -Wl,--wrap=ceil \
+            -Wl,--wrap=copysign \
+            -Wl,--wrap=cos \
+            -Wl,--wrap=cosh \
+            -Wl,--wrap=drem \
+            -Wl,--wrap=exp \
+            -Wl,--wrap=exp10 \
+            -Wl,--wrap=exp2 \
+            -Wl,--wrap=expm1 \
+            -Wl,--wrap=floor \
+            -Wl,--wrap=fma \
+            -Wl,--wrap=fmod \
+            -Wl,--wrap=hypot \
+            -Wl,--wrap=ldexp \
+            -Wl,--wrap=log \
+            -Wl,--wrap=log10 \
+            -Wl,--wrap=log1p \
+            -Wl,--wrap=log2 \
+            -Wl,--wrap=pow \
+            -Wl,--wrap=powint \
+            -Wl,--wrap=remainder \
+            -Wl,--wrap=remquo \
+            -Wl,--wrap=round \
+            -Wl,--wrap=sin \
+            -Wl,--wrap=sincos \
+            -Wl,--wrap=sinh \
+            -Wl,--wrap=sqrt \
+            -Wl,--wrap=tan \
+            -Wl,--wrap=tanh \
+            -Wl,--wrap=trunc
 
 VPATH := $(VPATH):$(STDPERIPH_DIR)
 
@@ -216,6 +335,7 @@ SYS_INCLUDE_DIRS = \
             $(SDK_DIR)/rp2_common/hardware_pwm/include \
             $(SDK_DIR)/rp2_common/pico_stdio_semihosting/include \
             $(SDK_DIR)/rp2_common/pico_float/include \
+            $(SDK_DIR)/rp2_common/pico_double/include \
             $(SDK_DIR)/rp2_common/hardware_resets/include \
             $(SDK_DIR)/rp2_common/pico_cxx_options/include \
             $(SDK_DIR)/rp2_common/pico_stdlib/include \
@@ -271,7 +391,7 @@ PICO_STDIO_LD_FLAGS  = \
             -Wl,--wrap=putchar \
             -Wl,--wrap=getchar
 
-EXTRA_LD_FLAGS += $(PICO_STDIO_LD_FLAGS) $(PICO_TRACE_LD_FLAGS)
+EXTRA_LD_FLAGS += $(PICO_STDIO_LD_FLAGS) $(PICO_TRACE_LD_FLAGS) $(PICO_FLOAT_LD_FLAGS) $(PICO_DOUBLE_LD_FLAGS)
 
 ifdef RP2350_TARGET
 
@@ -434,7 +554,9 @@ DEVICE_STDPERIPH_SRC := \
             $(PICO_LIB_SRC) \
             $(STDPERIPH_SRC) \
             $(TINYUSB_SRC) \
-            $(PICO_TRACE_SRC)
+            $(PICO_TRACE_SRC) \
+            $(PICO_FLOAT_SRC) \
+            $(PICO_DOUBLE_SRC)
 
 # Add a target-specific definition for PICO_LIB_TARGETS in order
 # to remove -flto=auto for pico-sdk file compilation

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -64,7 +64,6 @@ PICO_LIB_SRC = \
             common/hardware_claim/claim.c \
             common/pico_sync/critical_section.c \
             rp2_common/hardware_sync/sync.c \
-            rp2_common/pico_bootrom/bootrom.c \
             rp2_common/pico_runtime_init/runtime_init.c \
             rp2_common/pico_runtime_init/runtime_init_clocks.c \
             rp2_common/pico_runtime_init/runtime_init_stack_guard.c \
@@ -81,7 +80,6 @@ PICO_LIB_SRC = \
             rp2_common/pico_bootrom/bootrom.c \
             rp2_common/pico_bootrom/bootrom_lock.c \
             rp2_common/pico_divider/divider_compiler.c \
-            rp2_common/pico_double/double_math.c \
             rp2_common/pico_flash/flash.c \
             rp2_common/hardware_divider/divider.c \
             rp2_common/hardware_vreg/vreg.c \
@@ -89,7 +87,8 @@ PICO_LIB_SRC = \
             rp2_common/pico_standard_binary_info/standard_binary_info.c \
             rp2_common/pico_clib_interface/newlib_interface.c \
             rp2_common/pico_malloc/malloc.c \
-            rp2_common/pico_stdlib/stdlib.c
+            rp2_common/pico_stdlib/stdlib.c \
+            rp2_common/pico_bit_ops/bit_ops_aeabi.S
 
 TINY_USB_SRC_DIR = $(LIB_MAIN_DIR)/pico-sdk/lib/tinyusb/src
 TINYUSB_SRC := \
@@ -335,7 +334,6 @@ SYS_INCLUDE_DIRS = \
             $(SDK_DIR)/rp2_common/hardware_pwm/include \
             $(SDK_DIR)/rp2_common/pico_stdio_semihosting/include \
             $(SDK_DIR)/rp2_common/pico_float/include \
-            $(SDK_DIR)/rp2_common/pico_double/include \
             $(SDK_DIR)/rp2_common/hardware_resets/include \
             $(SDK_DIR)/rp2_common/pico_cxx_options/include \
             $(SDK_DIR)/rp2_common/pico_stdlib/include \
@@ -363,11 +361,6 @@ ARCH_FLAGS      += -DPICO_COPY_TO_RAM=$(RUN_FROM_RAM)
 # work around memcpy alignment issue
 ARCH_FLAGS      += -fno-builtin-memcpy
 
-# Automatically treating constants as single-precision breaks pico-sdk (-Werror=double-promotion)
-# We should go through BF code and explicitly declare constants as single rather than double as required,
-# rather than relying on this flag.
-# ARCH_FLAGS      += -fsingle-precision-constant
-
 PICO_STDIO_USB_FLAGS = \
             -DLIB_PICO_PRINTF=1 \
             -DLIB_PICO_PRINTF_PICO=1  \
@@ -391,7 +384,10 @@ PICO_STDIO_LD_FLAGS  = \
             -Wl,--wrap=putchar \
             -Wl,--wrap=getchar
 
-EXTRA_LD_FLAGS += $(PICO_STDIO_LD_FLAGS) $(PICO_TRACE_LD_FLAGS) $(PICO_FLOAT_LD_FLAGS) $(PICO_DOUBLE_LD_FLAGS)
+PICO_BIT_OPS_LD_FLAGS = \
+            -Wl,--wrap=__ctzdi2
+
+EXTRA_LD_FLAGS += $(PICO_STDIO_LD_FLAGS) $(PICO_TRACE_LD_FLAGS) $(PICO_FLOAT_LD_FLAGS) $(PICO_DOUBLE_LD_FLAGS) $(PICO_BIT_OPS_LD_FLAGS)
 
 ifdef RP2350_TARGET
 
@@ -477,8 +473,7 @@ endif
 
 PICO_STDIO_USB_SRC = \
             rp2_common/pico_stdio_usb/reset_interface.c \
-            rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c \
-            rp2_common/pico_bit_ops/bit_ops_aeabi.S
+            rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
 
 # TODO check
 #    rp2_common/pico_stdio_usb/stdio_usb_descriptors.c \

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -116,7 +116,7 @@ TINYUSB_SRC += \
             $(TINY_USB_SRC_DIR)/class/audio/audio_device.c
 
 # pico_float
-PICO_FLOAT_SRC  = \
+PICO_LIB_SRC  += \
             rp2_common/pico_float/float_common_m33.S \
             rp2_common/pico_float/float_conv32_vfp.S \
             rp2_common/pico_float/float_math.c \
@@ -165,8 +165,8 @@ PICO_FLOAT_LD_FLAGS = \
             -Wl,--wrap=tanhf \
             -Wl,--wrap=truncf
 
-#pico_double
-PICO_DOUBLE_SRC = \
+# pico_double
+PICO_LIB_SRC += \
             rp2_common/pico_double/double_aeabi_dcp.S \
             rp2_common/pico_double/double_conv_m33.S \
             rp2_common/pico_double/double_fma_dcp.S \
@@ -554,9 +554,7 @@ DEVICE_STDPERIPH_SRC := \
             $(PICO_LIB_SRC) \
             $(STDPERIPH_SRC) \
             $(TINYUSB_SRC) \
-            $(PICO_TRACE_SRC) \
-            $(PICO_FLOAT_SRC) \
-            $(PICO_DOUBLE_SRC)
+            $(PICO_TRACE_SRC)
 
 # Add a target-specific definition for PICO_LIB_TARGETS in order
 # to remove -flto=auto for pico-sdk file compilation

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -121,48 +121,50 @@ PICO_LIB_SRC  += \
             rp2_common/pico_float/float_math.c \
             rp2_common/pico_float/float_sci_m33_vfp.S
 
-PICO_FLOAT_LD_FLAGS = \
-            -Wl,--wrap=__aeabi_f2lz \
-            -Wl,--wrap=__aeabi_f2ulz \
-            -Wl,--wrap=__aeabi_l2f \
-            -Wl,--wrap=__aeabi_ul2f \
-            -Wl,--wrap=acosf \
-            -Wl,--wrap=acoshf \
-            -Wl,--wrap=asinf \
-            -Wl,--wrap=asinhf \
-            -Wl,--wrap=atan2f \
-            -Wl,--wrap=atanf \
-            -Wl,--wrap=atanhf \
-            -Wl,--wrap=cbrtf \
-            -Wl,--wrap=ceilf \
-            -Wl,--wrap=copysignf \
-            -Wl,--wrap=cosf \
-            -Wl,--wrap=coshf \
-            -Wl,--wrap=dremf \
-            -Wl,--wrap=exp10f \
-            -Wl,--wrap=exp2f \
-            -Wl,--wrap=expf \
-            -Wl,--wrap=expm1f \
-            -Wl,--wrap=floorf \
-            -Wl,--wrap=fmaf \
-            -Wl,--wrap=fmodf \
-            -Wl,--wrap=hypotf \
-            -Wl,--wrap=ldexpf \
-            -Wl,--wrap=log10f \
-            -Wl,--wrap=log1pf \
-            -Wl,--wrap=log2f \
-            -Wl,--wrap=logf \
-            -Wl,--wrap=powf \
-            -Wl,--wrap=powintf \
-            -Wl,--wrap=remainderf \
-            -Wl,--wrap=remquof \
-            -Wl,--wrap=roundf \
-            -Wl,--wrap=sincosf \
-            -Wl,--wrap=sinf \
-            -Wl,--wrap=sinhf \
-            -Wl,--wrap=tanf \
-            -Wl,--wrap=tanhf \
-            -Wl,--wrap=truncf
+PICO_FLOAT_WRAP_FNS = \
+            __aeabi_f2lz \
+            __aeabi_f2ulz \
+            __aeabi_l2f \
+            __aeabi_ul2f \
+            acosf \
+            acoshf \
+            asinf \
+            asinhf \
+            atan2f \
+            atanf \
+            atanhf \
+            cbrtf \
+            ceilf \
+            copysignf \
+            cosf \
+            coshf \
+            dremf \
+            exp10f \
+            exp2f \
+            expf \
+            expm1f \
+            floorf \
+            fmaf \
+            fmodf \
+            hypotf \
+            ldexpf \
+            log10f \
+            log1pf \
+            log2f \
+            logf \
+            powf \
+            powintf \
+            remainderf \
+            remquof \
+            roundf \
+            sincosf \
+            sinf \
+            sinhf \
+            tanf \
+            tanhf \
+            truncf
+
+PICO_FLOAT_LD_FLAGS = $(foreach fn, $(PICO_FLOAT_WRAP_FNS), -Wl,--wrap=$(fn))
 
 # pico_double
 PICO_LIB_SRC += \
@@ -172,68 +174,70 @@ PICO_LIB_SRC += \
             rp2_common/pico_double/double_math.c \
             rp2_common/pico_double/double_sci_m33.S
 
-PICO_DOUBLE_LD_FLAGS = \
-            -Wl,--wrap=__aeabi_cdcmpeq \
-            -Wl,--wrap=__aeabi_cdcmple \
-            -Wl,--wrap=__aeabi_cdrcmple \
-            -Wl,--wrap=__aeabi_d2f \
-            -Wl,--wrap=__aeabi_d2iz \
-            -Wl,--wrap=__aeabi_d2lz \
-            -Wl,--wrap=__aeabi_d2uiz \
-            -Wl,--wrap=__aeabi_d2ulz \
-            -Wl,--wrap=__aeabi_dadd \
-            -Wl,--wrap=__aeabi_dcmpeq \
-            -Wl,--wrap=__aeabi_dcmpge \
-            -Wl,--wrap=__aeabi_dcmpgt \
-            -Wl,--wrap=__aeabi_dcmple \
-            -Wl,--wrap=__aeabi_dcmplt \
-            -Wl,--wrap=__aeabi_dcmpun \
-            -Wl,--wrap=__aeabi_ddiv \
-            -Wl,--wrap=__aeabi_dmul \
-            -Wl,--wrap=__aeabi_drsub \
-            -Wl,--wrap=__aeabi_dsub \
-            -Wl,--wrap=__aeabi_i2d \
-            -Wl,--wrap=__aeabi_l2d \
-            -Wl,--wrap=__aeabi_ui2d \
-            -Wl,--wrap=__aeabi_ul2d \
-            -Wl,--wrap=acos \
-            -Wl,--wrap=acosh \
-            -Wl,--wrap=asin \
-            -Wl,--wrap=asinh \
-            -Wl,--wrap=atan \
-            -Wl,--wrap=atan2 \
-            -Wl,--wrap=atanh \
-            -Wl,--wrap=cbrt \
-            -Wl,--wrap=ceil \
-            -Wl,--wrap=copysign \
-            -Wl,--wrap=cos \
-            -Wl,--wrap=cosh \
-            -Wl,--wrap=drem \
-            -Wl,--wrap=exp \
-            -Wl,--wrap=exp10 \
-            -Wl,--wrap=exp2 \
-            -Wl,--wrap=expm1 \
-            -Wl,--wrap=floor \
-            -Wl,--wrap=fma \
-            -Wl,--wrap=fmod \
-            -Wl,--wrap=hypot \
-            -Wl,--wrap=ldexp \
-            -Wl,--wrap=log \
-            -Wl,--wrap=log10 \
-            -Wl,--wrap=log1p \
-            -Wl,--wrap=log2 \
-            -Wl,--wrap=pow \
-            -Wl,--wrap=powint \
-            -Wl,--wrap=remainder \
-            -Wl,--wrap=remquo \
-            -Wl,--wrap=round \
-            -Wl,--wrap=sin \
-            -Wl,--wrap=sincos \
-            -Wl,--wrap=sinh \
-            -Wl,--wrap=sqrt \
-            -Wl,--wrap=tan \
-            -Wl,--wrap=tanh \
-            -Wl,--wrap=trunc
+PICO_DOUBLE_WRAP_FNS = \
+            __aeabi_cdcmpeq \
+            __aeabi_cdcmple \
+            __aeabi_cdrcmple \
+            __aeabi_d2f \
+            __aeabi_d2iz \
+            __aeabi_d2lz \
+            __aeabi_d2uiz \
+            __aeabi_d2ulz \
+            __aeabi_dadd \
+            __aeabi_dcmpeq \
+            __aeabi_dcmpge \
+            __aeabi_dcmpgt \
+            __aeabi_dcmple \
+            __aeabi_dcmplt \
+            __aeabi_dcmpun \
+            __aeabi_ddiv \
+            __aeabi_dmul \
+            __aeabi_drsub \
+            __aeabi_dsub \
+            __aeabi_i2d \
+            __aeabi_l2d \
+            __aeabi_ui2d \
+            __aeabi_ul2d \
+            acos \
+            acosh \
+            asin \
+            asinh \
+            atan \
+            atan2 \
+            atanh \
+            cbrt \
+            ceil \
+            copysign \
+            cos \
+            cosh \
+            drem \
+            exp \
+            exp10 \
+            exp2 \
+            expm1 \
+            floor \
+            fma \
+            fmod \
+            hypot \
+            ldexp \
+            log \
+            log10 \
+            log1p \
+            log2 \
+            pow \
+            powint \
+            remainder \
+            remquo \
+            round \
+            sin \
+            sincos \
+            sinh \
+            sqrt \
+            tan \
+            tanh \
+            trunc
+
+PICO_DOUBLE_LD_FLAGS = $(foreach fn, $(PICO_DOUBLE_WRAP_FNS), -Wl,--wrap=$(fn))
 
 VPATH := $(VPATH):$(STDPERIPH_DIR)
 
@@ -374,15 +378,17 @@ PICO_STDIO_USB_FLAGS = \
             -DPICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=3000 \
             -DLIB_PICO_UNIQUEID=1
 
-PICO_STDIO_LD_FLAGS  = \
-            -Wl,--wrap=sprintf \
-            -Wl,--wrap=snprintf \
-            -Wl,--wrap=vsnprintf \
-            -Wl,--wrap=printf \
-            -Wl,--wrap=vprintf \
-            -Wl,--wrap=puts \
-            -Wl,--wrap=putchar \
-            -Wl,--wrap=getchar
+PICO_STDIO_WRAP_FNS  = \
+            sprintf \
+            snprintf \
+            vsnprintf \
+            printf \
+            vprintf \
+            puts \
+            putchar \
+            getchar
+
+PICO_STDIO_LD_FLAGS = $(foreach fn, $(PICO_STDIO_WRAP_FNS), -Wl,--wrap=$(fn))
 
 PICO_BIT_OPS_LD_FLAGS = \
             -Wl,--wrap=__ctzdi2


### PR DESCRIPTION
PICO: maths performance - use pico_float and pico_double from SDK

* Wrap floating point math functions and some double arithmetic with efficient pico-sdk versions.
* Also replace sqrt with sqrtf in scheduler (under USE_LATE_TASK_STATISTICS).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved float precision in gyro timing statistics by using single-precision sqrt, fixing a precision mismatch.

* **Performance**
  * Added explicit single- and double-precision FP support for RP2350 with math/bit-op libraries and linker wrappers, improving math operation reliability and performance.
  * Added stdio wrap list and extended linker flags for wrapped I/O and FP libs.

* **Chores**
  * Consolidated FP and bootrom sources into library, adjusted USB stdio wiring, and minor cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->