### PR TITLE
PIOUART updates after code review from merged PR

### DIFF
--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define EEPROM_CONF_VERSION 178
+#define EEPROM_CONF_VERSION 177
 
 bool isEEPROMVersionValid(void);
 bool isEEPROMStructureValid(void);

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -223,26 +223,29 @@ uartDeviceIdx_e uartDeviceIdxFromIdentifier(serialPortIdentifier_e identifier)
     return UARTDEV_INVALID;
 }
 
+#if SERIAL_PIOUART_COUNT > 0
 FAST_DATA_ZERO_INIT uartDevice_t pioUartDevice[SERIAL_PIOUART_COUNT];
+#endif
 
 uartDevice_t *pioUartDeviceFromIdentifier(serialPortIdentifier_e identifier)
 {
     // PIOUART devices must be used in order continuously from PIOUART0 (i.e. USE_PIOUART0 then USE_PIOUART1 ...)
+#if SERIAL_PIOUART_COUNT > 0
     int offset = identifier - SERIAL_PORT_PIOUART_FIRST;
     if (offset >= 0 && offset < SERIAL_PIOUART_COUNT) {
         return &pioUartDevice[offset];
     }
+#else
+    UNUSED(identifier);
+#endif
 
     return NULL;
 }
 
 uartDevice_t *uartDeviceFromIdentifier(serialPortIdentifier_e identifier)
 {
-    if (identifier >= SERIAL_PORT_PIOUART_FIRST ) {
-        uartDevice_t *device = pioUartDeviceFromIdentifier(identifier);
-        if (device != NULL) {
-            return device;
-        }
+    if (serialType(identifier) == SERIALTYPE_PIOUART) {
+        return pioUartDeviceFromIdentifier(identifier);
     }
 
     const uartDeviceIdx_e deviceIdx = uartDeviceIdxFromIdentifier(identifier);

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -167,7 +167,9 @@ typedef struct uartDevice_s {
 } uartDevice_t;
 
 extern uartDevice_t uartDevice[UARTDEV_COUNT];  // indexed by uartDeviceIdx_e;
+#if SERIAL_PIOUART_COUNT > 0
 extern uartDevice_t pioUartDevice[SERIAL_PIOUART_COUNT]; // used continuously in order, 0..SERIAL_PIOUART_COUNT-1
+#endif
 
 uartDeviceIdx_e uartDeviceIdxFromIdentifier(serialPortIdentifier_e identifier);
 uartDevice_t* uartDeviceFromIdentifier(serialPortIdentifier_e identifier);

--- a/src/main/target/serial_post.h
+++ b/src/main/target/serial_post.h
@@ -39,7 +39,7 @@ All <type><n>_(RX|TX)_PINS are normalized too:
  - if port is not enable, both will be undefined, possibly with warning
   - pass -DWARN_UNUSED_SERIAL_PORT to compiler to check pin defined without corresponding port being enabled.
 
-Generated on 2025-09-14
+Generated on 2025-09-16
 
 Configuration used:
 {   'LPUART': {'depends': {'UART'}, 'ids': [1]},
@@ -470,6 +470,76 @@ Configuration used:
 # undef LPUART1_TX_PIN
 #endif
 
+/****                                SOFTSERIAL                                 *****/
+
+#if defined(USE_SOFTSERIAL)
+// USE_SOFTSERIAL enables all SOFTSERIAL ports
+# if !defined(USE_SOFTSERIAL1)
+#  define USE_SOFTSERIAL1
+# endif
+# if !defined(USE_SOFTSERIAL2)
+#  define USE_SOFTSERIAL2
+# endif
+#endif
+
+#if defined(USE_SOFTSERIAL1)
+# define SERIAL_SOFTSERIAL1_USED 1
+#else
+# define SERIAL_SOFTSERIAL1_USED 0
+#endif
+#if defined(USE_SOFTSERIAL2)
+# define SERIAL_SOFTSERIAL2_USED 1
+#else
+# define SERIAL_SOFTSERIAL2_USED 0
+#endif
+
+#define SERIAL_SOFTSERIAL_MASK ((SERIAL_SOFTSERIAL1_USED * BIT(1 - 1)) | (SERIAL_SOFTSERIAL2_USED * BIT(2 - 1)))
+#define SERIAL_SOFTSERIAL_COUNT (SERIAL_SOFTSERIAL1_USED + SERIAL_SOFTSERIAL2_USED)
+// 0 if no port is defined
+#define SERIAL_SOFTSERIAL_MAX (SERIAL_SOFTSERIAL_MASK ? LOG2(SERIAL_SOFTSERIAL_MASK) + 1 : 0)
+
+#if SERIAL_SOFTSERIAL_COUNT != SERIAL_SOFTSERIAL_MAX
+# error SOFTSERIAL ports must start with SOFTSERIAL1 and be continuous
+#endif
+
+// Normalize SOFTSERIAL TX/RX
+#if SERIAL_SOFTSERIAL1_USED && !defined(SOFTSERIAL1_RX_PIN)
+# define SOFTSERIAL1_RX_PIN NONE
+#endif
+#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL1_USED && defined(SOFTSERIAL1_RX_PIN)
+# warning "SOFTSERIAL1_RX_PIN is defined but SOFTSERIAL1 is not enabled"
+#endif
+#if !SERIAL_SOFTSERIAL1_USED &&  defined(SOFTSERIAL1_RX_PIN)
+# undef SOFTSERIAL1_RX_PIN
+#endif
+#if SERIAL_SOFTSERIAL1_USED && !defined(SOFTSERIAL1_TX_PIN)
+# define SOFTSERIAL1_TX_PIN NONE
+#endif
+#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL1_USED && defined(SOFTSERIAL1_TX_PIN)
+# warning "SOFTSERIAL1_TX_PIN is defined but SOFTSERIAL1 is not enabled"
+#endif
+#if !SERIAL_SOFTSERIAL1_USED &&  defined(SOFTSERIAL1_TX_PIN)
+# undef SOFTSERIAL1_TX_PIN
+#endif
+#if SERIAL_SOFTSERIAL2_USED && !defined(SOFTSERIAL2_RX_PIN)
+# define SOFTSERIAL2_RX_PIN NONE
+#endif
+#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL2_USED && defined(SOFTSERIAL2_RX_PIN)
+# warning "SOFTSERIAL2_RX_PIN is defined but SOFTSERIAL2 is not enabled"
+#endif
+#if !SERIAL_SOFTSERIAL2_USED &&  defined(SOFTSERIAL2_RX_PIN)
+# undef SOFTSERIAL2_RX_PIN
+#endif
+#if SERIAL_SOFTSERIAL2_USED && !defined(SOFTSERIAL2_TX_PIN)
+# define SOFTSERIAL2_TX_PIN NONE
+#endif
+#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL2_USED && defined(SOFTSERIAL2_TX_PIN)
+# warning "SOFTSERIAL2_TX_PIN is defined but SOFTSERIAL2 is not enabled"
+#endif
+#if !SERIAL_SOFTSERIAL2_USED &&  defined(SOFTSERIAL2_TX_PIN)
+# undef SOFTSERIAL2_TX_PIN
+#endif
+
 /****                                PIOUART                                 *****/
 
 // normalize SERIAL_PIOUART_FIRST_INDEX
@@ -731,76 +801,6 @@ Configuration used:
 # undef PIOUART9_TX_PIN
 #endif
 
-/****                                SOFTSERIAL                                 *****/
-
-#if defined(USE_SOFTSERIAL)
-// USE_SOFTSERIAL enables all SOFTSERIAL ports
-# if !defined(USE_SOFTSERIAL1)
-#  define USE_SOFTSERIAL1
-# endif
-# if !defined(USE_SOFTSERIAL2)
-#  define USE_SOFTSERIAL2
-# endif
-#endif
-
-#if defined(USE_SOFTSERIAL1)
-# define SERIAL_SOFTSERIAL1_USED 1
-#else
-# define SERIAL_SOFTSERIAL1_USED 0
-#endif
-#if defined(USE_SOFTSERIAL2)
-# define SERIAL_SOFTSERIAL2_USED 1
-#else
-# define SERIAL_SOFTSERIAL2_USED 0
-#endif
-
-#define SERIAL_SOFTSERIAL_MASK ((SERIAL_SOFTSERIAL1_USED * BIT(1 - 1)) | (SERIAL_SOFTSERIAL2_USED * BIT(2 - 1)))
-#define SERIAL_SOFTSERIAL_COUNT (SERIAL_SOFTSERIAL1_USED + SERIAL_SOFTSERIAL2_USED)
-// 0 if no port is defined
-#define SERIAL_SOFTSERIAL_MAX (SERIAL_SOFTSERIAL_MASK ? LOG2(SERIAL_SOFTSERIAL_MASK) + 1 : 0)
-
-#if SERIAL_SOFTSERIAL_COUNT != SERIAL_SOFTSERIAL_MAX
-# error SOFTSERIAL ports must start with SOFTSERIAL1 and be continuous
-#endif
-
-// Normalize SOFTSERIAL TX/RX
-#if SERIAL_SOFTSERIAL1_USED && !defined(SOFTSERIAL1_RX_PIN)
-# define SOFTSERIAL1_RX_PIN NONE
-#endif
-#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL1_USED && defined(SOFTSERIAL1_RX_PIN)
-# warning "SOFTSERIAL1_RX_PIN is defined but SOFTSERIAL1 is not enabled"
-#endif
-#if !SERIAL_SOFTSERIAL1_USED &&  defined(SOFTSERIAL1_RX_PIN)
-# undef SOFTSERIAL1_RX_PIN
-#endif
-#if SERIAL_SOFTSERIAL1_USED && !defined(SOFTSERIAL1_TX_PIN)
-# define SOFTSERIAL1_TX_PIN NONE
-#endif
-#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL1_USED && defined(SOFTSERIAL1_TX_PIN)
-# warning "SOFTSERIAL1_TX_PIN is defined but SOFTSERIAL1 is not enabled"
-#endif
-#if !SERIAL_SOFTSERIAL1_USED &&  defined(SOFTSERIAL1_TX_PIN)
-# undef SOFTSERIAL1_TX_PIN
-#endif
-#if SERIAL_SOFTSERIAL2_USED && !defined(SOFTSERIAL2_RX_PIN)
-# define SOFTSERIAL2_RX_PIN NONE
-#endif
-#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL2_USED && defined(SOFTSERIAL2_RX_PIN)
-# warning "SOFTSERIAL2_RX_PIN is defined but SOFTSERIAL2 is not enabled"
-#endif
-#if !SERIAL_SOFTSERIAL2_USED &&  defined(SOFTSERIAL2_RX_PIN)
-# undef SOFTSERIAL2_RX_PIN
-#endif
-#if SERIAL_SOFTSERIAL2_USED && !defined(SOFTSERIAL2_TX_PIN)
-# define SOFTSERIAL2_TX_PIN NONE
-#endif
-#if defined(WARN_UNUSED_SERIAL_PORT) && !SERIAL_SOFTSERIAL2_USED && defined(SOFTSERIAL2_TX_PIN)
-# warning "SOFTSERIAL2_TX_PIN is defined but SOFTSERIAL2 is not enabled"
-#endif
-#if !SERIAL_SOFTSERIAL2_USED &&  defined(SOFTSERIAL2_TX_PIN)
-# undef SOFTSERIAL2_TX_PIN
-#endif
-
 /****                                VCP                                 *****/
 
 #if defined(USE_VCP)
@@ -816,17 +816,17 @@ Configuration used:
 #define SERIAL_VCP_MAX (SERIAL_VCP_MASK ? LOG2(SERIAL_VCP_MASK) + 1 : 0)
 
 // normalize USE_x after all ports are enumerated (x_COUNT of dependencies must be available)
-#if !defined(USE_UART) && (SERIAL_UART_COUNT || SERIAL_PIOUART_COUNT || SERIAL_LPUART_COUNT)
+#if !defined(USE_UART) && (SERIAL_UART_COUNT || SERIAL_LPUART_COUNT || SERIAL_PIOUART_COUNT)
 # define USE_UART
 #endif
 #if !defined(USE_LPUART) && (SERIAL_LPUART_COUNT)
 # define USE_LPUART
 #endif
-#if !defined(USE_PIOUART) && (SERIAL_PIOUART_COUNT)
-# define USE_PIOUART
-#endif
 #if !defined(USE_SOFTSERIAL) && (SERIAL_SOFTSERIAL_COUNT)
 # define USE_SOFTSERIAL
+#endif
+#if !defined(USE_PIOUART) && (SERIAL_PIOUART_COUNT)
+# define USE_PIOUART
 #endif
 #if !defined(USE_VCP) && (SERIAL_VCP_COUNT)
 # define USE_VCP

--- a/src/platform/PICO/uart/uart_pio.c
+++ b/src/platform/PICO/uart/uart_pio.c
@@ -21,8 +21,6 @@
 
 #include "platform.h"
 
-#ifdef USE_UART
-
 #include "drivers/io.h"
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"
@@ -32,6 +30,8 @@
 #include "hardware/pio.h"
 
 #include "serial_uart_pico.h"
+
+#if SERIAL_PIOUART_COUNT > 0
 
 // PIOUARTs are used in order, starting from PIOUART0
 STATIC_ASSERT(SERIAL_PIOUART_COUNT == SERIAL_PIOUART_MAX, should_be_enforced_PIOUART_COUNT_IS_PIOUART_MAX);
@@ -186,7 +186,6 @@ static bool ensurePioProgram(PIO pio, const pio_program_t *program, bool isTx)
     }
 }
 
-#if SERIAL_PIOUART_COUNT > 0
 static void uartPioIrqHandler(uartPort_t *s, pioDetails_t *pioDetailsPtr)
 {
     io_rw_32 *enableRegPtr = pioDetailsPtr->enableReg;
@@ -235,7 +234,6 @@ static void uartPioIrqHandler(uartPort_t *s, pioDetails_t *pioDetailsPtr)
         }
     }
 }
-#endif
 
 static void on_pioUART0(void)
 {
@@ -370,5 +368,36 @@ void uartEnableTxInterrupt_pio(uartPort_t *uartPort)
     // bprintf("uartEnableTxInterrupt_pio %p irqn_index %d, %p", uartPio, irqn_index, irqSourceTX);
     pio_set_irqn_source_enabled(uartPio, irqn_index, irqSourceTX, true);
 }
- 
-#endif
+
+#else
+
+void uartPinConfigure_pio(const serialPinConfig_t *pSerialPinConfig)
+{
+    UNUSED(pSerialPinConfig);
+}
+
+bool serialUART_pio(uartPort_t *s, uint32_t baudRate, portMode_e mode, portOptions_e options,
+                    const pioUartHardware_t *hardware, serialPortIdentifier_e identifier, IO_t txIO, IO_t rxIO)
+{
+    UNUSED(s);
+    UNUSED(baudRate);
+    UNUSED(mode);
+    UNUSED(options);
+    UNUSED(hardware);
+    UNUSED(identifier);
+    UNUSED(txIO);
+    UNUSED(rxIO);
+    return false;
+}
+
+void uartReconfigure_pio(uartPort_t *s)
+{
+    UNUSED(s);
+}
+
+void uartEnableTxInterrupt_pio(uartPort_t *uartPort)
+{
+    UNUSED(uartPort);
+}
+
+#endif // #if SERIAL_PIOUART_COUNT > 0

--- a/src/utils/gen-serial-j2.py
+++ b/src/utils/gen-serial-j2.py
@@ -16,15 +16,15 @@ serials = {
                "depends": {"UART"},
 #               "inverter": True,   # TODO: old code compatibility only, disabled
                },
+    "SOFTSERIAL": {"ids": list(range(1, 2 + 1)),
+                   "use_enables_all": True,
+                   "force_continuous": True,
+                   },
     "PIOUART": {"ids": list(range(0, 9 + 1)),
                "depends": {"UART"},
                 "first_index": True,   # support configurable first index for this port
                 "force_continuous": True,
                 },
-    "SOFTSERIAL": {"ids": list(range(1, 2 + 1)),
-                   "use_enables_all": True,
-                   "force_continuous": True,
-                   },
     "VCP": {"singleton": True,
             "no_pins": True}
 }


### PR DESCRIPTION
PIOUART updates after code review from merged PR

Revert increment of EEPROM_CONF_VERSION
No zero-length arrays when SERIAL_PIOUART_COUNT == 0
Change order in gen-serial-j2.py and serial_post.h
Tidy up uartDeviceFromIdentifier
