### PR TITLE
BUG: Return to "grep" for MacOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,10 @@ FATFS_DIR        = $(ROOT)/lib/main/FatFS
 FATFS_SRC        = $(notdir $(wildcard $(FATFS_DIR)/*.c))
 CSOURCES        := $(shell find $(SRC_DIR) -name '*.c')
 
-FC_VER_YEAR   := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_YEAR[[:space:]]+/  {print $$3}' src/main/build/version.h)
-FC_VER_MONTH  := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_MONTH[[:space:]]+/ {print $$3}' src/main/build/version.h)
-FC_VER_PATCH  := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_PATCH_LEVEL[[:space:]]+/ {print $$3}' src/main/build/version.h)
-FC_VER_SUFFIX := $(shell awk '/^[[:space:]]*.?define[[:space:]]+FC_VERSION_SUFFIX[[:space:]]+/ {gsub(/"/,""); print $$3}' src/main/build/version.h)
+FC_VER_YEAR   := $(shell grep "define FC_VERSION_YEAR "        src/main/build/version.h | awk '{print $$3}' )
+FC_VER_MONTH  := $(shell grep "define FC_VERSION_MONTH "       src/main/build/version.h | awk '{print $$3}' )
+FC_VER_PATCH  := $(shell grep "define FC_VERSION_PATCH_LEVEL " src/main/build/version.h | awk '{print $$3}' )
+FC_VER_SUFFIX := $(shell grep "define FC_VERSION_SUFFIX "      src/main/build/version.h | awk '{gsub(/"/,""); print $$3}')
 
 FC_VER       := $(FC_VER_YEAR).$(FC_VER_MONTH).$(FC_VER_PATCH)
 

--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -31,7 +31,7 @@
 #define FC_VERSION_YEAR             2025
 // The month the release is made
 #define FC_VERSION_MONTH            12
-// Increment when a bug-fix release is made (0 for initial YYYY.MM.X release)
+// Increment when a bug-fix release is made (0 for initial YYYY.M.X release)
 #define FC_VERSION_PATCH_LEVEL      0
 // Optional suffix for pre-releases (alpha, beta, rc1, etc). Empty string for final releases.
 #define FC_VERSION_SUFFIX           "beta"


### PR DESCRIPTION
based on feedback from MacOS builds the differing capability of AWK means we really need to stick with GREP to pull this information.

Another option is we create a version (txt) file, and remove the defines, and have make parse the text file, and simply provide the version information on the command line.
