### PR TITLE
Fix preprocess guard hash emission

### DIFF
--- a/mk/preprocess.mk
+++ b/mk/preprocess.mk
@@ -21,8 +21,9 @@ _pp_expand_raw = $(strip $(shell \
 ))
 
 # Expand only if the macro NAME is defined in header $1; otherwise yield empty
+
 _pp_expand_guarded_raw = $(strip $(shell \
-  printf '#if defined(%s)\n%s\n#endif\n' "$2" "$2" | \
+  printf '%bif defined(%s)\n%s\n%bendif\n' "\043" "$2" "$2" "\043" | \
   $(CROSS_CC) $(CPPFLAGS) \
     $(addprefix -D,$(OPTIONS)) \
     $(addprefix -I,$(INCLUDE_DIRS)) \

--- a/mk/preprocess.mk
+++ b/mk/preprocess.mk
@@ -21,9 +21,11 @@ _pp_expand_raw = $(strip $(shell \
 ))
 
 # Expand only if the macro NAME is defined in header $1; otherwise yield empty
+# _pp_hash stores a literal '#', keeping guard emission portable across shells.
+_pp_hash = \#
 
 _pp_expand_guarded_raw = $(strip $(shell \
-  printf '%bif defined(%s)\n%s\n%bendif\n' "\043" "$2" "$2" "\043" | \
+	printf '%sif defined(%s)\n%s\n%sendif\n' "$(_pp_hash)" "$2" "$2" "$(_pp_hash)" | \
   $(CROSS_CC) $(CPPFLAGS) \
     $(addprefix -D,$(OPTIONS)) \
     $(addprefix -I,$(INCLUDE_DIRS)) \

--- a/mk/preprocess.mk
+++ b/mk/preprocess.mk
@@ -25,7 +25,7 @@ _pp_expand_raw = $(strip $(shell \
 _pp_hash = \#
 
 _pp_expand_guarded_raw = $(strip $(shell \
-	printf '%sif defined(%s)\n%s\n%sendif\n' "$(_pp_hash)" "$2" "$2" "$(_pp_hash)" | \
+  printf '%sif defined(%s)\n%s\n%sendif\n' "$(_pp_hash)" "$2" "$2" "$(_pp_hash)" | \
   $(CROSS_CC) $(CPPFLAGS) \
     $(addprefix -D,$(OPTIONS)) \
     $(addprefix -I,$(INCLUDE_DIRS)) \


### PR DESCRIPTION
Fix for building locally on OSX

codex assisted so pls check

Codex summary:

- Swapped the literal #if/#endif text in mk/preprocess.mk:24 to use printf '%b…' "\\043" so the preprocessor guard lines are emitted with an actual hash character instead of the escape sequence \043.

- Required because the previous tweak wrote \043if … straight into generated make fragments, so downstream builds saw file paths like \043if defined(...), triggering shell syntax errors and missing-target failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how preprocessor guards are generated in the build to increase portability across environments. This change preserves dynamic macro insertion, does not alter runtime behavior, compiled artifacts, or public interfaces, and requires no action from users. Build outputs and functionality remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->