### PR TITLE
Use octal escape for preprocessor guard hash

### DIFF
--- a/mk/preprocess.mk
+++ b/mk/preprocess.mk
@@ -21,11 +21,9 @@ _pp_expand_raw = $(strip $(shell \
 ))
 
 # Expand only if the macro NAME is defined in header $1; otherwise yield empty
-# _pp_hash stores a literal '#', keeping guard emission portable across shells.
-_pp_hash = \#
-
+# Use octal-escaped '#' so old make (3.81 on macOS) doesn't treat it as a comment.
 _pp_expand_guarded_raw = $(strip $(shell \
-  printf '%sif defined(%s)\n%s\n%sendif\n' "$(_pp_hash)" "$2" "$2" "$(_pp_hash)" | \
+  printf '\043if defined(%s)\n%s\n\043endif\n' "$2" "$2" | \
   $(CROSS_CC) $(CPPFLAGS) \
     $(addprefix -D,$(OPTIONS)) \
     $(addprefix -I,$(INCLUDE_DIRS)) \

--- a/mk/preprocess.mk
+++ b/mk/preprocess.mk
@@ -23,7 +23,7 @@ _pp_expand_raw = $(strip $(shell \
 # Expand only if the macro NAME is defined in header $1; otherwise yield empty
 # Use octal-escaped '#' so old make (3.81 on macOS) doesn't treat it as a comment.
 _pp_expand_guarded_raw = $(strip $(shell \
-  printf '\043if defined(%s)\n%s\n\043endif\n' "$2" "$2" | \
+  printf '\043 if defined(%s)\n%s\n\043 endif\n' "$2" "$2" | \
   $(CROSS_CC) $(CPPFLAGS) \
     $(addprefix -D,$(OPTIONS)) \
     $(addprefix -I,$(INCLUDE_DIRS)) \


### PR DESCRIPTION
Changes made to the last PR ended up blocking compiling - so it needs this follow-up:

Upstream recently simplified mk/preprocess.mk to print the guard lines with plain #if/#endif, removing the old _pp_hash workaround. 

GNU make ≥4.x is fine with that, but macOS ships GNU make 3.81, which still treats a literal # inside a $(strip $(shell …)) call as the start of a comment. 

When 3.81 ingests the new file it discards everything after the #, leaving the strip call with mismatched parentheses and aborting the build (“unterminated call to function strip”). 

Reintroducing _pp_hash isn’t necessary—escaping the hash (\043) keeps the emitted preprocessor guard identical while giving old make a literal-free line to parse. The new PR exists to restore that compatibility so Betaflight continues to build on the stock macOS toolchain and on newer GNU make versions without regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing feature changes.
- Bug Fixes
  - Improved reliability of generated shell guards by using a more robust character-escaping approach, reducing misinterpretation across environments.
- Refactor
  - Simplified guard emission logic by removing an intermediate placeholder and inlining the escaped character, preserving behavior while reducing complexity.
- Notes
  - Public interfaces unchanged; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->