### PR TITLE
Fix servos not included in build options when using wing define

### DIFF
--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -162,7 +162,6 @@ void sbufWriteBuildInfoFlags(sbuf_t *dst)
         BUILD_OPTION_VTX,
 #endif
 #ifdef USE_WING
-        BUILD_OPTION_SERVOS,
         BUILD_OPTION_WING,
 #endif
 #ifdef USE_BRUSHED

--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -162,6 +162,7 @@ void sbufWriteBuildInfoFlags(sbuf_t *dst)
         BUILD_OPTION_VTX,
 #endif
 #ifdef USE_WING
+        BUILD_OPTION_SERVOS,
         BUILD_OPTION_WING,
 #endif
 #ifdef USE_BRUSHED

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -474,10 +474,6 @@
 
 #ifdef USE_WING
 
-#ifndef USE_SERVOS
-#define USE_SERVOS
-#endif
-
 #ifndef USE_ADVANCED_TPA
 #define USE_ADVANCED_TPA
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Configuration behavior updated: enabling wings no longer auto-enables servos. If your setup requires servos, enable them explicitly in your configuration.
  - This change prevents unintended servo activation and offers clearer, more deliberate control over hardware features.
  - No other configuration options are affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->