### PR TITLE
GYRO: Remove ability to set custom gyro alignment

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1858,11 +1858,8 @@ const clivalue_t valueTable[] = {
     /* i2cBus   */                                                                 \
     { "gyro_" STR(N) "_i2cBus",        VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cBus) },\
     /* i2c addr */                                                                 \
-    { "gyro_" STR(N) "_i2c_address",   VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cAddress) },\
-    /* custom roll/pitch/yaw */                                                    \
-    { "gyro_" STR(N) "_align_roll",   VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.roll) },\
-    { "gyro_" STR(N) "_align_pitch",  VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.pitch) },\
-    { "gyro_" STR(N) "_align_yaw",    VAR_INT16 | HARDWARE_VALUE, .config.minmax = { -3600, 3600 }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, customAlignment.yaw) }\
+    { "gyro_" STR(N) "_i2c_address",   VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, IDX, i2cAddress) }\
+    /* end      */
 
     GYRO_DEVICE_RECORDS(1, 0),
 #if GYRO_COUNT > 1


### PR DESCRIPTION
To be replaced with an ability to make small adjustments to the alignment (most probably just YAW) when required. 

TODO in future PR:
- Add adjustment config ability,
- remove custom alignment from config
- remove lookup table usage - opt only for explicit setting of pitch roll and yaw as vector

NOTE: Removing these to prevent the inadvertent bad configuration (which has already started to occur).

Gyro alignment is not user serviceable. Whilst there maybe a need to make a small micro adjustment (to yaw - say +/- 2-3 degrees max) for purists, this will only be needed on boards with more than one gyro (so as to do so individually). For those boards with 1 gyro it can be achieved with custom board alignment.

I will setup the appropriate PR for the above during the RC phase.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified gyro device configuration in the CLI by removing custom alignment parameters (roll, pitch, yaw).
  - I2C address configuration remains unchanged.
  - Impact: Existing custom alignment settings will no longer appear or be configurable via the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->