### PR TITLE
Update build options

### DIFF
--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -23,8 +23,8 @@
  * WARNING: This is an auto-generated file, please do not edit directly!
  *
  * Generator    : `src/utils/make-build-info.py`
- * Source       : https://build.betaflight.com/api/options/4.6.0
- * Input hash   : f612c38bb1cde0c284a8e23af1eb2049
+ * Source       : https://build.betaflight.com/api/options/2025.12
+ * Input hash   : 6a57c50d7938349a1e8363e85d6741dc
  */
 
 #include <stdint.h>
@@ -52,6 +52,9 @@ void sbufWriteBuildInfoFlags(sbuf_t *dst)
 #endif
 #ifdef USE_SERIALRX_JETIEXBUS
         BUILD_OPTION_SERIALRX_JETIEXBUS,
+#endif
+#ifdef USE_SERIALRX_MAVLINK
+        BUILD_OPTION_SERIALRX_MAVLINK,
 #endif
 #ifdef USE_RX_PPM
         BUILD_OPTION_RX_PPM,

--- a/src/main/msp/msp_build_info.h
+++ b/src/main/msp/msp_build_info.h
@@ -23,8 +23,8 @@
  * WARNING: This is an auto-generated file, please do not edit directly!
  *
  * Generator    : `src/utils/make-build-info.py`
- * Source       : https://build.betaflight.com/api/options/4.6.0
- * Input hash   : f612c38bb1cde0c284a8e23af1eb2049
+ * Source       : https://build.betaflight.com/api/options/2025.12
+ * Input hash   : 6a57c50d7938349a1e8363e85d6741dc
  */
 
 #pragma once
@@ -37,6 +37,7 @@
 #define BUILD_OPTION_SERIALRX_GHST              4099
 #define BUILD_OPTION_SERIALRX_IBUS              4100
 #define BUILD_OPTION_SERIALRX_JETIEXBUS         4101
+#define BUILD_OPTION_SERIALRX_MAVLINK           4109
 #define BUILD_OPTION_RX_PPM                     4102
 #define BUILD_OPTION_SERIALRX_SBUS              4103
 #define BUILD_OPTION_SERIALRX_SPEKTRUM          4104


### PR DESCRIPTION
- generated using generated using src/utils/make-build-info.py https://build.betaflight.com/api/options/2025.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional MAVLink-based Serial RX support, enabling use of MAVLink-compatible receivers/telemetry in supported builds. This will appear as a selectable build option and be reflected in build info.

- Chores
  - Updated build metadata to reference the latest options catalog (2025.12), improving accuracy of reported build options and version details in build information outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->