### PR TITLE
Increase telemtry baudrate

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1361,7 +1361,7 @@ static void cliSerial(const char *cmdName, char *cmdline)
             portConfig.gps_baudrateIndex = baudRateIndex;
             break;
         case 2:
-            if (baudRateIndex != BAUD_AUTO && baudRateIndex > BAUD_115200) {
+            if (baudRateIndex != BAUD_AUTO && baudRateIndex > BAUD_460800) {
                 continue;
             }
             portConfig.telemetry_baudrateIndex = baudRateIndex;


### PR DESCRIPTION
- Adding support for MAVlink 460K8 baudrate