### PR TITLE
Resolved telemetries transmit issue in MAVLink mode

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -91,7 +91,6 @@
 
 #define MAVLINK_SYSTEM_ID 1
 #define MAVLINK_COMPONENT_ID MAV_COMP_ID_AUTOPILOT1
-
 extern uint16_t rssi; // FIXME dependency on mw.c
 
 static serialPort_t *mavlinkPort = NULL;
@@ -121,9 +120,6 @@ static mavlink_message_t mavRecvMsg;
 static mavlink_status_t mavRecvStatus;
 static uint8_t txbuff_free = 100;  // tx buffer space in %, start with empty buffer
 static bool txbuff_valid = false;
-static uint32_t heartBrakeCounter;
-static uint32_t attitudeCounter;
-static uint32_t statusCounter;
 #endif
 
 static int mavlinkStreamTrigger(enum MAV_DATA_STREAM streamNum)
@@ -291,10 +287,6 @@ static void mavlinkSendSystemStatus(void)
         0);
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
-    statusCounter++;
-    if (statusCounter > 50) {
-        statusCounter = 0;
-    }
 }
 
 static void mavlinkSendRCChannelsAndRSSI(void)
@@ -437,10 +429,6 @@ static void mavlinkSendAttitude(void)
         0);
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
-    attitudeCounter++;
-    if (attitudeCounter > 50) {
-        attitudeCounter = 0;
-    }
 }
 
 static void mavlinkSendHUDAndHeartbeat(void)
@@ -551,10 +539,6 @@ static void mavlinkSendHUDAndHeartbeat(void)
         mavSystemState);
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
-    heartBrakeCounter++;
-    if (heartBrakeCounter > 50){
-        heartBrakeCounter = 0;
-    }
 }
 
 static void processMAVLinkTelemetry(void)
@@ -657,9 +641,6 @@ void handleMAVLinkTelemetry(void)
         if (shouldSendTelemetry) {
             txbuff_free = MAX(0, txbuff_free - mavlink_min_txbuff);
         }
-        DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 4, heartBrakeCounter);
-        DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 5, attitudeCounter);
-        DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 6, statusCounter);
     } else {
         shouldSendTelemetry = ((currentTimeUs - lastMavlinkMessageTime) >= TELEMETRY_MAVLINK_DELAY);
     }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -90,6 +90,7 @@
 #define TELEMETRY_MAVLINK_DELAY ((1000 * 1000) / TELEMETRY_MAVLINK_MAXRATE)
 
 #define MAVLINK_SYSTEM_ID 1
+#define MAVLINK_COMPONENT_ID MAV_COMP_ID_AUTOPILOT1
 
 extern uint16_t rssi; // FIXME dependency on mw.c
 
@@ -253,7 +254,7 @@ static void mavlinkSendSystemStatus(void)
         batteryRemaining = isBatteryVoltageConfigured() ? calculateBatteryPercentageRemaining() : batteryRemaining;
     }
 
-    mavlink_msg_sys_status_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_sys_status_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // onboard_control_sensors_present Bitmask showing which onboard controllers and sensors are present.
         //Value of 0: not present. Value of 1: present. Indices: 0: 3D gyro, 1: 3D acc, 2: 3D mag, 3: absolute pressure,
         // 4: differential pressure, 5: GPS, 6: optical flow, 7: computer vision position, 8: laser based position,
@@ -299,7 +300,7 @@ static void mavlinkSendSystemStatus(void)
 static void mavlinkSendRCChannelsAndRSSI(void)
 {
     uint16_t msgLength;
-    mavlink_msg_rc_channels_raw_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_rc_channels_raw_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // time_boot_ms Timestamp (milliseconds since system boot)
         millis(),
         // port Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.
@@ -347,7 +348,7 @@ static void mavlinkSendPosition(void)
         }
     }
 
-    mavlink_msg_gps_raw_int_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_gps_raw_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // time_usec Timestamp (microseconds since UNIX epoch or microseconds since system boot)
         micros(),
         // fix_type 0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.
@@ -379,7 +380,7 @@ static void mavlinkSendPosition(void)
     mavlinkSerialWrite(mavBuffer, msgLength);
 
     // Global position
-    mavlink_msg_global_position_int_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_global_position_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // time_usec Timestamp (microseconds since UNIX epoch or microseconds since system boot)
         micros(),
         // lat Latitude in 1E7 degrees
@@ -402,7 +403,7 @@ static void mavlinkSendPosition(void)
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
 
-    mavlink_msg_gps_global_origin_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_gps_global_origin_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // Latitude (WGS84), expressed as * 1E7
         GPS_home_llh.lat,
         // Longitude (WGS84), expressed as * 1E7
@@ -419,7 +420,7 @@ static void mavlinkSendPosition(void)
 static void mavlinkSendAttitude(void)
 {
     uint16_t msgLength;
-    mavlink_msg_attitude_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_attitude_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // time_boot_ms Timestamp (milliseconds since system boot)
         millis(),
         // roll Roll angle (rad)
@@ -459,7 +460,7 @@ static void mavlinkSendHUDAndHeartbeat(void)
 
     mavAltitude = getEstimatedAltitudeCm() / 100.0f;
 
-    mavlink_msg_vfr_hud_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_vfr_hud_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // airspeed Current airspeed in m/s
         mavAirSpeed,
         // groundspeed Current ground speed in m/s
@@ -537,7 +538,7 @@ static void mavlinkSendHUDAndHeartbeat(void)
         mavSystemState = MAV_STATE_STANDBY;
     }
 
-    mavlink_msg_heartbeat_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
+    mavlink_msg_heartbeat_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // type Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)
         mavSystemType,
         // autopilot Autopilot type / class. defined in MAV_AUTOPILOT ENUM

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -89,6 +89,7 @@
 #define TELEMETRY_MAVLINK_MAXRATE 50
 #define TELEMETRY_MAVLINK_DELAY ((1000 * 1000) / TELEMETRY_MAVLINK_MAXRATE)
 
+#define MAVLINK_SYSTEM_ID 1
 extern uint16_t rssi; // FIXME dependency on mw.c
 
 static serialPort_t *mavlinkPort = NULL;
@@ -248,7 +249,7 @@ static void mavlinkSendSystemStatus(void)
         batteryRemaining = isBatteryVoltageConfigured() ? calculateBatteryPercentageRemaining() : batteryRemaining;
     }
 
-    mavlink_msg_sys_status_pack(0, 200, &mavMsg,
+    mavlink_msg_sys_status_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // onboard_control_sensors_present Bitmask showing which onboard controllers and sensors are present.
         //Value of 0: not present. Value of 1: present. Indices: 0: 3D gyro, 1: 3D acc, 2: 3D mag, 3: absolute pressure,
         // 4: differential pressure, 5: GPS, 6: optical flow, 7: computer vision position, 8: laser based position,
@@ -290,7 +291,7 @@ static void mavlinkSendSystemStatus(void)
 static void mavlinkSendRCChannelsAndRSSI(void)
 {
     uint16_t msgLength;
-    mavlink_msg_rc_channels_raw_pack(0, 200, &mavMsg,
+    mavlink_msg_rc_channels_raw_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // time_boot_ms Timestamp (milliseconds since system boot)
         millis(),
         // port Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.
@@ -338,7 +339,7 @@ static void mavlinkSendPosition(void)
         }
     }
 
-    mavlink_msg_gps_raw_int_pack(0, 200, &mavMsg,
+    mavlink_msg_gps_raw_int_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // time_usec Timestamp (microseconds since UNIX epoch or microseconds since system boot)
         micros(),
         // fix_type 0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.
@@ -370,7 +371,7 @@ static void mavlinkSendPosition(void)
     mavlinkSerialWrite(mavBuffer, msgLength);
 
     // Global position
-    mavlink_msg_global_position_int_pack(0, 200, &mavMsg,
+    mavlink_msg_global_position_int_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // time_usec Timestamp (microseconds since UNIX epoch or microseconds since system boot)
         micros(),
         // lat Latitude in 1E7 degrees
@@ -393,7 +394,7 @@ static void mavlinkSendPosition(void)
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
 
-    mavlink_msg_gps_global_origin_pack(0, 200, &mavMsg,
+    mavlink_msg_gps_global_origin_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // Latitude (WGS84), expressed as * 1E7
         GPS_home_llh.lat,
         // Longitude (WGS84), expressed as * 1E7
@@ -410,7 +411,7 @@ static void mavlinkSendPosition(void)
 static void mavlinkSendAttitude(void)
 {
     uint16_t msgLength;
-    mavlink_msg_attitude_pack(0, 200, &mavMsg,
+    mavlink_msg_attitude_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // time_boot_ms Timestamp (milliseconds since system boot)
         millis(),
         // roll Roll angle (rad)
@@ -446,7 +447,7 @@ static void mavlinkSendHUDAndHeartbeat(void)
 
     mavAltitude = getEstimatedAltitudeCm() / 100.0f;
 
-    mavlink_msg_vfr_hud_pack(0, 200, &mavMsg,
+    mavlink_msg_vfr_hud_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // airspeed Current airspeed in m/s
         mavAirSpeed,
         // groundspeed Current ground speed in m/s
@@ -524,7 +525,7 @@ static void mavlinkSendHUDAndHeartbeat(void)
         mavSystemState = MAV_STATE_STANDBY;
     }
 
-    mavlink_msg_heartbeat_pack(0, 200, &mavMsg,
+    mavlink_msg_heartbeat_pack(MAVLINK_SYSTEM_ID, 200, &mavMsg,
         // type Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)
         mavSystemType,
         // autopilot Autopilot type / class. defined in MAV_AUTOPILOT ENUM


### PR DESCRIPTION
Resolved  issue in #14681. The telemetries data is unvisible in ELRS TX module.
- added nonzero (1) mavlink system ID
- added data packet counters for heartbeat, attitude and status packets in MAVKINK debug fields

The tests result:  the heartbeat and  attitude packets frequency is 5Hz, the status packet - 1Hz. The all are as expected.
But there are no telemetries data in TX.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry messages now include proper system and component identifiers so ground stations and multi‑vehicle setups recognize this vehicle reliably. No changes to telemetry content or behavior.

* **Chores**
  * Updated configuration submodule. No user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->