### PR TITLE
Added MAVLink telemetries battery status data send

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -548,7 +548,7 @@ static void mavlinkSendBatteryStatus(void)
 
     uint16_t voltages[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN];
     uint16_t voltagesExt[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_EXT_LEN];
-    memset(voltages, UINT16_MAX, sizeof(voltages));
+    memset(voltages, 0xff, sizeof(voltages));
     memset(voltagesExt, 0, sizeof(voltagesExt));
     if (isBatteryVoltageConfigured()) {
         uint8_t batteryCellCount = getBatteryCellCount();

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -552,7 +552,7 @@ static void mavlinkSendBatteryStatus(void)
     memset(voltagesExt, 0, sizeof(voltagesExt));
     if (isBatteryVoltageConfigured()) {
         uint8_t batteryCellCount = getBatteryCellCount();
-        if (batteryCellCount > 0 && telemetryConfig()->report_cell_voltage == true) {
+        if (batteryCellCount > 0 && telemetryConfig()->report_cell_voltage) {
             for (int cell=0; cell < batteryCellCount && cell < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN + MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_EXT_LEN; cell++) {
                 if (cell < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN) {
                     voltages[cell] = getBatteryAverageCellVoltage() * 10;

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -559,16 +559,16 @@ static void mavlinkSendBatteryStatus(void)
         voltages[0] = 0;
     }
 
-    // Battery current in centiamps, -1 if not available
-    int16_t currentBattery = -1;
+    // Battery amperage in centiamps (cA), -1 if not available
+    int16_t batteryAmperage = -1;
     if (isAmperageConfigured()) {
-        currentBattery = getAmperage(); // Already in cA (0.01A)
+        batteryAmperage = getAmperage(); // Already in cA (0.01A)
     }
 
     // mAh consumed, -1 if not available
-    int32_t currentConsumed = -1;
+    int32_t amperageConsumed = -1;
     if (isAmperageConfigured()) {
-        currentConsumed = getMAhDrawn(); // This is the key field for "Capa"
+        amperageConsumed = getMAhDrawn(); // This is the key field for "Capa"
     }
 
     // Battery percentage remaining
@@ -592,8 +592,8 @@ static void mavlinkSendBatteryStatus(void)
         0,                    // type: 0 = MAV_BATTERY_TYPE_UNKNOWN (could use MAV_BATTERY_TYPE_LIPO = 1)
         temperature,          // temperature: INT16_MAX = unknown
         voltages,             // voltages[10]: Cell voltages in mV
-        currentBattery,       // current_battery: Current in cA
-        currentConsumed,      // current_consumed: mAh drawn (CRITICAL for "Capa")
+        batteryAmperage,       // current_battery: Current in cA
+        amperageConsumed,      // current_consumed: mAh drawn (CRITICAL for "Capa")
         -1,                   // energy_consumed: -1 = not available (could calculate from Wh if needed)
         batteryRemaining,     // battery_remaining: Percentage 0-100
         0,                    // time_remaining: 0 = not calculated

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -563,8 +563,6 @@ static void mavlinkSendBatteryStatus(void)
         } else {
             voltages[0] = getBatteryVoltage() * 10;
         }
-    } else {
-        voltages[0] = 0;
     }
 
     // Battery amperage in centiamps (cA), -1 if not available

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -560,12 +560,10 @@ static void mavlinkSendBatteryStatus(void)
                     voltagesExt[cell - MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN] = getBatteryAverageCellVoltage() * 10;
                 }
             }
-        }
-        else {
+        } else {
             voltages[0] = getBatteryVoltage() * 10;
         }
-    }
-    else {
+    } else {
         voltages[0] = 0;
     }
 

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -559,7 +559,7 @@ static void mavlinkSendBatteryStatus(void)
         voltages[0] = 0;
     }
 
-    // Battery current in centiamps (cA), -1 if not available
+    // Battery current in centiamps, -1 if not available
     int16_t currentBattery = -1;
     if (isAmperageConfigured()) {
         currentBattery = getAmperage(); // Already in cA (0.01A)


### PR DESCRIPTION
## Description

This PR implements MAVLink battery status telemetry by adding the `BATTERY_STATUS` message to the telemetry stream.

### What Changed
- Added `mavlinkSendBatteryStatus()` function to send comprehensive battery data via MAVLink
- Configured battery status messages to be sent at 2 Hz on the EXTRA3 data stream
- Implemented support for reporting:
  - Total battery voltage (in millivolts)
  - Battery current (in centiamps, when amperage sensor is configured)
  - Consumed capacity (in mAh, when amperage sensor is configured)
  - Remaining battery percentage (calculated when voltage sensor is configured)
  - Per-cell voltage reporting (up to 14 cells)

### Why This Change
MAVLink ground stations and telemetry systems rely on standardized battery status messages to display real-time battery information to pilots. This implementation ensures Betaflight flight controllers can properly communicate battery data to MAVLink-compatible systems, improving situational awareness during flight.

### Testing
- Verified MAVLink telemetry communication with ground station
- Confirmed battery data is correctly reported and displayed

\![IMG_20251006_171740](https://github.com/user-attachments/assets/e657cde9-9044-436f-b989-785c89f36a1d)

---

<\!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds MAVLink battery status telemetry, including voltage, current, consumed mAh, and remaining percentage (when sensors are configured).
  * Supports per-cell voltage reporting for compatible setups.

* **Improvements**
  * Introduces a dedicated 2 Hz telemetry stream for battery data to improve update reliability and responsiveness.
  * Optimizes overall MAVLink telemetry streaming rates for better data delivery to ground stations.

<\!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds MAVLink BATTERY_STATUS telemetry on the EXTRA3 stream at 2 Hz, reporting pack voltage, per‑cell values (placeholders when not reported), extended cell data, current (centiamps), consumed mAh, remaining percentage, and temperature.
  * EXTRA2 telemetry remains documented at 10 Hz.
  * Unavailable sensor fields use defined default placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->