### PR TITLE
MAVLink serial RX providers improvement

### DIFF
--- a/src/main/rx/mavlink.c
+++ b/src/main/rx/mavlink.c
@@ -25,12 +25,33 @@
 
 #include "common/utils.h"
 
+#include "io/serial.h"
+
 #include "rx/rx.h"
 #include "rx/mavlink.h"
 
+#include "drivers/time.h"
+
+#include "build/debug.h"
+
+// mavlink library uses unnames unions that's causes GCC to complain if -Wpedantic is used
+// until this is resolved in mavlink library - ignore -Wpedantic for mavlink code
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include "common/mavlink.h"
+#pragma GCC diagnostic pop
+
 #define MAVLINK_CHANNEL_COUNT 18
+#define MAVLINK_BAUD_RATE_INDEX BAUD_460800
 static uint16_t mavlinkChannelData[MAVLINK_CHANNEL_COUNT];
 static bool frameReceived;
+
+static serialPort_t *serialPort = NULL;
+
+static mavlink_message_t mavRecvMsg;
+static mavlink_status_t mavRecvStatus;
+static uint8_t txbuff_free = 100;  // tx buffer space in %, start with empty buffer
+static bool txbuff_valid = false;
 
 void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg) {
     const uint16_t *channelsPtr = (uint16_t*)&msg->chan1_raw;
@@ -58,20 +79,67 @@ static float mavlinkReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t ch
     return mavlinkChannelData[channel];
 }
 
+static bool handleIncoming_RC_CHANNELS_OVERRIDE(void) {
+    mavlink_rc_channels_override_t msg;
+    mavlink_msg_rc_channels_override_decode(&mavRecvMsg, &msg);
+    mavlinkRxHandleMessage(&msg);
+    return true;
+}
+
+// Get RADIO_STATUS data
+static void handleIncoming_RADIO_STATUS(void)
+{
+    mavlink_radio_status_t msg;
+    mavlink_msg_radio_status_decode(&mavRecvMsg, &msg);
+    txbuff_valid = true;
+    txbuff_free = msg.txbuf;
+    DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 1, txbuff_free); // Last known TX buffer free space
+}
+
+STATIC_UNIT_TESTED void mavlinkDataReceive(uint16_t c, void *data)
+{
+    rxRuntimeState_t *const rxRuntimeState = (rxRuntimeState_t *const)data;
+    uint8_t result = mavlink_parse_char(0, c, &mavRecvMsg, &mavRecvStatus);
+    if (result == MAVLINK_FRAMING_OK) {
+        switch (mavRecvMsg.msgid) {
+        case MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE:
+            handleIncoming_RC_CHANNELS_OVERRIDE();
+            rxRuntimeState->lastRcFrameTimeUs = micros();
+            break;
+        case MAVLINK_MSG_ID_RADIO_STATUS:
+            handleIncoming_RADIO_STATUS();
+        }
+    }
+}
+
 bool mavlinkRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 {
     frameReceived = false;
+    for (int i = 0; i < MAVLINK_CHANNEL_COUNT; ++i) {
+        mavlinkChannelData[i] = rxConfig->midrc;;
+    }
 
     rxRuntimeState->channelData = mavlinkChannelData;
     rxRuntimeState->channelCount = MAVLINK_CHANNEL_COUNT;
     rxRuntimeState->rcReadRawFn = mavlinkReadRawRC;
     rxRuntimeState->rcFrameStatusFn = mavlinkFrameStatus;
 
-    for (int i = 0; i < MAVLINK_CHANNEL_COUNT; ++i) {
-        mavlinkChannelData[i] = rxConfig->midrc;;
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
     }
 
-    return true;
+    const uint32_t baudRate = baudRates[MAVLINK_BAUD_RATE_INDEX];
+    serialPort = openSerialPort(portConfig->identifier,
+        FUNCTION_RX_SERIAL,
+        mavlinkDataReceive,
+        rxRuntimeState,
+        baudRate,
+        MODE_RXTX,
+        (rxConfig->serialrx_inverted ? SERIAL_INVERTED : 0)
+    );
+
+    return serialPort != NULL;
 }
 
 #endif


### PR DESCRIPTION
MAVLink serial RX providers improvement. 
The PR #14681 released RC data reading in low priority telemetries task. It uses MAVLink telemetry setup, instead of standard RX serial switch on the configurators Port tab. 
This PR will resolve these issues.

This is a start point this work at moment. 
The MAVLink serial rx reads data by callback function now. The mode uses RX serial switch to enable it. The uart telemetries settings no need now.
The telemetries code was not changed til. It does not work in this PR.
The current PR state  is draft to check current methods RC data rate til.
The next improvement will the telemetry work in own low priority task.
The comparison RC data rate:
This PR:
![100Hz new](https://github.com/user-attachments/assets/f35d91eb-db98-466f-a402-428fe3074644)

Previous #14681 PR:
![50Hz olde](https://github.com/user-attachments/assets/1460b66b-5f58-420f-a793-927e19347755)

