### PR TITLE
Initialize 8 servos when available in the target (instead of 4)

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -77,6 +77,18 @@ void pgResetFn_servoConfig(servoConfig_t *servoConfig)
 #ifdef SERVO4_PIN
     servoConfig->dev.ioTags[3] = IO_TAG(SERVO4_PIN);
 #endif
+#ifdef SERVO5_PIN
+    servoConfig->dev.ioTags[4] = IO_TAG(SERVO5_PIN);
+#endif
+#ifdef SERVO6_PIN
+    servoConfig->dev.ioTags[5] = IO_TAG(SERVO6_PIN);
+#endif
+#ifdef SERVO7_PIN
+    servoConfig->dev.ioTags[6] = IO_TAG(SERVO7_PIN);
+#endif
+#ifdef SERVO8_PIN
+    servoConfig->dev.ioTags[7] = IO_TAG(SERVO8_PIN);
+#endif
 }
 
 PG_REGISTER_ARRAY(servoMixer_t, MAX_SERVO_RULES, customServoMixers, PG_SERVO_MIXER, 0);


### PR DESCRIPTION
Initializes up to 8 servos instead of 4 servos (when available in the target)

For example this target has 7 servos:
https://github.com/betaflight/config/blob/master/configs/SPEEDYBEEF405WING/config.h

Currently after flashing it shows only 4 in resources.
Support id:
ec9d6848-e2d2-4c6a-89d5-cdc1c9c73be6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded servo support up to 8 channels when compatible pins are available, enabling control of additional servos.
  * Automatically initializes extra servo outputs based on configuration; no action needed for existing setups.
  * Backwards compatible and non-disruptive, increasing flexibility for complex accessories (e.g., gimbals, retracts, payloads).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->