### PR TITLE
PICO IOConfigGPIO don't change output level when calling a second time

### DIFF
--- a/src/platform/PICO/io_pico.c
+++ b/src/platform/PICO/io_pico.c
@@ -139,11 +139,14 @@ SPI_IO_CS_HIGH_CFG (as defined)
     }
 
     uint16_t ioPin = IO_Pin(io);
-    bprintf("pico IOConfigGPIO pin %d for %d (0=in, 1=out)",ioPin, cfg);
-    if (gpio_get_function(ioPin) != GPIO_FUNC_NULL && gpio_get_function(ioPin) != GPIO_FUNC_SIO) {
-        bprintf("Warning: not redefining gpio function type from %d to SIO\n",gpio_get_function(ioPin));
-    } else {
+    bprintf("pico IOConfigGPIO gpio %d for 0x%02x (0=in, 1=out)",ioPin, cfg);
+
+    gpio_function_t currentFunction = gpio_get_function(ioPin);
+    if (currentFunction == GPIO_FUNC_NULL) {
+        // Select GPIO_FUNC_SIO, set direction to input, clear output value (set to low)
         gpio_init(ioPin);
+    } else if (currentFunction != GPIO_FUNC_SIO) {
+        bprintf("Warning: not redefining gpio function type from %d to SIO\n", currentFunction);
     }
 
     gpio_set_dir(ioPin, (cfg & 0x01)); // 0 = in, 1 = out


### PR DESCRIPTION
PICO IOConfigGPIO don't change output level when calling a second time to update direction / pullups.

Code was calling gpio_init, which set the output level to low, even when the pin was already initialised as gpio.

This was noticed when debugging a SPI device (SD card), which left the CSn low (device enabled) after initialisation, 
due to starting as an input, then changing to an output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures previously unconfigured pins initialize correctly, improving reliability on PICO devices.
  - Adds clearer detection and warnings when pins are in unexpected modes to prevent misconfiguration.
  - Refines log messages to display GPIO number and encoded value for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->