### PR TITLE
Update coding style guide URL in GH PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 2. Pull requests will only be accepted if they are opened against the `master` branch of our repository. Pull requests opened against other branches without prior consent from the maintainers will be closed;
 
-3. Please follow the coding style guidelines: https://github.com/betaflight/betaflight/blob/master/docs/development/CodingStyle.md
+3. Please follow the coding style guidelines: https://www.betaflight.com/docs/development/CodingStyle
 
 4. Keep your pull requests as small and concise as possible. One pull request should only ever add / update one feature. If the change that you are proposing has a wider scope, consider splitting it over multiple pull requests. In particular, pull requests that combine changes to features and one or more new targets are not acceptable.
 


### PR DESCRIPTION
In #12222 the documentation was removed from the main repo. However, the GitHub PR template was not updated and still references the old URL. This PR updates said URL.

Other things to consider, but not addressed in this PR:

* Item 7 still mentions Unified Targets;
* Item 8 references nightly builds, which hasn't been building for more than 3 years now.

If one could suggest some good lines for items 7 and 8 I could update them too :slightly_smiling_face: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the coding style guidelines link in the pull request template to point to the official website for clearer contributor guidance.
  * No functional or user-facing changes; this update only affects contributor documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->