### PR TITLE
Add SPI pins for larger H7 packages

### DIFF
--- a/src/platform/common/stm32/bus_spi_pinconfig.c
+++ b/src/platform/common/stm32/bus_spi_pinconfig.c
@@ -208,17 +208,13 @@ const spiHardware_t spiHardware[] = {
         .misoPins = {
             { DEFIO_TAG_E(PB14), GPIO_AF5_SPI2 },
             { DEFIO_TAG_E(PC2), GPIO_AF5_SPI2 },
-#if defined(STM32H7A3xx) || defined(STM32H7A3xxQ) || defined(STM32H743xx) || defined(STM32H750xx)
             { DEFIO_TAG_E(PI2), GPIO_AF5_SPI2 },
-#endif
         },
         .mosiPins = {
             { DEFIO_TAG_E(PB15), GPIO_AF5_SPI2 },
             { DEFIO_TAG_E(PC1), GPIO_AF5_SPI2 },
             { DEFIO_TAG_E(PC3), GPIO_AF5_SPI2 },
-#if defined(STM32H7A3xx) || defined(STM32H7A3xxQ) || defined(STM32H743xx) || defined(STM32H750xx)
             { DEFIO_TAG_E(PI3), GPIO_AF5_SPI2 },
-#endif
         },
         .rcc = RCC_APB1L(SPI2),
         //.dmaIrqHandler = DMA1_ST4_HANDLER,


### PR DESCRIPTION
On Discord, a user had some trouble getting SPI working for their UFBGA176+25 package H743 due to missing pins in `[bus_spi_pinconfig.c](https://github.com/betaflight/betaflight/blob/master/src/platform/common/stm32/bus_spi_pinconfig.c).

I assume when adding those pins, it was assumed manufacturers would only use LQFP100 or TFBGA100 packages, but I've seen people using larger package sizes twice now on Discord.

If it doesn't harm the overal code base, I'd say we simply add those other pins too.

Other arguments: PG9 was already present. PF9, with the same availability as the already present PF11, was missing, with PF7 and PF8 also being present.

(And yes, I still have left out one or two pins only available on the LQFP208 and TFBGA240+25 packages.. One could argue that if one wants to add the larger packages, one might as well add *ALL* the package pins. Wouldn't be too much trouble tho, but this is a good start I'd say.)

(The AF5 for the port G pins on SPI6 is correct. For some reason the other ports are on AF8, but those G port pins are AF5 again.. :roll_eyes:)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded SPI pin options for multiple STM32H7 variants, adding additional SCK/MISO/MOSI mappings for SPI1–SPI6. These new mappings are conditionally available on specific MCU variants, increasing board compatibility and routing flexibility while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->