### PR TITLE
Rename Configurator to App in PR Cloud build comment

### DIFF
--- a/.github/workflows/pr-cloud-comment.yml
+++ b/.github/workflows/pr-cloud-comment.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           message: |
             **Do you want to test this code? You can flash it directly from the Betaflight App:**
-            - Simply put `#${{ github.event.number }}` (this pull request number) in the `Select commit` field in the App Firmware Flasher tab (you need to `Enable expert mode`, `Show release candidates` and `Development`).
+            - Simply put `#${{ github.event.number }}` (this pull request number) in the `Select commit` field in the Firmware Flasher tab (you need to `Enable expert mode`, `Show release candidates` and `Development`).
 
             _**WARNING:** It may be unstable. Use only for testing!_
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated automated PR comment text to use the current product name ("Betaflight App") and renamed tab reference to "Firmware Flasher tab" to match updated terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->