### PR TITLE
Support for XMC flash chip XM25QH256B

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -136,6 +136,9 @@ struct {
     // BergMicro W25Q32
     // Datasheet: https://www.winbond.com/resource-files/w25q32jv%20dtr%20revf%2002242017.pdf?__locale=zh_TW
     { 0xE04016, 133, 50, 1024, 16 },
+    // XMC XM25QH256B
+    // Datasheet: https://www.xmcwh.com/uploads/499/XM25QU256B.pdf
+    { 0x206019, 166, 80, 8192, 16 },
     // End of list
     { 0x000000, 0, 0, 0, 0 }
 };


### PR DESCRIPTION
Adds support for the XM25QH256B flash chip.

I unfortunately didn't check if it was already supported before buying it for a DIY project. If you guys aren't comfortable adding support for random flash chips its fine, I can always keep building betaflight myself :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded hardware compatibility by adding support for an additional flash memory device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->