### PR TITLE
Support the “TO DO YAW_MOTORS_REVERSED”，Update mixer_init.c

### DIFF
--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -52,7 +52,11 @@ PG_REGISTER_WITH_RESET_FN(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 2);
 void pgResetFn_mixerConfig(mixerConfig_t *mixerConfig)
 {
     mixerConfig->mixerMode = DEFAULT_MIXER;
+#ifdef YAW_MOTORS_REVERSED
+    mixerConfig->yaw_motors_reversed = true;
+#else
     mixerConfig->yaw_motors_reversed = false;
+#endif
     mixerConfig->crashflip_motor_percent = 0;
 #ifdef USE_RACE_PRO
     mixerConfig->crashflip_rate = 30;


### PR DESCRIPTION
“TO DO YAW_MOTORS_REVERSED”
Simply add the "YAW_MOTORS_REVERSED" macro definition, with minimal code changes.

<img width="633" height="282" alt="image" src="https://github.com/user-attachments/assets/f4cf01bb-0717-41f1-acf6-b51dc16c39dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved yaw motor configuration initialization to properly respect motor reversal settings during system startup based on your flight controller configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->