### PR TITLE
Added flash driver def for Cypress S25FL128S.

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -133,7 +133,7 @@ struct {
     // Cypress S25FL128L
     // Datasheet: https://www.cypress.com/file/316171/download
     { 0x016018, 133, 50, 256, 256 },
-	// Cypress S25FL128S
+    // Cypress S25FL128S
     // Datasheet: https://www.infineon.com/row/public/documents/10/49/infineon-s25fl128s-s25fl256s-128-mb-16-mb-256-mb-32-mb-fl-s-flash-spi-multi-io-3-v-datasheet-en.pdf
     { 0x012018, 104, 50, 256, 256 },
     // BergMicro W25Q32


### PR DESCRIPTION
- Added flash driver definition for Cypress S25FL128S.
- Tested on custom board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Cypress S25FL128S flash devices.
  * Recognizes device characteristics enabling operation at higher SPI clock rates (up to 104 MHz) and up to 256 sectors for larger storage.
  * Datasheet reference included for device-specific behavior and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->