### PR TITLE
Remove erroneously committed SCEDEBUG stuff

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2161,10 +2161,6 @@ typedef enum {
 static ubxFrameParseState_e ubxFrameParseState = UBX_PARSE_PREAMBLE_SYNC_1;
 static uint16_t ubxFrameParsePayloadCounter;
 
-// SCEDEBUG To help debug which message is slow to process
-// static uint8_t lastUbxRcvMsgClass;
-// static uint8_t lastUbxRcvMsgID;
-
 // Combines message class & ID for a single value to switch on.
 #define CLSMSG(cls, msg) (((cls) << 8) | (msg))
 


### PR DESCRIPTION
I often add `SCEDEBUG` (my initials and `DEBUG`) as a comment on code I should remove before raising a PR, but this somehow slipped through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal debugging references from GPS parsing logic, streamlining the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->