### PR TITLE
Add MSP support for Attitude quaternions

### DIFF
--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -213,11 +213,12 @@
 #define MSP_CALCULATE_SIMPLIFIED_DTERM  144  // out message: Calculate D term filter values based on sliders without saving
 #define MSP_VALIDATE_SIMPLIFIED_TUNING  145  // out message: Returns array of true/false showing which simplified tuning groups match values
 
-// Additional non-MultiWii commands (150-166)
+// Additional non-MultiWii commands (150-167)
 #define MSP_STATUS_EX                   150  // out message: Cycletime, errors_count, CPU load, sensor present etc
 #define MSP_UID                         160  // out message: Unique device ID
 #define MSP_GPSSVINFO                   164  // out message: Get Signal Strength (only U-Blox)
 #define MSP_GPSSTATISTICS               166  // out message: Get GPS debugging data
+#define MSP_ATTITUDE_QUATERNION         167  // out message: Orientation quaternion components (w, x, y, z)
 
 // OSD specific commands (180-189)
 #define MSP_OSD_VIDEO_CONFIG            180  // out message: Get OSD video settings


### PR DESCRIPTION
## Problem
Currently only Euler angles available via MSP, which have gimbal lock issues and are less computationally efficient for many applications.

## Solution
Add MSP_ATTITUDE_QUATERNION message to expose flight controller's internal quaternion representation directly via MSP.

## Implementation
- New MSP message code 167: MSP_ATTITUDE_QUATERNION
- Transmits all four quaternion components (w, x, y, z) as unsigned 16-bit integers
- Uses scaling from float [-1, 1] range to unsigned [1, 65535] range with offset 32768
- Follows same normalization convention as blackbox (w always positive)
- MSP API version bumped to 1.48 as required by protocol

## Testing
- Verified correct encoding/decoding with companion Python library
- Confirmed quaternion normalization matches blackbox behavior
- Backward compatible - doesn't affect existing Euler angle messages

## Related Issue
Fixes #14759

**Checklist:**
- [x] Coding style guidelines followed
- [x] Single commit with descriptive message
- [x] API version updated
- [x] Changes are minimal and focused on one feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quaternion-based attitude data format for improved IMU representation
  * Added OSD video configuration commands for enhanced display control
  * Added display port and canvas control commands for flexible OSD rendering
  * Added commands to copy profiles and report transmitter info
  * Added beeper configuration options for audio customization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->