### PR TITLE
Revert "Enable SPI6 on H7"

### DIFF
--- a/src/platform/STM32/dma_reqmap_mcu.c
+++ b/src/platform/STM32/dma_reqmap_mcu.c
@@ -255,7 +255,7 @@ static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
     REQMAP_DIR(SPI, 5, SDO), // Not available in smaller packages
     REQMAP_DIR(SPI, 5, SDI), // ditto
     // REQMAP_DIR(SPI, 6, SDO), // SPI6 is on BDMA (todo)
-    // REQMAP_DIR(SPI, 6, SDO), // ditto
+    // REQMAP_DIR(SPI, 6, SDI), // ditto
 #endif // USE_SPI
 
 #ifdef USE_ADC


### PR DESCRIPTION
After finally checking on a real device found BDMA support has not been implemented on H7

- reverts betaflight/betaflight#14717



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unsupported SPI6 DMA request mappings and public entries, preventing attempts to use unavailable SPI6 DMA transfers and avoiding related misconfiguration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->