### PR TITLE
Implement BDMA for SPI6 on H7

### DIFF
--- a/src/platform/STM32/dma_reqmap_mcu.c
+++ b/src/platform/STM32/dma_reqmap_mcu.c
@@ -256,7 +256,7 @@ static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
     REQMAP_DIR(SPI, 4, SDI),
     REQMAP_DIR(SPI, 5, SDO), // Not available in smaller packages
     REQMAP_DIR(SPI, 5, SDI), // ditto
-    REQMAP_DIR(SPI, 6, SDO), // SPI6 is on BDMA
+    REQMAP_DIR(SPI, 6, SDO), // SPI6 uses BDMA
     REQMAP_DIR(SPI, 6, SDI), // ditto
 #endif // USE_SPI
 
@@ -371,6 +371,7 @@ static const dmaTimerMapping_t dmaTimerMapping[] = {
 #undef REQMAP_TIM
 
 #define DMA(d, s) { DMA_CODE(d, s, 0), (dmaResource_t *)DMA ## d ## _Stream ## s, 0 }
+#define BDMA_CH(c) { DMA_CODE(3, c, 0), (dmaResource_t *)BDMA_Channel ## c, 0 }
 
 static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
     DMA(1, 0),
@@ -389,9 +390,18 @@ static dmaChannelSpec_t dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS] = {
     DMA(2, 5),
     DMA(2, 6),
     DMA(2, 7),
+    BDMA_CH(0),
+    BDMA_CH(1),
+    BDMA_CH(2),
+    BDMA_CH(3),
+    BDMA_CH(4),
+    BDMA_CH(5),
+    BDMA_CH(6),
+    BDMA_CH(7),
 };
 
 #undef DMA
+#undef BDMA_CH
 
 #elif defined(STM32F4) || defined(STM32F7)
 

--- a/src/platform/STM32/dma_reqmap_mcu.h
+++ b/src/platform/STM32/dma_reqmap_mcu.h
@@ -21,8 +21,10 @@
 
 #pragma once
 
-#if defined(STM32H7) || defined(STM32G4)
-
+#if defined(STM32H7)
+#define MAX_PERIPHERAL_DMA_OPTIONS 24  // 16 DMA + 8 BDMA channels
+#define MAX_TIMER_DMA_OPTIONS 16
+#elif defined(STM32G4)
 #define MAX_PERIPHERAL_DMA_OPTIONS 16
 #define MAX_TIMER_DMA_OPTIONS 16
 #else

--- a/src/platform/STM32/dma_stm32h7xx.c
+++ b/src/platform/STM32/dma_stm32h7xx.c
@@ -52,6 +52,16 @@ dmaChannelDescriptor_t dmaDescriptors[DMA_LAST_HANDLER] = {
     DEFINE_DMA_CHANNEL(DMA2, 5, 38),
     DEFINE_DMA_CHANNEL(DMA2, 6, 48),
     DEFINE_DMA_CHANNEL(DMA2, 7, 54),
+
+    // BDMA channels
+    DEFINE_BDMA_CHANNEL(0,  0),
+    DEFINE_BDMA_CHANNEL(1,  4),
+    DEFINE_BDMA_CHANNEL(2,  8),
+    DEFINE_BDMA_CHANNEL(3, 12),
+    DEFINE_BDMA_CHANNEL(4, 16),
+    DEFINE_BDMA_CHANNEL(5, 20),
+    DEFINE_BDMA_CHANNEL(6, 24),
+    DEFINE_BDMA_CHANNEL(7, 28),
 };
 
 /*
@@ -74,9 +84,27 @@ DEFINE_DMA_IRQ_HANDLER(2, 5, DMA2_ST5_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 6, DMA2_ST6_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
+/*
+ * BDMA IRQ Handlers
+ */
+DEFINE_BDMA_IRQ_HANDLER(0, BDMA_CH0_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(1, BDMA_CH1_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(2, BDMA_CH2_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(3, BDMA_CH3_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(4, BDMA_CH4_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(5, BDMA_CH5_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(6, BDMA_CH6_HANDLER)
+DEFINE_BDMA_IRQ_HANDLER(7, BDMA_CH7_HANDLER)
+
 static void enableDmaClock(int index)
 {
-    RCC_ClockCmd(dmaDescriptors[index].dma == DMA1 ? RCC_AHB1(DMA1) : RCC_AHB1(DMA2), ENABLE);
+    if (dmaDescriptors[index].dma == DMA1) {
+        RCC_ClockCmd(RCC_AHB1(DMA1), ENABLE);
+    } else if (dmaDescriptors[index].dma == DMA2) {
+        RCC_ClockCmd(RCC_AHB1(DMA2), ENABLE);
+    } else if (dmaDescriptors[index].dma == (DMA_TypeDef *)BDMA) {
+        RCC_ClockCmd(RCC_AHB4(BDMA), ENABLE);
+    }
     // There seems to be no explicit control for DMAMUX1 clocking
 }
 

--- a/src/platform/STM32/mk/STM32H7.mk
+++ b/src/platform/STM32/mk/STM32H7.mk
@@ -49,6 +49,7 @@ STDPERIPH_SRC   = \
             stm32h7xx_hal_tim_ex.c \
             stm32h7xx_hal_uart.c \
             stm32h7xx_hal_uart_ex.c \
+            stm32h7xx_ll_bdma.c \
             stm32h7xx_ll_cordic.c \
             stm32h7xx_ll_crs.c \
             stm32h7xx_ll_dma.c \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BDMA (Basic DMA) support across STM32H7, G4, F4 and F7 lines
  * Exposed eight BDMA channels to DMA channel mappings for broader peripheral access

* **Refactor**
  * Reorganized DMA option branching to distinguish MCU variants
  * Adjusted peripheral and timer DMA option counts per variant for clearer allocation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->