### PR TITLE
feat(qspi): refactor/rename API to make intent more clear

### DIFF
--- a/src/main/drivers/bus_quadspi.h
+++ b/src/main/drivers/bus_quadspi.h
@@ -34,6 +34,11 @@
  * 2LINE uses D0, D1 (bidirectional).
  * 4LINE uses D0..D3 (bidirectional)
  *
+ * Each message (transmit or receive) has 3 parts: INSTRUCTION [ADDRESS] [DATA].
+ *
+ * The defined quadSpi[Transmit|Receive][111|114|444] define how many lines are used for each
+ * message.
+ *
  * See ST Micros' AN4760 "Quad-SPI (QSPI) interface on STM32 microcontrollers"
  */
 
@@ -42,6 +47,18 @@
 #if !(defined(STM32H7) || defined(STM32G4) || defined(PICO))
 #error Quad SPI unsupported on this MCU/platform
 #endif
+
+typedef enum {
+    QUADSPI_WIDTH_1_LINE = 1,
+    QUADSPI_WIDTH_2_LINES = 2,
+    QUADSPI_WIDTH_4_LINES = 4
+} QUADSPI_BusWidth;
+
+typedef struct QUADSPI_Widths {
+    QUADSPI_BusWidth Instruction;
+    QUADSPI_BusWidth Address;
+    QUADSPI_BusWidth Data;
+} QUADSPI_Widths;
 
 #define QUADSPI_IO_AF_BK_IO_CFG           IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, GPIO_NOPULL)
 #define QUADSPI_IO_AF_CLK_CFG             IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH, GPIO_NOPULL)
@@ -107,18 +124,13 @@ void quadSpiPreInit(void);
 bool quadSpiInit(quadSpiDevice_e device);
 void quadSpiSetDivisor(QUADSPI_TypeDef *instance, uint16_t divisor);
 
-bool quadSpiTransmit1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length);
-bool quadSpiReceive1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length);
-bool quadSpiReceive4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length);
+bool quadSpiTransmit111(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length);
+bool quadSpiTransmit114(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length);
+bool quadSpiTransmit444(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length);
 
-bool quadSpiInstructionWithData1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length);
-
-bool quadSpiReceiveWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length);
-bool quadSpiReceiveWithAddress4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length);
-bool quadSpiTransmitWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length);
-bool quadSpiTransmitWithAddress4LINES(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length);
-
-bool quadSpiInstructionWithAddress1LINE(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize);
+bool quadSpiReceive111(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length);
+bool quadSpiReceive114(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length);
+bool quadSpiReceive444(QUADSPI_TypeDef *instance, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length);
 
 //bool quadSpiIsBusBusy(SPI_TypeDef *instance);
 

--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -211,10 +211,10 @@ static bool flashQuadSpiInit(const flashConfig_t *flashConfig)
         bool status = false;
         switch (phase) {
         case TRY_1LINE:
-            status = quadSpiReceive1LINE(hqspi, FLASH_INSTRUCTION_RDID, 0, readIdResponse, 4);
+            status = quadSpiReceive111(hqspi, FLASH_INSTRUCTION_RDID, 0, 0, 0, readIdResponse, 4);
             break;
         case TRY_4LINE:
-            status = quadSpiReceive4LINES(hqspi, FLASH_INSTRUCTION_RDID, 2, readIdResponse, 3);
+            status = quadSpiReceive444(hqspi, FLASH_INSTRUCTION_RDID, 2, 0, 0, readIdResponse, 3);
             break;
         default:
             break;

--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -168,7 +168,7 @@ static uint8_t m25p16_readStatus(flashDevice_t *fdevice)
     } else {
 #ifdef USE_QUADSPI
         if (fdevice->io.mode == FLASHIO_QUADSPI) {
-            quadSpiReceive1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_READ_STATUS_REG, 0, &status, 1);
+            quadSpiReceive111(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_READ_STATUS_REG, 0, 0, 0, &status, 1);
         }
 #endif
     }
@@ -273,7 +273,7 @@ static void m25p16_configure(flashDevice_t *fdevice, uint32_t configurationFlags
         }
 #ifdef USE_QUADSPI
         else if (fdevice->io.mode == FLASHIO_QUADSPI) {
-            quadSpiTransmit1LINE(fdevice->io.handle.quadSpi, W25Q256_INSTRUCTION_ENTER_4BYTE_ADDRESS_MODE, 0, NULL, 0);
+            quadSpiTransmit111(fdevice->io.handle.quadSpi, W25Q256_INSTRUCTION_ENTER_4BYTE_ADDRESS_MODE, 0, 0, 0, NULL, 0);
         }
 #endif
     }
@@ -369,8 +369,8 @@ static void m25p16_eraseSectorQspi(flashDevice_t *fdevice, uint32_t address)
 {
     m25p16_waitForReady(fdevice);
 
-    quadSpiTransmit1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_WRITE_ENABLE, 0, NULL, 0);
-    quadSpiInstructionWithAddress1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_SECTOR_ERASE, 0, address, fdevice->isLargeFlash ? 32 : 24);
+    quadSpiTransmit111(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_WRITE_ENABLE, 0, 0, 0, NULL, 0);
+    quadSpiTransmit111(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_SECTOR_ERASE, 0, address, fdevice->isLargeFlash ? 32 : 24, NULL, 0);
 
     fdevice->couldBeBusy = true;
 }
@@ -401,8 +401,8 @@ static void m25p16_eraseCompletelyQspi(flashDevice_t *fdevice)
 {
     m25p16_waitForReady(fdevice);
 
-    quadSpiTransmit1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_WRITE_ENABLE, 0, NULL, 0);
-    quadSpiTransmit1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_BULK_ERASE, 0, NULL, 0);
+    quadSpiTransmit111(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_WRITE_ENABLE, 0, 0, 0, NULL, 0);
+    quadSpiTransmit111(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_BULK_ERASE, 0, 0, 0, NULL, 0);
 
     fdevice->couldBeBusy = true;
 }
@@ -542,9 +542,9 @@ static uint32_t m25p16_pageProgramContinueQspi(flashDevice_t *fdevice, uint8_t c
 
     m25p16_waitForReady(fdevice);
 
-    quadSpiTransmit1LINE(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_WRITE_ENABLE, 0, NULL, 0);
+    quadSpiTransmit111(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_WRITE_ENABLE, 0, 0, 0, NULL, 0);
 
-    quadSpiTransmitWithAddress4LINES(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_QPAGE_PROGRAM, 0,
+    quadSpiTransmit114(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_QPAGE_PROGRAM, 0,
                                      fdevice->currentWriteAddress, fdevice->isLargeFlash ? 32 : 24, pData, dataSize);
 
     fdevice->currentWriteAddress += dataSize;
@@ -612,7 +612,7 @@ static int m25p16_readBytesQspi(flashDevice_t *fdevice, uint32_t address, uint8_
 {
     m25p16_waitForReady(fdevice);
 
-    quadSpiReceiveWithAddress4LINES(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_QUAD_READ, M25P16_FAST_READ_DUMMY_CYCLES,
+    quadSpiReceive114(fdevice->io.handle.quadSpi, M25P16_INSTRUCTION_QUAD_READ, M25P16_FAST_READ_DUMMY_CYCLES,
                                     address, fdevice->isLargeFlash ? 32 : 24, buffer, length);
 
     return length;

--- a/src/main/drivers/flash/flash_w25q128fv.c
+++ b/src/main/drivers/flash/flash_w25q128fv.c
@@ -126,7 +126,7 @@ MMFLASH_CODE static void w25q128fv_performOneByteCommand(flashDeviceIO_t *io, ui
 {
 #if defined(USE_QUADSPI)
     QUADSPI_TypeDef *quadSpi = io->handle.quadSpi;
-    quadSpiTransmit1LINE(quadSpi, command, 0, NULL, 0);
+    quadSpiTransmit111(quadSpi, command, 0, 0, 0, NULL, 0);
 #elif defined(USE_OCTOSPI)
     OCTOSPI_TypeDef *octoSpi = io->handle.octoSpi;
     octoSpiTransmit1LINE(octoSpi, command, 0, NULL, 0);
@@ -139,7 +139,7 @@ MMFLASH_CODE static void w25q128fv_performCommandWithAddress(flashDeviceIO_t *io
 #if defined(USE_QUADSPI)
     QUADSPI_TypeDef *quadSpi = io->handle.quadSpi;
 
-    quadSpiInstructionWithAddress1LINE(quadSpi, command, 0, address & 0xffffff, W25Q128FV_ADDRESS_BITS);
+    quadSpiTransmit111(quadSpi, command, 0, address & 0xffffff, W25Q128FV_ADDRESS_BITS, NULL, 0);
 #elif defined(USE_OCTOSPI)
     OCTOSPI_TypeDef *octoSpi = io->handle.octoSpi;
 
@@ -158,7 +158,7 @@ MMFLASH_CODE static uint8_t w25q128fv_readRegister(flashDeviceIO_t *io, uint8_t 
 #if defined(USE_QUADSPI)
     QUADSPI_TypeDef *quadSpi = io->handle.quadSpi;
 
-    quadSpiReceive1LINE(quadSpi, command, 0, in, W25Q128FV_STATUS_REGISTER_BITS / 8);
+    quadSpiReceive111(quadSpi, command, 0, 0, 0, in, W25Q128FV_STATUS_REGISTER_BITS / 8);
 #elif defined(USE_OCTOSPI)
     OCTOSPI_TypeDef *octoSpi = io->handle.octoSpi;
 
@@ -173,7 +173,7 @@ static void w25q128fv_writeRegister(flashDeviceIO_t *io, uint8_t command, uint8_
 #if defined(USE_QUADSPI)
     QUADSPI_TypeDef *quadSpi = io->handle.quadSpi;
 
-    quadSpiTransmit1LINE(quadSpi, command, 0, &data, W25Q128FV_STATUS_REGISTER_BITS / 8);
+    quadSpiTransmit111(quadSpi, command, 0, 0, 0, &data, W25Q128FV_STATUS_REGISTER_BITS / 8);
 #elif defined(USE_OCTOSPI)
     OCTOSPI_TypeDef *octoSpi = io->handle.octoSpi;
 
@@ -376,9 +376,9 @@ MMFLASH_CODE static void w25q128fv_loadProgramData(flashDevice_t *fdevice, const
     QUADSPI_TypeDef *quadSpi = fdevice->io.handle.quadSpi;
 
 #ifdef USE_FLASH_WRITES_USING_4LINES
-    quadSpiTransmitWithAddress4LINES(quadSpi, W25Q128FV_INSTRUCTION_QUAD_PAGE_PROGRAM, 0, w25q128fvState.currentWriteAddress, W25Q128FV_ADDRESS_BITS, data, length);
+    quadSpiTransmit114(quadSpi, W25Q128FV_INSTRUCTION_QUAD_PAGE_PROGRAM, 0, w25q128fvState.currentWriteAddress, W25Q128FV_ADDRESS_BITS, data, length);
 #else
-    quadSpiTransmitWithAddress1LINE(quadSpi, W25Q128FV_INSTRUCTION_PAGE_PROGRAM, 0, w25q128fvState.currentWriteAddress, W25Q128FV_ADDRESS_BITS, data, length);
+    quadSpiTransmit111(quadSpi, W25Q128FV_INSTRUCTION_PAGE_PROGRAM, 0, w25q128fvState.currentWriteAddress, W25Q128FV_ADDRESS_BITS, data, length);
 #endif
 #elif defined(USE_OCTOSPI)
     OCTOSPI_TypeDef *octoSpi = fdevice->io.handle.octoSpi;
@@ -457,9 +457,9 @@ MMFLASH_CODE static int w25q128fv_readBytes(flashDevice_t *fdevice, uint32_t add
 #if defined(USE_QUADSPI)
     QUADSPI_TypeDef *quadSpi = fdevice->io.handle.quadSpi;
 #ifdef USE_FLASH_READS_USING_4LINES
-    bool status = quadSpiReceiveWithAddress4LINES(quadSpi, W25Q128FV_INSTRUCTION_FAST_READ_QUAD_OUTPUT, 8, address, W25Q128FV_ADDRESS_BITS, buffer, length);
+    bool status = quadSpiReceive114(quadSpi, W25Q128FV_INSTRUCTION_FAST_READ_QUAD_OUTPUT, 8, address, W25Q128FV_ADDRESS_BITS, buffer, length);
 #else
-    bool status = quadSpiReceiveWithAddress1LINE(quadSpi, W25Q128FV_INSTRUCTION_FAST_READ, 8, address, W25Q128FV_ADDRESS_BITS, buffer, length);
+    bool status = quadSpiReceive111(quadSpi, W25Q128FV_INSTRUCTION_FAST_READ, 8, address, W25Q128FV_ADDRESS_BITS, buffer, length);
 #endif
 #elif defined(USE_OCTOSPI)
     OCTOSPI_TypeDef *octoSpi = fdevice->io.handle.octoSpi;


### PR DESCRIPTION
This PR refactors/renames the QSPI api to be more clear about what the underlying bus widths will be used.

The new interface for qspi is:
```cpp
bool quadSpiTransmit111
bool quadSpiTransmit114
bool quadSpiTransmit444

bool quadSpiReceive111
bool quadSpiReceive114
bool quadSpiReceive444
```

from the previous
```cpp
bool quadSpiTransmit1LINE
bool quadSpiReceive1LINE
bool quadSpiReceive4LINES

bool quadSpiInstructionWithData1LINE

bool quadSpiReceiveWithAddress1LINE
bool quadSpiReceiveWithAddress4LINES
bool quadSpiTransmitWithAddress1LINE
bool quadSpiTransmitWithAddress4LINES

bool quadSpiInstructionWithAddress1LINE
```

where some were redundant and ambiguous in their functionality, which now are all accessed through a single api where the instruction, address and the data are all available to provide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Quad SPI driver consolidated into a unified, width-aware transfer API supporting 1/2/4‑line transfers. Legacy per-line interfaces were removed and replaced by new width-specific wrappers, simplifying command/address/data handling.
  * Flash read/write flows updated to use the unified transfer surface; observable behavior and higher-level features remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->