### PR TITLE
Fix QMC5883P detection

### DIFF
--- a/src/main/drivers/compass/compass_qmc5883.c
+++ b/src/main/drivers/compass/compass_qmc5883.c
@@ -194,16 +194,12 @@ static bool qmc5883Init(magDev_t *magDev)
         ack = ack && busWriteRegister(dev, QMC5883L_REG_RESET, 0x01);
         ack = ack && busWriteRegister(dev, QMC5883L_REG_CONF1, QMC5883L_MODE_CONTINUOUS | QMC5883L_ODR_200HZ | QMC5883L_OSR_512 | QMC5883L_RNG_8G);
     } else {
-        // For P variant we perform the special unlock/config writes here (retaining original behavior)
-        if (!busWriteRegister(dev, QMC5883P_REG_XYZ_UNLOCK, QMC5883P_XYZ_SIGN_CONFIG)) {
-            return false;
-        }
-        if (!busWriteRegister(dev, QMC5883P_REG_CONF1, QMC5883P_DEFAULT_CONF1)) {
-            return false;
-        }
-        if (!busWriteRegister(dev, QMC5883P_REG_CONF2, QMC5883P_DEFAULT_CONF2)) {
-            return false;
-        }
+        // Step 1: Write special XYZ sign configuration value to register 0x29
+        ack = ack && busWriteRegister(dev, QMC5883P_REG_XYZ_UNLOCK, QMC5883P_XYZ_SIGN_CONFIG);
+        // Step 2: Configure CONF1 register with continuous mode, 100Hz ODR, 8G range, and OSR1=8
+        ack = ack && busWriteRegister(dev, QMC5883P_REG_CONF1, QMC5883P_DEFAULT_CONF1);
+        // Step 3: Configure CONF2 register with OSR2=8 oversampling settings
+        ack = ack && busWriteRegister(dev, QMC5883P_REG_CONF2, QMC5883P_DEFAULT_CONF2);
     }
 
     if (!ack) {


### PR DESCRIPTION
Finally could test 5883P with a real device and needed to make a small adjustment in the code.
Tested with GEPRC M1025Q.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetometer initialization to perform explicit configuration writes with acknowledgment checks and to fail cleanly on write errors.
  * Simplified device detection to only verify chip identity and attach handlers, removing prior configuration writes from the detection path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->