### PR TITLE
accgyro: update icm40609 odr handling

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm40609.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm40609.c
@@ -227,7 +227,13 @@ typedef enum {
     ICM40609_ODR_CONFIG_COUNT
 } icm40609OdrConfig_e;
 
-static const uint8_t icm40609GyroOdrLut[ICM40609_ODR_CONFIG_COUNT] = {
+static const struct {
+    uint8_t gyroOdr;
+    uint8_t accOdr;
+    uint16_t rateHz;
+}  odrLut[] = {
+ [ICM40609_ODR_CONFIG_8K] = {  ICM40609_GYRO_ODR_8KHZ, ICM40609_ACCEL_ODR_8KHZ, 8000 }, 
+ ...
     [ICM40609_ODR_CONFIG_8K] = ICM40609_GYRO_ODR_8KHZ,
     [ICM40609_ODR_CONFIG_4K] = ICM40609_GYRO_ODR_4KHZ,
     [ICM40609_ODR_CONFIG_2K] = ICM40609_GYRO_ODR_2KHZ,


### PR DESCRIPTION
I used Codex to look at the drivers and make recommendations and updates based on our successful implementation of the 42688. There are the results - draft PR for discussion:

- Added ODR/sample-rate LUTs keyed from mpuDividerDrops to pick 8k/4k/2k/1k configs for both gyro and accel, and set gyroSampleRateHz/accSampleRateHz, gyroRateKHz, and gyroShortPeriod accordingly.
- Uses the selected ODRs when programming GYRO/ACCEL CONFIG registers instead of hard-coding 8 kHz/1 kHz.
- Leaves the UI filter in the low-latency path and adjusts AAF cutoffs (258/536 Hz) so AAF provides the main bandwidth;
- disables the gyro notch and HPF so the AAF is the primary shaping; accel AAF fixed to 258 Hz.
- Adds missing utils.h/system.h includes for llog2/timing helpers.

Why: keep device ODR in sync with configured decimation, set correct reported sample rates/periods for downstream code, and rely on AAF for cutoff instead of stacking extra filters.