### PR TITLE
Fix detection for QMC5883L using mode mask

### DIFF
--- a/src/main/drivers/compass/compass_qmc5883.c
+++ b/src/main/drivers/compass/compass_qmc5883.c
@@ -57,6 +57,7 @@
 // Sensor operation modes
 #define QMC5883L_MODE_STANDBY           0x00
 #define QMC5883L_MODE_CONTINUOUS        0x01
+#define QMC5883L_MODE_MASK              0x03
 
 #define QMC5883L_RNG_2G                 (0x00 << 4)
 #define QMC5883L_RNG_8G                 (0x01 << 4)
@@ -303,7 +304,7 @@ static bool qmc5883lDetect(magDev_t *magDev)
         // Should be in standby mode after soft reset and sensor is really present
         // Reading ChipID of 0xFF alone is not sufficient to be sure the QMC is present
         ack = busReadRegisterBuffer(dev, QMC5883L_REG_CONF1, &sig, 1);
-        if (ack && ((sig & 0x03) != QMC5883L_MODE_STANDBY)) {
+        if (ack && ((sig & QMC5883L_MODE_MASK) != QMC5883L_MODE_STANDBY)) {
             return false;
         }
 


### PR DESCRIPTION
- resolves #14721

<img width="751" height="401" alt="image" src="https://github.com/user-attachments/assets/214fa6c2-520d-44c6-bcab-40e98cd3c266" />

- reference: https://www.tinytronics.nl/image/data/Producten/Sensoren/Magnetisch%20veld/Datasheet-QMC5883L-1.0%20.pdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made QMC5883L compass sensor detection more robust by using a tolerant bit-masked check for the standby state, improving reliability and compatibility across hardware variants and device revisions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->