### PR TITLE
faster cos and sin method

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -187,8 +187,8 @@ FAST_CODE void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint
 {
     // setup variables
     const float omega = 2.0f * M_PIf * filterFreq * refreshRate * 0.000001f;
-    const float sn = sin_approx(omega);
-    const float cs = cos_approx(omega);
+    float sn, cs;
+    sincosf_approx(omega, &sn, &cs);
     const float alpha = sn / (2.0f * Q);
 
     switch (filterType) {

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -29,12 +29,12 @@
 #define power5(x) ((x)*(x)*(x)*(x)*(x))
 
 // Undefine this for use libc sinf/cosf. Keep this defined to use fast sin/cos approximations
-#define FAST_MATH             // order 9 approximation
-#define VERY_FAST_MATH        // order 7 approximation
+#define FAST_MATH
 
 // Use floating point M_PI instead explicitly.
 #define M_PIf       3.14159265358979323846f
 #define M_EULERf    2.71828182845904523536f
+#define INV_PIO2    (2.0f / M_PIf)
 
 #define RAD    (M_PIf / 180.0f)
 #define DEGREES_TO_DECIDEGREES(angle) ((angle) * 10)
@@ -116,9 +116,10 @@ float quickMedianFilter5f(const float * v);
 float quickMedianFilter7f(const float * v);
 float quickMedianFilter9f(const float * v);
 
-#if defined(FAST_MATH) || defined(VERY_FAST_MATH)
+#if defined(FAST_MATH)
 float sin_approx(float x);
 float cos_approx(float x);
+void sincosf_approx(float x, float *out_s, float *out_c);
 float atan2_approx(float y, float x);
 float acos_approx(float x);
 float asin_approx(float x);
@@ -129,6 +130,7 @@ float pow_approx(float a, float b);
 #else
 #define sin_approx(x)       sinf(x)
 #define cos_approx(x)       cosf(x)
+#define sincosf_approx(x, *out_s, *out_c) sincosf(x, *out_s, *out_c)
 #define atan2_approx(y,x)   atan2f(y,x)
 #define acos_approx(x)      acosf(x)
 #define tan_approx(x)       tanf(x)

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -130,7 +130,12 @@ float pow_approx(float a, float b);
 #else
 #define sin_approx(x)       sinf(x)
 #define cos_approx(x)       cosf(x)
-#define sincosf_approx(x, *out_s, *out_c) sincosf(x, *out_s, *out_c)
+// slower non fast math version
+static inline void sincosf_approx(float x, float *out_s, float *out_c)
+{
+    *out_s = sinf(x);
+    *out_c = cosf(x);
+}
 #define atan2_approx(y,x)   atan2f(y,x)
 #define acos_approx(x)      acosf(x)
 #define tan_approx(x)       tanf(x)

--- a/src/main/common/vector.c
+++ b/src/main/common/vector.c
@@ -101,8 +101,10 @@ vector2_t *vector2Normalize(vector2_t *result, const vector2_t *v)
 vector2_t *vector2Rotate(vector2_t *result, const vector2_t *v, const float angle)
 {
     vector2_t tmp;
-    tmp.x = v->x * cos_approx(angle) - v->y * sin_approx(angle);
-    tmp.y = v->x * sin_approx(angle) + v->y * cos_approx(angle);
+    float sin, cos;
+    sincosf_approx(angle, &sin, &cos);
+    tmp.x = v->x * cos - v->y * sin;
+    tmp.y = v->x * sin + v->y * cos;
     *result = tmp;
     return result;
 }
@@ -211,12 +213,14 @@ vector3_t *matrixTrnVectorMul(vector3_t *result, const matrix33_t *mat, const ve
 
 matrix33_t *buildRotationMatrix(matrix33_t *result, const fp_angles_t *rpy)
 {
-    const float cosx = cos_approx(rpy->angles.roll);
-    const float sinx = sin_approx(rpy->angles.roll);
-    const float cosy = cos_approx(rpy->angles.pitch);
-    const float siny = sin_approx(rpy->angles.pitch);
-    const float cosz = cos_approx(rpy->angles.yaw);
-    const float sinz = sin_approx(rpy->angles.yaw);
+    float cosx, sinx;
+    sincosf_approx(rpy->angles.roll, &sinx, &cosx);
+
+    float cosy, siny;
+    sincosf_approx(rpy->angles.pitch, &siny, &cosy);
+
+    float cosz, sinz;
+    sincosf_approx(rpy->angles.yaw, &sinz, &cosz);
 
     result->m[0][X] = cosz * cosy;
     result->m[0][Y] = -cosy * sinz;
@@ -238,8 +242,8 @@ vector3_t *applyRotationMatrix(vector3_t *v, const matrix33_t *rotationMatrix)
 
 matrix33_t *yawToRotationMatrixZ(matrix33_t *result, const float yaw)
 {
-    const float sinYaw = sin_approx(yaw);
-    const float cosYaw = cos_approx(yaw);
+    float sinYaw, cosYaw;
+    sincosf_approx(yaw, &sinYaw, &cosYaw);
 
     result->m[0][0] = cosYaw;
     result->m[0][1] = -sinYaw;

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -270,7 +270,7 @@ static void scaleRawSetpointToFpvCamAngle(void)
 
     if (lastFpvCamAngleDegrees != rxConfig()->fpvCamAngleDegrees) {
         lastFpvCamAngleDegrees = rxConfig()->fpvCamAngleDegrees;
-        sincosf_approx(rxConfig()->fpvCamAngleDegrees, &sinFactor, &cosFactor);
+        sincosf_approx(DEGREES_TO_RADIANS(rxConfig()->fpvCamAngleDegrees), &sinFactor, &cosFactor);
     }
 
     float roll = rawSetpoint[ROLL];

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -265,13 +265,12 @@ static void scaleRawSetpointToFpvCamAngle(void)
 {
     //recalculate sin/cos only when rxConfig()->fpvCamAngleDegrees changed
     static uint8_t lastFpvCamAngleDegrees = 0;
-    static float cosFactor = 1.0f;
-    static float sinFactor = 0.0f;
+    float cosFactor = 1.0f;
+    float sinFactor = 0.0f;
 
     if (lastFpvCamAngleDegrees != rxConfig()->fpvCamAngleDegrees) {
         lastFpvCamAngleDegrees = rxConfig()->fpvCamAngleDegrees;
-        cosFactor = cos_approx(rxConfig()->fpvCamAngleDegrees * RAD);
-        sinFactor = sin_approx(rxConfig()->fpvCamAngleDegrees * RAD);
+        sincosf_approx(rxConfig()->fpvCamAngleDegrees, &sinFactor, &cosFactor);
     }
 
     float roll = rawSetpoint[ROLL];

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1050,6 +1050,11 @@ TEST(ArmingPreventionTest, Paralyze)
 
 // STUBS
 extern "C" {
+    void sincosf_approx(float x, float *out_s, float *out_c) {
+        *out_s = sin_approx(x);
+        *out_c = cos_approx(x);
+    }
+
     uint32_t micros(void) { return simulationTime; }
     uint32_t millis(void) { return micros() / 1000; }
     bool isRxReceivingSignal(void) { return simulationHaveRx; }

--- a/src/test/unit/maths_unittest.cc
+++ b/src/test/unit/maths_unittest.cc
@@ -213,7 +213,7 @@ TEST(MathsUnittest, TestFastTrigonometrySinCos)
         sinError = MAX(sinError, fabs(approxResult - libmResult));
     }
     printf("sin_approx maximum absolute error = %e\n", sinError);
-    EXPECT_LE(sinError, 3e-6);
+    EXPECT_LE(sinError, 3.2e-6);
 
     double cosError = 0;
     for (float x = -10 * M_PI; x < 10 * M_PI; x += M_PI / 300) {


### PR DESCRIPTION
Thanks to @ledvinap for the code. I finally got around to implementing it. This should make sine and cosine faster with little to no accuracy hit. It also makes when sine and cosine are both calculated much faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster trigonometric computations improve runtime for rotation, sensor, and flight-control math.
* **Accuracy**
  * Reduced numerical error in sine/cosine evaluations, enhancing stability of orientation and control.
* **Tests**
  * Unit tests adjusted for updated numerical tolerances and to support the combined trig implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->