### PR TITLE
YAW_MOTORS_REVERSED now defined as bool (1 or 0)

### DIFF
--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -47,16 +47,18 @@
 
 #include "mixer_init.h"
 
+#ifndef YAW_MOTORS_REVERSED
+#define YAW_MOTORS_REVERSED 0
+#endif
+
 PG_REGISTER_WITH_RESET_FN(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 2);
 
 void pgResetFn_mixerConfig(mixerConfig_t *mixerConfig)
 {
     mixerConfig->mixerMode = DEFAULT_MIXER;
-#ifdef YAW_MOTORS_REVERSED
-    mixerConfig->yaw_motors_reversed = true;
-#else
-    mixerConfig->yaw_motors_reversed = false;
-#endif
+
+    mixerConfig->yaw_motors_reversed = YAW_MOTORS_REVERSED;
+
     mixerConfig->crashflip_motor_percent = 0;
 #ifdef USE_RACE_PRO
     mixerConfig->crashflip_rate = 30;


### PR DESCRIPTION
As per the label on the tin. Using the definition of 1 or 0 for enabling or disabling the reversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified yaw motor configuration initialization logic for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->