### PR TITLE
Fix openEscSerial

### DIFF
--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -641,10 +641,6 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
 
     if (mode != PROTOCOL_KISSALL) {
 
-        if (escSerialConfig()->ioTag == IO_TAG_NONE) {
-            return NULL;
-        }
-
         const ioTag_t tag = motorConfig->ioTags[output];
         const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, 0);
 
@@ -665,18 +661,27 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
         // this prevents a null-pointer dereference in __HAL_TIM_CLEAR_FLAG called by timerChClearCCFlag and similar accesses of timerHandle without the Instance being configured first.
         timerConfigure(escSerial->rxTimerHardware, 0xffff, 1);
 
-        escSerial->txTimerHardware = timerAllocate(escSerialConfig()->ioTag, OWNER_MOTOR, 0);
-        if (escSerial->txTimerHardware == NULL) {
-            return NULL;
-        }
+        // Allocate separate TX pin if configured, otherwise use RX pin for both TX and RX
+        if (escSerialConfig()->ioTag != IO_TAG_NONE) {
+            escSerial->txTimerHardware = timerAllocate(escSerialConfig()->ioTag, OWNER_MOTOR, 0);
+            if (escSerial->txTimerHardware == NULL) {
+                return NULL;
+            }
 
 #ifdef USE_HAL_DRIVER
-        escSerial->txTimerHandle = timerFindTimerHandle(escSerial->txTimerHardware->tim);
+            escSerial->txTimerHandle = timerFindTimerHandle(escSerial->txTimerHardware->tim);
 #endif
 
-        // Workaround to ensure that the timerHandle is configured before use, timer will be reconfigured to a different frequency below
-        // this prevents a null-pointer dereference in __HAL_TIM_CLEAR_FLAG called by timerChClearCCFlag and similar accesses of timerHandle without the Instance being configured first.
-        timerConfigure(escSerial->txTimerHardware, 0xffff, 1);
+            // Workaround to ensure that the timerHandle is configured before use, timer will be reconfigured to a different frequency below
+            // this prevents a null-pointer dereference in __HAL_TIM_CLEAR_FLAG called by timerChClearCCFlag and similar accesses of timerHandle without the Instance being configured first.
+            timerConfigure(escSerial->txTimerHardware, 0xffff, 1);
+        } else {
+            // No separate TX pin configured - use RX pin for both TX and RX (fallback mode)
+            escSerial->txTimerHardware = escSerial->rxTimerHardware;
+#ifdef USE_HAL_DRIVER
+            escSerial->txTimerHandle = escSerial->rxTimerHandle;
+#endif
+        }
     }
 
     escSerial->mode = mode;


### PR DESCRIPTION
- fixes #14427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Serial ESC Driver Improvement** – Removed hard failure when dedicated TX timer is unavailable. Added fallback mechanism that automatically reuses the RX timer for TX operations, enabling support for additional hardware configurations and improving driver robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->