### PR TITLE
>>>AT32F435XX cannot use USB<<<Don't review, don't merge.

### DIFF
--- a/src/platform/AT32/serial_usb_vcp_at32f4.c
+++ b/src/platform/AT32/serial_usb_vcp_at32f4.c
@@ -509,6 +509,7 @@ void usbVcpInit(void)
 
 serialPort_t *usbVcpOpen(void)
 {
+    usbVcpInit();
     vcpPort_t *s = &vcpPort;
     s->port.vTable = usbVTable;
     return &s->port;


### PR DESCRIPTION
I found that after updating the AT32F435XX to the "2025.12-RC3" version, the USB connection to the "Configuration" ground station fails, while it worked normally in the "2025.12-RC2" version and earlier. This is an emergency test！！！




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB serial device initialization to ensure proper setup when establishing connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->