### PR TITLE
Added estimation of AMSL altitude in case of loss GPS fix during flight

### DIFF
--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -239,7 +239,16 @@ int32_t getEstimatedAltitudeCm(void)
 #ifdef USE_GPS
 float getAltitudeAsl(void)
 {
-    return STATE(GPS_FIX) ? gpsSol.llh.altCm : GPS_home_llh.altCm + getEstimatedAltitudeCm();
+    if (STATE(GPS_FIX)) {
+        return gpsSol.llh.altCm;
+    }
+
+    // Optional: only use home AMSL if home is known; otherwise fall back to relative altitude.
+    if (STATE(GPS_FIX_HOME)) { // or an equivalent "home is valid" check if available
+        return GPS_home_llh.altCm + getEstimatedAltitudeCm();
+    }
+
+    return getEstimatedAltitudeCm();
 }
 #endif
 

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -239,7 +239,7 @@ int32_t getEstimatedAltitudeCm(void)
 #ifdef USE_GPS
 float getAltitudeAsl(void)
 {
-    return gpsSol.llh.altCm;
+    return STATE(GPS_FIX) ? gpsSol.llh.altCm : GPS_home_llh.altCm + getEstimatedAltitudeCm();
 }
 #endif
 

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -243,11 +243,12 @@ float getAltitudeAsl(void)
         return gpsSol.llh.altCm;
     }
 
-    // Optional: only use home AMSL if home is known; otherwise fall back to relative altitude.
-    if (STATE(GPS_FIX_HOME)) { // or an equivalent "home is valid" check if available
-        return GPS_home_llh.altCm + getEstimatedAltitudeCm();
+    // Only use home AMSL if home is known
+    if (STATE(GPS_FIX_HOME)) {
+        return (float)GPS_home_llh.altCm + (float)getEstimatedAltitudeCm();
     }
 
+    // Otherwise fall back to relative altitude
     return getEstimatedAltitudeCm();
 }
 #endif

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -395,6 +395,7 @@ extern "C" {
     mag_t mag;
 
     gpsSolutionData_t gpsSol;
+    gpsLocation_t GPS_home_llh;
 
     uint8_t debugMode;
     int16_t debug[DEBUG16_VALUE_COUNT];


### PR DESCRIPTION
The current getAltitudeAsl function uses GPS altitude as AMSL.
It works when GPS is fixed only.
This PR improves AMSL altitude estimation. When there is no GPS fix, then AMSL is computed as sum of home point altitude and relative altitude. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Altitude reporting now falls back to a stored home reference plus estimated altitude when a full GPS fix is unavailable, improving altitude stability during partial or lost GPS signal.

* **Tests**
  * Unit tests updated to include a home-location stub to validate the new fallback altitude behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->