### PR TITLE
cli: strToPin: handle Port I

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5308,7 +5308,8 @@ static bool strToPin(char *ptr, ioTag_t *tag)
         return true;
     } else {
         const unsigned port = (*ptr >= 'a') ? *ptr - 'a' : *ptr - 'A';
-        if (port < 8) {
+        // Ports A through I
+        if (port < 9) {
             ptr++;
 
             char *end;


### PR DESCRIPTION
I was unable to assign Servos to channels on `Port I`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Port support has been expanded to include port I. Users can now configure and utilize port I in addition to the previously available ports A through H. This expansion provides increased flexibility for hardware configurations and enables seamless access to additional device connectivity options, supporting more advanced system setups and use cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->