### PR TITLE
fix bug in crashflip auto rearm mode 

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -294,6 +294,10 @@ if (crashFlipModeActive) {
             // tell disarm() that this was not a user generated disarm
             // also clear the flag in rc_controls so that it will only be true when the pilot makes a new user manual disarm
             disarm(DISARM_REASON_CRASHFLIP); // stop the motors, revert crashflipMode and set motor direction normal
+        } else {
+            // we are in auto re-arm mode, terminate crashflip mode and set motor direction normal
+            setMotorSpinDirection(DSHOT_CMD_SPIN_DIRECTION_NORMAL);
+            crashFlipModeActive = false;
         }
     }
 }


### PR DESCRIPTION
Users - thanks Misza - reported failure to auto-re-arm  in RC3, after reverting the crashflip switch following a successful flip.
This PR ensures that when the switch is reverted, while armed, and when auto mode is enabled, that crashflipMode  will terminate and motor direction will be restored to normal. There is no disarm at this time, so the user should just revert the crashflip switch and take off.

I'm not sure how I missed this previously in #14777, which seemed to work fine.
Apologies. The solution seems obvious.

Keen to get confirmationthat the problem is now fixed. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic re-arm functionality for crashflip mode, allowing the system to safely reset motor control and exit crashflip automatically when the feature is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->