### PR TITLE
FIX: Return initialisation to exact order for AT32

### DIFF
--- a/src/main/drivers/usb_msc.h
+++ b/src/main/drivers/usb_msc.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-void mscInit(void);
+void mscButtonInit(void);
 bool mscCheckBootAndReset(void);
 uint8_t mscStart(void);
 bool mscCheckButton(void);

--- a/src/main/drivers/usb_msc_common.c
+++ b/src/main/drivers/usb_msc_common.c
@@ -53,7 +53,7 @@
 static IO_t mscButton;
 static timeMs_t lastActiveTimeMs = 0;
 
-void mscInit(void)
+void mscButtonInit(void)
 {
     if (usbDevConfig()->mscButtonPin) {
         mscButton = IOGetByTag(usbDevConfig()->mscButtonPin);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -271,10 +271,6 @@ static void sdCardAndFSInit(void)
 
 void initPhase1(void)
 {
-#if SERIAL_PORT_COUNT > 0
-    printfSerialInit();
-#endif
-
     // Initialize task data as soon as possible. Has to be done before tasksInit(),
     // and any init code that may try to modify task behaviour before tasksInit().
     tasksInitData();
@@ -580,7 +576,6 @@ void initMsc(void)
 {
 /* MSC mode will start after init, but will not allow scheduler to run,
  *  so there is no bottleneck in reading and writing data */
-    mscInit();
     ledInit(statusLedConfig());
 
 #ifdef USE_SDCARD
@@ -607,7 +602,7 @@ void initMsc(void)
     spiInitBusDMA();
 #endif
     if (mscStart() == 0) {
-         mscWaitForButton();
+        mscWaitForButton();
     } else {
         systemResetFromMsc();
     }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -36,6 +36,10 @@
 #include "usb/usb_cdc.h"
 #endif
 
+#ifdef USE_USB_MSC
+#include "drivers/usb_msc.h"
+#endif
+
 #include "scheduler/scheduler.h"
 
 void run(void);
@@ -49,22 +53,33 @@ int main(int argc, char * argv[])
     UNUSED(argv);
 #endif
 
+#if SERIAL_PORT_COUNT > 0
+    printfSerialInit();
+#endif
+
     // Do basic system initialisation including multicore support if applicable
     systemInit();
-
-#ifdef USE_USB_MSC
-    if (checkMsc()) {
-        // MSC mode so boot using single core
-        initPhase1();
-        initPhase2();
-        initMsc();
-        // Never returns
-    }
-#endif
 
 #ifdef USE_MULTICORE
     // Perform early initialisation prior to USB
     multicoreExecuteBlocking(initPhase1);
+
+    // Now perform the core initialisation
+    multicoreExecuteBlocking(initPhase2);
+#else
+    initPhase1();
+    initPhase2();
+#endif
+
+#ifdef USE_USB_MSC
+    mscButtonInit();
+    if (checkMsc()) {
+        // MSC mode TODO: boot using single core
+        initMsc();
+        // Never returns (but just in case...)
+        return 0;
+    }
+#endif
 
 #ifdef USE_VCP
     // initialise the USB CDC interface using core 0 all USB code, including
@@ -72,17 +87,10 @@ int main(int argc, char * argv[])
     usbVcpInit();
 #endif
 
-    // Now perform the core initialisation
-    multicoreExecuteBlocking(initPhase2);
-
+#ifdef USE_MULTICORE
     // Now perform the final initialisation
     multicoreExecuteBlocking(initPhase3);
 #else
-    initPhase1();
-#ifdef USE_VCP
-    usbVcpInit();
-#endif
-    initPhase2();
     initPhase3();
 #endif
 


### PR DESCRIPTION
TODO: PICO will require single core for MSC?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized system initialization sequence for optimized multicore and USB Mass Storage support
  * Improved serial port initialization timing during startup
  * Enhanced Mass Storage Class initialization workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->