### PR TITLE
PICO update default traced functions after multicore init changes.

### DIFF
--- a/src/platform/PICO/mk/PICO_trace.mk
+++ b/src/platform/PICO/mk/PICO_trace.mk
@@ -5,7 +5,7 @@
 # Enable by setting PICO_TRACE variable in make, e.g. by export PICO_TRACE=1; make ...
 #
 PICO_WRAPPED_FUNCTIONS = main
-PICO_WRAPPED_FUNCTIONS += init initEEPROM isEEPROMVersionValid resetEEPROM writeUnmodifiedConfigToEEPROM resetConfig pgResetAll
+PICO_WRAPPED_FUNCTIONS += initPhase1 initPhase2 initPhase3 initEEPROM isEEPROMVersionValid resetEEPROM writeUnmodifiedConfigToEEPROM resetConfig pgResetAll
 PICO_TRACE_LD_FLAGS += $(foreach fn, $(PICO_WRAPPED_FUNCTIONS), -Wl,--wrap=$(fn))
 PICO_TRACE_SRC += PICO/pico_trace.c
 

--- a/src/platform/PICO/pico_trace.c
+++ b/src/platform/PICO/pico_trace.c
@@ -97,7 +97,9 @@ int WRAPPER_FUNC(main)(int argc, char * argv[])
 
 
 // remember to add to PICO_WRAPPED_FUNCTIONS in PICO_trace.mk
-TRACEvoidvoid(init)
+    TRACEvoidvoid(initPhase1)
+    TRACEvoidvoid(initPhase2)
+    TRACEvoidvoid(initPhase3)
     TRACEvoidvoid(initEEPROM)
     TRACEvoidvoid(isEEPROMVersionValid)
     TRACEvoidvoid(writeUnmodifiedConfigToEEPROM)


### PR DESCRIPTION
PICO update default traced functions after multicore init changes.

Update list of functions to be wrapped, for trace of entry and exit when building with PICO_TRACE.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Split the initialization tracing mechanism into three separate phase markers (initPhase1, initPhase2, initPhase3) instead of a single initialization trace point.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->