### PR TITLE
Fix error in blackbox.c when building without LTO

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1952,11 +1952,11 @@ static void blackboxCheckAndLogFlightMode(void)
 {
     // Use != so that we can still detect a change if the counter wraps
     if (memcmp(&rcModeActivationMask, &blackboxLastFlightModeFlags, sizeof(blackboxLastFlightModeFlags))) {
-        flightLogEvent_flightMode_t eventData; // Add new data for current flight mode flags
-        eventData.lastFlags = blackboxLastFlightModeFlags;
+        flightLogEventData_t eventData; // Add new data for current flight mode flags
+        eventData.flightMode.lastFlags = blackboxLastFlightModeFlags;
         memcpy(&blackboxLastFlightModeFlags, &rcModeActivationMask, sizeof(blackboxLastFlightModeFlags));
-        memcpy(&eventData.flags, &rcModeActivationMask, sizeof(eventData.flags));
-        blackboxLogEvent(FLIGHT_LOG_EVENT_FLIGHTMODE, (flightLogEventData_t *)&eventData);
+        memcpy(&eventData.flightMode.flags, &rcModeActivationMask, sizeof(eventData.flightMode.flags));
+        blackboxLogEvent(FLIGHT_LOG_EVENT_FLIGHTMODE, &eventData);
     }
 }
 


### PR DESCRIPTION
Fix error in blackbox.c when building without LTO (link time optimisation)

Compiler doesn't like "data->" when data is a union type that is larger than the allocated memory of the passed-in variable:
"error: array subscript 'flightLogEventData_t ... is partly out of bounds" inside blackboxLogEvent()

The fix here is to allocate a union-type variable in the first place and write into that. 

An alternative would be to change
        blackboxWriteUnsignedVB(data->flightMode.flags);
to
        blackboxWriteUnsignedVB(((flightLogEvent_flightMode_t *)data)->flightMode.flags);
etc.

This only cropped up for the flightMode logging, maybe randomly according to inlining, but there are other instances that might be good to fix up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized flight mode event logging data structure for improved code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->