### PR TITLE
Add support for building using MSYS2.

### DIFF
--- a/mk/system-id.mk
+++ b/mk/system-id.mk
@@ -29,7 +29,7 @@ endif
 # Detect all Windows-based POSIX environments (MinGW, MSYS, Cygwin)
 ifneq (,$(filter MINGW% MSYS% CYGWIN%,$(UNAME)))
   OSFAMILY := windows
-    
+
   # Set specific environment flags if needed
   ifneq (,$(filter CYGWIN%,$(UNAME)))
     CYGWIN := 1


### PR DESCRIPTION
* If you run uname.exe from OUTSIDE of an msys2 shell, it reports 'MSYS_NT*', if you run the same uname.exe binary from inside a shell it reports 'MINGW*'.
* This allows firmware to be built by overriding the system path and just using the arm tools and msys2 paths.

Example path used for testing in Eclipse:

`C:\msys64\usr\bin${PathDelimiter}C:\msys64\ucrt64\bin${PathDelimiter}${GNU_ARM_TOOLS_HOME}\bin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified detection of Windows POSIX environments so MinGW, MSYS (MSYS2) and Cygwin are recognized consistently as Windows, improving build/tool behavior across those systems.
  * Still classifies the specific environment (Cygwin vs MINGW) and preserves existing Linux/macOS handling and the previous error path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->