### PR TITLE
Fix QSPI flash detection on STM32 MCUs.

### DIFF
--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -206,6 +206,10 @@ static bool flashQuadSpiInit(const flashConfig_t *flashConfig)
     // Set the callback argument when calling back to this driver for DMA completion
     dev->callbackArg = (uint32_t)&flashDevice;
 
+
+#if defined(QUADSPI_TRAIT_CS_SOFTWARE)
+    // Required for RP2350, but not for STM32 MCUs where the CS is controlled by hardware.
+
     if (flashConfig->csTag) {
         dev->busType_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
     } else {
@@ -215,6 +219,7 @@ static bool flashQuadSpiInit(const flashConfig_t *flashConfig)
     IOInit(dev->busType_u.spi.csnPin, OWNER_FLASH_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
+#endif
 
     flashDevice.io.mode = FLASHIO_QUADSPI;
     flashDevice.io.handle.dev = dev;

--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -75,6 +75,8 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 #define QUADSPI_TypeDef      void
 #define MAX_QUADSPI_PIN_SEL  1
 
+#define QUADSPI_TRAIT_CS_SOFTWARE       1
+
 #endif
 
 #define DMA_DATA_ZERO_INIT


### PR DESCRIPTION
There's a check in the qspi init code:

```
if (flashConfig->csTag) {
    dev->busType_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
} else {
    return false;
}
```

This was added by @SteveCEvans in 9829a48a8fa86233fcf0efabdff34576d130d958 via PR #14748 

STM32 FC's with QSPI don't specify a FLASH_CS_PIN, so the check will *always* fail.

Additionally usual QSPI config looks like this:

```
#define QUADSPI1_BK1_CS_PIN PB10
#define QUADSPI1_BK2_CS_PIN NONE
#define QUADSPI1_CS_FLAGS (QUADSPI_BK1_CS_HARDWARE | QUADSPI_BK2_CS_NONE | QUADSPI_CS_MODE_LINKED)
```

where QSPI CS pin is controlled by hardware. (e.g. SPRacingH7EXTREME)

or

```
#define QUADSPI1_BK1_CS_PIN NONE
#define QUADSPI1_BK2_CS_PIN PB10
#define QUADSPI1_MODE QUADSPI_MODE_BK2_ONLY
#define QUADSPI1_CS_FLAGS (QUADSPI_BK1_CS_NONE | QUADSPI_BK2_CS_SOFTWARE | QUADSPI_CS_MODE_SEPARATE)
```

where QSPI CS pin is controlled by hardware. (e.g. SPRacingH7NANO)

For QSPI software, see `bus_quadspi_hal.c`

```
quadSpiInitDevice()
quadSpiSelectDevice()
quadSpiDeselectDevice()
```

Usually the CS is controlled by hardware on STM32 boards.

<img width="825" height="326" alt="image" src="https://github.com/user-attachments/assets/30bfed57-40e0-4b20-9580-0dec93c02fe6" />

<img width="822" height="452" alt="image" src="https://github.com/user-attachments/assets/29f7c259-fd93-46b7-b4bc-e38cfd302072" />

This PR fixes this by adding a 'trait' to the RP2350.

Proof that this works on an STM32H743:

<img width="2750" height="1793" alt="image" src="https://github.com/user-attachments/assets/03fa9ae2-3b5d-4eb9-8f3e-9a53d400db72" />

Suggest that before BF2025 is released that it is tested on the SPRacingH7NANO and SPRacingH7EXTREME so that QSPI functionallity is verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added software-controlled chip select support for QUADSPI flash memory on the PICO platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->