### PR TITLE
Cli - Fix a bug with `flash_write`.

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2608,6 +2608,7 @@ static void cliFlashWrite(const char *cmdName, char *cmdline)
     if (!text) {
         cliShowInvalidArgumentCountError(cmdName);
     } else {
+        text++;
         flashfsSeekAbs(address);
         flashfsWrite((uint8_t*)text, strlen(text), true);
         flashfsFlushSync();


### PR DESCRIPTION
It wasn't skipping the space character.

* the buffer passed to `flashfsWrite` included the space character that was found by `strchr`.

before:

```
# flash_erase
Erasing, please wait ... 
.
Done.

# flash_write 0 test
Wrote 5 bytes at 0.

# flash_read 0 32
Reading 32 bytes at 0:
 testÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
```

after:

before:

```
# flash_erase
Erasing, please wait ... 
.
Done.

# flash_write 0 test
Wrote 4 bytes at 0.

# flash_read 0 32
Reading 32 bytes at 0:
testÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the CLI flash write operation to properly process payload text strings. This fix ensures accurate data handling when writing to flash memory through the command-line interface, resolving an issue that was affecting data integrity during flash write operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->