### PR TITLE
Fix w25n flash read

### DIFF
--- a/src/main/drivers/flash/flash_w25n.c
+++ b/src/main/drivers/flash/flash_w25n.c
@@ -944,7 +944,7 @@ LOCAL_UNUSED_FUNCTION static int w25n_readExtensionBytes(flashDevice_t *fdevice,
 
     w25n_performCommandWithPageAddress(&fdevice->io, W25N_INSTRUCTION_PAGE_DATA_READ, W25N_LINEAR_TO_PAGE(address));
 
-    uint32_t column = 2048;
+    uint32_t column = W25N_PAGE_SIZE;
 
     if (fdevice->io.mode == FLASHIO_SPI) {
         extDevice_t *dev = fdevice->io.handle.dev;


### PR DESCRIPTION
before:

```
# flash_erase
Erasing, please wait ... 
.
Done.

# flash_write 0 test
Wrote 5 bytes at 0.

# flash_read 0 32
Reading 32 bytes at 0:
©©©©©©©©©©©©©©©©©©©©©©©©©©©©©©©©  <-- or other similar garbage
```

after:

```
# flash_erase
Erasing, please wait ... 
.
Done.

# flash_write 0 test
Wrote 5 bytes at 0.

# flash_read 0 32
Reading 32 bytes at 0:
 testÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
```

See also #14826 which I discovered when fixing this.

I also included other W25N clean-up commits and included them here to reduce PR noise/overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash read reliability by correctly handling page boundaries, ensuring buffered data is re-read or flushed only when needed, and adding readiness waits before page reads.

* **Performance**
  * Reduced device reset wait time for faster flash initialization.

* **Internal Improvements**
  * Tightened encapsulation of flash state and unified SPI/QuadSPI read/write behavior to reduce side effects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->