### PR TITLE
HOUSEKEEPING: Using skip space

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -962,6 +962,15 @@ static void cliRepeat(char ch, uint8_t len)
 }
 #endif
 
+static char *skipSpace(char *buffer)
+{
+    while (*(buffer) == ' ') {
+        buffer++;
+    }
+
+    return buffer;
+}
+
 static void cliPrompt(void)
 {
     cliPrint("\r\n# ");
@@ -2603,7 +2612,7 @@ static void cliFlashVerify(const char *cmdName, char *cmdline)
 static void cliFlashWrite(const char *cmdName, char *cmdline)
 {
     const uint32_t address = atoi(cmdline);
-    const char *text = strchr(cmdline, ' ');
+    char *text = strchr(cmdline, ' ');
 
     if (!text) {
         cliShowInvalidArgumentCountError(cmdName);
@@ -3560,15 +3569,6 @@ static void cliMap(const char *cmdName, char *cmdline)
 
     buf[i] = '\0';
     cliPrintLinef("map %s", buf);
-}
-
-static char *skipSpace(char *buffer)
-{
-    while (*(buffer) == ' ') {
-        buffer++;
-    }
-
-    return buffer;
 }
 
 static char *checkCommand(char *cmdline, const char *command)


### PR DESCRIPTION
Adding the nitpick from previous PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flash-write command now trims any number of spaces between an address and the message, ensuring the message content is written correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->