### PR TITLE
PICO dshot timing update - fix erratic motor movement when disarmed

### DIFF
--- a/src/platform/PICO/dshot.pio
+++ b/src/platform/PICO/dshot.pio
@@ -38,13 +38,13 @@ start:
 bitloop:
     out    y, 1                             ; Shift next bit into y
     jmp    !y, outzero                      ;
-    set    pins, 1                [29]      ; To output a '1' bit, set high for 30 then low for 10 (based on bitlength = 40 cycles)
-    set    pins, 0                [6]       ; Delay to next "set" adds up to 10
+    set    pins, 1                [26]      ; To output a '1' bit, set high for 27 then low for 13 (based on bitlength = 40 cycles)
+    set    pins, 0                [9]       ; Delay to next "set" adds up to 13
     jmp    !osre, bitloop                   ; If not done output (finished shifting bits) then loop
     jmp    start
 outzero:
-    set    pins, 1                [13]      ; To output a '0', set high for 14 then low for 26
-    set    pins, 0                [21]      ; Delay to next "set" adds up to 26
+    set    pins, 1                [12]      ; To output a '0', set high for 13 then low for 27
+    set    pins, 0                [22]      ; Delay to next "set" adds up to 27
     jmp    !osre, bitloop         [1]       ; If not done output (finished shifting bits) then loop else wrap to start
 
 
@@ -84,15 +84,15 @@ bitloop:
     out    y, 1           side 0            ; Shift next bit into y
     jmp    !y, outzero    side 0            ;
 outone:
-    set    pins, 0        side 0  [15]      ; To output a '1' bit, set low for 30 then high for 10 (based on bitlength = 40 cycles)
+    set    pins, 0        side 0  [12]      ; To output a '1' bit, set low for 27 then high for 13 (based on bitlength = 40 cycles)
     nop                   side 0  [13]
-    set    pins, 1        side 0  [6]       ; Delay to next "set" adds up to 10
+    set    pins, 1        side 0  [9]       ; Delay to next "set" adds up to 13
     jmp    !osre, bitloop side 0            ; If not done output (finished shifting bits) then loop
     jmp    receive        side 0
 outzero:
-    set    pins, 0        side 0  [14]      ; To output a '0', set low for 15 then high for 25
-    set    pins, 1        side 0  [15]      ; Delay to next "set" adds up to 25
-    jmp    !osre, bitloop side 0  [6]       ; If not done output (finished shifting bits) then loop else wrap to start
+    set    pins, 0        side 0  [12]      ; To output a '0', set low for 13 then high for 27
+    set    pins, 1        side 0  [15]      ; Delay to next "set" adds up to 27
+    jmp    !osre, bitloop side 0  [8]       ; If not done output (finished shifting bits) then loop else wrap to start
 ;;;;;;; (dropped because short of instruction space)   nop                                     ; line up timings vs. arriving at receive from outone
 receive:
     set    pindirs, 0     side 0
@@ -131,13 +131,13 @@ bitloop:
     out    y, 1                             ; Shift next bit into y
     jmp    !y, outzero                      ;
 outone:
-    set    pins, 0                [29]      ; To output a '1' bit, set low for 30 then high for 10 (based on bitlength = 40 cycles)
-    set    pins, 1                [6]       ; Delay to next "set" adds up to 10
+    set    pins, 0                [26]      ; To output a '1' bit, set low for 27 then high for 13 (based on bitlength = 40 cycles)
+    set    pins, 1                [9]       ; Delay to next "set" adds up to 13
     jmp    !osre, bitloop                   ; If not done output (finished shifting bits) then loop
     jmp    receive
 outzero:
-    set    pins, 0                [14]      ; To output a '0', set low for 15 then high for 25
-    set    pins, 1                [20]      ; Delay to next "set" adds up to 25
+    set    pins, 0                [12]      ; To output a '0', set low for 13 then high for 27
+    set    pins, 1                [22]      ; Delay to next "set" adds up to 27
     jmp    !osre, bitloop         [1]       ; If not done output (finished shifting bits) then loop else wrap to start
     nop                                     ; line up timings vs. arriving at receive from outone
 receive:

--- a/src/platform/PICO/dshot_pio_programs.h
+++ b/src/platform/PICO/dshot_pio_programs.h
@@ -20,17 +20,17 @@ static const uint16_t dshot_600_program_instructions[] = {
             //     .wrap_target
     0xff00, //  0: set    pins, 0                [31]
     0xb442, //  1: nop                           [20]
-    0x80a0, //  2: pull   block
-    0x6050, //  3: out    y, 16
-    0x6041, //  4: out    y, 1
-    0x006a, //  5: jmp    !y, 10
-    0xfd01, //  6: set    pins, 1                [29]
-    0xe600, //  7: set    pins, 0                [6]
-    0x00e4, //  8: jmp    !osre, 4
-    0x0000, //  9: jmp    0
-    0xed01, // 10: set    pins, 1                [13]
-    0xf500, // 11: set    pins, 0                [21]
-    0x01e4, // 12: jmp    !osre, 4               [1]
+    0x80a0, //  2: pull   block                      
+    0x6050, //  3: out    y, 16                      
+    0x6041, //  4: out    y, 1                       
+    0x006a, //  5: jmp    !y, 10                     
+    0xfa01, //  6: set    pins, 1                [26]
+    0xe900, //  7: set    pins, 0                [9] 
+    0x00e4, //  8: jmp    !osre, 4                   
+    0x0000, //  9: jmp    0                          
+    0xec01, // 10: set    pins, 1                [12]
+    0xf600, // 11: set    pins, 0                [22]
+    0x01e4, // 12: jmp    !osre, 4               [1] 
             //     .wrap
 };
 
@@ -62,38 +62,38 @@ static inline pio_sm_config dshot_600_program_get_default_config(uint offset) {
 
 static const uint16_t dshot_600_bidir_debug_program_instructions[] = {
             //     .wrap_target
-    0xe081, //  0: set    pindirs, 1      side 0
+    0xe081, //  0: set    pindirs, 1      side 0     
     0xef01, //  1: set    pins, 1         side 0 [15]
     0xaf42, //  2: nop                    side 0 [15]
     0xaf42, //  3: nop                    side 0 [15]
-    0x90a0, //  4: pull   block           side 1
-    0x6050, //  5: out    y, 16           side 0
-    0x6041, //  6: out    y, 1            side 0
-    0x006d, //  7: jmp    !y, 13          side 0
-    0xef00, //  8: set    pins, 0         side 0 [15]
+    0x90a0, //  4: pull   block           side 1     
+    0x6050, //  5: out    y, 16           side 0     
+    0x6041, //  6: out    y, 1            side 0     
+    0x006d, //  7: jmp    !y, 13          side 0     
+    0xec00, //  8: set    pins, 0         side 0 [12]
     0xad42, //  9: nop                    side 0 [13]
-    0xe601, // 10: set    pins, 1         side 0 [6]
-    0x00e6, // 11: jmp    !osre, 6        side 0
-    0x0010, // 12: jmp    16              side 0
-    0xee00, // 13: set    pins, 0         side 0 [14]
+    0xe901, // 10: set    pins, 1         side 0 [9] 
+    0x00e6, // 11: jmp    !osre, 6        side 0     
+    0x0010, // 12: jmp    16              side 0     
+    0xec00, // 13: set    pins, 0         side 0 [12]
     0xef01, // 14: set    pins, 1         side 0 [15]
-    0x06e6, // 15: jmp    !osre, 6        side 0 [6]
-    0xe080, // 16: set    pindirs, 0      side 0
-    0xe033, // 17: set    x, 19           side 0
+    0x08e6, // 15: jmp    !osre, 6        side 0 [8] 
+    0xe080, // 16: set    pindirs, 0      side 0     
+    0xe033, // 17: set    x, 19           side 0     
     0xae42, // 18: nop                    side 0 [14]
     0x0e52, // 19: jmp    x--, 18         side 0 [14]
-    0x3220, // 20: wait   0 pin, 0        side 1 [2]
+    0x3220, // 20: wait   0 pin, 0        side 1 [2] 
     0xaf42, // 21: nop                    side 0 [15]
     0xef21, // 22: set    x, 1            side 0 [15]
-    0xe149, // 23: set    y, 9            side 0 [1]
-    0x001a, // 24: jmp    26              side 0
-    0xa442, // 25: nop                    side 0 [4]
-    0x5901, // 26: in     pins, 1         side 1 [9]
-    0x4901, // 27: in     pins, 1         side 0 [9]
-    0x5501, // 28: in     pins, 1         side 1 [5]
-    0x0099, // 29: jmp    y--, 25         side 0
-    0x8000, // 30: push   noblock         side 0
-    0x0057, // 31: jmp    x--, 23         side 0
+    0xe149, // 23: set    y, 9            side 0 [1] 
+    0x001a, // 24: jmp    26              side 0     
+    0xa442, // 25: nop                    side 0 [4] 
+    0x5901, // 26: in     pins, 1         side 1 [9] 
+    0x4901, // 27: in     pins, 1         side 0 [9] 
+    0x5501, // 28: in     pins, 1         side 1 [5] 
+    0x0099, // 29: jmp    y--, 25         side 0     
+    0x8000, // 30: push   noblock         side 0     
+    0x0057, // 31: jmp    x--, 23         side 0     
             //     .wrap
 };
 
@@ -126,36 +126,36 @@ static inline pio_sm_config dshot_600_bidir_debug_program_get_default_config(uin
 
 static const uint16_t dshot_600_bidir_program_instructions[] = {
             //     .wrap_target
-    0xe081, //  0: set    pindirs, 1
+    0xe081, //  0: set    pindirs, 1                 
     0xfe01, //  1: set    pins, 1                [30]
     0xb442, //  2: nop                           [20]
-    0x80a0, //  3: pull   block
-    0x6050, //  4: out    y, 16
-    0x6041, //  5: out    y, 1
-    0x006b, //  6: jmp    !y, 11
-    0xfd00, //  7: set    pins, 0                [29]
-    0xe601, //  8: set    pins, 1                [6]
-    0x00e5, //  9: jmp    !osre, 5
-    0x000f, // 10: jmp    15
-    0xee00, // 11: set    pins, 0                [14]
-    0xf401, // 12: set    pins, 1                [20]
-    0x01e5, // 13: jmp    !osre, 5               [1]
-    0xa042, // 14: nop
-    0xe080, // 15: set    pindirs, 0
-    0xe037, // 16: set    x, 23
+    0x80a0, //  3: pull   block                      
+    0x6050, //  4: out    y, 16                      
+    0x6041, //  5: out    y, 1                       
+    0x006b, //  6: jmp    !y, 11                     
+    0xfa00, //  7: set    pins, 0                [26]
+    0xe901, //  8: set    pins, 1                [9] 
+    0x00e5, //  9: jmp    !osre, 5                   
+    0x000f, // 10: jmp    15                         
+    0xec00, // 11: set    pins, 0                [12]
+    0xf601, // 12: set    pins, 1                [22]
+    0x01e5, // 13: jmp    !osre, 5               [1] 
+    0xa042, // 14: nop                               
+    0xe080, // 15: set    pindirs, 0                 
+    0xe037, // 16: set    x, 23                      
     0x1851, // 17: jmp    x--, 17                [24]
     0x3f20, // 18: wait   0 pin, 0               [31]
-    0xe221, // 19: set    x, 1                   [2]
-    0xa042, // 20: nop
-    0xe049, // 21: set    y, 9
-    0x0018, // 22: jmp    24
-    0xa442, // 23: nop                           [4]
-    0x4901, // 24: in     pins, 1                [9]
-    0x4901, // 25: in     pins, 1                [9]
-    0x4501, // 26: in     pins, 1                [5]
-    0x0097, // 27: jmp    y--, 23
-    0x8000, // 28: push   noblock
-    0x0054, // 29: jmp    x--, 20
+    0xe221, // 19: set    x, 1                   [2] 
+    0xa042, // 20: nop                               
+    0xe049, // 21: set    y, 9                       
+    0x0018, // 22: jmp    24                         
+    0xa442, // 23: nop                           [4] 
+    0x4901, // 24: in     pins, 1                [9] 
+    0x4901, // 25: in     pins, 1                [9] 
+    0x4501, // 26: in     pins, 1                [5] 
+    0x0097, // 27: jmp    y--, 23                    
+    0x8000, // 28: push   noblock                    
+    0x0054, // 29: jmp    x--, 20                    
             //     .wrap
 };
 


### PR DESCRIPTION
This PR shortens the Dshot600 timing to 3 * 556 ns. 

Currently the zero pulse is 620 ns, some ESCs apparently interpret the 620 ns pulse as a "one" and not as a "zero", resulting in erratic motor movement when motors are disarmed. See https://github.com/betaflight/betaflight/issues/14818

Note: Betaflight on F405 produces a 600 ns pulse

Dshot600 zero pulses on a MADFLIGHT_FC3 after applying first version of this PR:
<img width="800" height="480" alt="DS1Z_QuickPrint8" src="https://github.com/user-attachments/assets/cd48b2fc-6f31-4155-a13c-1ab1f8c97919" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined DSHOT 600 timing parameters on the PICO platform to improve signal timing consistency across variants.
  * Updated low-level PIO programs for DSHOT 600 (including bidirectional/debug variants) to align signaling and reduce timing-related transmission issues, improving motor command reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->