### PR TITLE
PICO: bidirectional DShot telemetry with edge detection

### DIFF
--- a/src/platform/PICO/dshot.pio
+++ b/src/platform/PICO/dshot.pio
@@ -51,74 +51,80 @@ outzero:
 ; gpio_set_pulls(pin, true, false) provides pull-up for idle HIGH when pindirs=0
 ; Expect to receive frame ~30us (independent of DSHOT speed) after output frame.
 ;
-; Transmit: 20 instructions (0-19)
-; Receive: 11 instructions (20-30):
-;   20:    settling delay before switching to input
-;   21:    switch to input mode
-;   22:    wait 1 pin (wait for HIGH)
-;   23:    set x (setup outer loop count before edge detection)
-;   24:    wait 0 pin (wait for falling edge)
-;   25-28: 5.56x oversampling loop (4 outer x 32 inner = 128 samples)
-;   29-30: switch back to output, drive HIGH
-; Total: 31 instructions (1 spare)
+; Transmit: 14 instructions
+; Receive: 13 instructions
+;       settling delay before switching to input
+;       switch to input mode
+;       wait 1 pin (wait for HIGH)
+;       set x (setup outer loop count before edge detection)
+;       wait 0 pin (wait for falling edge)
+;       5.56x oversampling loop (4 outer x 32 inner = 128 samples)
+;       switch back to output, drive HIGH
+; Total: 27 instructions
 
 .program dshot_600_bidir
 
 .define public BIDIR_START 0
 
 .wrap_target
-pull_data:
-    pull   block                            ; 0: Wait for TX data
-    set    pindirs, 1                       ; 1: Switch to output mode
-    out    y, 16                            ; 2: Discard top 16 bits
-    set    x, 20                            ; 3: 21 bits to transmit
+PUBLIC pull_data:
+    pull   block                            ; Wait for TX data
+    set    pindirs, 1                       ; Switch to output mode
+    out    y, 16                            ; Discard top 16 bits
 bitloop_tx:
-    out    y, 1                             ; 4: Shift bit to y
-    set    pins, 0                          ; 5: Start of bit (LOW)
-    jmp    !y, outzero_tx                   ; 6: Branch on bit value
+    out    y, 1                             ; Shift bit to y
+    set    pins, 0               [31]       ; Start of bit (LOW)
+    jmp    !y, outzero_tx        [8]        ; Branch on bit value
 outone_tx:
     ; '1' bit: 84 cycles LOW (67%), 41 cycles HIGH (33%)
-    nop                          [31]       ; 7: 32 cycles
-    nop                          [31]       ; 8: 32 cycles
-    nop                          [17]       ; 9: 18 cycles (total delay=82, LOW=1+1+82=84)
-    set    pins, 1               [31]       ; 10: 32 cycles HIGH
-    nop                          [6]        ; 11: 7 cycles HIGH
-    jmp    !osre, bitloop_tx                ; 12: 1 cycle, + out(1) = 41 HIGH total
-    jmp    receive                          ; 13: Done TX -> receive
+    nop                          [31]       ; 32 cycles
+    nop                          [10]       ; 18 cycles (total delay=82, LOW=1+1+82=84)
+    set    pins, 1               [31]       ; 32 cycles HIGH
+    ; 7 cycles HIGH
+    jmp    !osre, bitloop_tx     [7]        ; 1 cycle, + out(1) = 41 HIGH total
+    jmp    receive                          ; Done TX -> receive
 outzero_tx:
     ; '0' bit: 41 cycles LOW (33%), 84 cycles HIGH (67%)
-    nop                          [31]       ; 14: 32 cycles
-    nop                          [6]        ; 15: 7 cycles (total delay=39, LOW=1+1+39=41)
-    set    pins, 1               [31]       ; 16: 32 cycles HIGH
-    nop                          [31]       ; 17: 32 cycles HIGH
-    nop                          [17]       ; 18: 18 cycles HIGH
-    jmp    !osre, bitloop_tx                ; 19: 1 cycle, + out(1) = 84 HIGH total
+    ; 7 cycles (total delay=39, LOW=1+1+39=41)
+    set    pins, 1               [31]       ; 32 cycles HIGH
+    nop                          [31]       ; 32 cycles HIGH
+    ; 18 cycles HIGH
+    jmp    !osre, bitloop_tx     [18]       ; 1 cycle, + out(1) = 84 HIGH total
 
 receive:
     ; Delay before switching to input to let line settle after TX
     ; ~280ns settling delay = 21 cycles at 75 MHz
-    nop                          [20]       ; 20: 21 cycles settling delay
-    set    pindirs, 0                       ; 21: Switch to input mode
+    nop                          [20]       ; 21 cycles settling delay
+    set    pindirs, 0                       ; Switch to input mode
     ; Wait for start bit (falling edge from idle HIGH)
     ; Using 'wait' instructions for precise, deterministic edge detection
     ; At 75 MHz (clkdiv=2), 'wait' has 0-1 cycle jitter = 0-13.3ns
-    wait   1 pin 0                          ; 22: Wait for line to go HIGH (idle)
-    set    x, 3                             ; 23: Setup outer loop count (4 iterations) BEFORE edge detection
-    wait   0 pin 0                          ; 24: Wait for falling edge (start bit)
+PUBLIC wait_one:
+    wait   1 pin 0                          ; Wait for line to go HIGH (idle)
+    set    x, 3                             ; Setup outer loop count (4 iterations) BEFORE edge detection
+PUBLIC wait_zero:
+    wait   0 pin 0               [16]       ; Wait for falling edge (start bit), then 18 cycles until in pins
     ; Inner loop: 18 cycles per sample at 75 MHz
-    ; in[15](16) + jmp[1](2) = 18 cycles
     ; Telemetry bit = 100 cycles, so 100/18 = 5.56x oversampling
-    ; 21 bits × 5.56 = 117 samples needed, fits in 128 with margin
+    ; 21 bits × 5.56 = 117 samples needed, fits in 128 with margin (actually only +20 bit periods until final edge)
+
 
 outer_loop:
-    set    y, 31                            ; 25: 32 inner loop iterations
+    set    y, 31                            ; 32 inner loop iterations
 inner_loop:
-    in     pins, 1               [15]       ; 26: Sample pin + 15 delay = 16 cycles
-    jmp    y--, inner_loop       [1]        ; 27: Continue inner loop + 1 delay = 2 cycles
-    jmp    x--, outer_loop                  ; 28: Continue outer loop (1 cycle)
+    in     pins, 1               [14]       ; Sample pin + 14 delay = 15 cycles
+    jmp    y--, delayed_inner_loop          ; Continue inner loop via detour + 1 delay = 3 cycles, total 18
+    jmp    x--, outer_loop                  ; Continue outer loop, total 18
+    jmp    complete
+delayed_inner_loop:
+    jmp    inner_loop            [1]
 
     ; Sampling complete - 128 samples pushed via autopush (4 x 32-bit words)
     ; Set pin back to output HIGH (idle state) before wrapping.
-    set    pindirs, 1                       ; 29: Switch back to output mode
-    set    pins, 1                          ; 30: Set pin HIGH (idle state)
+PUBLIC complete:
+    set    pindirs, 1                       ; Switch back to output mode
+    set    pins, 1                          ; Set pin HIGH (idle state)
+    set    y, 4                             ;
+delay_next_output:
+    jmp    !y, delay_next_output [29]       ; TODO how much min delay here? 2us seen somewhere?? 5*30/75 = 2 us
 .wrap

--- a/src/platform/PICO/dshot_pio_programs.h
+++ b/src/platform/PICO/dshot_pio_programs.h
@@ -57,51 +57,54 @@ static inline pio_sm_config dshot_600_program_get_default_config(uint offset) {
 // --------------- //
 
 #define dshot_600_bidir_wrap_target 0
-#define dshot_600_bidir_wrap 30
+#define dshot_600_bidir_wrap 28
 #define dshot_600_bidir_pio_version 0
 
 #define dshot_600_bidir_BIDIR_START 0
+
+#define dshot_600_bidir_offset_pull_data 0u
+#define dshot_600_bidir_offset_wait_one 16u
+#define dshot_600_bidir_offset_wait_zero 18u
+#define dshot_600_bidir_offset_complete 25u
 
 static const uint16_t dshot_600_bidir_program_instructions[] = {
             //     .wrap_target
     0x80a0, //  0: pull   block
     0xe081, //  1: set    pindirs, 1
     0x6050, //  2: out    y, 16
-    0xe034, //  3: set    x, 20
-    0x6041, //  4: out    y, 1
-    0xe000, //  5: set    pins, 0
-    0x006e, //  6: jmp    !y, 14
-    0xbf42, //  7: nop                           [31]
-    0xbf42, //  8: nop                           [31]
-    0xb142, //  9: nop                           [17]
-    0xff01, // 10: set    pins, 1                [31]
-    0xa642, // 11: nop                           [6]
-    0x00e4, // 12: jmp    !osre, 4
-    0x0014, // 13: jmp    20
-    0xbf42, // 14: nop                           [31]
-    0xa642, // 15: nop                           [6]
-    0xff01, // 16: set    pins, 1                [31]
-    0xbf42, // 17: nop                           [31]
-    0xb142, // 18: nop                           [17]
-    0x00e4, // 19: jmp    !osre, 4
-    0xb442, // 20: nop                           [20]
-    0xe080, // 21: set    pindirs, 0
-    0x20a0, // 22: wait   1 pin, 0
-    0xe023, // 23: set    x, 3
-    0x2020, // 24: wait   0 pin, 0
-    0xe05f, // 25: set    y, 31
-    0x4f01, // 26: in     pins, 1                [15]
-    0x019a, // 27: jmp    y--, 26                [1]
-    0x0059, // 28: jmp    x--, 25
-    0xe081, // 29: set    pindirs, 1
-    0xe001, // 30: set    pins, 1
+    0x6041, //  3: out    y, 1
+    0xff00, //  4: set    pins, 0                [31]
+    0x086b, //  5: jmp    !y, 11                 [8]
+    0xbf42, //  6: nop                           [31]
+    0xaa42, //  7: nop                           [10]
+    0xff01, //  8: set    pins, 1                [31]
+    0x07e3, //  9: jmp    !osre, 3               [7]
+    0x000e, // 10: jmp    14
+    0xff01, // 11: set    pins, 1                [31]
+    0xbf42, // 12: nop                           [31]
+    0x12e3, // 13: jmp    !osre, 3               [18]
+    0xb442, // 14: nop                           [20]
+    0xe080, // 15: set    pindirs, 0
+    0x20a0, // 16: wait   1 pin, 0
+    0xe023, // 17: set    x, 3
+    0x3020, // 18: wait   0 pin, 0               [16]
+    0xe05f, // 19: set    y, 31
+    0x4e01, // 20: in     pins, 1                [14]
+    0x0098, // 21: jmp    y--, 24
+    0x0053, // 22: jmp    x--, 19
+    0x0019, // 23: jmp    25
+    0x0114, // 24: jmp    20                     [1]
+    0xe081, // 25: set    pindirs, 1
+    0xe001, // 26: set    pins, 1
+    0xe044, // 27: set    y, 4
+    0x1d7c, // 28: jmp    !y, 28                 [29]
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program dshot_600_bidir_program = {
     .instructions = dshot_600_bidir_program_instructions,
-    .length = 31,
+    .length = 29,
     .origin = -1,
     .pio_version = dshot_600_bidir_pio_version,
 #if PICO_PIO_VERSION > 0


### PR DESCRIPTION
## Summary
- Implement bidirectional DShot telemetry for RP2350 using PIO with edge detection
- PIO runs at 75 MHz (integer clock divider) for clean timing: 125 cycles per DShot bit, 100 cycles per telemetry bit
- CLZ-based edge detection with 5.5x oversampling (18 PIO cycles per sample)
- Transition-table run-length decoding with auto-calibration from 0 RPM frames
- Non-blocking FIFO reads to prevent watchdog hangs

## Key Implementation Details
- **PIO program**: 27 instructions with public labels for key offsets (pull_data, wait_one, wait_zero, complete)
- **Edge detection**: Uses `__builtin_clz` to find run lengths from 128 oversampled bits (4 x 32-bit words via autopush)
- **Run-length decoding**: Pre-computed transition thresholds instead of float multiply per edge
- **Auto-calibration**: Averages 32 stationary (0 RPM) frames to derive precise samples-per-bit rate
- **State machine management**: PC-based state detection with per-SM disable before TX FIFO write; waitCount-based stuck detection and restart for unresponsive ESCs
- **Safety**: Bounds check on edge count, CLZ-with-zero guard, non-blocking FIFO reads

## Credits
CLZ-based decoder, transition-table decoding, PIO instruction reduction, per-SM disable, and auto-calibration by Matthew Selby (Raspberry Pi).

## Test Plan
- [x] Test with BlueJay ESCs on RP2350B at 8kHz PID loop
- [x] Verify telemetry decode rate at 0 RPM
- [x] Verify telemetry decode rate with motors spinning
- [x] Test non-bidirectional DShot still works
- [x] Verify auto-calibration completes and improves decode rate