### PR TITLE
Scheduler - upgrade taskCount and lateTaskCount to uint32_t.

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -118,9 +118,9 @@ static uint8_t skippedOSDAttempts = 0;
 #endif
 
 #if defined(USE_LATE_TASK_STATISTICS)
-static int16_t lateTaskCount = 0;
+static uint32_t lateTaskCount = 0;
 static uint32_t lateTaskTotal = 0;
-static int16_t taskCount = 0;
+static uint32_t taskCount = 0;
 static uint32_t lateTaskPercentage = 0;
 static uint32_t nextTimingCycles;
 static int32_t gyroCyclesNow;


### PR DESCRIPTION
Scheduler - upgrade taskCount and lateTaskCount to uint32_t.

taskCount and lateTaskCount are currently int16_t, which can overflow (at least under test conditions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved task statistics tracking by optimizing internal data type handling to support larger values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->