### PR TITLE
CRSF: fix race condition in subset frame handling

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -392,8 +392,10 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
                 case CRSF_FRAMETYPE_SUBSET_RC_CHANNELS_PACKED:
                     if (crsfFrame.frame.deviceAddress == CRSF_ADDRESS_FLIGHT_CONTROLLER) {
                         rxRuntimeState->lastRcFrameTimeUs = currentTimeUs;
-                        crsfFrameDone = true;
+                        // IMPORTANT: Copy frame data BEFORE setting flag to avoid race condition
+                        // where crsfFrameStatus() could see flag=true but read stale data
                         memcpy(&crsfChannelDataFrame, &crsfFrame, sizeof(crsfFrame));
+                        crsfFrameDone = true;
                     }
                     break;
 


### PR DESCRIPTION
## Summary
- Fix race condition in CRSF ISR/main-task interaction when handling subset RC frames
- The `crsfFrameDone` flag was set before `memcpy()` completed, allowing the main task to process stale frame data

## Problem
When using variable-rate CRSF subset frames (e.g., channels 0-3 at 400Hz, aux channels at 50Hz), the main task could see `crsfFrameDone=true` but read the previous frame's data. This caused:
- Incorrect channel values (wrong `frameLength` leading to wrong `numOfChannels` calculation)
- False disarms when aux channel data from a previous frame was misinterpreted

## Fix
Perform `memcpy()` before setting `crsfFrameDone=true`, ensuring frame data is always consistent when the flag indicates a frame is ready.

## Test plan
- [x] Tested with ArduPilot sending CRSF subset frames at different rates
- [x] Verified no more false disarms due to stale frame data
- [x] Verified correct channel counts in parsed frames

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency in CRSF RX handling by preventing a potential race condition that could result in stale data being read.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->