### PR TITLE
Fix battery percentage calculation with battery capacity set to 0

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -501,10 +501,18 @@ uint8_t calculateBatteryPercentageRemaining(void)
         if (batteryCapacity > 0) {
             batteryPercentage = constrain(((float)batteryCapacity - currentMeter.mAhDrawn) * 100 / batteryCapacity, 0, 100);
         } else {
-            uint32_t batteryVoltage = (uint32_t)voltageMeter.displayFiltered;
+            uint32_t batteryVoltage = voltageMeter.displayFiltered;
             uint32_t batteryVoltageMin = batteryConfig()->vbatmincellvoltage * batteryCellCount;
             uint32_t batteryVoltageMax = batteryConfig()->vbatmaxcellvoltage * batteryCellCount;
-            batteryPercentage = (batteryVoltage <= batteryVoltageMin) ? 0 : (batteryVoltage >= batteryVoltageMax) ? 100 : (uint8_t)(((batteryVoltage - batteryVoltageMin) * 100) / (batteryVoltageMax - batteryVoltageMin));
+            if (batteryVoltage <= batteryVoltageMin) {
+                batteryPercentage = 0;
+            } else if (batteryVoltage >= batteryVoltageMax) {
+                batteryPercentage = 100;
+            } else if (batteryVoltageMax > batteryVoltageMin) {
+                batteryPercentage = (uint8_t)(((batteryVoltage - batteryVoltageMin) * 100) / (batteryVoltageMax - batteryVoltageMin));
+            } else {
+                batteryPercentage = 0;
+            }
         }
     }
 


### PR DESCRIPTION
In calculateBatteryPercentageRemaining(), if batteryConfig()->batteryCapacity == 0 and voltageMeter.displayFiltered < (batteryConfig()->vbatmincellvoltage * batteryCellCount) an integer underflow happens, and batteryPercentage is set to 100 instead of 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery percentage fallback when capacity is unavailable: now computes percentage from measured voltage with explicit linear scaling across the device's min/max voltage range, clamping results to 0–100 and handling edge cases for more reliable battery level reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->