### PR TITLE
fix: remove beacon timestamp update when blocked

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -456,9 +456,6 @@ void beeperUpdate(timeUs_t currentTimeUs)
                 lastDshotBeaconCommandTimeUs = currentTimeUs;
                 dshotCommandWrite(ALL_MOTORS, getMotorCount(), beeperConfig()->dshotBeaconTone, DSHOT_CMD_TYPE_INLINE);
             }
-        } else {
-            // make sure lastDshotBeaconCommandTimeUs is valid when DSHOT_BEACON_GUARD_DELAY_US elapses
-            lastDshotBeaconCommandTimeUs = currentTimeUs - dshotBeaconIntervalUs;
         }
     }
 #endif


### PR DESCRIPTION
Resolves #14545

The code in question is a result of the beeper refactor in https://github.com/betaflight/betaflight/pull/13492 which was NOT included in any Betaflight 4.5.x versions. It only appears in:
- 4.6+ versions
- 2025.12.x versions (2025.12.0-RC1, RC2, RC3, RC4, and 2025.12.1)

---

## Summary
Remove the else branch that sets lastDshotBeaconCommandTimeUs when beacon commands are blocked by arming state.

## Details
Timestamp now only updates on actual beacon transmissions, preventing arming deadlock where blocked beacons would continuously delay arming.

## Request testing
Please test to ensure arming behavior is correct and the deadlock is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced beacon timing reliability by streamlining command scheduling logic, eliminating unnecessary timing adjustments for more predictable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->