### PR TITLE
Cleanup unused patterns

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -71,8 +71,6 @@ typedef enum {
     GYRO_HARDWARE_COUNT
 } gyroHardware_e;
 
-extern const char * const gyroHardwareNames[GYRO_HARDWARE_COUNT];
-
 typedef enum {
     GYRO_HARDWARE_LPF_NORMAL,
     GYRO_HARDWARE_LPF_OPTION_1,

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -60,8 +60,6 @@ typedef enum {
     ACC_HARDWARE_COUNT
 } accelerationSensor_e;
 
-extern const char * const accelerationSensorNames[ACC_HARDWARE_COUNT];
-
 typedef struct acc_s {
     accDev_t dev;
     uint16_t sampleRateHz;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -39,8 +39,6 @@ typedef enum {
     BARO_HARDWARE_COUNT
 } baroSensor_e;
 
-extern const char * const baroSensorNames[BARO_HARDWARE_COUNT];
-
 typedef struct barometerConfig_s {
     uint8_t baro_busType;
     uint8_t baro_spi_device;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -48,8 +48,6 @@ typedef enum {
     MAG_HARDWARE_COUNT
 } magSensor_e;
 
-extern const char * const magSensorNames[MAG_HARDWARE_COUNT];
-
 typedef struct mag_s {
     bool isNewMagADCFlag;
     vector3_t magADC;

--- a/src/main/sensors/opticalflow.h
+++ b/src/main/sensors/opticalflow.h
@@ -33,8 +33,6 @@ typedef enum {
     OPTICALFLOW_HARDWARE_COUNT
 } opticalflowType_e;
 
-extern const char * const opticalflowTypeNames[OPTICALFLOW_HARDWARE_COUNT];
-
 typedef struct opticalflowConfig_s {
     uint8_t  opticalflow_hardware;
     uint16_t rotation;

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -39,8 +39,6 @@ typedef enum {
     RANGEFINDER_HARDWARE_COUNT
 } rangefinderType_e;
 
-extern const char * const rangefinderTypeNames[RANGEFINDER_HARDWARE_COUNT];
-
 typedef struct rangefinderConfig_s {
     uint8_t rangefinder_hardware;
 } rangefinderConfig_t;


### PR DESCRIPTION
Cleaning up unused patterns
Perhaps we should move sensor hardware from cli settings to sensor.h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup and optimization of sensor hardware declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->