### PR TITLE
Define USE_LED_STRIP if USE_LED_STRIP_64 is defined

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -282,7 +282,7 @@
 
 #endif // !defined(CLOUD_BUILD)
 
-#if !defined(USE_LED_STRIP) && defined(USE_LED_STRIP_64)
+#if defined(USE_LED_STRIP_64) && !defined(USE_LED_STRIP)
 #define USE_LED_STRIP
 #endif
 

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -282,6 +282,10 @@
 
 #endif // !defined(CLOUD_BUILD)
 
+#if !defined(USE_LED_STRIP) && defined(USE_LED_STRIP_64)
+#define USE_LED_STRIP
+#endif
+
 #if !defined(LED_STRIP_MAX_LENGTH)
 #ifdef USE_LED_STRIP_64
 #define LED_STRIP_MAX_LENGTH           64


### PR DESCRIPTION
Currently, if someone would choose LED_STRIP_64 in the firmware flasher without LED_STRIP (because they removed it), the LED strip wouldn't be functional. This tiny extra ifdef/define makes sure this won't happen, improving the experience for that very small number of users running into this issue :wink:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration issue so selecting a 64-unit LED strip now automatically enables LED strip support, preventing initialization failures.
  * Ensures devices using the 64-length variant behave consistently at startup and during configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->