### PR TITLE
Fix motor output not restored after ESC passthrough exit

### DIFF
--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -143,9 +143,8 @@ inline void setEscOutput(uint8_t selEsc)
 
 uint8_t esc4wayInit(void)
 {
-    motorShutdown();
     uint8_t escIndex = 0;
-
+    motorDisable();
     memset(&escHardware, 0, sizeof(escHardware));
     for (volatile uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
         if (motorIsMotorEnabled(i)) {
@@ -158,7 +157,6 @@ uint8_t esc4wayInit(void)
             }
         }
     }
-    motorDisable();
     escCount = escIndex;
     return escCount;
 }


### PR DESCRIPTION
After exiting ESC passthrough (e.g. disconnecting from BLHeli Configurator), reconnecting with Betaflight Configurator and navigating to the Motors tab shows: 

"Mixer mode problem detected - Quad X model requires 4 motor resources, but the current firmware configuration can only provide 0 available outputs for the selected mode."

This does not occur on 4.5.3.                                                                                                            

The critical difference:
  - motorDisable() sets enabled = false but keeps initialized = true
  - motorShutdown() sets both enabled = false and initialized = false

  esc4wayInit() calls motorShutdown()                                                                                                                                                                                                       
    → sets motorDevice.initialized = false                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
  esc4wayRelease() calls motorEnable()                                                                                                                                                                                                      
    → checks: if (motorDevice.initialized && ...)
    → initialized is false, condition fails
    → motorEnable() silently returns without re-enabling motors
    → motors stuck disabled until reboot
    → Configurator queries MSP_MOTOR, sees 0 available outputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized motor disable behavior during initialization to prevent timing-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->