### PR TITLE
MSP-adjCenter_adjScale

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1454,6 +1454,8 @@ case MSP_NAME:
             sbufWriteU8(dst, adjRange->range.endStep);
             sbufWriteU8(dst, adjRange->adjustmentConfig);
             sbufWriteU8(dst, adjRange->auxSwitchChannelIndex);
+            sbufWriteU16(dst, adjRange->adjustmentCenter);
+            sbufWriteU16(dst, adjRange->adjustmentScale);
         }
         break;
 
@@ -2791,6 +2793,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             adjRange->range.endStep = sbufReadU8(src);
             adjRange->adjustmentConfig = sbufReadU8(src);
             adjRange->auxSwitchChannelIndex = sbufReadU8(src);
+            if (sbufBytesRemaining(src) >= 4) {
+                adjRange->adjustmentCenter = sbufReadU16(src);
+                adjRange->adjustmentScale = sbufReadU16(src);
+            }
 
             activeAdjustmentRangeReset();
         } else {


### PR DESCRIPTION
* **New Features**
  * Exposes `adjustmentCenter` and `adjustmentRange` to MSP to complement https://github.com/betaflight/betaflight-configurator/pull/4863 for adding both variables to the Adjustments Tab.
  * Reduces to 8 bit, reducing storage and transfer size and improving efficiency.
  * Implements backward compatible checks with existing interfaces—no changes to public function behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced adjustment range handling with extended data support while maintaining full backwards compatibility.

* **Chores**
  * Updated configuration submodule dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->