### PR TITLE
AUTOPILOT: Step one, Flight plan guidance implementation 

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -162,6 +162,7 @@ COMMON_SRC = \
             flight/autopilot_wing.c \
             flight/dyn_notch_filter.c \
             flight/failsafe.c \
+            flight/flight_plan_nav.c \
             flight/gps_rescue_multirotor.c \
             flight/gps_rescue_wing.c \
             flight/imu.c \

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -64,6 +64,10 @@
 #include "flight/alt_hold.h"
 #include "flight/pos_hold.h"
 
+#if ENABLE_FLIGHT_PLAN
+#include "flight/flight_plan_nav.h"
+#endif
+
 #if defined(USE_DYN_NOTCH_FILTER)
 #include "flight/dyn_notch_filter.h"
 #endif
@@ -1077,6 +1081,24 @@ void processRxModes(timeUs_t currentTimeUs)
         }
     } else {
         DISABLE_FLIGHT_MODE(POS_HOLD_MODE);
+    }
+#endif
+
+#if ENABLE_FLIGHT_PLAN
+    if (ARMING_FLAG(ARMED)
+        && !FLIGHT_MODE(GPS_RESCUE_MODE)
+        && IS_RC_MODE_ACTIVE(BOXAUTOPILOT)
+        && sensors(SENSOR_ACC)
+        && sensors(SENSOR_GPS) && STATE(GPS_FIX)
+        && wasThrottleRaised()) {
+        if (!FLIGHT_MODE(AUTOPILOT_MODE)) {
+            ENABLE_FLIGHT_MODE(AUTOPILOT_MODE);
+            flightPlanNavEngage();
+        }
+        flightPlanNavUpdate(currentTimeUs);
+    } else if (FLIGHT_MODE(AUTOPILOT_MODE)) {
+        DISABLE_FLIGHT_MODE(AUTOPILOT_MODE);
+        flightPlanNavDisengage();
     }
 #endif
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -64,7 +64,7 @@
 #include "flight/alt_hold.h"
 #include "flight/pos_hold.h"
 
-#if ENABLE_FLIGHT_PLAN
+#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
 #include "flight/flight_plan_nav.h"
 #endif
 
@@ -1084,7 +1084,7 @@ void processRxModes(timeUs_t currentTimeUs)
     }
 #endif
 
-#if ENABLE_FLIGHT_PLAN
+#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
     if (ARMING_FLAG(ARMED)
         && !FLIGHT_MODE(GPS_RESCUE_MODE)
         && IS_RC_MODE_ACTIVE(BOXAUTOPILOT)

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -98,7 +98,7 @@
 #include "flight/alt_hold.h"
 #include "flight/autopilot.h"
 #include "flight/failsafe.h"
-#if ENABLE_FLIGHT_PLAN
+#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
 #include "flight/flight_plan_nav.h"
 #endif
 #include "flight/imu.h"
@@ -858,7 +858,7 @@ void initPhase3(void)
 
     positionInit();
     autopilotInit();
-#if ENABLE_FLIGHT_PLAN
+#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
     flightPlanNavInit();
 #endif
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -98,6 +98,9 @@
 #include "flight/alt_hold.h"
 #include "flight/autopilot.h"
 #include "flight/failsafe.h"
+#if ENABLE_FLIGHT_PLAN
+#include "flight/flight_plan_nav.h"
+#endif
 #include "flight/imu.h"
 #include "flight/mixer.h"
 #include "flight/gps_rescue.h"
@@ -855,6 +858,9 @@ void initPhase3(void)
 
     positionInit();
     autopilotInit();
+#if ENABLE_FLIGHT_PLAN
+    flightPlanNavInit();
+#endif
 
 #if defined(USE_VTX_COMMON) || defined(USE_VTX_CONTROL)
     vtxTableInit();

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -1,0 +1,217 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#if ENABLE_FLIGHT_PLAN
+
+#include "common/time.h"
+#include "common/vector.h"
+
+#include "drivers/time.h"
+
+#include "flight/flight_plan_nav.h"
+#include "flight/position_estimator.h"
+#include "flight/position_nav.h"
+
+#include "io/gps.h"
+
+#include "pg/autopilot.h"
+#include "pg/flight_plan.h"
+
+#define FP_MIN_CRUISE_MPS       1.0f
+#define FP_FLYBY_COMPLETION_MPS 2.0f
+#define FP_FLYOVER_COMPLETION_MPS 0.5f
+
+static struct {
+    flightPlanNavState_e state;
+    uint8_t currentIndex;
+    timeUs_t holdStartUs;
+    uint16_t holdDurationDs;
+    bool active;
+} fp;
+
+static void onWaypointReached(void *userData);
+
+static const waypoint_t *currentWaypoint(void)
+{
+    const flightPlanConfig_t *plan = flightPlanConfig();
+    if (fp.currentIndex >= plan->waypointCount) {
+        return NULL;
+    }
+    return &plan->waypoints[fp.currentIndex];
+}
+
+static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
+{
+    gpsLocation_t origin;
+    if (!positionEstimatorGetGpsOrigin(&origin)) {
+        return false;
+    }
+
+    const gpsLocation_t wpLoc = {
+        .lat = wp->latitude,
+        .lon = wp->longitude,
+        .altCm = wp->altitude,
+    };
+
+    vector2_t enuCm;
+    GPS_distance2d(&origin, &wpLoc, &enuCm);
+
+    out->x = enuCm.x * 0.01f;
+    out->y = enuCm.y * 0.01f;
+    out->z = (wp->altitude - origin.altCm) * 0.01f;
+    return true;
+}
+
+static bool dispatchWaypoint(void)
+{
+    const waypoint_t *wp = currentWaypoint();
+    if (wp == NULL) {
+        fp.state = FP_NAV_COMPLETE;
+        positionNavClearTarget();
+        return false;
+    }
+
+    vector3_t targetEnuM;
+    if (!computeTargetEnuM(wp, &targetEnuM)) {
+        // no origin yet; stay idle and retry next engage
+        fp.state = FP_NAV_IDLE;
+        return false;
+    }
+
+    const autopilotConfig_t *cfg = autopilotConfig();
+    const float arrivalRadiusM = cfg->waypointArrivalRadius * 0.01f;
+    float cruiseMps = (wp->speed > 0) ? wp->speed * 0.01f : cfg->maxVelocity * 0.01f;
+    if (cruiseMps < FP_MIN_CRUISE_MPS) {
+        cruiseMps = FP_MIN_CRUISE_MPS;
+    }
+
+    // FLYBY: advance with residual velocity so we curve through.
+    // FLYOVER/HOLD/LAND: require near-stop to count as arrived.
+    const float completionMps = (wp->type == WAYPOINT_TYPE_FLYBY)
+        ? FP_FLYBY_COMPLETION_MPS
+        : FP_FLYOVER_COMPLETION_MPS;
+
+    positionNavSetTargetEf(&targetEnuM, cruiseMps, arrivalRadiusM,
+                           completionMps, true, onWaypointReached, NULL);
+
+    fp.state = FP_NAV_TARGETING;
+    fp.holdDurationDs = wp->duration;
+    return true;
+}
+
+static void advanceToNext(void)
+{
+    fp.currentIndex++;
+    if (fp.currentIndex >= flightPlanConfig()->waypointCount) {
+        fp.state = FP_NAV_COMPLETE;
+        positionNavClearTarget();
+        return;
+    }
+    dispatchWaypoint();
+}
+
+static void onWaypointReached(void *userData)
+{
+    UNUSED(userData);
+    if (!fp.active) {
+        return;
+    }
+
+    const waypoint_t *wp = currentWaypoint();
+    if (wp == NULL) {
+        fp.state = FP_NAV_COMPLETE;
+        return;
+    }
+
+    if (wp->type == WAYPOINT_TYPE_HOLD && fp.holdDurationDs > 0) {
+        fp.state = FP_NAV_HOLDING;
+        fp.holdStartUs = micros();
+        return;
+    }
+
+    // TODO: WAYPOINT_TYPE_LAND — trigger descent/disarm path.
+    // TODO: WAYPOINT_PATTERN_ORBIT / FIGURE8 sub-target generation for HOLD.
+    advanceToNext();
+}
+
+void flightPlanNavInit(void)
+{
+    fp.state = FP_NAV_IDLE;
+    fp.currentIndex = 0;
+    fp.active = false;
+}
+
+void flightPlanNavEngage(void)
+{
+    fp.active = true;
+    fp.currentIndex = 0;
+    fp.state = FP_NAV_IDLE;
+
+    if (flightPlanConfig()->waypointCount == 0) {
+        fp.state = FP_NAV_COMPLETE;
+        return;
+    }
+
+    dispatchWaypoint();
+}
+
+void flightPlanNavDisengage(void)
+{
+    fp.active = false;
+    fp.state = FP_NAV_IDLE;
+    positionNavClearTarget();
+}
+
+void flightPlanNavUpdate(timeUs_t currentTimeUs)
+{
+    if (!fp.active) {
+        return;
+    }
+
+    if (fp.state == FP_NAV_HOLDING) {
+        const uint32_t holdUs = (uint32_t)fp.holdDurationDs * 100000u;
+        if (cmpTimeUs(currentTimeUs, fp.holdStartUs) >= (timeDelta_t)holdUs) {
+            advanceToNext();
+        }
+    }
+}
+
+bool flightPlanNavIsActive(void)
+{
+    return fp.active;
+}
+
+flightPlanNavState_e flightPlanNavGetState(void)
+{
+    return fp.state;
+}
+
+uint8_t flightPlanNavGetCurrentIndex(void)
+{
+    return fp.currentIndex;
+}
+
+#endif // ENABLE_FLIGHT_PLAN

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -186,6 +186,11 @@ void flightPlanNavEngage(void)
     // referenced to the same baseline the position controller uses.
     fp.zBiasM = positionEstimatorGetAltitudeCm() * 0.01f;
 
+    // HOLD waypoints keep the position target live for the hold duration; a
+    // new target replaces the previous on advance anyway, so this module
+    // never wants positionNav to auto-clear the target on reach.
+    positionNavSetAutoClearOnReach(false);
+
     if (flightPlanConfig()->waypointCount == 0) {
         fp.state = FP_NAV_COMPLETE;
         fp.active = true;

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -24,7 +24,8 @@
 
 #include "platform.h"
 
-#if ENABLE_FLIGHT_PLAN
+// positionNav is multirotor-only; flight plan execution follows suit.
+#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
 
 #include "common/time.h"
 #include "common/vector.h"
@@ -40,8 +41,8 @@
 #include "pg/autopilot.h"
 #include "pg/flight_plan.h"
 
-#define FP_MIN_CRUISE_MPS       1.0f
-#define FP_FLYBY_COMPLETION_MPS 2.0f
+#define FP_MIN_CRUISE_MPS         1.0f
+#define FP_FLYBY_COMPLETION_MPS   2.0f
 #define FP_FLYOVER_COMPLETION_MPS 0.5f
 
 static struct {
@@ -50,6 +51,7 @@ static struct {
     timeUs_t holdStartUs;
     uint16_t holdDurationDs;
     bool active;
+    float zBiasM;               // estimator Z at engage, so waypoint Z shares the estimator baseline
 } fp;
 
 static void onWaypointReached(void *userData);
@@ -81,7 +83,10 @@ static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
 
     out->x = enuCm.x * 0.01f;
     out->y = enuCm.y * 0.01f;
-    out->z = (wp->altitude - origin.altCm) * 0.01f;
+    // Waypoint altitude is AMSL (GPS frame); the estimator's Z is zeroed to
+    // whichever source armed it first (baro or GPS). zBiasM is the estimator
+    // reading at engage time, which aligns the target Z with the feedback Z.
+    out->z = (wp->altitude - origin.altCm) * 0.01f + fp.zBiasM;
     return true;
 }
 
@@ -96,13 +101,16 @@ static bool dispatchWaypoint(void)
 
     vector3_t targetEnuM;
     if (!computeTargetEnuM(wp, &targetEnuM)) {
-        // no origin yet; stay idle and retry next engage
+        // No GPS origin captured yet — stay IDLE and let flightPlanNavUpdate()
+        // retry once the estimator has locked in.
         fp.state = FP_NAV_IDLE;
         return false;
     }
 
     const autopilotConfig_t *cfg = autopilotConfig();
-    const float arrivalRadiusM = cfg->waypointArrivalRadius * 0.01f;
+    const bool isHoldOrLand = (wp->type == WAYPOINT_TYPE_HOLD) || (wp->type == WAYPOINT_TYPE_LAND);
+    const float arrivalRadiusM = (isHoldOrLand ? cfg->waypointHoldRadius : cfg->waypointArrivalRadius) * 0.01f;
+
     float cruiseMps = (wp->speed > 0) ? wp->speed * 0.01f : cfg->maxVelocity * 0.01f;
     if (cruiseMps < FP_MIN_CRUISE_MPS) {
         cruiseMps = FP_MIN_CRUISE_MPS;
@@ -124,12 +132,15 @@ static bool dispatchWaypoint(void)
 
 static void advanceToNext(void)
 {
-    fp.currentIndex++;
-    if (fp.currentIndex >= flightPlanConfig()->waypointCount) {
+    if (fp.currentIndex + 1 >= flightPlanConfig()->waypointCount) {
         fp.state = FP_NAV_COMPLETE;
         positionNavClearTarget();
         return;
     }
+    fp.currentIndex++;
+    // If dispatch fails (e.g. origin lost), state falls back to IDLE and the
+    // update loop will retry; index has already advanced so we won't replay
+    // the previous waypoint.
     dispatchWaypoint();
 }
 
@@ -143,6 +154,7 @@ static void onWaypointReached(void *userData)
     const waypoint_t *wp = currentWaypoint();
     if (wp == NULL) {
         fp.state = FP_NAV_COMPLETE;
+        positionNavClearTarget();
         return;
     }
 
@@ -162,19 +174,28 @@ void flightPlanNavInit(void)
     fp.state = FP_NAV_IDLE;
     fp.currentIndex = 0;
     fp.active = false;
+    fp.zBiasM = 0.0f;
 }
 
 void flightPlanNavEngage(void)
 {
-    fp.active = true;
     fp.currentIndex = 0;
     fp.state = FP_NAV_IDLE;
 
+    // Capture the estimator's current Z so subsequent waypoint altitudes are
+    // referenced to the same baseline the position controller uses.
+    fp.zBiasM = positionEstimatorGetAltitudeCm() * 0.01f;
+
     if (flightPlanConfig()->waypointCount == 0) {
         fp.state = FP_NAV_COMPLETE;
+        fp.active = true;
+        positionNavClearTarget();
         return;
     }
 
+    fp.active = true;
+    // Try to dispatch immediately; if the GPS origin isn't ready yet we stay
+    // IDLE and flightPlanNavUpdate() will retry.
     dispatchWaypoint();
 }
 
@@ -191,9 +212,16 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
         return;
     }
 
+    // Retry dispatch if we engaged before the estimator had an origin.
+    if (fp.state == FP_NAV_IDLE && flightPlanConfig()->waypointCount > 0) {
+        dispatchWaypoint();
+        return;
+    }
+
     if (fp.state == FP_NAV_HOLDING) {
         const uint32_t holdUs = (uint32_t)fp.holdDurationDs * 100000u;
-        if (cmpTimeUs(currentTimeUs, fp.holdStartUs) >= (timeDelta_t)holdUs) {
+        const uint32_t elapsedUs = (uint32_t)(currentTimeUs - fp.holdStartUs);
+        if (elapsedUs >= holdUs) {
             advanceToNext();
         }
     }
@@ -214,4 +242,4 @@ uint8_t flightPlanNavGetCurrentIndex(void)
     return fp.currentIndex;
 }
 
-#endif // ENABLE_FLIGHT_PLAN
+#endif // ENABLE_FLIGHT_PLAN && !USE_WING

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/time.h"
+
+typedef enum {
+    FP_NAV_IDLE = 0,
+    FP_NAV_TARGETING,
+    FP_NAV_HOLDING,
+    FP_NAV_COMPLETE,
+} flightPlanNavState_e;
+
+void flightPlanNavInit(void);
+
+// Called when AUTOPILOT mode transitions to active; resets to the first waypoint
+// and feeds it to positionNav. Silently no-ops if the plan is empty or the
+// position estimator has no GPS origin.
+void flightPlanNavEngage(void);
+
+// Called when AUTOPILOT mode transitions to inactive; clears any pending target.
+void flightPlanNavDisengage(void);
+
+// Should be called at the position-control rate. Currently only drives HOLD
+// timing; waypoint advance is callback-driven from positionNav.
+void flightPlanNavUpdate(timeUs_t currentTimeUs);
+
+bool flightPlanNavIsActive(void);
+flightPlanNavState_e flightPlanNavGetState(void);
+uint8_t flightPlanNavGetCurrentIndex(void);

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -36,15 +36,17 @@ typedef enum {
 void flightPlanNavInit(void);
 
 // Called when AUTOPILOT mode transitions to active; resets to the first waypoint
-// and feeds it to positionNav. Silently no-ops if the plan is empty or the
-// position estimator has no GPS origin.
+// and dispatches it to positionNav. If the estimator has no GPS origin yet, the
+// executor stays IDLE and flightPlanNavUpdate() retries dispatch.
 void flightPlanNavEngage(void);
 
 // Called when AUTOPILOT mode transitions to inactive; clears any pending target.
 void flightPlanNavDisengage(void);
 
-// Should be called at the position-control rate. Currently only drives HOLD
-// timing; waypoint advance is callback-driven from positionNav.
+// Called periodically while AUTOPILOT is active; the caller determines the
+// cadence (currently processRxModes()). currentTimeUs must be the current
+// monotonic microsecond timestamp. Drives HOLD-state timeout and retries
+// waypoint dispatch when a GPS origin becomes available.
 void flightPlanNavUpdate(timeUs_t currentTimeUs);
 
 bool flightPlanNavIsActive(void);

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -338,6 +338,14 @@ static void feedGPSMeasurements(timeUs_t nowUs)
                                 altSource == ALTITUDE_SOURCE_GPS_ONLY ||
                                 altSource == ALTITUDE_SOURCE_RANGEFINDER_PREFER);
 
+    // Late origin capture: if XY fusion was enabled before GPS_FIX became
+    // available (e.g. opticalflow-only arm), grab the origin the first time
+    // a valid fix arrives so downstream consumers (flight plan) can proceed.
+    if (xyEnabled && !gpsArmLocationSet && gpsXYAllowed) {
+        armLocationGps = gpsSol.llh;
+        gpsArmLocationSet = true;
+    }
+
     // XY position + velocity measurements
     if (xyEnabled && gpsXYAllowed && gpsArmLocationSet) {
         vector2_t gpsDistCm;

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -259,6 +259,11 @@ void positionEstimatorEnableXY(bool enable)
         lastXYMeasurementUs = 0;
         estimate.isValidXY = false;
 #ifdef USE_GPS
+        // Clear before recapture: a stale origin from a prior XY session must
+        // not survive into a new one, otherwise the late-capture path (see
+        // positionEstimatorUpdate) will skip and we'd target waypoints
+        // against the previous flight's baseline.
+        gpsArmLocationSet = false;
         if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
             armLocationGps = gpsSol.llh;
             gpsArmLocationSet = true;
@@ -685,6 +690,7 @@ void positionEstimatorResetXY(void)
     estimate.isValidXY = false;
     lastXYMeasurementUs = 0;
 #ifdef USE_GPS
+    gpsArmLocationSet = false;
     if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
         armLocationGps = gpsSol.llh;
         gpsArmLocationSet = true;

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -683,3 +683,17 @@ void positionEstimatorResetXY(void)
     }
 #endif
 }
+
+bool positionEstimatorGetGpsOrigin(gpsLocation_t *out)
+{
+#ifdef USE_GPS
+    if (!gpsArmLocationSet || out == NULL) {
+        return false;
+    }
+    *out = armLocationGps;
+    return true;
+#else
+    UNUSED(out);
+    return false;
+#endif
+}

--- a/src/main/flight/position_estimator.h
+++ b/src/main/flight/position_estimator.h
@@ -25,6 +25,8 @@
 #include "common/vector.h"
 #include "common/time.h"
 
+#include "io/gps.h"
+
 // Unified position estimate from Kalman-filter sensor fusion.
 // All values in local ENU (East-North-Up) centimeters, zeroed at arm point.
 typedef struct positionEstimate3d_s {
@@ -55,3 +57,7 @@ float positionEstimatorGetTrustXY(void);
 // Reset (e.g. on arm/disarm)
 void positionEstimatorResetZ(void);
 void positionEstimatorResetXY(void);
+
+// Returns the GPS location captured when XY estimation became active (arm point).
+// Returns false if no GPS origin has been captured yet.
+bool positionEstimatorGetGpsOrigin(gpsLocation_t *out);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -461,6 +461,18 @@ position_nav_unittest_SRC := \
 		$(USER_DIR)/flight/position_nav.c \
 		$(USER_DIR)/common/maths.c \
 		$(USER_DIR)/common/vector.c
+
+flight_plan_nav_unittest_SRC := \
+		$(USER_DIR)/flight/flight_plan_nav.c \
+		$(USER_DIR)/pg/autopilot.c \
+		$(USER_DIR)/pg/flight_plan.c \
+		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/vector.c
+
+flight_plan_nav_unittest_DEFINES := \
+		USE_GPS= \
+		USE_FLIGHT_PLAN= \
+		ENABLE_FLIGHT_PLAN=1
 rcdevice_unittest_DEFINES := \
 		USE_RCDEVICE=
 

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -106,6 +106,11 @@ bool positionEstimatorGetGpsOrigin(gpsLocation_t *out)
     return true;
 }
 
+float positionEstimatorGetAltitudeCm(void)
+{
+    return 0.0f;
+}
+
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
 {
     // Simplified flat-earth approximation sufficient for unit-test deltas.

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -97,6 +97,11 @@ void positionNavClearTarget(void)
     g_lastTarget.valid = false;
 }
 
+void positionNavSetAutoClearOnReach(bool autoClear)
+{
+    (void)autoClear;
+}
+
 bool positionEstimatorGetGpsOrigin(gpsLocation_t *out)
 {
     if (!g_stubGpsOriginSet || out == NULL) {

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -1,0 +1,355 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Betaflight. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "build/debug.h"
+
+    #include "common/maths.h"
+    #include "common/vector.h"
+
+    #include "flight/flight_plan_nav.h"
+    #include "flight/position_estimator.h"
+    #include "flight/position_nav.h"
+
+    #include "io/gps.h"
+
+    #include "pg/autopilot.h"
+    #include "pg/flight_plan.h"
+    #include "pg/pg.h"
+
+    int16_t debug[DEBUG16_VALUE_COUNT];
+    uint8_t debugMode;
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// --- Stubs and test hooks ---
+
+namespace {
+
+struct CapturedTarget {
+    vector3_t targetEfM;
+    float cruiseSpeedMps;
+    float acceptanceRadiusM;
+    float completionSpeedMps;
+    bool includeAltitude;
+    positionNavReachedCallbackFn callback;
+    void *userData;
+    bool valid;
+};
+
+CapturedTarget g_lastTarget;
+int g_setTargetCalls;
+int g_clearTargetCalls;
+
+gpsLocation_t g_stubGpsOrigin;
+bool g_stubGpsOriginSet;
+
+timeUs_t g_stubMicros;
+
+} // namespace
+
+extern "C" {
+
+void positionNavSetTargetEf(
+    const vector3_t *targetPosEfM,
+    float cruiseSpeedMps,
+    float acceptanceRadiusM,
+    float completionSpeedMps,
+    bool includeAltitude,
+    positionNavReachedCallbackFn callback,
+    void *userData)
+{
+    g_lastTarget.targetEfM = *targetPosEfM;
+    g_lastTarget.cruiseSpeedMps = cruiseSpeedMps;
+    g_lastTarget.acceptanceRadiusM = acceptanceRadiusM;
+    g_lastTarget.completionSpeedMps = completionSpeedMps;
+    g_lastTarget.includeAltitude = includeAltitude;
+    g_lastTarget.callback = callback;
+    g_lastTarget.userData = userData;
+    g_lastTarget.valid = true;
+    g_setTargetCalls++;
+}
+
+void positionNavClearTarget(void)
+{
+    g_clearTargetCalls++;
+    g_lastTarget.valid = false;
+}
+
+bool positionEstimatorGetGpsOrigin(gpsLocation_t *out)
+{
+    if (!g_stubGpsOriginSet || out == NULL) {
+        return false;
+    }
+    *out = g_stubGpsOrigin;
+    return true;
+}
+
+void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
+{
+    // Simplified flat-earth approximation sufficient for unit-test deltas.
+    // Matches the axis convention of the real implementation:
+    //   x = east (lon delta), y = north (lat delta), both in cm.
+    // 1 deg ~= 111319.49 m at the equator; 1e7 lat units per degree.
+    const float metresPerLatUnit = 111319.49f / 1.0e7f;
+    distance->x = (to->lon - from->lon) * metresPerLatUnit * 100.0f;
+    distance->y = (to->lat - from->lat) * metresPerLatUnit * 100.0f;
+}
+
+timeUs_t micros(void)
+{
+    return g_stubMicros;
+}
+
+uint32_t millis(void)
+{
+    return g_stubMicros / 1000;
+}
+
+} // extern "C"
+
+class FlightPlanNavTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        memset(&g_lastTarget, 0, sizeof(g_lastTarget));
+        g_setTargetCalls = 0;
+        g_clearTargetCalls = 0;
+        g_stubMicros = 0;
+
+        // Default GPS origin: equator, prime meridian, 100 m AMSL.
+        g_stubGpsOrigin.lat = 0;
+        g_stubGpsOrigin.lon = 0;
+        g_stubGpsOrigin.altCm = 10000;
+        g_stubGpsOriginSet = true;
+
+        flightPlanConfig_t *plan = flightPlanConfigMutable();
+        memset(plan, 0, sizeof(*plan));
+
+        autopilotConfig_t *cfg = autopilotConfigMutable();
+        memset(cfg, 0, sizeof(*cfg));
+        cfg->waypointArrivalRadius = 500; // 5 m
+        cfg->maxVelocity = 1000;          // 10 m/s
+
+        flightPlanNavInit();
+    }
+
+    void addWaypoint(int32_t lat, int32_t lon, int32_t altCm,
+                     uint8_t type, uint16_t speed = 0, uint16_t duration = 0,
+                     uint8_t pattern = WAYPOINT_PATTERN_ORBIT)
+    {
+        flightPlanConfig_t *plan = flightPlanConfigMutable();
+        waypoint_t *wp = &plan->waypoints[plan->waypointCount++];
+        wp->latitude = lat;
+        wp->longitude = lon;
+        wp->altitude = altCm;
+        wp->type = type;
+        wp->speed = speed;
+        wp->duration = duration;
+        wp->pattern = pattern;
+    }
+
+    void triggerReached() {
+        ASSERT_NE(g_lastTarget.callback, nullptr);
+        g_lastTarget.callback(g_lastTarget.userData);
+    }
+};
+
+TEST_F(FlightPlanNavTest, EmptyPlanGoesStraightToComplete)
+{
+    flightPlanNavEngage();
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
+    EXPECT_EQ(g_setTargetCalls, 0);
+}
+
+TEST_F(FlightPlanNavTest, NoGpsOriginLeavesStateIdle)
+{
+    g_stubGpsOriginSet = false;
+    addWaypoint(100, 200, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_IDLE);
+    EXPECT_EQ(g_setTargetCalls, 0);
+}
+
+TEST_F(FlightPlanNavTest, EngageSetsFirstWaypointTarget)
+{
+    // Origin at (0,0,100m). Waypoint 10m east, 20m north, 50m AMSL.
+    // ENU target should be (10, 20, 50 - 100 = -50) m.
+    const int32_t lonUnitsFor10m = (int32_t)((10.0f / 111319.49f) * 1.0e7f);
+    const int32_t latUnitsFor20m = (int32_t)((20.0f / 111319.49f) * 1.0e7f);
+    addWaypoint(latUnitsFor20m, lonUnitsFor10m, 5000, WAYPOINT_TYPE_FLYOVER, 300 /* 3 m/s */);
+
+    flightPlanNavEngage();
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(g_setTargetCalls, 1);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 20.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, -50.0f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 3.0f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.acceptanceRadiusM, 5.0f, 0.01f);
+    EXPECT_TRUE(g_lastTarget.includeAltitude);
+}
+
+TEST_F(FlightPlanNavTest, FallsBackToMaxVelocityWhenWaypointSpeedZero)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    ASSERT_TRUE(g_lastTarget.valid);
+    // maxVelocity is 1000 cm/s = 10 m/s.
+    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 10.0f, 0.01f);
+}
+
+TEST_F(FlightPlanNavTest, FlybyUsesHigherCompletionSpeedThanFlyover)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    const float flyoverCompletion = g_lastTarget.completionSpeedMps;
+
+    // Reset and add a FLYBY.
+    flightPlanConfigMutable()->waypointCount = 0;
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYBY);
+    flightPlanNavEngage();
+    const float flybyCompletion = g_lastTarget.completionSpeedMps;
+
+    EXPECT_GT(flybyCompletion, flyoverCompletion);
+}
+
+TEST_F(FlightPlanNavTest, WaypointReachedAdvancesToNext)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 20000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(g_setTargetCalls, 1);
+
+    triggerReached();
+
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(g_setTargetCalls, 2);
+}
+
+TEST_F(FlightPlanNavTest, ReachingLastWaypointCompletes)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    triggerReached();
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
+    EXPECT_GE(g_clearTargetCalls, 1);
+}
+
+TEST_F(FlightPlanNavTest, HoldWithDurationEntersHoldingThenAdvances)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_HOLD, 0, 20 /* 2.0 s */);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    triggerReached();
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+    EXPECT_EQ(g_setTargetCalls, 1);
+
+    // Tick before timer expires — still holding.
+    g_stubMicros += 1'000'000; // +1 s
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+
+    // Tick past expiry — advances.
+    g_stubMicros += 1'500'000; // +2.5 s total
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+    EXPECT_EQ(g_setTargetCalls, 2);
+}
+
+TEST_F(FlightPlanNavTest, HoldWithZeroDurationAdvancesImmediately)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_HOLD, 0, 0);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    triggerReached();
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+}
+
+TEST_F(FlightPlanNavTest, DisengageClearsTargetAndResetsState)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    ASSERT_TRUE(flightPlanNavIsActive());
+
+    flightPlanNavDisengage();
+
+    EXPECT_FALSE(flightPlanNavIsActive());
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_IDLE);
+    EXPECT_GE(g_clearTargetCalls, 1);
+}
+
+TEST_F(FlightPlanNavTest, DisengagedUpdateIsNoOp)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_HOLD, 0, 20);
+    flightPlanNavEngage();
+    triggerReached();
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+
+    flightPlanNavDisengage();
+    g_stubMicros += 10'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_IDLE);
+}
+
+TEST_F(FlightPlanNavTest, ReEngageRestartsAtFirstWaypoint)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    triggerReached();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 1);
+
+    flightPlanNavDisengage();
+    flightPlanNavEngage();
+
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+}
+
+TEST_F(FlightPlanNavTest, EngageClampsBelowMinCruiseSpeed)
+{
+    // maxVelocity small enough that 1 m/s floor should kick in.
+    autopilotConfigMutable()->maxVelocity = 20; // 0.2 m/s
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    EXPECT_GE(g_lastTarget.cruiseSpeedMps, 1.0f - 0.01f);
+}


### PR DESCRIPTION
## Summary

Adds the minimum glue needed to execute a flight plan autonomously when `BOXAUTOPILOT` is active. Position tracking and PID are handled by the `positionNav` module from #15026 — this PR only feeds it a target per waypoint and advances on the reached callback.

Builds on:
- #15026 (Nav autopilot) — `positionNavSetTargetEf()` and the position control loop
- #15030 (Flight plan PG + CLI + AUTOPILOT mode) — waypoint storage, CLI CRUD, `BOXAUTOPILOT` flag, `ENABLE_FLIGHT_PLAN` gate

## What this PR adds

- `flight/flight_plan_nav.c/h` — small state machine: on engage, walk the waypoint array; for each waypoint convert lat/lon/altAMSL to the ENU frame used by `positionNav` and call `positionNavSetTargetEf()`; advance on the reached callback.
- `positionEstimatorGetGpsOrigin()` — exposes the arm-time GPS location so waypoints can be converted to the estimator's ENU frame.
- `fc/core.c` — hook to engage/disengage the executor on `AUTOPILOT_MODE` transitions (gated on armed + GPS fix + throttle raised, mutually exclusive with `GPS_RESCUE_MODE`).
- `fc/init.c` — one-shot init.

## Waypoint type coverage

| Type | Status |
|------|--------|
| FLYOVER | supported (completion speed near zero) |
| FLYBY | supported (non-zero completion speed so craft curves through) |
| HOLD | supported; advances after `duration` elapses |
| LAND | TODO — currently advances like FLYOVER |
| ORBIT / FIGURE8 pattern | TODO — not yet generating sub-targets |

## Out of scope (follow-up PRs)

- LAND descent + touchdown detection
- ORBIT / FIGURE8 sub-target generation for HOLD
- Geofence enforcement (`maxDistanceFromHomeM`)
- RX loss policy (`rxLossPolicy`)
- Pilot stick override behaviour during AUTOPILOT
- SITL/Gazebo model changes (motor ordering, etc.) — separate PR
- OSD element wiring — separate PR

## Unit tests

Added `<flight_plan_nav_unittest.cc>` covering engage with empty plan, engage with no GPS origin, first-waypoint target geometry, speed fallback + floor, FLYBY vs FLYOVER completion thresholds, callback-driven advance, last-waypoint completion, HOLD timing, disengage/re-engage state reset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flight-plan navigation: autopilot can follow configured waypoints (fly-by, fly-over, hold) with configurable speeds and durations; engages via AUTOPILOT mode and advances/holds waypoints automatically.
  * Improved GPS origin handling so waypoint dispatch works reliably when origin is captured later.

* **Tests**
  * Added unit tests covering navigation behavior: engage/disengage, waypoint progression, holds, and speed selection.

* **Chores**
  * Updated build/test configuration to include the new navigation module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->