### PR TITLE
SENSOR: add INA226 power monitor support

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -327,6 +327,7 @@ COMMON_SRC += \
             drivers/compass/compass_mpu925x_ak8963.c \
             drivers/compass/compass_qmc5883.c \
             drivers/compass/compass_virtual.c \
+            drivers/ina226.c \
             drivers/max7456.c \
             drivers/vtx_rtc6705.c \
             drivers/vtx_rtc6705_soft_spi.c

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -164,9 +164,14 @@ bool cliMode = false;
 #include "sensors/battery.h"
 #include "sensors/boardalignment.h"
 #include "sensors/compass.h"
+#include "sensors/current.h"
 #include "sensors/gyro.h"
 #include "sensors/gyro_init.h"
 #include "sensors/sensors.h"
+
+#ifdef USE_CURRENT_METER_INA226
+#include "drivers/ina226.h"
+#endif
 
 #include "telemetry/frsky_hub.h"
 #include "telemetry/telemetry.h"
@@ -4684,6 +4689,212 @@ STATIC_UNIT_TESTED void cliSet(const char *cmdName, char *cmdline)
     }
 }
 
+#if defined(USE_I2C)
+static void cliI2cScan(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    
+    int busNum = 0;
+    if (*cmdline) {
+        busNum = atoi(cmdline);
+    }
+    
+    if (busNum < 0 || busNum >= I2CDEV_COUNT) {
+        cliPrintLinef("Usage: i2c_scan [bus] (0-%d)", I2CDEV_COUNT - 1);
+        return;
+    }
+    
+    i2cDevice_e device = busNum;
+    
+    cliPrintLinef("Scanning I2C bus %d...", busNum);
+    
+    int foundCount = 0;
+    for (uint8_t addr = 0x08; addr < 0x78; addr++) {
+        uint8_t data;
+        // Try to read one byte from address 0x00
+        if (i2cRead(device, addr, 0x00, 1, &data)) {
+            cliPrintLinef("  Found device at 0x%02X (dec %d)", addr, addr);
+            foundCount++;
+        }
+        delay(1);  // Small delay between scans
+    }
+    
+    if (foundCount == 0) {
+        cliPrintLinef("No devices found on I2C bus %d", busNum);
+    } else {
+        cliPrintLinef("Found %d device(s) on I2C bus %d", foundCount, busNum);
+    }
+}
+
+static void cliI2cRead(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    
+    int bus = 0, addr = 0, reg = 0, len = 1;
+    
+    char *ptr = cmdline;
+    char *tok;
+    
+    // Parse: bus addr reg [len]
+    tok = strtok(ptr, " ");
+    if (tok) bus = atoi(tok);
+    tok = strtok(NULL, " ");
+    if (tok) addr = strtol(tok, NULL, 0);  // allows 0x prefix
+    tok = strtok(NULL, " ");
+    if (tok) reg = strtol(tok, NULL, 0);
+    tok = strtok(NULL, " ");
+    if (tok) len = atoi(tok);
+    
+    if (addr < 0x08 || addr > 0x77 || len < 1 || len > 16) {
+        cliPrintLinef("Usage: i2c_read <bus> <addr> <reg> [len]");
+        cliPrintLinef("  bus: 0-%d", I2CDEV_COUNT - 1);
+        cliPrintLinef("  addr: 0x08-0x77 (7-bit address)");
+        cliPrintLinef("  reg: register address (0x00-0xFF)");
+        cliPrintLinef("  len: bytes to read (1-16, default 1)");
+        return;
+    }
+    
+    uint8_t data[16];
+    if (i2cRead((i2cDevice_e)bus, addr, reg, len, data)) {
+        cliPrintf("I2C[%d] 0x%02X reg 0x%02X:", bus, addr, reg);
+        for (int i = 0; i < len; i++) {
+            cliPrintf(" %02X", data[i]);
+        }
+        if (len == 2) {
+            // Show 16-bit value (big-endian, common for sensors)
+            uint16_t val16 = ((uint16_t)data[0] << 8) | data[1];
+            cliPrintf(" (=0x%04X, %u)", val16, val16);
+        }
+        cliPrintLinefeed();
+    } else {
+        cliPrintLinef("I2C read failed");
+    }
+}
+#endif
+
+#ifdef USE_CURRENT_METER_INA226
+static void cliINA226Status(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+    
+    cliPrintLinef("INA226 Current Sensor Status:");
+    cliPrintLinef("  Initialized: %s", ina226IsInitialized() ? "YES" : "NO");
+    cliPrintLinef("  Detect stage: %d (0=not tried, 1=mfg fail, 2=die fail, 3=ok)", ina226GetDetectStage());
+    cliPrintLinef("  Init stage: %d (0=not tried, 1=detect fail, 2=reset fail, 3=config fail, 4=ok)", ina226GetInitStage());
+    cliPrintLinef("  Last Manufacturer ID: 0x%04X (expected 0x5449 'TI')", ina226GetLastMfgId());
+    cliPrintLinef("  Last Die ID: 0x%04X (expected 0x2260)", ina226GetLastDieId());
+    
+    // Show configuration
+    const currentSensorINA226Config_t *config = currentSensorINA226Config();
+    cliPrintLinef("  Config: i2c_device=%d, address=0x%02X, shunt=%d uOhm, max_current=%d mA, vbat_scale=%d", 
+                  config->i2cDevice, config->address, config->shuntResistanceMicroOhms, 
+                  config->maxExpectedCurrentMa, config->vbatScale);
+    
+    // Calculate and show current LSB for debugging
+    uint32_t currentLsbNa = ((uint32_t)config->maxExpectedCurrentMa * 1000000UL) / 32768UL;
+    cliPrintLinef("  Calculated current_LSB: %lu nA (%lu.%02lu mA per bit)", 
+                  (unsigned long)currentLsbNa, 
+                  (unsigned long)(currentLsbNa / 1000000), 
+                  (unsigned long)((currentLsbNa % 1000000) / 10000));
+    
+    // Try direct read from INA226
+    if (ina226IsInitialized()) {
+        // Read current meter state
+        currentMeter_t meter;
+        currentMeterINA226Read(&meter);
+        cliPrintLinef("  Current (from state): %d.%02d A", meter.amperage / 100, ABS(meter.amperage) % 100);
+        cliPrintLinef("  mAh drawn: %d", meter.mAhDrawn);
+        
+        // Show cached voltage
+        uint16_t voltageMv = ina226GetLastVoltageMv();
+        cliPrintLinef("  Voltage (cached): %d.%02d V", voltageMv / 1000, (voltageMv % 1000) / 10);
+        
+        // Try calling ina226Read directly with proper calibration
+        cliPrintLinef("  --- Driver Read Test (with calibration) ---");
+        i2cDevice_e i2cDev = config->i2cDevice > 0 ? (config->i2cDevice - 1) : I2CDEV_0;
+        ina226Config_t testCfg = {
+            .i2cDevice = i2cDev,
+            .address = config->address,
+            .shuntResistorMicroOhms = config->shuntResistanceMicroOhms,
+            .maxCurrentMa = config->maxExpectedCurrentMa,
+            .calibrationValue = 0,
+            .currentLsbNa = currentLsbNa
+        };
+        // Calculate calibration
+        uint64_t numerator = 5120000000000ULL;
+        uint64_t denominator = (uint64_t)currentLsbNa * (uint64_t)config->shuntResistanceMicroOhms;
+        if (denominator > 0) {
+            testCfg.calibrationValue = (uint16_t)(numerator / denominator);
+        }
+        cliPrintLinef("  Calibration value: %d", testCfg.calibrationValue);
+        
+        ina226Data_t testData;
+        bool readOk = ina226Read(&testCfg, &testData);
+        cliPrintLinef("  ina226Read() returned: %s", readOk ? "TRUE" : "FALSE");
+        if (readOk) {
+            cliPrintLinef("  shuntVoltageRaw: %d (LSB=2.5uV -> %d uV)", 
+                          testData.shuntVoltageRaw, 
+                          (testData.shuntVoltageRaw * 25) / 10);
+            cliPrintLinef("  busVoltageRaw: 0x%04X", testData.busVoltageRaw);
+            cliPrintLinef("  busVoltageMv: %d", testData.busVoltageMv);
+            cliPrintLinef("  currentRaw: %d", testData.currentRaw);
+            cliPrintLinef("  currentMa: %ld", (long)testData.currentMa);
+            cliPrintLinef("  powerMw: %lu", (unsigned long)testData.powerMw);
+            cliPrintLinef("  dataValid: %s", testData.dataValid ? "YES" : "NO");
+        }
+        
+        // Force manual refresh and check result
+        cliPrintLinef("  --- Manual Refresh Test ---");
+        currentMeterINA226Refresh(1000);  // 1000us = 1ms fake update time
+        voltageMv = ina226GetLastVoltageMv();
+        cliPrintLinef("  After refresh voltage: %d.%02d V", voltageMv / 1000, (voltageMv % 1000) / 10);
+        
+        // Try direct I2C read of shunt voltage register (0x01)
+        cliPrintLinef("  --- Direct I2C Read Test ---");
+        uint8_t rxBuf[2] = { 0 };
+        bool i2cError = false;
+        
+        // Read shunt voltage register (0x01)
+        if (i2cRead(i2cDev, config->address, 0x01, 2, rxBuf)) {
+            while (i2cBusy(i2cDev, &i2cError)) {}
+            int16_t rawShunt = (int16_t)((rxBuf[0] << 8) | rxBuf[1]);
+            int32_t shuntUv = (rawShunt * 25) / 10;  // 2.5uV per LSB
+            cliPrintLinef("  Shunt voltage raw: %d -> %ld uV", rawShunt, (long)shuntUv);
+            // Calculate current from shunt voltage
+            if (config->shuntResistanceMicroOhms > 0) {
+                int32_t calcCurrentMa = (rawShunt * 2500L) / (int32_t)config->shuntResistanceMicroOhms;
+                cliPrintLinef("  Calc current from shunt: %ld mA", (long)calcCurrentMa);
+            }
+        }
+        
+        // Read bus voltage register (0x02)
+        if (i2cRead(i2cDev, config->address, 0x02, 2, rxBuf)) {
+            while (i2cBusy(i2cDev, &i2cError)) {}
+            uint16_t rawVoltage = (rxBuf[0] << 8) | rxBuf[1];
+            uint16_t voltageMvDirect = (uint32_t)rawVoltage * 125 / 100;
+            cliPrintLinef("  Bus voltage raw: 0x%04X -> %d mV", rawVoltage, voltageMvDirect);
+        }
+    }
+}
+
+static void cliINA226Init(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+    
+    cliPrintLinef("Manually initializing INA226...");
+    currentMeterINA226Init();
+    
+    if (ina226IsInitialized()) {
+        cliPrintLinef("INA226 initialized successfully!");
+    } else {
+        cliPrintLinef("INA226 initialization failed!");
+        cliPrintLinef("  Init stage: %d (1=detect, 2=reset, 3=config)", ina226GetInitStage());
+    }
+}
+#endif
+
 static void cliStatus(const char *cmdName, char *cmdline)
 {
     UNUSED(cmdName);
@@ -6636,6 +6847,14 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("gyroregisters", "dump gyro config registers contents", NULL, cliDumpGyroRegisters),
 #endif
     CLI_COMMAND_DEF("help", "display command help", "[search string]", cliHelp),
+#if defined(USE_I2C)
+    CLI_COMMAND_DEF("i2c_read", "read I2C register", "<bus> <addr> <reg> [len]", cliI2cRead),
+    CLI_COMMAND_DEF("i2c_scan", "scan I2C bus for devices", "[bus]", cliI2cScan),
+#endif
+#ifdef USE_CURRENT_METER_INA226
+    CLI_COMMAND_DEF("ina226_init", "manually initialize INA226", NULL, cliINA226Init),
+    CLI_COMMAND_DEF("ina226_status", "show INA226 current sensor status", NULL, cliINA226Status),
+#endif
 #ifdef USE_LED_STRIP_STATUS_MODE
         CLI_COMMAND_DEF("led", "configure leds", NULL, cliLed),
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -4794,10 +4794,14 @@ static void cliINA226Status(const char *cmdName, char *cmdline)
     // Calculate and show current LSB for debugging
     // Use 64-bit math to avoid overflow when maxExpectedCurrentMa >= 4295 mA
     uint64_t currentLsbNa = ((uint64_t)config->maxExpectedCurrentMa * 1000000ULL) / 32768ULL;
-    cliPrintLinef("  Calculated current_LSB: %llu nA (%llu.%02llu mA per bit)", 
-                  (unsigned long long)currentLsbNa, 
-                  (unsigned long long)(currentLsbNa / 1000000ULL), 
-                  (unsigned long long)((currentLsbNa % 1000000ULL) / 10000ULL));
+    // Use uint32_t casts — Betaflight's printf does not support %llu reliably
+    uint32_t lsbNaLo = (uint32_t)(currentLsbNa & 0xFFFFFFFF);
+    uint32_t lsbMaPart = (uint32_t)(currentLsbNa / 1000000ULL);
+    uint32_t lsbMaFrac = (uint32_t)((currentLsbNa % 1000000ULL) / 10000ULL);
+    cliPrintLinef("  Calculated current_LSB: %lu nA (%lu.%02lu mA per bit)",
+                  (unsigned long)lsbNaLo,
+                  (unsigned long)lsbMaPart,
+                  (unsigned long)lsbMaFrac);
     
     // Try direct read from INA226
     if (ina226IsInitialized()) {
@@ -4813,7 +4817,7 @@ static void cliINA226Status(const char *cmdName, char *cmdline)
         
         // Try calling ina226Read directly with proper calibration
         cliPrintLinef("  --- Driver Read Test (with calibration) ---");
-        i2cDevice_e i2cDev = config->i2cDevice > 0 ? (config->i2cDevice - 1) : I2CDEV_0;
+        i2cDevice_e i2cDev = config->i2cDevice > 0 ? I2C_CFG_TO_DEV(config->i2cDevice) : I2CDEV_FIRST;
         ina226Config_t testCfg = {
             .i2cDevice = i2cDev,
             .address = config->address,
@@ -4858,7 +4862,10 @@ static void cliINA226Status(const char *cmdName, char *cmdline)
         
         // Read shunt voltage register (0x01)
         if (i2cRead(i2cDev, config->address, 0x01, 2, rxBuf)) {
-            while (i2cBusy(i2cDev, &i2cError)) {}
+            timeUs_t busyTimeout = micros() + 10000;
+            while (i2cBusy(i2cDev, &i2cError)) {
+                if (cmpTimeUs(micros(), busyTimeout) >= 0) break;
+            }
             int16_t rawShunt = (int16_t)((rxBuf[0] << 8) | rxBuf[1]);
             int32_t shuntUv = (rawShunt * 25) / 10;  // 2.5uV per LSB
             cliPrintLinef("  Shunt voltage raw: %d -> %ld uV", rawShunt, (long)shuntUv);
@@ -4871,7 +4878,10 @@ static void cliINA226Status(const char *cmdName, char *cmdline)
         
         // Read bus voltage register (0x02)
         if (i2cRead(i2cDev, config->address, 0x02, 2, rxBuf)) {
-            while (i2cBusy(i2cDev, &i2cError)) {}
+            timeUs_t busyTimeout2 = micros() + 10000;
+            while (i2cBusy(i2cDev, &i2cError)) {
+                if (cmpTimeUs(micros(), busyTimeout2) >= 0) break;
+            }
             uint16_t rawVoltage = (rxBuf[0] << 8) | rxBuf[1];
             uint16_t voltageMvDirect = (uint32_t)rawVoltage * 125 / 100;
             cliPrintLinef("  Bus voltage raw: 0x%04X -> %d mV", rawVoltage, voltageMvDirect);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -127,6 +127,7 @@
 #include "sensors/battery.h"
 #include "sensors/boardalignment.h"
 #include "sensors/compass.h"
+#include "sensors/current.h"
 #include "sensors/esc_sensor.h"
 #include "sensors/gyro.h"
 #include "sensors/rangefinder.h"
@@ -1076,6 +1077,14 @@ const clivalue_t valueTable[] = {
 #ifdef USE_VIRTUAL_CURRENT_METER
     { "ibatv_scale",                VAR_INT16  | MASTER_VALUE, .config.minmax = { -16000, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, scale) },
     { "ibatv_offset",               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 16000 }, PG_CURRENT_SENSOR_VIRTUAL_CONFIG, offsetof(currentSensorVirtualConfig_t, offset) },
+#endif
+#ifdef USE_CURRENT_METER_INA226
+// PG_CURRENT_SENSOR_INA226_CONFIG
+    { "ina226_i2c_device",          VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2CDEV_COUNT }, PG_CURRENT_SENSOR_INA226_CONFIG, offsetof(currentSensorINA226Config_t, i2cDevice) },
+    { "ina226_address",             VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0x40, 0x4F }, PG_CURRENT_SENSOR_INA226_CONFIG, offsetof(currentSensorINA226Config_t, address) },
+    { "ina226_shunt_uohm",          VAR_UINT16 | HARDWARE_VALUE, .config.minmaxUnsigned = { 100, 65535 }, PG_CURRENT_SENSOR_INA226_CONFIG, offsetof(currentSensorINA226Config_t, shuntResistanceMicroOhms) },
+    { "ina226_max_current",         VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1000, 65535 }, PG_CURRENT_SENSOR_INA226_CONFIG, offsetof(currentSensorINA226Config_t, maxExpectedCurrentMa) },
+    { "ina226_vbat_scale",          VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 50, 150 }, PG_CURRENT_SENSOR_INA226_CONFIG, offsetof(currentSensorINA226Config_t, vbatScale) },
 #endif
 #ifdef USE_BATTERY_CONTINUE
     { "battery_continue",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, isBatteryContinueEnabled) },

--- a/src/main/drivers/ina226.c
+++ b/src/main/drivers/ina226.c
@@ -146,11 +146,13 @@ bool ina226Detect(i2cDevice_e device, uint8_t address)
         return false;
     }
     
-    ina226DetectStage = 3;  // Success
     // Validate manufacturer ID (Texas Instruments = 0x5449)
     if (ina226LastMfgId != INA226_MANUFACTURER_ID) {
+        ina226DetectStage = 4;  // Manufacturer ID mismatch
         return false;
     }
+    
+    ina226DetectStage = 3;  // Success
     return true;
 }
 
@@ -369,7 +371,8 @@ bool ina226Read(const ina226Config_t *config, ina226Data_t *data)
         }
         data->currentRaw = 0;
         data->powerRaw = 0;
-        data->powerMw = ((uint32_t)abs(data->currentMa) * (uint32_t)data->busVoltageMv) / 1000UL;
+        // Use uint64_t for consistency with calibrated path to prevent overflow with high current
+        data->powerMw = (uint32_t)(((uint64_t)abs(data->currentMa) * (uint64_t)data->busVoltageMv) / 1000ULL);
     }
     
     data->dataValid = true;

--- a/src/main/drivers/ina226.c
+++ b/src/main/drivers/ina226.c
@@ -1,0 +1,415 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "platform.h"
+
+#ifdef USE_CURRENT_METER_INA226
+
+#include "drivers/bus_i2c.h"
+#include "drivers/ina226.h"
+#include "drivers/time.h"
+
+/**
+ * @brief Write a 16-bit value to an INA226 register.
+ *
+ * Handles byte order (MSB first) and waits for the I2C transaction to complete.
+ *
+ * @param device  I2C device to use.
+ * @param address I2C address of the INA226.
+ * @param reg     Register address to write.
+ * @param value   16-bit value to write.
+ * @return true if write succeeded, false otherwise.
+ */
+static bool ina226WriteRegister(i2cDevice_e device, uint8_t address, uint8_t reg, uint16_t value)
+{
+    uint8_t data[2];
+    data[0] = (value >> 8) & 0xFF;  // MSB first
+    data[1] = value & 0xFF;         // LSB
+    
+    if (!i2cWriteBuffer(device, address, reg, 2, data)) {
+        return false;
+    }
+    
+    // Wait for write to complete (important for PICO platform)
+    bool error = false;
+    while (i2cBusy(device, &error)) {
+        // Wait until transfer is complete
+    }
+    
+    return !error;
+}
+
+/**
+ * @brief Read a 16-bit value from an INA226 register.
+ *
+ * Handles byte order (MSB first) and waits for the I2C transaction to complete.
+ *
+ * @param device  I2C device to use.
+ * @param address I2C address of the INA226.
+ * @param reg     Register address to read.
+ * @param value   Pointer to store the 16-bit value.
+ * @return true if read succeeded, false otherwise.
+ */
+static bool ina226ReadRegister(i2cDevice_e device, uint8_t address, uint8_t reg, uint16_t *value)
+{
+    uint8_t data[2];
+    if (!i2cRead(device, address, reg, 2, data)) {
+        return false;
+    }
+    
+    // Wait for read to complete (important for PICO platform)
+    bool error = false;
+    while (i2cBusy(device, &error)) {
+        // Wait until transfer is complete
+    }
+    
+    if (error) {
+        return false;
+    }
+    
+    *value = ((uint16_t)data[0] << 8) | data[1];  // MSB first
+    return true;
+}
+
+// Global variables for detection diagnostics  
+static uint16_t ina226LastMfgId = 0;
+static uint16_t ina226LastDieId = 0;
+static uint8_t ina226DetectStage = 0;  // 0=not tried, 1=mfg read fail, 2=die read fail, 3=success
+static uint8_t ina226InitStage = 0;    // 0=not tried, 1=detect fail, 2=reset fail, 3=config fail, 4=success
+
+uint16_t ina226GetLastMfgId(void) { return ina226LastMfgId; }
+uint16_t ina226GetLastDieId(void) { return ina226LastDieId; }
+uint8_t ina226GetDetectStage(void) { return ina226DetectStage; }
+uint8_t ina226GetInitStage(void) { return ina226InitStage; }
+
+/**
+ * @brief Detect INA226 at the specified I2C address.
+ *
+ * Reads manufacturer and die ID registers to verify device presence.
+ * Detection results are stored for diagnostic access via getter functions.
+ *
+ * @param device  I2C device to use.
+ * @param address I2C address to probe.
+ * @return true if INA226 detected, false otherwise.
+ */
+bool ina226Detect(i2cDevice_e device, uint8_t address)
+{
+    ina226DetectStage = 0;
+    ina226LastMfgId = 0;
+    ina226LastDieId = 0;
+    
+    // Try to read manufacturer ID
+    if (!ina226ReadRegister(device, address, INA226_REG_MANUFACTURER_ID, &ina226LastMfgId)) {
+        ina226DetectStage = 1;  // Manufacturer ID read failed
+        return false;
+    }
+    
+    // Read die ID  
+    if (!ina226ReadRegister(device, address, INA226_REG_DIE_ID, &ina226LastDieId)) {
+        ina226DetectStage = 2;  // Die ID read failed
+        return false;
+    }
+    
+    ina226DetectStage = 3;  // Success
+    // Accept any device that responds - we'll validate values if needed
+    return true;
+}
+
+/**
+ * @brief Calculate calibration register value for INA226.
+ *
+ * Computes Current_LSB and calibration value based on shunt resistor and
+ * maximum expected current. Uses uint64_t arithmetic to prevent overflow.
+ *
+ * @param config Pointer to INA226 configuration (modified with calculated values).
+ */
+static void ina226CalculateCalibration(ina226Config_t *config)
+{
+    // Calculate Current_LSB = MaxCurrent / 2^15
+    // Current_LSB in A = maxCurrentMa / 1000 / 32768
+    // To preserve precision, we calculate in nA:
+    // currentLsbNa = (maxCurrentMa * 1000000) / 32768
+    // IMPORTANT: Use uint64_t to avoid overflow when maxCurrentMa >= 4295 mA (4.3A)
+    // Example: 50000 * 1000000 = 50,000,000,000 which exceeds uint32_t max (4,294,967,295)
+    config->currentLsbNa = (uint32_t)(((uint64_t)config->maxCurrentMa * 1000000ULL) / 32768ULL);
+    
+    // Calibration = 0.00512 / (Current_LSB * RSHUNT)
+    // Where RSHUNT is in ohms
+    // Cal = 0.00512 / ((currentLsbNa * 1e-9) * (shuntResistorMicroOhms * 1e-6))
+    // Cal = 0.00512 / (currentLsbNa * shuntResistorMicroOhms * 1e-15)
+    // Cal = 0.00512 * 1e15 / (currentLsbNa * shuntResistorMicroOhms)
+    // Cal = 5.12e12 / (currentLsbNa * shuntResistorMicroOhms)
+    
+    uint64_t numerator = 5120000000000ULL;  // 5.12e12
+    uint64_t denominator = (uint64_t)config->currentLsbNa * (uint64_t)config->shuntResistorMicroOhms;
+    
+    if (denominator > 0) {
+        config->calibrationValue = (uint16_t)(numerator / denominator);
+    } else {
+        config->calibrationValue = 0;
+    }
+}
+
+/**
+ * @brief Initialize the INA226 power monitor.
+ *
+ * Detects the device, performs a software reset, calculates calibration,
+ * and configures the operating mode.
+ *
+ * @param config Pointer to INA226 configuration structure.
+ * @return true if initialization succeeded, false otherwise.
+ */
+bool ina226Init(ina226Config_t *config)
+{
+    ina226InitStage = 0;
+    
+    if (!config) {
+        return false;
+    }
+    
+    // Wait for I2C bus to stabilize (important for PICO platform)
+    delay(50);
+    
+    // Try the configured address only - no auto-detection to avoid I2C errors
+    bool detected = ina226Detect(config->i2cDevice, config->address);
+    
+    if (!detected) {
+        ina226InitStage = 1;  // Detect failed
+        return false;
+    }
+    
+    // Reset the device
+    if (!ina226Reset(config)) {
+        ina226InitStage = 2;  // Reset failed
+        return false;
+    }
+    
+    delay(5);  // Wait for reset to complete
+    
+    // Calculate calibration value
+    ina226CalculateCalibration(config);
+    
+    // Configure and write calibration
+    if (!ina226Configure(config)) {
+        ina226InitStage = 3;  // Configure failed
+        return false;
+    }
+    
+    ina226InitStage = 4;  // Success
+    return true;
+}
+
+/**
+ * @brief Reset the INA226 to default settings.
+ *
+ * @param config Pointer to INA226 configuration.
+ * @return true if reset succeeded, false otherwise.
+ */
+bool ina226Reset(const ina226Config_t *config)
+{
+    return ina226WriteRegister(config->i2cDevice, config->address, 
+                               INA226_REG_CONFIG, INA226_CONFIG_RESET);
+}
+
+/**
+ * @brief Configure INA226 operating mode and write calibration.
+ *
+ * Sets up continuous measurement with 16-sample averaging and 1.1ms
+ * conversion time for both shunt and bus voltage.
+ *
+ * @param config Pointer to INA226 configuration.
+ * @return true if configuration succeeded, false otherwise.
+ */
+bool ina226Configure(const ina226Config_t *config)
+{
+    // Configuration:
+    // - Average: 16 samples (improves noise performance)
+    // - Bus voltage conversion time: 1.1ms
+    // - Shunt voltage conversion time: 1.1ms
+    // - Mode: Continuous shunt and bus voltage
+    // This gives ~35ms total conversion time (16 * 2 * 1.1ms)
+    
+    uint16_t configReg = (INA226_AVG_16 << 9) |       // Average 16 samples
+                         (INA226_CT_1100US << 6) |     // Bus voltage 1.1ms
+                         (INA226_CT_1100US << 3) |     // Shunt voltage 1.1ms
+                         INA226_MODE_SHUNT_BUS_CONT;   // Continuous mode
+    
+    if (!ina226WriteRegister(config->i2cDevice, config->address, 
+                             INA226_REG_CONFIG, configReg)) {
+        return false;
+    }
+    
+    // Write calibration register
+    if (config->calibrationValue > 0) {
+        if (!ina226WriteRegister(config->i2cDevice, config->address,
+                                 INA226_REG_CALIBRATION, config->calibrationValue)) {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
+/**
+ * @brief Read all measurement data from INA226.
+ *
+ * Reads shunt voltage, bus voltage, current, and power registers.
+ * Converts raw values to engineering units (mV, mA, mW).
+ *
+ * @param config Pointer to INA226 configuration.
+ * @param data   Pointer to data structure to fill with readings.
+ * @return true if read succeeded, false otherwise.
+ */
+bool ina226Read(const ina226Config_t *config, ina226Data_t *data)
+{
+    if (!config || !data) {
+        return false;
+    }
+    
+    uint16_t regValue;
+    
+    // Read shunt voltage register
+    if (!ina226ReadRegister(config->i2cDevice, config->address, 
+                            INA226_REG_SHUNT_VOLTAGE, &regValue)) {
+        data->dataValid = false;
+        return false;
+    }
+    data->shuntVoltageRaw = (int16_t)regValue;
+    
+    // Read bus voltage register
+    if (!ina226ReadRegister(config->i2cDevice, config->address,
+                            INA226_REG_BUS_VOLTAGE, &regValue)) {
+        data->dataValid = false;
+        return false;
+    }
+    data->busVoltageRaw = regValue;
+    // Bus voltage: LSB = 1.25mV
+    data->busVoltageMv = (uint16_t)((uint32_t)data->busVoltageRaw * 125 / 100);
+    
+    // Read current register (requires calibration to be set)
+    if (config->calibrationValue > 0) {
+        if (!ina226ReadRegister(config->i2cDevice, config->address,
+                                INA226_REG_CURRENT, &regValue)) {
+            data->dataValid = false;
+            return false;
+        }
+        data->currentRaw = (int16_t)regValue;
+        // Convert to mA: current_mA = currentRaw * currentLsbNa / 1000000
+        // Use int64_t to prevent overflow when currentRaw * currentLsbNa > 2^31
+        // Example: currentRaw=30000 * currentLsbNa=1525878 = 45,776,340,000 (exceeds int32_t)
+        data->currentMa = (int32_t)(((int64_t)data->currentRaw * (int64_t)config->currentLsbNa) / 1000000LL);
+        
+        // Read power register
+        if (!ina226ReadRegister(config->i2cDevice, config->address,
+                                INA226_REG_POWER, &regValue)) {
+            data->dataValid = false;
+            return false;
+        }
+        data->powerRaw = regValue;
+        // Power LSB = 25 * Current_LSB
+        // power_mW = powerRaw * 25 * currentLsbNa / 1000000
+        data->powerMw = ((uint32_t)data->powerRaw * 25UL * config->currentLsbNa) / 1000000UL;
+    } else {
+        // No calibration - calculate current from shunt voltage and resistance
+        // shuntVoltage_uV = shuntVoltageRaw * 2.5
+        // current_mA = shuntVoltage_uV / shuntResistorMicroOhms * 1000
+        // current_mA = shuntVoltageRaw * 2.5 * 1000 / shuntResistorMicroOhms
+        // current_mA = shuntVoltageRaw * 2500 / shuntResistorMicroOhms
+        if (config->shuntResistorMicroOhms > 0) {
+            data->currentMa = ((int32_t)data->shuntVoltageRaw * 2500L) / 
+                              (int32_t)config->shuntResistorMicroOhms;
+        } else {
+            data->currentMa = 0;
+        }
+        data->currentRaw = 0;
+        data->powerRaw = 0;
+        data->powerMw = ((uint32_t)abs(data->currentMa) * (uint32_t)data->busVoltageMv) / 1000UL;
+    }
+    
+    data->dataValid = true;
+    return true;
+}
+
+/**
+ * @brief Read current measurement from INA226.
+ *
+ * @param config    Pointer to INA226 configuration.
+ * @param currentMa Pointer to store current in milliamps.
+ * @return true if read succeeded, false otherwise.
+ */
+bool ina226ReadCurrent(const ina226Config_t *config, int32_t *currentMa)
+{
+    ina226Data_t data;
+    
+    if (!ina226Read(config, &data)) {
+        return false;
+    }
+    
+    *currentMa = data.currentMa;
+    return true;
+}
+
+/**
+ * @brief Read bus voltage from INA226.
+ *
+ * @param config    Pointer to INA226 configuration.
+ * @param voltageMv Pointer to store voltage in millivolts.
+ * @return true if read succeeded, false otherwise.
+ */
+bool ina226ReadVoltage(const ina226Config_t *config, uint16_t *voltageMv)
+{
+    uint16_t regValue;
+    
+    if (!ina226ReadRegister(config->i2cDevice, config->address,
+                            INA226_REG_BUS_VOLTAGE, &regValue)) {
+        return false;
+    }
+    
+    // Bus voltage: LSB = 1.25mV
+    *voltageMv = (uint16_t)((uint32_t)regValue * 125 / 100);
+    return true;
+}
+
+/**
+ * @brief Read power measurement from INA226.
+ *
+ * @param config  Pointer to INA226 configuration.
+ * @param powerMw Pointer to store power in milliwatts.
+ * @return true if read succeeded, false otherwise.
+ */
+bool ina226ReadPower(const ina226Config_t *config, uint32_t *powerMw)
+{
+    ina226Data_t data;
+    
+    if (!ina226Read(config, &data)) {
+        return false;
+    }
+    
+    *powerMw = data.powerMw;
+    return true;
+}
+
+#endif // USE_CURRENT_METER_INA226

--- a/src/main/drivers/ina226.c
+++ b/src/main/drivers/ina226.c
@@ -54,9 +54,15 @@ static bool ina226WriteRegister(i2cDevice_e device, uint8_t address, uint8_t reg
     }
     
     // Wait for write to complete (important for PICO platform)
+    // Defensive timeout for cross-platform consistency (platform timeouts should trigger first)
     bool error = false;
-    while (i2cBusy(device, &error)) {
+    int timeout = 1000;
+    while (i2cBusy(device, &error) && --timeout > 0) {
         // Wait until transfer is complete
+    }
+    
+    if (timeout <= 0) {
+        return false;
     }
     
     return !error;
@@ -94,12 +100,14 @@ static bool ina226ReadRegister(i2cDevice_e device, uint8_t address, uint8_t reg,
     }
     
     // Wait for read to complete (important for PICO platform)
+    // Defensive timeout for cross-platform consistency (platform timeouts should trigger first)
     bool error = false;
-    while (i2cBusy(device, &error)) {
+    int timeout = 1000;
+    while (i2cBusy(device, &error) && --timeout > 0) {
         // Wait until transfer is complete
     }
     
-    if (error) {
+    if (timeout <= 0 || error) {
         return false;
     }
     

--- a/src/main/drivers/ina226.c
+++ b/src/main/drivers/ina226.c
@@ -28,6 +28,7 @@
 #ifdef USE_CURRENT_METER_INA226
 
 #include "common/maths.h"
+#include "common/time.h"
 #include "drivers/bus_i2c.h"
 #include "drivers/ina226.h"
 #include "drivers/time.h"
@@ -53,16 +54,14 @@ static bool ina226WriteRegister(i2cDevice_e device, uint8_t address, uint8_t reg
         return false;
     }
     
-    // Wait for write to complete (important for PICO platform)
-    // Defensive timeout for cross-platform consistency (platform timeouts should trigger first)
+    // Wait for write to complete with elapsed-time timeout
+    // Use micros() for deterministic behavior across MCU/optimization levels
     bool error = false;
-    int timeout = 1000;
-    while (i2cBusy(device, &error) && --timeout > 0) {
-        // Wait until transfer is complete
-    }
-    
-    if (timeout <= 0) {
-        return false;
+    const timeUs_t timeoutAt = micros() + 10000;  // 10ms timeout
+    while (i2cBusy(device, &error)) {
+        if (cmpTimeUs(micros(), timeoutAt) >= 0) {
+            return false;  // Timed out
+        }
     }
     
     return !error;
@@ -99,15 +98,17 @@ static bool ina226ReadRegister(i2cDevice_e device, uint8_t address, uint8_t reg,
         return false;
     }
     
-    // Wait for read to complete (important for PICO platform)
-    // Defensive timeout for cross-platform consistency (platform timeouts should trigger first)
+    // Wait for read to complete with elapsed-time timeout
+    // Use micros() for deterministic behavior across MCU/optimization levels
     bool error = false;
-    int timeout = 1000;
-    while (i2cBusy(device, &error) && --timeout > 0) {
-        // Wait until transfer is complete
+    const timeUs_t timeoutAt = micros() + 10000;  // 10ms timeout
+    while (i2cBusy(device, &error)) {
+        if (cmpTimeUs(micros(), timeoutAt) >= 0) {
+            return false;  // Timed out
+        }
     }
     
-    if (timeout <= 0 || error) {
+    if (error) {
         return false;
     }
     

--- a/src/main/drivers/ina226.h
+++ b/src/main/drivers/ina226.h
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "drivers/bus_i2c.h"
+
+// INA226 I2C addresses (7-bit)
+// Address is determined by A0 and A1 pins:
+// A0=GND, A1=GND: 0x40
+// A0=VS,  A1=GND: 0x41
+// A0=SDA, A1=GND: 0x42
+// A0=SCL, A1=GND: 0x43
+// ...and so on (16 possible addresses: 0x40-0x4F)
+#define INA226_I2C_ADDR_DEFAULT     0x40
+
+// INA226 Register addresses
+#define INA226_REG_CONFIG           0x00
+#define INA226_REG_SHUNT_VOLTAGE    0x01
+#define INA226_REG_BUS_VOLTAGE      0x02
+#define INA226_REG_POWER            0x03
+#define INA226_REG_CURRENT          0x04
+#define INA226_REG_CALIBRATION      0x05
+#define INA226_REG_MASK_ENABLE      0x06
+#define INA226_REG_ALERT_LIMIT      0x07
+#define INA226_REG_MANUFACTURER_ID  0xFE
+#define INA226_REG_DIE_ID           0xFF
+
+// INA226 expected ID values
+#define INA226_MANUFACTURER_ID      0x5449  // "TI" in ASCII
+#define INA226_DIE_ID               0x2260
+
+// Configuration register bits
+#define INA226_CONFIG_RESET         (1 << 15)
+
+// Operating modes (bits 0-2)
+#define INA226_MODE_POWER_DOWN      0x00
+#define INA226_MODE_SHUNT_TRIG      0x01
+#define INA226_MODE_BUS_TRIG        0x02
+#define INA226_MODE_SHUNT_BUS_TRIG  0x03
+#define INA226_MODE_SHUNT_CONT      0x05
+#define INA226_MODE_BUS_CONT        0x06
+#define INA226_MODE_SHUNT_BUS_CONT  0x07
+
+// Conversion times (bits 3-5 for shunt, bits 6-8 for bus)
+#define INA226_CT_140US             0x00
+#define INA226_CT_204US             0x01
+#define INA226_CT_332US             0x02
+#define INA226_CT_588US             0x03
+#define INA226_CT_1100US            0x04
+#define INA226_CT_2116US            0x05
+#define INA226_CT_4156US            0x06
+#define INA226_CT_8244US            0x07
+
+// Averaging modes (bits 9-11)
+#define INA226_AVG_1                0x00
+#define INA226_AVG_4                0x01
+#define INA226_AVG_16               0x02
+#define INA226_AVG_64               0x03
+#define INA226_AVG_128              0x04
+#define INA226_AVG_256              0x05
+#define INA226_AVG_512              0x06
+#define INA226_AVG_1024             0x07
+
+// LSB values
+#define INA226_SHUNT_VOLTAGE_LSB_UV 2.5f    // 2.5 µV per LSB
+#define INA226_BUS_VOLTAGE_LSB_MV   1.25f   // 1.25 mV per LSB
+
+// Calibration formula internal constant
+#define INA226_CALIBRATION_CONSTANT 0.00512f
+
+// Data structure for INA226 readings
+typedef struct {
+    int16_t shuntVoltageRaw;    // Raw shunt voltage register value
+    uint16_t busVoltageRaw;     // Raw bus voltage register value
+    int16_t currentRaw;         // Raw current register value
+    uint16_t powerRaw;          // Raw power register value
+    int32_t currentMa;          // Current in mA
+    uint16_t busVoltageMv;      // Bus voltage in mV
+    uint32_t powerMw;           // Power in mW
+    bool dataValid;             // True if last read was successful
+} ina226Data_t;
+
+typedef struct {
+    i2cDevice_e i2cDevice;
+    uint8_t address;
+    uint16_t shuntResistorMicroOhms;  // Shunt resistor value in µΩ (e.g., 1000 = 1mΩ)
+    uint16_t maxCurrentMa;            // Maximum expected current in mA
+    uint16_t calibrationValue;        // Calculated calibration register value
+    uint32_t currentLsbNa;            // Current LSB in nA
+} ina226Config_t;
+
+// Function prototypes
+bool ina226Detect(i2cDevice_e device, uint8_t address);
+bool ina226Init(ina226Config_t *config);
+bool ina226Configure(const ina226Config_t *config);
+bool ina226Read(const ina226Config_t *config, ina226Data_t *data);
+bool ina226ReadCurrent(const ina226Config_t *config, int32_t *currentMa);
+bool ina226ReadVoltage(const ina226Config_t *config, uint16_t *voltageMv);
+bool ina226ReadPower(const ina226Config_t *config, uint32_t *powerMw);
+bool ina226Reset(const ina226Config_t *config);
+// Diagnostic functions
+uint16_t ina226GetLastMfgId(void);
+uint16_t ina226GetLastDieId(void);
+uint8_t ina226GetDetectStage(void);
+uint8_t ina226GetInitStage(void);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -159,6 +159,7 @@
 //#define PG_SOFTSERIAL_PIN_CONFIG    558  // removed, merged into SERIAL_PIN_CONFIG
 #define PG_GIMBAL_TRACK_CONFIG      559
 #define PG_OPTICALFLOW_CONFIG       560
+#define PG_CURRENT_SENSOR_INA226_CONFIG 561
 
 
 // OSD configuration (subject to change)

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -151,6 +151,12 @@ void batteryUpdateVoltage(timeUs_t currentTimeUs)
             }
             break;
 #endif
+#ifdef USE_CURRENT_METER_INA226
+        case VOLTAGE_METER_INA226:
+            voltageMeterINA226Refresh();
+            voltageMeterINA226Read(&voltageMeter);
+            break;
+#endif
         case VOLTAGE_METER_ADC:
             voltageMeterADCRefresh();
             voltageMeterADCRead(VOLTAGE_SENSOR_ADC_VBAT, &voltageMeter);
@@ -401,6 +407,12 @@ void batteryInit(void)
 #endif
             break;
 
+        case VOLTAGE_METER_INA226:
+#ifdef USE_CURRENT_METER_INA226
+            voltageMeterINA226Init();
+#endif
+            break;
+
         case VOLTAGE_METER_ADC:
             voltageMeterADCInit();
             break;
@@ -435,6 +447,11 @@ void batteryInit(void)
             currentMeterMSPInit();
 #endif
             break;
+        case CURRENT_METER_INA226:
+#ifdef USE_CURRENT_METER_INA226
+            currentMeterINA226Init();
+#endif
+            break;
 
         default:
             break;
@@ -443,7 +460,11 @@ void batteryInit(void)
 
 void batteryUpdateCurrentMeter(timeUs_t currentTimeUs)
 {
-    if (batteryCellCount == 0) {
+    // Note: Don't return early if batteryCellCount==0 for INA226!
+    // INA226 voltage reading depends on current meter refresh being called.
+    // We need to refresh current meter even before battery is detected.
+    
+    if (batteryCellCount == 0 && batteryConfig()->currentMeterSource != CURRENT_METER_INA226) {
         currentMeterReset(&currentMeter);
         return;
     }
@@ -482,6 +503,12 @@ void batteryUpdateCurrentMeter(timeUs_t currentTimeUs)
 #ifdef USE_MSP_CURRENT_METER
             currentMeterMSPRefresh(currentTimeUs);
             currentMeterMSPRead(&currentMeter);
+#endif
+            break;
+        case CURRENT_METER_INA226:
+#ifdef USE_CURRENT_METER_INA226
+            currentMeterINA226Refresh(lastUpdateAt);
+            currentMeterINA226Read(&currentMeter);
 #endif
             break;
 

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -402,8 +402,9 @@ void currentMeterINA226Refresh(int32_t lastUpdateAt)
     // Sanity check: limit lastUpdateAt to prevent overflow (max 10 seconds = 10,000,000 us)
     // This handles the case where ibatLastServiced was 0 on first call
     // Skip mAh accumulation for unreasonable values rather than using fabricated delta
+    // Also skip when lastUpdateAt == 0 (voltage-only mode calling to trigger I2C read)
     bool skipMahUpdate = false;
-    if (lastUpdateAt > 10000000 || lastUpdateAt < 0) {
+    if (lastUpdateAt > 10000000 || lastUpdateAt <= 0) {
         skipMahUpdate = true;
     }
     

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -416,7 +416,9 @@ void currentMeterINA226Refresh(int32_t lastUpdateAt)
         if (scale == 0) {
             scale = 100;  // Safety: default to 1.00x if not configured
         }
-        ina226LastVoltageMv = (uint16_t)((uint32_t)data.busVoltageMv * scale / 100);
+        // Use wider integer to prevent overflow, then clamp to UINT16_MAX
+        uint32_t scaledVoltageMv = (uint32_t)data.busVoltageMv * scale / 100;
+        ina226LastVoltageMv = (scaledVoltageMv > UINT16_MAX) ? UINT16_MAX : (uint16_t)scaledVoltageMv;
         
         // Convert mA to centiamperes (1/100 A)
         int32_t centiAmps = data.currentMa / 10;

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -40,10 +40,15 @@
 #include "sensors/battery.h"
 #include "sensors/esc_sensor.h"
 
+#ifdef USE_CURRENT_METER_INA226
+#include "drivers/bus_i2c.h"
+#include "drivers/ina226.h"
+#endif
+
 #include "current.h"
 
 const char * const currentMeterSourceNames[CURRENT_METER_COUNT] = {
-    "NONE", "ADC", "VIRTUAL", "ESC", "MSP"
+    "NONE", "ADC", "VIRTUAL", "ESC", "MSP", "INA226"
 };
 
 const uint8_t currentMeterIds[] = {
@@ -68,6 +73,9 @@ const uint8_t currentMeterIds[] = {
 #endif
 #ifdef USE_MSP_CURRENT_METER
     CURRENT_METER_ID_MSP_1,
+#endif
+#ifdef USE_CURRENT_METER_INA226
+    CURRENT_METER_ID_INA226_1,
 #endif
 };
 
@@ -291,6 +299,150 @@ void currentMeterMSPRead(currentMeter_t *meter)
 #endif
 
 //
+// INA226
+//
+
+#ifdef USE_CURRENT_METER_INA226
+
+#ifndef DEFAULT_INA226_I2C_DEVICE
+#define DEFAULT_INA226_I2C_DEVICE 1  // 1 = I2CDEV_0 (internal I2C bus)
+#endif
+
+#ifndef DEFAULT_INA226_ADDRESS
+#define DEFAULT_INA226_ADDRESS INA226_I2C_ADDR_DEFAULT  // 0x40
+#endif
+
+#ifndef DEFAULT_INA226_SHUNT_RESISTANCE
+#define DEFAULT_INA226_SHUNT_RESISTANCE 1000  // 1mΩ = 1000µΩ
+#endif
+
+#ifndef DEFAULT_INA226_MAX_CURRENT
+#define DEFAULT_INA226_MAX_CURRENT 50000  // 50A
+#endif
+
+#ifndef DEFAULT_INA226_VBAT_SCALE
+#define DEFAULT_INA226_VBAT_SCALE 100  // 100 = 1.00x (no scaling)
+#endif
+
+PG_REGISTER_WITH_RESET_TEMPLATE(currentSensorINA226Config_t, currentSensorINA226Config, PG_CURRENT_SENSOR_INA226_CONFIG, 1);
+
+PG_RESET_TEMPLATE(currentSensorINA226Config_t, currentSensorINA226Config,
+    .i2cDevice = DEFAULT_INA226_I2C_DEVICE,
+    .address = DEFAULT_INA226_ADDRESS,
+    .shuntResistanceMicroOhms = DEFAULT_INA226_SHUNT_RESISTANCE,
+    .maxExpectedCurrentMa = DEFAULT_INA226_MAX_CURRENT,
+    .vbatScale = DEFAULT_INA226_VBAT_SCALE,
+);
+
+static currentMeterINA226State_t currentMeterINA226State;
+static ina226Config_t ina226Cfg;
+static bool ina226Initialized = false;
+static pt1Filter_t ina226Filter;
+static uint16_t ina226LastVoltageMv = 0;  // Last read voltage in mV (shared with voltage meter)
+
+// Store last detection result for diagnostics
+static uint8_t ina226LastDetectResult = 0;  // 0=not tried, 1=success, 2=mfg_id fail, 3=die_id fail, 4=init fail
+
+uint8_t ina226GetDetectResult(void) {
+    return ina226LastDetectResult;
+}
+
+bool ina226IsInitialized(void) {
+    return ina226Initialized;
+}
+
+uint16_t ina226GetLastVoltageMv(void) {
+    return ina226LastVoltageMv;
+}
+
+void currentMeterINA226Init(void)
+{
+    memset(&currentMeterINA226State, 0, sizeof(currentMeterINA226State_t));
+    ina226Initialized = false;
+    ina226LastDetectResult = 0;
+
+    const currentSensorINA226Config_t *config = currentSensorINA226Config();
+    
+    // Wait for INA226 to power up (datasheet says 10us typical, but give it more time)
+    delay(10);
+    
+    // Configure INA226 - i2cDevice follows Betaflight convention: 1 = I2CDEV_0, 2 = I2CDEV_1, etc.
+    if (config->i2cDevice < 1 || config->i2cDevice > I2CDEV_COUNT) {
+        // Invalid device, use default
+        ina226Cfg.i2cDevice = I2CDEV_0;
+    } else {
+        ina226Cfg.i2cDevice = I2C_CFG_TO_DEV(config->i2cDevice);
+    }
+    
+    ina226Cfg.address = config->address;
+    ina226Cfg.shuntResistorMicroOhms = config->shuntResistanceMicroOhms;
+    ina226Cfg.maxCurrentMa = config->maxExpectedCurrentMa;
+    
+    // Try to initialize at configured address only
+    // Note: If INA226 is not present, this will fail silently to avoid I2C bus errors
+    if (ina226Init(&ina226Cfg)) {
+        ina226Initialized = true;
+        ina226LastDetectResult = 1;  // Success
+        // Initialize the filter with a 10Hz cutoff (similar to ADC current filter)
+        pt1FilterInit(&ina226Filter, pt1FilterGain(GET_BATTERY_LPF_FREQUENCY(batteryConfig()->ibatLpfPeriod), HZ_TO_INTERVAL(50)));
+    } else {
+        ina226LastDetectResult = 4;  // Init failed
+    }
+}
+
+void currentMeterINA226Refresh(int32_t lastUpdateAt)
+{
+    if (!ina226Initialized) {
+        currentMeterINA226State.amperageLatest = 0;
+        currentMeterINA226State.amperage = 0;
+        ina226LastVoltageMv = 0;
+        return;
+    }
+    
+    // Sanity check: limit lastUpdateAt to prevent overflow (max 10 seconds = 10,000,000 us)
+    // This handles the case where ibatLastServiced was 0 on first call
+    if (lastUpdateAt > 10000000 || lastUpdateAt < 0) {
+        lastUpdateAt = 10000;  // Default to 10ms if unreasonable value
+    }
+    
+    // Read ALL data at once (shunt voltage, bus voltage, current, power)
+    // This avoids multiple I2C transactions
+    ina226Data_t data;
+    if (ina226Read(&ina226Cfg, &data)) {
+        // Store voltage for voltage meter to use (no separate I2C call needed)
+        // Apply calibration scale: vbatScale=100 means 1.00x, vbatScale=103 means 1.03x
+        const currentSensorINA226Config_t *config = currentSensorINA226Config();
+        uint8_t scale = config->vbatScale;
+        if (scale == 0) {
+            scale = 100;  // Safety: default to 1.00x if not configured
+        }
+        ina226LastVoltageMv = (uint16_t)((uint32_t)data.busVoltageMv * scale / 100);
+        
+        // Convert mA to centiamperes (1/100 A)
+        int32_t centiAmps = data.currentMa / 10;
+        
+        currentMeterINA226State.amperageLatest = centiAmps;
+        currentMeterINA226State.amperage = pt1FilterApply(&ina226Filter, centiAmps);
+        
+        // Update mAh drawn
+        // Use float from the start to avoid integer overflow:
+        // mAh = centiAmps * lastUpdateAt_us / (100 * 1000 * 3600) = centiAmps * lastUpdateAt_us / 360000000
+        currentMeterINA226State.mahDrawnState.mAhDrawnF += 
+            (float)currentMeterINA226State.amperageLatest * (float)lastUpdateAt / (100.0f * 1000.0f * 3600.0f);
+        currentMeterINA226State.mahDrawnState.mAhDrawn = (int32_t)currentMeterINA226State.mahDrawnState.mAhDrawnF;
+    }
+}
+
+void currentMeterINA226Read(currentMeter_t *meter)
+{
+    meter->amperageLatest = currentMeterINA226State.amperageLatest;
+    meter->amperage = currentMeterINA226State.amperage;
+    meter->mAhDrawn = currentMeterINA226State.mahDrawnState.mAhDrawn;
+}
+
+#endif // USE_CURRENT_METER_INA226
+
+//
 // API for current meters using IDs
 //
 // This API is used by MSP, for configuration/status.
@@ -318,6 +470,11 @@ void currentMeterRead(currentMeterId_e id, currentMeter_t *meter)
     else if (id >= CURRENT_METER_ID_ESC_MOTOR_1 && id <= CURRENT_METER_ID_ESC_MOTOR_20 ) {
         int motor = id - CURRENT_METER_ID_ESC_MOTOR_1;
         currentMeterESCReadMotor(motor, meter);
+    }
+#endif
+#ifdef USE_CURRENT_METER_INA226
+    else if (id == CURRENT_METER_ID_INA226_1) {
+        currentMeterINA226Read(meter);
     }
 #endif
     else {

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -368,8 +368,8 @@ void currentMeterINA226Init(void)
     
     // Configure INA226 - i2cDevice follows Betaflight convention: 1 = I2CDEV_0, 2 = I2CDEV_1, etc.
     if (config->i2cDevice < 1 || config->i2cDevice > I2CDEV_COUNT) {
-        // Invalid device, use default
-        ina226Cfg.i2cDevice = I2CDEV_0;
+        // Invalid device, use first available I2C bus (portable across all targets)
+        ina226Cfg.i2cDevice = I2CDEV_FIRST;
     } else {
         ina226Cfg.i2cDevice = I2C_CFG_TO_DEV(config->i2cDevice);
     }
@@ -434,6 +434,11 @@ void currentMeterINA226Refresh(int32_t lastUpdateAt)
             updateCurrentmAhDrawnState(&currentMeterINA226State.mahDrawnState, 
                                        currentMeterINA226State.amperageLatest, lastUpdateAt);
         }
+    } else {
+        // Read failed — clear values to avoid stale battery telemetry after I2C faults
+        currentMeterINA226State.amperageLatest = 0;
+        currentMeterINA226State.amperage = 0;
+        ina226LastVoltageMv = 0;
     }
 }
 

--- a/src/main/sensors/current.h
+++ b/src/main/sensors/current.h
@@ -29,6 +29,7 @@ typedef enum {
     CURRENT_METER_VIRTUAL,
     CURRENT_METER_ESC,
     CURRENT_METER_MSP,
+    CURRENT_METER_INA226,
     CURRENT_METER_COUNT
 } currentMeterSource_e;
 
@@ -113,6 +114,28 @@ typedef struct currentMeterMSPState_s {
 } currentMeterMSPState_t;
 
 //
+// INA226
+//
+
+#ifdef USE_CURRENT_METER_INA226
+typedef struct currentMeterINA226State_s {
+    currentMeterMAhDrawnState_t mahDrawnState;
+    int32_t amperage;           // current read by current sensor in centiampere (1/100th A)
+    int32_t amperageLatest;     // current read by current sensor in centiampere (1/100th A) (unfiltered)
+} currentMeterINA226State_t;
+
+typedef struct currentSensorINA226Config_s {
+    uint8_t i2cDevice;          // I2C device index (1-based, 0 = auto)
+    uint8_t address;            // I2C address (7-bit)
+    uint16_t shuntResistanceMicroOhms;  // Shunt resistor value in µΩ
+    uint16_t maxExpectedCurrentMa;      // Maximum expected current in mA (for calibration)
+    uint8_t vbatScale;          // Voltage scale factor (100 = 1.00x, 103 = 1.03x)
+} currentSensorINA226Config_t;
+
+PG_DECLARE(currentSensorINA226Config_t, currentSensorINA226Config);
+#endif
+
+//
 // Current Meter API
 //
 
@@ -135,6 +158,13 @@ void currentMeterMSPInit(void);
 void currentMeterMSPRefresh(timeUs_t currentTimeUs);
 void currentMeterMSPRead(currentMeter_t *meter);
 void currentMeterMSPSet(uint16_t amperage, uint16_t mAhDrawn);
+
+void currentMeterINA226Init(void);
+void currentMeterINA226Refresh(int32_t lastUpdateAt);
+void currentMeterINA226Read(currentMeter_t *meter);
+uint8_t ina226GetDetectResult(void);
+bool ina226IsInitialized(void);
+uint16_t ina226GetLastVoltageMv(void);  // Get voltage from last INA226 read (shared with voltage meter)
 
 //
 // API for reading current meters by id.

--- a/src/main/sensors/current_ids.h
+++ b/src/main/sensors/current_ids.h
@@ -72,4 +72,7 @@ typedef enum {
     CURRENT_METER_ID_MSP_1 = 90,       // 90-99 for MSP meters
     CURRENT_METER_ID_MSP_2,
 
+    CURRENT_METER_ID_INA226_1 = 100,   // 100-109 for INA226 meters
+    CURRENT_METER_ID_INA226_2,
+
 } currentMeterId_e;

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -336,6 +336,8 @@ void voltageMeterINA226Init(void)
     // currentMeterINA226Init() performs the actual hardware init (I2C detect, reset, calibration).
     // If voltage_meter_source=INA226 is set without current_meter=INA226, we must init it here.
     // The init is idempotent - multiple calls are safe.
+    // NOTE: This assumes battery/current PG configs are already loaded before this init runs.
+    // The init order in main.c ensures batteryInit() is called after pgResetAll() so configs are valid.
     if (!ina226IsInitialized()) {
         currentMeterINA226Init();
     }

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -331,8 +331,11 @@ void voltageMeterINA226Init(void)
     memset(&voltageMeterINA226State, 0, sizeof(voltageMeterINA226State_t));
     pt1FilterInit(&voltageMeterINA226State.displayFilter, pt1FilterGain(GET_BATTERY_LPF_FREQUENCY(batteryConfig()->vbatDisplayLpfPeriod), HZ_TO_INTERVAL(SLOW_VOLTAGE_TASK_FREQ_HZ)));
     
-    // If INA226 not yet initialized by current meter, initialize it now
-    // This allows voltage_meter_source=INA226 to work without requiring current_meter=INA226
+    // Cross-module initialization dependency:
+    // The INA226 hardware is shared between voltage and current meters.
+    // currentMeterINA226Init() performs the actual hardware init (I2C detect, reset, calibration).
+    // If voltage_meter_source=INA226 is set without current_meter=INA226, we must init it here.
+    // The init is idempotent - multiple calls are safe.
     if (!ina226IsInitialized()) {
         currentMeterINA226Init();
     }

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -46,10 +46,14 @@
 #include "sensors/battery.h"
 #include "sensors/esc_sensor.h"
 
+#ifdef USE_CURRENT_METER_INA226
+#include "sensors/current.h"  // For ina226 voltage access (shared with current meter)
+#endif
+
 #include "voltage.h"
 
 const char * const voltageMeterSourceNames[VOLTAGE_METER_COUNT] = {
-    "NONE", "ADC", "ESC"
+    "NONE", "ADC", "ESC", "INA226"
 };
 
 const uint8_t voltageMeterIds[] = {
@@ -303,6 +307,63 @@ void voltageMeterESCReadCombined(voltageMeter_t *voltageMeter)
 #else
     voltageMeter->displayFiltered = voltageMeterESCState.voltageDisplayFiltered;
     voltageMeter->unfiltered = voltageMeterESCState.voltageUnfiltered;
+#endif
+}
+
+//
+// INA226
+//
+
+#ifdef USE_CURRENT_METER_INA226
+typedef struct voltageMeterINA226State_s {
+    uint16_t voltageDisplayFiltered;         // battery voltage in 0.01V steps (filtered)
+    uint16_t voltageUnfiltered;              // battery voltage in 0.01V steps (unfiltered)
+    pt1Filter_t displayFilter;
+} voltageMeterINA226State_t;
+
+static voltageMeterINA226State_t voltageMeterINA226State;
+static bool voltageMeterINA226Initialized = false;
+#endif
+
+void voltageMeterINA226Init(void)
+{
+#ifdef USE_CURRENT_METER_INA226
+    memset(&voltageMeterINA226State, 0, sizeof(voltageMeterINA226State_t));
+    pt1FilterInit(&voltageMeterINA226State.displayFilter, pt1FilterGain(GET_BATTERY_LPF_FREQUENCY(batteryConfig()->vbatDisplayLpfPeriod), HZ_TO_INTERVAL(SLOW_VOLTAGE_TASK_FREQ_HZ)));
+    // INA226 is initialized by currentMeterINA226Init() in current.c
+    voltageMeterINA226Initialized = ina226IsInitialized();
+#endif
+}
+
+void voltageMeterINA226Refresh(void)
+{
+#ifdef USE_CURRENT_METER_INA226
+    if (!voltageMeterINA226Initialized) {
+        // Check if INA226 was initialized by current meter
+        voltageMeterINA226Initialized = ina226IsInitialized();
+        if (!voltageMeterINA226Initialized) {
+            return;
+        }
+    }
+    
+    // Get voltage from current meter's last read (no additional I2C call!)
+    // currentMeterINA226Refresh() reads all data at once including voltage
+    uint16_t voltageMv = ina226GetLastVoltageMv();
+    
+    // Convert mV to 0.01V (centivolt)
+    uint16_t voltageCv = voltageMv / 10;
+    voltageMeterINA226State.voltageUnfiltered = voltageCv;
+    voltageMeterINA226State.voltageDisplayFiltered = pt1FilterApply(&voltageMeterINA226State.displayFilter, voltageCv);
+#endif
+}
+
+void voltageMeterINA226Read(voltageMeter_t *voltageMeter)
+{
+#ifndef USE_CURRENT_METER_INA226
+    voltageMeterReset(voltageMeter);
+#else
+    voltageMeter->displayFiltered = voltageMeterINA226State.voltageDisplayFiltered;
+    voltageMeter->unfiltered = voltageMeterINA226State.voltageUnfiltered;
 #endif
 }
 

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -40,6 +40,7 @@ typedef enum {
     VOLTAGE_METER_NONE = 0,
     VOLTAGE_METER_ADC,
     VOLTAGE_METER_ESC,
+    VOLTAGE_METER_INA226,
     VOLTAGE_METER_COUNT
 } voltageMeterSource_e;
 
@@ -117,6 +118,10 @@ void voltageMeterESCInit(void);
 void voltageMeterESCRefresh(void);
 void voltageMeterESCReadCombined(voltageMeter_t *voltageMeter);
 void voltageMeterESCReadMotor(uint8_t motor, voltageMeter_t *voltageMeter);
+
+void voltageMeterINA226Init(void);
+void voltageMeterINA226Refresh(void);
+void voltageMeterINA226Read(voltageMeter_t *voltageMeter);
 
 //
 // api for battery stable voltage detection


### PR DESCRIPTION
# INA226 Power Monitor Driver for Betaflight

## Overview

This PR adds complete INA226 I2C power monitor support to Betaflight, enabling accurate current and voltage monitoring on boards without traditional ADC sensing.

## Features

- **Current Measurement:** High-precision current sensing via shunt resistor
- **Voltage Measurement:** Bus voltage monitoring (1.25mV resolution)
- **mAh Tracking:** Battery capacity consumption tracking
- **64-bit Math:** Overflow-safe calculations for high currents (up to 50A+)
- **CLI Commands:** Debugging and status commands
- **Configurable:** I2C address, bus, shunt resistance, max current

## Hardware Support

| Parameter | Value |
|-----------|-------|
| Chip | Texas Instruments INA226 |
| Interface | I2C (up to 2.94MHz, using 400kHz) |
| Default Address | 0x40 |
| Voltage Range | 0-36V |
| Current Range | ±81.92mV shunt voltage |
| Resolution | 16-bit ADC |

## Code Changes Summary

### New Files

| File | Description |
|------|-------------|
| `src/main/drivers/ina226.c` | INA226 driver with I2C communication |
| `src/main/drivers/ina226.h` | Driver header with config/data structures |

### Modified Files

| File | Change |
|------|--------|
| `src/main/sensors/current.c` | Add CURRENT_METER_INA226 implementation |
| `src/main/sensors/current.h` | Add INA226 current meter type and prototypes |
| `src/main/sensors/current_ids.h` | Add CURRENT_METER_INA226 enum |
| `src/main/sensors/voltage.c` | Add VOLTAGE_METER_INA226 implementation |
| `src/main/sensors/voltage.h` | Add INA226 voltage meter type |
| `src/main/sensors/battery.c` | Integrate INA226 into battery monitoring |
| `src/main/cli/cli.c` | Add `ina226_status` debug command |
| `src/main/cli/settings.c` | Add INA226 configuration parameters |
| `src/main/pg/pg_ids.h` | Add PG_INA226_CONFIG parameter group |
| `mk/source.mk` | Add ina226.c to build |

## Architecture

```
┌─────────────────────────────────────────────────────┐
│                   INA226 Driver                      │
│  ┌─────────────────────────────────────────────┐    │
│  │     ina226Read() - single I2C transaction   │    │
│  │         ↓                  ↓                │    │
│  │    currentRaw         busVoltageMv          │    │
│  └─────────────────────────────────────────────┘    │
│                 ↓                  ↓                 │
│      ┌──────────┴──────────────────┴──────────┐     │
│      ↓                                        ↓     │
│  Current Meter                         Voltage Meter│
│  currentMeterINA226Refresh()     voltageMeterINA226│
│      ↓                                        ↓     │
│  currentMa, mAh                     busVoltageMv    │
└─────────────────────────────────────────────────────┘
```

## Key Implementation Details

### 64-Bit Overflow Protection

```c
// currentLsbNa calculation (prevents overflow when maxCurrentMa >= 4295)
config->currentLsbNa = (uint32_t)(((uint64_t)config->maxCurrentMa * 1000000ULL) / 32768ULL);

// currentMa calculation (prevents overflow at high currents)
data->currentMa = (int32_t)(((int64_t)data->currentRaw * (int64_t)config->currentLsbNa) / 1000000LL);
```

### Battery Integration Fix

The driver includes a fix for the battery initialization order - INA226 refresh is allowed even when `batteryCellCount == 0`, since INA226 provides voltage readings needed to detect cell count.

## CLI Configuration

```bash
# View current settings
get ina226

# Configure INA226
set ina226_i2c_address = 64      # I2C address (0x40 = 64 decimal)
set ina226_i2c_bus = 0           # I2C bus number
set ina226_shunt_mohms = 2       # Shunt resistance in milliohms
set ina226_max_current = 50000   # Maximum expected current in mA

# Enable INA226 as current and voltage source
set current_meter = INA226
set voltage_meter_source = INA226

save
```

### Debug Command

```bash
# Show INA226 status and readings
ina226_status

# Output example:
# INA226: DETECTED at bus 0
# Address: 0x40
# Shunt: 2 mOhm
# Max Current: 50000 mA
# Current LSB: 1525878 nA
# Voltage: 16070 mV
# Current: 2570 mA
```

## Testing

**Test Hardware:**
- Board: MADFLIGHT FC3 (https://madflight.com/Board-FC3/)
- MCU: RP2350B (Raspberry Pi Pico 2) @ 150MHz
- INA226: Address 0x40, 2mΩ shunt
- Battery: 4S LiPo (16.27V)
- Load: Up to 2.55A (motor test)

**Verified Results:**
| Test | Result |
|------|--------|
| INA226 detection | ✅ Pass |
| Voltage reading | 16.07V (matches multimeter) |
| Current reading | 2.57A (matches PSU 2.55A) |
| Power calculation | ~41W (correct) |
| mAh tracking | 19 mAh after test |
| Battery cell detect | 4S detected |
| Configurator voltage | ✅ Visible |
| Configurator current | ✅ Visible |

## Commit Message

```
feat(sensor): add INA226 power monitor support

Add complete INA226 I2C power monitor integration:

Driver (ina226.c/h):
- I2C communication with configurable address (default 0x40)
- Automatic LSB calibration for shunt resistance and max current
- Bus voltage measurement with 1.25mV resolution
- 64-bit arithmetic to prevent integer overflow at high currents
- CLI commands for testing and debugging

Sensor integration:
- CURRENT_METER_INA226 type in current.c/h
- VOLTAGE_METER_INA226 type in voltage.c/h
- mAh tracking in battery.c
- CLI settings for shunt resistance and max current

Configuration parameters:
- ina226_shunt_mohms: Shunt resistance in milliohms
- ina226_max_current: Maximum expected current in mA
- ina226_i2c_address: I2C address (7-bit)
- ina226_i2c_bus: I2C bus selection

Tested on RP2350B with 2mΩ shunt, accurate to within 1% at 2.5A.
```

## PR Checklist

- [x] Code follows Betaflight coding style guidelines
- [x] Single feature: INA226 power monitor support
- [x] Build passes for PICO targets
- [x] Tested on real hardware
- [x] All functionality verified working
<img width="954" height="1067" alt="image" src="https://github.com/user-attachments/assets/2c09b350-5240-4174-9c31-4db4f704538e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * INA226 current/voltage sensor support over I2C: detection, calibration, init, continuous readout, and diagnostics.
  * CLI commands to scan I2C, read registers, and initialize/show INA226 status.
  * New user-configurable INA226 settings (I2C device, address, shunt resistance, max current, VBAT scale).
  * INA226 integrated into battery, current, and voltage monitoring and selectable meter lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->