### PR TITLE
Remove linker script for SITL target on MacOS x86-64

### DIFF
--- a/src/platform/SIMULATOR/mk/SITL.mk
+++ b/src/platform/SIMULATOR/mk/SITL.mk
@@ -61,7 +61,7 @@ OPTIMISE_SIZE       := -Os
 LTO_FLAGS           := $(OPTIMISATION_BASE) $(OPTIMISE_SPEED)
 endif
 
-ifneq ($(filter macosx-arm%,$(OSFAMILY)-$(ARCHFAMILY)),)
+ifneq ($(filter macosx-arm% macosx-x86_64%,$(OSFAMILY)-$(ARCHFAMILY)),)
 
     CFLAGS_DISABLED := -Werror -Wunsafe-loop-optimizations -fuse-linker-plugin
 


### PR DESCRIPTION
Compiling TARGET=SITL on Macos x86-64 requires the same CFLAGS and LD_FLAGS adjustments as already provided for
MacOS apple silicon.

Compiling with this CFLAGS and LD_FLAGS adjustments results in:

```
...
Linking SITL
__TEXT  __DATA  __OBJC  others  dec     hex
266240  77824   0       4295032832      4295376896      100064000
Creating exe - copying obj/main/betaflight_SITL.elf to obj/betaflight_2026.6.0-alpha_SITL
$ file obj/betaflight_2026.6.0-alpha_SITL                             fix_sitl_compilation_macos_x86_64
obj/betaflight_2026.6.0-alpha_SITL: Mach-O 64-bit executable x86_64
```

whereas keeping the original CFLAGS and LD_FLAGS results in:

```
$ make TARGET=SITL
EF HASH -> ./obj/main/SITL/.efhash_c3a37ce45124cee9e21cab7400798299
%% (optimised) lib/main/dyad/dyad.c
clang: error: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Werror,-Wdeprecated-ofast]
clang: error: optimization flag '-fuse-linker-plugin' is not supported [-Werror,-Wignored-optimization-argument]
make[1]: *** [obj/main/SITL/./lib/main/dyad/dyad.o] Error 1
make: *** [fwo] Error 2
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded macOS build support to include both ARM and x86_64 architectures, improving compatibility across different Mac platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->