### PR TITLE
FIX: Virtual GPS provider does not need a serial port

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -229,8 +229,6 @@ static void validateAndFixConfig(void)
     if (gpsConfig()->provider != GPS_MSP && gpsConfig()->provider != GPS_VIRTUAL && !gpsSerial) {
         featureDisableImmediate(FEATURE_GPS);
     }
-#else
-    featureDisableImmediate(FEATURE_GPS);
 #endif
 
     for (unsigned i = 0; i < PID_PROFILE_COUNT; i++) {


### PR DESCRIPTION
This pull request makes a targeted update to the GPS configuration validation logic. The main change is to ensure that the GPS feature is only disabled if neither the MSP nor VIRTUAL GPS providers are selected and no GPS serial is present.

- Configuration validation:
  * In `validateAndFixConfig` in `config.c`, added a check to prevent disabling the GPS feature when the GPS provider is set to `GPS_VIRTUAL`, in addition to the existing `GPS_MSP` check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS configuration validation to correctly handle a virtual GPS provider, ensuring GPS serial routing is removed when that provider is in use.
  * Prevents incorrect disabling or unexpected initialization of GPS by tightening the conditions under which GPS is turned off when no serial port is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->