### PR TITLE
flight/fc: add crashflip_no_rearm option

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1099,6 +1099,7 @@ const clivalue_t valueTable[] = {
     { "crashflip_motor_percent",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_motor_percent) },
     { "crashflip_rate",             VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_rate) },
     { "crashflip_auto_rearm",       VAR_INT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_auto_rearm) },
+    { "crashflip_no_rearm",         VAR_INT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_no_rearm) },
 #ifdef USE_RPM_LIMIT
     { "rpm_limit",                  VAR_INT8   |  MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit) },
     { "rpm_limit_p",                VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 },        PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit_p) },

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -88,6 +88,8 @@ void taskFiltering(timeUs_t currentTimeUs);
 void taskMainPidLoop(timeUs_t currentTimeUs);
 
 bool isCrashFlipModeActive(void);
+bool isCrashFlipExitThrottleWait(void);
+bool isCrashFlipDirectionPending(void);
 int8_t calculateThrottlePercent(void);
 uint8_t calculateThrottlePercentAbs(void);
 bool areSticksActive(uint8_t stickPercentLimit);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -689,11 +689,18 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs)
     // Find min and max throttle based on conditions. Throttle has to be known before mixing
     calculateThrottleAndCurrentMotorEndpoints(currentTimeUs);
 
+    if (isCrashFlipDirectionPending()) {
+        applyMotorStop();
+        return;
+    }
+
     if (applyCrashFlipModeToMotors()) {
         return;
-        // if crash flip modeis being applied to the motors, mixing is done
-        
-        
+    }
+
+    if (isCrashFlipExitThrottleWait()) {
+        applyMotorStop();
+        return;
     }
 
     motorMixer_t * activeMixer = &mixerRuntime.currentMixer[0];

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -97,6 +97,7 @@ typedef struct mixerConfig_s {
     uint8_t crashflip_motor_percent;
     uint8_t crashflip_rate;
     bool crashflip_auto_rearm;
+    bool crashflip_no_rearm;
     uint8_t mixer_type;
 #ifdef USE_RPM_LIMIT
     bool rpm_limit;

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -67,6 +67,7 @@ void pgResetFn_mixerConfig(mixerConfig_t *mixerConfig)
     mixerConfig->crashflip_rate = 0;
     mixerConfig->crashflip_auto_rearm = false;
 #endif
+    mixerConfig->crashflip_no_rearm = false;
     mixerConfig->mixer_type = MIXER_LEGACY;
 #ifdef USE_RPM_LIMIT
     mixerConfig->rpm_limit = false;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1599,6 +1599,7 @@ case MSP_NAME:
     case MSP_MIXER_CONFIG:
         sbufWriteU8(dst, mixerConfig()->mixerMode);
         sbufWriteU8(dst, mixerConfig()->yaw_motors_reversed);
+        sbufWriteU8(dst, mixerConfig()->crashflip_no_rearm);
         break;
 
     case MSP_RX_CONFIG:
@@ -3770,6 +3771,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
         if (sbufBytesRemaining(src) >= 1) {
             mixerConfigMutable()->yaw_motors_reversed = sbufReadU8(src);
+        }
+        if (sbufBytesRemaining(src) >= 1) {
+            mixerConfigMutable()->crashflip_no_rearm = sbufReadU8(src);
         }
         break;
 


### PR DESCRIPTION
Adds a new `crashflip_no_rearm` mixer config option.

When enabled, the flip-over-after-crash switch can be toggled while armed without requiring a disarm/rearm cycle. Turning the switch off reverts motor direction and keeps the craft armed. If throttle is above zero when exiting, motor output is suppressed until the stick returns to idle. Turning the switch on while already armed sends the reversed direction command immediately.

Takes priority over `crashflip_auto_rearm` when both are set. Requires DShot.

**CLI:** `set crashflip_no_rearm = ON`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "crashflip_no_rearm" configuration option to control crash flip recovery behavior when using DSHOT. This setting enables controlled disarming during crash detection as an alternative to automatic rearm, providing users with enhanced recovery mode customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->