### PR TITLE
SITL: add -z,noexecstack linker flag to suppress RWX segment warning

### DIFF
--- a/src/platform/SIMULATOR/mk/SITL.mk
+++ b/src/platform/SIMULATOR/mk/SITL.mk
@@ -45,6 +45,7 @@ LD_FLAGS    := \
             -Wl,-gc-sections,-Map,$(TARGET_MAP) \
             -Wl,-L$(LINKER_DIR) \
             -Wl,--cref \
+            -Wl,-z,noexecstack \
             -T$(LD_SCRIPT)
 
 ifneq ($(filter SITL_STATIC,$(OPTIONS)),)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SITL simulator build configuration to enhance stack protection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->