### PR TITLE
Add MSP2_MOTOR_SERVO_RESOURCE commands for pin assignment

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3872,6 +3872,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 // Motor
                 if (index < MAX_SUPPORTED_MOTORS) {
                     motorConfigMutable()->dev.ioTags[index] = ioTag;
+                    writeEEPROM();
                     setRebootRequired();
                 } else {
                     return MSP_RESULT_ERROR;
@@ -3882,6 +3883,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 // Servo
                 if (index < MAX_SUPPORTED_SERVOS) {
                     servoConfigMutable()->dev.ioTags[index] = ioTag;
+                    writeEEPROM();
                     setRebootRequired();
                 } else {
                     return MSP_RESULT_ERROR;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1333,6 +1333,7 @@ case MSP_NAME:
         {
             // Return motor and servo pin assignments
             // Format: [motorCount][servoCount][motor0_ioTag]...[motorN_ioTag][servo0_ioTag]...[servoN_ioTag]
+            STATIC_ASSERT(sizeof(ioTag_t) == sizeof(uint8_t), ioTag_size_must_be_one_byte);
             sbufWriteU8(dst, MAX_SUPPORTED_MOTORS);
 #ifdef USE_SERVOS
             sbufWriteU8(dst, MAX_SUPPORTED_SERVOS);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1329,6 +1329,29 @@ case MSP_NAME:
         }
         break;
 
+    case MSP2_MOTOR_SERVO_RESOURCE:
+        {
+            // Return motor and servo pin assignments
+            // Format: [motorCount][servoCount][motor0_ioTag]...[motorN_ioTag][servo0_ioTag]...[servoN_ioTag]
+            sbufWriteU8(dst, MAX_SUPPORTED_MOTORS);
+#ifdef USE_SERVOS
+            sbufWriteU8(dst, MAX_SUPPORTED_SERVOS);
+#else
+            sbufWriteU8(dst, 0);
+#endif
+            // Motor ioTags (1 byte each)
+            for (unsigned i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+                sbufWriteU8(dst, motorConfig()->dev.ioTags[i]);
+            }
+#ifdef USE_SERVOS
+            // Servo ioTags (1 byte each)
+            for (unsigned i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
+                sbufWriteU8(dst, servoConfig()->dev.ioTags[i]);
+            }
+#endif
+        }
+        break;
+
 #ifdef USE_VTX_COMMON
     case MSP2_GET_VTX_DEVICE_STATUS: {
         const vtxDevice_t *vtxDevice = vtxCommonDevice();
@@ -3819,6 +3842,43 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 }
 
                 motorConfigMutable()->dev.motorOutputReordering[i] = value;
+            }
+        }
+        break;
+
+    case MSP2_SET_MOTOR_SERVO_RESOURCE:
+        {
+            if (dataSize != 3) {
+                return MSP_RESULT_ERROR;
+            }
+
+            // Set a single motor or servo resource
+            // Format: [resourceType][index][ioTag]
+            // resourceType: 0 = MOTOR, 1 = SERVO
+            const uint8_t resourceType = sbufReadU8(src);
+            const uint8_t index = sbufReadU8(src);
+            const ioTag_t ioTag = sbufReadU8(src);
+
+            if (resourceType == 0) {
+                // Motor
+                if (index < MAX_SUPPORTED_MOTORS) {
+                    motorConfigMutable()->dev.ioTags[index] = ioTag;
+                } else {
+                    return MSP_RESULT_ERROR;
+                }
+            }
+#ifdef USE_SERVOS
+            else if (resourceType == 1) {
+                // Servo
+                if (index < MAX_SUPPORTED_SERVOS) {
+                    servoConfigMutable()->dev.ioTags[index] = ioTag;
+                } else {
+                    return MSP_RESULT_ERROR;
+                }
+            }
+#endif
+            else {
+                return MSP_RESULT_ERROR;
             }
         }
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3848,6 +3848,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 
     case MSP2_SET_MOTOR_SERVO_RESOURCE:
         {
+            if (ARMING_FLAG(ARMED)) {
+                return MSP_RESULT_ERROR;
+            }
+
             if (dataSize != 3) {
                 return MSP_RESULT_ERROR;
             }
@@ -3859,10 +3863,16 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             const uint8_t index = sbufReadU8(src);
             const ioTag_t ioTag = sbufReadU8(src);
 
+            // Validate ioTag: must be 0 (NONE) or refer to an existing pin
+            if (ioTag != 0 && IOGetByTag(ioTag) == NULL) {
+                return MSP_RESULT_ERROR;
+            }
+
             if (resourceType == 0) {
                 // Motor
                 if (index < MAX_SUPPORTED_MOTORS) {
                     motorConfigMutable()->dev.ioTags[index] = ioTag;
+                    setRebootRequired();
                 } else {
                     return MSP_RESULT_ERROR;
                 }
@@ -3872,6 +3882,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 // Servo
                 if (index < MAX_SUPPORTED_SERVOS) {
                     servoConfigMutable()->dev.ioTags[index] = ioTag;
+                    setRebootRequired();
                 } else {
                     return MSP_RESULT_ERROR;
                 }

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -36,6 +36,8 @@
 #define MSP2_SET_BATTERY_PROFILE            0x300F
 #define MSP2_CLI_SETTING                    0x3010
 #define MSP2_CLI_SETTING_INFO               0x3011
+#define MSP2_MOTOR_SERVO_RESOURCE           0x3012  // Get motor and servo pin assignments
+#define MSP2_SET_MOTOR_SERVO_RESOURCE       0x3013  // Set motor or servo pin assignment
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1


### PR DESCRIPTION
## Summary
- Add `MSP2_MOTOR_SERVO_RESOURCE` (0x300E) to read motor/servo pin assignments
- Add `MSP2_SET_MOTOR_SERVO_RESOURCE` (0x300F) to write pin assignments

## Motivation
Motor/servo resource pin assignments can only be viewed and modified via CLI. This adds MSP support to enable configurator UI for resource management.

## Changes
- `msp_protocol_v2_betaflight.h`: Define new MSP2 command codes
- `msp.c`: Implement read/write handlers for motor and servo ioTags

## Testing
Tested on SPEEDYBEEF405WING with companion configurator changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve motor and servo assignments: returns counts plus pin/IO assignments for motors and, when configured, servos.
  * Set individual motor or servo assignments: accepts a small validated payload only when the system is disarmed; rejects invalid indices or unknown IO tags and unsupported resource types.
  * Persisted changes and reboot: applying valid updates saves settings to non-volatile storage and marks the system for reboot to activate them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/14943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->