### PR TITLE
Add devcontainer build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,17 @@
 
 Betaflight is flight controller software (firmware) used to fly multi-rotor craft and fixed wing craft. Betaflight focuses on flight performance, leading-edge feature additions, and wide target support.
 
-
 ## Release Schedule
 
-| Date  | Release | Stage | Status |
-| - | - | - | - |
-| 26-12-2025 | 2025.12 | Release | Completed |
-| 01-04-2026 | 2026.6 | Beta | |
-| 01-05-2026 | 2026.6 | Release Candidate | |
-| 01-06-2026 | 2026.6 | Release | |
-| 01-10-2026 | 2026.12 | Beta | |
-| 01-11-2026 | 2026.12 | Release Candidate | |
-| 01-12-2026 | 2026.12 | Release | |
-
+| Date       | Release | Stage             | Status    |
+| ---------- | ------- | ----------------- | --------- |
+| 26-12-2025 | 2025.12 | Release           | Completed |
+| 01-04-2026 | 2026.6  | Beta              |           |
+| 01-05-2026 | 2026.6  | Release Candidate |           |
+| 01-06-2026 | 2026.6  | Release           |           |
+| 01-10-2026 | 2026.12 | Beta              |           |
+| 01-11-2026 | 2026.12 | Release Candidate |           |
+| 01-12-2026 | 2026.12 | Release           |           |
 
 ## News
 
@@ -51,48 +49,44 @@ The requirements for pull requests adding new targets or modifying existing targ
 
 Betaflight has the following features:
 
-* Multi-color RGB LED strip support (each LED can be a different color using variable length WS2811 Addressable RGB strips - use for Orientation Indicators, Low Battery Warning, Flight Mode Status, Initialization Troubleshooting, etc)
-* DShot (150, 300 and 600), Multishot, Oneshot (125 and 42) and Proshot1000 motor protocol support
-* Blackbox flight recorder logging (to onboard flash or external microSD card where equipped)
-* Support for targets that use the STM32 F4, G4, F7 and H7 processors
-* PWM, PPM, SPI, and Serial (SBus, SumH, SumD, Spektrum 1024/2048, XBus, etc) RX connection with failsafe detection
-* Multiple telemetry protocols (CRSF, FrSky, HoTT smart-port, MSP, etc)
-* RSSI via ADC - Uses ADC to read PWM RSSI signals, tested with FrSky D4R-II, X8R, X4R-SB, & XSR
-* OSD support & configuration without needing third-party OSD software/firmware/comm devices
-* OLED Displays - Display information on: Battery voltage/current/mAh, profile, rate profile, mode, version, sensors, etc
-* In-flight manual PID tuning and rate adjustment
-* PID and filter tuning using sliders
-* Rate profiles and in-flight selection of them
-* Configurable serial ports for Serial RX, Telemetry, ESC telemetry, MSP, GPS, OSD, Sonar, etc - Use most devices on any port, softserial included
-* VTX support for Unify Pro and IRC Tramp
-* and MUCH, MUCH more.
-
+- Multi-color RGB LED strip support (each LED can be a different color using variable length WS2811 Addressable RGB strips - use for Orientation Indicators, Low Battery Warning, Flight Mode Status, Initialization Troubleshooting, etc)
+- DShot (150, 300 and 600), Multishot, Oneshot (125 and 42) and Proshot1000 motor protocol support
+- Blackbox flight recorder logging (to onboard flash or external microSD card where equipped)
+- Support for targets that use the STM32 F4, G4, F7 and H7 processors
+- PWM, PPM, SPI, and Serial (SBus, SumH, SumD, Spektrum 1024/2048, XBus, etc) RX connection with failsafe detection
+- Multiple telemetry protocols (CRSF, FrSky, HoTT smart-port, MSP, etc)
+- RSSI via ADC - Uses ADC to read PWM RSSI signals, tested with FrSky D4R-II, X8R, X4R-SB, & XSR
+- OSD support & configuration without needing third-party OSD software/firmware/comm devices
+- OLED Displays - Display information on: Battery voltage/current/mAh, profile, rate profile, mode, version, sensors, etc
+- In-flight manual PID tuning and rate adjustment
+- PID and filter tuning using sliders
+- Rate profiles and in-flight selection of them
+- Configurable serial ports for Serial RX, Telemetry, ESC telemetry, MSP, GPS, OSD, Sonar, etc - Use most devices on any port, softserial included
+- VTX support for Unify Pro and IRC Tramp
+- and MUCH, MUCH more.
 
 ## Installation & Documentation
 
 See: https://betaflight.com/docs/wiki
 
-
 ## Support and Developers Channel
 
 There's a dedicated [Discord server](https://discord.gg/n4E6ak4u3c) for help, support and general community.
-
 
 ## Betaflight Application
 
 To configure Betaflight you should use the [Betaflight App](https://app.betaflight.com). It is a progressive web app, so should always be the latest version.
 
-
 ## Contributing
 
 Contributions are welcome and encouraged. You can contribute in many ways:
 
-* implement a new feature in the firmware or in the app (see [below](#Developers));
-* documentation updates and corrections;
-* How-To guides - received help? Help others!
-* bug reporting & fixes;
-* new feature ideas & suggestions;
-* provide a new translation for the app, or help us maintain the existing ones (see [below](#Translators)).
+- implement a new feature in the firmware or in the app (see [below](#developers));
+- documentation updates and corrections;
+- How-To guides - received help? Help others!
+- bug reporting & fixes;
+- new feature ideas & suggestions;
+- provide a new translation for the app, or help us maintain the existing ones (see [below](#translators)).
 
 The best place to start is the Betaflight Discord (registration [here](https://discord.gg/n4E6ak4u3c)). Next place is the github issue tracker:
 
@@ -105,22 +99,34 @@ If you want to contribute to our efforts financially, please consider making a d
 
 If you want to contribute financially on an ongoing basis, you should consider becoming a patron for us on [Patreon](https://www.patreon.com/betaflight).
 
-
 ## Developers
 
 Contribution of bugfixes and new features is encouraged. Please be aware that we have a thorough review process for pull requests, and be prepared to explain what you want to achieve with your pull request.
 Before starting to write code, please read our [development guidelines](https://www.betaflight.com/docs/development) and [coding style definition](https://www.betaflight.com/docs/development/CodingStyle).
 
-GitHub actions are used to run automatic builds
+GitHub actions are used to run automatic builds.
 
+### Building with Docker/Devcontainers
+
+A preconfigured [devcontainer](.devcontainer/README.md) is included for a consistent build environment across all platforms. This is the recommended approach for Windows developers:
+
+```bash
+# With VS Code: Install "Dev Containers" extension, open folder, and select "Reopen in Container"
+
+# Or command-line only:
+docker build -t betaflight-dev -f .devcontainer/containerfile .devcontainer/
+docker run --rm -v "${PWD}:/workspace" -w /workspace betaflight-dev make TARGET=SPEEDYBEEF405WING
+```
+
+See the [devcontainer documentation](.devcontainer/README.md) for detailed setup instructions including hardware flashing.
 
 ## Translators
 
 We want to make Betaflight accessible for pilots who are not fluent in English, and for this reason we are currently maintaining translations into 21 languages for Betaflight Configurator: Català, Dansk, Deutsch, Español, Euskera, Français, Galego, Hrvatski, Bahasa Indonesia, Italiano, 日本語, 한국어, Latviešu, Português, Português Brasileiro, polski, Русский язык, Svenska, 简体中文, 繁體中文.
 We have got a team of volunteer translators who do this work, but additional translators are always welcome to share the workload, and we are keen to add additional languages. If you would like to help us with translations, you have got the following options:
+
 - if you help by suggesting some updates or improvements to translations in a language you are familiar with, head to [crowdin](https://crowdin.com/project/betaflight-configurator) and add your suggested translations there;
 - if you would like to start working on the translation for a new language, or take on responsibility for proof-reading the translation for a language you are very familiar with, please head to the Betaflight Discord chat (registration [here](https://discord.gg/n4E6ak4u3c)), and join the ['translation'](https://discord.com/channels/868013470023548938/1057773726915100702) channel - the people in there can help you to get a new language added, or set you up as a proof reader.
-
 
 ## Hardware Issues
 
@@ -128,11 +134,9 @@ Betaflight does not manufacture or distribute their own hardware. While we are c
 
 If you encounter any hardware issues with your flight controller or another component, please contact the manufacturer or supplier of your hardware, or check [Discord](https://discord.gg/n4E6ak4u3c) to see if others with the same problem have found a solution.
 
-
 ## Betaflight Releases
 
 You can find our release [here](https://github.com/betaflight/betaflight/releases) on Github and we also have more detailed [release notes](https://www.betaflight.com/docs/category/release-notes) at [betaflight.com](https://www.betaflight.com).
-
 
 ## Open Source / Contributors
 


### PR DESCRIPTION
## Summary
Add a brief section to the README documenting how to use the existing devcontainer for building firmware, making it more discoverable for new contributors.

## Changes
- Add "Building with Docker/Devcontainers" section under Developers
- Reference the existing `.devcontainer/README.md` for detailed instructions
- Provide quick-start commands for both VS Code and CLI usage

This helps Windows developers and others discover the devcontainer option without having to dig through the `.devcontainer` folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a News section announcing a new versioning scheme (YYYY.M.PATCH) and updated release cadence.
  * Expanded developer setup with Docker/Devcontainers guidance and sample commands.
  * Minor editorial and formatting improvements across Translators/Support and other README sections.

* **Chores**
  * Improved README table layout and standardized bullet styling throughout documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->