### PR TITLE
MSP: validate servo mixer targetChannel and inputSource bounds in MSP_SET_SERVO_MIX_RULE

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2983,8 +2983,13 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         if (i >= MAX_SERVO_RULES) {
             return MSP_RESULT_ERROR;
         } else {
-            customServoMixersMutable(i)->targetChannel = sbufReadU8(src);
-            customServoMixersMutable(i)->inputSource = sbufReadU8(src);
+            const uint8_t targetChannel = sbufReadU8(src);
+            const uint8_t inputSource = sbufReadU8(src);
+            if (targetChannel >= MAX_SUPPORTED_SERVOS || inputSource >= INPUT_SOURCE_COUNT) {
+                return MSP_RESULT_ERROR;
+            }
+            customServoMixersMutable(i)->targetChannel = targetChannel;
+            customServoMixersMutable(i)->inputSource = inputSource;
             customServoMixersMutable(i)->rate = sbufReadU8(src);
             customServoMixersMutable(i)->speed = sbufReadU8(src);
             customServoMixersMutable(i)->min = sbufReadU8(src);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced input validation for servo mixer configuration with added bounds checking on channel and input values during both configuration updates and read operations, preventing invalid values from being applied and improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->