### PR TITLE
POLICY: ENABLE_ corrected comments, and repositioning to common_post.h due to config and target definitions.

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -696,3 +696,18 @@ extern struct linker_symbol __config_end;
 #endif
 #endif // USE_PINIO
 
+/*****************************************************
+
+ Place any ENABLE_X_FEATURE=0 definitions here for those
+ yet to be defined, and also for any backward compatibility
+ with USE_ flags.
+
+ e.g.
+
+ #if !defined(ENABLE_X_FEATURE) && defined(USE_X_FEATURE)
+ #define ENABLE_X_FEATURE 1
+ #elif !defined(ENABLE_X_FEATURE)
+ #define ENABLE_X_FEATURE 0
+ #endif
+
+******************************************************/

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -54,7 +54,11 @@
   line by passing ENABLE_X_FEATURE=0, unlike USE_ flags which can only be enabled or left undefined.
   This allows for more granular control during builds without modifying source files.
 
-  For backward compatibility, USE_ flags will continue to be supported in this file (common_pre.h)
+  This is especially beneficial for CI builds and custom user builds where certain features may need
+  to be turned off without editing code. It also assists in debugging and testing by allowing features
+  to be toggled on/off easily.
+
+  For backward compatibility, USE_ flags will continue to be supported in the file (common_post.h)
   only. When a USE_X_FEATURE is defined, it will automatically set ENABLE_X_FEATURE=1. Source code
   should transition to using #if ENABLE_X_FEATURE guards instead of #ifdef USE_X_FEATURE.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature flag documentation to clarify ENABLE_/USE_ flag behavior and backward compatibility guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->