### PR TITLE
PICO DSHOT (bidir) - fix for telemetry sampling.

### DIFF
--- a/src/platform/PICO/dshot_bidir_pico.c
+++ b/src/platform/PICO/dshot_bidir_pico.c
@@ -196,7 +196,7 @@ static uint32_t decodeOversampledTelemetry(int motorIndex, const uint32_t *buffe
     while (shiftcount > 0 && edgeCount < MAX_EDGES) {
         uint32_t testword = ones ? ~w0 : w0;
         if (testword == 0) {
-            break;  // Remaining bits are all the same polarity
+            break;  // Remaining bits are all the same polarity, also, we don't want to rely on behaviour of clz(0).
         }
         int runLength = __builtin_clz(testword);
         edgeDiffs[edgeCount++] = runLength;
@@ -214,8 +214,10 @@ static uint32_t decodeOversampledTelemetry(int motorIndex, const uint32_t *buffe
         shiftcount -= runLength;
     }
 
-    // Don't want to count last run of ones. "Padding" will be deduced later.
-    edgeCount--;
+    // Don't want to count last run of ones. "Padding" will be deduced later. (NB ones flag has been inverted at this point.)
+    if (!ones) {
+        edgeCount--;
+    }
 
     if (edgeCount < 2 || edgeCount > 21) {
         lastFailReason = FAIL_EDGE_COUNT;


### PR DESCRIPTION
PICO DSHOT (bidir) - fix for telemetry sampling.

PICO bidirectionsal DShot fix for telemetry sampling, was incorrectly dropping the final run of bits.
This only occurs when there is a complete run of 32 x "1" samples at the end, which can happen when
the ESC is transmitting a little on the fast side. (In testing, no problems seen on a 32-bit controller, but
consistent issues on an 8-bit controller running BlueJay.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced telemetry processing accuracy with improved edge detection logic
  * Added clarifying comments for code clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->