### PR TITLE
Add support for GigaDevice GD25Q16E and Zetta ZD25WQ32CE flash memories

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -142,6 +142,12 @@ struct {
     // XMC XM25QH256B
     // Datasheet: https://www.xmcwh.com/uploads/499/XM25QU256B.pdf
     { 0x206019, 166, 80, 8192, 16 },
+    // GigaDevice GD25Q16E
+    // Datasheet: https://download.gigadevice.com/Datasheet/DS-00473-GD25Q16E-Rev1.3.pdf
+    { 0xC84015, 104, 50, 32, 256 },
+    // Zetta ZD25WQ32CEIGR
+    // Datasheet: http://en.zettadevice.com/uploads/files/1009/WQ32C/1665301640977617c282766299.pdf
+    { 0xBA6016, 104, 50, 64, 256 },
     // End of list
     { 0x000000, 0, 0, 0, 0 }
 };


### PR DESCRIPTION
## Summary
Add support for two additional SPI flash memories to the m25p16 flash driver:

GigaDevice GD25Q16E (JEDEC ID: 0xC84015) - 16Mbit SPI flash
Zetta ZD25WQ32C (JEDEC ID: 0xBA6016) - 32Mbit SPI flash

## Testing
Flash memory identification has been verified on custom hardware.

## Checklist

- [x] Follows coding style guidelines
- [x] Single, focused change
- [x] Tested on hardware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new flash memory devices: GigaDevice GD25Q16E (JEDEC ID 0xC84015) and Zetta ZD25WQ32CEIGR (JEDEC ID 0xBA6016). Both devices support operation frequencies up to 104 MHz with 50 MHz maximum read clock capability, expanding hardware compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->