### PR TITLE
Constrain GYRO_CLKIN to supported IMU sensors

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -277,10 +277,6 @@ uint8_t icm426xxSpiDetect(const extDevice_t *dev)
     icm426xxSoftReset(dev);
     spiWriteReg(dev, ICM426XX_RA_PWR_MGMT0, 0x00);
 
-#if defined(USE_GYRO_CLKIN)
-    icm426xxEnableExternalClock(dev);
-#endif
-
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
@@ -313,6 +309,14 @@ uint8_t icm426xxSpiDetect(const extDevice_t *dev)
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
+
+#if defined(USE_GYRO_CLKIN)
+    // IMM42652/53 also support external clock but it's not currently tested and may require different handling, so only enable for 42688P for now.
+    if (icmDetected == ICM_42688P_SPI) {
+        icm426xxEnableExternalClock(dev);
+    }
+
+#endif
 
     return icmDetected;
 }


### PR DESCRIPTION
For now let's only activate `GYRO_CLKIN` for ICM42688P as it was not tested with other IMUs.

IMU Model | CLKIN Support | Pin for Clock | Implementation Status
-- | -- | -- | --
ICM42688P | Yes | Pin 6 | Native Support. The original implementation baseline for Betaflight.
ICM42686P | Yes | Pin 6 | Compatible. Identical register map for clock config; requires device ID inclusion in driver.
IIM42652 | Yes | Pin 6 | Compatible. Industrial version; requires device ID inclusion in driver.
IIM42653 | Yes | Pin 6 | Compatible. High-precision industrial version; requires device ID inclusion in driver.
ICM42605 | No | N/A | Hardware Lack. Pin 9 is reserved; no internal routing for external clock.
ICM42622P | No | N/A | Hardware Lack. Older generation architecture without external clock routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gyro and accelerometer external clock configuration for enhanced device compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->