### PR TITLE
fix: initialize vtxtable powerlabels buffer to prevent strncpy stack corruption (#14835)

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3034,6 +3034,7 @@ static void cliVtxTable(const char *cmdName, char *cmdline)
     } else if (strcasecmp(tok, "powerlabels") == 0) {
         // Power labels
         char label[VTX_TABLE_MAX_POWER_LEVELS][VTX_TABLE_POWER_LABEL_LENGTH + 1];
+        memset(label, 0, sizeof(label));
         int levels = vtxTableConfigMutable()->powerLevels;
         int count;
         for (count = 0; count < levels && (tok = strtok_r(NULL, " ", &saveptr)); count++) {


### PR DESCRIPTION
**AI-Generated Code**

Fixes stack corruption when using exactly 3-character VTX power labels via CLI `vtxtable powerlabels` command.  
Resolves: https://github.com/betaflight/betaflight/issues/14835

**Root Cause:** Missing buffer initialization before `strncpy` caused uninitialized memory to remain in the null-terminator slot. Subsequent `strlen()` read into uninitialized memory, and `toupper()` wrote back to stack, corrupting local variables.

**Fix:** Initialize label array with `memset` before `strncpy`, matching the established pattern used in the same function's `band` parsing and in the MSP handler.

**Changes:** +1 line in `src/main/cli/cli.c`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of power label data in VTX table configuration to prevent potential data integrity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->