### PR TITLE
Fix typos in source code comments

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -144,7 +144,7 @@ bool cmsDisplayPortSelect(const displayPort_t *instance)
 
 // XXX LEFT_MENU_COLUMN and RIGHT_MENU_COLUMN must be adjusted
 // dynamically depending on size of the active output device,
-// or statically to accomodate sizes of all supported devices.
+// or statically to accommodate sizes of all supported devices.
 //
 // Device characteristics
 // OLED

--- a/src/main/drivers/sdcard_sdio_baremetal.c
+++ b/src/main/drivers/sdcard_sdio_baremetal.c
@@ -548,7 +548,7 @@ static sdcardOperationStatus_e sdcardSdio_writeBlock(uint32_t blockIndex, uint8_
  * Returns:
  *     SDCARD_OPERATION_SUCCESS     - Multi-block write has been queued
  *     SDCARD_OPERATION_BUSY        - The card is already busy and cannot accept your write
- *     SDCARD_OPERATION_FAILURE     - A fatal error occured, card will be reset
+ *     SDCARD_OPERATION_FAILURE     - A fatal error occurred, card will be reset
  */
 static sdcardOperationStatus_e sdcardSdio_beginWriteBlocks(uint32_t blockIndex, uint32_t blockCount)
 {

--- a/src/main/drivers/sdcard_spi.c
+++ b/src/main/drivers/sdcard_spi.c
@@ -991,7 +991,7 @@ static sdcardOperationStatus_e sdcardSpi_writeBlock(uint32_t blockIndex, uint8_t
  * Returns:
  *     SDCARD_OPERATION_SUCCESS     - Multi-block write has been queued
  *     SDCARD_OPERATION_BUSY        - The card is already busy and cannot accept your write
- *     SDCARD_OPERATION_FAILURE     - A fatal error occured, card will be reset
+ *     SDCARD_OPERATION_FAILURE     - A fatal error occurred, card will be reset
  */
 static sdcardOperationStatus_e sdcardSpi_beginWriteBlocks(uint32_t blockIndex, uint32_t blockCount)
 {

--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -3324,7 +3324,7 @@ static void afatfs_findLargestContiguousFreeBlockBegin(void)
  * Returns:
  *     AFATFS_OPERATION_IN_PROGRESS - SD card is busy, call again later to resume
  *     AFATFS_OPERATION_SUCCESS - When the search has finished and afatfs.initState.freeSpaceSearch has been updated with the details of the best gap.
- *     AFATFS_OPERATION_FAILURE - When a read error occured
+ *     AFATFS_OPERATION_FAILURE - When a read error occurred
  */
 static afatfsOperationStatus_e afatfs_findLargestContiguousFreeBlockContinue(void)
 {
@@ -3344,7 +3344,7 @@ static afatfsOperationStatus_e afatfs_findLargestContiguousFreeBlockContinue(voi
                     break;
 
                     case AFATFS_FIND_CLUSTER_FATAL:
-                        // Some sort of read error occured
+                        // Some sort of read error occurred
                         return AFATFS_OPERATION_FAILURE;
 
                     case AFATFS_FIND_CLUSTER_NOT_FOUND:
@@ -3385,7 +3385,7 @@ static afatfsOperationStatus_e afatfs_findLargestContiguousFreeBlockContinue(voi
                     break;
 
                     case AFATFS_FIND_CLUSTER_FATAL:
-                        // Some sort of read error occured
+                        // Some sort of read error occurred
                         return AFATFS_OPERATION_FAILURE;
 
                     case AFATFS_FIND_CLUSTER_IN_PROGRESS:

--- a/src/main/pg/serial_uart.c
+++ b/src/main/pg/serial_uart.c
@@ -36,7 +36,7 @@
 #include "drivers/serial_uart.h"
 #include "drivers/dma_reqmap.h"
 
-// TODO(hertz@): UARTDEV_CONFIG_MAX is measured to be exactly 8, which cannot accomodate even all the UARTs below
+// TODO(hertz@): UARTDEV_CONFIG_MAX is measured to be exactly 8, which cannot accommodate even all the UARTs below
 PG_REGISTER_ARRAY_WITH_RESET_FN(serialUartConfig_t, UARTDEV_CONFIG_MAX, serialUartConfig, PG_SERIAL_UART_CONFIG, 0);
 
 typedef struct uartDmaopt_s {

--- a/src/main/rx/expresslrs_telemetry.c
+++ b/src/main/rx/expresslrs_telemetry.c
@@ -160,7 +160,7 @@ void confirmCurrentTelemetryPayload(const bool telemetryConfirmValue)
 
         currentOffset += bytesLastPayload;
         if (currentOffset >= length) {
-            // A 0th packet is always requred so the reciver can
+            // A 0th packet is always required so the receiver can
             // differentiate a new send from a resend, if this is
             // the first packet acked, send another, else IDLE
             if (currentPackage == 1) {

--- a/src/main/rx/mavlink.c
+++ b/src/main/rx/mavlink.c
@@ -40,7 +40,7 @@
 
 #include "build/debug.h"
 
-// mavlink library uses unnames unions that's causes GCC to complain if -Wpedantic is used
+// mavlink library uses unnamed unions that causes GCC to complain if -Wpedantic is used
 // until this is resolved in mavlink library - ignore -Wpedantic for mavlink code
 // FIXME
 #pragma GCC diagnostic push

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -75,7 +75,7 @@
 
 #include "build/debug.h"
 
-// mavlink library uses unnames unions that's causes GCC to complain if -Wpedantic is used
+// mavlink library uses unnamed unions that causes GCC to complain if -Wpedantic is used
 // until this is resolved in mavlink library - ignore -Wpedantic for mavlink code
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -495,7 +495,7 @@ static bool lineSent[SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS];
 int spektrumTmTextGenPutChar(uint8_t col, uint8_t row, char c)
 {
     if (row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS && col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS) {
-      // Only update and force a tm transmision if something has actually changed.
+      // Only update and force a tm transmission if something has actually changed.
         if (srxlTextBuff[row][col] != c) {
           srxlTextBuff[row][col] = c;
           lineSent[row] = false;


### PR DESCRIPTION
## Summary
- Fix spelling and grammar errors in comments across 9 source files
- No functional changes — comments only

### Corrections
- `occured` → `occurred` (asyncfatfs.c, sdcard_sdio_baremetal.c, sdcard_spi.c)
- `accomodate` → `accommodate` (cms.c, serial_uart.c)
- `requred` → `required`, `reciver` → `receiver` (expresslrs_telemetry.c)
- `transmision` → `transmission` (srxl.c)
- `unnames unions that's causes` → `unnamed unions that causes` (mavlink.c x2)

## Test plan
- [ ] Comments only — no code logic changes
- [ ] Verify CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling and grammar errors in code comments throughout the codebase, including fixes to commonly misspelled words for improved documentation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->