### PR TITLE
flash_m25p16: Add support for GD25Q128 flash chip

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -150,7 +150,7 @@ struct {
     { 0xBA6016, 104, 50, 64, 256 },
     // GD25Q128
     // Datasheet: https://download.gigadevice.com/Datasheet/DS-00480-GD25Q128E-Rev1.4.pdf
-    { 0xC84018, 104, 50, 256, 256 },
+    { 0xC84018, 104, 80, 4096, 16 },
     // End of list
     { 0x000000, 0, 0, 0, 0 }
 };


### PR DESCRIPTION
Adds JEDEC ID 0xC84018 (GD25Q128) with geometry of 256 sectors,
256 pages per sector, and max clocks of 104 MHz (SPI) and 50 MHz (read).
Datasheet reference: https://download.gigadevice.com/Datasheet/DS-00480-GD25Q128E-Rev1.4.pdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GD25Q128 flash memory device, expanding compatible hardware. Support includes the device's maximum SPI/read clock rates and sector/page layout to ensure proper performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->