### PR TITLE
Move platform-specific Bit_RESET definition from serial_4way to platform headers as GPIO_PIN_RESET

### DIFF
--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -49,12 +49,6 @@
 #include "io/serial_4way_stk500v2.h"
 #endif
 
-#if defined(USE_HAL_DRIVER)
-#define Bit_RESET GPIO_PIN_RESET
-#elif defined(AT32F435)
-#define Bit_RESET 0
-#endif
-
 #define USE_TXRX_LED
 
 #ifdef  USE_TXRX_LED
@@ -114,11 +108,11 @@ inline bool isMcuConnected(void)
 
 inline bool isEscHi(uint8_t selEsc)
 {
-    return (IORead(escHardware[selEsc].io) != Bit_RESET);
+    return (IORead(escHardware[selEsc].io) != GPIO_PIN_RESET);
 }
 inline bool isEscLo(uint8_t selEsc)
 {
-    return (IORead(escHardware[selEsc].io) == Bit_RESET);
+    return (IORead(escHardware[selEsc].io) == GPIO_PIN_RESET);
 }
 
 inline void setEscHi(uint8_t selEsc)

--- a/src/platform/AT32/include/platform/platform.h
+++ b/src/platform/AT32/include/platform/platform.h
@@ -71,6 +71,8 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 
 #define ADC_INTERNAL_VBAT4_ENABLED 0
 
+#define GPIO_PIN_RESET 0
+
 /* AT32F4 we need to specify the ADC device for each channel */
 #define PLATFORM_TRAIT_ADC_DEVICE 1
 #endif

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -111,6 +111,8 @@
 #define I2C_TRAIT_STATE 1
 #define I2C_TRAIT_AF_PIN 1
 
+#define GPIO_PIN_RESET 0
+
 #ifndef STM32F4
 #define STM32F4
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized GPIO pin reset comparisons across different microcontroller platforms for consistent behavior.

* **Refactor**
  * Consolidated platform-specific GPIO handling by introducing unified pin reset constants across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->