### PR TITLE
Add individual servo channel forwarding support and run servo mixer for default frame types

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -278,7 +278,8 @@ static void servoConfigureOutput(void)
 static bool hasIndividualServoForwarding(void)
 {
     for (int index = 0; index < MAX_SUPPORTED_SERVOS; index++) {
-        if (servoParams(index)->forwardFromChannel != (int8_t)CHANNEL_FORWARDING_DISABLED) {
+        const uint8_t channelToForwardFrom = servoParams(index)->forwardFromChannel;
+        if (channelToForwardFrom != CHANNEL_FORWARDING_DISABLED) {
             return true;
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed servo forwarding to work correctly across all mixer and frame types.
  * Improved detection and initialization of individual servo forwarding so servos enable reliably when configured.
  * Ensured servo outputs for previously-unhandled frame types are processed through the standard mixing and post-processing steps (stabilization and constraining).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->