### PR TITLE
Add ExpressLRS SPI receiver support for RP2350 (PICO) platform

### DIFF
--- a/src/main/drivers/rx/expresslrs_driver.c
+++ b/src/main/drivers/rx/expresslrs_driver.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include "platform.h"
 
-#ifdef USE_RX_EXPRESSLRS
+#if defined(USE_RX_EXPRESSLRS) && !defined(USE_EXPRESSLRS_TIMER_PICO)
 
 #include "build/debug.h"
 #include "build/debug_pin.h"
@@ -192,4 +192,4 @@ void expressLrsInitialiseTimer(const timerHardware_t *timHw, timerOvrHandlerRec_
     timerConfigUpdateCallback(timer, timerUpdateCb);
 }
 
-#endif
+#endif // USE_RX_EXPRESSLRS && !USE_EXPRESSLRS_TIMER_PICO

--- a/src/platform/PICO/README.md
+++ b/src/platform/PICO/README.md
@@ -1,0 +1,90 @@
+# RP2350 (PICO) Platform
+
+Betaflight platform support for the Raspberry Pi RP2350 microcontroller
+(Raspberry Pi Pico 2 and compatible boards).
+
+Two targets are provided:
+
+| Target    | MCU      | GPIO count | Notes                          |
+|-----------|----------|------------|--------------------------------|
+| `RP2350A` | RP2350A  | 30 (PA0–PA29) | SD card SPI blackbox backend |
+| `RP2350B` | RP2350B  | 48 (PA0–PA47) | QSPI flash blackbox backend  |
+
+---
+
+## Board `config.h` reference
+
+Each supported flight controller board has a `config.h` under
+`src/config/configs/<BOARD_NAME>/`. The sections below document the
+defines required for each feature area.
+
+### ExpressLRS (ELRS) receiver via SPI
+
+ELRS is supported using an SX1280 (2.4 GHz) radio connected over SPI.
+The RP2350 has two SPI buses (`SPI0` / `SPI1`); either can be used.
+
+#### Required defines
+
+```c
+// --- SPI bus pins (whichever bus the radio is wired to) ---
+#define SPI0_SCK_PIN        PA<n>   // SPI clock
+#define SPI0_SDI_PIN        PA<n>   // MISO (SX1280 → MCU)
+#define SPI0_SDO_PIN        PA<n>   // MOSI (MCU → SX1280)
+
+// --- Radio control pins ---
+#define RX_SPI_INSTANCE             SPI0    // or SPI1
+#define RX_SPI_CS                   PA<n>   // SX1280 chip-select (active-low)
+#define RX_SPI_EXTI                 PA<n>   // SX1280 DIO1 – packet-ready interrupt
+#define RX_EXPRESSLRS_SPI_BUSY_PIN  PA<n>   // SX1280 BUSY output
+#define RX_EXPRESSLRS_SPI_RESET_PIN PA<n>   // SX1280 nRESET (active-low)
+
+// --- Protocol defaults ---
+#define RX_SPI_DEFAULT_PROTOCOL     RX_SPI_EXPRESSLRS
+#define DEFAULT_RX_FEATURE          FEATURE_RX_SPI
+```
+
+#### Optional defines
+
+```c
+// Bind button GPIO (active-low by convention).
+#define RX_SPI_BIND         PA<n>
+
+// LED driven by the ELRS receiver driver (e.g. status LED on the radio module).
+#define RX_SPI_LED          PA<n>
+#define RX_SPI_LED_INVERTED         // add if the LED is active-low
+```
+
+#### RP2350-specific notes
+
+- **`RX_EXPRESSLRS_TIMER_INSTANCE` is not used on RP2350.**  The ELRS
+  tick/tock timer is implemented in `expresslrs_timer_pico.c` using the
+  pico-sdk `hardware_alarm` API rather than a hardware timer peripheral.
+  Do not copy this define from STM32 board configs.
+
+- `USE_RX_SPI`, `USE_RX_EXPRESSLRS`, and `USE_RX_SX1280` are enabled by
+  default via `common_pre.h`.  They do not need to be redefined in
+  `config.h` unless you are selectively disabling one of them with
+  `#undef`.
+
+- SX127X (900 MHz) is not currently supported; `USE_RX_SX127X` is
+  `#undef`'d in `target.h`.
+
+#### Minimal example
+
+```c
+// SPI bus 0 wired to the radio module
+#define SPI0_SCK_PIN                PA2
+#define SPI0_SDI_PIN                PA4
+#define SPI0_SDO_PIN                PA3
+
+// Radio control
+#define RX_SPI_INSTANCE             SPI0
+#define RX_SPI_CS                   PA5
+#define RX_SPI_EXTI                 PA6
+#define RX_EXPRESSLRS_SPI_BUSY_PIN  PA7
+#define RX_EXPRESSLRS_SPI_RESET_PIN PA8
+
+// Protocol
+#define RX_SPI_DEFAULT_PROTOCOL     RX_SPI_EXPRESSLRS
+#define DEFAULT_RX_FEATURE          FEATURE_RX_SPI
+```

--- a/src/platform/PICO/bus_spi_pico.c
+++ b/src/platform/PICO/bus_spi_pico.c
@@ -323,8 +323,15 @@ void spiInitBusDMA(void)
 
 void spiInternalResetStream(dmaChannelDescriptor_t *descriptor)
 {
-    //TODO: implement
-    UNUSED(descriptor);
+    // Abort the channel and wait for it to stop.
+    // Equivalent to STM32's LL_DMA_DisableStream() + polling loop.
+    dma_channel_abort(descriptor->channel);
+
+    // Clear any pending completion interrupt for this channel on both IRQ lines.
+    // RP2350 uses two DMA IRQ lines (IRQ0/IRQ1); the acknowledge registers are
+    // write-1-to-clear, so writing a bit that is already clear is a no-op.
+    dma_channel_acknowledge_irq0(descriptor->channel);
+    dma_channel_acknowledge_irq1(descriptor->channel);
 }
 
 bool spiInternalReadWriteBufPolled(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, int len)

--- a/src/platform/PICO/expresslrs_timer_pico.c
+++ b/src/platform/PICO/expresslrs_timer_pico.c
@@ -110,13 +110,15 @@ static void alarmCallback(uint alarm)
         dbgPinHi(0);
 
         int32_t adjustedPeriod = (int32_t)halfPeriod + timerState.frequencyOffsetTicks;
+        if (adjustedPeriod < 1) adjustedPeriod = 1;
+        if (adjustedPeriod > (int32_t)(2 * halfPeriod)) adjustedPeriod = (int32_t)(2 * halfPeriod);
 
         // Advance the absolute target by the adjusted half-period.  Using an
         // absolute target (not "now + period") avoids drift accumulation.
         nextAlarmTime = delayed_by_us(nextAlarmTime, (uint64_t)adjustedPeriod);
         if (hardware_alarm_set_target(alarmNum, nextAlarmTime)) {
             // Target was already in the past; reschedule from now to recover.
-            nextAlarmTime = make_timeout_time_us(halfPeriod);
+            nextAlarmTime = make_timeout_time_us((uint64_t)adjustedPeriod);
             hardware_alarm_set_target(alarmNum, nextAlarmTime);
         }
 
@@ -134,9 +136,12 @@ static void alarmCallback(uint alarm)
         // Consume the phase shift; it must not carry into the next cycle.
         timerState.phaseShiftUs = 0;
 
+        if (adjustedPeriod < 1) adjustedPeriod = 1;
+        if (adjustedPeriod > (int32_t)(2 * halfPeriod)) adjustedPeriod = (int32_t)(2 * halfPeriod);
+
         nextAlarmTime = delayed_by_us(nextAlarmTime, (uint64_t)adjustedPeriod);
         if (hardware_alarm_set_target(alarmNum, nextAlarmTime)) {
-            nextAlarmTime = make_timeout_time_us(halfPeriod);
+            nextAlarmTime = make_timeout_time_us((uint64_t)adjustedPeriod);
             hardware_alarm_set_target(alarmNum, nextAlarmTime);
         }
 

--- a/src/platform/PICO/expresslrs_timer_pico.c
+++ b/src/platform/PICO/expresslrs_timer_pico.c
@@ -1,0 +1,230 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * ELRS tick/tock timer for RP2350, using the pico-sdk hardware_alarm API.
+ *
+ * The RP2350 has a 64-bit 1µs free-running timer with four alarm channels.
+ * Each alarm fires once at a programmed absolute time; we reschedule it on
+ * every callback to reproduce the STM32 auto-reload behaviour while still
+ * being able to apply per-period phase and frequency corrections.
+ *
+ * Replaces src/main/drivers/rx/expresslrs_driver.c on this platform
+ * (that file is compiled only when !USE_EXPRESSLRS_TIMER_PICO).
+ */
+
+#include "platform.h"
+
+#if defined(USE_RX_EXPRESSLRS) && defined(USE_EXPRESSLRS_TIMER_PICO)
+
+#include "hardware/timer.h"
+
+#include "build/debug.h"
+#include "build/debug_pin.h"
+
+#include "drivers/timer.h"
+#include "drivers/rx/expresslrs_driver.h"
+
+#include "common/maths.h"
+
+// ---------------------------------------------------------------------------
+// Internal state – mirrors the STM32 driver layout exactly so the logic is
+// easy to compare.
+// ---------------------------------------------------------------------------
+
+#define TIMER_INTERVAL_US_DEFAULT   20000u
+#define TICK_TOCK_COUNT             2
+
+typedef enum {
+    TICK,
+    TOCK,
+} tickTock_e;
+
+typedef struct {
+    bool              running;
+    volatile tickTock_e tickTock;
+    uint32_t          intervalUs;
+    int32_t           frequencyOffsetTicks;
+    int32_t           phaseShiftUs;
+} elrsTimerState_t;
+
+typedef struct {
+    int32_t min;
+    int32_t max;
+} elrsPhaseShiftLimits_t;
+
+static uint                  alarmNum;
+static absolute_time_t       nextAlarmTime;
+static elrsPhaseShiftLimits_t phaseShiftLimits;
+
+static elrsTimerState_t timerState = {
+    .running              = false,
+    .tickTock             = TOCK,   // matches STM32 driver initialisation
+    .intervalUs           = TIMER_INTERVAL_US_DEFAULT,
+    .frequencyOffsetTicks = 0,
+    .phaseShiftUs         = 0,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static void expressLrsRecalculatePhaseShiftLimits(void)
+{
+    phaseShiftLimits.max =  (int32_t)(timerState.intervalUs / TICK_TOCK_COUNT);
+    phaseShiftLimits.min = -phaseShiftLimits.max;
+}
+
+// ---------------------------------------------------------------------------
+// Alarm callback – runs at NVIC interrupt level, equivalent to the STM32
+// timer overflow ISR.
+// ---------------------------------------------------------------------------
+
+static void alarmCallback(uint alarm)
+{
+    UNUSED(alarm);
+
+    const uint32_t halfPeriod = timerState.intervalUs / TICK_TOCK_COUNT;
+
+    if (timerState.tickTock == TICK) {
+        dbgPinHi(0);
+
+        int32_t adjustedPeriod = (int32_t)halfPeriod + timerState.frequencyOffsetTicks;
+
+        // Advance the absolute target by the adjusted half-period.  Using an
+        // absolute target (not "now + period") avoids drift accumulation.
+        nextAlarmTime = delayed_by_us(nextAlarmTime, (uint64_t)adjustedPeriod);
+        if (hardware_alarm_set_target(alarmNum, nextAlarmTime)) {
+            // Target was already in the past; reschedule from now to recover.
+            nextAlarmTime = make_timeout_time_us(halfPeriod);
+            hardware_alarm_set_target(alarmNum, nextAlarmTime);
+        }
+
+        expressLrsOnTimerTickISR();
+
+        timerState.tickTock = TOCK;
+    } else {
+        dbgPinLo(0);
+
+        // Apply phase shift on the TOCK half-period only (matches STM32 driver).
+        int32_t adjustedPeriod = (int32_t)halfPeriod
+                               + timerState.phaseShiftUs
+                               + timerState.frequencyOffsetTicks;
+
+        // Consume the phase shift; it must not carry into the next cycle.
+        timerState.phaseShiftUs = 0;
+
+        nextAlarmTime = delayed_by_us(nextAlarmTime, (uint64_t)adjustedPeriod);
+        if (hardware_alarm_set_target(alarmNum, nextAlarmTime)) {
+            nextAlarmTime = make_timeout_time_us(halfPeriod);
+            hardware_alarm_set_target(alarmNum, nextAlarmTime);
+        }
+
+        expressLrsOnTimerTockISR();
+
+        timerState.tickTock = TICK;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API – identical signatures to expresslrs_driver.c
+// ---------------------------------------------------------------------------
+
+void expressLrsTimerDebug(void)
+{
+    DEBUG_SET(DEBUG_RX_EXPRESSLRS_PHASELOCK, 2, timerState.frequencyOffsetTicks);
+    DEBUG_SET(DEBUG_RX_EXPRESSLRS_PHASELOCK, 3, timerState.phaseShiftUs);
+}
+
+void expressLrsUpdateTimerInterval(uint16_t intervalUs)
+{
+    timerState.intervalUs = intervalUs;
+    expressLrsRecalculatePhaseShiftLimits();
+    // No hardware reconfiguration needed; the new interval takes effect on
+    // the next alarm reschedule inside alarmCallback.
+}
+
+void expressLrsUpdatePhaseShift(int32_t newPhaseShift)
+{
+    timerState.phaseShiftUs = constrain(newPhaseShift,
+                                        phaseShiftLimits.min,
+                                        phaseShiftLimits.max);
+}
+
+void expressLrsTimerIncreaseFrequencyOffset(void)
+{
+    timerState.frequencyOffsetTicks++;
+}
+
+void expressLrsTimerDecreaseFrequencyOffset(void)
+{
+    timerState.frequencyOffsetTicks--;
+}
+
+void expressLrsTimerResetFrequencyOffset(void)
+{
+    timerState.frequencyOffsetTicks = 0;
+}
+
+bool expressLrsTimerIsRunning(void)
+{
+    return timerState.running;
+}
+
+void expressLrsTimerStop(void)
+{
+    hardware_alarm_cancel(alarmNum);
+    timerState.running = false;
+}
+
+void expressLrsTimerResume(void)
+{
+    timerState.tickTock = TOCK;
+    nextAlarmTime = make_timeout_time_us(timerState.intervalUs / TICK_TOCK_COUNT);
+    hardware_alarm_set_target(alarmNum, nextAlarmTime);
+    timerState.running = true;
+}
+
+void expressLrsInitialiseTimer(const timerHardware_t *timHw, timerOvrHandlerRec_t *timerUpdateCb)
+{
+    UNUSED(timHw);        // No STM32-style timer instance on RP2350
+    UNUSED(timerUpdateCb); // Callback registration is done via hardware_alarm API
+
+    // Claim the first available hardware alarm.  Panics if none are free.
+    alarmNum = hardware_alarm_claim_unused(true);
+
+    // Register the callback; this also enables the alarm's NVIC IRQ.
+    hardware_alarm_set_callback(alarmNum, alarmCallback);
+
+    // TODO: consider raising the alarm IRQ priority with irq_set_priority()
+    // if phase-lock accuracy proves insufficient at high ELRS rates.
+
+    expressLrsRecalculatePhaseShiftLimits();
+}
+
+void expressLrsTimerEnableIRQs(const timerHardware_t *timer)
+{
+    UNUSED(timer);
+    // IRQ is already enabled by hardware_alarm_set_callback() in
+    // expressLrsInitialiseTimer().  Nothing more to do here.
+}
+
+#endif // USE_RX_EXPRESSLRS && USE_EXPRESSLRS_TIMER_PICO

--- a/src/platform/PICO/expresslrs_timer_pico.c
+++ b/src/platform/PICO/expresslrs_timer_pico.c
@@ -35,11 +35,13 @@
 
 #if defined(USE_RX_EXPRESSLRS) && defined(USE_EXPRESSLRS_TIMER_PICO)
 
+#include "hardware/irq.h"
 #include "hardware/timer.h"
 
 #include "build/debug.h"
 #include "build/debug_pin.h"
 
+#include "drivers/nvic.h"
 #include "drivers/timer.h"
 #include "drivers/rx/expresslrs_driver.h"
 
@@ -214,8 +216,8 @@ void expressLrsInitialiseTimer(const timerHardware_t *timHw, timerOvrHandlerRec_
     // Register the callback; this also enables the alarm's NVIC IRQ.
     hardware_alarm_set_callback(alarmNum, alarmCallback);
 
-    // TODO: consider raising the alarm IRQ priority with irq_set_priority()
-    // if phase-lock accuracy proves insufficient at high ELRS rates.
+    // Raise the alarm IRQ priority to match the timer priority used on STM32.
+    irq_set_priority(hardware_alarm_get_irq_num(alarmNum), NVIC_PRIO_TIMER);
 
     expressLrsRecalculatePhaseShiftLimits();
 }

--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -138,6 +138,11 @@ extern uint32_t systemUniqueId[3];
 #define USE_DYN_IDLE
 #define USE_DYN_NOTCH_FILTER
 
+// ELRS tick/tock timer is implemented using the pico-sdk hardware_alarm API
+// (src/platform/PICO/expresslrs_timer_pico.c) instead of the generic
+// STM32-style timer driver (src/main/drivers/rx/expresslrs_driver.c).
+#define USE_EXPRESSLRS_TIMER_PICO
+
 // NVIC priority utility macros
 #define NVIC_PRIORITY_GROUPING NVIC_PriorityGroup_2
 #define NVIC_BUILD_PRIORITY(base,sub) (((((base)<<(4-(7-(NVIC_PRIORITY_GROUPING>>8))))|((sub)&(0x0f>>(7-(NVIC_PRIORITY_GROUPING>>8)))))<<4)&0xf0)

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -577,7 +577,8 @@ MCU_COMMON_SRC = \
             PICO/usb/usb_msc_pico.c \
             PICO/multicore.c \
             PICO/debug_pin.c \
-            PICO/light_ws2811strip_pico.c
+            PICO/light_ws2811strip_pico.c \
+            PICO/expresslrs_timer_pico.c
 
 # USB MSC support sources (TinyUSB backend on PICO)
 MSC_SRC = \

--- a/src/platform/PICO/target/RP2350A/target.h
+++ b/src/platform/PICO/target/RP2350A/target.h
@@ -100,12 +100,10 @@
 
 // Various untested or unsupported elements are undefined below
 
-#undef USE_RX_SPI
 #undef USE_RX_PWM
 #undef USE_RX_PPM
 #undef USE_RX_CC2500
-#undef USE_RX_EXPRESSLRS
-#undef USE_RX_SX1280
+#undef USE_RX_SX127X
 #undef USE_SERIALRX_GHST
 #undef USE_SERIALRX_IBUS
 #undef USE_SERIALRX_JETIEXBUS

--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -106,12 +106,10 @@
 
 // Various untested or unsupported elements are undefined below
 
-#undef USE_RX_SPI
 #undef USE_RX_PWM
 #undef USE_RX_PPM
 #undef USE_RX_CC2500
-#undef USE_RX_EXPRESSLRS
-#undef USE_RX_SX1280
+#undef USE_RX_SX127X
 #undef USE_SERIALRX_GHST
 #undef USE_SERIALRX_IBUS
 #undef USE_SERIALRX_JETIEXBUS


### PR DESCRIPTION
The RP2350 has no hardware timer peripheral compatible with the STM32-style ELRS tick/tock driver. Implement the same interface using the pico-sdk hardware_alarm API, which provides a 64-bit 1µs free-running timer with four alarm channels.

expresslrs_timer_pico.c implements the full expresslrs_driver.h API:
- Claims a hardware alarm with hardware_alarm_claim_unused()
- Reschedules on every callback using an absolute target time to avoid drift accumulation across tick/tock half-periods
- Applies frequencyOffsetTicks on both half-periods and phaseShiftUs on the TOCK half-period only, matching the STM32 driver behaviour exactly
- Handles the missed-alarm case (target already in the past) by rescheduling relative to now

The generic STM32 driver (expresslrs_driver.c) is gated out on this platform via USE_EXPRESSLRS_TIMER_PICO to prevent duplicate symbol definitions.

Also enables USE_RX_SPI / USE_RX_EXPRESSLRS / USE_RX_SX1280 for both RP2350A and RP2350B targets (previously undef'd), implements the spiInternalResetStream stub in bus_spi_pico.c using dma_channel_abort() and per-IRQ-line acknowledge, and adds a platform README documenting the board config.h defines required to wire up an SX1280 receiver.

Compile-tested on RP2350A and RP2350B. Hardware validation requires a board with an SX1280 connected and pin definitions in config.h.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RP2350 (PICO) platform: added a Pico-specific ExpressLRS tick/tock timer implementation and RP2350 ELRS SPI receiver support (SX1280).

* **Documentation**
  * Added RP2350 platform guide with board config guidance, SPI/ELRS pin requirements, example config, and platform notes.

* **Improvements**
  * More robust SPI DMA reset for RP2350.
  * Build/target configs updated to prefer the RP2350 timer when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->