### PR TITLE
Add support for the BOYAMICRO BY25Q64 flash.

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -139,6 +139,9 @@ struct {
     // BergMicro W25Q32
     // Datasheet: https://www.winbond.com/resource-files/w25q32jv%20dtr%20revf%2002242017.pdf?__locale=zh_TW
     { 0xE04016, 133, 50, 1024, 16 },
+    // BOYAMICRO BY25Q64
+    { 0x684017, 108, 54, 128, 256 },// BY25Q64
+    // Datasheet: https://www.boyamicro.com/storage/upload/pdf/BY25Q64ES.pdf
     // XMC XM25QH256B
     // Datasheet: https://www.xmcwh.com/uploads/499/XM25QU256B.pdf
     { 0x206019, 166, 80, 8192, 16 },


### PR DESCRIPTION
Add support for the BOYAMICRO BY25Q64 flash in flash_m25p16.c
<img width="468" height="330" alt="image" src="https://github.com/user-attachments/assets/db4c891f-cbee-498f-9ad6-e3fe41c98a0c" />
We’ve tested it, and everything works fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for BOYAMICRO BY25Q64 flash memory devices, enabling compatibility with systems using this flash chip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->