### PR TITLE
Guard Makefile git revision lookup with .git directory check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ include $(TARGET_DIR)/target.mk
 endif
 
 REVISION := norevision
-ifneq ($(wildcard .git),)
+ifneq ($(wildcard .git/),)
 ifeq ($(shell git diff --shortstat),)
 REVISION := $(shell git rev-parse --short=9 HEAD)
 endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now skips revision lookup when repository metadata is absent, leaving a default revision placeholder; revision detection runs only when repository data is present to avoid failures in non-repo environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->