### PR TITLE
Remove MCU-specific conditionals from src/main driver code

### DIFF
--- a/src/main/drivers/sdmmc_sdio.h
+++ b/src/main/drivers/sdmmc_sdio.h
@@ -32,14 +32,6 @@
 #include "platform.h"
 #include "drivers/dma.h"
 
-#ifdef STM32F4
-#include "stm32f4xx.h"
-#endif
-
-#ifdef STM32F7
-#include "stm32f7xx.h"
-#endif
-
  /* SDCARD pinouts
  *
  * SD CARD PINS

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -485,9 +485,7 @@ void onSerialRxPinChange(timerEdgeHandlerRec_t *cbRec, captureCompare_t capture)
         }
 
         timerChannelConfigInput(self->timerHardware, inverted ? ICPOLARITY_FALLING : ICPOLARITY_RISING, 0);
-#if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
         serialEnableCC(self);
-#endif
         self->rxEdge = LEADING;
 
         self->rxBitIndex = 0;
@@ -510,9 +508,7 @@ void onSerialRxPinChange(timerEdgeHandlerRec_t *cbRec, captureCompare_t capture)
         self->rxEdge = TRAILING;
         timerChannelConfigInput(self->timerHardware, inverted ? ICPOLARITY_RISING : ICPOLARITY_FALLING, 0);
     }
-#if defined(STM32F7) || defined(STM32H7) || defined(STM32G4)
     serialEnableCC(self);
-#endif
 }
 
 /*

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -40,10 +40,7 @@
 #include "pg/timerio.h"
 
 #define CC_CHANNELS_PER_TIMER         4 // TIM_Channel_1..4
-#ifdef AT32F435
-#define CC_INDEX_FROM_CHANNEL(x)      ((uint8_t)(x) - 1)
-#define CC_CHANNEL_FROM_INDEX(x)      ((uint16_t)(x) + 1)
-#else
+#ifndef CC_CHANNEL_FROM_INDEX
 #define CC_CHANNEL_FROM_INDEX(x)      ((uint16_t)(x) << 2)
 #define CC_INDEX_FROM_CHANNEL(x)      ((uint8_t)((x) >> 2))
 #endif

--- a/src/platform/AT32/include/platform/platform.h
+++ b/src/platform/AT32/include/platform/platform.h
@@ -42,6 +42,10 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 #define TIM_ICInitTypeDef   tmr_input_config_type
 #define TIM_OCStructInit    tmr_output_default_para_init
 #define TIM_Cmd             tmr_counter_enable
+
+// AT32 timer channels are 1-based sequential (not shifted by 2)
+#define CC_INDEX_FROM_CHANNEL(x)      ((uint8_t)(x) - 1)
+#define CC_CHANNEL_FROM_INDEX(x)      ((uint16_t)(x) + 1)
 #define TIM_CtrlPWMOutputs  tmr_output_enable
 #define TIM_TimeBaseInit    tmr_base_init
 #define TIM_ARRPreloadConfig tmr_period_buffer_enable


### PR DESCRIPTION
- sdmmc_sdio.h: remove redundant #ifdef STM32F4/F7 header includes
  (already provided by platform.h)
- serial_softserial.c: remove #if STM32F7/H7/G4 guards around
  serialEnableCC() calls (function exists on all platforms)
- timer.h: move AT32-specific channel indexing macros to AT32
  platform.h, use #ifndef guard for default definitions

https://github.com/betaflight/betaflight/pull/15033, https://github.com/betaflight/betaflight/pull/15035, https://github.com/betaflight/betaflight/pull/15037 are dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Serial input capture functionality now works consistently across all supported microcontroller platforms.

* **Chores**
  * Streamlined platform-specific code handling for device drivers and timer channels.
  * Enhanced AT32 platform support configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->