### PR TITLE
Add VTX pit mode Beeper and Dshot beacon

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -232,7 +232,8 @@ static const beeperTableEntry_t beeperTable[] = {
     { BEEPER_ENTRY(BEEPER_CRASHFLIP_MODE,        20, beep_2longerBeeps,    "CRASHFLIP") },
     { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_OPEN,   21, beep_camOpenBeep,     "CAM_CONNECTION_OPEN") },
     { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_CLOSE,  22, beep_camCloseBeep,    "CAM_CONNECTION_CLOSE") },
-    { BEEPER_ENTRY(BEEPER_ALL,                   23, NULL,                 "ALL") },
+    { BEEPER_ENTRY(BEEPER_VTX_PIT_MODE,         23, beep_2shortBeeps,     "VTX_PIT_MODE") },
+    { BEEPER_ENTRY(BEEPER_ALL,                   24, NULL,                 "ALL") },
 };
 
 static const beeperTableEntry_t *currentBeeperEntry = NULL;

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -59,6 +59,7 @@ typedef enum {
     BEEPER_CAM_CONNECTION_OPEN,     // When the 5 key simulation stated
     BEEPER_CAM_CONNECTION_CLOSE,    // When the 5 key simulation stop
     BEEPER_ARMING_GPS_NO_FIX,       // Beep a special tone when arming the board and GPS has no fix
+    BEEPER_VTX_PIT_MODE,            // Beep when VTX pit mode state changes
     BEEPER_ALL,                     // Turn ON or OFF all beeper conditions
     // BEEPER_ALL must remain at the bottom of this enum
 } beeperMode_e;
@@ -89,11 +90,13 @@ STATIC_ASSERT(BEEPER_ALL < sizeof(uint32_t) * 8, "BEEPER bits exhausted");
     | BEEPER_GET_FLAG(BEEPER_CAM_CONNECTION_OPEN) \
     | BEEPER_GET_FLAG(BEEPER_CAM_CONNECTION_CLOSE) \
     | BEEPER_GET_FLAG(BEEPER_ARMING_GPS_NO_FIX) \
+    | BEEPER_GET_FLAG(BEEPER_VTX_PIT_MODE) \
     )
 
 #define DSHOT_BEACON_ALLOWED_MODES ( \
     BEEPER_GET_FLAG(BEEPER_RX_SET) \
     | BEEPER_GET_FLAG(BEEPER_RX_LOST) \
+    | BEEPER_GET_FLAG(BEEPER_VTX_PIT_MODE) \
     )
 
 // record these modes as arming beep (for DShot)
@@ -109,7 +112,7 @@ STATIC_ASSERT(BEEPER_ALL < sizeof(uint32_t) * 8, "BEEPER bits exhausted");
 #endif // USE_RACE_PRO
 
 #ifndef DEFAULT_BEEPER_OFF_FLAGS
-#define DEFAULT_BEEPER_OFF_FLAGS (0)
+#define DEFAULT_BEEPER_OFF_FLAGS (BEEPER_GET_FLAG(BEEPER_VTX_PIT_MODE))
 #endif
 
 void beeper(beeperMode_e mode);

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -40,6 +40,7 @@
 #include "flight/failsafe.h"
 
 #include "io/vtx_control.h"
+#include "io/beeper.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -193,6 +194,10 @@ static bool vtxProcessPitMode(vtxDevice_t *vtxDevice)
 
         if (currPmSwitchState != prevPmSwitchState) {
             prevPmSwitchState = currPmSwitchState;
+
+#ifdef USE_BEEPER
+            beeper(BEEPER_VTX_PIT_MODE);
+#endif
 
             if (currPmSwitchState) {
 #if defined(VTX_SETTINGS_FREQCMD)


### PR DESCRIPTION
Changes Made:
Adds new beeper mode `BEEPER_VTX_PIT_MODE`.

Plays two short beeps on VTX pit mode OFF→ON and ON→OFF transitions.

- Added enum entry before `BEEPER_ALL` (MSP compatibility preserved)
- Exposed via `BEEPER_ALLOWED_MODES`
- Disabled by default via `DEFAULT_BEEPER_OFF_FLAGS`
- Supports DShot beacon builds
- Informational priority (23)
- No changes to VTX logic

Implements the feature as specified in the issue discussion by coderabbitai.

This closes https://github.com/betaflight/betaflight/issues/14939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio feedback notification when VTX pit mode is activated or deactivated, providing users with audible confirmation of state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->