### PR TITLE
Drivers: correct LSM6DSV16X FS_G_4000DPS encoding

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dsv16x.c
@@ -338,7 +338,7 @@
 #define LSM6DSV_CTRL6_FS_G_500DPS                       0x02
 #define LSM6DSV_CTRL6_FS_G_1000DPS                      0x03
 #define LSM6DSV_CTRL6_FS_G_2000DPS                      0x04
-#define LSM6DSV_CTRL6_FS_G_4000DPS                      0xc0
+#define LSM6DSV_CTRL6_FS_G_4000DPS                      0x0c
 
 // Control register 7 (R/W)
 #define LSM6DSV_CTRL7                       0x16


### PR DESCRIPTION
`LSM6DSV_CTRL6_FS_G_4000DPS` is currently defined as `0xC0`, but
`CTRL6.FS_G` occupies bits `[3:0]` and is masked by `0x0F`.

According to the LSM6DSV16X datasheet, the `±4000 dps` setting for
`FS_G[3:0]` is encoded as `1100b`, i.e. `0x0C`. With the current value,
the setting is masked out when `FS_G` is encoded, so the `±4000 dps`
full-scale range cannot be selected correctly.

This change updates the field value from `0xC0` to `0x0C`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gyroscope sensor configuration for ±4000 degrees per second full-scale range measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->