### PR TITLE
Update firmware build options from API

### DIFF
--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -35,9 +35,7 @@
 
 #include "msp/msp_build_info.h"
 
-void sbufWriteBuildInfoFlags(sbuf_t *dst)
-{
-    static const uint16_t options[] = {
+static const uint16_t buildOptions[] = {
 #ifdef USE_SERIALRX_CRSF
         BUILD_OPTION_SERIALRX_CRSF,
 #endif
@@ -194,10 +192,17 @@ void sbufWriteBuildInfoFlags(sbuf_t *dst)
 #ifdef USE_PWM_OUTPUT
         BUILD_OPTION_PWM_OUTPUT,
 #endif
-    };
+};
 
-    for (unsigned i = 0; i < ARRAYLEN(options); i++)
-    {
-        sbufWriteU16(dst, options[i]);
+void sbufWriteBuildInfoFlags(sbuf_t *dst)
+{
+    for (unsigned i = 0; i < ARRAYLEN(buildOptions); i++) {
+        sbufWriteU16(dst, buildOptions[i]);
     }
+}
+
+const uint16_t *getBuildOptions(unsigned *count)
+{
+    *count = ARRAYLEN(buildOptions);
+    return buildOptions;
 }

--- a/src/main/msp/msp_build_info.h
+++ b/src/main/msp/msp_build_info.h
@@ -89,3 +89,4 @@
 #define BUILD_OPTION_PWM_OUTPUT                 8235
 
 void sbufWriteBuildInfoFlags(sbuf_t *dst);
+const uint16_t *getBuildOptions(unsigned *count);

--- a/src/utils/make-build-info.py
+++ b/src/utils/make-build-info.py
@@ -19,6 +19,7 @@ HEADER_FILE_TEMPLATE = """{license_header}
 {defines}
 
 void sbufWriteBuildInfoFlags(sbuf_t *dst);
+const uint16_t *getBuildOptions(unsigned *count);
 """
 
 SOURCE_FILE_TEMPLATE = """{license_header}
@@ -33,16 +34,21 @@ SOURCE_FILE_TEMPLATE = """{license_header}
 
 #include "msp/msp_build_info.h"
 
+static const uint16_t buildOptions[] = {
+{build_options}
+};
+
 void sbufWriteBuildInfoFlags(sbuf_t *dst)
 {
-    static const uint16_t options[] = {
-{build_options}
-    };
-
-    for (unsigned i = 0; i < ARRAYLEN(options); i++)
-    {
-        sbufWriteU16(dst, options[i]);
+    for (unsigned i = 0; i < ARRAYLEN(buildOptions); i++) {
+        sbufWriteU16(dst, buildOptions[i]);
     }
+}
+
+const uint16_t *getBuildOptions(unsigned *count)
+{
+    *count = ARRAYLEN(buildOptions);
+    return buildOptions;
 }
 """
 


### PR DESCRIPTION
- generated using generated using src/utils/make-build-info.py https://build.betaflight.com/api/options/2026.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for three new build options: Flight Plan, Optical Flow, and Rangefinder.

* **Chores**
  * Updated build metadata to point to the latest options endpoint and input hash.
  * Exposed a way for tools to read the full list of build options at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->