### PR TITLE
Add clang-format devcontainer

### DIFF
--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -52,6 +52,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     clang-18 \
+    clang-format-18 \
     llvm-18-dev \
     libc++-18-dev \
     libc++abi-18-dev \
@@ -60,6 +61,7 @@ RUN apt-get update && \
 
 # Set clang/clang++ alternatives to clang-18
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
 
 # Install stm32flash from source - NOTE: make stm32flash_install points to a broken link


### PR DESCRIPTION
This is the companion PR to #15046 (see also #14900) , which adds clang-format into the devcontainer, so that users of the devcontainers automatically get the tool to format source files. What is actually included in that is a script you can call via `git clang-format-18`, which automatically formats staged files (among other things). If we explain this in the dev docs, this should already cover a lot of possible usages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container to include code formatting tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->