### PR TITLE
Add CI job to enforce source code formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,21 @@ jobs:
       - name: Run all unit tests
         run: make EXTRA_FLAGS=-Werror test-all
 
+  format:
+    name: Check sourcecode formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: sudo apt-get install -y clang-format-18
+
+      - name: Format
+        run: make format-all && git diff --exit-code
+
   result:
     name: Complete
-    needs: [build, test]
+    needs: [build, test, format]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -199,4 +211,8 @@ jobs:
 
       - name: Check test result
         if: ${{ needs.test.result != 'success' }}
+        run: exit 1
+
+      - name: Check formatting result
+        if: ${{ needs.format.result != 'success' }}
         run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -720,6 +720,11 @@ cppcheck: $(CSOURCES)
 cppcheck-result.xml: $(CSOURCES)
 	$(V0) $(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
 
+## format-all        : format all C source and header files in src/
+.PHONY: format-all
+format-all:
+	find src/ -type f \( -name '*.c' -o -name '*.h' \) -not -path '*/templates/*' -exec clang-format-18 -i {} \;
+
 # mkdirs
 $(DIRECTORIES):
 	mkdir -p $@


### PR DESCRIPTION
See #14900. This is a companion PR to #15059 and #15046.
This excludes the templates, because the double braces are of course not valid C.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated formatting enforcement: CI now runs a formatting check and will fail the pipeline if code is not formatted. A new project-level target was added to apply formatting across source files, and the CI result stage depends on the formatting check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->