### PR TITLE
feat: add support for Macronix MX25L12845G flash

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -81,6 +81,9 @@ struct {
     // Macronix MX25L25635E
     // Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/7331/MX25L25635E,%203V,%20256Mb,%20v1.3.pdf
     { 0xC22019, 80, 50, 512, 256 },
+    // Macronix MX25L12845G
+    // Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/8740/MX25L12845G,%203V,%20128Mb,%20v1.8.pdf
+    { 0xC22018, 120, 50, 256, 256 },
     // Micron M25P16
     // Datasheet: https://www.micron.com/-/media/client/global/documents/products/data-sheet/nor-flash/serial-nor/m25p/m25p16.pdf
     { 0x202015, 25, 20, 32, 256 },


### PR DESCRIPTION
Added the device configuration for the Macronix MX25L12845G Serial NOR Flash memory. This allows the Flight Controller to correctly identify and interface with this specific flash chip for tasks like Blackbox logging.

Added the JEDEC ID and geometry parameters to the flash detection table in m25p16FlashConfig[].
File modified: src/main/drivers/flash/flash_m25p16.c
Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/8740/MX25L12845G,%203V,%20128Mb,%20v1.8.pdf
- jedecID: 0xC22018 (check Table 6. ID Definitions under RDID command);
- maxClkSPIMHz: 120MHz (check Table 25. AC CHARACTERISTICS, symbol fSCLK, however it states that the maximum frequency can be 133MHz if the VCC range = 3.0V-3.6V, otherwise it is 120MHz);
- maxReadClkSPIMHz: 50MHz (check Table 25. AC CHARACTERISTICS, symbol fRSCLK);
- sectors: 256 (check Table 4. Memory Organization)
- pagesPerSector: 256 (check Table 4. Memory Organization)

Verification Results:
- Visual inspection: Under "Onboard dataflash chip" it shows "Free Space 16.0 MB" under Blackbox tab.
- CLI verification:
      # flash_info
      Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216 JEDEC ID=0x00c22018
      Partitions:
        0: FLASHFS   0 255
      FlashFS size=16777216, usedSize=0
- Successfully performed a test flight during which blackbox data has been written. The data has been read using Blackbox Betaflight.
- Verified that the data can be erased using "Erase flash" under Blackbox tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for an additional Macronix SPI NOR flash storage device variant, enabling automatic hardware recognition and proper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->