### PR TITLE
Fix SDK hydration race condition in parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -668,15 +668,15 @@ zip: $(TARGET_HEX)
 	$(V1) zip $(TARGET_ZIP) $(TARGET_HEX)
 
 .PHONY: binary
-binary:
+binary: $(PLATFORM_SDK_STAMP)
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
 
 .PHONY: hex
-hex:
+hex: $(PLATFORM_SDK_STAMP)
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
 .PHONY: uf2
-uf2:
+uf2: $(PLATFORM_SDK_STAMP)
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
 
 .PHONY: exe


### PR DESCRIPTION
Ensure platform SDK submodule is fully hydrated before launching the parallel sub-make. The order-only prerequisite on TARGET_OBJS was insufficient because GNU Make's parallel scheduler resolves source file prerequisites (via VPATH) concurrently with building the stamp, causing "No rule to make target" errors for HAL sources not yet cloned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system consistency to ensure platform SDK dependencies are properly initialized before building output binaries. This enhances build reliability and prevents potential issues from incomplete SDK setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->