### PR TITLE
Warn about missing libusb-1.0 and python3-venv before ESP32 tools install

### DIFF
--- a/src/platform/ESP32/mk/tools.mk
+++ b/src/platform/ESP32/mk/tools.mk
@@ -38,6 +38,8 @@ $(ESP_IDF_STAMP):
 esp_tools_install: | $(ESP_IDF_STAMP)
 	@ldconfig -p 2>/dev/null | grep -q libusb-1.0 || \
 		echo "WARNING: libusb-1.0 not found. Install it (e.g. 'sudo apt-get install libusb-1.0-0') or esp32 tools may fail."
+	@python3 -c 'import venv' 2>/dev/null || \
+		echo "WARNING: python3-venv not found. Install it (e.g. 'sudo apt-get install python3-venv') or esp32 tools may fail."
 	@echo "Installing ESP32 tools to $(IDF_TOOLS_PATH)"
 	$(V1) cd $(ESP_IDF_PATH) && IDF_TOOLS_PATH=$(IDF_TOOLS_PATH) ./install.sh esp32s3 || { echo "Failed to install ESP32 tools"; exit 1; }
 	@echo "ESP32 tools installed. Source export.sh before building:"

--- a/src/platform/ESP32/mk/tools.mk
+++ b/src/platform/ESP32/mk/tools.mk
@@ -36,6 +36,8 @@ $(ESP_IDF_STAMP):
 ## esp_tools_install  : Install ESP32 toolchain via esp-idf
 .PHONY: esp_tools_install
 esp_tools_install: | $(ESP_IDF_STAMP)
+	@ldconfig -p 2>/dev/null | grep -q libusb-1.0 || \
+		echo "WARNING: libusb-1.0 not found. Install it (e.g. 'sudo apt-get install libusb-1.0-0') or esp32 tools may fail."
 	@echo "Installing ESP32 tools to $(IDF_TOOLS_PATH)"
 	$(V1) cd $(ESP_IDF_PATH) && IDF_TOOLS_PATH=$(IDF_TOOLS_PATH) ./install.sh esp32s3 || { echo "Failed to install ESP32 tools"; exit 1; }
 	@echo "ESP32 tools installed. Source export.sh before building:"


### PR DESCRIPTION
## Summary
- Add pre-flight checks in `esp_tools_install` that warn when `libusb-1.0` or `python3-venv` are missing
- `openocd-esp32` requires `libusb-1.0` at runtime; without it the install extracts the tool then fails the post-install check with a confusing shared library error
- ESP-IDF's `install.sh` creates a Python virtual environment, which requires `python3-venv`; without it the install fails deep in `idf_tools.py`

## Test plan
- [ ] Run `make esp_tools_install` on a system without `libusb-1.0-0` and verify the warning is printed
- [ ] Run `make esp_tools_install` on a system without `python3-venv` and verify the warning is printed
- [ ] Run `make esp_tools_install` on a system with both packages and verify no warnings appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the ESP32 installation process by adding automatic preflight validation checks that verify required system dependencies and components are in place before tool installation begins. These checks provide early detection of missing prerequisites and deliver informative warnings to users, helping prevent installation failures and ensuring a smoother setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->