### PR TITLE
Brushed motor direction GPIO for turtle / crashflip (single reverse pin)

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -103,6 +103,7 @@ COMMON_SRC = \
             drivers/io.c \
             drivers/io_preinit.c \
             drivers/light_led.c \
+            drivers/brushed_reverse.c \
             drivers/motor.c \
             drivers/pinio.c \
             drivers/pin_pull_up_down.c \

--- a/src/main/drivers/brushed_reverse.c
+++ b/src/main/drivers/brushed_reverse.c
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#include "drivers/brushed_reverse.h"
+
+#include "drivers/io.h"
+#include "drivers/resource.h"
+
+#if defined(USE_BRUSHED_FLIPOVERAFTERCRASH) && defined(BRUSHED_REVERSE_PIN)
+
+static IO_t brushedReverseIO = IO_NONE;
+
+bool brushedReverseIsAvailable(void)
+{
+    return brushedReverseIO != IO_NONE;
+}
+
+static void brushedReverseWrite(bool reversed)
+{
+    if (brushedReverseIO == IO_NONE) {
+        return;
+    }
+
+#if defined(BRUSHED_FLIPOVERAFTERCRASH_LOW_ACTIVE)
+    // Active-low: reversed -> LOW, normal -> HIGH
+    if (reversed) {
+        IOLo(brushedReverseIO);
+    } else {
+        IOHi(brushedReverseIO);
+    }
+#else
+    // Active-high: reversed -> HIGH, normal -> LOW
+    if (reversed) {
+        IOHi(brushedReverseIO);
+    } else {
+        IOLo(brushedReverseIO);
+    }
+#endif
+}
+
+void brushedReverseInit(void)
+{
+    brushedReverseIO = IOGetByTag(IO_TAG(BRUSHED_REVERSE_PIN));
+    if (brushedReverseIO == IO_NONE) {
+        return;
+    }
+
+    // Configure early and drive to a known-safe default (normal direction).
+    IOInit(brushedReverseIO, OWNER_SYSTEM, 0);
+    IOConfigGPIO(brushedReverseIO, IOCFG_OUT_PP);
+    brushedReverseWrite(false);
+}
+
+void brushedReverseSetReversed(bool reversed)
+{
+    brushedReverseWrite(reversed);
+}
+
+#else
+
+bool brushedReverseIsAvailable(void)
+{
+    return false;
+}
+
+void brushedReverseInit(void)
+{
+}
+
+void brushedReverseSetReversed(bool reversed)
+{
+    UNUSED(reversed);
+}
+
+#endif
+

--- a/src/main/drivers/brushed_reverse.h
+++ b/src/main/drivers/brushed_reverse.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+// Brushed reverse control (external H-bridge / dual NMOS direction pin).
+//
+// When enabled (USE_BRUSHED_FLIPOVERAFTERCRASH + BRUSHED_REVERSE_PIN), this module:
+// - Configures the reverse GPIO early at boot and drives it to "normal" direction (safe state).
+// - Allows switching between normal/reversed direction at runtime.
+//
+// Polarity:
+// - If BRUSHED_FLIPOVERAFTERCRASH_LOW_ACTIVE is defined, "reversed" is active-low.
+// - Otherwise, "reversed" is active-high.
+
+void brushedReverseInit(void);
+void brushedReverseSetReversed(bool reversed);
+bool brushedReverseIsAvailable(void);
+

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -285,7 +285,7 @@ void updateArmingStatus(void)
 
 #ifdef USE_DSHOT
 // --- handle crashFlip behaviours while armed ---
-if (crashFlipModeActive) {
+if (isMotorProtocolDshot() && crashFlipModeActive) {
     if (!IS_RC_MODE_ACTIVE(BOXCRASHFLIP)) {
         // Pilot has reverted the crash flip switch while crashflip is active and craft is  armed
         if (!mixerConfig()->crashflip_auto_rearm) {

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -47,6 +47,7 @@
 #include "drivers/dshot_command.h"
 #include "drivers/light_led.h"
 #include "drivers/motor.h"
+#include "drivers/brushed_reverse.h"
 #include "drivers/sound_beeper.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
@@ -302,6 +303,21 @@ if (crashFlipModeActive) {
     }
 }
 #endif // USE_DSHOT
+
+#if defined(USE_BRUSHED_FLIPOVERAFTERCRASH)
+        // For brushed reverse-pin targets: if crashflip was active at arming time and the
+        // pilot now turns the switch off while still armed, restore normal direction.
+        if (crashFlipModeActive && !IS_RC_MODE_ACTIVE(BOXCRASHFLIP)) {
+            if (!mixerConfig()->crashflip_auto_rearm) {
+                setArmingDisabled(ARMING_DISABLED_CRASHFLIP);
+                clearWasLastDisarmUserRequested();
+                disarm(DISARM_REASON_CRASHFLIP);
+            } else {
+                brushedReverseSetReversed(false);
+                crashFlipModeActive = false;
+            }
+        }
+#endif
     } else {
         // arming switch on, but not yet armed; currently DISARMED
         // identify things that should delay, or prevent, arming, then arm
@@ -534,6 +550,9 @@ void disarm(flightLogDisarmReason_e reason)
 #ifdef USE_DSHOT
         setMotorSpinDirection(DSHOT_CMD_SPIN_DIRECTION_NORMAL);
 #endif
+#if defined(USE_BRUSHED_FLIPOVERAFTERCRASH)
+        brushedReverseSetReversed(false);
+#endif
 
         // make disarming beeps, but not if ARMING_DISABLED (RUNAWAY_TAKEOFF or CRASH_DETECTED)
         if (!(getArmingDisableFlags() & (ARMING_DISABLED_RUNAWAY_TAKEOFF | ARMING_DISABLED_CRASH_DETECTED))) {
@@ -592,6 +611,15 @@ if (isMotorProtocolDshot()) {
     setMotorSpinDirection(crashFlipModeActive ? DSHOT_CMD_SPIN_DIRECTION_REVERSED : DSHOT_CMD_SPIN_DIRECTION_NORMAL);
 }
 #endif // USE_DSHOT
+
+#if defined(USE_BRUSHED_FLIPOVERAFTERCRASH)
+        // For brushed reverse-pin targets, crashflip direction is implemented by a GPIO,
+        // and crashFlipModeActive must be set here (mixer uses it).
+        if (!isMotorProtocolDshot()) {
+            crashFlipModeActive = IS_RC_MODE_ACTIVE(BOXCRASHFLIP);
+            brushedReverseSetReversed(crashFlipModeActive);
+        }
+#endif
 
 #ifdef USE_LAUNCH_CONTROL
         if (!crashFlipModeActive && (canUseLaunchControl() || (tryingToArm == ARMING_DELAYED_LAUNCH_CONTROL))) {

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -77,6 +77,7 @@
 #include "drivers/timer.h"
 #include "drivers/transponder_ir.h"
 #include "drivers/usb_io.h"
+#include "drivers/brushed_reverse.h"
 #ifdef USE_USB_MSC
 #include "drivers/usb_msc.h"
 #endif
@@ -280,6 +281,10 @@ void initPhase1(void)
 
     // initialize IO (needed for all IO operations)
     IOInitGlobal();
+
+    // If the target provides a brushed direction pin, configure it immediately
+    // and drive it to the safe "normal direction" state to avoid shoot-through.
+    brushedReverseInit();
 
 #if defined(USE_TARGET_CONFIG)
     // Call once before the config is loaded for any target specific configuration required to support loading the config

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -294,6 +294,10 @@ void initActiveBoxIds(void)
     }
 #endif
 
+#ifdef USE_BRUSHED_FLIPOVERAFTERCRASH
+    BME(BOXCRASHFLIP);
+#endif
+
     if (featureIsEnabled(FEATURE_SERVO_TILT)) {
         BME(BOXCAMSTAB);
     }

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -294,7 +294,7 @@ void initActiveBoxIds(void)
     }
 #endif
 
-#ifdef USE_BRUSHED_FLIPOVERAFTERCRASH
+#if defined(USE_BRUSHED_FLIPOVERAFTERCRASH) && defined(BRUSHED_REVERSE_PIN)
     BME(BOXCRASHFLIP);
 #endif
 


### PR DESCRIPTION
Provide GPIO-based control of brushed motors to enable forward/reverse rotation, supporting turtle mode / crash flip functionality. Currently, only one GPIO is used; historically, NewBeeDrone has relied on this method for control. In the future, it would be possible to use three GPIOs together with a 3-to-8 decoder to achieve independent forward/reverse control for each brushed motor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brushed motor direction reversal control added to support automatic flip-over on crash for brushed setups.

* **Improvements**
  * Crash-flip now supports brushed hardware and is exposed where applicable.
  * Brushed reversal is initialized early on startup and always reset on disarm for safer behavior.
  * Crash-flip activation visibility adjusted in the configuration UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->