### PR TITLE
ESP32: Expand DMA interrupt pool and add USB VCP connection detection

### DIFF
--- a/src/platform/ESP32/dma_esp32.c
+++ b/src/platform/ESP32/dma_esp32.c
@@ -68,6 +68,9 @@ static const int gdmaRxIntrSource[ESP32_GDMA_CHANNEL_COUNT] = {
 static const int gdmaCpuIntrPool[] = {
     ESP32_CPU_INTR_DMA_CH0,
     ESP32_CPU_INTR_DMA_CH1,
+    ESP32_CPU_INTR_DMA_CH2,
+    ESP32_CPU_INTR_DMA_CH3,
+    ESP32_CPU_INTR_DMA_CH4,
 };
 
 #define GDMA_CPU_INTR_POOL_SIZE (int)(sizeof(gdmaCpuIntrPool) / sizeof(gdmaCpuIntrPool[0]))

--- a/src/platform/ESP32/include/platform/interrupt.h
+++ b/src/platform/ESP32/include/platform/interrupt.h
@@ -33,6 +33,10 @@
 #define ESP32_CPU_INTR_UART2    23
 #define ESP32_CPU_INTR_DMA_CH0  24
 #define ESP32_CPU_INTR_DMA_CH1  25
+#define ESP32_CPU_INTR_DMA_CH2  26
+#define ESP32_CPU_INTR_DMA_CH3  27
+#define ESP32_CPU_INTR_DMA_CH4  28
+#define ESP32_CPU_INTR_USB      29
 
 typedef void (*esp32IsrHandler_t)(void *arg);
 

--- a/src/platform/ESP32/light_ws2811strip_esp32.c
+++ b/src/platform/ESP32/light_ws2811strip_esp32.c
@@ -29,6 +29,7 @@
 #include "common/color.h"
 #include "common/maths.h"
 #include "common/utils.h"
+#include "drivers/dshot.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/light_ws2811strip.h"
@@ -46,12 +47,14 @@
 #include "esp_rom_gpio.h"
 #include "soc/gpio_sig_map.h"
 
-#define WS2812_RMT_CHANNEL     3       // Use last RMT TX channel (0-3 are TX on ESP32-S3)
-#define WS2812_RMT_CLK_DIV    4       // 80MHz / 4 = 20MHz (50ns per tick)
-#define WS2812_T0H_TICKS      8       // 400ns
-#define WS2812_T0L_TICKS      17      // 850ns
-#define WS2812_T1H_TICKS      16      // 800ns
-#define WS2812_T1L_TICKS      9       // 450ns
+// ESP32-S3 has 4 RMT TX channels (0-3). DShot uses channels 0..N-1 for
+// N motors. The LED strip uses the next available TX channel after DShot.
+#define WS2812_RMT_TX_CHANNELS  4
+#define WS2812_RMT_CLK_DIV     4       // 80MHz / 4 = 20MHz (50ns per tick)
+#define WS2812_T0H_TICKS       8       // 400ns
+#define WS2812_T0L_TICKS       17      // 850ns
+#define WS2812_T1H_TICKS       16      // 800ns
+#define WS2812_T1L_TICKS       9       // 450ns
 
 // RMTMEM is provided by periph_regs_esp32.c at 0x60016800
 // Each channel has 48 words (items) of memory
@@ -63,6 +66,7 @@ extern uint32_t RMTMEM[];
 static IO_t ledStripIO = IO_NONE;
 static bool ws2812Initialized = false;
 static ledStripFormatRGB_e ledFormat = LED_GRB;
+static uint8_t ws2812RmtChannel = 0;
 
 // Software buffer for LED strip RMT items
 // 24 bits per LED (GRB), plus end marker
@@ -102,6 +106,14 @@ bool ws2811LedStripHardwareInit(void)
 {
     if (!ledStripIO) return false;
 
+    // Assign the first free RMT TX channel after DShot motors.
+    // dshotMotorCount is set during dshotPwmDevInit which runs before LED init.
+    ws2812RmtChannel = dshotMotorCount;
+    if (ws2812RmtChannel >= WS2812_RMT_TX_CHANNELS) {
+        // All TX channels used by DShot, no room for LED strip
+        return false;
+    }
+
     // Enable RMT peripheral (may already be enabled by DShot)
     int __DECLARE_RCC_ATOMIC_ENV __attribute__((unused));
     rmt_ll_enable_bus_clock(0, true);
@@ -110,11 +122,14 @@ bool ws2811LedStripHardwareInit(void)
     // Enable direct memory access (non-FIFO mode)
     rmt_ll_enable_mem_access_nonfifo(&RMT, true);
 
-    uint8_t ch = WS2812_RMT_CHANNEL;
+    uint8_t ch = ws2812RmtChannel;
     uint32_t pin = IO_Pin(ledStripIO);
 
     rmt_ll_tx_set_channel_clock_div(&RMT, ch, WS2812_RMT_CLK_DIV);
     rmt_ll_tx_set_mem_blocks(&RMT, ch, 1);
+    rmt_ll_tx_fix_idle_level(&RMT, ch, 0, true);
+    rmt_ll_tx_enable_carrier_modulation(&RMT, ch, false);
+    rmt_ll_tx_enable_loop(&RMT, ch, false);
 
     // Connect RMT output to GPIO pin
     esp_rom_gpio_pad_select_gpio(pin);
@@ -157,7 +172,7 @@ void ws2811LedStripStartTransfer(void)
 
     ws2811LedDataTransferInProgress = true;
 
-    const uint8_t ch = WS2812_RMT_CHANNEL;
+    const uint8_t ch = ws2812RmtChannel;
     const uint32_t totalItems = WS2811_LED_STRIP_LENGTH * WS2812_BITS_PER_LED;
 
     // Write RMT items to hardware memory via RMTMEM
@@ -175,9 +190,14 @@ void ws2811LedStripStartTransfer(void)
     rmt_ll_tx_reset_pointer(&RMT, ch);
     rmt_ll_tx_start(&RMT, ch);
 
-    // Wait for completion (simple polling for now)
-    // ~30us per LED plus 50us reset pulse
-    delayMicroseconds(50 + (WS2811_LED_STRIP_LENGTH * 30));
+    // Wait for TX_DONE instead of blind delay
+    const timeUs_t startUs = micros();
+    while (!(rmt_ll_tx_get_interrupt_status_raw(&RMT, ch) & RMT_LL_EVENT_TX_DONE(ch))) {
+        if (cmpTimeUs(micros(), startUs) >= 5000) {
+            break;  // 5ms safety timeout
+        }
+    }
+    rmt_ll_clear_interrupt_status(&RMT, RMT_LL_EVENT_TX_DONE(ch));
 
     ws2811LedDataTransferInProgress = false;
 }

--- a/src/platform/ESP32/mk/ESP32S3.mk
+++ b/src/platform/ESP32/mk/ESP32S3.mk
@@ -101,6 +101,7 @@ MCU_COMMON_SRC = \
             ESP32/serial_usb_vcp_esp32.c \
             ESP32/system.c \
             ESP32/light_ws2811strip_esp32.c \
+            ESP32/timer_esp32.c \
             ESP32/periph_regs_esp32.c
 
 # ESP-IDF SOC peripheral descriptor sources (provide GPIO, SYSTIMER, RMT, etc. symbols)

--- a/src/platform/ESP32/serial_usb_vcp_esp32.c
+++ b/src/platform/ESP32/serial_usb_vcp_esp32.c
@@ -40,7 +40,15 @@
 #include "hal/usb_serial_jtag_ll.h"
 #pragma GCC diagnostic pop
 
+// SOF-based USB host connection detection.
+// USB full-speed host sends a SOF frame every 1ms. We poll the raw SOF
+// interrupt bit periodically — if SOF has been seen since the last check,
+// the host is connected. If not seen for SOF_TIMEOUT_US, assume disconnected.
+#define SOF_TIMEOUT_US  3000   // 3ms without SOF = disconnected
+
 static vcpPort_t vcpPort = { 0 };
+static timeUs_t lastSofTime = 0;
+static bool usbConnected = false;
 
 static void usbVcpSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
@@ -167,7 +175,17 @@ uint32_t usbVcpGetBaudRate(serialPort_t *instance)
 
 uint8_t usbVcpIsConnected(void)
 {
-    return 1;  // USB Serial/JTAG is always available when USB is connected
+    const timeUs_t now = micros();
+
+    if (usb_serial_jtag_ll_get_intraw_mask() & USB_SERIAL_JTAG_INTR_SOF) {
+        usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_INTR_SOF);
+        lastSofTime = now;
+        usbConnected = true;
+    } else if (usbConnected && cmpTimeUs(now, lastSofTime) >= SOF_TIMEOUT_US) {
+        usbConnected = false;
+    }
+
+    return usbConnected;
 }
 
 #endif // USE_VCP

--- a/src/platform/ESP32/target/ESP32S3/target.h
+++ b/src/platform/ESP32/target/ESP32S3/target.h
@@ -56,7 +56,6 @@
 #undef USE_TRANSPONDER
 #undef USE_FLASH
 #undef USE_FLASH_CHIP
-#undef USE_TIMER
 #undef USE_RCC
 
 // Config stored in flash partition

--- a/src/platform/ESP32/timer_def.h
+++ b/src/platform/ESP32/timer_def.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// ESP32-S3 minimal timer framework.
+// The ESP32 uses dedicated peripherals (LEDC for PWM, RMT for DShot/LED)
+// rather than general-purpose timers. This provides the minimum definitions
+// needed for USE_TIMER to be defined, enabling code paths in cli.c and
+// config.c that reference timerGetConfiguredByTag/timerAllocate.
+
+// No timer channels are mapped to pins - all PWM output uses LEDC/RMT directly.
+#define FULL_TIMER_CHANNEL_COUNT  0
+
+// No hardware timers tracked for resource allocation
+#define USED_TIMERS  0
+#define HARDWARE_TIMER_DEFINITION_COUNT  0

--- a/src/platform/ESP32/timer_esp32.c
+++ b/src/platform/ESP32/timer_esp32.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * ESP32-S3 minimal timer framework.
+ *
+ * The ESP32 uses LEDC for PWM and RMT for DShot/LED, not general-purpose
+ * timers. This file provides the empty timerHardware array and stub
+ * functions required when USE_TIMER is defined, enabling shared code
+ * paths (cli.c, config.c) that reference timer functions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_TIMER
+
+#include "common/utils.h"
+#include "drivers/io.h"
+#include "drivers/timer.h"
+
+// Empty timer hardware array - no pins mapped to timers on ESP32.
+// All PWM output is handled by LEDC/RMT peripherals directly.
+const timerHardware_t fullTimerHardware[1] = { { 0 } };
+
+void timerInit(void)
+{
+    // NOOP - ESP32 uses LEDC/RMT instead of general-purpose timers
+}
+
+const timerHardware_t *timerGetByTagAndIndex(ioTag_t ioTag, unsigned timerIndex)
+{
+    UNUSED(ioTag);
+    UNUSED(timerIndex);
+    return NULL;
+}
+
+int8_t timerGetTIMNumber(const timerHardware_t *timHw)
+{
+    UNUSED(timHw);
+    return -1;
+}
+
+int8_t timerGetNumberByIndex(uint8_t index)
+{
+    UNUSED(index);
+    return -1;
+}
+
+int8_t timerGetIndexByNumber(uint8_t number)
+{
+    UNUSED(number);
+    return -1;
+}
+
+#endif // USE_TIMER


### PR DESCRIPTION
## Summary
- Expand GDMA CPU interrupt pool from 2 to 5 lines (one per channel), allowing DMA users beyond SPI to register interrupt handlers without silent failure.
- Replace always-connected USB VCP stub with SOF frame polling to detect actual USB host presence. Reports disconnected after 3ms without a SOF frame, matching the ESP-IDF reference approach.

## Test plan
- [ ] Verify ESP32S3 build compiles cleanly
- [ ] Verify USB VCP connects/disconnects correctly when plugging/unplugging USB
- [ ] Verify SPI DMA transfers still function correctly with expanded interrupt pool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic USB connection state detection for more reliable VCP connectivity monitoring.
  * Enabled dynamic RMT channel allocation for WS2812 LED strips, allowing simultaneous use with DShot motors.
  * Expanded DMA interrupt handling support for additional channels on ESP32-S3.

* **Improvements**
  * Added timer framework support for ESP32-S3 platform builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->