### PR TITLE
ESP32: Enable SD card blackbox and fix SPI CS preinit

### DIFF
--- a/src/platform/ESP32/bus_spi_esp32.c
+++ b/src/platform/ESP32/bus_spi_esp32.c
@@ -177,26 +177,19 @@ void spiPinConfigure(const struct spiPinConfig_s *pConfig)
     }
 }
 
-void spiPreinit(void)
-{
-    // NOOP
-}
-
 void spiPreinitRegister(ioTag_t iotag, uint32_t iocfg, uint8_t init)
 {
-    UNUSED(iotag);
-    UNUSED(iocfg);
-    UNUSED(init);
+    ioPreinitByTag(iotag, iocfg, init);
 }
 
 void spiPreinitByIO(IO_t io)
 {
-    UNUSED(io);
+    ioPreinitByIO(io, IOCFG_IPU, PREINIT_PIN_STATE_HIGH);
 }
 
 void spiPreinitByTag(ioTag_t tag)
 {
-    UNUSED(tag);
+    spiPreinitByIO(IOGetByTag(tag));
 }
 
 void spiInitDevice(spiDevice_e device)

--- a/src/platform/ESP32/mk/ESP32S3.mk
+++ b/src/platform/ESP32/mk/ESP32S3.mk
@@ -85,6 +85,7 @@ MCU_COMMON_SRC = \
             drivers/adc.c \
             ESP32/adc_esp32.c \
             ESP32/bus_i2c_esp32.c \
+            drivers/bus_spi_config.c \
             ESP32/bus_spi_esp32.c \
             ESP32/config_flash.c \
             ESP32/debug_esp32.c \

--- a/src/platform/ESP32/target/ESP32S3/target.h
+++ b/src/platform/ESP32/target/ESP32S3/target.h
@@ -58,6 +58,13 @@
 #undef USE_FLASH_CHIP
 #undef USE_RCC
 
+// SD card over SPI for blackbox logging (runtime-configured pins)
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+
+// Default blackbox to serial; SD card available as an option
+#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_SERIAL
+
 // Config stored in flash partition
 #define CONFIG_IN_FLASH
 
@@ -133,4 +140,3 @@
 #undef USE_OSD_HD
 
 #undef USE_USB_MSC
-#undef USE_SDCARD


### PR DESCRIPTION
## Summary
- Enable `USE_SDCARD` and `USE_SDCARD_SPI` for ESP32-S3, allowing blackbox logging to SD card over SPI with runtime-configured pins.
- Set default blackbox device to serial, with SD card selectable at runtime via CLI or Configurator.
- Replace NOOP `spiPreinit` stubs with real implementations that drive CS pins high during init, fixing potential gyro/sensor detection failures on first boot.
- Add common `bus_spi_config.c` to the ESP32 build for device preinit dispatch (SD card, flash, RX SPI, etc.).

## Test plan
- [ ] Verify ESP32S3 build compiles cleanly
- [ ] Verify gyro detection succeeds on boot (CS preinit fix)
- [ ] Verify SD card is detected when connected to an SPI bus with correct CLI config
- [ ] Verify blackbox logging to SD card via `set blackbox_device = SDCARD`
- [ ] Verify serial blackbox still works as default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SD card support now available for ESP32-S3 via SPI with configurable pins
  * Serial blackbox recording enabled by default

* **Improvements**
  * Enhanced SPI pre-initialization consistency on ESP32 platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->