### PR TITLE
Auto-discover platform tools.mk via wildcard

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -345,9 +345,7 @@ PLATFORM_SDK_arm_CC         := $(if $(ARM_SDK_PREFIX),$(ARM_SDK_PREFIX)gcc,arm-n
 PLATFORM_SDK_arm_CC_VERSION := $(GCC_REQUIRED_VERSION)
 PLATFORM_SDK_arm_CC_INSTALL := arm_sdk_install
 
-include $(PLATFORM_DIR)/STM32/mk/tools.mk
-include $(PLATFORM_DIR)/PICO/mk/tools.mk
-include $(PLATFORM_DIR)/ESP32/mk/tools.mk
+include $(wildcard $(PLATFORM_DIR)/*/mk/tools.mk)
 
 ## platform-sdk-list-print : list registered SDK names (space-separated)
 .PHONY: platform-sdk-list-print


### PR DESCRIPTION
## Summary
Replace the hardcoded per-platform `include` lines in `mk/tools.mk` with a single wildcard glob:

```makefile
include $(wildcard $(PLATFORM_DIR)/*/mk/tools.mk)
```

## Motivation
Every time a new platform adds a submodule-based SDK (e.g. APM32F4 in #15098), a manual edit to `mk/tools.mk` is required to add the include line. This is easy to forget and creates an unnecessary review burden.

With this change, new platforms only need to drop a `mk/tools.mk` into their `src/platform/<NAME>/mk/` directory — the build system picks it up automatically.

## Testing
- `make platform-sdk-list-print` still lists all registered SDKs (stm32h5, stm32n6, pico, esp_idf)
- Existing platform builds are unaffected — `$(wildcard)` returns the same set of files that were previously hardcoded

## Notes
- `$(wildcard)` is evaluated at Makefile parse time, so there is no runtime cost
- Each platform's `tools.mk` appends to `PLATFORM_SDKS` independently with no cross-dependencies, so include order does not matter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved platform tool discovery to enable easier addition of future platform support without requiring core build file modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->