### PR TITLE
STM32N6: enable SDIO/SDCARD support

### DIFF
--- a/src/main/pg/sdio.c
+++ b/src/main/pg/sdio.c
@@ -67,7 +67,7 @@ PG_RESET_TEMPLATE(sdioConfig_t, sdioConfig,
     .device = SDIO_DEV_TO_CFG(SDIO_DEVICE),
 );
 
-#if defined(STM32H7) || defined(STM32H5)
+#if defined(STM32H7) || defined(STM32H5) || defined(STM32N6)
 PG_REGISTER_WITH_RESET_TEMPLATE(sdioPinConfig_t, sdioPinConfig, PG_SDIO_PIN_CONFIG, 0);
 
 PG_RESET_TEMPLATE(sdioPinConfig_t, sdioPinConfig,

--- a/src/platform/STM32/mk/STM32N6.mk
+++ b/src/platform/STM32/mk/STM32N6.mk
@@ -137,6 +137,7 @@ MCU_COMMON_SRC = \
             STM32/pwm_output_dshot_hal.c \
             STM32/rcc_stm32.c \
             STM32/serial_uart_ll.c \
+            STM32/sdio_n6xx.c \
             STM32/serial_uart_stm32n6xx.c \
             STM32/system_stm32n6xx.c \
             STM32/timer_hal.c \

--- a/src/platform/STM32/sdio_n6xx.c
+++ b/src/platform/STM32/sdio_n6xx.c
@@ -42,6 +42,7 @@
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/nvic.h"
+#include "drivers/dma.h"
 #include "drivers/sdio.h"
 
 typedef struct SD_Handle_s
@@ -144,11 +145,16 @@ void sdioPinConfigure(void)
 {
     SDIODevice device = SDIO_CFG_TO_DEV(sdioConfig()->device);
 
-    if (device == SDIOINVALID) {
+    if (device == SDIOINVALID || device >= SDIODEV_COUNT) {
         return;
     }
 
     sdioHardware = &sdioPinHardware[device];
+
+    if (!sdioHardware->instance) {
+        sdioHardware = NULL;
+        return;
+    }
 
     SDIOFINDPIN(CK);
     SDIOFINDPIN(CMD);
@@ -212,7 +218,7 @@ void HAL_SD_MspInit(SD_HandleTypeDef* hsd)
     HAL_NVIC_EnableIRQ(sdioHardware->irqn);
 }
 
-void SDIO_GPIO_Init(void)
+void sdioInitialize(void)
 {
     if (!sdioHardware) {
         return;
@@ -258,7 +264,7 @@ void SDIO_GPIO_Init(void)
     IOConfigGPIO(cmd, IOCFG_OUT_PP);
 }
 
-bool SD_Initialize_LL(DMA_ARCH_TYPE *dma)
+bool SD_InitialiseHardware(dmaResource_t *dma)
 {
     UNUSED(dma);
 
@@ -561,7 +567,6 @@ SD_Error_t SD_CheckRead(void)
 SD_Error_t SD_WriteBlocks_DMA(uint64_t WriteAddress, uint32_t *buffer, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
     SD_Error_t ErrorState = SD_OK;
-    SD_Handle.TXCplt = 1;
 
     if (BlockSize != 512) {
         return SD_ERROR; // unsupported.
@@ -571,8 +576,14 @@ SD_Error_t SD_WriteBlocks_DMA(uint64_t WriteAddress, uint32_t *buffer, uint32_t 
         return SD_ADDR_MISALIGNED;
     }
 
+    SD_Handle.TXCplt = 1;
+
+    // Cortex-M55 has D-cache — flush buffer to main memory before DMA reads it
+    SCB_CleanDCache_by_Addr(buffer, NumberOfBlocks * BlockSize);
+
     HAL_StatusTypeDef status;
     if ((status = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t *)buffer, WriteAddress, NumberOfBlocks)) != HAL_OK) {
+        SD_Handle.TXCplt = 0;
         return SD_ERROR;
     }
 
@@ -607,6 +618,7 @@ SD_Error_t SD_ReadBlocks_DMA(uint64_t ReadAddress, uint32_t *buffer, uint32_t Bl
 
     HAL_StatusTypeDef status;
     if ((status = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t *)buffer, ReadAddress, NumberOfBlocks)) != HAL_OK) {
+        SD_Handle.RXCplt = 0;
         return SD_ERROR;
     }
 
@@ -636,7 +648,9 @@ void HAL_SD_RxCpltCallback(SD_HandleTypeDef *hsd)
 
     SD_Handle.RXCplt = 0;
 
-    // N6 Cortex-M55 does not require SCB_InvalidateDCache_by_Addr like H7's Cortex-M7
+    // Cortex-M55 has D-cache — invalidate so CPU sees DMA-written data
+    uint32_t alignedAddr = (uint32_t)sdReadParameters.buffer & ~0x1F;
+    SCB_InvalidateDCache_by_Addr((uint32_t*)alignedAddr, sdReadParameters.NumberOfBlocks * sdReadParameters.BlockSize + ((uint32_t)sdReadParameters.buffer - alignedAddr));
 }
 
 void HAL_SD_ErrorCallback(SD_HandleTypeDef *hsd)

--- a/src/platform/STM32/target/STM32N657/target.h
+++ b/src/platform/STM32/target/STM32N657/target.h
@@ -73,11 +73,14 @@
 
 // #define USE_BEEPER
 
-// SDIO not yet supported on N6
-//#ifdef USE_SDCARD
-//#define USE_SDCARD_SPI
-//#define USE_SDCARD_SDIO
-//#endif
+#if !defined(ENABLE_SDIO_INIT)
+#define ENABLE_SDIO_INIT 1
+#endif
+
+#ifdef USE_SDCARD
+#define USE_SDCARD_SPI
+#define USE_SDCARD_SDIO
+#endif
 
 #define USE_SPI
 #define SPI_FULL_RECONFIGURABILITY


### PR DESCRIPTION
## Summary
- Fix the N6 SDIO driver to match the common Betaflight API (`sdioInitialize`, `SD_InitialiseHardware`)
- Add Cortex-M55 D-cache management for DMA transfers (`SCB_CleanDCache_by_Addr` before writes, `SCB_InvalidateDCache_by_Addr` after reads) — the M55 has a data cache unlike the H5's M33
- Enable SDIO in the STM32N657 target and register the `sdioPinConfig` parameter group for N6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended STM32N6 microcontroller support for SDIO (SD card interface) functionality.

* **Improvements**
  * Enhanced SDIO initialization with improved error handling and validation.
  * Optimized DMA operations for SD card read/write with cache coherency management.
  * Improved SD card transport configuration flexibility for supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->