### PR TITLE
STM32N6: add XSPI flash config storage and LRUN execution

### DIFF
--- a/src/main/drivers/bus_octospi.c
+++ b/src/main/drivers/bus_octospi.c
@@ -62,11 +62,11 @@ octoSpiDevice_t octoSpiDevice[OCTOSPIDEV_COUNT] = { 0 };
 
 MMFLASH_CODE_NOINLINE octoSpiDevice_e octoSpiDeviceByInstance(octoSpiResource_t *instance)
 {
-#ifdef USE_OCTOSPI_DEVICE_1
-    if (instance == (octoSpiResource_t *)OCTOSPI1) {
-        return OCTOSPIDEV_1;
+    for (size_t hwindex = 0; hwindex < OCTOSPIDEV_COUNT; hwindex++) {
+        if (octoSpiHardware[hwindex].reg == instance) {
+            return octoSpiHardware[hwindex].device;
+        }
     }
-#endif
 
     return OCTOSPIINVALID;
 }

--- a/src/platform/STM32/bus_octospi_stm32n6xx.c
+++ b/src/platform/STM32/bus_octospi_stm32n6xx.c
@@ -543,7 +543,7 @@ static MMFLASH_CODE_NOINLINE void xspiTestEnableDisableMemoryMappedMode(octoSpiD
     __enable_irq();
 }
 
-MMFLASH_DATA static const uint32_t xspi_addressSizeMap[] = {
+static const uint32_t xspi_addressSizeMap[] = {
     XSPI_ADDRESS_8_BITS,
     XSPI_ADDRESS_16_BITS,
     XSPI_ADDRESS_24_BITS,

--- a/src/platform/STM32/bus_octospi_stm32n6xx.c
+++ b/src/platform/STM32/bus_octospi_stm32n6xx.c
@@ -1,0 +1,864 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * XSPI support for STM32N6.
+ *
+ * The STM32N6 has three XSPI peripherals. XSPI2 is memory-mapped at
+ * 0x70000000 and is used for booting from external flash.
+ *
+ * This implementation assumes the bootloader has already configured
+ * XSPI2 in memory-mapped mode, matching the approach used for OCTOSPI
+ * on the STM32H7 series.
+ *
+ * The XSPI peripheral registers are register-compatible with the H7
+ * OCTOSPI peripheral, using XSPI_ prefixed defines instead of OCTOSPI_.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#ifdef USE_OCTOSPI
+
+#include "drivers/system.h"
+
+#include "drivers/bus_octospi.h"
+#include "drivers/bus_octospi_impl.h"
+
+// Provide platform-specific hardware table for STM32N6
+const octoSpiHardware_t octoSpiHardware[OCTOSPIDEV_COUNT] = {
+    {
+        .device = OCTOSPIDEV_1,
+        .reg = (octoSpiResource_t *)XSPI2,
+    }
+};
+
+#define XSPI_INTERFACE_COUNT         1
+
+#define XSPI_FUNCTIONAL_MODE_INDIRECT_WRITE ((uint32_t)0x00000000)
+#define XSPI_FUNCTIONAL_MODE_INDIRECT_READ  ((uint32_t)XSPI_CR_FMODE_0)
+#define XSPI_FUNCTIONAL_MODE_AUTO_POLLING   ((uint32_t)XSPI_CR_FMODE_1)
+#define XSPI_FUNCTIONAL_MODE_MEMORY_MAPPED  ((uint32_t)XSPI_CR_FMODE)
+
+#define XSPI_DHQC_DISABLE                ((uint32_t)0x00000000U)
+#define XSPI_DHQC_ENABLE                 ((uint32_t)XSPI_TCR_DHQC)
+
+#define XSPI_OPTYPE_COMMON_CFG           ((uint32_t)0x00000000U)
+
+#define XSPI_OPTYPE_READ_CFG             ((uint32_t)0x00000001U)
+#define XSPI_OPTYPE_WRITE_CFG            ((uint32_t)0x00000002U)
+#define XSPI_OPTYPE_WRAP_CFG             ((uint32_t)0x00000003U)
+
+#define XSPI_INSTRUCTION_NONE            ((uint32_t)0x00000000U)
+#define XSPI_INSTRUCTION_1_LINE          ((uint32_t)XSPI_CCR_IMODE_0)
+#define XSPI_INSTRUCTION_2_LINES         ((uint32_t)XSPI_CCR_IMODE_1)
+#define XSPI_INSTRUCTION_4_LINES         ((uint32_t)(XSPI_CCR_IMODE_0 | XSPI_CCR_IMODE_1))
+#define XSPI_INSTRUCTION_8_LINES         ((uint32_t)XSPI_CCR_IMODE_2)
+
+#define XSPI_INSTRUCTION_8_BITS          ((uint32_t)0x00000000U)
+#define XSPI_INSTRUCTION_16_BITS         ((uint32_t)XSPI_CCR_ISIZE_0)
+#define XSPI_INSTRUCTION_24_BITS         ((uint32_t)XSPI_CCR_ISIZE_1)
+#define XSPI_INSTRUCTION_32_BITS         ((uint32_t)XSPI_CCR_ISIZE)
+
+#define XSPI_INSTRUCTION_DTR_DISABLE     ((uint32_t)0x00000000U)
+#define XSPI_INSTRUCTION_DTR_ENABLE      ((uint32_t)XSPI_CCR_IDTR)
+
+#define XSPI_ADDRESS_NONE                ((uint32_t)0x00000000U)
+#define XSPI_ADDRESS_1_LINE              ((uint32_t)XSPI_CCR_ADMODE_0)
+#define XSPI_ADDRESS_2_LINES             ((uint32_t)XSPI_CCR_ADMODE_1)
+#define XSPI_ADDRESS_4_LINES             ((uint32_t)(XSPI_CCR_ADMODE_0 | XSPI_CCR_ADMODE_1))
+#define XSPI_ADDRESS_8_LINES             ((uint32_t)XSPI_CCR_ADMODE_2)
+
+#define XSPI_ADDRESS_8_BITS              ((uint32_t)0x00000000U)
+#define XSPI_ADDRESS_16_BITS             ((uint32_t)XSPI_CCR_ADSIZE_0)
+#define XSPI_ADDRESS_24_BITS             ((uint32_t)XSPI_CCR_ADSIZE_1)
+#define XSPI_ADDRESS_32_BITS             ((uint32_t)XSPI_CCR_ADSIZE)
+
+#define XSPI_ADDRESS_DTR_DISABLE         ((uint32_t)0x00000000U)
+#define XSPI_ADDRESS_DTR_ENABLE          ((uint32_t)XSPI_CCR_ADDTR)
+
+#define XSPI_DATA_NONE                   ((uint32_t)0x00000000U)
+#define XSPI_DATA_1_LINE                 ((uint32_t)XSPI_CCR_DMODE_0)
+#define XSPI_DATA_2_LINES                ((uint32_t)XSPI_CCR_DMODE_1)
+#define XSPI_DATA_4_LINES               ((uint32_t)(XSPI_CCR_DMODE_0 | XSPI_CCR_DMODE_1))
+#define XSPI_DATA_8_LINES                ((uint32_t)XSPI_CCR_DMODE_2)
+
+#define XSPI_DATA_DTR_DISABLE            ((uint32_t)0x00000000U)
+#define XSPI_DATA_DTR_ENABLE             ((uint32_t)XSPI_CCR_DDTR)
+
+#define XSPI_ALTERNATE_BYTES_NONE        ((uint32_t)0x00000000U)
+#define XSPI_ALTERNATE_BYTES_1_LINE      ((uint32_t)XSPI_CCR_ABMODE_0)
+#define XSPI_ALTERNATE_BYTES_2_LINES     ((uint32_t)XSPI_CCR_ABMODE_1)
+#define XSPI_ALTERNATE_BYTES_4_LINES     ((uint32_t)(XSPI_CCR_ABMODE_0 | XSPI_CCR_ABMODE_1))
+#define XSPI_ALTERNATE_BYTES_8_LINES     ((uint32_t)XSPI_CCR_ABMODE_2)
+
+#define XSPI_ALTERNATE_BYTES_8_BITS      ((uint32_t)0x00000000U)
+#define XSPI_ALTERNATE_BYTES_16_BITS     ((uint32_t)XSPI_CCR_ABSIZE_0)
+#define XSPI_ALTERNATE_BYTES_24_BITS     ((uint32_t)XSPI_CCR_ABSIZE_1)
+#define XSPI_ALTERNATE_BYTES_32_BITS     ((uint32_t)XSPI_CCR_ABSIZE)
+
+#define XSPI_ALTERNATE_BYTES_DTR_DISABLE ((uint32_t)0x00000000U)
+#define XSPI_ALTERNATE_BYTES_DTR_ENABLE  ((uint32_t)XSPI_CCR_ABDTR)
+
+#define XSPI_DQS_DISABLE                 ((uint32_t)0x00000000U)
+#define XSPI_DQS_ENABLE                  ((uint32_t)XSPI_CCR_DQSE)
+
+// XSPI does not have SIOO (Send Instruction Only Once) like OCTOSPI
+#define XSPI_SIOO_INST_EVERY_CMD         ((uint32_t)0x00000000U)
+
+static MMFLASH_CODE_NOINLINE void Error_Handler(void) {
+    while (1) {
+        NOOP;
+    }
+}
+
+#define __XSPI_GET_FLAG(__INSTANCE__, __FLAG__)           ((READ_BIT((__INSTANCE__)->SR, (__FLAG__)) != 0U) ? SET : RESET)
+#define __XSPI_CLEAR_FLAG(__INSTANCE__, __FLAG__)           WRITE_REG((__INSTANCE__)->FCR, (__FLAG__))
+#define __XSPI_ENABLE(__INSTANCE__)                       SET_BIT((__INSTANCE__)->CR, XSPI_CR_EN)
+#define __XSPI_DISABLE(__INSTANCE__)                      CLEAR_BIT((__INSTANCE__)->CR, XSPI_CR_EN)
+#define __XSPI_IS_ENABLED(__INSTANCE__)                   (READ_BIT((__INSTANCE__)->CR, XSPI_CR_EN) != 0U)
+
+MMFLASH_CODE_NOINLINE static void xspiAbort(XSPI_TypeDef *instance)
+{
+    SET_BIT(instance->CR, XSPI_CR_ABORT);
+}
+
+MMFLASH_CODE_NOINLINE static void xspiWaitStatusFlags(XSPI_TypeDef *instance, uint32_t mask, FlagStatus flagStatus)
+{
+    uint32_t regval;
+
+    switch (flagStatus) {
+    case SET:
+        while (!((regval = READ_REG(instance->SR)) & mask))
+            {}
+        break;
+    case RESET:
+        while (((regval = READ_REG(instance->SR)) & mask))
+            {}
+        break;
+    }
+
+    (void)regval;
+}
+
+typedef struct {
+    uint32_t OperationType;
+
+    uint32_t Instruction;
+    uint32_t InstructionMode;
+    uint32_t InstructionSize;
+    uint32_t InstructionDtrMode;
+
+    uint32_t Address;
+    uint32_t AddressMode;
+    uint32_t AddressSize;
+    uint32_t AddressDtrMode;
+
+    uint32_t AlternateBytes;
+    uint32_t AlternateBytesMode;
+    uint32_t AlternateBytesSize;
+    uint32_t AlternateBytesDtrMode;
+
+    uint32_t DummyCycles; // 0-31
+
+    uint32_t DataMode;
+    uint32_t DataDtrMode;
+    uint32_t NbData;
+
+    uint32_t DQSMode;
+    uint32_t SIOOMode;
+} XSPI_Command_t;
+
+MMFLASH_CODE_NOINLINE static ErrorStatus xspiConfigureCommand(XSPI_TypeDef *instance, XSPI_Command_t *cmd)
+{
+    ErrorStatus status = SUCCESS;
+
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, 0U);
+
+    instance->CCR = (cmd->DQSMode | cmd->SIOOMode);
+
+    if (cmd->AlternateBytesMode != XSPI_ALTERNATE_BYTES_NONE)
+    {
+        instance->ABR = cmd->AlternateBytes;
+
+        MODIFY_REG(
+            instance->ABR,
+            (XSPI_CCR_ABMODE | XSPI_CCR_ABDTR | XSPI_CCR_ABSIZE),
+            (cmd->AlternateBytesMode | cmd->AlternateBytesDtrMode | cmd->AlternateBytesSize)
+        );
+    }
+
+    MODIFY_REG(instance->TCR, XSPI_TCR_DCYC, cmd->DummyCycles);
+
+    if (cmd->DataMode != XSPI_DATA_NONE)
+    {
+      if (cmd->OperationType == XSPI_OPTYPE_COMMON_CFG)
+      {
+        instance->DLR = (cmd->NbData - 1U);
+      }
+    }
+
+    if (cmd->InstructionMode != XSPI_INSTRUCTION_NONE)
+    {
+      if (cmd->AddressMode != XSPI_ADDRESS_NONE)
+      {
+        if (cmd->DataMode != XSPI_DATA_NONE)
+        {
+          // instruction, address and data
+
+          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE  | XSPI_CCR_IDTR  | XSPI_CCR_ISIZE  |
+                                  XSPI_CCR_ADMODE | XSPI_CCR_ADDTR | XSPI_CCR_ADSIZE |
+                                  XSPI_CCR_DMODE  | XSPI_CCR_DDTR),
+                                 (cmd->InstructionMode | cmd->InstructionDtrMode | cmd->InstructionSize |
+                                  cmd->AddressMode     | cmd->AddressDtrMode     | cmd->AddressSize     |
+                                  cmd->DataMode        | cmd->DataDtrMode));
+        }
+        else
+        {
+          // instruction and address
+
+          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE  | XSPI_CCR_IDTR  | XSPI_CCR_ISIZE  |
+                                  XSPI_CCR_ADMODE | XSPI_CCR_ADDTR | XSPI_CCR_ADSIZE),
+                                 (cmd->InstructionMode | cmd->InstructionDtrMode | cmd->InstructionSize |
+                                  cmd->AddressMode     | cmd->AddressDtrMode     | cmd->AddressSize));
+
+          // DHQC bit is linked with DDTR
+          if (((instance->TCR & XSPI_TCR_DHQC_Msk) == XSPI_DHQC_ENABLE) &&
+              (cmd->InstructionDtrMode == XSPI_INSTRUCTION_DTR_ENABLE))
+          {
+            MODIFY_REG(instance->CCR, XSPI_CCR_DDTR, XSPI_DATA_DTR_ENABLE);
+          }
+        }
+
+        instance->IR = cmd->Instruction;
+
+        instance->AR = cmd->Address;
+      }
+      else
+      {
+        if (cmd->DataMode != XSPI_DATA_NONE)
+        {
+          // instruction and data
+
+          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE | XSPI_CCR_IDTR | XSPI_CCR_ISIZE |
+                                  XSPI_CCR_DMODE | XSPI_CCR_DDTR),
+                                 (cmd->InstructionMode | cmd->InstructionDtrMode | cmd->InstructionSize |
+                                  cmd->DataMode        | cmd->DataDtrMode));
+        }
+        else
+        {
+          // instruction only
+
+          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE | XSPI_CCR_IDTR | XSPI_CCR_ISIZE),
+                                 (cmd->InstructionMode | cmd->InstructionDtrMode | cmd->InstructionSize));
+
+          // DHQC bit is linked with DDTR
+          if (((instance->TCR & XSPI_TCR_DHQC_Msk) == XSPI_DHQC_ENABLE) &&
+              (cmd->InstructionDtrMode == XSPI_INSTRUCTION_DTR_ENABLE))
+          {
+            MODIFY_REG(instance->CCR, XSPI_CCR_DDTR, XSPI_DATA_DTR_ENABLE);
+          }
+        }
+
+        instance->IR = cmd->Instruction;
+
+      }
+    }
+    else
+    {
+      if (cmd->AddressMode != XSPI_ADDRESS_NONE)
+      {
+        if (cmd->DataMode != XSPI_DATA_NONE)
+        {
+          // address and data
+
+          MODIFY_REG(instance->CCR, (XSPI_CCR_ADMODE | XSPI_CCR_ADDTR | XSPI_CCR_ADSIZE |
+                                  XSPI_CCR_DMODE  | XSPI_CCR_DDTR),
+                                 (cmd->AddressMode | cmd->AddressDtrMode | cmd->AddressSize     |
+                                  cmd->DataMode    | cmd->DataDtrMode));
+        }
+        else
+        {
+          // address only
+
+          MODIFY_REG(instance->CCR, (XSPI_CCR_ADMODE | XSPI_CCR_ADDTR | XSPI_CCR_ADSIZE),
+                                 (cmd->AddressMode | cmd->AddressDtrMode | cmd->AddressSize));
+        }
+
+        instance->AR = cmd->Address;
+      }
+      else
+      {
+        // no instruction, no address
+        status = ERROR;
+      }
+    }
+
+    return status;
+}
+
+static MMFLASH_CODE_NOINLINE ErrorStatus xspiCommand(XSPI_TypeDef *instance, XSPI_Command_t *cmd)
+{
+    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+
+    ErrorStatus status = xspiConfigureCommand(instance, cmd);
+    if (status == SUCCESS) {
+        if (cmd->DataMode == XSPI_DATA_NONE)
+        {
+            // transfer is already started, wait now.
+            xspiWaitStatusFlags(instance, XSPI_SR_TCF, SET);
+            __XSPI_CLEAR_FLAG(instance, XSPI_SR_TCF);
+        }
+    }
+
+    return status;
+}
+
+/*
+ * Transmit
+ *
+ * Call xspiCommand first to configure the transaction stages.
+ */
+static MMFLASH_CODE_NOINLINE ErrorStatus xspiTransmit(XSPI_TypeDef *instance, uint8_t *data)
+{
+    if (data == NULL) {
+        return ERROR;
+    }
+
+    __IO uint32_t              XferCount = READ_REG(instance->DLR) + 1U;
+    uint8_t                    *pBuffPtr = data;
+
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, XSPI_FUNCTIONAL_MODE_INDIRECT_WRITE);
+
+    __IO uint32_t *data_reg = &instance->DR;
+    do
+    {
+      xspiWaitStatusFlags(instance, XSPI_SR_FTF, SET);
+
+      *((__IO uint8_t *)data_reg) = *pBuffPtr;
+      pBuffPtr++;
+      XferCount--;
+    } while (XferCount > 0U);
+
+    xspiWaitStatusFlags(instance, XSPI_SR_TCF, SET);
+    __XSPI_CLEAR_FLAG(instance, XSPI_SR_TCF);
+
+    return SUCCESS;
+}
+
+/*
+ * Receive
+ *
+ * Call xspiCommand first to configure the transaction stages.
+ */
+static MMFLASH_CODE_NOINLINE ErrorStatus xspiReceive(XSPI_TypeDef *instance, uint8_t *data)
+{
+    if (data == NULL) {
+        return ERROR;
+    }
+
+    __IO uint32_t              XferCount = READ_REG(instance->DLR) + 1U;
+    uint8_t                    *pBuffPtr = data;
+
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, XSPI_FUNCTIONAL_MODE_INDIRECT_READ);
+
+    uint32_t addr_reg = instance->AR;
+    uint32_t ir_reg = instance->IR;
+
+    // Trigger the transfer by re-writing the address or instruction register
+    if (READ_BIT(instance->CCR, XSPI_CCR_ADMODE) != XSPI_ADDRESS_NONE)
+    {
+      WRITE_REG(instance->AR, addr_reg);
+    }
+    else
+    {
+      WRITE_REG(instance->IR, ir_reg);
+    }
+
+    __IO uint32_t *data_reg = &instance->DR;
+
+    do
+    {
+      xspiWaitStatusFlags(instance, XSPI_SR_FTF | XSPI_SR_TCF, SET);
+
+      *pBuffPtr = *((__IO uint8_t *)data_reg);
+      pBuffPtr++;
+      XferCount--;
+    } while(XferCount > 0U);
+
+    xspiWaitStatusFlags(instance, XSPI_SR_TCF, SET);
+    __XSPI_CLEAR_FLAG(instance, XSPI_SR_TCF);
+
+    return SUCCESS;
+}
+
+typedef struct
+{
+    // CR register contains the all-important FMODE bits.
+    uint32_t CR;
+
+    // flash chip specific configuration set by the bootloader
+    uint32_t CCR;
+    uint32_t TCR;
+    uint32_t IR;
+    uint32_t ABR;
+    // address register - no meaning.
+    // data length register no meaning.
+
+} xspiMemoryMappedModeConfigurationRegisterBackup_t;
+
+xspiMemoryMappedModeConfigurationRegisterBackup_t xspiMMMCRBackups[XSPI_INTERFACE_COUNT];
+
+static void xspiBackupMemoryMappedModeConfiguration(XSPI_TypeDef *instance)
+{
+    octoSpiDevice_e device = octoSpiDeviceByInstance((octoSpiResource_t *)instance);
+    if (device == OCTOSPIINVALID) {
+        return;
+    }
+
+    xspiMemoryMappedModeConfigurationRegisterBackup_t *xspiMMMCRBackup = &xspiMMMCRBackups[device];
+
+    // backup all the registers used by memory mapped mode that:
+    // a) the bootloader configured.
+    // b) that other code in this implementation may have modified when memory mapped mode is disabled.
+
+    xspiMMMCRBackup->CR = instance->CR;
+    xspiMMMCRBackup->IR = instance->IR;
+    xspiMMMCRBackup->CCR = instance->CCR;
+    xspiMMMCRBackup->TCR = instance->TCR;
+    xspiMMMCRBackup->ABR = instance->ABR;
+}
+
+static MMFLASH_CODE_NOINLINE void xspiRestoreMemoryMappedModeConfiguration(XSPI_TypeDef *instance)
+{
+    octoSpiDevice_e device = octoSpiDeviceByInstance((octoSpiResource_t *)instance);
+    if (device == OCTOSPIINVALID) {
+        return;
+    }
+
+    xspiMemoryMappedModeConfigurationRegisterBackup_t *xspiMMMCRBackup = &xspiMMMCRBackups[device];
+
+    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+
+    instance->ABR = xspiMMMCRBackup->ABR;
+    instance->TCR = xspiMMMCRBackup->TCR;
+
+    instance->DLR = 0; // "no meaning" in MM mode.
+
+    instance->CCR = xspiMMMCRBackup->CCR;
+
+    instance->IR = xspiMMMCRBackup->IR;
+    instance->AR = 0; // "no meaning" in MM mode.
+
+    xspiAbort(instance);
+    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+
+    instance->CR = xspiMMMCRBackup->CR;
+}
+
+/*
+ * Disable memory mapped mode.
+ *
+ * @See octoSpiEnableMemoryMappedMode
+ * @See MMFLASH_CODE_NOINLINE
+ *
+ * Once this is called any code or data in the memory mapped region cannot be accessed.
+ * Thus, this function itself must be in RAM, and the caller's code and data should all be in RAM
+ * and this requirement continues until octoSpiEnableMemoryMappedMode is called.
+ * This applies to ISR code that runs from the memory mapped region, so likely the caller should
+ * also disable IRQs before calling this.
+ */
+MMFLASH_CODE_NOINLINE void octoSpiDisableMemoryMappedMode(octoSpiResource_t *instance_)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    if (READ_BIT(instance->CR, XSPI_CR_FMODE) != XSPI_CR_FMODE) {
+        failureMode(FAILURE_DEVELOPER); // likely not booted with memory mapped mode enabled, or mismatched calls to enable/disable memory map mode.
+    }
+
+    xspiAbort(instance);
+    if (__XSPI_GET_FLAG(instance, XSPI_SR_BUSY) == SET) {
+
+        __XSPI_DISABLE(instance);
+        xspiAbort(instance);
+    }
+    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+
+    uint32_t fmode = 0x0;  // b00 = indirect write, see XSPI->CR->FMODE
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, fmode);
+
+    uint32_t regval = READ_REG(instance->CR);
+    if ((regval & XSPI_CR_FMODE) != fmode) {
+        Error_Handler();
+    }
+
+    if (!__XSPI_IS_ENABLED(instance)) {
+        __XSPI_ENABLE(instance);
+    }
+}
+
+/*
+ * Enable memory mapped mode.
+ *
+ * @See octoSpiDisableMemoryMappedMode
+ * @See MMFLASH_CODE_NOINLINE
+ */
+
+MMFLASH_CODE_NOINLINE void octoSpiEnableMemoryMappedMode(octoSpiResource_t *instance_)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    xspiAbort(instance);
+    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+
+    xspiRestoreMemoryMappedModeConfiguration(instance);
+}
+
+static MMFLASH_CODE_NOINLINE void xspiTestEnableDisableMemoryMappedMode(octoSpiDevice_t *octoSpi)
+{
+    octoSpiResource_t *instance = octoSpi->dev;
+
+    __disable_irq();
+    octoSpiDisableMemoryMappedMode(instance);
+    octoSpiEnableMemoryMappedMode(instance);
+    __enable_irq();
+}
+
+MMFLASH_DATA static const uint32_t xspi_addressSizeMap[] = {
+    XSPI_ADDRESS_8_BITS,
+    XSPI_ADDRESS_16_BITS,
+    XSPI_ADDRESS_24_BITS,
+    XSPI_ADDRESS_32_BITS
+};
+
+MMFLASH_CODE static uint32_t xspi_addressSizeFromValue(uint8_t addressSize)
+{
+    return xspi_addressSizeMap[((addressSize + 1) / 8) - 1]; // rounds to nearest XSPI_ADDRESS_* value that will hold the address.
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiTransmit1LINE(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, const uint8_t *out, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_NONE;
+    cmd.AddressSize        = XSPI_ADDRESS_32_BITS;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_NONE;
+    cmd.NbData             = length;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    if (out) {
+        cmd.DataMode       = XSPI_DATA_1_LINE;
+    }
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS && out && length > 0) {
+        status = xspiTransmit(instance, (uint8_t *)out);
+    }
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiReceive1LINE(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_NONE;
+    cmd.AddressSize        = XSPI_ADDRESS_32_BITS;
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_1_LINE;
+    cmd.NbData             = length;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS) {
+        status = xspiReceive(instance, in);
+    }
+
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiReceive4LINES(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint8_t *in, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_4_LINES;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_NONE;
+    cmd.AddressSize        = XSPI_ADDRESS_32_BITS;
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_4_LINES;
+    cmd.NbData             = length;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS) {
+        status = xspiReceive(instance, in);
+    }
+
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiReceiveWithAddress1LINE(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.Address            = address;
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_1_LINE;
+    cmd.AddressSize        = xspi_addressSizeFromValue(addressSize);
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_1_LINE;
+    cmd.NbData             = length;
+
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS) {
+        status = xspiReceive(instance, in);
+    }
+
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiReceiveWithAddress4LINES(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, uint8_t *in, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.Address            = address;
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_1_LINE;
+    cmd.AddressSize        = xspi_addressSizeFromValue(addressSize);
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_4_LINES;
+    cmd.NbData             = length;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS) {
+        status = xspiReceive(instance, in);
+    }
+
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiTransmitWithAddress1LINE(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.Address            = address;
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_1_LINE;
+    cmd.AddressSize        = xspi_addressSizeFromValue(addressSize);
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_1_LINE;
+    cmd.NbData             = length;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS) {
+        status = xspiTransmit(instance, (uint8_t *)out);
+    }
+
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiTransmitWithAddress4LINES(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize, const uint8_t *out, int length)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.Address            = address;
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_1_LINE;
+    cmd.AddressSize        = xspi_addressSizeFromValue(addressSize);
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_4_LINES;
+    cmd.NbData             = length;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    if (status == SUCCESS) {
+        status = xspiTransmit(instance, (uint8_t *)out);
+    }
+
+    return status == SUCCESS;
+}
+
+MMFLASH_CODE_NOINLINE bool octoSpiInstructionWithAddress1LINE(octoSpiResource_t *instance_, uint8_t instruction, uint8_t dummyCycles, uint32_t address, uint8_t addressSize)
+{
+    XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
+    XSPI_Command_t cmd; // Can't initialise to zero as compiler optimization will use memset() which is not in RAM.
+
+    cmd.OperationType      = XSPI_OPTYPE_COMMON_CFG;
+
+    cmd.Instruction        = instruction;
+    cmd.InstructionDtrMode = XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd.InstructionMode    = XSPI_INSTRUCTION_1_LINE;
+    cmd.InstructionSize    = XSPI_INSTRUCTION_8_BITS;
+
+    cmd.Address            = address;
+    cmd.AddressDtrMode     = XSPI_ADDRESS_DTR_DISABLE;
+    cmd.AddressMode        = XSPI_ADDRESS_1_LINE;
+    cmd.AddressSize        = xspi_addressSizeFromValue(addressSize);
+
+    cmd.AlternateBytesMode = XSPI_ALTERNATE_BYTES_NONE;
+
+    cmd.DummyCycles        = dummyCycles;
+
+    cmd.DataDtrMode        = XSPI_DATA_DTR_DISABLE;
+    cmd.DataMode           = XSPI_DATA_NONE;
+    cmd.NbData             = 0;
+
+    cmd.DQSMode            = XSPI_DQS_DISABLE;
+    cmd.SIOOMode           = XSPI_SIOO_INST_EVERY_CMD;
+
+    ErrorStatus status = xspiCommand(instance, &cmd);
+
+    return status == SUCCESS;
+}
+
+void octoSpiInitDevice(octoSpiDevice_e device)
+{
+    octoSpiDevice_t *octoSpi = &(octoSpiDevice[device]);
+
+    if (isMemoryMappedModeEnabledOnBoot()) {
+        // Bootloader has already configured the IO, clocks and peripherals.
+        xspiBackupMemoryMappedModeConfiguration((XSPI_TypeDef *)octoSpi->dev);
+
+        xspiTestEnableDisableMemoryMappedMode(octoSpi);
+    } else {
+        failureMode(FAILURE_DEVELOPER); // trying to use this implementation when memory mapped mode is not already enabled by a bootloader
+    }
+}
+
+#endif

--- a/src/platform/STM32/bus_octospi_stm32n6xx.c
+++ b/src/platform/STM32/bus_octospi_stm32n6xx.c
@@ -203,7 +203,7 @@ MMFLASH_CODE_NOINLINE static ErrorStatus xspiConfigureCommand(XSPI_TypeDef *inst
         instance->ABR = cmd->AlternateBytes;
 
         MODIFY_REG(
-            instance->ABR,
+            instance->CCR,
             (XSPI_CCR_ABMODE | XSPI_CCR_ABDTR | XSPI_CCR_ABSIZE),
             (cmd->AlternateBytesMode | cmd->AlternateBytesDtrMode | cmd->AlternateBytesSize)
         );

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -182,6 +182,11 @@
 #define STM32N6
 #endif
 
+// N6 boots from external XSPI flash in memory-mapped mode
+#if !defined(USE_FLASH_MEMORY_MAPPED) && !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD)
+#define USE_FLASH_MEMORY_MAPPED
+#endif
+
 #endif // MCU family selection
 
 #ifdef STM32F4

--- a/src/platform/STM32/link/STM32N657XX_LRUN.ld
+++ b/src/platform/STM32/link/STM32N657XX_LRUN.ld
@@ -160,11 +160,14 @@ SECTIONS
   .ram_code :
   {
     . = ALIGN(4);
+    ram_code_start = .;
     *(.ram_code)
     *(.ram_code*)
     . = ALIGN(4);
+    ram_code_end = .;
     _etext = .;        /* end of all FLASH1-backed sections — startup copies _stext.._etext */
   } >RAM AT >FLASH1
+  ram_code = _etext;   /* stub LMA — LRUN already copied .ram_code via _sitext.._etext */
 
   /* Uninitialized data section */
   . = ALIGN(4);

--- a/src/platform/STM32/link/STM32N657XX_LRUN.ld
+++ b/src/platform/STM32/link/STM32N657XX_LRUN.ld
@@ -4,6 +4,8 @@
 **  File        : STM32N657XX_LRUN.ld
 **
 **  Abstract    : Linker script for STM32N657xx Device
+**                Load from external XSPI flash, Run from internal SRAM.
+**
 **                AXISRAM1   1024K  @ 0x24000000
 **                AXISRAM2   1024K  @ 0x24100000
 **                AXISRAM3    448K  @ 0x24200000
@@ -14,7 +16,8 @@
 **                AHBSRAM2     16K  @ 0x28004000
 **                BKPSRAM       8K  @ 0x2C000000
 **
-**  Boot from external XSPI flash at 0x70000000
+**  Boot from external XSPI flash at 0x70000000.
+**  All firmware code is copied to RAM at startup for performance.
 **
 *****************************************************************************
 */
@@ -23,7 +26,7 @@
 ENTRY(Reset_Handler)
 
 /*
-0x24000000 to 0x240FFFFF  1024K AXI SRAM1, main RAM
+0x24000000 to 0x240FFFFF  1024K AXI SRAM1, firmware code + data + bss + stack
 0x24100000 to 0x241FFFFF  1024K AXI SRAM2
 0x24200000 to 0x2426FFFF   448K AXI SRAM3
 0x24270000 to 0x242DFFFF   448K AXI SRAM4
@@ -34,9 +37,9 @@ ENTRY(Reset_Handler)
 0x2C000000 to 0x2C001FFF     8K Backup SRAM
 
 0x70000000 to 0x701FFFFF  2048K External XSPI flash
-0x70000000 to 0x7001FFFF   128K isr vector, startup code
-0x70020000 to 0x7003FFFF   128K config
-0x70040000 to 0x701FFFFF  1792K firmware
+0x70000000 to 0x7001FFFF   128K isr vector, startup bootstrap (XIP)
+0x70020000 to 0x7003FFFF   128K config storage
+0x70040000 to 0x701FFFFF  1792K firmware LMA (copied to RAM at boot)
 */
 
 /* Specify the memory areas */
@@ -76,19 +79,30 @@ _sstack = _estack - _Min_Stack_Size;
 /* Define output sections */
 SECTIONS
 {
-  /* The startup code goes first into FLASH */
+  /*
+   * ISR vector table and startup bootstrap in XSPI flash.
+   * Reset_Handler executes from here (XIP) before copying firmware to RAM.
+   */
   .isr_vector :
   {
     . = ALIGN(512);
     PROVIDE (isr_vector_table_base = .);
     KEEP(*(.isr_vector)) /* Startup code */
+    *(.text.Reset_Handler)
+    *(.text.Default_Handler)
     . = ALIGN(4);
   } >FLASH
 
-  /* The program code and other data goes into FLASH */
+  /*
+   * Firmware code and read-only data.
+   * Stored in FLASH1 (LMA), copied to and executed from RAM (VMA).
+   */
+  _sitext = LOADADDR(.text);
+
   .text :
   {
     . = ALIGN(4);
+    _stext = .;        /* start of text in RAM */
     *(.text)           /* .text sections (code) */
     *(.text*)          /* .text* sections (code) */
     *(.rodata)         /* .rodata sections (constants, strings, etc.) */
@@ -102,18 +116,18 @@ SECTIONS
 
     . = ALIGN(4);
     _etext = .;        /* define a global symbols at end of code */
-  } >FLASH1
+  } >RAM AT >FLASH1
 
   .ARM.extab   :
   {
     *(.ARM.extab* .gnu.linkonce.armextab.*)
-  } >FLASH1
+  } >RAM AT >FLASH1
 
   .ARM :
   {
     __exidx_start = .;
     *(.ARM.exidx*) __exidx_end = .;
-  } >FLASH1
+  } >RAM AT >FLASH1
 
   .pg_registry :
   {
@@ -121,14 +135,14 @@ SECTIONS
     KEEP (*(.pg_registry))
     KEEP (*(SORT(.pg_registry.*)))
     PROVIDE_HIDDEN (__pg_registry_end = .);
-  } >FLASH1
+  } >RAM AT >FLASH1
 
   .pg_resetdata :
   {
     PROVIDE_HIDDEN (__pg_resetdata_start = .);
     KEEP (*(.pg_resetdata))
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
-  } >FLASH1
+  } >RAM AT >FLASH1
 
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
@@ -143,6 +157,18 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
+  } >RAM AT >FLASH1
+
+  /*
+   * All code already runs from RAM, so .ram_code merges into the same
+   * region.  Keep the section so MMFLASH_CODE attributed functions still link.
+   */
+  .ram_code :
+  {
+    . = ALIGN(4);
+    *(.ram_code)
+    *(.ram_code*)
+    . = ALIGN(4);
   } >RAM AT >FLASH1
 
   /* Uninitialized data section */

--- a/src/platform/STM32/link/STM32N657XX_LRUN.ld
+++ b/src/platform/STM32/link/STM32N657XX_LRUN.ld
@@ -115,7 +115,6 @@ SECTIONS
     KEEP (*(.fini))
 
     . = ALIGN(4);
-    _etext = .;        /* define a global symbols at end of code */
   } >RAM AT >FLASH1
 
   .ARM.extab   :
@@ -144,19 +143,14 @@ SECTIONS
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
   } >RAM AT >FLASH1
 
-  /* used by the startup to initialize data */
-  _sidata = LOADADDR(.data);
-
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data :
   {
     . = ALIGN(4);
-    _sdata = .;        /* create a global symbol at data start */
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
 
     . = ALIGN(4);
-    _edata = .;        /* define a global symbol at data end */
   } >RAM AT >FLASH1
 
   /*
@@ -169,6 +163,7 @@ SECTIONS
     *(.ram_code)
     *(.ram_code*)
     . = ALIGN(4);
+    _etext = .;        /* end of all FLASH1-backed sections — startup copies _stext.._etext */
   } >RAM AT >FLASH1
 
   /* Uninitialized data section */

--- a/src/platform/STM32/link/STM32N657XX_LRUN.ld
+++ b/src/platform/STM32/link/STM32N657XX_LRUN.ld
@@ -157,6 +157,7 @@ SECTIONS
    * All code already runs from RAM, so .ram_code merges into the same
    * region.  Keep the section so MMFLASH_CODE attributed functions still link.
    */
+  ram_code = LOADADDR(.ram_code);  /* LMA in FLASH1 for initialiseMemorySections() */
   .ram_code :
   {
     . = ALIGN(4);
@@ -167,7 +168,6 @@ SECTIONS
     ram_code_end = .;
     _etext = .;        /* end of all FLASH1-backed sections — startup copies _stext.._etext */
   } >RAM AT >FLASH1
-  ram_code = _etext;   /* stub LMA — LRUN already copied .ram_code via _sitext.._etext */
 
   /* Uninitialized data section */
   . = ALIGN(4);

--- a/src/platform/STM32/mk/STM32N6.mk
+++ b/src/platform/STM32/mk/STM32N6.mk
@@ -120,10 +120,12 @@ VCP_SRC = \
 
 MCU_COMMON_SRC = \
             drivers/bus_i2c_timing.c \
+            drivers/bus_octospi.c \
             drivers/dshot_bitbang_decode.c \
             STM32/adc_stm32n6xx.c \
             STM32/bus_i2c_ll_init.c \
             STM32/bus_i2c_ll.c \
+            STM32/bus_octospi_stm32n6xx.c \
             STM32/bus_spi_ll.c \
             STM32/debug.c \
             STM32/dma_reqmap_mcu.c \

--- a/src/platform/STM32/startup/startup_stm32n657xx.s
+++ b/src/platform/STM32/startup/startup_stm32n657xx.s
@@ -31,23 +31,11 @@
 .global g_pfnVectors
 .global Default_Handler
 
-/* start address for the initialization values of the .text section.
-defined in linker script */
+/* Linker symbols used by Reset_Handler */
 .word _sitext
-/* start address for the .text section. defined in linker script */
 .word _stext
-/* end address for the .text section. defined in linker script */
 .word _etext
-/* start address for the initialization values of the .data section.
-defined in linker script */
-.word _sidata
-/* start address for the .data section. defined in linker script */
-.word _sdata
-/* end address for the .data section. defined in linker script */
-.word _edata
-/* start address for the .bss section. defined in linker script */
 .word _sbss
-/* end address for the .bss section. defined in linker script */
 .word _ebss
 
 /**
@@ -88,23 +76,6 @@ LoopCopyTextInit:
   adds r4, r0, r3
   cmp r4, r1
   bcc CopyTextInit
-
-/* Copy the data segment initializers from flash to SRAM */
-  ldr r0, =_sdata
-  ldr r1, =_edata
-  ldr r2, =_sidata
-  movs r3, #0
-  b LoopCopyDataInit
-
-CopyDataInit:
-  ldr r4, [r2, r3]
-  str r4, [r0, r3]
-  adds r3, r3, #4
-
-LoopCopyDataInit:
-  adds r4, r0, r3
-  cmp r4, r1
-  bcc CopyDataInit
 
 /* Zero fill the bss segment. */
   ldr r2, =_sbss

--- a/src/platform/STM32/startup/startup_stm32n657xx.s
+++ b/src/platform/STM32/startup/startup_stm32n657xx.s
@@ -7,6 +7,7 @@
  *                - Set the initial SP
  *                - Set the initial PC == Reset_Handler,
  *                - Set the vector table entries with the exceptions ISR address
+ *                - Copy firmware code from XSPI flash to RAM (LRUN)
  *                - Branches to main in the C library (which eventually
  *                  calls main()).
  ******************************************************************************
@@ -30,6 +31,13 @@
 .global g_pfnVectors
 .global Default_Handler
 
+/* start address for the initialization values of the .text section.
+defined in linker script */
+.word _sitext
+/* start address for the .text section. defined in linker script */
+.word _stext
+/* end address for the .text section. defined in linker script */
+.word _etext
 /* start address for the initialization values of the .data section.
 defined in linker script */
 .word _sidata
@@ -47,6 +55,10 @@ defined in linker script */
  *          starts execution following a reset event. Only the absolutely
  *          necessary set is performed, after which the application
  *          supplied main() routine is called.
+ *
+ *          This handler executes from XSPI flash (XIP) and copies all
+ *          firmware code and data to RAM before jumping to main().
+ *
  * @param  None
  * @retval : None
 */
@@ -59,8 +71,23 @@ Reset_Handler:
   msr   MSPLIM, r0
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
-/* Call the clock system initialization function.*/
-  bl  SystemInit
+
+/* Copy firmware code from XSPI flash to RAM (.text, .rodata, .pg_registry, etc.) */
+  ldr r0, =_stext
+  ldr r1, =_etext
+  ldr r2, =_sitext
+  movs r3, #0
+  b LoopCopyTextInit
+
+CopyTextInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyTextInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc CopyTextInit
 
 /* Copy the data segment initializers from flash to SRAM */
   ldr r0, =_sdata
@@ -119,7 +146,7 @@ Infinite_Loop:
 
 /******************************************************************************
 *
-* The STM32N657XX vector table.  Note that the proper constructs
+* The STM32N657XX vector table. Note that the proper constructs
 * must be placed on this to ensure that it ends up at physical address
 * 0x0000.0000.
 *
@@ -133,213 +160,205 @@ g_pfnVectors:
   .word Reset_Handler
   .word NMI_Handler
   .word HardFault_Handler
-  .word	MemManage_Handler
-  .word	BusFault_Handler
-  .word	UsageFault_Handler
-  .word	SecureFault_Handler
-  .word	0
-  .word	0
-  .word	0
-  .word	SVC_Handler
-  .word	DebugMon_Handler
-  .word	0
-  .word	PendSV_Handler
-  .word	SysTick_Handler
-  .word	PVD_PVM_IRQHandler         			/* PVDOUT through the EXTI line                                  */
-  .word	0                          			/* Reserved                                                      */
-  .word	DTS_IRQHandler             			/* Thermal sensor interruption                                   */
-  .word	RCC_IRQHandler             			/* RCC global interrupt                                          */
-  .word	LOCKUP_IRQHandler          			/* LOCKUP - no overstack in Cortex-M55                           */
-  .word	CACHE_ECC_IRQHandler       			/* Cache ECC error                                               */
-  .word	TCM_ECC_IRQHandler         			/* TCM ECC error                                                 */
-  .word	BCK_ECC_IRQHandler         			/* Backup RAM interrupts (SEC and DED)                           */
-  .word	FPU_IRQHandler             			/* FPU safety flag                                               */
-  .word	0                          			/* Reserved                                                      */
-  .word	RTC_S_IRQHandler           			/* RTC secure interrupt                                          */
-  .word	TAMP_IRQHandler            			/* TAMP secure and non-secure synchronous interrupt line         */
-  .word	RIFSC_TAMPER_IRQHandler    			/* RIF can generate an interrupt when a laser attack is detected */
-  .word	IAC_IRQHandler             			/* IAC global interrupt                                          */
-  .word	RCC_S_IRQHandler           			/* RCC global secure interrupt                                   */
-  .word	0                          			/* Reserved                                                      */
-  .word	RTC_IRQHandler             			/* RTC interrupt                                                 */
-  .word	0                          			/* Reserved                                                      */
-  .word	IWDG_IRQHandler         		  	/* Independent watchdog interrupt                                */
-  .word	WWDG_IRQHandler         		  	/* Window watchdog interrupt                                     */
-  .word	EXTI0_IRQHandler           			/* EXTI Line 0 interrupt through the EXTI line                   */
-  .word	EXTI1_IRQHandler           			/* EXTI Line 1 interrupt through the EXTI line                   */
-  .word	EXTI2_IRQHandler           			/* EXTI Line 2 interrupt through the EXTI line                   */
-  .word	EXTI3_IRQHandler           			/* EXTI Line 3 interrupt through the EXTI line                   */
-  .word	EXTI4_IRQHandler           			/* EXTI Line 4 interrupt through the EXTI line                   */
-  .word	EXTI5_IRQHandler           			/* EXTI Line 5 interrupt through the EXTI line                   */
-  .word	EXTI6_IRQHandler           			/* EXTI Line 6 interrupt through the EXTI line                   */
-  .word	EXTI7_IRQHandler           			/* EXTI Line 7 interrupt through the EXTI line                   */
-  .word	EXTI8_IRQHandler           			/* EXTI Line 8 interrupt through the EXTI line                   */
-  .word	EXTI9_IRQHandler           			/* EXTI Line 9 interrupt                                         */
-  .word	EXTI10_IRQHandler          			/* EXTI Line 10 interrupt                                        */
-  .word	EXTI11_IRQHandler          			/* EXTI Line 11 interrupt                                        */
-  .word	EXTI12_IRQHandler          			/* EXTI Line 12 interrupt                                        */
-  .word	EXTI13_IRQHandler          			/* EXTI Line 13 interrupt                                        */
-  .word	EXTI14_IRQHandler          			/* EXTI Line 14 interrupt                                        */
-  .word	EXTI15_IRQHandler          			/* EXTI Line 15 interrupt                                        */
-  .word	SAES_IRQHandler            			/* SAES global interrupt                                         */
-  .word	CRYP_IRQHandler            			/* CRYP global interrupt                                         */
-  .word	PKA_IRQHandler             			/* PKA global interrupt                                          */
-  .word	HASH_IRQHandler            			/* HASH global interrupt                                         */
-  .word	RNG_IRQHandler             			/* RNG global interrupt                                          */
-  .word	0                          			/* Reserved                                                      */
-  .word	MCE1_IRQHandler            			/* MCE1 global interrupt                                         */
-  .word	MCE2_IRQHandler            			/* MCE2 global interrupt                                         */
-  .word	MCE3_IRQHandler            			/* MCE3 global interrupt                                         */
-  .word	MCE4_IRQHandler            			/* MCE4 global interrupt                                         */
-  .word	ADC1_2_IRQHandler           		/* ADC1/ADC2 global interrupt                                    */
-  .word	CSI_IRQHandler         			    /* CSI global interrupt                                          */
-  .word	DCMIPP_IRQHandler          			/* DCMIPP global interrupt                                       */
-  .word	0                          			/* Reserved                                                      */
-  .word	0                          			/* Reserved                                                      */
-  .word	0                          			/* Reserved                                                      */
-  .word	PAHB_ERR_IRQHandler        			/* Write posting errors on Cortex-M55 PAHB interface             */
-  .word	NPU0_IRQHandler						/* NPU mst_ints[0] line                                          */
-  .word	NPU1_IRQHandler            			/* NPU mst_ints[1] line                                          */
-  .word	NPU2_IRQHandler            			/* NPU mst_ints[2] line                                          */
-  .word	NPU3_IRQHandler            			/* NPU mst_ints[3] line                                          */
-  .word	CACHEAXI_IRQHandler        			/* ATON interrupt cache                                          */
-  .word	LTDC_LO_IRQHandler         			/* LCD low-layer global interrupt                                */
-  .word	LTDC_LO_ERR_IRQHandler     			/* LCD low-layer error interrupt                                 */
-  .word	DMA2D_IRQHandler           			/* DMA2D global interrupt                                        */
-  .word	JPEG_IRQHandler            			/* JPEG global interrupt                                         */
-  .word	VENC_IRQHandler            			/* VENC global interrupt                                         */
-  .word	GFXMMU_IRQHandler          			/* GFXMMU global interrupt                                       */
-  .word	GFXTIM_IRQHandler          			/* GFXTIM global interrupt                                       */
-  .word	GPU2D_IRQHandler           			/* GPU2D global interrupt                                        */
-  .word	GPU2D_ER_IRQHandler     		  	/* GPU2D global interrupt                                        */
-  .word	ICACHE_IRQHandler       			/* GPU cache interrupt                                           */
-  .word	HPDMA1_Channel0_IRQHandler  		/* HPDMA1 Channel 0 interrupt                                    */
-  .word	HPDMA1_Channel1_IRQHandler  		/* HPDMA1 Channel 1 interrupt                                    */
-  .word	HPDMA1_Channel2_IRQHandler  		/* HPDMA1 Channel 2 interrupt                                    */
-  .word	HPDMA1_Channel3_IRQHandler  		/* HPDMA1 Channel 3 interrupt                                    */
-  .word	HPDMA1_Channel4_IRQHandler  		/* HPDMA1 Channel 4 interrupt                                    */
-  .word	HPDMA1_Channel5_IRQHandler  		/* HPDMA1 Channel 5 interrupt                                    */
-  .word	HPDMA1_Channel6_IRQHandler  		/* HPDMA1 Channel 6 interrupt                                    */
-  .word	HPDMA1_Channel7_IRQHandler  		/* HPDMA1 Channel 7 interrupt                                    */
-  .word	HPDMA1_Channel8_IRQHandler  		/* HPDMA1 Channel 8 interrupt                                    */
-  .word	HPDMA1_Channel9_IRQHandler  		/* HPDMA1 Channel 9 interrupt                                    */
-  .word	HPDMA1_Channel10_IRQHandler 		/* HPDMA1 Channel 10 interrupt                                   */
-  .word	HPDMA1_Channel11_IRQHandler 		/* HPDMA1 Channel 11 interrupt                                   */
-  .word	HPDMA1_Channel12_IRQHandler 		/* HPDMA1 Channel 12 interrupt                                   */
-  .word	HPDMA1_Channel13_IRQHandler 		/* HPDMA1 Channel 13 interrupt                                   */
-  .word	HPDMA1_Channel14_IRQHandler 		/* HPDMA1 Channel 14 interrupt                                   */
-  .word	HPDMA1_Channel15_IRQHandler 		/* HPDMA1 Channel 15 interrupt                                   */
-  .word	GPDMA1_Channel0_IRQHandler  		/* GPDMA1 channel 0 interrupt                                    */
-  .word	GPDMA1_Channel1_IRQHandler  		/* GPDMA1 channel 1 interrupt                                    */
-  .word	GPDMA1_Channel2_IRQHandler  		/* GPDMA1 channel 2 interrupt                                    */
-  .word	GPDMA1_Channel3_IRQHandler  		/* GPDMA1 channel 3 interrupt                                    */
-  .word	GPDMA1_Channel4_IRQHandler  		/* GPDMA1 channel 4 interrupt                                    */
-  .word	GPDMA1_Channel5_IRQHandler  		/* GPDMA1 channel 5 interrupt                                    */
-  .word	GPDMA1_Channel6_IRQHandler  		/* GPDMA1 channel 6 interrupt                                    */
-  .word	GPDMA1_Channel7_IRQHandler  		/* GPDMA1 channel 7 interrupt                                    */
-  .word	GPDMA1_Channel8_IRQHandler  		/* GPDMA1 channel 8 interrupt                                    */
-  .word	GPDMA1_Channel9_IRQHandler  		/* GPDMA1 channel 9 interrupt                                    */
-  .word	GPDMA1_Channel10_IRQHandler 		/* GPDMA1 channel 10 interrupt                                   */
-  .word	GPDMA1_Channel11_IRQHandler 		/* GPDMA1 channel 11 interrupt                                   */
-  .word	GPDMA1_Channel12_IRQHandler 		/* GPDMA1 channel 12 interrupt                                   */
-  .word	GPDMA1_Channel13_IRQHandler 		/* GPDMA1 channel 13 interrupt                                   */
-  .word	GPDMA1_Channel14_IRQHandler 		/* GPDMA1 channel 14 interrupt                                   */
-  .word	GPDMA1_Channel15_IRQHandler 		/* GPDMA1 channel 15 interrupt                                   */
-  .word	I2C1_EV_IRQHandler         			/* I2C1 event interrupt                                          */
-  .word	I2C1_ER_IRQHandler         			/* I2C1 error interrupt                                          */
-  .word	I2C2_EV_IRQHandler         			/* I2C2 event interrupt                                          */
-  .word	I2C2_ER_IRQHandler         			/* I2C2 error interrupt                                          */
-  .word	I2C3_EV_IRQHandler         			/* I2C3 event interrupt                                          */
-  .word	I2C3_ER_IRQHandler         			/* I2C3 error interrupt                                          */
-  .word	I2C4_EV_IRQHandler         			/* I2C4 event interrupt                                          */
-  .word	I2C4_ER_IRQHandler         			/* I2C4 error interrupt                                          */
-  .word	I3C1_EV_IRQHandler         			/* I3C1 event interrupt                                          */
-  .word	I3C1_ER_IRQHandler         			/* I3C1 error interrupt                                          */
-  .word	I3C2_EV_IRQHandler         			/* I3C2 event interrupt                                          */
-  .word	I3C2_ER_IRQHandler         			/* I3C2 error interrupt                                          */
-  .word	TIM1_BRK_IRQHandler        			/* TIM1 Break interrupt                                          */
-  .word	TIM1_UP_IRQHandler         			/* TIM1 Update interrupt                                         */
-  .word	TIM1_TRG_CCU_IRQHandler    			/* TIM1 Trigger and Commutation interrupts                       */
-  .word	TIM1_CC_IRQHandler         			/* TIM1 Capture Compare interrupt                                */
-  .word	TIM2_IRQHandler            			/* TIM2 global interrupt                                         */
-  .word	TIM3_IRQHandler            			/* TIM3 global interrupt                                         */
-  .word	TIM4_IRQHandler            			/* TIM4 global interrupt                                         */
-  .word	TIM5_IRQHandler            			/* TIM5 global interrupt                                         */
-  .word	TIM6_IRQHandler            			/* TIM6 Global interrupt                                         */
-  .word	TIM7_IRQHandler            			/* TIM7 Global interrupt                                         */
-  .word	TIM8_BRK_IRQHandler        			/* TIM8 Break interrupt                                          */
-  .word	TIM8_UP_IRQHandler         			/* TIM8 Update interrupt                                         */
-  .word	TIM8_TRG_CCU_IRQHandler    			/* TIM8 Trigger and Commutation interrupts                       */
-  .word	TIM8_CC_IRQHandler         			/* TIM8 Capture Compare interrupt                                */
-  .word	TIM9_IRQHandler            			/* TIM9 Global interrupt                                         */
-  .word	TIM10_IRQHandler           			/* TIM10 Global interrupt                                        */
-  .word	TIM11_IRQHandler           			/* TIM11 Global interrupt                                        */
-  .word	TIM12_IRQHandler           			/* TIM12 Global interrupt                                        */
-  .word	TIM13_IRQHandler           			/* TIM13 Global interrupt                                        */
-  .word	TIM14_IRQHandler           			/* TIM14 Global interrupt                                        */
-  .word	TIM15_IRQHandler           			/* TIM15 global interrupt                                        */
-  .word	TIM16_IRQHandler           			/* TIM16 global interrupt                                        */
-  .word	TIM17_IRQHandler           			/* TIM17 global interrupt                                        */
-  .word	TIM18_IRQHandler           			/* TIM18 Global interrupt                                        */
-  .word	LPTIM1_IRQHandler          			/* LPTIM1 global interrupt                                       */
-  .word	LPTIM2_IRQHandler          			/* LPTIM2 global interrupt                                       */
-  .word	LPTIM3_IRQHandler          			/* LPTIM3 global interrupt                                       */
-  .word	LPTIM4_IRQHandler          			/* LPTIM4 global interrupt                                       */
-  .word	LPTIM5_IRQHandler          			/* LPTIM5 global interrupt                                       */
-  .word	ADF1_FLT0_IRQHandler       			/* ADF1 filter 0 global interrupt                                */
-  .word	MDF1_FLT0_IRQHandler       			/* MDF global Interrupt for Filter0                              */
-  .word	MDF1_FLT1_IRQHandler       			/* MDF global Interrupt for Filter1                              */
-  .word	MDF1_FLT2_IRQHandler       			/* MDF global Interrupt for Filter2                              */
-  .word	MDF1_FLT3_IRQHandler       			/* MDF global Interrupt for Filter3                              */
-  .word	MDF1_FLT4_IRQHandler       			/* MDF global Interrupt for Filter4                              */
-  .word	MDF1_FLT5_IRQHandler       			/* MDF global Interrupt for Filter5                              */
-  .word	SAI1_A_IRQHandler   			    /* SAI1 global interrupt A                                       */
-  .word	SAI1_B_IRQHandler   		  	    /* SAI1 global interrupt B                                       */
-  .word	SAI2_A_IRQHandler   		  	    /* SAI2 global interrupt A                                       */
-  .word	SAI2_B_IRQHandler   			    /* SAI2 global interrupt B                                       */
-  .word	SPDIFRX_IRQHandler         			/* SPDIFRX global interrupt                                      */
-  .word	SPI1_IRQHandler            			/* SPI1 global interrupt A                                       */
-  .word	SPI2_IRQHandler            			/* SPI2 global interrupt A                                       */
-  .word	SPI3_IRQHandler            			/* SPI3 global interrupt A                                       */
-  .word	SPI4_IRQHandler            			/* SPI4 global interrupt A                                       */
-  .word	SPI5_IRQHandler            			/* SPI5 global interrupt A                                       */
-  .word	SPI6_IRQHandler            			/* SPI6 global interrupt A                                       */
-  .word	USART1_IRQHandler          			/* USART1 Global interrupt                                       */
-  .word	USART2_IRQHandler          			/* USART2 Global interrupt                                       */
-  .word	USART3_IRQHandler          			/* USART3 Global interrupt                                       */
-  .word	UART4_IRQHandler           			/* UART4 Global interrupt                                        */
-  .word	UART5_IRQHandler           			/* UART5 Global interrupt                                        */
-  .word	USART6_IRQHandler          			/* USART6 Global interrupt                                       */
-  .word	UART7_IRQHandler           			/* UART7 Global interrupt                                        */
-  .word	UART8_IRQHandler           			/* UART8 Global interrupt                                        */
-  .word	UART9_IRQHandler           			/* UART9 Global interrupt                                        */
-  .word	USART10_IRQHandler         			/* USART10 Global interrupt                                      */
-  .word	LPUART1_IRQHandler         			/* LPUART1 global interrupt                                      */
-  .word	XSPI1_IRQHandler           			/* XSPI1 global interrupt                                        */
-  .word	XSPI2_IRQHandler           			/* XSPI2 global interrupt                                        */
-  .word	XSPI3_IRQHandler           			/* XSPI3 global interrupt                                        */
-  .word	FMC_IRQHandler             			/* FMC global interrupt                                          */
-  .word	SDMMC1_IRQHandler          			/* SDMMC1 global interrupt                                       */
-  .word	SDMMC2_IRQHandler          			/* SDMMC2 global interrupt                                       */
-  .word	UCPD1_IRQHandler            		/* UCPD global interrupt                                         */
-  .word	USB1_OTG_HS_IRQHandler              /* USB OTG1 HS global interrupt                                  */
-  .word	USB2_OTG_HS_IRQHandler              /* USB OTG2 HS global interrupt                                  */
-  .word	ETH1_IRQHandler            			/* Ethernet global interrupt                                     */
-  .word	FDCAN1_IT0_IRQHandler         	    /* FDCAN1 interrupt 0                                            */
-  .word	FDCAN1_IT1_IRQHandler         	    /* FDCAN1 interrupt 1                                            */
-  .word	FDCAN2_IT0_IRQHandler        		/* FDCAN2 interrupt 0                                            */
-  .word	FDCAN2_IT1_IRQHandler        		/* FDCAN2 interrupt 1                                            */
-  .word	FDCAN3_IT0_IRQHandler        		/* FDCAN3 interrupt 0                                            */
-  .word	FDCAN3_IT1_IRQHandler        		/* FDCAN3 interrupt 1                                            */
-  .word	FDCAN_CU_IRQHandler        			/* Clock calibration unit interrupt line(FDCAN1 only)            */
-  .word	MDIOS_IRQHandler           			/* MDIOS global Interrupt                                        */
-  .word	DCMI_PSSI_IRQHandler       			/* DCMI/PSSI global interrupt                                    */
-  .word	WAKEUP_PIN_IRQHandler      			/* Wake-up pin interrupts                                        */
-  .word	CTI_INT0_IRQHandler          		/* Debug monitor (Cortex-M55 related)                            */
-  .word	CTI_INT1_IRQHandler          		/* Debug monitor (Cortex-M55 related)                            */
-  .word	0                          			/* Reserved                                                      */
-  .word	LTDC_UP_IRQHandler         			/* LCD up-layer global interrupt                                 */
-  .word	LTDC_UP_ERR_IRQHandler     			/* LCD up-layer error interrupt                                  */
+  .word MemManage_Handler
+  .word BusFault_Handler
+  .word UsageFault_Handler
+  .word SecureFault_Handler
+  .word 0
+  .word 0
+  .word 0
+  .word SVC_Handler
+  .word DebugMon_Handler
+  .word 0
+  .word PendSV_Handler
+  .word SysTick_Handler
+  /* External Interrupts */
+  .word PVD_PVM_IRQHandler                      /* PVD/PVM through EXTI Line detection               */
+  .word 0                                       /* Reserved                                          */
+  .word DTS_IRQHandler                          /* Digital Temperature Sensor                        */
+  .word IWDG_IRQHandler                         /* Internal Watchdog                                 */
+  .word 0                                       /* Reserved                                          */
+  .word RCC_IRQHandler                          /* RCC global interrupts                             */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word EXTI0_IRQHandler                        /* EXTI Line0                                        */
+  .word EXTI1_IRQHandler                        /* EXTI Line1                                        */
+  .word EXTI2_IRQHandler                        /* EXTI Line2                                        */
+  .word EXTI3_IRQHandler                        /* EXTI Line3                                        */
+  .word EXTI4_IRQHandler                        /* EXTI Line4                                        */
+  .word EXTI5_IRQHandler                        /* EXTI Line5                                        */
+  .word EXTI6_IRQHandler                        /* EXTI Line6                                        */
+  .word EXTI7_IRQHandler                        /* EXTI Line7                                        */
+  .word EXTI8_IRQHandler                        /* EXTI Line8                                        */
+  .word EXTI9_IRQHandler                        /* EXTI Line9                                        */
+  .word EXTI10_IRQHandler                       /* EXTI Line10                                       */
+  .word EXTI11_IRQHandler                       /* EXTI Line11                                       */
+  .word EXTI12_IRQHandler                       /* EXTI Line12                                       */
+  .word EXTI13_IRQHandler                       /* EXTI Line13                                       */
+  .word EXTI14_IRQHandler                       /* EXTI Line14                                       */
+  .word EXTI15_IRQHandler                       /* EXTI Line15                                       */
+  .word RTC_IRQHandler                          /* RTC wakeup and alarm interrupts                   */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word TAMP_IRQHandler                         /* Tamper                                            */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word RISAF1S_IRQHandler                      /* RISAF1 secure global                              */
+  .word IAC_IRQHandler                          /* IAC interrupt                                     */
+  .word RCC_S_IRQHandler                        /* RCC secure                                        */
+  .word 0                                       /* Reserved                                          */
+  .word SDMMC1_IRQHandler                       /* SDMMC1 global interrupt                           */
+  .word SDMMC2_IRQHandler                       /* SDMMC2 global interrupt                           */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word TIM1_BRK_IRQHandler                     /* TIM1 Break                                        */
+  .word TIM1_UP_IRQHandler                      /* TIM1 Update                                       */
+  .word TIM1_TRG_COM_IRQHandler                 /* TIM1 Trigger and Commutation                      */
+  .word TIM1_CC_IRQHandler                      /* TIM1 Capture Compare                              */
+  .word TIM2_IRQHandler                         /* TIM2                                              */
+  .word TIM3_IRQHandler                         /* TIM3                                              */
+  .word TIM4_IRQHandler                         /* TIM4                                              */
+  .word TIM5_IRQHandler                         /* TIM5                                              */
+  .word TIM6_IRQHandler                         /* TIM6                                              */
+  .word TIM7_IRQHandler                         /* TIM7                                              */
+  .word TIM8_BRK_IRQHandler                     /* TIM8 Break                                        */
+  .word TIM8_UP_IRQHandler                      /* TIM8 Update                                       */
+  .word TIM8_TRG_COM_IRQHandler                 /* TIM8 Trigger and Commutation                      */
+  .word TIM8_CC_IRQHandler                      /* TIM8 Capture Compare                              */
+  .word I2C1_EV_IRQHandler                      /* I2C1 Event                                        */
+  .word I2C1_ER_IRQHandler                      /* I2C1 Error                                        */
+  .word I2C2_EV_IRQHandler                      /* I2C2 Event                                        */
+  .word I2C2_ER_IRQHandler                      /* I2C2 Error                                        */
+  .word SPI1_IRQHandler                         /* SPI1                                              */
+  .word SPI2_IRQHandler                         /* SPI2                                              */
+  .word USART1_IRQHandler                       /* USART1                                            */
+  .word USART2_IRQHandler                       /* USART2                                            */
+  .word USART3_IRQHandler                       /* USART3                                            */
+  .word UART4_IRQHandler                        /* UART4                                             */
+  .word UART5_IRQHandler                        /* UART5                                             */
+  .word LPUART1_IRQHandler                      /* LP UART1                                          */
+  .word LPTIM1_IRQHandler                       /* LP TIM1                                           */
+  .word LPTIM2_IRQHandler                       /* LP TIM2                                           */
+  .word TIM15_IRQHandler                        /* TIM15                                             */
+  .word TIM16_IRQHandler                        /* TIM16                                             */
+  .word TIM17_IRQHandler                        /* TIM17                                             */
+  .word 0                                       /* Reserved                                          */
+  .word I2C3_EV_IRQHandler                      /* I2C3 Event                                        */
+  .word I2C3_ER_IRQHandler                      /* I2C3 Error                                        */
+  .word I2C4_EV_IRQHandler                      /* I2C4 Event                                        */
+  .word I2C4_ER_IRQHandler                      /* I2C4 Error                                        */
+  .word SPI3_IRQHandler                         /* SPI3                                              */
+  .word SPI4_IRQHandler                         /* SPI4                                              */
+  .word SPI5_IRQHandler                         /* SPI5                                              */
+  .word SPI6_IRQHandler                         /* SPI6                                              */
+  .word USART6_IRQHandler                       /* USART6                                            */
+  .word UART7_IRQHandler                        /* UART7                                             */
+  .word UART8_IRQHandler                        /* UART8                                             */
+  .word UART9_IRQHandler                        /* UART9                                             */
+  .word 0                                       /* Reserved                                          */
+  .word USB1_OTG_HS_IRQHandler                  /* USB1 OTG HS global                                */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word FMC_IRQHandler                          /* FMC                                               */
+  .word 0                                       /* Reserved                                          */
+  .word RISAF5S_IRQHandler                      /* RISAF5 secure                                     */
+  .word 0                                       /* Reserved                                          */
+  .word DMA2D_IRQHandler                        /* DMA2D                                             */
+  .word DCMIPP_IRQHandler                       /* DCMIPP global                                     */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word DMA1_Stream0_IRQHandler                 /* DMA1 Stream 0                                     */
+  .word DMA1_Stream1_IRQHandler                 /* DMA1 Stream 1                                     */
+  .word DMA1_Stream2_IRQHandler                 /* DMA1 Stream 2                                     */
+  .word DMA1_Stream3_IRQHandler                 /* DMA1 Stream 3                                     */
+  .word DMA1_Stream4_IRQHandler                 /* DMA1 Stream 4                                     */
+  .word DMA1_Stream5_IRQHandler                 /* DMA1 Stream 5                                     */
+  .word DMA1_Stream6_IRQHandler                 /* DMA1 Stream 6                                     */
+  .word DMA1_Stream7_IRQHandler                 /* DMA1 Stream 7                                     */
+  .word DMA1_Stream8_IRQHandler                 /* DMA1 Stream 8                                     */
+  .word DMA1_Stream9_IRQHandler                 /* DMA1 Stream 9                                     */
+  .word DMA1_Stream10_IRQHandler                /* DMA1 Stream 10                                    */
+  .word DMA1_Stream11_IRQHandler                /* DMA1 Stream 11                                    */
+  .word DMA1_Stream12_IRQHandler                /* DMA1 Stream 12                                    */
+  .word DMA1_Stream13_IRQHandler                /* DMA1 Stream 13                                    */
+  .word DMA1_Stream14_IRQHandler                /* DMA1 Stream 14                                    */
+  .word DMA1_Stream15_IRQHandler                /* DMA1 Stream 15                                    */
+  .word GPDMA1_IRQHandler                       /* GPDMA1 global                                     */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word FDCAN1_IT0_IRQHandler                   /* FDCAN1 interrupt line 0                           */
+  .word FDCAN1_IT1_IRQHandler                   /* FDCAN1 interrupt line 1                           */
+  .word FDCAN2_IT0_IRQHandler                   /* FDCAN2 interrupt line 0                           */
+  .word FDCAN2_IT1_IRQHandler                   /* FDCAN2 interrupt line 1                           */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word LPTIM3_IRQHandler                       /* LP TIM3                                           */
+  .word LPTIM4_IRQHandler                       /* LP TIM4                                           */
+  .word LPTIM5_IRQHandler                       /* LP TIM5                                           */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word MDIOS_IRQHandler                        /* MDIOS global                                      */
+  .word ETH1_SBD_IRQHandler                     /* Ethernet SBD                                      */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word GPU2D_IRQHandler                        /* GPU2D global                                      */
+  .word GPU2D_ER_IRQHandler                     /* GPU2D error                                       */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word XSPI1_IRQHandler                        /* XSPI1 global interrupt                            */
+  .word XSPI2_IRQHandler                        /* XSPI2 global interrupt                            */
+  .word XSPI3_IRQHandler                        /* XSPI3 global interrupt                            */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
+  .word 0                                       /* Reserved                                          */
 
 /*******************************************************************************
 *
@@ -349,594 +368,350 @@ g_pfnVectors:
 *
 *******************************************************************************/
 
-	.weak	NMI_Handler
-	.thumb_set NMI_Handler,Default_Handler
+  .weak NMI_Handler
+  .thumb_set NMI_Handler,Default_Handler
 
-	.weak	HardFault_Handler
-	.thumb_set HardFault_Handler,Default_Handler
+  .weak HardFault_Handler
+  .thumb_set HardFault_Handler,Default_Handler
 
-	.weak	MemManage_Handler
-	.thumb_set MemManage_Handler,Default_Handler
+  .weak MemManage_Handler
+  .thumb_set MemManage_Handler,Default_Handler
 
-	.weak	BusFault_Handler
-	.thumb_set BusFault_Handler,Default_Handler
+  .weak BusFault_Handler
+  .thumb_set BusFault_Handler,Default_Handler
 
-	.weak	UsageFault_Handler
-	.thumb_set UsageFault_Handler,Default_Handler
+  .weak UsageFault_Handler
+  .thumb_set UsageFault_Handler,Default_Handler
 
-	.weak	SecureFault_Handler
-	.thumb_set SecureFault_Handler,Default_Handler
+  .weak SecureFault_Handler
+  .thumb_set SecureFault_Handler,Default_Handler
 
-	.weak	SVC_Handler
-	.thumb_set SVC_Handler,Default_Handler
+  .weak SVC_Handler
+  .thumb_set SVC_Handler,Default_Handler
 
-	.weak	DebugMon_Handler
-	.thumb_set DebugMon_Handler,Default_Handler
+  .weak DebugMon_Handler
+  .thumb_set DebugMon_Handler,Default_Handler
 
-	.weak	PendSV_Handler
-	.thumb_set PendSV_Handler,Default_Handler
+  .weak PendSV_Handler
+  .thumb_set PendSV_Handler,Default_Handler
 
-	.weak	SysTick_Handler
-	.thumb_set SysTick_Handler,Default_Handler
+  .weak SysTick_Handler
+  .thumb_set SysTick_Handler,Default_Handler
 
-	.weak	PVD_PVM_IRQHandler
-	.thumb_set PVD_PVM_IRQHandler,Default_Handler
+  .weak PVD_PVM_IRQHandler
+  .thumb_set PVD_PVM_IRQHandler,Default_Handler
 
-	.weak	DTS_IRQHandler
-	.thumb_set DTS_IRQHandler,Default_Handler
+  .weak DTS_IRQHandler
+  .thumb_set DTS_IRQHandler,Default_Handler
 
-	.weak	RCC_IRQHandler
-	.thumb_set RCC_IRQHandler,Default_Handler
+  .weak IWDG_IRQHandler
+  .thumb_set IWDG_IRQHandler,Default_Handler
 
-	.weak	LOCKUP_IRQHandler
-	.thumb_set LOCKUP_IRQHandler,Default_Handler
+  .weak RCC_IRQHandler
+  .thumb_set RCC_IRQHandler,Default_Handler
 
-	.weak	CACHE_ECC_IRQHandler
-	.thumb_set CACHE_ECC_IRQHandler,Default_Handler
+  .weak EXTI0_IRQHandler
+  .thumb_set EXTI0_IRQHandler,Default_Handler
 
-	.weak	TCM_ECC_IRQHandler
-	.thumb_set TCM_ECC_IRQHandler,Default_Handler
+  .weak EXTI1_IRQHandler
+  .thumb_set EXTI1_IRQHandler,Default_Handler
 
-	.weak	BCK_ECC_IRQHandler
-	.thumb_set BCK_ECC_IRQHandler,Default_Handler
+  .weak EXTI2_IRQHandler
+  .thumb_set EXTI2_IRQHandler,Default_Handler
 
-	.weak	FPU_IRQHandler
-	.thumb_set FPU_IRQHandler,Default_Handler
+  .weak EXTI3_IRQHandler
+  .thumb_set EXTI3_IRQHandler,Default_Handler
 
-	.weak	RTC_S_IRQHandler
-	.thumb_set RTC_S_IRQHandler,Default_Handler
+  .weak EXTI4_IRQHandler
+  .thumb_set EXTI4_IRQHandler,Default_Handler
 
-	.weak	TAMP_IRQHandler
-	.thumb_set TAMP_IRQHandler,Default_Handler
+  .weak EXTI5_IRQHandler
+  .thumb_set EXTI5_IRQHandler,Default_Handler
 
-	.weak	RIFSC_TAMPER_IRQHandler
-	.thumb_set RIFSC_TAMPER_IRQHandler,Default_Handler
+  .weak EXTI6_IRQHandler
+  .thumb_set EXTI6_IRQHandler,Default_Handler
 
-	.weak	IAC_IRQHandler
-	.thumb_set IAC_IRQHandler,Default_Handler
+  .weak EXTI7_IRQHandler
+  .thumb_set EXTI7_IRQHandler,Default_Handler
 
-	.weak	RCC_S_IRQHandler
-	.thumb_set RCC_S_IRQHandler,Default_Handler
+  .weak EXTI8_IRQHandler
+  .thumb_set EXTI8_IRQHandler,Default_Handler
 
-	.weak	RTC_IRQHandler
-	.thumb_set RTC_IRQHandler,Default_Handler
+  .weak EXTI9_IRQHandler
+  .thumb_set EXTI9_IRQHandler,Default_Handler
 
-	.weak	IWDF_IRQHandler
-	.thumb_set IWDG_IRQHandler,Default_Handler
+  .weak EXTI10_IRQHandler
+  .thumb_set EXTI10_IRQHandler,Default_Handler
 
-	.weak	WWDG_IRQHandler
-	.thumb_set WWDG_IRQHandler,Default_Handler
+  .weak EXTI11_IRQHandler
+  .thumb_set EXTI11_IRQHandler,Default_Handler
 
-	.weak	EXTI0_IRQHandler
-	.thumb_set EXTI0_IRQHandler,Default_Handler
+  .weak EXTI12_IRQHandler
+  .thumb_set EXTI12_IRQHandler,Default_Handler
 
-	.weak	EXTI1_IRQHandler
-	.thumb_set EXTI1_IRQHandler,Default_Handler
+  .weak EXTI13_IRQHandler
+  .thumb_set EXTI13_IRQHandler,Default_Handler
 
-	.weak	EXTI2_IRQHandler
-	.thumb_set EXTI2_IRQHandler,Default_Handler
+  .weak EXTI14_IRQHandler
+  .thumb_set EXTI14_IRQHandler,Default_Handler
 
-	.weak	EXTI3_IRQHandler
-	.thumb_set EXTI3_IRQHandler,Default_Handler
+  .weak EXTI15_IRQHandler
+  .thumb_set EXTI15_IRQHandler,Default_Handler
 
-	.weak	EXTI4_IRQHandler
-	.thumb_set EXTI4_IRQHandler,Default_Handler
+  .weak RTC_IRQHandler
+  .thumb_set RTC_IRQHandler,Default_Handler
 
-	.weak	EXTI5_IRQHandler
-	.thumb_set EXTI5_IRQHandler,Default_Handler
+  .weak TAMP_IRQHandler
+  .thumb_set TAMP_IRQHandler,Default_Handler
 
-	.weak	EXTI6_IRQHandler
-	.thumb_set EXTI6_IRQHandler,Default_Handler
+  .weak RISAF1S_IRQHandler
+  .thumb_set RISAF1S_IRQHandler,Default_Handler
 
-	.weak	EXTI7_IRQHandler
-	.thumb_set EXTI7_IRQHandler,Default_Handler
+  .weak IAC_IRQHandler
+  .thumb_set IAC_IRQHandler,Default_Handler
 
-	.weak	EXTI8_IRQHandler
-	.thumb_set EXTI8_IRQHandler,Default_Handler
+  .weak RCC_S_IRQHandler
+  .thumb_set RCC_S_IRQHandler,Default_Handler
 
-	.weak	EXTI9_IRQHandler
-	.thumb_set EXTI9_IRQHandler,Default_Handler
+  .weak SDMMC1_IRQHandler
+  .thumb_set SDMMC1_IRQHandler,Default_Handler
 
-	.weak	EXTI10_IRQHandler
-	.thumb_set EXTI10_IRQHandler,Default_Handler
+  .weak SDMMC2_IRQHandler
+  .thumb_set SDMMC2_IRQHandler,Default_Handler
 
-	.weak	EXTI11_IRQHandler
-	.thumb_set EXTI11_IRQHandler,Default_Handler
+  .weak TIM1_BRK_IRQHandler
+  .thumb_set TIM1_BRK_IRQHandler,Default_Handler
 
-	.weak	EXTI12_IRQHandler
-	.thumb_set EXTI12_IRQHandler,Default_Handler
+  .weak TIM1_UP_IRQHandler
+  .thumb_set TIM1_UP_IRQHandler,Default_Handler
 
-	.weak	EXTI13_IRQHandler
-	.thumb_set EXTI13_IRQHandler,Default_Handler
+  .weak TIM1_TRG_COM_IRQHandler
+  .thumb_set TIM1_TRG_COM_IRQHandler,Default_Handler
 
-	.weak	EXTI14_IRQHandler
-	.thumb_set EXTI14_IRQHandler,Default_Handler
+  .weak TIM1_CC_IRQHandler
+  .thumb_set TIM1_CC_IRQHandler,Default_Handler
 
-	.weak	EXTI15_IRQHandler
-	.thumb_set EXTI15_IRQHandler,Default_Handler
+  .weak TIM2_IRQHandler
+  .thumb_set TIM2_IRQHandler,Default_Handler
 
-	.weak	SAES_IRQHandler
-	.thumb_set SAES_IRQHandler,Default_Handler
+  .weak TIM3_IRQHandler
+  .thumb_set TIM3_IRQHandler,Default_Handler
 
-	.weak	CRYP_IRQHandler
-	.thumb_set CRYP_IRQHandler,Default_Handler
+  .weak TIM4_IRQHandler
+  .thumb_set TIM4_IRQHandler,Default_Handler
 
-	.weak	PKA_IRQHandler
-	.thumb_set PKA_IRQHandler,Default_Handler
+  .weak TIM5_IRQHandler
+  .thumb_set TIM5_IRQHandler,Default_Handler
 
-	.weak	HASH_IRQHandler
-	.thumb_set HASH_IRQHandler,Default_Handler
+  .weak TIM6_IRQHandler
+  .thumb_set TIM6_IRQHandler,Default_Handler
 
-	.weak	RNG_IRQHandler
-	.thumb_set RNG_IRQHandler,Default_Handler
+  .weak TIM7_IRQHandler
+  .thumb_set TIM7_IRQHandler,Default_Handler
 
-	.weak	MCE1_IRQHandler
-	.thumb_set MCE1_IRQHandler,Default_Handler
+  .weak TIM8_BRK_IRQHandler
+  .thumb_set TIM8_BRK_IRQHandler,Default_Handler
 
-	.weak	MCE2_IRQHandler
-	.thumb_set MCE2_IRQHandler,Default_Handler
+  .weak TIM8_UP_IRQHandler
+  .thumb_set TIM8_UP_IRQHandler,Default_Handler
 
-	.weak	MCE3_IRQHandler
-	.thumb_set MCE3_IRQHandler,Default_Handler
+  .weak TIM8_TRG_COM_IRQHandler
+  .thumb_set TIM8_TRG_COM_IRQHandler,Default_Handler
 
-	.weak	MCE4_IRQHandler
-	.thumb_set MCE4_IRQHandler,Default_Handler
+  .weak TIM8_CC_IRQHandler
+  .thumb_set TIM8_CC_IRQHandler,Default_Handler
 
-	.weak	ADC1_2_IRQHandler
-	.thumb_set ADC1_2_IRQHandler,Default_Handler
+  .weak I2C1_EV_IRQHandler
+  .thumb_set I2C1_EV_IRQHandler,Default_Handler
 
-	.weak	CSI_IRQHandler
-	.thumb_set CSI_IRQHandler,Default_Handler
+  .weak I2C1_ER_IRQHandler
+  .thumb_set I2C1_ER_IRQHandler,Default_Handler
 
-	.weak	DCMIPP_IRQHandler
-	.thumb_set DCMIPP_IRQHandler,Default_Handler
+  .weak I2C2_EV_IRQHandler
+  .thumb_set I2C2_EV_IRQHandler,Default_Handler
 
-	.weak	PAHB_ERR_IRQHandler
-	.thumb_set PAHB_ERR_IRQHandler,Default_Handler
+  .weak I2C2_ER_IRQHandler
+  .thumb_set I2C2_ER_IRQHandler,Default_Handler
 
-	.weak	NPU0_IRQHandler
-	.thumb_set NPU0_IRQHandler,Default_Handler
+  .weak SPI1_IRQHandler
+  .thumb_set SPI1_IRQHandler,Default_Handler
 
-	.weak	NPU1_IRQHandler
-	.thumb_set NPU1_IRQHandler,Default_Handler
+  .weak SPI2_IRQHandler
+  .thumb_set SPI2_IRQHandler,Default_Handler
 
-	.weak	NPU2_IRQHandler
-	.thumb_set NPU2_IRQHandler,Default_Handler
+  .weak USART1_IRQHandler
+  .thumb_set USART1_IRQHandler,Default_Handler
 
-	.weak	NPU3_IRQHandler
-	.thumb_set NPU3_IRQHandler,Default_Handler
+  .weak USART2_IRQHandler
+  .thumb_set USART2_IRQHandler,Default_Handler
 
-	.weak	CACHEAXI_IRQHandler
-	.thumb_set CACHEAXI_IRQHandler,Default_Handler
+  .weak USART3_IRQHandler
+  .thumb_set USART3_IRQHandler,Default_Handler
 
-	.weak	LTDC_LO_IRQHandler
-	.thumb_set LTDC_LO_IRQHandler,Default_Handler
+  .weak UART4_IRQHandler
+  .thumb_set UART4_IRQHandler,Default_Handler
 
-	.weak	LTDC_LO_ERR_IRQHandler
-	.thumb_set LTDC_LO_ERR_IRQHandler,Default_Handler
+  .weak UART5_IRQHandler
+  .thumb_set UART5_IRQHandler,Default_Handler
 
-	.weak	DMA2D_IRQHandler
-	.thumb_set DMA2D_IRQHandler,Default_Handler
+  .weak LPUART1_IRQHandler
+  .thumb_set LPUART1_IRQHandler,Default_Handler
 
-	.weak	JPEG_IRQHandler
-	.thumb_set JPEG_IRQHandler,Default_Handler
+  .weak LPTIM1_IRQHandler
+  .thumb_set LPTIM1_IRQHandler,Default_Handler
 
-	.weak	VENC_IRQHandler
-	.thumb_set VENC_IRQHandler,Default_Handler
+  .weak LPTIM2_IRQHandler
+  .thumb_set LPTIM2_IRQHandler,Default_Handler
 
-	.weak	GFXMMU_IRQHandler
-	.thumb_set GFXMMU_IRQHandler,Default_Handler
+  .weak TIM15_IRQHandler
+  .thumb_set TIM15_IRQHandler,Default_Handler
 
-	.weak	GFXTIM_IRQHandler
-	.thumb_set GFXTIM_IRQHandler,Default_Handler
+  .weak TIM16_IRQHandler
+  .thumb_set TIM16_IRQHandler,Default_Handler
 
-	.weak	GPU2D_IRQHandler
-	.thumb_set GPU2D_IRQHandler,Default_Handler
+  .weak TIM17_IRQHandler
+  .thumb_set TIM17_IRQHandler,Default_Handler
 
-	.weak	GPU2D_ER_IRQHandler
-	.thumb_set GPU2D_ER_IRQHandler,Default_Handler
+  .weak I2C3_EV_IRQHandler
+  .thumb_set I2C3_EV_IRQHandler,Default_Handler
 
-	.weak	ICACHE_IRQHandler
-	.thumb_set ICACHE_IRQHandler,Default_Handler
+  .weak I2C3_ER_IRQHandler
+  .thumb_set I2C3_ER_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel0_IRQHandler
-	.thumb_set HPDMA1_Channel0_IRQHandler,Default_Handler
+  .weak I2C4_EV_IRQHandler
+  .thumb_set I2C4_EV_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel1_IRQHandler
-	.thumb_set HPDMA1_Channel1_IRQHandler,Default_Handler
+  .weak I2C4_ER_IRQHandler
+  .thumb_set I2C4_ER_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel2_IRQHandler
-	.thumb_set HPDMA1_Channel2_IRQHandler,Default_Handler
+  .weak SPI3_IRQHandler
+  .thumb_set SPI3_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel3_IRQHandler
-	.thumb_set HPDMA1_Channel3_IRQHandler,Default_Handler
+  .weak SPI4_IRQHandler
+  .thumb_set SPI4_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel4_IRQHandler
-	.thumb_set HPDMA1_Channel4_IRQHandler,Default_Handler
+  .weak SPI5_IRQHandler
+  .thumb_set SPI5_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel5_IRQHandler
-	.thumb_set HPDMA1_Channel5_IRQHandler,Default_Handler
+  .weak SPI6_IRQHandler
+  .thumb_set SPI6_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel6_IRQHandler
-	.thumb_set HPDMA1_Channel6_IRQHandler,Default_Handler
+  .weak USART6_IRQHandler
+  .thumb_set USART6_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel7_IRQHandler
-	.thumb_set HPDMA1_Channel7_IRQHandler,Default_Handler
+  .weak UART7_IRQHandler
+  .thumb_set UART7_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel8_IRQHandler
-	.thumb_set HPDMA1_Channel8_IRQHandler,Default_Handler
+  .weak UART8_IRQHandler
+  .thumb_set UART8_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel9_IRQHandler
-	.thumb_set HPDMA1_Channel9_IRQHandler,Default_Handler
+  .weak UART9_IRQHandler
+  .thumb_set UART9_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel10_IRQHandler
-	.thumb_set HPDMA1_Channel10_IRQHandler,Default_Handler
+  .weak USB1_OTG_HS_IRQHandler
+  .thumb_set USB1_OTG_HS_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel11_IRQHandler
-	.thumb_set HPDMA1_Channel11_IRQHandler,Default_Handler
+  .weak FMC_IRQHandler
+  .thumb_set FMC_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel12_IRQHandler
-	.thumb_set HPDMA1_Channel12_IRQHandler,Default_Handler
+  .weak RISAF5S_IRQHandler
+  .thumb_set RISAF5S_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel13_IRQHandler
-	.thumb_set HPDMA1_Channel13_IRQHandler,Default_Handler
+  .weak DMA2D_IRQHandler
+  .thumb_set DMA2D_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel14_IRQHandler
-	.thumb_set HPDMA1_Channel14_IRQHandler,Default_Handler
+  .weak DCMIPP_IRQHandler
+  .thumb_set DCMIPP_IRQHandler,Default_Handler
 
-	.weak	HPDMA1_Channel15_IRQHandler
-	.thumb_set HPDMA1_Channel15_IRQHandler,Default_Handler
+  .weak DMA1_Stream0_IRQHandler
+  .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel0_IRQHandler
-	.thumb_set GPDMA1_Channel0_IRQHandler,Default_Handler
+  .weak DMA1_Stream1_IRQHandler
+  .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel1_IRQHandler
-	.thumb_set GPDMA1_Channel1_IRQHandler,Default_Handler
+  .weak DMA1_Stream2_IRQHandler
+  .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel2_IRQHandler
-	.thumb_set GPDMA1_Channel2_IRQHandler,Default_Handler
+  .weak DMA1_Stream3_IRQHandler
+  .thumb_set DMA1_Stream3_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel3_IRQHandler
-	.thumb_set GPDMA1_Channel3_IRQHandler,Default_Handler
+  .weak DMA1_Stream4_IRQHandler
+  .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel4_IRQHandler
-	.thumb_set GPDMA1_Channel4_IRQHandler,Default_Handler
+  .weak DMA1_Stream5_IRQHandler
+  .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel5_IRQHandler
-	.thumb_set GPDMA1_Channel5_IRQHandler,Default_Handler
+  .weak DMA1_Stream6_IRQHandler
+  .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel6_IRQHandler
-	.thumb_set GPDMA1_Channel6_IRQHandler,Default_Handler
+  .weak DMA1_Stream7_IRQHandler
+  .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel7_IRQHandler
-	.thumb_set GPDMA1_Channel7_IRQHandler,Default_Handler
+  .weak DMA1_Stream8_IRQHandler
+  .thumb_set DMA1_Stream8_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel8_IRQHandler
-	.thumb_set GPDMA1_Channel8_IRQHandler,Default_Handler
+  .weak DMA1_Stream9_IRQHandler
+  .thumb_set DMA1_Stream9_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel9_IRQHandler
-	.thumb_set GPDMA1_Channel9_IRQHandler,Default_Handler
+  .weak DMA1_Stream10_IRQHandler
+  .thumb_set DMA1_Stream10_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel10_IRQHandler
-	.thumb_set GPDMA1_Channel10_IRQHandler,Default_Handler
+  .weak DMA1_Stream11_IRQHandler
+  .thumb_set DMA1_Stream11_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel11_IRQHandler
-	.thumb_set GPDMA1_Channel11_IRQHandler,Default_Handler
+  .weak DMA1_Stream12_IRQHandler
+  .thumb_set DMA1_Stream12_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel12_IRQHandler
-	.thumb_set GPDMA1_Channel12_IRQHandler,Default_Handler
+  .weak DMA1_Stream13_IRQHandler
+  .thumb_set DMA1_Stream13_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel13_IRQHandler
-	.thumb_set GPDMA1_Channel13_IRQHandler,Default_Handler
+  .weak DMA1_Stream14_IRQHandler
+  .thumb_set DMA1_Stream14_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel14_IRQHandler
-	.thumb_set GPDMA1_Channel14_IRQHandler,Default_Handler
+  .weak DMA1_Stream15_IRQHandler
+  .thumb_set DMA1_Stream15_IRQHandler,Default_Handler
 
-	.weak	GPDMA1_Channel15_IRQHandler
-	.thumb_set GPDMA1_Channel15_IRQHandler,Default_Handler
+  .weak GPDMA1_IRQHandler
+  .thumb_set GPDMA1_IRQHandler,Default_Handler
 
-	.weak	I2C1_EV_IRQHandler
-	.thumb_set I2C1_EV_IRQHandler,Default_Handler
+  .weak FDCAN1_IT0_IRQHandler
+  .thumb_set FDCAN1_IT0_IRQHandler,Default_Handler
 
-	.weak	I2C1_ER_IRQHandler
-	.thumb_set I2C1_ER_IRQHandler,Default_Handler
+  .weak FDCAN1_IT1_IRQHandler
+  .thumb_set FDCAN1_IT1_IRQHandler,Default_Handler
 
-	.weak	I2C2_EV_IRQHandler
-	.thumb_set I2C2_EV_IRQHandler,Default_Handler
+  .weak FDCAN2_IT0_IRQHandler
+  .thumb_set FDCAN2_IT0_IRQHandler,Default_Handler
 
-	.weak	I2C2_ER_IRQHandler
-	.thumb_set I2C2_ER_IRQHandler,Default_Handler
+  .weak FDCAN2_IT1_IRQHandler
+  .thumb_set FDCAN2_IT1_IRQHandler,Default_Handler
 
-	.weak	I2C3_EV_IRQHandler
-	.thumb_set I2C3_EV_IRQHandler,Default_Handler
+  .weak LPTIM3_IRQHandler
+  .thumb_set LPTIM3_IRQHandler,Default_Handler
 
-	.weak	I2C3_ER_IRQHandler
-	.thumb_set I2C3_ER_IRQHandler,Default_Handler
+  .weak LPTIM4_IRQHandler
+  .thumb_set LPTIM4_IRQHandler,Default_Handler
 
-	.weak	I2C4_EV_IRQHandler
-	.thumb_set I2C4_EV_IRQHandler,Default_Handler
+  .weak LPTIM5_IRQHandler
+  .thumb_set LPTIM5_IRQHandler,Default_Handler
 
-	.weak	I2C4_ER_IRQHandler
-	.thumb_set I2C4_ER_IRQHandler,Default_Handler
+  .weak MDIOS_IRQHandler
+  .thumb_set MDIOS_IRQHandler,Default_Handler
 
-	.weak	I3C1_EV_IRQHandler
-	.thumb_set I3C1_EV_IRQHandler,Default_Handler
+  .weak ETH1_SBD_IRQHandler
+  .thumb_set ETH1_SBD_IRQHandler,Default_Handler
 
-	.weak	I3C1_ER_IRQHandler
-	.thumb_set I3C1_ER_IRQHandler,Default_Handler
+  .weak GPU2D_IRQHandler
+  .thumb_set GPU2D_IRQHandler,Default_Handler
 
-	.weak	I3C2_EV_IRQHandler
-	.thumb_set I3C2_EV_IRQHandler,Default_Handler
+  .weak GPU2D_ER_IRQHandler
+  .thumb_set GPU2D_ER_IRQHandler,Default_Handler
 
-	.weak	I3C2_ER_IRQHandler
-	.thumb_set I3C2_ER_IRQHandler,Default_Handler
+  .weak XSPI1_IRQHandler
+  .thumb_set XSPI1_IRQHandler,Default_Handler
 
-	.weak	TIM1_BRK_IRQHandler
-	.thumb_set TIM1_BRK_IRQHandler,Default_Handler
+  .weak XSPI2_IRQHandler
+  .thumb_set XSPI2_IRQHandler,Default_Handler
 
-	.weak	TIM1_UP_IRQHandler
-	.thumb_set TIM1_UP_IRQHandler,Default_Handler
-
-	.weak	TIM1_TRG_CCU_IRQHandler
-	.thumb_set TIM1_TRG_CCU_IRQHandler,Default_Handler
-
-	.weak	TIM1_CC_IRQHandler
-	.thumb_set TIM1_CC_IRQHandler,Default_Handler
-
-	.weak	TIM2_IRQHandler
-	.thumb_set TIM2_IRQHandler,Default_Handler
-
-	.weak	TIM3_IRQHandler
-	.thumb_set TIM3_IRQHandler,Default_Handler
-
-	.weak	TIM4_IRQHandler
-	.thumb_set TIM4_IRQHandler,Default_Handler
-
-	.weak	TIM5_IRQHandler
-	.thumb_set TIM5_IRQHandler,Default_Handler
-
-	.weak	TIM6_IRQHandler
-	.thumb_set TIM6_IRQHandler,Default_Handler
-
-	.weak	TIM7_IRQHandler
-	.thumb_set TIM7_IRQHandler,Default_Handler
-
-	.weak	TIM8_BRK_IRQHandler
-	.thumb_set TIM8_BRK_IRQHandler,Default_Handler
-
-	.weak	TIM8_UP_IRQHandler
-	.thumb_set TIM8_UP_IRQHandler,Default_Handler
-
-	.weak	TIM8_TRG_CCU_IRQHandler
-	.thumb_set TIM8_TRG_CCU_IRQHandler,Default_Handler
-
-	.weak	TIM8_CC_IRQHandler
-	.thumb_set TIM8_CC_IRQHandler,Default_Handler
-
-	.weak	TIM9_IRQHandler
-	.thumb_set TIM9_IRQHandler,Default_Handler
-
-	.weak	TIM10_IRQHandler
-	.thumb_set TIM10_IRQHandler,Default_Handler
-
-	.weak	TIM11_IRQHandler
-	.thumb_set TIM11_IRQHandler,Default_Handler
-
-	.weak	TIM12_IRQHandler
-	.thumb_set TIM12_IRQHandler,Default_Handler
-
-	.weak	TIM13_IRQHandler
-	.thumb_set TIM13_IRQHandler,Default_Handler
-
-	.weak	TIM14_IRQHandler
-	.thumb_set TIM14_IRQHandler,Default_Handler
-
-	.weak	TIM15_IRQHandler
-	.thumb_set TIM15_IRQHandler,Default_Handler
-
-	.weak	TIM16_IRQHandler
-	.thumb_set TIM16_IRQHandler,Default_Handler
-
-	.weak	TIM17_IRQHandler
-	.thumb_set TIM17_IRQHandler,Default_Handler
-
-	.weak	TIM18_IRQHandler
-	.thumb_set TIM18_IRQHandler,Default_Handler
-
-	.weak	LPTIM1_IRQHandler
-	.thumb_set LPTIM1_IRQHandler,Default_Handler
-
-	.weak	LPTIM2_IRQHandler
-	.thumb_set LPTIM2_IRQHandler,Default_Handler
-
-	.weak	LPTIM3_IRQHandler
-	.thumb_set LPTIM3_IRQHandler,Default_Handler
-
-	.weak	LPTIM4_IRQHandler
-	.thumb_set LPTIM4_IRQHandler,Default_Handler
-
-	.weak	LPTIM5_IRQHandler
-	.thumb_set LPTIM5_IRQHandler,Default_Handler
-
-	.weak	ADF1_FLT0_IRQHandler
-	.thumb_set ADF1_FLT0_IRQHandler,Default_Handler
-
-	.weak	MDF1_FLT0_IRQHandler
-	.thumb_set MDF1_FLT0_IRQHandler,Default_Handler
-
-	.weak	MDF1_FLT1_IRQHandler
-	.thumb_set MDF1_FLT1_IRQHandler,Default_Handler
-
-	.weak	MDF1_FLT2_IRQHandler
-	.thumb_set MDF1_FLT2_IRQHandler,Default_Handler
-
-	.weak	MDF1_FLT3_IRQHandler
-	.thumb_set MDF1_FLT3_IRQHandler,Default_Handler
-
-	.weak	MDF1_FLT4_IRQHandler
-	.thumb_set MDF1_FLT4_IRQHandler,Default_Handler
-
-	.weak	MDF1_FLT5_IRQHandler
-	.thumb_set MDF1_FLT5_IRQHandler,Default_Handler
-
-	.weak	SAI1_A_IRQHandler
-	.thumb_set SAI1_A_IRQHandler,Default_Handler
-
-	.weak	SAI1_B_IRQHandler
-	.thumb_set SAI1_B_IRQHandler,Default_Handler
-
-	.weak	SAI2_A_IRQHandler
-	.thumb_set SAI2_A_IRQHandler,Default_Handler
-
-	.weak	SAI2_B_IRQHandler
-	.thumb_set SAI2_B_IRQHandler,Default_Handler
-
-	.weak	SPDIFRX_IRQHandler
-	.thumb_set SPDIFRX_IRQHandler,Default_Handler
-
-	.weak	SPI1_IRQHandler
-	.thumb_set SPI1_IRQHandler,Default_Handler
-
-	.weak	SPI2_IRQHandler
-	.thumb_set SPI2_IRQHandler,Default_Handler
-
-	.weak	SPI3_IRQHandler
-	.thumb_set SPI3_IRQHandler,Default_Handler
-
-	.weak	SPI4_IRQHandler
-	.thumb_set SPI4_IRQHandler,Default_Handler
-
-	.weak	SPI5_IRQHandler
-	.thumb_set SPI5_IRQHandler,Default_Handler
-
-	.weak	SPI6_IRQHandler
-	.thumb_set SPI6_IRQHandler,Default_Handler
-
-	.weak	USART1_IRQHandler
-	.thumb_set USART1_IRQHandler,Default_Handler
-
-	.weak	USART2_IRQHandler
-	.thumb_set USART2_IRQHandler,Default_Handler
-
-	.weak	USART3_IRQHandler
-	.thumb_set USART3_IRQHandler,Default_Handler
-
-	.weak	UART4_IRQHandler
-	.thumb_set UART4_IRQHandler,Default_Handler
-
-	.weak	UART5_IRQHandler
-	.thumb_set UART5_IRQHandler,Default_Handler
-
-	.weak	USART6_IRQHandler
-	.thumb_set USART6_IRQHandler,Default_Handler
-
-	.weak	UART7_IRQHandler
-	.thumb_set UART7_IRQHandler,Default_Handler
-
-	.weak	UART8_IRQHandler
-	.thumb_set UART8_IRQHandler,Default_Handler
-
-	.weak	UART9_IRQHandler
-	.thumb_set UART9_IRQHandler,Default_Handler
-
-	.weak	USART10_IRQHandler
-	.thumb_set USART10_IRQHandler,Default_Handler
-
-	.weak	LPUART1_IRQHandler
-	.thumb_set LPUART1_IRQHandler,Default_Handler
-
-	.weak	XSPI1_IRQHandler
-	.thumb_set XSPI1_IRQHandler,Default_Handler
-
-	.weak	XSPI2_IRQHandler
-	.thumb_set XSPI2_IRQHandler,Default_Handler
-
-	.weak	XSPI3_IRQHandler
-	.thumb_set XSPI3_IRQHandler,Default_Handler
-
-	.weak	FMC_IRQHandler
-	.thumb_set FMC_IRQHandler,Default_Handler
-
-	.weak	SDMMC1_IRQHandler
-	.thumb_set SDMMC1_IRQHandler,Default_Handler
-
-	.weak	SDMMC2_IRQHandler
-	.thumb_set SDMMC2_IRQHandler,Default_Handler
-
-	.weak	UCPD1_IRQHandler
-	.thumb_set UCPD1_IRQHandler,Default_Handler
-
-	.weak	USB1_OTG_HS_IRQHandler
-	.thumb_set USB1_OTG_HS_IRQHandler,Default_Handler
-
-	.weak	USB2_OTG_HS_IRQHandler
-	.thumb_set USB2_OTG_HS_IRQHandler,Default_Handler
-
-	.weak	ETH1_IRQHandler
-	.thumb_set ETH1_IRQHandler,Default_Handler
-
-	.weak	FDCAN1_IT0_IRQHandler
-	.thumb_set FDCAN1_IT0_IRQHandler,Default_Handler
-
-	.weak	FDCAN1_IT1_IRQHandler
-	.thumb_set FDCAN1_IT1_IRQHandler,Default_Handler
-
-	.weak	FDCAN2_IT0_IRQHandler
-	.thumb_set FDCAN2_IT0_IRQHandler,Default_Handler
-
-	.weak	FDCAN2_IT1_IRQHandler
-	.thumb_set FDCAN2_IT1_IRQHandler,Default_Handler
-
-	.weak	FDCAN3_IT0_IRQHandler
-	.thumb_set FDCAN3_IT0_IRQHandler,Default_Handler
-
-	.weak	FDCAN3_IT1_IRQHandler
-	.thumb_set FDCAN3_IT1_IRQHandler,Default_Handler
-
-	.weak	FDCAN_CU_IRQHandler
-	.thumb_set FDCAN_CU_IRQHandler,Default_Handler
-
-	.weak	MDIOS_IRQHandler
-	.thumb_set MDIOS_IRQHandler,Default_Handler
-
-	.weak	DCMI_PSSI_IRQHandler
-	.thumb_set DCMI_PSSI_IRQHandler,Default_Handler
-
-	.weak	WAKEUP_PIN_IRQHandler
-	.thumb_set WAKEUP_PIN_IRQHandler,Default_Handler
-
-	.weak	CTI_INT0_IRQHandler
-	.thumb_set CTI_INT0_IRQHandler,Default_Handler
-
-	.weak	CTI_INT1_IRQHandler
-	.thumb_set CTI_INT1_IRQHandler,Default_Handler
-
-	.weak	LTDC_UP_IRQHandler
-	.thumb_set LTDC_UP_IRQHandler,Default_Handler
-
-	.weak	LTDC_UP_ERR_IRQHandler
-	.thumb_set LTDC_UP_ERR_IRQHandler,Default_Handler
-
-	.weak	SystemInit
-
-/************************ (C) COPYRIGHT STMicroelectonics *****END OF FILE****/
+  .weak XSPI3_IRQHandler
+  .thumb_set XSPI3_IRQHandler,Default_Handler

--- a/src/platform/STM32/system_stm32n6xx.c
+++ b/src/platform/STM32/system_stm32n6xx.c
@@ -53,13 +53,25 @@ bool isMPUSoftReset(void)
         return false;
 }
 
+static bool memoryMappedModeEnabledOnBoot = false;
+
 bool isMemoryMappedModeEnabledOnBoot(void)
 {
-    return false;
+    return memoryMappedModeEnabledOnBoot;
+}
+
+void memoryMappedModeInit(void)
+{
+#ifdef USE_OCTOSPI
+    // XSPI2 is memory-mapped at 0x70000000 for boot flash
+    memoryMappedModeEnabledOnBoot = READ_BIT(XSPI2->CR, XSPI_CR_FMODE) == XSPI_CR_FMODE;
+#endif
 }
 
 void systemInit(void)
 {
+    memoryMappedModeInit();
+
     // Configure NVIC preempt/priority groups
     HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITY_GROUPING);
 

--- a/src/platform/STM32/system_stm32n6xx.c
+++ b/src/platform/STM32/system_stm32n6xx.c
@@ -62,9 +62,9 @@ bool isMemoryMappedModeEnabledOnBoot(void)
 
 void memoryMappedModeInit(void)
 {
-#ifdef USE_OCTOSPI
-    // XSPI2 is memory-mapped at 0x70000000 for boot flash
-    memoryMappedModeEnabledOnBoot = READ_BIT(XSPI2->CR, XSPI_CR_FMODE) == XSPI_CR_FMODE;
+#if defined(USE_OCTOSPI) && defined(FLASH_OCTOSPI_INSTANCE)
+    // Boot flash XSPI peripheral is memory-mapped at 0x70000000 by the bootloader
+    memoryMappedModeEnabledOnBoot = READ_BIT(FLASH_OCTOSPI_INSTANCE->CR, XSPI_CR_FMODE) == XSPI_CR_FMODE;
 #endif
 }
 

--- a/src/platform/STM32/system_stm32n6xx.c
+++ b/src/platform/STM32/system_stm32n6xx.c
@@ -86,6 +86,11 @@ void systemInit(void)
     SET_BIT(RCC->MEMENSR, RCC_MEMENR_AXISRAM5EN);
     SET_BIT(RCC->MEMENSR, RCC_MEMENR_AXISRAM6EN);
 
+    // Copy .fastram_data, .dmaram_data, etc. from flash to RAM.
+    // On other platforms this runs from SystemInit (assembly startup), but the
+    // N6 LRUN bootstrap only copies the main _stext.._etext range.
+    initialiseMemorySections();
+
     // Init cycle counter
     cycleCounterInit();
 

--- a/src/platform/STM32/target/STM32N657/target.h
+++ b/src/platform/STM32/target/STM32N657/target.h
@@ -62,9 +62,17 @@
 #define TARGET_IO_PORTP     0xffff
 #define TARGET_IO_PORTQ     0xffff
 
+// XSPI2 is used for boot flash at 0x70000000
+#define USE_OCTOSPI
+#define USE_OCTOSPI_DEVICE_1
+#define USE_FLASH_MEMORY_MAPPED
+#define USE_FLASH_W25Q128FV
+#define USE_FLASH_CHIP
+#define FLASH_OCTOSPI_INSTANCE  XSPI2
+
 // Provide a default so that this target builds on the build server.
-#if !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD) && !defined(CONFIG_IN_EXTERNAL_FLASH)
-#define CONFIG_IN_RAM
+#if !defined(CONFIG_IN_RAM) && !defined(CONFIG_IN_SDCARD) && !defined(CONFIG_IN_EXTERNAL_FLASH) && !defined(CONFIG_IN_MEMORY_MAPPED_FLASH)
+#define CONFIG_IN_MEMORY_MAPPED_FLASH
 #endif
 #define EEPROM_SIZE     5120
 


### PR DESCRIPTION
## Summary
- Add XSPI driver for STM32N6 (`bus_octospi_stm32n6xx.c`) implementing the octoSpi API via the XSPI2 peripheral
- Enable persistent config storage on external XSPI boot flash (`CONFIG_IN_MEMORY_MAPPED_FLASH`)
- Implement full Load-and-Run (LRUN): all firmware code copied from XSPI flash to internal SRAM at boot for execution at full RAM speed
- Make `octoSpiDeviceByInstance()` generic (uses hardware table instead of hardcoded `OCTOSPI1`)
- Add memory-mapped mode detection in `system_stm32n6xx.c`
- RAM usage: 66% (692KB / 1024KB AXISRAM1), leaving 332KB headroom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External OctoSPI support for STM32N6 with indirect transmit/receive APIs and memory-mapped control (enable/disable).
  * Boot-time detection of memory-mapped flash.

* **Chores**
  * Execute-from-RAM boot: firmware executes from RAM while preserving flash load addresses.
  * Device selection moved to runtime lookup instead of compile-time mapping.
  * Linker/startup and vector table updated to support RAM execution from external flash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->