### PR TITLE
gps rescue with position hold during climb phase

### DIFF
--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -819,7 +819,7 @@ void gpsRescueUpdate(void)
             gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
             gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
         } else {
-            resetPositionControl(POSHOLD_TASK_RATE_HZ);
+            resetPositionControl(TASK_GPS_RESCUE_RATE_HZ);
         }
         break;
 

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -815,11 +815,9 @@ void gpsRescueUpdate(void)
         // give velocity P and I no error that otherwise could be present due to velocity drift at the start of the rescue
         rescueState.intent.targetVelocityCmS = rescueState.sensor.velocityToHomeCmS;
         if (positionEstimatorIsValidXY()){
-            positionControl();
+            positionControl(); //only for this phase
             gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
             gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
-        } else {
-            resetPositionControl(TASK_GPS_RESCUE_RATE_HZ);
         }
         break;
 

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -211,6 +211,16 @@ static void rescueAttainPosition(bool newGpsData)
         rescueState.intent.disarmThreshold = gpsRescueConfig()->disarmThreshold * 0.1f;
         rescueState.sensor.imuYawCogGain = 1.0f;
         return;
+    case RESCUE_ATTAIN_ALT:
+        // Altitude-Control wird weiter unten (wie früher) ausgeführt.
+        // Hier machen wir nur die Positionsregelung und überspringen danach Yaw + Velocity.
+        if (positionEstimatorIsValidXY()) {
+            positionControl();                    // echte X/Y-Hold während des Steigens
+            gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
+            gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
+        }
+        // Wenn kein valider Position Estimator vorhanden ist → normales altes Verhalten
+        break;
     case RESCUE_DO_NOTHING:
         // 20s of hover for switch induced sanity failures to allow time to recover
         gpsRescueAngle[AI_PITCH] = 0.0f;
@@ -814,11 +824,6 @@ void gpsRescueUpdate(void)
 
         // give velocity P and I no error that otherwise could be present due to velocity drift at the start of the rescue
         rescueState.intent.targetVelocityCmS = rescueState.sensor.velocityToHomeCmS;
-        if (positionEstimatorIsValidXY()){
-            positionControl(); //only for this phase
-            gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
-            gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
-        }
         break;
 
     case RESCUE_ROTATE:

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -211,16 +211,6 @@ static void rescueAttainPosition(bool newGpsData)
         rescueState.intent.disarmThreshold = gpsRescueConfig()->disarmThreshold * 0.1f;
         rescueState.sensor.imuYawCogGain = 1.0f;
         return;
-    case RESCUE_ATTAIN_ALT:
-        // Altitude-Control wird weiter unten (wie früher) ausgeführt.
-        // Hier machen wir nur die Positionsregelung und überspringen danach Yaw + Velocity.
-        if (positionEstimatorIsValidXY()) {
-            positionControl();                    // echte X/Y-Hold während des Steigens
-            gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
-            gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
-        }
-        // Wenn kein valider Position Estimator vorhanden ist → normales altes Verhalten
-        break;
     case RESCUE_DO_NOTHING:
         // 20s of hover for switch induced sanity failures to allow time to recover
         gpsRescueAngle[AI_PITCH] = 0.0f;
@@ -340,6 +330,13 @@ static void rescueAttainPosition(bool newGpsData)
 
     gpsRescueAngle[AI_PITCH] = pitchAdjustmentFiltered;
     // this angle gets added to the normal pitch Angle Mode control values in pid.c - will be seen in pitch setpoint
+
+    if (rescueState.phase == RESCUE_ATTAIN_ALT && positionEstimatorIsValidXY()) {
+            // Wir nutzen den internen Autopiloten, um die X/Y Koordinaten "festzunageln"
+            positionControl(); 
+            gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
+            gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
+        }
 
     DEBUG_SET(DEBUG_GPS_RESCUE_VELOCITY, 3, lrintf(rescueState.intent.targetVelocityCmS)); // target velocity to home
     DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 1, lrintf(rescueState.intent.targetVelocityCmS)); // target velocity to home

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -784,7 +784,7 @@ void gpsRescueUpdate(void)
                 // otherwise behave as for a normal rescue
                 initialiseRescueValues ();
                 returnAltitudeLow = getAltitudeCmControl() < rescueState.intent.returnAltitudeCm;
-                if (positionEstimatorIsValidXY())
+                if (positionEstimatorIsValidXY()){
                     resetPositionControl(TASK_GPS_RESCUE_RATE_HZ);
                 }
                 rescueState.phase = RESCUE_ATTAIN_ALT;
@@ -814,12 +814,11 @@ void gpsRescueUpdate(void)
 
         // give velocity P and I no error that otherwise could be present due to velocity drift at the start of the rescue
         rescueState.intent.targetVelocityCmS = rescueState.sensor.velocityToHomeCmS;
-        if (positionEstimatorIsValidXY())
+        if (positionEstimatorIsValidXY()){
             positionControl();
             gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
             gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
         } else {
-            // Work like bevor without position hold
             resetPositionControl(POSHOLD_TASK_RATE_HZ);
         }
         break;

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -784,6 +784,9 @@ void gpsRescueUpdate(void)
                 // otherwise behave as for a normal rescue
                 initialiseRescueValues ();
                 returnAltitudeLow = getAltitudeCmControl() < rescueState.intent.returnAltitudeCm;
+                if (positionEstimatorIsValidXY())
+                    resetPositionControl(TASK_GPS_RESCUE_RATE_HZ);
+                }
                 rescueState.phase = RESCUE_ATTAIN_ALT;
             }
         }
@@ -811,6 +814,14 @@ void gpsRescueUpdate(void)
 
         // give velocity P and I no error that otherwise could be present due to velocity drift at the start of the rescue
         rescueState.intent.targetVelocityCmS = rescueState.sensor.velocityToHomeCmS;
+        if (positionEstimatorIsValidXY())
+            positionControl();
+            gpsRescueAngle[AI_PITCH] = autopilotAngle[AI_PITCH];
+            gpsRescueAngle[AI_ROLL]  = autopilotAngle[AI_ROLL];
+        } else {
+            // Work like bevor without position hold
+            resetPositionControl(POSHOLD_TASK_RATE_HZ);
+        }
         break;
 
     case RESCUE_ROTATE:


### PR DESCRIPTION
gps_rescue: add sensor-gated position hold during initialize and climb phase

Only enable positionControl() when position estimator reports valid XY data.
Previously, position hold was always executed during RESCUE_ATTAIN_ALT,
even if the estimator became invalid after initialization.

This change:
- Adds continuous sensorsOk() checks in RESCUE_ATTAIN_ALT
- Gates positionControl() execution on estimator validity
- Resets position control when sensor data becomes invalid
- Improves safety by preventing position hold with invalid XY estimate during rescue climb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS‑rescue reliability by requiring valid position estimates before enabling position‑hold during initialization and altitude attainment.
  * Position‑hold/control now only engages when position sensing is validated; if invalid, position control is reset to preserve previous safe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->