### PR TITLE
Expand chirp debug channels for offline system identification

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1208,9 +1208,15 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
     // input / excitation shaping
     float chirpFiltered  = phaseCompApply(&pidRuntime.chirpFilter, chirp);
 
-    // ToDo: check if this can be reconstructed offline for rotating filter and if so, remove the debug
-    // fit (0...2*pi) into int16_t (-32768 to 32767)
+    // debug channels for offline system identification / autotune analysis
+    // 0: sinarg phase (0…2π scaled to ±32k) — enables offline chirp signal reconstruction
+    // 1: active chirp axis (0 = roll, 1 = pitch, 2 = yaw, -1 = inactive)
+    // 2: instantaneous chirp frequency in deci-Hz — maps time to frequency for spectral analysis
+    // 3: raw chirp excitation × 1000 (before phase comp filter) — reference signal for cross-correlation
     DEBUG_SET(DEBUG_CHIRP, 0, lrintf(5.0e3f * sinarg));
+    DEBUG_SET(DEBUG_CHIRP, 1, FLIGHT_MODE(CHIRP_MODE) ? chirpAxis : -1);
+    DEBUG_SET(DEBUG_CHIRP, 2, lrintf(10.0f * pidRuntime.chirp.fchirp));
+    DEBUG_SET(DEBUG_CHIRP, 3, lrintf(1.0e3f * chirp));
 
 #endif // USE_CHIRP
 


### PR DESCRIPTION
## Summary

- Populates the 3 unused `DEBUG_CHIRP` slots with data needed by the Betaflight App to perform frequency response analysis from blackbox logs
- Enables app-based autotune: fly a chirp, land, import the log, and the app can compute a Bode plot and recommend PID gains

### Debug channels

| Slot | Value | Units | Purpose |
|------|-------|-------|---------|
| `debug[0]` | `sinarg × 5000` | - | Phase reference (unchanged) |
| `debug[1]` | chirp axis | 0/1/2 or -1 | Identifies roll/pitch/yaw, -1 when inactive |
| `debug[2]` | `fchirp × 10` | deci-Hz | Instantaneous chirp frequency |
| `debug[3]` | `chirp × 1000` | - | Raw excitation before phase-comp filter |

With `debug_mode = CHIRP` and blackbox logging enabled, a post-flight analysis tool can:

1. Detect chirp segments via `debug[1]` (axis ≥ 0)
2. Use `debug[3]` as the clean input reference signal
3. Use `setpoint[axis]` (includes chirp) and `gyroADC[axis]` (system response) to compute the closed-loop transfer function via FFT
4. Use `debug[2]` to map each sample to its corresponding frequency without re-deriving chirp timing
5. Extract the plant from the closed-loop using the known PID gains in the blackbox header
6. Compute recommended PID gains targeting desired bandwidth and phase margin

### What this does NOT change

- No new flight modes, parameters, or runtime behavior
- Zero additional CPU cost (DEBUG_SET is compiled out when debug mode is not CHIRP)
- No RAM impact
- Chirp signal generation and injection are unchanged

## Test plan

- [x] Builds cleanly on STM32F405 and STM32H743
- [x] All unit tests pass
- [x] Verify debug values in Betaflight App debug tab with `debug_mode = CHIRP`
- [x] Confirm blackbox log contains all 4 debug channels during chirp flight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced diagnostic output for the chirp feature, now providing real-time data including phase-derived samples, active axis information, frequency values, and excitation measurements for better visibility into flight controller behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->