### PR TITLE
feat: add CAN peripheral support for STM32G4, STM32H7 and STM32C593 (ENABLE_CAN)

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -9,6 +9,7 @@ PG_SRC = \
             pg/bus_i2c.c \
             pg/bus_quadspi.c \
             pg/bus_spi.c \
+            pg/can.c \
             pg/dashboard.c \
             pg/displayport_profiles.c \
             pg/dyn_notch.c \

--- a/src/main/drivers/can/can.h
+++ b/src/main/drivers/can/can.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/can/can_types.h"
+#include "drivers/io_types.h"
+
+typedef enum {
+    CANINVALID = -1,
+    CANDEV_1 = 0,
+    CANDEV_2,
+    CANDEV_3,
+    CANDEV_COUNT
+} canDevice_e;
+
+// Macros to convert between CLI device number (1-based) and canDevice_e (0-based).
+#define CAN_CFG_TO_DEV(x)   ((x) - 1)
+#define CAN_DEV_TO_CFG(x)   ((x) + 1)
+
+// Maximum payload length for a Classic CAN frame.
+#define CAN_CLASSIC_MAX_DLC 8
+
+// Callback invoked from interrupt context when a message is received.
+//  identifier  - 11-bit (standard) or 29-bit (extended) message identifier
+//  isExtended  - true if the identifier is 29-bit
+//  data        - pointer to message payload (valid only during the callback)
+//  length      - payload length in bytes (0..8 for classic CAN)
+typedef void (*canRxCallbackPtr)(uint32_t identifier, bool isExtended,
+                                 const uint8_t *data, uint8_t length);
+
+// Initialise the given CAN device. Returns false if the device has no
+// hardware resources configured or the peripheral failed to start.
+bool canInit(canDevice_e device);
+
+// Transmit a classic CAN frame. Returns true if the frame was queued,
+// false if the TX FIFO is full, the device is uninitialised, or the
+// parameters are invalid.
+bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
+                 const uint8_t *data, uint8_t length);
+
+// Register a callback for received messages on the given device.
+// Passing NULL removes the callback. Only one callback per device is
+// supported; registering a new callback replaces any previous one.
+void canRegisterRxCallback(canDevice_e device, canRxCallbackPtr callback);

--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -65,6 +65,7 @@ typedef struct canDevice_s {
     uint8_t irq0;
     uint8_t irq1;
     canRxCallbackPtr rxCallback;
+    volatile uint32_t rxOverruns;   // FIFO 0 message-lost events (diagnostics)
     bool initialized;
 } canDevice_t;
 

--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#include "drivers/can/can.h"
+#include "drivers/can/can_types.h"
+#include "drivers/io_types.h"
+
+#if PLATFORM_TRAIT_RCC
+#include "platform/rcc_types.h"
+#endif
+
+// Maximum number of alternate pin options per TX/RX line.
+#define CAN_MAX_PIN_SEL 3
+
+typedef struct canPinDef_s {
+    ioTag_t pin;
+    uint8_t af;
+} canPinDef_t;
+
+typedef struct canHardware_s {
+    canDevice_e device;
+    canResource_t *reg;
+    canPinDef_t txPins[CAN_MAX_PIN_SEL];
+    canPinDef_t rxPins[CAN_MAX_PIN_SEL];
+#if PLATFORM_TRAIT_RCC
+    rccPeriphTag_t rcc;
+#endif
+    uint8_t irq0;                   // FDCANx_IT0_IRQn
+    uint8_t irq1;                   // FDCANx_IT1_IRQn
+} canHardware_t;
+
+extern const canHardware_t canHardware[CANDEV_COUNT];
+
+typedef struct canDevice_s {
+    canResource_t *reg;
+    ioTag_t tx;
+    ioTag_t rx;
+    uint8_t txAF;
+    uint8_t rxAF;
+#if PLATFORM_TRAIT_RCC
+    rccPeriphTag_t rcc;
+#endif
+    uint8_t irq0;
+    uint8_t irq1;
+    canRxCallbackPtr rxCallback;
+    bool initialized;
+} canDevice_t;
+
+extern canDevice_t canDevice[CANDEV_COUNT];
+
+// Internal: shared init routine implemented per-platform in can_hw.c.
+void canInitDevice(canDevice_e device);
+
+// Internal: ISR dispatch helper invoked from named FDCANx IRQ handlers.
+void canIrqHandler(canDevice_e device);
+
+// Configure the device pin assignments from the PG config. Called from fc/init.c
+// before canInit().
+struct canPinConfig_s;
+void canPinConfigure(const struct canPinConfig_s *pConfig);

--- a/src/main/drivers/can/can_types.h
+++ b/src/main/drivers/can/can_types.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// canResource_t is an opaque data type which represents an FDCAN
+// peripheral, implemented differently across MCU families.
+// Code in src/main references CAN peripherals through canResource_t pointers;
+// platform code casts these to the native MCU type (e.g. FDCAN_GlobalTypeDef*).
+typedef struct canResource_s canResource_t;

--- a/src/main/drivers/nvic.h
+++ b/src/main/drivers/nvic.h
@@ -77,3 +77,4 @@
 #define NVIC_PRIO_USB_WUP                  NVIC_BUILD_PRIORITY(1, 0)
 #define NVIC_PRIO_SPI_DMA                  NVIC_BUILD_PRIORITY(0, 0)
 #define NVIC_PRIO_SDIO_DMA                 NVIC_BUILD_PRIORITY(0, 0)
+#define NVIC_PRIO_CAN                      NVIC_BUILD_PRIORITY(1, 2)

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -121,6 +121,8 @@ static const char * const ownerNames[] = {
     "GYRO_CLKIN",
     [OWNER_PIOUART_TX] = "PIOUART_TX",
     [OWNER_PIOUART_RX] = "PIOUART_RX",
+    [OWNER_CAN_TX] = "CAN_TX",
+    [OWNER_CAN_RX] = "CAN_RX",
     // Keep in sync with resourceOwner_e.
 };
 

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -117,6 +117,8 @@ typedef enum {
     OWNER_GYRO_CLKIN,
     OWNER_PIOUART_TX,            // TX must be just before RX
     OWNER_PIOUART_RX,
+    OWNER_CAN_TX,                // TX must be just before RX
+    OWNER_CAN_RX,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -676,11 +676,11 @@ void initPhase3(void)
 #endif
 #endif // USE_I2C
 
-#if ENABLE_CAN
+#endif // TARGET_BUS_INIT
+
+#if ENABLE_CAN && !defined(TARGET_BUS_INIT)
     configureCANBusses();
 #endif
-
-#endif // TARGET_BUS_INIT
 
 #ifdef USE_HARDWARE_REVISION_DETECTION
     updateHardwareRevision();

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -51,6 +51,8 @@
 #include "drivers/bus_quadspi.h"
 #include "drivers/bus_spi.h"
 #include "drivers/buttons.h"
+#include "drivers/can/can.h"
+#include "drivers/can/can_impl.h"
 #include "drivers/camera_control.h"
 #include "drivers/compass/compass.h"
 #include "drivers/dma.h"
@@ -147,6 +149,7 @@
 #include "pg/bus_i2c.h"
 #include "pg/bus_spi.h"
 #include "pg/bus_quadspi.h"
+#include "pg/can.h"
 #include "pg/flash.h"
 #include "pg/mco.h"
 #include "pg/motor.h"
@@ -263,6 +266,16 @@ static void configureOctoSPIBusses(void)
 #endif
 #endif
 }
+
+#if ENABLE_CAN
+static void configureCANBusses(void)
+{
+    canPinConfigure(canPinConfig(0));
+    canInit(CANDEV_1);
+    canInit(CANDEV_2);
+    canInit(CANDEV_3);
+}
+#endif
 
 #ifdef USE_SDCARD
 static void sdCardAndFSInit(void)
@@ -662,6 +675,10 @@ void initPhase3(void)
     i2cInit(I2CDEV_4);
 #endif
 #endif // USE_I2C
+
+#if ENABLE_CAN
+    configureCANBusses();
+#endif
 
 #endif // TARGET_BUS_INIT
 

--- a/src/main/pg/can.c
+++ b/src/main/pg/can.c
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_CAN
+
+#include "drivers/io.h"
+
+#include "pg/can.h"
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+
+#ifndef CAN1_TX_PIN
+#define CAN1_TX_PIN NONE
+#define CAN1_RX_PIN NONE
+#endif
+
+#ifndef CAN2_TX_PIN
+#define CAN2_TX_PIN NONE
+#define CAN2_RX_PIN NONE
+#endif
+
+#ifndef CAN3_TX_PIN
+#define CAN3_TX_PIN NONE
+#define CAN3_RX_PIN NONE
+#endif
+
+typedef struct canDefaultConfig_s {
+    canDevice_e device;
+    ioTag_t tx;
+    ioTag_t rx;
+} canDefaultConfig_t;
+
+static const canDefaultConfig_t canDefaultConfig[] = {
+    { CANDEV_1, IO_TAG(CAN1_TX_PIN), IO_TAG(CAN1_RX_PIN) },
+    { CANDEV_2, IO_TAG(CAN2_TX_PIN), IO_TAG(CAN2_RX_PIN) },
+    { CANDEV_3, IO_TAG(CAN3_TX_PIN), IO_TAG(CAN3_RX_PIN) },
+};
+
+PG_REGISTER_ARRAY_WITH_RESET_FN(canPinConfig_t, CANDEV_COUNT, canPinConfig, PG_CAN_PIN_CONFIG, 0);
+
+void pgResetFn_canPinConfig(canPinConfig_t *config)
+{
+    for (size_t i = 0; i < ARRAYLEN(canDefaultConfig); i++) {
+        const canDefaultConfig_t *defconf = &canDefaultConfig[i];
+        config[defconf->device].ioTagTx = defconf->tx;
+        config[defconf->device].ioTagRx = defconf->rx;
+    }
+}
+
+#endif // ENABLE_CAN

--- a/src/main/pg/can.c
+++ b/src/main/pg/can.c
@@ -29,18 +29,26 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
+// Default each pin macro independently so a target that defines only TX
+// (or only RX) still compiles — missing pins fall back to NONE.
 #ifndef CAN1_TX_PIN
 #define CAN1_TX_PIN NONE
+#endif
+#ifndef CAN1_RX_PIN
 #define CAN1_RX_PIN NONE
 #endif
 
 #ifndef CAN2_TX_PIN
 #define CAN2_TX_PIN NONE
+#endif
+#ifndef CAN2_RX_PIN
 #define CAN2_RX_PIN NONE
 #endif
 
 #ifndef CAN3_TX_PIN
 #define CAN3_TX_PIN NONE
+#endif
+#ifndef CAN3_RX_PIN
 #define CAN3_RX_PIN NONE
 #endif
 

--- a/src/main/pg/can.h
+++ b/src/main/pg/can.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drivers/can/can.h"
+#include "drivers/io_types.h"
+
+#include "pg/pg.h"
+
+typedef struct canPinConfig_s {
+    ioTag_t ioTagTx;
+    ioTag_t ioTagRx;
+} canPinConfig_t;
+
+PG_DECLARE_ARRAY(canPinConfig_t, CANDEV_COUNT, canPinConfig);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -161,6 +161,7 @@
 #define PG_OPTICALFLOW_CONFIG       560
 #define PG_BATTERY_PROFILES         561
 #define PG_FLIGHT_PLAN_CONFIG       562
+#define PG_CAN_PIN_CONFIG           563
 
 
 // OSD configuration (subject to change)

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -765,3 +765,7 @@ extern struct linker_symbol __config_end;
 #elif !defined(ENABLE_FLIGHT_PLAN)
 #define ENABLE_FLIGHT_PLAN 0
 #endif
+
+#if !defined(ENABLE_CAN)
+#define ENABLE_CAN 0
+#endif

--- a/src/platform/STM32/can_stm32c5xx.c
+++ b/src/platform/STM32/can_stm32c5xx.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#if ENABLE_CAN
+
+#include "drivers/can/can.h"
+#include "drivers/can/can_impl.h"
+#include "drivers/io.h"
+#include "platform/rcc.h"
+
+// C5 FDCAN specifics:
+//  - C591 has no FDCAN peripheral; hardware-table rows only exist when a
+//    variant with FDCAN (e.g. C593) is selected.
+//  - Silicon exposes only FDCAN1 and FDCAN2. The CANDEV_3 row is emitted as
+//    a zero-initialised placeholder so the fixed-length canHardware[] array
+//    still has CANDEV_COUNT entries; canPinConfigure() skips rows whose reg
+//    pointer is NULL.
+//  - FDCAN clock-enable is on the APB1H bus (RCC_APB1HENR_FDCANEN), same
+//    layout as H5/H7. The encoded RCC_APB1H(FDCAN) macro handles it.
+//  - Pin AF values use the HAL2 naming (HAL_GPIO_AF9_FDCANx); the numeric
+//    value is still 9 as on G4/H7, but the symbol name is HAL_-prefixed on
+//    this SDK.
+//  - Pin options listed here are the silicon-advertised FDCAN TX/RX lines
+//    for C593 (AF9). An actual C593 target will be added in a separate PR;
+//    the pin list can be extended then as needed.
+const canHardware_t canHardware[CANDEV_COUNT] = {
+    {
+        .device = CANDEV_1,
+        .reg = (canResource_t *)FDCAN1,
+        .txPins = {
+            { DEFIO_TAG_E(PA12), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB9),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD1),  HAL_GPIO_AF9_FDCAN1 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PA11), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB8),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD0),  HAL_GPIO_AF9_FDCAN1 },
+        },
+        .rcc = RCC_APB1H(FDCAN),
+        .irq0 = FDCAN1_IT0_IRQn,
+        .irq1 = FDCAN1_IT1_IRQn,
+    },
+#if defined(FDCAN2)
+    {
+        .device = CANDEV_2,
+        .reg = (canResource_t *)FDCAN2,
+        .txPins = {
+            { DEFIO_TAG_E(PB6),  HAL_GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PB13), HAL_GPIO_AF9_FDCAN2 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PB5),  HAL_GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PB12), HAL_GPIO_AF9_FDCAN2 },
+        },
+        .rcc = RCC_APB1H(FDCAN),
+        .irq0 = FDCAN2_IT0_IRQn,
+        .irq1 = FDCAN2_IT1_IRQn,
+    },
+#else
+    { 0 },
+#endif
+    // C5 does not expose FDCAN3; leave CANDEV_3 row empty so the array
+    // index layout stays consistent with G4 / H7.
+    { 0 },
+};
+
+#endif // ENABLE_CAN

--- a/src/platform/STM32/can_stm32g4xx.c
+++ b/src/platform/STM32/can_stm32g4xx.c
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#if ENABLE_CAN
+
+#include "drivers/can/can.h"
+#include "drivers/can/can_impl.h"
+#include "drivers/io.h"
+#include "platform/rcc.h"
+
+// On G4 all FDCAN instances share a single RCC enable bit
+// (RCC_APB1ENR1_FDCANEN). RCC_ClockCmd() is idempotent when the same
+// peripheral is enabled multiple times, so storing the same tag on
+// each row is fine.
+const canHardware_t canHardware[CANDEV_COUNT] = {
+    {
+        .device = CANDEV_1,
+        .reg = (canResource_t *)FDCAN1,
+        .txPins = {
+            { DEFIO_TAG_E(PA12), GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB9),  GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD1),  GPIO_AF9_FDCAN1 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PA11), GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB8),  GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD0),  GPIO_AF9_FDCAN1 },
+        },
+        .rcc = RCC_APB11(FDCAN),
+        .irq0 = FDCAN1_IT0_IRQn,
+        .irq1 = FDCAN1_IT1_IRQn,
+    },
+    {
+        .device = CANDEV_2,
+        .reg = (canResource_t *)FDCAN2,
+        .txPins = {
+            { DEFIO_TAG_E(PB6),  GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PB13), GPIO_AF9_FDCAN2 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PB5),  GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PB12), GPIO_AF9_FDCAN2 },
+        },
+        .rcc = RCC_APB11(FDCAN),
+        .irq0 = FDCAN2_IT0_IRQn,
+        .irq1 = FDCAN2_IT1_IRQn,
+    },
+    {
+        .device = CANDEV_3,
+        .reg = (canResource_t *)FDCAN3,
+        .txPins = {
+            { DEFIO_TAG_E(PA15), GPIO_AF11_FDCAN3 },
+            { DEFIO_TAG_E(PB4),  GPIO_AF11_FDCAN3 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PA8),  GPIO_AF11_FDCAN3 },
+            { DEFIO_TAG_E(PB3),  GPIO_AF11_FDCAN3 },
+        },
+        .rcc = RCC_APB11(FDCAN),
+        .irq0 = FDCAN3_IT0_IRQn,
+        .irq1 = FDCAN3_IT1_IRQn,
+    },
+};
+
+#endif // ENABLE_CAN

--- a/src/platform/STM32/can_stm32h7xx.c
+++ b/src/platform/STM32/can_stm32h7xx.c
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#if ENABLE_CAN
+
+#include "drivers/can/can.h"
+#include "drivers/can/can_impl.h"
+#include "drivers/io.h"
+#include "platform/rcc.h"
+
+// H7 FDCAN specifics:
+//  - All instances share a single RCC enable bit (RCC_APB1HENR_FDCANEN),
+//    so RCC_APB1H(FDCAN) is stored on every row. The peripheral clock tree
+//    on H7 sources FDCAN from the dedicated FDCAN kernel clock (sel'd via
+//    RCC->D2CCIP1R.FDCANSEL) which is independent from the bus clock.
+//  - Only STM32H72x/H73x variants include FDCAN3; on H74x/H75x it is absent
+//    and the FDCAN3 row is skipped via #ifdef FDCAN3.
+const canHardware_t canHardware[CANDEV_COUNT] = {
+    {
+        .device = CANDEV_1,
+        .reg = (canResource_t *)FDCAN1,
+        .txPins = {
+            { DEFIO_TAG_E(PA12), GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB9),  GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD1),  GPIO_AF9_FDCAN1 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PA11), GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB8),  GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD0),  GPIO_AF9_FDCAN1 },
+        },
+        .rcc = RCC_APB1H(FDCAN),
+        .irq0 = FDCAN1_IT0_IRQn,
+        .irq1 = FDCAN1_IT1_IRQn,
+    },
+    {
+        .device = CANDEV_2,
+        .reg = (canResource_t *)FDCAN2,
+        .txPins = {
+            { DEFIO_TAG_E(PB6),  GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PB13), GPIO_AF9_FDCAN2 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PB5),  GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PB12), GPIO_AF9_FDCAN2 },
+        },
+        .rcc = RCC_APB1H(FDCAN),
+        .irq0 = FDCAN2_IT0_IRQn,
+        .irq1 = FDCAN2_IT1_IRQn,
+    },
+#if defined(FDCAN3)
+    {
+        .device = CANDEV_3,
+        .reg = (canResource_t *)FDCAN3,
+        .txPins = {
+            { DEFIO_TAG_E(PA15), GPIO_AF2_FDCAN3 },
+            { DEFIO_TAG_E(PD13), GPIO_AF2_FDCAN3 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PA8),  GPIO_AF2_FDCAN3 },
+            { DEFIO_TAG_E(PD12), GPIO_AF2_FDCAN3 },
+        },
+        .rcc = RCC_APB1H(FDCAN),
+        .irq0 = FDCAN3_IT0_IRQn,
+        .irq1 = FDCAN3_IT1_IRQn,
+    },
+#else
+    // Placeholder for H74x/H75x which lack FDCAN3. Empty reg field signals
+    // "not available" to canPinConfigure / canInit.
+    { 0 },
+#endif
+};
+
+#endif // ENABLE_CAN

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -308,7 +308,9 @@
 #define USE_RTC_TIME
 #define USE_PERSISTENT_MSC_RTC
 #define USE_LATE_TASK_STATISTICS
+#if !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
+#endif
 #endif
 
 #ifdef STM32G4
@@ -326,7 +328,9 @@
 #define USE_MCO_DEVICE1
 #define USE_DMA_SPEC
 #define USE_LATE_TASK_STATISTICS
+#if !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
+#endif
 #endif
 
 #ifdef STM32H5
@@ -348,7 +352,7 @@
 #define USE_PERSISTENT_OBJECTS
 #define USE_LATE_TASK_STATISTICS
 // C591 has no FDCAN hardware; enable CAN only on variants that do (e.g. C593).
-#if defined(STM32C593xx)
+#if defined(STM32C593xx) && !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
 #endif
 #endif

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -308,6 +308,7 @@
 #define USE_RTC_TIME
 #define USE_PERSISTENT_MSC_RTC
 #define USE_LATE_TASK_STATISTICS
+#define ENABLE_CAN 1
 #endif
 
 #ifdef STM32G4

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -325,6 +325,7 @@
 #define USE_MCO_DEVICE1
 #define USE_DMA_SPEC
 #define USE_LATE_TASK_STATISTICS
+#define ENABLE_CAN 1
 #endif
 
 #ifdef STM32H5

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -347,6 +347,10 @@
 #define USE_DMA_SPEC
 #define USE_PERSISTENT_OBJECTS
 #define USE_LATE_TASK_STATISTICS
+// C591 has no FDCAN hardware; enable CAN only on variants that do (e.g. C593).
+#if defined(STM32C593xx)
+#define ENABLE_CAN 1
+#endif
 #endif
 
 #ifdef STM32N6

--- a/src/platform/STM32/mk/STM32C5.mk
+++ b/src/platform/STM32/mk/STM32C5.mk
@@ -134,6 +134,7 @@ MCU_COMMON_SRC = \
             STM32/bus_spi_hal2.c \
             STM32/bus_i2c_ll.c \
             STM32/bus_i2c_ll_init.c \
+            STM32/can_stm32c5xx.c \
             drivers/bus_i2c_timing.c \
             STM32/serial_uart_ll.c \
             STM32/serial_uart_stm32c5xx.c \

--- a/src/platform/STM32/mk/STM32G4.mk
+++ b/src/platform/STM32/mk/STM32G4.mk
@@ -129,6 +129,7 @@ MCU_COMMON_SRC = \
             drivers/bus_quadspi.c \
             drivers/dshot_bitbang_decode.c \
             STM32/adc_stm32g4xx.c \
+            STM32/can_stm32g4xx.c \
             STM32/bus_i2c_ll_init.c \
             STM32/bus_i2c_ll.c \
             STM32/bus_spi_ll.c \

--- a/src/platform/STM32/mk/STM32H7.mk
+++ b/src/platform/STM32/mk/STM32H7.mk
@@ -296,6 +296,7 @@ MCU_COMMON_SRC = \
             STM32/bus_spi_ll.c \
             STM32/bus_quadspi_hal.c \
             STM32/bus_octospi_stm32h7xx.c \
+            STM32/can_stm32h7xx.c \
             STM32/debug.c \
             STM32/dma_reqmap_mcu.c \
             STM32/dma_stm32h7xx.c \

--- a/src/platform/STM32/mk/STM32_COMMON.mk
+++ b/src/platform/STM32/mk/STM32_COMMON.mk
@@ -5,6 +5,8 @@ MCU_COMMON_SRC += \
             common/stm32/system.c \
             common/stm32/config_flash.c \
             common/stm32/bus_spi_pinconfig.c \
+            common/stm32/can_hw.c \
+            common/stm32/can_pinconfig.c \
             common/stm32/mco.c \
             drivers/bus_spi_config.c \
             drivers/serial_pinconfig.c \
@@ -31,6 +33,7 @@ SIZE_OPTIMISED_SRC += \
             common/stm32/bus_i2c_pinconfig.c \
             common/stm32/config_flash.c \
             common/stm32/bus_spi_pinconfig.c \
+            common/stm32/can_pinconfig.c \
             common/stm32/pwm_output_beeper.c \
             common/stm32/serial_uart_pinconfig.c
 

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -1,0 +1,444 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if ENABLE_CAN
+
+#include "common/utils.h"
+
+#include "drivers/can/can.h"
+#include "drivers/can/can_impl.h"
+#include "drivers/io.h"
+#include "drivers/nvic.h"
+#include "drivers/resource.h"
+#include "platform/rcc.h"
+
+//-----------------------------------------------------------------------------
+// Message RAM layout (G4)
+//
+// The G4 has a single shared message RAM at SRAMCAN_BASE, divided into three
+// equal regions (one per FDCAN instance). Within each region the layout of
+// filters / FIFOs / buffers is fixed by hardware.
+//
+// The element counts below mirror the ones used by ST's HAL, so the fixed
+// offsets inside the region match what the FDCAN peripheral already uses.
+//-----------------------------------------------------------------------------
+
+#if defined(STM32G4)
+
+#define CAN_SRAM_FLS_NBR    (28U)
+#define CAN_SRAM_FLE_NBR    (8U)
+#define CAN_SRAM_RF0_NBR    (3U)
+#define CAN_SRAM_RF1_NBR    (3U)
+#define CAN_SRAM_TEF_NBR    (3U)
+#define CAN_SRAM_TFQ_NBR    (3U)
+
+#define CAN_SRAM_FLS_SIZE   (1U * 4U)       // standard filter element
+#define CAN_SRAM_FLE_SIZE   (2U * 4U)       // extended filter element
+#define CAN_SRAM_RF_SIZE    (18U * 4U)      // Rx FIFO element (header + 64B payload)
+#define CAN_SRAM_TEF_SIZE   (2U * 4U)       // Tx event FIFO element
+#define CAN_SRAM_TFQ_SIZE   (18U * 4U)      // Tx FIFO element
+
+#define CAN_SRAM_FLSSA      (0U)
+#define CAN_SRAM_FLESA      (CAN_SRAM_FLSSA + CAN_SRAM_FLS_NBR * CAN_SRAM_FLS_SIZE)
+#define CAN_SRAM_RF0SA      (CAN_SRAM_FLESA + CAN_SRAM_FLE_NBR * CAN_SRAM_FLE_SIZE)
+#define CAN_SRAM_RF1SA      (CAN_SRAM_RF0SA + CAN_SRAM_RF0_NBR * CAN_SRAM_RF_SIZE)
+#define CAN_SRAM_TEFSA      (CAN_SRAM_RF1SA + CAN_SRAM_RF1_NBR * CAN_SRAM_RF_SIZE)
+#define CAN_SRAM_TFQSA      (CAN_SRAM_TEFSA + CAN_SRAM_TEF_NBR * CAN_SRAM_TEF_SIZE)
+#define CAN_SRAM_PER_INSTANCE \
+                            (CAN_SRAM_TFQSA + CAN_SRAM_TFQ_NBR * CAN_SRAM_TFQ_SIZE)
+
+static uint32_t canMessageRamBase(canDevice_e device)
+{
+    // Each FDCAN instance owns a CAN_SRAM_PER_INSTANCE-sized region, laid out
+    // FDCAN1, FDCAN2, FDCAN3 in ascending address order from SRAMCAN_BASE.
+    return SRAMCAN_BASE + (uint32_t)device * CAN_SRAM_PER_INSTANCE;
+}
+
+#endif // STM32G4
+
+//-----------------------------------------------------------------------------
+// Bit timing for 1 Mbit/s classic CAN
+//
+// The FDCAN kernel clock on G4 is sourced from PCLK1 by default (170 MHz on
+// overclocked G474). The HAL default at reset maps FDCAN_CLK = HSE = 24 MHz on
+// typical FC boards; we assume the PCLK1 path here. Nominal bit time is
+// (1 + tseg1 + tseg2) prescaler-scaled tq. Choose tq = 8 -> divisor must be
+// (PCLK1 / 1M / 8). The config below works for the common 170/160 MHz and
+// 24 MHz clock options and errs toward sample-point ~ 75 %.
+//
+// A future pass should make this configurable via PG; for now it targets
+// a 24 MHz FDCAN kernel clock (common STM32G474 default when PLLQ isn't
+// routed to FDCAN).
+//-----------------------------------------------------------------------------
+
+// NBTP fields: NTSEG1=bits 8:15, NTSEG2=bits 0:6, NBRP=16:24, NSJW=25:31
+// For 1 Mbps with 24 MHz kernel clock: prescaler 1, tseg1 17, tseg2 6, sjw 1
+#define CAN_NBTP_NSJW_POS       (25U)
+#define CAN_NBTP_NBRP_POS       (16U)
+#define CAN_NBTP_NTSEG1_POS     (8U)
+#define CAN_NBTP_NTSEG2_POS     (0U)
+
+static uint32_t canNominalBitTiming(void)
+{
+    // prescaler - 1, tseg1 - 1, tseg2 - 1, sjw - 1
+    // 24 MHz / (1 * (1 + 17 + 6)) = 1 MHz
+    const uint32_t nbrp = 0;        // prescaler 1
+    const uint32_t ntseg1 = 16;     // tseg1 17
+    const uint32_t ntseg2 = 5;      // tseg2 6
+    const uint32_t nsjw = 0;        // sjw 1
+
+    return (nsjw << CAN_NBTP_NSJW_POS)
+         | (nbrp << CAN_NBTP_NBRP_POS)
+         | (ntseg1 << CAN_NBTP_NTSEG1_POS)
+         | (ntseg2 << CAN_NBTP_NTSEG2_POS);
+}
+
+//-----------------------------------------------------------------------------
+// Classic CAN frame header encoding for the Tx FIFO element (G4).
+//
+// Word 0: ID field.
+//  - Standard ID occupies bits 18..28 (11-bit ID shifted left by 18).
+//  - Extended ID occupies bits 0..28, with XTD (bit 30) set.
+// Word 1: DLC + flags (bits 16..19 = DLC, FDF = bit 21, BRS = bit 20).
+// Words 2..: payload, packed little-endian 4 bytes per word.
+//-----------------------------------------------------------------------------
+
+#define CAN_TX_WORD0_XTD        (1UL << 30)
+#define CAN_TX_WORD1_DLC_POS    (16U)
+
+// Rx header encoding (mirrors the Tx layout with additional filter info we ignore)
+#define CAN_RX_WORD0_XTD        (1UL << 30)
+#define CAN_RX_WORD0_EXTID_MASK (0x1FFFFFFFUL)
+#define CAN_RX_WORD0_STDID_POS  (18U)
+#define CAN_RX_WORD0_STDID_MASK (0x7FFUL << CAN_RX_WORD0_STDID_POS)
+#define CAN_RX_WORD1_DLC_POS    (16U)
+#define CAN_RX_WORD1_DLC_MASK   (0xFUL << CAN_RX_WORD1_DLC_POS)
+
+//-----------------------------------------------------------------------------
+// Low-level helpers (register level)
+//-----------------------------------------------------------------------------
+
+static FDCAN_GlobalTypeDef *canRegs(canDevice_e device)
+{
+    return (FDCAN_GlobalTypeDef *)canDevice[device].reg;
+}
+
+// Enter INIT + CCE (configuration change enable). Required for any change to
+// bit timing or message RAM layout. Busy-loops until the peripheral reports
+// that INIT has taken effect.
+static bool canEnterConfigMode(FDCAN_GlobalTypeDef *regs)
+{
+    regs->CCCR |= FDCAN_CCCR_INIT;
+
+    // Peripheral synchronises to the bus before asserting INIT. Give it a
+    // bounded number of polls so a disconnected transceiver does not hang us.
+    uint32_t timeout = 100000;
+    while (!(regs->CCCR & FDCAN_CCCR_INIT) && timeout--) {
+        // spin
+    }
+    if (!(regs->CCCR & FDCAN_CCCR_INIT)) {
+        return false;
+    }
+
+    regs->CCCR |= FDCAN_CCCR_CCE;
+    return true;
+}
+
+static void canExitConfigMode(FDCAN_GlobalTypeDef *regs)
+{
+    regs->CCCR &= ~FDCAN_CCCR_INIT;
+}
+
+// Clear out the whole per-instance message RAM region. A cold peripheral
+// contains indeterminate SRAM contents; sending garbage would be reported as
+// a spurious message.
+static void canClearMessageRam(uint32_t base)
+{
+#if defined(STM32G4)
+    for (uint32_t addr = base; addr < base + CAN_SRAM_PER_INSTANCE; addr += 4) {
+        *(volatile uint32_t *)addr = 0;
+    }
+#else
+    UNUSED(base);
+#endif
+}
+
+static void canEnableInterrupt(canDevice_e device, uint8_t irq)
+{
+    UNUSED(device);
+#if defined(USE_HAL_DRIVER)
+    HAL_NVIC_SetPriority(irq, NVIC_PRIORITY_BASE(NVIC_PRIO_CAN),
+                         NVIC_PRIORITY_SUB(NVIC_PRIO_CAN));
+    HAL_NVIC_EnableIRQ(irq);
+#else
+    NVIC_SetPriority(irq, NVIC_PRIO_CAN);
+    NVIC_EnableIRQ(irq);
+#endif
+}
+
+//-----------------------------------------------------------------------------
+// Init / public API
+//-----------------------------------------------------------------------------
+
+void canInitDevice(canDevice_e device)
+{
+    if (device < 0 || device >= CANDEV_COUNT) {
+        return;
+    }
+
+    canDevice_t *pDev = &canDevice[device];
+
+    if (!pDev->reg || !pDev->tx || !pDev->rx) {
+        return;
+    }
+
+    FDCAN_GlobalTypeDef *regs = (FDCAN_GlobalTypeDef *)pDev->reg;
+
+    // Kernel clock first; register writes before this have undefined effect.
+    RCC_ClockCmd(pDev->rcc, ENABLE);
+
+    // Claim the pins. IOInit's resource-owner records let the CLI `resource`
+    // command surface pin conflicts against existing drivers.
+    IO_t txIO = IOGetByTag(pDev->tx);
+    IO_t rxIO = IOGetByTag(pDev->rx);
+
+    IOInit(txIO, OWNER_CAN_TX, RESOURCE_INDEX(device));
+    IOInit(rxIO, OWNER_CAN_RX, RESOURCE_INDEX(device));
+
+    // TX is a push-pull alternate; RX needs a pull-up so the line idles
+    // recessive when no transceiver is connected (prevents spurious dominant
+    // readings during initialisation).
+    IOConfigGPIOAF(txIO, IOCFG_AF_PP, pDev->txAF);
+    IOConfigGPIOAF(rxIO, IOCFG_AF_PP_UP, pDev->rxAF);
+
+    if (!canEnterConfigMode(regs)) {
+        // Peripheral did not latch INIT; nothing more we can do safely.
+        return;
+    }
+
+    // Classic CAN: clear the FD-enable and bit-rate-switch bits. Everything
+    // else in CCCR can be left at reset (normal mode, no monitoring).
+    regs->CCCR &= ~((1UL << 8) | (1UL << 9));    // clear FDOE (8) and BRSE (9)
+
+    // Nominal bit timing. Data bit timing (DBTP) is not needed for classic CAN.
+    regs->NBTP = canNominalBitTiming();
+
+#if defined(STM32G4)
+    // Accept-non-matching policy: route everything to Rx FIFO 0 (fields 00b
+    // in ANFS / ANFE). No filter list entries are installed in this first
+    // cut, which is fine because the accept-non-match path handles everything.
+    regs->RXGFC &= ~(FDCAN_RXGFC_ANFS | FDCAN_RXGFC_ANFE);
+
+    // Wipe the per-instance message RAM region.
+    canClearMessageRam(canMessageRamBase(device));
+#endif
+
+    // Enable RX FIFO 0 new-message interrupt, route it to IRQ line 0, and
+    // arm the peripheral side of IRQ line 0.
+    regs->IE  |= FDCAN_IE_RF0NE;
+    regs->ILS &= ~(1UL << 3);                 // RF0N -> line 0
+    regs->ILE |= FDCAN_ILE_EINT0;
+
+    canEnableInterrupt(device, pDev->irq0);
+
+    canExitConfigMode(regs);
+
+    pDev->initialized = true;
+}
+
+bool canInit(canDevice_e device)
+{
+    if (device < 0 || device >= CANDEV_COUNT) {
+        return false;
+    }
+
+    canInitDevice(device);
+    return canDevice[device].initialized;
+}
+
+void canRegisterRxCallback(canDevice_e device, canRxCallbackPtr callback)
+{
+    if (device < 0 || device >= CANDEV_COUNT) {
+        return;
+    }
+
+    canDevice[device].rxCallback = callback;
+}
+
+bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
+                 const uint8_t *data, uint8_t length)
+{
+    if (device < 0 || device >= CANDEV_COUNT) {
+        return false;
+    }
+
+    canDevice_t *pDev = &canDevice[device];
+    if (!pDev->initialized || length > CAN_CLASSIC_MAX_DLC) {
+        return false;
+    }
+
+    FDCAN_GlobalTypeDef *regs = canRegs(device);
+
+    // Bail early if the hardware FIFO is full. The caller decides whether to
+    // retry or drop; we don't block so the ISR-side callers stay non-blocking.
+    uint32_t txfqs = regs->TXFQS;
+    if (txfqs & FDCAN_TXFQS_TFQF) {
+        return false;
+    }
+
+#if defined(STM32G4)
+    // Put index tells us which slot in the Tx FIFO the next message belongs
+    // in. The peripheral manages the ring; software just fills the slot and
+    // sets the corresponding TXBAR bit.
+    uint32_t putIndex = (txfqs & FDCAN_TXFQS_TFQPI) >> 16;
+    uint32_t base = canMessageRamBase(device) + CAN_SRAM_TFQSA
+                    + putIndex * CAN_SRAM_TFQ_SIZE;
+
+    volatile uint32_t *slot = (volatile uint32_t *)base;
+
+    // Word 0: identifier with XTD flag if extended.
+    if (isExtended) {
+        slot[0] = CAN_TX_WORD0_XTD | (identifier & 0x1FFFFFFFUL);
+    } else {
+        slot[0] = (identifier & 0x7FFUL) << 18;
+    }
+
+    // Word 1: length only (no BRS/FDF -> classic CAN frame).
+    slot[1] = (uint32_t)length << CAN_TX_WORD1_DLC_POS;
+
+    // Words 2+: copy the payload in 32-bit chunks, handling any trailing
+    // 1..3 bytes by masking. The Tx RAM requires 32-bit writes.
+    uint32_t words[2] = { 0, 0 };
+    for (uint8_t i = 0; i < length; i++) {
+        words[i >> 2] |= ((uint32_t)data[i]) << ((i & 3U) * 8U);
+    }
+    slot[2] = words[0];
+    slot[3] = words[1];
+
+    // Trigger transmission of this slot.
+    regs->TXBAR = 1UL << putIndex;
+#else
+    UNUSED(identifier);
+    UNUSED(isExtended);
+    UNUSED(data);
+    UNUSED(length);
+#endif
+
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+// ISR dispatch
+//-----------------------------------------------------------------------------
+
+static void canDispatchRx(canDevice_e device)
+{
+    canDevice_t *pDev = &canDevice[device];
+    FDCAN_GlobalTypeDef *regs = canRegs(device);
+
+    // Drain the FIFO. F0FL = fill level; looping until it hits zero guarantees
+    // we handle multiple arrivals that may have accumulated before the ISR ran.
+    while (regs->RXF0S & FDCAN_RXF0S_F0FL) {
+        uint32_t getIndex = (regs->RXF0S & FDCAN_RXF0S_F0GI) >> 8;
+
+#if defined(STM32G4)
+        uint32_t base = canMessageRamBase(device) + CAN_SRAM_RF0SA
+                        + getIndex * CAN_SRAM_RF_SIZE;
+        volatile const uint32_t *slot = (volatile const uint32_t *)base;
+
+        uint32_t w0 = slot[0];
+        uint32_t w1 = slot[1];
+
+        bool isExtended = (w0 & CAN_RX_WORD0_XTD) != 0;
+        uint32_t identifier = isExtended
+            ? (w0 & CAN_RX_WORD0_EXTID_MASK)
+            : ((w0 & CAN_RX_WORD0_STDID_MASK) >> CAN_RX_WORD0_STDID_POS);
+
+        uint8_t dlc = (w1 & CAN_RX_WORD1_DLC_MASK) >> CAN_RX_WORD1_DLC_POS;
+        if (dlc > CAN_CLASSIC_MAX_DLC) {
+            dlc = CAN_CLASSIC_MAX_DLC;        // classic CAN safety clamp
+        }
+
+        uint8_t payload[CAN_CLASSIC_MAX_DLC];
+        uint32_t w2 = slot[2];
+        uint32_t w3 = slot[3];
+        for (uint8_t i = 0; i < dlc; i++) {
+            uint32_t word = (i < 4) ? w2 : w3;
+            payload[i] = (uint8_t)(word >> ((i & 3U) * 8U));
+        }
+#else
+        uint32_t identifier = 0;
+        bool isExtended = false;
+        uint8_t dlc = 0;
+        uint8_t payload[CAN_CLASSIC_MAX_DLC] = { 0 };
+#endif
+
+        // Ack the slot so the peripheral can recycle it for the next message.
+        // Must be done before invoking the callback in case the callback is
+        // slow; pending messages can still queue in other slots.
+        regs->RXF0A = getIndex;
+
+        if (pDev->rxCallback) {
+            pDev->rxCallback(identifier, isExtended, payload, dlc);
+        }
+    }
+}
+
+void canIrqHandler(canDevice_e device)
+{
+    FDCAN_GlobalTypeDef *regs = canRegs(device);
+
+    uint32_t ir = regs->IR;
+
+    if (ir & FDCAN_IR_RF0N) {
+        regs->IR = FDCAN_IR_RF0N;             // write-1-to-clear
+        canDispatchRx(device);
+    }
+}
+
+// Strong definitions of the FDCAN IRQ handlers (weak stubs in startup *.s).
+// These only exist when CAN is compiled in; otherwise the linker keeps the
+// weak Default_Handler stubs.
+
+void FDCAN1_IT0_IRQHandler(void)
+{
+    canIrqHandler(CANDEV_1);
+}
+
+void FDCAN2_IT0_IRQHandler(void)
+{
+    canIrqHandler(CANDEV_2);
+}
+
+#if defined(STM32G4)
+void FDCAN3_IT0_IRQHandler(void)
+{
+    canIrqHandler(CANDEV_3);
+}
+#endif
+
+#endif // ENABLE_CAN

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -39,15 +39,15 @@
 //-----------------------------------------------------------------------------
 // Message RAM layout
 //
-// Both G4 and H7 expose the same Bosch M_CAN IP and share a dedicated
-// Message RAM (CAN SRAM) at SRAMCAN_BASE. The significant difference is
-// *who* picks the layout:
+// All currently supported families (G4, H7, C5) expose the same Bosch M_CAN
+// IP and share a dedicated Message RAM (CAN SRAM) at SRAMCAN_BASE. The
+// significant difference is *who* picks the layout:
 //
-//   - G4: layout is fixed by silicon. Each FDCAN instance owns a region of
-//     SRAMCAN_SIZE bytes at SRAMCAN_BASE + N*SRAMCAN_SIZE; the sub-ranges
-//     (filters, FIFOs, Tx buffers) are at hardwired offsets within the
-//     region. We only have to match the HAL's assumed element counts and
-//     sizes when addressing the RAM.
+//   - G4 and C5: layout is fixed by silicon. Each FDCAN instance owns a
+//     region of SRAMCAN_SIZE bytes at SRAMCAN_BASE + N*SRAMCAN_SIZE; the
+//     sub-ranges (filters, FIFOs, Tx buffers) are at hardwired offsets
+//     within the region. We only have to match the SDK's assumed element
+//     counts and sizes when addressing the RAM.
 //
 //   - H7: layout is software-defined. We partition the shared RAM and
 //     program the start-address / element-count / element-size into each
@@ -65,12 +65,13 @@
 //   word 2: data[0..3]
 //   word 3: data[4..7]
 //
-// On G4 the hardware reserves 18 words per element (enough for FD 64-byte
-// payloads); we just leave words 4..17 unused. On H7 we select element size
-// code 0b000 = 8-byte data which gives a natural 4-word element.
+// On G4/C5 the hardware reserves 18 words per element (enough for FD
+// 64-byte payloads); we just leave words 4..17 unused. On H7 we select
+// element size code 0b000 = 8-byte data which gives a natural 4-word
+// element.
 //-----------------------------------------------------------------------------
 
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32C5)
 
 // Element counts mirror ST's HAL private constants so the fixed offsets we
 // compute below match the silicon layout.
@@ -124,11 +125,11 @@
 
 #endif
 
-// Per-instance base address of Message RAM. On both families the regions
-// are laid out contiguously from SRAMCAN_BASE in device-index order.
+// Per-instance base address of Message RAM. On all supported families the
+// regions are laid out contiguously from SRAMCAN_BASE in device-index order.
 static uint32_t canMessageRamBase(canDevice_e device)
 {
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32C5)
     return SRAMCAN_BASE + (uint32_t)device * CAN_SRAM_PER_INSTANCE;
 #elif defined(STM32H7)
     return SRAMCAN_BASE + (uint32_t)device * CAN_H7_PER_INSTANCE_WORDS * 4U;
@@ -140,7 +141,7 @@ static uint32_t canMessageRamBase(canDevice_e device)
 
 static uint32_t canRxElementAddress(canDevice_e device, uint32_t index)
 {
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32C5)
     return canMessageRamBase(device) + CAN_SRAM_RF0SA + index * CAN_SRAM_RF_SIZE;
 #elif defined(STM32H7)
     return canMessageRamBase(device)
@@ -154,7 +155,7 @@ static uint32_t canRxElementAddress(canDevice_e device, uint32_t index)
 
 static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
 {
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32C5)
     return canMessageRamBase(device) + CAN_SRAM_TFQSA + index * CAN_SRAM_TFQ_SIZE;
 #elif defined(STM32H7)
     return canMessageRamBase(device)
@@ -258,7 +259,7 @@ static void canClearMessageRam(canDevice_e device)
 {
     uint32_t base = canMessageRamBase(device);
 
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32C5)
     uint32_t bytes = CAN_SRAM_PER_INSTANCE;
 #elif defined(STM32H7)
     uint32_t bytes = CAN_H7_PER_INSTANCE_WORDS * 4U;
@@ -371,7 +372,7 @@ void canInitDevice(canDevice_e device)
     // Wipe the per-instance message RAM region to remove any prior contents.
     canClearMessageRam(device);
 
-#if defined(STM32G4)
+#if defined(STM32G4) || defined(STM32C5)
     // Accept-non-matching policy: route everything to Rx FIFO 0 (fields 00b
     // in ANFS / ANFE). The Message RAM layout itself is fixed by silicon.
     regs->RXGFC &= ~(FDCAN_RXGFC_ANFS | FDCAN_RXGFC_ANFE);

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -37,18 +37,43 @@
 #include "platform/rcc.h"
 
 //-----------------------------------------------------------------------------
-// Message RAM layout (G4)
+// Message RAM layout
 //
-// The G4 has a single shared message RAM at SRAMCAN_BASE, divided into three
-// equal regions (one per FDCAN instance). Within each region the layout of
-// filters / FIFOs / buffers is fixed by hardware.
+// Both G4 and H7 expose the same Bosch M_CAN IP and share a dedicated
+// Message RAM (CAN SRAM) at SRAMCAN_BASE. The significant difference is
+// *who* picks the layout:
 //
-// The element counts below mirror the ones used by ST's HAL, so the fixed
-// offsets inside the region match what the FDCAN peripheral already uses.
+//   - G4: layout is fixed by silicon. Each FDCAN instance owns a region of
+//     SRAMCAN_SIZE bytes at SRAMCAN_BASE + N*SRAMCAN_SIZE; the sub-ranges
+//     (filters, FIFOs, Tx buffers) are at hardwired offsets within the
+//     region. We only have to match the HAL's assumed element counts and
+//     sizes when addressing the RAM.
+//
+//   - H7: layout is software-defined. We partition the shared RAM and
+//     program the start-address / element-count / element-size into each
+//     instance's SIDFC/XIDFC/RXF0C/RXF1C/RXBC/TXEFC/TXBC and RXESC/TXESC
+//     registers. The driver hands out a fixed-size slice to each instance
+//     using a per-instance word offset; within each slice we only use
+//     Rx FIFO 0 and the Tx FIFO, and pick the smallest element size
+//     (8-byte data) since this driver currently targets classic CAN.
+//
+// To keep the Tx / Rx element access paths identical across families, both
+// configurations use a 4-word slot layout:
+//
+//   word 0: identifier + XTD flag
+//   word 1: DLC (+ classic CAN flags, zero for now)
+//   word 2: data[0..3]
+//   word 3: data[4..7]
+//
+// On G4 the hardware reserves 18 words per element (enough for FD 64-byte
+// payloads); we just leave words 4..17 unused. On H7 we select element size
+// code 0b000 = 8-byte data which gives a natural 4-word element.
 //-----------------------------------------------------------------------------
 
 #if defined(STM32G4)
 
+// Element counts mirror ST's HAL private constants so the fixed offsets we
+// compute below match the silicon layout.
 #define CAN_SRAM_FLS_NBR    (28U)
 #define CAN_SRAM_FLE_NBR    (8U)
 #define CAN_SRAM_RF0_NBR    (3U)
@@ -56,11 +81,11 @@
 #define CAN_SRAM_TEF_NBR    (3U)
 #define CAN_SRAM_TFQ_NBR    (3U)
 
-#define CAN_SRAM_FLS_SIZE   (1U * 4U)       // standard filter element
-#define CAN_SRAM_FLE_SIZE   (2U * 4U)       // extended filter element
-#define CAN_SRAM_RF_SIZE    (18U * 4U)      // Rx FIFO element (header + 64B payload)
-#define CAN_SRAM_TEF_SIZE   (2U * 4U)       // Tx event FIFO element
-#define CAN_SRAM_TFQ_SIZE   (18U * 4U)      // Tx FIFO element
+#define CAN_SRAM_FLS_SIZE   (1U * 4U)           // standard filter element
+#define CAN_SRAM_FLE_SIZE   (2U * 4U)           // extended filter element
+#define CAN_SRAM_RF_SIZE    (18U * 4U)          // Rx FIFO element (header + 64B)
+#define CAN_SRAM_TEF_SIZE   (2U * 4U)           // Tx event FIFO element
+#define CAN_SRAM_TFQ_SIZE   (18U * 4U)          // Tx FIFO element
 
 #define CAN_SRAM_FLSSA      (0U)
 #define CAN_SRAM_FLESA      (CAN_SRAM_FLSSA + CAN_SRAM_FLS_NBR * CAN_SRAM_FLS_SIZE)
@@ -71,32 +96,87 @@
 #define CAN_SRAM_PER_INSTANCE \
                             (CAN_SRAM_TFQSA + CAN_SRAM_TFQ_NBR * CAN_SRAM_TFQ_SIZE)
 
+#define CAN_RX_ELEMENT_BYTES    CAN_SRAM_RF_SIZE
+#define CAN_TX_ELEMENT_BYTES    CAN_SRAM_TFQ_SIZE
+
+#elif defined(STM32H7)
+
+// H7 layout (software-defined). Values are in *elements* or *bytes* as noted.
+// Per-instance RAM reservation in WORDS (1 word = 4 bytes):
+//  - 3 Rx FIFO 0 slots × 4 words = 12 words
+//  - 3 Tx FIFO slots  × 4 words = 12 words
+//  Round to a fixed 64-word (256-byte) slice per instance to leave head-room
+//  for future additions (extra FIFOs, filters). Total usage with 3 instances
+//  is 192 words / 768 bytes out of the 10 KiB of shared Message RAM.
+#define CAN_H7_RF0_NBR              (3U)
+#define CAN_H7_TFQ_NBR              (3U)
+#define CAN_H7_ELEMENT_WORDS        (4U)        // 2 hdr + 8-byte data
+#define CAN_H7_PER_INSTANCE_WORDS   (64U)
+#define CAN_H7_RF0_WORD_OFFSET      (0U)
+#define CAN_H7_TFQ_WORD_OFFSET      (CAN_H7_RF0_WORD_OFFSET + \
+                                     CAN_H7_RF0_NBR * CAN_H7_ELEMENT_WORDS)
+
+// Element-size code 0b000 = 8-byte data field (classic CAN).
+#define CAN_H7_ESC_CODE_8B          (0U)
+
+#define CAN_RX_ELEMENT_BYTES        (CAN_H7_ELEMENT_WORDS * 4U)
+#define CAN_TX_ELEMENT_BYTES        (CAN_H7_ELEMENT_WORDS * 4U)
+
+#endif
+
+// Per-instance base address of Message RAM. On both families the regions
+// are laid out contiguously from SRAMCAN_BASE in device-index order.
 static uint32_t canMessageRamBase(canDevice_e device)
 {
-    // Each FDCAN instance owns a CAN_SRAM_PER_INSTANCE-sized region, laid out
-    // FDCAN1, FDCAN2, FDCAN3 in ascending address order from SRAMCAN_BASE.
+#if defined(STM32G4)
     return SRAMCAN_BASE + (uint32_t)device * CAN_SRAM_PER_INSTANCE;
+#elif defined(STM32H7)
+    return SRAMCAN_BASE + (uint32_t)device * CAN_H7_PER_INSTANCE_WORDS * 4U;
+#else
+    UNUSED(device);
+    return 0;
+#endif
 }
 
-#endif // STM32G4
+static uint32_t canRxElementAddress(canDevice_e device, uint32_t index)
+{
+#if defined(STM32G4)
+    return canMessageRamBase(device) + CAN_SRAM_RF0SA + index * CAN_SRAM_RF_SIZE;
+#elif defined(STM32H7)
+    return canMessageRamBase(device)
+         + CAN_H7_RF0_WORD_OFFSET * 4U
+         + index * CAN_RX_ELEMENT_BYTES;
+#else
+    UNUSED(device); UNUSED(index);
+    return 0;
+#endif
+}
+
+static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
+{
+#if defined(STM32G4)
+    return canMessageRamBase(device) + CAN_SRAM_TFQSA + index * CAN_SRAM_TFQ_SIZE;
+#elif defined(STM32H7)
+    return canMessageRamBase(device)
+         + CAN_H7_TFQ_WORD_OFFSET * 4U
+         + index * CAN_TX_ELEMENT_BYTES;
+#else
+    UNUSED(device); UNUSED(index);
+    return 0;
+#endif
+}
 
 //-----------------------------------------------------------------------------
 // Bit timing for 1 Mbit/s classic CAN
 //
-// The FDCAN kernel clock on G4 is sourced from PCLK1 by default (170 MHz on
-// overclocked G474). The HAL default at reset maps FDCAN_CLK = HSE = 24 MHz on
-// typical FC boards; we assume the PCLK1 path here. Nominal bit time is
-// (1 + tseg1 + tseg2) prescaler-scaled tq. Choose tq = 8 -> divisor must be
-// (PCLK1 / 1M / 8). The config below works for the common 170/160 MHz and
-// 24 MHz clock options and errs toward sample-point ~ 75 %.
-//
-// A future pass should make this configurable via PG; for now it targets
-// a 24 MHz FDCAN kernel clock (common STM32G474 default when PLLQ isn't
-// routed to FDCAN).
+// The FDCAN kernel clock tree differs per family. On G4 the default kernel
+// clock routing produces 24 MHz on many FC boards; on H7 the FDCAN_CLK is
+// selected via RCC->D2CCIP1R.FDCANSEL and typically also lands at around
+// 24 MHz on boards that haven't explicitly tuned it. The current constants
+// target that 24 MHz case; a future pass should make bit timing a PG value.
 //-----------------------------------------------------------------------------
 
 // NBTP fields: NTSEG1=bits 8:15, NTSEG2=bits 0:6, NBRP=16:24, NSJW=25:31
-// For 1 Mbps with 24 MHz kernel clock: prescaler 1, tseg1 17, tseg2 6, sjw 1
 #define CAN_NBTP_NSJW_POS       (25U)
 #define CAN_NBTP_NBRP_POS       (16U)
 #define CAN_NBTP_NTSEG1_POS     (8U)
@@ -104,8 +184,7 @@ static uint32_t canMessageRamBase(canDevice_e device)
 
 static uint32_t canNominalBitTiming(void)
 {
-    // prescaler - 1, tseg1 - 1, tseg2 - 1, sjw - 1
-    // 24 MHz / (1 * (1 + 17 + 6)) = 1 MHz
+    // 24 MHz / (1 * (1 + 17 + 6)) = 1 MHz (sample point ~75 %)
     const uint32_t nbrp = 0;        // prescaler 1
     const uint32_t ntseg1 = 16;     // tseg1 17
     const uint32_t ntseg2 = 5;      // tseg2 6
@@ -118,7 +197,7 @@ static uint32_t canNominalBitTiming(void)
 }
 
 //-----------------------------------------------------------------------------
-// Classic CAN frame header encoding for the Tx FIFO element (G4).
+// Tx/Rx element header encoding (identical across G4 and H7 M_CAN IP)
 //
 // Word 0: ID field.
 //  - Standard ID occupies bits 18..28 (11-bit ID shifted left by 18).
@@ -130,7 +209,6 @@ static uint32_t canNominalBitTiming(void)
 #define CAN_TX_WORD0_XTD        (1UL << 30)
 #define CAN_TX_WORD1_DLC_POS    (16U)
 
-// Rx header encoding (mirrors the Tx layout with additional filter info we ignore)
 #define CAN_RX_WORD0_XTD        (1UL << 30)
 #define CAN_RX_WORD0_EXTID_MASK (0x1FFFFFFFUL)
 #define CAN_RX_WORD0_STDID_POS  (18U)
@@ -173,18 +251,24 @@ static void canExitConfigMode(FDCAN_GlobalTypeDef *regs)
     regs->CCCR &= ~FDCAN_CCCR_INIT;
 }
 
-// Clear out the whole per-instance message RAM region. A cold peripheral
-// contains indeterminate SRAM contents; sending garbage would be reported as
-// a spurious message.
-static void canClearMessageRam(uint32_t base)
+// Clear out the per-instance message RAM region. A cold peripheral contains
+// indeterminate SRAM contents; sending garbage would be reported as spurious
+// messages on start-up.
+static void canClearMessageRam(canDevice_e device)
 {
+    uint32_t base = canMessageRamBase(device);
+
 #if defined(STM32G4)
-    for (uint32_t addr = base; addr < base + CAN_SRAM_PER_INSTANCE; addr += 4) {
+    uint32_t bytes = CAN_SRAM_PER_INSTANCE;
+#elif defined(STM32H7)
+    uint32_t bytes = CAN_H7_PER_INSTANCE_WORDS * 4U;
+#else
+    uint32_t bytes = 0;
+#endif
+
+    for (uint32_t addr = base; addr < base + bytes; addr += 4) {
         *(volatile uint32_t *)addr = 0;
     }
-#else
-    UNUSED(base);
-#endif
 }
 
 static void canEnableInterrupt(canDevice_e device, uint8_t irq)
@@ -199,6 +283,43 @@ static void canEnableInterrupt(canDevice_e device, uint8_t irq)
     NVIC_EnableIRQ(irq);
 #endif
 }
+
+#if defined(STM32H7)
+// Program the H7 Message RAM layout for this instance. Addresses in the
+// SIDFC/XIDFC/RXF0C/TXBC registers are word offsets from SRAMCAN_BASE, not
+// absolute byte addresses. We only activate Rx FIFO 0 and the Tx FIFO; the
+// other regions (standard/extended filters, Rx FIFO 1, Rx buffers, Tx event
+// FIFO) are left zero-sized.
+static void canConfigureMessageRamH7(canDevice_e device, FDCAN_GlobalTypeDef *regs)
+{
+    const uint32_t instanceWords = (uint32_t)device * CAN_H7_PER_INSTANCE_WORDS;
+
+    const uint32_t rf0SA = instanceWords + CAN_H7_RF0_WORD_OFFSET;
+    const uint32_t tfqSA = instanceWords + CAN_H7_TFQ_WORD_OFFSET;
+
+    // No standard / extended filter lists installed — point at the region
+    // start with size 0 so the peripheral never walks them.
+    regs->SIDFC = (instanceWords << FDCAN_SIDFC_FLSSA_Pos) & FDCAN_SIDFC_FLSSA_Msk;
+    regs->XIDFC = (instanceWords << FDCAN_XIDFC_FLESA_Pos) & FDCAN_XIDFC_FLESA_Msk;
+
+    // Rx FIFO 0: 3 classic-CAN elements.
+    regs->RXF0C = ((rf0SA << FDCAN_RXF0C_F0SA_Pos) & FDCAN_RXF0C_F0SA_Msk)
+                | ((CAN_H7_RF0_NBR << FDCAN_RXF0C_F0S_Pos) & FDCAN_RXF0C_F0S_Msk);
+    regs->RXF1C = 0;
+    regs->RXBC  = 0;
+
+    // All Rx paths use 8-byte data elements (smallest, matches classic CAN).
+    regs->RXESC = (CAN_H7_ESC_CODE_8B << FDCAN_RXESC_F0DS_Pos)
+                | (CAN_H7_ESC_CODE_8B << FDCAN_RXESC_F1DS_Pos)
+                | (CAN_H7_ESC_CODE_8B << FDCAN_RXESC_RBDS_Pos);
+
+    // Tx buffers: 3 FIFO-mode slots, 0 dedicated buffers. TFQM = 0 (FIFO mode).
+    regs->TXBC = ((tfqSA << FDCAN_TXBC_TBSA_Pos) & FDCAN_TXBC_TBSA_Msk)
+               | ((CAN_H7_TFQ_NBR << FDCAN_TXBC_TFQS_Pos) & FDCAN_TXBC_TFQS_Msk);
+    regs->TXEFC = 0;
+    regs->TXESC = (CAN_H7_ESC_CODE_8B << FDCAN_TXESC_TBDS_Pos);
+}
+#endif // STM32H7
 
 //-----------------------------------------------------------------------------
 // Init / public API
@@ -247,14 +368,18 @@ void canInitDevice(canDevice_e device)
     // Nominal bit timing. Data bit timing (DBTP) is not needed for classic CAN.
     regs->NBTP = canNominalBitTiming();
 
+    // Wipe the per-instance message RAM region to remove any prior contents.
+    canClearMessageRam(device);
+
 #if defined(STM32G4)
     // Accept-non-matching policy: route everything to Rx FIFO 0 (fields 00b
-    // in ANFS / ANFE). No filter list entries are installed in this first
-    // cut, which is fine because the accept-non-match path handles everything.
+    // in ANFS / ANFE). The Message RAM layout itself is fixed by silicon.
     regs->RXGFC &= ~(FDCAN_RXGFC_ANFS | FDCAN_RXGFC_ANFE);
-
-    // Wipe the per-instance message RAM region.
-    canClearMessageRam(canMessageRamBase(device));
+#elif defined(STM32H7)
+    // H7 uses a separate GFC register and requires explicit Message RAM
+    // configuration via SIDFC/XIDFC/RXF0C/TXBC/RXESC/TXESC.
+    regs->GFC &= ~(FDCAN_GFC_ANFS | FDCAN_GFC_ANFE);
+    canConfigureMessageRamH7(device, regs);
 #endif
 
     // Enable RX FIFO 0 new-message interrupt, route it to IRQ line 0, and
@@ -310,15 +435,11 @@ bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
         return false;
     }
 
-#if defined(STM32G4)
     // Put index tells us which slot in the Tx FIFO the next message belongs
     // in. The peripheral manages the ring; software just fills the slot and
     // sets the corresponding TXBAR bit.
     uint32_t putIndex = (txfqs & FDCAN_TXFQS_TFQPI) >> 16;
-    uint32_t base = canMessageRamBase(device) + CAN_SRAM_TFQSA
-                    + putIndex * CAN_SRAM_TFQ_SIZE;
-
-    volatile uint32_t *slot = (volatile uint32_t *)base;
+    volatile uint32_t *slot = (volatile uint32_t *)canTxElementAddress(device, putIndex);
 
     // Word 0: identifier with XTD flag if extended.
     if (isExtended) {
@@ -330,8 +451,9 @@ bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
     // Word 1: length only (no BRS/FDF -> classic CAN frame).
     slot[1] = (uint32_t)length << CAN_TX_WORD1_DLC_POS;
 
-    // Words 2+: copy the payload in 32-bit chunks, handling any trailing
-    // 1..3 bytes by masking. The Tx RAM requires 32-bit writes.
+    // Words 2..3: copy the payload in 32-bit chunks. The Tx RAM requires
+    // 32-bit writes and classic CAN tops out at 8 bytes of payload, so two
+    // words is always enough.
     uint32_t words[2] = { 0, 0 };
     for (uint8_t i = 0; i < length; i++) {
         words[i >> 2] |= ((uint32_t)data[i]) << ((i & 3U) * 8U);
@@ -341,12 +463,6 @@ bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
 
     // Trigger transmission of this slot.
     regs->TXBAR = 1UL << putIndex;
-#else
-    UNUSED(identifier);
-    UNUSED(isExtended);
-    UNUSED(data);
-    UNUSED(length);
-#endif
 
     return true;
 }
@@ -365,10 +481,8 @@ static void canDispatchRx(canDevice_e device)
     while (regs->RXF0S & FDCAN_RXF0S_F0FL) {
         uint32_t getIndex = (regs->RXF0S & FDCAN_RXF0S_F0GI) >> 8;
 
-#if defined(STM32G4)
-        uint32_t base = canMessageRamBase(device) + CAN_SRAM_RF0SA
-                        + getIndex * CAN_SRAM_RF_SIZE;
-        volatile const uint32_t *slot = (volatile const uint32_t *)base;
+        volatile const uint32_t *slot =
+            (volatile const uint32_t *)canRxElementAddress(device, getIndex);
 
         uint32_t w0 = slot[0];
         uint32_t w1 = slot[1];
@@ -390,12 +504,6 @@ static void canDispatchRx(canDevice_e device)
             uint32_t word = (i < 4) ? w2 : w3;
             payload[i] = (uint8_t)(word >> ((i & 3U) * 8U));
         }
-#else
-        uint32_t identifier = 0;
-        bool isExtended = false;
-        uint8_t dlc = 0;
-        uint8_t payload[CAN_CLASSIC_MAX_DLC] = { 0 };
-#endif
 
         // Ack the slot so the peripheral can recycle it for the next message.
         // Must be done before invoking the callback in case the callback is
@@ -422,7 +530,8 @@ void canIrqHandler(canDevice_e device)
 
 // Strong definitions of the FDCAN IRQ handlers (weak stubs in startup *.s).
 // These only exist when CAN is compiled in; otherwise the linker keeps the
-// weak Default_Handler stubs.
+// weak Default_Handler stubs. FDCAN3 is guarded with #ifdef so H7 variants
+// without that instance (H74x/H75x) do not pick up an unresolved symbol.
 
 void FDCAN1_IT0_IRQHandler(void)
 {
@@ -434,7 +543,7 @@ void FDCAN2_IT0_IRQHandler(void)
     canIrqHandler(CANDEV_2);
 }
 
-#if defined(STM32G4)
+#if defined(FDCAN3)
 void FDCAN3_IT0_IRQHandler(void)
 {
     canIrqHandler(CANDEV_3);

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -27,6 +27,16 @@
 
 #if ENABLE_CAN
 
+// Driver supports the Bosch M_CAN IP as implemented on G4 / H7 / C5.
+// Other families either lack FDCAN (e.g. F4 / F7) or use a different IP
+// revision that this driver has not been ported to yet. Fail loud at
+// compile time if ENABLE_CAN is forced on elsewhere, rather than silently
+// producing a non-functional build where TX would accept frames but do
+// nothing.
+#if !defined(STM32G4) && !defined(STM32H7) && !defined(STM32C5)
+#error "ENABLE_CAN is set but the target MCU family has no FDCAN support in this driver"
+#endif
+
 #include "common/utils.h"
 
 #include "drivers/can/can.h"
@@ -170,11 +180,22 @@ static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
 //-----------------------------------------------------------------------------
 // Bit timing for 1 Mbit/s classic CAN
 //
-// The FDCAN kernel clock tree differs per family. On G4 the default kernel
-// clock routing produces 24 MHz on many FC boards; on H7 the FDCAN_CLK is
-// selected via RCC->D2CCIP1R.FDCANSEL and typically also lands at around
-// 24 MHz on boards that haven't explicitly tuned it. The current constants
-// target that 24 MHz case; a future pass should make bit timing a PG value.
+// The FDCAN kernel clock tree differs per family and per board. On G4 the
+// system clock config explicitly selects RCC_FDCANCLKSOURCE_PCLK1 (see
+// system_stm32g4xx.c) which on overclocked FCs runs at 150-170 MHz. On H7
+// the selector in RCC->D2CCIP1R.FDCANSEL defaults to HSE but may be tuned
+// per board. Hard-coding a prescaler therefore gives the wrong line rate on
+// any board whose FDCAN kernel clock does not match the assumption.
+//
+// canNominalBitTiming() discovers the actual FDCAN kernel clock at init
+// time and searches for a (prescaler, tseg1, tseg2) triple that lands
+// exactly on CAN_BITRATE_NOMINAL with a sample point near 75 %. On clocks
+// that are integer multiples of 1 MHz (common FC configurations) the search
+// always succeeds; if no valid setting is found we fall back to the
+// historical 24 MHz preset rather than misconfiguring silently.
+//
+// TODO: expose the target bit rate (and eventually the FDCAN clock source
+// selection) via a PG so boards running at non-integer MHz can override.
 //-----------------------------------------------------------------------------
 
 // NBTP fields: NTSEG1=bits 8:15, NTSEG2=bits 0:6, NBRP=16:24, NSJW=25:31
@@ -183,18 +204,84 @@ static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
 #define CAN_NBTP_NTSEG1_POS     (8U)
 #define CAN_NBTP_NTSEG2_POS     (0U)
 
+#define CAN_BITRATE_NOMINAL     (1000000U)
+#define CAN_NBRP_MAX            (512U)
+#define CAN_NTSEG1_MAX          (256U)
+#define CAN_NTSEG2_MAX          (128U)
+#define CAN_TOTAL_TQ_MIN        (8U)
+#define CAN_TOTAL_TQ_MAX        (25U)
+
+// Sample-point target in tenths of a per-mille (i.e. 750 = 75.0%).
+#define CAN_SAMPLE_POINT_PERMILLE (750U)
+
+static uint32_t canPackNominalBitTiming(uint32_t nbrp, uint32_t ntseg1,
+                                        uint32_t ntseg2, uint32_t nsjw)
+{
+    // Register fields store (value - 1); caller passes the real tq counts.
+    return ((nsjw - 1U)   << CAN_NBTP_NSJW_POS)
+         | ((nbrp - 1U)   << CAN_NBTP_NBRP_POS)
+         | ((ntseg1 - 1U) << CAN_NBTP_NTSEG1_POS)
+         | ((ntseg2 - 1U) << CAN_NBTP_NTSEG2_POS);
+}
+
+// Query the FDCAN kernel clock. HAL_RCCEx_GetPeriphCLKFreq tracks the
+// family's actual clock-source selection where available; C5's HAL2 has
+// no equivalent that works without a handle, so fall back to PCLK1 which
+// matches the HAL2 reset default for FDCAN.
+static uint32_t canGetKernelClockHz(void)
+{
+#if defined(STM32G4) || defined(STM32H7)
+    return HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_FDCAN);
+#else
+    return HAL_RCC_GetPCLK1Freq();
+#endif
+}
+
 static uint32_t canNominalBitTiming(void)
 {
-    // 24 MHz / (1 * (1 + 17 + 6)) = 1 MHz (sample point ~75 %)
-    const uint32_t nbrp = 0;        // prescaler 1
-    const uint32_t ntseg1 = 16;     // tseg1 17
-    const uint32_t ntseg2 = 5;      // tseg2 6
-    const uint32_t nsjw = 0;        // sjw 1
+    const uint32_t kernelHz = canGetKernelClockHz();
 
-    return (nsjw << CAN_NBTP_NSJW_POS)
-         | (nbrp << CAN_NBTP_NBRP_POS)
-         | (ntseg1 << CAN_NBTP_NTSEG1_POS)
-         | (ntseg2 << CAN_NBTP_NTSEG2_POS);
+    // Search for a prescaler that divides the kernel clock down to an
+    // integer tq count in the valid range [8..25]. Pick the first match,
+    // which is the smallest prescaler (gives finest resolution for SJW).
+    for (uint32_t nbrp = 1; nbrp <= CAN_NBRP_MAX; nbrp++) {
+        if ((kernelHz % nbrp) != 0U) {
+            continue;
+        }
+        const uint32_t tqClock = kernelHz / nbrp;
+        if ((tqClock % CAN_BITRATE_NOMINAL) != 0U) {
+            continue;
+        }
+        const uint32_t totalTq = tqClock / CAN_BITRATE_NOMINAL;
+        if (totalTq < CAN_TOTAL_TQ_MIN || totalTq > CAN_TOTAL_TQ_MAX) {
+            continue;
+        }
+
+        // Sample point falls after (1 SYNC_SEG + tseg1). Round to the
+        // nearest tq and clamp so tseg2 stays >= 1.
+        uint32_t ntseg1 = (totalTq * CAN_SAMPLE_POINT_PERMILLE + 500U) / 1000U;
+        if (ntseg1 < 1U) {
+            ntseg1 = 1U;
+        }
+        if (ntseg1 >= totalTq) {
+            ntseg1 = totalTq - 1U;
+        }
+        const uint32_t ntseg2 = totalTq - 1U - ntseg1;
+        if (ntseg1 < 1U || ntseg1 > CAN_NTSEG1_MAX) {
+            continue;
+        }
+        if (ntseg2 < 1U || ntseg2 > CAN_NTSEG2_MAX) {
+            continue;
+        }
+
+        // SJW = min(4, tseg2) keeps resync margin within spec.
+        const uint32_t nsjw = (ntseg2 < 4U) ? ntseg2 : 4U;
+        return canPackNominalBitTiming(nbrp, ntseg1, ntseg2, nsjw);
+    }
+
+    // Fallback: legacy 24 MHz preset. Produces 1 Mbit/s only on 24 MHz
+    // kernel clocks; on any other clock this is better than wedging init.
+    return canPackNominalBitTiming(1U, 17U, 6U, 1U);
 }
 
 //-----------------------------------------------------------------------------
@@ -226,6 +313,12 @@ static FDCAN_GlobalTypeDef *canRegs(canDevice_e device)
     return (FDCAN_GlobalTypeDef *)canDevice[device].reg;
 }
 
+// Bounded spin count for CCCR.INIT transitions. At 170 MHz SYSCLK this
+// translates to ~600 us of worst-case polling, which is more than enough
+// for the peripheral to synchronise (the datasheet spec is a few bit times)
+// but short enough that a stuck peripheral does not wedge boot.
+#define CAN_INIT_SPIN_MAX       (100000U)
+
 // Enter INIT + CCE (configuration change enable). Required for any change to
 // bit timing or message RAM layout. Busy-loops until the peripheral reports
 // that INIT has taken effect.
@@ -235,7 +328,7 @@ static bool canEnterConfigMode(FDCAN_GlobalTypeDef *regs)
 
     // Peripheral synchronises to the bus before asserting INIT. Give it a
     // bounded number of polls so a disconnected transceiver does not hang us.
-    uint32_t timeout = 100000;
+    uint32_t timeout = CAN_INIT_SPIN_MAX;
     while (!(regs->CCCR & FDCAN_CCCR_INIT) && timeout--) {
         // spin
     }
@@ -247,9 +340,21 @@ static bool canEnterConfigMode(FDCAN_GlobalTypeDef *regs)
     return true;
 }
 
-static void canExitConfigMode(FDCAN_GlobalTypeDef *regs)
+// Leaving INIT is also asynchronous: the peripheral waits for 11 consecutive
+// recessive bits on the bus before it accepts normal operation. Poll CCCR
+// until the bit clears so callers do not attempt TX/RX while the controller
+// is still held in init. Returns false on timeout so the caller can decide
+// whether to mark the device initialised or bail.
+static bool canExitConfigMode(FDCAN_GlobalTypeDef *regs)
 {
     regs->CCCR &= ~FDCAN_CCCR_INIT;
+
+    uint32_t timeout = CAN_INIT_SPIN_MAX;
+    while ((regs->CCCR & FDCAN_CCCR_INIT) && timeout--) {
+        // spin
+    }
+
+    return (regs->CCCR & FDCAN_CCCR_INIT) == 0U;
 }
 
 // Clear out the per-instance message RAM region. A cold peripheral contains
@@ -364,7 +469,7 @@ void canInitDevice(canDevice_e device)
 
     // Classic CAN: clear the FD-enable and bit-rate-switch bits. Everything
     // else in CCCR can be left at reset (normal mode, no monitoring).
-    regs->CCCR &= ~((1UL << 8) | (1UL << 9));    // clear FDOE (8) and BRSE (9)
+    regs->CCCR &= ~(FDCAN_CCCR_FDOE | FDCAN_CCCR_BRSE);
 
     // Nominal bit timing. Data bit timing (DBTP) is not needed for classic CAN.
     regs->NBTP = canNominalBitTiming();
@@ -383,15 +488,21 @@ void canInitDevice(canDevice_e device)
     canConfigureMessageRamH7(device, regs);
 #endif
 
-    // Enable RX FIFO 0 new-message interrupt, route it to IRQ line 0, and
-    // arm the peripheral side of IRQ line 0.
-    regs->IE  |= FDCAN_IE_RF0NE;
-    regs->ILS &= ~(1UL << 3);                 // RF0N -> line 0
+    // Enable Rx FIFO 0 new-message and message-lost interrupts, and arm
+    // the peripheral side of IRQ line 0. The line-select register (ILS)
+    // resets to 0 which routes all sources to line 0, so no write needed.
+    // Enabling RF0LE lets the IRQ path observe and clear overrun flags so
+    // the peripheral does not stay stuck in the "lost" state after a burst.
+    regs->IE  |= FDCAN_IE_RF0NE | FDCAN_IE_RF0LE;
     regs->ILE |= FDCAN_ILE_EINT0;
 
     canEnableInterrupt(device, pDev->irq0);
 
-    canExitConfigMode(regs);
+    if (!canExitConfigMode(regs)) {
+        // Peripheral stuck in init — leave device flagged uninitialised so
+        // canTransmit() and canInit()'s caller see the failure.
+        return;
+    }
 
     pDev->initialized = true;
 }
@@ -415,6 +526,10 @@ void canRegisterRxCallback(canDevice_e device, canRxCallbackPtr callback)
     canDevice[device].rxCallback = callback;
 }
 
+// NOTE: canTransmit() is NOT internally synchronised. The read-modify-write
+// sequence on the Tx FIFO (read TXFQS put-index, write slot, set TXBAR) is
+// not re-entrant; calling concurrently from thread context and an ISR can
+// corrupt messages. Callers must serialise externally if they need that.
 bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
                  const uint8_t *data, uint8_t length)
 {
@@ -424,6 +539,12 @@ bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
 
     canDevice_t *pDev = &canDevice[device];
     if (!pDev->initialized || length > CAN_CLASSIC_MAX_DLC) {
+        return false;
+    }
+
+    // Per API contract: data may be NULL only if length is zero. Reject
+    // the invalid combination rather than dereferencing a null pointer.
+    if (length > 0 && data == NULL) {
         return false;
     }
 
@@ -526,6 +647,14 @@ void canIrqHandler(canDevice_e device)
     if (ir & FDCAN_IR_RF0N) {
         regs->IR = FDCAN_IR_RF0N;             // write-1-to-clear
         canDispatchRx(device);
+    }
+
+    // RF0L = Rx FIFO 0 message lost (overrun). Drop the flag so the
+    // peripheral re-arms; dropped frames are visible in the device state
+    // via an incrementing counter for diagnostics.
+    if (ir & FDCAN_IR_RF0L) {
+        regs->IR = FDCAN_IR_RF0L;
+        canDevice[device].rxOverruns++;
     }
 }
 

--- a/src/platform/common/stm32/can_pinconfig.c
+++ b/src/platform/common/stm32/can_pinconfig.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if ENABLE_CAN
+
+#include "drivers/can/can.h"
+#include "drivers/can/can_impl.h"
+#include "drivers/io.h"
+
+#include "pg/can.h"
+
+canDevice_t canDevice[CANDEV_COUNT];
+
+void canPinConfigure(const canPinConfig_t *pConfig)
+{
+    for (size_t hwindex = 0; hwindex < ARRAYLEN(canHardware); hwindex++) {
+        const canHardware_t *hw = &canHardware[hwindex];
+
+        if (!hw->reg) {
+            continue;
+        }
+
+        const canDevice_e device = hw->device;
+        canDevice_t *pDev = &canDevice[device];
+
+        for (int pindex = 0; pindex < CAN_MAX_PIN_SEL; pindex++) {
+            if (pConfig[device].ioTagTx && pConfig[device].ioTagTx == hw->txPins[pindex].pin) {
+                pDev->tx = hw->txPins[pindex].pin;
+                pDev->txAF = hw->txPins[pindex].af;
+            }
+            if (pConfig[device].ioTagRx && pConfig[device].ioTagRx == hw->rxPins[pindex].pin) {
+                pDev->rx = hw->rxPins[pindex].pin;
+                pDev->rxAF = hw->rxPins[pindex].af;
+            }
+        }
+
+        if (pDev->tx && pDev->rx) {
+            pDev->reg = hw->reg;
+#if PLATFORM_TRAIT_RCC
+            pDev->rcc = hw->rcc;
+#endif
+            pDev->irq0 = hw->irq0;
+            pDev->irq1 = hw->irq1;
+        }
+    }
+}
+
+#endif // ENABLE_CAN


### PR DESCRIPTION
## Summary
- Adds a foundational FDCAN peripheral driver using direct register access (no HAL), gated by `ENABLE_CAN`.
- Provides a message-oriented TX/RX API (`canInit`, `canTransmit`, `canRegisterRxCallback`) that higher-level protocols (DroneCAN, etc.) can build on.
- Supported MCUs: **STM32G4** (FDCAN1/2/3), **STM32H7** (FDCAN1/2 on H74x/H75x, FDCAN1/2/3 on H72x/H73x), and **STM32C593** scaffolding (FDCAN1/2 — no in-tree target yet; enables a future C593 target to use CAN without further platform changes).

## Design notes

**Feature gate.** `ENABLE_CAN` follows the project's `ENABLE_*` macro pattern: defined to `1` in `src/platform/STM32/include/platform/platform.h` inside the relevant MCU blocks, with a default-off fallback in `src/main/target/common_post.h`. On C5 the enable is further gated with `#if defined(STM32C593xx)` so STM32C591 (no FDCAN silicon) stays `ENABLE_CAN=0`. Source uses `#if ENABLE_CAN` throughout so command-line overrides (`ENABLE_CAN=0`) work.

**No HAL.** The driver writes directly to `FDCAN_GlobalTypeDef` registers (`CCCR`, `NBTP`, `IE`/`ILE`/`ILS`, `TXFQS`/`TXBAR`, `RXF0S`/`RXF0A`, and on H7 also `GFC`, `SIDFC`, `XIDFC`, `RXF0C`, `TXBC`, `RXESC`, `TXESC`). ST does not publish an LL driver for FDCAN, so this is the LL-equivalent approach Betaflight uses for other peripherals.

**Family differences handled internally.**
- **G4 and C5**: Message RAM layout is fixed by silicon — same register set (`RXGFC`) and same RAM partitioning (28 filter / 3 FIFO / 3 TX slots). Each FDCAN instance owns a hardware-defined region at `SRAMCAN_BASE + N * SRAMCAN_SIZE`. A single code path covers both.
- **H7**: Message RAM layout is software-defined. The driver partitions the shared 10 KiB RAM into 256-byte per-instance slices, using 8-byte data elements (smallest size) so the slot layout stays identical to G4/C5.
- **FDCAN3**: Hardware-table row and the strong `FDCAN3_IT0_IRQHandler` are both guarded with `#if defined(FDCAN3)` so variants without FDCAN3 (H74x/H75x, C5) link cleanly.
- **RCC**: G4 uses `RCC_APB11(FDCAN)`, H7/C5 use `RCC_APB1H(FDCAN)`. All instances on a given MCU share a single enable bit.

**Layering.** Mirrors the existing SPI/UART architecture:
- `src/main/drivers/can/` — platform-independent headers (API, opaque resource type, hardware/device table definitions).
- `src/platform/common/stm32/can_hw.c` — shared LL init, TX via `TXBAR`, RX via FIFO 0 with IRQ-driven dispatch; family-specific blocks for Message RAM setup.
- `src/platform/common/stm32/can_pinconfig.c` — resolves PG-configured pins against the hardware table.
- `src/platform/STM32/can_stm32g4xx.c`, `can_stm32h7xx.c`, `can_stm32c5xx.c` — per-family hardware tables (pin options, RCC, IRQs).
- `src/main/pg/can.[ch]` — PG registration.

**Not added to `busType_e`.** CAN is message-oriented, not register-read oriented like SPI/I2C. Adding it to `busType_e` would force it into an `extDevice_t`/`busDevice_t` abstraction that is a poor fit; it gets its own API instead.

**Classic CAN only for now.** The init sets 1 Mbit/s classic CAN (no FD, no BRS). Bit timing currently assumes a 24 MHz FDCAN kernel clock — that constant should become configurable in a follow-up.

## Files

| Area | File | Purpose |
|------|------|---------|
| Driver API | `src/main/drivers/can/can.h` | Public API |
| Driver API | `src/main/drivers/can/can_impl.h` | `canHardware_t`, `canDevice_t` |
| Driver API | `src/main/drivers/can/can_types.h` | Opaque `canResource_t` |
| Platform | `src/platform/common/stm32/can_hw.c` | LL init/TX/RX/IRQ (direct register access) |
| Platform | `src/platform/common/stm32/can_pinconfig.c` | Pin resolution |
| Platform | `src/platform/STM32/can_stm32g4xx.c` | G4 hardware table |
| Platform | `src/platform/STM32/can_stm32h7xx.c` | H7 hardware table |
| Platform | `src/platform/STM32/can_stm32c5xx.c` | C5/C593 hardware table (ENABLE_CAN-gated) |
| PG | `src/main/pg/can.[ch]` | Pin config PG |
| Wiring | `src/main/drivers/resource.[ch]` | `OWNER_CAN_TX`, `OWNER_CAN_RX` |
| Wiring | `src/main/drivers/nvic.h` | `NVIC_PRIO_CAN` |
| Wiring | `src/main/pg/pg_ids.h` | `PG_CAN_PIN_CONFIG = 563` |
| Wiring | `src/main/fc/init.c` | `configureCANBusses()` after I2C init |
| Wiring | `src/main/target/common_post.h` | `ENABLE_CAN 0` default |
| Wiring | `src/platform/STM32/include/platform/platform.h` | `ENABLE_CAN 1` on G4, H7, and C593 |
| Build | `src/platform/STM32/mk/STM32G4.mk`, `STM32H7.mk`, `STM32C5.mk`, `STM32_COMMON.mk`, `mk/source.mk` | Source list additions |

## Test plan

- [x] `make all` — all 33 CI targets build cleanly
- [x] G4 targets (`STM32G47X`, `AIRBOTG4AIO`) compile the CAN driver
- [x] H7 targets without FDCAN3 (`STM32H743`, `STM32H750`, `SPRACINGH7EXTREME`) compile cleanly with FDCAN3 guards in effect
- [x] H7 targets with FDCAN3 (`STM32H723`, `STM32H725`, `STM32H730`, `STM32H735`, `SPRACINGH7RF`) compile the FDCAN3 code path
- [x] C591 target (CI-excluded, built manually) compiles cleanly — confirms CAN code compiles away on a C5 variant without FDCAN silicon
- [x] Non-G4/H7/C5 targets (F4, F7, N6, AT32, APM32, RP2350, SITL) correctly compile CAN code away to nothing — no undefined symbols or unresolved FDCAN references
- [x] No conflicts with the weak `FDCAN1_IT0_IRQHandler` / `FDCAN2_IT0_IRQHandler` / `FDCAN3_IT0_IRQHandler` aliases in G4/H7 startup
- [ ] Hardware bring-up on a G4 flight controller: verify clock enable, GPIO AF config, transition through INIT mode
- [ ] Hardware bring-up on an H7 flight controller: verify Message RAM partitioning is correct
- [ ] Logic analyzer capture of `canTransmit()` on a G4 / H7 TX pin — confirm valid CAN frames at 1 Mbit/s
- [ ] Internal loopback test (`CCCR.TEST` + `TEST.LBCK`) — transmit a frame, verify `canRegisterRxCallback` fires with matching identifier / payload
- [ ] RX FIFO overrun behavior under sustained traffic

## Follow-ups (separate PRs)

- STM32C593 target / board config (will automatically inherit CAN support from this PR).
- Higher-level protocol integration (DroneCAN), CLI `resource CAN_TX / CAN_RX` commands, configurable bit rate / kernel clock source.
- STM32H5 and STM32N6 support (both have FDCAN hardware; not yet in CI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added CAN (Controller Area Network) bus support with message transmission and reception capabilities
* Enabled support for up to three simultaneous CAN devices
* CAN driver available on STM32H7, STM32G4, and STM32C5 microcontroller families

## Chores
* Updated build system to include CAN driver components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->