### PR TITLE
SITL: move .pg_registry out of the executable segment

### DIFF
--- a/src/platform/SIMULATOR/link/sitl.ld
+++ b/src/platform/SIMULATOR/link/sitl.ld
@@ -20,7 +20,7 @@ SECTIONS {
     PROVIDE_HIDDEN (___pg_resetdata_end = . );
   }
 }
-INSERT AFTER .text;
+INSERT BEFORE .fini_array;
 
 
 


### PR DESCRIPTION
## Summary

Resolves the GNU ld warning on SITL builds:

```
/usr/bin/ld: warning: obj/main/betaflight_SITL.elf has a LOAD segment with RWX permissions
```

`sitl.ld` used `INSERT AFTER .text;`, which forced `.pg_registry` (marked `WA` by the toolchain since `const` on a custom section doesn't strip the write flag) to sit adjacent to `.text` (`AX`). ld collapsed both into one LOAD segment, producing RWX.

Changing to `INSERT BEFORE .fini_array;` places `.pg_registry` in the writable data segment where it belongs. The code segment reverts to R+X, the warning goes away, and the `__pg_registry_start/_end` and `__pg_resetdata_start/_end` symbols remain intact.

Cosmetic only — SITL runs as a regular userspace process, so it had no runtime impact. Firmware targets are unaffected (they don't use `sitl.ld`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized binary section layout in the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->