### PR TITLE
Display altitude in sensors tab even if not armed

### DIFF
--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -59,12 +59,13 @@ static float filteredAltitudeDerivative = 0.0f;
 
 static float controlAltitudeCm = 0.0f;
 static float controlAltitudeDerivative = 0.0f;
+static bool wasArmed = false;
 
 #ifdef USE_VARIO
 static int16_t estimatedVario = 0;
 #endif
 
-void positionInit(void)
+static void positionResetAltitudeState(void)
 {
     const float sampleTimeS = HZ_TO_INTERVAL(TASK_ALTITUDE_RATE_HZ);
 
@@ -75,6 +76,18 @@ void positionInit(void)
     const float altitudeDerivativeCutoffHz = positionConfig()->altitude_d_lpf / 100.0f;
     const float altitudeDerivativeGain = pt2FilterGain(altitudeDerivativeCutoffHz, sampleTimeS);
     pt2FilterInit(&altitudeDerivativeLpf, altitudeDerivativeGain);
+
+    filteredAltitudeCm = 0.0f;
+    displayAltitudeCm = 0.0f;
+    filteredAltitudeDerivative = 0.0f;
+    controlAltitudeCm = 0.0f;
+    controlAltitudeDerivative = 0.0f;
+}
+
+void positionInit(void)
+{
+    positionResetAltitudeState();
+    wasArmed = ARMING_FLAG(ARMED);
 
     positionEstimatorInit();
 }
@@ -92,6 +105,14 @@ PG_RESET_TEMPLATE(positionConfig_t, positionConfig,
 #if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
 void calculateEstimatedAltitude(void)
 {
+    const bool isArmed = ARMING_FLAG(ARMED);
+
+    if (isArmed != wasArmed) {
+        positionEstimatorResetZ();
+        positionResetAltitudeState();
+        wasArmed = isArmed;
+    }
+
     // Run the Kalman filter estimator (prediction + all sensor measurement updates)
     positionEstimatorUpdate();
 

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -99,18 +99,12 @@ void calculateEstimatedAltitude(void)
     const float kfAltCm = positionEstimatorGetAltitudeCm();
     const float kfVelCm = positionEstimatorGetAltitudeDerivative();
 
-    if (!ARMING_FLAG(ARMED)) {
-        filteredAltitudeCm = 0.0f;
-        displayAltitudeCm = 0.0f;
-        controlAltitudeCm = 0.0f;
-        controlAltitudeDerivative = 0.0f;
-    } else {
-        // Apply PT2 display smoothing on top of KF output
-        filteredAltitudeCm = pt2FilterApply(&altitudeLpf, kfAltCm);
-        displayAltitudeCm = filteredAltitudeCm;
-        controlAltitudeCm = kfAltCm;
-        controlAltitudeDerivative = kfVelCm;
-    }
+    // Keep altitude estimate updating while disarmed so sensors/debug views show live data.
+    // Arming-specific references are handled in estimator sensor offsets/reset logic.
+    filteredAltitudeCm = pt2FilterApply(&altitudeLpf, kfAltCm);
+    displayAltitudeCm = filteredAltitudeCm;
+    controlAltitudeCm = kfAltCm;
+    controlAltitudeDerivative = kfVelCm;
 
     filteredAltitudeDerivative = pt2FilterApply(&altitudeDerivativeLpf, controlAltitudeDerivative);
 

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -189,6 +189,7 @@ static bool gpsAltOffsetSet = false;
 #ifdef USE_BARO
 static float baroAltOffsetCm = 0.0f;
 static float baroAltAccumulator = 0.0f;
+static bool baroOffsetSet = false;
 #endif
 
 #ifdef USE_RANGEFINDER
@@ -236,6 +237,7 @@ void positionEstimatorInit(void)
 #ifdef USE_BARO
     baroAltOffsetCm = 0.0f;
     baroAltAccumulator = 0.0f;
+    baroOffsetSet = false;
 #endif
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
@@ -389,11 +391,11 @@ static void feedBaroMeasurements(timeUs_t nowUs)
 
     const float baroAltCm = getBaroAltitude();
 
-    if (!ARMING_FLAG(ARMED)) {
-        // Accumulate a smoothed offset while disarmed
-        baroAltAccumulator = 0.2f * baroAltCm + 0.8f * baroAltAccumulator;
-        baroAltOffsetCm = baroAltAccumulator;
-        return;
+    if (!baroOffsetSet) {
+        // Capture disarmed baseline once; keep live relative altitude while disarmed.
+        baroAltAccumulator = baroAltCm;
+        baroAltOffsetCm = baroAltCm;
+        baroOffsetSet = true;
     }
 
     // Scale R based on altitude_prefer_baro: higher value = lower baro R = more trust
@@ -421,11 +423,6 @@ static void feedRangefinderMeasurements(timeUs_t nowUs)
 
     float altCm;
     if (!rangefinderSampleAltitudeCm(&altCm, positionConfig()->rangefinder_max_range_cm)) {
-        return;
-    }
-
-    if (!ARMING_FLAG(ARMED)) {
-        rangefinderAltOffsetCm = altCm;
         return;
     }
 
@@ -565,16 +562,10 @@ void positionEstimatorUpdate(void)
     float accelEast, accelNorth, accelUp;
     getLinearAccelENU(&accelEast, &accelNorth, &accelUp);
 
-    // Z-axis: always runs (for altitude hold, OSD, vario)
-    if (ARMING_FLAG(ARMED)) {
-        kalmanPredict(&kfZ, dt, accelUp);
-    } else {
-        // While disarmed, hold Z at zero and let sensors calibrate offsets
-        kalmanInit(&kfZ, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
-#ifdef USE_RANGEFINDER
-        rangefinderOffsetSet = false;
-#endif
-    }
+    // Z-axis: always runs (for altitude hold, OSD, vario).
+    // While disarmed, predict with zero acceleration so covariance continues to evolve
+    // and incoming baro/rangefinder updates remain responsive.
+    kalmanPredict(&kfZ, dt, ARMING_FLAG(ARMED) ? accelUp : 0.0f);
 
     // XY axes: only when a consumer is active
     if (xyEnabled && ARMING_FLAG(ARMED)) {
@@ -661,6 +652,7 @@ void positionEstimatorResetZ(void)
 #ifdef USE_BARO
     baroAltOffsetCm = 0.0f;
     baroAltAccumulator = 0.0f;
+    baroOffsetSet = false;
 #endif
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -445,6 +445,17 @@ poshold_unittest_SRC := \
 		$(USER_DIR)/common/filter.c \
 		$(USER_DIR)/pg/rx.c
 
+position_estimator_unittest_SRC := \
+		$(USER_DIR)/flight/position_estimator.c \
+		$(USER_DIR)/flight/position_filter.c \
+		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/vector.c
+
+position_estimator_unittest_DEFINES := \
+		USE_GPS= \
+		USE_BARO= \
+		USE_RANGEFINDER=
+
 rcdevice_unittest_DEFINES := \
 		USE_RCDEVICE=
 

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -443,6 +443,7 @@ extern "C" {
 
     void positionEstimatorInit(void) { }
     void positionEstimatorUpdate(void) { }
+    void positionEstimatorResetZ(void) { }
     bool positionEstimatorIsValidZ(void) { return false; }
     float positionEstimatorGetAltitudeCm(void) { return 0.0f; }
     float positionEstimatorGetAltitudeDerivative(void) { return 0.0f; }

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -315,6 +315,42 @@ TEST_F(PosHoldTest, SticksActiveZerosOutput)
     EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.01f);
 }
 
+TEST_F(PosHoldTest, EstimateValidityTransitionsUnavailableAvailableUnavailable)
+{
+    initAndSettleAt(0, 0, 0);
+
+    testEstimate.isValidXY = false;
+    EXPECT_FALSE(positionControl());
+
+    testEstimate.isValidXY = true;
+    testEstimate.position.x = 80.0f;
+    runIterations(SETTLE_ITERATIONS);
+    EXPECT_TRUE(positionControl());
+    EXPECT_NE(autopilotAngle[AI_ROLL], 0.0f);
+
+    testEstimate.isValidXY = false;
+    EXPECT_FALSE(positionControl());
+}
+
+TEST_F(PosHoldTest, VelocityTransitionSimulatesFallbackAndRecovery)
+{
+    initAndSettleAt(0, 0, 0);
+
+    testEstimate.velocity.x = 120.0f;
+    runIterations(SETTLE_ITERATIONS);
+    const float highVelocityRoll = autopilotAngle[AI_ROLL];
+    EXPECT_NE(highVelocityRoll, 0.0f);
+
+    testEstimate.velocity.x = 20.0f;
+    runIterations(SETTLE_ITERATIONS);
+    const float lowVelocityRoll = autopilotAngle[AI_ROLL];
+    EXPECT_LT(fabsf(lowVelocityRoll), fabsf(highVelocityRoll));
+
+    testEstimate.velocity.x = 0.0f;
+    runIterations(SETTLE_ITERATIONS);
+    EXPECT_NEAR(autopilotAngle[AI_ROLL], 0.0f, 0.2f);
+}
+
 // -- GPS-like scenario: large displacement, position + velocity --
 
 TEST_F(PosHoldTest, GpsScenarioDriftAndReturn)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -1,0 +1,138 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+#include "platform.h"
+#include "build/debug.h"
+#include "pg/pg_ids.h"
+
+#include "common/maths.h"
+#include "common/vector.h"
+
+#include "drivers/time.h"
+
+#include "fc/runtime_config.h"
+
+#include "flight/imu.h"
+#include "flight/position.h"
+#include "flight/position_estimator.h"
+
+#include "io/gps.h"
+
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/rangefinder.h"
+#include "sensors/sensors.h"
+
+PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
+}
+
+#include "gtest/gtest.h"
+
+extern "C" {
+uint8_t armingFlags = 0;
+uint8_t stateFlags = 0;
+uint16_t flightModeFlags = 0;
+uint8_t debugMode = 0;
+int16_t debug[DEBUG16_VALUE_COUNT];
+
+acc_t acc;
+matrix33_t rMat;
+gpsSolutionData_t gpsSol;
+
+static uint32_t enabledSensors = 0;
+static bool rfHealthy = false;
+static float rfAltCm = 0.0f;
+static float baroAltCm = 0.0f;
+static timeUs_t fakeMicros = 0;
+
+bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
+bool rangefinderIsHealthy(void) { return rfHealthy; }
+int32_t rangefinderGetLatestAltitude(void) { return lrintf(rfAltCm); }
+float getBaroAltitude(void) { return baroAltCm; }
+
+timeUs_t micros(void) { return fakeMicros; }
+
+bool gpsHasNewData(uint16_t *gpsStamp)
+{
+    (*gpsStamp)++;
+    return true;
+}
+
+void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *dest)
+{
+    UNUSED(from);
+    UNUSED(to);
+    dest->x = 0.0f;
+    dest->y = 0.0f;
+}
+}
+
+static void stepEstimator(unsigned count = 1)
+{
+    for (unsigned i = 0; i < count; i++) {
+        fakeMicros += 10000; // 100 Hz
+        positionEstimatorUpdate();
+    }
+}
+
+class PositionEstimatorTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        memset(&acc, 0, sizeof(acc));
+        memset(&rMat, 0, sizeof(rMat));
+        memset(&gpsSol, 0, sizeof(gpsSol));
+        memset(debug, 0, sizeof(debug));
+
+        // Identity rotation and 1G reciprocal scale so zero accel stays zero.
+        rMat.m[0][0] = 1.0f;
+        rMat.m[1][1] = 1.0f;
+        rMat.m[2][2] = 1.0f;
+        acc.dev.acc_1G_rec = 1.0f;
+
+        enabledSensors = SENSOR_GPS | SENSOR_BARO | SENSOR_RANGEFINDER;
+        rfHealthy = true;
+        rfAltCm = 100.0f;
+        baroAltCm = 100.0f;
+        gpsSol.llh.altCm = 100.0f;
+        gpsSol.dop.pdop = 100; // pDOP 1.0
+
+        stateFlags = GPS_FIX;
+        armingFlags = ARMED;
+        fakeMicros = 0;
+
+        positionConfigMutable()->altitude_source = ALTITUDE_SOURCE_RANGEFINDER_PREFER;
+        positionConfigMutable()->altitude_prefer_baro = 100;
+        positionConfigMutable()->rangefinder_max_range_cm = 400;
+
+        positionEstimatorInit();
+    }
+};
+
+TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)
+{
+    // Establish offsets/baseline near zero.
+    stepEstimator(10);
+    const float baseline = positionEstimatorGetAltitudeCm();
+
+    // Rangefinder unavailable: fallback should use baro/GPS updates.
+    rfHealthy = false;
+    baroAltCm = 150.0f;
+    gpsSol.llh.altCm = 150.0f;
+    stepEstimator(40);
+    const float fallbackAltitude = positionEstimatorGetAltitudeCm();
+    EXPECT_GT(fallbackAltitude, baseline + 10.0f);
+
+    // Rangefinder becomes available again at a lower relative altitude.
+    rfHealthy = true;
+    rfAltCm = 120.0f; // +20cm relative to RF offset baseline
+    stepEstimator(40);
+    const float recoveredAltitude = positionEstimatorGetAltitudeCm();
+
+    // In RANGEFINDER_PREFER, recovered altitude should be pulled down toward RF value.
+    EXPECT_LT(recoveredAltitude, fallbackAltitude - 5.0f);
+    EXPECT_TRUE(positionEstimatorIsValidZ());
+}
+

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <math.h>
 
 extern "C" {
 #include "platform.h"


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/betaflight/betaflight/pull/14922 whereby the baro altitude wasn't displayed in the sensors tab when disarmed, changing prior behaviour.

The log below was taken using a Caddx Protos using `debug_mode = AUTOPILOT_ALTITUDE` with `altitude_source = RANGEFINDER_PREFER` and `rangefinder_max_range_cm = 100`. Thus in ALT HOLD mode if the altitude went above 1m the baro would be used, but below than the rangefinder would be used.

[RANGEFINDER_PREFER.bbl.zip](https://github.com/user-attachments/files/26761686/RANGEFINDER_PREFER.bbl.zip)

As expected below 1m the altitude hold is very stable.
<img width="1896" height="810" alt="image" src="https://github.com/user-attachments/assets/f25b5c6c-d2a9-4f92-a8da-654f63ff6545" />

Whereas above it is somewhat less so.
<img width="1898" height="812" alt="image" src="https://github.com/user-attachments/assets/46ca6ba4-d73d-4ad8-97f9-aedf25b0f14c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve filtered/display/control altitude outputs when disarmed for consistent values
  * Capture barometer baseline once to stabilize baro altitude
  * Continue vertical-state prediction while disarmed for smoother altitude estimation and filtering
  * Reset altitude/filter state on arming transitions to avoid stale states

* **Tests**
  * Added unit tests for altitude-source selection, estimator fallback/recovery, and position-hold transitions; new test build target included
<!-- end of auto-generated comment: release notes by coderabbit.ai -->