### PR TITLE
msp: add MSP2_WING_TUNING / MSP2_SET_WING_TUNING for wing config fields

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -136,6 +136,7 @@ COMMON_SRC = \
             msp/msp_box.c \
             msp/msp_build_info.c \
             msp/msp_serial.c \
+            msp/msp_wing.c \
             scheduler/scheduler.c \
             sensors/adcinternal.c \
             sensors/battery.c \

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -112,6 +112,7 @@
 #include "msp/msp_protocol_v2_betaflight.h"
 #include "msp/msp_protocol_v2_common.h"
 #include "msp/msp_serial.h"
+#include "msp/msp_wing.h"
 
 #include "osd/osd.h"
 #include "osd/osd_elements.h"
@@ -2760,6 +2761,12 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
         break;
 #endif
 
+#ifdef USE_WING
+    case MSP2_WING_TUNING:
+        serializeWingTuning(dst, currentPidProfile);
+        break;
+#endif
+
     default:
         return MSP_RESULT_CMD_UNKNOWN;
     }
@@ -4328,6 +4335,22 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         profile->consumptionWarningPercentage = consumptionWarnPct;
         break;
     }
+
+#ifdef USE_WING
+    case MSP2_SET_WING_TUNING:
+        if (!deserializeWingTuning(src, currentPidProfile)) {
+            return MSP_RESULT_ERROR;
+        }
+        // Reinitialize derived runtime state so the new wing tuning
+        // takes effect on the next tick, not just after reboot/profile
+        // reload. Matches the comprehensive-reinit pattern used by
+        // nearby handlers that mutate both PID and mixer-relevant
+        // fields (yaw_type affects mixer output routing).
+        pidInitConfig(currentPidProfile);
+        initEscEndpoints();
+        mixerInitProfile();
+        break;
+#endif
 
     default:
         // we do not know how to handle the (valid) message, indicate error MSP $M!

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -36,6 +36,8 @@
 #define MSP2_SET_BATTERY_PROFILE            0x300F
 #define MSP2_CLI_SETTING                    0x3010
 #define MSP2_CLI_SETTING_INFO               0x3011
+#define MSP2_WING_TUNING                    0x3012
+#define MSP2_SET_WING_TUNING                0x3013
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/msp/msp_wing.c
+++ b/src/main/msp/msp_wing.c
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Wing-specific MSP2 message serialization.
+//
+// Wire contract (both messages, little-endian, append-only): see
+// .plan/WIRE_FORMAT.md. A shared golden hex vector lives in
+// .plan/GOLDEN_VECTOR.md and is round-tripped by the firmware unit
+// test (src/test/unit/wing_msp_unittest.cc) AND the configurator
+// vitest. If a field is reordered or its sign flipped in either repo,
+// both tests fail in sync.
+//
+// Signed fields use the bit-pattern cast convention (uint write, int
+// read) -- matches MSP_SET_PID_ADVANCED convention, since streambuf
+// exposes only U8/U16/U32.
+
+#include "platform.h"
+
+#ifdef USE_WING
+
+#include "msp/msp_wing.h"
+
+// 39 bytes. Signed fields: angle_pitch_offset, tpa_speed_pitch_offset,
+// tpa_curve_expo.
+void serializeWingTuning(sbuf_t *dst, const pidProfile_t *profile)
+{
+    sbufWriteU8(dst, profile->pid[PID_ROLL].S);
+    sbufWriteU8(dst, profile->pid[PID_PITCH].S);
+    sbufWriteU8(dst, profile->pid[PID_YAW].S);
+    sbufWriteU8(dst, profile->yaw_type);
+    sbufWriteU16(dst, (uint16_t)profile->angle_pitch_offset);
+    sbufWriteU8(dst, profile->angle_earth_ref);
+    sbufWriteU8(dst, profile->tpa_mode);
+    sbufWriteU8(dst, profile->tpa_speed_type);
+    sbufWriteU16(dst, profile->tpa_speed_basic_delay);
+    sbufWriteU16(dst, profile->tpa_speed_basic_gravity);
+    sbufWriteU16(dst, profile->tpa_speed_max_voltage);
+    sbufWriteU16(dst, (uint16_t)profile->tpa_speed_pitch_offset);
+    sbufWriteU8(dst, profile->tpa_curve_type);
+    sbufWriteU8(dst, profile->tpa_curve_stall_throttle);
+    sbufWriteU16(dst, profile->tpa_curve_pid_thr0);
+    sbufWriteU16(dst, profile->tpa_curve_pid_thr100);
+    sbufWriteU8(dst, (uint8_t)profile->tpa_curve_expo);
+    sbufWriteU16(dst, profile->spa_center[FD_ROLL]);
+    sbufWriteU16(dst, profile->spa_width[FD_ROLL]);
+    sbufWriteU8(dst, profile->spa_mode[FD_ROLL]);
+    sbufWriteU16(dst, profile->spa_center[FD_PITCH]);
+    sbufWriteU16(dst, profile->spa_width[FD_PITCH]);
+    sbufWriteU8(dst, profile->spa_mode[FD_PITCH]);
+    sbufWriteU16(dst, profile->spa_center[FD_YAW]);
+    sbufWriteU16(dst, profile->spa_width[FD_YAW]);
+    sbufWriteU8(dst, profile->spa_mode[FD_YAW]);
+}
+
+// V1 payload is fixed at 39 bytes. Fields appended in a future minor API
+// version must add their own sbufBytesRemaining() >= N guard before reading,
+// per the append-only contract. If this guard fails on a truncated V1
+// payload, the profile is left untouched; caller sees false return.
+bool deserializeWingTuning(sbuf_t *src, pidProfile_t *profile)
+{
+    if (sbufBytesRemaining(src) < 39) {
+        return false;
+    }
+    profile->pid[PID_ROLL].S          = sbufReadU8(src);
+    profile->pid[PID_PITCH].S         = sbufReadU8(src);
+    profile->pid[PID_YAW].S           = sbufReadU8(src);
+    profile->yaw_type                 = sbufReadU8(src);
+    profile->angle_pitch_offset       = (int16_t)sbufReadU16(src);
+    profile->angle_earth_ref          = sbufReadU8(src);
+    profile->tpa_mode                 = sbufReadU8(src);
+    profile->tpa_speed_type           = sbufReadU8(src);
+    profile->tpa_speed_basic_delay    = sbufReadU16(src);
+    profile->tpa_speed_basic_gravity  = sbufReadU16(src);
+    profile->tpa_speed_max_voltage    = sbufReadU16(src);
+    profile->tpa_speed_pitch_offset   = (int16_t)sbufReadU16(src);
+    profile->tpa_curve_type           = sbufReadU8(src);
+    profile->tpa_curve_stall_throttle = sbufReadU8(src);
+    profile->tpa_curve_pid_thr0       = sbufReadU16(src);
+    profile->tpa_curve_pid_thr100     = sbufReadU16(src);
+    profile->tpa_curve_expo           = (int8_t)sbufReadU8(src);
+    profile->spa_center[FD_ROLL]      = sbufReadU16(src);
+    profile->spa_width[FD_ROLL]       = sbufReadU16(src);
+    profile->spa_mode[FD_ROLL]        = sbufReadU8(src);
+    profile->spa_center[FD_PITCH]     = sbufReadU16(src);
+    profile->spa_width[FD_PITCH]      = sbufReadU16(src);
+    profile->spa_mode[FD_PITCH]       = sbufReadU8(src);
+    profile->spa_center[FD_YAW]       = sbufReadU16(src);
+    profile->spa_width[FD_YAW]        = sbufReadU16(src);
+    profile->spa_mode[FD_YAW]         = sbufReadU8(src);
+    return true;
+}
+
+#endif // USE_WING

--- a/src/main/msp/msp_wing.h
+++ b/src/main/msp/msp_wing.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/streambuf.h"
+#include "flight/pid.h"
+
+#ifdef USE_WING
+
+// MSP2_WING_TUNING: serialize 26 wing config fields from profile.
+// Wire format: see .plan/WIRE_FORMAT.md (39 bytes, little-endian).
+void serializeWingTuning(sbuf_t *dst, const pidProfile_t *profile);
+
+// MSP2_SET_WING_TUNING: deserialize into profile. Uses sbufBytesRemaining()
+// guards; returns true if all fields present, false if short. Does NOT
+// write EEPROM -- caller handles persistence via MSP_EEPROM_WRITE.
+bool deserializeWingTuning(sbuf_t *src, pidProfile_t *profile);
+
+#endif // USE_WING

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -519,6 +519,13 @@ vtx_msp_unittest_DEFINES := \
 		USE_VTX_TABLE= \
 		USE_VTX_MSP=
 
+wing_msp_unittest_SRC := \
+		$(USER_DIR)/common/streambuf.c \
+		$(USER_DIR)/msp/msp_wing.c
+
+wing_msp_unittest_DEFINES := \
+		USE_WING=
+
 pwl_unittest_SRC := \
 		$(USER_DIR)/common/pwl.c
 

--- a/src/test/unit/wing_msp_unittest.cc
+++ b/src/test/unit/wing_msp_unittest.cc
@@ -1,0 +1,178 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Golden-vector round-trip tests for MSP2 wing tuning messages. The hex
+// arrays here are the cross-repo wire contract -- the same bytes must
+// round-trip through the configurator's wing_msp.test.js. When anyone
+// reorders a field in either repo, both tests fail in sync.
+//
+// Canonical values documented in .plan/GOLDEN_VECTOR.md. Negative values
+// for signed fields are deliberate (flushes out readU vs readI bugs).
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "common/streambuf.h"
+    #include "flight/pid.h"
+    #include "msp/msp_wing.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// 39-byte golden vector for MSP2_WING_TUNING.
+// See .plan/GOLDEN_VECTOR.md for the pidProfile_t values it encodes.
+static const uint8_t WING_TUNING_GOLDEN[] = {
+    0x1E, 0x28, 0x00, 0x01,        // S[R], S[P], S[Y], yaw_type
+    0x88, 0xFF,                    // angle_pitch_offset (-120)
+    0x64,                          // angle_earth_ref
+    0x00, 0x01,                    // tpa_mode, tpa_speed_type
+    0x20, 0x03, 0x96, 0x00,        // tpa_speed_basic_delay, basic_gravity
+    0x60, 0x09,                    // tpa_speed_max_voltage
+    0xCE, 0xFF,                    // tpa_speed_pitch_offset (-50)
+    0x01, 0x23,                    // tpa_curve_type, stall_throttle
+    0x96, 0x00, 0x50, 0x00,        // tpa_curve_pid_thr0, thr100
+    0xFB,                          // tpa_curve_expo (-5)
+    0x90, 0x01, 0xFA, 0x00, 0x02,  // spa R: center, width, mode
+    0x5E, 0x01, 0xC8, 0x00, 0x01,  // spa P
+    0x2C, 0x01, 0x96, 0x00, 0x00,  // spa Y
+};
+
+// Populate a pidProfile_t with the canonical wing-tuning values.
+static void populateCanonicalWingProfile(pidProfile_t *p)
+{
+    memset(p, 0, sizeof(*p));
+    p->pid[PID_ROLL].S = 30;
+    p->pid[PID_PITCH].S = 40;
+    p->pid[PID_YAW].S = 0;
+    p->yaw_type = 1;
+    p->angle_pitch_offset = -120;
+    p->angle_earth_ref = 100;
+    p->tpa_mode = 0;
+    p->tpa_speed_type = 1;
+    p->tpa_speed_basic_delay = 800;
+    p->tpa_speed_basic_gravity = 150;
+    p->tpa_speed_max_voltage = 2400;
+    p->tpa_speed_pitch_offset = -50;
+    p->tpa_curve_type = 1;
+    p->tpa_curve_stall_throttle = 35;
+    p->tpa_curve_pid_thr0 = 150;
+    p->tpa_curve_pid_thr100 = 80;
+    p->tpa_curve_expo = -5;
+    p->spa_center[FD_ROLL] = 400;
+    p->spa_width[FD_ROLL] = 250;
+    p->spa_mode[FD_ROLL] = 2;
+    p->spa_center[FD_PITCH] = 350;
+    p->spa_width[FD_PITCH] = 200;
+    p->spa_mode[FD_PITCH] = 1;
+    p->spa_center[FD_YAW] = 300;
+    p->spa_width[FD_YAW] = 150;
+    p->spa_mode[FD_YAW] = 0;
+}
+
+TEST(WingMspUnitTest, ConfigEncodesToGoldenVector)
+{
+    pidProfile_t profile;
+    populateCanonicalWingProfile(&profile);
+
+    uint8_t buffer[64] = {0};
+    sbuf_t sbuf;
+    sbufInit(&sbuf, buffer, buffer + sizeof(buffer));
+
+    serializeWingTuning(&sbuf, &profile);
+
+    const size_t written = (size_t)(sbuf.ptr - buffer);
+    EXPECT_EQ(sizeof(WING_TUNING_GOLDEN), written);
+    EXPECT_EQ(0, memcmp(buffer, WING_TUNING_GOLDEN, sizeof(WING_TUNING_GOLDEN)));
+}
+
+TEST(WingMspUnitTest, ConfigDecodesGoldenVector)
+{
+    pidProfile_t profile;
+    memset(&profile, 0, sizeof(profile));
+
+    sbuf_t sbuf;
+    sbufInit(&sbuf, (uint8_t *)WING_TUNING_GOLDEN,
+             (uint8_t *)WING_TUNING_GOLDEN + sizeof(WING_TUNING_GOLDEN));
+
+    const bool ok = deserializeWingTuning(&sbuf, &profile);
+    EXPECT_TRUE(ok);
+
+    pidProfile_t expected;
+    populateCanonicalWingProfile(&expected);
+
+    EXPECT_EQ(expected.pid[PID_ROLL].S,          profile.pid[PID_ROLL].S);
+    EXPECT_EQ(expected.pid[PID_PITCH].S,         profile.pid[PID_PITCH].S);
+    EXPECT_EQ(expected.pid[PID_YAW].S,           profile.pid[PID_YAW].S);
+    EXPECT_EQ(expected.yaw_type,                 profile.yaw_type);
+    EXPECT_EQ(expected.angle_pitch_offset,       profile.angle_pitch_offset);
+    EXPECT_EQ(expected.angle_earth_ref,          profile.angle_earth_ref);
+    EXPECT_EQ(expected.tpa_mode,                 profile.tpa_mode);
+    EXPECT_EQ(expected.tpa_speed_type,           profile.tpa_speed_type);
+    EXPECT_EQ(expected.tpa_speed_basic_delay,    profile.tpa_speed_basic_delay);
+    EXPECT_EQ(expected.tpa_speed_basic_gravity,  profile.tpa_speed_basic_gravity);
+    EXPECT_EQ(expected.tpa_speed_max_voltage,    profile.tpa_speed_max_voltage);
+    EXPECT_EQ(expected.tpa_speed_pitch_offset,   profile.tpa_speed_pitch_offset);
+    EXPECT_EQ(expected.tpa_curve_type,           profile.tpa_curve_type);
+    EXPECT_EQ(expected.tpa_curve_stall_throttle, profile.tpa_curve_stall_throttle);
+    EXPECT_EQ(expected.tpa_curve_pid_thr0,       profile.tpa_curve_pid_thr0);
+    EXPECT_EQ(expected.tpa_curve_pid_thr100,     profile.tpa_curve_pid_thr100);
+    EXPECT_EQ(expected.tpa_curve_expo,           profile.tpa_curve_expo);
+    for (int i = 0; i < XYZ_AXIS_COUNT; i++) {
+        EXPECT_EQ(expected.spa_center[i], profile.spa_center[i]);
+        EXPECT_EQ(expected.spa_width[i],  profile.spa_width[i]);
+        EXPECT_EQ(expected.spa_mode[i],   profile.spa_mode[i]);
+    }
+}
+
+TEST(WingMspUnitTest, ConfigRoundTrips)
+{
+    pidProfile_t source;
+    populateCanonicalWingProfile(&source);
+
+    uint8_t buffer[64] = {0};
+    sbuf_t writer;
+    sbufInit(&writer, buffer, buffer + sizeof(buffer));
+    serializeWingTuning(&writer, &source);
+    const size_t written = (size_t)(writer.ptr - buffer);
+
+    pidProfile_t roundTripped;
+    memset(&roundTripped, 0, sizeof(roundTripped));
+    sbuf_t reader;
+    sbufInit(&reader, buffer, buffer + written);
+    EXPECT_TRUE(deserializeWingTuning(&reader, &roundTripped));
+
+    EXPECT_EQ(0, memcmp(&source.pid[PID_ROLL], &roundTripped.pid[PID_ROLL], sizeof(pidf_t)));
+    EXPECT_EQ(source.angle_pitch_offset,     roundTripped.angle_pitch_offset);
+    EXPECT_EQ(source.tpa_speed_pitch_offset, roundTripped.tpa_speed_pitch_offset);
+    EXPECT_EQ(source.tpa_curve_expo,         roundTripped.tpa_curve_expo);
+}
+
+TEST(WingMspUnitTest, DeserializeRejectsTruncatedPayload)
+{
+    pidProfile_t profile;
+    memset(&profile, 0, sizeof(profile));
+
+    // Feed only the first 10 bytes of the golden vector.
+    sbuf_t sbuf;
+    sbufInit(&sbuf, (uint8_t *)WING_TUNING_GOLDEN, (uint8_t *)WING_TUNING_GOLDEN + 10);
+
+    EXPECT_FALSE(deserializeWingTuning(&sbuf, &profile));
+}


### PR DESCRIPTION
Tuning tab - https://youtu.be/JOVxj9ci__U

edit; configurator side - https://github.com/betaflight/betaflight-configurator/pull/5015

Adds two MSP2 codes exposing 26 wing-specific pidProfile_t fields (S-term gains, SPA center/width/mode per axis, TPA mode/curve/speed params, yaw_type, angle_pitch_offset, angle_earth_ref) to external MSP clients:

  MSP2_WING_TUNING       0x3012  GET   39 bytes, little-endian
  MSP2_SET_WING_TUNING   0x3013  SET   same layout

Both gated #ifdef USE_WING. No impact on multirotor builds.

Unblocks the Configurator Wing Tuning tab migrating off CLI get/set, which eliminates 2-3 s reload latency and a USB CDC re-init reboot on every Save. The Configurator PR is a separate repo and will follow this one.

Runtime wing-mode state (live TPA attenuation, SPA scaling per axis, effective S-term contribution) is intentionally NOT included. That data is already plumbed to blackbox via DEBUG_SET(DEBUG_TPA, ...) and DEBUG_SET(DEBUG_SPA, ...) at the full 8 kHz loop rate, which is the canonical way to analyze wing-mode behavior post-flight. MSP polling at 4 Hz would be strictly worse and has no in-flight use case.

Serializers are factored into src/main/msp/msp_wing.{c,h} so they are unit-testable in isolation (mirrors the existing precedent of msp_box.c / msp_build_info.c / io/vtx_msp.c). The msp.c handlers are one-line shims. A golden hex vector unit test at
src/test/unit/wing_msp_unittest.cc round-trips the 26 fields through serializer and deserializer; the same vector will be consumed by the companion configurator vitest so cross-repo wire drift fails loudly on both sides.

Signed fields (angle_pitch_offset, tpa_speed_pitch_offset, tpa_curve_expo) use the uint-write / int-read bit-pattern cast convention, matching MSP_SET_PID_ADVANCED. Deliberately negative values in the test vector flush out readU vs readI regressions.

Append-only wire contract: fields may only be appended, never reordered or type-changed. Enum index meanings are part of the contract -- lookupTableYawType / lookupTableTpaMode / lookupTableTpaCurveType / lookupTableSpaMode values must not be renumbered within a minor version.

API_VERSION_MINOR 48 -> 49. The ELRS MSP-version-response test fixture CRC was updated (0xAF -> 0x7A) to reflect the new version byte -- standard version-bump fallout.

wing_launch_* fields (under USE_WING_LAUNCH) are out of scope; PR #15121 covers those separately but can be added if/when merged 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wing tuning parameters can now be configured via MSP2 protocol with immediate application on the next flight control cycle, eliminating the need for device reboot or profile reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->