### PR TITLE
Expose transponder provider and data via CLI

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1500,7 +1500,7 @@ const clivalue_t valueTable[] = {
 // PG_TRANSPONDER_CONFIG
 #ifdef USE_TRANSPONDER
     { PARAM_NAME_TRANSPONDER_PROVIDER, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_TRANSPONDER_PROVIDER }, PG_TRANSPONDER_CONFIG, offsetof(transponderConfig_t, provider) },
-    { PARAM_NAME_TRANSPONDER_DATA,     VAR_UINT8 | MASTER_VALUE | MODE_ARRAY,  .config.array.length = 9, PG_TRANSPONDER_CONFIG, offsetof(transponderConfig_t, data) },
+    { PARAM_NAME_TRANSPONDER_DATA,     VAR_UINT8 | MASTER_VALUE | MODE_ARRAY,  .config.array.length = TRANSPONDER_DATA_LENGTH, PG_TRANSPONDER_CONFIG, offsetof(transponderConfig_t, data) },
 #endif
 
 // PG_SDCARD_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -44,6 +44,7 @@
 #include "drivers/mco.h"
 #include "drivers/pinio.h"
 #include "drivers/sdio.h"
+#include "drivers/transponder_ir.h"
 #include "drivers/vtx_common.h"
 #include "drivers/vtx_table.h"
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -71,6 +71,7 @@
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/serial.h"
+#include "io/transponder_ir.h"
 #include "io/vtx.h"
 #include "io/vtx_control.h"
 #include "io/vtx_rtc6705.h"
@@ -565,6 +566,12 @@ const char* const lookupTableYawType[] = {
 };
 #endif // USE_WING
 
+#ifdef USE_TRANSPONDER
+static const char * const lookupTableTransponderProvider[] = {
+    "NONE", "ILAP", "ARCITIMER", "ERLT"
+};
+#endif
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -708,6 +715,9 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableTpaSpeedType),
     LOOKUP_TABLE_ENTRY(lookupTableYawType),
 #endif // USE_WING
+#ifdef USE_TRANSPONDER
+    LOOKUP_TABLE_ENTRY(lookupTableTransponderProvider),
+#endif
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -1484,6 +1494,12 @@ const clivalue_t valueTable[] = {
     { "ledstrip_brightness",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 100 }, PG_LED_STRIP_CONFIG, offsetof(ledStripConfig_t, ledstrip_brightness) },
     { "ledstrip_rainbow_delta",     VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, HSV_HUE_MAX }, PG_LED_STRIP_CONFIG, offsetof(ledStripConfig_t, ledstrip_rainbow_delta) },
     { "ledstrip_rainbow_freq",      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1, 2000 }, PG_LED_STRIP_CONFIG, offsetof(ledStripConfig_t, ledstrip_rainbow_freq) },
+#endif
+
+// PG_TRANSPONDER_CONFIG
+#ifdef USE_TRANSPONDER
+    { PARAM_NAME_TRANSPONDER_PROVIDER, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_TRANSPONDER_PROVIDER }, PG_TRANSPONDER_CONFIG, offsetof(transponderConfig_t, provider) },
+    { PARAM_NAME_TRANSPONDER_DATA,     VAR_UINT8 | MASTER_VALUE | MODE_ARRAY,  .config.array.length = 9, PG_TRANSPONDER_CONFIG, offsetof(transponderConfig_t, data) },
 #endif
 
 // PG_SDCARD_CONFIG

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -162,6 +162,9 @@ typedef enum {
     TABLE_TPA_SPEED_TYPE,
     TABLE_YAW_TYPE,
 #endif // USE_WING
+#ifdef USE_TRANSPONDER
+    TABLE_TRANSPONDER_PROVIDER,
+#endif
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -325,3 +325,8 @@
 #ifdef USE_MAG
 #define PARAM_NAME_IMU_MAG_DECLINATION "mag_declination"
 #endif
+
+#ifdef USE_TRANSPONDER
+#define PARAM_NAME_TRANSPONDER_PROVIDER "transponder_provider"
+#define PARAM_NAME_TRANSPONDER_DATA "transponder_data"
+#endif

--- a/src/main/io/transponder_ir.c
+++ b/src/main/io/transponder_ir.c
@@ -90,6 +90,9 @@ void transponderUpdate(timeUs_t currentTimeUs)
     }
 
     uint8_t provider = transponderConfig()->provider;
+    if (provider == TRANSPONDER_NONE) {
+        return;
+    }
 
     // TODO use a random number generator for random jitter?  The idea here is to avoid multiple transmitters transmitting at the same time.
     uint32_t jitter = (transponderRequirements[provider - 1].transmitJitter / 10 * jitterDurations[jitterIndex++]);

--- a/src/main/io/transponder_ir.h
+++ b/src/main/io/transponder_ir.h
@@ -23,10 +23,13 @@
 #include "common/time.h"
 #include "pg/pg.h"
 
+// Storage size for transponder data, sized for the largest provider (ARCITIMER = 9).
+#define TRANSPONDER_DATA_LENGTH 9
+
 typedef struct transponderConfig_s {
     transponderProvider_e provider;
     uint8_t reserved;
-    uint8_t data[9];
+    uint8_t data[TRANSPONDER_DATA_LENGTH];
     ioTag_t ioTag;
 } transponderConfig_t;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4354,14 +4354,14 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
             return MSP_RESULT_ERROR;
         }
 
-        const uint8_t requirementIndex = provider - 1;
-        const uint8_t transponderDataSize = transponderRequirements[requirementIndex].dataLength;
-
         transponderConfigMutable()->provider = provider;
 
         if (provider == TRANSPONDER_NONE) {
             break;
         }
+
+        const uint8_t requirementIndex = provider - 1;
+        const uint8_t transponderDataSize = transponderRequirements[requirementIndex].dataLength;
 
         if (bytesRemaining != transponderDataSize) {
             return MSP_RESULT_ERROR;


### PR DESCRIPTION
Add `transponder_provider` (lookup: NONE/ILAP/ARCITIMER/ERLT) and `transponder_data` (9-byte array) as CLI settings on the existing `PG_TRANSPONDER_CONFIG`. Previously the fields were only configurable via MSP; the configurator is dropping its Transponder tab in favour of CLI access (see betaflight/betaflight-configurator#5020), so these need to be reachable with `get`/`set`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable transponder support: enable transponder mode, choose a provider, and set transponder data (up to 9 bytes). Settings appear in system settings and parameter lists only when transponder support is enabled.

* **Bug Fixes**
  * Transponder processing now exits cleanly when no provider is selected, preventing unintended activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->