### PR TITLE
feat: CAN CLI surface (resource CAN_TX/RX, set can_bitrate)

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -135,6 +135,7 @@ bool cliMode = false;
 #include "pg/board.h"
 #include "pg/bus_i2c.h"
 #include "pg/bus_spi.h"
+#include "pg/can.h"
 #include "pg/flight_plan.h"
 #include "pg/gyrodev.h"
 #include "pg/max7456.h"
@@ -6310,6 +6311,10 @@ const cliResourceValue_t resourceTable[] = {
     DEFW( OWNER_SPI_SCK,       PG_SPI_PIN_CONFIG, spiPinConfig_t, ioTagSck, SPIDEV_COUNT ),
     DEFW( OWNER_SPI_SDI,       PG_SPI_PIN_CONFIG, spiPinConfig_t, ioTagMiso, SPIDEV_COUNT ),
     DEFW( OWNER_SPI_SDO,       PG_SPI_PIN_CONFIG, spiPinConfig_t, ioTagMosi, SPIDEV_COUNT ),
+#endif
+#if ENABLE_CAN
+    DEFW( OWNER_CAN_TX,        PG_CAN_PIN_CONFIG, canPinConfig_t, ioTagTx, CANDEV_COUNT ),
+    DEFW( OWNER_CAN_RX,        PG_CAN_PIN_CONFIG, canPinConfig_t, ioTagRx, CANDEV_COUNT ),
 #endif
 #ifdef USE_ESCSERIAL
     DEFS( OWNER_ESCSERIAL,     PG_ESCSERIAL_CONFIG, escSerialConfig_t, ioTag ),

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1906,7 +1906,7 @@ const clivalue_t valueTable[] = {
 #endif
 #if ENABLE_CAN
 // PG_CAN_CONFIG
-    { "can_bitrate",    VAR_UINT32 | HARDWARE_VALUE, .config.u32Max = 1000000, PG_CAN_CONFIG, offsetof(canConfig_t, bitrate) },
+    { "can_bitrate_khz", VAR_UINT16 | HARDWARE_VALUE, .config.minmaxUnsigned = { 125, 1000 }, PG_CAN_CONFIG, offsetof(canConfig_t, bitrate_khz) },
 #endif
 #ifdef USE_MCO
 #if defined(USE_MCO_DEVICE1)

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -86,6 +86,7 @@
 #include "pg/beeper.h"
 #include "pg/beeper_dev.h"
 #include "pg/bus_i2c.h"
+#include "pg/can.h"
 #include "pg/dashboard.h"
 #include "pg/displayport_profiles.h"
 #include "pg/dyn_notch.h"
@@ -1902,6 +1903,10 @@ const clivalue_t valueTable[] = {
     { "i2c4_pullup",    VAR_UINT8  | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_I2C_CONFIG, PG_ARRAY_ELEMENT_OFFSET(i2cConfig_t, I2CDEV_4, pullUp) },
     { "i2c4_clockspeed_khz", VAR_UINT16 | HARDWARE_VALUE, .config.minmax = { I2C_CLOCKSPEED_MIN_KHZ, I2C_CLOCKSPEED_MAX_KHZ }, PG_I2C_CONFIG, PG_ARRAY_ELEMENT_OFFSET(i2cConfig_t, I2CDEV_4, clockSpeed) },
 #endif
+#endif
+#if ENABLE_CAN
+// PG_CAN_CONFIG
+    { "can_bitrate",    VAR_UINT32 | HARDWARE_VALUE, .config.u32Max = 1000000, PG_CAN_CONFIG, offsetof(canConfig_t, bitrate) },
 #endif
 #ifdef USE_MCO
 #if defined(USE_MCO_DEVICE1)

--- a/src/main/drivers/can/can.h
+++ b/src/main/drivers/can/can.h
@@ -53,9 +53,10 @@ typedef void (*canRxCallbackPtr)(uint32_t identifier, bool isExtended,
                                  const uint8_t *data, uint8_t length);
 
 // Initialise the given CAN device at the specified nominal bit rate (Hz).
-// Returns false if the device has no hardware resources configured or the
-// peripheral failed to start. A bitrate the driver cannot synthesise from
-// the current FDCAN kernel clock falls back to a legacy 1 Mbit/s preset.
+// Returns false if the device has no hardware resources configured, the
+// peripheral failed to start, or the driver could not synthesise the
+// requested bit rate from the current FDCAN kernel clock. On failure the
+// device stays uninitialised and subsequent canTransmit() calls return false.
 bool canInit(canDevice_e device, uint32_t bitrate);
 
 // Transmit a classic CAN frame. Returns true if the frame was queued,

--- a/src/main/drivers/can/can.h
+++ b/src/main/drivers/can/can.h
@@ -52,9 +52,11 @@ typedef enum {
 typedef void (*canRxCallbackPtr)(uint32_t identifier, bool isExtended,
                                  const uint8_t *data, uint8_t length);
 
-// Initialise the given CAN device. Returns false if the device has no
-// hardware resources configured or the peripheral failed to start.
-bool canInit(canDevice_e device);
+// Initialise the given CAN device at the specified nominal bit rate (Hz).
+// Returns false if the device has no hardware resources configured or the
+// peripheral failed to start. A bitrate the driver cannot synthesise from
+// the current FDCAN kernel clock falls back to a legacy 1 Mbit/s preset.
+bool canInit(canDevice_e device, uint32_t bitrate);
 
 // Transmit a classic CAN frame. Returns true if the frame was queued,
 // false if the TX FIFO is full, the device is uninitialised, or the

--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -72,7 +72,7 @@ typedef struct canDevice_s {
 extern canDevice_t canDevice[CANDEV_COUNT];
 
 // Internal: shared init routine implemented per-platform in can_hw.c.
-void canInitDevice(canDevice_e device);
+void canInitDevice(canDevice_e device, uint32_t bitrate);
 
 // Internal: ISR dispatch helper invoked from named FDCANx IRQ handlers.
 void canIrqHandler(canDevice_e device);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -271,7 +271,7 @@ static void configureOctoSPIBusses(void)
 static void configureCANBusses(void)
 {
     canPinConfigure(canPinConfig(0));
-    const uint32_t bitrate = canConfig()->bitrate;
+    const uint32_t bitrate = (uint32_t)canConfig()->bitrate_khz * 1000U;
     canInit(CANDEV_1, bitrate);
     canInit(CANDEV_2, bitrate);
     canInit(CANDEV_3, bitrate);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -271,9 +271,10 @@ static void configureOctoSPIBusses(void)
 static void configureCANBusses(void)
 {
     canPinConfigure(canPinConfig(0));
-    canInit(CANDEV_1);
-    canInit(CANDEV_2);
-    canInit(CANDEV_3);
+    const uint32_t bitrate = canConfig()->bitrate;
+    canInit(CANDEV_1, bitrate);
+    canInit(CANDEV_2, bitrate);
+    canInit(CANDEV_3, bitrate);
 }
 #endif
 

--- a/src/main/pg/can.c
+++ b/src/main/pg/can.c
@@ -75,4 +75,10 @@ void pgResetFn_canPinConfig(canPinConfig_t *config)
     }
 }
 
+PG_REGISTER_WITH_RESET_TEMPLATE(canConfig_t, canConfig, PG_CAN_CONFIG, 0);
+
+PG_RESET_TEMPLATE(canConfig_t, canConfig,
+    .bitrate = 1000000U,
+);
+
 #endif // ENABLE_CAN

--- a/src/main/pg/can.c
+++ b/src/main/pg/can.c
@@ -78,7 +78,7 @@ void pgResetFn_canPinConfig(canPinConfig_t *config)
 PG_REGISTER_WITH_RESET_TEMPLATE(canConfig_t, canConfig, PG_CAN_CONFIG, 0);
 
 PG_RESET_TEMPLATE(canConfig_t, canConfig,
-    .bitrate = 1000000U,
+    .bitrate_khz = 1000U,
 );
 
 #endif // ENABLE_CAN

--- a/src/main/pg/can.h
+++ b/src/main/pg/can.h
@@ -34,7 +34,7 @@ typedef struct canPinConfig_s {
 PG_DECLARE_ARRAY(canPinConfig_t, CANDEV_COUNT, canPinConfig);
 
 typedef struct canConfig_s {
-    uint32_t bitrate;       // nominal bit rate in Hz (default 1 Mbit/s)
+    uint16_t bitrate_khz;   // nominal bit rate in kHz (default 1000 = 1 Mbit/s)
 } canConfig_t;
 
 PG_DECLARE(canConfig_t, canConfig);

--- a/src/main/pg/can.h
+++ b/src/main/pg/can.h
@@ -32,3 +32,9 @@ typedef struct canPinConfig_s {
 } canPinConfig_t;
 
 PG_DECLARE_ARRAY(canPinConfig_t, CANDEV_COUNT, canPinConfig);
+
+typedef struct canConfig_s {
+    uint32_t bitrate;       // nominal bit rate in Hz (default 1 Mbit/s)
+} canConfig_t;
+
+PG_DECLARE(canConfig_t, canConfig);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -162,6 +162,7 @@
 #define PG_BATTERY_PROFILES         561
 #define PG_FLIGHT_PLAN_CONFIG       562
 #define PG_CAN_PIN_CONFIG           563
+#define PG_CAN_CONFIG               564
 
 
 // OSD configuration (subject to change)

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -192,8 +192,8 @@ static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
 // exactly on the requested bit rate with a sample point near 75 %. On
 // clocks that are integer multiples of the target rate (common FC
 // configurations) the search always succeeds; if no valid setting is
-// found we fall back to the historical 1 Mbit/s @ 24 MHz preset rather
-// than misconfiguring silently.
+// found we return false so the caller can leave the device uninitialised
+// rather than silently running at a different bit rate than configured.
 //-----------------------------------------------------------------------------
 
 // NBTP fields: NTSEG1=bits 8:15, NTSEG2=bits 0:6, NBRP=16:24, NSJW=25:31
@@ -234,12 +234,10 @@ static uint32_t canGetKernelClockHz(void)
 #endif
 }
 
-static uint32_t canNominalBitTiming(uint32_t bitrate)
+static bool canNominalBitTiming(uint32_t bitrate, uint32_t *nbtp)
 {
-    // Zero (or otherwise unset) skips the search and uses the fallback so
-    // a misconfigured PG does not divide-by-zero here.
-    if (bitrate == 0U) {
-        return canPackNominalBitTiming(1U, 17U, 6U, 1U);
+    if (bitrate == 0U || nbtp == NULL) {
+        return false;
     }
 
     const uint32_t kernelHz = canGetKernelClockHz();
@@ -260,31 +258,29 @@ static uint32_t canNominalBitTiming(uint32_t bitrate)
             continue;
         }
 
-        // Sample point falls after (1 SYNC_SEG + tseg1). Round to the
-        // nearest tq and clamp so tseg2 stays >= 1.
-        uint32_t ntseg1 = (totalTq * CAN_SAMPLE_POINT_PERMILLE + 500U) / 1000U;
-        if (ntseg1 < 1U) {
-            ntseg1 = 1U;
+        // Sample point is (SYNC_SEG + TSEG1) / totalTq. Round the target
+        // position to the nearest tq, then clamp so TSEG1 >= 1 and
+        // TSEG2 >= 1.
+        uint32_t samplePointTq = (totalTq * CAN_SAMPLE_POINT_PERMILLE + 500U) / 1000U;
+        if (samplePointTq < 2U) {
+            samplePointTq = 2U;
         }
-        if (ntseg1 >= totalTq) {
-            ntseg1 = totalTq - 1U;
+        if (samplePointTq >= totalTq) {
+            samplePointTq = totalTq - 1U;
         }
-        const uint32_t ntseg2 = totalTq - 1U - ntseg1;
-        if (ntseg1 < 1U || ntseg1 > CAN_NTSEG1_MAX) {
-            continue;
-        }
-        if (ntseg2 < 1U || ntseg2 > CAN_NTSEG2_MAX) {
+        const uint32_t ntseg1 = samplePointTq - 1U;
+        const uint32_t ntseg2 = totalTq - samplePointTq;
+        if (ntseg1 > CAN_NTSEG1_MAX || ntseg2 > CAN_NTSEG2_MAX) {
             continue;
         }
 
         // SJW = min(4, tseg2) keeps resync margin within spec.
         const uint32_t nsjw = (ntseg2 < 4U) ? ntseg2 : 4U;
-        return canPackNominalBitTiming(nbrp, ntseg1, ntseg2, nsjw);
+        *nbtp = canPackNominalBitTiming(nbrp, ntseg1, ntseg2, nsjw);
+        return true;
     }
 
-    // Fallback: legacy 24 MHz preset. Produces 1 Mbit/s only on 24 MHz
-    // kernel clocks; on any other clock this is better than wedging init.
-    return canPackNominalBitTiming(1U, 17U, 6U, 1U);
+    return false;
 }
 
 //-----------------------------------------------------------------------------
@@ -475,7 +471,13 @@ void canInitDevice(canDevice_e device, uint32_t bitrate)
     regs->CCCR &= ~(FDCAN_CCCR_FDOE | FDCAN_CCCR_BRSE);
 
     // Nominal bit timing. Data bit timing (DBTP) is not needed for classic CAN.
-    regs->NBTP = canNominalBitTiming(bitrate);
+    // If synthesis fails the caller-visible `initialized` flag stays false so
+    // canTransmit() rejects traffic rather than running at an unknown rate.
+    uint32_t nbtp;
+    if (!canNominalBitTiming(bitrate, &nbtp)) {
+        return;
+    }
+    regs->NBTP = nbtp;
 
     // Wipe the per-instance message RAM region to remove any prior contents.
     canClearMessageRam(device);

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -189,13 +189,11 @@ static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
 //
 // canNominalBitTiming() discovers the actual FDCAN kernel clock at init
 // time and searches for a (prescaler, tseg1, tseg2) triple that lands
-// exactly on CAN_BITRATE_NOMINAL with a sample point near 75 %. On clocks
-// that are integer multiples of 1 MHz (common FC configurations) the search
-// always succeeds; if no valid setting is found we fall back to the
-// historical 24 MHz preset rather than misconfiguring silently.
-//
-// TODO: expose the target bit rate (and eventually the FDCAN clock source
-// selection) via a PG so boards running at non-integer MHz can override.
+// exactly on the requested bit rate with a sample point near 75 %. On
+// clocks that are integer multiples of the target rate (common FC
+// configurations) the search always succeeds; if no valid setting is
+// found we fall back to the historical 1 Mbit/s @ 24 MHz preset rather
+// than misconfiguring silently.
 //-----------------------------------------------------------------------------
 
 // NBTP fields: NTSEG1=bits 8:15, NTSEG2=bits 0:6, NBRP=16:24, NSJW=25:31
@@ -204,7 +202,6 @@ static uint32_t canTxElementAddress(canDevice_e device, uint32_t index)
 #define CAN_NBTP_NTSEG1_POS     (8U)
 #define CAN_NBTP_NTSEG2_POS     (0U)
 
-#define CAN_BITRATE_NOMINAL     (1000000U)
 #define CAN_NBRP_MAX            (512U)
 #define CAN_NTSEG1_MAX          (256U)
 #define CAN_NTSEG2_MAX          (128U)
@@ -237,8 +234,14 @@ static uint32_t canGetKernelClockHz(void)
 #endif
 }
 
-static uint32_t canNominalBitTiming(void)
+static uint32_t canNominalBitTiming(uint32_t bitrate)
 {
+    // Zero (or otherwise unset) skips the search and uses the fallback so
+    // a misconfigured PG does not divide-by-zero here.
+    if (bitrate == 0U) {
+        return canPackNominalBitTiming(1U, 17U, 6U, 1U);
+    }
+
     const uint32_t kernelHz = canGetKernelClockHz();
 
     // Search for a prescaler that divides the kernel clock down to an
@@ -249,10 +252,10 @@ static uint32_t canNominalBitTiming(void)
             continue;
         }
         const uint32_t tqClock = kernelHz / nbrp;
-        if ((tqClock % CAN_BITRATE_NOMINAL) != 0U) {
+        if ((tqClock % bitrate) != 0U) {
             continue;
         }
-        const uint32_t totalTq = tqClock / CAN_BITRATE_NOMINAL;
+        const uint32_t totalTq = tqClock / bitrate;
         if (totalTq < CAN_TOTAL_TQ_MIN || totalTq > CAN_TOTAL_TQ_MAX) {
             continue;
         }
@@ -431,7 +434,7 @@ static void canConfigureMessageRamH7(canDevice_e device, FDCAN_GlobalTypeDef *re
 // Init / public API
 //-----------------------------------------------------------------------------
 
-void canInitDevice(canDevice_e device)
+void canInitDevice(canDevice_e device, uint32_t bitrate)
 {
     if (device < 0 || device >= CANDEV_COUNT) {
         return;
@@ -472,7 +475,7 @@ void canInitDevice(canDevice_e device)
     regs->CCCR &= ~(FDCAN_CCCR_FDOE | FDCAN_CCCR_BRSE);
 
     // Nominal bit timing. Data bit timing (DBTP) is not needed for classic CAN.
-    regs->NBTP = canNominalBitTiming();
+    regs->NBTP = canNominalBitTiming(bitrate);
 
     // Wipe the per-instance message RAM region to remove any prior contents.
     canClearMessageRam(device);
@@ -507,13 +510,13 @@ void canInitDevice(canDevice_e device)
     pDev->initialized = true;
 }
 
-bool canInit(canDevice_e device)
+bool canInit(canDevice_e device, uint32_t bitrate)
 {
     if (device < 0 || device >= CANDEV_COUNT) {
         return false;
     }
 
-    canInitDevice(device);
+    canInitDevice(device, bitrate);
     return canDevice[device].initialized;
 }
 


### PR DESCRIPTION
Adds the CLI surface on top of the CAN driver landed in #15115: `resource CAN_TX / CAN_RX <n> <pin>` for pin assignment, and `set can_bitrate` for the nominal bus bit rate (default 1 Mbit/s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CAN bitrate can be configured via CLI (default 1000 kHz / 1 Mbit/s).
  * CLI resource commands can view/set CAN Tx/Rx pin assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->