### PR TITLE
serial: per-feature UART assignment foundation

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -126,6 +126,7 @@ COMMON_SRC = \
             io/beeper.c \
             io/piniobox.c \
             io/serial.c \
+            io/serial_feature_map.c \
             io/serial_resource.c \
             io/smartaudio_protocol.c \
             io/statusindicator.c \
@@ -498,6 +499,7 @@ SIZE_OPTIMISED_SRC += \
             config/simplified_tuning.c \
             io/dashboard.c \
             io/serial.c \
+            io/serial_feature_map.c \
             io/serial_4way.c \
             io/serial_4way_avrootloader.c \
             io/serial_4way_stk500v2.c \

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -134,6 +134,7 @@ COMMON_SRC = \
             io/beeper.c \
             io/piniobox.c \
             io/serial.c \
+            io/serial_feature_map.c \
             io/serial_resource.c \
             io/smartaudio_protocol.c \
             io/statusindicator.c \
@@ -517,6 +518,7 @@ SIZE_OPTIMISED_SRC += \
             config/simplified_tuning.c \
             io/dashboard.c \
             io/serial.c \
+            io/serial_feature_map.c \
             io/serial_4way.c \
             io/serial_4way_avrootloader.c \
             io/serial_4way_stk500v2.c \

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -111,7 +111,8 @@ PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
     .sample_rate = BLACKBOX_RATE_QUARTER,
     .device = DEFAULT_BLACKBOX_DEVICE,
     .mode = BLACKBOX_MODE_NORMAL,
-    .high_resolution = false
+    .high_resolution = false,
+    .blackbox_uart = SERIAL_PORT_NONE,
 );
 
 STATIC_ASSERT((sizeof(blackboxConfig()->fields_disabled_mask) * 8) >= FLIGHT_LOG_FIELD_SELECT_COUNT, too_many_flight_log_fields_selections);

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -65,6 +65,7 @@ typedef struct blackboxConfig_s {
     uint8_t device;
     uint8_t mode;
     uint8_t high_resolution;
+    int8_t blackbox_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } blackboxConfig_t;
 
 PG_DECLARE(blackboxConfig_t, blackboxConfig);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -117,6 +117,7 @@ bool cliMode = false;
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/serial.h"
+#include "io/serial_feature_map.h"
 #include "io/transponder_ir.h"
 #include "io/usb_msc.h"
 #include "io/vtx_control.h"
@@ -1469,6 +1470,12 @@ static void cliSerial(const char *cmdName, char *cmdline)
     }
 
     memcpy(currentConfig, &portConfig, sizeof(portConfig));
+
+    // Mirror the legacy bitmask into the per-feature PG fields.  Legacy
+    // functionMask is still authoritative at runtime; the shadow is
+    // maintained so the two views stay in sync until feature call sites
+    // migrate over.
+    serialApplyFunctionMask(portConfig.identifier, portConfig.functionMask);
 
     cliDumpPrintLinef(0, false, format,
         serialName(portConfig.identifier, invalidName),

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1469,13 +1469,16 @@ static void cliSerial(const char *cmdName, char *cmdline)
         return;
     }
 
-    memcpy(currentConfig, &portConfig, sizeof(portConfig));
+    // Mirror the legacy bitmask into the per-feature PG fields.  If the
+    // requested combination cannot be represented we reject the whole
+    // command so the synthesized view and the stored functionMask stay
+    // in sync.
+    if (!serialApplyFunctionMask(portConfig.identifier, portConfig.functionMask)) {
+        cliShowParseError(cmdName);
+        return;
+    }
 
-    // Mirror the legacy bitmask into the per-feature PG fields.  Legacy
-    // functionMask is still authoritative at runtime; the shadow is
-    // maintained so the two views stay in sync until feature call sites
-    // migrate over.
-    serialApplyFunctionMask(portConfig.identifier, portConfig.functionMask);
+    memcpy(currentConfig, &portConfig, sizeof(portConfig));
 
     cliDumpPrintLinef(0, false, format,
         serialName(portConfig.identifier, invalidName),

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1507,13 +1507,16 @@ RAM_CODE static void cliSerial(const char *cmdName, char *cmdline)
         return;
     }
 
-    memcpy(currentConfig, &portConfig, sizeof(portConfig));
+    // Mirror the legacy bitmask into the per-feature PG fields.  If the
+    // requested combination cannot be represented we reject the whole
+    // command so the synthesized view and the stored functionMask stay
+    // in sync.
+    if (!serialApplyFunctionMask(portConfig.identifier, portConfig.functionMask)) {
+        cliShowParseError(cmdName);
+        return;
+    }
 
-    // Mirror the legacy bitmask into the per-feature PG fields.  Legacy
-    // functionMask is still authoritative at runtime; the shadow is
-    // maintained so the two views stay in sync until feature call sites
-    // migrate over.
-    serialApplyFunctionMask(portConfig.identifier, portConfig.functionMask);
+    memcpy(currentConfig, &portConfig, sizeof(portConfig));
 
     cliDumpPrintLinef(0, false, format,
         serialName(portConfig.identifier, invalidName),

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -120,6 +120,7 @@ bool cliMode = false;
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/serial.h"
+#include "io/serial_feature_map.h"
 #include "io/transponder_ir.h"
 #include "io/usb_msc.h"
 #include "io/vtx_control.h"
@@ -1507,6 +1508,12 @@ RAM_CODE static void cliSerial(const char *cmdName, char *cmdline)
     }
 
     memcpy(currentConfig, &portConfig, sizeof(portConfig));
+
+    // Mirror the legacy bitmask into the per-feature PG fields.  Legacy
+    // functionMask is still authoritative at runtime; the shadow is
+    // maintained so the two views stay in sync until feature call sites
+    // migrate over.
+    serialApplyFunctionMask(portConfig.identifier, portConfig.functionMask);
 
     cliDumpPrintLinef(0, false, format,
         serialName(portConfig.identifier, invalidName),

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -62,6 +62,7 @@
 #include "io/gps.h"
 #include "io/ledstrip.h"
 #include "io/serial.h"
+#include "io/serial_feature_map.h"
 #include "io/vtx.h"
 
 #include "msp/msp_box.h"
@@ -230,6 +231,12 @@ static void validateAndFixConfig(void)
     if (!isSerialConfigValid(serialConfigMutable())) {
         PG_RESET(serialConfig);
     }
+
+    // Populate the per-feature UART fields from the legacy functionMask
+    // bitmask so pre-existing configs keep working during the migration
+    // window.  Idempotent — running it every boot is fine while the
+    // legacy mask is still the source of truth.
+    serialBackfillFeatureFields();
 
 #if defined(USE_GPS)
     const serialPortConfig_t *gpsSerial = findSerialPortConfig(FUNCTION_GPS);

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -52,6 +52,7 @@
 #include "config/config.h"
 
 #include "io/serial.h"
+#include "io/serial_feature_map.h"
 
 #include "msp/msp_serial.h"
 
@@ -426,7 +427,7 @@ const serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function
     while (findSerialPortConfigState.lastIndex < ARRAYLEN(serialConfig()->portConfigs)) {
         const serialPortConfig_t *candidate = &serialConfig()->portConfigs[findSerialPortConfigState.lastIndex++];
 
-        if (candidate->functionMask & function) {
+        if (serialSynthesizeFunctionMask(candidate->identifier) & function) {
             return candidate;
         }
     }
@@ -435,15 +436,23 @@ const serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function
 
 portSharing_e determinePortSharing(const serialPortConfig_t *portConfig, serialPortFunction_e function)
 {
-    if (!portConfig || (portConfig->functionMask & function) == 0) {
+    if (!portConfig) {
         return PORTSHARING_UNUSED;
     }
-    return portConfig->functionMask == function ? PORTSHARING_NOT_SHARED : PORTSHARING_SHARED;
+    const uint32_t mask = serialSynthesizeFunctionMask(portConfig->identifier);
+    if ((mask & function) == 0) {
+        return PORTSHARING_UNUSED;
+    }
+    return mask == (uint32_t)function ? PORTSHARING_NOT_SHARED : PORTSHARING_SHARED;
 }
 
 bool isSerialPortShared(const serialPortConfig_t *portConfig, uint16_t functionMask, serialPortFunction_e sharedWithFunction)
 {
-    return (portConfig) && (portConfig->functionMask & sharedWithFunction) && (portConfig->functionMask & functionMask);
+    if (!portConfig) {
+        return false;
+    }
+    const uint32_t mask = serialSynthesizeFunctionMask(portConfig->identifier);
+    return (mask & sharedWithFunction) && (mask & functionMask);
 }
 
 serialPort_t *findSharedSerialPort(uint16_t functionMask, serialPortFunction_e sharedWithFunction)

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -52,6 +52,7 @@
 #include "config/config.h"
 
 #include "io/serial.h"
+#include "io/serial_feature_map.h"
 
 #include "msp/msp_serial.h"
 
@@ -456,7 +457,7 @@ const serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function
     while (findSerialPortConfigState.lastIndex < ARRAYLEN(serialConfig()->portConfigs)) {
         const serialPortConfig_t *candidate = &serialConfig()->portConfigs[findSerialPortConfigState.lastIndex++];
 
-        if (candidate->functionMask & function) {
+        if (serialSynthesizeFunctionMask(candidate->identifier) & function) {
             return candidate;
         }
     }
@@ -465,15 +466,23 @@ const serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function
 
 portSharing_e determinePortSharing(const serialPortConfig_t *portConfig, serialPortFunction_e function)
 {
-    if (!portConfig || (portConfig->functionMask & function) == 0) {
+    if (!portConfig) {
         return PORTSHARING_UNUSED;
     }
-    return portConfig->functionMask == function ? PORTSHARING_NOT_SHARED : PORTSHARING_SHARED;
+    const uint32_t mask = serialSynthesizeFunctionMask(portConfig->identifier);
+    if ((mask & function) == 0) {
+        return PORTSHARING_UNUSED;
+    }
+    return mask == (uint32_t)function ? PORTSHARING_NOT_SHARED : PORTSHARING_SHARED;
 }
 
 bool isSerialPortShared(const serialPortConfig_t *portConfig, uint16_t functionMask, serialPortFunction_e sharedWithFunction)
 {
-    return (portConfig) && (portConfig->functionMask & sharedWithFunction) && (portConfig->functionMask & functionMask);
+    if (!portConfig) {
+        return false;
+    }
+    const uint32_t mask = serialSynthesizeFunctionMask(portConfig->identifier);
+    return (mask & sharedWithFunction) && (mask & functionMask);
 }
 
 serialPort_t *findSharedSerialPort(uint16_t functionMask, serialPortFunction_e sharedWithFunction)

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -279,19 +279,111 @@ static void clearClaimsOnPort(serialPortIdentifier_e identifier)
 #ifdef USE_TELEMETRY
 // A build can define USE_TELEMETRY without any individual protocol, leaving
 // assignTelemetrySlot() unreachable; mark it possibly-unused so -Werror
-// -Wunused-function doesn't fire (e.g. on PICO).
-static MAYBE_UNUSED bool assignTelemetrySlot(serialPortIdentifier_e identifier, uint8_t protocol)
+// -Wunused-function doesn't fire (e.g. on PICO).  Callers must pre-validate
+// slot availability via canApplyFunctionMask() — this helper asserts on
+// overflow rather than returning an error.
+static MAYBE_UNUSED void assignTelemetrySlot(serialPortIdentifier_e identifier, uint8_t protocol)
 {
     for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
         if (telemetryConfig()->providers[i].protocol == TELEMETRY_PROTOCOL_NONE) {
             telemetryConfigMutable()->providers[i].protocol = protocol;
             telemetryConfigMutable()->providers[i].uart = identifier;
-            return true;
+            return;
         }
     }
-    return false;
 }
 #endif
+
+#ifdef USE_TELEMETRY
+static unsigned countTelemetryBits(uint32_t mask)
+{
+    unsigned n = 0;
+#ifdef USE_TELEMETRY_FRSKY_HUB
+    if (mask & FUNCTION_TELEMETRY_FRSKY_HUB) n++;
+#endif
+#ifdef USE_TELEMETRY_HOTT
+    if (mask & FUNCTION_TELEMETRY_HOTT) n++;
+#endif
+#ifdef USE_TELEMETRY_LTM
+    if (mask & FUNCTION_TELEMETRY_LTM) n++;
+#endif
+#ifdef USE_TELEMETRY_SMARTPORT
+    if (mask & FUNCTION_TELEMETRY_SMARTPORT) n++;
+#endif
+#ifdef USE_TELEMETRY_MAVLINK
+    if (mask & FUNCTION_TELEMETRY_MAVLINK) n++;
+#endif
+#ifdef USE_TELEMETRY_IBUS
+    if (mask & FUNCTION_TELEMETRY_IBUS) n++;
+#endif
+    (void)mask;  // A USE_TELEMETRY build without any sub-protocol touches none.
+    return n;
+}
+#endif
+
+// Check whether a mask can be applied to `identifier` without leaving the
+// feature PGs in an inconsistent state.  Counts bits per category and checks
+// MSP/telemetry slot availability as if clearClaimsOnPort(identifier) had
+// already run — slots currently held by this port are considered free for
+// the new mask.  No PG mutations are performed.
+static bool canApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
+{
+#ifdef USE_VTX_COMMON
+    unsigned vtxBits = 0;
+#ifdef USE_VTX_SMARTAUDIO
+    if (mask & FUNCTION_VTX_SMARTAUDIO) vtxBits++;
+#endif
+#ifdef USE_VTX_TRAMP
+    if (mask & FUNCTION_VTX_TRAMP) vtxBits++;
+#endif
+#ifdef USE_VTX_MSP
+    if (mask & FUNCTION_VTX_MSP) vtxBits++;
+#endif
+    if (vtxBits > 1) {
+        return false;
+    }
+#endif
+
+#ifdef USE_RANGEFINDER
+    unsigned lidarBits = 0;
+    if (mask & FUNCTION_LIDAR_TF) lidarBits++;
+    if (mask & FUNCTION_LIDAR_NL) lidarBits++;
+    if (lidarBits > 1) {
+        return false;
+    }
+#endif
+
+    if (mask & FUNCTION_MSP) {
+        unsigned availableMsp = 0;
+        for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+            if (mspConfig()->msp_uart[i] == SERIAL_PORT_NONE
+                || mspConfig()->msp_uart[i] == identifier) {
+                availableMsp++;
+            }
+        }
+        if (availableMsp < 1) {
+            return false;
+        }
+    }
+
+#ifdef USE_TELEMETRY
+    const unsigned tlmNeeded = countTelemetryBits(mask);
+    if (tlmNeeded > 0) {
+        unsigned availableTlm = 0;
+        for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
+            if (telemetryConfig()->providers[i].protocol == TELEMETRY_PROTOCOL_NONE
+                || telemetryConfig()->providers[i].uart == identifier) {
+                availableTlm++;
+            }
+        }
+        if (availableTlm < tlmNeeded) {
+            return false;
+        }
+    }
+#endif
+
+    return true;
+}
 
 bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 {
@@ -299,21 +391,21 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
         return mask == 0;
     }
 
+    // Validate against the pre-clear state so callers see an atomic
+    // success/failure; if the mask can't be represented we must not
+    // have touched the PGs.
+    if (!canApplyFunctionMask(identifier, mask)) {
+        return false;
+    }
+
     clearClaimsOnPort(identifier);
 
-    bool ok = true;
-
     if (mask & FUNCTION_MSP) {
-        bool placed = false;
         for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
             if (mspConfig()->msp_uart[i] == SERIAL_PORT_NONE) {
                 mspConfigMutable()->msp_uart[i] = identifier;
-                placed = true;
                 break;
             }
-        }
-        if (!placed) {
-            ok = false;
         }
     }
 #ifdef USE_GPS
@@ -347,74 +439,58 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
     }
 #endif
 #ifdef USE_VTX_COMMON
-    {
-        // At most one VTX bit may be set; later bits overwrite earlier ones and flag a conflict.
-        uint8_t vtxBits = 0;
+    // VTX bit count pre-validated ≤ 1; at most one branch fires.
 #ifdef USE_VTX_SMARTAUDIO
-        if (mask & FUNCTION_VTX_SMARTAUDIO) {
-            vtxSettingsConfigMutable()->vtx_uart = identifier;
-            vtxSettingsConfigMutable()->vtx_type = VTXDEV_SMARTAUDIO;
-            vtxBits++;
-        }
-#endif
-#ifdef USE_VTX_TRAMP
-        if (mask & FUNCTION_VTX_TRAMP) {
-            vtxSettingsConfigMutable()->vtx_uart = identifier;
-            vtxSettingsConfigMutable()->vtx_type = VTXDEV_TRAMP;
-            vtxBits++;
-        }
-#endif
-#ifdef USE_VTX_MSP
-        if (mask & FUNCTION_VTX_MSP) {
-            vtxSettingsConfigMutable()->vtx_uart = identifier;
-            vtxSettingsConfigMutable()->vtx_type = VTXDEV_MSP;
-            vtxBits++;
-        }
-#endif
-        if (vtxBits > 1) {
-            ok = false;
-        }
+    if (mask & FUNCTION_VTX_SMARTAUDIO) {
+        vtxSettingsConfigMutable()->vtx_uart = identifier;
+        vtxSettingsConfigMutable()->vtx_type = VTXDEV_SMARTAUDIO;
     }
 #endif
+#ifdef USE_VTX_TRAMP
+    if (mask & FUNCTION_VTX_TRAMP) {
+        vtxSettingsConfigMutable()->vtx_uart = identifier;
+        vtxSettingsConfigMutable()->vtx_type = VTXDEV_TRAMP;
+    }
+#endif
+#ifdef USE_VTX_MSP
+    if (mask & FUNCTION_VTX_MSP) {
+        vtxSettingsConfigMutable()->vtx_uart = identifier;
+        vtxSettingsConfigMutable()->vtx_type = VTXDEV_MSP;
+    }
+#endif
+#endif
 #ifdef USE_RANGEFINDER
-    {
-        // Only overwrite rangefinder_hardware when its current value is
-        // clearly in the *other* lidar category; a compatible or
-        // unselected (RANGEFINDER_NONE) value is left alone so the user's
-        // specific model choice is preserved across CLI/MSP writes.
-        uint8_t lidarBits = 0;
-        if (mask & FUNCTION_LIDAR_TF) {
-            rangefinderConfigMutable()->rangefinder_uart = identifier;
-            switch (rangefinderConfig()->rangefinder_hardware) {
-            case RANGEFINDER_NOOPLOOP_F2:
-            case RANGEFINDER_NOOPLOOP_F2P:
-            case RANGEFINDER_NOOPLOOP_F2PH:
-            case RANGEFINDER_NOOPLOOP_F:
-            case RANGEFINDER_NOOPLOOP_FP:
-            case RANGEFINDER_NOOPLOOP_F2MINI:
-                rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
-                break;
-            default:
-                break;  // compatible or unset — leave alone
-            }
-            lidarBits++;
+    // Lidar bit count pre-validated ≤ 1; at most one branch fires.  Only
+    // overwrite rangefinder_hardware when the current value is clearly in
+    // the *other* lidar category; a compatible or unselected
+    // (RANGEFINDER_NONE) value is left alone so the user's specific model
+    // choice is preserved across CLI/MSP writes.
+    if (mask & FUNCTION_LIDAR_TF) {
+        rangefinderConfigMutable()->rangefinder_uart = identifier;
+        switch (rangefinderConfig()->rangefinder_hardware) {
+        case RANGEFINDER_NOOPLOOP_F2:
+        case RANGEFINDER_NOOPLOOP_F2P:
+        case RANGEFINDER_NOOPLOOP_F2PH:
+        case RANGEFINDER_NOOPLOOP_F:
+        case RANGEFINDER_NOOPLOOP_FP:
+        case RANGEFINDER_NOOPLOOP_F2MINI:
+            rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
+            break;
+        default:
+            break;  // compatible or unset — leave alone
         }
-        if (mask & FUNCTION_LIDAR_NL) {
-            rangefinderConfigMutable()->rangefinder_uart = identifier;
-            switch (rangefinderConfig()->rangefinder_hardware) {
-            case RANGEFINDER_TFMINI:
-            case RANGEFINDER_TF02:
-            case RANGEFINDER_TFNOVA:
-            case RANGEFINDER_UPT1:
-                rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
-                break;
-            default:
-                break;
-            }
-            lidarBits++;
-        }
-        if (lidarBits > 1) {
-            ok = false;
+    }
+    if (mask & FUNCTION_LIDAR_NL) {
+        rangefinderConfigMutable()->rangefinder_uart = identifier;
+        switch (rangefinderConfig()->rangefinder_hardware) {
+        case RANGEFINDER_TFMINI:
+        case RANGEFINDER_TF02:
+        case RANGEFINDER_TFNOVA:
+        case RANGEFINDER_UPT1:
+            rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
+            break;
+        default:
+            break;
         }
     }
 #endif
@@ -428,39 +504,28 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
     }
 #endif
 #ifdef USE_TELEMETRY
+    // Telemetry slot availability pre-validated; assignTelemetrySlot always fits.
 #ifdef USE_TELEMETRY_FRSKY_HUB
-    if (mask & FUNCTION_TELEMETRY_FRSKY_HUB) {
-        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_FRSKY_HUB);
-    }
+    if (mask & FUNCTION_TELEMETRY_FRSKY_HUB) assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_FRSKY_HUB);
 #endif
 #ifdef USE_TELEMETRY_HOTT
-    if (mask & FUNCTION_TELEMETRY_HOTT) {
-        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_HOTT);
-    }
+    if (mask & FUNCTION_TELEMETRY_HOTT) assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_HOTT);
 #endif
 #ifdef USE_TELEMETRY_LTM
-    if (mask & FUNCTION_TELEMETRY_LTM) {
-        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_LTM);
-    }
+    if (mask & FUNCTION_TELEMETRY_LTM) assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_LTM);
 #endif
 #ifdef USE_TELEMETRY_SMARTPORT
-    if (mask & FUNCTION_TELEMETRY_SMARTPORT) {
-        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_SMARTPORT);
-    }
+    if (mask & FUNCTION_TELEMETRY_SMARTPORT) assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_SMARTPORT);
 #endif
 #ifdef USE_TELEMETRY_MAVLINK
-    if (mask & FUNCTION_TELEMETRY_MAVLINK) {
-        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_MAVLINK);
-    }
+    if (mask & FUNCTION_TELEMETRY_MAVLINK) assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_MAVLINK);
 #endif
 #ifdef USE_TELEMETRY_IBUS
-    if (mask & FUNCTION_TELEMETRY_IBUS) {
-        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_IBUS);
-    }
+    if (mask & FUNCTION_TELEMETRY_IBUS) assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_IBUS);
 #endif
 #endif
 
-    return ok;
+    return true;
 }
 
 void serialBackfillFeatureFields(void)
@@ -468,8 +533,17 @@ void serialBackfillFeatureFields(void)
     // Apply every port's mask unconditionally: apply-with-mask=0 runs the
     // clear phase so stale *_uart fields from EEPROM cannot out-live a
     // port that no longer claims them in the legacy view.
+    //
+    // A per-port apply can only fail if the legacy mask itself is
+    // structurally invalid (two VTX protocols on one port, two lidar
+    // categories on one port, or more MSP/telemetry claims across ports
+    // than slots hold).  None of those are reachable from a well-formed
+    // legacy config, so the return value is intentionally discarded; the
+    // synthesized view of a partially-migrated port simply omits the bits
+    // that couldn't be represented, which matches the legacy-is-invalid
+    // semantics those masks had before migration.
     for (unsigned i = 0; i < ARRAYLEN(serialConfig()->portConfigs); i++) {
         const serialPortConfig_t *port = &serialConfig()->portConfigs[i];
-        serialApplyFunctionMask(port->identifier, port->functionMask);
+        (void)serialApplyFunctionMask(port->identifier, port->functionMask);
     }
 }

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -277,7 +277,10 @@ static void clearClaimsOnPort(serialPortIdentifier_e identifier)
 }
 
 #ifdef USE_TELEMETRY
-static bool assignTelemetrySlot(serialPortIdentifier_e identifier, uint8_t protocol)
+// A build can define USE_TELEMETRY without any individual protocol, leaving
+// assignTelemetrySlot() unreachable; mark it possibly-unused so -Werror
+// -Wunused-function doesn't fire (e.g. on PICO).
+static MAYBE_UNUSED bool assignTelemetrySlot(serialPortIdentifier_e identifier, uint8_t protocol)
 {
     for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
         if (telemetryConfig()->providers[i].protocol == TELEMETRY_PROTOCOL_NONE) {

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -27,19 +27,133 @@
 #include "io/serial.h"
 #include "io/serial_feature_map.h"
 
-// Skeleton: returns a synthesized view of which function bits would be
-// set on the given port by looking at each feature's PG.  Individual
-// feature PGs are wired in subsequent commits; until then the legacy
-// serialConfig functionMask remains the source of truth.
+#ifdef USE_GPS
+#include "pg/gps.h"
+#endif
+#if defined(USE_RX_PWM) || defined(USE_RX_PPM) || defined(USE_SERIALRX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
+#include "pg/rx.h"
+#endif
+#ifdef USE_BLACKBOX
+#include "blackbox/blackbox.h"
+#endif
+#ifdef USE_ESC_SENSOR
+#include "sensors/esc_sensor.h"
+#endif
+#ifdef USE_RCDEVICE
+#include "pg/rcdevice.h"
+#endif
+#ifdef USE_GIMBAL
+#include "pg/gimbal.h"
+#endif
+#ifdef USE_VTX_COMMON
+#include "drivers/vtx_common.h"
+#include "io/vtx.h"
+#endif
+#ifdef USE_RANGEFINDER
+#include "sensors/rangefinder.h"
+#endif
+#ifdef USE_OSD
+#include "osd/osd.h"
+#endif
 
 uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 {
-    (void)identifier;
-    return 0;
+    if (identifier == SERIAL_PORT_NONE) {
+        return 0;
+    }
+
+    uint32_t mask = 0;
+
+#ifdef USE_GPS
+    if (gpsConfig()->gps_uart == identifier) {
+        mask |= FUNCTION_GPS;
+    }
+#endif
+#if defined(USE_RX_PWM) || defined(USE_RX_PPM) || defined(USE_SERIALRX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
+    if (rxConfig()->rx_uart == identifier) {
+        mask |= FUNCTION_RX_SERIAL;
+    }
+#endif
+#ifdef USE_BLACKBOX
+    if (blackboxConfig()->blackbox_uart == identifier) {
+        mask |= FUNCTION_BLACKBOX;
+    }
+#endif
+#ifdef USE_ESC_SENSOR
+    if (escSensorConfig()->esc_sensor_uart == identifier) {
+        mask |= FUNCTION_ESC_SENSOR;
+    }
+#endif
+#ifdef USE_RCDEVICE
+    if (rcdeviceConfig()->rcdevice_uart == identifier) {
+        mask |= FUNCTION_RCDEVICE;
+    }
+#endif
+#ifdef USE_GIMBAL
+    if (gimbalTrackConfig()->gimbal_uart == identifier) {
+        mask |= FUNCTION_GIMBAL;
+    }
+#endif
+#ifdef USE_VTX_COMMON
+    if (vtxSettingsConfig()->vtx_uart == identifier) {
+        switch (vtxSettingsConfig()->vtx_type) {
+#ifdef USE_VTX_SMARTAUDIO
+        case VTXDEV_SMARTAUDIO:
+            mask |= FUNCTION_VTX_SMARTAUDIO;
+            break;
+#endif
+#ifdef USE_VTX_TRAMP
+        case VTXDEV_TRAMP:
+            mask |= FUNCTION_VTX_TRAMP;
+            break;
+#endif
+#ifdef USE_VTX_MSP
+        case VTXDEV_MSP:
+            mask |= FUNCTION_VTX_MSP;
+            break;
+#endif
+        default:
+            break;
+        }
+    }
+#endif
+#ifdef USE_RANGEFINDER
+    if (rangefinderConfig()->rangefinder_uart == identifier) {
+        switch (rangefinderConfig()->rangefinder_hardware) {
+        case RANGEFINDER_TFMINI:
+        case RANGEFINDER_TF02:
+        case RANGEFINDER_TFNOVA:
+        case RANGEFINDER_UPT1:
+            mask |= FUNCTION_LIDAR_TF;
+            break;
+        case RANGEFINDER_NOOPLOOP_F2:
+        case RANGEFINDER_NOOPLOOP_F2P:
+        case RANGEFINDER_NOOPLOOP_F2PH:
+        case RANGEFINDER_NOOPLOOP_F:
+        case RANGEFINDER_NOOPLOOP_FP:
+        case RANGEFINDER_NOOPLOOP_F2MINI:
+            mask |= FUNCTION_LIDAR_NL;
+            break;
+        default:
+            break;
+        }
+    }
+#endif
+#ifdef USE_OSD
+    if (osdConfig()->osd_uart == identifier && osdConfig()->displayPortDevice == OSD_DISPLAYPORT_DEVICE_FRSKYOSD) {
+        mask |= FUNCTION_FRSKY_OSD;
+    }
+    if (osdConfig()->osd_custom_text_uart == identifier) {
+        mask |= FUNCTION_OSD_CUSTOM_TEXT;
+    }
+#endif
+
+    return mask;
 }
 
 bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 {
+    // Decomposer wired in a later task; for now behavior is unchanged.
     (void)identifier;
     (void)mask;
     return true;

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -375,22 +375,12 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 #endif
 #ifdef USE_RANGEFINDER
     {
+        // Only overwrite rangefinder_hardware when its current value is
+        // clearly in the *other* lidar category; a compatible or
+        // unselected (RANGEFINDER_NONE) value is left alone so the user's
+        // specific model choice is preserved across CLI/MSP writes.
         uint8_t lidarBits = 0;
         if (mask & FUNCTION_LIDAR_TF) {
-            rangefinderConfigMutable()->rangefinder_uart = identifier;
-            switch (rangefinderConfig()->rangefinder_hardware) {
-            case RANGEFINDER_TFMINI:
-            case RANGEFINDER_TF02:
-            case RANGEFINDER_TFNOVA:
-            case RANGEFINDER_UPT1:
-                break;  // compatible; leave alone
-            default:
-                rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
-                break;
-            }
-            lidarBits++;
-        }
-        if (mask & FUNCTION_LIDAR_NL) {
             rangefinderConfigMutable()->rangefinder_uart = identifier;
             switch (rangefinderConfig()->rangefinder_hardware) {
             case RANGEFINDER_NOOPLOOP_F2:
@@ -399,9 +389,23 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
             case RANGEFINDER_NOOPLOOP_F:
             case RANGEFINDER_NOOPLOOP_FP:
             case RANGEFINDER_NOOPLOOP_F2MINI:
+                rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
                 break;
             default:
+                break;  // compatible or unset — leave alone
+            }
+            lidarBits++;
+        }
+        if (mask & FUNCTION_LIDAR_NL) {
+            rangefinderConfigMutable()->rangefinder_uart = identifier;
+            switch (rangefinderConfig()->rangefinder_hardware) {
+            case RANGEFINDER_TFMINI:
+            case RANGEFINDER_TF02:
+            case RANGEFINDER_TFNOVA:
+            case RANGEFINDER_UPT1:
                 rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
+                break;
+            default:
                 break;
             }
             lidarBits++;
@@ -458,10 +462,11 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 
 void serialBackfillFeatureFields(void)
 {
+    // Apply every port's mask unconditionally: apply-with-mask=0 runs the
+    // clear phase so stale *_uart fields from EEPROM cannot out-live a
+    // port that no longer claims them in the legacy view.
     for (unsigned i = 0; i < ARRAYLEN(serialConfig()->portConfigs); i++) {
         const serialPortConfig_t *port = &serialConfig()->portConfigs[i];
-        if (port->functionMask != 0) {
-            serialApplyFunctionMask(port->identifier, port->functionMask);
-        }
+        serialApplyFunctionMask(port->identifier, port->functionMask);
     }
 }

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -27,6 +27,9 @@
 #include "io/serial.h"
 #include "io/serial_feature_map.h"
 
+#include "msp/msp_serial.h"
+#include "pg/msp.h"
+
 #ifdef USE_GPS
 #include "pg/gps.h"
 #endif
@@ -55,6 +58,9 @@
 #ifdef USE_OSD
 #include "osd/osd.h"
 #endif
+#ifdef USE_TELEMETRY
+#include "telemetry/telemetry.h"
+#endif
 
 uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 {
@@ -63,6 +69,13 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
     }
 
     uint32_t mask = 0;
+
+    for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+        if (mspConfig()->msp_uart[i] == identifier) {
+            mask |= FUNCTION_MSP;
+            break;
+        }
+    }
 
 #ifdef USE_GPS
     if (gpsConfig()->gps_uart == identifier) {
@@ -145,6 +158,47 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
     }
     if (osdConfig()->osd_custom_text_uart == identifier) {
         mask |= FUNCTION_OSD_CUSTOM_TEXT;
+    }
+#endif
+#ifdef USE_TELEMETRY
+    for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
+        if (telemetryConfig()->providers[i].uart != identifier) {
+            continue;
+        }
+        switch (telemetryConfig()->providers[i].protocol) {
+#ifdef USE_TELEMETRY_FRSKY_HUB
+        case TELEMETRY_PROTOCOL_FRSKY_HUB:
+            mask |= FUNCTION_TELEMETRY_FRSKY_HUB;
+            break;
+#endif
+#ifdef USE_TELEMETRY_HOTT
+        case TELEMETRY_PROTOCOL_HOTT:
+            mask |= FUNCTION_TELEMETRY_HOTT;
+            break;
+#endif
+#ifdef USE_TELEMETRY_LTM
+        case TELEMETRY_PROTOCOL_LTM:
+            mask |= FUNCTION_TELEMETRY_LTM;
+            break;
+#endif
+#ifdef USE_TELEMETRY_SMARTPORT
+        case TELEMETRY_PROTOCOL_SMARTPORT:
+            mask |= FUNCTION_TELEMETRY_SMARTPORT;
+            break;
+#endif
+#ifdef USE_TELEMETRY_MAVLINK
+        case TELEMETRY_PROTOCOL_MAVLINK:
+            mask |= FUNCTION_TELEMETRY_MAVLINK;
+            break;
+#endif
+#ifdef USE_TELEMETRY_IBUS
+        case TELEMETRY_PROTOCOL_IBUS:
+            mask |= FUNCTION_TELEMETRY_IBUS;
+            break;
+#endif
+        default:
+            break;
+        }
     }
 #endif
 

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "io/serial.h"
+#include "io/serial_feature_map.h"
+
+// Skeleton: returns a synthesized view of which function bits would be
+// set on the given port by looking at each feature's PG.  Individual
+// feature PGs are wired in subsequent commits; until then the legacy
+// serialConfig functionMask remains the source of truth.
+
+uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
+{
+    (void)identifier;
+    return 0;
+}
+
+bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
+{
+    (void)identifier;
+    (void)mask;
+    return true;
+}

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -205,10 +205,251 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
     return mask;
 }
 
+// Clear any feature PG field currently naming `identifier` so the
+// apply phase can reassign cleanly.  Collapsed-enum selectors
+// (rangefinder_hardware, displayPortDevice, vtx_type) are left alone —
+// removing a UART doesn't imply changing the chosen hardware/protocol.
+static void clearClaimsOnPort(serialPortIdentifier_e identifier)
+{
+    for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+        if (mspConfig()->msp_uart[i] == identifier) {
+            mspConfigMutable()->msp_uart[i] = SERIAL_PORT_NONE;
+        }
+    }
+#ifdef USE_GPS
+    if (gpsConfig()->gps_uart == identifier) {
+        gpsConfigMutable()->gps_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#if defined(USE_RX_PWM) || defined(USE_RX_PPM) || defined(USE_SERIALRX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
+    if (rxConfig()->rx_uart == identifier) {
+        rxConfigMutable()->rx_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_BLACKBOX
+    if (blackboxConfig()->blackbox_uart == identifier) {
+        blackboxConfigMutable()->blackbox_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_ESC_SENSOR
+    if (escSensorConfig()->esc_sensor_uart == identifier) {
+        escSensorConfigMutable()->esc_sensor_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_RCDEVICE
+    if (rcdeviceConfig()->rcdevice_uart == identifier) {
+        rcdeviceConfigMutable()->rcdevice_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_GIMBAL
+    if (gimbalTrackConfig()->gimbal_uart == identifier) {
+        gimbalTrackConfigMutable()->gimbal_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_VTX_COMMON
+    if (vtxSettingsConfig()->vtx_uart == identifier) {
+        vtxSettingsConfigMutable()->vtx_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_RANGEFINDER
+    if (rangefinderConfig()->rangefinder_uart == identifier) {
+        rangefinderConfigMutable()->rangefinder_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_OSD
+    if (osdConfig()->osd_uart == identifier) {
+        osdConfigMutable()->osd_uart = SERIAL_PORT_NONE;
+    }
+    if (osdConfig()->osd_custom_text_uart == identifier) {
+        osdConfigMutable()->osd_custom_text_uart = SERIAL_PORT_NONE;
+    }
+#endif
+#ifdef USE_TELEMETRY
+    for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
+        if (telemetryConfig()->providers[i].uart == identifier) {
+            telemetryConfigMutable()->providers[i].protocol = TELEMETRY_PROTOCOL_NONE;
+            telemetryConfigMutable()->providers[i].uart = SERIAL_PORT_NONE;
+        }
+    }
+#endif
+}
+
+#ifdef USE_TELEMETRY
+static bool assignTelemetrySlot(serialPortIdentifier_e identifier, uint8_t protocol)
+{
+    for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
+        if (telemetryConfig()->providers[i].protocol == TELEMETRY_PROTOCOL_NONE) {
+            telemetryConfigMutable()->providers[i].protocol = protocol;
+            telemetryConfigMutable()->providers[i].uart = identifier;
+            return true;
+        }
+    }
+    return false;
+}
+#endif
+
 bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 {
-    // Decomposer wired in a later task; for now behavior is unchanged.
-    (void)identifier;
-    (void)mask;
-    return true;
+    if (identifier == SERIAL_PORT_NONE) {
+        return mask == 0;
+    }
+
+    clearClaimsOnPort(identifier);
+
+    bool ok = true;
+
+    if (mask & FUNCTION_MSP) {
+        bool placed = false;
+        for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+            if (mspConfig()->msp_uart[i] == SERIAL_PORT_NONE) {
+                mspConfigMutable()->msp_uart[i] = identifier;
+                placed = true;
+                break;
+            }
+        }
+        if (!placed) {
+            ok = false;
+        }
+    }
+#ifdef USE_GPS
+    if (mask & FUNCTION_GPS) {
+        gpsConfigMutable()->gps_uart = identifier;
+    }
+#endif
+#if defined(USE_RX_PWM) || defined(USE_RX_PPM) || defined(USE_SERIALRX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
+    if (mask & FUNCTION_RX_SERIAL) {
+        rxConfigMutable()->rx_uart = identifier;
+    }
+#endif
+#ifdef USE_BLACKBOX
+    if (mask & FUNCTION_BLACKBOX) {
+        blackboxConfigMutable()->blackbox_uart = identifier;
+    }
+#endif
+#ifdef USE_ESC_SENSOR
+    if (mask & FUNCTION_ESC_SENSOR) {
+        escSensorConfigMutable()->esc_sensor_uart = identifier;
+    }
+#endif
+#ifdef USE_RCDEVICE
+    if (mask & FUNCTION_RCDEVICE) {
+        rcdeviceConfigMutable()->rcdevice_uart = identifier;
+    }
+#endif
+#ifdef USE_GIMBAL
+    if (mask & FUNCTION_GIMBAL) {
+        gimbalTrackConfigMutable()->gimbal_uart = identifier;
+    }
+#endif
+#ifdef USE_VTX_COMMON
+    {
+        // At most one VTX bit may be set; later bits overwrite earlier ones and flag a conflict.
+        uint8_t vtxBits = 0;
+#ifdef USE_VTX_SMARTAUDIO
+        if (mask & FUNCTION_VTX_SMARTAUDIO) {
+            vtxSettingsConfigMutable()->vtx_uart = identifier;
+            vtxSettingsConfigMutable()->vtx_type = VTXDEV_SMARTAUDIO;
+            vtxBits++;
+        }
+#endif
+#ifdef USE_VTX_TRAMP
+        if (mask & FUNCTION_VTX_TRAMP) {
+            vtxSettingsConfigMutable()->vtx_uart = identifier;
+            vtxSettingsConfigMutable()->vtx_type = VTXDEV_TRAMP;
+            vtxBits++;
+        }
+#endif
+#ifdef USE_VTX_MSP
+        if (mask & FUNCTION_VTX_MSP) {
+            vtxSettingsConfigMutable()->vtx_uart = identifier;
+            vtxSettingsConfigMutable()->vtx_type = VTXDEV_MSP;
+            vtxBits++;
+        }
+#endif
+        if (vtxBits > 1) {
+            ok = false;
+        }
+    }
+#endif
+#ifdef USE_RANGEFINDER
+    {
+        uint8_t lidarBits = 0;
+        if (mask & FUNCTION_LIDAR_TF) {
+            rangefinderConfigMutable()->rangefinder_uart = identifier;
+            switch (rangefinderConfig()->rangefinder_hardware) {
+            case RANGEFINDER_TFMINI:
+            case RANGEFINDER_TF02:
+            case RANGEFINDER_TFNOVA:
+            case RANGEFINDER_UPT1:
+                break;  // compatible; leave alone
+            default:
+                rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
+                break;
+            }
+            lidarBits++;
+        }
+        if (mask & FUNCTION_LIDAR_NL) {
+            rangefinderConfigMutable()->rangefinder_uart = identifier;
+            switch (rangefinderConfig()->rangefinder_hardware) {
+            case RANGEFINDER_NOOPLOOP_F2:
+            case RANGEFINDER_NOOPLOOP_F2P:
+            case RANGEFINDER_NOOPLOOP_F2PH:
+            case RANGEFINDER_NOOPLOOP_F:
+            case RANGEFINDER_NOOPLOOP_FP:
+            case RANGEFINDER_NOOPLOOP_F2MINI:
+                break;
+            default:
+                rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
+                break;
+            }
+            lidarBits++;
+        }
+        if (lidarBits > 1) {
+            ok = false;
+        }
+    }
+#endif
+#ifdef USE_OSD
+    if (mask & FUNCTION_FRSKY_OSD) {
+        osdConfigMutable()->osd_uart = identifier;
+        osdConfigMutable()->displayPortDevice = OSD_DISPLAYPORT_DEVICE_FRSKYOSD;
+    }
+    if (mask & FUNCTION_OSD_CUSTOM_TEXT) {
+        osdConfigMutable()->osd_custom_text_uart = identifier;
+    }
+#endif
+#ifdef USE_TELEMETRY
+#ifdef USE_TELEMETRY_FRSKY_HUB
+    if (mask & FUNCTION_TELEMETRY_FRSKY_HUB) {
+        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_FRSKY_HUB);
+    }
+#endif
+#ifdef USE_TELEMETRY_HOTT
+    if (mask & FUNCTION_TELEMETRY_HOTT) {
+        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_HOTT);
+    }
+#endif
+#ifdef USE_TELEMETRY_LTM
+    if (mask & FUNCTION_TELEMETRY_LTM) {
+        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_LTM);
+    }
+#endif
+#ifdef USE_TELEMETRY_SMARTPORT
+    if (mask & FUNCTION_TELEMETRY_SMARTPORT) {
+        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_SMARTPORT);
+    }
+#endif
+#ifdef USE_TELEMETRY_MAVLINK
+    if (mask & FUNCTION_TELEMETRY_MAVLINK) {
+        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_MAVLINK);
+    }
+#endif
+#ifdef USE_TELEMETRY_IBUS
+    if (mask & FUNCTION_TELEMETRY_IBUS) {
+        ok &= assignTelemetrySlot(identifier, TELEMETRY_PROTOCOL_IBUS);
+    }
+#endif
+#endif
+
+    return ok;
 }

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -24,6 +24,8 @@
 
 #include "platform.h"
 
+#include "common/utils.h"
+
 #include "io/serial.h"
 #include "io/serial_feature_map.h"
 
@@ -452,4 +454,14 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 #endif
 
     return ok;
+}
+
+void serialBackfillFeatureFields(void)
+{
+    for (unsigned i = 0; i < ARRAYLEN(serialConfig()->portConfigs); i++) {
+        const serialPortConfig_t *port = &serialConfig()->portConfigs[i];
+        if (port->functionMask != 0) {
+            serialApplyFunctionMask(port->identifier, port->functionMask);
+        }
+    }
 }

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -134,24 +134,7 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 #endif
 #ifdef USE_RANGEFINDER
     if (rangefinderConfig()->rangefinder_uart == identifier) {
-        switch (rangefinderConfig()->rangefinder_hardware) {
-        case RANGEFINDER_TFMINI:
-        case RANGEFINDER_TF02:
-        case RANGEFINDER_TFNOVA:
-        case RANGEFINDER_UPT1:
-            mask |= FUNCTION_LIDAR_TF;
-            break;
-        case RANGEFINDER_NOOPLOOP_F2:
-        case RANGEFINDER_NOOPLOOP_F2P:
-        case RANGEFINDER_NOOPLOOP_F2PH:
-        case RANGEFINDER_NOOPLOOP_F:
-        case RANGEFINDER_NOOPLOOP_FP:
-        case RANGEFINDER_NOOPLOOP_F2MINI:
-            mask |= FUNCTION_LIDAR_NL;
-            break;
-        default:
-            break;
-        }
+        mask |= FUNCTION_LIDAR;
     }
 #endif
 #ifdef USE_OSD
@@ -344,15 +327,6 @@ static bool canApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mas
     }
 #endif
 
-#ifdef USE_RANGEFINDER
-    unsigned lidarBits = 0;
-    if (mask & FUNCTION_LIDAR_TF) lidarBits++;
-    if (mask & FUNCTION_LIDAR_NL) lidarBits++;
-    if (lidarBits > 1) {
-        return false;
-    }
-#endif
-
     if (mask & FUNCTION_MSP) {
         unsigned availableMsp = 0;
         for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
@@ -460,38 +434,8 @@ bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
 #endif
 #endif
 #ifdef USE_RANGEFINDER
-    // Lidar bit count pre-validated ≤ 1; at most one branch fires.  Only
-    // overwrite rangefinder_hardware when the current value is clearly in
-    // the *other* lidar category; a compatible or unselected
-    // (RANGEFINDER_NONE) value is left alone so the user's specific model
-    // choice is preserved across CLI/MSP writes.
-    if (mask & FUNCTION_LIDAR_TF) {
+    if (mask & FUNCTION_LIDAR) {
         rangefinderConfigMutable()->rangefinder_uart = identifier;
-        switch (rangefinderConfig()->rangefinder_hardware) {
-        case RANGEFINDER_NOOPLOOP_F2:
-        case RANGEFINDER_NOOPLOOP_F2P:
-        case RANGEFINDER_NOOPLOOP_F2PH:
-        case RANGEFINDER_NOOPLOOP_F:
-        case RANGEFINDER_NOOPLOOP_FP:
-        case RANGEFINDER_NOOPLOOP_F2MINI:
-            rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
-            break;
-        default:
-            break;  // compatible or unset — leave alone
-        }
-    }
-    if (mask & FUNCTION_LIDAR_NL) {
-        rangefinderConfigMutable()->rangefinder_uart = identifier;
-        switch (rangefinderConfig()->rangefinder_hardware) {
-        case RANGEFINDER_TFMINI:
-        case RANGEFINDER_TF02:
-        case RANGEFINDER_TFNOVA:
-        case RANGEFINDER_UPT1:
-            rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
-            break;
-        default:
-            break;
-        }
     }
 #endif
 #ifdef USE_OSD

--- a/src/main/io/serial_feature_map.h
+++ b/src/main/io/serial_feature_map.h
@@ -36,3 +36,10 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier);
 // migration on config load.  Returns false when the requested combination
 // cannot be represented (e.g. more MSP ports requested than slots available).
 bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask);
+
+// Walk serialConfig.portConfigs[] and populate the per-feature PG fields
+// from each port's legacy functionMask.  Idempotent.  Called once after
+// EEPROM load so pre-existing configs carry their function assignments
+// into the new per-feature view while the legacy mask is still the
+// runtime source of truth.
+void serialBackfillFeatureFields(void);

--- a/src/main/io/serial_feature_map.h
+++ b/src/main/io/serial_feature_map.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "io/serial.h"
+
+// Walk every feature PG that claims a UART and build a functionMask
+// for the given port.  Drives the back-compat view exposed over MSP
+// (MSP_CF_SERIAL_CONFIG) and the CLI `serial` command's output.
+uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier);
+
+// Apply a legacy bitmask to the feature PGs.  Used by MSP_SET_CF_SERIAL_CONFIG
+// and the CLI `serial` command's write path, and by the one-shot EEPROM
+// migration on config load.  Returns false when the requested combination
+// cannot be represented (e.g. more MSP ports requested than slots available).
+bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask);

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -39,6 +39,7 @@
 
 #include "flight/failsafe.h"
 
+#include "io/serial.h"
 #include "io/vtx_control.h"
 
 #include "pg/pg.h"
@@ -64,6 +65,8 @@ void pgResetFn_vtxSettingsConfig(vtxSettingsConfig_t *vtxSettingsConfig)
     vtxSettingsConfig->pitModeFreq = VTX_TABLE_DEFAULT_PITMODE_FREQ;
     vtxSettingsConfig->lowPowerDisarm = VTX_LOW_POWER_DISARM_OFF;
     vtxSettingsConfig->softserialAlt = 0;
+    vtxSettingsConfig->vtx_type = VTXDEV_UNSUPPORTED;
+    vtxSettingsConfig->vtx_uart = SERIAL_PORT_NONE;
 }
 
 typedef enum {

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -40,6 +40,8 @@ typedef struct vtxSettingsConfig_s {
     uint16_t pitModeFreq;   // sets out-of-range pitmode frequency
     uint8_t lowPowerDisarm; // min power while disarmed, from vtxLowerPowerDisarm_e
     uint8_t softserialAlt;  // prepend 0xff before sending frame even with SOFTSERIAL
+    uint8_t vtx_type;       // vtxDevType_e: VTXDEV_UNSUPPORTED/SMARTAUDIO/TRAMP/MSP, picks the driver
+    int8_t vtx_uart;        // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } vtxSettingsConfig_t;
 
 PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -100,6 +100,7 @@
 #include "io/ledstrip.h"
 #include "io/serial.h"
 #include "io/serial_4way.h"
+#include "io/serial_feature_map.h"
 #include "io/transponder_ir.h"
 #include "io/usb_msc.h"
 #include "io/vtx_control.h"
@@ -4061,6 +4062,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 portConfig->gps_baudrateIndex = sbufReadU8(src);
                 portConfig->telemetry_baudrateIndex = sbufReadU8(src);
                 portConfig->blackbox_baudrateIndex = sbufReadU8(src);
+                serialApplyFunctionMask(identifier, portConfig->functionMask);
             }
         }
         break;
@@ -4088,6 +4090,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             portConfig->gps_baudrateIndex = sbufReadU8(src);
             portConfig->telemetry_baudrateIndex = sbufReadU8(src);
             portConfig->blackbox_baudrateIndex = sbufReadU8(src);
+            serialApplyFunctionMask(identifier, portConfig->functionMask);
             // Skip unknown bytes
             while (start - sbufBytesRemaining(src) < portConfigSize && sbufBytesRemaining(src)) {
                 sbufReadU8(src);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4062,7 +4062,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 portConfig->gps_baudrateIndex = sbufReadU8(src);
                 portConfig->telemetry_baudrateIndex = sbufReadU8(src);
                 portConfig->blackbox_baudrateIndex = sbufReadU8(src);
-                serialApplyFunctionMask(identifier, portConfig->functionMask);
+                if (!serialApplyFunctionMask(identifier, portConfig->functionMask)) {
+                    return MSP_RESULT_ERROR;
+                }
             }
         }
         break;
@@ -4090,7 +4092,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             portConfig->gps_baudrateIndex = sbufReadU8(src);
             portConfig->telemetry_baudrateIndex = sbufReadU8(src);
             portConfig->blackbox_baudrateIndex = sbufReadU8(src);
-            serialApplyFunctionMask(identifier, portConfig->functionMask);
+            if (!serialApplyFunctionMask(identifier, portConfig->functionMask)) {
+                return MSP_RESULT_ERROR;
+            }
             // Skip unknown bytes
             while (start - sbufBytesRemaining(src) < portConfigSize && sbufBytesRemaining(src)) {
                 sbufReadU8(src);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -4268,7 +4268,9 @@ RAM_CODE static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t
                 portConfig->gps_baudrateIndex = sbufReadU8(src);
                 portConfig->telemetry_baudrateIndex = sbufReadU8(src);
                 portConfig->blackbox_baudrateIndex = sbufReadU8(src);
-                serialApplyFunctionMask(identifier, portConfig->functionMask);
+                if (!serialApplyFunctionMask(identifier, portConfig->functionMask)) {
+                    return MSP_RESULT_ERROR;
+                }
             }
         }
         break;
@@ -4299,7 +4301,9 @@ RAM_CODE static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t
             portConfig->gps_baudrateIndex = sbufReadU8(src);
             portConfig->telemetry_baudrateIndex = sbufReadU8(src);
             portConfig->blackbox_baudrateIndex = sbufReadU8(src);
-            serialApplyFunctionMask(identifier, portConfig->functionMask);
+            if (!serialApplyFunctionMask(identifier, portConfig->functionMask)) {
+                return MSP_RESULT_ERROR;
+            }
             // Skip unknown bytes
             while (start - sbufBytesRemaining(src) < portConfigSize && sbufBytesRemaining(src)) {
                 sbufReadU8(src);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -101,6 +101,7 @@
 #include "io/ledstrip.h"
 #include "io/serial.h"
 #include "io/serial_4way.h"
+#include "io/serial_feature_map.h"
 #include "io/transponder_ir.h"
 #include "io/usb_msc.h"
 #include "io/vtx_control.h"
@@ -4267,6 +4268,7 @@ RAM_CODE static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t
                 portConfig->gps_baudrateIndex = sbufReadU8(src);
                 portConfig->telemetry_baudrateIndex = sbufReadU8(src);
                 portConfig->blackbox_baudrateIndex = sbufReadU8(src);
+                serialApplyFunctionMask(identifier, portConfig->functionMask);
             }
         }
         break;
@@ -4297,6 +4299,7 @@ RAM_CODE static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t
             portConfig->gps_baudrateIndex = sbufReadU8(src);
             portConfig->telemetry_baudrateIndex = sbufReadU8(src);
             portConfig->blackbox_baudrateIndex = sbufReadU8(src);
+            serialApplyFunctionMask(identifier, portConfig->functionMask);
             // Skip unknown bytes
             while (start - sbufBytesRemaining(src) < portConfigSize && sbufBytesRemaining(src)) {
                 sbufReadU8(src);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -80,6 +80,7 @@
 #include "io/beeper.h"
 #include "io/flashfs.h"
 #include "io/gps.h"
+#include "io/serial.h"
 
 #include "osd/osd.h"
 #include "osd/osd_elements.h"
@@ -433,6 +434,9 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 #ifdef USE_RACE_PRO
     osdConfig->osd_show_spec_prearm = true;
 #endif // USE_RACE_PRO
+
+    osdConfig->osd_uart = SERIAL_PORT_NONE;
+    osdConfig->osd_custom_text_uart = SERIAL_PORT_NONE;
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -378,6 +378,8 @@ typedef struct osdConfig_s {
     uint8_t osd_show_spec_prearm;
 #endif // USE_SPEC_PREARM_SCREEN
     displayPortSeverity_e arming_logo;        // font from which to display logo on arming
+    int8_t osd_uart;                          // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned. Bit chosen by displayPortDevice (FRSKYOSD=FUNCTION_FRSKY_OSD, else none).
+    int8_t osd_custom_text_uart;              // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned.  Always maps to FUNCTION_OSD_CUSTOM_TEXT when set.
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -398,6 +398,8 @@ typedef struct osdConfig_s {
     uint8_t osd_show_spec_prearm;
 #endif // USE_SPEC_PREARM_SCREEN
     displayPortSeverity_e arming_logo;        // font from which to display logo on arming
+    int8_t osd_uart;                          // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned. Bit chosen by displayPortDevice (FRSKYOSD=FUNCTION_FRSKY_OSD, else none).
+    int8_t osd_custom_text_uart;              // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned.  Always maps to FUNCTION_OSD_CUSTOM_TEXT when set.
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/pg/gimbal.c
+++ b/src/main/pg/gimbal.c
@@ -23,6 +23,8 @@
 
 #ifdef USE_GIMBAL
 
+#include "io/serial.h"
+
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
@@ -48,6 +50,7 @@ PG_RESET_TEMPLATE(gimbalTrackConfig_t, gimbalTrackConfig,
     .gimbal_yaw_offset          = 0,
     .gimbal_yaw_limit           = 100,
     .gimbal_stabilisation       = 0,
-    .gimbal_sensitivity         = 15
+    .gimbal_sensitivity         = 15,
+    .gimbal_uart                = SERIAL_PORT_NONE,
 );
 #endif

--- a/src/main/pg/gimbal.h
+++ b/src/main/pg/gimbal.h
@@ -42,6 +42,7 @@ typedef struct gimbalTrackConfig_s {
     int8_t gimbal_yaw_limit;
     int8_t gimbal_stabilisation;
     int8_t gimbal_sensitivity;
+    int8_t gimbal_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } gimbalTrackConfig_t;
 
 PG_DECLARE(gimbalTrackConfig_t, gimbalTrackConfig);

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -23,6 +23,7 @@
 #ifdef USE_GPS
 
 #include "io/gps.h"
+#include "io/serial.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -50,6 +51,7 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .gps_ublox_utc_standard = UBLOX_UTC_STANDARD_AUTO,
     .gps_ublox_enable_ana = false,
     .nmeaCustomCommands = "",
+    .gps_uart = SERIAL_PORT_NONE,
 );
 
 #endif // USE_GPS

--- a/src/main/pg/gps.h
+++ b/src/main/pg/gps.h
@@ -42,6 +42,7 @@ typedef struct gpsConfig_s {
     uint8_t gps_ublox_utc_standard;
     bool gps_ublox_enable_ana;
     char nmeaCustomCommands[NMEA_CUSTOM_COMMANDS_MAX_LENGTH + 1];
+    int8_t gps_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);

--- a/src/main/pg/msp.c
+++ b/src/main/pg/msp.c
@@ -20,9 +20,19 @@
 
 #include "platform.h"
 
+#include "io/serial.h"
+
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
 #include "msp.h"
 
-PG_REGISTER(mspConfig_t, mspConfig, PG_MSP_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(mspConfig_t, mspConfig, PG_MSP_CONFIG, 0);
+
+void pgResetFn_mspConfig(mspConfig_t *mspConfig)
+{
+    mspConfig->halfDuplex = 0;
+    for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+        mspConfig->msp_uart[i] = SERIAL_PORT_NONE;
+    }
+}

--- a/src/main/pg/msp.h
+++ b/src/main/pg/msp.h
@@ -21,11 +21,13 @@
 #pragma once
 
 #include "drivers/io_types.h"
+#include "msp/msp_serial.h"
 
 #include "pg/pg.h"
 
 typedef struct mspConfig_s {
     uint8_t halfDuplex; // allow msp to operate in half duplex mode
+    int8_t msp_uart[MAX_MSP_PORT_COUNT];  // serialPortIdentifier_e per slot; SERIAL_PORT_NONE = unused
 } mspConfig_t;
 
 PG_DECLARE(mspConfig_t, mspConfig);

--- a/src/main/pg/rcdevice.c
+++ b/src/main/pg/rcdevice.c
@@ -20,6 +20,8 @@
 
 #include "platform.h"
 
+#include "io/serial.h"
+
 #include "pg/pg_ids.h"
 #include "pg/rcdevice.h"
 
@@ -31,4 +33,5 @@ void pgResetFn_rcdeviceConfig(rcdeviceConfig_t *rcdeviceConfig)
     rcdeviceConfig->initDeviceAttemptInterval = 1000;
     rcdeviceConfig->feature = 0;
     rcdeviceConfig->protocolVersion = 0;
+    rcdeviceConfig->rcdevice_uart = SERIAL_PORT_NONE;
 }

--- a/src/main/pg/rcdevice.h
+++ b/src/main/pg/rcdevice.h
@@ -30,6 +30,7 @@ typedef struct rcdeviceConfig_s {
     // sometimes FC can't get featureInfo from devie(still no idea), so user can set it manaually.
     uint32_t feature;
     uint8_t protocolVersion;
+    int8_t rcdevice_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } rcdeviceConfig_t;
 
 PG_DECLARE(rcdeviceConfig_t, rcdeviceConfig);

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -31,6 +31,7 @@
 #include "drivers/io.h"
 #include "fc/rc.h"
 #include "fc/rc_controls.h"
+#include "io/serial.h"
 #include "rx/rx.h"
 #include "rx/rx_spi.h"
 
@@ -115,6 +116,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .sbus_baud_fast = false,
         .msp_override_channels_mask = 0,
         .crsf_use_negotiated_baud = false,
+        .rx_uart = SERIAL_PORT_NONE,
     );
 
 #ifdef RX_CHANNELS_TAER

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -63,6 +63,7 @@ typedef struct rxConfig_s {
     uint32_t msp_override_channels_mask;       // Channels to override when the MSP override mode is enabled
     uint8_t msp_override_failsafe;             // if false then extra RC link is always required in msp_override mode, true - allows control via msp_override without extra RC link (autonomous use case)
     uint8_t crsf_use_negotiated_baud;          // Use negotiated baud rate for CRSF V3
+    int8_t rx_uart;                            // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -75,7 +75,8 @@ Byte 9: 8-bit CRC
 PG_REGISTER_WITH_RESET_TEMPLATE(escSensorConfig_t, escSensorConfig, PG_ESC_SENSOR_CONFIG, 0);
 
 PG_RESET_TEMPLATE(escSensorConfig_t, escSensorConfig,
-        .halfDuplex = 0
+        .halfDuplex = 0,
+        .esc_sensor_uart = SERIAL_PORT_NONE,
 );
 
 /*

--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -25,7 +25,7 @@
 typedef struct escSensorConfig_s {
     uint8_t halfDuplex;             // Set to false to listen on the TX pin for telemetry data
     uint16_t offset;                // offset consumed by the flight controller / VTX / cam / ... in milliampere
-
+    int8_t esc_sensor_uart;         // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } escSensorConfig_t;
 
 PG_DECLARE(escSensorConfig_t, escSensorConfig);

--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -27,7 +27,7 @@
 typedef struct escSensorConfig_s {
     uint8_t halfDuplex;             // Set to false to listen on the TX pin for telemetry data
     uint16_t offset;                // offset consumed by the flight controller / VTX / cam / ... in milliampere
-
+    int8_t esc_sensor_uart;         // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned
 } escSensorConfig_t;
 
 PG_DECLARE(escSensorConfig_t, escSensorConfig);

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -47,6 +47,7 @@
 #include "drivers/time.h"
 
 #include "fc/runtime_config.h"
+#include "io/serial.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -77,6 +78,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(rangefinderConfig_t, rangefinderConfig, PG_RANGE
 
 PG_RESET_TEMPLATE(rangefinderConfig_t, rangefinderConfig,
     .rangefinder_hardware = RANGEFINDER_NONE,
+    .rangefinder_uart = SERIAL_PORT_NONE,
 );
 
 #ifdef USE_RANGEFINDER_HCSR04

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -48,6 +48,7 @@ typedef enum {
 
 typedef struct rangefinderConfig_s {
     uint8_t rangefinder_hardware;
+    int8_t rangefinder_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned. FUNCTION_LIDAR_TF/LIDAR_NL selected by rangefinder_hardware.
 } rangefinderConfig_t;
 
 PG_DECLARE(rangefinderConfig_t, rangefinderConfig);

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -48,7 +48,7 @@ typedef enum {
 
 typedef struct rangefinderConfig_s {
     uint8_t rangefinder_hardware;
-    int8_t rangefinder_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned. FUNCTION_LIDAR_TF/LIDAR_NL selected by rangefinder_hardware.
+    int8_t rangefinder_uart;  // serialPortIdentifier_e; SERIAL_PORT_NONE = unassigned. Driver selected by rangefinder_hardware.
 } rangefinderConfig_t;
 
 PG_DECLARE(rangefinderConfig_t, rangefinderConfig);

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -60,35 +60,38 @@
 #include "telemetry/ibus.h"
 #include "telemetry/msp_shared.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 6);
+PG_REGISTER_WITH_RESET_FN(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 6);
 
-PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
-    .telemetry_inverted = false,
-    .halfDuplex = 1,
-    .gpsNoFixLatitude = 0,
-    .gpsNoFixLongitude = 0,
-    .frsky_coordinate_format = FRSKY_FORMAT_DMS,
-    .frsky_unit = UNIT_METRIC,
-    .frsky_vfas_precision = 0,
-    .hottAlarmSoundInterval = 5,
-    .pidValuesAsTelemetry = 0,
-    .report_cell_voltage = false,
-    .flysky_sensors = {
-            IBUS_SENSOR_TYPE_TEMPERATURE,
-            IBUS_SENSOR_TYPE_RPM_FLYSKY,
-            IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE
-    },
-    .disabledSensors = ESC_SENSOR_ALL | SENSOR_CAP_USED,
-    .mavlink_mah_as_heading_divisor = 0,
-    .mavlink_min_txbuff = 35,
-    .mavlink_extended_status_rate = 2,
-    .mavlink_rc_channels_rate = 1,
-    .mavlink_position_rate = 2,
-    .mavlink_extra1_rate = 2,
-    .mavlink_extra2_rate = 2,
-    .mavlink_extra3_rate = 1,
-    .crsf_tlm_accgyro = 0,
-);
+void pgResetFn_telemetryConfig(telemetryConfig_t *telemetryConfig)
+{
+    telemetryConfig->telemetry_inverted = false;
+    telemetryConfig->halfDuplex = 1;
+    telemetryConfig->gpsNoFixLatitude = 0;
+    telemetryConfig->gpsNoFixLongitude = 0;
+    telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
+    telemetryConfig->frsky_unit = UNIT_METRIC;
+    telemetryConfig->frsky_vfas_precision = 0;
+    telemetryConfig->hottAlarmSoundInterval = 5;
+    telemetryConfig->pidValuesAsTelemetry = 0;
+    telemetryConfig->report_cell_voltage = false;
+    telemetryConfig->flysky_sensors[0] = IBUS_SENSOR_TYPE_TEMPERATURE;
+    telemetryConfig->flysky_sensors[1] = IBUS_SENSOR_TYPE_RPM_FLYSKY;
+    telemetryConfig->flysky_sensors[2] = IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE;
+    telemetryConfig->disabledSensors = ESC_SENSOR_ALL | SENSOR_CAP_USED;
+    telemetryConfig->mavlink_mah_as_heading_divisor = 0;
+    telemetryConfig->mavlink_min_txbuff = 35;
+    telemetryConfig->mavlink_extended_status_rate = 2;
+    telemetryConfig->mavlink_rc_channels_rate = 1;
+    telemetryConfig->mavlink_position_rate = 2;
+    telemetryConfig->mavlink_extra1_rate = 2;
+    telemetryConfig->mavlink_extra2_rate = 2;
+    telemetryConfig->mavlink_extra3_rate = 1;
+    telemetryConfig->crsf_tlm_accgyro = 0;
+    for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
+        telemetryConfig->providers[i].protocol = TELEMETRY_PROTOCOL_NONE;
+        telemetryConfig->providers[i].uart = SERIAL_PORT_NONE;
+    }
+}
 
 void telemetryInit(void)
 {

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -57,7 +57,10 @@ typedef struct telemetryProvider_s {
     int8_t uart;       // serialPortIdentifier_e; SERIAL_PORT_NONE = unused slot
 } telemetryProvider_t;
 
-#define MAX_TELEMETRY_PROVIDERS 3
+// One slot per protocol bit in serialPortFunction_e (FrSky Hub, HoTT, LTM,
+// SmartPort, MAVLink, iBus).  Sized so a legacy functionMask that assigns
+// every telemetry protocol across distinct ports still decomposes cleanly.
+#define MAX_TELEMETRY_PROVIDERS 6
 
 typedef enum {
     SENSOR_VOLTAGE         = 1 << 0,

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -43,6 +43,23 @@ typedef enum {
 } frskyGpsCoordFormat_e;
 
 typedef enum {
+    TELEMETRY_PROTOCOL_NONE = 0,
+    TELEMETRY_PROTOCOL_FRSKY_HUB,
+    TELEMETRY_PROTOCOL_HOTT,
+    TELEMETRY_PROTOCOL_LTM,
+    TELEMETRY_PROTOCOL_SMARTPORT,
+    TELEMETRY_PROTOCOL_MAVLINK,
+    TELEMETRY_PROTOCOL_IBUS,
+} telemetryProtocol_e;
+
+typedef struct telemetryProvider_s {
+    uint8_t protocol;  // telemetryProtocol_e
+    int8_t uart;       // serialPortIdentifier_e; SERIAL_PORT_NONE = unused slot
+} telemetryProvider_t;
+
+#define MAX_TELEMETRY_PROVIDERS 3
+
+typedef enum {
     SENSOR_VOLTAGE         = 1 << 0,
     SENSOR_CURRENT         = 1 << 1,
     SENSOR_FUEL            = 1 << 2,
@@ -93,6 +110,7 @@ typedef struct telemetryConfig_s {
     uint8_t mavlink_extra2_rate;
     uint8_t mavlink_extra3_rate;
     uint8_t crsf_tlm_accgyro;
+    telemetryProvider_t providers[MAX_TELEMETRY_PROVIDERS];
 } telemetryConfig_t;
 
 PG_DECLARE(telemetryConfig_t, telemetryConfig);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -331,6 +331,30 @@ scheduler_unittest_SRC := \
 scheduler_unittest_DEFINES := \
 		USE_OSD=
 
+serial_feature_map_unittest_SRC := \
+		$(USER_DIR)/io/serial_feature_map.c
+
+serial_feature_map_unittest_DEFINES := \
+		USE_GPS= \
+		USE_SERIALRX= \
+		USE_BLACKBOX= \
+		USE_ESC_SENSOR= \
+		USE_RCDEVICE= \
+		USE_GIMBAL= \
+		USE_VTX_COMMON= \
+		USE_VTX_SMARTAUDIO= \
+		USE_VTX_TRAMP= \
+		USE_VTX_MSP= \
+		USE_RANGEFINDER= \
+		USE_OSD= \
+		USE_TELEMETRY= \
+		USE_TELEMETRY_FRSKY_HUB= \
+		USE_TELEMETRY_HOTT= \
+		USE_TELEMETRY_LTM= \
+		USE_TELEMETRY_SMARTPORT= \
+		USE_TELEMETRY_MAVLINK= \
+		USE_TELEMETRY_IBUS=
+
 sensor_gyro_unittest_SRC := \
 		$(USER_DIR)/sensors/gyro.c \
 		$(USER_DIR)/sensors/gyro_init.c \

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -414,6 +414,30 @@ scheduler_unittest_SRC := \
 scheduler_unittest_DEFINES := \
 		USE_OSD=
 
+serial_feature_map_unittest_SRC := \
+		$(USER_DIR)/io/serial_feature_map.c
+
+serial_feature_map_unittest_DEFINES := \
+		USE_GPS= \
+		USE_SERIALRX= \
+		USE_BLACKBOX= \
+		USE_ESC_SENSOR= \
+		USE_RCDEVICE= \
+		USE_GIMBAL= \
+		USE_VTX_COMMON= \
+		USE_VTX_SMARTAUDIO= \
+		USE_VTX_TRAMP= \
+		USE_VTX_MSP= \
+		USE_RANGEFINDER= \
+		USE_OSD= \
+		USE_TELEMETRY= \
+		USE_TELEMETRY_FRSKY_HUB= \
+		USE_TELEMETRY_HOTT= \
+		USE_TELEMETRY_LTM= \
+		USE_TELEMETRY_SMARTPORT= \
+		USE_TELEMETRY_MAVLINK= \
+		USE_TELEMETRY_IBUS=
+
 sensor_gyro_unittest_SRC := \
 		$(USER_DIR)/sensors/gyro.c \
 		$(USER_DIR)/sensors/gyro_init.c \

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -230,6 +230,15 @@ int32_t taskGuardCycles;
 
 uint32_t micros(void) {return 0;}
 
+// serial_feature_map decomposer is referenced by cliSerial(); the CLI unit
+// tests do not exercise it, so a stub is sufficient.
+bool serialApplyFunctionMask(serialPortIdentifier_e identifier, uint32_t mask)
+{
+    (void)identifier;
+    (void)mask;
+    return true;
+}
+
 int32_t getAmperage(void)
 {
     return 100;

--- a/src/test/unit/io_serial_unittest.cc
+++ b/src/test/unit/io_serial_unittest.cc
@@ -86,4 +86,16 @@ extern "C" {
     void serialSetBaudRateCb(serialPort_t *, void (*)(serialPort_t *context, uint32_t baud), serialPort_t *) {}
 
     void pinioSet(int, bool) {}
+
+    // serial_feature_map is exercised by its own unit test; stub here so
+    // findSerialPortConfig/determinePortSharing/isSerialPortShared can link
+    // against the legacy functionMask view the io_serial tests rely on.
+    uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier) {
+        for (unsigned i = 0; i < SERIAL_PORT_COUNT; i++) {
+            if (serialConfig()->portConfigs[i].identifier == identifier) {
+                return serialConfig()->portConfigs[i].functionMask;
+            }
+        }
+        return 0;
+    }
 }

--- a/src/test/unit/io_serial_unittest.cc
+++ b/src/test/unit/io_serial_unittest.cc
@@ -94,6 +94,18 @@ extern "C" {
     void serialSetBaudRateCb(serialPort_t *, void (*)(serialPort_t *context, uint32_t baud), serialPort_t *) {}
 
     void pinioSet(int, bool) {}
+
+    // serial_feature_map is exercised by its own unit test; stub here so
+    // findSerialPortConfig/determinePortSharing/isSerialPortShared can link
+    // against the legacy functionMask view the io_serial tests rely on.
+    uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier) {
+        for (unsigned i = 0; i < SERIAL_PORT_COUNT; i++) {
+            if (serialConfig()->portConfigs[i].identifier == identifier) {
+                return serialConfig()->portConfigs[i].functionMask;
+            }
+        }
+        return 0;
+    }
 }
 
 TEST(IoSerialTest, TestPassthroughEscape)

--- a/src/test/unit/serial_feature_map_unittest.cc
+++ b/src/test/unit/serial_feature_map_unittest.cc
@@ -280,6 +280,47 @@ TEST(SerialFeatureMap, DecomposeRejectsMspOverflow)
     EXPECT_FALSE(serialApplyFunctionMask(SERIAL_PORT_USART6, FUNCTION_MSP));
 }
 
+TEST(SerialFeatureMap, DecomposeAcceptsAllTelemetryProtocols)
+{
+    resetAllConfigs();
+    // Six protocol bits across six distinct ports must all fit.
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART1, FUNCTION_TELEMETRY_FRSKY_HUB));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART2, FUNCTION_TELEMETRY_HOTT));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART3, FUNCTION_TELEMETRY_LTM));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART4,  FUNCTION_TELEMETRY_SMARTPORT));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5,  FUNCTION_TELEMETRY_MAVLINK));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART6, FUNCTION_TELEMETRY_IBUS));
+}
+
+TEST(SerialFeatureMap, RangefinderPreservesCompatibleHardwareSelection)
+{
+    resetAllConfigs();
+    // User picked a specific TF model; FUNCTION_LIDAR_TF on the same
+    // category must NOT downgrade that choice to the default.
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFNOVA;
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_TF));
+    EXPECT_EQ(RANGEFINDER_TFNOVA, rangefinderConfig()->rangefinder_hardware);
+
+    // Specific Nooploop model preserved across FUNCTION_LIDAR_NL writes.
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2MINI;
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_NL));
+    EXPECT_EQ(RANGEFINDER_NOOPLOOP_F2MINI, rangefinderConfig()->rangefinder_hardware);
+}
+
+TEST(SerialFeatureMap, RangefinderOverwritesWrongCategoryOnly)
+{
+    resetAllConfigs();
+    // NL model with a TF bit incoming → snap to TFMINI default.
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_TF));
+    EXPECT_EQ(RANGEFINDER_TFMINI, rangefinderConfig()->rangefinder_hardware);
+
+    // Unset (NONE) is left alone — user can pick a specific model later.
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NONE;
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_TF));
+    EXPECT_EQ(RANGEFINDER_NONE, rangefinderConfig()->rangefinder_hardware);
+}
+
 TEST(SerialFeatureMap, BackfillRehydratesFromLegacyMask)
 {
     resetAllConfigs();
@@ -299,4 +340,19 @@ TEST(SerialFeatureMap, BackfillRehydratesFromLegacyMask)
     EXPECT_EQ(FUNCTION_GPS, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
     EXPECT_EQ((uint32_t)(FUNCTION_MSP | FUNCTION_BLACKBOX),
               serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+}
+
+TEST(SerialFeatureMap, BackfillClearsStaleFeatureFieldsForZeroMaskPort)
+{
+    resetAllConfigs();
+    // Pretend the new PG fields carry a stale claim to UART3 from a
+    // previous save, but the legacy mask on UART3 now claims nothing.
+    gpsConfigMutable()->gps_uart = SERIAL_PORT_USART3;
+    serialConfigMutable()->portConfigs[0].identifier = SERIAL_PORT_USART3;
+    serialConfigMutable()->portConfigs[0].functionMask = 0;
+
+    serialBackfillFeatureFields();
+
+    EXPECT_EQ(SERIAL_PORT_NONE, gpsConfig()->gps_uart);
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
 }

--- a/src/test/unit/serial_feature_map_unittest.cc
+++ b/src/test/unit/serial_feature_map_unittest.cc
@@ -1,0 +1,302 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "drivers/vtx_common.h"
+
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+    #include "pg/msp.h"
+    #include "pg/gps.h"
+    #include "pg/rx.h"
+    #include "pg/rcdevice.h"
+    #include "pg/gimbal.h"
+
+    #include "blackbox/blackbox.h"
+
+    #include "sensors/esc_sensor.h"
+    #include "sensors/rangefinder.h"
+
+    #include "osd/osd.h"
+
+    #include "io/serial.h"
+    #include "io/serial_feature_map.h"
+    #include "io/vtx.h"
+
+    #include "telemetry/telemetry.h"
+
+    // PG instances for feature configs read by the synthesizer/decomposer.
+    PG_REGISTER(mspConfig_t, mspConfig, PG_MSP_CONFIG, 0);
+    PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
+    PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
+    PG_REGISTER(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 0);
+    PG_REGISTER(escSensorConfig_t, escSensorConfig, PG_ESC_SENSOR_CONFIG, 0);
+    PG_REGISTER(rcdeviceConfig_t, rcdeviceConfig, PG_RCDEVICE_CONFIG, 0);
+    PG_REGISTER(gimbalTrackConfig_t, gimbalTrackConfig, PG_GIMBAL_TRACK_CONFIG, 0);
+    PG_REGISTER(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTINGS_CONFIG, 0);
+    PG_REGISTER(rangefinderConfig_t, rangefinderConfig, PG_RANGEFINDER_CONFIG, 0);
+    PG_REGISTER(osdConfig_t, osdConfig, PG_OSD_CONFIG, 0);
+    PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
+    PG_REGISTER(serialConfig_t, serialConfig, PG_SERIAL_CONFIG, 0);
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+// Reset every PG under test to an "unassigned" baseline.
+void resetAllConfigs(void)
+{
+    memset(mspConfigMutable(), 0, sizeof(*mspConfigMutable()));
+    for (unsigned i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+        mspConfigMutable()->msp_uart[i] = SERIAL_PORT_NONE;
+    }
+
+    memset(gpsConfigMutable(), 0, sizeof(*gpsConfigMutable()));
+    gpsConfigMutable()->gps_uart = SERIAL_PORT_NONE;
+
+    memset(rxConfigMutable(), 0, sizeof(*rxConfigMutable()));
+    rxConfigMutable()->rx_uart = SERIAL_PORT_NONE;
+
+    memset(blackboxConfigMutable(), 0, sizeof(*blackboxConfigMutable()));
+    blackboxConfigMutable()->blackbox_uart = SERIAL_PORT_NONE;
+
+    memset(escSensorConfigMutable(), 0, sizeof(*escSensorConfigMutable()));
+    escSensorConfigMutable()->esc_sensor_uart = SERIAL_PORT_NONE;
+
+    memset(rcdeviceConfigMutable(), 0, sizeof(*rcdeviceConfigMutable()));
+    rcdeviceConfigMutable()->rcdevice_uart = SERIAL_PORT_NONE;
+
+    memset(gimbalTrackConfigMutable(), 0, sizeof(*gimbalTrackConfigMutable()));
+    gimbalTrackConfigMutable()->gimbal_uart = SERIAL_PORT_NONE;
+
+    memset(vtxSettingsConfigMutable(), 0, sizeof(*vtxSettingsConfigMutable()));
+    vtxSettingsConfigMutable()->vtx_uart = SERIAL_PORT_NONE;
+    vtxSettingsConfigMutable()->vtx_type = VTXDEV_UNSUPPORTED;
+
+    memset(rangefinderConfigMutable(), 0, sizeof(*rangefinderConfigMutable()));
+    rangefinderConfigMutable()->rangefinder_uart = SERIAL_PORT_NONE;
+
+    memset(osdConfigMutable(), 0, sizeof(*osdConfigMutable()));
+    osdConfigMutable()->osd_uart = SERIAL_PORT_NONE;
+    osdConfigMutable()->osd_custom_text_uart = SERIAL_PORT_NONE;
+
+    memset(telemetryConfigMutable(), 0, sizeof(*telemetryConfigMutable()));
+    for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
+        telemetryConfigMutable()->providers[i].protocol = TELEMETRY_PROTOCOL_NONE;
+        telemetryConfigMutable()->providers[i].uart = SERIAL_PORT_NONE;
+    }
+
+    memset(serialConfigMutable(), 0, sizeof(*serialConfigMutable()));
+    for (unsigned i = 0; i < SERIAL_PORT_COUNT; i++) {
+        serialConfigMutable()->portConfigs[i].identifier = SERIAL_PORT_NONE;
+    }
+}
+
+} // namespace
+
+TEST(SerialFeatureMap, SynthesizesZeroWhenNothingAssigned)
+{
+    resetAllConfigs();
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_USB_VCP));
+}
+
+TEST(SerialFeatureMap, SingleBitFeatures)
+{
+    resetAllConfigs();
+    gpsConfigMutable()->gps_uart = SERIAL_PORT_USART1;
+    rxConfigMutable()->rx_uart = SERIAL_PORT_USART3;
+    blackboxConfigMutable()->blackbox_uart = SERIAL_PORT_USART6;
+    escSensorConfigMutable()->esc_sensor_uart = SERIAL_PORT_USART2;
+
+    EXPECT_EQ(FUNCTION_GPS, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+    EXPECT_EQ(FUNCTION_RX_SERIAL, serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+    EXPECT_EQ(FUNCTION_BLACKBOX, serialSynthesizeFunctionMask(SERIAL_PORT_USART6));
+    EXPECT_EQ(FUNCTION_ESC_SENSOR, serialSynthesizeFunctionMask(SERIAL_PORT_USART2));
+    // Unassigned port stays empty.
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_UART4));
+}
+
+TEST(SerialFeatureMap, MspMultiSlot)
+{
+    resetAllConfigs();
+    mspConfigMutable()->msp_uart[0] = SERIAL_PORT_USB_VCP;
+    mspConfigMutable()->msp_uart[1] = SERIAL_PORT_USART3;
+
+    EXPECT_EQ(FUNCTION_MSP, serialSynthesizeFunctionMask(SERIAL_PORT_USB_VCP));
+    EXPECT_EQ(FUNCTION_MSP, serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+}
+
+TEST(SerialFeatureMap, TelemetryProviderSlots)
+{
+    resetAllConfigs();
+    telemetryConfigMutable()->providers[0].protocol = TELEMETRY_PROTOCOL_SMARTPORT;
+    telemetryConfigMutable()->providers[0].uart = SERIAL_PORT_USART3;
+    telemetryConfigMutable()->providers[1].protocol = TELEMETRY_PROTOCOL_MAVLINK;
+    telemetryConfigMutable()->providers[1].uart = SERIAL_PORT_USART6;
+
+    EXPECT_EQ(FUNCTION_TELEMETRY_SMARTPORT, serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+    EXPECT_EQ(FUNCTION_TELEMETRY_MAVLINK, serialSynthesizeFunctionMask(SERIAL_PORT_USART6));
+}
+
+TEST(SerialFeatureMap, VtxCollapseByType)
+{
+    resetAllConfigs();
+    vtxSettingsConfigMutable()->vtx_uart = SERIAL_PORT_UART4;
+
+    vtxSettingsConfigMutable()->vtx_type = VTXDEV_SMARTAUDIO;
+    EXPECT_EQ(FUNCTION_VTX_SMARTAUDIO, serialSynthesizeFunctionMask(SERIAL_PORT_UART4));
+
+    vtxSettingsConfigMutable()->vtx_type = VTXDEV_TRAMP;
+    EXPECT_EQ(FUNCTION_VTX_TRAMP, serialSynthesizeFunctionMask(SERIAL_PORT_UART4));
+
+    vtxSettingsConfigMutable()->vtx_type = VTXDEV_MSP;
+    EXPECT_EQ(FUNCTION_VTX_MSP, serialSynthesizeFunctionMask(SERIAL_PORT_UART4));
+
+    // Unsupported VTX type means the port has no VTX function bit.
+    vtxSettingsConfigMutable()->vtx_type = VTXDEV_UNSUPPORTED;
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_UART4));
+}
+
+TEST(SerialFeatureMap, RangefinderCollapseByHardware)
+{
+    resetAllConfigs();
+    rangefinderConfigMutable()->rangefinder_uart = SERIAL_PORT_UART5;
+
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
+    EXPECT_EQ(FUNCTION_LIDAR_TF, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
+
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
+    EXPECT_EQ(FUNCTION_LIDAR_NL, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
+
+    // Non-serial rangefinder (e.g. I2C) emits nothing even if uart is assigned.
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_HCSR04;
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
+}
+
+TEST(SerialFeatureMap, OsdCollapseByDisplayPortDevice)
+{
+    resetAllConfigs();
+    osdConfigMutable()->osd_uart = SERIAL_PORT_USART1;
+
+    osdConfigMutable()->displayPortDevice = OSD_DISPLAYPORT_DEVICE_FRSKYOSD;
+    EXPECT_EQ(FUNCTION_FRSKY_OSD, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+
+    // MSP-displayport uses an existing MSP port, so osd_uart contributes no bit.
+    osdConfigMutable()->displayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
+    EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+}
+
+TEST(SerialFeatureMap, SharedPortCombinesBits)
+{
+    resetAllConfigs();
+    mspConfigMutable()->msp_uart[0] = SERIAL_PORT_USART3;
+    blackboxConfigMutable()->blackbox_uart = SERIAL_PORT_USART3;
+
+    EXPECT_EQ((uint32_t)(FUNCTION_MSP | FUNCTION_BLACKBOX),
+              serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+}
+
+TEST(SerialFeatureMap, DecomposeAndSynthesizeRoundTrip)
+{
+    resetAllConfigs();
+
+    const serialPortIdentifier_e gpsPort = SERIAL_PORT_USART1;
+    const serialPortIdentifier_e rxPort = SERIAL_PORT_USART3;
+    const serialPortIdentifier_e mspPort = SERIAL_PORT_USB_VCP;
+    const serialPortIdentifier_e tlmPort = SERIAL_PORT_USART6;
+
+    EXPECT_TRUE(serialApplyFunctionMask(gpsPort, FUNCTION_GPS));
+    EXPECT_TRUE(serialApplyFunctionMask(rxPort, FUNCTION_RX_SERIAL));
+    EXPECT_TRUE(serialApplyFunctionMask(mspPort, FUNCTION_MSP));
+    EXPECT_TRUE(serialApplyFunctionMask(tlmPort, FUNCTION_TELEMETRY_SMARTPORT));
+
+    EXPECT_EQ(FUNCTION_GPS, serialSynthesizeFunctionMask(gpsPort));
+    EXPECT_EQ(FUNCTION_RX_SERIAL, serialSynthesizeFunctionMask(rxPort));
+    EXPECT_EQ(FUNCTION_MSP, serialSynthesizeFunctionMask(mspPort));
+    EXPECT_EQ(FUNCTION_TELEMETRY_SMARTPORT, serialSynthesizeFunctionMask(tlmPort));
+}
+
+TEST(SerialFeatureMap, DecomposeReassignClearsOldPort)
+{
+    resetAllConfigs();
+    // First put GPS on UART1.
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART1, FUNCTION_GPS));
+    EXPECT_EQ(FUNCTION_GPS, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+
+    // Rewrite UART1 with only FUNCTION_RX_SERIAL — GPS must leave the port.
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART1, FUNCTION_RX_SERIAL));
+    EXPECT_EQ(FUNCTION_RX_SERIAL, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+    EXPECT_EQ(SERIAL_PORT_NONE, gpsConfig()->gps_uart);
+}
+
+TEST(SerialFeatureMap, DecomposeMspFillsAcrossSlots)
+{
+    resetAllConfigs();
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USB_VCP, FUNCTION_MSP));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART3, FUNCTION_MSP));
+
+    // Both ports should now produce FUNCTION_MSP.
+    EXPECT_EQ(FUNCTION_MSP, serialSynthesizeFunctionMask(SERIAL_PORT_USB_VCP));
+    EXPECT_EQ(FUNCTION_MSP, serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+}
+
+TEST(SerialFeatureMap, DecomposeRejectsMspOverflow)
+{
+    resetAllConfigs();
+    // Fill every MSP slot.
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USB_VCP, FUNCTION_MSP));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART1, FUNCTION_MSP));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART3, FUNCTION_MSP));
+    // One more should fail because MAX_MSP_PORT_COUNT is exhausted.
+    EXPECT_FALSE(serialApplyFunctionMask(SERIAL_PORT_USART6, FUNCTION_MSP));
+}
+
+TEST(SerialFeatureMap, BackfillRehydratesFromLegacyMask)
+{
+    resetAllConfigs();
+    // Simulate an EEPROM load: populate the legacy functionMask and
+    // identifier on a couple of port configs.
+    serialConfigMutable()->portConfigs[0].identifier = SERIAL_PORT_USART1;
+    serialConfigMutable()->portConfigs[0].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[1].identifier = SERIAL_PORT_USART3;
+    serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP | FUNCTION_BLACKBOX;
+
+    serialBackfillFeatureFields();
+
+    EXPECT_EQ(SERIAL_PORT_USART1, gpsConfig()->gps_uart);
+    EXPECT_EQ(SERIAL_PORT_USART3, mspConfig()->msp_uart[0]);
+    EXPECT_EQ(SERIAL_PORT_USART3, blackboxConfig()->blackbox_uart);
+    // Synthesizer now reproduces the legacy view.
+    EXPECT_EQ(FUNCTION_GPS, serialSynthesizeFunctionMask(SERIAL_PORT_USART1));
+    EXPECT_EQ((uint32_t)(FUNCTION_MSP | FUNCTION_BLACKBOX),
+              serialSynthesizeFunctionMask(SERIAL_PORT_USART3));
+}

--- a/src/test/unit/serial_feature_map_unittest.cc
+++ b/src/test/unit/serial_feature_map_unittest.cc
@@ -280,6 +280,25 @@ TEST(SerialFeatureMap, DecomposeRejectsMspOverflow)
     EXPECT_FALSE(serialApplyFunctionMask(SERIAL_PORT_USART6, FUNCTION_MSP));
 }
 
+TEST(SerialFeatureMap, FailedApplyLeavesPriorStateIntact)
+{
+    resetAllConfigs();
+    // Set up a valid claim, then attempt an invalid apply on the same port.
+    gpsConfigMutable()->gps_uart = SERIAL_PORT_USART1;
+    blackboxConfigMutable()->blackbox_uart = SERIAL_PORT_USART1;
+
+    // Two VTX bits on one port is structurally invalid and must fail.
+    EXPECT_FALSE(serialApplyFunctionMask(
+        SERIAL_PORT_USART1, FUNCTION_VTX_SMARTAUDIO | FUNCTION_VTX_TRAMP));
+
+    // Prior feature claims for the port survive — validation happens before
+    // any PG mutation, so a rejected mask is atomic from the caller's view.
+    EXPECT_EQ(SERIAL_PORT_USART1, gpsConfig()->gps_uart);
+    EXPECT_EQ(SERIAL_PORT_USART1, blackboxConfig()->blackbox_uart);
+    EXPECT_EQ(SERIAL_PORT_NONE, vtxSettingsConfig()->vtx_uart);
+    EXPECT_EQ(VTXDEV_UNSUPPORTED, vtxSettingsConfig()->vtx_type);
+}
+
 TEST(SerialFeatureMap, DecomposeAcceptsAllTelemetryProtocols)
 {
     resetAllConfigs();

--- a/src/test/unit/serial_feature_map_unittest.cc
+++ b/src/test/unit/serial_feature_map_unittest.cc
@@ -186,19 +186,21 @@ TEST(SerialFeatureMap, VtxCollapseByType)
     EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_UART4));
 }
 
-TEST(SerialFeatureMap, RangefinderCollapseByHardware)
+TEST(SerialFeatureMap, RangefinderIndependentOfHardwareSelection)
 {
     resetAllConfigs();
     rangefinderConfigMutable()->rangefinder_uart = SERIAL_PORT_UART5;
 
     rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFMINI;
-    EXPECT_EQ(FUNCTION_LIDAR_TF, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
+    EXPECT_EQ(FUNCTION_LIDAR, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
 
     rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
-    EXPECT_EQ(FUNCTION_LIDAR_NL, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
+    EXPECT_EQ(FUNCTION_LIDAR, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
 
-    // Non-serial rangefinder (e.g. I2C) emits nothing even if uart is assigned.
-    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_HCSR04;
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NONE;
+    EXPECT_EQ(FUNCTION_LIDAR, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
+
+    rangefinderConfigMutable()->rangefinder_uart = SERIAL_PORT_NONE;
     EXPECT_EQ(0u, serialSynthesizeFunctionMask(SERIAL_PORT_UART5));
 }
 
@@ -311,32 +313,22 @@ TEST(SerialFeatureMap, DecomposeAcceptsAllTelemetryProtocols)
     EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_USART6, FUNCTION_TELEMETRY_IBUS));
 }
 
-TEST(SerialFeatureMap, RangefinderPreservesCompatibleHardwareSelection)
+TEST(SerialFeatureMap, RangefinderPreservesHardwareSelection)
 {
     resetAllConfigs();
-    // User picked a specific TF model; FUNCTION_LIDAR_TF on the same
-    // category must NOT downgrade that choice to the default.
+    // The port assignment and the driver choice are orthogonal: applying the
+    // mask must never disturb the user's model selection.
     rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TFNOVA;
-    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_TF));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR));
+    EXPECT_EQ(SERIAL_PORT_UART5, rangefinderConfig()->rangefinder_uart);
     EXPECT_EQ(RANGEFINDER_TFNOVA, rangefinderConfig()->rangefinder_hardware);
 
-    // Specific Nooploop model preserved across FUNCTION_LIDAR_NL writes.
     rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2MINI;
-    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_NL));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR));
     EXPECT_EQ(RANGEFINDER_NOOPLOOP_F2MINI, rangefinderConfig()->rangefinder_hardware);
-}
 
-TEST(SerialFeatureMap, RangefinderOverwritesWrongCategoryOnly)
-{
-    resetAllConfigs();
-    // NL model with a TF bit incoming → snap to TFMINI default.
-    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NOOPLOOP_F2;
-    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_TF));
-    EXPECT_EQ(RANGEFINDER_TFMINI, rangefinderConfig()->rangefinder_hardware);
-
-    // Unset (NONE) is left alone — user can pick a specific model later.
     rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_NONE;
-    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR_TF));
+    EXPECT_TRUE(serialApplyFunctionMask(SERIAL_PORT_UART5, FUNCTION_LIDAR));
     EXPECT_EQ(RANGEFINDER_NONE, rangefinderConfig()->rangefinder_hardware);
 }
 


### PR DESCRIPTION
## Summary

Introduces per-feature UART fields on each feature's PG (e.g. `gps_uart`, `rx_uart`, `msp_uart[]`, `telemetry.providers[]`, `vtx_uart`) as the eventual source of truth for which port does what. The legacy `serialConfig.portConfigs[].functionMask` bitmask stays authoritative at runtime; a synthesizer/decomposer pair keeps the two views in sync so nothing behavioural changes yet.

- New `io/serial_feature_map.{c,h}`: `serialSynthesizeFunctionMask()` (PGs → mask) and `serialApplyFunctionMask()` (mask → PGs).
- CLI `serial` and MSP `(2_COMMON_)SET_SERIAL_CONFIG` writes mirror into the new PGs.
- Config load runs a one-shot back-fill so existing EEPROMs populate the new fields.
- `findSerialPortConfig` / `determinePortSharing` / `isSerialPortShared` now read the synthesized view.
- 13 unit tests cover synth/decompose/backfill/collapse behaviour.

## Follow-ups (not in this PR)

- Per-feature migration: each feature reads its own PG uart field instead of `findSerialPortConfig(FUNCTION_X)`. ~20 features, one PR each for safe runtime testing.
- Stop writing legacy `functionMask` once every consumer has moved.
- Deprecation window, then remove `functionMask` and bump MSP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-feature UART assignments across supported subsystems, including multi-provider telemetry configuration.
  * Improved serial port sharing and feature mapping.

* **Bug Fixes**
  * CLI and MSP reject unsupported serial-function combinations.
  * Existing configurations are migrated automatically during validation.
  * Reset configurations now correctly use unassigned UART defaults.

* **Tests**
  * Added coverage for serial feature mapping, reassignment, sharing, validation, and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->