### PR TITLE
fix: escprog ki 255 (KISSALL) broken on DShot builds (fixes #15114)

### DIFF
--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -34,6 +34,7 @@
 #include "drivers/io.h"
 #include "drivers/light_led.h"
 #include "drivers/nvic.h"
+#include "drivers/motor.h"
 #include "drivers/pwm_output.h"
 #include "drivers/serial.h"
 #include "drivers/serial_escserial.h"
@@ -716,9 +717,8 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
     else if (mode==PROTOCOL_KISSALL) {
         escSerial->outputCount = 0;
         memset(&escOutputs, 0, sizeof(escOutputs));
-        pwmOutputPort_t *pwmMotors = pwmGetMotors();
         for (volatile uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
-            if (pwmMotors[i].enabled && pwmMotors[i].io != IO_NONE) {
+            if (motorIsMotorEnabled(i) && motorGetIo(i) != IO_NONE) {
                 const ioTag_t tag = motorConfig->ioTags[i];
                 if (tag != IO_TAG_NONE) {
                     const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, 0);
@@ -727,7 +727,7 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
                         // this prevents a null-pointer dereference in __HAL_TIM_CLEAR_FLAG called by timerChannelClearFlag and similar accesses of timerHandle without the Instance being configured first.
                         timerConfigure(timerHardware, 0xffff, 1);
                         escSerialOutputPortConfig(timerHardware);
-                        escOutputs[escSerial->outputCount].io = pwmMotors[i].io;
+                        escOutputs[escSerial->outputCount].io = motorGetIo(i);
                         if (timerHardware->output & TIMER_OUTPUT_INVERTED) {
                             escOutputs[escSerial->outputCount].inverted = 1;
                         }


### PR DESCRIPTION
AI Generated code

---

## Problem

 (KISSALL) drives signal lines high (ESCs enter bootloader) but never forwards any serial data when using DShot motor protocols (e.g. DShot600). Single-ESC passthrough (`escprog ki 0`, `ki 1`, etc.) works correctly.

**Regression since PR #14214** — broken in 4.5.3+, worked in 4.5.2.

## Root Cause

In `serial_escserial.c`, the `PROTOCOL_KISSALL` path inside `openEscSerial()` enumerated motor pins via `pwmGetMotors()`:

```c
pwmOutputPort_t *pwmMotors = pwmGetMotors();
for (volatile uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
    if (pwmMotors[i].enabled && pwmMotors[i].io != IO_NONE) {
```

With DShot, `pwmMotors[]` is never populated — so `outputCount` stays 0 and nothing is transmitted.

PR #14214 fixed this exact pattern in `serial_4way.c` by switching to `motorIsMotorEnabled()` / `motorGetIo()`, but `serial_escserial.c` was not updated at the same time.

## Fix

Apply the same pattern used in `serial_4way.c` since PR #14214:

```c
for (volatile uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
    if (motorIsMotorEnabled(i) && motorGetIo(i) != IO_NONE) {
```

Also adds `#include "drivers/motor.h"` to expose these functions.

## Testing

Tested concept against FOXEERF722V4 target with DShot600 as reported in the issue.

Resolves #15114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal motor configuration handling logic to enhance system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->