### PR TITLE
Update mt29f flash support

### DIFF
--- a/src/main/drivers/flash/flash_mt29f.c
+++ b/src/main/drivers/flash/flash_mt29f.c
@@ -129,10 +129,15 @@ struct {
 } mt29fFlashConfig[] = {
     // Micron MT29F1G01ABAFDWB-IT:F
     // Datasheet: https://www.micron.com/content/dam/micron/global/secure/products/data-sheet/nand-flash/70-series/m78a-1gb-3v-nand-spi.pdf
-    { 0x2C14, 1024, 64, 2048 },
+    { 0x2C14, 1024, 64, 2048 }, // 1Gb, 3.3V version - tested
+	// Datasheet: https://www.micron.com/content/dam/micron/global/secure/products/data-sheet/nand-flash/70-series/m79a-2gb-nand-spi-auto.pdf
+    { 0x2C24, 2048, 64, 2048 }, // 2Gb, 3.3V version - untested // from m78a-1gb-3v-nand-spi.pdf and m79a-2gb-nand-spi-auto.pdf datasheet
+    { 0x2C36, 3096, 64, 2048 }, // 3Gb, 3.3V version - untested // from m78a-1gb-3v-nand-spi.pdf datasheet only
+    { 0x2C46, 4096, 64, 2048 }, // 4Gb, 3.3V version - untested // from m78a-1gb-3v-nand-spi.pdf datasheet only
     // Micron MT29F4G01ABAFDWB-IT:F
     // Datasheet: https://www.micron.com/content/dam/micron/global/secure/products/data-sheet/nand-flash/70-series/m70a-4gb-3v-nand-spi.pdf
-    { 0x2C34, 2048, 64, 4096 },
+    { 0x2C34, 2048, 64, 4096 }, // 4Gb, 3.3V version - tested
+    { 0x2C35, 2048, 64, 4096 }, // 4Gb, 1.8V version - untested
     { 0, 0, 0, 0 },
 };
 

--- a/src/main/drivers/flash/flash_mt29f.c
+++ b/src/main/drivers/flash/flash_mt29f.c
@@ -130,6 +130,9 @@ struct {
     // Micron MT29F1G01ABAFDWB-IT:F
     // Datasheet: https://www.micron.com/content/dam/micron/global/secure/products/data-sheet/nand-flash/70-series/m78a-1gb-3v-nand-spi.pdf
     { 0x2C14, 1024, 64, 2048 },
+    // Micron MT29F4G01ABAFDWB-IT:F
+    // Datasheet: https://www.micron.com/content/dam/micron/global/secure/products/data-sheet/nand-flash/70-series/m70a-4gb-3v-nand-spi.pdf
+    { 0x2C34, 2048, 64, 4096 },
     { 0, 0, 0, 0 },
 };
 


### PR DESCRIPTION
Add tested support for the MT29F4G01ABAFDWB-IT:F chip (tested) using an H743 using QuadSPI.
Add untested support for other variants.

```
# flash_info
Flash sectors=2048, sectorSize=262144, pagesPerSector=64, pageSize=4096, totalSize=536870912 JEDEC ID=0x002c342c
Partitions:
  0: FLASHFS   0 2047
FlashFS size=536870912, usedSize=0
```

```
# flash_scan
Verifying
Success
```

1024 * 1024 * 4 = 4194304 bits
4194304 bits / 8 = 524288
524288 / 1024 = 512MB

last page offset = 524288 - 4096 (page size) = 520192

```
# flash_read 520192 1024
Reading 1024 bytes at 520192:
0007f000 >> **0123456789ABCDEF**0007f020 >> **0123456789ABCDEF**0007f040 >> **0123456789ABCDEF**0007f060 >> **0123456789ABCDEF**0007f080 >> **0123456789ABCDEF**0007f0a0 >> **0123456789ABCDEF**0007f0c0 >> **0123456789ABCDEF**0007f0e0 >> **0123456789ABCDEF**0007f100 >> **0123456789ABCDEF**0007f120 >> **0123456789ABCDEF**0007f140 >> **0123456789ABCDEF**0007f160 >> **0123456789ABCDEF**0007f180 >> **0123456789ABCDEF**0007f1a0 >> **0123456789ABCDEF**0007f1c0 >> **0123456789ABCDEF**0007f1e0 >> **0123456789ABCDEF**0007f200 >> **0123456789ABCDEF**0007f220 >> **0123456789ABCDEF**0007f240 >> **0123456789ABCDEF**0007f260 >> **0123456789ABCDEF**0007f280 >> **0123456789ABCDEF**0007f2a0 >> **0123456789ABCDEF**0007f2c0 >> **0123456789ABCDEF**0007f2e0 >> **0123456789ABCDEF**0007f300 >> **0123456789ABCDEF**0007f320 >> **0123456789ABCDEF**0007f340 >> **0123456789ABCDEF**0007f360 >> **0123456789ABCDEF**0007f380 >> **0123456789ABCDEF**0007f3a0 >> **0123456789ABCDEF**0007f3c0 >> **0123456789ABCDEF**0007f3e0 >> **0123456789ABCDEF**
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Extended support for Micron MT29F NAND flash memory devices, including 2Gb and 3Gb/4Gb capacity variants with multiple voltage configurations and page size options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->