### PR TITLE
ComputeLedStripColorByVtxFreq

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1392,18 +1392,15 @@ void ledStripInit(void)
 static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 {
     static timeUs_t colorUpdateTimeUs = 0;
-    static uint16_t currentVtxFrequency = 0;
 
-    hsvColor_t currentHsv;
     static hsvColor_t previousHsv = {0, 0, 0};
+    hsvColor_t currentHsv = hsv[COLOR_BLACK];
+    // will be replaced by color as needed
+    const hsvColor_t beaconHsv = hsv[ledStripConfig()->ledstrip_beacon_color];
+    // no custom color modifications for beacon color
 
-    uint8_t colorIndex = COLOR_BLACK;
-    uint8_t beaconColor = COLOR_BLACK;
-
-    bool useCustomColors = true;
-    bool useVtxColors = false;
-    bool beeperEventsPermitted = true;
-    bool periodicBlink = false;
+    const hsvColor_t visualBeeperHsv = hsv[ledStripConfig()->ledstrip_visual_beeper_color];
+    // no custom color mofifications for visual_beeper color
 
     unsigned flashPeriod = 0;
     unsigned onPercent = 0;
@@ -1411,90 +1408,71 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
     switch (ledStripConfig()->ledstrip_profile)
     {
         case LED_PROFILE_RACE:
-            colorIndex = ledStripConfig()->ledstrip_race_color;
-            // All LEDs steadily at colour, but if black,  colour according to VTx frequency
-            useVtxColors = (colorIndex == COLOR_BLACK);
+        {
+            const uint8_t raceColor = ledStripConfig()->ledstrip_race_color;
 
+            if (raceColor == COLOR_BLACK) {
 #ifdef USE_VTX_COMMON
-            if (useVtxColors) {
                 const vtxDevice_t *vtxDevice = vtxCommonDevice();
                 if (vtxDevice) {
                     uint8_t const band = vtxSettingsConfig()->band;
                     uint8_t const channel = vtxSettingsConfig()->channel;
-                    uint16_t freq = 0;
+                    uint16_t vtxFrequency = VTX_SETTINGS_MIN_FREQUENCY_MHZ;
 
                     if (band && channel) {
-                        freq = vtxCommonLookupFrequency(vtxDevice, band, channel);
+                        vtxFrequency = vtxCommonLookupFrequency(vtxDevice, band, channel);
                     } else {
-                        freq = vtxSettingsConfig()->freq;
+                        vtxFrequency = vtxSettingsConfig()->freq;
                         // use manually configured frequency if no band and channel
                     }
 
-                    currentVtxFrequency = freq;
+                    currentHsv = getHsvFromVtxFrequency(vtxFrequency);
+                }
+#endif
+            } else {
+                currentHsv = ledStripStatusModeConfig()->colors[raceColor];
+                // non-black race colors  can be customised
+            }
+
+            if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive()) {
+                flashPeriod = BEACON_FAILSAFE_PERIOD_MS;
+                // must not be configured to zero
+                onPercent   = BEACON_FAILSAFE_ON_PERCENT;
+
+                const unsigned onPeriod = flashPeriod * onPercent / 100;
+
+                if (onPeriod > 0 && (millis() % flashPeriod) < onPeriod) {
+                    currentHsv = visualBeeperHsv;
+                }
+            } else {
+                if (ledStripConfig()->ledstrip_visual_beeper && isBeeperOn()) {
+                    currentHsv = visualBeeperHsv;
                 }
             }
-#endif
+
             break;
+        }
 
         case LED_PROFILE_BEACON:
-                // flash all LEDs, alternating between beacon color and off
-            if (!ledStripConfig()->ledstrip_beacon_armed_only || ARMING_FLAG(ARMED))
-            {
-                flashPeriod = ledStripConfig()->ledstrip_beacon_period_ms;
-                onPercent   = ledStripConfig()->ledstrip_beacon_percent;
-                beaconColor = ledStripConfig()->ledstrip_beacon_color;
-                periodicBlink = true;
-                // use a periodical blink pattern
-                useVtxColors = false;
-                // do not overlay the vtx color (not calculated anyway)
+        {
+            flashPeriod = ledStripConfig()->ledstrip_beacon_period_ms;
+            // must not be configurable  to zero
+            onPercent   = ledStripConfig()->ledstrip_beacon_percent;
+
+            const unsigned onPeriod = flashPeriod * onPercent / 100;
+
+            if ((millis() % flashPeriod) < onPeriod) {
+                currentHsv = beaconHsv;
             }
+
             break;
+        }
 
         default:
             break;
     }
 
-    if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive()) {
-        // turn LEDs on and off at fixed intervals to help find it if lost
-        flashPeriod = BEACON_FAILSAFE_PERIOD_MS;
-        onPercent   = BEACON_FAILSAFE_ON_PERCENT;
-        periodicBlink = true;
-        // use a periodical blink pattern
-        beaconColor = ledStripConfig()->ledstrip_visual_beeper_color;
-        beeperEventsPermitted = false;
-        // do not allow transient led flashes at the same time, can mess up the regular timing
-    }
-
-    if (periodicBlink && flashPeriod > 0){
-        // Handle a periodic blink request
-        const unsigned onPeriod = flashPeriod * onPercent / 100;
-        const bool ledOn = (millis() % flashPeriod) < onPeriod; 
-        colorIndex = ledOn ? beaconColor : COLOR_BLACK;
-        // use the configured beacon color when the LED is on
-        useVtxColors = useVtxColors && !ledOn;
-        // Don't override the beep color with the Vtx color while the beep color is active
-        useCustomColors = false;
-        // these blinks will not use the custom color table to ensure reliable interpretation
-    }
-
-    if (ledStripConfig()->ledstrip_visual_beeper && beeperEventsPermitted && isBeeperOn()) {
-        // Handle transient visual beeps with audio beeps, e.g. on arming or calibrating something
-        colorIndex = ledStripConfig()->ledstrip_visual_beeper_color;
-        useCustomColors = false;
-        // use the system-defined visual_beeper_color, not allowing customisation
-        useVtxColors = false;
-    // Don't override the beep color with the Vtx color while the beep color is active
-    }
-
-    if (useVtxColors) {
-        currentHsv = getHsvFromVtxFrequency(currentVtxFrequency);
-        // apply the algorithm to calculate HSV values from VTx frequency
-    } else {
-        currentHsv = (useCustomColors) ? ledStripStatusModeConfig()->colors[colorIndex] : hsv[colorIndex];
-        // get the HSV value of the current color
-    }
-
-        bool updateLedStripColor =
+    bool updateLedStripColor =
         currentHsv.h != previousHsv.h ||
         currentHsv.s != previousHsv.s ||
         currentHsv.v != previousHsv.v ||

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -137,6 +137,7 @@ const hsvColor_t hsv[] = {
 #define VTX_FREQ_MAX 5900  // upper frequency limit for which the Hue changes, above this Hue is HUE_MAX
 #define VTX_HUE_MAX 345    // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
 
+#ifdef USE_VTX_COMMON
 static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
 {
     hsvColor_t color = HSV(BLACK);
@@ -163,7 +164,7 @@ static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
         return color;
     }
 }
-
+#endif
 
 PG_REGISTER_WITH_RESET_FN(ledStripConfig_t, ledStripConfig, PG_LED_STRIP_CONFIG, 3);
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -858,8 +858,8 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
         hsvColor_t color = getHsvFromVtxFrequency(frequency);
         if (vtxStatus & VTX_STATUS_PIT_MODE) {
             color.v = blink ? color.v : 15;
-            // blink to a pale color when in pit mode
-            // if no vtx color (black means vtx frequency known) blink from off to pale red (0,0,15)
+            // if getHsvFromVtxFrequency returns a color, blink down to a pale color when in pit mode, but
+            // if black is returned,  blink up from off (0,0,0) to pale red (0,0,15)
         }
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
     }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -112,12 +112,6 @@ static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 #define BEACON_FAILSAFE_PERIOD_US 250      // 2Hz
 #define BEACON_FAILSAFE_ON_PERCENT 50      // 50% duty cycle
 
-#define VTX_FREQ_MIN 5650 // Below this will be white, above we get colour starting at an orange - red
-#define VTX_FREQ_RANGE 250.0f // leads to hue max at 5918 (R8 is 5917) or above
-#define VTX_HUE_MAX 345.0f // Hue for R8 or above should not hit red (360). 345 is a strong magenta but not like red
-#define VTX_SCALER (VTX_HUE_MAX / VTX_FREQ_RANGE)
-
-
 const hsvColor_t hsv[] = {
     //                        H    S    V
     [COLOR_BLACK] =        {  0,   0,   0},
@@ -139,10 +133,16 @@ const hsvColor_t hsv[] = {
 #define HSV(color) (hsv[COLOR_ ## color])
 
 
+
+#define VTX_FREQ_MIN 5650 // Below this will be white, above we get colour starting at an orange - red
+#define VTX_FREQ_RANGE 250.0f // leads to hue max at 5918 (R8 is 5917) or above
+#define VTX_HUE_MAX 345.0f // Hue for R8 or above should not hit red (360). 345 is a strong magenta but not like red
+
 static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
 {
     hsvColor_t color;
-
+    const float hsvScaleFactor = VTX_HUE_MAX / VTX_FREQ_RANGE;
+    
     if (freq < VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
     // usuallyt caused by misc configured frequency or no band / channel
         color = HSV(BLACK);
@@ -151,9 +151,8 @@ static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
         // show colours above R1
         color.s = 0; 
         color.v = 255; 
-        float hue = (float)(freq - (uint16_t)VTX_FREQ_MIN) * VTX_SCALER;
-        
-        // Clamp to 330
+        float hue = (float)(freq - (uint16_t)VTX_FREQ_MIN) * hsvScaleFactor;
+        // set hue to range from 0 to VTX_HUE_MAX
         color.h = (hue > VTX_HUE_MAX) ? (uint16_t)VTX_HUE_MAX : (uint16_t)hue;
     } 
     else { // Frequencies below R1 will be white
@@ -854,18 +853,7 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
     }
     else { // calculate the VTX color based on frequency
 
-        hsvColor_t color;
-        if (frequency < VTX_FREQ_MIN) {
-            color.h = 0;
-            color.s = 0;   // 0 Saturation = White
-        } else {
-            color.s = 255; // All colours fully saturated
-            float hue = (float)(frequency - VTX_FREQ_MIN) * VTX_SCALER;
-            
-            // Clamp Hue to VTX_HUE_MAX (330)
-            color.h = (hue > VTX_HUE_MAX) ? (uint16_t)VTX_HUE_MAX : (uint16_t)hue;
-        }
-
+        hsvColor_t color = getHsvByVtxFrequency(frequency);
         color.v = (vtxStatus & VTX_STATUS_PIT_MODE) ? (blink ? 15 : 0) : 255; // blink when in pit mode
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
     }
@@ -1410,9 +1398,8 @@ static uint8_t selectVisualBeeperColor(uint8_t colorIndex, bool *colorIndexIsCus
 static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 {
     static timeUs_t colorUpdateTimeUs = 0;
-     static uint16_t lastVtxFreq = 0;
-         uint16_t currentVtxFreq = 0;
-    static bool vtxFreqChanged;
+    static uint16_t lastVtxFreq = 0;
+    bool vtxFreqChanged = false;
     bool useDirectHsv = false;
 
     uint8_t colorIndex = COLOR_BLACK;
@@ -1441,6 +1428,7 @@ case LED_PROFILE_RACE:
                         useDirectHsv = true;
                         uint8_t const band = vtxSettingsConfig()->band;
                         uint8_t const channel = vtxSettingsConfig()->channel;
+                        uint16_t currentVtxFreq = 0;
                         
                         if (band && channel) {
                             currentVtxFreq = vtxCommonLookupFrequency(vtxDevice, band, channel);
@@ -1483,9 +1471,9 @@ case LED_PROFILE_RACE:
         colorIndex = selectVisualBeeperColor(colorIndex, &useCustomColors);
     }
 
-    bool updateStripColor = vtxFreqChanged || (colorIndex != previousProfileColorIndex) || (currentTimeUs >= colorUpdateTimeUs);
+    bool updateLedStripColor = vtxFreqChanged || (colorIndex != previousProfileColorIndex) || (currentTimeUs >= colorUpdateTimeUs);
 
-     if (updateStripColor) {
+     if (updateLedStripColor) {
         if (useDirectHsv) {
             hsvColor_t vtxHsv = getHsvByVtxFrequency(lastVtxFreq);
             setStripColor(&vtxHsv);

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1472,7 +1472,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         // do not allow transient led flashes at the same time, can mess up the regular timing
     }
 
-    if (periodicBlink){
+    if (periodicBlink && flashPeriod > 0){
         // Handle a periodic blink request
         const unsigned onPeriod = flashPeriod * onPercent / 100;
         const bool ledOn = (millis() % flashPeriod) < onPeriod;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1471,7 +1471,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         const bool ledOn = (millis() % flashPeriod) < onPeriod; 
         colorIndex = ledOn ? beaconColor : COLOR_BLACK;
         // use the configured beacon color when the LED is on
-        useVtxColors = !ledOn;
+        useVtxColors = useVtxColors && !ledOn;
         // Don't override the beep color with the Vtx color while the beep color is active
         useCustomColors = false;
         // these blinks will not use the custom color table to ensure reliable interpretation

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -114,9 +114,9 @@ static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 
 const hsvColor_t hsv[] = {
     //                        H    S    V
-    [COLOR_BLACK] =        {  0,   0,   0},
-    [COLOR_WHITE] =        {  0, 255, 255},
-    [COLOR_RED] =          {  0,   0, 255},
+    [COLOR_BLACK] =        {  0,   0,   0}, // LED is off
+    [COLOR_WHITE] =        {  0, 255, 255}, // for white, S must be 255 and V must be 255, H is ignored
+    [COLOR_RED] =          {  0,   0, 255}, // for full colour S must be 0 and V must be 255
     [COLOR_ORANGE] =       { 30,   0, 255},
     [COLOR_YELLOW] =       { 60,   0, 255},
     [COLOR_LIME_GREEN] =   { 90,   0, 255},
@@ -134,32 +134,36 @@ const hsvColor_t hsv[] = {
 
 
 
-#define VTX_FREQ_MIN 5650 // Below this will be white, above we get colour starting at an orange - red
-#define VTX_FREQ_RANGE 250.0f // leads to hue max at 5918 (R8 is 5917) or above
-#define VTX_HUE_MAX 345.0f // Hue for R8 or above should not hit red (360). 345 is a strong magenta but not like red
+#define VTX_FREQ_MIN 5653  // Below this VTx frequency will be white, above it we get color,starting at full Red.  R1 at 5658 is a slightly orange red.
+#define VTX_FREQ_MAX 5900  // upper frequency limit for whichover which the Hue changes, above this Hue is HUE_MAX
+#define VTX_HUE_MAX 345    // Maximum Hue value.Hue is red at 0 and 360.  345 is a strong magenta that is easily distinguished from red
 
 static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
 {
-    hsvColor_t color;
-    const float hsvScaleFactor = VTX_HUE_MAX / VTX_FREQ_RANGE;
-    
-    if (freq < VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
-    // usuallyt caused by misc configured frequency or no band / channel
-        color = HSV(BLACK);
-    } 
-    else if (freq >= VTX_FREQ_MIN) {
-        // show colours above R1
-        color.s = 0; 
-        color.v = 255; 
-        float hue = (float)(freq - (uint16_t)VTX_FREQ_MIN) * hsvScaleFactor;
-        // set hue to range from 0 to VTX_HUE_MAX
-        color.h = (hue > VTX_HUE_MAX) ? (uint16_t)VTX_HUE_MAX : (uint16_t)hue;
-    } 
-    else { // Frequencies below R1 will be white
-        color = HSV(WHITE);
+    hsvColor_t color = HSV(BLACK);
+
+    // Invalid or no VTX data, eg User has not set band or channel
+    if (freq <= VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
+        return color;
     }
-    
+
+    if (freq < VTX_FREQ_MIN) {
+        return HSV(WHITE);
+    } else {
+        //  give the LED a solid color above VTX_FREQ_MIN
+        if (freq > VTX_FREQ_MAX) {
+            freq = VTX_FREQ_MAX;
+            // Clamp incoming frequencyto mapping range
+        }
+    color.s = 0;
+    color.v = 255;
+    // for strong colours in betaflight, S must be 0 and V must be 255
+
+    color.h = scaleRange(freq, VTX_FREQ_MIN, VTX_FREQ_MAX, 0, VTX_HUE_MAX);
+    // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
+
     return color;
+    }
 }
 
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -133,46 +133,43 @@ const hsvColor_t hsv[] = {
 
 
 
-#define VTX_FREQ_MIN 5358   // Lowest frequency at which Vtx colors start (Just below L1)
-                            // L1 is 5362, R1 is 8 *  37 MHz channels higher,  at 5658.
-                            // Below 5355, LEDs will be white, then  Red at this frequency, returning  orange-Red for L1
-                            // Above this the color Hue rotates  as the frequency moves  through the  LowBand channels until again becoming orange-red for R1
-                            // then the same color rotation applies above R1 through to R8
-#define VTX_FREQ_MAX 5900   // upper frequency limit for which the Hue changes, above this Hue is fixed at HUE_MAX
-#define VTX_HUE_MAX 355     // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
+#define VTX_HUE_START_FREQ 5654     // frequency, just below R1 at 5658, that returns solid red
+#define VTX_HUE_STOP_FREQ 5900      // frequency just below R8  at 5917,  above which Hue does not exceed VTX_HUE_MAX
+#define VTX_HUE_MAX 355             // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
 
 #ifdef USE_VTX_COMMON
 static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
 {
+// assign LowBand and RaceBand Vtx channels to colors, with the same color for the same channel number in each band.
+
     hsvColor_t color = HSV(BLACK);
-    const unsigned bandRange = 296 // 8 channels per band, each 37MHz wide
+    const unsigned bandRange = 296; // width of the L or R bands;  8 channels per band, each 37MHz wide
 
     if (freq < VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
-        // Invalid or no VTX data, eg User hasn't set band or channel
-        return color; // black; turn LEDs off
-    }
-
-    if (freq < VTX_FREQ_MIN) {
+        // Invalid channel or frequency value, e.g., user hasn't set band or channel
+        return color;
+        // turn LEDs off
+    } else if (freq < VTX_HUE_START_FREQ - bandRange) {
         return HSV(WHITE);
-        // if below L1, exit and show white
+        // frequency too low to map; exit and show white
     }
-
-    if (freq < VTX_FREQ_MIN + bandRange){
-        // if below R1, shift up from L1...L8 to R1...R8 range  
-        freq += bandRange;
-    }
-        if (freq > VTX_FREQ_MAX) {
-            freq = VTX_FREQ_MAX;
-            // Clamp incoming frequency to an upper limit
+    else {
+        if (freq < VTX_HUE_START_FREQ) {
+            // fold frequencies below RaceBand up to equivalent RaceBand frequencies for Hue assignment 
+            freq += bandRange;
+        }
+    if (freq > VTX_HUE_STOP_FREQ) {
+            freq = VTX_HUE_STOP_FREQ;
+            // Clamp incoming frequencies to an upper limit around R8
     }
 
         color.s = 0;
         color.v = 255;
         // for strong colours in betaflight, S must be 0 and V must be 255
-
-        color.h = scaleRange(freq, VTX_FREQ_MIN + 296, VTX_FREQ_MAX, 0, VTX_HUE_MAX);
+        color.h = scaleRange(freq, VTX_HUE_START_FREQ, VTX_HUE_STOP_FREQ, 0, VTX_HUE_MAX);
         // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
         return color;
+    }
 }
 #endif
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -153,16 +153,15 @@ static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
         //  give the LED a solid color above VTX_FREQ_MIN
         if (freq > VTX_FREQ_MAX) {
             freq = VTX_FREQ_MAX;
-            // Clamp incoming frequencyto mapping range
+            // Clamp incoming frequency to mapping range
         }
-    color.s = 0;
-    color.v = 255;
-    // for strong colours in betaflight, S must be 0 and V must be 255
+        color.s = 0;
+        color.v = 255;
+        // for strong colours in betaflight, S must be 0 and V must be 255
 
-    color.h = scaleRange(freq, VTX_FREQ_MIN, VTX_FREQ_MAX, 0, VTX_HUE_MAX);
-    // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
-
-    return color;
+        color.h = scaleRange(freq, VTX_FREQ_MIN, VTX_FREQ_MAX, 0, VTX_HUE_MAX);
+        // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
+        return color;
     }
 }
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -112,10 +112,10 @@ static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 #define BEACON_FAILSAFE_PERIOD_US 250      // 2Hz
 #define BEACON_FAILSAFE_ON_PERCENT 50      // 50% duty cycle
 
-#define VTX_FREQ_MIN 5658 // R1, anything below this will be white
-#define VTX_FREQ_RANGE 259.0f // R2 should be Red with Hue of 0
-#define VTX_HUE_MAX 330.0f // Hue for R8 or above cannot be higher than 330
-#define VTX_SCALER (VTX_HUE_MAX / VTX_FREQ_RANGE) // Pre-calculated as 1.2741312f by compiler
+#define VTX_FREQ_MIN 5650 // Below this will be white, above we get colour starting at an orange - red
+#define VTX_FREQ_RANGE 250.0f // leads to hue max at 5918 (R8 is 5917) or above
+#define VTX_HUE_MAX 345.0f // Hue for R8 or above should not hit red (360). 345 is a strong magenta but not like red
+#define VTX_SCALER (VTX_HUE_MAX / VTX_FREQ_RANGE)
 
 
 const hsvColor_t hsv[] = {

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -112,6 +112,12 @@ static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 #define BEACON_FAILSAFE_PERIOD_US 250      // 2Hz
 #define BEACON_FAILSAFE_ON_PERCENT 50      // 50% duty cycle
 
+#define VTX_FREQ_MIN 5658 // R1, anything below this will be white
+#define VTX_FREQ_RANGE 259.0f // R2 should be Red with Hue of 0
+#define VTX_HUE_MAX 330.0f // Hue for R8 or above cannot be higher than 330
+#define VTX_SCALER (VTX_HUE_MAX / VTX_FREQ_RANGE) // Pre-calculated as 1.2741312f by compiler
+
+
 const hsvColor_t hsv[] = {
     //                        H    S    V
     [COLOR_BLACK] =        {  0,   0,   0},
@@ -131,6 +137,32 @@ const hsvColor_t hsv[] = {
 };
 // macro to save typing on default colors
 #define HSV(color) (hsv[COLOR_ ## color])
+
+
+static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
+{
+    hsvColor_t color;
+
+    if (freq < VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
+    // usuallyt caused by misc configured frequency or no band / channel
+        color = HSV(BLACK);
+    } 
+    else if (freq >= VTX_FREQ_MIN) {
+        // show colours above R1
+        color.s = 0; 
+        color.v = 255; 
+        float hue = (float)(freq - (uint16_t)VTX_FREQ_MIN) * VTX_SCALER;
+        
+        // Clamp to 330
+        color.h = (hue > VTX_HUE_MAX) ? (uint16_t)VTX_HUE_MAX : (uint16_t)hue;
+    } 
+    else { // Frequencies below R1 will be white
+        color = HSV(WHITE);
+    }
+    
+    return color;
+}
+
 
 PG_REGISTER_WITH_RESET_FN(ledStripConfig_t, ledStripConfig, PG_LED_STRIP_CONFIG, 3);
 
@@ -755,31 +787,7 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
 }
 
 #ifdef USE_VTX_COMMON
-static const struct {
-    uint16_t freq_upper_limit;
-    uint8_t color_index;
-} freq_to_color_lookup[] = {
-    {VTX_SETTINGS_MIN_FREQUENCY_MHZ, COLOR_BLACK},       // invalid
-    // Freqs are divided to match Raceband channels
-    {                          5672, COLOR_WHITE},       // R1
-    {                          5711, COLOR_RED},         // R2
-    {                          5750, COLOR_ORANGE},      // R3
-    {                          5789, COLOR_YELLOW},      // R4
-    {                          5829, COLOR_GREEN},       // R5
-    {                          5867, COLOR_BLUE},        // R6
-    {                          5906, COLOR_DARK_VIOLET}, // R7
-    {VTX_SETTINGS_MAX_FREQUENCY_MHZ, COLOR_DEEP_PINK},   // R8
-};
 
-static uint8_t getColorByVtxFrequency(const uint16_t freq)
-{
-    for (unsigned iter = 0; iter < ARRAYLEN(freq_to_color_lookup); iter++) {
-        if (freq <= freq_to_color_lookup[iter].freq_upper_limit) {
-            return freq_to_color_lookup[iter].color_index;
-        }
-    }
-    return COLOR_BLACK; // invalid
-}
 
 static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
 {
@@ -844,10 +852,20 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
             }
         }
     }
-    else { // show frequency
-        // calculate the VTX color based on frequency
-        uint8_t const colorIndex = getColorByVtxFrequency(frequency);
-        hsvColor_t color = ledStripStatusModeConfig()->colors[colorIndex];
+    else { // calculate the VTX color based on frequency
+
+        hsvColor_t color;
+        if (frequency < VTX_FREQ_MIN) {
+            color.h = 0;
+            color.s = 0;   // 0 Saturation = White
+        } else {
+            color.s = 255; // All colours fully saturated
+            float hue = (float)(frequency - VTX_FREQ_MIN) * VTX_SCALER;
+            
+            // Clamp Hue to VTX_HUE_MAX (330)
+            color.h = (hue > VTX_HUE_MAX) ? (uint16_t)VTX_HUE_MAX : (uint16_t)hue;
+        }
+
         color.v = (vtxStatus & VTX_STATUS_PIT_MODE) ? (blink ? 15 : 0) : 255; // blink when in pit mode
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
     }
@@ -1392,6 +1410,11 @@ static uint8_t selectVisualBeeperColor(uint8_t colorIndex, bool *colorIndexIsCus
 static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 {
     static timeUs_t colorUpdateTimeUs = 0;
+     static uint16_t lastVtxFreq = 0;
+         uint16_t currentVtxFreq = 0;
+    static bool vtxFreqChanged;
+    bool useDirectHsv = false;
+
     uint8_t colorIndex = COLOR_BLACK;
     bool blinkLed = false;
     bool visualBeeperOverride = true;
@@ -1408,28 +1431,30 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         colorIndex = ledStripConfig()->ledstrip_visual_beeper_color;
     } else {
         switch (ledStripConfig()->ledstrip_profile) {
-            case LED_PROFILE_RACE:
+case LED_PROFILE_RACE:
                 colorIndex = ledStripConfig()->ledstrip_race_color;
 #ifdef USE_VTX_COMMON
                 if (colorIndex == COLOR_BLACK) {
-                    // ledstrip_race_color is not set. Set color based on VTX frequency
+                    // when ledstrip_race_color is black, Color is set using HSV from VTx frequency
                     const vtxDevice_t *vtxDevice = vtxCommonDevice();
                     if (vtxDevice) {
-                        uint16_t freq;
-                        uint8_t const band = vtxSettingsConfigMutable()->band;
+                        useDirectHsv = true;
+                        uint8_t const band = vtxSettingsConfig()->band;
                         uint8_t const channel = vtxSettingsConfig()->channel;
+                        
                         if (band && channel) {
-                            freq = vtxCommonLookupFrequency(vtxDevice, band, channel);
+                            currentVtxFreq = vtxCommonLookupFrequency(vtxDevice, band, channel);
                         } else {
-                            // Direct frequency is used
-                            freq = vtxSettingsConfig()->freq;
+                            // If no band/channel, use the direct frequency
+                            currentVtxFreq = vtxSettingsConfig()->freq;
                         }
-                        colorIndex = getColorByVtxFrequency(freq);
-                        // getColorByVtxFrequency always uses custom colors
-                        // as they may be reassigned by the race director
-                        useCustomColors = true;
+
+                        if (currentVtxFreq != lastVtxFreq) {
+                            vtxFreqChanged = true;
+                            lastVtxFreq = currentVtxFreq;
+                        }
                     }
-                }
+                } 
 #endif
                 break;
 
@@ -1458,8 +1483,18 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         colorIndex = selectVisualBeeperColor(colorIndex, &useCustomColors);
     }
 
-    if ((colorIndex != previousProfileColorIndex) || (currentTimeUs >= colorUpdateTimeUs)) {
-        setStripColor((useCustomColors) ? &ledStripStatusModeConfig()->colors[colorIndex] : &hsv[colorIndex]);
+    bool updateStripColor = vtxFreqChanged || (colorIndex != previousProfileColorIndex) || (currentTimeUs >= colorUpdateTimeUs);
+
+     if (updateStripColor) {
+        if (useDirectHsv) {
+            hsvColor_t vtxHsv = getHsvByVtxFrequency(lastVtxFreq);
+            setStripColor(&vtxHsv);
+        } else {
+            // APPLY ORIGINAL PALETTE
+            setStripColor((useCustomColors) ? &ledStripStatusModeConfig()->colors[colorIndex] : &hsv[colorIndex]);
+        }
+
+        // UPDATE STATE
         previousProfileColorIndex = colorIndex;
         colorUpdateTimeUs = currentTimeUs + PROFILE_COLOR_UPDATE_INTERVAL_US;
         return LED_PROFILE_ADVANCE;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1416,22 +1416,16 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
             useVtxColors = (colorIndex == COLOR_BLACK);
 
 #ifdef USE_VTX_COMMON
-            if (useVtxColors)
-            {
+            if (useVtxColors) {
                 const vtxDevice_t *vtxDevice = vtxCommonDevice();
-
-                if (vtxDevice)
-                {
+                if (vtxDevice) {
                     uint8_t const band = vtxSettingsConfig()->band;
                     uint8_t const channel = vtxSettingsConfig()->channel;
                     uint16_t freq = 0;
 
-                    if (band && channel)
-                    {
+                    if (band && channel) {
                         freq = vtxCommonLookupFrequency(vtxDevice, band, channel);
-                    }
-                    else
-                    {
+                    } else {
                         freq = vtxSettingsConfig()->freq;
                         // use manually configured frequency if no band and channel
                     }
@@ -1460,9 +1454,8 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
             break;
     }
 
-    if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive())
+    if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive()) {
         // turn LEDs on and off at fixed intervals to help find it if lost
-    {
         flashPeriod = BEACON_FAILSAFE_PERIOD_MS;
         onPercent   = BEACON_FAILSAFE_ON_PERCENT;
         periodicBlink = true;
@@ -1475,8 +1468,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
     if (periodicBlink && flashPeriod > 0){
         // Handle a periodic blink request
         const unsigned onPeriod = flashPeriod * onPercent / 100;
-        const bool ledOn = (millis() % flashPeriod) < onPeriod;
-        
+        const bool ledOn = (millis() % flashPeriod) < onPeriod; 
         colorIndex = ledOn ? beaconColor : COLOR_BLACK;
         // use the configured beacon color when the LED is on
         useVtxColors = !ledOn;
@@ -1485,28 +1477,24 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         // these blinks will not use the custom color table to ensure reliable interpretation
     }
 
-    if (beeperEventsPermitted && isBeeperOn())
-    // Handle transient visual beeps with audio beeps, e.g. on arming or calibrating something
-    {
-        useVtxColors = false;
-        // Don't override the beep color with the Vtx color while the beep color is active
+    if (ledStripConfig()->ledstrip_visual_beeper && beeperEventsPermitted && isBeeperOn()) {
+        // Handle transient visual beeps with audio beeps, e.g. on arming or calibrating something
+        colorIndex = ledStripConfig()->ledstrip_visual_beeper_color;
         useCustomColors = false;
+        // use the system-defined visual_beeper_color, not allowing customisation
+        useVtxColors = false;
+    // Don't override the beep color with the Vtx color while the beep color is active
     }
 
-    if (useVtxColors)
-    {
+    if (useVtxColors) {
         currentHsv = getHsvFromVtxFrequency(currentVtxFrequency);
         // apply the algorithm to calculate HSV values from VTx frequency
-    }
-    else
-    {
-        currentHsv = (useCustomColors)
-            ? ledStripStatusModeConfig()->colors[colorIndex]
-            : hsv[colorIndex];
-            // get the HSV value of the current color
+    } else {
+        currentHsv = (useCustomColors) ? ledStripStatusModeConfig()->colors[colorIndex] : hsv[colorIndex];
+        // get the HSV value of the current color
     }
 
-    bool updateLedStripColor =
+        bool updateLedStripColor =
         currentHsv.h != previousHsv.h ||
         currentHsv.s != previousHsv.s ||
         currentHsv.v != previousHsv.v ||
@@ -1514,8 +1502,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         (currentTimeUs >= colorUpdateTimeUs);
         // or update interval is reached
 
-    if (updateLedStripColor)
-    {
+    if (updateLedStripColor) {
         setStripColor(&currentHsv);
         // set all LEDs to the current HSV values
 
@@ -1530,8 +1517,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 
 
 timeUs_t executeTimeUs;
-void ledStripUpdate(timeUs_t currentTimeUs)
-{
+void ledStripUpdate(timeUs_t currentTimeUs) {
     static uint16_t ledStateDurationFractionUs[2] = { 0 };
     static bool applyProfile = true;
     static timeUs_t updateStartTimeUs = 0;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -856,7 +856,11 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
     else { // calculate the VTX color based on frequency
 
         hsvColor_t color = getHsvFromVtxFrequency(frequency);
-        color.v = (vtxStatus & VTX_STATUS_PIT_MODE) ? (blink ? 15 : 0) : 255; // blink when in pit mode
+        if (vtxStatus & VTX_STATUS_PIT_MODE) {
+            color.v = blink ? color.v : 15;
+            // blink to a pale color when in pit mode
+            // if no vtx color (black means vtx frequency known) blink from off to pale red (0,0,15)
+        }
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
     }
 }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -85,7 +85,6 @@
 #define COLOR_UNDEFINED 255
 
 static bool ledStripEnabled = false;
-static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 
 #define HZ_TO_US(hz) ((int32_t)((1000 * 1000) / (hz)))
 
@@ -109,7 +108,7 @@ static uint8_t previousProfileColorIndex = COLOR_UNDEFINED;
 
 #define VISUAL_BEEPER_COLOR COLOR_WHITE
 
-#define BEACON_FAILSAFE_PERIOD_US 250      // 2Hz
+#define BEACON_FAILSAFE_PERIOD_MS 250      // 2Hz
 #define BEACON_FAILSAFE_ON_PERCENT 50      // 50% duty cycle
 
 const hsvColor_t hsv[] = {
@@ -1365,8 +1364,6 @@ void ledStripDisable(void)
 {
     if (ledStripEnabled) {
         ledStripEnabled = false;
-        previousProfileColorIndex = COLOR_UNDEFINED;
-
         setStripColor(&HSV(BLACK));
 
         // Multiple calls may be required as normally broken into multiple parts
@@ -1389,110 +1386,123 @@ void ledStripInit(void)
 
 static uint8_t selectVisualBeeperColor(uint8_t colorIndex, bool *colorIndexIsCustom)
 {
-    if (ledStripConfig()->ledstrip_visual_beeper && isBeeperOn()) {
-        if (colorIndexIsCustom)
+    if (ledStripConfig()->ledstrip_visual_beeper) {
+        if (colorIndexIsCustom) {
             *colorIndexIsCustom = false;
+        }
+
         return ledStripConfig()->ledstrip_visual_beeper_color;
-    } else {
-        return colorIndex;
     }
+
+    return colorIndex;
 }
 
 static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 {
     static timeUs_t colorUpdateTimeUs = 0;
     static uint16_t lastVtxFreq = 0;
-    bool vtxFreqChanged = false;
-    bool useDirectHsv = false;
+
+    hsvColor_t currentHsv;
+    static hsvColor_t previousHsv = {0, 0, 0};
 
     uint8_t colorIndex = COLOR_BLACK;
-    bool blinkLed = false;
-    bool visualBeeperOverride = true;
+    uint8_t beaconColor = COLOR_BLACK;
+
     bool useCustomColors = false;
-    unsigned flashPeriod;
-    unsigned onPercent;
+    bool useVtxFrequency = false;
+
+    bool beaconMode = false;
+    unsigned flashPeriod = 0;
+    unsigned onPercent = 0;
+
+    switch (ledStripConfig()->ledstrip_profile) {
+
+    case LED_PROFILE_RACE:
+        colorIndex = ledStripConfig()->ledstrip_race_color;
+        useVtxFrequency = (colorIndex == COLOR_BLACK);
+
+#ifdef USE_VTX_COMMON
+        if (useVtxFrequency) {
+            const vtxDevice_t *vtxDevice = vtxCommonDevice();
+
+            if (vtxDevice) {
+                uint8_t const band = vtxSettingsConfig()->band;
+                uint8_t const channel = vtxSettingsConfig()->channel;
+                uint16_t freq = 0;
+
+                if (band && channel) {
+                    freq = vtxCommonLookupFrequency(vtxDevice, band, channel);
+                } else {
+                    freq = vtxSettingsConfig()->freq;
+                }
+
+                lastVtxFreq = freq;
+            }
+        }
+#endif
+        break;
+
+    case LED_PROFILE_BEACON:
+        if (!ledStripConfig()->ledstrip_beacon_armed_only || ARMING_FLAG(ARMED)) {
+            flashPeriod = ledStripConfig()->ledstrip_beacon_period_ms;
+            onPercent   = ledStripConfig()->ledstrip_beacon_percent;
+            beaconColor = ledStripConfig()->ledstrip_beacon_color;
+
+            beaconMode = true;
+        }
+        break;
+
+    default:
+        break;
+    }
 
     if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive()) {
-        // RX_SET or failsafe - force the beacon on and override the profile settings
-        blinkLed = true;
-        visualBeeperOverride = false; // prevent the visual beeper from interfering
-        flashPeriod = BEACON_FAILSAFE_PERIOD_US;
-        onPercent = BEACON_FAILSAFE_ON_PERCENT;
-        colorIndex = ledStripConfig()->ledstrip_visual_beeper_color;
-    } else {
-        switch (ledStripConfig()->ledstrip_profile) {
-case LED_PROFILE_RACE:
-                colorIndex = ledStripConfig()->ledstrip_race_color;
-#ifdef USE_VTX_COMMON
-                if (colorIndex == COLOR_BLACK) {
-                    // when ledstrip_race_color is black, Color is set using HSV from VTx frequency
-                    const vtxDevice_t *vtxDevice = vtxCommonDevice();
-                    if (vtxDevice) {
-                        useDirectHsv = true;
-                        uint8_t const band = vtxSettingsConfig()->band;
-                        uint8_t const channel = vtxSettingsConfig()->channel;
-                        uint16_t currentVtxFreq = 0;
-                        
-                        if (band && channel) {
-                            currentVtxFreq = vtxCommonLookupFrequency(vtxDevice, band, channel);
-                        } else {
-                            // If no band/channel, use the direct frequency
-                            currentVtxFreq = vtxSettingsConfig()->freq;
-                        }
+        flashPeriod = BEACON_FAILSAFE_PERIOD_MS;
+        onPercent   = BEACON_FAILSAFE_ON_PERCENT;
+        beaconColor = ledStripConfig()->ledstrip_visual_beeper_color;
 
-                        if (currentVtxFreq != lastVtxFreq) {
-                            vtxFreqChanged = true;
-                            lastVtxFreq = currentVtxFreq;
-                        }
-                    }
-                } 
-#endif
-                break;
-
-            case LED_PROFILE_BEACON: {
-                if (!ledStripConfig()->ledstrip_beacon_armed_only || ARMING_FLAG(ARMED)) {
-                    flashPeriod = ledStripConfig()->ledstrip_beacon_period_ms;
-                    onPercent = ledStripConfig()->ledstrip_beacon_percent;
-                    colorIndex = ledStripConfig()->ledstrip_beacon_color;
-                    blinkLed = true;
-                }
-                break;
-            }
-
-            default:
-                break;
-        }
+        beaconMode = true;
+        useVtxFrequency = false;
     }
 
-    if (blinkLed) {
+    if (beaconMode) {
         const unsigned onPeriod = flashPeriod * onPercent / 100;
-        const bool beaconState = (millis() % flashPeriod) < onPeriod;
-        colorIndex = (beaconState) ? colorIndex : COLOR_BLACK;
+        const bool beaconOn = (millis() % flashPeriod) < onPeriod;
+
+        colorIndex = (beaconOn) ? beaconColor : COLOR_BLACK;
     }
 
-    if (visualBeeperOverride) {
+    if (isBeeperOn()) {
+        useVtxFrequency = false;
         colorIndex = selectVisualBeeperColor(colorIndex, &useCustomColors);
     }
 
-    bool updateLedStripColor = vtxFreqChanged || (colorIndex != previousProfileColorIndex) || (currentTimeUs >= colorUpdateTimeUs);
+    if (useVtxFrequency) {
+        currentHsv = getHsvByVtxFrequency(lastVtxFreq);
+    } else {
+        currentHsv = (useCustomColors)
+            ? ledStripStatusModeConfig()->colors[colorIndex]
+            : hsv[colorIndex];
+    }
 
-     if (updateLedStripColor) {
-        if (useDirectHsv) {
-            hsvColor_t vtxHsv = getHsvByVtxFrequency(lastVtxFreq);
-            setStripColor(&vtxHsv);
-        } else {
-            // APPLY ORIGINAL PALETTE
-            setStripColor((useCustomColors) ? &ledStripStatusModeConfig()->colors[colorIndex] : &hsv[colorIndex]);
-        }
+    bool updateLedStripColor =
+        currentHsv.h != previousHsv.h ||
+        currentHsv.s != previousHsv.s ||
+        currentHsv.v != previousHsv.v ||
+        (currentTimeUs >= colorUpdateTimeUs);
 
-        // UPDATE STATE
-        previousProfileColorIndex = colorIndex;
+    if (updateLedStripColor) {
+        setStripColor(&currentHsv);
+
+        previousHsv = currentHsv;
         colorUpdateTimeUs = currentTimeUs + PROFILE_COLOR_UPDATE_INTERVAL_US;
+
         return LED_PROFILE_ADVANCE;
     }
 
     return LED_PROFILE_SLOW;
 }
+
 
 timeUs_t executeTimeUs;
 void ledStripUpdate(timeUs_t currentTimeUs)

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -134,9 +134,9 @@ const hsvColor_t hsv[] = {
 
 
 
-#define VTX_FREQ_MIN 5653  // Below this VTx frequency will be white, above it we get color,starting at full Red.  R1 at 5658 is a slightly orange red.
-#define VTX_FREQ_MAX 5900  // upper frequency limit for whichover which the Hue changes, above this Hue is HUE_MAX
-#define VTX_HUE_MAX 345    // Maximum Hue value.Hue is red at 0 and 360.  345 is a strong magenta that is easily distinguished from red
+#define VTX_FREQ_MIN 5653  // Below this VTx frequency, LEDs will be white. Above it we get colors, starting from full  Red at this frequency.  R1 at 5658 is a slightly orange red.
+#define VTX_FREQ_MAX 5900  // upper frequency limit for which the Hue changes, above this Hue is HUE_MAX
+#define VTX_HUE_MAX 345    // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
 
 static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
 {

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1486,7 +1486,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         currentHsv.s != previousHsv.s ||
         currentHsv.v != previousHsv.v ||
         // HSV value has changed
-        (currentTimeUs >= colorUpdateTimeUs);
+        (cmpTimeUs(currentTimeUs, colorUpdateTimeUs) >= 0);
         // or update interval is reached
 
     if (updateLedStripColor) {

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -168,6 +168,10 @@ static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
         // for strong colours in betaflight, S must be 0 and V must be 255
         color.h = scaleRange(freq, VTX_HUE_START_FREQ, VTX_HUE_STOP_FREQ, 0, VTX_HUE_MAX);
         // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
+        if (color.h < 165) {
+    color.h *= 0.9;
+    // warm up the yellow, pull cyan a bit further from blue, and keep a decent green
+}
         return color;
     }
 }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -137,7 +137,7 @@ const hsvColor_t hsv[] = {
 #define VTX_FREQ_MAX 5900  // upper frequency limit for which the Hue changes, above this Hue is HUE_MAX
 #define VTX_HUE_MAX 345    // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
 
-static hsvColor_t getHsvByVtxFrequency(uint16_t freq)
+static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
 {
     hsvColor_t color = HSV(BLACK);
 
@@ -855,7 +855,7 @@ static void applyLedVtxLayer(bool updateNow, timeUs_t *timer)
     }
     else { // calculate the VTX color based on frequency
 
-        hsvColor_t color = getHsvByVtxFrequency(frequency);
+        hsvColor_t color = getHsvFromVtxFrequency(frequency);
         color.v = (vtxStatus & VTX_STATUS_PIT_MODE) ? (blink ? 15 : 0) : 255; // blink when in pit mode
         applyLedHsv(LED_MOV_OVERLAY(LED_FLAG_OVERLAY(LED_OVERLAY_VTX)), &color);
     }
@@ -1400,7 +1400,7 @@ static uint8_t selectVisualBeeperColor(uint8_t colorIndex, bool *colorIndexIsCus
 static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 {
     static timeUs_t colorUpdateTimeUs = 0;
-    static uint16_t lastVtxFreq = 0;
+    static uint16_t currentVtxFrequency = 0;
 
     hsvColor_t currentHsv;
     static hsvColor_t previousHsv = {0, 0, 0};
@@ -1409,90 +1409,122 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
     uint8_t beaconColor = COLOR_BLACK;
 
     bool useCustomColors = false;
-    bool useVtxFrequency = false;
+    bool useVtxColors = false;
+    bool beeperEventsPermitted = true;
+    bool periodicBlink = false;
 
-    bool beaconMode = false;
     unsigned flashPeriod = 0;
     unsigned onPercent = 0;
 
-    switch (ledStripConfig()->ledstrip_profile) {
-
-    case LED_PROFILE_RACE:
-        colorIndex = ledStripConfig()->ledstrip_race_color;
-        useVtxFrequency = (colorIndex == COLOR_BLACK);
+    switch (ledStripConfig()->ledstrip_profile)
+    {
+        case LED_PROFILE_RACE:
+            colorIndex = ledStripConfig()->ledstrip_race_color;
+            // All LEDs steadily at colour, but if black,  colour according to VTx frequency
+            useVtxColors = (colorIndex == COLOR_BLACK);
 
 #ifdef USE_VTX_COMMON
-        if (useVtxFrequency) {
-            const vtxDevice_t *vtxDevice = vtxCommonDevice();
+            if (useVtxColors)
+            {
+                const vtxDevice_t *vtxDevice = vtxCommonDevice();
 
-            if (vtxDevice) {
-                uint8_t const band = vtxSettingsConfig()->band;
-                uint8_t const channel = vtxSettingsConfig()->channel;
-                uint16_t freq = 0;
+                if (vtxDevice)
+                {
+                    uint8_t const band = vtxSettingsConfig()->band;
+                    uint8_t const channel = vtxSettingsConfig()->channel;
+                    uint16_t freq = 0;
 
-                if (band && channel) {
-                    freq = vtxCommonLookupFrequency(vtxDevice, band, channel);
-                } else {
-                    freq = vtxSettingsConfig()->freq;
+                    if (band && channel)
+                    {
+                        freq = vtxCommonLookupFrequency(vtxDevice, band, channel);
+                    }
+                    else
+                    {
+                        freq = vtxSettingsConfig()->freq;
+                        // use manually configured frequency if no band and channel
+                    }
+
+                    currentVtxFrequency = freq;
                 }
-
-                lastVtxFreq = freq;
             }
-        }
 #endif
-        break;
+            break;
 
-    case LED_PROFILE_BEACON:
-        if (!ledStripConfig()->ledstrip_beacon_armed_only || ARMING_FLAG(ARMED)) {
-            flashPeriod = ledStripConfig()->ledstrip_beacon_period_ms;
-            onPercent   = ledStripConfig()->ledstrip_beacon_percent;
-            beaconColor = ledStripConfig()->ledstrip_beacon_color;
+        case LED_PROFILE_BEACON:
+                // flash all LEDs, alternating between beacon color and off
+            if (!ledStripConfig()->ledstrip_beacon_armed_only || ARMING_FLAG(ARMED))
+            {
+                flashPeriod = ledStripConfig()->ledstrip_beacon_period_ms;
+                onPercent   = ledStripConfig()->ledstrip_beacon_percent;
+                beaconColor = ledStripConfig()->ledstrip_beacon_color;
+                periodicBlink = true;
+                // use a periodical blink pattern
+                useVtxColors = false;
+                // do not overlay the vtx color (not calculated anyway)
+            }
+            break;
 
-            beaconMode = true;
-        }
-        break;
-
-    default:
-        break;
+        default:
+            break;
     }
 
-    if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive()) {
+    if (IS_RC_MODE_ACTIVE(BOXBEEPERON) || failsafeIsActive())
+        // turn LEDs on and off at fixed intervals to help find it if lost
+    {
         flashPeriod = BEACON_FAILSAFE_PERIOD_MS;
         onPercent   = BEACON_FAILSAFE_ON_PERCENT;
+        periodicBlink = true;
+        // use a periodical blink pattern
         beaconColor = ledStripConfig()->ledstrip_visual_beeper_color;
-
-        beaconMode = true;
-        useVtxFrequency = false;
+        beeperEventsPermitted = false;
+        // do not allow transient led flashes at the same time, can mess up the regular timing
     }
 
-    if (beaconMode) {
+    if (periodicBlink){
+        // Handle a periodic blink request
         const unsigned onPeriod = flashPeriod * onPercent / 100;
-        const bool beaconOn = (millis() % flashPeriod) < onPeriod;
-
-        colorIndex = (beaconOn) ? beaconColor : COLOR_BLACK;
+        const bool ledOn = (millis() % flashPeriod) < onPeriod;
+        
+        colorIndex = ledOn ? beaconColor : COLOR_BLACK;
+        // use the configured beacon color when the LED is on
+        useVtxColors = !ledOn;
+        // Don't override the beep color with the Vtx color while the beep color is active
     }
 
-    if (isBeeperOn()) {
-        useVtxFrequency = false;
+    if (beeperEventsPermitted && isBeeperOn())
+    // Handle transient visual beeps with audio beeps, e.g. on arming or calibrating something
+    {
+        useVtxColors = false;
+        // Don't override the beep color with the Vtx color while the beep color is active
         colorIndex = selectVisualBeeperColor(colorIndex, &useCustomColors);
+        // set the active color to use for the visual beep
     }
 
-    if (useVtxFrequency) {
-        currentHsv = getHsvByVtxFrequency(lastVtxFreq);
-    } else {
+    if (useVtxColors)
+    {
+        currentHsv = getHsvFromVtxFrequency(currentVtxFrequency);
+        // apply the algorithm to calculate HSV values from VTx frequency
+    }
+    else
+    {
         currentHsv = (useCustomColors)
             ? ledStripStatusModeConfig()->colors[colorIndex]
             : hsv[colorIndex];
+            // get the HSV value of the current color
     }
 
     bool updateLedStripColor =
         currentHsv.h != previousHsv.h ||
         currentHsv.s != previousHsv.s ||
         currentHsv.v != previousHsv.v ||
+        // HSV value has changed
         (currentTimeUs >= colorUpdateTimeUs);
+        // or update interval is reached
 
-    if (updateLedStripColor) {
+    if (updateLedStripColor)
+    {
         setStripColor(&currentHsv);
+        // set all LEDs to the current HSV values
 
         previousHsv = currentHsv;
         colorUpdateTimeUs = currentTimeUs + PROFILE_COLOR_UPDATE_INTERVAL_US;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -108,7 +108,7 @@ static bool ledStripEnabled = false;
 
 #define VISUAL_BEEPER_COLOR COLOR_WHITE
 
-#define BEACON_FAILSAFE_PERIOD_MS 250      // 2Hz
+#define BEACON_FAILSAFE_PERIOD_MS 250      // 4Hz
 #define BEACON_FAILSAFE_ON_PERCENT 50      // 50% duty cycle
 
 const hsvColor_t hsv[] = {

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -142,7 +142,7 @@ static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
     hsvColor_t color = HSV(BLACK);
 
     // Invalid or no VTX data, eg User has not set band or channel
-    if (freq <= VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
+    if (freq < VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
         return color;
     }
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1388,18 +1388,6 @@ void ledStripInit(void)
     ws2811LedStripInit(ledStripConfig()->ioTag, (ledStripFormatRGB_e)ledStripConfig()->ledstrip_grb_rgb);
 }
 
-static uint8_t selectVisualBeeperColor(uint8_t colorIndex, bool *colorIndexIsCustom)
-{
-    if (ledStripConfig()->ledstrip_visual_beeper) {
-        if (colorIndexIsCustom) {
-            *colorIndexIsCustom = false;
-        }
-
-        return ledStripConfig()->ledstrip_visual_beeper_color;
-    }
-
-    return colorIndex;
-}
 
 static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
 {
@@ -1412,7 +1400,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
     uint8_t colorIndex = COLOR_BLACK;
     uint8_t beaconColor = COLOR_BLACK;
 
-    bool useCustomColors = false;
+    bool useCustomColors = true;
     bool useVtxColors = false;
     bool beeperEventsPermitted = true;
     bool periodicBlink = false;
@@ -1493,6 +1481,8 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
         // use the configured beacon color when the LED is on
         useVtxColors = !ledOn;
         // Don't override the beep color with the Vtx color while the beep color is active
+        useCustomColors = false;
+        // these blinks will not use the custom color table to ensure reliable interpretation
     }
 
     if (beeperEventsPermitted && isBeeperOn())
@@ -1500,8 +1490,7 @@ static ledProfileSequence_t applySimpleProfile(timeUs_t currentTimeUs)
     {
         useVtxColors = false;
         // Don't override the beep color with the Vtx color while the beep color is active
-        colorIndex = selectVisualBeeperColor(colorIndex, &useCustomColors);
-        // set the active color to use for the visual beep
+        useCustomColors = false;
     }
 
     if (useVtxColors)

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -169,7 +169,7 @@ static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
         color.h = scaleRange(freq, VTX_HUE_START_FREQ, VTX_HUE_STOP_FREQ, 0, VTX_HUE_MAX);
         // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
         if (color.h < 165) {
-    color.h *= 0.9;
+    color.h = (color.h * 9) / 10;
     // warm up the yellow, pull cyan a bit further from blue, and keep a decent green
 }
         return color;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -116,11 +116,11 @@ const hsvColor_t hsv[] = {
     [COLOR_BLACK] =        {  0,   0,   0}, // LED is off
     [COLOR_WHITE] =        {  0, 255, 255}, // for white, S must be 255 and V must be 255, H is ignored
     [COLOR_RED] =          {  0,   0, 255}, // for full colour S must be 0 and V must be 255
-    [COLOR_ORANGE] =       { 30,   0, 255},
-    [COLOR_YELLOW] =       { 60,   0, 255},
-    [COLOR_LIME_GREEN] =   { 90,   0, 255},
-    [COLOR_GREEN] =        {120,   0, 255},
-    [COLOR_MINT_GREEN] =   {150,   0, 255},
+    [COLOR_ORANGE] =       { 15,   0, 255},
+    [COLOR_YELLOW] =       { 50,   0, 255},
+    [COLOR_LIME_GREEN] =   { 100,  0, 255},
+    [COLOR_GREEN] =        {115,   0, 255},
+    [COLOR_MINT_GREEN] =   {125,   0, 255},
     [COLOR_CYAN] =         {180,   0, 255},
     [COLOR_LIGHT_BLUE] =   {210,   0, 255},
     [COLOR_BLUE] =         {240,   0, 255},
@@ -133,38 +133,49 @@ const hsvColor_t hsv[] = {
 
 
 
-#define VTX_FREQ_MIN 5653  // Below this VTx frequency, LEDs will be white. Above it we get colors, starting from full  Red at this frequency.  R1 at 5658 is a slightly orange red.
-#define VTX_FREQ_MAX 5900  // upper frequency limit for which the Hue changes, above this Hue is HUE_MAX
-#define VTX_HUE_MAX 345    // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
+#define VTX_FREQ_MIN 5358   // Lowest frequency at which Vtx colors start (Just below L1)
+                            // L1 is 5362, R1 is 8 *  37 MHz channels higher,  at 5658.
+                            // Below 5355, LEDs will be white, then  Red at this frequency, returning  orange-Red for L1
+                            // Above this the color Hue rotates  as the frequency moves  through the  LowBand channels until again becoming orange-red for R1
+                            // then the same color rotation applies above R1 through to R8
+#define VTX_FREQ_MAX 5900   // upper frequency limit for which the Hue changes, above this Hue is fixed at HUE_MAX
+#define VTX_HUE_MAX 355     // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
 
 #ifdef USE_VTX_COMMON
 static hsvColor_t getHsvFromVtxFrequency(uint16_t freq)
 {
     hsvColor_t color = HSV(BLACK);
+    const unsigned bandRange = 296 // 8 channels per band, each 37MHz wide
 
-    // Invalid or no VTX data, eg User has not set band or channel
     if (freq < VTX_SETTINGS_MIN_FREQUENCY_MHZ) {
-        return color;
+        // Invalid or no VTX data, eg User hasn't set band or channel
+        return color; // black; turn LEDs off
     }
 
     if (freq < VTX_FREQ_MIN) {
         return HSV(WHITE);
-    } else {
-        //  give the LED a solid color above VTX_FREQ_MIN
+        // if below L1, exit and show white
+    }
+
+    if (freq < VTX_FREQ_MIN + bandRange){
+        // if below R1, shift up from L1...L8 to R1...R8 range  
+        freq += bandRange;
+    }
         if (freq > VTX_FREQ_MAX) {
             freq = VTX_FREQ_MAX;
-            // Clamp incoming frequency to mapping range
-        }
+            // Clamp incoming frequency to an upper limit
+    }
+
         color.s = 0;
         color.v = 255;
         // for strong colours in betaflight, S must be 0 and V must be 255
 
-        color.h = scaleRange(freq, VTX_FREQ_MIN, VTX_FREQ_MAX, 0, VTX_HUE_MAX);
+        color.h = scaleRange(freq, VTX_FREQ_MIN + 296, VTX_FREQ_MAX, 0, VTX_HUE_MAX);
         // scale Hue from 0 (red) to VTX_HUE_MAX, linearly across frequency range
         return color;
-    }
 }
 #endif
+
 
 PG_REGISTER_WITH_RESET_FN(ledStripConfig_t, ledStripConfig, PG_LED_STRIP_CONFIG, 3);
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -133,7 +133,7 @@ const hsvColor_t hsv[] = {
 
 
 
-#define VTX_HUE_START_FREQ 5654     // frequency, just below R1 at 5658, that returns solid red
+#define VTX_HUE_START_FREQ 5658     //  R1, returns solid red at R1
 #define VTX_HUE_STOP_FREQ 5900      // frequency just below R8  at 5917,  above which Hue does not exceed VTX_HUE_MAX
 #define VTX_HUE_MAX 355             // Maximum Hue value. Hue is circular in degrees, with red at 0 and 360.  345 is a strong magenta that is easily distinguished from red.
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -182,7 +182,7 @@ PG_REGISTER_WITH_RESET_FN(ledStripConfig_t, ledStripConfig, PG_LED_STRIP_CONFIG,
 
 void pgResetFn_ledStripConfig(ledStripConfig_t *ledStripConfig)
 {
-    ledStripConfig->ledstrip_visual_beeper = 0;
+    ledStripConfig->ledstrip_visual_beeper = 1;
 #ifdef USE_LED_STRIP_STATUS_MODE
     ledStripConfig->ledstrip_profile = LED_PROFILE_STATUS;
 #else


### PR DESCRIPTION
This PR changes how the LEDStrip colours change automatically according to the VTx frequency, providing  8 distinct colors instead of 6 for the 8 RaceBand and LowBand channels

- in both Low and Race Bands, identical  channel numbers have the same color
- these colors will not be affected by changes in the custom color table, ensuring consistent outcomes even if the color table has been modified.
- improves the rendering of the default named colors
- defaults the visual_beeper to on, in Race Profile, probably  useful for most people with ledstrips (will flash for LowBattery, on arming or on Profile changes, etc... settings editable in Configurator).
- improves code readability and provides some minor bugfixes

As before, to enable automatic Vtx colors, apply this snippet in the CLI:


```
set ledstrip_profile = RACE
set ledstrip_race_color = BLACK
```

To text on any FC with a LED strip, build firmware with Ledstrip and VTx, and this PR. Apply the snippet above, thenchange  VTx Band/Channel in Configurator and note the LEDs change color as per the table below.

No changes are intended to the 'Status' Profile. This PR only affects the 'simple' `Race` and `Beacon` profiles.

There are small  changes to the default  Hue values for some named colors. These improve the rendering and distinctiveness of orange, yellow, lime green, green and mint_green when displayed with  modern LED strips.

**Notes for Race Directors**

In some locations, Channels R3...R6 are compromised by domestic  Wifi. If LowBand is legal in your country, and if the VTx supports LowBand, pilots on those channels can be reassigned to L3...L6, without changing the color for pilots on the same channel number, regardless of band. For example, whether  a pilot is on R4 or L4, the color will be the same. This simplifies color interpretation since the color matches the channel number for both bands.  Unfortunately, L3 and below are often not detected by Lap Timers and hence often can't be used. A group of seven 'good' channels for racing is therefore: 
- R1
- R2
- L4
- L5
- L6
- R7
- R8
A group of 7 pilots on these channels will get a color set by their channel number, whether in Race or Low Band, as if they were all on Race band only.
If R3 is not badly affected by Wifi and if the lap timer doesn't like L3, then R3 can be added back to the list of seven, above, for 8-up racing.

In a mix of Low and Race Bands,  the  color  indicates  the channel number only, so if you want unique colors for each pilot, keep each pilot on a unique channel number, regardless of the band. If, say, a group of 8 are on Race Band, but the pilot on R5 wants to try Lowband, moving them R5->L5, and not using R5 in that group any more, will let them keep the same color they were previously assigned. 

If Race Directors want to prevent the LEDs from flashing during a race (eg to stop flashing on low battery etc) then they should ask users to either  `set ledstrip_visual_beeper = OFF` in the CLI, or get them disable the unwanted beeper settings in Configurator. Note that  even if the visual_beeper is disabled completely, the quad will still flash  LEDs on failsafe or when the beeper mode switch is enabled, so that it can be found if lost or failsafe occurs. Race Directors cannot change the color assigned to a VTx channel by customising the custom color assignment table. If Race directors want a particular person to use a specific color, they can use Race Mode and set the color by name. This color can be customised via the custom color assignment table.


**Summary of Changes:**
- LEDstrip VTx color is now assigned by a mathematical algorithm for frequencies in both Low and RaceBands. Any frequency below L1 is white, and any illegal frequency is black.
- in both Low and Race  bands, the HSV values are rotated from Red for Channel 1 through to Deep_Pink  in Channel 8, according to the frequency of that channel. Hence L1 will have the same color as R1, and so on.
- The color is set according to the Vtx frequency, not the  band or channel number. The color will respond to manual frequency assignment correctly. The same  color will be returned for the same frequency on different bands.

- The HSV color code for VTx channels  is calculated mathematically, and is  not a 'color name' based lookup table, hence it custom changes to the named colors in the color table have no effect on VTx colors, keeping them predictable even if the color table has been messed around.
- In contrast, named ledstrip colors remain responsive to changes in the custom color table; e.g. `ledstrip_visual_beeper_color and `ledstrip_beacon_color` are still named colors and will respond to color table changes, as will colors displayed via the Status Profile, other than when the Status Profile uses a vtx color overlay.
- Visual_beeper is now explicitly is blocked in the 2Hz on/off Beacon Profile and during the 4Hz on/off Failsafe or Beeper Mode pattern, to not interfere with those patterns.
- Visual beeper defaults to On (only affects Race Profile

The default color table has been tweaked to improve rendering of orange, yellow and the green colors.
- bugfixes for possible divide by zero, incorrect beacon/ visual_beeper colors in some edge cases, and improved  race profile documentation.


**Detailed testing method:**

Flash with Ledstrip and Vtx in the firmware. Start with the default color table (if changed previously, use the snippet provided below to reset to the new defaults). in Configurator check which Beeper events are enabled.

- use at least 6 LEDs on the string, numbered consecutively in Configurator's wire ordering mode. Set them to any fixed color with no overlays, to start with.
- enable a 'Beeper mode switch in Configurator's Modes Tab
- Bind an Rx and attach a  Vtx, ideally one that displays channel and band, best if its analog so it won't overheat while testing.
- In CLI, set `ledstrip_profile` to `status` and check that the colours are correct (as per Configurator assignments).
- In CLI, set `ledstrip_profile` to `beacon`, check the color for  `ledstrip_beacon_color`, check the beacon timing.  Confirm thatthe LEDs all flash on and off at 2Hz with default timing.
- In CLI, set `ledstrip_profile to `race` and set`ledstrip_race_color` to some fixed color by name, eg Green. Confirm that all LEDs go green.
- In CLI, set `ledstrip_profile to `race` and set`ledstrip_race_color` to black, and confirm that the LEDs change color to reflect the currently active VTx frequency. Confirm that if either band or channel are not set, and frequency is not entered directly, then, all LEDs go 'off'. Confirm that if direct entry of VTx frequency is toggled on, that the color changes with frequency between 5653 (red) and 5900 (deep_pink/magenta).
- Test the behaviour when the beeper switch (beeper mode)  is enabled in Race Profile. All LEDs should alternate between the base color and the `ledstrip_visual_beeper_color` at about 2Hz. 
- Test a failsafe in Race Profile. LEDs should flash the same as for the switch to beeper mode.
- Test VTx PitMode in Race Profile. If a color is defined by the Vtx, the LEDs should periodically 'flash' to a dim version of the same color. If there is no VTx frequency available, the LEDs will be all black; when PitMode is enabled like this, the LEDs should flash a dim Red.
- If Beeper events are enabled in Configurator, when the quad would usually make an audible Beep, and if `ledstrip_visual_beeper is 'ON', the LEDs should also flash o the configured  `ledstrip_visual_beeper_color` while the beep sounds. This will not happen in any periodical (regular) on/off pattern like beacon mode, beeper switch, or failsafe, but should happen in Race Profile. Confirm by generating low battery warnings or performing stick actions like changing profiles, calibrating gyro, arming, etc.
- In Status Profile, but not in any other Profile, an overlay to display VTx settings on the first 6 LEDs of your strip may be enabled. For 15s after changing a VTx setting, the first of the six LEDs with the overlay enabled should flash green, and the next 6 should indicate the powerLevel in orange, or be off. For example if power level is 1, the second LED, the one immediately after the green one, should blink orange, but if power level is three, then three LEDs after the green blinking one should flash orange.
- Finally check the behaviour with custom color table modifications. VTx driven Race Profile colors, visual_beeper colors, and periodic blinks like Beacon Mode or BeeperMode/Failsafe, all ignore custom color table modifications, so that the color displayed is always consistent with the user configuration. Constantly 'on'  colors (eg when a non-black color  is enabled, or when Status mode sets some LEDs to a fixed color, will be affected by  custom color table modification of that color.
**Notes:**

Previously an internal  lookup table assigned specific  'named' colours to 6 frequency ranges. Only 6 different colors were possible.

With this PR, the Hue value changes linearly according  to frequency, starting with Red for R1 through to  Magenta at R8, providing 8 different colors to support 8-up racing.

The colour end-points and scaling have been optimised with the intent of returning reasonably distinctive color separations for VTx channels on different frequencies. The end result is a pure  Red for low frequencies like R1,  a solid  yellow for R2,  a well-defined green for R3, a cyan at R4 that is very different from the at R5, a bright violet/lavender  at R6, a 'magenta' or slightly purple pink at R7 and a hot, reddish 'deep_pink' at  R8.

All Frequencies below L1 are shown white, and all above R8 are deep_pink. 
If the user enters a frequency below the minimum allowed, or does not enter a Band and Channel, the LEDs are turned off. The code handles manually entered frequencies as well.

The Ledstrip code has been refactored and commented to explain how it works and to robustly implement the regular on/off patterns of the Beacon Profile and the Failsafe / Beeper Mode pattern, and there is a a mechanism to block other 'visual beeper signals which can affect timing and display while in these regular on/off patterns.

This table summarises the result for Low and Race Band channels:

| Channel | SeparationMHz | Hue| Visual Color   |
|:-------:|:---------------:|:-------------:|:--------------------|
| **1**  | 37            | **0**        | Red |
| **2**  | 37            | **46**        |  Yellow |
| **3**  | 37            | **91**       | Green  |
| **4**  | 37            | **137**       | Cyan |
| **5**  | 37            | **203**       | Blue |
| **6**  | 37            | **254**       |Violet * |
| **7**  | 37            | **304**       | Magenta *     |
| **8**  | 37            | **355**       | Deep_Pink *  |

* the purples and pinks for channels 6, 7 and 8 are the least distinctive visual separations. Their appearance varies according to the relative brightness of the specifc RGB Leds  in the ledstrip. Violet  is more of a bright lavender than a dark purple;  Magenta is  a bright pink, and  Deep_Pink is kind of a reddish fluoro lipstick pink.

The other colors are distinctive and look good. There is no 'green' in the yellow, and blue is clearly different from cyan.

To return a modified color table back to to the (new) defaults, or to compare the old color table to new:

```
# color 0 BLACK
color 0 0,0,0 
#color 1 WHITE
color 1 0,255,255 
# color 2 RED
color 2 0,0,255
# color 3 ORANGE
color 3 15,0,255
 # color 4 YELLOW
color 4 50,0,255
# color 5 LIME_GREEN
color 5 100,0,255
# color 6 GREEN
color 6 115,0,255
# color 7 MINT_GREEN
color 7 125,0,255
# color 8 CYAN
color 8 180,0,255
# color  9 LIGHT_BLUE
color 9 210,0,255
# color  10 BLUE
color 10  240,0,255
# color 11 VIOLET
color 11 270,0,255
# color 12 MAGENTA
color 12 300,0,255
# color 13 DEEP_PINK
color 13 330,0,255
 # not assigned or used
color 14 0,0,0
color 15 0,0,0
```

** Discussion**
This method for calculating Vtx colors  permits no user-customisation by editing the color table. What you get,  is what you get. If your particular Led strip has strong green, the yellow will have a green tinge. These days most strips are very similar in color rendition. To permit some customisation of these colors the VTx c a bit customisable, we could perhaps expose the maximum hue and the tweak values below blue to be  CLI editable, but if we did this, those values  could be misconfigured and then the colors could become confusing.

Personally I like the simplicity of this approach. Previously there were presets that reassigned  colors by name to something else by editing the color table. These changes persisted and affected all named colors that were changed, including in Status mode. Changes of that kind now will be ignored, leading to consistent colors when set according to VTx frequency. All race pilots will get consistent color coding by VTx channel with no effort on their part.

The use of LowBand frequencies is illegal in many countries, but it is a reality that R3...R6 can be badly affected by domestic Wifi noise in some venues. By sharing the colors applied for R1..R8, a user can drop one of these to L1...L8 and retain the same color while avoiding the interference. See the notes for race directors at the top for more info.

I am not sure that this method is best - it certainly isn't perfect, but I hope it is a big improvement over the previous situationt :-) Please let me know what you think.

A concern has been raised that `DEEP_PINK` (Hue 255) may not be sufficiently different from Pure Red (Hue 0, or 360), but on all LED Strips tested so far (three separate testers), the difference is very obvious. I needed to set  deep pink (R8) this way to ensure it was clearly different from the 'magenta' at R7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * VTX frequency → LED color now uses a continuous hue gradient for smoother transitions.
  * LED brightness is toggled for pit-mode blinking for clearer indication.
  * Beacon/failsafe blinking uses millisecond timing for steadier flashes.
  * LED updates are sent only on meaningful HSV changes or at a forced refresh interval to reduce updates.
  * Very low/invalid VTX frequencies show neutral/off to avoid misleading colors.
  * Visual beeper/blink modes temporarily override color selection for consistent timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->