### PR TITLE
Resolved wrong string buffers size issue

### DIFF
--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -30,13 +30,13 @@
 
 #define LOGFILE_PREFIX "LOG"
 #define LOGFILE_SUFFIX "BFL"
+#define NAME_BUFFER_LENGTH 13   //file name template: LOG00001.BFL, 13 = 12 symbols + \0
 
 static FILE *blackboxVirtualFile = NULL;
 static int32_t largestLogFileNumber = 0;
 
 bool blackboxVirtualOpen(void)
 {
-    const size_t log_name_length = strlen(LOGFILE_PREFIX) + 5 + strlen(LOGFILE_SUFFIX) + 1; //file name template: LOG00001.BFL
     DIR *dir = opendir(".");
     if (!dir) {
         return false; // Failed to open directory
@@ -44,7 +44,7 @@ bool blackboxVirtualOpen(void)
 
     struct dirent *entry;
     while ((entry = readdir(dir)) != NULL) {
-        if (strlen(entry->d_name) == log_name_length
+        if (strlen(entry->d_name) == NAME_BUFFER_LENGTH - 1
             && strncmp(entry->d_name, LOGFILE_PREFIX, strlen(LOGFILE_PREFIX)) == 0
             && strncmp(entry->d_name + 9, LOGFILE_SUFFIX, strlen(LOGFILE_SUFFIX)) == 0) {
 
@@ -87,9 +87,8 @@ bool blackboxVirtualBeginLog(void)
     if (blackboxVirtualFile != NULL) {
         return false;
     }
-    const size_t name_buffer_length = snprintf(NULL, 0, "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX) + 1;
-    char filename[name_buffer_length];
-    snprintf(filename, sizeof(filename), "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
+    char filename[NAME_BUFFER_LENGTH];
+    snprintf(filename, NAME_BUFFER_LENGTH, "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");
     if (blackboxVirtualFile != NULL) {
         largestLogFileNumber++;

--- a/src/main/blackbox/blackbox_virtual.c
+++ b/src/main/blackbox/blackbox_virtual.c
@@ -87,7 +87,7 @@ bool blackboxVirtualBeginLog(void)
     if (blackboxVirtualFile != NULL) {
         return false;
     }
-    const size_t name_buffer_length = snprintf(NULL, 0, "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
+    const size_t name_buffer_length = snprintf(NULL, 0, "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX) + 1;
     char filename[name_buffer_length];
     snprintf(filename, sizeof(filename), "%s%05u.%s", LOGFILE_PREFIX, (largestLogFileNumber + 1) % 100000, LOGFILE_SUFFIX);
     blackboxVirtualFile = fopen(filename, "w");


### PR DESCRIPTION
Resolved file name buffer length issue in the SITL virtual black box. 
The file extension was  .bf, instead of bfl.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual log file naming and allocation to ensure consistent, safe filename handling and avoid potential logging errors or data loss during flight data recording.
  * Makes logging more robust and reliable on devices, reducing the chance of failed log creation or interrupted recordings and improving overall data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->