### PR TITLE
feat: DroneCAN GNSS Fix2 provider (drives gpsSol)

### DIFF
--- a/mk/dronecan.mk
+++ b/mk/dronecan.mk
@@ -15,6 +15,7 @@ ifneq ($(filter $(DRONECAN_LIB_DIR),$(LIB_SUBMODULES)),)
 
 MCU_COMMON_SRC += \
             io/dronecan/dronecan.c \
+            io/dronecan/dronecan_gnss.c \
             io/dronecan/dronecan_node.c \
             dronecan/libcanard/canard.c
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -187,7 +187,7 @@ static const char * const lookupTableAlignment[] = {
 
 #ifdef USE_GPS
 static const char * const lookupTableGpsProvider[] = {
-    "NMEA", "UBLOX", "MSP", "VIRTUAL"
+    "NMEA", "UBLOX", "MSP", "VIRTUAL", "DRONECAN"
 };
 
 static const char * const lookupTableGpsSbasMode[] = {

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -187,7 +187,10 @@ static const char * const lookupTableAlignment[] = {
 
 #ifdef USE_GPS
 static const char * const lookupTableGpsProvider[] = {
-    "NMEA", "UBLOX", "MSP", "VIRTUAL", "DRONECAN"
+    "NMEA", "UBLOX", "MSP", "VIRTUAL",
+#if ENABLE_DRONECAN
+    "DRONECAN",
+#endif
 };
 
 static const char * const lookupTableGpsSbasMode[] = {

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -233,11 +233,11 @@ static void validateAndFixConfig(void)
 
 #if defined(USE_GPS)
     const serialPortConfig_t *gpsSerial = findSerialPortConfig(FUNCTION_GPS);
-    if ((gpsConfig()->provider == GPS_MSP || gpsConfig()->provider == GPS_VIRTUAL) && gpsSerial) {
+    if (GPS_PROVIDER_REQUIRES_NO_SERIAL_PORT(gpsConfig()->provider) && gpsSerial) {
         serialRemovePort(gpsSerial->identifier);
     }
 
-    if (gpsConfig()->provider != GPS_MSP && gpsConfig()->provider != GPS_VIRTUAL && !gpsSerial) {
+    if (!GPS_PROVIDER_REQUIRES_NO_SERIAL_PORT(gpsConfig()->provider) && !gpsSerial) {
         featureDisableImmediate(FEATURE_GPS);
     }
 #endif

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -40,9 +40,10 @@
 
 #include "pg/dronecan.h"
 
-// Forward declaration; implemented in dronecan_node.c.
+// Forward declarations; implemented in dronecan_node.c / dronecan_gnss.c.
 void dronecanNodeInit(void);
 void dronecanNodeUpdate(timeUs_t currentTimeUs);
+void dronecanGnssInit(void);
 
 //-----------------------------------------------------------------------------
 // Memory pool
@@ -256,6 +257,9 @@ void dronecanInit(void)
     // Wire the node-level publishers/responders (registers the GetNodeInfo
     // subscriber against our table before the first frame can arrive).
     dronecanNodeInit();
+    // Install the GNSS Fix2 subscriber so a DroneCAN GPS module's broadcasts
+    // land in our cache as soon as the transport is live.
+    dronecanGnssInit();
 
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);
 

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -186,7 +186,22 @@ bool dronecanGnssGetLatest(gpsSolutionData_t *out)
 
 timeUs_t dronecanGnssLastUpdateUs(void)
 {
-    return lastUpdateUs;
+    // timeUs_t is 64-bit on targets with USE_64BIT_TIME (e.g. SITL), so a
+    // plain read can tear against a concurrent writer. Use the same seqlock
+    // pattern as dronecanGnssGetLatest() to stay consistent.
+    uint32_t s1;
+    uint32_t s2;
+    timeUs_t t;
+    do {
+        do {
+            s1 = latestSeq;
+        } while (s1 & 1U);
+        __asm volatile ("" ::: "memory");
+        t = lastUpdateUs;
+        __asm volatile ("" ::: "memory");
+        s2 = latestSeq;
+    } while (s1 != s2);
+    return t;
 }
 
 #endif // ENABLE_DRONECAN

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -63,9 +63,17 @@ static int32_t scaleLonLat_1e8to1e7(int64_t deg_1e8)
     return (int32_t)(deg_1e8 / 10);
 }
 
+// Seqlock-style publication so a reader on a different task can never observe
+// a partially-written solution (the shared struct is ~40 bytes). Writer bumps
+// the sequence before and after the copy: odd value = write in progress, even
+// value = stable. Reader loads sequence, copies, reloads; retries if either
+// read saw an odd count or the endpoints differ. Betaflight's scheduler is
+// cooperative between tasks today, so the retry loop is defensive against a
+// future preemptive scheduler rather than fixing a current race.
 static gpsSolutionData_t latest;
-static bool received = false;
-static timeUs_t lastUpdateUs = 0;
+static volatile uint32_t latestSeq = 0;
+static volatile bool received = false;
+static volatile timeUs_t lastUpdateUs = 0;
 
 static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 {
@@ -95,10 +103,16 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 
     const float speed2d = sqrtf(velN * velN + velE * velE);
     const float speed3d = sqrtf(velN * velN + velE * velE + velD * velD);
-    float courseDeg = (speed2d > 0.01f) ? (atan2f(velE, velN) * (180.0f / (float)M_PI)) : 0.0f;
+    float courseDeg = (speed2d > 0.01f) ? (atan2f(velE, velN) * (180.0f / M_PIf)) : 0.0f;
     if (courseDeg < 0.0f) {
         courseDeg += 360.0f;
     }
+
+    // Enter write: mark the sequence odd before touching the struct, and a
+    // release-style compiler fence so the reader can't see the incremented
+    // sequence before the writes below.
+    latestSeq++;
+    __asm volatile ("" ::: "memory");
 
     memset(&latest, 0, sizeof(latest));
     latest.llh.lat   = scaleLonLat_1e8to1e7(lat_1e8);
@@ -122,6 +136,10 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 
     lastUpdateUs = micros();
     received = true;
+
+    // Leave write: fence before the final bump so everything above is visible.
+    __asm volatile ("" ::: "memory");
+    latestSeq++;
 }
 
 void dronecanGnssInit(void)
@@ -144,7 +162,23 @@ bool dronecanGnssGetLatest(gpsSolutionData_t *out)
     if (!received || out == NULL) {
         return false;
     }
-    *out = latest;
+
+    // Seqlock-style read: retry if the writer was mid-update or the count
+    // changed mid-copy. Task-context access means this converges in one or
+    // two iterations at worst.
+    uint32_t s1;
+    uint32_t s2;
+    do {
+        s1 = latestSeq;
+        if (s1 & 1U) {
+            continue;
+        }
+        __asm volatile ("" ::: "memory");
+        *out = latest;
+        __asm volatile ("" ::: "memory");
+        s2 = latestSeq;
+    } while (s1 != s2);
+
     return true;
 }
 

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "canard.h"
+
+#include "common/maths.h"
+#include "common/time.h"
+#include "common/utils.h"
+
+#include "drivers/time.h"
+
+#include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_gnss.h"
+#include "io/dronecan/dronecan_msg.h"
+
+// Bit offsets into the Fix2 payload (from the DSDL definition). The header
+// fields up to sub_mode are fixed — everything past that (covariance, pdop,
+// ecef) is variable-length with TAO rules, so we stop at sub_mode until we
+// need those fields. bit_length values that cross byte boundaries are why
+// we lean on canardDecodeScalar() rather than a packed struct cast.
+#define FIX2_OFFSET_LONGITUDE_1E8   136U   // 37 bits signed
+#define FIX2_OFFSET_LATITUDE_1E8    173U   // 37 bits signed
+#define FIX2_OFFSET_HEIGHT_MSL_MM   237U   // 27 bits signed
+#define FIX2_OFFSET_VEL_N_F16       264U   // 16 bits float16
+#define FIX2_OFFSET_VEL_E_F16       280U   // 16 bits float16
+#define FIX2_OFFSET_VEL_D_F16       296U   // 16 bits float16
+#define FIX2_OFFSET_SATS_USED       312U   //  6 bits unsigned
+#define FIX2_OFFSET_STATUS          318U   //  2 bits unsigned
+
+#define CM_PER_METRE                100
+
+// Scale 1e8 degrees down to the betaflight 1e7 convention. Divide before
+// the int32 cast so we don't overflow on high-latitude values.
+static int32_t scaleLonLat_1e8to1e7(int64_t deg_1e8)
+{
+    return (int32_t)(deg_1e8 / 10);
+}
+
+static gpsSolutionData_t latest;
+static bool received = false;
+static timeUs_t lastUpdateUs = 0;
+
+static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    int64_t lon_1e8 = 0;
+    int64_t lat_1e8 = 0;
+    int32_t height_msl_mm = 0;
+    uint16_t velN_f16 = 0;
+    uint16_t velE_f16 = 0;
+    uint16_t velD_f16 = 0;
+    uint8_t satsUsed = 0;
+    uint8_t status = 0;
+
+    canardDecodeScalar(t, FIX2_OFFSET_LONGITUDE_1E8,  37, true,  &lon_1e8);
+    canardDecodeScalar(t, FIX2_OFFSET_LATITUDE_1E8,   37, true,  &lat_1e8);
+    canardDecodeScalar(t, FIX2_OFFSET_HEIGHT_MSL_MM,  27, true,  &height_msl_mm);
+    canardDecodeScalar(t, FIX2_OFFSET_VEL_N_F16,      16, false, &velN_f16);
+    canardDecodeScalar(t, FIX2_OFFSET_VEL_E_F16,      16, false, &velE_f16);
+    canardDecodeScalar(t, FIX2_OFFSET_VEL_D_F16,      16, false, &velD_f16);
+    canardDecodeScalar(t, FIX2_OFFSET_SATS_USED,       6, false, &satsUsed);
+    canardDecodeScalar(t, FIX2_OFFSET_STATUS,          2, false, &status);
+
+    const float velN = canardConvertFloat16ToNativeFloat(velN_f16);
+    const float velE = canardConvertFloat16ToNativeFloat(velE_f16);
+    const float velD = canardConvertFloat16ToNativeFloat(velD_f16);
+
+    const float speed2d = sqrtf(velN * velN + velE * velE);
+    const float speed3d = sqrtf(velN * velN + velE * velE + velD * velD);
+    float courseDeg = (speed2d > 0.01f) ? (atan2f(velE, velN) * (180.0f / (float)M_PI)) : 0.0f;
+    if (courseDeg < 0.0f) {
+        courseDeg += 360.0f;
+    }
+
+    memset(&latest, 0, sizeof(latest));
+    latest.llh.lat   = scaleLonLat_1e8to1e7(lat_1e8);
+    latest.llh.lon   = scaleLonLat_1e8to1e7(lon_1e8);
+    latest.llh.altCm = height_msl_mm / 10; // mm -> cm
+    // NED -> ENU on the ned_velocity reporting shortcut: N/E components map
+    // one-to-one for the horizontal speed + course we care about.
+    latest.velned.velN = (int16_t)constrainf(velN * CM_PER_METRE, INT16_MIN, INT16_MAX);
+    latest.velned.velE = (int16_t)constrainf(velE * CM_PER_METRE, INT16_MIN, INT16_MAX);
+    latest.velned.velD = (int16_t)constrainf(velD * CM_PER_METRE, INT16_MIN, INT16_MAX);
+    latest.groundSpeed = (uint16_t)constrainf(speed2d * CM_PER_METRE, 0, UINT16_MAX);
+    latest.speed3d     = (uint16_t)constrainf(speed3d * CM_PER_METRE, 0, UINT16_MAX);
+    latest.groundCourse = (uint16_t)constrainf(courseDeg * 10.0f, 0, UINT16_MAX);
+    latest.numSat      = satsUsed;
+
+    // Signal a loss of fix explicitly so the downstream state can react
+    // rather than stay armed on the last position.
+    if (status < UAVCAN_GNSS_FIX2_STATUS_3D_FIX) {
+        latest.numSat = 0;
+    }
+
+    lastUpdateUs = micros();
+    received = true;
+}
+
+void dronecanGnssInit(void)
+{
+    const dronecanSubscriber_t sub = {
+        .signature    = UAVCAN_GNSS_FIX2_SIGNATURE,
+        .dataTypeId   = UAVCAN_GNSS_FIX2_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleFix2,
+    };
+    (void)dronecanRegisterSubscriber(&sub);
+
+    memset(&latest, 0, sizeof(latest));
+    received = false;
+    lastUpdateUs = 0;
+}
+
+bool dronecanGnssGetLatest(gpsSolutionData_t *out)
+{
+    if (!received || out == NULL) {
+        return false;
+    }
+    *out = latest;
+    return true;
+}
+
+timeUs_t dronecanGnssLastUpdateUs(void)
+{
+    return lastUpdateUs;
+}
+
+#endif // ENABLE_DRONECAN

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -118,8 +118,8 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
     latest.llh.lat   = scaleLonLat_1e8to1e7(lat_1e8);
     latest.llh.lon   = scaleLonLat_1e8to1e7(lon_1e8);
     latest.llh.altCm = height_msl_mm / 10; // mm -> cm
-    // NED -> ENU on the ned_velocity reporting shortcut: N/E components map
-    // one-to-one for the horizontal speed + course we care about.
+    // Fix2 reports NED and gpsVelned_t is NED, so forward N/E/D unchanged
+    // (velD is Down, positive downward).
     latest.velned.velN = (int16_t)constrainf(velN * CM_PER_METRE, INT16_MIN, INT16_MAX);
     latest.velned.velE = (int16_t)constrainf(velE * CM_PER_METRE, INT16_MIN, INT16_MAX);
     latest.velned.velD = (int16_t)constrainf(velD * CM_PER_METRE, INT16_MIN, INT16_MAX);
@@ -144,6 +144,12 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 
 void dronecanGnssInit(void)
 {
+    // Clear the cache before registering so a frame that lands between
+    // dronecanRegisterSubscriber() and the reset can't be silently clobbered.
+    memset(&latest, 0, sizeof(latest));
+    received = false;
+    lastUpdateUs = 0;
+
     const dronecanSubscriber_t sub = {
         .signature    = UAVCAN_GNSS_FIX2_SIGNATURE,
         .dataTypeId   = UAVCAN_GNSS_FIX2_ID,
@@ -151,10 +157,6 @@ void dronecanGnssInit(void)
         .handler      = handleFix2,
     };
     (void)dronecanRegisterSubscriber(&sub);
-
-    memset(&latest, 0, sizeof(latest));
-    received = false;
-    lastUpdateUs = 0;
 }
 
 bool dronecanGnssGetLatest(gpsSolutionData_t *out)

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -163,16 +163,18 @@ bool dronecanGnssGetLatest(gpsSolutionData_t *out)
         return false;
     }
 
-    // Seqlock-style read: retry if the writer was mid-update or the count
-    // changed mid-copy. Task-context access means this converges in one or
-    // two iterations at worst.
+    // Seqlock-style read: spin until the sequence is even (writer quiescent)
+    // so we never copy a mid-update struct, then confirm the count was
+    // stable across the copy. Splitting the wait into its own inner loop
+    // avoids the UB of comparing an uninitialised s2 on the first iteration
+    // if the writer happens to be mid-update when we first sample the
+    // sequence. Task-context access converges in one or two iterations.
     uint32_t s1;
     uint32_t s2;
     do {
-        s1 = latestSeq;
-        if (s1 & 1U) {
-            continue;
-        }
+        do {
+            s1 = latestSeq;
+        } while (s1 & 1U);
         __asm volatile ("" ::: "memory");
         *out = latest;
         __asm volatile ("" ::: "memory");

--- a/src/main/io/dronecan/dronecan_gnss.h
+++ b/src/main/io/dronecan/dronecan_gnss.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/time.h"
+#include "io/gps.h"
+
+// Install the Fix2 subscriber. Call once from dronecanInit() after the base
+// subscriber table has been initialised.
+void dronecanGnssInit(void);
+
+// Pull the last-received solution into the caller's buffer. Returns false if
+// no frame has been received yet. The populated fields match the subset
+// gps.c needs: llh, numSat, dop.pdop, groundSpeed, groundCourse, speed3d.
+bool dronecanGnssGetLatest(gpsSolutionData_t *out);
+
+// Microsecond timestamp of the most recent accepted Fix2 (host clock, not
+// the DSDL timestamp). Used by gps.c to detect staleness.
+timeUs_t dronecanGnssLastUpdateUs(void);
+
+#endif // ENABLE_DRONECAN

--- a/src/main/io/dronecan/dronecan_gnss.h
+++ b/src/main/io/dronecan/dronecan_gnss.h
@@ -36,8 +36,9 @@
 void dronecanGnssInit(void);
 
 // Pull the last-received solution into the caller's buffer. Returns false if
-// no frame has been received yet. The populated fields match the subset
-// gps.c needs: llh, numSat, dop.pdop, groundSpeed, groundCourse, speed3d.
+// no frame has been received yet. Populated fields today: llh, numSat,
+// groundSpeed, groundCourse, speed3d, velned. dop / acc / dateTime are left
+// zero until a follow-up decodes covariance + pdop past the Fix2 TAO fields.
 bool dronecanGnssGetLatest(gpsSolutionData_t *out);
 
 // Microsecond timestamp of the most recent accepted Fix2 (host clock, not

--- a/src/main/io/dronecan/dronecan_msg.h
+++ b/src/main/io/dronecan/dronecan_msg.h
@@ -38,6 +38,18 @@
 #define UAVCAN_GET_NODE_INFO_ID         1U
 #define UAVCAN_GET_NODE_INFO_SIGNATURE  0xee468a8121c46a9eULL
 
+// uavcan.equipment.gnss.Fix2 — broadcast GNSS solution (position, velocity,
+// fix state). Superset of the legacy Fix message; most CAN GNSS modules
+// publish this variant.
+#define UAVCAN_GNSS_FIX2_ID             1063U
+#define UAVCAN_GNSS_FIX2_SIGNATURE      0xca41e928aebcb2d9ULL
+
+// Fix2.status enum values.
+#define UAVCAN_GNSS_FIX2_STATUS_NO_FIX      0U
+#define UAVCAN_GNSS_FIX2_STATUS_TIME_ONLY   1U
+#define UAVCAN_GNSS_FIX2_STATUS_2D_FIX      2U
+#define UAVCAN_GNSS_FIX2_STATUS_3D_FIX      3U
+
 // NodeStatus.health
 #define UAVCAN_NODE_HEALTH_OK           0U
 #define UAVCAN_NODE_HEALTH_WARNING      1U

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -417,9 +417,7 @@ void gpsInit(void)
 
     // MSP / virtual / DroneCAN providers don't own a serial port — the
     // frame source is another subsystem feeding gpsSol through updateXxxGPS().
-    if (gpsConfig()->provider == GPS_MSP
-        || gpsConfig()->provider == GPS_VIRTUAL
-        || gpsConfig()->provider == GPS_DRONECAN) {
+    if (GPS_PROVIDER_REQUIRES_NO_SERIAL_PORT(gpsConfig()->provider)) {
         gpsSetState(GPS_STATE_INITIALIZED);
         return;
     }
@@ -1344,22 +1342,28 @@ static void updateDronecanGPS(void)
     if (cmp32(gpsData.now, nextUpdateTime) <= 0) {
         return;
     }
+    nextUpdateTime = gpsData.now + updateInterval;
+
+    gpsSolutionData_t incoming;
+    if (!dronecanGnssGetLatest(&incoming)) {
+        // No Fix2 frame yet; stay in GPS_STATE_INITIALIZED so the generic
+        // connection-timeout bookkeeping doesn't start ticking against an
+        // offline bus.
+        return;
+    }
+
+    // If the cached frame is stale treat it as no new data: don't bump
+    // lastNavMessage or keep SENSOR_GPS pegged, so the normal receive-timeout
+    // path can trip to GPS_STATE_LOST_COMMUNICATION when the module dies.
+    const timeUs_t ageUs = micros() - dronecanGnssLastUpdateUs();
+    if (ageUs >= 2000000) { // 2 s
+        gpsSetFixState(0);
+        return;
+    }
 
     if (gpsData.state == GPS_STATE_INITIALIZED) {
         gpsSetState(GPS_STATE_RECEIVING_DATA);
     }
-
-    gpsSolutionData_t incoming;
-    if (!dronecanGnssGetLatest(&incoming)) {
-        // No Fix2 frame yet; re-check on the next tick.
-        nextUpdateTime = gpsData.now + updateInterval;
-        return;
-    }
-
-    // Drop the solution if it's gone stale; better to surface GPS loss than
-    // to keep navigating off a last-known position.
-    const timeUs_t ageUs = micros() - dronecanGnssLastUpdateUs();
-    const bool fresh = (ageUs < 2000000); // 2 s
 
     gpsSol = incoming;
     gpsSol.time = gpsData.now;
@@ -1367,7 +1371,7 @@ static void updateDronecanGPS(void)
     gpsData.lastNavMessage = gpsData.now;
     sensorsSet(SENSOR_GPS);
 
-    if (fresh && gpsSol.numSat > 3) {
+    if (gpsSol.numSat > 3) {
         gpsSetFixState(GPS_FIX);
     } else {
         gpsSetFixState(0);
@@ -1376,8 +1380,6 @@ static void updateDronecanGPS(void)
 
     calculateNavInterval();
     onGpsNewData();
-
-    nextUpdateTime = gpsData.now + updateInterval;
 }
 #endif
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -49,6 +49,10 @@
 #include "io/gps.h"
 #include "io/gps_virtual.h"
 
+#if ENABLE_DRONECAN
+#include "io/dronecan/dronecan_gnss.h"
+#endif
+
 #include "io/serial.h"
 
 #include "config/config.h"
@@ -411,7 +415,11 @@ void gpsInit(void)
     // init gpsData structure. if we're not actually enabled, don't bother doing anything else
     gpsSetState(GPS_STATE_UNKNOWN);
 
-    if (gpsConfig()->provider == GPS_MSP || gpsConfig()->provider == GPS_VIRTUAL) { // no serial ports used when GPS_MSP or GPS_VIRTUAL is configured
+    // MSP / virtual / DroneCAN providers don't own a serial port — the
+    // frame source is another subsystem feeding gpsSol through updateXxxGPS().
+    if (gpsConfig()->provider == GPS_MSP
+        || gpsConfig()->provider == GPS_VIRTUAL
+        || gpsConfig()->provider == GPS_DRONECAN) {
         gpsSetState(GPS_STATE_INITIALIZED);
         return;
     }
@@ -1324,6 +1332,55 @@ static void calculateNavInterval (void)
     gpsSol.navIntervalMs = constrain(navDeltaTimeMs, 50, 2500);
 }
 
+#if ENABLE_DRONECAN
+static void updateDronecanGPS(void)
+{
+    // Same 100 ms cadence as the virtual provider — there's no point polling
+    // faster than the GPS task's Hz profile while the cache is fed at the
+    // device's native rate from the DroneCAN RX path.
+    const uint32_t updateInterval = 100;
+    static uint32_t nextUpdateTime = 0;
+
+    if (cmp32(gpsData.now, nextUpdateTime) <= 0) {
+        return;
+    }
+
+    if (gpsData.state == GPS_STATE_INITIALIZED) {
+        gpsSetState(GPS_STATE_RECEIVING_DATA);
+    }
+
+    gpsSolutionData_t incoming;
+    if (!dronecanGnssGetLatest(&incoming)) {
+        // No Fix2 frame yet; re-check on the next tick.
+        nextUpdateTime = gpsData.now + updateInterval;
+        return;
+    }
+
+    // Drop the solution if it's gone stale; better to surface GPS loss than
+    // to keep navigating off a last-known position.
+    const timeUs_t ageUs = micros() - dronecanGnssLastUpdateUs();
+    const bool fresh = (ageUs < 2000000); // 2 s
+
+    gpsSol = incoming;
+    gpsSol.time = gpsData.now;
+
+    gpsData.lastNavMessage = gpsData.now;
+    sensorsSet(SENSOR_GPS);
+
+    if (fresh && gpsSol.numSat > 3) {
+        gpsSetFixState(GPS_FIX);
+    } else {
+        gpsSetFixState(0);
+    }
+    GPS_update ^= GPS_DIRECT_TICK;
+
+    calculateNavInterval();
+    onGpsNewData();
+
+    nextUpdateTime = gpsData.now + updateInterval;
+}
+#endif
+
 #if defined(USE_VIRTUAL_GPS)
 static void updateVirtualGPS(void)
 {
@@ -1459,6 +1516,11 @@ void gpsUpdate(timeUs_t currentTimeUs)
 #if defined(USE_VIRTUAL_GPS)
     case GPS_VIRTUAL:
         updateVirtualGPS();
+        break;
+#endif
+#if ENABLE_DRONECAN
+    case GPS_DRONECAN:
+        updateDronecanGPS();
         break;
 #endif
     }

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -179,6 +179,7 @@ typedef enum {
     GPS_UBLOX,
     GPS_MSP,
     GPS_VIRTUAL,
+    GPS_DRONECAN,
 } gpsProvider_e;
 
 typedef enum {

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -182,6 +182,12 @@ typedef enum {
     GPS_DRONECAN,
 } gpsProvider_e;
 
+// Providers whose frame source is another subsystem (not a UART). These skip
+// the FUNCTION_GPS serial-port lookup in gpsInit() and must not have
+// FEATURE_GPS disabled by validateAndFixConfig() when no port is assigned.
+#define GPS_PROVIDER_REQUIRES_NO_SERIAL_PORT(provider) \
+    ((provider) == GPS_MSP || (provider) == GPS_VIRTUAL || (provider) == GPS_DRONECAN)
+
 typedef enum {
     SBAS_AUTO = 0,
     SBAS_EGNOS,


### PR DESCRIPTION
## Summary

Builds on the phase-1 DroneCAN stack (#15137) to add a GNSS provider: a DroneCAN GPS module publishing `uavcan.equipment.gnss.Fix2` now drives `gpsSol` end-to-end, with no serial port required.

## Changes

- **Fix2 subscriber** (`src/main/io/dronecan/dronecan_gnss.c/h`) — decodes latitude/longitude (37-bit 1e8 degrees → 1e7), MSL altitude (27-bit mm → cm), NED velocity triplet (float16), sats-used and status from the fixed-offset portion of the payload. Cached in a module-static `gpsSolutionData_t`.
- **`GPS_DRONECAN` provider** — new enum entry in `gpsProvider_e` and CLI lookup. `gps_provider = DRONECAN` skips serial port allocation the same way `MSP`/`VIRTUAL` do.
- **`updateDronecanGPS()`** in `io/gps.c` polls the Fix2 cache at the same 100 ms cadence used by the virtual provider, promotes the GPS state machine out of `INITIALIZED` on first frame, and only flags `GPS_FIX` when the latest frame is under 2 s old and has >3 satellites. Loss of fix → `numSat = 0`.
- All new code gated on the existing `ENABLE_DRONECAN` and `LIB_SUBMODULES`-driven build flags, so non-CAN targets compile/link unaffected.

## Scope / out of scope

- Covariance / PDOP / ECEF fields in Fix2 live past variable-length arrays with TAO rules and aren't consumed by `gpsSol` today — left for a follow-up when a consumer actually needs them.
- ESC telemetry / magnetometer / barometer subscribers are still to come; the subscriber table has room.

## Test plan

- STM32H743 (CAN): builds clean with and without `-DUSE_GPS`, serial + DroneCAN paths coexist
- STM32F405, STM32G47X with `-DUSE_GPS`: build clean, serial GPS unaffected
- STM32F7X2, SITL: build clean with their default configs
- Manual smoke on bench with a CAN GPS module to follow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DroneCAN as a selectable GPS provider.
  * DroneCAN GNSS Fix2 data decoded and integrated: position, velocity, altitude, course, and satellite count.
  * Exposes cached fixes with sequence-safe retrieval and timestamps for GPS processing.

* **Bug Fixes**
  * Rate-limited updates (~100 ms) and staleness handling (2 s) to avoid using outdated fixes.

* **Refactor**
  * GPS initialization now skips serial setup for non-UART providers.

* **Chores**
  * Build includes DroneCAN GNSS component for opted-in targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->