### PR TITLE
MSP: Expose additional rpm fields

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1988,6 +1988,20 @@ case MSP_NAME:
 #else
         sbufWriteU8(dst, 0);
 #endif
+        // Added in MSP API 1.48
+#if defined(USE_RPM_FILTER)
+        sbufWriteU16(dst, rpmFilterConfig()->rpm_filter_fade_range_hz);
+        sbufWriteU16(dst, rpmFilterConfig()->rpm_filter_q);
+        for (int i = 0; i < RPM_FILTER_HARMONICS_MAX; i++) {
+            sbufWriteU8(dst, rpmFilterConfig()->rpm_filter_weights[i]);
+        }
+#else
+        sbufWriteU16(dst, 0);
+        sbufWriteU16(dst, 0);
+        for (int i = 0; i < RPM_FILTER_HARMONICS_MAX; i++) {
+            sbufWriteU8(dst, 0);
+        }
+#endif
         break;
 
     case MSP_PID_ADVANCED:
@@ -3331,6 +3345,22 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             dynNotchConfigMutable()->dyn_notch_count = i;
 #else
             sbufReadU8(src);
+#endif
+        }
+        if (sbufBytesRemaining(src) >= 7) {
+            // Added in MSP API 1.48
+#if defined(USE_RPM_FILTER)
+            rpmFilterConfigMutable()->rpm_filter_fade_range_hz = sbufReadU16(src);
+            rpmFilterConfigMutable()->rpm_filter_q = sbufReadU16(src);
+            for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
+                rpmFilterConfigMutable()->rpm_filter_weights[j] = sbufReadU8(src);
+            }
+#else
+            sbufReadU16(src);
+            sbufReadU16(src);
+            for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
+                sbufReadU8(src);
+            }
 #endif
         }
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3350,10 +3350,26 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         if (sbufBytesRemaining(src) >= 7) {
             // Added in MSP API 1.48
 #if defined(USE_RPM_FILTER)
-            rpmFilterConfigMutable()->rpm_filter_fade_range_hz = sbufReadU16(src);
-            rpmFilterConfigMutable()->rpm_filter_q = sbufReadU16(src);
-            for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
-                rpmFilterConfigMutable()->rpm_filter_weights[j] = sbufReadU8(src);
+            {
+                const uint16_t fadeRangeHz = sbufReadU16(src);
+                const uint16_t q = sbufReadU16(src);
+                uint8_t weights[RPM_FILTER_HARMONICS_MAX];
+                for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
+                    weights[j] = sbufReadU8(src);
+                }
+                if (q < 250 || q > 3000 || fadeRangeHz > 1000) {
+                    return MSP_RESULT_ERROR;
+                }
+                for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
+                    if (weights[j] > 100) {
+                        return MSP_RESULT_ERROR;
+                    }
+                }
+                rpmFilterConfigMutable()->rpm_filter_fade_range_hz = fadeRangeHz;
+                rpmFilterConfigMutable()->rpm_filter_q = q;
+                for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
+                    rpmFilterConfigMutable()->rpm_filter_weights[j] = weights[j];
+                }
             }
 #else
             sbufReadU16(src);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MSP API 1.48 RPM filter configuration: users can now configure fade range, Q, and harmonic weights for finer RPM-based filtering control.
  * Safe defaults when RPM filtering is disabled: extra parameters are ignored and treated as zeros.

* **Bug Fixes**
  * Input validation added to prevent invalid RPM filter values and report errors for out-of-range settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->