### PR TITLE
feat: LCD console subsystem for runtime debug output

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -104,6 +104,8 @@ COMMON_SRC = \
             drivers/dma.c \
             drivers/io.c \
             drivers/io_preinit.c \
+            drivers/lcd_console.c \
+            drivers/lcd_panel/lcd_panel_stub.c \
             drivers/light_led.c \
             drivers/motor.c \
             drivers/pinio.c \
@@ -112,6 +114,7 @@ COMMON_SRC = \
             drivers/resource.c \
             drivers/serial.c \
             drivers/serial_impl.c \
+            drivers/serial_lcd_console.c \
             drivers/sound_beeper.c \
             drivers/stack_check.c \
             drivers/timer_common.c \

--- a/src/main/drivers/lcd_console.c
+++ b/src/main/drivers/lcd_console.c
@@ -23,6 +23,13 @@
 
 #if ENABLE_LCD_CONSOLE
 
+// Compile-time check: ENABLE_LCD_CONSOLE requires exactly one panel selector
+// to be defined. Without one, lcdPanelGet() is undefined and the link fails
+// with a less obvious message. Add new backends to this list as they land.
+#if !defined(LCD_CONSOLE_PANEL_STUB)
+#error "ENABLE_LCD_CONSOLE is set but no LCD_CONSOLE_PANEL_<NAME> selector is defined. See drivers/lcd_panel/."
+#endif
+
 #include <string.h>
 
 #include "drivers/lcd_console.h"
@@ -49,7 +56,12 @@ static void blankRow(uint16_t row)
 
 static void scrollUpOne(void)
 {
+    // Shift the in-memory grid up by one. Pending dirty rows must shift in
+    // lockstep so a later flush still re-draws the right cells (otherwise a
+    // cell that was dirty at the old position would be lost while a freshly
+    // flushed-from cell would silently move out of sync with the panel).
     memmove(&grid[0][0], &grid[1][0], (ROWS - 1) * COLS);
+    memmove(&dirty[0], &dirty[1], ROWS - 1);
     blankRow(ROWS - 1);
     if (panel && panel->vtable->scrollUp) {
         panel->vtable->scrollUp(panel, 1);
@@ -87,7 +99,11 @@ bool lcdConsoleInit(void)
         return true;
     }
     panel = lcdPanelGet();
-    if (!panel || !panel->vtable || !panel->vtable->init) {
+    // init and drawGlyphCell are mandatory (see lcd_panel.h); the rest are
+    // optional and NULL-checked at the call sites.
+    if (!panel || !panel->vtable
+            || !panel->vtable->init
+            || !panel->vtable->drawGlyphCell) {
         return false;
     }
     if (!panel->vtable->init(panel)) {
@@ -116,6 +132,7 @@ void lcdConsoleClear(void)
     if (panel->vtable->clearRect) {
         panel->vtable->clearRect(panel, 0, 0, ROWS, COLS);
     }
+    lcdConsoleFlush();
 }
 
 void lcdConsolePutc(uint8_t c)

--- a/src/main/drivers/lcd_console.c
+++ b/src/main/drivers/lcd_console.c
@@ -1,0 +1,197 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_LCD_CONSOLE
+
+#include <string.h>
+
+#include "drivers/lcd_console.h"
+#include "drivers/lcd_panel.h"
+
+#define COLS LCD_CONSOLE_COLS
+#define ROWS LCD_CONSOLE_ROWS
+
+#define TAB_STOP 8
+#define BLANK_GLYPH ' '
+
+static uint8_t grid[ROWS][COLS];
+static uint8_t dirty[ROWS];   // 1 if row needs redraw
+static uint16_t cursorRow;
+static uint16_t cursorCol;
+static lcdPanel_t *panel;
+static bool initialised;
+
+static void blankRow(uint16_t row)
+{
+    memset(&grid[row][0], BLANK_GLYPH, COLS);
+    dirty[row] = 1;
+}
+
+static void scrollUpOne(void)
+{
+    memmove(&grid[0][0], &grid[1][0], (ROWS - 1) * COLS);
+    blankRow(ROWS - 1);
+    if (panel && panel->vtable->scrollUp) {
+        panel->vtable->scrollUp(panel, 1);
+    } else {
+        // Backend can't hardware-scroll; mark all rows for redraw.
+        for (uint16_t r = 0; r < ROWS; r++) {
+            dirty[r] = 1;
+        }
+    }
+}
+
+static void newline(void)
+{
+    cursorCol = 0;
+    if (cursorRow + 1 < ROWS) {
+        cursorRow++;
+    } else {
+        scrollUpOne();
+    }
+}
+
+static void putGlyph(uint8_t glyph)
+{
+    if (cursorCol >= COLS) {
+        newline();
+    }
+    grid[cursorRow][cursorCol] = glyph;
+    dirty[cursorRow] = 1;
+    cursorCol++;
+}
+
+bool lcdConsoleInit(void)
+{
+    if (initialised) {
+        return true;
+    }
+    panel = lcdPanelGet();
+    if (!panel || !panel->vtable || !panel->vtable->init) {
+        return false;
+    }
+    if (!panel->vtable->init(panel)) {
+        return false;
+    }
+    for (uint16_t r = 0; r < ROWS; r++) {
+        memset(&grid[r][0], BLANK_GLYPH, COLS);
+        dirty[r] = 0;
+    }
+    cursorRow = 0;
+    cursorCol = 0;
+    initialised = true;
+    return true;
+}
+
+void lcdConsoleClear(void)
+{
+    if (!initialised && !lcdConsoleInit()) {
+        return;
+    }
+    for (uint16_t r = 0; r < ROWS; r++) {
+        blankRow(r);
+    }
+    cursorRow = 0;
+    cursorCol = 0;
+    if (panel->vtable->clearRect) {
+        panel->vtable->clearRect(panel, 0, 0, ROWS, COLS);
+    }
+}
+
+void lcdConsolePutc(uint8_t c)
+{
+    if (!initialised && !lcdConsoleInit()) {
+        return;
+    }
+    switch (c) {
+    case '\r':
+        cursorCol = 0;
+        return;
+    case '\n':
+        newline();
+        return;
+    case '\b':
+        if (cursorCol > 0) {
+            cursorCol--;
+            grid[cursorRow][cursorCol] = BLANK_GLYPH;
+            dirty[cursorRow] = 1;
+        }
+        return;
+    case '\t': {
+        uint16_t next = (cursorCol + TAB_STOP) & ~(TAB_STOP - 1);
+        if (next > COLS) {
+            next = COLS;
+        }
+        while (cursorCol < next) {
+            putGlyph(BLANK_GLYPH);
+        }
+        return;
+    }
+    default:
+        if (c < 0x20 || c == 0x7f) {
+            return;     // ignore other control chars for now
+        }
+        putGlyph(c);
+        return;
+    }
+}
+
+void lcdConsoleWrite(const uint8_t *buf, size_t len)
+{
+    if (!initialised && !lcdConsoleInit()) {
+        return;
+    }
+    for (size_t i = 0; i < len; i++) {
+        lcdConsolePutc(buf[i]);
+    }
+    lcdConsoleFlush();
+}
+
+void lcdConsoleFlush(void)
+{
+    if (!initialised) {
+        return;
+    }
+    for (uint16_t r = 0; r < ROWS; r++) {
+        if (!dirty[r]) {
+            continue;
+        }
+        for (uint16_t col = 0; col < COLS; col++) {
+            panel->vtable->drawGlyphCell(panel, r, col, grid[r][col], 0);
+        }
+        dirty[r] = 0;
+    }
+    if (panel->vtable->flush) {
+        panel->vtable->flush(panel);
+    }
+}
+
+bool lcdConsoleIsBusy(void)
+{
+    if (!initialised || !panel || !panel->vtable->isBusy) {
+        return false;
+    }
+    return panel->vtable->isBusy(panel);
+}
+
+#endif // ENABLE_LCD_CONSOLE

--- a/src/main/drivers/lcd_console.h
+++ b/src/main/drivers/lcd_console.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+// L2 — terminal logic for the LCD console. Hardware-agnostic; calls into
+// the L3 panel vtable (drivers/lcd_panel.h). Code in src/main/ must not
+// include any panel/MCU-specific headers — the only seam is lcdPanelGet().
+
+#ifndef LCD_CONSOLE_COLS
+#define LCD_CONSOLE_COLS 80
+#endif
+#ifndef LCD_CONSOLE_ROWS
+#define LCD_CONSOLE_ROWS 25
+#endif
+
+// Initialise the terminal layer and the underlying panel. Idempotent and
+// lazy-safe: the first call into any putc/write API will call this, but
+// callers can also invoke it explicitly during boot to get earlier failure
+// signal if the panel can't come up.
+bool lcdConsoleInit(void);
+
+// Write a single byte to the terminal. Honours \r \n \b \t; everything else
+// is treated as a printable codepoint and written into the cell at the
+// current cursor. Wraps to the next row at the right edge; scrolls up at
+// the bottom.
+void lcdConsolePutc(uint8_t c);
+
+// Write a buffer. Equivalent to looping lcdConsolePutc() but lets the
+// backend buffer draws and flush once at the end.
+void lcdConsoleWrite(const uint8_t *buf, size_t len);
+
+// Reset the cursor to (0, 0) and blank the grid.
+void lcdConsoleClear(void);
+
+// Commit any buffered draws to the panel.
+void lcdConsoleFlush(void);
+
+// True while the panel still has pending bus/DMA traffic. Used by the L1
+// virtual serialPort_t to honour isSerialTransmitBufferEmpty.
+bool lcdConsoleIsBusy(void);

--- a/src/main/drivers/lcd_panel.h
+++ b/src/main/drivers/lcd_panel.h
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+// L3 vtable for an LCD console backend.
+//
+// A backend renders a fixed grid of monochrome glyphs. The L2 terminal layer
+// owns the glyph grid (cursor, scroll buffer, font lookup) and calls these
+// hooks to push state to the panel. Backends are selected at compile time
+// via LCD_CONSOLE_PANEL_<NAME> defines in the per-config config.h; only one
+// backend exposes lcdPanelGet() per build.
+
+struct lcdPanel_s;
+
+typedef struct lcdPanelVTable_s {
+    // Bring up the underlying hardware/bus and clear the panel. Called once
+    // by the L2 layer at first use.
+    bool (*init)(struct lcdPanel_s *panel);
+
+    // Render a single glyph cell at (row, col). The glyph is an 8-bit
+    // codepoint mapped through the font selected by L2; attr is reserved
+    // (0 = normal). The backend may buffer; flush() commits.
+    void (*drawGlyphCell)(struct lcdPanel_s *panel,
+                          uint16_t row, uint16_t col,
+                          uint8_t glyph, uint8_t attr);
+
+    // Clear an inclusive rectangle of cells.
+    void (*clearRect)(struct lcdPanel_s *panel,
+                      uint16_t row, uint16_t col,
+                      uint16_t rows, uint16_t cols);
+
+    // Scroll the visible region up by `rows` cell rows. Backends that can
+    // do this with a hardware/framebuffer copy should; otherwise the L2
+    // layer falls back to row-by-row redraw via drawGlyphCell.
+    void (*scrollUp)(struct lcdPanel_s *panel, uint16_t rows);
+
+    // Commit any buffered draws. Idempotent.
+    void (*flush)(struct lcdPanel_s *panel);
+
+    // Return true if the backend still has pending bus/DMA traffic. The
+    // virtual serialPort_t reports !isBusy() to its isSerialTransmitBufferEmpty
+    // caller so writers can back-pressure correctly.
+    bool (*isBusy)(struct lcdPanel_s *panel);
+} lcdPanelVTable_t;
+
+typedef struct lcdPanel_s {
+    const lcdPanelVTable_t *vtable;
+    uint16_t cols;
+    uint16_t rows;
+    void *priv;     // backend-private state
+} lcdPanel_t;
+
+// Each L4 backend provides exactly one lcdPanelGet() definition selected at
+// compile time. The L2 layer calls it during lcdConsoleInit().
+lcdPanel_t *lcdPanelGet(void);

--- a/src/main/drivers/lcd_panel.h
+++ b/src/main/drivers/lcd_panel.h
@@ -32,37 +32,49 @@
 // hooks to push state to the panel. Backends are selected at compile time
 // via LCD_CONSOLE_PANEL_<NAME> defines in the per-config config.h; only one
 // backend exposes lcdPanelGet() per build.
+//
+// Backend init() runs early in main() (right after systemInit()), before the
+// initPhase1/2/3 stages that bring up I2C/SPI/QuadSPI/DMA. Backends that
+// require those buses must self-defer their hardware bring-up until the bus
+// is available — e.g. a no-op init() and a lazy first-use bring-up inside
+// drawGlyphCell()/flush(). The stub backend is RAM-only and unaffected.
 
 struct lcdPanel_s;
 
 typedef struct lcdPanelVTable_s {
-    // Bring up the underlying hardware/bus and clear the panel. Called once
-    // by the L2 layer at first use.
+    // [required] Bring up the underlying hardware/bus and clear the panel.
+    // Called once by the L2 layer at first use; must return true on success.
     bool (*init)(struct lcdPanel_s *panel);
 
-    // Render a single glyph cell at (row, col). The glyph is an 8-bit
-    // codepoint mapped through the font selected by L2; attr is reserved
-    // (0 = normal). The backend may buffer; flush() commits.
+    // [required] Render a single glyph cell at (row, col). The glyph is an
+    // 8-bit codepoint mapped through the font selected by the backend; attr
+    // is reserved (0 = normal). The backend may buffer; flush() commits.
     void (*drawGlyphCell)(struct lcdPanel_s *panel,
                           uint16_t row, uint16_t col,
                           uint8_t glyph, uint8_t attr);
 
-    // Clear an inclusive rectangle of cells.
+    // [optional, may be NULL] Clear a `rows × cols` rectangle of cells
+    // starting at (row, col). Half-open in both axes. When NULL, the L2
+    // layer falls back to per-cell drawGlyphCell() with the blank glyph.
     void (*clearRect)(struct lcdPanel_s *panel,
                       uint16_t row, uint16_t col,
                       uint16_t rows, uint16_t cols);
 
-    // Scroll the visible region up by `rows` cell rows. Backends that can
-    // do this with a hardware/framebuffer copy should; otherwise the L2
-    // layer falls back to row-by-row redraw via drawGlyphCell.
+    // [optional, may be NULL] Scroll the visible region up by `rows` cell
+    // rows. Backends that can do this with a hardware/framebuffer copy
+    // should; when NULL, the L2 layer falls back to marking every row dirty
+    // and redrawing via drawGlyphCell.
     void (*scrollUp)(struct lcdPanel_s *panel, uint16_t rows);
 
-    // Commit any buffered draws. Idempotent.
+    // [optional, may be NULL] Commit any buffered draws. Idempotent. When
+    // NULL the backend is assumed to commit synchronously inside
+    // drawGlyphCell/clearRect/scrollUp.
     void (*flush)(struct lcdPanel_s *panel);
 
-    // Return true if the backend still has pending bus/DMA traffic. The
-    // virtual serialPort_t reports !isBusy() to its isSerialTransmitBufferEmpty
-    // caller so writers can back-pressure correctly.
+    // [optional, may be NULL] Return true if the backend still has pending
+    // bus/DMA traffic. The virtual serialPort_t reports !isBusy() to its
+    // isSerialTransmitBufferEmpty caller so writers can back-pressure
+    // correctly. When NULL the backend is assumed to be never busy.
     bool (*isBusy)(struct lcdPanel_s *panel);
 } lcdPanelVTable_t;
 

--- a/src/main/drivers/lcd_panel/lcd_panel_stub.c
+++ b/src/main/drivers/lcd_panel/lcd_panel_stub.c
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if defined(LCD_CONSOLE_PANEL_STUB)
+
+#include <string.h>
+
+#include "drivers/lcd_console.h"
+#include "drivers/lcd_panel.h"
+
+// RAM-only L4 backend. Mirrors the L2 grid into a static buffer so the
+// console output is inspectable from a debugger or a CLI dump command
+// without any real LCD attached. Useful for validating the abstraction
+// during PR-A bring-up and as a regression aid.
+
+#define STUB_COLS LCD_CONSOLE_COLS
+#define STUB_ROWS LCD_CONSOLE_ROWS
+
+static char stubGrid[STUB_ROWS][STUB_COLS];
+
+static bool stubInit(lcdPanel_t *panel)
+{
+    UNUSED(panel);
+    memset(stubGrid, ' ', sizeof(stubGrid));
+    return true;
+}
+
+static void stubDrawGlyphCell(lcdPanel_t *panel, uint16_t row, uint16_t col,
+                              uint8_t glyph, uint8_t attr)
+{
+    UNUSED(panel);
+    UNUSED(attr);
+    if (row < STUB_ROWS && col < STUB_COLS) {
+        stubGrid[row][col] = (char)glyph;
+    }
+}
+
+static void stubClearRect(lcdPanel_t *panel, uint16_t row, uint16_t col,
+                          uint16_t rows, uint16_t cols)
+{
+    UNUSED(panel);
+    for (uint16_t r = row; r < row + rows && r < STUB_ROWS; r++) {
+        for (uint16_t c = col; c < col + cols && c < STUB_COLS; c++) {
+            stubGrid[r][c] = ' ';
+        }
+    }
+}
+
+static void stubScrollUp(lcdPanel_t *panel, uint16_t rows)
+{
+    UNUSED(panel);
+    if (rows == 0 || rows >= STUB_ROWS) {
+        memset(stubGrid, ' ', sizeof(stubGrid));
+        return;
+    }
+    memmove(&stubGrid[0][0], &stubGrid[rows][0], (STUB_ROWS - rows) * STUB_COLS);
+    memset(&stubGrid[STUB_ROWS - rows][0], ' ', rows * STUB_COLS);
+}
+
+static void stubFlush(lcdPanel_t *panel)
+{
+    UNUSED(panel);
+}
+
+static bool stubIsBusy(lcdPanel_t *panel)
+{
+    UNUSED(panel);
+    return false;
+}
+
+static const lcdPanelVTable_t stubVTable = {
+    .init = stubInit,
+    .drawGlyphCell = stubDrawGlyphCell,
+    .clearRect = stubClearRect,
+    .scrollUp = stubScrollUp,
+    .flush = stubFlush,
+    .isBusy = stubIsBusy,
+};
+
+static lcdPanel_t stubPanel = {
+    .vtable = &stubVTable,
+    .cols = STUB_COLS,
+    .rows = STUB_ROWS,
+    .priv = NULL,
+};
+
+lcdPanel_t *lcdPanelGet(void)
+{
+    return &stubPanel;
+}
+
+#endif // LCD_CONSOLE_PANEL_STUB

--- a/src/main/drivers/lcd_panel/lcd_panel_stub.c
+++ b/src/main/drivers/lcd_panel/lcd_panel_stub.c
@@ -69,7 +69,10 @@ static void stubClearRect(lcdPanel_t *panel, uint16_t row, uint16_t col,
 static void stubScrollUp(lcdPanel_t *panel, uint16_t rows)
 {
     UNUSED(panel);
-    if (rows == 0 || rows >= STUB_ROWS) {
+    if (rows == 0) {
+        return;
+    }
+    if (rows >= STUB_ROWS) {
         memset(stubGrid, ' ', sizeof(stubGrid));
         return;
     }

--- a/src/main/drivers/serial_lcd_console.c
+++ b/src/main/drivers/serial_lcd_console.c
@@ -166,11 +166,15 @@ static void lcdSerialEndWrite(serialPort_t *instance)
     lcdConsoleFlush();
 }
 
-// Explicit logging API — bypass the global printf sink.
+// Explicit logging API — bypass the global printf sink. These helpers are
+// callable independently of whether ENABLE_LCD_PRINTF_REDIRECT routed the
+// global printf sink at boot, so they can't rely on main.c having opened
+// the L1 port. Each entry point opens it lazily and bails silently if the
+// panel can't come up.
 
 void lcdConsolePuts(const char *s)
 {
-    if (!s) {
+    if (!s || !lcdConsoleSerialOpen()) {
         return;
     }
     lcdConsoleWrite((const uint8_t *)s, strlen(s));
@@ -184,6 +188,9 @@ static void lcdConsolePrintfPutc(void *p, char c)
 
 void lcdConsolePrintf(const char *fmt, ...)
 {
+    if (!lcdConsoleSerialOpen()) {
+        return;
+    }
     va_list va;
     va_start(va, fmt);
     tfp_format(NULL, lcdConsolePrintfPutc, fmt, va);

--- a/src/main/drivers/serial_lcd_console.c
+++ b/src/main/drivers/serial_lcd_console.c
@@ -114,13 +114,21 @@ static void lcdSerialSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 static bool lcdSerialIsTransmitBufferEmpty(const serialPort_t *instance)
 {
     UNUSED(instance);
+    // tfp_printf and other per-byte writers go through serialWrite() (which
+    // hands a single byte to lcdConsolePutc) and only check
+    // isSerialTransmitBufferEmpty at the end of the print to wait for the
+    // line to drain. Without flushing here, dirty rows would sit in L2 until
+    // a later writer triggers endWrite or an explicit flush. Flushing on
+    // every poll is idempotent — flush is a no-op when nothing is dirty.
+    lcdConsoleFlush();
     return !lcdConsoleIsBusy();
 }
 
 static void lcdSerialSetMode(serialPort_t *instance, portMode_e mode)
 {
-    UNUSED(instance);
-    UNUSED(mode);
+    if (instance) {
+        instance->mode = mode;
+    }
 }
 
 static void lcdSerialSetCtrlLineStateCb(serialPort_t *instance,

--- a/src/main/drivers/serial_lcd_console.c
+++ b/src/main/drivers/serial_lcd_console.c
@@ -1,0 +1,186 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_LCD_CONSOLE
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "common/printf.h"
+
+#include "drivers/lcd_console.h"
+#include "drivers/serial.h"
+#include "drivers/serial_lcd_console.h"
+
+static void lcdSerialWrite(serialPort_t *instance, uint8_t ch);
+static uint32_t lcdSerialTotalRxWaiting(const serialPort_t *instance);
+static uint32_t lcdSerialTotalTxFree(const serialPort_t *instance);
+static uint8_t lcdSerialRead(serialPort_t *instance);
+static void lcdSerialSetBaudRate(serialPort_t *instance, uint32_t baudRate);
+static bool lcdSerialIsTransmitBufferEmpty(const serialPort_t *instance);
+static void lcdSerialSetMode(serialPort_t *instance, portMode_e mode);
+static void lcdSerialSetCtrlLineStateCb(serialPort_t *instance,
+        void (*cb)(void *instance, uint16_t ctrlLineState), void *context);
+static void lcdSerialSetBaudRateCb(serialPort_t *instance,
+        void (*cb)(serialPort_t *context, uint32_t baud), serialPort_t *context);
+static void lcdSerialWriteBuf(serialPort_t *instance, const void *data, int count);
+static void lcdSerialBeginWrite(serialPort_t *instance);
+static void lcdSerialEndWrite(serialPort_t *instance);
+
+static const struct serialPortVTable lcdSerialVTable = {
+    .serialWrite                = lcdSerialWrite,
+    .serialTotalRxWaiting       = lcdSerialTotalRxWaiting,
+    .serialTotalTxFree          = lcdSerialTotalTxFree,
+    .serialRead                 = lcdSerialRead,
+    .serialSetBaudRate          = lcdSerialSetBaudRate,
+    .isSerialTransmitBufferEmpty = lcdSerialIsTransmitBufferEmpty,
+    .setMode                    = lcdSerialSetMode,
+    .setCtrlLineStateCb         = lcdSerialSetCtrlLineStateCb,
+    .setBaudRateCb              = lcdSerialSetBaudRateCb,
+    .writeBuf                   = lcdSerialWriteBuf,
+    .beginWrite                 = lcdSerialBeginWrite,
+    .endWrite                   = lcdSerialEndWrite,
+};
+
+static serialPort_t lcdSerialPort = {
+    .vTable = &lcdSerialVTable,
+};
+
+static bool serialOpened;
+
+serialPort_t *lcdConsoleSerialOpen(void)
+{
+    if (!serialOpened) {
+        if (!lcdConsoleInit()) {
+            return NULL;
+        }
+        lcdSerialPort.mode = MODE_TX;
+        serialOpened = true;
+    }
+    return &lcdSerialPort;
+}
+
+static void lcdSerialWrite(serialPort_t *instance, uint8_t ch)
+{
+    UNUSED(instance);
+    lcdConsolePutc(ch);
+}
+
+static uint32_t lcdSerialTotalRxWaiting(const serialPort_t *instance)
+{
+    UNUSED(instance);
+    return 0;
+}
+
+static uint32_t lcdSerialTotalTxFree(const serialPort_t *instance)
+{
+    UNUSED(instance);
+    return UINT16_MAX;      // Always accept; the L2/L3 layers throttle as needed.
+}
+
+static uint8_t lcdSerialRead(serialPort_t *instance)
+{
+    UNUSED(instance);
+    return 0;               // Write-only sink.
+}
+
+static void lcdSerialSetBaudRate(serialPort_t *instance, uint32_t baudRate)
+{
+    UNUSED(instance);
+    UNUSED(baudRate);
+}
+
+static bool lcdSerialIsTransmitBufferEmpty(const serialPort_t *instance)
+{
+    UNUSED(instance);
+    return !lcdConsoleIsBusy();
+}
+
+static void lcdSerialSetMode(serialPort_t *instance, portMode_e mode)
+{
+    UNUSED(instance);
+    UNUSED(mode);
+}
+
+static void lcdSerialSetCtrlLineStateCb(serialPort_t *instance,
+        void (*cb)(void *instance, uint16_t ctrlLineState), void *context)
+{
+    UNUSED(instance);
+    UNUSED(cb);
+    UNUSED(context);
+}
+
+static void lcdSerialSetBaudRateCb(serialPort_t *instance,
+        void (*cb)(serialPort_t *context, uint32_t baud), serialPort_t *context)
+{
+    UNUSED(instance);
+    UNUSED(cb);
+    UNUSED(context);
+}
+
+static void lcdSerialWriteBuf(serialPort_t *instance, const void *data, int count)
+{
+    UNUSED(instance);
+    if (count > 0) {
+        lcdConsoleWrite((const uint8_t *)data, (size_t)count);
+    }
+}
+
+static void lcdSerialBeginWrite(serialPort_t *instance)
+{
+    UNUSED(instance);
+}
+
+static void lcdSerialEndWrite(serialPort_t *instance)
+{
+    UNUSED(instance);
+    lcdConsoleFlush();
+}
+
+// Explicit logging API — bypass the global printf sink.
+
+void lcdConsolePuts(const char *s)
+{
+    if (!s) {
+        return;
+    }
+    lcdConsoleWrite((const uint8_t *)s, strlen(s));
+}
+
+static void lcdConsolePrintfPutc(void *p, char c)
+{
+    UNUSED(p);
+    lcdConsolePutc((uint8_t)c);
+}
+
+void lcdConsolePrintf(const char *fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    tfp_format(NULL, lcdConsolePrintfPutc, fmt, va);
+    va_end(va);
+    lcdConsoleFlush();
+}
+
+#endif // ENABLE_LCD_CONSOLE

--- a/src/main/drivers/serial_lcd_console.h
+++ b/src/main/drivers/serial_lcd_console.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// L1 — virtual serialPort_t over the LCD console terminal layer, plus an
+// explicit log API for code that wants to write to the LCD regardless of
+// where the global printf sink is currently pointed.
+
+struct serialPort_s;
+
+// Singleton accessor. Lazy-inits the L2/L3 layers on first call. Returns
+// NULL only if the panel failed to come up.
+struct serialPort_s *lcdConsoleSerialOpen(void);
+
+// Write a null-terminated string straight to the LCD, bypassing the global
+// printf sink. Use when CLI may be active and you still want output on the LCD.
+void lcdConsolePuts(const char *s);
+
+// Formatted print straight to the LCD; same caveat as lcdConsolePuts().
+void lcdConsolePrintf(const char *fmt, ...);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -29,6 +29,11 @@
 
 #include "drivers/system.h"
 
+#if ENABLE_LCD_CONSOLE && ENABLE_LCD_PRINTF_REDIRECT
+#include "common/printf_serial.h"
+#include "drivers/serial_lcd_console.h"
+#endif
+
 #include "fc/init.h"
 
 #ifdef USE_MULTICORE
@@ -63,6 +68,18 @@ int main(int argc, char * argv[])
 
     // Do basic system initialisation including multicore support if applicable
     systemInit();
+
+#if ENABLE_LCD_CONSOLE && ENABLE_LCD_PRINTF_REDIRECT
+    // Route the global tfp_printf sink to the LCD console so boot-time and
+    // runtime debug output appears on the panel. CLI sessions still capture
+    // printf for their duration via cliEnter()'s setPrintfSerialPort().
+    {
+        struct serialPort_s *lcdPort = lcdConsoleSerialOpen();
+        if (lcdPort) {
+            setPrintfSerialPort(lcdPort);
+        }
+    }
+#endif
 
 #ifdef USE_MULTICORE
     // Perform early initialisation prior to USB

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -813,3 +813,16 @@ extern struct linker_symbol __fontdata_end;
 #if !defined(ENABLE_DRONECAN)
 #define ENABLE_DRONECAN ENABLE_CAN
 #endif
+
+// LCD console — runtime debug terminal that scrolls printf/trace output to
+// an attached LCD. Independent of the OSD/displayPort stack. Off by default;
+// configs opt in by setting ENABLE_LCD_CONSOLE 1 plus a panel selector
+// (LCD_CONSOLE_PANEL_STUB / _LTDC / _SSD1306_I2C / _ST7789_SPI / ...).
+// ENABLE_LCD_PRINTF_REDIRECT routes the global tfp_printf sink to the LCD
+// at boot; turn it off to keep the LCD reachable only via lcdConsolePrintf().
+#if !defined(ENABLE_LCD_CONSOLE)
+#define ENABLE_LCD_CONSOLE 0
+#endif
+#if !defined(ENABLE_LCD_PRINTF_REDIRECT)
+#define ENABLE_LCD_PRINTF_REDIRECT ENABLE_LCD_CONSOLE
+#endif


### PR DESCRIPTION
## Summary

- Adds an opt-in **LCD console** subsystem that redirects `printf`/trace output to an attached LCD as scrolling text — a runtime debug aid for development and bring-up.
- The CLI is **not** affected: it keeps its existing serial/USB port and behaviour. `cliEnter()` already captures printf for the duration of a CLI session, so the LCD only shows output during normal operation.
- Layered architecture lets any future target use any panel over any bus (i2c/spi/serial/parallel/framebuffer) — this PR ships only the framework plus a RAM-mirror stub backend.

## Architecture

| Layer | Files | Notes |
|---|---|---|
| L1 | `drivers/serial_lcd_console.{c,h}` | Virtual `serialPort_t` (so existing `printf_serial` / `bufWriter_t` / CLI-style writers work unchanged) plus an explicit `lcdConsolePuts` / `lcdConsolePrintf` API for code that wants to log to the LCD even during a CLI session. |
| L2 | `drivers/lcd_console.{c,h}` | Hardware-agnostic terminal: cursor, scroll, line wrap, `\r \n \b \t` handling. No HAL/MCU/bus headers. |
| L3 | `drivers/lcd_panel.h` | vtable interface a backend implements (`init`, `drawGlyphCell`, `clearRect`, `scrollUp`, `flush`, `isBusy`). |
| L4 | `drivers/lcd_panel/lcd_panel_stub.c` | RAM-mirror backend, useful for validation and inspection via debugger/CLI. Real backends (LTDC framebuffer, SSD1306-i2c, ST7789-spi, …) plug in via the same vtable. |

`main.c` routes the global `tfp_printf` sink to the LCD virtual port right after `systemInit()` when `ENABLE_LCD_CONSOLE` is on. `cliEnter()`'s existing `setPrintfSerialPort(cliPort)` cleanly takes over for CLI sessions, then `cliExit()` reboots and the LCD becomes the sink again.

## Feature gates

Uses the new \`ENABLE_X\` convention (value-based, defaulted in \`common_post.h\`):

\`\`\`c
#define ENABLE_LCD_CONSOLE 1                  // master enable
#define LCD_CONSOLE_PANEL_STUB                // backend selector (per build)
#define LCD_CONSOLE_COLS 80
#define LCD_CONSOLE_ROWS 25
#define ENABLE_LCD_PRINTF_REDIRECT 1          // defaults to ENABLE_LCD_CONSOLE
\`\`\`

Defaults are \`0\` so every existing target builds bit-identically when not opting in.

## Test plan

- [x] \`make TARGET=STM32F405\` (LCD off) builds cleanly — baseline unchanged
- [x] \`make TARGET=STM32F405 EXTRA_FLAGS='-DENABLE_LCD_CONSOLE=1 -DLCD_CONSOLE_PANEL_STUB'\` builds cleanly; adds ~1.1 KB text and ~4 KB bss
- [x] \`make all\` across all 30 CI_TARGETS — clean exit, including the STM32N657 skeleton
- [ ] Real-hardware exercise via a follow-up PR: STM32N657DK + LTDC backend showing boot trace on the on-board LCD
- [ ] Future backends: SSD1306-i2c and ST7789-spi for community boards

This is the first of three planned PRs:
- **PR-A (this PR)**: subsystem + stub backend, no MCU work
- PR-B: STM32N657DK config + LTDC backend
- PR-C: real bus-attached panel backends (SSD1306-i2c, ST7789-spi)

Independent and self-contained — PR-B and PR-C can land separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LCD console display: character grid with cursor, scrolling, and efficient redraws.
  * Serial-style LCD port plus direct logging APIs for string and formatted output.
  * Optional runtime redirect of system debug/printf output to the LCD panel.

* **Chores**
  * Build updated to include new LCD console and panel drivers and enable related configuration flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->