### PR TITLE
[4.5.4] Backport src/config submodule handling (#14158, #14175, #14190)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ stm32.mak
 # artefacts for VS Code
 /.vscode/
 
-# artefacts for Visual Studio 
+# artefacts for Visual Studio
 /.vs
 
 # artefacts for CLion
@@ -57,5 +57,6 @@ ubuntu*.log
 eeprom.bin
 
 # config used for building targets
-/src/config
+# changed to submodule
+#/src/config
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "config"]
+	path = src/config
+	url = https://github.com/betaflight/config.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "config"]
 	path = src/config
 	url = https://github.com/betaflight/config.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = src/config
 	url = https://github.com/betaflight/config.git
 	branch = master
+	ignore = dirty

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -52,7 +52,7 @@ endif #config
 .PHONY: configs
 configs:
 ifeq ($(shell realpath $(CONFIG_DIR)),$(shell realpath $(CONFIGS_SUBMODULE_DIR)))
-	git submodule update --init -- $(CONFIGS_SUBMODULE_DIR)
+	git submodule update --init --remote -- $(CONFIGS_SUBMODULE_DIR)
 else
 ifeq ($(wildcard $(CONFIG_DIR)),)
 	@echo "Hydrating clone for configs: $(CONFIG_DIR)"

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,6 +1,7 @@
 
 CONFIGS_REPO_URL ?= https://github.com/betaflight/config
-
+# handle only this directory as config submodule
+CONFIGS_SUBMODULE_DIR = src/config
 BASE_CONFIGS      = $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(CONFIG_DIR)/configs/*/config.h)))))
 
 ifneq ($(filter-out %_install test% %_clean clean% %-print %.hex %.h hex checks help configs $(BASE_TARGETS) $(BASE_CONFIGS),$(MAKECMDGOALS)),)
@@ -50,11 +51,15 @@ endif #config
 
 .PHONY: configs
 configs:
+ifeq ($(shell realpath $(CONFIG_DIR)),$(shell realpath $(CONFIGS_SUBMODULE_DIR)))
+	git submodule update --init -- $(CONFIGS_SUBMODULE_DIR)
+else
 ifeq ($(wildcard $(CONFIG_DIR)),)
 	@echo "Hydrating clone for configs: $(CONFIG_DIR)"
 	$(V0) git clone $(CONFIGS_REPO_URL) $(CONFIG_DIR)
 else
 	$(V0) git -C $(CONFIG_DIR) pull origin
+endif
 endif
 
 $(BASE_CONFIGS):


### PR DESCRIPTION
## Summary

Backports `src/config` submodule handling to `4.5-maintenance` so cloud builds (and any other workflow that leaves `src/config` in detached HEAD) no longer fail with:

```
git -C ./src/config pull origin
You are not currently on a branch.
Please specify which branch you want to merge with.
make: *** [mk/config.mk:57: configs] Error 1
```

The existing 4.5 `make configs` rule does a plain `git pull origin` against `src/config`, which requires being on a branch — so it breaks any workflow that pins to a specific config SHA. Master switched to a real submodule + `git submodule update --remote` and that works regardless of HEAD state.

## Cherry-picks

Three small commits from `master`, in order:

- **#14158** — Add `betaflight/config` as submodule. Adds `.gitmodules`, the `src/config` gitlink, and switches `mk/config.mk` to use `git submodule update` when `CONFIG_DIR` resolves to `src/config`.
- **#14175** — Adds `branch = master` to `.gitmodules` and `--remote` to `git submodule update` so the submodule auto-tracks `master` of `betaflight/config` (which is also what 4.5 needs — `betaflight/config` only has a `master` branch).
- **#14190** — Adds `ignore = dirty` to suppress noise from submodule worktree changes.

All three applied cleanly with no conflicts.

## Submodule SHA

A fourth commit bumps `src/config` from `d6644d1` (the SHA pinned by #14175 in January) to `8057d26`, which matches what `master` currently ships with, giving fresh clones of 4.5-maintenance the same starting point.

Note: with `--remote` in the `configs` rule, the pinned SHA is mostly informational — `make configs` always pulls the latest `master` of `betaflight/config`. The pin matters for fresh clones and for anyone who runs a bare `git submodule update --init` without `--remote`.

## Verification

- `make configs` works in three states: fresh hydrate, on-a-branch, and detached HEAD (the original failure mode).
- `MATEKF405SE` builds end-to-end.

## Migration note for existing users

Anyone running 4.5-maintenance with a manually-cloned `src/config` directory will need to run `git submodule update --init` once after pulling this change, or move their old clone aside. The cherry-picked commits don't migrate existing checkouts automatically.