### PR TITLE
Auto-include rangefinder/opticalflow drivers for cloud build options

### DIFF
--- a/src/main/sensors/opticalflow.c
+++ b/src/main/sensors/opticalflow.c
@@ -95,7 +95,7 @@ static bool opticalflowDetect(opticalflowDev_t * dev, uint8_t opticalflowHardwar
 
     switch (opticalflowHardwareToUse) {
         case OPTICALFLOW_MT:
-#ifdef USE_RANGEFINDER_MT
+#if defined(USE_OPTICALFLOW_MT) && defined(USE_RANGEFINDER_MT)
             if (mtOpticalflowDetect(dev, rangefinderConfig()->rangefinder_hardware)) {
                 opticalflowHardware = OPTICALFLOW_MT;
                 rescheduleTask(TASK_OPTICALFLOW, TASK_PERIOD_MS(dev->delayMs));
@@ -103,7 +103,7 @@ static bool opticalflowDetect(opticalflowDev_t * dev, uint8_t opticalflowHardwar
 #endif
             break;
 
-#if defined(USE_RANGEFINDER_UPT1) && defined(USE_OPTICALFLOW)
+#if defined(USE_OPTICALFLOW_UPT1) && defined(USE_RANGEFINDER_UPT1)
         case OPTICALFLOW_UPT1:
             if (upt1OpticalflowDetect(dev)) {
                 opticalflowHardware = OPTICALFLOW_UPT1;

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -195,6 +195,37 @@
 
 #endif // END MAG HW defines
 
+#if defined(USE_RANGEFINDER)
+
+#ifndef USE_RANGEFINDER_HCSR04
+#define USE_RANGEFINDER_HCSR04
+#endif
+#ifndef USE_RANGEFINDER_TF
+#define USE_RANGEFINDER_TF
+#endif
+#ifndef USE_RANGEFINDER_MT
+#define USE_RANGEFINDER_MT
+#endif
+#ifndef USE_RANGEFINDER_NOOPLOOP
+#define USE_RANGEFINDER_NOOPLOOP
+#endif
+#ifndef USE_RANGEFINDER_UPT1
+#define USE_RANGEFINDER_UPT1
+#endif
+
+#endif // USE_RANGEFINDER
+
+#if defined(USE_OPTICALFLOW)
+
+#ifndef USE_OPTICALFLOW_MT
+#define USE_OPTICALFLOW_MT
+#endif
+#ifndef USE_OPTICALFLOW_UPT1
+#define USE_OPTICALFLOW_UPT1
+#endif
+
+#endif // USE_OPTICALFLOW
+
 #if defined(USE_RX_CC2500)
 
 #if !defined(USE_RX_SPI)
@@ -647,27 +678,33 @@
 #undef USED_TIMERS
 #endif
 
+// Hardware cross-deps: OF drivers need their rangefinder driver counterparts
+// (the optical flow code lives inside the rangefinder driver files)
 #if defined(USE_OPTICALFLOW_MT)
 #ifndef USE_RANGEFINDER_MT
 #define USE_RANGEFINDER_MT
 #endif
-#ifndef USE_OPTICALFLOW
-#define USE_OPTICALFLOW
-#endif
 #endif // USE_OPTICALFLOW_MT
 
-#if defined(USE_RANGEFINDER_UPT1)
-#ifndef USE_OPTICALFLOW
-#define USE_OPTICALFLOW
+#if defined(USE_OPTICALFLOW_UPT1)
+#ifndef USE_RANGEFINDER_UPT1
+#define USE_RANGEFINDER_UPT1
 #endif
-#endif // USE_RANGEFINDER_UPT1
+#endif // USE_OPTICALFLOW_UPT1
 
+// Bottom-up: individual rangefinder drivers → USE_RANGEFINDER
 #if defined(USE_RANGEFINDER_HCSR04) || defined(USE_RANGEFINDER_TF) || defined(USE_RANGEFINDER_MT) || defined(USE_RANGEFINDER_NOOPLOOP) || defined(USE_RANGEFINDER_UPT1)
-
 #ifndef USE_RANGEFINDER
 #define USE_RANGEFINDER
 #endif
 #endif // USE_RANGEFINDER_XXX
+
+// Bottom-up: individual opticalflow drivers → USE_OPTICALFLOW
+#if defined(USE_OPTICALFLOW_MT) || defined(USE_OPTICALFLOW_UPT1)
+#ifndef USE_OPTICALFLOW
+#define USE_OPTICALFLOW
+#endif
+#endif // USE_OPTICALFLOW_XXX
 
 #ifndef USE_GPS_RESCUE
 #undef USE_CMS_GPS_RESCUE_MENU


### PR DESCRIPTION
# Plan: Auto-include rangefinder/opticalflow drivers for cloud build options

## Summary

Cloud build exposes `USE_RANGEFINDER` and `USE_OPTICALFLOW` as selectable build options (visible in `msp_build_info.c`). However, unlike `USE_MAG` — which auto-includes all individual mag driver defines in `common_post.h` (lines 157–196) — selecting `USE_RANGEFINDER` or `USE_OPTICALFLOW` in a cloud build does **not** automatically pull in the individual driver defines (`USE_RANGEFINDER_MT`, `USE_RANGEFINDER_UPT1`, `USE_OPTICALFLOW_MT`, `USE_OPTICALFLOW_UPT1`).

In classic (non-cloud) builds, these drivers are explicitly listed in `common_pre.h` (lines 302–307) under the `TARGET_FLASH_SIZE >= 1024` gate. Cloud builds skip that block entirely, so the drivers never get defined.

The fix adds MAG-style auto-inclusion blocks in `common_post.h` and cleans up the existing bottom-up/cross-dependency logic to follow four clear rules:

1. `USE_RANGEFINDER` → includes all `USE_RANGEFINDER_*` drivers (top-down)
2. `USE_OPTICALFLOW` → includes all `USE_OPTICALFLOW_*` drivers (top-down)
3. Any `USE_RANGEFINDER_*` → includes `USE_RANGEFINDER` (bottom-up)
4. Any `USE_OPTICALFLOW_*` → includes `USE_OPTICALFLOW` (bottom-up)

Plus necessary hardware cross-deps: `USE_OPTICALFLOW_MT` → `USE_RANGEFINDER_MT` and `USE_OPTICALFLOW_UPT1` → `USE_RANGEFINDER_UPT1`, because the optical flow code for these devices lives inside their rangefinder drivers.

In `opticalflow.c`, both detection cases now use consistent guards requiring both the `USE_OPTICALFLOW_*` driver define and its `USE_RANGEFINDER_*` counterpart.

## Changes applied

### 1. common_post.h — Top-down auto-inclusion blocks (after MAG block)

```c
#if defined(USE_RANGEFINDER)

#ifndef USE_RANGEFINDER_HCSR04
#define USE_RANGEFINDER_HCSR04
#endif
#ifndef USE_RANGEFINDER_TF
#define USE_RANGEFINDER_TF
#endif
#ifndef USE_RANGEFINDER_MT
#define USE_RANGEFINDER_MT
#endif
#ifndef USE_RANGEFINDER_NOOPLOOP
#define USE_RANGEFINDER_NOOPLOOP
#endif
#ifndef USE_RANGEFINDER_UPT1
#define USE_RANGEFINDER_UPT1
#endif

#endif // USE_RANGEFINDER

#if defined(USE_OPTICALFLOW)

#ifndef USE_OPTICALFLOW_MT
#define USE_OPTICALFLOW_MT
#endif
#ifndef USE_OPTICALFLOW_UPT1
#define USE_OPTICALFLOW_UPT1
#endif

#endif // USE_OPTICALFLOW
```

### 2. common_post.h — Rewritten bottom-up and cross-dependency blocks

```c
// Hardware cross-deps: OF drivers need their rangefinder driver counterparts
// (the optical flow code lives inside the rangefinder driver files)
#if defined(USE_OPTICALFLOW_MT)
#ifndef USE_RANGEFINDER_MT
#define USE_RANGEFINDER_MT
#endif
#endif // USE_OPTICALFLOW_MT

#if defined(USE_OPTICALFLOW_UPT1)
#ifndef USE_RANGEFINDER_UPT1
#define USE_RANGEFINDER_UPT1
#endif
#endif // USE_OPTICALFLOW_UPT1

// Bottom-up: individual rangefinder drivers → USE_RANGEFINDER
#if defined(USE_RANGEFINDER_HCSR04) || defined(USE_RANGEFINDER_TF) || defined(USE_RANGEFINDER_MT) || defined(USE_RANGEFINDER_NOOPLOOP) || defined(USE_RANGEFINDER_UPT1)
#ifndef USE_RANGEFINDER
#define USE_RANGEFINDER
#endif
#endif // USE_RANGEFINDER_XXX

// Bottom-up: individual opticalflow drivers → USE_OPTICALFLOW
#if defined(USE_OPTICALFLOW_MT) || defined(USE_OPTICALFLOW_UPT1)
#ifndef USE_OPTICALFLOW
#define USE_OPTICALFLOW
#endif
#endif // USE_OPTICALFLOW_XXX
```

Key changes from existing code:
- **Removed** `USE_RANGEFINDER_UPT1` → `USE_OPTICALFLOW` cross-dep (rangefinder no longer implies optical flow; they are independent feature trees)
- **Removed** `USE_OPTICALFLOW` from the `USE_OPTICALFLOW_MT` block (now handled by the new bottom-up block)
- **Added** `USE_OPTICALFLOW_UPT1` → `USE_RANGEFINDER_UPT1` cross-dep (mirrors the MT pattern)
- **Added** bottom-up block for `USE_OPTICALFLOW_*` → `USE_OPTICALFLOW`

The removed `USE_RANGEFINDER_UPT1` → `USE_OPTICALFLOW` cross-dep is safe: no target.h defines `USE_RANGEFINDER_UPT1` directly, and in classic builds `USE_OPTICALFLOW_MT` (defined in `common_pre.h:307`) already provides `USE_OPTICALFLOW` via the new bottom-up block.

### 3. opticalflow.c — Consistent guards for both detection cases

Both cases now require their `USE_OPTICALFLOW_*` driver define AND the corresponding `USE_RANGEFINDER_*` dependency:

```c
// Line 98 (was: #ifdef USE_RANGEFINDER_MT)
#if defined(USE_OPTICALFLOW_MT) && defined(USE_RANGEFINDER_MT)

// Line 106 (was: #if defined(USE_RANGEFINDER_UPT1) && defined(USE_OPTICALFLOW))
#if defined(USE_OPTICALFLOW_UPT1) && defined(USE_RANGEFINDER_UPT1)
```

The `USE_RANGEFINDER_*` requirement is guaranteed by the cross-dep blocks in common_post.h, but kept explicit as a safety guard since the detection functions (`mtOpticalflowDetect`, `upt1OpticalflowDetect`) live inside the rangefinder driver files.

### 4. No changes needed in common_pre.h or common_defaults_post.h

- `common_pre.h`: The classic build block (lines 302–308) remains as-is; it's only reached for non-cloud builds.
- `common_defaults_post.h`: Only has pin defaults for `RANGEFINDER_HCSR04` which are unaffected.

## Scenario walkthrough

| Cloud build selects | Top-down defines | Cross-dep defines | Bottom-up defines |
|---|---|---|---|
| `USE_RANGEFINDER` only | all `USE_RANGEFINDER_*` | — | `USE_RANGEFINDER` (already) |
| `USE_OPTICALFLOW` only | `USE_OPTICALFLOW_MT`, `USE_OPTICALFLOW_UPT1` | `USE_RANGEFINDER_MT`, `USE_RANGEFINDER_UPT1` | `USE_RANGEFINDER`, `USE_OPTICALFLOW` (already) |
| Both | all `USE_RANGEFINDER_*` + all `USE_OPTICALFLOW_*` | `USE_RANGEFINDER_MT` (already), `USE_RANGEFINDER_UPT1` (already) | both (already) |
| `USE_OPTICALFLOW_MT` only (target) | — | `USE_RANGEFINDER_MT` | `USE_RANGEFINDER`, `USE_OPTICALFLOW` |

Note: selecting `USE_RANGEFINDER` alone does **not** pull in `USE_OPTICALFLOW`. The user must explicitly select `USE_OPTICALFLOW` if they want optical flow. This is a change from the previous implicit `USE_RANGEFINDER_UPT1` → `USE_OPTICALFLOW` cross-dep.

## File change summary

| File | Change |
|------|--------|
| `src/main/target/common_post.h` | Add `USE_RANGEFINDER` top-down auto-includes block (after MAG block) |
| `src/main/target/common_post.h` | Add `USE_OPTICALFLOW` top-down auto-includes block |
| `src/main/target/common_post.h` | Rewrite bottom-up blocks: add OF cross-deps + bottom-up, remove `USE_RANGEFINDER_UPT1` → `USE_OPTICALFLOW` |
| `src/main/sensors/opticalflow.c` | Line 98: `#ifdef USE_RANGEFINDER_MT` → `#if defined(USE_OPTICALFLOW_MT) && defined(USE_RANGEFINDER_MT)` |
| `src/main/sensors/opticalflow.c` | Line 106: `#if defined(USE_RANGEFINDER_UPT1) && defined(USE_OPTICALFLOW)` → `#if defined(USE_OPTICALFLOW_UPT1) && defined(USE_RANGEFINDER_UPT1)` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build-time configuration for optical flow and rangefinder sensor feature compilation to refine conditional feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->