### PR TITLE
PICO: gyro_clkin platform abstraction so RP2350 can use USE_GYRO_CLKIN

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -39,8 +39,8 @@
 #include "drivers/accgyro/accgyro_spi_icm426xx.h"
 #include "drivers/bus_spi.h"
 #include "drivers/exti.h"
+#include "drivers/gyro_clkin.h"
 #include "drivers/io.h"
-#include "drivers/pwm_output.h"
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
@@ -189,7 +189,10 @@ static void setUserBank(const extDevice_t *dev, const uint8_t user_bank)
 }
 
 #if defined(USE_GYRO_CLKIN)
-static pwmOutputPort_t pwmGyroClk = {0};
+static struct {
+    bool enabled;
+    IO_t io;
+} gyroClkInState = {0};
 
 static int findByExtDevice(const extDevice_t *dev) {
    for (int i = 0; i < GYRO_COUNT; i++) {
@@ -212,34 +215,17 @@ static bool initExternalClock(const extDevice_t *dev)
 
     const ioTag_t tag = gyroDeviceConfig(cfg)->clkIn;
     const IO_t io = IOGetByTag(tag);
-    if (pwmGyroClk.enabled) {
-       // pwm is already taken, but test for shared clkIn pin
-       return pwmGyroClk.io == io;
+    if (gyroClkInState.enabled) {
+       // CLKIN is already running for an earlier gyro; only succeed if it's the same pin
+       return gyroClkInState.io == io;
     }
 
-    const timerHardware_t *timer = timerAllocate(tag, OWNER_GYRO_CLKIN, RESOURCE_INDEX(cfg));
-    if (!timer) {
-        // Error handling: failed to allocate timer
+    if (!gyroClkInInit(tag, ICM426XX_CLKIN_FREQ, RESOURCE_INDEX(cfg))) {
         return false;
     }
 
-    pwmGyroClk.io = io;
-    pwmGyroClk.enabled = true;
-
-    IOInit(io, OWNER_GYRO_CLKIN, RESOURCE_INDEX(cfg));
-    IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
-
-    const uint32_t clock = timerClock(timer);  // Get the timer clock frequency
-    const uint16_t period = clock / ICM426XX_CLKIN_FREQ;
-
-    // Calculate duty cycle value for 50%
-    const uint16_t value = period / 2;
-
-    // Configure PWM output
-    pwmOutputConfig(&pwmGyroClk.channel, timer, clock, period - 1, value - 1, 0);
-
-    // Set CCR value
-    pwmWriteChannel(&pwmGyroClk.channel, value - 1);
+    gyroClkInState.io = io;
+    gyroClkInState.enabled = true;
 
     return true;
 }

--- a/src/main/drivers/gyro_clkin.h
+++ b/src/main/drivers/gyro_clkin.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "drivers/io_types.h"
+
+// Drive the supplied pin with a 50% duty-cycle square wave at freqHz, suitable
+// for clocking an external sensor (e.g. ICM-426xx CLKIN). Implemented per
+// platform — STM32 uses its timer/PWM abstraction, PICO uses the pico-sdk PWM
+// hardware directly. Returns true on success, false if the pin can't be
+// driven at the requested frequency or resources can't be allocated.
+bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex);

--- a/src/platform/PICO/gyro_clkin_pico.c
+++ b/src/platform/PICO/gyro_clkin_pico.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if defined(USE_GYRO_CLKIN)
+
+#include <stdint.h>
+
+#include "hardware/clocks.h"
+#include "hardware/gpio.h"
+#include "hardware/pwm.h"
+
+#include "drivers/gyro_clkin.h"
+#include "drivers/io.h"
+#include "drivers/io_impl.h"
+#include "drivers/resource.h"
+
+bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex)
+{
+    if (!tag || freqHz == 0) {
+        return false;
+    }
+
+    const IO_t io = IOGetByTag(tag);
+    if (!io) {
+        return false;
+    }
+
+    IOInit(io, OWNER_GYRO_CLKIN, resourceIndex);
+
+    const uint8_t pin = IO_GPIOPinIdx(io);
+    const uint8_t slice = pwm_gpio_to_slice_num(pin);
+    const uint8_t channel = pwm_gpio_to_channel(pin);
+
+    // PWM block clock is sys_clk; pick clkdiv=1 and derive wrap directly. The
+    // 16-bit wrap register caps the achievable lower bound (~sys_clk / 65536),
+    // which is well below the typical 32 kHz CLKIN rate even at 150 MHz sys_clk.
+    const uint32_t sysClk = clock_get_hz(clk_sys);
+    const uint32_t wrap = (sysClk / freqHz) - 1;
+    if (wrap > UINT16_MAX) {
+        return false;
+    }
+
+    gpio_set_function(pin, GPIO_FUNC_PWM);
+    pwm_set_clkdiv(slice, 1.0f);
+    pwm_set_wrap(slice, (uint16_t)wrap);
+    pwm_set_chan_level(slice, channel, (uint16_t)((wrap + 1) / 2));
+    pwm_set_enabled(slice, true);
+
+    return true;
+}
+
+#endif

--- a/src/platform/PICO/gyro_clkin_pico.c
+++ b/src/platform/PICO/gyro_clkin_pico.c
@@ -45,8 +45,6 @@ bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex)
         return false;
     }
 
-    IOInit(io, OWNER_GYRO_CLKIN, resourceIndex);
-
     const uint8_t pin = IO_GPIOPinIdx(io);
     const uint8_t slice = pwm_gpio_to_slice_num(pin);
     const uint8_t channel = pwm_gpio_to_channel(pin);
@@ -55,15 +53,26 @@ bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex)
     // 16-bit wrap register caps the achievable lower bound (~sys_clk / 65536),
     // which is well below the typical 32 kHz CLKIN rate even at 150 MHz sys_clk.
     const uint32_t sysClk = clock_get_hz(clk_sys);
-    const uint32_t wrap = (sysClk / freqHz) - 1;
-    if (wrap > UINT16_MAX) {
+    const uint32_t divisor = sysClk / freqHz;
+    if (divisor < 2 || divisor > (uint32_t)UINT16_MAX + 1) {
+        return false;  // freqHz too high (no valid square wave) or too low for 16-bit wrap
+    }
+    const uint16_t wrap = (uint16_t)(divisor - 1);
+
+    // RP2350 PWM slices share clkdiv/wrap across both channels, so reconfiguring
+    // a slice that another peripheral has already claimed (motor, servo, beeper)
+    // would clobber its rate. Refuse if the slice is already running. The
+    // inverse direction (a later motor init clobbering CLKIN) is not protected
+    // here and relies on init order — gyro init runs before pwmInit.
+    if (pwm_hw->en & (1u << slice)) {
         return false;
     }
 
+    IOInit(io, OWNER_GYRO_CLKIN, resourceIndex);
     gpio_set_function(pin, GPIO_FUNC_PWM);
     pwm_set_clkdiv(slice, 1.0f);
-    pwm_set_wrap(slice, (uint16_t)wrap);
-    pwm_set_chan_level(slice, channel, (uint16_t)((wrap + 1) / 2));
+    pwm_set_wrap(slice, wrap);
+    pwm_set_chan_level(slice, channel, (uint16_t)((wrap + 1u) / 2u));
     pwm_set_enabled(slice, true);
 
     return true;

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -583,6 +583,7 @@ MCU_COMMON_SRC = \
             PICO/pwm_motor_pico.c \
             PICO/pwm_servo_pico.c \
             PICO/pwm_beeper_pico.c \
+            PICO/gyro_clkin_pico.c \
             PICO/serial_usb_vcp_pico.c \
             PICO/system.c \
             PICO/uart/serial_uart_pico.c \

--- a/src/platform/STM32/gyro_clkin_stm32.c
+++ b/src/platform/STM32/gyro_clkin_stm32.c
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if defined(USE_GYRO_CLKIN)
+
+#include "drivers/gyro_clkin.h"
+#include "drivers/io.h"
+#include "drivers/pwm_output.h"
+#include "drivers/resource.h"
+#include "drivers/timer.h"
+
+static timerChannel_t pwmChannel;
+
+bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex)
+{
+    if (!tag || freqHz == 0) {
+        return false;
+    }
+
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_GYRO_CLKIN, resourceIndex);
+    if (!timer) {
+        return false;
+    }
+
+    const IO_t io = IOGetByTag(tag);
+    IOInit(io, OWNER_GYRO_CLKIN, resourceIndex);
+    IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
+
+    const uint32_t clock = timerClock(timer);
+    const uint16_t period = clock / freqHz;
+    const uint16_t value = period / 2;
+
+    pwmOutputConfig(&pwmChannel, timer, clock, period - 1, value - 1, 0);
+    pwmWriteChannel(&pwmChannel, value - 1);
+
+    return true;
+}
+
+#endif

--- a/src/platform/STM32/gyro_clkin_stm32.c
+++ b/src/platform/STM32/gyro_clkin_stm32.c
@@ -43,15 +43,24 @@ bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex)
     }
 
     const IO_t io = IOGetByTag(tag);
+    if (!io) {
+        return false;
+    }
+
+    const uint32_t clock = timerClock(timer);
+    const uint32_t period = clock / freqHz;
+    if (period < 2 || period > UINT16_MAX) {
+        return false;
+    }
+
     IOInit(io, OWNER_GYRO_CLKIN, resourceIndex);
     IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
 
-    const uint32_t clock = timerClock(timer);
-    const uint16_t period = clock / freqHz;
-    const uint16_t value = period / 2;
+    const uint16_t period16 = (uint16_t)period;
+    const uint16_t value16 = period16 / 2;
 
-    pwmOutputConfig(&pwmChannel, timer, clock, period - 1, value - 1, 0);
-    pwmWriteChannel(&pwmChannel, value - 1);
+    pwmOutputConfig(&pwmChannel, timer, clock, period16 - 1, value16 - 1, 0);
+    pwmWriteChannel(&pwmChannel, value16 - 1);
 
     return true;
 }

--- a/src/platform/STM32/mk/STM32_COMMON.mk
+++ b/src/platform/STM32/mk/STM32_COMMON.mk
@@ -18,6 +18,7 @@ MCU_COMMON_SRC += \
             common/stm32/serial_uart_pinconfig.c \
             common/stm32/dshot_dpwm.c \
             STM32/pwm_output_hw.c \
+            STM32/gyro_clkin_stm32.c \
             common/stm32/rx_pwm_hw.c \
             common/stm32/pwm_output_dshot_shared.c \
             common/stm32/pwm_output_beeper.c \


### PR DESCRIPTION
## Summary

`USE_GYRO_CLKIN` was a compile error on the PICO platform because `accgyro_spi_icm426xx.c` called STM32-only timer/PWM APIs (`timerAllocate`, `IOConfigGPIOAF`, `pwmOutputConfig`, `pwmWriteChannel`) directly from `src/main`. This refactor moves the CLKIN PWM generation behind a small platform interface so each platform can implement it natively.

## Changes

**New interface** — `src/main/drivers/gyro_clkin.h`:

```c
bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex);
```

**Implementations**:

- `src/platform/STM32/gyro_clkin_stm32.c` — moves the existing `timerAllocate` → `IOConfigGPIOAF` → `pwmOutputConfig` → `pwmWriteChannel` logic out of the gyro driver. No behaviour change for STM32 targets.
- `src/platform/PICO/gyro_clkin_pico.c` — pico-sdk `hardware/pwm.h` directly: `pwm_set_clkdiv`/`wrap`/`chan_level`/`enabled` at `sys_clk / freqHz`.

**Caller** — `accgyro_spi_icm426xx.c`:

- The `#if defined(USE_GYRO_CLKIN)` block keeps only the high-level "is CLKIN already running, and on which pin" guard and delegates init to `gyroClkInInit()`.
- Replaces the `pwmOutputPort_t pwmGyroClk` bookkeeping with a small struct holding just `enabled` + `io` (the STM32 `timerChannel_t` storage moves into the platform impl).
- `pwm_output.h` include dropped — no longer needed.

**Wiring**: new files added to `STM32_COMMON.mk` and `RP2350.mk`. Files self-gate on `#if defined(USE_GYRO_CLKIN)` so they compile to empty TUs when the flag is off.

Companion config change (drops the TODO on MADFLIGHT_FC3): betaflight/config#1089.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated gyro clock-in driver for external sensor clock initialization.
  * Added support for configurable external clock frequencies on PICO and STM32 platforms.
  * Improved resource management by isolating gyro clock configuration from shared PWM resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->