### PR TITLE
PICO: Split RP2350 LOAD segments into PHDRS to avoid RWX warning

### DIFF
--- a/src/platform/PICO/link/pico_rp2350_RunFromFLASH.ld
+++ b/src/platform/PICO/link/pico_rp2350_RunFromFLASH.ld
@@ -25,11 +25,27 @@ INCLUDE "pico_rp2350_memory.ld"
 
 ENTRY(_entry_point)
 
+/* Split code/rodata from RAM-resident sections into separate PT_LOAD segments.
+ * The `data` segment carries the load images of RAM-resident sections (.data,
+ * .tdata, .scratch_x, .scratch_y) -- some of which contain executable code that
+ * runs from SRAM after copy. Explicit FLAGS(6) marks the load-time view as R+W
+ * (not RWX), silencing ld's `--warn-rwx-segments` while leaving runtime
+ * execution from RAM unaffected (Cortex-M has no W^X enforcement). Two text
+ * PHDRs are needed because flash-resident code/data lives both before and
+ * after the data-segment load images: one PT_LOAD per non-contiguous flash
+ * chunk so the UF2 converter sees no LMA overlap. */
+PHDRS
+{
+    text1 PT_LOAD FLAGS(5);  /* R+X -- early FLASH code/rodata */
+    data  PT_LOAD FLAGS(6);  /* R+W -- load images of RAM-resident sections */
+    text2 PT_LOAD FLAGS(5);  /* R+X -- late FLASH (flash_end + pg registry) */
+}
+
 SECTIONS
 {
     .flash_begin : {
         __flash_binary_start = .;
-    } > FLASH
+    } > FLASH :text1
 
     /* The bootrom will enter the image at the point indicated in your
        IMAGE_DEF, which is usually the reset handler of your vector table.
@@ -92,7 +108,7 @@ SECTIONS
 
         *(.eh_frame*)
         . = ALIGN(4);
-    } > FLASH
+    } > FLASH :text1
 
     /* Note the boot2 section is optional, and should be discarded if there is
        no reference to it *inside* the binary, as it is not called by the
@@ -110,7 +126,7 @@ SECTIONS
         __boot2_start__ = .;
         *(.boot2)
         __boot2_end__ = .;
-    } > FLASH
+    } > FLASH :text1
 
     ASSERT(__boot2_end__ - __boot2_start__ <= 256,
         "ERROR: Pico second stage bootloader must be no more than 256 bytes in size")
@@ -121,18 +137,18 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
-    } > FLASH
+    } > FLASH :text1
 
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > FLASH
+    } > FLASH :text1
 
     __exidx_start = .;
     .ARM.exidx :
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > FLASH
+    } > FLASH :text1
     __exidx_end = .;
 
     /* Machine inspectable binary information */
@@ -142,7 +158,7 @@ SECTIONS
     {
         KEEP(*(.binary_info.keep.*))
         *(.binary_info.*)
-    } > FLASH
+    } > FLASH :text1
     __binary_info_end = .;
     . = ALIGN(4);
 
@@ -182,14 +198,14 @@ SECTIONS
 
         *(.jcr)
         . = ALIGN(4);
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
 
     .tdata : {
         . = ALIGN(4);
 		*(.tdata .tdata.* .gnu.linkonce.td.*)
         /* All data end */
         __tdata_end = .;
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
     PROVIDE(__data_end__ = .);
 
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
@@ -233,7 +249,7 @@ SECTIONS
         *(.scratch_x.*)
         . = ALIGN(4);
         __scratch_x_end__ = .;
-    } > SCRATCH_X AT > FLASH
+    } > SCRATCH_X AT > FLASH :data
     __scratch_x_source__ = LOADADDR(.scratch_x);
 
     .scratch_y : {
@@ -241,7 +257,7 @@ SECTIONS
         *(.scratch_y.*)
         . = ALIGN(4);
         __scratch_y_end__ = .;
-    } > SCRATCH_Y AT > FLASH =0xa5a5a5a5 /* BF: want to fill with STACK_FILL_CHAR to allow stack check - this doesn't seem to do it */
+    } > SCRATCH_Y AT > FLASH :data =0xa5a5a5a5 /* BF: want to fill with STACK_FILL_CHAR to allow stack check - this doesn't seem to do it */
     __scratch_y_source__ = LOADADDR(.scratch_y);
 
     /* .stack*_dummy section doesn't contains any symbols. It is only
@@ -268,7 +284,7 @@ SECTIONS
     .flash_end : {
         KEEP(*(.embedded_end_block*))
         PROVIDE(__flash_binary_end = .);
-    } > FLASH =0xaa
+    } > FLASH :text2 =0xaa
 
 
     /* Base address where the config is stored. */
@@ -285,14 +301,14 @@ SECTIONS
       KEEP (*(.pg_registry))
       KEEP (*(SORT(.pg_registry.*)))
       PROVIDE_HIDDEN (__pg_registry_end = .);
-    } >FLASH
+    } >FLASH :text2
 
     .pg_resetdata :
     {
       PROVIDE_HIDDEN (__pg_resetdata_start = .);
       KEEP (*(.pg_resetdata))
       PROVIDE_HIDDEN (__pg_resetdata_end = .);
-    } >FLASH
+    } >FLASH :text2
 
 
     /* stack limit is poorly named, but historically is maximum heap ptr */

--- a/src/platform/PICO/link/pico_rp2350_RunFromHybrid.ld
+++ b/src/platform/PICO/link/pico_rp2350_RunFromHybrid.ld
@@ -30,11 +30,27 @@ INCLUDE "pico_rp2350_memory.ld"
 
 ENTRY(_entry_point)
 
+/* Split code/rodata from RAM-resident sections into separate PT_LOAD segments.
+ * The `data` segment carries the load images of RAM-resident sections
+ * (.text, .data, .tdata, .scratch_x, .scratch_y) -- some of which contain
+ * executable code that runs from SRAM after copy. Explicit FLAGS(6) marks the
+ * load-time view as R+W (not RWX), silencing ld's `--warn-rwx-segments`
+ * while leaving runtime execution from RAM unaffected (Cortex-M has no W^X
+ * enforcement). Two text PHDRs are needed because flash-resident code/data
+ * lives both before and after the data-segment load images: one PT_LOAD per
+ * non-contiguous flash chunk so the UF2 converter sees no LMA overlap. */
+PHDRS
+{
+    text1 PT_LOAD FLAGS(5);  /* R+X -- early FLASH code/rodata */
+    data  PT_LOAD FLAGS(6);  /* R+W -- load images of RAM-resident sections */
+    text2 PT_LOAD FLAGS(5);  /* R+X -- late FLASH (flash_end + pg registry) */
+}
+
 SECTIONS
 {
     .flash_begin : {
         __flash_binary_start = .;
-    } > FLASH
+    } > FLASH :text1
 
     /* The bootrom will enter the image at the point indicated in your
        IMAGE_DEF, which is usually the reset handler of your vector table.
@@ -59,7 +75,7 @@ SECTIONS
         */config/*(*.text*)
         */pg/*(*.text*)
         . = ALIGN(4);
-    } > FLASH
+    } > FLASH :text1
 
     /* Note the boot2 section is optional, and should be discarded if there is
        no reference to it *inside* the binary, as it is not called by the
@@ -77,7 +93,7 @@ SECTIONS
         __boot2_start__ = .;
         *(.boot2)
         __boot2_end__ = .;
-    } > FLASH
+    } > FLASH :text1
 
     ASSERT(__boot2_end__ - __boot2_start__ <= 256,
         "ERROR: Pico second stage bootloader must be no more than 256 bytes in size")
@@ -90,18 +106,18 @@ SECTIONS
         */config/*(*.rodata*)
         */pg/*(*.rodata*)
         . = ALIGN(4);
-    } > FLASH
+    } > FLASH :text1
 
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > FLASH
+    } > FLASH :text1
 
     __exidx_start = .;
     .ARM.exidx :
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > FLASH
+    } > FLASH :text1
     __exidx_end = .;
 
     /* Machine inspectable binary information */
@@ -111,7 +127,7 @@ SECTIONS
     {
         KEEP(*(.binary_info.keep.*))
         *(.binary_info.*)
-    } > FLASH
+    } > FLASH :text1
     __binary_info_end = .;
     . = ALIGN(4);
 
@@ -146,7 +162,7 @@ SECTIONS
         *(.eh_frame*)
         . = ALIGN(4);
         __ram_text_end__ = .;
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
     __ram_text_source__ = LOADADDR(.text);
     . = ALIGN(4);
 
@@ -196,14 +212,14 @@ SECTIONS
 
         *(.jcr)
         . = ALIGN(4);
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
 
     .tdata : {
         . = ALIGN(4);
         *(.tdata .tdata.* .gnu.linkonce.td.*)
         /* All data end */
         __tdata_end = .;
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
     PROVIDE(__data_end__ = .);
 
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
@@ -219,7 +235,7 @@ SECTIONS
         __tls_end = .;
     } > RAM
 
-    .bss : {
+    .bss (NOLOAD) : {
         . = ALIGN(4);
         __tbss_end = .;
 
@@ -247,7 +263,7 @@ SECTIONS
         *(.scratch_x.*)
         . = ALIGN(4);
         __scratch_x_end__ = .;
-    } > SCRATCH_X AT > FLASH
+    } > SCRATCH_X AT > FLASH :data
     __scratch_x_source__ = LOADADDR(.scratch_x);
 
     .scratch_y : {
@@ -255,7 +271,7 @@ SECTIONS
         *(.scratch_y.*)
         . = ALIGN(4);
         __scratch_y_end__ = .;
-    } > SCRATCH_Y AT > FLASH /*=0xa5a5a5a5*/ /* BF: TODO want to fill with STACK_FILL_CHAR to allow stack check - this doesn't seem to do it */
+    } > SCRATCH_Y AT > FLASH :data /*=0xa5a5a5a5*/ /* BF: TODO want to fill with STACK_FILL_CHAR to allow stack check - this doesn't seem to do it */
     __scratch_y_source__ = LOADADDR(.scratch_y);
 
     /* .stack*_dummy section doesn't contains any symbols. It is only
@@ -282,7 +298,7 @@ SECTIONS
     .flash_end : {
         KEEP(*(.embedded_end_block*))
         PROVIDE(__flash_binary_end = .);
-    } > FLASH =0xaa
+    } > FLASH :text2 =0xaa
 
 
     /* Base address where the config is stored. */
@@ -299,14 +315,14 @@ SECTIONS
       KEEP (*(.pg_registry))
       KEEP (*(SORT(.pg_registry.*)))
       PROVIDE_HIDDEN (__pg_registry_end = .);
-    } >FLASH
+    } >FLASH :text2
 
     .pg_resetdata :
     {
       PROVIDE_HIDDEN (__pg_resetdata_start = .);
       KEEP (*(.pg_resetdata))
       PROVIDE_HIDDEN (__pg_resetdata_end = .);
-    } >FLASH
+    } >FLASH :text2
 
 
     /* stack limit is poorly named, but historically is maximum heap ptr */

--- a/src/platform/PICO/link/pico_rp2350_RunFromRAM.ld
+++ b/src/platform/PICO/link/pico_rp2350_RunFromRAM.ld
@@ -30,11 +30,27 @@ INCLUDE "pico_rp2350_memory.ld"
 
 ENTRY(_entry_point)
 
+/* Split code/rodata from RAM-resident sections into separate PT_LOAD segments.
+ * The `data` segment carries the load images of RAM-resident sections
+ * (.text, .data, .tdata, .scratch_x, .scratch_y) -- some of which contain
+ * executable code that runs from SRAM after copy. Explicit FLAGS(6) marks the
+ * load-time view as R+W (not RWX), silencing ld's `--warn-rwx-segments`
+ * while leaving runtime execution from RAM unaffected (Cortex-M has no W^X
+ * enforcement). Two text PHDRs are needed because flash-resident code/data
+ * lives both before and after the data-segment load images: one PT_LOAD per
+ * non-contiguous flash chunk so the UF2 converter sees no LMA overlap. */
+PHDRS
+{
+    text1 PT_LOAD FLAGS(5);  /* R+X -- early FLASH code/rodata */
+    data  PT_LOAD FLAGS(6);  /* R+W -- load images of RAM-resident sections */
+    text2 PT_LOAD FLAGS(5);  /* R+X -- late FLASH (flash_end + pg registry) */
+}
+
 SECTIONS
 {
     .flash_begin : {
         __flash_binary_start = .;
-    } > FLASH
+    } > FLASH :text1
 
     /* The bootrom will enter the image at the point indicated in your
        IMAGE_DEF, which is usually the reset handler of your vector table.
@@ -55,7 +71,7 @@ SECTIONS
         __embedded_block_end = .;
         KEEP (*(.reset))
         . = ALIGN(4);
-    } > FLASH
+    } > FLASH :text1
 
     /* Note the boot2 section is optional, and should be discarded if there is
        no reference to it *inside* the binary, as it is not called by the
@@ -73,7 +89,7 @@ SECTIONS
         __boot2_start__ = .;
         *(.boot2)
         __boot2_end__ = .;
-    } > FLASH
+    } > FLASH :text1
 
     ASSERT(__boot2_end__ - __boot2_start__ <= 256,
         "ERROR: Pico second stage bootloader must be no more than 256 bytes in size")
@@ -82,18 +98,18 @@ SECTIONS
         /* segments not marked as .flashdata are instead pulled into .data (in RAM) to avoid accidental flash accesses */
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
-    } > FLASH
+    } > FLASH :text1
 
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > FLASH
+    } > FLASH :text1
 
     __exidx_start = .;
     .ARM.exidx :
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > FLASH
+    } > FLASH :text1
     __exidx_end = .;
 
     /* Machine inspectable binary information */
@@ -103,7 +119,7 @@ SECTIONS
     {
         KEEP(*(.binary_info.keep.*))
         *(.binary_info.*)
-    } > FLASH
+    } > FLASH :text1
     __binary_info_end = .;
     . = ALIGN(4);
 
@@ -138,7 +154,7 @@ SECTIONS
         *(.eh_frame*)
         . = ALIGN(4);
         __ram_text_end__ = .;
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
     __ram_text_source__ = LOADADDR(.text);
     . = ALIGN(4);
 
@@ -188,14 +204,14 @@ SECTIONS
 
         *(.jcr)
         . = ALIGN(4);
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
 
     .tdata : {
         . = ALIGN(4);
         *(.tdata .tdata.* .gnu.linkonce.td.*)
         /* All data end */
         __tdata_end = .;
-    } > RAM AT> FLASH
+    } > RAM AT> FLASH :data
     PROVIDE(__data_end__ = .);
 
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
@@ -211,7 +227,7 @@ SECTIONS
         __tls_end = .;
     } > RAM
 
-    .bss : {
+    .bss (NOLOAD) : {
         . = ALIGN(4);
         __tbss_end = .;
 
@@ -239,7 +255,7 @@ SECTIONS
         *(.scratch_x.*)
         . = ALIGN(4);
         __scratch_x_end__ = .;
-    } > SCRATCH_X AT > FLASH
+    } > SCRATCH_X AT > FLASH :data
     __scratch_x_source__ = LOADADDR(.scratch_x);
 
     .scratch_y : {
@@ -247,7 +263,7 @@ SECTIONS
         *(.scratch_y.*)
         . = ALIGN(4);
         __scratch_y_end__ = .;
-    } > SCRATCH_Y AT > FLASH /*=0xa5a5a5a5*/ /* BF: TODO want to fill with STACK_FILL_CHAR to allow stack check - this doesn't seem to do it */
+    } > SCRATCH_Y AT > FLASH :data /*=0xa5a5a5a5*/ /* BF: TODO want to fill with STACK_FILL_CHAR to allow stack check - this doesn't seem to do it */
     __scratch_y_source__ = LOADADDR(.scratch_y);
 
     /* .stack*_dummy section doesn't contains any symbols. It is only
@@ -274,7 +290,7 @@ SECTIONS
     .flash_end : {
         KEEP(*(.embedded_end_block*))
         PROVIDE(__flash_binary_end = .);
-    } > FLASH =0xaa
+    } > FLASH :text2 =0xaa
 
 
     /* Base address where the config is stored. */
@@ -291,14 +307,14 @@ SECTIONS
       KEEP (*(.pg_registry))
       KEEP (*(SORT(.pg_registry.*)))
       PROVIDE_HIDDEN (__pg_registry_end = .);
-    } >FLASH
+    } >FLASH :text2
 
     .pg_resetdata :
     {
       PROVIDE_HIDDEN (__pg_resetdata_start = .);
       KEEP (*(.pg_resetdata))
       PROVIDE_HIDDEN (__pg_resetdata_end = .);
-    } >FLASH
+    } >FLASH :text2
 
 
     /* stack limit is poorly named, but historically is maximum heap ptr */


### PR DESCRIPTION
## Summary

Every RP2350 build currently emits

```
ld: warning: <elf> has a LOAD segment with RWX permissions
```

at link time. Root cause: the three RP2350 linker scripts
(`pico_rp2350_RunFrom{FLASH,Hybrid,RAM}.ld`) declare no `PHDRS`, so
ld's default phdr allocator merges adjacent allocated sections into
a single `PT_LOAD` whose `p_flags` is the union of section flags.
The load images of `.scratch_x`/`.scratch_y` (and, under Hybrid/RAM,
`.text`) carry executable section flags because their VMA is in SRAM
and the bytes are copied there at boot for execution -- so the
merged `.text + .data + .scratch_*` segment ends up RWX.

This PR declares explicit phdrs and tags every allocated output
section, so the resulting ELF has clean R+X / R+W LOAD segments.

### Approach

Three phdrs per script:

```
text1 PT_LOAD FLAGS(5);  /* R+X -- early FLASH code/rodata */
data  PT_LOAD FLAGS(6);  /* R+W -- load images of RAM-resident sections */
text2 PT_LOAD FLAGS(5);  /* R+X -- late FLASH (flash_end + pg registry) */
```

- `FLAGS(6)` on `data` forces the load-time view to R+W rather than
  RWX. This is a lie about runtime permissions for the SRAM-resident
  code, but Cortex-M has no W^X enforcement, the loader (boot ROM)
  only does memcpy, and execution happens from SRAM after the copy
  -- exactly as before. The fix is purely cosmetic at runtime.
- Two `text` phdrs are required because flash-resident sections
  appear both before and after the data load images
  (`.flash_end`, `.pg_registry`, `.pg_resetdata` sit after
  `.scratch_y` in the script). A single text phdr would compute its
  LMA range as the bounding box, overlapping the data phdr's LMA --
  which the BF UF2 converter (`ELF -> UF2`) rejects.
- `.bss` is now marked `(NOLOAD)` in the Hybrid and RAM scripts to
  match the convention already used in FromFLASH; without this, ld
  emits ``section `.bss' can't be allocated in segment N`` under the
  new phdr layout.

