### PR TITLE
fix: restore selectable RX provider on SITL via FEATURE_RX_UDP

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -234,6 +234,7 @@ static const char * const mixerNames[] = {
 #define _R(_flag, _name) [LOG2(_flag)] = _name
 static const char * const featureNames[] = {
     _R(FEATURE_RX_PPM, "RX_PPM"),
+    _R(FEATURE_RX_UDP, "RX_UDP"),
     _R(FEATURE_INFLIGHT_ACC_CAL, "INFLIGHT_ACC_CAL"),
     _R(FEATURE_RX_SERIAL, "RX_SERIAL"),
     _R(FEATURE_MOTOR_STOP, "MOTOR_STOP"),

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -314,7 +314,16 @@ static void validateAndFixConfig(void)
     }
 #endif // USE_ACC
 
-    if (!(featureIsConfigured(FEATURE_RX_PARALLEL_PWM) || featureIsConfigured(FEATURE_RX_PPM) || featureIsConfigured(FEATURE_RX_SERIAL) || featureIsConfigured(FEATURE_RX_MSP) || featureIsConfigured(FEATURE_RX_SPI) || featureIsConfigured(FEATURE_RX_UDP))) {
+    bool hasConfiguredRxFeature =
+        featureIsConfigured(FEATURE_RX_PARALLEL_PWM) ||
+        featureIsConfigured(FEATURE_RX_PPM) ||
+        featureIsConfigured(FEATURE_RX_SERIAL) ||
+        featureIsConfigured(FEATURE_RX_MSP) ||
+        featureIsConfigured(FEATURE_RX_SPI);
+#if ENABLE_RX_UDP
+    hasConfiguredRxFeature = hasConfiguredRxFeature || featureIsConfigured(FEATURE_RX_UDP);
+#endif
+    if (!hasConfiguredRxFeature) {
         featureEnableImmediate(DEFAULT_RX_FEATURE);
     }
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -314,31 +314,37 @@ static void validateAndFixConfig(void)
     }
 #endif // USE_ACC
 
-    if (!(featureIsConfigured(FEATURE_RX_PARALLEL_PWM) || featureIsConfigured(FEATURE_RX_PPM) || featureIsConfigured(FEATURE_RX_SERIAL) || featureIsConfigured(FEATURE_RX_MSP) || featureIsConfigured(FEATURE_RX_SPI))) {
+    if (!(featureIsConfigured(FEATURE_RX_PARALLEL_PWM) || featureIsConfigured(FEATURE_RX_PPM) || featureIsConfigured(FEATURE_RX_SERIAL) || featureIsConfigured(FEATURE_RX_MSP) || featureIsConfigured(FEATURE_RX_SPI) || featureIsConfigured(FEATURE_RX_UDP))) {
         featureEnableImmediate(DEFAULT_RX_FEATURE);
     }
 
     if (featureIsConfigured(FEATURE_RX_PPM)) {
-        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_MSP | FEATURE_RX_SPI);
+        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_MSP | FEATURE_RX_SPI | FEATURE_RX_UDP);
     }
 
     if (featureIsConfigured(FEATURE_RX_MSP)) {
-        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM | FEATURE_RX_SPI);
+        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM | FEATURE_RX_SPI | FEATURE_RX_UDP);
     }
 
     if (featureIsConfigured(FEATURE_RX_SERIAL)) {
-        featureDisableImmediate(FEATURE_RX_PARALLEL_PWM | FEATURE_RX_MSP | FEATURE_RX_PPM | FEATURE_RX_SPI);
+        featureDisableImmediate(FEATURE_RX_PARALLEL_PWM | FEATURE_RX_MSP | FEATURE_RX_PPM | FEATURE_RX_SPI | FEATURE_RX_UDP);
     }
 
 #ifdef USE_RX_SPI
     if (featureIsConfigured(FEATURE_RX_SPI)) {
-        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM | FEATURE_RX_MSP);
+        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM | FEATURE_RX_MSP | FEATURE_RX_UDP);
     }
 #endif // USE_RX_SPI
 
     if (featureIsConfigured(FEATURE_RX_PARALLEL_PWM)) {
-        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_MSP | FEATURE_RX_PPM | FEATURE_RX_SPI);
+        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_MSP | FEATURE_RX_PPM | FEATURE_RX_SPI | FEATURE_RX_UDP);
     }
+
+#if ENABLE_RX_UDP
+    if (featureIsConfigured(FEATURE_RX_UDP)) {
+        featureDisableImmediate(FEATURE_RX_SERIAL | FEATURE_RX_PARALLEL_PWM | FEATURE_RX_PPM | FEATURE_RX_MSP | FEATURE_RX_SPI);
+    }
+#endif // ENABLE_RX_UDP
 
 #if defined(USE_ADC)
     if (featureIsConfigured(FEATURE_RSSI_ADC)) {

--- a/src/main/config/feature.c
+++ b/src/main/config/feature.c
@@ -70,6 +70,9 @@ uint32_t featuresSupportedByBuild =
 #ifdef USE_RX_MSP
     | FEATURE_RX_MSP
 #endif
+#if ENABLE_RX_UDP
+    | FEATURE_RX_UDP
+#endif
 #ifdef USE_ADC
     | FEATURE_RSSI_ADC
 #endif

--- a/src/main/config/feature.h
+++ b/src/main/config/feature.h
@@ -28,7 +28,9 @@
 
 #ifndef DEFAULT_RX_FEATURE
 
-#if defined(USE_SERIALRX)
+#if ENABLE_RX_UDP
+#define DEFAULT_RX_FEATURE FEATURE_RX_UDP
+#elif defined(USE_SERIALRX)
 #define DEFAULT_RX_FEATURE FEATURE_RX_SERIAL
 #elif defined(USE_RX_MSP)
 #define DEFAULT_RX_FEATURE FEATURE_RX_MSP
@@ -44,6 +46,7 @@
 //  cli/cli.c:featureNames
 typedef enum {
     FEATURE_RX_PPM = 1 << 0,
+    FEATURE_RX_UDP = 1 << 1,
     FEATURE_INFLIGHT_ACC_CAL = 1 << 2,
     FEATURE_RX_SERIAL = 1 << 3,
     FEATURE_MOTOR_STOP = 1 << 4,

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -321,8 +321,10 @@ static bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntime
 void rxInit(void)
 {
 #if ENABLE_RX_UDP
-    rxRuntimeState.rxProvider = RX_PROVIDER_UDP;
-#else
+    if (featureIsEnabled(FEATURE_RX_UDP)) {
+        rxRuntimeState.rxProvider = RX_PROVIDER_UDP;
+    } else
+#endif
     if (featureIsEnabled(FEATURE_RX_PARALLEL_PWM)) {
         rxRuntimeState.rxProvider = RX_PROVIDER_PARALLEL_PWM;
     } else if (featureIsEnabled(FEATURE_RX_PPM)) {
@@ -336,7 +338,6 @@ void rxInit(void)
     } else {
         rxRuntimeState.rxProvider = RX_PROVIDER_NONE;
     }
-#endif
     rxRuntimeState.serialrxProvider = rxConfig()->serialrx_provider;
     rxRuntimeState.rcReadRawFn = nullReadRawRC;
     rxRuntimeState.rcFrameStatusFn = nullFrameStatus;

--- a/src/platform/SIMULATOR/target/SITL/target.h
+++ b/src/platform/SIMULATOR/target/SITL/target.h
@@ -96,7 +96,9 @@
 
 #define ENABLE_RX_UDP           1
 
-#define DEFAULT_RX_FEATURE      FEATURE_RX_MSP
+// DEFAULT_RX_FEATURE is picked by config/feature.h: FEATURE_RX_UDP when
+// ENABLE_RX_UDP=1 (bare SITL / Gazebo), else FEATURE_RX_MSP. Configs that want
+// MSP RX as the default (e.g. SITL_X_PLANE) override DEFAULT_RX_FEATURE.
 #define DEFAULT_FEATURES        (FEATURE_GPS | FEATURE_TELEMETRY)
 
 // Gazebo Iris model uses "props in" motor directions (M0/M3=CW, M1/M2=CCW),


### PR DESCRIPTION
## Summary

Restore selectable RX provider on SITL by promoting UDP to a first-class `FEATURE_RX_UDP`.

The Gazebo Harmonic / UDP RX work in #15140 hardcoded `rxRuntimeState.rxProvider = RX_PROVIDER_UDP` whenever `ENABLE_RX_UDP=1`, which made it impossible to select MSP RX (or any other provider) on SITL builds — the feature-driven branch in `rxInit()` became unreachable. This effectively broke the long-standing MSP-over-TCP-UART workflow used by Configurator and SITL test harnesses.

## What changed

UDP RC is a *transport* (peer to PPM, parallel PWM, UART, MSP, SPI), not a framing protocol — so it slots cleanly into the existing `FEATURE_RX_*` mutual-exclusion machinery rather than under `serialrx_provider` / `rx_spi_protocol`.

- `feature.h` — add `FEATURE_RX_UDP = 1 << 1`; promote it to the top of the `DEFAULT_RX_FEATURE` chain on `ENABLE_RX_UDP` builds.
- `feature.c` — include in `featuresSupportedByBuild` (gated on `ENABLE_RX_UDP`).
- `cli.c` — add to `featureNames` so CLI `feature` shows / accepts `RX_UDP`.
- `config.c` — include in the `FEATURE_RX_*` mutual-exclusion checks (selecting one disables the others).
- `rx.c` — replace the unconditional `RX_PROVIDER_UDP` assignment with `featureIsEnabled(FEATURE_RX_UDP)` ahead of the standard feature-driven chain.
- `platform/SIMULATOR/target/SITL/target.h` — drop the now-redundant `DEFAULT_RX_FEATURE FEATURE_RX_MSP` override (it was being shadowed by the hardcode anyway).

## Behaviour

- Bare SITL target: `DEFAULT_RX_FEATURE = FEATURE_RX_UDP`. Gazebo workflow unchanged — UDP RC packets on port 9004 still drive RC channels out-of-the-box.
- MSP RX is now reachable: `feature -RX_UDP`, `feature RX_MSP`, `save`. (`SITL_X_PLANE` / `SITL_REAL_FLIGHT` configs in betaflight/config will need a corresponding `DEFAULT_RX_FEATURE FEATURE_RX_MSP` override since their bridges don't push UDP RC — separate config-repo PR.)
- Non-SITL builds: `ENABLE_RX_UDP` defaults to 0 in `common_post.h`, so `FEATURE_RX_UDP` is not in `featuresSupportedByBuild` and the UDP code is compiled out as before.

## Build verification

- `TARGET=SITL` — 407,406 bytes, links clean.
- `TARGET=STM32F405` — 603,577 bytes, links clean (sanity check the feature enum change doesn't disturb non-SITL builds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UDP receiver is now a selectable runtime receiver option when enabled in the build.
  * CLI now reports the UDP receiver in the feature list.
  * Default receiver selection will prefer UDP when the build enables it.

* **Bug Fixes**
  * Receiver validation improved: UDP is treated mutually exclusively with other RX modes and won't be forced as default if it's the only configured RX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->