### PR TITLE
Add X32M7 SDK submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,8 @@
 	branch = master
 	ignore = dirty
 	update = none
+[submodule "lib/main/X32M7"]
+	path = lib/main/X32M7
+	url = https://github.com/X-CORE-LABS-PTE-LTD/X32M7_Std_SDK.git
+	ignore = dirty
+	update = none


### PR DESCRIPTION
Add X32M7 SDK as a submodule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies configuration to include new development libraries.
  * Added a new external SDK as a submodule, configured to ignore local modifications and to avoid automatic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->