### PR TITLE
feat(osd): add MGRS coordinate display element (2025.12 stable line)

### DIFF
--- a/lib/main/mgrs/LICENSE
+++ b/lib/main/mgrs/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012, Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral, Calvin Metcalf
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.

--- a/lib/main/mgrs/betaflight_readme.txt
+++ b/lib/main/mgrs/betaflight_readme.txt
@@ -1,0 +1,32 @@
+Military Grid Reference System (MGRS)
+
+Source from: https://github.com/proj4js/mgrs (commit reference: master, 2025-01-05 release v2.1.0)
+License:     MIT (see LICENSE)
+
+This is a port — not a 1:1 copy — of the proj4js/mgrs forward conversion path
+(latitude/longitude -> MGRS string). It is restructured for an embedded C
+flight-controller environment:
+
+  - Forward-only: only LL -> MGRS is implemented. The inverse path
+    (MGRS -> lat/lon, bounding boxes, decode) is NOT included. A flight
+    controller emits MGRS for OSD/telemetry; it never parses one.
+  - Single precision floats throughout. Cortex-M FPUs are single-precision;
+    using doubles trips the soft-float path and is too slow for our budget.
+  - No exceptions / no allocations / no errno. The single failure mode
+    (latitude outside the [-80, 84] MGRS band) returns false and writes a
+    fixed placeholder string to the caller's buffer.
+  - Inputs use int32 latitude/longitude scaled by 1e7 to match
+    gpsLocation_t in src/main/io/gps.h (avoids a degree-string round-trip).
+  - Output is a single readable string of the form "NN Z SS NNNNN NNNNN"
+    (space-separated grid-zone, 100k square, easting, northing) sized for
+    direct OSD use. Zones 1-9 are zero-padded so the string width is fixed
+    at 17 chars + NUL — useful for OSD column layout.
+
+The math is unchanged from upstream: WGS84 ellipsoid, transverse Mercator
+forward, 6th-order series. Norwegian (zone 32V) and Svalbard (31X/33X/35X/37X)
+exceptions are preserved. The 100k-square letter set logic (with I/O
+exclusion and the row/column rollover dance) is preserved verbatim.
+
+Test vectors in src/test/unit/mgrs_unittest.cc are taken directly from the
+upstream proj4js/mgrs test suite (test/test.js) so this port can be
+verified against the same gold-standard outputs as the source library.

--- a/lib/main/mgrs/mgrs.c
+++ b/lib/main/mgrs/mgrs.c
@@ -1,0 +1,399 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Military Grid Reference System (MGRS) — forward encoder.
+ *
+ * Ported from proj4js/mgrs (MIT licensed, see LICENSE in this directory).
+ * The math is the standard WGS84 transverse-Mercator forward — same as
+ * UTM — followed by the MGRS letter substitutions for the latitude band
+ * and the 100 km grid square.
+ *
+ * Differences from upstream (see also betaflight_readme.txt):
+ *   - integer 1e-7 deg inputs at the API boundary (matches
+ *     gpsLocation_t in io/gps.h);
+ *   - no exceptions / allocations / errno;
+ *   - fixed OSD-friendly output format with zero-padded zone and
+ *     space-separated easting / northing groups.
+ *
+ * Numerical precision: the inner math uses `double`. The sixth-order
+ * meridional-arc series and the easting / northing polynomials accumulate
+ * enough rounding error in single precision to drift 1–2 m at the OSD's
+ * 1 m precision step — which would round to the wrong MGRS digit. The
+ * existing Plus Codes feature in osd_elements.c already promotes lat/lon
+ * to `double` for OLC_Encode (see OSD_ELEMENT_TYPE_4 path), so this is
+ * consistent precedent. The function is only called at OSD redraw cadence
+ * (~30 Hz worst case), well within budget on every supported MCU.
+ *
+ * Public API contract is documented in mgrs.h.
+ */
+
+#include <math.h>
+#include <stddef.h>
+
+#include "mgrs.h"
+
+/* ---------------------------------------------------------------------------
+ * WGS84 ellipsoid + transverse-Mercator constants.
+ *
+ * All values are taken from the proj4js port of the NGA Geotrans library.
+ * The inner math uses `double` to match upstream precision; see file
+ * header for rationale.
+ * ------------------------------------------------------------------------ */
+
+#define MGRS_PI                3.14159265358979323846  /* full double-precision M_PI */
+#define MGRS_ECC_SQUARED       0.00669438              /* WGS84 first eccentricity squared */
+#define MGRS_SCALE_FACTOR      0.9996                  /* UTM scale factor on central meridian */
+#define MGRS_SEMI_MAJOR_AXIS   6378137.0               /* WGS84 equatorial radius, metres */
+#define MGRS_EASTING_OFFSET    500000.0                /* False easting, metres */
+#define MGRS_NORTHING_OFFSET   10000000.0              /* False northing for southern hemisphere */
+#define MGRS_UTM_ZONE_WIDTH    6.0                     /* Each UTM zone is 6 deg of longitude */
+#define MGRS_HALF_ZONE_WIDTH   3.0                     /* Half of MGRS_UTM_ZONE_WIDTH */
+
+/* ---------------------------------------------------------------------------
+ * 100 km grid-square letter set tables.
+ *
+ * MGRS divides each UTM zone into 100 km squares labelled by two letters.
+ * The letter assignment cycles through 6 sets per zone family. The columns
+ * (easting axis) start at A/J/S; the rows (northing axis) start at A/F/A/F.
+ * Letters 'I' and 'O' are excluded everywhere, and rows additionally exclude
+ * letters past 'V'. See the NGA spec, table 1.
+ * ------------------------------------------------------------------------ */
+
+#define MGRS_NUM_100K_SETS     6
+static const char SET_ORIGIN_COLUMN_LETTERS[MGRS_NUM_100K_SETS + 1] = "AJSAJS";
+static const char SET_ORIGIN_ROW_LETTERS[MGRS_NUM_100K_SETS + 1]    = "AFAFAF";
+
+/* Letters used in the column / row rollover logic. */
+#define LET_A 'A'
+#define LET_I 'I'
+#define LET_O 'O'
+#define LET_V 'V'
+#define LET_Z 'Z'
+
+/* Out-of-range placeholder string written when the polar guard fires. */
+#define MGRS_PLACEHOLDER "--MGRS--"
+
+/* ---------------------------------------------------------------------------
+ * UTM result struct — internal only. The external API hides the UTM step.
+ * ------------------------------------------------------------------------ */
+
+typedef struct mgrsUtm_s {
+    int    zone;       /* UTM zone number 1..60 */
+    char   band;       /* MGRS latitude band letter, eg 'U' for Vienna */
+    double easting;    /* metres east of zone false-origin */
+    double northing;   /* metres north of equator (or +1e7 for southern hemi) */
+} mgrsUtm_t;
+
+/* ---------------------------------------------------------------------------
+ * Helpers
+ * ------------------------------------------------------------------------ */
+
+static double mgrsDegToRad(double deg)
+{
+    return deg * (MGRS_PI / 180.0);
+}
+
+/*
+ * Returns the MGRS latitude-band letter ('C'..'X', skipping 'I' and 'O')
+ * for the given decimal-degree latitude. Returns 'Z' if the latitude is
+ * outside the MGRS coverage band [-80, 84].
+ *
+ * Band 'X' is special-cased because it is 12 deg tall (72..84) instead of
+ * the standard 8 deg. All other bands are 8 deg starting at -80.
+ */
+static char mgrsGetLatBandLetter(double lat_deg)
+{
+    if (lat_deg <= 84.0 && lat_deg >= 72.0) {
+        return 'X';
+    }
+    if (lat_deg < 72.0 && lat_deg >= -80.0) {
+        static const char band_letters[] = "CDEFGHJKLMNPQRSTUVWX";
+        const int idx = (int)floor((lat_deg - (-80.0)) / 8.0);
+        return band_letters[idx];
+    }
+    return 'Z';
+}
+
+/*
+ * MGRS letter sets cycle through 6 patterns per zone, indexed by
+ * (zone mod 6). Zones whose mod is 0 use set 6, not set 0.
+ */
+static int mgrsGet100kSetForZone(int zone)
+{
+    int set = zone % MGRS_NUM_100K_SETS;
+    if (set == 0) {
+        set = MGRS_NUM_100K_SETS;
+    }
+    return set;
+}
+
+/*
+ * Produce the two-letter 100 km grid-square ID from a column index, row
+ * index, and the zone's letter set.
+ *
+ * The MGRS spec excludes letters 'I' and 'O' from both axes, and rows
+ * additionally wrap after 'V'. The control flow below is a verbatim port
+ * of proj4js's getLetter100kID (in turn from NGA Geotrans) — small and
+ * subtle, but well-tested for decades. Touch with extreme care.
+ */
+static void mgrsGetLetter100kID(int column, int row, int set, char *col_out, char *row_out)
+{
+    const int idx = set - 1;
+    const int colOrigin = SET_ORIGIN_COLUMN_LETTERS[idx];
+    const int rowOrigin = SET_ORIGIN_ROW_LETTERS[idx];
+
+    int colInt = colOrigin + column - 1;
+    int rowInt = rowOrigin + row;
+    int rollover = 0;
+
+    if (colInt > LET_Z) {
+        colInt = colInt - LET_Z + LET_A - 1;
+        rollover = 1;
+    }
+    if (colInt == LET_I
+        || (colOrigin < LET_I && colInt > LET_I)
+        || ((colInt > LET_I || colOrigin < LET_I) && rollover)) {
+        colInt++;
+    }
+    if (colInt == LET_O
+        || (colOrigin < LET_O && colInt > LET_O)
+        || ((colInt > LET_O || colOrigin < LET_O) && rollover)) {
+        colInt++;
+        if (colInt == LET_I) {
+            colInt++;
+        }
+    }
+    if (colInt > LET_Z) {
+        colInt = colInt - LET_Z + LET_A - 1;
+    }
+
+    rollover = 0;
+    if (rowInt > LET_V) {
+        rowInt = rowInt - LET_V + LET_A - 1;
+        rollover = 1;
+    }
+    if (rowInt == LET_I
+        || (rowOrigin < LET_I && rowInt > LET_I)
+        || ((rowInt > LET_I || rowOrigin < LET_I) && rollover)) {
+        rowInt++;
+    }
+    if (rowInt == LET_O
+        || (rowOrigin < LET_O && rowInt > LET_O)
+        || ((rowInt > LET_O || rowOrigin < LET_O) && rollover)) {
+        rowInt++;
+        if (rowInt == LET_I) {
+            rowInt++;
+        }
+    }
+    if (rowInt > LET_V) {
+        rowInt = rowInt - LET_V + LET_A - 1;
+    }
+
+    *col_out = (char)colInt;
+    *row_out = (char)rowInt;
+}
+
+/*
+ * WGS84 latitude/longitude -> UTM forward conversion (sixth-order series).
+ *
+ * Includes the Norwegian (zone 32V) and Svalbard (zones 31X/33X/35X/37X)
+ * special-case zone re-assignments. Polar regions (above 84N or below 80S)
+ * are NOT handled here; mgrsEncode applies that guard before calling.
+ */
+static void mgrsLLtoUTM(double lat_deg, double lon_deg, mgrsUtm_t *out)
+{
+    /* Default zone from longitude. Zone 1 is -180..-174, zone 60 is 174..180. */
+    int zone = (int)floor((lon_deg + 180.0) / MGRS_UTM_ZONE_WIDTH) + 1;
+    if (lon_deg == 180.0) {
+        zone = 60;
+    }
+
+    /* Norwegian zone exception: south-west Norway extends zone 32V west. */
+    if (lat_deg >= 56.0 && lat_deg < 64.0 && lon_deg >= 3.0 && lon_deg < 12.0) {
+        zone = 32;
+    }
+
+    /* Svalbard zone exceptions: zones 31X / 33X / 35X / 37X cover wider strips. */
+    if (lat_deg >= 72.0 && lat_deg < 84.0) {
+        if (lon_deg >= 0.0 && lon_deg < 9.0) {
+            zone = 31;
+        } else if (lon_deg >= 9.0 && lon_deg < 21.0) {
+            zone = 33;
+        } else if (lon_deg >= 21.0 && lon_deg < 33.0) {
+            zone = 35;
+        } else if (lon_deg >= 33.0 && lon_deg < 42.0) {
+            zone = 37;
+        }
+    }
+
+    const double lat_rad = mgrsDegToRad(lat_deg);
+    const double lon_rad = mgrsDegToRad(lon_deg);
+    const double lon_origin_rad =
+        mgrsDegToRad((zone - 1) * MGRS_UTM_ZONE_WIDTH - 180.0 + MGRS_HALF_ZONE_WIDTH);
+
+    const double ecc2 = MGRS_ECC_SQUARED;
+    const double ecc4 = ecc2 * ecc2;
+    const double ecc6 = ecc4 * ecc2;
+    const double eccPrimeSquared = ecc2 / (1.0 - ecc2);
+
+    const double sinLat = sin(lat_rad);
+    const double cosLat = cos(lat_rad);
+    const double tanLat = tan(lat_rad);
+
+    const double N = MGRS_SEMI_MAJOR_AXIS / sqrt(1.0 - ecc2 * sinLat * sinLat);
+    const double T = tanLat * tanLat;
+    const double C = eccPrimeSquared * cosLat * cosLat;
+    const double A = cosLat * (lon_rad - lon_origin_rad);
+
+    /* Meridional arc M (sixth-order series). */
+    const double M = MGRS_SEMI_MAJOR_AXIS * (
+          (1.0 - ecc2 / 4.0 - 3.0 * ecc4 / 64.0 - 5.0 * ecc6 / 256.0) * lat_rad
+        - (3.0 * ecc2 / 8.0 + 3.0 * ecc4 / 32.0 + 45.0 * ecc6 / 1024.0) * sin(2.0 * lat_rad)
+        + (15.0 * ecc4 / 256.0 + 45.0 * ecc6 / 1024.0) * sin(4.0 * lat_rad)
+        - (35.0 * ecc6 / 3072.0) * sin(6.0 * lat_rad)
+    );
+
+    const double A2 = A * A;
+    const double A3 = A2 * A;
+    const double A4 = A3 * A;
+    const double A5 = A4 * A;
+    const double A6 = A5 * A;
+
+    const double utmEasting = MGRS_SCALE_FACTOR * N * (
+          A
+        + (1.0 - T + C) * A3 / 6.0
+        + (5.0 - 18.0 * T + T * T + 72.0 * C - 58.0 * eccPrimeSquared) * A5 / 120.0
+    ) + MGRS_EASTING_OFFSET;
+
+    double utmNorthing = MGRS_SCALE_FACTOR * (
+        M + N * tanLat * (
+              A2 / 2.0
+            + (5.0 - T + 9.0 * C + 4.0 * C * C) * A4 / 24.0
+            + (61.0 - 58.0 * T + T * T + 600.0 * C - 330.0 * eccPrimeSquared) * A6 / 720.0
+        )
+    );
+    if (lat_deg < 0.0) {
+        utmNorthing += MGRS_NORTHING_OFFSET;
+    }
+
+    out->zone     = zone;
+    out->band     = mgrsGetLatBandLetter(lat_deg);
+    out->easting  = utmEasting;
+    out->northing = utmNorthing;
+}
+
+/* ---------------------------------------------------------------------------
+ * Output formatting
+ *
+ * Writes:    "NN Z SS [DDDDD DDDDD]"   for precision >= 1
+ * or:        "NN Z SS"                  for precision == 0
+ *
+ * where N = decimal digit, Z = band letter, S = 100k-square letter, and
+ * D = easting/northing digit. The number of D's per group equals
+ * `precision`. Zone is always two digits (zero-padded) so the OSD column
+ * width is fixed.
+ * ------------------------------------------------------------------------ */
+
+/* Write n decimal digits of `value` (with leading zeros) starting at `out`. */
+static void mgrsWriteDigits(char *out, unsigned int value, unsigned int n)
+{
+    out += n;
+    for (unsigned int i = 0; i < n; i++) {
+        *--out = (char)('0' + (value % 10));
+        value /= 10;
+    }
+}
+
+/* Truncate `value` (a positive easting or northing in metres) to its
+ * lowest 5 decimal digits (mod 100000), then drop the lowest (5-precision)
+ * digits to get the MGRS digit group at that precision.  */
+static unsigned int mgrsTruncateAxis(double value, unsigned int precision)
+{
+    unsigned int truncated = (unsigned int)floor(value) % 100000U;
+    for (unsigned int i = 0; i < (5U - precision); i++) {
+        truncated /= 10U;
+    }
+    return truncated;
+}
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * ------------------------------------------------------------------------ */
+
+bool mgrsEncode(int32_t lat_e7, int32_t lon_e7, uint8_t precision, char *out)
+{
+    if (out == NULL) {
+        return false;
+    }
+
+    if (precision > MGRS_PRECISION_MAX) {
+        precision = MGRS_PRECISION_MAX;
+    }
+
+    const double lat_deg = (double)lat_e7 * 1.0e-7;
+    const double lon_deg = (double)lon_e7 * 1.0e-7;
+
+    /* Polar guard: latitudes outside [-80, 84] are MGRS UPS regions. We do
+     * not implement UPS — a flight controller in those regions has bigger
+     * problems. Write a placeholder and signal failure. */
+    if (lat_deg < -80.0 || lat_deg > 84.0) {
+        const char *p = MGRS_PLACEHOLDER;
+        unsigned int i = 0;
+        while (p[i] != '\0' && i < (MGRS_BUFFER_SIZE - 1U)) {
+            out[i] = p[i];
+            i++;
+        }
+        out[i] = '\0';
+        return false;
+    }
+
+    mgrsUtm_t utm;
+    mgrsLLtoUTM(lat_deg, lon_deg, &utm);
+
+    const int set = mgrsGet100kSetForZone(utm.zone);
+    const int eastCol = (int)floor(utm.easting / 100000.0);
+    const int northRow = ((int)floor(utm.northing / 100000.0)) % 20;
+
+    char col100k = '?';
+    char row100k = '?';
+    mgrsGetLetter100kID(eastCol, northRow, set, &col100k, &row100k);
+
+    /* "NN Z SS" — zone (zero-padded two digits), band letter, 100k pair. */
+    int p = 0;
+    out[p++] = (char)('0' + (utm.zone / 10));
+    out[p++] = (char)('0' + (utm.zone % 10));
+    out[p++] = utm.band;
+    out[p++] = col100k;
+    out[p++] = row100k;
+
+    if (precision > 0) {
+        const unsigned int eastDigits  = mgrsTruncateAxis(utm.easting,  precision);
+        const unsigned int northDigits = mgrsTruncateAxis(utm.northing, precision);
+
+        out[p++] = ' ';
+        mgrsWriteDigits(&out[p], eastDigits, precision);
+        p += precision;
+
+        out[p++] = ' ';
+        mgrsWriteDigits(&out[p], northDigits, precision);
+        p += precision;
+    }
+    out[p] = '\0';
+    return true;
+}

--- a/lib/main/mgrs/mgrs.h
+++ b/lib/main/mgrs/mgrs.h
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Military Grid Reference System (MGRS) — forward encoder.
+ *
+ * Produces an MGRS reference string from a WGS84 lat/lon pair so the OSD
+ * can display a single, easy-to-radio-back grid for downed-aircraft
+ * recovery. MGRS is friendlier than decimal degrees in the field because
+ * it is short, line-of-sight chunked (100 km grid -> 1 km square ->
+ * 10 m / 1 m offset), and tied directly to printed military maps.
+ *
+ * Forward only: a flight controller emits an MGRS string, it never
+ * parses one. Decode/inverse paths from upstream proj4js/mgrs are
+ * deliberately omitted to save flash.
+ *
+ * Math is a port of proj4js/mgrs (MIT licensed; see LICENSE in this
+ * directory). The port differs from upstream as follows:
+ *   - single-precision floats only (Cortex-M FPU is single-precision);
+ *   - integer 1e-7 deg inputs (matches gpsLocation_t in io/gps.h);
+ *   - no exceptions / allocations / errno: a single bool return signals
+ *     the only failure mode (latitude outside MGRS coverage, ie polar);
+ *   - output string is ready for OSD: zone is zero-padded to 2 digits
+ *     and the easting / northing groups are space-separated.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*
+ * Maximum supported precision in MGRS digits per axis. 5 = 1 m. The MGRS
+ * spec also defines a 6 (0.1 m) but consumer GPS modules cannot resolve
+ * to that level so it is intentionally not supported here.
+ */
+#define MGRS_PRECISION_MAX 5
+
+/*
+ * Buffer size needed for the longest MGRS output, ie at MGRS_PRECISION_MAX:
+ *
+ *   "NN Z SS DDDDD DDDDD\0"
+ *    └┬┘ │ └┬┘  └─┬─┘ └─┬─┘ NUL
+ *  zone  │  100k square     5 east   5 north
+ *        │
+ *        latitude band letter
+ *
+ * 2 (zone) + 1 (band) + 2 (100k) + 1 (sp) + 5 (east) + 1 (sp) + 5 (north) + 1 (NUL) = 18
+ *
+ * Lower precision values produce shorter strings; callers using a fixed
+ * MGRS_PRECISION_MAX precision can size the buffer with this constant.
+ */
+#define MGRS_BUFFER_SIZE 18
+
+/*
+ * Encode a WGS84 lat/lon to an MGRS reference string.
+ *
+ * @param lat_e7    Latitude  scaled by 1e7 (matches gpsLocation_t.lat).
+ * @param lon_e7    Longitude scaled by 1e7 (matches gpsLocation_t.lon).
+ * @param precision Digits per axis, 0..MGRS_PRECISION_MAX.
+ *                    5 = 1 m, 4 = 10 m, 3 = 100 m, 2 = 1 km,
+ *                    1 = 10 km, 0 = 100 km (grid square only, no
+ *                    easting/northing groups in the output).
+ *                  Values above MGRS_PRECISION_MAX are clamped.
+ * @param out       Caller-supplied output buffer. Must hold at least
+ *                  MGRS_BUFFER_SIZE bytes for the worst case. Receives a
+ *                  NUL-terminated string on success, and a fixed
+ *                  placeholder ("--MGRS---" style) on failure.
+ *
+ * @return  true on success;
+ *          false if the latitude is outside the MGRS coverage band
+ *          (below 80S or above 84N — the polar UPS regions, which are
+ *          intentionally not supported on the flight controller).
+ */
+bool mgrsEncode(int32_t lat_e7, int32_t lon_e7, uint8_t precision, char *out);

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -558,3 +558,14 @@ INCLUDE_DIRS += $(LIB_MAIN_DIR)/$(OLC_DIR)
 SRC += $(OLC_DIR)/olc.c
 SIZE_OPTIMISED_SRC += $(OLC_DIR)/olc.c
 endif
+
+# Search path and source files for the MGRS forward-conversion library.
+# Compiled in size-optimised mode like OLC; the encoder is only called at
+# OSD redraw cadence so per-call cost is irrelevant — flash size matters more.
+MGRS_DIR := mgrs
+
+ifneq ($(MGRS_DIR),)
+INCLUDE_DIRS += $(LIB_MAIN_DIR)/$(MGRS_DIR)
+SRC += $(MGRS_DIR)/mgrs.c
+SIZE_OPTIMISED_SRC += $(MGRS_DIR)/mgrs.c
+endif

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1714,6 +1714,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_RANGEFINDER
     { "osd_lidar_dist_pos",         VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_LIDAR_DIST]) },
 #endif //USE_RANGEFINDER
+#ifdef USE_GPS_MGRS
+    { "osd_gps_mgrs_pos",           VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 0, OSD_POSCFG_MAX }, PG_OSD_ELEMENT_CONFIG, offsetof(osdElementConfig_t, item_pos[OSD_GPS_MGRS]) },
+#endif // USE_GPS_MGRS
 #endif // end of #ifdef USE_OSD
 
 // PG_SYSTEM_CONFIG

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -161,7 +161,7 @@ STATIC_ASSERT(OSD_POS_MAX == OSD_POS(63,31), OSD_POS_MAX_incorrect);
 
 PG_REGISTER_WITH_RESET_FN(osdConfig_t, osdConfig, PG_OSD_CONFIG, 12);
 
-PG_REGISTER_WITH_RESET_FN(osdElementConfig_t, osdElementConfig, PG_OSD_ELEMENT_CONFIG, 1);
+PG_REGISTER_WITH_RESET_FN(osdElementConfig_t, osdElementConfig, PG_OSD_ELEMENT_CONFIG, 2);
 
 // Controls the display order of the OSD post-flight statistics.
 // Adjust the ordering here to control how the post-flight stats are presented.

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -195,6 +195,7 @@ typedef enum {
     OSD_CUSTOM_MSG2,
     OSD_CUSTOM_MSG3,
     OSD_LIDAR_DIST,
+    OSD_GPS_MGRS,               // Military Grid Reference System position string
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -179,6 +179,11 @@
 #include "olc.h"
 #endif
 
+#ifdef USE_GPS_MGRS
+// located in lib/main/mgrs
+#include "mgrs.h"
+#endif
+
 #define AH_SYMBOL_COUNT 9
 #define AH_SIDEBAR_WIDTH_POS 7
 #define AH_SIDEBAR_HEIGHT_POS 3
@@ -1204,6 +1209,31 @@ static void osdElementGpsCoordinate(osdElementParms_t *element)
     }
 }
 
+#ifdef USE_GPS_MGRS
+// MGRS reference, eg "33UVT 12345 67890". Easier to radio back than decimal
+// degrees when recovering a downed aircraft because each group is short and
+// chunks the position into a 100 km cell + 1 km square + 1 m offset on a
+// printed military grid map. Only displayed once a fix has ever been
+// acquired; before that we show a placeholder of the same width so the
+// surrounding OSD layout doesn't reflow on first lock.
+static void osdElementGpsMgrs(osdElementParms_t *element)
+{
+    if (STATE(GPS_FIX_EVER)) {
+        // gpsSol.llh.lat / lon are already int32 scaled by 1e7, exactly the
+        // form mgrsEncode expects, so no conversion needed.
+        mgrsEncode(gpsSol.llh.lat, gpsSol.llh.lon, MGRS_PRECISION_MAX, element->buff);
+    } else {
+        memcpy(element->buff, "----- ----- -----", 17);
+        element->buff[17] = '\0';
+    }
+    if (STATE(GPS_FIX_EVER) && !STATE(GPS_FIX)) {
+        SET_BLINK(element->item); // had a fix, lost it — blink to flag stale data
+    } else {
+        CLR_BLINK(element->item);
+    }
+}
+#endif // USE_GPS_MGRS
+
 static void osdElementGpsSats(osdElementParms_t *element)
 {
     if ((STATE(GPS_FIX) == 0) || (gpsSol.numSat < GPS_MIN_SAT_COUNT) ) {
@@ -1986,6 +2016,9 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #ifdef USE_GPS
     [OSD_GPS_LON]                 = osdElementGpsCoordinate,
     [OSD_GPS_LAT]                 = osdElementGpsCoordinate,
+#ifdef USE_GPS_MGRS
+    [OSD_GPS_MGRS]                = osdElementGpsMgrs,
+#endif
 #endif
     [OSD_DEBUG]                   = osdElementDebug,
     [OSD_DEBUG2]                  = osdElementDebug2,
@@ -2140,6 +2173,9 @@ void osdAddActiveElements(void)
         osdAddActiveElement(OSD_HOME_DIR);
         osdAddActiveElement(OSD_FLIGHT_DIST);
         osdAddActiveElement(OSD_EFFICIENCY);
+#ifdef USE_GPS_MGRS
+        osdAddActiveElement(OSD_GPS_MGRS);
+#endif
     }
 #endif // GPS
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -662,6 +662,7 @@ extern struct linker_symbol __config_end;
 #ifndef USE_GPS
 #undef USE_GPS_PLUS_CODES
 #undef USE_GPS_LAP_TIMER
+#undef USE_GPS_MGRS
 #endif
 
 #ifdef USE_GPS_LAP_TIMER

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -261,6 +261,10 @@
 #define USE_GPS_PLUS_CODES
 #endif
 
+#if !defined(USE_GPS_MGRS)
+#define USE_GPS_MGRS
+#endif
+
 #if !defined(USE_LED_STRIP)
 #define USE_LED_STRIP
 #endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -22,6 +22,10 @@ include $(MAKE_SCRIPT_DIR)/system-id.mk
 
 VPATH := $(VPATH):$(USER_DIR):$(TEST_DIR)
 
+# Allow tests to depend on third-party / vendored sources under lib/main/.
+# Used by tests for libraries that ship as .c files (e.g. lib/main/mgrs/).
+LIB_MAIN_DIR := $(ROOT)/lib/main
+
 # specify which files that are included in the test in addition to the unittest file.
 # variables available:
 #   <test_name>_SRC
@@ -205,6 +209,13 @@ ledstrip_unittest_DEFINES := \
 maths_unittest_SRC := \
 		$(USER_DIR)/common/maths.c \
 		$(USER_DIR)/common/vector.c
+
+
+mgrs_unittest_SRC := \
+		$(LIB_MAIN_DIR)/mgrs/mgrs.c
+
+mgrs_unittest_INCLUDE_DIRS := \
+		$(LIB_MAIN_DIR)/mgrs
 
 
 motor_output_unittest_SRC := \
@@ -737,7 +748,8 @@ ifeq ($1,$(basename $1))
 # standard global test
 $1_OBJS = $(patsubst \
 	$(TEST_DIR)/%,$(OBJECT_DIR)/$1/%,$(patsubst \
-	$(USER_DIR)/%,$(OBJECT_DIR)/$1/%,$($1_SRC:=.o)))
+	$(USER_DIR)/%,$(OBJECT_DIR)/$1/%,$(patsubst \
+	$(LIB_MAIN_DIR)/%,$(OBJECT_DIR)/$1/lib_main/%,$($1_SRC:=.o))))
 else
 # test executed for each target, $1 has the form of test.target
 $1_SRC = $(addsuffix .o,$(call $(basename $1)_SRC,$(call target,$1)))
@@ -767,6 +779,16 @@ $(OBJECT_DIR)/$1/%.c.o: $(USER_DIR)/%.c
 
 $(OBJECT_DIR)/$1/%.c.o: $(TEST_DIR)/%.c
 	@echo "compiling test c file: $$<" "$(STDOUT)"
+	$(V1) mkdir -p $$(dir $$@)
+	$(V1) $(CC) $(C_FLAGS) $$(call test_cflags,$$($1_INCLUDE_DIRS)) \
+                $$(foreach def,$$($1_DEFINES),-D $$(def)) \
+                -c $$< -o $$@
+
+# Compile vendored / third-party sources from lib/main/ into a per-test
+# subdirectory so their object files don't collide with same-named
+# user-code sources from src/main/.
+$(OBJECT_DIR)/$1/lib_main/%.c.o: $(LIB_MAIN_DIR)/%.c
+	@echo "compiling lib_main: $$<" "$(STDOUT)"
 	$(V1) mkdir -p $$(dir $$@)
 	$(V1) $(CC) $(C_FLAGS) $$(call test_cflags,$$($1_INCLUDE_DIRS)) \
                 $$(foreach def,$$($1_DEFINES),-D $$(def)) \

--- a/src/test/unit/mgrs_unittest.cc
+++ b/src/test/unit/mgrs_unittest.cc
@@ -1,0 +1,237 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Unit tests for the MGRS forward encoder (lib/main/mgrs/).
+ *
+ * Test vectors are derived directly from the upstream proj4js/mgrs test
+ * suite (test/test.js). Each fixture below cites the matching proj4js
+ * expected string so the port stays verifiable against the same
+ * gold-standard outputs as the source library.
+ *
+ * The proj4js outputs are bare strings like "33UXP0500444997". Our port
+ * emits the OSD-friendly form "33UXP 05004 44997" (zero-padded 2-digit
+ * zone + space + 5-digit easting + space + 5-digit northing) — the
+ * fixture strings below are the proj4js outputs after that fixed
+ * transformation.
+ *
+ * Latitude / longitude are passed in as int32 scaled by 1e7 to match
+ * gpsLocation_t in src/main/io/gps.h.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+extern "C" {
+    #include "mgrs.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// --- Helpers -----------------------------------------------------------------
+
+// Convert a decimal-degree literal to the int32 1e-7 scale used by
+// gpsLocation_t. Wrapped in a function (not a macro) so floating-point
+// constants in the test file are evaluated at compile time.
+static int32_t deg_to_e7(double deg)
+{
+    // round-half-away-from-zero to match how a GPS receiver reports.
+    return (int32_t)(deg * 1.0e7 + (deg >= 0 ? 0.5 : -0.5));
+}
+
+// --- Mid-zone fixtures (proj4js test.js: "First MGRS set" — Vienna) ----------
+
+// proj4js: mgrs.toPoint('33UXP04')  -> [16.41450, 48.24949]
+// proj4js: mgrs.forward([16.41450, 48.24949])     -> '33UXP0500444997'
+// proj4js: mgrs.forward([16.41450, 48.24949], 1)  -> '33UXP04'
+// proj4js: mgrs.forward([16.41450, 48.24949], 0)  -> '33UXP'
+
+TEST(MgrsForward, ViennaPrecision5_OneMeter)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(48.24949), deg_to_e7(16.41450), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("33UXP 05004 44997", buf);
+}
+
+TEST(MgrsForward, ViennaPrecision1_TenKilometers)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(48.24949), deg_to_e7(16.41450), 1, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("33UXP 0 4", buf);
+}
+
+TEST(MgrsForward, ViennaPrecision0_GridSquareOnly)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(48.24949), deg_to_e7(16.41450), 0, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("33UXP", buf);
+}
+
+// --- Equator / Prime Meridian (proj4js test.js: "Second MGRS set") -----------
+
+// proj4js: mgrs.forward([0, 0], 5)        -> '31NAA6602100000'
+// proj4js: mgrs.forward([0, 0.00001], 5)  -> '31NAA6602100001'
+
+TEST(MgrsForward, EquatorPrimeMeridian_Precision5)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(0, 0, 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("31NAA 66021 00000", buf);
+}
+
+TEST(MgrsForward, JustNorthOfEquator_Precision5)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(0.00001), 0, 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("31NAA 66021 00001", buf);
+}
+
+// --- Western hemisphere mid-zone (proj4js test.js: "third mgrs set" — Las Vegas) ---
+
+// proj4js: mgrs.forward([-115.0820944, 36.2361322])     -> '11SPA7234911844'
+// proj4js: mgrs.forward([-115.0820944, 36.2361322], 0)  -> '11SPA'
+
+TEST(MgrsForward, LasVegasPrecision5_OneMeter)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(36.2361322), deg_to_e7(-115.0820944), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("11SPA 72349 11844", buf);
+}
+
+TEST(MgrsForward, LasVegasPrecision0_GridSquareOnly)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(36.2361322), deg_to_e7(-115.0820944), 0, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("11SPA", buf);
+}
+
+// --- Norwegian zone-32V exception ------------------------------------------
+// MGRS extends zone 32V westward to cover south-west Norway (lat 56..64, lon 3..12).
+// Without the exception, longitudes 3..6 would land in zone 31; the exception
+// reassigns the strip to 32. The reference strings below come from running
+// proj4js mgrs.forward() (the upstream library we ported) on the same inputs.
+
+TEST(MgrsForward, NorwayException_Lat60Lon5_IsZone32V)
+{
+    // proj4js: mgrs.forward([5, 60]) -> '32VKM7697958157'
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(60.0), deg_to_e7(5.0), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("32VKM 76979 58157", buf);
+}
+
+TEST(MgrsForward, NorwayException_Lat63Lon11_IsZone32V)
+{
+    // Cross-checks the upper-right corner of the Norway exception box.
+    // proj4js: mgrs.forward([11, 63]) -> '32VPQ0129387164'
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(63.0), deg_to_e7(11.0), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("32VPQ 01293 87164", buf);
+}
+
+TEST(MgrsForward, NorwayException_JustOutside_FallsToDefaultZone)
+{
+    // Sanity check: lat 55 is below the Norway exception band (which starts
+    // at 56), so longitude 5 stays in the default zone 31U. If we accidentally
+    // widened the exception, this test catches it.
+    // proj4js: mgrs.forward([5, 55]) -> '31UFA2792896620'
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(55.0), deg_to_e7(5.0), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("31UFA 27928 96620", buf);
+}
+
+// --- Svalbard zone exceptions ----------------------------------------------
+// Above 72 deg N, MGRS uses zones 31X/33X/35X/37X (each twice the normal width)
+// instead of the default 6-degree zones. These tests pin each special-case
+// branch separately so a regression in one cannot hide behind another.
+
+TEST(MgrsForward, SvalbardException_Lat78Lon8_IsZone31X)
+{
+    // Default zone for lon=8 would be 32; exception forces 31.
+    // proj4js: mgrs.forward([8, 78]) -> '31XFG1591463320'
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(78.0), deg_to_e7(8.0), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("31XFG 15914 63320", buf);
+}
+
+TEST(MgrsForward, SvalbardException_Lat78Lon10_IsZone33X)
+{
+    // Default zone for lon=10 would be 32; exception forces 33.
+    // proj4js: mgrs.forward([10, 78]) -> '33XUG8408563320'
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(78.0), deg_to_e7(10.0), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("33XUG 84085 63320", buf);
+}
+
+TEST(MgrsForward, SvalbardException_Lat78Lon35_IsZone37X)
+{
+    // Default zone for lon=35 would be 36; exception forces 37.
+    // proj4js: mgrs.forward([35, 78]) -> '37XDG0722961538'
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(78.0), deg_to_e7(35.0), 5, buf);
+    EXPECT_TRUE(ok);
+    EXPECT_STREQ("37XDG 07229 61538", buf);
+}
+
+// --- Polar bounds (proj4js test.js: "forward throws an error when latitude is near pole") ---
+
+// proj4js raises for latitudes outside [-80, 84]. Our port returns false
+// and writes a placeholder, since flight controllers can't throw.
+
+TEST(MgrsForward, NorthOfCoverage_ReturnsFalse)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(88.0), deg_to_e7(45.0), 5, buf);
+    EXPECT_FALSE(ok);
+}
+
+TEST(MgrsForward, SouthOfCoverage_ReturnsFalse)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(-88.0), deg_to_e7(45.0), 5, buf);
+    EXPECT_FALSE(ok);
+}
+
+// --- Buffer / size sanity ----------------------------------------------------
+
+// At MGRS_PRECISION_MAX (5), the longest output is 17 chars + NUL =
+// MGRS_BUFFER_SIZE bytes. Make sure the encoder doesn't write past that.
+// (We trust EXPECT_STREQ above to verify the *content*; this test pins the
+// invariant that the buffer-size constant is correct for what the encoder
+// produces.)
+
+TEST(MgrsForward, OutputFitsInDeclaredBufferSize)
+{
+    char buf[MGRS_BUFFER_SIZE] = {0};
+    const bool ok = mgrsEncode(deg_to_e7(48.24949), deg_to_e7(16.41450), MGRS_PRECISION_MAX, buf);
+    EXPECT_TRUE(ok);
+    // Strlen including NUL must not exceed our published buffer-size constant.
+    EXPECT_LE(strlen(buf) + 1, (size_t)MGRS_BUFFER_SIZE);
+}


### PR DESCRIPTION
> **Note:** This is a sibling of #15149, rebased onto the **2025.12.2 stable release line** instead of `master`/alpha. Same feature, same commits, adapted to the stable file context. Opened as draft for personal cloud-build flashing — not intended for upstream merge into the maintenance branch unless explicitly requested by maintainers.

## Summary
Adds a new OSD element `OSD_GPS_MGRS` that renders the current GPS fix as a Military Grid Reference System string, eg `33UVT 12345 67890`. MGRS is friendlier than decimal degrees in the field for downed-aircraft recovery — short, line-of-sight chunked (100 km cell → 1 km square → 1 m offset), and maps directly to printed military grid maps.

## Implementation
- `lib/main/mgrs/` — forward encoder ported from [proj4js/mgrs](https://github.com/proj4js/mgrs) (MIT, see `LICENSE`). Forward-only (the FC never decodes MGRS), `int32`-e7 inputs matching `gpsLocation_t`, no exceptions / allocations / errno.
- Inner math uses `double` for 1 m precision parity with the upstream library; mirrors the precedent already set by `USE_GPS_PLUS_CODES` which promotes lat/lon to `double` for `OLC_Encode` in `osd_elements.c`.
- New top-level OSD item `OSD_GPS_MGRS` with its own draw function `osdElementGpsMgrs`. Auto-added to active elements when the GPS sensor is present.
- Output is fixed-width `"NN Z SS DDDDD DDDDD"` (zone zero-padded for stable column width) so the OSD layout doesn't reflow on first fix; pre-fix placeholder keeps the same width.
- Gated by `USE_GPS_MGRS`, default-on in `target/common_pre.h` (mirrors `USE_GPS_PLUS_CODES`) and auto-undef'd in `common_post.h` when `USE_GPS` is off.
- Bumps `osdElementConfig` PG version 1 → 2 per the warning in `osd.h` (note: this differs from #15149 which bumps 3 → 4 because the stable line's existing version was 1).

## Test plan
- [x] Same code as #15149's tests (byte-identical encoder + 16 gtest cases). #15149's test suite passed 16/16.
- [x] Cherry-pick onto 2025.12.2 with 4 small structural conflicts (all master-only context absent from stable line — see commit-by-commit diffs for exact resolution).
- [ ] Cloud build via this PR's number for `DAKEFPVF405` — flashed and verified `GPS_MGRS` element renders correctly on OSD with live GPS fix.

## Notes
- `src/test/Makefile` adds the same generic `LIB_MAIN_DIR` shim as #15149.
- See #15149 for the master-targeted equivalent.
