### PR TITLE
Send 0x03 gps time CRSF message

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -95,6 +95,7 @@ static uint32_t lastGpsSolnTime;
 #endif
 #if defined(USE_CRSF_V3) && defined(USE_GPS)
 static timeUs_t lastGpsTimeFrameTime = (timeUs_t)(-30000000);  // Send GPS Time immediately, then every 30s thereafter while disarmed
+static uint32_t lastGpsTimeSolnTime;  // Keep separate GPS soln time to not delay normal GPS frames
 #endif
 #ifdef USE_BARO
 static uint32_t lastBaroTime;
@@ -989,11 +990,11 @@ static bool processCrsf(uint32_t currentTimeUs, uint32_t crsfLastCycleTime)
 #ifdef USE_GPS
 #if defined(USE_CRSF_V3)
 // Removed isCrsfV3Running check from GPS Time 0x03 message as it requires baudrate negotiation which ELRS does not perform
-    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && gpsSol.time != lastGpsSolnTime && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
+    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && gpsSol.time != lastGpsTimeSolnTime && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
         crsfInitializeFrame(dst);
         crsfFrameGpsTime(dst);
         crsfFinalize(dst);
-		lastGpsSolnTime = gpsSol.time;
+		lastGpsTimeSolnTime  = gpsSol.time;
         lastGpsTimeFrameTime = currentTimeUs;
         return true;
     }

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -86,7 +86,7 @@
 
 static bool crsfTelemetryEnabled;
 static bool deviceInfoReplyPending;
-static timeUs_t lastGpsTimeFrameTime = 0;
+static timeUs_t lastGpsTimeFrameTime = (timeUs_t)(-30000000);  // Send GPS Time immediately, then every 30s thereafter while disarmed
 #if defined(USE_CRSF_V3)
 static bool telemetryResponsePending;
 #endif

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -86,6 +86,7 @@
 
 static bool crsfTelemetryEnabled;
 static bool deviceInfoReplyPending;
+static timeUs_t lastGpsTimeFrameTime = 0;
 #if defined(USE_CRSF_V3)
 static bool telemetryResponsePending;
 #endif
@@ -985,11 +986,11 @@ static bool processCrsf(uint32_t currentTimeUs, uint32_t crsfLastCycleTime)
 
 #ifdef USE_GPS
 #if defined(USE_CRSF_V3)
-    if (isCrsfV3Running && crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && gpsSol.time != lastGpsSolnTime && gpsSol.dateTime.valid) {
+    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
         crsfInitializeFrame(dst);
         crsfFrameGpsTime(dst);
         crsfFinalize(dst);
-        crsfTimedSchedule &= ~BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX);
+        lastGpsTimeFrameTime = currentTimeUs;
         return true;
     }
     if (isCrsfV3Running && crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_EXTENDED_INDEX) && gpsSol.time != lastGpsSolnTime) {

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -986,10 +986,11 @@ static bool processCrsf(uint32_t currentTimeUs, uint32_t crsfLastCycleTime)
 
 #ifdef USE_GPS
 #if defined(USE_CRSF_V3)
-    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
+    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && gpsSol.time != lastGpsSolnTime && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
         crsfInitializeFrame(dst);
         crsfFrameGpsTime(dst);
         crsfFinalize(dst);
+		lastGpsSolnTime = gpsSol.time;
         lastGpsTimeFrameTime = currentTimeUs;
         return true;
     }

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -88,11 +88,13 @@ static bool crsfTelemetryEnabled;
 static bool deviceInfoReplyPending;
 #if defined(USE_CRSF_V3)
 static bool telemetryResponsePending;
-static timeUs_t lastGpsTimeFrameTime = (timeUs_t)(-30000000);  // Send GPS Time immediately, then every 30s thereafter while disarmed
 #endif
 static uint8_t crsfFrame[CRSF_FRAME_SIZE_MAX];
 #ifdef USE_GPS
 static uint32_t lastGpsSolnTime;
+#endif
+#if defined(USE_CRSF_V3) && defined(USE_GPS)
+static timeUs_t lastGpsTimeFrameTime = (timeUs_t)(-30000000);  // Send GPS Time immediately, then every 30s thereafter while disarmed
 #endif
 #ifdef USE_BARO
 static uint32_t lastBaroTime;

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -989,12 +989,11 @@ static bool processCrsf(uint32_t currentTimeUs, uint32_t crsfLastCycleTime)
 
 #ifdef USE_GPS
 #if defined(USE_CRSF_V3)
-// Removed isCrsfV3Running check from GPS Time 0x03 message as it requires baudrate negotiation which ELRS does not perform
-    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && gpsSol.time != lastGpsTimeSolnTime && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
+    if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && gpsSol.time != lastGpsTimeSolnTime && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) { // Removed isCrsfV3Running check from GPS Time 0x03 message as it requires baudrate negotiation which ELRS does not perform
         crsfInitializeFrame(dst);
         crsfFrameGpsTime(dst);
         crsfFinalize(dst);
-		lastGpsTimeSolnTime  = gpsSol.time;
+        lastGpsTimeSolnTime = gpsSol.time;
         lastGpsTimeFrameTime = currentTimeUs;
         return true;
     }

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -86,9 +86,9 @@
 
 static bool crsfTelemetryEnabled;
 static bool deviceInfoReplyPending;
-static timeUs_t lastGpsTimeFrameTime = (timeUs_t)(-30000000);  // Send GPS Time immediately, then every 30s thereafter while disarmed
 #if defined(USE_CRSF_V3)
 static bool telemetryResponsePending;
+static timeUs_t lastGpsTimeFrameTime = (timeUs_t)(-30000000);  // Send GPS Time immediately, then every 30s thereafter while disarmed
 #endif
 static uint8_t crsfFrame[CRSF_FRAME_SIZE_MAX];
 #ifdef USE_GPS

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -988,6 +988,7 @@ static bool processCrsf(uint32_t currentTimeUs, uint32_t crsfLastCycleTime)
 
 #ifdef USE_GPS
 #if defined(USE_CRSF_V3)
+// Removed isCrsfV3Running check from GPS Time 0x03 message as it requires baudrate negotiation which ELRS does not perform
     if (crsfTimedSchedule & BIT(CRSF_TIMED_FRAME_GPS_TIME_INDEX) && !ARMING_FLAG(ARMED) && gpsSol.dateTime.valid && gpsSol.time != lastGpsSolnTime && cmpTimeUs(currentTimeUs, lastGpsTimeFrameTime) > 30000000) {
         crsfInitializeFrame(dst);
         crsfFrameGpsTime(dst);


### PR DESCRIPTION
EdgeTX now supports setting the radio RTC from CRSF GPS Time frames (0x03), but Betaflight never sends them. The frame is gated behind isCrsfV3Running, which requires a CRSF V3 baud rate negotiation handshake that ELRS never initiates. Thus this message is never sent for ELRS receivers. 

The isCrsfV3Running gate is replaced with two narrower conditions: a check that the craft is disarmed (so that telemetry bandwidth is not wasted while flying), and at most one GPS Time frame is sent every 30 seconds. The first frame is sent immediately on GPS time validity rather than waiting for the initial 30s interval. The GPS Extended telemetry frame (0x06) is unchanged and remains gated behind isCrsfV3Running.

The 0x03 frame is 11 bytes. Using standard ELRS telemetry, this takes 3 OTA packets to deliver, so the low send rate is intentional to avoid consuming meaningful telemetry bandwidth for what is essentially a one-shot RTC sync.

Requires: https://github.com/EdgeTX/edgetx/pull/7317

Tested with the above EdgeTX PR and ELRS v4.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS time telemetry: transmissions now only occur when disarmed and the GPS fix is valid, require a changed GPS time, and are rate-limited (30s) to reduce duplicates and ensure accurate updates while preserving scheduled flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->