### PR TITLE
Fix QMC5883P

### DIFF
--- a/src/main/drivers/compass/compass_qmc5883.c
+++ b/src/main/drivers/compass/compass_qmc5883.c
@@ -126,14 +126,11 @@
 
 // Status register bits
 #define QMC5883P_STATUS_DATA_READY     0x01
-#define QMC5883P_STATUS_DATA_OVERRUN   0x02
+#define QMC5883P_STATUS_OVL            0x02  // magnetic field overflow (exceeds range), NOT data register locking
 
 // Special configuration registers and values
 #define QMC5883P_REG_XYZ_UNLOCK        0x29
 #define QMC5883P_XYZ_SIGN_CONFIG       0x06
-
-// Unlock register for data overrun recovery (uses Z_MSB register)
-#define QMC5883P_REG_DATA_UNLOCK       QMC5883P_REG_DATA_OUTPUT_Z_MSB
 
 // Default configuration for Betaflight
 #define QMC5883P_DEFAULT_CONF1         (QMC5883P_MODE_CONTINUOUS | QMC5883P_ODR_100HZ | QMC5883P_RNG_8G | QMC5883P_OSR1_8)
@@ -172,9 +169,9 @@ static const qmc_descriptor_t qmc5883p_desc = {
     .i2c_address = QMC5883P_I2C_ADDRESS,
     .reg_status = QMC5883P_REG_STATUS,
     .reg_data = QMC5883P_REG_DATA_OUTPUT_X,
-    .reg_data_unlock = QMC5883P_REG_DATA_UNLOCK,
+    .reg_data_unlock = 0,                       // P has no data register locking
     .status_data_ready_mask = QMC5883P_STATUS_DATA_READY,
-    .status_data_overrun_mask = QMC5883P_STATUS_DATA_OVERRUN,
+    .status_data_overrun_mask = 0,              // P has no DOR bit; bit 1 is OVL (magnetic overflow), not data lock
     .default_odr_hz = 100,
 };
 

--- a/src/main/drivers/compass/compass_qmc5883.c
+++ b/src/main/drivers/compass/compass_qmc5883.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#ifdef USE_MAG_QMC5883
+#if defined(USE_MAG_QMC5883L) || defined(USE_MAG_QMC5883P)
 
 #include "common/axis.h"
 #include "common/maths.h"
@@ -289,7 +289,7 @@ static bool qmc5883Read(magDev_t *magDev, int16_t *magData)
     return false;
 }
 
-static bool qmc5883lDetect(magDev_t *magDev)
+bool qmc5883lDetect(magDev_t *magDev)
 {
 
     extDevice_t *dev = &magDev->dev;
@@ -322,7 +322,7 @@ static bool qmc5883lDetect(magDev_t *magDev)
     return false;
 }
 
-static bool qmc5883pDetect(magDev_t *magDev)
+bool qmc5883pDetect(magDev_t *magDev)
 {
     extDevice_t *dev = &magDev->dev;
 
@@ -350,27 +350,6 @@ static bool qmc5883pDetect(magDev_t *magDev)
     magDev->init = qmc5883Init;
     magDev->read = qmc5883Read;
     return true;
-}
-
-static void resetI2CAddress(magDev_t *magDev)
-{
-    extDevice_t *dev = &magDev->dev;
-    if (dev->bus->busType == BUS_TYPE_I2C) {
-        dev->busType_u.i2c.address = 0; // ensure probe sets its default
-    }
-}
-
-bool qmc5883Detect(magDev_t *magDev)
-{
-    resetI2CAddress(magDev);
-    if (qmc5883lDetect(magDev)) {
-        return true;
-    }
-    resetI2CAddress(magDev);
-    if (qmc5883pDetect(magDev)) {
-        return true;
-    }
-    return false;
 }
 
 #endif

--- a/src/main/drivers/compass/compass_qmc5883.h
+++ b/src/main/drivers/compass/compass_qmc5883.h
@@ -22,5 +22,6 @@
 
 #include "drivers/io_types.h"
 
-bool qmc5883Detect(magDev_t *magDev);
+bool qmc5883lDetect(magDev_t *magDev);
+bool qmc5883pDetect(magDev_t *magDev);
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -134,7 +134,7 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
     compassConfig->mag_spi_csn = IO_TAG(MAG_CS_PIN);
     compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     compassConfig->mag_i2c_address = 0;
-#elif defined(USE_MAG_HMC5883) || defined(USE_MAG_QMC5883) || defined(USE_MAG_AK8975) || defined(USE_MAG_IST8310) || defined(USE_MAG_MMC560X) || (defined(USE_MAG_AK8963) && !(defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250)))
+#elif defined(USE_MAG_HMC5883) || defined(USE_MAG_QMC5883L) || defined(USE_MAG_QMC5883P) || defined(USE_MAG_AK8975) || defined(USE_MAG_IST8310) || defined(USE_MAG_MMC560X) || (defined(USE_MAG_AK8963) && !(defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250)))
     compassConfig->mag_busType = BUS_TYPE_I2C;
     compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(MAG_I2C_INSTANCE);
     compassConfig->mag_i2c_address = MAG_I2C_ADDRESS;
@@ -302,14 +302,27 @@ static bool compassDetect(magDev_t *magDev, uint8_t *alignment)
 #endif
         FALLTHROUGH;
 
-    case MAG_QMC5883:
-#ifdef USE_MAG_QMC5883
+    case MAG_QMC5883L:
+#ifdef USE_MAG_QMC5883L
         if (dev->bus->busType == BUS_TYPE_I2C) {
             dev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
 
-        if (qmc5883Detect(magDev)) {
-            magHardware = MAG_QMC5883;
+        if (qmc5883lDetect(magDev)) {
+            magHardware = MAG_QMC5883L;
+            break;
+        }
+#endif
+        FALLTHROUGH;
+
+    case MAG_QMC5883P:
+#ifdef USE_MAG_QMC5883P
+        if (dev->bus->busType == BUS_TYPE_I2C) {
+            dev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
+        }
+
+        if (qmc5883pDetect(magDev)) {
+            magHardware = MAG_QMC5883P;
             break;
         }
 #endif

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -40,12 +40,13 @@ typedef enum {
     MAG_HMC5883 = 2,
     MAG_AK8975 = 3,
     MAG_AK8963 = 4,
-    MAG_QMC5883 = 5,
+    MAG_QMC5883L = 5,
     MAG_LIS2MDL = 6,
     MAG_LIS3MDL = 7,
     MAG_MPU925X_AK8963 = 8,
     MAG_IST8310 = 9,
     MAG_MMC560X = 10,
+    MAG_QMC5883P = 11,
     MAG_HARDWARE_COUNT
 } magSensor_e;
 

--- a/src/main/sensors/sensors.c
+++ b/src/main/sensors/sensors.c
@@ -124,12 +124,13 @@ const char * const lookupTableMagHardware[MAG_HARDWARE_COUNT] = {
     [MAG_HMC5883] = "HMC5883",
     [MAG_AK8975] = "AK8975",
     [MAG_AK8963] = "AK8963",
-    [MAG_QMC5883] = "QMC5883",
+    [MAG_QMC5883L] = "QMC5883L",
     [MAG_LIS2MDL] = "LIS2MDL",
     [MAG_LIS3MDL] = "LIS3MDL",
     [MAG_MPU925X_AK8963] = "MPU925X_AK8963",
     [MAG_IST8310] = "IST8310",
-    [MAG_MMC560X] = "MMC560X"
+    [MAG_MMC560X] = "MMC560X",
+    [MAG_QMC5883P] = "QMC5883P"
 };
 
 // sync with rangefinderType_e

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -168,6 +168,14 @@
 #ifndef USE_MAG_QMC5883
 #define USE_MAG_QMC5883
 #endif
+#ifdef USE_MAG_QMC5883
+#ifndef USE_MAG_QMC5883L
+#define USE_MAG_QMC5883L
+#endif
+#ifndef USE_MAG_QMC5883P
+#define USE_MAG_QMC5883P
+#endif
+#endif
 #ifndef USE_MAG_LIS2MDL
 #define USE_MAG_LIS2MDL
 #endif


### PR DESCRIPTION
# QMC5883P Fix Plan

## Background

The QMC5883L and QMC5883P were unified into a single driver in commit `60a911254` (`compass_qmc5883.c`). The unification introduced a descriptor-based approach (`qmc_descriptor_t`) where both variants share common `qmc5883Init()` and `qmc5883Read()` functions, with variant-specific behavior driven by descriptor fields and `if (desc->variant == QMC_VARIANT_P)` checks.

Three issues have been identified.

---

## Issue 1: QMC5883L/P variants not reported separately -- DONE

### Problem

When a QMC5883P is detected, Betaflight reports it as `QMC5883` -- identical to the L variant. There is no way for the user (via CLI `status`, Configurator, or OSD) to know which chip was actually found. Additionally the L variant should be shown as `QMC5883L`, not the ambiguous `QMC5883`.

### Changes made

1. **`src/main/sensors/compass.h`** -- Renamed `MAG_QMC5883` to `MAG_QMC5883L` (value 5, unchanged), added `MAG_QMC5883P = 11` after `MAG_MMC560X = 10`.

2. **`src/main/sensors/sensors.c`** -- Updated lookup table: `[MAG_QMC5883L] = "QMC5883L"`, added `[MAG_QMC5883P] = "QMC5883P"`.

3. **`src/main/sensors/compass.c`** -- Split detection into two separate `case` blocks:
   - `case MAG_QMC5883L:` guarded by `#ifdef USE_MAG_QMC5883L`, calls `qmc5883lDetect()`
   - `case MAG_QMC5883P:` guarded by `#ifdef USE_MAG_QMC5883P`, calls `qmc5883pDetect()`
   - Updated bus config `#elif` to reference `USE_MAG_QMC5883L` and `USE_MAG_QMC5883P` instead of `USE_MAG_QMC5883`.

4. **`src/main/drivers/compass/compass_qmc5883.h`** -- Exports `qmc5883lDetect()` and `qmc5883pDetect()` instead of the unified `qmc5883Detect()`.

5. **`src/main/drivers/compass/compass_qmc5883.c`** -- Made `qmc5883lDetect()` and `qmc5883pDetect()` non-static. Removed `resetI2CAddress()` helper and unified `qmc5883Detect()` wrapper. Changed compilation guard to `#if defined(USE_MAG_QMC5883L) || defined(USE_MAG_QMC5883P)`.

6. **`src/main/target/common_post.h`** -- Kept `USE_MAG_QMC5883` as backwards-compatible umbrella. When defined, it now also defines `USE_MAG_QMC5883L` and `USE_MAG_QMC5883P`. Existing target configs that `#define USE_MAG_QMC5883` continue to work unchanged.

### Backwards compatibility

- **EEPROM**: `MAG_QMC5883L` retains value `5` (same as the old `MAG_QMC5883`), so existing configs with `mag_hardware = 5` will detect the L variant as before.
- **Build defines**: Existing target configs with `#define USE_MAG_QMC5883` continue to enable both variants via the `common_post.h` expansion. Targets can now also individually define `USE_MAG_QMC5883L` or `USE_MAG_QMC5883P` for finer control.
- **CLI**: `set mag_hardware = QMC5883L` (auto-detect tries L then P via fallthrough). `set mag_hardware = QMC5883P` forces P-only detection.

---

## Issue 2: Incorrect data overrun / unlock handling for QMC5883P -- DONE

### Problem

The QMC5883L status register (0x06) has three bits:
- Bit 0 `DRDY`: Data ready
- Bit 1 `OVL`: Magnetic field overflow (field exceeds measurement range)
- Bit 2 `DOR`: Data skipped -- new measurement completed before previous data was read. **Data output registers are locked** until the lock register (0x05, which is Z_MSB) is read.

The QMC5883P status register (0x09) has only two bits:
- Bit 0 `DRDY`: Data ready
- Bit 1 `OVL`: Overflow -- magnetic field exceeds measurement range

**The P does NOT have a DOR (data skipped/locked) bit.** The P's bit 1 (`OVL`) means magnetic overflow, NOT data register locking. Yet the current code maps it to `status_data_overrun_mask` and triggers a "data unlock" read of register 0x06 (Z_MSB), which is meaningless on the P.

Current problematic code in `qmc5883Read()`:
```c
} else if (status & desc->status_data_overrun_mask) {
    if (busReadRegisterBufferStart(dev, desc->reg_data_unlock, buf + sizeof(buf) - 1, 1)) {
        status = 0; // force status read next
    }
}
```

For the P variant, this fires on magnetic overflow (OVL), reads Z_MSB as an "unlock" (which does nothing), and wastes a read cycle. The actual OVL condition (magnetic saturation) goes unhandled.

### Changes made

1. **Removed** `QMC5883P_REG_DATA_UNLOCK` and `QMC5883P_STATUS_DATA_OVERRUN` defines.
2. **Renamed** the overflow define to `QMC5883P_STATUS_OVL` with a comment clarifying it means magnetic field overflow, not data register locking.
3. **Set** `.reg_data_unlock = 0` and `.status_data_overrun_mask = 0` in `qmc5883p_desc`. The data-overrun branch in `qmc5883Read()` (`else if (status & desc->status_data_overrun_mask)`) now never fires for P since `status & 0` is always false. The L variant is unchanged.

---

## Issue 3: 8 gauss range vs 2 gauss range -- TODO

### Problem

Both the L and P variants are configured with 8G range. Earth's magnetic field is approximately 0.25-0.65 gauss. The 2G range would provide 4x better resolution:
- 8G range: ~122 nT/LSB
- 2G range: ~30.5 nT/LSB

### Analysis

Possible reasons the 8G range was originally chosen:
1. **Copied from reference code** without explicit justification.
2. **Hard-iron offsets** from permanent magnets near the compass could push total field beyond 2G, causing clipping.
3. **Saturation protection** -- clipping produces wrong readings that confuse the heading estimator.

### Recommendation

Switching to 2G is worth investigating but needs hardware testing. A test build with 2G + debug logging of OVL events would determine if saturation is a practical concern.

---

## Summary

| File | Issue 1 | Issue 2 | Issue 3 |
|------|---------|---------|---------|
| `sensors/compass.h` | `MAG_QMC5883` -> `MAG_QMC5883L`, add `MAG_QMC5883P` | -- | -- |
| `sensors/sensors.c` | `"QMC5883L"`, `"QMC5883P"` strings | -- | -- |
| `sensors/compass.c` | Split detection, update bus config guards | -- | -- |
| `drivers/compass/compass_qmc5883.h` | Export L/P detect separately | -- | -- |
| `drivers/compass/compass_qmc5883.c` | Remove unified detect, update `#ifdef` | Zero out overrun fields, rename `STATUS_OVL` | Optional: `RNG_2G` |
| `target/common_post.h` | `USE_MAG_QMC5883` expands to L+P | -- | -- |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured QMC5883 magnetometer sensor support by splitting the previously unified hardware detection mechanism into two independent, variant-specific detection pathways for the L and P model variants. Each variant now features dedicated configuration and initialization handling to improve hardware identification accuracy, enhance detection precision, and strengthen compass sensor reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->