### PR TITLE
Improve OSD VTX information in non factory band

### DIFF
--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -82,9 +82,8 @@ void vtxCommonSetBandAndChannel(vtxDevice_t *vtxDevice, uint8_t band, uint8_t ch
     if (freq != 0) {
         selectedChannel = channel;
         selectedBand = band;
-        if (vtxTableIsFactoryBand[band - 1]) {
-            vtxDevice->vTable->setBandAndChannel(vtxDevice, band, channel);
-        } else {
+        vtxDevice->vTable->setBandAndChannel(vtxDevice, band, channel);
+        if (!vtxTableIsFactoryBand[band - 1]) {
             vtxDevice->vTable->setFrequency(vtxDevice, freq);
         }
     }

--- a/src/main/drivers/vtx_common.c
+++ b/src/main/drivers/vtx_common.c
@@ -82,8 +82,12 @@ void vtxCommonSetBandAndChannel(vtxDevice_t *vtxDevice, uint8_t band, uint8_t ch
     if (freq != 0) {
         selectedChannel = channel;
         selectedBand = band;
-        vtxDevice->vTable->setBandAndChannel(vtxDevice, band, channel);
-        if (!vtxTableIsFactoryBand[band - 1]) {
+        bool isSmartAudio = (vtxDevice->vTable->getDeviceType(vtxDevice) == VTXDEV_SMARTAUDIO);
+        bool isFactoryBand = vtxTableIsFactoryBand[band - 1];
+        if (!isSmartAudio || isFactoryBand) {
+            vtxDevice->vTable->setBandAndChannel(vtxDevice, band, channel);
+        }
+        if (!isFactoryBand) {
             vtxDevice->vTable->setFrequency(vtxDevice, freq);
         }
     }


### PR DESCRIPTION
When using the VTX with an MSP connection (like HDZERO), the current status is displayed on the OSD.
Configure channels and bands for devices other than the factory-band

<img width="476" height="332" alt="befor" src="https://github.com/user-attachments/assets/d90619ce-0748-4fa5-81f2-1ada4f283c09" />

<img width="478" height="336" alt="after" src="https://github.com/user-attachments/assets/28ce8704-7c02-4b08-a831-4acb348c25d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video transmitter band/channel setting logic to handle SmartAudio devices and factory vs. non-factory bands correctly, reducing incorrect frequency selections and improving switching reliability for non-standard bands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->