### PR TITLE
STM32C5: document why ICACHE is intentionally left disabled

### DIFF
--- a/src/platform/STM32/system_stm32c5xx.c
+++ b/src/platform/STM32/system_stm32c5xx.c
@@ -130,6 +130,27 @@ void systemInit(void)
     // call it here instead -- by this point .data is live.
     HAL_Init();
 
+    // ICACHE is intentionally left at reset default (disabled) on STM32C5.
+    //
+    // Despite the name, ICACHE on Cortex-M33 sits on the C-AHB code bus
+    // and caches *anything* fetched through it -- not only instructions.
+    // SRAM accessed via the code-region alias (addresses below 0x2000_0000)
+    // and const data in flash both go through ICACHE; the system-bus alias
+    // (0x2000_xxxx) bypasses it. ICACHE has only one maintenance op (full
+    // invalidate), so per-region exclusion via MPU is the only knob.
+    //
+    // Enabling it here without an audit risks:
+    //   - stale reads from DMA buffers reached via the code-region alias
+    //     (DMA writes are not snooped by ICACHE);
+    //   - stale flash reads from regions that change at runtime (option
+    //     bytes after a write, OTP, anything reprogrammed by a bootloader
+    //     path).
+    //
+    // Before turning this on a future change must (a) confirm SRAM access
+    // always uses the system-bus alias, (b) add MPU non-cacheable regions
+    // for OTP and any runtime-rewritten flash per ST guidance, and
+    // (c) audit DMA buffer access patterns.
+
     // Configure NVIC preempt/priority groups (CMSIS direct, HAL2 has no wrapper)
     NVIC_SetPriorityGrouping(NVIC_PRIORITY_GROUPING);
 


### PR DESCRIPTION
## Summary

Adds a rationale block in `systemInit()` at the natural seam where `HAL_ICACHE_Enable()` would be added.

Follows up on review feedback from @SteveCEvans on #15172: ICACHE on Cortex-M33 is *not* an instruction-only cache despite the name -- it sits on the C-AHB code bus and caches anything fetched through it, including SRAM via the code-region alias (addresses below `0x2000_0000`) and `const` data in flash. The current C5 bring-up leaves ICACHE at reset default (off), which is correct, but nothing in the code explains *why* -- so a future "free perf win" enable can silently corrupt DMA buffer reads (DMA writes aren't snooped by ICACHE) or flash regions that change at runtime (option bytes after a write, OTP, anything reprogrammed by a bootloader path).

The new comment block:
- States ICACHE is intentionally disabled.
- Explains the M33 ICACHE behaviour (caches data on C-AHB, not just instructions).
- Lists the realistic failure modes if it were enabled blindly.
- Lists the audit steps required before turning it on (system-bus alias only; MPU non-cacheable regions for OTP/runtime-rewritten flash; DMA buffer access pattern audit).

Comment-only change -- no functional impact.

cc @SteveCEvans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced system initialization documentation with detailed guidance on ICACHE configuration, including important considerations for DMA buffer coherency and aliased memory access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->