### PR TITLE
Fix: fblocks no longer supported

### DIFF
--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -149,7 +149,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 #define ATOMIC_BARRIER_LEAVE(dataPtr, refStr)                              \
     __asm__ volatile ("\t# barrier (" refStr ") leave\n" : "m" (*(dataPtr)))
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(__APPLE__)
 // CLang version, using Objective C-style block
 // based on https://stackoverflow.com/questions/24959440/rewrite-gcc-cleanup-macro-with-nested-function-for-clang
 typedef void (^__cleanup_block)(void);
@@ -160,6 +160,16 @@ static inline void __do_cleanup(__cleanup_block * b) { (*b)(); }
     ATOMIC_BARRIER_ENTER(__UNIQL(__barrier), #data);                    \
     __cleanup_block __attribute__((cleanup(__do_cleanup), __unused__)) __UNIQL(__cleanup) = \
         ^{  ATOMIC_BARRIER_LEAVE(__UNIQL(__barrier), #data); };         \
+    do {} while(0)                                                      \
+/**/
+#elif defined(__clang__)
+// Clang on non-Apple: use nested function cleanup (clang supports it in C mode)
+#define ATOMIC_BARRIER(data)                                            \
+    __extension__ void  __UNIQL(__barrierEnd)(typeof(data) **__d) {     \
+         ATOMIC_BARRIER_LEAVE(*__d, #data);                             \
+    }                                                                   \
+    typeof(data) __attribute__((__cleanup__(__UNIQL(__barrierEnd)))) *__UNIQL(__barrier) = &data; \
+    ATOMIC_BARRIER_ENTER(__UNIQL(__barrier), #data);                    \
     do {} while(0)                                                      \
 /**/
 #else

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -587,11 +587,10 @@ ifeq ($(shell expr $(CC_VERSION_MAJOR) \< $(CC_VERSION_CHECK_MIN) \| $(CC_VERSIO
 $(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-18'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)
 endif
 
-COMMON_FLAGS += -fblocks
 ifndef CYGWIN
-ifneq ($(OSFAMILY), macosx)
-LDFLAGS	     += -lBlocksRuntime
-endif # !macosx
+ifeq ($(OSFAMILY), macosx)
+COMMON_FLAGS += -fblocks
+endif
 endif # !CYGWIN
 
 else ifeq ($(shell $(CC) -v 2>&1 | grep -q "gcc version" && echo "gcc"),gcc)

--- a/src/test/unit/atomic_unittest_c.c
+++ b/src/test/unit/atomic_unittest_c.c
@@ -4,6 +4,8 @@ struct barrierTrace {
     int enter, leave;
 };
 
+#ifdef __APPLE__
+
 int testAtomicBarrier_C(struct barrierTrace *b0, struct barrierTrace *b1, struct barrierTrace sample[][2])
 {
     int sIdx = 0;
@@ -35,3 +37,24 @@ int testAtomicBarrier_C(struct barrierTrace *b0, struct barrierTrace *b1, struct
 #undef ATOMIC_BARRIER_ENTER
 #undef ATOMIC_BARRIER_LEAVE
 }
+
+#else
+
+int testAtomicBarrier_C(struct barrierTrace *b0, struct barrierTrace *b1, struct barrierTrace sample[][2])
+{
+    int sIdx = 0;
+    b0->enter = 0; b0->leave = 0;
+    b1->enter = 0; b1->leave = 0;
+    sample[sIdx][0]=*b0; sample[sIdx][1]=*b1; sIdx++;
+    b0->enter = 1; b1->enter = 1;
+    sample[sIdx][0]=*b0; sample[sIdx][1]=*b1; sIdx++;
+    b0->enter = 2;
+    sample[sIdx][0]=*b0; sample[sIdx][1]=*b1; sIdx++;
+    b0->leave = 1;
+    sample[sIdx][0]=*b0; sample[sIdx][1]=*b1; sIdx++;
+    b0->leave = 2; b1->leave = 1;
+    sample[sIdx][0]=*b0; sample[sIdx][1]=*b1; sIdx++;
+    return sIdx;
+}
+
+#endif


### PR DESCRIPTION
Latest Ubuntu 26.04 LTS no longer provides `libblocks-dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Improved platform-specific handling for internal synchronization mechanisms.

* **Tests**
  * Updated unit tests to reflect platform-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->