### PR TITLE
usb: derive product name from BOARD_NAME when a config is built

### DIFF
--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -26,6 +26,14 @@
 #include "config.h"
 #endif
 
+// USB product name: prefer BOARD_NAME from config.h; otherwise fall back to
+// the target-specific USBD_PRODUCT_STRING defined in target.h.
+#if defined(BOARD_NAME) && !defined(USBD_PRODUCT_STRING)
+#define USBD_PRODUCT_STRINGIFY_(x) #x
+#define USBD_PRODUCT_STRINGIFY(x) USBD_PRODUCT_STRINGIFY_(x)
+#define USBD_PRODUCT_STRING "Betaflight - " USBD_PRODUCT_STRINGIFY(BOARD_NAME)
+#endif
+
 #include "target/common_pre.h"
 
 // MCU specific platform from platform/X

--- a/src/platform/APM32/target/APM32F405/target.h
+++ b/src/platform/APM32/target/APM32F405/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight APM32F405"
+#define USBD_PRODUCT_STRING     "Betaflight - APM32F405"
 #endif
 
 #ifndef APM32F405

--- a/src/platform/APM32/target/APM32F407/target.h
+++ b/src/platform/APM32/target/APM32F407/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight APM32F407"
+#define USBD_PRODUCT_STRING     "Betaflight - APM32F407"
 #endif
 
 #ifndef APM32F407

--- a/src/platform/AT32/target/AT32F435G/target.h
+++ b/src/platform/AT32/target/AT32F435G/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight AT32F435"
+#define USBD_PRODUCT_STRING     "Betaflight - AT32F435"
 #endif
 
 #ifndef AT32F435

--- a/src/platform/AT32/target/AT32F435M/target.h
+++ b/src/platform/AT32/target/AT32F435M/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight AT32F435"
+#define USBD_PRODUCT_STRING     "Betaflight - AT32F435"
 #endif
 
 #ifndef AT32F435

--- a/src/platform/ESP32/target/ESP32S3/target.h
+++ b/src/platform/ESP32/target/ESP32S3/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight ESP32S3"
+#define USBD_PRODUCT_STRING     "Betaflight - ESP32S3"
 #endif
 
 #define USE_UART0

--- a/src/platform/ESP32/target/ESP32WROOM/target.h
+++ b/src/platform/ESP32/target/ESP32WROOM/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight ESP32-WROOM"
+#define USBD_PRODUCT_STRING     "Betaflight - ESP32-WROOM"
 #endif
 
 #define USE_UART0

--- a/src/platform/PICO/target/RP2350A/target.h
+++ b/src/platform/PICO/target/RP2350A/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight RP2350A"
+#define USBD_PRODUCT_STRING     "Betaflight - RP2350A"
 #endif
 
 #ifdef PICO_TRACE

--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight RP2350B"
+#define USBD_PRODUCT_STRING     "Betaflight - RP2350B"
 #endif
 
 #ifdef PICO_TRACE

--- a/src/platform/STM32/target/STM32C591/target.h
+++ b/src/platform/STM32/target/STM32C591/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32C591"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32C591"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/platform/STM32/target/STM32F405/target.h
+++ b/src/platform/STM32/target/STM32F405/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F405"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F405"
 #endif
 
 #ifndef STM32F405

--- a/src/platform/STM32/target/STM32F411/target.h
+++ b/src/platform/STM32/target/STM32F411/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F411"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F411"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/platform/STM32/target/STM32F446/target.h
+++ b/src/platform/STM32/target/STM32F446/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING             "Betaflight STM32F446"
+#define USBD_PRODUCT_STRING             "Betaflight - STM32F446"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/platform/STM32/target/STM32F745/target.h
+++ b/src/platform/STM32/target/STM32F745/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F745"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F745"
 #endif
 
 #ifndef STM32F745

--- a/src/platform/STM32/target/STM32F7X2/target.h
+++ b/src/platform/STM32/target/STM32F7X2/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F722"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F722"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/platform/STM32/target/STM32G47X/target.h
+++ b/src/platform/STM32/target/STM32G47X/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32G473"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32G473"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/platform/STM32/target/STM32H562/target.h
+++ b/src/platform/STM32/target/STM32H562/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H562"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H562"
 #endif
 
 //#undef USE_PWM

--- a/src/platform/STM32/target/STM32H563/target.h
+++ b/src/platform/STM32/target/STM32H563/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H563"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H563"
 #endif
 
 //#undef USE_PWM

--- a/src/platform/STM32/target/STM32H723/target.h
+++ b/src/platform/STM32/target/STM32H723/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H723"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H723"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/platform/STM32/target/STM32H725/target.h
+++ b/src/platform/STM32/target/STM32H725/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H725"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H725"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/platform/STM32/target/STM32H730/target.h
+++ b/src/platform/STM32/target/STM32H730/target.h
@@ -40,7 +40,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H730"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H730"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/platform/STM32/target/STM32H735/target.h
+++ b/src/platform/STM32/target/STM32H735/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H735"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H735"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/platform/STM32/target/STM32H743/target.h
+++ b/src/platform/STM32/target/STM32H743/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H743"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H743"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/platform/STM32/target/STM32H750/target.h
+++ b/src/platform/STM32/target/STM32H750/target.h
@@ -40,7 +40,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H750"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H750"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/platform/STM32/target/STM32N657/target.h
+++ b/src/platform/STM32/target/STM32N657/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32N657"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32N657"
 #endif
 
 #define USE_I2C_DEVICE_1


### PR DESCRIPTION
## Summary
- USB product string now follows the format `Betaflight - <name>`.
- When building with `CONFIG=`, `<name>` is taken from `BOARD_NAME` in the config header, so the device identifies as the actual board (e.g. `Betaflight - AIKONF4V2`) rather than the underlying MCU.
- Plain `TARGET=` builds keep the MCU-based fallback (e.g. `Betaflight - STM32F411`); the format has been normalised across all target headers for consistency.

The override is centralised in `src/main/platform.h` immediately after `config.h` is included; each target's `#ifndef USBD_PRODUCT_STRING` guard then defers to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized USB device product names across all supported hardware targets using a consistent hyphen-separated format for improved clarity when identifying devices in system lists and configuration tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->