### PR TITLE
GPS: add fast-path for UBX_PARSE_PAYLOAD_CONTENT state

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2627,8 +2627,25 @@ static bool UBLOX_parse_gps(void)
 
 static bool gpsNewFrameUBLOX(uint8_t data)
 {
-    bool newPositionDataReceived = false;
     ubloxParsingAlmostDone = false;
+
+    // Fast path for payload content — this is the hot loop state, hit once per payload byte (up to 392 times for NAV-SAT).
+    // Handling it before the switch avoids the jump table lookup for the vast majority of bytes in a message.
+    if (ubxFrameParseState == UBX_PARSE_PAYLOAD_CONTENT) {
+        ubxRcvMsgChecksumB += (ubxRcvMsgChecksumA += data);   // Accumulate both checksums.
+        if (ubxFrameParsePayloadCounter < UBLOX_PAYLOAD_SIZE) {
+            // Only add bytes to the buffer if we haven't reached the max supported payload size.
+            // Note that we still read & checksum every byte so the checksum calculates correctly.
+            ubxRcvMsgPayload.rawBytes[ubxFrameParsePayloadCounter] = data;
+        }
+        if (++ubxFrameParsePayloadCounter >= ubxRcvMsgPayloadLength) {
+            // All bytes for payload length processed.
+            ubxFrameParseState = UBX_PARSE_CHECKSUM_A;
+        }
+        return false;
+    }
+
+    bool newPositionDataReceived = false;
 
     switch (ubxFrameParseState) {
     case UBX_PARSE_PREAMBLE_SYNC_1:
@@ -2693,18 +2710,7 @@ static bool gpsNewFrameUBLOX(uint8_t data)
         ubxFrameParseState = UBX_PARSE_PAYLOAD_CONTENT;
         break;
     case UBX_PARSE_PAYLOAD_CONTENT:
-        ubxRcvMsgChecksumB += (ubxRcvMsgChecksumA += data);   // Accumulate both checksums.
-        if (ubxFrameParsePayloadCounter < UBLOX_PAYLOAD_SIZE) {
-            // Only add bytes to the buffer if we haven't reached the max supported payload size.
-            // Note that we still read & checksum every byte so the checksum calculates correctly.
-            ubxRcvMsgPayload.rawBytes[ubxFrameParsePayloadCounter] = data;
-        }
-        if (++ubxFrameParsePayloadCounter >= ubxRcvMsgPayloadLength) {
-            // All bytes for payload length processed.
-            ubxFrameParseState = UBX_PARSE_CHECKSUM_A;
-            break;
-        }
-        // More payload content left, stay in this state.
+        // Handled by the fast path above; this case is unreachable but kept for enum completeness.
         break;
     case UBX_PARSE_CHECKSUM_A:
         if (ubxRcvMsgChecksumA == data) {


### PR DESCRIPTION
`UBX_PARSE_PAYLOAD_CONTENT` is the only state that repeats many times per frame it's worth extract the corresponding block into the fastpath.
Reasoning: for one UBX packet, the parser sees roughly:
```
PREAMBLE_SYNC_1         1 byte
PREAMBLE_SYNC_2         1 byte
MESSAGE_CLASS           1 byte
MESSAGE_ID              1 byte
PAYLOAD_LENGTH_LSB      1 byte
PAYLOAD_LENGTH_MSB      1 byte
PAYLOAD_CONTENT         92 bytes for NAV-PVT, up to ~392 bytes for NAV-SAT
CHECKSUM_A              1 byte
CHECKSUM_B              1 byte
```
So the non-payload cases are hit once each per packet. The payload case is hit for almost the entire packet. That makes it the hot state.
Extracting it means the common path becomes:
```
if (ubxFrameParseState == UBX_PARSE_PAYLOAD_CONTENT) {
    ...
    return false;
}
```
instead of entering the full switch dispatch for every payload byte.
Roughly, for a 32-sat NAV-SAT, payload is 8 + 12 * 32 = 392 bytes. Total packet is about 400 bytes. That means about 98% of bytes are payload bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized GPS UBX payload parsing to process payload bytes more efficiently, reducing per-byte overhead. This improves parsing throughput, lowers CPU use during GPS frame handling, and speeds recognition of new position data, resulting in more responsive and reliable GPS updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->