### PR TITLE
failsafe: add BOXFAILSAFELAND mode to override procedure to Land

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1090,7 +1090,7 @@ void processRxModes(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_GPS_RESCUE
-    if (ARMING_FLAG(ARMED) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
+    if (ARMING_FLAG(ARMED) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE) || (failsafeIsActive() && getEffectiveFailsafeProcedure() == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
         if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -83,6 +83,7 @@ typedef enum {
     BOXBEEPERMUTE,
     BOXREADY,
     BOXLAPTIMERRESET,
+    BOXFAILSAFELAND,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -140,15 +140,20 @@ bool failsafeIsActive(void) // real or BOXFAILSAFE induced stage 2 failsafe is c
 }
 
 // Returns the failsafe procedure to run on RX-loss stage 2.
-// When BOXFAILSAFELAND is mapped and active, the configured procedure is
-// overridden to AUTO_LANDING so pilots can disable GPS Rescue from the radio
-// (e.g. when flying indoors). The switch state is sampled at stage 2 entry.
+// While failsafe is active, returns the value latched at stage 2 entry so that
+// flipping BOXFAILSAFELAND mid-failsafe does not desync the state machine from
+// the GPS_RESCUE_MODE flight flag in core.c.
+// Outside an active failsafe, BOXFAILSAFELAND overrides the configured
+// procedure to AUTO_LANDING so pilots can disable GPS Rescue from the radio.
 failsafeProcedure_e getEffectiveFailsafeProcedure(void)
 {
+    if (failsafeState.active) {
+        return failsafeState.activeProcedure;
+    }
     if (IS_RC_MODE_ACTIVE(BOXFAILSAFELAND)) {
         return FAILSAFE_PROCEDURE_AUTO_LANDING;
     }
-    return failsafeConfig()->failsafe_procedure;
+    return (failsafeProcedure_e)failsafeConfig()->failsafe_procedure;
 }
 
 void failsafeStartMonitoring(void)
@@ -329,7 +334,12 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                 } else {
                     failsafeState.active = true;
                     failsafeState.events++;
-                    switch (getEffectiveFailsafeProcedure()) {
+                    // Latch the procedure at stage 2 entry so that toggling BOXFAILSAFELAND mid-failsafe
+                    // cannot desync the state machine from core.c's GPS_RESCUE_MODE flight-flag gating.
+                    failsafeState.activeProcedure = IS_RC_MODE_ACTIVE(BOXFAILSAFELAND)
+                        ? FAILSAFE_PROCEDURE_AUTO_LANDING
+                        : (failsafeProcedure_e)failsafeConfig()->failsafe_procedure;
+                    switch (failsafeState.activeProcedure) {
                         case FAILSAFE_PROCEDURE_AUTO_LANDING:
                             //  Enter Stage 2 with settings for landing mode
                             ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
@@ -349,6 +359,11 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                             break;
 #endif
                         case FAILSAFE_PROCEDURE_COUNT:
+                        default:
+                            // unreachable in practice (config is clamped) but reprocessState is set
+                            // unconditionally below, so guarantee a terminal phase to avoid spinning
+                            ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
+                            failsafeState.phase = FAILSAFE_LANDED;
                             break;
                     }
                     if (failsafeState.boxFailsafeSwitchWasOn) {

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -139,6 +139,18 @@ bool failsafeIsActive(void) // real or BOXFAILSAFE induced stage 2 failsafe is c
     return failsafeState.active;
 }
 
+// Returns the failsafe procedure to run on RX-loss stage 2.
+// When BOXFAILSAFELAND is mapped and active, the configured procedure is
+// overridden to AUTO_LANDING so pilots can disable GPS Rescue from the radio
+// (e.g. when flying indoors). The switch state is sampled at stage 2 entry.
+failsafeProcedure_e getEffectiveFailsafeProcedure(void)
+{
+    if (IS_RC_MODE_ACTIVE(BOXFAILSAFELAND)) {
+        return FAILSAFE_PROCEDURE_AUTO_LANDING;
+    }
+    return failsafeConfig()->failsafe_procedure;
+}
+
 void failsafeStartMonitoring(void)
 {
     failsafeState.monitoring = true;
@@ -282,7 +294,7 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                     } else if (!receivingRxData) {
                         if (millis() > failsafeState.throttleLowPeriod
 #ifdef USE_GPS_RESCUE
-                            && failsafeConfig()->failsafe_procedure != FAILSAFE_PROCEDURE_GPS_RESCUE
+                            && getEffectiveFailsafeProcedure() != FAILSAFE_PROCEDURE_GPS_RESCUE
 #endif
                             ) {
                             //  JustDisarm if throttle was LOW for at least 'failsafe_throttle_low_delay' before failsafe
@@ -317,7 +329,7 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                 } else {
                     failsafeState.active = true;
                     failsafeState.events++;
-                    switch (failsafeConfig()->failsafe_procedure) {
+                    switch (getEffectiveFailsafeProcedure()) {
                         case FAILSAFE_PROCEDURE_AUTO_LANDING:
                             //  Enter Stage 2 with settings for landing mode
                             ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
@@ -336,6 +348,8 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                             failsafeState.phase = FAILSAFE_GPS_RESCUE;
                             break;
 #endif
+                        case FAILSAFE_PROCEDURE_COUNT:
+                            break;
                     }
                     if (failsafeState.boxFailsafeSwitchWasOn) {
                         failsafeState.receivingRxDataPeriodPreset = 0;

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -114,6 +114,7 @@ void failsafeReset(void)
     failsafeState.phase = FAILSAFE_IDLE;
     failsafeState.rxLinkState = FAILSAFE_RXLINK_DOWN;
     failsafeState.boxFailsafeSwitchWasOn = false;
+    failsafeState.activeProcedure = FAILSAFE_PROCEDURE_AUTO_LANDING;
 }
 
 void failsafeInit(void)
@@ -145,14 +146,18 @@ bool failsafeIsActive(void) // real or BOXFAILSAFE induced stage 2 failsafe is c
 // the GPS_RESCUE_MODE flight flag in core.c.
 // Outside an active failsafe, BOXFAILSAFELAND overrides the configured
 // procedure to AUTO_LANDING so pilots can disable GPS Rescue from the radio.
+// The override only exists on USE_GPS_RESCUE builds; otherwise it would silently
+// reroute DROP_IT to AUTO_LANDING with no GPS-rescue alternative to suppress.
 failsafeProcedure_e getEffectiveFailsafeProcedure(void)
 {
     if (failsafeState.active) {
         return failsafeState.activeProcedure;
     }
+#ifdef USE_GPS_RESCUE
     if (IS_RC_MODE_ACTIVE(BOXFAILSAFELAND)) {
         return FAILSAFE_PROCEDURE_AUTO_LANDING;
     }
+#endif
     return (failsafeProcedure_e)failsafeConfig()->failsafe_procedure;
 }
 
@@ -343,9 +348,13 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                     failsafeState.events++;
                     // Latch the procedure at stage 2 entry so that toggling BOXFAILSAFELAND mid-failsafe
                     // cannot desync the state machine from core.c's GPS_RESCUE_MODE flight-flag gating.
+#ifdef USE_GPS_RESCUE
                     failsafeState.activeProcedure = IS_RC_MODE_ACTIVE(BOXFAILSAFELAND)
                         ? FAILSAFE_PROCEDURE_AUTO_LANDING
                         : (failsafeProcedure_e)failsafeConfig()->failsafe_procedure;
+#else
+                    failsafeState.activeProcedure = (failsafeProcedure_e)failsafeConfig()->failsafe_procedure;
+#endif
                     switch (failsafeState.activeProcedure) {
                         case FAILSAFE_PROCEDURE_AUTO_LANDING:
                             //  Enter Stage 2 with settings for landing mode

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -289,6 +289,10 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                     if (failsafeState.boxFailsafeSwitchWasOn && (failsafeConfig()->failsafe_switch_mode == FAILSAFE_SWITCH_MODE_KILL)) {
                         // Failsafe switch is configured as KILL switch and is switched ON
                         failsafeState.active = true;
+                        // KILL bypasses procedure dispatch and goes straight to LANDED;
+                        // overwrite the latch so getEffectiveFailsafeProcedure() cannot
+                        // return a stale GPS_RESCUE value carried over from a prior failsafe.
+                        failsafeState.activeProcedure = FAILSAFE_PROCEDURE_AUTO_LANDING;
                         failsafeState.events++;
                         ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
                         failsafeState.phase = FAILSAFE_LANDED;
@@ -305,6 +309,9 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                             //  JustDisarm if throttle was LOW for at least 'failsafe_throttle_low_delay' before failsafe
                             //  protects against false arming when the Tx is powered up after the quad
                             failsafeState.active = true;
+                            // JustDisarm also bypasses procedure dispatch; overwrite the latch
+                            // for the same reason as the KILL path above.
+                            failsafeState.activeProcedure = FAILSAFE_PROCEDURE_AUTO_LANDING;
                             failsafeState.events++;
                             ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
                             failsafeState.phase = FAILSAFE_LANDED;

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -91,6 +91,7 @@ typedef struct failsafeState_s {
     failsafePhase_e phase;
     failsafeRxLinkState_e rxLinkState;
     bool boxFailsafeSwitchWasOn;
+    failsafeProcedure_e activeProcedure;    // latched at stage 2 entry; valid while failsafeState.active
 } failsafeState_t;
 
 void failsafeInit(void);

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -101,6 +101,7 @@ void failsafeUpdateState(void);
 void failsafeCheckDataFailurePeriod(void);
 
 failsafePhase_e failsafePhase(void);
+failsafeProcedure_e getEffectiveFailsafeProcedure(void);
 bool failsafeIsMonitoring(void);
 bool failsafeIsActive(void);
 bool failsafeIsReceivingRxData(void);

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -102,7 +102,8 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
     { .boxId = BOXREADY, .boxName = "READY", .permanentId = 53},
     { .boxId = BOXLAPTIMERRESET, .boxName = "LAP TIMER RESET", .permanentId = 54},
     { .boxId = BOXCHIRP, .boxName = "CHIRP", .permanentId = 55},
-    { .boxId = BOXAUTOPILOT, .boxName = "AUTOPILOT", .permanentId = 56}
+    { .boxId = BOXAUTOPILOT, .boxName = "AUTOPILOT", .permanentId = 56},
+    { .boxId = BOXFAILSAFELAND, .boxName = "FAILSAFE LAND", .permanentId = 57}
 };
 
 // mask of enabled IDs, calculated on startup based on enabled features. boxId_e is used as bit index
@@ -261,6 +262,7 @@ void initActiveBoxIds(void)
 #endif
 
     BME(BOXFAILSAFE);
+    BME(BOXFAILSAFELAND);
 
     if (mixerConfig()->mixerMode == MIXER_FLYING_WING || mixerConfig()->mixerMode == MIXER_AIRPLANE || mixerConfig()->mixerMode == MIXER_CUSTOM_AIRPLANE) {
         BME(BOXPASSTHRU);

--- a/src/main/msp/msp_box.c
+++ b/src/main/msp/msp_box.c
@@ -262,7 +262,9 @@ void initActiveBoxIds(void)
 #endif
 
     BME(BOXFAILSAFE);
+#ifdef USE_GPS_RESCUE
     BME(BOXFAILSAFELAND);
+#endif
 
     if (mixerConfig()->mixerMode == MIXER_FLYING_WING || mixerConfig()->mixerMode == MIXER_AIRPLANE || mixerConfig()->mixerMode == MIXER_CUSTOM_AIRPLANE) {
         BME(BOXPASSTHRU);

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1091,6 +1091,7 @@ extern "C" {
     void failsafeStartMonitoring(void) {}
     void failsafeUpdateState(void) {}
     bool failsafeIsActive(void) { return false; }
+    failsafeProcedure_e getEffectiveFailsafeProcedure(void) { return (failsafeProcedure_e)failsafeConfig()->failsafe_procedure; }
     bool failsafeIsReceivingRxData(void) { return true; }
     bool rxAreFlightChannelsValid(void) { return false; }
     void pidResetIterm(void) {}

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -775,7 +775,14 @@ TEST(FlightFailsafeTest, TestFailsafeLandOverrideRedirectsGpsRescueToLanding)
     EXPECT_TRUE(failsafeIsActive());
     EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
 
+    // releasing the override switch mid-failsafe must NOT change the active procedure;
+    // the helper must keep returning the value latched at stage 2 entry
     deactivateBoxFailsafe();
+    failsafeUpdateState();
+
+    EXPECT_TRUE(failsafeIsActive());
+    EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
+    EXPECT_EQ(FAILSAFE_PROCEDURE_AUTO_LANDING, getEffectiveFailsafeProcedure());
 }
 
 // STUBS

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -723,6 +723,7 @@ TEST(FlightFailsafeTest, TestEffectiveFailsafeProcedureRespectsOverrideBox)
 {
     // given GPS Rescue configured and override switch OFF
     configureFailsafe();
+    failsafeInit();
     failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
     deactivateBoxFailsafe();
 

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -103,6 +103,14 @@ void deactivateBoxFailsafe()
     rcModeUpdate(&newMask);
 }
 
+void activateBoxFailsafeLand()
+{
+    boxBitmask_t newMask;
+    memset(&newMask, 0, sizeof(newMask));
+    bitArraySet(&newMask, BOXFAILSAFELAND);
+    rcModeUpdate(&newMask);
+}
+
 //
 // Stepwise tests
 //
@@ -708,6 +716,66 @@ TEST(FlightFailsafeTest, TestFailsafeNotActivatedWhenDisarmedAndRXLossIsDetected
 
     // but now arming is possible
     EXPECT_FALSE(isArmingDisabled());
+}
+
+/****************************************************************************************/
+TEST(FlightFailsafeTest, TestEffectiveFailsafeProcedureRespectsOverrideBox)
+{
+    // given GPS Rescue configured and override switch OFF
+    configureFailsafe();
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
+    deactivateBoxFailsafe();
+
+    // expect the configured procedure
+    EXPECT_EQ(FAILSAFE_PROCEDURE_GPS_RESCUE, getEffectiveFailsafeProcedure());
+
+    // when override switch is flipped ON
+    activateBoxFailsafeLand();
+
+    // expect override forces AUTO_LANDING
+    EXPECT_EQ(FAILSAFE_PROCEDURE_AUTO_LANDING, getEffectiveFailsafeProcedure());
+
+    // and reverting the switch restores the configured procedure
+    deactivateBoxFailsafe();
+    EXPECT_EQ(FAILSAFE_PROCEDURE_GPS_RESCUE, getEffectiveFailsafeProcedure());
+}
+
+/****************************************************************************************/
+TEST(FlightFailsafeTest, TestFailsafeLandOverrideRedirectsGpsRescueToLanding)
+{
+    // given GPS Rescue is the configured procedure but override switch is ON
+    configureFailsafe();
+    failsafeInit();
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
+    failsafeConfigMutable()->failsafe_switch_mode = FAILSAFE_SWITCH_MODE_STAGE1;
+
+    DISABLE_ARMING_FLAG(ARMED);
+    resetCallCounters();
+    failsafeStartMonitoring();
+
+    ENABLE_ARMING_FLAG(ARMED);
+    throttleStatus = THROTTLE_HIGH;
+    activateBoxFailsafeLand();
+    failsafeOnValidDataReceived();
+
+    sysTickUptime = 0;
+    failsafeUpdateState();
+
+    // simulate Rx loss for the stage 1 duration
+    sysTickUptime += (failsafeConfig()->failsafe_delay * MILLIS_PER_TENTH_SECOND);
+    failsafeOnValidDataFailed();
+    failsafeUpdateState();
+
+    // exceed stage 1 by one tick
+    sysTickUptime++;
+    failsafeOnValidDataFailed();
+    failsafeUpdateState();
+
+    // override should have routed us to LANDING, not GPS rescue
+    EXPECT_TRUE(failsafeIsActive());
+    EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
+
+    deactivateBoxFailsafe();
 }
 
 // STUBS

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -163,6 +163,7 @@ extern "C" {
     void failsafeStartMonitoring(void) {}
     void failsafeUpdateState(void) {}
     bool failsafeIsActive(void) { return false; }
+    failsafeProcedure_e getEffectiveFailsafeProcedure(void) { return (failsafeProcedure_e)failsafeConfig()->failsafe_procedure; }
     bool rxAreFlightChannelsValid(void) { return false; }
     bool failsafeIsReceivingRxData(void) { return false; }
     void pidResetIterm(void) {}


### PR DESCRIPTION
## Summary

Adds a new RCMODE box, `BOXFAILSAFELAND`, that pilots can map to an AUX switch in the Modes tab. When the switch is active, a real RX-loss failsafe runs `FAILSAFE_PROCEDURE_AUTO_LANDING` regardless of the configured `failsafe_procedure`. When inactive, behaviour is unchanged.

## Motivation

Pilots flying with `failsafe_procedure = GPS_RESCUE` outdoors currently have to bring a laptop (or use a phone configurator) to switch the procedure to `AUTO_LANDING` before flying indoors, where GPS Rescue is unsafe (no satellites, walls, ceiling). This mode lets the pilot disable GPS Rescue from the radio without changing config.

## Implementation

A small helper, `getEffectiveFailsafeProcedure()`, centralises the override:

```c
failsafeProcedure_e getEffectiveFailsafeProcedure(void)
{
    if (IS_RC_MODE_ACTIVE(BOXFAILSAFELAND)) {
        return FAILSAFE_PROCEDURE_AUTO_LANDING;
    }
    return failsafeConfig()->failsafe_procedure;
}
```

The helper is consulted at the three RX-loss-time read sites:
- `failsafe.c` stage 2 entry (the procedure dispatch switch)
- `failsafe.c` throttle-low quiet-disarm guard
- `core.c` `GPS_RESCUE_MODE` flight-flag gate

## Scope decisions

- **Override forces `AUTO_LANDING` only** (not `DROP`, not configurable). Keeps the change minimal and safe-by-default for the indoor use case.
- **Failsafe-only**: the manual `BOXGPSRESCUE` "RTH" switch is intentionally unaffected; `gpsRescueIsConfigured()` is unchanged so it still reports the configured procedure.
- **Boot-time accelerometer init unchanged**: GPS rescue may still be the configured procedure for the next outdoor flight, so accel init logic stays driven by the static config.
- **No PG version bump**: `BOXFAILSAFELAND` is appended at the end of `boxId_e`, so no existing `modeActivationCondition` values shift and saved user configs remain valid on upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Failsafe Land" RC mode selectable by a switch to force auto-landing when active during failsafe events.
  * Failsafe logic now uses the effective (and latched) procedure so GPS Rescue follows any active override once a failsafe stage begins.

* **Bug Fixes**
  * Ensures kill/JustDisarm paths and stage transitions update the active procedure to avoid stale GPS Rescue state.

* **Tests**
  * Added unit tests covering the override, latching, and stage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->