### PR TITLE
usb: derive product name from BOARD_NAME when a config is built (4.5)

### DIFF
--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -30,6 +30,14 @@
 #include "config.h"
 #endif
 
+// USB product name: prefer BOARD_NAME from config.h; otherwise fall back to
+// the target-specific USBD_PRODUCT_STRING defined in target.h.
+#if defined(BOARD_NAME) && !defined(USBD_PRODUCT_STRING)
+#define USBD_PRODUCT_STRINGIFY_(x) #x
+#define USBD_PRODUCT_STRINGIFY(x) USBD_PRODUCT_STRINGIFY_(x)
+#define USBD_PRODUCT_STRING "Betaflight - " USBD_PRODUCT_STRINGIFY(BOARD_NAME)
+#endif
+
 #include "target/common_pre.h"
 
 // MCU specific platform from drivers/XX

--- a/src/main/target/AT32F435G/target.h
+++ b/src/main/target/AT32F435G/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight AT32F435"
+#define USBD_PRODUCT_STRING     "Betaflight - AT32F435"
 #endif
 
 #ifndef AT32F435

--- a/src/main/target/AT32F435M/target.h
+++ b/src/main/target/AT32F435M/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight AT32F435"
+#define USBD_PRODUCT_STRING     "Betaflight - AT32F435"
 #endif
 
 #ifndef AT32F435

--- a/src/main/target/STM32F405/target.h
+++ b/src/main/target/STM32F405/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F405"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F405"
 #endif
 
 #ifndef STM32F405

--- a/src/main/target/STM32F411/target.h
+++ b/src/main/target/STM32F411/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F411"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F411"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/main/target/STM32F446/target.h
+++ b/src/main/target/STM32F446/target.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING             "Betaflight STM32F446"
+#define USBD_PRODUCT_STRING             "Betaflight - STM32F446"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/main/target/STM32F745/target.h
+++ b/src/main/target/STM32F745/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F745"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F745"
 #endif
 
 #ifndef STM32F745

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32F7x2"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32F7x2"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/main/target/STM32G47X/target.h
+++ b/src/main/target/STM32G47X/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32G47x"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32G47x"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/main/target/STM32H723/target.h
+++ b/src/main/target/STM32H723/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H723"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H723"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/main/target/STM32H725/target.h
+++ b/src/main/target/STM32H725/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H725"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H725"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/main/target/STM32H730/target.h
+++ b/src/main/target/STM32H730/target.h
@@ -40,7 +40,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H730"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H730"
 #endif
 
 #if !defined(USE_I2C)

--- a/src/main/target/STM32H743/target.h
+++ b/src/main/target/STM32H743/target.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H743"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H743"
 #endif
 
 #define USE_I2C_DEVICE_1

--- a/src/main/target/STM32H750/target.h
+++ b/src/main/target/STM32H750/target.h
@@ -40,7 +40,7 @@
 #endif
 
 #ifndef USBD_PRODUCT_STRING
-#define USBD_PRODUCT_STRING     "Betaflight STM32H750"
+#define USBD_PRODUCT_STRING     "Betaflight - STM32H750"
 #endif
 
 #if !defined(USE_I2C)


### PR DESCRIPTION
## Summary
Backport of #15182 to `4.5-maintenance`.

- USB product string now follows the format `Betaflight - <name>`.
- When building with `CONFIG=`, `<name>` is taken from `BOARD_NAME` in the config header, so the device identifies as the actual board (e.g. `Betaflight - AIKONF4V2`) rather than the underlying MCU.
- Plain `TARGET=` builds keep the MCU-based fallback (e.g. `Betaflight - STM32F411`); the format has been normalised across all target headers for consistency.

The override is centralised in `src/main/platform.h` immediately after `config.h` is included; each target's `#ifndef USBD_PRODUCT_STRING` guard then defers to it.

## Test plan
- [ ] Build a `CONFIG=` target and confirm the host-side USB product name matches `Betaflight - <BOARD_NAME>`.
- [ ] Build a plain `TARGET=` (no config) and confirm the product name matches `Betaflight - <MCU>`.
- [ ] Verify enumeration on at least one STM32 and AT32 target.