### PR TITLE
drivers/bus: NULL-check dev->bus in busBusy()

### DIFF
--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -169,6 +169,9 @@ bool busBusy(const extDevice_t *dev, bool *error)
 #if !defined(USE_I2C)
     UNUSED(error);
 #endif
+    if (!dev->bus) {
+        return false;
+    }
     switch (dev->bus->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:


### PR DESCRIPTION
## Summary
- `virtualBaroDetect()` populates the `baroDev_t` function pointers but never assigns `dev->bus`
- `taskUpdateBaro()` calls `busBusy(&baro.dev.dev, NULL)` every scheduler iteration, which dereferences `dev->bus->busType`
- On targets where address 0 isn't readable this hard-faults; elsewhere it silently reads zero-mapped memory and happens to behave
- A device with no bus cannot be busy — return false in that case

## Test plan
- [x] Build a target with `USE_VIRTUAL_BARO` and confirm `taskUpdateBaro` runs without faulting
- [x] Smoke-test a real-baro target (SPI or I2C) to confirm no regression in the busy path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability by adding defensive validation for hardware bus configurations, preventing potential issues in certain device scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->