### PR TITLE
[backport] fix(config): unconditionally clamp failsafe_procedure to valid range

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -370,6 +370,9 @@ static void validateAndFixConfig(void)
             failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
         }
 #endif
+        if (failsafeConfig()->failsafe_procedure >= FAILSAFE_PROCEDURE_COUNT) {
+            failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
+        }
 
         if (isModeActivationConditionPresent(BOXGPSRESCUE)) {
             removeModeActivationCondition(BOXGPSRESCUE);


### PR DESCRIPTION
> **AI Generated PR — Anthropic Claude (claude-sonnet-4-6) on behalf of nerdCopter**
> If developer opinion deems this fix unwarranted, please close without hesitation.

Backport of https://github.com/betaflight/betaflight/pull/15192

Resolves #15189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced failsafe procedure validation to detect invalid configuration values and automatically correct them to a safe default, improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->