### PR TITLE
fix(config): unconditionally clamp failsafe_procedure to valid range

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -380,6 +380,9 @@ static void validateAndFixConfig(void)
             failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
         }
 #endif
+        if (failsafeConfig()->failsafe_procedure >= FAILSAFE_PROCEDURE_COUNT) {
+            failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
+        }
 
         if (isModeActivationConditionPresent(BOXGPSRESCUE)) {
             removeModeActivationCondition(BOXGPSRESCUE);


### PR DESCRIPTION
> **AI Generated PR — Anthropic Claude (claude-sonnet-4-6) on behalf of nerdCopter**
> If developer opinion deems this fix unwarranted, please close without hesitation.

Resolves #15189

## Problem

`validateAndFixConfig()` sanitizes `failsafe_procedure` only inside a `#ifdef USE_GPS_RESCUE` block. When that feature is absent, `FAILSAFE_PROCEDURE_COUNT == 2` and the numeric value `2` (previously `FAILSAFE_PROCEDURE_GPS_RESCUE`) becomes out of range. A user who flashes from a GPS-rescue-capable build to a non-GPS-rescue build **without full chip erase** retains this stale value in EEPROM — it is never clamped.

## Fix

Add an unconditional `>= FAILSAFE_PROCEDURE_COUNT` check immediately after the guarded block. `FAILSAFE_PROCEDURE_COUNT` is always defined as the enum sentinel and correctly reflects the valid range for the current build.

```c
#ifdef USE_GPS_RESCUE
    if (failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE) {
        failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
    }
#endif
    if (failsafeConfig()->failsafe_procedure >= FAILSAFE_PROCEDURE_COUNT) {
        failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
    }
```

## Notes

- **Low priority** — full chip erase is the default in Betaflight Configurator; this edge case only affects users who explicitly disable it when switching between GPS-rescue-capable and non-capable builds.
- Equivalent fix already merged to EmuFlight: [EmuFlight PR #1151](https://github.com/emuflight/EmuFlight/pull/1151)
- Companion PRs for `4.5-maintenance` and `2025.12-maintenance` submitted separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failsafe configuration validation to ensure only valid procedure values are accepted, automatically correcting invalid entries to a safe default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->