### PR TITLE
Fix CLI entry race condition in MSP serial processing (fixes #14169, #15071)

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -532,10 +532,8 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             continue;
         }
 
-        // There are bytes incoming - abort pending request once on new activity burst.
-        // This must be outside the inner loop so that characters within the same burst
-        // (e.g. '#' followed by '\r') do not cancel the CLI pending request that '#' sets.
-        // Matches the pre-PR-13940 behaviour where pending was cleared once per task tick.
+        // Abort pending request once per activity burst, not per byte.
+        // Prevents multi-byte sequences (e.g. '#\r') from cancelling CLI entry.
         if (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
             mspPort->lastActivityMs = millis();
             mspPort->pendingRequest = MSP_PENDING_NONE;

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -532,13 +532,17 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             continue;
         }
 
-        // whilst port is idle, poll incoming until portState changes or no more bytes
-        while (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
-
-            // There are bytes incoming - abort pending request
+        // There are bytes incoming - abort pending request once on new activity burst.
+        // This must be outside the inner loop so that characters within the same burst
+        // (e.g. '#' followed by '\r') do not cancel the CLI pending request that '#' sets.
+        // Matches the pre-PR-13940 behaviour where pending was cleared once per task tick.
+        if (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
             mspPort->lastActivityMs = millis();
             mspPort->pendingRequest = MSP_PENDING_NONE;
+        }
 
+        // whilst port is idle, poll incoming until portState changes or no more bytes
+        while (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
             const uint8_t c = serialRead(mspPort->port);
             if (c == '$') {
                 mspPort->portState = PORT_MSP_PACKET;


### PR DESCRIPTION
AI Generated code

---

## Summary

Fixes race condition in  preventing CLI entry on MSP ports.

## Root Cause

PR #13940 refactored the MSP processing loop, inadvertently moving the  abort logic **inside** the byte-processing while loop. When applications sent CLI commands like , , or when MSP polling arrived in the same RX burst, the  flag was cleared before the 100 ms guard in `mspProcessPendingRequest` could fire.

Result: legacy Android CLI app and web configurator (master.app.betaflight.com) both lost CLI access.

## Solution

Move pending request abort to an outer guard **before** the while loop—restoring the pre-PR-13940 semantics where pending requests clear once per activity burst, not once per byte. The fix is minimal (3 lines moved) and preserves all of PR #13940's architectural improvements.

## What Was Preserved from PR #13940

- ✅ `mspPortState_e` / `mspPacketState_e` state machine refactor
- ✅ New `PORT_CLI_CMD` state and STX (0x2) non-interactive passthrough mode  
- ✅ `cliEnter(port, bool interactive)` signature and dispatch logic
- ✅ `cliProcess()` bool return type
- ✅ All MSP packet processing restructuring
- ✅ Interactive vs. non-interactive CLI mode separation

## Testing

- Unit tests: 44/44 pass (including `test_cli_unittest`)
- Config: `make CONFIG=FOXEERF405` builds successfully  
- Hardware: FOXEERF405 tested—web configurator CLI works, legacy Betaflight CLI (Pavel Osnova) Android app CLI works

## Related Issues & PRs

- Closes #14169 (Legacy Android CLI + SITL segfault post-PR #13940)
- Related to #15071 (Protocol stability concerns across projects)
- Related to #13940 (Original MSP CLI passthrough feature)

---

**Attribution:** AI generated code: Anthropic Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented premature cancellation of pending serial/CLI requests when rapid data arrives, preserving command/response state.
  * Improved port behavior on incoming data to reduce missed or aborted interactions, making serial communication more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->