### PR TITLE
Chirp signal feed for Angle controller shifted

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -622,10 +622,18 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
         DEBUG_SET(DEBUG_ANGLE_MODE, 2, lrintf(angleFeedforward * 10.0f)); // feedforward amount in degrees
         DEBUG_SET(DEBUG_ANGLE_MODE, 3, lrintf(currentAngle * 10.0f)); // angle returned
 
+        DEBUG_SET(DEBUG_CHIRP, 1, lrintf(currentAngle * 10.0f)); // angle returned
+        DEBUG_SET(DEBUG_CHIRP, 2, lrintf(angleTarget * 10.0f));  // target angle
+
+
         DEBUG_SET(DEBUG_ANGLE_TARGET, 0, lrintf(angleTarget * 10.0f));
         DEBUG_SET(DEBUG_ANGLE_TARGET, 1, lrintf(sinAngle * 10.0f)); // modification factor from earthRef
         // debug ANGLE_TARGET 2 is yaw attenuation
         DEBUG_SET(DEBUG_ANGLE_TARGET, 3, lrintf(currentAngle * 10.0f)); // angle returned
+    }
+    else if (axis == FD_PITCH) {
+        DEBUG_SET(DEBUG_CHIRP, 3, lrintf(currentAngle * 10.0f)); // angle returned
+        DEBUG_SET(DEBUG_CHIRP, 4, lrintf(angleTarget * 10.0f));  // target angle
     }
 
     DEBUG_SET(DEBUG_CURRENT_ANGLE, axis, lrintf(currentAngle * 10.0f)); // current angle
@@ -1238,6 +1246,9 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         // When Race Mode is active PITCH control is also GYRO based in level or horizon mode
 #if defined(USE_ACC)
         pidRuntime.axisInAngleMode[axis] = false;
+#ifdef USE_CHIRP
+        currentPidSetpoint += currentChirp;
+#endif // USE_CHIRP
         if (axis < FD_YAW) {
             if (levelMode == LEVEL_MODE_RP || (levelMode == LEVEL_MODE_R && axis == FD_ROLL)) {
                 pidRuntime.axisInAngleMode[axis] = true;
@@ -1290,9 +1301,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
 
         // -----calculate error rate
         const float gyroRate = gyro.gyroADCf[axis]; // Process variable from gyro output in deg/sec
-#ifdef USE_CHIRP
-        currentPidSetpoint += currentChirp;
-#endif // USE_CHIRP
+
         float errorRate = currentPidSetpoint - gyroRate; // r - y
 #if defined(USE_ACC)
         handleCrashRecovery(


### PR DESCRIPTION
# Enabling Offline Tuning of the Angle Controller

## Goal

The goal of this change is to enable offline tuning of both the angle controller and the angular rate controller using a single chirp excitation.  

Currently, we are working on an extension of the tool created by @pichim, which already allows users to tune the angular rate controller offline after a flight using a chirp signal. This extension will additionally allow offline tuning of the angle controller.

---

## Motivation

At the moment, the chirp signal is injected directly into the angular rate controller setpoint.  
This makes it possible to identify and tune the angular rate controller, but it does not allow proper identification of the outer angle control loop.

To make offline tuning of the angle controller possible, the chirp signal must instead be injected before the angle transformation stage whenever Angle Mode is active.

### Current Control Loop

<img width="884" height="203" alt="Chirp_Control_Loop_Angle" src="https://github.com/user-attachments/assets/e3c27480-7e4e-4132-b208-5d0f3582fcf9" />


### Proposed Control Loop

<img width="689" height="153" alt="Control_Loop_Angle_new" src="https://github.com/user-attachments/assets/c08196a0-ccf6-4f46-a138-d996cbeae3a9" />


With this change, the chirp excitation propagates through the complete angle control path, allowing analysis and tuning of:

- Angle controller
- PT3 angle filtering
- Angular rate controller
- Plant response

while maintaining the existing behaviour in Acro mode.

---

## Code Changes

The actual code changes are relatively small.

The main modification is that the chirp signal is now injected before the angle transformation function is called instead of after it.

Additionally, several debug logs were added, which are required for reliable offline analysis and controller identification.

---

## Functionality Changes

The functionality of the chirp itself does not change.

### Angle Mode

When the chirp is started in Angle Mode, the chirp signal is injected before the angle transformation stage.  
As a result, the chirp is included in the setpoint transformation and propagates through the complete cascaded control structure.

### Acro Mode

When the chirp is started in Acro mode (angular rate mode), the angle control path is bypassed as before.  
In this case, the chirp injection behaves exactly as it does today and is applied directly to the angular rate controller setpoint.
<img width="476" height="145" alt="Regelkreis_Gyro" src="https://github.com/user-attachments/assets/7c3b058b-ca32-4b9e-a91b-68b185824b83" />

---

## Testing

The changes were tested on multiple platforms, including:

- newer digital drones
- an older analog drone

Test flights were performed in both:

- Angle Mode
- Acro Mode

No functional issues or flight instabilities were observed during testing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PID controller diagnostics and debug output configuration for improved flight control monitoring.
  * Refined chirp contribution timing in the PID control loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->