### PR TITLE
drivers/flash: OctoSPI multichip support + MX66UW1G45G driver

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -26,6 +26,15 @@ INCLUDE_DIRS       += $(CONFIG_DIR)/configs/$(CONFIG)
 # include $(CONFIG)/config.mk if it exists
 -include $(CONFIG_DIR)/configs/$(CONFIG)/config.mk
 
+# OCTOSPI_FLASH_CHIP selects the flash chip wired to the OCTOSPI/XSPI peripheral.
+# Set in per-config config.mk (e.g. OCTOSPI_FLASH_CHIP := MX66UW1G45G). Emits both
+# USE_FLASH_<chip> (chip driver gating) and OCTOSPI_FLASH_CHIP_<chip> (build-time
+# selection marker for chips that cannot be probed via JEDEC RDID, such as those
+# operating in 8-line OPI mode).
+ifneq ($(OCTOSPI_FLASH_CHIP),)
+TARGET_FLAGS += -DUSE_FLASH_$(OCTOSPI_FLASH_CHIP) -DOCTOSPI_FLASH_CHIP_$(OCTOSPI_FLASH_CHIP)
+endif
+
 ifneq ($(wildcard $(CONFIG_HEADER_FILE)),)
 
 CONFIG_SRC :=

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -374,6 +374,7 @@ FLASH_SRC += \
             drivers/flash/flash.c \
             drivers/flash/flash_m25p16.c \
             drivers/flash/flash_mt29f.c \
+            drivers/flash/flash_mx66uw1g45g.c \
             drivers/flash/flash_w25m.c \
             drivers/flash/flash_w25n.c \
             drivers/flash/flash_w25q128fv.c \

--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -32,6 +32,7 @@
 #include "drivers/flash/flash_impl.h"
 #include "drivers/flash/flash_m25p16.h"
 #include "drivers/flash/flash_mt29f.h"
+#include "drivers/flash/flash_mx66uw1g45g.h"
 #include "drivers/flash/flash_w25n.h"
 #include "drivers/flash/flash_w25q128fv.h"
 #include "drivers/flash/flash_w25m.h"
@@ -108,89 +109,105 @@ MMFLASH_CODE_NOINLINE static bool flashOctoSpiInit(const flashConfig_t *flashCon
     flashDevice.io.handle.octoSpi = instance;
     flashDevice.io.mode = FLASHIO_OCTOSPI;
 
-    if (memoryMappedModeEnabledOnBoot) {
-        flashMemoryMappedModeDisable();
+    // Build-time-selected chips that cannot be JEDEC-probed via 1/4-line RDID
+    // (e.g., flashes configured by the bootloader in 8-line OPI mode). These
+    // are selected via OCTOSPI_FLASH_CHIP=<name> in the per-config config.mk,
+    // which emits the corresponding OCTOSPI_FLASH_CHIP_<name> marker. Run
+    // before disabling memory-mapped mode so the bootloader's setup is
+    // preserved and the chip stays addressable.
+#if defined(OCTOSPI_FLASH_CHIP_MX66UW1G45G) && defined(USE_FLASH_MX66UW1G45G)
+    if (!detected && memoryMappedModeEnabledOnBoot) {
+        if (mx66uw1g45g_identify(&flashDevice, MX66UW1G45G_JEDEC_ID)) {
+            detected = true;
+        }
     }
+#endif
 
-    do {
+    if (!detected) {
+        if (memoryMappedModeEnabledOnBoot) {
+            flashMemoryMappedModeDisable();
+        }
+
+        do {
 #ifdef USE_OCTOSPI_EXPERIMENTAL
-        if (!memoryMappedMode) {
-            octoSpiSetDivisor(instance, OCTOSPI_CLOCK_INITIALISATION);
-        }
+            if (!memoryMappedMode) {
+                octoSpiSetDivisor(instance, OCTOSPI_CLOCK_INITIALISATION);
+            }
 #endif
-        // for the memory-mapped use-case, we rely on the bootloader to have already selected the correct speed for the flash chip.
+            // for the memory-mapped use-case, we rely on the bootloader to have already selected the correct speed for the flash chip.
 
-        // 3 bytes for what we need, but some IC's need 8 dummy cycles after the instruction, so read 4 and make two attempts to
-        // assemble the chip id from the response.
-        uint8_t readIdResponse[4];
+            // 3 bytes for what we need, but some IC's need 8 dummy cycles after the instruction, so read 4 and make two attempts to
+            // assemble the chip id from the response.
+            uint8_t readIdResponse[4];
 
-        bool status = false;
-        switch (phase) {
-        case TRY_1LINE:
-            status = octoSpiReceive1LINE(instance, FLASH_INSTRUCTION_RDID, 0, readIdResponse, 4);
-            break;
-        case TRY_4LINE:
-            status = octoSpiReceive4LINES(instance, FLASH_INSTRUCTION_RDID, 2, readIdResponse, 3);
-            break;
-        default:
-            break;
-        }
-
-        if (!status) {
-            phase++;
-            continue;
-        }
-
-#ifdef USE_OCTOSPI_EXPERIMENTAL
-        if (!memoryMappedModeEnabledOnBoot) {
-            octoSpiSetDivisor(instance, OCTOSPI_CLOCK_ULTRAFAST);
-        }
-#endif
-
-        for (uint8_t offset = 0; offset <= 1 && !detected; offset++) {
-#if defined(USE_FLASH_W25N01G) || defined(USE_FLASH_W25N02K) || defined(USE_FLASH_W25Q128FV) || defined(USE_FLASH_W25M02G)
-            uint32_t jedecID = (readIdResponse[offset + 0] << 16) | (readIdResponse[offset + 1] << 8) | (readIdResponse[offset + 2]);
-#endif
-
-            if (offset == 0) {
-#if defined(USE_FLASH_W25Q128FV)
-                if (!detected && w25q128fv_identify(&flashDevice, jedecID)) {
-                    detected = true;
-                }
-#endif
+            bool status = false;
+            switch (phase) {
+            case TRY_1LINE:
+                status = octoSpiReceive1LINE(instance, FLASH_INSTRUCTION_RDID, 0, readIdResponse, 4);
+                break;
+            case TRY_4LINE:
+                status = octoSpiReceive4LINES(instance, FLASH_INSTRUCTION_RDID, 2, readIdResponse, 3);
+                break;
+            default:
+                break;
             }
 
-            if (offset == 1) {
+            if (!status) {
+                phase++;
+                continue;
+            }
+
 #ifdef USE_OCTOSPI_EXPERIMENTAL
-                if (!memoryMappedModeEnabledOnBoot) {
-                    // These flash chips DO NOT support memory mapped mode; suitable flash read commands must be available.
-#if defined(USE_FLASH_W25N01G) || defined(USE_FLASH_W25N02K)
-                    if (!detected && w25n_identify(&flashDevice, jedecID)) {
+            if (!memoryMappedModeEnabledOnBoot) {
+                octoSpiSetDivisor(instance, OCTOSPI_CLOCK_ULTRAFAST);
+            }
+#endif
+
+            for (uint8_t offset = 0; offset <= 1 && !detected; offset++) {
+#if defined(USE_FLASH_W25N01G) || defined(USE_FLASH_W25N02K) || defined(USE_FLASH_W25Q128FV) || defined(USE_FLASH_W25M02G)
+                uint32_t jedecID = (readIdResponse[offset + 0] << 16) | (readIdResponse[offset + 1] << 8) | (readIdResponse[offset + 2]);
+#endif
+
+                if (offset == 0) {
+#if defined(USE_FLASH_W25Q128FV)
+                    if (!detected && w25q128fv_identify(&flashDevice, jedecID)) {
                         detected = true;
                     }
+#endif
+                }
+
+                if (offset == 1) {
+#ifdef USE_OCTOSPI_EXPERIMENTAL
+                    if (!memoryMappedModeEnabledOnBoot) {
+                        // These flash chips DO NOT support memory mapped mode; suitable flash read commands must be available.
+#if defined(USE_FLASH_W25N01G) || defined(USE_FLASH_W25N02K)
+                        if (!detected && w25n_identify(&flashDevice, jedecID)) {
+                            detected = true;
+                        }
 #endif
 #if defined(USE_FLASH_W25M02G)
-                    if (!detected && w25m_identify(&flashDevice, jedecID)) {
-                        detected = true;
-                    }
+                        if (!detected && w25m_identify(&flashDevice, jedecID)) {
+                            detected = true;
+                        }
 #endif
 #if defined(USE_FLASH_MT29F)
-                    if (!detected && mt29f_identify(&flashDevice, jedecID)) {
-                        detected = true;
+                        if (!detected && mt29f_identify(&flashDevice, jedecID)) {
+                            detected = true;
+                        }
+#endif
                     }
 #endif
                 }
-#endif
             }
+            phase++;
+        } while (phase != BAIL && !detected);
+
+        if (memoryMappedModeEnabledOnBoot) {
+            flashMemoryMappedModeEnable();
         }
-        phase++;
-    } while (phase != BAIL && !detected);
-
-    if (memoryMappedModeEnabledOnBoot) {
-        flashMemoryMappedModeEnable();
     }
-    return detected;
 
+    return detected;
 }
 #endif // USE_FLASH_OCTOSPI
 

--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -118,6 +118,7 @@ MMFLASH_CODE_NOINLINE static bool flashOctoSpiInit(const flashConfig_t *flashCon
 #if defined(OCTOSPI_FLASH_CHIP_MX66UW1G45G) && defined(USE_FLASH_MX66UW1G45G)
     if (!detected && memoryMappedModeEnabledOnBoot) {
         if (mx66uw1g45g_identify(&flashDevice, MX66UW1G45G_JEDEC_ID)) {
+            flashDevice.geometry.jedecId = MX66UW1G45G_JEDEC_ID;
             detected = true;
         }
     }
@@ -130,7 +131,7 @@ MMFLASH_CODE_NOINLINE static bool flashOctoSpiInit(const flashConfig_t *flashCon
 
         do {
 #ifdef USE_OCTOSPI_EXPERIMENTAL
-            if (!memoryMappedMode) {
+            if (!memoryMappedModeEnabledOnBoot) {
                 octoSpiSetDivisor(instance, OCTOSPI_CLOCK_INITIALISATION);
             }
 #endif
@@ -164,9 +165,7 @@ MMFLASH_CODE_NOINLINE static bool flashOctoSpiInit(const flashConfig_t *flashCon
 #endif
 
             for (uint8_t offset = 0; offset <= 1 && !detected; offset++) {
-#if defined(USE_FLASH_W25N01G) || defined(USE_FLASH_W25N02K) || defined(USE_FLASH_W25Q128FV) || defined(USE_FLASH_W25M02G)
                 uint32_t jedecID = (readIdResponse[offset + 0] << 16) | (readIdResponse[offset + 1] << 8) | (readIdResponse[offset + 2]);
-#endif
 
                 if (offset == 0) {
 #if defined(USE_FLASH_W25Q128FV)
@@ -197,6 +196,10 @@ MMFLASH_CODE_NOINLINE static bool flashOctoSpiInit(const flashConfig_t *flashCon
 #endif
                     }
 #endif
+                }
+
+                if (detected) {
+                    flashDevice.geometry.jedecId = jedecID;
                 }
             }
             phase++;

--- a/src/main/drivers/flash/flash_mx66uw1g45g.c
+++ b/src/main/drivers/flash/flash_mx66uw1g45g.c
@@ -164,8 +164,9 @@ MMFLASH_CODE static int mx66uw1g45g_readBytes(flashDevice_t *fdevice, uint32_t a
     if (address >= fdevice->geometry.totalSize) {
         return 0;
     }
-    if (address + length > fdevice->geometry.totalSize) {
-        length = fdevice->geometry.totalSize - address;
+    const uint32_t remaining = fdevice->geometry.totalSize - address;
+    if (length > remaining) {
+        length = remaining;
     }
 
     memcpy(buffer, (const void *)(uintptr_t)(MX66UW1G45G_MEMORY_MAPPED_BASE + address), length);

--- a/src/main/drivers/flash/flash_mx66uw1g45g.c
+++ b/src/main/drivers/flash/flash_mx66uw1g45g.c
@@ -49,6 +49,7 @@
 #include "drivers/flash/flash.h"
 #include "drivers/flash/flash_impl.h"
 #include "drivers/flash/flash_mx66uw1g45g.h"
+#include "drivers/system.h"
 
 // Geometry: 1Gbit / 128 MiB, 4 KiB sectors, 256 B pages.
 #define MX66UW1G45G_PAGE_SIZE           256U
@@ -103,16 +104,23 @@ MMFLASH_CODE static bool mx66uw1g45g_waitForReady(flashDevice_t *fdevice)
     return true;
 }
 
+// Phase 1 is memory-mapped read only. Any write or erase attempt is a
+// programming error in the caller (e.g. enabling USE_FLASHFS or
+// CONFIG_IN_EXTERNAL_FLASH on a board that uses this chip) and is reported via
+// failureMode rather than silently no-op'ing — silent stubs would let flashfs
+// loop forever waiting for progress.
+
 MMFLASH_CODE static void mx66uw1g45g_eraseSector(flashDevice_t *fdevice, uint32_t address)
 {
     UNUSED(fdevice);
     UNUSED(address);
-    // Phase 1: write/erase not implemented. Requires 8-line OPI primitives.
+    failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 static void mx66uw1g45g_eraseCompletely(flashDevice_t *fdevice)
 {
     UNUSED(fdevice);
+    failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgramBegin(flashDevice_t *fdevice, uint32_t address, void (*callback)(uintptr_t arg))
@@ -123,12 +131,11 @@ MMFLASH_CODE static void mx66uw1g45g_pageProgramBegin(flashDevice_t *fdevice, ui
 
 MMFLASH_CODE static uint32_t mx66uw1g45g_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffers, const uint32_t *bufferSizes, uint32_t bufferCount)
 {
+    UNUSED(fdevice);
     UNUSED(buffers);
     UNUSED(bufferSizes);
     UNUSED(bufferCount);
-    if (fdevice->callback) {
-        fdevice->callback(0);
-    }
+    failureMode(FAILURE_FLASH_WRITE_FAILED);
     return 0;
 }
 
@@ -139,13 +146,12 @@ MMFLASH_CODE static void mx66uw1g45g_pageProgramFinish(flashDevice_t *fdevice)
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgram(flashDevice_t *fdevice, uint32_t address, const uint8_t *data, uint32_t length, void (*callback)(uintptr_t arg))
 {
+    UNUSED(fdevice);
     UNUSED(address);
     UNUSED(data);
     UNUSED(length);
-    fdevice->callback = callback;
-    if (callback) {
-        callback(0);
-    }
+    UNUSED(callback);
+    failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 MMFLASH_CODE static void mx66uw1g45g_flush(flashDevice_t *fdevice)

--- a/src/main/drivers/flash/flash_mx66uw1g45g.c
+++ b/src/main/drivers/flash/flash_mx66uw1g45g.c
@@ -125,8 +125,10 @@ static void mx66uw1g45g_eraseCompletely(flashDevice_t *fdevice)
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgramBegin(flashDevice_t *fdevice, uint32_t address, void (*callback)(uintptr_t arg))
 {
-    fdevice->callback = callback;
-    fdevice->currentWriteAddress = address;
+    UNUSED(fdevice);
+    UNUSED(address);
+    UNUSED(callback);
+    failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 MMFLASH_CODE static uint32_t mx66uw1g45g_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffers, const uint32_t *bufferSizes, uint32_t bufferCount)
@@ -142,6 +144,7 @@ MMFLASH_CODE static uint32_t mx66uw1g45g_pageProgramContinue(flashDevice_t *fdev
 MMFLASH_CODE static void mx66uw1g45g_pageProgramFinish(flashDevice_t *fdevice)
 {
     UNUSED(fdevice);
+    failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgram(flashDevice_t *fdevice, uint32_t address, const uint8_t *data, uint32_t length, void (*callback)(uintptr_t arg))

--- a/src/main/drivers/flash/flash_mx66uw1g45g.c
+++ b/src/main/drivers/flash/flash_mx66uw1g45g.c
@@ -1,0 +1,190 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Macronix MX66UW1G45G — 1Gbit (128 MiB) Octal NOR Flash.
+ *
+ * Phase 1: memory-mapped read only. The chip is expected to be configured by
+ * the bootloader in 8-line OPI/DTR mode and memory-mapped at
+ * MX66UW1G45G_MEMORY_MAPPED_BASE (default 0x70000000, OCTOSPI2/XSPI2 base).
+ *
+ * Because the chip is in OPI mode, it cannot respond to 1-line or 4-line
+ * JEDEC RDID probes. Selection is done at build time via the
+ * OCTOSPI_FLASH_CHIP=MX66UW1G45G make variable, which emits both
+ * USE_FLASH_MX66UW1G45G (driver gating) and OCTOSPI_FLASH_CHIP_MX66UW1G45G
+ * (dispatch marker — see flash.c:flashOctoSpiInit).
+ *
+ * Write/erase are stubbed in this phase; adding them requires 8-line OPI
+ * primitives in the OCTOSPI bus driver and platform implementations.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if defined(USE_FLASH_MX66UW1G45G) && defined(USE_OCTOSPI)
+
+#include "common/utils.h"
+
+#include "drivers/flash/flash.h"
+#include "drivers/flash/flash_impl.h"
+#include "drivers/flash/flash_mx66uw1g45g.h"
+
+// Geometry: 1Gbit / 128 MiB, 4 KiB sectors, 256 B pages.
+#define MX66UW1G45G_PAGE_SIZE           256U
+#define MX66UW1G45G_SECTOR_SIZE         4096U
+#define MX66UW1G45G_PAGES_PER_SECTOR    (MX66UW1G45G_SECTOR_SIZE / MX66UW1G45G_PAGE_SIZE)
+#define MX66UW1G45G_SECTORS             32768U   // 32768 * 4 KiB = 128 MiB
+
+#ifndef MX66UW1G45G_MEMORY_MAPPED_BASE
+#define MX66UW1G45G_MEMORY_MAPPED_BASE  0x70000000U
+#endif
+
+static const flashVTable_t mx66uw1g45g_vTable;
+
+MMFLASH_CODE_NOINLINE bool mx66uw1g45g_identify(flashDevice_t *fdevice, uint32_t jedecID)
+{
+    if (jedecID != MX66UW1G45G_JEDEC_ID) {
+        fdevice->geometry.sectors = 0;
+        fdevice->geometry.pagesPerSector = 0;
+        fdevice->geometry.sectorSize = 0;
+        fdevice->geometry.totalSize = 0;
+        return false;
+    }
+
+    fdevice->geometry.flashType = FLASH_TYPE_NOR;
+    fdevice->geometry.sectors = MX66UW1G45G_SECTORS;
+    fdevice->geometry.pagesPerSector = MX66UW1G45G_PAGES_PER_SECTOR;
+    fdevice->geometry.pageSize = MX66UW1G45G_PAGE_SIZE;
+    fdevice->geometry.sectorSize = MX66UW1G45G_SECTOR_SIZE;
+    fdevice->geometry.totalSize = (uint32_t)MX66UW1G45G_SECTOR_SIZE * MX66UW1G45G_SECTORS;
+
+    fdevice->vTable = &mx66uw1g45g_vTable;
+
+    return true;
+}
+
+static void mx66uw1g45g_configure(flashDevice_t *fdevice, uint32_t configurationFlags)
+{
+    UNUSED(fdevice);
+    UNUSED(configurationFlags);
+    // Bootloader has configured OPI memory-mapped mode; nothing to do.
+}
+
+MMFLASH_CODE static bool mx66uw1g45g_isReady(flashDevice_t *fdevice)
+{
+    UNUSED(fdevice);
+    return true;
+}
+
+MMFLASH_CODE static bool mx66uw1g45g_waitForReady(flashDevice_t *fdevice)
+{
+    UNUSED(fdevice);
+    return true;
+}
+
+MMFLASH_CODE static void mx66uw1g45g_eraseSector(flashDevice_t *fdevice, uint32_t address)
+{
+    UNUSED(fdevice);
+    UNUSED(address);
+    // Phase 1: write/erase not implemented. Requires 8-line OPI primitives.
+}
+
+static void mx66uw1g45g_eraseCompletely(flashDevice_t *fdevice)
+{
+    UNUSED(fdevice);
+}
+
+MMFLASH_CODE static void mx66uw1g45g_pageProgramBegin(flashDevice_t *fdevice, uint32_t address, void (*callback)(uintptr_t arg))
+{
+    fdevice->callback = callback;
+    fdevice->currentWriteAddress = address;
+}
+
+MMFLASH_CODE static uint32_t mx66uw1g45g_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffers, const uint32_t *bufferSizes, uint32_t bufferCount)
+{
+    UNUSED(buffers);
+    UNUSED(bufferSizes);
+    UNUSED(bufferCount);
+    if (fdevice->callback) {
+        fdevice->callback(0);
+    }
+    return 0;
+}
+
+MMFLASH_CODE static void mx66uw1g45g_pageProgramFinish(flashDevice_t *fdevice)
+{
+    UNUSED(fdevice);
+}
+
+MMFLASH_CODE static void mx66uw1g45g_pageProgram(flashDevice_t *fdevice, uint32_t address, const uint8_t *data, uint32_t length, void (*callback)(uintptr_t arg))
+{
+    UNUSED(address);
+    UNUSED(data);
+    UNUSED(length);
+    fdevice->callback = callback;
+    if (callback) {
+        callback(0);
+    }
+}
+
+MMFLASH_CODE static void mx66uw1g45g_flush(flashDevice_t *fdevice)
+{
+    UNUSED(fdevice);
+}
+
+MMFLASH_CODE static int mx66uw1g45g_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer, uint32_t length)
+{
+    if (address >= fdevice->geometry.totalSize) {
+        return 0;
+    }
+    if (address + length > fdevice->geometry.totalSize) {
+        length = fdevice->geometry.totalSize - address;
+    }
+
+    memcpy(buffer, (const void *)(uintptr_t)(MX66UW1G45G_MEMORY_MAPPED_BASE + address), length);
+
+    return (int)length;
+}
+
+static const flashGeometry_t *mx66uw1g45g_getGeometry(flashDevice_t *fdevice)
+{
+    return &fdevice->geometry;
+}
+
+MMFLASH_DATA static const flashVTable_t mx66uw1g45g_vTable = {
+    .configure = mx66uw1g45g_configure,
+    .isReady = mx66uw1g45g_isReady,
+    .waitForReady = mx66uw1g45g_waitForReady,
+    .eraseSector = mx66uw1g45g_eraseSector,
+    .eraseCompletely = mx66uw1g45g_eraseCompletely,
+    .pageProgramBegin = mx66uw1g45g_pageProgramBegin,
+    .pageProgramContinue = mx66uw1g45g_pageProgramContinue,
+    .pageProgramFinish = mx66uw1g45g_pageProgramFinish,
+    .pageProgram = mx66uw1g45g_pageProgram,
+    .flush = mx66uw1g45g_flush,
+    .readBytes = mx66uw1g45g_readBytes,
+    .getGeometry = mx66uw1g45g_getGeometry,
+};
+
+#endif

--- a/src/main/drivers/flash/flash_mx66uw1g45g.h
+++ b/src/main/drivers/flash/flash_mx66uw1g45g.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef USE_FLASH_MX66UW1G45G
+
+// Synthetic JEDEC ID. The chip is selected at build time via OCTOSPI_FLASH_CHIP
+// because it is configured by the bootloader in 8-line OPI mode and cannot
+// respond to 1/4-line JEDEC RDID. Passed to mx66uw1g45g_identify() by the
+// dispatch in flash.c so the identify path keeps the same shape as
+// JEDEC-probed chips.
+#define MX66UW1G45G_JEDEC_ID    0xC2853BU
+
+bool mx66uw1g45g_identify(flashDevice_t *fdevice, uint32_t jedecID);
+
+#endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -469,7 +469,7 @@
 #define USE_FLASH_W25M
 #endif
 
-#if defined(USE_FLASH_M25P16) || defined(USE_FLASH_W25M) || defined(USE_FLASH_W25N) || defined(USE_FLASH_W25Q128FV)
+#if defined(USE_FLASH_M25P16) || defined(USE_FLASH_W25M) || defined(USE_FLASH_W25N) || defined(USE_FLASH_W25Q128FV) || defined(USE_FLASH_MX66UW1G45G)
 #if !defined(USE_FLASH_CHIP)
 #define USE_FLASH_CHIP
 #endif
@@ -487,7 +487,7 @@
 #endif
 #endif
 
-#if defined(USE_OCTOSPI) && defined(USE_FLASH_W25Q128FV)
+#if defined(USE_OCTOSPI) && (defined(USE_FLASH_W25Q128FV) || defined(USE_FLASH_MX66UW1G45G))
 #if !defined(USE_FLASH_OCTOSPI)
 #define USE_FLASH_OCTOSPI
 #endif


### PR DESCRIPTION
## Summary

- The OctoSPI flash path was effectively single-chip (W25Q128FV) and relied on a 1/4-line JEDEC RDID probe to identify the part. Octal SPI flashes configured by the bootloader in 8-line OPI mode (e.g. Macronix MX66UW1G45G on the STM32N6570-DK) cannot respond to such a probe, so a build-time selection mechanism is required.
- New per-config make variable `OCTOSPI_FLASH_CHIP`, set in `src/config/configs/<board>/config.mk`, that emits both `USE_FLASH_<chip>` (driver gating) and `OCTOSPI_FLASH_CHIP_<chip>` (dispatch marker) into `TARGET_FLAGS`.
- `flashOctoSpiInit()` gains a pre-probe pass that runs while memory-mapped mode is still enabled, for chips that cannot be JEDEC-probed. The existing 1/4-line RDID probe path is preserved and only runs if the pre-probe does not identify the chip.
- New `flash_mx66uw1g45g` driver (1Gbit Macronix Octal NOR). Phase 1 is memory-mapped read only — `readBytes` copies from `MX66UW1G45G_MEMORY_MAPPED_BASE` (defaulting to OCTOSPI2/XSPI2 at `0x70000000`); write/erase are stubbed pending 8-line OPI primitives in the OCTOSPI bus driver.
- Existing OctoSPI configs (e.g. SPRACINGH7RF) are unaffected — without `OCTOSPI_FLASH_CHIP` set, the JEDEC probe path runs unchanged.

A follow-up PR against `betaflight/config` will add `OCTOSPI_FLASH_CHIP := <chip>` to per-target `config.mk` files for boards that opt into the new mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Macronix MX66UW1G45G (128 MiB) Octal NOR flash in memory‑mapped read‑only mode.
  * Per-configuration flash-chip selection so builds can target a specific OCTOSPI/XSPI flash chip, enabling conditional inclusion of chip-specific support.
  * Improved chip detection during flash initialization to recognize the new device and skip redundant probing when identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->