### PR TITLE
[2025.12] Backport CLI MSP race-condition fix (#15193)

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -528,13 +528,15 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             continue;
         }
 
-        // whilst port is idle, poll incoming until portState changes or no more bytes
-        while (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
-
-            // There are bytes incoming - abort pending request
+        // Abort pending request once per activity burst, not per byte.
+        // Prevents multi-byte sequences (e.g. '#\r') from cancelling CLI entry.
+        if (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
             mspPort->lastActivityMs = millis();
             mspPort->pendingRequest = MSP_PENDING_NONE;
+        }
 
+        // whilst port is idle, poll incoming until portState changes or no more bytes
+        while (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
             const uint8_t c = serialRead(mspPort->port);
             if (c == '$') {
                 mspPort->portState = PORT_MSP_PACKET;


### PR DESCRIPTION
## Summary

Backports the fix from #15193 to `2025.12-maintenance`. The bug was introduced by #13940, which shipped in 2025.12.0 — so this race condition is currently live in 2025.12.0 through 2025.12.2.

## Bug

`mspSerialProcess()` was clearing `pendingRequest` once per byte instead of once per activity burst, so multi-byte sequences (`#\r`, `#\r\n`) and MSP polls arriving in the same RX burst as the `#` would cancel CLI entry. Symptom: legacy Android CLI app and `master.app.betaflight.com` web Configurator lose CLI access on ports running MSP.

## Fix

Hoist the `pendingRequest = MSP_PENDING_NONE` assignment out of the byte loop into an outer guard. Three lines moved; cherry-picked cleanly.

## Verification

- Cherry-picked `2a8c9e9fd` cleanly onto current `2025.12-maintenance` head (`e7d45859f`).
- `MATEKF405SE` builds.