### PR TITLE
GPS: add a CLI option to keep UBX-NAV-SAT messages after arm

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6086,6 +6086,11 @@ static void cliStatus(const char *cmdName, char *cmdline)
         }
 #ifdef USE_GPS_UBLOX
         cliPrintf(", version =  %s", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
+        if (gpsConfig()->gps_keep_nav_sat_after_arm == false) {
+            cliPrint("UBX_NAV_SAT messages will be off after arm, ");
+        } else {
+            cliPrint("UBX_NAV_SAT messages will be on after arm, ");
+        }
 #endif
     } else {
         cliPrint("NOT ENABLED");

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6085,11 +6085,14 @@ static void cliStatus(const char *cmdName, char *cmdline)
             }
         }
 #ifdef USE_GPS_UBLOX
-        cliPrintf(", version =  %s", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
-        if (gpsConfig()->gps_keep_nav_sat_after_arm == false) {
-            cliPrint("UBX_NAV_SAT messages will be off after arm, ");
-        } else {
-            cliPrint("UBX_NAV_SAT messages will be on after arm, ");
+        if (gpsConfig()->provider == GPS_UBLOX) {
+            cliPrintf(", version = %s",
+                (gpsData.platformVersion != UBX_VERSION_UNDEF)
+                    ? ubloxVersionMap[gpsData.platformVersion].str
+                    : "unknown");
+            cliPrint(gpsConfig()->gps_keep_nav_sat_after_arm
+                ? ", UBX_NAV_SAT messages will be on after arm"
+                : ", UBX_NAV_SAT messages will be off after arm");
         }
 #endif
     } else {

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1129,6 +1129,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_GPS_UBLOX_UTC_STANDARD,     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_UBLOX_UTC_STANDARD }, PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_ublox_utc_standard) },
     { PARAM_NAME_GPS_UBLOX_USE_GALILEO,      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_ublox_use_galileo) },
     { PARAM_NAME_GPS_UBLOX_ENABLE_ANA,       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_ublox_enable_ana) },
+    { PARAM_NAME_GPS_UBLOX_NAV_SAT_AFTER_ARM,VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_keep_nav_sat_after_arm) },
     { PARAM_NAME_GPS_SET_HOME_POINT_ONCE,    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_set_home_point_once) },
     { PARAM_NAME_GPS_USE_3D_SPEED,           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, gps_use_3d_speed) },
     { PARAM_NAME_GPS_SBAS_INTEGRITY,         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON },         PG_GPS_CONFIG, offsetof(gpsConfig_t, sbas_integrity) },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -261,6 +261,7 @@
 #define PARAM_NAME_GPS_UBLOX_FLIGHT_MODEL "gps_ublox_flight_model"
 #define PARAM_NAME_GPS_UBLOX_UTC_STANDARD "gps_ublox_utc_standard"
 #define PARAM_NAME_GPS_UBLOX_ENABLE_ANA "gps_ublox_enable_ana"
+#define PARAM_NAME_GPS_UBLOX_NAV_SAT_AFTER_ARM "gps_ublox_keep_nav_sat_messages_after_arm"
 #define PARAM_NAME_GPS_SET_HOME_POINT_ONCE "gps_set_home_point_once"
 #define PARAM_NAME_GPS_USE_3D_SPEED "gps_use_3d_speed"
 #define PARAM_NAME_GPS_NMEA_CUSTOM_COMMANDS "gps_nmea_custom_commands"

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2929,7 +2929,7 @@ void GPS_reset_home_position(void)
 
 #ifdef USE_GPS_UBLOX
     // disable Sat Info requests on arming
-    if (gpsConfig()->provider == GPS_UBLOX) {
+    if (gpsConfig()->provider == GPS_UBLOX && gpsConfig()->gps_keep_nav_sat_after_arm == false) {
         setSatInfoMessageRate(0);
     }
 #endif

--- a/src/main/pg/gps.c
+++ b/src/main/pg/gps.c
@@ -49,6 +49,7 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .sbas_integrity = false,
     .gps_ublox_utc_standard = UBLOX_UTC_STANDARD_AUTO,
     .gps_ublox_enable_ana = false,
+    .gps_keep_nav_sat_after_arm = false,
     .nmeaCustomCommands = "",
 );
 

--- a/src/main/pg/gps.h
+++ b/src/main/pg/gps.h
@@ -35,6 +35,7 @@ typedef struct gpsConfig_s {
     uint8_t gps_ublox_acquire_model;
     uint8_t gps_ublox_flight_model;
     uint8_t gps_update_rate_hz;
+    uint8_t gps_keep_nav_sat_after_arm;
     bool gps_ublox_use_galileo;
     bool gps_set_home_point_once;
     bool gps_use_3d_speed;


### PR DESCRIPTION
As mentioned in discussion https://github.com/betaflight/betaflight/discussions/15052 sometimes during the flight the number of satellies may drop below the limit making RTH unavailable. For the long-range cruising we could benefit from keeping UBX-NAV-SAT messages on after arm as soon as aloft the receiver is likely to acquire more satellites which improves positioning accuracy.

The feature is off by default to keep the existing behaviour, however it could be turned on via CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GPS setting to control whether NAV‑SAT messages remain enabled after arming; CLI shows this setting.
* **Bug Fixes**
  * Arming behavior updated to respect the new setting (NAV‑SAT messages now disabled only when the setting is off).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->