### PR TITLE
msp: expose gyro_lpf1_dyn_expo over MSP_FILTER_CONFIG

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2002,6 +2002,12 @@ case MSP_NAME:
             sbufWriteU8(dst, 0);
         }
 #endif
+        // Added in MSP API 1.49
+#if defined(USE_DYN_LPF)
+        sbufWriteU8(dst, gyroConfig()->gyro_lpf1_dyn_expo);
+#else
+        sbufWriteU8(dst, 0);
+#endif
         break;
 
     case MSP_PID_ADVANCED:
@@ -3373,6 +3379,14 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             for (int j = 0; j < RPM_FILTER_HARMONICS_MAX; j++) {
                 sbufReadU8(src);
             }
+#endif
+        }
+        if (sbufBytesRemaining(src) >= 1) {
+            // Added in MSP API 1.49
+#if defined(USE_DYN_LPF)
+            gyroConfigMutable()->gyro_lpf1_dyn_expo = sbufReadU8(src);
+#else
+            sbufReadU8(src);
 #endif
         }
 


### PR DESCRIPTION
## Summary

- Adds `gyro_lpf1_dyn_expo` to `MSP_FILTER_CONFIG` and `MSP_SET_FILTER_CONFIG` so the configurator can read/write it the same way it already does for `dterm_lpf1_dyn_expo` (which has been in MSP since API 1.44).
- Bumps `API_VERSION_MINOR` from 48 to 49.
- Refreshes the hardcoded CRSF CRC byte in the ELRS telemetry MSP-version unit test (now `0x7A`, covers both `API_VERSION_MAJOR` and `API_VERSION_MINOR`).

## Why

`gyro_lpf1_dyn_expo` already exists as a CLI variable, an OSD CMS menu entry, and a blackbox header field, but it is the only piece of the gyro dynamic LPF (`min_hz`, `max_hz`, `expo`) that the configurator cannot reach over MSP. The matching D-term filter exposes all three of these. This patch closes that gap so a configurator change can wire up the UI in the same place it already exposes `dterm_lpf1_dyn_expo`.

The setting controls the curvature of the throttle→cutoff mapping — `dynLpfCutoffFreq()` in `pid.c` (shared by gyro and D-term). Higher expo values keep the cutoff lower at low throttle and ramp up faster near full throttle. With expo = 0 the firmware falls back to the older `dynThrottle()` cubic shaping.

## Compatibility

- Old configurators talking to new firmware: harmless — they don't read the extra byte from `MSP_FILTER_CONFIG`, and `MSP_SET_FILTER_CONFIG` falls back to leaving `gyro_lpf1_dyn_expo` at its existing value if the trailing byte is missing (`sbufBytesRemaining(src) >= 1` guard).
- New configurator talking to old firmware: the trailing byte is reported as zero / the old configurator's set won't include it; behaviour is preserved.

## Related

- Maintenance PR [betaflight#15204](https://github.com/betaflight/betaflight/pull/15204) replaces the hardcoded ELRS test CRC with a runtime computation so future API bumps don't need to touch this test. If that lands first, this PR's test-file edit becomes redundant on rebase.
- Configurator side: [betaflight-configurator#5095](https://github.com/betaflight/betaflight-configurator/pull/5095).

## Test plan

- [ ] CI build passes for all targets
- [ ] CI unit tests pass
- [ ] Verify `MSP_FILTER_CONFIG` round-trip with the configurator branch from #5095 (read/write/persist)
- [ ] CLI `gyro_lpf1_dyn_expo` still accepts 0–10 and persists across reboot (unchanged)

## Notes for reviewers

- Same shape as the API 1.44 addition for `dterm_lpf1_dyn_expo`; nothing novel in protocol design.
- `gyro_lpf1_dyn_expo` lives in `gyroConfig` (master/global), unlike `dterm_lpf1_dyn_expo` which lives in `pidProfile`. The MSP code uses `gyroConfigMutable()` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MSP API 1.49 support for gyro low-pass filter dynamic exponential configuration, enabling users to adjust gyro filtering parameters through compatible configuration tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15203)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->