### PR TITLE
test: compute CRSF CRC at runtime in ELRS MSP version test

### DIFF
--- a/src/test/unit/rx_spi_expresslrs_telemetry_unittest.cc
+++ b/src/test/unit/rx_spi_expresslrs_telemetry_unittest.cc
@@ -29,6 +29,7 @@ extern "C" {
     #include "platform.h"
 
     #include "build/version.h"
+    #include "common/crc.h"
     #include "common/printf.h"
 
     #include "drivers/io.h"
@@ -227,7 +228,11 @@ TEST(RxSpiExpressLrsTelemetryUnitTest, TestFlightMode)
 TEST(RxSpiExpressLrsTelemetryUnitTest, TestMspVersionRequest)
 {
     uint8_t request[15] = {238, 12, 122, 200, 234, 48, 0, 1, 1, 0, 0, 0, 0, 128, 0};
-    uint8_t response[12] = {200, 10, 123, 234, 200, 48, 3, 1, 0, API_VERSION_MAJOR, API_VERSION_MINOR, 0xAF};
+    uint8_t response[12] = {200, 10, 123, 234, 200, 48, 3, 1, 0, API_VERSION_MAJOR, API_VERSION_MINOR, 0};
+    // Last byte is the CRSF CRC-8 (poly 0xD5) over the frame bytes from the type byte
+    // through the last data byte (response[2..10]); compute it at runtime so this test
+    // does not need to be touched when API_VERSION_MAJOR or API_VERSION_MINOR change.
+    response[11] = crc8_dvb_s2_update(0, &response[2], 9);
     uint8_t data1[6] = {1, request[0], request[1], request[2], request[3], request[4]};
     uint8_t data2[6] = {2, request[5], request[6], request[7], request[8], request[9]};
     uint8_t data3[6] = {3, request[10], request[11], request[12], request[13], request[14]};


### PR DESCRIPTION
## Summary

Replaces the hardcoded CRSF CRC byte in `TestMspVersionRequest` (`rx_spi_expresslrs_telemetry_unittest.cc`) with a runtime call to `crc8_dvb_s2_update()` so the test no longer needs to be edited every time `API_VERSION_MAJOR` or `API_VERSION_MINOR` changes.

## Why

The test builds an expected MSP-version response frame and compares it byte-for-byte against the telemetry payload, including the trailing CRSF CRC-8. That CRC is computed over `response[2..10]`, which contains both `API_VERSION_MAJOR` and `API_VERSION_MINOR`. Any API version bump silently invalidates the hardcoded constant — and the test then fails on the byte-equality loop at line 268, with no hint that the real cause is a stale checksum rather than a problem with the version values themselves.

This is the kind of paper cut every API bump PR has had to deal with. The fix is small: `common/crc.c` is already linked into this test target, so it's a one-line `#include` plus replacing the constant with a call to the CRSF polynomial helper that the firmware itself uses.

## Out of scope

This is split out from the API-1.49 bump in [betaflight#15203](https://github.com/betaflight/betaflight/pull/15203) (where the maintenance trap was originally surfaced) so it can be reviewed and landed on its own merits, independent of any feature work.

## Test plan

- [ ] `make test` passes — the existing `EXPECT_EQ(response[i], payload[i])` loop now validates a CRC computed by the same helper the production code uses, so any divergence still fails the test loudly.
- [ ] No behaviour change at the current API version (1.48): the runtime computation produces the same `0xAF` that was previously hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness for telemetry validation by computing expected values dynamically instead of using hardcoded data, reducing maintenance burden when dependencies change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->