### PR TITLE
telemetry/mavlink: send GLOBAL_POSITION_INT.hdg in centidegrees

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -116,6 +116,11 @@ static int16_t headingOrScaledMilliAmpereHoursDrawn(void)
     return DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 }
 
+static uint16_t getHeadingCentidegrees(void)
+{
+    return (uint16_t)(attitude.values.yaw * 10);
+}
+
 void freeMAVLinkTelemetryPort(void)
 {
     closeSerialPort(mavlinkPort);
@@ -334,8 +339,8 @@ static void mavlinkSendPosition(void)
         gpsSol.velned.velE,
         // Ground Z Speed (Altitude), expressed as m/s * 100
         gpsSol.velned.velD,
-        // heading Current heading in degrees, in compass units (0..360, 0=north)
-        headingOrScaledMilliAmpereHoursDrawn()
+        // hdg Vehicle heading (yaw angle), 0.0..359.99 degrees in centidegrees. UINT16_MAX = unknown.
+        getHeadingCentidegrees()
     );
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);


### PR DESCRIPTION
## Summary

`GLOBAL_POSITION_INT.hdg` is specified in centidegrees (0..35999) per the MAVLink common dialect, but the existing helper returns degrees — a 100x under-scale that leaves QGroundControl's heading indicator only sweeping the first ~3.6 degrees of compass before clipping back to zero.

## What changed

- New `getHeadingCentidegrees()` helper for cdeg-spec MAVLink fields.
- `GLOBAL_POSITION_INT.hdg` now uses it; field doc-comment corrected.
- `VFR_HUD.heading` is degrees per spec and keeps the original helper, including its mAh-as-heading override for the Connex Prosight OSD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected heading data in GPS position messages. The heading field now properly computes from vehicle yaw in centidegrees, replacing a previous ambiguous calculation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->