### PR TITLE
build(make): switch arm sdk download to xpack github cdn

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -26,28 +26,26 @@ GCC_REQUIRED_VERSION ?= 13.3.1
 ## arm_sdk_install   : Install Arm SDK
 .PHONY: arm_sdk_install
 
-# source: https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
+# source: https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases
+XPACK_VERSION := 13.3.1-1.1
 ifeq ($(OSFAMILY)-$(ARCHFAMILY), linux-x86_64)
-  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
-  DL_CHECKSUM = 0601a9588bc5b9c99ad2b56133b7f118
+  ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-linux-x64.tar.gz
+  DL_CHECKSUM = 006c89337eced277fdf4c1c3bf3aebe55c85e8d52cba8d412009717fb781b959
 else ifeq ($(OSFAMILY)-$(ARCHFAMILY), macosx-x86_64)
-  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
-  DL_CHECKSUM = 4bb141e44b831635fde4e8139d470f1f
+  ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-darwin-x64.tar.gz
+  DL_CHECKSUM = afd69764478275ee3e5b9a12d61250ae348a79a4d1fa767e5fa2762ae8b77b2a
 else ifeq ($(OSFAMILY)-$(ARCHFAMILY), macosx-arm64)
-  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz
-  DL_CHECKSUM = f1c18320bb3121fa89dca11399273f4e
+  ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-darwin-arm64.tar.gz
+  DL_CHECKSUM = e37c379cbc423353902aada84b2b4d5a9316c2c8746c9608e69c8ac23e654aa3
 else ifeq ($(OSFAMILY), windows)
-  ARM_SDK_URL := https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip
-  DL_CHECKSUM = 39d9882ca0eb475e81170ae826c1435d
+  ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-win32-x64.zip
+  DL_CHECKSUM = 49cda1bf01215f3df0613972d21f9fec3eb79dca82506365e7da2ff74b921733
 else
   $(error No toolchain URL defined for $(OSFAMILY)-$(ARCHFAMILY))
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
-# remove compression suffixes
-ARM_SDK_DIR := $(TOOLS_DIR)/$(patsubst %.zip,%, 	\
-			    $(patsubst %.tar.xz,%, 	\
-			    $(notdir $(ARM_SDK_URL))))
+ARM_SDK_DIR := $(TOOLS_DIR)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)
 
 SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/.installed
 
@@ -62,7 +60,7 @@ arm_sdk_install: arm_sdk_download $(SDK_INSTALL_MARKER)
 
 $(SDK_INSTALL_MARKER): $(DL_DIR)/$(ARM_SDK_FILE)
         # verify ckecksum first
-	@checksum=$$(md5sum "$<" | awk '{print $$1}'); \
+	@checksum=$$(sha256sum "$<" | awk '{print $$1}'); \
 	if [ "$$checksum" != "$(DL_CHECKSUM)" ]; then \
 		echo "$@ Checksum mismatch! Expected $(DL_CHECKSUM), got $$checksum."; \
 		exit 1; \

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -81,7 +81,7 @@ arm_sdk_download: | $(DL_DIR)
 arm_sdk_download: $(DL_DIR)/$(ARM_SDK_FILE)
 $(DL_DIR)/$(ARM_SDK_FILE):
         # download the source only if it's newer than what we already have
-	$(V1) curl -L -k -o "$@" $(if $(wildcard $@), -z "$@",) "$(ARM_SDK_URL)"
+	$(V1) curl -L -k --fail -o "$@" $(if $(wildcard $@), -z "$@",) "$(ARM_SDK_URL)"
 
 ## arm_sdk_clean     : Uninstall Arm SDK
 .PHONY: arm_sdk_clean

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -37,6 +37,9 @@ else ifeq ($(OSFAMILY)-$(ARCHFAMILY), macosx-x86_64)
 else ifeq ($(OSFAMILY)-$(ARCHFAMILY), macosx-arm64)
   ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-darwin-arm64.tar.gz
   DL_CHECKSUM = e37c379cbc423353902aada84b2b4d5a9316c2c8746c9608e69c8ac23e654aa3
+else ifeq ($(OSFAMILY)-$(ARCHFAMILY), linux-arm64)
+  ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-linux-arm64.tar.gz
+  DL_CHECKSUM = 34fa25d7dcd57bfdd3aeff5c595eac20dbf21a2d84b72e6c2db3bc67d556a1af
 else ifeq ($(OSFAMILY), windows)
   ARM_SDK_URL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_VERSION)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)-win32-x64.zip
   DL_CHECKSUM = 49cda1bf01215f3df0613972d21f9fec3eb79dca82506365e7da2ff74b921733


### PR DESCRIPTION
AI Generated pull-request

Resolves #15206

## Summary

Replaces the Arm developer portal download (`developer.arm.com`) with the [xPack GNU Arm Embedded GCC](https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack) distribution served via GitHub CDN. GCC version remains **13.3.1** — xPack repackages the same toolchain, just from a faster host.

## Motivation

The Arm developer portal's media servers are slow and variable. Measured locally:

| Source | Archive | Download Time | Relative Speed |
|--------|---------|---------------|----------------|
| `developer.arm.com` | `.tar.xz` | 12m 33s | baseline |
| xPack GitHub CDN | `.tar.gz` | 3m 10s | **~3.9× faster** |

The GitHub CDN maintained a consistently high transfer rate throughout; the Arm host showed noticeable variability. Despite xPack's `.tar.gz` being marginally larger than the `.tar.xz`, the CDN throughput advantage makes it significantly faster in practice.

## Changes to `mk/tools.mk`

| What | Before | After |
|------|--------|-------|
| Download source | `developer.arm.com` | `github.com/xpack-dev-tools/.../releases` |
| Version variable | hardcoded in URL | `XPACK_VERSION := 13.3.1-1.1` |
| Install dir | derived via `patsubst %.tar.xz` chain | explicit `$(TOOLS_DIR)/xpack-arm-none-eabi-gcc-$(XPACK_VERSION)` |
| Linux archive | `.tar.xz` | `.tar.gz` |
| macOS archives | `.tar.xz` | `.tar.gz` |
| Windows archive | `.zip` | `.zip` (same extension, updated filename) |
| Checksum algorithm | MD5 (`md5sum`) | SHA-256 (`sha256sum`) — matches xPack published checksums |
| `tar` flag | `tar -xf` | `tar -xf` (unchanged; auto-detects compression) |

The `patsubst` chain that derived `ARM_SDK_DIR` from the filename assumed the archive name matched the internal directory name. xPack's naming convention includes a platform suffix in the archive name (`-linux-x64`) that is absent from the extracted directory, so the derivation is replaced with an explicit assignment.

## CI

No workflow changes required. The cache key in `ci.yml` includes `hashFiles('mk/tools.mk')` and auto-invalidates when this file changes.

## Test plan

- [x] `make arm_sdk_download` — skips correctly when file already present
- [x] `make arm_sdk_install` — SHA-256 checksum passes; extracts to `tools/xpack-arm-none-eabi-gcc-13.3.1-1.1/`; `.installed` marker created
- [x] `make arm_sdk_version` — reports `arm-none-eabi-gcc (xPack GNU Arm Embedded GCC x86_64) 13.3.1 20240614`
- [x] `make STM32F405 STM32F411 STM32H743` — all targets build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now uses xpack-distributed ARM toolchain artifacts and a fixed, versioned install path.
  * Toolchain version pinned to 13.3.1-1.1 for reproducible installs.
  * Download now fails fast on HTTP errors.
  * Checksum verification upgraded from MD5 to SHA-256 for stronger integrity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->