### PR TITLE
fix(build): detect git worktrees when setting REVISION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ include $(TARGET_DIR)/target.mk
 endif
 
 REVISION := norevision
-ifneq ($(wildcard .git/),)
+ifneq ($(wildcard .git),)
 ifeq ($(shell git diff --shortstat),)
 REVISION := $(shell git rev-parse --short=9 HEAD)
 endif


### PR DESCRIPTION
AI Generated pull-request

Resolves #15208

## Summary

- `$(wildcard .git/)` requires `.git` to be a directory; in a git worktree `.git` is a file, so the guard never fires and `REVISION` stays `norevision`
- Remove the trailing slash: `$(wildcard .git)` matches both a `.git` directory (normal checkout) and a `.git` file (worktree)

## Change

```diff
-ifneq ($(wildcard .git/),)
+ifneq ($(wildcard .git),)
```

One character. No other files touched.

## Test

Built `FOXEERF405` from a worktree; confirmed `strings` output on the ELF shows the real 9-char SHA (`85775c497`) instead of `norevision`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system's Git revision detection logic to more accurately identify repository state and assign version metadata accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->