### PR TITLE
telemetry/mavlink: add RX dispatch and handshake responders

### DIFF
--- a/src/main/rx/mavlink.h
+++ b/src/main/rx/mavlink.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define MAVLINK_COMM_NUM_BUFFERS 1
+#define MAVLINK_COMM_NUM_BUFFERS 2
 #define RSSI_DBM_MIN (-130)
 #define RSSI_DBM_MAX 0
 

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -83,7 +83,7 @@
 #include "common/mavlink.h"
 #pragma GCC diagnostic pop
 
-#define TELEMETRY_MAVLINK_INITIAL_PORT_MODE MODE_TX
+#define TELEMETRY_MAVLINK_INITIAL_PORT_MODE MODE_RXTX
 #define TELEMETRY_MAVLINK_MAXRATE 50
 #define TELEMETRY_MAVLINK_DELAY ((1000 * 1000) / TELEMETRY_MAVLINK_MAXRATE)
 
@@ -98,6 +98,10 @@ static bool mavlinkTelemetryEnabled =  false;
 static portSharing_e mavlinkPortSharing;
 static uint32_t lastMavlinkMessageTime = 0;
 static armingDisableFlags_e lastArmingDisableFlags = 0;
+
+static mavlink_message_t mavRxMsg;
+static mavlink_status_t mavRxStatus;
+static bool mavlinkPortOwned = false;
 
 static mavlink_message_t mavMsg;
 static uint8_t mavBuffer[MAVLINK_MAX_PACKET_LEN];
@@ -187,10 +191,85 @@ static void mavlinkSendSystemTime(void)
     mavlinkSerialWrite(mavBuffer, msgLength);
 }
 
+static void handleHeartbeatRx(const mavlink_message_t *msg)
+{
+    UNUSED(msg);
+    // Stub for now; later tiers will track GCS liveness and target replies by sysid/compid.
+}
+
+static void handlePing(const mavlink_message_t *msg)
+{
+    mavlink_ping_t ping;
+    mavlink_msg_ping_decode(msg, &ping);
+
+    if ((ping.target_system != 0 && ping.target_system != MAVLINK_SYSTEM_ID) ||
+        (ping.target_component != 0 && ping.target_component != MAVLINK_COMPONENT_ID)) {
+        return;
+    }
+
+    mavlink_msg_ping_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        ping.time_usec,
+        ping.seq,
+        msg->sysid,
+        msg->compid);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void handleTimesync(const mavlink_message_t *msg)
+{
+    mavlink_timesync_t timesync;
+    mavlink_msg_timesync_decode(msg, &timesync);
+
+    // tc1 == 0 marks a request from the GCS; non-zero is a response we never solicited.
+    if (timesync.tc1 != 0) {
+        return;
+    }
+
+    mavlink_msg_timesync_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        (int64_t)micros() * 1000LL,
+        timesync.ts1,
+        msg->sysid,
+        msg->compid);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkDispatch(const mavlink_message_t *msg)
+{
+    switch (msg->msgid) {
+    case MAVLINK_MSG_ID_HEARTBEAT:
+        handleHeartbeatRx(msg);
+        break;
+    case MAVLINK_MSG_ID_PING:
+        handlePing(msg);
+        break;
+    case MAVLINK_MSG_ID_TIMESYNC:
+        handleTimesync(msg);
+        break;
+    default:
+        break;
+    }
+}
+
+static void mavlinkProcessIncoming(void)
+{
+    if (!mavlinkPortOwned || !mavlinkPort) {
+        return;
+    }
+    while (serialRxBytesWaiting(mavlinkPort)) {
+        const uint8_t c = serialRead(mavlinkPort);
+        if (mavlink_parse_char(MAVLINK_COMM_1, c, &mavRxMsg, &mavRxStatus) == MAVLINK_FRAMING_OK) {
+            mavlinkDispatch(&mavRxMsg);
+        }
+    }
+}
+
 void freeMAVLinkTelemetryPort(void)
 {
     closeSerialPort(mavlinkPort);
     mavlinkPort = NULL;
+    mavlinkPortOwned = false;
     mavlinkTelemetryEnabled = false;
 }
 
@@ -220,6 +299,7 @@ void configureMAVLinkTelemetryPort(void)
 
     // Reset STATUSTEXT de-dup so the first run after link-up emits any current disable reasons.
     lastArmingDisableFlags = 0;
+    mavlinkPortOwned = true;
     mavlinkTelemetryEnabled = true;
 }
 
@@ -750,6 +830,7 @@ void checkMAVLinkTelemetryState(void)
         if (!mavlinkTelemetryEnabled && telemetrySharedPort != NULL) {
             mavlinkPort = telemetrySharedPort;
             lastArmingDisableFlags = 0;
+            mavlinkPortOwned = false;
             mavlinkTelemetryEnabled = true;
             configureMAVLinkStreamRates();
         }
@@ -774,6 +855,8 @@ void handleMAVLinkTelemetry(void)
     if (!mavlinkTelemetryEnabled || !mavlinkPort) {
         return;
     }
+
+    mavlinkProcessIncoming();
 
     bool shouldSendTelemetry = false;
     uint32_t now = micros();

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -202,8 +202,9 @@ static void handlePing(const mavlink_message_t *msg)
     mavlink_ping_t ping;
     mavlink_msg_ping_decode(msg, &ping);
 
-    if ((ping.target_system != 0 && ping.target_system != MAVLINK_SYSTEM_ID) ||
-        (ping.target_component != 0 && ping.target_component != MAVLINK_COMPONENT_ID)) {
+    // PING request per spec has target_system == 0 && target_component == 0;
+    // non-zero target fields indicate a response, which we must not echo back.
+    if (ping.target_system != 0 || ping.target_component != 0) {
         return;
     }
 
@@ -221,8 +222,14 @@ static void handleTimesync(const mavlink_message_t *msg)
     mavlink_timesync_t timesync;
     mavlink_msg_timesync_decode(msg, &timesync);
 
-    // tc1 == 0 marks a request from the GCS; non-zero is a response we never solicited.
+    // tc1 == 0 marks a request; non-zero is a response we never solicited.
     if (timesync.tc1 != 0) {
+        return;
+    }
+
+    // Accept broadcast or directed-to-us; ignore requests addressed to other systems.
+    if ((timesync.target_system != 0 && timesync.target_system != MAVLINK_SYSTEM_ID) ||
+        (timesync.target_component != 0 && timesync.target_component != MAVLINK_COMPONENT_ID)) {
         return;
     }
 
@@ -257,7 +264,9 @@ static void mavlinkProcessIncoming(void)
     if (!mavlinkPortOwned || !mavlinkPort) {
         return;
     }
-    while (serialRxBytesWaiting(mavlinkPort)) {
+    // Bound the drain so a flooded link cannot starve the telemetry task.
+    uint16_t rxBudget = 64;
+    while (rxBudget-- && serialRxBytesWaiting(mavlinkPort)) {
         const uint8_t c = serialRead(mavlinkPort);
         if (mavlink_parse_char(MAVLINK_COMM_1, c, &mavRxMsg, &mavRxStatus) == MAVLINK_FRAMING_OK) {
             mavlinkDispatch(&mavRxMsg);
@@ -300,6 +309,7 @@ void configureMAVLinkTelemetryPort(void)
     // Reset STATUSTEXT de-dup so the first run after link-up emits any current disable reasons.
     lastArmingDisableFlags = 0;
     mavlinkPortOwned = true;
+    mavlink_reset_channel_status(MAVLINK_COMM_1);
     mavlinkTelemetryEnabled = true;
 }
 


### PR DESCRIPTION
## Summary

Foundation for QGroundControl two-way support. The MAVLink telemetry port is currently TX-only; this PR opens it `MODE_RXTX`, adds a parse loop that decodes incoming MAVLink frames, and dispatches by msgid. It is the structural keystone for the COMMAND/MISSION/PARAM handlers in upcoming PRs.

Three handshake responders ship with the infrastructure to validate the dispatcher end-to-end against a real GCS:

- **HEARTBEAT** — stub; later tiers will track GCS liveness and target replies by sysid/compid.
- **PING** — echo `time_usec`/`seq`; target the requesting sysid/compid in the reply.
- **TIMESYNC** — on `tc1 == 0` (request), reply with our time in ns and echoed `ts1`.

## Channel allocation

The new parser uses `MAVLINK_COMM_1` so it does not collide with `rx/mavlink.c`'s `MAVLINK_COMM_0` in builds where MAVLink is also the serial RX provider. `MAVLINK_COMM_NUM_BUFFERS` is bumped from 1 to 2 to size the channel arrays accordingly. RAM cost: one extra `mavlink_message_t` + `mavlink_status_t` (~325 bytes).

## Shared-port behaviour

When MAVLink is the serial RX provider, the telemetry port is shared (`telemetrySharedPort`) and `rx/mavlink.c` already drains bytes via its byte-callback. To avoid double-consumption, dispatch in this PR is gated on `mavlinkPortOwned`, which is `false` when the shared port is adopted. `rx/mavlink.c` remains the sole parser in that case. Routing the shared-port path through this dispatcher is a separate refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable bidirectional MAVLink: device now parses incoming frames and can respond to HEARTBEAT, PING and TIMESYNC.

* **Improvements**
  * Increased MAVLink buffer capacity for more robust serial handling.

* **Stability**
  * Added port ownership/handling to prevent conflicts when sharing the MAVLink port.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15211)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->