### PR TITLE
feat(devcontainer): add Gazebo SITL simulation container

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -279,12 +279,16 @@ docker build -t bf-dev-gazebo -f .devcontainer/containerfile.gazebo .devcontaine
 The simulation requires three processes running concurrently inside the container.
 Use three separate host terminals — the first starts the container, the others attach to it.
 
+> **Note:** Gazebo's GUI requires a display. On Linux the `docker run` command below forwards your host X11 socket into the container. On macOS, install [XQuartz](https://www.xquartz.org) and run `xhost +localhost` first.
+
 **Host terminal 1 — start the container and build SITL:**
 
 ```bash
 docker run -it --rm \
   --name bf-gazebo \
   --network=host \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v "$(pwd)":/workspace \
   bf-dev-gazebo
 
@@ -292,7 +296,7 @@ docker run -it --rm \
 make TARGET=SITL
 
 # Then start SITL
-./obj/main/betaflight_SITL.elf 127.0.0.1
+./obj/main/betaflight_SITL.elf
 ```
 
 **Host terminal 2 — attach and start Gazebo:**

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -276,23 +276,40 @@ docker build -t bf-dev-gazebo -f .devcontainer/containerfile.gazebo .devcontaine
 
 ### Running a simulation
 
+The simulation requires three processes running concurrently inside the container.
+Use three separate host terminals — the first starts the container, the others attach to it.
+
+**Host terminal 1 — start the container and build SITL:**
+
 ```bash
-# Start the container with host networking (for UDP ports)
 docker run -it --rm \
+  --name bf-gazebo \
   --network=host \
   -v "$(pwd)":/workspace \
   bf-dev-gazebo
 
-# Inside the container — build SITL
+# Inside the container — build SITL (only needed once per workspace)
 make TARGET=SITL
 
-# Terminal 1: Start SITL
+# Then start SITL
 ./obj/main/betaflight_SITL.elf 127.0.0.1
+```
 
-# Terminal 2: Start Gazebo with the demo world
+**Host terminal 2 — attach and start Gazebo:**
+
+```bash
+docker exec -it bf-gazebo bash
+
+# Inside the container
 gz sim -r ~/aeroloop_gazebo/worlds/betaloop_iris_betaflight_demo_harmonic.sdf
+```
 
-# Terminal 3: Start WebSocket proxy for the Betaflight App
+**Host terminal 3 — attach and start the WebSocket proxy:**
+
+```bash
+docker exec -it bf-gazebo bash
+
+# Inside the container
 websockify 127.0.0.1:6761 127.0.0.1:5761
 ```
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -250,7 +250,7 @@ This allows testing firmware changes without physical hardware.
 
 ### Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │  Gazebo Container                                   │
 │                                                     │

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -242,3 +242,68 @@ You can then build and flash the firmware as usual:
         Transitioning to dfuMANIFEST state
 
 ```
+
+## Gazebo SITL Simulation
+
+A separate container is provided for running Betaflight SITL with [Gazebo Harmonic](https://gazebosim.org/) simulation.
+This allows testing firmware changes without physical hardware.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Gazebo Container                                   │
+│                                                     │
+│  ┌──────────────┐  UDP 9002/9003  ┌──────────────┐  │
+│  │   Gazebo      │◄──────────────►│ Betaflight   │  │
+│  │   Harmonic    │  motor/sensor  │ SITL (.elf)  │  │
+│  │   + Bridge    │                │              │  │
+│  └──────────────┘                └──────┬───────┘  │
+│                                         │ TCP 5761 │
+└─────────────────────────────────────────┼──────────┘
+                                          │
+                              ┌───────────▼──────────┐
+                              │  Betaflight App      │
+                              │  ws://localhost:6761  │
+                              └──────────────────────┘
+```
+
+### Building the Gazebo container
+
+```bash
+docker build -t bf-dev-gazebo -f .devcontainer/containerfile.gazebo .devcontainer/
+```
+
+### Running a simulation
+
+```bash
+# Start the container with host networking (for UDP ports)
+docker run -it --rm \
+  --network=host \
+  -v "$(pwd)":/workspace \
+  bf-dev-gazebo
+
+# Inside the container — build SITL
+make TARGET=SITL
+
+# Terminal 1: Start SITL
+./obj/main/betaflight_SITL.elf 127.0.0.1
+
+# Terminal 2: Start Gazebo with the demo world
+gz sim -r ~/aeroloop_gazebo/worlds/betaloop_iris_betaflight_demo_harmonic.sdf
+
+# Terminal 3: Start WebSocket proxy for the Betaflight App
+websockify 127.0.0.1:6761 127.0.0.1:5761
+```
+
+Then connect the Betaflight App to `ws://127.0.0.1:6761`.
+
+### Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 9002 | UDP | SITL → Gazebo (motor commands) |
+| 9003 | UDP | Gazebo → SITL (sensor data) |
+| 9004 | UDP | External → SITL (RC input) |
+| 5761 | TCP | SITL UART1 (MSP serial proxy) |
+| 6761 | TCP | WebSocket proxy for Betaflight App |

--- a/.devcontainer/containerfile.gazebo
+++ b/.devcontainer/containerfile.gazebo
@@ -1,0 +1,106 @@
+# Gazebo Harmonic + Betaflight SITL simulation container
+# Provides a complete simulation environment for testing Betaflight firmware
+# without physical hardware.
+#
+# Communication:
+#   SITL ←→ Gazebo via UDP (ports 9002/9003)
+#   SITL ←→ Configurator via TCP/WebSocket (port 5761/6761)
+#   SITL ←→ RC input via UDP (port 9004)
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base tools
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    locales \
+    git \
+    ca-certificates \
+    curl \
+    wget \
+    sudo \
+    bash \
+    bash-completion \
+    nano \
+    btop \
+    build-essential \
+    cmake \
+    pkg-config \
+    clang-18 \
+    python3 \
+    python3-pip \
+    python3-websockify \
+    && rm -rf /var/lib/apt/lists/*
+
+# Generate locale
+RUN sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# Install cppzmq before Gazebo repo (needed for gz-transport linking)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cppzmq-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Gazebo Harmonic from OSRF packages
+RUN curl -fsSL https://packages.osrfoundation.org/gazebo.gpg | \
+    dd of=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable noble main" | \
+    tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gz-harmonic \
+    libgz-sim8-dev \
+    libgz-plugin2-dev \
+    libgz-math7-dev \
+    libgz-transport13-dev \
+    libgz-msgs10-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Betaflight firmware build dependencies (for SITL target)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    python-is-python3 \
+    libblocksruntime-dev \
+    xxd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set clang alternatives
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+
+# Reuse Ubuntu's default user (UID/GID 1000) or create devpod
+ARG USERNAME=devpod
+
+RUN if id -u 1000 >/dev/null 2>&1; then \
+        EXISTING=$(id -nu 1000) && \
+        usermod -l $USERNAME -d /home/$USERNAME -m $EXISTING 2>/dev/null || true && \
+        groupmod -n $USERNAME $(id -gn 1000) 2>/dev/null || true; \
+    else \
+        groupadd --gid 1000 $USERNAME && \
+        useradd --uid 1000 --gid 1000 -m $USERNAME --shell /bin/bash; \
+    fi && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER $USERNAME
+
+# Clone and build the Betaflight Gazebo bridge plugin
+RUN git clone --branch gz https://github.com/betaflight/aeroloop_gazebo.git /home/$USERNAME/aeroloop_gazebo && \
+    cd /home/$USERNAME/aeroloop_gazebo/plugins && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make -j$(nproc)
+
+# Set Gazebo environment for aeroloop models and plugins
+ENV SDF_PATH="/home/$USERNAME/aeroloop_gazebo/models"
+ENV GZ_SIM_RESOURCE_PATH="/home/$USERNAME/aeroloop_gazebo/worlds"
+ENV GZ_SIM_SYSTEM_PLUGIN_PATH="/home/$USERNAME/aeroloop_gazebo/plugins/build"
+
+WORKDIR /workspace
+
+# Default: start bash (user launches SITL + Gazebo manually)
+CMD [ "bash" ]

--- a/.devcontainer/containerfile.gazebo
+++ b/.devcontainer/containerfile.gazebo
@@ -89,8 +89,11 @@ RUN if id -u 1000 >/dev/null 2>&1; then \
 USER $USERNAME
 
 # Clone and build the Betaflight Gazebo bridge plugin
+ARG AEROLOOP_REF=a6c16d2d653932a96ced279522ba39b6da15f78c
 RUN git clone --branch gz https://github.com/betaflight/aeroloop_gazebo.git /home/$USERNAME/aeroloop_gazebo && \
-    cd /home/$USERNAME/aeroloop_gazebo/plugins && \
+    cd /home/$USERNAME/aeroloop_gazebo && \
+    git checkout "$AEROLOOP_REF" && \
+    cd plugins && \
     mkdir build && cd build && \
     cmake .. && \
     make -j$(nproc)

--- a/.devcontainer/devcontainer.gazebo.json
+++ b/.devcontainer/devcontainer.gazebo.json
@@ -1,0 +1,13 @@
+{
+  "name": "betaflight gazebo SITL",
+  "build": {
+    "dockerfile": "containerfile.gazebo",
+    "context": "."
+  },
+  "runArgs": [
+    "--network=host"
+  ],
+  "remoteUser": "devpod",
+  "features": {},
+  "forwardPorts": [5761, 6761, 9002, 9003, 9004]
+}


### PR DESCRIPTION
## Summary

- Add a separate devcontainer (`containerfile.gazebo`) for running Betaflight SITL with Gazebo Harmonic simulation
- Include `devcontainer.gazebo.json` with host networking and port forwarding for SITL/Gazebo UDP communication
- Update `.devcontainer/README.md` with Gazebo SITL section: architecture diagram, build/run instructions, and port reference

## Details

This enables testing firmware changes without physical hardware by providing a containerized Gazebo Harmonic environment with the [aeroloop_gazebo](https://github.com/betaflight/aeroloop_gazebo) bridge plugin pre-built.

**Container includes:**
- Ubuntu 24.04 base with Gazebo Harmonic 8.11
- clang-18 and SITL build dependencies
- aeroloop_gazebo bridge plugin (motor/sensor UDP bridge)
- websockify for Betaflight App WebSocket connectivity

**Communication:**
| Port | Protocol | Purpose |
|------|----------|---------|
| 9002 | UDP | SITL → Gazebo (motor commands) |
| 9003 | UDP | Gazebo → SITL (sensor data) |
| 9004 | UDP | External → SITL (RC input) |
| 5761 | TCP | SITL UART1 (MSP serial proxy) |
| 6761 | TCP | WebSocket proxy for Betaflight App |

## Test plan

- [x] Build the Gazebo container: `docker build -t bf-dev-gazebo -f .devcontainer/containerfile.gazebo .devcontainer/`
- [x] Run container and build SITL: `make TARGET=SITL`
- [x] Start SITL + Gazebo + websockify and verify communication
- [x] Connect Betaflight App to `ws://127.0.0.1:6761`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Gazebo SITL simulation guide with architecture diagram, Docker build/run instructions, terminal workflow for running the simulation and proxies, and a ports/protocol table.

* **Chores**
  * Added a devcontainer configuration and accompanying container image definition to provision a Gazebo Harmonic + Betaflight SITL environment with required tooling, locales, build steps, and forwarded ports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->