### PR TITLE
telemetry/mavlink: add HOME_POSITION/SYSTEM_TIME/STATUSTEXT TX

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -34,6 +34,7 @@
 #include "common/maths.h"
 #include "common/axis.h"
 #include "common/color.h"
+#include "common/time.h"
 #include "common/utils.h"
 
 #include "config/feature.h"
@@ -96,6 +97,7 @@ static const serialPortConfig_t *portConfig;
 static bool mavlinkTelemetryEnabled =  false;
 static portSharing_e mavlinkPortSharing;
 static uint32_t lastMavlinkMessageTime = 0;
+static armingDisableFlags_e lastArmingDisableFlags = 0;
 
 static mavlink_message_t mavMsg;
 static uint8_t mavBuffer[MAVLINK_MAX_PACKET_LEN];
@@ -119,6 +121,68 @@ static int16_t headingOrScaledMilliAmpereHoursDrawn(void)
 static uint16_t getHeadingCentidegrees(void)
 {
     return (uint16_t)(attitude.values.yaw * 10);
+}
+
+static void mavlinkSendStatusText(uint8_t severity, const char *text)
+{
+    mavlink_msg_statustext_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        severity, text, 0, 0);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkProcessArmingStatusText(void)
+{
+    const armingDisableFlags_e flags = getArmingDisableFlags();
+    if (flags == lastArmingDisableFlags) {
+        return;
+    }
+    lastArmingDisableFlags = flags;
+
+    if (flags == 0) {
+        return;
+    }
+
+    char text[50] = "Arming disabled:";
+    size_t pos = strlen(text);
+
+    for (int bit = 0; bit < 32 && pos < sizeof(text) - 1; bit++) {
+        const armingDisableFlags_e thisFlag = (armingDisableFlags_e)(1u << bit);
+        if (!(flags & thisFlag)) {
+            continue;
+        }
+        const char *name = getArmingDisableFlagName(thisFlag);
+        if (!name) {
+            continue;
+        }
+        if (pos < sizeof(text) - 1) {
+            text[pos++] = ' ';
+        }
+        const size_t nameLen = strlen(name);
+        const size_t avail = sizeof(text) - 1 - pos;
+        const size_t copyLen = (nameLen < avail) ? nameLen : avail;
+        memcpy(text + pos, name, copyLen);
+        pos += copyLen;
+    }
+    text[pos] = '\0';
+
+    mavlinkSendStatusText(MAV_SEVERITY_NOTICE, text);
+}
+
+static void mavlinkSendSystemTime(void)
+{
+    uint64_t timeUnixUsec = 0;
+#ifdef USE_RTC_TIME
+    rtcTime_t rtcMs;
+    if (rtcHasTime() && rtcGet(&rtcMs) && rtcMs > 0) {
+        timeUnixUsec = (uint64_t)rtcMs * 1000ULL;
+    }
+#endif
+
+    mavlink_msg_system_time_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        timeUnixUsec, millis());
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
 }
 
 void freeMAVLinkTelemetryPort(void)
@@ -223,6 +287,8 @@ static void mavlinkSendSystemStatus(void)
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
 
+    mavlinkSendSystemTime();
+
     // Packets transmit counter to debug actual data rate
     static uint32_t transmitCounter = 0;
     DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 2, transmitCounter);
@@ -265,6 +331,25 @@ static void mavlinkSendRCChannelsAndRSSI(void)
 }
 
 #if defined(USE_GPS)
+static void mavlinkSendHomePosition(void)
+{
+    if (!STATE(GPS_FIX_HOME)) {
+        return;
+    }
+
+    static const float identityQuat[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    mavlink_msg_home_position_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        GPS_home_llh.lat,
+        GPS_home_llh.lon,
+        GPS_home_llh.altCm * 10,
+        0.0f, 0.0f, 0.0f,
+        identityQuat,
+        0.0f, 0.0f, 0.0f,
+        micros());
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
 static void mavlinkSendPosition(void)
 {
     uint16_t msgLength;
@@ -356,6 +441,8 @@ static void mavlinkSendPosition(void)
         micros());
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
+
+    mavlinkSendHomePosition();
 
     // Packets transmit counter to debug actual data rate
     static uint32_t transmitCounter = 0;
@@ -693,6 +780,7 @@ void handleMAVLinkTelemetry(void)
 
     if (shouldSendTelemetry) {
         processMAVLinkTelemetry();
+        mavlinkProcessArmingStatusText();
         lastMavlinkMessageTime = now;
     }
 }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -143,10 +143,10 @@ static void mavlinkProcessArmingStatusText(void)
         return;
     }
 
-    char text[50] = "Arming disabled:";
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = "Arming disabled:";
     size_t pos = strlen(text);
 
-    for (int bit = 0; bit < 32 && pos < sizeof(text) - 1; bit++) {
+    for (unsigned bit = 0; bit < ARMING_DISABLE_FLAGS_COUNT && pos < sizeof(text) - 1; bit++) {
         const armingDisableFlags_e thisFlag = (armingDisableFlags_e)(1u << bit);
         if (!(flags & thisFlag)) {
             continue;
@@ -155,12 +155,14 @@ static void mavlinkProcessArmingStatusText(void)
         if (!name) {
             continue;
         }
-        if (pos < sizeof(text) - 1) {
-            text[pos++] = ' ';
+        // Need room for " " + at least one char of the name; otherwise stop appending.
+        if (sizeof(text) - 1 - pos < 2) {
+            break;
         }
+        text[pos++] = ' ';
         const size_t nameLen = strlen(name);
-        const size_t avail = sizeof(text) - 1 - pos;
-        const size_t copyLen = (nameLen < avail) ? nameLen : avail;
+        const size_t maxCopy = sizeof(text) - 1 - pos;
+        const size_t copyLen = (nameLen < maxCopy) ? nameLen : maxCopy;
         memcpy(text + pos, name, copyLen);
         pos += copyLen;
     }
@@ -216,6 +218,8 @@ void configureMAVLinkTelemetryPort(void)
         return;
     }
 
+    // Reset STATUSTEXT de-dup so the first run after link-up emits any current disable reasons.
+    lastArmingDisableFlags = 0;
     mavlinkTelemetryEnabled = true;
 }
 
@@ -745,6 +749,7 @@ void checkMAVLinkTelemetryState(void)
     if (portConfig && telemetryCheckRxPortShared(portConfig, rxRuntimeState.serialrxProvider)) {
         if (!mavlinkTelemetryEnabled && telemetrySharedPort != NULL) {
             mavlinkPort = telemetrySharedPort;
+            lastArmingDisableFlags = 0;
             mavlinkTelemetryEnabled = true;
             configureMAVLinkStreamRates();
         }


### PR DESCRIPTION
## Summary

Three TX-only awareness messages for QGroundControl. Pure additions, independent of the RX dispatch refactor in #15211 — can land in either order.

## Messages added

- **HOME_POSITION** — sent alongside `GPS_GLOBAL_ORIGIN` at the position-stream rate when `STATE(GPS_FIX_HOME)`. Carries `GPS_home_llh` (lat/lon/altitude AMSL), identity quaternion, zero local-offset and approach vectors. QGC's "Go Home" / map-centring needs this.
- **SYSTEM_TIME** — sent at the extended-status stream rate. `time_unix_usec` populated from RTC when `USE_RTC_TIME` is built in and `rtcHasTime()` returns true; zero otherwise. `time_boot_ms` always populated. Used by QGC for log-correlation.
- **STATUSTEXT** — fires on a transition of `getArmingDisableFlags()` to a new non-zero value. Builds a space-separated list of disable-reason names via `getArmingDisableFlagName()` and broadcasts at `MAV_SEVERITY_NOTICE`. De-dups on no change so the QGC chat log isn't spammed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry now reports arming-disable status updates as status messages (only when the status changes)
  * Periodic system time broadcasts added to telemetry for improved time synchronization
  * GPS home position is transmitted over telemetry when home lock is available

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15213)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->