### PR TITLE
RX MSP Override: require fresh MSP RC data before substituting channels

### DIFF
--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -36,6 +36,18 @@
 static uint16_t mspFrame[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 static bool rxMspFrameDone = false;
 static bool rxMspOverrideFrameDone = false;
+static bool rxMspRcFrameEverReceived = false;
+static timeMs_t lastRxMspRcFrameMs = 0;
+static uint8_t lastRxMspRcFrameChannelCount = 0;
+
+// Substitute MSP RC values into the override path only if a frame containing
+// the channel arrived within this window. Without this guard:
+//  - empty mspFrame[] (companion never sent, or stopped) would clamp masked
+//    channels to rx_min_usec the instant BOXMSPOVERRIDE activated;
+//  - a short MSP_SET_RAW_RC frame (e.g. AETR-only) would still leave any
+//    masked AUX channel reading from the zero-filled tail of mspFrame[].
+// 300 ms gives honest support for ~5 Hz MSP RC with timing margin.
+#define RX_MSP_RC_FRAME_FRESH_MS 300
 
 float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan)
 {
@@ -59,6 +71,20 @@ void rxMspFrameReceive(const uint16_t *frame, int channelCount)
 
     rxMspFrameDone = true;
     rxMspOverrideFrameDone = true;
+    lastRxMspRcFrameMs = millis();
+    lastRxMspRcFrameChannelCount = channelCount;
+    rxMspRcFrameEverReceived = true;
+}
+
+bool rxMspIsRcChannelFresh(uint8_t chan)
+{
+    if (!rxMspRcFrameEverReceived) {
+        return false;
+    }
+    if (chan >= lastRxMspRcFrameChannelCount) {
+        return false;
+    }
+    return (millis() - lastRxMspRcFrameMs) <= RX_MSP_RC_FRAME_FRESH_MS;
 }
 
 static uint8_t rxMspFrameStatus(rxRuntimeState_t *rxRuntimeState)

--- a/src/main/rx/msp.h
+++ b/src/main/rx/msp.h
@@ -26,3 +26,4 @@ float rxMspReadRawRC(const rxRuntimeState_t *rxRuntimeState, uint8_t chan);
 void rxMspInit(const struct rxConfig_s *rxConfig, struct rxRuntimeState_s *rxRuntimeState);
 void rxMspFrameReceive(const uint16_t *frame, int channelCount);
 uint8_t rxMspOverrideFrameStatus(void);
+bool rxMspIsRcChannelFresh(uint8_t chan);

--- a/src/main/rx/msp_override.c
+++ b/src/main/rx/msp_override.c
@@ -35,7 +35,7 @@ uint16_t rxMspOverrideReadRawRc(const rxRuntimeState_t *rxRuntimeState, const rx
 
     bool override = (1 << chan) & rxConfig->msp_override_channels_mask;
 
-    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && override) {
+    if (IS_RC_MODE_ACTIVE(BOXMSPOVERRIDE) && override && rxMspIsRcChannelFresh(chan)) {
         return overrideSample;
     } else {
         return rxSample;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -298,6 +298,14 @@ rx_ibus_unittest_SRC := \
 		$(USER_DIR)/rx/ibus.c
 
 
+rx_msp_override_unittest_SRC := \
+		$(USER_DIR)/rx/msp.c
+
+rx_msp_override_unittest_DEFINES := \
+		USE_RX_MSP= \
+		USE_RX_MSP_OVERRIDE=
+
+
 rx_ranges_unittest_SRC := \
 		$(USER_DIR)/common/bitarray.c \
 		$(USER_DIR)/common/crc.c \

--- a/src/test/unit/rx_msp_override_unittest.cc
+++ b/src/test/unit/rx_msp_override_unittest.cc
@@ -1,19 +1,20 @@
 /*
- * This file is part of Cleanflight and Betaflight.
+ * This file is part of Betaflight.
  *
- * Cleanflight and Betaflight are free software. You can redistribute
- * this software and/or modify this software under the terms of the
- * GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
  *
- * Cleanflight and Betaflight are distributed in the hope that they
- * will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this software.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
  *
  * If not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/test/unit/rx_msp_override_unittest.cc
+++ b/src/test/unit/rx_msp_override_unittest.cc
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "pg/rx.h"
+    #include "rx/rx.h"
+    #include "rx/msp.h"
+}
+
+#include "gtest/gtest.h"
+
+static uint32_t simulationMillis = 0;
+
+extern "C" {
+    uint32_t millis(void) { return simulationMillis; }
+    uint32_t micros(void) { return simulationMillis * 1000; }
+}
+
+// rxMspIsRcChannelFresh returns true only when the most recent MSP_SET_RAW_RC
+// frame both (a) included the requested channel and (b) arrived within the
+// freshness window. Without these guards an empty or short MSP frame would
+// allow rxMspOverrideReadRawRc() to clamp masked channels to rx_min_usec.
+TEST(MspOverrideTest, ChannelFreshness)
+{
+    // Before any frame is received, every channel is stale.
+    simulationMillis = 1000;
+    EXPECT_FALSE(rxMspIsRcChannelFresh(0));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(3));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(8));
+
+    // A 4-channel (AETR-only) frame makes channels 0..3 fresh; AUX channels
+    // beyond the frame's channelCount remain stale even though the frame
+    // itself is current.
+    uint16_t frame4[MAX_SUPPORTED_RC_CHANNEL_COUNT] = {1500, 1500, 1500, 1000};
+    rxMspFrameReceive(frame4, 4);
+    EXPECT_TRUE(rxMspIsRcChannelFresh(0));
+    EXPECT_TRUE(rxMspIsRcChannelFresh(3));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(4));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(8));
+
+    // Inside the freshness window: still fresh.
+    simulationMillis = 1000 + 250;
+    EXPECT_TRUE(rxMspIsRcChannelFresh(0));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(4));
+
+    // A 6-channel frame extends freshness to AUX2 (channel 5).
+    simulationMillis = 1500;
+    uint16_t frame6[MAX_SUPPORTED_RC_CHANNEL_COUNT] = {1500, 1500, 1500, 1000, 2000, 1750};
+    rxMspFrameReceive(frame6, 6);
+    EXPECT_TRUE(rxMspIsRcChannelFresh(0));
+    EXPECT_TRUE(rxMspIsRcChannelFresh(5));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(6));
+
+    // Past the freshness window every channel becomes stale, regardless of
+    // whether earlier frames had covered it.
+    simulationMillis = 1500 + 301;
+    EXPECT_FALSE(rxMspIsRcChannelFresh(0));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(5));
+
+    // A subsequent shorter frame shrinks coverage: a previously-fresh AUX
+    // channel must drop back to stale even while channels 0..3 stay fresh.
+    simulationMillis = 2000;
+    rxMspFrameReceive(frame4, 4);
+    EXPECT_TRUE(rxMspIsRcChannelFresh(3));
+    EXPECT_FALSE(rxMspIsRcChannelFresh(5));
+}


### PR DESCRIPTION
## Summary

When `BOXMSPOVERRIDE` was active and `msp_override_channels_mask` had bits
set, `rxMspOverrideReadRawRc()` substituted `mspFrame[chan]` for any masked
channel without checking whether MSP had ever provided that channel. The
substitution path then `constrainf`d the value to `[rx_min_usec, rx_max_usec]`,
so when no companion was sending `MSP_SET_RAW_RC` (or the frame was shorter
than the masked channel — `rxMspFrameReceive()` zero-fills the tail), the
masked channel was clamped to `rx_min_usec` the instant the mode activated.
With a typical mask covering ROLL/PITCH/YAW + an AUX, this forced sticks to
floor and pinned the masked AUX outside any mode range, causing the unstable
behavior reported during MSP OVERRIDE transitions.

## Changes

- `src/main/rx/msp.c`/`.h`: track per-channel MSP RC frame freshness via
  `lastRxMspRcFrameMs`, `lastRxMspRcFrameChannelCount`, `rxMspRcFrameEverReceived`;
  expose `rxMspIsRcChannelFresh(uint8_t chan)` returning `true` only if a
  frame containing that channel arrived within `RX_MSP_RC_FRAME_FRESH_MS`
  (300 ms — comfortably above 5 Hz MSP rates).
- `src/main/rx/msp_override.c`: `rxMspOverrideReadRawRc()` now requires
  this freshness check before returning the override sample. Live RX value
  passes through unchanged otherwise. Behavior is unchanged when a companion
  is sending fresh frames covering the masked channels.
- `src/test/unit/rx_msp_override_unittest.cc` (new): pins the freshness
  contract — no frame ever / short frame / fresh frame / window expiry /
  later short frame shrinks coverage.

## Context

Supersedes #13524, which attempted the same intended guard (default-init
`mspFrame[]` to safe values) and was abandoned. This PR implements the
direction @ledvinap suggested in the #13524 review ("prevent MSP override
until first data are received") using per-channel frame freshness and
channel count rather than treating `0` as a sentinel value.

The clamp-to-`rx_min_usec` failure mode was introduced by #13352
(_Ensure MSP channel data is valid_) — before that PR, channels outside the
MSP frame held their previous values; after, `constrainf(0, ...)` clamps to
the floor. #13380 (`msp_override_failsafe`) is the only landed defensive
code in this area but does not cover the clamp.

Refs #14004 — describes MSP override transition instability with
`msp_override_channels_mask = 15`; this patch prevents masked channels from
being substituted with zero-filled MSP data before fresh per-channel data
exists.

## Test plan

- [x] `make test` — 53 PASS, 0 FAIL (includes new `rx_msp_override_unittest`).
- [x] `make CONFIG=BETAFPVF405_ELRS` clean (53% flash).
- [x] Field-verified on BetaFPV F4 2-3S 20A AIO V1 (STM32F405) with
      `msp_override_channels_mask = 39`, `msp_override_failsafe = OFF`,
      MSP OVERRIDE on AUX5: button now correctly toggles the mode on/off,
      ANGLE/HORIZON on AUX2 keep responding while MSP OVERRIDE is active.

Note: `.github/pull_request_template.md` references `make pre-push`, but no
such target exists in the current `Makefile` — happy to add one if maintainers
want.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code).
🤖 Independently reviewed by [Codex](https://chatgpt.com/codex).
🙃 Verified by a human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSP RC override behavior by adding a channel “freshness” check with a 300 ms window, so overridden RC samples are only used when recently updated via the MSP RC frame.

* **New Features**
  * Exposed a new channel freshness indicator to determine whether a given MSP RC channel should be treated as up to date.

* **Tests**
  * Added unit tests covering MSP RC channel freshness semantics, including initial stale state, multi-channel frames, expiration by time window, and reduced freshness after subsequent frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->