### PR TITLE
fix(uart): guard half-duplex pinless UART modes

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -252,6 +252,25 @@ uartDevice_t *uartDeviceFromIdentifier(serialPortIdentifier_e identifier)
     return deviceIdx != UARTDEV_INVALID ? &uartDevice[deviceIdx] : NULL;
 }
 
+static portMode_e uartSanitizeMode(const uartDevice_t *uartDevice, portMode_e mode, portOptions_e options)
+{
+    if (!uartDevice->tx.pin) {
+        mode &= ~MODE_TX;
+    }
+
+    if (!uartDevice->rx.pin && !((options & SERIAL_BIDIR) && uartDevice->tx.pin)) {
+        mode &= ~MODE_RX;
+    }
+
+    return mode;
+}
+
+static bool uartCanWrite(const uartPort_t *uartPort)
+{
+    const uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    return (uartPort->port.mode & MODE_TX) && uartDevice->tx.pin;
+}
+
 serialPort_t *uartOpen(serialPortIdentifier_e identifier, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options)
 {
     uartDevice_t *uartDevice = uartDeviceFromIdentifier(identifier);
@@ -260,6 +279,7 @@ serialPort_t *uartOpen(serialPortIdentifier_e identifier, serialReceiveCallbackP
     }
     // fill identifier early, so initialization code can use it
     uartDevice->port.port.identifier = identifier;
+    mode = uartSanitizeMode(uartDevice, mode, options);
 
     uartPort_t *uartPort = serialUART(uartDevice, baudRate, mode, options);
     if (!uartPort) {
@@ -284,6 +304,8 @@ serialPort_t *uartOpen(serialPortIdentifier_e identifier, serialReceiveCallbackP
 static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
+    uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    uartPort->port.mode = uartSanitizeMode(uartDevice, uartPort->port.mode, uartPort->port.options);
     uartPort->port.baudRate = baudRate;
     uartReconfigure(uartPort);
 }
@@ -291,7 +313,8 @@ static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 static void uartSetMode(serialPort_t *instance, portMode_e mode)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
-    uartPort->port.mode = mode;
+    uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    uartPort->port.mode = uartSanitizeMode(uartDevice, mode, uartPort->port.options);
     uartReconfigure(uartPort);
 }
 
@@ -398,6 +421,10 @@ static void uartWrite(serialPort_t *instance, uint8_t ch)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
 
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
+
     // Check if the TX line is being pulled low by an unpowered peripheral
     if (uartPort->checkUsartTxOutput && !uartPort->checkUsartTxOutput(uartPort)) {
         // TX line is being pulled low, so don't transmit
@@ -426,6 +453,10 @@ static void uartBeginWrite(serialPort_t *instance)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
 
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
+
     // Check if the TX line is being pulled low by an unpowered peripheral
     if (uartPort->checkUsartTxOutput) {
         uartPort->checkUsartTxOutput(uartPort);
@@ -437,6 +468,10 @@ static void uartWriteBuf(serialPort_t *instance, const void *data, int count)
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartDevice_t *uart = container_of(uartPort, uartDevice_t, port);
     const uint8_t *bytePtr = (const uint8_t*)data;
+
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
 
     // Test if checkUsartTxOutput() detected TX line being pulled low by an unpowered peripheral
     if (uart->txPinState == TX_PIN_MONITOR) {
@@ -464,6 +499,10 @@ static void uartEndWrite(serialPort_t *instance)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartDevice_t *uart = container_of(uartPort, uartDevice_t, port);
+
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
 
     // Check if the TX line is being pulled low by an unpowered peripheral
     if (uart->txPinState == TX_PIN_MONITOR) {

--- a/src/platform/STM32/serial_uart_ll.c
+++ b/src/platform/STM32/serial_uart_ll.c
@@ -44,6 +44,12 @@
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
 
+static bool uartCanTx(const uartPort_t *uartPort)
+{
+    const uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    return (uartPort->port.mode & MODE_TX) && uartDevice->tx.pin;
+}
+
 static void usartConfigurePinInversion(uartPort_t *uartPort)
 {
     USART_TypeDef *USARTx = (USART_TypeDef *)uartPort->USARTx;
@@ -74,6 +80,7 @@ static void uartConfigurePinSwap(uartPort_t *uartPort)
 void uartReconfigure(uartPort_t *uartPort)
 {
     USART_TypeDef *USARTx = (USART_TypeDef *)uartPort->USARTx;
+    const bool canTx = uartCanTx(uartPort);
 
     // Disable all UART interrupts before disabling the peripheral to prevent
     // an interrupt storm. With UE=0, TC is always asserted (transmitter idle),
@@ -98,7 +105,7 @@ void uartReconfigure(uartPort_t *uartPort)
     if (uartPort->port.mode & MODE_RX) {
         direction |= LL_USART_DIRECTION_RX;
     }
-    if (uartPort->port.mode & MODE_TX) {
+    if (canTx) {
         direction |= LL_USART_DIRECTION_TX;
     }
     usartInit.TransferDirection = direction;
@@ -167,7 +174,7 @@ void uartReconfigure(uartPort_t *uartPort)
     }
 
     // Transmit DMA or IRQ
-    if (uartPort->port.mode & MODE_TX) {
+    if (canTx) {
 #ifdef USE_DMA
         if (uartPort->txDMAResource) {
             xLL_EX_DMA_ConfigStream(uartPort->txDMAResource,
@@ -234,6 +241,11 @@ void uartTryStartTxDMA(uartPort_t *s)
     USART_TypeDef *USARTx = (USART_TypeDef *)s->USARTx;
 
     ATOMIC_BLOCK(NVIC_PRIO_SERIALUART_TXDMA) {
+        if (!uartCanTx(s)) {
+            s->txDMAEmpty = true;
+            return;
+        }
+
         if (IS_DMA_ENABLED(s->txDMAResource)) {
             // DMA is already in progress
             return;
@@ -291,6 +303,7 @@ void uartDmaIrqHandler(dmaChannelDescriptor_t* descriptor)
 FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
 {
     USART_TypeDef *USARTx = (USART_TypeDef *)s->USARTx;
+    const bool canTx = uartCanTx(s);
 
     /* UART in mode Receiver ---------------------------------------------------*/
     if (LL_USART_IsEnabledIT_RXNE(USARTx) && LL_USART_IsActiveFlag_RXNE(USARTx)) {
@@ -326,8 +339,16 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
         LL_USART_ClearFlag_ORE(USARTx);
     }
 
+    if (!canTx) {
+        CLEAR_BIT(USARTx->CR1, USART_CR1_TXEIE | USART_CR1_TCIE);
+
+        if (LL_USART_IsActiveFlag_TC(USARTx)) {
+            LL_USART_ClearFlag_TC(USARTx);
+        }
+    }
+
     // UART transmission completed
-    if (LL_USART_IsEnabledIT_TC(USARTx) && LL_USART_IsActiveFlag_TC(USARTx)) {
+    if (canTx && LL_USART_IsEnabledIT_TC(USARTx) && LL_USART_IsActiveFlag_TC(USARTx)) {
         LL_USART_ClearFlag_TC(USARTx);
 
         // Switch TX to an input with pull-up so it's state can be monitored
@@ -340,7 +361,7 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
 #endif
     }
 
-    if (LL_USART_IsEnabledIT_TXE(USARTx) && LL_USART_IsActiveFlag_TXE(USARTx)) {
+    if (canTx && LL_USART_IsEnabledIT_TXE(USARTx) && LL_USART_IsActiveFlag_TXE(USARTx)) {
         /* Check that a Tx process is ongoing */
         if (s->port.txBufferTail == s->port.txBufferHead) {
             /* Disable the UART Transmit Data Register Empty Interrupt */


### PR DESCRIPTION
Clamp UART runtime modes to the pins that actually exist so RX-only ports cannot be switched into TX mode by GPS passthrough or other serial users. Also make the STM32 LL IRQ handler clear TXE/TC interrupts when a port has no TX pin, allowing already-bad TC/TXE states to recover instead of repeatedly entering the UART IRQ.

A real H743 setup exposed a crash when an RX-only UART was accidentally configured as GPS. During flight/runtime GPS configuration the port could be switched into TX-capable mode even though the target only provides half of the UART pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UART driver now respects RX-only and TX-only pin configurations.
  * Prevented transmit activity (interrupts/buffers/DMA) when no TX pin is present to avoid spurious TX work.
  * Configuration sanitization validates requested UART modes against available hardware pins to prevent invalid setups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15218)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->