### PR TITLE
feat(flash): add support for XTX XT25F128F

### DIFF
--- a/src/main/drivers/flash/flash_m25p16.c
+++ b/src/main/drivers/flash/flash_m25p16.c
@@ -160,6 +160,9 @@ struct {
     // Boyamicro BY25Q128ES
     // Datasheet: https://www.lcsc.com/datasheet/C49023667.pdf
     { 0x684018, 104, 50, 256, 256 },
+    // XTX XT25F128F
+    // Datasheet: https://www.xtxtech.com/Products/info_productModel_XT25F128FSSIGT.html
+    { 0x0B4018, 96, 80, 256, 256 },
     // End of list
     { 0x000000, 0, 0, 0, 0 }
 };


### PR DESCRIPTION
Added JEDEC ID and parameters for XTX XT25F128F flash chip.
Verified on SPEDIXF405 target.
Datasheet:https://www.xtxtech.com/Products/info_productModel_XT25F128FSSIGT.html
(Notice: Please view datasheets directly on our website. To prevent link expiration, we provide live online versions instead of static PDFs.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the XTX XT25F128F SPI flash device.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->