### PR TITLE
telemetry/mavlink: vehicle-setup unlock + custom_mode discovery

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -104,6 +104,38 @@ static mavlink_message_t mavRxMsg;
 static mavlink_status_t mavRxStatus;
 static bool mavlinkPortOwned = false;
 
+// Betaflight-specific MAVLink custom_mode values. Stable enumeration emitted in
+// HEARTBEAT.custom_mode and advertised via AVAILABLE_MODES; consumed in T3 by
+// MAV_CMD_DO_SET_MODE handling.
+typedef enum {
+    BF_MAV_MODE_ACRO = 0,
+    BF_MAV_MODE_ANGLE,
+    BF_MAV_MODE_HORIZON,
+    BF_MAV_MODE_ALT_HOLD,
+    BF_MAV_MODE_POS_HOLD,
+    BF_MAV_MODE_AUTOPILOT,
+    BF_MAV_MODE_RTL,
+    BF_MAV_MODE_FAILSAFE,
+    BF_MAV_MODE_COUNT,
+} bfMavMode_e;
+
+typedef struct {
+    const char *name;
+    uint8_t standardMode;
+    uint32_t properties;
+} bfMavModeDescriptor_t;
+
+static const bfMavModeDescriptor_t bfMavModeDescriptors[BF_MAV_MODE_COUNT] = {
+    [BF_MAV_MODE_ACRO]      = { "Acro",      MAV_STANDARD_MODE_NON_STANDARD,  0 },
+    [BF_MAV_MODE_ANGLE]     = { "Angle",     MAV_STANDARD_MODE_NON_STANDARD,  0 },
+    [BF_MAV_MODE_HORIZON]   = { "Horizon",   MAV_STANDARD_MODE_NON_STANDARD,  0 },
+    [BF_MAV_MODE_ALT_HOLD]  = { "Alt Hold",  MAV_STANDARD_MODE_ALTITUDE_HOLD, 0 },
+    [BF_MAV_MODE_POS_HOLD]  = { "Pos Hold",  MAV_STANDARD_MODE_POSITION_HOLD, 0 },
+    [BF_MAV_MODE_AUTOPILOT] = { "Autopilot", MAV_STANDARD_MODE_MISSION,       0 },
+    [BF_MAV_MODE_RTL]       = { "RTL",       MAV_STANDARD_MODE_SAFE_RECOVERY, 0 },
+    [BF_MAV_MODE_FAILSAFE]  = { "Failsafe",  MAV_STANDARD_MODE_SAFE_RECOVERY, MAV_MODE_PROPERTY_NOT_USER_SELECTABLE },
+};
+
 static mavlink_message_t mavMsg;
 static uint8_t mavBuffer[MAVLINK_MAX_PACKET_LEN];
 
@@ -299,11 +331,63 @@ static void mavlinkSendComponentInformation(void)
     mavlinkSerialWrite(mavBuffer, msgLength);
 }
 
-static void handleRequestMessage(uint32_t messageId,
+static uint32_t mavlinkComputeCustomMode(void)
+{
+    if (FLIGHT_MODE(FAILSAFE_MODE) || failsafeIsActive()) {
+        return BF_MAV_MODE_FAILSAFE;
+    }
+    if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+        return BF_MAV_MODE_RTL;
+    }
+    if (FLIGHT_MODE(AUTOPILOT_MODE)) {
+        return BF_MAV_MODE_AUTOPILOT;
+    }
+    if (FLIGHT_MODE(POS_HOLD_MODE)) {
+        return BF_MAV_MODE_POS_HOLD;
+    }
+    if (FLIGHT_MODE(ALT_HOLD_MODE)) {
+        return BF_MAV_MODE_ALT_HOLD;
+    }
+    if (FLIGHT_MODE(HORIZON_MODE)) {
+        return BF_MAV_MODE_HORIZON;
+    }
+    if (FLIGHT_MODE(ANGLE_MODE)) {
+        return BF_MAV_MODE_ANGLE;
+    }
+    return BF_MAV_MODE_ACRO;
+}
+
+static void mavlinkSendAvailableMode(uint8_t modeIndex)
+{
+    if (modeIndex < 1 || modeIndex > BF_MAV_MODE_COUNT) {
+        return;
+    }
+    const uint8_t idx0 = modeIndex - 1;
+    const bfMavModeDescriptor_t *desc = &bfMavModeDescriptors[idx0];
+
+    mavlink_msg_available_modes_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        BF_MAV_MODE_COUNT,
+        modeIndex,
+        desc->standardMode,
+        idx0,
+        desc->properties,
+        desc->name);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkSendAvailableModesMonitor(void)
+{
+    mavlink_msg_available_modes_monitor_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, 1);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void handleRequestMessage(const mavlink_command_long_t *cmd,
     uint8_t targetSystem, uint8_t targetComponent)
 {
     uint8_t result;
-    switch (messageId) {
+    switch ((uint32_t)cmd->param1) {
     case MAVLINK_MSG_ID_AUTOPILOT_VERSION:
         mavlinkSendAutopilotVersion();
         result = MAV_RESULT_ACCEPTED;
@@ -314,6 +398,20 @@ static void handleRequestMessage(uint32_t messageId,
         break;
     case MAVLINK_MSG_ID_COMPONENT_INFORMATION:
         mavlinkSendComponentInformation();
+        result = MAV_RESULT_ACCEPTED;
+        break;
+    case MAVLINK_MSG_ID_AVAILABLE_MODES: {
+        const uint8_t modeIndex = (uint8_t)cmd->param2;
+        if (modeIndex < 1 || modeIndex > BF_MAV_MODE_COUNT) {
+            result = MAV_RESULT_DENIED;
+        } else {
+            mavlinkSendAvailableMode(modeIndex);
+            result = MAV_RESULT_ACCEPTED;
+        }
+        break;
+    }
+    case MAVLINK_MSG_ID_AVAILABLE_MODES_MONITOR:
+        mavlinkSendAvailableModesMonitor();
         result = MAV_RESULT_ACCEPTED;
         break;
     default:
@@ -340,7 +438,7 @@ static void handleCommandLong(const mavlink_message_t *msg)
         mavlinkSendCommandAck(cmd.command, MAV_RESULT_ACCEPTED, msg->sysid, msg->compid);
         break;
     case MAV_CMD_REQUEST_MESSAGE:
-        handleRequestMessage((uint32_t)cmd.param1, msg->sysid, msg->compid);
+        handleRequestMessage(&cmd, msg->sysid, msg->compid);
         break;
     default:
         mavlinkSendCommandAck(cmd.command, MAV_RESULT_UNSUPPORTED, msg->sysid, msg->compid);
@@ -755,11 +853,8 @@ static void mavlinkSendHUDAndHeartbeat(void)
             break;
     }
 
-    // Custom mode for compatibility with APM OSDs
-    uint8_t mavCustomMode = 1;  // Acro by default
-
-    if (FLIGHT_MODE(ANGLE_MODE | HORIZON_MODE | ALT_HOLD_MODE | POS_HOLD_MODE)) {
-        mavCustomMode = 0;      //Stabilize
+    const uint32_t mavCustomMode = mavlinkComputeCustomMode();
+    if (mavCustomMode != BF_MAV_MODE_ACRO) {
         mavModes |= MAV_MODE_FLAG_STABILIZE_ENABLED;
     }
 

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -23,6 +23,7 @@
  *
  * Author: Konstantin Sharlaimov
  */
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -383,11 +384,31 @@ static void mavlinkSendAvailableModesMonitor(void)
     mavlinkSerialWrite(mavBuffer, msgLength);
 }
 
+// COMMAND_LONG params arrive as floats from an external GCS. Casting NaN/inf or
+// out-of-range values to integer types is undefined behaviour, so validate first.
+static bool cmdParamToUint32(float f, uint32_t maxValue, uint32_t *out)
+{
+    if (!isfinite(f) || f < 0.0f) {
+        return false;
+    }
+    if ((double)f > (double)maxValue) {
+        return false;
+    }
+    *out = (uint32_t)f;
+    return true;
+}
+
 static void handleRequestMessage(const mavlink_command_long_t *cmd,
     uint8_t targetSystem, uint8_t targetComponent)
 {
+    uint32_t messageId;
+    if (!cmdParamToUint32(cmd->param1, UINT32_MAX, &messageId)) {
+        mavlinkSendCommandAck(MAV_CMD_REQUEST_MESSAGE, MAV_RESULT_DENIED, targetSystem, targetComponent);
+        return;
+    }
+
     uint8_t result;
-    switch ((uint32_t)cmd->param1) {
+    switch (messageId) {
     case MAVLINK_MSG_ID_AUTOPILOT_VERSION:
         mavlinkSendAutopilotVersion();
         result = MAV_RESULT_ACCEPTED;
@@ -401,13 +422,13 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
         result = MAV_RESULT_ACCEPTED;
         break;
     case MAVLINK_MSG_ID_AVAILABLE_MODES: {
-        const uint8_t modeIndex = (uint8_t)cmd->param2;
-        if (modeIndex < 1 || modeIndex > BF_MAV_MODE_COUNT) {
+        uint32_t modeIndex;
+        if (!cmdParamToUint32(cmd->param2, BF_MAV_MODE_COUNT, &modeIndex) || modeIndex < 1) {
             result = MAV_RESULT_DENIED;
-        } else {
-            mavlinkSendAvailableMode(modeIndex);
-            result = MAV_RESULT_ACCEPTED;
+            break;
         }
+        mavlinkSendAvailableMode((uint8_t)modeIndex);
+        result = MAV_RESULT_ACCEPTED;
         break;
     }
     case MAVLINK_MSG_ID_AVAILABLE_MODES_MONITOR:
@@ -433,10 +454,19 @@ static void handleCommandLong(const mavlink_message_t *msg)
     }
 
     switch (cmd.command) {
-    case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES:
-        mavlinkSendAutopilotVersion();
+    case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES: {
+        // Spec: param1 is MAV_BOOL — 1 = send AUTOPILOT_VERSION, 0 = ignore.
+        uint32_t request;
+        if (!cmdParamToUint32(cmd.param1, 1, &request)) {
+            mavlinkSendCommandAck(cmd.command, MAV_RESULT_DENIED, msg->sysid, msg->compid);
+            break;
+        }
+        if (request == 1) {
+            mavlinkSendAutopilotVersion();
+        }
         mavlinkSendCommandAck(cmd.command, MAV_RESULT_ACCEPTED, msg->sysid, msg->compid);
         break;
+    }
     case MAV_CMD_REQUEST_MESSAGE:
         handleRequestMessage(&cmd, msg->sysid, msg->compid);
         break;

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -75,6 +75,7 @@
 #include "telemetry/mavlink.h"
 
 #include "build/debug.h"
+#include "build/version.h"
 
 // mavlink library uses unnamed unions that causes GCC to complain if -Wpedantic is used
 // until this is resolved in mavlink library - ignore -Wpedantic for mavlink code
@@ -242,6 +243,111 @@ static void handleTimesync(const mavlink_message_t *msg)
     mavlinkSerialWrite(mavBuffer, msgLength);
 }
 
+static void mavlinkSendCommandAck(uint16_t command, uint8_t result,
+    uint8_t targetSystem, uint8_t targetComponent)
+{
+    mavlink_msg_command_ack_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        command, result, 0, 0, targetSystem, targetComponent);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkSendAutopilotVersion(void)
+{
+    const uint64_t capabilities = MAV_PROTOCOL_CAPABILITY_MAVLINK2;
+    const uint32_t flightSwVersion =
+        ((uint32_t)(FC_VERSION_YEAR - FC_CALVER_BASE_YEAR) << 24) |
+        ((uint32_t)FC_VERSION_MONTH << 16) |
+        ((uint32_t)FC_VERSION_PATCH_LEVEL << 8);
+
+    const uint8_t emptyCustom[8] = {0};
+    uint8_t uid2[18] = {0};
+    const uint32_t uidWords[3] = { U_ID_0, U_ID_1, U_ID_2 };
+    memcpy(uid2, uidWords, sizeof(uidWords));
+
+    mavlink_msg_autopilot_version_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        capabilities,
+        flightSwVersion,
+        0,
+        0,
+        0,
+        emptyCustom,
+        emptyCustom,
+        emptyCustom,
+        0,
+        0,
+        ((uint64_t)U_ID_0 << 32) | U_ID_1,
+        uid2);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkSendProtocolVersion(void)
+{
+    const uint8_t emptyHash[8] = {0};
+    mavlink_msg_protocol_version_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        200, 100, 200, emptyHash, emptyHash);
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkSendComponentInformation(void)
+{
+    mavlink_msg_component_information_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        millis(), 0, "", 0, "");
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void handleRequestMessage(uint32_t messageId,
+    uint8_t targetSystem, uint8_t targetComponent)
+{
+    uint8_t result;
+    switch (messageId) {
+    case MAVLINK_MSG_ID_AUTOPILOT_VERSION:
+        mavlinkSendAutopilotVersion();
+        result = MAV_RESULT_ACCEPTED;
+        break;
+    case MAVLINK_MSG_ID_PROTOCOL_VERSION:
+        mavlinkSendProtocolVersion();
+        result = MAV_RESULT_ACCEPTED;
+        break;
+    case MAVLINK_MSG_ID_COMPONENT_INFORMATION:
+        mavlinkSendComponentInformation();
+        result = MAV_RESULT_ACCEPTED;
+        break;
+    default:
+        result = MAV_RESULT_UNSUPPORTED;
+        break;
+    }
+    mavlinkSendCommandAck(MAV_CMD_REQUEST_MESSAGE, result, targetSystem, targetComponent);
+}
+
+static void handleCommandLong(const mavlink_message_t *msg)
+{
+    mavlink_command_long_t cmd;
+    mavlink_msg_command_long_decode(msg, &cmd);
+
+    // Accept broadcast or directed-to-us; ignore commands addressed to other systems.
+    if ((cmd.target_system != 0 && cmd.target_system != MAVLINK_SYSTEM_ID) ||
+        (cmd.target_component != 0 && cmd.target_component != MAVLINK_COMPONENT_ID)) {
+        return;
+    }
+
+    switch (cmd.command) {
+    case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES:
+        mavlinkSendAutopilotVersion();
+        mavlinkSendCommandAck(cmd.command, MAV_RESULT_ACCEPTED, msg->sysid, msg->compid);
+        break;
+    case MAV_CMD_REQUEST_MESSAGE:
+        handleRequestMessage((uint32_t)cmd.param1, msg->sysid, msg->compid);
+        break;
+    default:
+        mavlinkSendCommandAck(cmd.command, MAV_RESULT_UNSUPPORTED, msg->sysid, msg->compid);
+        break;
+    }
+}
+
 static void mavlinkDispatch(const mavlink_message_t *msg)
 {
     switch (msg->msgid) {
@@ -253,6 +359,9 @@ static void mavlinkDispatch(const mavlink_message_t *msg)
         break;
     case MAVLINK_MSG_ID_TIMESYNC:
         handleTimesync(msg);
+        break;
+    case MAVLINK_MSG_ID_COMMAND_LONG:
+        handleCommandLong(msg);
         break;
     default:
         break;


### PR DESCRIPTION
T1b (Vehicle Setup unlock) and T1d (mode discovery) rolled together. Handles `MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES` and `MAV_CMD_REQUEST_MESSAGE` via the dispatcher from #15211, sending AUTOPILOT_VERSION (FC_VERSION + MCU UID; MAVLINK2 capability — more bits as T2/T3/T4 land), PROTOCOL_VERSION (200/100/200), and a COMPONENT_INFORMATION stub. Replaces the APM-compat custom_mode (0=Stab / 1=Acro) with a proper enum — ACRO, ANGLE, HORIZON, ALT_HOLD, POS_HOLD, AUTOPILOT, RTL, FAILSAFE — emitted in HEARTBEAT.custom_mode and advertised via AVAILABLE_MODES + AVAILABLE_MODES_MONITOR (also returned via REQUEST_MESSAGE; param2 is the 1-based mode index). Adds `mavlinkSendCommandAck` as the foundation for T3 (DO_SET_MODE / arm / RTL). STM32F405 +~3 KB text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced MAVLink command handling: process incoming command requests and send appropriate acknowledgments.
  * Responses to message requests now include version, protocol, component, and available-modes information.
  * Heartbeat and telemetry updated with stable custom-mode support and safer parameter validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->