### PR TITLE
Set d_max_advance default to 0 to match configurator guidance

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -186,7 +186,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .thrustLinearization = 0,
         .d_max = D_MAX_DEFAULT,
         .d_max_gain = 37,
-        .d_max_advance = 20,
+        .d_max_advance = 0,
         .motor_output_limit = 100,
         .auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY,
         .profileName = { 0 },


### PR DESCRIPTION
## Summary

Change the firmware default for `d_max_advance` from `20` to `0` so it matches the guidance the Betaflight Configurator already gives users.

## Rationale

The configurator's help text for D Max Advance ([`pidTuningDMaxAdvanceHelp` in `locales/en/messages.json`](https://github.com/betaflight/betaflight-configurator/blob/master/locales/en/messages.json)) currently reads:

> *"D Max Advance adds sensitivity to the Gain factor when the sticks are moved quickly... **Generally it is best left at zero**... WARNING: Either Advance, or Gain, must be set above about 20, or D will not increase as it should. Setting both to zero will lock D at the base value."*

But the firmware default in `src/main/flight/pid.c` is `20`, so every fresh install / config reset starts in a state the configurator immediately tells the user to change. Users who follow the documented recommendation have to remember to manually zero this on every reset.

This PR aligns the firmware default with the configurator's published guidance.

## Why this is safe

- `d_max_gain` (default `37`) is unchanged, so the gyro-driven D-Max boost path is fully active.
- The configurator's stated minimum condition — "Either Advance, or Gain, must be set above about 20" — is satisfied entirely by the existing `d_max_gain = 37`.
- Setting Advance = 0 removes only the setpoint-derived predictive boost, which the configurator tooltip describes as "occasionally useful for low authority aircraft that tend to lag badly at the start of a move" — a niche case, not a default.
- The CLI/MSP range remains `0..200`, so any user wanting the previous behaviour or higher Advance can still set it.

## Alternative

If maintainers prefer to keep `20` as the firmware default, the configurator help text should be updated to drop the "Generally it is best left at zero" wording so the two surfaces agree. Either fix resolves the inconsistency.

## Test plan

- [x] Build firmware with this change, flash to a 5-inch test rig.
- [x] Verify defaults reset to `d_max_advance = 0` via CLI `dump` and Configurator PID tab.
- [x] Fly a freestyle / race-style pattern, confirm no oscillation or noticeable difference in normal flight.
- [x] Verify D-Max blackbox traces show boost active (driven by `d_max_gain`) on rapid gyro changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted default flight control tuning parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15221)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->