### PR TITLE
telemetry/mavlink: MISSION protocol upload/download

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -287,6 +287,7 @@ COMMON_SRC = \
             telemetry/smartport.c \
             telemetry/ltm.c \
             telemetry/mavlink.c \
+            telemetry/mavlink_mission.c \
             telemetry/msp_shared.c \
             telemetry/ibus.c \
             telemetry/ibus_shared.c \

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2565,6 +2565,7 @@ static void cliServoMix(const char *cmdName, char *cmdline)
 static const char * const waypointTypeNames[] = {
     "FLYOVER", "FLYBY", "HOLD", "LAND", "TAKEOFF"
 };
+STATIC_ASSERT(WAYPOINT_TYPE_COUNT == ARRAYLEN(waypointTypeNames), waypointTypeNames_array_length_mismatch);
 
 static const char * const waypointPatternNames[] = {
     "ORBIT", "FIGURE8"
@@ -2987,7 +2988,7 @@ static void cliWaypoint(const char *cmdName, char *cmdline)
         }
     }
     if (!typeFound) {
-        cliPrintErrorLinef(cmdName, "INVALID TYPE. USE: FLYOVER, FLYBY, HOLD, LAND");
+        cliPrintErrorLinef(cmdName, "INVALID TYPE. USE: FLYOVER, FLYBY, HOLD, LAND, TAKEOFF");
         return;
     }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2563,7 +2563,8 @@ static void cliServoMix(const char *cmdName, char *cmdline)
 #if ENABLE_FLIGHT_PLAN
 
 static const char * const waypointTypeNames[] = {
-    "FLYOVER", "FLYBY", "HOLD", "LAND", "TAKEOFF"
+    "FLYOVER", "FLYBY", "HOLD", "LAND", "TAKEOFF",
+    "ALT_CHANGE", "DELAY", "YAW_RATE"
 };
 STATIC_ASSERT(WAYPOINT_TYPE_COUNT == ARRAYLEN(waypointTypeNames), waypointTypeNames_array_length_mismatch);
 
@@ -2988,7 +2989,7 @@ static void cliWaypoint(const char *cmdName, char *cmdline)
         }
     }
     if (!typeFound) {
-        cliPrintErrorLinef(cmdName, "INVALID TYPE. USE: FLYOVER, FLYBY, HOLD, LAND, TAKEOFF");
+        cliPrintErrorLinef(cmdName, "INVALID TYPE. USE: FLYOVER, FLYBY, HOLD, LAND, TAKEOFF, ALT_CHANGE, DELAY, YAW_RATE");
         return;
     }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2563,7 +2563,7 @@ static void cliServoMix(const char *cmdName, char *cmdline)
 #if ENABLE_FLIGHT_PLAN
 
 static const char * const waypointTypeNames[] = {
-    "FLYOVER", "FLYBY", "HOLD", "LAND"
+    "FLYOVER", "FLYBY", "HOLD", "LAND", "TAKEOFF"
 };
 
 static const char * const waypointPatternNames[] = {

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -27,6 +27,7 @@
 // positionNav is multirotor-only; flight plan execution follows suit.
 #if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
 
+#include "common/maths.h"
 #include "common/time.h"
 #include "common/vector.h"
 
@@ -44,6 +45,7 @@
 #define FP_MIN_CRUISE_MPS         1.0f
 #define FP_FLYBY_COMPLETION_MPS   2.0f
 #define FP_FLYOVER_COMPLETION_MPS 0.5f
+#define FP_DELAY_MIN_CRUISE_MPS   0.1f
 
 static struct {
     flightPlanNavState_e state;
@@ -52,6 +54,18 @@ static struct {
     uint16_t holdDurationDs;
     bool active;
     float zBiasM;               // estimator Z at engage, so waypoint Z shares the estimator baseline
+
+    // Staged modifiers — populated by drainModifiers(), consumed by the next
+    // positional dispatch. altOverride is one-shot; delay arms a timer that
+    // clamps cruise during the next leg; yawRateCapDps is stored but not yet
+    // consumed (needs autopilot yaw control to land first).
+    bool     altOverridePending;
+    int32_t  altOverrideCm;
+    uint8_t  altOverrideMode;       // 0=Neutral, 1=Climbing, 2=Descending; informational
+    bool     delayActive;
+    uint16_t delayDurationDs;
+    timeUs_t delayEndUs;
+    float    yawRateCapDps;
 } fp;
 
 static flightPlanWaypointReachedFn reachedListener = NULL;
@@ -92,17 +106,61 @@ static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
     return true;
 }
 
+// Walk fp.currentIndex past any consecutive modifier waypoints, applying their
+// effect to staged fp state. Returns the first positional waypoint, or NULL if
+// the plan ended (caller transitions to FP_NAV_COMPLETE). Bounded by
+// MAX_WAYPOINTS so a pathological all-modifier mission can't spin.
+static const waypoint_t *drainModifiers(void)
+{
+    for (uint8_t guard = 0; guard < MAX_WAYPOINTS; guard++) {
+        const waypoint_t *wp = currentWaypoint();
+        if (wp == NULL) {
+            return NULL;
+        }
+        switch (wp->type) {
+        case WAYPOINT_TYPE_ALT_CHANGE:
+            fp.altOverridePending = true;
+            fp.altOverrideCm = wp->altitude;
+            fp.altOverrideMode = wp->pattern;
+            break;
+        case WAYPOINT_TYPE_DELAY:
+            fp.delayActive = true;
+            fp.delayDurationDs = wp->duration;
+            fp.delayEndUs = micros() + (uint32_t)wp->duration * 100000u;
+            break;
+        case WAYPOINT_TYPE_YAW_RATE:
+            // Stored only. Hook point: once autopilot_multirotor.c controls
+            // yaw, call into a setter here to apply the cap.
+            fp.yawRateCapDps = (float)wp->speed;
+            break;
+        default:
+            return wp;
+        }
+        if (++fp.currentIndex >= flightPlanConfig()->waypointCount) {
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
 static bool dispatchWaypoint(void)
 {
-    const waypoint_t *wp = currentWaypoint();
+    const waypoint_t *wp = drainModifiers();
     if (wp == NULL) {
         fp.state = FP_NAV_COMPLETE;
         positionNavClearTarget();
         return false;
     }
 
+    // Apply one-shot altitude override before computing the ENU target.
+    waypoint_t effective = *wp;
+    if (fp.altOverridePending) {
+        effective.altitude = fp.altOverrideCm;
+        fp.altOverridePending = false;
+    }
+
     vector3_t targetEnuM;
-    if (!computeTargetEnuM(wp, &targetEnuM)) {
+    if (!computeTargetEnuM(&effective, &targetEnuM)) {
         // No GPS origin captured yet — stay IDLE and let flightPlanNavUpdate()
         // retry once the estimator has locked in.
         fp.state = FP_NAV_IDLE;
@@ -110,17 +168,29 @@ static bool dispatchWaypoint(void)
     }
 
     const autopilotConfig_t *cfg = autopilotConfig();
-    const bool isHoldOrLand = (wp->type == WAYPOINT_TYPE_HOLD) || (wp->type == WAYPOINT_TYPE_LAND);
+    const bool isHoldOrLand = (effective.type == WAYPOINT_TYPE_HOLD) || (effective.type == WAYPOINT_TYPE_LAND);
     const float arrivalRadiusM = (isHoldOrLand ? cfg->waypointHoldRadius : cfg->waypointArrivalRadius) * 0.01f;
 
-    float cruiseMps = (wp->speed > 0) ? wp->speed * 0.01f : cfg->maxVelocity * 0.01f;
+    float cruiseMps = (effective.speed > 0) ? effective.speed * 0.01f : cfg->maxVelocity * 0.01f;
     if (cruiseMps < FP_MIN_CRUISE_MPS) {
         cruiseMps = FP_MIN_CRUISE_MPS;
     }
 
+    // DELAY: clamp cruise so traversal-time ≈ delay-seconds, scaled by the
+    // leg length the executor is about to drive. Skip when the leg is
+    // effectively zero (hold-to-hold) to avoid div-by-near-zero.
+    if (fp.delayActive) {
+        const float delaySec = fp.delayDurationDs * 0.1f;
+        const float legLenM = vector3Norm(&targetEnuM);
+        if (delaySec > 0.0f && legLenM > 0.1f) {
+            const float scaledMps = MAX(FP_DELAY_MIN_CRUISE_MPS, legLenM / delaySec);
+            cruiseMps = MIN(cruiseMps, scaledMps);
+        }
+    }
+
     // FLYBY: advance with residual velocity so we curve through.
     // FLYOVER/HOLD/LAND: require near-stop to count as arrived.
-    const float completionMps = (wp->type == WAYPOINT_TYPE_FLYBY)
+    const float completionMps = (effective.type == WAYPOINT_TYPE_FLYBY)
         ? FP_FLYBY_COMPLETION_MPS
         : FP_FLYOVER_COMPLETION_MPS;
 
@@ -128,7 +198,7 @@ static bool dispatchWaypoint(void)
                            completionMps, true, onWaypointReached, NULL);
 
     fp.state = FP_NAV_TARGETING;
-    fp.holdDurationDs = wp->duration;
+    fp.holdDurationDs = effective.duration;
     return true;
 }
 
@@ -175,18 +245,31 @@ static void onWaypointReached(void *userData)
     advanceToNext();
 }
 
+static void clearModifierState(void)
+{
+    fp.altOverridePending = false;
+    fp.altOverrideCm = 0;
+    fp.altOverrideMode = 0;
+    fp.delayActive = false;
+    fp.delayDurationDs = 0;
+    fp.delayEndUs = 0;
+    fp.yawRateCapDps = 0.0f;
+}
+
 void flightPlanNavInit(void)
 {
     fp.state = FP_NAV_IDLE;
     fp.currentIndex = 0;
     fp.active = false;
     fp.zBiasM = 0.0f;
+    clearModifierState();
 }
 
 void flightPlanNavEngage(void)
 {
     fp.currentIndex = 0;
     fp.state = FP_NAV_IDLE;
+    clearModifierState();
 
     // Capture the estimator's current Z so subsequent waypoint altitudes are
     // referenced to the same baseline the position controller uses.
@@ -227,6 +310,15 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     if (fp.state == FP_NAV_IDLE && flightPlanConfig()->waypointCount > 0) {
         dispatchWaypoint();
         return;
+    }
+
+    // DELAY-window expiry: clear the cap and re-issue the current leg at the
+    // unmodified cruise so we don't crawl for the rest of the leg.
+    if (fp.delayActive && cmpTimeUs(currentTimeUs, fp.delayEndUs) >= 0) {
+        fp.delayActive = false;
+        if (fp.state == FP_NAV_TARGETING) {
+            dispatchWaypoint();
+        }
     }
 
     if (fp.state == FP_NAV_HOLDING) {

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -54,6 +54,8 @@ static struct {
     float zBiasM;               // estimator Z at engage, so waypoint Z shares the estimator baseline
 } fp;
 
+static flightPlanWaypointReachedFn reachedListener = NULL;
+
 static void onWaypointReached(void *userData);
 
 static const waypoint_t *currentWaypoint(void)
@@ -158,6 +160,10 @@ static void onWaypointReached(void *userData)
         return;
     }
 
+    if (reachedListener) {
+        reachedListener(fp.currentIndex);
+    }
+
     if (wp->type == WAYPOINT_TYPE_HOLD && fp.holdDurationDs > 0) {
         fp.state = FP_NAV_HOLDING;
         fp.holdStartUs = micros();
@@ -245,6 +251,11 @@ flightPlanNavState_e flightPlanNavGetState(void)
 uint8_t flightPlanNavGetCurrentIndex(void)
 {
     return fp.currentIndex;
+}
+
+void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn)
+{
+    reachedListener = fn;
 }
 
 #endif // ENABLE_FLIGHT_PLAN && !USE_WING

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -152,11 +152,14 @@ static bool dispatchWaypoint(void)
         return false;
     }
 
-    // Apply one-shot altitude override before computing the ENU target.
+    // Apply the staged altitude override before computing the ENU target.
+    // The override sticks for the whole leg — cleared in advanceToNext() once
+    // we move on — so a retry from FP_NAV_IDLE (estimator origin not ready
+    // yet) or a delay-expiry re-dispatch (cruise restore) both keep the
+    // overridden altitude in place.
     waypoint_t effective = *wp;
     if (fp.altOverridePending) {
         effective.altitude = fp.altOverrideCm;
-        fp.altOverridePending = false;
     }
 
     vector3_t targetEnuM;
@@ -177,11 +180,19 @@ static bool dispatchWaypoint(void)
     }
 
     // DELAY: clamp cruise so traversal-time ≈ delay-seconds, scaled by the
-    // leg length the executor is about to drive. Skip when the leg is
-    // effectively zero (hold-to-hold) to avoid div-by-near-zero.
+    // *remaining* leg (current position → target). targetEnuM is origin →
+    // target, so subtracting the current ENU estimate gives the leg vector
+    // the position controller is actually going to drive. Skip when the
+    // remaining leg is effectively zero to avoid div-by-near-zero.
     if (fp.delayActive) {
         const float delaySec = fp.delayDurationDs * 0.1f;
-        const float legLenM = vector3Norm(&targetEnuM);
+        const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+        const vector3_t legVec = {
+            .x = targetEnuM.x - est->position.x * 0.01f,
+            .y = targetEnuM.y - est->position.y * 0.01f,
+            .z = targetEnuM.z - est->position.z * 0.01f,
+        };
+        const float legLenM = vector3Norm(&legVec);
         if (delaySec > 0.0f && legLenM > 0.1f) {
             const float scaledMps = MAX(FP_DELAY_MIN_CRUISE_MPS, legLenM / delaySec);
             cruiseMps = MIN(cruiseMps, scaledMps);
@@ -204,6 +215,11 @@ static bool dispatchWaypoint(void)
 
 static void advanceToNext(void)
 {
+    // The leg that's ending consumed any staged altitude override; clear it
+    // before the next drainModifiers() pass so a new override (or none) is
+    // staged cleanly for the upcoming leg.
+    fp.altOverridePending = false;
+
     if (fp.currentIndex + 1 >= flightPlanConfig()->waypointCount) {
         fp.state = FP_NAV_COMPLETE;
         positionNavClearTarget();

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -52,3 +52,9 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs);
 bool flightPlanNavIsActive(void);
 flightPlanNavState_e flightPlanNavGetState(void);
 uint8_t flightPlanNavGetCurrentIndex(void);
+
+// Single observer slot for "waypoint reached" — invoked with the index of the
+// waypoint that was just reached, before any HOLD timer or advance. Pass NULL
+// to detach. Used by telemetry/mavlink_mission to emit MISSION_ITEM_REACHED.
+typedef void (*flightPlanWaypointReachedFn)(uint8_t index);
+void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn);

--- a/src/main/pg/flight_plan.h
+++ b/src/main/pg/flight_plan.h
@@ -36,7 +36,8 @@ typedef enum {
     WAYPOINT_TYPE_FLYOVER = 0,
     WAYPOINT_TYPE_FLYBY,
     WAYPOINT_TYPE_HOLD,
-    WAYPOINT_TYPE_LAND
+    WAYPOINT_TYPE_LAND,
+    WAYPOINT_TYPE_TAKEOFF
 } waypointType_e;
 
 typedef enum {

--- a/src/main/pg/flight_plan.h
+++ b/src/main/pg/flight_plan.h
@@ -38,6 +38,11 @@ typedef enum {
     WAYPOINT_TYPE_HOLD,
     WAYPOINT_TYPE_LAND,
     WAYPOINT_TYPE_TAKEOFF,
+    // Modifier types — no positional dispatch; mutate executor state and the
+    // dispatch loop drains them onto the next positional waypoint.
+    WAYPOINT_TYPE_ALT_CHANGE,
+    WAYPOINT_TYPE_DELAY,
+    WAYPOINT_TYPE_YAW_RATE,
     WAYPOINT_TYPE_COUNT
 } waypointType_e;
 

--- a/src/main/pg/flight_plan.h
+++ b/src/main/pg/flight_plan.h
@@ -37,7 +37,8 @@ typedef enum {
     WAYPOINT_TYPE_FLYBY,
     WAYPOINT_TYPE_HOLD,
     WAYPOINT_TYPE_LAND,
-    WAYPOINT_TYPE_TAKEOFF
+    WAYPOINT_TYPE_TAKEOFF,
+    WAYPOINT_TYPE_COUNT
 } waypointType_e;
 
 typedef enum {

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -865,7 +865,10 @@ extern struct linker_symbol __fontdata_end;
 #endif
 
 #if !defined(ENABLE_TELEMETRY_MAVLINK_MISSION)
-#if defined(USE_TELEMETRY_MAVLINK) && ENABLE_FLIGHT_PLAN
+// flight_plan_nav.c (and the autopilot hook in fc/core.c) are gated on
+// !defined(USE_WING); the mission module reaches into those symbols, so match
+// the same shape here to keep wing builds linkable when USE_FLIGHT_PLAN lands.
+#if defined(USE_TELEMETRY_MAVLINK) && ENABLE_FLIGHT_PLAN && !defined(USE_WING)
 #define ENABLE_TELEMETRY_MAVLINK_MISSION 1
 #else
 #define ENABLE_TELEMETRY_MAVLINK_MISSION 0

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -864,6 +864,14 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_FLIGHT_PLAN 0
 #endif
 
+#if !defined(ENABLE_TELEMETRY_MAVLINK_MISSION)
+#if defined(USE_TELEMETRY_MAVLINK) && ENABLE_FLIGHT_PLAN
+#define ENABLE_TELEMETRY_MAVLINK_MISSION 1
+#else
+#define ENABLE_TELEMETRY_MAVLINK_MISSION 0
+#endif
+#endif
+
 #if !defined(ENABLE_RX_UDP)
 #define ENABLE_RX_UDP 0
 #endif

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -74,6 +74,9 @@
 
 #include "telemetry/telemetry.h"
 #include "telemetry/mavlink.h"
+#if ENABLE_TELEMETRY_MAVLINK_MISSION
+#include "telemetry/mavlink_mission.h"
+#endif
 
 #include "build/debug.h"
 #include "build/version.h"
@@ -144,6 +147,17 @@ static void mavlinkSerialWrite(uint8_t * buf, uint16_t length)
 {
     for (int i = 0; i < length; i++)
         serialWrite(mavlinkPort, buf[i]);
+}
+
+// Pack-to-buffer + write helper shared with telemetry/mavlink_mission so the
+// mission module reuses this file's static mavBuffer/mavlinkPort path.
+void mavlinkSendMessage(mavlink_message_t *msg)
+{
+    if (!mavlinkPort) {
+        return;
+    }
+    const uint16_t length = mavlink_msg_to_send_buffer(mavBuffer, msg);
+    mavlinkSerialWrite(mavBuffer, length);
 }
 
 static int16_t headingOrScaledMilliAmpereHoursDrawn(void)
@@ -492,6 +506,9 @@ static void mavlinkDispatch(const mavlink_message_t *msg)
         handleCommandLong(msg);
         break;
     default:
+#if ENABLE_TELEMETRY_MAVLINK_MISSION
+        mavMissionHandleMessage(msg);
+#endif
         break;
     }
 }
@@ -548,6 +565,9 @@ void configureMAVLinkTelemetryPort(void)
     mavlinkPortOwned = true;
     mavlink_reset_channel_status(MAVLINK_COMM_1);
     mavlinkTelemetryEnabled = true;
+#if ENABLE_TELEMETRY_MAVLINK_MISSION
+    mavMissionInit();
+#endif
 }
 
 static void mavlinkSendSystemStatus(void)
@@ -1101,6 +1121,9 @@ void handleMAVLinkTelemetry(void)
     }
 
     mavlinkProcessIncoming();
+#if ENABLE_TELEMETRY_MAVLINK_MISSION
+    mavMissionUpdate(millis());
+#endif
 
     bool shouldSendTelemetry = false;
     uint32_t now = micros();

--- a/src/main/telemetry/mavlink.h
+++ b/src/main/telemetry/mavlink.h
@@ -29,6 +29,16 @@ void checkMAVLinkTelemetryState(void);
 void freeMAVLinkTelemetryPort(void);
 void configureMAVLinkTelemetryPort(void);
 
+// Forward-typedef so consumers can hold pointers without dragging in
+// common/mavlink.h (which carries -Wpedantic-noisy unnamed unions).
+typedef struct __mavlink_message mavlink_message_t;
+
+// Pack a fully-formed mavlink_message_t into the shared TX buffer and write it
+// to the open MAVLink serial port. Implemented in telemetry/mavlink.c; shared
+// with telemetry/mavlink_mission.c so the mission module reuses the same
+// buffer/port path.
+void mavlinkSendMessage(mavlink_message_t *msg);
+
 typedef struct mavlinkTelemetryStream_s {
     uint8_t rate;
     timeMs_t updateTime;

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -1,0 +1,511 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if ENABLE_TELEMETRY_MAVLINK_MISSION
+
+#include "common/time.h"
+
+#include "drivers/time.h"
+
+#include "config/config.h"
+
+#include "fc/runtime_config.h"
+
+#include "flight/flight_plan_nav.h"
+
+#include "io/gps.h"
+
+#include "pg/flight_plan.h"
+
+#include "telemetry/mavlink_mission.h"
+
+#define MAVLINK_SYSTEM_ID 1
+#define MAVLINK_COMPONENT_ID MAV_COMP_ID_AUTOPILOT1
+
+#define MISSION_UPLOAD_RETRY_MS   1500
+#define MISSION_UPLOAD_MAX_RETRY  5
+#define MISSION_DOWNLOAD_IDLE_MS  5000
+#define MISSION_CURRENT_PERIOD_MS 1000
+
+// Provided by telemetry/mavlink.c — packs the message into the shared TX buffer
+// and writes it to the open MAVLink serial port.
+extern void mavlinkSendMessage(mavlink_message_t *msg);
+
+typedef enum {
+    MISSION_IDLE,
+    MISSION_RECEIVING,  // sent REQUEST_INT, awaiting MISSION_ITEM_INT
+    MISSION_SENDING,    // sent COUNT, awaiting MISSION_REQUEST_INT
+} missionState_e;
+
+static struct {
+    missionState_e state;
+    uint16_t nextSeq;
+    uint16_t totalCount;
+    uint8_t  partnerSys;
+    uint8_t  partnerComp;
+    timeMs_t lastActivityMs;
+    uint8_t  retries;
+    timeMs_t lastCurrentTxMs;
+    int16_t  pendingReachedIndex;
+    bool     rtlTerminator;     // current upload ends with NAV_RETURN_TO_LAUNCH (last slot discarded)
+} m;
+
+static mavlink_message_t txMsg;
+
+static void sendAck(uint8_t partnerSys, uint8_t partnerComp, uint8_t type)
+{
+    mavlink_msg_mission_ack_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+        partnerSys, partnerComp, type, MAV_MISSION_TYPE_MISSION, 0);
+    mavlinkSendMessage(&txMsg);
+}
+
+static void sendRequestInt(uint8_t partnerSys, uint8_t partnerComp, uint16_t seq)
+{
+    mavlink_msg_mission_request_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+        partnerSys, partnerComp, seq, MAV_MISSION_TYPE_MISSION);
+    mavlinkSendMessage(&txMsg);
+}
+
+static void sendCount(uint8_t partnerSys, uint8_t partnerComp, uint16_t count)
+{
+    mavlink_msg_mission_count_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+        partnerSys, partnerComp, count, MAV_MISSION_TYPE_MISSION, 0);
+    mavlinkSendMessage(&txMsg);
+}
+
+static void abortUpload(uint8_t result)
+{
+    sendAck(m.partnerSys, m.partnerComp, result);
+    m.state = MISSION_IDLE;
+}
+
+static uint8_t mapTypeToMavCmd(uint8_t type, uint16_t duration_ds, float *param1Out)
+{
+    *param1Out = 0.0f;
+    switch (type) {
+    case WAYPOINT_TYPE_FLYOVER:
+    case WAYPOINT_TYPE_FLYBY:
+        return MAV_CMD_NAV_WAYPOINT;
+    case WAYPOINT_TYPE_HOLD:
+        *param1Out = duration_ds * 0.1f;
+        return MAV_CMD_NAV_LOITER_TIME;
+    case WAYPOINT_TYPE_LAND:
+        return MAV_CMD_NAV_LAND;
+    case WAYPOINT_TYPE_TAKEOFF:
+        return MAV_CMD_NAV_TAKEOFF;
+    default:
+        return MAV_CMD_NAV_WAYPOINT;
+    }
+}
+
+static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t seq)
+{
+    const flightPlanConfig_t *plan = flightPlanConfig();
+    const waypoint_t *wp = &plan->waypoints[seq];
+
+    float param1 = 0.0f;
+    const uint16_t command = mapTypeToMavCmd(wp->type, wp->duration, &param1);
+    const uint8_t current = (flightPlanNavIsActive() && seq == flightPlanNavGetCurrentIndex()) ? 1 : 0;
+
+    mavlink_msg_mission_item_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+        partnerSys, partnerComp, seq, MAV_FRAME_GLOBAL_INT, command, current, 1,
+        param1, 0.0f, 0.0f, 0.0f,
+        wp->latitude, wp->longitude, wp->altitude * 0.01f,
+        MAV_MISSION_TYPE_MISSION);
+    mavlinkSendMessage(&txMsg);
+}
+
+static bool decodeFrameAltCm(uint8_t frame, float z, int32_t *altCmOut, uint8_t *resultOut)
+{
+    if (!isfinite(z)) {
+        *resultOut = MAV_MISSION_INVALID_PARAM7;
+        return false;
+    }
+    switch (frame) {
+    case MAV_FRAME_GLOBAL_INT:
+        *altCmOut = (int32_t)(z * 100.0f);
+        return true;
+    case MAV_FRAME_GLOBAL_RELATIVE_ALT_INT:
+        if (!STATE(GPS_FIX_HOME)) {
+            *resultOut = MAV_MISSION_INVALID;
+            return false;
+        }
+        *altCmOut = (int32_t)(z * 100.0f) + GPS_home_llh.altCm;
+        return true;
+    default:
+        *resultOut = MAV_MISSION_UNSUPPORTED_FRAME;
+        return false;
+    }
+}
+
+static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t *wp,
+                                bool isLastSlot, bool *isRtlTerminator, uint8_t *resultOut)
+{
+    *isRtlTerminator = false;
+
+    if (it->command == MAV_CMD_NAV_RETURN_TO_LAUNCH) {
+        if (!isLastSlot) {
+            *resultOut = MAV_MISSION_UNSUPPORTED;
+            return false;
+        }
+        *isRtlTerminator = true;
+        return true;
+    }
+
+    int32_t altCm;
+    if (!decodeFrameAltCm(it->frame, it->z, &altCm, resultOut)) {
+        return false;
+    }
+
+    if (it->x < -900000000 || it->x > 900000000) {
+        *resultOut = MAV_MISSION_INVALID_PARAM5_X;
+        return false;
+    }
+    if (it->y < -1800000000 || it->y > 1800000000) {
+        *resultOut = MAV_MISSION_INVALID_PARAM6_Y;
+        return false;
+    }
+    if (!isfinite(it->param1) || !isfinite(it->param2) || !isfinite(it->param3) || !isfinite(it->param4)) {
+        *resultOut = MAV_MISSION_INVALID;
+        return false;
+    }
+
+    wp->latitude = it->x;
+    wp->longitude = it->y;
+    wp->altitude = altCm;
+    wp->speed = 0;
+    wp->duration = 0;
+    wp->pattern = WAYPOINT_PATTERN_ORBIT;
+
+    switch (it->command) {
+    case MAV_CMD_NAV_WAYPOINT:
+        wp->type = WAYPOINT_TYPE_FLYBY;
+        if (it->param1 > 0.0f) {
+            const float ds = it->param1 * 10.0f;
+            wp->duration = (ds >= UINT16_MAX) ? UINT16_MAX : (uint16_t)ds;
+        }
+        break;
+    case MAV_CMD_NAV_LOITER_TIME:
+        wp->type = WAYPOINT_TYPE_HOLD;
+        if (it->param1 > 0.0f) {
+            const float ds = it->param1 * 10.0f;
+            wp->duration = (ds >= UINT16_MAX) ? UINT16_MAX : (uint16_t)ds;
+        }
+        break;
+    case MAV_CMD_NAV_LOITER_TURNS:
+        wp->type = WAYPOINT_TYPE_HOLD;
+        break;
+    case MAV_CMD_NAV_LOITER_UNLIM:
+        wp->type = WAYPOINT_TYPE_HOLD;
+        wp->duration = UINT16_MAX;
+        break;
+    case MAV_CMD_NAV_LAND:
+        wp->type = WAYPOINT_TYPE_LAND;
+        break;
+    case MAV_CMD_NAV_TAKEOFF:
+        wp->type = WAYPOINT_TYPE_TAKEOFF;
+        break;
+    default:
+        *resultOut = MAV_MISSION_UNSUPPORTED;
+        return false;
+    }
+    return true;
+}
+
+static void handleRequestList(const mavlink_message_t *msg)
+{
+    const uint16_t count = flightPlanConfig()->waypointCount;
+    m.partnerSys = msg->sysid;
+    m.partnerComp = msg->compid;
+
+    if (count == 0) {
+        sendCount(msg->sysid, msg->compid, 0);
+        m.state = MISSION_IDLE;
+        return;
+    }
+
+    m.state = MISSION_SENDING;
+    m.nextSeq = 0;
+    m.totalCount = count;
+    m.lastActivityMs = millis();
+    sendCount(msg->sysid, msg->compid, count);
+}
+
+static void handleRequestInt(const mavlink_message_t *msg)
+{
+    mavlink_mission_request_int_t req;
+    mavlink_msg_mission_request_int_decode(msg, &req);
+
+    if (req.mission_type != MAV_MISSION_TYPE_MISSION) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+        return;
+    }
+    if (m.state != MISSION_SENDING) {
+        return;
+    }
+    // Allow current seq or one-back retransmit; everything else is out of sequence.
+    if (req.seq != m.nextSeq && !(m.nextSeq > 0 && req.seq == m.nextSeq - 1)) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_INVALID_SEQUENCE);
+        m.state = MISSION_IDLE;
+        return;
+    }
+    if (req.seq >= m.totalCount) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_INVALID_SEQUENCE);
+        m.state = MISSION_IDLE;
+        return;
+    }
+
+    sendMissionItem(msg->sysid, msg->compid, req.seq);
+    if (req.seq == m.totalCount - 1) {
+        // Final item — partner is expected to send MISSION_ACK; drop to IDLE on receipt
+        // or via the SENDING-idle timeout.
+        m.nextSeq = req.seq + 1;
+    } else if (req.seq == m.nextSeq) {
+        m.nextSeq++;
+    }
+    m.lastActivityMs = millis();
+}
+
+static void handleCount(const mavlink_message_t *msg)
+{
+    mavlink_mission_count_t mc;
+    mavlink_msg_mission_count_decode(msg, &mc);
+
+    if (mc.mission_type != MAV_MISSION_TYPE_MISSION) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+        return;
+    }
+    if (FLIGHT_MODE(AUTOPILOT_MODE)) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_DENIED);
+        return;
+    }
+    if (mc.count > MAX_WAYPOINTS) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_NO_SPACE);
+        return;
+    }
+    if (mc.count == 0) {
+        flightPlanConfigMutable()->waypointCount = 0;
+        saveConfigAndNotify();
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_ACCEPTED);
+        m.state = MISSION_IDLE;
+        return;
+    }
+
+    m.state = MISSION_RECEIVING;
+    m.nextSeq = 0;
+    m.totalCount = mc.count;
+    m.partnerSys = msg->sysid;
+    m.partnerComp = msg->compid;
+    m.lastActivityMs = millis();
+    m.retries = 0;
+    m.rtlTerminator = false;
+    sendRequestInt(msg->sysid, msg->compid, 0);
+}
+
+static void handleItemInt(const mavlink_message_t *msg)
+{
+    if (m.state != MISSION_RECEIVING) {
+        return;
+    }
+
+    mavlink_mission_item_int_t it;
+    mavlink_msg_mission_item_int_decode(msg, &it);
+
+    if (it.mission_type != MAV_MISSION_TYPE_MISSION) {
+        abortUpload(MAV_MISSION_UNSUPPORTED);
+        return;
+    }
+    if (it.seq != m.nextSeq) {
+        abortUpload(MAV_MISSION_INVALID_SEQUENCE);
+        return;
+    }
+
+    waypoint_t wp;
+    bool isRtl = false;
+    const bool isLastSlot = (it.seq == m.totalCount - 1);
+    uint8_t result = MAV_MISSION_ACCEPTED;
+    if (!mapMavCmdToWaypoint(&it, &wp, isLastSlot, &isRtl, &result)) {
+        abortUpload(result);
+        return;
+    }
+
+    if (isRtl) {
+        // RTL discards its own slot; mission count finalises at items received so far.
+        m.rtlTerminator = true;
+    } else {
+        flightPlanConfigMutable()->waypoints[it.seq] = wp;
+    }
+
+    m.nextSeq++;
+    m.lastActivityMs = millis();
+    m.retries = 0;
+
+    if (m.nextSeq < m.totalCount) {
+        sendRequestInt(msg->sysid, msg->compid, m.nextSeq);
+        return;
+    }
+
+    // Upload complete.
+    const uint16_t finalCount = m.rtlTerminator ? m.totalCount - 1 : m.totalCount;
+    flightPlanConfigMutable()->waypointCount = finalCount;
+    saveConfigAndNotify();
+    sendAck(msg->sysid, msg->compid, MAV_MISSION_ACCEPTED);
+    m.state = MISSION_IDLE;
+}
+
+static void handleClearAll(const mavlink_message_t *msg)
+{
+    mavlink_mission_clear_all_t mc;
+    mavlink_msg_mission_clear_all_decode(msg, &mc);
+    if (mc.mission_type != MAV_MISSION_TYPE_MISSION) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+        return;
+    }
+    if (FLIGHT_MODE(AUTOPILOT_MODE)) {
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_DENIED);
+        return;
+    }
+    flightPlanConfigMutable()->waypointCount = 0;
+    saveConfigAndNotify();
+    sendAck(msg->sysid, msg->compid, MAV_MISSION_ACCEPTED);
+    m.state = MISSION_IDLE;
+}
+
+static void handleMissionAck(const mavlink_message_t *msg)
+{
+    UNUSED(msg);
+    if (m.state == MISSION_SENDING) {
+        m.state = MISSION_IDLE;
+    }
+}
+
+static void onWaypointReached(uint8_t index)
+{
+    m.pendingReachedIndex = index;
+}
+
+void mavMissionInit(void)
+{
+    memset(&m, 0, sizeof(m));
+    m.state = MISSION_IDLE;
+    m.pendingReachedIndex = -1;
+    flightPlanNavSetReachedListener(onWaypointReached);
+}
+
+bool mavMissionHandleMessage(const mavlink_message_t *msg)
+{
+    // target filter — accept broadcast or directed-to-us; same pattern as
+    // handleCommandLong() in mavlink.c. We must decode the targeting fields out
+    // of the typed payload, but the offset differs per message; keep it simple
+    // and filter inside each handler where the decode happens.
+    switch (msg->msgid) {
+    case MAVLINK_MSG_ID_MISSION_REQUEST_LIST: {
+        mavlink_mission_request_list_t r;
+        mavlink_msg_mission_request_list_decode(msg, &r);
+        if ((r.target_system && r.target_system != MAVLINK_SYSTEM_ID) ||
+            (r.target_component && r.target_component != MAVLINK_COMPONENT_ID)) {
+            return true;
+        }
+        if (r.mission_type != MAV_MISSION_TYPE_MISSION) {
+            sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+            return true;
+        }
+        handleRequestList(msg);
+        return true;
+    }
+    case MAVLINK_MSG_ID_MISSION_REQUEST_INT:
+        handleRequestInt(msg);
+        return true;
+    case MAVLINK_MSG_ID_MISSION_COUNT:
+        handleCount(msg);
+        return true;
+    case MAVLINK_MSG_ID_MISSION_ITEM_INT:
+        handleItemInt(msg);
+        return true;
+    case MAVLINK_MSG_ID_MISSION_CLEAR_ALL:
+        handleClearAll(msg);
+        return true;
+    case MAVLINK_MSG_ID_MISSION_ACK:
+        handleMissionAck(msg);
+        return true;
+    default:
+        return false;
+    }
+}
+
+void mavMissionUpdate(timeMs_t nowMs)
+{
+    // RECEIVING timeout: retransmit REQUEST_INT, give up after MAX_RETRY.
+    if (m.state == MISSION_RECEIVING && (nowMs - m.lastActivityMs) >= MISSION_UPLOAD_RETRY_MS) {
+        if (m.retries >= MISSION_UPLOAD_MAX_RETRY) {
+            abortUpload(MAV_MISSION_OPERATION_CANCELLED);
+        } else {
+            m.retries++;
+            m.lastActivityMs = nowMs;
+            sendRequestInt(m.partnerSys, m.partnerComp, m.nextSeq);
+        }
+    }
+
+    // SENDING idle: spec leaves recovery to the partner; just drop state.
+    if (m.state == MISSION_SENDING && (nowMs - m.lastActivityMs) >= MISSION_DOWNLOAD_IDLE_MS) {
+        m.state = MISSION_IDLE;
+    }
+
+    // MISSION_ITEM_REACHED — drain as soon as the executor flagged one.
+    if (m.pendingReachedIndex >= 0) {
+        mavlink_msg_mission_item_reached_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+            (uint16_t)m.pendingReachedIndex);
+        mavlinkSendMessage(&txMsg);
+        m.pendingReachedIndex = -1;
+    }
+
+    // MISSION_CURRENT @ 1 Hz — lets QGC display the live cursor whether or not
+    // the mission is being executed.
+    if ((nowMs - m.lastCurrentTxMs) >= MISSION_CURRENT_PERIOD_MS) {
+        const uint16_t total = flightPlanConfig()->waypointCount;
+        const bool active = flightPlanNavIsActive();
+        const uint16_t seq = (total && active) ? flightPlanNavGetCurrentIndex() : 0;
+        const uint8_t missionMode = active ? 1 : 2;
+        uint8_t missionState;
+        if (total == 0) {
+            missionState = MISSION_STATE_NO_MISSION;
+        } else if (!active) {
+            missionState = MISSION_STATE_NOT_STARTED;
+        } else if (flightPlanNavGetState() == FP_NAV_COMPLETE) {
+            missionState = MISSION_STATE_COMPLETE;
+        } else {
+            missionState = MISSION_STATE_ACTIVE;
+        }
+        mavlink_msg_mission_current_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+            seq, total, missionState, missionMode, 0, 0, 0);
+        mavlinkSendMessage(&txMsg);
+        m.lastCurrentTxMs = nowMs;
+    }
+}
+
+#endif // ENABLE_TELEMETRY_MAVLINK_MISSION

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -120,38 +120,57 @@ static void abortUpload(uint8_t result)
     m.state = MISSION_IDLE;
 }
 
-static uint16_t mapTypeToMavCmd(uint8_t type, uint16_t duration_ds, float *param1Out)
-{
-    *param1Out = 0.0f;
-    switch (type) {
-    case WAYPOINT_TYPE_FLYOVER:
-    case WAYPOINT_TYPE_FLYBY:
-        return MAV_CMD_NAV_WAYPOINT;
-    case WAYPOINT_TYPE_HOLD:
-        *param1Out = duration_ds * 0.1f;
-        return MAV_CMD_NAV_LOITER_TIME;
-    case WAYPOINT_TYPE_LAND:
-        return MAV_CMD_NAV_LAND;
-    case WAYPOINT_TYPE_TAKEOFF:
-        return MAV_CMD_NAV_TAKEOFF;
-    default:
-        return MAV_CMD_NAV_WAYPOINT;
-    }
-}
-
 static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t seq)
 {
     const flightPlanConfig_t *plan = flightPlanConfig();
     const waypoint_t *wp = &plan->waypoints[seq];
 
+    uint16_t command;
     float param1 = 0.0f;
-    const uint16_t command = mapTypeToMavCmd(wp->type, wp->duration, &param1);
+    float param2 = 0.0f;
+    int32_t lat = wp->latitude;
+    int32_t lon = wp->longitude;
+    float zM = wp->altitude * 0.01f;
+
+    switch (wp->type) {
+    case WAYPOINT_TYPE_HOLD:
+        command = MAV_CMD_NAV_LOITER_TIME;
+        param1 = wp->duration * 0.1f;
+        break;
+    case WAYPOINT_TYPE_LAND:
+        command = MAV_CMD_NAV_LAND;
+        break;
+    case WAYPOINT_TYPE_TAKEOFF:
+        command = MAV_CMD_NAV_TAKEOFF;
+        break;
+    case WAYPOINT_TYPE_ALT_CHANGE:
+        command = MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT;
+        param1 = (float)wp->pattern;     // climb-mode round-trip
+        lat = 0; lon = 0;                // no horizontal target
+        break;
+    case WAYPOINT_TYPE_DELAY:
+        command = MAV_CMD_NAV_DELAY;
+        param1 = wp->duration * 0.1f;
+        lat = 0; lon = 0; zM = 0.0f;
+        break;
+    case WAYPOINT_TYPE_YAW_RATE:
+        command = MAV_CMD_NAV_SET_YAW_SPEED;
+        param2 = (float)wp->speed;
+        lat = 0; lon = 0; zM = 0.0f;
+        break;
+    case WAYPOINT_TYPE_FLYOVER:
+    case WAYPOINT_TYPE_FLYBY:
+    default:
+        command = MAV_CMD_NAV_WAYPOINT;
+        break;
+    }
+
     const uint8_t current = (flightPlanNavIsActive() && seq == flightPlanNavGetCurrentIndex()) ? 1 : 0;
 
     mavlink_msg_mission_item_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
         partnerSys, partnerComp, seq, MAV_FRAME_GLOBAL_INT, command, current, 1,
-        param1, 0.0f, 0.0f, 0.0f,
-        wp->latitude, wp->longitude, wp->altitude * 0.01f,
+        param1, param2, 0.0f, 0.0f,
+        lat, lon, zM,
         MAV_MISSION_TYPE_MISSION);
     mavlinkSendMessage(&txMsg);
 }
@@ -193,26 +212,34 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
         return true;
     }
 
-    int32_t altCm;
-    if (!decodeFrameAltCm(it->frame, it->z, &altCm, resultOut)) {
-        return false;
-    }
+    // Modifier commands carry no horizontal position; the generic lat/lon range
+    // check and frame-based alt decode are skipped (with ALT_CHANGE pulling alt
+    // explicitly below). DELAY / SET_YAW_SPEED ignore all coord fields.
+    const bool isModifier = (it->command == MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT)
+                         || (it->command == MAV_CMD_NAV_DELAY)
+                         || (it->command == MAV_CMD_NAV_SET_YAW_SPEED);
 
-    if (it->x < -900000000 || it->x > 900000000) {
-        *resultOut = MAV_MISSION_INVALID_PARAM5_X;
-        return false;
-    }
-    if (it->y < -1800000000 || it->y > 1800000000) {
-        *resultOut = MAV_MISSION_INVALID_PARAM6_Y;
-        return false;
+    int32_t altCm = 0;
+    if (!isModifier) {
+        if (!decodeFrameAltCm(it->frame, it->z, &altCm, resultOut)) {
+            return false;
+        }
+        if (it->x < -900000000 || it->x > 900000000) {
+            *resultOut = MAV_MISSION_INVALID_PARAM5_X;
+            return false;
+        }
+        if (it->y < -1800000000 || it->y > 1800000000) {
+            *resultOut = MAV_MISSION_INVALID_PARAM6_Y;
+            return false;
+        }
     }
     if (!isfinite(it->param1) || !isfinite(it->param2) || !isfinite(it->param3) || !isfinite(it->param4)) {
         *resultOut = MAV_MISSION_INVALID;
         return false;
     }
 
-    wp->latitude = it->x;
-    wp->longitude = it->y;
+    wp->latitude = isModifier ? 0 : it->x;
+    wp->longitude = isModifier ? 0 : it->y;
     wp->altitude = altCm;
     wp->speed = 0;
     wp->duration = 0;
@@ -280,18 +307,55 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
         // TAKEOFF_LOCAL is the local-frame variant — see LAND_LOCAL note.
         wp->type = WAYPOINT_TYPE_TAKEOFF;
         break;
-    // Intentionally rejected — no positional mapping fits, or semantics would
-    // produce unsafe flight if force-fit into waypoint_t:
-    //   NAV_CONTINUE_AND_CHANGE_ALT  — alt-only, no lat/lon to store
-    //   NAV_ROI                      — camera target; mapping to HOLD would
-    //                                  fly the vehicle to the camera point
-    //   NAV_PATHPLANNING             — planner enable/disable, not a goal
-    //   NAV_GUIDED_ENABLE            — off-board control toggle
-    //   NAV_DELAY                    — timer, no position
-    //   NAV_SET_YAW_SPEED            — relative attitude tweak
+    case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT: {
+        // Modifier: re-targets the next positional waypoint's altitude. param1
+        // is the climb-mode (0=Neutral, 1=Climbing, 2=Descending) — preserved
+        // for round-trip but not yet enforced by the executor.
+        if (it->param1 < -0.5f || it->param1 > 2.5f) {
+            *resultOut = MAV_MISSION_INVALID_PARAM1;
+            return false;
+        }
+        int32_t modAltCm;
+        if (!decodeFrameAltCm(it->frame, it->z, &modAltCm, resultOut)) {
+            return false;
+        }
+        wp->type = WAYPOINT_TYPE_ALT_CHANGE;
+        wp->altitude = modAltCm;
+        wp->pattern = (uint8_t)lrintf(it->param1);
+        break;
+    }
+    case MAV_CMD_NAV_DELAY: {
+        // Modifier: scales cruise on the next leg so traversal ≈ delay seconds.
+        // ToD form (param1 == -1 with HH:MM:SS) is rejected — Betaflight targets
+        // don't universally have RTC.
+        if (it->param1 < 0.0f) {
+            *resultOut = MAV_MISSION_INVALID_PARAM1;
+            return false;
+        }
+        const float ds = it->param1 * 10.0f;
+        wp->type = WAYPOINT_TYPE_DELAY;
+        wp->duration = (ds >= UINT16_MAX) ? UINT16_MAX : (uint16_t)ds;
+        break;
+    }
+    case MAV_CMD_NAV_SET_YAW_SPEED:
+        // Modifier: yaw-rate cap. Stored + round-tripped now; executor
+        // consumption is gated on yaw control during AUTOPILOT_MODE landing,
+        // which is a capability follow-up. param1 (angle to adjust) and
+        // param3 (relative flag) are intentionally ignored.
+        if (it->param2 < 0.0f) {
+            *resultOut = MAV_MISSION_INVALID_PARAM2;
+            return false;
+        }
+        wp->type = WAYPOINT_TYPE_YAW_RATE;
+        wp->speed = (it->param2 >= (float)UINT16_MAX) ? UINT16_MAX : (uint16_t)it->param2;
+        break;
+    // Still rejected — no positional or modifier mapping that's safe to fit:
+    //   NAV_ROI               — camera target; mapping to HOLD would fly the
+    //                           vehicle to the camera point
+    //   NAV_PATHPLANNING      — planner enable/disable, not a goal
+    //   NAV_GUIDED_ENABLE     — off-board control toggle
     //   NAV_FENCE_* / NAV_RALLY_POINT — different mission_type, rejected
-    //                                  earlier by the MISSION_TYPE_MISSION
-    //                                  filter on every handler
+    //                           earlier by the MISSION_TYPE_MISSION filter
     default:
         *resultOut = MAV_MISSION_UNSUPPORTED;
         return false;

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -220,6 +220,10 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
 
     switch (it->command) {
     case MAV_CMD_NAV_WAYPOINT:
+    case MAV_CMD_NAV_SPLINE_WAYPOINT:
+        // SPLINE_WAYPOINT shares the param1/x/y/z layout with NAV_WAYPOINT; the
+        // executor flies a straight line through it, which is a faithful
+        // approximation for the QGC plan-editor's curved preview.
         wp->type = WAYPOINT_TYPE_FLYBY;
         if (it->param1 > 0.0f) {
             const float ds = it->param1 * 10.0f;
@@ -241,11 +245,26 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
         wp->duration = UINT16_MAX;
         break;
     case MAV_CMD_NAV_LAND:
+    case MAV_CMD_NAV_VTOL_LAND:
+        // VTOL_LAND is the multi-rotor-half of a quadplane landing; on a pure
+        // multirotor it has the same semantics as NAV_LAND.
         wp->type = WAYPOINT_TYPE_LAND;
         break;
     case MAV_CMD_NAV_TAKEOFF:
+    case MAV_CMD_NAV_VTOL_TAKEOFF:
+        // VTOL_TAKEOFF likewise collapses to NAV_TAKEOFF on a multirotor; the
+        // "transition heading" param is fixed-wing-only and ignored.
         wp->type = WAYPOINT_TYPE_TAKEOFF;
         break;
+    // Intentionally unsupported (no fit for waypoint_t or no executor support):
+    //   NAV_LAND_LOCAL / NAV_TAKEOFF_LOCAL  — local frame, also rejected by frame check
+    //   NAV_FOLLOW                          — dynamic target tracking
+    //   NAV_CONTINUE_AND_CHANGE_ALT         — no lat/lon, needs alt-only state
+    //   NAV_LOITER_TO_ALT                   — needs alt-arrival latch in executor
+    //   NAV_ROI / NAV_PATHPLANNING          — not positional waypoints
+    //   NAV_GUIDED_ENABLE / NAV_DELAY       — control/timer, not a waypoint
+    //   NAV_PAYLOAD_PLACE                   — no payload-release mechanism
+    //   NAV_SET_YAW_SPEED / NAV_FENCE_* / NAV_RALLY_POINT — different domains
     default:
         *resultOut = MAV_MISSION_UNSUPPORTED;
         return false;

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -42,6 +42,7 @@
 
 #include "pg/flight_plan.h"
 
+#include "telemetry/mavlink.h"
 #include "telemetry/mavlink_mission.h"
 
 #define MAVLINK_SYSTEM_ID 1
@@ -51,10 +52,6 @@
 #define MISSION_UPLOAD_MAX_RETRY  5
 #define MISSION_DOWNLOAD_IDLE_MS  5000
 #define MISSION_CURRENT_PERIOD_MS 1000
-
-// Provided by telemetry/mavlink.c — packs the message into the shared TX buffer
-// and writes it to the open MAVLink serial port.
-extern void mavlinkSendMessage(mavlink_message_t *msg);
 
 typedef enum {
     MISSION_IDLE,
@@ -76,6 +73,25 @@ static struct {
 } m;
 
 static mavlink_message_t txMsg;
+
+static bool targetIsUs(uint8_t target_system, uint8_t target_component)
+{
+    if (target_system && target_system != MAVLINK_SYSTEM_ID) {
+        return false;
+    }
+    if (target_component && target_component != MAVLINK_COMPONENT_ID) {
+        return false;
+    }
+    return true;
+}
+
+// During an active transfer, reject any traffic from a sysid/compid that isn't
+// the partner we started the session with. Stops a second GCS from interleaving
+// into an in-flight upload or download.
+static bool senderIsActivePartner(const mavlink_message_t *msg)
+{
+    return msg->sysid == m.partnerSys && msg->compid == m.partnerComp;
+}
 
 static void sendAck(uint8_t partnerSys, uint8_t partnerComp, uint8_t type)
 {
@@ -104,7 +120,7 @@ static void abortUpload(uint8_t result)
     m.state = MISSION_IDLE;
 }
 
-static uint8_t mapTypeToMavCmd(uint8_t type, uint16_t duration_ds, float *param1Out)
+static uint16_t mapTypeToMavCmd(uint8_t type, uint16_t duration_ds, float *param1Out)
 {
     *param1Out = 0.0f;
     switch (type) {
@@ -261,11 +277,14 @@ static void handleRequestInt(const mavlink_message_t *msg)
     mavlink_mission_request_int_t req;
     mavlink_msg_mission_request_int_decode(msg, &req);
 
+    if (!targetIsUs(req.target_system, req.target_component)) {
+        return;
+    }
     if (req.mission_type != MAV_MISSION_TYPE_MISSION) {
         sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
         return;
     }
-    if (m.state != MISSION_SENDING) {
+    if (m.state != MISSION_SENDING || !senderIsActivePartner(msg)) {
         return;
     }
     // Allow current seq or one-back retransmit; everything else is out of sequence.
@@ -296,6 +315,9 @@ static void handleCount(const mavlink_message_t *msg)
     mavlink_mission_count_t mc;
     mavlink_msg_mission_count_decode(msg, &mc);
 
+    if (!targetIsUs(mc.target_system, mc.target_component)) {
+        return;
+    }
     if (mc.mission_type != MAV_MISSION_TYPE_MISSION) {
         sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
         return;
@@ -316,6 +338,11 @@ static void handleCount(const mavlink_message_t *msg)
         return;
     }
 
+    // MAVLink semantics: a new upload replaces any existing mission. Zero the
+    // count immediately so any consumer (CLI dump, executor on next engage)
+    // doesn't see a half-overwritten waypoint table mid-transfer.
+    flightPlanConfigMutable()->waypointCount = 0;
+
     m.state = MISSION_RECEIVING;
     m.nextSeq = 0;
     m.totalCount = mc.count;
@@ -329,13 +356,15 @@ static void handleCount(const mavlink_message_t *msg)
 
 static void handleItemInt(const mavlink_message_t *msg)
 {
-    if (m.state != MISSION_RECEIVING) {
-        return;
-    }
-
     mavlink_mission_item_int_t it;
     mavlink_msg_mission_item_int_decode(msg, &it);
 
+    if (!targetIsUs(it.target_system, it.target_component)) {
+        return;
+    }
+    if (m.state != MISSION_RECEIVING || !senderIsActivePartner(msg)) {
+        return;
+    }
     if (it.mission_type != MAV_MISSION_TYPE_MISSION) {
         abortUpload(MAV_MISSION_UNSUPPORTED);
         return;
@@ -382,6 +411,9 @@ static void handleClearAll(const mavlink_message_t *msg)
 {
     mavlink_mission_clear_all_t mc;
     mavlink_msg_mission_clear_all_decode(msg, &mc);
+    if (!targetIsUs(mc.target_system, mc.target_component)) {
+        return;
+    }
     if (mc.mission_type != MAV_MISSION_TYPE_MISSION) {
         sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
         return;
@@ -398,8 +430,12 @@ static void handleClearAll(const mavlink_message_t *msg)
 
 static void handleMissionAck(const mavlink_message_t *msg)
 {
-    UNUSED(msg);
-    if (m.state == MISSION_SENDING) {
+    mavlink_mission_ack_t ack;
+    mavlink_msg_mission_ack_decode(msg, &ack);
+    if (!targetIsUs(ack.target_system, ack.target_component)) {
+        return;
+    }
+    if (m.state == MISSION_SENDING && senderIsActivePartner(msg)) {
         m.state = MISSION_IDLE;
     }
 }
@@ -419,16 +455,14 @@ void mavMissionInit(void)
 
 bool mavMissionHandleMessage(const mavlink_message_t *msg)
 {
-    // target filter — accept broadcast or directed-to-us; same pattern as
-    // handleCommandLong() in mavlink.c. We must decode the targeting fields out
-    // of the typed payload, but the offset differs per message; keep it simple
-    // and filter inside each handler where the decode happens.
+    // Each handler decodes the typed payload and applies its own target filter
+    // via targetIsUs(); per-message session-partner enforcement also lives in
+    // the handlers that act on an active transfer.
     switch (msg->msgid) {
     case MAVLINK_MSG_ID_MISSION_REQUEST_LIST: {
         mavlink_mission_request_list_t r;
         mavlink_msg_mission_request_list_decode(msg, &r);
-        if ((r.target_system && r.target_system != MAVLINK_SYSTEM_ID) ||
-            (r.target_component && r.target_component != MAVLINK_COMPONENT_ID)) {
+        if (!targetIsUs(r.target_system, r.target_component)) {
             return true;
         }
         if (r.mission_type != MAV_MISSION_TYPE_MISSION) {

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -244,27 +244,54 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
         wp->type = WAYPOINT_TYPE_HOLD;
         wp->duration = UINT16_MAX;
         break;
+    case MAV_CMD_NAV_LOITER_TO_ALT:
+        // Best-effort: hold at lat/lon. The "loiter until alt reached" latch
+        // needs executor work — without it the waypoint advances on arrival
+        // like any other HOLD-zero. Capability follow-up.
+        wp->type = WAYPOINT_TYPE_HOLD;
+        break;
+    case MAV_CMD_NAV_FOLLOW:
+        // Best-effort: hover at the initial target position. Dynamic vehicle
+        // following needs an updating target source the executor doesn't have
+        // today — capability follow-up.
+        wp->type = WAYPOINT_TYPE_HOLD;
+        break;
     case MAV_CMD_NAV_LAND:
     case MAV_CMD_NAV_VTOL_LAND:
+    case MAV_CMD_NAV_LAND_LOCAL:
         // VTOL_LAND is the multi-rotor-half of a quadplane landing; on a pure
-        // multirotor it has the same semantics as NAV_LAND.
+        // multirotor it has the same semantics as NAV_LAND. LAND_LOCAL is the
+        // local-frame variant — the frame check rejects actual LOCAL_NED items
+        // before we get here; the case is kept for protocol completeness in
+        // case a GCS sends LAND_LOCAL with a global frame.
+        wp->type = WAYPOINT_TYPE_LAND;
+        break;
+    case MAV_CMD_NAV_PAYLOAD_PLACE:
+        // Treated as LAND for now — descend to the named position. The actual
+        // payload-release step is a capability follow-up (no release mechanism
+        // on a Betaflight quad today).
         wp->type = WAYPOINT_TYPE_LAND;
         break;
     case MAV_CMD_NAV_TAKEOFF:
     case MAV_CMD_NAV_VTOL_TAKEOFF:
+    case MAV_CMD_NAV_TAKEOFF_LOCAL:
         // VTOL_TAKEOFF likewise collapses to NAV_TAKEOFF on a multirotor; the
         // "transition heading" param is fixed-wing-only and ignored.
+        // TAKEOFF_LOCAL is the local-frame variant — see LAND_LOCAL note.
         wp->type = WAYPOINT_TYPE_TAKEOFF;
         break;
-    // Intentionally unsupported (no fit for waypoint_t or no executor support):
-    //   NAV_LAND_LOCAL / NAV_TAKEOFF_LOCAL  — local frame, also rejected by frame check
-    //   NAV_FOLLOW                          — dynamic target tracking
-    //   NAV_CONTINUE_AND_CHANGE_ALT         — no lat/lon, needs alt-only state
-    //   NAV_LOITER_TO_ALT                   — needs alt-arrival latch in executor
-    //   NAV_ROI / NAV_PATHPLANNING          — not positional waypoints
-    //   NAV_GUIDED_ENABLE / NAV_DELAY       — control/timer, not a waypoint
-    //   NAV_PAYLOAD_PLACE                   — no payload-release mechanism
-    //   NAV_SET_YAW_SPEED / NAV_FENCE_* / NAV_RALLY_POINT — different domains
+    // Intentionally rejected — no positional mapping fits, or semantics would
+    // produce unsafe flight if force-fit into waypoint_t:
+    //   NAV_CONTINUE_AND_CHANGE_ALT  — alt-only, no lat/lon to store
+    //   NAV_ROI                      — camera target; mapping to HOLD would
+    //                                  fly the vehicle to the camera point
+    //   NAV_PATHPLANNING             — planner enable/disable, not a goal
+    //   NAV_GUIDED_ENABLE            — off-board control toggle
+    //   NAV_DELAY                    — timer, no position
+    //   NAV_SET_YAW_SPEED            — relative attitude tweak
+    //   NAV_FENCE_* / NAV_RALLY_POINT — different mission_type, rejected
+    //                                  earlier by the MISSION_TYPE_MISSION
+    //                                  filter on every handler
     default:
         *resultOut = MAV_MISSION_UNSUPPORTED;
         return false;

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -181,10 +181,15 @@ static bool decodeFrameAltCm(uint8_t frame, float z, int32_t *altCmOut, uint8_t 
         *resultOut = MAV_MISSION_INVALID_PARAM7;
         return false;
     }
+    // The _INT frame variants were superseded in MAVLink 2024-03 by their
+    // non-_INT counterparts as synonymous aliases; accept either form so a
+    // modern GCS using the post-2024-03 names still round-trips.
     switch (frame) {
+    case MAV_FRAME_GLOBAL:
     case MAV_FRAME_GLOBAL_INT:
         *altCmOut = (int32_t)(z * 100.0f);
         return true;
+    case MAV_FRAME_GLOBAL_RELATIVE_ALT:
     case MAV_FRAME_GLOBAL_RELATIVE_ALT_INT:
         if (!STATE(GPS_FIX_HOME)) {
             *resultOut = MAV_MISSION_INVALID;

--- a/src/main/telemetry/mavlink_mission.h
+++ b/src/main/telemetry/mavlink_mission.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "common/time.h"
+
+#if ENABLE_TELEMETRY_MAVLINK_MISSION
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include "common/mavlink.h"
+#pragma GCC diagnostic pop
+
+void mavMissionInit(void);
+bool mavMissionHandleMessage(const mavlink_message_t *msg);
+void mavMissionUpdate(timeMs_t nowMs);
+
+#endif

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -116,6 +116,15 @@ float positionEstimatorGetAltitudeCm(void)
     return 0.0f;
 }
 
+const positionEstimate3d_t *positionEstimatorGetEstimate(void)
+{
+    // Treat the vehicle as parked at the ENU origin for unit-test purposes;
+    // matches the pre-delay-leg-vector behaviour where the leg length was the
+    // full target distance from the origin.
+    static const positionEstimate3d_t stubEstimate = {};
+    return &stubEstimate;
+}
+
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
 {
     // Simplified flat-earth approximation sufficient for unit-test deltas.


### PR DESCRIPTION
Wires the MAVLink mission protocol on top of the T1 dispatcher (#15220) and the `flight_plan_nav` executor (#14923). A new `telemetry/mavlink_mission` translation unit runs the upload (`COUNT` → `REQUEST_INT` loop → `ITEM_INT` → `ACK` with 1.5 s × 5 retransmit), download (`REQUEST_LIST` → `COUNT` → `ITEM_INT` replay), and `MISSION_CLEAR_ALL` paths. Periodic `MISSION_CURRENT` @ 1 Hz plus `MISSION_ITEM_REACHED` hooked into a new observer slot on `flight_plan_nav` lets QGC follow the live cursor.

Frame support is `GLOBAL_INT` (AMSL direct) and `GLOBAL_RELATIVE_ALT_INT` (`GPS_home_llh.altCm` added at ingest); other frames return `MAV_MISSION_UNSUPPORTED_FRAME`. Command mapping: `NAV_WAYPOINT` → `FLYBY`, `NAV_LAND` → `LAND`, `NAV_LOITER_TIME`/`TURNS`/`UNLIM` → `HOLD`, `NAV_TAKEOFF` → new `WAYPOINT_TYPE_TAKEOFF`, and `NAV_RETURN_TO_LAUNCH` accepted only as a terminal end-marker at the last slot (count truncates, no mode change). Anything else is rejected with `MAV_MISSION_UNSUPPORTED`.

Upload is refused with `MAV_MISSION_DENIED` while `AUTOPILOT_MODE` is engaged so the executor never reads a half-staged plan; otherwise items are written direct into `flightPlanConfigMutable()` and persisted with a single `saveConfigAndNotify()` on `MISSION_ACK`. Shared-port RX (rx/mavlink consumer) still bypasses the telemetry dispatcher — same caveat as T1, tracked separately.

Gated on `ENABLE_TELEMETRY_MAVLINK_MISSION` (default 1 when `USE_TELEMETRY_MAVLINK` and `ENABLE_FLIGHT_PLAN` are both set). Footprint on STM32F405: ~5.3 KB FLASH / ~400 B BSS when compiled in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TAKEOFF waypoint type added to CLI.
  * Full MAVLink mission support: mission upload/download, item/ack flows, retransmits/timeouts, and periodic mission status.
  * Flight plans emit waypoint-reached events for telemetry reporting.

* **Chores**
  * Mission telemetry integration enabled by default when telemetry and flight-plan features are active.

* **Tests**
  * Added unit test stub to support flight-plan navigation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->