### PR TITLE
Fix duplicate PG ID

### DIFF
--- a/src/main/pg/displayport_profiles.c
+++ b/src/main/pg/displayport_profiles.c
@@ -60,7 +60,7 @@ void pgResetFn_displayPortProfileMax7456(displayPortProfile_t *displayPortProfil
 
 #if ENABLE_FB_OSD
 
-PG_REGISTER_WITH_RESET_FN(displayPortProfile_t, displayPortProfileFbOsd, PG_DISPLAY_PORT_FBOSD_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(displayPortProfile_t, displayPortProfileFbOsd, PG_DISPLAY_PORT_FBOSD_CONFIG, 1);
 
 void pgResetFn_displayPortProfileFbOsd(displayPortProfile_t *displayPortProfile)
 {

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -166,7 +166,7 @@
 #define PG_DRONECAN_CONFIG          565
 
 // TODO TBC
-#define PG_DISPLAY_PORT_FBOSD_CONFIG 561
+#define PG_DISPLAY_PORT_FBOSD_CONFIG 566
 
 // OSD configuration (subject to change)
 #define PG_OSD_FONT_CONFIG 2047

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -399,6 +399,14 @@ transponder_ir_unittest_SRC := \
 ws2811_unittest_SRC := \
 		$(USER_DIR)/drivers/light_ws2811strip.c
 
+
+.PHONY: check-pg-ids
+check-pg-ids:
+	@pg=$(USER_DIR)/pg/pg_ids.h; \
+	if [ ! -f "$$pg" ]; then echo "pg_ids.h not found at $$pg"; exit 1; fi; \
+	awk -f $(TEST_DIR)/check_pg_ids.awk $$pg
+
+
 huffman_unittest_SRC := \
 		$(USER_DIR)/common/huffman.c \
 		$(USER_DIR)/common/huffman_table.c
@@ -676,7 +684,7 @@ include $(MAKE_SCRIPT_DIR)/build_verbosity.mk
 # House-keeping build targets.
 
 ## test        : Build and run the non target specific Unit Tests (default goal)
-test: $(TESTS:%=test_%)
+test: check-pg-ids $(TESTS:%=test_%)
 
 ## test-all : Build and run all Unit Tests
 test-all: $(TESTS_ALL:%=test_%)

--- a/src/test/unit/check_pg_ids.awk
+++ b/src/test/unit/check_pg_ids.awk
@@ -1,0 +1,63 @@
+# check_pg_ids.awk
+# Usage: awk -f check_pg_ids.awk path/to/pg_ids.h
+# Prints duplicates and exits non-zero if any found
+
+function hexval(s,   i, c, d, lo, digits) {
+    lo = "0123456789abcdef"
+    digits = tolower(s)
+    v = 0
+    for (i = 3; i <= length(digits); i++) {
+        c = substr(digits, i, 1)
+        d = index(lo, c) - 1
+        if (d < 0) return ""
+        v = v * 16 + d
+    }
+    return v
+}
+
+function tonum(s,   v) {
+    if (s ~ /^0x[0-9a-fA-F]+$/) {
+        return hexval(s)
+    } else if (s ~ /^[0-9]+$/) {
+        return s + 0
+    }
+    return ""
+}
+
+/^[ \t]*#define[ \t]+PG_[A-Z0-9_]+[ \t]+[^ \/\t]+/ {
+    line = NR
+    line_text = $0
+    sub(/\/\/.*$/, "", line_text)
+    # split fields after removing comments
+    n = split(line_text, fields, /[ \t]+/)
+    name = fields[2]
+    val = fields[3]
+    v = tonum(val)
+    if (v == "") next
+    if (v in valmap) {
+        valmap_dup[v] = valmap_dup[v] ? valmap_dup[v] ", " name : valmap[v] ", " name
+        dup = 1
+    } else {
+        valmap[v] = name
+    }
+    if (name in namemap) {
+        namemap[name] = namemap[name] ", " line
+        dup = 1
+    } else {
+        namemap[name] = line
+    }
+}
+
+END {
+    if (dup) {
+        for (k in valmap_dup) {
+            print "Duplicate numeric value " k " ->" valmap_dup[k]
+        }
+        for (n in namemap) {
+            if (index(namemap[n], ",") > 0) {
+                print "Duplicate define name " n " on lines " namemap[n]
+            }
+        }
+        exit 1
+    }
+}

--- a/src/test/unit/check_pg_ids.awk
+++ b/src/test/unit/check_pg_ids.awk
@@ -2,7 +2,7 @@
 # Usage: awk -f check_pg_ids.awk path/to/pg_ids.h
 # Prints duplicates and exits non-zero if any found
 
-function hexval(s,   i, c, d, lo, digits) {
+function hexval(s,   i, c, d, lo, digits, v) {
     lo = "0123456789abcdef"
     digits = tolower(s)
     v = 0


### PR DESCRIPTION
- fixes #15223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal configuration parameter group identifier.
* **Bug Fixes**
  * Enabled reset behavior for the DisplayPort OSD profile so profile resets are applied.
* **Tests**
  * Added a pre-test validation target and a script to detect duplicate parameter IDs before unit tests run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15225)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->