### PR TITLE
Add MSP_RAW_BARO command

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1204,6 +1204,16 @@ static bool mspProcessOutCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, sbuf_t
         break;
     }
 
+    case MSP_RAW_BARO:
+#if defined(USE_BARO)
+        sbufWriteU32(dst, baro.pressure);
+        sbufWriteU32(dst, baro.temperature);
+#else
+        sbufWriteU32(dst, 0);
+        sbufWriteU32(dst, 0);
+#endif
+        break;
+
 case MSP_NAME:
         sbufWriteString(dst, pilotConfig()->craftName);
         break;

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -219,6 +219,7 @@
 #define MSP_GPSSVINFO                   164  // out message: Get Signal Strength (only U-Blox)
 #define MSP_GPSSTATISTICS               166  // out message: Get GPS debugging data
 #define MSP_ATTITUDE_QUATERNION         167  // out message: Orientation quaternion components (w, x, y, z)
+#define MSP_RAW_BARO                    168  // out message: Barometer pressure [Pa], temperature [cdegC]
 
 // OSD specific commands (180-189)
 #define MSP_OSD_VIDEO_CONFIG            180  // out message: Get OSD video settings


### PR DESCRIPTION
## Summary

This adds a new read-only `MSP_RAW_BARO` command that returns the latest
barometer pressure and temperature values.

The payload contains:

- pressure in Pa
- temperature in centi-degrees Celsius

When barometer support is not enabled, the command returns zero values.

## Motivation

`MSP_ALTITUDE` exposes estimated altitude and vario data, but there is no
minimal MSP command for consumers that need the raw barometer pressure and
temperature values.

## Testing

Built successfully.

Tested by requesting `MSP_RAW_BARO` and verifying that the response contains
the expected pressure and temperature payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MSP protocol command to request raw barometer data, including pressure (Pa) and temperature (centi-degrees C) measurements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->