### PR TITLE
chore: remove dead code in #if 0 blocks

### DIFF
--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -177,18 +177,6 @@ static void drawHorizonalPercentageBar(uint8_t width,uint8_t percent)
         LCDprint(154); // empty
 }
 
-#if 0
-static void fillScreenWithCharacters(void)
-{
-    for (uint8_t row = 0; row < SCREEN_CHARACTER_ROW_COUNT; row++) {
-        for (uint8_t column = 0; column < SCREEN_CHARACTER_COLUMN_COUNT; column++) {
-            i2c_OLED_set_xy(dev, column, row);
-            i2c_OLED_send_char(dev, 'A' + column);
-        }
-    }
-}
-#endif
-
 static void updateTicker(void)
 {
     static uint8_t tickerIndex = 0;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -525,29 +525,6 @@ static uint8_t ubloxAddValSet(ubxMessage_t * tx_buffer, ubxValGetSetBytes_e key,
     return 4 + len;
 }
 
-// the following lines are not being used, because we are not currently sending ubloxValGet messages
-#if 0
-static size_t ubloxAddValGet(ubxMessage_t * tx_buffer, ubxValGetSetBytes_e key, size_t offset) {
-    const uint8_t zeroes[8] = {0};
-
-    return ubloxAddValSet(tx_buffer, key, zeroes, offset);
-}
-
-static size_t ubloxValGet(ubxMessage_t * tx_buffer, ubxValGetSetBytes_e key, ubloxValLayer_e layer)
-{
-    tx_buffer->header.preamble1 = PREAMBLE1;
-    tx_buffer->header.preamble2 = PREAMBLE2;
-    tx_buffer->header.msg_class = CLASS_CFG;
-    tx_buffer->header.msg_id = MSG_CFG_VALGET;
-
-    tx_buffer->payload.cfg_valget.version = 1;
-    tx_buffer->payload.cfg_valget.layer = layer;
-    tx_buffer->payload.cfg_valget.position = 0;
-
-    return ubloxAddValGet(tx_buffer, key, 0);
-}
-#endif // not used
-
 static uint8_t ubloxValSet(ubxMessage_t * tx_buffer, ubxValGetSetBytes_e key, uint8_t * payload, ubloxValLayer_e layer)
 {
     memset(&tx_buffer->payload.cfg_valset, 0, sizeof(ubxCfgValSet_t));

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -670,13 +670,6 @@ void saSetPitFreq(uint16_t freq)
     saSetFreq(freq | SA_FREQ_SETPIT);
 }
 
-#if 0
-static void saGetPitFreq(void)
-{
-    saDoDevSetFreq(SA_FREQ_GETPIT);
-}
-#endif
-
 void saSetMode(int mode)
 {
     static uint8_t buf[6] = { 0xAA, 0x55, SACMD(SA_CMD_SET_MODE), 1 };


### PR DESCRIPTION
## Summary
- Remove 4 dead functions wrapped in `#if 0` blocks that are never compiled in any configuration
- `fillScreenWithCharacters()` in `dashboard.c` — unused OLED debug utility
- `saGetPitFreq()` in `vtx_smartaudio.c` — unused SmartAudio pit frequency wrapper
- `ubloxAddValGet()` and `ubloxValGet()` in `gps.c` — unused u-blox VALGET message builders

**Note:** `pgResetFn_accelerometerConfig()` was listed in #15127 but is **not dead code** — it is dynamically referenced via the `PG_REGISTER_WITH_RESET_FN` macro which token-pastes the function name into a linker-section function pointer.

Closes #15127

## Test plan
- [ ] `make TARGET=STM32F405` compiles without errors
- [ ] `make TARGET=SITL` compiles without errors
- [ ] `make test` passes — no regressions expected since removed code was never compiled
- [ ] Binary output is identical — `#if 0` code was already excluded by the preprocessor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up codebase by removing disabled code blocks that were no longer in use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->