### PR TITLE
STM32N6: working CONFIG_IN_MEMORY_MAPPED_FLASH on OPENN657V1

### DIFF
--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -475,13 +475,26 @@ MMFLASH_CODE bool flashWaitForReady(void)
     return flashDevice.vTable->waitForReady(&flashDevice);
 }
 
-static bool flashWaitForReadyOrFail(void)
+MMFLASH_CODE static bool flashWaitForReadyOrFail(void)
 {
     if (!flashDevice.vTable->waitForReady) {
         return true;
     }
 
     if (!flashDevice.vTable->waitForReady(&flashDevice)) {
+#ifdef USE_FLASH_MEMORY_MAPPED
+        // failureMode lives in XIP. When this trips from a save/erase
+        // loop inside the MMFLASH window, the call to failureMode would
+        // fault. Re-engage memory-mapped mode (best-effort — the chip
+        // may already be in a bad state) so the failure handler is
+        // reachable. Gated on the runtime boot state so the non-MM
+        // experimental path (flashOctoSpiInit under
+        // USE_OCTOSPI_EXPERIMENTAL) does not reconfigure the
+        // controller or unmask IRQs when MM was never enabled.
+        if (isMemoryMappedModeEnabledOnBoot()) {
+            flashMemoryMappedModeEnable();
+        }
+#endif
         failureMode(FAILURE_EXTERNAL_FLASH_WRITE_FAILED);
         return false;
     }
@@ -591,7 +604,7 @@ const flashGeometry_t *flashGetGeometry(void)
 
 static void flashConfigurePartitions(void)
 {
-#if defined(FIRMWARE_SIZE) || defined(CONFIG_IN_EXTERNAL_FLASH) || defined(USE_FLASHFS)
+#if defined(FIRMWARE_SIZE) || defined(CONFIG_IN_EXTERNAL_FLASH) || defined(CONFIG_IN_MEMORY_MAPPED_FLASH) || defined(USE_FLASHFS)
     const flashGeometry_t *flashGeometry = flashGetGeometry();
     if (flashGeometry->totalSize == 0) {
         return;

--- a/src/main/drivers/flash/flash_mx66uw1g45g.c
+++ b/src/main/drivers/flash/flash_mx66uw1g45g.c
@@ -22,18 +22,30 @@
 /*
  * Macronix MX66UW1G45G — 1Gbit (128 MiB) Octal NOR Flash.
  *
- * Phase 1: memory-mapped read only. The chip is expected to be configured by
- * the bootloader in 8-line OPI/DTR mode and memory-mapped at
- * MX66UW1G45G_MEMORY_MAPPED_BASE (default 0x70000000, OCTOSPI2/XSPI2 base).
+ * 1S-1S-1S indirect read/write/sector-erase through the platform HAL's
+ * XSPI primitives. The OBL flash-update path uses the same pattern
+ * against the same chip and is the proven reference for post-erase
+ * RDSR while WIP=1 — BF's hand-rolled XSPI sequencer in
+ * bus_octospi_stm32n6xx.c does not handle that case reliably.
  *
- * Because the chip is in OPI mode, it cannot respond to 1-line or 4-line
- * JEDEC RDID probes. Selection is done at build time via the
- * OCTOSPI_FLASH_CHIP=MX66UW1G45G make variable, which emits both
- * USE_FLASH_MX66UW1G45G (driver gating) and OCTOSPI_FLASH_CHIP_MX66UW1G45G
- * (dispatch marker — see flash.c:flashOctoSpiInit).
+ * The N6 boot ROM hands BF a chip that the FSBL stub / OpenBootloader
+ * has already walked back from 8S-8S-8D OPI/DTR to 1S-1S-1S via a soft
+ * reset, with the XSPI controller configured for memory-mapped
+ * FAST_READ_4B (0x0C + 8 dummy, 4-byte address). Everything here
+ * assumes that handoff state and never re-initialises the controller.
  *
- * Write/erase are stubbed in this phase; adding them requires 8-line OPI
- * primitives in the OCTOSPI bus driver and platform implementations.
+ * HAL XSPI module and HAL core (HAL_GetTick) are pulled into the
+ * .ram_code section by the N657 XIP linker script so these calls are
+ * safe while memory-mapped mode is disabled.
+ *
+ * Selection is build-time via OCTOSPI_FLASH_CHIP=MX66UW1G45G in the
+ * per-config config.mk, which emits both USE_FLASH_MX66UW1G45G and
+ * OCTOSPI_FLASH_CHIP_MX66UW1G45G — the chip cannot answer 1/4-line
+ * RDID while configured for OPI, so JEDEC probing isn't an option.
+ *
+ * Read path uses indirect FAST_READ_4B regardless of MM state, so the
+ * caller (config_eeprom.c) can disable MM mode before reading config
+ * back to RAM without special-casing the load.
  */
 
 #include <stdbool.h>
@@ -44,12 +56,16 @@
 
 #if defined(USE_FLASH_MX66UW1G45G) && defined(USE_OCTOSPI)
 
+#include "stm32n6xx_hal.h"
+
 #include "common/utils.h"
 
+#include "drivers/bus_octospi.h"
 #include "drivers/flash/flash.h"
 #include "drivers/flash/flash_impl.h"
 #include "drivers/flash/flash_mx66uw1g45g.h"
 #include "drivers/system.h"
+#include "drivers/time.h"
 
 // Geometry: 1Gbit / 128 MiB, 4 KiB sectors, 256 B pages.
 #define MX66UW1G45G_PAGE_SIZE           256U
@@ -61,7 +77,46 @@
 #define MX66UW1G45G_MEMORY_MAPPED_BASE  0x70000000U
 #endif
 
-static const flashVTable_t mx66uw1g45g_vTable;
+// 1S-1S-1S command set (post-reset state).
+#define MX66_CMD_RDSR                   0x05U   // read status register
+#define MX66_CMD_WREN                   0x06U   // write enable
+#define MX66_CMD_READ_4B                0x0CU   // 4-byte FAST_READ
+#define MX66_CMD_READ_4B_DUMMY          8U
+#define MX66_CMD_PP_4B                  0x12U   // 4-byte page program
+#define MX66_CMD_SE_4B                  0x21U   // 4-byte 4 KiB sector erase
+
+#define MX66_SR_WIP                     0x01U   // write-in-progress bit
+#define MX66_SR_WEL                     0x02U   // write-enable latch bit
+
+// Datasheet typ/max values (Rev 0.91, Macronix MX66UW1G45G):
+//   tPP  page program:  150 us typ / 1 ms max   -> 50 ms safety margin
+//   tSE  sector erase:  35 ms typ  / 400 ms max -> 800 ms safety margin
+#define MX66_TIMEOUT_PROGRAM_MS         50U
+#define MX66_TIMEOUT_SECTOR_MS          800U
+
+// HAL handle is allocated in fastram_data and statically initialised
+// against XSPI2. The controller itself is left as the bootloader set
+// it up; this handle exists only so HAL_XSPI_Command/_Receive/_Transmit
+// have somewhere to read Init.MemoryMode/.MemoryType and track State.
+MMFLASH_DATA static XSPI_HandleTypeDef hxspi_mx66 = {
+    .Instance = XSPI2,
+    .Init = {
+        .MemoryMode     = HAL_XSPI_SINGLE_MEM,
+        .MemoryType     = HAL_XSPI_MEMTYPE_MACRONIX,
+        .SampleShifting = HAL_XSPI_SAMPLE_SHIFT_NONE,
+    },
+    .State     = HAL_XSPI_STATE_READY,
+    .ErrorCode = HAL_XSPI_ERROR_NONE,
+};
+
+MMFLASH_DATA static flashVTable_t mx66uw1g45g_vTable;
+
+// Latched once the chip driver hits an unrecoverable error during erase
+// or program (timeout waiting for WIP=0, WREN failed, HAL_XSPI_Command
+// rejected the opcode). Drives mx66uw1g45g_isReady / _waitForReady to
+// report "not ready" so the meta-driver's flashWaitForReadyOrFail trips
+// failureMode instead of treating a skipped operation as success.
+MMFLASH_DATA static bool mx66_error_latched;
 
 MMFLASH_CODE_NOINLINE bool mx66uw1g45g_identify(flashDevice_t *fdevice, uint32_t jedecID)
 {
@@ -92,69 +147,231 @@ static void mx66uw1g45g_configure(flashDevice_t *fdevice, uint32_t configuration
     // Bootloader has configured OPI memory-mapped mode; nothing to do.
 }
 
+// Pre-fill the command struct with the immutable fields shared by every
+// 1S-1S-1S command this driver issues. Caller adjusts Instruction /
+// AddressMode / AddressWidth / Address / DataMode / DataLength.
+MMFLASH_CODE static void mx66_prepare_cmd_1s(XSPI_RegularCmdTypeDef *cmd)
+{
+    cmd->OperationType         = HAL_XSPI_OPTYPE_COMMON_CFG;
+    cmd->IOSelect              = HAL_XSPI_SELECT_IO_7_0;
+    cmd->InstructionMode       = HAL_XSPI_INSTRUCTION_1_LINE;
+    cmd->InstructionWidth      = HAL_XSPI_INSTRUCTION_8_BITS;
+    cmd->InstructionDTRMode    = HAL_XSPI_INSTRUCTION_DTR_DISABLE;
+    cmd->AddressMode           = HAL_XSPI_ADDRESS_NONE;
+    cmd->AddressWidth          = HAL_XSPI_ADDRESS_32_BITS;
+    cmd->AddressDTRMode        = HAL_XSPI_ADDRESS_DTR_DISABLE;
+    cmd->Address               = 0;
+    cmd->AlternateBytes        = 0;
+    cmd->AlternateBytesMode    = HAL_XSPI_ALT_BYTES_NONE;
+    cmd->AlternateBytesWidth   = HAL_XSPI_ALT_BYTES_8_BITS;
+    cmd->AlternateBytesDTRMode = HAL_XSPI_ALT_BYTES_DTR_DISABLE;
+    cmd->DataMode              = HAL_XSPI_DATA_NONE;
+    cmd->DataLength            = 0;
+    cmd->DataDTRMode           = HAL_XSPI_DATA_DTR_DISABLE;
+    cmd->DummyCycles           = 0;
+    cmd->DQSMode               = HAL_XSPI_DQS_DISABLE;
+}
+
+MMFLASH_CODE static bool mx66_wait_ready(uint32_t timeoutMs)
+{
+    XSPI_RegularCmdTypeDef cmd = {0};
+    uint8_t status;
+    uint32_t tickstart = HAL_GetTick();
+
+    mx66_prepare_cmd_1s(&cmd);
+    cmd.Instruction = MX66_CMD_RDSR;
+    cmd.DataMode    = HAL_XSPI_DATA_1_LINE;
+    cmd.DataLength  = 1;
+
+    do {
+        if (HAL_XSPI_Command(&hxspi_mx66, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+            return false;
+        }
+        if (HAL_XSPI_Receive(&hxspi_mx66, &status, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+            return false;
+        }
+        if ((status & MX66_SR_WIP) == 0) {
+            return true;
+        }
+    } while ((HAL_GetTick() - tickstart) < timeoutMs);
+
+    return false;
+}
+
+MMFLASH_CODE static uint8_t mx66_readStatus(void)
+{
+    XSPI_RegularCmdTypeDef cmd = {0};
+    uint8_t status = 0xFFU;
+
+    mx66_prepare_cmd_1s(&cmd);
+    cmd.Instruction = MX66_CMD_RDSR;
+    cmd.DataMode    = HAL_XSPI_DATA_1_LINE;
+    cmd.DataLength  = 1;
+
+    if (HAL_XSPI_Command(&hxspi_mx66, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return 0xFFU;
+    }
+    if (HAL_XSPI_Receive(&hxspi_mx66, &status, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return 0xFFU;
+    }
+    return status;
+}
+
+MMFLASH_CODE static bool mx66_write_enable(void)
+{
+    XSPI_RegularCmdTypeDef cmd = {0};
+    mx66_prepare_cmd_1s(&cmd);
+    cmd.Instruction = MX66_CMD_WREN;
+    if (HAL_XSPI_Command(&hxspi_mx66, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return false;
+    }
+    // Verify the chip actually latched WEL before treating WREN as a
+    // success. Per the MX66 datasheet, PP_4B / SE_4B are ignored when
+    // WEL=0, and the subsequent waitForReady poll sees WIP=0
+    // immediately — silently turning a dropped WREN into a no-op
+    // write. mx66_readStatus returns 0xFF on its own HAL failures, so
+    // treat that as a fault too.
+    const uint8_t status = mx66_readStatus();
+    return (status != 0xFFU) && ((status & MX66_SR_WEL) != 0U);
+}
+
 MMFLASH_CODE static bool mx66uw1g45g_isReady(flashDevice_t *fdevice)
 {
     UNUSED(fdevice);
-    return true;
+    if (mx66_error_latched) {
+        return false;
+    }
+    return (mx66_readStatus() & MX66_SR_WIP) == 0;
 }
 
 MMFLASH_CODE static bool mx66uw1g45g_waitForReady(flashDevice_t *fdevice)
 {
     UNUSED(fdevice);
-    return true;
+    if (mx66_error_latched) {
+        return false;
+    }
+    return mx66_wait_ready(MX66_TIMEOUT_SECTOR_MS);
 }
-
-// Phase 1 is memory-mapped read only. Any write or erase attempt is a
-// programming error in the caller (e.g. enabling USE_FLASHFS or
-// CONFIG_IN_EXTERNAL_FLASH on a board that uses this chip) and is reported via
-// failureMode rather than silently no-op'ing — silent stubs would let flashfs
-// loop forever waiting for progress.
 
 MMFLASH_CODE static void mx66uw1g45g_eraseSector(flashDevice_t *fdevice, uint32_t address)
 {
     UNUSED(fdevice);
-    UNUSED(address);
-    failureMode(FAILURE_FLASH_WRITE_FAILED);
+
+    if (!mx66_wait_ready(MX66_TIMEOUT_SECTOR_MS) ||
+        !mx66_write_enable()) {
+        mx66_error_latched = true;
+        return;
+    }
+
+    XSPI_RegularCmdTypeDef cmd = {0};
+    mx66_prepare_cmd_1s(&cmd);
+    cmd.Instruction  = MX66_CMD_SE_4B;
+    cmd.AddressMode  = HAL_XSPI_ADDRESS_1_LINE;
+    cmd.AddressWidth = HAL_XSPI_ADDRESS_32_BITS;
+    cmd.Address      = address;
+
+    if (HAL_XSPI_Command(&hxspi_mx66, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        mx66_error_latched = true;
+        return;
+    }
+    // The wait-for-completion poll happens via flashWaitForReadyOrFail
+    // after we return; tSE allowance lives in MX66_TIMEOUT_SECTOR_MS.
 }
 
 static void mx66uw1g45g_eraseCompletely(flashDevice_t *fdevice)
 {
+    // No use case in BF for whole-chip erase on the boot chip; refuse rather
+    // than silently destroying the firmware that's running.
     UNUSED(fdevice);
     failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgramBegin(flashDevice_t *fdevice, uint32_t address, void (*callback)(uintptr_t arg))
 {
-    UNUSED(fdevice);
-    UNUSED(address);
-    UNUSED(callback);
-    failureMode(FAILURE_FLASH_WRITE_FAILED);
+    fdevice->callback = callback;
+    fdevice->currentWriteAddress = address;
+    fdevice->bytesWritten = 0;
+}
+
+MMFLASH_CODE static bool mx66_page_program(uint32_t address, const uint8_t *data, uint32_t length)
+{
+    if (length == 0 || length > MX66UW1G45G_PAGE_SIZE) {
+        return false;
+    }
+    // The chip wraps writes at the page boundary; caller must split
+    // straddles or the early bytes of the same page get clobbered.
+    if (((address & (MX66UW1G45G_PAGE_SIZE - 1)) + length) > MX66UW1G45G_PAGE_SIZE) {
+        return false;
+    }
+
+    if (!mx66_wait_ready(MX66_TIMEOUT_PROGRAM_MS)) {
+        return false;
+    }
+    if (!mx66_write_enable()) {
+        return false;
+    }
+
+    XSPI_RegularCmdTypeDef cmd = {0};
+    mx66_prepare_cmd_1s(&cmd);
+    cmd.Instruction  = MX66_CMD_PP_4B;
+    cmd.AddressMode  = HAL_XSPI_ADDRESS_1_LINE;
+    cmd.AddressWidth = HAL_XSPI_ADDRESS_32_BITS;
+    cmd.Address      = address;
+    cmd.DataMode     = HAL_XSPI_DATA_1_LINE;
+    cmd.DataLength   = length;
+
+    if (HAL_XSPI_Command(&hxspi_mx66, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return false;
+    }
+    return HAL_XSPI_Transmit(&hxspi_mx66, (uint8_t *)data, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) == HAL_OK;
 }
 
 MMFLASH_CODE static uint32_t mx66uw1g45g_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffers, const uint32_t *bufferSizes, uint32_t bufferCount)
 {
-    UNUSED(fdevice);
-    UNUSED(buffers);
-    UNUSED(bufferSizes);
-    UNUSED(bufferCount);
-    failureMode(FAILURE_FLASH_WRITE_FAILED);
-    return 0;
+    uint32_t totalWritten = 0;
+
+    for (uint32_t i = 0; i < bufferCount; i++) {
+        const uint8_t *data  = buffers[i];
+        uint32_t       remaining = bufferSizes[i];
+
+        while (remaining > 0) {
+            uint32_t pageOffset = fdevice->currentWriteAddress & (MX66UW1G45G_PAGE_SIZE - 1);
+            uint32_t chunk      = MX66UW1G45G_PAGE_SIZE - pageOffset;
+            if (chunk > remaining) {
+                chunk = remaining;
+            }
+            if (!mx66_page_program(fdevice->currentWriteAddress, data, chunk)) {
+                // Latch the error so the meta-driver's next
+                // flashWaitForReadyOrFail trips failureMode instead of
+                // accepting a short write as success.
+                mx66_error_latched = true;
+                fdevice->bytesWritten += totalWritten;
+                return totalWritten;
+            }
+            fdevice->currentWriteAddress += chunk;
+            data         += chunk;
+            remaining    -= chunk;
+            totalWritten += chunk;
+        }
+    }
+
+    fdevice->bytesWritten += totalWritten;
+    if (fdevice->callback) {
+        fdevice->callback(totalWritten);
+    }
+    return totalWritten;
 }
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgramFinish(flashDevice_t *fdevice)
 {
     UNUSED(fdevice);
-    failureMode(FAILURE_FLASH_WRITE_FAILED);
 }
 
 MMFLASH_CODE static void mx66uw1g45g_pageProgram(flashDevice_t *fdevice, uint32_t address, const uint8_t *data, uint32_t length, void (*callback)(uintptr_t arg))
 {
-    UNUSED(fdevice);
-    UNUSED(address);
-    UNUSED(data);
-    UNUSED(length);
-    UNUSED(callback);
-    failureMode(FAILURE_FLASH_WRITE_FAILED);
+    mx66uw1g45g_pageProgramBegin(fdevice, address, callback);
+    mx66uw1g45g_pageProgramContinue(fdevice, &data, &length, 1);
+    mx66uw1g45g_pageProgramFinish(fdevice);
 }
 
 MMFLASH_CODE static void mx66uw1g45g_flush(flashDevice_t *fdevice)
@@ -172,8 +389,22 @@ MMFLASH_CODE static int mx66uw1g45g_readBytes(flashDevice_t *fdevice, uint32_t a
         length = remaining;
     }
 
-    memcpy(buffer, (const void *)(uintptr_t)(MX66UW1G45G_MEMORY_MAPPED_BASE + address), length);
+    XSPI_RegularCmdTypeDef cmd = {0};
+    mx66_prepare_cmd_1s(&cmd);
+    cmd.Instruction  = MX66_CMD_READ_4B;
+    cmd.AddressMode  = HAL_XSPI_ADDRESS_1_LINE;
+    cmd.AddressWidth = HAL_XSPI_ADDRESS_32_BITS;
+    cmd.Address      = address;
+    cmd.DataMode     = HAL_XSPI_DATA_1_LINE;
+    cmd.DataLength   = length;
+    cmd.DummyCycles  = MX66_CMD_READ_4B_DUMMY;
 
+    if (HAL_XSPI_Command(&hxspi_mx66, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return 0;
+    }
+    if (HAL_XSPI_Receive(&hxspi_mx66, buffer, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return 0;
+    }
     return (int)length;
 }
 
@@ -182,7 +413,7 @@ static const flashGeometry_t *mx66uw1g45g_getGeometry(flashDevice_t *fdevice)
     return &fdevice->geometry;
 }
 
-MMFLASH_DATA static const flashVTable_t mx66uw1g45g_vTable = {
+MMFLASH_DATA static flashVTable_t mx66uw1g45g_vTable = {
     .configure = mx66uw1g45g_configure,
     .isReady = mx66uw1g45g_isReady,
     .waitForReady = mx66uw1g45g_waitForReady,

--- a/src/platform/STM32/bus_octospi_stm32n6xx.c
+++ b/src/platform/STM32/bus_octospi_stm32n6xx.c
@@ -46,7 +46,16 @@
 #include "drivers/bus_octospi.h"
 #include "drivers/bus_octospi_impl.h"
 
-// Provide platform-specific hardware table for STM32N6
+// Provide platform-specific hardware table for STM32N6.
+//
+// Placed in .fastram_data (AXISRAM) rather than the default
+// .rodata.octoSpiHardware (XIP). octoSpiDeviceByInstance walks this
+// table from MMFLASH_CODE while memory-mapped mode is disabled — XIP
+// reads in that window only succeed by luck of D-cache residency.
+// GCC 13.3 with -fdata-sections + const ignores a `MMFLASH_DATA const`
+// attribute on the definition, so the attribute is applied directly
+// (section() before const) to force the section choice through.
+__attribute__((section(".fastram_data"), aligned(4)))
 const octoSpiHardware_t octoSpiHardware[OCTOSPIDEV_COUNT] = {
     {
         .device = OCTOSPIDEV_1,
@@ -127,6 +136,7 @@ const octoSpiHardware_t octoSpiHardware[OCTOSPIDEV_COUNT] = {
 // XSPI does not have SIOO (Send Instruction Only Once) like OCTOSPI
 #define XSPI_SIOO_INST_EVERY_CMD         ((uint32_t)0x00000000U)
 
+__attribute__((unused))
 static MMFLASH_CODE_NOINLINE void Error_Handler(void) {
     while (1) {
         NOOP;
@@ -139,6 +149,7 @@ static MMFLASH_CODE_NOINLINE void Error_Handler(void) {
 #define __XSPI_DISABLE(__INSTANCE__)                      CLEAR_BIT((__INSTANCE__)->CR, XSPI_CR_EN)
 #define __XSPI_IS_ENABLED(__INSTANCE__)                   (READ_BIT((__INSTANCE__)->CR, XSPI_CR_EN) != 0U)
 
+__attribute__((unused))
 MMFLASH_CODE_NOINLINE static void xspiAbort(XSPI_TypeDef *instance)
 {
     SET_BIT(instance->CR, XSPI_CR_ABORT);
@@ -261,8 +272,8 @@ MMFLASH_CODE_NOINLINE static ErrorStatus xspiConfigureCommand(XSPI_TypeDef *inst
         {
           // instruction and data
 
-          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE | XSPI_CCR_IDTR | XSPI_CCR_ISIZE |
-                                  XSPI_CCR_DMODE | XSPI_CCR_DDTR),
+          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE  | XSPI_CCR_IDTR  | XSPI_CCR_ISIZE  |
+                                  XSPI_CCR_DMODE  | XSPI_CCR_DDTR),
                                  (cmd->InstructionMode | cmd->InstructionDtrMode | cmd->InstructionSize |
                                   cmd->DataMode        | cmd->DataDtrMode));
         }
@@ -270,7 +281,7 @@ MMFLASH_CODE_NOINLINE static ErrorStatus xspiConfigureCommand(XSPI_TypeDef *inst
         {
           // instruction only
 
-          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE | XSPI_CCR_IDTR | XSPI_CCR_ISIZE),
+          MODIFY_REG(instance->CCR, (XSPI_CCR_IMODE  | XSPI_CCR_IDTR  | XSPI_CCR_ISIZE),
                                  (cmd->InstructionMode | cmd->InstructionDtrMode | cmd->InstructionSize));
 
           // DHQC bit is linked with DDTR
@@ -326,8 +337,10 @@ static MMFLASH_CODE_NOINLINE ErrorStatus xspiCommand(XSPI_TypeDef *instance, XSP
     if (status == SUCCESS) {
         if (cmd->DataMode == XSPI_DATA_NONE)
         {
-            // transfer is already started, wait now.
-            xspiWaitStatusFlags(instance, XSPI_SR_TCF, SET);
+            // No-data command starts on IR/AR write — wait BUSY=RESET (not
+            // TCF=SET) to match HAL_XSPI_Command. Waiting TCF was racing
+            // with the next command's writes when BUSY hadn't drained.
+            xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
             __XSPI_CLEAR_FLAG(instance, XSPI_SR_TCF);
         }
     }
@@ -459,22 +472,31 @@ static MMFLASH_CODE_NOINLINE void xspiRestoreMemoryMappedModeConfiguration(XSPI_
 
     xspiMemoryMappedModeConfigurationRegisterBackup_t *xspiMMMCRBackup = &xspiMMMCRBackups[device];
 
-    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+    // Mirror HAL_XSPI_Abort: drain any in-flight indirect transfer
+    // before reprogramming the read-side command.
+    if ((READ_REG(instance->SR) & XSPI_SR_BUSY) != 0U) {
+        SET_BIT(instance->CR, XSPI_CR_ABORT);
+        xspiWaitStatusFlags(instance, XSPI_SR_TCF, SET);
+        __XSPI_CLEAR_FLAG(instance, XSPI_SR_TCF);
+        xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
+    }
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, 0U);
 
+    // Reprogram read-side CCR/IR/TCR/ABR from the boot-time backup so
+    // the memory-mapped FAST_READ_4B command is what gets emitted on
+    // AXI reads. DLR/AR have no meaning in MM mode.
     instance->ABR = xspiMMMCRBackup->ABR;
     instance->TCR = xspiMMMCRBackup->TCR;
-
-    instance->DLR = 0; // "no meaning" in MM mode.
-
+    instance->DLR = 0;
     instance->CCR = xspiMMMCRBackup->CCR;
+    instance->IR  = xspiMMMCRBackup->IR;
+    instance->AR  = 0;
 
-    instance->IR = xspiMMMCRBackup->IR;
-    instance->AR = 0; // "no meaning" in MM mode.
-
-    xspiAbort(instance);
-    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
-
-    instance->CR = xspiMMMCRBackup->CR;
+    // Engage memory-mapped via FMODE-only MODIFY_REG, matching
+    // HAL_XSPI_MemoryMapped.
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, XSPI_FUNCTIONAL_MODE_MEMORY_MAPPED);
+    __DSB();
+    __ISB();
 }
 
 /*
@@ -496,25 +518,19 @@ MMFLASH_CODE_NOINLINE void octoSpiDisableMemoryMappedMode(octoSpiResource_t *ins
         failureMode(FAILURE_DEVELOPER); // likely not booted with memory mapped mode enabled, or mismatched calls to enable/disable memory map mode.
     }
 
-    xspiAbort(instance);
-    if (__XSPI_GET_FLAG(instance, XSPI_SR_BUSY) == SET) {
-
-        __XSPI_DISABLE(instance);
-        xspiAbort(instance);
+    // Mirror HAL_XSPI_Abort. Only the BUSY-set branch issues CR.ABORT;
+    // otherwise just drop FMODE to indirect-write. Waiting TCF/BUSY then
+    // clearing TCF leaves the controller in a quiet state for the next
+    // indirect command.
+    if ((READ_REG(instance->SR) & XSPI_SR_BUSY) != 0U) {
+        SET_BIT(instance->CR, XSPI_CR_ABORT);
+        xspiWaitStatusFlags(instance, XSPI_SR_TCF, SET);
+        __XSPI_CLEAR_FLAG(instance, XSPI_SR_TCF);
+        xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
     }
-    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
-
-    uint32_t fmode = 0x0;  // b00 = indirect write, see XSPI->CR->FMODE
-    MODIFY_REG(instance->CR, XSPI_CR_FMODE, fmode);
-
-    uint32_t regval = READ_REG(instance->CR);
-    if ((regval & XSPI_CR_FMODE) != fmode) {
-        Error_Handler();
-    }
-
-    if (!__XSPI_IS_ENABLED(instance)) {
-        __XSPI_ENABLE(instance);
-    }
+    MODIFY_REG(instance->CR, XSPI_CR_FMODE, 0U);
+    __DSB();
+    __ISB();
 }
 
 /*
@@ -527,9 +543,11 @@ MMFLASH_CODE_NOINLINE void octoSpiDisableMemoryMappedMode(octoSpiResource_t *ins
 MMFLASH_CODE_NOINLINE void octoSpiEnableMemoryMappedMode(octoSpiResource_t *instance_)
 {
     XSPI_TypeDef *instance = (XSPI_TypeDef *)instance_;
-    xspiAbort(instance);
-    xspiWaitStatusFlags(instance, XSPI_SR_BUSY, RESET);
-
+    // xspiRestoreMemoryMappedModeConfiguration does its own
+    // HAL_XSPI_Abort-pattern drain (conditional on BUSY=SET) before
+    // reprogramming CCR/IR/TCR/ABR. An unconditional CR.ABORT here
+    // wedges the controller waiting BUSY=RESET when there's nothing
+    // in flight to abort.
     xspiRestoreMemoryMappedModeConfiguration(instance);
 }
 
@@ -544,6 +562,10 @@ static MMFLASH_CODE_NOINLINE void xspiTestEnableDisableMemoryMappedMode(octoSpiD
     __enable_irq();
 }
 
+// Read from MMFLASH_CODE during MM-disabled writes — must be in AXISRAM,
+// not .rodata at XIP. Attribute is applied directly because GCC 13.3
+// strips a `MMFLASH_DATA const` decoration off when -fdata-sections fires.
+__attribute__((section(".fastram_data"), aligned(4)))
 static const uint32_t xspi_addressSizeMap[] = {
     XSPI_ADDRESS_8_BITS,
     XSPI_ADDRESS_16_BITS,

--- a/src/platform/STM32/link/STM32N657XX_XIP.ld
+++ b/src/platform/STM32/link/STM32N657XX_XIP.ld
@@ -94,10 +94,10 @@ SECTIONS
   .text :
   {
     . = ALIGN(4);
-    *(.text)
-    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o) .text*)
-    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o) .rodata)
-    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o) .rodata*)
+    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o *stm32n6xx_hal_xspi.o *stm32n6xx_hal.o) .text)
+    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o *stm32n6xx_hal_xspi.o *stm32n6xx_hal.o) .text*)
+    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o *stm32n6xx_hal_xspi.o *stm32n6xx_hal.o) .rodata)
+    *(EXCLUDE_FILE(*system_stm32n6xx.o *stm32n6xx_hal_rcc.o *stm32n6xx_hal_rcc_ex.o *stm32n6xx_hal_xspi.o *stm32n6xx_hal.o) .rodata*)
     *(.glue_7)
     *(.glue_7t)
     *(.eh_frame)
@@ -148,11 +148,20 @@ SECTIONS
     _stext = .;
     ram_code_start = .;
     /* Clock-switch code path. Whole-file matched (file-prefixed
-     * pattern claims every .text* input section from these .o
-     * files) — paired with the EXCLUDE_FILE in .text above. */
-    *system_stm32n6xx.o(.text* .rodata*)
-    *stm32n6xx_hal_rcc.o(.text* .rodata*)
-    *stm32n6xx_hal_rcc_ex.o(.text* .rodata*)
+     * pattern claims every .text/.rodata input section from these
+     * .o files, including the bare `.text` that GCC still emits
+     * even with -ffunction-sections) — paired with the EXCLUDE_FILE
+     * in .text above. */
+    *system_stm32n6xx.o(.text .text* .rodata*)
+    *stm32n6xx_hal_rcc.o(.text .text* .rodata*)
+    *stm32n6xx_hal_rcc_ex.o(.text .text* .rodata*)
+    /* HAL XSPI primitives + HAL_GetTick. flash_mx66uw1g45g.c calls
+     * HAL_XSPI_Command / _Receive / _Transmit while memory-mapped
+     * mode is disabled — must live in AXISRAM, not XIP. EXCLUDE_FILE
+     * above strips them from the .text/.rodata regions so the linker
+     * lets us re-bind them here. */
+    *stm32n6xx_hal_xspi.o(.text .text* .rodata*)
+    *stm32n6xx_hal.o(.text .text* .rodata*)
     *(.ram_code)
     *(.ram_code*)
     . = ALIGN(32);

--- a/src/platform/STM32/mk/STM32N6.mk
+++ b/src/platform/STM32/mk/STM32N6.mk
@@ -46,6 +46,7 @@ STDPERIPH_SRC   = \
             stm32n6xx_hal_tim_ex.c \
             stm32n6xx_hal_uart.c \
             stm32n6xx_hal_uart_ex.c \
+            stm32n6xx_hal_xspi.c \
             stm32n6xx_ll_dma.c \
             stm32n6xx_ll_exti.c \
             stm32n6xx_ll_i2c.c \

--- a/src/platform/STM32/startup/stm32n6xx_hal_conf.h
+++ b/src/platform/STM32/startup/stm32n6xx_hal_conf.h
@@ -30,6 +30,11 @@
 #define HAL_TIM_MODULE_ENABLED
 #define HAL_UART_MODULE_ENABLED
 #define HAL_USART_MODULE_ENABLED
+// XSPI enabled for the MX66UW1G45G flash driver used by
+// CONFIG_IN_MEMORY_MAPPED_FLASH. Linker pulls hal_xspi/hal text into
+// .ram_code so HAL_XSPI_Command/_Receive/_Transmit are callable while
+// memory-mapped mode is disabled.
+#define HAL_XSPI_MODULE_ENABLED
 // LTDC + RIF enabled for the LCD console subsystem; --gc-sections drops the
 // driver code in builds that don't reference it.
 #define HAL_LTDC_MODULE_ENABLED
@@ -188,6 +193,10 @@
 #ifdef HAL_USART_MODULE_ENABLED
 #include "stm32n6xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_XSPI_MODULE_ENABLED
+#include "stm32n6xx_hal_xspi.h"
+#endif /* HAL_XSPI_MODULE_ENABLED */
 
 #ifdef HAL_LTDC_MODULE_ENABLED
 #include "stm32n6xx_hal_ltdc.h"

--- a/src/platform/STM32/target/STM32N657/target.h
+++ b/src/platform/STM32/target/STM32N657/target.h
@@ -69,19 +69,32 @@
 //
 // USE_OCTOSPI + FLASH_OCTOSPI_INSTANCE are always needed so
 // memoryMappedModeInit() can verify XSPI2->CR.FMODE on boot. The other
-// flags below drive flashInit / octoSpiInitDevice, which BF doesn't
-// require for the bring-up XIP scenario (config in RAM, no flashfs):
-// the FSBL stub leaves XSPI memory-mapped, BF runs XIP, XSPI never
-// needs to be poked again. A per-config #define BF_N6_NO_FLASH_CHIP
-// (set in src/config/.../config.h) skips the chip-driver path which
-// otherwise probes the wrong JEDEC ID and bus-faults the chip.
+// flags below drive flashInit / octoSpiInitDevice. Boards without a
+// flash chip wired (synthetic / DK-only configs) set
+// #define BF_N6_NO_FLASH_CHIP in their per-config config.h to skip the
+// chip-driver path.
+//
+// MX66UW1G45G is the boot flash on the reference ST DK and OPENN657V1.
+// For CONFIG_IN_MEMORY_MAPPED_FLASH to work the per-config also needs
+// OCTOSPI_FLASH_CHIP := MX66UW1G45G in its config.mk — that emits
+// OCTOSPI_FLASH_CHIP_MX66UW1G45G for the build-time chip dispatch in
+// flash.c (the chip can't answer 1/4-line RDID when the bootloader
+// leaves it in OPI mode, so it bypasses JEDEC probing).
 #define USE_OCTOSPI
 #define USE_FLASH_MEMORY_MAPPED
 #define FLASH_OCTOSPI_INSTANCE  XSPI2
 
 #ifndef BF_N6_NO_FLASH_CHIP
 #define USE_OCTOSPI_DEVICE_1
-#define USE_FLASH_W25Q128FV
+// Default the chip selection to MX66 only if the per-config hasn't
+// already picked one. USE_FLASH_CHIP isn't yet set at this point
+// (common_post.h derives it later from the chip-specific defines),
+// so the gate has to be against the other OCTOSPI-class chip macros
+// directly — letting a per-config opt into a different chip (e.g.
+// USE_FLASH_W25Q128FV) without also having to set BF_N6_NO_FLASH_CHIP.
+#if !defined(USE_FLASH_MX66UW1G45G) && !defined(USE_FLASH_W25Q128FV)
+#define USE_FLASH_MX66UW1G45G
+#endif
 #define USE_FLASH_CHIP
 #endif
 


### PR DESCRIPTION
## Summary

Brings the OPENN657V1 board up to a state where BF runs XIP from XSPI flash and the config persists across reboots — full eepromLoad / ensureEEPROMStructureIsValid / saveEEPROMToMemoryMappedFlash / re-load cycle working, VCP enumerates cleanly.

Three load-bearing changes:

1. **MX66UW1G45G driver re-driven through `HAL_XSPI_Command` / `_Receive` / `_Transmit`** — same pattern as the OBL flash-update path. BF's hand-rolled XSPI sequencer deterministically wedged in the FTF|TCF poll on RDSR-while-WIP=1 right after SE_4B; HAL doesn't.

2. **`octoSpiHardware[]` and `xspi_addressSizeMap[]` placed in `.fastram_data`** instead of the default `.rodata.<varname>` at XIP. `octoSpiDeviceByInstance` walks those from `MMFLASH_CODE` while memory-mapped mode is disabled, so XIP residency only worked when the M55 D-cache happened to hold the line — visible as ~60% intermittency on the load path. GCC 13.3 with `-fdata-sections` strips `MMFLASH_DATA` off `const` definitions, so the section attribute is applied raw on the definition.

3. **Redundant unconditional `CR.ABORT` removed from `octoSpiEnableMemoryMappedMode`** — wedged the controller on an idle peripheral waiting `BUSY=RESET` after an abort that had nothing to abort. The follow-on `xspiRestoreMemoryMappedModeConfiguration` already does its own HAL_XSPI_Abort-style drain conditional on `BUSY=SET`.

Plus the supporting plumbing for the HAL-XSPI switch: `HAL_XSPI_MODULE_ENABLED` + header include, `stm32n6xx_hal_xspi.c` added to `STDPERIPH_SRC`, and the N657 XIP linker script extended to pull `stm32n6xx_hal_xspi.o` + `stm32n6xx_hal.o` (for `HAL_GetTick`) whole-file into `.ram_code` with matching `EXCLUDE_FILE` entries on `.text`/`.rodata` so they don't bind into XIP first.

`flash.c` also picks up `CONFIG_IN_MEMORY_MAPPED_FLASH` in the partition-config guard and `MMFLASH_CODE` on `flashWaitForReadyOrFail` so it survives the MM-disabled window on the load path too.

Merge of `betaflight/master` brings in #15241 (lib/main → lib/modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full functional read/write/erase support for the MX66UW1G45G flash, including robust page programming and indirect reads.
  * XSPI HAL support enabled so flash operations can run when memory-mapped mode is temporarily disabled.

* **Improvements**
  * More resilient memory-mapped mode transitions and faster RAM placement for critical flash helpers.
  * Partition setup now included for in-memory-mapped flash builds; default flash selection updated to prefer MX66 on compatible targets.

* **Bug Fixes**
  * Failure paths now attempt best-effort recovery before reporting external flash write failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->