### PR TITLE
build: auto-clean stale .d files when sources move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -718,9 +718,9 @@ $(AUTOHYDRATE_STAMPS):
 # scan: just stat the first .c prereq the .d declares.
 .PHONY: clean-stale-deps
 clean-stale-deps:
-	$(V1) if [ -d $(OBJECT_DIR) ]; then \
-	    find $(OBJECT_DIR) -name '*.d' 2>/dev/null | while IFS= read -r dfile; do \
-	        src=$$(grep -oE '[^[:space:]]+\.c\b' "$$dfile" 2>/dev/null | head -1); \
+	$(V1) if [ -d "$(OBJECT_DIR)" ]; then \
+	    find "$(OBJECT_DIR)" -name '*.d' 2>/dev/null | while IFS= read -r dfile; do \
+	        src=$$(awk '{ for (i=1; i<=NF; i++) if ($$i ~ /\.c$$/) { print $$i; exit } }' "$$dfile" 2>/dev/null); \
 	        if [ -n "$$src" ] && [ ! -f "$$src" ]; then \
 	            echo "Removing stale dependency file: $$dfile (source moved: $$src)"; \
 	            $(RM) "$$dfile"; \

--- a/Makefile
+++ b/Makefile
@@ -710,20 +710,38 @@ $(AUTOHYDRATE_STAMPS):
 	$(V1) git submodule update --init -- "$(@:/.git=)" \
 	    || { echo "submodule update failed: $(@:/.git=)"; exit 1; }
 
+# Drop .d files whose recorded source path no longer exists. The most
+# common trigger is pulling across a source-move commit (e.g. promoting
+# an embedded vendor tree to a submodule) — gcc's -MMD pinned the .o to
+# the previous path, and make then bails with "No rule to make target
+# <old-path>" before the compiler ever runs to regenerate the .d. Cheap
+# scan: just stat the first .c prereq the .d declares.
+.PHONY: clean-stale-deps
+clean-stale-deps:
+	$(V1) if [ -d $(OBJECT_DIR) ]; then \
+	    find $(OBJECT_DIR) -name '*.d' 2>/dev/null | while IFS= read -r dfile; do \
+	        src=$$(grep -oE '[^[:space:]]+\.c\b' "$$dfile" 2>/dev/null | head -1); \
+	        if [ -n "$$src" ] && [ ! -f "$$src" ]; then \
+	            echo "Removing stale dependency file: $$dfile (source moved: $$src)"; \
+	            $(RM) "$$dfile"; \
+	        fi; \
+	    done; \
+	fi
+
 .PHONY: binary
-binary: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS)
+binary: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS) clean-stale-deps
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_BIN)
 
 .PHONY: hex
-hex: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS)
+hex: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS) clean-stale-deps
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_HEX)
 
 .PHONY: uf2
-uf2: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS)
+uf2: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS) clean-stale-deps
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_UF2)
 
 .PHONY: exe
-exe: $(AUTOHYDRATE_STAMPS)
+exe: $(AUTOHYDRATE_STAMPS) clean-stale-deps
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_EXE)
 
 # FWO (Firmware Output) is the default output for building the firmware


### PR DESCRIPTION
## Summary

Follow-up to #15241. After the lib/main → lib/modules rename, existing obj/ trees still hold .d files pinning each .o to the previous source path; the next build fails with `No rule to make target 'dronecan/libcanard/canard.c'` (or any moved vendor source) before gcc ever runs to refresh the .d.

Adds a `clean-stale-deps` phony that pulls the first .c prereq out of each .d under `$(OBJECT_DIR)` and drops the .d if that source no longer exists. The next compile regenerates the .d at the new path. Wired into binary / hex / uf2 / exe as a prereq so it runs once per build — single stat-only scan before the recursive make.

Same idea as the existing `check-stale-submodule-paths` (catches stray files at moved submodule paths), just on the other end of the build chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a maintenance step that removes stale dependency files before builds.
  * Build outputs now run this cleanup automatically, improving build reliability and preventing incorrect incremental builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->