### PR TITLE
CRSF: bound subset RC channel unpacking

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -534,29 +534,30 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeState_t *rxRuntimeState)
             // get the channel resolution settings
             uint8_t channelBits;
             uint16_t channelMask;
+            float subsetChannelScale;
             uint8_t channelRes = configByte & CRSF_SUBSET_RC_RES_CONFIGURATION_MASK;
             configByte >>= CRSF_SUBSET_RC_RES_CONFIGURATION_BITS;
             switch (channelRes) {
             case CRSF_SUBSET_RC_RES_CONF_10B:
                 channelBits = CRSF_SUBSET_RC_RES_BITS_10B;
                 channelMask = CRSF_SUBSET_RC_RES_MASK_10B;
-                channelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_10B;
+                subsetChannelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_10B;
                 break;
             default:
             case CRSF_SUBSET_RC_RES_CONF_11B:
                 channelBits = CRSF_SUBSET_RC_RES_BITS_11B;
                 channelMask = CRSF_SUBSET_RC_RES_MASK_11B;
-                channelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_11B;
+                subsetChannelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_11B;
                 break;
             case CRSF_SUBSET_RC_RES_CONF_12B:
                 channelBits = CRSF_SUBSET_RC_RES_BITS_12B;
                 channelMask = CRSF_SUBSET_RC_RES_MASK_12B;
-                channelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_12B;
+                subsetChannelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_12B;
                 break;
             case CRSF_SUBSET_RC_RES_CONF_13B:
                 channelBits = CRSF_SUBSET_RC_RES_BITS_13B;
                 channelMask = CRSF_SUBSET_RC_RES_MASK_13B;
-                channelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_13B;
+                subsetChannelScale = CRSF_SUBSET_RC_CHANNEL_SCALE_13B;
                 break;
             }
 
@@ -564,12 +565,18 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeState_t *rxRuntimeState)
             configByte >>= CRSF_SUBSET_RC_RESERVED_CONFIGURATION_BITS;
 
             // calculate the number of channels packed
-            uint8_t numOfChannels = ((crsfChannelDataFrame.frame.frameLength - CRSF_FRAME_LENGTH_TYPE_CRC - 1) * 8) / channelBits;
+            const int packedChannelDataLength = crsfChannelDataFrame.frame.frameLength - CRSF_FRAME_LENGTH_TYPE_CRC - 1;
+            const uint8_t numOfChannels = packedChannelDataLength > 0 ? (packedChannelDataLength * 8) / channelBits : 0;
+            if (numOfChannels == 0 || startChannel >= CRSF_MAX_CHANNEL) {
+                return RX_FRAME_DROPPED;
+            }
+            const uint8_t channelsToProcess = MIN(numOfChannels, CRSF_MAX_CHANNEL - startChannel);
+            channelScale = subsetChannelScale;
 
             // unpack the channel data
             uint8_t bitsMerged = 0;
             uint32_t readValue = 0;
-            for (uint8_t n = 0; n < numOfChannels; n++) {
+            for (uint8_t n = 0; n < channelsToProcess; n++) {
                 while (bitsMerged < channelBits) {
                     uint8_t readByte = payload[readByteIndex++];
                     readValue |= ((uint32_t) readByte) << bitsMerged;

--- a/src/test/unit/rx_crsf_unittest.cc
+++ b/src/test/unit/rx_crsf_unittest.cc
@@ -327,6 +327,57 @@ TEST(CrossFireTest, TestCapturedSubsetData)
     EXPECT_EQ(2011, (uint16_t)crsfReadRawRC(NULL, 7));
 }
 
+TEST(CrossFireTest, TestSubsetDataIgnoresUnsupportedChannels)
+{
+    memset(&crsfFrame, 0, sizeof(crsfFrame));
+    memset(crsfChannelData, 0, sizeof(crsfChannelData));
+
+    crsfFrame.frame.deviceAddress = CRSF_ADDRESS_FLIGHT_CONTROLLER;
+    crsfFrame.frame.frameLength = 6;
+    crsfFrame.frame.type = CRSF_FRAMETYPE_SUBSET_RC_CHANNELS_PACKED;
+    crsfFrame.frame.payload[0] = 15 |
+        (CRSF_SUBSET_RC_RES_CONF_10B << CRSF_SUBSET_RC_STARTING_CHANNEL_BITS);
+    crsfFrame.frame.payload[1] = 0x55;
+    crsfFrame.frame.payload[2] = 0xA9;
+    crsfFrame.frame.payload[3] = 0x0A;
+
+    crsfFrameDone = true;
+    memcpy(&crsfChannelDataFrame, &crsfFrame, sizeof(crsfFrame));
+
+    const uint8_t status = crsfFrameStatus();
+    EXPECT_EQ(RX_FRAME_COMPLETE, status);
+    EXPECT_FALSE(crsfFrameDone);
+    for (int ii = 0; ii < CRSF_MAX_CHANNEL - 1; ++ii) {
+        EXPECT_EQ(0, crsfChannelData[ii]);
+    }
+    EXPECT_EQ(0x155, crsfChannelData[15]);
+}
+
+TEST(CrossFireTest, TestSubsetDataDropsUnsupportedChannels)
+{
+    memset(&crsfFrame, 0, sizeof(crsfFrame));
+    memset(crsfChannelData, 0, sizeof(crsfChannelData));
+
+    crsfFrame.frame.deviceAddress = CRSF_ADDRESS_FLIGHT_CONTROLLER;
+    crsfFrame.frame.frameLength = 6;
+    crsfFrame.frame.type = CRSF_FRAMETYPE_SUBSET_RC_CHANNELS_PACKED;
+    crsfFrame.frame.payload[0] = CRSF_MAX_CHANNEL |
+        (CRSF_SUBSET_RC_RES_CONF_10B << CRSF_SUBSET_RC_STARTING_CHANNEL_BITS);
+    crsfFrame.frame.payload[1] = 0x55;
+    crsfFrame.frame.payload[2] = 0xA9;
+    crsfFrame.frame.payload[3] = 0x0A;
+
+    crsfFrameDone = true;
+    memcpy(&crsfChannelDataFrame, &crsfFrame, sizeof(crsfFrame));
+
+    const uint8_t status = crsfFrameStatus();
+    EXPECT_EQ(RX_FRAME_DROPPED, status);
+    EXPECT_FALSE(crsfFrameDone);
+    for (int ii = 0; ii < CRSF_MAX_CHANNEL; ++ii) {
+        EXPECT_EQ(0, crsfChannelData[ii]);
+    }
+}
+
 TEST(CrossFireTest, TestCrsfDataReceive)
 {
     crsfFrameDone = false;


### PR DESCRIPTION
## Summary

- Bound CRSF subset RC unpacking to Betaflight's supported 16 CRSF channels.
- Preserve supported overlap when a subset frame starts inside the supported range but carries unsupported trailing channels.
- Drop subset frames that start entirely outside the supported channel range.
- Add CRSF unit coverage for both cases.

## Problem

Subset RC frames encode the starting channel in a 5-bit field, while Betaflight's CRSF receiver stores and advertises 16 channels. The previous unpack loop used the decoded start channel directly when writing `crsfChannelData[startChannel + n]`, so a malformed or unsupported subset frame starting near the end of the supported range could write beyond the channel array.

## Fix

The parser now calculates the decoded channel count before updating `channelScale` or writing channel data. It drops empty/unsupported-only subset frames, and clamps processing to the supported channel overlap for frames that carry extra channels beyond channel 15.

This avoids accepting unusable frames as fresh RX data while preserving valid channel updates that overlap Betaflight's supported CRSF channel range.

## Issue / PR Check

I did not find an open PR or issue specifically covering this CRSF subset RC bounds issue. Related items checked but not linked as fixes:

- #14893 fixed a CRSF subset frame race, not this bounds check.
- #14291 reports bad AUX ranges and appears related to subset-frame consistency/race behavior.
- #14779 concerns MSP-over-CRSF response handling.
- #13652 concerns RSSI values.

## Test Plan

- [x] `make -C src/test test_rx_crsf_unittest V=0`
- [x] `make EXTRA_FLAGS=-Werror checks`
- [x] `make EXTRA_FLAGS=-Werror test-all`
- [x] `make STM32F405 EXTRA_FLAGS=-Werror`
- [x] ASan-filtered regression check:
  `make -C src/test test_rx_crsf_unittest OBJECT_DIR=../../obj/test-asan OPTIMIZE="-O0 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" USE_COVERAGE= EXEC_OPTS='--gtest_filter=CrossFireTest.TestSubsetData*'`

Note: the current PR template mentions `make pre-push`, but current `master` does not define that target.

AI assistance: this PR was prepared with AI assistance. I reviewed the diff and ran the tests listed above.
