### PR TITLE
AT32: add gyro_clkin platform implementation

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -611,7 +611,7 @@
 #endif
 #endif
 
-#if defined(USE_RX_PWM) || defined(USE_DSHOT) || defined(USE_LED_STRIP) || defined(USE_TRANSPONDER) || defined(USE_BEEPER) || defined(USE_SERIAL_4WAY_BLHELI_INTERFACE)
+#if defined(USE_RX_PWM) || defined(USE_DSHOT) || defined(USE_LED_STRIP) || defined(USE_TRANSPONDER) || defined(USE_BEEPER) || defined(USE_SERIAL_4WAY_BLHELI_INTERFACE) || defined(USE_GYRO_CLKIN)
 #ifndef USE_PWM_OUTPUT
 #define USE_PWM_OUTPUT
 #endif

--- a/src/platform/AT32/gyro_clkin_at32.c
+++ b/src/platform/AT32/gyro_clkin_at32.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if defined(USE_GYRO_CLKIN)
+
+#include "drivers/gyro_clkin.h"
+#include "drivers/io.h"
+#include "drivers/pwm_output.h"
+#include "drivers/resource.h"
+#include "drivers/timer.h"
+
+static timerChannel_t pwmChannel;
+
+bool gyroClkInInit(ioTag_t tag, uint32_t freqHz, uint8_t resourceIndex)
+{
+    if (!tag || freqHz == 0) {
+        return false;
+    }
+
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_GYRO_CLKIN, resourceIndex);
+    if (!timer) {
+        return false;
+    }
+
+    const IO_t io = IOGetByTag(tag);
+    if (!io) {
+        return false;
+    }
+
+    const uint32_t clock = timerClock(timer);
+    const uint32_t period = clock / freqHz;
+    if (period < 2 || period > UINT16_MAX) {
+        return false;
+    }
+
+    IOInit(io, OWNER_GYRO_CLKIN, resourceIndex);
+    IOConfigGPIOAF(io, IOCFG_AF_PP, timer->alternateFunction);
+
+    const uint16_t period16 = (uint16_t)period;
+    const uint16_t value16 = period16 / 2;
+
+    pwmOutputConfig(&pwmChannel, timer, clock, period16 - 1, value16 - 1, 0);
+    pwmWriteChannel(&pwmChannel, value16 - 1);
+
+    return true;
+}
+
+#endif

--- a/src/platform/AT32/mk/AT32F4.mk
+++ b/src/platform/AT32/mk/AT32F4.mk
@@ -101,6 +101,7 @@ MCU_COMMON_SRC = \
             AT32/dshot_bitbang.c \
             AT32/dshot_bitbang_stdperiph.c \
             AT32/exti_at32.c \
+            AT32/gyro_clkin_at32.c \
             AT32/io_at32.c \
             AT32/light_ws2811strip_at32f43x.c \
             AT32/persistent_at32bsp.c \


### PR DESCRIPTION
#15162 moved `gyroClkInInit()` behind a platform interface but only landed STM32 and PICO backends, so AT32 targets defining `USE_GYRO_CLKIN` failed to link (e.g. `make ACCIF435ELITE`).

Adds `src/platform/AT32/gyro_clkin_at32.c` mirroring the STM32 implementation — `timerAllocate` / `pwmOutputConfig` / `pwmWriteChannel` / `IOConfigGPIOAF` are common API surface, so the body is unchanged. Wired into `AT32F4.mk`.

Verified by building `ACCIF435ELITE` locally — links cleanly.

Fixes #15248.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gyro clock-input support for AT32 platforms with configurable clock frequency and automatic resource initialization.
  * Enables gyro timing synchronization (PWM-based clock output) on AT32-based devices.

* **Chores**
  * Integrated gyro clock-input into the AT32 build/config so the feature is enabled when selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->