### PR TITLE
cli: NULL-safe nextArg, fix CLI null-deref crashes in aux/color/led

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -1106,6 +1106,9 @@ static void cliShowArgumentRangeError(const char *cmdName, char *name, int min, 
 
 static const char *nextArg(const char *currentArg)
 {
+    if (!currentArg) {
+        return NULL;
+    }
     const char *ptr = strchr(currentArg, ' ');
     while (ptr && *ptr == ' ') {
         ptr++;
@@ -2139,7 +2142,9 @@ static void cliLed(const char *cmdName, char *cmdline)
         i = atoi(ptr);
         if (i >= 0 && i < LED_STRIP_MAX_LENGTH) {
             ptr = nextArg(cmdline);
-            if (parseLedStripConfig(i, ptr)) {
+            if (!ptr) {
+                cliShowInvalidArgumentCountError(cmdName);
+            } else if (parseLedStripConfig(i, ptr)) {
                 generateLedConfig((ledConfig_t *)&ledStripStatusModeConfig()->ledConfigs[i], ledConfigBuffer, sizeof(ledConfigBuffer));
                 cliDumpPrintLinef(0, false, format, i, ledConfigBuffer);
             } else {
@@ -2178,7 +2183,9 @@ static void cliColor(const char *cmdName, char *cmdline)
         const int i = atoi(ptr);
         if (i < LED_CONFIGURABLE_COLOR_COUNT) {
             ptr = nextArg(cmdline);
-            if (parseColor(i, ptr)) {
+            if (!ptr) {
+                cliShowInvalidArgumentCountError(cmdName);
+            } else if (parseColor(i, ptr)) {
                 const hsvColor_t *color = &ledStripStatusModeConfig()->colors[i];
                 cliDumpPrintLinef(0, false, format, i, color->h, color->s, color->v);
             } else {

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2181,7 +2181,7 @@ static void cliColor(const char *cmdName, char *cmdline)
     } else {
         const char *ptr = cmdline;
         const int i = atoi(ptr);
-        if (i < LED_CONFIGURABLE_COLOR_COUNT) {
+        if (i >= 0 && i < LED_CONFIGURABLE_COLOR_COUNT) {
             ptr = nextArg(cmdline);
             if (!ptr) {
                 cliShowInvalidArgumentCountError(cmdName);


### PR DESCRIPTION
`nextArg()` calls `strchr()` directly on its argument, so when chained calls cascade a NULL (the string had no further spaces) the next `nextArg()` crashes. Several call sites also feed the NULL straight into parsers that deref it.

Reproducers from the bug reports (all crash on stock master):

```
# aux aI       # cliAux  -> NULL deref via processChannelRangeArgs
# color I      # cliColor -> NULL deref inside parseColor
# led +        # cliLed  -> NULL deref inside parseLedStripConfig
```

Fix:
- `nextArg()` short-circuits to `NULL` on `NULL` input — this single guard covers the chained-call path that takes down `cliAux` via `processChannelRangeArgs`.
- `cliLed` and `cliColor` treat a `NULL` result from `nextArg()` as a missing-argument error (`cliShowInvalidArgumentCountError`) instead of handing it to the parser.

All other `ptr = nextArg(...)` sites in `cli.c` already gate on `if (ptr)`, so no other call sites needed changes.

Builds cleanly (STM32G47X) and existing `test_cli_unittest` passes.

Fixes #13701
Fixes #13702
Fixes #13704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI handlers for LED and color commands now validate the presence of value tokens before parsing, preventing null-pointer issues.
  * Improved input validation and clearer "invalid argument count" error reporting when required command arguments are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->