### PR TITLE
Fix CRSF frame length validation

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -346,6 +346,13 @@ STATIC_UNIT_TESTED uint8_t crsfFrameCmdCRC(void)
 }
 #endif
 
+static bool crsfFrameLengthIsValid(void)
+{
+    const uint8_t frameLength = crsfFrame.frame.frameLength;
+    return frameLength >= CRSF_FRAME_LENGTH_TYPE_CRC &&
+        frameLength <= CRSF_FRAME_SIZE_MAX - CRSF_FRAME_LENGTH_ADDRESS - CRSF_FRAME_LENGTH_FRAMELENGTH;
+}
+
 // Receive ISR callback, called back from serial port
 STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
 {
@@ -379,7 +386,13 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
     // assume frame is 5 bytes long until we have received the frame length
     // full frame length includes the length of the address and framelength fields
     // sometimes we can receive some garbage data. So, we need to check max size for preventing buffer overrun.
-    const int fullFrameLength = crsfFramePosition < 3 ? 5 : MIN(crsfFrame.frame.frameLength + CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH, CRSF_FRAME_SIZE_MAX);
+    if (crsfFramePosition == CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH &&
+        !crsfFrameLengthIsValid()) {
+        crsfFramePosition = 0;
+        return;
+    }
+    const int fullFrameLength = crsfFramePosition < 3 ? 5 :
+        crsfFrame.frame.frameLength + CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH;
 
     if (crsfFramePosition < fullFrameLength) {
         crsfFrame.bytes[crsfFramePosition++] = (uint8_t)c;

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -388,6 +388,8 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
     // sometimes we can receive some garbage data. So, we need to check max size for preventing buffer overrun.
     if (crsfFramePosition == CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH &&
         !crsfFrameLengthIsValid()) {
+        // Invalid declared lengths are protocol violations, not evidence of a negotiated-baud mismatch.
+        // Drop them without contributing to the CRSFv3 baud fallback error counter.
         crsfFramePosition = 0;
         return;
     }

--- a/src/test/unit/rx_crsf_unittest.cc
+++ b/src/test/unit/rx_crsf_unittest.cc
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include <limits.h>
 #include <algorithm>
@@ -43,7 +44,7 @@ extern "C" {
 
     rssiSource_e rssiSource;
 
-    void crsfDataReceive(uint16_t c);
+    void crsfDataReceive(uint16_t c, void *data);
     uint8_t crsfFrameCRC(void);
     uint8_t crsfFrameCmdCRC(void);
     uint8_t crsfFrameStatus(void);
@@ -233,6 +234,32 @@ typedef struct crsfRcChannelsFrame_s {
     uint8_t payload[CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_CRC];
 } crsfRcChannelsFrame_t;
 
+static void receiveCrsfFrameBytes(const uint8_t *frame, size_t frameSize, rxRuntimeState_t *rxRuntimeState)
+{
+    for (size_t ii = 0; ii < frameSize; ++ii) {
+        crsfDataReceive(frame[ii], rxRuntimeState);
+    }
+}
+
+static size_t buildCrsfFrame(uint8_t *frame, uint8_t frameLength, uint8_t deviceAddress)
+{
+    const uint8_t type = CRSF_FRAMETYPE_RC_CHANNELS_PACKED;
+    const int payloadLength = frameLength - CRSF_FRAME_LENGTH_TYPE_CRC;
+    uint8_t crc = crc8_dvb_s2(0, type);
+
+    frame[0] = deviceAddress;
+    frame[1] = frameLength;
+    frame[2] = type;
+    for (int ii = 0; ii < payloadLength; ++ii) {
+        const uint8_t payloadByte = (uint8_t)ii;
+        frame[3 + ii] = payloadByte;
+        crc = crc8_dvb_s2(crc, payloadByte);
+    }
+    frame[3 + payloadLength] = crc;
+
+    return frameLength + CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH;
+}
+
 
 TEST(CrossFireTest, TestCapturedData)
 {
@@ -383,7 +410,7 @@ TEST(CrossFireTest, TestCrsfDataReceive)
     crsfFrameDone = false;
     const uint8_t *pData = capturedData;
     for (unsigned int ii = 0; ii < sizeof(crsfRcChannelsFrame_t); ++ii) {
-        crsfDataReceive(*pData++);
+        crsfDataReceive(*pData++, NULL);
     }
     EXPECT_FALSE(crsfFrameDone); // data is not a valid rc channels frame so don't expect crsfFrameDone to be true
     EXPECT_EQ(CRSF_ADDRESS_BROADCAST, crsfFrame.frame.deviceAddress);
@@ -402,14 +429,82 @@ TEST(CrossFireTest, TestOversizedFrameLengthIsRejected)
     crsfFrameDone = false;
     dummyTimeUs += 10000;
 
-    crsfDataReceive(CRSF_ADDRESS_FLIGHT_CONTROLLER);
-    crsfDataReceive(CRSF_FRAME_SIZE_MAX);
-    crsfDataReceive(CRSF_FRAMETYPE_RC_CHANNELS_PACKED);
+    crsfDataReceive(CRSF_ADDRESS_FLIGHT_CONTROLLER, NULL);
+    crsfDataReceive(CRSF_FRAME_SIZE_MAX, NULL);
+    crsfDataReceive(CRSF_FRAMETYPE_RC_CHANNELS_PACKED, NULL);
     for (int ii = 0; ii < CRSF_FRAME_SIZE_MAX - 3; ++ii) {
-        crsfDataReceive(0);
+        crsfDataReceive(0, NULL);
     }
 
     EXPECT_FALSE(crsfFrameDone);
+}
+
+TEST(CrossFireTest, TestValidFrameLengthBoundsAreReceived)
+{
+    const uint8_t maxValidFrameLength = CRSF_FRAME_SIZE_MAX -
+        CRSF_FRAME_LENGTH_ADDRESS - CRSF_FRAME_LENGTH_FRAMELENGTH;
+    const uint8_t validFrameLengths[] = {
+        CRSF_FRAME_LENGTH_TYPE_CRC,
+        maxValidFrameLength,
+    };
+    uint8_t frame[CRSF_FRAME_SIZE_MAX];
+
+    for (size_t ii = 0; ii < ARRAYLEN(validFrameLengths); ++ii) {
+        memset(&crsfFrame, 0, sizeof(crsfFrame));
+        crsfFrameDone = false;
+        rxRuntimeState_t rxRuntimeState = {};
+        dummyTimeUs += 10000;
+
+        const size_t frameSize = buildCrsfFrame(frame, validFrameLengths[ii], CRSF_ADDRESS_FLIGHT_CONTROLLER);
+        receiveCrsfFrameBytes(frame, frameSize, &rxRuntimeState);
+
+        EXPECT_TRUE(crsfFrameDone);
+        EXPECT_EQ(dummyTimeUs, rxRuntimeState.lastRcFrameTimeUs);
+        EXPECT_EQ(CRSF_ADDRESS_FLIGHT_CONTROLLER, crsfFrame.frame.deviceAddress);
+        EXPECT_EQ(validFrameLengths[ii], crsfFrame.frame.frameLength);
+        EXPECT_EQ(CRSF_FRAMETYPE_RC_CHANNELS_PACKED, crsfFrame.frame.type);
+
+        EXPECT_EQ(crsfFrameCRC(), frame[frameSize - 1]);
+    }
+}
+
+TEST(CrossFireTest, TestInvalidFrameLengthBoundsAreRejectedAndRecover)
+{
+    const uint8_t maxValidFrameLength = CRSF_FRAME_SIZE_MAX -
+        CRSF_FRAME_LENGTH_ADDRESS - CRSF_FRAME_LENGTH_FRAMELENGTH;
+    const uint8_t invalidFrameLengths[] = {
+        0,
+        CRSF_FRAME_LENGTH_TYPE_CRC - 1,
+        (uint8_t)(maxValidFrameLength + 1),
+        CRSF_FRAME_SIZE_MAX,
+    };
+    uint8_t frame[CRSF_FRAME_SIZE_MAX];
+
+    for (size_t ii = 0; ii < ARRAYLEN(invalidFrameLengths); ++ii) {
+        memset(&crsfFrame, 0, sizeof(crsfFrame));
+        crsfFrameDone = false;
+        rxRuntimeState_t rxRuntimeState = {};
+        dummyTimeUs += 10000;
+
+        const uint8_t invalidFramePrefix[] = {
+            CRSF_ADDRESS_FLIGHT_CONTROLLER,
+            invalidFrameLengths[ii],
+            CRSF_FRAMETYPE_RC_CHANNELS_PACKED,
+        };
+        receiveCrsfFrameBytes(invalidFramePrefix, sizeof(invalidFramePrefix), &rxRuntimeState);
+
+        EXPECT_FALSE(crsfFrameDone);
+        EXPECT_EQ(0, rxRuntimeState.lastRcFrameTimeUs);
+
+        const size_t frameSize = buildCrsfFrame(frame, CRSF_FRAME_LENGTH_TYPE_CRC, CRSF_ADDRESS_FLIGHT_CONTROLLER);
+        receiveCrsfFrameBytes(frame, frameSize, &rxRuntimeState);
+
+        EXPECT_TRUE(crsfFrameDone);
+        EXPECT_EQ(dummyTimeUs, rxRuntimeState.lastRcFrameTimeUs);
+        EXPECT_EQ(CRSF_ADDRESS_FLIGHT_CONTROLLER, crsfFrame.frame.deviceAddress);
+        EXPECT_EQ(CRSF_FRAME_LENGTH_TYPE_CRC, crsfFrame.frame.frameLength);
+        EXPECT_EQ(CRSF_FRAMETYPE_RC_CHANNELS_PACKED, crsfFrame.frame.type);
+    }
 }
 
 // STUBS

--- a/src/test/unit/rx_crsf_unittest.cc
+++ b/src/test/unit/rx_crsf_unittest.cc
@@ -396,6 +396,22 @@ TEST(CrossFireTest, TestCrsfDataReceive)
     EXPECT_EQ(crc, crsfFrame.frame.payload[CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE]);
 }
 
+TEST(CrossFireTest, TestOversizedFrameLengthIsRejected)
+{
+    memset(&crsfFrame, 0, sizeof(crsfFrame));
+    crsfFrameDone = false;
+    dummyTimeUs += 10000;
+
+    crsfDataReceive(CRSF_ADDRESS_FLIGHT_CONTROLLER);
+    crsfDataReceive(CRSF_FRAME_SIZE_MAX);
+    crsfDataReceive(CRSF_FRAMETYPE_RC_CHANNELS_PACKED);
+    for (int ii = 0; ii < CRSF_FRAME_SIZE_MAX - 3; ++ii) {
+        crsfDataReceive(0);
+    }
+
+    EXPECT_FALSE(crsfFrameDone);
+}
+
 // STUBS
 
 extern "C" {


### PR DESCRIPTION
## Summary

- Reject CRSF frames whose declared length cannot fit in the receive buffer.
- Drop invalid length fields before the parser reaches the CRC check.
- Add CRSF unit coverage for the oversized declared-length case.

## Problem

CRSF frames carry a length byte that includes the type, payload, and CRC fields.
Betaflight stores received CRSF bytes in a `CRSF_FRAME_SIZE_MAX` backing buffer.
The previous receive path capped the number of bytes stored with `MIN(...)`, but
kept the original declared length in `crsfFrame.frame.frameLength`.

That meant a malformed frame could declare a length larger than the backing
buffer can hold. Once the truncated frame reached the CRC check,
`crsfFrameCRC()` used the oversized declared length to walk payload bytes and
could read beyond the stored frame.

## Fix

The receive parser now validates the declared CRSF length as soon as the length
byte has been received. A valid declared length must include at least the type
and CRC fields, and the full frame length must fit within `CRSF_FRAME_SIZE_MAX`
after the address and length bytes are included.

Invalid frames reset the receive position and are dropped before any CRC
calculation. Valid frames still use the declared length to determine when the
frame is complete.

I also checked the nearby CRSF consumers and did not find any legitimate code
path that depends on accepting the old truncated/oversized length state.

## Issue / PR Check

I did not find an open PR or issue specifically covering this CRSF frame-length
CRC over-read. Searches checked:

- open PRs/issues for `CRSF frame length`
- open PRs/issues for `CRSF oversized`
- open PRs/issues for `crsf frameLength`
- open issues for `crsf crc`

## Test Plan

- [x] ASan regression before the fix reproduced the original issue as
  `global-buffer-overflow` in `crsfFrameCRC()`:
  `make -C src/test test_rx_crsf_unittest OBJECT_DIR=../../obj/test-asan-crsf-length-before OPTIMIZE="-O0 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" USE_COVERAGE= EXEC_OPTS='--gtest_filter=CrossFireTest.TestOversizedFrameLengthIsRejected'`
- [x] ASan regression after the fix:
  `make -C src/test test_rx_crsf_unittest OBJECT_DIR=../../obj/test-asan-crsf-length-after OPTIMIZE="-O0 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" USE_COVERAGE= EXEC_OPTS='--gtest_filter=CrossFireTest.TestOversizedFrameLengthIsRejected'`
- [x] CRSF unit tests:
  `make -C src/test test_rx_crsf_unittest OBJECT_DIR=../../obj/test-crsf-length-normal V=0`
- [x] Checks:
  `make EXTRA_FLAGS=-Werror checks`
- [x] Target build:
  `make STM32F405 EXTRA_FLAGS=-Werror`
- [x] Full unit suite:
  `make -C src/test test-all OBJECT_DIR=../../obj/test-crsf-length-all`
- [x] Post-rebase CRSF unit tests:
  `make -C src/test test_rx_crsf_unittest OBJECT_DIR=../../obj/test-crsf-length-rebased V=0`
- [x] Post-rebase whitespace check:
  `git diff --check origin/master..HEAD -- src/main/rx/crsf.c src/test/unit/rx_crsf_unittest.cc`

AI assistance: this PR was prepared with AI assistance. I reviewed the diff and
ran the tests listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRSF receiver robustness by validating declared frame length as soon as it’s received. Invalid or oversized frame lengths are rejected early to prevent incorrect frame assembly and processing.

* **Tests**
  * Added unit tests for RC channels frame length bounds, verifying that minimum/maximum valid lengths are accepted and invalid/oversized lengths are rejected, including recovery after invalid frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->