### PR TITLE
[backport] fix(uart): guard half-duplex pinless UART modes (#15218)

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -252,6 +252,25 @@ uartDevice_t *uartDeviceFromIdentifier(serialPortIdentifier_e identifier)
     return deviceIdx != UARTDEV_INVALID ? &uartDevice[deviceIdx] : NULL;
 }
 
+static inline portMode_e uartSanitizeMode(const uartDevice_t *uartDevice, portMode_e mode, portOptions_e options)
+{
+    if (!uartDevice->tx.pin) {
+        mode &= ~MODE_TX;
+    }
+
+    if (!uartDevice->rx.pin && !((options & SERIAL_BIDIR) && uartDevice->tx.pin)) {
+        mode &= ~MODE_RX;
+    }
+
+    return mode;
+}
+
+static inline bool uartCanWrite(const uartPort_t *uartPort)
+{
+    const uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    return (uartPort->port.mode & MODE_TX) && uartDevice->tx.pin;
+}
+
 serialPort_t *uartOpen(serialPortIdentifier_e identifier, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_e mode, portOptions_e options)
 {
     uartDevice_t *uartDevice = uartDeviceFromIdentifier(identifier);
@@ -260,6 +279,7 @@ serialPort_t *uartOpen(serialPortIdentifier_e identifier, serialReceiveCallbackP
     }
     // fill identifier early, so initialization code can use it
     uartDevice->port.port.identifier = identifier;
+    mode = uartSanitizeMode(uartDevice, mode, options);
 
     uartPort_t *uartPort = serialUART(uartDevice, baudRate, mode, options);
     if (!uartPort) {
@@ -284,6 +304,8 @@ serialPort_t *uartOpen(serialPortIdentifier_e identifier, serialReceiveCallbackP
 static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
+    uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    uartPort->port.mode = uartSanitizeMode(uartDevice, uartPort->port.mode, uartPort->port.options);
     uartPort->port.baudRate = baudRate;
     uartReconfigure(uartPort);
 }
@@ -291,7 +313,8 @@ static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 static void uartSetMode(serialPort_t *instance, portMode_e mode)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
-    uartPort->port.mode = mode;
+    uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    uartPort->port.mode = uartSanitizeMode(uartDevice, mode, uartPort->port.options);
     uartReconfigure(uartPort);
 }
 
@@ -407,6 +430,10 @@ static void uartWrite(serialPort_t *instance, uint8_t ch)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
 
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
+
     // Check if the TX line is being pulled low by an unpowered peripheral
     if (uartPort->checkUsartTxOutput && !uartPort->checkUsartTxOutput(uartPort)) {
         // TX line is being pulled low, so don't transmit
@@ -435,6 +462,10 @@ static void uartBeginWrite(serialPort_t *instance)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
 
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
+
     // Check if the TX line is being pulled low by an unpowered peripheral
     if (uartPort->checkUsartTxOutput) {
         uartPort->checkUsartTxOutput(uartPort);
@@ -446,6 +477,10 @@ static void uartWriteBuf(serialPort_t *instance, const void *data, int count)
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartDevice_t *uart = container_of(uartPort, uartDevice_t, port);
     const uint8_t *bytePtr = (const uint8_t*)data;
+
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
 
     // Test if checkUsartTxOutput() detected TX line being pulled low by an unpowered peripheral
     if (uart->txPinState == TX_PIN_MONITOR) {
@@ -473,6 +508,10 @@ static void uartEndWrite(serialPort_t *instance)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartDevice_t *uart = container_of(uartPort, uartDevice_t, port);
+
+    if (!uartCanWrite(uartPort)) {
+        return;
+    }
 
     // Check if the TX line is being pulled low by an unpowered peripheral
     if (uart->txPinState == TX_PIN_MONITOR) {

--- a/src/platform/STM32/serial_uart_hal.c
+++ b/src/platform/STM32/serial_uart_hal.c
@@ -48,6 +48,12 @@
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
 
+static inline bool uartCanTx(const uartPort_t *uartPort)
+{
+    const uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    return (uartPort->port.mode & MODE_TX) && uartDevice->tx.pin;
+}
+
 static void usartConfigurePinInversion(uartPort_t *uartPort)
 {
     bool inverted = uartPort->port.options & SERIAL_INVERTED;
@@ -82,6 +88,8 @@ static void uartConfigurePinSwap(uartPort_t *uartPort)
 
 void uartReconfigure(uartPort_t *uartPort)
 {
+    const bool canTx = uartCanTx(uartPort);
+
     HAL_UART_DeInit(&uartPort->Handle);
     uartPort->Handle.Init.BaudRate = uartPort->port.baudRate;
     // according to the stm32 documentation wordlen has to be 9 for parity bits
@@ -100,7 +108,7 @@ void uartReconfigure(uartPort_t *uartPort)
 
     if (uartPort->port.mode & MODE_RX)
         uartPort->Handle.Init.Mode |= UART_MODE_RX;
-    if (uartPort->port.mode & MODE_TX)
+    if (canTx)
         uartPort->Handle.Init.Mode |= UART_MODE_TX;
 
     usartConfigurePinInversion(uartPort);
@@ -171,7 +179,7 @@ void uartReconfigure(uartPort_t *uartPort)
     }
 
     // Transmit DMA or IRQ
-    if (uartPort->port.mode & MODE_TX) {
+    if (canTx) {
 #ifdef USE_DMA
         if (uartPort->txDMAResource) {
             uartPort->txDMAHandle.Instance = (DMA_ARCH_TYPE *)uartPort->txDMAResource;
@@ -263,6 +271,11 @@ void uartTxMonitor(uartPort_t *s)
 void uartTryStartTxDMA(uartPort_t *s)
 {
     ATOMIC_BLOCK(NVIC_PRIO_SERIALUART_TXDMA) {
+        if (!uartCanTx(s)) {
+            s->txDMAEmpty = true;
+            return;
+        }
+
         if (IS_DMA_ENABLED(s->txDMAResource)) {
             // DMA is already in progress
             return;
@@ -332,9 +345,14 @@ void uartDmaIrqHandler(dmaChannelDescriptor_t* descriptor)
 }
 #endif
 
+// NOSONAR cognitive complexity: this handler is a flat sequence of independent
+// USART flag-clear branches; extracting per-event helpers would add ITCM call overhead
+// for a FAST_IRQ_HANDLER and obscure the linear flag-handling structure.
 FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
 {
     UART_HandleTypeDef *huart = &s->Handle;
+    const bool canTx = uartCanTx(s);
+
     /* UART in mode Receiver ---------------------------------------------------*/
     if ((__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET)) {
         uint8_t rbyte = (uint8_t)(huart->Instance->RDR & (uint8_t) 0xff);
@@ -373,8 +391,28 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
     }
 
+    // When the port has no usable TX pin (RX-only, pinless, or half-duplex without TX),
+    // the TC flag stays asserted (TX peripheral disabled or never fed data), which
+    // would cause uartIrqHandler to re-enter continuously and starve thread-mode tasks.
+    // Disable TXE/TC interrupts and clear the residual TC flag so the IRQ stops re-firing.
+    //
+    // This clear-path is load-bearing on HAL because __HAL_UART_GET_IT(UART_IT_TC) below
+    // reads only ISR.TC (no CR1.TCIE enable-bit check), unlike LL_USART_IsEnabledIT_TC
+    // in master's LL variant which gates on both flag and enable. Without this clear,
+    // the TC branch would re-execute even after the TCIE bit is cleared. Backport of
+    // master commit 81f88b5bf (#15218).
+    //
+    // CR1 is mutated only from IRQ context at NVIC_PRIO_SERIALUART or higher elsewhere
+    // in this driver; the non-atomic RMW via CLEAR_BIT is safe at this priority level.
+    if (!canTx) {
+        CLEAR_BIT(huart->Instance->CR1, USART_CR1_TXEIE | USART_CR1_TCIE);
+        if (__HAL_UART_GET_IT(huart, UART_IT_TC)) {
+            __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
+        }
+    }
+
     // UART transmission completed
-    if ((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
+    if (canTx && (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
 
         // Switch TX to an input with pull-up so it's state can be monitored
@@ -387,7 +425,7 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
 #endif
     }
 
-    if (
+    if (canTx &&
 #ifdef USE_DMA
         !s->txDMAResource &&
 #endif

--- a/src/platform/STM32/serial_uart_hal.c
+++ b/src/platform/STM32/serial_uart_hal.c
@@ -54,6 +54,20 @@ static inline bool uartCanTx(const uartPort_t *uartPort)
     return (uartPort->port.mode & MODE_TX) && uartDevice->tx.pin;
 }
 
+// Disable every UART IT-enable bit before HAL_UART_DeInit / re-init. HAL clears
+// CR1/CR3 during DeInit, but the window between entering DeInit and that clear
+// is interruptable; a pending IRQ that fires while CR1.UE is being torn down
+// can re-enter uartIrqHandler with stale ISR flags. Pre-clearing the IT-enable
+// bits combined with the per-branch CR1/CR3 IT-enable gating in uartIrqHandler
+// closes that window. Caller must hold the NVIC line for this UART disabled.
+static inline void uartDisableIrqSources(uartPort_t *uartPort)
+{
+    CLEAR_BIT(uartPort->USARTx->CR1,
+              USART_CR1_PEIE | USART_CR1_RXNEIE | USART_CR1_IDLEIE |
+              USART_CR1_TXEIE | USART_CR1_TCIE);
+    CLEAR_BIT(uartPort->USARTx->CR3, USART_CR3_EIE);
+}
+
 static void usartConfigurePinInversion(uartPort_t *uartPort)
 {
     bool inverted = uartPort->port.options & SERIAL_INVERTED;
@@ -88,7 +102,20 @@ static void uartConfigurePinSwap(uartPort_t *uartPort)
 
 void uartReconfigure(uartPort_t *uartPort)
 {
+    const uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
+    const IRQn_Type irqn = (IRQn_Type)uartDevice->hardware->irqn;
+    const bool irqWasEnabled = NVIC_GetEnableIRQ(irqn) != 0;
     const bool canTx = uartCanTx(uartPort);
+
+    // Quiesce the UART IRQ line before tearing down the peripheral. HAL_UART_DeInit
+    // clears CR1.UE early but leaves the IT-enable bits set for a few instructions;
+    // a UART IRQ taken during that window with stale TXE/TC ISR flags is what
+    // causes the reconfigure-time freeze on H7 + real GPS (see #15218 follow-up).
+    HAL_NVIC_DisableIRQ(irqn);
+    uartDisableIrqSources(uartPort);
+    HAL_NVIC_ClearPendingIRQ(irqn);
+    __DSB();
+    __ISB();
 
     HAL_UART_DeInit(&uartPort->Handle);
     uartPort->Handle.Init.BaudRate = uartPort->port.baudRate;
@@ -222,7 +249,11 @@ void uartReconfigure(uartPort_t *uartPort)
             SET_BIT(uartPort->USARTx->CR1, USART_CR1_TCIE);
         }
     }
-    return;
+
+    if (irqWasEnabled) {
+        HAL_NVIC_ClearPendingIRQ(irqn);
+        HAL_NVIC_EnableIRQ(irqn);
+    }
 }
 
 bool checkUsartTxOutput(uartPort_t *s)
@@ -348,13 +379,24 @@ void uartDmaIrqHandler(dmaChannelDescriptor_t* descriptor)
 // NOSONAR cognitive complexity: this handler is a flat sequence of independent
 // USART flag-clear branches; extracting per-event helpers would add ITCM call overhead
 // for a FAST_IRQ_HANDLER and obscure the linear flag-handling structure.
+//
+// Every branch is double-gated: the cached cr1/cr3 IT-enable bits AND the ISR flag.
+// HAL's __HAL_UART_GET_IT reads only the ISR (no enable-bit check), unlike master's
+// LL handler which uses LL_USART_IsEnabledIT_* + LL_USART_IsActiveFlag_*. Without
+// the explicit cr1/cr3 gate, an IRQ taken with stale ISR flags after the IT-enable
+// bits are cleared (e.g. mid-reconfigure on a port with valid TX pin) re-fires the
+// branch and storms the handler. Caching cr1/cr3 at entry preserves the original
+// behaviour where the RXNE path disables PEIE/EIE for subsequent IRQs without
+// affecting flag-handling on the current invocation.
 FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
 {
     UART_HandleTypeDef *huart = &s->Handle;
     const bool canTx = uartCanTx(s);
+    const uint32_t cr1 = huart->Instance->CR1;
+    const uint32_t cr3 = huart->Instance->CR3;
 
     /* UART in mode Receiver ---------------------------------------------------*/
-    if ((__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET)) {
+    if ((cr1 & USART_CR1_RXNEIE) && (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET)) {
         uint8_t rbyte = (uint8_t)(huart->Instance->RDR & (uint8_t) 0xff);
 
         if (s->port.rxCallback) {
@@ -372,38 +414,30 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
     }
 
     /* UART parity error interrupt occurred -------------------------------------*/
-    if ((__HAL_UART_GET_IT(huart, UART_IT_PE) != RESET)) {
+    if ((cr1 & USART_CR1_PEIE) && (__HAL_UART_GET_IT(huart, UART_IT_PE) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_PEF);
     }
 
     /* UART frame error interrupt occurred --------------------------------------*/
-    if ((__HAL_UART_GET_IT(huart, UART_IT_FE) != RESET)) {
+    if ((cr3 & USART_CR3_EIE) && (__HAL_UART_GET_IT(huart, UART_IT_FE) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_FEF);
     }
 
     /* UART noise error interrupt occurred --------------------------------------*/
-    if ((__HAL_UART_GET_IT(huart, UART_IT_NE) != RESET)) {
+    if ((cr3 & USART_CR3_EIE) && (__HAL_UART_GET_IT(huart, UART_IT_NE) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_NEF);
     }
 
     /* UART Over-Run interrupt occurred -----------------------------------------*/
-    if ((__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET)) {
+    if ((cr3 & USART_CR3_EIE) && (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
     }
 
-    // When the port has no usable TX pin (RX-only, pinless, or half-duplex without TX),
-    // the TC flag stays asserted (TX peripheral disabled or never fed data), which
-    // would cause uartIrqHandler to re-enter continuously and starve thread-mode tasks.
-    // Disable TXE/TC interrupts and clear the residual TC flag so the IRQ stops re-firing.
-    //
-    // This clear-path is load-bearing on HAL because __HAL_UART_GET_IT(UART_IT_TC) below
-    // reads only ISR.TC (no CR1.TCIE enable-bit check), unlike LL_USART_IsEnabledIT_TC
-    // in master's LL variant which gates on both flag and enable. Without this clear,
-    // the TC branch would re-execute even after the TCIE bit is cleared. Backport of
-    // master commit 81f88b5bf (#15218).
-    //
-    // CR1 is mutated only from IRQ context at NVIC_PRIO_SERIALUART or higher elsewhere
-    // in this driver; the non-atomic RMW via CLEAR_BIT is safe at this priority level.
+    // Pinless / RX-only / half-duplex-without-TX defence-in-depth: TC stays asserted
+    // when the TX peripheral never sends, and the per-branch TCIE gate alone won't
+    // catch a port that was opened with canTx==false but somehow has TCIE set in
+    // cached cr1 (race against another writer). Clearing TXEIE/TCIE here is
+    // idempotent and ensures the storm cannot re-arm.
     if (!canTx) {
         CLEAR_BIT(huart->Instance->CR1, USART_CR1_TXEIE | USART_CR1_TCIE);
         if (__HAL_UART_GET_IT(huart, UART_IT_TC)) {
@@ -412,7 +446,7 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
     }
 
     // UART transmission completed
-    if (canTx && (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
+    if (canTx && (cr1 & USART_CR1_TCIE) && (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
 
         // Switch TX to an input with pull-up so it's state can be monitored
@@ -429,6 +463,7 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
 #ifdef USE_DMA
         !s->txDMAResource &&
 #endif
+        (cr1 & USART_CR1_TXEIE) &&
         (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET)) {
         /* Check that a Tx process is ongoing */
         if (s->port.txBufferTail == s->port.txBufferHead) {
@@ -445,8 +480,7 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
     }
 
     // UART reception idle detected
-
-    if (__HAL_UART_GET_IT(huart, UART_IT_IDLE)) {
+    if ((cr1 & USART_CR1_IDLEIE) && __HAL_UART_GET_IT(huart, UART_IT_IDLE)) {
         if (s->port.idleCallback) {
             s->port.idleCallback();
         }


### PR DESCRIPTION
## Summary

Backport of master commit `81f88b5bf` ([#15218](https://github.com/betaflight/betaflight/pull/15218)) onto the `2025.12-maintenance` line. Fixes a UART interrupt-storm freeze that occurs when a UART is configured for GPS but no module is connected: after ~4–6 hours the flight controller becomes unresponsive (OSD stops updating, control is lost, only a power cycle recovers).

**Update (post-review by @kedeng):** the original backport only addressed the pinless / no-TX case. A second freeze mechanism — a reconfigure-window IRQ race on ports with valid TX/RX pins — was reproduced by @kedeng (GDB on STM32H743 + UART8 + real UBLOX GPS) and is now also fixed in this PR. See [Expanded scope](#expanded-scope-reconfigure-window-irq-race) below.

## Field report

Reproduced by reporter on **CHAMP_H743, HDZero HALO FC, Matek H743 FC, and SpeedyBee F7 V3** — all H7/F7 targets. Static bench test with USB power only and no GPS module attached freezes in the same time window. Disabling GPS or disabling the configured GPS UART eliminates the freeze.

## Root cause

With no TX pin populated, the STM32 USART `TC` flag stays asserted (transmitter idle, no data ever queued). `uartIrqHandler` re-enters continuously and starves thread-mode tasks (`SERIAL` / `OSD` / `MSP`). GPS baud-rate scanning calls `uartSetBaudRate` every ~2.5 s, repeatedly arming `TXEIE`/`TCIE` on the pinless port — explains the slow-accumulating state corruption that surfaces as a hang after several hours rather than immediately.

Gyro EXTI runs at NVIC priority (0,0) and preempts UART at (1,2), so the PID loop survives — consistent with the report of "OSD/control die, FC keeps stabilising" right up to the point of total unresponsiveness.

## What this PR does

Mirrors the master fix structurally, but the platform half is hand-translated because master's `src/platform/STM32/serial_uart_ll.c` does not exist on this branch (LL UART migration #15035 is master-only). The HAL equivalent lives in `serial_uart_hal.c`.

### `src/main/drivers/serial_uart.c` (cross-platform driver)

- `uartSanitizeMode()` clamps `MODE_TX` / `MODE_RX` off when the corresponding pin is absent, preserving `MODE_RX` on `SERIAL_BIDIR` half-duplex configurations where TX doubles as RX (SmartAudio, SmartPort, inverted SBus).
- Applied at `uartOpen` / `uartSetBaudRate` / `uartSetMode`.
- `uartCanWrite()` guards `uartWrite` / `uartBeginWrite` / `uartWriteBuf` / `uartEndWrite`.

### `src/platform/STM32/serial_uart_hal.c` (F7 / G4 / H7)

- `uartCanTx()` helper gates `uartReconfigure()` (Init.Mode + TX-DMA/IRQ block), `uartTryStartTxDMA()` (early-return with `txDMAEmpty=true`), and `uartIrqHandler()` (TC + TXE branches).
- `!canTx` clear-path in the IRQ handler disables `TXEIE`/`TCIE` and clears the residual `TC` flag (defense-in-depth, kept after the kedeng-review expansion below).

### HAL vs LL asymmetry — important note for reviewers

Master's LL `uartIrqHandler` gates the TC branch on **both** `LL_USART_IsActiveFlag_TC` **and** `LL_USART_IsEnabledIT_TC` (flag + enable bit). The HAL macro `__HAL_UART_GET_IT(UART_IT_TC)` reads only ISR.TC — there is no enable-bit check (see `stm32xxxx_hal_uart.h`). The original backport relied on the `!canTx` clear-path to work around this asymmetry. The expansion below extends the workaround to the whole IRQ handler, mirroring how master's LL handler gates every branch.

## Expanded scope: reconfigure-window IRQ race

**Reported by @kedeng** with GDB evidence on STM32H743 + UART8 + a real UBLOX GPS module attached (valid TX/RX pins, so `canTx == true`).

### Mechanism

1. GPS baud-rate scanning calls `serialSetBaudRate()` → `uartSetBaudRate()` → `uartReconfigure()` periodically.
2. `uartReconfigure()` calls `HAL_UART_DeInit()`, which clears `CR1.UE` early but leaves `TXEIE`/`TCIE`/`RXNEIE`/etc. set for several instructions while it walks state.
3. A pending UART IRQ taken in that window re-enters `uartIrqHandler()` with stale ISR flags.
4. HAL `__HAL_UART_GET_IT()` reads only the ISR flag, no enable-bit gating — so the branch executes despite the peripheral being mid-deinit. The IRQ storms until the reconfigure finishes.

This is the same LL/HAL asymmetry the `!canTx` clear-path was already a workaround for, but the workaround was scoped only to the TC branch.

### Fix

Mirror master's LL gating idiom at the HAL layer in two places:

**`uartReconfigure()`** — close the deinit window:

- Capture `irqn = uartDevice->hardware->irqn` and `irqWasEnabled = NVIC_GetEnableIRQ(irqn)` at entry.
- New helper `uartDisableIrqSources()` clears `CR1.{PEIE,RXNEIE,IDLEIE,TXEIE,TCIE}` and `CR3.EIE`.
- Before `HAL_UART_DeInit()`: `HAL_NVIC_DisableIRQ(irqn)` → `uartDisableIrqSources()` → `HAL_NVIC_ClearPendingIRQ(irqn)` → `__DSB()` + `__ISB()`. The DSB/ISB pair guarantees the IT-enable clears retire and any pipelined IRQ entry is squashed before DeInit begins.
- After all reconfigure work: if `irqWasEnabled`, `HAL_NVIC_ClearPendingIRQ` + `HAL_NVIC_EnableIRQ` to restore the line.

**`uartIrqHandler()`** — match master's LL per-branch IT-enable gating:

- Cache `cr1 = huart->Instance->CR1` and `cr3 = huart->Instance->CR3` at entry.
- Gate every `__HAL_UART_GET_IT(...)` branch on the matching IT-enable bit from the cached CR1/CR3:
  - RXNE → `cr1 & USART_CR1_RXNEIE`
  - PE → `cr1 & USART_CR1_PEIE`
  - FE / NE / ORE → `cr3 & USART_CR3_EIE`
  - TC → `cr1 & USART_CR1_TCIE` (in addition to existing `canTx` gate)
  - TXE → `cr1 & USART_CR1_TXEIE` (in addition to existing `canTx` gate)
  - IDLE → `cr1 & USART_CR1_IDLEIE`

Caching at top preserves the original semantic where the RXNE path's clear of `PEIE`/`EIE` affects only **subsequent** IRQ invocations, not the current one.

The pre-existing `!canTx` clear-path is retained as defense-in-depth.

## Scope

- **Affected**: F7, G4, H7 (HAL UART driver).
- **F4 / APM32 / AT32**: pick up the cross-platform writer guards and mode-sanitization passively. Their per-platform IRQ handlers are not modified — matches master scope (those platforms use stdperiph-style `USART_GetITStatus()` / `usart_flag_get()` which already gate on enable+flag, so they don't have the storm mechanism).
- **STM32H5**: not a valid `TARGET=` on 2025.12 (H5 UART driver landed in master via #15068 after the branch point). Out of scope.

## Build verification (local)

| Target | Result | text (before → after expansion) |
|--------|--------|---|
| `make test` | PASS | — |
| STM32H743 | PASS | 629053 → 629549 (+496 B) |
| STM32H723 | PASS | 629017 → 629553 (+536 B) |
| STM32F7X2 | PASS | 452707 → 452931 (+224 B) |
| STM32G47X | PASS | 432600 → 432856 (+256 B) |
| STM32F405 | PASS | 582852 (unchanged — no path through `serial_uart_hal.c`) |

## Test plan

- [ ] **Bench reproduction (primary, pinless)**: CHAMP_H743 or equivalent H7 board; `serial X 2 ...` to assign a UART for GPS; `feature GPS`; `set gps_provider = UBLOX`; no module connected; USB power only. Run 8 hours (2× reporter's reproduction window). FC should remain responsive (CLI returns within 100 ms, `tasks` shows `SERIAL`/`OSD` Late counters at 0 or low single digits).
- [ ] **Working-case regression**: same target, real UBLOX GPS attached — normal fix acquisition, GPS tab populates.
- [ ] **MSP DisplayPort regression**: HDZero / DJI / Walksnail on a TX-capable UART (one H7 + one F7) — OSD elements render and update.
- [ ] **ESC serial passthrough**: `serialpassthrough esc_sensor` connects to BLHeli/AM32 (motors removed).
- [ ] **GPS passthrough**: `gpspassthrough` with real GPS — UBX traffic visible.
- [ ] **`serialpassthrough` on pinless TX**: invoking with `tx` mode on a UART with no TX pin returns cleanly to CLI (silent no-op — documented behaviour change).
- [ ] **H7 + DMA TX dormancy**: with DMA TX enabled and pinless TX, `s->txDMAEmpty` stays true and `HAL_UART_Transmit_DMA` is not invoked.
- [ ] **Reconfigure-window storm reproduction (post-kedeng-review)**: instrument `uartReconfigure()` to inject a forced UART IRQ between `uartDisableIrqSources()` and `HAL_UART_DeInit()` clearing CR1. Confirm `uartIrqHandler` enters with `cr1 == 0` and exits without taking any branch (all gating predicates short-circuit on `cr1==0`/`cr3==0`).
- [ ] **kedeng reproduction case (post-kedeng-review)**: STM32H743 + UART8 + real UBLOX GPS attached with valid TX/RX pins. After 8 hours bench idle with periodic baud-scan churn (e.g. cycle `set gps_provider` between UBLOX and NMEA via CLI every 30 s), CLI remains responsive and no UART IRQ counter shows continuous firing.

## Release notes

For `2025.12.3`:

> Fixes a UART interrupt storm that could cause the flight controller to freeze (loss of OSD and control) after several hours when GPS is enabled but no GPS module is connected on F7 / G4 / H7 targets. Affects any FC where a UART is configured for GPS (`serial X 2 ...`, `feature GPS`) but the GPS module is absent or disconnected. The freeze is a flight-safety issue: a multirotor armed in this configuration may become unresponsive in flight. Recommended for all users running 2025.12.x.
>
> Also fixes a related freeze on H7/F7/G4 boards with a real GPS module connected that could be triggered during GPS baud-rate scanning, by closing a window in `HAL_UART_DeInit()` where stale UART interrupt flags could storm the IRQ handler (reported by @kedeng).
>
> Behavioural change: `serialpassthrough` invoked with `tx` mode on a UART resource with no TX pin assigned now silently drops outgoing bytes instead of triggering the interrupt storm. If a passthrough session appears to work but the remote endpoint sees nothing, verify the UART has a TX pin via `resource show`.

## References

- Master PR: betaflight/betaflight#15218 (`81f88b5bf`)
- Related master commit: #15035 (HAL → LL UART migration; explains why this is a translation backport, not a clean cherry-pick)
- Follow-up review: @kedeng's reconfigure-window analysis ([comment in this PR](https://github.com/betaflight/betaflight/pull/15258#issuecomment-4552145819))
