### PR TITLE
fix(common): guard atoi() with PLATFORM_NO_LIBC

### DIFF
--- a/src/main/common/strtol.c
+++ b/src/main/common/strtol.c
@@ -128,9 +128,9 @@ unsigned long strtoul(const char * str, char ** endptr, int base)
 {
     return _strto_l(str, endptr, base, 0);
 }
-#endif
 
 int atoi(const char *str)
 {
     return strtol(str, NULL, 10);
 }
+#endif


### PR DESCRIPTION
atoi() sat outside the PLATFORM_NO_LIBC guard, so it was defined on targets whose libc already provides it. Move the #endif past atoi() to share the same gate as strtol() and strtoul().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized platform-specific code compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->