### PR TITLE
fix(accgyro): IIM-42652 FSR/AAF + restore IIM-42653 AAF placement

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -32,6 +32,7 @@
 
 #include "common/axis.h"
 #include "common/utils.h"
+#include "build/build_config.h"
 #include "build/debug.h"
 
 #include "drivers/accgyro/accgyro.h"
@@ -300,7 +301,7 @@ uint8_t icm426xxSpiDetect(const extDevice_t *dev)
     } while (attemptsRemaining--);
 
 #if defined(USE_GYRO_CLKIN)
-    // IMM42652/53 also support external clock but it's not currently tested and may require different handling, so only enable for 42688P for now.
+    // IIM42652/53 also support external clock but it's not currently tested and may require different handling, so only enable for 42688P for now.
     if (icmDetected == ICM_42688P_SPI) {
         icm426xxEnableExternalClock(dev);
     }
@@ -314,7 +315,6 @@ void icm426xxAccInit(accDev_t *acc)
 {
     switch (acc->mpuDetectionResult.sensor) {
     case IIM_42653_SPI:
-    case IIM_42652_SPI:
 #if ENABLE_42686_EXTENDED_RANGE
     case ICM_42686P_SPI:
 #endif
@@ -323,6 +323,7 @@ void icm426xxAccInit(accDev_t *acc)
 #if !ENABLE_42686_EXTENDED_RANGE
     case ICM_42686P_SPI:
 #endif
+    case IIM_42652_SPI:
     default:
         acc->acc_1G = 512 * 4; // Accel scale 16g (2048 LSB/g)
         break;
@@ -349,7 +350,7 @@ bool icm426xxSpiAccDetect(accDev_t *acc)
     return true;
 }
 
-static aafConfig_t getGyroAafConfig(const mpuSensor_e, const aafConfig_e);
+STATIC_UNIT_TESTED aafConfig_t getGyroAafConfig(const mpuSensor_e, const aafConfig_e);
 
 static void turnGyroAccOff(const extDevice_t *dev)
 {
@@ -434,13 +435,13 @@ void icm426xxGyroInit(gyroDev_t *gyro)
     // Set the gyro/accel full-scale range (FSR) and output data rate (ODR).
     //
     // FS_SEL mapping per variant (GYRO_FS_SEL / ACCEL_FS_SEL bits [7:5]):
-    //   ICM-42605/ICM-42622P/ICM-42688-P: FS_SEL=0 → ±2000DPS / ±16G (max)
-    //   ICM-42686-P:                      FS_SEL=0 → ±4000DPS / ±32G, FS_SEL=1 → ±2000DPS / ±16G
-    //   IIM-42652/IIM-42653:              FS_SEL=0 → ±4000DPS / ±32G (max)
+    //   ICM-42605/ICM-42622P/ICM-42688-P/IIM-42652: FS_SEL=0 → ±2000DPS / ±16G (max)
+    //   ICM-42686-P:                                FS_SEL=0 → ±4000DPS / ±32G, FS_SEL=1 → ±2000DPS / ±16G
+    //   IIM-42653:                                  FS_SEL=0 → ±4000DPS / ±32G (max)
     //
-    // ICM-42605/ICM-42622P/ICM-42688-P use FS_SEL=0 for ±2000DPS / ±16G.
+    // IIM-42652 is the industrial variant of the ICM-42688-P and shares its ±2000DPS / ±16G silicon max range.
     // ICM-42686-P requires FS_SEL=1 for ±2000DPS / ±16G (FS_SEL=0 is its extended ±4000DPS / ±32G range).
-    // IIM-42652/IIM-42653 use FS_SEL=0 for their native ±4000DPS / ±32G range.
+    // IIM-42653 uses FS_SEL=0 for its native ±4000DPS / ±32G range.
 
     uint8_t fsSel = 0;
     if (gyro->mpuDetectionResult.sensor == ICM_42686P_SPI) {
@@ -451,8 +452,8 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 #endif
     }
     // All other variants use FS_SEL=0:
-    //   ICM-42605/ICM-42622P/ICM-42688-P → ±2000DPS / ±16G
-    //   IIM-42652/IIM-42653              → ±4000DPS / ±32G
+    //   ICM-42605/ICM-42622P/ICM-42688-P/IIM-42652 → ±2000DPS / ±16G
+    //   IIM-42653                                  → ±4000DPS / ±32G
 
     spiWriteReg(dev, ICM426XX_RA_GYRO_CONFIG0, (fsSel << 5) | (odrConfig & 0x0F));
     delay(15);
@@ -470,8 +471,9 @@ bool icm426xxSpiGyroDetect(gyroDev_t *gyro)
     case ICM_42686P_SPI:
 #endif
     case ICM_42688P_SPI:
+    case IIM_42652_SPI:
         gyro->scale = GYRO_SCALE_2000DPS;
-        // ICM-42605/ICM-42622P/ICM-42686P/ICM-42688P: 132.48 LSB/°C for 16-bit register read, offset 25°C
+        // ICM-42605/ICM-42622P/ICM-42686P/ICM-42688P/IIM-42652: 132.48 LSB/°C for 16-bit register read, offset 25°C
         gyro->tempScale = 1.0f / 132.48f;
         gyro->tempZero = 25.0f;
         break;
@@ -479,10 +481,9 @@ bool icm426xxSpiGyroDetect(gyroDev_t *gyro)
 #if ENABLE_42686_EXTENDED_RANGE
     case ICM_42686P_SPI:
 #endif
-    case IIM_42652_SPI:
     case IIM_42653_SPI:
         gyro->scale = GYRO_SCALE_4000DPS;
-        // ICM-42686P (extended range) / IIM-42652 / IIM-42653: 132.48 LSB/°C, offset 25°C
+        // ICM-42686P (extended range) / IIM-42653: 132.48 LSB/°C, offset 25°C
         gyro->tempScale = 1.0f / 132.48f;
         gyro->tempZero = 25.0f;
         break;
@@ -496,12 +497,10 @@ bool icm426xxSpiGyroDetect(gyroDev_t *gyro)
     return true;
 }
 
-static aafConfig_t getGyroAafConfig(const mpuSensor_e gyroModel, const aafConfig_e config)
+STATIC_UNIT_TESTED aafConfig_t getGyroAafConfig(const mpuSensor_e gyroModel, const aafConfig_e config)
 {
     switch (gyroModel){
     case ICM_42605_SPI:
-    case IIM_42652_SPI:
-    case IIM_42653_SPI:
         switch (config) {
         case GYRO_HARDWARE_LPF_NORMAL:
             return aafLUT42605[AAF_CONFIG_258HZ];
@@ -515,6 +514,8 @@ static aafConfig_t getGyroAafConfig(const mpuSensor_e gyroModel, const aafConfig
     case ICM_42622P_SPI:
     case ICM_42686P_SPI:
     case ICM_42688P_SPI:
+    case IIM_42652_SPI:
+    case IIM_42653_SPI:
     default:
         switch (config) {
         case GYRO_HARDWARE_LPF_NORMAL:

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -95,6 +95,17 @@ baro_ms5611_unittest_DEFINES := \
                 USE_BARO_MS5611= \
                 USE_BARO_SPI_MS5611=
 
+accgyro_spi_icm426xx_unittest_SRC := \
+		$(USER_DIR)/drivers/accgyro/accgyro_spi_icm426xx.c
+
+accgyro_spi_icm426xx_unittest_DEFINES := \
+                USE_GYRO_SPI_ICM42605= \
+                USE_ACCGYRO_ICM42622P= \
+                USE_ACCGYRO_ICM42686P= \
+                USE_GYRO_SPI_ICM42688P= \
+                USE_ACCGYRO_IIM42652= \
+                USE_ACCGYRO_IIM42653=
+
 # This test is disabled due to build errors.
 # Its source code is archived in unit/battery_unittest.cc.txt
 #

--- a/src/test/unit/accgyro_spi_icm426xx_unittest.cc
+++ b/src/test/unit/accgyro_spi_icm426xx_unittest.cc
@@ -1,0 +1,277 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Betaflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+extern "C" {
+
+#include "platform.h"
+#include "target.h"
+#include "build/build_config.h"
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/bus.h"
+#include "drivers/sensor.h"
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+#include "sensors/gyro.h"
+
+PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+
+bool icm426xxSpiGyroDetect(gyroDev_t *gyro);
+bool icm426xxSpiAccDetect(accDev_t *acc);
+void icm426xxAccInit(accDev_t *acc);
+
+// MUST mirror the file-static definitions in src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+// (search for `typedef struct aafConfig_s` and `typedef enum { AAF_CONFIG_258HZ`).
+// If the driver's struct fields are reordered or resized, the static_assert below fails loudly;
+// a silent field-order drift would otherwise corrupt cfg.delt reads in the AAF tests.
+typedef struct aafConfig_s {
+    uint8_t delt;
+    uint16_t deltSqr;
+    uint8_t bitshift;
+} aafConfig_t;
+
+typedef enum {
+    AAF_CONFIG_258HZ = 0,
+    AAF_CONFIG_536HZ,
+    AAF_CONFIG_997HZ,
+    AAF_CONFIG_1962HZ,
+    AAF_CONFIG_COUNT
+} aafConfig_e;
+
+static_assert(offsetof(aafConfig_t, delt) == 0,
+              "aafConfig_t layout has drifted from the driver TU — update the local mirror above");
+static_assert(offsetof(aafConfig_t, deltSqr) == 2,
+              "aafConfig_t layout has drifted from the driver TU — update the local mirror above");
+static_assert(offsetof(aafConfig_t, bitshift) == 4,
+              "aafConfig_t layout has drifted from the driver TU — update the local mirror above");
+
+STATIC_UNIT_TESTED aafConfig_t getGyroAafConfig(const mpuSensor_e gyroModel, const aafConfig_e config);
+
+} // extern "C"
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// Expected per-sensor delt for static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL) (258 Hz):
+// aafLUT42605[AAF_CONFIG_258HZ] = { 21, 440, 6 } -- ICM_42605_SPI only
+// aafLUT42688[AAF_CONFIG_258HZ] = {  6,  36, 10 } -- all other ICM-426xx family chips
+static constexpr uint8_t AAF_DELT_42605_NORMAL = 21;
+static constexpr uint8_t AAF_DELT_42688_NORMAL = 6;
+
+// --- icm426xxSpiGyroDetect: gyro->scale per sensor ---------------------------
+
+TEST(AccgyroSpiIcm426xx, GyroScaleIcm42605)
+{
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = ICM_42605_SPI;
+    EXPECT_TRUE(icm426xxSpiGyroDetect(&gyro));
+    EXPECT_FLOAT_EQ(GYRO_SCALE_2000DPS, gyro.scale);
+}
+
+TEST(AccgyroSpiIcm426xx, GyroScaleIcm42622P)
+{
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = ICM_42622P_SPI;
+    EXPECT_TRUE(icm426xxSpiGyroDetect(&gyro));
+    EXPECT_FLOAT_EQ(GYRO_SCALE_2000DPS, gyro.scale);
+}
+
+TEST(AccgyroSpiIcm426xx, GyroScaleIcm42686P)
+{
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = ICM_42686P_SPI;
+    EXPECT_TRUE(icm426xxSpiGyroDetect(&gyro));
+#if ENABLE_42686_EXTENDED_RANGE
+    EXPECT_FLOAT_EQ(GYRO_SCALE_4000DPS, gyro.scale);
+#else
+    EXPECT_FLOAT_EQ(GYRO_SCALE_2000DPS, gyro.scale);
+#endif
+}
+
+TEST(AccgyroSpiIcm426xx, GyroScaleIcm42688P)
+{
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = ICM_42688P_SPI;
+    EXPECT_TRUE(icm426xxSpiGyroDetect(&gyro));
+    EXPECT_FLOAT_EQ(GYRO_SCALE_2000DPS, gyro.scale);
+}
+
+TEST(AccgyroSpiIcm426xx, GyroScaleIim42652)
+{
+    // Regression guard: IIM-42652 silicon max FSR is ±2000 dps, not ±4000 dps.
+    // Pre-fix code (PR #14424) incorrectly mapped IIM_42652_SPI to GYRO_SCALE_4000DPS.
+    // Also assert tempScale/tempZero so a future refactor that drops IIM_42652
+    // out of the 2000DPS arm (and therefore out of the temperature-init block)
+    // is caught here rather than silently producing zero-init temperature values.
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = IIM_42652_SPI;
+    EXPECT_TRUE(icm426xxSpiGyroDetect(&gyro));
+    EXPECT_FLOAT_EQ(GYRO_SCALE_2000DPS, gyro.scale);
+    EXPECT_FLOAT_EQ(1.0f / 132.48f, gyro.tempScale);
+    EXPECT_FLOAT_EQ(25.0f, gyro.tempZero);
+}
+
+TEST(AccgyroSpiIcm426xx, GyroScaleIim42653)
+{
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = IIM_42653_SPI;
+    EXPECT_TRUE(icm426xxSpiGyroDetect(&gyro));
+    EXPECT_FLOAT_EQ(GYRO_SCALE_4000DPS, gyro.scale);
+}
+
+TEST(AccgyroSpiIcm426xx, GyroScaleUnknownSensorRejected)
+{
+    gyroDev_t gyro = {};
+    gyro.mpuDetectionResult.sensor = MPU_NONE;
+    EXPECT_FALSE(icm426xxSpiGyroDetect(&gyro));
+}
+
+// --- icm426xxAccInit: acc->acc_1G per sensor ---------------------------------
+
+TEST(AccgyroSpiIcm426xx, AccOneGIcm42605)
+{
+    accDev_t acc = {};
+    acc.mpuDetectionResult.sensor = ICM_42605_SPI;
+    icm426xxAccInit(&acc);
+    EXPECT_EQ(512u * 4u, acc.acc_1G); // ±16g
+}
+
+TEST(AccgyroSpiIcm426xx, AccOneGIcm42622P)
+{
+    accDev_t acc = {};
+    acc.mpuDetectionResult.sensor = ICM_42622P_SPI;
+    icm426xxAccInit(&acc);
+    EXPECT_EQ(512u * 4u, acc.acc_1G); // ±16g
+}
+
+TEST(AccgyroSpiIcm426xx, AccOneGIcm42686P)
+{
+    accDev_t acc = {};
+    acc.mpuDetectionResult.sensor = ICM_42686P_SPI;
+    icm426xxAccInit(&acc);
+#if ENABLE_42686_EXTENDED_RANGE
+    EXPECT_EQ(512u * 2u, acc.acc_1G); // ±32g
+#else
+    EXPECT_EQ(512u * 4u, acc.acc_1G); // ±16g
+#endif
+}
+
+TEST(AccgyroSpiIcm426xx, AccOneGIcm42688P)
+{
+    accDev_t acc = {};
+    acc.mpuDetectionResult.sensor = ICM_42688P_SPI;
+    icm426xxAccInit(&acc);
+    EXPECT_EQ(512u * 4u, acc.acc_1G); // ±16g
+}
+
+TEST(AccgyroSpiIcm426xx, AccOneGIim42652)
+{
+    // Regression guard: IIM-42652 silicon max FSR is ±16g, not ±32g.
+    // Pre-fix code (PR #14424) incorrectly mapped IIM_42652_SPI to the 32g (acc_1G = 1024) arm.
+    accDev_t acc = {};
+    acc.mpuDetectionResult.sensor = IIM_42652_SPI;
+    icm426xxAccInit(&acc);
+    EXPECT_EQ(512u * 4u, acc.acc_1G); // ±16g
+}
+
+TEST(AccgyroSpiIcm426xx, AccOneGIim42653)
+{
+    accDev_t acc = {};
+    acc.mpuDetectionResult.sensor = IIM_42653_SPI;
+    icm426xxAccInit(&acc);
+    EXPECT_EQ(512u * 2u, acc.acc_1G); // ±32g
+}
+
+// --- getGyroAafConfig: NORMAL cutoff delt per sensor -------------------------
+
+TEST(AccgyroSpiIcm426xx, AafNormalIcm42605)
+{
+    const aafConfig_t cfg = getGyroAafConfig(ICM_42605_SPI, static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL));
+    EXPECT_EQ(AAF_DELT_42605_NORMAL, cfg.delt);
+}
+
+TEST(AccgyroSpiIcm426xx, AafNormalIcm42622P)
+{
+    const aafConfig_t cfg = getGyroAafConfig(ICM_42622P_SPI, static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL));
+    EXPECT_EQ(AAF_DELT_42688_NORMAL, cfg.delt);
+}
+
+TEST(AccgyroSpiIcm426xx, AafNormalIcm42686P)
+{
+    const aafConfig_t cfg = getGyroAafConfig(ICM_42686P_SPI, static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL));
+    EXPECT_EQ(AAF_DELT_42688_NORMAL, cfg.delt);
+}
+
+TEST(AccgyroSpiIcm426xx, AafNormalIcm42688P)
+{
+    const aafConfig_t cfg = getGyroAafConfig(ICM_42688P_SPI, static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL));
+    EXPECT_EQ(AAF_DELT_42688_NORMAL, cfg.delt);
+}
+
+TEST(AccgyroSpiIcm426xx, AafNormalIim42652)
+{
+    // Regression guard: IIM-42652 AAF block is the industrial 42688-P IP, must use aafLUT42688.
+    // Pre-fix code (PR #14424) incorrectly mapped IIM_42652_SPI to aafLUT42605 (cutoff ~249 Hz instead of ~258 Hz).
+    const aafConfig_t cfg = getGyroAafConfig(IIM_42652_SPI, static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL));
+    EXPECT_EQ(AAF_DELT_42688_NORMAL, cfg.delt);
+}
+
+TEST(AccgyroSpiIcm426xx, AafNormalIim42653)
+{
+    // Regression guard: PR #14095 originally placed IIM_42653_SPI on aafLUT42688; PR #14424 silently
+    // moved it to aafLUT42605. Restore the original placement to match the 42653 datasheet AAF block.
+    const aafConfig_t cfg = getGyroAafConfig(IIM_42653_SPI, static_cast<aafConfig_e>(GYRO_HARDWARE_LPF_NORMAL));
+    EXPECT_EQ(AAF_DELT_42688_NORMAL, cfg.delt);
+}
+
+// --- STUBS for SPI / IO / MPU symbols pulled in by the driver TU -------------
+
+extern "C" {
+
+void delay(uint32_t) {}
+
+void spiSetClkDivisor(const extDevice_t *, uint16_t) {}
+
+uint16_t spiCalculateDivider(uint32_t)
+{
+    return 2;
+}
+
+void spiWriteReg(const extDevice_t *, uint8_t, uint8_t) {}
+
+uint8_t spiReadRegMsk(const extDevice_t *, uint8_t)
+{
+    // Drives the WHO_AM_I detection loop in icm426xxSpiDetect (not exercised by these tests);
+    // returning 0 is harmless because the tests never call icm426xxSpiDetect.
+    return 0;
+}
+
+void mpuGyroInit(gyroDev_t *) {}
+
+bool mpuGyroReadSPI(gyroDev_t *)
+{
+    return false;
+}
+
+bool mpuAccReadSPI(accDev_t *)
+{
+    return false;
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary
- **IIM-42652**: corrects gyro full-scale range (±4000 DPS → silicon-correct ±2000 DPS) and accel range (±32 g → ±16 g), and moves the AAF LUT from `aafLUT42605` to `aafLUT42688` (IIM-42652 is the industrial variant of the ICM-42688-P and shares its AAF block). Field-tested.
- **IIM-42653**: restores the AAF LUT placement to `aafLUT42688` (PR #14095 placement). PR #14424 silently moved it to `aafLUT42605` alongside the new IIM-42652 entry — this PR partial-reverts that side effect. Gyro/accel FSR unchanged (still ±4000 / ±32).
- Adds `src/test/unit/accgyro_spi_icm426xx_unittest.cc` (19 Google Test cases pinning per-sensor `gyro->scale`, `acc->acc_1G`, and `getGyroAafConfig(...).delt` for all six ICM-426xx family chips) with `offsetof` `static_assert`s guarding the file-static type mirror against silent layout drift.
- Drive-by fixes in the same file: `IMM42652/53` → `IIM42652/53` typo at the CLKIN comment; FSR mapping comment block rewritten to enumerate the three FSR groups correctly.

## ⚠ Breaking change for IIM-42652 users

After this fix, IIM-42652 boards report **half the previous raw register value** for gyro and **double the previous raw register value** for accel, which is the silicon-correct interpretation. **Effective PID gain doubles on existing tunes** — users with IIM-42652 hardware **must reset and re-tune PIDs** before flying, or risk unstable flight on first arm. This is also called out in the merge-commit body via a `BREAKING CHANGE:` footer. Release-cutter: please ensure the GitHub Release notes name the chip and the retune requirement.

## Background

PR #14424 (also mine) added IIM-42652 detection but mis-classified it as a sibling of IIM-42653 instead of an industrial-grade ICM-42688-P. Per the TDK IIM-42652 datasheet (WHO_AM_I = 0x6F, max gyro FSR ±2000 dps, max accel FSR ±16 g, same AAF block as ICM-42688-P), the correct silicon classification is the ICM-42688-P family. The same PR silently moved `IIM_42653_SPI` from the `aafLUT42688` arm (where PR #14095 originally placed it) to the `aafLUT42605` arm — this PR restores that placement too.

## Test plan
- [x] `make test` — full Betaflight test suite, 54 binaries PASS including the new `test_accgyro_spi_icm426xx_unittest` (19 cases).
- [x] Unit test pins per-sensor scale/acc_1G/AAF-delt expectations for all 6 ICM-426xx variants and the unknown-sensor rejection path. Each IIM-42652 / IIM-42653 case carries a regression-guard comment naming the PR that introduced the wrong behaviour.
- [x] `offsetof` `static_assert`s on `aafConfig_t` (`delt=0`, `deltSqr=2`, `bitshift=4`) catch any future field reorder/resize in the driver's file-static struct that would silently corrupt the test mirror.
- [ ] Reporter (field test): IIM-42652 attitude tracks 1:1 with physical rotation; ±45°/±90° tilt reads correctly in configurator Setup tab; accel calibrates to ~1 G stationary; AAF NORMAL cutoff ~258 Hz (was ~249 Hz pre-fix).
- [ ] Reviewer (optional, regression guard): build any target that defines `USE_ACCGYRO_IIM42652` or `USE_ACCGYRO_IIM42653` (e.g. one of the SAKURAH743 board variants in `config/`) and verify no new warnings.

## Files changed
- `src/main/drivers/accgyro/accgyro_spi_icm426xx.c` — driver fix (3 switches), comment block rewrite, typo fix, `static` → `STATIC_UNIT_TESTED` on `getGyroAafConfig`, `#include "build/build_config.h"`
- `src/test/unit/accgyro_spi_icm426xx_unittest.cc` — new unit test (277 lines, 19 TESTs)
- `src/test/Makefile` — new test registration block

## Out of scope (deferred to follow-up issues)
- Refactor the three per-sensor switches in `accgyro_spi_icm426xx.c` into a single data-driven `variants[]` table. The new unit test substantially reduces the recurrence risk that motivated this refactor.
- Cross-check IIM-42653 AAF cutoff against TDK datasheet revision on physical hardware before next release.
- Pre-existing latent type confusion at `accgyro_spi_icm426xx.c:386`: `getGyroAafConfig` parameter typed `aafConfig_e` but caller passes `gyroHardwareLpf_e` (both happen to align ordinally). Not introduced by this PR; worth a separate tidy-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected device variant handling and sensor scaling initialization for the ICM426xx/IIM426xx sensor family.
  * Fixed gyro temperature scaling assignment based on sensor variant detection.
  * Updated anti-alias filter configuration for improved sensor compatibility.

* **Tests**
  * Added comprehensive unit tests for ICM426xx sensor driver.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->