### PR TITLE
PICO: Simplify pico_trace

### DIFF
--- a/src/platform/PICO/dshot_pico.c
+++ b/src/platform/PICO/dshot_pico.c
@@ -241,7 +241,7 @@ static void dshotUpdateComplete(void)
     pio_set_sm_mask_enabled(dshotPio, motorMask, true);
 
 #ifdef PICO_TRACE
-    if (cuc % 65536 == 1) {
+    if (cuc % 262144 == 1) {
         bprintf("update complete %d, per motor %d of which ready %d nr wait %d nr other %d",
                 cuc, cucm, cucrts, cucwait, cucother);
         cucm = 0; cucrts = 0; cucwait = 0; cucother = 0;

--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -30,6 +30,7 @@
 #include "hardware/i2c.h"
 #include "hardware/spi.h"
 #include "hardware/uart.h"
+#include "pico_trace.h"
 
 #define NVIC_PriorityGroup_2         0x500
 #define PLATFORM_NO_LIBC             0

--- a/src/platform/PICO/osd/osd_pico.c
+++ b/src/platform/PICO/osd/osd_pico.c
@@ -434,7 +434,6 @@ static void vsync_callback_debug(void)
     static uint32_t n_to_c;
 
     if (ddc % NN == 0) {
-        schedulerIgnoreTaskExecTime();
 #if 0
         bprintf("%d vsync_callback busy %d %d nisz %d dmb %d (previous tainted n to c %d)",
                 ddc, business, busybuf, nisz, dmb, n_to_c);

--- a/src/platform/PICO/pico_trace.c
+++ b/src/platform/PICO/pico_trace.c
@@ -25,27 +25,9 @@
 #include "pico/stdio_uart.h"
 #include "pico/platform/compiler.h"
 
-static int depth;
-
-static const char* prefix[]= {
-    "-- ",
-    "--- ",
-    "---- ",
-    "----- ",
-    "------ ",
-    "------- "
-};
-
-static const int plen = sizeof(prefix)/sizeof(prefix[0]);
-
 #if !defined(PICO_TRACE_UART_INSTANCE) || !defined(PICO_TRACE_TX_GPIO) || !defined(PICO_TRACE_RX_GPIO)
 #error PICO_TRACE build requires defines for PICO_TRACE_UART_INSTANCE, PICO_TRACE_TX_GPIO, PICO_TRACE_RX_GPIO
 #endif
-
-void picotrace_prefix(void)
-{
-    stdio_printf(prefix[depth%plen]);
-}
 
 // Wrap main to insert the initialisation code.
 extern int main(int argc, char * argv[]);
@@ -55,9 +37,7 @@ int WRAPPER_FUNC(main)(int argc, char * argv[])
     //stdio_init_all();
     stdio_uart_init_full(UART_INSTANCE(PICO_TRACE_UART_INSTANCE), 115200, PICO_TRACE_TX_GPIO, PICO_TRACE_RX_GPIO);
     tprintf("\n=== Betaflight main ===");
-    depth++;
     int mr = REAL_FUNC(main)(argc, argv);
-    depth--;
     tprintf("\n=== Betaflight main end ===");
     return mr;
 }
@@ -68,7 +48,7 @@ int WRAPPER_FUNC(main)(int argc, char * argv[])
     void WRAPPER_FUNC(x)(void)                  \
     {                                           \
         tprintf("Enter " #x "");                \
-        depth++;REAL_FUNC(x)();depth--;         \
+        REAL_FUNC(x)();                         \
         tprintf("Exit  " #x "");                \
     }
 
@@ -78,9 +58,7 @@ int WRAPPER_FUNC(main)(int argc, char * argv[])
     bool WRAPPER_FUNC(x)(void)                  \
     {                                           \
         tprintf("Enter " #x "");                \
-        depth++;                                \
         bool ret__ = REAL_FUNC(x)();            \
-        depth--;                                \
         tprintf("Exit  " #x "");                \
         return ret__;                           \
     }
@@ -91,7 +69,7 @@ int WRAPPER_FUNC(main)(int argc, char * argv[])
     void WRAPPER_FUNC(x)(bool xyz__)                  \
     {                                                 \
         tprintf("Enter " #x " [%d]", xyz__);          \
-        depth++; REAL_FUNC(x)(xyz__); depth--;        \
+        REAL_FUNC(x)(xyz__);                          \
         tprintf("Exit  " #x "");                      \
     }
 

--- a/src/platform/PICO/pico_trace.h
+++ b/src/platform/PICO/pico_trace.h
@@ -1,21 +1,34 @@
-#pragma once
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
-extern void picotrace_prefix(void);
-
-#if 0
-
-// with depth prefix
-#define tprintf(fmt,...) do {                        \
-        picotrace_prefix();                          \
-        stdio_printf(fmt, ## __VA_ARGS__);           \
-        stdio_printf("\n");                          \
-    } while (0)
-
+#ifdef PICO_TRACE
+#define bprintf tprintf
 #else
+#define bprintf(fmt,...)
+#endif
+
+void schedulerIgnoreTaskExecTime(void);
 
 #define tprintf(fmt,...) do {                        \
-        stdio_printf(fmt, ## __VA_ARGS__);           \
-        stdio_printf("\n");                          \
+        schedulerIgnoreTaskExecTime();               \
+        stdio_printf(fmt "\n", ## __VA_ARGS__);      \
     } while (0)
 
-#endif

--- a/src/platform/PICO/pico_trace.h
+++ b/src/platform/PICO/pico_trace.h
@@ -19,6 +19,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #ifdef PICO_TRACE
 #define bprintf tprintf
 #else

--- a/src/platform/PICO/target/RP2350A/target.h
+++ b/src/platform/PICO/target/RP2350A/target.h
@@ -29,13 +29,6 @@
 #define USBD_PRODUCT_STRING     "Betaflight - RP2350A"
 #endif
 
-#ifdef PICO_TRACE
-#include "pico_trace.h"
-#define bprintf tprintf
-#else
-#define bprintf(fmt,...)
-#endif
-
 #ifndef RP2350A
 #define RP2350A
 #endif

--- a/src/platform/PICO/target/RP2350B/target.h
+++ b/src/platform/PICO/target/RP2350B/target.h
@@ -29,13 +29,6 @@
 #define USBD_PRODUCT_STRING     "Betaflight - RP2350B"
 #endif
 
-#ifdef PICO_TRACE
-#include "pico_trace.h"
-#define bprintf tprintf
-#else
-#define bprintf(fmt,...)
-#endif
-
 #ifndef RP2350B
 #define RP2350B
 #endif

--- a/src/platform/PICO/uart/uart_hw.c
+++ b/src/platform/PICO/uart/uart_hw.c
@@ -299,20 +299,19 @@ void uartReconfigure_hw(uartPort_t *s)
     // so we only consider option changes to baud rate and mode here.
 
     uart_inst_t *uartInstance = UART_INST(s->USARTx);
-    bprintf("uartReconfigure for port %p with USARTX %p", s, uartInstance);
     int achievedBaudrate = uart_init(uartInstance, s->port.baudRate);
-#ifdef PICO_TRACE
+#if defined(PICO_TRACE_UART_EXTRA) && defined(PICO_TRACE)
+    bprintf("uartReconfigure for port %p with USARTX %p", s, uartInstance);
     bprintf("uartReconfigure h/w %p, requested baudRate %d, achieving %d", uartInstance, s->port.baudRate, achievedBaudrate);
+    bprintf("uartReconfigure note options 0x%0x, port.mode = 0x%x", s->port.options, s->port.mode);
 #else
     UNUSED(achievedBaudrate);
 #endif
 
-    bprintf("uartReconfigure note options 0x%0x, port.mode = 0x%x", s->port.options, s->port.mode);
 
 // TODO would like to verify rx pin has been setup?
 //    if ((s->mode & MODE_RX) && rxIO) {
     if (s->port.mode & MODE_RX) {
-        bprintf("serialUART setting RX irq");
         uart_set_irqs_enabled(uartInstance, true, false);
     }
 }

--- a/src/platform/PICO/uart/uart_pio.c
+++ b/src/platform/PICO/uart/uart_pio.c
@@ -354,7 +354,6 @@ bool serialUART_pio(uartPort_t *s, uint32_t baudRate, portMode_e mode, portOptio
 
 void uartReconfigure_pio(uartPort_t *s)
 {
-    bprintf("uartReconfigure for port %p with PIO %p, mode = 0x%x", s, uartPio, s->port.mode);
     const serialPortIdentifier_e identifier = s->port.identifier;
     pioDetails_t *uartPioDetailsPtr = UART_PIO_DETAILS_PTR(identifier);
     uint sm_tx = uartPioDetailsPtr->sm_tx;
@@ -368,8 +367,11 @@ void uartReconfigure_pio(uartPort_t *s)
 
     // (re)init program, with baud rate
     // Arrange GPIO including pullup for RX, assign PIO SM pins, FIFO, clock, enable SM
+#if defined(PICO_TRACE_UART_EXTRA) && defined(PICO_TRACE)
+    bprintf("uartReconfigure for port %p with PIO %p, mode = 0x%x", s, uartPio, s->port.mode);
     bprintf("uartReconfigure_pio init rx, tx programs, pins %d, %d, (requested) baudrate %d",
             uartPioDetailsPtr->rxPin, uartPioDetailsPtr->txPin, s->port.baudRate);
+#endif
     uart_rx_program_init(uartPio, sm_rx, rxProgram_offset, uartPioDetailsPtr->rxPin, s->port.baudRate);
     uartDevice_t *uartDev = uartDeviceFromIdentifier(identifier);
     IO_t txIO = IOGetByTag(uartDev->tx.pin);


### PR DESCRIPTION
Simplify pico_trace and add call to schedulerIgnoreTaskExecTime on each bprintf.
Remove unused code for trace indentation by call depth.
Move #include for conditional bprintf definition from target.h files to PICO platform.h.
Remove call to schedulerIgnoreTaskExecTime from vsync_callback_debug in osd_pico.c. 
Reduce trace: guard to avoid trace in uart reconfigure (might be called from ISR). 
Reduce trace: DShot don't trace so often (when PICO_TRACE enabled).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced and consolidated debug trace output to emit far fewer messages and simplify trace formatting.
  * Centralized trace wiring and made extra UART tracing opt-in to limit verbose logs.

* **Bug Fixes**
  * Adjusted debug timing behavior to avoid disturbing normal scheduling during VSync/debug instrumentation.
  * Suppressed unnecessary debug prints during UART reconfiguration unless verbose tracing is explicitly enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->