### PR TITLE
drivers/flash: declare partition locals for CONFIG_IN_MEMORY_MAPPED_FLASH

### DIFF
--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -591,7 +591,7 @@ const flashGeometry_t *flashGetGeometry(void)
 
 static void flashConfigurePartitions(void)
 {
-#if defined(FIRMWARE_SIZE) || defined(CONFIG_IN_EXTERNAL_FLASH) || defined(USE_FLASHFS)
+#if defined(FIRMWARE_SIZE) || defined(CONFIG_IN_EXTERNAL_FLASH) || defined(CONFIG_IN_MEMORY_MAPPED_FLASH) || defined(USE_FLASHFS)
     const flashGeometry_t *flashGeometry = flashGetGeometry();
     if (flashGeometry->totalSize == 0) {
         return;


### PR DESCRIPTION
`flashConfigurePartitions()` declares its `flashGeometry` / `startSector` /
`endSector` locals inside an outer `#if` gated on
`FIRMWARE_SIZE || CONFIG_IN_EXTERNAL_FLASH || USE_FLASHFS`. The inner
`#if` at line 625 then uses those same locals under
`CONFIG_IN_EXTERNAL_FLASH || CONFIG_IN_MEMORY_MAPPED_FLASH`.

A target with only `CONFIG_IN_MEMORY_MAPPED_FLASH` defined fails to
compile:

```
flash.c:633:20: error: 'endSector' undeclared (first use in this function)
```

Reproduced on STM32N657 OPENN657V1: target.h sets
`CONFIG_IN_MEMORY_MAPPED_FLASH`, the config has no
`CONFIG_IN_EXTERNAL_FLASH` / `FIRMWARE_SIZE`, and `USE_FLASHFS` ends
up undef'd because `USE_FLASH_CHIP` is set early via
`USE_FLASH_MX66UW1G45G` before `common_pre.h`'s `USE_FLASH` block
runs.

Add `CONFIG_IN_MEMORY_MAPPED_FLASH` to the outer gate so the locals
are declared whenever the inner block uses them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed partition setup to properly execute for in-memory mapped flash configurations, expanding hardware support beyond previously available options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->