### PR TITLE
PICO: Fix unsafe use of naive MAX, MIN macros

### DIFF
--- a/src/platform/PICO/bus_i2c_pico.c
+++ b/src/platform/PICO/bus_i2c_pico.c
@@ -29,6 +29,8 @@
 
 #include "pg/bus_i2c.h"
 
+#include "common/maths.h"
+
 #include "hardware/i2c.h"
 #include "hardware/dma.h"
 #include "hardware/irq.h"

--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+// pico sdk header includes
 #include "RP2350.h"
-
 #include "pico.h"
 #include "pico/stdlib.h"
 #include "hardware/dma.h"
@@ -30,6 +30,11 @@
 #include "hardware/i2c.h"
 #include "hardware/spi.h"
 #include "hardware/uart.h"
+
+// Revert MAX, MIN definitions because they are unsafe for general use (double evaluations).
+// Code that requires MAX, MIN should include common/maths.h
+#undef MAX
+#undef MIN
 
 #define NVIC_PriorityGroup_2         0x500
 #define PLATFORM_NO_LIBC             0

--- a/src/platform/PICO/system.c
+++ b/src/platform/PICO/system.c
@@ -24,6 +24,7 @@
 
 #include "platform.h"
 
+#include "common/maths.h"
 #include "common/time.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
@@ -114,7 +115,7 @@ void systemInit(void)
     // load the unique id into a local array
     pico_unique_board_id_t id;
     pico_get_unique_board_id(&id);
-    memcpy(&systemUniqueId, &id.id, MIN(sizeof(systemUniqueId), PICO_UNIQUE_BOARD_ID_SIZE_BYTES));
+    memcpy(&systemUniqueId, &id.id, MIN(sizeof(systemUniqueId), (uint32_t)PICO_UNIQUE_BOARD_ID_SIZE_BYTES));
 
 
 #ifdef USE_MULTICORE

--- a/src/platform/PICO/usb/usb_msc_pico.c
+++ b/src/platform/PICO/usb/usb_msc_pico.c
@@ -26,6 +26,7 @@
 
 #include "build/build_config.h"
 
+#include "common/maths.h"
 #include "common/utils.h"
 
 #include "blackbox/blackbox.h"


### PR DESCRIPTION
PICO: Fix unsafe use of naive MAX, MIN macros

There is a basic definition of MAX, MIN in a pico sdk header that does not protect against double evaluation of its arguments.
The definitions in common/maths.h do not get used, because they are guarded by #ifndef-s.

This leads to inefficiencies, and memory corruption bugs, such as following on from this in msp.c

           const unsigned textLength = MIN(textSpace, sbufReadU8(src));

The fix here is to undefine MAX, MIN immediately after including the relevant pico sdk headers via platform.h.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized platform-level code dependencies for improved maintainability.
  * Enhanced type safety in memory operations.
  * Removed conflicting macro definitions to prevent compilation issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight/pull/15269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->