### PR TITLE
fix(flashfs): avoid blocking MSP during NOR chip erase

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3188,7 +3188,8 @@ static void cliFlashErase(const char *cmdName, char *cmdline)
     cliWriterFlush();
     flashfsEraseCompletely();
 
-    while (!flashfsIsReady() && !flashfsIsEraseInProgress()) {
+    while (!flashfsIsReady()) {
+        flashfsEraseAsync();
 #ifndef MINIMAL_CLI
         cliPrintf(".");
         if (i++ > 120) {

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -178,6 +178,7 @@ static const void *cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
 
     flashfsEraseCompletely();
     while (!flashfsIsReady()) {
+        flashfsEraseAsync();
         //TODO: Make this non-blocking!
         delay(100);
     }

--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -516,10 +516,6 @@ void flashEraseCompletely(void)
 {
     flashDevice.callback = NULL;
     flashDevice.vTable->eraseCompletely(&flashDevice);
-
-    if (!flashWaitForReadyOrFail()) {
-        return;
-    }
 }
 
 /* The callback, if provided, will receive the totoal number of bytes transfered

--- a/src/main/drivers/flash/flash.c
+++ b/src/main/drivers/flash/flash.c
@@ -28,6 +28,8 @@
 
 #ifdef USE_FLASH_CHIP
 
+#include "common/utils.h"
+
 #include "drivers/flash/flash.h"
 #include "drivers/flash/flash_impl.h"
 #include "drivers/flash/flash_m25p16.h"
@@ -475,6 +477,40 @@ MMFLASH_CODE bool flashWaitForReady(void)
     return flashDevice.vTable->waitForReady(&flashDevice);
 }
 
+MMFLASH_CODE static void flashExternalWriteFailed(void)
+{
+#ifdef USE_FLASH_MEMORY_MAPPED
+    // failureMode lives in XIP. When this trips from a save/erase
+    // loop inside the MMFLASH window, the call to failureMode would
+    // fault. Re-engage memory-mapped mode (best-effort — the chip
+    // may already be in a bad state) so the failure handler is
+    // reachable. Gated on the runtime boot state so the non-MM
+    // experimental path (flashOctoSpiInit under
+    // USE_OCTOSPI_EXPERIMENTAL) does not reconfigure the
+    // controller or unmask IRQs when MM was never enabled.
+    if (isMemoryMappedModeEnabledOnBoot()) {
+        flashMemoryMappedModeEnable();
+    }
+#endif
+
+    failureMode(FAILURE_EXTERNAL_FLASH_WRITE_FAILED);
+}
+
+MMFLASH_CODE bool flashIsReadyOrFail(void)
+{
+    if (flashIsReady()) {
+        flashDevice.timeoutAt = 0;
+        return true;
+    }
+
+    if (flashDevice.timeoutAt && cmp32(microsISR() / 1000, flashDevice.timeoutAt) >= 0) {
+        flashExternalWriteFailed();
+        return false;
+    }
+
+    return false;
+}
+
 MMFLASH_CODE static bool flashWaitForReadyOrFail(void)
 {
     if (!flashDevice.vTable->waitForReady) {
@@ -482,20 +518,7 @@ MMFLASH_CODE static bool flashWaitForReadyOrFail(void)
     }
 
     if (!flashDevice.vTable->waitForReady(&flashDevice)) {
-#ifdef USE_FLASH_MEMORY_MAPPED
-        // failureMode lives in XIP. When this trips from a save/erase
-        // loop inside the MMFLASH window, the call to failureMode would
-        // fault. Re-engage memory-mapped mode (best-effort — the chip
-        // may already be in a bad state) so the failure handler is
-        // reachable. Gated on the runtime boot state so the non-MM
-        // experimental path (flashOctoSpiInit under
-        // USE_OCTOSPI_EXPERIMENTAL) does not reconfigure the
-        // controller or unmask IRQs when MM was never enabled.
-        if (isMemoryMappedModeEnabledOnBoot()) {
-            flashMemoryMappedModeEnable();
-        }
-#endif
-        failureMode(FAILURE_EXTERNAL_FLASH_WRITE_FAILED);
+        flashExternalWriteFailed();
         return false;
     }
 

--- a/src/main/drivers/flash/flash.h
+++ b/src/main/drivers/flash/flash.h
@@ -61,6 +61,7 @@ void flashPreinit(const flashConfig_t *flashConfig);
 bool flashInit(const flashConfig_t *flashConfig);
 
 bool flashIsReady(void);
+bool flashIsReadyOrFail(void);
 bool flashWaitForReady(void);
 void flashEraseSector(uint32_t address);
 void flashEraseCompletely(void);

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -45,6 +45,7 @@
 #include "common/printf.h"
 #include "drivers/flash/flash.h"
 #include "drivers/light_led.h"
+#include "drivers/time.h"
 
 #include "io/flashfs.h"
 
@@ -448,7 +449,7 @@ void flashfsEraseAsync(void)
 {
     if (flashfsState == FLASHFS_ERASING) {
         if (eraseOperationIsChipErase) {
-            if (flashIsReady()) {
+            if (flashIsReadyOrFail()) {
                 eraseOperationIsChipErase = false;
                 flashfsState = FLASHFS_IDLE;
                 LED1_OFF;
@@ -686,6 +687,7 @@ bool flashfsVerifyEntireFlash(void)
 
     while (!flashfsIsReady()) {
         flashfsEraseAsync();
+        delay(100);
     }
 
     uint32_t address = 0;

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -58,6 +58,7 @@ static const flashGeometry_t *flashGeometry = NULL;
 static uint32_t flashfsSize = 0;
 static flashfsState_e flashfsState = FLASHFS_IDLE;
 static flashSector_t eraseSectorCurrent = 0;
+static bool eraseOperationIsChipErase = false;
 
 static DMA_DATA_ZERO_INIT uint8_t flashWriteBuffer[FLASHFS_WRITE_BUFFER_SIZE];
 
@@ -165,13 +166,18 @@ static void flashfsSetTailAddress(uint32_t address)
 void flashfsEraseCompletely(void)
 {
     if (flashGeometry->sectors > 0 && flashPartitionCount() > 0) {
-        // if there's a single FLASHFS partition and it uses the entire flash then do a full erase
-        const bool doFullErase = (flashPartitionCount() == 1) && (FLASH_PARTITION_SECTOR_COUNT(flashPartition) == flashGeometry->sectors);
+        // If there's a single FLASHFS partition and it uses the entire NOR flash then do a full erase.
+        const bool doFullErase = flashGeometry->flashType == FLASH_TYPE_NOR
+            && (flashPartitionCount() == 1)
+            && (FLASH_PARTITION_SECTOR_COUNT(flashPartition) == flashGeometry->sectors);
         if (doFullErase) {
             flashEraseCompletely();
+            eraseOperationIsChipErase = true;
+            flashfsState = FLASHFS_ERASING;
         } else {
             // start asynchronous erase of all sectors
             eraseSectorCurrent = flashPartition->startSector;
+            eraseOperationIsChipErase = false;
             flashfsState = FLASHFS_ERASING;
         }
     }
@@ -215,11 +221,6 @@ bool flashfsIsReady(void)
     // Check for flash chip existence first, then check if idle and ready.
 
     return (flashfsIsSupported() && (flashfsState == FLASHFS_IDLE) && flashIsReady());
-}
-
-bool flashfsIsEraseInProgress(void)
-{
-    return flashfsState == FLASHFS_ERASING;
 }
 
 bool flashfsIsSupported(void)
@@ -446,7 +447,16 @@ void flashfsFlushSync(void)
 void flashfsEraseAsync(void)
 {
     if (flashfsState == FLASHFS_ERASING) {
-        if ((flashfsIsSupported() && flashIsReady())) {
+        if (eraseOperationIsChipErase) {
+            if (flashIsReady()) {
+                eraseOperationIsChipErase = false;
+                flashfsState = FLASHFS_IDLE;
+                LED1_OFF;
+            }
+            return;
+        }
+
+        if (flashIsReady()) {
             if (eraseSectorCurrent <= flashPartition->endSector) {
                 // Erase sector
                 uint32_t sectorAddress = eraseSectorCurrent * flashGeometry->sectorSize;
@@ -673,6 +683,10 @@ void flashfsInit(void)
 bool flashfsVerifyEntireFlash(void)
 {
     flashfsEraseCompletely();
+
+    while (!flashfsIsReady()) {
+        flashfsEraseAsync();
+    }
 
     uint32_t address = 0;
     flashfsSeekAbs(address);

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -54,7 +54,5 @@ bool flashfsIsSupported(void);
 
 bool flashfsIsReady(void);
 bool flashfsIsEOF(void);
-bool flashfsIsEraseInProgress(void);
 
 bool flashfsVerifyEntireFlash(void);
-


### PR DESCRIPTION
  ## Summary

  This PR fixes a regression where erasing onboard flash from Configurator / MSP can take much longer than the real
  flash erase time.

  On affected targets, a W25Q128 chip erase itself takes about 37 seconds, but erasing from the ground station can
  take roughly twice as long and trigger MSP queue issues. 

<img width="1753" height="1137" alt="image" src="https://github.com/user-attachments/assets/5ecb7222-dee5-4b08-85a0-334c6623b50c" />


  ## Root Cause

  The regression is caused by a change in the shared flash erase API semantics.

  In Betaflight 4.5.2, `flashEraseCompletely()` only started the chip erase operation and returned immediately:

  ```c
  void flashEraseCompletely(void)
  {
      flashDevice.callback = NULL;
      flashDevice.vTable->eraseCompletely(&flashDevice);
  }
```

  That allowed MSP erase requests to return promptly while Configurator continued polling MSP_DATAFLASH_SUMMARY until
  the flash became ready.

  On current master, flashEraseCompletely() was changed to wait synchronously after starting the erase:

  ```c
  void flashEraseCompletely(void)
  {
      flashDevice.callback = NULL;
      flashDevice.vTable->eraseCompletely(&flashDevice);

      if (!flashWaitForReadyOrFail()) {
          return;
      }
  }
  ```

  For NOR flash such as W25Q128, the low-level driver sends the chip erase command quickly, but the flash chip
  remains internally busy for tens of seconds. Because MSP_DATAFLASH_ERASE calls this path through:

```
  MSP_DATAFLASH_ERASE
  blackboxEraseAll()
  flashfsEraseCompletely()
  flashEraseCompletely()
```

  the MSP handler became blocked for the full chip erase duration. During that time Configurator does not receive the
  erase response, starts timing out and retrying MSP requests, and the MSP queue can fill.

  This issue is not present in 4.5.2 because the shared flashEraseCompletely() API was still start-only there.

  ## Fix

  This PR restores flashEraseCompletely() to start-only behavior and moves completion tracking into FlashFS:

  - flashEraseCompletely() starts the erase and returns.
  - FlashFS marks full NOR chip erase as FLASHFS_ERASING.
  - flashfsEraseAsync() polls flashIsReady() and returns FlashFS to idle once the chip erase completes.
  - CLI, CMS, and flash verification paths still wait synchronously by driving flashfsEraseAsync() while waiting for
    flashfsIsReady().

  This keeps MSP responsive while preserving the expected blocking behavior for user-facing CLI/CMS erase commands.

  ## Notes

  The fix does not make the flash chip erase faster. The actual W25Q128 chip erase time remains about the same. The
  improvement is that MSP no longer blocks for the entire erase duration, so Configurator can continue polling
  normally instead of hitting timeout / queue-full behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures flash erase operations reliably complete before verification; added stronger readiness/failure handling and clear failure signaling to avoid partial or stuck erases.

* **Refactor**
  * Erase flow rewritten to poll and drive full-chip or sector erases to completion (including timed retries), with a centralized failure/recovery path for improved reliability and simpler control logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->