### PR TITLE
flight: fix inverted accelerometer sign in vertical Kalman fusion (alt hold / GPS rescue oscillation)

### DIFF
--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -284,9 +284,7 @@ void autopilotClearAltHoldHoverThrottle(void)
 
 void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS)
 {
-    // Use the altitude_d_lpf-filtered vertical velocity for the inner damping loop;
-    // the raw Kalman velocity is too noisy at the task rate and causes throttle hunting.
-    const float vz = getAltitudeDerivative();
+    const float vz = getAltitudeDerivativeControl();
     const float altitudeErrorCm = targetAltitudeCm - getAltitudeCmControl();
 
     // increase inner-loop P when |vz| is high (same shaping as legacy D boost)

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -284,7 +284,9 @@ void autopilotClearAltHoldHoverThrottle(void)
 
 void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS)
 {
-    const float vz = getAltitudeDerivativeControl();
+    // Use the altitude_d_lpf-filtered vertical velocity for the inner damping loop;
+    // the raw Kalman velocity is too noisy at the task rate and causes throttle hunting.
+    const float vz = getAltitudeDerivative();
     const float altitudeErrorCm = targetAltitudeCm - getAltitudeCmControl();
 
     // increase inner-loop P when |vz| is high (same shaping as legacy D boost)

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -289,10 +289,12 @@ static void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelU
     vector3_t accEF_NED;
     matrixVectorMul(&accEF_NED, &rMat, &accBF);
 
-    // NED -> ENU, subtract gravity (NED gravity = [0,0,+1g]), convert G -> cm/s^2
+    // NED -> ENU, remove the 1g gravity reaction from the measured Z, convert G -> cm/s^2.
+    // accADC reports specific force, so a stationary craft reads +1g on Z; subtracting it
+    // yields the true linear vertical acceleration with Up positive (matches velocity/D sign).
     *accelEast  =  accEF_NED.y * GRAVITY_CMSS;
     *accelNorth =  accEF_NED.x * GRAVITY_CMSS;
-    *accelUp    = -(accEF_NED.z - 1.0f) * GRAVITY_CMSS;
+    *accelUp    = (accEF_NED.z - 1.0f) * GRAVITY_CMSS;
 }
 
 #ifdef USE_GPS

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -87,11 +87,14 @@ protected:
         memset(&gpsSol, 0, sizeof(gpsSol));
         memset(debug, 0, sizeof(debug));
 
-        // Identity rotation and 1G reciprocal scale so zero accel stays zero.
+        // Identity rotation and 1G reciprocal scale. A level, stationary craft
+        // measures +1g specific force on Z, which the estimator subtracts to get
+        // zero linear vertical acceleration (no spurious bias into the Kalman).
         rMat.m[0][0] = 1.0f;
         rMat.m[1][1] = 1.0f;
         rMat.m[2][2] = 1.0f;
         acc.dev.acc_1G_rec = 1.0f;
+        acc.accADC.z = 1.0f;
 
         enabledSensors = SENSOR_GPS | SENSOR_BARO | SENSOR_RANGEFINDER;
         rfHealthy = true;


### PR DESCRIPTION
## Summary

Altitude Hold held altitude cleanly in the **2025.12 release** but oscillates (throttle hunting) in current `master` / dev builds. **The same regression affects GPS Rescue**, since it shares the altitude controller — expect throttle hunting during the climb, return, and descent/landing phases.

### Root cause

The vertical (Up) acceleration fed into the altitude Kalman filter was **negated**. In `position_estimator.c`:

```c
*accelUp = -(accEF_NED.z - 1.0f) * GRAVITY_CMSS;   // inverted
```

With the sign inverted, the linear vertical acceleration entering the Kalman predict step has the wrong polarity. This creates a **positive feedback loop** in the vertical-velocity path that feeds the inner damping loop (position D): the velocity estimate is largely inverted, the altitude reading is distorted, and the D-term response is inverted — driving the throttle hunting seen in Alt Hold and GPS Rescue.

Credit to **@ctzsnooze** for diagnosing this from blackbox logs: the unfiltered Kalman outputs are actually very smooth, so noise was never the problem — the inverted acc fusion was.

### Fix

Remove the sign inversion so Up is positive after subtracting the 1g gravity reaction:

```c
*accelUp = (accEF_NED.z - 1.0f) * GRAVITY_CMSS;
```

One-line change. Because Alt Hold and GPS Rescue both feed through the shared `altitudeControl()` / vertical-velocity path, this fixes **both** at once. With the sign corrected, the unfiltered Kalman velocity is smooth and fast (using the acc signal to respond quicker than GPS or Baro), so no extra output filtering is needed.

### Note on the earlier approach

This PR originally proposed routing the `altitude_d_lpf`-filtered velocity (`getAltitudeDerivative()`) into the inner loop instead of the raw `getAltitudeDerivativeControl()`. That masked the symptom but was **not the cause** and only added delay, so it has been **reverted**. The inner loop again uses the raw `getAltitudeDerivativeControl()` feed.

### Testing

- `make test` passes — `test_position_estimator_unittest`, `test_althold_unittest`, `test_poshold_unittest` and full suite green.
- The unit-test fixture (`position_estimator_unittest.cc`) was corrected to model **+1g** specific force on Z for a level/stationary craft, so it reflects real sensor behaviour and is independent of the sign convention.
- Hand-held testing (blackbox): with the fix, baro/GPS/acc noise is clearly present in the raw sensors but does not appear in the Kalman altitude/velocity outputs (no PT2 filtering on those). Accelerometer, vertical velocity, and D-term traces are all sign-appropriate.
- Recommend confirming against a blackbox log (`DEBUG_AUTOPILOT_ALTITUDE`) from an affected craft for **both**:
  - **Altitude Hold** — hover and hold.
  - **GPS Rescue** — full rescue cycle (climb → return → descent/landing).

### Follow-ups (out of scope here)

- Inner/outer loop reworked to avoid duplicate integration (second "altitude P"-type term) for acc/optical-flow-only operation.
- Kalman Q/R tuning (Baro+GPS optimum may not suit optical flow — change cautiously).
- Blackbox alt-hold debug field labels not matching the logged data.
