### PR TITLE
allow for POS_HOLD in SITL

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -864,6 +864,10 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_FLIGHT_PLAN 0
 #endif
 
+#if defined(USE_POSITION_HOLD) && !(defined(USE_GPS) || defined(USE_OPTICALFLOW))
+#error "USE_POSITION_HOLD requires USE_GPS and/or USE_OPTICALFLOW to be defined"
+#endif
+
 #if !defined(ENABLE_TELEMETRY_MAVLINK_MISSION)
 // flight_plan_nav.c (and the autopilot hook in fc/core.c) are gated on
 // !defined(USE_WING); the mission module reaches into those symbols, so match

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -527,10 +527,6 @@
 
 #endif // USE_WING
 
-#if defined(USE_POSITION_HOLD) && !(defined(USE_GPS) || defined(USE_OPTICALFLOW))
-#error "USE_POSITION_HOLD requires USE_GPS and/or USE_OPTICALFLOW to be defined"
-#endif
-
 // backwards compatibility for older config.h targets
 #ifndef GYRO_CONFIG_USE_GYRO_1
 #define GYRO_CONFIG_USE_GYRO_1 0

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -305,9 +305,7 @@ static void updateState(const fdm_packet* pkt)
     x = constrain(pkt->imu_angular_velocity_rpy[0] * GYRO_SCALE * RAD2DEG, -32767, 32767);
     y = constrain(-pkt->imu_angular_velocity_rpy[1] * GYRO_SCALE * RAD2DEG, -32767, 32767);
     z = constrain(-pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-    
     virtualGyroSet(virtualGyroDev, x, y, z);
-
 #if ENABLE_GAZEBO_BRIDGE
     // Gazebo plugin doesn't fill pkt->pressure; derive from altitude using the
     // standard atmosphere model: P = 101325 * (1 - 2.25577e-5 * h)^5.25588

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -304,11 +304,8 @@ static void updateState(const fdm_packet* pkt)
 
     x = constrain(pkt->imu_angular_velocity_rpy[0] * GYRO_SCALE * RAD2DEG, -32767, 32767);
     y = constrain(-pkt->imu_angular_velocity_rpy[1] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-#if ENABLE_GAZEBO_BRIDGE
-    z = constrain(pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-#else
     z = constrain(-pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-#endif
+    
     virtualGyroSet(virtualGyroDev, x, y, z);
 
 #if ENABLE_GAZEBO_BRIDGE


### PR DESCRIPTION
This pull request allows for position hold mode on the SITL target. The common_pre step previously required USE_GPS to be defined in order to build against the USE_POS_HOLD flag. 

the SITL target implicitly defines USE_GPS but due to the build ordering it would result in a build error being thrown, which this pull request fixes by putting the USE_POS_HOLD gate in the post build step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build-time validation for position-hold configuration handling, changing how invalid configurations are reported.
* **Bug Fixes**
  * Made simulator IMU Z-axis mapping consistent across simulator bridge builds, resolving inconsistent yaw/rotation behavior in some simulator setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->