### PR TITLE
STM32N6 I2C: fix CR1 IT-enable RMW race vs ISR (enables BMP280 baro)

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -159,7 +159,19 @@ bool bmp280Detect(baroDev_t *baro)
         defaultAddressApplied = true;
     }
 
-    busReadRegisterBuffer(dev, BMP280_CHIP_ID_REG, &bmp280_chip_id, 1);  /* read Chip Id */
+    bmp280_chip_id = 0;
+    busReadRegisterBuffer(dev, BMP280_CHIP_ID_REG, &bmp280_chip_id, 1);
+
+    if ((bmp280_chip_id != BMP280_DEFAULT_CHIP_ID) && (bmp280_chip_id != BME280_DEFAULT_CHIP_ID)) {
+        // Some BMP280 modules wire SDO to VDD, putting the chip at 0x77.
+        // Retry on the alternate address before giving up so boards with
+        // either strap value are auto-detected from a single config.
+        if (defaultAddressApplied && dev->bus->busType == BUS_TYPE_I2C) {
+            dev->busType_u.i2c.address = 0x77;
+            bmp280_chip_id = 0;
+            busReadRegisterBuffer(dev, BMP280_CHIP_ID_REG, &bmp280_chip_id, 1);
+        }
+    }
 
     if ((bmp280_chip_id != BMP280_DEFAULT_CHIP_ID) && (bmp280_chip_id != BME280_DEFAULT_CHIP_ID)) {
         bmp280BusDeinit(dev);

--- a/src/platform/STM32/bus_i2c_ll.c
+++ b/src/platform/STM32/bus_i2c_ll.c
@@ -96,10 +96,12 @@ static void i2cEVIRQHandler(i2cDevice_e device)
             LL_I2C_TransmitData8(I2Cx, *state->write_p++);
             state->bytes--;
         }
-        // Must disable IT_TX once the last byte has shifted out — TXIS
-        // keeps re-asserting otherwise and the IRQ tail-chains forever
-        // until IWDG fires.
-        if (state->bytes == 0) {
+        // Disable IT_TX once the last byte has shifted out (TXIS reasserts
+        // immediately otherwise and the IRQ tail-chains until IWDG fires).
+        // Also disable if this IRQ fired during a read transaction
+        // (state->writing=0); a stray IT_TX surviving a prior write would
+        // otherwise tail-chain through the SOFTEND read setup.
+        if (state->bytes == 0 || !state->writing) {
             LL_I2C_DisableIT_TX(I2Cx);
         }
         return;
@@ -394,11 +396,17 @@ bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len
         LL_I2C_TransmitData8(I2Cx, reg_);
     }
 
-    // Enable interrupts to handle remaining data bytes
-    LL_I2C_EnableIT_TX(I2Cx);
-    LL_I2C_EnableIT_NACK(I2Cx);
-    LL_I2C_EnableIT_STOP(I2Cx);
-    LL_I2C_EnableIT_ERR(I2Cx);
+    // Enable interrupts in a single atomic CR1 write — the LL Enable*
+    // helpers are RMW (LDR/ORR/STR). The IRQ runs at the highest NVIC
+    // priority, so a single ISR-driven Disable* between the foreground
+    // LDR and STR makes the stale STR re-set bits the IRQ just cleared,
+    // leaving stray ITs enabled that tail-chain the next transaction.
+    {
+        const uint32_t primask = __get_PRIMASK();
+        __disable_irq();
+        I2Cx->CR1 |= I2C_CR1_TXIE | I2C_CR1_NACKIE | I2C_CR1_STOPIE | I2C_CR1_ERRIE;
+        __set_PRIMASK(primask);
+    }
 
     return true;
 }
@@ -529,14 +537,15 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len,
     state->error = false;
     state->transactionStartUs = microsISR();
 
+    uint32_t crBitsToEnable;
+
     if (reg_ == 0xFF) {
         // No register address, directly start read
         LL_I2C_HandleTransfer(I2Cx, state->addr, LL_I2C_ADDRSLAVE_7BIT,
                               len, LL_I2C_MODE_AUTOEND,
                               LL_I2C_GENERATE_START_READ);
 
-        // Enable RX interrupts
-        LL_I2C_EnableIT_RX(I2Cx);
+        crBitsToEnable = I2C_CR1_RXIE;
     } else {
         // First send register address with SOFTEND, TC interrupt will trigger restart
         LL_I2C_HandleTransfer(I2Cx, state->addr, LL_I2C_ADDRSLAVE_7BIT,
@@ -556,13 +565,20 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len,
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
 
-        // Enable TC interrupt - ISR will handle the restart and switch to RX
-        LL_I2C_EnableIT_TC(I2Cx);
+        // TC interrupt fires after slave ACKs the reg byte; ISR handles
+        // the RESTART then switches to RX interrupts for the read phase.
+        crBitsToEnable = I2C_CR1_TCIE;
     }
 
-    LL_I2C_EnableIT_NACK(I2Cx);
-    LL_I2C_EnableIT_STOP(I2Cx);
-    LL_I2C_EnableIT_ERR(I2Cx);
+    // Single atomic CR1 write — see comment in i2cWriteBuffer for why
+    // separate Enable* RMWs can race the ISR's Disable* and leave stray
+    // ITs enabled that tail-chain the next transaction.
+    {
+        const uint32_t primask = __get_PRIMASK();
+        __disable_irq();
+        I2Cx->CR1 |= crBitsToEnable | I2C_CR1_NACKIE | I2C_CR1_STOPIE | I2C_CR1_ERRIE;
+        __set_PRIMASK(primask);
+    }
 
     return true;
 }


### PR DESCRIPTION
The async `bus_i2c_ll` IT-enable sequence (`LL_I2C_EnableIT_TX/NACK/STOP/ERR`)
is four separate LDR/ORR/STR RMWs on CR1. The I2C event IRQ runs at NVIC
priority 0 (highest), and on Cortex-M55 can preempt between the foreground
LDR and STR — the stale OR'd value gets stored back, re-setting bits the
ISR just cleared. On STM32N6/OPENN657V1 with BMP280, this leaves `TXIE`
stuck set across the SOFTEND read setup; the next TXIS-after-START-WRITE
fires the IRQ, `state->writing=0` so nothing drains TXIS, the IRQ
tail-chains until IWDG fires (~58k entries in ~5 s).

Fix: collapse the four sequential `LL_I2C_EnableIT_*()` calls into one
`I2Cx->CR1 |= ...` RMW bracketed by `__disable_irq()`/`__set_PRIMASK()`
so the ISR cannot preempt mid-RMW. Defensive belt-and-braces: TXIS
branch in the ISR now also disables IT_TX when `state->writing=0`, so a
stray TXIE surviving any future race can't tail-chain again.

Also: `bmp280Detect` falls back to address 0x77 if 0x76 NACKs, since
some modules tie SDO to VDD — boards with either strap value now
auto-detect from a single config.

Verified on OPENN657V1: `status` reports `BARO: BMP280`, TASK_BARO runs
cleanly, I2C error count 9 over 35 s uptime (vs 51 stall-recoveries +
16 catch-alls in 25 s without the fix). No regressions observed on other
I2C devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced barometer sensor detection with automatic retry using alternate I2C address for improved hardware compatibility.
  * Fixed I2C communication interrupt handling during read operations to prevent signal interference and ensure reliable data transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->