### PR TITLE
SITL Yaw Convention Fix

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -864,6 +864,10 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_FLIGHT_PLAN 0
 #endif
 
+#if defined(USE_POSITION_HOLD) && !(defined(USE_GPS) || defined(USE_OPTICALFLOW))
+#error "USE_POSITION_HOLD requires USE_GPS and/or USE_OPTICALFLOW to be defined"
+#endif
+
 #if !defined(ENABLE_TELEMETRY_MAVLINK_MISSION)
 // flight_plan_nav.c (and the autopilot hook in fc/core.c) are gated on
 // !defined(USE_WING); the mission module reaches into those symbols, so match

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -527,10 +527,6 @@
 
 #endif // USE_WING
 
-#if defined(USE_POSITION_HOLD) && !(defined(USE_GPS) || defined(USE_OPTICALFLOW))
-#error "USE_POSITION_HOLD requires USE_GPS and/or USE_OPTICALFLOW to be defined"
-#endif
-
 // backwards compatibility for older config.h targets
 #ifndef GYRO_CONFIG_USE_GYRO_1
 #define GYRO_CONFIG_USE_GYRO_1 0

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -304,11 +304,8 @@ static void updateState(const fdm_packet* pkt)
 
     x = constrain(pkt->imu_angular_velocity_rpy[0] * GYRO_SCALE * RAD2DEG, -32767, 32767);
     y = constrain(-pkt->imu_angular_velocity_rpy[1] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-#if ENABLE_GAZEBO_BRIDGE
-    z = constrain(pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-#else
     z = constrain(-pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-#endif
+    
     virtualGyroSet(virtualGyroDev, x, y, z);
 
 #if ENABLE_GAZEBO_BRIDGE


### PR DESCRIPTION
This pull requests fixes the SITL yaw convention specifically for the Gazebo Harmonic environment. Previously when yaw would be applied to the drone in simulation it would result in the drone yawing infinitely with a negative feedback loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected simulator gyro Z-axis measurement behavior for improved simulation accuracy.

* **Chores**
  * Enhanced compile-time validation to enforce feature dependencies, preventing invalid build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->