### PR TITLE
The MAVLink packets rates change by using Ground Control Station

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -170,11 +170,6 @@ static int16_t headingOrScaledMilliAmpereHoursDrawn(void)
     return DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 }
 
-static uint16_t getHeadingCentidegrees(void)
-{
-    return (uint16_t)(attitude.values.yaw * 10);
-}
-
 static void mavlinkSendStatusText(uint8_t severity, const char *text)
 {
     mavlink_msg_statustext_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
@@ -802,6 +797,11 @@ static void mavlinkSendGpsRaw(void)
     static uint32_t transmitCounter = 0;
     DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 4, transmitCounter);
     transmitCounter = (transmitCounter + 1) % 100;
+}
+
+static uint16_t getHeadingCentidegrees(void)
+{
+    return (uint16_t)(attitude.values.yaw * 10);
 }
 
 static void mavlinkSendGpsGlobalPosition(void)

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1159,7 +1159,11 @@ static void configureMAVLinkOutputMessagesIntervals(void)
         }
 
         if (rate != 0) {
-            mavTelemetryOutputMessages[i].updateInterval = 1000 / rate;
+            uint32_t interval = 1000 / rate;
+            if (interval < MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
+                interval = MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS;
+            }
+            mavTelemetryOutputMessages[i].updateInterval = interval;
             // Phase offset (3*i) staggers transmissions across ~15ms to reduce TX buffer spikes
             mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
         }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -473,7 +473,7 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
             result = MAV_RESULT_DENIED;
             break;
         }
-        mavlinkSendMessageInterval(cmd->param2);
+        mavlinkSendMessageInterval(msgId);
         result = MAV_RESULT_ACCEPTED;
         break;
     default:

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -483,6 +483,7 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
 {
     uint32_t msgId;
     uint32_t intervalMs;
+    bool success = false;
 
     if (!cmdParamToUint32(cmd->param1, UINT32_MAX, &msgId)) {
         mavlinkSendCommandAck(cmd->command, MAV_RESULT_DENIED, targetSystem, targetComponent);
@@ -490,12 +491,15 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
     }
 
     if (cmd->param2 < 0.0f) {
-        mavlinkSendCommandAck(cmd->command, MAV_RESULT_UNSUPPORTED, targetSystem, targetComponent);
-        return;
+        // Set default value
+        success = setMessageUpdateInterval(msgId, 0);
+    } else {
+        intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
+        if (intervalMs == 0) {
+            intervalMs = UINT32_MAX; // Switch send message off
+        }
+        success = setMessageUpdateInterval(msgId, intervalMs);
     }
-
-    intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
-    bool success = setMessageUpdateInterval(msgId, intervalMs);
     mavlinkSendCommandAck(cmd->command, success ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED, targetSystem, targetComponent);
 }
 
@@ -1154,36 +1158,52 @@ static mavlinkTelemetryOutputMessage_t mavTelemetryOutputMessages[] = {
 };
 #define TELEMETRIES_OUTPUT_MESSAGES_COUNT ARRAYLEN(mavTelemetryOutputMessages)
 
+static uint32_t getConfigStreamUpdateInterval(uint8_t stream) {
+    uint32_t rate = 0;
+    uint32_t updateInterval;
+
+    switch (stream) {
+    case MAV_DATA_STREAM_EXTENDED_STATUS:
+        rate = telemetryConfig()->mavlink_extended_status_rate;
+        break;
+    case MAV_DATA_STREAM_RC_CHANNELS:
+        rate = telemetryConfig()->mavlink_rc_channels_rate;
+        break;
+    case MAV_DATA_STREAM_EXTRA1:
+        rate = telemetryConfig()->mavlink_extra1_rate;
+        break;
+    case MAV_DATA_STREAM_EXTRA2:
+        rate = telemetryConfig()->mavlink_extra2_rate;
+        break;
+    case MAV_DATA_STREAM_EXTRA3:
+        rate = telemetryConfig()->mavlink_extra3_rate;
+        break;
+    case MAV_DATA_STREAM_POSITION:
+        rate = telemetryConfig()->mavlink_position_rate;
+        break;
+    }
+
+    if (rate != 0) {
+        updateInterval = 1000 / rate;
+        if (updateInterval < MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
+            updateInterval = MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS;
+        }
+    } else {
+        updateInterval = UINT32_MAX;
+    }
+
+    return updateInterval;
+}
+
 static void configureMAVLinkOutputMessagesIntervals(void)
 {
     // Seed timers to avoid burst on enable
     timeMs_t nowMs = millis();
 
     for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
-        int rate = 0;
-        if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTENDED_STATUS) {
-            rate = telemetryConfig()->mavlink_extended_status_rate;
-        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_RC_CHANNELS) {
-            rate = telemetryConfig()->mavlink_rc_channels_rate;
-        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTRA1) {
-            rate = telemetryConfig()->mavlink_extra1_rate;
-        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTRA2) {
-            rate = telemetryConfig()->mavlink_extra2_rate;
-        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTRA3) {
-            rate = telemetryConfig()->mavlink_extra3_rate;
-        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_POSITION) {
-            rate = telemetryConfig()->mavlink_position_rate;
-        }
-
-        if (rate != 0) {
-            uint32_t interval = 1000 / rate;
-            if (interval < MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
-                interval = MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS;
-            }
-            mavTelemetryOutputMessages[i].updateInterval = interval;
-            // Phase offset (3*i) staggers transmissions across ~15ms to reduce TX buffer spikes
-            mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
-        }
+        mavTelemetryOutputMessages[i].updateInterval = getConfigStreamUpdateInterval(mavTelemetryOutputMessages[i].stream);
+        // Phase offset (3*i) staggers transmissions across ~15ms to reduce TX buffer spikes
+        mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
     }
 }
 
@@ -1198,17 +1218,21 @@ static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterva
     return false;
 }
 
+// Set intervalMs update interval for MAVLink message
+// If intervalMs == 0, then set default value from config
+// If intervalMs == INT32_MAX, then switch off message send
 static bool setMessageUpdateInterval(uint32_t messageId, uint32_t intervalMs)
 {
-    if (intervalMs == 0) {
-        intervalMs = UINT32_MAX;
-    }
-    if (intervalMs >= MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
-        for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
-            if (mavTelemetryOutputMessages[i].id == messageId) {
-                mavTelemetryOutputMessages[i].updateInterval = intervalMs;
-                return true;
+    for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
+        if (mavTelemetryOutputMessages[i].id == messageId) {
+            if (intervalMs == 0) { // Set default value
+                intervalMs = getConfigStreamUpdateInterval(mavTelemetryOutputMessages[i].stream);
             }
+            if(intervalMs < MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
+                intervalMs = MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS;
+            }
+            mavTelemetryOutputMessages[i].updateInterval = intervalMs;
+            return true;
         }
     }
     return false;

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -744,8 +744,9 @@ static void mavlinkSendGpsRaw(void)
     uint16_t msgLength;
     uint8_t gpsFixType = 0;
 
-    if (!sensors(SENSOR_GPS))
+    if (!sensors(SENSOR_GPS)) {
         return;
+    }
 
     if (!STATE(GPS_FIX)) {
         gpsFixType = 1;
@@ -805,6 +806,10 @@ static void mavlinkSendGpsGlobalPosition(void)
 {
     uint16_t msgLength;
 
+    if (!sensors(SENSOR_GPS)) {
+        return;
+    }
+
     // Global position
     mavlink_msg_global_position_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // time_usec Timestamp (microseconds since UNIX epoch or microseconds since system boot)
@@ -833,6 +838,10 @@ static void mavlinkSendGpsGlobalPosition(void)
 static void mavlinkSendGpsGlobalOrigin(void)
 {
     uint16_t msgLength;
+
+    if (!sensors(SENSOR_GPS)) {
+        return;
+    }
 
     mavlink_msg_gps_global_origin_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // Latitude (WGS84), expressed as * 1E7

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -487,7 +487,7 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
     if (cmd->param2 < 0.0f) {
         // Disable message per MAVLink spec (param2 < 0 means disable)
         success = setMessageUpdateInterval(msgId, UINT32_MAX);
-    } if (cmd->param2 == 0.0f) {
+    } else if (cmd->param2 == 0.0f) {
         // param2 == 0 means "request default rate" per MAVLink spec
         success = setMessageUpdateInterval(msgId, 0);
     } else {

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -416,10 +416,15 @@ static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterva
 static void mavlinkSendMessageInterval(uint32_t messageId)
 {
     uint16_t msgLength;
-    uint32_t updateInterval;
+    uint32_t updateIntervalMs;
+    int32_t updateIntervalUs = -1;
 
-    bool result = getMessageUpdateInterval(messageId, &updateInterval);
-    msgLength = mavlink_msg_message_interval_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, messageId, result ? (int32_t)(updateInterval) * 1000 : -1);
+    bool result = getMessageUpdateInterval(messageId, &updateIntervalMs);
+    if (result) {
+        updateIntervalUs = updateIntervalMs * 1000 <= INT32_MAX ? (int32_t)(updateIntervalMs * 1000) : INT32_MAX;
+    }
+
+    msgLength = mavlink_msg_message_interval_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, messageId, updateIntervalUs);
 
     mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1225,7 +1225,7 @@ static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterva
 
 // Set intervalMs update interval for MAVLink message
 // If intervalMs == 0, then set default value from config
-// If intervalMs == INT32_MAX, then switch off message send
+// If intervalMs == UINT32_MAX, then switch off message send
 static bool setMessageUpdateInterval(uint32_t messageId, uint32_t intervalMs)
 {
     for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -682,26 +682,7 @@ static void mavlinkSendRCChannelsAndRSSI(void)
 }
 
 #if defined(USE_GPS)
-static void mavlinkSendHomePosition(void)
-{
-    if (!STATE(GPS_FIX_HOME)) {
-        return;
-    }
-
-    static const float identityQuat[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
-    mavlink_msg_home_position_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
-        GPS_home_llh.lat,
-        GPS_home_llh.lon,
-        GPS_home_llh.altCm * 10,
-        0.0f, 0.0f, 0.0f,
-        identityQuat,
-        0.0f, 0.0f, 0.0f,
-        micros());
-    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
-    mavlinkSerialWrite(mavBuffer, msgLength);
-}
-
-static void mavlinkSendPosition(void)
+static void mavlinkSendGpsRaw(void)
 {
     uint16_t msgLength;
     uint8_t gpsFixType = 0;
@@ -757,6 +738,16 @@ static void mavlinkSendPosition(void)
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
 
+    // Packets transmit counter to debug actual data rate
+    static uint32_t transmitCounter = 0;
+    DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 4, transmitCounter);
+    transmitCounter = (transmitCounter + 1) % 100;
+}
+
+static void mavlinkSendGpsGlobalPosition(void)
+{
+    uint16_t msgLength;
+
     // Global position
     mavlink_msg_global_position_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // time_usec Timestamp (microseconds since UNIX epoch or microseconds since system boot)
@@ -780,6 +771,11 @@ static void mavlinkSendPosition(void)
     );
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
+static void mavlinkSendGpsGlobalOrigin(void)
+{
+    uint16_t msgLength;
 
     mavlink_msg_gps_global_origin_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
         // Latitude (WGS84), expressed as * 1E7
@@ -792,13 +788,25 @@ static void mavlinkSendPosition(void)
         micros());
     msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
+}
 
-    mavlinkSendHomePosition();
+static void mavlinkSendHomePosition(void)
+{
+    if (!STATE(GPS_FIX_HOME)) {
+        return;
+    }
 
-    // Packets transmit counter to debug actual data rate
-    static uint32_t transmitCounter = 0;
-    DEBUG_SET(DEBUG_MAVLINK_TELEMETRY, 4, transmitCounter);
-    transmitCounter = (transmitCounter + 1) % 100;
+    static const float identityQuat[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    mavlink_msg_home_position_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        GPS_home_llh.lat,
+        GPS_home_llh.lon,
+        GPS_home_llh.altCm * 10,
+        0.0f, 0.0f, 0.0f,
+        identityQuat,
+        0.0f, 0.0f, 0.0f,
+        micros());
+    const uint16_t msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
 }
 #endif
 
@@ -829,38 +837,9 @@ static void mavlinkSendAttitude(void)
     transmitCounter = (transmitCounter + 1) % 100;
 }
 
-static void mavlinkSendHUDAndHeartbeat(void)
+static void mavlinkSendHeartbeat(void)
 {
     uint16_t msgLength;
-    float mavAltitude = 0;
-    float mavGroundSpeed = 0;
-    float mavAirSpeed = 0;
-    float mavClimbRate = 0;
-
-#if defined(USE_GPS)
-    // use ground speed if source available
-    if (sensors(SENSOR_GPS)) {
-        mavGroundSpeed = gpsSol.groundSpeed / 100.0f;
-    }
-#endif
-
-    mavAltitude = getEstimatedAltitudeCm() / 100.0f;
-
-    mavlink_msg_vfr_hud_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
-        // airspeed Current airspeed in m/s
-        mavAirSpeed,
-        // groundspeed Current ground speed in m/s
-        mavGroundSpeed,
-        // heading Current heading in degrees, in compass units (0..360, 0=north)
-        headingOrScaledMilliAmpereHoursDrawn(),
-        // throttle Current throttle setting in integer percent, 0 to 100
-        scaleRange(constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
-        // alt Current altitude (MSL), in meters, if we have sonar or baro use them, otherwise use GPS (less accurate)
-        mavAltitude,
-        // climb Current climb rate in meters/second
-        mavClimbRate);
-    msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
-    mavlinkSerialWrite(mavBuffer, msgLength);
 
     uint8_t mavModes = MAV_MODE_MANUAL_DISARMED;
     if (ARMING_FLAG(ARMED))
@@ -941,6 +920,40 @@ static void mavlinkSendHUDAndHeartbeat(void)
     transmitCounter = (transmitCounter + 1) % 100;
 }
 
+static void mavlinkSendHUD(void)
+{
+    uint16_t msgLength;
+    float mavAltitude = 0;
+    float mavGroundSpeed = 0;
+    float mavAirSpeed = 0;
+    float mavClimbRate = 0;
+
+#if defined(USE_GPS)
+    // use ground speed if source available
+    if (sensors(SENSOR_GPS)) {
+        mavGroundSpeed = gpsSol.groundSpeed / 100.0f;
+    }
+#endif
+
+    mavAltitude = getEstimatedAltitudeCm() / 100.0f;
+
+    mavlink_msg_vfr_hud_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg,
+        // airspeed Current airspeed in m/s
+        mavAirSpeed,
+        // groundspeed Current ground speed in m/s
+        mavGroundSpeed,
+        // heading Current heading in degrees, in compass units (0..360, 0=north)
+        headingOrScaledMilliAmpereHoursDrawn(),
+        // throttle Current throttle setting in integer percent, 0 to 100
+        scaleRange(constrain(rcData[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
+        // alt Current altitude (MSL), in meters, if we have sonar or baro use them, otherwise use GPS (less accurate)
+        mavAltitude,
+        // climb Current climb rate in meters/second
+        mavClimbRate);
+    msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
 static void mavlinkSendBatteryStatus(void)
 {
     uint16_t msgLength;
@@ -1014,75 +1027,124 @@ static void mavlinkSendBatteryStatus(void)
     transmitCounter = (transmitCounter + 1) % 100;
 }
 
-/* MAVLink telemetry data streams
-* Rate values are zero-initialized and populated from CLI settings via configureMAVLinkStreamRates()
+/* MAVLink telemetry output data messages
+* updateInterval values are UINT32_MAX-initialized and populated from CLI settings via configureMAVLinkOutputMessagesIntervals()
+* The CLI commands set rates for the messages streams groups
+* The MAV_CMD_SET_MESSAGE_INTERVAL handler will set the update time for any message individually by message id from the GCS command
 */
-static mavlinkTelemetryStream_t mavTelemetryStreams[] = {
-    [MAV_DATA_STREAM_EXTENDED_STATUS] = {
-        .rate = 0,
+static mavlinkTelemetryOutputMessage_t mavTelemetryOutputMessages[] = {
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_EXTENDED_STATUS,
+        .updateInterval = UINT32_MAX,
         .updateTime = 0,
-        .streamFunc = mavlinkSendSystemStatus,
+        .sendMessageFunc = mavlinkSendSystemStatus,
     },
-    [MAV_DATA_STREAM_RC_CHANNELS] = {
-        .rate = 0,
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_RC_CHANNELS,
+        .updateInterval = UINT32_MAX,
         .updateTime = 0,
-        .streamFunc = mavlinkSendRCChannelsAndRSSI,
+        .sendMessageFunc = mavlinkSendRCChannelsAndRSSI,
     },
-    [MAV_DATA_STREAM_POSITION] = {
-        .rate = 0,
-        .updateTime = 0,
 #ifdef USE_GPS
-        .streamFunc = mavlinkSendPosition,
-#else
-        .streamFunc = NULL,
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_POSITION,
+        .updateInterval = UINT32_MAX,
+        .updateTime = 0,
+        .sendMessageFunc = mavlinkSendGpsRaw,
+    },
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_POSITION,
+        .updateInterval = UINT32_MAX,
+        .updateTime = 0,
+        .sendMessageFunc = mavlinkSendGpsGlobalPosition,
+    },
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_POSITION,
+        .updateInterval = UINT32_MAX,
+        .updateTime = 0,
+        .sendMessageFunc = mavlinkSendGpsGlobalOrigin,
+    },
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_POSITION,
+        .updateInterval = UINT32_MAX,
+        .updateTime = 0,
+        .sendMessageFunc = mavlinkSendHomePosition,
+    },
 #endif
-    },
-    [MAV_DATA_STREAM_EXTRA1] = {
-        .rate = 0,
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_EXTRA1,
+        .updateInterval = UINT32_MAX,
         .updateTime = 0,
-        .streamFunc = mavlinkSendAttitude,
+        .sendMessageFunc = mavlinkSendAttitude,
     },
-    [MAV_DATA_STREAM_EXTRA2] = {
-        .rate = 0,
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_EXTRA2,
+        .updateInterval = UINT32_MAX,
         .updateTime = 0,
-        .streamFunc = mavlinkSendHUDAndHeartbeat,
+        .sendMessageFunc = mavlinkSendHeartbeat,
     },
-    [MAV_DATA_STREAM_EXTRA3] = {
-        .rate = 0,
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_EXTRA2,
+        .updateInterval = UINT32_MAX,
         .updateTime = 0,
-        .streamFunc = mavlinkSendBatteryStatus,
+        .sendMessageFunc = mavlinkSendHUD,
+    },
+    {
+        .id = 0,
+        .stream = MAV_DATA_STREAM_EXTRA3,
+        .updateInterval = UINT32_MAX,
+        .updateTime = 0,
+        .sendMessageFunc = mavlinkSendBatteryStatus,
     }
 };
-#define TELEMETRIES_STREAM_COUNT ARRAYLEN(mavTelemetryStreams)
+#define TELEMETRIES_OUTPUT_MESSAGES_COUNT ARRAYLEN(mavTelemetryOutputMessages)
 
-static void configureMAVLinkStreamRates(void)
+static void configureMAVLinkOutputMessagesIntervals(void)
 {
-    mavTelemetryStreams[MAV_DATA_STREAM_EXTENDED_STATUS].rate = telemetryConfig()->mavlink_extended_status_rate;
-    mavTelemetryStreams[MAV_DATA_STREAM_RC_CHANNELS].rate = telemetryConfig()->mavlink_rc_channels_rate;
-#ifdef USE_GPS
-    mavTelemetryStreams[MAV_DATA_STREAM_POSITION].rate = telemetryConfig()->mavlink_position_rate;
-#endif
-    mavTelemetryStreams[MAV_DATA_STREAM_EXTRA1].rate = telemetryConfig()->mavlink_extra1_rate;
-    mavTelemetryStreams[MAV_DATA_STREAM_EXTRA2].rate = telemetryConfig()->mavlink_extra2_rate;
-    mavTelemetryStreams[MAV_DATA_STREAM_EXTRA3].rate = telemetryConfig()->mavlink_extra3_rate;
-
     // Seed timers to avoid burst on enable
     timeMs_t nowMs = millis();
-    for (uint16_t i = 0; i < TELEMETRIES_STREAM_COUNT; i++) {
-        const uint8_t rate = mavTelemetryStreams[i].rate;
-        // Phase offset (3*i) staggers transmissions across ~15ms to reduce TX buffer spikes
-        mavTelemetryStreams[i].updateTime = (rate > 0) ? nowMs + (timeMs_t)(1000 / rate) + 3 * i : 0;
+
+    for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
+        int rate = 0;
+        if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTENDED_STATUS) {
+            rate = telemetryConfig()->mavlink_extended_status_rate;
+        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_RC_CHANNELS) {
+            rate = telemetryConfig()->mavlink_rc_channels_rate;
+        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTRA1) {
+            rate = telemetryConfig()->mavlink_extra1_rate;
+        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTRA2) {
+            rate = telemetryConfig()->mavlink_extra2_rate;
+        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_EXTRA3) {
+            rate = telemetryConfig()->mavlink_extra3_rate;
+        } else if (mavTelemetryOutputMessages[i].stream == MAV_DATA_STREAM_POSITION) {
+            rate = telemetryConfig()->mavlink_position_rate;
+        }
+
+        if (rate != 0) {
+            mavTelemetryOutputMessages[i].updateInterval = 1000 / rate;
+            // Phase offset (3*i) staggers transmissions across ~15ms to reduce TX buffer spikes
+            mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
+        }
     }
 }
 
 static void processMAVLinkTelemetry(void)
 {
     timeMs_t currentTimeMs = millis();
-    for (uint16_t i = 0; i < TELEMETRIES_STREAM_COUNT; i++) {
-        if (mavTelemetryStreams[i].rate != 0 && mavTelemetryStreams[i].streamFunc != NULL) {
-            if (currentTimeMs >= mavTelemetryStreams[i].updateTime) {
-                mavTelemetryStreams[i].streamFunc();
-                mavTelemetryStreams[i].updateTime = currentTimeMs + (timeMs_t)(1000 / mavTelemetryStreams[i].rate);
+    for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
+        if (mavTelemetryOutputMessages[i].updateInterval != UINT32_MAX && mavTelemetryOutputMessages[i].sendMessageFunc != NULL) {
+            if (currentTimeMs >= mavTelemetryOutputMessages[i].updateTime) {
+                mavTelemetryOutputMessages[i].sendMessageFunc();
+                mavTelemetryOutputMessages[i].updateTime = currentTimeMs + mavTelemetryOutputMessages[i].updateInterval;
             }
         }
     }
@@ -1096,7 +1158,7 @@ void checkMAVLinkTelemetryState(void)
             lastArmingDisableFlags = 0;
             mavlinkPortOwned = false;
             mavlinkTelemetryEnabled = true;
-            configureMAVLinkStreamRates();
+            configureMAVLinkOutputMessagesIntervals();
         }
     } else {
         bool newTelemetryEnabledValue = telemetryDetermineEnabledState(mavlinkPortSharing);
@@ -1107,7 +1169,7 @@ void checkMAVLinkTelemetryState(void)
 
         if (newTelemetryEnabledValue) {
             configureMAVLinkTelemetryPort();
-            configureMAVLinkStreamRates();
+            configureMAVLinkOutputMessagesIntervals();
         } else {
             freeMAVLinkTelemetryPort();
         }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -491,7 +491,7 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
         // param2 == 0 means "request default rate" per MAVLink spec
         success = setMessageUpdateInterval(msgId, 0);
     } else {
-        uint32_t intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
+        uint32_t intervalMs = (cmd->param2 >= 1000.0f) ? (uint32_t)(cmd->param2 / 1000.0f) : 1;
         success = setMessageUpdateInterval(msgId, intervalMs);
     }
     mavlinkSendCommandAck(cmd->command, success ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED, targetSystem, targetComponent);

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -496,14 +496,16 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
     }
 
     if (cmd->param2 < 0.0f) {
-        // Set default value
-        success = setMessageUpdateInterval(msgId, 0);
+        // Disable message per MAVLink spec (param2 < 0 means disable)
+        success = setMessageUpdateInterval(msgId, UINT32_MAX);
     } else {
         intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
         if (intervalMs == 0) {
-            intervalMs = UINT32_MAX; // Switch send message off
+            // param2 == 0 means "request default rate" per MAVLink spec
+            success = setMessageUpdateInterval(msgId, 0);
+        } else {
+            success = setMessageUpdateInterval(msgId, intervalMs);
         }
-        success = setMessageUpdateInterval(msgId, intervalMs);
     }
     mavlinkSendCommandAck(cmd->command, success ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED, targetSystem, targetComponent);
 }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -477,7 +477,6 @@ static bool setMessageUpdateInterval(uint32_t id, uint32_t intervalMs);
 static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t targetSystem, uint8_t targetComponent)
 {
     uint32_t msgId;
-    uint32_t intervalMs;
     bool success = false;
 
     if (!cmdParamToUint32(cmd->param1, UINT32_MAX, &msgId)) {
@@ -488,14 +487,12 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
     if (cmd->param2 < 0.0f) {
         // Disable message per MAVLink spec (param2 < 0 means disable)
         success = setMessageUpdateInterval(msgId, UINT32_MAX);
+    } if (cmd->param2 == 0.0f) {
+        // param2 == 0 means "request default rate" per MAVLink spec
+        success = setMessageUpdateInterval(msgId, 0);
     } else {
-        intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
-        if (intervalMs == 0) {
-            // param2 == 0 means "request default rate" per MAVLink spec
-            success = setMessageUpdateInterval(msgId, 0);
-        } else {
-            success = setMessageUpdateInterval(msgId, intervalMs);
-        }
+        uint32_t intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
+        success = setMessageUpdateInterval(msgId, intervalMs);
     }
     mavlinkSendCommandAck(cmd->command, success ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED, targetSystem, targetComponent);
 }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1179,6 +1179,9 @@ static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterva
 
 static bool setMessageUpdateInterval(uint32_t messageId, uint32_t intervalMs)
 {
+    if (intervalMs == 0) {
+        intervalMs = UINT32_MAX;
+    }
     if (intervalMs >= MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
         for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
             if (mavTelemetryOutputMessages[i].id == messageId) {

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -463,6 +463,11 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
         result = MAV_RESULT_ACCEPTED;
         break;
     case MAVLINK_MSG_ID_MESSAGE_INTERVAL:
+        uint32_t msgId;
+        if (!cmdParamToUint32(cmd->param2, UINT32_MAX, &msgId)) {
+            result = MAV_RESULT_DENIED;
+            break;
+        }
         mavlinkSendMessageInterval(cmd->param2);
         result = MAV_RESULT_ACCEPTED;
         break;
@@ -476,10 +481,22 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
 static bool setMessageUpdateInterval(uint32_t id, uint32_t intervalMs);
 static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t targetSystem, uint8_t targetComponent)
 {
-    uint32_t msgId = cmd->param1;
-    uint32_t intervalMs = cmd->param2 / 1000;
-    bool result = setMessageUpdateInterval(msgId, intervalMs);
-    mavlinkSendCommandAck(cmd->command, result ? MAV_RESULT_ACCEPTED : MAV_RESULT_UNSUPPORTED, targetSystem, targetComponent);
+    uint32_t msgId;
+    uint32_t intervalMs;
+
+    if (!cmdParamToUint32(cmd->param1, UINT32_MAX, &msgId)) {
+        mavlinkSendCommandAck(cmd->command, MAV_RESULT_DENIED, targetSystem, targetComponent);
+        return;
+    }
+
+    if (cmd->param2 < 0.0f) {
+        mavlinkSendCommandAck(cmd->command, MAV_RESULT_UNSUPPORTED, targetSystem, targetComponent);
+        return;
+    }
+
+    intervalMs = (uint32_t)(cmd->param2 / 1000.0f);
+    bool success = setMessageUpdateInterval(msgId, intervalMs);
+    mavlinkSendCommandAck(cmd->command, success ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED, targetSystem, targetComponent);
 }
 
 static void handleCommandLong(const mavlink_message_t *msg)

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -407,23 +407,15 @@ static bool cmdParamToUint32(float f, uint32_t maxValue, uint32_t *out)
     return true;
 }
 
-static uint8_t getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval);
+static int32_t getMessageUpdateInterval(uint32_t messageId);
 static void mavlinkSendMessageInterval(uint32_t messageId)
 {
     uint16_t msgLength;
-    uint32_t updateIntervalMs;
-    int32_t updateIntervalUs = -1; // message not supported
+    int32_t updateIntervalUs;
 
-    uint8_t result = getMessageUpdateInterval(messageId, &updateIntervalMs);
-    if (result == 0) {
-        updateIntervalUs = updateIntervalMs * 1000 <= INT32_MAX ? (int32_t)(updateIntervalMs * 1000) : INT32_MAX;
-    } else if (result == 2) {
-        updateIntervalUs = 0; // message disabled
-    }
-
-    msgLength = mavlink_msg_message_interval_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, messageId, updateIntervalUs);
-
-    mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    updateIntervalUs = getMessageUpdateInterval(messageId);
+    mavlink_msg_message_interval_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, messageId, updateIntervalUs);
+    msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
     mavlinkSerialWrite(mavBuffer, msgLength);
 }
 
@@ -464,7 +456,7 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
         mavlinkSendAvailableModesMonitor();
         result = MAV_RESULT_ACCEPTED;
         break;
-    case MAVLINK_MSG_ID_MESSAGE_INTERVAL:
+    case MAVLINK_MSG_ID_MESSAGE_INTERVAL: {
         uint32_t msgId;
         if (!cmdParamToUint32(cmd->param2, UINT32_MAX, &msgId)) {
             result = MAV_RESULT_DENIED;
@@ -473,6 +465,7 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
         mavlinkSendMessageInterval(msgId);
         result = MAV_RESULT_ACCEPTED;
         break;
+    }
     default:
         result = MAV_RESULT_UNSUPPORTED;
         break;
@@ -1225,18 +1218,22 @@ static void configureMAVLinkOutputMessagesIntervals(void)
     }
 }
 
-// return value 0 - Ok
-// return value 1 - message not found
-// return value 2 - message disabled
-static uint8_t getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval)
+// A return value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.
+static int32_t getMessageUpdateInterval(uint32_t messageId)
 {
+    int32_t updateIntervalUs = 0;
     for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
         if (mavTelemetryOutputMessages[i].id == messageId) {
-            *updateInterval = mavTelemetryOutputMessages[i].updateInterval;
-            return (*updateInterval != UINT32_MAX) ? 0 : 2;
+            uint32_t updateIntervalMs = mavTelemetryOutputMessages[i].updateInterval;
+            if (updateIntervalMs == UINT32_MAX) {
+                updateIntervalUs = -1;
+            } else {
+                updateIntervalUs = updateIntervalMs * 1000 <= INT32_MAX ? (int32_t)(updateIntervalMs * 1000) : INT32_MAX;
+            }
+            break;
         }
     }
-    return 1;
+    return updateIntervalUs;
 }
 
 // Set intervalMs update interval for MAVLink message

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -831,7 +831,7 @@ static void mavlinkSendGpsGlobalOrigin(void)
 {
     uint16_t msgLength;
 
-    if (!sensors(SENSOR_GPS)) {
+    if (!sensors(SENSOR_GPS) || !STATE(GPS_FIX_HOME)) {
         return;
     }
 

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -456,6 +456,15 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
     mavlinkSendCommandAck(MAV_CMD_REQUEST_MESSAGE, result, targetSystem, targetComponent);
 }
 
+static bool setMessageUpdateInterval(uint32_t id, uint32_t intervalMs);
+static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t targetSystem, uint8_t targetComponent)
+{
+    uint32_t msgId = cmd->param1;
+    uint32_t intervalMs = cmd->param2 / 1000;
+    bool result = setMessageUpdateInterval(msgId, intervalMs);
+    mavlinkSendCommandAck(cmd->command, result ? MAV_RESULT_ACCEPTED : MAV_RESULT_UNSUPPORTED, targetSystem, targetComponent);
+}
+
 static void handleCommandLong(const mavlink_message_t *msg)
 {
     mavlink_command_long_t cmd;
@@ -483,6 +492,9 @@ static void handleCommandLong(const mavlink_message_t *msg)
     }
     case MAV_CMD_REQUEST_MESSAGE:
         handleRequestMessage(&cmd, msg->sysid, msg->compid);
+        break;
+    case MAV_CMD_SET_MESSAGE_INTERVAL:
+        handleSetMessageInterval(&cmd, msg->sysid, msg->compid);
         break;
     default:
         mavlinkSendCommandAck(cmd.command, MAV_RESULT_UNSUPPORTED, msg->sysid, msg->compid);
@@ -1034,14 +1046,14 @@ static void mavlinkSendBatteryStatus(void)
 */
 static mavlinkTelemetryOutputMessage_t mavTelemetryOutputMessages[] = {
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_SYS_STATUS,
         .stream = MAV_DATA_STREAM_EXTENDED_STATUS,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendSystemStatus,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_RC_CHANNELS_RAW,
         .stream = MAV_DATA_STREAM_RC_CHANNELS,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
@@ -1049,28 +1061,28 @@ static mavlinkTelemetryOutputMessage_t mavTelemetryOutputMessages[] = {
     },
 #ifdef USE_GPS
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_GPS_RAW_INT,
         .stream = MAV_DATA_STREAM_POSITION,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendGpsRaw,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
         .stream = MAV_DATA_STREAM_POSITION,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendGpsGlobalPosition,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN,
         .stream = MAV_DATA_STREAM_POSITION,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendGpsGlobalOrigin,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_HOME_POSITION,
         .stream = MAV_DATA_STREAM_POSITION,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
@@ -1078,28 +1090,28 @@ static mavlinkTelemetryOutputMessage_t mavTelemetryOutputMessages[] = {
     },
 #endif
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_ATTITUDE,
         .stream = MAV_DATA_STREAM_EXTRA1,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendAttitude,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_HEARTBEAT,
         .stream = MAV_DATA_STREAM_EXTRA2,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendHeartbeat,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_VFR_HUD,
         .stream = MAV_DATA_STREAM_EXTRA2,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
         .sendMessageFunc = mavlinkSendHUD,
     },
     {
-        .id = 0,
+        .id = MAVLINK_MSG_ID_BATTERY_STATUS,
         .stream = MAV_DATA_STREAM_EXTRA3,
         .updateInterval = UINT32_MAX,
         .updateTime = 0,
@@ -1135,6 +1147,19 @@ static void configureMAVLinkOutputMessagesIntervals(void)
             mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
         }
     }
+}
+
+static bool setMessageUpdateInterval(uint32_t messageId, uint32_t intervalMs)
+{
+    if (intervalMs >= MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS) {
+        for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
+            if (mavTelemetryOutputMessages[i].id == messageId) {
+                mavTelemetryOutputMessages[i].updateInterval = intervalMs;
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 static void processMAVLinkTelemetry(void)

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1211,7 +1211,9 @@ static void configureMAVLinkOutputMessagesIntervals(void)
     for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
         mavTelemetryOutputMessages[i].updateInterval = getConfigStreamUpdateInterval(mavTelemetryOutputMessages[i].stream);
         // Phase offset (3*i) staggers transmissions across ~15ms to reduce TX buffer spikes
-        mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
+        if (mavTelemetryOutputMessages[i].updateInterval != UINT32_MAX) {
+            mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
+        }
     }
 }
 

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -412,16 +412,18 @@ static bool cmdParamToUint32(float f, uint32_t maxValue, uint32_t *out)
     return true;
 }
 
-static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval);
+static uint8_t getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval);
 static void mavlinkSendMessageInterval(uint32_t messageId)
 {
     uint16_t msgLength;
     uint32_t updateIntervalMs;
-    int32_t updateIntervalUs = -1;
+    int32_t updateIntervalUs = -1; // message not supported
 
-    bool result = getMessageUpdateInterval(messageId, &updateIntervalMs);
-    if (result) {
+    uint8_t result = getMessageUpdateInterval(messageId, &updateIntervalMs);
+    if (result == 0) {
         updateIntervalUs = updateIntervalMs * 1000 <= INT32_MAX ? (int32_t)(updateIntervalMs * 1000) : INT32_MAX;
+    } else if (result == 2) {
+        updateIntervalUs = 0; // message disabled
     }
 
     msgLength = mavlink_msg_message_interval_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, messageId, updateIntervalUs);
@@ -1223,15 +1225,18 @@ static void configureMAVLinkOutputMessagesIntervals(void)
     }
 }
 
-static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval)
+// return value 0 - Ok
+// return value 1 - message not found
+// return value 2 - message disabled
+static uint8_t getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval)
 {
     for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
         if (mavTelemetryOutputMessages[i].id == messageId) {
             *updateInterval = mavTelemetryOutputMessages[i].updateInterval;
-            return *updateInterval != UINT32_MAX;
+            return (*updateInterval != UINT32_MAX) ? 0 : 2;
         }
     }
-    return false;
+    return 1;
 }
 
 // Set intervalMs update interval for MAVLink message

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -412,6 +412,19 @@ static bool cmdParamToUint32(float f, uint32_t maxValue, uint32_t *out)
     return true;
 }
 
+static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval);
+static void mavlinkSendMessageInterval(uint32_t messageId)
+{
+    uint16_t msgLength;
+    uint32_t updateInterval;
+
+    bool result = getMessageUpdateInterval(messageId, &updateInterval);
+    msgLength = mavlink_msg_message_interval_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &mavMsg, messageId, result ? (int32_t)(updateInterval) * 1000 : -1);
+
+    mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+
 static void handleRequestMessage(const mavlink_command_long_t *cmd,
     uint8_t targetSystem, uint8_t targetComponent)
 {
@@ -447,6 +460,10 @@ static void handleRequestMessage(const mavlink_command_long_t *cmd,
     }
     case MAVLINK_MSG_ID_AVAILABLE_MODES_MONITOR:
         mavlinkSendAvailableModesMonitor();
+        result = MAV_RESULT_ACCEPTED;
+        break;
+    case MAVLINK_MSG_ID_MESSAGE_INTERVAL:
+        mavlinkSendMessageInterval(cmd->param2);
         result = MAV_RESULT_ACCEPTED;
         break;
     default:
@@ -1147,6 +1164,17 @@ static void configureMAVLinkOutputMessagesIntervals(void)
             mavTelemetryOutputMessages[i].updateTime =  nowMs + mavTelemetryOutputMessages[i].updateInterval + 3 * i;
         }
     }
+}
+
+static bool getMessageUpdateInterval(uint32_t messageId, uint32_t *updateInterval)
+{
+    for (uint16_t i = 0; i < TELEMETRIES_OUTPUT_MESSAGES_COUNT; i++) {
+        if (mavTelemetryOutputMessages[i].id == messageId) {
+            *updateInterval = mavTelemetryOutputMessages[i].updateInterval;
+            return *updateInterval != UINT32_MAX;
+        }
+    }
+    return false;
 }
 
 static bool setMessageUpdateInterval(uint32_t messageId, uint32_t intervalMs)

--- a/src/main/telemetry/mavlink.h
+++ b/src/main/telemetry/mavlink.h
@@ -22,6 +22,8 @@
 
 #include "common/time.h"
 
+#define MIN_MAVLINK_TELEMETRY_UPDATE_INTERVAL_MS 20
+
 void initMAVLinkTelemetry(void);
 void handleMAVLinkTelemetry(void);
 void checkMAVLinkTelemetryState(void);
@@ -40,7 +42,7 @@ typedef struct __mavlink_message mavlink_message_t;
 void mavlinkSendMessage(mavlink_message_t *msg);
 
 typedef struct mavlinkTelemetryOutputMessage_s {
-    const uint8_t id;
+    const uint32_t id;
     const uint8_t stream;
     timeMs_t updateInterval;
     timeMs_t updateTime;

--- a/src/main/telemetry/mavlink.h
+++ b/src/main/telemetry/mavlink.h
@@ -39,8 +39,10 @@ typedef struct __mavlink_message mavlink_message_t;
 // buffer/port path.
 void mavlinkSendMessage(mavlink_message_t *msg);
 
-typedef struct mavlinkTelemetryStream_s {
-    uint8_t rate;
+typedef struct mavlinkTelemetryOutputMessage_s {
+    const uint8_t id;
+    const uint8_t stream;
+    timeMs_t updateInterval;
     timeMs_t updateTime;
-    void (*const streamFunc)(void);
-} mavlinkTelemetryStream_t;
+    void (*const sendMessageFunc)(void);
+} mavlinkTelemetryOutputMessage_t;


### PR DESCRIPTION
Added handlers for MAVLink MAV_CMD_SET_MESSAGE_INTERVAL and MAVLINK_MSG_ID_MESSAGE_INTERVAL commands to change MAVLink data packets rate from Ground control station.
The CLI commands set MAVLink data rate for the packet group (streams) - #14729.
This PR allows to change data rates individually for each packet from GCS by using  MAV_CMD_SET_MESSAGE_INTERVAL  command.
This PR also resolved this issue report: #12351



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure update intervals per telemetry message.
  * Request and set message intervals remotely, with ACKs and support for disabling or reverting to defaults.

* **Refactor**
  * Telemetry scheduling moved to per-message timing for finer control and phased dispatch.
  * GPS, global position/origin, heartbeat, and HUD outputs separated into distinct send paths.
  * Minimum telemetry update interval standardized to 20 ms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->