### PR TITLE
refactor: consolidate serial LIDAR function bits into FUNCTION_LIDAR

### DIFF
--- a/src/main/drivers/rangefinder/rangefinder_lidartf.c
+++ b/src/main/drivers/rangefinder/rangefinder_lidartf.c
@@ -287,12 +287,12 @@ bool lidarTFDetect(rangefinderDev_t *dev, rangefinderType_e rfType)
         return false; // supplied rfType is not TF
     }
 
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR_TF);
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR);
     if (!portConfig) {
         return false;
     }
 
-    tfSerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR_TF, NULL, NULL, 115200, MODE_RXTX, 0);
+    tfSerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR, NULL, NULL, 115200, MODE_RXTX, 0);
     if (tfSerialPort == NULL) {
         return false;
     }

--- a/src/main/drivers/rangefinder/rangefinder_nooploop.c
+++ b/src/main/drivers/rangefinder/rangefinder_nooploop.c
@@ -235,12 +235,12 @@ bool nooploopDetect(rangefinderDev_t *dev, rangefinderType_e rfType)
         return false;
     }
 
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR_NL);
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR);
     if (!portConfig) {
         return false;
     }
 
-    nooploopSerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR_NL, NULL, NULL, NOOPLOOP_BAUDRATE, MODE_RXTX, 0);
+    nooploopSerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR, NULL, NULL, NOOPLOOP_BAUDRATE, MODE_RXTX, 0);
     if (nooploopSerialPort == NULL) {
         return false;
     }

--- a/src/main/drivers/rangefinder/rangefinder_upt1.c
+++ b/src/main/drivers/rangefinder/rangefinder_upt1.c
@@ -284,18 +284,20 @@ int32_t rangefinderUPT1GetDistance(rangefinderDev_t *dev)
 
 bool rangefinderUPT1Detect(rangefinderDev_t *dev)
 {
-    // Check if serial port is configured for rangefinder/optical flow
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR);
-
-    if (!portConfig) {
-        return false;
-    }
-
-    // Open serial port at 115200n1 (per UP-T1-001-Plus specification)
-    upt1SerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR, NULL, NULL, UPT1_BAUDRATE, MODE_RXTX, 0);
-
+    // UP-T1-001-Plus uses the same serial port for both rangefinder and optical flow.
+    // Reuse the port if optical flow detection already opened it, since openSerialPort()
+    // rejects an already-in-use port and would otherwise clear upt1SerialPort.
     if (upt1SerialPort == NULL) {
-        return false;
+        const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR);
+        if (!portConfig) {
+            return false;
+        }
+
+        // Open serial port at 115200n1 (per UP-T1-001-Plus specification)
+        upt1SerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR, NULL, NULL, UPT1_BAUDRATE, MODE_RXTX, 0);
+        if (upt1SerialPort == NULL) {
+            return false;
+        }
     }
 
     dev->delayMs = 10;  // 50Hz frame rate = 20ms period, but oversample 2x

--- a/src/main/drivers/rangefinder/rangefinder_upt1.c
+++ b/src/main/drivers/rangefinder/rangefinder_upt1.c
@@ -285,14 +285,14 @@ int32_t rangefinderUPT1GetDistance(rangefinderDev_t *dev)
 bool rangefinderUPT1Detect(rangefinderDev_t *dev)
 {
     // Check if serial port is configured for rangefinder/optical flow
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR_TF);
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR);
 
     if (!portConfig) {
         return false;
     }
 
     // Open serial port at 115200n1 (per UP-T1-001-Plus specification)
-    upt1SerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR_TF, NULL, NULL, UPT1_BAUDRATE, MODE_RXTX, 0);
+    upt1SerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR, NULL, NULL, UPT1_BAUDRATE, MODE_RXTX, 0);
 
     if (upt1SerialPort == NULL) {
         return false;
@@ -338,11 +338,11 @@ bool upt1OpticalflowDetect(opticalflowDev_t *dev)
     // UP-T1-001-Plus uses the same serial port for both rangefinder and optical flow
     // Check if serial port is configured (should already be open from rangefinder detection)
     if (upt1SerialPort == NULL) {
-        const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR_TF);
+        const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_LIDAR);
         if (!portConfig) {
             return false;
         }
-        upt1SerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR_TF, NULL, NULL, UPT1_BAUDRATE, MODE_RXTX, 0);
+        upt1SerialPort = openSerialPort(portConfig->identifier, FUNCTION_LIDAR, NULL, NULL, UPT1_BAUDRATE, MODE_RXTX, 0);
         if (upt1SerialPort == NULL) {
             return false;
         }

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -48,12 +48,11 @@ typedef enum {
     FUNCTION_TELEMETRY_IBUS      = (1 << 12), // 4096
     FUNCTION_VTX_TRAMP           = (1 << 13), // 8192
     FUNCTION_RCDEVICE            = (1 << 14), // 16384
-    FUNCTION_LIDAR_TF            = (1 << 15), // 32768
+    FUNCTION_LIDAR               = (1 << 15), // 32768 - unified serial rangefinder bit (was FUNCTION_LIDAR_TF); the driver is selected via rangefinder_hardware
     FUNCTION_FRSKY_OSD           = (1 << 16), // 65536
     FUNCTION_VTX_MSP             = (1 << 17), // 131072
     FUNCTION_GIMBAL              = (1 << 18), // 262144
-    FUNCTION_LIDAR_NL            = (1 << 19), // 524288
-    FUNCTION_OSD_CUSTOM_TEXT     = (1 << 20), // 1048576
+    FUNCTION_OSD_CUSTOM_TEXT     = (1 << 19), // 524288 - moved into the bit freed by consolidating the serial LIDAR functions (was 1 << 20)
 } serialPortFunction_e;
 
 #define TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY_HUB | FUNCTION_TELEMETRY_LTM | FUNCTION_TELEMETRY_MAVLINK)


### PR DESCRIPTION
## Summary

Consolidates the per-driver serial rangefinder port-function bits into a single `FUNCTION_LIDAR` bit. Closes #15296 (firmware portion).

Each serial rangefinder driver previously defined or borrowed its own `serialPortFunction_e` bit (`FUNCTION_LIDAR_TF` = `1 << 15`, `FUNCTION_LIDAR_NL` = `1 << 19`), with `rangefinder_upt1.c` borrowing the TF bit. Since the active driver is already selected by the `rangefinder_hardware` setting, all serial rangefinders can share one function bit — saving a scarce function-mask bit and removing the port-assignment bug where drivers borrow each other's bit.

- `io/serial.h`: rename `FUNCTION_LIDAR_TF` → `FUNCTION_LIDAR` (keeps value `1 << 15`); remove `FUNCTION_LIDAR_NL` and move `FUNCTION_OSD_CUSTOM_TEXT` into the freed `1 << 19` slot (was `1 << 20`) so the top of the enum stays contiguous.
- `rangefinder_lidartf.c`, `rangefinder_upt1.c`, `rangefinder_nooploop.c`: use `FUNCTION_LIDAR`.

## Config carry-over (no migration)

`FUNCTION_LIDAR` reuses the former `FUNCTION_LIDAR_TF` bit value, so existing **LIDAR_TF and UPT1** serial configurations are preserved with no migration. **Nooploop** (former `FUNCTION_LIDAR_NL`) and **OSD custom text** serial configurations need the port re-selected once after upgrading, since their bit values changed; until then the now-unused bit is ignored harmlessly (`isSerialConfigValid()` does not reject unknown function bits).

Bumping the `PG_SERIAL_CONFIG` version was deliberately avoided: `pgLoad()` discards stored data on a version mismatch, which would reset every user's entire serial-port configuration. Betaflight has no in-place config-migration framework, so reusing the TF bit value is the least-disruptive option.

## Test plan

- `make TARGET=SITL` — clean build (serial.c and all three rangefinder drivers compile, `.elf` produced).
- `make test_io_serial_unittest` — PASS.

## Out of scope (follow-ups)

- **betaflight-configurator**: no change required — it handles serial function masks numerically, not by named bit.
- **sp10m01** (`rangefinder_sp10m01.c`) and `serial_feature_map.c`: deferred — they come from unmerged PRs #15295 / #15131 and are not present on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified LIDAR/rangefinder handling so all rangefinder types share a single serial-port selection and configuration.

* **Behavior**
  * Detection now fails earlier when required serial configuration is absent and reuses an already-open LIDAR serial port when available.

* **Compatibility**
  * No public APIs or user-facing settings were removed; behavior is consolidated under the unified LIDAR selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->