### PR TITLE
Make LTO and -Wdouble-promotion per-MCU-family toggles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ DEBUG_MIXED = no
 LTO ?= yes
 
 # Promotion of float to double is treated as an error by default. An {mcu}.mk can
-# set "DOUBLE_PROMOTION := no" to demote it to a suppressed warning
+# set "DOUBLE_PROMOTION := no" to disable the diagnostic entirely
 # (-Wno-double-promotion) instead.
 DOUBLE_PROMOTION ?= yes
 
@@ -337,7 +337,7 @@ ifeq ($(LTO),no)
 CFLAGS_DISABLED += -flto=auto -fuse-linker-plugin
 endif
 
-# Select whether double-promotion is an error (default) or a suppressed warning.
+# Select whether double-promotion is an error (default) or disabled entirely.
 ifeq ($(DOUBLE_PROMOTION),no)
 WARN_DOUBLE_PROMOTION := -Wno-double-promotion
 else

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,16 @@ EXTRA_LD_FLAGS  :=
 #
 DEBUG_MIXED = no
 
+# Link-time optimisation is enabled by default. An {mcu}.mk can set "LTO := no"
+# (e.g. for an XIP / run-from-RAM layout that relies on per-function sections)
+# to strip the LTO flags from every optimisation profile and the link.
+LTO ?= yes
+
+# Promotion of float to double is treated as an error by default. An {mcu}.mk can
+# set "DOUBLE_PROMOTION := no" to demote it to a suppressed warning
+# (-Wno-double-promotion) instead.
+DOUBLE_PROMOTION ?= yes
+
 ifeq ($(DEBUG),INFO)
 DEBUG_MIXED = yes
 endif
@@ -318,6 +328,23 @@ endif
 #
 
 #
+# Resolve per-family build toggles now that the {mcu}.mk has been included.
+#
+
+# Disabling LTO routes its flags through CFLAGS_DISABLED so they are stripped
+# from every optimisation profile (CC_*_OPTIMISATION) and from LTO_FLAGS/LD_FLAGS.
+ifeq ($(LTO),no)
+CFLAGS_DISABLED += -flto=auto -fuse-linker-plugin
+endif
+
+# Select whether double-promotion is an error (default) or a suppressed warning.
+ifeq ($(DOUBLE_PROMOTION),no)
+WARN_DOUBLE_PROMOTION := -Wno-double-promotion
+else
+WARN_DOUBLE_PROMOTION := -Wdouble-promotion
+endif
+
+#
 # Tool options.
 #
 CC_DEBUG_OPTIMISATION   := $(OPTIMISE_DEFAULT)
@@ -350,7 +377,7 @@ CFLAGS     += $(ARCH_FLAGS) \
               $(addprefix -isystem,$(SYS_INCLUDE_DIRS)) \
               $(DEBUG_FLAGS) \
               -std=gnu17 \
-              -Wall -Wextra -Werror -Wunsafe-loop-optimizations -Wdouble-promotion \
+              -Wall -Wextra -Werror -Wunsafe-loop-optimizations $(WARN_DOUBLE_PROMOTION) \
               $(EXTRA_WARNING_FLAGS) \
               -ffunction-sections \
               -fdata-sections \

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -627,5 +627,5 @@ $(PICO_LIB_TARGETS): CC_DEFAULT_OPTIMISATION := $(PICO_LIB_OPTIMISATION)
 # that can't work if build uses lto (link time optimisation has the effect of
 # breaking files up into temporary files)
 ifeq ($(RUN_FROM_RAM),1)
-OPTIMISATION_BASE     := $(filter-out -flto=auto, $(OPTIMISATION_BASE))
+LTO                   := no
 endif

--- a/src/platform/STM32/mk/STM32N6.mk
+++ b/src/platform/STM32/mk/STM32N6.mk
@@ -132,7 +132,7 @@ DEVICE_FLAGS       += -DN6_XIP_BUILD
 # into AXISRAM. Drop LTO for XIP only — clock funcs run from RAM,
 # instruction fetches survive the AXI clock transition during
 # HAL_RCC_OscConfig's HSI-park dance. Size cost is ~5-10% .text.
-OPTIMISATION_BASE   := -ffast-math -fmerge-all-constants
+LTO                 := no
 else ifeq ($(RAM_ONLY),1)
 DEFAULT_LD_SCRIPT   = $(LINKER_DIR)/STM32N657XX_RAM.ld
 DEVICE_FLAGS       += -DN6_RAM_ONLY_BUILD


### PR DESCRIPTION
Adds two build toggles, both defaulting to the current behaviour and overridable from any `{mcu}.mk` or the command line:

- `LTO` (default `yes`): set `LTO := no` to strip `-flto=auto`/`-fuse-linker-plugin` from every optimisation profile and from the link.
- `DOUBLE_PROMOTION` (default `yes`): set `DOUBLE_PROMOTION := no` to demote `-Wdouble-promotion` to `-Wno-double-promotion`.

Migrates the existing hand-rolled LTO removals in STM32N6 (XIP) and RP2350 (`RUN_FROM_RAM`) onto the new toggle. This also drops the dead `-flto` that previously still reached the linker via `LTO_FLAGS` in both cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-configurable build toggles for Link Time Optimization (default: enabled) and for double-promotion warnings (default: enabled), letting builders enable/disable LTO and suppress or enable the related compiler warning.

* **Chores**
  * Updated platform build flows to respect the new LTO toggle, ensuring RAM/XIP build paths can disable LTO consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->